### PR TITLE
Add /etc/default/docker support to upstart, too (mirroring sysvinit)

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -6,5 +6,10 @@ stop on runlevel [!2345]
 respawn
 
 script
-	/usr/bin/docker -d
+	DOCKER=/usr/bin/$UPSTART_JOB
+	DOCKER_OPTS=
+	if [ -f /etc/default/$UPSTART_JOB ]; then
+		. /etc/default/$UPSTART_JOB
+	fi
+	"$DOCKER" -d $DOCKER_OPTS
 end script


### PR DESCRIPTION
Now, we can have "/etc/default/docker" that contains:

``` bash
DOCKER_OPTS="-D -H=unix:///var/run/docker.sock -H=tcp://127.0.0.1:4243"
```

... and both Upstart and SysV will use it correctly to start the docker daemon with the proper options.
