### PR TITLE
docs - remove references to run -a

### DIFF
--- a/docs/sources/documentation/commandline/basecommands.rst
+++ b/docs/sources/documentation/commandline/basecommands.rst
@@ -17,7 +17,7 @@ Running an interactive shell
 
   # Run an interactive shell in the base image,
   # allocate a tty, attach stdin and stdout
-  docker run -a -i -t base /bin/bash
+  docker run -i -t base /bin/bash
 
 
 Starting a long-running worker process

--- a/docs/sources/documentation/installation/windows.rst
+++ b/docs/sources/documentation/installation/windows.rst
@@ -156,7 +156,7 @@ You are now ready for the docker’s “hello world” example. Run
 
 .. code-block:: bash
 
-	docker run -a busybox echo hello world 
+	docker run busybox echo hello world
 
 .. image:: images/win/run_04.gif
    :alt: run docker


### PR DESCRIPTION
This pull request removes references in the docs to the excised -a flag.
