### PR TITLE
Some minor cleanup of cleanup in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ install:
 	install -m 0755 bin/docker $(DESTDIR)/$(INSDIR)
 	install -o root -m 0755 etc/docker.upstart $(DESTDIR)/etc/init/docker.conf
 
-$(BUILD_SRC): cleanup
+$(BUILD_SRC): clean
 	# Copy ourselves into $BUILD_SRC to comply with unusual golang constraints
 	tar --exclude=*.tar.gz --exclude=checkout.tgz -f checkout.tgz -cz *
 	mkdir -p $(BUILD_SRC)/$(GITHUB_PATH)
@@ -79,6 +79,5 @@ gotest:
 	done
 	@sudo rm -rf /tmp/docker-*
 
-cleanup:
-
+clean:
 	rm -rf $(BUILD_PATH) debian/$(PKG_NAME)* debian/files $(BUILD_SRC) checkout.tgz

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TMPDIR=$(shell mktemp -d -t XXXXXX)
 
 
 # Build a debian source package
-all: build_in_deb
+all: clean build_in_deb
 
 build_in_deb:
 	echo "GOPATH = " $(ROOT_PATH)

--- a/Makefile
+++ b/Makefile
@@ -80,4 +80,4 @@ gotest:
 	@sudo rm -rf /tmp/docker-*
 
 clean:
-	rm -rf $(BUILD_PATH) debian/$(PKG_NAME)* debian/files $(BUILD_SRC) checkout.tgz
+	rm -rf $(BUILD_PATH) debian/$(PKG_NAME)* debian/files $(BUILD_SRC) checkout.tgz bin


### PR DESCRIPTION
1. Rename cleanup to clean to match conventions
2. Adding bin to clean, this prevents build failures and also ensures only recent artifacts are packaged
3. Default make now results in an implicit clean before building.
