### PR TITLE
More unit test fixes

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -142,12 +142,13 @@ func TestGetImagesJSON(t *testing.T) {
 
 	srv := &Server{runtime: runtime}
 
-	initialImages, err := srv.Images(true, "")
+	// all=0
+
+	initialImages, err := srv.Images(false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// all=0
 	req, err := http.NewRequest("GET", "/images/json?all=0", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -182,6 +183,12 @@ func TestGetImagesJSON(t *testing.T) {
 	r2 := httptest.NewRecorder()
 
 	// all=1
+
+	initialImages, err = srv.Images(true, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	req2, err := http.NewRequest("GET", "/images/json?all=true", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -352,7 +359,7 @@ func TestGetImagesByName(t *testing.T) {
 	if err := json.Unmarshal(r.Body.Bytes(), img); err != nil {
 		t.Fatal(err)
 	}
-	if img.ID != GetTestImage(runtime).ID || img.Comment != "Imported from http://get.docker.io/images/busybox" {
+	if img.ID != unitTestImageId {
 		t.Errorf("Error inspecting image")
 	}
 }

--- a/container_test.go
+++ b/container_test.go
@@ -511,12 +511,11 @@ func TestKillDifferentUser(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Give some time to lxc to spawn the process (setuid might take some time)
-	container.WaitTimeout(500 * time.Millisecond)
-
-	if !container.State.Running {
-		t.Errorf("Container should be running")
-	}
+	setTimeout(t, "Waiting for the container to be started timed out", 2 * time.Second, func() {
+		for !container.State.Running {
+			time.Sleep(10 * time.Millisecond)
+		}
+	})
 
 	if err := container.Kill(); err != nil {
 		t.Fatal(err)
@@ -1001,7 +1000,7 @@ func TestEnv(t *testing.T) {
 	defer nuke(runtime)
 	container, err := NewBuilder(runtime).Create(&Config{
 		Image: GetTestImage(runtime).ID,
-		Cmd:   []string{"/usr/bin/env"},
+		Cmd:   []string{"env"},
 	},
 	)
 	if err != nil {

--- a/contrib/mkimage-unittest.sh
+++ b/contrib/mkimage-unittest.sh
@@ -23,7 +23,9 @@ mkdir bin etc dev dev/pts lib proc sys tmp
 touch etc/resolv.conf
 cp /etc/nsswitch.conf etc/nsswitch.conf
 echo root:x:0:0:root:/:/bin/sh > etc/passwd
+echo daemon:x:1:1:daemon:/usr/sbin:/bin/sh >> etc/passwd
 echo root:x:0: > etc/group
+echo daemon:x:1: >> etc/group
 ln -s lib lib64
 ln -s bin sbin
 cp $BUSYBOX $SOCAT bin
@@ -41,6 +43,7 @@ do
     cp -a /dev/$X dev
 done
 
+chmod 0755 $ROOTFS # See #486
 tar -cf- . | docker import - docker-ut
 docker run -i -u root docker-ut /bin/echo Success.
 rm -rf $ROOTFS


### PR DESCRIPTION
- Fix TestGetImagesJSON when there is more than one image in the test
  repository;
- Remove an hardcoded constant use in TestGetImagesByName;
- Wait in a loop in TestKillDifferentUser;
- Use env instead of /usr/bin/env in TestEnv;
- Create a daemon user in contrib/mkimage-unittest.sh.

I think we are pretty close to something that finally works. Next steps are:
- clean up the docker-ut repository on the index (so older tests can continue to work, see #1072);
- switch to a new test image repository (I guess we can keep docker-unit-tests), with an updated image (so I can make a pull request for #33).
