### PR TITLE
fix error in python webapp example

### DIFF
--- a/docs/sources/examples/python_web_app.rst
+++ b/docs/sources/examples/python_web_app.rst
@@ -86,7 +86,7 @@ http://0.0.0.0:5000/`` in the log output.
 
 .. code-block:: bash
 
-    WEB_PORT=$(sudo docker port $WEB_WORKER 5000)
+    WEB_PORT=$(sudo docker port $WEB_WORKER 5000 | awk -F: '{ print $2 }')
 
 Look up the public-facing port which is NAT-ed. Find the private port
 used by the container and store it inside of the ``WEB_PORT`` variable.


### PR DESCRIPTION
When getting the private port used by a container using `docker port` it returns an address like `0.0.0.0:49353`, strip just the portnumber of the address with awk to used it in the rest of the example code.
