### PR TITLE
Switch sphinx man_pages generation to use commandline/cli

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -31,7 +31,7 @@ help:
 #	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
 #	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
 #	@echo "  text       to make text files"
-#	@echo "  man        to make manual pages"
+	@echo "  man        to make a manual page"
 #	@echo "  texinfo    to make Texinfo files"
 #	@echo "  info       to make Texinfo files and run them through makeinfo"
 #	@echo "  gettext    to make PO message catalogs"

--- a/docs/sources/conf.py
+++ b/docs/sources/conf.py
@@ -235,7 +235,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('toctree', 'docker', u'Docker Documentation',
+    ('commandline/cli', 'docker', u'Docker Documentation',
      [u'Team Docker'], 1)
 ]
 


### PR DESCRIPTION
... instead of toctree for a more relevant/useful man page.

This fixes #1957 and #1958.

Right now, if we run `make -C docs man`, we get a big monolithic man page that contains _all_ the documentation we've got.  This switches it to just be a copy of the main reference for the CLI, which is fairly lightweight (especially in comparison), and matches more closely what users would expect from typing `man docker`.
