### PR TITLE
added sizes on docker ps and docker images

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -589,7 +589,7 @@ func (srv *Server) CmdImages(stdin io.ReadCloser, stdout io.Writer, args ...stri
 	}
 	w := tabwriter.NewWriter(stdout, 20, 1, 3, ' ', 0)
 	if !*quiet {
-		fmt.Fprintln(w, "REPOSITORY\tTAG\tID\tCREATED")
+		fmt.Fprintln(w, "REPOSITORY\tTAG\tID\tCREATED\tSIZE")
 	}
 	var allImages map[string]*Image
 	var err error
@@ -618,6 +618,7 @@ func (srv *Server) CmdImages(stdin io.ReadCloser, stdout io.Writer, args ...stri
 					/* TAG */ tag,
 					/* ID */ TruncateId(id),
 					/* CREATED */ HumanDuration(time.Now().Sub(image.Created)) + " ago",
+					/* SIZE */ image.GetSize(),
 				} {
 					if idx == 0 {
 						w.Write([]byte(field))
@@ -675,7 +676,7 @@ func (srv *Server) CmdPs(stdin io.ReadCloser, stdout io.Writer, args ...string) 
 	}
 	w := tabwriter.NewWriter(stdout, 12, 1, 3, ' ', 0)
 	if !*quiet {
-		fmt.Fprintln(w, "ID\tIMAGE\tCOMMAND\tCREATED\tSTATUS\tCOMMENT")
+		fmt.Fprintln(w, "ID\tIMAGE\tCOMMAND\tCREATED\tSTATUS\tSIZE")
 	}
 	for i, container := range srv.runtime.List() {
 		if !container.State.Running && !*flAll && *nLast == -1 {
@@ -695,7 +696,7 @@ func (srv *Server) CmdPs(stdin io.ReadCloser, stdout io.Writer, args ...string) 
 				/* COMMAND */ command,
 				/* CREATED */ HumanDuration(time.Now().Sub(container.Created)) + " ago",
 				/* STATUS */ container.State.String(),
-				/* COMMENT */ "",
+				/* SIZE */ container.GetSize(),
 			} {
 				if idx == 0 {
 					w.Write([]byte(field))

--- a/container.go
+++ b/container.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -749,4 +750,28 @@ func validateId(id string) error {
 		return fmt.Errorf("Invalid empty id")
 	}
 	return nil
+}
+
+// GetSize, return real size, virtual size
+func (container *Container) GetSize() string {
+	var sizeRw, sizeRootfs int64
+	var strSize string
+
+	filepath.Walk(container.rwPath(), func(path string, fileInfo os.FileInfo, err error) error {
+		sizeRw += fileInfo.Size()
+		return nil
+	})
+
+	_, err := os.Stat(container.RootfsPath())
+	if err == nil {
+		filepath.Walk(container.RootfsPath(), func(path string, fileInfo os.FileInfo, err error) error {
+			sizeRootfs += fileInfo.Size()
+			return nil
+		})
+	}
+	strSize = HumanSize(sizeRw)
+	if sizeRootfs > 0 {
+		strSize += " (virtual " + HumanSize(sizeRootfs) + ")"
+	}
+	return strSize
 }

--- a/image.go
+++ b/image.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -256,4 +257,29 @@ func (img *Image) layer() (string, error) {
 		return "", err
 	}
 	return layerPath(root), nil
+}
+
+func (img *Image) GetSize() string {
+	var size, virtualSize int64
+
+	layer, err := img.layer()
+	if err != nil {
+		return "<invalid size>"
+	}
+	filepath.Walk(layer, func(path string, fileInfo os.FileInfo, err error) error {
+		size += fileInfo.Size()
+		return nil
+	})
+
+	layers, err := img.layers()
+	if err != nil {
+		return "<invalid size>"
+	}
+	for _, layer := range layers {
+		filepath.Walk(layer, func(path string, fileInfo os.FileInfo, err error) error {
+			virtualSize += fileInfo.Size()
+			return nil
+		})
+	}
+	return HumanSize(size) + " (virtual " + HumanSize(virtualSize) + ")"
 }

--- a/utils.go
+++ b/utils.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -121,6 +122,19 @@ func HumanDuration(d time.Duration) string {
 		return fmt.Sprintf("%d months", hours/24/30)
 	}
 	return fmt.Sprintf("%d years", d.Hours()/24/365)
+}
+
+// HumanSize returns a human-readabla approximation of a size
+// (eg. "44K", "17M", "66G")
+
+func HumanSize(size int64) string {
+	if size/1024 > 1024 {
+		if size/1024/1024 > 1024 {
+			return strconv.FormatInt(size/1024/1024, 10) + "G"
+		}
+		return strconv.FormatInt(size/1024/1024, 10) + "M"
+	}
+	return strconv.FormatInt(size/1024, 10) + "K"
 }
 
 func Trunc(s string, maxlen int) string {


### PR DESCRIPTION
Fixes #22
## containers

display size of rw and if available size of rootfs, in this exemple, only the last one is running:

```
./bin/docker ps -a             
ID             IMAGE         COMMAND                CREATED        STATUS         SIZE
1467f91a2709   base:latest   /bin/bash              30 hours ago   Exit 0         16K
25b1a4d9d238   base:latest   /bin/bash              30 hours ago   Exit -127      16K (virtual 4K)
889eed10d120   base:latest   /bin/bash              30 hours ago   Exit 0         16K
06776824bc28   base:latest   /bin/bash              30 hours ago   Exit 0         16K
6fb4de5c4bea   base:latest   /bin/bash              30 hours ago   Exit 0         16K
019bac054a0c   base:latest   /bin/bash              31 hours ago   Exit 0         4K (virtual 4K)
77530940f940   base:latest   /bin/bash              31 hours ago   Exit 0         4K (virtual 4K)
1cae820e12ca   base:latest   /bin/bash              31 hours ago   Exit 0         4K (virtual 4K)
e295719906dd   base:latest   /bin/bash              31 hours ago   Exit 0         16K
a6190ecabe37   base:latest   /bin/bash              31 hours ago   Exit 0         4K (virtual 4K)
1650aa02482b   base:latest   /bin/bash              31 hours ago   Exit 0         4K (virtual 4K)
c65e9a2ea3c0   base:latest   /bin/bash              31 hours ago   Exit 0         4K (virtual 4K)
a3f224ff5229   base:latest   /bin/bash              32 hours ago   Exit 0         16K
9ab960de2f8a   base:latest   /bin/bash              32 hours ago   Exit 0         16K
bb8f8d1b2ea0   base:latest   /bin/bash              4 days ago     Exit -127      16K (virtual 4K)
2d358ce51d87   base:latest   /bin/bash              4 days ago     Exit 0         16K
a13f4ba6204a   base:latest   /bin/bash              4 days ago     Exit 0         16K
59bd80f6f359   base:latest   /bin/bash              4 days ago     Exit 0         16K
65559fd8e242   base:latest   -i -t /bin/bash        4 days ago     Exit 127       16K
a18f1dfef7ca   base:latest   /bin/sh -c while tru   4 days ago     Up 1 seconds   16K (virtual 171M)
```
## images

display size of current layer, and parent's layers as virtual

```
./bin/docker images           
REPOSITORY          TAG                 ID                  CREATED             SIZE
dhrp/sshd           latest              1bd442970c79        2 weeks ago         20K (virtual 284M)
base                ubuntu-quantal      b750fe79269d        3 weeks ago         24K (virtual 171M)
base                ubuntu-12.10        b750fe79269d        3 weeks ago         24K (virtual 171M)
base                ubuntu-quantl       b750fe79269d        3 weeks ago         24K (virtual 171M)
base                latest              b750fe79269d        3 weeks ago         24K (virtual 171M)
<none>              <none>              fa594d99163a        2 weeks ago
```
