### PR TITLE
remove docker-ruby from docs

### DIFF
--- a/docs/sources/api/docker_remote_api.rst
+++ b/docs/sources/api/docker_remote_api.rst
@@ -175,8 +175,6 @@ and we will add the libraries here.
 +======================+================+============================================+
 | Python               | docker-py      | https://github.com/dotcloud/docker-py      |
 +----------------------+----------------+--------------------------------------------+
-| Ruby                 | docker-ruby    | https://github.com/ActiveState/docker-ruby |
-+----------------------+----------------+--------------------------------------------+
 | Ruby                 | docker-client  | https://github.com/geku/docker-client      |
 +----------------------+----------------+--------------------------------------------+
 | Ruby                 | docker-api     | https://github.com/swipely/docker-api      |


### PR DESCRIPTION
we don't maintain it anymore as we now recommend proper HTTP api based clients instead.
