### PR TITLE
Fix a deadlock in CmdStream.

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -52,17 +52,21 @@ func CmdStream(cmd *exec.Cmd) (io.Reader, error) {
 		return nil, err
 	}
 	pipeR, pipeW := io.Pipe()
+	errChan := make(chan []byte)
+	go func() {
+		errText, e := ioutil.ReadAll(stderr)
+		if e != nil {
+			errText = []byte("(...couldn't fetch stderr: " + e.Error() + ")")
+		}
+		errChan <- errText
+	}()
 	go func() {
 		_, err := io.Copy(pipeW, stdout)
 		if err != nil {
 			pipeW.CloseWithError(err)
 		}
-		errText, e := ioutil.ReadAll(stderr)
-		if e != nil {
-			errText = []byte("(...couldn't fetch stderr: " + e.Error() + ")")
-		}
+		errText := <-errChan
 		if err := cmd.Wait(); err != nil {
-			// FIXME: can this block if stderr outputs more than the size of StderrPipe()'s buffer?
 			pipeW.CloseWithError(errors.New(err.Error() + ": " + string(errText)))
 		} else {
 			pipeW.Close()


### PR DESCRIPTION
As per FIXME, CmdStream could have deadlocked if a command printed
enough on stderr. This commit fixes that, but still keeps all of
the stderr output in memory.
