### PR TITLE
Add support for mounting individual files from the host.

### DIFF
--- a/container_test.go
+++ b/container_test.go
@@ -1223,6 +1223,13 @@ func TestBindMounts(t *testing.T) {
 	if _, err := runContainer(r, []string{"-v", fmt.Sprintf("%s:.", tmpDir), "_", "ls", "."}, nil); err == nil {
 		t.Fatal("Container bind mounted illegal directory")
 	}
+
+	// test mount a file
+	runContainer(r, []string{"-v", fmt.Sprintf("%s/holla:/tmp/holla:rw", tmpDir), "_", "sh", "-c", "echo -n 'yotta' > /tmp/holla"}, t)
+	content := readFile(path.Join(tmpDir, "holla"), t) // Will fail if the file doesn't exist
+	if content != "yotta" {
+		t.Fatal("Container failed to write to bind mount file")
+	}
 }
 
 // Test that VolumesRW values are copied to the new container.  Regression test for #1201


### PR DESCRIPTION
Add support for mounting individual files from the host.

The core ability was already there in the lxc template as evident from mounting things like resolv.conf, so no changes there.  This just touches up the bit of container setup that makes sure mount points exist inside the container to make a file for files and a directory for directories.

This involves docker checking the host filesystem to see whether the mount parameter refers to a file or directory, and so has the sideeffect that missing mount locations on the host are now grounds for an error from docker.  (Previously this went unremarked upon until lxc died, and the error message ended up in the container logs instead of being reported to the terminal that ran docker.)
