### PR TITLE
Change to correct working directory

### DIFF
--- a/docs/sources/contributing/devenvironment.rst
+++ b/docs/sources/contributing/devenvironment.rst
@@ -56,7 +56,7 @@ To create the Docker binary, run this command:
 
 .. code-block:: bash
 
-	sudo docker run -lxc-conf=lxc.aa_profile=unconfined -privileged -v `pwd`:/go/src/github.com/dotcloud/docker docker hack/make.sh binary
+  sudo docker run -lxc-conf=lxc.aa_profile=unconfined -privileged -v `pwd`:/go/src/github.com/dotcloud/docker -w /go/src/github.com/dotcloud/docker docker hack/make.sh binary
 
 This will create the Docker binary in ``./bundles/<version>-dev/binary/``
 
@@ -75,7 +75,7 @@ To execute the test cases, run this command:
 
 .. code-block:: bash
 
-	sudo docker run -lxc-conf=lxc.aa_profile=unconfined -privileged -v `pwd`:/go/src/github.com/dotcloud/docker docker hack/make.sh test
+	sudo docker run -lxc-conf=lxc.aa_profile=unconfined -privileged -v `pwd`:/go/src/github.com/dotcloud/docker -w /go/src/github.com/dotcloud/docker docker hack/make.sh test
 
 
 If the test are successful then the tail of the output should look something like this


### PR DESCRIPTION
Maybe I missed something, but we need to change to the correct working directory before running those commands. Otherwise hack/make.sh can't be found.
