### PR TITLE
Private registry auth

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -665,9 +665,9 @@ type ImgData struct {
 }
 
 type Registry struct {
-	client		  *http.Client
-	authConfig	  *auth.AuthConfig
-	reqFactory	  *utils.HTTPRequestFactory
+	client        *http.Client
+	authConfig    *auth.AuthConfig
+	reqFactory    *utils.HTTPRequestFactory
 	indexEndpoint string
 }
 
@@ -700,4 +700,3 @@ func NewRegistry(authConfig *auth.AuthConfig, factory *utils.HTTPRequestFactory,
 	r.reqFactory = factory
 	return r, nil
 }
-

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -153,11 +153,10 @@ func doWithCookies(c *http.Client, req *http.Request) (*http.Response, error) {
 	return res, err
 }
 
-func setTokenAuth(req *http.Request, token []string) *http.Request {
+func setTokenAuth(req *http.Request, token []string) {
 	if req.Header.Get("Authorization") == "" { // Don't override
 		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
 	}
-	return req
 }
 
 // Retrieve the history of a given image from the Registry.
@@ -167,7 +166,7 @@ func (r *Registry) GetRemoteHistory(imgID, registry string, token []string) ([]s
 	if err != nil {
 		return nil, err
 	}
-	req = setTokenAuth(req, token)
+	setTokenAuth(req, token)
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
 		return nil, err
@@ -200,7 +199,7 @@ func (r *Registry) LookupRemoteImage(imgID, registry string, token []string) boo
 	if err != nil {
 		return false
 	}
-	req = setTokenAuth(req, token)
+	setTokenAuth(req, token)
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
 		return false
@@ -216,7 +215,7 @@ func (r *Registry) GetRemoteImageJSON(imgID, registry string, token []string) ([
 	if err != nil {
 		return nil, -1, fmt.Errorf("Failed to download json: %s", err)
 	}
-	req = setTokenAuth(req, token)
+	setTokenAuth(req, token)
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
 		return nil, -1, fmt.Errorf("Failed to download json: %s", err)
@@ -243,7 +242,7 @@ func (r *Registry) GetRemoteImageLayer(imgID, registry string, token []string) (
 	if err != nil {
 		return nil, fmt.Errorf("Error while getting from the server: %s\n", err)
 	}
-	req = setTokenAuth(req, token)
+	setTokenAuth(req, token)
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
 		return nil, err
@@ -269,7 +268,7 @@ func (r *Registry) GetRemoteTags(registries []string, repository string, token [
 		if err != nil {
 			return nil, err
 		}
-		req = setTokenAuth(req, token)
+		setTokenAuth(req, token)
 		res, err := doWithCookies(r.client, req)
 		if err != nil {
 			return nil, err
@@ -372,7 +371,7 @@ func (r *Registry) PushImageChecksumRegistry(imgData *ImgData, registry string, 
 	if err != nil {
 		return err
 	}
-	req = setTokenAuth(req, token)
+	setTokenAuth(req, token)
 	req.Header.Set("X-Docker-Checksum", imgData.Checksum)
 
 	res, err := doWithCookies(r.client, req)
@@ -409,7 +408,7 @@ func (r *Registry) PushImageJSONRegistry(imgData *ImgData, jsonRaw []byte, regis
 		return err
 	}
 	req.Header.Add("Content-type", "application/json")
-	req = setTokenAuth(req, token)
+	setTokenAuth(req, token)
 
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
@@ -444,7 +443,7 @@ func (r *Registry) PushImageLayerRegistry(imgID string, layer io.Reader, registr
 	}
 	req.ContentLength = -1
 	req.TransferEncoding = []string{"chunked"}
-	req = setTokenAuth(req, token)
+	setTokenAuth(req, token)
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
 		return "", fmt.Errorf("Failed to upload layer: %s", err)
@@ -473,7 +472,7 @@ func (r *Registry) PushRegistryTag(remote, revision, tag, registry string, token
 		return err
 	}
 	req.Header.Add("Content-type", "application/json")
-	req = setTokenAuth(req, token)
+	setTokenAuth(req, token)
 	req.ContentLength = int64(len(revision))
 	res, err := doWithCookies(r.client, req)
 	if err != nil {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -153,7 +153,7 @@ func doWithCookies(c *http.Client, req *http.Request) (*http.Response, error) {
 	return res, err
 }
 
-func setTokenAuth(req *http.Request, token []string) (*http.Request) {
+func setTokenAuth(req *http.Request, token []string) *http.Request {
 	if req.Header.Get("Authorization") == "" { // Don't override
 		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
 	}
@@ -269,9 +269,7 @@ func (r *Registry) GetRemoteTags(registries []string, repository string, token [
 		if err != nil {
 			return nil, err
 		}
-		if req.Header.Get("Authorization") == "" { // Don't override
-			req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
-		}
+		req = setTokenAuth(req, token)
 		res, err := doWithCookies(r.client, req)
 		if err != nil {
 			return nil, err

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -153,6 +153,13 @@ func doWithCookies(c *http.Client, req *http.Request) (*http.Response, error) {
 	return res, err
 }
 
+func setTokenAuth(req *http.Request, token []string) (*http.Request) {
+	if req.Header.Get("Authorization") == "" { // Don't override
+		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
+	}
+	return req
+}
+
 // Retrieve the history of a given image from the Registry.
 // Return a list of the parent's json (requested image included)
 func (r *Registry) GetRemoteHistory(imgID, registry string, token []string) ([]string, error) {
@@ -160,9 +167,7 @@ func (r *Registry) GetRemoteHistory(imgID, registry string, token []string) ([]s
 	if err != nil {
 		return nil, err
 	}
-	if req.Header.Get("Authorization") == "" { // Don't override
-		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
-	}
+	req = setTokenAuth(req, token)
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
 		return nil, err
@@ -195,9 +200,7 @@ func (r *Registry) LookupRemoteImage(imgID, registry string, token []string) boo
 	if err != nil {
 		return false
 	}
-	if req.Header.Get("Authorization") == "" { // Don't override
-		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
-	}
+	req = setTokenAuth(req, token)
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
 		return false
@@ -213,9 +216,7 @@ func (r *Registry) GetRemoteImageJSON(imgID, registry string, token []string) ([
 	if err != nil {
 		return nil, -1, fmt.Errorf("Failed to download json: %s", err)
 	}
-	if req.Header.Get("Authorization") == "" { // Don't override
-		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
-	}
+	req = setTokenAuth(req, token)
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
 		return nil, -1, fmt.Errorf("Failed to download json: %s", err)
@@ -242,9 +243,7 @@ func (r *Registry) GetRemoteImageLayer(imgID, registry string, token []string) (
 	if err != nil {
 		return nil, fmt.Errorf("Error while getting from the server: %s\n", err)
 	}
-	if req.Header.Get("Authorization") == "" { // Don't override
-		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
-	}
+	req = setTokenAuth(req, token)
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
 		return nil, err
@@ -375,9 +374,7 @@ func (r *Registry) PushImageChecksumRegistry(imgData *ImgData, registry string, 
 	if err != nil {
 		return err
 	}
-	if req.Header.Get("Authorization") == "" { // Don't override
-		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
-	}
+	req = setTokenAuth(req, token)
 	req.Header.Set("X-Docker-Checksum", imgData.Checksum)
 
 	res, err := doWithCookies(r.client, req)
@@ -414,9 +411,7 @@ func (r *Registry) PushImageJSONRegistry(imgData *ImgData, jsonRaw []byte, regis
 		return err
 	}
 	req.Header.Add("Content-type", "application/json")
-	if req.Header.Get("Authorization") == "" { // Don't override
-		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
-	}
+	req = setTokenAuth(req, token)
 
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
@@ -451,9 +446,7 @@ func (r *Registry) PushImageLayerRegistry(imgID string, layer io.Reader, registr
 	}
 	req.ContentLength = -1
 	req.TransferEncoding = []string{"chunked"}
-	if req.Header.Get("Authorization") == "" { // Don't override
-		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
-	}
+	req = setTokenAuth(req, token)
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
 		return "", fmt.Errorf("Failed to upload layer: %s", err)
@@ -482,9 +475,7 @@ func (r *Registry) PushRegistryTag(remote, revision, tag, registry string, token
 		return err
 	}
 	req.Header.Add("Content-type", "application/json")
-	if req.Header.Get("Authorization") == "" { // Don't override
-		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
-	}
+	req = setTokenAuth(req, token)
 	req.ContentLength = int64(len(revision))
 	res, err := doWithCookies(r.client, req)
 	if err != nil {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -15,7 +15,7 @@ var (
 
 func spawnTestRegistry(t *testing.T) *Registry {
 	authConfig := &auth.AuthConfig{}
-	r, err := NewRegistry("", authConfig, utils.NewHTTPRequestFactory())
+	r, err := NewRegistry(authConfig, utils.NewHTTPRequestFactory(), makeURL("/v1/"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +99,7 @@ func TestGetRemoteTags(t *testing.T) {
 
 func TestGetRepositoryData(t *testing.T) {
 	r := spawnTestRegistry(t)
-	data, err := r.GetRepositoryData(makeURL("/v1/"), "foo42/bar")
+	data, err := r.GetRepositoryData("foo42/bar")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,15 +168,14 @@ func TestPushImageJSONIndex(t *testing.T) {
 			Checksum: "sha256:bea7bf2e4bacd479344b737328db47b18880d09096e6674165533aa994f5e9f2",
 		},
 	}
-	ep := makeURL("/v1/")
-	repoData, err := r.PushImageJSONIndex(ep, "foo42/bar", imgData, false, nil)
+	repoData, err := r.PushImageJSONIndex("foo42/bar", imgData, false, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if repoData == nil {
 		t.Fatal("Expected RepositoryData object")
 	}
-	repoData, err = r.PushImageJSONIndex(ep, "foo42/bar", imgData, true, []string{ep})
+	repoData, err = r.PushImageJSONIndex("foo42/bar", imgData, true, []string{r.indexEndpoint})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils/http.go
+++ b/utils/http.go
@@ -107,6 +107,23 @@ func (h *HTTPMetaHeadersDecorator) ChangeRequest(req *http.Request) (newReq *htt
 	return req, nil
 }
 
+type HTTPAuthDecorator struct {
+	login string
+	password string
+}
+
+func NewHTTPAuthDecorator(login, password string) HTTPRequestDecorator {
+	ret := new(HTTPAuthDecorator)
+	ret.login = login
+	ret.password = password
+	return ret
+}
+
+func (self *HTTPAuthDecorator) ChangeRequest(req *http.Request) (*http.Request, error) {
+	req.SetBasicAuth(self.login, self.password)
+	return req, nil
+}
+
 // HTTPRequestFactory creates an HTTP request
 // and applies a list of decorators on the request.
 type HTTPRequestFactory struct {
@@ -117,6 +134,10 @@ func NewHTTPRequestFactory(d ...HTTPRequestDecorator) *HTTPRequestFactory {
 	return &HTTPRequestFactory{
 		decorators: d,
 	}
+}
+
+func (self *HTTPRequestFactory) AddDecorator(d... HTTPRequestDecorator) {
+	self.decorators = append(self.decorators, d...)
 }
 
 // NewRequest() creates a new *http.Request,
@@ -144,5 +165,6 @@ func (h *HTTPRequestFactory) NewRequest(method, urlStr string, body io.Reader, d
 			return nil, err
 		}
 	}
+	Debugf("%v -- HEADERS: %v", req.URL, req.Header)
 	return req, err
 }


### PR DESCRIPTION
This enables people to put nginx or apache with basic auth in front of their private registry and still be able to push and pull images.

Only allowed over HTTPS for now.
