### PR TITLE
Add option for tmpfs based read-write container root

### DIFF
--- a/container.go
+++ b/container.go
@@ -82,6 +82,7 @@ type Config struct {
 	Entrypoint      []string
 	NetworkDisabled bool
 	Privileged      bool
+	TmpfsRootOpts   string
 }
 
 type HostConfig struct {
@@ -149,6 +150,8 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 
 	var flLxcOpts ListOpts
 	cmd.Var(&flLxcOpts, "lxc-conf", "Add custom lxc options -lxc-conf=\"lxc.cgroup.cpuset.cpus = 0,1\"")
+
+	flTmpfsRootOpts := cmd.String("tmpfsroot", "", "Make container root a tmpfs backed filesystem with these tmpfs options")
 
 	if err := cmd.Parse(args); err != nil {
 		return nil, nil, cmd, err
@@ -224,6 +227,7 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 		Entrypoint:      entrypoint,
 		Privileged:      *flPrivileged,
 		WorkingDir:      *flWorkingDir,
+		TmpfsRootOpts:   *flTmpfsRootOpts,
 	}
 	hostConfig := &HostConfig{
 		Binds:           binds,
@@ -1083,6 +1087,17 @@ func (container *Container) Mount() error {
 	if err != nil {
 		return err
 	}
+
+	if err := os.Mkdir(container.rwPath(), 0755); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	if opts := container.Config.TmpfsRootOpts; opts != "" {
+		if err := mount("none", container.rwPath(), "tmpfs", 0, opts); err != nil {
+			return err
+		}
+	}
+
 	return image.Mount(container.RootfsPath(), container.rwPath())
 }
 
@@ -1106,7 +1121,14 @@ func (container *Container) Mounted() (bool, error) {
 }
 
 func (container *Container) Unmount() error {
-	return Unmount(container.RootfsPath())
+	if err := Unmount(container.RootfsPath()); err != nil {
+		return err
+	}
+	mounted, err := Mounted(container.rwPath())
+	if err != nil || !mounted {
+		return err
+	}
+	return syscall.Unmount(container.rwPath(), 0)
 }
 
 // ShortID returns a shorthand version of the container's id for convenience.


### PR DESCRIPTION
This adds a '-tmpfsroot' option that causes the rw directory to be created as a tmpfs (ie, ram backed) directory. I want to use this setup in order to have very fast writes for my containers.  The rw directory is mounted & unmounted  on container start and stop, so anyone using this needs to be prepared for their files to reset on start and stop.

An example call:
docker run -i -t -d -tmpfsroot="size=1g" ubuntu /bin/bash

I should note that the aufs man page warns against tmpfs usage like this: tmpfs doesn't track in-use inode numbers, and uses a simple counter for allocation.  My interpretation of the man page is that you would need two in-memory inodes with the same number, so you would need to create an tmpfs file/directory and keep it around until the (32-bit) counter wraps.  
