### PR TITLE
remove + from minor kernel version for kernels built from git

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -528,7 +528,9 @@ func GetKernelVersion() (*KernelVersionInfo, error) {
 	}
 
 	if len(tmp2) > 2 {
-		minor, err = strconv.Atoi(tmp2[2])
+		// Removes "+" because git kernels might set it
+		minorUnparsed := strings.Trim(tmp2[2], "+")
+		minor, err = strconv.Atoi(minorUnparsed)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Some kernels have versions which look like this: `3.9.5+`. Docker fails to parse these properly and prints a warning.

This PR adds a Trim operation on the string with the minor version of the kernel to remove the trailing + character.
