### PR TITLE
Add udev rules files for hiding the docker loopback devices from udisks

### DIFF
--- a/contrib/udev/80-docker.rules
+++ b/contrib/udev/80-docker.rules
@@ -1,0 +1,3 @@
+# hide docker's loopback devices from udisks, and thus from user desktops
+SUBSYSTEM=="block", ENV{DM_NAME}=="docker-*", ENV{UDISKS_PRESENTATION_HIDE}="1", ENV{UDISKS_IGNORE}="1"
+SUBSYSTEM=="block", DEVPATH=="/devices/virtual/block/loop*", ATTR{loop/backing_file}=="/var/lib/docker/*", ENV{UDISKS_PRESENTATION_HIDE}="1", ENV{UDISKS_IGNORE}="1"


### PR DESCRIPTION
This prevents them from showing up on the desktop in a window manager, for example.

@lsm5 was the one who committed this to the Fedora specfile, but he tells me @alexlarsson is really to blame for figuring it through originally; major kudos.  I'm adding it to contrib so everyone can benefit (with a separate file for udisks1 vs udisks2, since they use different environment variables). :+1:

The Fedora guys have tested against udisks2, and I've tested against udisks1 with great success. :+1:
