### PR TITLE
Update bundlescript shebangs to be bash, reflecting how they're actually invoked

### DIFF
--- a/hack/make/binary
+++ b/hack/make/binary
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DEST=$1
 

--- a/hack/make/dynbinary
+++ b/hack/make/dynbinary
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DEST=$1
 

--- a/hack/make/dyntest
+++ b/hack/make/dyntest
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DEST=$1
 INIT=$DEST/../dynbinary/dockerinit-$VERSION

--- a/hack/make/test
+++ b/hack/make/test
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DEST=$1
 

--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DEST="$1"
 BINARY="$DEST/../binary/docker-$VERSION"

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DEST=$1
 


### PR DESCRIPTION
```
15:45:02  tianon:> they really are run as bash
15:45:05  tianon:> invoked within bash
...
15:46:37  tianon:> they get sourced directly within make.sh
15:46:39  tianon:> which is bash
15:46:46  tianon:> that's why those bash arrays work
15:46:50  tianon:> those definitely aren't posix :)
```

See https://github.com/dotcloud/docker/blob/master/hack/make.sh#L70 (and line one of make.sh, where it's clearly a bash script)
