### PR TITLE
fixed #910. print user name to docker info output

### DIFF
--- a/api_params.go
+++ b/api_params.go
@@ -17,16 +17,17 @@ type APIImages struct {
 }
 
 type APIInfo struct {
-	Debug           bool
-	Containers      int
-	Images          int
-	NFd             int    `json:",omitempty"`
-	NGoroutines     int    `json:",omitempty"`
-	MemoryLimit     bool   `json:",omitempty"`
-	SwapLimit       bool   `json:",omitempty"`
-	LXCVersion      string `json:",omitempty"`
-	NEventsListener int    `json:",omitempty"`
-	KernelVersion   string `json:",omitempty"`
+	Debug              bool
+	Containers         int
+	Images             int
+	NFd                int    `json:",omitempty"`
+	NGoroutines        int    `json:",omitempty"`
+	MemoryLimit        bool   `json:",omitempty"`
+	SwapLimit          bool   `json:",omitempty"`
+	LXCVersion         string `json:",omitempty"`
+	NEventsListener    int    `json:",omitempty"`
+	KernelVersion      string `json:",omitempty"`
+	IndexServerAddress string `json:",omitempty"`
 }
 
 type APITop struct {

--- a/commands.go
+++ b/commands.go
@@ -495,6 +495,11 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		fmt.Fprintf(cli.out, "EventsListeners: %d\n", out.NEventsListener)
 		fmt.Fprintf(cli.out, "Kernel Version: %s\n", out.KernelVersion)
 	}
+	if cli.authConfig != nil {
+		fmt.Fprintf(cli.out, "Username: %v\n", cli.authConfig.Username)
+		// XXX Should we print registry address even if the user was not logged in?
+		fmt.Fprintf(cli.out, "Registry: %v\n", auth.IndexServerAddress())
+	}
 	if !out.MemoryLimit {
 		fmt.Fprintf(cli.err, "WARNING: No memory limit support\n")
 	}

--- a/commands.go
+++ b/commands.go
@@ -495,6 +495,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		fmt.Fprintf(cli.out, "EventsListeners: %d\n", out.NEventsListener)
 		fmt.Fprintf(cli.out, "Kernel Version: %s\n", out.KernelVersion)
 	}
+
 	if len(out.IndexServerAddress) != 0 {
 		u := cli.configFile.Configs[out.IndexServerAddress].Username
 		if len(u) > 0 {

--- a/commands.go
+++ b/commands.go
@@ -495,10 +495,12 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		fmt.Fprintf(cli.out, "EventsListeners: %d\n", out.NEventsListener)
 		fmt.Fprintf(cli.out, "Kernel Version: %s\n", out.KernelVersion)
 	}
-	if cli.authConfig != nil {
-		fmt.Fprintf(cli.out, "Username: %v\n", cli.authConfig.Username)
-		// XXX Should we print registry address even if the user was not logged in?
-		fmt.Fprintf(cli.out, "Registry: %v\n", auth.IndexServerAddress())
+	if len(out.IndexServerAddress) != 0 {
+		u := cli.configFile.Configs[out.IndexServerAddress].Username
+		if len(u) > 0 {
+			fmt.Fprintf(cli.out, "Username: %v\n", u)
+			fmt.Fprintf(cli.out, "Registry: %v\n", out.IndexServerAddress)
+		}
 	}
 	if !out.MemoryLimit {
 		fmt.Fprintf(cli.err, "WARNING: No memory limit support\n")

--- a/server.go
+++ b/server.go
@@ -265,16 +265,17 @@ func (srv *Server) DockerInfo() *APIInfo {
 	}
 
 	return &APIInfo{
-		Containers:      len(srv.runtime.List()),
-		Images:          imgcount,
-		MemoryLimit:     srv.runtime.capabilities.MemoryLimit,
-		SwapLimit:       srv.runtime.capabilities.SwapLimit,
-		Debug:           os.Getenv("DEBUG") != "",
-		NFd:             utils.GetTotalUsedFds(),
-		NGoroutines:     runtime.NumGoroutine(),
-		LXCVersion:      lxcVersion,
-		NEventsListener: len(srv.events),
-		KernelVersion:   kernelVersion,
+		Containers:         len(srv.runtime.List()),
+		Images:             imgcount,
+		MemoryLimit:        srv.runtime.capabilities.MemoryLimit,
+		SwapLimit:          srv.runtime.capabilities.SwapLimit,
+		Debug:              os.Getenv("DEBUG") != "",
+		NFd:                utils.GetTotalUsedFds(),
+		NGoroutines:        runtime.NumGoroutine(),
+		LXCVersion:         lxcVersion,
+		NEventsListener:    len(srv.events),
+		KernelVersion:      kernelVersion,
+		IndexServerAddress: auth.IndexServerAddress(),
 	}
 }
 


### PR DESCRIPTION
fixed #910. 
Example output:

```
$ ./docker info
Containers: 12
Images: 3
Username: monnand
Registry: https://index.docker.io/v1
WARNING: No swap limit support
```
