### PR TITLE
Check kernel capabilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,7 @@ endif
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
 GIT_STATUS = $(shell test -n "`git status --porcelain`" && echo "+CHANGES")
 
-NO_MEMORY_LIMIT ?= 0
-export NO_MEMORY_LIMIT
-
-BUILD_OPTIONS = -ldflags "-X main.GIT_COMMIT $(GIT_COMMIT)$(GIT_STATUS) -X main.NO_MEMORY_LIMIT $(NO_MEMORY_LIMIT)"
+BUILD_OPTIONS = -ldflags "-X main.GIT_COMMIT $(GIT_COMMIT)$(GIT_STATUS)"
 
 SRC_DIR := $(GOPATH)/src
 

--- a/commands.go
+++ b/commands.go
@@ -907,7 +907,7 @@ func (srv *Server) CmdTag(stdin io.ReadCloser, stdout io.Writer, args ...string)
 }
 
 func (srv *Server) CmdRun(stdin io.ReadCloser, stdout rcli.DockerConn, args ...string) error {
-	config, err := ParseRun(args, stdout)
+	config, err := ParseRun(args, stdout, srv.runtime.capabilities)
 	if err != nil {
 		return err
 	}

--- a/commands.go
+++ b/commands.go
@@ -183,10 +183,14 @@ func (srv *Server) CmdWait(stdin io.ReadCloser, stdout io.Writer, args ...string
 
 // 'docker version': show version information
 func (srv *Server) CmdVersion(stdin io.ReadCloser, stdout io.Writer, args ...string) error {
-	fmt.Fprintf(stdout, "Version:%s\n", VERSION)
-	fmt.Fprintf(stdout, "Git Commit:%s\n", GIT_COMMIT)
-	if NO_MEMORY_LIMIT {
-		fmt.Fprintf(stdout, "Memory limit disabled\n")
+	fmt.Fprintf(stdout, "Version: %s\n", VERSION)
+	fmt.Fprintf(stdout, "Git Commit: %s\n", GIT_COMMIT)
+	fmt.Fprintf(stdout, "Kernel: %s\n", srv.runtime.kernelVersion)
+	if !srv.runtime.capabilities.MemoryLimit {
+		fmt.Fprintf(stdout, "WARNING: No memory limit support\n")
+	}
+	if !srv.runtime.capabilities.SwapLimit {
+		fmt.Fprintf(stdout, "WARNING: No swap limit support\n")
 	}
 	return nil
 }

--- a/commands.go
+++ b/commands.go
@@ -21,8 +21,7 @@ import (
 const VERSION = "0.1.6"
 
 var (
-	GIT_COMMIT      string
-	NO_MEMORY_LIMIT bool
+	GIT_COMMIT string
 )
 
 func (srv *Server) Name() string {

--- a/container.go
+++ b/container.go
@@ -373,9 +373,14 @@ func (container *Container) Start() error {
 		return err
 	}
 
-	if container.Config.Memory > 0 && NO_MEMORY_LIMIT {
-		log.Printf("WARNING: This version of docker has been compiled without memory limit support. Discarding the limit.")
+	// Make sure the config is compatible with the current kernel
+	if container.Config.Memory > 0 && !container.runtime.capabilities.MemoryLimit {
+		log.Printf("WARNING: Your kernel does not support memory limit capabilities. Limitation discarded.\n")
 		container.Config.Memory = 0
+	}
+	if container.Config.Memory > 0 && !container.runtime.capabilities.SwapLimit {
+		log.Printf("WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.\n")
+		container.Config.MemorySwap = -1
 	}
 
 	if err := container.generateLXCConfig(); err != nil {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -14,8 +14,7 @@ import (
 )
 
 var (
-	GIT_COMMIT      string
-	NO_MEMORY_LIMIT string
+	GIT_COMMIT string
 )
 
 func main() {
@@ -39,14 +38,10 @@ func main() {
 		os.Setenv("DEBUG", "1")
 	}
 	docker.GIT_COMMIT = GIT_COMMIT
-	docker.NO_MEMORY_LIMIT = NO_MEMORY_LIMIT == "1"
 	if *flDaemon {
 		if flag.NArg() != 0 {
 			flag.Usage()
 			return
-		}
-		if NO_MEMORY_LIMIT == "1" {
-			log.Printf("WARNING: This version of docker has been compiled without memory limit support.")
 		}
 		if err := daemon(*pidfile); err != nil {
 			log.Fatal(err)

--- a/runtime.go
+++ b/runtime.go
@@ -305,11 +305,16 @@ func NewRuntime() (*Runtime, error) {
 		log.Printf("WARNING: You are running linux kernel version %s, which might be unstable running docker. Please upgrade your kernel to 3.8.0.", k.String())
 	}
 
-	_, err1 := ioutil.ReadFile("/sys/fs/cgroup/memory/memory.limit_in_bytes")
-	_, err2 := ioutil.ReadFile("/sys/fs/cgroup/memory/memory.soft_limit_in_bytes")
+	cgroupMemoryMountpoint, err := FindCgroupMountpoint("memory")
+	if err != nil {
+		return nil, err
+	}
+
+	_, err1 := ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "/memory.limit_in_bytes"))
+	_, err2 := ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.soft_limit_in_bytes"))
 	runtime.capabilities.MemoryLimit = err1 == nil && err2 == nil
 
-	_, err = ioutil.ReadFile("/sys/fs/cgroup/memory/memeory.memsw.limit_in_bytes")
+	_, err = ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memeory.memsw.limit_in_bytes"))
 	runtime.capabilities.SwapLimit = err == nil
 
 	return runtime, nil

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -46,8 +46,6 @@ func layerArchive(tarfile string) (io.Reader, error) {
 }
 
 func init() {
-	NO_MEMORY_LIMIT = os.Getenv("NO_MEMORY_LIMIT") == "1"
-
 	// Hack to run sys init during unit testing
 	if SelfPath() == "/sbin/init" {
 		SysInit()

--- a/utils.go
+++ b/utils.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -477,4 +478,21 @@ func CompareKernelVersion(a, b *KernelVersionInfo) int {
 		return 1
 	}
 	return 0
+}
+
+func FindCgroupMountpoint(cgroupType string) (string, error) {
+	output, err := exec.Command("mount").CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+
+	reg := regexp.MustCompile(`^cgroup on (.*) type cgroup \(.*` + cgroupType + `[,\)]`)
+	for _, line := range strings.Split(string(output), "\n") {
+		r := reg.FindStringSubmatch(line)
+		if len(r) == 2 {
+			return r[1], nil
+		}
+		fmt.Printf("line: %s (%d)\n", line, len(r))
+	}
+	return "", fmt.Errorf("cgroup mountpoint not found")
 }

--- a/utils.go
+++ b/utils.go
@@ -13,8 +13,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -383,4 +385,96 @@ func CopyEscapable(dst io.Writer, src io.ReadCloser) (written int64, err error) 
 		}
 	}
 	return written, err
+}
+
+type KernelVersionInfo struct {
+	Kernel   int
+	Major    int
+	Minor    int
+	Specific int
+}
+
+func GetKernelVersion() (*KernelVersionInfo, error) {
+	var uts syscall.Utsname
+
+	if err := syscall.Uname(&uts); err != nil {
+		return nil, err
+	}
+
+	release := make([]byte, len(uts.Release))
+
+	i := 0
+	for _, c := range uts.Release {
+		release[i] = byte(c)
+		i++
+	}
+
+	tmp := strings.SplitN(string(release), "-", 2)
+	if len(tmp) != 2 {
+		return nil, fmt.Errorf("Unrecognized kernel version")
+	}
+	tmp2 := strings.SplitN(tmp[0], ".", 3)
+	if len(tmp2) != 3 {
+		return nil, fmt.Errorf("Unrecognized kernel version")
+	}
+
+	kernel, err := strconv.Atoi(tmp2[0])
+	if err != nil {
+		return nil, err
+	}
+
+	major, err := strconv.Atoi(tmp2[1])
+	if err != nil {
+		return nil, err
+	}
+
+	minor, err := strconv.Atoi(tmp2[2])
+	if err != nil {
+		return nil, err
+	}
+
+	specific, err := strconv.Atoi(strings.Split(tmp[1], "-")[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return &KernelVersionInfo{
+		Kernel:   kernel,
+		Major:    major,
+		Minor:    minor,
+		Specific: specific,
+	}, nil
+}
+
+func (k *KernelVersionInfo) String() string {
+	return fmt.Sprintf("%d.%d.%d-%d", k.Kernel, k.Major, k.Minor, k.Specific)
+}
+
+// Compare two KernelVersionInfo struct.
+// Returns -1 if a < b, = if a == b, 1 it a > b
+func CompareKernelVersion(a, b *KernelVersionInfo) int {
+	if a.Kernel < b.Kernel {
+		return -1
+	} else if a.Kernel > b.Kernel {
+		return 1
+	}
+
+	if a.Major < b.Major {
+		return -1
+	} else if a.Major > b.Major {
+		return 1
+	}
+
+	if a.Minor < b.Minor {
+		return -1
+	} else if a.Minor > b.Minor {
+		return 1
+	}
+
+	if a.Specific < b.Specific {
+		return -1
+	} else if a.Specific > b.Specific {
+		return 1
+	}
+	return 0
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -228,3 +228,36 @@ func assertIndexGet(t *testing.T, index *TruncIndex, input, expectedResult strin
 		t.Fatalf("Getting '%s' returned '%s' instead of '%s'", input, result, expectedResult)
 	}
 }
+
+func assertKernelVersion(t *testing.T, a, b *KernelVersionInfo, result int) {
+	if r := CompareKernelVersion(a, b); r != result {
+		t.Fatalf("Unepected kernel version comparaison result. Found %d, expected %d", r, result)
+	}
+}
+
+func TestCompareKernelVersion(t *testing.T) {
+	assertKernelVersion(t,
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
+		0)
+	assertKernelVersion(t,
+		&KernelVersionInfo{Kernel: 2, Major: 6, Minor: 0, Specific: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
+		-1)
+	assertKernelVersion(t,
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
+		&KernelVersionInfo{Kernel: 2, Major: 6, Minor: 0, Specific: 0},
+		1)
+	assertKernelVersion(t,
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 16},
+		-1)
+	assertKernelVersion(t,
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 5, Specific: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
+		1)
+	assertKernelVersion(t,
+		&KernelVersionInfo{Kernel: 3, Major: 0, Minor: 20, Specific: 25},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
+		-1)
+}


### PR DESCRIPTION
Allow docker to run on kernels that does not support all its features like memory limit.

Known regression: No raw mode support when trying to docker run in tty mode with memory limit while it is not supported.
This regression will soon be fixed with the API
