### PR TITLE
Fix for issue #923 (replace `ifconfig` in docs with `iproute`).

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ PORT=$(docker port $JOB 4444)
 
 # Connect to the public port via the host's public address
 # Please note that because of how routing works connecting to localhost or 127.0.0.1 $PORT will not work.
-IP=$(ifconfig eth0 | perl -n -e 'if (m/inet addr:([\d\.]+)/g) { print $1 }')
+# Replace *eth0* according to your local interface name.
+IP=$(ip -o -4 addr list eth0 | perl -n -e 'if (m{inet\s([\d\.]+)\/\d+\s}xms) { print $1 }')
 echo hello world | nc $IP $PORT
 
 # Verify that the network connection worked

--- a/docs/sources/examples/running_redis_service.rst
+++ b/docs/sources/examples/running_redis_service.rst
@@ -72,7 +72,7 @@ Connect to the host os with the redis-cli.
 
     docker ps  # grab the new container id
     docker port <container_id> 6379  # grab the external port
-    ifconfig   # grab the host ip address
+    ip a s   # grab the host ip address
     redis-cli -h <host ipaddress> -p <external port>
     redis 192.168.0.1:49153> set docker awesome
     OK

--- a/docs/sources/examples/running_redis_service.rst
+++ b/docs/sources/examples/running_redis_service.rst
@@ -72,7 +72,7 @@ Connect to the host os with the redis-cli.
 
     docker ps  # grab the new container id
     docker port <container_id> 6379  # grab the external port
-    ip a s   # grab the host ip address
+    ip addr show   # grab the host ip address
     redis-cli -h <host ipaddress> -p <external port>
     redis 192.168.0.1:49153> set docker awesome
     OK

--- a/docs/sources/examples/running_ssh_service.rst
+++ b/docs/sources/examples/running_ssh_service.rst
@@ -59,7 +59,7 @@ The password is 'screencast'
 	 # it has now given us a port to connect to
 	 # we have to connect using a public ip of our host
 	 $ hostname
-	 # *ifconfig* is deprecated, better use *ip a s* now
+	 # *ifconfig* is deprecated, better use *ip addr show* now
 	 $ ifconfig
 	 $ ssh root@192.168.33.10 -p 49153
 	 # Ah! forgot to set root passwd
@@ -71,7 +71,7 @@ The password is 'screencast'
 	 $ docker commit 9e863f0ca0af31c8b951048ba87641d67c382d08d655c2e4879c51410e0fedc1 dhrp/sshd
 	 $ docker run -d -p 22 dhrp/sshd /usr/sbin/sshd -D
 	 $ docker port a0aaa9558c90cf5c7782648df904a82365ebacce523e4acc085ac1213bfe2206 22
-	 # *ifconfig* is deprecated, better use *ip a s* now
+	 # *ifconfig* is deprecated, better use *ip addr show* now
 	 $ ifconfig
 	 $ ssh root@192.168.33.10 -p 49154
 	 # Thanks for watching, Thatcher thatcher@dotcloud.com

--- a/docs/sources/examples/running_ssh_service.rst
+++ b/docs/sources/examples/running_ssh_service.rst
@@ -59,6 +59,7 @@ The password is 'screencast'
 	 # it has now given us a port to connect to
 	 # we have to connect using a public ip of our host
 	 $ hostname
+	 # *ifconfig* is deprecated, better use *ip a s* now
 	 $ ifconfig
 	 $ ssh root@192.168.33.10 -p 49153
 	 # Ah! forgot to set root passwd
@@ -70,6 +71,7 @@ The password is 'screencast'
 	 $ docker commit 9e863f0ca0af31c8b951048ba87641d67c382d08d655c2e4879c51410e0fedc1 dhrp/sshd
 	 $ docker run -d -p 22 dhrp/sshd /usr/sbin/sshd -D
 	 $ docker port a0aaa9558c90cf5c7782648df904a82365ebacce523e4acc085ac1213bfe2206 22
+	 # *ifconfig* is deprecated, better use *ip a s* now
 	 $ ifconfig
 	 $ ssh root@192.168.33.10 -p 49154
 	 # Thanks for watching, Thatcher thatcher@dotcloud.com

--- a/docs/sources/use/basics.rst
+++ b/docs/sources/use/basics.rst
@@ -82,7 +82,8 @@ Expose a service on a TCP port
 
   # Connect to the public port via the host's public address
   # Please note that because of how routing works connecting to localhost or 127.0.0.1 $PORT will not work.
-  IP=$(ifconfig eth0 | perl -n -e 'if (m/inet addr:([\d\.]+)/g) { print $1 }')
+  # Replace *eth0* according to your local interface name.
+  IP=$(ip -o -4 addr list eth0 | perl -n -e 'if (m{inet\s([\d\.]+)\/\d+\s}xms) { print $1 }')
   echo hello world | nc $IP $PORT
 
   # Verify that the network connection worked


### PR DESCRIPTION
Fixed #923 by replacing the usage of 'ifconfig' with 'ip a' where appropriate and added a note to use 'ip a' instead of 'ifconfig' for a screencast transscript.
