### PR TITLE
Rename the 'NAMES' column header of 'ps' output to 'NAME'

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1180,7 +1180,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 	}
 	w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
 	if !*quiet {
-		fmt.Fprint(w, "ID\tIMAGE\tCOMMAND\tCREATED\tSTATUS\tPORTS\tNAMES")
+		fmt.Fprint(w, "ID\tIMAGE\tCOMMAND\tCREATED\tSTATUS\tPORTS\tNAME")
 		if *size {
 			fmt.Fprintln(w, "\tSIZE")
 		} else {


### PR DESCRIPTION
Since a container can ever have only one name, it is misleading to label
the column header in plural form.
