### PR TITLE
vagrant: Simplify provisioning to build from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.vagrant
+.vagrant*
 bin
 docker/docker
 .*.swp

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,115 +2,30 @@
 # vi: set ft=ruby :
 
 def v10(config)
-  # All Vagrant configuration is done here. The most common configuration
-  # options are documented and commented below. For a complete reference,
-  # please see the online documentation at vagrantup.com.
-
-  # Every Vagrant virtual environment requires a box to build off of.
   config.vm.box = "quantal64_3.5.0-25"
-
-  # The url from where the 'config.vm.box' box will be fetched if it
-  # doesn't already exist on the user's system.
   config.vm.box_url = "http://get.docker.io/vbox/ubuntu/12.10/quantal64_3.5.0-25.box"
 
-  # Boot with a GUI so you can see the screen. (Default is headless)
-  # config.vm.boot_mode = :gui
-
-  # Assign this VM to a host-only network IP, allowing you to access it
-  # via the IP. Host-only networks can talk to the host machine as well as
-  # any other machines on the same network, but cannot be accessed (through this
-  # network interface) by any external networks.
-  config.vm.network :hostonly, "192.168.33.10"
-
-  # Assign this VM to a bridged network, allowing you to connect directly to a
-  # network using the host's network device. This makes the VM appear as another
-  # physical device on your network.
-  #config.vm.network :bridged
-
-  # Forward a port from the guest to the host, which allows for outside
-  # computers to access the VM, whereas host only networking does not.
-  # config.vm.forward_port 80, 8080
+  config.vm.share_folder "v-data", "/opt/go/src/github.com/dotcloud/docker", File.dirname(__FILE__)
 
   # Ensure puppet is installed on the instance
   config.vm.provision :shell, :inline => "apt-get -qq update; apt-get install -y puppet"
 
-  # Share an additional folder to the guest VM. The first argument is
-  # an identifier, the second is the path on the guest to mount the
-  # folder, and the third is the path on the host to the actual folder.
-  config.vm.share_folder "v-data", "~/docker", File.dirname(__FILE__)
-
-  # Enable provisioning with Puppet stand alone.  Puppet manifests
-  # are contained in a directory path relative to this Vagrantfile.
-  # You will need to create the manifests directory and a manifest in
-  # the file quantal64.pp in the manifests_path directory.
-  #
-  # An example Puppet manifest to provision the message of the day:
-  #
-  # # group { "puppet":
-  # #   ensure => "present",
-  # # }
-  # #
-  # # File { owner => 0, group => 0, mode => 0644 }
-  # #
-  # # file { '/etc/motd':
-  # #   content => "Welcome to your Vagrant-built virtual machine!
-  # #               Managed by Puppet.\n"
-  # # }
-  #
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = "puppet/manifests"
     puppet.manifest_file  = "quantal64.pp"
     puppet.module_path = "puppet/modules"
   end
-
-  # Enable provisioning with chef solo, specifying a cookbooks path, roles
-  # path, and data_bags path (all relative to this Vagrantfile), and adding 
-  # some recipes and/or roles.
-  #
-  # config.vm.provision :chef_solo do |chef|
-  #   chef.cookbooks_path = "../my-recipes/cookbooks"
-  #   chef.roles_path = "../my-recipes/roles"
-  #   chef.data_bags_path = "../my-recipes/data_bags"
-  #   chef.add_recipe "mysql"
-  #   chef.add_role "web"
-  #
-  #   # You may also specify custom JSON attributes:
-  #   chef.json = { :mysql_password => "foo" }
-  # end
-
-  # Enable provisioning with chef server, specifying the chef server URL,
-  # and the path to the validation key (relative to this Vagrantfile).
-  #
-  # The Opscode Platform uses HTTPS. Substitute your organization for
-  # ORGNAME in the URL and validation key.
-  #
-  # If you have your own Chef Server, use the appropriate URL, which may be
-  # HTTP instead of HTTPS depending on your configuration. Also change the
-  # validation key to validation.pem.
-  #
-  # config.vm.provision :chef_client do |chef|
-  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
-  #   chef.validation_key_path = "ORGNAME-validator.pem"
-  # end
-  #
-  # If you're using the Opscode platform, your validator client is
-  # ORGNAME-validator, replacing ORGNAME with your organization name.
-  #
-  # IF you have your own Chef Server, the default validation client name is
-  # chef-validator, unless you changed the configuration.
-  #
-  #   chef.validation_client_name = "ORGNAME-validator"
 end
 
-"#{Vagrant::VERSION}" < "1.1.0" and Vagrant::Config.run do |config|
+Vagrant::VERSION < "1.1.0" and Vagrant::Config.run do |config|
   v10(config)
 end
 
-"#{Vagrant::VERSION}" >= "1.1.0" and Vagrant.configure("1") do |config|
+Vagrant::VERSION >= "1.1.0" and Vagrant.configure("1") do |config|
   v10(config)
 end
 
-"#{Vagrant::VERSION}" >= "1.1.0" and Vagrant.configure("2") do |config|
+Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
   config.vm.provider :aws do |aws|
     config.vm.box = "dummy"
     config.vm.box_url = "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
@@ -130,10 +45,10 @@ end
     config.ssh.private_key_path = ENV["RS_PRIVATE_KEY"]
     rs.username = ENV["RS_USERNAME"]
     rs.api_key  = ENV["RS_API_KEY"]
-    rs.public_key_path = ENV["RS_PUBLIC_KEY"] 
+    rs.public_key_path = ENV["RS_PUBLIC_KEY"]
     rs.flavor   = /512MB/
     rs.image    = /Ubuntu/
-  end   
+  end
 
   config.vm.provider :virtualbox do |vb|
     config.vm.box = "quantal64_3.5.0-25"

--- a/puppet/modules/docker/manifests/init.pp
+++ b/puppet/modules/docker/manifests/init.pp
@@ -1,76 +1,29 @@
 class virtualbox {
-	Package { ensure => "installed" }
+    Package { ensure => "installed" }
 
-	user { "vagrant":
-		name => "vagrant",
-		ensure => present,
-		comment => "Vagrant User",
-		shell => "/bin/bash",
-		home => "/home/vagrant",
-	}
+    # remove some files from the base vagrant image because they're old
+    file { "/home/vagrant/docker-master":
+        ensure => absent,
+        recurse => true,
+        force => true,
+        purge => true,
+    }
+    file { "/usr/local/bin/dockerd":
+        ensure => absent,
+    }
 
-	file { "/home/vagrant":
-		mode => 644,
-		require => User["vagrant"],
-	}
-
-	# remove some files from the base vagrant image because they're old
-	file { "/home/vagrant/docker-master":
-		ensure => absent,
-		recurse => true,
-		force => true,
-		purge => true,
-		require => File["/home/vagrant"],
-	}
-	file { "/usr/local/bin/dockerd":
-		ensure => absent,
-	}
-
-	# Set up VirtualBox guest utils
-	package { "virtualbox-guest-utils": }
+    # Set up VirtualBox guest utils
+    package { "virtualbox-guest-utils": }
     exec { "vbox-add" :
         command => "/etc/init.d/vboxadd setup",
         require => [
-			Package["virtualbox-guest-utils"],
-			Package["linux-headers-3.5.0-25-generic"], ],
+            Package["virtualbox-guest-utils"],
+            Package["linux-headers-3.5.0-25-generic"], ],
     }
 }
 
-class ec2 {
-	user { "vagrant":
-		name => "ubuntu",
-		ensure => present,
-		comment => "Vagrant User",
-		shell => "/bin/bash",
-		home => "/home/ubuntu",
-	}
-	file { "/home/vagrant":
-		ensure => link,
-		target => "/home/ubuntu",
-		require => User["vagrant"],
-	}
-}
-
-class rax {
-	user { "vagrant":
-		name => "ubuntu",
-		ensure => present,
-		comment => "Vagrant User",
-		shell => "/bin/bash",
-		home => "/home/ubuntu",
-	}
-	file { "/home/vagrant":
-		ensure => link,
-		target => "/home/ubuntu",
-		require => User["vagrant"],
-	}
-}
-
 class docker {
-
-    # update this with latest docker binary distro
-    $docker_url = "http://get.docker.io/builds/$kernel/$hardwaremodel/docker-master.tgz"
-    # update this with latest go binary distry
+    # update this with latest go binary dist
     $go_url = "http://go.googlecode.com/files/go1.0.3.linux-amd64.tar.gz"
 
     Package { ensure => "installed" }
@@ -81,29 +34,21 @@ class docker {
                "linux-image-extra-3.5.0-25-generic",
                "linux-headers-3.5.0-25-generic"]: }
 
-    notify { "docker_url = $docker_url": withpath => true }
-
     $ec2_version = file("/etc/ec2_version", "/dev/null")
     $rax_version = inline_template("<%= %x{/usr/bin/xenstore-read vm-data/provider_data/provider} %>")
 
     if ($ec2_version) {
-		$vagrant_user = "ubuntu"
-		include ec2
+        $vagrant_user = "ubuntu"
+        $vagrant_home = "/home/ubuntu"
     } elsif ($rax_version) {
-		$vagrant_user = "vagrant"
-        include rax
+        $vagrant_user = "root"
+        $vagrant_home = "/root"
     } else {
-    # virtualbox is the vagrant default, so it should be safe to assume
-		$vagrant_user = "vagrant"
+        # virtualbox is the vagrant default, so it should be safe to assume
+        $vagrant_user = "vagrant"
+        $vagrant_home = "/home/vagrant"
         include virtualbox
     }
-
-	file { "/usr/local/bin":
-		ensure => directory,
-		owner => root,
-		group => root,
-		mode => 755,
-	}
 
     exec { "fetch-go":
         require => Package["wget"],
@@ -111,37 +56,41 @@ class docker {
         creates => "/usr/local/go/bin/go",
     }
 
-    exec { "fetch-docker" :
-        command => "/usr/bin/wget -O - $docker_url | /bin/tar xz -C /tmp",
-        require => Package["wget"],
-    }
-
     file { "/etc/init/dockerd.conf":
         mode => 600,
         owner => "root",
         group => "root",
         content => template("docker/dockerd.conf"),
-        require => Exec["copy-docker-bin"],
     }
 
-    file { "/home/vagrant/.profile":
+    file { "/opt/go":
+        owner => $vagrant_user,
+        group => $vagrant_user,
+        recurse => true,
+    }
+
+    file { "${vagrant_home}/.profile":
         mode => 644,
         owner => $vagrant_user,
-        group => "ubuntu",
+        group => $vagrant_user,
         content => template("docker/profile"),
-        require => File["/home/vagrant"],
     }
 
-    exec { "copy-docker-bin" :
-        command => "/usr/bin/sudo /bin/cp -f /tmp/docker-master/docker /usr/local/bin/",
-        require => [ Exec["fetch-docker"], File["/usr/local/bin"] ],
+     exec { "build-docker" :
+        cwd  => "/opt/go/src/github.com/dotcloud/docker",
+        user => $vagrant_user,
+        environment => "GOPATH=/opt/go",
+        command => "/usr/local/go/bin/go get -v ./... && /usr/local/go/bin/go install ./docker",
+        creates => "/opt/go/bin/docker",
+        logoutput => "on_failure",
+        require => [ Exec["fetch-go"], File["/opt/go"] ],
     }
 
     service { "dockerd" :
         ensure => "running",
         start => "/sbin/initctl start dockerd",
         stop => "/sbin/initctl stop dockerd",
-        require => File["/etc/init/dockerd.conf"],
+        require => [ Exec["build-docker"], File["/etc/init/dockerd.conf"] ],
         name => "dockerd",
         provider => "base"
     }

--- a/puppet/modules/docker/templates/dockerd.conf
+++ b/puppet/modules/docker/templates/dockerd.conf
@@ -8,5 +8,5 @@ respawn
 
 script
     test -f /etc/default/locale && . /etc/default/locale || true
-    LANG=$LANG LC_ALL=$LANG /usr/local/bin/docker -d >> /var/log/dockerd 2>&1
+    LANG=$LANG LC_ALL=$LANG /opt/go/bin/docker -d >> /var/log/dockerd 2>&1
 end script

--- a/puppet/modules/docker/templates/profile
+++ b/puppet/modules/docker/templates/profile
@@ -21,7 +21,10 @@ if [ -d "$HOME/bin" ] ; then
     PATH="$HOME/bin:$PATH"
 fi
 
-# set ~/docker as the go path
-export GOPATH=~/docker
-# add go to the PATH
-export PATH=$PATH:/usr/local/go/bin
+export GOPATH=/opt/go
+export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
+
+docker=/opt/go/src/github.com/dotcloud/docker
+if [ -d $docker ]; then
+  cd $docker
+fi


### PR DESCRIPTION
This sets up an idiomatic Go workspace in `/opt/go` with the source shared from the host directory in  `/opt/go/src/github.com/dotcloud/docker` and docker compiled/installed into `/opt/go/bin`.

~~Tested on Virtualbox, but I was unable to test on AWS due to #182.~~

Tested on Virtualbox, AWS, and Rackspace.
