### PR TITLE
Added support for a `docker ip` command

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,6 +51,7 @@ Gareth Rushgrove <gareth@morethanseven.net>
 Guillaume J. Charmes <guillaume.charmes@dotcloud.com>
 Harley Laue <losinggeneration@gmail.com>
 Hunter Blanks <hunter@twilio.com>
+James Turnbull <james@lovedthanlost.net>
 Jeff Lindsay <progrium@gmail.com>
 Jeremy Grosser <jeremy@synack.me>
 Joffrey F <joffrey@dotcloud.com>

--- a/commands.go
+++ b/commands.go
@@ -95,6 +95,7 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 		{"info", "Display system-wide information"},
 		{"insert", "Insert a file in an image"},
 		{"inspect", "Return low-level information on a container"},
+		{"ip", "Return the IP address of a container"},
 		{"kill", "Kill a running container"},
 		{"login", "Register or Login to the docker registry server"},
 		{"logs", "Fetch the logs of a container"},
@@ -668,6 +669,30 @@ func (cli *DockerCli) CmdPort(args ...string) error {
 	} else {
 		return fmt.Errorf("Error: No private port '%s' allocated on %s", cmd.Arg(1), cmd.Arg(0))
 	}
+	return nil
+}
+
+func (cli *DockerCli) CmdIp(args ...string) error {
+	cmd := Subcmd("ip", "CONTAINER", "Lookup the IP address of the container")
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+	if cmd.NArg() != 1 {
+		cmd.Usage()
+		return nil
+	}
+
+	body, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil)
+	if err != nil {
+		return err
+	}
+	var out Container
+	err = json.Unmarshal(body, &out)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cli.out, "%s\n", out.NetworkSettings.IPAddress)
 	return nil
 }
 

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -40,6 +40,7 @@ Available Commands
    command/info
    command/insert
    command/inspect
+   command/ip
    command/kill
    command/login
    command/logs

--- a/docs/sources/commandline/command/ip.rst
+++ b/docs/sources/commandline/command/ip.rst
@@ -1,0 +1,13 @@
+:title: IP Command
+:description: Lookup the IP address of a container
+:keywords: ip, docker, container, documentation
+
+=========================================================================
+``ip`` -- Lookup the IP address of a container
+=========================================================================
+
+::
+
+    Usage: docker ip [OPTIONS] CONTAINER
+
+    Lookup the IP address of a container

--- a/docs/sources/commandline/index.rst
+++ b/docs/sources/commandline/index.rst
@@ -25,6 +25,7 @@ Contents:
   info    <command/info>
   insert  <command/insert>
   inspect <command/inspect>
+  ip      <command/ip>
   kill    <command/kill>
   login   <command/login>
   logs    <command/logs>


### PR DESCRIPTION
Much like `docker port` except this command
returns the IP address of a specified container.

``` bash
$ sudo docker ip CONTAINER_ID
17.2.16.0.1
```
