### PR TITLE
don't forward SIGCHLD to container

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -549,6 +549,9 @@ func (cli *DockerCli) forwardAllSignals(cid string) chan os.Signal {
 	utils.CatchAll(sigc)
 	go func() {
 		for s := range sigc {
+			if s == syscall.SIGCHLD {
+				continue
+			}
 			if _, _, err := cli.call("POST", fmt.Sprintf("/containers/%s/kill?signal=%d", cid, s), nil); err != nil {
 				utils.Debugf("Error sending signal: %s", err)
 			}


### PR DESCRIPTION
It makes no sense to forward SIGCHLD to the container since the container doesn't care about any child processes of the cli exiting.
