### PR TITLE
Nicer output for 'docker build'

### DIFF
--- a/FIXME
+++ b/FIXME
@@ -16,7 +16,6 @@ to put them - so we put them here :)
 * Unify build commands and regular commands
 * Move source code into src/ subdir for clarity
 * Clean up the Makefile, it's a mess
-* docker buidl: show short IDs
 * docker build: on non-existent local path for ADD, don't show full absolute path on the host
 * mount into /dockerinit rather than /sbin/init
 * docker tag foo REPO:TAG

--- a/buildfile.go
+++ b/buildfile.go
@@ -101,6 +101,7 @@ func (b *buildFile) CmdRun(args string) error {
 	if cache, err := b.srv.ImageGetCached(b.image, b.config); err != nil {
 		return err
 	} else if cache != nil {
+		fmt.Fprintf(b.out, " ---> Using cache\n")
 		utils.Debugf("[BUILDER] Use cached version")
 		b.image = cache.ID
 		return nil
@@ -185,6 +186,7 @@ func (b *buildFile) CmdAdd(args string) error {
 		return err
 	}
 	b.tmpContainers[container.ID] = struct{}{}
+	fmt.Fprintf(b.out, " ---> Running in %s\n", utils.TruncateID(container.ID))
 
 	if err := container.EnsureMounted(); err != nil {
 		return err
@@ -235,6 +237,7 @@ func (b *buildFile) run() (string, error) {
 		return "", err
 	}
 	b.tmpContainers[c.ID] = struct{}{}
+	fmt.Fprintf(b.out, " ---> Running in %s\n", utils.TruncateID(c.ID))
 
 	//start the container
 	if err := c.Start(); err != nil {
@@ -261,6 +264,7 @@ func (b *buildFile) commit(id string, autoCmd []string, comment string) error {
 		if cache, err := b.srv.ImageGetCached(b.image, b.config); err != nil {
 			return err
 		} else if cache != nil {
+			fmt.Fprintf(b.out, " ---> Using cache\n")
 			utils.Debugf("[BUILDER] Use cached version")
 			b.image = cache.ID
 			return nil
@@ -274,6 +278,7 @@ func (b *buildFile) commit(id string, autoCmd []string, comment string) error {
 			return err
 		}
 		b.tmpContainers[container.ID] = struct{}{}
+		fmt.Fprintf(b.out, " ---> Running in %s\n", utils.TruncateID(container.ID))
 
 		if err := container.EnsureMounted(); err != nil {
 			return err
@@ -314,6 +319,7 @@ func (b *buildFile) Build(dockerfile, context io.Reader) (string, error) {
 		b.context = name
 	}
 	file := bufio.NewReader(dockerfile)
+	stepN := 0
 	for {
 		line, err := file.ReadString('\n')
 		if err != nil {
@@ -334,12 +340,13 @@ func (b *buildFile) Build(dockerfile, context io.Reader) (string, error) {
 		}
 		instruction := strings.ToLower(strings.Trim(tmp[0], " "))
 		arguments := strings.Trim(tmp[1], " ")
-
-		fmt.Fprintf(b.out, "%s %s (%s)\n", strings.ToUpper(instruction), arguments, b.image)
+		stepN += 1
+		// FIXME: only count known instructions as build steps
+		fmt.Fprintf(b.out, "Step %d : %s %s\n", stepN, strings.ToUpper(instruction), arguments)
 
 		method, exists := reflect.TypeOf(b).MethodByName("Cmd" + strings.ToUpper(instruction[:1]) + strings.ToLower(instruction[1:]))
 		if !exists {
-			fmt.Fprintf(b.out, "Skipping unknown instruction %s\n", strings.ToUpper(instruction))
+			fmt.Fprintf(b.out, "# Skipping unknown instruction %s\n", strings.ToUpper(instruction))
 			continue
 		}
 		ret := method.Func.Call([]reflect.Value{reflect.ValueOf(b), reflect.ValueOf(arguments)})[0].Interface()
@@ -347,10 +354,10 @@ func (b *buildFile) Build(dockerfile, context io.Reader) (string, error) {
 			return "", ret.(error)
 		}
 
-		fmt.Fprintf(b.out, "===> %v\n", b.image)
+		fmt.Fprintf(b.out, " ---> %v\n", utils.TruncateID(b.image))
 	}
 	if b.image != "" {
-		fmt.Fprintf(b.out, "Build successful.\n===> %s\n", b.image)
+		fmt.Fprintf(b.out, "Successfully built %s\n", utils.TruncateID(b.image))
 		return b.image, nil
 	}
 	return "", fmt.Errorf("An error occured during the build\n")

--- a/docs/sources/use/builder.rst
+++ b/docs/sources/use/builder.rst
@@ -15,10 +15,18 @@ steps and commit them along the way, giving you a final image.
 1. Usage
 ========
 
-To use Docker Builder, assemble the steps into a text file (commonly referred to
-as a Dockerfile) and supply this to `docker build` on STDIN, like so:
+To build an image from a source repository, create a description file called `Dockerfile`
+at the root of your repository. This file will describe the steps to assemble
+the image.
 
-    ``docker build - < Dockerfile``
+Then call `docker build` with the path of your source repository as argument:
+
+    ``docker build .``
+
+You can specify a repository and tag at which to save the new image if the
+build succeeds:
+
+    ``docker build -t shykes/myapp .``
 
 Docker will run your steps one-by-one, committing the result if necessary, 
 before finally outputting the ID of your new image.


### PR DESCRIPTION
``` bash
$ docker build .
Caching Context 20480/? (n/a)
Step 1 : FROM ubuntu:12.10
 ---> b750fe79269d
Step 2 : RUN apt-get update
 ---> Using cache
 ---> 3e11a97c3f82
Step 3 : RUN apt-get install -q -y znc
 ---> Using cache
 ---> 9dc7a7486e87
Step 4 : ADD . /src
 ---> Running in cd485a64f4e5
 ---> e5c7a600f55f
Step 5 : RUN cd /src && chmod +x zncrun && cp zncrun /usr/local/bin/
 ---> Running in 4364147033ee
 ---> 530281523792
Step 6 : RUN mkdir /.znc && chown irc: /.znc
 ---> Running in 55cbeda6cfea
 ---> 3bc2659ff2cf
Step 7 : EXPOSE 6667
 ---> Running in 1c98533d0fb8
 ---> 9a0c13d994e3
Step 8 : CMD ["zncrun"]
 ---> Running in d0d676825465
 ---> 1131036da4b5
Successfully built 1131036da4b5
```

Note: the "caching context" line is still ugly, but is being fixed in a different PR.
