### PR TITLE
Remove "-v" from "go test" (since it's easy to add back manually via TESTFLAGS)

### DIFF
--- a/hack/make/dyntest
+++ b/hack/make/dyntest
@@ -34,7 +34,7 @@ bundle_test() {
 				
 				# Run the tests with the optional $TESTFLAGS.
 				export TEST_DOCKERINIT_PATH=$DEST/../dynbinary/dockerinit-$VERSION
-				go test -v -ldflags "$LDFLAGS -X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\"" $BUILDFLAGS $TESTFLAGS
+				go test -ldflags "$LDFLAGS -X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\"" $BUILDFLAGS $TESTFLAGS
 			); then
 				TESTS_FAILED+=("$test_dir")
 				sleep 1 # give it a second, so observers watching can take note

--- a/hack/make/test
+++ b/hack/make/test
@@ -27,7 +27,7 @@ bundle_test() {
 				go test -i -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS
 				
 				# Run the tests with the optional $TESTFLAGS.
-				go test -v -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS $TESTFLAGS
+				go test -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS $TESTFLAGS
 			); then
 				TESTS_FAILED+=("$test_dir")
 				sleep 1 # give it a second, so observers watching can take note


### PR DESCRIPTION
@creack - you were too slow :)

Fixes #2806
