### PR TITLE
Added `pull base` command to Linux docs

### DIFF
--- a/docs/sources/documentation/installation/ubuntulinux.rst
+++ b/docs/sources/documentation/installation/ubuntulinux.rst
@@ -40,6 +40,7 @@ Run your first container!
 
 ::
 
+    sudo ./docker pull base
     sudo ./docker run -i -t base /bin/bash
 
 Consider adding docker to your PATH for simplicity.


### PR DESCRIPTION
Following the Linux example I ended with `2013/03/26 22:26:00 Error creating container: No such image: base`. I added the `./docker pull base` command to the docs.

Sorry for the new-line change, the Github editor did that. Let me know if you want me to change that.
