### PR TITLE
Container memory limit can be specified in kilobytes, megabytes or gigabytes

### DIFF
--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -568,7 +568,7 @@ network communication.
       -h="": Container host name
       -i=false: Keep stdin open even if not attached
       -privileged=false: Give extended privileges to this container
-      -m=0: Memory limit (in bytes)
+      -m="": Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
       -n=true: Enable networking for this container
       -p=[]: Map a network port to the container
       -rm=false: Automatically remove the container when it exits (incompatible with -d)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"regexp"
 )
 
 var (
@@ -175,6 +176,37 @@ func HumanSize(size int64) string {
 	}
 	return fmt.Sprintf("%.4g %s", sizef, units[i])
 }
+
+// Parses a human-readable string representing an amount of RAM
+// in bytes, kibibytes, mebibytes or gibibytes, and returns the
+// number of bytes, or -1 if the string is unparseable.
+// Units are case-insensitive, and the 'b' suffix is optional.
+func RAMInBytes(size string) (bytes int64, err error) {
+	re, error := regexp.Compile("^(\\d+)([kKmMgG])?[bB]?$")
+	if error != nil { return -1, error }
+
+	matches := re.FindStringSubmatch(size)
+
+	if len(matches) != 3 {
+		return -1, fmt.Errorf("Invalid size: '%s'", size)
+	}
+
+	memLimit, error := strconv.ParseInt(matches[1], 10, 0)
+	if error != nil { return -1, error }
+ 
+	unit := strings.ToLower(matches[2])
+
+	if unit == "k" {
+		memLimit *= 1024
+	} else if unit == "m" {
+		memLimit *= 1024*1024
+	} else if unit == "g" {
+		memLimit *= 1024*1024*1024
+	}
+
+	return memLimit, nil
+}
+
 
 func Trunc(s string, maxlen int) string {
 	if len(s) <= maxlen {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -265,6 +265,39 @@ func TestHumanSize(t *testing.T) {
 	}
 }
 
+func TestRAMInBytes(t *testing.T) {
+	assertRAMInBytes(t, "32",   false, 32)
+	assertRAMInBytes(t, "32b",  false, 32)
+	assertRAMInBytes(t, "32B",  false, 32)
+	assertRAMInBytes(t, "32k",  false, 32*1024)
+	assertRAMInBytes(t, "32K",  false, 32*1024)
+	assertRAMInBytes(t, "32kb", false, 32*1024)
+	assertRAMInBytes(t, "32Kb", false, 32*1024)
+	assertRAMInBytes(t, "32Mb", false, 32*1024*1024)
+	assertRAMInBytes(t, "32Gb", false, 32*1024*1024*1024)
+
+	assertRAMInBytes(t, "",      true, -1)
+	assertRAMInBytes(t, "hello", true, -1)
+	assertRAMInBytes(t, "-32",   true, -1)
+	assertRAMInBytes(t, " 32 ",  true, -1)
+	assertRAMInBytes(t, "32 mb", true, -1)
+	assertRAMInBytes(t, "32m b", true, -1)
+	assertRAMInBytes(t, "32bm",  true, -1)
+}
+
+func assertRAMInBytes(t *testing.T, size string, expectError bool, expectedBytes int64) {
+	actualBytes, err := RAMInBytes(size)
+	if (err != nil) && !expectError {
+		t.Errorf("Unexpected error parsing '%s': %s", size, err)
+	}
+	if (err == nil) && expectError {
+		t.Errorf("Expected to get an error parsing '%s', but got none (bytes=%d)", size, actualBytes)
+	}
+	if actualBytes != expectedBytes {
+		t.Errorf("Expected '%s' to parse as %d bytes, got %d", size, expectedBytes, actualBytes)
+	}
+}
+
 func TestParseHost(t *testing.T) {
 	if addr, err := ParseHost("127.0.0.1", 4243, "0.0.0.0"); err != nil || addr != "tcp://0.0.0.0:4243" {
 		t.Errorf("0.0.0.0 -> expected tcp://0.0.0.0:4243, got %s", addr)


### PR DESCRIPTION
```
-m 10  # 10 bytes
-m 10b # 10 bytes
-m 10k # 10240 bytes (10 * 1024)
-m 10m # 10485760 bytes (10 * 1024 * 1024)
-m 10g # 10737418240 bytes (10 * 1024 * 1024 * 1024)
```

Units are case-insensitive, and 'kb', 'mb' and 'gb' are equivalent to 'k', 'm' and 'g'.
