### PR TITLE
writeBroadcaster: thread safety and using a map instead of a list

### DIFF
--- a/container.go
+++ b/container.go
@@ -161,14 +161,14 @@ func (container *Container) startPty() error {
 
 	// Copy the PTYs to our broadcasters
 	go func() {
-		defer container.stdout.Close()
+		defer container.stdout.CloseWriters()
 		Debugf("[startPty] Begin of stdout pipe")
 		io.Copy(container.stdout, stdoutMaster)
 		Debugf("[startPty] End of stdout pipe")
 	}()
 
 	go func() {
-		defer container.stderr.Close()
+		defer container.stderr.CloseWriters()
 		Debugf("[startPty] Begin of stderr pipe")
 		io.Copy(container.stderr, stderrMaster)
 		Debugf("[startPty] End of stderr pipe")
@@ -374,10 +374,10 @@ func (container *Container) monitor() {
 	if err := container.releaseNetwork(); err != nil {
 		log.Printf("%v: Failed to release network: %v", container.Id, err)
 	}
-	if err := container.stdout.Close(); err != nil {
+	if err := container.stdout.CloseWriters(); err != nil {
 		Debugf("%s: Error close stdout: %s", container.Id, err)
 	}
-	if err := container.stderr.Close(); err != nil {
+	if err := container.stderr.CloseWriters(); err != nil {
 		Debugf("%s: Error close stderr: %s", container.Id, err)
 	}
 	if err := container.Unmount(); err != nil {

--- a/utils.go
+++ b/utils.go
@@ -242,7 +242,7 @@ func (w *writeBroadcaster) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func (w *writeBroadcaster) Close() error {
+func (w *writeBroadcaster) CloseWriters() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	for writer := range w.writers {

--- a/utils_test.go
+++ b/utils_test.go
@@ -122,7 +122,7 @@ func TestWriteBroadcaster(t *testing.T) {
 		t.Errorf("Buffer contains %v", bufferC.String())
 	}
 
-	writer.Close()
+	writer.CloseWriters()
 }
 
 type devNullCloser int


### PR DESCRIPTION
writeBroadcaster seems to be used concurrently by Container.StdoutPipe (as far as I can tell, it isn't very strange to call it when there are some writes happening).

RemoveWriter currently requires concrete writers to support equality operators. While that's nearly always the case (pointers do), we still might wish to just do away with the function. I've added a comment warning about that.

I couldn't see a reason why a list was preferable to a map, so I assume that there is none. If that's the case, the second commit simplifies writeBroadcaster a bit. In that case, Runtime.containers should probably undergo the same treatment.
