### PR TITLE
document what `vagrant up` is actually doing

### DIFF
--- a/docs/sources/installation/vagrant.rst
+++ b/docs/sources/installation/vagrant.rst
@@ -53,9 +53,7 @@ Spin it up
 
    * Download the 'official' Precise64 base ubuntu virtual machine image from vagrantup.com
    * Boot this image in virtualbox
-   * Add the `Docker PPA sources <https://launchpad.net/~dotcloud/+archive/lxc-docker>`_ to /etc/apt/sources.lst
-   * Update your sources
-   * Install lxc-docker
+   * Follow official :ref:`ubuntu_linux` installation path
 
    You now have a Ubuntu Virtual Machine running with docker pre-installed.
 


### PR DESCRIPTION
It was especially confusing that install-with-vagrant manual mentioned outdated PPA that Vagrantfile doesn't actually use. It now points to official Ubuntu installation instructions (as Vagrantfile seems to follow it). It should be future proof!
