### PR TITLE
Camelize some snake_case variable names

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -76,13 +76,13 @@ func LoadConfig(rootPath string) (*AuthConfig, error) {
 		return nil, err
 	}
 	arr := strings.Split(string(b), "\n")
-	orig_auth := strings.Split(arr[0], " = ")
-	orig_email := strings.Split(arr[1], " = ")
-	authConfig, err := DecodeAuth(orig_auth[1])
+	origAuth := strings.Split(arr[0], " = ")
+	origEmail := strings.Split(arr[1], " = ")
+	authConfig, err := DecodeAuth(origAuth[1])
 	if err != nil {
 		return nil, err
 	}
-	authConfig.Email = orig_email[1]
+	authConfig.Email = origEmail[1]
 	authConfig.rootPath = rootPath
 	return authConfig, nil
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -17,11 +17,11 @@ func main() {
 		return
 	}
 	// FIXME: Switch d and D ? (to be more sshd like)
-	fl_daemon := flag.Bool("d", false, "Daemon mode")
-	fl_debug := flag.Bool("D", false, "Debug mode")
+	flDaemon := flag.Bool("d", false, "Daemon mode")
+	flDebug := flag.Bool("D", false, "Debug mode")
 	flag.Parse()
-	rcli.DEBUG_FLAG = *fl_debug
-	if *fl_daemon {
+	rcli.DEBUG_FLAG = *flDebug
+	if *flDaemon {
 		if flag.NArg() != 0 {
 			flag.Usage()
 			return
@@ -59,22 +59,22 @@ func runCommand(args []string) error {
 	// closing the connection.
 	// See http://code.google.com/p/go/issues/detail?id=3345
 	if conn, err := rcli.Call("tcp", "127.0.0.1:4242", args...); err == nil {
-		receive_stdout := docker.Go(func() error {
+		receiveStdout := docker.Go(func() error {
 			_, err := io.Copy(os.Stdout, conn)
 			return err
 		})
-		send_stdin := docker.Go(func() error {
+		sendStdin := docker.Go(func() error {
 			_, err := io.Copy(conn, os.Stdin)
 			if err := conn.CloseWrite(); err != nil {
 				log.Printf("Couldn't send EOF: " + err.Error())
 			}
 			return err
 		})
-		if err := <-receive_stdout; err != nil {
+		if err := <-receiveStdout; err != nil {
 			return err
 		}
 		if !term.IsTerminal(0) {
-			if err := <-send_stdin; err != nil {
+			if err := <-sendStdin; err != nil {
 				return err
 			}
 		}

--- a/runtime.go
+++ b/runtime.go
@@ -234,9 +234,9 @@ func NewRuntime() (*Runtime, error) {
 }
 
 func NewRuntimeFromDirectory(root string) (*Runtime, error) {
-	runtime_repo := path.Join(root, "containers")
+	runtimeRepo := path.Join(root, "containers")
 
-	if err := os.MkdirAll(runtime_repo, 0700); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(runtimeRepo, 0700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 
@@ -260,7 +260,7 @@ func NewRuntimeFromDirectory(root string) (*Runtime, error) {
 
 	runtime := &Runtime{
 		root:           root,
-		repository:     runtime_repo,
+		repository:     runtimeRepo,
 		containers:     list.New(),
 		networkManager: netManager,
 		graph:          g,

--- a/utils.go
+++ b/utils.go
@@ -63,25 +63,25 @@ func Debugf(format string, a ...interface{}) {
 
 // Reader with progress bar
 type progressReader struct {
-	reader        io.ReadCloser // Stream to read from
-	output        io.Writer     // Where to send progress bar to
-	read_total    int           // Expected stream length (bytes)
-	read_progress int           // How much has been read so far (bytes)
-	last_update   int           // How many bytes read at least update
+	reader       io.ReadCloser // Stream to read from
+	output       io.Writer     // Where to send progress bar to
+	readTotal    int           // Expected stream length (bytes)
+	readProgress int           // How much has been read so far (bytes)
+	lastUpdate   int           // How many bytes read at least update
 }
 
 func (r *progressReader) Read(p []byte) (n int, err error) {
 	read, err := io.ReadCloser(r.reader).Read(p)
-	r.read_progress += read
+	r.readProgress += read
 
 	// Only update progress for every 1% read
-	update_every := int(0.01 * float64(r.read_total))
-	if r.read_progress-r.last_update > update_every || r.read_progress == r.read_total {
+	updateEvery := int(0.01 * float64(r.readTotal))
+	if r.readProgress-r.lastUpdate > updateEvery || r.readProgress == r.readTotal {
 		fmt.Fprintf(r.output, "%d/%d (%.0f%%)\r",
-			r.read_progress,
-			r.read_total,
-			float64(r.read_progress)/float64(r.read_total)*100)
-		r.last_update = r.read_progress
+			r.readProgress,
+			r.readTotal,
+			float64(r.readProgress)/float64(r.readTotal)*100)
+		r.lastUpdate = r.readProgress
 	}
 	// Send newline when complete
 	if err == io.EOF {


### PR DESCRIPTION
In Go we use :camel: not :snake:.

:smirk:
