### PR TITLE
use the work Path for docker cp CONTAINER:PATH - atm, that is all it is

### DIFF
--- a/api.go
+++ b/api.go
@@ -978,7 +978,7 @@ func postContainersCopy(srv *Server, version float64, w http.ResponseWriter, r *
 	}
 
 	if copyData.Resource == "" {
-		return fmt.Errorf("Resource cannot be empty")
+		return fmt.Errorf("Path cannot be empty")
 	}
 	if copyData.Resource[0] == '/' {
 		copyData.Resource = copyData.Resource[1:]

--- a/commands.go
+++ b/commands.go
@@ -1924,7 +1924,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 }
 
 func (cli *DockerCli) CmdCp(args ...string) error {
-	cmd := Subcmd("cp", "CONTAINER:RESOURCE HOSTPATH", "Copy files/folders from the RESOURCE to the HOSTPATH")
+	cmd := Subcmd("cp", "CONTAINER:PATH HOSTPATH", "Copy files/folders from the PATH to the HOSTPATH")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -1938,7 +1938,7 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 	info := strings.Split(cmd.Arg(0), ":")
 
 	if len(info) != 2 {
-		return fmt.Errorf("Error: Resource not specified")
+		return fmt.Errorf("Error: Path not specified")
 	}
 
 	copyData.Resource = info[1]

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -219,10 +219,15 @@ Full -run example
 
 ::
 
-    Usage: docker cp CONTAINER:RESOURCE HOSTPATH
+    Usage: docker cp CONTAINER:PATH HOSTPATH
 
     Copy files/folders from the containers filesystem to the host
     path.  Paths are relative to the root of the filesystem.
+    
+.. code-block:: bash
+
+    $ sudo docker cp 7bb0e258aefe:/etc/debian_version .
+    $ sudo docker cp blue_frog:/etc/hosts .
 
 .. _cli_diff:
 


### PR DESCRIPTION
expunge the word 'Resource' in reference to a file/dir in a CONTAINER - that way users don't wonder how its different from a Path

@metalivedev
