### PR TITLE
Change comment in docs example on daemon mode from referring to "D" to "-d"

### DIFF
--- a/docs/sources/examples/running_ssh_service.rst
+++ b/docs/sources/examples/running_ssh_service.rst
@@ -64,7 +64,7 @@ The password is 'screencast'
          $ docker commit a30a3a2f2b130749995f5902f079dc6ad31ea0621fac595128ec59c6da07feea dhrp/sshd 
          # I gave the name dhrp/sshd for the container
          # now we can run it again 
-         $ docker run -d dhrp/sshd /usr/sbin/sshd -D # D for daemon mode 
+         $ docker run -d dhrp/sshd /usr/sbin/sshd -D # -d for daemon mode 
          # is it running?
          $ docker ps
          # yes!


### PR DESCRIPTION
The comment on line 67 is a bit confusing: it says `# D for daemon mode` when my understanding is that -d is the flag for daemon mode. It's particularly confusing for a newbie since this line uses both -d and -D, so I'm suggesting this clarification.

(I'm just getting started with Docker, so please pardon me if I'm wrong!)
