### PR TITLE
Do not log non-running containers

### DIFF
--- a/container.go
+++ b/container.go
@@ -256,6 +256,14 @@ func (container *Container) Start() error {
 		container.Config.Env...,
 	)
 
+	// Setup logging of stdout and stderr to disk
+	if err := container.runtime.LogToDisk(container.stdout, container.logPath("stdout")); err != nil {
+		return err
+	}
+	if err := container.runtime.LogToDisk(container.stderr, container.logPath("stderr")); err != nil {
+		return err
+	}
+
 	var err error
 	if container.Config.Tty {
 		container.cmd.Env = append(

--- a/runtime.go
+++ b/runtime.go
@@ -140,13 +140,6 @@ func (runtime *Runtime) Register(container *Container) error {
 	} else {
 		container.stdinPipe = NopWriteCloser(ioutil.Discard) // Silently drop stdin
 	}
-	// Setup logging of stdout and stderr to disk
-	if err := runtime.LogToDisk(container.stdout, container.logPath("stdout")); err != nil {
-		return err
-	}
-	if err := runtime.LogToDisk(container.stderr, container.logPath("stderr")); err != nil {
-		return err
-	}
 	// done
 	runtime.containers.PushBack(container)
 	return nil
@@ -157,7 +150,7 @@ func (runtime *Runtime) LogToDisk(src *writeBroadcaster, dst string) error {
 	if err != nil {
 		return err
 	}
-	src.AddWriter(NopWriteCloser(log))
+	src.AddWriter(log)
 	return nil
 }
 


### PR DESCRIPTION
When we have too much container, even stopped, we reach the FD limit.

Now, we log only when a container starts. So when we close the log, we really want to close it.
