### PR TITLE
Refresh container state after docker crash

### DIFF
--- a/container.go
+++ b/container.go
@@ -127,6 +127,7 @@ func (container *Container) FromDisk() error {
 	if err := json.Unmarshal(data, container); err != nil {
 		return err
 	}
+	container.State.resetLock()
 	return nil
 }
 

--- a/container.go
+++ b/container.go
@@ -127,7 +127,6 @@ func (container *Container) FromDisk() error {
 	if err := json.Unmarshal(data, container); err != nil {
 		return err
 	}
-	container.State.resetLock()
 	return nil
 }
 

--- a/runtime.go
+++ b/runtime.go
@@ -11,7 +11,6 @@ import (
 	"path"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -154,9 +153,7 @@ func (runtime *Runtime) Register(container *Container) error {
 
 	container.runtime = runtime
 	// Setup state lock (formerly in newState()
-	lock := new(sync.Mutex)
-	container.State.stateChangeLock = lock
-	container.State.stateChangeCond = sync.NewCond(lock)
+	container.State.initLock()
 	// Attach to stdout and stderr
 	container.stderr = newWriteBroadcaster()
 	container.stdout = newWriteBroadcaster()

--- a/runtime.go
+++ b/runtime.go
@@ -117,6 +117,7 @@ func (runtime *Runtime) Load(id string) (*Container, error) {
 	if err := container.FromDisk(); err != nil {
 		return nil, err
 	}
+	container.State.initLock()
 	if container.Id != id {
 		return container, fmt.Errorf("Container %s is stored at %s", container.Id, id)
 	}

--- a/runtime.go
+++ b/runtime.go
@@ -136,14 +136,14 @@ func (runtime *Runtime) Register(container *Container) error {
 	}
 
 	// FIXME: if the container is supposed to be running but is not, auto restart it?
-	// If the container is supposed to be running, make sure of if
+	// If the container is supposed to be running, make sure of it
 	if container.State.Running {
 		if output, err := exec.Command("lxc-info", "-n", container.Id).CombinedOutput(); err != nil {
 			return err
 		} else {
 			if !strings.Contains(string(output), "RUNNING") {
 				Debugf("Container %s was supposed to be running be is not.", container.Id)
-				container.State.Running = false
+				container.State.setStopped(-127)
 				if err := container.ToDisk(); err != nil {
 					return err
 				}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"os/user"
 	"testing"
+	"time"
 )
 
 // FIXME: this is no longer needed
@@ -302,11 +303,12 @@ func TestRestore(t *testing.T) {
 	}
 
 	// Simulate a crash/manual quit of dockerd: process dies, states stays 'Running'
-	if err := container2.Stop(); err != nil {
-		t.Fatalf("Could not stop container: %v", err)
-	}
-
+	cStdin, _ := container2.StdinPipe()
+	cStdin.Close()
+	container2.State.setStopped(-1)
+	time.Sleep(time.Second)
 	container2.State.Running = true
+	container2.ToDisk()
 
 	if len(runtime1.List()) != 2 {
 		t.Errorf("Expected 2 container, %v found", len(runtime1.List()))

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -281,7 +281,7 @@ func TestRestore(t *testing.T) {
 	defer runtime1.Destroy(container1)
 
 	// Create a second container meant to be killed
-	container1_1, err := runtime1.Create(&Config{
+	container2, err := runtime1.Create(&Config{
 		Image:     GetTestImage(runtime1).Id,
 		Cmd:       []string{"/bin/cat"},
 		OpenStdin: true,
@@ -290,23 +290,23 @@ func TestRestore(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer runtime1.Destroy(container1_1)
+	defer runtime1.Destroy(container2)
 
 	// Start the container non blocking
-	if err := container1_1.Start(); err != nil {
+	if err := container2.Start(); err != nil {
 		t.Fatal(err)
 	}
 
-	if !container1_1.State.Running {
-		t.Fatalf("Container %v should appear as running but isn't", container1_1.Id)
+	if !container2.State.Running {
+		t.Fatalf("Container %v should appear as running but isn't", container2.Id)
 	}
 
 	// Simulate a crash/manual quit of dockerd: process dies, states stays 'Running'
-	if err := container1_1.Stop(); err != nil {
+	if err := container2.Stop(); err != nil {
 		t.Fatalf("Could not stop container: %v", err)
 	}
 
-	container1_1.State.Running = true
+	container2.State.Running = true
 
 	if len(runtime1.List()) != 2 {
 		t.Errorf("Expected 2 container, %v found", len(runtime1.List()))
@@ -315,8 +315,8 @@ func TestRestore(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !container1_1.State.Running {
-		t.Fatalf("Container %v should appear as running but isn't", container1_1.Id)
+	if !container2.State.Running {
+		t.Fatalf("Container %v should appear as running but isn't", container2.Id)
 	}
 
 	// Here are are simulating a docker restart - that is, reloading all containers
@@ -339,11 +339,11 @@ func TestRestore(t *testing.T) {
 	if runningCount != 0 {
 		t.Fatalf("Expected 0 container alive, %d found", runningCount)
 	}
-	container2 := runtime2.Get(container1.Id)
-	if container2 == nil {
+	container3 := runtime2.Get(container1.Id)
+	if container3 == nil {
 		t.Fatal("Unable to Get container")
 	}
-	if err := container2.Run(); err != nil {
+	if err := container3.Run(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -305,7 +305,9 @@ func TestRestore(t *testing.T) {
 	// Simulate a crash/manual quit of dockerd: process dies, states stays 'Running'
 	cStdin, _ := container2.StdinPipe()
 	cStdin.Close()
-	container2.WaitTimeout(time.Second)
+	if err := container2.WaitTimeout(time.Second); err != nil {
+		t.Fatal(err)
+	}
 	container2.State.Running = true
 	container2.ToDisk()
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -305,8 +305,7 @@ func TestRestore(t *testing.T) {
 	// Simulate a crash/manual quit of dockerd: process dies, states stays 'Running'
 	cStdin, _ := container2.StdinPipe()
 	cStdin.Close()
-	container2.State.setStopped(-1)
-	time.Sleep(time.Second)
+	container2.WaitTimeout(time.Second)
 	container2.State.Running = true
 	container2.ToDisk()
 

--- a/state.go
+++ b/state.go
@@ -39,6 +39,11 @@ func (s *State) setStopped(exitCode int) {
 	s.broadcast()
 }
 
+func (s *State) resetLock() {
+	s.stateChangeLock = &sync.Mutex{}
+	s.stateChangeCond = sync.NewCond(s.stateChangeLock)
+}
+
 func (s *State) broadcast() {
 	s.stateChangeLock.Lock()
 	s.stateChangeCond.Broadcast()

--- a/state.go
+++ b/state.go
@@ -39,9 +39,11 @@ func (s *State) setStopped(exitCode int) {
 	s.broadcast()
 }
 
-func (s *State) resetLock() {
-	s.stateChangeLock = &sync.Mutex{}
-	s.stateChangeCond = sync.NewCond(s.stateChangeLock)
+func (s *State) initLock() {
+	if s.stateChangeLock == nil {
+		s.stateChangeLock = &sync.Mutex{}
+		s.stateChangeCond = sync.NewCond(s.stateChangeLock)
+	}
 }
 
 func (s *State) broadcast() {


### PR DESCRIPTION
This time using lxc-info to poll the container state (Fix for #257)
