### PR TITLE
Automatically create non-existent bind-mounted host directories

### DIFF
--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1100,7 +1100,16 @@ using the container, but inside the current working directory.
 
 .. code-block:: bash
 
-   $ sudo docker run -p 127.0.0.1:80:8080 ubuntu bash
+    $ sudo docker run -v /dont/exist:/foo -w /foo -i -t ubuntu bash
+
+When the host directory of a bind-mounted volume doesn't exist, Docker
+will automatically create this directory on the host for you. In the
+example above, Docker will create the ``/dont/exist`` folder before
+starting your container.
+
+.. code-block:: bash
+
+    $ sudo docker run -p 127.0.0.1:80:8080 ubuntu bash
 
 This binds port ``8080`` of the container to port ``80`` on ``127.0.0.1`` of the
 host machine. :ref:`port_redirection` explains in detail how to manipulate ports

--- a/docs/sources/use/working_with_volumes.rst
+++ b/docs/sources/use/working_with_volumes.rst
@@ -89,11 +89,15 @@ Mount a Host Directory as a Container Volume:
 ::
 
   -v=[]: Create a bind mount with: [host-dir]:[container-dir]:[rw|ro].
-  If "host-dir" is missing, then docker creates a new volume.
 
-This is not available from a Dockerfile as it makes the built image less portable
-or shareable. [host-dir] volumes are 100% host dependent and will break on any 
-other machine.
+If ``host-dir`` is missing from the command, then docker creates a new volume.
+If ``host-dir`` is present but points to a non-existent directory on the host,
+Docker will automatically create this directory and use it as the source of the
+bind-mount.
+
+Note that this is not available from a Dockerfile due the portability and
+sharing purpose of it. The ``host-dir`` volumes are entirely host-dependent and
+might not work on any other machine.
 
 For example::
 

--- a/server.go
+++ b/server.go
@@ -1909,8 +1909,11 @@ func (srv *Server) ContainerStart(job *engine.Job) engine.Status {
 			// ensure the source exists on the host
 			_, err := os.Stat(source)
 			if err != nil && os.IsNotExist(err) {
-				job.Errorf("Invalid bind mount '%s' : source doesn't exist", bind)
-				return engine.StatusErr
+				err = os.MkdirAll(source, 0755)
+				if err != nil {
+					job.Errorf("Could not create local directory '%s' for bind mount: %s!", source, err.Error())
+					return engine.StatusErr
+				}
 			}
 		}
 		// Register any links from the host config before starting the container


### PR DESCRIPTION
This change allows Docker to automatically create non-existent, host-side, bind-mounted directories on container start. Fixes #1279.
