### PR TITLE
Improve documentation + instructions

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+PYTHON        = python
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -38,6 +39,7 @@ help:
 #	@echo "  linkcheck  to check all external links for integrity"
 #	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 	@echo "  docs       to build the docs and copy the static files to the outputdir"
+	@echo "  server     to serve the docs in your browser under \`http://localhost:8000\`"
 	@echo "  publish    to publish the app to dotcloud"
 
 clean:
@@ -49,6 +51,8 @@ docs:
 	@echo
 	@echo "Build finished. The documentation pages are now in $(BUILDDIR)/html."
 
+server:
+	@cd $(BUILDDIR)/html; $(PYTHON) -m SimpleHTTPServer 8000
 
 site:
 	cp -r website $(BUILDDIR)/

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,8 +14,10 @@ Installation
 ------------
 
 * Work in your own fork of the code, we accept pull requests.
-* Install sphinx: ``pip install sphinx``
-* Install sphinx httpdomain contrib package ``sphinxcontrib-httpdomain``
+* Install sphinx: `pip install sphinx`
+    * Mac OS X: `[sudo] pip-2.7 install sphinx`)
+* Install sphinx httpdomain contrib package: `pip install sphinxcontrib-httpdomain`
+    * Mac OS X: `[sudo] pip-2.7 install sphinxcontrib-httpdomain`
 * If pip is not available you can probably install it using your favorite package manager as **python-pip**
 
 Usage

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,14 +22,14 @@ Installation
 
 Usage
 -----
-* change the .rst files with your favorite editor to your liking
-* run *make docs* to clean up old files and generate new ones
-* your static website can now be found in the _build dir
-* to preview what you have generated run `make server` and open <http://localhost:8000/> in your favorite browser.
+* Change the `.rst` files with your favorite editor to your liking.
+* Run `make docs` to clean up old files and generate new ones.
+* Your static website can now be found in the `_build` directory.
+* To preview what you have generated run `make server` and open <http://localhost:8000/> in your favorite browser.
 
-Working using github's file editor
+Working using GitHub's file editor
 ----------------------------------
-Alternatively, for small changes and typo's you might want to use github's built in file editor. It allows
+Alternatively, for small changes and typo's you might want to use GitHub's built in file editor. It allows
 you to preview your changes right online. Just be carefull not to create many commits.
 
 Images

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@ Usage
 * change the .rst files with your favorite editor to your liking
 * run *make docs* to clean up old files and generate new ones
 * your static website can now be found in the _build dir
-* to preview what you have generated, cd into _build/html and then run 'python -m SimpleHTTPServer 8000'
+* to preview what you have generated run `make server` and open <http://localhost:8000/> in your favorite browser.
 
 Working using github's file editor
 ----------------------------------

--- a/docs/sources/api/index.rst
+++ b/docs/sources/api/index.rst
@@ -2,8 +2,8 @@
 :description: docker documentation
 :keywords: docker, ipa, documentation
 
-API's
-=============
+APIs
+====
 
 This following :
 

--- a/docs/sources/concepts/introduction.rst
+++ b/docs/sources/concepts/introduction.rst
@@ -5,8 +5,8 @@
 Introduction
 ============
 
-Docker - The Linux container runtime
-------------------------------------
+Docker -- The Linux container runtime
+-------------------------------------
 
 Docker complements LXC with a high-level API which operates at the process level. It runs unix processes with strong guarantees of isolation and repeatability across servers.
 

--- a/docs/sources/contributing/devenvironment.rst
+++ b/docs/sources/contributing/devenvironment.rst
@@ -1,8 +1,8 @@
-:title: Setting up a dev environment
+:title: Setting Up a Dev Environment
 :description: Guides on how to contribute to docker
 :keywords: Docker, documentation, developers, contributing, dev environment
 
-Setting up a dev environment
+Setting Up a Dev Environment
 ============================
 
 Instructions that have been verified to work on Ubuntu 12.10,

--- a/docs/sources/examples/couchdb_data_volumes.rst
+++ b/docs/sources/examples/couchdb_data_volumes.rst
@@ -4,8 +4,8 @@
 
 .. _running_couchdb_service:
 
-Create a CouchDB service
-========================
+CouchDB Service
+===============
 
 .. include:: example_header.inc
 

--- a/docs/sources/examples/index.rst
+++ b/docs/sources/examples/index.rst
@@ -1,6 +1,6 @@
 :title: Docker Examples
 :description: Examples on how to use Docker
-:keywords: docker, hello world, examples
+:keywords: docker, hello world, python, couch, couchdb, redis, ssh, sshd, examples
 
 
 

--- a/docs/sources/examples/python_web_app.rst
+++ b/docs/sources/examples/python_web_app.rst
@@ -4,8 +4,8 @@
 
 .. _python_web_app:
 
-Building a python web app
-=========================
+Python Web App
+==============
 
 .. include:: example_header.inc
 

--- a/docs/sources/examples/running_examples.rst
+++ b/docs/sources/examples/running_examples.rst
@@ -4,7 +4,7 @@
 
 .. _running_examples:
 
-Running The Examples
+Running the Examples
 --------------------
 
 All the examples assume your machine is running the docker daemon. To run the docker daemon in the background, simply type:

--- a/docs/sources/examples/running_redis_service.rst
+++ b/docs/sources/examples/running_redis_service.rst
@@ -4,8 +4,8 @@
 
 .. _running_redis_service:
 
-Create a redis service
-======================
+Redis Service
+=============
 
 .. include:: example_header.inc
 

--- a/docs/sources/examples/running_ssh_service.rst
+++ b/docs/sources/examples/running_ssh_service.rst
@@ -4,8 +4,8 @@
 
 .. _running_ssh_service:
 
-Create an ssh daemon service
-============================
+SSH Daemon Service
+==================
 
 .. include:: example_header.inc
 

--- a/docs/sources/index.rst
+++ b/docs/sources/index.rst
@@ -7,8 +7,8 @@
 Introduction
 ============
 
-Docker - The Linux container runtime
-------------------------------------
+Docker -- The Linux container runtime
+-------------------------------------
 
 Docker complements LXC with a high-level API which operates at the process level. It runs unix processes with strong guarantees of isolation and repeatability across servers.
 

--- a/docs/sources/use/basics.rst
+++ b/docs/sources/use/basics.rst
@@ -3,8 +3,8 @@
 :keywords: Examples, Usage, basic commands, docker, documentation, examples
 
 
-The basics
-=============
+The Basics
+==========
 
 Starting Docker
 ---------------

--- a/docs/sources/use/workingwithrepository.rst
+++ b/docs/sources/use/workingwithrepository.rst
@@ -4,8 +4,8 @@
 
 .. _working_with_the_repository:
 
-Working with the repository
-============================
+Working with the Repository
+===========================
 
 
 Top-level repositories and user repositories

--- a/docs/sources/use/workingwithrepository.rst
+++ b/docs/sources/use/workingwithrepository.rst
@@ -14,9 +14,9 @@ Top-level repositories and user repositories
 Generally, there are two types of repositories: Top-level repositories which are controlled by the people behind
 Docker, and user repositories.
 
-* Top-level repositories can easily be recognized by not having a / (slash) in their name. These repositories can
+* Top-level repositories can easily be recognized by not having a ``/`` (slash) in their name. These repositories can
   generally be trusted.
-* User repositories always come in the form of <username>/<repo_name>. This is what your published images will look like.
+* User repositories always come in the form of ``<username>/<repo_name>``. This is what your published images will look like.
 * User images are not checked, it is therefore up to you whether or not you trust the creator of this image.
 
 


### PR DESCRIPTION
- Add `make server` command to serve built docs through Python web server
- Add Mac OS X instructions for installing doc Python tools
- Consistently use title case for section headers
- Rename example titles for consistency (while preserving links)
- Use code blocks where appropriate
