### PR TITLE
Fixed LxcConf example in Remote API v1.4 and v1.5

### DIFF
--- a/docs/sources/api/docker_remote_api_v1.4.rst
+++ b/docs/sources/api/docker_remote_api_v1.4.rst
@@ -359,7 +359,7 @@ Start a container
 
            {
                 "Binds":["/tmp:/tmp"],
-                "LxcConf":{"lxc.utsname":"docker"}
+                "LxcConf":[{"Key":"lxc.utsname","Value":"docker"}]
            }
 
         **Example response**:

--- a/docs/sources/api/docker_remote_api_v1.5.rst
+++ b/docs/sources/api/docker_remote_api_v1.5.rst
@@ -358,7 +358,7 @@ Start a container
 
            {
                 "Binds":["/tmp:/tmp"],
-                "LxcConf":{"lxc.utsname":"docker"}
+                "LxcConf":[{"Key":"lxc.utsname","Value":"docker"}]
            }
 
         **Example response**:


### PR DESCRIPTION
Based on how the command line docker sends the request.
