### PR TITLE
Add host and container info to DockerInfo API #1091

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ Briehan Lombaard <briehan.lombaard@gmail.com>
 Bruno Bigras <bigras.bruno@gmail.com>
 Caleb Spare <cespare@gmail.com>
 Calen Pennington <cale@edx.org>
+Chance Zibolski <chance.zibolski@gmail.com>
 Charles Hooper <charles.hooper@dotcloud.com>
 Christopher Currie <codemonkey+github@gmail.com>
 Colin Dunklau <colin.dunklau@gmail.com>

--- a/api_params.go
+++ b/api_params.go
@@ -20,6 +20,13 @@ type APIImages struct {
 type APIInfo struct {
 	Debug              bool
 	Containers         int
+	RunningContainers  int
+	MemUsageRunning    int64
+	MemUsageTotal      int64
+	CPUCores           int
+	CPUAverage         [3]float64
+	FreeRAM            uint64
+	TotalRAM           uint64
 	Images             int
 	NFd                int    `json:",omitempty"`
 	NGoroutines        int    `json:",omitempty"`

--- a/commands.go
+++ b/commands.go
@@ -459,7 +459,16 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		return err
 	}
 
-	fmt.Fprintf(cli.out, "Containers: %d\n", out.Containers)
+	fmt.Fprintf(cli.out, "Running Containers: %d\n", out.RunningContainers)
+	fmt.Fprintf(cli.out, "Total Containers: %d\n", out.Containers)
+	if out.RunningContainers > 0 {
+		fmt.Fprintf(cli.out, "Memory Usage (Running): %v\n",
+			utils.ByteSize(out.MemUsageRunning))
+	}
+	if out.MemUsageTotal != 0 {
+		fmt.Fprintf(cli.out, "Max Memory Usage (Total Combined Memory Limit): %s\n",
+			utils.ByteSize(out.MemUsageTotal))
+	}
 	fmt.Fprintf(cli.out, "Images: %d\n", out.Images)
 	if out.Debug || os.Getenv("DEBUG") != "" {
 		fmt.Fprintf(cli.out, "Debug mode (server): %v\n", out.Debug)
@@ -479,6 +488,12 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 			fmt.Fprintf(cli.out, "Registry: %v\n", out.IndexServerAddress)
 		}
 	}
+	fmt.Fprintf(cli.out, "CPU Cores: %d\n", out.CPUCores)
+	fmt.Fprintf(cli.out, "CPU Averages: %.2f %.2f %.2f\n",
+		out.CPUAverage[0], out.CPUAverage[1], out.CPUAverage[2])
+	fmt.Fprintf(cli.out, "Free RAM: %v\n", utils.ByteSize(out.FreeRAM))
+	fmt.Fprintf(cli.out, "Total RAM: %v\n", utils.ByteSize(out.TotalRAM))
+
 	if !out.MemoryLimit {
 		fmt.Fprintf(cli.err, "WARNING: No memory limit support\n")
 	}

--- a/container.go
+++ b/container.go
@@ -1462,6 +1462,15 @@ func (container *Container) rwPath() string {
 	return path.Join(container.root, "rw")
 }
 
+func (container *Container) cgroupPath(cgroupType string) (string, error) {
+	cgroupMemoryMountpoint, err := utils.FindCgroupMountpoint(cgroupType)
+	if err != nil {
+		return "", err
+	}
+	cgroup_path := path.Join(cgroupMemoryMountpoint, "lxc", container.ID)
+	return cgroup_path, nil
+}
+
 func validateID(id string) error {
 	if id == "" {
 		return fmt.Errorf("Invalid empty id")
@@ -1517,4 +1526,50 @@ func (container *Container) Copy(resource string) (archive.Archive, error) {
 func (container *Container) Exposes(p Port) bool {
 	_, exists := container.Config.ExposedPorts[p]
 	return exists
+}
+
+type MemStat struct {
+	rss   int64
+	cache int64
+	swap  int64
+}
+
+func (container *Container) GetMemStat() (*MemStat, error) {
+	cgroup_path, err := container.cgroupPath("memory")
+	if err != nil {
+		return nil, err
+	}
+
+	cgroup_file := path.Join(cgroup_path, "memory.stat")
+	content, err := ioutil.ReadFile(cgroup_file)
+	if err != nil {
+		return nil, err
+	}
+	buf := bytes.NewBuffer(content)
+	memory := new(MemStat)
+
+	for {
+		line, err := buf.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		info := strings.Fields(line)
+		switch info[0] {
+		case "rss":
+			memory.rss, err = strconv.ParseInt(info[1], 10, 64)
+		case "cache":
+			memory.cache, err = strconv.ParseInt(info[1], 10, 64)
+		case "swap":
+			memory.swap, err = strconv.ParseInt(info[1], 10, 64)
+		default:
+			err = nil
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	return memory, nil
 }

--- a/runtime.go
+++ b/runtime.go
@@ -27,6 +27,17 @@ type Capabilities struct {
 	AppArmor               bool
 }
 
+type MemUsage struct {
+	running int64
+	total   int64
+}
+
+type ContainerInfo struct {
+	NumRunning int
+	NumTotal   int
+	MemInfo    *MemUsage
+}
+
 type Runtime struct {
 	repository     string
 	containers     *list.List
@@ -48,6 +59,42 @@ func (runtime *Runtime) List() []*Container {
 		containers.Add(e.Value.(*Container))
 	}
 	return *containers
+}
+
+func (runtime *Runtime) ListRunning() []*Container {
+	running := new(History)
+	for e := runtime.containers.Front(); e != nil; e = e.Next() {
+		if container := e.Value.(*Container); container.State.Running {
+			running.Add(container)
+		}
+	}
+	return *running
+}
+
+func (runtime *Runtime) ContainerMemUsage() *MemUsage {
+	containers := runtime.List()
+	usage := new(MemUsage)
+	for _, container := range containers {
+		used, err := container.GetMemStat()
+		if err != nil {
+			return usage
+		}
+		total_usage := (used.rss + used.cache + used.swap)
+		if container.State.Running {
+			usage.running += total_usage
+		}
+		usage.total += container.Config.Memory
+	}
+	return usage
+}
+
+func (runtime *Runtime) NewContainerInfo() *ContainerInfo {
+	info := ContainerInfo{
+		NumRunning: len(runtime.ListRunning()),
+		NumTotal:   len(runtime.List()),
+		MemInfo:    runtime.ContainerMemUsage(),
+	}
+	return &info
 }
 
 func (runtime *Runtime) getContainerElement(id string) *list.Element {

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/gograph"
 	"github.com/dotcloud/docker/registry"
+	"github.com/dotcloud/docker/stats"
 	"github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"
@@ -349,8 +350,18 @@ func (srv *Server) DockerInfo() *APIInfo {
 		kernelVersion = kv.String()
 	}
 
+	containerinfo := srv.runtime.NewContainerInfo()
+	sysinfo := stats.NewSysInfo()
+
 	return &APIInfo{
-		Containers:         len(srv.runtime.List()),
+		Containers:         containerinfo.NumTotal,
+		RunningContainers:  containerinfo.NumRunning,
+		MemUsageRunning:    containerinfo.MemInfo.running,
+		MemUsageTotal:      containerinfo.MemInfo.total,
+		CPUCores:           sysinfo.CpuInfo.Cpus,
+		CPUAverage:         sysinfo.CpuInfo.Average,
+		FreeRAM:            sysinfo.MemInfo.Free,
+		TotalRAM:           sysinfo.MemInfo.Total,
 		Images:             imgcount,
 		MemoryLimit:        srv.runtime.capabilities.MemoryLimit,
 		SwapLimit:          srv.runtime.capabilities.SwapLimit,

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -1,0 +1,16 @@
+package stats
+
+type CpuInfo struct {
+	Cpus    int
+	Average [3]float64
+}
+
+type MemInfo struct {
+	Free  uint64
+	Total uint64
+}
+
+type SysInfo struct {
+	CpuInfo CpuInfo
+	MemInfo MemInfo
+}

--- a/stats/stats_darwin.go
+++ b/stats/stats_darwin.go
@@ -1,0 +1,7 @@
+package stats
+
+func NewSysInfo() *SysInfo {
+	sysinfo := new(SysInfo)
+	sysinfo.CpuInfo.Cpus = runtime.NumCPU()
+	return sysinfo
+}

--- a/stats/stats_linux.go
+++ b/stats/stats_linux.go
@@ -1,0 +1,20 @@
+package stats
+
+import (
+	"runtime"
+	"syscall"
+)
+
+func NewSysInfo() *SysInfo {
+	var info syscall.Sysinfo_t
+	err := syscall.Sysinfo(&info)
+	sysinfo := new(SysInfo)
+	if err == nil {
+		sysinfo.MemInfo = MemInfo{Free: info.Freeram, Total: info.Totalram}
+		for i, avg := range info.Loads {
+			sysinfo.CpuInfo.Average[i] = float64(avg) / 65536.0
+		}
+	}
+	sysinfo.CpuInfo.Cpus = runtime.NumCPU()
+	return sysinfo
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1142,3 +1142,39 @@ func PartParser(template, data string) (map[string]string, error) {
 	}
 	return out, nil
 }
+
+type ByteSize float64
+
+const (
+	_           = iota // ignore first value by assigning to blank identifier
+	KB ByteSize = 1 << (10 * iota)
+	MB
+	GB
+	TB
+	PB
+	EB
+	ZB
+	YB
+)
+
+func (b ByteSize) String() string {
+	switch {
+	case b >= YB:
+		return fmt.Sprintf("%.2fYB", b/YB)
+	case b >= ZB:
+		return fmt.Sprintf("%.2fZB", b/ZB)
+	case b >= EB:
+		return fmt.Sprintf("%.2fEB", b/EB)
+	case b >= PB:
+		return fmt.Sprintf("%.2fPB", b/PB)
+	case b >= TB:
+		return fmt.Sprintf("%.2fTB", b/TB)
+	case b >= GB:
+		return fmt.Sprintf("%.2fGB", b/GB)
+	case b >= MB:
+		return fmt.Sprintf("%.2fMB", b/MB)
+	case b >= KB:
+		return fmt.Sprintf("%.2fKB", b/KB)
+	}
+	return fmt.Sprintf("%.2fB", b)
+}


### PR DESCRIPTION
This PR addresses issue #1091 and adds the following information to the DockerInfo API endpoint and the `docker info` command:
- Number of running containers
- Memory usage of running containers
- Max memory usage of all containers (combined memlimits)
- Number of Logical CPUs on the server
- 1, 5, and 15 minute CPU Averages of the server
- Free RAM on the server
- Total RAM on the server

It's probably rough around the edges, so I would really appreciate any feedback.
