### PR TITLE
Runtime: Remove unused funtion hasFilesystemSupport()

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -81,25 +81,6 @@ func (runtime *Runtime) getContainerElement(id string) *list.Element {
 	return nil
 }
 
-func hasFilesystemSupport(fstype string) bool {
-	content, err := ioutil.ReadFile("/proc/filesystems")
-	if err != nil {
-		log.Printf("WARNING: Unable to read /proc/filesystems, assuming fs %s is not supported.", fstype)
-		return false
-	}
-	lines := strings.Split(string(content), "\n")
-	for _, line := range lines {
-		if strings.HasPrefix(line, "nodev") {
-			line = line[5:]
-		}
-		line = strings.TrimSpace(line)
-		if line == fstype {
-			return true
-		}
-	}
-	return false
-}
-
 func (runtime *Runtime) GetDeviceSet() (DeviceSet, error) {
 	if runtime.deviceSet == nil {
 		return nil, fmt.Errorf("No device set available")


### PR DESCRIPTION
This used to be used to be used to detect AUFS support, but is not
used anymore.
