### PR TITLE
Set commentstring in Vim syntax plugin

### DIFF
--- a/contrib/vim-syntax/syntax/dockerfile.vim
+++ b/contrib/vim-syntax/syntax/dockerfile.vim
@@ -20,3 +20,5 @@ highlight link dockerfileString String
 
 syntax match dockerfileComment "\v^\s*#.*$"
 highlight link dockerfileComment Comment
+
+set commentstring=#\ %s


### PR DESCRIPTION
By setting the commentstring, you support commenting with plugins like tComment.
Now Vim won't default to incorrect `/* */` comments.
