### PR TITLE
fix ByParent

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -253,14 +253,14 @@ func (graph *Graph) WalkAll(handler func(*Image)) error {
 func (graph *Graph) ByParent() (map[string][]*Image, error) {
 	byParent := make(map[string][]*Image)
 	err := graph.WalkAll(func(image *Image) {
-		image, err := graph.Get(image.Parent)
+		parent, err := graph.Get(image.Parent)
 		if err != nil {
 			return
 		}
-		if children, exists := byParent[image.Parent]; exists {
-			byParent[image.Parent] = []*Image{image}
+		if children, exists := byParent[parent.Id]; exists {
+			byParent[parent.Id] = []*Image{image}
 		} else {
-			byParent[image.Parent] = append(children, image)
+			byParent[parent.Id] = append(children, image)
 		}
 	})
 	return byParent, err


### PR DESCRIPTION
The ByParent method wasn't building it's data correctly.  The iterator function is handed the variable `image` and that was being overwritten by the parent lookup.

The way I spotted it was that some non-'head's were making it into `docker images`:

Before:

```
$ docker images
REPOSITORY          TAG                 ID                  CREATED
ndj/couchdb         latest              0645f350865e        4 days ago
ndj/sshd            latest              1d5fc7dd9cc8        6 days ago
ndj/postgresql      latest              9a33a1bfd3c0        4 days ago
ubuntu              12.04               8dbd9e392a96        3 weeks ago
ubuntu              12.10               b750fe79269d        6 weeks ago
ubuntu              quantal             b750fe79269d        6 weeks ago
ubuntu              latest              8dbd9e392a96        3 weeks ago
ubuntu              precise             8dbd9e392a96        3 weeks ago
<none>              <none>              984b07945695        4 days ago
<none>              <none>              491345fb39fc        6 days ago
<none>              <none>              82dd2a9db804        4 days ago
```

After:

```
$ docker images
REPOSITORY          TAG                 ID                  CREATED
ndj/sshd            latest              1d5fc7dd9cc8        6 days ago
ndj/postgresql      latest              9a33a1bfd3c0        4 days ago
ubuntu              latest              8dbd9e392a96        3 weeks ago
ubuntu              12.10               b750fe79269d        6 weeks ago
ubuntu              quantal             b750fe79269d        6 weeks ago
ubuntu              12.04               8dbd9e392a96        3 weeks ago
ubuntu              precise             8dbd9e392a96        3 weeks ago
ndj/couchdb         latest              0645f350865e        4 days ago
```
