### PR TITLE
Update FindCgroupMountpoint to be more forgiving

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -442,7 +442,7 @@ func FindCgroupMountpoint(cgroupType string) (string, error) {
 		return "", err
 	}
 
-	reg := regexp.MustCompile(`^cgroup on (.*) type cgroup \(.*` + cgroupType + `[,\)]`)
+	reg := regexp.MustCompile(`^.* on (.*) type cgroup \(.*` + cgroupType + `[,\)]`)
 	for _, line := range strings.Split(string(output), "\n") {
 		r := reg.FindStringSubmatch(line)
 		if len(r) == 2 {


### PR DESCRIPTION
On Gentoo, the memory cgroup is mounted at /sys/fs/cgroup/memory, but the mount line looks like the following:
memory on /sys/fs/cgroup/memory type cgroup (rw,nosuid,nodev,noexec,relatime,memory)

(note that the first word on the line is "memory", not "cgroup", but the other essentials are there, namely the type of cgroup and the memory mount option)

This is as I mentioned in [this comment](https://github.com/dotcloud/docker/issues/313#issuecomment-16750517), but didn't fully realize what was going on until today.
