### PR TITLE
fix(systemd): provide a better description

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Easily create lightweight, portable, self-sufficient containers from any application!
+Description=Docker Application Container Engine 
 Documentation=http://docs.docker.io
 Requires=network.target
 After=multi-user.target


### PR DESCRIPTION
Fix-up the docker service file description to declare what the service is not what it does.

When a systemd machine starts up the Description of each unit scrolls by instead of the service's filename. Because the current description doesn't say what it is it isn't very friendly:

```
Oct 31 20:40:49 localhost systemd[1]: Started Update Engine.
Oct 31 20:40:49 localhost systemd[1]: Starting Multi-User System.
Oct 31 20:40:49 localhost systemd[1]: Reached target Multi-User System.
Oct 31 20:40:49 localhost systemd[1]: Starting Easily create lightweight, portable, self-sufficient containers from any application!...
Oct 31 20:40:49 localhost systemd[1]: Started Easily create lightweight, portable, self-sufficient containers from any application!.
```
