### PR TITLE
Add a check to avoid double start

### DIFF
--- a/container.go
+++ b/container.go
@@ -230,6 +230,9 @@ func (container *Container) start() error {
 }
 
 func (container *Container) Start() error {
+	if container.State.Running {
+		return fmt.Errorf("The container %s is already running.", container.Id)
+	}
 	if err := container.EnsureMounted(); err != nil {
 		return err
 	}

--- a/container_test.go
+++ b/container_test.go
@@ -231,6 +231,40 @@ func TestCommitRun(t *testing.T) {
 	}
 }
 
+func TestStart(t *testing.T) {
+	runtime, err := newTestRuntime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nuke(runtime)
+	container, err := runtime.Create(
+		&Config{
+			Image:     GetTestImage(runtime).Id,
+			Memory:    33554432,
+			Cmd:       []string{"/bin/cat"},
+			OpenStdin: true,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.Destroy(container)
+
+	if err := container.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Give some time to the process to start
+	container.WaitTimeout(500 * time.Millisecond)
+
+	if !container.State.Running {
+		t.Errorf("Container should be running")
+	}
+	if err := container.Start(); err == nil {
+		t.Fatalf("A running containter should be able to be started")
+	}
+}
+
 func TestRun(t *testing.T) {
 	runtime, err := newTestRuntime()
 	if err != nil {


### PR DESCRIPTION
Right now, if we start a running container (really running), the server panics.

Add a check to avoid this as well as a unit test.
