### PR TITLE
Basic support for IPv6 addresses

### DIFF
--- a/api.go
+++ b/api.go
@@ -914,7 +914,7 @@ func makeHttpHandler(srv *Server, logging bool, localMethod string, localRoute s
 func createRouter(srv *Server, logging bool) (*mux.Router, error) {
 	r := mux.NewRouter()
 
-	m := map[string]map[string]func(*Server, float64, http.ResponseWriter, *http.Request, map[string]string) error{
+	m := map[string]map[string]HttpApiFunc{
 		"GET": {
 			"/auth":                           getAuth,
 			"/version":                        getVersion,

--- a/api.go
+++ b/api.go
@@ -23,7 +23,6 @@ const DEFAULTHTTPHOST string = "127.0.0.1"
 const DEFAULTHTTPPORT int = 4243
 
 type HttpApiFunc func(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error
-type WsApiFunc func(srv *Server, ws *websocket.Conn, vars map[string]string) error
 
 func hijackServer(w http.ResponseWriter) (io.ReadCloser, io.Writer, error) {
 	conn, _, err := w.(http.Hijacker).Hijack()

--- a/api.go
+++ b/api.go
@@ -876,14 +876,6 @@ func writeCorsHeaders(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, OPTIONS")
 }
 
-func logRequest(logging bool, localMethod string, localRoute string, r *http.Request) {
-	utils.Debugf("Calling %s %s", localMethod, localRoute)
-
-	if logging {
-		log.Println(r.Method, r.RequestURI)
-	}
-}
-
 func makeHttpHandler(srv *Server, logging bool, localMethod string, localRoute string, handlerFunc HttpApiFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// log the request

--- a/api_test.go
+++ b/api_test.go
@@ -461,25 +461,47 @@ func TestGetContainersTop(t *testing.T) {
 
 	container, err := builder.Create(
 		&Config{
-			Image: GetTestImage(runtime).ID,
-			Cmd:   []string{"/bin/sh", "-c", "sleep 2"},
+			Image:     GetTestImage(runtime).ID,
+			Cmd:       []string{"/bin/sh", "-c", "cat"},
+			OpenStdin: true,
 		},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
+	defer func() {
+		// Make sure the process dies before destorying runtime
+		container.stdin.Close()
+		container.WaitTimeout(2 * time.Second)
+	}()
+
 	hostConfig := &HostConfig{}
 	if err := container.Start(hostConfig); err != nil {
 		t.Fatal(err)
 	}
 
-	// Give some time to the process to start
-	container.WaitTimeout(500 * time.Millisecond)
+	setTimeout(t, "Waiting for the container to be started timed out", 10*time.Second, func() {
+		for {
+			if container.State.Running {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	})
 
 	if !container.State.Running {
-		t.Errorf("Container should be running")
+		t.Fatalf("Container should be running")
 	}
+
+	// Make sure sh spawn up cat
+	setTimeout(t, "read/write assertion timed out", 2*time.Second, func() {
+		in, _ := container.StdinPipe()
+		out, _ := container.StdoutPipe()
+		if err := assertPipe("hello\n", "hello", out, in, 15); err != nil {
+			t.Fatal(err)
+		}
+	})
 
 	r := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", "/"+container.ID+"/top?ps_args=u", bytes.NewReader([]byte{}))
@@ -504,11 +526,11 @@ func TestGetContainersTop(t *testing.T) {
 	if len(procs.Processes) != 2 {
 		t.Fatalf("Expected 2 processes, found %d.", len(procs.Processes))
 	}
-	if procs.Processes[0][10] != "/bin/sh" && procs.Processes[0][10] != "sleep" {
-		t.Fatalf("Expected `sleep` or `/bin/sh`, found %s.", procs.Processes[0][10])
+	if procs.Processes[0][10] != "/bin/sh" && procs.Processes[0][10] != "cat" {
+		t.Fatalf("Expected `cat` or `/bin/sh`, found %s.", procs.Processes[0][10])
 	}
-	if procs.Processes[1][10] != "/bin/sh" && procs.Processes[1][10] != "sleep" {
-		t.Fatalf("Expected `sleep` or `/bin/sh`, found %s.", procs.Processes[1][10])
+	if procs.Processes[1][10] != "/bin/sh" && procs.Processes[1][10] != "cat" {
+		t.Fatalf("Expected `cat` or `/bin/sh`, found %s.", procs.Processes[1][10])
 	}
 }
 

--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -226,7 +226,7 @@ func buildImage(context testContextTemplate, t *testing.T, srv *Server, useCache
 	}
 	port := httpServer.URL[idx+1:]
 
-	ip := srv.runtime.networkManager.bridgeNetwork.IP
+	ip := srv.runtime.networkManager.networks[0].IP
 	dockerfile := constructDockerfile(context.dockerfile, ip, port)
 
 	buildfile := NewBuildFile(srv, ioutil.Discard, false, useCache)
@@ -456,7 +456,7 @@ func TestForbiddenContextPath(t *testing.T) {
 	}
 	port := httpServer.URL[idx+1:]
 
-	ip := srv.runtime.networkManager.bridgeNetwork.IP
+	ip := srv.runtime.networkManager.networks[0].IP
 	dockerfile := constructDockerfile(context.dockerfile, ip, port)
 
 	buildfile := NewBuildFile(srv, ioutil.Discard, false, true)

--- a/container.go
+++ b/container.go
@@ -168,11 +168,14 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *flag.FlagSet
 }
 
 type NetworkSettings struct {
-	IPAddress   string
-	IPPrefixLen int
-	Gateway     string
-	Bridge      string
-	PortMapping map[string]string
+	IPAddress     string
+	IPPrefixLen   int
+	Gateway       string
+	IPV6Address   string
+	IPV6PrefixLen int
+	GatewayV6     string
+	Bridge        string
+	PortMapping   map[string]string
 }
 
 // String returns a human-readable description of the port mapping defined in the settings
@@ -495,7 +498,7 @@ func (container *Container) Start() error {
 	}
 
 	// Networking
-	params = append(params, "-g", container.network.Gateway.String())
+	params = append(params, "-g", container.network.IPs[0].Gateway.String())
 
 	// User
 	if container.Config.User != "" {
@@ -608,9 +611,17 @@ func (container *Container) allocateNetwork() error {
 	}
 	container.network = iface
 	container.NetworkSettings.Bridge = container.runtime.networkManager.bridgeIface
-	container.NetworkSettings.IPAddress = iface.IPNet.IP.String()
-	container.NetworkSettings.IPPrefixLen, _ = iface.IPNet.Mask.Size()
-	container.NetworkSettings.Gateway = iface.Gateway.String()
+
+	container.NetworkSettings.IPAddress = iface.IPs[0].IPNet.IP.String()
+	container.NetworkSettings.IPPrefixLen, _ = iface.IPs[0].IPNet.Mask.Size()
+	container.NetworkSettings.Gateway = iface.IPs[0].Gateway.String()
+
+	if len(iface.IPs) >= 2 {
+		container.NetworkSettings.IPV6Address = iface.IPs[1].IPNet.IP.String()
+		container.NetworkSettings.IPV6PrefixLen, _ = iface.IPs[1].IPNet.Mask.Size()
+		container.NetworkSettings.GatewayV6 = iface.IPs[1].Gateway.String()
+	}
+
 	return nil
 }
 

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -3,7 +3,7 @@
 # Original version by Jeff Lindsay <progrium@gmail.com>
 # Revamped by Jerome Petazzoni <jerome@dotcloud.com>
 #
-# This script canonical location is http://get.docker.io/; to update it, run:
+# This script canonical location is https://get.docker.io/; to update it, run:
 # s3cmd put -m text/x-shellscript -P install.sh s3://get.docker.io/index
 
 echo "Ensuring basic dependencies are installed..."
@@ -36,7 +36,7 @@ else
 fi
 
 echo "Downloading docker binary and uncompressing into /usr/local/bin..."
-curl -s http://get.docker.io/builds/$(uname -s)/$(uname -m)/docker-latest.tgz |
+curl -s https://get.docker.io/builds/$(uname -s)/$(uname -m)/docker-latest.tgz |
 tar -C /usr/local/bin --strip-components=1 -zxf- \
 docker-latest/docker
 

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -81,7 +81,7 @@ lxc.mount.entry = sysfs {{$ROOTFS}}/sys sysfs nosuid,nodev,noexec 0 0
 lxc.mount.entry = devpts {{$ROOTFS}}/dev/pts devpts newinstance,ptmxmode=0666,nosuid,noexec 0 0
 #lxc.mount.entry = varrun {{$ROOTFS}}/var/run tmpfs mode=755,size=4096k,nosuid,nodev,noexec 0 0
 #lxc.mount.entry = varlock {{$ROOTFS}}/var/lock tmpfs size=1024k,nosuid,nodev,noexec 0 0
-#lxc.mount.entry = shm {{$ROOTFS}}/dev/shm tmpfs size=65536k,nosuid,nodev,noexec 0 0
+lxc.mount.entry = shm {{$ROOTFS}}/dev/shm tmpfs size=65536k,nosuid,nodev,noexec 0 0
 
 # Inject docker-init
 lxc.mount.entry = {{.SysInitPath}} {{$ROOTFS}}/.dockerinit none bind,ro 0 0

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -20,6 +20,10 @@ lxc.network.link = {{.NetworkSettings.Bridge}}
 lxc.network.name = eth0
 lxc.network.mtu = 1500
 lxc.network.ipv4 = {{.NetworkSettings.IPAddress}}/{{.NetworkSettings.IPPrefixLen}}
+{{if .NetworkSettings.IPV6Address}}
+lxc.network.ipv6 = {{.NetworkSettings.IPV6Address}}/{{.NetworkSettings.IPV6PrefixLen}}
+lxc.network.ipv6.gateway = {{.NetworkSettings.GatewayV6}}
+{{end}}
 
 # root filesystem
 {{$ROOTFS := .RootfsPath}}

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -24,6 +24,9 @@ lxc.network.link = {{.NetworkSettings.Bridge}}
 lxc.network.name = eth0
 lxc.network.mtu = 1500
 lxc.network.ipv4 = {{.NetworkSettings.IPAddress}}/{{.NetworkSettings.IPPrefixLen}}
+{{if .NetworkSettings.IPV6Address}}
+lxc.network.ipv6 = {{.NetworkSettings.IPV6Address}}/{{.NetworkSettings.IPV6PrefixLen}}
+lxc.network.ipv6.gateway = {{.NetworkSettings.GatewayV6}}
 {{end}}
 
 # root filesystem

--- a/network.go
+++ b/network.go
@@ -24,10 +24,10 @@ const (
 
 // Calculates the first and last IP addresses in an IPNet
 func networkRange(network *net.IPNet) (net.IP, net.IP) {
-	netIP := network.IP.To4()
+	netIP := network.IP
 	firstIP := netIP.Mask(network.Mask)
-	lastIP := net.IPv4(0, 0, 0, 0).To4()
-	for i := 0; i < len(lastIP); i++ {
+	lastIP := make(net.IP, len(firstIP))
+	for i := 0; i < len(firstIP); i++ {
 		lastIP[i] = netIP[i] | ^network.Mask[i]
 	}
 	return firstIP, lastIP
@@ -56,6 +56,24 @@ func intToIP(n int32) net.IP {
 	b := make([]byte, 4)
 	binary.BigEndian.PutUint32(b, uint32(n))
 	return net.IP(b)
+}
+
+// Finds the n-th IP address after addr
+func addIp(addr net.IP, n int32) net.IP {
+	// TODO: This is incredibly inefficient
+	var i int32
+	for i = 0; i < n; i++ {
+		for j := len(addr) - 1; j >= 0; j-- {
+			if addr[j] != 255 {
+				addr[j]++
+				break
+			} else {
+				addr[j] = 0
+			}
+		}
+	}
+
+	return addr
 }
 
 // Given a netmask, calculates the number of available hosts
@@ -152,8 +170,9 @@ func CreateBridgeIface(ifaceName string) error {
 	return nil
 }
 
-// Return the IPv4 address of a network interface
-func getIfaceAddr(name string) (net.Addr, error) {
+// Finds the IPv4 & IPv6 networks bound to a network interface
+// The first is guaranteed to be IPv4 (or this will return error)
+func getIfaceNetworks(name string) ([]NetworkInterfaceIP, error) {
 	iface, err := net.InterfaceByName(name)
 	if err != nil {
 		return nil, err
@@ -162,21 +181,69 @@ func getIfaceAddr(name string) (net.Addr, error) {
 	if err != nil {
 		return nil, err
 	}
-	var addrs4 []net.Addr
+
+	utils.Debugf("Iface addresses on %s: %s", name, addrs)
+
+	var nets4 []*net.IPNet
+	var nets6 []*net.IPNet
 	for _, addr := range addrs {
-		ip := (addr.(*net.IPNet)).IP
+		network := (addr.(*net.IPNet))
+		ip := network.IP
 		if ip4 := ip.To4(); len(ip4) == net.IPv4len {
-			addrs4 = append(addrs4, addr)
+			nets4 = append(nets4, network)
+		} else if ip6 := ip.To16(); len(ip6) == net.IPv6len {
+			nets6 = append(nets6, network)
 		}
 	}
+
+	var bestNet4 *net.IPNet
 	switch {
-	case len(addrs4) == 0:
-		return nil, fmt.Errorf("Interface %v has no IP addresses", name)
-	case len(addrs4) > 1:
+	case len(nets4) == 0:
+		return nil, fmt.Errorf("Interface %v has no IPv4 addresses", name)
+	case len(nets4) == 1:
+		bestNet4 = nets4[0]
+	case len(nets4) > 1:
+		bestNet4 = nets4[0]
 		fmt.Printf("Interface %v has more than 1 IPv4 address. Defaulting to using %v\n",
-			name, (addrs4[0].(*net.IPNet)).IP)
+			name, bestNet4.IP)
 	}
-	return addrs4[0], nil
+
+	var bestNet6 *net.IPNet
+	warnMultipleIpv6 := false
+	for _, net6 := range nets6 {
+		ip := net6.IP
+		if ip.IsGlobalUnicast() {
+			if bestNet6 == nil {
+				bestNet6 = net6
+			} else {
+				warnMultipleIpv6 = true
+			}
+		}
+	}
+
+	if bestNet6 == nil {
+		fmt.Printf("Interface %v has no (suitable) IPv6 address. Won't use IPv6.\n",
+			name)
+	} else if warnMultipleIpv6 {
+		fmt.Printf("Interface %v has more than 1 IPv6 address. Defaulting to using %v\n",
+			name, bestNet6.IP)
+	}
+
+	networks := []NetworkInterfaceIP{}
+
+	if bestNet4 != nil {
+		utils.Debugf("Chose IPv4: %s", bestNet4)
+		networks = append(networks, NetworkInterfaceIP{IPNet: *bestNet4, Gateway: bestNet4.IP})
+	}
+
+	if bestNet6 != nil {
+		utils.Debugf("Chose IPv6: %s", bestNet6)
+		networks = append(networks, NetworkInterfaceIP{IPNet: *bestNet6, Gateway: bestNet6.IP})
+	}
+
+	utils.Debugf("Networks: %s", networks)
+
+	return networks, nil
 }
 
 // Port mapper takes care of mapping external ports to containers by setting
@@ -354,22 +421,24 @@ func newPortAllocator() (*PortAllocator, error) {
 
 // IP allocator: Atomatically allocate and release networking ports
 type IPAllocator struct {
-	network       *net.IPNet
+	networks      []NetworkInterfaceIP
 	queueAlloc    chan allocatedIP
 	queueReleased chan net.IP
 	inUse         map[int32]struct{}
 }
 
 type allocatedIP struct {
-	ip  net.IP
+	ips []NetworkInterfaceIP
 	err error
 }
 
 func (alloc *IPAllocator) run() {
-	firstIP, _ := networkRange(alloc.network)
+	primaryNetwork := alloc.networks[0]
+
+	firstIP, _ := networkRange(&primaryNetwork.IPNet)
 	ipNum := ipToInt(firstIP)
-	ownIP := ipToInt(alloc.network.IP)
-	size := networkSize(alloc.network.Mask)
+	ownIP := ipToInt(primaryNetwork.IPNet.IP)
+	size := networkSize(primaryNetwork.IPNet.Mask)
 
 	pos := int32(1)
 	max := size - 2 // -1 for the broadcast address, -1 for the gateway address
@@ -396,13 +465,24 @@ func (alloc *IPAllocator) run() {
 			}
 		}
 
-		ip := allocatedIP{ip: intToIP(newNum)}
+		allocated := allocatedIP{}
 		if inUse {
-			ip.err = errors.New("No unallocated IP available")
+			allocated.err = errors.New("No unallocated IP available")
+		} else {
+			ips := []NetworkInterfaceIP{}
+
+			for i := 0; i < len(alloc.networks); i++ {
+				netFirstIp, _ := networkRange(&alloc.networks[i].IPNet)
+				addr := addIp(netFirstIp, newNum-ipNum)
+				ipnet := net.IPNet{IP: net.IP(addr), Mask: alloc.networks[i].IPNet.Mask}
+				ips = append(ips, NetworkInterfaceIP{IPNet: ipnet, Gateway: alloc.networks[i].Gateway})
+			}
+
+			allocated.ips = ips
 		}
 
 		select {
-		case alloc.queueAlloc <- ip:
+		case alloc.queueAlloc <- allocated:
 			alloc.inUse[newNum] = struct{}{}
 		case released := <-alloc.queueReleased:
 			r := ipToInt(released)
@@ -425,18 +505,18 @@ func (alloc *IPAllocator) run() {
 	}
 }
 
-func (alloc *IPAllocator) Acquire() (net.IP, error) {
+func (alloc *IPAllocator) Acquire() ([]NetworkInterfaceIP, error) {
 	ip := <-alloc.queueAlloc
-	return ip.ip, ip.err
+	return ip.ips, ip.err
 }
 
 func (alloc *IPAllocator) Release(ip net.IP) {
 	alloc.queueReleased <- ip
 }
 
-func newIPAllocator(network *net.IPNet) *IPAllocator {
+func newIPAllocator(networks []NetworkInterfaceIP) *IPAllocator {
 	alloc := &IPAllocator{
-		network:       network,
+		networks:      networks,
 		queueAlloc:    make(chan allocatedIP),
 		queueReleased: make(chan net.IP),
 		inUse:         make(map[int32]struct{}),
@@ -448,10 +528,13 @@ func newIPAllocator(network *net.IPNet) *IPAllocator {
 }
 
 // Network interface represents the networking stack of a container
-type NetworkInterface struct {
+type NetworkInterfaceIP struct {
 	IPNet   net.IPNet
 	Gateway net.IP
+}
 
+type NetworkInterface struct {
+	IPs      []NetworkInterfaceIP
 	manager  *NetworkManager
 	extPorts []int
 }
@@ -468,7 +551,7 @@ func (iface *NetworkInterface) AllocatePort(spec string) (*Nat, error) {
 		return nil, err
 	}
 	nat.Frontend = extPort
-	if err := iface.manager.portMapper.Map(nat.Frontend, net.TCPAddr{IP: iface.IPNet.IP, Port: nat.Backend}); err != nil {
+	if err := iface.manager.portMapper.Map(nat.Frontend, net.TCPAddr{IP: iface.IPs[0].IPNet.IP, Port: nat.Backend}); err != nil {
 		iface.manager.portAllocator.Release(nat.Frontend)
 		return nil, err
 	}
@@ -533,15 +616,14 @@ func (iface *NetworkInterface) Release() {
 
 	}
 
-	iface.manager.ipAllocator.Release(iface.IPNet.IP)
+	iface.manager.ipAllocator.Release(iface.IPs[0].IPNet.IP)
 }
 
 // Network Manager manages a set of network interfaces
 // Only *one* manager per host machine should be used
 type NetworkManager struct {
 	bridgeIface   string
-	bridgeNetwork *net.IPNet
-
+	networks      []NetworkInterfaceIP
 	ipAllocator   *IPAllocator
 	portAllocator *PortAllocator
 	portMapper    *PortMapper
@@ -549,33 +631,34 @@ type NetworkManager struct {
 
 // Allocate a network interface
 func (manager *NetworkManager) Allocate() (*NetworkInterface, error) {
-	ip, err := manager.ipAllocator.Acquire()
+	ips, err := manager.ipAllocator.Acquire()
 	if err != nil {
 		return nil, err
 	}
+
 	iface := &NetworkInterface{
-		IPNet:   net.IPNet{IP: ip, Mask: manager.bridgeNetwork.Mask},
-		Gateway: manager.bridgeNetwork.IP,
+		IPs:     ips,
 		manager: manager,
 	}
+
+	utils.Debugf("Allocated IPs: %s", iface.IPs)
+
 	return iface, nil
 }
 
 func newNetworkManager(bridgeIface string) (*NetworkManager, error) {
-	addr, err := getIfaceAddr(bridgeIface)
+	networks, err := getIfaceNetworks(bridgeIface)
 	if err != nil {
 		// If the iface is not found, try to create it
 		if err := CreateBridgeIface(bridgeIface); err != nil {
 			return nil, err
 		}
-		addr, err = getIfaceAddr(bridgeIface)
+		networks, err = getIfaceNetworks(bridgeIface)
 		if err != nil {
 			return nil, err
 		}
 	}
-	network := addr.(*net.IPNet)
-
-	ipAllocator := newIPAllocator(network)
+	ipAllocator := newIPAllocator(networks)
 
 	portAllocator, err := newPortAllocator()
 	if err != nil {
@@ -589,7 +672,7 @@ func newNetworkManager(bridgeIface string) (*NetworkManager, error) {
 
 	manager := &NetworkManager{
 		bridgeIface:   bridgeIface,
-		bridgeNetwork: network,
+		networks:      networks,
 		ipAllocator:   ipAllocator,
 		portAllocator: portAllocator,
 		portMapper:    portMapper,

--- a/network.go
+++ b/network.go
@@ -24,10 +24,10 @@ const (
 
 // Calculates the first and last IP addresses in an IPNet
 func networkRange(network *net.IPNet) (net.IP, net.IP) {
-	netIP := network.IP.To4()
+	netIP := network.IP
 	firstIP := netIP.Mask(network.Mask)
-	lastIP := net.IPv4(0, 0, 0, 0).To4()
-	for i := 0; i < len(lastIP); i++ {
+	lastIP := make(net.IP, len(firstIP))
+	for i := 0; i < len(firstIP); i++ {
 		lastIP[i] = netIP[i] | ^network.Mask[i]
 	}
 	return firstIP, lastIP
@@ -56,6 +56,24 @@ func intToIP(n int32) net.IP {
 	b := make([]byte, 4)
 	binary.BigEndian.PutUint32(b, uint32(n))
 	return net.IP(b)
+}
+
+// Finds the n-th IP address after addr
+func addIp(addr net.IP, n int32) net.IP {
+	// TODO: This is incredibly inefficient
+	var i int32
+	for i = 0; i < n; i++ {
+		for j := len(addr) - 1; j >= 0; j-- {
+			if addr[j] != 255 {
+				addr[j]++
+				break
+			} else {
+				addr[j] = 0
+			}
+		}
+	}
+
+	return addr
 }
 
 // Given a netmask, calculates the number of available hosts
@@ -184,8 +202,9 @@ func CreateBridgeIface(ifaceName string) error {
 	return nil
 }
 
-// Return the IPv4 address of a network interface
-func getIfaceAddr(name string) (net.Addr, error) {
+// Finds the IPv4 & IPv6 networks bound to a network interface
+// The first is guaranteed to be IPv4 (or this will return error)
+func getIfaceNetworks(name string) ([]NetworkInterfaceIP, error) {
 	iface, err := net.InterfaceByName(name)
 	if err != nil {
 		return nil, err
@@ -194,21 +213,69 @@ func getIfaceAddr(name string) (net.Addr, error) {
 	if err != nil {
 		return nil, err
 	}
-	var addrs4 []net.Addr
+
+	utils.Debugf("Iface addresses on %s: %s", name, addrs)
+
+	var nets4 []*net.IPNet
+	var nets6 []*net.IPNet
 	for _, addr := range addrs {
-		ip := (addr.(*net.IPNet)).IP
+		network := (addr.(*net.IPNet))
+		ip := network.IP
 		if ip4 := ip.To4(); len(ip4) == net.IPv4len {
-			addrs4 = append(addrs4, addr)
+			nets4 = append(nets4, network)
+		} else if ip6 := ip.To16(); len(ip6) == net.IPv6len {
+			nets6 = append(nets6, network)
 		}
 	}
+
+	var bestNet4 *net.IPNet
 	switch {
-	case len(addrs4) == 0:
-		return nil, fmt.Errorf("Interface %v has no IP addresses", name)
-	case len(addrs4) > 1:
+	case len(nets4) == 0:
+		return nil, fmt.Errorf("Interface %v has no IPv4 addresses", name)
+	case len(nets4) == 1:
+		bestNet4 = nets4[0]
+	case len(nets4) > 1:
+		bestNet4 = nets4[0]
 		fmt.Printf("Interface %v has more than 1 IPv4 address. Defaulting to using %v\n",
-			name, (addrs4[0].(*net.IPNet)).IP)
+			name, bestNet4.IP)
 	}
-	return addrs4[0], nil
+
+	var bestNet6 *net.IPNet
+	warnMultipleIpv6 := false
+	for _, net6 := range nets6 {
+		ip := net6.IP
+		if ip.IsGlobalUnicast() {
+			if bestNet6 == nil {
+				bestNet6 = net6
+			} else {
+				warnMultipleIpv6 = true
+			}
+		}
+	}
+
+	if bestNet6 == nil {
+		fmt.Printf("Interface %v has no (suitable) IPv6 address. Won't use IPv6.\n",
+			name)
+	} else if warnMultipleIpv6 {
+		fmt.Printf("Interface %v has more than 1 IPv6 address. Defaulting to using %v\n",
+			name, bestNet6.IP)
+	}
+
+	networks := []NetworkInterfaceIP{}
+
+	if bestNet4 != nil {
+		utils.Debugf("Chose IPv4: %s", bestNet4)
+		networks = append(networks, NetworkInterfaceIP{IPNet: *bestNet4, Gateway: bestNet4.IP})
+	}
+
+	if bestNet6 != nil {
+		utils.Debugf("Chose IPv6: %s", bestNet6)
+		networks = append(networks, NetworkInterfaceIP{IPNet: *bestNet6, Gateway: bestNet6.IP})
+	}
+
+	utils.Debugf("Networks: %s", networks)
+
+	return networks, nil
 }
 
 // Port mapper takes care of mapping external ports to containers by setting
@@ -387,22 +454,24 @@ func newPortAllocator() (*PortAllocator, error) {
 
 // IP allocator: Atomatically allocate and release networking ports
 type IPAllocator struct {
-	network       *net.IPNet
+	networks      []NetworkInterfaceIP
 	queueAlloc    chan allocatedIP
 	queueReleased chan net.IP
 	inUse         map[int32]struct{}
 }
 
 type allocatedIP struct {
-	ip  net.IP
+	ips []NetworkInterfaceIP
 	err error
 }
 
 func (alloc *IPAllocator) run() {
-	firstIP, _ := networkRange(alloc.network)
+	primaryNetwork := alloc.networks[0]
+
+	firstIP, _ := networkRange(&primaryNetwork.IPNet)
 	ipNum := ipToInt(firstIP)
-	ownIP := ipToInt(alloc.network.IP)
-	size := networkSize(alloc.network.Mask)
+	ownIP := ipToInt(primaryNetwork.IPNet.IP)
+	size := networkSize(primaryNetwork.IPNet.Mask)
 
 	pos := int32(1)
 	max := size - 2 // -1 for the broadcast address, -1 for the gateway address
@@ -429,13 +498,24 @@ func (alloc *IPAllocator) run() {
 			}
 		}
 
-		ip := allocatedIP{ip: intToIP(newNum)}
+		allocated := allocatedIP{}
 		if inUse {
-			ip.err = errors.New("No unallocated IP available")
+			allocated.err = errors.New("No unallocated IP available")
+		} else {
+			ips := []NetworkInterfaceIP{}
+
+			for i := 0; i < len(alloc.networks); i++ {
+				netFirstIp, _ := networkRange(&alloc.networks[i].IPNet)
+				addr := addIp(netFirstIp, newNum-ipNum)
+				ipnet := net.IPNet{IP: net.IP(addr), Mask: alloc.networks[i].IPNet.Mask}
+				ips = append(ips, NetworkInterfaceIP{IPNet: ipnet, Gateway: alloc.networks[i].Gateway})
+			}
+
+			allocated.ips = ips
 		}
 
 		select {
-		case alloc.queueAlloc <- ip:
+		case alloc.queueAlloc <- allocated:
 			alloc.inUse[newNum] = struct{}{}
 		case released := <-alloc.queueReleased:
 			r := ipToInt(released)
@@ -458,18 +538,18 @@ func (alloc *IPAllocator) run() {
 	}
 }
 
-func (alloc *IPAllocator) Acquire() (net.IP, error) {
+func (alloc *IPAllocator) Acquire() ([]NetworkInterfaceIP, error) {
 	ip := <-alloc.queueAlloc
-	return ip.ip, ip.err
+	return ip.ips, ip.err
 }
 
 func (alloc *IPAllocator) Release(ip net.IP) {
 	alloc.queueReleased <- ip
 }
 
-func newIPAllocator(network *net.IPNet) *IPAllocator {
+func newIPAllocator(networks []NetworkInterfaceIP) *IPAllocator {
 	alloc := &IPAllocator{
-		network:       network,
+		networks:      networks,
 		queueAlloc:    make(chan allocatedIP),
 		queueReleased: make(chan net.IP),
 		inUse:         make(map[int32]struct{}),
@@ -481,10 +561,13 @@ func newIPAllocator(network *net.IPNet) *IPAllocator {
 }
 
 // Network interface represents the networking stack of a container
-type NetworkInterface struct {
+type NetworkInterfaceIP struct {
 	IPNet   net.IPNet
 	Gateway net.IP
+}
 
+type NetworkInterface struct {
+	IPs      []NetworkInterfaceIP
 	manager  *NetworkManager
 	extPorts []*Nat
 	disabled bool
@@ -507,7 +590,7 @@ func (iface *NetworkInterface) AllocatePort(spec string) (*Nat, error) {
 		if err != nil {
 			return nil, err
 		}
-		backend := &net.TCPAddr{IP: iface.IPNet.IP, Port: nat.Backend}
+		backend := &net.TCPAddr{IP: iface.IPs[0].IPNet.IP, Port: nat.Backend}
 		if err := iface.manager.portMapper.Map(extPort, backend); err != nil {
 			iface.manager.tcpPortAllocator.Release(extPort)
 			return nil, err
@@ -518,7 +601,7 @@ func (iface *NetworkInterface) AllocatePort(spec string) (*Nat, error) {
 		if err != nil {
 			return nil, err
 		}
-		backend := &net.UDPAddr{IP: iface.IPNet.IP, Port: nat.Backend}
+		backend := &net.UDPAddr{IP: iface.IPs[0].IPNet.IP, Port: nat.Backend}
 		if err := iface.manager.portMapper.Map(extPort, backend); err != nil {
 			iface.manager.udpPortAllocator.Release(extPort)
 			return nil, err
@@ -611,14 +694,13 @@ func (iface *NetworkInterface) Release() {
 		}
 	}
 
-	iface.manager.ipAllocator.Release(iface.IPNet.IP)
+	iface.manager.ipAllocator.Release(iface.IPs[0].IPNet.IP)
 }
 
 // Network Manager manages a set of network interfaces
 // Only *one* manager per host machine should be used
 type NetworkManager struct {
 	bridgeIface   string
-	bridgeNetwork *net.IPNet
 
 	ipAllocator      *IPAllocator
 	tcpPortAllocator *PortAllocator
@@ -626,24 +708,28 @@ type NetworkManager struct {
 	portMapper       *PortMapper
 
 	disabled bool
+
+	networks      []NetworkInterfaceIP
 }
 
 // Allocate a network interface
 func (manager *NetworkManager) Allocate() (*NetworkInterface, error) {
-
 	if manager.disabled {
 		return &NetworkInterface{disabled: true}, nil
 	}
 
-	ip, err := manager.ipAllocator.Acquire()
+	ips, err := manager.ipAllocator.Acquire()
 	if err != nil {
 		return nil, err
 	}
+
 	iface := &NetworkInterface{
-		IPNet:   net.IPNet{IP: ip, Mask: manager.bridgeNetwork.Mask},
-		Gateway: manager.bridgeNetwork.IP,
+		IPs:     ips,
 		manager: manager,
 	}
+
+	utils.Debugf("Allocated IPs: %s", iface.IPs)
+
 	return iface, nil
 }
 
@@ -656,20 +742,18 @@ func newNetworkManager(bridgeIface string) (*NetworkManager, error) {
 		return manager, nil
 	}
 
-	addr, err := getIfaceAddr(bridgeIface)
+	networks, err := getIfaceNetworks(bridgeIface)
 	if err != nil {
 		// If the iface is not found, try to create it
 		if err := CreateBridgeIface(bridgeIface); err != nil {
 			return nil, err
 		}
-		addr, err = getIfaceAddr(bridgeIface)
+		networks, err = getIfaceNetworks(bridgeIface)
 		if err != nil {
 			return nil, err
 		}
 	}
-	network := addr.(*net.IPNet)
-
-	ipAllocator := newIPAllocator(network)
+	ipAllocator := newIPAllocator(networks)
 
 	tcpPortAllocator, err := newPortAllocator()
 	if err != nil {
@@ -687,11 +771,12 @@ func newNetworkManager(bridgeIface string) (*NetworkManager, error) {
 
 	manager := &NetworkManager{
 		bridgeIface:      bridgeIface,
-		bridgeNetwork:    network,
 		ipAllocator:      ipAllocator,
 		tcpPortAllocator: tcpPortAllocator,
 		udpPortAllocator: udpPortAllocator,
 		portMapper:       portMapper,
+
+		networks:      networks,
 	}
 	return manager, nil
 }

--- a/network_test.go
+++ b/network_test.go
@@ -248,7 +248,9 @@ func TestIPAllocator(t *testing.T) {
 	}
 
 	gwIP, n, _ := net.ParseCIDR("127.0.0.1/29")
-	alloc := newIPAllocator(&net.IPNet{IP: gwIP, Mask: n.Mask})
+	network := NetworkInterfaceIP{IPNet: net.IPNet{IP: gwIP, Mask: n.Mask}, Gateway: gwIP}
+	networks := []NetworkInterfaceIP{network}
+	alloc := newIPAllocator(networks)
 	// Pool after initialisation (f = free, u = used)
 	// 2(f) - 3(f) - 4(f) - 5(f) - 6(f)
 	//  ↑
@@ -256,12 +258,12 @@ func TestIPAllocator(t *testing.T) {
 	// Check that we get 5 IPs, from 127.0.0.2–127.0.0.6, in that
 	// order.
 	for i := 0; i < 5; i++ {
-		ip, err := alloc.Acquire()
+		ips, err := alloc.Acquire()
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		assertIPEquals(t, expectedIPs[i], ip)
+		assertIPEquals(t, expectedIPs[i], ips[0].IPNet.IP)
 	}
 	// Before loop begin
 	// 2(f) - 3(f) - 4(f) - 5(f) - 6(f)
@@ -310,12 +312,12 @@ func TestIPAllocator(t *testing.T) {
 	// with the first released IP
 	newIPs := make([]net.IP, 3)
 	for i := 0; i < 3; i++ {
-		ip, err := alloc.Acquire()
+		ips, err := alloc.Acquire()
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		newIPs[i] = ip
+		newIPs[i] = ips[0].IPNet.IP
 	}
 	// Before loop begin
 	// 2(u) - 3(u) - 4(f) - 5(f) - 6(f)

--- a/network_test.go
+++ b/network_test.go
@@ -179,7 +179,9 @@ func TestIPAllocator(t *testing.T) {
 	}
 
 	gwIP, n, _ := net.ParseCIDR("127.0.0.1/29")
-	alloc := newIPAllocator(&net.IPNet{IP: gwIP, Mask: n.Mask})
+	network := NetworkInterfaceIP{IPNet: net.IPNet{IP: gwIP, Mask: n.Mask}, Gateway: gwIP}
+	networks := []NetworkInterfaceIP{network}
+	alloc := newIPAllocator(networks)
 	// Pool after initialisation (f = free, u = used)
 	// 2(f) - 3(f) - 4(f) - 5(f) - 6(f)
 	//  ↑
@@ -187,12 +189,12 @@ func TestIPAllocator(t *testing.T) {
 	// Check that we get 5 IPs, from 127.0.0.2–127.0.0.6, in that
 	// order.
 	for i := 0; i < 5; i++ {
-		ip, err := alloc.Acquire()
+		ips, err := alloc.Acquire()
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		assertIPEquals(t, expectedIPs[i], ip)
+		assertIPEquals(t, expectedIPs[i], ips[0].IPNet.IP)
 	}
 	// Before loop begin
 	// 2(f) - 3(f) - 4(f) - 5(f) - 6(f)
@@ -241,12 +243,12 @@ func TestIPAllocator(t *testing.T) {
 	// with the first released IP
 	newIPs := make([]net.IP, 3)
 	for i := 0; i < 3; i++ {
-		ip, err := alloc.Acquire()
+		ips, err := alloc.Acquire()
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		newIPs[i] = ip
+		newIPs[i] = ips[0].IPNet.IP
 	}
 	// Before loop begin
 	// 2(u) - 3(u) - 4(f) - 5(f) - 6(f)


### PR DESCRIPTION
Assign an IPv6 address to a guest, if a (non-auto-generated) IPv6 address is assigned on docker0.

The IPv4 network remains "primary", and determines the assignment on subsequent networks.  Thus, if you get 172.16.42.n,  then you'll get ::n as your IPv6.  So we only need to track the IPv4 assignments.

Likely you'll have to do this:
sudo sysctl -w net.ipv6.conf.all.forwarding=1

If you're using IPv6 neighbour discovery this is also needed (and should probably be done by docker in future, but this requires knowing what the 'external' network device is, which I think would require a docker configuration file):
sudo sysctl -w net.ipv6.conf.all.proxy_ndp=1
sudo ip -6 neigh add proxy <prefix>::2 dev eth0
sudo ip -6 neigh add proxy <prefix>::3 dev eth0
sudo ip -6 neigh add proxy <prefix>::4 dev eth0
...
