### PR TITLE
1594 - return non-zero exit code if at least one container has failed to start

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -584,15 +584,17 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 		return nil
 	}
 
+	var encounteredError error
 	for _, name := range args {
 		_, _, err := cli.call("POST", "/containers/"+name+"/start", nil)
 		if err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
+			encounteredError = fmt.Errorf("Error: failed to start one or more containers")
 		} else {
 			fmt.Fprintf(cli.out, "%s\n", name)
 		}
 	}
-	return nil
+	return encounteredError
 }
 
 func (cli *DockerCli) CmdInspect(args ...string) error {


### PR DESCRIPTION
This makes docker start exit with exit code 1 if at least one container
didn't start. This also prints an error at the end.

This PR doesn't change the behavior of `docker start cid1 cid2...`. The only differences are the non-zero exit code and the extra error printed at the end.

This fixes #1594.
