### PR TITLE
Fix a bug which caused creation of empty images (and volumes) to crash.

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -108,7 +108,9 @@ func TarFilter(path string, compression Compression, filter []string) (io.Reader
 //  identity (uncompressed), gzip, bzip2, xz.
 // FIXME: specify behavior when target path exists vs. doesn't exist.
 func Untar(archive io.Reader, path string) error {
-
+	if archive == nil {
+		return fmt.Errorf("Empty archive")
+	}
 	bufferedArchive := bufio.NewReaderSize(archive, 10)
 	buf, err := bufferedArchive.Peek(10)
 	if err != nil {

--- a/container_test.go
+++ b/container_test.go
@@ -556,6 +556,30 @@ func TestKillDifferentUser(t *testing.T) {
 	}
 }
 
+// Test that creating a container with a volume doesn't crash. Regression test for #995.
+func TestCreateVolume(t *testing.T) {
+	runtime, err := newTestRuntime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nuke(runtime)
+
+	config, _, err := ParseRun([]string{"-v", "/var/lib/data", GetTestImage(runtime).ID, "echo", "hello", "world"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	c, err := NewBuilder(runtime).Create(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.Destroy(c)
+	if err := c.Start(); err != nil {
+		t.Fatal(err)
+	}
+	c.WaitTimeout(500 * time.Millisecond)
+	c.Wait()
+}
+
 func TestKill(t *testing.T) {
 	runtime, err := newTestRuntime()
 	if err != nil {

--- a/image.go
+++ b/image.go
@@ -92,9 +92,11 @@ func StoreImage(img *Image, layerData Archive, root string, store bool) error {
 		defer file.Close()
 		layerData = file
 	}
-
-	if err := Untar(layerData, layer); err != nil {
-		return err
+	// If layerData is not nil, unpack it into the new layer
+	if layerData != nil {
+		if err := Untar(layerData, layer); err != nil {
+			return err
+		}
 	}
 
 	return StoreSize(img, root)


### PR DESCRIPTION
Fixes #995.
