### PR TITLE
Make /events API send headers immediately

### DIFF
--- a/api.go
+++ b/api.go
@@ -72,12 +72,12 @@ func httpError(w http.ResponseWriter, err error) {
 		statusCode = http.StatusUnauthorized
 	} else if strings.Contains(err.Error(), "hasn't been activated") {
 		statusCode = http.StatusForbidden
-	}	
-	
+	}
+
 	if err != nil {
 		utils.Errorf("HTTP Error: statusCode=%d %s", statusCode, err.Error())
-		http.Error(w, err.Error(), statusCode)		
-	}	
+		http.Error(w, err.Error(), statusCode)
+	}
 }
 
 func writeJSON(w http.ResponseWriter, code int, v interface{}) error {
@@ -236,7 +236,7 @@ func getEvents(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 	}
 	w.Header().Set("Content-Type", "application/json")
 	wf := utils.NewWriteFlusher(w)
-	wf.Write([]byte{})
+	wf.Flush()
 	if since != 0 {
 		// If since, send previous events that happened after the timestamp
 		for _, event := range srv.events {

--- a/api.go
+++ b/api.go
@@ -236,6 +236,7 @@ func getEvents(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 	}
 	w.Header().Set("Content-Type", "application/json")
 	wf := utils.NewWriteFlusher(w)
+	wf.Write([]byte{})
 	if since != 0 {
 		// If since, send previous events that happened after the timestamp
 		for _, event := range srv.events {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -616,6 +616,13 @@ func (wf *WriteFlusher) Write(b []byte) (n int, err error) {
 	return n, err
 }
 
+// Flush the stream immediately.
+func (wf *WriteFlusher) Flush() {
+	wf.Lock()
+	defer wf.Unlock()
+	wf.flusher.Flush()
+}
+
 func NewWriteFlusher(w io.Writer) *WriteFlusher {
 	var flusher http.Flusher
 	if f, ok := w.(http.Flusher); ok {


### PR DESCRIPTION
Go's `net/http` API does not send headers until the first call to `ResponseWriter.Write()`.  Ordinarily, this is fine, because in most cases, responses are returned immediately.  However, for the events API, nothing is written until some event is sent, which causes timeouts and/or hangs in some HTTP client APIs, which wait for headers before returning from the "make request" call.
