### PR TITLE
add an example of docker ps, and also of link aliases

### DIFF
--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -799,6 +799,15 @@ Known Issues (kill)
       -notrunc=false: Don't truncate output
       -q=false: Only display numeric IDs
 
+Running ``docker ps`` showing 2 linked containers.
+
+.. code-block:: bash
+
+    $ docker ps
+    CONTAINER ID        IMAGE                        COMMAND                CREATED              STATUS              PORTS               NAMES
+    4c01db0b339c        ubuntu:12.04                 bash                   17 seconds ago       Up 16 seconds                           webapp              
+    d7886598dbe2        crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db     
+
 .. _cli_pull:
 
 ``pull``

--- a/docs/sources/use/working_with_links_names.rst
+++ b/docs/sources/use/working_with_links_names.rst
@@ -54,9 +54,9 @@ inter-container communication is set to false.
 
 .. code-block:: bash
 
-    # Example: there is an image called redis-2.6 that exposes the port 6379 and starts redis-server.
+    # Example: there is an image called crosbymichael/redis that exposes the port 6379 and starts redis-server.
     # Let's name the container as "redis" based on that image and run it as daemon.
-    $ sudo docker run -d -name redis redis-2.6
+    $ sudo docker run -d -name redis crosbymichael/redis
 
 We can issue all the commands that you would expect using the name "redis"; start, stop,
 attach, using the name for our container. The name also allows us to link other containers
@@ -102,3 +102,12 @@ about the child container.
 
 Accessing the network information along with the environment of the child container allows
 us to easily connect to the Redis service on the specific IP and port in the environment.
+
+Running ``docker ps`` shows the 2 containers, and the webapp/db alias name for the redis container.
+
+.. code-block:: bash
+
+    $ docker ps
+    CONTAINER ID        IMAGE                        COMMAND                CREATED              STATUS              PORTS               NAMES
+    4c01db0b339c        ubuntu:12.04                 bash                   17 seconds ago       Up 16 seconds                           webapp              
+    d7886598dbe2        crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db     


### PR DESCRIPTION
a question from irc prompted me to add a little more info :)

@metalivedev

```
<jjjjjosh> does anyone know why, when you do `docker ps` the column is called "names" and not "name"?
<jjjjjosh> i'm mostly curious
* kennethreitz has quit (Quit: Textual IRC Client: www.textualapp.com)
* ngpestelos (~textual@122.53.113.50) has joined #docker
<jjjjjosh> i tried doing `sudo docker run -d -name foo -name bar ubuntu /bin/sh -c "while true; do echo Hello world; sleep 1; done"`
* mrunalp has quit (Ping timeout: 246 seconds)
<jjjjjosh> and it just takes the last name (so, "bar")
* siong1987 has quit (Quit: My MacBook has gone to sleep. ZZZzzz…)
* ccs (~ccs@c-76-126-102-42.hsd1.ca.comcast.net) has joined #docker
<jamesottaway> if you spawn another container and link it to the first, you'll see another name on the first container
<jamesottaway> so spawn foo, then spawn bar and link to foo
<jamesottaway> the names for foo will be 'foo' and 'bar/foo'
<jjjjjosh> awesome thanks!
```

<div class="discussion-labels">doc</div>
