### PR TITLE
Allow non-privileged containers to create device nodes.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -177,6 +177,7 @@ Keli Hu <dev@keli.hu>
 Ken Cochrane <kencochrane@gmail.com>
 Kevin Clark <kevin.clark@gmail.com>
 Kevin J. Lynagh <kevin@keminglabs.com>
+Kevin Wallace <kevin@pentabarf.net>
 Keyvan Fatehi <keyvanfatehi@gmail.com>
 kim0 <email.ahmedkamal@googlemail.com>
 Kim BKC Carlbacker <kim.carlbacker@gmail.com>

--- a/execdriver/lxc/init.go
+++ b/execdriver/lxc/init.go
@@ -114,7 +114,6 @@ func setupCapabilities(args *execdriver.InitArgs) error {
 		capability.CAP_SYS_RESOURCE,
 		capability.CAP_SYS_TIME,
 		capability.CAP_SYS_TTY_CONFIG,
-		capability.CAP_MKNOD,
 		capability.CAP_AUDIT_WRITE,
 		capability.CAP_AUDIT_CONTROL,
 		capability.CAP_MAC_OVERRIDE,

--- a/execdriver/lxc/lxc_template.go
+++ b/execdriver/lxc/lxc_template.go
@@ -39,6 +39,10 @@ lxc.cgroup.devices.allow = a
 # no implicit access to devices
 lxc.cgroup.devices.deny = a
 
+# but allow mknod for any device
+lxc.cgroup.devices.allow = c *:* m
+lxc.cgroup.devices.allow = b *:* m
+
 # /dev/null and zero
 lxc.cgroup.devices.allow = c 1:3 rwm
 lxc.cgroup.devices.allow = c 1:5 rwm

--- a/execdriver/native/default_template.go
+++ b/execdriver/native/default_template.go
@@ -65,7 +65,6 @@ func getDefaultTemplate() *libcontainer.Container {
 			libcontainer.GetCapability("SYS_RESOURCE"),
 			libcontainer.GetCapability("SYS_TIME"),
 			libcontainer.GetCapability("SYS_TTY_CONFIG"),
-			libcontainer.GetCapability("MKNOD"),
 			libcontainer.GetCapability("AUDIT_WRITE"),
 			libcontainer.GetCapability("AUDIT_CONTROL"),
 			libcontainer.GetCapability("MAC_OVERRIDE"),

--- a/integration/container_test.go
+++ b/integration/container_test.go
@@ -1594,16 +1594,16 @@ func TestPrivilegedCanMount(t *testing.T) {
 	}
 }
 
-func TestPrivilegedCannotMknod(t *testing.T) {
+func TestUnprivilegedCanMknod(t *testing.T) {
 	eng := NewTestEngine(t)
 	runtime := mkRuntimeFromEngine(eng, t)
 	defer runtime.Nuke()
-	if output, _ := runContainer(eng, runtime, []string{"_", "sh", "-c", "mknod /tmp/sda b 8 0 || echo ok"}, t); output != "ok\n" {
-		t.Fatal("Could mknod into secure container")
+	if output, _ := runContainer(eng, runtime, []string{"_", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok"}, t); output != "ok\n" {
+		t.Fatal("Couldn't mknod into secure container")
 	}
 }
 
-func TestPrivilegedCannotMount(t *testing.T) {
+func TestUnprivilegedCannotMount(t *testing.T) {
 	eng := NewTestEngine(t)
 	runtime := mkRuntimeFromEngine(eng, t)
 	defer runtime.Nuke()

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -171,6 +171,10 @@ func (c *Cgroup) setupDevices(cgroupRoot string, pid int) (err error) {
 		}
 
 		allow := []string{
+			// allow mknod for any device
+			"c *:* m",
+			"b *:* m",
+
 			// /dev/null, zero, full
 			"c 1:3 rwm",
 			"c 1:5 rwm",


### PR DESCRIPTION
Allow non-privileged containers to create device nodes.

Such nodes could already be created by importing a tarball to a container; now
they can be created from within the container itself.

This gives non-privileged containers the mknod kernel capability, and modifies
their cgroup settings to allow creation of _any_ node, not just whitelisted
ones.  Use of such nodes is still controlled by the existing cgroup whitelist.

Fixes #2191
