### PR TITLE
Add cgroup-bin dependency to our Ubuntu package

### DIFF
--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -96,6 +96,7 @@ EOF
 		    --depends lxc \
 		    --depends aufs-tools \
 		    --depends iptables \
+		    --depends cgroup-bin \
 		    --description "$PACKAGE_DESCRIPTION" \
 		    --maintainer "$PACKAGE_MAINTAINER" \
 		    --conflicts lxc-docker-virtual-package \


### PR DESCRIPTION
Since cgroup-bin is only "recommended" by the lxc package on Ubuntu, but is necessary for having the proper cgroups mounted for Docker to function, this makes some sense for us to add separately.

Fixes #2990
