### PR TITLE
Add getlxctemplate command to get the default lxc template.

### DIFF
--- a/api.go
+++ b/api.go
@@ -192,6 +192,16 @@ func getInfo(srv *Server, version float64, w http.ResponseWriter, r *http.Reques
 	return nil
 }
 
+func getLxcTemplate(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	out := LxcTemplate
+	b, err := json.Marshal(out)
+	if err != nil {
+		return err
+	}
+	writeJSON(w, b)
+	return nil
+}
+
 func getEvents(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	sendEvent := func(wf *utils.WriteFlusher, event *utils.JSONMessage) error {
 		b, err := json.Marshal(event)
@@ -1008,6 +1018,7 @@ func createRouter(srv *Server, logging bool) (*mux.Router, error) {
 	m := map[string]map[string]HttpApiFunc{
 		"GET": {
 			"/events":                         getEvents,
+			"/get_lxc_template":               getLxcTemplate,
 			"/info":                           getInfo,
 			"/version":                        getVersion,
 			"/images/json":                    getImagesJSON,

--- a/commands.go
+++ b/commands.go
@@ -114,7 +114,7 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 }
 
 func (cli *DockerCli) CmdGetlxctemplate(args ...string) error {
-	cmd := Subcmd("info", "", "Display system-wide information")
+	cmd := Subcmd("getlxctemplate", "", "Get the default LXC template")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}

--- a/commands.go
+++ b/commands.go
@@ -81,6 +81,7 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 		{"diff", "Inspect changes on a container's filesystem"},
 		{"events", "Get real time events from the server"},
 		{"export", "Stream the contents of a container as a tar archive"},
+		{"getlxctemplate", "get the default LXC template"},
 		{"history", "Show the history of an image"},
 		{"images", "List images"},
 		{"import", "Create a new filesystem image from the contents of a tarball"},
@@ -109,6 +110,30 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 		help += fmt.Sprintf("    %-10.10s%s\n", command[0], command[1])
 	}
 	fmt.Fprintf(cli.err, "%s\n", help)
+	return nil
+}
+
+func (cli *DockerCli) CmdGetlxctemplate(args ...string) error {
+	cmd := Subcmd("info", "", "Display system-wide information")
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+	if cmd.NArg() > 0 {
+		cmd.Usage()
+		return nil
+	}
+
+	body, _, err := cli.call("GET", "/get_lxc_template", nil)
+	if err != nil {
+		return err
+	}
+
+	var out string
+	if err := json.Unmarshal(body, &out); err != nil {
+		return err
+	}
+	fmt.Fprintf(cli.out, "%s\n", out);
+
 	return nil
 }
 


### PR DESCRIPTION
Useful with PR #1383 so if you hand edit the template, you can detect if/when it changes, or you can get the template to programmatically edit it.
