### PR TITLE
fix layer size computation: handle hard links correctly

### DIFF
--- a/container.go
+++ b/container.go
@@ -1559,20 +1559,46 @@ func validateID(id string) error {
 // GetSize, return real size, virtual size
 func (container *Container) GetSize() (int64, int64) {
 	var sizeRw, sizeRootfs int64
+	data := make(map[uint64]bool)
 
 	filepath.Walk(container.rwPath(), func(path string, fileInfo os.FileInfo, err error) error {
-		if fileInfo != nil {
-			sizeRw += fileInfo.Size()
+		if fileInfo == nil {
+			return nil
 		}
+		size := fileInfo.Size()
+		if size == 0 {
+			return nil
+		}
+
+		inode := fileInfo.Sys().(*syscall.Stat_t).Ino
+		if _, entryExists := data[inode]; entryExists {
+			return nil
+		}
+		data[inode] = false
+
+		sizeRw += size
 		return nil
 	})
 
+	data = make(map[uint64]bool)
 	_, err := os.Stat(container.RootfsPath())
 	if err == nil {
 		filepath.Walk(container.RootfsPath(), func(path string, fileInfo os.FileInfo, err error) error {
-			if fileInfo != nil {
-				sizeRootfs += fileInfo.Size()
+			if fileInfo == nil {
+				return nil
 			}
+			size := fileInfo.Size()
+			if size == 0 {
+				return nil
+			}
+
+			inode := fileInfo.Sys().(*syscall.Stat_t).Ino
+			if _, entryExists := data[inode]; entryExists {
+				return nil
+			}
+			data[inode] = false
+
+			sizeRootfs += size
 			return nil
 		})
 	}


### PR DESCRIPTION
This change makes docker compute layer sizes correctly.

The old code isn't taking hard links into account. Layers could appear as being 1-1.5-2x larger than they really were when a lot of hard links are involved.

With this change, the layer size is being computed correctly and reported exactly the same as `du`. The reason why it has to be computed correctly and take hard links into account is because that's the real amount of space that data is going to take.

Tar also handles hard links and the data isn't showing up twice in the tarball. That means there's no reason for Docker to compute the amount of space these layers are taking up on disk in any other way, other than the same way as `du`.
