### PR TITLE
Added a Dockerfile which installs all deps and builds the Docs

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,15 @@
+from ubuntu:12.04
+maintainer Nick Stinemates
+
+run apt-get update
+run apt-get install -y python-setuptools make
+run easy_install pip
+add . /docs
+run pip install -r /docs/requirements.txt
+run cd /docs; make docs
+
+expose 8000
+
+workdir /docs/_build/html
+
+entrypoint ["python", "-m", "SimpleHTTPServer"]


### PR DESCRIPTION
`server.py` was created because there's a limitation in SimpleHTTPServer on being able to pass in which directory it serves. So you must first chdir to the appropriate directory.
