### PR TITLE
use --numeric-owner for Tar and Untar

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -92,7 +92,7 @@ func Tar(path string, compression Compression) (io.Reader, error) {
 // Tar creates an archive from the directory at `path`, only including files whose relative
 // paths are included in `filter`. If `filter` is nil, then all files are included.
 func TarFilter(path string, compression Compression, filter []string) (io.Reader, error) {
-	args := []string{"tar", "-f", "-", "-C", path}
+	args := []string{"tar", "--numeric-owner", "-f", "-", "-C", path}
 	if filter == nil {
 		filter = []string{"."}
 	}
@@ -118,7 +118,7 @@ func Untar(archive io.Reader, path string) error {
 
 	utils.Debugf("Archive compression detected: %s", compression.Extension())
 
-	cmd := exec.Command("tar", "-f", "-", "-C", path, "-x"+compression.Flag())
+	cmd := exec.Command("tar", "--numeric-owner", "-f", "-", "-C", path, "-x"+compression.Flag())
 	cmd.Stdin = bufferedArchive
 	// Hardcode locale environment for predictable outcome regardless of host configuration.
 	//   (see https://github.com/dotcloud/docker/issues/355)


### PR DESCRIPTION
This issue was first discovered in #791. When a docker image is exported and imported again, the users and groups can get messed up.
The right thing to do is to not try and use the host's user to user id and group to group id mappings and just use the numeric values.

Using dokku's buildstep, I've tried to import it and start pgsql in a container run from the imported image.
It complained that user id 112 doesn't exist.

`--numeric-owner` was added both to compression and decompression. That should ensure everything is OK.

The tests are passing and no extra tests are needed.
