### PR TITLE
Add initial init scripts library

### DIFF
--- a/contrib/init/openrc/docker.confd
+++ b/contrib/init/openrc/docker.confd
@@ -1,0 +1,13 @@
+# /etc/conf.d/docker: config file for /etc/init.d/docker
+
+# where the docker daemon output gets piped
+#DOCKER_LOGFILE="/var/log/docker.log"
+
+# where docker's pid get stored
+#DOCKER_PIDFILE="/run/docker.pid"
+
+# where the docker daemon itself is run from
+#DOCKER_BINARY="/usr/bin/docker"
+
+# any other random options you want to pass to docker
+DOCKER_OPTS=""

--- a/contrib/init/openrc/docker.initd
+++ b/contrib/init/openrc/docker.initd
@@ -1,0 +1,31 @@
+#!/sbin/runscript
+# Copyright 1999-2013 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+DOCKER_LOGFILE=${DOCKER_LOGFILE:-/var/log/${SVCNAME}.log}
+DOCKER_PIDFILE=${DOCKER_PIDFILE:-/run/${SVCNAME}.pid}
+DOCKER_BINARY=${DOCKER_BINARY:-/usr/bin/docker}
+DOCKER_OPTS=${DOCKER_OPTS:-}
+
+start() {
+	checkpath -f -m 0644 -o root:docker "$DOCKER_LOGFILE"
+
+	ebegin "Starting docker daemon"
+	start-stop-daemon --start --background \
+		--exec "$DOCKER_BINARY" \
+		--pidfile "$DOCKER_PIDFILE" \
+		--stdout "$DOCKER_LOGFILE" \
+		--stderr "$DOCKER_LOGFILE" \
+		-- -d -p "$DOCKER_PIDFILE" \
+		$DOCKER_OPTS
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping docker daemon"
+	start-stop-daemon --stop \
+		--exec "$DOCKER_BINARY" \
+		--pidfile "$DOCKER_PIDFILE"
+	eend $?
+}

--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Easily create lightweight, portable, self-sufficient containers from any application!
+Documentation=http://docs.docker.io
+Requires=network.target
+After=multi-user.target
+
+[Service]
+Type=simple
+ExecStartPre=/bin/mount --make-rprivate /
+ExecStart=/usr/bin/docker -d
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/init/sysvinit/docker
+++ b/contrib/init/sysvinit/docker
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:           docker
+# Required-Start:     $syslog $remote_fs
+# Required-Stop:      $syslog $remote_fs
+# Default-Start:      2 3 4 5
+# Default-Stop:       0 1 6
+# Short-Description:  Linux container runtime
+# Description:        Linux container runtime
+### END INIT INFO
+
+DOCKER=/usr/bin/docker
+DOCKER_PIDFILE=/var/run/docker.pid
+DOCKER_OPTS=
+
+PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
+
+# Check lxc-docker is present
+[ -x $DOCKER ] || (log_failure_msg "docker not present"; exit 1)
+
+# Get lsb functions
+. /lib/lsb/init-functions
+
+if [ -f /etc/default/lxc ]; then
+	. /etc/default/lxc
+fi
+
+if [ "$1" = start ] && which initctl >/dev/null && initctl version | grep -q upstart; then
+	exit 1
+fi
+
+check_root_id ()
+{
+	if [ "$(id -u)" != "0" ]; then
+		log_failure_msg "Docker must be run as root"; exit 1
+	fi
+}
+
+case "$1" in
+	start)
+		check_root_id || exit 1
+		log_begin_msg "Starting Docker"
+		mount | grep cgroup >/dev/null || mount -t cgroup none /sys/fs/cgroup 2>/dev/null
+		start-stop-daemon --start --background $NO_CLOSE \
+			--exec "$DOCKER" \
+			--pidfile "$DOCKER_PIDFILE" \
+			-- -d -p "$DOCKER_PIDFILE" \
+			$DOCKER_OPTS
+		log_end_msg $?
+		;;
+
+	stop)
+		check_root_id || exit 1
+		log_begin_msg "Stopping Docker"
+		start-stop-daemon --stop \
+			--pidfile "$DOCKER_PIDFILE"
+		log_end_msg $?
+		;;
+
+	restart)
+		check_root_id || exit 1
+		docker_pid=`cat "$DOCKER_PIDFILE" 2>/dev/null`
+		[ -n "$docker_pid" ] \
+			&& ps -p $docker_pid > /dev/null 2>&1 \
+			&& $0 stop
+		$0 start
+		;;
+
+	force-reload)
+		check_root_id || exit 1
+		$0 restart
+		;;
+
+	status)
+		status_of_proc -p "$DOCKER_PIDFILE" "$DOCKER" docker
+		;;
+
+	*)
+		echo "Usage: $0 {start|stop|restart|status}"
+		exit 1
+		;;
+esac
+
+exit 0

--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -1,0 +1,10 @@
+description "Docker daemon"
+
+start on filesystem and started lxc-net
+stop on runlevel [!2345]
+
+respawn
+
+script
+	/usr/bin/docker -d
+end script

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -19,26 +19,17 @@ Docker is a great building block for automating distributed systems:
 large-scale web deployments, database clusters, continuous deployment systems,
 private PaaS, service-oriented architectures, etc."
 
-UPSTART_SCRIPT='description     "Docker daemon"
-
-start on filesystem and started lxc-net
-stop on runlevel [!2345]
-
-respawn
-
-script
-    /usr/bin/docker -d
-end script
-'
-
 # Build docker as an ubuntu package using FPM and REPREPRO (sue me).
 # bundle_binary must be called first.
 bundle_ubuntu() {
 	DIR=$DEST/build
 
-	# Generate an upstart config file (ubuntu-specific)
-	mkdir -p $DIR/etc/init
-	echo "$UPSTART_SCRIPT" > $DIR/etc/init/docker.conf
+	# Include our init scripts
+	mkdir -p $DIR/etc
+	cp -R contrib/init/upstart $DIR/etc/init
+	cp -R contrib/init/sysvinit $DIR/etc/init.d
+	mkdir -p $DIR/lib/systemd
+	cp -R contrib/init/systemd $DIR/lib/systemd/system
 
 	# Copy the binary
 	# This will fail if the binary bundle hasn't been built
@@ -47,29 +38,40 @@ bundle_ubuntu() {
 	# This will fail if the binary bundle hasn't been built
 	cp $DEST/../binary/docker-$VERSION $DIR/usr/bin/docker
 
-	# Generate postinstall/prerm scripts
-	cat >/tmp/postinstall <<EOF
+	# Generate postinst/prerm scripts
+	cat >/tmp/postinst <<'EOF'
 #!/bin/sh
-/sbin/stop docker || true
-/bin/grep -q "^docker:" /etc/group || /usr/sbin/addgroup --system docker || true
-/sbin/start docker
+service docker stop || true
+grep -q '^docker:' /etc/group || groupadd --system docker || true
+service docker start
 EOF
-	cat >/tmp/prerm <<EOF
+	cat >/tmp/prerm <<'EOF'
 #!/bin/sh
-/sbin/stop docker || true
-/usr/sbin/delgroup docker || true
+service docker stop || true
+
+case "$1" in
+	purge|remove|abort-install)
+		groupdel docker || true
+		;;
+		
+	upgrade|failed-upgrade|abort-upgrade)
+		# don't touch docker group
+		;;
+esac
 EOF
-	chmod +x /tmp/postinstall /tmp/prerm
+	chmod +x /tmp/postinst /tmp/prerm
 
 	(
 		cd $DEST
 		fpm -s dir -C $DIR \
 		    --name lxc-docker-$VERSION --version $PKGVERSION \
-		    --after-install /tmp/postinstall \
+		    --after-install /tmp/postinst \
 		    --before-remove /tmp/prerm \
 		    --architecture "$PACKAGE_ARCHITECTURE" \
 		    --prefix / \
-		    --depends lxc --depends aufs-tools \
+		    --depends lxc \
+		    --depends aufs-tools \
+		    --depends iptables \
 		    --description "$PACKAGE_DESCRIPTION" \
 		    --maintainer "$PACKAGE_MAINTAINER" \
 		    --conflicts lxc-docker-virtual-package \
@@ -80,6 +82,7 @@ EOF
 		    --url "$PACKAGE_URL" \
 		    --vendor "$PACKAGE_VENDOR" \
 		    --config-files /etc/init/docker.conf \
+		    --config-files /etc/init.d/docker \
 		    -t deb .
 		mkdir empty
 		fpm -s dir -C empty \
@@ -90,7 +93,6 @@ EOF
 		    --maintainer "$PACKAGE_MAINTAINER" \
 		    --url "$PACKAGE_URL" \
 		    --vendor "$PACKAGE_VENDOR" \
-		    --config-files /etc/init/docker.conf \
 		    -t deb .
 	)
 }


### PR DESCRIPTION
This is the init library as promised in #1534.  I also updated the `hack/make/ubuntu` script to use it, and to be more generic for use in Debian too by including both the upstart and the sysvinit, and adding the official upstart check to the top (so we can use the same get.docker.io package in both Ubuntu and Debian).

/cc @mzdaniel @shykes @jpetazzo @mattdm
