### PR TITLE
log errors from iptables

### DIFF
--- a/network.go
+++ b/network.go
@@ -68,8 +68,10 @@ func networkSize(mask net.IPMask) (int32, error) {
 
 // Wrapper around the iptables command
 func iptables(args ...string) error {
-	if err := exec.Command("/sbin/iptables", args...).Run(); err != nil {
-		return fmt.Errorf("iptables failed: iptables %v", strings.Join(args, " "))
+	if output, err := exec.Command("/sbin/iptables", args...).CombinedOutput(); err != nil {
+		argsCombined := strings.Join(args, " ")
+		log.Printf("iptables failed (iptables %v): %s", argsCombined, output)
+		return fmt.Errorf("iptables failed: iptables %v", argsCombined)
 	}
 	return nil
 }

--- a/network.go
+++ b/network.go
@@ -70,7 +70,7 @@ func networkSize(mask net.IPMask) (int32, error) {
 func iptables(args ...string) error {
 	if output, err := exec.Command("/sbin/iptables", args...).CombinedOutput(); err != nil {
 		argsCombined := strings.Join(args, " ")
-		log.Printf("iptables failed (iptables %v): %s", argsCombined, output)
+		log.Printf("ERROR: iptables failed (iptables %v): %s", argsCombined, output)
 		return fmt.Errorf("iptables failed: iptables %v", argsCombined)
 	}
 	return nil


### PR DESCRIPTION
eg:

```
$ go install -v github.com/dotcloud/docker/...; and sudo ~/go/bin/docker -d
github.com/dotcloud/docker
github.com/dotcloud/docker/docker
2013/03/22 21:57:19 ERROR: iptables failed (iptables -t nat -D PREROUTING -j DOCKER): iptables: No chain/target/match by that name.
2013/03/22 21:57:19 ERROR: iptables failed (iptables -t nat -X DOCKER): iptables: Too many links.
2013/03/22 21:57:19 ERROR: iptables failed (iptables -t nat -N DOCKER): iptables: Chain already exists.
2013/03/22 21:57:19 Unable to setup port networking: Failed to create DOCKER chain
$
```
