### PR TITLE
docs/api/remote: fix rst syntax in the "Search images" section

### DIFF
--- a/docs/sources/api/docker_remote_api.rst
+++ b/docs/sources/api/docker_remote_api.rst
@@ -839,9 +839,9 @@ Search images
 		}
 	   ]
 
-	   :query term: term to search
-	   :statuscode 200: no error
-	   :statuscode 500: server error
+	:query term: term to search
+	:statuscode 200: no error
+	:statuscode 500: server error
 
 
 3.3 Misc


### PR DESCRIPTION
You can see it live: http://docs.docker.io/en/latest/api/docker_remote_api/#search-images
