### PR TITLE
Keep env variables out of the command line

### DIFF
--- a/container.go
+++ b/container.go
@@ -444,16 +444,11 @@ func (container *Container) SaveHostConfig(hostConfig *HostConfig) (err error) {
 }
 
 func (container *Container) generateEnvConfig(env []string) error {
-	fo, err := os.Create(container.EnvConfigPath())
+	data, err := json.Marshal(env)
 	if err != nil {
 		return err
 	}
-	defer fo.Close()
-	for _, item := range env {
-		if _, err := fo.WriteString(item + "\n"); err != nil {
-			return err
-		}
-	}
+	ioutil.WriteFile(container.EnvConfigPath(), data, 0600)
 	return nil
 }
 

--- a/container.go
+++ b/container.go
@@ -226,6 +226,18 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 		}
 	}
 
+	envs := []string{}
+
+	for _, env := range flEnv {
+		arr := strings.Split(env, "=")
+		if len(arr) > 1 {
+			envs = append(envs, env)
+		} else {
+			v := os.Getenv(env)
+			envs = append(envs, env+"="+v)
+		}
+	}
+
 	var binds []string
 
 	// add any bind targets to the list of container volumes
@@ -298,7 +310,7 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 		AttachStdin:     flAttach.Get("stdin"),
 		AttachStdout:    flAttach.Get("stdout"),
 		AttachStderr:    flAttach.Get("stderr"),
-		Env:             flEnv,
+		Env:             envs,
 		Cmd:             runCmd,
 		Dns:             flDns,
 		Image:           image,

--- a/container_test.go
+++ b/container_test.go
@@ -973,14 +973,14 @@ func TestTty(t *testing.T) {
 }
 
 func TestEnv(t *testing.T) {
+	os.Setenv("TRUE", "false")
 	runtime := mkRuntime(t)
 	defer nuke(runtime)
-	container, _, err := runtime.Create(&Config{
-		Image: GetTestImage(runtime).ID,
-		Cmd:   []string{"env"},
-	},
-		"",
-	)
+	config, _, _, err := ParseRun([]string{"-e=FALSE=true", "-e=TRUE", GetTestImage(runtime).ID, "env"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	container, _, err := runtime.Create(config, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1010,6 +1010,8 @@ func TestEnv(t *testing.T) {
 		"HOME=/",
 		"container=lxc",
 		"HOSTNAME=" + container.ShortID(),
+		"FALSE=true",
+		"TRUE=false",
 	}
 	sort.Strings(goodEnv)
 	if len(goodEnv) != len(actualEnv) {

--- a/container_test.go
+++ b/container_test.go
@@ -974,9 +974,10 @@ func TestTty(t *testing.T) {
 
 func TestEnv(t *testing.T) {
 	os.Setenv("TRUE", "false")
+	os.Setenv("TRICKY", "tri\ncky\n")
 	runtime := mkRuntime(t)
 	defer nuke(runtime)
-	config, _, _, err := ParseRun([]string{"-e=FALSE=true", "-e=TRUE", GetTestImage(runtime).ID, "env"}, nil)
+	config, _, _, err := ParseRun([]string{"-e=FALSE=true", "-e=TRUE", "-e=TRICKY", GetTestImage(runtime).ID, "env"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1012,6 +1013,9 @@ func TestEnv(t *testing.T) {
 		"HOSTNAME=" + container.ShortID(),
 		"FALSE=true",
 		"TRUE=false",
+		"TRICKY=tri",
+		"cky",
+		"",
 	}
 	sort.Strings(goodEnv)
 	if len(goodEnv) != len(actualEnv) {

--- a/graph.go
+++ b/graph.go
@@ -201,6 +201,7 @@ func (graph *Graph) getDockerInitLayer() (string, error) {
 		"/proc":            "dir",
 		"/sys":             "dir",
 		"/.dockerinit":     "file",
+		"/.dockerenv":      "file",
 		"/etc/resolv.conf": "file",
 		"/etc/hosts":       "file",
 		"/etc/hostname":    "file",

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -97,6 +97,9 @@ lxc.mount.entry = shm {{$ROOTFS}}/dev/shm tmpfs size=65536k,nosuid,nodev,noexec 
 # Inject dockerinit
 lxc.mount.entry = {{.SysInitPath}} {{$ROOTFS}}/.dockerinit none bind,ro 0 0
 
+# Inject env
+lxc.mount.entry = {{.EnvConfigPath}} {{$ROOTFS}}/.dockerenv none bind,ro 0 0
+
 # In order to get a working DNS environment, mount bind (ro) the host's /etc/resolv.conf into the container
 lxc.mount.entry = {{.ResolvConfPath}} {{$ROOTFS}}/etc/resolv.conf none bind,ro 0 0
 {{if .Volumes}}

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/dotcloud/docker/netlink"
 	"github.com/dotcloud/docker/utils"
+	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -69,9 +70,14 @@ func changeUser(u string) {
 }
 
 // Clear environment pollution introduced by lxc-start
-func cleanupEnv(env utils.ListOpts) {
+func cleanupEnv() {
 	os.Clearenv()
-	for _, kv := range env {
+	content, err := ioutil.ReadFile("/.dockerenv")
+	if err != nil {
+		log.Fatalf("Unable to load environment variables: %v", err)
+	}
+	lines := strings.Split(string(content), "\n")
+	for _, kv := range lines {
 		parts := strings.SplitN(kv, "=", 2)
 		if len(parts) == 1 {
 			parts = append(parts, "")
@@ -104,12 +110,9 @@ func SysInit() {
 	var gw = flag.String("g", "", "gateway address")
 	var workdir = flag.String("w", "", "workdir")
 
-	var flEnv utils.ListOpts
-	flag.Var(&flEnv, "e", "Set environment variables")
-
 	flag.Parse()
 
-	cleanupEnv(flEnv)
+	cleanupEnv()
 	setupNetworking(*gw)
 	setupWorkingDirectory(*workdir)
 	changeUser(*u)

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -1,6 +1,7 @@
 package sysinit
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"github.com/dotcloud/docker/netlink"
@@ -72,11 +73,15 @@ func changeUser(u string) {
 // Clear environment pollution introduced by lxc-start
 func cleanupEnv() {
 	os.Clearenv()
+	var lines []string
 	content, err := ioutil.ReadFile("/.dockerenv")
 	if err != nil {
 		log.Fatalf("Unable to load environment variables: %v", err)
 	}
-	lines := strings.Split(string(content), "\n")
+	err = json.Unmarshal(content, &lines)
+	if err != nil {
+		log.Fatalf("Unable to unmarshal environment variables: %v", err)
+	}
 	for _, kv := range lines {
 		parts := strings.SplitN(kv, "=", 2)
 		if len(parts) == 1 {


### PR DESCRIPTION
Environment variables are commonly used instead of program arguments to pass passwords and other secrets to a process because they don't show up in the process list. But currently docker sets the environment variables of the container by passing them as arguments to docker-init and so you can't really use them to send passwords.

This pull request changes that so the environment variables are instead written to a file and bind mounted into the container at /.dockerenv

Also included is a change to the run command so that you can say you want to pass an environment variable to the container and still keep the actual value out of the command line.

```
PASSWORD=test docker run -e PASSWORD ubuntu env
```
