### PR TITLE
API documentation: added format of Volumes and Binds parameters to "create" and "start" 

### DIFF
--- a/docs/sources/api/docker_remote_api_v1.7.rst
+++ b/docs/sources/api/docker_remote_api_v1.7.rst
@@ -132,7 +132,9 @@ Create a container
 		],
 		"Dns":null,
 		"Image":"base",
-		"Volumes":{},
+		"Volumes":{
+			"/tmp": {}
+		},
 		"VolumesFrom":"",
 		"WorkingDir":""
 
@@ -361,8 +363,12 @@ Start a container
 
            {
                 "Binds":["/tmp:/tmp"],
-                "LxcConf":{"lxc.utsname":"docker"}
+                "LxcConf":{"lxc.utsname":"docker"},
+                "PortBindings":null
+                "PublishAllPorts":false
            }
+           
+        Binds need to reference Volumes that were defined during container creation.
 
         **Example response**:
 


### PR DESCRIPTION
API documentation clarifications:
- Added sample Volumes parameter to container create API.
- Added PortBindings and PublishAllPorts parameter to container start API
- Added note to container start about Binds needed to be declared as Volumes during container create.
