### PR TITLE
Pass a guaranteed environment to bsdtar for predictable behav...

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -54,6 +54,9 @@ func Tar(path string, compression Compression) (io.Reader, error) {
 func Untar(archive io.Reader, path string) error {
 	cmd := exec.Command("bsdtar", "-f", "-", "-C", path, "-x")
 	cmd.Stdin = archive
+	// Hardcode locale environment for predictable outcome regardless of host configuration.
+	//   (see https://github.com/dotcloud/docker/issues/355)
+	cmd.Env = []string{"LANG=en_US.utf-8", "LC_ALL=en_US.utf-8"}
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s: %s", err, output)

--- a/packaging/ubuntu/docker.upstart
+++ b/packaging/ubuntu/docker.upstart
@@ -5,6 +5,5 @@ stop on starting rc RUNLEVEL=[016]
 respawn
 
 script
-    # FIXME: docker should not depend on the system having en_US.UTF-8
-    LC_ALL='en_US.UTF-8' /usr/bin/docker -d
+    /usr/bin/docker -d
 end script


### PR DESCRIPTION
...ior without depending on the underlying host configuration.

Could someone who's experienced this issue give this a try, or tell me how to reproduce? Thanks.
