### PR TITLE
Static docker init

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1403,18 +1403,6 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 // Ports type - Used to parse multiple -p flags
 type ports []int
 
-// ListOpts type
-type ListOpts []string
-
-func (opts *ListOpts) String() string {
-	return fmt.Sprint(*opts)
-}
-
-func (opts *ListOpts) Set(value string) error {
-	*opts = append(*opts, value)
-	return nil
-}
-
 // AttachOpts stores arguments to 'docker run -a', eg. which streams to attach to
 type AttachOpts map[string]bool
 

--- a/container.go
+++ b/container.go
@@ -167,30 +167,30 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 
 	flCpuShares := cmd.Int64("c", 0, "CPU shares (relative weight)")
 
-	var flPublish ListOpts
+	var flPublish utils.ListOpts
 	cmd.Var(&flPublish, "p", "Publish a container's port to the host (use 'docker port' to see the actual mapping)")
 
-	var flExpose ListOpts
+	var flExpose utils.ListOpts
 	cmd.Var(&flExpose, "expose", "Expose a port from the container without publishing it to your host")
 
-	var flEnv ListOpts
+	var flEnv utils.ListOpts
 	cmd.Var(&flEnv, "e", "Set environment variables")
 
-	var flDns ListOpts
+	var flDns utils.ListOpts
 	cmd.Var(&flDns, "dns", "Set custom dns servers")
 
 	flVolumes := NewPathOpts()
 	cmd.Var(flVolumes, "v", "Bind mount a volume (e.g. from the host: -v /host:/container, from docker: -v /container)")
 
-	var flVolumesFrom ListOpts
+	var flVolumesFrom utils.ListOpts
 	cmd.Var(&flVolumesFrom, "volumes-from", "Mount volumes from the specified container")
 
 	flEntrypoint := cmd.String("entrypoint", "", "Overwrite the default entrypoint of the image")
 
-	var flLxcOpts ListOpts
+	var flLxcOpts utils.ListOpts
 	cmd.Var(&flLxcOpts, "lxc-conf", "Add custom lxc options -lxc-conf=\"lxc.cgroup.cpuset.cpus = 0,1\"")
 
-	var flLinks ListOpts
+	var flLinks utils.ListOpts
 	cmd.Var(&flLinks, "link", "Add link to another container (containerid:alias)")
 
 	if err := cmd.Parse(args); err != nil {

--- a/container_test.go
+++ b/container_test.go
@@ -407,6 +407,44 @@ func TestOutput(t *testing.T) {
 	}
 }
 
+func TestContainerNetwork(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+	container, err := runtime.Create(
+		&Config{
+			Image: GetTestImage(runtime).ID,
+			Cmd:   []string{"ping", "-c", "1", "127.0.0.1"},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.Destroy(container)
+	if err := container.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if container.State.ExitCode != 0 {
+		t.Errorf("Unexpected ping 127.0.0.1 exit code %d (expected 0)", container.State.ExitCode)
+	}
+
+	container, err = runtime.Create(
+		&Config{
+			Image: GetTestImage(runtime).ID,
+			Cmd:   []string{"ping", "-c", "1", "8.8.8.8"},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.Destroy(container)
+	if err := container.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if container.State.ExitCode != 0 {
+		t.Errorf("Unexpected ping 8.8.8.8 exit code %d (expected 0)", container.State.ExitCode)
+	}
+}
+
 func TestKillDifferentUser(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)

--- a/docker-init/docker-init.go
+++ b/docker-init/docker-init.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/dotcloud/docker"
+	"github.com/dotcloud/docker/sysinit"
 )
 
 var (
@@ -11,6 +11,6 @@ var (
 
 func main() {
 	// Running in init mode
-	docker.SysInit()
+	sysinit.SysInit()
 	return
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -37,7 +37,7 @@ func main() {
 	flGraphPath := flag.String("g", "/var/lib/docker", "Path to graph storage base dir.")
 	flEnableCors := flag.Bool("api-enable-cors", false, "Enable CORS requests in the remote api.")
 	flDns := flag.String("dns", "", "Set custom dns servers")
-	flHosts := docker.ListOpts{fmt.Sprintf("unix://%s", docker.DEFAULTUNIXSOCKET)}
+	flHosts := utils.ListOpts{fmt.Sprintf("unix://%s", docker.DEFAULTUNIXSOCKET)}
 	flag.Var(&flHosts, "H", "tcp://host:port to bind/connect to or unix://path/to/socket to use")
 	flEnableIptables := flag.Bool("iptables", true, "Disable iptables within docker")
 	flDefaultIp := flag.String("ip", "0.0.0.0", "Default ip address to use when binding a containers ports")

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/dotcloud/docker"
 	"github.com/dotcloud/docker/devmapper"
+	"github.com/dotcloud/docker/sysinit"
 	"github.com/dotcloud/docker/utils"
 	"io/ioutil"
 	"log"
@@ -24,7 +25,7 @@ var (
 func main() {
 	if selfPath := utils.SelfPath(); selfPath == "/sbin/init" || selfPath == "/.dockerinit" {
 		// Running in init mode
-		docker.SysInit()
+		sysinit.SysInit()
 		return
 	}
 	// FIXME: Switch d and D ? (to be more sshd like)

--- a/netlink/netlink.go
+++ b/netlink/netlink.go
@@ -1,0 +1,548 @@
+package netlink
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"syscall"
+	"unsafe"
+)
+
+var nextSeqNr int
+
+func nativeEndian() binary.ByteOrder {
+	var x uint32 = 0x01020304
+	if *(*byte)(unsafe.Pointer(&x)) == 0x01 {
+		return binary.BigEndian
+	}
+	return binary.LittleEndian
+}
+
+func getSeq() int {
+	nextSeqNr = nextSeqNr + 1
+	return nextSeqNr
+}
+
+func getIpFamily(ip net.IP) int {
+	if len(ip) <= net.IPv4len {
+		return syscall.AF_INET
+	}
+	if ip.To4() != nil {
+		return syscall.AF_INET
+	}
+	return syscall.AF_INET6
+}
+
+type NetlinkRequestData interface {
+	ToWireFormat() []byte
+}
+
+type IfInfomsg struct {
+	syscall.IfInfomsg
+}
+
+func newIfInfomsg(family int) *IfInfomsg {
+	msg := &IfInfomsg{}
+	msg.Family = uint8(family)
+	msg.Type = uint16(0)
+	msg.Index = int32(0)
+	msg.Flags = uint32(0)
+	msg.Change = uint32(0)
+
+	return msg
+}
+
+func (msg *IfInfomsg) ToWireFormat() []byte {
+	native := nativeEndian()
+
+	len := syscall.SizeofIfInfomsg
+	b := make([]byte, len)
+	b[0] = msg.Family
+	b[1] = 0
+	native.PutUint16(b[2:4], msg.Type)
+	native.PutUint32(b[4:8], uint32(msg.Index))
+	native.PutUint32(b[8:12], msg.Flags)
+	native.PutUint32(b[12:16], msg.Change)
+	return b
+}
+
+type IfAddrmsg struct {
+	syscall.IfAddrmsg
+}
+
+func newIfAddrmsg(family int) *IfAddrmsg {
+	msg := &IfAddrmsg{}
+	msg.Family = uint8(family)
+	msg.Prefixlen = uint8(0)
+	msg.Flags = uint8(0)
+	msg.Scope = uint8(0)
+	msg.Index = uint32(0)
+
+	return msg
+}
+
+func (msg *IfAddrmsg) ToWireFormat() []byte {
+	native := nativeEndian()
+
+	len := syscall.SizeofIfAddrmsg
+	b := make([]byte, len)
+	b[0] = msg.Family
+	b[1] = msg.Prefixlen
+	b[2] = msg.Flags
+	b[3] = msg.Scope
+	native.PutUint32(b[4:8], msg.Index)
+	return b
+}
+
+type RtMsg struct {
+	syscall.RtMsg
+}
+
+func newRtMsg(family int) *RtMsg {
+	msg := &RtMsg{}
+	msg.Family = uint8(family)
+	msg.Table = syscall.RT_TABLE_MAIN
+	msg.Scope = syscall.RT_SCOPE_UNIVERSE
+	msg.Protocol = syscall.RTPROT_BOOT
+	msg.Type = syscall.RTN_UNICAST
+
+	return msg
+}
+
+func (msg *RtMsg) ToWireFormat() []byte {
+	native := nativeEndian()
+
+	len := syscall.SizeofRtMsg
+	b := make([]byte, len)
+	b[0] = msg.Family
+	b[1] = msg.Dst_len
+	b[2] = msg.Src_len
+	b[3] = msg.Tos
+	b[4] = msg.Table
+	b[5] = msg.Protocol
+	b[6] = msg.Scope
+	b[7] = msg.Type
+	native.PutUint32(b[8:12], msg.Flags)
+	return b
+}
+
+func rtaAlignOf(attrlen int) int {
+	return (attrlen + syscall.RTA_ALIGNTO - 1) & ^(syscall.RTA_ALIGNTO - 1)
+}
+
+type RtAttr struct {
+	syscall.RtAttr
+	Data []byte
+}
+
+func newRtAttr(attrType int, data []byte) *RtAttr {
+	attr := &RtAttr{}
+	attr.Type = uint16(attrType)
+	attr.Data = data
+
+	return attr
+}
+
+func (attr *RtAttr) ToWireFormat() []byte {
+	native := nativeEndian()
+
+	len := syscall.SizeofRtAttr + len(attr.Data)
+	b := make([]byte, rtaAlignOf(len))
+	native.PutUint16(b[0:2], uint16(len))
+	native.PutUint16(b[2:4], attr.Type)
+	for i, d := range attr.Data {
+		b[4+i] = d
+	}
+
+	return b
+}
+
+type NetlinkRequest struct {
+	syscall.NlMsghdr
+	Data []NetlinkRequestData
+}
+
+func (rr *NetlinkRequest) ToWireFormat() []byte {
+	native := nativeEndian()
+
+	length := rr.Len
+	dataBytes := make([][]byte, len(rr.Data))
+	for i, data := range rr.Data {
+		dataBytes[i] = data.ToWireFormat()
+		length = length + uint32(len(dataBytes[i]))
+	}
+	b := make([]byte, length)
+	native.PutUint32(b[0:4], length)
+	native.PutUint16(b[4:6], rr.Type)
+	native.PutUint16(b[6:8], rr.Flags)
+	native.PutUint32(b[8:12], rr.Seq)
+	native.PutUint32(b[12:16], rr.Pid)
+
+	i := 16
+	for _, data := range dataBytes {
+		for _, dataByte := range data {
+			b[i] = dataByte
+			i = i + 1
+		}
+	}
+	return b
+}
+
+func (rr *NetlinkRequest) AddData(data NetlinkRequestData) {
+	rr.Data = append(rr.Data, data)
+}
+
+func newNetlinkRequest(proto, flags int) *NetlinkRequest {
+	rr := &NetlinkRequest{}
+	rr.Len = uint32(syscall.NLMSG_HDRLEN)
+	rr.Type = uint16(proto)
+	rr.Flags = syscall.NLM_F_REQUEST | uint16(flags)
+	rr.Seq = uint32(getSeq())
+	return rr
+}
+
+type NetlinkSocket struct {
+	fd  int
+	lsa syscall.SockaddrNetlink
+}
+
+func getNetlinkSocket() (*NetlinkSocket, error) {
+	fd, err := syscall.Socket(syscall.AF_NETLINK, syscall.SOCK_RAW, syscall.NETLINK_ROUTE)
+	if err != nil {
+		return nil, err
+	}
+	s := &NetlinkSocket{
+		fd: fd,
+	}
+	s.lsa.Family = syscall.AF_NETLINK
+	if err := syscall.Bind(fd, &s.lsa); err != nil {
+		syscall.Close(fd)
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func (s *NetlinkSocket) Close() {
+	syscall.Close(s.fd)
+}
+
+func (s *NetlinkSocket) Send(request *NetlinkRequest) error {
+	if err := syscall.Sendto(s.fd, request.ToWireFormat(), 0, &s.lsa); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *NetlinkSocket) Recieve() ([]syscall.NetlinkMessage, error) {
+	rb := make([]byte, syscall.Getpagesize())
+	nr, _, err := syscall.Recvfrom(s.fd, rb, 0)
+	if err != nil {
+		return nil, err
+	}
+	if nr < syscall.NLMSG_HDRLEN {
+		return nil, fmt.Errorf("Got short response from netlink")
+	}
+	rb = rb[:nr]
+	return syscall.ParseNetlinkMessage(rb)
+}
+
+func (s *NetlinkSocket) GetPid() (uint32, error) {
+	lsa, err := syscall.Getsockname(s.fd)
+	if err != nil {
+		return 0, err
+	}
+	switch v := lsa.(type) {
+	case *syscall.SockaddrNetlink:
+		return v.Pid, nil
+	}
+	return 0, fmt.Errorf("Wrong socket type")
+}
+
+func (s *NetlinkSocket) HandleAck(seq uint32) error {
+	native := nativeEndian()
+
+	pid, err := s.GetPid()
+	if err != nil {
+		return err
+	}
+
+done:
+	for {
+		msgs, err := s.Recieve()
+		if err != nil {
+			return err
+		}
+		for _, m := range msgs {
+			if m.Header.Seq != seq {
+				return fmt.Errorf("Wrong Seq nr %d, expected %d", m.Header.Seq, seq)
+			}
+			if m.Header.Pid != pid {
+				return fmt.Errorf("Wrong pid %d, expected %d", m.Header.Pid, pid)
+			}
+			if m.Header.Type == syscall.NLMSG_DONE {
+				break done
+			}
+			if m.Header.Type == syscall.NLMSG_ERROR {
+				error := int32(native.Uint32(m.Data[0:4]))
+				if error == 0 {
+					break done
+				}
+				return syscall.Errno(-error)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Add a new default gateway. Identical to:
+// ip route add default via $ip
+func AddDefaultGw(ip net.IP) error {
+	s, err := getNetlinkSocket()
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	family := getIpFamily(ip)
+
+	wb := newNetlinkRequest(syscall.RTM_NEWROUTE, syscall.NLM_F_CREATE|syscall.NLM_F_EXCL|syscall.NLM_F_ACK)
+
+	msg := newRtMsg(family)
+	wb.AddData(msg)
+
+	var ipData []byte
+	if family == syscall.AF_INET {
+		ipData = ip.To4()
+	} else {
+		ipData = ip.To16()
+	}
+
+	gateway := newRtAttr(syscall.RTA_GATEWAY, ipData)
+
+	wb.AddData(gateway)
+
+	if err := s.Send(wb); err != nil {
+		return err
+	}
+
+	return s.HandleAck(wb.Seq)
+
+}
+
+// Bring up a particular network interface
+func NetworkLinkUp(iface *net.Interface) error {
+	s, err := getNetlinkSocket()
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	wb := newNetlinkRequest(syscall.RTM_NEWLINK, syscall.NLM_F_ACK)
+
+	msg := newIfInfomsg(syscall.AF_UNSPEC)
+	msg.Change = syscall.IFF_UP
+	msg.Flags = syscall.IFF_UP
+	msg.Index = int32(iface.Index)
+	wb.AddData(msg)
+
+	if err := s.Send(wb); err != nil {
+		return err
+	}
+
+	return s.HandleAck(wb.Seq)
+}
+
+// Add an Ip address to an interface. This is identical to:
+// ip addr add $ip/$ipNet dev $iface
+func NetworkLinkAddIp(iface *net.Interface, ip net.IP, ipNet *net.IPNet) error {
+	s, err := getNetlinkSocket()
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	family := getIpFamily(ip)
+
+	wb := newNetlinkRequest(syscall.RTM_NEWADDR, syscall.NLM_F_CREATE|syscall.NLM_F_EXCL|syscall.NLM_F_ACK)
+
+	msg := newIfAddrmsg(family)
+	msg.Index = uint32(iface.Index)
+	prefixLen, _ := ipNet.Mask.Size()
+	msg.Prefixlen = uint8(prefixLen)
+	wb.AddData(msg)
+
+	var ipData []byte
+	if family == syscall.AF_INET {
+		ipData = ip.To4()
+	} else {
+		ipData = ip.To16()
+	}
+
+	localData := newRtAttr(syscall.IFA_LOCAL, ipData)
+	wb.AddData(localData)
+
+	addrData := newRtAttr(syscall.IFA_ADDRESS, ipData)
+	wb.AddData(addrData)
+
+	if err := s.Send(wb); err != nil {
+		return err
+	}
+
+	return s.HandleAck(wb.Seq)
+}
+
+func zeroTerminated(s string) []byte {
+	bytes := make([]byte, len(s)+1)
+	for i := 0; i < len(s); i++ {
+		bytes[i] = s[i]
+	}
+	bytes[len(s)] = 0
+	return bytes
+}
+
+func nonZeroTerminated(s string) []byte {
+	bytes := make([]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		bytes[i] = s[i]
+	}
+	return bytes
+}
+
+// Add a new network link of a specified type. This is identical to
+// running: ip add link $name type $linkType
+func NetworkLinkAdd(name string, linkType string) error {
+	s, err := getNetlinkSocket()
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	wb := newNetlinkRequest(syscall.RTM_NEWLINK, syscall.NLM_F_CREATE|syscall.NLM_F_EXCL|syscall.NLM_F_ACK)
+
+	msg := newIfInfomsg(syscall.AF_UNSPEC)
+	wb.AddData(msg)
+
+	nameData := newRtAttr(syscall.IFLA_IFNAME, zeroTerminated(name))
+	wb.AddData(nameData)
+
+	IFLA_INFO_KIND := 1
+
+	kindData := newRtAttr(IFLA_INFO_KIND, nonZeroTerminated(linkType))
+
+	infoData := newRtAttr(syscall.IFLA_LINKINFO, kindData.ToWireFormat())
+	wb.AddData(infoData)
+
+	if err := s.Send(wb); err != nil {
+		return err
+	}
+
+	return s.HandleAck(wb.Seq)
+}
+
+// Returns an array of IPNet for all the currently routed subnets on ipv4
+// This is similar to the first column of "ip route" output
+func NetworkGetRoutes() ([]*net.IPNet, error) {
+	native := nativeEndian()
+
+	s, err := getNetlinkSocket()
+	if err != nil {
+		return nil, err
+	}
+	defer s.Close()
+
+	wb := newNetlinkRequest(syscall.RTM_GETROUTE, syscall.NLM_F_DUMP)
+
+	msg := newIfInfomsg(syscall.AF_UNSPEC)
+	wb.AddData(msg)
+
+	if err := s.Send(wb); err != nil {
+		return nil, err
+	}
+
+	pid, err := s.GetPid()
+	if err != nil {
+		return nil, err
+	}
+
+	res := make([]*net.IPNet, 0)
+
+done:
+	for {
+		msgs, err := s.Recieve()
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range msgs {
+			if m.Header.Seq != wb.Seq {
+				return nil, fmt.Errorf("Wrong Seq nr %d, expected 1", m.Header.Seq)
+			}
+			if m.Header.Pid != pid {
+				return nil, fmt.Errorf("Wrong pid %d, expected %d", m.Header.Pid, pid)
+			}
+			if m.Header.Type == syscall.NLMSG_DONE {
+				break done
+			}
+			if m.Header.Type == syscall.NLMSG_ERROR {
+				error := int32(native.Uint32(m.Data[0:4]))
+				if error == 0 {
+					break done
+				}
+				return nil, syscall.Errno(-error)
+			}
+			if m.Header.Type != syscall.RTM_NEWROUTE {
+				continue
+			}
+
+			var iface *net.Interface = nil
+			var ipNet *net.IPNet = nil
+
+			msg := (*RtMsg)(unsafe.Pointer(&m.Data[0:syscall.SizeofRtMsg][0]))
+
+			if msg.Flags&syscall.RTM_F_CLONED != 0 {
+				// Ignore cloned routes
+				continue
+			}
+
+			if msg.Table != syscall.RT_TABLE_MAIN {
+				// Ignore non-main tables
+				continue
+			}
+
+			if msg.Family != syscall.AF_INET {
+				// Ignore non-ipv4 routes
+				continue
+			}
+
+			if msg.Dst_len == 0 {
+				// Ignore default routes
+				continue
+			}
+
+			attrs, err := syscall.ParseNetlinkRouteAttr(&m)
+			if err != nil {
+				return nil, err
+			}
+			for _, attr := range attrs {
+				switch attr.Attr.Type {
+				case syscall.RTA_DST:
+					ip := attr.Value
+					ipNet = &net.IPNet{
+						IP:   ip,
+						Mask: net.CIDRMask(int(msg.Dst_len), 8*len(ip)),
+					}
+				case syscall.RTA_OIF:
+					index := int(native.Uint32(attr.Value[0:4]))
+					iface, _ = net.InterfaceByIndex(index)
+					_ = iface
+				}
+			}
+			if ipNet != nil {
+				res = append(res, ipNet)
+			}
+		}
+	}
+
+	return res, nil
+}

--- a/network.go
+++ b/network.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"github.com/dotcloud/docker/iptables"
 	"github.com/dotcloud/docker/proxy"
+	"github.com/dotcloud/docker/netlink"
 	"github.com/dotcloud/docker/utils"
 	"log"
 	"net"
-	"os/exec"
 	"strconv"
-	"strings"
 	"sync"
 )
 
@@ -68,42 +67,10 @@ func networkSize(mask net.IPMask) int32 {
 	return int32(binary.BigEndian.Uint32(m)) + 1
 }
 
-//Wrapper around the ip command
-func ip(args ...string) (string, error) {
-	path, err := exec.LookPath("ip")
-	if err != nil {
-		return "", fmt.Errorf("command not found: ip")
-	}
-	output, err := exec.Command(path, args...).CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("ip failed: ip %v", strings.Join(args, " "))
-	}
-	return string(output), nil
-}
-
-func checkRouteOverlaps(routes string, dockerNetwork *net.IPNet) error {
-	utils.Debugf("Routes:\n\n%s", routes)
-	for _, line := range strings.Split(routes, "\n") {
-		if strings.Trim(line, "\r\n\t ") == "" || strings.Contains(line, "default") {
-			continue
-		}
-		_, network, err := net.ParseCIDR(strings.Split(line, " ")[0])
-		if err != nil {
-			// is this a mask-less IP address?
-			if ip := net.ParseIP(strings.Split(line, " ")[0]); ip == nil {
-				// fail only if it's neither a network nor a mask-less IP address
-				return fmt.Errorf("Unexpected ip route output: %s (%s)", err, line)
-			} else {
-				_, network, err = net.ParseCIDR(ip.String() + "/32")
-				if err != nil {
-					return err
-				}
-			}
-		}
-		if err == nil && network != nil {
-			if networkOverlaps(dockerNetwork, network) {
-				return fmt.Errorf("Network %s is already routed: '%s'", dockerNetwork, line)
-			}
+func checkRouteOverlaps(networks []*net.IPNet, dockerNetwork *net.IPNet) error {
+	for _, network := range networks {
+		if networkOverlaps(dockerNetwork, network) {
+			return fmt.Errorf("Network %s is already routed: '%s'", dockerNetwork, network)
 		}
 	}
 	return nil
@@ -139,7 +106,7 @@ func CreateBridgeIface(config *DaemonConfig) error {
 		if err != nil {
 			return err
 		}
-		routes, err := ip("route")
+		routes, err := netlink.NetworkGetRoutes()
 		if err != nil {
 			return err
 		}
@@ -155,15 +122,22 @@ func CreateBridgeIface(config *DaemonConfig) error {
 	}
 	utils.Debugf("Creating bridge %s with network %s", config.BridgeIface, ifaceAddr)
 
-	if output, err := ip("link", "add", config.BridgeIface, "type", "bridge"); err != nil {
-		return fmt.Errorf("Error creating bridge: %s (output: %s)", err, output)
+	if err := netlink.NetworkLinkAdd(config.BridgeIface, "bridge"); err != nil {
+		return fmt.Errorf("Error creating bridge: %s", err)
 	}
-
-	if output, err := ip("addr", "add", ifaceAddr, "dev", config.BridgeIface); err != nil {
-		return fmt.Errorf("Unable to add private network: %s (%s)", err, output)
+	iface, err := net.InterfaceByName(config.BridgeIface)
+	if err != nil {
+		return err
 	}
-	if output, err := ip("link", "set", config.BridgeIface, "up"); err != nil {
-		return fmt.Errorf("Unable to start network bridge: %s (%s)", err, output)
+	ipAddr, ipNet, err := net.ParseCIDR(ifaceAddr)
+	if err != nil {
+		return err
+	}
+	if netlink.NetworkLinkAddIp(iface, ipAddr, ipNet); err != nil {
+		return fmt.Errorf("Unable to add private network: %s", err)
+	}
+	if err := netlink.NetworkLinkUp(iface); err != nil {
+		return fmt.Errorf("Unable to start network bridge: %s", err)
 	}
 	if config.EnableIptables {
 		if err := iptables.Raw("-t", "nat", "-A", "POSTROUTING", "-s", ifaceAddr,

--- a/network_test.go
+++ b/network_test.go
@@ -277,12 +277,13 @@ func TestNetworkOverlaps(t *testing.T) {
 }
 
 func TestCheckRouteOverlaps(t *testing.T) {
-	routes := `default via 10.0.2.2 dev eth0
-10.0.2.0 dev eth0  proto kernel  scope link  src 10.0.2.15
-10.0.3.0/24 dev lxcbr0  proto kernel  scope link  src 10.0.3.1
-10.0.42.0/24 dev testdockbr0  proto kernel  scope link  src 10.0.42.1
-172.16.42.0/24 dev docker0  proto kernel  scope link  src 172.16.42.1
-192.168.142.0/24 dev eth1  proto kernel  scope link  src 192.168.142.142`
+	routesData := []string{"10.0.2.0/32", "10.0.3.0/24", "10.0.42.0/24", "172.16.42.0/24", "192.168.142.0/24"}
+
+	routes := []*net.IPNet{}
+	for _, addr := range routesData {
+		_, netX, _ := net.ParseCIDR(addr)
+		routes = append(routes, netX)
+	}
 
 	_, netX, _ := net.ParseCIDR("172.16.0.1/24")
 	if err := checkRouteOverlaps(routes, netX); err != nil {

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/dotcloud/docker/devmapper"
+	"github.com/dotcloud/docker/sysinit"
 	"github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"
@@ -142,7 +143,7 @@ func init() {
 
 	// Hack to run sys init during unit testing
 	if selfPath := utils.SelfPath(); selfPath == "/sbin/init" || selfPath == "/.dockerinit" {
-		SysInit()
+		sysinit.SysInit()
 		return
 	}
 

--- a/sysinit.go
+++ b/sysinit.go
@@ -3,8 +3,10 @@ package docker
 import (
 	"flag"
 	"fmt"
+	"github.com/dotcloud/docker/netlink"
 	"github.com/dotcloud/docker/utils"
 	"log"
+	"net"
 	"os"
 	"os/exec"
 	"strconv"
@@ -17,7 +19,14 @@ func setupNetworking(gw string) {
 	if gw == "" {
 		return
 	}
-	if _, err := ip("route", "add", "default", "via", gw); err != nil {
+
+	ip := net.ParseIP(gw)
+	if ip == nil {
+		log.Fatalf("Unable to set up networking, %s is not a valid IP", gw)
+		return
+	}
+
+	if err := netlink.AddDefaultGw(ip); err != nil {
 		log.Fatalf("Unable to set up networking: %v", err)
 	}
 }

--- a/sysinit.go
+++ b/sysinit.go
@@ -67,7 +67,7 @@ func changeUser(u string) {
 }
 
 // Clear environment pollution introduced by lxc-start
-func cleanupEnv(env ListOpts) {
+func cleanupEnv(env utils.ListOpts) {
 	os.Clearenv()
 	for _, kv := range env {
 		parts := strings.SplitN(kv, "=", 2)
@@ -102,7 +102,7 @@ func SysInit() {
 	var gw = flag.String("g", "", "gateway address")
 	var workdir = flag.String("w", "", "workdir")
 
-	var flEnv ListOpts
+	var flEnv utils.ListOpts
 	flag.Var(&flEnv, "e", "Set environment variables")
 
 	flag.Parse()

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -1,4 +1,4 @@
-package docker
+package sysinit
 
 import (
 	"flag"

--- a/utils.go
+++ b/utils.go
@@ -199,7 +199,7 @@ func MergeConfig(userConf, imageConf *Config) {
 	}
 }
 
-func parseLxcConfOpts(opts ListOpts) ([]KeyValuePair, error) {
+func parseLxcConfOpts(opts utils.ListOpts) ([]KeyValuePair, error) {
 	out := make([]KeyValuePair, len(opts))
 	for i, o := range opts {
 		k, v, err := parseLxcOpt(o)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -22,6 +22,18 @@ import (
 	"time"
 )
 
+// ListOpts type
+type ListOpts []string
+
+func (opts *ListOpts) String() string {
+	return fmt.Sprint(*opts)
+}
+
+func (opts *ListOpts) Set(value string) error {
+	*opts = append(*opts, value)
+	return nil
+}
+
 // Go is a basic promise implementation: it wraps calls a function in a goroutine,
 // and returns a channel which will later return the function's return value.
 func Go(f func() error) chan error {


### PR DESCRIPTION
This moves the SysInit code to a separate module, allowing docker-init to avoid importing the main docker module, which in turn means it doesn't pick up dependencies like sqlite.

Note, this pull is based on (and contains the commits from) my netlink pull (https://github.com/dotcloud/docker/pull/2156) to avoid conflicts with that as they touch the same code.
