### PR TITLE
841 - docs: warn about the transmission of data to the docker daemon & ADD without context

### DIFF
--- a/docs/sources/commandline/command/build.rst
+++ b/docs/sources/commandline/command/build.rst
@@ -22,6 +22,7 @@ Examples
 | This will read the Dockerfile from the current directory. It will also send any other files and directories found in the current directory to the docker daemon.
 | The contents of this directory would be used by ADD commands found within the Dockerfile.
 | This will send a lot of data to the docker daemon if the current directory contains a lot of data.
+| If the absolute path is provided instead of '.', only the files and directories required by the ADD commands from the Dockerfile will be added to the context and transferred to the docker daemon.
 |
 
 .. code-block:: bash

--- a/docs/sources/commandline/command/build.rst
+++ b/docs/sources/commandline/command/build.rst
@@ -19,10 +19,14 @@ Examples
 
     docker build .
 
-This will take the local Dockerfile
+| This will read the Dockerfile from the current directory. It will also send any other files and directories found in the current directory to the docker daemon.
+| The contents of this directory would be used by ADD commands found within the Dockerfile.
+| This will send a lot of data to the docker daemon if the current directory contains a lot of data.
+|
 
 .. code-block:: bash
 
     docker build -
 
-This will read a Dockerfile form Stdin without context
+| This will read a Dockerfile from Stdin without context. Due to the lack of a context, no contents of any local directory will be sent to the docker daemon.
+| ADD doesn't work when running in this mode due to the absence of the context, thus having no source files to copy to the container.


### PR DESCRIPTION
This updates the documentation to mention that:
1. a lot of data may get sent to the docker daemon if there is a lot of
data in the directory passed to docker build
2. ADD doesn't work in the absence of the context
3. running without a context doesn't send file data to the docker
daemon
4. explain that the data sent to the docker daemon will be used by ADD
commands

updated:
5. explain that using an absolute path with docker build will only transfer the data needed by the ADD commands found in the Dockerfile to be found in that directory

This PR fixes #841.
