### PR TITLE
Fixes issues with mounting subdirectories of /mnt in container.

### DIFF
--- a/lxc_template.go
+++ b/lxc_template.go
@@ -81,6 +81,8 @@ lxc.cgroup.devices.allow = c 10:200 rwm
 {{end}}
 
 # standard mount point
+# Use mnt.putold as per https://bugs.launchpad.net/ubuntu/+source/lxc/+bug/986385
+lxc.pivotdir = lxc_putold
 #  WARNING: procfs is a known attack vector and should probably be disabled
 #           if your userspace allows it. eg. see http://blog.zx2c4.com/749
 lxc.mount.entry = proc {{$ROOTFS}}/proc proc nosuid,nodev,noexec 0 0


### PR DESCRIPTION
Tested with
mkdir /mnt/data
docker run -v /mnt/data:/mnt/data  -t ubuntu:12.10 touch /mnt/data/bar

Expected /mnt/data/bar on host.
