### PR TITLE
Adding git commit to the version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifeq ($(VERBOSE), 1)
 GO_OPTIONS += -v
 endif
 
-BUILD_OPTIONS = -ldflags "-X main.GIT_COMMIT `git rev-parse HEAD`"
+BUILD_OPTIONS = -ldflags "-X main.GIT_COMMIT `git rev-parse --short HEAD`"
 
 SRC_DIR := $(GOPATH)/src
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,10 @@ ifeq ($(VERBOSE), 1)
 GO_OPTIONS += -v
 endif
 
-BUILD_OPTIONS = -ldflags "-X main.GIT_COMMIT `git rev-parse --short HEAD`"
+GIT_COMMIT = $(shell git rev-parse --short HEAD)
+GIT_STATUS = $(shell test -n "`git status --porcelain`" && echo "+CHANGES")
+
+BUILD_OPTIONS = -ldflags "-X main.GIT_COMMIT $(GIT_COMMIT)$(GIT_STATUS)"
 
 SRC_DIR := $(GOPATH)/src
 

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ ifeq ($(VERBOSE), 1)
 GO_OPTIONS += -v
 endif
 
+BUILD_OPTIONS = -ldflags "-X main.GIT_COMMIT `git rev-parse HEAD`"
+
 SRC_DIR := $(GOPATH)/src
 
 DOCKER_DIR := $(SRC_DIR)/$(DOCKER_PACKAGE)
@@ -24,7 +26,7 @@ all: $(DOCKER_BIN)
 
 $(DOCKER_BIN): $(DOCKER_DIR)
 	@mkdir -p  $(dir $@)
-	@(cd $(DOCKER_MAIN); go get $(GO_OPTIONS); go build $(GO_OPTIONS) -o $@)
+	@(cd $(DOCKER_MAIN); go get $(GO_OPTIONS); go build $(GO_OPTIONS) $(BUILD_OPTIONS) -o $@)
 	@echo $(DOCKER_BIN_RELATIVE) is created.
 
 $(DOCKER_DIR):

--- a/commands.go
+++ b/commands.go
@@ -21,6 +21,8 @@ import (
 
 const VERSION = "0.1.0"
 
+var GIT_COMMIT string
+
 func (srv *Server) Name() string {
 	return "docker"
 }
@@ -128,6 +130,7 @@ func (srv *Server) CmdWait(stdin io.ReadCloser, stdout io.Writer, args ...string
 // 'docker version': show version information
 func (srv *Server) CmdVersion(stdin io.ReadCloser, stdout io.Writer, args ...string) error {
 	fmt.Fprintf(stdout, "Version:%s\n", VERSION)
+	fmt.Fprintf(stdout, "Git Commit:%s\n", GIT_COMMIT)
 	return nil
 }
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -10,6 +10,8 @@ import (
 	"os"
 )
 
+var GIT_COMMIT string
+
 func main() {
 	if docker.SelfPath() == "/sbin/init" {
 		// Running in init mode
@@ -21,6 +23,7 @@ func main() {
 	flDebug := flag.Bool("D", false, "Debug mode")
 	flag.Parse()
 	rcli.DEBUG_FLAG = *flDebug
+	docker.GIT_COMMIT = GIT_COMMIT
 	if *flDaemon {
 		if flag.NArg() != 0 {
 			flag.Usage()


### PR DESCRIPTION
The Makefile must be used in order to inject the git commit
via -ldflags.
