### PR TITLE
Add flag to enable cross domain requests in Remote Api

### DIFF
--- a/api.go
+++ b/api.go
@@ -793,6 +793,7 @@ func createRouter(srv *Server, logging bool) (*mux.Router, error) {
 		if srv.enableCors {
 			writeCorsHeaders(w, r)
 		}
+		w.WriteHeader(http.StatusOK)
 	})
 	return r, nil
 }

--- a/api.go
+++ b/api.go
@@ -706,6 +706,7 @@ func postBuild(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 func writeCorsHeaders(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Access-Control-Allow-Origin", "*")
 	w.Header().Add("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept")
+	w.Header().Add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, OPTIONS")
 }
 
 func ListenAndServe(addr string, srv *Server, logging bool) error {
@@ -774,12 +775,12 @@ func ListenAndServe(addr string, srv *Server, logging bool) error {
 				if err != nil {
 					version = API_VERSION
 				}
+				if srv.enableCors {
+					writeCorsHeaders(w, r)
+				}
 				if version == 0 || version > API_VERSION {
 					w.WriteHeader(http.StatusNotFound)
 					return
-				}
-				if srv.enableCors {
-					writeCorsHeaders(w, r)
 				}
 				if err := localFct(srv, version, w, r, mux.Vars(r)); err != nil {
 					httpError(w, err)

--- a/api_test.go
+++ b/api_test.go
@@ -1260,7 +1260,7 @@ func TestOptionsRoute(t *testing.T) {
 	}
 
 	router.ServeHTTP(r, req)
-	if r.Code != 200 {
+	if r.Code != http.StatusOK {
 		t.Errorf("Expected response for OPTIONS request to be \"200\", %v found.", r.Code)
 	}
 }
@@ -1287,7 +1287,7 @@ func TestGetEnabledCors(t *testing.T) {
 	}
 
 	router.ServeHTTP(r, req)
-	if r.Code != 200 {
+	if r.Code != http.StatusOK {
 		t.Errorf("Expected response for OPTIONS request to be \"200\", %v found.", r.Code)
 	}
 

--- a/api_test.go
+++ b/api_test.go
@@ -1239,6 +1239,32 @@ func TestDeleteContainers(t *testing.T) {
 	}
 }
 
+func TestGetEnabledCors(t *testing.T) {
+	runtime, err := newTestRuntime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nuke(runtime)
+
+	srv := &Server{runtime: runtime, enableCors: true}
+
+	r := httptest.NewRecorder()
+
+	if err := getVersion(srv, API_VERSION, r, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	allowOrigin := r.Header().Get("Access-Control-Allow-Origin")
+	allowHeaders := r.Header().Get("Access-Control-Allow-Headers")
+
+	if allowOrigin != "*" {
+		t.Errorf("Expected header Access-Control-Allow-Origin to be \"*\", %s found.", allowOrigin)
+	}
+	if allowHeaders != "Origin, X-Requested-With, Content-Type, Accept" {
+		t.Errorf("Expected header Access-Control-Allow-Headers to be \"Origin, X-Requested-With, Content-Type, Accept\", %s found.", allowHeaders)
+	}
+}
+
 func TestDeleteImages(t *testing.T) {
 	//FIXME: Implement this test
 	t.Log("Test not implemented")

--- a/api_test.go
+++ b/api_test.go
@@ -1239,6 +1239,32 @@ func TestDeleteContainers(t *testing.T) {
 	}
 }
 
+func TestOptionsRoute(t *testing.T) {
+	runtime, err := newTestRuntime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nuke(runtime)
+
+	srv := &Server{runtime: runtime, enableCors: true}
+
+	r := httptest.NewRecorder()
+	router, err := createRouter(srv, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("OPTIONS", "/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router.ServeHTTP(r, req)
+	if r.Code != 200 {
+		t.Errorf("Expected response for OPTIONS request to be \"200\", %v found.", r.Code)
+	}
+}
+
 func TestGetEnabledCors(t *testing.T) {
 	runtime, err := newTestRuntime()
 	if err != nil {
@@ -1250,18 +1276,33 @@ func TestGetEnabledCors(t *testing.T) {
 
 	r := httptest.NewRecorder()
 
-	if err := getVersion(srv, API_VERSION, r, nil, nil); err != nil {
+	router, err := createRouter(srv, false)
+	if err != nil {
 		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("GET", "/version", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	router.ServeHTTP(r, req)
+	if r.Code != 200 {
+		t.Errorf("Expected response for OPTIONS request to be \"200\", %v found.", r.Code)
 	}
 
 	allowOrigin := r.Header().Get("Access-Control-Allow-Origin")
 	allowHeaders := r.Header().Get("Access-Control-Allow-Headers")
+	allowMethods := r.Header().Get("Access-Control-Allow-Methods")
 
 	if allowOrigin != "*" {
 		t.Errorf("Expected header Access-Control-Allow-Origin to be \"*\", %s found.", allowOrigin)
 	}
 	if allowHeaders != "Origin, X-Requested-With, Content-Type, Accept" {
 		t.Errorf("Expected header Access-Control-Allow-Headers to be \"Origin, X-Requested-With, Content-Type, Accept\", %s found.", allowHeaders)
+	}
+	if allowMethods != "GET, POST, DELETE, PUT, OPTIONS" {
+		t.Errorf("Expected hearder Access-Control-Allow-Methods to be \"GET, POST, DELETE, PUT, OPTIONS\", %s found.", allowMethods)
 	}
 }
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -33,6 +33,7 @@ func main() {
 	bridgeName := flag.String("b", "", "Attach containers to a pre-existing network bridge")
 	pidfile := flag.String("p", "/var/run/docker.pid", "File containing process PID")
 	flHost := flag.String("H", fmt.Sprintf("%s:%d", host, port), "Host:port to bind/connect to")
+	flEnableCors := flag.Bool("api-enable-cors", false, "Enable CORS requests in the remote api.")
 	flag.Parse()
 	if *bridgeName != "" {
 		docker.NetworkBridgeIface = *bridgeName
@@ -65,7 +66,7 @@ func main() {
 			flag.Usage()
 			return
 		}
-		if err := daemon(*pidfile, host, port, *flAutoRestart); err != nil {
+		if err := daemon(*pidfile, host, port, *flAutoRestart, *flEnableCors); err != nil {
 			log.Fatal(err)
 			os.Exit(-1)
 		}
@@ -104,7 +105,7 @@ func removePidFile(pidfile string) {
 	}
 }
 
-func daemon(pidfile, addr string, port int, autoRestart bool) error {
+func daemon(pidfile, addr string, port int, autoRestart, enableCors bool) error {
 	if addr != "127.0.0.1" {
 		log.Println("/!\\ DON'T BIND ON ANOTHER IP ADDRESS THAN 127.0.0.1 IF YOU DON'T KNOW WHAT YOU'RE DOING /!\\")
 	}
@@ -122,7 +123,7 @@ func daemon(pidfile, addr string, port int, autoRestart bool) error {
 		os.Exit(0)
 	}()
 
-	server, err := docker.NewServer(autoRestart)
+	server, err := docker.NewServer(autoRestart, enableCors)
 	if err != nil {
 		return err
 	}

--- a/docs/sources/api/docker_remote_api.rst
+++ b/docs/sources/api/docker_remote_api.rst
@@ -1056,3 +1056,11 @@ Here are the steps of 'docker run' :
 
 In this first version of the API, some of the endpoints, like /attach, /pull or /push uses hijacking to transport stdin,
 stdout and stderr on the same socket. This might change in the future.
+
+
+3.3 CORS Requests
+-----------------
+
+To enable cross origin requests to the remote api add the flag "-api-enable-cors" when running docker in daemon mode.
+    
+    docker -d -H="192.168.1.9:4243" -api-enable-cors

--- a/server.go
+++ b/server.go
@@ -870,7 +870,7 @@ func (srv *Server) ImageInspect(name string) (*Image, error) {
 	return nil, fmt.Errorf("No such image: %s", name)
 }
 
-func NewServer(autoRestart bool) (*Server, error) {
+func NewServer(autoRestart, enableCors bool) (*Server, error) {
 	if runtime.GOARCH != "amd64" {
 		log.Fatalf("The docker runtime currently only supports amd64 (not %s). This will change in the future. Aborting.", runtime.GOARCH)
 	}
@@ -879,12 +879,14 @@ func NewServer(autoRestart bool) (*Server, error) {
 		return nil, err
 	}
 	srv := &Server{
-		runtime: runtime,
+		runtime:    runtime,
+		enableCors: enableCors,
 	}
 	runtime.srv = srv
 	return srv, nil
 }
 
 type Server struct {
-	runtime *Runtime
+	runtime    *Runtime
+	enableCors bool
 }


### PR DESCRIPTION
Add the **-api-enable-cors** flag when running docker
in daemon mode to allow CORS requests to be made to
the Remote Api.  The default value is false for this
flag to not allow cross origin request to be made.

When the flag is set to true, the api will add the Access-Control-Allow-Origin and Access-Control-Allow-Headers to the response so that in browser requests can be made to the api.

Also adds a handler for OPTIONS requests.  The standard
for cross domain requests is to initially make an
OPTIONS request to an api.

Example:

```
docker -d -H="192.168.1.9:4243" -api-enable-cors
```
