### PR TITLE
Add Capabilities bit support to docker layers

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -102,7 +102,7 @@ func escapeName(name string) string {
 // Tar creates an archive from the directory at `path`, only including files whose relative
 // paths are included in `filter`. If `filter` is nil, then all files are included.
 func TarFilter(path string, compression Compression, filter []string, recursive bool, createFiles []string) (io.Reader, error) {
-	args := []string{"tar", "--numeric-owner", "-f", "-", "-C", path, "-T", "-"}
+	args := []string{"tar", "--numeric-owner", "--xattrs", "-f", "-", "-C", path, "-T", "-"}
 	if filter == nil {
 		filter = []string{"."}
 	}
@@ -176,7 +176,7 @@ func Untar(archive io.Reader, path string) error {
 
 	utils.Debugf("Archive compression detected: %s", compression.Extension())
 
-	cmd := exec.Command("tar", "--numeric-owner", "-f", "-", "-C", path, "-x"+compression.Flag())
+	cmd := exec.Command("tar", "--xattrs", "--xattrs-include=security.capability", "--numeric-owner", "-f", "-", "-C", path, "-x"+compression.Flag())
 	cmd.Stdin = io.MultiReader(bytes.NewReader(buf), archive)
 	// Hardcode locale environment for predictable outcome regardless of host configuration.
 	//   (see https://github.com/dotcloud/docker/issues/355)

--- a/image.go
+++ b/image.go
@@ -174,6 +174,8 @@ func (image *Image) applyLayer(layer, target string) error {
 			return err
 		}
 
+		srcCapability, _ := Lgetxattr(srcPath, "security.capability")
+
 		relPath, err := filepath.Rel(layer, srcPath)
 		if err != nil {
 			return err
@@ -282,6 +284,12 @@ func (image *Image) applyLayer(layer, target string) error {
 				if err != nil {
 					return err
 				}
+			}
+
+			if srcCapability != nil {
+				syscall.Setxattr(targetPath, "security.capability", srcCapability, 0)
+			} else {
+				syscall.Removexattr(targetPath, "security.capability")
 			}
 
 			ts := []syscall.Timeval{

--- a/utils.go
+++ b/utils.go
@@ -346,3 +346,29 @@ func CopyFile(dstFile, srcFile *os.File) error {
 	_, err = io.Copy(dstFile, srcFile)
 	return err
 }
+
+func Lgetxattr(path string, attr string) ([]byte, error) {
+	var stat syscall.Stat_t
+	if err := syscall.Lstat(path, &stat); err != nil {
+		return nil, err
+	}
+	// No binding for lgetxattr yet...
+	if stat.Mode&syscall.S_IFLNK == syscall.S_IFLNK {
+		return nil, syscall.ENODATA
+	}
+
+	dest := make([]byte, 128)
+	sz, err := syscall.Getxattr(path, attr, dest)
+	if err != nil {
+		return nil, err
+	}
+	if sz > 128 {
+		dest = make([]byte, sz)
+		sz, err = syscall.Getxattr(path, attr, dest)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return dest[:sz], nil
+}


### PR DESCRIPTION
This adds support for storing capability bits (via xattrs) in docker layers.

I tested by running the mattdm/fedora:f19 image, installed httpd which has an attr in /sbin/suexec, commited the container to an image, started a container based on that image and verified (with the attr command) that /sbin/suexec still was set.

Note, this replaces https://github.com/dotcloud/docker/pull/2048 which seems to have a lot of unecessary commits in it.
