### PR TITLE
Build the docker binary statically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ endif
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
 GIT_STATUS = $(shell test -n "`git status --porcelain`" && echo "+CHANGES")
 
-BUILD_OPTIONS = -ldflags "-X main.GIT_COMMIT $(GIT_COMMIT)$(GIT_STATUS)"
+# Use -ldflags '-d' to build statically
+BUILD_OPTIONS = -ldflags "-X main.GIT_COMMIT $(GIT_COMMIT)$(GIT_STATUS) -d"
 
 SRC_DIR := $(GOPATH)/src
 


### PR DESCRIPTION
This might be harder than I thought... Currently the build fails with:

``` bash
$ make clean all VERBOSE=1
_/home/sandbox/docker/docker
bin/docker is created.
sandbox@sandbox:~/docker$
sandbox@sandbox:~/docker$
sandbox@sandbox:~/docker$ make clean all VERBOSE=1
github.com/shin-/cookiejar (download)
github.com/gorilla/mux (download)
github.com/gorilla/context (download)
github.com/kr/pty (download)
github.com/dotcloud/docker/auth
github.com/dotcloud/docker/utils
github.com/shin-/cookiejar
github.com/dotcloud/docker/registry
github.com/dotcloud/docker/term
github.com/gorilla/context
github.com/gorilla/mux
github.com/kr/pty
github.com/dotcloud/docker
_/home/sandbox/docker/docker
# _/home/sandbox/docker/docker
/usr/local/go/pkg/tool/linux_amd64/6l: $WORK/github.com/dotcloud/docker/term.a(_cgo_import.6): cannot use dynamic imports with -d flag
/usr/local/go/pkg/tool/linux_amd64/6l: /usr/local/go/pkg/linux_amd64/net.a(_cgo_import.6): cannot use dynamic imports with -d flag
/usr/local/go/pkg/tool/linux_amd64/6l: /usr/local/go/pkg/linux_amd64/os/user.a(_cgo_import.6): cannot use dynamic imports with -d flag
/usr/local/go/pkg/tool/linux_amd64/6l: /usr/local/go/pkg/linux_amd64/runtime/cgo.a(_cgo_import.6): cannot use dynamic imports with -d flag
/tmp/go-build741118392/github.com/dotcloud/docker/term.a(termios_linux.cg)(.text): ioctl: not defined
/tmp/go-build741118392/github.com/dotcloud/docker/term.a(termios_linux.cg)(.text): ioctl: not defined
/tmp/go-build741118392/github.com/dotcloud/docker/term.a(termios_linux.cg)(.text): __stack_chk_fail: not defined
/usr/local/go/pkg/linux_amd64/net.a(cgo_unix.cgo2.o)(.text): getaddrinfo: not defined
/usr/local/go/pkg/linux_amd64/net.a(cgo_unix.cgo2.o)(.text): gai_strerror: not defined
/usr/local/go/pkg/linux_amd64/net.a(cgo_unix.cgo2.o)(.text): freeaddrinfo: not defined
/usr/local/go/pkg/linux_amd64/net.a(cgo_unix.cgo2.o)(.text): free: not defined
/usr/local/go/pkg/linux_amd64/net.a(cgo_unix.cgo2.o)(.text): __errno_location: not defined
/usr/local/go/pkg/linux_amd64/net.a(cgo_unix.cgo2.o)(.text): getaddrinfo: not defined
/usr/local/go/pkg/linux_amd64/os/user.a(lookup_unix.cgo2)(.text): sysconf: not defined
/usr/local/go/pkg/linux_amd64/os/user.a(lookup_unix.cgo2)(.text): getpwuid_r: not defined
/usr/local/go/pkg/linux_amd64/os/user.a(lookup_unix.cgo2)(.text): malloc: not defined
/usr/local/go/pkg/linux_amd64/os/user.a(lookup_unix.cgo2)(.text): getpwnam_r: not defined
/usr/local/go/pkg/linux_amd64/os/user.a(lookup_unix.cgo2)(.text): free: not defined
/usr/local/go/pkg/linux_amd64/runtime/cgo.a(gcc_linux_amd64.)(.text): sigfillset: not defined
/usr/local/go/pkg/linux_amd64/runtime/cgo.a(gcc_linux_amd64.)(.text): sigprocmask: not defined
/usr/local/go/pkg/linux_amd64/runtime/cgo.a(gcc_linux_amd64.)(.text): pthread_attr_init: not defined
too many errors
make: *** [/home/sandbox/docker/bin/docker] Error 2
```

This thread seems relevant: http://comments.gmane.org/gmane.comp.lang.go.general/61679
