### PR TITLE
Print the container id before the hijack in `docker run` (see also #804)

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1228,6 +1228,9 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		return err
 	}
 
+	if !config.AttachStdout && !config.AttachStderr {
+		fmt.Println(out.ID)
+	}
 	if connections > 0 {
 		chErrors := make(chan error, connections)
 		cli.monitorTtySize(out.ID)
@@ -1261,9 +1264,6 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 			}
 			connections -= 1
 		}
-	}
-	if !config.AttachStdout && !config.AttachStderr {
-		fmt.Println(out.ID)
 	}
 	return nil
 }


### PR DESCRIPTION
This is useful when you want to get the container id before you start to interact with stdin (which is what I'm doing in dotcloud/sandbox).
