### PR TITLE
Add warning when net.ipv4.ip_forwarding = 0

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -22,6 +22,7 @@ Caleb Spare <cespare@gmail.com>
 Calen Pennington <cale@edx.org>
 Charles Hooper <charles.hooper@dotcloud.com>
 Christopher Currie <codemonkey+github@gmail.com>
+Colin Rice <colin@daedrum.net>
 Daniel Gasienica <daniel@gasienica.ch>
 Daniel Mizyrycki <daniel.mizyrycki@dotcloud.com>
 Daniel Robinson <gottagetmac@gmail.com>

--- a/api.go
+++ b/api.go
@@ -522,7 +522,7 @@ func postContainersCreate(srv *Server, version float64, w http.ResponseWriter, r
 		out.Warnings = append(out.Warnings, "Your kernel does not support memory swap capabilities. Limitation discarded.")
 	}
 
-	if srv.runtime.capabilities.IPv4Forwarding {
+	if !srv.runtime.capabilities.IPv4Forwarding {
 		log.Println("Warning: IPv4 forwarding is disabled.")
 		out.Warnings = append(out.Warnings, "IPv4 forwarding is disabled.")
 	}

--- a/api.go
+++ b/api.go
@@ -522,6 +522,11 @@ func postContainersCreate(srv *Server, version float64, w http.ResponseWriter, r
 		out.Warnings = append(out.Warnings, "Your kernel does not support memory swap capabilities. Limitation discarded.")
 	}
 
+	if srv.runtime.capabilities.IPv4Forwarding {
+		log.Println("Warning: IPv4 forwarding is disabled.")
+		out.Warnings = append(out.Warnings, "IPv4 forwarding is disabled.")
+	}
+
 	b, err := json.Marshal(out)
 	if err != nil {
 		return err

--- a/api_params.go
+++ b/api_params.go
@@ -24,6 +24,7 @@ type APIInfo struct {
 	NGoroutines        int    `json:",omitempty"`
 	MemoryLimit        bool   `json:",omitempty"`
 	SwapLimit          bool   `json:",omitempty"`
+	IPv4Forwarding     bool   `json:",omitempty"`
 	LXCVersion         string `json:",omitempty"`
 	NEventsListener    int    `json:",omitempty"`
 	KernelVersion      string `json:",omitempty"`

--- a/commands.go
+++ b/commands.go
@@ -510,6 +510,9 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	if !out.SwapLimit {
 		fmt.Fprintf(cli.err, "WARNING: No swap limit support\n")
 	}
+	if !out.IPv4Forwarding {
+		fmt.Fprintf(cli.err, "WARNING: IPv4 forwarding is disabled.\n")
+	}
 	return nil
 }
 

--- a/container.go
+++ b/container.go
@@ -534,6 +534,10 @@ func (container *Container) Start(hostConfig *HostConfig) error {
 		container.Config.MemorySwap = -1
 	}
 
+	if !container.runtime.capabilities.IPv4Forwarding {
+		log.Printf("WARNING: IPv4 forwarding is disabled. Networking will not work")
+	}
+
 	// Create the requested bind mounts
 	binds := make(map[string]BindMap)
 	// Define illegal container destinations

--- a/docs/sources/api/docker_remote_api_v1.4.rst
+++ b/docs/sources/api/docker_remote_api_v1.4.rst
@@ -1025,7 +1025,8 @@ Display system-wide information
 		"NFd": 11,
 		"NGoroutines":21,
 		"MemoryLimit":true,
-		"SwapLimit":false
+		"SwapLimit":false,
+		"IPv4Forwarding":true
 	   }
 
         :statuscode 200: no error

--- a/runtime.go
+++ b/runtime.go
@@ -15,8 +15,9 @@ import (
 )
 
 type Capabilities struct {
-	MemoryLimit bool
-	SwapLimit   bool
+	MemoryLimit    bool
+	SwapLimit      bool
+	IPv4Forwarding bool
 }
 
 type Runtime struct {
@@ -239,6 +240,12 @@ func (runtime *Runtime) UpdateCapabilities(quiet bool) {
 		runtime.capabilities.SwapLimit = err == nil
 		if !runtime.capabilities.SwapLimit && !quiet {
 			log.Printf("WARNING: Your kernel does not support cgroup swap limit.")
+		}
+
+		content, err3 := ioutil.ReadFile("/proc/sys/net/ipv4/ip_forward")
+		runtime.capabilities.IPv4Forwarding = err3 == nil && len(content) > 0 && content[0] == '1'
+		if !runtime.capabilities.IPv4Forwarding && !quiet {
+			log.Printf("WARNING: IPv4 forwarding is disabled.")
 		}
 	}
 }

--- a/server.go
+++ b/server.go
@@ -269,6 +269,7 @@ func (srv *Server) DockerInfo() *APIInfo {
 		Images:             imgcount,
 		MemoryLimit:        srv.runtime.capabilities.MemoryLimit,
 		SwapLimit:          srv.runtime.capabilities.SwapLimit,
+		IPv4Forwarding:     srv.runtime.capabilities.IPv4Forwarding,
 		Debug:              os.Getenv("DEBUG") != "",
 		NFd:                utils.GetTotalUsedFds(),
 		NGoroutines:        runtime.NumGoroutine(),


### PR DESCRIPTION
Added warnings to api.go, container.go, commands.go, and runtime.go
Also updated APIInfo to return whether IPv4Forwarding is enabled

Fixes Issue #490 (As much as it can be)
