### PR TITLE
basic version of the /events endpoint

### DIFF
--- a/api_params.go
+++ b/api_params.go
@@ -17,13 +17,14 @@ type APIImages struct {
 }
 
 type APIInfo struct {
-	Debug       bool
-	Containers  int
-	Images      int
-	NFd         int  `json:",omitempty"`
-	NGoroutines int  `json:",omitempty"`
-	MemoryLimit bool `json:",omitempty"`
-	SwapLimit   bool `json:",omitempty"`
+	Debug           bool
+	Containers      int
+	Images          int
+	NFd             int  `json:",omitempty"`
+	NGoroutines     int  `json:",omitempty"`
+	MemoryLimit     bool `json:",omitempty"`
+	SwapLimit       bool `json:",omitempty"`
+	NEventsListener int  `json:",omitempty"`
 }
 
 type APITop struct {

--- a/commands.go
+++ b/commands.go
@@ -78,6 +78,7 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 		{"build", "Build a container from a Dockerfile"},
 		{"commit", "Create a new image from a container's changes"},
 		{"diff", "Inspect changes on a container's filesystem"},
+		{"events", "Get real time events from the server"},
 		{"export", "Stream the contents of a container as a tar archive"},
 		{"history", "Show the history of an image"},
 		{"images", "List images"},
@@ -466,6 +467,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		fmt.Fprintf(cli.out, "Debug mode (client): %v\n", os.Getenv("DEBUG") != "")
 		fmt.Fprintf(cli.out, "Fds: %d\n", out.NFd)
 		fmt.Fprintf(cli.out, "Goroutines: %d\n", out.NGoroutines)
+		fmt.Fprintf(cli.out, "EventsListeners: %d\n", out.NEventsListener)
 	}
 	if !out.MemoryLimit {
 		fmt.Fprintf(cli.err, "WARNING: No memory limit support\n")
@@ -1055,6 +1057,23 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	return nil
 }
 
+func (cli *DockerCli) CmdEvents(args ...string) error {
+	cmd := Subcmd("events", "", "Get real time events from the server")
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+
+	if cmd.NArg() != 0 {
+		cmd.Usage()
+		return nil
+	}
+
+	if err := cli.stream("GET", "/events", nil, cli.out); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (cli *DockerCli) CmdExport(args ...string) error {
 	cmd := Subcmd("export", "CONTAINER", "Export the contents of a filesystem as a tar archive")
 	if err := cmd.Parse(args); err != nil {
@@ -1509,19 +1528,13 @@ func (cli *DockerCli) stream(method, path string, in io.Reader, out io.Writer) e
 	if resp.Header.Get("Content-Type") == "application/json" {
 		dec := json.NewDecoder(resp.Body)
 		for {
-			var m utils.JSONMessage
-			if err := dec.Decode(&m); err == io.EOF {
+			var jm utils.JSONMessage
+			if err := dec.Decode(&jm); err == io.EOF {
 				break
 			} else if err != nil {
 				return err
 			}
-			if m.Progress != "" {
-				fmt.Fprintf(out, "%s %s\r", m.Status, m.Progress)
-			} else if m.Error != "" {
-				return fmt.Errorf(m.Error)
-			} else {
-				fmt.Fprintf(out, "%s\n", m.Status)
-			}
+			jm.Display(out)
 		}
 	} else {
 		if _, err := io.Copy(out, resp.Body); err != nil {

--- a/commands.go
+++ b/commands.go
@@ -1058,7 +1058,8 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 }
 
 func (cli *DockerCli) CmdEvents(args ...string) error {
-	cmd := Subcmd("events", "", "Get real time events from the server")
+	cmd := Subcmd("events", "[OPTIONS]", "Get real time events from the server")
+	since := cmd.String("since", "", "Show events previously created (used for polling).")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -1068,7 +1069,12 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 		return nil
 	}
 
-	if err := cli.stream("GET", "/events", nil, cli.out); err != nil {
+	v := url.Values{}
+	if *since != "" {
+		v.Set("since", *since)
+	}
+
+	if err := cli.stream("GET", "/events?"+v.Encode(), nil, cli.out); err != nil {
 		return err
 	}
 	return nil

--- a/commands_test.go
+++ b/commands_test.go
@@ -38,7 +38,7 @@ func setTimeout(t *testing.T, msg string, d time.Duration, f func()) {
 		f()
 		c <- false
 	}()
-	if <-c {
+	if <-c && msg != "" {
 		t.Fatal(msg)
 	}
 }

--- a/container.go
+++ b/container.go
@@ -789,7 +789,9 @@ func (container *Container) monitor() {
 		}
 	}
 	utils.Debugf("Process finished")
-
+	if container.runtime != nil && container.runtime.srv != nil {
+		container.runtime.srv.LogEvent("die", container.ShortID())
+	}
 	exitCode := -1
 	if container.cmd != nil {
 		exitCode = container.cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()

--- a/docs/sources/api/docker_remote_api.rst
+++ b/docs/sources/api/docker_remote_api.rst
@@ -44,6 +44,10 @@ What's new
 
    **New!** List the processes running inside a container.
 
+.. http:get:: /events:
+
+   **New!** Monitor docker's events via streaming or via polling
+
 Builder (/build):
 
 - Simplify the upload of the build context

--- a/docs/sources/api/docker_remote_api_v1.3.rst
+++ b/docs/sources/api/docker_remote_api_v1.3.rst
@@ -1059,6 +1059,36 @@ Create a new image from a container's changes
         :statuscode 500: server error
 
 
+Monitor Docker's events
+***********************
+
+.. http:get:: /events
+
+	Get events from docker, either in real time via streaming, or via polling (using `since`)
+
+	**Example request**:
+
+	.. sourcecode:: http
+
+           POST /events?since=1374067924
+
+        **Example response**:
+
+        .. sourcecode:: http
+
+           HTTP/1.1 200 OK
+	   Content-Type: application/json
+
+	   {"status":"create","id":"dfdf82bd3881","time":1374067924}
+	   {"status":"start","id":"dfdf82bd3881","time":1374067924}
+	   {"status":"stop","id":"dfdf82bd3881","time":1374067966}
+	   {"status":"destroy","id":"dfdf82bd3881","time":1374067970}
+
+	:query since: timestamp used for polling
+        :statuscode 200: no error
+        :statuscode 500: server error
+
+
 3. Going further
 ================
 

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -17,12 +17,12 @@ import (
 )
 
 const (
-	unitTestImageName	= "docker-test-image"
-	unitTestImageID		= "83599e29c455eb719f77d799bc7c51521b9551972f5a850d7ad265bc1b5292f6" // 1.0
-	unitTestNetworkBridge	= "testdockbr0"
-	unitTestStoreBase	= "/var/lib/docker/unit-tests"
-	testDaemonAddr		= "127.0.0.1:4270"
-	testDaemonProto		= "tcp"
+	unitTestImageName     = "docker-test-image"
+	unitTestImageID       = "83599e29c455eb719f77d799bc7c51521b9551972f5a850d7ad265bc1b5292f6" // 1.0
+	unitTestNetworkBridge = "testdockbr0"
+	unitTestStoreBase     = "/var/lib/docker/unit-tests"
+	testDaemonAddr        = "127.0.0.1:4270"
+	testDaemonProto       = "tcp"
 )
 
 var globalRuntime *Runtime

--- a/server.go
+++ b/server.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 )
 
 func (srv *Server) DockerVersion() APIVersion {
@@ -953,7 +954,7 @@ func (srv *Server) deleteImage(img *Image, repoName, tag string) ([]APIRmi, erro
 	}
 	if tagDeleted {
 		imgs = append(imgs, APIRmi{Untagged: img.ShortID()})
-		srv.SendEvent("untagged", img.ShortID())
+		srv.SendEvent("untag", img.ShortID())
 	}
 	if len(srv.runtime.repositories.ByID()[img.ID]) == 0 {
 		if err := srv.deleteImageAndChildren(img.ID, &imgs); err != nil {
@@ -1180,7 +1181,7 @@ func NewServer(flGraphPath string, autoRestart, enableCors bool, dns ListOpts) (
 
 func (srv *Server) SendEvent(action, id string) {
 	for _, c := range srv.events {
-		c <- utils.JSONMessage{Status: action, ID: id}
+		c <- utils.JSONMessage{Status: action, ID: id, Time: time.Now().Unix()}
 	}
 }
 

--- a/server.go
+++ b/server.go
@@ -1185,7 +1185,10 @@ func (srv *Server) LogEvent(action, id string) {
 	jm := utils.JSONMessage{Status: action, ID: id, Time: now}
 	srv.events = append(srv.events, jm)
 	for _, c := range srv.listeners {
-		c <- jm
+		select { // non blocking channel
+		case c <- jm:
+		default:
+		}
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -1,7 +1,9 @@
 package docker
 
 import (
+	"github.com/dotcloud/docker/utils"
 	"testing"
+	"time"
 )
 
 func TestContainerTagImageDelete(t *testing.T) {
@@ -161,5 +163,43 @@ func TestRunWithTooLowMemoryLimit(t *testing.T) {
 	if err == nil {
 		t.Errorf("Memory limit is smaller than the allowed limit. Container creation should've failed!")
 	}
+
+}
+
+func TestLogEvent(t *testing.T) {
+	runtime := mkRuntime(t)
+	srv := &Server{
+		runtime:   runtime,
+		events:    make([]utils.JSONMessage, 0, 64),
+		listeners: make(map[string]chan utils.JSONMessage),
+	}
+
+	srv.LogEvent("fakeaction", "fakeid")
+
+	listener := make(chan utils.JSONMessage)
+	srv.Lock()
+	srv.listeners["test"] = listener
+	srv.Unlock()
+
+	srv.LogEvent("fakeaction2", "fakeid")
+
+	if len(srv.events) != 2 {
+		t.Fatalf("Expected 2 events, found %d", len(srv.events))
+	}
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		srv.LogEvent("fakeaction3", "fakeid")
+		time.Sleep(200 * time.Millisecond)
+		srv.LogEvent("fakeaction4", "fakeid")
+	}()
+
+	setTimeout(t, "Listening for events timed out", 2*time.Second, func() {
+		for i := 2; i < 4; i++ {
+			event := <-listener
+			if event != srv.events[i] {
+				t.Fatalf("Event received it different than expected")
+			}
+		}
+	})
 
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -611,7 +611,22 @@ type JSONMessage struct {
 	Status   string `json:"status,omitempty"`
 	Progress string `json:"progress,omitempty"`
 	Error    string `json:"error,omitempty"`
+	ID	 string `json:"id,omitempty"`
 }
+
+func (jm *JSONMessage) Display(out io.Writer) (error) {
+	if jm.Progress != "" {
+		fmt.Fprintf(out, "%s %s\r", jm.Status, jm.Progress)
+	} else if jm.Error != "" {
+		return fmt.Errorf(jm.Error)
+	} else if jm.ID != "" {
+		fmt.Fprintf(out, "%s: %s\n", jm.ID, jm.Status)
+	} else {
+		fmt.Fprintf(out, "%s\n", jm.Status)
+	}
+	return nil
+}
+
 
 type StreamFormatter struct {
 	json bool

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -612,9 +612,13 @@ type JSONMessage struct {
 	Progress string `json:"progress,omitempty"`
 	Error    string `json:"error,omitempty"`
 	ID	 string `json:"id,omitempty"`
+	Time	 int64 `json:"time,omitempty"`
 }
 
 func (jm *JSONMessage) Display(out io.Writer) (error) {
+	if jm.Time != 0 {
+		fmt.Fprintf(out, "[%s] ", time.Unix(jm.Time, 0))
+	}
 	if jm.Progress != "" {
 		fmt.Fprintf(out, "%s %s\r", jm.Status, jm.Progress)
 	} else if jm.Error != "" {


### PR DESCRIPTION
Fixes #1167 

Initial version of the /events endpoint
It uses JSON streaming, like `pull` or `push`

use `docker events` or call `GET /events HTTP/1.1` to try

List of supported events:
- kill : container kill
- export : container export
- create : container create
- restart : container restart
- die : container's process finishes
- destroy : container destroy
- delete : image delete
- untag : image untag
- start : container start
- stop container stop

It supports polling, you can use `since=<timestamp>` to get previous events. For now only the last 64 last events are stored. `GET /events?since=1374067924 HTTP/1.1` will return something like:

```
{"status":"create","id":"dfdf82bd3881","time":1374067924}
{"status":"start","id":"dfdf82bd3881","time":1374067924}
{"status":"die","id":"dfdf82bd3881","time":1374067966}
{"status":"stop","id":"dfdf82bd3881","time":1374067966}
{"status":"destroy","id":"dfdf82bd3881","time":1374067970}
```
