### PR TITLE
Fix sysvinit upstart detection and give it a pretty message

### DIFF
--- a/contrib/init/sysvinit/docker
+++ b/contrib/init/sysvinit/docker
@@ -29,7 +29,8 @@ if [ -f /etc/default/$BASE ]; then
 	. /etc/default/$BASE
 fi
 
-if [ "$1" = start ] && which initctl >/dev/null && initctl version | grep -q upstart; then
+if which initctl >/dev/null && initctl version | grep -q upstart; then
+	log_failure_msg "Docker is managed via upstart, try using service $BASE $1"
 	exit 1
 fi
 


### PR DESCRIPTION
This way, Ubuntu users trying to `/etc/init.d/docker restart` will get a nice message pointing them to upstart instead.
