### PR TITLE
Use /proc/mounts instead of mount(8) to find cgroup mountpoints

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,5 +54,10 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
   config.vm.provider :vmware_fusion do |vm|
     config.vm.box = "precise64"
     config.vm.box_url = "http://files.vagrantup.com/precise64_vmware_fusion.box"
+    config.vm.provision :shell, :inline => <<-UPDATE
+      apt-get update
+      apt-get dist-upgrade
+      apt-get install linux-image-extra-3.2.0-40-virtual
+    UPDATE
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,4 +50,9 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     config.vm.box = BOX_NAME
     config.vm.box_url = BOX_URI
   end
+
+  config.vm.provider :vmware_fusion do |vm|
+    config.vm.box = "precise64"
+    config.vm.box_url = "http://files.vagrantup.com/precise64_vmware_fusion.box"
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,9 +55,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     config.vm.box = "precise64"
     config.vm.box_url = "http://files.vagrantup.com/precise64_vmware_fusion.box"
     config.vm.provision :shell, :inline => <<-UPDATE
-      apt-get update
-      apt-get dist-upgrade
-      apt-get install linux-image-extra-3.2.0-40-virtual
+      apt-get install -y linux-image-extra-3.2.0-29-virtual
     UPDATE
   end
 end


### PR DESCRIPTION
Specifically, Ubuntu Precise's cgroup-lite script uses mount -n
to mount the cgroup filesystems so they don't appear in mtab, so
detection always fails unless the admin updates mtab with /proc/mounts.

/proc/mounts is valid on just about every Linux machine in existence and
as a bonus is much easier to parse.

I also removed the regex in favor of a more accurate parser that should
also support monolitic cgroup mounts (e.g. mount -t cgroup none /cgroup).
