### PR TITLE
Make - read from stdin for rm and rmi

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -701,7 +701,25 @@ func (cli *DockerCli) CmdRmi(args ...string) error {
 		return nil
 	}
 
-	for _, name := range cmd.Args() {
+	input := cmd.Args()
+
+	for c, name := range input {
+		if name == "-" {
+			input = append(input[:c], input[c+1:]...)
+			buff, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				break
+			}
+			lines := strings.Split(string(buff), "\n")
+			if len(lines[len(lines)-1]) == 0 {
+				lines = lines[:len(lines)-1]
+			}
+			input = append(input, lines...)
+			break
+		}
+	}
+
+	for _, name := range input {
 		body, _, err := cli.call("DELETE", "/images/"+name, nil)
 		if err != nil {
 			fmt.Fprintf(cli.err, "%s", err)
@@ -770,7 +788,26 @@ func (cli *DockerCli) CmdRm(args ...string) error {
 	if *v {
 		val.Set("v", "1")
 	}
-	for _, name := range cmd.Args() {
+
+	input := cmd.Args()
+
+	for c, name := range input {
+		if name == "-" {
+			input = append(input[:c], input[c+1:]...)
+			buff, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				break
+			}
+			lines := strings.Split(string(buff), "\n")
+			if len(lines[len(lines)-1]) == 0 {
+				lines = lines[:len(lines)-1]
+			}
+			input = append(input, lines...)
+			break
+		}
+	}
+
+	for _, name := range input {
 		_, _, err := cli.call("DELETE", "/containers/"+name+"?"+val.Encode(), nil)
 		if err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)


### PR DESCRIPTION
Modify Command.go so that if we pass `-` on the command line docker rm and docker rmi also try and remove images recieved on stdin as a list of images/containers one per line

This matches the syntax used in other linux programs, such as xz.

This is a partial fix for #928

I'm pretty sure there should be some basic tests added. But I'm not seeing anywhere that explicitly tests commands. Am I missing a test file or are we not doing tests for commands?
