### PR TITLE
run: introduce -ro for read-only containers

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -201,6 +201,7 @@ func (graph *Graph) getDockerInitLayer() (string, error) {
 		"/dev/shm":         "dir",
 		"/proc":            "dir",
 		"/sys":             "dir",
+		"/lxc_putold":      "dir",
 		"/.dockerinit":     "file",
 		"/.dockerenv":      "file",
 		"/etc/resolv.conf": "file",


### PR DESCRIPTION
Instead of having a read-writable top layer, containers started with -ro
will have a read-only top layer.

The motivation is to avoid mistakes when “dockerizing” software: regular
software is written under the assumption that they can write data to any
writable path on the machine. In order to be able to throw away docker
containers at will and be reasonably sure that no data is lost, one can
use -ro and use volumes for all data that should be writable. That way,
when you forget to use a volume (or the software in question starts
using a new path that you don’t have a volume for), you’ll get errors
instead of silent data loss and bad surprises.

The following changes were necessary to make this work:

  • Create /lxc_putold in the docker init layer, otherwise lxc-start
    will try to create it and fail (due to read-only failsystem)

  • Mount a tmpfs over /dev, create /dev/{shm,pts}, lxc-start wants to
    re-create the files in there. Perhaps lxc-start could be changed in
    the future to not require that if the files are already there.
