### PR TITLE
CmdAdd and CmdEnv now respect Dockerfile-set ENV variables

### DIFF
--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -99,6 +99,36 @@ CMD Hello world
 `,
 		nil,
 	},
+
+	{
+		`
+from %s
+env    FOO /foo/baz
+env    BAR /bar
+env    BAZ $BAR
+env    FOOPATH $PATH:$FOO
+run    [ "$BAR" = "$BAZ" ]
+run    [ "$FOOPATH" = "$PATH:/foo/baz" ]
+`,
+		nil,
+	},
+
+	{
+		`
+from %s
+env    FOO /bar
+env    TEST testdir
+env    BAZ /foobar
+add    testfile $BAZ/
+add    $TEST $FOO
+run    [ "$(cat /foobar/testfile)" = "test1" ]
+run    [ "$(cat /bar/withfile)" = "test2" ]
+`,
+		[][2]string{
+			{"testfile", "test1"},
+			{"testdir/withfile", "test2"},
+		},
+	},
 }
 
 // FIXME: test building with 2 successive overlapping ADD commands

--- a/commands.go
+++ b/commands.go
@@ -1237,6 +1237,28 @@ func (opts AttachOpts) Get(val string) bool {
 	return false
 }
 
+//EnvOpts stores a unique set of environment variables
+type EnvOpts map[string]string
+
+func NewEnvOpts() EnvOpts {
+	return make(EnvOpts)
+}
+
+func (opts EnvOpts) String() string {
+	return fmt.Sprintf("%v", map[string]string(opts))
+}
+
+func (opts EnvOpts) Set(val string) error {
+	parts := strings.SplitN(val, "=", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("Bad environment variable assignment: %s", val)
+	}
+	key := parts[0]
+	value := parts[1]
+	opts[key] = value
+	return nil
+}
+
 // PathOpts stores a unique set of absolute paths
 type PathOpts map[string]struct{}
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -59,7 +59,6 @@ func assertPipe(input, output string, r io.Reader, w io.Writer, count int) error
 	return nil
 }
 
-
 // TestRunHostname checks that 'docker run -h' correctly sets a custom hostname
 func TestRunHostname(t *testing.T) {
 	stdout, stdoutPipe := io.Pipe()
@@ -90,7 +89,6 @@ func TestRunHostname(t *testing.T) {
 	})
 
 }
-
 
 // TestAttachStdin checks attaching to stdin without stdout and stderr.
 // 'docker run -i -a stdin' should sends the client's stdin to the command,

--- a/container.go
+++ b/container.go
@@ -70,7 +70,7 @@ type Config struct {
 	Tty          bool // Attach standard streams to a tty, including stdin if it is not closed.
 	OpenStdin    bool // Open stdin
 	StdinOnce    bool // If true, close stdin after the 1 attached client disconnects.
-	Env          []string
+	Env          map[string]string
 	Cmd          []string
 	Dns          []string
 	Image        string // Name of the image as it was passed by the operator (eg. could be symbolic)
@@ -114,8 +114,8 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 	var flPorts ListOpts
 	cmd.Var(&flPorts, "p", "Expose a container's port to the host (use 'docker port' to see the actual mapping)")
 
-	var flEnv ListOpts
-	cmd.Var(&flEnv, "e", "Set environment variables")
+	flEnv := NewEnvOpts()
+	cmd.Var(flEnv, "e", "Set environment variables")
 
 	var flDns ListOpts
 	cmd.Var(&flDns, "dns", "Set custom dns servers")
@@ -629,8 +629,8 @@ func (container *Container) Start(hostConfig *HostConfig) error {
 		"-e", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 	)
 
-	for _, elem := range container.Config.Env {
-		params = append(params, "-e", elem)
+	for key, value := range container.Config.Env {
+		params = append(params, "-e", key+"="+value)
 	}
 
 	// Program

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -18,12 +18,12 @@ import (
 )
 
 const (
-	unitTestImageName	= "docker-test-image"
-	unitTestImageID		= "83599e29c455eb719f77d799bc7c51521b9551972f5a850d7ad265bc1b5292f6" // 1.0
-	unitTestNetworkBridge	= "testdockbr0"
-	unitTestStoreBase	= "/var/lib/docker/unit-tests"
-	testDaemonAddr		= "127.0.0.1:4270"
-	testDaemonProto		= "tcp"
+	unitTestImageName     = "docker-test-image"
+	unitTestImageID       = "83599e29c455eb719f77d799bc7c51521b9551972f5a850d7ad265bc1b5292f6" // 1.0
+	unitTestNetworkBridge = "testdockbr0"
+	unitTestStoreBase     = "/var/lib/docker/unit-tests"
+	testDaemonAddr        = "127.0.0.1:4270"
+	testDaemonProto       = "tcp"
 )
 
 var globalRuntime *Runtime

--- a/utils.go
+++ b/utils.go
@@ -35,8 +35,8 @@ func CompareConfig(a, b *Config) bool {
 			return false
 		}
 	}
-	for i := 0; i < len(a.Env); i++ {
-		if a.Env[i] != b.Env[i] {
+	for key, _ := range a.Env {
+		if a.Env[key] != b.Env[key] {
 			return false
 		}
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,13 +1,13 @@
 package docker
 
 import (
+	"github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
 	"strings"
 	"testing"
-	"github.com/dotcloud/docker/utils"
 )
 
 // This file contains utility functions for docker's unit test suite.


### PR DESCRIPTION
Fixes #1136

Notes:

This changes the type of environment variable options.
Building and running the following dockerfile will produce the functionality of the output that follows it.

```
#Dockerfile. Directory also has a directory named 'testdir' which contains a file named 'myfile'.
FROM ubuntu:12.10
ENV DESTPATH /foobar
ENV ORIGPATH ./testdir
ENV FOOPATH $ORIGPATH/dir${DESTPATH}/dir
ADD $ORIGPATH $DESTPATH/$ORIGPATH
RUN echo $FOOPATH
#docker logs outputs './testdir/dir/foobar/dir'

#docker run -i -t image /bin/bash
$ ls / | grep foobar
foobar
$ cd /foobar && ls
testdir
$ cd testdir && ls
myfile
```
