### PR TITLE
Store register refactor + vagrant fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant::Config.run do |config|
   # Share an additional folder to the guest VM. The first argument is
   # an identifier, the second is the path on the guest to mount the
   # folder, and the third is the path on the host to the actual folder.
-  # config.vm.share_folder "v-data", "/vagrant_data", "../data"
+  config.vm.share_folder "v-data", "~/docker", "~/docker"
 
   # Enable provisioning with Puppet stand alone.  Puppet manifests
   # are contained in a directory path relative to this Vagrantfile.

--- a/puppet/modules/docker/manifests/init.pp
+++ b/puppet/modules/docker/manifests/init.pp
@@ -8,6 +8,7 @@ class docker {
     Package { ensure => "installed" }
 
     package { ["lxc", "debootstrap", "wget", "bsdtar", "git",
+               "pkg-config", "libsqlite3-dev",
                "linux-image-3.5.0-25-generic",
                "linux-image-extra-3.5.0-25-generic",
                "virtualbox-guest-utils",
@@ -42,16 +43,17 @@ class docker {
         require => [Exec["fetch-docker"], Exec["debootstrap"]]
     }
 
+    file { "/home/vagrant/.profile":
+        mode => 644,
+        owner => "vagrant",
+        group => "vagrant",
+        content => template("docker/profile"),
+    }
+
     exec { "copy-docker-bin" :
         require => Exec["fetch-docker"],
         command => "/bin/cp /home/vagrant/docker-master/docker /usr/local/bin",
         creates => "/usr/local/bin/docker"
-    }
-
-    exec { "copy-dockerd-bin" :
-        require => Exec["fetch-docker"],
-        command => "/bin/cp /home/vagrant/docker-master/dockerd /usr/local/bin",
-        creates => "/usr/local/bin/dockerd"
     }
 
     exec { "vbox-add" :

--- a/puppet/modules/docker/templates/dockerd.conf
+++ b/puppet/modules/docker/templates/dockerd.conf
@@ -8,5 +8,5 @@ respawn
 
 script
     test -f /etc/default/locale && . /etc/default/locale || true
-    LANG=$LANG LC_ALL=$LANG /usr/local/bin/dockerd
+    LANG=$LANG LC_ALL=$LANG /usr/local/bin/docker -d
 end script

--- a/puppet/modules/docker/templates/profile
+++ b/puppet/modules/docker/templates/profile
@@ -1,0 +1,27 @@
+# ~/.profile: executed by the command interpreter for login shells.
+# This file is not read by bash(1), if ~/.bash_profile or ~/.bash_login
+# exists.
+# see /usr/share/doc/bash/examples/startup-files for examples.
+# the files are located in the bash-doc package.
+
+# the default umask is set in /etc/profile; for setting the umask
+# for ssh logins, install and configure the libpam-umask package.
+#umask 022
+
+# if running bash
+if [ -n "$BASH_VERSION" ]; then
+    # include .bashrc if it exists
+    if [ -f "$HOME/.bashrc" ]; then
+        . "$HOME/.bashrc"
+    fi
+fi
+
+# set PATH so it includes user's private bin if it exists
+if [ -d "$HOME/bin" ] ; then
+    PATH="$HOME/bin:$PATH"
+fi
+
+# set ~/docker as the go path
+export GOPATH=~/docker
+# add go to the PATH
+export PATH=$PATH:/usr/local/go/bin


### PR DESCRIPTION
Sorry, there are two changes on the same pull request, I originally had them on two different branches and I couldn't figure out how to back out and either way, the fixes aren't related so I'm keeping it like this.

Vagrant is updated to work with the new single binary changes, and including new required packages, and added ENV variables to the .profile and added vagrant shared folder for easier mapping of files back and forth.

fs/store.Register refactor was just cleaning up the code a little, per Solomon's suggestions. unit test for Register was also added.
