### PR TITLE
Hint for Remote API doc details in header links

### DIFF
--- a/docs/sources/api/docker_remote_api.rst
+++ b/docs/sources/api/docker_remote_api.rst
@@ -23,6 +23,8 @@ Docker Remote API
 - Since API version 1.2, the auth configuration is now handled client
   side, so the client has to send the authConfig as POST in
   /images/(name)/push
+- This document is mostly a changelog. Click the per-version header for
+  more detailed request and response documentation.
 
 2. Versions
 ===========

--- a/docs/sources/api/docker_remote_api.rst
+++ b/docs/sources/api/docker_remote_api.rst
@@ -23,8 +23,6 @@ Docker Remote API
 - Since API version 1.2, the auth configuration is now handled client
   side, so the client has to send the authConfig as POST in
   /images/(name)/push
-- This document is mostly a changelog. Click the per-version header for
-  more detailed request and response documentation.
 
 2. Versions
 ===========
@@ -37,8 +35,13 @@ Calling /images/<name>/insert is the same as calling
 You can still call an old version of the api using
 /v1.0/images/<name>/insert
 
+1.5
+***
+
+Full Documentation
+------------------
+
 :doc:`docker_remote_api_v1.5`
-*****************************
 
 What's new
 ----------
@@ -59,8 +62,13 @@ What's new
    dicts each containing `PublicPort`, `PrivatePort` and `Type` describing a
    port mapping.
 
+1.4
+***
+
+Full Documentation
+------------------
+
 :doc:`docker_remote_api_v1.4`
-*****************************
 
 What's new
 ----------
@@ -77,10 +85,15 @@ What's new
 
    **New!** Image's name added in the events
 
-:doc:`docker_remote_api_v1.3`
-*****************************
+1.3
+***
 
 docker v0.5.0 51f6c4a_
+
+Full Documentation
+------------------
+
+:doc:`docker_remote_api_v1.3`
 
 What's new
 ----------
@@ -114,10 +127,15 @@ Start containers (/containers/<id>/start):
 - You can now pass host-specific configuration (e.g. bind mounts) in
   the POST body for start calls
 
-:doc:`docker_remote_api_v1.2`
-*****************************
+1.2
+***
 
 docker v0.4.2 2e7649b_
+
+Full Documentation
+------------------
+
+:doc:`docker_remote_api_v1.2`
 
 What's new
 ----------
@@ -144,10 +162,15 @@ The client should send it's authConfig as POST on each call of
   deleted/untagged.
 
 
-:doc:`docker_remote_api_v1.1`
-*****************************
+1.1
+***
 
 docker v0.4.0 a8ae398_
+
+Full Documentation
+------------------
+
+:doc:`docker_remote_api_v1.1`
 
 What's new
 ----------
@@ -168,11 +191,15 @@ What's new
 	   {"error":"Invalid..."}
 	   ...
 
-
-:doc:`docker_remote_api_v1.0`
-*****************************
+1.0
+***
 
 docker v0.3.4 8d73740_
+
+Full Documentation
+------------------
+
+:doc:`docker_remote_api_v1.0`
 
 What's new
 ----------


### PR DESCRIPTION
I was wondering where the detailed Remote API docs were, since I didn't realize the version headers were links. This PR just adds a line in the introduction that points out that there are indeed detailed docs.
