### PR TITLE
dockerbuilder : batch apt-get install operations for speed

### DIFF
--- a/hack/dockerbuilder/Dockerfile
+++ b/hack/dockerbuilder/Dockerfile
@@ -19,19 +19,14 @@ run	add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) 
 run	add-apt-repository -y ppa:dotcloud/docker-golang/ubuntu
 run	apt-get update
 # Packages required to checkout, build and upload docker
-run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q s3cmd
-run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q curl
+run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q s3cmd curl
 run	curl -s -o /go.tar.gz https://go.googlecode.com/files/go1.1.1.linux-amd64.tar.gz
 run	tar -C /usr/local -xzf /go.tar.gz
 run	echo "export PATH=/usr/local/go/bin:$PATH" > /.bashrc
 run	echo "export PATH=/usr/local/go/bin:$PATH" > /.bash_profile
-run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q git
-run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q build-essential
+run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q git build-essential
 # Packages required to build an ubuntu package
-run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q golang-stable
-run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q debhelper
-run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q autotools-dev
-run	apt-get install -y -q devscripts
+run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q golang-stable debhelper autotools-dev devscripts
 # Copy dockerbuilder files into the container
 add	.       /src
 run	cp /src/dockerbuilder /usr/local/bin/ && chmod +x /usr/local/bin/dockerbuilder


### PR DESCRIPTION
The dockerbuilder Dockerfile was installing one package per apt-get install operation.

This PR changes it so that consecutive run apt-get install operations are batched into a single operation.

With these changes, the dockerbuilder image gets built in 2 minutes and 25 seconds. It gets built in 3 minutes without these changes.

Here are the logs of two runs showing how long it took to build the image without and with these changes:

```
time docker build -t big-dockerfile $PWD
Caching Context 10240/? (n/a)
FROM ubuntu:12.04 ()
===> 8dbd9e392a964056420e5d58ca5cc376ef18e2de93b5cc90e868a1bbc8318c1c
MAINTAINER Solomon Hykes <solomon@dotcloud.com> (8dbd9e392a964056420e5d58ca5cc376ef18e2de93b5cc90e868a1bbc8318c1c)
===> 753b36355429bdfa033747455ead9699e40e5fe4dabb50f13b27ff1d1cf754db
RUN dpkg-divert --local --rename --add /sbin/initctl (753b36355429bdfa033747455ead9699e40e5fe4dabb50f13b27ff1d1cf754db)
===> 142ef542efbb976d2a461f6762dbd6a092031aafc6d80a4243970402011a4950
RUN ln -s /bin/true /sbin/initctl (142ef542efbb976d2a461f6762dbd6a092031aafc6d80a4243970402011a4950)
===> 6c2f1f6dd4aba49c32be8438525eae23d8a1ef1895944590e235db5e81902cad
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q python-software-properties (6c2f1f6dd4aba49c32be8438525eae23d8a1ef1895944590e235db5e81902cad)
===> bc3c5f907592401ff134a7d3ccc7582e555e03fff53c43ab6eebe7cf224e5716
RUN add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe" (bc3c5f907592401ff134a7d3ccc7582e555e03fff53c43ab6eebe7cf224e5716)
===> c5b94555c34441be73f57c731723a7eab1c11102f6584b73c09e3f1df6136d00
RUN add-apt-repository -y ppa:dotcloud/docker-golang/ubuntu (c5b94555c34441be73f57c731723a7eab1c11102f6584b73c09e3f1df6136d00)
===> ccd8ea74a7bd02d641ebdbba03d3b3119471f65b0bfeb677b87a3a13342a9c59
RUN apt-get update (ccd8ea74a7bd02d641ebdbba03d3b3119471f65b0bfeb677b87a3a13342a9c59)
===> 7a13348943e6f75cba71b6f8fe1fa21e680052650764eaa7c8d16c546f4d128d
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q s3cmd (7a13348943e6f75cba71b6f8fe1fa21e680052650764eaa7c8d16c546f4d128d)
===> 8d646a3fad094b1d16ac8653b4c80b41844e9c376227ef6eb33606c3a2fcfc55
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q curl (8d646a3fad094b1d16ac8653b4c80b41844e9c376227ef6eb33606c3a2fcfc55)
===> 83ce7eac38743324b8a359286041b797b2d5b86b26589246a330e36524413162
RUN curl -s -o /go.tar.gz https://go.googlecode.com/files/go1.1.1.linux-amd64.tar.gz (83ce7eac38743324b8a359286041b797b2d5b86b26589246a330e36524413162)
===> 2994aef48dca8f19b736bcdbb29eb2f564d436a6fd4cfe5a7b94ce7370a5b649
RUN tar -C /usr/local -xzf /go.tar.gz (2994aef48dca8f19b736bcdbb29eb2f564d436a6fd4cfe5a7b94ce7370a5b649)
===> cf64503367a8eacedcabbd84618db59d7fc5dfc0014a1282bc7792f9cd24f768
RUN echo "export PATH=/usr/local/go/bin:$PATH" > /.bashrc (cf64503367a8eacedcabbd84618db59d7fc5dfc0014a1282bc7792f9cd24f768)
===> e5c52d35134a7fe54a787bc4b7693ee2dcb8b560eac5e1884605e169ed925217
RUN echo "export PATH=/usr/local/go/bin:$PATH" > /.bash_profile (e5c52d35134a7fe54a787bc4b7693ee2dcb8b560eac5e1884605e169ed925217)
===> 2f74c5206fff5af5ac9cb41a3a5e5e1265f80e587033c0c56aa720fd2cd53168
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q git (2f74c5206fff5af5ac9cb41a3a5e5e1265f80e587033c0c56aa720fd2cd53168)
===> feb10288044b6e753469dbcad76bc6b8d0bc840e93eeeba14ae11be331e81f57
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q build-essential (feb10288044b6e753469dbcad76bc6b8d0bc840e93eeeba14ae11be331e81f57)
===> 56d28a456209579af1ce41189668d37f6bb51c2870686480e1d3135c6245d975
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q golang-stable (56d28a456209579af1ce41189668d37f6bb51c2870686480e1d3135c6245d975)
===> e118a8398d9684ca5fa6ec775d0e5c15a36d4517e2e4c85524d9806ea5451b08
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q debhelper (e118a8398d9684ca5fa6ec775d0e5c15a36d4517e2e4c85524d9806ea5451b08)
===> e98cc1943ca911a95616c8291df05ba11128f5263e73df3a727b7d3850da5535
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q autotools-dev (e98cc1943ca911a95616c8291df05ba11128f5263e73df3a727b7d3850da5535)
===> 53bbd7d99967e5bb1c2610401b796d68e647083a1b5f335392248692c60bb416
RUN apt-get install -y -q devscripts (53bbd7d99967e5bb1c2610401b796d68e647083a1b5f335392248692c60bb416)
===> d767c5ba72ce53b6317681cc846af91ae5644b6dcbb6a6c3110522211ab907e6
ADD .       /src (d767c5ba72ce53b6317681cc846af91ae5644b6dcbb6a6c3110522211ab907e6)
===> 06c526fa0b80c72bc1ff270e3d1b5254774f4a4684036a3652aa015d2e24fd82
RUN cp /src/dockerbuilder /usr/local/bin/ && chmod +x /usr/local/bin/dockerbuilder (06c526fa0b80c72bc1ff270e3d1b5254774f4a4684036a3652aa015d2e24fd82)
===> 7f8d5d3ab94f2378a636f3acb71d37424d864105de4bea9bcc0937d78b3a5428
CMD ["dockerbuilder"] (7f8d5d3ab94f2378a636f3acb71d37424d864105de4bea9bcc0937d78b3a5428)
===> 183ba46f59c2a75b09fe2484620748393f2670455af85cb3e90d286f4080257f
Build successful.
===> 183ba46f59c2a75b09fe2484620748393f2670455af85cb3e90d286f4080257f

real    3m0.092s
user    0m0.048s
sys     0m0.028s


time docker build -t new-dockerfile $PWD
Caching Context 10240/? (n/a)
FROM ubuntu:12.04 ()
===> 8dbd9e392a964056420e5d58ca5cc376ef18e2de93b5cc90e868a1bbc8318c1c
MAINTAINER Solomon Hykes <solomon@dotcloud.com> (8dbd9e392a964056420e5d58ca5cc376ef18e2de93b5cc90e868a1bbc8318c1c)
===> 87d2d4558531bc1252cb05fd9e628135ae60c703e3259361248fffd51b6cf2b1
RUN dpkg-divert --local --rename --add /sbin/initctl (87d2d4558531bc1252cb05fd9e628135ae60c703e3259361248fffd51b6cf2b1)
===> 219472237395d70ebac62f3d040be980c67d4057a0d5df5cefda669493e09ec0
RUN ln -s /bin/true /sbin/initctl (219472237395d70ebac62f3d040be980c67d4057a0d5df5cefda669493e09ec0)
===> 63119609f99febde92161bb839a88c5edf1a25ba9606cc245185ceee78e8e5b0
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q python-software-properties (63119609f99febde92161bb839a88c5edf1a25ba9606cc245185ceee78e8e5b0)
===> 56258f2980f558675578cf495ab247f35fa89feff3eae1a86a2eb6facdac274c
RUN add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc) universe" (56258f2980f558675578cf495ab247f35fa89feff3eae1a86a2eb6facdac274c)
===> 8717b112915c28d0aa51b2dd58c74557644b917269fea215b3d5bc97d5a35789
RUN add-apt-repository -y ppa:dotcloud/docker-golang/ubuntu (8717b112915c28d0aa51b2dd58c74557644b917269fea215b3d5bc97d5a35789)
===> 5453b0d33d6723bc94edc99c327d7b297620a40b4ba84d0664dd6bc75a729b6b
RUN apt-get update (5453b0d33d6723bc94edc99c327d7b297620a40b4ba84d0664dd6bc75a729b6b)
===> c8cee11ae90ef5b95e7f43353b02c7bb73bf89546ddbfaa4ac068c56ae720e8d
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q s3cmd curl (c8cee11ae90ef5b95e7f43353b02c7bb73bf89546ddbfaa4ac068c56ae720e8d)
===> a14e368133abf3888e90fc9f606bb8e7a12155238526948c639147b93f9cb0aa
RUN curl -s -o /go.tar.gz https://go.googlecode.com/files/go1.1.1.linux-amd64.tar.gz (a14e368133abf3888e90fc9f606bb8e7a12155238526948c639147b93f9cb0aa)
===> 8deff25bf92f4988024f3448b8e5599e3a004f2870aef4418264c748b098fa7d
RUN tar -C /usr/local -xzf /go.tar.gz (8deff25bf92f4988024f3448b8e5599e3a004f2870aef4418264c748b098fa7d)
===> 43958203a9fcee534c3a54f0c9c61d2d10998db0ed50854329b6aeaaf001fb0e
RUN echo "export PATH=/usr/local/go/bin:$PATH" > /.bashrc (43958203a9fcee534c3a54f0c9c61d2d10998db0ed50854329b6aeaaf001fb0e)
===> aeec44b63808d7bf2ca8816a0217cee2990463b26c8cc055350a023adc028acb
RUN echo "export PATH=/usr/local/go/bin:$PATH" > /.bash_profile (aeec44b63808d7bf2ca8816a0217cee2990463b26c8cc055350a023adc028acb)
===> 3b73984b38ba2d70ae7a8124b696492d146030de31acf37209902363a0d25e5c
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q git build-essential (3b73984b38ba2d70ae7a8124b696492d146030de31acf37209902363a0d25e5c)
===> d2357003d5fd1f1c854452b4b9443f4263f124f896396d524fd091285b93ef67
RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q golang-stable debhelper autotools-dev devscripts (d2357003d5fd1f1c854452b4b9443f4263f124f896396d524fd091285b93ef67)
===> 57941a5416eda0e6e3e63c95107f03f1d2c6729eec759858da4204a2dffc000b
ADD .       /src (57941a5416eda0e6e3e63c95107f03f1d2c6729eec759858da4204a2dffc000b)
===> 48b4e22db6170fc4abad1b2609b601767f20a2ce8db786066876ebea1e43319d
RUN cp /src/dockerbuilder /usr/local/bin/ && chmod +x /usr/local/bin/dockerbuilder (48b4e22db6170fc4abad1b2609b601767f20a2ce8db786066876ebea1e43319d)
===> be50ba5af3c7bca9960f451f24b2203a7d70ba127a0a7da40c2d4cc08383c077
CMD ["dockerbuilder"] (be50ba5af3c7bca9960f451f24b2203a7d70ba127a0a7da40c2d4cc08383c077)
===> b693932f2119f642a1b25389468c48556771f2d656c50961576f7a53b4eac582
Build successful.
===> b693932f2119f642a1b25389468c48556771f2d656c50961576f7a53b4eac582

real    2m25.453s
user    0m0.024s
sys     0m0.008s
```
