### PR TITLE
Automatically remove the rcfile generated by docker -i from /tmp

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -111,6 +111,7 @@ func InteractiveMode(scripts ...string) error {
 	if err != nil {
 		return err
 	}
+	defer os.Remove(rcfile.Name())
 	io.WriteString(rcfile, "enable -n help\n")
 	os.Setenv("PATH", tmp+":"+os.Getenv("PATH"))
 	os.Setenv("PS1", "\\h docker> ")


### PR DESCRIPTION
This is a very small thing I spotted while reading client.go
