### PR TITLE
Allow an override for the FROM line in Dockerfile

### DIFF
--- a/api.go
+++ b/api.go
@@ -874,6 +874,7 @@ func postBuild(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 	}
 	remoteURL := r.FormValue("remote")
 	repoName := r.FormValue("t")
+	overrideFrom := r.FormValue("b")
 	rawSuppressOutput := r.FormValue("q")
 	rawNoCache := r.FormValue("nocache")
 	repoName, tag := utils.ParseRepositoryTag(repoName)
@@ -927,7 +928,7 @@ func postBuild(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 		return err
 	}
 
-	b := NewBuildFile(srv, utils.NewWriteFlusher(w), !suppressOutput, !noCache)
+	b := NewBuildFile(srv, utils.NewWriteFlusher(w), !suppressOutput, !noCache, overrideFrom)
 	id, err := b.Build(context)
 	if err != nil {
 		fmt.Fprintf(w, "Error build: %s\n", err)

--- a/buildfile.go
+++ b/buildfile.go
@@ -37,6 +37,8 @@ type buildFile struct {
 	tmpImages     map[string]struct{}
 
 	out io.Writer
+
+	overrideFrom string
 }
 
 func (b *buildFile) clearTmp(containers, images map[string]struct{}) {
@@ -52,6 +54,11 @@ func (b *buildFile) clearTmp(containers, images map[string]struct{}) {
 }
 
 func (b *buildFile) CmdFrom(name string) error {
+
+	if b.overrideFrom!= "" {
+		name = b.overrideFrom
+	}
+
 	image, err := b.runtime.repositories.LookupImage(name)
 	if err != nil {
 		if b.runtime.graph.IsNotExist(err) {
@@ -522,7 +529,7 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 	return "", fmt.Errorf("An error occurred during the build\n")
 }
 
-func NewBuildFile(srv *Server, out io.Writer, verbose, utilizeCache bool) BuildFile {
+func NewBuildFile(srv *Server, out io.Writer, verbose, utilizeCache bool, overrideFrom string) BuildFile {
 	return &buildFile{
 		builder:       NewBuilder(srv.runtime),
 		runtime:       srv.runtime,
@@ -533,5 +540,6 @@ func NewBuildFile(srv *Server, out io.Writer, verbose, utilizeCache bool) BuildF
 		tmpImages:     make(map[string]struct{}),
 		verbose:       verbose,
 		utilizeCache:  utilizeCache,
+		overrideFrom: overrideFrom,
 	}
 }

--- a/commands.go
+++ b/commands.go
@@ -160,6 +160,7 @@ func mkBuildContext(dockerfile string, files [][2]string) (Archive, error) {
 func (cli *DockerCli) CmdBuild(args ...string) error {
 	cmd := Subcmd("build", "[OPTIONS] PATH | URL | -", "Build a new container image from the source code at PATH")
 	tag := cmd.String("t", "", "Repository name (and optionally a tag) to be applied to the resulting image in case of success")
+	from := cmd.String("b", "", "Base image to start with. This overrides the FROM line of the dockerfile")
 	suppressOutput := cmd.Bool("q", false, "Suppress verbose build output")
 	noCache := cmd.Bool("no-cache", false, "Do not use cache when building the image")
 	if err := cmd.Parse(args); err != nil {
@@ -202,7 +203,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	// Upload the build context
 	v := &url.Values{}
 	v.Set("t", *tag)
-
+	v.Set("b", *from)
 	if *suppressOutput {
 		v.Set("q", "1")
 	}


### PR DESCRIPTION
Docker build gets an option to override FROM
This makes reuse of Dockerfiles easier.

Example:

docker build -t mhennings/ubuntu-chef -b ubuntu .

The from line in the Dockerfile is ignored instead "ubuntu" is used as the
value for FROM
