### PR TITLE
improved the example docs to help #303 

### DIFF
--- a/docs/sources/examples/example_header.inc
+++ b/docs/sources/examples/example_header.inc
@@ -1,0 +1,4 @@
+
+.. warning::
+    
+    This example assumes that you have Docker running in daemon mode. For more information please see :ref:`running_examples`

--- a/docs/sources/examples/hello_world.rst
+++ b/docs/sources/examples/hello_world.rst
@@ -6,8 +6,10 @@
 
 Hello World
 ===========
-This is the most basic example available for using Docker. The example assumes you have Docker installed.
 
+.. include:: example_header.inc
+
+This is the most basic example available for using Docker. The example assumes you have Docker installed.
 
 Download the base container
 

--- a/docs/sources/examples/hello_world_daemon.rst
+++ b/docs/sources/examples/hello_world_daemon.rst
@@ -6,6 +6,9 @@
 
 Hello World Daemon
 ==================
+
+.. include:: example_header.inc
+
 The most boring daemon ever written.
 
 This example assumes you have Docker installed and with the base image already imported ``docker pull base``.
@@ -18,7 +21,7 @@ out every second. It will continue to do this until we stop it.
 
     CONTAINER_ID=$(docker run -d base /bin/sh -c "while true; do echo hello world; sleep 1; done")
 
-We are going to run a simple hello world daemon in a new container made from the busybox daemon.
+We are going to run a simple hello world daemon in a new container made from the base image.
 
 - **"docker run -d "** run a command in a new container. We pass "-d" so it runs as a daemon.
 - **"base"** is the image we want to run the command inside of.

--- a/docs/sources/examples/index.rst
+++ b/docs/sources/examples/index.rst
@@ -12,6 +12,7 @@ Contents:
 .. toctree::
    :maxdepth: 1
 
+   running_examples
    hello_world
    hello_world_daemon
    python_web_app

--- a/docs/sources/examples/python_web_app.rst
+++ b/docs/sources/examples/python_web_app.rst
@@ -6,6 +6,9 @@
 
 Building a python web app
 =========================
+
+.. include:: example_header.inc
+
 The goal of this example is to show you how you can author your own docker images using a parent image, making changes to it, and then saving the results as a new image. We will do that by making a simple hello flask web application image.
 
 **Steps:**

--- a/docs/sources/examples/running_examples.rst
+++ b/docs/sources/examples/running_examples.rst
@@ -1,0 +1,32 @@
+:title: Running the Examples
+:description: An overview on how to run the docker examples
+:keywords: docker, examples, how to
+
+.. _running_examples:
+
+Running The Examples
+--------------------
+
+There are two ways to run docker, daemon and standalone mode. 
+
+When you run the docker command it will first check to see if there is already a docker daemon running in the background it can connect too, and if so, it will use that daemon to run all of the commands. 
+
+If there is no daemon then docker will run in standalone mode. 
+
+Docker needs to be run from a privileged account (root). Depending on which mode you are using, will determine how you need to execute docker.
+
+1. The most common way is to run a docker daemon as root in the background, and then connect to it from the docker client from any account.
+
+    .. code-block:: bash
+
+        # starting docker daemon in the background
+        $ sudo docker -d &
+    
+        # now you can run docker commands from any account.
+        $ docker <command>
+
+2. Standalone: You need to run every command as root, or using sudo
+
+    .. code-block:: bash
+
+        $ sudo docker <command>

--- a/docs/sources/examples/running_ssh_service.rst
+++ b/docs/sources/examples/running_ssh_service.rst
@@ -7,7 +7,7 @@
 Create an ssh daemon service
 ============================
 
-
+.. include:: example_header.inc
 
 
 **Video:**


### PR DESCRIPTION
The example docs didn't make it obvious that the docker daemon was running in the background, I made it more obvious and added a page explaining how to run the examples.

The warning header on the examples needs to be styled, maybe @dhrp can help me with that. We have something we use on the dotcloud docs, so maybe we can use the same? See the warning on the top of http://docs.dotcloud.com/services/postgresql/

This is for #303
