### PR TITLE
block concurrent push/pull

### DIFF
--- a/runtime_test.go
+++ b/runtime_test.go
@@ -129,11 +129,7 @@ func setupBaseImage() {
 	}
 
 	// Create the "Server"
-	srv := &Server{
-		runtime:     runtime,
-		pullingPool: make(map[string]struct{}),
-		pushingPool: make(map[string]struct{}),
-	}
+	srv := newServer(runtime)
 
 	// If the unit test is not found, try to download it.
 	if img, err := runtime.repositories.LookupImage(unitTestImageName); err != nil || img.ID != unitTestImageID {
@@ -150,11 +146,7 @@ func spawnGlobalDaemon() {
 		return
 	}
 	globalRuntime = mkRuntime(log.New(os.Stderr, "", 0))
-	srv := &Server{
-		runtime:     globalRuntime,
-		pullingPool: make(map[string]struct{}),
-		pushingPool: make(map[string]struct{}),
-	}
+	srv := newServer(globalRuntime)
 
 	// Spawn a Daemon
 	go func() {
@@ -644,7 +636,7 @@ func TestReloadContainerLinks(t *testing.T) {
 func TestDefaultContainerName(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)
-	srv := &Server{runtime: runtime}
+	srv := newServer(runtime)
 
 	config, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
 	if err != nil {
@@ -681,7 +673,7 @@ func TestDefaultContainerName(t *testing.T) {
 func TestRandomContainerName(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)
-	srv := &Server{runtime: runtime}
+	srv := newServer(runtime)
 
 	config, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
 	if err != nil {
@@ -718,7 +710,7 @@ func TestRandomContainerName(t *testing.T) {
 func TestLinkChildContainer(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)
-	srv := &Server{runtime: runtime}
+	srv := newServer(runtime)
 
 	config, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
 	if err != nil {
@@ -769,7 +761,7 @@ func TestLinkChildContainer(t *testing.T) {
 func TestGetAllChildren(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)
-	srv := &Server{runtime: runtime}
+	srv := newServer(runtime)
 
 	config, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -521,11 +521,9 @@ func (srv *Server) pullImage(r *registry.Registry, out io.Writer, imgID, endpoin
 	for _, id := range history {
 
 		// ensure no two downloads of the same layer happen at the same time
-		if err := srv.poolAdd("pull", "layer:"+id); err != nil {
-			utils.Errorf("Image (id: %s) pull is already running, skipping: %v", id, err)
-			return nil
-		}
-		defer srv.poolRemove("pull", "layer:"+id)
+		name := "layer:" + id
+		srv.poolLock(name)
+		defer srv.poolUnlock(name)
 
 		if !srv.runtime.graph.Exists(id) {
 			out.Write(sf.FormatProgress(utils.TruncateID(id), "Pulling", "metadata"))
@@ -618,14 +616,9 @@ func (srv *Server) pullRepository(r *registry.Registry, out io.Writer, localName
 			}
 
 			// ensure no two downloads of the same image happen at the same time
-			if err := srv.poolAdd("pull", "img:"+img.ID); err != nil {
-				utils.Errorf("Image (id: %s) pull is already running, skipping: %v", img.ID, err)
-				if parallel {
-					errors <- nil
-				}
-				return
-			}
-			defer srv.poolRemove("pull", "img:"+img.ID)
+			name := "img:" + img.ID
+			srv.poolLock(name)
+			defer srv.poolUnlock(name)
 
 			out.Write(sf.FormatProgress(utils.TruncateID(img.ID), "Pulling", fmt.Sprintf("image (%s) from %s", img.Tag, localName)))
 			success := false
@@ -689,42 +682,28 @@ func (srv *Server) pullRepository(r *registry.Registry, out io.Writer, localName
 	return nil
 }
 
-func (srv *Server) poolAdd(kind, key string) error {
+func (srv *Server) poolLock(key string) {
 	srv.Lock()
-	defer srv.Unlock()
-
-	if _, exists := srv.pullingPool[key]; exists {
-		return fmt.Errorf("pull %s is already in progress", key)
+	// Cannot use defer to unlock due to need for careful ordering of locking and unlocking
+	mutex, exists := srv.pool[key]
+	if exists {
+		// Unlock the server lock before taking the pool lock to avoid blocking unrelated operations
+		srv.Unlock()
+		mutex.Lock()
+	} else {
+		mutex = new(sync.Mutex)
+		srv.pool[key] = mutex
+		// Lock the pool lock before releasing the server lock to ensure that we nobody else takes it first
+		mutex.Lock()
+		srv.Unlock()
 	}
-	if _, exists := srv.pushingPool[key]; exists {
-		return fmt.Errorf("push %s is already in progress", key)
-	}
-
-	switch kind {
-	case "pull":
-		srv.pullingPool[key] = struct{}{}
-		break
-	case "push":
-		srv.pushingPool[key] = struct{}{}
-		break
-	default:
-		return fmt.Errorf("Unknown pool type")
-	}
-	return nil
 }
 
-func (srv *Server) poolRemove(kind, key string) error {
-	switch kind {
-	case "pull":
-		delete(srv.pullingPool, key)
-		break
-	case "push":
-		delete(srv.pushingPool, key)
-		break
-	default:
-		return fmt.Errorf("Unknown pool type")
-	}
-	return nil
+func (srv *Server) poolUnlock(key string) {
+	srv.Lock()
+	defer srv.Unlock()
+	mutex := srv.pool[key]
+	mutex.Unlock()
 }
 
 func (srv *Server) ImagePull(localName string, tag string, out io.Writer, sf *utils.StreamFormatter, authConfig *auth.AuthConfig, metaHeaders map[string][]string, parallel bool) error {
@@ -732,10 +711,10 @@ func (srv *Server) ImagePull(localName string, tag string, out io.Writer, sf *ut
 	if err != nil {
 		return err
 	}
-	if err := srv.poolAdd("pull", localName+":"+tag); err != nil {
-		return err
-	}
-	defer srv.poolRemove("pull", localName+":"+tag)
+
+	name := localName + ":" + tag
+	srv.poolLock(name)
+	defer srv.poolUnlock(name)
 
 	// Resolve the Repository name from fqn to endpoint + name
 	endpoint, remoteName, err := registry.ResolveRepositoryName(localName)
@@ -924,10 +903,8 @@ func (srv *Server) pushImage(r *registry.Registry, out io.Writer, remote, imgID,
 
 // FIXME: Allow to interrupt current push when new push of same image is done.
 func (srv *Server) ImagePush(localName string, out io.Writer, sf *utils.StreamFormatter, authConfig *auth.AuthConfig, metaHeaders map[string][]string) error {
-	if err := srv.poolAdd("push", localName); err != nil {
-		return err
-	}
-	defer srv.poolRemove("push", localName)
+	srv.poolLock(localName)
+	defer srv.poolUnlock(localName)
 
 	// Resolve the Repository name from fqn to endpoint + name
 	endpoint, remoteName, err := registry.ResolveRepositoryName(localName)
@@ -1504,12 +1481,11 @@ func NewServer(config *DaemonConfig) (*Server, error) {
 		return nil, err
 	}
 	srv := &Server{
-		runtime:     runtime,
-		pullingPool: make(map[string]struct{}),
-		pushingPool: make(map[string]struct{}),
-		events:      make([]utils.JSONMessage, 0, 64), //only keeps the 64 last events
-		listeners:   make(map[string]chan utils.JSONMessage),
-		reqFactory:  nil,
+		runtime:    runtime,
+		pool:       make(map[string]*sync.Mutex),
+		events:     make([]utils.JSONMessage, 0, 64), //only keeps the 64 last events
+		listeners:  make(map[string]chan utils.JSONMessage),
+		reqFactory: nil,
 	}
 	runtime.srv = srv
 	return srv, nil
@@ -1541,10 +1517,9 @@ func (srv *Server) LogEvent(action, id, from string) {
 
 type Server struct {
 	sync.Mutex
-	runtime     *Runtime
-	pullingPool map[string]struct{}
-	pushingPool map[string]struct{}
-	events      []utils.JSONMessage
-	listeners   map[string]chan utils.JSONMessage
-	reqFactory  *utils.HTTPRequestFactory
+	runtime    *Runtime
+	pool       map[string]*sync.Mutex
+	events     []utils.JSONMessage
+	listeners  map[string]chan utils.JSONMessage
+	reqFactory *utils.HTTPRequestFactory
 }

--- a/server_test.go
+++ b/server_test.go
@@ -295,53 +295,39 @@ func TestContainerTop(t *testing.T) {
 
 func TestPools(t *testing.T) {
 	runtime := mkRuntime(t)
-	srv := &Server{
-		runtime:     runtime,
-		pullingPool: make(map[string]struct{}),
-		pushingPool: make(map[string]struct{}),
-	}
+	srv := newServer(runtime)
 	defer nuke(runtime)
 
-	err := srv.poolAdd("pull", "test1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = srv.poolAdd("pull", "test2")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = srv.poolAdd("push", "test1")
-	if err == nil || err.Error() != "pull test1 is already in progress" {
-		t.Fatalf("Expected `pull test1 is already in progress`")
-	}
-	err = srv.poolAdd("pull", "test1")
-	if err == nil || err.Error() != "pull test1 is already in progress" {
-		t.Fatalf("Expected `pull test1 is already in progress`")
-	}
-	err = srv.poolAdd("wait", "test3")
-	if err == nil || err.Error() != "Unknown pool type" {
-		t.Fatalf("Expected `Unknown pool type`")
+	srv.poolLock("test1")
+	srv.poolLock("test2")
+
+	c := make(chan bool)
+
+	go func() {
+		srv.poolLock("test1")
+		c <- true
+	}()
+
+	select {
+	case <-c:
+		t.Fatalf("Expected test1 lock to block")
+	case <-time.After(1 * time.Second):
 	}
 
-	err = srv.poolRemove("pull", "test2")
-	if err != nil {
-		t.Fatal(err)
+	srv.poolUnlock("test2")
+
+	select {
+	case <-c:
+		t.Fatalf("Expected test1 lock to block")
+	case <-time.After(1 * time.Second):
 	}
-	err = srv.poolRemove("pull", "test2")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = srv.poolRemove("pull", "test1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = srv.poolRemove("push", "test1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = srv.poolRemove("wait", "test3")
-	if err == nil || err.Error() != "Unknown pool type" {
-		t.Fatalf("Expected `Unknown pool type`")
+
+	srv.poolUnlock("test1")
+
+	select {
+	case <-time.After(1 * time.Second):
+		t.Fatalf("Expected test1 lock to be unlocked")
+	case <-c:
 	}
 }
 


### PR DESCRIPTION
Block concurrent push/pull attempts instead of
failing. This makes users of the api able to
rely on the fact that e.g. an image will be pulled
if POST /images/create returns 200 OK, instead of
having to parse the reply payload and poll if
docker returns "pull already in progress".
