### PR TITLE
Registry tests (bis)

### DIFF
--- a/image.go
+++ b/image.go
@@ -142,7 +142,7 @@ func MountAUFS(ro []string, rw string, target string) error {
 
 // TarLayer returns a tar archive of the image's filesystem layer.
 func (image *Image) TarLayer(compression Compression) (Archive, error) {
-	layerPath, err := image.layer()
+	layerPath, err := image.Layer()
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func (img *Image) layers() ([]string, error) {
 	var e error
 	if err := img.WalkHistory(
 		func(img *Image) (err error) {
-			if layer, err := img.layer(); err != nil {
+			if layer, err := img.Layer(); err != nil {
 				e = err
 			} else if layer != "" {
 				list = append(list, layer)
@@ -279,7 +279,7 @@ func (img *Image) root() (string, error) {
 }
 
 // Return the path of an image's layer
-func (img *Image) layer() (string, error) {
+func (img *Image) Layer() (string, error) {
 	root, err := img.root()
 	if err != nil {
 		return "", err
@@ -304,7 +304,7 @@ func (img *Image) Checksum() (string, error) {
 		return checksum, nil
 	}
 
-	layer, err := img.layer()
+	layer, err := img.Layer()
 	if err != nil {
 		return "", err
 	}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -3,55 +3,55 @@ package registry
 import (
 	"crypto/rand"
 	"encoding/hex"
-    "github.com/dotcloud/docker"
+	"github.com/dotcloud/docker"
 	"github.com/dotcloud/docker/auth"
-    "io/ioutil"
+	"io/ioutil"
 	"os"
 	"os/exec"
-    "path"
-    "sync"
+	"path"
+	"sync"
 	"testing"
 )
 
 const unitTestStoreBase string = "/var/lib/docker/unit-tests"
 
 func CopyDirectory(source, dest string) error {
-    if _, err := exec.Command("cp", "-ra", source, dest).Output(); err != nil {
-        return err
-    }
-    return nil
+	if _, err := exec.Command("cp", "-ra", source, dest).Output(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func nuke(srv *docker.Server) error {
-    var wg sync.WaitGroup
-    for _, container := range srv.Runtime().List() {
-        wg.Add(1)
-        go func(c *docker.Container) {
-            c.Kill()
-            wg.Done()
-        }(container)
-    }
-    wg.Wait()
-    return os.RemoveAll(srv.Runtime().Root())
+	var wg sync.WaitGroup
+	for _, container := range srv.Runtime().List() {
+		wg.Add(1)
+		go func(c *docker.Container) {
+			c.Kill()
+			wg.Done()
+		}(container)
+	}
+	wg.Wait()
+	return os.RemoveAll(srv.Runtime().Root())
 }
 
 func newTestServer() (*docker.Server, error) {
-    root, err := ioutil.TempDir("", "docker-test")
-    if err != nil {
-        return nil, err
-    }
-    if err := os.Remove(root); err != nil {
-        return nil, err
-    }
-    if err := CopyDirectory(unitTestStoreBase, root); err != nil {
-        return nil, err
-    }
+	root, err := ioutil.TempDir("", "docker-test")
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Remove(root); err != nil {
+		return nil, err
+	}
+	if err := CopyDirectory(unitTestStoreBase, root); err != nil {
+		return nil, err
+	}
 
-    srv, err := docker.NewServerFromDirectory(root, false)
-    if err != nil {
-        return nil, err
-    }
-    return srv, nil
+	srv, err := docker.NewServerFromDirectory(root, false)
+	if err != nil {
+		return nil, err
+	}
+	return srv, nil
 }
 
 func TestPull(t *testing.T) {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,168 +1,194 @@
 package registry
 
-// import (
-// 	"crypto/rand"
-// 	"encoding/hex"
-// 	"github.com/dotcloud/docker"
-// 	"github.com/dotcloud/docker/auth"
-// 	"io/ioutil"
-// 	"os"
-// 	"path"
-// 	"testing"
-// )
+import (
+	"crypto/rand"
+	"encoding/hex"
+    "github.com/dotcloud/docker"
+	"github.com/dotcloud/docker/auth"
+    "io/ioutil"
+	"os"
+	"os/exec"
+    "path"
+    "sync"
+	"testing"
+)
 
-// func newTestRuntime() (*Runtime, error) {
-// 	root, err := ioutil.TempDir("", "docker-test")
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	if err := os.Remove(root); err != nil {
-// 		return nil, err
-// 	}
+const unitTestStoreBase string = "/var/lib/docker/unit-tests"
 
-// 	if err := os.MkdirAll(root, 0700); err != nil && !os.IsExist(err) {
-// 		return nil, err
-// 	}
+func CopyDirectory(source, dest string) error {
+    if _, err := exec.Command("cp", "-ra", source, dest).Output(); err != nil {
+        return err
+    }
+    return nil
+}
 
-// 	return runtime, nil
-// }
+func nuke(srv *docker.Server) error {
+    var wg sync.WaitGroup
+    for _, container := range srv.Runtime().List() {
+        wg.Add(1)
+        go func(c *docker.Container) {
+            c.Kill()
+            wg.Done()
+        }(container)
+    }
+    wg.Wait()
+    return os.RemoveAll(srv.Runtime().Root())
+}
 
-// func TestPull(t *testing.T) {
-// 	os.Setenv("DOCKER_INDEX_URL", "")
-// 	runtime, err := newTestRuntime()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	defer nuke(runtime)
+func newTestServer() (*docker.Server, error) {
+    root, err := ioutil.TempDir("", "docker-test")
+    if err != nil {
+        return nil, err
+    }
+    if err := os.Remove(root); err != nil {
+        return nil, err
+    }
+    if err := CopyDirectory(unitTestStoreBase, root); err != nil {
+        return nil, err
+    }
 
-// 	err = runtime.graph.PullRepository(ioutil.Discard, "busybox", "", runtime.repositories, nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	img, err := runtime.repositories.LookupImage("busybox")
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+    srv, err := docker.NewServerFromDirectory(root, false)
+    if err != nil {
+        return nil, err
+    }
+    return srv, nil
+}
 
-// 	// Try to run something on this image to make sure the layer's been downloaded properly.
-// 	config, _, err := docker.ParseRun([]string{img.Id, "echo", "Hello World"}, runtime.capabilities)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+func TestPull(t *testing.T) {
+	os.Setenv("DOCKER_INDEX_URL", "")
+	srv, err := newTestServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nuke(srv)
 
-// 	b := NewBuilder(runtime)
-// 	container, err := b.Create(config)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	if err := container.Start(); err != nil {
-// 		t.Fatal(err)
-// 	}
+	err = srv.ImagePull("busybox", "", "", ioutil.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	img, err := srv.ImageInspect("busybox")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	if status := container.Wait(); status != 0 {
-// 		t.Fatalf("Expected status code 0, found %d instead", status)
-// 	}
-// }
+	// Try to run something on this image to make sure the layer's been downloaded properly.
+	config, _, err := docker.ParseRun([]string{img.Id, "/bin/echo", "HelloWorld"}, &docker.Capabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// func TestPullTag(t *testing.T) {
-// 	os.Setenv("DOCKER_INDEX_URL", "")
-// 	runtime, err := newTestRuntime()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	defer nuke(runtime)
+	b := docker.NewBuilder(srv.Runtime())
+	container, err := b.Create(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := container.Start(); err != nil {
+		t.Fatal(err)
+	}
 
-// 	err = runtime.graph.PullRepository(ioutil.Discard, "ubuntu", "12.04", runtime.repositories, nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	_, err = runtime.repositories.LookupImage("ubuntu:12.04")
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	if status := container.Wait(); status != 0 {
+		t.Fatalf("Expected status code 0, found %d instead", status)
+	}
+}
 
-// 	img2, err := runtime.repositories.LookupImage("ubuntu:12.10")
-// 	if img2 != nil {
-// 		t.Fatalf("Expected nil image but found %v instead", img2.Id)
-// 	}
-// }
+func TestPullTag(t *testing.T) {
+	os.Setenv("DOCKER_INDEX_URL", "")
+	srv, err := newTestServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nuke(srv)
 
-// func login(runtime *Runtime) error {
-// 	authConfig := auth.NewAuthConfig("unittester", "surlautrerivejetattendrai", "noise+unittester@dotcloud.com", runtime.root)
-// 	runtime.authConfig = authConfig
-// 	_, err := auth.Login(authConfig)
-// 	return err
-// }
+	err = srv.ImagePull("ubuntu", "12.04", "", ioutil.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = srv.ImageInspect("ubuntu:12.04")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// func TestPush(t *testing.T) {
-// 	os.Setenv("DOCKER_INDEX_URL", "https://indexstaging-docker.dotcloud.com")
-// 	defer os.Setenv("DOCKER_INDEX_URL", "")
-// 	runtime, err := newTestRuntime()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	defer nuke(runtime)
+	img2, err := srv.ImageInspect("ubuntu:12.10")
+	if img2 != nil {
+		t.Fatalf("Expected nil image but found %v instead", img2.Id)
+	}
+}
 
-// 	err = login(runtime)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+func login(srv *docker.Server) error {
+	authConfig := auth.NewAuthConfig("unittester", "surlautrerivejetattendrai", "noise+unittester@dotcloud.com", srv.Runtime().Root())
+	srv.Registry().ResetClient(authConfig)
+	_, err := auth.Login(authConfig)
+	return err
+}
 
-// 	err = runtime.graph.PullRepository(ioutil.Discard, "joffrey/busybox", "", runtime.repositories, nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	tokenBuffer := make([]byte, 16)
-// 	_, err = rand.Read(tokenBuffer)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	token := hex.EncodeToString(tokenBuffer)[:29]
-// 	config, _, err := ParseRun([]string{"joffrey/busybox", "touch", "/" + token}, runtime.capabilities)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+func TestPush(t *testing.T) {
+	os.Setenv("DOCKER_INDEX_URL", "https://indexstaging-docker.dotcloud.com")
+	defer os.Setenv("DOCKER_INDEX_URL", "")
+	srv, err := newTestServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nuke(srv)
 
-// 	b := NewBuilder(runtime)
-// 	container, err := b.Create(config)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	if err := container.Start(); err != nil {
-// 		t.Fatal(err)
-// 	}
+	err = login(srv)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	if status := container.Wait(); status != 0 {
-// 		t.Fatalf("Expected status code 0, found %d instead", status)
-// 	}
+	err = srv.ImagePull("joffrey/busybox", "", "", ioutil.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokenBuffer := make([]byte, 16)
+	_, err = rand.Read(tokenBuffer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := hex.EncodeToString(tokenBuffer)[:29]
+	config, _, err := docker.ParseRun([]string{"joffrey/busybox", "touch", "/" + token}, &docker.Capabilities{})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	img, err := b.Commit(container, "unittester/"+token, "", "", "", nil)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	b := docker.NewBuilder(srv.Runtime())
+	container, err := b.Create(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := container.Start(); err != nil {
+		t.Fatal(err)
+	}
 
-// 	repo := runtime.repositories.Repositories["unittester/"+token]
-// 	err = runtime.graph.PushRepository(ioutil.Discard, "unittester/"+token, repo, runtime.authConfig)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	if status := container.Wait(); status != 0 {
+		t.Fatalf("Expected status code 0, found %d instead", status)
+	}
 
-// 	// Remove image so we can pull it again
-// 	if err := runtime.graph.Delete(img.Id); err != nil {
-// 		t.Fatal(err)
-// 	}
+	img, err := b.Commit(container, "unittester/"+token, "", "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	err = runtime.graph.PullRepository(ioutil.Discard, "unittester/"+token, "", runtime.repositories, runtime.authConfig)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	err = srv.ImagePush("unittester/"+token, "", ioutil.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-// 	layerPath, err := img.layer()
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
+	// Remove image so we can pull it again
+	if err := srv.ImageDelete(img.Id); err != nil {
+		t.Fatal(err)
+	}
 
-// 	if _, err := os.Stat(path.Join(layerPath, token)); err != nil {
-// 		t.Fatalf("Error while trying to retrieve token file: %v", err)
-// 	}
-// }
+	err = srv.ImagePull("unittester/"+token, "", "", ioutil.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	layerPath, err := img.Layer()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(path.Join(layerPath, token)); err != nil {
+		t.Fatalf("Error while trying to retrieve token file: %v", err)
+	}
+}

--- a/runtime.go
+++ b/runtime.go
@@ -244,6 +244,10 @@ func (runtime *Runtime) UpdateCapabilities(quiet bool) {
 	}
 }
 
+func (runtime *Runtime) Root() string {
+	return runtime.root
+}
+
 // FIXME: harmonize with NewGraph()
 func NewRuntime(autoRestart bool) (*Runtime, error) {
 	runtime, err := NewRuntimeFromDirectory("/var/lib/docker", autoRestart)

--- a/server.go
+++ b/server.go
@@ -831,14 +831,33 @@ func (srv *Server) ImageInspect(name string) (*Image, error) {
 	return nil, fmt.Errorf("No such image: %s", name)
 }
 
+func (srv *Server) Registry() *registry.Registry {
+	return srv.registry
+}
+
+func (srv *Server) Runtime() *Runtime {
+	return srv.runtime
+}
+
 func NewServer(autoRestart bool) (*Server, error) {
+	return NewServerFromDirectory("", autoRestart)
+}
+
+func NewServerFromDirectory(root string, autoRestart bool) (*Server, error) {
 	if runtime.GOARCH != "amd64" {
 		log.Fatalf("The docker runtime currently only supports amd64 (not %s). This will change in the future. Aborting.", runtime.GOARCH)
 	}
-	runtime, err := NewRuntime(autoRestart)
+	var runtime *Runtime
+	var err error
+	if root != "" {
+		runtime, err = NewRuntimeFromDirectory(root, autoRestart)
+	} else {
+		runtime, err = NewRuntime(autoRestart)
+	}
 	if err != nil {
 		return nil, err
 	}
+
 	srv := &Server{
 		runtime:  runtime,
 		registry: registry.NewRegistry(runtime.root),


### PR DESCRIPTION
I'm putting up the pull request already, although there's still a problem with `TestPull` and `TestPush` when trying to start containers, looks like the `/sbin/init` binary is not the right one.

stderr logs for the container look like this:

```
flag provided but not defined: -g
Usage of /sbin/init:
  -test.bench="": regular expression to select benchmarks to run
  -test.benchtime=1: approximate run time for each benchmark, in seconds
  -test.cpu="": comma-separated list of number of CPUs to use for each test
  -test.cpuprofile="": write a cpu profile to the named file during execution
  -test.memprofile="": write a memory profile to the named file after execution
  -test.memprofilerate=0: if >=0, sets runtime.MemProfileRate
  -test.parallel=1: maximum test parallelism
  -test.run="": regular expression to select tests and examples to run
  -test.short=false: run smaller test suite to save time
  -test.timeout=0: if positive, sets an aggregate time limit for all tests
  -test.v=false: verbose: print additional output
```

FWIW the same logic was working in the first version (#578)
