### PR TITLE
Assume that if VAGRANT_DEFAULT_PROVIDER is set we shouldn't install vbox tools

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,8 @@ Vagrant::Config.run do |config|
       "apt-get update -qq; apt-get install -q -y linux-image-3.8.0-19-generic; "
     # Add guest additions if local vbox VM
     is_vbox = true
-    ARGV.each do |arg| is_vbox &&= !arg.downcase.start_with?("--provider") end
+    # The logic here makes a few assumptions (i.e. no one uses --provider=virtualbox)
+    ARGV.each do |arg| is_vbox &&= ( !arg.downcase.start_with?("--provider") && !ENV['VAGRANT_DEFAULT_PROVIDER'] )end
     if is_vbox
       pkg_cmd << "apt-get install -q -y linux-headers-3.8.0-19-generic dkms; " \
         "echo 'Downloading VBox Guest Additions...'; " \


### PR DESCRIPTION
In Vagrant, you can set VAGRANT_DEFAULT_PROVIDER in the shell to be your default provider (i.e. "vmware_fusion"). Assume that if this is set we should not install the vbox tools.

It would be ideal to improve this logic, so that we install the tools required for the provider in question (or have multiple prepared boxes), but this works for the moment.
