### PR TITLE
Pty fix 1

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -803,6 +803,8 @@ func (srv *Server) CmdAttach(stdin io.ReadCloser, stdout rcli.DockerConn, args .
 
 	if container.Config.Tty {
 		stdout.SetOptionRawTerminal()
+		// Flush the options to make sure the client sets the raw mode
+		stdout.Write([]byte{})
 	}
 	return <-container.Attach(stdin, nil, stdout, stdout)
 }
@@ -888,8 +890,11 @@ func (srv *Server) CmdRun(stdin io.ReadCloser, stdout rcli.DockerConn, args ...s
 		fmt.Fprintln(stdout, "Error: Command not specified")
 		return fmt.Errorf("Command not specified")
 	}
+
 	if config.Tty {
 		stdout.SetOptionRawTerminal()
+		// Flush the options to make sure the client sets the raw mode
+		stdout.Write([]byte{})
 	}
 
 	// Create new container

--- a/commands.go
+++ b/commands.go
@@ -894,7 +894,7 @@ func (srv *Server) CmdRun(stdin io.ReadCloser, stdout rcli.DockerConn, args ...s
 	if config.Tty {
 		stdout.SetOptionRawTerminal()
 		// Flush the options to make sure the client sets the raw mode
-		stdout.Write([]byte{})
+		stdout.Flush()
 	}
 
 	// Create new container

--- a/container.go
+++ b/container.go
@@ -202,7 +202,7 @@ func (container *Container) startPty() error {
 		container.cmd.Stdin = stdoutSlave
 		// FIXME: The following appears to be broken.
 		// "cannot set terminal process group (-1): Inappropriate ioctl for device"
-		// container.cmd.SysProcAttr = &syscall.SysProcAttr{Setctty: true, Setsid: true}
+		container.cmd.SysProcAttr = &syscall.SysProcAttr{Setctty: true, Setsid: true}
 		go func() {
 			defer container.stdin.Close()
 			Debugf("[startPty] Begin of stdin pipe")

--- a/container.go
+++ b/container.go
@@ -251,6 +251,9 @@ func (container *Container) Attach(stdin io.ReadCloser, stdinCloser io.Closer, s
 					defer cStderr.Close()
 				}
 				if container.Config.StdinOnce {
+					if container.Config.Tty {
+						defer container.Kill()
+					}
 					defer cStdin.Close()
 				}
 				_, err := io.Copy(cStdin, stdin)

--- a/rcli/tcp.go
+++ b/rcli/tcp.go
@@ -92,6 +92,11 @@ func (c *DockerTCPConn) Write(b []byte) (int, error) {
 	return n + optionsLen, err
 }
 
+func (c *DockerTCPConn) Flush() error {
+	_, err := c.conn.Write([]byte{})
+	return err
+}
+
 func (c *DockerTCPConn) Close() error { return c.conn.Close() }
 
 func (c *DockerTCPConn) CloseWrite() error { return c.conn.CloseWrite() }

--- a/rcli/types.go
+++ b/rcli/types.go
@@ -29,6 +29,7 @@ type DockerConn interface {
 	CloseRead() error
 	GetOptions() *DockerConnOptions
 	SetOptionRawTerminal()
+	Flush() error
 }
 
 type DockerLocalConn struct {
@@ -55,6 +56,8 @@ func (c *DockerLocalConn) Close() error {
 	}
 	return c.writer.Close()
 }
+
+func (c *DockerLocalConn) Flush() error { return nil }
 
 func (c *DockerLocalConn) CloseWrite() error { return nil }
 


### PR DESCRIPTION
This fixes the issues related to pty by allowing the process to grab the controlling terminal.

Main side effect: stdout and stderr are combined within stdout in the logs. Which is expected as we are dealing with a terminal.

Fixes #327 in the meantime :)
