### PR TITLE
Introduce sessions as a clean way to handle cleanup of temp. containers

### DIFF
--- a/api_params.go
+++ b/api_params.go
@@ -42,6 +42,17 @@ type APIContainers struct {
 	SizeRootFs int64
 }
 
+type APISessions struct {
+	ID         string `json:"Id"`
+	Created    int64
+
+	Name string
+	AutomaticRelease bool
+	Timeout int64
+
+	Containers []APIContainers
+}
+
 type APISearch struct {
 	Name        string
 	Description string

--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -100,7 +100,7 @@ func TestBuild(t *testing.T) {
 			pushingPool: make(map[string]struct{}),
 		}
 
-		buildfile := NewBuildFile(srv, ioutil.Discard)
+		buildfile := NewBuildFile(srv, ioutil.Discard, "")
 		if _, err := buildfile.Build(mkTestContext(ctx.dockerfile, ctx.files, t)); err != nil {
 			t.Fatal(err)
 		}

--- a/container.go
+++ b/container.go
@@ -26,6 +26,8 @@ type Container struct {
 
 	ID string
 
+	Session string
+
 	Created time.Time
 
 	Path string
@@ -76,6 +78,7 @@ type Config struct {
 	Image        string // Name of the image as it was passed by the operator (eg. could be symbolic)
 	Volumes      map[string]struct{}
 	VolumesFrom  string
+    Session string // id of the session, this container belongs to
 }
 
 type HostConfig struct {
@@ -102,6 +105,7 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 	flStdin := cmd.Bool("i", false, "Keep stdin open even if not attached")
 	flTty := cmd.Bool("t", false, "Allocate a pseudo-tty")
 	flMemory := cmd.Int64("m", 0, "Memory limit (in bytes)")
+	flSession := cmd.String("s", "", "Session")
 
 	if capabilities != nil && *flMemory > 0 && !capabilities.MemoryLimit {
 		//fmt.Fprintf(stdout, "WARNING: Your kernel does not support memory limit capabilities. Limitation discarded.\n")
@@ -177,6 +181,7 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 		Image:        image,
 		Volumes:      flVolumes,
 		VolumesFrom:  *flVolumesFrom,
+		Session: *flSession,
 	}
 	hostConfig := &HostConfig{
 		Binds: flBinds,

--- a/session.go
+++ b/session.go
@@ -1,0 +1,71 @@
+package docker
+
+import (
+	"encoding/json"
+	"github.com/dotcloud/docker/utils"
+	"io/ioutil"
+	"time"
+	"path"
+)
+
+type Session struct {
+	root string
+	ID string
+
+Created time.Time
+
+	Name string
+	AutomaticRelease bool
+	Timeout int64
+
+	Path string
+
+	runtime *Runtime
+}
+
+
+type SessionConfig struct {
+	AutomaticRelease bool
+	Timeout int64
+	Name string
+}
+
+func (session *Session) When() time.Time {
+	return session.Created
+}
+
+
+func (session *Session) jsonPath() string {
+	return path.Join(session.root, "config.json")
+}
+
+
+func (session *Session) FromDisk() error {
+	data, err := ioutil.ReadFile(session.jsonPath())
+	if err != nil {
+		return err
+	}
+	// Load session settings
+	if err := json.Unmarshal(data, session); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (session *Session) ToDisk() (err error) {
+	data, err := json.Marshal(session)
+	if err != nil {
+		return
+	}
+	return ioutil.WriteFile(session.jsonPath(), data, 0666)
+}
+
+// ShortID returns a shorthand version of the session's id for convenience.
+// A collision with other session shorthands is very unlikely, but possible.
+// In case of a collision a lookup with Runtime.Get() will fail, and the caller
+// will need to use a langer prefix, or the full-length session Id.
+func (session *Session) ShortID() string {
+	return utils.TruncateID(session.ID)
+}
+
+


### PR DESCRIPTION
Introduce sessions as a clean way to handle cleanup of temporary containers.
# Why?

When working with docker, especially the builder a lot of temporary containers
are required.

In a production environment keeping old containers is important too.

So if there was a way to distinct between short lived containers that are
tempoary and those that need to be kept an automatic clean up routine could
take care of the containers that are not interesting any more.
# How?

Before work start a new session. This is optional, if you do not create a
session the behavior of docker is the same as before.

DOCKER_SESSION=`docker session`

In this example we create a simple session, that has no name and will not be
automatically cleaned.

On the docker commands run and build you can specify the session, to attach
the newly created container to the session.

docker run -s $DOCKER_SESSION ....
docker build -s $DOCKER_SESSION ....

Afterwards the sessions can be listed with

docker sessions

or if you want to see the containers

docker sessions -c

The filter options from docker ps work too.

To clean up you simply call

docker clean

Sessions will be cleaned only if a timeout was set, and there is no active
container, and no container has been active within the time of the timeout. If
the session itself is younger as the timeout it wont be collected.

If you do not need to automatically clean up, you still can use sessions as a
grouping function.

To delete a session explicitly call

docker rms  <sessionid>
# 

Please let me know what you think. I am aware of the fact that this feature might be more and less usefull for different users.
