### PR TITLE
Use utils.ParseRepositoryTag instead of strings.Split(name, ":") in server.ImageDelete

### DIFF
--- a/api.go
+++ b/api.go
@@ -786,12 +786,7 @@ func postBuild(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 	remoteURL := r.FormValue("remote")
 	repoName := r.FormValue("t")
 	rawSuppressOutput := r.FormValue("q")
-	tag := ""
-	if strings.Contains(repoName, ":") {
-		remoteParts := strings.Split(repoName, ":")
-		tag = remoteParts[1]
-		repoName = remoteParts[0]
-	}
+	repoName, tag := utils.ParseRepositoryTag(repoName)
 
 	var context io.Reader
 

--- a/server.go
+++ b/server.go
@@ -1037,13 +1037,7 @@ func (srv *Server) ImageDelete(name string, autoPrune bool) ([]APIRmi, error) {
 		return nil, nil
 	}
 
-	var tag string
-	if strings.Contains(name, ":") {
-		nameParts := strings.Split(name, ":")
-		name = nameParts[0]
-		tag = nameParts[1]
-	}
-
+	name, tag := utils.ParseRepositoryTag(name)
 	return srv.deleteImage(img, name, tag)
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -20,7 +20,11 @@ func TestContainerTagImageDelete(t *testing.T) {
 	if err := srv.runtime.repositories.Set("utest", "tag1", unitTestImageName, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := srv.runtime.repositories.Set("utest:5000/docker", "tag2", unitTestImageName, false); err != nil {
+
+	if err := srv.runtime.repositories.Set("utest/docker", "tag2", unitTestImageName, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.runtime.repositories.Set("utest:5000/docker", "tag3", unitTestImageName, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -29,11 +33,24 @@ func TestContainerTagImageDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if len(images) != len(initialImages)+3 {
+		t.Errorf("Expected %d images, %d found", len(initialImages)+2, len(images))
+	}
+
+	if _, err := srv.ImageDelete("utest/docker:tag2", true); err != nil {
+		t.Fatal(err)
+	}
+
+	images, err = srv.Images(false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	if len(images) != len(initialImages)+2 {
 		t.Errorf("Expected %d images, %d found", len(initialImages)+2, len(images))
 	}
 
-	if _, err := srv.ImageDelete("utest:5000/docker:tag2", true); err != nil {
+	if _, err := srv.ImageDelete("utest:5000/docker:tag3", true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -20,7 +20,7 @@ func TestContainerTagImageDelete(t *testing.T) {
 	if err := srv.runtime.repositories.Set("utest", "tag1", unitTestImageName, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := srv.runtime.repositories.Set("utest/docker", "tag2", unitTestImageName, false); err != nil {
+	if err := srv.runtime.repositories.Set("utest:5000/docker", "tag2", unitTestImageName, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -33,7 +33,7 @@ func TestContainerTagImageDelete(t *testing.T) {
 		t.Errorf("Expected %d images, %d found", len(initialImages)+2, len(images))
 	}
 
-	if _, err := srv.ImageDelete("utest/docker:tag2", true); err != nil {
+	if _, err := srv.ImageDelete("utest:5000/docker:tag2", true); err != nil {
 		t.Fatal(err)
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -611,11 +611,11 @@ type JSONMessage struct {
 	Status   string `json:"status,omitempty"`
 	Progress string `json:"progress,omitempty"`
 	Error    string `json:"error,omitempty"`
-	ID	 string `json:"id,omitempty"`
-	Time	 int64 `json:"time,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Time     int64  `json:"time,omitempty"`
 }
 
-func (jm *JSONMessage) Display(out io.Writer) (error) {
+func (jm *JSONMessage) Display(out io.Writer) error {
 	if jm.Time != 0 {
 		fmt.Fprintf(out, "[%s] ", time.Unix(jm.Time, 0))
 	}
@@ -630,7 +630,6 @@ func (jm *JSONMessage) Display(out io.Writer) (error) {
 	}
 	return nil
 }
-
 
 type StreamFormatter struct {
 	json bool

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -282,3 +282,24 @@ func TestParseHost(t *testing.T) {
 		t.Errorf("unix:///var/run/docker.sock -> expected unix:///var/run/docker.sock, got %s", addr)
 	}
 }
+
+func TestParseRepositoryTag(t *testing.T) {
+	if repo, tag := ParseRepositoryTag("root"); repo != "root" || tag != "" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "root", "", repo, tag)
+	}
+	if repo, tag := ParseRepositoryTag("root:tag"); repo != "root" || tag != "tag" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "root", "tag", repo, tag)
+	}
+	if repo, tag := ParseRepositoryTag("user/repo"); repo != "user/repo" || tag != "" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "user/repo", "", repo, tag)
+	}
+	if repo, tag := ParseRepositoryTag("user/repo:tag"); repo != "user/repo" || tag != "tag" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "user/repo", "tag", repo, tag)
+	}
+	if repo, tag := ParseRepositoryTag("url:5000/repo"); repo != "url:5000/repo" || tag != "" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "url:5000/repo", "", repo, tag)
+	}
+	if repo, tag := ParseRepositoryTag("url:5000/repo:tag"); repo != "url:5000/repo" || tag != "tag" {
+		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "url:5000/repo", "tag", repo, tag)
+	}
+}


### PR DESCRIPTION
Fixes #1307
