### PR TITLE
Implementation of multiline syntax for Dockerfile

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -449,7 +449,7 @@ func TestGetContainersChanges(t *testing.T) {
 }
 
 func TestGetContainersTop(t *testing.T) {
-        t.Skip("Fixme. Skipping test for now. Reported error when testing using dind: 'api_test.go:527: Expected 2 processes, found 0.'")
+	t.Skip("Fixme. Skipping test for now. Reported error when testing using dind: 'api_test.go:527: Expected 2 processes, found 0.'")
 	runtime, err := newTestRuntime()
 	if err != nil {
 		t.Fatal(err)

--- a/buildfile.go
+++ b/buildfile.go
@@ -459,7 +459,7 @@ func (b *buildFile) commit(id string, autoCmd []string, comment string) error {
 }
 
 // Long lines can be split with a backslash
-var lineContinuation = regexp.MustCompile(`\s*\\.*\n`)
+var lineContinuation = regexp.MustCompile(`\s*\\\s*\n`)
 
 func (b *buildFile) Build(context io.Reader) (string, error) {
 	// FIXME: @creack any reason for using /tmp instead of ""?

--- a/buildfile.go
+++ b/buildfile.go
@@ -485,14 +485,6 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 	dockerfile = lineContinuation.ReplaceAllString(dockerfile, " ")
 	stepN := 0
 	for _, line := range strings.Split(dockerfile, "\n") {
-		/*		line, err := dockerfile.ReadString('\n')
-				if err != nil {
-					if err == io.EOF && line == "" {
-						break
-					} else if err != io.EOF {
-						return "", err
-					}
-				}*/
 		line = strings.Trim(strings.Replace(line, "\t", " ", -1), " \t\r\n")
 		// Skip comments and empty line
 		if len(line) == 0 || line[0] == '#' {

--- a/buildfile.go
+++ b/buildfile.go
@@ -458,7 +458,8 @@ func (b *buildFile) commit(id string, autoCmd []string, comment string) error {
 	return nil
 }
 
-var multilineRegex = regexp.MustCompile("\\.*\n")
+// Long lines can be split with a backslash
+var lineContinuation = regexp.MustCompile(`\s*\\.*\n`)
 
 func (b *buildFile) Build(context io.Reader) (string, error) {
 	// FIXME: @creack any reason for using /tmp instead of ""?
@@ -481,7 +482,7 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 		return "", err
 	}
 	dockerfile := string(fileBytes)
-	// dockerfile = multilineRegex.ReplaceAllString(dockerfile, " ")
+	dockerfile = lineContinuation.ReplaceAllString(dockerfile, " ")
 	stepN := 0
 	for _, line := range strings.Split(dockerfile, "\n") {
 		/*		line, err := dockerfile.ReadString('\n')

--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -45,6 +45,21 @@ run    [ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]
 		nil,
 	},
 
+	// Exactly the same as above, except uses a line split with a \ to test
+	// multiline support.
+	{
+		`
+from   {IMAGE}
+run    sh -c 'echo root:testpass \
+	> /tmp/passwd'
+run    mkdir -p /var/run/sshd
+run    [ "$(cat /tmp/passwd)" = "root:testpass" ]
+run    [ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]
+`,
+		nil,
+		nil,
+	},
+
 	{
 		`
 from {IMAGE}

--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -60,6 +60,19 @@ run    [ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]
 		nil,
 	},
 
+	// Line containing literal "\n"
+	{
+		`
+from   {IMAGE}
+run    sh -c 'echo root:testpass > /tmp/passwd'
+run    echo "foo \n bar"; echo "baz"
+run    mkdir -p /var/run/sshd
+run    [ "$(cat /tmp/passwd)" = "root:testpass" ]
+run    [ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]
+`,
+		nil,
+		nil,
+	},
 	{
 		`
 from {IMAGE}

--- a/container.go
+++ b/container.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"log"
+	"net"
 	"os"
 	"os/exec"
 	"path"
@@ -20,7 +21,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-	"net"
 )
 
 type Container struct {
@@ -813,10 +813,10 @@ func (container *Container) allocateNetwork() error {
 			iface = &NetworkInterface{disabled: true}
 		} else {
 			iface = &NetworkInterface{
-				IPNet: net.IPNet{IP: net.ParseIP(container.NetworkSettings.IPAddress), Mask: manager.bridgeNetwork.Mask},
+				IPNet:   net.IPNet{IP: net.ParseIP(container.NetworkSettings.IPAddress), Mask: manager.bridgeNetwork.Mask},
 				Gateway: manager.bridgeNetwork.IP,
 				manager: manager,
-				}
+			}
 			ipNum := ipToInt(iface.IPNet.IP)
 			manager.ipAllocator.inUse[ipNum] = struct{}{}
 		}
@@ -827,10 +827,10 @@ func (container *Container) allocateNetwork() error {
 		portSpecs = container.Config.PortSpecs
 	} else {
 		for backend, frontend := range container.NetworkSettings.PortMapping["Tcp"] {
-			portSpecs = append(portSpecs, fmt.Sprintf("%s:%s/tcp",frontend, backend))
+			portSpecs = append(portSpecs, fmt.Sprintf("%s:%s/tcp", frontend, backend))
 		}
 		for backend, frontend := range container.NetworkSettings.PortMapping["Udp"] {
-			portSpecs = append(portSpecs, fmt.Sprintf("%s:%s/udp",frontend, backend))
+			portSpecs = append(portSpecs, fmt.Sprintf("%s:%s/udp", frontend, backend))
 		}
 	}
 

--- a/network.go
+++ b/network.go
@@ -642,7 +642,7 @@ func (manager *NetworkManager) Allocate() (*NetworkInterface, error) {
 	if err != nil {
 		return nil, err
 	}
-	// avoid duplicate IP 
+	// avoid duplicate IP
 	ipNum := ipToInt(ip)
 	firstIP := manager.ipAllocator.network.IP.To4().Mask(manager.ipAllocator.network.Mask)
 	firstIPNum := ipToInt(firstIP) + 1

--- a/server.go
+++ b/server.go
@@ -679,7 +679,7 @@ func (srv *Server) getImageList(localRepo map[string]string) ([][]*registry.ImgD
 		depGraph.NewNode(img.ID)
 		img.WalkHistory(func(current *Image) error {
 			imgList[current.ID] = &registry.ImgData{
-				ID: current.ID,
+				ID:  current.ID,
 				Tag: tag,
 			}
 			parent, err := current.GetParent()

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -366,7 +366,6 @@ func TestParseRelease(t *testing.T) {
 	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "19-generic"}, 0)
 }
 
-
 func TestDependencyGraphCircular(t *testing.T) {
 	g1 := NewDependencyGraph()
 	a := g1.NewNode("a")


### PR DESCRIPTION
This PR implments #1799.  

Passes all tests, with what appear to be harmless (?) warnings:

```
$ time sudo GOPATH=/home/jason/work/go /home/jason/bin/go test
2013/09/09 17:03:22 Listening for HTTP on 127.0.0.1:4270 (tcp)
2013/09/09 17:03:25 WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.
2013/09/09 17:03:25 WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.
2013/09/09 17:03:28 Container b1834cfb30eace958b61fe28260cc0fc2b45481b3594b2fbcca3c9b86f9d534e failed to exit within 1 seconds of SIGTERM - using the force
2013/09/09 17:03:31 Container d897754a96f30f067c975a28a330534574572c8f1b2256e1f223a24c9a618e93 failed to exit within 1 seconds of SIGTERM - using the force
2013/09/09 17:03:46 error killing container 57ef82d41eff720215e5a534c6d992634cfb34247243414a346863e8b1a17f7b (lxc-kill: failed to get the init pid
, exit status 255)
2013/09/09 17:03:46 error killing container d5e6fb3fb8e8c350ba392604fd87dce295667eb5598a2c3ca123b976d1594ff3 (lxc-kill: failed to get the init pid
, exit status 255)
2013/09/09 17:03:47 error killing container 11b9887bc338c05abcade0a2878c26a2116ef334baaa7e40db5843233a5928c4 (lxc-kill: failed to get the init pid
, exit status 255)
2013/09/09 17:03:58 WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.
PASS
ok      github.com/dotcloud/docker  56.965s

real    0m58.942s
user    0m6.020s
sys 0m9.624s
```
