### PR TITLE
devmapper: Support running docker inside docker

### DIFF
--- a/devmapper/deviceset_devmapper.go
+++ b/devmapper/deviceset_devmapper.go
@@ -690,6 +690,14 @@ func NewDeviceSetDM(root string) *DeviceSetDM {
 		base = "docker-" + base
 	}
 
+	// When run inside a container we prefix the device names, because the devmapper device
+	// namespace is shared between all containers, and we don't want to mess with docker running
+	// on the host. To get a unique prefix we use that device node and the inode of the docker root dir
+	var stat syscall.Stat_t
+	if os.Getenv("container") != "" && syscall.Stat(root, &stat) == nil {
+		base = fmt.Sprintf("%s-%d:%d", base, stat.Dev, stat.Ino)
+	}
+
 	return &DeviceSetDM{
 		initialized:  false,
 		root:         root,

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -105,19 +105,19 @@ func removeDev(name string) {
 func cleanupDevMapper() {
 	infos, _ := ioutil.ReadDir("/dev/mapper")
 	if infos != nil {
-		hasPool := false
+		var pools []string
 		for _, info := range infos {
 			name := info.Name()
 			if strings.HasPrefix(name, "docker-unit-tests-devices-") {
-				if name == "docker-unit-tests-devices-pool" {
-					hasPool = true
+				if strings.HasSuffix(name,"-pool") {
+					pools = append(pools, name)
 				} else {
 					removeDev(name)
 				}
 			}
 			// We need to remove the pool last as the other devices block it
-			if hasPool {
-				removeDev("docker-unit-tests-devices-pool")
+			for _, n := range pools {
+				removeDev(n)
 			}
 		}
 	}


### PR DESCRIPTION
The devicemapper device namespace is global, so when running docker inside
a docker container we prefix the device names with the docker container
id to avoid conflicts with the host instance.
