### PR TITLE
TestKill and TestMultipleContainers: run sleep instead of cat /bin/zero....

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -588,7 +588,7 @@ func TestKill(t *testing.T) {
 	defer nuke(runtime)
 	container, err := NewBuilder(runtime).Create(&Config{
 		Image: GetTestImage(runtime).ID,
-		Cmd:   []string{"cat", "/dev/zero"},
+		Cmd:   []string{"sleep", "2"},
 	},
 	)
 	if err != nil {
@@ -897,7 +897,7 @@ func TestMultipleContainers(t *testing.T) {
 
 	container1, err := builder.Create(&Config{
 		Image: GetTestImage(runtime).ID,
-		Cmd:   []string{"cat", "/dev/zero"},
+		Cmd:   []string{"sleep", "2"},
 	},
 	)
 	if err != nil {
@@ -907,7 +907,7 @@ func TestMultipleContainers(t *testing.T) {
 
 	container2, err := builder.Create(&Config{
 		Image: GetTestImage(runtime).ID,
-		Cmd:   []string{"cat", "/dev/zero"},
+		Cmd:   []string{"sleep", "2"},
 	},
 	)
 	if err != nil {


### PR DESCRIPTION
... fixes #737

```
root      1570  0.0  0.0  25572  1328 pts/0    S+   16:37   0:00 lxc-start -n 11f7d3e608d643b9babd30801a521cf988953cefff6afcb837db870dc6193a02 -f /tmp/docker-test826634064/containers/11f7d3e608d643b9babd30801a521cf988953cefff6afcb837db870dc6193a02/config.lxc -- /sbin/init -g 10.0.42.1 -e HOME=/ -e PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin -- cat /dev/zero
```

Well, I can see why that would be a problem. But it's more complicated than that.
TestKill and TestMultipleContainers both cause the same problem ( both run cat /dev/zero ). The actual call that fails to return is: 

```
container.WaitTimeout(500 * time.Millisecond)
```

I checked the function and other than leaving the 'done' channel hanging if it hits timeout before completing it looks ok and shouldnt cause this behavior. It seems that something is causing scheduler to mess up and all goroutines just stop. I tried spawning goroutines that just tick current time every 200ms, when TestKill() gets to WaitTimeout() part, it stops ticking.

All that seemed like distraction from the actual problem so after stopping for couple seconds I just asked myself why are we even spawning containers that "cat /dev/null" when what we want is containers that just exist so that we can kill them later, sleep is more than enough for this and removes the whole huge io spike while running tests.
