### PR TITLE
Inject local files

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -121,7 +121,7 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 }
 
 func (cli *DockerCli) CmdInsert(args ...string) error {
-	cmd := cli.Subcmd("insert", "IMAGE URL PATH", "Insert a file from URL in the IMAGE at PATH")
+	cmd := cli.Subcmd("insert", "IMAGE URL|FILE DESTPATH", "Insert a file from URL or FILE in the IMAGE at PATH")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}

--- a/docs/sources/api/docker_remote_api_v1.8.rst
+++ b/docs/sources/api/docker_remote_api_v1.8.rst
@@ -727,7 +727,14 @@ Insert a file in an image
 
 .. http:post:: /images/(name)/insert
 
-	Insert a file from ``url`` in the image ``name`` at ``path``
+	Insert a file from ``url`` to the image ``name``. Within the image,
+	put the file at ``path``.
+
+	The ``url`` can be a Unix file path or it can be a URL.
+
+	If a path to a file is given, the file that is evaluated for existence
+	and added to the image will be the path that is local to the docker daemon
+	(and not the client if they are run on different hosts.)
 
 	**Example request**:
 

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -670,9 +670,12 @@ preserved.
 
 ::
 
-    Usage: docker insert IMAGE URL PATH
+    Usage: docker insert IMAGE SRC PATH
 
-    Insert a file from URL in the IMAGE at PATH
+    Insert a file from SRC in the IMAGE at PATH.
+
+SRC may be a path to a file on the host system or a URL.
+
 
 Use the specified ``IMAGE`` as the parent for a new image which adds a
 :ref:`layer <layer_def>` containing the new file. The ``insert`` command does

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -404,8 +404,18 @@ func TestImageInsert(t *testing.T) {
 		t.Fatal("expected an error and got none")
 	}
 
-	// success returns nil
+	// bad filename fails
+	if err := srv.ImageInsert(unitTestImageID, "/tmp/foobar1234abc", "/foo", ioutil.Discard, sf); err == nil {
+		t.Fatal("expected an error and got none")
+	}
+
+	// url success returns nil
 	if err := srv.ImageInsert(unitTestImageID, "https://www.docker.io/static/img/docker-top-logo.png", "/foo", ioutil.Discard, sf); err != nil {
+		t.Fatalf("expected no error, but got %v", err)
+	}
+
+	// local file success returns nil
+	if err := srv.ImageInsert(unitTestImageID, "/etc/issue", "/foo", ioutil.Discard, sf); err != nil {
 		t.Fatalf("expected no error, but got %v", err)
 	}
 }


### PR DESCRIPTION
Add tests for local file insert

In this [pull request](https://github.com/dotcloud/docker/pull/1942#issuecomment-27370427) that I previously worked on, there was a request by @gurjeet for a feature to allow local files to be injected into a container.  This pull request implements local file injection.
