### PR TITLE
Allow insecure ssl

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -31,6 +32,7 @@ type AuthConfig struct {
 	Auth          string `json:"auth"`
 	Email         string `json:"email"`
 	ServerAddress string `json:"serveraddress,omitempty"`
+	InsecureSSL   bool   `json:"insecuressl,omitempty"`
 }
 
 type ConfigFile struct {
@@ -135,6 +137,7 @@ func SaveConfig(configFile *ConfigFile) error {
 		authCopy.Username = ""
 		authCopy.Password = ""
 		authCopy.ServerAddress = ""
+		authCopy.InsecureSSL = false
 		configs[k] = authCopy
 	}
 
@@ -151,7 +154,8 @@ func SaveConfig(configFile *ConfigFile) error {
 
 // try to register/login to the registry server
 func Login(authConfig *AuthConfig, factory *utils.HTTPRequestFactory) (string, error) {
-	client := &http.Client{}
+	httpTransport := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: authConfig.InsecureSSL}}
+	client := &http.Client{Transport: httpTransport}
 	reqStatusCode := 0
 	var status string
 	var reqBody []byte
@@ -174,7 +178,7 @@ func Login(authConfig *AuthConfig, factory *utils.HTTPRequestFactory) (string, e
 
 	// using `bytes.NewReader(jsonBody)` here causes the server to respond with a 411 status.
 	b := strings.NewReader(string(jsonBody))
-	req1, err := http.Post(serverAddress+"users/", "application/json; charset=utf-8", b)
+	req1, err := client.Post(serverAddress+"users/", "application/json; charset=utf-8", b)
 	if err != nil {
 		return "", fmt.Errorf("Server Error: %s", err)
 	}

--- a/buildfile.go
+++ b/buildfile.go
@@ -72,7 +72,7 @@ func (b *buildFile) CmdFrom(name string) error {
 	if err != nil {
 		if b.runtime.graph.IsNotExist(err) {
 			remote, tag := utils.ParseRepositoryTag(name)
-			if err := b.srv.ImagePull(remote, tag, b.outOld, b.sf, b.authConfig, nil, true); err != nil {
+			if err := b.srv.ImagePull(remote, tag, b.outOld, b.sf, b.authConfig, nil, true, false); err != nil {
 				return err
 			}
 			image, err = b.runtime.repositories.LookupImage(name)

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -793,6 +793,7 @@ Known Issues (kill)
     -e="": email
     -p="": password
     -u="": username
+    -insecure-ssl=false: trust unverified registry server ssl certificates
 
     If you want to login to a private registry you can
     specify this by adding the server name.


### PR DESCRIPTION
This will allow support for private docker registries that have self-signed or otherwise unverified ssl certificates. Useful in non-production environments. As per prior pull request comments, this is implemented using commandline arguments to the push, pull, import and login commands. It was not implemented in the run command as it did not fit in nicely with the parameter parsing. In order to run images from a private registry it must be explicitly pulled first.
