### PR TITLE
update golang on "Setting Up a Dev Environment" doc

### DIFF
--- a/docs/sources/contributing/devenvironment.rst
+++ b/docs/sources/contributing/devenvironment.rst
@@ -5,7 +5,28 @@
 Setting Up a Dev Environment
 ============================
 
-Instructions that have been verified to work on Ubuntu 12.10,
+Instructions that have been verified to work on Ubuntu Precise 12.04 (LTS) (64-bit),
+
+
+Dependencies
+------------
+
+**Linux kernel 3.8**
+
+Due to a bug in LXC docker works best on the 3.8 kernel. Precise comes with a 3.2 kernel, so we need to upgrade it. The kernel we install comes with AUFS built in.
+
+
+.. code-block:: bash
+
+   # install the backported kernel
+   sudo apt-get update && sudo apt-get install linux-image-generic-lts-raring
+
+   # reboot
+   sudo reboot
+
+
+Installation
+------------
 
 .. code-block:: bash
 		

--- a/docs/sources/contributing/devenvironment.rst
+++ b/docs/sources/contributing/devenvironment.rst
@@ -8,8 +8,11 @@ Setting Up a Dev Environment
 Instructions that have been verified to work on Ubuntu 12.10,
 
 .. code-block:: bash
-
-    sudo apt-get -y install lxc wget bsdtar curl golang git
+		
+    sudo apt-get install python-software-properties
+    sudo add-apt-repository ppa:gophers/go
+    sudo apt-get update
+    sudo apt-get -y install lxc wget bsdtar curl golang-stable git
 
     export GOPATH=~/go/
     export PATH=$GOPATH/bin:$PATH


### PR DESCRIPTION
Docker requires go1.0.3
In "Setting Up a Dev Environment" http://docs.docker.io/en/latest/contributing/devenvironment.html

It says `sudo apt-get install golang` but it only gives you go 1.0.2.
We need to change this to use the ppa

/cc @johncosta @kencochrane 
