### PR TITLE
Change fetching of gpg key from http to https

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -67,7 +67,7 @@ to follow them again.*
 .. code-block:: bash
 
    # Add the Docker repository key to your local keychain
-   sudo sh -c "curl http://get.docker.io/gpg | apt-key add -"
+   sudo sh -c "curl https://get.docker.io/gpg | apt-key add -"
 
    # Add the Docker repository to your apt sources list.
    sudo sh -c "echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"


### PR DESCRIPTION
Or was there any reason to fetch using http?
