### PR TITLE
[docs] use angle brackets in MAINTAINER example email

### DIFF
--- a/docs/sources/use/builder.rst
+++ b/docs/sources/use/builder.rst
@@ -321,7 +321,7 @@ the command given by ``CMD`` is executed.
     # VERSION               0.0.1
 
     FROM      ubuntu
-    MAINTAINER Guillaume J. Charmes "guillaume@dotcloud.com"
+    MAINTAINER Guillaume J. Charmes <guillaume@dotcloud.com>
 
     # make sure the package repository is up to date
     RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list


### PR DESCRIPTION
MAINTAINER example from [builder usage doc](http://docs.docker.io/en/latest/use/builder/#dockerfile-examples) uses quotes:

```
MAINTAINER Guillaume J. Charmes "guillaume@dotcloud.com"
```

It must use angle brackets `<>` instead.
