### PR TITLE
Use correct upstart script with new build tool

### DIFF
--- a/hack/release/make.sh
+++ b/hack/release/make.sh
@@ -57,7 +57,9 @@ stop on runlevel [!2345]
 
 respawn
 
-exec docker -d
+script
+    /usr/bin/docker -d
+end script
 '
 
 # Each "bundle" is a different type of build artefact: static binary, Ubuntu


### PR DESCRIPTION
Fix lxc fork/exec issue with new build process
