### PR TITLE
utils: fix compilation on Darwin

### DIFF
--- a/utils/uname_darwin.go
+++ b/utils/uname_darwin.go
@@ -2,9 +2,12 @@ package utils
 
 import (
 	"errors"
-	"syscall"
 )
 
-func uname() (*syscall.Utsname, error) {
+type Utsname struct {
+	Release [65]byte
+}
+
+func uname() (*Utsname, error) {
 	return nil, errors.New("Kernel version detection is not available on darwin")
 }

--- a/utils/uname_linux.go
+++ b/utils/uname_linux.go
@@ -4,8 +4,9 @@ import (
 	"syscall"
 )
 
-// FIXME: Move this to utils package
-func uname() (*syscall.Utsname, error) {
+type Utsname syscall.Utsname
+
+func uname() (*Utsname, error) {
 	uts := &syscall.Utsname{}
 
 	if err := syscall.Uname(uts); err != nil {


### PR DESCRIPTION
Although Docker daemon does not work on Darwin, the API client will have
to work. That said, I'm fixing the compilation of the package on Darwin.

I've also removed an apparently old FIXME note.
