### PR TITLE
Use opaque requests when we need to preserve urlencoding in registry requests

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -156,7 +156,7 @@ func (r *Registry) GetRemoteTags(registries []string, repository string, token [
 	}
 	for _, host := range registries {
 		endpoint := fmt.Sprintf("https://%s/v1/repositories/%s/tags", host, repository)
-		req, err := http.NewRequest("GET", endpoint, nil)
+		req, err := r.opaqueRequest("GET", endpoint, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -190,7 +190,7 @@ func (r *Registry) GetRemoteTags(registries []string, repository string, token [
 func (r *Registry) GetRepositoryData(remote string) (*RepositoryData, error) {
 	repositoryTarget := auth.IndexServerAddress() + "/repositories/" + remote + "/images"
 
-	req, err := http.NewRequest("GET", repositoryTarget, nil)
+	req, err := r.opaqueRequest("GET", repositoryTarget, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -309,6 +309,15 @@ func (r *Registry) PushImageLayerRegistry(imgId string, layer io.Reader, registr
 	return nil
 }
 
+func (r *Registry) opaqueRequest(method, urlStr string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, urlStr, body)
+	if err != nil {
+		return nil, err
+	}
+	req.URL.Opaque = strings.Replace(urlStr, req.URL.Scheme + ":", "", 1)
+	return req, err
+}
+
 // push a tag on the registry.
 // Remote has the format '<user>/<repo>
 func (r *Registry) PushRegistryTag(remote, revision, tag, registry string, token []string) error {
@@ -316,7 +325,7 @@ func (r *Registry) PushRegistryTag(remote, revision, tag, registry string, token
 	revision = "\"" + revision + "\""
 	registry = "https://" + registry + "/v1"
 
-	req, err := http.NewRequest("PUT", registry+"/repositories/"+remote+"/tags/"+tag, strings.NewReader(revision))
+	req, err := r.opaqueRequest("PUT", registry+"/repositories/"+remote+"/tags/"+tag, strings.NewReader(revision))
 	if err != nil {
 		return err
 	}
@@ -346,7 +355,7 @@ func (r *Registry) PushImageJSONIndex(remote string, imgList []*ImgData, validat
 
 	utils.Debugf("Image list pushed to index:\n%s\n", imgListJSON)
 
-	req, err := http.NewRequest("PUT", auth.IndexServerAddress()+"/repositories/"+remote+"/"+suffix, bytes.NewReader(imgListJSON))
+	req, err := r.opaqueRequest("PUT", auth.IndexServerAddress()+"/repositories/"+remote+"/"+suffix, bytes.NewReader(imgListJSON))
 	if err != nil {
 		return nil, err
 	}
@@ -366,7 +375,7 @@ func (r *Registry) PushImageJSONIndex(remote string, imgList []*ImgData, validat
 	// Redirect if necessary
 	for res.StatusCode >= 300 && res.StatusCode < 400 {
 		utils.Debugf("Redirected to %s\n", res.Header.Get("Location"))
-		req, err = http.NewRequest("PUT", res.Header.Get("Location"), bytes.NewReader(imgListJSON))
+		req, err = r.opaqueRequest("PUT", res.Header.Get("Location"), bytes.NewReader(imgListJSON))
 		if err != nil {
 			return nil, err
 		}

--- a/server.go
+++ b/server.go
@@ -532,7 +532,7 @@ func (srv *Server) pushRepository(r *registry.Registry, out io.Writer, name stri
 				// FIXME: Continue on error?
 				return err
 			}
-			out.Write(sf.FormatStatus("Pushing tags for rev [%s] on {%s}", elem.ID, ep+"/users/"+srvName+"/"+elem.Tag))
+			out.Write(sf.FormatStatus("Pushing tags for rev [%s] on {%s}", elem.ID, ep+"/repositories/"+srvName+"/tags/"+elem.Tag))
 			if err := r.PushRegistryTag(srvName, elem.ID, elem.Tag, ep, repoData.Tokens); err != nil {
 				return err
 			}


### PR DESCRIPTION
Go decodes the URL path when creating a request, which is something we don't want (related to highland developement). 
http://tip.golang.org/pkg/net/url/#URL
