### PR TITLE
479 - add -rm support to docker run

### DIFF
--- a/docs/sources/commandline/command/run.rst
+++ b/docs/sources/commandline/command/run.rst
@@ -23,6 +23,7 @@
       -m=0: Memory limit (in bytes)
       -n=true: Enable networking for this container
       -p=[]: Map a network port to the container
+      -rm=false: Automatically remove the container when it exits (incompatible with -d)
       -t=false: Allocate a pseudo-tty
       -u="": Username or UID
       -dns=[]: Set custom dns servers for the container

--- a/runtime.go
+++ b/runtime.go
@@ -174,7 +174,8 @@ func (runtime *Runtime) Register(container *Container) error {
 		close(container.waitLock)
 	} else if !nomonitor {
 		container.allocateNetwork()
-		go container.monitor()
+		// hostConfig isn't needed here and can be nil
+		go container.monitor(nil)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds support for automatically removing the container when the container exits (or a signal to stop is received). This PR fixes #479.

It's currently supported only when -d isn't provided. It doesn't make sense to automatically remove a container created via `docker run -d`. There are two reasons why this is implemented this way: 1) we might want to retrieve some kind of exit status or logs before removing the container 2) making this run on the server side is difficult in the current architecture.

Please feel free to provide feedback for this PR.
