### PR TITLE
`docker import` doesn't download an image

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Running an interactive shell
 
 ```bash
 # Download a base image
-docker import base
+docker pull base
 
 # Run an interactive shell in the base image,
 # allocate a tty, attach stdin and stdout


### PR DESCRIPTION
```
$ docker import base
Downloading from http://base
Error: Get http://base: lookup base: no such host
```

only `docker pull` does:

```
$ docker pull base
Pulling base...
Pulling repo: https://registry.docker.io/v1/users/base
Pull completed
```
