### PR TITLE
Use correct auth config when logging in.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -303,7 +303,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	}
 
 	cli.LoadConfigFile()
-	authconfig, ok := cli.configFile.Configs[auth.IndexServerAddress()]
+	authconfig, ok := cli.configFile.Configs[serverAddress]
 	if !ok {
 		authconfig = auth.AuthConfig{}
 	}


### PR DESCRIPTION
When logging in into a registry other than index.docker.io, docker will re-use cached credentials from i.d.io. This results in docker not asking for a password but instead sending what-ever password was cached for i.d.io.

cc @samalba
