### PR TITLE
Easy setup w/ Vagrant & Puppet

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ notice: /Stage[main]/Docker/Service[dockerd]/ensure: ensure changed 'stopped' to
 
 notice: Finished catalog run in 329.74 seconds
 ```
-When this has successfully completed, you should be albe to get into your new system with `vagrant ssh` and use `docker`:
+
+When this has successfully completed, you should be able to get into your new system with `vagrant ssh` and use `docker`:
 
 ```bash
 $ vagrant ssh

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ notice: /Stage[main]/Docker/Service[dockerd]/ensure: ensure changed 'stopped' to
 
 notice: Finished catalog run in 329.74 seconds
 ```
-3. When this has successfully completed, you should be albe to get into your new system with `vagrant ssh` and use `docker`:
+When this has successfully completed, you should be albe to get into your new system with `vagrant ssh` and use `docker`:
 
 ```bash
 $ vagrant ssh

--- a/README.md
+++ b/README.md
@@ -78,3 +78,84 @@ Client installation
 4. Download the latest version of the [docker binaries](https://dl.dropbox.com/u/20637798/docker.tar.gz) (`wget https://dl.dropbox.com/u/20637798/docker.tar.gz`)
 5. Extract the contents of the tar file `tar -xf docker.tar.gz`
 6. You can now use the docker client binary `./docker`. Consider adding it to your `PATH` for simplicity.
+
+Vagrant Usage
+-------------
+
+1. Install Vagrant from http://vagrantup.com
+2. Run `vagrant up`. This will take a few minutes as it does the following:
+    - Download Quantal64 base box
+    - Kick off Puppet to do:
+        - Download & untar most recent docker binary tarball to vagrant homedir.
+        - Debootstrap to /var/lib/docker/images/ubuntu.
+        - Install & run dockerd as service.
+        - Put docker in /usr/local/bin.
+        - Put latest Go toolchain in /usr/local/go.
+
+Sample run output:
+
+```bash
+$ vagrant up
+[default] Importing base box 'quantal64'...
+[default] Matching MAC address for NAT networking...
+[default] Clearing any previously set forwarded ports...
+[default] Forwarding ports...
+[default] -- 22 => 2222 (adapter 1)
+[default] Creating shared folders metadata...
+[default] Clearing any previously set network interfaces...
+[default] Booting VM...
+[default] Waiting for VM to boot. This can take a few minutes.
+[default] VM booted and ready for use!
+[default] Mounting shared folders...
+[default] -- v-root: /vagrant
+[default] -- manifests: /tmp/vagrant-puppet/manifests
+[default] -- v-pp-m0: /tmp/vagrant-puppet/modules-0
+[default] Running provisioner: Vagrant::Provisioners::Puppet...
+[default] Running Puppet with /tmp/vagrant-puppet/manifests/quantal64.pp...
+stdin: is not a tty
+notice: /Stage[main]//Node[default]/Exec[apt_update]/returns: executed successfully
+
+notice: /Stage[main]/Docker/Exec[fetch-docker]/returns: executed successfully
+notice: /Stage[main]/Docker/Package[lxc]/ensure: ensure changed 'purged' to 'present'
+notice: /Stage[main]/Docker/Exec[fetch-go]/returns: executed successfully
+
+notice: /Stage[main]/Docker/Exec[copy-docker-bin]/returns: executed successfully
+notice: /Stage[main]/Docker/Exec[debootstrap]/returns: executed successfully
+notice: /Stage[main]/Docker/File[/etc/init/dockerd.conf]/ensure: defined content as '{md5}78a593d38dd9919af14d8f0545ac95e9'
+
+notice: /Stage[main]/Docker/Service[dockerd]/ensure: ensure changed 'stopped' to 'running'
+
+notice: Finished catalog run in 329.74 seconds
+```
+3. When this has successfully completed, you should be albe to get into your new system with `vagrant ssh` and use `docker`:
+
+```bash
+$ vagrant ssh
+Welcome to Ubuntu 12.10 (GNU/Linux 3.5.0-17-generic x86_64)
+
+ * Documentation:  https://help.ubuntu.com/
+
+Last login: Sun Feb  3 19:37:37 2013
+vagrant@vagrant-ubuntu-12:~$ DOCKER=localhost:4242 docker help
+Usage: docker COMMAND [arg...]
+
+A self-sufficient runtime for linux containers.
+
+Commands:
+    run       Run a command in a container
+    ps        Display a list of containers
+    pull      Download a tarball and create a container from it
+    put       Upload a tarball and create a container from it
+    rm        Remove containers
+    wait      Wait for the state of a container to change
+    stop      Stop a running container
+    logs      Fetch the logs of a container
+    diff      Inspect changes on a container's filesystem
+    commit    Save the state of a container
+    attach    Attach to the standard inputs and outputs of a running container
+    info      Display system-wide information
+    tar       Stream the contents of a container as a tar archive
+    web       Generate a web UI
+    attach    Attach to a running container
+```
+    

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,100 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant::Config.run do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "quantal64"
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  config.vm.box_url = "http://unworkable.org/~niallo/quantal64.box"
+
+  # Boot with a GUI so you can see the screen. (Default is headless)
+  # config.vm.boot_mode = :gui
+
+  # Assign this VM to a host-only network IP, allowing you to access it
+  # via the IP. Host-only networks can talk to the host machine as well as
+  # any other machines on the same network, but cannot be accessed (through this
+  # network interface) by any external networks.
+  # config.vm.network :hostonly, "192.168.33.10"
+
+  # Assign this VM to a bridged network, allowing you to connect directly to a
+  # network using the host's network device. This makes the VM appear as another
+  # physical device on your network.
+  # config.vm.network :bridged
+
+  # Forward a port from the guest to the host, which allows for outside
+  # computers to access the VM, whereas host only networking does not.
+  # config.vm.forward_port 80, 8080
+
+  # Share an additional folder to the guest VM. The first argument is
+  # an identifier, the second is the path on the guest to mount the
+  # folder, and the third is the path on the host to the actual folder.
+  # config.vm.share_folder "v-data", "/vagrant_data", "../data"
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file quantal64.pp in the manifests_path directory.
+  #
+  # An example Puppet manifest to provision the message of the day:
+  #
+  # # group { "puppet":
+  # #   ensure => "present",
+  # # }
+  # #
+  # # File { owner => 0, group => 0, mode => 0644 }
+  # #
+  # # file { '/etc/motd':
+  # #   content => "Welcome to your Vagrant-built virtual machine!
+  # #               Managed by Puppet.\n"
+  # # }
+  #
+  config.vm.provision :puppet do |puppet|
+    puppet.manifests_path = "puppet/manifests"
+    puppet.manifest_file  = "quantal64.pp"
+    puppet.module_path = "puppet/modules"
+  end
+
+  # Enable provisioning with chef solo, specifying a cookbooks path, roles
+  # path, and data_bags path (all relative to this Vagrantfile), and adding 
+  # some recipes and/or roles.
+  #
+  # config.vm.provision :chef_solo do |chef|
+  #   chef.cookbooks_path = "../my-recipes/cookbooks"
+  #   chef.roles_path = "../my-recipes/roles"
+  #   chef.data_bags_path = "../my-recipes/data_bags"
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { :mysql_password => "foo" }
+  # end
+
+  # Enable provisioning with chef server, specifying the chef server URL,
+  # and the path to the validation key (relative to this Vagrantfile).
+  #
+  # The Opscode Platform uses HTTPS. Substitute your organization for
+  # ORGNAME in the URL and validation key.
+  #
+  # If you have your own Chef Server, use the appropriate URL, which may be
+  # HTTP instead of HTTPS depending on your configuration. Also change the
+  # validation key to validation.pem.
+  #
+  # config.vm.provision :chef_client do |chef|
+  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
+  #   chef.validation_key_path = "ORGNAME-validator.pem"
+  # end
+  #
+  # If you're using the Opscode platform, your validator client is
+  # ORGNAME-validator, replacing ORGNAME with your organization name.
+  #
+  # IF you have your own Chef Server, the default validation client name is
+  # chef-validator, unless you changed the configuration.
+  #
+  #   chef.validation_client_name = "ORGNAME-validator"
+end

--- a/puppet/manifests/quantal64.pp
+++ b/puppet/manifests/quantal64.pp
@@ -1,0 +1,17 @@
+node default {
+    exec {
+        "apt_update" : 
+            command => "/usr/bin/apt-get update"
+    }
+
+    Package {
+        require => Exec['apt_update']
+    }
+
+    group { "puppet":
+        ensure => "present"
+    }
+
+    include "docker"
+
+}

--- a/puppet/modules/docker/manifests/init.pp
+++ b/puppet/modules/docker/manifests/init.pp
@@ -1,0 +1,57 @@
+class docker {
+
+    # update this with latest docker binary distro
+    # XXX: this is actually a bzip2 file rather than gzip despite extension
+    $docker_url = "https://dl.dropbox.com/u/20637798/docker.tar.gz"
+    # update this with latest go binary distry
+    $go_url = "http://go.googlecode.com/files/go1.0.3.linux-amd64.tar.gz"
+
+
+    Package { ensure => "installed" }
+
+    package { ["lxc", "debootstrap", "wget"]: }
+
+    exec { "debootstrap" :
+        require => Package["debootstrap"],
+        command => "/usr/sbin/debootstrap --arch=amd64 quantal /var/lib/docker/images/ubuntu",
+        creates => "/var/lib/docker/images/ubuntu",
+        timeout => 0
+    }
+
+    exec { "fetch-go":
+        require => Package["wget"],
+        command => "/usr/bin/wget -O - $go_url | /bin/tar xz -C /usr/local",
+        creates => "/usr/local/go/bin/go",
+    }
+
+    exec { "fetch-docker" :
+        require => Package["wget"],
+        command => "/usr/bin/wget -O - $docker_url | /bin/tar xj -C /home/vagrant",
+        creates => "/home/vagrant/docker/dockerd"
+    }
+
+    file { "/etc/init/dockerd.conf":
+        mode => 600,
+        owner => "root",
+        group => "root",
+        content => template("docker/dockerd.conf"),
+        require => [Exec["fetch-docker"], Exec["debootstrap"]]
+    }
+
+    exec { "copy-docker-bin" :
+        require => Exec["fetch-docker"],
+        command => "/bin/cp /home/vagrant/docker/docker /usr/local/bin",
+        creates => "/usr/local/bin/docker"
+    }
+
+    service { "dockerd" :
+        ensure => "running",
+        start => "/sbin/initctl start dockerd",
+        stop => "/sbin/initctl stop dockerd",
+        require => File["/etc/init/dockerd.conf"],
+        name => "dockerd",
+        provider => "base"
+    }
+
+
+}

--- a/puppet/modules/docker/manifests/init.pp
+++ b/puppet/modules/docker/manifests/init.pp
@@ -1,7 +1,6 @@
 class docker {
 
     # update this with latest docker binary distro
-    # XXX: this is actually a bzip2 file rather than gzip despite extension
     $docker_url = "https://dl.dropbox.com/u/20637798/docker.tar.gz"
     # update this with latest go binary distry
     $go_url = "http://go.googlecode.com/files/go1.0.3.linux-amd64.tar.gz"
@@ -26,7 +25,7 @@ class docker {
 
     exec { "fetch-docker" :
         require => Package["wget"],
-        command => "/usr/bin/wget -O - $docker_url | /bin/tar xj -C /home/vagrant",
+        command => "/usr/bin/wget -O - $docker_url | /bin/tar xz -C /home/vagrant",
         creates => "/home/vagrant/docker/dockerd"
     }
 

--- a/puppet/modules/docker/templates/dockerd.conf
+++ b/puppet/modules/docker/templates/dockerd.conf
@@ -1,0 +1,11 @@
+description     "Run dockerd"
+
+stop on runlevel [!2345]
+start on runlevel [3]
+
+# if you want it to automatically restart if it crashes, leave the next line in
+respawn
+
+script
+    /home/vagrant/dockerd/dockerd
+end script


### PR DESCRIPTION
Added Vagrantfile and Puppet config that does all of the following with a simple `vagrant up`:
- Download Quantal64 base box
- Kick off Puppet to do:
  - Download & untar most recent docker binary tarball to vagrant homedir.
  - Debootstrap to /var/lib/docker/images/ubuntu.
  - Install & run dockerd as service.
  - Put docker in /usr/local/bin.
  - Put latest Go toolchain in /usr/local/go.
