### PR TITLE
Disable signals create escape sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,9 @@ JOB=$(docker run -d -p 4444 base /bin/nc -l -p 4444)
 PORT=$(docker port $JOB 4444)
 
 # Connect to the public port via the host's public address
-echo hello world | nc $(hostname) $PORT
+# Please note that because of how routing works connecting to localhost or 127.0.0.1 $PORT will not work.
+IP=$(ifconfig eth0 | perl -n -e 'if (m/inet addr:([\d\.]+)/g) { print $1 }')
+echo hello world | nc $IP $PORT
 
 # Verify that the network connection worked
 echo "Daemon received: $(docker logs $JOB)"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ docker pull base
 docker run -i -t base /bin/bash
 ```
 
+Detaching from the interactive shell
+------------------------------------
+```
+# In order to detach without killing the shell, you can use the escape sequence Ctrl-p + Ctrl-q
+# Note: this works only in tty mode (run with -t option).
+```
 
 Starting a long-running worker process
 --------------------------------------

--- a/commands.go
+++ b/commands.go
@@ -419,7 +419,8 @@ func (srv *Server) CmdKill(stdin io.ReadCloser, stdout io.Writer, args ...string
 	return nil
 }
 
-func (srv *Server) CmdImport(stdin io.ReadCloser, stdout io.Writer, args ...string) error {
+func (srv *Server) CmdImport(stdin io.ReadCloser, stdout rcli.DockerConn, args ...string) error {
+	stdout.Flush()
 	cmd := rcli.Subcmd(stdout, "import", "[OPTIONS] URL|- [REPOSITORY [TAG]]", "Create a new filesystem image from the contents of a tarball")
 	var archive io.Reader
 	var resp *http.Response

--- a/commands.go
+++ b/commands.go
@@ -803,9 +803,9 @@ func (srv *Server) CmdAttach(stdin io.ReadCloser, stdout rcli.DockerConn, args .
 
 	if container.Config.Tty {
 		stdout.SetOptionRawTerminal()
-		// Flush the options to make sure the client sets the raw mode
-		stdout.Write([]byte{})
 	}
+	// Flush the options to make sure the client sets the raw mode
+	stdout.Flush()
 	return <-container.Attach(stdin, nil, stdout, stdout)
 }
 
@@ -893,9 +893,10 @@ func (srv *Server) CmdRun(stdin io.ReadCloser, stdout rcli.DockerConn, args ...s
 
 	if config.Tty {
 		stdout.SetOptionRawTerminal()
-		// Flush the options to make sure the client sets the raw mode
-		stdout.Flush()
 	}
+	// Flush the options to make sure the client sets the raw mode
+	// or tell the client there is no options
+	stdout.Flush()
 
 	// Create new container
 	container, err := srv.runtime.Create(config)

--- a/commands_test.go
+++ b/commands_test.go
@@ -228,15 +228,13 @@ func TestRunDisconnectTty(t *testing.T) {
 		<-c1
 	})
 
-	// Client disconnect after run -i should cause stdin to be closed, which should
-	// cause /bin/cat to exit.
-	setTimeout(t, "Waiting for /bin/cat to exit timed out", 2*time.Second, func() {
-		container := runtime.List()[0]
-		container.Wait()
-		if container.State.Running {
-			t.Fatalf("/bin/cat is still running after closing stdin")
-		}
-	})
+	// Client disconnect after run -i should keep stdin out in TTY mode
+	container := runtime.List()[0]
+	// Give some time to monitor to do his thing
+	container.WaitTimeout(500 * time.Millisecond)
+	if !container.State.Running {
+		t.Fatalf("/bin/cat should  still be running after closing stdin (tty mode)")
+	}
 }
 
 // TestAttachStdin checks attaching to stdin without stdout and stderr.

--- a/container.go
+++ b/container.go
@@ -255,7 +255,7 @@ func (container *Container) Attach(stdin io.ReadCloser, stdinCloser io.Closer, s
 				if container.Config.StdinOnce && !container.Config.Tty {
 					defer cStdin.Close()
 				}
-				_, err := io.Copy(cStdin, stdin)
+				_, err := CopyEscapable(cStdin, stdin)
 				if err != nil {
 					Debugf("[error] attach stdin: %s\n", err)
 				}

--- a/container.go
+++ b/container.go
@@ -250,10 +250,7 @@ func (container *Container) Attach(stdin io.ReadCloser, stdinCloser io.Closer, s
 				if cStderr != nil {
 					defer cStderr.Close()
 				}
-				if container.Config.StdinOnce {
-					if container.Config.Tty {
-						defer container.Kill()
-					}
+				if container.Config.StdinOnce && !container.Config.Tty {
 					defer cStdin.Close()
 				}
 				_, err := io.Copy(cStdin, stdin)

--- a/container.go
+++ b/container.go
@@ -255,7 +255,11 @@ func (container *Container) Attach(stdin io.ReadCloser, stdinCloser io.Closer, s
 				if container.Config.StdinOnce && !container.Config.Tty {
 					defer cStdin.Close()
 				}
-				_, err := CopyEscapable(cStdin, stdin)
+				if container.Config.Tty {
+					_, err = CopyEscapable(cStdin, stdin)
+				} else {
+					_, err = io.Copy(cStdin, stdin)
+				}
 				if err != nil {
 					Debugf("[error] attach stdin: %s\n", err)
 				}

--- a/container_test.go
+++ b/container_test.go
@@ -267,8 +267,7 @@ func TestStart(t *testing.T) {
 	// Try to avoid the timeoout in destroy. Best effort, don't check error
 	cStdin, _ := container.StdinPipe()
 	cStdin.Close()
-	container.WaitTimeout(500 * time.Millisecond)
-	container.State.setStopped(0)
+	container.WaitTimeout(2 * time.Second)
 }
 
 func TestRun(t *testing.T) {

--- a/container_test.go
+++ b/container_test.go
@@ -267,6 +267,8 @@ func TestStart(t *testing.T) {
 	// Try to avoid the timeoout in destroy. Best effort, don't check error
 	cStdin, _ := container.StdinPipe()
 	cStdin.Close()
+	container.WaitTimeout(500 * time.Millisecond)
+	container.State.setStopped(0)
 }
 
 func TestRun(t *testing.T) {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -56,15 +56,6 @@ func daemon() error {
 }
 
 func runCommand(args []string) error {
-	var oldState *term.State
-	var err error
-	if term.IsTerminal(int(os.Stdin.Fd())) && os.Getenv("NORAW") == "" {
-		oldState, err = term.MakeRaw(int(os.Stdin.Fd()))
-		if err != nil {
-			return err
-		}
-		defer term.Restore(int(os.Stdin.Fd()), oldState)
-	}
 	// FIXME: we want to use unix sockets here, but net.UnixConn doesn't expose
 	// CloseWrite(), which we need to cleanly signal that stdin is closed without
 	// closing the connection.

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -56,6 +56,15 @@ func daemon() error {
 }
 
 func runCommand(args []string) error {
+	var oldState *term.State
+	var err error
+	if term.IsTerminal(int(os.Stdin.Fd())) && os.Getenv("NORAW") == "" {
+		oldState, err = term.MakeRaw(int(os.Stdin.Fd()))
+		if err != nil {
+			return err
+		}
+		defer term.Restore(int(os.Stdin.Fd()), oldState)
+	}
 	// FIXME: we want to use unix sockets here, but net.UnixConn doesn't expose
 	// CloseWrite(), which we need to cleanly signal that stdin is closed without
 	// closing the connection.

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,3 +40,35 @@ Notes
 So changes to those pages should be made directly in html
 * For the template the css is compiled from less. When changes are needed they can be compiled using
 lessc ``lessc main.less`` or watched using watch-lessc ``watch-lessc -i main.less -o main.css``
+
+
+Guides on using sphinx
+----------------------
+* To make links to certain pages create a link target like so:
+
+  ```
+    .. _hello_world:
+
+    Hello world
+    ===========
+
+    This is.. (etc.)
+  ```
+
+  The ``_hello_world:`` will make it possible to link to this position (page and marker) from all other pages.
+
+* Notes, warnings and alarms
+
+  ```
+    # a note (use when something is important)
+    .. note::
+
+    # a warning (orange)
+    .. warning::
+
+    # danger (red, use sparsely)
+    .. danger::
+
+* Code examples
+
+  Start without $, so it's easy to copy and paste.

--- a/docs/sources/commandline/basics.rst
+++ b/docs/sources/commandline/basics.rst
@@ -69,7 +69,8 @@ Expose a service on a TCP port
 
   # Connect to the public port via the host's public address
   # Please note that because of how routing works connecting to localhost or 127.0.0.1 $PORT will not work.
-  echo hello world | nc $(hostname) $PORT
+  IP=$(ifconfig eth0 | perl -n -e 'if (m/inet addr:([\d\.]+)/g) { print $1 }')
+  echo hello world | nc $IP $PORT
 
   # Verify that the network connection worked
   echo "Daemon received: $(docker logs $JOB)"

--- a/docs/sources/examples/example_header.inc
+++ b/docs/sources/examples/example_header.inc
@@ -1,4 +1,4 @@
 
-.. warning::
+.. note::
     
-    This example assumes that you have Docker running in daemon mode. For more information please see :ref:`running_examples`
+    This example assumes you have Docker running in daemon mode. For more information please see :ref:`running_examples`

--- a/docs/sources/examples/hello_world.rst
+++ b/docs/sources/examples/hello_world.rst
@@ -9,7 +9,7 @@ Hello World
 
 .. include:: example_header.inc
 
-This is the most basic example available for using Docker. The example assumes you have Docker installed.
+This is the most basic example available for using Docker.
 
 Download the base container
 

--- a/docs/sources/examples/running_examples.rst
+++ b/docs/sources/examples/running_examples.rst
@@ -7,26 +7,27 @@
 Running The Examples
 --------------------
 
-There are two ways to run docker, daemon and standalone mode. 
+There are two ways to run docker, daemon mode and standalone mode.
 
-When you run the docker command it will first check to see if there is already a docker daemon running in the background it can connect too, and if so, it will use that daemon to run all of the commands. 
+When you run the docker command it will first check if there is a docker daemon running in the background it can connect to.
 
-If there is no daemon then docker will run in standalone mode. 
+* If it exists it will use that daemon to run all of the commands.
+* If it does not exist docker will run in standalone mode (docker will exit after each command).
 
-Docker needs to be run from a privileged account (root). Depending on which mode you are using, will determine how you need to execute docker.
+Docker needs to be run from a privileged account (root).
 
-1. The most common way is to run a docker daemon as root in the background, and then connect to it from the docker client from any account.
+1. The most common (and recommended) way is to run a docker daemon as root in the background, and then connect to it from the docker client from any account.
 
-    .. code-block:: bash
+   .. code-block:: bash
 
-        # starting docker daemon in the background
-        $ sudo docker -d &
-    
-        # now you can run docker commands from any account.
-        $ docker <command>
+      # starting docker daemon in the background
+      sudo docker -d &
+
+      # now you can run docker commands from any account.
+      docker <command>
 
 2. Standalone: You need to run every command as root, or using sudo
 
-    .. code-block:: bash
+   .. code-block:: bash
 
-        $ sudo docker <command>
+       sudo docker <command>

--- a/docs/theme/docker/static/css/main.css
+++ b/docs/theme/docker/static/css/main.css
@@ -82,7 +82,7 @@ h4 {
 .btn-custom {
   background-color: #292929 !important;
   background-repeat: repeat-x;
-  filter: progid:dximagetransform.microsoft.gradient(startColorstr="#515151", endColorstr="#282828");
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#515151", endColorstr="#282828");
   background-image: -khtml-gradient(linear, left top, left bottom, from(#515151), to(#282828));
   background-image: -moz-linear-gradient(top, #515151, #282828);
   background-image: -ms-linear-gradient(top, #515151, #282828);
@@ -130,6 +130,27 @@ section.header {
 .section img {
   margin: 15px 15px 15px 0;
   border: 2px solid gray;
+}
+.admonition {
+  padding: 10px;
+  border: 1px solid grey;
+  margin-bottom: 10px;
+  margin-top: 10px;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+.admonition .admonition-title {
+  font-weight: bold;
+}
+.admonition.note {
+  background-color: #f1ebba;
+}
+.admonition.warning {
+  background-color: #eed9af;
+}
+.admonition.danger {
+  background-color: #e9bcab;
 }
 /* ===================
 	left navigation

--- a/docs/theme/docker/static/css/main.less
+++ b/docs/theme/docker/static/css/main.less
@@ -179,7 +179,33 @@ section.header {
   border: 2px solid gray;
 }
 
+.admonition {
+  padding: 10px;
+  border: 1px solid grey;
 
+  margin-bottom: 10px;
+  margin-top: 10px;
+
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+}
+
+.admonition .admonition-title {
+  font-weight: bold;
+}
+
+.admonition.note {
+  background-color: rgb(241, 235, 186);
+}
+
+.admonition.warning {
+  background-color: rgb(238, 217, 175);
+}
+
+.admonition.danger {
+  background-color: rgb(233, 188, 171);
+}
 
 /* ===================
 	left navigation

--- a/network.go
+++ b/network.go
@@ -111,6 +111,8 @@ func checkRouteOverlaps(dockerNetwork *net.IPNet) error {
 }
 
 func CreateBridgeIface(ifaceName string) error {
+	// FIXME: try more IP ranges
+	// FIXME: try bigger ranges! /24 is too small.
 	addrs := []string{"172.16.42.1/24", "10.0.42.1/24", "192.168.42.1/24"}
 
 	var ifaceAddr string
@@ -127,7 +129,7 @@ func CreateBridgeIface(ifaceName string) error {
 		}
 	}
 	if ifaceAddr == "" {
-		return fmt.Errorf("Impossible to create a bridge. Please create a bridge manually and restart docker with -br <bridgeName>")
+		return fmt.Errorf("Could not find a free IP address range for interface '%s'. Please configure its address manually and run 'docker -b %s'", ifaceName, ifaceName)
 	} else {
 		Debugf("Creating bridge %s with network %s", ifaceName, ifaceAddr)
 	}

--- a/rcli/tcp.go
+++ b/rcli/tcp.go
@@ -93,7 +93,7 @@ func (c *DockerTCPConn) Write(b []byte) (int, error) {
 }
 
 func (c *DockerTCPConn) Flush() error {
-	_, err := c.conn.Write([]byte{})
+	_, err := c.Write([]byte{})
 	return err
 }
 

--- a/runtime.go
+++ b/runtime.go
@@ -116,7 +116,6 @@ func (runtime *Runtime) Load(id string) (*Container, error) {
 	if err := container.FromDisk(); err != nil {
 		return nil, err
 	}
-	container.State.initLock()
 	if container.Id != id {
 		return container, fmt.Errorf("Container %s is stored at %s", container.Id, id)
 	}
@@ -136,6 +135,7 @@ func (runtime *Runtime) Register(container *Container) error {
 	}
 
 	// FIXME: if the container is supposed to be running but is not, auto restart it?
+	//        if so, then we need to restart monitor and init a new lock
 	// If the container is supposed to be running, make sure of it
 	if container.State.Running {
 		if output, err := exec.Command("lxc-info", "-n", container.Id).CombinedOutput(); err != nil {
@@ -152,8 +152,7 @@ func (runtime *Runtime) Register(container *Container) error {
 	}
 
 	container.runtime = runtime
-	// Setup state lock (formerly in newState()
-	container.State.initLock()
+
 	// Attach to stdout and stderr
 	container.stderr = newWriteBroadcaster()
 	container.stdout = newWriteBroadcaster()

--- a/runtime.go
+++ b/runtime.go
@@ -150,6 +150,7 @@ func (runtime *Runtime) Register(container *Container) error {
 			}
 		}
 	}
+	container.State.initLock()
 
 	container.runtime = runtime
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -358,4 +358,5 @@ func TestRestore(t *testing.T) {
 	if err := container3.Run(); err != nil {
 		t.Fatal(err)
 	}
+	container2.State.Running = false
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -314,7 +314,7 @@ func TestRestore(t *testing.T) {
 	// Simulate a crash/manual quit of dockerd: process dies, states stays 'Running'
 	cStdin, _ := container2.StdinPipe()
 	cStdin.Close()
-	if err := container2.WaitTimeout(time.Second); err != nil {
+	if err := container2.WaitTimeout(2 * time.Second); err != nil {
 		t.Fatal(err)
 	}
 	container2.State.Running = true

--- a/state.go
+++ b/state.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"sync"
 	"time"
 )
 
@@ -10,6 +11,7 @@ type State struct {
 	Pid       int
 	ExitCode  int
 	StartedAt time.Time
+	l         *sync.Mutex
 }
 
 // String returns a human-readable description of the state
@@ -31,4 +33,16 @@ func (s *State) setStopped(exitCode int) {
 	s.Running = false
 	s.Pid = 0
 	s.ExitCode = exitCode
+}
+
+func (s *State) initLock() {
+	s.l = &sync.Mutex{}
+}
+
+func (s *State) lock() {
+	s.l.Lock()
+}
+
+func (s *State) unlock() {
+	s.l.Unlock()
 }

--- a/state.go
+++ b/state.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"fmt"
-	"sync"
 	"time"
 )
 
@@ -11,9 +10,6 @@ type State struct {
 	Pid       int
 	ExitCode  int
 	StartedAt time.Time
-
-	stateChangeLock *sync.Mutex
-	stateChangeCond *sync.Cond
 }
 
 // String returns a human-readable description of the state
@@ -29,31 +25,10 @@ func (s *State) setRunning(pid int) {
 	s.ExitCode = 0
 	s.Pid = pid
 	s.StartedAt = time.Now()
-	s.broadcast()
 }
 
 func (s *State) setStopped(exitCode int) {
 	s.Running = false
 	s.Pid = 0
 	s.ExitCode = exitCode
-	s.broadcast()
-}
-
-func (s *State) initLock() {
-	if s.stateChangeLock == nil {
-		s.stateChangeLock = &sync.Mutex{}
-		s.stateChangeCond = sync.NewCond(s.stateChangeLock)
-	}
-}
-
-func (s *State) broadcast() {
-	s.stateChangeLock.Lock()
-	s.stateChangeCond.Broadcast()
-	s.stateChangeLock.Unlock()
-}
-
-func (s *State) wait() {
-	s.stateChangeLock.Lock()
-	s.stateChangeCond.Wait()
-	s.stateChangeLock.Unlock()
 }

--- a/term/termios_linux.go
+++ b/term/termios_linux.go
@@ -15,7 +15,8 @@ void MakeRaw(int fd) {
   ioctl(fd, TCGETS, &t);
 
   t.c_iflag &= ~(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON);
-  t.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN);
+  t.c_oflag &= ~OPOST;
+  t.c_lflag &= ~(ECHO | ECHONL | ICANON | IEXTEN | ISIG);
   t.c_cflag &= ~(CSIZE | PARENB);
   t.c_cflag |= CS8;
 

--- a/utils.go
+++ b/utils.go
@@ -349,9 +349,11 @@ func CopyEscapable(dst io.Writer, src io.ReadCloser) (written int64, err error) 
 		nr, er := src.Read(buf)
 		if nr > 0 {
 			// ---- Docker addition
-			if nr == 1 && buf[0] == '' {
+			// char 16 is C-p
+			if nr == 1 && buf[0] == 16 {
 				nr, er = src.Read(buf)
-				if nr == 1 && buf[0] == '' {
+				// char 17 is C-q
+				if nr == 1 && buf[0] == 17 {
 					if err := src.Close(); err != nil {
 						return 0, err
 					}

--- a/utils.go
+++ b/utils.go
@@ -344,15 +344,6 @@ func TruncateId(id string) string {
 
 // Code c/c from io.Copy() modified to handle escape sequence
 func CopyEscapable(dst io.Writer, src io.ReadCloser) (written int64, err error) {
-	// If the writer has a ReadFrom method, use it to do the copy.
-	// Avoids an allocation and a copy.
-	if rt, ok := dst.(io.ReaderFrom); ok {
-		return rt.ReadFrom(src)
-	}
-	// Similarly, if the reader has a WriteTo method, use it to do the copy.
-	if wt, ok := src.(io.WriterTo); ok {
-		return wt.WriteTo(dst)
-	}
 	buf := make([]byte, 32*1024)
 	for {
 		nr, er := src.Read(buf)


### PR DESCRIPTION
Put back the posix raw mode and add an escape sequence.

ctrl-c and all signals are forwarded to the container. In order to detach, the escape sequence is ctrl-p + ctrl-q

It would be nice to merge #326 prior this to avoid unexpected output from commands.
