### PR TITLE
add https for apt-get on 12.04

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -73,6 +73,9 @@ Docker is available as a Debian package, which makes installation easy.
 
 .. code-block:: bash
 
+   # Install https for apt-get
+   sudo apt-get install apt-transport-https
+
    # Add the Docker repository key to your local keychain
    sudo sh -c "curl https://get.docker.io/gpg | apt-key add -"
 


### PR DESCRIPTION
After adding a https:// source, the `apt-get update` fails with this message:

http://askubuntu.com/questions/104160/method-driver-usr-lib-apt-methods-https-could-not-be-found-update-error
