### PR TITLE
Add `apt-get install curl` to Ubuntu docs

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -75,7 +75,7 @@ Docker is available as a Debian package, which makes installation easy.
 
    # Add the Docker repository key to your local keychain
    # using apt-key finger you can check the fingerprint matches 36A1 D786 9245 C895 0F96 6E92 D857 6A8B A88D 21E9
-   sudo sh -c "curl https://get.docker.io/gpg | apt-key add -"
+   sudo sh -c "wget -qO- https://get.docker.io/gpg | apt-key add -"
 
    # Add the Docker repository to your apt sources list.
    sudo sh -c "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
@@ -129,7 +129,7 @@ to follow them again.*
 
    # Add the Docker repository key to your local keychain
    # using apt-key finger you can check the fingerprint matches 36A1 D786 9245 C895 0F96 6E92 D857 6A8B A88D 21E9
-   sudo sh -c "curl https://get.docker.io/gpg | apt-key add -"
+   sudo sh -c "wget -qO- https://get.docker.io/gpg | apt-key add -"
 
    # Add the Docker repository to your apt sources list.
    sudo sh -c "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"


### PR DESCRIPTION
Curl isn't installed on Ubuntu 12.04 by default.
