### PR TITLE
API, issue 1471: Use groups for socket permissions

### DIFF
--- a/api.go
+++ b/api.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -1086,7 +1087,25 @@ func ListenAndServe(proto, addr string, srv *Server, logging bool) error {
 		return e
 	}
 	if proto == "unix" {
-		os.Chmod(addr, 0700)
+		if err := os.Chmod(addr, 0660); err != nil {
+			return err
+		}
+
+		groups, err := ioutil.ReadFile("/etc/group")
+		if err != nil {
+			return err
+		}
+		re := regexp.MustCompile("(^|\n)docker:.*?:([0-9]+)")
+		if gidMatch := re.FindStringSubmatch(string(groups)); gidMatch != nil {
+			gid, err := strconv.Atoi(gidMatch[2])
+			if err != nil {
+				return err
+			}
+			utils.Debugf("docker group found. gid: %d", gid)
+			if err := os.Chown(addr, 0, gid); err != nil {
+				return err
+			}
+		}
 	}
 	httpSrv := http.Server{Addr: addr, Handler: r}
 	return httpSrv.Serve(l)


### PR DESCRIPTION
As discussed in PR #1417, this PR implements @mhennings idea to allow users in the docker group to run the client mode. Still the same original security concerns apply so the sysadmin should carefully consider them before adding users to the docker group.
