### PR TITLE
#194 - add and use xz as default image compression

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -15,6 +15,7 @@ const (
 	Uncompressed Compression = iota
 	Bzip2
 	Gzip
+	Xz
 )
 
 func (compression *Compression) Flag() string {
@@ -23,6 +24,8 @@ func (compression *Compression) Flag() string {
 		return "j"
 	case Gzip:
 		return "z"
+	case Xz:
+		return "J"
 	}
 	return ""
 }

--- a/registry.go
+++ b/registry.go
@@ -267,14 +267,14 @@ func (graph *Graph) PushImage(stdout io.Writer, imgOrig *Image, authConfig *auth
 
 		// FIXME: Don't do this :D. Check the S3 requierement and implement chunks of 5MB
 		// FIXME2: I won't stress it enough, DON'T DO THIS! very high priority
-		layerData2, err := Tar(path.Join(graph.Root, img.Id, "layer"), Gzip)
+		layerData2, err := Tar(path.Join(graph.Root, img.Id, "layer"), Xz)
 		tmp, err := ioutil.ReadAll(layerData2)
 		if err != nil {
 			return err
 		}
 		layerLength := len(tmp)
 
-		layerData, err := Tar(path.Join(graph.Root, img.Id, "layer"), Gzip)
+		layerData, err := Tar(path.Join(graph.Root, img.Id, "layer"), Xz)
 		if err != nil {
 			return fmt.Errorf("Failed to generate layer archive: %s", err)
 		}


### PR DESCRIPTION
This pull request adds support for xz compression and makes it the default for uploads to the registry.

Please note that bsdtar can handle xz compression and decompression without external programs.

xz can lower the size of the images down to 20-30% of the original size.
