### PR TITLE
Fix help text for -v option

### DIFF
--- a/docs/sources/commandline/command/run.rst
+++ b/docs/sources/commandline/command/run.rst
@@ -27,7 +27,7 @@
       -t=false: Allocate a pseudo-tty
       -u="": Username or UID
       -dns=[]: Set custom dns servers for the container
-      -v=[]: Create a bind mount with: [host-dir]:[container-dir]:[rw|ro]. If "host-dir" is missing, then docker creates a new volume.
+      -v=[]: Create a bind mount with: [host-dir]:[container-dir]:[rw|ro]. If "container-dir" is missing, then docker creates a new volume.
       -volumes-from="": Mount all volumes from the given container.
       -entrypoint="": Overwrite the default entrypoint set by the image.
       -w="": Working directory inside the container


### PR DESCRIPTION
The help text for sudo docker run -v is slightly incorrect: it indicates that host-dir will be created if missing, when in fact docker will (quite rightly) throw an error in this situation. It should refer to container-dir instead.
