### PR TITLE
Fixe the race condition between docker run and docker logs from #428

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -975,6 +975,7 @@ func (srv *Server) CmdRun(stdin io.ReadCloser, stdout rcli.DockerConn, args ...s
 	}
 	Debugf("Waiting for attach to return\n")
 	<-attachErr
+	container.Wait()
 	// Expecting I/O pipe error, discarding
 	return nil
 }


### PR DESCRIPTION
Wait for the container to terminate at the end of CmdRun.
