### PR TITLE
Revert "docker.upstart: avoid spawning a `sh` process"

### DIFF
--- a/packaging/ubuntu/docker.upstart
+++ b/packaging/ubuntu/docker.upstart
@@ -5,4 +5,6 @@ stop on runlevel [!2345]
 
 respawn
 
-exec /usr/bin/docker -d
+script
+    /usr/bin/docker -d
+end script


### PR DESCRIPTION
This reverts commit 24dd50490a027f01ea086eb90663d53348fa770e.

Fixes #1422
