### PR TITLE
Crlf on raw mode

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -79,7 +79,7 @@ func (srv *Server) CmdLogin(stdin io.ReadCloser, stdout rcli.DockerConn, args ..
 			n, err := stdin.Read(char)
 			if n > 0 {
 				if char[0] == '\r' || char[0] == '\n' {
-					stdout.Write([]byte{'\n'})
+					stdout.Write([]byte{'\r', '\n'})
 					break
 				} else if char[0] == 127 || char[0] == '\b' {
 					if i > 0 {
@@ -99,7 +99,7 @@ func (srv *Server) CmdLogin(stdin io.ReadCloser, stdout rcli.DockerConn, args ..
 			}
 			if err != nil {
 				if err != io.EOF {
-					fmt.Fprintf(stdout, "Read error: %v\n", err)
+					fmt.Fprintf(stdout, "Read error: %v\r\n", err)
 				}
 				break
 			}
@@ -149,7 +149,7 @@ func (srv *Server) CmdLogin(stdin io.ReadCloser, stdout rcli.DockerConn, args ..
 	newAuthConfig := auth.NewAuthConfig(username, password, email, srv.runtime.root)
 	status, err := auth.Login(newAuthConfig)
 	if err != nil {
-		fmt.Fprintln(stdout, "Error:", err)
+		fmt.Fprintf(stdout, "Error: %s\r\n", err)
 	} else {
 		srv.runtime.authConfig = newAuthConfig
 	}

--- a/registry.go
+++ b/registry.go
@@ -97,7 +97,7 @@ func (graph *Graph) LookupRemoteImage(imgId string, authConfig *auth.AuthConfig)
 func (graph *Graph) getRemoteImage(stdout io.Writer, imgId string, authConfig *auth.AuthConfig) (*Image, Archive, error) {
 	client := &http.Client{}
 
-	fmt.Fprintf(stdout, "Pulling %s metadata\n", imgId)
+	fmt.Fprintf(stdout, "Pulling %s metadata\r\n", imgId)
 	// Get the Json
 	req, err := http.NewRequest("GET", REGISTRY_ENDPOINT+"/images/"+imgId+"/json", nil)
 	if err != nil {
@@ -125,7 +125,7 @@ func (graph *Graph) getRemoteImage(stdout io.Writer, imgId string, authConfig *a
 	img.Id = imgId
 
 	// Get the layer
-	fmt.Fprintf(stdout, "Pulling %s fs layer\n", imgId)
+	fmt.Fprintf(stdout, "Pulling %s fs layer\r\n", imgId)
 	req, err = http.NewRequest("GET", REGISTRY_ENDPOINT+"/images/"+imgId+"/layer", nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error while getting from the server: %s\n", err)
@@ -164,7 +164,7 @@ func (graph *Graph) PullImage(stdout io.Writer, imgId string, authConfig *auth.A
 func (graph *Graph) PullRepository(stdout io.Writer, remote, askedTag string, repositories *TagStore, authConfig *auth.AuthConfig) error {
 	client := &http.Client{}
 
-	fmt.Fprintf(stdout, "Pulling repository %s\n", remote)
+	fmt.Fprintf(stdout, "Pulling repository %s\r\n", remote)
 
 	var repositoryTarget string
 	// If we are asking for 'root' repository, lookup on the Library's registry
@@ -196,7 +196,7 @@ func (graph *Graph) PullRepository(stdout io.Writer, remote, askedTag string, re
 		return err
 	}
 	for tag, rev := range t {
-		fmt.Fprintf(stdout, "Pulling tag %s:%s\n", remote, tag)
+		fmt.Fprintf(stdout, "Pulling tag %s:%s\r\n", remote, tag)
 		if err = graph.PullImage(stdout, rev, authConfig); err != nil {
 			return err
 		}
@@ -223,7 +223,7 @@ func (graph *Graph) PushImage(stdout io.Writer, imgOrig *Image, authConfig *auth
 			return fmt.Errorf("Error while retreiving the path for {%s}: %s", img.Id, err)
 		}
 
-		fmt.Fprintf(stdout, "Pushing %s metadata\n", img.Id)
+		fmt.Fprintf(stdout, "Pushing %s metadata\r\n", img.Id)
 
 		// FIXME: try json with UTF8
 		jsonData := strings.NewReader(string(jsonRaw))
@@ -253,7 +253,7 @@ func (graph *Graph) PushImage(stdout io.Writer, imgOrig *Image, authConfig *auth
 			}
 		}
 
-		fmt.Fprintf(stdout, "Pushing %s fs layer\n", img.Id)
+		fmt.Fprintf(stdout, "Pushing %s fs layer\r\n", img.Id)
 		req2, err := http.NewRequest("PUT", REGISTRY_ENDPOINT+"/images/"+img.Id+"/layer", nil)
 		req2.SetBasicAuth(authConfig.Username, authConfig.Password)
 		res2, err := client.Do(req2)
@@ -375,15 +375,15 @@ func (graph *Graph) pushPrimitive(stdout io.Writer, remote, tag, imgId string, a
 	// Check if the local impage exists
 	img, err := graph.Get(imgId)
 	if err != nil {
-		fmt.Fprintf(stdout, "Skipping tag %s:%s: %s does not exist\n", remote, tag, imgId)
+		fmt.Fprintf(stdout, "Skipping tag %s:%s: %s does not exist\r\n", remote, tag, imgId)
 		return nil
 	}
-	fmt.Fprintf(stdout, "Pushing tag %s:%s\n", remote, tag)
+	fmt.Fprintf(stdout, "Pushing tag %s:%s\r\n", remote, tag)
 	// Push the image
 	if err = graph.PushImage(stdout, img, authConfig); err != nil {
 		return err
 	}
-	fmt.Fprintf(stdout, "Registering tag %s:%s\n", remote, tag)
+	fmt.Fprintf(stdout, "Registering tag %s:%s\r\n", remote, tag)
 	// And then the tag
 	if err = graph.pushTag(remote, imgId, tag, authConfig); err != nil {
 		return err
@@ -399,7 +399,7 @@ func (graph *Graph) PushRepository(stdout io.Writer, remote string, localRepo Re
 		return fmt.Errorf("Permission denied on repository %s\n", remote)
 	}
 
-	fmt.Fprintf(stdout, "Pushing repository %s (%d tags)\n", remote, len(localRepo))
+	fmt.Fprintf(stdout, "Pushing repository %s (%d tags)\r\n", remote, len(localRepo))
 	// For each image within the repo, push them
 	for tag, imgId := range localRepo {
 		if err := graph.pushPrimitive(stdout, remote, tag, imgId, authConfig); err != nil {


### PR DESCRIPTION
fixes #384 and #389 

As we can't set/unset the raw mode, we need to send CRLF to the client in order to have a correct output.

Once we'll have a smart client capable of this, then we can remove them :)
