### PR TITLE
device-mapper: Move all devicemapper spew to log through utils.Debugf().

### DIFF
--- a/devmapper/deviceset_devmapper.go
+++ b/devmapper/deviceset_devmapper.go
@@ -327,7 +327,18 @@ func setCloseOnExec(name string) {
 	}
 }
 
+func (devices *DeviceSetDM) log(level int, file string, line int, dmError int, message string)  {
+	if level >= 7 {
+		return // Ignore _LOG_DEBUG
+	}
+
+	utils.Debugf("libdevmapper(%d): %s:%d (%d) %s", level, file, line, dmError, message)
+}
+
+
 func (devices *DeviceSetDM) initDevmapper() error {
+	logInit(devices)
+
 	info, err := getInfo(devices.getPoolName())
 	if info == nil {
 		utils.Debugf("Error device getInfo: %s", err)

--- a/devmapper/devmapper_log.go
+++ b/devmapper/devmapper_log.go
@@ -1,0 +1,13 @@
+package devmapper
+
+import "C"
+
+// Due to the way cgo works this has to be in a separate file, as devmapper.go has
+// definitions in the cgo block, which is incompatible with using "//export"
+
+//export DevmapperLogCallback
+func DevmapperLogCallback(level C.int, file *C.char, line C.int, dm_errno_or_class C.int, message *C.char) {
+	if dmLogger != nil {
+		dmLogger.log(int(level), C.GoString(file), int(line), int(dm_errno_or_class), C.GoString(message))
+	}
+}


### PR DESCRIPTION
This means you wont get a bunch of device mapper error spew in the tests.
It also means long term that we could try to extract better error messages from devmapper if needed.
