### PR TITLE
Reverse priority of tag lookup in TagStore.GetImage

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -204,14 +204,14 @@ func (store *TagStore) GetImage(repoName, tagOrID string) (*Image, error) {
 	} else if repo == nil {
 		return nil, nil
 	}
-	//go through all the tags, to see if tag is in fact an ID
+	if revision, exists := repo[tagOrID]; exists {
+		return store.graph.Get(revision)
+	}
+	// If no matching tag is found, search through images for a matching image id
 	for _, revision := range repo {
 		if strings.HasPrefix(revision, tagOrID) {
 			return store.graph.Get(revision)
 		}
-	}
-	if revision, exists := repo[tagOrID]; exists {
-		return store.graph.Get(revision)
 	}
 	return nil, nil
 }


### PR DESCRIPTION
Currently, if you have the following images:

```
foo/bar      1       23b27d50fb49
foo/bar      2       f2b86ec3fcc4
```

And you issue the following command:

```
docker tag foo/bar:2 foo/bar latest
```

docker will tag the "wrong" image, because the image id for foo/bar:1 starts
with a "2". That is, you'll end up with the following:

```
foo/bar      1       23b27d50fb49
foo/bar      2       f2b86ec3fcc4
foo/bar      latest  23b27d50fb49
```

This commit reverses the priority given to tags vs. image ids in the
construction `<user>/<repo>:<tagOrId>`, meaning that if a tag that is an exact
match for the specified `tagOrId`, it will be tagged in preference to an image
with an id that happens to start with the correct character sequence.
