### PR TITLE
Add configuration file into /etc/default/ for ubuntu and debian packages

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Andy Smith <github@anarkystic.com>
 Antony Messerli <amesserl@rackspace.com>
 Barry Allard <barry.allard@gmail.com>
 Brandon Liu <bdon@bdon.org>
+Brian Gehrich <brian-docker.io@rustproof.org>
 Brian McCallister <brianm@skife.org>
 Bruno Bigras <bigras.bruno@gmail.com>
 Caleb Spare <cespare@gmail.com>

--- a/packaging/debian/lxc-docker.default
+++ b/packaging/debian/lxc-docker.default
@@ -1,0 +1,4 @@
+# configuration file for docker (http://docker.io)
+# this file is sourced by /etc/init.d/lxc-docker
+#
+

--- a/packaging/debian/lxc-docker.init
+++ b/packaging/debian/lxc-docker.init
@@ -15,6 +15,9 @@ DOCKER=/usr/bin/lxc-docker
 # Check lxc-docker is present
 [ -x $DOCKER ] || (log_failure_msg "lxc-docker not present"; exit 1)
 
+# source /etc/default/lxc-docker, if it exists
+[ -r /etc/default/lxc-docker ] && . /etc/default/lxc-docker
+
 PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
 
 # Get lsb functions

--- a/packaging/ubuntu/Makefile
+++ b/packaging/ubuntu/Makefile
@@ -24,6 +24,7 @@ install:
 	mkdir -p ${DESTDIR}/DEBIAN
 	install -m 0755 src/${GITHUB_PATH}/docker/docker ${DESTDIR}/usr/bin
 	install -o root -m 0755 debian/docker.upstart ${DESTDIR}/etc/init/docker.conf
+	install -o root -m 0644 debian/docker.default ${DESTDIR}/etc/default/docker
 	install debian/lxc-docker.prerm ${DESTDIR}/DEBIAN/prerm
 	install debian/lxc-docker.postinst ${DESTDIR}/DEBIAN/postinst
 

--- a/packaging/ubuntu/docker.default
+++ b/packaging/ubuntu/docker.default
@@ -1,0 +1,4 @@
+# configuration file for docker (http://docker.io)
+# this file is sourced by the docker upstart script in /etc/init/docker.conf
+#
+

--- a/packaging/ubuntu/docker.upstart
+++ b/packaging/ubuntu/docker.upstart
@@ -5,5 +5,8 @@ stop on starting rc RUNLEVEL=[016]
 respawn
 
 script
+    # source /etc/default/docker, if it exists
+    [ -r /etc/default/docker ] && . /etc/default/docker
+
     /usr/bin/docker -d
 end script


### PR DESCRIPTION
This PR is based on a small change that I have found useful in my local environment.  Like what is used in many other ubuntu/debian packages, I have created a /etc/default/docker configuration file that is sourced by a modified version of the upstart script.  This allows me to properly setup the environment for the docker daemon to run.  Specifically, I use this to setup custom proxy variables for docker to use.

While I am not currently using the debian package, I have made similar changes to it as well.

If you find this PR contains something docker would benefit from, please feel free to take the patch as-is, or make any necessary changes.  All of my changes are noted in the commit message.
