### PR TITLE
fix docker version's git commit output

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,6 +41,7 @@ Jérôme Petazzoni <jerome.petazzoni@dotcloud.com>
 Ken Cochrane <kencochrane@gmail.com>
 Kevin J. Lynagh <kevin@keminglabs.com>
 Louis Opter <kalessin@kalessin.fr>
+Marcus Farkas <toothlessgear@finitebox.com>
 Maxim Treskin <zerthurd@gmail.com>
 Michael Crosby <crosby.michael@gmail.com>
 Mikhail Sobolev <mss@mawhrin.net>

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 GIT_COMMIT = $(shell git rev-parse --short HEAD)
 GIT_STATUS = $(shell test -n "`git status --porcelain`" && echo "+CHANGES")
 
-BUILD_OPTIONS = -ldflags "-X main.GIT_COMMIT $(GIT_COMMIT)$(GIT_STATUS)"
+BUILD_OPTIONS = -ldflags "-X main.GITCOMMIT $(GIT_COMMIT)$(GIT_STATUS)"
 
 SRC_DIR := $(GOPATH)/src
 


### PR DESCRIPTION
A small patch, which shows the git commit version again, after the change fd224ee590dc9f003f6507b529a9f47cceb02c44 has been made.
