### PR TITLE
Add :create flag to shared folders (prevents first run vagrant failures)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,7 +34,7 @@ Vagrant.configure("1") do |config|
   # Share an additional folder to the guest VM. The first argument is
   # an identifier, the second is the path on the guest to mount the
   # folder, and the third is the path on the host to the actual folder.
-  config.vm.share_folder "v-data", "~/docker", "~/docker"
+  config.vm.share_folder "v-data", "~/docker", "~/docker", :create => true
 
   # Enable provisioning with Puppet stand alone.  Puppet manifests
   # are contained in a directory path relative to this Vagrantfile.


### PR DESCRIPTION
Currently, if the specified shared folders don't exist (eg: `~/docker`), running `vagrant up` will result in a error. This flag creates the folder if it's missing, which is an intuitive behaviour. 
