### PR TITLE
fix aufs mount on ubuntu13.04+btrfs

### DIFF
--- a/image.go
+++ b/image.go
@@ -126,6 +126,8 @@ func MountAUFS(ro []string, rw string, target string) error {
 	}
 	branches := fmt.Sprintf("br:%v:%v", rwBranch, roBranches)
 
+	branches += ",xino=/dev/shm/aufs.xino"
+
 	//if error, try to load aufs kernel module
 	if err := mount("none", target, "aufs", 0, branches); err != nil {
 		log.Printf("Kernel does not support AUFS, trying to load the AUFS module with modprobe...")


### PR DESCRIPTION
Fixes #825 

After some research, I found that if we put the "xino stuff" in /dev/shm/ it works everywhere (including btrfs and xfs)

@jpetazzo can you take a look ?
