### PR TITLE
Allow namespaces to be 3 characters

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -65,9 +65,9 @@ func validateRepositoryName(repositoryName string) error {
 		namespace = nameParts[0]
 		name = nameParts[1]
 	}
-	validNamespace := regexp.MustCompile(`^([a-z0-9_]{4,30})$`)
+	validNamespace := regexp.MustCompile(`^([a-z0-9_]{3,30})$`)
 	if !validNamespace.MatchString(namespace) {
-		return fmt.Errorf("Invalid namespace name (%s), only [a-z0-9_] are allowed, size between 4 and 30", namespace)
+		return fmt.Errorf("Invalid namespace name (%s), only [a-z0-9_] are allowed, size between 3 and 30", namespace)
 	}
 	validRepo := regexp.MustCompile(`^([a-zA-Z0-9-_.]+)$`)
 	if !validRepo.MatchString(name) {


### PR DESCRIPTION
The acronym for our group internally is 3 characters. Having to come up with another letter to add sounds hard. So why not just change it ? ;)
