### PR TITLE
Rework install.sh to work with cloud-init

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 # This script is meant for quick & easy install via 'curl URL-OF-SCRIPT | sh'
-# Courtesy of Jeff Lindsay <progrium@gmail.com>
+# Original version by Jeff Lindsay <progrium@gmail.com>
+# Revamped by Jerome Petazzoni <jerome@dotcloud.com>
+#
+# This script canonical location is http://get.docker.io/; to update it, run:
+# s3cmd put -m text/x-shellscript -P install.sh s3://get.docker.io/index
 
 echo "Ensuring basic dependencies are installed..."
 apt-get -qq update
@@ -47,5 +51,5 @@ fi
 echo "Starting dockerd..."
 start dockerd > /dev/null
 
-echo "Finished!"
+echo "Done."
 echo

--- a/install.sh
+++ b/install.sh
@@ -2,18 +2,13 @@
 # This script is meant for quick & easy install via 'curl URL-OF-SCRIPT | bash'
 # Courtesy of Jeff Lindsay <progrium@gmail.com>
 
-cd /tmp
-
 echo "Ensuring dependencies are installed..."
 apt-get --yes install lxc wget bsdtar 2>&1 > /dev/null
 
-echo "Downloading docker binary..."
-wget -q https://dl.dropbox.com/u/20637798/docker.tar.gz 2>&1 > /dev/null
-tar -xf docker.tar.gz 2>&1 > /dev/null
-
-echo "Installing into /usr/local/bin..."
-mv docker/docker /usr/local/bin
-mv dockerd/dockerd /usr/local/bin
+echo "Downloading docker binary and uncompressing into /usr/local/bin..."
+curl -s http://get.docker.io/builds/$(uname -s)/$(uname -m)/docker-master.tgz |
+tar -C /usr/local/bin --strip-components=1 -zxf- \
+docker-master/docker docker-master/dockerd
 
 if [[ -f /etc/init/dockerd.conf ]]
 then
@@ -25,11 +20,6 @@ fi
 
 echo "Restarting dockerd..."
 restart dockerd > /dev/null
-
-echo "Cleaning up..."
-rmdir docker
-rmdir dockerd
-rm docker.tar.gz
 
 echo "Finished!"
 echo

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# This script is meant for quick & easy install via 'curl URL-OF-SCRIPT | bash'
+# This script is meant for quick & easy install via 'curl URL-OF-SCRIPT | sh'
 # Courtesy of Jeff Lindsay <progrium@gmail.com>
 
 echo "Ensuring basic dependencies are installed..."
@@ -36,7 +36,7 @@ curl -s http://get.docker.io/builds/$(uname -s)/$(uname -m)/docker-master.tgz |
 tar -C /usr/local/bin --strip-components=1 -zxf- \
 docker-master/docker docker-master/dockerd
 
-if [[ -f /etc/init/dockerd.conf ]]
+if [ -f /etc/init/dockerd.conf ]
 then
   echo "Upstart script already exists."
 else

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,34 @@
 # This script is meant for quick & easy install via 'curl URL-OF-SCRIPT | bash'
 # Courtesy of Jeff Lindsay <progrium@gmail.com>
 
-echo "Ensuring dependencies are installed..."
-apt-get --yes install lxc wget bsdtar 2>&1 > /dev/null
+echo "Ensuring basic dependencies are installed..."
+apt-get -qq update
+apt-get -qq install lxc wget bsdtar
+
+echo "Looking in /proc/filesystems to see if we have AUFS support..."
+if grep -q aufs /proc/filesystems
+then
+    echo "Found."
+else
+    echo "Ahem, it looks like the current kernel does not support AUFS."
+    echo "Let's see if we can load the AUFS module with modprobe..."
+    if modprobe aufs
+    then
+        echo "Module loaded."
+    else
+        echo "Ahem, things didn't turn out as expected."
+        KPKG=linux-image-extra-$(uname -r)
+        echo "Trying to install $KPKG..."
+        if apt-get -qq install $KPKG
+        then
+            echo "Installed."
+        else
+            echo "Oops, we couldn't install the -extra kernel."
+            echo "Are you sure you are running a supported version of Ubuntu?"
+            echo "Proceeding anyway, but Docker will probably NOT WORK!"
+        fi
+    fi
+fi
 
 echo "Downloading docker binary and uncompressing into /usr/local/bin..."
 curl -s http://get.docker.io/builds/$(uname -s)/$(uname -m)/docker-master.tgz |

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
-# This script is meant for quick & easy install via 'curl URL-OF-SCRIPPT | bash'
+#!/bin/sh
+# This script is meant for quick & easy install via 'curl URL-OF-SCRIPT | bash'
 # Courtesy of Jeff Lindsay <progrium@gmail.com>
 
 cd /tmp

--- a/install.sh
+++ b/install.sh
@@ -18,8 +18,8 @@ else
   echo "exec /usr/local/bin/dockerd" > /etc/init/dockerd.conf
 fi
 
-echo "Restarting dockerd..."
-restart dockerd > /dev/null
+echo "Starting dockerd..."
+start dockerd > /dev/null
 
 echo "Finished!"
 echo


### PR DESCRIPTION
Jeff's `install.sh` has been reworked, and can now be used as a `cloud-init` script.

To use it: create an EC2 instance (Ubuntu, 64 bits), and in the user data, specify the following:

```
#include
http://get.docker.io/
```

At the end of the boot process, the script will be downloaded and executed. It will take care of downloading the latest builds of `docker` and `dockerd`.
