### PR TITLE
#507 - make docker run handle SIGINT/SIGTERM

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1403,7 +1403,6 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 					if err := cli.CmdStop("-t", "4", runResult.ID); err != nil {
 						fmt.Printf("failed to stop container:", err)
 					}
-					return
 				}
 			}
 		}()

--- a/commands.go
+++ b/commands.go
@@ -1399,7 +1399,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 			for sig := range signals {
 				fmt.Printf("\nReceived signal: %s; cleaning up\n", sig)
 				if err := cli.CmdStop("-t", "4", runResult.ID); err != nil {
-					fmt.Printf("failed to stop container:", err)
+					fmt.Printf("failed to stop container: %v", err)
 				}
 			}
 		}()

--- a/commands.go
+++ b/commands.go
@@ -1393,6 +1393,21 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 			v.Set("stderr", "1")
 		}
 
+		signals := make(chan os.Signal, 1)
+		signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+		go func() {
+			for {
+				sig := <-signals
+				if sig == syscall.SIGINT || sig == syscall.SIGTERM {
+					fmt.Printf("\nReceived signal: %s; cleaning up\n", sig)
+					if err := cli.CmdStop("-t", "4", runResult.ID); err != nil {
+						fmt.Printf("failed to stop container:", err)
+					}
+					return
+				}
+			}
+		}()
+
 		if err := cli.hijack("POST", "/containers/"+runResult.ID+"/attach?"+v.Encode(), config.Tty, cli.in, cli.out); err != nil {
 			utils.Debugf("Error hijack: %s", err)
 			return err

--- a/commands.go
+++ b/commands.go
@@ -1396,13 +1396,10 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		signals := make(chan os.Signal, 1)
 		signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 		go func() {
-			for {
-				sig := <-signals
-				if sig == syscall.SIGINT || sig == syscall.SIGTERM {
-					fmt.Printf("\nReceived signal: %s; cleaning up\n", sig)
-					if err := cli.CmdStop("-t", "4", runResult.ID); err != nil {
-						fmt.Printf("failed to stop container:", err)
-					}
+			for sig := range signals {
+				fmt.Printf("\nReceived signal: %s; cleaning up\n", sig)
+				if err := cli.CmdStop("-t", "4", runResult.ID); err != nil {
+					fmt.Printf("failed to stop container:", err)
 				}
 			}
 		}()


### PR DESCRIPTION
This PR adds SIGTERM and SIGINT handling to docker run. When any of the two signals is received by a `docker run` process, `docker stop` will be run to try to stop the container. If the container fails to stop graciously in 4 seconds, it's killed by `docker stop`.

Observations:
1. `docker stop` isn't called, the CmdStop function is called instead to avoid duplicating any code.
2. Running things under a process monitoring solution will also require proper return codes, otherwise processes will always seem to be exiting cleanly.
3. This PR doesn't break signal handling for bash running in a container (e.g.: `docker run -i -t ubuntu bash.. ^c).
4. There's an issue with sending a SIGTERM/SIGINT to something which has set up a TTY:

```
$ docker run -i -t ubuntu bash
root@8158df67a66a:/# 
                     Received signal: interrupt; cleaning up
                                                            bk@bkm:~$
```

Questions:
1. What SIGKILL timeout should be set for `docker stop`?
2. How should the TTY output formatting issue be fixed?
3. What other changes should be made?
4. How could we test this?

This PR fixes #507.
