### PR TITLE
Implement container size calculations for devicemapper

### DIFF
--- a/devmapper/deviceset.go
+++ b/devmapper/deviceset.go
@@ -549,7 +549,7 @@ func (devices *DeviceSet) deactivateDevice(hash string) error {
 			utils.Debugf("\n--->Err: %s\n", err)
 			return err
 		}
-		if err := devices.waitRemove(hash); err != nil {
+		if err := devices.waitRemove(devname); err != nil {
 			return err
 		}
 	}
@@ -560,13 +560,9 @@ func (devices *DeviceSet) deactivateDevice(hash string) error {
 // waitRemove blocks until either:
 // a) the device registered at <device_set_prefix>-<hash> is removed,
 // or b) the 1 second timeout expires.
-func (devices *DeviceSet) waitRemove(hash string) error {
-	utils.Debugf("[deviceset %s] waitRemove(%s)", devices.devicePrefix, hash)
-	defer utils.Debugf("[deviceset %s] waitRemove END", devices.devicePrefix, hash)
-	devname, err := devices.byHash(hash)
-	if err != nil {
-		return err
-	}
+func (devices *DeviceSet) waitRemove(devname string) error {
+	utils.Debugf("[deviceset %s] waitRemove(%s)", devices.devicePrefix, devname)
+	defer utils.Debugf("[deviceset %s] waitRemove(%s) END", devices.devicePrefix, devname)
 	i := 0
 	for ; i < 1000; i += 1 {
 		devinfo, err := getInfo(devname)

--- a/image.go
+++ b/image.go
@@ -393,7 +393,7 @@ func (image *Image) ensureImageDevice(devices *devmapper.DeviceSet) error {
 
 	if err = image.applyLayer(layerPath(root), mountDir); err != nil {
 		utils.Debugf("Error applying layer: %s", err)
-		devices.UnmountDevice(image.ID, mountDir, true)
+		devices.UnmountDevice(image.ID, mountDir)
 		devices.RemoveDevice(image.ID)
 		return err
 	}
@@ -406,18 +406,18 @@ func (image *Image) ensureImageDevice(devices *devmapper.DeviceSet) error {
 	// part of the container changes
 	dockerinitLayer, err := image.getDockerInitLayer()
 	if err != nil {
-		devices.UnmountDevice(image.ID, mountDir, true)
+		devices.UnmountDevice(image.ID, mountDir)
 		devices.RemoveDevice(image.ID)
 		return err
 	}
 
 	if err := image.applyLayer(dockerinitLayer, mountDir); err != nil {
-		devices.UnmountDevice(image.ID, mountDir, true)
+		devices.UnmountDevice(image.ID, mountDir)
 		devices.RemoveDevice(image.ID)
 		return err
 	}
 
-	if err := devices.UnmountDevice(image.ID, mountDir, true); err != nil {
+	if err := devices.UnmountDevice(image.ID, mountDir); err != nil {
 		devices.RemoveDevice(image.ID)
 		return err
 	}
@@ -473,7 +473,7 @@ func (image *Image) Unmount(runtime *Runtime, root string, id string) error {
 		return err
 	}
 
-	if err = devices.UnmountDevice(id, root, true); err != nil {
+	if err = devices.UnmountDevice(id, root); err != nil {
 		return err
 	}
 
@@ -490,8 +490,6 @@ func (image *Image) Changes(runtime *Runtime, root, rw, id string) ([]Change, er
 		return nil, err
 	}
 
-	wasActivated := devices.HasActivatedDevice(image.ID)
-
 	// We re-use rw for the temporary mount of the base image as its
 	// not used by device-mapper otherwise
 	err = devices.MountDevice(image.ID, rw, true)
@@ -500,7 +498,7 @@ func (image *Image) Changes(runtime *Runtime, root, rw, id string) ([]Change, er
 	}
 
 	changes, err := ChangesDirs(root, rw)
-	devices.UnmountDevice(image.ID, rw, !wasActivated)
+	devices.UnmountDevice(image.ID, rw)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This solves https://github.com/dotcloud/docker/issues/2271 by implementing size calculation based on Container.Changes(). Its a bit slow as it needs to recurse over the filesystems, but it at least works.

The actual GetSize() calculation is the last commit. The other are a series of commits that are meant to make concurrent Mount()/Unmount() of devicemapper devices "safe". Currently they can be problematic if two threads mount and then unmount in parallel, as the first to unmount will try to deactivate the device used by the second thread.
