### PR TITLE
Add an option to set the working directory

### DIFF
--- a/docs/sources/api/docker_remote_api_v1.4.rst
+++ b/docs/sources/api/docker_remote_api_v1.4.rst
@@ -129,7 +129,9 @@ Create a container
 		"Dns":null,
 		"Image":"base",
 		"Volumes":{},
-		"VolumesFrom":""
+		"VolumesFrom":"",
+		"WorkingDir":""
+
 	   }
 	   
 	**Example response**:
@@ -195,7 +197,9 @@ Inspect a container
 				"Dns": null,
 				"Image": "base",
 				"Volumes": {},
-				"VolumesFrom": ""
+				"VolumesFrom": "",
+				"WorkingDir":""
+
 			},
 			"State": {
 				"Running": false,
@@ -746,7 +750,8 @@ Inspect an image
 				,"Dns":null,
 				"Image":"base",
 				"Volumes":null,
-				"VolumesFrom":""
+				"VolumesFrom":"",
+				"WorkingDir":""
 			},
 		"Size": 6824592
 	   }

--- a/docs/sources/commandline/command/run.rst
+++ b/docs/sources/commandline/command/run.rst
@@ -29,6 +29,7 @@
       -v=[]: Create a bind mount with: [host-dir]:[container-dir]:[rw|ro]. If "host-dir" is missing, then docker creates a new volume.
       -volumes-from="": Mount all volumes from the given container.
       -entrypoint="": Overwrite the default entrypoint set by the image.
+      -w="": Working directory inside the container
 
 
 Examples
@@ -61,4 +62,23 @@ and it also lifts all the limitations enforced by the ``device``
 cgroup controller. In other words, the container can then do almost
 everything that the host can do. This flag exists to allow special
 use-cases, like running Docker within Docker.
+
+.. code-block:: bash
+
+   docker  run -w /path/to/dir/ -i -t  ubuntu pwd
+
+The ``-w`` lets the command beeing executed inside directory given, 
+here /path/to/dir/. If the path does not exists it is created inside the 
+container.
+
+.. code-block:: bash
+
+   docker  run  -v `pwd`:`pwd` -w `pwd` -i -t  ubuntu pwd
+
+The ``-v`` flag mounts the current working directory into the container. 
+The ``-w`` lets the command beeing executed inside the current 
+working directory, by changeing into the directory to the value
+returned by ``pwd``. So this combination executes the command
+using the container, but inside the current working directory.
+
 

--- a/sysinit.go
+++ b/sysinit.go
@@ -22,6 +22,15 @@ func setupNetworking(gw string) {
 	}
 }
 
+// Setup working directory
+func setupWorkingDirectory(workdir string) {
+	if workdir == "" {
+		return
+	}
+    syscall.Chdir(workdir)
+}
+
+
 // Takes care of dropping privileges to the desired user
 func changeUser(u string) {
 	if u == "" {
@@ -83,6 +92,7 @@ func SysInit() {
 	}
 	var u = flag.String("u", "", "username or uid")
 	var gw = flag.String("g", "", "gateway address")
+	var workdir = flag.String("w", "", "workdir")
 
 	var flEnv ListOpts
 	flag.Var(&flEnv, "e", "Set environment variables")
@@ -91,6 +101,7 @@ func SysInit() {
 
 	cleanupEnv(flEnv)
 	setupNetworking(*gw)
+	setupWorkingDirectory(*workdir)
 	changeUser(*u)
 	executeProgram(flag.Arg(0), flag.Args())
 }


### PR DESCRIPTION
## Add Working directory option

This makes it possible to simply wrap a command inside a container without changing the directory. The purpose is to make it easier to use  a container as an unified build environment.

Examples:

At ~/workspace/docker

``` bash
$ docker  run  -v `pwd`:`pwd` -w `pwd` -i -t  ubuntu ls
AUTHORS      Makefile   archive.go     changes.go         docker
[...]
```

The line above executed "ls" within the current working directory. But the ls was executed within the docker container.

the -v param maps the volumes, while the new -w param sets the working directory before executing the command.

``` bash
docker  run  -v `pwd`:`pwd` -w `pwd` -i -t  ubuntu pwd
/home/marco/workspace/docker
```

The line above executed "pwd" within the current working directory. But the ls was executed within the docker container.

If this change is welcome i would be interested in creating a alias like "docker wrap" to make the commandline easier to use.
