### PR TITLE
Clarified the documentation for the -p flag.

### DIFF
--- a/container.go
+++ b/container.go
@@ -143,7 +143,7 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 	flCpuShares := cmd.Int64("c", 0, "CPU shares (relative weight)")
 
 	var flPorts ListOpts
-	cmd.Var(&flPorts, "p", "Expose a container's port to the host (use 'docker port' to see the actual mapping)")
+	cmd.Var(&flPorts, "p", "Expose a container's port to the host with the format [host_port:]container_port (use 'docker port' to see the actual mapping)")
 
 	var flEnv ListOpts
 	cmd.Var(&flEnv, "e", "Set environment variables")

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -543,7 +543,7 @@ Insert file from github
       -privileged=false: Give extended privileges to this container
       -m=0: Memory limit (in bytes)
       -n=true: Enable networking for this container
-      -p=[]: Map a network port to the container
+      -p=[]: Map a network port to the container with the format [host_port:]container_port
       -rm=false: Automatically remove the container when it exits (incompatible with -d)
       -t=false: Allocate a pseudo-tty
       -u="": Username or UID


### PR DESCRIPTION
Now explicitly states you can pass in a host port and a container port.
