### PR TITLE
added -i option to ps to filter results by image name

### DIFF
--- a/api.go
+++ b/api.go
@@ -322,12 +322,13 @@ func getContainersJSON(srv *Server, version float64, w http.ResponseWriter, r *h
 	}
 	since := r.Form.Get("since")
 	before := r.Form.Get("before")
+	imageFilter := r.Form.Get("imageFilter")
 	n, err := strconv.Atoi(r.Form.Get("limit"))
 	if err != nil {
 		n = -1
 	}
 
-	outs := srv.Containers(all, size, n, since, before)
+	outs := srv.Containers(all, size, n, since, before, imageFilter)
 
 	if version < 1.5 {
 		outs2 := []APIContainersOld{}

--- a/commands.go
+++ b/commands.go
@@ -1141,7 +1141,7 @@ func displayablePorts(ports []APIPort) string {
 }
 
 func (cli *DockerCli) CmdPs(args ...string) error {
-	cmd := Subcmd("ps", "[OPTIONS]", "List containers")
+	cmd := Subcmd("ps", "[OPTIONS] [IMAGENAME]", "List containers")
 	quiet := cmd.Bool("q", false, "Only display numeric IDs")
 	size := cmd.Bool("s", false, "Display sizes")
 	all := cmd.Bool("a", false, "Show all containers. Only running containers are shown by default.")
@@ -1172,6 +1172,9 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 	}
 	if *size {
 		v.Set("size", "1")
+	}
+	if cmd.NArg() > 0 {
+		v.Set("imageFilter", cmd.Arg(0))
 	}
 
 	body, _, err := cli.call("GET", "/containers/json?"+v.Encode(), nil)

--- a/server.go
+++ b/server.go
@@ -441,7 +441,7 @@ func (srv *Server) ContainerChanges(name string) ([]Change, error) {
 	return nil, fmt.Errorf("No such container: %s", name)
 }
 
-func (srv *Server) Containers(all, size bool, n int, since, before string) []APIContainers {
+func (srv *Server) Containers(all, size bool, n int, since, before, imageFilter string) []APIContainers {
 	var foundBefore bool
 	var displayed int
 	out := []APIContainers{}
@@ -464,6 +464,12 @@ func (srv *Server) Containers(all, size bool, n int, since, before string) []API
 		}
 		if container.ShortID() == since {
 			break
+		}
+		imageName := srv.runtime.repositories.ImageName(container.Image)
+		if imageFilter != "" {
+			if matches, _ := path.Match(imageFilter, imageName); !matches {
+				continue
+			}
 		}
 		displayed++
 		c := createAPIContainer(container, size, srv.runtime)


### PR DESCRIPTION
Added option to ps command which allows you to filter results by the image name containers are based on. This can be used in conjunction with the rm command to easily delete groups of containers. For example, this would delete all containers based on any ubuntu image.

```
docker ps -a -q -i ubuntu* | xargs docker rm
```

The parameter is interpreted using the path.Match function, so wildcards are allowed. path.Match is used instead of regexp.MatchString to mirror the functionality of the image filter in https://github.com/dotcloud/docker/pull/1817.
