### PR TITLE
Update upstart check in sysvinit to be exactly the same as the init_is_upstart function

### DIFF
--- a/contrib/init/sysvinit/docker
+++ b/contrib/init/sysvinit/docker
@@ -29,7 +29,8 @@ if [ -f /etc/default/$BASE ]; then
 	. /etc/default/$BASE
 fi
 
-if which initctl >/dev/null && initctl version | grep -q upstart; then
+# see also init_is_upstart in /lib/lsb/init-functions (which isn't available in Ubuntu 12.04, or we'd use it)
+if [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | /bin/grep -q upstart; then
 	log_failure_msg "Docker is managed via upstart, try using service $BASE $1"
 	exit 1
 fi


### PR DESCRIPTION
... from /lib/lsb/init-functions (which function isn't available in 12.04 or we'd just use it directly).

/cc @paultag

see also https://wiki.ubuntu.com/UpstartCompatibleInitScripts
