### PR TITLE
Add mercurial to the list of packages needed in a dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ Setting up a dev environment
 Instructions that have been verified to work on Ubuntu 12.10,
 
 ```bash
-sudo apt-get -y install lxc curl xz-utils golang git
+sudo apt-get -y install lxc curl xz-utils golang git mercurial
 
 export GOPATH=~/go/
 export PATH=$GOPATH/bin:$PATH


### PR DESCRIPTION
The dev environment setup procedure fails if mercurial is not installed on the machine, it cannot download stuff from
http://code.google.com/p/go.net for instance.

In case somebody googles the error message, here's what happens after the clone step, without mercurial:

```
code.google.com/p/go.net (download)
go: missing Mercurial command. See http://golang.org/s/gogetcmd
package code.google.com/p/go.net/websocket: exec: "hg": executable file not found in $PATH
github.com/dotcloud/tar (download)
github.com/gorilla/mux (download)
github.com/gorilla/context (download)
github.com/kr/pty (download)
api.go:4:2: cannot find package "code.google.com/p/go.net/websocket" in any of:
        /usr/lib/go/src/pkg/code.google.com/p/go.net/websocket (from $GOROOT)
        /home/jbbarth/go/src/code.google.com/p/go.net/websocket (from $GOPATH)
```

And with mercurial:

```
code.google.com/p/go.net (download)
github.com/dotcloud/tar (download)
github.com/gorilla/mux (download)
github.com/gorilla/context (download)
github.com/kr/pty (download)
code.google.com/p/go.net/websocket
github.com/dotcloud/tar
github.com/dotcloud/docker/term
github.com/gorilla/context
github.com/gorilla/mux
github.com/kr/pty
github.com/dotcloud/docker/contrib
github.com/dotcloud/docker/utils
github.com/dotcloud/docker/auth
github.com/dotcloud/docker/registry
github.com/dotcloud/docker
github.com/dotcloud/docker/docker
```

Thanks
