### PR TITLE
Add vim syntax highlighting for Dockerfiles from @honza

### DIFF
--- a/contrib/vim-syntax/LICENSE
+++ b/contrib/vim-syntax/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2013 Honza Pokorny
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/contrib/vim-syntax/README.md
+++ b/contrib/vim-syntax/README.md
@@ -1,0 +1,23 @@
+dockerfile.vim
+==============
+
+Syntax highlighting for Dockerfiles
+
+Installation
+------------
+
+Via pathogen, the usual way...
+
+Features
+--------
+
+The syntax highlighting includes:
+
+* The directives (e.g. `FROM`)
+* Strings
+* Comments
+
+License
+-------
+
+BSD, short and sweet

--- a/contrib/vim-syntax/doc/dockerfile.txt
+++ b/contrib/vim-syntax/doc/dockerfile.txt
@@ -1,0 +1,18 @@
+*dockerfile.txt*  Syntax highlighting for Dockerfiles
+
+Author: Honza Pokorny <http://honza.ca>
+License: BSD
+
+INSTALLATION                                                     *installation*
+
+Drop it on your Pathogen path and you're all set.
+
+FEATURES                                                             *features*
+
+The syntax highlighting includes:
+
+* The directives (e.g. FROM)
+* Strings
+* Comments
+
+ vim:tw=78:et:ft=help:norl:

--- a/contrib/vim-syntax/ftdetect/dockerfile.vim
+++ b/contrib/vim-syntax/ftdetect/dockerfile.vim
@@ -1,0 +1,1 @@
+au BufNewFile,BufRead Dockerfile set filetype=dockerfile

--- a/contrib/vim-syntax/syntax/dockerfile.vim
+++ b/contrib/vim-syntax/syntax/dockerfile.vim
@@ -1,0 +1,22 @@
+" dockerfile.vim - Syntax highlighting for Dockerfiles
+" Maintainer:   Honza Pokorny <http://honza.ca>
+" Version:      0.5
+
+
+if exists("b:current_syntax")
+    finish
+endif
+
+let b:current_syntax = "dockerfile"
+
+syntax case ignore
+
+syntax match dockerfileKeyword /\v^\s*(FROM|MAINTAINER|RUN|CMD|EXPOSE|ENV|ADD)\s/
+syntax match dockerfileKeyword /\v^\s*(ENTRYPOINT|VOLUME|USER|WORKDIR)\s/
+highlight link dockerfileKeyword Keyword
+
+syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/
+highlight link dockerfileString String
+
+syntax match dockerfileComment "\v^\s*#.*$"
+highlight link dockerfileComment Comment


### PR DESCRIPTION
See https://github.com/honza/dockerfile.vim
See also https://twitter.com/_honza/status/390046317579620352

Just like the zsh completion script - this should help facilitate more collaboration and centralization.
