### PR TITLE
Add ability to specify alternate LXC config template file

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -619,10 +619,13 @@ func TestPostContainersCreate(t *testing.T) {
 
 	srv := &Server{runtime: runtime}
 
-	configJSON, err := json.Marshal(&Config{
-		Image:  GetTestImage(runtime).ID,
-		Memory: 33554432,
-		Cmd:    []string{"touch", "/test"},
+	configJSON, err := json.Marshal(&CreateContainerRequest{
+		Config{
+			Image:  GetTestImage(runtime).ID,
+			Memory: 33554432,
+			Cmd:    []string{"touch", "/test"},
+		},
+		"",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/buildfile.go
+++ b/buildfile.go
@@ -26,12 +26,13 @@ type buildFile struct {
 	builder *Builder
 	srv     *Server
 
-	image        string
-	maintainer   string
-	config       *Config
-	context      string
-	verbose      bool
-	utilizeCache bool
+	image           string
+	maintainer      string
+	config          *Config
+	context         string
+	verbose         bool
+	utilizeCache    bool
+	lxcTemplateText string
 
 	tmpContainers map[string]struct{}
 	tmpImages     map[string]struct{}
@@ -84,14 +85,18 @@ func (b *buildFile) CmdRun(args string) error {
 	if b.image == "" {
 		return fmt.Errorf("Please provide a source image with `from` prior to run")
 	}
-	config, _, _, err := ParseRun([]string{b.image, "/bin/sh", "-c", args}, nil)
+	runConfig, err := ParseRun([]string{b.image, "/bin/sh", "-c", args}, nil)
 	if err != nil {
 		return err
 	}
 
+	config := runConfig.Configuration
 	cmd := b.config.Cmd
 	b.config.Cmd = nil
 	MergeConfig(b.config, config)
+	if b.lxcTemplateText != "" {
+		b.runtime.LxcTemplate = b.lxcTemplateText
+	}
 
 	defer func(cmd []string) { b.config.Cmd = cmd }(cmd)
 
@@ -370,6 +375,7 @@ func (b *buildFile) run() (string, error) {
 		return "", fmt.Errorf("Please provide a source image with `from` prior to run")
 	}
 	b.config.Image = b.image
+	b.srv.SetConfigLxcTemplate(b.runtime)
 
 	// Create the container and start it
 	c, err := b.builder.Create(b.config)
@@ -471,6 +477,16 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 	}
 	defer os.RemoveAll(name)
 	b.context = name
+
+	// if there's an lxc template in the post, use it
+	templatePath := path.Join(name, "DockerLxcTemplate")
+	_, err = os.Stat(templatePath)
+	if err == nil {
+		b.lxcTemplateText, err = ReadTemplateFile(templatePath)
+		if err != nil {
+			return "", err
+		}
+	}
 	dockerfile, err := os.Open(path.Join(name, "Dockerfile"))
 	if err != nil {
 		return "", fmt.Errorf("Can't build a directory with no Dockerfile")

--- a/commands.go
+++ b/commands.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	GITCOMMIT string
-	VERSION string
+	VERSION   string
 )
 
 func (cli *DockerCli) getMethod(name string) (reflect.Method, bool) {

--- a/commands.go
+++ b/commands.go
@@ -1391,10 +1391,13 @@ func (cli *DockerCli) CmdTag(args ...string) error {
 }
 
 func (cli *DockerCli) CmdRun(args ...string) error {
-	config, hostConfig, cmd, err := ParseRun(args, nil)
+	runConfig, err := ParseRun(args, nil)
 	if err != nil {
 		return err
 	}
+
+	config, hostConfig, cmd := runConfig.Configuration, runConfig.HostConfiguration, runConfig.Flags
+
 	if config.Image == "" {
 		cmd.Usage()
 		return nil
@@ -1413,7 +1416,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	}
 
 	//create the container
-	body, statusCode, err := cli.call("POST", "/containers/create", config)
+	body, statusCode, err := cli.call("POST", "/containers/create", CreateContainerRequest{*config, runConfig.LxcTemplateText})
 	//if image not found try to pull it
 	if statusCode == 404 {
 		_, tag := utils.ParseRepositoryTag(config.Image)

--- a/commands_test.go
+++ b/commands_test.go
@@ -152,7 +152,6 @@ func TestRunWorkdirExists(t *testing.T) {
 
 }
 
-
 func TestRunExit(t *testing.T) {
 	stdin, stdinPipe := io.Pipe()
 	stdout, stdoutPipe := io.Pipe()

--- a/container.go
+++ b/container.go
@@ -208,7 +208,8 @@ func ParseRun(args []string, capabilities *Capabilities) (*RunConfig, error) {
 	var lxcConf []KeyValuePair
 	lxcConf, err := parseLxcConfOpts(flLxcOpts)
 	if err != nil {
-		return nil, nil, cmd, err
+		return &RunConfig{nil, nil, "", cmd}, err
+	}
 
 	templateText := ""
 	if *flTemplate != "" {

--- a/container.go
+++ b/container.go
@@ -165,7 +165,7 @@ func ParseRun(args []string, capabilities *Capabilities) (*RunConfig, error) {
 		return &RunConfig{nil, nil, "", cmd}, fmt.Errorf("Conflicting options: -a and -d")
 	}
 	if *flWorkingDir != "" && !path.IsAbs(*flWorkingDir) {
-		return nil, nil, cmd, ErrInvaidWorikingDirectory
+		return &RunConfig{nil, nil, "", cmd}, ErrInvaidWorikingDirectory
 	}
 	// If neither -d or -a are set, attach to everything by default
 	if len(flAttach) == 0 && !*flDetach {

--- a/container.go
+++ b/container.go
@@ -355,15 +355,15 @@ func (container *Container) generateLXCConfig(hostConfig *HostConfig) error {
 		return err
 	}
 	defer fo.Close()
-	compiledTemplate, err := GetLxcTemplateCompiled(container.runtime)
+	compiledTemplates, err := GetLxcTemplateCompiled(container.runtime)
 	if err != nil {
 		return err
 	}
-	if err := compiledTemplate.Execute(fo, container); err != nil {
+	if err := compiledTemplates.LxcTemplateCompiled.Execute(fo, container); err != nil {
 		return err
 	}
 	if hostConfig != nil {
-		if err := LxcHostConfigTemplateCompiled.Execute(fo, hostConfig); err != nil {
+		if err := compiledTemplates.LxcHostConfigTemplateCompiled.Execute(fo, hostConfig); err != nil {
 			return err
 		}
 	}

--- a/container.go
+++ b/container.go
@@ -87,6 +87,7 @@ type HostConfig struct {
 	Binds           []string
 	ContainerIDFile string
 	LxcConf         []KeyValuePair
+	LxcTemplate     string
 }
 
 type BindMap struct {
@@ -104,7 +105,14 @@ type KeyValuePair struct {
 	Value string
 }
 
-func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, *flag.FlagSet, error) {
+type RunConfig struct {
+	Configuration     *Config
+	HostConfiguration *HostConfig
+	LxcTemplateText   string
+	Flags             *flag.FlagSet
+}
+
+func ParseRun(args []string, capabilities *Capabilities) (*RunConfig, error) {
 	cmd := Subcmd("run", "[OPTIONS] IMAGE [COMMAND] [ARG...]", "Run a command in a new container")
 	if len(args) > 0 && args[0] != "--help" {
 		cmd.SetOutput(ioutil.Discard)
@@ -148,12 +156,13 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 
 	var flLxcOpts ListOpts
 	cmd.Var(&flLxcOpts, "lxc-conf", "Add custom lxc options -lxc-conf=\"lxc.cgroup.cpuset.cpus = 0,1\"")
+	flTemplate := cmd.String("T", "", "Set custom LXC template filename")
 
 	if err := cmd.Parse(args); err != nil {
-		return nil, nil, cmd, err
+		return &RunConfig{nil, nil, "", cmd}, err
 	}
 	if *flDetach && len(flAttach) > 0 {
-		return nil, nil, cmd, fmt.Errorf("Conflicting options: -a and -d")
+		return &RunConfig{nil, nil, "", cmd}, fmt.Errorf("Conflicting options: -a and -d")
 	}
 	if *flWorkingDir != "" && !path.IsAbs(*flWorkingDir) {
 		return nil, nil, cmd, ErrInvaidWorikingDirectory
@@ -200,6 +209,14 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 	lxcConf, err := parseLxcConfOpts(flLxcOpts)
 	if err != nil {
 		return nil, nil, cmd, err
+
+	templateText := ""
+	if *flTemplate != "" {
+		var err error
+		templateText, err = ReadTemplateFile(*flTemplate)
+		if err != nil {
+			return &RunConfig{nil, nil, "", cmd}, err
+		}
 	}
 
 	config := &Config{
@@ -239,7 +256,8 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 	if config.OpenStdin && config.AttachStdin {
 		config.StdinOnce = true
 	}
-	return config, hostConfig, cmd, nil
+
+	return &RunConfig{config, hostConfig, templateText, cmd}, nil
 }
 
 type PortMapping map[string]string
@@ -337,7 +355,11 @@ func (container *Container) generateLXCConfig(hostConfig *HostConfig) error {
 		return err
 	}
 	defer fo.Close()
-	if err := LxcTemplateCompiled.Execute(fo, container); err != nil {
+	compiledTemplate, err := GetLxcTemplateCompiled(container.runtime)
+	if err != nil {
+		return err
+	}
+	if err := compiledTemplate.Execute(fo, container); err != nil {
 		return err
 	}
 	if hostConfig != nil {

--- a/container_test.go
+++ b/container_test.go
@@ -458,10 +458,11 @@ func TestCreateVolume(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)
 
-	config, hc, _, err := ParseRun([]string{"-v", "/var/lib/data", GetTestImage(runtime).ID, "echo", "hello", "world"}, nil)
+	runConfig, err := ParseRun([]string{"-v", "/var/lib/data", GetTestImage(runtime).ID, "echo", "hello", "world"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	config, hc := runConfig.Configuration, runConfig.HostConfiguration
 	c, err := NewBuilder(runtime).Create(config)
 	if err != nil {
 		t.Fatal(err)
@@ -1382,10 +1383,11 @@ func TestOnlyLoopbackExistsWhenUsingDisableNetworkOption(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)
 
-	config, hc, _, err := ParseRun([]string{"-n=false", GetTestImage(runtime).ID, "ip", "addr", "show"}, nil)
+	runConfig, err := ParseRun([]string{"-n=false", GetTestImage(runtime).ID, "ip", "addr", "show"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	config, hc := runConfig.Configuration, runConfig.HostConfiguration
 	c, err := NewBuilder(runtime).Create(config)
 	if err != nil {
 		t.Fatal(err)

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -36,6 +36,8 @@ func main() {
 	flEnableCors := flag.Bool("api-enable-cors", false, "Enable CORS requests in the remote api.")
 	flDns := flag.String("dns", "", "Set custom dns servers")
 	flHosts := docker.ListOpts{fmt.Sprintf("unix://%s", docker.DEFAULTUNIXSOCKET)}
+	flTemplate := flag.String("T", "", "Set custom LXC template filename")
+
 	flag.Var(&flHosts, "H", "tcp://host:port to bind/connect to or unix://path/to/socket to use")
 	flag.Parse()
 	if *flVersion {
@@ -64,7 +66,7 @@ func main() {
 			flag.Usage()
 			return
 		}
-		if err := daemon(*pidfile, *flGraphPath, flHosts, *flAutoRestart, *flEnableCors, *flDns); err != nil {
+		if err := daemon(*pidfile, *flGraphPath, flHosts, *flAutoRestart, *flEnableCors, *flDns, *flTemplate); err != nil {
 			log.Fatal(err)
 			os.Exit(-1)
 		}
@@ -112,7 +114,7 @@ func removePidFile(pidfile string) {
 	}
 }
 
-func daemon(pidfile string, flGraphPath string, protoAddrs []string, autoRestart, enableCors bool, flDns string) error {
+func daemon(pidfile string, flGraphPath string, protoAddrs []string, autoRestart, enableCors bool, flDns string, templateFile string) error {
 	if err := createPidFile(pidfile); err != nil {
 		log.Fatal(err)
 	}
@@ -130,7 +132,7 @@ func daemon(pidfile string, flGraphPath string, protoAddrs []string, autoRestart
 	if flDns != "" {
 		dns = []string{flDns}
 	}
-	server, err := docker.NewServer(flGraphPath, autoRestart, enableCors, dns)
+	server, err := docker.NewServer(flGraphPath, autoRestart, enableCors, dns, templateFile)
 	if err != nil {
 		return err
 	}

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -132,7 +132,12 @@ const LxcHostConfigTemplate = `
 var LxcTemplateCompiled *template.Template
 var LxcHostConfigTemplateCompiled *template.Template
 
-func GetLxcTemplateCompiled(runtime *Runtime) (*template.Template, error) {
+type CompiledTemplates struct {
+	LxcTemplateCompiled *template.Template
+	LxcHostConfigTemplateCompiled *template.Template
+}
+	
+func GetLxcTemplateCompiled(runtime *Runtime) (*CompiledTemplates, error) {
 	funcMap := template.FuncMap{
 		"getMemorySwap": getMemorySwap,
 	}
@@ -146,7 +151,15 @@ func GetLxcTemplateCompiled(runtime *Runtime) (*template.Template, error) {
 	funcMap := template.FuncMap{
 		"getMemorySwap": getMemorySwap,
 	}
-	return template.New("lxc").Funcs(funcMap).Parse(templateText)
+	lxcTemplateCompiled, err := template.New("lxc").Funcs(funcMap).Parse(templateText)
+	if err != nil {
+		return nil, err
+	}
+	lxcHostConfigTemplateCompiled := template.New("lxc-hostconfig").Funcs(funcMap).Parse(LxcHostConfigTemplate)
+	if err != nil {
+		return nil, err
+	}
+	return &CompiledTemplates{lxcTemplateCompiled, lxcHostConfigTemplateCompiled}, nil
 }
 
 func getMemorySwap(config *Config) int64 {

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -133,15 +133,11 @@ var LxcTemplateCompiled *template.Template
 var LxcHostConfigTemplateCompiled *template.Template
 
 type CompiledTemplates struct {
-	LxcTemplateCompiled *template.Template
+	LxcTemplateCompiled           *template.Template
 	LxcHostConfigTemplateCompiled *template.Template
 }
-	
-func GetLxcTemplateCompiled(runtime *Runtime) (*CompiledTemplates, error) {
-	funcMap := template.FuncMap{
-		"getMemorySwap": getMemorySwap,
-	}
 
+func GetLxcTemplateCompiled(runtime *Runtime) (*CompiledTemplates, error) {
 	templateText := LxcTemplate
 
 	if runtime.LxcTemplate != "" {
@@ -151,11 +147,13 @@ func GetLxcTemplateCompiled(runtime *Runtime) (*CompiledTemplates, error) {
 	funcMap := template.FuncMap{
 		"getMemorySwap": getMemorySwap,
 	}
+
 	lxcTemplateCompiled, err := template.New("lxc").Funcs(funcMap).Parse(templateText)
 	if err != nil {
 		return nil, err
 	}
-	lxcHostConfigTemplateCompiled := template.New("lxc-hostconfig").Funcs(funcMap).Parse(LxcHostConfigTemplate)
+
+	lxcHostConfigTemplateCompiled, err := template.New("lxc-hostconfig").Funcs(funcMap).Parse(LxcHostConfigTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -132,6 +132,23 @@ const LxcHostConfigTemplate = `
 var LxcTemplateCompiled *template.Template
 var LxcHostConfigTemplateCompiled *template.Template
 
+func GetLxcTemplateCompiled(runtime *Runtime) (*template.Template, error) {
+	funcMap := template.FuncMap{
+		"getMemorySwap": getMemorySwap,
+	}
+
+	templateText := LxcTemplate
+
+	if runtime.LxcTemplate != "" {
+		templateText = runtime.LxcTemplate
+	}
+
+	funcMap := template.FuncMap{
+		"getMemorySwap": getMemorySwap,
+	}
+	return template.New("lxc").Funcs(funcMap).Parse(templateText)
+}
+
 func getMemorySwap(config *Config) int64 {
 	// By default, MemorySwap is set to twice the size of RAM.
 	// If you want to omit MemorySwap, set it to `-1'.

--- a/runtime.go
+++ b/runtime.go
@@ -34,6 +34,7 @@ type Runtime struct {
 	volumes        *Graph
 	srv            *Server
 	Dns            []string
+	LxcTemplate    string
 }
 
 var sysInitPath string
@@ -250,8 +251,16 @@ func (runtime *Runtime) UpdateCapabilities(quiet bool) {
 	}
 }
 
+func ReadTemplateFile(filename string) (string, error) {
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
 // FIXME: harmonize with NewGraph()
-func NewRuntime(flGraphPath string, autoRestart bool, dns []string) (*Runtime, error) {
+func NewRuntime(flGraphPath string, autoRestart bool, dns []string, templateFile string) (*Runtime, error) {
 	runtime, err := NewRuntimeFromDirectory(flGraphPath, autoRestart)
 	if err != nil {
 		return nil, err
@@ -267,6 +276,12 @@ func NewRuntime(flGraphPath string, autoRestart bool, dns []string) (*Runtime, e
 		}
 	}
 	runtime.UpdateCapabilities(false)
+	if templateFile != "" {
+		runtime.LxcTemplate, err = ReadTemplateFile(templateFile)
+		if err != nil {
+			return nil, err
+		}
+	}
 	return runtime, nil
 }
 

--- a/server.go
+++ b/server.go
@@ -883,7 +883,7 @@ func (srv *Server) ContainerCreate(config *Config, runtime *Runtime) (string, er
 				tag = DEFAULTTAG
 			}
 
-			return "", fmt.Errorf("No such image: %s (tag: %s)", config.Image, tag)	
+			return "", fmt.Errorf("No such image: %s (tag: %s)", config.Image, tag)
 		}
 		return "", err
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -83,13 +83,13 @@ func TestCreateRm(t *testing.T) {
 	defer nuke(runtime)
 
 	srv := &Server{runtime: runtime}
-
-	config, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
+	runConfig, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	config := runConfig.Configuration
 
-	id, err := srv.ContainerCreate(config)
+	id, err := srv.ContainerCreate(config, runtime)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,12 +114,13 @@ func TestCommit(t *testing.T) {
 
 	srv := &Server{runtime: runtime}
 
-	config, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "/bin/cat"}, nil)
+	runConfig, err := ParseRun([]string{GetTestImage(runtime).ID, "/bin/cat"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	config := runConfig.Configuration
 
-	id, err := srv.ContainerCreate(config)
+	id, err := srv.ContainerCreate(config, runtime)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,12 +136,13 @@ func TestCreateStartRestartStopStartKillRm(t *testing.T) {
 
 	srv := &Server{runtime: runtime}
 
-	config, hostConfig, _, err := ParseRun([]string{GetTestImage(runtime).ID, "/bin/cat"}, nil)
+	runConfig, err := ParseRun([]string{GetTestImage(runtime).ID, "/bin/cat"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	config, hostConfig := runConfig.Configuration, runConfig.HostConfiguration
 
-	id, err := srv.ContainerCreate(config)
+	id, err := srv.ContainerCreate(config, runtime)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,6 +200,7 @@ func TestRunWithTooLowMemoryLimit(t *testing.T) {
 			CpuShares: 1000,
 			Cmd:       []string{"/bin/cat"},
 		},
+		runtime,
 	)
 	if err == nil {
 		t.Errorf("Memory limit is smaller than the allowed limit. Container creation should've failed!")
@@ -357,12 +360,13 @@ func TestRmi(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, hostConfig, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
+	runConfig, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	containerID, err := srv.ContainerCreate(config)
+	config, hostConfig := runConfig.Configuration, runConfig.HostConfiguration
+	containerID, err := srv.ContainerCreate(config, runtime)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -383,7 +387,7 @@ func TestRmi(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	containerID, err = srv.ContainerCreate(config)
+	containerID, err = srv.ContainerCreate(config, runtime)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sysinit.go
+++ b/sysinit.go
@@ -27,9 +27,8 @@ func setupWorkingDirectory(workdir string) {
 	if workdir == "" {
 		return
 	}
-    syscall.Chdir(workdir)
+	syscall.Chdir(workdir)
 }
-
 
 // Takes care of dropping privileges to the desired user
 func changeUser(u string) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -89,7 +89,9 @@ func readFile(src string, t *testing.T) (content string) {
 // The caller is responsible for destroying the container.
 // Call t.Fatal() at the first error.
 func mkContainer(r *Runtime, args []string, t *testing.T) (*Container, *HostConfig, error) {
-	config, hostConfig, _, err := ParseRun(args, nil)
+	runConfig, err := ParseRun(args, nil)
+	config, hostConfig := runConfig.Configuration, runConfig.HostConfiguration
+
 	defer func() {
 		if err != nil && t != nil {
 			t.Fatal(err)


### PR DESCRIPTION
Add ability to specify alternate LXC config template file

Either:
- to the server as a whole with the -T option with docker -d
- on a specific run with the -T option to docker run
- during container build with DockerLxcTemplate in the
  directory along side Dockerfile
