### PR TITLE
update docker search to reflect future changes of the api

### DIFF
--- a/api_params.go
+++ b/api_params.go
@@ -78,11 +78,6 @@ type APIContainersOld struct {
 	SizeRootFs int64
 }
 
-type APISearch struct {
-	Name        string
-	Description string
-}
-
 type APIID struct {
 	ID string `json:"Id"`
 }

--- a/commands.go
+++ b/commands.go
@@ -1429,20 +1429,14 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 	}
 	w := tabwriter.NewWriter(cli.out, 10, 1, 3, ' ', 0)
 	fmt.Fprintf(w, "NAME\tDESCRIPTION\tSTARS\tOFFICIAL\tTRUSTED\n")
-	_, width := cli.getTtySize()
-	if width == 0 {
-		width = 45
-	} else {
-		width = width - 10 - 54 //remote the first column
-	}
 	for _, out := range outs {
 		if (*trusted && !out.IsTrusted) || (*stars > out.StarCount) {
 			continue
 		}
 		desc := strings.Replace(out.Description, "\n", " ", -1)
 		desc = strings.Replace(desc, "\r", " ", -1)
-		if !*noTrunc && len(desc) > width {
-			desc = utils.Trunc(desc, width-3) + "..."
+		if !*noTrunc && len(desc) > 45 {
+			desc = utils.Trunc(desc, 42) + "..."
 		}
 		fmt.Fprintf(w, "%s\t%s\t%d\t", out.Name, desc, out.StarCount)
 		if out.IsOfficial {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -426,7 +426,7 @@ _docker_run()
 
 _docker_search()
 {
-	COMPREPLY=( $( compgen -W "-notrunc" -- "$cur" ) )
+	COMPREPLY=( $( compgen -W "-notrunc" "-stars" "-trusted" -- "$cur" ) )
 }
 
 _docker_start()

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -683,8 +683,11 @@ to the newly created container.
 
     Usage: docker search TERM
 
-    Searches for the TERM parameter on the Docker index and prints out
-    a list of repositories that match.
+    Search the docker index for images
+
+     -notrunc=false: Don't truncate output
+     -stars=0: Only displays with at least xxx stars
+     -trusted=false: Only show trusted builds
 
 .. _cli_start:
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -615,10 +615,18 @@ func (r *Registry) GetAuthConfig(withPasswd bool) *auth.AuthConfig {
 	}
 }
 
+type SearchResult struct {
+	StarCount   int    `json:"star_count"`
+	IsOfficial  bool   `json:"is_official"`
+	Name        string `json:"name"`
+	IsTrusted   bool   `json:"is_trusted"`
+	Description string `json:"description"`
+}
+
 type SearchResults struct {
-	Query      string              `json:"query"`
-	NumResults int                 `json:"num_results"`
-	Results    []map[string]string `json:"results"`
+	Query      string         `json:"query"`
+	NumResults int            `json:"num_results"`
+	Results    []SearchResult `json:"results"`
 }
 
 type RepositoryData struct {

--- a/server.go
+++ b/server.go
@@ -183,7 +183,7 @@ func (srv *Server) ContainerExport(name string, out io.Writer) error {
 	return fmt.Errorf("No such container: %s", name)
 }
 
-func (srv *Server) ImagesSearch(term string) ([]APISearch, error) {
+func (srv *Server) ImagesSearch(term string) ([]registry.SearchResult, error) {
 	r, err := registry.NewRegistry(srv.runtime.config.Root, nil, srv.HTTPRequestFactory(nil))
 	if err != nil {
 		return nil, err
@@ -192,15 +192,7 @@ func (srv *Server) ImagesSearch(term string) ([]APISearch, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	var outs []APISearch
-	for _, repo := range results.Results {
-		var out APISearch
-		out.Description = repo["description"]
-		out.Name = repo["name"]
-		outs = append(outs, out)
-	}
-	return outs, nil
+	return results.Results, nil
 }
 
 func (srv *Server) ImageInsert(name, url, path string, out io.Writer, sf *utils.StreamFormatter) (string, error) {


### PR DESCRIPTION
I removed `APISearch`, the docker daemon serves as a proxy in that case, so I use the struct from the registry package.

```
$ docker search kencochrane
Found 2 results matching your query ("kencochrane")
NAME                    DESCRIPTION         STARS               OFFICIAL            TRUSTED BUILD
kencochrane/testrepo                        0                                       [OK]
kencochrane/testrepo2                       1                                       [OK]
```

Related to #2359
