### PR TITLE
utils.go: Fix merge logic for user and hostname.

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -49,10 +49,10 @@ func CompareConfig(a, b *Config) bool {
 }
 
 func MergeConfig(userConf, imageConf *Config) {
-	if userConf.Hostname != "" {
+	if userConf.Hostname == "" {
 		userConf.Hostname = imageConf.Hostname
 	}
-	if userConf.User != "" {
+	if userConf.User == "" {
 		userConf.User = imageConf.User
 	}
 	if userConf.Memory == 0 {


### PR DESCRIPTION
Fall back to image-specified hostname if user doesn't
provide one, instead of only using image-specified
hostname if the user _does_ try to set one.
(ditto for username)

Closes #694.
