### PR TITLE
Allow loopback and base fs sizes set by env var

### DIFF
--- a/runtime_test.go
+++ b/runtime_test.go
@@ -127,6 +127,9 @@ func cleanupDevMapper() {
 
 func init() {
 	os.Setenv("TEST", "1")
+	os.Setenv("DOCKER_LOOPBACK_DATA_SIZE", "209715200") // 200MB
+	os.Setenv("DOCKER_LOOPBACK_META_SIZE", "104857600") // 100MB
+	os.Setenv("DOCKER_BASE_FS_SIZE", "157286400") // 150MB
 
 	// Hack to run sys init during unit testing
 	if selfPath := utils.SelfPath(); selfPath == "/sbin/init" || selfPath == "/.dockerinit" {


### PR DESCRIPTION
Set env vars to control sparse filesize.

``` bash

DOCKER_LOOPBACK_META_SIZE
DOCKER_LOOPBACK_DATA_SIZE
DOCKER_BASE_FS_SIZE
```

Default Values

``` bash
DOCKER_LOOPBACK_META_SIZE=2 * 1024 * 1024 * 1024
DOCKER_LOOPBACK_DATA_SIZE=100 * 1024 * 1024 * 1024
DOCKER_BASE_FS_SIZE=10 * 1024 * 1024 * 1024

```
