### PR TITLE
check on the client side that there is a Dockerfile

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -195,6 +195,10 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		if _, err := os.Stat(cmd.Arg(0)); err != nil {
 			return err
 		}
+		filename := path.Join(cmd.Arg(0), "Dockerfile")
+		if _, err = os.Stat(filename); os.IsNotExist(err) {
+			return fmt.Errorf("no Dockerfile found in %s", cmd.Arg(0))
+		}
 		context, err = archive.Tar(cmd.Arg(0), archive.Uncompressed)
 	}
 	var body io.Reader


### PR DESCRIPTION
 so we don't upload a huge stack of files, only to realise we can't do anything

Closes #2319

I think that i count 3 places in the code that have the literal string `Dockerfile` - I wonder if thats getting to a DRYlimit.

at the moment, i feel that if you put a Dockerfile into `/`, then you are expecting docker to tar up your complete fs - I'm sure as I do more `dind`, i might change my opinion :)
