### PR TITLE
Fix data race in TestLogEvent

### DIFF
--- a/api.go
+++ b/api.go
@@ -254,7 +254,7 @@ func getEvents(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 	wf.Flush()
 	if since != 0 {
 		// If since, send previous events that happened after the timestamp
-		for _, event := range srv.events {
+		for _, event := range srv.GetEvents() {
 			if event.Time >= since {
 				err := sendEvent(wf, &event)
 				if err != nil && err.Error() == "JSON error" {

--- a/server_unit_test.go
+++ b/server_unit_test.go
@@ -70,8 +70,9 @@ func TestLogEvent(t *testing.T) {
 
 	srv.LogEvent("fakeaction2", "fakeid", "fakeimage")
 
-	if len(srv.events) != 2 {
-		t.Fatalf("Expected 2 events, found %d", len(srv.events))
+	numEvents := len(srv.GetEvents())
+	if numEvents != 2 {
+		t.Fatalf("Expected 2 events, found %d", numEvents)
 	}
 	go func() {
 		time.Sleep(200 * time.Millisecond)
@@ -83,7 +84,7 @@ func TestLogEvent(t *testing.T) {
 	setTimeout(t, "Listening for events timed out", 2*time.Second, func() {
 		for i := 2; i < 4; i++ {
 			event := <-listener
-			if event != srv.events[i] {
+			if event != srv.GetEvents()[i] {
 				t.Fatalf("Event received it different than expected")
 			}
 		}


### PR DESCRIPTION
Found with -race. Improve locking on Server.

```
==================
WARNING: DATA RACE
Write by goroutine 61:
  github.com/dotcloud/docker.(*Server).LogEvent()
      /go/src/github.com/dotcloud/docker/server.go:1846 +0x262
  github.com/dotcloud/docker.func·059()
      /go/src/github.com/dotcloud/docker/server_unit_test.go:80 +0x105

Previous read by goroutine 63:
  github.com/dotcloud/docker.func·060()
      /go/src/github.com/dotcloud/docker/server_unit_test.go:86 +0x116
  github.com/dotcloud/docker.func·062()
      /go/src/github.com/dotcloud/docker/server_unit_test.go:103 +0x4e

Goroutine 61 (running) created at:
  github.com/dotcloud/docker.TestLogEvent()
      /go/src/github.com/dotcloud/docker/server_unit_test.go:81 +0x49a
  testing.tRunner()
      /usr/local/go/src/pkg/testing/testing.go:391 +0x10f

Goroutine 63 (running) created at:
  github.com/dotcloud/docker.setTimeout()
      /go/src/github.com/dotcloud/docker/server_unit_test.go:105 +0x191
  github.com/dotcloud/docker.TestLogEvent()
      /go/src/github.com/dotcloud/docker/server_unit_test.go:90 +0x55a
  testing.tRunner()
      /usr/local/go/src/pkg/testing/testing.go:391 +0x10f
==================
--- PASS: TestLogEvent (0.40 seconds)
=== RUN TestSortUniquePorts
--- PASS: TestSortUniquePorts (0.00 seconds)
=== RUN TestSortSamePortWithDifferentProto
--- PASS: TestSortSamePortWithDifferentProto (0.00 seconds)
=== RUN TestLookupImage
--- PASS: TestLookupImage (0.02 seconds)
PASS
Found 1 data race(s)
```
