### PR TITLE
Ignore ErrClosedPipe for stdin in Container.Attach.

### DIFF
--- a/container.go
+++ b/container.go
@@ -470,11 +470,13 @@ func (container *Container) Attach(stdin io.ReadCloser, stdinCloser io.Closer, s
 				} else {
 					_, err = io.Copy(cStdin, stdin)
 				}
+				if err == io.ErrClosedPipe {
+					err = nil
+				}
 				if err != nil {
 					utils.Errorf("attach: stdin: %s", err)
 				}
-				// Discard error, expecting pipe error
-				errors <- nil
+				errors <- err
 			}()
 		}
 	}


### PR DESCRIPTION
This is a minor cleanup after #2242.
(We already ignore ErrClosedPipe for stdout and stderr, and the consensus was that we should ignore them as well for stdin.)
