### PR TITLE
Update ubuntu documentation to add linux headers as well

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -32,13 +32,13 @@ Dependencies
 
 **Linux kernel 3.8**
 
-Due to a bug in LXC docker works best on the 3.8 kernel. Precise comes with a 3.2 kernel, so we need to upgrade it. The kernel we install comes with AUFS built in.
+Due to a bug in LXC, docker works best on the 3.8 kernel. Precise comes with a 3.2 kernel, so we need to upgrade it. The kernel we install comes with AUFS built in.
 
 
 .. code-block:: bash
 
    # install the backported kernel
-   sudo apt-get update && sudo apt-get install linux-image-generic-lts-raring
+   sudo apt-get update && sudo apt-get install linux-image-generic-lts-raring linux-headers-generic-lts-raring
 
    # reboot
    sudo reboot


### PR DESCRIPTION
If you are running Ubuntu with a native root zfs file system(1), following the ubuntu getting started documentation will render your system unbootable. If you only install the kernel then the zfs DKMS module never gets build and added to the initramfs so you fail to boot. The solution it so also install the kernel headers. 

1) https://github.com/zfsonlinux/pkg-zfs/wiki/HOWTO-install-Ubuntu-to-a-Native-ZFS-Root-Filesystem
