### PR TITLE
Help identify you are in a Docker container

### DIFF
--- a/container.go
+++ b/container.go
@@ -590,6 +590,7 @@ func (container *Container) Start() (err error) {
 	env := []string{
 		"HOME=/",
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		"container_manager=docker",
 		"HOSTNAME=" + container.Config.Hostname,
 	}
 

--- a/integration/container_test.go
+++ b/integration/container_test.go
@@ -1045,6 +1045,7 @@ func TestEnv(t *testing.T) {
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"HOME=/",
 		"container=lxc",
+		"container_manager=docker",
 		"HOSTNAME=" + utils.TruncateID(container.ID),
 		"FALSE=true",
 		"TRUE=false",


### PR DESCRIPTION
Add environment variable:

```
docker=true
```

This will provide a mechanism for tools like Facter and Ohai to identify that they are running in a Docker container.

See http://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/.
Thanks to Paul Nasrat for the pointer to this.
