### PR TITLE
Allow attaching to stdin separately from stdout and stderr

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -874,7 +874,6 @@ func (srv *Server) CmdRun(stdin io.ReadCloser, stdout io.Writer, args ...string)
 	if !config.Detach {
 		var attachErr chan error
 		if config.OpenStdin {
-			config.StdinOnce = true
 			Debugf("Attaching with stdin\n")
 			attachErr = container.Attach(stdin, stdout, stdout)
 		} else {

--- a/commands_test.go
+++ b/commands_test.go
@@ -94,11 +94,15 @@ func TestRunDisconnect(t *testing.T) {
 		<-c1
 	})
 
-	// Check the status of the container
-	container := runtime.containers.Back().Value.(*Container)
-	if container.State.Running {
-		t.Fatalf("/bin/cat is still running after closing stdin")
-	}
+	// Client disconnect after run -i should cause stdin to be closed, which should
+	// cause /bin/cat to exit.
+	setTimeout(t, "Waiting for /bin/cat to exit timed out", 2*time.Second, func() {
+		container := runtime.List()[0]
+		container.Wait()
+		if container.State.Running {
+			t.Fatalf("/bin/cat is still running after closing stdin")
+		}
+	})
 }
 
 // Expected behaviour, the process stays alive when the client disconnects

--- a/commands_test.go
+++ b/commands_test.go
@@ -2,8 +2,11 @@ package docker
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"log"
 	"strings"
 	"testing"
 	"time"
@@ -103,6 +106,61 @@ func TestRunDisconnect(t *testing.T) {
 			t.Fatalf("/bin/cat is still running after closing stdin")
 		}
 	})
+}
+
+// TestAttachStdin checks attaching to stdin without stdout and stderr.
+// 'docker run -i -a stdin' should sends the client's stdin to the command,
+// then detach from it and print the container id.
+func TestAttachStdin(t *testing.T) {
+	runtime, err := newTestRuntime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nuke(runtime)
+	srv := &Server{runtime: runtime}
+
+	stdinR, stdinW := io.Pipe()
+	var stdout bytes.Buffer
+
+	ch := make(chan struct{})
+	go func() {
+		srv.CmdRun(stdinR, &stdout, "-i", "-a", "stdin", GetTestImage(runtime).Id, "sh", "-c", "echo hello; cat")
+		close(ch)
+	}()
+
+	// Send input to the command, close stdin, wait for CmdRun to return
+	setTimeout(t, "Read/Write timed out", 2*time.Second, func() {
+		if _, err := stdinW.Write([]byte("hi there\n")); err != nil {
+			t.Fatal(err)
+		}
+		stdinW.Close()
+		<-ch
+	})
+
+	// Check output
+	cmdOutput := string(stdout.Bytes())
+	container := runtime.List()[0]
+	if cmdOutput != container.ShortId()+"\n" {
+		t.Fatalf("Wrong output: should be '%s', not '%s'\n", container.ShortId()+"\n", cmdOutput)
+	}
+
+	setTimeout(t, "Waiting for command to exit timed out", 2*time.Second, func() {
+		container.Wait()
+	})
+
+	// Check logs
+	if cmdLogs, err := container.ReadLog("stdout"); err != nil {
+		t.Fatal(err)
+	} else {
+		if output, err := ioutil.ReadAll(cmdLogs); err != nil {
+			t.Fatal(err)
+		} else {
+			expectedLog := "hello\nhi there\n"
+			if string(output) != expectedLog {
+				t.Fatalf("Unexpected logs: should be '%s', not '%s'\n", expectedLog, output)
+			}
+		}
+	}
 }
 
 // Expected behaviour, the process stays alive when the client disconnects

--- a/commands_test.go
+++ b/commands_test.go
@@ -71,9 +71,9 @@ func TestRunDisconnect(t *testing.T) {
 	stdout, stdoutPipe := io.Pipe()
 	c1 := make(chan struct{})
 	go func() {
-		if err := srv.CmdRun(stdin, stdoutPipe, "-i", GetTestImage(runtime).Id, "/bin/cat"); err != nil {
-			t.Fatal(err)
-		}
+		// We're simulating a disconnect so the return value doesn't matter. What matters is the
+		// fact that CmdRun returns.
+		srv.CmdRun(stdin, stdoutPipe, "-i", GetTestImage(runtime).Id, "/bin/cat")
 		close(c1)
 	}()
 
@@ -135,9 +135,9 @@ func TestAttachDisconnect(t *testing.T) {
 	// Attach to it
 	c1 := make(chan struct{})
 	go func() {
-		if err := srv.CmdAttach(stdin, stdoutPipe, container.Id); err != nil {
-			t.Fatal(err)
-		}
+		// We're simulating a disconnect so the return value doesn't matter. What matters is the
+		// fact that CmdAttach returns.
+		srv.CmdAttach(stdin, stdoutPipe, container.Id)
 		close(c1)
 	}()
 

--- a/container.go
+++ b/container.go
@@ -101,6 +101,10 @@ func ParseRun(args []string, stdout io.Writer) (*Config, error) {
 		Cmd:       runCmd,
 		Image:     image,
 	}
+	// When allocating stdin in attached mode, close stdin at client disconnect
+	if config.OpenStdin && !config.Detach {
+		config.StdinOnce = true
+	}
 	return config, nil
 }
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"os/user"
+	"sync"
 	"testing"
 )
 
@@ -17,6 +18,15 @@ var unitTestStoreBase string
 var srv *Server
 
 func nuke(runtime *Runtime) error {
+	var wg sync.WaitGroup
+	for _, container := range runtime.List() {
+		wg.Add(1)
+		go func() {
+			container.Kill()
+			wg.Add(-1)
+		}()
+	}
+	wg.Wait()
 	return os.RemoveAll(runtime.root)
 }
 


### PR DESCRIPTION
To solve #234 we need a way to attach stdin separately from stdout and stderr.
