### PR TITLE
Mount /dev/shm as a tmpfs

### DIFF
--- a/lxc_template.go
+++ b/lxc_template.go
@@ -81,7 +81,7 @@ lxc.mount.entry = sysfs {{$ROOTFS}}/sys sysfs nosuid,nodev,noexec 0 0
 lxc.mount.entry = devpts {{$ROOTFS}}/dev/pts devpts newinstance,ptmxmode=0666,nosuid,noexec 0 0
 #lxc.mount.entry = varrun {{$ROOTFS}}/var/run tmpfs mode=755,size=4096k,nosuid,nodev,noexec 0 0
 #lxc.mount.entry = varlock {{$ROOTFS}}/var/lock tmpfs size=1024k,nosuid,nodev,noexec 0 0
-#lxc.mount.entry = shm {{$ROOTFS}}/dev/shm tmpfs size=65536k,nosuid,nodev,noexec 0 0
+lxc.mount.entry = shm {{$ROOTFS}}/dev/shm tmpfs size=65536k,nosuid,nodev,noexec 0 0
 
 # Inject docker-init
 lxc.mount.entry = {{.SysInitPath}} {{$ROOTFS}}/.dockerinit none bind,ro 0 0


### PR DESCRIPTION
Fixes #1122 (Re-forked from the current head).

The issue as explained by @jpetazzo (far better than I could):

> The problem comes from the fact that Docker containers do not have `/dev/shm` mounted as `tmpfs`.
> The Python package tries to create a file in `/dev/shm`, but before doing so, it checks if `/dev/shm` is indeed a temporary filesystem. If it's not, it will go through `/proc/mounts` to find one. Unfortunately, for a reason that I can't explain, `/etc/resolv.conf` (which is a bind mount on a _file_) will appear as being of type `/dev/shm` and will confuse the multiprocessing module.
> 
> Fix: as mentioned, uncomment the line that will setup `/dev/shm` to be a `tmpfs` within the container.
