### PR TITLE
Ignore build_src in tests.

### DIFF
--- a/hack/make/test
+++ b/hack/make/test
@@ -19,7 +19,7 @@ bundle_test() {
 # holding Go test files, and prints their paths on standard output, one per
 # line.
 find_test_dirs() {
-       find . -name '*_test.go' | grep -v '^./vendor' |
+       find . -name '*_test.go' | grep -E -v '^./(vendor|build_src)' |
                { while read f; do dirname $f; done; } |
                sort -u
 }


### PR DESCRIPTION
If someone has done a non docker build they may have vendor test files
in build_src.
