### PR TITLE
Add Developer Certificate of Origin Text

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,39 @@ name and email address match your git configuration. The AUTHORS file is
 regenerated occasionally from the git commit history, so a mismatch may result
 in your changes being overwritten.
 
+### Sign your work
+
+The sign-off is a simple line at the end of the explanation for the
+patch, which certifies that you wrote it or otherwise have the right to
+pass it on as an open-source patch.  The rules are pretty simple: if you
+can certify the below:
+
+```
+Docker Developer Grant and Certificate of Origin 1.0
+
+By making a contribution to the Docker Project ("Project"), I represent and warrant that:
+
+a. The contribution was created in whole or in part by me and I have the right to submit the contribution on my own behalf or on behalf of a third party who has authorized me to submit this contribution to the Project; or
+
+
+b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right and authorization to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license) that I have identified in the contribution; or
+
+c. The contribution was provided directly to me by some other person who represented and warranted (a) or (b) and I have not modified it.
+
+d. I understand and agree that this Project and the contribution are publicly known and that a record of the contribution (including all personal information I submit with it, including my sign-off record) is maintained indefinitely and may be redistributed consistent with this Project or the open source license(s) involved.
+
+e. I hereby grant to the Project, dotCloud, Inc and its successors;  and recipients of software distributed by the Project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, modify, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute this contribution and such modifications and derivative works consistent with this Project, the open source license indicated in the previous work or other appropriate open source license specified by the Project and approved by the Open Source Initiative(OSI) at http://www.opensource.org.
+```
+
+then you just add a line saying
+
+    Docker-DCO-1.0-Signed-off-by: Joe Smith <joe.smith@email.com> @github_handle
+
+using your real name (sorry, no pseudonyms or anonymous contributions.)
+
+If you have any questions, please refer to the FAQ in the [docs](http://docs.docker.io)
+
+
 
 ### How can I become a maintainer?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ c. The contribution was provided directly to me by some other person who represe
 
 d. I understand and agree that this Project and the contribution are publicly known and that a record of the contribution (including all personal information I submit with it, including my sign-off record) is maintained indefinitely and may be redistributed consistent with this Project or the open source license(s) involved.
 
-e. I hereby grant to the Project, dotCloud, Inc and its successors;  and recipients of software distributed by the Project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, modify, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute this contribution and such modifications and derivative works consistent with this Project, the open source license indicated in the previous work or other appropriate open source license specified by the Project and approved by the Open Source Initiative(OSI) at http://www.opensource.org.
+e. I hereby grant to the Project, Docker, Inc and its successors;  and recipients of software distributed by the Project a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, modify, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute this contribution and such modifications and derivative works consistent with this Project, the open source license indicated in the previous work or other appropriate open source license specified by the Project and approved by the Open Source Initiative(OSI) at http://www.opensource.org.
 ```
 
 then you just add a line saying

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ e. I hereby grant to the Project, Docker, Inc and its successors;  and recipient
 
 then you just add a line saying
 
-    Docker-DCO-1.0-Signed-off-by: Joe Smith <joe.smith@email.com> @github_handle
+    Docker-DCO-1.0-Signed-off-by: Joe Smith <joe.smith@email.com> (github: github_handle)
 
 using your real name (sorry, no pseudonyms or anonymous contributions.)
 


### PR DESCRIPTION
We purposely chose to license Docker under the Apache 2.0 license. This is a well-known
license, which is popular for its permissive and flexible properties, while still
encouraging a collaborative community. It also makes certain representations with regard
to contributions, and the rights given to contributors, the project, people who use Docker,
people who modify Docker, etc.

This approach to contributions is inspired by the popular Linux Developer
"Certificate of Origin". This approach makes it simple for new contributors to get started,
and avoids bureaucracy in tracking contributions and contributors.

To indicate accordance, each individual contribution to the Project is signed off by the
developer, using his or her real name, email address, and github handle in the format below:

```
Docker-DCO-1.0-Signed-off-by: Joe Smith <joe.smith@email.com>
```
