### PR TITLE
Adding a reference to ps -a

### DIFF
--- a/docs/sources/examples/python_web_app.rst
+++ b/docs/sources/examples/python_web_app.rst
@@ -36,7 +36,13 @@ Inside of the "shykes/pybuilder" image there is a command called buildapp, we ar
     docker attach $BUILD_JOB
     [...]
 
-We attach to the new container to see what is going on. Ctrl-C to disconnect
+While this container is running, we can attach to the new container to see what is going on. Ctrl-C to disconnect.
+
+.. code-block:: bash
+
+    docker ps -a
+    
+List all docker containers. If this container has already finished running, it will still be listed here.
 
 .. code-block:: bash
 


### PR DESCRIPTION
It was confusing to me as a first-time user that my docker attach command failed; I was expecting the container to run continuously, and when I couldn't attach to it, I assumed something was wrong. ps -a shows that the container still exists, which gives the user confidence to go to the next step.
