### PR TITLE
Fix for attach not taking additional options

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -822,7 +822,7 @@ func (srv *Server) CmdAttach(stdin io.ReadCloser, stdout io.Writer, args ...stri
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
-	if cmd.NArg() != 1 {
+	if cmd.NArg() == 0 {
 		cmd.Usage()
 		return nil
 	}


### PR DESCRIPTION
ezbercih@ubuntu-server:~/code/go/src/github.com/dotcloud/docker/docker$ JOB=$(docker run base /bin/sh -c "while true; do echo Hello world; sleep 1; done")
ezbercih@ubuntu-server:~/code/go/src/github.com/dotcloud/docker/docker$ docker ps
ID          IMAGE              COMMAND                CREATED         STATUS         COMMENT
30a00b56    a1f063269abde34e   /bin/sh -c while tru   3 seconds ago   Up 3 seconds
ezbercih@ubuntu-server:~/code/go/src/github.com/dotcloud/docker/docker$ docker attach 30a00b56 -i

Usage: docker attach [OPTIONS]

Attach to a running container

  -e=true: Attach to stderr
  -i=false: Attach to stdin
  -o=true: Attach to stdout
ezbercih@ubuntu-server:~/code/go/src/github.com/dotcloud/docker/docker$ docker attach 30a00b56
Hello world
Hello world
Hello world
