### PR TITLE
Create a long-running dockerinit

### DIFF
--- a/container.go
+++ b/container.go
@@ -670,7 +670,7 @@ func (container *Container) Start() (err error) {
 		container.Config.NetworkDisabled = true
 		container.buildHostnameAndHostsFiles("127.0.1.1")
 	} else {
-		if err := container.allocateNetwork(); err != nil {
+		if err := container.allocateNetwork(false); err != nil {
 			return err
 		}
 		container.buildHostnameAndHostsFiles(container.NetworkSettings.IPAddress)
@@ -1243,14 +1243,14 @@ ff02::2		ip6-allrouters
 	ioutil.WriteFile(container.HostsPath, hostsContent, 0644)
 }
 
-func (container *Container) allocateNetwork() error {
+func (container *Container) allocateNetwork(reconnect bool) error {
 	if container.Config.NetworkDisabled {
 		return nil
 	}
 
 	var iface *NetworkInterface
 	var err error
-	if container.State.Ghost {
+	if reconnect {
 		manager := container.runtime.networkManager
 		if manager.disabled {
 			iface = &NetworkInterface{disabled: true}
@@ -1291,7 +1291,7 @@ func (container *Container) allocateNetwork() error {
 	portSpecs := make(map[Port]struct{})
 	bindings := make(map[Port][]PortBinding)
 
-	if !container.State.Ghost {
+	if !reconnect {
 		if container.Config.ExposedPorts != nil {
 			portSpecs = container.Config.ExposedPorts
 		}

--- a/container.go
+++ b/container.go
@@ -887,6 +887,10 @@ func (container *Container) Start() (err error) {
 		params = append(params, "-stdin")
 	}
 
+	if container.hostConfig.Privileged {
+		params = append(params, "-privileged")
+	}
+
 	// Init any links between the parent and children
 	runtime := container.runtime
 

--- a/container.go
+++ b/container.go
@@ -998,7 +998,7 @@ func (container *Container) Start() (err error) {
 
 	// FIXME: save state on disk *first*, then converge
 	// this way disk state is used as a journal, eg. we can restore after crash etc.
-	container.State.setRunning(container.cmd.Process.Pid)
+	container.State.setRunning()
 
 	// Init the locks
 	container.waitLock = make(chan struct{})

--- a/container.go
+++ b/container.go
@@ -878,7 +878,6 @@ func (container *Container) Start() (err error) {
 	env := []string{
 		"HOME=/",
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-		"container=lxc",
 		"HOSTNAME=" + container.Config.Hostname,
 	}
 

--- a/container.go
+++ b/container.go
@@ -862,7 +862,11 @@ func (container *Container) Start() (err error) {
 
 	// Networking
 	if !container.Config.NetworkDisabled {
-		params = append(params, "-g", container.network.Gateway.String())
+		network := container.NetworkSettings
+		params = append(params,
+			"-g", network.Gateway,
+			"-i", fmt.Sprintf("%s/%d", network.IPAddress, network.IPPrefixLen),
+		)
 	}
 
 	// User

--- a/graph.go
+++ b/graph.go
@@ -198,6 +198,7 @@ func (graph *Graph) getDockerInitLayer() (string, error) {
 	for pth, typ := range map[string]string{
 		"/dev/pts":         "dir",
 		"/dev/shm":         "dir",
+		"/dev/console":     "file",
 		"/proc":            "dir",
 		"/sys":             "dir",
 		"/.dockerinit":     "file",

--- a/graph.go
+++ b/graph.go
@@ -179,8 +179,7 @@ func (graph *Graph) Mktemp(id string) (string, error) {
 }
 
 // getDockerInitLayer returns the path of a layer containing a mountpoint suitable
-// for bind-mounting dockerinit into the container. The mountpoint is simply an
-// empty file at /.dockerinit
+// for bind-mounting special files and directories into the container.
 //
 // This extra layer is used by all containers as the top-most ro layer. It protects
 // the container from unwanted side-effects on the rw layer.
@@ -203,6 +202,7 @@ func (graph *Graph) getDockerInitLayer() (string, error) {
 		"/sys":             "dir",
 		"/.dockerinit":     "file",
 		"/.dockerenv":      "file",
+		"/.docker-shared":  "dir",
 		"/etc/resolv.conf": "file",
 		"/etc/hosts":       "file",
 		"/etc/hostname":    "file",

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -29,6 +29,8 @@ git_clone github.com/gorilla/mux/ 9b36453141c
 
 git_clone github.com/dotcloud/tar/ e5ea6bb21a
 
+git_clone github.com/syndtr/gocapability 3454319be2
+
 # Docker requires code.google.com/p/go.net/websocket
 PKG=code.google.com/p/go.net REV=84a4013f96e0
 (

--- a/integration/container_test.go
+++ b/integration/container_test.go
@@ -1653,31 +1653,3 @@ func TestMultipleVolumesFrom(t *testing.T) {
 		t.Fail()
 	}
 }
-
-func TestRestartGhost(t *testing.T) {
-	runtime := mkRuntime(t)
-	defer nuke(runtime)
-
-	container, _, err := runtime.Create(
-		&docker.Config{
-			Image:   GetTestImage(runtime).ID,
-			Cmd:     []string{"sh", "-c", "echo -n bar > /test/foo"},
-			Volumes: map[string]struct{}{"/test": {}},
-		},
-		"",
-	)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := container.Kill(); err != nil {
-		t.Fatal(err)
-	}
-
-	container.State.Ghost = true
-	_, err = container.Output()
-
-	if err != nil {
-		t.Fatal(err)
-	}
-}

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -5,13 +5,6 @@ import (
 )
 
 const LxcTemplate = `
-# hostname
-{{if .Config.Hostname}}
-lxc.utsname = {{.Config.Hostname}}
-{{else}}
-lxc.utsname = {{.Id}}
-{{end}}
-
 {{if .Config.NetworkDisabled}}
 # network is disabled (-n=false)
 lxc.network.type = empty

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -11,11 +11,9 @@ lxc.network.type = empty
 {{else}}
 # network configuration
 lxc.network.type = veth
-lxc.network.flags = up
 lxc.network.link = {{.NetworkSettings.Bridge}}
 lxc.network.name = eth0
 lxc.network.mtu = 1500
-lxc.network.ipv4 = {{.NetworkSettings.IPAddress}}/{{.NetworkSettings.IPPrefixLen}}
 {{end}}
 
 # root filesystem

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -110,18 +110,11 @@ lxc.mount.entry = {{$realPath}} {{$ROOTFS}}/{{$virtualPath}} none bind,{{ if ind
 {{end}}
 
 {{if (getHostConfig .).Privileged}}
-# retain all capabilities; no lxc.cap.drop line
 {{if (getCapabilities .).AppArmor}}
 lxc.aa_profile = unconfined
 {{else}}
 #lxc.aa_profile = unconfined
 {{end}}
-{{else}}
-# drop linux capabilities (apply mainly to the user root in the container)
-#  (Note: 'lxc.cap.keep' is coming soon and should replace this under the
-#         security principle 'deny all unless explicitly permitted', see
-#         http://sourceforge.net/mailarchive/message.php?msg_id=31054627 )
-lxc.cap.drop = audit_control audit_write mac_admin mac_override mknod setpcap sys_admin sys_module sys_nice sys_pacct sys_rawio sys_resource sys_time sys_tty_config
 {{end}}
 
 # limits

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -93,8 +93,9 @@ lxc.mount.entry = devpts {{$ROOTFS}}/dev/pts devpts newinstance,ptmxmode=0666,no
 #lxc.mount.entry = varlock {{$ROOTFS}}/var/lock tmpfs size=1024k,nosuid,nodev,noexec 0 0
 lxc.mount.entry = shm {{$ROOTFS}}/dev/shm tmpfs size=65536k,nosuid,nodev,noexec 0 0
 
-# Inject dockerinit
+# Inject dockerinit and shared socket dir
 lxc.mount.entry = {{.SysInitPath}} {{$ROOTFS}}/.dockerinit none bind,ro 0 0
+lxc.mount.entry = {{.SharedPath}} {{$ROOTFS}}/.docker-shared none bind,rw 0 0
 
 # Inject env
 lxc.mount.entry = {{.EnvConfigPath}} {{$ROOTFS}}/.dockerenv none bind,ro 0 0

--- a/lxc_template_unit_test.go
+++ b/lxc_template_unit_test.go
@@ -29,7 +29,6 @@ func TestLXCConfig(t *testing.T) {
 	container := &Container{
 		root: root,
 		Config: &Config{
-			Hostname:        "foobar",
 			Memory:          int64(mem),
 			CpuShares:       int64(cpu),
 			NetworkDisabled: true,
@@ -41,7 +40,6 @@ func TestLXCConfig(t *testing.T) {
 	if err := container.generateLXCConfig(); err != nil {
 		t.Fatal(err)
 	}
-	grepFile(t, container.lxcConfigPath(), "lxc.utsname = foobar")
 	grepFile(t, container.lxcConfigPath(),
 		fmt.Sprintf("lxc.cgroup.memory.limit_in_bytes = %d", mem))
 	grepFile(t, container.lxcConfigPath(),

--- a/runtime.go
+++ b/runtime.go
@@ -166,6 +166,7 @@ func (runtime *Runtime) Register(container *Container) error {
 
 			container.waitLock = make(chan struct{})
 			container.rpcLock = make(chan struct{})
+			container.ptyLock = make(chan struct{})
 
 			go container.monitor(true)
 		}

--- a/runtime.go
+++ b/runtime.go
@@ -165,8 +165,9 @@ func (runtime *Runtime) Register(container *Container) error {
 			}
 
 			container.waitLock = make(chan struct{})
+			container.rpcLock = make(chan struct{})
 
-			go container.monitor()
+			go container.monitor(true)
 		}
 	}
 	return nil
@@ -470,6 +471,12 @@ func (runtime *Runtime) Create(config *Config, name string) (*Container, []strin
 		}
 	} else {
 		container.ResolvConfPath = "/etc/resolv.conf"
+	}
+
+	// Create the shared socket directory
+	container.SharedPath = path.Join(container.root, "shared")
+	if err := os.Mkdir(container.SharedPath, 0700); err != nil {
+		return nil, nil, err
 	}
 
 	// Step 2: save the container json

--- a/server.go
+++ b/server.go
@@ -1691,10 +1691,6 @@ func (srv *Server) ContainerAttach(name string, logs, stream, stdin, stdout, std
 
 	//stream
 	if stream {
-		if container.State.Ghost {
-			return fmt.Errorf("Impossible to attach to a ghost container")
-		}
-
 		var (
 			cStdin           io.ReadCloser
 			cStdout, cStderr io.Writer

--- a/state.go
+++ b/state.go
@@ -10,7 +10,6 @@ import (
 type State struct {
 	sync.Mutex
 	Running    bool
-	Pid        int
 	ExitCode   int
 	StartedAt  time.Time
 	FinishedAt time.Time
@@ -24,16 +23,14 @@ func (s *State) String() string {
 	return fmt.Sprintf("Exit %d", s.ExitCode)
 }
 
-func (s *State) setRunning(pid int) {
+func (s *State) setRunning() {
 	s.Running = true
 	s.ExitCode = 0
-	s.Pid = pid
 	s.StartedAt = time.Now()
 }
 
 func (s *State) setStopped(exitCode int) {
 	s.Running = false
-	s.Pid = 0
 	s.FinishedAt = time.Now()
 	s.ExitCode = exitCode
 }

--- a/state.go
+++ b/state.go
@@ -14,15 +14,11 @@ type State struct {
 	ExitCode   int
 	StartedAt  time.Time
 	FinishedAt time.Time
-	Ghost      bool
 }
 
 // String returns a human-readable description of the state
 func (s *State) String() string {
 	if s.Running {
-		if s.Ghost {
-			return fmt.Sprintf("Ghost")
-		}
 		return fmt.Sprintf("Up %s", utils.HumanDuration(time.Now().Sub(s.StartedAt)))
 	}
 	return fmt.Sprintf("Exit %d", s.ExitCode)
@@ -30,7 +26,6 @@ func (s *State) String() string {
 
 func (s *State) setRunning(pid int) {
 	s.Running = true
-	s.Ghost = false
 	s.ExitCode = 0
 	s.Pid = pid
 	s.StartedAt = time.Now()

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -123,6 +123,18 @@ func dockerInitApp(args *DockerInitArgs) error {
 		return err
 	}
 
+	// Forward all signals to the app
+	sigchan := make(chan os.Signal, 1)
+	utils.CatchAll(sigchan)
+	go func() {
+		for sig := range sigchan {
+			if sig == syscall.SIGCHLD {
+				continue
+			}
+			cmd.Process.Signal(sig)
+		}
+	}()
+
 	// Wait for the app to exit.  Also, as pid 1 it's our job to reap all
 	// orphaned zombies.
 	var wstatus syscall.WaitStatus

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -653,6 +653,9 @@ func SysInit() {
 		log.Fatalf("Unable to unmarshal environment variables: %v", err)
 	}
 
+	// Propagate the plugin-specific container env variable
+	env = append(env, "container="+os.Getenv("container"))
+
 	args := &DockerInitArgs{
 		user:       *user,
 		gateway:    *gateway,

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -11,96 +11,137 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path"
 	"strconv"
 	"strings"
 	"syscall"
 )
 
-// Setup networking
-func setupNetworking(gw string) {
-	if gw == "" {
-		return
+func setupNetworking(args *DockerInitArgs) error {
+	if args.gateway == "" {
+		return nil
 	}
 
-	ip := net.ParseIP(gw)
+	ip := net.ParseIP(args.gateway)
 	if ip == nil {
-		log.Fatalf("Unable to set up networking, %s is not a valid IP", gw)
-		return
+		return fmt.Errorf("Unable to set up networking, %s is not a valid IP", args.gateway)
 	}
 
 	if err := netlink.AddDefaultGw(ip); err != nil {
-		log.Fatalf("Unable to set up networking: %v", err)
+		return fmt.Errorf("Unable to set up networking: %v", err)
 	}
+	return nil
 }
 
-// Setup working directory
-func setupWorkingDirectory(workdir string) {
-	if workdir == "" {
-		return
+func getCredential(args *DockerInitArgs) (*syscall.Credential, error) {
+	if args.user == "" {
+		return nil, nil
 	}
-	if err := syscall.Chdir(workdir); err != nil {
-		log.Fatalf("Unable to change dir to %v: %v", workdir, err)
-	}
-}
-
-// Takes care of dropping privileges to the desired user
-func changeUser(u string) {
-	if u == "" {
-		return
-	}
-	userent, err := utils.UserLookup(u)
+	userent, err := utils.UserLookup(args.user)
 	if err != nil {
-		log.Fatalf("Unable to find user %v: %v", u, err)
+		return nil, fmt.Errorf("Unable to find user %v: %v", args.user, err)
 	}
 
 	uid, err := strconv.Atoi(userent.Uid)
 	if err != nil {
-		log.Fatalf("Invalid uid: %v", userent.Uid)
+		return nil, fmt.Errorf("Invalid uid: %v", userent.Uid)
 	}
 	gid, err := strconv.Atoi(userent.Gid)
 	if err != nil {
-		log.Fatalf("Invalid gid: %v", userent.Gid)
+		return nil, fmt.Errorf("Invalid gid: %v", userent.Gid)
 	}
 
-	if err := syscall.Setgid(gid); err != nil {
-		log.Fatalf("setgid failed: %v", err)
-	}
-	if err := syscall.Setuid(uid); err != nil {
-		log.Fatalf("setuid failed: %v", err)
-	}
+	return &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}, nil
 }
 
-// Clear environment pollution introduced by lxc-start
-func cleanupEnv() {
-	os.Clearenv()
-	var lines []string
-	content, err := ioutil.ReadFile("/.dockerenv")
-	if err != nil {
-		log.Fatalf("Unable to load environment variables: %v", err)
-	}
-	err = json.Unmarshal(content, &lines)
-	if err != nil {
-		log.Fatalf("Unable to unmarshal environment variables: %v", err)
-	}
-	for _, kv := range lines {
+func getEnv(args *DockerInitArgs, key string) string {
+	for _, kv := range args.env {
 		parts := strings.SplitN(kv, "=", 2)
-		if len(parts) == 1 {
-			parts = append(parts, "")
+		if parts[0] == key && len(parts) == 2 {
+			return parts[1]
 		}
-		os.Setenv(parts[0], parts[1])
 	}
+	return ""
 }
 
-func executeProgram(name string, args []string) {
-	path, err := exec.LookPath(name)
-	if err != nil {
-		log.Printf("Unable to locate %v", name)
-		os.Exit(127)
+func getCmdPath(args *DockerInitArgs) (string, error) {
+
+	// Set PATH in dockerinit so we can find the cmd
+	envPath := getEnv(args, "PATH")
+	if envPath != "" {
+		os.Setenv("PATH", envPath)
 	}
 
-	if err := syscall.Exec(path, args, os.Environ()); err != nil {
-		panic(err)
+	// Find the cmd
+	cmdPath, err := exec.LookPath(args.args[0])
+	if err != nil {
+		if args.workDir == "" {
+			return "", err
+		}
+		cmdPath, err = exec.LookPath(path.Join(args.workDir, args.args[0]))
+		if err != nil {
+			return "", err
+		}
 	}
+
+	return cmdPath, nil
+}
+
+// Run as pid 1 in the typical Docker usage: an app container that doesn't
+// need its own init process.  Running as pid 1 allows us to monitor the
+// container app and return its exit code.
+func dockerInitApp(args *DockerInitArgs) error {
+
+	// Prepare the cmd based on the given args
+	cmdPath, err := getCmdPath(args)
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(cmdPath, args.args[1:]...)
+	cmd.Dir = args.workDir
+	cmd.Env = args.env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// Update uid/gid credentials if needed
+	credential, err := getCredential(args)
+	if err != nil {
+		return err
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Credential: credential}
+
+	// Network setup
+	err = setupNetworking(args)
+	if err != nil {
+		return err
+	}
+
+	// Start the app
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	// Wait for it to exit
+	err = cmd.Wait()
+	if err != nil {
+		_, ok := err.(*exec.ExitError)
+		if !ok {
+			return err
+		}
+	}
+	exitCode := cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+	os.Exit(exitCode)
+	return nil
+}
+
+type DockerInitArgs struct {
+	user    string
+	gateway string
+	workDir string
+	env     []string
+	args    []string
 }
 
 // Sys Init code
@@ -111,15 +152,34 @@ func SysInit() {
 		fmt.Println("You should not invoke dockerinit manually")
 		os.Exit(1)
 	}
-	var u = flag.String("u", "", "username or uid")
-	var gw = flag.String("g", "", "gateway address")
-	var workdir = flag.String("w", "", "workdir")
 
+	// Get cmdline arguments
+	user := flag.String("u", "", "username or uid")
+	gateway := flag.String("g", "", "gateway address")
+	workDir := flag.String("w", "", "workdir")
 	flag.Parse()
 
-	cleanupEnv()
-	setupNetworking(*gw)
-	setupWorkingDirectory(*workdir)
-	changeUser(*u)
-	executeProgram(flag.Arg(0), flag.Args())
+	// Get env
+	var env []string
+	content, err := ioutil.ReadFile("/.dockerenv")
+	if err != nil {
+		log.Fatalf("Unable to load environment variables: %v", err)
+	}
+	err = json.Unmarshal(content, &env)
+	if err != nil {
+		log.Fatalf("Unable to unmarshal environment variables: %v", err)
+	}
+
+	args := &DockerInitArgs{
+		user:    *user,
+		gateway: *gateway,
+		workDir: *workDir,
+		env:     env,
+		args:    flag.Args(),
+	}
+
+	err = dockerInitApp(args)
+	if err != nil {
+		log.Fatal(err)
+	}
 }

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/dotcloud/docker/netlink"
 	"github.com/dotcloud/docker/utils"
+	"github.com/kr/pty"
 	"io/ioutil"
 	"log"
 	"net"
@@ -21,9 +22,14 @@ import (
 
 const SharedPath = "/.docker-shared"
 const RpcSocketName = "rpc.sock"
+const ConsoleSocketName = "con.sock"
 
 func rpcSocketPath() string {
 	return path.Join(SharedPath, RpcSocketName)
+}
+
+func consoleSocketPath() string {
+	return path.Join(SharedPath, ConsoleSocketName)
 }
 
 type DockerInitRpc struct {
@@ -32,6 +38,14 @@ type DockerInitRpc struct {
 	exitCode    chan int
 	process     *os.Process
 	processLock chan struct{}
+}
+
+type DockerInitConsole struct {
+	stdin     *os.File
+	stdout    *os.File
+	stderr    *os.File
+	ptyMaster *os.File
+	openStdin bool
 }
 
 // RPC: Resume container start or container exit
@@ -91,6 +105,55 @@ func rpcServer(dockerInitRpc *DockerInitRpc) {
 		// The RPC connection has closed, which means the docker daemon
 		// exited.  Cancel the Wait() call.
 		dockerInitRpc.cancel <- 1
+	}
+}
+
+// Send console FDs to docker over a UNIX socket
+func consoleFdServer(dockerInitConsole *DockerInitConsole) {
+
+	os.Remove(consoleSocketPath())
+	addr := &net.UnixAddr{Net: "unix", Name: consoleSocketPath()}
+	listener, err := net.ListenUnix("unix", addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			log.Printf("fd socket accept error: %s", err)
+			continue
+		}
+
+		dummy := []byte("1")
+		var fds []int
+		if dockerInitConsole.ptyMaster != nil {
+			fds = []int{int(dockerInitConsole.ptyMaster.Fd())}
+		} else {
+			fds = []int{
+				int(dockerInitConsole.stdout.Fd()),
+				int(dockerInitConsole.stderr.Fd())}
+
+			if dockerInitConsole.stdin != nil {
+				fds = append(fds, int(dockerInitConsole.stdin.Fd()))
+			}
+		}
+
+		rights := syscall.UnixRights(fds...)
+		_, _, err = conn.WriteMsgUnix(dummy, rights, nil)
+		if err != nil {
+			log.Printf("%s", err)
+		}
+
+		// Only give stdin to the first caller and then close it on our
+		// side.  This gives the docker daemon the power to close the
+		// app's stdin in StdinOnce mode.
+		if dockerInitConsole.openStdin && dockerInitConsole.stdin != nil {
+			dockerInitConsole.stdin.Close()
+			dockerInitConsole.stdin = nil
+		}
+
+		conn.Close()
 	}
 }
 
@@ -164,10 +227,12 @@ func getCmdPath(args *DockerInitArgs) (string, error) {
 	return cmdPath, nil
 }
 
-// Start the RPC server and wait for docker to tell us to
-// resume starting the container.
-func startServerAndWait(dockerInitRpc *DockerInitRpc) error {
+// Start the RPC and console FD servers and wait for docker to tell us to
+// resume starting the container.  This gives docker a chance to get the
+// console FDs before we start so that it won't miss any console output.
+func startServersAndWait(dockerInitRpc *DockerInitRpc, dockerInitConsole *DockerInitConsole) error {
 
+	go consoleFdServer(dockerInitConsole)
 	go rpcServer(dockerInitRpc)
 
 	select {
@@ -189,6 +254,12 @@ func dockerInitRpcNew() *DockerInitRpc {
 	}
 }
 
+func dockerInitConsoleNew(args *DockerInitArgs) *DockerInitConsole {
+	return &DockerInitConsole{
+		openStdin: args.openStdin,
+	}
+}
+
 // Run as pid 1 in the typical Docker usage: an app container that doesn't
 // need its own init process.  Running as pid 1 allows us to monitor the
 // container app and return its exit code.
@@ -202,9 +273,6 @@ func dockerInitApp(args *DockerInitArgs) error {
 	cmd := exec.Command(cmdPath, args.args[1:]...)
 	cmd.Dir = args.workDir
 	cmd.Env = args.env
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
 
 	// Update uid/gid credentials if needed
 	credential, err := getCredential(args)
@@ -213,10 +281,55 @@ func dockerInitApp(args *DockerInitArgs) error {
 	}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Credential: credential}
 
+	cmd.SysProcAttr.Setsid = true
+
+	// Console setup.  Hook up the container app's stdin/stdout/stderr to
+	// either a pty or pipes.  The FDs for the controlling side of the
+	// pty/pipes will be passed to docker later via a UNIX socket.
+	dockerInitConsole := dockerInitConsoleNew(args)
+	if args.tty {
+		ptyMaster, ptySlave, err := pty.Open()
+		if err != nil {
+			return err
+		}
+		dockerInitConsole.ptyMaster = ptyMaster
+		cmd.Stdout = ptySlave
+		cmd.Stderr = ptySlave
+		if args.openStdin {
+			cmd.Stdin = ptySlave
+			cmd.SysProcAttr.Setctty = true
+		}
+	} else {
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return err
+		}
+		dockerInitConsole.stdout = stdout.(*os.File)
+
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			return err
+		}
+		dockerInitConsole.stderr = stderr.(*os.File)
+		if args.openStdin {
+			// Can't use cmd.StdinPipe() here, since in Go 1.2 it
+			// returns an io.WriteCloser with the underlying object
+			// being an *exec.closeOnce, neither of which provides
+			// a way to convert to an FD.
+			pipeRead, pipeWrite, err := os.Pipe()
+			if err != nil {
+				return err
+			}
+			cmd.Stdin = pipeRead
+			dockerInitConsole.stdin = pipeWrite
+		}
+	}
+
 	dockerInitRpc := dockerInitRpcNew()
 
-	// Start the RPC and server and wait for the resume call from docker
-	err = startServerAndWait(dockerInitRpc)
+	// Start the RPC and console FD servers and wait for the resume call
+	// from docker
+	err = startServersAndWait(dockerInitRpc, dockerInitConsole)
 	if err != nil {
 		return err
 	}
@@ -282,11 +395,13 @@ func dockerInitApp(args *DockerInitArgs) error {
 }
 
 type DockerInitArgs struct {
-	user    string
-	gateway string
-	workDir string
-	env     []string
-	args    []string
+	user      string
+	gateway   string
+	workDir   string
+	tty       bool
+	openStdin bool
+	env       []string
+	args      []string
 }
 
 // Sys Init code
@@ -302,6 +417,8 @@ func SysInit() {
 	user := flag.String("u", "", "username or uid")
 	gateway := flag.String("g", "", "gateway address")
 	workDir := flag.String("w", "", "workdir")
+	tty := flag.Bool("tty", false, "use pseudo-tty")
+	openStdin := flag.Bool("stdin", false, "open stdin")
 	flag.Parse()
 
 	// Get env
@@ -316,11 +433,13 @@ func SysInit() {
 	}
 
 	args := &DockerInitArgs{
-		user:    *user,
-		gateway: *gateway,
-		workDir: *workDir,
-		env:     env,
-		args:    flag.Args(),
+		user:      *user,
+		gateway:   *gateway,
+		workDir:   *workDir,
+		tty:       *tty,
+		openStdin: *openStdin,
+		env:       env,
+		args:      flag.Args(),
 	}
 
 	err = dockerInitApp(args)

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -159,6 +159,14 @@ func consoleFdServer(dockerInitConsole *DockerInitConsole) {
 	}
 }
 
+func setupHostname(args *DockerInitArgs) error {
+	hostname := getEnv(args, "HOSTNAME")
+	if hostname == "" {
+		return nil
+	}
+	return syscall.Sethostname([]byte(hostname))
+}
+
 func setupNetworking(args *DockerInitArgs) error {
 	if args.gateway == "" {
 		return nil
@@ -268,7 +276,11 @@ func setupCapabilities(args *DockerInitArgs) error {
 
 func setupCommon(args *DockerInitArgs) error {
 
-	err := setupNetworking(args)
+	err := setupHostname(args)
+	if err != nil {
+		return err
+	}
+	err = setupNetworking(args)
 	if err != nil {
 		return err
 	}

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -27,9 +27,11 @@ func rpcSocketPath() string {
 }
 
 type DockerInitRpc struct {
-	resume   chan int
-	cancel   chan int
-	exitCode chan int
+	resume      chan int
+	cancel      chan int
+	exitCode    chan int
+	process     *os.Process
+	processLock chan struct{}
 }
 
 // RPC: Resume container start or container exit
@@ -52,6 +54,12 @@ func (dockerInitRpc *DockerInitRpc) Wait(_ int, exitCode *int) error {
 		*exitCode = -1
 	}
 	return nil
+}
+
+// RPC: Send a signal to the container app
+func (dockerInitRpc *DockerInitRpc) Signal(signal syscall.Signal, _ *int) error {
+	<-dockerInitRpc.processLock
+	return dockerInitRpc.process.Signal(signal)
 }
 
 // Serve RPC commands over a UNIX socket
@@ -174,9 +182,10 @@ func startServerAndWait(dockerInitRpc *DockerInitRpc) error {
 
 func dockerInitRpcNew() *DockerInitRpc {
 	return &DockerInitRpc{
-		resume:   make(chan int),
-		exitCode: make(chan int),
-		cancel:   make(chan int),
+		resume:      make(chan int),
+		exitCode:    make(chan int),
+		cancel:      make(chan int),
+		processLock: make(chan struct{}),
 	}
 }
 
@@ -223,6 +232,9 @@ func dockerInitApp(args *DockerInitArgs) error {
 	if err != nil {
 		return err
 	}
+
+	dockerInitRpc.process = cmd.Process
+	close(dockerInitRpc.processLock)
 
 	// Forward all signals to the app
 	sigchan := make(chan os.Signal, 1)

--- a/vendor/src/github.com/syndtr/gocapability/LICENSE
+++ b/vendor/src/github.com/syndtr/gocapability/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2013 Suryandaru Triandana <syndtr@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/src/github.com/syndtr/gocapability/capability/capability.go
+++ b/vendor/src/github.com/syndtr/gocapability/capability/capability.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Package capability provides utilities for manipulating POSIX capabilities.
+package capability
+
+type Capabilities interface {
+	// Get check whether a capability present in the given
+	// capabilities set. The 'which' value should be one of EFFECTIVE,
+	// PERMITTED, INHERITABLE or BOUNDING.
+	Get(which CapType, what Cap) bool
+
+	// Empty check whether all capability bits of the given capabilities
+	// set are zero. The 'which' value should be one of EFFECTIVE,
+	// PERMITTED, INHERITABLE or BOUNDING.
+	Empty(which CapType) bool
+
+	// Full check whether all capability bits of the given capabilities
+	// set are one. The 'which' value should be one of EFFECTIVE,
+	// PERMITTED, INHERITABLE or BOUNDING.
+	Full(which CapType) bool
+
+	// Set sets capabilities of the given capabilities sets. The
+	// 'which' value should be one or combination (OR'ed) of EFFECTIVE,
+	// PERMITTED, INHERITABLE or BOUNDING.
+	Set(which CapType, caps ...Cap)
+
+	// Unset unsets capabilities of the given capabilities sets. The
+	// 'which' value should be one or combination (OR'ed) of EFFECTIVE,
+	// PERMITTED, INHERITABLE or BOUNDING.
+	Unset(which CapType, caps ...Cap)
+
+	// Fill sets all bits of the given capabilities kind to one. The
+	// 'kind' value should be one or combination (OR'ed) of CAPS or
+	// BOUNDS.
+	Fill(kind CapType)
+
+	// Clear sets all bits of the given capabilities kind to zero. The
+	// 'kind' value should be one or combination (OR'ed) of CAPS or
+	// BOUNDS.
+	Clear(kind CapType)
+
+	// String return current capabilities state of the given capabilities
+	// set as string. The 'which' value should be one of EFFECTIVE,
+	// PERMITTED, INHERITABLE or BOUNDING.
+	StringCap(which CapType) string
+
+	// String return current capabilities state as string.
+	String() string
+
+	// Load load actual capabilities value. This will overwrite all
+	// outstanding changes.
+	Load() error
+
+	// Apply apply the capabilities settings, so all changes will take
+	// effect.
+	Apply(kind CapType) error
+}
+
+// NewPid create new initialized Capabilities object for given pid.
+func NewPid(pid int) (Capabilities, error) {
+	return newPid(pid)
+}
+
+// NewFile create new initialized Capabilities object for given named file.
+func NewFile(name string) (Capabilities, error) {
+	return newFile(name)
+}

--- a/vendor/src/github.com/syndtr/gocapability/capability/capability_linux.go
+++ b/vendor/src/github.com/syndtr/gocapability/capability/capability_linux.go
@@ -1,0 +1,561 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package capability
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+)
+
+var errUnknownVers = errors.New("unknown capability version")
+
+const (
+	linuxCapVer1 = 0x19980330
+	linuxCapVer2 = 0x20071026
+	linuxCapVer3 = 0x20080522
+)
+
+var capVers uint32
+
+func init() {
+	var hdr capHeader
+	capget(&hdr, nil)
+	capVers = hdr.version
+}
+
+func mkStringCap(c Capabilities, which CapType) (ret string) {
+	for i, first := Cap(0), true; i <= CAP_LAST_CAP; i++ {
+		if !c.Get(which, i) {
+			continue
+		}
+		if first {
+			first = false
+		} else {
+			ret += ", "
+		}
+		ret += i.String()
+	}
+	return
+}
+
+func mkString(c Capabilities, max CapType) (ret string) {
+	ret = "{"
+	for i := CapType(1); i <= max; i <<= 1 {
+		ret += " " + i.String() + "=\""
+		if c.Empty(i) {
+			ret += "empty"
+		} else if c.Full(i) {
+			ret += "full"
+		} else {
+			ret += c.StringCap(i)
+		}
+		ret += "\""
+	}
+	ret += " }"
+	return
+}
+
+func newPid(pid int) (c Capabilities, err error) {
+	switch capVers {
+	case linuxCapVer1:
+		p := new(capsV1)
+		p.hdr.version = capVers
+		p.hdr.pid = pid
+		c = p
+	case linuxCapVer2, linuxCapVer3:
+		p := new(capsV3)
+		p.hdr.version = capVers
+		p.hdr.pid = pid
+		c = p
+	default:
+		err = errUnknownVers
+		return
+	}
+	err = c.Load()
+	if err != nil {
+		c = nil
+	}
+	return
+}
+
+type capsV1 struct {
+	hdr  capHeader
+	data capData
+}
+
+func (c *capsV1) Get(which CapType, what Cap) bool {
+	if what > 32 {
+		return false
+	}
+
+	switch which {
+	case EFFECTIVE:
+		return (1<<uint(what))&c.data.effective != 0
+	case PERMITTED:
+		return (1<<uint(what))&c.data.permitted != 0
+	case INHERITABLE:
+		return (1<<uint(what))&c.data.inheritable != 0
+	}
+
+	return false
+}
+
+func (c *capsV1) getData(which CapType) (ret uint32) {
+	switch which {
+	case EFFECTIVE:
+		ret = c.data.effective
+	case PERMITTED:
+		ret = c.data.permitted
+	case INHERITABLE:
+		ret = c.data.inheritable
+	}
+	return
+}
+
+func (c *capsV1) Empty(which CapType) bool {
+	return c.getData(which) == 0
+}
+
+func (c *capsV1) Full(which CapType) bool {
+	return (c.getData(which) & 0x7fffffff) == 0x7fffffff
+}
+
+func (c *capsV1) Set(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		if what > 32 {
+			continue
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data.effective |= 1 << uint(what)
+		}
+		if which&PERMITTED != 0 {
+			c.data.permitted |= 1 << uint(what)
+		}
+		if which&INHERITABLE != 0 {
+			c.data.inheritable |= 1 << uint(what)
+		}
+	}
+}
+
+func (c *capsV1) Unset(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		if what > 32 {
+			continue
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data.effective &= ^(1 << uint(what))
+		}
+		if which&PERMITTED != 0 {
+			c.data.permitted &= ^(1 << uint(what))
+		}
+		if which&INHERITABLE != 0 {
+			c.data.inheritable &= ^(1 << uint(what))
+		}
+	}
+}
+
+func (c *capsV1) Fill(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data.effective = 0x7fffffff
+		c.data.permitted = 0x7fffffff
+		c.data.inheritable = 0
+	}
+}
+
+func (c *capsV1) Clear(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data.effective = 0
+		c.data.permitted = 0
+		c.data.inheritable = 0
+	}
+}
+
+func (c *capsV1) StringCap(which CapType) (ret string) {
+	return mkStringCap(c, which)
+}
+
+func (c *capsV1) String() (ret string) {
+	return mkString(c, BOUNDING)
+}
+
+func (c *capsV1) Load() (err error) {
+	return capget(&c.hdr, &c.data)
+}
+
+func (c *capsV1) Apply(kind CapType) error {
+	if kind&CAPS == CAPS {
+		return capset(&c.hdr, &c.data)
+	}
+	return nil
+}
+
+type capsV3 struct {
+	hdr    capHeader
+	data   [2]capData
+	bounds [2]uint32
+}
+
+func (c *capsV3) Get(which CapType, what Cap) bool {
+	var i uint
+	if what > 31 {
+		i = uint(what) >> 5
+		what %= 32
+	}
+
+	switch which {
+	case EFFECTIVE:
+		return (1<<uint(what))&c.data[i].effective != 0
+	case PERMITTED:
+		return (1<<uint(what))&c.data[i].permitted != 0
+	case INHERITABLE:
+		return (1<<uint(what))&c.data[i].inheritable != 0
+	case BOUNDING:
+		return (1<<uint(what))&c.bounds[i] != 0
+	}
+
+	return false
+}
+
+func (c *capsV3) getData(which CapType, dest []uint32) {
+	switch which {
+	case EFFECTIVE:
+		dest[0] = c.data[0].effective
+		dest[1] = c.data[1].effective
+	case PERMITTED:
+		dest[0] = c.data[0].permitted
+		dest[1] = c.data[1].permitted
+	case INHERITABLE:
+		dest[0] = c.data[0].inheritable
+		dest[1] = c.data[1].inheritable
+	case BOUNDING:
+		dest[0] = c.bounds[0]
+		dest[1] = c.bounds[1]
+	}
+}
+
+func (c *capsV3) Empty(which CapType) bool {
+	var data [2]uint32
+	c.getData(which, data[:])
+	return data[0] == 0 && data[1] == 0
+}
+
+func (c *capsV3) Full(which CapType) bool {
+	var data [2]uint32
+	c.getData(which, data[:])
+	if (data[0] & 0xffffffff) != 0xffffffff {
+		return false
+	}
+	return (data[1] & capUpperMask) == capUpperMask
+}
+
+func (c *capsV3) Set(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		var i uint
+		if what > 31 {
+			i = uint(what) >> 5
+			what %= 32
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data[i].effective |= 1 << uint(what)
+		}
+		if which&PERMITTED != 0 {
+			c.data[i].permitted |= 1 << uint(what)
+		}
+		if which&INHERITABLE != 0 {
+			c.data[i].inheritable |= 1 << uint(what)
+		}
+		if which&BOUNDING != 0 {
+			c.bounds[i] |= 1 << uint(what)
+		}
+	}
+}
+
+func (c *capsV3) Unset(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		var i uint
+		if what > 31 {
+			i = uint(what) >> 5
+			what %= 32
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data[i].effective &= ^(1 << uint(what))
+		}
+		if which&PERMITTED != 0 {
+			c.data[i].permitted &= ^(1 << uint(what))
+		}
+		if which&INHERITABLE != 0 {
+			c.data[i].inheritable &= ^(1 << uint(what))
+		}
+		if which&BOUNDING != 0 {
+			c.bounds[i] &= ^(1 << uint(what))
+		}
+	}
+}
+
+func (c *capsV3) Fill(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data[0].effective = 0xffffffff
+		c.data[0].permitted = 0xffffffff
+		c.data[0].inheritable = 0
+		c.data[1].effective = 0xffffffff
+		c.data[1].permitted = 0xffffffff
+		c.data[1].inheritable = 0
+	}
+
+	if kind&BOUNDS == BOUNDS {
+		c.bounds[0] = 0xffffffff
+		c.bounds[1] = 0xffffffff
+	}
+}
+
+func (c *capsV3) Clear(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data[0].effective = 0
+		c.data[0].permitted = 0
+		c.data[0].inheritable = 0
+		c.data[1].effective = 0
+		c.data[1].permitted = 0
+		c.data[1].inheritable = 0
+	}
+
+	if kind&BOUNDS == BOUNDS {
+		c.bounds[0] = 0
+		c.bounds[1] = 0
+	}
+}
+
+func (c *capsV3) StringCap(which CapType) (ret string) {
+	return mkStringCap(c, which)
+}
+
+func (c *capsV3) String() (ret string) {
+	return mkString(c, BOUNDING)
+}
+
+func (c *capsV3) Load() (err error) {
+	err = capget(&c.hdr, &c.data[0])
+	if err != nil {
+		return
+	}
+
+	f, err := os.Open(fmt.Sprintf("/proc/%d/status", c.hdr.pid))
+	if err != nil {
+		return
+	}
+	b := bufio.NewReader(f)
+	for {
+		line, e := b.ReadString('\n')
+		if e != nil {
+			if e != io.EOF {
+				err = e
+			}
+			break
+		}
+		if strings.HasPrefix(line, "CapB") {
+			fmt.Sscanf(line[4:], "nd:  %08x%08x", &c.bounds[1], &c.bounds[0])
+			break
+		}
+	}
+	f.Close()
+
+	return
+}
+
+func (c *capsV3) Apply(kind CapType) (err error) {
+	if kind&BOUNDS == BOUNDS {
+		var data [2]capData
+		err = capget(&c.hdr, &data[0])
+		if err != nil {
+			return
+		}
+		if (1<<uint(CAP_SETPCAP))&data[0].effective != 0 {
+			for i := Cap(0); i <= CAP_LAST_CAP; i++ {
+				if c.Get(BOUNDING, i) {
+					continue
+				}
+				err = prctl(syscall.PR_CAPBSET_DROP, uintptr(i), 0, 0, 0)
+				if err != nil {
+					return
+				}
+			}
+		}
+	}
+
+	if kind&CAPS == CAPS {
+		return capset(&c.hdr, &c.data[0])
+	}
+
+	return
+}
+
+func newFile(path string) (c Capabilities, err error) {
+	c = &capsFile{path: path}
+	err = c.Load()
+	if err != nil {
+		c = nil
+	}
+	return
+}
+
+type capsFile struct {
+	path string
+	data vfscapData
+}
+
+func (c *capsFile) Get(which CapType, what Cap) bool {
+	var i uint
+	if what > 31 {
+		if c.data.version == 1 {
+			return false
+		}
+		i = uint(what) >> 5
+		what %= 32
+	}
+
+	switch which {
+	case EFFECTIVE:
+		return (1<<uint(what))&c.data.effective[i] != 0
+	case PERMITTED:
+		return (1<<uint(what))&c.data.data[i].permitted != 0
+	case INHERITABLE:
+		return (1<<uint(what))&c.data.data[i].inheritable != 0
+	}
+
+	return false
+}
+
+func (c *capsFile) getData(which CapType, dest []uint32) {
+	switch which {
+	case EFFECTIVE:
+		dest[0] = c.data.effective[0]
+		dest[1] = c.data.effective[1]
+	case PERMITTED:
+		dest[0] = c.data.data[0].permitted
+		dest[1] = c.data.data[1].permitted
+	case INHERITABLE:
+		dest[0] = c.data.data[0].inheritable
+		dest[1] = c.data.data[1].inheritable
+	}
+}
+
+func (c *capsFile) Empty(which CapType) bool {
+	var data [2]uint32
+	c.getData(which, data[:])
+	return data[0] == 0 && data[1] == 0
+}
+
+func (c *capsFile) Full(which CapType) bool {
+	var data [2]uint32
+	c.getData(which, data[:])
+	if c.data.version == 0 {
+		return (data[0] & 0x7fffffff) == 0x7fffffff
+	}
+	if (data[0] & 0xffffffff) != 0xffffffff {
+		return false
+	}
+	return (data[1] & capUpperMask) == capUpperMask
+}
+
+func (c *capsFile) Set(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		var i uint
+		if what > 31 {
+			if c.data.version == 1 {
+				continue
+			}
+			i = uint(what) >> 5
+			what %= 32
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data.effective[i] |= 1 << uint(what)
+		}
+		if which&PERMITTED != 0 {
+			c.data.data[i].permitted |= 1 << uint(what)
+		}
+		if which&INHERITABLE != 0 {
+			c.data.data[i].inheritable |= 1 << uint(what)
+		}
+	}
+}
+
+func (c *capsFile) Unset(which CapType, caps ...Cap) {
+	for _, what := range caps {
+		var i uint
+		if what > 31 {
+			if c.data.version == 1 {
+				continue
+			}
+			i = uint(what) >> 5
+			what %= 32
+		}
+
+		if which&EFFECTIVE != 0 {
+			c.data.effective[i] &= ^(1 << uint(what))
+		}
+		if which&PERMITTED != 0 {
+			c.data.data[i].permitted &= ^(1 << uint(what))
+		}
+		if which&INHERITABLE != 0 {
+			c.data.data[i].inheritable &= ^(1 << uint(what))
+		}
+	}
+}
+
+func (c *capsFile) Fill(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data.effective[0] = 0xffffffff
+		c.data.data[0].permitted = 0xffffffff
+		c.data.data[0].inheritable = 0
+		if c.data.version == 2 {
+			c.data.effective[1] = 0xffffffff
+			c.data.data[1].permitted = 0xffffffff
+			c.data.data[1].inheritable = 0
+		}
+	}
+}
+
+func (c *capsFile) Clear(kind CapType) {
+	if kind&CAPS == CAPS {
+		c.data.effective[0] = 0
+		c.data.data[0].permitted = 0
+		c.data.data[0].inheritable = 0
+		if c.data.version == 2 {
+			c.data.effective[1] = 0
+			c.data.data[1].permitted = 0
+			c.data.data[1].inheritable = 0
+		}
+	}
+}
+
+func (c *capsFile) StringCap(which CapType) (ret string) {
+	return mkStringCap(c, which)
+}
+
+func (c *capsFile) String() (ret string) {
+	return mkString(c, INHERITABLE)
+}
+
+func (c *capsFile) Load() (err error) {
+	return getVfsCap(c.path, &c.data)
+}
+
+func (c *capsFile) Apply(kind CapType) (err error) {
+	if kind&CAPS == CAPS {
+		return setVfsCap(c.path, &c.data)
+	}
+	return
+}

--- a/vendor/src/github.com/syndtr/gocapability/capability/capability_noop.go
+++ b/vendor/src/github.com/syndtr/gocapability/capability/capability_noop.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// +build !linux
+
+package capability
+
+import "errors"
+
+func newPid(pid int) (Capabilities, error) {
+	return nil, errors.New("not supported")
+}
+
+func newFile(path string) (Capabilities, error) {
+	return nil, errors.New("not supported")
+}

--- a/vendor/src/github.com/syndtr/gocapability/capability/capability_test.go
+++ b/vendor/src/github.com/syndtr/gocapability/capability/capability_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package capability
+
+import "testing"
+
+func TestState(t *testing.T) {
+	testEmpty := func(name string, c Capabilities, whats CapType) {
+		for i := CapType(1); i <= BOUNDING; i <<= 1 {
+			if (i&whats) != 0 && !c.Empty(i) {
+				t.Errorf(name+": capabilities set %q wasn't empty", i)
+			}
+		}
+	}
+	testFull := func(name string, c Capabilities, whats CapType) {
+		for i := CapType(1); i <= BOUNDING; i <<= 1 {
+			if (i&whats) != 0 && !c.Full(i) {
+				t.Errorf(name+": capabilities set %q wasn't full", i)
+			}
+		}
+	}
+	testPartial := func(name string, c Capabilities, whats CapType) {
+		for i := CapType(1); i <= BOUNDING; i <<= 1 {
+			if (i&whats) != 0 && (c.Empty(i) || c.Full(i)) {
+				t.Errorf(name+": capabilities set %q wasn't partial", i)
+			}
+		}
+	}
+	testGet := func(name string, c Capabilities, whats CapType, max Cap) {
+		for i := CapType(1); i <= BOUNDING; i <<= 1 {
+			if (i & whats) == 0 {
+				continue
+			}
+			for j := Cap(0); j <= max; j++ {
+				if !c.Get(i, j) {
+					t.Errorf(name+": capability %q wasn't found on %q", j, i)
+				}
+			}
+		}
+	}
+
+	capf := new(capsFile)
+	capf.data.version = 2
+	for _, tc := range []struct {
+		name string
+		c    Capabilities
+		sets CapType
+		max  Cap
+	}{
+		{"v1", new(capsV1), EFFECTIVE | PERMITTED, CAP_AUDIT_CONTROL},
+		{"v3", new(capsV3), EFFECTIVE | PERMITTED | BOUNDING, CAP_LAST_CAP},
+		{"file_v1", new(capsFile), EFFECTIVE | PERMITTED, CAP_AUDIT_CONTROL},
+		{"file_v2", capf, EFFECTIVE | PERMITTED, CAP_LAST_CAP},
+	} {
+		testEmpty(tc.name, tc.c, tc.sets)
+		tc.c.Fill(CAPS | BOUNDS)
+		testFull(tc.name, tc.c, tc.sets)
+		testGet(tc.name, tc.c, tc.sets, tc.max)
+		tc.c.Clear(CAPS | BOUNDS)
+		testEmpty(tc.name, tc.c, tc.sets)
+		for i := CapType(1); i <= BOUNDING; i <<= 1 {
+			for j := Cap(0); j <= CAP_LAST_CAP; j++ {
+				tc.c.Set(i, j)
+			}
+		}
+		testFull(tc.name, tc.c, tc.sets)
+		testGet(tc.name, tc.c, tc.sets, tc.max)
+		for i := CapType(1); i <= BOUNDING; i <<= 1 {
+			for j := Cap(0); j <= CAP_LAST_CAP; j++ {
+				tc.c.Unset(i, j)
+			}
+		}
+		testEmpty(tc.name, tc.c, tc.sets)
+		tc.c.Set(PERMITTED, CAP_CHOWN)
+		testPartial(tc.name, tc.c, PERMITTED)
+		tc.c.Clear(CAPS | BOUNDS)
+		testEmpty(tc.name, tc.c, tc.sets)
+	}
+}

--- a/vendor/src/github.com/syndtr/gocapability/capability/enum.go
+++ b/vendor/src/github.com/syndtr/gocapability/capability/enum.go
@@ -1,0 +1,338 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package capability
+
+type CapType uint
+
+func (c CapType) String() string {
+	switch c {
+	case EFFECTIVE:
+		return "effective"
+	case PERMITTED:
+		return "permitted"
+	case INHERITABLE:
+		return "inheritable"
+	case BOUNDING:
+		return "bounding"
+	case CAPS:
+		return "caps"
+	}
+	return "unknown"
+}
+
+const (
+	EFFECTIVE CapType = 1 << iota
+	PERMITTED
+	INHERITABLE
+	BOUNDING
+
+	CAPS   = EFFECTIVE | PERMITTED | INHERITABLE
+	BOUNDS = BOUNDING
+)
+
+type Cap int
+
+func (c Cap) String() string {
+	switch c {
+	case CAP_CHOWN:
+		return "chown"
+	case CAP_DAC_OVERRIDE:
+		return "dac_override"
+	case CAP_DAC_READ_SEARCH:
+		return "dac_read_search"
+	case CAP_FOWNER:
+		return "fowner"
+	case CAP_FSETID:
+		return "fsetid"
+	case CAP_KILL:
+		return "kill"
+	case CAP_SETGID:
+		return "setgid"
+	case CAP_SETUID:
+		return "setuid"
+	case CAP_SETPCAP:
+		return "setpcap"
+	case CAP_LINUX_IMMUTABLE:
+		return "linux_immutable"
+	case CAP_NET_BIND_SERVICE:
+		return "net_bind_service"
+	case CAP_NET_BROADCAST:
+		return "net_broadcast"
+	case CAP_NET_ADMIN:
+		return "net_admin"
+	case CAP_NET_RAW:
+		return "net_raw"
+	case CAP_IPC_LOCK:
+		return "ipc_lock"
+	case CAP_IPC_OWNER:
+		return "ipc_owner"
+	case CAP_SYS_MODULE:
+		return "sys_module"
+	case CAP_SYS_RAWIO:
+		return "sys_rawio"
+	case CAP_SYS_CHROOT:
+		return "sys_chroot"
+	case CAP_SYS_PTRACE:
+		return "sys_ptrace"
+	case CAP_SYS_PACCT:
+		return "sys_psacct"
+	case CAP_SYS_ADMIN:
+		return "sys_admin"
+	case CAP_SYS_BOOT:
+		return "sys_boot"
+	case CAP_SYS_NICE:
+		return "sys_nice"
+	case CAP_SYS_RESOURCE:
+		return "sys_resource"
+	case CAP_SYS_TIME:
+		return "sys_time"
+	case CAP_SYS_TTY_CONFIG:
+		return "sys_tty_config"
+	case CAP_MKNOD:
+		return "mknod"
+	case CAP_LEASE:
+		return "lease"
+	case CAP_AUDIT_WRITE:
+		return "audit_write"
+	case CAP_AUDIT_CONTROL:
+		return "audit_control"
+	case CAP_SETFCAP:
+		return "setfcap"
+	case CAP_MAC_OVERRIDE:
+		return "mac_override"
+	case CAP_MAC_ADMIN:
+		return "mac_admin"
+	case CAP_SYSLOG:
+		return "syslog"
+	case CAP_WAKE_ALARM:
+		return "wake_alarm"
+	case CAP_BLOCK_SUSPEND:
+		return "block_suspend"
+	}
+	return "unknown"
+}
+
+const (
+	// POSIX-draft defined capabilities.
+
+	// In a system with the [_POSIX_CHOWN_RESTRICTED] option defined, this
+	// overrides the restriction of changing file ownership and group
+	// ownership.
+	CAP_CHOWN Cap = 0
+
+	// Override all DAC access, including ACL execute access if
+	// [_POSIX_ACL] is defined. Excluding DAC access covered by
+	// CAP_LINUX_IMMUTABLE.
+	CAP_DAC_OVERRIDE Cap = 1
+
+	// Overrides all DAC restrictions regarding read and search on files
+	// and directories, including ACL restrictions if [_POSIX_ACL] is
+	// defined. Excluding DAC access covered by CAP_LINUX_IMMUTABLE.
+	CAP_DAC_READ_SEARCH Cap = 2
+
+	// Overrides all restrictions about allowed operations on files, where
+	// file owner ID must be equal to the user ID, except where CAP_FSETID
+	// is applicable. It doesn't override MAC and DAC restrictions.
+	CAP_FOWNER Cap = 3
+
+	// Overrides the following restrictions that the effective user ID
+	// shall match the file owner ID when setting the S_ISUID and S_ISGID
+	// bits on that file; that the effective group ID (or one of the
+	// supplementary group IDs) shall match the file owner ID when setting
+	// the S_ISGID bit on that file; that the S_ISUID and S_ISGID bits are
+	// cleared on successful return from chown(2) (not implemented).
+	CAP_FSETID Cap = 4
+
+	// Overrides the restriction that the real or effective user ID of a
+	// process sending a signal must match the real or effective user ID
+	// of the process receiving the signal.
+	CAP_KILL Cap = 5
+
+	// Allows setgid(2) manipulation
+	// Allows setgroups(2)
+	// Allows forged gids on socket credentials passing.
+	CAP_SETGID Cap = 6
+
+	// Allows set*uid(2) manipulation (including fsuid).
+	// Allows forged pids on socket credentials passing.
+	CAP_SETUID Cap = 7
+
+	// Linux-specific capabilities
+
+	// Without VFS support for capabilities:
+	//   Transfer any capability in your permitted set to any pid,
+	//   remove any capability in your permitted set from any pid
+	// With VFS support for capabilities (neither of above, but)
+	//   Add any capability from current's capability bounding set
+	//     to the current process' inheritable set
+	//   Allow taking bits out of capability bounding set
+	//   Allow modification of the securebits for a process
+	CAP_SETPCAP Cap = 8
+
+	// Allow modification of S_IMMUTABLE and S_APPEND file attributes
+	CAP_LINUX_IMMUTABLE Cap = 9
+
+	// Allows binding to TCP/UDP sockets below 1024
+	// Allows binding to ATM VCIs below 32
+	CAP_NET_BIND_SERVICE Cap = 10
+
+	// Allow broadcasting, listen to multicast
+	CAP_NET_BROADCAST Cap = 11
+
+	// Allow interface configuration
+	// Allow administration of IP firewall, masquerading and accounting
+	// Allow setting debug option on sockets
+	// Allow modification of routing tables
+	// Allow setting arbitrary process / process group ownership on
+	// sockets
+	// Allow binding to any address for transparent proxying (also via NET_RAW)
+	// Allow setting TOS (type of service)
+	// Allow setting promiscuous mode
+	// Allow clearing driver statistics
+	// Allow multicasting
+	// Allow read/write of device-specific registers
+	// Allow activation of ATM control sockets
+	CAP_NET_ADMIN Cap = 12
+
+	// Allow use of RAW sockets
+	// Allow use of PACKET sockets
+	// Allow binding to any address for transparent proxying (also via NET_ADMIN)
+	CAP_NET_RAW Cap = 13
+
+	// Allow locking of shared memory segments
+	// Allow mlock and mlockall (which doesn't really have anything to do
+	// with IPC)
+	CAP_IPC_LOCK Cap = 14
+
+	// Override IPC ownership checks
+	CAP_IPC_OWNER Cap = 15
+
+	// Insert and remove kernel modules - modify kernel without limit
+	CAP_SYS_MODULE Cap = 16
+
+	// Allow ioperm/iopl access
+	// Allow sending USB messages to any device via /proc/bus/usb
+	CAP_SYS_RAWIO Cap = 17
+
+	// Allow use of chroot()
+	CAP_SYS_CHROOT Cap = 18
+
+	// Allow ptrace() of any process
+	CAP_SYS_PTRACE Cap = 19
+
+	// Allow configuration of process accounting
+	CAP_SYS_PACCT Cap = 20
+
+	// Allow configuration of the secure attention key
+	// Allow administration of the random device
+	// Allow examination and configuration of disk quotas
+	// Allow setting the domainname
+	// Allow setting the hostname
+	// Allow calling bdflush()
+	// Allow mount() and umount(), setting up new smb connection
+	// Allow some autofs root ioctls
+	// Allow nfsservctl
+	// Allow VM86_REQUEST_IRQ
+	// Allow to read/write pci config on alpha
+	// Allow irix_prctl on mips (setstacksize)
+	// Allow flushing all cache on m68k (sys_cacheflush)
+	// Allow removing semaphores
+	// Used instead of CAP_CHOWN to "chown" IPC message queues, semaphores
+	// and shared memory
+	// Allow locking/unlocking of shared memory segment
+	// Allow turning swap on/off
+	// Allow forged pids on socket credentials passing
+	// Allow setting readahead and flushing buffers on block devices
+	// Allow setting geometry in floppy driver
+	// Allow turning DMA on/off in xd driver
+	// Allow administration of md devices (mostly the above, but some
+	// extra ioctls)
+	// Allow tuning the ide driver
+	// Allow access to the nvram device
+	// Allow administration of apm_bios, serial and bttv (TV) device
+	// Allow manufacturer commands in isdn CAPI support driver
+	// Allow reading non-standardized portions of pci configuration space
+	// Allow DDI debug ioctl on sbpcd driver
+	// Allow setting up serial ports
+	// Allow sending raw qic-117 commands
+	// Allow enabling/disabling tagged queuing on SCSI controllers and sending
+	// arbitrary SCSI commands
+	// Allow setting encryption key on loopback filesystem
+	// Allow setting zone reclaim policy
+	CAP_SYS_ADMIN Cap = 21
+
+	// Allow use of reboot()
+	CAP_SYS_BOOT Cap = 22
+
+	// Allow raising priority and setting priority on other (different
+	// UID) processes
+	// Allow use of FIFO and round-robin (realtime) scheduling on own
+	// processes and setting the scheduling algorithm used by another
+	// process.
+	// Allow setting cpu affinity on other processes
+	CAP_SYS_NICE Cap = 23
+
+	// Override resource limits. Set resource limits.
+	// Override quota limits.
+	// Override reserved space on ext2 filesystem
+	// Modify data journaling mode on ext3 filesystem (uses journaling
+	// resources)
+	// NOTE: ext2 honors fsuid when checking for resource overrides, so
+	// you can override using fsuid too
+	// Override size restrictions on IPC message queues
+	// Allow more than 64hz interrupts from the real-time clock
+	// Override max number of consoles on console allocation
+	// Override max number of keymaps
+	CAP_SYS_RESOURCE Cap = 24
+
+	// Allow manipulation of system clock
+	// Allow irix_stime on mips
+	// Allow setting the real-time clock
+	CAP_SYS_TIME Cap = 25
+
+	// Allow configuration of tty devices
+	// Allow vhangup() of tty
+	CAP_SYS_TTY_CONFIG Cap = 26
+
+	// Allow the privileged aspects of mknod()
+	CAP_MKNOD Cap = 27
+
+	// Allow taking of leases on files
+	CAP_LEASE Cap = 28
+
+	CAP_AUDIT_WRITE   Cap = 29
+	CAP_AUDIT_CONTROL Cap = 30
+	CAP_SETFCAP       Cap = 31
+
+	// Override MAC access.
+	// The base kernel enforces no MAC policy.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based overrides of that policy, this is
+	// the capability it should use to do so.
+	CAP_MAC_OVERRIDE Cap = 32
+
+	// Allow MAC configuration or state changes.
+	// The base kernel requires no MAC configuration.
+	// An LSM may enforce a MAC policy, and if it does and it chooses
+	// to implement capability based checks on modifications to that
+	// policy or the data required to maintain it, this is the
+	// capability it should use to do so.
+	CAP_MAC_ADMIN Cap = 33
+
+	// Allow configuring the kernel's syslog (printk behaviour)
+	CAP_SYSLOG Cap = 34
+
+	// Allow triggering something that will wake the system
+	CAP_WAKE_ALARM Cap = 35
+
+	// Allow preventing system suspends
+	CAP_BLOCK_SUSPEND Cap = 36
+
+	CAP_LAST_CAP = CAP_BLOCK_SUSPEND
+)
+
+const capUpperMask = (uint32(1) << (uint(CAP_LAST_CAP) - 31)) - 1

--- a/vendor/src/github.com/syndtr/gocapability/capability/syscall_linux.go
+++ b/vendor/src/github.com/syndtr/gocapability/capability/syscall_linux.go
@@ -1,0 +1,143 @@
+// Copyright (c) 2013, Suryandaru Triandana <syndtr@gmail.com>
+// All rights reserved.
+//
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package capability
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+type capHeader struct {
+	version uint32
+	pid     int
+}
+
+type capData struct {
+	effective   uint32
+	permitted   uint32
+	inheritable uint32
+}
+
+func capget(hdr *capHeader, data *capData) (err error) {
+	_, _, e1 := syscall.Syscall(syscall.SYS_CAPGET, uintptr(unsafe.Pointer(hdr)), uintptr(unsafe.Pointer(data)), 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+func capset(hdr *capHeader, data *capData) (err error) {
+	_, _, e1 := syscall.Syscall(syscall.SYS_CAPSET, uintptr(unsafe.Pointer(hdr)), uintptr(unsafe.Pointer(data)), 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+func prctl(option int, arg2, arg3, arg4, arg5 uintptr) (err error) {
+	_, _, e1 := syscall.Syscall6(syscall.SYS_PRCTL, uintptr(option), arg2, arg3, arg4, arg5, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+const (
+	vfsXattrName = "security.capability"
+
+	vfsCapVerMask = 0xff000000
+	vfsCapVer1    = 0x01000000
+	vfsCapVer2    = 0x02000000
+
+	vfsCapFlagMask      = ^vfsCapVerMask
+	vfsCapFlageffective = 0x000001
+
+	vfscapDataSizeV1 = 4 * (1 + 2*1)
+	vfscapDataSizeV2 = 4 * (1 + 2*2)
+)
+
+type vfscapData struct {
+	magic uint32
+	data  [2]struct {
+		permitted   uint32
+		inheritable uint32
+	}
+	effective [2]uint32
+	version   int8
+}
+
+var (
+	_vfsXattrName *byte
+)
+
+func init() {
+	_vfsXattrName, _ = syscall.BytePtrFromString(vfsXattrName)
+}
+
+func getVfsCap(path string, dest *vfscapData) (err error) {
+	var _p0 *byte
+	_p0, err = syscall.BytePtrFromString(path)
+	if err != nil {
+		return
+	}
+	r0, _, e1 := syscall.Syscall6(syscall.SYS_GETXATTR, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_vfsXattrName)), uintptr(unsafe.Pointer(dest)), vfscapDataSizeV2, 0, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	switch dest.magic & vfsCapVerMask {
+	case vfsCapVer1:
+		dest.version = 1
+		if r0 != vfscapDataSizeV1 {
+			return syscall.EINVAL
+		}
+		dest.data[1].permitted = 0
+		dest.data[1].inheritable = 0
+	case vfsCapVer2:
+		dest.version = 2
+		if r0 != vfscapDataSizeV2 {
+			return syscall.EINVAL
+		}
+	default:
+		return syscall.EINVAL
+	}
+	if dest.magic&vfsCapFlageffective != 0 {
+		dest.effective[0] = dest.data[0].permitted | dest.data[0].inheritable
+		dest.effective[1] = dest.data[1].permitted | dest.data[1].inheritable
+	} else {
+		dest.effective[0] = 0
+		dest.effective[1] = 0
+	}
+	return
+}
+
+func setVfsCap(path string, data *vfscapData) (err error) {
+	var _p0 *byte
+	_p0, err = syscall.BytePtrFromString(path)
+	if err != nil {
+		return
+	}
+	var size uintptr
+	if data.version == 1 {
+		data.magic = vfsCapVer1
+		size = vfscapDataSizeV1
+	} else if data.version == 2 {
+		data.magic = vfsCapVer2
+		if data.effective[0] != 0 || data.effective[1] != 0 {
+			data.magic |= vfsCapFlageffective
+			data.data[0].permitted |= data.effective[0]
+			data.data[1].permitted |= data.effective[1]
+		}
+		size = vfscapDataSizeV2
+	} else {
+		return syscall.EINVAL
+	}
+	_, _, e1 := syscall.Syscall6(syscall.SYS_SETXATTR, uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(_vfsXattrName)), uintptr(unsafe.Pointer(data)), size, 0, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}


### PR DESCRIPTION
NOTE: This is kind of a big feature, so please let me know if this doesn't yet belong in a PR, or if it needs more discussion on the mailing list.  Also, the commits are already split up, but let me know if it makes sense to also split it up into multiple PRs.

If docker is going to work on libvirt-lxc (and thus be supported on RHEL), a long-running dockerinit is the only realistic way to achieve that (that I'm aware of it).  But it also gives other benefits.  Here's an excerpt from my email to the docker-dev mailing list:

The biggest challenges [when porting docker to libvirt-lxc] were:
- getting the exit code from the container
- getting separated stdout/stderr streams

Neither is supported by libvirt-lxc, so the only viable solution was to
create a long-running dockerinit which runs for the lifetime of the
container, with the container application as its child process.  Docker
then communicates with dockerinit over a UNIX socket.

Having a long-running dockerinit has other advantages as well:
- Removes the need for a Ghost state since we can always reconnect to
  the container for console connection, exit notification, and exit code
  reporting, even after a docker daemon restart.  This could even enable
  getting rid of the docker daemon altogether, and doing everything
  client-side.
- Moves a lot of code from the container backend plugins (e.g., lxc,
  libvirt-lxc, ...) into the docker core where it can be shared, which
  means more consistent behavior, better test coverage, simpler plugins.

/cc @alexlarsson @jpetazzo
