### PR TITLE
Added check in runtime.restore() for crashed containers still marked as running

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -224,6 +224,11 @@ func (runtime *Runtime) restore() error {
 		if err != nil {
 			Debugf("Failed to load container %v: %v", id, err)
 			continue
+		} else if container.State.Running {
+			if _, err := os.Stat(fmt.Sprintf("/proc/%d", container.State.Pid)); err != nil {
+				Debugf("Could not stat /proc/%v, assuming process has crashed.", container.State.Pid)
+				container.State.setStopped(-127)
+			}
 		}
 		Debugf("Loaded container %v", container.Id)
 	}


### PR DESCRIPTION
Fixes #257
