### PR TITLE
Unable to find image error should print to stderr

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1423,7 +1423,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 			tag = DEFAULTTAG
 		}
 
-		fmt.Printf("Unable to find image '%s' (tag: %s) locally\n", config.Image, tag)
+		fmt.Fprintf(cli.err, "Unable to find image '%s' (tag: %s) locally\n", config.Image, tag)
 
 		v := url.Values{}
 		repos, tag := utils.ParseRepositoryTag(config.Image)


### PR DESCRIPTION
The "Unable to find image" error should print to stderr since users depend on the output of `docker run -d` being the id of the docker container 
