### PR TITLE
65 autodownload unittest image

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1,4 +1,4 @@
-package commands
+package docker
 
 import (
 	"bufio"
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/dotcloud/docker"
 	"github.com/dotcloud/docker/fs"
 	"github.com/dotcloud/docker/future"
 	"github.com/dotcloud/docker/rcli"
@@ -550,7 +549,7 @@ func (srv *Server) CmdPs(stdin io.ReadCloser, stdout io.Writer, args ...string) 
 		if !*quiet {
 			command := fmt.Sprintf("%s %s", container.Path, strings.Join(container.Args, " "))
 			if !*fl_full {
-				command = docker.Trunc(command, 20)
+				command = Trunc(command, 20)
 			}
 			for idx, field := range []string{
 				/* ID */ container.Id,
@@ -741,10 +740,10 @@ func (srv *Server) CmdLogs(stdin io.ReadCloser, stdout io.Writer, args ...string
 	return errors.New("No such container: " + cmd.Arg(0))
 }
 
-func (srv *Server) CreateContainer(img *fs.Image, ports []int, user string, tty bool, openStdin bool, memory int64, comment string, cmd string, args ...string) (*docker.Container, error) {
+func (srv *Server) CreateContainer(img *fs.Image, ports []int, user string, tty bool, openStdin bool, memory int64, comment string, cmd string, args ...string) (*Container, error) {
 	id := future.RandomId()[:8]
 	container, err := srv.containers.Create(id, cmd, args, img,
-		&docker.Config{
+		&Config{
 			Hostname:  id,
 			Ports:     ports,
 			User:      user,
@@ -945,12 +944,12 @@ func (srv *Server) CmdRun(stdin io.ReadCloser, stdout io.Writer, args ...string)
 	return nil
 }
 
-func New() (*Server, error) {
+func NewServer() (*Server, error) {
 	future.Seed()
 	// if err != nil {
 	// 	return nil, err
 	// }
-	containers, err := docker.New()
+	containers, err := New()
 	if err != nil {
 		return nil, err
 	}
@@ -1001,6 +1000,6 @@ func (srv *Server) CmdWeb(stdin io.ReadCloser, stdout io.Writer, args ...string)
 }
 
 type Server struct {
-	containers *docker.Docker
+	containers *Docker
 	images     *fs.Store
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"github.com/dotcloud/docker"
-	"github.com/dotcloud/docker/commands"
 	"github.com/dotcloud/docker/future"
 	"github.com/dotcloud/docker/rcli"
 	"github.com/dotcloud/docker/term"
@@ -36,7 +35,7 @@ func main() {
 }
 
 func daemon() error {
-	service, err := commands.New()
+	service, err := docker.NewServer()
 	if err != nil {
 		return err
 	}
@@ -78,7 +77,7 @@ func runCommand(args []string) error {
 			}
 		}
 	} else {
-		service, err := commands.New()
+		service, err := docker.NewServer()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix issue #65, Download via CmdImport the busybox image and perform the tests.
We do not need anymore to manually download the debootstrap
In order to do that, I had to move the commands package within the main docker's one (import cycle).
