### PR TITLE
Add TAG instruction to Dockerfile builder

### DIFF
--- a/api.go
+++ b/api.go
@@ -712,12 +712,7 @@ func postBuild(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 		return err
 	}
 	remote := r.FormValue("t")
-	tag := ""
-	if strings.Contains(remote, ":") {
-		remoteParts := strings.Split(remote, ":")
-		tag = remoteParts[1]
-		remote = remoteParts[0]
-	}
+	remote, tag := splitTagParts(remote)
 
 	dockerfile, _, err := r.FormFile("Dockerfile")
 	if err != nil {

--- a/buildfile.go
+++ b/buildfile.go
@@ -225,6 +225,10 @@ func (b *buildFile) CmdAdd(args string) error {
 	return nil
 }
 
+func (b *buildFile) CmdTag(tag string) error {
+	return b.runtime.repositories.Set("<none>", tag, b.image, false)
+}
+
 func (b *buildFile) run() (string, error) {
 	if b.image == "" {
 		return "", fmt.Errorf("Please provide a source image with `from` prior to run")

--- a/buildfile.go
+++ b/buildfile.go
@@ -225,8 +225,9 @@ func (b *buildFile) CmdAdd(args string) error {
 	return nil
 }
 
-func (b *buildFile) CmdTag(tag string) error {
-	return b.runtime.repositories.Set("<none>", tag, b.image, false)
+func (b *buildFile) CmdTag(remote string) error {
+	remote, tag := splitTagParts(remote)
+	return b.runtime.repositories.Set(remote, tag, b.image, false)
 }
 
 func (b *buildFile) run() (string, error) {

--- a/docs/sources/use/builder.rst
+++ b/docs/sources/use/builder.rst
@@ -140,7 +140,7 @@ The context must be set in order to use this instruction. (see examples)
     ``TAG <value>``
 
 The `TAG` instruction will tag the current image version in the default repository.  You can have multiple 
-`TAG` instructions in a Dockerfile.
+`TAG` instructions in a Dockerfile.  The format for the tag should be `repo:tag`.
 
 3. Dockerfile Examples
 ======================

--- a/docs/sources/use/builder.rst
+++ b/docs/sources/use/builder.rst
@@ -134,6 +134,14 @@ The `ADD` instruction will insert the files from the `<src>` path of the context
 of the container.
 The context must be set in order to use this instruction. (see examples)
 
+2.9 TAG
+-------
+
+    ``TAG <value>``
+
+The `TAG` instruction will tag the current image version in the default repository.  You can have multiple 
+`TAG` instructions in a Dockerfile.
+
 3. Dockerfile Examples
 ======================
 

--- a/utils.go
+++ b/utils.go
@@ -1,5 +1,9 @@
 package docker
 
+import (
+	"strings"
+)
+
 // Compare two Config struct. Do not compare the "Image" nor "Hostname" fields
 // If OpenStdin is set, then it differs
 func CompareConfig(a, b *Config) bool {
@@ -85,4 +89,14 @@ func MergeConfig(userConf, imageConf *Config) {
 	if userConf.Dns == nil || len(userConf.Dns) == 0 {
 		userConf.Dns = imageConf.Dns
 	}
+}
+
+func splitTagParts(remote string) (string, string) {
+	tag := ""
+	if strings.Contains(remote, ":") {
+		parts := strings.Split(remote, ":")
+		tag = parts[1]
+		remote = parts[0]
+	}
+	return remote, tag
 }


### PR DESCRIPTION
The TAG instruction added to the buildfile allows
a tag to be applied to the result of each step.
Multiple tags can be in the same Dockerfile.  The
tag format is repo:tag which is consistent with the cli 
and Remote/Api.

This should resolve issue #842 
