### PR TITLE
Remove two calls to go test

### DIFF
--- a/hack/make/test
+++ b/hack/make/test
@@ -16,8 +16,7 @@ bundle_test() {
 		for test_dir in $(find_test_dirs); do (
 			set -x
 			cd $test_dir
-			go test -i -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS
-			go test -v -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS $TESTFLAGS
+			go test -i -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS $TESTFLAGS
 		)  done
 	} 2>&1 | tee $DEST/test.log
 }


### PR DESCRIPTION
@shykes @vieux 

Do we want to keep the `-v` flag for go test ?
