### PR TITLE
Sort APIImages by most recent creation date.

### DIFF
--- a/server.go
+++ b/server.go
@@ -242,7 +242,7 @@ func (srv *Server) Images(all bool, filter string) ([]APIImages, error) {
 		}
 	}
 
-	sortImagesByCreation(outs)
+	sortImagesByCreationAndTag(outs)
 	return outs, nil
 }
 

--- a/server.go
+++ b/server.go
@@ -241,6 +241,8 @@ func (srv *Server) Images(all bool, filter string) ([]APIImages, error) {
 			outs = append(outs, out)
 		}
 	}
+
+	sortImagesByCreation(outs)
 	return outs, nil
 }
 

--- a/sorter.go
+++ b/sorter.go
@@ -1,0 +1,36 @@
+package docker
+
+import "sort"
+
+type imageSorter struct {
+	images []APIImages
+	by     func(i1, i2 *APIImages) bool // Closure used in the Less method.
+}
+
+// Len is part of sort.Interface.
+func (s *imageSorter) Len() int {
+	return len(s.images)
+}
+
+// Swap is part of sort.Interface.
+func (s *imageSorter) Swap(i, j int) {
+	s.images[i], s.images[j] = s.images[j], s.images[i]
+}
+
+// Less is part of sort.Interface. It is implemented by calling the "by" closure in the sorter.
+func (s *imageSorter) Less(i, j int) bool {
+	return s.by(&s.images[i], &s.images[j])
+}
+
+// Sort []ApiImages by most recent creation date.
+func sortImagesByCreation(images []APIImages) {
+	creation := func(i1, i2 *APIImages) bool {
+		return i1.Created > i2.Created
+	}
+
+	sorter := &imageSorter{
+		images: images,
+		by:     creation}
+
+	sort.Sort(sorter)
+}

--- a/sorter.go
+++ b/sorter.go
@@ -22,15 +22,15 @@ func (s *imageSorter) Less(i, j int) bool {
 	return s.by(&s.images[i], &s.images[j])
 }
 
-// Sort []ApiImages by most recent creation date.
-func sortImagesByCreation(images []APIImages) {
-	creation := func(i1, i2 *APIImages) bool {
-		return i1.Created > i2.Created
+// Sort []ApiImages by most recent creation date and tag name.
+func sortImagesByCreationAndTag(images []APIImages) {
+	creationAndTag := func(i1, i2 *APIImages) bool {
+		return i1.Created > i2.Created || (i1.Created == i2.Created && i2.Tag > i1.Tag)
 	}
 
 	sorter := &imageSorter{
 		images: images,
-		by:     creation}
+		by:     creationAndTag}
 
 	sort.Sort(sorter)
 }

--- a/sorter_test.go
+++ b/sorter_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestServerListOrderedImages(t *testing.T) {
+func TestServerListOrderedImagesByCreationDate(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)
 
@@ -26,5 +26,32 @@ func TestServerListOrderedImages(t *testing.T) {
 
 	if images[0].Created < images[1].Created {
 		t.Error("Expected []APIImges to be ordered by most recent creation date.")
+	}
+}
+
+func TestServerListOrderedImagesByCreationDateAndTag(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+
+	archive, err := fakeTar()
+	if err != nil {
+		t.Fatal(err)
+	}
+	image, err := runtime.graph.Create(archive, nil, "Testing", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &Server{runtime: runtime}
+	srv.ContainerTag(image.ID, "repo", "foo", false)
+	srv.ContainerTag(image.ID, "repo", "bar", false)
+
+	images, err := srv.Images(true, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if images[0].Created != images[1].Created || images[0].Tag >= images[1].Tag {
+		t.Error("Expected []APIImges to be ordered by most recent creation date and tag name.")
 	}
 }

--- a/sorter_test.go
+++ b/sorter_test.go
@@ -1,0 +1,30 @@
+package docker
+
+import (
+	"testing"
+)
+
+func TestServerListOrderedImages(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+
+	archive, err := fakeTar()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = runtime.graph.Create(archive, nil, "Testing", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &Server{runtime: runtime}
+
+	images, err := srv.Images(true, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if images[0].Created < images[1].Created {
+		t.Error("Expected []APIImges to be ordered by most recent creation date.")
+	}
+}


### PR DESCRIPTION
This makes the command `docker images` to return the most recent created images first.

Fixes #985.
