### PR TITLE
Minor code simplification for Containers api

### DIFF
--- a/server.go
+++ b/server.go
@@ -464,14 +464,11 @@ func (srv *Server) Containers(all, size bool, n int, since, before string) []API
 		if !container.State.Running && !all && n == -1 && since == "" && before == "" {
 			continue
 		}
-		if before != "" {
+		if before != "" && !foundBefore {
 			if container.ID == before || utils.TruncateID(container.ID) == before {
 				foundBefore = true
-				continue
 			}
-			if !foundBefore {
-				continue
-			}
+			continue
 		}
 		if displayed == n {
 			break


### PR DESCRIPTION
Just a little bit simpler. Also should stop comparing container ids when "beforeId" is found.
