### PR TITLE
2506 - More informative error message on name collisions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,6 +44,7 @@ Daniel Nordberg <dnordberg@gmail.com>
 Daniel Robinson <gottagetmac@gmail.com>
 Daniel Von Fange <daniel@leancoder.com>
 Daniel YC Lin <dlin.tw@gmail.com>
+Darren Coxall <darren@darrencoxall.com>
 David Calavera <david.calavera@gmail.com>
 David Sissitka <me@dsissitka.com>
 Deni Bertovic <deni@kset.org>

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -231,6 +231,18 @@ func TestRuntimeCreate(t *testing.T) {
 		t.Errorf("Exists() returned false for a newly created container")
 	}
 
+	// Test that conflict error displays correct details
+	testContainer, _, _ := runtime.Create(
+		&docker.Config{
+			Image: GetTestImage(runtime).ID,
+			Cmd:   []string{"ls", "-al"},
+		},
+		"conflictname",
+	)
+	if _, _, err := runtime.Create(&docker.Config{Image: GetTestImage(runtime).ID, Cmd: []string{"ls", "-al"}}, testContainer.Name); err == nil || !strings.Contains(err.Error(), utils.TruncateID(testContainer.ID)) {
+		t.Fatalf("Name conflict error doesn't include the correct short id. Message was: %s", err.Error())
+	}
+
 	// Make sure create with bad parameters returns an error
 	if _, _, err = runtime.Create(&docker.Config{Image: GetTestImage(runtime).ID}, ""); err == nil {
 		t.Fatal("Builder.Create should throw an error when Cmd is missing")

--- a/runtime.go
+++ b/runtime.go
@@ -402,7 +402,8 @@ func (runtime *Runtime) Create(config *Config, name string) (*Container, []strin
 	// Set the enitity in the graph using the default name specified
 	if _, err := runtime.containerGraph.Set(name, id); err != nil {
 		if strings.HasSuffix(err.Error(), "name are not unique") {
-			return nil, nil, fmt.Errorf("Conflict, %s already exists.", name)
+			conflictingContainer, _ := runtime.GetByName(name)
+			return nil, nil, fmt.Errorf("Conflict, The name %s is already assigned to %s. You have to delete (or rename) that container to be able to assign %s to a container again.", name, utils.TruncateID(conflictingContainer.ID), name)
 		}
 		return nil, nil, err
 	}


### PR DESCRIPTION
Fixes #2506

This should provide the proposed error message for conflicting names including information as to how to overcome the error. I agree the error was a bit ambiguous and so I feel this is an improvement but I am more than happy to discuss as it is a bit long winded compared to some of the other error messages.

My first contribution so go easy. I didn't test the change as there was no test coverage for the error text initially. If someone could confirm that I am doing the correct thing to get the conflicting containers ID?
