### PR TITLE
344 use Go 1.0.3 to build docker

### DIFF
--- a/hack/dockerbuilder/Dockerfile
+++ b/hack/dockerbuilder/Dockerfile
@@ -4,8 +4,12 @@ maintainer	Solomon Hykes <solomon@dotcloud.com>
 from	ubuntu:12.10
 run	apt-get update
 run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q s3cmd
+run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q curl
 # Packages required to checkout and build docker
-run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q golang
+run	curl -s -o /go.tar.gz https://go.googlecode.com/files/go1.0.3.linux-amd64.tar.gz
+run	tar -C /usr/local -xzf /go.tar.gz
+run	echo "export PATH=$PATH:/usr/local/go/bin" > /.bashrc
+run	echo "export PATH=$PATH:/usr/local/go/bin" > /.bash_profile
 run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q git
 run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q build-essential
 # Packages required to build an ubuntu package

--- a/hack/dockerbuilder/dockerbuilder
+++ b/hack/dockerbuilder/dockerbuilder
@@ -2,6 +2,8 @@
 set -x
 set -e
 
+export PATH=$PATH:/usr/local/go/bin
+
 PACKAGE=github.com/dotcloud/docker
 
 if [ $# -gt 1 ]; then


### PR DESCRIPTION
This pull request makes the changes needed for issue #344.

It changes the Dockerfile to download Go 1.0.3 for Linux amd64 from Google and to set the right path within the dockerbuilder script.

It has been tested and this is the output when using the resulting image:

```
docker run 750cd0bb0b25
+ set -e
Warning: environment variable AWS_ID is not set. Won't upload to S3.
+ export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin
+ PACKAGE=github.com/dotcloud/docker
+ [ 0 -gt 1 ]
+ export REVISION=
+ [ -z  ]
+ echo Warning: environment variable AWS_ID is not set. Won't upload to S3.
+ NO_S3=1
+ [ -z  ]
+ echo Warning: environment variable AWS_KEY is not set. Won't upload to S3.
+ NO_S3=1
+ [ -z  ]
+ echo Warning: environment variable GPG_KEY is not set. Ubuntu package upload will not succeed.
+ NO_UBUNTU=1
+ [ -z  ]
+ rm -fr docker-master
Warning: environment variable AWS_KEY is not set. Won't upload to S3.
Warning: environment variable GPG_KEY is not set. Ubuntu package upload will not succeed.
+ git clone https://github.com/dotcloud/docker docker-master
Cloning into 'docker-master'...
+ cd docker-master
+ [ -z  ]
+ make release
rm -fr docker-v0.2.1
git clone /docker-master docker-v0.2.1
Cloning into 'docker-v0.2.1'...
done.
cd docker-v0.2.1; git checkout -q v0.2.1
rm -f docker-v0.2.1.tgz
cd docker-v0.2.1; make; cp -R bin docker-v0.2.1; tar -f ../docker-v0.2.1.tgz -zv -c docker-v0.2.1
make[1]: Entering directory `/docker-master/docker-v0.2.1'
bin/docker is created.
make[1]: Leaving directory `/docker-master/docker-v0.2.1'
docker-v0.2.1/
docker-v0.2.1/docker
+ [ -z 1 ]
+ [ -z 1 ]

```
