### PR TITLE
Show tag used when image is missing

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1402,6 +1402,13 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	body, statusCode, err := cli.call("POST", "/containers/create", config)
 	//if image not found try to pull it
 	if statusCode == 404 {
+		_, tag := utils.ParseRepositoryTag(config.Image)
+		if tag == "" {
+			tag = DEFAULTTAG
+		}
+
+		fmt.Printf("Unable to find image '%s' (tag: %s) locally\n", config.Image, tag)
+
 		v := url.Values{}
 		repos, tag := utils.ParseRepositoryTag(config.Image)
 		v.Set("fromImage", repos)

--- a/server.go
+++ b/server.go
@@ -828,7 +828,13 @@ func (srv *Server) ContainerCreate(config *Config) (string, error) {
 	container, err := b.Create(config)
 	if err != nil {
 		if srv.runtime.graph.IsNotExist(err) {
-			return "", fmt.Errorf("No such image: %s", config.Image)
+
+			_, tag := utils.ParseRepositoryTag(config.Image)
+			if tag == "" {
+				tag = DEFAULTTAG
+			}
+
+			return "", fmt.Errorf("No such image: %s (tag: %s)", config.Image, tag)
 		}
 		return "", err
 	}


### PR DESCRIPTION
This helps users understand why a local image wasn't used when 'run' is executed.
