### PR TITLE
Make docker build return exit code of build step

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -220,42 +220,16 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	if *rm {
 		v.Set("rm", "1")
 	}
-	req, err := http.NewRequest("POST", fmt.Sprintf("/v%g/build?%s", APIVERSION, v.Encode()), body)
-	if err != nil {
-		return err
-	}
+
+	headers := http.Header(make(map[string][]string))
 	if context != nil {
-		req.Header.Set("Content-Type", "application/tar")
+		headers.Set("Content-Type", "application/tar")
 	}
-	dial, err := net.Dial(cli.proto, cli.addr)
-	if err != nil {
-		return err
+	err = cli.stream("POST", fmt.Sprintf("/build?%s", v.Encode()), body, cli.out, headers)
+	if jerr, ok := err.(*utils.JSONError); ok {
+		return &utils.StatusError{Status: jerr.Message, StatusCode: jerr.Code}
 	}
-	clientconn := httputil.NewClientConn(dial, nil)
-	resp, err := clientconn.Do(req)
-	defer clientconn.Close()
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	// Check for errors
-	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-		if len(body) == 0 {
-			return fmt.Errorf("Error: %s", http.StatusText(resp.StatusCode))
-		}
-		return fmt.Errorf("Error: %s", body)
-	}
-
-	// Output the result
-	if _, err := io.Copy(cli.out, resp.Body); err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // 'docker login': login / register a user to registry service.
@@ -699,7 +673,7 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 	}
 	fmt.Fprintf(cli.out, "]")
 	if status != 0 {
-		return &utils.StatusError{Status: status}
+		return &utils.StatusError{StatusCode: status}
 	}
 	return nil
 }
@@ -1584,7 +1558,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 		return err
 	}
 	if status != 0 {
-		return &utils.StatusError{Status: status}
+		return &utils.StatusError{StatusCode: status}
 	}
 
 	return nil
@@ -2167,7 +2141,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		}
 	}
 	if status != 0 {
-		return &utils.StatusError{Status: status}
+		return &utils.StatusError{StatusCode: status}
 	}
 	return nil
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -100,7 +100,10 @@ func main() {
 		protoAddrParts := strings.SplitN(flHosts[0], "://", 2)
 		if err := docker.ParseCommands(protoAddrParts[0], protoAddrParts[1], flag.Args()...); err != nil {
 			if sterr, ok := err.(*utils.StatusError); ok {
-				os.Exit(sterr.Status)
+				if sterr.Status != "" {
+					log.Println(sterr.Status)
+				}
+				os.Exit(sterr.StatusCode)
 			}
 			log.Fatal(err)
 		}

--- a/docs/sources/api/docker_remote_api.rst
+++ b/docs/sources/api/docker_remote_api.rst
@@ -138,6 +138,11 @@ What's new
    This URI no longer exists.  The ``images -viz`` output is now generated in
    the client, using the ``/images/json`` data.
 
+.. http:post:: /build
+
+   **New!** This endpoint now returns build status as json stream. In case
+   of a build error, it returns the exit status of the failed command.
+
 v1.6
 ****
 

--- a/docs/sources/api/docker_remote_api_v1.7.rst
+++ b/docs/sources/api/docker_remote_api_v1.7.rst
@@ -990,9 +990,11 @@ Build an image from Dockerfile via stdin
    .. sourcecode:: http
 
       HTTP/1.1 200 OK
+      Content-Type: application/json
 
-      {{ STREAM }}
-
+      {"status":"Step 1..."}
+      {"status":"..."}
+      {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
 
    The stream must be a tar archive compressed with one of the
    following algorithms: identity (no compression), gzip, bzip2,

--- a/integration/buildfile_test.go
+++ b/integration/buildfile_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dotcloud/docker"
 	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/engine"
+	"github.com/dotcloud/docker/utils"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -226,11 +227,14 @@ func mkTestingFileServer(files [][2]string) (*httptest.Server, error) {
 
 func TestBuild(t *testing.T) {
 	for _, ctx := range testContexts {
-		buildImage(ctx, t, nil, true)
+		_, err := buildImage(ctx, t, nil, true)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 
-func buildImage(context testContextTemplate, t *testing.T, eng *engine.Engine, useCache bool) *docker.Image {
+func buildImage(context testContextTemplate, t *testing.T, eng *engine.Engine, useCache bool) (*docker.Image, error) {
 	if eng == nil {
 		eng = NewTestEngine(t)
 		runtime := mkRuntimeFromEngine(eng, t)
@@ -262,25 +266,24 @@ func buildImage(context testContextTemplate, t *testing.T, eng *engine.Engine, u
 	}
 	dockerfile := constructDockerfile(context.dockerfile, ip, port)
 
-	buildfile := docker.NewBuildFile(srv, ioutil.Discard, false, useCache, false)
+	buildfile := docker.NewBuildFile(srv, ioutil.Discard, false, useCache, false, utils.NewStreamFormatter(false))
 	id, err := buildfile.Build(mkTestContext(dockerfile, context.files, t))
 	if err != nil {
-		t.Fatal(err)
+		return nil, err
 	}
 
-	img, err := srv.ImageInspect(id)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return img
+	return srv.ImageInspect(id)
 }
 
 func TestVolume(t *testing.T) {
-	img := buildImage(testContextTemplate{`
+	img, err := buildImage(testContextTemplate{`
         from {IMAGE}
         volume /test
         cmd Hello world
     `, nil, nil}, t, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(img.Config.Volumes) == 0 {
 		t.Fail()
@@ -293,10 +296,13 @@ func TestVolume(t *testing.T) {
 }
 
 func TestBuildMaintainer(t *testing.T) {
-	img := buildImage(testContextTemplate{`
+	img, err := buildImage(testContextTemplate{`
         from {IMAGE}
         maintainer dockerio
     `, nil, nil}, t, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if img.Author != "dockerio" {
 		t.Fail()
@@ -304,10 +310,13 @@ func TestBuildMaintainer(t *testing.T) {
 }
 
 func TestBuildUser(t *testing.T) {
-	img := buildImage(testContextTemplate{`
+	img, err := buildImage(testContextTemplate{`
         from {IMAGE}
         user dockerio
     `, nil, nil}, t, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if img.Config.User != "dockerio" {
 		t.Fail()
@@ -315,11 +324,15 @@ func TestBuildUser(t *testing.T) {
 }
 
 func TestBuildEnv(t *testing.T) {
-	img := buildImage(testContextTemplate{`
+	img, err := buildImage(testContextTemplate{`
         from {IMAGE}
         env port 4243
         `,
 		nil, nil}, t, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	hasEnv := false
 	for _, envVar := range img.Config.Env {
 		if envVar == "port=4243" {
@@ -333,11 +346,14 @@ func TestBuildEnv(t *testing.T) {
 }
 
 func TestBuildCmd(t *testing.T) {
-	img := buildImage(testContextTemplate{`
+	img, err := buildImage(testContextTemplate{`
         from {IMAGE}
         cmd ["/bin/echo", "Hello World"]
         `,
 		nil, nil}, t, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if img.Config.Cmd[0] != "/bin/echo" {
 		t.Log(img.Config.Cmd[0])
@@ -350,11 +366,14 @@ func TestBuildCmd(t *testing.T) {
 }
 
 func TestBuildExpose(t *testing.T) {
-	img := buildImage(testContextTemplate{`
+	img, err := buildImage(testContextTemplate{`
         from {IMAGE}
         expose 4243
         `,
 		nil, nil}, t, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if img.Config.PortSpecs[0] != "4243" {
 		t.Fail()
@@ -362,11 +381,14 @@ func TestBuildExpose(t *testing.T) {
 }
 
 func TestBuildEntrypoint(t *testing.T) {
-	img := buildImage(testContextTemplate{`
+	img, err := buildImage(testContextTemplate{`
         from {IMAGE}
         entrypoint ["/bin/echo"]
         `,
 		nil, nil}, t, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if img.Config.Entrypoint[0] != "/bin/echo" {
 	}
@@ -378,19 +400,25 @@ func TestBuildEntrypointRunCleanup(t *testing.T) {
 	eng := NewTestEngine(t)
 	defer nuke(mkRuntimeFromEngine(eng, t))
 
-	img := buildImage(testContextTemplate{`
+	img, err := buildImage(testContextTemplate{`
         from {IMAGE}
         run echo "hello"
         `,
 		nil, nil}, t, eng, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	img = buildImage(testContextTemplate{`
+	img, err = buildImage(testContextTemplate{`
         from {IMAGE}
         run echo "hello"
         add foo /foo
         entrypoint ["/bin/echo"]
         `,
 		[][2]string{{"foo", "HEYO"}}, nil}, t, eng, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if len(img.Config.Cmd) != 0 {
 		t.Fail()
@@ -407,11 +435,18 @@ func TestBuildImageWithCache(t *testing.T) {
         `,
 		nil, nil}
 
-	img := buildImage(template, t, eng, true)
+	img, err := buildImage(template, t, eng, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	imageId := img.ID
 
 	img = nil
-	img = buildImage(template, t, eng, true)
+	img, err = buildImage(template, t, eng, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if imageId != img.ID {
 		t.Logf("Image ids should match: %s != %s", imageId, img.ID)
@@ -429,11 +464,17 @@ func TestBuildImageWithoutCache(t *testing.T) {
         `,
 		nil, nil}
 
-	img := buildImage(template, t, eng, true)
+	img, err := buildImage(template, t, eng, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 	imageId := img.ID
 
 	img = nil
-	img = buildImage(template, t, eng, false)
+	img, err = buildImage(template, t, eng, false)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if imageId == img.ID {
 		t.Logf("Image ids should not match: %s == %s", imageId, img.ID)
@@ -475,7 +516,7 @@ func TestForbiddenContextPath(t *testing.T) {
 	}
 	dockerfile := constructDockerfile(context.dockerfile, ip, port)
 
-	buildfile := docker.NewBuildFile(srv, ioutil.Discard, false, true, false)
+	buildfile := docker.NewBuildFile(srv, ioutil.Discard, false, true, false, utils.NewStreamFormatter(false))
 	_, err = buildfile.Build(mkTestContext(dockerfile, context.files, t))
 
 	if err == nil {
@@ -521,7 +562,7 @@ func TestBuildADDFileNotFound(t *testing.T) {
 	}
 	dockerfile := constructDockerfile(context.dockerfile, ip, port)
 
-	buildfile := docker.NewBuildFile(mkServerFromEngine(eng, t), ioutil.Discard, false, true, false)
+	buildfile := docker.NewBuildFile(mkServerFromEngine(eng, t), ioutil.Discard, false, true, false, utils.NewStreamFormatter(false))
 	_, err = buildfile.Build(mkTestContext(dockerfile, context.files, t))
 
 	if err == nil {
@@ -539,17 +580,25 @@ func TestBuildInheritance(t *testing.T) {
 	eng := NewTestEngine(t)
 	defer nuke(mkRuntimeFromEngine(eng, t))
 
-	img := buildImage(testContextTemplate{`
+	img, err := buildImage(testContextTemplate{`
             from {IMAGE}
             expose 4243
             `,
 		nil, nil}, t, eng, true)
 
-	img2 := buildImage(testContextTemplate{fmt.Sprintf(`
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	img2, _ := buildImage(testContextTemplate{fmt.Sprintf(`
             from %s
             entrypoint ["/bin/echo"]
             `, img.ID),
 		nil, nil}, t, eng, true)
+
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// from child
 	if img2.Config.Entrypoint[0] != "/bin/echo" {
@@ -559,5 +608,25 @@ func TestBuildInheritance(t *testing.T) {
 	// from parent
 	if img.Config.PortSpecs[0] != "4243" {
 		t.Fail()
+	}
+}
+
+func TestBuildFails(t *testing.T) {
+	_, err := buildImage(testContextTemplate{`
+        from {IMAGE}
+        run sh -c "exit 23"
+        `,
+		nil, nil}, t, nil, true)
+
+	if err == nil {
+		t.Fatal("Error should not be nil")
+	}
+
+	sterr, ok := err.(*utils.JSONError)
+	if !ok {
+		t.Fatalf("Error should be utils.JSONError")
+	}
+	if sterr.Code != 23 {
+		t.Fatalf("StatusCode %d unexpected, should be 23", sterr.Code)
 	}
 }

--- a/integration/commands_test.go
+++ b/integration/commands_test.go
@@ -905,9 +905,12 @@ run    [ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]
 		nil,
 		nil,
 	}
-	image := buildImage(testBuilder, t, eng, true)
+	image, err := buildImage(testBuilder, t, eng, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err := mkServerFromEngine(eng, t).ContainerTag(image.ID, "test", "latest", false)
+	err = mkServerFromEngine(eng, t).ContainerTag(image.ID, "test", "latest", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1184,11 +1184,12 @@ func (graph *DependencyGraph) GenerateTraversalMap() ([][]string, error) {
 
 // An StatusError reports an unsuccessful exit by a command.
 type StatusError struct {
-	Status int
+	Status     string
+	StatusCode int
 }
 
 func (e *StatusError) Error() string {
-	return fmt.Sprintf("Status: %d", e.Status)
+	return fmt.Sprintf("Status: %s, Code: %d", e.Status, e.StatusCode)
 }
 
 func quote(word string, buf *bytes.Buffer) {


### PR DESCRIPTION
If a command during build fails, `docker build` now returns with the exit code of that command.

This closes #1150.

It seems like either tests or the buildbot is already broken for current master: http://docker-ci.dotcloud.com/builders/docker/builds/418

I can't get all the tests to pass either (neither directly on my ubuntu 13.04, in the docker dev env, in vagrant on ubuntu 12.04 and in the docker dev env within vagrant), there is still this test failing:

--- FAIL: TestPrivilegedCanMount (0.84 seconds)
        container_test.go:1508: Could not mount into privileged container

But that's the case for both master and this branch, so I'm confident this shouldn't introduce regressions.
