### PR TITLE
Issue #880 - cache ADD commands in dockerfiles

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -68,6 +68,7 @@ Francisco Souza <f@souza.cc>
 Frederick F. Kautz IV <fkautz@alumni.cmu.edu>
 Gabriel Monroy <gabriel@opdemand.com>
 Gareth Rushgrove <gareth@morethanseven.net>
+Graydon Hoare <graydon@pobox.com>
 Greg Thornton <xdissent@me.com>
 Guillaume J. Charmes <guillaume.charmes@dotcloud.com>
 Gurjeet Singh <gurjeet@singh.im>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### Builder
+
+- ADD now uses image cache, based on sha256 of added content.
+
 ## 0.7.2 (2013-12-16)
 
 #### Runtime


### PR DESCRIPTION
This implements content-based caching of ADD commands in Dockerfiles, the subject of issue #880. It works for local files, file trees and remote URLs. It does not use `utils/tarsum.go` as that seemed inflexible and memory-intensive. This change also does not include more sophisticated cache control such as I suggested in the bug, such as a DEPEND command that scans file trees within the container or reads stdout/err of commands run. I may file some of those as followup bugs.

Comments / corrections welcome. It seems to work for me but I'm not sure how you'd like to test it. Could possibly add in mechanisms for observing cache hits or misses to `infrastructure/buildfile_test.go`, but I wanted to get a little feedback on the approach first.
