### PR TITLE
[WIP] Docker packaging for Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,11 +1,11 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-BOX_NAME = ENV['BOX_NAME'] || "ubuntu"
-BOX_URI = ENV['BOX_URI'] || "http://files.vagrantup.com/precise64.box"
-VF_BOX_URI = ENV['BOX_URI'] || "http://files.vagrantup.com/precise64_vmware_fusion.box"
-AWS_REGION = ENV['AWS_REGION'] || "us-east-1"
-AWS_AMI    = ENV['AWS_AMI']    || "ami-d0f89fb9"
+BOX_NAME             = ENV['BOX_NAME']   || "docker"
+BOX_URI              = ENV['BOX_URI']    || "http://files.vagrantup.com/precise64.box"
+VF_BOX_URI           = ENV['BOX_URI']    || "http://files.vagrantup.com/precise64_vmware_fusion.box"
+AWS_REGION           = ENV['AWS_REGION'] || "us-east-1"
+AWS_AMI              = ENV['AWS_AMI']    || "ami-d0f89fb9"
 FORWARD_DOCKER_PORTS = ENV['FORWARD_DOCKER_PORTS']
 
 Vagrant::Config.run do |config|
@@ -13,38 +13,7 @@ Vagrant::Config.run do |config|
   config.vm.box = BOX_NAME
   config.vm.box_url = BOX_URI
   config.vm.forward_port 4243, 4243
-
-  # Provision docker and new kernel if deployment was not done
-  if Dir.glob("#{File.dirname(__FILE__)}/.vagrant/machines/default/*/id").empty?
-    # Add lxc-docker package
-    pkg_cmd = "apt-get update -qq; apt-get install -q -y python-software-properties; " \
-      "add-apt-repository -y ppa:dotcloud/lxc-docker; apt-get update -qq; " \
-      "apt-get install -q -y lxc-docker; "
-    # Add X.org Ubuntu backported 3.8 kernel
-    pkg_cmd << "add-apt-repository -y ppa:ubuntu-x-swat/r-lts-backport; " \
-      "apt-get update -qq; apt-get install -q -y linux-image-3.8.0-19-generic; "
-    # Add guest additions if local vbox VM
-    is_vbox = true
-    ARGV.each do |arg| is_vbox &&= !arg.downcase.start_with?("--provider") end
-    if is_vbox
-      pkg_cmd << "apt-get install -q -y linux-headers-3.8.0-19-generic dkms; " \
-        "echo 'Downloading VBox Guest Additions...'; " \
-        "wget -q http://dlc.sun.com.edgesuite.net/virtualbox/4.2.12/VBoxGuestAdditions_4.2.12.iso; "
-      # Prepare the VM to add guest additions after reboot
-      pkg_cmd << "echo -e 'mount -o loop,ro /home/vagrant/VBoxGuestAdditions_4.2.12.iso /mnt\n" \
-        "echo yes | /mnt/VBoxLinuxAdditions.run\numount /mnt\n" \
-          "rm /root/guest_additions.sh; ' > /root/guest_additions.sh; " \
-        "chmod 700 /root/guest_additions.sh; " \
-        "sed -i -E 's#^exit 0#[ -x /root/guest_additions.sh ] \\&\\& /root/guest_additions.sh#' /etc/rc.local; " \
-        "echo 'Installation of VBox Guest Additions is proceeding in the background.'; " \
-        "echo '\"vagrant reload\" can be used in about 2 minutes to activate the new guest additions.'; "
-    end
-    # Activate new kernel
-    pkg_cmd << "shutdown -r +1; "
-    config.vm.provision :shell, :inline => pkg_cmd
-  end
 end
-
 
 # Providers were added on Vagrant >= 1.1.0
 Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|

--- a/packaging/vagrant/.gitignore
+++ b/packaging/vagrant/.gitignore
@@ -1,0 +1,2 @@
+/packer_cache
+*.box

--- a/packaging/vagrant/README.vagrant
+++ b/packaging/vagrant/README.vagrant
@@ -1,0 +1,30 @@
+Vagrant boxes of Docker
+=======================
+
+Provides pre-built system images for various vagrant targets.
+
+For now we provide the following images:
+
+* VirtualBox
+* VMWare Fusion (FIXME: Needs to be tested)
+
+How to build
+------------
+
+The build relies on an external tool called packer. To install head to
+<http://packer.io> and follow the instructions there.
+
+Once installed, make sure to be in the same directory as this file and
+execute:
+
+`package build --only=virtualbox template.json`
+
+or remove the --only option to build all the targets.
+
+TODO
+----
+
+* Add cgroup swap limit
+* Check why aufs is not loaded on start
+* Check why the vagrant user doesn't have access to the docker socket
+

--- a/packaging/vagrant/README.vagrant
+++ b/packaging/vagrant/README.vagrant
@@ -24,7 +24,6 @@ or remove the --only option to build all the targets.
 TODO
 ----
 
-* Add cgroup swap limit
 * Check why aufs is not loaded on start
 * Check why the vagrant user doesn't have access to the docker socket
 

--- a/packaging/vagrant/http/preseed.cfg
+++ b/packaging/vagrant/http/preseed.cfg
@@ -1,0 +1,60 @@
+### Based on ubuntu-server-minimalvm.seed ###
+# Don't install kernel headers.
+d-i base-installer/kernel/headers boolean false
+# Don't even install the standard task.
+tasksel tasksel/skip-tasks string standard
+# Only install basic language packs. Let tasksel ask about tasks.
+d-i pkgsel/language-pack-patterns string
+# No language support packages.
+d-i pkgsel/install-language-support boolean false
+# Verbose output and no boot splash screen.
+d-i debian-installer/quiet boolean false
+d-i debian-installer/splash boolean false
+# Install the debconf oem-config frontend (if in OEM mode).
+d-i oem-config-udeb/frontend string debconf
+# Add the network and tasks oem-config steps by default.
+#oem-config oem-config/steps multiselect language, timezone, keyboard, user, network, tasks
+
+# Use the 3.8 kernel for Docker
+d-i base-installer/kernel/altmeta string lts-raring
+
+# Clock is UTC
+d-i time/zone string UTC
+d-i clock-setup/utc-auto boolean true
+
+# Partition the disk
+d-i partman-auto/method string regular
+d-i partman-auto/choose_recipe select atomic
+d-i partman/confirm_write_new_label boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+
+# Don't use a proxy to access the outside world
+choose-mirror-bin mirror/http/proxy string
+
+## Default user, we can get away with a recipe to change this
+d-i passwd/user-fullname string vagrant
+d-i passwd/username string vagrant
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i user-setup/encrypt-home boolean false
+d-i user-setup/allow-password-weak boolean true
+
+# Make sure SSH server is installed
+d-i pkgsel/include string openssh-server
+tasksel tasksel/first multiselect
+
+# Whether to upgrade packages after debootstrap.
+# Allowed values: none, safe-upgrade, full-upgrade
+d-i pkgsel/upgrade select full-upgrade
+
+#For the update
+d-i pkgsel/update-policy select none
+
+# Grub setup
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/timeout string 2
+
+# Reboot after everything is done
+d-i finish-install/reboot_in_progress note

--- a/packaging/vagrant/scripts/base.sh
+++ b/packaging/vagrant/scripts/base.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+date > /etc/vagrant_box_build_time
+
+# Prepare the system's package-manager and make it
+# minimal.
+
+# Compress apt indexes
+cat <<EOF > /etc/apt/apt.conf.d/02compress-indexes
+Acquire::GzipIndexes "true";
+Acquire::CompressionTypes::Order:: "gz";
+EOF
+apt-get update
+
+# Install base utils
+apt-get install -qy curl

--- a/packaging/vagrant/scripts/cleanup.sh
+++ b/packaging/vagrant/scripts/cleanup.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+# Remove items used for building, since they aren't needed anymore
+echo "*** removing unnessary packages"
+aptitude purge ~c
+apt-get -y autoremove
+apt-get clean
+
+# Removing leftover leases and persistent rules
+echo "*** cleaning up dhcp leases"
+rm -f /var/lib/dhcp/*
+
+# Make sure Udev doesn't block our network
+# http://6.ptmc.org/?p=164
+echo "*** cleaning up udev rules"
+rm /etc/udev/rules.d/70-persistent-net.rules
+mkdir /etc/udev/rules.d/70-persistent-net.rules
+rm -rf /dev/.udev/
+rm /lib/udev/rules.d/75-persistent-net-generator.rules
+
+echo "Adding a 2 sec delay to the interface up, to make the dhclient happy"
+echo "pre-up sleep 2" >> /etc/network/interfaces

--- a/packaging/vagrant/scripts/docker.sh
+++ b/packaging/vagrant/scripts/docker.sh
@@ -5,5 +5,9 @@ set -e
 curl https://get.docker.io/gpg | apt-key add -
 echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 apt-get update
+
 apt-get install -qy lxc-docker
 
+# Enable more cgroup features
+sed -e 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"/g' -i /etc/default/grub
+update-grub

--- a/packaging/vagrant/scripts/docker.sh
+++ b/packaging/vagrant/scripts/docker.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+curl https://get.docker.io/gpg | apt-key add -
+echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list
+apt-get update
+apt-get install -qy lxc-docker
+

--- a/packaging/vagrant/scripts/vagrant.sh
+++ b/packaging/vagrant/scripts/vagrant.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+# Install NFS client
+apt-get -y install nfs-common
+
+# Setup sudo to allow no-password sudo for "admin"
+groupadd -r admin
+usermod -a -G admin vagrant
+cp /etc/sudoers /etc/sudoers.orig
+sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
+sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
+
+# Installing vagrant keys
+mkdir /home/vagrant/.ssh
+chmod 700 /home/vagrant/.ssh
+cd /home/vagrant/.ssh
+wget --no-check-certificate 'https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub' -O authorized_keys
+chmod 600 /home/vagrant/.ssh/authorized_keys
+chown -R vagrant /home/vagrant/.ssh

--- a/packaging/vagrant/scripts/virtualbox.sh
+++ b/packaging/vagrant/scripts/virtualbox.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+VBOX_VERSION=$(cat /home/vagrant/.vbox_version)
+VBOX_ISO=VBoxGuestAdditions_$VBOX_VERSION.iso
+
+# Abort if not on VirtualBox
+[ -f "$VBOX_ISO" ] || exit 0
+
+apt-get -y install dkms
+mount -o loop "$VBOX_ISO" /mnt
+
+# Installing the virtualbox guest additions
+sh /mnt/VBoxLinuxAdditions.run --nox11 || true
+
+umount /mnt
+rm "$VBOX_ISO"

--- a/packaging/vagrant/scripts/zerodisk.sh
+++ b/packaging/vagrant/scripts/zerodisk.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# Zero out the free space to save space in the final image:
+dd if=/dev/zero of=/EMPTY bs=1M
+rm -f /EMPTY

--- a/packaging/vagrant/template.json
+++ b/packaging/vagrant/template.json
@@ -1,0 +1,95 @@
+{
+  "provisioners": [
+    {
+      "type": "shell",
+      "scripts": [
+        "scripts/base.sh",
+        "scripts/vagrant.sh",
+        "scripts/virtualbox.sh",
+        "scripts/docker.sh",
+        "scripts/cleanup.sh",
+        "scripts/zerodisk.sh"
+      ],
+      "override": {
+        "virtualbox": {
+          "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'"
+        },
+        "vmware": {
+          "execute_command": "echo 'vagrant'|sudo -S sh '{{.Path}}'"
+        }
+      }
+    }
+  ],
+  "builders": [
+    {
+      "type": "virtualbox",
+      "boot_command": [
+        "<esc><esc><enter><wait>",
+        "/install/vmlinuz noapic preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>",
+        "debian-installer=en_US auto locale=en_US kbd-chooser/method=us <wait>",
+        "hostname={{ .Name }} <wait>",
+        "fb=false debconf/frontend=noninteractive <wait>",
+        "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA keyboard-configuration/variant=USA console-setup/ask_detect=false <wait>",
+        "initrd=/install/initrd.gz -- <enter><wait>"
+      ],
+      "boot_wait": "4s",
+      "disk_size": 10140,
+      "guest_os_type": "Ubuntu_64",
+      "http_directory": "http",
+      "iso_checksum": "2cbe868812a871242cdcdd8f2fd6feb9",
+      "iso_checksum_type": "md5",
+      "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.3-server-amd64.iso",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo 'shutdown -P now' > shutdown.sh; echo 'vagrant'|sudo -S sh 'shutdown.sh'",
+      "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+      "virtualbox_version_file": ".vbox_version",
+      "vboxmanage": [
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--memory",
+          "1024"
+        ],
+        [
+          "modifyvm",
+          "{{.Name}}",
+          "--cpus",
+          "1"
+        ]
+      ]
+    },
+    {
+      "type": "vmware",
+      "boot_command": [
+        "<esc><esc><enter><wait>",
+        "/install/vmlinuz noapic preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>",
+        "debian-installer=en_US auto locale=en_US kbd-chooser/method=us <wait>",
+        "hostname={{ .Name }} <wait>",
+        "fb=false debconf/frontend=noninteractive <wait>",
+        "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA keyboard-configuration/variant=USA console-setup/ask_detect=false <wait>",
+        "initrd=/install/initrd.gz -- <enter><wait>"
+      ],
+      "boot_wait": "4s",
+      "disk_size": 10140,
+      "guest_os_type": "ubuntu-64",
+      "http_directory": "http",
+      "iso_checksum": "2cbe868812a871242cdcdd8f2fd6feb9",
+      "iso_checksum_type": "md5",
+      "iso_url": "http://releases.ubuntu.com/12.04/ubuntu-12.04.3-server-amd64.iso",
+      "ssh_username": "vagrant",
+      "ssh_password": "vagrant",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "10000s",
+      "shutdown_command": "echo 'shutdown -P now' > shutdown.sh; echo 'vagrant'|sudo -S sh 'shutdown.sh'",
+      "vmx_data": {
+        "memsize": "1024",
+        "numvcpus": "1",
+        "cpuid.coresPerSocket": "1"
+      }
+    }
+  ],
+  "post-processors": ["vagrant"]
+}

--- a/packaging/vagrant/template.json
+++ b/packaging/vagrant/template.json
@@ -43,7 +43,7 @@
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -P now' > shutdown.sh; echo 'vagrant'|sudo -S sh 'shutdown.sh'",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
       "virtualbox_version_file": ".vbox_version",
       "vboxmanage": [
@@ -83,7 +83,7 @@
       "ssh_password": "vagrant",
       "ssh_port": 22,
       "ssh_wait_timeout": "10000s",
-      "shutdown_command": "echo 'shutdown -P now' > shutdown.sh; echo 'vagrant'|sudo -S sh 'shutdown.sh'",
+      "shutdown_command": "echo 'vagrant'|sudo -S shutdown -P now",
       "vmx_data": {
         "memsize": "1024",
         "numvcpus": "1",


### PR DESCRIPTION
This is a first run to package docker in a nice pre-built vagrant box. It's not finished yet but I thought it might be better to avoid duplicating the effort. Feel free to take over as I'm going to be quite busy for a while.

The current build uses [packer](http://packer.io), the build tool developed by the same guy that's behind vagrant. It supports only 3 vagrant targets (VirtualBox, VMWare Fusion, AWS) for the moment but more are surely to come. For now only VirtualBox is tested and VMWare is supposed to work but I didn't have it available on my computer.

The build installs Ubuntu 12.04.3 with the raring (3.8) kernel, a minimal set of dependencies and the new docker 0.6.
Install packer and run `packer --only=virtualbox template.json` to get the output (~280MB)

There's still a couple of things I wanted to check out:
- the .sock file is not accessible from the vagrant user
- play more with the install to make sure docker is working properly
- see if it's an issue that the manpages are missing (this keeps the box lighter)

That's it for now. Feel free to close if you feel this is not needed I won't get offended :)
