### PR TITLE
push: Try direct registry communication when index fails (Fixes #615)

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -400,6 +400,17 @@ func (r *Registry) PushImageJsonIndex(remote string, imgList []*ImgData, validat
 	}, nil
 }
 
+func (r *Registry) DirectRepositoryData(endpoint string) *RepositoryData {
+	var (
+		tokens = []string{}
+		endpoints = []string{endpoint}
+	)
+	return &RepositoryData{
+		Tokens:    tokens,
+		Endpoints: endpoints,
+	}
+}
+
 func (r *Registry) SearchRepositories(term string) (*SearchResults, error) {
 	u := auth.IndexServerAddress() + "/search?q=" + url.QueryEscape(term)
 	req, err := http.NewRequest("GET", u, nil)


### PR DESCRIPTION
When specifying a custom -registry, the index is assumed to reside at
the same place. Attempt to do the sensible thing when this turns out not
to be the case and instead of failing hard, try to connect to the
specified registry as an endpoint without any authentication token.
