### PR TITLE
Updated documentation footer to say "Docker Inc." instead of dotCloud. And added Read the Docs.

### DIFF
--- a/docs/theme/docker/layout.html
+++ b/docs/theme/docker/layout.html
@@ -129,7 +129,8 @@
                 <div class="row footer">
                     <div class="span12 tbox">
                         <div class="tbox">
-                            <p>Docker is an open source project, sponsored by  <a href="https://dotcloud.com">dotCloud</a>, under the <a href="https://github.com/dotcloud/docker/blob/master/LICENSE" title="Docker licence, hosted in the Github repository">apache 2.0 licence</a></p>
+                            <p>Docker is an open source project, sponsored by  <a href="https://www.docker.com">Docker Inc.</a>, under the <a href="https://github.com/dotcloud/docker/blob/master/LICENSE" title="Docker licence, hosted in the Github repository">apache 2.0 licence</a></p>
+                            <p>Documentation proudly hosted by <a href="http://www.readthedocs.org">Read the Docs</a></p>
                         </div>
 
                         <div class="social links">


### PR DESCRIPTION
Updated documentation footer to say "Docker Inc." instead of dotCloud. And added Read the Docs.
Added link to Read the Docs for giving them credit to hosting us. (Thanks Read The Docs!)
