### PR TITLE
Fixes #2909 - conditional compilation

### DIFF
--- a/btrfs.go
+++ b/btrfs.go
@@ -1,0 +1,29 @@
+// +build linux,386
+
+package docker
+
+/*
+#include <sys/ioctl.h>
+#include <linux/fs.h>
+#include <errno.h>
+
+// See linux.git/fs/btrfs/ioctl.h
+#define BTRFS_IOCTL_MAGIC 0x94
+#define BTRFS_IOC_CLONE _IOW(BTRFS_IOCTL_MAGIC, 9, int)
+
+int
+btrfs_reflink(int fd_out, int fd_in)
+{
+  int res;
+  res = ioctl(fd_out, BTRFS_IOC_CLONE, fd_in);
+  if (res < 0)
+    return errno;
+  return 0;
+}
+
+*/
+import "C"
+
+func btrfs_reflink(fd_out, fd_in uintptr) int {
+	return C.btrfs_reflink(C.int(fd_out), C.int(fd_in))
+}

--- a/btrfs_stub.go
+++ b/btrfs_stub.go
@@ -1,0 +1,7 @@
+// +build darwin
+
+package docker
+
+func btrfs_reflink(fd_out, fd_in uintptr) int {
+	return 255
+}

--- a/graphdriver/devmapper/attach_loopback.go
+++ b/graphdriver/devmapper/attach_loopback.go
@@ -1,3 +1,5 @@
+// +build linux,386
+
 package devmapper
 
 import (

--- a/graphdriver/devmapper/deviceset.go
+++ b/graphdriver/devmapper/deviceset.go
@@ -1,3 +1,5 @@
+// +build linux,386
+
 package devmapper
 
 import (

--- a/graphdriver/devmapper/devmapper.go
+++ b/graphdriver/devmapper/devmapper.go
@@ -1,3 +1,5 @@
+// +build linux,386
+
 package devmapper
 
 import (

--- a/graphdriver/devmapper/devmapper_log.go
+++ b/graphdriver/devmapper/devmapper_log.go
@@ -1,3 +1,5 @@
+// +build linux,386
+
 package devmapper
 
 import "C"

--- a/graphdriver/devmapper/devmapper_wrapper.go
+++ b/graphdriver/devmapper/devmapper_wrapper.go
@@ -1,3 +1,5 @@
+// +build linux,386
+
 package devmapper
 
 /*

--- a/graphdriver/devmapper/driver.go
+++ b/graphdriver/devmapper/driver.go
@@ -1,3 +1,5 @@
+// +build linux,386
+
 package devmapper
 
 import (

--- a/graphdriver/devmapper/ioctl.go
+++ b/graphdriver/devmapper/ioctl.go
@@ -1,3 +1,5 @@
+// +build linux,386
+
 package devmapper
 
 import (

--- a/graphdriver/devmapper/mount.go
+++ b/graphdriver/devmapper/mount.go
@@ -1,3 +1,5 @@
+// +build linux,386
+
 package devmapper
 
 import (

--- a/graphdriver/devmapper/sys.go
+++ b/graphdriver/devmapper/sys.go
@@ -1,3 +1,5 @@
+// +build linux,386
+
 package devmapper
 
 import (

--- a/utils.go
+++ b/utils.go
@@ -1,26 +1,5 @@
 package docker
 
-/*
-#include <sys/ioctl.h>
-#include <linux/fs.h>
-#include <errno.h>
-
-// See linux.git/fs/btrfs/ioctl.h
-#define BTRFS_IOCTL_MAGIC 0x94
-#define BTRFS_IOC_CLONE _IOW(BTRFS_IOCTL_MAGIC, 9, int)
-
-int
-btrfs_reflink(int fd_out, int fd_in)
-{
-  int res;
-  res = ioctl(fd_out, BTRFS_IOC_CLONE, fd_in);
-  if (res < 0)
-    return errno;
-  return 0;
-}
-
-*/
-import "C"
 import (
 	"fmt"
 	"github.com/dotcloud/docker/archive"
@@ -347,7 +326,7 @@ func migratePortMappings(config *Config, hostConfig *HostConfig) error {
 }
 
 func BtrfsReflink(fd_out, fd_in uintptr) error {
-	res := C.btrfs_reflink(C.int(fd_out), C.int(fd_in))
+	res := btrfs_reflink(fd_out, fd_in)
 	if res != 0 {
 		return syscall.Errno(res)
 	}


### PR DESCRIPTION
Adds conditional compilation flags to modules that can't compile on darwin (mac os x), and moves the btrfs function from utils.go into a separate module that can is stubbed on darwin.

With these changes I can compile a working docker (client only, of course) from master on os x 10.8 using go 1.2.

I have no idea if this is the right approach.
