### PR TITLE
Allow ENTRYPOINT without CMD

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -38,7 +38,9 @@ func (builder *Builder) Create(config *Config) (*Container, error) {
 		MergeConfig(config, img.Config)
 	}
 
-	if config.Cmd == nil || len(config.Cmd) == 0 {
+	if len(config.Entrypoint) != 0 && config.Cmd == nil {
+		config.Cmd = []string{}
+	} else if config.Cmd == nil || len(config.Cmd) == 0 {
 		return nil, fmt.Errorf("No command specified")
 	}
 

--- a/buildfile.go
+++ b/buildfile.go
@@ -93,6 +93,8 @@ func (b *buildFile) CmdRun(args string) error {
 	b.config.Cmd = nil
 	MergeConfig(b.config, config)
 
+	defer func(cmd []string) { b.config.Cmd = cmd }(cmd)
+
 	utils.Debugf("Command to be executed: %v", b.config.Cmd)
 
 	if b.utilizeCache {
@@ -115,7 +117,7 @@ func (b *buildFile) CmdRun(args string) error {
 	if err := b.commit(cid, cmd, "run"); err != nil {
 		return err
 	}
-	b.config.Cmd = cmd
+
 	return nil
 }
 

--- a/container_test.go
+++ b/container_test.go
@@ -996,6 +996,28 @@ func TestEntrypoint(t *testing.T) {
 	}
 }
 
+func TestEntrypointNoCmd(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+	container, err := NewBuilder(runtime).Create(
+		&Config{
+			Image:      GetTestImage(runtime).ID,
+			Entrypoint: []string{"/bin/echo", "foobar"},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.Destroy(container)
+	output, err := container.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Trim(string(output), "\r\n") != "foobar" {
+		t.Error(string(output))
+	}
+}
+
 func grepFile(t *testing.T, path string, pattern string) {
 	f, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
This pull request actually fixes a couple of related **ENTRYPOINT** issues:

The following Dockerfile

```
FROM ubuntu
ENTRYPOINT ["echo"]
```

will build fine, but will fail on a run (with no args) with `Error: No command specified`

My expectation is that `echo` will run with no args.  If you pass in args, (`docker run test /var`) everything will work fine.

The following Dockerfile

```
FROM ubuntu
RUN echo "HELLO"
ENTRYPOINT ["echo"]
```

produces the same result but building and running this (with no args)

```
FROM ubuntu
RUN echo "HELLO"
ADD test /test
ENTRYPOINT ["echo"]
```

produces 

```
vagrant@local-docker:~$ docker run test
/bin/sh -c echo "HELLO"
```

Running with args works as expected.

Seems like  the execed cmd in `CmdRun` is unintentionally getting cached and passed as an argument to the `Entrypoint` cmd.

This pull request 
- makes sure that `config.Cmd` is cleaned within `CmdRun`
- allows for no command to specified if there is an entrypoint
