### PR TITLE
Add the rest api port to vagrantfile's port_forward

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ Vagrant::Config.run do |config|
   # Setup virtual machine box. This VM configuration code is always executed.
   config.vm.box = BOX_NAME
   config.vm.box_url = BOX_URI
+  config.vm.forward_port 4243, 4243
 
   # Provision docker and new kernel if deployment was not done
   if Dir.glob("#{File.dirname(__FILE__)}/.vagrant/machines/default/*/id").empty?


### PR DESCRIPTION
What do you think about adding, the rest api port (4243) in the Vagrantfile port_forward ?

Like this the client in your host can connect to the deamon in your vm, with no further configuration.

In my case, I compiled docker on OS X, so (once the ppa will include a version of docker with the rest api) I can do :

```
$>vagrant up
$>docker images
```

And it'll list docker's images inside the vm.
