### PR TITLE
Fixing Issue #98: Adding DOCKER to output chain during iptables setup

### DIFF
--- a/network.go
+++ b/network.go
@@ -124,6 +124,9 @@ func (mapper *PortMapper) setup() error {
 	if err := iptables("-t", "nat", "-A", "PREROUTING", "-j", "DOCKER"); err != nil {
 		return errors.New("Unable to setup port networking: Failed to inject docker in PREROUTING chain")
 	}
+	if err := iptables("-t", "nat", "-A", "OUTPUT", "-j", "DOCKER"); err != nil {
+		return errors.New("Unable to setup port networking: Failed to inject docker in OUTPUT chain")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Added the iptables fix for NAT issues to network.go.  Fixes my problems with accessing NAT ports on the docker host.
