### PR TITLE
registry.go: Fixed missing Body.Close()

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -64,6 +64,9 @@ func (r *Registry) LookupRemoteImage(imgId, registry string, authConfig *auth.Au
 	}
 	req.SetBasicAuth(authConfig.Username, authConfig.Password)
 	res, err := rt.RoundTrip(req)
+	if err == nil {
+		defer res.Body.Close()
+	}
 	return err == nil && res.StatusCode == 307
 }
 
@@ -152,7 +155,9 @@ func (r *Registry) GetRemoteTags(registries []string, repository string, token [
 		}
 		req.Header.Set("Authorization", "Token "+strings.Join(token, ", "))
 		res, err := r.client.Do(req)
-		defer res.Body.Close()
+		if err == nil {
+			defer res.Body.Close()
+		}
 		utils.Debugf("Got status code %d from %s", res.StatusCode, endpoint)
 		if err != nil || (res.StatusCode != 200 && res.StatusCode != 404) {
 			continue

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -477,9 +477,15 @@ func NewRegistry(root string) *Registry {
 	// If the auth file does not exist, keep going
 	authConfig, _ := auth.LoadConfig(root)
 
+	httpTransport := &http.Transport{
+		DisableKeepAlives: true,
+	}
+
 	r := &Registry{
 		authConfig: authConfig,
-		client:     &http.Client{},
+		client: &http.Client{
+			Transport: httpTransport,
+		},
 	}
 	r.client.Jar = cookiejar.NewCookieJar()
 	return r

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -64,10 +64,11 @@ func (r *Registry) LookupRemoteImage(imgId, registry string, authConfig *auth.Au
 	}
 	req.SetBasicAuth(authConfig.Username, authConfig.Password)
 	res, err := rt.RoundTrip(req)
-	if err == nil {
-		defer res.Body.Close()
+	if err != nil {
+		return false
 	}
-	return err == nil && res.StatusCode == 307
+	res.Body.Close()
+	return res.StatusCode == 307
 }
 
 func (r *Registry) getImagesInRepository(repository string, authConfig *auth.AuthConfig) ([]map[string]string, error) {
@@ -155,18 +156,19 @@ func (r *Registry) GetRemoteTags(registries []string, repository string, token [
 		}
 		req.Header.Set("Authorization", "Token "+strings.Join(token, ", "))
 		res, err := r.client.Do(req)
-		if err == nil {
-			defer res.Body.Close()
-		}
 		utils.Debugf("Got status code %d from %s", res.StatusCode, endpoint)
-		if err != nil || (res.StatusCode != 200 && res.StatusCode != 404) {
+		if err != nil {
+			return nil, err
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != 200 && res.StatusCode != 404 {
 			continue
 		} else if res.StatusCode == 404 {
 			return nil, fmt.Errorf("Repository not found")
 		}
 
 		result := make(map[string]string)
-
 		rawJson, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			return nil, err

--- a/server.go
+++ b/server.go
@@ -321,6 +321,7 @@ func (srv *Server) pullImage(r *registry.Registry, out io.Writer, imgId, endpoin
 			if err != nil {
 				return err
 			}
+			defer layer.Close()
 			if err := srv.runtime.graph.Register(utils.ProgressReader(layer, contentLength, out, sf.FormatProgress("Downloading", "%v/%v (%v)"), sf), false, img); err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixed several missing Body.Close() in the registry's client code. It's part of the investigation / fixes related to push/pull issues.
