### PR TITLE
utils: remove dotcloud/tar dep

### DIFF
--- a/hack/infrastructure/docker-ci/docker-coverage/coverage-docker.sh
+++ b/hack/infrastructure/docker-ci/docker-coverage/coverage-docker.sh
@@ -23,7 +23,7 @@ cd $BASE_PATH/go
 GOPATH=$BASE_PATH/go go get github.com/axw/gocov/gocov
 sudo -E GOPATH=$GOPATH ./bin/gocov test -deps -exclude-goroot -v\
  -exclude github.com/gorilla/context,github.com/gorilla/mux,github.com/kr/pty,\
-code.google.com/p/go.net/websocket,github.com/dotcloud/tar\
+code.google.com/p/go.net/websocket\
  github.com/dotcloud/docker | ./bin/gocov report; exit_status=$?
 
 # Cleanup testing directory

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -27,8 +27,6 @@ git_clone github.com/gorilla/context/ 708054d61e5
 
 git_clone github.com/gorilla/mux/ 9b36453141c
 
-git_clone github.com/dotcloud/tar/ e5ea6bb21a
-
 # Docker requires code.google.com/p/go.net/websocket
 PKG=code.google.com/p/go.net REV=84a4013f96e0
 (

--- a/utils/tarsum.go
+++ b/utils/tarsum.go
@@ -5,7 +5,7 @@ import (
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
-	"github.com/dotcloud/tar"
+	"archive/tar"
 	"hash"
 	"io"
 	"sort"


### PR DESCRIPTION
to be committed once go1.2 is out.
