### PR TITLE
Use add-apt-repository to add docker repo

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -34,7 +34,7 @@ Add the custom package sources to your apt sources list. Copy and paste the foll
 
 .. code-block:: bash
 
-   sudo sh -c "echo 'deb http://ppa.launchpad.net/dotcloud/lxc-docker/ubuntu precise main' >> /etc/apt/sources.list"
+   sudo add-apt-repository ppa:dotcloud/lxc-docker
 
 
 Update your sources. You will see a warning that GPG signatures cannot be verified.


### PR DESCRIPTION
'add-apt-repository' is concise and less error-prone. It also takes care of downloading and adding the GPG keys so apt doesn't complain about unsigned packages.
