### PR TITLE
Update the "docker attach" section of the Hello World example

### DIFF
--- a/docs/sources/examples/hello_world.rst
+++ b/docs/sources/examples/hello_world.rst
@@ -131,8 +131,6 @@ Attach to the container to see the results in real-time.
 
 - **"docker attach**" This will allow us to attach to a background
   process to see what is going on.
-- **"-sig-proxy=true"** Proxify all received signal to the process
-  (even in non-tty mode)
 - **$CONTAINER_ID** The Id of the container we want to attach too.
 
 Exit from the container attachment by pressing Control-C.


### PR DESCRIPTION
This removes the description about "-sig-proxy=true" from the example in Hello, World.  I removed this from the example because it is not currently being used in the example when you use "docker attach".  Having the description for an option that is not being used in the Hello, World example is confusing for new learners of Docker.
