### PR TITLE
Update utils.go to not enforce extra constraints on the kernel "flavor" (such as being integral or even comparable one to another)

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -399,10 +399,10 @@ func CopyEscapable(dst io.Writer, src io.ReadCloser) (written int64, err error) 
 }
 
 type KernelVersionInfo struct {
-	Kernel   int
-	Major    int
-	Minor    int
-	Specific int
+	Kernel int
+	Major  int
+	Minor  int
+	Flavor string
 }
 
 // FIXME: this doens't build on Darwin
@@ -445,21 +445,18 @@ func GetKernelVersion() (*KernelVersionInfo, error) {
 		return nil, err
 	}
 
-	specific, err := strconv.Atoi(strings.Split(tmp[1], "-")[0])
-	if err != nil {
-		return nil, err
-	}
+	flavor := tmp[1]
 
 	return &KernelVersionInfo{
-		Kernel:   kernel,
-		Major:    major,
-		Minor:    minor,
-		Specific: specific,
+		Kernel: kernel,
+		Major:  major,
+		Minor:  minor,
+		Flavor: flavor,
 	}, nil
 }
 
 func (k *KernelVersionInfo) String() string {
-	return fmt.Sprintf("%d.%d.%d-%d", k.Kernel, k.Major, k.Minor, k.Specific)
+	return fmt.Sprintf("%d.%d.%d-%s", k.Kernel, k.Major, k.Minor, k.Flavor)
 }
 
 // Compare two KernelVersionInfo struct.
@@ -483,11 +480,6 @@ func CompareKernelVersion(a, b *KernelVersionInfo) int {
 		return 1
 	}
 
-	if a.Specific < b.Specific {
-		return -1
-	} else if a.Specific > b.Specific {
-		return 1
-	}
 	return 0
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -237,27 +237,27 @@ func assertKernelVersion(t *testing.T, a, b *KernelVersionInfo, result int) {
 
 func TestCompareKernelVersion(t *testing.T) {
 	assertKernelVersion(t,
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
 		0)
 	assertKernelVersion(t,
-		&KernelVersionInfo{Kernel: 2, Major: 6, Minor: 0, Specific: 0},
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
+		&KernelVersionInfo{Kernel: 2, Major: 6, Minor: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
 		-1)
 	assertKernelVersion(t,
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
-		&KernelVersionInfo{Kernel: 2, Major: 6, Minor: 0, Specific: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
+		&KernelVersionInfo{Kernel: 2, Major: 6, Minor: 0},
 		1)
 	assertKernelVersion(t,
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 16},
-		-1)
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "0"},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "16"},
+		0)
 	assertKernelVersion(t,
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 5, Specific: 0},
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 5},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
 		1)
 	assertKernelVersion(t,
-		&KernelVersionInfo{Kernel: 3, Major: 0, Minor: 20, Specific: 25},
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Specific: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 0, Minor: 20, Flavor: "25"},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "0"},
 		-1)
 }


### PR DESCRIPTION
This is especially to fix the current docker on kernels such as gentoo-sources, where the "flavor" is the string "gentoo", and that obviously fails to be converted to an integer.

This was discussed with @shykes in https://github.com/dotcloud/docker/issues/313#issuecomment-16746821.
