### PR TITLE
Let userland proxy handle container-bound traffic

### DIFF
--- a/network.go
+++ b/network.go
@@ -253,6 +253,7 @@ func (mapper *PortMapper) setup() error {
 
 func (mapper *PortMapper) iptablesForward(rule string, port int, proto string, dest_addr string, dest_port int) error {
 	return iptables("-t", "nat", rule, "DOCKER", "-p", proto, "--dport", strconv.Itoa(port),
+		"!", "-i", NetworkBridgeIface,
 		"-j", "DNAT", "--to-destination", net.JoinHostPort(dest_addr, strconv.Itoa(dest_port)))
 }
 
@@ -264,7 +265,7 @@ func (mapper *PortMapper) Map(port int, backendAddr net.Addr) error {
 			return err
 		}
 		mapper.tcpMapping[port] = backendAddr.(*net.TCPAddr)
-		proxy, err := NewProxy(&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port}, backendAddr)
+		proxy, err := NewProxy(&net.TCPAddr{IP: net.IPv4(0, 0, 0, 0), Port: port}, backendAddr)
 		if err != nil {
 			mapper.Unmap(port, "tcp")
 			return err
@@ -278,7 +279,7 @@ func (mapper *PortMapper) Map(port int, backendAddr net.Addr) error {
 			return err
 		}
 		mapper.udpMapping[port] = backendAddr.(*net.UDPAddr)
-		proxy, err := NewProxy(&net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port}, backendAddr)
+		proxy, err := NewProxy(&net.UDPAddr{IP: net.IPv4(0, 0, 0, 0), Port: port}, backendAddr)
 		if err != nil {
 			mapper.Unmap(port, "udp")
 			return err


### PR DESCRIPTION
This changeset does two things:
- allow connections to the userland proxy on all interfaces (not only `lo`);
- allow connections originating from containers to reach the userland proxy, instead of being natted.

It allows containers to "talk to themselves" on their exposed ports; i.e., without that change, a container with a `55432->80` mapping could not connect to `hostaddr:55432`, neither could other containers when L2 isolation was enabled (with e.g. `ebtables -P FORWARD DROP`).

The only side-effect is that those connections will now be shown as originating from the host. It is deemed to be a minor inconvenience. Note: external connections are not affected, and containers will still see their true origin.
