### PR TITLE
Support granular capabilities

### DIFF
--- a/container.go
+++ b/container.go
@@ -89,6 +89,7 @@ type Config struct {
 	Entrypoint      []string
 	NetworkDisabled bool
 	Privileged      bool
+	Capabilities    []string
 }
 
 type HostConfig struct {
@@ -194,6 +195,9 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 
 	var flVolumesFrom utils.ListOpts
 	cmd.Var(&flVolumesFrom, "volumes-from", "Mount volumes from the specified container")
+
+	var flCapabilities utils.ListOpts
+	cmd.Var(&flCapabilities, "cap", "Priviledges to white-list against deny-all capabilities policy")
 
 	flEntrypoint := cmd.String("entrypoint", "", "Overwrite the default entrypoint of the image")
 
@@ -310,6 +314,7 @@ func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, 
 		VolumesFrom:     strings.Join(flVolumesFrom, ","),
 		Entrypoint:      entrypoint,
 		Privileged:      *flPrivileged,
+		Capabilities:    flCapabilities,
 		WorkingDir:      *flWorkingDir,
 	}
 

--- a/container_test.go
+++ b/container_test.go
@@ -1559,6 +1559,22 @@ func TestPrivilegedCanMount(t *testing.T) {
 	}
 }
 
+func TestLeastPrivilegedCanMknod(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+	if output, _ := runContainer(runtime, []string{"-cap", "mknod", "_", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok"}, t); output != "ok\n" {
+		t.Fatal("Could not mknod into semi-privileged container")
+	}
+}
+
+func TestLeastPrivilegedCanMount(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+	if output, _ := runContainer(runtime, []string{"-cap", "sys_admin", "_", "sh", "-c", "mount -t tmpfs none /tmp && echo ok"}, t); output != "ok\n" {
+		t.Fatal("Could not mount into semi-privileged container")
+	}
+}
+
 func TestPrivilegedCannotMknod(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -399,7 +399,7 @@ _docker_run()
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "-a -c -cidfile -d -dns -e -entrypoint -h -i -lxc-conf -m -n -p -privileged -t -u -v -volumes-from -w" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "-a -c -cap -cidfile -d -dns -e -entrypoint -h -i -lxc-conf -m -n -p -privileged -t -u -v -volumes-from -w" -- "$cur" ) )
 			;;
 		*)
 			local counter=$cpos

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -563,6 +563,7 @@ network communication.
       -h="": Container host name
       -i=false: Keep stdin open even if not attached
       -privileged=false: Give extended privileges to this container
+      -cap=[]: Privileges to allow on container with default-deny policy
       -m=0: Memory limit (in bytes)
       -n=true: Enable networking for this container
       -p=[]: Map a network port to the container
@@ -605,11 +606,30 @@ allow it to run:
 
    docker run -privileged mount -t tmpfs none /var/spool/squid
 
-The ``-privileged`` flag gives *all* capabilities to the container,
-and it also lifts all the limitations enforced by the ``device``
-cgroup controller. In other words, the container can then do almost
-everything that the host can do. This flag exists to allow special
-use-cases, like running Docker within Docker.
+The ``-privileged`` flag lifts all the limitations enforced by the ``device``
+cgroup controller and unless specific ``-cap`` arguments are provided,
+gives *all* capabilities to the container. In other words, the container
+can then do almost everything that the host can do. This flag exists to
+allow special use-cases, like running Docker within Docker.
+
+Alternatively, it is possible to enable the specific capabilities required
+by your applications:
+
+.. code-block:: bash
+
+   docker run -cap sys_admin mount -t tmpfs none /var/spool/squid
+
+The ``-cap`` flag gives limited capabilities to the container according
+to the principle of default-deny. This can be used either to reduce or
+enhance the priviledges of a container versus the default capabilities set.
+
+This option is a more granular alternative to the ``-priviledged`` option,
+but is more difficult to use as a consequence.
+
+If paired with the ``-priviledged`` option, only the capabilities
+set with ``-cap`` will be available to the container. However,
+the ``-priviledged`` option will, as usual, lift the limitations
+enforced by the ``device`` cgroup controller.
 
 .. code-block:: bash
 

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+    "strings"
 	"text/template"
 )
 
@@ -106,6 +107,12 @@ lxc.mount.entry = {{$realPath}} {{$ROOTFS}}/{{$virtualPath}} none bind,{{ if ind
 {{end}}
 {{end}}
 
+{{if .Config.Capabilities}}
+# Least-priviledge, granular capabilities
+{{with $capabilities := getCapabilities .Config}}
+lxc.cap.keep = {{$capabilities}}
+{{end}}
+{{else}}
 {{if .Config.Privileged}}
 # retain all capabilities; no lxc.cap.drop line
 {{else}}
@@ -114,6 +121,7 @@ lxc.mount.entry = {{$realPath}} {{$ROOTFS}}/{{$virtualPath}} none bind,{{ if ind
 #         security principle 'deny all unless explicitly permitted', see
 #         http://sourceforge.net/mailarchive/message.php?msg_id=31054627 )
 lxc.cap.drop = audit_control audit_write mac_admin mac_override mknod setpcap sys_admin sys_boot sys_module sys_nice sys_pacct sys_rawio sys_resource sys_time sys_tty_config
+{{end}}
 {{end}}
 
 # limits
@@ -140,6 +148,10 @@ const LxcHostConfigTemplate = `
 var LxcTemplateCompiled *template.Template
 var LxcHostConfigTemplateCompiled *template.Template
 
+func getCapabilities(config *Config) string {
+    return strings.Join(config.Capabilities, " ")
+}
+
 func getMemorySwap(config *Config) int64 {
 	// By default, MemorySwap is set to twice the size of RAM.
 	// If you want to omit MemorySwap, set it to `-1'.
@@ -153,6 +165,7 @@ func init() {
 	var err error
 	funcMap := template.FuncMap{
 		"getMemorySwap": getMemorySwap,
+        "getCapabilities": getCapabilities,
 	}
 	LxcTemplateCompiled, err = template.New("lxc").Funcs(funcMap).Parse(LxcTemplate)
 	if err != nil {


### PR DESCRIPTION
Rather than only supporting lxc.cap.drop, support
should be added for lxc.cap.keep. This would enable
the principle of deny-by-default, with an ability to
granularly enable capabilities.

Allusion to the necessity for this feature is already
noted in lxc_template.go

Resolves issue #2080
