### PR TITLE
fix(hack/PACKAGERS): add xz utils as a runtime dep

### DIFF
--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -116,6 +116,7 @@ To run properly, docker needs the following software to be installed at runtime:
 * iptables version 1.4 or later
 * The lxc utility scripts (http://lxc.sourceforge.net) version 0.8 or later.
 * Git version 1.7 or later 
+* XZ Utils 4.9 or later
 
 ## Kernel dependencies
 


### PR DESCRIPTION
I ran into this this as CoreOS hadn't been shipping xz utils.
