### PR TITLE
Closing HTTP connection after Registry ping

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -47,6 +47,8 @@ func pingRegistryEndpoint(endpoint string) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close() 
+
 	if resp.Header.Get("X-Docker-Registry-Version") == "" {
 		return errors.New("This does not look like a Registry server (\"X-Docker-Registry-Version\" header not found in the response)")
 	}


### PR DESCRIPTION
Pinging the registry (`/v1/_ping`) doesn't close the socket, leaving lots of sockets in CLOSE_WAIT.
