### PR TITLE
Add contrib/mkimage-centos.sh back (from #1621), and associated documentation link

### DIFF
--- a/contrib/mkimage-centos.sh
+++ b/contrib/mkimage-centos.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Create a CentOS base image for Docker
+# From unclejack https://github.com/dotcloud/docker/issues/290
+set -e
+
+MIRROR_URL="http://centos.netnitco.net/6.4/os/x86_64/"
+MIRROR_URL_UPDATES="http://centos.netnitco.net/6.4/updates/x86_64/"
+
+yum install -y febootstrap xz
+
+febootstrap -i bash -i coreutils -i tar -i bzip2 -i gzip -i vim-minimal -i wget -i patch -i diffutils -i iproute -i yum centos centos64  $MIRROR_URL -u $MIRROR_URL_UPDATES
+touch centos64/etc/resolv.conf
+touch centos64/sbin/init
+
+tar --numeric-owner -Jcpf centos-64.tar.xz -C centos64 .

--- a/docs/sources/use/baseimages.rst
+++ b/docs/sources/use/baseimages.rst
@@ -27,7 +27,7 @@ It can be as simple as this to create an Ubuntu base image::
   $ sudo debootstrap raring raring > /dev/null
   $ sudo tar -C raring -c . | sudo docker import - raring
   a29c15f1bf7a
-  $ sudo docker run raring cat /etc/lsb-release                     
+  $ sudo docker run raring cat /etc/lsb-release
   DISTRIB_ID=Ubuntu
   DISTRIB_RELEASE=13.04
   DISTRIB_CODENAME=raring
@@ -37,5 +37,7 @@ There are more example scripts for creating base images in the
 Docker Github Repo:
 
 * `BusyBox <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-busybox.sh>`_
-* `Debian
+* `CentOS
+  <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-centos.sh>`_
+* `Debian/Ubuntu
   <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-debian.sh>`_


### PR DESCRIPTION
Somewhere between #1621 and #1703, we lost `contrib/mkimage-centos.sh` (thanks to @dsissitka for pointing it out and for finding the relevant issues to resurrect it).
