### PR TITLE
Remove teams from the registry API

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,5 @@
 Solomon Hykes <solomon@dotcloud.com>
 Guillaume Charmes <guillaume@dotcloud.com>
+Victor Vieux <victor@dotcloud.com>
 api.go: Victor Vieux <victor@dotcloud.com>
 Vagrantfile: Daniel Mizyrycki <daniel@dotcloud.com>

--- a/docs/sources/api/registry_api.rst
+++ b/docs/sources/api/registry_api.rst
@@ -246,7 +246,6 @@ The Index has two main purposes (along with its fancy social features):
 
 - Resolve short names (to avoid passing absolute URLs all the time)
    - username/projectname -> \https://registry.docker.io/users/<username>/repositories/<projectname>/
-   - team/projectname -> \https://registry.docker.io/team/<team>/repositories/<projectname>/
 - Authenticate a user as a repos owner (for a central referenced repository)
 
 3.1 Without an Index


### PR DESCRIPTION
I would like to suggest removing the concept of "teams" in the registry API. It seems to me that we could use the same model as github, where organizations are a special kind of user, with no change to the url structure or how repositories can be found.

Registry maintainers - what do you think? @samalba @kencochrane @shin- 
