### PR TITLE
doc: syntax to run a specific image tag

### DIFF
--- a/docs/sources/commandline/command/run.rst
+++ b/docs/sources/commandline/command/run.rst
@@ -8,7 +8,7 @@
 
 ::
 
-    Usage: docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
+    Usage: docker run [OPTIONS] IMAGE[:TAG] [COMMAND] [ARG...]
 
     Run a command in a new container
 


### PR DESCRIPTION
I couldn't find the syntax to run a specific image tag (e.g. `docker run -i -t ubuntu:12.10 lsb_release -a`) anywhere in the docs. This looks like a good place to keep it.
