### PR TITLE
Fixes the flags for nc in example

### DIFF
--- a/docs/sources/use/basics.rst
+++ b/docs/sources/use/basics.rst
@@ -144,7 +144,7 @@ Expose a service on a TCP port
 .. code-block:: bash
 
   # Expose port 4444 of this container, and tell netcat to listen on it
-  JOB=$(sudo docker run -d -p 4444 ubuntu:12.10 /bin/nc -l -p 4444)
+  JOB=$(sudo docker run -d -p 4444 ubuntu:12.10 /bin/nc -l 4444)
 
   # Which public port is NATed to my container?
   PORT=$(sudo docker port $JOB 4444)


### PR DESCRIPTION
The `-p` flag for `nc` should not be used with `-l`.

From the manpage of nc:

```
  -l      Used to specify that nc should listen for an incoming connection rather than initiate a connection to a
          remote host.  It is an error to use this option in conjunction with the -p, -s, or -z options.  Addition‐
          ally, any timeouts specified with the -w option are ignored.
```

`nc` unfortunately does not spit an error in this erroneous case.
