### PR TITLE
Fix incorrect title on CouchDB example page in Docs

### DIFF
--- a/docs/sources/examples/couchdb_data_volumes.rst
+++ b/docs/sources/examples/couchdb_data_volumes.rst
@@ -2,9 +2,9 @@
 :description: Sharing data between 2 couchdb databases
 :keywords: docker, example, package installation, networking, couchdb, data volumes
 
-.. _running_redis_service:
+.. _running_couchdb_service:
 
-Create a redis service
+Create a CouchDB service
 ======================
 
 .. include:: example_header.inc


### PR DESCRIPTION
The CouchDB example page was titled incorrectly, "Create a redis service"
