### PR TITLE
Fix undeleted mountpoint on destroy

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -76,10 +76,9 @@ func (docker *Docker) Destroy(container *Container) error {
 		if err := container.Mountpoint.Umount(); err != nil {
 			log.Printf("Unable to umount container %v: %v", container.Id, err)
 		}
-
-		if err := container.Mountpoint.Deregister(); err != nil {
-			log.Printf("Unable to deregiser mountpoint %v: %v", container.Mountpoint.Root, err)
-		}
+	}
+	if err := container.Mountpoint.Deregister(); err != nil {
+		log.Printf("Unable to deregiser mountpoint %v: %v", container.Mountpoint.Root, err)
 	}
 	if err := os.RemoveAll(container.Root); err != nil {
 		log.Printf("Unable to remove filesystem for %v: %v", container.Id, err)


### PR DESCRIPTION
Issue #77, Now mountpoints are always deleted even when not currently mounted.
