### PR TITLE
Fix bash completion.

### DIFF
--- a/contrib/docker.bash
+++ b/contrib/docker.bash
@@ -21,7 +21,6 @@
 # If the docker daemon is using a unix socket for communication your user
 # must have access to the socket for the completions to function correctly
 
-have docker && {
 __docker_containers_all()
 {
 	local containers
@@ -542,4 +541,3 @@ _docker()
 }
 
 complete -F _docker docker
-}


### PR DESCRIPTION
have() is a deprecated function, using _have() should be better but it is not available in older bash completion packages. The default completions does not use have like this, it is mostly used when determining alternatives where its needed so removing have altogether is probably better.

This pq should solve #1639 .
