### PR TITLE
Expose addr, port, proto env variables when linking, Closes #2430

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -151,6 +151,7 @@ Roberto Hashioka <roberto_hashioka@hotmail.com>
 Ryan Fowler <rwfowler@gmail.com>
 Sam Alba <sam.alba@gmail.com>
 Sam J Sharpe <sam.sharpe@digital.cabinet-office.gov.uk>
+Scott Bessler <scottbessler@gmail.com>
 Sean P. Kane <skane@newrelic.com>
 Shawn Siefkas <shawn.siefkas@meredith.com>
 Shih-Yuan Lee <fourdollars@gmail.com>

--- a/docs/sources/examples/linking_into_redis.rst
+++ b/docs/sources/examples/linking_into_redis.rst
@@ -87,6 +87,9 @@ Now lets start our web application with a link into redis.
     TERM=xterm
     DB_PORT=tcp://172.17.0.8:6379
     DB_PORT_6379_TCP=tcp://172.17.0.8:6379
+    DB_PORT_6379_TCP_PROTO=tcp
+    DB_PORT_6379_TCP_ADDR=172.17.0.8
+    DB_PORT_6379_TCP_PORT=6379
     PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     PWD=/
     DB_ENV_PASSWORD=dockerpass
@@ -111,6 +114,9 @@ network and environment information from the child.
     DB_PORT=tcp://172.17.0.8:6379
     # A specific protocol, ip, and port of various services
     DB_PORT_6379_TCP=tcp://172.17.0.8:6379
+    DB_PORT_6379_TCP_PROTO=tcp
+    DB_PORT_6379_TCP_ADDR=172.17.0.8
+    DB_PORT_6379_TCP_PORT=6379
     # Get environment variables of the container 
     DB_ENV_PASSWORD=dockerpass
 

--- a/links.go
+++ b/links.go
@@ -60,6 +60,9 @@ func (l *Link) ToEnv() []string {
 	// Load exposed ports into the environment
 	for _, p := range l.Ports {
 		env = append(env, fmt.Sprintf("%s_PORT_%s_%s=%s://%s:%s", alias, p.Port(), strings.ToUpper(p.Proto()), p.Proto(), l.ChildIP, p.Port()))
+		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_ADDR=%s", alias, p.Port(), strings.ToUpper(p.Proto()), l.ChildIP))
+		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_PORT=%s", alias, p.Port(), strings.ToUpper(p.Proto()), p.Port()))
+		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_PROTO=%s", alias, p.Port(), strings.ToUpper(p.Proto()), p.Proto()))
 	}
 
 	// Load the linked container's name into the environment

--- a/links_test.go
+++ b/links_test.go
@@ -95,6 +95,15 @@ func TestLinkEnv(t *testing.T) {
 	if env["DOCKER_PORT_6379_TCP"] != "tcp://172.0.17.2:6379" {
 		t.Fatalf("Expected tcp://172.0.17.2:6379, got %s", env["DOCKER_PORT_6379_TCP"])
 	}
+	if env["DOCKER_PORT_6379_TCP_PROTO"] != "tcp" {
+		t.Fatalf("Expected tcp, got %s", env["DOCKER_PORT_6379_TCP_PROTO"])
+	}
+	if env["DOCKER_PORT_6379_TCP_ADDR"] != "172.0.17.2" {
+		t.Fatalf("Expected 172.0.17.2, got %s", env["DOCKER_PORT_6379_TCP_ADDR"])
+	}
+	if env["DOCKER_PORT_6379_TCP_PORT"] != "6379" {
+		t.Fatalf("Expected 6379, got %s", env["DOCKER_PORT_6379_TCP_PORT"])
+	}
 	if env["DOCKER_NAME"] != "/db/docker" {
 		t.Fatalf("Expected /db/docker, got %s", env["DOCKER_NAME"])
 	}


### PR DESCRIPTION
Currently the {proto}://{ip}:{port} is exposed, but no variable with just the IP is exposed, it seems that often one will want just the IP of the linked container. 

For example in the redis documentation example, you might see the following in addition to the current environment variables:

```
# The ip of the service running in the container
DB_PORT_6379_TCP_ADDR=172.17.0.8
```
