### PR TITLE
Display error if docker cp resource not specified

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1532,6 +1532,10 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 	var copyData APICopy
 	info := strings.Split(cmd.Arg(0), ":")
 
+	if len(info) != 2 {
+		return fmt.Errorf("Error: Resource not specified")
+	}
+
 	copyData.Resource = info[1]
 	copyData.HostPath = cmd.Arg(1)
 


### PR DESCRIPTION
Display an error message if a container resource is not supplied to 'docker cp'.

Fixes error in #1661
