### PR TITLE
Allow insecure ssl

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -137,7 +137,6 @@ func SaveConfig(configFile *ConfigFile) error {
 		authCopy.Username = ""
 		authCopy.Password = ""
 		authCopy.ServerAddress = ""
-		authCopy.InsecureSSL = false
 		configs[k] = authCopy
 	}
 
@@ -178,7 +177,7 @@ func Login(authConfig *AuthConfig, factory *utils.HTTPRequestFactory) (string, e
 
 	// using `bytes.NewReader(jsonBody)` here causes the server to respond with a 411 status.
 	b := strings.NewReader(string(jsonBody))
-	req1, err := http.Post(serverAddress+"users/", "application/json; charset=utf-8", b)
+	req1, err := client.Post(serverAddress+"users/", "application/json; charset=utf-8", b)
 	if err != nil {
 		return "", fmt.Errorf("Server Error: %s", err)
 	}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/base64"
+    "crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -31,6 +32,7 @@ type AuthConfig struct {
 	Auth          string `json:"auth"`
 	Email         string `json:"email"`
 	ServerAddress string `json:"serveraddress,omitempty"`
+	InsecureSSL   bool `json:"insecuressl,omitempty"`
 }
 
 type ConfigFile struct {
@@ -135,6 +137,7 @@ func SaveConfig(configFile *ConfigFile) error {
 		authCopy.Username = ""
 		authCopy.Password = ""
 		authCopy.ServerAddress = ""
+		authCopy.InsecureSSL = false
 		configs[k] = authCopy
 	}
 
@@ -151,7 +154,8 @@ func SaveConfig(configFile *ConfigFile) error {
 
 // try to register/login to the registry server
 func Login(authConfig *AuthConfig, factory *utils.HTTPRequestFactory) (string, error) {
-	client := &http.Client{}
+	httpTransport := &http.Transport{TLSClientConfig: &tls.Config { InsecureSkipVerify: authConfig.InsecureSSL }}
+	client := &http.Client{Transport: httpTransport}
 	reqStatusCode := 0
 	var status string
 	var reqBody []byte

--- a/commands.go
+++ b/commands.go
@@ -267,10 +267,12 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	cmd := Subcmd("login", "[OPTIONS] [SERVER]", "Register or Login to a docker registry server, if no server is specified \""+auth.IndexServerAddress()+"\" is the default.")
 
 	var username, password, email string
+	var insecureSSL bool
 
 	cmd.StringVar(&username, "u", "", "username")
 	cmd.StringVar(&password, "p", "", "password")
 	cmd.StringVar(&email, "e", "", "email")
+	cmd.BoolVar(&insecureSSL, "insecure-ssl", false, "trust unverified registry server ssl certificates")
 	err := cmd.Parse(args)
 	if err != nil {
 		return nil
@@ -345,6 +347,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	authconfig.Password = password
 	authconfig.Email = email
 	authconfig.ServerAddress = serverAddress
+	authconfig.InsecureSSL = insecureSSL
 	cli.configFile.Configs[serverAddress] = authconfig
 
 	body, statusCode, err := cli.call("POST", "/auth", cli.configFile.Configs[serverAddress])

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -417,6 +417,7 @@ Insert file from github
     -e="": email
     -p="": password
     -u="": username
+    -insecure-ssl=false: trust unverified registry server ssl certificates
 
     If you want to login to a private registry you can
     specify this by adding the server name.

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -647,7 +647,7 @@ func NewRegistry(root string, authConfig *auth.AuthConfig, factory *utils.HTTPRe
 	httpTransport := &http.Transport{
 		DisableKeepAlives: true,
 		Proxy:             http.ProxyFromEnvironment,
-		TLSClientConfig: &tls.Config { InsecureSkipVerify: authConfig.InsecureSSL }
+		TLSClientConfig: &tls.Config { InsecureSkipVerify: authConfig.InsecureSSL },
 	}
 
 	r = &Registry{


### PR DESCRIPTION
This will allow support for private docker registries that have self-signed or otherwise unverified ssl certificates. Useful in non-production environments. The basic flow is that one specifies if insecure ssl is allowed for a given registry with a switch argument to docker login. That state is stored in .dockercfg for use in later calls to the registry.
