### PR TITLE
Use only one deb line in /etc/apt

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant::Config.run do |config|
   config.vm.box_url = BOX_URI
   # Add docker PPA key to the local repository and install docker
   pkg_cmd = "apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys #{PPA_KEY}; "
-  pkg_cmd << "echo 'deb http://ppa.launchpad.net/dotcloud/lxc-docker/ubuntu precise main' >>/etc/apt/sources.list; "
+  pkg_cmd << "echo 'deb http://ppa.launchpad.net/dotcloud/lxc-docker/ubuntu precise main' >/etc/apt/sources.list.d/lxc-docker.list; "
   pkg_cmd << "apt-get update -qq; apt-get install -q -y lxc-docker"
   if ARGV.include?("--provider=aws".downcase)
     # Add AUFS dependency to amazon's VM


### PR DESCRIPTION
This prevents the script from filling up /etc/apt/sources.list with more than one deb line which cause a warning when updating.
