### PR TITLE
Ensure container name on register

### DIFF
--- a/runtime_test.go
+++ b/runtime_test.go
@@ -119,7 +119,7 @@ func init() {
 
 func setupBaseImage() {
 	config := &DaemonConfig{
-		Root:   unitTestStoreBase,
+		Root:        unitTestStoreBase,
 		AutoRestart: false,
 		BridgeIface: unitTestNetworkBridge,
 	}
@@ -826,5 +826,21 @@ func TestGetAllChildren(t *testing.T) {
 		if value.ID != childContainer.ID {
 			t.Fatalf("Expected id %s got %s", childContainer.ID, value.ID)
 		}
+	}
+}
+
+func TestGetFullName(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+
+	name, err := runtime.getFullName("testing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if name != "/testing" {
+		t.Fatalf("Expected /testing got %s", name)
+	}
+	if _, err := runtime.getFullName(""); err == nil {
+		t.Fatal("Error should not be nil")
 	}
 }

--- a/server.go
+++ b/server.go
@@ -1055,7 +1055,10 @@ func (srv *Server) ContainerDestroy(name string, removeVolume, removeLink bool) 
 		if container == nil {
 			return fmt.Errorf("No such link: %s", name)
 		}
-		name = srv.runtime.getFullName(name)
+		name, err := srv.runtime.getFullName(name)
+		if err != nil {
+			return err
+		}
 		parent, n := path.Split(name)
 		if parent == "/" {
 			return fmt.Errorf("Conflict, cannot remove the default name of the container")


### PR DESCRIPTION
Fixes #2491 

This ensures that the container has a name and the `getFullName` method does not panic on an empty string. 

ping @vieux @shykes @creack 
