### PR TITLE
Docker init created by contrib setup script should set proper UTF8 LANG

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -45,7 +45,7 @@ then
   echo "Upstart script already exists."
 else
   echo "Creating /etc/init/dockerd.conf..."
-  echo "exec /usr/local/bin/docker -d" > /etc/init/dockerd.conf
+  echo "exec env LANG=\"en_US.UTF-8\" /usr/local/bin/docker -d" > /etc/init/dockerd.conf
 fi
 
 echo "Starting dockerd..."


### PR DESCRIPTION
Otherwise there will be errors when trying to pull images from the repo; see: https://github.com/dotcloud/docker/issues/355
