### PR TITLE
Fix typo in Vagrantfile.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,7 +69,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
   config.vm.provider :vmware_fusion do |f, override|
     override.vm.box = BOX_NAME
     override.vm.box_url = VF_BOX_URI
-    override.vm.synced_folder ".", "/vagrant", disabled: true
+    override.vm.synced_folder ".", "/vagrant", :disabled => true
     f.vmx["displayName"] = "docker"
   end
 


### PR DESCRIPTION
On ubuntu 12.04 the `vagrant up` command will fail with a syntax error that is corrected here.
