### PR TITLE
Add verbose output to docker build

### DIFF
--- a/api.go
+++ b/api.go
@@ -756,6 +756,7 @@ func postBuild(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 	}
 	remoteURL := r.FormValue("remote")
 	repoName := r.FormValue("t")
+	rawSuppressOutput := r.FormValue("q")
 	tag := ""
 	if strings.Contains(repoName, ":") {
 		remoteParts := strings.Split(repoName, ":")
@@ -802,7 +803,13 @@ func postBuild(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 		}
 		context = c
 	}
-	b := NewBuildFile(srv, utils.NewWriteFlusher(w))
+
+	suppressOutput, err := getBoolParam(rawSuppressOutput)
+	if err != nil {
+		return err
+	}
+
+	b := NewBuildFile(srv, utils.NewWriteFlusher(w), !suppressOutput)
 	id, err := b.Build(context)
 	if err != nil {
 		fmt.Fprintf(w, "Error build: %s\n", err)

--- a/buildfile.go
+++ b/buildfile.go
@@ -28,6 +28,7 @@ type buildFile struct {
 	maintainer string
 	config     *Config
 	context    string
+	verbose    bool
 
 	lastContainer *Container
 	tmpContainers map[string]struct{}
@@ -303,6 +304,13 @@ func (b *buildFile) run() (string, error) {
 		return "", err
 	}
 
+	if b.verbose {
+		err = <-c.Attach(nil, nil, b.out, b.out)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	// Wait for it to finish
 	if ret := c.Wait(); ret != 0 {
 		return "", fmt.Errorf("The command %v returned a non-zero code: %d", b.config.Cmd, ret)
@@ -450,7 +458,7 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 	return "", fmt.Errorf("An error occured during the build\n")
 }
 
-func NewBuildFile(srv *Server, out io.Writer) BuildFile {
+func NewBuildFile(srv *Server, out io.Writer, verbose bool) BuildFile {
 	return &buildFile{
 		builder:       NewBuilder(srv.runtime),
 		runtime:       srv.runtime,
@@ -459,5 +467,6 @@ func NewBuildFile(srv *Server, out io.Writer) BuildFile {
 		out:           out,
 		tmpContainers: make(map[string]struct{}),
 		tmpImages:     make(map[string]struct{}),
+		verbose:       verbose,
 	}
 }

--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -117,7 +117,7 @@ func TestBuild(t *testing.T) {
 			pushingPool: make(map[string]struct{}),
 		}
 
-		buildfile := NewBuildFile(srv, ioutil.Discard)
+		buildfile := NewBuildFile(srv, ioutil.Discard, false)
 		if _, err := buildfile.Build(mkTestContext(ctx.dockerfile, ctx.files, t)); err != nil {
 			t.Fatal(err)
 		}

--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -137,7 +137,7 @@ func TestVolume(t *testing.T) {
 		pushingPool: make(map[string]struct{}),
 	}
 
-	buildfile := NewBuildFile(srv, ioutil.Discard)
+	buildfile := NewBuildFile(srv, ioutil.Discard, false)
 	imgId, err := buildfile.Build(mkTestContext(`
 from %s
 VOLUME /test
@@ -153,7 +153,7 @@ CMD Hello world
 	if len(img.Config.Volumes) == 0 {
 		t.Fail()
 	}
-	for key, _ := range img.Config.Volumes {
+	for key := range img.Config.Volumes {
 		if key != "/test" {
 			t.Fail()
 		}

--- a/commands.go
+++ b/commands.go
@@ -157,6 +157,8 @@ func mkBuildContext(dockerfile string, files [][2]string) (Archive, error) {
 func (cli *DockerCli) CmdBuild(args ...string) error {
 	cmd := Subcmd("build", "[OPTIONS] PATH | URL | -", "Build a new container image from the source code at PATH")
 	tag := cmd.String("t", "", "Tag to be applied to the resulting image in case of success")
+	suppressOutput := cmd.Bool("q", false, "Suppress verbose build output")
+
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -194,6 +196,10 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	// Upload the build context
 	v := &url.Values{}
 	v.Set("t", *tag)
+
+	if *suppressOutput {
+		v.Set("q", "1")
+	}
 	if isRemote {
 		v.Set("remote", cmd.Arg(0))
 	}

--- a/docs/sources/api/docker_remote_api_v1.3.rst
+++ b/docs/sources/api/docker_remote_api_v1.3.rst
@@ -881,6 +881,7 @@ Build an image from Dockerfile via stdin
         The Content-type header should be set to "application/tar".
 
 	:query t: tag to be applied to the resulting image in case of success
+	:query q: suppress verbose build output
 	:statuscode 200: no error
         :statuscode 500: server error
 

--- a/docs/sources/commandline/command/build.rst
+++ b/docs/sources/commandline/command/build.rst
@@ -11,6 +11,7 @@
     Usage: docker build [OPTIONS] PATH | URL | -
     Build a new container image from the source code at PATH
       -t="": Tag to be applied to the resulting image in case of success.
+      -q=false: Suppress verbose build output.
     When a single Dockerfile is given as URL, then no context is set. When a git repository is set as URL, the repository is used as context
 
 


### PR DESCRIPTION
Verbose output is enabled by default and the flag `-q` can be used to suppress the verbose output.

This should resolve #846 
