### PR TITLE
strings.Split may return an empty string on no match

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -445,7 +445,7 @@ func FindCgroupMountpoint(cgroupType string) (string, error) {
 	// cgroup /sys/fs/cgroup/devices cgroup rw,relatime,devices 0 0
 	for _, line := range strings.Split(string(output), "\n") {
 		parts := strings.Split(line, " ")
-		if len(parts) > 1 && parts[2] == "cgroup" {
+		if len(parts) == 6 && parts[2] == "cgroup" {
 			for _, opt := range strings.Split(parts[3], ",") {
 				if opt == cgroupType {
 					return parts[1], nil

--- a/utils.go
+++ b/utils.go
@@ -445,7 +445,7 @@ func FindCgroupMountpoint(cgroupType string) (string, error) {
 	// cgroup /sys/fs/cgroup/devices cgroup rw,relatime,devices 0 0
 	for _, line := range strings.Split(string(output), "\n") {
 		parts := strings.Split(line, " ")
-		if parts[2] == "cgroup" {
+		if len(parts) > 1 && parts[2] == "cgroup" {
 			for _, opt := range strings.Split(parts[3], ",") {
 				if opt == cgroupType {
 					return parts[1], nil


### PR DESCRIPTION
- This fixes an index out of range crash if cgroup memory is not
  enabled.
