### PR TITLE
Fixes: Building docker in Virtualbox fails

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -151,6 +151,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     override.vm.provision :shell, :inline => $vbox_script
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
   end
 end
 


### PR DESCRIPTION
Building docker in virtualbox fails since the machine has not enough memory. 

Error: 

```
sudo docker run -privileged -v `pwd`:/go/src/github.com/dotcloud/docker docker 

---> Making bundle: binary (in bundles/0.7.0-dev/binary)
# github.com/dotcloud/docker/docker
collect2: ld terminated with signal 9 [Killed]
```
