### PR TITLE
Add GitHub usernames to MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,6 @@
-Solomon Hykes <solomon@dotcloud.com>
-Guillaume Charmes <guillaume@dotcloud.com>
-Victor Vieux <victor@dotcloud.com>
-Michael Crosby <michael@crosbymichael.com>
-api.go: Victor Vieux <victor@dotcloud.com>
-Vagrantfile: Daniel Mizyrycki <daniel@dotcloud.com>
+Solomon Hykes <solomon@dotcloud.com> (@shykes)
+Guillaume Charmes <guillaume@dotcloud.com> (@creack)
+Victor Vieux <victor@dotcloud.com> (@vieux)
+Michael Crosby <michael@crosbymichael.com> (@crosbymichael)
+api.go: Victor Vieux <victor@dotcloud.com> (@vieux)
+Vagrantfile: Daniel Mizyrycki <daniel@dotcloud.com> (@mzdaniel)

--- a/docs/MAINTAINERS
+++ b/docs/MAINTAINERS
@@ -1,2 +1,2 @@
-Andy Rothfusz <andy@dotcloud.com>
-Ken Cochrane <ken@dotcloud.com>
+Andy Rothfusz <andy@dotcloud.com> (@metalivedev)
+Ken Cochrane <ken@dotcloud.com> (@kencochrane)

--- a/docs/sources/api/MAINTAINERS
+++ b/docs/sources/api/MAINTAINERS
@@ -1,1 +1,1 @@
-Solomon Hykes <solomon@dotcloud.com>
+Solomon Hykes <solomon@dotcloud.com> (@shykes)

--- a/docs/theme/MAINTAINERS
+++ b/docs/theme/MAINTAINERS
@@ -1,1 +1,1 @@
-Thatcher Peskens <thatcher@dotcloud.com>
+Thatcher Peskens <thatcher@dotcloud.com> (@dhrp)

--- a/hack/dockerbuilder/MAINTAINERS
+++ b/hack/dockerbuilder/MAINTAINERS
@@ -1,1 +1,1 @@
-Daniel Mizyrycki <daniel@dotcloud.com>
+Daniel Mizyrycki <daniel@dotcloud.com> (@mzdaniel)

--- a/hack/infrastructure/MAINTAINERS
+++ b/hack/infrastructure/MAINTAINERS
@@ -1,2 +1,2 @@
-Ken Cochrane <ken@dotcloud.com>
-Jerome Petazzoni <jerome@dotcloud.com>
+Ken Cochrane <ken@dotcloud.com> (@kencochrane)
+Jerome Petazzoni <jerome@dotcloud.com> (@jpetazzo)

--- a/library/MAINTAINERS
+++ b/library/MAINTAINERS
@@ -1,1 +1,1 @@
-Joffrey Fuhrer <joffrey@dotcloud.com>
+Joffrey Fuhrer <joffrey@dotcloud.com> (@shin-)

--- a/packaging/MAINTAINERS
+++ b/packaging/MAINTAINERS
@@ -1,1 +1,1 @@
-Daniel Mizyrycki <daniel@dotcloud.com>
+Daniel Mizyrycki <daniel@dotcloud.com> (@mzdaniel)

--- a/registry/MAINTAINERS
+++ b/registry/MAINTAINERS
@@ -1,3 +1,3 @@
-Sam Alba <sam@dotcloud.com>
-Joffrey Fuhrer <joffrey@dotcloud.com>
-Ken Cochrane <ken@dotcloud.com>
+Sam Alba <sam@dotcloud.com> (@samalba)
+Joffrey Fuhrer <joffrey@dotcloud.com> (@shin-)
+Ken Cochrane <ken@dotcloud.com> (@kencochrane)

--- a/term/MAINTAINERS
+++ b/term/MAINTAINERS
@@ -1,2 +1,2 @@
-Guillaume Charmes <guillaume@dotcloud.com>
-Solomon Hykes <solomon@dotcloud.com>
+Guillaume Charmes <guillaume@dotcloud.com> (@creack)
+Solomon Hykes <solomon@dotcloud.com> (@shykes)

--- a/testing/MAINTAINERS
+++ b/testing/MAINTAINERS
@@ -1,1 +1,1 @@
-Daniel Mizyrycki <daniel@dotcloud.com>
+Daniel Mizyrycki <daniel@dotcloud.com> (@mzdaniel)


### PR DESCRIPTION
This makes it easier to ping people when writing comments.
