### PR TITLE
Update Dockerfile and hack to support compiling device-mapper code statically (using go1.2rc1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,12 +36,21 @@ run	apt-get install -y -q mercurial
 run	apt-get install -y -q build-essential
 
 # Install Go from source (for eventual cross-compiling)
-env	CGO_ENABLED 0
-run	curl -s https://go.googlecode.com/files/go1.1.2.src.tar.gz | tar -v -C / -xz && mv /go /goroot
+run	curl -s https://go.googlecode.com/files/go1.2rc1.src.tar.gz | tar -v -C / -xz && mv /go /goroot
 run	cd /goroot/src && ./make.bash
 env GOROOT	/goroot
 env	PATH	$PATH:/goroot/bin
 env	GOPATH	/go:/go/src/github.com/dotcloud/docker/vendor
+
+# Create Go cache with tag netgo (for static compilation of Go while preserving CGO support)
+run	go install -ldflags '-w -linkmode external -extldflags "-static -Wl,--unresolved-symbols=ignore-in-shared-libs"' -tags netgo -a std
+
+# Get lvm2 source for compiling statically
+run	git clone git://git.fedorahosted.org/git/lvm2.git /lvm2
+run	cd /lvm2 && git checkout v2_02_102
+# can't use git clone -b because it's not supported by git versions before 1.7.10
+run	cd /lvm2 && ./configure --enable-static_link && make && make install_device-mapper
+# see https://git.fedorahosted.org/cgit/lvm2.git/refs/tags for release tags
 
 # Ubuntu stuff
 run	apt-get install -y -q ruby1.9.3 rubygems libffi-dev

--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -32,14 +32,14 @@ the process.
 
 ## System build dependencies
 
-To build docker, you will need the following system dependencies
+To build docker, you will need the following system dependencies:
 
 * An amd64 machine
 * A recent version of git and mercurial
-* Go version 1.1.2
+* Go version 1.2rc1
+* A copy of libdevmapper.a (statically compiled), and associated headers
 * A clean checkout of the source must be added to a valid Go [workspace](http://golang.org/doc/code.html#Workspaces)
-under the path *src/github.com/dotcloud/docker*. See 
-
+under the path *src/github.com/dotcloud/docker*.
 
 ## Go dependencies
 
@@ -55,15 +55,13 @@ NOTE: if you''re not able to package the exact version (to the exact commit) of 
 please get in touch so we can remediate! Who knows what discrepancies can be caused by even the
 slightest deviation. We promise to do our best to make everybody happy.
 
+## Disabling CGO for the net package
 
-## Disabling CGO
-
-Make sure to disable CGO on your system, and then recompile the standard library on the build
-machine:
+Make sure to disable CGO on your system for the net package using `-tags netgo`,
+and then recompile the standard library on the build machine:
 
 ```bash
-export CGO_ENABLED=0
-cd /tmp && echo 'package main' > t.go && go test -a -i -v
+go install -ldflags '-w -linkmode external -extldflags "-static -Wl,--unresolved-symbols=ignore-in-shared-libs"' -tags netgo -a std
 ```
 
 ## Building Docker
@@ -71,7 +69,7 @@ cd /tmp && echo 'package main' > t.go && go test -a -i -v
 To build the docker binary, run the following command with the source checkout as the
 working directory:
 
-```
+```bash
 ./hack/make.sh binary
 ```
 
@@ -80,9 +78,9 @@ This will create a static binary under *./bundles/$VERSION/binary/docker-$VERSIO
 
 You are encouraged to use ./hack/make.sh without modification. If you must absolutely write
 your own script (are you really, really sure you need to? make.sh is really not that complicated),
-then please take care the respect the following:
+then please take care to respect the following:
 
-* In *./hack/make.sh*: $LDFLAGS, $VERSION and $GITCOMMIT
+* In *./hack/make.sh*: $LDFLAGS, $BUILDFLAGS, $VERSION and $GITCOMMIT
 * In *./hack/make/binary*: the exact build command to run
 
 You may be tempted to tweak these settings. In particular, being a rigorous maintainer, you may want
@@ -106,7 +104,6 @@ dependencies to be installed (see below).
 
 The test suite will also download a small test container, so you will need internet connectivity.
 
-
 ## Runtime dependencies
 
 To run properly, docker needs the following software to be installed at runtime:
@@ -115,7 +112,7 @@ To run properly, docker needs the following software to be installed at runtime:
 * iproute2 version 3.5 or later (build after 2012-05-21), and specifically the "ip" utility.
 * iptables version 1.4 or later
 * The lxc utility scripts (http://lxc.sourceforge.net) version 0.8 or later.
-* Git version 1.7 or later 
+* Git version 1.7 or later
 
 ## Kernel dependencies
 

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -44,8 +44,8 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 # Use these flags when compiling the tests and final binary
-LDFLAGS="-X main.GITCOMMIT $GITCOMMIT -X main.VERSION $VERSION -d -w"
-
+LDFLAGS='-X main.GITCOMMIT "'$GITCOMMIT'" -X main.VERSION "'$VERSION'" -w -linkmode external -extldflags "-static -Wl,--unresolved-symbols=ignore-in-shared-libs"'
+BUILDFLAGS='-tags netgo'
 
 bundle() {
 	bundlescript=$1

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -2,6 +2,6 @@
 
 DEST=$1
 
-if go build -o $DEST/docker-$VERSION -ldflags "$LDFLAGS" ./docker; then
+if go build -o $DEST/docker-$VERSION -ldflags "$LDFLAGS" $BUILDFLAGS ./docker; then
 	echo "Created binary: $DEST/docker-$VERSION"
 fi

--- a/hack/make/test
+++ b/hack/make/test
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 DEST=$1
 
 set -e
@@ -9,7 +11,7 @@ bundle_test() {
 		for test_dir in $(find_test_dirs); do (
 			set -x
 			cd $test_dir
-			go test -v -ldflags "$LDFLAGS"
+			go test -v -ldflags "$LDFLAGS" $BUILDFLAGS
 		)  done
 	} 2>&1 | tee $DEST/test.log
 }


### PR DESCRIPTION
Lots of thanks to @creack for figuring out the hard parts via https://github.com/creack/docker_devmapper/blob/master/Dockerfile.

/cc @vieux @shykes @creack

Also, I've updated the packaging documentation in `hack` to reflect the newer requirements (hopefully didn't forget anything - so that needs more eyeballs on it).
