### PR TITLE
Re-enable CGO but keep docker statically linked

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,38 +21,48 @@
 # -e AWS_SECRET_KEY=bar \
 # -e GPG_PASSPHRASE=gloubiboulga \
 # -lxc-conf=lxc.aa_profile=unconfined -privileged docker hack/release.sh
-# 
+#
 
-docker-version 0.6.1
-from	ubuntu:12.04
+docker-version	0.6.2
+from		ubuntu:12.04
 maintainer	Solomon Hykes <solomon@dotcloud.com>
+
 # Build dependencies
 run	echo 'deb http://archive.ubuntu.com/ubuntu precise main universe' > /etc/apt/sources.list
 run	apt-get update
 run	apt-get install -y -q curl
 run	apt-get install -y -q git
 run	apt-get install -y -q mercurial
-# Install Go
-run	curl -s https://go.googlecode.com/files/go1.1.2.linux-amd64.tar.gz | tar -v -C /usr/local -xz
-env	PATH	/usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
-env	GOPATH	/go:/go/src/github.com/dotcloud/docker/vendor
-env	CGO_ENABLED 0
-run	cd /tmp && echo 'package main' > t.go && go test -a -i -v
+run	apt-get install -y -q gcc build-essential
+
+# Install Go // FIXME: Requires go1.1.3 (no released yet, so we use tip)
+run	hg clone https://code.google.com/p/go /goroot
+run	cd /goroot/src && ./all.bash
+
+env	PATH	 /goroot/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
+env	GOROOT	 /goroot
+env	GOPATH	 /go:/go/src/github.com/dotcloud/docker/vendor
+
 # Ubuntu stuff
 run	apt-get install -y -q ruby1.9.3 rubygems libffi-dev
 run	gem install fpm
 run	apt-get install -y -q reprepro dpkg-sig
+
 # Install s3cmd 1.0.1 (earlier versions don't support env variables in the config)
 run	apt-get install -y -q python-pip
 run	pip install s3cmd
 run	pip install python-magic
 run	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_KEY\n' > /.s3cfg
+
 # Runtime dependencies
 run	apt-get install -y -q iptables
 run	apt-get install -y -q lxc
 volume	/var/lib/docker
 workdir	/go/src/github.com/dotcloud/docker
+
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 entrypoint ["hack/dind"]
+
 # Upload docker source
 add	.       /go/src/github.com/dotcloud/docker
+

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -25,9 +25,9 @@ set -e
 # but really, they shouldn't. We want to be in a container!
 RESOLVCONF=$(readlink --canonicalize /etc/resolv.conf)
 grep -q "$RESOLVCONF" /proc/mounts || {
-	echo "# WARNING! I don't seem to be running in a docker container.
+	echo "# WARNING! I don't seem to be running in a docker container."
 	echo "# The result of this command might be an incorrect build, and will not be officially supported."
-	echo "# Try this: 'docker build -t docker . && docker run docker ./hack/make.sh'
+	echo "# Try this: 'docker build -t docker . && docker run docker ./hack/make.sh'"
 }
 
 # List of bundles to create when no argument is passed
@@ -45,8 +45,8 @@ then
 fi
 
 # Use these flags when compiling the tests and final binary
-LDFLAGS="-X main.GITCOMMIT $GITCOMMIT -X main.VERSION $VERSION -d -w"
-
+LDFLAGS='-X main.GITCOMMIT '$GITCOMMIT' -X main.VERSION '$VERSION' -w -linkmode external -extldflags "-static -Wl,--unresolved-symbols=ignore-in-shared-libs"'
+BUILDFLAGS='-tags netgo'
 
 bundle() {
 	bundlescript=$1

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -1,4 +1,4 @@
 
 DEST=$1
 
-go build -o $DEST/docker-$VERSION -ldflags "$LDFLAGS" ./docker
+go build -o $DEST/docker-$VERSION -ldflags $LDFLAGS $BUILDFLAGS ./docker

--- a/hack/make/test
+++ b/hack/make/test
@@ -6,10 +6,12 @@ set -e
 bundle_test() {
 	{
 		date
-		for test_dir in $(find_test_dirs); do (
-			set -x
+		dirs=$(find_test_dirs)
+		set -x
+		go install -ldflags "$LDFLAGS" $BUILDFLAGS -a std
+		for test_dir in $dirs; do (
 			cd $test_dir
-			go test -v -ldflags "$LDFLAGS"
+			go test -v -ldflags "$LDFLAGS" $BUILDFLAGS
 		)  done
 	} 2>&1 | tee $DEST/test.log
 }


### PR DESCRIPTION
This change requires go1.1.3 which is not yet release. The dockerfile uses tip.
