### PR TITLE
Fix documentation index for cli

### DIFF
--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -32,11 +32,13 @@ Available Commands
    command/commit
    command/cp
    command/diff
+   command/events
    command/export
    command/history
    command/images
    command/import
    command/info
+   command/insert
    command/inspect
    command/kill
    command/login


### PR DESCRIPTION
This will fix the index of commands:
http://docs.docker.io/en/latest/commandline/cli/

Forgot to do that in the previous (already merged) PR.
