### PR TITLE
Expand upon Builder documentation and tidy

### DIFF
--- a/docs/sources/builder/basics.rst
+++ b/docs/sources/builder/basics.rst
@@ -126,12 +126,11 @@ curl was installed within the image.
 3. Dockerfile Examples
 ======================
 
-::
+.. code-block:: bash
 
     # Nginx
     #
     # VERSION               0.0.1
-    # DOCKER-VERSION        0.2
     
     FROM      ubuntu
     MAINTAINER Guillaume J. Charmes "guillaume@dotcloud.com"
@@ -143,12 +142,11 @@ curl was installed within the image.
     RUN apt-get install -y inotify-tools nginx apache2 openssh-server
     INSERT https://raw.github.com/creack/docker-vps/master/nginx-wrapper.sh /usr/sbin/nginx-wrapper
 
-::
+.. code-block:: bash
 
     # Firefox over VNC
     #
     # VERSION               0.3
-    # DOCKER-VERSION        0.2
     
     FROM ubuntu
     # make sure the package repository is up to date
@@ -160,8 +158,25 @@ curl was installed within the image.
     RUN mkdir /.vnc
     # Setup a password
     RUN x11vnc -storepasswd 1234 ~/.vnc/passwd
-    # Autostart firefox (might not be the best way to do it, but it does the trick)
+    # Autostart firefox (might not be the best way, but it does the trick)
     RUN bash -c 'echo "firefox" >> /.bashrc'
     
     EXPOSE 5900
     CMD    ["x11vnc", "-forever", "-usepw", "-create"]
+
+.. code-block:: bash
+
+    # Multiple images example
+    #
+    # VERSION               0.1
+
+    FROM ubuntu
+    RUN echo foo > bar
+    # Will output something like ===> 907ad6c2736f
+
+    FROM ubuntu
+    RUN echo moo > oink
+    # Will output something like ===> 695d7793cbe4
+
+    # You'll now have two images, 907ad6c2736f with /bar, and 695d7793cbe4 with
+    # /oink.


### PR DESCRIPTION
Standardizes on uppercase for instructions, gives 
example usage.
Wrap at 80 columns
