### PR TITLE
Prepare test image for faster test runs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,8 +22,13 @@ Vagrant::Config.run do |config|
     pkg_cmd = "wget -q -O - https://get.docker.io/gpg | apt-key add -;" \
       "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list;" \
       "apt-get update -qq; apt-get install -q -y --force-yes lxc-docker; "
+
     # Add Ubuntu raring backported kernel
     pkg_cmd << "apt-get update -qq; apt-get install -q -y linux-image-generic-lts-raring; "
+
+    pkg_cmd << "wget -q -O /usr/local/bin/jq http://stedolan.github.io/jq/download/linux64/jq; " \
+               "chmod 0700 /usr/local/bin/jq; " 
+
     # Add guest additions if local vbox VM. As virtualbox is the default provider,
     # it is assumed it won't be explicitly stated.
     if ENV["VAGRANT_DEFAULT_PROVIDER"].nil? && ARGV.none? { |arg| arg.downcase.start_with?("--provider") }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,8 +26,9 @@ Vagrant::Config.run do |config|
     # Add Ubuntu raring backported kernel
     pkg_cmd << "apt-get update -qq; apt-get install -q -y linux-image-generic-lts-raring; "
 
+    # Install jq, used by test scripts.
     pkg_cmd << "wget -q -O /usr/local/bin/jq http://stedolan.github.io/jq/download/linux64/jq; " \
-               "chmod 0700 /usr/local/bin/jq; " 
+               "chmod 0755 /usr/local/bin/jq; " 
 
     # Add guest additions if local vbox VM. As virtualbox is the default provider,
     # it is assumed it won't be explicitly stated.

--- a/docs/sources/contributing/devenvironment.rst
+++ b/docs/sources/contributing/devenvironment.rst
@@ -64,19 +64,17 @@ This will create the Docker binary in ``./bundles/<version>-dev/binary/``
 Step 5: Run the Tests
 ---------------------
 
-To run the Docker test cases you first need to disable `AppArmor <https://wiki.ubuntu.com/AppArmor>`_ using the following commands
+To prepare the test image, run this command:
 
 .. code-block:: bash
 
-	sudo /etc/init.d/apparmor stop
-	sudo /etc/init.d/apparmor teardown
+	hack/prepare_tests.sh
 
 To execute the test cases, run this command:
 
 .. code-block:: bash
 
-	sudo docker run -lxc-conf=lxc.aa_profile=unconfined -privileged -v `pwd`:/go/src/github.com/dotcloud/docker docker hack/make.sh test
-
+  hack/run_tests.sh
 
 If the test are successful then the tail of the output should look something like this
 
@@ -107,8 +105,6 @@ If the test are successful then the tail of the output should look something lik
 	--- PASS: TestDependencyGraph (0.00 seconds)
 	PASS
 	ok  	github.com/dotcloud/docker/utils	0.017s
-
-
 
 
 Step 6: Use Docker

--- a/hack/make/test_prepare
+++ b/hack/make/test_prepare
@@ -1,0 +1,26 @@
+DEST=$1
+
+set -ex
+
+# bundle_binary must be called first.
+prepare_test() {
+  # Copy the binary
+	# This will fail if the binary bundle hasn't been built
+	mkdir -p $DIR/usr/bin
+	cp $DEST/../binary/docker-$VERSION $DIR/usr/bin/docker
+
+
+  # install test dependencies
+  go test -v -i -ldflags "$LDFLAGS"
+
+  # start docker pointing to the unit test graph
+  docker -d -g /var/lib/docker/unit-tests &
+
+  sleep 2
+
+  # pull the test image
+  docker pull docker-test-image
+}
+
+
+prepare_test

--- a/hack/prepare_tests.sh
+++ b/hack/prepare_tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script prepares the docker images to run tests efficiently.
+#
+# Requirements: 
+# - jq http://stedolan.github.io/jq/ for parsing out json
+
+set -e
+
+DOCKER="sudo docker"
+
+# do the build as normal
+$DOCKER build -t docker .
+
+# save the config
+config=$($DOCKER inspect docker | jq .[0].config)
+
+id=$($DOCKER run -d -dns=8.8.8.8 -lxc-conf=lxc.aa_profile=unconfined -privileged -v `pwd`:/go/src/github.com/dotcloud/docker docker hack/make.sh binary test_prepare)
+$DOCKER attach $id
+
+# update the config with the id, so that the volumes are copied
+config=$(echo $config | jq ".VolumesFrom=\"$id\" | .Volumes=null")
+
+# commit a new image with the existing config
+$DOCKER commit -run="$config" $id docker-test

--- a/hack/run_tests.sh
+++ b/hack/run_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script runs the docker tests.
+#
+# Requirements: 
+# - prepare_tests.sh has been run to build the docker-test image
+
+set -e
+
+# stop apparmor interfering with us
+sudo /etc/init.d/apparmor stop
+sudo /etc/init.d/apparmor teardown
+
+# run the tests!
+sudo docker run -dns=8.8.8.8 -lxc-conf=lxc.aa_profile=unconfined -privileged -v `pwd`:/go/src/github.com/dotcloud/docker docker-test hack/make.sh test


### PR DESCRIPTION
A script `hack/prepare_tests.sh` that builds a test image that
- installs docker test dependencies
- pulls `runtime_test.go`'s `docker-test-image` into the correct graph location

The test suite can then use this image as its basis. I've wrapped this up in `hack/run_tests.sh`

This makes running the test suite much faster, since it doesn't have to do all the preparation each time.

The existing test running approach should still work.
