### PR TITLE
Updated to use /usr/sbin/service which is more generic, as opposed to /sbin/[start | stop] which are upstart specific.

### DIFF
--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -50,13 +50,13 @@ bundle_ubuntu() {
 	# Generate postinstall/prerm scripts
 	cat >/tmp/postinstall <<EOF
 #!/bin/sh
-/sbin/stop docker || true
+/usr/sbin/service docker stop || true
 /bin/grep -q "^docker:" /etc/group || /usr/sbin/addgroup --system docker || true
-/sbin/start docker
+/usr/sbin/service docker start
 EOF
 	cat >/tmp/prerm <<EOF
 #!/bin/sh
-/sbin/stop docker || true
+/usr/sbin/service docker stop || true
 /usr/sbin/delgroup docker || true
 EOF
 	chmod +x /tmp/postinstall /tmp/prerm


### PR DESCRIPTION
Hello,
This patch improves compatability with the .debs you build and stock debian systems, by modifying the script to look for a more generic stop/start tool.

Thanks
--brendan
