### PR TITLE
Change dockercfg to json and support multiple auth remote

### DIFF
--- a/api.go
+++ b/api.go
@@ -179,7 +179,7 @@ func getInfo(srv *Server, version float64, w http.ResponseWriter, r *http.Reques
 }
 
 func getEvents(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	sendEvent := func(wf *utils.WriteFlusher, event *utils.JSONMessage) (error) {
+	sendEvent := func(wf *utils.WriteFlusher, event *utils.JSONMessage) error {
 		b, err := json.Marshal(event)
 		if err != nil {
 			return fmt.Errorf("JSON error")

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -102,6 +102,7 @@ func LoadConfig(rootPath string) (*ConfigFile, error) {
 			if err != nil {
 				return nil, err
 			}
+			authConfig.Auth = ""
 			configFile.Configs[k] = authConfig
 		}
 	}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -11,7 +11,9 @@ import (
 func TestEncodeAuth(t *testing.T) {
 	newAuthConfig := &AuthConfig{Username: "ken", Password: "test", Email: "test@example.com"}
 	authStr := encodeAuth(newAuthConfig)
-	decAuthConfig, err := decodeAuth(authStr)
+	decAuthConfig := &AuthConfig{}
+	var err error
+	decAuthConfig.Username, decAuthConfig.Password, err = decodeAuth(authStr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,8 +31,8 @@ func TestEncodeAuth(t *testing.T) {
 func TestLogin(t *testing.T) {
 	os.Setenv("DOCKER_INDEX_URL", "https://indexstaging-docker.dotcloud.com")
 	defer os.Setenv("DOCKER_INDEX_URL", "")
-	authConfig := NewAuthConfig("unittester", "surlautrerivejetattendrai", "noise+unittester@dotcloud.com", "/tmp")
-	status, err := Login(authConfig, false)
+	authConfig := &AuthConfig{Username: "unittester", Password: "surlautrerivejetattendrai", Email: "noise+unittester@dotcloud.com"}
+	status, err := Login(authConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,8 +51,8 @@ func TestCreateAccount(t *testing.T) {
 	}
 	token := hex.EncodeToString(tokenBuffer)[:12]
 	username := "ut" + token
-	authConfig := NewAuthConfig(username, "test42", "docker-ut+"+token+"@example.com", "/tmp")
-	status, err := Login(authConfig, false)
+	authConfig := &AuthConfig{Username: username, Password: "test42", Email: "docker-ut+"+token+"@example.com"}
+	status, err := Login(authConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,7 +62,7 @@ func TestCreateAccount(t *testing.T) {
 		t.Fatalf("Expected status: \"%s\", found \"%s\" instead.", expectedStatus, status)
 	}
 
-	status, err = Login(authConfig, false)
+	status, err = Login(authConfig)
 	if err == nil {
 		t.Fatalf("Expected error but found nil instead")
 	}


### PR DESCRIPTION
Related to #1246 

.dockercfg is now in JSON and can store multiple auth remote, for exemple:

```
$>cat ~/.dockercfg
auth = xxxxxxxxxxxxxxxxxxxx
email = victor@dotcloud.com
```

Becomes:

```
cat ~/.dockercfg | python -mjson.tool
{
    "https://index.docker.io/v1/": {
        "auth": "xxxxxxxxxxxxxxxxxxxx",
        "email": "victor@dotcloud.com"
    }
}
```

I drop support for API  version < 1.2 (auth stored in the server) as the format of the .dockercfg as changed.
This is a **first step** to improve `docker login`, for now, docker login and docker push will always use the index url as key, but pushing to another auth will be easier. (we could for example add a parameter to `docker login`, like `docker login "https://index.docker.io/v1/"` or `docker login "http://localhost:5000"`

/cc @samalba 
