### PR TITLE
Adding check for content-type header

### DIFF
--- a/api.go
+++ b/api.go
@@ -555,8 +555,10 @@ func postContainersStart(srv *Server, version float64, w http.ResponseWriter, r 
 
 	// allow a nil body for backwards compatibility
 	if r.Body != nil {
-		if err := json.NewDecoder(r.Body).Decode(hostConfig); err != nil {
-			return err
+		if r.Header.Get("Content-Type") == "application/json" {
+			if err := json.NewDecoder(r.Body).Decode(hostConfig); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This fixes #1069 but I think there may be a deeper error that may need attention and may make this somewhat irrelevant. Also, if checking Content-Type like this is desired here there are probably several other places it should be applied in api.go.
