### PR TITLE
Grab the Basho apt key in a more secure manner

### DIFF
--- a/docs/sources/examples/running_riak_service.rst
+++ b/docs/sources/examples/running_riak_service.rst
@@ -68,7 +68,7 @@ Next, we add Basho's APT repository:
 
 .. code-block:: bash
 
-    RUN curl -s http://apt.basho.com/gpg/basho.apt.key | apt-key add --
+    RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F933E597DDF2E833
     RUN echo "deb http://apt.basho.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/basho.list
     RUN apt-get update
 


### PR DESCRIPTION
Fixes #1987

Use gpg recv-keys instead of curl to grab the Basho apt key.
