### PR TITLE
Fix pull for official images

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -211,6 +211,11 @@ func (graph *Graph) getRemoteTags(stdout io.Writer, registries []string, reposit
 
 func (graph *Graph) getImageForTag(stdout io.Writer, tag, remote, registry string, token []string) (string, error) {
 	client := graph.getHttpClient()
+
+	if !strings.Contains(remote, "/") {
+		remote = "library/" + remote
+	}
+
 	registryEndpoint := "https://" + registry + "/v1"
 	repositoryTarget := registryEndpoint + "/repositories/" + remote + "/tags/" + tag
 


### PR DESCRIPTION
When pulling official images (no user namespace) with a given tag (e.g. `docker pull ubuntu:12.04`), registry failed with error 404 when trying to retrieve the image ID associated with this tag. This patch fixes it.
