### PR TITLE
setup network when reconnecting to ghost container

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -172,6 +172,7 @@ func (runtime *Runtime) Register(container *Container) error {
 	if !container.State.Running {
 		close(container.waitLock)
 	} else if !nomonitor {
+		container.allocateNetwork()
 		go container.monitor()
 	}
 	return nil


### PR DESCRIPTION
Re-adding the line to setup the network when reconnecting to a ghost
container.  It was inadvertently removed by commit
31638ab2ad2a5380d447780f05f7aa078c9421f5.
