### PR TITLE
Copy authConfigs on save so data is not modified

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -116,14 +116,19 @@ func SaveConfig(configFile *ConfigFile) error {
 		os.Remove(confFile)
 		return nil
 	}
+
+	configs := make(map[string]AuthConfig, len(configFile.Configs))
 	for k, authConfig := range configFile.Configs {
-		authConfig.Auth = encodeAuth(&authConfig)
-		authConfig.Username = ""
-		authConfig.Password = ""
-		configFile.Configs[k] = authConfig
+		authCopy := authConfig
+
+		authCopy.Auth = encodeAuth(&authCopy)
+		authCopy.Username = ""
+		authCopy.Password = ""
+
+		configs[k] = authCopy
 	}
 
-	b, err := json.Marshal(configFile.Configs)
+	b, err := json.Marshal(configs)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
SaveConfig sets the Username and Password to an empty string
on save.  A copy of the authConfigs need to be made so that the
in memory data is not modified.

This is a small issue with the config changes that caused the cli to require the login twice for the push command again after a successful login.

```
docker push crosbymichael/testimage
The push refers to a repository [crosbymichael/testimage] (len: 1)
Processing checksums
Sending image list
Username (): crosbymichael
Password:
Email (): michael@crosbymichael.com
Login Succeeded <<-- successful login but asks to login again
2013/07/25 00:08:56 Please login prior to push. ('docker login')  <<--err
```
