### PR TITLE
Fix installation link from welcome page.

### DIFF
--- a/docs/sources/index.rst
+++ b/docs/sources/index.rst
@@ -32,7 +32,7 @@ For an overview of Docker, please see the `Introduction
 <http://www.docker.io>`_. When you're ready to start working with
 Docker, we have a `quick start <http://www.docker.io/gettingstarted>`_
 and a more in-depth guide to :ref:`ubuntu_linux` and other
-`installation </installation>`_ paths including prebuilt binaries,
+:ref:`installation_list` paths including prebuilt binaries,
 Vagrant-created VMs, Rackspace and Amazon instances.
 
 Enough reading! :ref:`Try it out! <running_examples>`

--- a/docs/sources/installation/index.rst
+++ b/docs/sources/installation/index.rst
@@ -1,11 +1,16 @@
-:title: Documentation
-:description: -- todo: change me
-:keywords: todo, docker, documentation, installation, OS support
+:title: Docker Installation
+:description: many ways to install Docker
+:keywords: docker, installation
 
-
+.. _installation_list:
 
 Installation
 ============
+
+There are a number of ways to install Docker, depending on where you
+want to run the daemon. The :ref:`ubuntu_linux` installation is the
+officially-tested version, and the community adds more techniques for
+installing Docker all the time.
 
 Contents:
 


### PR DESCRIPTION
The /installation works in a test local server but not on the live docs. I think changing it to a `:ref:` will fix it since other ref's work. The ref continues to work on the local server test as well.
