### PR TITLE
Allow backwards-compatible colon syntax for tags in 'commit' command

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1205,6 +1205,9 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 		return nil
 	}
 	name, repository, tag := cmd.Arg(0), cmd.Arg(1), cmd.Arg(2)
+	if tag == "" && strings.Contains(repository, ":") {
+		repository, tag, _ = strings.Split(repository, ":")
+	}
 	if name == "" {
 		cmd.Usage()
 		return nil


### PR DESCRIPTION
Hi there,

I'm not a go programmer, just a docker user.  I've been foiled by the inconsistent syntax of the "commit" command many times, even though I'm aware of it.  The command doesn't use the colon-based tag syntax used by, I believe, every other command in the docker repertoire.

What happens is that when you accidentally use the commit command with a colon to designate the tag name, docker happily creates a repository where the _repository_ name includes a colon.  This is clearly not the user's intent, and it renders the image name unusable by the rest of the docker commands.  For example, you cannot then remove the image by name, since the rmi command interprets the colon-based name correctly, and can't find the repository with the colon in the repository name.  You must use look up the image id and can only remove it by id.

The pull request here is simply my best guess at modifying the commit command to correctly determine that the user intended to create a tag name with the colon-based syntax.  It first tests to see that there is no formal tag argument, then tests to see if there is a colon in the repository name.  If so, it reparses the repository and tag arguments by splitting the repository string on colon.

I can't even compile this as I don't have the go language environment set up.  I'm submitting this to spark a conversation, not necessarily provide the solution.  I did make a good faith effort to use the proper syntax, however, so I wouldn't be entirely surprised if the code actually worked.

If you guys could fix this, it would make me so happy.  Thanks!
