### PR TITLE
Add step to docker installation using vagrant (Mac, Linux)

### DIFF
--- a/docs/sources/installation/vagrant.rst
+++ b/docs/sources/installation/vagrant.rst
@@ -37,7 +37,13 @@ Spin it up
 
       git clone https://github.com/dotcloud/docker.git
 
-2. Run vagrant from the sources directory
+2. Change directory to docker
+
+   .. code-block:: bash
+
+      cd docker
+
+3. Run vagrant from the sources directory
 
    .. code-block:: bash
 


### PR DESCRIPTION
Issue #1792 

To explicitly state the need to change directory (to docker) in the process of installing docker using vagrant 
