### PR TITLE
735 include verb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ docs/_templates
 bundles/
 .hg/
 .git/
+y.output
+buildfile_lexer.go
+buildfile_parser.go

--- a/buildfile.nex
+++ b/buildfile.nex
@@ -1,0 +1,150 @@
+/[0-9]+/ {
+    i, err := strconv.ParseUint(yylex.Text(), 10, 16)
+    if err != nil {
+        yylex.Error("Invalid decimal integer: " + yylex.Text())
+    }
+    lval.i = int(i)
+    return tokInt
+}
+
+/,/ {
+    return tokComma
+}
+
+/:/ {
+    return tokColon
+}
+
+/\[/ {
+    return tokLBracket
+}
+
+/\]/ {
+    return tokRBracket
+}
+
+/"[^"]*"/ {
+    t := yylex.Text()
+    lval.s = linecont.ReplaceAllString(t[1:len(t)-1], "")
+    lval.s = whitespace.ReplaceAllString(lval.s, " ")
+    return tokStr
+}
+
+/'[^']*'/ {
+    t := yylex.Text()
+    lval.s = linecont.ReplaceAllString(t[1:len(t)-1], "")
+    lval.s = whitespace.ReplaceAllString(lval.s, " ")
+    return tokStr
+}
+
+/[a-zA-Z][a-zA-Z_.0-9]*/ {
+    lval.s = yylex.Text()
+    if tok, ok := instructions[strings.ToLower(lval.s)]; ok {
+        return tok
+    }
+    return tokId
+}
+
+/[^"',\[\]\n\r\t \\]+/ {
+    lval.s = yylex.Text()
+    return tokArg
+}
+
+/[ \t\r]/ {
+    // ignore whitespace
+}
+
+/[\\]/ {
+    
+}
+
+/#[^\n]*\n/ {
+    // ignore comments
+    yylex.l++
+}
+
+/\n+/ {
+    yylex.l += len(yylex.Text())
+}
+
+/./ {
+    yylex.Error(fmt.Sprintf("Unexpected character: %q", yylex.Text()))
+}
+
+//
+//" nex -e -o buildfile_lexer.go buildfile.nex
+
+package docker 
+
+import (
+    "strconv"
+    "os"
+    "fmt"
+    "regexp"
+)
+
+var instructions = map[string]int{
+    "from":       tokFrom,
+    "maintainer": tokMaintainer,
+    "run":        tokRun,
+    "cmd":        tokCommand,
+    "expose":     tokExpose,
+    "env":        tokEnv,
+    "add":        tokAdd,
+    "entrypoint": tokEntryPoint,
+    "volume":     tokVolume,
+    "user":       tokUser,
+    "workdir":    tokWorkDir,
+}
+
+// Long lines can be split with a backslash
+var (
+    linecont = regexp.MustCompile(`\s*\\\s*\n`)
+    whitespace = regexp.MustCompile(`\s+`)
+)
+
+func parse(reader io.Reader) (file *dockerFile, err error) {
+    defer func() {
+        if e := recover(); e != nil {
+            switch e := e.(type) {
+            case error:
+                err = e
+            }
+        }
+    }()
+    lexer := NewLexer(reader)
+    yyParse(lexer)
+    file = parsedFile
+    return 
+}
+
+func parseFile(filename string) (*dockerFile, error) {
+    fd, err := os.Open(filename)
+    if err != nil { 
+        return nil, err 
+    }
+    file, err := parse(fd)
+    fd.Close()
+    return file, nil
+}
+
+func (yylex Lexer) Error(e string) {
+    panic(fmt.Errorf("%d: %s", yylex.l + 1, e))
+}
+
+func token(tok int, lval *yySymType) string {
+    switch tok {
+    case tokComma:
+        return ","
+    case tokColon:
+        return ":"
+    case tokLBracket:
+        return "["
+    case tokRBracket:
+        return "]"
+    case tokInt:
+        return strconv.Itoa(lval.i)
+    default:
+        return lval.s
+    }
+}

--- a/buildfile.nex
+++ b/buildfile.nex
@@ -95,6 +95,7 @@ var instructions = map[string]int{
     "volume":     tokVolume,
     "user":       tokUser,
     "workdir":    tokWorkDir,
+    "include":    tokInclude,
 }
 
 // Long lines can be split with a backslash

--- a/buildfile.y
+++ b/buildfile.y
@@ -1,0 +1,311 @@
+%{
+// go tool yacc -o buildfile_parser.go buildfile.y 
+
+package docker
+
+import (
+	"strings"
+	"strconv"
+)
+%}
+
+%union {
+	i int
+	ia []int
+	s string
+	sa []string
+	v interface{}
+	va []interface{}
+}
+
+%token <s> tokId
+%token <i> tokInt
+%token <s> tokStr
+%token <s> tokArg
+
+%type <va> instructions
+%type <sa> shellArgs condArgs execArgs
+%type <sa> spaceArgList commaArgList
+%type <ia> ints
+
+%type <v> instruction 
+%type <v> fromInstr
+%type <v> maintainerInstr
+%type <v> runInstr
+%type <v> commandInstr
+%type <v> exposeInstr
+%type <v> envInstr
+%type <v> addInstr
+%type <v> entryPointInstr
+%type <v> volumeInstr
+%type <v> userInstr
+%type <v> workDirInstr
+%type <s> arg
+
+%token tokComma
+%token tokColon
+%token tokLBracket
+%token tokRBracket
+%token tokFrom
+%token tokMaintainer
+%token tokCommand
+%token tokRun
+%token tokExpose
+%token tokEnv
+%token tokAdd
+%token tokEntryPoint
+%token tokVolume
+%token tokUser
+%token tokWorkDir
+
+%%
+
+buildFile : 
+	instructions 
+	{
+		parsedFile = &dockerFile{$1}
+	}
+
+instructions : 
+	instructions instruction 
+	{
+		if $2 == nil {
+			$$ = make([]interface{}, 0)
+			$$ = append($$, $1)
+		} else {
+			$$ = $1
+			$$ = append($1, $2)
+		}
+	} 
+|	instruction 
+	{
+		if $1 == nil {
+			$$ = []interface{}{}
+		} else {
+			$$ = make([]interface{}, 0)
+			$$ = append($$, $1)
+		}
+	}
+
+instruction: 
+	fromInstr 
+|	maintainerInstr
+|	commandInstr
+|	runInstr
+|	exposeInstr
+|	envInstr
+|	addInstr
+|	entryPointInstr
+|	volumeInstr
+|	userInstr
+|	workDirInstr
+
+fromInstr: 
+	tokFrom arg
+	{
+		$$ = &fromArgs{
+			name: $2,
+		}
+	}
+|	tokFrom arg tokColon arg
+	{
+		$$ = &fromArgs{
+			name: $2 + ":" + $4,
+		}		
+	}
+
+maintainerInstr: 
+	tokMaintainer spaceArgList
+	{
+		$$ = &maintainerArgs{
+			name: strings.Join($2, " "),
+		}
+	}
+
+runInstr: 
+	tokRun shellArgs
+	{
+		$$ = &runArgs{
+			cmd: fixcmd($2),
+		}
+	}
+|	tokRun execArgs
+	{
+		$$ = &runArgs{
+			cmd: $2,
+		}
+	}
+|	tokRun condArgs
+	{
+		$$ = &runArgs{
+			cmd: fixcmd($2),
+		}
+	}
+
+commandInstr: 
+	tokCommand shellArgs
+	{
+		$$ = &cmdArgs{
+			cmd: fixcmd($2),
+		}
+	}
+|	tokCommand execArgs
+	{
+		$$ = &cmdArgs{
+			cmd: $2,
+		}
+	}
+|	tokCommand condArgs
+	{
+		$$ = &cmdArgs{
+			cmd: fixcmd($2),
+		}
+	}
+
+exposeInstr:
+	tokExpose ints 
+	{
+		$$ = &exposeArgs{
+			ports: $2,
+		}
+	}
+
+envInstr:
+	tokEnv tokId arg
+	{
+		$$ = &envArgs{
+			key:   $2,
+			value: $3,
+		}
+	}
+
+addInstr:
+	tokAdd arg arg 
+	{
+		$$ = &addArgs{
+			src: $2,
+			dst: $3,
+		}	
+	}
+
+entryPointInstr: 
+	tokEntryPoint shellArgs
+	{
+		$$ = &entryPointArgs{
+			cmd: fixcmd($2),
+		}
+	}
+|	tokEntryPoint execArgs
+	{
+		$$ = &entryPointArgs{
+			cmd: $2,
+		}
+	}
+|	tokEntryPoint condArgs
+	{
+		$$ = &entryPointArgs{
+			cmd: $2,
+		}
+	}
+
+volumeInstr:
+	tokVolume shellArgs
+	{
+		$$ = &volumeArgs{
+			volumes: $2,
+		}	
+	}
+|	tokVolume execArgs
+	{
+		$$ = &volumeArgs{
+			volumes: $2,
+		}	
+	}
+
+userInstr: 
+	tokUser arg 
+	{
+		$$ = &userArgs{
+			name: $2,
+		}
+	}
+
+workDirInstr:
+	tokWorkDir arg 
+	{
+		$$ = &workDirArgs{
+			path: $2,
+		}	
+	}
+
+/* 
+We have 3 types of argument lists here:
+1. [ foo bar baz ] -- shell condition eval
+2. [ foo, bar, baz ] -- docker arguments to exec
+3. foo bar baz -- docker arguments to /bin/sh -c
+*/
+
+condArgs: 
+	tokLBracket spaceArgList tokRBracket 
+	{
+		$$ = append([]string{"["}, append($2, "]")...)
+	}
+
+shellArgs: 
+	spaceArgList
+
+execArgs: 
+	tokLBracket commaArgList tokRBracket 
+	{
+		$$ = $2
+	}
+
+spaceArgList:
+	spaceArgList arg 
+	{
+		$$ = append($1, $2)
+	} 
+|	arg 
+	{
+		if $1 == "" {
+			$$ = []string{}
+		} else {
+			$$ = []string{$1}
+		}
+	}
+
+commaArgList:
+	commaArgList tokComma arg 
+	{
+		$$ = append($1, $3)
+	} 
+|	arg tokComma arg
+	{
+		$$ = []string{$1, $3}
+	}
+
+arg: 
+	tokArg 
+|	tokId
+|	tokStr
+|	tokInt 
+	{
+		$$ = strconv.Itoa($1)
+	}
+
+ints: 
+	ints tokInt 
+	{
+		$$ = append($1, $2)
+	} 
+|	tokInt 
+	{
+		if $1 == 0 {
+			$$ = []int{}
+		} else {
+			$$ = []int{$1}
+		}
+	}
+
+%%
+

--- a/buildfile.y
+++ b/buildfile.y
@@ -40,6 +40,7 @@ import (
 %type <v> volumeInstr
 %type <v> userInstr
 %type <v> workDirInstr
+%type <v> includeInstr
 %type <s> arg
 
 %token tokComma
@@ -57,6 +58,7 @@ import (
 %token tokVolume
 %token tokUser
 %token tokWorkDir
+%token tokInclude 
 
 %%
 
@@ -99,6 +101,7 @@ instruction:
 |	volumeInstr
 |	userInstr
 |	workDirInstr
+|	includeInstr
 
 fromInstr: 
 	tokFrom arg
@@ -235,6 +238,14 @@ workDirInstr:
 	{
 		$$ = &workDirArgs{
 			path: $2,
+		}	
+	}
+
+includeInstr:
+	tokInclude arg 
+	{
+		$$ = &includeArgs{
+			filename: $2,
 		}	
 	}
 

--- a/buildfile_parser_helper.go
+++ b/buildfile_parser_helper.go
@@ -52,6 +52,10 @@ type workDirArgs struct {
 	path string
 }
 
+type includeArgs struct {
+	filename string
+}
+
 type dockerFile struct {
 	instructions []interface{}
 }
@@ -124,6 +128,10 @@ func (args *userArgs) String() string {
 
 func (args *workDirArgs) String() string {
 	return "WORKDIR " + args.path
+}
+
+func (args *includeArgs) String() string {
+	return "INCLUDE " + args.filename
 }
 
 func (file *dockerFile) String() string {

--- a/buildfile_parser_helper.go
+++ b/buildfile_parser_helper.go
@@ -1,0 +1,137 @@
+package docker
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type fromArgs struct {
+	name string
+}
+
+type maintainerArgs struct {
+	name string
+}
+
+type runArgs struct {
+	cmd []string
+}
+
+type cmdArgs struct {
+	cmd []string
+}
+
+type exposeArgs struct {
+	ports []int
+}
+
+type envArgs struct {
+	key   string
+	value string
+}
+
+type addArgs struct {
+	src string
+	dst string
+}
+
+type entryPointArgs struct {
+	cmd []string
+}
+
+type volumeArgs struct {
+	volumes []string
+}
+
+type userArgs struct {
+	name string
+}
+
+type workDirArgs struct {
+	path string
+}
+
+type dockerFile struct {
+	instructions []interface{}
+}
+
+// used by the parser
+var (
+	parsedFile *dockerFile
+	shell      = map[string]bool{
+		"sh":        true,
+		"/bin/sh":   true,
+		"bash":      true,
+		"/bin/bash": true,
+		"csh":       true,
+		"/bin/csh":  true,
+	}
+)
+
+func fixcmd(cmd []string) []string {
+	if !shell[cmd[0]] {
+		cmd = append([]string{"/bin/sh", "-c"}, strings.Join(cmd, " "))
+	}
+	return cmd
+}
+
+// String version of instructions returned by the parser
+
+func (args *fromArgs) String() string {
+	return "FROM " + args.name
+}
+
+func (args *maintainerArgs) String() string {
+	return "MAINTAINER " + args.name
+}
+
+func (args *runArgs) String() string {
+	return "RUN " + strings.Join(args.cmd, " ")
+}
+
+func (args *cmdArgs) String() string {
+	return "CMD " + strings.Join(args.cmd, " ")
+}
+
+func (args *exposeArgs) String() string {
+	a := make([]string, len(args.ports))
+	for i := 0; i < len(args.ports); i++ {
+		a[i] = strconv.Itoa(args.ports[i])
+	}
+	return "EXPOSE " + strings.Join(a, " ")
+}
+
+func (args *envArgs) String() string {
+	return "ENV " + args.key + " " + args.value
+}
+
+func (args *addArgs) String() string {
+	return "ADD " + args.src + " " + args.dst
+}
+
+func (args *entryPointArgs) String() string {
+	return "ENTRYPOINT " + strings.Join(args.cmd, " ")
+}
+
+func (args *volumeArgs) String() string {
+	return "VOLUME " + strings.Join(args.volumes, " ")
+}
+
+func (args *userArgs) String() string {
+	return "USER " + args.name
+}
+
+func (args *workDirArgs) String() string {
+	return "WORKDIR " + args.path
+}
+
+func (file *dockerFile) String() string {
+	a := make([]string, len(file.instructions))
+	for i, _ := range a {
+		v := file.instructions[i]
+		instr := v.(fmt.Stringer)
+		a[i] = instr.String()
+	}
+	return strings.Join(a, "\n")
+}

--- a/buildfile_parser_test.go
+++ b/buildfile_parser_test.go
@@ -74,6 +74,7 @@ var parsetests = []parsetest{
 	{`env port 4243`, `ENV port 4243`},
 	{`cmd ["/bin/echo", "Hello World"]`, `CMD /bin/echo Hello World`},
 	{`cmd Hello world`, `CMD /bin/sh -c Hello world`},
+	{`include foo/bar/baz`, `INCLUDE foo/bar/baz`},
 }
 
 func TestLexer(t *testing.T) {

--- a/buildfile_parser_test.go
+++ b/buildfile_parser_test.go
@@ -1,0 +1,125 @@
+/*
+	go test buildfile_parser_test.go \
+		buildfile_parser.go buildfile_lexer.go \
+		buildfile_parser_helper.go
+*/
+
+package docker
+
+import (
+	"strings"
+	"testing"
+)
+
+type lextest struct {
+	s      string
+	tokens []string
+}
+
+type parsetest struct {
+	s      string
+	parsed string
+}
+
+var lextests = []lextest{
+	{`run    mkdir -p /var/run/sshd`,
+		[]string{"run", "mkdir", "-p", "/var/run/sshd"},
+	},
+	{`run    [ "$(cat /tmp/passwd)" = "root:testpass" ]`,
+		[]string{"run", "[", `$(cat /tmp/passwd)`, "=", `root:testpass`, "]"},
+	},
+	{`from {IMAGE}`,
+		[]string{"from", "{IMAGE}"},
+	},
+	{`run    sh -c 'echo root:testpass \
+    > /tmp/passwd'`,
+		[]string{"run", "sh", "-c", "echo root:testpass > /tmp/passwd"},
+	},
+	{`cmd ["/bin/echo", "Hello World"]`,
+		[]string{"cmd", "[", `/bin/echo`, ",", `Hello World`, "]"},
+	},
+}
+
+var parsetests = []parsetest{
+	{`run    mkdir -p /var/run/sshd`, `RUN /bin/sh -c mkdir -p /var/run/sshd`},
+	{`run    [ "$(cat /tmp/passwd)" = "root:testpass" ]`, `RUN /bin/sh -c [ $(cat /tmp/passwd) = root:testpass ]`},
+	{`from   {IMAGE}`, `FROM {IMAGE}`},
+	{`from   {IMAGE}:{TAG}`, `FROM {IMAGE}:{TAG}`},
+	{`run    sh -c 'echo root:testpass > /tmp/passwd'`, `RUN sh -c echo root:testpass > /tmp/passwd`},
+	{`run    [ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]`, `RUN /bin/sh -c [ $(ls -d /var/run/sshd) = /var/run/sshd ]`},
+	{`run    sh -c 'echo root:testpass \
+        > /tmp/passwd'`, `RUN sh -c echo root:testpass > /tmp/passwd`},
+	{`run    echo "foo \n bar"; echo "baz"`, `RUN /bin/sh -c echo foo \n bar ; echo baz`},
+	{`add foo /usr/lib/bla/bar`, `ADD foo /usr/lib/bla/bar`},
+	{`run [ "$(cat /usr/lib/bla/bar)" = 'hello' ]`, `RUN /bin/sh -c [ $(cat /usr/lib/bla/bar) = hello ]`},
+	{`add http://{SERVERADDR}/baz /usr/lib/baz/quux`, `ADD http://{SERVERADDR}/baz /usr/lib/baz/quux`},
+	{`add f /`, `ADD f /`},
+	{`add d /somewheeeere/over/the/rainbooow`, `ADD d /somewheeeere/over/the/rainbooow`},
+	{`env    FOO BAR`, `ENV FOO BAR`},
+	{`run    [ "$FOO" = "BAR" ]`, `RUN /bin/sh -c [ $FOO = BAR ]`},
+	{`ENTRYPOINT /bin/echo`, `ENTRYPOINT /bin/sh -c /bin/echo`},
+	{`VOLUME /test`, `VOLUME /test`},
+	{`env    FOO /foo/baz`, `ENV FOO /foo/baz`},
+	{`env    BAR /bar`, `ENV BAR /bar`},
+	{`env    BAZ $BAR`, `ENV BAZ $BAR`},
+	{`env    FOOPATH $PATH:$FOO`, `ENV FOOPATH $PATH:$FOO`},
+	{`add    testfile $BAZ/`, `ADD testfile $BAZ/`},
+	{`add    $TEST $FOO`, `ADD $TEST $FOO`},
+	{`USER joelr`, `USER joelr`},
+	{`MAINTAINER Solomon Hykes <solomon@dotcloud.com>`, `MAINTAINER Solomon Hykes <solomon@dotcloud.com>`},
+	{`WORKDIR /foo/bar/baz`, `WORKDIR /foo/bar/baz`},
+	{`EXPOSE 1234`, `EXPOSE 1234`},
+	{`EXPOSE 1234 5679 3456`, `EXPOSE 1234 5679 3456`},
+	{`from 83599e29c455eb719f77d799bc7c51521b9551972f5a850d7ad265bc1b5292f6`, `FROM 83599e29c455eb719f77d799bc7c51521b9551972f5a850d7ad265bc1b5292f6`},
+	{`env port 4243`, `ENV port 4243`},
+	{`cmd ["/bin/echo", "Hello World"]`, `CMD /bin/echo Hello World`},
+	{`cmd Hello world`, `CMD /bin/sh -c Hello world`},
+}
+
+func TestLexer(t *testing.T) {
+	for _, test := range lextests {
+		seq(t, testlex(test.s), test.tokens)
+	}
+}
+
+func TestParser(t *testing.T) {
+	for _, test := range parsetests {
+		bf, err := testparse(test.s)
+		if err != nil {
+			t.Fatalf("Error parsing %s: %s", test.s, err)
+		}
+		if s := bf.String(); s != test.parsed {
+			t.Fatalf("Expected '%s' but got '%s'", test.parsed, s)
+		}
+	}
+}
+
+func testlex(s string) []string {
+	a := make([]string, 0)
+	r := strings.NewReader(s)
+	lexer := NewLexer(r)
+	lval := &yySymType{}
+	for {
+		tok := lexer.Lex(lval)
+		if tok == 0 {
+			break
+		}
+		a = append(a, token(tok, lval))
+	}
+	return a
+}
+
+func testparse(s string) (*dockerFile, error) {
+	return parse(strings.NewReader(s))
+}
+
+func seq(t *testing.T, a1, a2 []string) {
+	if len(a1) != len(a2) {
+		t.Fatalf("%v(%d) != %v(%d)", a1, len(a1), a2, len(a2))
+	}
+	for i := 0; i < len(a1); i++ {
+		if a1[i] != a2[i] {
+			t.Fatalf("%v != %v, %v @ %d != %v", a1, a2, a1[i], i, a2[i])
+		}
+	}
+}

--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -189,6 +189,29 @@ run    [ "$(cat /bar/withfile)" = "test2" ]
 		},
 		nil,
 	},
+
+	{
+		`
+from {IMAGE}
+include incfile
+add    testfile1 $BAZ/
+add    $TEST $FOO
+run    [ "$(cat /foobar/testfile1)" = "test3" ]
+run    [ "$(cat /bar/withfile1)" = "test4" ]
+`,
+		[][2]string{
+			{"testfile1", "test3"},
+			{"testdir/withfile1", "test4"},
+			{"incfile",
+				`
+env    FOO /bar
+env    TEST testdir
+env    BAZ /foobar
+`,
+			},
+		},
+		nil,
+	},
 }
 
 // FIXME: test building with 2 successive overlapping ADD commands

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -56,6 +56,15 @@ bundle() {
 }
 
 main() {
+	# Most bundles need buildfile_lexer.go and buildfile_parser.go
+	if ! go run vendor/src/github.com/wagerlabs/nex/nex.go -e -o buildfile_lexer.go buildfile.nex; then
+    	echo "Could not invoke nex, run vendor.sh once to pull in this dependency"
+    	exit 1
+	fi
+	if ! go tool yacc -o buildfile_parser.go buildfile.y; then 
+	    echo "Failed to generate buildfile_parser.go from buildfile.y"
+	    exit 1
+	fi
 	# We want this to fail if the bundles already exist and cannot be removed.
 	# This is to avoid mixing bundles from different versions of the code.
 	mkdir -p bundles

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -2,6 +2,16 @@
 
 DEST=$1
 
+if ! go run vendor/src/github.com/wagerlabs/nex/nex.go -e -o buildfile_lexer.go buildfile.nex; then
+    echo "Could not invoke nex, run vendor.sh once to pull in this dependency"
+    exit 1
+fi
+
+if ! go tool yacc -o buildfile_parser.go buildfile.y; then 
+    echo "Failed to generate buildfile_parser.go from buildfile.y"
+    exit 1
+fi
+
 if go build -o $DEST/docker-$VERSION -ldflags "$LDFLAGS" ./docker; then
 	echo "Created binary: $DEST/docker-$VERSION"
 fi

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -2,16 +2,6 @@
 
 DEST=$1
 
-if ! go run vendor/src/github.com/wagerlabs/nex/nex.go -e -o buildfile_lexer.go buildfile.nex; then
-    echo "Could not invoke nex, run vendor.sh once to pull in this dependency"
-    exit 1
-fi
-
-if ! go tool yacc -o buildfile_parser.go buildfile.y; then 
-    echo "Failed to generate buildfile_parser.go from buildfile.y"
-    exit 1
-fi
-
 if go build -o $DEST/docker-$VERSION -ldflags "$LDFLAGS" ./docker; then
 	echo "Created binary: $DEST/docker-$VERSION"
 fi

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -29,6 +29,8 @@ git_clone github.com/gorilla/mux/ 9b36453141c
 
 git_clone github.com/dotcloud/tar/ e5ea6bb21a
 
+git_clone github.com/wagerlabs/nex 3048f74
+
 # Docker requires code.google.com/p/go.net/websocket
 PKG=code.google.com/p/go.net REV=84a4013f96e0
 (


### PR DESCRIPTION
This patch implements the include verb. 

There are tests in buildfile_test.go and buildfile_parser_test.go. All tests pass, both old and new.

Include files must be located in the same directory tree as the main Dockerfile, not in the parent or sibling directories.
