### PR TITLE
Enable IPv4/IPv6 forwarding automatically

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -326,6 +326,15 @@ func (runtime *Runtime) UpdateCapabilities(quiet bool) {
 		}
 	}
 
+	// Enable IPv4 forwarding
+	if errFwd4 := ioutil.WriteFile("/proc/sys/net/ipv4/ip_forward", []byte{'1', '\n'}, 0644); errFwd4 != nil {
+		log.Printf("WARNING: unable to enable IPv4 forwarding: %s\n", errFwd4)
+	}
+	// Enable IPv6 forwarding
+	if errFwd6 := ioutil.WriteFile("/proc/sys/net/ipv6/conf/all/forwarding", []byte{'1', '\n'}, 0644); errFwd6 != nil {
+		log.Printf("WARNING: unable to enable IPv6 forwarding: %s\n", errFwd6)
+	}
+
 	content, err3 := ioutil.ReadFile("/proc/sys/net/ipv4/ip_forward")
 	runtime.capabilities.IPv4ForwardingDisabled = err3 != nil || len(content) == 0 || content[0] != '1'
 	if runtime.capabilities.IPv4ForwardingDisabled && !quiet {


### PR DESCRIPTION
After some discussion with @shykes, we decided it makes sense to have this enabled in the core, which fixes one of our longest-standing usability issues.

Since `IPv4Forwarding` is officially part of the API, I had to insert this code in "runtime.go" to make sure forwarding is enabled before we check whether it is (which is still important to check, because the kernel could still tell us "no").  This way, if the kernel denies our request for forwarding, we'll still get the warning we have in place now.

Of course, if I'm told where it should have gone to make sure it runs before UpdateCapabilities, I'm more than happy to move it, but after digging around, this seemed like the most appropriate place given the constraints.

If the code addition looks good, I'll go ahead and add a new commit to update the two docs that reference `ip_forward` (Arch and Gentoo install instructions).
