### PR TITLE
Improve push/pull/import to json stream

### DIFF
--- a/api.go
+++ b/api.go
@@ -288,6 +288,7 @@ func postImagesCreate(srv *Server, w http.ResponseWriter, r *http.Request, vars 
 
 	if image != "" { //pull
 		registry := r.Form.Get("registry")
+		w.Header().Set("Content-Type", "application/json")
 		if err := srv.ImagePull(image, tag, registry, w); err != nil {
 			return err
 		}

--- a/commands.go
+++ b/commands.go
@@ -1223,8 +1223,31 @@ func (cli *DockerCli) stream(method, path string, in io.Reader, out io.Writer) e
 		return fmt.Errorf("error: %s", body)
 	}
 
-	if _, err := io.Copy(out, resp.Body); err != nil {
-		return err
+	if resp.Header.Get("Content-Type") == "application/json" {
+
+		type Message struct {
+			Status   string `json:"status,omitempty"`
+			Progress string `json:"progress,omitempty"`
+		}
+		dec := json.NewDecoder(resp.Body)
+		for {
+			var m Message
+			if err := dec.Decode(&m); err == io.EOF {
+				break
+			} else if err != nil {
+				return err
+			}
+			if m.Status != "" {
+				fmt.Fprintf(out, "%s\n", m.Status)
+			} else if m.Progress != "" {
+				fmt.Fprintf(out, "Downloading... %s\r", m.Progress)
+			}
+		}
+		fmt.Fprintf(out, "\n")
+	} else {
+		if _, err := io.Copy(out, resp.Body); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -84,17 +84,12 @@ func (r *progressReader) Read(p []byte) (n int, err error) {
 	}
 	if r.readProgress-r.lastUpdate > updateEvery || err != nil {
 		if r.readTotal > 0 {
-			fmt.Fprintf(r.output, r.template+"\r", r.readProgress, r.readTotal, fmt.Sprintf("%.0f%%", float64(r.readProgress)/float64(r.readTotal)*100))
+			fmt.Fprintf(r.output, r.template, r.readProgress, r.readTotal)
 		} else {
-			fmt.Fprintf(r.output, r.template+"\r", r.readProgress, "?", "n/a")
+			fmt.Fprintf(r.output, r.template, r.readProgress, "?")
 		}
 		r.lastUpdate = r.readProgress
 	}
-	// Send newline when complete
-	if err != nil {
-		fmt.Fprintf(r.output, "\n")
-	}
-
 	return read, err
 }
 func (r *progressReader) Close() error {
@@ -102,7 +97,7 @@ func (r *progressReader) Close() error {
 }
 func ProgressReader(r io.ReadCloser, size int, output io.Writer, template string) *progressReader {
 	if template == "" {
-		template = "%v/%v (%v)"
+		template = "{\"progress\":\"%v/%v\"}"
 	}
 	return &progressReader{r, NewWriteFlusher(output), size, 0, 0, template}
 }


### PR DESCRIPTION
Currently push/pull/import

Uses chunked http, not very handy when you want to parse it, for exemple to display a nice progress bar if you build a non-console client.

We could use json streaming, it's quite standard look like this:

```
{"status" : "Pulling repository busybox from https://index.docker.io/v1"}
{"status" : "Pulling image e9aa60c60128cad1 (latest) from busybox"}
{"status" : "Pulling e9aa60c60128cad1 metadata"}
{"status" : "Pulling e9aa60c60128cad1 fs layer"}
{"progress" : "5778/? (n/a)"}
...
```

I implemented the pull command using json stream on v1.1
So /v1/ will be chunked http and /v1.1/ json stream.
The client decodes using the content-type header.

It's pretty basic for now, if the future we could add a "error" key, to know when the pull went bad.
Feel free to comment.
