### PR TITLE
Expand the engine API with 'create' and 'start' jobs Edit

### DIFF
--- a/api.go
+++ b/api.go
@@ -526,43 +526,36 @@ func postContainersCreate(srv *Server, version float64, w http.ResponseWriter, r
 	if err := parseForm(r); err != nil {
 		return nil
 	}
-	config := &Config{}
 	out := &APIRun{}
-	name := r.Form.Get("name")
-
-	if err := json.NewDecoder(r.Body).Decode(config); err != nil {
+	job := srv.Eng.Job("create", r.Form.Get("name"))
+	if err := job.DecodeEnv(r.Body); err != nil {
 		return err
 	}
-
 	resolvConf, err := utils.GetResolvConf()
 	if err != nil {
 		return err
 	}
-
-	if !config.NetworkDisabled && len(config.Dns) == 0 && len(srv.runtime.config.Dns) == 0 && utils.CheckLocalDns(resolvConf) {
+	if !job.GetenvBool("NetworkDisabled") && len(job.Getenv("Dns")) == 0 && len(srv.runtime.config.Dns) == 0 && utils.CheckLocalDns(resolvConf) {
 		out.Warnings = append(out.Warnings, fmt.Sprintf("Docker detected local DNS server on resolv.conf. Using default external servers: %v", defaultDns))
-		config.Dns = defaultDns
+		job.SetenvList("Dns", defaultDns)
 	}
-
-	id, warnings, err := srv.ContainerCreate(config, name)
-	if err != nil {
+	// Read container ID from the first line of stdout
+	job.StdoutParseString(&out.ID)
+	// Read warnings from stderr
+	job.StderrParseLines(&out.Warnings, 0)
+	if err := job.Run(); err != nil {
 		return err
 	}
-	out.ID = id
-	for _, warning := range warnings {
-		out.Warnings = append(out.Warnings, warning)
-	}
-
-	if config.Memory > 0 && !srv.runtime.capabilities.MemoryLimit {
+	if job.GetenvInt("Memory") > 0 && !srv.runtime.capabilities.MemoryLimit {
 		log.Println("WARNING: Your kernel does not support memory limit capabilities. Limitation discarded.")
 		out.Warnings = append(out.Warnings, "Your kernel does not support memory limit capabilities. Limitation discarded.")
 	}
-	if config.Memory > 0 && !srv.runtime.capabilities.SwapLimit {
+	if job.GetenvInt("Memory") > 0 && !srv.runtime.capabilities.SwapLimit {
 		log.Println("WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.")
 		out.Warnings = append(out.Warnings, "Your kernel does not support memory swap capabilities. Limitation discarded.")
 	}
 
-	if !config.NetworkDisabled && srv.runtime.capabilities.IPv4ForwardingDisabled {
+	if !job.GetenvBool("NetworkDisabled") && srv.runtime.capabilities.IPv4ForwardingDisabled {
 		log.Println("Warning: IPv4 forwarding is disabled.")
 		out.Warnings = append(out.Warnings, "IPv4 forwarding is disabled.")
 	}

--- a/api.go
+++ b/api.go
@@ -541,43 +541,36 @@ func postContainersCreate(srv *Server, version float64, w http.ResponseWriter, r
 	if err := parseForm(r); err != nil {
 		return nil
 	}
-	config := &Config{}
 	out := &APIRun{}
-	name := r.Form.Get("name")
-
-	if err := json.NewDecoder(r.Body).Decode(config); err != nil {
+	job := srv.Eng.Job("create", r.Form.Get("name"))
+	if err := job.DecodeEnv(r.Body); err != nil {
 		return err
 	}
-
 	resolvConf, err := utils.GetResolvConf()
 	if err != nil {
 		return err
 	}
-
-	if !config.NetworkDisabled && len(config.Dns) == 0 && len(srv.runtime.config.Dns) == 0 && utils.CheckLocalDns(resolvConf) {
+	if !job.GetenvBool("NetworkDisabled") && len(job.Getenv("Dns")) == 0 && len(srv.runtime.config.Dns) == 0 && utils.CheckLocalDns(resolvConf) {
 		out.Warnings = append(out.Warnings, fmt.Sprintf("Docker detected local DNS server on resolv.conf. Using default external servers: %v", defaultDns))
-		config.Dns = defaultDns
+		job.SetenvList("Dns", defaultDns)
 	}
-
-	id, warnings, err := srv.ContainerCreate(config, name)
-	if err != nil {
+	// Read container ID from the first line of stdout
+	job.StdoutParseString(&out.ID)
+	// Read warnings from stderr
+	job.StderrParseLines(&out.Warnings, 0)
+	if err := job.Run(); err != nil {
 		return err
 	}
-	out.ID = id
-	for _, warning := range warnings {
-		out.Warnings = append(out.Warnings, warning)
-	}
-
-	if config.Memory > 0 && !srv.runtime.capabilities.MemoryLimit {
+	if job.GetenvInt("Memory") > 0 && !srv.runtime.capabilities.MemoryLimit {
 		log.Println("WARNING: Your kernel does not support memory limit capabilities. Limitation discarded.")
 		out.Warnings = append(out.Warnings, "Your kernel does not support memory limit capabilities. Limitation discarded.")
 	}
-	if config.Memory > 0 && !srv.runtime.capabilities.SwapLimit {
+	if job.GetenvInt("Memory") > 0 && !srv.runtime.capabilities.SwapLimit {
 		log.Println("WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.")
 		out.Warnings = append(out.Warnings, "Your kernel does not support memory swap capabilities. Limitation discarded.")
 	}
 
-	if !config.NetworkDisabled && srv.runtime.capabilities.IPv4ForwardingDisabled {
+	if !job.GetenvBool("NetworkDisabled") && srv.runtime.capabilities.IPv4ForwardingDisabled {
 		log.Println("Warning: IPv4 forwarding is disabled.")
 		out.Warnings = append(out.Warnings, "IPv4 forwarding is disabled.")
 	}
@@ -654,26 +647,23 @@ func deleteImages(srv *Server, version float64, w http.ResponseWriter, r *http.R
 }
 
 func postContainersStart(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	var hostConfig *HostConfig
-	// allow a nil body for backwards compatibility
-	if r.Body != nil {
-		if matchesContentType(r.Header.Get("Content-Type"), "application/json") {
-			hostConfig = &HostConfig{}
-			if err := json.NewDecoder(r.Body).Decode(hostConfig); err != nil {
-				return err
-			}
-		}
-	}
-
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
 	}
 	name := vars["name"]
-	// Register any links from the host config before starting the container
-	if err := srv.RegisterLinks(name, hostConfig); err != nil {
-		return err
+	job := srv.Eng.Job("start", name)
+	if err := job.ImportEnv(HostConfig{}); err != nil {
+		return fmt.Errorf("Couldn't initialize host configuration")
 	}
-	if err := srv.ContainerStart(name, hostConfig); err != nil {
+	// allow a nil body for backwards compatibility
+	if r.Body != nil {
+		if matchesContentType(r.Header.Get("Content-Type"), "application/json") {
+			if err := job.DecodeEnv(r.Body); err != nil {
+				return err
+			}
+		}
+	}
+	if err := job.Run(); err != nil {
 		return err
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/api.go
+++ b/api.go
@@ -644,6 +644,9 @@ func postContainersStart(srv *Server, version float64, w http.ResponseWriter, r 
 	}
 	name := vars["name"]
 	job := srv.Eng.Job("start", name)
+	if err := job.ImportEnv(HostConfig{}); err != nil {
+		return fmt.Errorf("Couldn't initialize host configuration")
+	}
 	// allow a nil body for backwards compatibility
 	if r.Body != nil {
 		if matchesContentType(r.Header.Get("Content-Type"), "application/json") {

--- a/api_test.go
+++ b/api_test.go
@@ -781,10 +781,10 @@ func TestPostContainersRestart(t *testing.T) {
 }
 
 func TestPostContainersStart(t *testing.T) {
-	runtime := mkRuntime(t)
+	eng := NewTestEngine(t)
+	srv := mkServerFromEngine(eng, t)
+	runtime := srv.runtime
 	defer nuke(runtime)
-
-	srv := &Server{runtime: runtime}
 
 	container, _, err := runtime.Create(
 		&Config{

--- a/api_test.go
+++ b/api_test.go
@@ -609,10 +609,10 @@ func TestPostCommit(t *testing.T) {
 }
 
 func TestPostContainersCreate(t *testing.T) {
-	runtime := mkRuntime(t)
+	eng := NewTestEngine(t)
+	srv := mkServerFromEngine(eng, t)
+	runtime := srv.runtime
 	defer nuke(runtime)
-
-	srv := &Server{runtime: runtime}
 
 	configJSON, err := json.Marshal(&Config{
 		Image:  GetTestImage(runtime).ID,
@@ -756,27 +756,23 @@ func TestPostContainersRestart(t *testing.T) {
 }
 
 func TestPostContainersStart(t *testing.T) {
-	runtime := mkRuntime(t)
+	eng := NewTestEngine(t)
+	srv := mkServerFromEngine(eng, t)
+	runtime := srv.runtime
 	defer nuke(runtime)
 
-	srv := &Server{runtime: runtime}
-
-	container, _, err := runtime.Create(
+	id := createTestContainer(
+		eng,
 		&Config{
 			Image:     GetTestImage(runtime).ID,
 			Cmd:       []string{"/bin/cat"},
 			OpenStdin: true,
 		},
-		"",
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer runtime.Destroy(container)
+		t)
 
 	hostConfigJSON, err := json.Marshal(&HostConfig{})
 
-	req, err := http.NewRequest("POST", "/containers/"+container.ID+"/start", bytes.NewReader(hostConfigJSON))
+	req, err := http.NewRequest("POST", "/containers/"+id+"/start", bytes.NewReader(hostConfigJSON))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -784,22 +780,26 @@ func TestPostContainersStart(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 
 	r := httptest.NewRecorder()
-	if err := postContainersStart(srv, APIVERSION, r, req, map[string]string{"name": container.ID}); err != nil {
+	if err := postContainersStart(srv, APIVERSION, r, req, map[string]string{"name": id}); err != nil {
 		t.Fatal(err)
 	}
 	if r.Code != http.StatusNoContent {
 		t.Fatalf("%d NO CONTENT expected, received %d\n", http.StatusNoContent, r.Code)
 	}
 
+	container := runtime.Get(id)
+	if container == nil {
+		t.Fatalf("Container %s was not created", id)
+	}
 	// Give some time to the process to start
+	// FIXME: use Wait once it's available as a job
 	container.WaitTimeout(500 * time.Millisecond)
-
 	if !container.State.Running {
 		t.Errorf("Container should be running")
 	}
 
 	r = httptest.NewRecorder()
-	if err = postContainersStart(srv, APIVERSION, r, req, map[string]string{"name": container.ID}); err == nil {
+	if err = postContainersStart(srv, APIVERSION, r, req, map[string]string{"name": id}); err == nil {
 		t.Fatalf("A running container should be able to be started")
 	}
 

--- a/buildfile_test.go
+++ b/buildfile_test.go
@@ -544,10 +544,7 @@ func TestBuildADDFileNotFound(t *testing.T) {
 }
 
 func TestBuildInheritance(t *testing.T) {
-	runtime, err := newTestRuntime("")
-	if err != nil {
-		t.Fatal(err)
-	}
+	runtime := mkRuntime(t)
 	defer nuke(runtime)
 
 	srv := &Server{

--- a/config.go
+++ b/config.go
@@ -9,7 +9,6 @@ import (
 type DaemonConfig struct {
 	Pidfile                     string
 	Root                        string
-	ProtoAddresses              []string
 	AutoRestart                 bool
 	EnableCors                  bool
 	Dns                         []string
@@ -36,7 +35,6 @@ func ConfigFromJob(job *engine.Job) *DaemonConfig {
 	} else {
 		config.BridgeIface = DefaultNetworkBridge
 	}
-	config.ProtoAddresses = job.GetenvList("ProtoAddresses")
 	config.DefaultIp = net.ParseIP(job.Getenv("DefaultIp"))
 	config.InterContainerCommunication = job.GetenvBool("InterContainerCommunication")
 	return &config

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -71,7 +71,8 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		job := eng.Job("serveapi")
+		// Load plugin: httpapi
+		job := eng.Job("initapi")
 		job.Setenv("Pidfile", *pidfile)
 		job.Setenv("Root", *flRoot)
 		job.SetenvBool("AutoRestart", *flAutoRestart)
@@ -79,9 +80,14 @@ func main() {
 		job.Setenv("Dns", *flDns)
 		job.SetenvBool("EnableIptables", *flEnableIptables)
 		job.Setenv("BridgeIface", *bridgeName)
-		job.SetenvList("ProtoAddresses", flHosts)
 		job.Setenv("DefaultIp", *flDefaultIp)
 		job.SetenvBool("InterContainerCommunication", *flInterContainerComm)
+		if err := job.Run(); err != nil {
+			log.Fatal(err)
+		}
+		// Serve api
+		job = eng.Job("serveapi", flHosts...)
+		job.SetenvBool("Logging", true)
 		if err := job.Run(); err != nil {
 			log.Fatal(err)
 		}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -86,8 +86,8 @@ func main() {
 			log.Fatal(err)
 		}
 		// Serve api
-		job := eng.Job("serveapi", flHosts...)
-		job.Setenv("Logging", true)
+		job = eng.Job("serveapi", flHosts...)
+		job.SetenvBool("Logging", true)
 		if err := job.Run(); err != nil {
 			log.Fatal(err)
 		}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -71,7 +71,8 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		job := eng.Job("serveapi")
+		// Load plugin: httpapi
+		job := eng.Job("initapi")
 		job.Setenv("Pidfile", *pidfile)
 		job.Setenv("Root", *flRoot)
 		job.SetenvBool("AutoRestart", *flAutoRestart)
@@ -79,10 +80,13 @@ func main() {
 		job.Setenv("Dns", *flDns)
 		job.SetenvBool("EnableIptables", *flEnableIptables)
 		job.Setenv("BridgeIface", *bridgeName)
-		job.SetenvList("ProtoAddresses", flHosts)
 		job.Setenv("DefaultIp", *flDefaultIp)
 		job.SetenvBool("InterContainerCommunication", *flInterContainerComm)
 		if err := job.Run(); err != nil {
+			log.Fatal(err)
+		}
+		// Serve api
+		if err := eng.Job("serveapi", flHosts...).Run(); err != nil {
 			log.Fatal(err)
 		}
 	} else {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -86,7 +86,9 @@ func main() {
 			log.Fatal(err)
 		}
 		// Serve api
-		if err := eng.Job("serveapi", flHosts...).Run(); err != nil {
+		job := eng.Job("serveapi", flHosts...)
+		job.Setenv("Logging", true)
+		if err := job.Run(); err != nil {
 			log.Fatal(err)
 		}
 	} else {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -115,5 +115,5 @@ func (eng *Engine) Job(name string, args ...string) *Job {
 
 func (eng *Engine) Logf(format string, args ...interface{}) (n int, err error) {
 	prefixedFormat := fmt.Sprintf("[%s] %s\n", eng, strings.TrimRight(format, "\n"))
-	return fmt.Printf(prefixedFormat, args...)
+	return fmt.Fprintf(os.Stderr, prefixedFormat, args...)
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -13,10 +13,11 @@ type Handler func(*Job) string
 
 var globalHandlers map[string]Handler
 
+func init() {
+	globalHandlers = make(map[string]Handler)
+}
+
 func Register(name string, handler Handler) error {
-	if globalHandlers == nil {
-		globalHandlers = make(map[string]Handler)
-	}
 	globalHandlers[name] = handler
 	return nil
 }
@@ -27,6 +28,7 @@ func Register(name string, handler Handler) error {
 type Engine struct {
 	root		string
 	handlers	map[string]Handler
+	hack		Hack	// data for temporary hackery (see hack.go)
 }
 
 // New initializes a new engine managing the directory specified at `root`.
@@ -66,7 +68,7 @@ func New(root string) (*Engine, error) {
 // This function mimics `Command` from the standard os/exec package.
 func (eng *Engine) Job(name string, args ...string) *Job {
 	job := &Job{
-		eng:		eng,
+		Eng:		eng,
 		Name:		name,
 		Args:		args,
 		Stdin:		os.Stdin,

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"log"
 	"runtime"
+	"strings"
 	"github.com/dotcloud/docker/utils"
 )
 
@@ -33,6 +34,11 @@ type Engine struct {
 	root		string
 	handlers	map[string]Handler
 	hack		Hack	// data for temporary hackery (see hack.go)
+	id		string
+}
+
+func (eng *Engine) Root() string {
+	return eng.root
 }
 
 func (eng *Engine) Register(name string, handler Handler) error {
@@ -84,6 +90,10 @@ func New(root string) (*Engine, error) {
 	return eng, nil
 }
 
+func (eng *Engine) String() string {
+	return fmt.Sprintf("%s|%s", eng.Root(), eng.id[:8])
+}
+
 // Job creates a new job which can later be executed.
 // This function mimics `Command` from the standard os/exec package.
 func (eng *Engine) Job(name string, args ...string) *Job {
@@ -102,3 +112,8 @@ func (eng *Engine) Job(name string, args ...string) *Job {
 	return job
 }
 
+
+func (eng *Engine) Logf(format string, args ...interface{}) (n int, err error) {
+	prefixedFormat := fmt.Sprintf("[%s] %s\n", eng, strings.TrimRight(format, "\n"))
+	return fmt.Printf(prefixedFormat, args...)
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -6,15 +6,21 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"strings"
 )
 
 type Handler func(*Job) string
 
 var globalHandlers map[string]Handler
 
+func init() {
+	globalHandlers = make(map[string]Handler)
+}
+
 func Register(name string, handler Handler) error {
-	if globalHandlers == nil {
-		globalHandlers = make(map[string]Handler)
+	_, exists := globalHandlers[name]
+	if exists {
+		return fmt.Errorf("Can't overwrite global handler for command %s", name)
 	}
 	globalHandlers[name] = handler
 	return nil
@@ -24,9 +30,26 @@ func Register(name string, handler Handler) error {
 // It acts as a store for *containers*, and allows manipulation of these
 // containers by executing *jobs*.
 type Engine struct {
-	root     string
-	handlers map[string]Handler
+	root		string
+	handlers	map[string]Handler
+	hack		Hack	// data for temporary hackery (see hack.go)
+	id		string
 }
+
+func (eng *Engine) Root() string {
+	return eng.root
+}
+
+func (eng *Engine) Register(name string, handler Handler) error {
+	eng.Logf("Register(%s) (handlers=%v)", name, eng.handlers)
+	_, exists := eng.handlers[name]
+	if exists {
+		return fmt.Errorf("Can't overwrite handler for command %s", name)
+	}
+	eng.handlers[name] = handler
+	return nil
+}
+
 
 // New initializes a new engine managing the directory specified at `root`.
 // `root` is used to store containers and any other state private to the engine.
@@ -55,26 +78,40 @@ func New(root string) (*Engine, error) {
 		return nil, err
 	}
 	eng := &Engine{
-		root:     root,
-		handlers: globalHandlers,
+		root:		root,
+		handlers:	make(map[string]Handler),
+		id:		utils.RandomString(),
+	}
+	// Copy existing global handlers
+	for k, v := range globalHandlers {
+		eng.handlers[k] = v
 	}
 	return eng, nil
+}
+
+func (eng *Engine) String() string {
+	return fmt.Sprintf("%s|%s", eng.Root(), eng.id[:8])
 }
 
 // Job creates a new job which can later be executed.
 // This function mimics `Command` from the standard os/exec package.
 func (eng *Engine) Job(name string, args ...string) *Job {
 	job := &Job{
-		eng:    eng,
-		Name:   name,
-		Args:   args,
-		Stdin:  os.Stdin,
-		Stdout: os.Stdout,
-		Stderr: os.Stderr,
+		Eng:		eng,
+		Name:		name,
+		Args:		args,
+		Stdin:		os.Stdin,
+		Stdout:		os.Stdout,
+		Stderr:		os.Stderr,
 	}
 	handler, exists := eng.handlers[name]
 	if exists {
 		job.handler = handler
 	}
 	return job
+}
+
+func (eng *Engine) Logf(format string, args ...interface{}) (n int, err error) {
+	prefixedFormat := fmt.Sprintf("[%s] %s\n", eng, strings.TrimRight(format, "\n"))
+	return fmt.Fprintf(os.Stderr, prefixedFormat, args...)
 }

--- a/engine/hack.go
+++ b/engine/hack.go
@@ -1,0 +1,23 @@
+package engine
+
+
+type Hack map[string]interface{}
+
+
+func (eng *Engine) Hack_GetGlobalVar(key string) interface{} {
+	if eng.hack == nil {
+		return nil
+	}
+	val, exists := eng.hack[key]
+	if !exists {
+		return nil
+	}
+	return val
+}
+
+func (eng *Engine) Hack_SetGlobalVar(key string, val interface{}) {
+	if eng.hack == nil {
+		eng.hack = make(Hack)
+	}
+	eng.hack[key] = val
+}

--- a/engine/job.go
+++ b/engine/job.go
@@ -1,11 +1,16 @@
 package engine
 
 import (
-	"encoding/json"
-	"fmt"
-	"github.com/dotcloud/docker/utils"
+	"bufio"
+	"bytes"
 	"io"
+	"io/ioutil"
+	"strconv"
 	"strings"
+	"fmt"
+	"sync"
+	"encoding/json"
+	"os"
 )
 
 // A job is the fundamental unit of work in the docker engine.
@@ -22,24 +27,43 @@ import (
 // This allows for richer error reporting.
 //
 type Job struct {
-	eng     *Engine
-	Name    string
-	Args    []string
-	env     []string
-	Stdin   io.ReadCloser
-	Stdout  io.WriteCloser
-	Stderr  io.WriteCloser
-	handler func(*Job) string
-	status  string
+	Eng	*Engine
+	Name	string
+	Args	[]string
+	env	[]string
+	Stdin	io.Reader
+	Stdout	io.Writer
+	Stderr	io.Writer
+	handler	func(*Job) string
+	status	string
+	onExit	[]func()
 }
 
 // Run executes the job and blocks until the job completes.
 // If the job returns a failure status, an error is returned
 // which includes the status.
 func (job *Job) Run() error {
-	randId := utils.RandomString()[:4]
-	fmt.Printf("Job #%s: %s\n", randId, job)
-	defer fmt.Printf("Job #%s: %s = '%s'", randId, job, job.status)
+	defer func() {
+		var wg sync.WaitGroup
+		for _, f := range job.onExit {
+			wg.Add(1)
+			go func(f func()) {
+				f()
+				wg.Done()
+			}(f)
+		}
+		wg.Wait()
+	}()
+	if job.Stdout != nil && job.Stdout != os.Stdout {
+		job.Stdout = io.MultiWriter(job.Stdout, os.Stdout)
+	}
+	if job.Stderr != nil && job.Stderr != os.Stderr {
+		job.Stderr = io.MultiWriter(job.Stderr, os.Stderr)
+	}
+	job.Eng.Logf("+job %s", job.CallString())
+	defer func() {
+		job.Eng.Logf("-job %s%s", job.CallString(), job.StatusString())
+	}()
 	if job.handler == nil {
 		job.status = "command not found"
 	} else {
@@ -51,9 +75,84 @@ func (job *Job) Run() error {
 	return nil
 }
 
+func (job *Job) StdoutParseLines(dst *[]string, limit int) {
+	job.parseLines(job.StdoutPipe(), dst, limit)
+}
+
+func (job *Job) StderrParseLines(dst *[]string, limit int) {
+	job.parseLines(job.StderrPipe(), dst, limit)
+}
+
+func (job *Job) parseLines(src io.Reader, dst *[]string, limit int) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(src)
+		for scanner.Scan() {
+			// If the limit is reached, flush the rest of the source and return
+			if limit > 0 && len(*dst) >= limit {
+				io.Copy(ioutil.Discard, src)
+				return
+			}
+			line := scanner.Text()
+			// Append the line (with delimitor removed)
+			*dst = append(*dst, line)
+		}
+	}()
+	job.onExit = append(job.onExit, wg.Wait)
+}
+
+func (job *Job) StdoutParseString(dst *string) {
+	lines := make([]string, 0, 1)
+	job.StdoutParseLines(&lines, 1)
+	job.onExit = append(job.onExit, func() { if len(lines) >= 1 { *dst = lines[0] }})
+}
+
+func (job *Job) StderrParseString(dst *string) {
+	lines := make([]string, 0, 1)
+	job.StderrParseLines(&lines, 1)
+	job.onExit = append(job.onExit, func() { *dst = lines[0]; })
+}
+
+func (job *Job) StdoutPipe() io.ReadCloser {
+	r, w := io.Pipe()
+	job.Stdout = w
+	job.onExit = append(job.onExit, func(){ w.Close() })
+	return r
+}
+
+func (job *Job) StderrPipe() io.ReadCloser {
+	r, w := io.Pipe()
+	job.Stderr = w
+	job.onExit = append(job.onExit, func(){ w.Close() })
+	return r
+}
+
+
+func (job *Job) CallString() string {
+	return fmt.Sprintf("%s(%s)", job.Name, strings.Join(job.Args, ", "))
+}
+
+func (job *Job) StatusString() string {
+	// FIXME: if a job returns the empty string, it will be printed
+	// as not having returned.
+	// (this only affects String which is a convenience function).
+	if job.status != "" {
+		var okerr string
+		if job.status == "0" {
+			okerr = "OK"
+		} else {
+			okerr = "ERR"
+		}
+		return fmt.Sprintf(" = %s (%s)", okerr, job.status)
+	}
+	return ""
+}
+
 // String returns a human-readable description of `job`
 func (job *Job) String() string {
-	return strings.Join(append([]string{job.Name}, job.Args...), " ")
+	return fmt.Sprintf("%s.%s%s", job.Eng, job.CallString(), job.StatusString())
 }
 
 func (job *Job) Getenv(key string) (value string) {
@@ -90,6 +189,19 @@ func (job *Job) SetenvBool(key string, value bool) {
 	}
 }
 
+func (job *Job) GetenvInt(key string) int64 {
+	s := strings.Trim(job.Getenv(key), " \t")
+	val, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return -1
+	}
+	return val
+}
+
+func (job *Job) SetenvInt(key string, value int64) {
+	job.Setenv(key, fmt.Sprintf("%d", value))
+}
+
 func (job *Job) GetenvList(key string) []string {
 	sval := job.Getenv(key)
 	l := make([]string, 0, 1)
@@ -110,4 +222,110 @@ func (job *Job) SetenvList(key string, value []string) error {
 
 func (job *Job) Setenv(key, value string) {
 	job.env = append(job.env, key+"="+value)
+}
+
+// DecodeEnv decodes `src` as a json dictionary, and adds
+// each decoded key-value pair to the environment.
+//
+// If `text` cannot be decoded as a json dictionary, an error
+// is returned.
+func (job *Job) DecodeEnv(src io.Reader) error {
+	m := make(map[string]interface{})
+	if err := json.NewDecoder(src).Decode(&m); err != nil {
+		return err
+	}
+	for k, v := range m {
+		// FIXME: we fix-convert float values to int, because
+		// encoding/json decodes integers to float64, but cannot encode them back.
+		// (See http://golang.org/src/pkg/encoding/json/decode.go#L46)
+		if fval, ok := v.(float64); ok {
+			job.SetenvInt(k, int64(fval))
+		} else if sval, ok := v.(string); ok {
+			job.Setenv(k, sval)
+		} else	if val, err := json.Marshal(v); err == nil {
+			job.Setenv(k, string(val))
+		} else {
+			job.Setenv(k, fmt.Sprintf("%v", v))
+		}
+	}
+	return nil
+}
+
+func (job *Job) EncodeEnv(dst io.Writer) error {
+	m := make(map[string]interface{})
+	for k, v := range job.Environ() {
+		var val interface{}
+		if err := json.Unmarshal([]byte(v), &val); err == nil {
+			// FIXME: we fix-convert float values to int, because
+			// encoding/json decodes integers to float64, but cannot encode them back.
+			// (See http://golang.org/src/pkg/encoding/json/decode.go#L46)
+			if fval, isFloat := val.(float64); isFloat {
+				val = int(fval)
+			}
+			m[k] = val
+		} else {
+			m[k] = v
+		}
+	}
+	if err := json.NewEncoder(dst).Encode(&m); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (job *Job) ExportEnv(dst interface{}) (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("ExportEnv %s", err)
+		}
+	}()
+	var buf bytes.Buffer
+	// step 1: encode/marshal the env to an intermediary json representation
+	if err := job.EncodeEnv(&buf); err != nil {
+		return err
+	}
+	// step 2: decode/unmarshal the intermediary json into the destination object
+	if err := json.NewDecoder(&buf).Decode(dst); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (job *Job) ImportEnv(src interface{}) (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("ImportEnv: %s", err)
+		}
+	}()
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(src); err != nil {
+		return err
+	}
+	if err := job.DecodeEnv(&buf); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (job *Job) Environ() map[string]string {
+	m := make(map[string]string)
+	for _, kv := range job.env {
+		parts := strings.SplitN(kv, "=", 2)
+		m[parts[0]] = parts[1]
+	}
+	return m
+}
+
+func (job *Job) Logf(format string, args ...interface{}) (n int, err error) {
+	prefixedFormat := fmt.Sprintf("[%s] %s\n", job, strings.TrimRight(format, "\n"))
+	return fmt.Fprintf(job.Stderr, prefixedFormat, args...)
+}
+
+func (job *Job) Printf(format string, args ...interface{}) (n int, err error) {
+	return fmt.Fprintf(job.Stdout, format, args...)
+}
+
+func (job *Job) Errorf(format string, args ...interface{}) (n int, err error) {
+	return fmt.Fprintf(job.Stderr, format, args...)
+
 }

--- a/engine/job.go
+++ b/engine/job.go
@@ -239,17 +239,14 @@ func (job *Job) DecodeEnv(src io.Reader) error {
 		// encoding/json decodes integers to float64, but cannot encode them back.
 		// (See http://golang.org/src/pkg/encoding/json/decode.go#L46)
 		if fval, ok := v.(float64); ok {
-			job.Logf("Converted to float: %v->%v", v, fval)
 			job.SetenvInt(k, int64(fval))
 		} else if sval, ok := v.(string); ok {
-			job.Logf("Converted to string: %v->%v", v, sval)
 			job.Setenv(k, sval)
 		} else	if val, err := json.Marshal(v); err == nil {
 			job.Setenv(k, string(val))
 		} else {
 			job.Setenv(k, fmt.Sprintf("%v", v))
 		}
-		job.Logf("Decoded %s=%#v to %s=%#v", k, v, k, job.Getenv(k))
 	}
 	return nil
 }
@@ -269,7 +266,6 @@ func (job *Job) EncodeEnv(dst io.Writer) error {
 		} else {
 			m[k] = v
 		}
-		job.Logf("Encoded %s=%#v to %s=%#v", k, v, k, m[k])
 	}
 	if err := json.NewEncoder(dst).Encode(&m); err != nil {
 		return err
@@ -278,24 +274,20 @@ func (job *Job) EncodeEnv(dst io.Writer) error {
 }
 
 func (job *Job) ExportEnv(dst interface{}) (err error) {
-	fmt.Fprintf(os.Stderr, "ExportEnv()\n")
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("ExportEnv %s", err)
 		}
 	}()
 	var buf bytes.Buffer
-	job.Logf("ExportEnv: step 1: encode/marshal the env to an intermediary json representation")
-	fmt.Fprintf(os.Stderr, "Printed ExportEnv step 1\n")
+	// step 1: encode/marshal the env to an intermediary json representation
 	if err := job.EncodeEnv(&buf); err != nil {
 		return err
 	}
-	job.Logf("ExportEnv: step 1 complete: json=|%s|", buf)
-	job.Logf("ExportEnv: step 2: decode/unmarshal the intermediary json into the destination object")
+	// step 2: decode/unmarshal the intermediary json into the destination object
 	if err := json.NewDecoder(&buf).Decode(dst); err != nil {
 		return err
 	}
-	job.Logf("ExportEnv: step 2 complete")
 	return nil
 }
 
@@ -309,7 +301,6 @@ func (job *Job) ImportEnv(src interface{}) (err error) {
 	if err := json.NewEncoder(&buf).Encode(src); err != nil {
 		return err
 	}
-	job.Logf("ImportEnv: json=|%s|", buf)
 	if err := job.DecodeEnv(&buf); err != nil {
 		return err
 	}

--- a/engine/job.go
+++ b/engine/job.go
@@ -149,10 +149,22 @@ func (job *Job) DecodeEnv(src io.Reader) error {
 }
 
 func (job *Job) EncodeEnv(dst io.Writer) error {
-	return json.NewEncoder(dst).Encode(job.Environ())
+	m := make(map[string]interface{})
+	for k, v := range job.Environ() {
+		var val interface{}
+		if err := json.Unmarshal([]byte(v), &val); err == nil {
+			m[k] = val
+		} else {
+			m[k] = v
+		}
+	}
+	if err := json.NewEncoder(dst).Encode(&m); err != nil {
+		return err
+	}
+	return nil
 }
 
-func (job *Job) ExportEnv(dst interface{}) error {
+func (job *Job) ExportEnv(dst interface{}) (err error) {
 	var buf bytes.Buffer
 	if err := job.EncodeEnv(&buf); err != nil {
 		return err

--- a/engine/job.go
+++ b/engine/job.go
@@ -1,11 +1,16 @@
 package engine
 
 import (
+	"bufio"
 	"bytes"
 	"io"
+	"io/ioutil"
+	"strconv"
 	"strings"
 	"fmt"
+	"sync"
 	"encoding/json"
+	"os"
 )
 
 // A job is the fundamental unit of work in the docker engine.
@@ -26,20 +31,38 @@ type Job struct {
 	Name	string
 	Args	[]string
 	env	[]string
-	Stdin	io.ReadCloser
-	Stdout	io.WriteCloser
-	Stderr	io.WriteCloser
+	Stdin	io.Reader
+	Stdout	io.Writer
+	Stderr	io.Writer
 	handler	func(*Job) string
 	status	string
+	onExit	[]func()
 }
 
 // Run executes the job and blocks until the job completes.
 // If the job returns a failure status, an error is returned
 // which includes the status.
 func (job *Job) Run() error {
-	job.Logf("{")
 	defer func() {
-		job.Logf("}")
+		var wg sync.WaitGroup
+		for _, f := range job.onExit {
+			wg.Add(1)
+			go func(f func()) {
+				f()
+				wg.Done()
+			}(f)
+		}
+		wg.Wait()
+	}()
+	if job.Stdout != nil && job.Stdout != os.Stdout {
+		job.Stdout = io.MultiWriter(job.Stdout, os.Stdout)
+	}
+	if job.Stderr != nil && job.Stderr != os.Stderr {
+		job.Stderr = io.MultiWriter(job.Stderr, os.Stderr)
+	}
+	job.Eng.Logf("+job %s", job.CallString())
+	defer func() {
+		job.Eng.Logf("-job %s%s", job.CallString(), job.StatusString())
 	}()
 	if job.handler == nil {
 		job.status = "command not found"
@@ -52,9 +75,66 @@ func (job *Job) Run() error {
 	return nil
 }
 
-// String returns a human-readable description of `job`
-func (job *Job) String() string {
-	s := fmt.Sprintf("%s.%s(%s)", job.Eng, job.Name, strings.Join(job.Args, ", "))
+func (job *Job) StdoutParseLines(dst *[]string, limit int) {
+	job.parseLines(job.StdoutPipe(), dst, limit)
+}
+
+func (job *Job) StderrParseLines(dst *[]string, limit int) {
+	job.parseLines(job.StderrPipe(), dst, limit)
+}
+
+func (job *Job) parseLines(src io.Reader, dst *[]string, limit int) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		scanner := bufio.NewScanner(src)
+		for scanner.Scan() {
+			// If the limit is reached, flush the rest of the source and return
+			if limit > 0 && len(*dst) >= limit {
+				io.Copy(ioutil.Discard, src)
+				return
+			}
+			line := scanner.Text()
+			// Append the line (with delimitor removed)
+			*dst = append(*dst, line)
+		}
+	}()
+	job.onExit = append(job.onExit, wg.Wait)
+}
+
+func (job *Job) StdoutParseString(dst *string) {
+	lines := make([]string, 0, 1)
+	job.StdoutParseLines(&lines, 1)
+	job.onExit = append(job.onExit, func() { if len(lines) >= 1 { *dst = lines[0] }})
+}
+
+func (job *Job) StderrParseString(dst *string) {
+	lines := make([]string, 0, 1)
+	job.StderrParseLines(&lines, 1)
+	job.onExit = append(job.onExit, func() { *dst = lines[0]; })
+}
+
+func (job *Job) StdoutPipe() io.ReadCloser {
+	r, w := io.Pipe()
+	job.Stdout = w
+	job.onExit = append(job.onExit, func(){ w.Close() })
+	return r
+}
+
+func (job *Job) StderrPipe() io.ReadCloser {
+	r, w := io.Pipe()
+	job.Stderr = w
+	job.onExit = append(job.onExit, func(){ w.Close() })
+	return r
+}
+
+
+func (job *Job) CallString() string {
+	return fmt.Sprintf("%s(%s)", job.Name, strings.Join(job.Args, ", "))
+}
+
+func (job *Job) StatusString() string {
 	// FIXME: if a job returns the empty string, it will be printed
 	// as not having returned.
 	// (this only affects String which is a convenience function).
@@ -65,9 +145,14 @@ func (job *Job) String() string {
 		} else {
 			okerr = "ERR"
 		}
-		s = fmt.Sprintf("%s = %s (%s)", s, okerr, job.status)
+		return fmt.Sprintf(" = %s (%s)", okerr, job.status)
 	}
-	return s
+	return ""
+}
+
+// String returns a human-readable description of `job`
+func (job *Job) String() string {
+	return fmt.Sprintf("%s.%s%s", job.Eng, job.CallString(), job.StatusString())
 }
 
 func (job *Job) Getenv(key string) (value string) {
@@ -104,6 +189,19 @@ func (job *Job) SetenvBool(key string, value bool) {
 	}
 }
 
+func (job *Job) GetenvInt(key string) int64 {
+	s := strings.Trim(job.Getenv(key), " \t")
+	val, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return -1
+	}
+	return val
+}
+
+func (job *Job) SetenvInt(key string, value int64) {
+	job.Setenv(key, fmt.Sprintf("%d", value))
+}
+
 func (job *Job) GetenvList(key string) []string {
 	sval := job.Getenv(key)
 	l := make([]string, 0, 1)
@@ -137,13 +235,21 @@ func (job *Job) DecodeEnv(src io.Reader) error {
 		return err
 	}
 	for k, v := range m {
-		if sval, ok := v.(string); ok {
+		// FIXME: we fix-convert float values to int, because
+		// encoding/json decodes integers to float64, but cannot encode them back.
+		// (See http://golang.org/src/pkg/encoding/json/decode.go#L46)
+		if fval, ok := v.(float64); ok {
+			job.Logf("Converted to float: %v->%v", v, fval)
+			job.SetenvInt(k, int64(fval))
+		} else if sval, ok := v.(string); ok {
+			job.Logf("Converted to string: %v->%v", v, sval)
 			job.Setenv(k, sval)
 		} else	if val, err := json.Marshal(v); err == nil {
 			job.Setenv(k, string(val))
 		} else {
 			job.Setenv(k, fmt.Sprintf("%v", v))
 		}
+		job.Logf("Decoded %s=%#v to %s=%#v", k, v, k, job.Getenv(k))
 	}
 	return nil
 }
@@ -153,10 +259,17 @@ func (job *Job) EncodeEnv(dst io.Writer) error {
 	for k, v := range job.Environ() {
 		var val interface{}
 		if err := json.Unmarshal([]byte(v), &val); err == nil {
+			// FIXME: we fix-convert float values to int, because
+			// encoding/json decodes integers to float64, but cannot encode them back.
+			// (See http://golang.org/src/pkg/encoding/json/decode.go#L46)
+			if fval, isFloat := val.(float64); isFloat {
+				val = int(fval)
+			}
 			m[k] = val
 		} else {
 			m[k] = v
 		}
+		job.Logf("Encoded %s=%#v to %s=%#v", k, v, k, m[k])
 	}
 	if err := json.NewEncoder(dst).Encode(&m); err != nil {
 		return err
@@ -165,21 +278,38 @@ func (job *Job) EncodeEnv(dst io.Writer) error {
 }
 
 func (job *Job) ExportEnv(dst interface{}) (err error) {
+	fmt.Fprintf(os.Stderr, "ExportEnv()\n")
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("ExportEnv %s", err)
+		}
+	}()
 	var buf bytes.Buffer
+	job.Logf("ExportEnv: step 1: encode/marshal the env to an intermediary json representation")
+	fmt.Fprintf(os.Stderr, "Printed ExportEnv step 1\n")
 	if err := job.EncodeEnv(&buf); err != nil {
 		return err
 	}
+	job.Logf("ExportEnv: step 1 complete: json=|%s|", buf)
+	job.Logf("ExportEnv: step 2: decode/unmarshal the intermediary json into the destination object")
 	if err := json.NewDecoder(&buf).Decode(dst); err != nil {
 		return err
 	}
+	job.Logf("ExportEnv: step 2 complete")
 	return nil
 }
 
-func (job *Job) ImportEnv(src interface{}) error {
+func (job *Job) ImportEnv(src interface{}) (err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("ImportEnv: %s", err)
+		}
+	}()
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(src); err != nil {
 		return err
 	}
+	job.Logf("ImportEnv: json=|%s|", buf)
 	if err := job.DecodeEnv(&buf); err != nil {
 		return err
 	}
@@ -197,5 +327,14 @@ func (job *Job) Environ() map[string]string {
 
 func (job *Job) Logf(format string, args ...interface{}) (n int, err error) {
 	prefixedFormat := fmt.Sprintf("[%s] %s\n", job, strings.TrimRight(format, "\n"))
-	return fmt.Fprintf(job.Stdout, prefixedFormat, args...)
+	return fmt.Fprintf(job.Stderr, prefixedFormat, args...)
+}
+
+func (job *Job) Printf(format string, args ...interface{}) (n int, err error) {
+	return fmt.Fprintf(job.Stdout, format, args...)
+}
+
+func (job *Job) Errorf(format string, args ...interface{}) (n int, err error) {
+	return fmt.Fprintf(job.Stderr, format, args...)
+
 }

--- a/engine/utils.go
+++ b/engine/utils.go
@@ -15,7 +15,7 @@ func init() {
 	Register("dummy", func(job *Job) string { return ""; })
 }
 
-func mkEngine(t *testing.T) *Engine {
+func NewTestEngine(t *testing.T) *Engine {
 	// Use the caller function name as a prefix.
 	// This helps trace temp directories back to their test.
 	pc, _, _, _ := runtime.Caller(1)
@@ -38,5 +38,5 @@ func mkEngine(t *testing.T) *Engine {
 }
 
 func mkJob(t *testing.T, name string, args ...string) *Job {
-	return mkEngine(t).Job(name, args...)
+	return NewTestEngine(t).Job(name, args...)
 }

--- a/engine/utils.go
+++ b/engine/utils.go
@@ -15,7 +15,7 @@ func init() {
 	Register("dummy", func(job *Job) string { return "" })
 }
 
-func mkEngine(t *testing.T) *Engine {
+func newTestEngine(t *testing.T) *Engine {
 	// Use the caller function name as a prefix.
 	// This helps trace temp directories back to their test.
 	pc, _, _, _ := runtime.Caller(1)
@@ -38,5 +38,5 @@ func mkEngine(t *testing.T) *Engine {
 }
 
 func mkJob(t *testing.T, name string, args ...string) *Job {
-	return mkEngine(t).Job(name, args...)
+	return newTestEngine(t).Job(name, args...)
 }

--- a/engine/utils.go
+++ b/engine/utils.go
@@ -15,7 +15,7 @@ func init() {
 	Register("dummy", func(job *Job) string { return ""; })
 }
 
-func NewTestEngine(t *testing.T) *Engine {
+func newTestEngine(t *testing.T) *Engine {
 	// Use the caller function name as a prefix.
 	// This helps trace temp directories back to their test.
 	pc, _, _, _ := runtime.Caller(1)
@@ -38,5 +38,5 @@ func NewTestEngine(t *testing.T) *Engine {
 }
 
 func mkJob(t *testing.T, name string, args ...string) *Job {
-	return NewTestEngine(t).Job(name, args...)
+	return newTestEngine(t).Job(name, args...)
 }

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -645,20 +645,17 @@ func TestReloadContainerLinks(t *testing.T) {
 }
 
 func TestDefaultContainerName(t *testing.T) {
-	runtime := mkRuntime(t)
+	eng := NewTestEngine(t)
+	srv := mkServerFromEngine(eng, t)
+	runtime := srv.runtime
 	defer nuke(runtime)
-	srv := &Server{runtime: runtime}
 
 	config, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	shortId, _, err := srv.ContainerCreate(config, "some_name")
-	if err != nil {
-		t.Fatal(err)
-	}
-	container := runtime.Get(shortId)
+	container := runtime.Get(createNamedTestContainer(eng, config, t, "some_name"))
 	containerID := container.ID
 
 	if container.Name != "/some_name" {
@@ -682,20 +679,17 @@ func TestDefaultContainerName(t *testing.T) {
 }
 
 func TestRandomContainerName(t *testing.T) {
-	runtime := mkRuntime(t)
+	eng := NewTestEngine(t)
+	srv := mkServerFromEngine(eng, t)
+	runtime := srv.runtime
 	defer nuke(runtime)
-	srv := &Server{runtime: runtime}
 
 	config, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	shortId, _, err := srv.ContainerCreate(config, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	container := runtime.Get(shortId)
+	container := runtime.Get(createTestContainer(eng, config, t))
 	containerID := container.ID
 
 	if container.Name == "" {
@@ -719,20 +713,17 @@ func TestRandomContainerName(t *testing.T) {
 }
 
 func TestLinkChildContainer(t *testing.T) {
-	runtime := mkRuntime(t)
+	eng := NewTestEngine(t)
+	srv := mkServerFromEngine(eng, t)
+	runtime := srv.runtime
 	defer nuke(runtime)
-	srv := &Server{runtime: runtime}
 
 	config, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	shortId, _, err := srv.ContainerCreate(config, "/webapp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	container := runtime.Get(shortId)
+	container := runtime.Get(createNamedTestContainer(eng, config, t, "/webapp"))
 
 	webapp, err := runtime.GetByName("/webapp")
 	if err != nil {
@@ -748,12 +739,7 @@ func TestLinkChildContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	shortId, _, err = srv.ContainerCreate(config, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	childContainer := runtime.Get(shortId)
+	childContainer := runtime.Get(createTestContainer(eng, config, t))
 
 	if err := runtime.RegisterLink(webapp, childContainer, "db"); err != nil {
 		t.Fatal(err)
@@ -770,20 +756,17 @@ func TestLinkChildContainer(t *testing.T) {
 }
 
 func TestGetAllChildren(t *testing.T) {
-	runtime := mkRuntime(t)
+	eng := NewTestEngine(t)
+	srv := mkServerFromEngine(eng, t)
+	runtime := srv.runtime
 	defer nuke(runtime)
-	srv := &Server{runtime: runtime}
 
 	config, _, _, err := ParseRun([]string{GetTestImage(runtime).ID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	shortId, _, err := srv.ContainerCreate(config, "/webapp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	container := runtime.Get(shortId)
+	container := runtime.Get(createNamedTestContainer(eng, config, t, "/webapp"))
 
 	webapp, err := runtime.GetByName("/webapp")
 	if err != nil {
@@ -799,12 +782,7 @@ func TestGetAllChildren(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	shortId, _, err = srv.ContainerCreate(config, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	childContainer := runtime.Get(shortId)
+	childContainer := runtime.Get(createTestContainer(eng, config, t))
 
 	if err := runtime.RegisterLink(webapp, childContainer, "db"); err != nil {
 		t.Fatal(err)

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -183,7 +183,7 @@ func GetTestImage(runtime *Runtime) *Image {
 			return image
 		}
 	}
-	log.Fatalf("Test image %v not found", unitTestImageID)
+	log.Fatalf("Test image %v not found in %s: %s", unitTestImageID, runtime.graph.Root, imgs)
 	return nil
 }
 

--- a/server.go
+++ b/server.go
@@ -44,8 +44,11 @@ func jobInitApi(job *engine.Job) string {
 	if err != nil {
 		return err.Error()
 	}
-	if err := utils.CreatePidFile(srv.runtime.config.Pidfile); err != nil {
-		log.Fatal(err)
+	if srv.runtime.config.Pidfile != "" {
+		job.Logf("Creating pidfile")
+		if err := utils.CreatePidFile(srv.runtime.config.Pidfile); err != nil {
+			log.Fatal(err)
+		}
 	}
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, os.Kill, os.Signal(syscall.SIGTERM))

--- a/server.go
+++ b/server.go
@@ -60,10 +60,10 @@ func jobInitApi(job *engine.Job) string {
 		os.Exit(0)
 	}()
 	job.Eng.Hack_SetGlobalVar("httpapi.server", srv)
-	if err := engine.Register("start", srv.ContainerStart); err != nil {
+	if err := job.Eng.Register("start", srv.ContainerStart); err != nil {
 		return err.Error()
 	}
-	if err := engine.Register("serveapi", srv.ListenAndServe); err != nil {
+	if err := job.Eng.Register("serveapi", srv.ListenAndServe); err != nil {
 		return err.Error()
 	}
 	return "0"

--- a/server.go
+++ b/server.go
@@ -1332,14 +1332,11 @@ func (srv *Server) RegisterLinks(name string, hostConfig *HostConfig) error {
 }
 
 func (srv *Server) ContainerStart(job *engine.Job) string {
-	job.Logf("srv engine = %s", srv.Eng.Root())
-	job.Logf("job engine = %s", job.Eng.Root())
 	if len(job.Args) < 1 {
 		return fmt.Sprintf("Usage: %s container_id", job.Name)
 	}
 	name := job.Args[0]
 	runtime := srv.runtime
-	job.Logf("loading containers from %s", runtime.repository)
 	container := runtime.Get(name)
 	if container == nil {
 		return fmt.Sprintf("No such container: %s", name)

--- a/server.go
+++ b/server.go
@@ -88,7 +88,8 @@ func (srv *Server) ListenAndServe(job *engine.Job) string {
 			return "Invalid protocol format."
 		}
 		go func() {
-			chErrors <- ListenAndServe(protoAddrParts[0], protoAddrParts[1], srv, true)
+			// FIXME: merge Server.ListenAndServe with ListenAndServe
+			chErrors <- ListenAndServe(protoAddrParts[0], protoAddrParts[1], srv, job.GetenvBool("Logging"))
 		}()
 	}
 	for i := 0; i < len(protoAddrs); i += 1 {

--- a/server_test.go
+++ b/server_test.go
@@ -1,7 +1,6 @@
 package docker
 
 import (
-	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/utils"
 	"strings"
 	"testing"
@@ -110,7 +109,7 @@ func TestCreateRm(t *testing.T) {
 }
 
 func TestCreateRmVolumes(t *testing.T) {
-	eng := engine.NewTestEngine(t)
+	eng := NewTestEngine(t)
 
 	srv := mkServerFromEngine(eng, t)
 	runtime := srv.runtime
@@ -174,7 +173,7 @@ func TestCommit(t *testing.T) {
 }
 
 func TestCreateStartRestartStopStartKillRm(t *testing.T) {
-	eng := engine.NewTestEngine(t)
+	eng := NewTestEngine(t)
 	srv := mkServerFromEngine(eng, t)
 	runtime := srv.runtime
 	defer nuke(runtime)
@@ -397,7 +396,7 @@ func TestLogEvent(t *testing.T) {
 }
 
 func TestRmi(t *testing.T) {
-	eng := engine.NewTestEngine(t)
+	eng := NewTestEngine(t)
 	srv := mkServerFromEngine(eng, t)
 	runtime := srv.runtime
 	defer nuke(runtime)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -27,6 +27,12 @@ var (
 	INITSHA1  string // sha1sum of separate static dockerinit, if Docker itself was compiled dynamically via ./hack/make.sh dynbinary
 )
 
+// A common interface to access the Fatal method of
+// both testing.B and testing.T.
+type Fataler interface {
+	Fatal(args ...interface{})
+}
+
 // ListOpts type
 type ListOpts []string
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -28,6 +28,12 @@ var (
 	INITSHA1  string // sha1sum of separate static dockerinit, if Docker itself was compiled dynamically via ./hack/make.sh dynbinary
 )
 
+// A common interface to access the Fatal method of
+// both testing.B and testing.T.
+type Fataler interface {
+	Fatal(args ...interface{})
+}
+
 // ListOpts type
 type ListOpts []string
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -41,11 +41,11 @@ func mkRuntime(f utils.Fataler) *Runtime {
 func mkServerFromEngine(eng *engine.Engine, t utils.Fataler) *Server {
 	iSrv := eng.Hack_GetGlobalVar("httpapi.server")
 	if iSrv == nil {
-		t.Fatal("Legacy server field not set in engine")
+		panic("Legacy server field not set in engine")
 	}
 	srv, ok := iSrv.(*Server)
 	if !ok {
-		t.Fatal("Legacy server field in engine does not cast to *Server")
+		panic("Legacy server field in engine does not cast to *Server")
 	}
 	return srv
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -21,27 +21,24 @@ var globalTestID string
 
 // Create a temporary runtime suitable for unit testing.
 // Call t.Fatal() at the first error.
-func mkRuntime(f Fataler) *Runtime {
-	// Use the caller function name as a prefix.
-	// This helps trace temp directories back to their test.
-	pc, _, _, _ := runtime.Caller(1)
-	callerLongName := runtime.FuncForPC(pc).Name()
-	parts := strings.Split(callerLongName, ".")
-	callerShortName := parts[len(parts)-1]
-	if globalTestID == "" {
-		globalTestID = GenerateID()[:4]
-	}
-	prefix := fmt.Sprintf("docker-test%s-%s-", globalTestID, callerShortName)
-	utils.Debugf("prefix = '%s'", prefix)
-
-	runtime, err := newTestRuntime(prefix)
+func mkRuntime(f utils.Fataler) *Runtime {
+	root, err := newTestDirectory(unitTestStoreBase)
 	if err != nil {
 		f.Fatal(err)
 	}
-	return runtime
+	config := &DaemonConfig{
+		Root:   root,
+		AutoRestart: false,
+	}
+	r, err := NewRuntimeFromDirectory(config)
+	if err != nil {
+		f.Fatal(err)
+	}
+	r.UpdateCapabilities(true)
+	return r
 }
 
-func mkServerFromEngine(eng *engine.Engine, t Fataler) *Server {
+func mkServerFromEngine(eng *engine.Engine, t utils.Fataler) *Server {
 	iSrv := eng.Hack_GetGlobalVar("httpapi.server")
 	if iSrv == nil {
 		t.Fatal("Legacy server field not set in engine")
@@ -53,42 +50,53 @@ func mkServerFromEngine(eng *engine.Engine, t Fataler) *Server {
 	return srv
 }
 
-// A common interface to access the Fatal method of
-// both testing.B and testing.T.
-type Fataler interface {
-	Fatal(args ...interface{})
+
+func NewTestEngine(t utils.Fataler) *engine.Engine {
+	root, err := newTestDirectory(unitTestStoreBase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eng, err := engine.New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Load default plugins
+	// (This is manually copied and modified from main() until we have a more generic plugin system)
+	job := eng.Job("initapi")
+	job.Setenv("Root", root)
+	job.SetenvBool("AutoRestart", false)
+	if err := job.Run(); err != nil {
+		t.Fatal(err)
+	}
+	return eng
 }
 
-func newTestRuntime(prefix string) (runtime *Runtime, err error) {
+func newTestDirectory(templateDir string) (dir string, err error) {
+	if globalTestID == "" {
+		globalTestID = GenerateID()[:4]
+	}
+	prefix := fmt.Sprintf("docker-test%s-%s-", globalTestID, getCallerName(2))
 	if prefix == "" {
 		prefix = "docker-test-"
 	}
-	utils.Debugf("prefix = %s", prefix)
-	utils.Debugf("newTestRuntime start")
-	root, err := ioutil.TempDir("", prefix)
-	defer func() {
-		utils.Debugf("newTestRuntime: %s", root)
-	}()
-	if err != nil {
-		return nil, err
+	dir, err = ioutil.TempDir("", prefix)
+	if err = os.Remove(dir); err != nil {
+		return
 	}
-	if err := os.Remove(root); err != nil {
-		return nil, err
+	if err = utils.CopyDirectory(templateDir, dir); err != nil {
+		return
 	}
-	if err := utils.CopyDirectory(unitTestStoreBase, root); err != nil {
-		return nil, err
-	}
+	return
+}
 
-	config := &DaemonConfig{
-		Root:   root,
-		AutoRestart: false,
-	}
-	runtime, err = NewRuntimeFromDirectory(config)
-	if err != nil {
-		return nil, err
-	}
-	runtime.UpdateCapabilities(true)
-	return runtime, nil
+func getCallerName(depth int) string {
+	// Use the caller function name as a prefix.
+	// This helps trace temp directories back to their test.
+	pc, _, _, _ := runtime.Caller(depth + 1)
+	callerLongName := runtime.FuncForPC(pc).Name()
+	parts := strings.Split(callerLongName, ".")
+	callerShortName := parts[len(parts)-1]
+	return callerShortName
 }
 
 // Write `content` to the file at path `dst`, creating it if necessary,

--- a/utils_test.go
+++ b/utils_test.go
@@ -38,6 +38,22 @@ func mkRuntime(f utils.Fataler) *Runtime {
 	return r
 }
 
+func createNamedTestContainer(eng *engine.Engine, config *Config, f utils.Fataler, name string) (shortId string) {
+	job := eng.Job("create", name)
+	if err := job.ImportEnv(config); err != nil {
+		f.Fatal(err)
+	}
+	job.StdoutParseString(&shortId)
+	if err := job.Run(); err != nil {
+		f.Fatal(err)
+	}
+	return
+}
+
+func createTestContainer(eng *engine.Engine, config *Config, f utils.Fataler) (shortId string) {
+	return createNamedTestContainer(eng, config, f, "")
+}
+
 func mkServerFromEngine(eng *engine.Engine, t utils.Fataler) *Server {
 	iSrv := eng.Hack_GetGlobalVar("httpapi.server")
 	if iSrv == nil {

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"
@@ -38,6 +39,18 @@ func mkRuntime(f Fataler) *Runtime {
 		f.Fatal(err)
 	}
 	return runtime
+}
+
+func mkServerFromEngine(eng *engine.Engine, t Fataler) *Server {
+	iSrv := eng.Hack_GetGlobalVar("httpapi.server")
+	if iSrv == nil {
+		t.Fatal("Legacy server field not set in engine")
+	}
+	srv, ok := iSrv.(*Server)
+	if !ok {
+		t.Fatal("Legacy server field in engine does not cast to *Server")
+	}
+	return srv
 }
 
 // A common interface to access the Fatal method of


### PR DESCRIPTION
This is in the same spirit as #2352. It inserts the engine as an indirection for creating and starting a container, with minimal disruption on the implementation and code structure.
