### PR TITLE
proper resolv.conf parsing

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -772,7 +772,7 @@ func GetResolvConf() ([]byte, error) {
 // CheckLocalDns looks into the /etc/resolv.conf,
 // it returns true if there is a local nameserver or if there is no nameserver.
 func CheckLocalDns(resolvConf []byte) bool {
-	var parsedResolvConf = ParseResolvConf(resolvConf)
+	var parsedResolvConf = StripComments(resolvConf, []byte("#"))
 	if !bytes.Contains(parsedResolvConf, []byte("nameserver")) {
 		return true
 	}
@@ -787,20 +787,20 @@ func CheckLocalDns(resolvConf []byte) bool {
 	return false
 }
 
-// ParseResolvConf parses the resolv.conf file into lines and strips away comments.
-func ParseResolvConf(resolvConf []byte) []byte {
-	lines := bytes.Split(resolvConf, []byte("\n"))
-	var noCommentsResolvConf []byte
+// StripComments parses input into lines and strips away comments.
+func StripComments(input []byte, commentMarker []byte) []byte {
+	lines := bytes.Split(input, []byte("\n"))
+	var output []byte
 	for _, currentLine := range lines {
-		var cleanLine = bytes.TrimLeft(currentLine, " \t")
-		var commentIndex = bytes.Index(cleanLine, []byte("#"))
+		var commentIndex = bytes.Index(currentLine, commentMarker)
 		if ( commentIndex == -1 ) {
-			noCommentsResolvConf = append(noCommentsResolvConf, cleanLine...)
+			output = append(output, currentLine...)
 		} else {
-			noCommentsResolvConf = append(noCommentsResolvConf, cleanLine[:commentIndex]...)
+			output = append(output, currentLine[:commentIndex]...)
 		}
+		output = append(output, []byte("\n")...)
 	}
-	return noCommentsResolvConf
+	return output
 }
 
 func ParseHost(host string, port int, addr string) string {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -323,6 +323,16 @@ func TestCheckLocalDns(t *testing.T) {
 nameserver 10.0.2.3
 search dotcloud.net`: false,
 		`# Dynamic
+#nameserver 127.0.0.1
+nameserver 10.0.2.3
+search dotcloud.net`: false,
+		`# Dynamic
+nameserver 10.0.2.3 #not used 127.0.1.1
+search dotcloud.net`: false,
+		`# Dynamic
+#nameserver 10.0.2.3
+#search dotcloud.net`: true,
+		`# Dynamic
 nameserver 127.0.0.1
 search dotcloud.net`: true,
 		`# Dynamic


### PR DESCRIPTION
This pullrequest parses resolv.conf properly. It splits in lines and strips away comments. 

This prevents issues such as:
- commented localhost nameserver, which should not be used. This would mean you get the default google-dns nameservers; eg:

```
nameserver 10.0.0.2
#nameserver 127.0.1.1
```
- commented nameservers, which means we have no nameservers at all, eg:

```
#nameserver 10.0.0.2
```
