### PR TITLE
Add tgz bundlescript

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -37,6 +37,7 @@ DEFAULT_BUNDLES=(
 	test
 	dynbinary
 	dyntest
+	tgz
 	ubuntu
 )
 

--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+DEST="$1"
+BINARY="$DEST/../binary/docker-$VERSION"
+TGZ="$DEST/docker-$VERSION.tgz"
+
+set -e
+
+if [ ! -x "$BINARY" ]; then
+	echo >&2 'error: binary must be run before tgz'
+	false
+fi
+
+mkdir -p "$DEST/build"
+
+mkdir -p "$DEST/build/usr/local/bin"
+cp -L "$BINARY" "$DEST/build/usr/local/bin/docker"
+
+tar --numeric-owner --owner 0 -C "$DEST/build" -czf "$TGZ" usr
+
+rm -rf "$DEST/build"
+
+echo "Created tgz: $TGZ"


### PR DESCRIPTION
Closes #1675

Note that the exact URL for grabbing a specific version is changed from the old (and deprecated) "v" prefix intentionally, reflecting the change of the paths within from "docker-VERSION/docker" to "usr/local/bin/docker".

I was waiting for @shykes to review the tgz to make sure he was OK with the format, but I realized he can do that just as well (if not better) from a PR directly.

Here's some example output:
http://tianon-docker.s3.amazonaws.com/builds/Linux/x86_64/docker-0.6.6-dev.tgz
and/or
http://tianon-docker.s3.amazonaws.com/builds/Linux/x86_64/docker-latest.tgz
