### PR TITLE
Fix the Makefile, rule=hack to make it work on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ fmt:
 	@gofmt -s -l -w .
 
 hack:
-	@(cd $(CURDIR)/buildbot; vagrant up)
+	cd $(CURDIR)/buildbot && vagrant up


### PR DESCRIPTION
Rule hack in Makefile did run on Cygwin but not on the Windows command line.
