### PR TITLE
Add required go version for compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Installing from source
 ----------------------
 
 1. Make sure you have a [Go language](http://golang.org/doc/install)
-compiler and [git](http://git-scm.com) installed.
+compiler >= 1.1 and [git](http://git-scm.com) installed.
 2. Checkout the source code
 
    ```bash


### PR DESCRIPTION
I know #1013 is supposed to fix this but for those building right now, like me, it'd be nice to have the right info. Especially for those new to go.
