### PR TITLE
Update Gentoo docs to reflect the package name change from app-emulation/lxc-docker to app-emulation/docker

### DIFF
--- a/docs/sources/installation/gentoolinux.rst
+++ b/docs/sources/installation/gentoolinux.rst
@@ -35,15 +35,15 @@ then invoke the following:
 
    sudo layman -f -a docker
 
-Once that completes, the ``app-emulation/lxc-docker`` package will be available
+Once that completes, the ``app-emulation/docker`` package will be available
 for emerge:
 
 .. code-block:: bash
 
-   sudo emerge -av app-emulation/lxc-docker
+   sudo emerge -av app-emulation/docker
 
 If you prefer to use the official binaries, or just do not wish to compile
-docker, emerge ``app-emulation/lxc-docker-bin`` instead.  It is important to
+docker, emerge ``app-emulation/docker-bin`` instead.  It is important to
 remember that Gentoo is still an unsupported platform, even when using the
 official binaries.
 
@@ -54,7 +54,7 @@ portage tree also contains ``sys-fs/aufs3``, which contains the patches
 necessary for adding AUFS support to other kernel source packages (and a
 ``kernel-patch`` use flag to perform the patching automatically).
 
-Between ``app-emulation/lxc`` and ``app-emulation/lxc-docker``, all the
+Between ``app-emulation/lxc`` and ``app-emulation/docker``, all the
 necessary kernel configuration flags should be checked for and warned about in
 the standard manner.
 

--- a/docs/sources/installation/gentoolinux.rst
+++ b/docs/sources/installation/gentoolinux.rst
@@ -11,7 +11,10 @@ Gentoo Linux
 
 .. include:: install_unofficial.inc
 
-Installing Docker on Gentoo Linux can be accomplished by using the overlay provided at https://github.com/tianon/docker-overlay.  The most up-to-date documentation for properly installing the overlay can be found in the overlay README.  The information here is provided for reference, and may be out of date.
+Installing Docker on Gentoo Linux can be accomplished by using the overlay
+provided at https://github.com/tianon/docker-overlay.  The most up-to-date
+documentation for properly installing the overlay can be found in the overlay
+README.  The information here is provided for reference, and may be out of date.
 
 Installation
 ^^^^^^^^^^^^
@@ -22,30 +25,49 @@ Ensure that layman is installed:
 
    sudo emerge -av app-portage/layman
 
-Using your favorite editor, add ``https://raw.github.com/tianon/docker-overlay/master/repositories.xml`` to the ``overlays`` section in ``/etc/layman/layman.cfg`` (as per instructions on the `Gentoo Wiki <http://wiki.gentoo.org/wiki/Layman#Adding_custom_overlays>`_), then invoke the following:
+Using your favorite editor, add
+``https://raw.github.com/tianon/docker-overlay/master/repositories.xml`` to the
+``overlays`` section in ``/etc/layman/layman.cfg`` (as per instructions on the
+`Gentoo Wiki <http://wiki.gentoo.org/wiki/Layman#Adding_custom_overlays>`_),
+then invoke the following:
 
 .. code-block:: bash
 
    sudo layman -f -a docker
 
-Once that completes, the ``app-emulation/lxc-docker`` package will be available for emerge:
+Once that completes, the ``app-emulation/lxc-docker`` package will be available
+for emerge:
 
 .. code-block:: bash
 
    sudo emerge -av app-emulation/lxc-docker
 
-If you prefer to use the official binaries, or just do not wish to compile docker, emerge ``app-emulation/lxc-docker-bin`` instead.  It is important to remember that Gentoo is still an unsupported platform, even when using the official binaries.
+If you prefer to use the official binaries, or just do not wish to compile
+docker, emerge ``app-emulation/lxc-docker-bin`` instead.  It is important to
+remember that Gentoo is still an unsupported platform, even when using the
+official binaries.
 
-The package should already include all the necessary dependencies.  For the simplest installation experience, use ``sys-kernel/aufs-sources`` directly as your kernel sources.  If you prefer not to use ``sys-kernel/aufs-sources``, the portage tree also contains ``sys-fs/aufs3``, which contains the patches necessary for adding AUFS support to other kernel source packages (and a ``kernel-patch`` use flag to perform the patching automatically).
+The package should already include all the necessary dependencies.  For the
+simplest installation experience, use ``sys-kernel/aufs-sources`` directly as
+your kernel sources.  If you prefer not to use ``sys-kernel/aufs-sources``, the
+portage tree also contains ``sys-fs/aufs3``, which contains the patches
+necessary for adding AUFS support to other kernel source packages (and a
+``kernel-patch`` use flag to perform the patching automatically).
 
-Between ``app-emulation/lxc`` and ``app-emulation/lxc-docker``, all the necessary kernel configuration flags should be checked for and warned about in the standard manner.
+Between ``app-emulation/lxc`` and ``app-emulation/lxc-docker``, all the
+necessary kernel configuration flags should be checked for and warned about in
+the standard manner.
 
-If any issues arise from this ebuild or the resulting binary, including and especially missing kernel configuration flags and/or dependencies, `open an issue <https://github.com/tianon/docker-overlay/issues>`_ on the docker-overlay repository or ping tianon in the #docker IRC channel.
+If any issues arise from this ebuild or the resulting binary, including and
+especially missing kernel configuration flags and/or dependencies, `open an
+issue <https://github.com/tianon/docker-overlay/issues>`_ on the docker-overlay
+repository or ping tianon in the #docker IRC channel.
 
 Starting Docker
 ^^^^^^^^^^^^^^^
 
-Ensure that you are running a kernel that includes the necessary AUFS support and includes all the necessary modules and/or configuration for LXC.
+Ensure that you are running a kernel that includes the necessary AUFS support
+and includes all the necessary modules and/or configuration for LXC.
 
 OpenRC
 ------
@@ -80,7 +102,8 @@ To start on system boot:
 Network Configuration
 ^^^^^^^^^^^^^^^^^^^^^
 
-IPv4 packet forwarding is disabled by default, so internet access from inside the container will not work unless ``net.ipv4.ip_forward`` is enabled:
+IPv4 packet forwarding is disabled by default, so internet access from inside
+the container will not work unless ``net.ipv4.ip_forward`` is enabled:
 
 .. code-block:: bash
 
@@ -95,4 +118,8 @@ Or, to enable it more permanently:
 fork/exec /usr/sbin/lxc-start: operation not permitted
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Unfortunately, Gentoo suffers from `issue #1422 <https://github.com/dotcloud/docker/issues/1422>`_, meaning that after every fresh start of docker, the first docker run fails due to some tricky terminal issues, so be sure to run something trivial (such as ``docker run -i -t busybox echo hi``) before attempting to run anything important.
+Unfortunately, Gentoo suffers from `issue #1422
+<https://github.com/dotcloud/docker/issues/1422>`_, meaning that after every
+fresh start of docker, the first docker run fails due to some tricky terminal
+issues, so be sure to run something trivial (such as ``docker run -i -t busybox
+echo hi``) before attempting to run anything important.


### PR DESCRIPTION
We discussed this in today's #docker-meeting, especially in light of both the eventual optionality of LXC and the naming movements happening for Red Hat, and I've implemented it in my overlay so this is the documentation update to match.

I've also reformatted the file to 80 columns, as requested. :)
