### PR TITLE
handle errors during the creation of port mapper

### DIFF
--- a/network.go
+++ b/network.go
@@ -348,6 +348,9 @@ func newNetworkManager(bridgeIface string) (*NetworkManager, error) {
 	}
 
 	portMapper, err := newPortMapper()
+	if err != nil {
+		return nil, err
+	}
 
 	manager := &NetworkManager{
 		bridgeIface:   bridgeIface,


### PR DESCRIPTION
without this change, docker crashes with nil pointer reference followed by ugly goroutine stack trace. after this change, one would see an one-line error message:

example:

```
2013/03/22 21:42:55 Unable to setup port networking: Failed to create DOCKER chain

(which was possibly introduced by commit 3c6b8bb88)
```
