### PR TITLE
Fix libffi build failure for the main Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ env	GOPATH	/go
 env	CGO_ENABLED 0
 run	cd /tmp && echo 'package main' > t.go && go test -a -i -v
 # Ubuntu stuff
-run	apt-get install -y -q ruby1.9.3 rubygems
+run	apt-get install -y -q ruby1.9.3 rubygems libffi-dev
 run	gem install fpm
 run	apt-get install -y -q reprepro dpkg-sig
 # Install s3cmd 1.0.1 (earlier versions don't support env variables in the config)


### PR DESCRIPTION
This PR changes the main Dockerfile so that it's using libffi-dev to avoid having to build libffi from sources.

This fixes the following error I've run into:

```
ERROR:  Error installing fpm:
        ERROR: Failed to build gem native extension.

        /usr/bin/ruby1.8 extconf.rb
checking for ffi.h... no
checking for ffi.h in /usr/local/include,/usr/include/ffi... no
checking for rb_thread_blocking_region()... no
checking for rb_thread_call_with_gvl()... no
checking for rb_thread_call_without_gvl()... no
checking for ffi_prep_cif_var()... no
creating extconf.h
creating Makefile

make
Configuring libffi
pwd: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
configure: error: working directory cannot be determined
make: *** ["/var/lib/gems/1.8/gems/ffi-1.9.0/ext/ffi_c/libffi-x86_64-linux"/.libs/libffi_convenience.a] Error 1


Gem files will remain installed in /var/lib/gems/1.8/gems/ffi-1.9.0 for inspection.
Results logged to /var/lib/gems/1.8/gems/ffi-1.9.0/ext/ffi_c/gem_make.out
Building native extensions.  This could take a while...
Building native extensions.  This could take a while...
Building native extensions.  This could take a while...
Error build: The command [/bin/sh -c gem install fpm] returned a non-zero code: 1
The command [/bin/sh -c gem install fpm] returned a non-zero code: 1
```
