### PR TITLE
use utils.ParseRepositoryTag instead of strings.split in docker images

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1172,14 +1172,10 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 			fmt.Fprintln(w, "REPOSITORY\tTAG\tIMAGE ID\tCREATED\tSIZE")
 		}
 
-		var repo string
-		var tag string
 		for _, out := range outs {
 			for _, repotag := range out.RepoTags {
 
-				components := strings.SplitN(repotag, ":", 2)
-				repo = components[0]
-				tag = components[1]
+				repo, tag := utils.ParseRepositoryTag(repotag)
 
 				if !*noTrunc {
 					out.ID = utils.TruncateID(out.ID)
@@ -1241,7 +1237,7 @@ func PrintTreeNode(cli *DockerCli, noTrunc *bool, image APIImages, prefix string
 
 	fmt.Fprintf(cli.out, "%s%s Size: %s (virtual %s)", prefix, imageID, utils.HumanSize(image.Size), utils.HumanSize(image.VirtualSize))
 	if image.RepoTags[0] != "<none>:<none>" {
-		fmt.Fprintf(cli.out, " Tags: %s\n", strings.Join(image.RepoTags, ","))
+		fmt.Fprintf(cli.out, " Tags: %s\n", strings.Join(image.RepoTags, ", "))
 	} else {
 		fmt.Fprint(cli.out, "\n")
 	}


### PR DESCRIPTION
Fix docker images output with private registry (`private.registry.fr:5000/repo:tag`)
