### PR TITLE
650 http utils and user agent field

### DIFF
--- a/api.go
+++ b/api.go
@@ -87,7 +87,7 @@ func postAuth(srv *Server, version float64, w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		return err
 	}
-	status, err := auth.Login(authConfig)
+	status, err := auth.Login(authConfig, srv.HTTPRequestFactory())
 	if err != nil {
 		return err
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/dotcloud/docker/utils"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -140,7 +141,7 @@ func SaveConfig(configFile *ConfigFile) error {
 }
 
 // try to register/login to the registry server
-func Login(authConfig *AuthConfig) (string, error) {
+func Login(authConfig *AuthConfig, factory *utils.HTTPRequestFactory) (string, error) {
 	client := &http.Client{}
 	reqStatusCode := 0
 	var status string
@@ -171,7 +172,7 @@ func Login(authConfig *AuthConfig) (string, error) {
 			"Please check your e-mail for a confirmation link.")
 	} else if reqStatusCode == 400 {
 		if string(reqBody) == "\"Username or email already exists\"" {
-			req, err := http.NewRequest("GET", IndexServerAddress()+"users/", nil)
+			req, err := factory.NewRequest("GET", IndexServerAddress()+"users/", nil)
 			req.SetBasicAuth(authConfig.Username, authConfig.Password)
 			resp, err := client.Do(req)
 			if err != nil {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -33,7 +33,7 @@ func TestLogin(t *testing.T) {
 	os.Setenv("DOCKER_INDEX_URL", "https://indexstaging-docker.dotcloud.com")
 	defer os.Setenv("DOCKER_INDEX_URL", "")
 	authConfig := &AuthConfig{Username: "unittester", Password: "surlautrerivejetattendrai", Email: "noise+unittester@dotcloud.com"}
-	status, err := Login(authConfig)
+	status, err := Login(authConfig, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func TestCreateAccount(t *testing.T) {
 	token := hex.EncodeToString(tokenBuffer)[:12]
 	username := "ut" + token
 	authConfig := &AuthConfig{Username: username, Password: "test42", Email: "docker-ut+" + token + "@example.com"}
-	status, err := Login(authConfig)
+	status, err := Login(authConfig, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestCreateAccount(t *testing.T) {
 		t.Fatalf("Expected status: \"%s\", found \"%s\" instead.", expectedStatus, status)
 	}
 
-	status, err = Login(authConfig)
+	status, err = Login(authConfig, nil)
 	if err == nil {
 		t.Fatalf("Expected error but found nil instead")
 	}

--- a/server.go
+++ b/server.go
@@ -52,9 +52,9 @@ func (v *simpleVersionInfo) Version() string {
 // docker, go, git-commit (of the docker) and the host's kernel.
 //
 // Such information will be used on call to NewRegistry().
-func (srv *Server) versionInfos() []registry.VersionInfo {
+func (srv *Server) versionInfos() []utils.VersionInfo {
 	v := srv.DockerVersion()
-	ret := make([]registry.VersionInfo, 0, 4)
+	ret := make([]utils.VersionInfo, 0, 4)
 	ret = append(ret, &simpleVersionInfo{"docker", v.Version})
 
 	if len(v.GoVersion) > 0 {
@@ -102,7 +102,7 @@ func (srv *Server) ContainerExport(name string, out io.Writer) error {
 }
 
 func (srv *Server) ImagesSearch(term string) ([]APISearch, error) {
-	r, err := registry.NewRegistry(srv.runtime.root, nil, srv.versionInfos()...)
+	r, err := registry.NewRegistry(srv.runtime.root, nil, srv.reqFactory)
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +559,7 @@ func (srv *Server) poolRemove(kind, key string) error {
 }
 
 func (srv *Server) ImagePull(localName string, tag string, out io.Writer, sf *utils.StreamFormatter, authConfig *auth.AuthConfig) error {
-	r, err := registry.NewRegistry(srv.runtime.root, authConfig, srv.versionInfos()...)
+	r, err := registry.NewRegistry(srv.runtime.root, authConfig, srv.reqFactory)
 	if err != nil {
 		return err
 	}
@@ -720,7 +720,7 @@ func (srv *Server) ImagePush(localName string, out io.Writer, sf *utils.StreamFo
 
 	out = utils.NewWriteFlusher(out)
 	img, err := srv.runtime.graph.Get(localName)
-	r, err2 := registry.NewRegistry(srv.runtime.root, authConfig, srv.versionInfos()...)
+	r, err2 := registry.NewRegistry(srv.runtime.root, authConfig, srv.reqFactory)
 	if err2 != nil {
 		return err2
 	}
@@ -1164,7 +1164,11 @@ func NewServer(flGraphPath string, autoRestart, enableCors bool, dns ListOpts) (
 		pushingPool: make(map[string]struct{}),
 		events:      make([]utils.JSONMessage, 0, 64), //only keeps the 64 last events
 		listeners:   make(map[string]chan utils.JSONMessage),
+		reqFactory:  nil,
 	}
+	ud := utils.NewHTTPUserAgentDecorator(srv.versionInfos()...)
+	factory := utils.NewHTTPRequestFactory(ud)
+	srv.reqFactory = factory
 	runtime.srv = srv
 	return srv, nil
 }
@@ -1189,4 +1193,5 @@ type Server struct {
 	pushingPool map[string]struct{}
 	events      []utils.JSONMessage
 	listeners   map[string]chan utils.JSONMessage
+	reqFactory  *utils.HTTPRequestFactory
 }

--- a/server.go
+++ b/server.go
@@ -1173,6 +1173,15 @@ func NewServer(flGraphPath string, autoRestart, enableCors bool, dns ListOpts) (
 	return srv, nil
 }
 
+func (srv *Server) HTTPRequestFactory() *utils.HTTPRequestFactory {
+	if srv.reqFactory == nil {
+		ud := utils.NewHTTPUserAgentDecorator(srv.versionInfos()...)
+		factory := utils.NewHTTPRequestFactory(ud)
+		srv.reqFactory = factory
+	}
+	return srv.reqFactory
+}
+
 func (srv *Server) LogEvent(action, id string) {
 	now := time.Now().Unix()
 	jm := utils.JSONMessage{Status: action, ID: id, Time: now}

--- a/server.go
+++ b/server.go
@@ -102,7 +102,7 @@ func (srv *Server) ContainerExport(name string, out io.Writer) error {
 }
 
 func (srv *Server) ImagesSearch(term string) ([]APISearch, error) {
-	r, err := registry.NewRegistry(srv.runtime.root, nil, srv.reqFactory)
+	r, err := registry.NewRegistry(srv.runtime.root, nil, srv.HTTPRequestFactory())
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +559,7 @@ func (srv *Server) poolRemove(kind, key string) error {
 }
 
 func (srv *Server) ImagePull(localName string, tag string, out io.Writer, sf *utils.StreamFormatter, authConfig *auth.AuthConfig) error {
-	r, err := registry.NewRegistry(srv.runtime.root, authConfig, srv.reqFactory)
+	r, err := registry.NewRegistry(srv.runtime.root, authConfig, srv.HTTPRequestFactory())
 	if err != nil {
 		return err
 	}
@@ -720,7 +720,7 @@ func (srv *Server) ImagePush(localName string, out io.Writer, sf *utils.StreamFo
 
 	out = utils.NewWriteFlusher(out)
 	img, err := srv.runtime.graph.Get(localName)
-	r, err2 := registry.NewRegistry(srv.runtime.root, authConfig, srv.reqFactory)
+	r, err2 := registry.NewRegistry(srv.runtime.root, authConfig, srv.HTTPRequestFactory())
 	if err2 != nil {
 		return err2
 	}
@@ -1166,9 +1166,6 @@ func NewServer(flGraphPath string, autoRestart, enableCors bool, dns ListOpts) (
 		listeners:   make(map[string]chan utils.JSONMessage),
 		reqFactory:  nil,
 	}
-	ud := utils.NewHTTPUserAgentDecorator(srv.versionInfos()...)
-	factory := utils.NewHTTPRequestFactory(ud)
-	srv.reqFactory = factory
 	runtime.srv = srv
 	return srv, nil
 }

--- a/utils/http.go
+++ b/utils/http.go
@@ -1,0 +1,129 @@
+package utils
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// VersionInfo is used to model entities which has a version.
+// It is basically a tupple with name and version.
+type VersionInfo interface {
+	Name() string
+	Version() string
+}
+
+func validVersion(version VersionInfo) bool {
+	stopChars := " \t\r\n/"
+	if strings.ContainsAny(version.Name(), stopChars) {
+		return false
+	}
+	if strings.ContainsAny(version.Version(), stopChars) {
+		return false
+	}
+	return true
+}
+
+// Convert versions to a string and append the string to the string base.
+//
+// Each VersionInfo will be converted to a string in the format of
+// "product/version", where the "product" is get from the Name() method, while
+// version is get from the Version() method. Several pieces of verson information
+// will be concatinated and separated by space.
+func appendVersions(base string, versions ...VersionInfo) string {
+	if len(versions) == 0 {
+		return base
+	}
+
+	var buf bytes.Buffer
+	if len(base) > 0 {
+		buf.Write([]byte(base))
+	}
+
+	for _, v := range versions {
+		name := []byte(v.Name())
+		version := []byte(v.Version())
+
+		if len(name) == 0 || len(version) == 0 {
+			continue
+		}
+		if !validVersion(v) {
+			continue
+		}
+		buf.Write([]byte(v.Name()))
+		buf.Write([]byte("/"))
+		buf.Write([]byte(v.Version()))
+		buf.Write([]byte(" "))
+	}
+	return buf.String()
+}
+
+// HTTPRequestDecorator is used to change an instance of
+// http.Request. It could be used to add more header fields,
+// change body, etc.
+type HTTPRequestDecorator interface {
+	// ChangeRequest() changes the request accordingly.
+	// The changed request will be returned or err will be non-nil
+	// if an error occur.
+	ChangeRequest(req *http.Request) (newReq *http.Request, err error)
+}
+
+// HTTPUserAgentDecorator appends the product/version to the user agent field
+// of a request.
+type HTTPUserAgentDecorator struct {
+	versions []VersionInfo
+}
+
+func NewHTTPUserAgentDecorator(versions ...VersionInfo) HTTPRequestDecorator {
+	ret := new(HTTPUserAgentDecorator)
+	ret.versions = versions
+	return ret
+}
+
+func (self *HTTPUserAgentDecorator) ChangeRequest(req *http.Request) (newReq *http.Request, err error) {
+	if req == nil {
+		return req, nil
+	}
+
+	userAgent := appendVersions(req.UserAgent(), self.versions...)
+	if len(userAgent) > 0 {
+		req.Header.Set("User-Agent", userAgent)
+	}
+	return req, nil
+}
+
+// HTTPRequestFactory creates an HTTP request
+// and applies a list of decorators on the request.
+type HTTPRequestFactory struct {
+	decorators []HTTPRequestDecorator
+}
+
+func NewHTTPRequestFactory(d ...HTTPRequestDecorator) *HTTPRequestFactory {
+	ret := new(HTTPRequestFactory)
+	ret.decorators = d
+	return ret
+}
+
+// NewRequest() creates a new *http.Request,
+// applies all decorators in the HTTPRequestFactory on the request,
+// then applies decorators provided by d on the request.
+func (self *HTTPRequestFactory) NewRequest(method, urlStr string, body io.Reader, d ...HTTPRequestDecorator) (*http.Request, error) {
+	req, err := http.NewRequest(method, urlStr, body)
+	if err != nil {
+		return nil, err
+	}
+	for _, dec := range self.decorators {
+		req, err = dec.ChangeRequest(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, dec := range d {
+		req, err = dec.ChangeRequest(req)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return req, err
+}

--- a/utils/http.go
+++ b/utils/http.go
@@ -113,6 +113,11 @@ func (self *HTTPRequestFactory) NewRequest(method, urlStr string, body io.Reader
 	if err != nil {
 		return nil, err
 	}
+
+	// By default, a nil factory should work.
+	if self == nil {
+		return req, nil
+	}
 	for _, dec := range self.decorators {
 		req, err = dec.ChangeRequest(req)
 		if err != nil {


### PR DESCRIPTION
fix #650 and #156

This is a follow up of #1064.

Changes:
- Added a file `http.go` in package `utils`. In side this file:
  - `VersionInfo` and its related functions mentioned in #1064 are moved into this file.
  - Defined a new interface `HTTPRequestDecorator`. It has a method named `ChangeRequest()`, which takes an HTTP request, changes it and return the modified request (or error).
  - Defined a new structure `HTTPUserAgentDecorator`, which implements `HTTPRequestDecorator`. It has a list of `VersionInfo` and append this information to user agent field to an HTTP request.
  - Defined a new structure `HTTPRequestFactory`. It has a method `NewRequest()` used to create a new HTTP request. This method is compatible with the `NewRequest()` function in standard `net/http` package. `HTTPRequestFactory` has a member which is a list of `HTTPRequestDecorator`. On a call to `NewRequest()`, the `HTTPRequestFactory` first creates an HTTP request and then applies all the decorators on this request.
- Changed `server.go` and `auth/auth.go` accordingly, so that they will use `HTTPRequestFactory` to create `*http.Request`, which will automatically add the User-Agent field.

With `HTTPRequestFactory` and `HTTPRequestDecorator`, it will be easy to add new header field, change request body and do other things on the requests.

P.S. The name `HTTPRequestDecorator` may lead to the decorator design pattern. Although it is fairly simple to apply this pattern on the interface, I didn't use the decorator pattern here in the code. Is there any better choice than `HTTPRequestDecorator`?
