### PR TITLE
Container/Image/Conflig cleanup

### DIFF
--- a/api_params.go
+++ b/api_params.go
@@ -56,13 +56,13 @@ type APIContainers struct {
 
 func (self *APIContainers) ToLegacy() APIContainersOld {
 	return APIContainersOld{
-		ID: self.ID,
-		Image: self.Image,
-		Command: self.Command,
-		Created: self.Created,
-		Status: self.Status,
-		Ports: displayablePorts(self.Ports),
-		SizeRw: self.SizeRw,
+		ID:         self.ID,
+		Image:      self.Image,
+		Command:    self.Command,
+		Created:    self.Created,
+		Status:     self.Status,
+		Ports:      displayablePorts(self.Ports),
+		SizeRw:     self.SizeRw,
 		SizeRootFs: self.SizeRootFs,
 	}
 }

--- a/api_test.go
+++ b/api_test.go
@@ -566,7 +566,6 @@ func TestPostCommit(t *testing.T) {
 
 	srv := &Server{runtime: runtime}
 
-
 	// Create a container and remove a file
 	container, err := runtime.Create(
 		&Config{

--- a/buildfile.go
+++ b/buildfile.go
@@ -79,7 +79,7 @@ func (b *buildFile) CmdRun(args string) error {
 	if b.image == "" {
 		return fmt.Errorf("Please provide a source image with `from` prior to run")
 	}
-	config, _, _, err := ParseRun([]string{b.image, "/bin/sh", "-c", args}, nil)
+	config, _, _, _, err := ParseRun([]string{b.image, "/bin/sh", "-c", args}, nil)
 	if err != nil {
 		return err
 	}
@@ -445,7 +445,7 @@ func (b *buildFile) commit(id string, autoCmd []string, comment string) error {
 	autoConfig := *b.config
 	autoConfig.Cmd = autoCmd
 	// Commit the container
-	image, err := b.runtime.Commit(container, "", "", "", b.maintainer, &autoConfig)
+	image, err := b.runtime.Commit(container, "", "", b.maintainer, &autoConfig)
 	if err != nil {
 		return err
 	}

--- a/container_test.go
+++ b/container_test.go
@@ -171,7 +171,7 @@ func TestDiff(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	img, err := runtime.graph.Create(rwTar, container1, "unit test commited image - diff", "", nil)
+	img, err := runtime.graph.Create(rwTar, container1, "", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -239,7 +239,7 @@ func TestCommitAutoRun(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	img, err := runtime.graph.Create(rwTar, container1, "unit test commited image", "", &Config{Cmd: []string{"cat", "/world"}})
+	img, err := runtime.graph.Create(rwTar, container1, "", &Config{Cmd: []string{"cat", "/world"}})
 	if err != nil {
 		t.Error(err)
 	}
@@ -299,7 +299,7 @@ func TestCommitRun(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	img, err := runtime.graph.Create(rwTar, container1, "unit test commited image", "", nil)
+	img, err := runtime.graph.Create(rwTar, container1, "", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -467,7 +467,7 @@ func TestCreateVolume(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)
 
-	config, hc, _, err := ParseRun([]string{"-v", "/var/lib/data", GetTestImage(runtime).ID, "echo", "hello", "world"}, nil)
+	config, hc, _, _, err := ParseRun([]string{"-v", "/var/lib/data", GetTestImage(runtime).ID, "echo", "hello", "world"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1064,16 +1064,18 @@ func TestLXCConfig(t *testing.T) {
 		Image: GetTestImage(runtime).ID,
 		Cmd:   []string{"/bin/true"},
 
-		Hostname:  "foobar",
-		Memory:    int64(mem),
-		CpuShares: int64(cpu),
+		Hostname: "foobar",
+		Memory:   int64(mem),
 	},
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
-	container.generateLXCConfig(nil)
+	hostConfig := &HostConfig{
+		CpuShares: int64(cpu),
+	}
+	container.generateLXCConfig(hostConfig)
 	grepFile(t, container.lxcConfigPath(), "lxc.utsname = foobar")
 	grepFile(t, container.lxcConfigPath(),
 		fmt.Sprintf("lxc.cgroup.memory.limit_in_bytes = %d", mem))
@@ -1105,7 +1107,6 @@ func TestCustomLxcConfig(t *testing.T) {
 			Value: "0,1",
 		},
 	}}
-
 	container.generateLXCConfig(hostConfig)
 	grepFile(t, container.lxcConfigPath(), "lxc.utsname = docker")
 	grepFile(t, container.lxcConfigPath(), "lxc.cgroup.cpuset.cpus = 0,1")
@@ -1219,7 +1220,7 @@ func TestCopyVolumeUidGid(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	img, err := r.graph.Create(rwTar, container1, "unit test commited image", "", nil)
+	img, err := r.graph.Create(rwTar, container1, "", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1264,7 +1265,7 @@ func TestCopyVolumeContent(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	img, err := r.graph.Create(rwTar, container1, "unit test commited image", "", nil)
+	img, err := r.graph.Create(rwTar, container1, "", nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1484,7 +1485,7 @@ func TestOnlyLoopbackExistsWhenUsingDisableNetworkOption(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)
 
-	config, hc, _, err := ParseRun([]string{"-n=false", GetTestImage(runtime).ID, "ip", "addr", "show"}, nil)
+	config, hc, _, _, err := ParseRun([]string{"-n=false", GetTestImage(runtime).ID, "ip", "addr", "show"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1503,6 +1504,7 @@ func TestOnlyLoopbackExistsWhenUsingDisableNetworkOption(t *testing.T) {
 	}
 	c.WaitTimeout(500 * time.Millisecond)
 	c.Wait()
+
 	output, err := ioutil.ReadAll(stdout)
 	if err != nil {
 		t.Fatal(err)

--- a/container_test.go
+++ b/container_test.go
@@ -398,7 +398,7 @@ func TestOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
-	output, err := container.Output()
+	output, err := container.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -573,7 +573,7 @@ func TestRestart(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
-	output, err := container.Output()
+	output, err := container.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -582,7 +582,7 @@ func TestRestart(t *testing.T) {
 	}
 
 	// Run the container again and check the output
-	output, err = container.Output()
+	output, err = container.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -681,7 +681,7 @@ func TestUser(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
-	output, err := container.Output()
+	output, err := container.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -701,7 +701,7 @@ func TestUser(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
-	output, err = container.Output()
+	output, err = container.Output(&HostConfig{})
 	if err != nil || container.State.ExitCode != 0 {
 		t.Fatal(err)
 	}
@@ -721,7 +721,7 @@ func TestUser(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
-	output, err = container.Output()
+	output, err = container.Output(&HostConfig{})
 	if err != nil || container.State.ExitCode != 0 {
 		t.Fatal(err)
 	}
@@ -741,7 +741,7 @@ func TestUser(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
-	output, err = container.Output()
+	output, err = container.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	} else if container.State.ExitCode != 0 {
@@ -763,7 +763,7 @@ func TestUser(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
-	output, err = container.Output()
+	output, err = container.Output(&HostConfig{})
 	if err != nil || container.State.ExitCode != 0 {
 		t.Fatal(err)
 	}
@@ -783,7 +783,7 @@ func TestUser(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
-	output, err = container.Output()
+	output, err = container.Output(&HostConfig{})
 	if container.State.ExitCode == 0 {
 		t.Fatal("Starting container with wrong uid should fail but it passed.")
 	}
@@ -997,7 +997,7 @@ func TestEntrypoint(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
-	output, err := container.Output()
+	output, err := container.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1019,7 +1019,7 @@ func TestEntrypointNoCmd(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
-	output, err := container.Output()
+	output, err := container.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1125,7 +1125,7 @@ func BenchmarkRunSequencial(b *testing.B) {
 			b.Fatal(err)
 		}
 		defer runtime.Destroy(container)
-		output, err := container.Output()
+		output, err := container.Output(&HostConfig{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -1334,7 +1334,7 @@ func TestVolumesFromReadonlyMount(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer runtime.Destroy(container)
-	_, err = container.Output()
+	_, err = container.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1344,9 +1344,8 @@ func TestVolumesFromReadonlyMount(t *testing.T) {
 
 	container2, err := runtime.Create(
 		&Config{
-			Image:       GetTestImage(runtime).ID,
-			Cmd:         []string{"/bin/echo", "-n", "foobar"},
-			VolumesFrom: container.ID,
+			Image: GetTestImage(runtime).ID,
+			Cmd:   []string{"/bin/echo", "-n", "foobar"},
 		},
 	)
 	if err != nil {
@@ -1354,7 +1353,11 @@ func TestVolumesFromReadonlyMount(t *testing.T) {
 	}
 	defer runtime.Destroy(container2)
 
-	_, err = container2.Output()
+	_, err = container2.Output(
+		&HostConfig{
+			VolumesFrom: container.ID,
+		},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1395,7 +1398,7 @@ func TestRestartWithVolumes(t *testing.T) {
 		}
 	}
 
-	_, err = container.Output()
+	_, err = container.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1405,7 +1408,7 @@ func TestRestartWithVolumes(t *testing.T) {
 		t.Fail()
 	}
 	// Run the container again to verify the volume path persists
-	_, err = container.Output()
+	_, err = container.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1438,7 +1441,7 @@ func TestVolumesFromWithVolumes(t *testing.T) {
 		}
 	}
 
-	_, err = container.Output()
+	_, err = container.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1450,10 +1453,9 @@ func TestVolumesFromWithVolumes(t *testing.T) {
 
 	container2, err := runtime.Create(
 		&Config{
-			Image:       GetTestImage(runtime).ID,
-			Cmd:         []string{"cat", "/test/foo"},
-			VolumesFrom: container.ID,
-			Volumes:     map[string]struct{}{"/test": {}},
+			Image:   GetTestImage(runtime).ID,
+			Cmd:     []string{"cat", "/test/foo"},
+			Volumes: map[string]struct{}{"/test": {}},
 		},
 	)
 	if err != nil {
@@ -1461,7 +1463,11 @@ func TestVolumesFromWithVolumes(t *testing.T) {
 	}
 	defer runtime.Destroy(container2)
 
-	output, err := container2.Output()
+	output, err := container2.Output(
+		&HostConfig{
+			VolumesFrom: container.ID,
+		},
+	)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1475,7 +1481,7 @@ func TestVolumesFromWithVolumes(t *testing.T) {
 	}
 
 	// Ensure it restarts successfully
-	_, err = container2.Output()
+	_, err = container2.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1573,7 +1579,7 @@ func TestMultipleVolumesFrom(t *testing.T) {
 		}
 	}
 
-	_, err = container.Output()
+	_, err = container.Output(&HostConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1600,15 +1606,14 @@ func TestMultipleVolumesFrom(t *testing.T) {
 			t.FailNow()
 		}
 	}
-	if _, err := container2.Output(); err != nil {
+	if _, err := container2.Output(&HostConfig{}); err != nil {
 		t.Fatal(err)
 	}
 
 	container3, err := runtime.Create(
 		&Config{
-			Image:       GetTestImage(runtime).ID,
-			Cmd:         []string{"/bin/echo", "-n", "foobar"},
-			VolumesFrom: strings.Join([]string{container.ID, container2.ID}, ","),
+			Image: GetTestImage(runtime).ID,
+			Cmd:   []string{"/bin/echo", "-n", "foobar"},
 		})
 
 	if err != nil {
@@ -1616,7 +1621,7 @@ func TestMultipleVolumesFrom(t *testing.T) {
 	}
 	defer runtime.Destroy(container3)
 
-	if _, err := container3.Output(); err != nil {
+	if _, err := container3.Output(&HostConfig{VolumesFrom: strings.Join([]string{container.ID, container2.ID}, ",")}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/docs/sources/api/docker_remote_api_v1.5.rst
+++ b/docs/sources/api/docker_remote_api_v1.5.rst
@@ -114,10 +114,6 @@ Create a container
 		"Hostname":"",
 		"User":"",
 		"Memory":0,
-		"MemorySwap":0,
-		"AttachStdin":false,
-		"AttachStdout":true,
-		"AttachStderr":true,
 		"PortSpecs":null,
 		"Privileged": false,
 		"Tty":false,
@@ -127,10 +123,8 @@ Create a container
 		"Cmd":[
 			"date"
 		],
-		"Dns":null,
 		"Image":"ubuntu",
 		"Volumes":{},
-		"VolumesFrom":"",
 		"WorkingDir":""
 
 	   }
@@ -183,10 +177,6 @@ Inspect a container
 				"Hostname": "4fa6e0f0c678",
 				"User": "",
 				"Memory": 0,
-				"MemorySwap": 0,
-				"AttachStdin": false,
-				"AttachStdout": true,
-				"AttachStderr": true,
 				"PortSpecs": null,
 				"Tty": false,
 				"OpenStdin": false,
@@ -195,10 +185,8 @@ Inspect a container
 				"Cmd": [
 					"date"
 				],
-				"Dns": null,
 				"Image": "ubuntu",
 				"Volumes": {},
-				"VolumesFrom": "",
 				"WorkingDir":""
 
 			},
@@ -357,8 +345,12 @@ Start a container
            Content-Type: application/json
 
            {
-                "Binds":["/tmp:/tmp"],
-                "LxcConf":[{"Key":"lxc.utsname","Value":"docker"}]
+		"Binds":["/tmp:/tmp"],
+		"Dns":null,
+		"LxcConf":[{"Key":"lxc.utsname","Value":"docker"}],
+		"MemorySwap":0,
+		"NetworkDisabled":false,
+		"VolumesFrom":"",
            }
 
         **Example response**:
@@ -743,20 +735,14 @@ Inspect an image
 				"Hostname":"",
 				"User":"",
 				"Memory":0,
-				"MemorySwap":0,
-				"AttachStdin":false,
-				"AttachStdout":false,
-				"AttachStderr":false,
 				"PortSpecs":null,
 				"Tty":true,
 				"OpenStdin":true,
 				"StdinOnce":false,
 				"Env":null,
-				"Cmd": ["/bin/bash"]
-				,"Dns":null,
+				"Cmd": ["/bin/bash"],
 				"Image":"centos",
 				"Volumes":null,
-				"VolumesFrom":"",
 				"WorkingDir":""
 			},
 		"Size": 6824592
@@ -1089,21 +1075,20 @@ Create a new image from a container's changes
 
     .. sourcecode:: http
 
-        POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+        POST /commit?container=44c004db4b17&repo=myrepo HTTP/1.1
 
     **Example response**:
 
     .. sourcecode:: http
 
         HTTP/1.1 201 OK
-	    Content-Type: application/vnd.docker.raw-stream
+	Content-Type: application/vnd.docker.raw-stream
 
         {"Id":"596069db4bf5"}
 
     :query container: source container
     :query repo: repository
     :query tag: tag
-    :query m: commit message
     :query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
     :query run: config automatically applied when the image is run. (ex: {"Cmd": ["cat", "/world"], "PortSpecs":["22"]})
     :statuscode 201: no error

--- a/graph.go
+++ b/graph.go
@@ -81,7 +81,7 @@ func (graph *Graph) Get(name string) (*Image, error) {
 		return nil, fmt.Errorf("Image stored at '%s' has wrong id '%s'", id, img.ID)
 	}
 	img.graph = graph
-	if img.Size == 0 {
+	if img.size == 0 {
 		root, err := img.root()
 		if err != nil {
 			return nil, err
@@ -94,19 +94,16 @@ func (graph *Graph) Get(name string) (*Image, error) {
 }
 
 // Create creates a new image and registers it in the graph.
-func (graph *Graph) Create(layerData Archive, container *Container, comment, author string, config *Config) (*Image, error) {
+func (graph *Graph) Create(layerData Archive, container *Container, author string, config *Config) (*Image, error) {
 	img := &Image{
 		ID:            GenerateID(),
-		Comment:       comment,
 		Created:       time.Now(),
 		DockerVersion: VERSION,
 		Author:        author,
 		Config:        config,
-		Architecture:  "x86_64",
 	}
 	if container != nil {
 		img.Parent = container.Image
-		img.Container = container.ID
 		img.ContainerConfig = *container.Config
 	}
 	if err := graph.Register(nil, layerData, img); err != nil {

--- a/graph_test.go
+++ b/graph_test.go
@@ -35,7 +35,6 @@ func TestInterruptedRegister(t *testing.T) {
 	badArchive, w := io.Pipe() // Use a pipe reader as a fake archive which never yields data
 	image := &Image{
 		ID:      GenerateID(),
-		Comment: "testing",
 		Created: time.Now(),
 	}
 	go graph.Register(nil, badArchive, image)
@@ -63,15 +62,12 @@ func TestGraphCreate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	image, err := graph.Create(archive, nil, "Testing", "", nil)
+	image, err := graph.Create(archive, nil, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := ValidateID(image.ID); err != nil {
 		t.Fatal(err)
-	}
-	if image.Comment != "Testing" {
-		t.Fatalf("Wrong comment: should be '%s', not '%s'", "Testing", image.Comment)
 	}
 	if image.DockerVersion != VERSION {
 		t.Fatalf("Wrong docker_version: should be '%s', not '%s'", VERSION, image.DockerVersion)
@@ -96,7 +92,6 @@ func TestRegister(t *testing.T) {
 	}
 	image := &Image{
 		ID:      GenerateID(),
-		Comment: "testing",
 		Created: time.Now(),
 	}
 	err = graph.Register(nil, archive, image)
@@ -114,9 +109,6 @@ func TestRegister(t *testing.T) {
 		if resultImg.ID != image.ID {
 			t.Fatalf("Wrong image ID. Should be '%s', not '%s'", image.ID, resultImg.ID)
 		}
-		if resultImg.Comment != image.Comment {
-			t.Fatalf("Wrong image comment. Should be '%s', not '%s'", image.Comment, resultImg.Comment)
-		}
 	}
 }
 
@@ -127,7 +119,7 @@ func TestMount(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	image, err := graph.Create(archive, nil, "Testing", "", nil)
+	image, err := graph.Create(archive, nil, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,7 +163,7 @@ func createTestImage(graph *Graph, t *testing.T) *Image {
 	if err != nil {
 		t.Fatal(err)
 	}
-	img, err := graph.Create(archive, nil, "Test image", "", nil)
+	img, err := graph.Create(archive, nil, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +178,7 @@ func TestDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertNImages(graph, t, 0)
-	img, err := graph.Create(archive, nil, "Bla bla", "", nil)
+	img, err := graph.Create(archive, nil, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +193,7 @@ func TestDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Test 2 create (same name) / 1 delete
-	img1, err := graph.Create(archive, nil, "Testing", "", nil)
+	img1, err := graph.Create(archive, nil, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +201,7 @@ func TestDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = graph.Create(archive, nil, "Testing", "", nil); err != nil {
+	if _, err = graph.Create(archive, nil, "", nil); err != nil {
 		t.Fatal(err)
 	}
 	assertNImages(graph, t, 2)
@@ -247,19 +239,16 @@ func TestByParent(t *testing.T) {
 	defer os.RemoveAll(graph.Root)
 	parentImage := &Image{
 		ID:      GenerateID(),
-		Comment: "parent",
 		Created: time.Now(),
 		Parent:  "",
 	}
 	childImage1 := &Image{
 		ID:      GenerateID(),
-		Comment: "child1",
 		Created: time.Now(),
 		Parent:  parentImage.ID,
 	}
 	childImage2 := &Image{
 		ID:      GenerateID(),
-		Comment: "child2",
 		Created: time.Now(),
 		Parent:  parentImage.ID,
 	}

--- a/image.go
+++ b/image.go
@@ -21,16 +21,13 @@ import (
 type Image struct {
 	ID              string    `json:"id"`
 	Parent          string    `json:"parent,omitempty"`
-	Comment         string    `json:"comment,omitempty"`
 	Created         time.Time `json:"created"`
-	Container       string    `json:"container,omitempty"`
-	ContainerConfig Config    `json:"container_config,omitempty"`
+	ContainerConfig Config    `json:"container_config,omitempty"` //DEPRECATED
 	DockerVersion   string    `json:"docker_version,omitempty"`
 	Author          string    `json:"author,omitempty"`
 	Config          *Config   `json:"config,omitempty"`
-	Architecture    string    `json:"architecture,omitempty"`
 	graph           *Graph
-	Size            int64
+	size            int64
 }
 
 func LoadImage(root string) (*Image, error) {
@@ -56,7 +53,7 @@ func LoadImage(root string) (*Image, error) {
 		if size, err := strconv.Atoi(string(buf)); err != nil {
 			return nil, err
 		} else {
-			img.Size = int64(size)
+			img.size = int64(size)
 		}
 	}
 
@@ -119,7 +116,7 @@ func StoreSize(img *Image, root string) error {
 		totalSize += fileInfo.Size()
 		return nil
 	})
-	img.Size = totalSize
+	img.size = totalSize
 
 	if err := ioutil.WriteFile(path.Join(root, "layersize"), []byte(strconv.Itoa(int(totalSize))), 0600); err != nil {
 		return nil
@@ -327,7 +324,7 @@ func (img *Image) getParentsSize(size int64) int64 {
 	if err != nil || parentImage == nil {
 		return size
 	}
-	size += parentImage.Size
+	size += parentImage.size
 	return parentImage.getParentsSize(size)
 }
 

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -6,34 +6,34 @@ import (
 
 const LxcTemplate = `
 # hostname
-{{if .Config.Hostname}}
-lxc.utsname = {{.Config.Hostname}}
+{{if .Container.Config.Hostname}}
+lxc.utsname = {{.Container.Config.Hostname}}
 {{else}}
-lxc.utsname = {{.Id}}
+lxc.utsname = {{.Container.Id}}
 {{end}}
 #lxc.aa_profile = unconfined
 
-{{if .Config.NetworkDisabled}}
+{{if .HostConfig.NetworkDisabled}}
 # network is disabled (-n=false)
 lxc.network.type = empty
 {{else}}
 # network configuration
 lxc.network.type = veth
 lxc.network.flags = up
-lxc.network.link = {{.NetworkSettings.Bridge}}
+lxc.network.link = {{.Container.NetworkSettings.Bridge}}
 lxc.network.name = eth0
 lxc.network.mtu = 1500
-lxc.network.ipv4 = {{.NetworkSettings.IPAddress}}/{{.NetworkSettings.IPPrefixLen}}
+lxc.network.ipv4 = {{.Container.NetworkSettings.IPAddress}}/{{.Container.NetworkSettings.IPPrefixLen}}
 {{end}}
 
 # root filesystem
-{{$ROOTFS := .RootfsPath}}
+:){{$ROOTFS := .Container.RootfsPath}}
 lxc.rootfs = {{$ROOTFS}}
 
-{{if and .HostnamePath .HostsPath}}
+{{if and .Container.HostnamePath .Container.HostsPath}}
 # enable domain name support
-lxc.mount.entry = {{.HostnamePath}} {{$ROOTFS}}/etc/hostname none bind,ro 0 0
-lxc.mount.entry = {{.HostsPath}} {{$ROOTFS}}/etc/hosts none bind,ro 0 0
+lxc.mount.entry = {{.Container.HostnamePath}} {{$ROOTFS}}/etc/hostname none bind,ro 0 0
+lxc.mount.entry = {{.Container.HostsPath}} {{$ROOTFS}}/etc/hosts none bind,ro 0 0
 {{end}}
 
 # use a dedicated pts for the container (and limit the number of pseudo terminal
@@ -46,7 +46,7 @@ lxc.console = none
 # no controlling tty at all
 lxc.tty = 1
 
-{{if .Config.Privileged}}
+{{if .Container.Config.Privileged}}
 lxc.cgroup.devices.allow = a 
 {{else}}
 # no implicit access to devices
@@ -93,18 +93,18 @@ lxc.mount.entry = devpts {{$ROOTFS}}/dev/pts devpts newinstance,ptmxmode=0666,no
 lxc.mount.entry = shm {{$ROOTFS}}/dev/shm tmpfs size=65536k,nosuid,nodev,noexec 0 0
 
 # Inject docker-init
-lxc.mount.entry = {{.SysInitPath}} {{$ROOTFS}}/.dockerinit none bind,ro 0 0
+lxc.mount.entry = {{.Container.SysInitPath}} {{$ROOTFS}}/.dockerinit none bind,ro 0 0
 
 # In order to get a working DNS environment, mount bind (ro) the host's /etc/resolv.conf into the container
-lxc.mount.entry = {{.ResolvConfPath}} {{$ROOTFS}}/etc/resolv.conf none bind,ro 0 0
-{{if .Volumes}}
-{{ $rw := .VolumesRW }}
-{{range $virtualPath, $realPath := .Volumes}}
+lxc.mount.entry = {{.Container.ResolvConfPath}} {{$ROOTFS}}/etc/resolv.conf none bind,ro 0 0
+{{if .Container.Volumes}}
+{{ $rw := .Container.VolumesRW }}
+{{range $virtualPath, $realPath := .Container.Volumes}}
 lxc.mount.entry = {{$realPath}} {{$ROOTFS}}/{{$virtualPath}} none bind,{{ if index $rw $virtualPath }}rw{{else}}ro{{end}} 0 0
 {{end}}
 {{end}}
 
-{{if .Config.Privileged}}
+{{if .Container.Config.Privileged}}
 # retain all capabilities; no lxc.cap.drop line
 {{else}}
 # drop linux capabilities (apply mainly to the user root in the container)
@@ -115,28 +115,24 @@ lxc.cap.drop = audit_control audit_write mac_admin mac_override mknod setfcap se
 {{end}}
 
 # limits
-{{if .Config.Memory}}
-lxc.cgroup.memory.limit_in_bytes = {{.Config.Memory}}
-lxc.cgroup.memory.soft_limit_in_bytes = {{.Config.Memory}}
-{{with $memSwap := getMemorySwap .Config}}
+{{if .Container.Config.Memory}}
+lxc.cgroup.memory.limit_in_bytes = {{.Container.Config.Memory}}
+lxc.cgroup.memory.soft_limit_in_bytes = {{.Container.Config.Memory}}
+{{with $memSwap := getMemorySwap .Container.Config}}
 lxc.cgroup.memory.memsw.limit_in_bytes = {{$memSwap}}
 {{end}}
 {{end}}
-{{if .Config.CpuShares}}
-lxc.cgroup.cpu.shares = {{.Config.CpuShares}}
-{{end}}
-`
-
-const LxcHostConfigTemplate = `
-{{if .LxcConf}}
-{{range $pair := .LxcConf}}
+{{if .HostConfig.LxcConf}}
+{{range $pair := .HostConfig.LxcConf}}
 {{$pair.Key}} = {{$pair.Value}}
 {{end}}
+{{end}}
+{{if .HostConfig.CpuShares}}
+lxc.cgroup.cpu.shares = {{.HostConfig.CpuShares}}
 {{end}}
 `
 
 var LxcTemplateCompiled *template.Template
-var LxcHostConfigTemplateCompiled *template.Template
 
 func getMemorySwap(config *Config) int64 {
 	// By default, MemorySwap is set to twice the size of RAM.
@@ -153,10 +149,6 @@ func init() {
 		"getMemorySwap": getMemorySwap,
 	}
 	LxcTemplateCompiled, err = template.New("lxc").Funcs(funcMap).Parse(LxcTemplate)
-	if err != nil {
-		panic(err)
-	}
-	LxcHostConfigTemplateCompiled, err = template.New("lxc-hostconfig").Funcs(funcMap).Parse(LxcHostConfigTemplate)
 	if err != nil {
 		panic(err)
 	}

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -118,7 +118,7 @@ lxc.cap.drop = audit_control audit_write mac_admin mac_override mknod setfcap se
 {{if .Container.Config.Memory}}
 lxc.cgroup.memory.limit_in_bytes = {{.Container.Config.Memory}}
 lxc.cgroup.memory.soft_limit_in_bytes = {{.Container.Config.Memory}}
-{{with $memSwap := getMemorySwap .Container.Config}}
+{{with $memSwap := getMemorySwap .Container.Config .HostConfig}}
 lxc.cgroup.memory.memsw.limit_in_bytes = {{$memSwap}}
 {{end}}
 {{end}}
@@ -134,10 +134,10 @@ lxc.cgroup.cpu.shares = {{.HostConfig.CpuShares}}
 
 var LxcTemplateCompiled *template.Template
 
-func getMemorySwap(config *Config) int64 {
+func getMemorySwap(config *Config, hostConfig *HostConfig) int64 {
 	// By default, MemorySwap is set to twice the size of RAM.
 	// If you want to omit MemorySwap, set it to `-1'.
-	if config.MemorySwap < 0 {
+	if hostConfig.MemorySwap < 0 {
 		return 0
 	}
 	return config.Memory * 2

--- a/server.go
+++ b/server.go
@@ -918,9 +918,6 @@ func (srv *Server) ContainerCreate(config *Config) (string, error) {
 		config.Memory = 0
 	}
 
-	if config.Memory > 0 && !srv.runtime.capabilities.SwapLimit {
-		config.MemorySwap = -1
-	}
 	container, err := srv.runtime.Create(config)
 	if err != nil {
 		if srv.runtime.graph.IsNotExist(err) {

--- a/server.go
+++ b/server.go
@@ -134,7 +134,7 @@ func (srv *Server) ImageInsert(name, url, path string, out io.Writer, sf *utils.
 	}
 	defer file.Body.Close()
 
-	config, _, _, err := ParseRun([]string{img.ID, "echo", "insert", url, path}, srv.runtime.capabilities)
+	config, _, _, _, err := ParseRun([]string{img.ID, "echo", "insert", url, path}, srv.runtime.capabilities)
 	if err != nil {
 		return "", err
 	}
@@ -148,7 +148,7 @@ func (srv *Server) ImageInsert(name, url, path string, out io.Writer, sf *utils.
 		return "", err
 	}
 	// FIXME: Handle custom repo, tag comment, author
-	img, err = srv.runtime.Commit(c, "", "", img.Comment, img.Author, nil)
+	img, err = srv.runtime.Commit(c, "", "", img.Author, nil)
 	if err != nil {
 		return "", err
 	}
@@ -226,8 +226,8 @@ func (srv *Server) Images(all bool, filter string) ([]APIImages, error) {
 			out.Tag = tag
 			out.ID = image.ID
 			out.Created = image.Created.Unix()
-			out.Size = image.Size
-			out.VirtualSize = image.getParentsSize(0) + image.Size
+			out.Size = image.size
+			out.VirtualSize = image.getParentsSize(0) + image.size
 			outs = append(outs, out)
 		}
 	}
@@ -237,8 +237,8 @@ func (srv *Server) Images(all bool, filter string) ([]APIImages, error) {
 			var out APIImages
 			out.ID = image.ID
 			out.Created = image.Created.Unix()
-			out.Size = image.Size
-			out.VirtualSize = image.getParentsSize(0) + image.Size
+			out.Size = image.size
+			out.VirtualSize = image.getParentsSize(0) + image.size
 			outs = append(outs, out)
 		}
 	}
@@ -396,12 +396,12 @@ func (srv *Server) Containers(all, size bool, n int, since, before string) []API
 	return retContainers
 }
 
-func (srv *Server) ContainerCommit(name, repo, tag, author, comment string, config *Config) (string, error) {
+func (srv *Server) ContainerCommit(name, repo, tag, author string, config *Config) (string, error) {
 	container := srv.runtime.Get(name)
 	if container == nil {
 		return "", fmt.Errorf("No such container: %s", name)
 	}
-	img, err := srv.runtime.Commit(container, repo, tag, comment, author, config)
+	img, err := srv.runtime.Commit(container, repo, tag, author, config)
 	if err != nil {
 		return "", err
 	}
@@ -894,7 +894,7 @@ func (srv *Server) ImageImport(src, repo, tag string, in io.Reader, out io.Write
 		}
 		archive = utils.ProgressReader(resp.Body, int(resp.ContentLength), out, sf.FormatProgress("", "Importing", "%8v/%v (%v)"), sf, true)
 	}
-	img, err := srv.runtime.graph.Create(archive, nil, "Imported from "+src, "", nil)
+	img, err := srv.runtime.graph.Create(archive, nil, "", nil)
 	if err != nil {
 		return err
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -84,7 +84,7 @@ func TestCreateRm(t *testing.T) {
 
 	srv := &Server{runtime: runtime}
 
-	config, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
+	config, _, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestCommit(t *testing.T) {
 
 	srv := &Server{runtime: runtime}
 
-	config, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "/bin/cat"}, nil)
+	config, _, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "/bin/cat"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := srv.ContainerCommit(id, "testrepo", "testtag", "", "", config); err != nil {
+	if _, err := srv.ContainerCommit(id, "testrepo", "testtag", "", config); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -135,7 +135,7 @@ func TestCreateStartRestartStopStartKillRm(t *testing.T) {
 
 	srv := &Server{runtime: runtime}
 
-	config, hostConfig, _, err := ParseRun([]string{GetTestImage(runtime).ID, "/bin/cat"}, nil)
+	config, hostConfig, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "/bin/cat"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,10 +193,9 @@ func TestRunWithTooLowMemoryLimit(t *testing.T) {
 	// Try to create a container with a memory limit of 1 byte less than the minimum allowed limit.
 	_, err = srv.ContainerCreate(
 		&Config{
-			Image:     GetTestImage(runtime).ID,
-			Memory:    524287,
-			CpuShares: 1000,
-			Cmd:       []string{"/bin/cat"},
+			Image:  GetTestImage(runtime).ID,
+			Memory: 524287,
+			Cmd:    []string{"/bin/cat"},
 		},
 	)
 	if err == nil {
@@ -357,7 +356,7 @@ func TestRmi(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config, hostConfig, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
+	config, hostConfig, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -373,7 +372,7 @@ func TestRmi(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	imageID, err := srv.ContainerCommit(containerID, "test", "", "", "", nil)
+	imageID, err := srv.ContainerCommit(containerID, "test", "", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -394,7 +393,7 @@ func TestRmi(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = srv.ContainerCommit(containerID, "test", "", "", "", nil)
+	_, err = srv.ContainerCommit(containerID, "test", "", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sorter_test.go
+++ b/sorter_test.go
@@ -12,7 +12,7 @@ func TestServerListOrderedImagesByCreationDate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = runtime.graph.Create(archive, nil, "Testing", "", nil)
+	_, err = runtime.graph.Create(archive, nil, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,7 +37,7 @@ func TestServerListOrderedImagesByCreationDateAndTag(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	image, err := runtime.graph.Create(archive, nil, "Testing", "", nil)
+	image, err := runtime.graph.Create(archive, nil, "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils.go
+++ b/utils.go
@@ -12,14 +12,10 @@ func CompareConfig(a, b *Config) bool {
 		a.OpenStdin || b.OpenStdin {
 		return false
 	}
-	if a.AttachStdout != b.AttachStdout ||
-		a.AttachStderr != b.AttachStderr ||
-		a.User != b.User ||
+	if a.User != b.User ||
 		a.Memory != b.Memory ||
-		a.MemorySwap != b.MemorySwap ||
 		a.OpenStdin != b.OpenStdin ||
-		a.Tty != b.Tty ||
-		a.VolumesFrom != b.VolumesFrom {
+		a.Tty != b.Tty {
 		return false
 	}
 	if len(a.Cmd) != len(b.Cmd) ||
@@ -65,9 +61,6 @@ func MergeConfig(userConf, imageConf *Config) {
 	}
 	if userConf.Memory == 0 {
 		userConf.Memory = imageConf.Memory
-	}
-	if userConf.MemorySwap == 0 {
-		userConf.MemorySwap = imageConf.MemorySwap
 	}
 	if userConf.PortSpecs == nil || len(userConf.PortSpecs) == 0 {
 		userConf.PortSpecs = imageConf.PortSpecs
@@ -120,9 +113,6 @@ func MergeConfig(userConf, imageConf *Config) {
 	}
 	if userConf.WorkingDir == "" {
 		userConf.WorkingDir = imageConf.WorkingDir
-	}
-	if userConf.VolumesFrom == "" {
-		userConf.VolumesFrom = imageConf.VolumesFrom
 	}
 	if userConf.Volumes == nil || len(userConf.Volumes) == 0 {
 		userConf.Volumes = imageConf.Volumes

--- a/utils.go
+++ b/utils.go
@@ -17,14 +17,12 @@ func CompareConfig(a, b *Config) bool {
 		a.User != b.User ||
 		a.Memory != b.Memory ||
 		a.MemorySwap != b.MemorySwap ||
-		a.CpuShares != b.CpuShares ||
 		a.OpenStdin != b.OpenStdin ||
 		a.Tty != b.Tty ||
 		a.VolumesFrom != b.VolumesFrom {
 		return false
 	}
 	if len(a.Cmd) != len(b.Cmd) ||
-		len(a.Dns) != len(b.Dns) ||
 		len(a.Env) != len(b.Env) ||
 		len(a.PortSpecs) != len(b.PortSpecs) ||
 		len(a.Entrypoint) != len(b.Entrypoint) ||
@@ -37,11 +35,7 @@ func CompareConfig(a, b *Config) bool {
 			return false
 		}
 	}
-	for i := 0; i < len(a.Dns); i++ {
-		if a.Dns[i] != b.Dns[i] {
-			return false
-		}
-	}
+
 	for i := 0; i < len(a.Env); i++ {
 		if a.Env[i] != b.Env[i] {
 			return false
@@ -74,9 +68,6 @@ func MergeConfig(userConf, imageConf *Config) {
 	}
 	if userConf.MemorySwap == 0 {
 		userConf.MemorySwap = imageConf.MemorySwap
-	}
-	if userConf.CpuShares == 0 {
-		userConf.CpuShares = imageConf.CpuShares
 	}
 	if userConf.PortSpecs == nil || len(userConf.PortSpecs) == 0 {
 		userConf.PortSpecs = imageConf.PortSpecs
@@ -123,12 +114,6 @@ func MergeConfig(userConf, imageConf *Config) {
 	}
 	if userConf.Cmd == nil || len(userConf.Cmd) == 0 {
 		userConf.Cmd = imageConf.Cmd
-	}
-	if userConf.Dns == nil || len(userConf.Dns) == 0 {
-		userConf.Dns = imageConf.Dns
-	} else {
-		//duplicates aren't an issue here
-		userConf.Dns = append(userConf.Dns, imageConf.Dns...)
 	}
 	if userConf.Entrypoint == nil || len(userConf.Entrypoint) == 0 {
 		userConf.Entrypoint = imageConf.Entrypoint

--- a/utils_test.go
+++ b/utils_test.go
@@ -144,38 +144,26 @@ func TestCompareConfig(t *testing.T) {
 	volumes1 := make(map[string]struct{})
 	volumes1["/test1"] = struct{}{}
 	config1 := Config{
-		PortSpecs:   []string{"1111:1111", "2222:2222"},
-		Env:         []string{"VAR1=1", "VAR2=2"},
-		VolumesFrom: "11111111",
-		Volumes:     volumes1,
+		PortSpecs: []string{"1111:1111", "2222:2222"},
+		Env:       []string{"VAR1=1", "VAR2=2"},
+		Volumes:   volumes1,
 	}
 	config2 := Config{
-		PortSpecs:   []string{"0000:0000", "2222:2222"},
-		Env:         []string{"VAR1=1", "VAR2=2"},
-		VolumesFrom: "11111111",
-		Volumes:     volumes1,
-	}
-	config3 := Config{
-		PortSpecs:   []string{"0000:0000", "2222:2222"},
-		Env:         []string{"VAR1=1", "VAR2=2"},
-		VolumesFrom: "22222222",
-		Volumes:     volumes1,
+		PortSpecs: []string{"0000:0000", "2222:2222"},
+		Env:       []string{"VAR1=1", "VAR2=2"},
+		Volumes:   volumes1,
 	}
 	volumes2 := make(map[string]struct{})
 	volumes2["/test2"] = struct{}{}
-	config4 := Config{
-		PortSpecs:   []string{"0000:0000", "2222:2222"},
-		Env:         []string{"VAR1=1", "VAR2=2"},
-		VolumesFrom: "11111111",
-		Volumes:     volumes2,
+	config3 := Config{
+		PortSpecs: []string{"0000:0000", "2222:2222"},
+		Env:       []string{"VAR1=1", "VAR2=2"},
+		Volumes:   volumes2,
 	}
 	if CompareConfig(&config1, &config2) {
 		t.Fatalf("CompareConfig should return false, PortSpecs are different")
 	}
 	if CompareConfig(&config1, &config3) {
-		t.Fatalf("CompareConfig should return false, VolumesFrom are different")
-	}
-	if CompareConfig(&config1, &config4) {
 		t.Fatalf("CompareConfig should return false, Volumes are different")
 	}
 	if !CompareConfig(&config1, &config1) {
@@ -188,10 +176,9 @@ func TestMergeConfig(t *testing.T) {
 	volumesImage["/test1"] = struct{}{}
 	volumesImage["/test2"] = struct{}{}
 	configImage := &Config{
-		PortSpecs:   []string{"1111:1111", "2222:2222"},
-		Env:         []string{"VAR1=1", "VAR2=2"},
-		VolumesFrom: "1111",
-		Volumes:     volumesImage,
+		PortSpecs: []string{"1111:1111", "2222:2222"},
+		Env:       []string{"VAR1=1", "VAR2=2"},
+		Volumes:   volumesImage,
 	}
 
 	volumesUser := make(map[string]struct{})
@@ -228,10 +215,6 @@ func TestMergeConfig(t *testing.T) {
 		if v != "/test1" && v != "/test2" && v != "/test3" {
 			t.Fatalf("Expected /test1 or /test2 or /test3, found %s", v)
 		}
-	}
-
-	if configUser.VolumesFrom != "1111" {
-		t.Fatalf("Expected VolumesFrom to be 1111, found %s", configUser.VolumesFrom)
 	}
 }
 


### PR DESCRIPTION
Here a first  PR to clean up Container, Image and Config structs.

Problems:
*Config was used to both represents container's configuration and cli parameters.
*Some fields in images were unused or subject to change in the future, so we removed them.
*Some fields were only used by the client, and not meant to be save on disk

Changes:
_Some fields move from Config to HostConfig (`cpushare`, `networkDisabled`, etc...)
*We removed `comment`, `architecture` and `container` from Image
*A new struct was created to represents command line arguments not meant to be save on disk (`Attach_`, the`cidfile`, etc...)
*All the`dns/resolv.conf`stuff it now done at`start`and not at`create`
*lxc config file is now generated with only one template (as it needs both`container`and`hostConfig`)

**Please tell me if you have any comment**
