### PR TITLE
fix the broken enter key of interactive mode in the client

### DIFF
--- a/client/term.go
+++ b/client/term.go
@@ -123,11 +123,11 @@ func MakeRaw(fd int) (*State, error) {
         if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(getTermios), uintptr(unsafe.Pointer(&oldState.termios)), 0, 0, 0); err != 0 {
                 return nil, err
         }
-	
+
         newState := oldState.termios
         newState.Iflag &^= ISTRIP | INLCR | IGNCR | IXON | IXOFF
-	newState.Iflag |= ICRNL
-	newState.Oflag |= ONLCR
+        newState.Iflag |= ICRNL
+        newState.Oflag |= ONLCR
         newState.Lflag &^= ECHO | ICANON | ISIG
         if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(setTermios), uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
                 return nil, err

--- a/client/term.go
+++ b/client/term.go
@@ -123,9 +123,11 @@ func MakeRaw(fd int) (*State, error) {
         if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(getTermios), uintptr(unsafe.Pointer(&oldState.termios)), 0, 0, 0); err != 0 {
                 return nil, err
         }
-
+	
         newState := oldState.termios
-        newState.Iflag &^= istrip | INLCR | ICRNL | IGNCR | IXON | IXOFF
+        newState.Iflag &^= ISTRIP | INLCR | IGNCR | IXON | IXOFF
+	newState.Iflag |= ICRNL
+	newState.Oflag |= ONLCR
         newState.Lflag &^= ECHO | ICANON | ISIG
         if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(setTermios), uintptr(unsafe.Pointer(&newState)), 0, 0, 0); err != 0 {
                 return nil, err


### PR DESCRIPTION
Where previously hitting Enter in an interactive container process would yield "^M" and require you to hit Ctrl-J to push a newline, these flags ensure that newlines are sent with carriage returns.
