### PR TITLE
Add JSON data to Container.Config, specified with -j option of "run" com...

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -905,12 +906,18 @@ func TestLXCConfig(t *testing.T) {
 	memMin := 33554432
 	memMax := 536870912
 	mem := memMin + rand.Intn(memMax-memMin)
+
+        // JSON with cgroup
+	var jsonMap interface{}
+	json.Unmarshal([]byte("{\"cgroup\":{\"cpufoo\":\"dotbar\"}}"), &jsonMap)
+
 	container, err := runtime.Create(&Config{
 		Image: GetTestImage(runtime).Id,
 		Cmd:   []string{"/bin/true"},
 
 		Hostname: "foobar",
 		Memory:   int64(mem),
+		JsonMap:  jsonMap,
 	},
 	)
 	if err != nil {
@@ -923,6 +930,7 @@ func TestLXCConfig(t *testing.T) {
 		fmt.Sprintf("lxc.cgroup.memory.limit_in_bytes = %d", mem))
 	grepFile(t, container.lxcConfigPath(),
 		fmt.Sprintf("lxc.cgroup.memory.memsw.limit_in_bytes = %d", mem*2))
+	grepFile(t, container.lxcConfigPath(), "lxc.cgroup.cpufoo = dotbar")
 }
 
 func BenchmarkRunSequencial(b *testing.B) {

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -92,6 +92,12 @@ lxc.cgroup.memory.soft_limit_in_bytes = {{.Config.Memory}}
 lxc.cgroup.memory.memsw.limit_in_bytes = {{$memSwap}}
 {{end}}
 {{end}}
+
+{{if .Config.JsonMap}}{{if .Config.JsonMap.cgroup}}
+# JSON: cgroup key-values
+{{range $k, $v := .Config.JsonMap.cgroup}}lxc.cgroup.{{$k}} = {{$v}}
+{{end}}{{end}}
+{{end}}
 `
 
 var LxcTemplateCompiled *template.Template


### PR DESCRIPTION
...mand  #439

Adds a field JsonMap to Container.Config.  The lxc_template uses data stored there to
augment the lxc config file.

The "run" command now has a "-j" command to specify the JSON object.

Currently only a "cgroup" field is supported.  It simply takes the key-value pairs from
the "cgroup" field (if exists) and emits  lxc.cgroup.key = value

Addresses issue #439
