### PR TITLE
Add ability to specify custom filename to be used as Dockerfile.

### DIFF
--- a/api.go
+++ b/api.go
@@ -850,6 +850,7 @@ func postBuild(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 	rawSuppressOutput := r.FormValue("q")
 	rawNoCache := r.FormValue("nocache")
 	rawRm := r.FormValue("rm")
+	filename := r.FormValue("filename")
 	repoName, tag := utils.ParseRepositoryTag(repoName)
 
 	var context io.Reader
@@ -905,7 +906,7 @@ func postBuild(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 		return err
 	}
 
-	b := NewBuildFile(srv, utils.NewWriteFlusher(w), !suppressOutput, !noCache, rm)
+	b := NewBuildFile(srv, utils.NewWriteFlusher(w), !suppressOutput, !noCache, rm, filename)
 	id, err := b.Build(context)
 	if err != nil {
 		return fmt.Errorf("Error build: %s", err)

--- a/buildfile.go
+++ b/buildfile.go
@@ -31,6 +31,7 @@ type buildFile struct {
 	verbose      bool
 	utilizeCache bool
 	rm           bool
+	dockerfile	string
 
 	tmpContainers map[string]struct{}
 	tmpImages     map[string]struct{}
@@ -468,7 +469,12 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 	}
 	defer os.RemoveAll(name)
 	b.context = name
-	filename := path.Join(name, "Dockerfile")
+	var filename string
+	if b.dockerfile != "" {
+		filename = path.Join(name, b.dockerfile)
+	} else {
+		filename = path.Join(name, "Dockerfile")
+	}
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		return "", fmt.Errorf("Can't build a directory with no Dockerfile")
 	}
@@ -518,7 +524,7 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 	return "", fmt.Errorf("An error occurred during the build\n")
 }
 
-func NewBuildFile(srv *Server, out io.Writer, verbose, utilizeCache, rm bool) BuildFile {
+func NewBuildFile(srv *Server, out io.Writer, verbose, utilizeCache, rm bool, filename string) BuildFile {
 	return &buildFile{
 		runtime:       srv.runtime,
 		srv:           srv,
@@ -529,5 +535,6 @@ func NewBuildFile(srv *Server, out io.Writer, verbose, utilizeCache, rm bool) Bu
 		verbose:       verbose,
 		utilizeCache:  utilizeCache,
 		rm:            rm,
+		dockerfile:		filename,
 	}
 }

--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -257,7 +257,7 @@ func buildImage(context testContextTemplate, t *testing.T, srv *Server, useCache
 	ip := srv.runtime.networkManager.bridgeNetwork.IP
 	dockerfile := constructDockerfile(context.dockerfile, ip, port)
 
-	buildfile := NewBuildFile(srv, ioutil.Discard, false, useCache, false)
+	buildfile := NewBuildFile(srv, ioutil.Discard, false, useCache, false, "")
 	id, err := buildfile.Build(mkTestContext(dockerfile, context.files, t))
 	if err != nil {
 		t.Fatal(err)
@@ -498,7 +498,7 @@ func TestForbiddenContextPath(t *testing.T) {
 	ip := srv.runtime.networkManager.bridgeNetwork.IP
 	dockerfile := constructDockerfile(context.dockerfile, ip, port)
 
-	buildfile := NewBuildFile(srv, ioutil.Discard, false, true, false)
+	buildfile := NewBuildFile(srv, ioutil.Discard, false, true, false, "")
 	_, err = buildfile.Build(mkTestContext(dockerfile, context.files, t))
 
 	if err == nil {
@@ -546,7 +546,7 @@ func TestBuildADDFileNotFound(t *testing.T) {
 	ip := srv.runtime.networkManager.bridgeNetwork.IP
 	dockerfile := constructDockerfile(context.dockerfile, ip, port)
 
-	buildfile := NewBuildFile(srv, ioutil.Discard, false, true, false)
+	buildfile := NewBuildFile(srv, ioutil.Discard, false, true, false, "")
 	_, err = buildfile.Build(mkTestContext(dockerfile, context.files, t))
 
 	if err == nil {

--- a/commands.go
+++ b/commands.go
@@ -171,6 +171,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	suppressOutput := cmd.Bool("q", false, "Suppress verbose build output")
 	noCache := cmd.Bool("no-cache", false, "Do not use cache when building the image")
 	rm := cmd.Bool("rm", false, "Remove intermediate containers after a successful build")
+	filename := cmd.String("f", "", "Name of the file to be used as Dockerfile")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -224,6 +225,9 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	if *rm {
 		v.Set("rm", "1")
 	}
+
+	v.Set("filename", *filename)
+
 	req, err := http.NewRequest("POST", fmt.Sprintf("/v%g/build?%s", APIVERSION, v.Encode()), body)
 	if err != nil {
 		return err


### PR DESCRIPTION
Now one can perform the following commands in the same directory:

```
docker build -t db_container -f db.dockerfile .
docker build -t web_container -f web.dockerfile .
docker build -t client_container -f client.dockerfile .
docker build -t client_container .
```

The last one will use the default Dockerfile file.
