### PR TITLE
Container commit doesn't use a query parameter, uses POST body

### DIFF
--- a/docs/sources/api/docker_remote_api_v1.0.rst
+++ b/docs/sources/api/docker_remote_api_v1.0.rst
@@ -970,28 +970,33 @@ Create a new image from a container's changes
 
 	**Example request**:
 
-        .. sourcecode:: http
+    .. sourcecode:: http
 
-           POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       Content-Type: application/json
+   
+       {
+           "Cmd": ["cat", "/world"],
+           "PortSpecs":["22"]
+       }
 
-        **Example response**:
+    **Example response**:
 
-        .. sourcecode:: http
+    .. sourcecode:: http
 
-           HTTP/1.1 201 OK
-	   Content-Type: application/vnd.docker.raw-stream
+       HTTP/1.1 201 OK
+       Content-Type: application/vnd.docker.raw-stream
 
-           {"Id":"596069db4bf5"}
+       {"Id":"596069db4bf5"}
 
-	:query container: source container
-	:query repo: repository
-	:query tag: tag
-	:query m: commit message
-	:query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
-	:query run: config automatically applied when the image is run. (ex: {"Cmd": ["cat", "/world"], "PortSpecs":["22"]})
-        :statuscode 201: no error
-	:statuscode 404: no such container
-        :statuscode 500: server error
+    :query container: source container
+    :query repo: repository
+    :query tag: tag
+    :query m: commit message
+    :query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
+    :statuscode 201: no error
+    :statuscode 404: no such container
+    :statuscode 500: server error
 
 
 3. Going further

--- a/docs/sources/api/docker_remote_api_v1.1.rst
+++ b/docs/sources/api/docker_remote_api_v1.1.rst
@@ -977,32 +977,37 @@ Create a new image from a container's changes
 
 .. http:post:: /commit
 
-	Create a new image from a container's changes
+    Create a new image from a container's changes
 
-	**Example request**:
+    **Example request**:
+    
+    .. sourcecode:: http
+    
+       POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       Content-Type: application/json
+   
+       {
+           "Cmd": ["cat", "/world"],
+           "PortSpecs":["22"]
+       }
+    
+    **Example response**:
+    
+    .. sourcecode:: http
+    
+        HTTP/1.1 201 OK
+        Content-Type: application/vnd.docker.raw-stream
 
-        .. sourcecode:: http
+        {"Id":"596069db4bf5"}
 
-           POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
-
-        **Example response**:
-
-        .. sourcecode:: http
-
-           HTTP/1.1 201 OK
-	   Content-Type: application/vnd.docker.raw-stream
-
-           {"Id":"596069db4bf5"}
-
-	:query container: source container
-	:query repo: repository
-	:query tag: tag
-	:query m: commit message
-	:query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
-	:query run: config automatically applied when the image is run. (ex: {"Cmd": ["cat", "/world"], "PortSpecs":["22"]})
-        :statuscode 201: no error
-	:statuscode 404: no such container
-        :statuscode 500: server error
+    :query container: source container
+    :query repo: repository
+    :query tag: tag
+    :query m: commit message
+    :query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
+    :statuscode 201: no error
+    :statuscode 404: no such container
+    :statuscode 500: server error
 
 
 3. Going further

--- a/docs/sources/api/docker_remote_api_v1.2.rst
+++ b/docs/sources/api/docker_remote_api_v1.2.rst
@@ -985,32 +985,37 @@ Create a new image from a container's changes
 
 .. http:post:: /commit
 
-	Create a new image from a container's changes
+    Create a new image from a container's changes
 
-	**Example request**:
+    **Example request**:
 
-        .. sourcecode:: http
+    .. sourcecode:: http
 
-           POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       Content-Type: application/json
+   
+       {
+           "Cmd": ["cat", "/world"],
+           "PortSpecs":["22"]
+       }
 
-        **Example response**:
+    **Example response**:
 
-        .. sourcecode:: http
+    .. sourcecode:: http
 
-           HTTP/1.1 201 OK
+       HTTP/1.1 201 OK
 	   Content-Type: application/vnd.docker.raw-stream
 
-           {"Id":"596069db4bf5"}
+       {"Id":"596069db4bf5"}
 
-	:query container: source container
-	:query repo: repository
-	:query tag: tag
-	:query m: commit message
-	:query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
-	:query run: config automatically applied when the image is run. (ex: {"Cmd": ["cat", "/world"], "PortSpecs":["22"]})
-        :statuscode 201: no error
-	:statuscode 404: no such container
-        :statuscode 500: server error
+    :query container: source container
+    :query repo: repository
+    :query tag: tag
+    :query m: commit message
+    :query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
+    :statuscode 201: no error
+    :statuscode 404: no such container
+    :statuscode 500: server error
 
 
 3. Going further

--- a/docs/sources/api/docker_remote_api_v1.3.rst
+++ b/docs/sources/api/docker_remote_api_v1.3.rst
@@ -1034,32 +1034,37 @@ Create a new image from a container's changes
 
 .. http:post:: /commit
 
-	Create a new image from a container's changes
+    Create a new image from a container's changes
 
-	**Example request**:
+    **Example request**:
 
-        .. sourcecode:: http
+    .. sourcecode:: http
 
-           POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       Content-Type: application/json
+   
+       {
+           "Cmd": ["cat", "/world"],
+           "PortSpecs":["22"]
+       }
 
-        **Example response**:
+    **Example response**:
 
-        .. sourcecode:: http
+    .. sourcecode:: http
 
-           HTTP/1.1 201 OK
+       HTTP/1.1 201 OK
 	   Content-Type: application/vnd.docker.raw-stream
 
-           {"Id":"596069db4bf5"}
+       {"Id":"596069db4bf5"}
 
-	:query container: source container
-	:query repo: repository
-	:query tag: tag
-	:query m: commit message
-	:query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
-	:query run: config automatically applied when the image is run. (ex: {"Cmd": ["cat", "/world"], "PortSpecs":["22"]})
-        :statuscode 201: no error
-	:statuscode 404: no such container
-        :statuscode 500: server error
+    :query container: source container
+    :query repo: repository
+    :query tag: tag
+    :query m: commit message
+    :query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
+    :statuscode 201: no error
+    :statuscode 404: no such container
+    :statuscode 500: server error
 
 
 Monitor Docker's events

--- a/docs/sources/api/docker_remote_api_v1.4.rst
+++ b/docs/sources/api/docker_remote_api_v1.4.rst
@@ -1084,23 +1084,28 @@ Create a new image from a container's changes
 
     .. sourcecode:: http
 
-        POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       Content-Type: application/json
+   
+       {
+           "Cmd": ["cat", "/world"],
+           "PortSpecs":["22"]
+       }
 
     **Example response**:
 
     .. sourcecode:: http
 
-        HTTP/1.1 201 OK
-	    Content-Type: application/vnd.docker.raw-stream
+       HTTP/1.1 201 OK
+	   Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+       {"Id":"596069db4bf5"}
 
     :query container: source container
     :query repo: repository
     :query tag: tag
     :query m: commit message
     :query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
-    :query run: config automatically applied when the image is run. (ex: {"Cmd": ["cat", "/world"], "PortSpecs":["22"]})
     :statuscode 201: no error
     :statuscode 404: no such container
     :statuscode 500: server error

--- a/docs/sources/api/docker_remote_api_v1.5.rst
+++ b/docs/sources/api/docker_remote_api_v1.5.rst
@@ -1050,32 +1050,37 @@ Create a new image from a container's changes
 
 .. http:post:: /commit
 
-  Create a new image from a container's changes
+    Create a new image from a container's changes
 
-  **Example request**:
+    **Example request**:
 
-  .. sourcecode:: http
+    .. sourcecode:: http
 
-    POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       Content-Type: application/json
+   
+       {
+           "Cmd": ["cat", "/world"],
+           "PortSpecs":["22"]
+       }
 
-  **Example response**:
+    **Example response**:
 
-  .. sourcecode:: http
+    .. sourcecode:: http
 
-    HTTP/1.1 201 OK
-    Content-Type: application/vnd.docker.raw-stream
+       HTTP/1.1 201 OK
+	   Content-Type: application/vnd.docker.raw-stream
 
-    {"Id":"596069db4bf5"}
+       {"Id":"596069db4bf5"}
 
-  :query container: source container
-  :query repo: repository
-  :query tag: tag
-  :query m: commit message
-  :query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
-  :query run: config automatically applied when the image is run. (ex: {"Cmd": ["cat", "/world"], "PortSpecs":["22"]})
-  :statuscode 201: no error
-  :statuscode 404: no such container
-  :statuscode 500: server error
+    :query container: source container
+    :query repo: repository
+    :query tag: tag
+    :query m: commit message
+    :query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
+    :statuscode 201: no error
+    :statuscode 404: no such container
+    :statuscode 500: server error
 
 Monitor Docker's events
 ***********************

--- a/docs/sources/api/docker_remote_api_v1.6.rst
+++ b/docs/sources/api/docker_remote_api_v1.6.rst
@@ -1136,7 +1136,13 @@ Create a new image from a container's changes
 
     .. sourcecode:: http
 
-        POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+       Content-Type: application/json
+       
+       {
+           "Cmd": ["cat", "/world"],
+           "PortSpecs":["22"]
+       }
 
     **Example response**:
 
@@ -1152,7 +1158,6 @@ Create a new image from a container's changes
     :query tag: tag
     :query m: commit message
     :query author: author (eg. "John Hannibal Smith <hannibal@a-team.com>")
-    :query run: config automatically applied when the image is run. (ex: {"Cmd": ["cat", "/world"], "PortSpecs":["22"]})
     :statuscode 201: no error
     :statuscode 404: no such container
     :statuscode 500: server error


### PR DESCRIPTION
Figured I'd update the latest remote API docs for this.  Since the code for this area doesn't have anything regarding supporting older versions, not sure how this should show up in the docs.  But on the other hand, as I'm looking through the Docker history, I don't see this ever taking a run query parameter over the POST body style.
