### PR TITLE
Stop invalid calls to Registry

### DIFF
--- a/server.go
+++ b/server.go
@@ -1011,15 +1011,8 @@ func (srv *Server) ImagePull(localName string, tag string, out io.Writer, sf *ut
 		localName = remoteName
 	}
 
-	err = srv.pullRepository(r, out, localName, remoteName, tag, endpoint, sf, parallel)
-	if err == registry.ErrLoginRequired {
+	if err = srv.pullRepository(r, out, localName, remoteName, tag, endpoint, sf, parallel); err != nil {
 		return err
-	}
-	if err != nil {
-		if err := srv.pullImage(r, out, remoteName, endpoint, nil, sf); err != nil {
-			return err
-		}
-		return nil
 	}
 
 	return nil


### PR DESCRIPTION
This code was resulting in a call for
`/v1/images/<namespace>/<repository>/ancestry` which the Registry
doesn't understand. Furthermore, it was masking the original
error.

Fixes #2940
