### PR TITLE
156 user agent header

### DIFF
--- a/api_params.go
+++ b/api_params.go
@@ -66,18 +66,6 @@ type APIVersion struct {
 	GoVersion string `json:",omitempty"`
 }
 
-func (v *APIVersion) Name() string {
-	return "docker"
-}
-
-func (v *APIVersion) Version() string {
-	r, err := json.Marshal(v)
-	if err != nil {
-		return r.Version
-	}
-	return string(r)
-}
-
 type APIWait struct {
 	StatusCode int
 }

--- a/api_params.go
+++ b/api_params.go
@@ -66,6 +66,18 @@ type APIVersion struct {
 	GoVersion string `json:",omitempty"`
 }
 
+func (v *APIVersion) Name() string {
+	return "docker"
+}
+
+func (v *APIVersion) Version() string {
+	r, err := json.Marshal(v)
+	if err != nil {
+		return r.Version
+	}
+	return string(r)
+}
+
 type APIWait struct {
 	StatusCode int
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -132,7 +132,6 @@ func (r *Registry) setUserAgent(req *http.Request, extra ...VersionChecker) {
 	}
 
 	header, _ := json.Marshal(userAgent)
-	userAgent = nil
 	req.Header.Set("User-Agent", string(header))
 	return
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -145,9 +145,7 @@ func (r *Registry) GetRemoteHistory(imgID, registry string, token []string) ([]s
 		return nil, err
 	}
 	req.Header.Set("Authorization", "Token "+strings.Join(token, ", "))
-	if err != nil {
-		return nil, err
-	}
+	r.setUserAgent(req)
 	res, err := r.client.Do(req)
 	if err != nil || res.StatusCode != 200 {
 		if res != nil {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -112,6 +112,8 @@ func doWithCookies(c *http.Client, req *http.Request) (*http.Response, error) {
 	return c.Do(req)
 }
 
+// Set the user agent field in the header based on the versions provided
+// in NewRegistry() and extra.
 func (r *Registry) setUserAgent(req *http.Request, extra ...VersionChecker) {
 	if len(r.baseVersions)+len(extra) == 0 {
 		return
@@ -582,6 +584,12 @@ func validVersion(version VersionChecker) bool {
 	return true
 }
 
+// Convert versions to a string and append the string to the string base.
+//
+// Each VersionChecker will be converted to a string in the format of
+// "product/version", where the "product" is get from the Name() method, while
+// version is get from the Version() method. Several pieces of verson information
+// will be concatinated and separated by space.
 func appendVersions(base string, versions ...VersionChecker) string {
 	if len(versions) == 0 {
 		return base

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -98,9 +98,9 @@ func ResolveRepositoryName(reposName string) (string, string, error) {
 	return endpoint, reposName, err
 }
 
-// VersionChecker is used to model entities which has a version.
+// VersionInfo is used to model entities which has a version.
 // It is basically a tupple with name and version.
-type VersionChecker interface {
+type VersionInfo interface {
 	Name() string
 	Version() string
 }
@@ -114,7 +114,7 @@ func doWithCookies(c *http.Client, req *http.Request) (*http.Response, error) {
 
 // Set the user agent field in the header based on the versions provided
 // in NewRegistry() and extra.
-func (r *Registry) setUserAgent(req *http.Request, extra ...VersionChecker) {
+func (r *Registry) setUserAgent(req *http.Request, extra ...VersionInfo) {
 	if len(r.baseVersions)+len(extra) == 0 {
 		return
 	}
@@ -569,11 +569,11 @@ type ImgData struct {
 type Registry struct {
 	client          *http.Client
 	authConfig      *auth.AuthConfig
-	baseVersions    []VersionChecker
+	baseVersions    []VersionInfo
 	baseVersionsStr string
 }
 
-func validVersion(version VersionChecker) bool {
+func validVersion(version VersionInfo) bool {
 	stopChars := " \t\r\n/"
 	if strings.ContainsAny(version.Name(), stopChars) {
 		return false
@@ -586,11 +586,11 @@ func validVersion(version VersionChecker) bool {
 
 // Convert versions to a string and append the string to the string base.
 //
-// Each VersionChecker will be converted to a string in the format of
+// Each VersionInfo will be converted to a string in the format of
 // "product/version", where the "product" is get from the Name() method, while
 // version is get from the Version() method. Several pieces of verson information
 // will be concatinated and separated by space.
-func appendVersions(base string, versions ...VersionChecker) string {
+func appendVersions(base string, versions ...VersionInfo) string {
 	if len(versions) == 0 {
 		return base
 	}
@@ -612,7 +612,7 @@ func appendVersions(base string, versions ...VersionChecker) string {
 	return buf.String()
 }
 
-func NewRegistry(root string, authConfig *auth.AuthConfig, baseVersions ...VersionChecker) (r *Registry, err error) {
+func NewRegistry(root string, authConfig *auth.AuthConfig, baseVersions ...VersionInfo) (r *Registry, err error) {
 	httpTransport := &http.Transport{
 		DisableKeepAlives: true,
 		Proxy:             http.ProxyFromEnvironment,

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -116,9 +116,11 @@ func (r *Registry) setUserAgent(req *http.Request, extra ...VersionChecker) {
 	if len(r.baseVersions)+len(extra) == 0 {
 		return
 	}
-
-	userAgent := appendVersions(r.baseVersionsStr, extra...)
-	req.Header.Set("User-Agent", userAgent)
+	if len(extra) == 0 {
+		req.Header.Set("User-Agent", r.baseVersionsStr)
+	} else {
+		req.Header.Set("User-Agent", appendVersions(r.baseVersionsStr, extra...))
+	}
 	return
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -119,9 +119,15 @@ func (r *Registry) setUserAgent(req *http.Request, extra ...VersionChecker) {
 	userAgent := make(map[string]string, len(r.baseVersions)+len(extra))
 
 	for _, v := range r.baseVersions {
+		if v == nil {
+			continue
+		}
 		userAgent[v.Name()] = v.Version()
 	}
 	for _, v := range extra {
+		if v == nil {
+			continue
+		}
 		userAgent[v.Name()] = v.Version()
 	}
 
@@ -188,7 +194,7 @@ func (r *Registry) GetRemoteImageJSON(imgID, registry string, token []string) ([
 		return nil, -1, fmt.Errorf("Failed to download json: %s", err)
 	}
 	req.Header.Set("Authorization", "Token "+strings.Join(token, ", "))
-	r.setUserAgent(req, nil)
+	r.setUserAgent(req)
 	res, err := r.client.Do(req)
 	if err != nil {
 		return nil, -1, fmt.Errorf("Failed to download json: %s", err)
@@ -216,7 +222,7 @@ func (r *Registry) GetRemoteImageLayer(imgID, registry string, token []string) (
 		return nil, fmt.Errorf("Error while getting from the server: %s\n", err)
 	}
 	req.Header.Set("Authorization", "Token "+strings.Join(token, ", "))
-	r.setUserAgent(req, nil)
+	r.setUserAgent(req)
 	res, err := r.client.Do(req)
 	if err != nil {
 		return nil, err
@@ -237,7 +243,7 @@ func (r *Registry) GetRemoteTags(registries []string, repository string, token [
 			return nil, err
 		}
 		req.Header.Set("Authorization", "Token "+strings.Join(token, ", "))
-		r.setUserAgent(req, nil)
+		r.setUserAgent(req)
 		res, err := r.client.Do(req)
 		if err != nil {
 			return nil, err
@@ -276,7 +282,7 @@ func (r *Registry) GetRepositoryData(indexEp, remote string) (*RepositoryData, e
 		req.SetBasicAuth(r.authConfig.Username, r.authConfig.Password)
 	}
 	req.Header.Set("X-Docker-Token", "true")
-	r.setUserAgent(req, nil)
+	r.setUserAgent(req)
 
 	res, err := r.client.Do(req)
 	if err != nil {
@@ -340,7 +346,7 @@ func (r *Registry) PushImageJSONRegistry(imgData *ImgData, jsonRaw []byte, regis
 	req.Header.Add("Content-type", "application/json")
 	req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
 	req.Header.Set("X-Docker-Checksum", imgData.Checksum)
-	r.setUserAgent(req, nil)
+	r.setUserAgent(req)
 
 	utils.Debugf("Setting checksum for %s: %s", imgData.ID, imgData.Checksum)
 	res, err := doWithCookies(r.client, req)
@@ -375,7 +381,7 @@ func (r *Registry) PushImageLayerRegistry(imgID string, layer io.Reader, registr
 	req.ContentLength = -1
 	req.TransferEncoding = []string{"chunked"}
 	req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
-	r.setUserAgent(req, nil)
+	r.setUserAgent(req)
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
 		return fmt.Errorf("Failed to upload layer: %s", err)
@@ -413,7 +419,7 @@ func (r *Registry) PushRegistryTag(remote, revision, tag, registry string, token
 	}
 	req.Header.Add("Content-type", "application/json")
 	req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
-	r.setUserAgent(req, nil)
+	r.setUserAgent(req)
 	req.ContentLength = int64(len(revision))
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
@@ -446,7 +452,7 @@ func (r *Registry) PushImageJSONIndex(indexEp, remote string, imgList []*ImgData
 	req.SetBasicAuth(r.authConfig.Username, r.authConfig.Password)
 	req.ContentLength = int64(len(imgListJSON))
 	req.Header.Set("X-Docker-Token", "true")
-	r.setUserAgent(req, nil)
+	r.setUserAgent(req)
 	if validate {
 		req.Header["X-Docker-Endpoints"] = regs
 	}
@@ -467,7 +473,7 @@ func (r *Registry) PushImageJSONIndex(indexEp, remote string, imgList []*ImgData
 		req.SetBasicAuth(r.authConfig.Username, r.authConfig.Password)
 		req.ContentLength = int64(len(imgListJSON))
 		req.Header.Set("X-Docker-Token", "true")
-		r.setUserAgent(req, nil)
+		r.setUserAgent(req)
 		if validate {
 			req.Header["X-Docker-Endpoints"] = regs
 		}

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -18,12 +18,12 @@ import (
 )
 
 const (
-	unitTestImageName	= "docker-test-image"
-	unitTestImageID		= "83599e29c455eb719f77d799bc7c51521b9551972f5a850d7ad265bc1b5292f6" // 1.0
-	unitTestNetworkBridge	= "testdockbr0"
-	unitTestStoreBase	= "/var/lib/docker/unit-tests"
-	testDaemonAddr		= "127.0.0.1:4270"
-	testDaemonProto		= "tcp"
+	unitTestImageName     = "docker-test-image"
+	unitTestImageID       = "83599e29c455eb719f77d799bc7c51521b9551972f5a850d7ad265bc1b5292f6" // 1.0
+	unitTestNetworkBridge = "testdockbr0"
+	unitTestStoreBase     = "/var/lib/docker/unit-tests"
+	testDaemonAddr        = "127.0.0.1:4270"
+	testDaemonProto       = "tcp"
 )
 
 var globalRuntime *Runtime

--- a/server.go
+++ b/server.go
@@ -26,6 +26,11 @@ func (srv *Server) DockerVersion() APIVersion {
 	}
 }
 
+// plainVersionChecker is a simple implementation of
+// the interface VersionChecker, which is used
+// to provide version information for some product,
+// component, etc. It stores the product name and the version
+// in string and returns them on calls to Name() and Version().
 type plainVersionChecker struct {
 	name    string
 	version string
@@ -39,6 +44,10 @@ func (v *plainVersionChecker) Version() string {
 	return v.version
 }
 
+// versionCheckers() returns version informations of:
+// docker, go, git-commit (of the docker) and the host's kernel.
+//
+// Such information will be used on call to NewRegistry().
 func (srv *Server) versionCheckers() []registry.VersionChecker {
 	v := srv.DockerVersion()
 	ret := make([]registry.VersionChecker, 0, 4)

--- a/server.go
+++ b/server.go
@@ -48,7 +48,7 @@ func (v *simpleVersionInfo) Version() string {
 // docker, go, git-commit (of the docker) and the host's kernel.
 //
 // Such information will be used on call to NewRegistry().
-func (srv *Server) versionCheckers() []registry.VersionInfo {
+func (srv *Server) versionInfos() []registry.VersionInfo {
 	v := srv.DockerVersion()
 	ret := make([]registry.VersionInfo, 0, 4)
 	ret = append(ret, &simpleVersionInfo{"docker", v.Version})
@@ -96,7 +96,7 @@ func (srv *Server) ContainerExport(name string, out io.Writer) error {
 }
 
 func (srv *Server) ImagesSearch(term string) ([]APISearch, error) {
-	r, err := registry.NewRegistry(srv.runtime.root, nil, srv.versionCheckers()...)
+	r, err := registry.NewRegistry(srv.runtime.root, nil, srv.versionInfos()...)
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +511,7 @@ func (srv *Server) poolRemove(kind, key string) error {
 }
 
 func (srv *Server) ImagePull(localName string, tag string, out io.Writer, sf *utils.StreamFormatter, authConfig *auth.AuthConfig) error {
-	r, err := registry.NewRegistry(srv.runtime.root, authConfig, srv.versionCheckers()...)
+	r, err := registry.NewRegistry(srv.runtime.root, authConfig, srv.versionInfos()...)
 	if err != nil {
 		return err
 	}
@@ -728,7 +728,7 @@ func (srv *Server) ImagePush(localName string, out io.Writer, sf *utils.StreamFo
 
 	out = utils.NewWriteFlusher(out)
 	img, err := srv.runtime.graph.Get(localName)
-	r, err2 := registry.NewRegistry(srv.runtime.root, authConfig, srv.versionCheckers()...)
+	r, err2 := registry.NewRegistry(srv.runtime.root, authConfig, srv.versionInfos()...)
 	if err2 != nil {
 		return err2
 	}

--- a/server.go
+++ b/server.go
@@ -41,7 +41,7 @@ func (v *plainVersionChecker) Version() string {
 
 func (srv *Server) versionCheckers() []registry.VersionChecker {
 	v := srv.DockerVersion()
-	ret := make([]registry.VersionChecker, 0, 3)
+	ret := make([]registry.VersionChecker, 0, 4)
 	ret = append(ret, &plainVersionChecker{"docker", v.Version})
 
 	if len(v.GoVersion) > 0 {
@@ -50,6 +50,11 @@ func (srv *Server) versionCheckers() []registry.VersionChecker {
 	if len(v.GitCommit) > 0 {
 		ret = append(ret, &plainVersionChecker{"git-commit", v.GitCommit})
 	}
+	kernelVersion, err := utils.GetKernelVersion()
+	if err == nil {
+		ret = append(ret, &plainVersionChecker{"kernel", kernelVersion.String()})
+	}
+
 	return ret
 }
 

--- a/server.go
+++ b/server.go
@@ -55,7 +55,7 @@ func (srv *Server) ContainerExport(name string, out io.Writer) error {
 }
 
 func (srv *Server) ImagesSearch(term string) ([]APISearch, error) {
-	r, err := registry.NewRegistry(srv.runtime.root, nil)
+	r, err := registry.NewRegistry(srv.runtime.root, nil, srv.DockerVersion())
 	if err != nil {
 		return nil, err
 	}
@@ -470,7 +470,7 @@ func (srv *Server) poolRemove(kind, key string) error {
 }
 
 func (srv *Server) ImagePull(localName string, tag string, out io.Writer, sf *utils.StreamFormatter, authConfig *auth.AuthConfig) error {
-	r, err := registry.NewRegistry(srv.runtime.root, authConfig)
+	r, err := registry.NewRegistry(srv.runtime.root, authConfig, srv.DockerVersion())
 	if err != nil {
 		return err
 	}
@@ -687,7 +687,7 @@ func (srv *Server) ImagePush(localName string, out io.Writer, sf *utils.StreamFo
 
 	out = utils.NewWriteFlusher(out)
 	img, err := srv.runtime.graph.Get(localName)
-	r, err2 := registry.NewRegistry(srv.runtime.root, authConfig)
+	r, err2 := registry.NewRegistry(srv.runtime.root, authConfig, srv.DockerVersion())
 	if err2 != nil {
 		return err2
 	}

--- a/server.go
+++ b/server.go
@@ -26,21 +26,21 @@ func (srv *Server) DockerVersion() APIVersion {
 	}
 }
 
-// plainVersionChecker is a simple implementation of
-// the interface VersionChecker, which is used
+// simpleVersionInfo is a simple implementation of
+// the interface VersionInfo, which is used
 // to provide version information for some product,
 // component, etc. It stores the product name and the version
 // in string and returns them on calls to Name() and Version().
-type plainVersionChecker struct {
+type simpleVersionInfo struct {
 	name    string
 	version string
 }
 
-func (v *plainVersionChecker) Name() string {
+func (v *simpleVersionInfo) Name() string {
 	return v.name
 }
 
-func (v *plainVersionChecker) Version() string {
+func (v *simpleVersionInfo) Version() string {
 	return v.version
 }
 
@@ -48,20 +48,20 @@ func (v *plainVersionChecker) Version() string {
 // docker, go, git-commit (of the docker) and the host's kernel.
 //
 // Such information will be used on call to NewRegistry().
-func (srv *Server) versionCheckers() []registry.VersionChecker {
+func (srv *Server) versionCheckers() []registry.VersionInfo {
 	v := srv.DockerVersion()
-	ret := make([]registry.VersionChecker, 0, 4)
-	ret = append(ret, &plainVersionChecker{"docker", v.Version})
+	ret := make([]registry.VersionInfo, 0, 4)
+	ret = append(ret, &simpleVersionInfo{"docker", v.Version})
 
 	if len(v.GoVersion) > 0 {
-		ret = append(ret, &plainVersionChecker{"go", v.GoVersion})
+		ret = append(ret, &simpleVersionInfo{"go", v.GoVersion})
 	}
 	if len(v.GitCommit) > 0 {
-		ret = append(ret, &plainVersionChecker{"git-commit", v.GitCommit})
+		ret = append(ret, &simpleVersionInfo{"git-commit", v.GitCommit})
 	}
 	kernelVersion, err := utils.GetKernelVersion()
 	if err == nil {
-		ret = append(ret, &plainVersionChecker{"kernel", kernelVersion.String()})
+		ret = append(ret, &simpleVersionInfo{"kernel", kernelVersion.String()})
 	}
 
 	return ret


### PR DESCRIPTION
Fixed issue #156: **Add client version to the Headers**
- Added an interface in package _registry_ named `VersionChceker`, which can be used to represent some entity who has a version.
- When create a _Registry_ with `NewRegistry()`, the user can optionally provide arbitrary number of _VersionChecker_ interfaces. The _Registry_ will remember them and put them in the _User-Agent_ header when it makes any HTTP request.
- Added a new internal method for _Registry_, named `setUserAgent()`, which can set the _User-Agent_ header for an _http.Request_. It also takes arbitrary number of _VersionChecker_ interfaces which can be used to over-write or append new version information besides the base versions (the versions sent on call to `NewRegistry()`).
- The version information contained in the _User-Agent_ header is json encoded. I'm not sure if this is what we want, but it seems better to me if it is easy to parse. (But if other format is needed instead, it won't be hard to change.)
- Right now, the client will send the following version information:
  - Docker's version
  - Git commit (if present)
  - Go version
  - Host's kernel version

Here is an example of a _User-Agent_ header: `{"docker":"0.4.2","go":"go1.1","kernel":"3.8.0-25-generic"}`
