### PR TITLE
Make sure apt https driver is installed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,7 +18,7 @@ Vagrant::Config.run do |config|
   if Dir.glob("#{File.dirname(__FILE__)}/.vagrant/machines/default/*/id").empty?
     # Add lxc-docker package
     pkg_cmd = "wget -q -O - http://get.docker.io/gpg | apt-key add -;" \
-      "echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list;" \
+      "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list;" \
       "apt-get update -qq; apt-get install -q -y --force-yes lxc-docker; "
     # Add X.org Ubuntu backported 3.8 kernel
     pkg_cmd << "apt-get update -qq; apt-get install -q -y python-software-properties; " \


### PR DESCRIPTION
Provisioning depends on the https driver for apt. We need to make sure it is installed before the we can add the docker apt source and install docker. At least the VMWare Fusion Vagrant box specified in the Vagrant file does need this fix to be able to install Docker successfully.
