### PR TITLE
Improved hostConfig reload

### DIFF
--- a/api.go
+++ b/api.go
@@ -654,11 +654,11 @@ func deleteImages(srv *Server, version float64, w http.ResponseWriter, r *http.R
 }
 
 func postContainersStart(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	hostConfig := &HostConfig{}
-
+	var hostConfig *HostConfig
 	// allow a nil body for backwards compatibility
 	if r.Body != nil {
 		if matchesContentType(r.Header.Get("Content-Type"), "application/json") {
+			hostConfig = &HostConfig{}
 			if err := json.NewDecoder(r.Body).Decode(hostConfig); err != nil {
 				return err
 			}

--- a/container.go
+++ b/container.go
@@ -564,7 +564,7 @@ func (container *Container) Start(hostConfig *HostConfig) error {
 	container.State.Lock()
 	defer container.State.Unlock()
 
-	if len(hostConfig.Binds) == 0 && len(hostConfig.LxcConf) == 0 {
+	if hostConfig == nil { // in docker start of docker restart we want to reuse previous HostConfigFile
 		hostConfig, _ = container.ReadHostConfig()
 	}
 


### PR DESCRIPTION
When doing `docker start` or `docker restart` we want to reload the `hostConfig` from the filesystem.
Instead of comparing if it's empty, we use nil.

ping @creack @crosbymichael 
