### PR TITLE
Added the ability to specify multiple containers in -volumes-from

### DIFF
--- a/container.go
+++ b/container.go
@@ -128,7 +128,7 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 	flVolumes := NewPathOpts()
 	cmd.Var(flVolumes, "v", "Bind mount a volume (e.g. from the host: -v /host:/container, from docker: -v /container)")
 
-	flVolumesFrom := cmd.String("volumes-from", "", "Mount volumes from the specified container")
+	flVolumesFrom := cmd.String("volumes-from", "", "Mount volumes from the comma-separated list of containers")
 	flEntrypoint := cmd.String("entrypoint", "", "Overwrite the default entrypoint of the image")
 
 	if err := cmd.Parse(args); err != nil {
@@ -609,20 +609,22 @@ func (container *Container) Start(hostConfig *HostConfig) error {
 	}
 
 	if container.Config.VolumesFrom != "" {
-		c := container.runtime.Get(container.Config.VolumesFrom)
-		if c == nil {
-			return fmt.Errorf("Container %s not found. Impossible to mount its volumes", container.ID)
-		}
-		for volPath, id := range c.Volumes {
-			if _, exists := container.Volumes[volPath]; exists {
-				return fmt.Errorf("The requested volume %s overlap one of the volume of the container %s", volPath, c.ID)
+		for _, cont := range strings.Split(container.Config.VolumesFrom, ",") {
+			c := container.runtime.Get(cont)
+			if c == nil {
+				return fmt.Errorf("Container %s not found. Impossible to mount its volumes", container.ID)
 			}
-			if err := os.MkdirAll(path.Join(container.RootfsPath(), volPath), 0755); err != nil {
-				return nil
-			}
-			container.Volumes[volPath] = id
-			if isRW, exists := c.VolumesRW[volPath]; exists {
-				container.VolumesRW[volPath] = isRW
+			for volPath, id := range c.Volumes {
+				if _, exists := container.Volumes[volPath]; exists {
+					return fmt.Errorf("The requested volume %s overlap one of the volume of the container %s", volPath, c.ID)
+				}
+				if err := os.MkdirAll(path.Join(container.RootfsPath(), volPath), 0755); err != nil {
+					return nil
+				}
+				container.Volumes[volPath] = id
+				if isRW, exists := c.VolumesRW[volPath]; exists {
+					container.VolumesRW[volPath] = isRW
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This is a quick change to allow -volumes-from to grab volumes from multiple containers. I needed this for a project and I didn't really consider any further implications, but I figured this might be useful for someone.
