### PR TITLE
Make docker compatible with the new registry

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -16,7 +16,7 @@ import (
 const CONFIGFILE = ".dockercfg"
 
 // the registry server we want to login against
-const REGISTRY_SERVER = "https://registry.docker.io"
+const INDEX_SERVER = "https://index.docker.io"
 
 type AuthConfig struct {
 	Username string `json:"username"`
@@ -113,7 +113,7 @@ func Login(authConfig *AuthConfig) (string, error) {
 
 	// using `bytes.NewReader(jsonBody)` here causes the server to respond with a 411 status.
 	b := strings.NewReader(string(jsonBody))
-	req1, err := http.Post(REGISTRY_SERVER+"/v1/users", "application/json; charset=utf-8", b)
+	req1, err := http.Post(INDEX_SERVER+"/v1/users", "application/json; charset=utf-8", b)
 	if err != nil {
 		errMsg = fmt.Sprintf("Server Error: %s", err)
 		return "", errors.New(errMsg)
@@ -134,7 +134,7 @@ func Login(authConfig *AuthConfig) (string, error) {
 		// FIXME: This should be 'exists', not 'exist'. Need to change on the server first.
 		if string(reqBody) == "Username or email already exist" {
 			client := &http.Client{}
-			req, err := http.NewRequest("GET", REGISTRY_SERVER+"/v1/users", nil)
+			req, err := http.NewRequest("GET", INDEX_SERVER+"/v1/users", nil)
 			req.SetBasicAuth(authConfig.Username, authConfig.Password)
 			resp, err := client.Do(req)
 			if err != nil {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -15,7 +15,7 @@ import (
 const CONFIGFILE = ".dockercfg"
 
 // the registry server we want to login against
-const INDEX_SERVER = "http://indexstaging-docker.dotcloud.com"
+const INDEX_SERVER = "https://indexstaging-docker.dotcloud.com"
 
 type AuthConfig struct {
 	Username string `json:"username"`
@@ -123,8 +123,12 @@ func Login(authConfig *AuthConfig) (string, error) {
 	}
 
 	if reqStatusCode == 201 {
-		status = "Account Created\n"
+		status = "Account created. Please use the confirmation link we sent"+
+			" to your e-mail to activate it.\n"
 		storeConfig = true
+	} else if reqStatusCode == 403 {
+		return "", fmt.Errorf("Login: Your account hasn't been activated. "+
+			"Please check your e-mail for a confirmation link.")
 	} else if reqStatusCode == 400 {
 		if string(reqBody) == "\"Username or email already exists\"" {
 			req, err := http.NewRequest("GET", INDEX_SERVER+"/v1/users/", nil)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -126,8 +126,7 @@ func Login(authConfig *AuthConfig) (string, error) {
 		status = "Account Created\n"
 		storeConfig = true
 	} else if reqStatusCode == 400 {
-		// FIXME: This should be 'exists', not 'exist'. Need to change on the server first.
-		if string(reqBody) == "\"Username or email already exist\"" {
+		if string(reqBody) == "\"Username or email already exists\"" {
 			req, err := http.NewRequest("GET", INDEX_SERVER+"/v1/users/", nil)
 			req.SetBasicAuth(authConfig.Username, authConfig.Password)
 			resp, err := client.Do(req)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -15,7 +15,7 @@ import (
 const CONFIGFILE = ".dockercfg"
 
 // the registry server we want to login against
-const INDEX_SERVER = "https://indexstaging-docker.dotcloud.com"
+const INDEX_SERVER = "https://index.docker.io"
 
 type AuthConfig struct {
 	Username string `json:"username"`
@@ -131,11 +131,11 @@ func Login(authConfig *AuthConfig) (string, error) {
 	}
 
 	if reqStatusCode == 201 {
-		status = "Account created. Please use the confirmation link we sent"+
+		status = "Account created. Please use the confirmation link we sent" +
 			" to your e-mail to activate it.\n"
 		storeConfig = true
 	} else if reqStatusCode == 403 {
-		return "", fmt.Errorf("Login: Your account hasn't been activated. "+
+		return "", fmt.Errorf("Login: Your account hasn't been activated. " +
 			"Please check your e-mail for a confirmation link.")
 	} else if reqStatusCode == 400 {
 		if string(reqBody) == "\"Username or email already exists\"" {

--- a/commands.go
+++ b/commands.go
@@ -529,9 +529,6 @@ func (srv *Server) CmdPush(stdin io.ReadCloser, stdout rcli.DockerConn, args ...
 	Debugf("Pushing [%s] to [%s]\n", local, remote)
 
 	// Try to get the image
-	// FIXME: Handle lookup
-	// FIXME: Also push the tags in case of ./docker push myrepo:mytag
-	//	img, err := srv.runtime.LookupImage(cmd.Arg(0))
 	img, err := srv.runtime.graph.Get(local)
 	if err != nil {
 		Debugf("The push refers to a repository [%s] (len: %d)\n", local, len(srv.runtime.repositories.Repositories[local]))

--- a/commands.go
+++ b/commands.go
@@ -492,64 +492,64 @@ func (srv *Server) CmdImport(stdin io.ReadCloser, stdout rcli.DockerConn, args .
 	return nil
 }
 
-func (srv *Server) CmdPush(stdin io.ReadCloser, stdout rcli.DockerConn, args ...string) error {
-	cmd := rcli.Subcmd(stdout, "push", "NAME", "Push an image or a repository to the registry")
-	if err := cmd.Parse(args); err != nil {
-		return nil
-	}
-	local := cmd.Arg(0)
+// func (srv *Server) CmdPush(stdin io.ReadCloser, stdout rcli.DockerConn, args ...string) error {
+// 	cmd := rcli.Subcmd(stdout, "push", "NAME", "Push an image or a repository to the registry")
+// 	if err := cmd.Parse(args); err != nil {
+// 		return nil
+// 	}
+// 	local := cmd.Arg(0)
 
-	if local == "" {
-		cmd.Usage()
-		return nil
-	}
+// 	if local == "" {
+// 		cmd.Usage()
+// 		return nil
+// 	}
 
-	// If the login failed, abort
-	if srv.runtime.authConfig == nil || srv.runtime.authConfig.Username == "" {
-		if err := srv.CmdLogin(stdin, stdout, args...); err != nil {
-			return err
-		}
-		if srv.runtime.authConfig == nil || srv.runtime.authConfig.Username == "" {
-			return fmt.Errorf("Please login prior to push. ('docker login')")
-		}
-	}
+// 	// If the login failed, abort
+// 	if srv.runtime.authConfig == nil || srv.runtime.authConfig.Username == "" {
+// 		if err := srv.CmdLogin(stdin, stdout, args...); err != nil {
+// 			return err
+// 		}
+// 		if srv.runtime.authConfig == nil || srv.runtime.authConfig.Username == "" {
+// 			return fmt.Errorf("Please login prior to push. ('docker login')")
+// 		}
+// 	}
 
-	var remote string
+// 	var remote string
 
-	tmp := strings.SplitN(local, "/", 2)
-	if len(tmp) == 1 {
-		return fmt.Errorf(
-			"Impossible to push a \"root\" repository. Please rename your repository in <user>/<repo> (ex: %s/%s)",
-			srv.runtime.authConfig.Username, local)
-	} else {
-		remote = local
-	}
+// 	tmp := strings.SplitN(local, "/", 2)
+// 	if len(tmp) == 1 {
+// 		return fmt.Errorf(
+// 			"Impossible to push a \"root\" repository. Please rename your repository in <user>/<repo> (ex: %s/%s)",
+// 			srv.runtime.authConfig.Username, local)
+// 	} else {
+// 		remote = local
+// 	}
 
-	Debugf("Pushing [%s] to [%s]\n", local, remote)
+// 	Debugf("Pushing [%s] to [%s]\n", local, remote)
 
-	// Try to get the image
-	// FIXME: Handle lookup
-	// FIXME: Also push the tags in case of ./docker push myrepo:mytag
-	//	img, err := srv.runtime.LookupImage(cmd.Arg(0))
-	img, err := srv.runtime.graph.Get(local)
-	if err != nil {
-		Debugf("The push refers to a repository [%s] (len: %d)\n", local, len(srv.runtime.repositories.Repositories[local]))
-		// If it fails, try to get the repository
-		if localRepo, exists := srv.runtime.repositories.Repositories[local]; exists {
-			if err := srv.runtime.graph.PushRepository(stdout, remote, localRepo, srv.runtime.authConfig); err != nil {
-				return err
-			}
-			return nil
-		}
+// 	// Try to get the image
+// 	// FIXME: Handle lookup
+// 	// FIXME: Also push the tags in case of ./docker push myrepo:mytag
+// 	//	img, err := srv.runtime.LookupImage(cmd.Arg(0))
+// 	img, err := srv.runtime.graph.Get(local)
+// 	if err != nil {
+// 		Debugf("The push refers to a repository [%s] (len: %d)\n", local, len(srv.runtime.repositories.Repositories[local]))
+// 		// If it fails, try to get the repository
+// 		if localRepo, exists := srv.runtime.repositories.Repositories[local]; exists {
+// 			if err := srv.runtime.graph.PushRepository(stdout, remote, localRepo, srv.runtime.authConfig); err != nil {
+// 				return err
+// 			}
+// 			return nil
+// 		}
 
-		return err
-	}
-	err = srv.runtime.graph.PushImage(stdout, img, srv.runtime.authConfig)
-	if err != nil {
-		return err
-	}
-	return nil
-}
+// 		return err
+// 	}
+// 	err = srv.runtime.graph.PushImage(stdout, img, srv.runtime.authConfig)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	return nil
+// }
 
 func (srv *Server) CmdPull(stdin io.ReadCloser, stdout io.Writer, args ...string) error {
 	cmd := rcli.Subcmd(stdout, "pull", "NAME", "Pull an image or a repository from the registry")

--- a/commands.go
+++ b/commands.go
@@ -553,6 +553,8 @@ func (srv *Server) CmdPush(stdin io.ReadCloser, stdout rcli.DockerConn, args ...
 
 func (srv *Server) CmdPull(stdin io.ReadCloser, stdout io.Writer, args ...string) error {
 	cmd := rcli.Subcmd(stdout, "pull", "NAME", "Pull an image or a repository from the registry")
+	tag := cmd.String("t", "", "Download tagged image in repository")
+	registry := cmd.String("registry", "", "Registry to download from. Necessary if image is pulled by ID")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -563,14 +565,14 @@ func (srv *Server) CmdPull(stdin io.ReadCloser, stdout io.Writer, args ...string
 	}
 
 	// FIXME: CmdPull should be a wrapper around Runtime.Pull()
-	if srv.runtime.graph.LookupRemoteImage(remote, srv.runtime.authConfig) {
-		if err := srv.runtime.graph.PullImage(stdout, remote, srv.runtime.authConfig); err != nil {
+	if *registry != "" {
+		if err := srv.runtime.graph.PullImage(stdout, remote, *registry, nil); err != nil {
 			return err
 		}
 		return nil
 	}
 	// FIXME: Allow pull repo:tag
-	if err := srv.runtime.graph.PullRepository(stdout, remote, "", srv.runtime.repositories, srv.runtime.authConfig); err != nil {
+	if err := srv.runtime.graph.PullRepository(stdout, remote, *tag, srv.runtime.repositories, srv.runtime.authConfig); err != nil {
 		return err
 	}
 	return nil

--- a/commands.go
+++ b/commands.go
@@ -565,6 +565,12 @@ func (srv *Server) CmdPull(stdin io.ReadCloser, stdout io.Writer, args ...string
 		return nil
 	}
 
+	if strings.Contains(remote, ":") {
+		remoteParts := strings.Split(remote, ":")
+		tag = &remoteParts[1]
+		remote = remoteParts[0]
+	}
+
 	// FIXME: CmdPull should be a wrapper around Runtime.Pull()
 	if *registry != "" {
 		if err := srv.runtime.graph.PullImage(stdout, remote, *registry, nil); err != nil {
@@ -572,7 +578,6 @@ func (srv *Server) CmdPull(stdin io.ReadCloser, stdout io.Writer, args ...string
 		}
 		return nil
 	}
-	// FIXME: Allow pull repo:tag
 	if err := srv.runtime.graph.PullRepository(stdout, remote, *tag, srv.runtime.repositories, srv.runtime.authConfig); err != nil {
 		return err
 	}

--- a/container.go
+++ b/container.go
@@ -1,8 +1,6 @@
 package docker
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"github.com/dotcloud/docker/rcli"
@@ -698,15 +696,11 @@ func (container *Container) ExportRw() (Archive, error) {
 }
 
 func (container *Container) RwChecksum() (string, error) {
-	h := sha256.New()
-	rwData, err := container.ExportRw()
+	rwData, err := Tar(container.rwPath(), Xz)
 	if err != nil {
 		return "", err
 	}
-	if _, err := io.Copy(h, rwData); err != nil {
-		return "", err
-	}
-	return "sha256:"+hex.EncodeToString(h.Sum(nil)), nil
+	return HashData(rwData)
 }
 
 func (container *Container) Export() (Archive, error) {

--- a/container.go
+++ b/container.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"github.com/dotcloud/docker/rcli"
@@ -705,7 +706,7 @@ func (container *Container) RwChecksum() (string, error) {
 	if _, err := io.Copy(h, rwData); err != nil {
 		return "", err
 	}
-	return string(h.Sum(nil)), nil
+	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func (container *Container) Export() (Archive, error) {

--- a/container.go
+++ b/container.go
@@ -706,7 +706,7 @@ func (container *Container) RwChecksum() (string, error) {
 	if _, err := io.Copy(h, rwData); err != nil {
 		return "", err
 	}
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return "sha256:"+hex.EncodeToString(h.Sum(nil)), nil
 }
 
 func (container *Container) Export() (Archive, error) {

--- a/container.go
+++ b/container.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"github.com/dotcloud/docker/rcli"
@@ -693,6 +694,18 @@ func (container *Container) Wait() int {
 
 func (container *Container) ExportRw() (Archive, error) {
 	return Tar(container.rwPath(), Uncompressed)
+}
+
+func (container *Container) RwChecksum() (string, error) {
+	h := sha256.New()
+	rwData, err := container.ExportRw()
+	if err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(h, rwData); err != nil {
+		return "", err
+	}
+	return string(h.Sum(nil)), nil
 }
 
 func (container *Container) Export() (Archive, error) {

--- a/graph.go
+++ b/graph.go
@@ -98,11 +98,13 @@ func (graph *Graph) Create(layerData Archive, container *Container, comment, aut
 		img.Parent = container.Image
 		img.Container = container.Id
 		img.ContainerConfig = *container.Config
-		if config == nil {
-			if parentImage, err := graph.Get(container.Image); err == nil && parentImage != nil {
-				img.Config = parentImage.Config
-			}
+		// FIXME: If an image is pulled from a raw URL (not created from a container),
+		// its checksum will not be computed, which will cause a push to fail
+		checksum, err := container.RwChecksum()
+		if err != nil {
+			return nil, err
 		}
+		img.Checksum = checksum
 	}
 	if err := graph.Register(layerData, img); err != nil {
 		return nil, err

--- a/graph.go
+++ b/graph.go
@@ -2,7 +2,7 @@ package docker
 
 import (
 	"fmt"
-	"io"
+	"net/http"
 	"io/ioutil"
 	"os"
 	"path"
@@ -15,6 +15,7 @@ import (
 type Graph struct {
 	Root    string
 	idIndex *TruncIndex
+	httpClient *http.Client
 }
 
 // NewGraph instantiates a new graph at the given root path in the filesystem.

--- a/graph.go
+++ b/graph.go
@@ -292,3 +292,30 @@ func (graph *Graph) Heads() (map[string]*Image, error) {
 func (graph *Graph) imageRoot(id string) string {
 	return path.Join(graph.Root, id)
 }
+
+func (graph *Graph) Checksums(repo Repository) ([]map[string]string, error) {
+	var checksums map[string]string
+	var result []map[string]string
+	for _, id := range repo {
+		img, err := graph.Get(id)
+		if err != nil {
+			return nil, err
+		}
+		err = img.WalkHistory(func(image *Image) error {
+			checksums[image.Id] = image.Checksum
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	i := 0
+	for id, sum := range checksums {
+		result[i] = map[string]string{
+			"id": id,
+			"checksum": sum,
+		}
+		i++
+	}
+	return result, nil
+}

--- a/graph.go
+++ b/graph.go
@@ -286,31 +286,3 @@ func (graph *Graph) Heads() (map[string]*Image, error) {
 func (graph *Graph) imageRoot(id string) string {
 	return path.Join(graph.Root, id)
 }
-
-func (graph *Graph) Checksums(repo Repository) ([]map[string]string, error) {
-	var result []map[string]string
-	checksums := map[string]string{}
-	for _, id := range repo {
-		img, err := graph.Get(id)
-		if err != nil {
-			return nil, err
-		}
-		err = img.WalkHistory(func(image *Image) error {
-			checksums[image.Id], err = image.Checksum()
-			return err
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-	i := 0
-	result = make([]map[string]string, len(checksums))
-	for id, sum := range checksums {
-		result[i] = map[string]string{
-			"id":       id,
-			"checksum": sum,
-		}
-		i++
-	}
-	return result, nil
-}

--- a/graph.go
+++ b/graph.go
@@ -294,8 +294,8 @@ func (graph *Graph) imageRoot(id string) string {
 }
 
 func (graph *Graph) Checksums(repo Repository) ([]map[string]string, error) {
-	var checksums map[string]string
 	var result []map[string]string
+	checksums := map[string]string{}
 	for _, id := range repo {
 		img, err := graph.Get(id)
 		if err != nil {
@@ -310,6 +310,7 @@ func (graph *Graph) Checksums(repo Repository) ([]map[string]string, error) {
 		}
 	}
 	i := 0
+	result = make([]map[string]string, len(checksums))
 	for id, sum := range checksums {
 		result[i] = map[string]string{
 			"id":       id,

--- a/graph.go
+++ b/graph.go
@@ -2,8 +2,8 @@ package docker
 
 import (
 	"fmt"
-	"net/http"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -13,8 +13,8 @@ import (
 
 // A Graph is a store for versioned filesystem images and the relationship between them.
 type Graph struct {
-	Root    string
-	idIndex *TruncIndex
+	Root       string
+	idIndex    *TruncIndex
 	httpClient *http.Client
 }
 

--- a/graph.go
+++ b/graph.go
@@ -297,10 +297,7 @@ func (graph *Graph) Checksums(repo Repository) ([]map[string]string, error) {
 		}
 		err = img.WalkHistory(func(image *Image) error {
 			checksums[image.Id], err = image.Checksum()
-			if err != nil {
-				return err
-			}
-			return nil
+			return err
 		})
 		if err != nil {
 			return nil, err

--- a/graph.go
+++ b/graph.go
@@ -312,7 +312,7 @@ func (graph *Graph) Checksums(repo Repository) ([]map[string]string, error) {
 	i := 0
 	for id, sum := range checksums {
 		result[i] = map[string]string{
-			"id": id,
+			"id":       id,
 			"checksum": sum,
 		}
 		i++

--- a/graph.go
+++ b/graph.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"os"

--- a/graph.go
+++ b/graph.go
@@ -81,6 +81,13 @@ func (graph *Graph) Get(name string) (*Image, error) {
 		return nil, fmt.Errorf("Image stored at '%s' has wrong id '%s'", id, img.Id)
 	}
 	img.graph = graph
+
+	if img.Checksum == "" {
+		err := img.FixChecksum()
+		if err != nil {
+			return nil, err
+		}
+	}
 	return img, nil
 }
 
@@ -98,7 +105,7 @@ func (graph *Graph) Create(layerData Archive, container *Container, comment, aut
 		img.Parent = container.Image
 		img.Container = container.Id
 		img.ContainerConfig = *container.Config
-		// FIXME: If an image is pulled from a raw URL (not created from a container),
+		// FIXME: If an image is imported from a raw URL (not created from a container),
 		// its checksum will not be computed, which will cause a push to fail
 		checksum, err := container.RwChecksum()
 		if err != nil {

--- a/image.go
+++ b/image.go
@@ -18,6 +18,7 @@ import (
 type Image struct {
 	Id              string    `json:"id"`
 	Parent          string    `json:"parent,omitempty"`
+	Checksum        string    `json:"checksum,omitempty"`
 	Comment         string    `json:"comment,omitempty"`
 	Created         time.Time `json:"created"`
 	Container       string    `json:"container,omitempty"`

--- a/image.go
+++ b/image.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -294,10 +293,10 @@ func (img *Image) Checksum() (string, error) {
 	}
 
 	h := sha256.New()
-	if _, err := io.Copy(h, bytes.NewBuffer(jsonData)); err != nil {
+	if _, err := h.Write(jsonData); err != nil {
 		return "", err
 	}
-	if _, err := io.Copy(h, strings.NewReader("\n")); err != nil {
+	if _, err := h.Write([]byte("\n")); err != nil {
 		return "", err
 	}
 	if _, err := io.Copy(h, layerData); err != nil {

--- a/image.go
+++ b/image.go
@@ -303,7 +303,7 @@ func (img *Image) Checksum() (string, error) {
 		return "", err
 	}
 
-	hash := "sha256:"+hex.EncodeToString(h.Sum(nil))
+	hash := "sha256:" + hex.EncodeToString(h.Sum(nil))
 	if *checksums == nil {
 		*checksums = map[string]string{}
 	}

--- a/image.go
+++ b/image.go
@@ -283,20 +283,24 @@ func (img *Image) Checksum() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	layerData, err := Tar(layer, Xz)
-	if err != nil {
-		return "", err
-	}
-	h := sha256.New()
-	if _, err := io.Copy(h, layerData); err != nil {
-		return "", err
-	}
-
 	jsonData, err := ioutil.ReadFile(jsonPath(root))
 	if err != nil {
 		return "", err
 	}
+
+	layerData, err := Tar(layer, Xz)
+	if err != nil {
+		return "", err
+	}
+
+	h := sha256.New()
 	if _, err := io.Copy(h, bytes.NewBuffer(jsonData)); err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(h, strings.NewReader("\n")); err != nil {
+		return "", err
+	}
+	if _, err := io.Copy(h, layerData); err != nil {
 		return "", err
 	}
 

--- a/registry.go
+++ b/registry.go
@@ -45,7 +45,7 @@ func (graph *Graph) getRemoteHistory(imgId, registry string, token []string) ([]
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Token " + strings.Join(token, ", "))
+	req.Header.Set("Authorization", "Token "+strings.Join(token, ", "))
 	res, err := client.Do(req)
 	if err != nil || res.StatusCode != 200 {
 		if res != nil {
@@ -90,7 +90,7 @@ func (graph *Graph) LookupRemoteImage(imgId, registry string, authConfig *auth.A
 }
 
 func (graph *Graph) getImagesInRepository(repository string, authConfig *auth.AuthConfig) ([]map[string]string, error) {
-	u := INDEX_ENDPOINT+"/repositories/"+repository+"/images"
+	u := INDEX_ENDPOINT + "/repositories/" + repository + "/images"
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -131,7 +131,7 @@ func (graph *Graph) getRemoteImage(stdout io.Writer, imgId, registry string, tok
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to download json: %s", err)
 	}
-	req.Header.Set("Authorization", "Token " + strings.Join(token, ", "))
+	req.Header.Set("Authorization", "Token "+strings.Join(token, ", "))
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to download json: %s", err)
@@ -158,7 +158,7 @@ func (graph *Graph) getRemoteImage(stdout io.Writer, imgId, registry string, tok
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error while getting from the server: %s\n", err)
 	}
-	req.Header.Set("Authorization", "Token " + strings.Join(token, ", "))
+	req.Header.Set("Authorization", "Token "+strings.Join(token, ", "))
 	res, err = client.Do(req)
 	if err != nil {
 		return nil, nil, err
@@ -174,7 +174,7 @@ func (graph *Graph) getRemoteTags(stdout io.Writer, registries []string, reposit
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set("Authorization", "Token " + strings.Join(token, ", "))
+		req.Header.Set("Authorization", "Token "+strings.Join(token, ", "))
 		res, err := client.Do(req)
 		defer res.Body.Close()
 		if err != nil || (res.StatusCode != 200 && res.StatusCode != 404) {
@@ -209,7 +209,7 @@ func (graph *Graph) getImageForTag(stdout io.Writer, tag, remote, registry strin
 	if err != nil {
 		return "", err
 	}
-	req.Header.Set("Authorization", "Token " + strings.Join(token, ", "))
+	req.Header.Set("Authorization", "Token "+strings.Join(token, ", "))
 	res, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("Error while retrieving repository info: %v", err)
@@ -357,7 +357,7 @@ func pushImageRec(graph *Graph, stdout io.Writer, img *Image, registry string, t
 		return err
 	}
 	req.Header.Add("Content-type", "application/json")
-	req.Header.Set("Authorization", "Token " + strings.Join(token, ","))
+	req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
 
 	checksum, err := img.Checksum()
 	if err != nil {
@@ -403,7 +403,7 @@ func pushImageRec(graph *Graph, stdout io.Writer, img *Image, registry string, t
 
 	req3.ContentLength = -1
 	req3.TransferEncoding = []string{"chunked"}
-	req3.Header.Set("Authorization", "Token " + strings.Join(token, ","))
+	req3.Header.Set("Authorization", "Token "+strings.Join(token, ","))
 	res3, err := doWithCookies(client, req3)
 	if err != nil {
 		return fmt.Errorf("Failed to upload layer: %s", err)
@@ -442,7 +442,7 @@ func (graph *Graph) pushTag(remote, revision, tag, registry string, token []stri
 		return err
 	}
 	req.Header.Add("Content-type", "application/json")
-	req.Header.Set("Authorization", "Token " + strings.Join(token, ","))
+	req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
 	req.ContentLength = int64(len(revision))
 	res, err := doWithCookies(client, req)
 	if err != nil {
@@ -492,7 +492,6 @@ func (graph *Graph) PushRepository(stdout io.Writer, remote string, localRepo Re
 	if err != nil {
 		return fmt.Errorf("Error occured while fetching the list: %v", err)
 	}
-
 
 	// Filter list to only send images/checksums not already uploaded
 	i := 0

--- a/registry.go
+++ b/registry.go
@@ -279,6 +279,9 @@ func (graph *Graph) PullRepository(stdout io.Writer, remote, askedTag string, re
 		return err
 	}
 	defer res.Body.Close()
+	if res.StatusCode == 401 {
+		return fmt.Errorf("Please login first (HTTP code %d)", res.StatusCode)
+	}
 	// TODO: Right now we're ignoring checksums in the response body.
 	// In the future, we need to use them to check image validity.
 	if res.StatusCode != 200 {

--- a/registry.go
+++ b/registry.go
@@ -375,7 +375,8 @@ func pushImageRec(graph *Graph, stdout io.Writer, img *Image, registry string, t
 	if res.StatusCode != 200 {
 		errBody, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			errBody = []byte(err.Error())
+			return fmt.Errorf("HTTP code %d while uploading metadata and error when"+
+				" trying to parse response body: %v", res.StatusCode, err)
 		}
 		var jsonBody map[string]string
 		if err := json.Unmarshal(errBody, &jsonBody); err != nil {

--- a/registry.go
+++ b/registry.go
@@ -187,8 +187,8 @@ func (graph *Graph) getRemoteTags(stdout io.Writer, registries []string, reposit
 		req.Header.Set("Authorization", "Token "+strings.Join(token, ", "))
 		res, err := client.Do(req)
 		defer res.Body.Close()
+		Debugf("Got status code %d from %s", res.StatusCode, endpoint)
 		if err != nil || (res.StatusCode != 200 && res.StatusCode != 404) {
-			Debugf("Registry isn't responding: trying another registry endpoint")
 			continue
 		} else if res.StatusCode == 404 {
 			return nil, fmt.Errorf("Repository not found")

--- a/registry.go
+++ b/registry.go
@@ -269,7 +269,7 @@ func (graph *Graph) PullRepository(stdout io.Writer, remote, askedTag string, re
 	if err != nil {
 		return err
 	}
-	if authConfig != nil {
+	if authConfig != nil && len(authConfig.Username) > 0 {
 		req.SetBasicAuth(authConfig.Username, authConfig.Password)
 	}
 	req.Header.Set("X-Docker-Token", "true")
@@ -309,6 +309,7 @@ func (graph *Graph) PullRepository(stdout io.Writer, remote, askedTag string, re
 	}
 
 	for askedTag, imgId := range tagsList {
+		fmt.Fprintf(stdout, "Resolving tag \"%s:%s\" from %s\n", remote, askedTag, endpoints)
 		success := false
 		for _, registry := range endpoints {
 			if imgId == "" {

--- a/registry.go
+++ b/registry.go
@@ -277,7 +277,7 @@ func (graph *Graph) PullRepository(stdout io.Writer, remote, askedTag string, re
 			return err
 		}
 	} else {
-		tagsList = map[string]string{ askedTag : "" }
+		tagsList = map[string]string{askedTag: ""}
 	}
 
 	for askedTag, imgId := range tagsList {
@@ -286,13 +286,13 @@ func (graph *Graph) PullRepository(stdout io.Writer, remote, askedTag string, re
 			if imgId == "" {
 				imgId, err = graph.getImageForTag(stdout, askedTag, remote, registry, token)
 				if err != nil {
-					fmt.Fprintf(stdout, "Error while retrieving image for tag: %v (%v) ; " +
-					"checking next endpoint", askedTag, err)
+					fmt.Fprintf(stdout, "Error while retrieving image for tag: %v (%v) ; "+
+						"checking next endpoint", askedTag, err)
 					continue
 				}
 			}
 
-			if err := graph.PullImage(stdout, imgId, "https://" + registry + "/v1", token); err != nil {
+			if err := graph.PullImage(stdout, imgId, "https://"+registry+"/v1", token); err != nil {
 				return err
 			}
 

--- a/registry.go
+++ b/registry.go
@@ -239,7 +239,7 @@ func (graph *Graph) PullRepository(stdout io.Writer, remote, askedTag string, re
 	client := graph.getHttpClient()
 
 	fmt.Fprintf(stdout, "Pulling repository %s\r\n", remote)
-	repositoryTarget := INDEX_ENDPOINT + "/repositories/" + remote + "/checksums"
+	repositoryTarget := INDEX_ENDPOINT + "/repositories/" + remote + "/checksums/"
 
 	req, err := http.NewRequest("GET", repositoryTarget, nil)
 	if err != nil {
@@ -248,6 +248,7 @@ func (graph *Graph) PullRepository(stdout io.Writer, remote, askedTag string, re
 	if authConfig != nil {
 		req.SetBasicAuth(authConfig.Username, authConfig.Password)
 	}
+	req.Header.Set("X-Docker-Token", "true")
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -461,6 +462,7 @@ func (graph *Graph) PushRepository(stdout io.Writer, remote string, localRepo Re
 		return err
 	}
 	req.SetBasicAuth(authConfig.Username, authConfig.Password)
+	req.Header.Set("X-Docker-Token", "true")
 	res, err := client.Do(req)
 	if err != nil {
 		return err
@@ -473,6 +475,7 @@ func (graph *Graph) PushRepository(stdout io.Writer, remote string, localRepo Re
 			return err
 		}
 		req.SetBasicAuth(authConfig.Username, authConfig.Password)
+		req.Header.Set("X-Docker-Token", "true")
 		res, err = client.Do(req)
 		if err != nil {
 			return err
@@ -488,6 +491,7 @@ func (graph *Graph) PushRepository(stdout io.Writer, remote string, localRepo Re
 	if res.Header.Get("X-Docker-Token") != "" {
 		token = res.Header["X-Docker-Token"]
 	} else {
+		Debugf("Response headers:\n %s\n", res.Header)
 		return fmt.Errorf("Index response didn't contain an access token")
 	}
 	if res.Header.Get("X-Docker-Endpoints") != "" {

--- a/registry.go
+++ b/registry.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"path"
 	"strings"
 )

--- a/registry.go
+++ b/registry.go
@@ -168,6 +168,11 @@ func (graph *Graph) getRemoteImage(stdout io.Writer, imgId, registry string, tok
 
 func (graph *Graph) getRemoteTags(stdout io.Writer, registries []string, repository string, token []string) (map[string]string, error) {
 	client := graph.getHttpClient()
+	if strings.Count(repository, "/") == 0 {
+		// This will be removed once the Registry supports auto-resolution on
+		// the "library" namespace
+		repository = "library/" + repository
+	}
 	for _, host := range registries {
 		endpoint := "https://" + host + "/v1/repositories/" + repository + "/tags"
 		req, err := http.NewRequest("GET", endpoint, nil)
@@ -257,7 +262,7 @@ func (graph *Graph) PullImage(stdout io.Writer, imgId, registry string, token []
 func (graph *Graph) PullRepository(stdout io.Writer, remote, askedTag string, repositories *TagStore, authConfig *auth.AuthConfig) error {
 	client := graph.getHttpClient()
 
-	fmt.Fprintf(stdout, "Pulling repository %s\r\n", remote)
+	fmt.Fprintf(stdout, "Pulling repository %s from %s\r\n", remote, INDEX_ENDPOINT)
 	repositoryTarget := INDEX_ENDPOINT + "/repositories/" + remote + "/images"
 
 	req, err := http.NewRequest("GET", repositoryTarget, nil)

--- a/registry.go
+++ b/registry.go
@@ -466,6 +466,20 @@ func (graph *Graph) PushRepository(stdout io.Writer, remote string, localRepo Re
 		return err
 	}
 	res.Body.Close()
+	for res.StatusCode >= 300 && res.StatusCode < 400 {
+		Debugf("Redirected to %s\n", res.Header.Get("Location"))
+		req, err = http.NewRequest("PUT", res.Header.Get("Location"), nil)
+		if err != nil {
+			return err
+		}
+		req.SetBasicAuth(authConfig.Username, authConfig.Password)
+		res, err = client.Do(req)
+		if err != nil {
+			return err
+		}
+		res.Body.Close()
+	}
+
 	if res.StatusCode != 200 && res.StatusCode != 201 {
 		return fmt.Errorf("Error: Status %d trying to push repository %s", res.StatusCode, remote)
 	}

--- a/utils.go
+++ b/utils.go
@@ -397,6 +397,15 @@ func CopyEscapable(dst io.Writer, src io.ReadCloser) (written int64, err error) 
 	return written, err
 }
 
+
+func HashData(src io.Reader) (string, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, src); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}
+
 type KernelVersionInfo struct {
 	Kernel int
 	Major  int
@@ -457,12 +466,4 @@ func FindCgroupMountpoint(cgroupType string) (string, error) {
 	}
 
 	return "", fmt.Errorf("cgroup mountpoint not found for %s", cgroupType)
-}
-
-func HashData(src io.Reader) (string, error) {
-	h := sha256.New()
-	if _, err := io.Copy(h, src); err != nil {
-		return "", err
-	}
-	return "sha256:"+hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,8 @@ package docker
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"github.com/dotcloud/docker/rcli"
@@ -455,4 +457,12 @@ func FindCgroupMountpoint(cgroupType string) (string, error) {
 	}
 
 	return "", fmt.Errorf("cgroup mountpoint not found for %s", cgroupType)
+}
+
+func HashData(src io.Reader) (string, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, src); err != nil {
+		return "", err
+	}
+	return "sha256:"+hex.EncodeToString(h.Sum(nil)), nil
 }


### PR DESCRIPTION
These changes will allow docker to push and pull using the new registry API.

A few details probably need to be ironed out before it's 100% ready but this version should at least provide the same set of functionality its predecessor had, plus some more things.
