### PR TITLE
change option description to reflect the semantics

### DIFF
--- a/container.go
+++ b/container.go
@@ -80,7 +80,7 @@ func ParseRun(args []string, stdout io.Writer) (*Config, error) {
 	flMemory := cmd.Int64("m", 0, "Memory limit (in bytes)")
 
 	var flPorts ports
-	cmd.Var(&flPorts, "p", "Map a network port to the container")
+	cmd.Var(&flPorts, "p", "Expose a container's port to the host (use 'docker port' to see the actual mapping)")
 
 	var flEnv ListOpts
 	cmd.Var(&flEnv, "e", "Set environment variables")


### PR DESCRIPTION
At least, for me, 'map' means that there are two values and one is "mapped" to
another.

In this case, just one value is provided (container's port), the other value is
automatically obtained (host's port) and the actual mapping can be seen using
`docker port` command.
