### PR TITLE
sd notify

### DIFF
--- a/api.go
+++ b/api.go
@@ -72,12 +72,12 @@ func httpError(w http.ResponseWriter, err error) {
 		statusCode = http.StatusUnauthorized
 	} else if strings.Contains(err.Error(), "hasn't been activated") {
 		statusCode = http.StatusForbidden
-	}	
-	
+	}
+
 	if err != nil {
 		utils.Errorf("HTTP Error: statusCode=%d %s", statusCode, err.Error())
-		http.Error(w, err.Error(), statusCode)		
-	}	
+		http.Error(w, err.Error(), statusCode)
+	}
 }
 
 func writeJSON(w http.ResponseWriter, code int, v interface{}) error {

--- a/api.go
+++ b/api.go
@@ -1083,8 +1083,6 @@ func createRouter(srv *Server, logging bool) (*mux.Router, error) {
 }
 
 func ListenAndServe(proto, addr string, srv *Server, logging bool) error {
-	log.Printf("Listening for HTTP on %s (%s)\n", addr, proto)
-
 	r, err := createRouter(srv, logging)
 	if err != nil {
 		return err
@@ -1115,5 +1113,10 @@ func ListenAndServe(proto, addr string, srv *Server, logging bool) error {
 		}
 	}
 	httpSrv := http.Server{Addr: addr, Handler: r}
+
+	log.Printf("Listening for HTTP on %s (%s)\n", addr, proto)
+	// Tell the init daemon we are accepting requests
+	go sd_notify("READY=1")
+
 	return httpSrv.Serve(l)
 }

--- a/api_params.go
+++ b/api_params.go
@@ -56,13 +56,13 @@ type APIContainers struct {
 
 func (self *APIContainers) ToLegacy() APIContainersOld {
 	return APIContainersOld{
-		ID: self.ID,
-		Image: self.Image,
-		Command: self.Command,
-		Created: self.Created,
-		Status: self.Status,
-		Ports: displayablePorts(self.Ports),
-		SizeRw: self.SizeRw,
+		ID:         self.ID,
+		Image:      self.Image,
+		Command:    self.Command,
+		Created:    self.Created,
+		Status:     self.Status,
+		Ports:      displayablePorts(self.Ports),
+		SizeRw:     self.SizeRw,
 		SizeRootFs: self.SizeRootFs,
 	}
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -96,7 +96,6 @@ func init() {
 	startFds, startGoroutines = utils.GetTotalUsedFds(), runtime.NumGoroutine()
 }
 
-
 func setupBaseImage() {
 	runtime, err := NewRuntimeFromDirectory(unitTestStoreBase, false)
 	if err != nil {
@@ -119,7 +118,6 @@ func setupBaseImage() {
 		}
 	}
 }
-
 
 func spawnGlobalDaemon() {
 	if globalRuntime != nil {

--- a/sd_notify.go
+++ b/sd_notify.go
@@ -1,0 +1,33 @@
+package docker
+
+import (
+	"errors"
+	"net"
+	"os"
+)
+
+var sdNotifyNoSocket = errors.New("No socket")
+
+// Send a message to the init daemon. It is common to ignore the error.
+func sd_notify(state string) error {
+	socketAddr := &net.UnixAddr{
+		Name: os.Getenv("NOTIFY_SOCKET"),
+		Net:  "unixgram",
+	}
+
+	if socketAddr.Name == "" {
+		return sdNotifyNoSocket
+	}
+
+	conn, err := net.DialUnix(socketAddr.Net, nil, socketAddr)
+	if err != nil {
+		return err
+	}
+
+	_, err = conn.Write([]byte(state))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/state.go
+++ b/state.go
@@ -9,12 +9,12 @@ import (
 
 type State struct {
 	sync.Mutex
-	Running   bool
-	Pid       int
-	ExitCode  int
-	StartedAt time.Time
+	Running    bool
+	Pid        int
+	ExitCode   int
+	StartedAt  time.Time
 	FinishedAt time.Time
-	Ghost     bool
+	Ghost      bool
 }
 
 // String returns a human-readable description of the state

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,15 +1,15 @@
 package docker
 
 import (
-	"github.com/dotcloud/docker/utils"
 	"fmt"
+	"github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 	"testing"
-	"runtime"
 )
 
 // This file contains utility functions for docker's unit test suite.
@@ -26,7 +26,7 @@ func mkRuntime(f Fataler) *Runtime {
 	pc, _, _, _ := runtime.Caller(1)
 	callerLongName := runtime.FuncForPC(pc).Name()
 	parts := strings.Split(callerLongName, ".")
-	callerShortName := parts[len(parts) - 1]
+	callerShortName := parts[len(parts)-1]
 	if globalTestID == "" {
 		globalTestID = GenerateID()[:4]
 	}


### PR DESCRIPTION
Fixes #2322
For issue 2322. This allows systemd (or another init system) to know when docker is ready to receive requests.

Tested with the following systemd service file.

[Unit]
Description=Docker Linux Container Manager

[Service]
Type=notify
ExecStart=/usr/local/bin/docker -d

[Install]
WantedBy=multi-user.target
