### PR TITLE
Add cross compilation to the standard build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,10 @@ volume	/var/lib/docker
 workdir	/go/src/github.com/dotcloud/docker
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
-entrypoint ["hack/dind"]
+entrypoint	["hack/dind"]
 
 # Upload docker source
-add	.       /go/src/github.com/dotcloud/docker
+add	.	/go/src/github.com/dotcloud/docker
+
+# Build Go for cross compiling
+run	/go/src/github.com/dotcloud/docker/hack/cross-setup.sh

--- a/hack/cross-platforms
+++ b/hack/cross-platforms
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+CROSS_PLATFORMS=(
+	# see http://golang.org/doc/install/source#environment
+	# and https://github.com/davecheney/golang-crosscompile
+	darwin-386
+	darwin-amd64
+	
+	linux-386
+	linux-amd64
+	linux-arm
+	
+	# platforms that don't compile yet but need to:
+	#windows-386
+	#windows-amd64
+	#freebsd-386
+	#freebsd-amd64
+	
+	# possible future platforms:
+	#openbsd-386
+	#openbsd-amd64
+	#netbsd-386
+	#netbsd-amd64
+	
+	# platforms golang-crosscompile has that Go's documentation claims shouldn't work:
+	#freebsd-arm
+	#openbsd-arm
+	#netbsd-arm
+)

--- a/hack/cross-setup.sh
+++ b/hack/cross-setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+DEST="$1"
+
+source "$(dirname "$BASH_SOURCE")/cross-platforms"
+
+if [ ! -d /goroot/src ]; then
+	echo >&2 "# ERROR! I can't seem to find /goroot/src."
+	echo >&2 "# This probably means we're not running this inside the official container."
+	exit 1
+fi
+
+for PLATFORM in ${CROSS_PLATFORMS[@]}; do
+	(
+		cd /goroot/src \
+			&& GOOS=${PLATFORM%-*} \
+				GOARCH=${PLATFORM#*-} \
+				./make.bash --no-clean
+	)
+done

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -35,6 +35,7 @@ DEFAULT_BUNDLES=(
 	test
 	binary
 	ubuntu
+	cross
 )
 
 VERSION=$(cat ./VERSION)

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+DEST="$1"
+
+HACKMAKEDIR="$(dirname "$BASH_SOURCE")"
+
+source "$HACKMAKEDIR/../cross-platforms"
+
+for PLATFORM in ${CROSS_PLATFORMS[@]}; do
+	VERSION="$PLATFORM-$VERSION" \
+		GOOS=${PLATFORM%-*} \
+		GOARCH=${PLATFORM#*-} \
+		source "$HACKMAKEDIR/binary" "$DEST"
+done


### PR DESCRIPTION
Currently, we will cross compile for Darwin (386, amd64) and Linux (386, amd64, and arm), but only because windows and freebsd currently won't compile without some tweaks to the docker source.

There are also a few small hack and Dockerfile related cleanups here, including restructuring the Dockerfile to grab the Go source instead of precompiled binaries (since we need that for cross compiling - have to cross compile the toolchain first, of course).

/cc @shykes
