### PR TITLE
524 fix aufs links related warnings

### DIFF
--- a/docs/sources/contributing/devenvironment.rst
+++ b/docs/sources/contributing/devenvironment.rst
@@ -33,7 +33,7 @@ Installation
     sudo apt-get install python-software-properties
     sudo add-apt-repository ppa:gophers/go
     sudo apt-get update
-    sudo apt-get -y install lxc wget bsdtar curl golang-stable git
+    sudo apt-get -y install lxc wget bsdtar curl golang-stable git aufs-tools
 
     export GOPATH=~/go/
     export PATH=$GOPATH/bin:$PATH

--- a/hack/Vagrantfile
+++ b/hack/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant::Config.run do |config|
   pkg_cmd = "touch #{DOCKER_PATH}; "
   # Install docker dependencies
   pkg_cmd << "export DEBIAN_FRONTEND=noninteractive; apt-get -qq update; " \
-    "apt-get install -q -y lxc bsdtar git golang make linux-image-extra-3.8.0-19-generic; " \
+    "apt-get install -q -y lxc bsdtar git aufs-tools golang make linux-image-extra-3.8.0-19-generic; " \
     "chown -R #{USER}.#{USER} #{GOPATH}; " \
     "install -m 0664 #{CFG_PATH}/bash_profile /home/#{USER}/.bash_profile"
   config.vm.provision :shell, :inline => pkg_cmd

--- a/mount.go
+++ b/mount.go
@@ -2,13 +2,18 @@ package docker
 
 import (
 	"fmt"
+	"github.com/dotcloud/docker/utils"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"syscall"
 	"time"
 )
 
 func Unmount(target string) error {
+	if err := exec.Command("auplink", target, "flush").Run(); err != nil {
+		utils.Debugf("[warning]: couldn't run auplink before unmount: %s", err)
+	}
 	if err := syscall.Unmount(target, 0); err != nil {
 		return err
 	}

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -10,7 +10,7 @@ Homepage: http://github.com/dotcloud/docker
 
 Package: lxc-docker
 Architecture: linux-any
-Depends: ${shlibs:Depends}, ${misc:Depends}, lxc, bsdtar
+Depends: ${shlibs:Depends}, ${misc:Depends}, lxc, bsdtar, aufs-tools
 Description: Linux container runtime
  Docker complements LXC with a high-level API which operates at the process
  level. It runs unix processes with strong guarantees of isolation and

--- a/packaging/ubuntu/control
+++ b/packaging/ubuntu/control
@@ -8,7 +8,7 @@ Homepage: http://github.com/dotcloud/docker
 
 Package: lxc-docker
 Architecture: linux-any
-Depends: ${misc:Depends},${shlibs:Depends},lxc,bsdtar
+Depends: ${misc:Depends},${shlibs:Depends},lxc,bsdtar,aufs-tools
 Conflicts: docker
 Description: lxc-docker is a Linux container runtime
  Docker complements LXC with a high-level API which operates at the process

--- a/testing/Vagrantfile
+++ b/testing/Vagrantfile
@@ -30,7 +30,7 @@ Vagrant::Config.run do |config|
     # Install docker dependencies
     pkg_cmd << "apt-get install -q -y python-software-properties; " \
       "add-apt-repository -y ppa:gophers/go/ubuntu; apt-get update -qq; " \
-      "DEBIAN_FRONTEND=noninteractive apt-get install -q -y lxc bsdtar git golang-stable make; "
+      "DEBIAN_FRONTEND=noninteractive apt-get install -q -y lxc bsdtar git golang-stable aufs-tools make; "
     # Activate new kernel
     pkg_cmd << "shutdown -r +1; "
     config.vm.provision :shell, :inline => pkg_cmd


### PR DESCRIPTION
This PR fixes #524.

The first commit modifies mount.go so that we try to run `auplink` before unmounting the aufs layers. If docker fails to run auplink, it will print a warning and move on.
The warning looks something along these lines:
`[warning]: couldn't run auplink before unmount: couldn't find auplink in $PATH`

The second commit adds aufs-tools to the list of dependencies for the installation of lxc-docker on Ubuntu and Debian.

`auplink` makes sure that hard links across layers are handled properly upon unmount.

@creack Please take a look at this PR.
