### PR TITLE
Swap "go get" for "go get -d", especially to compile on go1.1rc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ $(DOCKER_BIN): $(DOCKER_DIR)
 $(DOCKER_DIR):
 	@mkdir -p $(dir $@)
 	@if [ -h $@ ]; then rm -f $@; fi; ln -sf $(CURDIR)/ $@
-	@(cd $(DOCKER_MAIN); go get $(GO_OPTIONS))
+	@(cd $(DOCKER_MAIN); go get -d $(GO_OPTIONS))
 
 whichrelease:
 	echo $(RELEASE_VERSION)


### PR DESCRIPTION
Summary says it all.  See also issue #561.
