### PR TITLE
Adding direct reference to contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,8 +301,7 @@ Contributing to Docker
 ======================
 
 Want to hack on Docker? Awesome! There are instructions to get you
-started on the website:
-http://docs.docker.io/en/latest/contributing/contributing/
+started [here](CONTRIBUTING.md).
 
 They are probably not perfect, please let us know if anything feels
 wrong or incomplete.


### PR DESCRIPTION
The URL for the contribution instructions simply lead to a page on docs.docker.io, that in itself had a link back to this repository's `CONTRIBUTING.md`. This pull request changes this to link directly to `CONTRIBUTING.md`. I did not create an issue for this as it is a rather minor change.

I hope this is useful!

Andreas
