### PR TITLE
Corrects misspellings of 'Sphinx'

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -136,7 +136,7 @@ Manpages
 --------
 
 * To make the manpages, run ``make man``. Please note there is a bug
-  in spinx 1.1.3 which makes this fail.  Upgrade to the latest version
+  in Sphinx 1.1.3 which makes this fail.  Upgrade to the latest version
   of Sphinx.
 * Then preview the manpage by running ``man _build/man/docker.1``,
   where ``_build/man/docker.1`` is the path to the generated manfile

--- a/docs/theme/docker/layout.html
+++ b/docs/theme/docker/layout.html
@@ -35,7 +35,7 @@
     %}
 
     {#
-        This part is hopefully complex because things like |cut '/index/' are not available in spinx jinja
+        This part is hopefully complex because things like |cut '/index/' are not available in Sphinx jinja
         and will make it crash. (and we need index/ out.
     #}
     <link rel="canonical" href="http://docs.docker.io/en/latest/


### PR DESCRIPTION
"Sphinx" is misspelled as "Spinx" a few times. Not anymore!
