### PR TITLE
Api Server Changes becoming it more Restful.

### DIFF
--- a/api.go
+++ b/api.go
@@ -538,13 +538,15 @@ func deleteImages(srv *Server, version float64, w http.ResponseWriter, r *http.R
 
 func postContainersStart(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
+    w.WriteHeader(http.StatusBadRequest)
 		return fmt.Errorf("Missing parameter")
 	}
 	name := vars["name"]
 	if err := srv.ContainerStart(name); err != nil {
+    w.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(http.StatusOK)
 	return nil
 }
 
@@ -558,14 +560,16 @@ func postContainersStop(srv *Server, version float64, w http.ResponseWriter, r *
 	}
 
 	if vars == nil {
+    w.WriteHeader(http.StatusBadRequest)
 		return fmt.Errorf("Missing parameter")
 	}
 	name := vars["name"]
 
 	if err := srv.ContainerStop(name, t); err != nil {
+    w.WriteHeader(http.StatusInternalServerError)
 		return err
 	}
-	w.WriteHeader(http.StatusNoContent)
+	w.WriteHeader(http.StatusOK)
 	return nil
 }
 

--- a/api_test.go
+++ b/api_test.go
@@ -953,8 +953,8 @@ func TestPostContainersStart(t *testing.T) {
 	if err := postContainersStart(srv, APIVERSION, r, nil, map[string]string{"name": container.ID}); err != nil {
 		t.Fatal(err)
 	}
-	if r.Code != http.StatusNoContent {
-		t.Fatalf("%d NO CONTENT expected, received %d\n", http.StatusNoContent, r.Code)
+	if r.Code != http.StatusOK {
+		t.Fatalf("HTTP Status 200 expected, received %d\n", r.Code)
 	}
 
 	// Give some time to the process to start
@@ -1015,8 +1015,8 @@ func TestPostContainersStop(t *testing.T) {
 	if err := postContainersStop(srv, APIVERSION, r, req, map[string]string{"name": container.ID}); err != nil {
 		t.Fatal(err)
 	}
-	if r.Code != http.StatusNoContent {
-		t.Fatalf("%d NO CONTENT expected, received %d\n", http.StatusNoContent, r.Code)
+	if r.Code != http.StatusOK {
+		t.Fatalf("HTTP Status 200 expected, received %d\n", r.Code)
 	}
 	if container.State.Running {
 		t.Fatalf("The container hasn't been stopped")


### PR DESCRIPTION
It was responding 404 Status on successful requests and missing HTTP Status when errors occurred. 

Changes applied :
- When the server receives wrong parameters from client it returns "400 Bad Request".
- When a problem occurred when starting or stopping a Container it returns "500 Internal Server Error".
- On success it returns "200 OK".

Have i missed something ? 
