### PR TITLE
fix container restart race condition

### DIFF
--- a/container.go
+++ b/container.go
@@ -1287,9 +1287,6 @@ func (container *Container) monitor() {
 		exitCode = container.cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
 	}
 
-	// Report status back
-	container.State.setStopped(exitCode)
-
 	if container.runtime != nil && container.runtime.srv != nil {
 		container.runtime.srv.LogEvent("die", container.ID, container.runtime.repositories.ImageName(container.Image))
 	}
@@ -1301,6 +1298,9 @@ func (container *Container) monitor() {
 	if container.Config.OpenStdin {
 		container.stdin, container.stdinPipe = io.Pipe()
 	}
+
+	// Report status back
+	container.State.setStopped(exitCode)
 
 	// Release the lock
 	close(container.waitLock)


### PR DESCRIPTION
Finish container cleanup before setting the state to stopped.
Otherwise, for an application that exits quickly, a call to Restart
can allow Start to be called again before cleanup is done, resulting in
overritten data in the Container struct.
