### PR TITLE
Vendor and build without docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/_templates
 .dotcloud
 *.test
 vendor/
+bundles/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/_templates
 .gopath/
 .dotcloud
 *.test
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ run	apt-get install -y -q mercurial
 run	curl -s https://go.googlecode.com/files/go1.1.2.linux-amd64.tar.gz | tar -v -C /usr/local -xz
 env	PATH	/usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
 env	GOPATH	/go:/vendor
-env	CGO_ENABLED 0
 run	cd /tmp && echo 'package main' > t.go && go test -a -i -v
 # Ubuntu stuff
 run	apt-get install -y -q ruby1.9.3 rubygems libffi-dev
@@ -24,9 +23,11 @@ run	pip install s3cmd
 run	pip install python-magic
 run	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_KEY\n' > /.s3cfg
 # Upload docker source
-add 	vendor	/vendor
 add	.       /go/src/github.com/dotcloud/docker
 run	ln -s	/go/src/github.com/dotcloud/docker /src
+# Setup vendor
+run     cd /go/src/github.com/dotcloud/docker && ./vendor.sh
+run    ln -s   /go/src/github.com/dotcloud/docker/vendor /vendor
 # Build the binary
 run	cd /go/src/github.com/dotcloud/docker && hack/release/make.sh
 cmd	cd /go/src/github.com/dotcloud/docker && hack/release/release.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ run	apt-get install -y -q mercurial
 # Install Go
 run	curl -s https://go.googlecode.com/files/go1.1.2.linux-amd64.tar.gz | tar -v -C /usr/local -xz
 env	PATH	/usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
-env	GOPATH	/go
+env	GOPATH	/go:/vendor
 env	CGO_ENABLED 0
 run	cd /tmp && echo 'package main' > t.go && go test -a -i -v
 # Ubuntu stuff
@@ -23,13 +23,8 @@ run	apt-get install -y -q python-pip
 run	pip install s3cmd
 run	pip install python-magic
 run	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_KEY\n' > /.s3cfg
-# Download dependencies
-run	PKG=github.com/kr/pty REV=27435c699;		 git clone http://$PKG /go/src/$PKG && cd /go/src/$PKG && git checkout -f $REV
-run	PKG=github.com/gorilla/context/ REV=708054d61e5; git clone http://$PKG /go/src/$PKG && cd /go/src/$PKG && git checkout -f $REV
-run	PKG=github.com/gorilla/mux/ REV=9b36453141c;	 git clone http://$PKG /go/src/$PKG && cd /go/src/$PKG && git checkout -f $REV
-run	PKG=github.com/dotcloud/tar/ REV=d06045a6d9;	 git clone http://$PKG /go/src/$PKG && cd /go/src/$PKG && git checkout -f $REV
-run	PKG=code.google.com/p/go.net/ REV=84a4013f96e0;  hg  clone http://$PKG /go/src/$PKG && cd /go/src/$PKG && hg  checkout    $REV
 # Upload docker source
+add 	vendor	/vendor
 add	.       /go/src/github.com/dotcloud/docker
 run	ln -s	/go/src/github.com/dotcloud/docker /src
 # Build the binary

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ supported.
 * [Windows (with Vagrant)](http://docs.docker.io/en/latest/installation/windows/)
 * [Amazon EC2 (with Vagrant)](http://docs.docker.io/en/latest/installation/amazon/)
 
+Source build for packaging
+--------------------------
+
+This process should only be used by people creating Linux distro packages.
+Everyone else should use the instructions above.
+
+```
+./vendor.sh
+./hack/release/make-without-docker.sh
+```
+
 Usage examples
 ==============
 

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -1,0 +1,41 @@
+# common build utilities and variables used in make.sh and
+# make-without-docker.sh
+
+VERSION=$(cat ./VERSION)
+PKGVERSION="$VERSION"
+GITCOMMIT=$(git rev-parse --short HEAD)
+if test -n "$(git status --porcelain)"
+then
+	GITCOMMIT="$GITCOMMIT-dirty"
+	PKGVERSION="$PKGVERSION-$(date +%Y%m%d%H%M%S)-$GITCOMMIT"
+fi
+
+PACKAGE_URL="http://www.docker.io/"
+PACKAGE_MAINTAINER="docker@dotcloud.com"
+PACKAGE_DESCRIPTION="lxc-docker is a Linux container runtime
+Docker complements LXC with a high-level API which operates at the process
+level. It runs unix processes with strong guarantees of isolation and
+repeatability across servers.
+Docker is a great building block for automating distributed systems:
+large-scale web deployments, database clusters, continuous deployment systems,
+private PaaS, service-oriented architectures, etc."
+
+LDFLAGS="-X main.GITCOMMIT $GITCOMMIT -X main.VERSION $VERSION -w"
+
+export CGO_ENABLED="0"
+
+# Each "bundle" is a different type of build artefact: static binary, Ubuntu
+# package, etc.
+
+# Build Docker as a static binary file
+bundle_binary() {
+	TARGET=bundles/$VERSION/binary/docker-$VERSION
+
+	if [ $# -eq 1 ]; then
+		TARGET=$1
+	fi
+
+	mkdir -p $(dirname $TARGET)
+
+	go build -o $TARGET -ldflags "$LDFLAGS" ./docker
+}

--- a/hack/release/make-without-docker.sh
+++ b/hack/release/make-without-docker.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# This script builds various binary artifacts from a checkout of the docker
+# source code without docker installed first. It should be used for distro
+# packaging only.
+
+set -e
+
+. hack/release/common.sh
+
+prepare_gopath() {
+	DOCKER_VENDOR=$PWD/vendor/src/github.com/dotcloud/docker
+	if [ -h $DOCKER_VENDOR ]; then
+		rm -f $DOCKER_VENDOR;
+	fi
+
+	ln -sf $PWD $DOCKER_VENDOR
+}
+
+main() {
+        cat <<EOF
+###############################################################################
+
+ This version of the build is unsupported. It is your responsibility to ensure
+ all dependencies are met and that the right version of go is used.
+
+###############################################################################
+EOF
+	prepare_gopath
+	BIN_TARGET=bin/docker
+	GOPATH=$PWD/vendor bundle_binary $BIN_TARGET
+	echo $BIN_TARGET is created.
+}
+
+main

--- a/vendor.sh
+++ b/vendor.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Downloads dependencies into vendor/ directory
+if [[ ! -d vendor ]]; then
+  mkdir vendor
+fi
+vendor_dir=${PWD}/vendor
+
+git_clone () {
+  PKG=$1
+  REV=$2
+  if [[ ! -d src/$PKG ]]; then
+    cd $vendor_dir && git clone http://$PKG src/$PKG && cd src/$PKG && git checkout -f $REV
+  fi
+}
+
+git_clone github.com/kr/pty 27435c699
+
+git_clone github.com/gorilla/context/ 708054d61e5
+
+git_clone github.com/gorilla/mux/ 9b36453141c
+
+git_clone github.com/dotcloud/tar/ d06045a6d9
+
+# Docker requires code.google.com/p/go.net/websocket
+PKG=code.google.com/p/go.net REV=84a4013f96e0
+if [[ ! -d src/$PKG ]]; then
+  cd $vendor_dir && hg clone https://$PKG src/$PKG && cd src/$PKG && hg checkout -r $REV
+fi


### PR DESCRIPTION
This adds the vendor script from @cap10morgan and adds a "build docker without docker script". 

This attempts to share as much code as possible while introducing one script, hack/release/make-without-docker.sh, that sets up the GOPATH and builds. The vendor script and setup is also shared in the Dockefile.

No libraries are checked into the repo with this PR. Deps are fetched everytime vendor.sh is ran.
