### PR TITLE
Fixes issue #899 that prevents committing a container which hasn't been started yet

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -79,6 +79,11 @@ func (builder *Builder) Create(config *Config) (*Container, error) {
 	if err := os.Mkdir(container.root, 0700); err != nil {
 		return nil, err
 	}
+	
+	// create the 'rw' directory in case a container is commited without being started
+	if err := os.Mkdir(path.Join(container.root, "rw"), 0755); err != nil {
+		return nil, err
+	}
 
 	if len(config.Dns) == 0 && len(builder.runtime.Dns) == 0 && utils.CheckLocalDns() {
 		//"WARNING: Docker detected local DNS server on resolv.conf. Using default external servers: %v", defaultDns


### PR DESCRIPTION
Create the 'rw' directory when the container is created to prevent crashing if the container is committed to an image before it is started (and hence before any aufs writes create the 'rw' directory implicitly).  Something is expecting 'rw' to exist which causes a crash.
