### PR TITLE
Vendor and build version 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/_templates
 .dotcloud
 *.test
 vendor/
+bundles/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/_templates
 .gopath/
 .dotcloud
 *.test
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ run	apt-get install -y -q mercurial
 # Install Go
 run	curl -s https://go.googlecode.com/files/go1.1.2.linux-amd64.tar.gz | tar -v -C /usr/local -xz
 env	PATH	/usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
-env	GOPATH	/go
+env	GOPATH	/go:/vendor
 env	CGO_ENABLED 0
 run	cd /tmp && echo 'package main' > t.go && go test -a -i -v
 # Ubuntu stuff
@@ -23,13 +23,8 @@ run	apt-get install -y -q python-pip
 run	pip install s3cmd
 run	pip install python-magic
 run	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_KEY\n' > /.s3cfg
-# Download dependencies
-run	PKG=github.com/kr/pty REV=27435c699;		 git clone http://$PKG /go/src/$PKG && cd /go/src/$PKG && git checkout -f $REV
-run	PKG=github.com/gorilla/context/ REV=708054d61e5; git clone http://$PKG /go/src/$PKG && cd /go/src/$PKG && git checkout -f $REV
-run	PKG=github.com/gorilla/mux/ REV=9b36453141c;	 git clone http://$PKG /go/src/$PKG && cd /go/src/$PKG && git checkout -f $REV
-run	PKG=github.com/dotcloud/tar/ REV=d06045a6d9;	 git clone http://$PKG /go/src/$PKG && cd /go/src/$PKG && git checkout -f $REV
-run	PKG=code.google.com/p/go.net/ REV=84a4013f96e0;  hg  clone http://$PKG /go/src/$PKG && cd /go/src/$PKG && hg  checkout    $REV
 # Upload docker source
+add 	vendor	/vendor
 add	.       /go/src/github.com/dotcloud/docker
 run	ln -s	/go/src/github.com/dotcloud/docker /src
 # Build the binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ run	apt-get install -y -q mercurial
 run	curl -s https://go.googlecode.com/files/go1.1.2.linux-amd64.tar.gz | tar -v -C /usr/local -xz
 env	PATH	/usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
 env	GOPATH	/go:/vendor
-env	CGO_ENABLED 0
 run	cd /tmp && echo 'package main' > t.go && go test -a -i -v
 # Ubuntu stuff
 run	apt-get install -y -q ruby1.9.3 rubygems libffi-dev
@@ -24,9 +23,11 @@ run	pip install s3cmd
 run	pip install python-magic
 run	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_KEY\n' > /.s3cfg
 # Upload docker source
-add 	vendor	/vendor
 add	.       /go/src/github.com/dotcloud/docker
 run	ln -s	/go/src/github.com/dotcloud/docker /src
+# Setup vendor
+run     cd /go/src/github.com/dotcloud/docker && ./vendor.sh
+run    ln -s   /go/src/github.com/dotcloud/docker/vendor /vendor
 # Build the binary
-run	cd /go/src/github.com/dotcloud/docker && hack/release/make.sh
+run	cd /go/src/github.com/dotcloud/docker && hack/release/make.sh binary ubuntu
 cmd	cd /go/src/github.com/dotcloud/docker && hack/release/release.sh

--- a/README.md
+++ b/README.md
@@ -163,6 +163,17 @@ supported.
 * [Windows (with Vagrant)](http://docs.docker.io/en/latest/installation/windows/)
 * [Amazon EC2 (with Vagrant)](http://docs.docker.io/en/latest/installation/amazon/)
 
+Source build for packaging
+--------------------------
+
+This process should only be used by people creating Linux distro packages.
+Everyone else should use the instructions above.
+
+```
+./vendor.sh
+./hack/release/make.sh
+```
+
 Usage examples
 ==============
 

--- a/hack/release/make.sh
+++ b/hack/release/make.sh
@@ -20,16 +20,6 @@
 
 set -e
 
-# We're a nice, sexy, little shell script, and people might try to run us;
-# but really, they shouldn't. We want to be in a container!
-RESOLVCONF=$(readlink --canonicalize /etc/resolv.conf)
-grep -q "$RESOLVCONF" /proc/mounts || {
-	echo "# I will only run within a container."
-	echo "# Try this instead:"
-	echo "docker build ."
-	exit 1
-}
-
 VERSION=$(cat ./VERSION)
 PKGVERSION="$VERSION"
 GITCOMMIT=$(git rev-parse --short HEAD)
@@ -39,40 +29,59 @@ then
 	PKGVERSION="$PKGVERSION-$(date +%Y%m%d%H%M%S)-$GITCOMMIT"
 fi
 
-PACKAGE_ARCHITECTURE="$(dpkg-architecture -qDEB_HOST_ARCH)"
-PACKAGE_URL="http://www.docker.io/"
-PACKAGE_MAINTAINER="docker@dotcloud.com"
-PACKAGE_DESCRIPTION="lxc-docker is a Linux container runtime
-Docker complements LXC with a high-level API which operates at the process
-level. It runs unix processes with strong guarantees of isolation and
-repeatability across servers.
-Docker is a great building block for automating distributed systems:
-large-scale web deployments, database clusters, continuous deployment systems,
-private PaaS, service-oriented architectures, etc."
+LDFLAGS="-X main.GITCOMMIT $GITCOMMIT -X main.VERSION $VERSION -w"
 
-UPSTART_SCRIPT='description     "Docker daemon"
+export CGO_ENABLED="0"
 
-start on filesystem or runlevel [2345]
-stop on runlevel [!2345]
+prepare_gopath() {
+	DOCKER_VENDOR=$PWD/vendor/src/github.com/dotcloud/docker
+	if [ -h $DOCKER_VENDOR ]; then
+		rm -f $DOCKER_VENDOR;
+	fi
 
-respawn
-
-script
-    /usr/bin/docker -d
-end script
-'
+	ln -sf $PWD $DOCKER_VENDOR
+}
 
 # Each "bundle" is a different type of build artefact: static binary, Ubuntu
 # package, etc.
 
 # Build Docker as a static binary file
 bundle_binary() {
-	mkdir -p bundles/$VERSION/binary
-	go build -o bundles/$VERSION/binary/docker-$VERSION \
-		-ldflags "-X main.GITCOMMIT $GITCOMMIT -X main.VERSION $VERSION -d -w" \
-		./docker
+	TARGET=bundles/$VERSION/binary/docker-$VERSION
+
+	# Unofficial builds will pass in a different target
+	if [ $# -eq 1 ]; then
+		TARGET=$1
+	else
+		# TODO: For some reason binary versions of golang from golang.org don't like
+		# this flag. Add it into the official build as it had it originally and it
+		# seems to work. This keeps developers who use make-without-docker.sh from
+		# being confused by default.
+
+		# Setup LDFLAGS for the official build
+		LDFLAGS="$LDFLAGS -d"
+	fi
+
+	mkdir -p $(dirname $TARGET)
+
+	go build -o $TARGET -ldflags "$LDFLAGS" ./docker
 }
 
+# Build an unofficial static binary file
+bundle_unofficial_binary() {
+        cat <<EOF
+###############################################################################
+
+ This version of the build is unsupported. It is your responsibility to ensure
+ all dependencies are met and that the right version of go is used.
+
+###############################################################################
+EOF
+	prepare_gopath
+	BIN_TARGET=bin/docker
+	GOPATH="$PWD/vendor" bundle_binary $BIN_TARGET
+	echo $BIN_TARGET is created.
+}
 
 # Build Docker's test suite as a collection of binary files (one per
 # sub-package to test)
@@ -81,7 +90,7 @@ bundle_test() {
 	for test_dir in $(find_test_dirs); do
 		test_binary=$(
 			cd $test_dir
-			go test -c -v -ldflags "-X main.GITCOMMIT $GITCOMMIT -X main.VERSION $VERSION -d -w" >&2
+			go test -c -v -ldflags "$LDFLAGS" >&2
 			find . -maxdepth 1 -type f -name '*.test' -executable
 		)
 		cp $test_dir/$test_binary bundles/$VERSION/test/
@@ -91,6 +100,7 @@ bundle_test() {
 # Build docker as an ubuntu package using FPM and REPREPRO (sue me).
 # bundle_binary must be called first.
 bundle_ubuntu() {
+	. hack/release/ubuntu.sh
 	mkdir -p bundles/$VERSION/ubuntu
 
 	DIR=$(pwd)/bundles/$VERSION/ubuntu/build
@@ -159,9 +169,21 @@ find_test_dirs() {
 
 
 main() {
-	bundle_binary
-	bundle_ubuntu
-	#bundle_test
+	TARGETS=unofficial_binary
+
+	if [ $# -ne 0 ]; then
+		TARGETS=$@
+	fi
+
+	prepare_gopath
+	for i in $TARGETS; do
+		bundle_$i
+	done
+
+	if [ "$TARGETS" = "unofficial_binary" ]; then
+		return
+	fi
+
 	cat <<EOF
 ###############################################################################
 Now run the resulting image, making sure that you set AWS_S3_BUCKET,
@@ -176,4 +198,4 @@ docker run -e AWS_S3_BUCKET=get-staging.docker.io \\
 EOF
 }
 
-main
+main $@

--- a/hack/release/ubuntu.sh
+++ b/hack/release/ubuntu.sh
@@ -1,0 +1,23 @@
+# Set variables for the Ubuntu packaging
+
+PACKAGE_URL="http://www.docker.io/"
+PACKAGE_MAINTAINER="docker@dotcloud.com"
+PACKAGE_DESCRIPTION="lxc-docker is a Linux container runtime
+Docker complements LXC with a high-level API which operates at the process
+level. It runs unix processes with strong guarantees of isolation and
+repeatability across servers.
+Docker is a great building block for automating distributed systems:
+large-scale web deployments, database clusters, continuous deployment systems,
+private PaaS, service-oriented architectures, etc."
+PACKAGE_ARCHITECTURE="$(dpkg-architecture -qDEB_HOST_ARCH)"
+UPSTART_SCRIPT='description     "Docker daemon"
+
+start on filesystem or runlevel [2345]
+stop on runlevel [!2345]
+
+respawn
+
+script
+    /usr/bin/docker -d
+end script
+'

--- a/vendor.sh
+++ b/vendor.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Downloads dependencies into vendor/ directory
+if [[ ! -d vendor ]]; then
+  mkdir vendor
+fi
+vendor_dir=${PWD}/vendor
+
+git_clone () {
+  PKG=$1
+  REV=$2
+  if [[ ! -d src/$PKG ]]; then
+    cd $vendor_dir && git clone http://$PKG src/$PKG && cd src/$PKG && git checkout -f $REV
+  fi
+}
+
+git_clone github.com/kr/pty 27435c699
+
+git_clone github.com/gorilla/context/ 708054d61e5
+
+git_clone github.com/gorilla/mux/ 9b36453141c
+
+git_clone github.com/dotcloud/tar/ d06045a6d9
+
+# Docker requires code.google.com/p/go.net/websocket
+PKG=code.google.com/p/go.net REV=84a4013f96e0
+if [[ ! -d src/$PKG ]]; then
+  cd $vendor_dir && hg clone https://$PKG src/$PKG && cd src/$PKG && hg checkout -r $REV
+fi


### PR DESCRIPTION
This second version gets rid of make-without-docker.sh and has make.sh default to building the unofficial build of docker. This is an alternative to #1688

This adds the vendor script from @cap10morgan and adds the "build docker without docker" ability to make.sh. The vendor script and setup is also shared in the Dockefile.

No libraries are checked into the repo with this PR. Deps are fetched everytime vendor.sh is ran.
