### PR TITLE
Pass "meta" headers in API calls to the registry

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -56,7 +56,7 @@ func (b *buildFile) CmdFrom(name string) error {
 	if err != nil {
 		if b.runtime.graph.IsNotExist(err) {
 			remote, tag := utils.ParseRepositoryTag(name)
-			if err := b.srv.ImagePull(remote, tag, b.out, utils.NewStreamFormatter(false), nil, true); err != nil {
+			if err := b.srv.ImagePull(remote, tag, b.out, utils.NewStreamFormatter(false), nil, nil, true); err != nil {
 				return err
 			}
 			image, err = b.runtime.repositories.LookupImage(name)

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -101,7 +101,7 @@ func init() {
 	// If the unit test is not found, try to download it.
 	if img, err := globalRuntime.repositories.LookupImage(unitTestImageName); err != nil || img.ID != unitTestImageID {
 		// Retrieve the Image
-		if err := srv.ImagePull(unitTestImageName, "", os.Stdout, utils.NewStreamFormatter(false), nil, true); err != nil {
+		if err := srv.ImagePull(unitTestImageName, "", os.Stdout, utils.NewStreamFormatter(false), nil, nil, true); err != nil {
 			panic(err)
 		}
 	}

--- a/utils/http.go
+++ b/utils/http.go
@@ -93,6 +93,20 @@ func (self *HTTPUserAgentDecorator) ChangeRequest(req *http.Request) (newReq *ht
 	return req, nil
 }
 
+type HTTPMetaHeadersDecorator struct {
+	Headers map[string][]string
+}
+
+func (self *HTTPMetaHeadersDecorator) ChangeRequest(req *http.Request) (newReq *http.Request, err error) {
+	if self.Headers == nil {
+		return req, nil
+	}
+	for k, v := range self.Headers {
+		req.Header[k] = v
+	}
+	return req, nil
+}
+
 // HTTPRequestFactory creates an HTTP request
 // and applies a list of decorators on the request.
 type HTTPRequestFactory struct {


### PR DESCRIPTION
This will allow us to implement registry storages that use external authentication. The first use case for this is to allow upen-stack support (by allowing keystone tokens to be passed through to the registry, then to glance)

cc @samalba
