### PR TITLE
Allow rmi to remove image from its name

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -351,7 +351,11 @@ func (srv *Server) CmdRmi(stdin io.ReadCloser, stdout io.Writer, args ...string)
 		return nil
 	}
 	for _, name := range cmd.Args() {
-		if err := srv.runtime.graph.Delete(name); err != nil {
+		img, err := srv.runtime.repositories.LookupImage(name)
+		if err != nil {
+			return err
+		}
+		if err := srv.runtime.graph.Delete(img.Id); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Note that this will leave orphan images.

We need to implement a command that will garbage collect them.
The garbage collection should also empty the :garbage: folder.
