### PR TITLE
Provide a synced folder for the virtualbox provisioner

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -105,6 +105,7 @@ kim0 <email.ahmedkamal@googlemail.com>
 Kimbro Staken <kstaken@kstaken.com>
 Kiran Gangadharan <kiran.daredevil@gmail.com>
 Konstantin Pelykh <kpelykh@zettaset.com>
+Kushal Pisavadia <kushal@violentlymild.com>
 Kyle Conroy <kyle.j.conroy@gmail.com>
 Laurie Voss <github@seldo.com>
 Louis Opter <kalessin@kalessin.fr>

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,6 +80,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
   config.vm.provider :virtualbox do |vb|
     config.vm.box = BOX_NAME
     config.vm.box_url = BOX_URI
+    vb.synced_folder ".", "/vagrant"
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
   end


### PR DESCRIPTION
By default, spinning up a VM using the VirtualBox provisioner doesn't
set a synced folder which means local development (beyond toying with
docker commands) can't really happen.

This fixes that and means local development can occur.
