### PR TITLE
docs: fix a typo in the ubuntu installation guide

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -163,7 +163,7 @@ Then reload UFW:
 
 
 UFW's default set of rules denied all `incoming`, so if you want to be able to reach your containers from another host,
-you should allow incoming connexions on the docker port (default 4243):
+you should allow incoming connections on the docker port (default 4243):
 
 .. code-block:: bash
 


### PR DESCRIPTION
Very small correction, but happy to contribute!

(or at least I _think_ this is a typo!)
