### PR TITLE
Networking

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -11,9 +11,10 @@ import (
 )
 
 type Docker struct {
-	root       string
-	repository string
-	containers *list.List
+	root             string
+	repository       string
+	containers       *list.List
+	networkAllocator *NetworkAllocator
 }
 
 func (docker *Docker) List() []*Container {
@@ -51,7 +52,7 @@ func (docker *Docker) Create(id string, command string, args []string, layers []
 		return nil, fmt.Errorf("Container %v already exists", id)
 	}
 	root := path.Join(docker.repository, id)
-	container, err := createContainer(id, root, command, args, layers, config)
+	container, err := createContainer(id, root, command, args, layers, config, docker.networkAllocator)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +87,7 @@ func (docker *Docker) restore() error {
 		return err
 	}
 	for _, v := range dir {
-		container, err := loadContainer(path.Join(docker.repository, v.Name()))
+		container, err := loadContainer(path.Join(docker.repository, v.Name()), docker.networkAllocator)
 		if err != nil {
 			log.Printf("Failed to load container %v: %v", v.Name(), err)
 			continue
@@ -101,10 +102,15 @@ func New() (*Docker, error) {
 }
 
 func NewFromDirectory(root string) (*Docker, error) {
+	alloc, err := newNetworkAllocator(networkBridgeIface)
+	if err != nil {
+		return nil, err
+	}
 	docker := &Docker{
-		root:       root,
-		repository: path.Join(root, "containers"),
-		containers: list.New(),
+		root:             root,
+		repository:       path.Join(root, "containers"),
+		containers:       list.New(),
+		networkAllocator: alloc,
 	}
 
 	if err := os.MkdirAll(docker.repository, 0700); err != nil && !os.IsExist(err) {

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -19,7 +19,7 @@ lxc.network.flags = up
 lxc.network.link = lxcbr0
 lxc.network.name = eth0
 lxc.network.mtu = 1500
-lxc.network.ipv4 = {{.Network.IpAddress}}/{{.Network.IpPrefixLen}}
+lxc.network.ipv4 = {{.NetworkConfig.IpAddress}}/{{.NetworkConfig.IpPrefixLen}}
 
 # root filesystem
 {{$ROOTFS := .Filesystem.RootFS}}

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -19,7 +19,7 @@ lxc.network.flags = up
 lxc.network.link = lxcbr0
 lxc.network.name = eth0
 lxc.network.mtu = 1500
-lxc.network.ipv4 = {{.NetworkConfig.IpAddress}}/{{.NetworkConfig.IpPrefixLen}}
+lxc.network.ipv4 = {{.NetworkSettings.IpAddress}}/{{.NetworkSettings.IpPrefixLen}}
 
 # root filesystem
 {{$ROOTFS := .Filesystem.RootFS}}

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -82,7 +82,7 @@ lxc.mount.entry = /etc/resolv.conf {{$ROOTFS}}/etc/resolv.conf none bind,ro 0 0
 
 
 # drop linux capabilities (apply mainly to the user root in the container)
-#lxc.cap.drop = audit_control audit_write mac_admin mac_override mknod net_raw setfcap setpcap sys_admin sys_boot sys_module sys_nice sys_pacct sys_rawio sys_resource sys_time sys_tty_config
+lxc.cap.drop = audit_control audit_write mac_admin mac_override mknod net_raw setfcap setpcap sys_admin sys_boot sys_module sys_nice sys_pacct sys_rawio sys_resource sys_time sys_tty_config
 
 # limits
 {{if .Config.Ram}}

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -14,12 +14,12 @@ lxc.utsname = {{.Id}}
 #lxc.aa_profile = unconfined
 
 # network configuration
-#lxc.network.type = veth
-#lxc.network.flags = up
-#lxc.network.link = br0
-#lxc.network.name = eth0  # Internal container network interface name
-#lxc.network.mtu = 1500
-#lxc.network.ipv4 = {ip_address}/{ip_prefix_len}
+lxc.network.type = veth
+lxc.network.flags = up
+lxc.network.link = lxcbr0
+lxc.network.name = eth0
+lxc.network.mtu = 1500
+lxc.network.ipv4 = {{.Network.IpAddress}}/{{.Network.IpPrefixLen}}
 
 # root filesystem
 {{$ROOTFS := .Filesystem.RootFS}}
@@ -82,7 +82,7 @@ lxc.mount.entry = /etc/resolv.conf {{$ROOTFS}}/etc/resolv.conf none bind,ro 0 0
 
 
 # drop linux capabilities (apply mainly to the user root in the container)
-lxc.cap.drop = audit_control audit_write mac_admin mac_override mknod net_raw setfcap setpcap sys_admin sys_boot sys_module sys_nice sys_pacct sys_rawio sys_resource sys_time sys_tty_config
+#lxc.cap.drop = audit_control audit_write mac_admin mac_override mknod net_raw setfcap setpcap sys_admin sys_boot sys_module sys_nice sys_pacct sys_rawio sys_resource sys_time sys_tty_config
 
 # limits
 {{if .Config.Ram}}

--- a/network.go
+++ b/network.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"math/rand"
 	"net"
 )
 
@@ -15,8 +16,10 @@ type NetworkInterface struct {
 	Gateway     net.IP
 }
 
-func allocateIPAddress() string {
-	return "10.0.3.2"
+func allocateIPAddress(network *net.IPNet) net.IP {
+	ip := network.IP.Mask(network.Mask)
+	ip[3] = byte(rand.Intn(254))
+	return ip
 }
 
 func getBridgeAddr(name string) (net.Addr, error) {
@@ -52,7 +55,7 @@ func allocateNetwork() (*NetworkInterface, error) {
 	bridge := bridgeAddr.(*net.IPNet)
 	ipPrefixLen, _ := bridge.Mask.Size()
 	iface := &NetworkInterface{
-		IpAddress:   allocateIPAddress(),
+		IpAddress:   allocateIPAddress(bridge).String(),
 		IpPrefixLen: ipPrefixLen,
 		Gateway:     bridge.IP,
 	}

--- a/network.go
+++ b/network.go
@@ -1,12 +1,12 @@
 package docker
 
 import (
+	"fmt"
 	"net"
 )
 
 const (
-	networkGateway   = "10.0.3.1"
-	networkPrefixLen = 24
+	networkBridgeIface = "lxcbr0"
 )
 
 type NetworkInterface struct {
@@ -19,11 +19,42 @@ func allocateIPAddress() string {
 	return "10.0.3.2"
 }
 
+func getBridgeAddr(name string) (net.Addr, error) {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, err
+	}
+	var addrs4 []net.Addr
+	for _, addr := range addrs {
+		ip := (addr.(*net.IPNet)).IP
+		if ip4 := ip.To4(); len(ip4) == net.IPv4len {
+			addrs4 = append(addrs4, addr)
+		}
+	}
+	switch {
+	case len(addrs4) == 0:
+		return nil, fmt.Errorf("Bridge %v has no IP addresses", name)
+	case len(addrs4) > 1:
+		return nil, fmt.Errorf("Bridge %v has more than 1 IPv4 address", name)
+	}
+	return addrs4[0], nil
+}
+
 func allocateNetwork() (*NetworkInterface, error) {
+	bridgeAddr, err := getBridgeAddr(networkBridgeIface)
+	if err != nil {
+		return nil, err
+	}
+	bridge := bridgeAddr.(*net.IPNet)
+	ipPrefixLen, _ := bridge.Mask.Size()
 	iface := &NetworkInterface{
 		IpAddress:   allocateIPAddress(),
-		IpPrefixLen: networkPrefixLen,
-		Gateway:     net.ParseIP(networkGateway),
+		IpPrefixLen: ipPrefixLen,
+		Gateway:     bridge.IP,
 	}
 	return iface, nil
 }

--- a/network.go
+++ b/network.go
@@ -1,0 +1,29 @@
+package docker
+
+import (
+	"net"
+)
+
+const (
+	networkGateway   = "10.0.3.1"
+	networkPrefixLen = 24
+)
+
+type NetworkInterface struct {
+	IpAddress   string
+	IpPrefixLen int
+	Gateway     net.IP
+}
+
+func allocateIPAddress() string {
+	return "10.0.3.2"
+}
+
+func allocateNetwork() (*NetworkInterface, error) {
+	iface := &NetworkInterface{
+		IpAddress:   allocateIPAddress(),
+		IpPrefixLen: networkPrefixLen,
+		Gateway:     net.ParseIP(networkGateway),
+	}
+	return iface, nil
+}

--- a/network.go
+++ b/network.go
@@ -5,20 +5,20 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"log"
 	"net"
+	"os/exec"
+	"strconv"
+	"strings"
 )
 
 const (
 	networkBridgeIface = "lxcbr0"
+	portRangeStart     = 49153
+	portRangeEnd       = 65535
 )
 
-type NetworkInterface struct {
-	IPNet   net.IPNet
-	Gateway net.IP
-}
-
-// IP utils
-
+// Calculates the first and last IP addresses in an IPNet
 func networkRange(network *net.IPNet) (net.IP, net.IP) {
 	netIP := network.IP.To4()
 	firstIP := netIP.Mask(network.Mask)
@@ -29,6 +29,7 @@ func networkRange(network *net.IPNet) (net.IP, net.IP) {
 	return firstIP, lastIP
 }
 
+// Converts a 4 bytes IP into a 32 bit integer
 func ipToInt(ip net.IP) (int32, error) {
 	buf := bytes.NewBuffer(ip.To4())
 	var n int32
@@ -38,6 +39,7 @@ func ipToInt(ip net.IP) (int32, error) {
 	return n, nil
 }
 
+// Converts 32 bit integer into a 4 bytes IP address
 func intToIp(n int32) (net.IP, error) {
 	var buf bytes.Buffer
 	if err := binary.Write(&buf, binary.BigEndian, &n); err != nil {
@@ -50,6 +52,7 @@ func intToIp(n int32) (net.IP, error) {
 	return ip, nil
 }
 
+// Given a netmask, calculates the number of available hosts
 func networkSize(mask net.IPMask) (int32, error) {
 	m := net.IPv4Mask(0, 0, 0, 0)
 	for i := 0; i < net.IPv4len; i++ {
@@ -63,6 +66,15 @@ func networkSize(mask net.IPMask) (int32, error) {
 	return n + 1, nil
 }
 
+// Wrapper around the iptables command
+func iptables(args ...string) error {
+	if err := exec.Command("/sbin/iptables", args...).Run(); err != nil {
+		return fmt.Errorf("iptables failed: iptables %v", strings.Join(args, " "))
+	}
+	return nil
+}
+
+// Return the IPv4 address of a network interface
 func getIfaceAddr(name string) (net.Addr, error) {
 	iface, err := net.InterfaceByName(name)
 	if err != nil {
@@ -81,60 +93,122 @@ func getIfaceAddr(name string) (net.Addr, error) {
 	}
 	switch {
 	case len(addrs4) == 0:
-		return nil, fmt.Errorf("Bridge %v has no IP addresses", name)
+		return nil, fmt.Errorf("Interface %v has no IP addresses", name)
 	case len(addrs4) > 1:
-		return nil, fmt.Errorf("Bridge %v has more than 1 IPv4 address", name)
+		return nil, fmt.Errorf("Interface %v has more than 1 IPv4 address", name)
 	}
 	return addrs4[0], nil
 }
 
-// Network allocator
-func newNetworkAllocator(iface string) (*NetworkAllocator, error) {
-	addr, err := getIfaceAddr(iface)
-	if err != nil {
-		return nil, err
-	}
-	network := addr.(*net.IPNet)
-
-	alloc := &NetworkAllocator{
-		iface: iface,
-		net:   network,
-	}
-	if err := alloc.populateFromNetwork(network); err != nil {
-		return nil, err
-	}
-	return alloc, nil
+// Port mapper takes care of mapping external ports to containers by setting
+// up iptables rules.
+// It keeps track of all mappings and is able to unmap at will
+type PortMapper struct {
+	mapping map[int]net.TCPAddr
 }
 
-type NetworkAllocator struct {
-	iface string
-	net   *net.IPNet
-	queue chan (net.IP)
+func (mapper *PortMapper) cleanup() error {
+	// Ignore errors - This could mean the chains were never set up
+	iptables("-t", "nat", "-D", "PREROUTING", "-j", "DOCKER")
+	iptables("-t", "nat", "-F", "DOCKER")
+	iptables("-t", "nat", "-X", "DOCKER")
+	mapper.mapping = make(map[int]net.TCPAddr)
+	return nil
 }
 
-func (alloc *NetworkAllocator) acquireIP() (net.IP, error) {
-	select {
-	case ip := <-alloc.queue:
-		return ip, nil
-	default:
-		return net.IP{}, errors.New("No more IP addresses available")
+func (mapper *PortMapper) setup() error {
+	if err := iptables("-t", "nat", "-N", "DOCKER"); err != nil {
+		return errors.New("Unable to setup port networking: Failed to create DOCKER chain")
 	}
-	return net.IP{}, nil
-}
-
-func (alloc *NetworkAllocator) releaseIP(ip net.IP) error {
-	select {
-	case alloc.queue <- ip:
-		return nil
-	default:
-		return errors.New("Too many IP addresses have been released")
+	if err := iptables("-t", "nat", "-A", "PREROUTING", "-j", "DOCKER"); err != nil {
+		return errors.New("Unable to setup port networking: Failed to inject docker in PREROUTING chain")
 	}
 	return nil
 }
 
-func (alloc *NetworkAllocator) populateFromNetwork(network *net.IPNet) error {
-	firstIP, _ := networkRange(network)
-	size, err := networkSize(network.Mask)
+func (mapper *PortMapper) iptablesForward(rule string, port int, dest net.TCPAddr) error {
+	return iptables("-t", "nat", rule, "DOCKER", "-p", "tcp", "--dport", strconv.Itoa(port),
+		"-j", "DNAT", "--to-destination", net.JoinHostPort(dest.IP.String(), strconv.Itoa(dest.Port)))
+}
+
+func (mapper *PortMapper) Map(port int, dest net.TCPAddr) error {
+	if err := mapper.iptablesForward("-A", port, dest); err != nil {
+		return err
+	}
+	mapper.mapping[port] = dest
+	return nil
+}
+
+func (mapper *PortMapper) Unmap(port int) error {
+	dest, ok := mapper.mapping[port]
+	if !ok {
+		return errors.New("Port is not mapped")
+	}
+	if err := mapper.iptablesForward("-D", port, dest); err != nil {
+		return err
+	}
+	delete(mapper.mapping, port)
+	return nil
+}
+
+func newPortMapper() (*PortMapper, error) {
+	mapper := &PortMapper{}
+	if err := mapper.cleanup(); err != nil {
+		return nil, err
+	}
+	if err := mapper.setup(); err != nil {
+		return nil, err
+	}
+	return mapper, nil
+}
+
+// Port allocator: Atomatically allocate and release networking ports
+type PortAllocator struct {
+	ports chan (int)
+}
+
+func (alloc *PortAllocator) populate(start, end int) {
+	alloc.ports = make(chan int, end-start)
+	for port := start; port < end; port++ {
+		alloc.ports <- port
+	}
+}
+
+func (alloc *PortAllocator) Acquire() (int, error) {
+	select {
+	case port := <-alloc.ports:
+		return port, nil
+	default:
+		return -1, errors.New("No more ports available")
+	}
+	return -1, nil
+}
+
+func (alloc *PortAllocator) Release(port int) error {
+	select {
+	case alloc.ports <- port:
+		return nil
+	default:
+		return errors.New("Too many ports have been released")
+	}
+	return nil
+}
+
+func newPortAllocator(start, end int) (*PortAllocator, error) {
+	allocator := &PortAllocator{}
+	allocator.populate(start, end)
+	return allocator, nil
+}
+
+// IP allocator: Atomatically allocate and release networking ports
+type IPAllocator struct {
+	network *net.IPNet
+	queue   chan (net.IP)
+}
+
+func (alloc *IPAllocator) populate() error {
+	firstIP, _ := networkRange(alloc.network)
+	size, err := networkSize(alloc.network.Mask)
 	if err != nil {
 		return err
 	}
@@ -152,27 +226,131 @@ func (alloc *NetworkAllocator) populateFromNetwork(network *net.IPNet) error {
 			return err
 		}
 		// Discard the network IP (that's the host IP address)
-		if ip.Equal(network.IP) {
+		if ip.Equal(alloc.network.IP) {
 			continue
 		}
-		alloc.releaseIP(ip)
+		alloc.queue <- ip
 	}
 	return nil
 }
 
-func (alloc *NetworkAllocator) Allocate() (*NetworkInterface, error) {
-	// ipPrefixLen, _ := alloc.net.Mask.Size()
-	ip, err := alloc.acquireIP()
+func (alloc *IPAllocator) Acquire() (net.IP, error) {
+	select {
+	case ip := <-alloc.queue:
+		return ip, nil
+	default:
+		return net.IP{}, errors.New("No more IP addresses available")
+	}
+	return net.IP{}, nil
+}
+
+func (alloc *IPAllocator) Release(ip net.IP) error {
+	select {
+	case alloc.queue <- ip:
+		return nil
+	default:
+		return errors.New("Too many IP addresses have been released")
+	}
+	return nil
+}
+
+func newIPAllocator(network *net.IPNet) (*IPAllocator, error) {
+	alloc := &IPAllocator{
+		network: network,
+	}
+	if err := alloc.populate(); err != nil {
+		return nil, err
+	}
+	return alloc, nil
+}
+
+// Network interface represents the networking stack of a container
+type NetworkInterface struct {
+	IPNet   net.IPNet
+	Gateway net.IP
+
+	manager  *NetworkManager
+	extPorts []int
+}
+
+// Allocate an external TCP port and map it to the interface
+func (iface *NetworkInterface) AllocatePort(port int) (int, error) {
+	extPort, err := iface.manager.portAllocator.Acquire()
+	if err != nil {
+		return -1, err
+	}
+	if err := iface.manager.portMapper.Map(extPort, net.TCPAddr{iface.IPNet.IP, port}); err != nil {
+		iface.manager.portAllocator.Release(extPort)
+		return -1, err
+	}
+	iface.extPorts = append(iface.extPorts, extPort)
+	return extPort, nil
+}
+
+// Release: Network cleanup - release all resources
+func (iface *NetworkInterface) Release() error {
+	for _, port := range iface.extPorts {
+		if err := iface.manager.portMapper.Unmap(port); err != nil {
+			log.Printf("Unable to unmap port %v: %v", port, err)
+		}
+		if err := iface.manager.portAllocator.Release(port); err != nil {
+			log.Printf("Unable to release port %v: %v", port, err)
+		}
+
+	}
+	return iface.manager.ipAllocator.Release(iface.IPNet.IP)
+}
+
+// Network Manager manages a set of network interfaces
+// Only *one* manager per host machine should be used
+type NetworkManager struct {
+	bridgeIface   string
+	bridgeNetwork *net.IPNet
+
+	ipAllocator   *IPAllocator
+	portAllocator *PortAllocator
+	portMapper    *PortMapper
+}
+
+// Allocate a network interface
+func (manager *NetworkManager) Allocate() (*NetworkInterface, error) {
+	ip, err := manager.ipAllocator.Acquire()
 	if err != nil {
 		return nil, err
 	}
 	iface := &NetworkInterface{
-		IPNet:   net.IPNet{ip, alloc.net.Mask},
-		Gateway: alloc.net.IP,
+		IPNet:   net.IPNet{ip, manager.bridgeNetwork.Mask},
+		Gateway: manager.bridgeNetwork.IP,
+		manager: manager,
 	}
 	return iface, nil
 }
 
-func (alloc *NetworkAllocator) Release(iface *NetworkInterface) error {
-	return alloc.releaseIP(iface.IPNet.IP)
+func newNetworkManager(bridgeIface string) (*NetworkManager, error) {
+	addr, err := getIfaceAddr(bridgeIface)
+	if err != nil {
+		return nil, err
+	}
+	network := addr.(*net.IPNet)
+
+	ipAllocator, err := newIPAllocator(network)
+	if err != nil {
+		return nil, err
+	}
+
+	portAllocator, err := newPortAllocator(portRangeStart, portRangeEnd)
+	if err != nil {
+		return nil, err
+	}
+
+	portMapper, err := newPortMapper()
+
+	manager := &NetworkManager{
+		bridgeIface:   bridgeIface,
+		bridgeNetwork: network,
+		ipAllocator:   ipAllocator,
+		portAllocator: portAllocator,
+		portMapper:    portMapper,
+	}
+	return manager, nil
 }

--- a/network_test.go
+++ b/network_test.go
@@ -103,22 +103,22 @@ func TestConversion(t *testing.T) {
 func TestNetworkAllocator(t *testing.T) {
 	alloc := NetworkAllocator{}
 	_, n, _ := net.ParseCIDR("127.0.0.1/29")
-	alloc.PopulateFromNetwork(n)
+	alloc.populateFromNetwork(n)
 	var lastIP net.IP
 	for i := 0; i < 5; i++ {
-		ip, err := alloc.Acquire()
+		ip, err := alloc.acquireIP()
 		if err != nil {
 			t.Fatal(err)
 		}
 		lastIP = ip
 	}
-	ip, err := alloc.Acquire()
+	ip, err := alloc.acquireIP()
 	if err == nil {
 		t.Fatal("There shouldn't be any IP addresses at this point")
 	}
 	// Release 1 IP
-	alloc.Release(lastIP)
-	ip, err = alloc.Acquire()
+	alloc.releaseIP(lastIP)
+	ip, err = alloc.acquireIP()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/network_test.go
+++ b/network_test.go
@@ -99,3 +99,30 @@ func TestConversion(t *testing.T) {
 		t.Error(conv.String())
 	}
 }
+
+func TestNetworkAllocator(t *testing.T) {
+	alloc := NetworkAllocator{}
+	_, n, _ := net.ParseCIDR("127.0.0.1/29")
+	alloc.PopulateFromNetwork(n)
+	var lastIP net.IP
+	for i := 0; i < 5; i++ {
+		ip, err := alloc.Acquire()
+		if err != nil {
+			t.Fatal(err)
+		}
+		lastIP = ip
+	}
+	ip, err := alloc.Acquire()
+	if err == nil {
+		t.Fatal("There shouldn't be any IP addresses at this point")
+	}
+	// Release 1 IP
+	alloc.Release(lastIP)
+	ip, err = alloc.Acquire()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ip.Equal(lastIP) {
+		t.Fatal(ip.String())
+	}
+}

--- a/network_test.go
+++ b/network_test.go
@@ -1,0 +1,101 @@
+package docker
+
+import (
+	"net"
+	"testing"
+)
+
+func TestNetworkRange(t *testing.T) {
+	// Simple class C test
+	_, network, _ := net.ParseCIDR("192.168.0.1/24")
+	first, last := networkRange(network)
+	if !first.Equal(net.ParseIP("192.168.0.0")) {
+		t.Error(first.String())
+	}
+	if !last.Equal(net.ParseIP("192.168.0.255")) {
+		t.Error(last.String())
+	}
+	if size, err := networkSize(network.Mask); err != nil || size != 256 {
+		t.Error(size, err)
+	}
+
+	// Class A test
+	_, network, _ = net.ParseCIDR("10.0.0.1/8")
+	first, last = networkRange(network)
+	if !first.Equal(net.ParseIP("10.0.0.0")) {
+		t.Error(first.String())
+	}
+	if !last.Equal(net.ParseIP("10.255.255.255")) {
+		t.Error(last.String())
+	}
+	if size, err := networkSize(network.Mask); err != nil || size != 16777216 {
+		t.Error(size, err)
+	}
+
+	// Class A, random IP address
+	_, network, _ = net.ParseCIDR("10.1.2.3/8")
+	first, last = networkRange(network)
+	if !first.Equal(net.ParseIP("10.0.0.0")) {
+		t.Error(first.String())
+	}
+	if !last.Equal(net.ParseIP("10.255.255.255")) {
+		t.Error(last.String())
+	}
+
+	// 32bit mask
+	_, network, _ = net.ParseCIDR("10.1.2.3/32")
+	first, last = networkRange(network)
+	if !first.Equal(net.ParseIP("10.1.2.3")) {
+		t.Error(first.String())
+	}
+	if !last.Equal(net.ParseIP("10.1.2.3")) {
+		t.Error(last.String())
+	}
+	if size, err := networkSize(network.Mask); err != nil || size != 1 {
+		t.Error(size, err)
+	}
+
+	// 31bit mask
+	_, network, _ = net.ParseCIDR("10.1.2.3/31")
+	first, last = networkRange(network)
+	if !first.Equal(net.ParseIP("10.1.2.2")) {
+		t.Error(first.String())
+	}
+	if !last.Equal(net.ParseIP("10.1.2.3")) {
+		t.Error(last.String())
+	}
+	if size, err := networkSize(network.Mask); err != nil || size != 2 {
+		t.Error(size, err)
+	}
+
+	// 26bit mask
+	_, network, _ = net.ParseCIDR("10.1.2.3/26")
+	first, last = networkRange(network)
+	if !first.Equal(net.ParseIP("10.1.2.0")) {
+		t.Error(first.String())
+	}
+	if !last.Equal(net.ParseIP("10.1.2.63")) {
+		t.Error(last.String())
+	}
+	if size, err := networkSize(network.Mask); err != nil || size != 64 {
+		t.Error(size, err)
+	}
+}
+
+func TestConversion(t *testing.T) {
+	ip := net.ParseIP("127.0.0.1")
+	i, err := ipToInt(ip)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if i == 0 {
+		t.Fatal("converted to zero")
+	}
+	conv, err := intToIp(i)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ip.Equal(conv) {
+		t.Error(conv.String())
+	}
+}

--- a/network_test.go
+++ b/network_test.go
@@ -100,25 +100,27 @@ func TestConversion(t *testing.T) {
 	}
 }
 
-func TestNetworkAllocator(t *testing.T) {
-	alloc := NetworkAllocator{}
-	_, n, _ := net.ParseCIDR("127.0.0.1/29")
-	alloc.populateFromNetwork(n)
+func TestIPAllocator(t *testing.T) {
+	gwIP, n, _ := net.ParseCIDR("127.0.0.1/29")
+	alloc, err := newIPAllocator(&net.IPNet{gwIP, n.Mask})
+	if err != nil {
+		t.Fatal(err)
+	}
 	var lastIP net.IP
 	for i := 0; i < 5; i++ {
-		ip, err := alloc.acquireIP()
+		ip, err := alloc.Acquire()
 		if err != nil {
 			t.Fatal(err)
 		}
 		lastIP = ip
 	}
-	ip, err := alloc.acquireIP()
+	ip, err := alloc.Acquire()
 	if err == nil {
 		t.Fatal("There shouldn't be any IP addresses at this point")
 	}
 	// Release 1 IP
-	alloc.releaseIP(lastIP)
-	ip, err = alloc.acquireIP()
+	alloc.Release(lastIP)
+	ip, err = alloc.Acquire()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -11,7 +11,7 @@ import (
 	"github.com/dotcloud/docker/image"
 	"github.com/dotcloud/docker/rcli"
 	"io"
-	// "net/http"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -393,20 +393,20 @@ func (srv *Server) CmdPull(stdin io.ReadCloser, stdout io.Writer, args ...string
 	fmt.Fprintf(stdout, "Downloading from %s\n", u.String())
 	// Download with curl (pretty progress bar)
 	// If curl is not available, fallback to http.Get()
-	// archive, err := future.Curl(u.String(), stdout)
-	// if err != nil {
-	// 	if resp, err := http.Get(u.String()); err != nil {
-	// 		return err
-	// 	} else {
-	// 		archive = resp.Body
-	// 	}
-	// }
-	// fmt.Fprintf(stdout, "Unpacking to %s\n", name)
-	// img, err := srv.images.Import(name, archive, nil)
-	// if err != nil {
-	// 	return err
-	// }
-	// fmt.Fprintln(stdout, img.Id)
+	archive, err := future.Curl(u.String(), stdout)
+	if err != nil {
+		if resp, err := http.Get(u.String()); err != nil {
+			return err
+		} else {
+			archive = resp.Body
+		}
+	}
+	fmt.Fprintf(stdout, "Unpacking to %s\n", name)
+	img, err := srv.images.Import(name, archive, nil)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(stdout, img.Id)
 	return nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -11,10 +11,11 @@ import (
 	"github.com/dotcloud/docker/image"
 	"github.com/dotcloud/docker/rcli"
 	"io"
-	"net/http"
+	// "net/http"
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"text/tabwriter"
@@ -392,20 +393,20 @@ func (srv *Server) CmdPull(stdin io.ReadCloser, stdout io.Writer, args ...string
 	fmt.Fprintf(stdout, "Downloading from %s\n", u.String())
 	// Download with curl (pretty progress bar)
 	// If curl is not available, fallback to http.Get()
-	archive, err := future.Curl(u.String(), stdout)
-	if err != nil {
-		if resp, err := http.Get(u.String()); err != nil {
-			return err
-		} else {
-			archive = resp.Body
-		}
-	}
-	fmt.Fprintf(stdout, "Unpacking to %s\n", name)
-	img, err := srv.images.Import(name, archive, nil)
-	if err != nil {
-		return err
-	}
-	fmt.Fprintln(stdout, img.Id)
+	// archive, err := future.Curl(u.String(), stdout)
+	// if err != nil {
+	// 	if resp, err := http.Get(u.String()); err != nil {
+	// 		return err
+	// 	} else {
+	// 		archive = resp.Body
+	// 	}
+	// }
+	// fmt.Fprintf(stdout, "Unpacking to %s\n", name)
+	// img, err := srv.images.Import(name, archive, nil)
+	// if err != nil {
+	// 	return err
+	// }
+	// fmt.Fprintln(stdout, img.Id)
 	return nil
 }
 
@@ -679,10 +680,10 @@ func (srv *Server) CmdLogs(stdin io.ReadCloser, stdout io.Writer, args ...string
 	return errors.New("No such container: " + cmd.Arg(0))
 }
 
-func (srv *Server) CreateContainer(img *image.Image, user string, tty bool, openStdin bool, comment string, cmd string, args ...string) (*docker.Container, error) {
+func (srv *Server) CreateContainer(img *image.Image, ports []int, user string, tty bool, openStdin bool, comment string, cmd string, args ...string) (*docker.Container, error) {
 	id := future.RandomId()[:8]
 	container, err := srv.containers.Create(id, cmd, args, img.Layers,
-		&docker.Config{Hostname: id, User: user, Tty: tty, OpenStdin: openStdin})
+		&docker.Config{Hostname: id, Ports: ports, User: user, Tty: tty, OpenStdin: openStdin})
 	if err != nil {
 		return nil, err
 	}
@@ -743,6 +744,22 @@ func (srv *Server) CmdAttach(stdin io.ReadCloser, stdout io.Writer, args ...stri
 	return nil
 }
 
+// Ports type - Used to parse multiple -p flags
+type ports []int
+
+func (p *ports) String() string {
+	return fmt.Sprint(*p)
+}
+
+func (p *ports) Set(value string) error {
+	port, err := strconv.Atoi(value)
+	if err != nil {
+		return fmt.Errorf("Invalid port: %v", value)
+	}
+	*p = append(*p, port)
+	return nil
+}
+
 func (srv *Server) CmdRun(stdin io.ReadCloser, stdout io.Writer, args ...string) error {
 	cmd := rcli.Subcmd(stdout, "run", "[OPTIONS] IMAGE COMMAND [ARG...]", "Run a command in a new container")
 	fl_user := cmd.String("u", "", "Username or UID")
@@ -750,6 +767,8 @@ func (srv *Server) CmdRun(stdin io.ReadCloser, stdout io.Writer, args ...string)
 	fl_stdin := cmd.Bool("i", false, "Keep stdin open even if not attached")
 	fl_tty := cmd.Bool("t", false, "Allocate a pseudo-tty")
 	fl_comment := cmd.String("c", "", "Comment")
+	var fl_ports ports
+	cmd.Var(&fl_ports, "p", "Map a network port to the container")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -775,7 +794,7 @@ func (srv *Server) CmdRun(stdin io.ReadCloser, stdout io.Writer, args ...string)
 		return errors.New("No such image: " + name)
 	}
 	// Create new container
-	container, err := srv.CreateContainer(img, *fl_user, *fl_tty, *fl_stdin, *fl_comment, cmdline[0], cmdline[1:]...)
+	container, err := srv.CreateContainer(img, fl_ports, *fl_user, *fl_tty, *fl_stdin, *fl_comment, cmdline[0], cmdline[1:]...)
 	if err != nil {
 		return errors.New("Error creating container: " + err.Error())
 	}

--- a/sysinit.go
+++ b/sysinit.go
@@ -11,6 +11,17 @@ import (
 	"syscall"
 )
 
+// Setup networking
+func setupNetworking(gw string) {
+	if gw == "" {
+		return
+	}
+	cmd := exec.Command("/sbin/route", "add", "default", "gw", gw)
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("Unable to set up networking: %v", err)
+	}
+}
+
 // Takes care of dropping privileges to the desired user
 func changeUser(u string) {
 	if u == "" {
@@ -62,8 +73,11 @@ func SysInit() {
 		os.Exit(1)
 	}
 	var u = flag.String("u", "", "username or uid")
+	var gw = flag.String("g", "", "gateway address")
 
 	flag.Parse()
+
+	setupNetworking(*gw)
 	changeUser(*u)
 	executeProgram(flag.Arg(0), flag.Args())
 }


### PR DESCRIPTION
Implemented networking support for Docker.
- At startup, Docker analyzes the bridge interface it will be using (by default, `lxcbr0`) to determine the IP address range it will be assigning to containers, netmask and gateway.
- Before a container starts, Docker allocates an IP address on the bridge interface and configures LXC to create a virtual ethernet interface using that IP. The IP is automatically released (and recycled) as soon as the container is not running anymore.
- Once a container is created, but before the process is started, Docker's sysinit code will take care of setting up the routing table. The default route will point to the host bridge interface.

Docker now also supports routing inbound traffic to containers (TCP only).
- By default, no inbound traffic is forwarded to containers
- You can expose a TCP port of a container by using the `-p` option of `docker run`, e.g. `docker run -p 1234 base -- nc -l 1234`
- Docker in turn will allocate a TCP port on the host and forward it to the container (range: [49153,65535]).
- The port exposed on the host will be different from the port the container is listening to internally. You can figure out the port mapping by running `docker inspect` and looking under NetworkSettings.
- You can expose multiple ports on a single container. Just supply the `-p` option several times.
- The ports are automatically released and unmapped as soon as the container stops running

Under the hood, port forwarding is implemented using `iptables`. Docker will do its best not to interfere with your existing rules.
- It will create a new chain named `DOCKER` (`nat` table). This chain will contain all of docker's rules.
- docker will also append a single rule inside the `PREROUTING` chain which will jump to the `DOCKER` chain. 
- docker will never flush nor remove any rules or chain that don't belong to it.
