### PR TITLE
Fix #108, reattach now works properly

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -220,6 +220,7 @@ func (w *writeBroadcaster) AddWriter(writer io.WriteCloser) {
 	w.writers.PushBack(writer)
 }
 
+// FIXME: Is that function used?
 func (w *writeBroadcaster) RemoveWriter(writer io.WriteCloser) {
 	for e := w.writers.Front(); e != nil; e = e.Next() {
 		v := e.Value.(io.Writer)
@@ -252,6 +253,7 @@ func (w *writeBroadcaster) Close() error {
 		writer := e.Value.(io.WriteCloser)
 		writer.Close()
 	}
+	w.writers.Init()
 	return nil
 }
 


### PR DESCRIPTION
The issue was that .Close() on the write side of the pipe does not kill the pipe as the Read side still block and waits for input.

Because of this, the write never failed and just block. Now that the logs do not need to be kept open all the time (#266), just reinit the list when it is closed.
