### PR TITLE
2070 validate source for bind mounts

### DIFF
--- a/commands_test.go
+++ b/commands_test.go
@@ -660,4 +660,22 @@ func TestCmdLogs(t *testing.T) {
 	if err := cli.CmdLogs(globalRuntime.List()[0].ID); err != nil {
 		t.Fatal(err)
 	}
+
+// Expected behaviour: using / as a bind mount source should throw an error
+func TestRunErrorBindMountRootSource(t *testing.T) {
+
+	cli := NewDockerCli(nil, nil, ioutil.Discard, testDaemonProto, testDaemonAddr)
+	defer cleanup(globalRuntime)
+
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		if err := cli.CmdRun("-v", "/:/tmp", unitTestImageID, "echo 'should fail'"); err == nil {
+			t.Fatal("should have failed to run when using / as a source for the bind mount")
+		}
+	}()
+
+	setTimeout(t, "CmdRun timed out", 5*time.Second, func() {
+		<-c
+	})
 }

--- a/commands_test.go
+++ b/commands_test.go
@@ -679,3 +679,22 @@ func TestRunErrorBindMountRootSource(t *testing.T) {
 		<-c
 	})
 }
+
+// Expected behaviour: error out when attempting to bind mount non-existing source paths
+func TestRunErrorBindNonExistingSource(t *testing.T) {
+
+	cli := NewDockerCli(nil, nil, ioutil.Discard, testDaemonProto, testDaemonAddr)
+	defer cleanup(globalRuntime)
+
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		if err := cli.CmdRun("-v", "/i/dont/exist:/tmp", unitTestImageID, "echo 'should fail'"); err == nil {
+			t.Fatal("should have failed to run when using /i/dont/exist as a source for the bind mount")
+		}
+	}()
+
+	setTimeout(t, "CmdRun timed out", 5*time.Second, func() {
+		<-c
+	})
+}

--- a/container.go
+++ b/container.go
@@ -251,6 +251,9 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 	for bind := range flVolumes {
 		arr := strings.Split(bind, ":")
 		if len(arr) > 1 {
+			if arr[0] == "/" {
+				return nil, nil, cmd, fmt.Errorf("Invalid bind mount: source can't be '/'")
+			}
 			dstDir := arr[1]
 			flVolumes[dstDir] = struct{}{}
 			binds = append(binds, bind)


### PR DESCRIPTION
This PR fixes issue #2070.

It makes the following changes:
- It adds client side validation of the bind mount to reject bind mounts which attempt to bind mount the root of the host to the container. This means it will reject bind mounts such as "/:/any/container/path" right away without attempting to connect to the server.
- It adds server side validation of the bind mounts to reject bind mounts which attempt to bind mount the root of the host to the container. The server will reject bind mounts such as "/:/any/container/path".
- It adds server side checking to ensure that the path exists on the host before attempting to bind mount it in the container. ContainerStart will error out and notify the client of the exact error.

Two tests have been added to ensure that these errors are getting thrown when appropriate.
