### PR TITLE
Discard error when loading old container format

### DIFF
--- a/container.go
+++ b/container.go
@@ -266,7 +266,8 @@ func (container *Container) FromDisk() error {
 		return err
 	}
 	// Load container settings
-	if err := json.Unmarshal(data, container); err != nil {
+	// udp broke compat of docker.PortMapping, but it's not used when loading a container, we can skip it
+	if err := json.Unmarshal(data, container); err != nil && !strings.Contains(err.Error(), "docker.PortMapping") {
 		return err
 	}
 	return nil


### PR DESCRIPTION
UDP changed the format of `Container.NetworkSetting.PortMapping`
A struct only used when the container running, otherwise it's `nil`, (the information is kept on `Container.PortSpecs`)

So if an "old container" is stopped on "0.4.8" and restarted in "0.5.0" no problem.
But if the 0.4.8 docker daemon in killed and the container restarted in 0.5.0, the JSON UnMarshal will fail because of this. See #1314 

So, if UnMarshal fail on `PortMapping` we can skip the error.
