### PR TITLE
Implement login with private registry

### DIFF
--- a/api.go
+++ b/api.go
@@ -484,7 +484,6 @@ func postImagesInsert(srv *Server, version float64, w http.ResponseWriter, r *ht
 }
 
 func postImagesPush(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	authConfig := &auth.AuthConfig{}
 	metaHeaders := map[string][]string{}
 	for k, v := range r.Header {
 		if strings.HasPrefix(k, "X-Meta-") {

--- a/api.go
+++ b/api.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"code.google.com/p/go.net/websocket"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"github.com/dotcloud/docker/auth"
@@ -395,13 +394,12 @@ func postImagesCreate(srv *Server, version float64, w http.ResponseWriter, r *ht
 	tag := r.Form.Get("tag")
 	repo := r.Form.Get("repo")
 
-	authEncoded := r.Form.Get("authConfig")
+	authJson := r.Header.Get("X-Registry-Auth")
 	authConfig := &auth.AuthConfig{}
-	if authEncoded != "" {
-		authJson := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authEncoded))
-		if err := json.NewDecoder(authJson).Decode(authConfig); err != nil {
+	if authJson != "" {
+		if err := json.NewDecoder(strings.NewReader(authJson)).Decode(authConfig); err != nil {
 			// for a pull it is not an error if no auth was given
-			// to increase compatibilit to existing api it is defaulting to be empty
+			// to increase compatibility with the existing api it is defaulting to be empty
 			authConfig = &auth.AuthConfig{}
 		}
 	}
@@ -495,17 +493,14 @@ func postImagesPush(srv *Server, version float64, w http.ResponseWriter, r *http
 	}
 	authConfig := &auth.AuthConfig{}
 
-	authEncoded := r.Form.Get("authConfig")
-	if authEncoded != "" {
-		// the new format is to handle the authConfg as a parameter
-		authJson := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authEncoded))
-		if err := json.NewDecoder(authJson).Decode(authConfig); err != nil {
-			// for a pull it is not an error if no auth was given
-			// to increase compatibilit to existing api it is defaulting to be empty
+	authJson := r.Header.Get("X-Registry-Auth")
+	if authJson != "" {
+		if err := json.NewDecoder(strings.NewReader(authJson)).Decode(authConfig); err != nil {
+			// to increase compatibility with the existing api it is defaulting to be empty
 			authConfig = &auth.AuthConfig{}
 		}
 	} else {
-		// the old format is supported for compatibility if there was no authConfig parameter
+		// the old format is supported for compatibility if there was no authConfig header
 		if err := json.NewDecoder(r.Body).Decode(authConfig); err != nil {
 			return err
 		}

--- a/commands.go
+++ b/commands.go
@@ -842,7 +842,7 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 			return err
 		}
 		registryAuthHeader := []string{
-			string(buf),
+			base64.URLEncoding.EncodeToString(buf),
 		}
 
 		return cli.stream("POST", "/images/"+name+"/push?"+v.Encode(), nil, cli.out, map[string][]string{
@@ -901,7 +901,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 			return err
 		}
 		registryAuthHeader := []string{
-			string(buf),
+			base64.URLEncoding.EncodeToString(buf),
 		}
 
 		return cli.stream("POST", "/images/create?"+v.Encode(), nil, cli.out, map[string][]string{

--- a/commands.go
+++ b/commands.go
@@ -841,8 +841,9 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 		if err != nil {
 			return err
 		}
+		v.Set("authConfig", base64.URLEncoding.EncodeToString(buf))
 
-		return cli.stream("POST", "/images/"+name+"/push?"+v.Encode(), bytes.NewBuffer(buf), cli.out)
+		return cli.stream("POST", "/images/"+name+"/push?"+v.Encode(), nil, cli.out)
 	}
 
 	if err := push(authConfig); err != nil {
@@ -897,7 +898,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 		}
 		v.Set("authConfig", base64.URLEncoding.EncodeToString(buf))
 
-		return cli.stream("POST", "/images/create?"+v.Encode(), bytes.NewBuffer(buf), cli.out)
+		return cli.stream("POST", "/images/create?"+v.Encode(), nil, cli.out)
 	}
 
 	if err := pull(authConfig); err != nil {

--- a/commands.go
+++ b/commands.go
@@ -1457,9 +1457,13 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		if err != nil {
 			return err
 		}
-		v.Set("authConfig", base64.URLEncoding.EncodeToString(buf))
 
-		err = cli.stream("POST", "/images/create?"+v.Encode(), nil, cli.err, nil)
+		registryAuthHeader := []string{
+			base64.URLEncoding.EncodeToString(buf),
+		}
+		err = cli.stream("POST", "/images/create?"+v.Encode(), nil, cli.err, map[string][]string{
+			"X-Registry-Auth": registryAuthHeader,
+		})
 		if err != nil {
 			return err
 		}

--- a/docs/sources/api/docker_remote_api_v1.4.rst
+++ b/docs/sources/api/docker_remote_api_v1.4.rst
@@ -991,7 +991,8 @@ Check auth configuration
 	   {
 		"username":"hannibal",
 		"password:"xxxx",
-		"email":"hannibal@a-team.com"
+		"email":"hannibal@a-team.com",
+		"serveraddress":"https://index.docker.io/v1/"
 	   }
 
         **Example response**:

--- a/docs/sources/commandline/command/login.rst
+++ b/docs/sources/commandline/command/login.rst
@@ -8,10 +8,17 @@
 
 ::
 
-    Usage: docker login [OPTIONS]
+    Usage: docker login [OPTIONS] [SERVER]
 
     Register or Login to the docker registry server
 
     -e="": email
     -p="": password
     -u="": username
+
+    If you want to login to a private registry you can
+    specify this by adding the server name.
+
+    example:
+    docker login localhost:8080
+

--- a/server.go
+++ b/server.go
@@ -655,6 +655,9 @@ func (srv *Server) ImagePull(localName string, tag string, out io.Writer, sf *ut
 
 	out = utils.NewWriteFlusher(out)
 	err = srv.pullRepository(r, out, localName, remoteName, tag, endpoint, sf, parallel)
+	if err == registry.ErrLoginRequired {
+		return err
+	}
 	if err != nil {
 		if err := srv.pullImage(r, out, remoteName, endpoint, nil, sf); err != nil {
 			return err


### PR DESCRIPTION
To improve the use of docker with a private registry the login
command is extended with a parameter for the server address.

While implementing i noticed that two problems hindered authentication to a
private registry:
1. the resolve of the authentication did not match during push
   because the looked up key was for example localhost:8080 but
   the stored one would have been https://localhost:8080
   
   Besides The lookup needs to still work if the https->http fallback
   is used
2. During pull of an image no authentication is sent, which
   means all repositories are expected to be private.

These points are fixed now. The changes are implemented in
a way to be compatible to existing behavior both in the
API as also with the private registry.

Update:
- login does not require the full url any more, you can login
  to the repository prefix:
  
  example:
  docker logon localhost:8080

Fixed corner corner cases:
- When login is done during pull and push the registry endpoint is used and
  not the central index
- When Remote sends a 401 during pull, it is now correctly delegating to
  CmdLogin
- After a Login is done pull and push are using the newly entered login data,
  and not the previous ones. This one seems to be also broken in master, too.
- Auth config is now transfered in a parameter instead of the body when
  /images/create is called.
