### PR TITLE
Include gpgv when making debian-based images

### DIFF
--- a/contrib/mkimage-debian.sh
+++ b/contrib/mkimage-debian.sh
@@ -10,7 +10,7 @@ unstableSuite='sid'
 latestSuite="$testingSuite"
 
 variant='minbase'
-include='iproute,iputils-ping'
+include='iproute,iputils-ping,gpgv'
 
 repo="$1"
 suite="${2:-$latestSuite}"


### PR DESCRIPTION
Otherwise, with ubuntu lucid, on the first `apt-get update` we get:
...
W: GPG error: http://archive.ubuntu.com lucid Release: Could not execute '/usr/bin/gpgv' to verify signature (is gpgv installed?)
