### PR TITLE
Fix broken link on documentation website between examples.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,6 +21,7 @@ Jonathan Rudenberg <jonathan@titanous.com>
 Julien Barbier <write0@gmail.com>
 Jérôme Petazzoni <jerome.petazzoni@dotcloud.com>
 Ken Cochrane <kencochrane@gmail.com>
+Kevin J. Lynagh <kevin@keminglabs.com>
 Louis Opter <kalessin@kalessin.fr>
 Mikhail Sobolev <mss@mawhrin.net>
 Nelson Chen <crazysim@gmail.com>

--- a/docs/sources/examples/index.rst
+++ b/docs/sources/examples/index.rst
@@ -15,4 +15,4 @@ Contents:
    hello_world
    hello_world_daemon
    python_web_app
-   runningsshservice
+   running_ssh_service

--- a/docs/sources/examples/python_web_app.rst
+++ b/docs/sources/examples/python_web_app.rst
@@ -65,6 +65,4 @@ See the example in action
       <iframe width="720" height="350" src="http://ascii.io/a/2573/raw" frameborder="0"></iframe>
     </div>
 
-Continue to the `base commands`_
-
-.. _base commands: ../commandline/basecommands.html
+Continue to :ref:`running_ssh_service`.

--- a/docs/sources/examples/running_ssh_service.rst
+++ b/docs/sources/examples/running_ssh_service.rst
@@ -1,3 +1,8 @@
+:title: Running an SSH service
+:description: A screencast of installing and running an sshd service
+:keywords: docker, example, package installation, networking
+
+.. _running_ssh_service:
 
 Create an ssh daemon service
 ============================


### PR DESCRIPTION
Broken link was from python_web_app to nonexistent "base commands page"; updated to point to next item in examples menu, running_ssh_service screencast.

Problem is at the bottom of this page: http://docs.docker.io/en/latest/examples/python_web_app/
