### PR TITLE
Depend on golang-go instead of golang-stable

### DIFF
--- a/packaging/ubuntu/control
+++ b/packaging/ubuntu/control
@@ -2,7 +2,7 @@ Source: lxc-docker
 Section: misc
 Priority: extra
 Maintainer: Daniel Mizyrycki <daniel@dotcloud.com>
-Build-Depends: debhelper,autotools-dev,devscripts,golang-stable
+Build-Depends: debhelper,autotools-dev,devscripts,golang-go
 Standards-Version: 3.9.3
 Homepage: http://github.com/dotcloud/docker
 


### PR DESCRIPTION
golang-stable is part of gophers/go PPA which is frozen:
http://blog.labix.org/2013/06/15/in-flight-deb-packages-of-go

Since there is a official golang-go package available on ubuntu >= 12.04
and we don't officially support older versions anyway, we can just
depend on that instead.
