### PR TITLE
There is no package called "golang-stable" in any upstream Debian/Ubuntu repository

### DIFF
--- a/packaging/ubuntu/control
+++ b/packaging/ubuntu/control
@@ -2,7 +2,7 @@ Source: lxc-docker
 Section: misc
 Priority: extra
 Maintainer: Daniel Mizyrycki <daniel@dotcloud.com>
-Build-Depends: debhelper,autotools-dev,devscripts,golang-stable
+Build-Depends: debhelper,autotools-dev,devscripts,golang
 Standards-Version: 3.9.3
 Homepage: http://github.com/dotcloud/docker
 


### PR DESCRIPTION
...change it to "golang"

http://packages.debian.org/search?keywords=golang
http://packages.ubuntu.com/search?keywords=golang
