### PR TITLE
Add proper bash completion for "docker push"

### DIFF
--- a/contrib/docker.bash
+++ b/contrib/docker.bash
@@ -341,7 +341,7 @@ _docker_pull()
 
 _docker_push()
 {
-	return
+	__docker_image_repos
 }
 
 _docker_restart()


### PR DESCRIPTION
Simple enough change.  We probably need to also go through this completion file and make sure it's got all the flags from the latest code, but our flag logic will have to change anyhow for #1775 (getopt), so it's probably best if we just wait for that to merge before we take the time to vet this whole file.
