### PR TITLE
2371 sort by private ports

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -26,7 +26,6 @@ import (
 	"reflect"
 	"regexp"
 	"runtime"
-	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -1255,6 +1254,10 @@ func PrintTreeNode(cli *DockerCli, noTrunc *bool, image APIImages, prefix string
 }
 
 func displayablePorts(ports []APIPort) string {
+
+	var portSlice APIPortSlice = APIPortSlice(ports)
+	ports = portSlice.sortByPrivatePort()
+
 	result := []string{}
 	for _, port := range ports {
 		if port.IP == "" {
@@ -1263,7 +1266,7 @@ func displayablePorts(ports []APIPort) string {
 			result = append(result, fmt.Sprintf("%s:%d->%d/%s", port.IP, port.PublicPort, port.PrivatePort, port.Type))
 		}
 	}
-	sort.Strings(result)
+
 	return strings.Join(result, ", ")
 }
 

--- a/sorter.go
+++ b/sorter.go
@@ -2,6 +2,52 @@ package docker
 
 import "sort"
 
+type APIPortSorter struct {
+	APIPorts []APIPort
+	by       func(port1, port2 *APIPort) bool
+}
+
+func (portSorter *APIPortSorter) Len() int {
+	return len(portSorter.APIPorts)
+}
+
+func (portSorter *APIPortSorter) Swap(i, j int) {
+	portSorter.APIPorts[i], portSorter.APIPorts[j] = portSorter.APIPorts[j], portSorter.APIPorts[i]
+}
+
+func (portSorter *APIPortSorter) Less(i, j int) bool {
+	return portSorter.by(&portSorter.APIPorts[i], &portSorter.APIPorts[j])
+}
+
+type By func(port1, port2 *APIPort) bool
+
+func (by By) Sort(APIPorts []APIPort) {
+	portSorter := &APIPortSorter{
+		APIPorts: APIPorts,
+		by:       by,
+	}
+	sort.Sort(portSorter)
+}
+
+// APIPortSlice is a type to allow sorting functions on a slice of APIPort
+type APIPortSlice []APIPort
+
+func (ports APIPortSlice) sortByPrivatePort() []APIPort {
+	privatePort := func(port1, port2 *APIPort) bool {
+		return port1.PrivatePort < port2.PrivatePort
+	}
+	By(privatePort).Sort(ports)
+	return ports
+}
+
+func (ports APIPortSlice) sortByPublicPort() []APIPort {
+	publicPort := func(port1, port2 *APIPort) bool {
+		return port1.PublicPort < port2.PublicPort
+	}
+	By(publicPort).Sort(ports)
+	return ports
+}
+
 type imageSorter struct {
 	images []APIImages
 	by     func(i1, i2 *APIImages) bool // Closure used in the Less method.

--- a/sorter_unit_test.go
+++ b/sorter_unit_test.go
@@ -5,6 +5,105 @@ import (
 	"testing"
 )
 
+var (
+	privatePortSortFunc By = func(port1, port2 *APIPort) bool {
+		return port1.PrivatePort < port2.PrivatePort
+	}
+	publicPortSortFunc By = func(port1, port2 *APIPort) bool {
+		return port1.PublicPort < port2.PublicPort
+	}
+)
+
+func createTestAPIPorts() []APIPort {
+	return []APIPort{
+		APIPort{
+			PublicPort:  2000,
+			PrivatePort: 3000,
+			Type:        "tcp",
+            IP:          "1.2.3.4",
+		},
+		APIPort{
+			PublicPort:  1,
+			PrivatePort: 2,
+			Type:        "tcp",
+            IP:          "1.2.3.4",
+		},
+		APIPort{
+			PublicPort:  2,
+			PrivatePort: 1,
+			Type:        "tcp",
+            IP:          "1.2.3.4",
+		},
+		APIPort{
+			PublicPort:  3,
+			PrivatePort: 7,
+			Type:        "tcp",
+            IP:          "1.2.3.4",
+		},
+	}
+}
+
+func TestAPIPortSliceSortMethodBy(t *testing.T) {
+	ports := createTestAPIPorts()
+
+	privatePort := func(port1, port2 *APIPort) bool {
+		return port1.PrivatePort < port2.PrivatePort
+	}
+
+	By(privatePort).Sort(ports)
+
+	if ports[0].PrivatePort != 1 {
+		t.Error(printSortErrorMessage("By", "Private", 1, ports[0].PrivatePort))
+	}
+
+	publicPort := func(port1, port2 *APIPort) bool {
+		return port1.PublicPort < port2.PublicPort
+	}
+
+	By(publicPort).Sort(ports)
+
+	if ports[0].PublicPort != 1 {
+		t.Error(printSortErrorMessage("By", "Public", 1, ports[0].PublicPort))
+	}
+}
+
+func TestAPIPortSliceSortMethodByWithEmptySlice(t *testing.T) {
+	// No assertions because test's point is to make sure error is not thrown
+	ports := []APIPort{}
+	By(publicPortSortFunc).Sort(ports)
+	By(privatePortSortFunc).Sort(ports)
+}
+
+func TestAPIPortSliceSortByPrivatePort(t *testing.T) {
+	ports := createTestAPIPorts()
+
+	apiPortSlice := APIPortSlice(ports)
+	ports = apiPortSlice.sortByPrivatePort()
+
+	if ports[0].PrivatePort != 1 {
+		t.Error(printSortErrorMessage("TestAPIPortSliceSortByPrivatePort", "Private",
+			1, ports[0].PrivatePort))
+	}
+}
+
+func TestAPIPortSliceSortByPublicPort(t *testing.T) {
+	ports := createTestAPIPorts()
+
+	apiPortSlice := APIPortSlice(ports)
+	ports = apiPortSlice.sortByPublicPort()
+
+	if ports[0].PublicPort != 1 {
+		t.Error(printSortErrorMessage("TestAPIPortSliceSortByPublicPort", "Public",
+			1, ports[0].PublicPort))
+	}
+}
+
+func printSortErrorMessage(methodName, APIPortType string, expected, actual int64) string {
+	return fmt.Sprintf("%s function failed. "+
+		"The expected first %s port is %d and the actual was %d",
+		methodName, APIPortType, expected, actual)
+}
+
 func TestSortUniquePorts(t *testing.T) {
 	ports := []Port{
 		Port("6379/tcp"),
@@ -37,5 +136,14 @@ func TestSortSamePortWithDifferentProto(t *testing.T) {
 	first := ports[0]
 	if fmt.Sprint(first) != "6379/tcp" {
 		t.Fail()
+	}
+}
+
+func TestDisplayablePortsOutputString(t *testing.T) {
+    expected := "1.2.3.4:2->1/tcp, 1.2.3.4:1->2/tcp, 1.2.3.4:3->7/tcp, 1.2.3.4:2000->3000/tcp"
+	actual := displayablePorts(createTestAPIPorts())
+	if expected != actual {
+		t.Error(fmt.Sprintf("TestDisplayablePortsOutputString fail. "+
+			"Expected was %s and Actual was %s", expected, actual))
 	}
 }


### PR DESCRIPTION
Closes #2371.  This pull request adds ascending-sort by private port when printing the open ports to stdout.
