### PR TITLE
Apply volumes-from before creating volumes

### DIFF
--- a/container.go
+++ b/container.go
@@ -587,7 +587,7 @@ func (container *Container) Start(hostConfig *HostConfig) error {
 		}
 		for volPath, id := range c.Volumes {
 			if _, exists := container.Volumes[volPath]; exists {
-				return fmt.Errorf("The requested volume %s overlap one of the volume of the container %s", volPath, c.ID)
+				continue
 			}
 			if err := os.MkdirAll(path.Join(container.RootfsPath(), volPath), 0755); err != nil {
 				return nil
@@ -602,10 +602,12 @@ func (container *Container) Start(hostConfig *HostConfig) error {
 	// Create the requested volumes if they don't exist
 	for volPath := range container.Config.Volumes {
 		volPath = path.Clean(volPath)
-		// If an external bind is defined for this volume, use that as a source
+		// Skip existing volumes
 		if _, exists := container.Volumes[volPath]; exists {
-			// Skip existing mounts
-		} else if bindMap, exists := binds[volPath]; exists {
+			continue
+		}
+		// If an external bind is defined for this volume, use that as a source
+		if bindMap, exists := binds[volPath]; exists {
 			container.Volumes[volPath] = bindMap.SrcPath
 			if strings.ToLower(bindMap.Mode) == "rw" {
 				container.VolumesRW[volPath] = true

--- a/container_test.go
+++ b/container_test.go
@@ -1333,6 +1333,12 @@ func TestVolumesFromWithVolumes(t *testing.T) {
 	if container.Volumes["/test"] != container2.Volumes["/test"] {
 		t.Fail()
 	}
+
+	// Ensure it restarts successfully
+	_, err = container2.Output()
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestOnlyLoopbackExistsWhenUsingDisableNetworkOption(t *testing.T) {


### PR DESCRIPTION
Copies the volumes from the container specified in `Config.VolumesFrom` before
creating volumes from `Config.Volumes`. Skips any preexisting volumes when
processing `Config.Volumes`. Fixes #1351

Use case:

``` sh
root@precise64:~/tmp# docker build -t xdissent/tmp .
Uploading context 10240 bytes
Step 1 : FROM base
 ---> b750fe79269d
Step 2 : VOLUME /tmp
 ---> Running in ed427cf54db8
 ---> 83bef1f787c8
Step 3 : CMD echo bar > /tmp/foo
 ---> Running in b6d4ce528cba
 ---> d391e03bf19e
Successfully built d391e03bf19e
root@precise64:~/tmp# docker run -t xdissent/tmp
root@precise64:~/tmp# docker run -volumes-from $(docker ps -l -q) -t xdissent/tmp cat /tmp/foo
bar
root@precise64:~/tmp# docker start $(docker ps -l -q)
84000140132c
root@precise64:~/tmp# docker logs $(docker ps -l -q)
bar
bar
```
