### PR TITLE
Create /var/lib/docker so new installs don't fail

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -109,6 +109,12 @@ func New() (*Docker, error) {
 }
 
 func NewFromDirectory(root string) (*Docker, error) {
+	docker_repo := path.Join(root, "containers")
+
+	if err := os.MkdirAll(docker_repo, 0700); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
 	store, err := fs.New(path.Join(root, "images"))
 	if err != nil {
 		return nil, err
@@ -120,14 +126,10 @@ func NewFromDirectory(root string) (*Docker, error) {
 
 	docker := &Docker{
 		root:           root,
-		repository:     path.Join(root, "containers"),
+		repository:     docker_repo,
 		containers:     list.New(),
 		Store:          store,
 		networkManager: netManager,
-	}
-
-	if err := os.MkdirAll(docker.repository, 0700); err != nil && !os.IsExist(err) {
-		return nil, err
 	}
 
 	if err := docker.restore(); err != nil {

--- a/future/future.go
+++ b/future/future.go
@@ -113,12 +113,16 @@ func (r *progressReader) Read(p []byte) (n int, err error) {
 
 	// Only update progress for every 1% read
 	update_every := int(0.01 * float64(r.read_total))
-    if r.read_progress - r.last_update > update_every {
+    if r.read_progress - r.last_update > update_every || r.read_progress == r.read_total {
 		fmt.Fprintf(r.output, "%d/%d (%.0f%%)\r", 
 			r.read_progress,
 			r.read_total,
 			float64(r.read_progress) / float64(r.read_total) * 100)
 		r.last_update = r.read_progress
+	}
+	// Send newline when complete
+	if err == io.EOF {
+		fmt.Fprintf(r.output, "\n")
 	}
 
 	return read, err


### PR DESCRIPTION
Fixes bug #71 (new installs fail because /var/lib/docker doesn't exist) and also makes a minor improvement to the download progress bar
