### PR TITLE
Adding more tests around `auth.ResolveAuthConfig`

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -75,20 +75,31 @@ func TestCreateAccount(t *testing.T) {
 	}
 }
 
-func TestSameAuthDataPostSave(t *testing.T) {
+func setupTempConfigFile() (*ConfigFile, error) {
 	root, err := ioutil.TempDir("", "docker-test")
 	if err != nil {
-		t.Fatal(err)
+		return nil, err
 	}
 	configFile := &ConfigFile{
 		rootPath: root,
-		Configs:  make(map[string]AuthConfig, 1),
+		Configs:  make(map[string]AuthConfig),
 	}
 
-	configFile.Configs["testIndex"] = AuthConfig{
-		Username: "docker-user",
-		Password: "docker-pass",
-		Email:    "docker@docker.io",
+	for _, registry := range []string{"testIndex", IndexServerAddress()} {
+		configFile.Configs[registry] = AuthConfig{
+			Username: "docker-user",
+			Password: "docker-pass",
+			Email:    "docker@docker.io",
+		}
+	}
+
+	return configFile, nil
+}
+
+func TestSameAuthDataPostSave(t *testing.T) {
+	configFile, err := setupTempConfigFile()
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	err = SaveConfig(configFile)
@@ -108,5 +119,70 @@ func TestSameAuthDataPostSave(t *testing.T) {
 	}
 	if authConfig.Auth != "" {
 		t.Fail()
+	}
+}
+
+func TestResolveAuthConfigIndexServer(t *testing.T) {
+	configFile, err := setupTempConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, registry := range []string{"", IndexServerAddress()} {
+		resolved := configFile.ResolveAuthConfig(registry)
+		if resolved != configFile.Configs[IndexServerAddress()] {
+			t.Fail()
+		}
+	}
+}
+
+func TestResolveAuthConfigFullURL(t *testing.T) {
+	configFile, err := setupTempConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	registryAuth := AuthConfig{
+		Username: "foo-user",
+		Password: "foo-pass",
+		Email:    "foo@example.com",
+	}
+	localAuth := AuthConfig{
+		Username: "bar-user",
+		Password: "bar-pass",
+		Email:    "bar@example.com",
+	}
+	configFile.Configs["https://registry.example.com/v1/"] = registryAuth
+	configFile.Configs["http://localhost:8000/v1/"] = localAuth
+
+	validRegistries := map[string][]string{
+		"https://registry.example.com/v1/": {
+			"https://registry.example.com/v1/",
+			"http://registry.example.com/v1/",
+			"registry.example.com",
+			"registry.example.com/v1/",
+		},
+		"http://localhost:8000/v1/": {
+			"https://localhost:8000/v1/",
+			"http://localhost:8000/v1/",
+			"localhost:8000",
+			"localhost:8000/v1/",
+		},
+	}
+
+	for configKey, registries := range validRegistries {
+		for _, registry := range registries {
+			var (
+				configured AuthConfig
+				ok         bool
+			)
+			resolved := configFile.ResolveAuthConfig(registry)
+			if configured, ok = configFile.Configs[configKey]; !ok {
+				t.Fail()
+			}
+			if resolved.Email != configured.Email {
+				t.Errorf("%s -> %q != %q\n", registry, resolved.Email, configured.Email)
+			}
+		}
 	}
 }


### PR DESCRIPTION
mostly because I've been failing at getting docker `0.6.2` working with docker-registry `0.6.0` with regard to login and push.  I suspect there may be some mismatched expectations between `auth.ResolveAuthConfig` and `registry.ResolveRepositoryName`, but I haven't done enough research or experimentation to think it's anything more than user error.  More tests are good, no?
