### PR TITLE
Check for a terminal before using escapes

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -2328,7 +2328,7 @@ func (cli *DockerCli) stream(method, path string, in io.Reader, out io.Writer, h
 	}
 
 	if matchesContentType(resp.Header.Get("Content-Type"), "application/json") {
-		return utils.DisplayJSONMessagesStream(resp.Body, out)
+		return utils.DisplayJSONMessagesStream(resp.Body, out, cli.isTerminal)
 	}
 	if _, err := io.Copy(out, resp.Body); err != nil {
 		return err


### PR DESCRIPTION
Close #2627

Here's what I get from my terminal (Ubuntu 12.04) with this patch

```
$ sudo docker pull base | grep -v kweepa
Pulling repository base
b750fe79269d: Download complete
27cf78414709: Download complete
```

This change will affect output from:
- insert
- import
- push
- pull
- events
- export
- run

(Those are the commands which use `cli.stream()`)
