### PR TITLE
Make lxc-start namespace SLAVE, not PRIVATE

### DIFF
--- a/container.go
+++ b/container.go
@@ -814,7 +814,7 @@ func (container *Container) Start(hostConfig *HostConfig) (err error) {
 		// mount / MS_REC|MS_PRIVATE, but since we can't really clone or fork
 		// without exec in go we have to do this horrible shell hack...
 		shellString :=
-			"mount --make-rprivate /; exec " +
+			"mount --make-rslave /; exec " +
 				utils.ShellQuoteArguments(params)
 
 		params = []string{


### PR DESCRIPTION
If the root namespace is SHARED we need to change it to avoid
changes inside the container to propagate out of the container
(like when it unmounts everything).

However, making it private meant it took a snapshot of existing
mounts and keept them open making it impossible for the host
to fully unmount them. Instead we make it SLAVE, so we apply
unmount requests from the parent, but don't propagate back
local changes to the parent.

TThis fixes https://github.com/dotcloud/docker/issues/2286
