### PR TITLE
Made calling change log before run return empty list.

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -99,7 +99,7 @@ func Changes(layers []string, rw string) ([]Change, error) {
 		changes = append(changes, change)
 		return nil
 	})
-	if err != nil {
+	if err != nil && !os.IsNotExist(err) {
 		return nil, err
 	}
 	return changes, nil

--- a/container_test.go
+++ b/container_test.go
@@ -138,12 +138,21 @@ func TestDiff(t *testing.T) {
 	container1, _, _ := mkContainer(runtime, []string{"_", "/bin/rm", "/etc/passwd"}, t)
 	defer runtime.Destroy(container1)
 
+	// The changelog should be empty and not fail before run. See #1705
+	c, err := container1.Changes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(c) != 0 {
+		t.Fatalf("Changelog should be empty before run")
+	}
+
 	if err := container1.Run(); err != nil {
 		t.Fatal(err)
 	}
 
 	// Check the changelog
-	c, err := container1.Changes()
+	c, err = container1.Changes()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Made calling change log before container has run return empty list instead of the error returned previously.

Fixes #1705.
