### PR TITLE
use the directory where the vagrantfile is located for mounting

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,7 @@ def v10(config)
   # Share an additional folder to the guest VM. The first argument is
   # an identifier, the second is the path on the guest to mount the
   # folder, and the third is the path on the host to the actual folder.
-  config.vm.share_folder "v-data", "~/docker", "~/docker"
+  config.vm.share_folder "v-data", "~/docker", File.dirname(__FILE__)
 
   # Enable provisioning with Puppet stand alone.  Puppet manifests
   # are contained in a directory path relative to this Vagrantfile.


### PR DESCRIPTION
This is pretty much #202 but with the second argument as the directory where the Vagrantfile resides. 
