### PR TITLE
2089 fix restart runtime error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -140,6 +140,7 @@ odk- <github@odkurzacz.org>
 Pascal Borreli <pascal@borreli.com>
 Paul Bowsher <pbowsher@globalpersonals.co.uk>
 Paul Hammond <paul@paulhammond.org>
+Paul Nasrat <pnasrat@gmail.com>
 Phil Spitler <pspitler@gmail.com>
 Piotr Bogdan <ppbogdan@gmail.com>
 pysqz <randomq@126.com>

--- a/container.go
+++ b/container.go
@@ -1062,12 +1062,7 @@ func (container *Container) allocateNetwork() error {
 
 	var iface *NetworkInterface
 	var err error
-	if !container.State.Ghost {
-		iface, err = container.runtime.networkManager.Allocate()
-		if err != nil {
-			return err
-		}
-	} else {
+	if container.State.Ghost {
 		manager := container.runtime.networkManager
 		if manager.disabled {
 			iface = &NetworkInterface{disabled: true}
@@ -1077,8 +1072,20 @@ func (container *Container) allocateNetwork() error {
 				Gateway: manager.bridgeNetwork.IP,
 				manager: manager,
 			}
-			ipNum := ipToInt(iface.IPNet.IP)
-			manager.ipAllocator.inUse[ipNum] = struct{}{}
+			if iface !=nil && iface.IPNet.IP != nil {
+				ipNum := ipToInt(iface.IPNet.IP)
+				manager.ipAllocator.inUse[ipNum] = struct{}{}
+			} else {
+				iface, err = container.runtime.networkManager.Allocate()
+				if err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		iface, err = container.runtime.networkManager.Allocate()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/container_test.go
+++ b/container_test.go
@@ -1652,3 +1652,29 @@ func TestMultipleVolumesFrom(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestRestartGhost(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+
+	container, err := runtime.Create(&Config{
+		Image:   GetTestImage(runtime).ID,
+		Cmd:     []string{"sh", "-c", "echo -n bar > /test/foo"},
+		Volumes: map[string]struct{}{"/test": {}},
+	},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := container.Kill(); err != nil {
+		t.Fatal(err)
+	}
+
+	container.State.Ghost = true
+	_, err = container.Output()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/container_test.go
+++ b/container_test.go
@@ -1657,11 +1657,13 @@ func TestRestartGhost(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)
 
-	container, err := runtime.Create(&Config{
-		Image:   GetTestImage(runtime).ID,
-		Cmd:     []string{"sh", "-c", "echo -n bar > /test/foo"},
-		Volumes: map[string]struct{}{"/test": {}},
-	},
+	container, _, err := runtime.Create(
+		&Config{
+			Image:   GetTestImage(runtime).ID,
+			Cmd:     []string{"sh", "-c", "echo -n bar > /test/foo"},
+			Volumes: map[string]struct{}{"/test": {}},
+		},
+		"",
 	)
 
 	if err != nil {


### PR DESCRIPTION
Tested with unittest and latest reproducer in bug.

```
root@precise64:/vagrant# ID=$(docker run -d busybox sleep 60)
root@precise64:/vagrant# invoke-rc.d docker restart
invoke-rc.d: unknown initscript, /etc/init.d/docker not found.
root@precise64:/vagrant# docker kill $ID
68cfb88cf047
root@precise64:/vagrant# docker start $ID
68cfb88cf047
root@precise64:/vagrant# docker ps
ID                  IMAGE               COMMAND             CREATED             STATUS              PORTS
68cfb88cf047        busybox:latest      sleep 60            10 seconds ago      Up 8 seconds
```
