### PR TITLE
Add apt https support to Ubuntu Precise setup instructions

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -66,6 +66,9 @@ to follow them again.*
 
 .. code-block:: bash
 
+   # Ubuntu Precise does not support https-repositories by default, so let's add that
+   sudo apt-get install -y apt-transport-https
+
    # Add the Docker repository key to your local keychain
    sudo sh -c "curl https://get.docker.io/gpg | apt-key add -"
 


### PR DESCRIPTION
(The apt-transport-https Package is not installed by default, which will give you `E: The method driver /usr/lib/apt/methods/https could not be found.` on apt-get update)
