### PR TITLE
Fix issue #120, initialize TCPAddr w/ field names

### DIFF
--- a/network.go
+++ b/network.go
@@ -279,7 +279,7 @@ func (iface *NetworkInterface) AllocatePort(port int) (int, error) {
 	if err != nil {
 		return -1, err
 	}
-	if err := iface.manager.portMapper.Map(extPort, net.TCPAddr{iface.IPNet.IP, port}); err != nil {
+	if err := iface.manager.portMapper.Map(extPort, net.TCPAddr{IP: iface.IPNet.IP, Port: port}); err != nil {
 		iface.manager.portAllocator.Release(extPort)
 		return -1, err
 	}

--- a/network.go
+++ b/network.go
@@ -319,7 +319,7 @@ func (manager *NetworkManager) Allocate() (*NetworkInterface, error) {
 		return nil, err
 	}
 	iface := &NetworkInterface{
-		IPNet:   net.IPNet{ip, manager.bridgeNetwork.Mask},
+		IPNet:   net.IPNet{IP: ip, Mask: manager.bridgeNetwork.Mask},
 		Gateway: manager.bridgeNetwork.IP,
 		manager: manager,
 	}


### PR DESCRIPTION
Current Go tip (+74e65f07a0c8) and likely Go 1.1 does not build docker since net.TCPAddr struct has an additional field now for IPv6:

type TCPAddr struct {
    IP   IP
    Port int
    Zone string // IPv6 scoped addressing zone
}

Initializing the struct with named fields resolves this problem.
