### PR TITLE
add -h (previously add -host and -port)

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1199,7 +1199,7 @@ func (cli *DockerCli) stream(method, path string, in io.Reader, out io.Writer) e
 	if (method == "POST" || method == "PUT") && in == nil {
 		in = bytes.NewReader([]byte{})
 	}
-	req, err := http.NewRequest(method, fmt.Sprintf("http://%s:%d/v%f%s", cli.addr, cli.port, API_VERSION, path), in)
+	req, err := http.NewRequest(method, fmt.Sprintf("http://%s:%d/v%g%s", cli.addr, cli.port, API_VERSION, path), in)
 	if err != nil {
 		return err
 	}
@@ -1230,7 +1230,7 @@ func (cli *DockerCli) stream(method, path string, in io.Reader, out io.Writer) e
 }
 
 func (cli *DockerCli) hijack(method, path string, setRawTerminal bool) error {
-	req, err := http.NewRequest(method, fmt.Sprintf("/v%f%s", API_VERSION, path), nil)
+	req, err := http.NewRequest(method, fmt.Sprintf("/v%g%s", API_VERSION, path), nil)
 	if err != nil {
 		return err
 	}

--- a/commands.go
+++ b/commands.go
@@ -30,8 +30,8 @@ var (
 	GIT_COMMIT string
 )
 
-func ParseCommands(args ...string) error {
-	cli := NewDockerCli("0.0.0.0", 4243)
+func ParseCommands(host string, port int, args ...string) error {
+	cli := NewDockerCli(host, port)
 
 	if len(args) > 0 {
 		methodName := "Cmd" + strings.ToUpper(args[0][:1]) + strings.ToLower(args[0][1:])

--- a/commands.go
+++ b/commands.go
@@ -53,7 +53,7 @@ func ParseCommands(addr string, port int, args ...string) error {
 }
 
 func (cli *DockerCli) CmdHelp(args ...string) error {
-	help := fmt.Sprintf("Usage: docker [OPTIONS] COMMAND [arg...]\n  -h=\"%s:%d\": Host:port to bind/connect to\n\nA self-sufficient runtime for linux containers.\n\nCommands:\n", cli.addr, cli.port)
+	help := fmt.Sprintf("Usage: docker [OPTIONS] COMMAND [arg...]\n  -H=\"%s:%d\": Host:port to bind/connect to\n\nA self-sufficient runtime for linux containers.\n\nCommands:\n", cli.addr, cli.port)
 	for cmd, description := range map[string]string{
 		"attach":  "Attach to a running container",
 		"build":   "Build a container from Dockerfile or via stdin",

--- a/commands.go
+++ b/commands.go
@@ -53,7 +53,7 @@ func ParseCommands(host string, port int, args ...string) error {
 }
 
 func (cli *DockerCli) CmdHelp(args ...string) error {
-	help := "Usage: docker COMMAND [arg...]\n\nA self-sufficient runtime for linux containers.\n\nCommands:\n"
+	help := "Usage: docker [OPTIONS] COMMAND [arg...]\n  -host=\"0.0.0.0\": Host to bind/connect to\n  -port=4243: Port to listen/connect to\n\nA self-sufficient runtime for linux containers.\n\nCommands:\n"
 	for cmd, description := range map[string]string{
 		"attach":  "Attach to a running container",
 		"build":   "Build a container from Dockerfile or via stdin",

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -32,7 +32,7 @@ func main() {
 	flAutoRestart := flag.Bool("r", false, "Restart previously running containers")
 	bridgeName := flag.String("b", "", "Attach containers to a pre-existing network bridge")
 	pidfile := flag.String("p", "/var/run/docker.pid", "File containing process PID")
-	flHost := flag.String("h", fmt.Sprintf("%s:%d", host, port), "Host:port to bind/connect to")
+	flHost := flag.String("H", fmt.Sprintf("%s:%d", host, port), "Host:port to bind/connect to")
 	flag.Parse()
 	if *bridgeName != "" {
 		docker.NetworkBridgeIface = *bridgeName

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -101,6 +101,9 @@ func removePidFile(pidfile string) {
 }
 
 func daemon(pidfile, addr string, port int, autoRestart bool) error {
+	if addr != "127.0.0.1" {
+		log.Println("/!\\ DON'T BIND ON ANOTHER IP ADDRESS THAN 127.0.0.1 IF YOU DON'T KNOW WHAT YOU'RE DOING /!\\")
+	}
 	if err := createPidFile(pidfile); err != nil {
 		log.Fatal(err)
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 )
 
@@ -23,20 +24,34 @@ func main() {
 		docker.SysInit()
 		return
 	}
+	host:= "127.0.0.1"
+	port:= 4243
 	// FIXME: Switch d and D ? (to be more sshd like)
 	flDaemon := flag.Bool("d", false, "Daemon mode")
 	flDebug := flag.Bool("D", false, "Debug mode")
 	flAutoRestart := flag.Bool("r", false, "Restart previously running containers")
 	bridgeName := flag.String("b", "", "Attach containers to a pre-existing network bridge")
 	pidfile := flag.String("p", "/var/run/docker.pid", "File containing process PID")
-	port := flag.Int("port", 4243, "Port to listen/connect to")
-	host := flag.String("host", "0.0.0.0", "Host bind/connect to")
+	flHost := flag.String("h", fmt.Sprintf("%s:%d", host, port), "Host:port to bind/connect to")
 	flag.Parse()
 	if *bridgeName != "" {
 		docker.NetworkBridgeIface = *bridgeName
 	} else {
 		docker.NetworkBridgeIface = docker.DefaultNetworkBridge
 	}
+
+	if strings.Contains(*flHost, ":") && len(strings.Split(*flHost, ":")) == 2 {
+		hostParts := strings.Split(*flHost, ":")
+		if hostParts[0] != "" {
+			host = hostParts[0]
+		}
+		if p, err := strconv.Atoi(hostParts[1]); err == nil {
+			port = p
+		}
+	} else if !strings.Contains(*flHost, ":") {
+		host = *flHost
+	}
+
 	if *flDebug {
 		os.Setenv("DEBUG", "1")
 	}
@@ -46,12 +61,12 @@ func main() {
 			flag.Usage()
 			return
 		}
-		if err := daemon(*pidfile, *host, *port, *flAutoRestart); err != nil {
+		if err := daemon(*pidfile, host, port, *flAutoRestart); err != nil {
 			log.Fatal(err)
 			os.Exit(-1)
 		}
 	} else {
-		if err := docker.ParseCommands(*host, *port, flag.Args()...); err != nil {
+		if err := docker.ParseCommands(host, port, flag.Args()...); err != nil {
 			log.Fatal(err)
 			os.Exit(-1)
 		}
@@ -85,7 +100,7 @@ func removePidFile(pidfile string) {
 	}
 }
 
-func daemon(pidfile, host string, port int, autoRestart bool) error {
+func daemon(pidfile, addr string, port int, autoRestart bool) error {
 	if err := createPidFile(pidfile); err != nil {
 		log.Fatal(err)
 	}
@@ -105,5 +120,5 @@ func daemon(pidfile, host string, port int, autoRestart bool) error {
 		return err
 	}
 
-	return docker.ListenAndServe(fmt.Sprintf("%s:%d", host, port), server, true)
+	return docker.ListenAndServe(fmt.Sprintf("%s:%d", addr, port), server, true)
 }

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -14,7 +14,9 @@ To list available commands, either run ``docker`` with no parameters or execute
 ``docker help``::
 
   $ docker
-    Usage: docker COMMAND [arg...]
+    Usage: docker [OPTIONS] COMMAND [arg...]
+      -host="0.0.0.0": Host to bind/connect to
+      -port=4243: Port to listen/connect to
 
     A self-sufficient runtime for linux containers.
 

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -15,8 +15,7 @@ To list available commands, either run ``docker`` with no parameters or execute
 
   $ docker
     Usage: docker [OPTIONS] COMMAND [arg...]
-      -host="0.0.0.0": Host to bind/connect to
-      -port=4243: Port to listen/connect to
+      -h="127.0.0.1:4243": Host:port to bind/connect to
 
     A self-sufficient runtime for linux containers.
 

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -15,7 +15,7 @@ To list available commands, either run ``docker`` with no parameters or execute
 
   $ docker
     Usage: docker [OPTIONS] COMMAND [arg...]
-      -h="127.0.0.1:4243": Host:port to bind/connect to
+      -H="127.0.0.1:4243": Host:port to bind/connect to
 
     A self-sufficient runtime for linux containers.
 

--- a/docs/sources/use/basics.rst
+++ b/docs/sources/use/basics.rst
@@ -42,9 +42,9 @@ use -host and -port on both deamon and client
 .. code-block:: bash
 
    # Run docker in daemon mode
-   sudo <path to>/docker -host 127.0.0.1 -port 5555 &
+   sudo <path to>/docker -h 0.0.0.0:5555 &
    # Download a base image
-   docker -port 5555 pull base
+   docker -h :5555 pull base
 
 
 Starting a long-running worker process

--- a/docs/sources/use/basics.rst
+++ b/docs/sources/use/basics.rst
@@ -33,6 +33,19 @@ Running an interactive shell
   # allocate a tty, attach stdin and stdout
   docker run -i -t base /bin/bash
 
+Bind Docker to another host/port
+--------------------------------
+
+If you want Docker to listen to another port and bind to another ip
+use -host and -port on both deamon and client
+
+.. code-block:: bash
+
+   # Run docker in daemon mode
+   sudo <path to>/docker -host 127.0.0.1 -port 5555 &
+   # Download a base image
+   docker -port 5555 pull base
+
 
 Starting a long-running worker process
 --------------------------------------

--- a/docs/sources/use/basics.rst
+++ b/docs/sources/use/basics.rst
@@ -42,9 +42,9 @@ use -host and -port on both deamon and client
 .. code-block:: bash
 
    # Run docker in daemon mode
-   sudo <path to>/docker -h 0.0.0.0:5555 &
+   sudo <path to>/docker -H 0.0.0.0:5555 &
    # Download a base image
-   docker -h :5555 pull base
+   docker -H :5555 pull base
 
 
 Starting a long-running worker process


### PR DESCRIPTION
Add the ability to specify the host and the port for the client/server, for exemple:

```
#Change port:
$>docker -d -h :5555&
$>docker -h :5555 images

#Change host to connect:
$>docker -d #machine192.168.0.1
$>docker -h 192.168.0.1 images #machine192.168.0.2

#Change host and port
$>docker -d -h 0.0.0.0:4444&
$>docker -h :4444 images 
```

Fixes #573 
