### PR TITLE
From FIXME: local path for ADD

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -293,7 +293,7 @@ func (b *buildFile) addContext(container *Container, orig, dest string) error {
 	}
 	fi, err := os.Stat(origPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("%s: no such file or directory", orig)
 	}
 	if fi.IsDir() {
 		if err := CopyWithTar(origPath, destPath); err != nil {


### PR DESCRIPTION
on non-existent local path for ADD, don't show full absolute path on the host

with go fmt this time
