### PR TITLE
Make the ENTRYPOINT example work

### DIFF
--- a/docs/sources/use/builder.rst
+++ b/docs/sources/use/builder.rst
@@ -179,7 +179,7 @@ The copy obeys the following rules:
 3.8 ENTRYPOINT
 -------------
 
-    ``ENTRYPOINT /bin/echo``
+    ``ENTRYPOINT ["/bin/echo"]``
 
 The ``ENTRYPOINT`` instruction adds an entry command that will not be
 overwritten when arguments are passed to docker run, unlike the


### PR DESCRIPTION
The incantation listed in the ENTRYPOINT example didn't actually pass the arguments to your script. Changing the definition to an array fixes this.
