### PR TITLE
prevent crash when .dockercfg not readable

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -80,7 +80,7 @@ func LoadConfig(rootPath string) (*ConfigFile, error) {
 	}
 	b, err := ioutil.ReadFile(confFile)
 	if err != nil {
-		return nil, err
+		return &configFile, err
 	}
 
 	if err := json.Unmarshal(b, &configFile.Configs); err != nil {

--- a/commands.go
+++ b/commands.go
@@ -1751,7 +1751,10 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, proto, addr string) *Doc
 		err = out
 	}
 
-	configFile, _ := auth.LoadConfig(os.Getenv("HOME"))
+	configFile, e := auth.LoadConfig(os.Getenv("HOME"))
+	if e != nil {
+		fmt.Fprintf(err, "WARNING: %s\n", e)
+	}
 	return &DockerCli{
 		proto:      proto,
 		addr:       addr,


### PR DESCRIPTION
Fixes #1528 

Add warning and doesn't crash.
