### PR TITLE
411 add architecture field

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -107,6 +107,7 @@ func (graph *Graph) Create(layerData Archive, container *Container, comment, aut
 		DockerVersion: VERSION,
 		Author:        author,
 		Config:        config,
+		Architecture:  "x86_64",
 	}
 	if container != nil {
 		img.Parent = container.Image

--- a/image.go
+++ b/image.go
@@ -27,6 +27,7 @@ type Image struct {
 	DockerVersion   string    `json:"docker_version,omitempty"`
 	Author          string    `json:"author,omitempty"`
 	Config          *Config   `json:"config,omitempty"`
+	Architecture    string    `json:"architecture,omitempty"`
 	graph           *Graph
 }
 


### PR DESCRIPTION
This pull request adds the architecture field to the image struct - see #411.

It hardcodes the architecture to amd64 because that's the only architecture docker can really support now. This has to be changed in the future so that the actual architecture is set and handled properly throughout the life cycle of the image.

The tests passed without errors with these changes.
