### PR TITLE
rename containers/ps to containers/json

### DIFF
--- a/api.go
+++ b/api.go
@@ -206,7 +206,7 @@ func getContainersChanges(srv *Server, version float64, w http.ResponseWriter, r
 	return nil
 }
 
-func getContainersPs(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func getContainersJson(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
 	}
@@ -627,7 +627,8 @@ func ListenAndServe(addr string, srv *Server, logging bool) error {
 			"/images/search":                getImagesSearch,
 			"/images/{name:.*}/history":     getImagesHistory,
 			"/images/{name:.*}/json":        getImagesByName,
-			"/containers/ps":                getContainersPs,
+			"/containers/ps":                getContainersJson,
+			"/containers/json":              getContainersJson,
 			"/containers/{name:.*}/export":  getContainersExport,
 			"/containers/{name:.*}/changes": getContainersChanges,
 			"/containers/{name:.*}/json":    getContainersByName,

--- a/api_test.go
+++ b/api_test.go
@@ -318,7 +318,7 @@ func TestGetImagesByName(t *testing.T) {
 	}
 }
 
-func TestGetContainersPs(t *testing.T) {
+func TestGetContainersJson(t *testing.T) {
 	runtime, err := newTestRuntime()
 	if err != nil {
 		t.Fatal(err)
@@ -336,13 +336,13 @@ func TestGetContainersPs(t *testing.T) {
 	}
 	defer runtime.Destroy(container)
 
-	req, err := http.NewRequest("GET", "/containers?quiet=1&all=1", nil)
+	req, err := http.NewRequest("GET", "/containers/json?all=1", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	r := httptest.NewRecorder()
-	if err := getContainersPs(srv, API_VERSION, r, req, nil); err != nil {
+	if err := getContainersJson(srv, API_VERSION, r, req, nil); err != nil {
 		t.Fatal(err)
 	}
 	containers := []ApiContainers{}

--- a/commands.go
+++ b/commands.go
@@ -788,7 +788,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 		v.Set("before", *before)
 	}
 
-	body, _, err := cli.call("GET", "/containers/ps?"+v.Encode(), nil)
+	body, _, err := cli.call("GET", "/containers/json?"+v.Encode(), nil)
 	if err != nil {
 		return err
 	}

--- a/docs/sources/api/docker_remote_api.rst
+++ b/docs/sources/api/docker_remote_api.rst
@@ -24,7 +24,7 @@ Docker Remote API
 List containers
 ***************
 
-.. http:get:: /containers/ps
+.. http:get:: /containers/json
 
 	List containers
 
@@ -32,7 +32,7 @@ List containers
 
 	.. sourcecode:: http
 
-	   GET /containers/ps?all=1&before=8dfafdbc3a40 HTTP/1.1
+	   GET /containers/json?all=1&before=8dfafdbc3a40 HTTP/1.1
 	   
 	**Example response**:
 


### PR DESCRIPTION
I propose to rename /containers/ps to /containers/json to be more consistant with /images.
/ps will still work, but will be undocumented.
