### PR TITLE
use Go 1.1.2 for dockerbuilder

### DIFF
--- a/hack/dockerbuilder/Dockerfile
+++ b/hack/dockerbuilder/Dockerfile
@@ -23,7 +23,7 @@ run	add-apt-repository -y ppa:dotcloud/docker-golang/ubuntu
 run	apt-get update
 # Packages required to checkout, build and upload docker
 run	DEBIAN_FRONTEND=noninteractive apt-get install -y -q s3cmd curl
-run	curl -s -o /go.tar.gz https://go.googlecode.com/files/go1.1.1.linux-amd64.tar.gz
+run	curl -s -o /go.tar.gz https://go.googlecode.com/files/go1.1.2.linux-amd64.tar.gz
 run	tar -C /usr/local -xzf /go.tar.gz
 run	echo "export PATH=/usr/local/go/bin:$PATH" > /.bashrc
 run	echo "export PATH=/usr/local/go/bin:$PATH" > /.bash_profile


### PR DESCRIPTION
This PR changes the dockerbuilder Dockerfile so that it uses Go 1.1.2 for building docker binary releases.

There is no negative side effect and switching to this version now is OK. The PPA packages will be built with Go 1.1.2 when they get updated.
