### PR TITLE
Use ip to setup the gateway in sysinit.go

### DIFF
--- a/sysinit.go
+++ b/sysinit.go
@@ -17,8 +17,7 @@ func setupNetworking(gw string) {
 	if gw == "" {
 		return
 	}
-	cmd := exec.Command("/sbin/route", "add", "default", "gw", gw)
-	if err := cmd.Run(); err != nil {
+	if _, err := ip("route", "add", "default", "via", gw); err != nil {
 		log.Fatalf("Unable to set up networking: %v", err)
 	}
 }


### PR DESCRIPTION
ip from iproute2 replaces the legacy route tool which is often not
installed by default on recent Linux distributions.

The same patch has been done in network.go and is re-used here.
