### PR TITLE
Remove v from latest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ release: $(BINRELEASE)
 	s3cmd -P put $(BINRELEASE) s3://get.docker.io/builds/`uname -s`/`uname -m`/docker-$(RELEASE_VERSION).tgz
 	s3cmd -P put docker-latest.tgz s3://get.docker.io/builds/`uname -s`/`uname -m`/docker-latest.tgz
 	s3cmd -P put $(SRCRELEASE)/bin/docker s3://get.docker.io/builds/`uname -s`/`uname -m`/docker
-	echo $(RELEASE_VERSION) > latest ; s3cmd -P put latest s3://get.docker.io/latest ; rm latest
+	echo $(RELEASE_VERSION) | sed 's/^.//' > latest ; s3cmd -P put latest s3://get.docker.io/latest ; rm latest
 
 srcrelease: $(SRCRELEASE)
 deps: $(DOCKER_DIR)


### PR DESCRIPTION
http://get.docker.io/latest should contain `0.5.1`, the current makefile put `v0.5.1` (I changed it manually)
Fixes #1346

/cc @mzdaniel 
