### PR TITLE
Fixed a misspelled command in the docs.

### DIFF
--- a/docs/sources/documentation/installation/macos.rst
+++ b/docs/sources/documentation/installation/macos.rst
@@ -32,7 +32,7 @@ Installation
 
 .. code-block:: bash
 
-    vagant up
+    vagrant up
 
 Vagrant will:
 


### PR DESCRIPTION
`vagrant up` command was misspelled as `vagant up`.
