### PR TITLE
Dont escape json strings in logs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -105,6 +105,7 @@ kim0 <email.ahmedkamal@googlemail.com>
 Kimbro Staken <kstaken@kstaken.com>
 Kiran Gangadharan <kiran.daredevil@gmail.com>
 Konstantin Pelykh <kpelykh@zettaset.com>
+Kushal Pisavadia <kushal@violentlymild.com>
 Kyle Conroy <kyle.j.conroy@gmail.com>
 Laurie Voss <github@seldo.com>
 Louis Opter <kalessin@kalessin.fr>

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -297,7 +297,7 @@ func CreateJSONLog(log string, stream string, created time.Time) JSONLog {
 		(&jsonLog).Log = jsonLine
 	}
 
-	return message
+	return jsonLog
 }
 
 func (w *WriteBroadcaster) Write(p []byte) (n int, err error) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -283,7 +283,7 @@ func escapeLog(line string) (*json.RawMessage, error) {
 	return objmap, json.Unmarshal([]byte(line), &objmap)
 }
 
-func CreateJSONLog(log string, stream Stream, created time.Time) JSONLog {
+func CreateJSONLog(log string, stream string, created time.Time) JSONLog {
 	jsonLog := JSONLog{
 		Log:     log,
 		Stream:  stream,

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -280,7 +280,8 @@ type JSONLog struct {
 
 func escapeLog(line string) (*json.RawMessage, error) {
 	var objmap *json.RawMessage
-	return objmap, json.Unmarshal([]byte(line), &objmap)
+	err := json.Unmarshal([]byte(line), &objmap)
+	return objmap, err
 }
 
 func CreateJSONLog(log string, stream string, created time.Time) JSONLog {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -273,9 +273,31 @@ func (w *WriteBroadcaster) AddWriter(writer io.WriteCloser, stream string) {
 }
 
 type JSONLog struct {
-	Log     string    `json:"log,omitempty"`
-	Stream  string    `json:"stream,omitempty"`
-	Created time.Time `json:"time"`
+	Log     interface{} `json:"log,omitempty"`
+	Stream  string      `json:"stream,omitempty"`
+	Created time.Time   `json:"time"`
+}
+
+func escapeLog(line string) (*json.RawMessage, error) {
+	var objmap *json.RawMessage
+	return objmap, json.Unmarshal([]byte(line), &objmap)
+}
+
+func CreateJSONLog(log string, stream Stream, created time.Time) JSONLog {
+	jsonLog := JSONLog{
+		Log:     log,
+		Stream:  stream,
+		Created: created,
+	}
+
+	// convert our string into a json.RawMessage if it's a
+	// string containing valid JSON.
+	jsonLine, err := escapeLog(log)
+	if err == nil {
+		(&jsonLog).Log = jsonLine
+	}
+
+	return message
 }
 
 func (w *WriteBroadcaster) Write(p []byte) (n int, err error) {
@@ -292,7 +314,8 @@ func (w *WriteBroadcaster) Write(p []byte) (n int, err error) {
 					w.buf.Write([]byte(line))
 					break
 				}
-				b, err := json.Marshal(&JSONLog{Log: line, Stream: sw.stream, Created: time.Now()})
+				jsonLog := CreateJSONLog(line, sw.stream, time.Now())
+				b, err := json.Marshal(&jsonLog)
 				if err != nil {
 					// On error, evict the writer
 					delete(w.writers, sw)


### PR DESCRIPTION
This fixes a bug in docker where logs shipped to `/var/lib/containers/id/id-json.log` would have JSON-formatted STDOUT/STDERR escaped instead of embedding it directly.

This fixes that by utilising an interface{} for the JSONLog struct instead of relying on a raw string.

Here's a self-contained example of this working: https://gist.github.com/KushalP/6982477
