### PR TITLE
validate memory limits & error out if it's less than 524288

### DIFF
--- a/server.go
+++ b/server.go
@@ -652,6 +652,10 @@ func (srv *Server) ImageImport(src, repo, tag string, in io.Reader, out io.Write
 
 func (srv *Server) ContainerCreate(config *Config) (string, error) {
 
+	if config.Memory != 0 && config.Memory < 524288 {
+		return "", fmt.Errorf("Memory limit must be given in bytes (minimum 524288 bytes)")
+	}
+
 	if config.Memory > 0 && !srv.runtime.capabilities.MemoryLimit {
 		config.Memory = 0
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -147,3 +147,25 @@ func TestCreateStartRestartStopStartKillRm(t *testing.T) {
 	}
 
 }
+
+func TestRunWithTooLowMemoryLimit(t *testing.T) {
+	runtime, err := newTestRuntime()
+	srv := &Server{runtime: runtime}
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nuke(runtime)
+	// Try to create a container with a memory limit of 1 byte less than the minimum allowed limit.
+	_, err = srv.ContainerCreate(
+		&Config{
+			Image:     GetTestImage(runtime).ID,
+			Memory:    524287,
+			CpuShares: 1000,
+			Cmd:       []string{"/bin/cat"},
+		},
+	)
+	if err == nil {
+		t.Errorf("Memory limit is smaller than the allowed limit. Container creation should've failed!")
+	}
+
+}


### PR DESCRIPTION
Right now, we're not performing validation on the values passed as memory limits.
The following example shows what happens right now (it's not always the same, the printed errors vary):

```
docker run -i -m 512 ubuntu true
lxc-start: Device or resource busy - write /sys/fs/cgroup/memory/lxc/1b696c395503673593d80dd248439dbf15c1c68e6e8be0a83944bf2f0c4aea15/memory.limit_in_bytes : Device or resource busy
lxc-start: Error setting memory.limit_in_bytes to 512 for lxc/1b696c395503673593d80dd248439dbf15c1c68e6e8be0a83944bf2f0c4aea15

lxc-start: failed to setup the cgroups for '1b696c395503673593d80dd248439dbf15c1c68e6e8be0a83944bf2f0c4aea15'
lxc-start: failed to spawn '1b696c395503673593d80dd248439dbf15c1c68e6e8be0a83944bf2f0c4aea15'

# FAILED EXECUTION
```

Ideally, we'd want to catch this and throw an error - it's the best we can do. We can't make assumptions about the value we were given as a memory limit, so we have to set a minimum acceptable memory limit in bytes so that we can detect bad limits.

This PR makes a change in server.go so that we throw an error right away if the memory limit is set to less than 512 KB (524288).
This changes docker's behavior to this:

```
# let's make it fail
 docker run -i -m 16 ubuntu true
2013/06/14 19:59:20 Error: Memory limit must be given in bytes (minimum 524288 bytes)
# did we exit cleanly?
 echo $?
1
# oh, so it has to be in bytes
# let's try again
 docker run -i -m 16777216 ubuntu true
# did we exit cleanly?
 echo $?
0
# is the minimum limit real?
 docker run -i -m 524288 ubuntu true
 echo $?
0
 docker run -i -m 524287 ubuntu true
2013/06/14 20:02:48 Error: Memory limit must be given in bytes (minimum 524288 bytes)
# it looks like it is
```
