### PR TITLE
avoid pushing layers which already exist in registry

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -357,15 +357,15 @@ func (r *Registry) PushImageJSONIndex(remote string, imgList []*ImgData, validat
 	repoData, err := r.GetRepositoryData(remote)
 
 	if err != nil {
-	    if err.Error() == "HTTP code: 404" {
-	        repoData = &RepositoryData{
-	            Endpoints: nil,
-	            Tokens:    nil,
-	        }
-	    } else {
-	        utils.Debugf("Error getting repository data: %s", err.Error())
-	        return nil, err
-	    }
+		if err.Error() == "HTTP code: 404" {
+			repoData = &RepositoryData{
+				Endpoints: nil,
+				Tokens:    nil,
+			}
+		} else {
+			utils.Debugf("Error getting repository data: %s", err.Error())
+			return nil, err
+		}
 	}
 
 	utils.Debugf("Image list pushed to index:\n%s\n", imgListJSON)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -424,10 +424,20 @@ func (r *Registry) PushImageJSONIndex(remote string, imgList []*ImgData, validat
 		}
 	}
 
-	return &RepositoryData{
-		Tokens:    tokens,
-		Endpoints: endpoints,
-	}, nil
+	repoData, err := r.GetRepositoryData(remote)
+
+	if err != nil {
+		if err.Error() == "HTTP code: 404" {
+			return &RepositoryData{
+				Endpoints: endpoints,
+				Tokens:    tokens,
+			}, nil
+		} else {
+			utils.Debugf("Error getting repository data: %s", err.Error())
+			return nil, err
+		}
+	}
+	return repoData, nil
 }
 
 func (r *Registry) SearchRepositories(term string) (*SearchResults, error) {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -348,9 +348,24 @@ func (r *Registry) PushImageJSONIndex(remote string, imgList []*ImgData, validat
 	if err != nil {
 		return nil, err
 	}
+
 	var suffix string
 	if validate {
 		suffix = "images"
+	}
+
+	repoData, err := r.GetRepositoryData(remote)
+
+	if err != nil {
+	    if err.Error() == "HTTP code: 404" {
+	        repoData = &RepositoryData{
+	            Endpoints: nil,
+	            Tokens:    nil,
+	        }
+	    } else {
+	        utils.Debugf("Error getting repository data: %s", err.Error())
+	        return nil, err
+	    }
 	}
 
 	utils.Debugf("Image list pushed to index:\n%s\n", imgListJSON)
@@ -424,19 +439,8 @@ func (r *Registry) PushImageJSONIndex(remote string, imgList []*ImgData, validat
 		}
 	}
 
-	repoData, err := r.GetRepositoryData(remote)
-
-	if err != nil {
-		if err.Error() == "HTTP code: 404" {
-			return &RepositoryData{
-				Endpoints: endpoints,
-				Tokens:    tokens,
-			}, nil
-		} else {
-			utils.Debugf("Error getting repository data: %s", err.Error())
-			return nil, err
-		}
-	}
+	repoData.Endpoints = endpoints
+	repoData.Tokens = tokens
 	return repoData, nil
 }
 

--- a/server.go
+++ b/server.go
@@ -572,7 +572,7 @@ func (srv *Server) pushRepository(r *registry.Registry, out io.Writer, name stri
 		// For each image within the repo, push them
 		for _, elem := range imgList {
 			if _, exists := repoData.ImgList[elem.ID]; exists {
-				out.Write(sf.FormatStatus("Image %s already on registry, skipping", name))
+				out.Write(sf.FormatStatus("Image %s already on registry, skipping", elem.ID))
 				continue
 			}
 			if err := srv.pushImage(r, out, name, elem.ID, ep, repoData.Tokens, sf); err != nil {


### PR DESCRIPTION
The RepositoryData returned in PushImageJSONIndex does not contain any image data. This is why every time we push to a registry all layers are pushed again and again.
