### PR TITLE
Vagrantfile: Add support for VMWare Fusion provider 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,7 @@
 
 BOX_NAME = ENV['BOX_NAME'] || "ubuntu"
 BOX_URI = ENV['BOX_URI'] || "http://files.vagrantup.com/precise64.box"
+VF_BOX_URI = ENV['BOX_URI'] || "http://files.vagrantup.com/precise64_vmware_fusion.box"
 AWS_REGION = ENV['AWS_REGION'] || "us-east-1"
 AWS_AMI    = ENV['AWS_AMI']    || "ami-d0f89fb9"
 FORWARD_DOCKER_PORTS = ENV['FORWARD_DOCKER_PORTS']
@@ -65,6 +66,13 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     rs.public_key_path = ENV["RS_PUBLIC_KEY"]
     rs.flavor   = /512MB/
     rs.image    = /Ubuntu/
+  end
+
+  config.vm.provider :vmware_fusion do |f, override|
+    override.vm.box = BOX_NAME
+    override.vm.box_url = VF_BOX_URI
+    override.vm.synced_folder ".", "/vagrant", disabled: true
+    f.vmx["displayName"] = "docker"
   end
 
   config.vm.provider :virtualbox do |vb|


### PR DESCRIPTION
As a user who has blown $150 on VMWare Fusion and vagrant-vmware, I would like to use my new shiny to hack on Docker. Docker already has a multi-provider Vagrantfile, so adding another one presents little risk.

Known Issues:
- The docker install of a new kernel breaks the Vagrant shared folder.
  - This seems to be because the VMWare hgfs module doesn't build against a 3.8 kernel.
  - I don't believe that the shared folder support is actually in use
