### PR TITLE
Move iptable rules outside of create bridge

### DIFF
--- a/iptables/iptables.go
+++ b/iptables/iptables.go
@@ -92,6 +92,11 @@ func (c *Chain) Remove() error {
 	return nil
 }
 
+// Check if an existing rule exists
+func Exists(args ...string) bool {
+	return Raw(append([]string{"-C"}, args...)...) == nil
+}
+
 func Raw(args ...string) error {
 	path, err := exec.LookPath("iptables")
 	if err != nil {


### PR DESCRIPTION
This allows the user to toggle enabling and
disabling intercontainer communication when
they run the daemon.

ping @vieux 
