### PR TITLE
Update all the mkimage scripts to use --numeric-owner as a tar argument

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -62,6 +62,6 @@ mknod -m 666 ${DEV}/full c 1 7
 mknod -m 600 ${DEV}/initctl p
 mknod -m 666 ${DEV}/ptmx c 5 2
 
-tar -C $ROOTFS -c . | docker import - archlinux
+tar --numeric-owner -C $ROOTFS -c . | docker import - archlinux
 docker run -i -t archlinux echo Success.
 rm -rf $ROOTFS

--- a/contrib/mkimage-busybox.sh
+++ b/contrib/mkimage-busybox.sh
@@ -35,5 +35,5 @@ do
     cp -a /dev/$X dev
 done
 
-tar -cf- . | docker import - busybox
+tar --numeric-owner -cf- . | docker import - busybox
 docker run -i -u root busybox /bin/echo Success.

--- a/contrib/mkimage-debootstrap.sh
+++ b/contrib/mkimage-debootstrap.sh
@@ -189,10 +189,10 @@ if [ "$justTar" ]; then
 	touch "$repo"
 	
 	# fill the tarball
-	sudo tar -caf "$repo" .
+	sudo tar --numeric-owner -caf "$repo" .
 else
 	# create the image (and tag $repo:$suite)
-	sudo tar -c . | $docker import - $repo $suite
+	sudo tar --numeric-owner -c . | $docker import - $repo $suite
 	
 	# test the image
 	$docker run -i -t $repo:$suite echo success

--- a/contrib/mkimage-unittest.sh
+++ b/contrib/mkimage-unittest.sh
@@ -44,6 +44,6 @@ do
 done
 
 chmod 0755 $ROOTFS # See #486
-tar -cf- . | docker import - docker-ut
+tar --numeric-owner -cf- . | docker import - docker-ut
 docker run -i -u root docker-ut /bin/echo Success.
 rm -rf $ROOTFS


### PR DESCRIPTION
This is as pointed out by @unclejack on #2358, to make sure we preserve the numeric IDs inside the image like we need to, which can cause issues otherwise.
