### PR TITLE
Source a docker default file

### DIFF
--- a/contrib/init/sysvinit/docker
+++ b/contrib/init/sysvinit/docker
@@ -29,6 +29,10 @@ if [ -f /etc/default/$BASE ]; then
 	. /etc/default/$BASE
 fi
 
+if [ -f /etc/default/docker ]; then
+	. /etc/default/docker
+fi
+
 if [ "$1" = start ] && which initctl >/dev/null && initctl version | grep -q upstart; then
 	exit 1
 fi


### PR DESCRIPTION
To allow for easy setting of options without having to replace the whole init file or the lxc default file.
