### PR TITLE
Add a 'fmt' target to the Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,6 @@ endif
 
 test: all
 	@(cd $(DOCKER_DIR); sudo -E go test $(GO_OPTIONS))
+
+fmt:
+	@find . -name "*.go" -exec gofmt -l -w {} \;


### PR DESCRIPTION
A convenience for gofmting all the code, including subpackages.
