### PR TITLE
Pass b.config to b.builder.Commit

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -287,7 +287,7 @@ func (b *buildFile) commit(id string) error {
 	}
 
 	// Commit the container
-	image, err := b.builder.Commit(container, "", "", "", b.maintainer, nil)
+	image, err := b.builder.Commit(container, "", "", "", b.maintainer, b.config)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes a bug where the final image from docker build would end up without a config section in its json file, rendering CMD and EXPOSE inoperable.
