### PR TITLE
Adds instruction about UDP port redirection

### DIFF
--- a/docs/sources/use/port_redirection.rst
+++ b/docs/sources/use/port_redirection.rst
@@ -8,7 +8,7 @@
 Port redirection
 ================
 
-Docker can redirect public TCP ports to your container, so it can be
+Docker can redirect public TCP and UDP ports to your container, so it can be
 reached over the network.  Port redirection is done on ``docker run``
 using the -p flag.
 
@@ -25,6 +25,12 @@ will be allocated.
     # PUBLIC port 80 is redirected to PRIVATE port 80
     sudo docker run -p 80:80 <image> <cmd>
 
+To redirect a UDP port the redirection must be expressed as *PUBLIC:PRIVATE/udp*:
+
+.. code-block:: bash
+
+    # PUBLIC port 5300 is redirected to the PRIVATE port 53 using UDP
+    sudo docker run -p 5300:53/udp <image> <cmd>
 
 Default port redirects can be built into a container with the
 ``EXPOSE`` build command.


### PR DESCRIPTION
The docs totally miss the UDP redirection. After some research I found this page https://github.com/dotcloud/docker/commit/fac0d87d00ada08309ea3b82cae69beeef637c89 with the istructions.

If the option is stable I think it should be add in the documentation
