### PR TITLE
fix tag when pulling an image via docker run

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1256,7 +1256,13 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	//if image not found try to pull it
 	if statusCode == 404 {
 		v := url.Values{}
-		v.Set("fromImage", config.Image)
+		if strings.Contains(config.Image, ":") {
+			remoteParts := strings.Split(config.Image, ":")
+			v.Set("fromImage", remoteParts[0])
+			v.Set("tag", remoteParts[1])
+		} else {
+			v.Set("fromImage", config.Image)
+		}
 		err = cli.stream("POST", "/images/create?"+v.Encode(), nil, cli.err)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes #1119 

When docker run an unknown image, it fails if we specify the tag

```
$> COUCH1=$(docker run -d -v /var/lib/couchdb shykes/couchdb:2013-05-03) 20:10:57
Pulling repository shykes/couchdb:2013-05-03 from https://index.docker.io/v1
2013/07/03 20:11:06 Error: No such image: shykes/couchdb:2013-05-03
$>
```

Thanks @rogaha for noticing
