### PR TITLE
Removing the deprecated `base` repository from more docs

### DIFF
--- a/contrib/crashTest.go
+++ b/contrib/crashTest.go
@@ -77,7 +77,7 @@ func crashTest() error {
 			stop = false
 			for i := 0; i < 100 && !stop; {
 				func() error {
-					cmd := exec.Command(DOCKERPATH, "run", "base", "echo", fmt.Sprintf("%d", totalTestCount))
+					cmd := exec.Command(DOCKERPATH, "run", "ubuntu", "echo", fmt.Sprintf("%d", totalTestCount))
 					i++
 					totalTestCount++
 					outPipe, err := cmd.StdoutPipe()

--- a/docs/sources/api/docker_remote_api_v1.0.rst
+++ b/docs/sources/api/docker_remote_api_v1.0.rst
@@ -49,28 +49,28 @@ List containers
 	   [
 		{
 			"Id": "8dfafdbc3a40",
-			"Image": "base:latest",
+			"Image": "ubuntu:latest",
 			"Command": "echo 1",
 			"Created": 1367854155,
 			"Status": "Exit 0"
 		},
 		{
 			"Id": "9cd87474be90",
-			"Image": "base:latest",
+			"Image": "ubuntu:latest",
 			"Command": "echo 222222",
 			"Created": 1367854155,
 			"Status": "Exit 0"
 		},
 		{
 			"Id": "3176a2479c92",
-			"Image": "base:latest",
+			"Image": "centos:latest",
 			"Command": "echo 3333333333333333",
 			"Created": 1367854154,
 			"Status": "Exit 0"
 		},
 		{
 			"Id": "4cb07b47f9fb",
-			"Image": "base:latest",
+			"Image": "fedora:latest",
 			"Command": "echo 444444444444444444444444444444444",
 			"Created": 1367854152,
 			"Status": "Exit 0"
@@ -117,7 +117,7 @@ Create a container
 			"date"
 		],
 		"Dns":null,
-		"Image":"base",
+		"Image":"ubuntu",
 		"Volumes":{},
 		"VolumesFrom":""
 	   }
@@ -183,7 +183,7 @@ Inspect a container
 					"date"
 				],
 				"Dns": null,
-				"Image": "base",
+				"Image": "ubuntu",
 				"Volumes": {},
 				"VolumesFrom": ""
 			},
@@ -490,14 +490,14 @@ List Images
 	   
 	   [
 		{
-			"Repository":"base",
-			"Tag":"ubuntu-12.10",
+			"Repository":"ubuntu",
+			"Tag":"precise",
 			"Id":"b750fe79269d",
 			"Created":1364102658
 		},
 		{
-			"Repository":"base",
-			"Tag":"ubuntu-quantal",
+			"Repository":"ubuntu",
+			"Tag":"12.04",
 			"Id":"b750fe79269d",
 			"Created":1364102658
 		}
@@ -529,9 +529,9 @@ List Images
 	   "d6434d954665" -> "d82cbacda43a"
 	   base -> "e9aa60c60128" [style=invis]
 	   "074be284591f" -> "f71189fff3de"
-	   "b750fe79269d" [label="b750fe79269d\nbase",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
-	   "e9aa60c60128" [label="e9aa60c60128\nbase2",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
-	   "9a33b36209ed" [label="9a33b36209ed\ntest",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "b750fe79269d" [label="b750fe79269d\nubuntu",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "e9aa60c60128" [label="e9aa60c60128\ncentos",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "9a33b36209ed" [label="9a33b36209ed\nfedora",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
 	   base [style=invisible]
 	   }
  
@@ -552,7 +552,7 @@ Create an image
 
         .. sourcecode:: http
 
-           POST /images/create?fromImage=base HTTP/1.1
+           POST /images/create?fromImage=ubuntu HTTP/1.1
 
         **Example response**:
 
@@ -572,8 +572,8 @@ Create an image
         :statuscode 500: server error
 
 
-Insert a file in a image
-************************
+Insert a file in an image
+*************************
 
 .. http:post:: /images/(name)/insert
 
@@ -608,7 +608,7 @@ Inspect an image
 
 	.. sourcecode:: http
 
-	   GET /images/base/json HTTP/1.1
+	   GET /images/centos/json HTTP/1.1
 
 	**Example response**:
 
@@ -638,7 +638,7 @@ Inspect an image
 				"Env":null,
 				"Cmd": ["/bin/bash"]
 				,"Dns":null,
-				"Image":"base",
+				"Image":"centos",
 				"Volumes":null,
 				"VolumesFrom":""
 			}
@@ -660,7 +660,7 @@ Get the history of an image
 
         .. sourcecode:: http
 
-           GET /images/base/history HTTP/1.1
+           GET /images/fedora/history HTTP/1.1
 
         **Example response**:
 

--- a/docs/sources/api/docker_remote_api_v1.1.rst
+++ b/docs/sources/api/docker_remote_api_v1.1.rst
@@ -49,28 +49,28 @@ List containers
 	   [
 		{
 			"Id": "8dfafdbc3a40",
-			"Image": "base:latest",
+			"Image": "ubuntu:latest",
 			"Command": "echo 1",
 			"Created": 1367854155,
 			"Status": "Exit 0"
 		},
 		{
 			"Id": "9cd87474be90",
-			"Image": "base:latest",
+			"Image": "ubuntu:latest",
 			"Command": "echo 222222",
 			"Created": 1367854155,
 			"Status": "Exit 0"
 		},
 		{
 			"Id": "3176a2479c92",
-			"Image": "base:latest",
+			"Image": "centos:latest",
 			"Command": "echo 3333333333333333",
 			"Created": 1367854154,
 			"Status": "Exit 0"
 		},
 		{
 			"Id": "4cb07b47f9fb",
-			"Image": "base:latest",
+			"Image": "fedora:latest",
 			"Command": "echo 444444444444444444444444444444444",
 			"Created": 1367854152,
 			"Status": "Exit 0"
@@ -117,7 +117,7 @@ Create a container
 			"date"
 		],
 		"Dns":null,
-		"Image":"base",
+		"Image":"ubuntu",
 		"Volumes":{},
 		"VolumesFrom":""
 	   }
@@ -183,7 +183,7 @@ Inspect a container
 					"date"
 				],
 				"Dns": null,
-				"Image": "base",
+				"Image": "ubuntu",
 				"Volumes": {},
 				"VolumesFrom": ""
 			},
@@ -490,14 +490,14 @@ List Images
 	   
 	   [
 		{
-			"Repository":"base",
-			"Tag":"ubuntu-12.10",
+			"Repository":"ubuntu",
+			"Tag":"precise",
 			"Id":"b750fe79269d",
 			"Created":1364102658
 		},
 		{
-			"Repository":"base",
-			"Tag":"ubuntu-quantal",
+			"Repository":"ubuntu",
+			"Tag":"12.04",
 			"Id":"b750fe79269d",
 			"Created":1364102658
 		}
@@ -529,9 +529,9 @@ List Images
 	   "d6434d954665" -> "d82cbacda43a"
 	   base -> "e9aa60c60128" [style=invis]
 	   "074be284591f" -> "f71189fff3de"
-	   "b750fe79269d" [label="b750fe79269d\nbase",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
-	   "e9aa60c60128" [label="e9aa60c60128\nbase2",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
-	   "9a33b36209ed" [label="9a33b36209ed\ntest",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "b750fe79269d" [label="b750fe79269d\nubuntu",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "e9aa60c60128" [label="e9aa60c60128\ncentos",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "9a33b36209ed" [label="9a33b36209ed\nfedora",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
 	   base [style=invisible]
 	   }
  
@@ -552,7 +552,7 @@ Create an image
 
         .. sourcecode:: http
 
-           POST /images/create?fromImage=base HTTP/1.1
+           POST /images/create?fromImage=ubuntu HTTP/1.1
 
         **Example response**:
 
@@ -575,8 +575,8 @@ Create an image
         :statuscode 500: server error
 
 
-Insert a file in a image
-************************
+Insert a file in an image
+*************************
 
 .. http:post:: /images/(name)/insert
 
@@ -615,7 +615,7 @@ Inspect an image
 
 	.. sourcecode:: http
 
-	   GET /images/base/json HTTP/1.1
+	   GET /images/centos/json HTTP/1.1
 
 	**Example response**:
 
@@ -645,7 +645,7 @@ Inspect an image
 				"Env":null,
 				"Cmd": ["/bin/bash"]
 				,"Dns":null,
-				"Image":"base",
+				"Image":"centos",
 				"Volumes":null,
 				"VolumesFrom":""
 			}
@@ -667,7 +667,7 @@ Get the history of an image
 
         .. sourcecode:: http
 
-           GET /images/base/history HTTP/1.1
+           GET /images/fedora/history HTTP/1.1
 
         **Example response**:
 

--- a/docs/sources/api/docker_remote_api_v1.2.rst
+++ b/docs/sources/api/docker_remote_api_v1.2.rst
@@ -49,7 +49,7 @@ List containers
 	   [
 		{
 			"Id": "8dfafdbc3a40",
-			"Image": "base:latest",
+			"Image": "ubuntu:latest",
 			"Command": "echo 1",
 			"Created": 1367854155,
 			"Status": "Exit 0",
@@ -59,7 +59,7 @@ List containers
 		},
 		{
 			"Id": "9cd87474be90",
-			"Image": "base:latest",
+			"Image": "ubuntu:latest",
 			"Command": "echo 222222",
 			"Created": 1367854155,
 			"Status": "Exit 0",
@@ -69,7 +69,7 @@ List containers
 		},
 		{
 			"Id": "3176a2479c92",
-			"Image": "base:latest",
+			"Image": "centos:latest",
 			"Command": "echo 3333333333333333",
 			"Created": 1367854154,
 			"Status": "Exit 0",
@@ -79,7 +79,7 @@ List containers
 		},
 		{
 			"Id": "4cb07b47f9fb",
-			"Image": "base:latest",
+			"Image": "fedora:latest",
 			"Command": "echo 444444444444444444444444444444444",
 			"Created": 1367854152,
 			"Status": "Exit 0",
@@ -129,7 +129,7 @@ Create a container
 			"date"
 		],
 		"Dns":null,
-		"Image":"base",
+		"Image":"ubuntu",
 		"Volumes":{},
 		"VolumesFrom":""
 	   }
@@ -195,7 +195,7 @@ Inspect a container
 					"date"
 				],
 				"Dns": null,
-				"Image": "base",
+				"Image": "ubuntu",
 				"Volumes": {},
 				"VolumesFrom": ""
 			},
@@ -502,16 +502,16 @@ List Images
 	   
 	   [
 		{
-			"Repository":"base",
-			"Tag":"ubuntu-12.10",
+			"Repository":"ubuntu",
+			"Tag":"precise",
 			"Id":"b750fe79269d",
 			"Created":1364102658,
 			"Size":24653,
 			"VirtualSize":180116135
 		},
 		{
-			"Repository":"base",
-			"Tag":"ubuntu-quantal",
+			"Repository":"ubuntu",
+			"Tag":"12.04",
 			"Id":"b750fe79269d",
 			"Created":1364102658,
 			"Size":24653,
@@ -545,9 +545,9 @@ List Images
 	   "d6434d954665" -> "d82cbacda43a"
 	   base -> "e9aa60c60128" [style=invis]
 	   "074be284591f" -> "f71189fff3de"
-	   "b750fe79269d" [label="b750fe79269d\nbase",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
-	   "e9aa60c60128" [label="e9aa60c60128\nbase2",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
-	   "9a33b36209ed" [label="9a33b36209ed\ntest",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "b750fe79269d" [label="b750fe79269d\nubuntu",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "e9aa60c60128" [label="e9aa60c60128\ncentos",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "9a33b36209ed" [label="9a33b36209ed\nfedora",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
 	   base [style=invisible]
 	   }
  
@@ -568,7 +568,7 @@ Create an image
 
         .. sourcecode:: http
 
-           POST /images/create?fromImage=base HTTP/1.1
+           POST /images/create?fromImage=ubuntu HTTP/1.1
 
         **Example response**:
 
@@ -591,8 +591,8 @@ Create an image
         :statuscode 500: server error
 
 
-Insert a file in a image
-************************
+Insert a file in an image
+*************************
 
 .. http:post:: /images/(name)/insert
 
@@ -631,7 +631,7 @@ Inspect an image
 
 	.. sourcecode:: http
 
-	   GET /images/base/json HTTP/1.1
+	   GET /images/centos/json HTTP/1.1
 
 	**Example response**:
 
@@ -661,7 +661,7 @@ Inspect an image
 				"Env":null,
 				"Cmd": ["/bin/bash"]
 				,"Dns":null,
-				"Image":"base",
+				"Image":"centos",
 				"Volumes":null,
 				"VolumesFrom":""
 			},
@@ -684,7 +684,7 @@ Get the history of an image
 
         .. sourcecode:: http
 
-           GET /images/base/history HTTP/1.1
+           GET /images/fedora/history HTTP/1.1
 
         **Example response**:
 
@@ -696,7 +696,7 @@ Get the history of an image
 	   [
 		{
 			"Id":"b750fe79269d",
-			"Tag":["base:latest"],
+			"Tag":["ubuntu:latest"],
 			"Created":1364102658,
 			"CreatedBy":"/bin/bash"
 		},

--- a/docs/sources/api/docker_remote_api_v1.3.rst
+++ b/docs/sources/api/docker_remote_api_v1.3.rst
@@ -49,7 +49,7 @@ List containers
 	   [
 		{
 			"Id": "8dfafdbc3a40",
-			"Image": "base:latest",
+			"Image": "ubuntu:latest",
 			"Command": "echo 1",
 			"Created": 1367854155,
 			"Status": "Exit 0",
@@ -59,7 +59,7 @@ List containers
 		},
 		{
 			"Id": "9cd87474be90",
-			"Image": "base:latest",
+			"Image": "ubuntu:latest",
 			"Command": "echo 222222",
 			"Created": 1367854155,
 			"Status": "Exit 0",
@@ -69,7 +69,7 @@ List containers
 		},
 		{
 			"Id": "3176a2479c92",
-			"Image": "base:latest",
+			"Image": "centos:latest",
 			"Command": "echo 3333333333333333",
 			"Created": 1367854154,
 			"Status": "Exit 0",
@@ -79,7 +79,7 @@ List containers
 		},
 		{
 			"Id": "4cb07b47f9fb",
-			"Image": "base:latest",
+			"Image": "fedora:latest",
 			"Command": "echo 444444444444444444444444444444444",
 			"Created": 1367854152,
 			"Status": "Exit 0",
@@ -130,7 +130,7 @@ Create a container
 			"date"
 		],
 		"Dns":null,
-		"Image":"base",
+		"Image":"ubuntu",
 		"Volumes":{},
 		"VolumesFrom":""
 	   }
@@ -196,7 +196,7 @@ Inspect a container
 					"date"
 				],
 				"Dns": null,
-				"Image": "base",
+				"Image": "ubuntu",
 				"Volumes": {},
 				"VolumesFrom": ""
 			},
@@ -550,16 +550,16 @@ List Images
 	   
 	   [
 		{
-			"Repository":"base",
-			"Tag":"ubuntu-12.10",
+			"Repository":"ubuntu",
+			"Tag":"precise",
 			"Id":"b750fe79269d",
 			"Created":1364102658,
 			"Size":24653,
 			"VirtualSize":180116135
 		},
 		{
-			"Repository":"base",
-			"Tag":"ubuntu-quantal",
+			"Repository":"ubuntu",
+			"Tag":"12.04",
 			"Id":"b750fe79269d",
 			"Created":1364102658,
 			"Size":24653,
@@ -593,9 +593,9 @@ List Images
 	   "d6434d954665" -> "d82cbacda43a"
 	   base -> "e9aa60c60128" [style=invis]
 	   "074be284591f" -> "f71189fff3de"
-	   "b750fe79269d" [label="b750fe79269d\nbase",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
-	   "e9aa60c60128" [label="e9aa60c60128\nbase2",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
-	   "9a33b36209ed" [label="9a33b36209ed\ntest",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "b750fe79269d" [label="b750fe79269d\nubuntu",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "e9aa60c60128" [label="e9aa60c60128\ncentos",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "9a33b36209ed" [label="9a33b36209ed\nfedora",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
 	   base [style=invisible]
 	   }
  
@@ -616,7 +616,7 @@ Create an image
 
         .. sourcecode:: http
 
-           POST /images/create?fromImage=base HTTP/1.1
+           POST /images/create?fromImage=ubuntu HTTP/1.1
 
         **Example response**:
 
@@ -639,8 +639,8 @@ Create an image
         :statuscode 500: server error
 
 
-Insert a file in a image
-************************
+Insert a file in an image
+*************************
 
 .. http:post:: /images/(name)/insert
 
@@ -679,7 +679,7 @@ Inspect an image
 
 	.. sourcecode:: http
 
-	   GET /images/base/json HTTP/1.1
+	   GET /images/centos/json HTTP/1.1
 
 	**Example response**:
 
@@ -709,7 +709,7 @@ Inspect an image
 				"Env":null,
 				"Cmd": ["/bin/bash"]
 				,"Dns":null,
-				"Image":"base",
+				"Image":"centos",
 				"Volumes":null,
 				"VolumesFrom":""
 			},
@@ -732,7 +732,7 @@ Get the history of an image
 
         .. sourcecode:: http
 
-           GET /images/base/history HTTP/1.1
+           GET /images/fedora/history HTTP/1.1
 
         **Example response**:
 

--- a/docs/sources/api/docker_remote_api_v1.4.rst
+++ b/docs/sources/api/docker_remote_api_v1.4.rst
@@ -46,7 +46,7 @@ List containers
 	   [
 		{
 			"Id": "8dfafdbc3a40",
-			"Image": "base:latest",
+			"Image": "ubuntu:latest",
 			"Command": "echo 1",
 			"Created": 1367854155,
 			"Status": "Exit 0",
@@ -56,7 +56,7 @@ List containers
 		},
 		{
 			"Id": "9cd87474be90",
-			"Image": "base:latest",
+			"Image": "ubuntu:latest",
 			"Command": "echo 222222",
 			"Created": 1367854155,
 			"Status": "Exit 0",
@@ -66,7 +66,7 @@ List containers
 		},
 		{
 			"Id": "3176a2479c92",
-			"Image": "base:latest",
+			"Image": "centos:latest",
 			"Command": "echo 3333333333333333",
 			"Created": 1367854154,
 			"Status": "Exit 0",
@@ -76,7 +76,7 @@ List containers
 		},
 		{
 			"Id": "4cb07b47f9fb",
-			"Image": "base:latest",
+			"Image": "fedora:latest",
 			"Command": "echo 444444444444444444444444444444444",
 			"Created": 1367854152,
 			"Status": "Exit 0",
@@ -128,7 +128,7 @@ Create a container
 			"date"
 		],
 		"Dns":null,
-		"Image":"base",
+		"Image":"ubuntu",
 		"Volumes":{},
 		"VolumesFrom":"",
 		"WorkingDir":""
@@ -196,7 +196,7 @@ Inspect a container
 					"date"
 				],
 				"Dns": null,
-				"Image": "base",
+				"Image": "ubuntu",
 				"Volumes": {},
 				"VolumesFrom": "",
 				"WorkingDir":""
@@ -592,16 +592,16 @@ List Images
 	   
 	   [
 		{
-			"Repository":"base",
-			"Tag":"ubuntu-12.10",
+			"Repository":"ubuntu",
+			"Tag":"precise",
 			"Id":"b750fe79269d",
 			"Created":1364102658,
 			"Size":24653,
 			"VirtualSize":180116135
 		},
 		{
-			"Repository":"base",
-			"Tag":"ubuntu-quantal",
+			"Repository":"ubuntu",
+			"Tag":"12.04",
 			"Id":"b750fe79269d",
 			"Created":1364102658,
 			"Size":24653,
@@ -635,9 +635,9 @@ List Images
 	   "d6434d954665" -> "d82cbacda43a"
 	   base -> "e9aa60c60128" [style=invis]
 	   "074be284591f" -> "f71189fff3de"
-	   "b750fe79269d" [label="b750fe79269d\nbase",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
-	   "e9aa60c60128" [label="e9aa60c60128\nbase2",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
-	   "9a33b36209ed" [label="9a33b36209ed\ntest",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "b750fe79269d" [label="b750fe79269d\nubuntu",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "e9aa60c60128" [label="e9aa60c60128\ncentos",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "9a33b36209ed" [label="9a33b36209ed\nfedora",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
 	   base [style=invisible]
 	   }
  
@@ -658,7 +658,7 @@ Create an image
 
         .. sourcecode:: http
 
-           POST /images/create?fromImage=base HTTP/1.1
+           POST /images/create?fromImage=ubuntu HTTP/1.1
 
         **Example response**:
 
@@ -721,7 +721,7 @@ Inspect an image
 
 	.. sourcecode:: http
 
-	   GET /images/base/json HTTP/1.1
+	   GET /images/centos/json HTTP/1.1
 
 	**Example response**:
 
@@ -751,7 +751,7 @@ Inspect an image
 				"Env":null,
 				"Cmd": ["/bin/bash"]
 				,"Dns":null,
-				"Image":"base",
+				"Image":"centos",
 				"Volumes":null,
 				"VolumesFrom":"",
 				"WorkingDir":""
@@ -776,7 +776,7 @@ Get the history of an image
 
         .. sourcecode:: http
 
-           GET /images/base/history HTTP/1.1
+           GET /images/fedora/history HTTP/1.1
 
         **Example response**:
 
@@ -1126,10 +1126,10 @@ Monitor Docker's events
            HTTP/1.1 200 OK
 	   Content-Type: application/json
 
-	   {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-	   {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-	   {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-	   {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+	   {"status":"create","id":"dfdf82bd3881","from":"ubuntu:latest","time":1374067924}
+	   {"status":"start","id":"dfdf82bd3881","from":"ubuntu:latest","time":1374067924}
+	   {"status":"stop","id":"dfdf82bd3881","from":"ubuntu:latest","time":1374067966}
+	   {"status":"destroy","id":"dfdf82bd3881","from":"ubuntu:latest","time":1374067970}
 
 	:query since: timestamp used for polling
         :statuscode 200: no error

--- a/docs/sources/api/docker_remote_api_v1.5.rst
+++ b/docs/sources/api/docker_remote_api_v1.5.rst
@@ -46,7 +46,7 @@ List containers
 	   [
 		{
 			"Id": "8dfafdbc3a40",
-			"Image": "base:latest",
+			"Image": "ubuntu:latest",
 			"Command": "echo 1",
 			"Created": 1367854155,
 			"Status": "Exit 0",
@@ -56,7 +56,7 @@ List containers
 		},
 		{
 			"Id": "9cd87474be90",
-			"Image": "base:latest",
+			"Image": "ubuntu:latest",
 			"Command": "echo 222222",
 			"Created": 1367854155,
 			"Status": "Exit 0",
@@ -66,7 +66,7 @@ List containers
 		},
 		{
 			"Id": "3176a2479c92",
-			"Image": "base:latest",
+			"Image": "centos:latest",
 			"Command": "echo 3333333333333333",
 			"Created": 1367854154,
 			"Status": "Exit 0",
@@ -76,7 +76,7 @@ List containers
 		},
 		{
 			"Id": "4cb07b47f9fb",
-			"Image": "base:latest",
+			"Image": "fedora:latest",
 			"Command": "echo 444444444444444444444444444444444",
 			"Created": 1367854152,
 			"Status": "Exit 0",
@@ -128,7 +128,7 @@ Create a container
 			"date"
 		],
 		"Dns":null,
-		"Image":"base",
+		"Image":"ubuntu",
 		"Volumes":{},
 		"VolumesFrom":"",
 		"WorkingDir":""
@@ -196,7 +196,7 @@ Inspect a container
 					"date"
 				],
 				"Dns": null,
-				"Image": "base",
+				"Image": "ubuntu",
 				"Volumes": {},
 				"VolumesFrom": "",
 				"WorkingDir":""
@@ -591,16 +591,16 @@ List Images
 	   
 	   [
 		{
-			"Repository":"base",
-			"Tag":"ubuntu-12.10",
+			"Repository":"ubuntu",
+			"Tag":"precise",
 			"Id":"b750fe79269d",
 			"Created":1364102658,
 			"Size":24653,
 			"VirtualSize":180116135
 		},
 		{
-			"Repository":"base",
-			"Tag":"ubuntu-quantal",
+			"Repository":"ubuntu",
+			"Tag":"12.04",
 			"Id":"b750fe79269d",
 			"Created":1364102658,
 			"Size":24653,
@@ -634,9 +634,9 @@ List Images
 	   "d6434d954665" -> "d82cbacda43a"
 	   base -> "e9aa60c60128" [style=invis]
 	   "074be284591f" -> "f71189fff3de"
-	   "b750fe79269d" [label="b750fe79269d\nbase",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
-	   "e9aa60c60128" [label="e9aa60c60128\nbase2",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
-	   "9a33b36209ed" [label="9a33b36209ed\ntest",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "b750fe79269d" [label="b750fe79269d\nubuntu",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "e9aa60c60128" [label="e9aa60c60128\ncentos",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
+	   "9a33b36209ed" [label="9a33b36209ed\nfedora",shape=box,fillcolor="paleturquoise",style="filled,rounded"];
 	   base [style=invisible]
 	   }
  
@@ -657,7 +657,7 @@ Create an image
 
         .. sourcecode:: http
 
-           POST /images/create?fromImage=base HTTP/1.1
+           POST /images/create?fromImage=ubuntu HTTP/1.1
 
         **Example response**:
 
@@ -724,7 +724,7 @@ Inspect an image
 
 	.. sourcecode:: http
 
-	   GET /images/base/json HTTP/1.1
+	   GET /images/centos/json HTTP/1.1
 
 	**Example response**:
 
@@ -754,7 +754,7 @@ Inspect an image
 				"Env":null,
 				"Cmd": ["/bin/bash"]
 				,"Dns":null,
-				"Image":"base",
+				"Image":"centos",
 				"Volumes":null,
 				"VolumesFrom":"",
 				"WorkingDir":""
@@ -778,7 +778,7 @@ Get the history of an image
 
         .. sourcecode:: http
 
-           GET /images/base/history HTTP/1.1
+           GET /images/fedora/history HTTP/1.1
 
         **Example response**:
 
@@ -1131,10 +1131,10 @@ Monitor Docker's events
            HTTP/1.1 200 OK
 	   Content-Type: application/json
 
-	   {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-	   {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-	   {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-	   {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+	   {"status":"create","id":"dfdf82bd3881","from":"ubuntu:latest","time":1374067924}
+	   {"status":"start","id":"dfdf82bd3881","from":"ubuntu:latest","time":1374067924}
+	   {"status":"stop","id":"dfdf82bd3881","from":"ubuntu:latest","time":1374067966}
+	   {"status":"destroy","id":"dfdf82bd3881","from":"ubuntu:latest","time":1374067970}
 
 	:query since: timestamp used for polling
         :statuscode 200: no error

--- a/docs/sources/api/index_api.rst
+++ b/docs/sources/api/index_api.rst
@@ -541,10 +541,11 @@ Search
       Content-Type: application/json
 
       {"query":"search_term",
-        "num_results": 2,
+        "num_results": 3,
         "results" : [
-           {"name": "dotcloud/base", "description": "A base ubuntu64  image..."},
-           {"name": "base2", "description": "A base ubuntu64  image..."},
+           {"name": "ubuntu", "description": "An ubuntu image..."},
+           {"name": "centos", "description": "A centos image..."},
+           {"name": "fedora", "description": "A fedora image..."}
          ]
        }
 

--- a/docs/sources/examples/running_ssh_service.rst
+++ b/docs/sources/examples/running_ssh_service.rst
@@ -47,7 +47,7 @@ The password is 'screencast'
          # I had it so it was quick
          # now let's connect using -i for interactive and with -t for terminal 
          # we execute /bin/bash to get a prompt.
-         $ docker run -i -t base /bin/bash
+         $ docker run -i -t ubuntu /bin/bash
          # yes! we are in!
          # now lets install openssh
          $ apt-get update

--- a/docs/sources/use/baseimages.rst
+++ b/docs/sources/use/baseimages.rst
@@ -37,7 +37,5 @@ There are more example scripts for creating base images in the
 Docker Github Repo:
 
 * `BusyBox <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-busybox.sh>`_
-* `CentOS
-  <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-centos.sh>`_
 * `Debian
   <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-debian.sh>`_


### PR DESCRIPTION
Was discussing the `base` repository with @shykes on IRC and we found a few more references to it within docs.  While I was looking over them, I saw a few more small issues that needed fixing, so I took care of those also (such as backporting a small grammar fix across all the remote api docs and removing a reference on the baseimages page to a contrib/mkimage-centos.sh that doesn't exist).
