### PR TITLE
Add a notice to the notice explaining BXA regulations is informational.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -6,7 +6,8 @@ This product includes software developed at Docker, Inc. (http://www.docker.com)
 This product contains software (https://github.com/kr/pty) developed
 by Keith Rarick, licensed under the MIT License.
 
-The following is courtesy of our legal counsel:
+The following is courtesy of our legal counsel, and is purely informational.
+This is nonbinding advice on how to comply with US law.
 
 Transfers of Docker shall be in accordance with applicable export
 controls of any country and all other applicable legal requirements.

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ wrong or incomplete.
 *Brought to you courtesy of our legal counsel. For more context,
 please see the Notice document.*
 
+This is purely nonbinding advice on how to comply with US law.
+
 Transfers of Docker shall be in accordance with applicable export controls 
 of any country and all other applicable legal requirements. Without limiting the 
 foregoing, Docker shall not be distributed or downloaded to any individual or 


### PR DESCRIPTION
 This clarifies that the paragraph that follows is purely advice
 regarding how to comply with US law, and is not part of the License,
 nor a condition for redistributing.
