### PR TITLE
Deleted references to AUFS in Arch docs

### DIFF
--- a/docs/sources/installation/archlinux.rst
+++ b/docs/sources/installation/archlinux.rst
@@ -12,25 +12,27 @@ Arch Linux
 .. include:: install_unofficial.inc
 
 Installing on Arch Linux is not officially supported but can be handled via 
-either of the following AUR packages:
+one of the following AUR packages:
 
 * `lxc-docker <https://aur.archlinux.org/packages/lxc-docker/>`_
 * `lxc-docker-git <https://aur.archlinux.org/packages/lxc-docker-git/>`_
+* `lxc-docker-nightly <https://aur.archlinux.org/packages/lxc-docker-nightly/>`_
 
 The lxc-docker package will install the latest tagged version of docker. 
 The lxc-docker-git package will build from the current master branch.
+The lxc-docker-nightly package will install the latest build.
 
 Dependencies
 ------------
 
 Docker depends on several packages which are specified as dependencies in
-either AUR package.
+the AUR packages. The core dependencies are:
 
 * bridge-utils
 * device-mapper
-* go
 * iproute2
 * lxc
+
 
 Installation
 ------------
@@ -42,7 +44,7 @@ done so before.
 
 ::
 
-    yaourt -S lxc-docker-git
+    yaourt -S lxc-docker
 
 
 Starting Docker

--- a/docs/sources/installation/archlinux.rst
+++ b/docs/sources/installation/archlinux.rst
@@ -30,7 +30,6 @@ either AUR package.
 * bridge-utils
 * go
 * iproute2
-* linux-aufs_friendly
 * lxc
 
 Installation
@@ -41,9 +40,6 @@ The instructions here assume **yaourt** is installed.  See
 for information on building and installing packages from the AUR if you have not
 done so before.
 
-Keep in mind that if **linux-aufs_friendly** is not already installed that a
-new kernel will be compiled and this can take quite a while.
-
 ::
 
     yaourt -S lxc-docker-git
@@ -51,9 +47,6 @@ new kernel will be compiled and this can take quite a while.
 
 Starting Docker
 ---------------
-
-Prior to starting docker modify your bootloader to use the 
-**linux-aufs_friendly** kernel and reboot your system.
 
 There is a systemd service unit created for docker.  To start the docker service:
 

--- a/docs/sources/installation/archlinux.rst
+++ b/docs/sources/installation/archlinux.rst
@@ -26,8 +26,8 @@ Dependencies
 Docker depends on several packages which are specified as dependencies in
 either AUR package.
 
-* aufs3
 * bridge-utils
+* device-mapper
 * go
 * iproute2
 * lxc


### PR DESCRIPTION
AUFS is no longer a dependency (both lxc-docker and lxc-docker-git AUR packages are >=0.7), and the Arch kernel doesn't need to be replaced with AUFS_friendly.
