### PR TITLE
Ubuntu 13.04 - add-apt-repository

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -92,6 +92,17 @@ have AUFS filesystem support enabled, so we need to install it.
    sudo apt-get update
    sudo apt-get install linux-image-extra-`uname -r`
 
+**add-apt-repository support**
+
+Some installations of Ubuntu 13.04 (Digital Ocean's Ubuntu 13.04 x64 Server in
+this case) require software-properties-common to be installed before being able
+to use add-apt-repository.
+
+.. code-block:: bash
+
+  sudo apt-get install software-properties-common
+
+
 Installation
 ------------
 


### PR DESCRIPTION
Some installations of ubuntu 13.04 (Digital Ocean's Ubuntu 13.04 x64 Server in this case) require software-properties-common to be installed before being able to use add-apt-repository.

Not installing it will yield the following:

```
# sudo add-apt-repository ppa:dotcloud/lxc-docker
sudo: add-apt-repository: command not found
```
