### PR TITLE
Issue 858: Disable network configuration

### DIFF
--- a/container.go
+++ b/container.go
@@ -514,8 +514,12 @@ func (container *Container) Start(hostConfig *HostConfig) error {
 	if err := container.EnsureMounted(); err != nil {
 		return err
 	}
-	if err := container.allocateNetwork(); err != nil {
-		return err
+	if container.runtime.networkManager.disabled {
+		container.Config.NetworkEnabled = false
+	} else {
+		if err := container.allocateNetwork(); err != nil {
+			return err
+		}
 	}
 
 	// Make sure the config is compatible with the current kernel

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -28,7 +28,7 @@ func main() {
 	flDaemon := flag.Bool("d", false, "Daemon mode")
 	flDebug := flag.Bool("D", false, "Debug mode")
 	flAutoRestart := flag.Bool("r", false, "Restart previously running containers")
-	bridgeName := flag.String("b", "", "Attach containers to a pre-existing network bridge")
+	bridgeName := flag.String("b", "", "Attach containers to a pre-existing network bridge. Use 'none' to disable container networking")
 	pidfile := flag.String("p", "/var/run/docker.pid", "File containing process PID")
 	flGraphPath := flag.String("g", "/var/lib/docker", "Path to graph storage base dir.")
 	flEnableCors := flag.Bool("api-enable-cors", false, "Enable CORS requests in the remote api.")

--- a/docs/sources/commandline/command/run.rst
+++ b/docs/sources/commandline/command/run.rst
@@ -20,6 +20,7 @@
       -h="": Container host name
       -i=false: Keep stdin open even if not attached
       -m=0: Memory limit (in bytes)
+      -n=true: Enable networking for this container
       -p=[]: Map a network port to the container
       -t=false: Allocate a pseudo-tty
       -u="": Username or UID

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -13,7 +13,10 @@ lxc.utsname = {{.Id}}
 {{end}}
 #lxc.aa_profile = unconfined
 
-{{if .Config.NetworkEnabled}}
+{{if .Config.NetworkDisabled}}
+# network is disabled (-n=false)
+lxc.network.type = empty
+{{else}}
 # network configuration
 lxc.network.type = veth
 lxc.network.flags = up
@@ -21,9 +24,6 @@ lxc.network.link = {{.NetworkSettings.Bridge}}
 lxc.network.name = eth0
 lxc.network.mtu = 1500
 lxc.network.ipv4 = {{.NetworkSettings.IPAddress}}/{{.NetworkSettings.IPPrefixLen}}
-{{else}}
-# Network configuration disabled
-lxc.network.type = empty
 {{end}}
 
 # root filesystem

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -13,6 +13,7 @@ lxc.utsname = {{.Id}}
 {{end}}
 #lxc.aa_profile = unconfined
 
+{{if .Config.NetworkEnabled}}
 # network configuration
 lxc.network.type = veth
 lxc.network.flags = up
@@ -20,6 +21,10 @@ lxc.network.link = {{.NetworkSettings.Bridge}}
 lxc.network.name = eth0
 lxc.network.mtu = 1500
 lxc.network.ipv4 = {{.NetworkSettings.IPAddress}}/{{.NetworkSettings.IPPrefixLen}}
+{{else}}
+# Network configuration disabled
+lxc.network.type = empty
+{{end}}
 
 # root filesystem
 {{$ROOTFS := .RootfsPath}}

--- a/network.go
+++ b/network.go
@@ -17,6 +17,7 @@ var NetworkBridgeIface string
 
 const (
 	DefaultNetworkBridge = "docker0"
+	DisableNetworkBridge = "none"
 	portRangeStart       = 49153
 	portRangeEnd         = 65535
 )
@@ -453,10 +454,16 @@ type NetworkInterface struct {
 
 	manager  *NetworkManager
 	extPorts []*Nat
+	disabled bool
 }
 
 // Allocate an external TCP port and map it to the interface
 func (iface *NetworkInterface) AllocatePort(spec string) (*Nat, error) {
+
+	if iface.disabled {
+		return nil, fmt.Errorf("Trying to allocate port for interface %v, which is disabled", iface) // FIXME
+	}
+
 	nat, err := parseNat(spec)
 	if err != nil {
 		return nil, err
@@ -552,6 +559,11 @@ func parseNat(spec string) (*Nat, error) {
 
 // Release: Network cleanup - release all resources
 func (iface *NetworkInterface) Release() {
+
+	if iface.disabled {
+		return
+	}
+
 	for _, nat := range iface.extPorts {
 		utils.Debugf("Unmaping %v/%v", nat.Proto, nat.Frontend)
 		if err := iface.manager.portMapper.Unmap(nat.Frontend, nat.Proto); err != nil {
@@ -579,10 +591,17 @@ type NetworkManager struct {
 	tcpPortAllocator *PortAllocator
 	udpPortAllocator *PortAllocator
 	portMapper       *PortMapper
+
+	disabled bool
 }
 
 // Allocate a network interface
 func (manager *NetworkManager) Allocate() (*NetworkInterface, error) {
+
+	if manager.disabled {
+		return &NetworkInterface{disabled: true}, nil
+	}
+
 	ip, err := manager.ipAllocator.Acquire()
 	if err != nil {
 		return nil, err
@@ -596,6 +615,14 @@ func (manager *NetworkManager) Allocate() (*NetworkInterface, error) {
 }
 
 func newNetworkManager(bridgeIface string) (*NetworkManager, error) {
+
+	if bridgeIface == DisableNetworkBridge {
+		manager := &NetworkManager{
+			disabled: true,
+		}
+		return manager, nil
+	}
+
 	addr, err := getIfaceAddr(bridgeIface)
 	if err != nil {
 		// If the iface is not found, try to create it


### PR DESCRIPTION
This introduces two ways to skip network configuration changes usually performed by docker, as inspired by [issue 858](https://github.com/dotcloud/docker/issues/858):
- _docker run **-n=false**_ creates network-less containers
  
  Containers created with this option will only have a loopback interface. A given host can of course have both normal and network-less containers.
- _docker **-b none** -d_ completely disables network configuration in the docker daemon.
  
  This implies **-n=false** for every container, and also skips bridge creation & iptables operations. 

[Issue 858](https://github.com/dotcloud/docker/issues/858) is originally about disabling iptables, but I felt like these two levels of control made more sense - at least as a starting point. Maybe I'm missing something? Do we also need the ability to specifically disable iptables?

Note that there is currently no unit test for the "-b none" part of the branch - I'm waiting to see if the feature is interesting enough and confirm the approach is not completely backwards before figuring out how the test runtime stuff works (as it is a global daemon option, it looks like we'd need to run a separate test server).

This is my first docker pull request, so please let me know if I'm doing things wrong!
