### PR TITLE
Add cp command and copy api endpoint to copy container files/folders to the host

### DIFF
--- a/api.go
+++ b/api.go
@@ -878,23 +878,24 @@ func postContainersCopy(srv *Server, version float64, w http.ResponseWriter, r *
 	name := vars["name"]
 
 	copyData := &APICopy{}
-	if r.Header.Get("Content-Type") == "application/json" {
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "application/json" {
 		if err := json.NewDecoder(r.Body).Decode(copyData); err != nil {
 			return err
 		}
 	} else {
-		return fmt.Errorf("Content-Type not supported: %s", r.Header.Get("Content-Type"))
+		return fmt.Errorf("Content-Type not supported: %s", contentType)
 	}
 
 	if copyData.Resource == "" {
 		return fmt.Errorf("Resource cannot be empty")
 	}
 	if copyData.Resource[0] == '/' {
-		return fmt.Errorf("Resource cannot contain a leading /")
+		copyData.Resource = copyData.Resource[1:]
 	}
 
 	if err := srv.ContainerCopy(name, copyData.Resource, w); err != nil {
-		utils.Debugf("%s", err)
+		utils.Debugf("%s", err.Error())
 		return err
 	}
 	return nil

--- a/api_params.go
+++ b/api_params.go
@@ -86,3 +86,8 @@ type APIImageConfig struct {
 	ID string `json:"Id"`
 	*Config
 }
+
+type APICopy struct {
+	Resource string
+	HostPath string
+}

--- a/api_test.go
+++ b/api_test.go
@@ -1181,7 +1181,7 @@ func TestPostContainersCopy(t *testing.T) {
 	}
 
 	r := httptest.NewRecorder()
-	copyData := APICopy{HostPath: ".", Resource: "test.txt"}
+	copyData := APICopy{HostPath: ".", Resource: "/test.txt"}
 
 	jsonData, err := json.Marshal(copyData)
 	if err != nil {

--- a/api_test.go
+++ b/api_test.go
@@ -1156,6 +1156,70 @@ func TestJsonContentType(t *testing.T) {
 	}
 }
 
+func TestPostContainersCopy(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+
+	srv := &Server{runtime: runtime}
+
+	builder := NewBuilder(runtime)
+
+	// Create a container and remove a file
+	container, err := builder.Create(
+		&Config{
+			Image: GetTestImage(runtime).ID,
+			Cmd:   []string{"touch", "/test.txt"},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.Destroy(container)
+
+	if err := container.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	r := httptest.NewRecorder()
+	copyData := APICopy{HostPath: ".", Resource: "test.txt"}
+
+	jsonData, err := json.Marshal(copyData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("POST", "/containers/"+container.ID+"/copy", bytes.NewReader(jsonData))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("Content-Type", "application/json")
+	if err = postContainersCopy(srv, APIVERSION, r, req, map[string]string{"name": container.ID}); err != nil {
+		t.Fatal(err)
+	}
+
+	if r.Code != http.StatusOK {
+		t.Fatalf("%d OK expected, received %d\n", http.StatusOK, r.Code)
+	}
+
+	found := false
+	for tarReader := tar.NewReader(r.Body); ; {
+		h, err := tarReader.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatal(err)
+		}
+		if h.Name == "test.txt" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("The created test file has not been found in the copied output")
+	}
+}
+
 // Mocked types for tests
 type NopConn struct {
 	io.ReadCloser

--- a/commands.go
+++ b/commands.go
@@ -1492,8 +1492,8 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 		return err
 	}
 
-	r := bytes.NewReader(data)
 	if statusCode == 200 {
+		r := bytes.NewReader(data)
 		if err := Untar(r, copyData.HostPath); err != nil {
 			return err
 		}

--- a/container.go
+++ b/container.go
@@ -1094,5 +1094,19 @@ func (container *Container) Copy(resource string) (Archive, error) {
 	if err := container.EnsureMounted(); err != nil {
 		return nil, err
 	}
-	return TarFilter(container.RootfsPath(), Uncompressed, []string{resource})
+	var filter []string
+	basePath := path.Join(container.RootfsPath(), resource)
+	stat, err := os.Stat(basePath)
+	if err != nil {
+		return nil, err
+	}
+	if !stat.IsDir() {
+		d, f := path.Split(basePath)
+		basePath = d
+		filter = []string{f}
+	} else {
+		filter = []string{path.Base(basePath)}
+		basePath = path.Dir(basePath)
+	}
+	return TarFilter(basePath, Uncompressed, filter)
 }

--- a/container.go
+++ b/container.go
@@ -1089,3 +1089,10 @@ func (container *Container) GetSize() (int64, int64) {
 	}
 	return sizeRw, sizeRootfs
 }
+
+func (container *Container) Copy(resource string) (Archive, error) {
+	if err := container.EnsureMounted(); err != nil {
+		return nil, err
+	}
+	return TarFilter(container.RootfsPath(), Uncompressed, []string{resource})
+}

--- a/docs/sources/api/docker_remote_api_v1.3.rst
+++ b/docs/sources/api/docker_remote_api_v1.3.rst
@@ -525,6 +525,38 @@ Remove a container
         :statuscode 500: server error
 
 
+Copy files or folders from a container
+**************************************
+
+.. http:post:: /containers/(id)/copy
+
+	Copy files or folders of container ``id``
+
+	**Example request**:
+
+	.. sourcecode:: http
+
+	   POST /containers/4fa6e0f0c678/copy HTTP/1.1
+	   Content-Type: application/json
+
+	   {
+		"Resource":"test.txt"
+	   }
+
+	**Example response**:
+
+	.. sourcecode:: http
+
+	   HTTP/1.1 200 OK
+	   Content-Type: application/octet-stream
+	   
+	   {{ STREAM }}
+
+	:statuscode 200: no error
+	:statuscode 404: no such container
+	:statuscode 500: server error
+
+
 2.2 Images
 ----------
 
@@ -1090,7 +1122,6 @@ Monitor Docker's events
 	:query since: timestamp used for polling
         :statuscode 200: no error
         :statuscode 500: server error
-
 
 3. Going further
 ================

--- a/docs/sources/api/docker_remote_api_v1.3.rst
+++ b/docs/sources/api/docker_remote_api_v1.3.rst
@@ -525,38 +525,6 @@ Remove a container
         :statuscode 500: server error
 
 
-Copy files or folders from a container
-**************************************
-
-.. http:post:: /containers/(id)/copy
-
-	Copy files or folders of container ``id``
-
-	**Example request**:
-
-	.. sourcecode:: http
-
-	   POST /containers/4fa6e0f0c678/copy HTTP/1.1
-	   Content-Type: application/json
-
-	   {
-		"Resource":"test.txt"
-	   }
-
-	**Example response**:
-
-	.. sourcecode:: http
-
-	   HTTP/1.1 200 OK
-	   Content-Type: application/octet-stream
-	   
-	   {{ STREAM }}
-
-	:statuscode 200: no error
-	:statuscode 404: no such container
-	:statuscode 500: server error
-
-
 2.2 Images
 ----------
 
@@ -1122,6 +1090,7 @@ Monitor Docker's events
 	:query since: timestamp used for polling
         :statuscode 200: no error
         :statuscode 500: server error
+
 
 3. Going further
 ================

--- a/docs/sources/api/docker_remote_api_v1.4.rst
+++ b/docs/sources/api/docker_remote_api_v1.4.rst
@@ -528,6 +528,38 @@ Remove a container
         :statuscode 500: server error
 
 
+Copy files or folders from a container
+**************************************
+
+.. http:post:: /containers/(id)/copy
+
+	Copy files or folders of container ``id``
+
+	**Example request**:
+
+	.. sourcecode:: http
+
+	   POST /containers/4fa6e0f0c678/copy HTTP/1.1
+	   Content-Type: application/json
+
+	   {
+		"Resource":"test.txt"
+	   }
+
+	**Example response**:
+
+	.. sourcecode:: http
+
+	   HTTP/1.1 200 OK
+	   Content-Type: application/octet-stream
+	   
+	   {{ STREAM }}
+
+	:statuscode 200: no error
+	:statuscode 404: no such container
+	:statuscode 500: server error
+
+
 2.2 Images
 ----------
 

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -30,6 +30,7 @@ Available Commands
    command/attach
    command/build
    command/commit
+   command/cp
    command/diff
    command/export
    command/history

--- a/docs/sources/commandline/command/cp.rst
+++ b/docs/sources/commandline/command/cp.rst
@@ -1,0 +1,13 @@
+:title: Cp Command
+:description: Copy files/folders from the containers filesystem to the host path
+:keywords: cp, docker, container, documentation, copy
+
+===========================================================
+``cp`` -- Copy files/folders from the containers filesystem to the host path
+===========================================================
+
+::
+
+    Usage: docker cp CONTAINER:RESOURCE HOSTPATH
+
+    Copy files/folders from the containers filesystem to the host path.  Paths are relative to the root of the filesystem.

--- a/docs/sources/commandline/index.rst
+++ b/docs/sources/commandline/index.rst
@@ -15,6 +15,7 @@ Contents:
   attach  <command/attach>
   build   <command/build>
   commit  <command/commit>
+  cp      <command/cp>
   diff    <command/diff>
   export  <command/export>
   history <command/history>

--- a/server.go
+++ b/server.go
@@ -1169,6 +1169,23 @@ func (srv *Server) ImageInspect(name string) (*Image, error) {
 	return nil, fmt.Errorf("No such image: %s", name)
 }
 
+func (srv *Server) ContainerCopy(name string, resource string, out io.Writer) error {
+	if container := srv.runtime.Get(name); container != nil {
+
+		data, err := container.Copy(resource)
+		if err != nil {
+			return err
+		}
+
+		if _, err := io.Copy(out, data); err != nil {
+			return err
+		}
+		return nil
+	}
+	return fmt.Errorf("No such container: %s", name)
+
+}
+
 func NewServer(flGraphPath string, autoRestart, enableCors bool, dns ListOpts) (*Server, error) {
 	if runtime.GOARCH != "amd64" {
 		log.Fatalf("The docker runtime currently only supports amd64 (not %s). This will change in the future. Aborting.", runtime.GOARCH)


### PR DESCRIPTION
The `cp` command and copy api endpoint allows users
to copy files/folders from a containers filesystem to the host.

The syntax for the command came from #382 mirroring scp.

CLI Command:

```
docker cp 9be9a765dd28:var/log host/logs
```

API Endpoint:

```
POST /containers/4fa6e0f0c678/copy HTTP/1.1
Content-Type: application/json
{
    "Resource":"test.txt"
}
```

Closes #382
