### PR TITLE
Fix contrib/mkimage-debian.sh apt caching prevention

### DIFF
--- a/contrib/mkimage-debian.sh
+++ b/contrib/mkimage-debian.sh
@@ -10,12 +10,18 @@ variant='minbase'
 include='iproute,iputils-ping'
 
 repo="$1"
-suite="${2:-$stableSuite}"
+suite="$2"
 mirror="${3:-}" # stick to the default debootstrap mirror if one is not provided
 
-if [ ! "$repo" ]; then
-	echo >&2 "usage: $0 repo [suite [mirror]]"
+if [ ! "$repo" ] || [ ! "$suite" ]; then
+	echo >&2 "usage: $0 repo suite [mirror]"
+	echo >&2
 	echo >&2 "   ie: $0 tianon/debian squeeze"
+	echo >&2 "       $0 tianon/debian squeeze http://ftp.uk.debian.org/debian/"
+	echo >&2
+	echo >&2 "   ie: $0 tianon/ubuntu precise"
+	echo >&2 "       $0 tianon/ubuntu precise http://mirrors.melbourne.co.uk/ubuntu/"
+	echo >&2
 	exit 1
 fi
 
@@ -33,8 +39,12 @@ sudo debootstrap --verbose --variant="$variant" --include="$include" "$suite" "$
 cd "$target"
 
 # prevent init scripts from running during install/update
+#  policy-rc.d (for most scripts)
 echo $'#!/bin/sh\nexit 101' | sudo tee usr/sbin/policy-rc.d > /dev/null
 sudo chmod +x usr/sbin/policy-rc.d
+#  initctl (for some pesky upstart scripts)
+sudo chroot . dpkg-divert --local --rename --add /sbin/initctl
+sudo ln -sf /bin/true sbin/initctl
 # see https://github.com/dotcloud/docker/issues/446#issuecomment-16953173
 
 # shrink the image, since apt makes us fat (wheezy: ~157.5MB vs ~120MB)
@@ -42,9 +52,16 @@ sudo chroot . apt-get clean
 
 # while we're at it, apt is unnecessarily slow inside containers
 #  this forces dpkg not to call sync() after package extraction and speeds up install
+#    the benefit is huge on spinning disks, and the penalty is nonexistent on SSD or decent server virtualization
 echo 'force-unsafe-io' | sudo tee etc/dpkg/dpkg.cfg.d/02apt-speedup > /dev/null
-#  we don't need an apt cache in a container
-echo 'Acquire::http {No-Cache=True;};' | sudo tee etc/apt/apt.conf.d/no-cache > /dev/null
+#  we want to effectively run "apt-get clean" after every install to keep images small
+echo 'DPkg::Post-Invoke {"/bin/rm -f /var/cache/apt/archives/*.deb || true";};' | sudo tee etc/apt/apt.conf.d/no-cache > /dev/null
+
+# helpful undo lines for each the above tweaks (for lack of a better home to keep track of them):
+#  rm /usr/sbin/policy-rc.d
+#  rm /sbin/initctl; dpkg-divert --rename --remove /sbin/initctl
+#  rm /etc/dpkg/dpkg.cfg.d/02apt-speedup
+#  rm /etc/apt/apt.conf.d/no-cache
 
 # create the image (and tag $repo:$suite)
 sudo tar -c . | docker import - $repo $suite


### PR DESCRIPTION
With many thanks to @paulepanter for pointing it out and @dsissitka for helping me test (especially with an SSD and a nice visualization environment to help verify the validity and impact of "force-unsafe-io" - http://imgur.com/abRh5qD).

I added another comment to the force-unsafe-io line to reflect our testing (since my 7200rpm spinning disk workstation was pretty dramatic - python went from 30s down to 12s, and xorg went from 3m down to 2m, and as you can see from @dsissitka's screenshot above, the impact to faster disks is nonexistent, as expected).

To fix the automatic "apt-get clean" issue (that we thought "No-Cache=true" meant), we tested by running "apt-get clean; find / -name '_.deb'; apt-get install -y python; find / -name '_.deb'" with each solution, and here's the ones we tried:
- obviously `No-Cache=True;` - only applies to proxies
- `Clean-Installed=True;` - is already on by default and doesn't actually apply to what we're trying to do (see `man apt.conf`)
- `Max-Age=0` - just makes sure that we redownload for every install, but doesn't delete files after install
- `Dir::Cache::pkgcache ""; Dir::Cache::srcpkgcache "";` - doesn't apply to the archive files, so doesn't correspond to "apt-get clean after every install"
- `Dir::Cache::archives "/tmp";` - we don't ever clear out /tmp or use tmpfs for it (at least not automatically), so this doesn't help much; it just moves the files elsewhere in the image
- finally, `DPkg::Post-Invoke {"/bin/rm -f /var/cache/apt/archives/*.deb || true";};` which just deletes all the archives as soon as install is finished, and actually does what we want :+1:

(final thanks goes out to http://askubuntu.com/a/81211/89630)

/cc @jpetazzo since we both should've tested these two more thoroughly on #1883 :)
