### PR TITLE
Packaging a container for software distribution

### DIFF
--- a/api.go
+++ b/api.go
@@ -497,6 +497,17 @@ func postImagesPush(srv *Server, version float64, w http.ResponseWriter, r *http
 	return nil
 }
 
+func getImagesGet(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	name := vars["name"]
+	srv.ImageExport(name, w)
+	return nil
+}
+
+func postImagesLoad(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	srv.ImageLoad(r.Body, w)
+	return nil
+}
+
 func postContainersCreate(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	config := &Config{}
 	out := &APIRun{}
@@ -987,6 +998,7 @@ func createRouter(srv *Server, logging bool) (*mux.Router, error) {
 			"/images/json":                    getImagesJSON,
 			"/images/viz":                     getImagesViz,
 			"/images/search":                  getImagesSearch,
+			"/images/{name:.*}/get":           getImagesGet,
 			"/images/{name:.*}/history":       getImagesHistory,
 			"/images/{name:.*}/json":          getImagesByName,
 			"/containers/ps":                  getContainersJSON,
@@ -1003,6 +1015,7 @@ func createRouter(srv *Server, logging bool) (*mux.Router, error) {
 			"/build":                        postBuild,
 			"/images/create":                postImagesCreate,
 			"/images/{name:.*}/insert":      postImagesInsert,
+			"/images/load":                  postImagesLoad,
 			"/images/{name:.*}/push":        postImagesPush,
 			"/images/{name:.*}/tag":         postImagesTag,
 			"/containers/create":            postContainersCreate,

--- a/commands.go
+++ b/commands.go
@@ -91,6 +91,7 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 		{"insert", "Insert a file in an image"},
 		{"inspect", "Return low-level information on a container"},
 		{"kill", "Kill a running container"},
+		{"load", "Load an image from a tar archive"},
 		{"login", "Register or Login to the docker registry server"},
 		{"logs", "Fetch the logs of a container"},
 		{"port", "Lookup the public-facing port which is NAT-ed to PRIVATE_PORT"},
@@ -102,6 +103,7 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 		{"rm", "Remove one or more containers"},
 		{"rmi", "Remove one or more images"},
 		{"run", "Run a command in a new container"},
+		{"save", "Save an image to a tar archive"},
 		{"search", "Search for an image in the docker index"},
 		{"start", "Start a stopped container"},
 		{"stop", "Stop a running container"},
@@ -1611,6 +1613,42 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func (cli *DockerCli) CmdSave(args ...string) error {
+	cmd := Subcmd("save", "IMAGE DESTINATION", "Save an image to a tar archive")
+	if err := cmd.Parse(args); err != nil {
+		cmd.Usage()
+		return nil
+	}
+
+	if cmd.NArg() != 1 {
+		cmd.Usage()
+		return nil
+	}
+
+	image := cmd.Arg(0)
+
+	if err := cli.stream("GET", "/images/"+image+"/get", nil, cli.out, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (cli *DockerCli) CmdLoad(args ...string) error {
+	cmd := Subcmd("load", "SOURCE", "Load an image from a tar archive")
+
+	if cmd.NArg() != 0 {
+		cmd.Usage()
+		return nil
+	}
+
+	err := cli.stream("POST", "/images/load", cli.in, cli.out, nil)
+	if err != nil {
+		fmt.Println("Send failed", err)
+	}
+
 	return nil
 }
 

--- a/server.go
+++ b/server.go
@@ -101,6 +101,148 @@ func (srv *Server) ContainerExport(name string, out io.Writer) error {
 	return fmt.Errorf("No such container: %s", name)
 }
 
+func (srv *Server) ImageExport(name string, out io.Writer) error {
+	// get image json
+	tempdir, err := ioutil.TempDir("", "docker-export-")
+	if err != nil {
+		utils.Debugf("save", name, "")
+		return err
+	}
+	utils.Debugf("Serializing %s", name)
+
+	rootRepo := srv.runtime.repositories.Repositories[name]
+	for _, rootImage := range rootRepo {
+		image, _ := srv.ImageInspect(rootImage)
+		for i := image; i != nil; {
+			// temporary directory
+			tmpImageDir := path.Join(tempdir, i.ID)
+			os.Mkdir(tmpImageDir, os.ModeDir)
+
+			// serialize json
+			b, err := json.Marshal(i)
+			if err != nil {
+				utils.Debugf("%s", err)
+				os.RemoveAll(tempdir)
+				return err
+			}
+			ioutil.WriteFile(path.Join(tmpImageDir, "json"), b, os.ModeAppend)
+
+			// serialize filesystem
+			fs, err := Tar(path.Join(srv.runtime.graph.Root, i.ID, "layer"), Uncompressed)
+			if err != nil {
+				utils.Debugf("%s", err)
+				os.RemoveAll(tempdir)
+				return err
+			}
+			fsTar, err := os.Create(path.Join(tmpImageDir, "layer.tar"))
+			if err != nil {
+				os.RemoveAll(tempdir)
+				utils.Debugf("%s", err)
+				return err
+			}
+			_, err = io.Copy(fsTar, fs)
+			if err != nil {
+				utils.Debugf("%s", err)
+				os.RemoveAll(tempdir)
+				return err
+			}
+			fsTar.Close()
+
+			// find parent
+			if i.Parent != "" {
+				i, err = srv.ImageInspect(i.Parent)
+				if err != nil {
+					utils.Debugf("%s", err)
+					os.RemoveAll(tempdir)
+					return err
+				}
+			} else {
+				i = nil
+			}
+		}
+	}
+
+	// write repositories
+	rootRepoMap := map[string]Repository{}
+	rootRepoMap[name] = rootRepo
+	rootRepoJson, _ := json.Marshal(rootRepoMap)
+
+	ioutil.WriteFile(path.Join(tempdir, "repositories"), rootRepoJson, os.ModeAppend)
+
+	fs, err := Tar(tempdir, Uncompressed)
+	if err != nil {
+		os.RemoveAll(tempdir)
+		return err
+	}
+	if _, err := io.Copy(out, fs); err != nil {
+		os.RemoveAll(tempdir)
+		return err
+	}
+	os.RemoveAll(tempdir)
+	return nil
+}
+
+func (srv *Server) ImageLoad(in io.Reader, out io.Writer) error {
+	tmpImageDir, _ := ioutil.TempDir("", "docker-import-")
+	repoTarFile := path.Join(tmpImageDir, "repo.tar")
+	repoDir := path.Join(tmpImageDir, "repo")
+	tarFile, _ := os.Create(repoTarFile)
+	io.Copy(tarFile, in)
+	tarFile.Close()
+	repoFile, _ := os.Open(repoTarFile)
+	os.Mkdir(repoDir, os.ModeDir)
+	Untar(repoFile, repoDir)
+	repositoriesJson, _ := ioutil.ReadFile(path.Join(tmpImageDir, "repo", "repositories"))
+	repositories := map[string]Repository{}
+	json.Unmarshal(repositoriesJson, &repositories)
+
+	for imageName, tagMap := range repositories {
+		for tag, address := range tagMap {
+			err := srv.recursiveLoad(address, tmpImageDir)
+			if err != nil {
+				utils.Debugf("Error loading repository")
+			}
+			srv.runtime.repositories.Set(imageName, tag, address, true)
+		}
+	}
+	os.RemoveAll(tmpImageDir)
+	return nil
+}
+
+func (srv *Server) recursiveLoad(address, tmpImageDir string) error {
+	_, err := srv.ImageInspect(address)
+	utils.Debugf("Attempting to load %s", "address")
+	if err != nil {
+		utils.Debugf("Loading %s", address)
+		imageJson, err := ioutil.ReadFile(path.Join(tmpImageDir, "repo", address, "json"))
+		if err != nil {
+			return err
+			utils.Debugf("Error reading json", err)
+		}
+		layer, err := os.Open(path.Join(tmpImageDir, "repo", address, "layer.tar"))
+		if err != nil {
+			utils.Debugf("Error reading embedded tar", err)
+			return err
+		}
+		img, err := NewImgJSON(imageJson)
+		if err != nil {
+			utils.Debugf("Error unmarshalling json", err)
+			return err
+		}
+		if img.Parent != "" {
+			if !srv.runtime.graph.Exists(img.Parent) {
+				srv.recursiveLoad(img.Parent, tmpImageDir)
+			}
+		}
+		err = srv.runtime.graph.Register(imageJson, layer, img)
+		if err != nil {
+			utils.Debugf("Error registering image")
+		}
+	}
+	utils.Debugf("Completed processing %s", address)
+	return nil
+}
+
 func (srv *Server) ImagesSearch(term string) ([]APISearch, error) {
 	r, err := registry.NewRegistry(srv.runtime.root, nil, srv.HTTPRequestFactory(nil))
 	if err != nil {


### PR DESCRIPTION
I'm planning to use Docker to ship software to my customers. Therefore, I need to be able to export an image (including metadata like RUN and EXPOSE) as a file.

Running a registry will not work for my purposes because the software needs to be installable without Internet access.

Docker currently has import/export commands, but there are a few issues with them:
- They work on a container, not an image
- They only import/export root filesystems, therefore metadata is lost

Perhaps an API for this could be:

```
docker package IMAGE_ID > my_software.docker
```

And then either:

```
docker run my_software.docker
```

Or:

```
docker import my_software.docker my_software
docker run my_software
```

I realize this issue may be a bit of a cross section of a few different features, but I couldn't find any existing issues describing this idea.
