### PR TITLE
Release script tweaks

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -97,7 +97,7 @@ write_to_s3() {
 	DEST=$1
 	F=`mktemp`
 	cat > $F
-	s3cmd --acl-public put $F $DEST
+	s3cmd --acl-public --mime-type='text/plain' put $F $DEST
 	rm -f $F
 }
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -107,7 +107,7 @@ s3_url() {
 			echo "https://$BUCKET"
 			;;
 		*)
-			echo "http://$BUCKET.s3.amazonaws.com"
+			s3cmd ws-info s3://$BUCKET | awk -v 'FS=: +' '/http:\/\/'$BUCKET'/ { gsub(/\/+$/, "", $2); print $2 }'
 			;;
 	esac
 }


### PR DESCRIPTION
The first fix here is to allow `release.sh` to work properly with non-*.docker.io buckets by asking s3cmd for the proper "website" URL (ie, http://bucket.s3-website-REGION.amazonaws.com/, like http://tianon-docker.s3-website-us-west-2.amazonaws.com/).  The second fix is to move our https://get.docker.io/ubuntu/info page directly to https://get.docker.io/ubuntu/ (because we get lots of people hitting that URL and then wondering why it's a 404 and thinking that's why their repo isn't working, when APT doesn't ever even hit that URL), with a URL-backwards-compatibility redirect at /ubuntu/info.  The same fix/tweak was applied for /builds/info to /builds/, for consistency.
