### PR TITLE
Fix minor documentation error in ‘Running Redis Service’ example

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Brian McCallister <brianm@skife.org>
 Bruno Bigras <bigras.bruno@gmail.com>
 Caleb Spare <cespare@gmail.com>
 Charles Hooper <charles.hooper@dotcloud.com>
+Daniel Gasienica <daniel@gasienica.ch>
 Daniel Mizyrycki <daniel.mizyrycki@dotcloud.com>
 Daniel Robinson <gottagetmac@gmail.com>
 Daniel Von Fange <daniel@leancoder.com>

--- a/docs/sources/examples/running_redis_service.rst
+++ b/docs/sources/examples/running_redis_service.rst
@@ -34,7 +34,7 @@ Snapshot the installation
 
 .. code-block:: bash
 
-    docker ps -a  # grab the container id (this will be the last one in the list)
+    docker ps -a  # grab the container id (this will be the first one in the list)
     docker commit <container_id> <your username>/redis
 
 Run the service


### PR DESCRIPTION
Just a minor fix.
