### PR TITLE
Install script should be fetched over https, not http.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Quick install on Ubuntu 12.04 and 12.10
 ---------------------------------------
 
 ```bash
-curl get.docker.io | sudo sh -x
+curl https://get.docker.io | sudo sh -x
 ```
 
 Binary installs


### PR DESCRIPTION
Fetching from http://get.docker.io and executing is insecure. https works out of the box, so we should use it.
