### PR TITLE
Lock state before we modify.

### DIFF
--- a/container.go
+++ b/container.go
@@ -1300,7 +1300,9 @@ func (container *Container) monitor() {
 	}
 
 	// Report status back
+	container.State.Lock()
 	container.State.setStopped(exitCode)
+	container.State.Unlock()
 
 	// Release the lock
 	close(container.waitLock)


### PR DESCRIPTION
When we start a container we lock state, we should do the same in stop.

Detected via -race.

See Issue #713
