### PR TITLE
Do not overwrite env vars. Closes#1493

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -929,6 +929,7 @@ func TestEnv(t *testing.T) {
 	defer nuke(runtime)
 	container, err := NewBuilder(runtime).Create(&Config{
 		Image: GetTestImage(runtime).ID,
+		Env:   []string{"ANSWER=42"},
 		Cmd:   []string{"env"},
 	},
 	)
@@ -957,6 +958,7 @@ func TestEnv(t *testing.T) {
 	}
 	sort.Strings(actualEnv)
 	goodEnv := []string{
+		"ANSWER=42",
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"HOME=/",
 		"container=lxc",
@@ -970,6 +972,104 @@ func TestEnv(t *testing.T) {
 		if actualEnv[i] != goodEnv[i] {
 			t.Fatalf("Wrong environment variable: should be %s, not %s", goodEnv[i], actualEnv[i])
 		}
+	}
+}
+
+func TestEnvHomeNotOverwritenDuringRun(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+	container, err := NewBuilder(runtime).Create(&Config{
+		Image: GetTestImage(runtime).ID,
+		Env:   []string{"HOME=/tmp"},
+		Cmd:   []string{"env"},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.Destroy(container)
+
+	stdout, err := container.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stdout.Close()
+	hostConfig := &HostConfig{}
+	if err := container.Start(hostConfig); err != nil {
+		t.Fatal(err)
+	}
+	container.Wait()
+	output, err := ioutil.ReadAll(stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envLines := strings.Split(string(output), "\n")
+
+	// Find home env
+	homeKeyLen := len("HOME=")
+	homeLine := ""
+	for _, line := range envLines {
+		if (len(line) > homeKeyLen) && (line[0:homeKeyLen] == "HOME=") {
+			homeLine = line
+		}
+	}
+
+	if homeLine == "" {
+		t.Fatal("HOME env var not present!")
+	}
+
+	if (homeLine != "HOME=/tmp") {
+		t.Fatalf("HOME should be 'HOME=/tmp', but is: '%s'", homeLine)
+	}
+}
+
+func TestEnvDoNotOverrideVars(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+	container, err := NewBuilder(runtime).Create(&Config{
+		Image: GetTestImage(runtime).ID,
+		Env:   []string{"HOMER=/wants/a/donut"},
+		Cmd:   []string{"env"},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.Destroy(container)
+
+	stdout, err := container.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stdout.Close()
+	hostConfig := &HostConfig{}
+	if err := container.Start(hostConfig); err != nil {
+		t.Fatal(err)
+	}
+	container.Wait()
+	output, err := ioutil.ReadAll(stdout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	envLines := strings.Split(string(output), "\n")
+
+	// Find home env
+	homeKeyLen := len("HOME=")
+	homeLine := ""
+	for _, line := range envLines {
+		if (len(line) > homeKeyLen) && (line[0:homeKeyLen] == "HOME=") {
+			homeLine = line
+		}
+	}
+
+	if homeLine == "" {
+		t.Fatalf("HOME env var not present!. Env: %s", output)
+	}
+
+	if (homeLine != "HOME=/") {
+		t.Fatalf("HOME should be 'HOME=/', but is: '%s'", homeLine)
 	}
 }
 


### PR DESCRIPTION
Issue #1493 describes that setting the `HOME` env var in a Dockerfile doesn't work.
I've verified this issue, and created a fix. 

I also took the liberty to extend another test to make sure that non-default env vars still work, and to apply the fix for the `HOME` env var at the `PATH`, `container` and `HOSTNAME` vars.
