### PR TITLE
Remove CR/NL from description in docker CLI

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1079,7 +1079,12 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 	w := tabwriter.NewWriter(os.Stdout, 20, 1, 3, ' ', 0)
 	fmt.Fprintf(w, "NAME\tDESCRIPTION\n")
 	for _, out := range outs {
-		fmt.Fprintf(w, "%s\t%s\n", out.Name, out.Description)
+		desc := strings.Replace(out.Description, "\n", " ", -1)
+		desc = strings.Replace(desc, "\r", " ", -1)
+		if len(desc) > 45 {
+			desc = utils.Trunc(desc, 42) + "..."
+		}
+		fmt.Fprintf(w, "%s\t%s\n", out.Name, desc)
 	}
 	w.Flush()
 	return nil

--- a/server.go
+++ b/server.go
@@ -63,9 +63,6 @@ func (srv *Server) ImagesSearch(term string) ([]APISearch, error) {
 	for _, repo := range results.Results {
 		var out APISearch
 		out.Description = repo["description"]
-		if len(out.Description) > 45 {
-			out.Description = utils.Trunc(out.Description, 42) + "..."
-		}
 		out.Name = repo["name"]
 		outs = append(outs, out)
 	}


### PR DESCRIPTION
Also moved description shortening to client side (other clients might want the full desc).

Fixes #556 
