### PR TITLE
force kill now use lxc-kill. Fixes #383

### DIFF
--- a/container.go
+++ b/container.go
@@ -551,15 +551,15 @@ func (container *Container) kill() error {
 		return nil
 	}
 
-	// Sending SIGINT to the process via lxc
+	// Sending SIGKILL to the process via lxc
 	output, err := exec.Command("lxc-kill", "-n", container.Id, "9").CombinedOutput()
 	if err != nil {
-		Debugf("error killing container %s (%s, %s)", container.Id, output, err)
+		log.Printf("error killing container %s (%s, %s)", container.Id, output, err)
 	}
 
 	// 2. Wait for the process to die, in last resort, try to kill the process directly
 	if err := container.WaitTimeout(10 * time.Second); err != nil {
-		log.Printf("Container %s failed to exit within 10 seconds of SIGINT - trying direct SIGKILL", container.Id)
+		log.Printf("Container %s failed to exit within 10 seconds of lxc SIGKILL - trying direct SIGKILL", container.Id)
 		if err := container.cmd.Process.Kill(); err != nil {
 			return err
 		}

--- a/container.go
+++ b/container.go
@@ -550,9 +550,21 @@ func (container *Container) kill() error {
 	if !container.State.Running || container.cmd == nil {
 		return nil
 	}
-	if err := container.cmd.Process.Kill(); err != nil {
-		return err
+
+	// Sending SIGINT to the process via lxc
+	output, err := exec.Command("lxc-kill", "-n", container.Id, "9").CombinedOutput()
+	if err != nil {
+		Debugf("error killing container %s (%s, %s)", container.Id, output, err)
 	}
+
+	// 2. Wait for the process to die, in last resort, try to kill the process directly
+	if err := container.WaitTimeout(10 * time.Second); err != nil {
+		log.Printf("Container %s failed to exit within 10 seconds of SIGINT - trying direct SIGKILL", container.Id)
+		if err := container.cmd.Process.Kill(); err != nil {
+			return err
+		}
+	}
+
 	// Wait for the container to be actually stopped
 	container.Wait()
 	return nil

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -17,7 +17,6 @@ const testLayerPath string = "/var/lib/docker/docker-ut.tar"
 const unitTestImageName string = "docker-ut"
 
 var unitTestStoreBase string
-var srv *Server
 
 func nuke(runtime *Runtime) error {
 	var wg sync.WaitGroup


### PR DESCRIPTION
The issue wasn't actually caused by go even though it is a strange behavior.

Killing a process from outside its namespace might fail. Forcekilling via lxc avoid the issue.
