### PR TITLE
testing, issue #1948: Increase TestRunDetach timeout

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -400,7 +400,7 @@ func TestRunDetach(t *testing.T) {
 	})
 
 	// wait for CmdRun to return
-	setTimeout(t, "Waiting for CmdRun timed out", 5*time.Second, func() {
+	setTimeout(t, "Waiting for CmdRun timed out", 15*time.Second, func() {
 		<-ch
 	})
 
@@ -458,7 +458,7 @@ func TestAttachDetach(t *testing.T) {
 	})
 
 	// wait for CmdRun to return
-	setTimeout(t, "Waiting for CmdAttach timed out", 5*time.Second, func() {
+	setTimeout(t, "Waiting for CmdAttach timed out", 15*time.Second, func() {
 		<-ch
 	})
 


### PR DESCRIPTION
In production deployments, we are still seen:

--- FAIL: TestRunDetach (5.11 seconds)
    commands_test.go:42: Waiting for CmdRun timed out
=== RUN TestAttachDetach
--- FAIL: TestAttachDetach (5.06 seconds)
    commands_test.go:42: Waiting for CmdAttach timed ou

http://docker-ci.dotcloud.com/builders/docker/builds/332/steps/shell/logs/stdio
thttp://docker-ci.dotcloud.com/builders/pullrequest/builds/619/steps/shell/logs/stdio
