### PR TITLE
Makefile: simplify "fmt" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,4 +43,4 @@ test: all
 	@(cd $(DOCKER_DIR); sudo -E go test $(GO_OPTIONS))
 
 fmt:
-	@find . -name "*.go" -exec gofmt -l -w {} \;
+	@gofmt -s -l -w .


### PR DESCRIPTION
Also include the `-s` flag, which simplifies code.
