### PR TITLE
Catch errClosing error when TCP and UDP proxies are terminated.

### DIFF
--- a/network_proxy.go
+++ b/network_proxy.go
@@ -103,7 +103,11 @@ func (proxy *TCPProxy) Run() {
 	for {
 		client, err := proxy.listener.Accept()
 		if err != nil {
-			utils.Errorf("Stopping proxy on tcp/%v for tcp/%v (%v)", proxy.frontendAddr, proxy.backendAddr, err.Error())
+			if utils.IsClosedError(err) {
+				utils.Debugf("Stopping proxy on tcp/%v for tcp/%v (socket was closed)", proxy.frontendAddr, proxy.backendAddr)
+			} else {
+				utils.Errorf("Stopping proxy on tcp/%v for tcp/%v (%v)", proxy.frontendAddr, proxy.backendAddr, err.Error())
+			}
 			return
 		}
 		go proxy.clientLoop(client.(*net.TCPConn), quit)
@@ -205,7 +209,11 @@ func (proxy *UDPProxy) Run() {
 			// NOTE: Apparently ReadFrom doesn't return
 			// ECONNREFUSED like Read do (see comment in
 			// UDPProxy.replyLoop)
-			utils.Errorf("Stopping proxy on udp/%v for udp/%v (%v)", proxy.frontendAddr, proxy.backendAddr, err.Error())
+			if utils.IsClosedError(err) {
+				utils.Debugf("Stopping proxy on udp/%v for udp/%v (socket was closed)", proxy.frontendAddr, proxy.backendAddr)
+			} else {
+				utils.Errorf("Stopping proxy on udp/%v for udp/%v (%v)", proxy.frontendAddr, proxy.backendAddr, err.Error())
+			}
 			break
 		}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1028,3 +1028,13 @@ type StatusError struct {
 func (e *StatusError) Error() string {
 	return fmt.Sprintf("Status: %d", e.Status)
 }
+
+func IsClosedError(err error) bool {
+	/* This comparison is ugly, but unfortunately, net.go doesn't export errClosing.
+	 * See:
+	 * http://golang.org/src/pkg/net/net.go
+	 * https://code.google.com/p/go/issues/detail?id=4337
+	 * https://groups.google.com/forum/#!msg/golang-nuts/0_aaCvBmOcM/SptmDyX1XJMJ
+	 */
+	return strings.HasSuffix(err.Error(), "use of closed network connection")
+}


### PR DESCRIPTION
This removes a couple of spurious error messages when running the tests.
