### PR TITLE
Add https cert and key options to docker

### DIFF
--- a/api.go
+++ b/api.go
@@ -1077,15 +1077,8 @@ func ListenAndServe(proto, addr string, srv *Server, logging bool) error {
 		return e
 	}
 
-	if len(srv.sslKey) > 0 && len(srv.sslCert) > 0 {
-		config := &tls.Config{}
-		config.NextProtos = []string{"http/1.1"}
-		config.Certificates = make([]tls.Certificate, 1)
-		config.Certificates[0], err = tls.LoadX509KeyPair(srv.sslCert, srv.sslKey)
-		if err != nil {
-			return err
-		}
-		l = tls.NewListener(l, config)
+	if srv.tlsConfig != nil {
+		l = tls.NewListener(l, srv.tlsConfig)
 	}
 
 	if proto == "unix" {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -37,6 +37,8 @@ func main() {
 	flDns := flag.String("dns", "", "Set custom dns servers")
 	flHosts := docker.ListOpts{fmt.Sprintf("unix://%s", docker.DEFAULTUNIXSOCKET)}
 	flag.Var(&flHosts, "H", "tcp://host:port to bind/connect to or unix://path/to/socket to use")
+	flCert := flag.String("sslcert", "", "path to SSL certificate file")
+	flKey := flag.String("sslkey", "", "path to SSL key file")
 	flag.Parse()
 	if *flVersion {
 		showVersion()
@@ -64,7 +66,7 @@ func main() {
 			flag.Usage()
 			return
 		}
-		if err := daemon(*pidfile, *flGraphPath, flHosts, *flAutoRestart, *flEnableCors, *flDns); err != nil {
+		if err := daemon(*pidfile, *flGraphPath, flHosts, *flAutoRestart, *flEnableCors, *flDns, *flCert, *flKey); err != nil {
 			log.Fatal(err)
 			os.Exit(-1)
 		}
@@ -115,7 +117,7 @@ func removePidFile(pidfile string) {
 	}
 }
 
-func daemon(pidfile string, flGraphPath string, protoAddrs []string, autoRestart, enableCors bool, flDns string) error {
+func daemon(pidfile string, flGraphPath string, protoAddrs []string, autoRestart, enableCors bool, flDns string, sslCert string, sslKey string) error {
 	if err := createPidFile(pidfile); err != nil {
 		log.Fatal(err)
 	}
@@ -133,7 +135,7 @@ func daemon(pidfile string, flGraphPath string, protoAddrs []string, autoRestart
 	if flDns != "" {
 		dns = []string{flDns}
 	}
-	server, err := docker.NewServer(flGraphPath, autoRestart, enableCors, dns)
+	server, err := docker.NewServer(flGraphPath, autoRestart, enableCors, dns, sslCert, sslKey)
 	if err != nil {
 		return err
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -59,6 +59,11 @@ func main() {
 	if *flDebug {
 		os.Setenv("DEBUG", "1")
 	}
+
+	if (len(*flKey) > 0) != (len(*flCert) > 0) {
+		log.Fatal("sslcert or sslkey set without the other. Please set both to enable https")
+	}
+
 	docker.GITCOMMIT = GITCOMMIT
 	docker.VERSION = VERSION
 	if *flDaemon {

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -88,4 +88,7 @@ Available Commands
 
 .. include:: command/wait.rst
 
+Server Flags
+~~~~~~~~~~~~
 
+.. include:: server/https.rst

--- a/docs/sources/commandline/index.rst
+++ b/docs/sources/commandline/index.rst
@@ -43,3 +43,4 @@ Contents:
   top     <command/top>
   version <command/version>
   wait    <command/wait>
+  https   <server/https>

--- a/docs/sources/commandline/server/https.rst
+++ b/docs/sources/commandline/server/https.rst
@@ -2,9 +2,9 @@
 :description: Flags to run docker with HTTPS
 :keywords: docker, documentation, server, daemon, https
 
-================================================
+=======================================================
 ``-sslkey, -sslcert`` -- Run a docker daemon with https
-================================================
+=======================================================
 
 ::
 

--- a/docs/sources/commandline/server/https.rst
+++ b/docs/sources/commandline/server/https.rst
@@ -1,0 +1,25 @@
+:title: HTTPS Docker Flags
+:description: Flags to run docker with HTTPS
+:keywords: docker, documentation, server, daemon, https
+
+================================================
+``-sslkey, -sslcert`` -- Run a docker daemon with https
+================================================
+
+::
+
+    -sslcert="": path to SSL certificate file
+    -sslkey="": path to SSL key file
+
+
+Examples
+--------
+
+.. code-block:: bash
+
+    sudo docker -d -H=tcp://0.0.0.0 -sslcert=cert.pem -sslkey=privkey.pem
+
+This will run docker as a daemon listening for https
+connections. This command uses go's built in https server so it only supports
+a subset of the full TLS protocol. Currently it only supports TLSv1.0 but when
+go 1.2 comes out it will have support for TLSv1.2.

--- a/docs/sources/examples/https.rst
+++ b/docs/sources/examples/https.rst
@@ -19,6 +19,7 @@ and a private key file. How to do this securely is beyond the scope of this
 example, however the following command will generate an example one.
 
 .. code-block:: bash
+
     openssl dsaparam -out dsaparam.pem 2048
     openssl gendsa -out privkey.pem dsaparam.pem
     openssl req -new -x509 -key privkey.pem -out cacert.pem -days 1095
@@ -28,6 +29,7 @@ Docker can then run using these certificates. Most commonly you will want to
 run docker on a different port that the default unix socket when in https mode.
 
 .. code-block:: bash
+
     sudo docker -d -sslkey=privkey.pem -sslcert=cacert.pem -H=tcp://0.0.0.0
 
 Note that when run in this way, the docker client will not work with docker.

--- a/docs/sources/examples/https.rst
+++ b/docs/sources/examples/https.rst
@@ -1,0 +1,33 @@
+:title: Docker HTTPS Setup
+:description: How to setup docker with https
+:keywords: docker, example, https, daemon
+
+.. _running_docker_https:
+
+Running docker with https
+=========================
+
+Normally docker runs via http on ``/var/run/docker.sock``
+
+.. code-block:: bash
+
+   sudo docker -d &
+
+
+If you wish to run docker via https you first need to generate a certificate
+and a private key file. How to do this securely is beyond the scope of this
+example, however the following command will generate an example one.
+
+.. code-block:: bash
+    openssl dsaparam -out dsaparam.pem 2048
+    openssl gendsa -out privkey.pem dsaparam.pem
+    openssl req -new -x509 -key privkey.pem -out cacert.pem -days 1095
+
+
+Docker can then run using these certificates. Most commonly you will want to
+run docker on a different port that the default unix socket when in https mode.
+
+.. code-block:: bash
+    sudo docker -d -sslkey=privkey.pem -sslcert=cacert.pem -H=tcp://0.0.0.0
+
+Note that when run in this way, the docker client will not work with docker.

--- a/docs/sources/examples/index.rst
+++ b/docs/sources/examples/index.rst
@@ -24,3 +24,4 @@ to more substantial services like you might find in production.
    postgresql_service
    mongodb
    running_riak_service
+   https

--- a/server.go
+++ b/server.go
@@ -1302,7 +1302,7 @@ func (srv *Server) ContainerCopy(name string, resource string, out io.Writer) er
 
 }
 
-func NewServer(flGraphPath string, autoRestart, enableCors bool, dns ListOpts) (*Server, error) {
+func NewServer(flGraphPath string, autoRestart, enableCors bool, dns ListOpts, sslCert string, sslKey string) (*Server, error) {
 	if runtime.GOARCH != "amd64" {
 		log.Fatalf("The docker runtime currently only supports amd64 (not %s). This will change in the future. Aborting.", runtime.GOARCH)
 	}
@@ -1318,6 +1318,8 @@ func NewServer(flGraphPath string, autoRestart, enableCors bool, dns ListOpts) (
 		events:      make([]utils.JSONMessage, 0, 64), //only keeps the 64 last events
 		listeners:   make(map[string]chan utils.JSONMessage),
 		reqFactory:  nil,
+		sslKey:      sslKey,
+		sslCert:     sslCert,
 	}
 	runtime.srv = srv
 	return srv, nil
@@ -1356,4 +1358,6 @@ type Server struct {
 	events      []utils.JSONMessage
 	listeners   map[string]chan utils.JSONMessage
 	reqFactory  *utils.HTTPRequestFactory
+	sslCert     string
+	sslKey      string
 }

--- a/server.go
+++ b/server.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"bufio"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1302,7 +1303,7 @@ func (srv *Server) ContainerCopy(name string, resource string, out io.Writer) er
 
 }
 
-func NewServer(flGraphPath string, autoRestart, enableCors bool, dns ListOpts, sslCert string, sslKey string) (*Server, error) {
+func NewServer(flGraphPath string, autoRestart, enableCors bool, dns ListOpts, tlsConfig *tls.Config) (*Server, error) {
 	if runtime.GOARCH != "amd64" {
 		log.Fatalf("The docker runtime currently only supports amd64 (not %s). This will change in the future. Aborting.", runtime.GOARCH)
 	}
@@ -1318,8 +1319,7 @@ func NewServer(flGraphPath string, autoRestart, enableCors bool, dns ListOpts, s
 		events:      make([]utils.JSONMessage, 0, 64), //only keeps the 64 last events
 		listeners:   make(map[string]chan utils.JSONMessage),
 		reqFactory:  nil,
-		sslKey:      sslKey,
-		sslCert:     sslCert,
+		tlsConfig:   tlsConfig,
 	}
 	runtime.srv = srv
 	return srv, nil
@@ -1358,6 +1358,5 @@ type Server struct {
 	events      []utils.JSONMessage
 	listeners   map[string]chan utils.JSONMessage
 	reqFactory  *utils.HTTPRequestFactory
-	sslCert     string
-	sslKey      string
+	tlsConfig   *tls.Config
 }


### PR DESCRIPTION
This adds two new options to the docker daemon which pass in a ssl certificate and private key. When both of these are passed in, it uses https rather than http.

Partially fixes issue #1745
