### PR TITLE
Replace multiline with empty string not space

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -481,7 +481,7 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 		return "", err
 	}
 	dockerfile := string(fileBytes)
-	dockerfile = lineContinuation.ReplaceAllString(dockerfile, " ")
+	dockerfile = lineContinuation.ReplaceAllString(dockerfile, "")
 	stepN := 0
 	for _, line := range strings.Split(dockerfile, "\n") {
 		line = strings.Trim(strings.Replace(line, "\t", " ", -1), " \t\r\n")


### PR DESCRIPTION
Ensure we don't introduce unexpected spaces when processing multiline in Dockerfiles
