### PR TITLE
add websocket support to /container/<name>/attach/ws

### DIFF
--- a/api.go
+++ b/api.go
@@ -914,7 +914,7 @@ func makeHttpHandler(srv *Server, logging bool, localMethod string, localRoute s
 func createRouter(srv *Server, logging bool) (*mux.Router, error) {
 	r := mux.NewRouter()
 
-	m := map[string]map[string]func(*Server, float64, http.ResponseWriter, *http.Request, map[string]string) error{
+	m := map[string]map[string]HttpApiFunc{
 		"GET": {
 			"/auth":                           getAuth,
 			"/version":                        getVersion,

--- a/api.go
+++ b/api.go
@@ -23,7 +23,6 @@ const DEFAULTHTTPHOST string = "127.0.0.1"
 const DEFAULTHTTPPORT int = 4243
 
 type HttpApiFunc func(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error
-type WsApiFunc func(srv *Server, ws *websocket.Conn, vars map[string]string) error
 
 func hijackServer(w http.ResponseWriter) (io.ReadCloser, io.Writer, error) {
 	conn, _, err := w.(http.Hijacker).Hijack()

--- a/api.go
+++ b/api.go
@@ -876,14 +876,6 @@ func writeCorsHeaders(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, OPTIONS")
 }
 
-func logRequest(logging bool, localMethod string, localRoute string, r *http.Request) {
-	utils.Debugf("Calling %s %s", localMethod, localRoute)
-
-	if logging {
-		log.Println(r.Method, r.RequestURI)
-	}
-}
-
 func makeHttpHandler(srv *Server, logging bool, localMethod string, localRoute string, handlerFunc HttpApiFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// log the request

--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -34,13 +34,20 @@ Dependencies
 
 **Linux kernel 3.8**
 
-Due to a bug in LXC docker works best on the 3.8 kernel. Precise comes with a 3.2 kernel, so we need to upgrade it. The kernel we install comes with AUFS built in.
+Due to a bug in LXC, docker works best on the 3.8 kernel. Precise
+comes with a 3.2 kernel, so we need to upgrade it. The kernel we
+install comes with AUFS built in. We also include the generic headers
+to enable packages that depend on them, like ZFS and the VirtualBox
+guest additions. If you didn't install the headers for your "precise"
+kernel, then you can skip these headers for the "raring" kernel. But
+it is safer to include them if you're not sure.
 
 
 .. code-block:: bash
 
    # install the backported kernel
-   sudo apt-get update && sudo apt-get install linux-image-generic-lts-raring
+   sudo apt-get update
+   sudo apt-get install linux-image-generic-lts-raring linux-headers-generic-lts-raring
 
    # reboot
    sudo reboot

--- a/network.go
+++ b/network.go
@@ -131,8 +131,8 @@ func CreateBridgeIface(ifaceName string) error {
 		// In theory this shouldn't matter - in practice there's bound to be a few scripts relying
 		// on the internal addressing or other stupid things like that.
 		// The shouldn't, but hey, let's not break them unless we really have to.
-		"172.16.42.1/16",
-		"10.0.42.1/16", // Don't even try using the entire /8, that's too intrusive
+		"172.17.42.1/16", // Don't use 172.16.0.0/16, it conflicts with EC2 DNS 172.16.0.23
+		"10.0.42.1/16",   // Don't even try using the entire /8, that's too intrusive
 		"10.1.42.1/16",
 		"10.42.42.1/16",
 		"172.16.42.1/24",


### PR DESCRIPTION
This function add the possibility to attach containers streams to a
websocket. When a websocket is asked the request is upgraded to this
protocol..

Partly fix #876 and fix #879

Example of usage:

```
package main

import (
    "fmt"
    "code.google.com/p/go.net/websocket"
)

func main() {
    origin := "http://localhost/"
    // replace by a working url
    url := "ws://localhost:4243/v1.3/containers/450a8d4a34ee/attach/ws?logs=1&stderr=1&stdout=1"
    ws, err := websocket.Dial(url, "", origin)
    if err != nil {
        fmt.Printf("error: %s", err)
        return
    }


    for {
        msg := make([]byte, 500)
        var n int
        if n, err = ws.Read(msg); err != nil {
            break
        }
        fmt.Printf("%s.\n", msg[:n])
    }
}
```
