### PR TITLE
remove unused RwChecksum and use base directory instead of rw for changes

### DIFF
--- a/container.go
+++ b/container.go
@@ -1270,15 +1270,7 @@ func (container *Container) ExportRw() (Archive, error) {
 	if err != nil {
 		return nil, err
 	}
-	return image.ExportChanges(container.runtime, container.RootfsPath(), container.rwPath(), container.ID)
-}
-
-func (container *Container) RwChecksum() (string, error) {
-	rwData, err := Tar(container.rwPath(), Xz)
-	if err != nil {
-		return "", err
-	}
-	return utils.HashData(rwData)
+	return image.ExportChanges(container.runtime, container.RootfsPath(), path.Join(container.root, "base"), container.ID)
 }
 
 func (container *Container) Export() (Archive, error) {

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -45,7 +45,7 @@ fi
 
 # Use these flags when compiling the tests and final binary
 LDFLAGS='-X main.GITCOMMIT "'$GITCOMMIT'" -X main.VERSION "'$VERSION'" -w -linkmode external -extldflags "-lpthread -static -Wl,--unresolved-symbols=ignore-all"'
-BUILDFLAGS='-tags netgo'
+BUILDFLAGS='-tags netgo -a'
 
 
 bundle() {

--- a/runtime.go
+++ b/runtime.go
@@ -321,7 +321,39 @@ func (runtime *Runtime) restore() error {
 		}
 		return len(ic.Links) < len(jc.Links)
 	})
+
+	deviceSet := runtime.config.DeviceSet
 	for _, container := range containers {
+
+		// Perform a migration for aufs containers
+		if !deviceSet.HasDevice(container.ID) {
+			utils.Debugf("[migration] Begin migration of %s", container.ID)
+
+			image, err := runtime.graph.Get(container.Image)
+			if err != nil {
+				utils.Debugf("[migratoin] Failed to get image %s", err)
+				continue
+			}
+			if err := image.Mount(runtime, container.RootfsPath(), container.rwPath(), container.ID); err != nil {
+				utils.Debugf("[migratoin] Failed to mount image %s", err)
+				continue
+			}
+
+			if err := image.applyLayer(container.rwPath(), container.RootfsPath()); err != nil {
+				utils.Debugf("[migration] Failed to apply layer %s", err)
+			}
+
+			if err := image.Unmount(runtime, container.RootfsPath(), container.ID); err != nil {
+				utils.Debugf("[migraton] Failed to unmount image %s", err)
+			}
+
+			if err := os.RemoveAll(container.rwPath()); err != nil {
+				utils.Debugf("[migration] Failed to remove rw dir %s", err)
+			}
+
+			utils.Debugf("[migration] End migration of %s", container.ID)
+		}
+
 		if err := runtime.Register(container); err != nil {
 			utils.Debugf("Failed to register container %s: %s", container.ID, err)
 			continue


### PR DESCRIPTION
I kept `ExportRw` in container.go, do you think we should change this as well ? (And remove any mention of rw ?)

/cc @creack @crosbymichael @alexlarsson
