### PR TITLE
Add a link on how to install docker on the Raspberry Pi

### DIFF
--- a/docs/sources/installation/archlinux.rst
+++ b/docs/sources/installation/archlinux.rst
@@ -16,6 +16,9 @@ either of the following AUR packages:
 The lxc-docker package will install the latest tagged version of docker. 
 The lxc-docker-git package will build from the current master branch.
 
+**Note :** for Arch Linux running on a Raspberry Pi, an installation procedure can be found at `resin.io <http://resin.io/docker-on-raspberry-pi//>`_
+
+
 Dependencies
 ------------
 


### PR DESCRIPTION
The guys at resin.io have put together a procedure to install docker on a raspberry pi (the 25$ ARM platform), running Archlinux. It should be nice to know it directly from here, since it involves additionnal non-trivial steps (like patching the Linux kernel).
