### PR TITLE
Devmapper: Mount images readonly when calculating changes

### DIFF
--- a/devmapper/deviceset_devmapper.go
+++ b/devmapper/deviceset_devmapper.go
@@ -650,7 +650,7 @@ func (devices *DeviceSetDM) Shutdown() error {
 	return nil
 }
 
-func (devices *DeviceSetDM) MountDevice(hash, path string) error {
+func (devices *DeviceSetDM) MountDevice(hash, path string, readOnly bool) error {
 	devices.Lock()
 	defer devices.Unlock()
 
@@ -666,9 +666,15 @@ func (devices *DeviceSetDM) MountDevice(hash, path string) error {
 
 	info := devices.Devices[hash]
 
-	err := syscall.Mount(info.DevName(), path, "ext4", syscall.MS_MGC_VAL, "discard")
+	var flags uintptr = syscall.MS_MGC_VAL
+
+	if readOnly {
+		flags = flags | syscall.MS_RDONLY
+	}
+
+	err := syscall.Mount(info.DevName(), path, "ext4", flags, "discard")
 	if err != nil && err == syscall.EINVAL {
-		err = syscall.Mount(info.DevName(), path, "ext4", syscall.MS_MGC_VAL, "")
+		err = syscall.Mount(info.DevName(), path, "ext4", flags, "")
 	}
 	if err != nil {
 		utils.Debugf("\n--->Err: %s\n", err)

--- a/image.go
+++ b/image.go
@@ -384,7 +384,7 @@ func (image *Image) ensureImageDevice(devices *devmapper.DeviceSetDM) error {
 		return err
 	}
 
-	if err := devices.MountDevice(image.ID, mountDir); err != nil {
+	if err := devices.MountDevice(image.ID, mountDir, false); err != nil {
 		utils.Debugf("Error mounting device: %s", err)
 		devices.RemoveDevice(image.ID)
 		return err
@@ -467,7 +467,7 @@ func (image *Image) Mount(runtime *Runtime, root, rw string, id string) error {
 	}
 
 	utils.Debugf("Mounting container %s at %s for container", id, root)
-	if err := devices.MountDevice(id, root); err != nil {
+	if err := devices.MountDevice(id, root, false); err != nil {
 		return err
 	}
 
@@ -509,7 +509,7 @@ func (image *Image) Changes(runtime *Runtime, root, rw, id string) ([]Change, er
 
 	// We re-use rw for the temporary mount of the base image as its
 	// not used by device-mapper otherwise
-	err = devices.MountDevice(image.ID, rw)
+	err = devices.MountDevice(image.ID, rw, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There is no need to have this be writable, and there is a chance
that e.g. atime updates will cause writes to the image which is
bad for disk use wrt sharing between all containers.
