### PR TITLE
Add ENTRYPOINT instruction to allow args and omit the cmd for docker run

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -50,12 +50,23 @@ func (builder *Builder) Create(config *Config) (*Container, error) {
 		config.Hostname = id[:12]
 	}
 
+	var args []string
+	var entrypoint string
+
+	if len(config.Entrypoint) != 0 {
+		entrypoint = config.Entrypoint[0]
+		args = append(config.Entrypoint[1:], config.Cmd...)
+	} else {
+		entrypoint = config.Cmd[0]
+		args = config.Cmd[1:]
+	}
+
 	container := &Container{
 		// FIXME: we should generate the ID here instead of receiving it as an argument
 		ID:              id,
 		Created:         time.Now(),
-		Path:            config.Cmd[0],
-		Args:            config.Cmd[1:], //FIXME: de-duplicate from config
+		Path:            entrypoint,
+		Args:            args, //FIXME: de-duplicate from config
 		Config:          config,
 		Image:           img.ID, // Always use the resolved image id
 		NetworkSettings: &NetworkSettings{},

--- a/buildfile.go
+++ b/buildfile.go
@@ -141,7 +141,7 @@ func (b *buildFile) CmdEnv(args string) error {
 func (b *buildFile) CmdCmd(args string) error {
 	var cmd []string
 	if err := json.Unmarshal([]byte(args), &cmd); err != nil {
-		utils.Debugf("Error unmarshalling: %s, using /bin/sh -c", err)
+		utils.Debugf("Error unmarshalling: %s, setting cmd to /bin/sh -c", err)
 		cmd = []string{"/bin/sh", "-c", args}
 	}
 	if err := b.commit("", cmd, fmt.Sprintf("CMD %v", cmd)); err != nil {
@@ -163,6 +163,23 @@ func (b *buildFile) CmdInsert(args string) error {
 
 func (b *buildFile) CmdCopy(args string) error {
 	return fmt.Errorf("COPY has been deprecated. Please use ADD instead")
+}
+
+func (b *buildFile) CmdEntrypoint(args string) error {
+	if args == "" {
+		return fmt.Errorf("Entrypoint cannot be empty")
+	}
+
+	var entrypoint []string
+	if err := json.Unmarshal([]byte(args), &entrypoint); err != nil {
+		b.config.Entrypoint = []string{"/bin/sh", "-c", args}
+	} else {
+		b.config.Entrypoint = entrypoint
+	}
+	if err := b.commit("", b.config.Cmd, fmt.Sprintf("ENTRYPOINT %s", args)); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (b *buildFile) addRemote(container *Container, orig, dest string) error {

--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -82,6 +82,15 @@ run    [ "$FOO" = "BAR" ]
 `,
 		nil,
 	},
+
+	{
+		`
+from docker-ut
+ENTRYPOINT /bin/echo
+CMD Hello world
+`,
+		nil,
+	},
 }
 
 // FIXME: test building with 2 successive overlapping ADD commands

--- a/container.go
+++ b/container.go
@@ -76,6 +76,7 @@ type Config struct {
 	Image        string // Name of the image as it was passed by the operator (eg. could be symbolic)
 	Volumes      map[string]struct{}
 	VolumesFrom  string
+	Entrypoint   []string
 }
 
 type HostConfig struct {
@@ -123,6 +124,7 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 	cmd.Var(flVolumes, "v", "Attach a data volume")
 
 	flVolumesFrom := cmd.String("volumes-from", "", "Mount volumes from the specified container")
+	flEntrypoint := cmd.String("entrypoint", "", "Overwrite the default entrypoint of the image")
 
 	var flBinds ListOpts
 	cmd.Var(&flBinds, "b", "Bind mount a volume from the host (e.g. -b /host:/container)")
@@ -153,6 +155,7 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 
 	parsedArgs := cmd.Args()
 	runCmd := []string{}
+	entrypoint := []string{}
 	image := ""
 	if len(parsedArgs) >= 1 {
 		image = cmd.Arg(0)
@@ -160,6 +163,10 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 	if len(parsedArgs) > 1 {
 		runCmd = parsedArgs[1:]
 	}
+	if *flEntrypoint != "" {
+		entrypoint = []string{*flEntrypoint}
+	}
+
 	config := &Config{
 		Hostname:     *flHostname,
 		PortSpecs:    flPorts,
@@ -177,6 +184,7 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 		Image:        image,
 		Volumes:      flVolumes,
 		VolumesFrom:  *flVolumesFrom,
+		Entrypoint:   entrypoint,
 	}
 	hostConfig := &HostConfig{
 		Binds: flBinds,

--- a/container_test.go
+++ b/container_test.go
@@ -1043,6 +1043,32 @@ func TestEnv(t *testing.T) {
 	}
 }
 
+func TestEntrypoint(t *testing.T) {
+	runtime, err := newTestRuntime()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer nuke(runtime)
+	container, err := NewBuilder(runtime).Create(
+		&Config{
+			Image:      GetTestImage(runtime).ID,
+			Entrypoint: []string{"/bin/echo"},
+			Cmd:        []string{"-n", "foobar"},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.Destroy(container)
+	output, err := container.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(output) != "foobar" {
+		t.Error(string(output))
+	}
+}
+
 func grepFile(t *testing.T, path string, pattern string) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/docs/sources/commandline/command/run.rst
+++ b/docs/sources/commandline/command/run.rst
@@ -26,3 +26,4 @@
       -v=[]: Creates a new volume and mounts it at the specified path.
       -volumes-from="": Mount all volumes from the given container.
       -b=[]: Create a bind mount with: [host-dir]:[container-dir]:[rw|ro]
+      -entrypoint="": Overwrite the default entrypoint set by the image.

--- a/docs/sources/use/builder.rst
+++ b/docs/sources/use/builder.rst
@@ -153,6 +153,13 @@ of `<src>` will be written at `<dst>`.
 If `<dest>` doesn't exist, it is created along with all missing directories in its path. All new
 files and directories are created with mode 0700, uid and gid 0.
 
+2.8 ENTRYPOINT
+-------------
+
+    ``ENTRYPOINT /bin/echo``
+
+The `ENTRYPOINT` instruction adds an entry command that will not be overwritten when arguments are passed to docker run, unlike the behavior of `CMD`.  This allows arguments to be passed to the entrypoint.  i.e. `docker run <image> -d` will pass the "-d" argument to the entrypoint.
+
 3. Dockerfile Examples
 ======================
 

--- a/hack/RELEASE.md
+++ b/hack/RELEASE.md
@@ -1,0 +1,119 @@
+## A maintainer's guide to releasing Docker
+
+So you're in charge of a docker release? Cool. Here's what to do.
+
+If your experience deviates from this document, please document the changes to keep it
+up-to-date.
+
+
+### 1. Pull from master and create a release branch
+
+	```bash
+	$ git checkout master
+	$ git pull
+	$ git checkout -b bump_$VERSION
+	```
+
+### 2. Update CHANGELOG.md
+
+	You can run this command for reference:
+
+	```bash
+	LAST_VERSION=$(git tag | grep -E "v[0-9\.]+$" | sort -nr | head -n 1)
+	git log $LAST_VERSION..HEAD
+	```
+
+	Each change should be formatted as ```BULLET CATEGORY: DESCRIPTION```
+
+	* BULLET is either ```-```, ```+``` or ```*```, to indicate a bugfix,
+	new feature or upgrade, respectively.
+
+	* CATEGORY should describe which part of the project is affected.
+	Valid categories are:
+		* Runtime
+		* Remote API
+		* Builder
+		* Documentation
+		* Hack
+
+	* DESCRIPTION: a concise description of the change that is relevant to the end-user,
+	using the present tense.
+	Changes should be described in terms of how they affect the user, for example "new feature
+	X which allows Y", "fixed bug which caused X", "increased performance of Y".
+
+	EXAMPLES:
+
+		```
+		 + Builder: 'docker build -t FOO' applies the tag FOO to the newly built container.
+		 * Runtime: improve detection of kernel version
+		 - Remote API: fix a bug in the optional unix socket transport
+		 ```
+
+### 3. Change VERSION in commands.go
+
+### 4. Run all tests
+
+### 5. Commit and create a pull request
+
+	```bash
+	$ git add commands.go CHANGELOG.md
+	$ git commit -m "Bump version to $VERSION"
+	$ git push origin bump_$VERSION
+	```
+
+### 6. Get 2 other maintainers to validate the pull request
+
+### 7. Merge the pull request and apply tags
+
+	```bash
+	$ git checkout master
+	$ git merge bump_$VERSION
+	$ git tag -a v$VERSION # Don't forget the v!
+	$ git tag -f -a latest
+	$ git push
+	$ git push --tags
+	```
+
+### 8. Publish binaries
+
+	To run this you will need access to the release credentials.
+	Get them from [the infrastructure maintainers](https://github.com/dotcloud/docker/blob/master/hack/infrastructure/MAINTAINERS).
+
+	```bash
+	$ RELEASE_IMAGE=image_provided_by_infrastructure_maintainers
+	$ BUILD=$(docker run -d -e RELEASE_PPA=0 $RELEASE_IMAGE)
+	```
+
+	This will do 2 things:
+	
+	* It will build and upload the binaries on http://get.docker.io
+	* It will *test* the release on our Ubuntu PPA (a PPA is a community repository for ubuntu packages)
+
+	Wait for the build to complete.
+
+	```bash
+	$ docker wait $BUILD # This should print 0. If it doesn't, your build failed.
+	```
+
+	Check that the output looks OK. Here's an example of a correct output:
+
+	```bash
+	$ docker logs 2>&1 b4e7c8299d73 | grep -e 'Public URL' -e 'Successfully uploaded'
+	Public URL of the object is: http://get.docker.io.s3.amazonaws.com/builds/Linux/x86_64/docker-v0.4.7.tgz
+	Public URL of the object is: http://get.docker.io.s3.amazonaws.com/builds/Linux/x86_64/docker-latest.tgz
+	Successfully uploaded packages.
+	```
+
+	If you don't see 3 lines similar to this, something might be wrong. Check the full logs and try again.
+	
+
+### 9. Publish Ubuntu packages
+
+	If everything went well in the previous step, you can finalize the release by submitting the Ubuntu packages.
+
+	```bash
+	$ RELEASE_IMAGE=image_provided_by_infrastructure_maintainers
+	$ docker run -e RELEASE_PPA=1 $RELEASE_IMAGE
+	```
+
+	If that goes well, congratulations! You're done.

--- a/utils.go
+++ b/utils.go
@@ -44,7 +44,11 @@ func CompareConfig(a, b *Config) bool {
 			return false
 		}
 	}
-
+	for i := 0; i < len(a.Entrypoint); i++ {
+		if a.Entrypoint[i] != b.Entrypoint[i] {
+			return false
+		}
+	}
 	return true
 }
 
@@ -84,5 +88,8 @@ func MergeConfig(userConf, imageConf *Config) {
 	}
 	if userConf.Dns == nil || len(userConf.Dns) == 0 {
 		userConf.Dns = imageConf.Dns
+	}
+	if userConf.Entrypoint == nil || len(userConf.Entrypoint) == 0 {
+		userConf.Entrypoint = imageConf.Entrypoint
 	}
 }


### PR DESCRIPTION
This allows a user to set an ENTRYPOINT in the Dockerfile so when the resulting image is ran, the the client can pass args to _docker run_ and not overwrite the ENTRYPOINT, unlike setting a default CMD.

References Issue #1008

Example:

```
FROM ubuntu
RUN apt-get update
ADD test /test
ENTRYPOINT /test
CMD -help

----------------------------
docker run 0f9cb9352c12
-n is required to echo your name.
docker run 0f9cb9352c12 -n="John"
Hello John
```
