### PR TITLE
Add clarification of multiple "go test" calls in hack/make/*test

### DIFF
--- a/hack/make/dyntest
+++ b/hack/make/dyntest
@@ -22,7 +22,12 @@ bundle_test() {
 		for test_dir in $(find_test_dirs); do (
 			set -x
 			cd $test_dir
+			
+			# Install packages that are dependencies of the tests.
+			#   Note: Does not run the tests.
 			go test -i -ldflags "$LDFLAGS" $BUILDFLAGS
+			
+			# Run the tests with the optional $TESTFLAGS.
 			export TEST_DOCKERINIT_PATH=$DEST/../dynbinary/dockerinit-$VERSION
 			go test -v -ldflags "$LDFLAGS -X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\"" $BUILDFLAGS $TESTFLAGS
 		)  done

--- a/hack/make/test
+++ b/hack/make/test
@@ -16,7 +16,12 @@ bundle_test() {
 		for test_dir in $(find_test_dirs); do (
 			set -x
 			cd $test_dir
+			
+			# Install packages that are dependencies of the tests.
+			#   Note: Does not run the tests.
 			go test -i -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS
+			
+			# Run the tests with the optional $TESTFLAGS.
 			go test -v -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS $TESTFLAGS
 		)  done
 	} 2>&1 | tee $DEST/test.log


### PR DESCRIPTION
This is in response to #2668, to help ensure we don't have further confusion about why we invoke `go test` twice in our test scripts (we really should have added comments like this to begin with - I'll take the blame for that one).

/cc @crosbymichael @shykes
