### PR TITLE
Filter image listing using path.Match

### DIFF
--- a/server.go
+++ b/server.go
@@ -211,7 +211,7 @@ func (srv *Server) Images(all bool, filter string) ([]APIImages, error) {
 	outs := []APIImages{} //produce [] when empty instead of 'null'
 	for name, repository := range srv.runtime.repositories.Repositories {
 		if filter != "" {
-			if match, _ := path.Match ( filter, name ); !match {
+			if match, _ := path.Match(filter, name); !match {
 				continue
 			}
 		}
@@ -681,7 +681,7 @@ func (srv *Server) getImageList(localRepo map[string]string) ([][]*registry.ImgD
 		depGraph.NewNode(img.ID)
 		img.WalkHistory(func(current *Image) error {
 			imgList[current.ID] = &registry.ImgData{
-				ID: current.ID,
+				ID:  current.ID,
 				Tag: tag,
 			}
 			parent, err := current.GetParent()

--- a/server.go
+++ b/server.go
@@ -210,8 +210,10 @@ func (srv *Server) Images(all bool, filter string) ([]APIImages, error) {
 	}
 	outs := []APIImages{} //produce [] when empty instead of 'null'
 	for name, repository := range srv.runtime.repositories.Repositories {
-		if filter != "" && name != filter {
-			continue
+		if filter != "" {
+			if match, _ := path.Match ( filter, name ); !match {
+				continue
+			}
 		}
 		for tag, id := range repository {
 			var out APIImages

--- a/server_test.go
+++ b/server_test.go
@@ -431,3 +431,57 @@ func TestRmi(t *testing.T) {
 		}
 	}
 }
+
+func TestImagesFilter(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+
+	srv := &Server{runtime: runtime}
+
+	if err := srv.runtime.repositories.Set("utest", "tag1", unitTestImageName, false); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := srv.runtime.repositories.Set("utest/docker", "tag2", unitTestImageName, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.runtime.repositories.Set("utest:5000/docker", "tag3", unitTestImageName, false); err != nil {
+		t.Fatal(err)
+	}
+
+	images, err := srv.Images(false, "utest*/*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(images) != 2 {
+		t.Fatal("incorrect number of matches returned")
+	}
+
+	images, err = srv.Images(false, "utest")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(images) != 1 {
+		t.Fatal("incorrect number of matches returned")
+	}
+
+	images, err = srv.Images(false, "utest*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(images) != 1 {
+		t.Fatal("incorrect number of matches returned")
+	}
+
+	images, err = srv.Images(false, "*5000*/*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(images) != 1 {
+		t.Fatal("incorrect number of matches returned")
+	}
+}


### PR DESCRIPTION
From issue https://github.com/dotcloud/docker/issues/928
Making it easier to filter the images command so that it can be piped into other commands

> docker images -q *testing\* | docker rmi

Uses path.Match which may not be the best because _/_ is a special character.

> ie. web\* will not match website/main, you will need to do web_/_
