### PR TITLE
Fixes #1852: Add proxy option

### DIFF
--- a/config.go
+++ b/config.go
@@ -16,6 +16,7 @@ type DaemonConfig struct {
 	BridgeIface                 string
 	DefaultIp                   net.IP
 	InterContainerCommunication bool
+	ProxyUrl                    string
 }
 
 // ConfigFromJob creates and returns a new DaemonConfig object
@@ -37,5 +38,6 @@ func ConfigFromJob(job *engine.Job) *DaemonConfig {
 	}
 	config.DefaultIp = net.ParseIP(job.Getenv("DefaultIp"))
 	config.InterContainerCommunication = job.GetenvBool("InterContainerCommunication")
+	config.ProxyUrl = job.Getenv("ProxyUrl")
 	return &config
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -38,6 +38,7 @@ func main() {
 	flEnableIptables := flag.Bool("iptables", true, "Disable iptables within docker")
 	flDefaultIp := flag.String("ip", "0.0.0.0", "Default ip address to use when binding a containers ports")
 	flInterContainerComm := flag.Bool("icc", true, "Enable inter-container communication")
+	flProxyUrl := flag.String("proxy", "", "Set http proxy url")
 
 	flag.Parse()
 
@@ -82,6 +83,7 @@ func main() {
 		job.Setenv("BridgeIface", *bridgeName)
 		job.Setenv("DefaultIp", *flDefaultIp)
 		job.SetenvBool("InterContainerCommunication", *flInterContainerComm)
+		job.Setenv("ProxyUrl", *flProxyUrl)
 		if err := job.Run(); err != nil {
 			log.Fatal(err)
 		}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -647,10 +647,19 @@ type Registry struct {
 	reqFactory *utils.HTTPRequestFactory
 }
 
-func NewRegistry(root string, authConfig *auth.AuthConfig, factory *utils.HTTPRequestFactory) (r *Registry, err error) {
+func NewRegistry(root, proxy string, authConfig *auth.AuthConfig, factory *utils.HTTPRequestFactory) (r *Registry, err error) {
+	proxyFunc := http.ProxyFromEnvironment
+
+	if proxy != "" {
+		u, err := url.Parse(proxy)
+		if err == nil {
+			proxyFunc = http.ProxyURL(u)
+		}
+	}
+
 	httpTransport := &http.Transport{
 		DisableKeepAlives: true,
-		Proxy:             http.ProxyFromEnvironment,
+		Proxy:             proxyFunc,
 	}
 
 	r = &Registry{

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -15,7 +15,7 @@ var (
 
 func spawnTestRegistry(t *testing.T) *Registry {
 	authConfig := &auth.AuthConfig{}
-	r, err := NewRegistry("", authConfig, utils.NewHTTPRequestFactory())
+	r, err := NewRegistry("", "", authConfig, utils.NewHTTPRequestFactory())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server.go
+++ b/server.go
@@ -417,7 +417,7 @@ func (srv *Server) recursiveLoad(address, tmpImageDir string) error {
 }
 
 func (srv *Server) ImagesSearch(term string) ([]registry.SearchResult, error) {
-	r, err := registry.NewRegistry(srv.runtime.config.Root, nil, srv.HTTPRequestFactory(nil))
+	r, err := registry.NewRegistry(srv.runtime.config.Root, srv.runtime.config.ProxyUrl, nil, srv.HTTPRequestFactory(nil))
 	if err != nil {
 		return nil, err
 	}
@@ -973,7 +973,7 @@ func (srv *Server) poolRemove(kind, key string) error {
 }
 
 func (srv *Server) ImagePull(localName string, tag string, out io.Writer, sf *utils.StreamFormatter, authConfig *auth.AuthConfig, metaHeaders map[string][]string, parallel bool) error {
-	r, err := registry.NewRegistry(srv.runtime.config.Root, authConfig, srv.HTTPRequestFactory(metaHeaders))
+	r, err := registry.NewRegistry(srv.runtime.config.Root, srv.runtime.config.ProxyUrl, authConfig, srv.HTTPRequestFactory(metaHeaders))
 	if err != nil {
 		return err
 	}
@@ -1185,7 +1185,7 @@ func (srv *Server) ImagePush(localName string, out io.Writer, sf *utils.StreamFo
 
 	out = utils.NewWriteFlusher(out)
 	img, err := srv.runtime.graph.Get(localName)
-	r, err2 := registry.NewRegistry(srv.runtime.config.Root, authConfig, srv.HTTPRequestFactory(metaHeaders))
+	r, err2 := registry.NewRegistry(srv.runtime.config.Root, srv.runtime.config.ProxyUrl, authConfig, srv.HTTPRequestFactory(metaHeaders))
 	if err2 != nil {
 		return err2
 	}


### PR DESCRIPTION
Docker daemon process cannot see proxy setting from environment.
Or upstart has not provided environment variables.

This patch provides the option "-proxy".
User can set this via DOCKER_OPTS in /etc/default/docker
