### PR TITLE
Add workdir support for the Buildfile

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -222,6 +222,11 @@ func (b *buildFile) CmdEntrypoint(args string) error {
 	return nil
 }
 
+func (b *buildFile) CmdWorkdir(workdir string) error {
+	b.config.WorkingDir = workdir
+	return b.commit("", b.config.Cmd, fmt.Sprintf("WORKDIR %v", workdir))
+}
+
 func (b *buildFile) CmdVolume(args string) error {
 	if args == "" {
 		return fmt.Errorf("Volume cannot be empty")

--- a/docs/sources/use/builder.rst
+++ b/docs/sources/use/builder.rst
@@ -205,6 +205,14 @@ to the entrypoint.
 The ``VOLUME`` instruction will add one or more new volumes to any
 container created from the image.
 
+3.10 WORKDIR
+--------------
+
+    ``WORKDIR /path/to/workdir``
+
+The ``WORKDIR`` instruction sets the working directory in which
+the command given by ``CMD`` is executed.
+
 4. Dockerfile Examples
 ======================
 

--- a/utils.go
+++ b/utils.go
@@ -132,6 +132,9 @@ func MergeConfig(userConf, imageConf *Config) {
 	if userConf.Entrypoint == nil || len(userConf.Entrypoint) == 0 {
 		userConf.Entrypoint = imageConf.Entrypoint
 	}
+	if userConf.WorkingDir == "" {
+		userConf.WorkingDir = imageConf.WorkingDir
+	}
 	if userConf.VolumesFrom == "" {
 		userConf.VolumesFrom = imageConf.VolumesFrom
 	}


### PR DESCRIPTION
For consistency the Buildfile should have the option to
set the working directory.

Of course that is one option more to the buildfile,
so please tell me if we really want this to happen.
