### PR TITLE
ADD improvements: use tar for copy + automatically unpack local archives

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -200,21 +200,17 @@ func (b *buildFile) CmdAdd(args string) error {
 		if err := os.MkdirAll(destPath, 0700); err != nil {
 			return err
 		}
-
-		files, err := ioutil.ReadDir(path.Join(b.context, orig))
-		if err != nil {
+		if err := CopyWithTar(origPath, destPath); err != nil {
 			return err
 		}
-		for _, fi := range files {
-			if err := utils.CopyDirectory(path.Join(origPath, fi.Name()), path.Join(destPath, fi.Name())); err != nil {
-				return err
-			}
-		}
-	} else {
+		// First try to unpack the source as an archive
+	} else if err := UntarPath(origPath, destPath); err != nil {
+		utils.Debugf("Couldn't untar %s to %s: %s", origPath, destPath, err)
+		// If that fails, just copy it as a regular file
 		if err := os.MkdirAll(path.Dir(destPath), 0700); err != nil {
 			return err
 		}
-		if err := utils.CopyDirectory(origPath, destPath); err != nil {
+		if err := CopyWithTar(origPath, destPath); err != nil {
 			return err
 		}
 	}

--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -23,6 +23,12 @@ from   ` + unitTestImageName + `
 run    sh -c 'echo root:testpass > /tmp/passwd'
 run    mkdir -p /var/run/sshd`
 
+// FIXME: test building with a context
+
+// FIXME: test building with a local ADD as first command
+
+// FIXME: test building with 2 successive overlapping ADD commands
+
 func TestBuild(t *testing.T) {
 	dockerfiles := []string{Dockerfile, DockerfileNoNewLine}
 	for _, Dockerfile := range dockerfiles {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -548,6 +548,7 @@ func GetKernelVersion() (*KernelVersionInfo, error) {
 	}, nil
 }
 
+// FIXME: this is deprecated by CopyWithTar in archive.go
 func CopyDirectory(source, dest string) error {
 	if output, err := exec.Command("cp", "-ra", source, dest).CombinedOutput(); err != nil {
 		return fmt.Errorf("Error copy: %s (%s)", err, output)


### PR DESCRIPTION
- Builder: ADD of a local file will detect tar archives and unpack them into the container instead of copying them as a regular file.
- Builder: ADD uses tar/untar for copies instead of calling 'cp -ar'.
  This is more consistent, reduces the number of dependencies, and
  fixe #896.
