### PR TITLE
docker build: initial work on the include command

### DIFF
--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -189,6 +189,18 @@ run    [ "$(cat /bar/withfile)" = "test2" ]
 		},
 		nil,
 	},
+
+	{
+		`
+from {IMAGE}
+include foo
+include http://{SERVERADDR}/baz
+run    [ "$(cat /testfile1)" = "test1" ]
+run    [ "$(cat /testfile2)" = "test2" ]
+`,
+		[][2]string{{"foo", "run echo test1 > /testfile1"}},
+		[][2]string{{"/baz", "run echo test2 > /testfile2"}},
+	},
 }
 
 // FIXME: test building with 2 successive overlapping ADD commands


### PR DESCRIPTION
This is some initial work to add the 'include' command to dockerfile build as suggested by issue #735.

When the client starts a build process it creates a tarball of the whole directory containing the `Dockerfile` and it sends it to the server. Hence including a file which is located outside of the directory containing the `Dockerfile` (eg: `include ../common/server_stuff`) would result in a "file not found" error on the server site. Trying to circumvent this issue with symbolic links won't help, since on the server side they will still be broken.

Including remote files works fine. Nested includes work fine too as long as they do not reference external files.

I think we could instruct the client to look for external include statements inside of the Dockerfile and take care of them by 1) temporarily copying these files into the working directory 2) update the path to the file to include. I'm not completely satisfied by this approach, but I do not have other ideas...

A couple of final notes: 
- I'm still new to go, keep that in mind while reviewing my patch :)
- I updated the unit tests but I have not been able to run them. I got some failures even without my changes. I'm running the tests using `sudo go test'.
