### PR TITLE
Ability to run containers on particular cpu cores

### DIFF
--- a/container.go
+++ b/container.go
@@ -63,6 +63,8 @@ type Config struct {
 	Memory          int64 // Memory limit (in bytes)
 	MemorySwap      int64 // Total memory usage (memory + swap); set `-1' to disable swap
 	CpuShares       int64 // CPU shares (relative weight vs. other containers)
+	Cpus            []string
+	CpusString      string
 	AttachStdin     bool
 	AttachStdout    bool
 	AttachStderr    bool
@@ -115,6 +117,9 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 	}
 
 	flCpuShares := cmd.Int64("c", 0, "CPU shares (relative weight)")
+
+	var flCpus ListOpts
+	cmd.Var(&flCpus, "C", "Which logical CPU cores to make available to the container")
 
 	var flPorts ListOpts
 	cmd.Var(&flPorts, "p", "Expose a container's port to the host (use 'docker port' to see the actual mapping)")
@@ -174,7 +179,6 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 	if *flEntrypoint != "" {
 		entrypoint = []string{*flEntrypoint}
 	}
-
 	config := &Config{
 		Hostname:        *flHostname,
 		PortSpecs:       flPorts,
@@ -184,6 +188,8 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 		OpenStdin:       *flStdin,
 		Memory:          *flMemory,
 		CpuShares:       *flCpuShares,
+		Cpus:            flCpus,
+		CpusString:			 strings.Join(flCpus, ","),
 		AttachStdin:     flAttach.Get("stdin"),
 		AttachStdout:    flAttach.Get("stdout"),
 		AttachStderr:    flAttach.Get("stderr"),

--- a/container.go
+++ b/container.go
@@ -63,7 +63,6 @@ type Config struct {
 	Memory          int64 // Memory limit (in bytes)
 	MemorySwap      int64 // Total memory usage (memory + swap); set `-1' to disable swap
 	CpuShares       int64 // CPU shares (relative weight vs. other containers)
-	Cpus            []string
 	CpusString      string
 	AttachStdin     bool
 	AttachStdout    bool
@@ -188,8 +187,7 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 		OpenStdin:       *flStdin,
 		Memory:          *flMemory,
 		CpuShares:       *flCpuShares,
-		Cpus:            flCpus,
-		CpusString:			 strings.Join(flCpus, ","),
+		CpusString:      strings.Join(flCpus, ","),
 		AttachStdin:     flAttach.Get("stdin"),
 		AttachStdout:    flAttach.Get("stdout"),
 		AttachStderr:    flAttach.Get("stderr"),

--- a/docs/sources/commandline/command/run.rst
+++ b/docs/sources/commandline/command/run.rst
@@ -12,6 +12,7 @@
 
     Run a command in a new container
 
+      -C=[]: Which logical CPU cores to make available to the container
       -a=map[]: Attach to stdin, stdout or stderr.
       -c=0: CPU shares (relative weight)
       -cidfile="": Write the container ID to the file

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -112,6 +112,9 @@ lxc.cgroup.memory.memsw.limit_in_bytes = {{$memSwap}}
 {{if .Config.CpuShares}}
 lxc.cgroup.cpu.shares = {{.Config.CpuShares}}
 {{end}}
+{{if .Config.Cpus}}
+lxc.cgroup.cpuset.cpus = {{.Config.CpusString}}
+{{end}}
 `
 
 var LxcTemplateCompiled *template.Template

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -112,7 +112,7 @@ lxc.cgroup.memory.memsw.limit_in_bytes = {{$memSwap}}
 {{if .Config.CpuShares}}
 lxc.cgroup.cpu.shares = {{.Config.CpuShares}}
 {{end}}
-{{if .Config.Cpus}}
+{{if .Config.CpusString}}
 lxc.cgroup.cpuset.cpus = {{.Config.CpusString}}
 {{end}}
 `

--- a/utils.go
+++ b/utils.go
@@ -17,6 +17,7 @@ func CompareConfig(a, b *Config) bool {
 		a.Memory != b.Memory ||
 		a.MemorySwap != b.MemorySwap ||
 		a.CpuShares != b.CpuShares ||
+		a.CpusString != b.CpusString ||
 		a.OpenStdin != b.OpenStdin ||
 		a.Tty != b.Tty {
 		return false
@@ -25,8 +26,7 @@ func CompareConfig(a, b *Config) bool {
 		len(a.Dns) != len(b.Dns) ||
 		len(a.Env) != len(b.Env) ||
 		len(a.PortSpecs) != len(b.PortSpecs) ||
-		len(a.Entrypoint) != len(b.Entrypoint) ||
-		len(a.Cpus) != len(b.Cpus) {
+		len(a.Entrypoint) != len(b.Entrypoint) {
 		return false
 	}
 
@@ -55,11 +55,6 @@ func CompareConfig(a, b *Config) bool {
 			return false
 		}
 	}
-	for i := 0; i < len(a.Cpus); i++ {
-		if a.Cpus[i] != b.Cpus[i] {
-			return false
-		}
-	}
 	return true
 }
 
@@ -76,8 +71,8 @@ func MergeConfig(userConf, imageConf *Config) {
 	if userConf.CpuShares == 0 {
 		userConf.CpuShares = imageConf.CpuShares
 	}
-	if userConf.Cpus == nil || len(userConf.Cpus) == 0 {
-		 userConf.Cpus = imageConf.Cpus
+	if userConf.CpusString == "" {
+		 userConf.CpusString = imageConf.CpusString
 	}
 	if userConf.PortSpecs == nil || len(userConf.PortSpecs) == 0 {
 		userConf.PortSpecs = imageConf.PortSpecs

--- a/utils.go
+++ b/utils.go
@@ -25,7 +25,8 @@ func CompareConfig(a, b *Config) bool {
 		len(a.Dns) != len(b.Dns) ||
 		len(a.Env) != len(b.Env) ||
 		len(a.PortSpecs) != len(b.PortSpecs) ||
-		len(a.Entrypoint) != len(b.Entrypoint) {
+		len(a.Entrypoint) != len(b.Entrypoint) ||
+		len(a.Cpus) != len(b.Cpus) {
 		return false
 	}
 
@@ -54,6 +55,11 @@ func CompareConfig(a, b *Config) bool {
 			return false
 		}
 	}
+	for i := 0; i < len(a.Cpus); i++ {
+		if a.Cpus[i] != b.Cpus[i] {
+			return false
+		}
+	}
 	return true
 }
 
@@ -69,6 +75,9 @@ func MergeConfig(userConf, imageConf *Config) {
 	}
 	if userConf.CpuShares == 0 {
 		userConf.CpuShares = imageConf.CpuShares
+	}
+	if userConf.Cpus == nil || len(userConf.Cpus) == 0 {
+		 userConf.Cpus = imageConf.Cpus
 	}
 	if userConf.PortSpecs == nil || len(userConf.PortSpecs) == 0 {
 		userConf.PortSpecs = imageConf.PortSpecs


### PR DESCRIPTION
Added a -C argument to docker run, which sets lxc.cgroup.cpuset.cpus. That makes it possible to run containers on particular cpu cores, complementing the current -c argument. The following command will run the container on cores 0 and 1, with half a share each (using the convention that each core has 1024 shares total).

```
bin/docker run -i -t -c 512 -C 0 -C 1 761b29a3baab /bin/bash
```

I don't know of a satisfactory way to implement this on top of docker. It's very important to my application to have fine-grained control over cpu allocation.

Thanks!
