### PR TITLE
Support file injection

### DIFF
--- a/copy_tree.go
+++ b/copy_tree.go
@@ -9,8 +9,6 @@ import (
 type treeCopyingVisitor struct {
 	src  string
 	dest string
-
-	err error
 }
 
 func copyFile(src string, dest string, info os.FileInfo) error {
@@ -65,6 +63,5 @@ func CopyTree(src string, dest string) error {
 		return visitor.visit(path, info)
 	}
 
-	filepath.Walk(src, f)
-	return visitor.err
+	return filepath.Walk(src, f)
 }

--- a/copy_tree.go
+++ b/copy_tree.go
@@ -1,0 +1,70 @@
+package docker
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type treeCopyingVisitor struct {
+	src  string
+	dest string
+
+	err error
+}
+
+func copyFile(src string, dest string, info os.FileInfo) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+	destFile, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_CREATE, info.Mode())
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+	_, err = io.Copy(destFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (self *treeCopyingVisitor) visit(src string, info os.FileInfo) error {
+	rel, err := filepath.Rel(self.src, src)
+	if err != nil {
+		return err
+	}
+
+	dest := filepath.Join(self.dest, rel)
+
+	if info.IsDir() {
+		err = os.Mkdir(dest, info.Mode())
+		if err != nil {
+			if os.IsExist(err) {
+				err = nil
+			}
+		}
+	} else {
+		err = copyFile(src, dest, info)
+	}
+
+	return err
+}
+
+func CopyTree(src string, dest string) error {
+	visitor := &treeCopyingVisitor{src: src, dest: dest}
+
+	f := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		return visitor.visit(path, info)
+	}
+
+	filepath.Walk(src, f)
+	return visitor.err
+}

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -83,6 +83,10 @@ lxc.mount.entry = {{.SysInitPath}} {{$ROOTFS}}/sbin/init none bind,ro 0 0
 
 # In order to get a working DNS environment, mount bind (ro) the host's /etc/resolv.conf into the container
 lxc.mount.entry = {{.ResolvConfPath}} {{$ROOTFS}}/etc/resolv.conf none bind,ro 0 0
+{{if .DockerMountPath}}
+lxc.mount.entry = {{.DockerMountPath}} {{$ROOTFS}}/.docker none bind,ro 0 0
+{{end}}
+
 {{if .Volumes}}
 {{ $rw := .VolumesRW }}
 {{range $virtualPath, $realPath := .Volumes}}


### PR DESCRIPTION
Support file injection into the containers e.g. SSH authorized keys.  An alternative is to support cloud-init, but this seems more lightweight (and cloud-init support would probably require file injection of the config files anyway!)

Injected files are first injected into a new volume-like mount that is auto-created, at /.docker.  Files to be injected are created under /.docker/files, e.g. /.docker/files/root/.ssh/authorized_keys.

Files are then recursively copied by .dockerinit from /.docker/files to /

File modes can be specified.  All files/directories are currently owned by root, and any missing directories are mode 700.  This "works for me", in that I typically want to inject system files, in particular the root ssh key.  Fixing ownership would be tricky because of different UIDs (?)

The /.docker mountpoint may be generally applicable; e.g. it may be cleaner than the specialized /etc/resolv.conf mountpoint (which then means /etc/resolv.conf is readonly in the guest).
