### PR TITLE
add load from remote

### DIFF
--- a/api.go
+++ b/api.go
@@ -548,7 +548,13 @@ func getImagesGet(srv *Server, version float64, w http.ResponseWriter, r *http.R
 }
 
 func postImagesLoad(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	return srv.ImageLoad(r.Body)
+	if err := parseForm(r); err != nil {
+		return err
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	wf := utils.NewWriteFlusher(w)
+	return srv.ImageLoad(r.Form.Get("fromSrc"), r.Body, wf, utils.NewStreamFormatter(true))
 }
 
 func postContainersCreate(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/commands.go
+++ b/commands.go
@@ -2171,7 +2171,7 @@ func (cli *DockerCli) CmdSave(args ...string) error {
 }
 
 func (cli *DockerCli) CmdLoad(args ...string) error {
-	cmd := cli.Subcmd("load", "URL|-", "Load an image from a tar archive")
+	cmd := cli.Subcmd("load", "URL|-", "Loads a tarred repository from the standard input stream or a remote url.\nRestores both images and tags.\n\n   Use \"docker://[OTHER_DOCKER_HOST]/[IMAGE]\" to load\n   an image directly from another docker daemon")
 	if err := cmd.Parse(args); err != nil {
 		return err
 	}

--- a/commands.go
+++ b/commands.go
@@ -2171,17 +2171,26 @@ func (cli *DockerCli) CmdSave(args ...string) error {
 }
 
 func (cli *DockerCli) CmdLoad(args ...string) error {
-	cmd := cli.Subcmd("load", "SOURCE", "Load an image from a tar archive")
+	cmd := cli.Subcmd("load", "URL|-", "Load an image from a tar archive")
 	if err := cmd.Parse(args); err != nil {
 		return err
 	}
 
-	if cmd.NArg() != 0 {
+	if cmd.NArg() != 1 {
 		cmd.Usage()
 		return nil
 	}
 
-	if err := cli.stream("POST", "/images/load", cli.in, cli.out, nil); err != nil {
+	v := url.Values{}
+	v.Set("fromSrc", cmd.Arg(0))
+
+	var in io.Reader
+
+	if cmd.Arg(0) == "-" {
+		in = cli.in
+	}
+
+	if err := cli.stream("POST", "/images/load?"+v.Encode(), in, cli.out, nil); err != nil {
 		return err
 	}
 	return nil

--- a/commands.go
+++ b/commands.go
@@ -2182,15 +2182,16 @@ func (cli *DockerCli) CmdLoad(args ...string) error {
 	}
 
 	var (
-		remoteDocker bool
-		v            = url.Values{}
-		src          = cmd.Arg(0)
+		v   = url.Values{}
+		src = cmd.Arg(0)
 	)
 
-	if strings.HasPrefix(src, "docker://") {
-		remoteDocker = true
-		src = strings.TrimPrefix(src, "docker://")
-		src = "https://" + src[:strings.Index(src, "/")] + "/images" + src[strings.Index(src, "/"):] + "/get"
+	u, err := url.Parse(src)
+	if err != nil {
+		return err
+	}
+	if u.Scheme == "docker" {
+		src = "https://" + u.Host + "/images" + u.RequestURI() + "/get"
 	}
 	v.Set("fromSrc", src)
 
@@ -2201,8 +2202,8 @@ func (cli *DockerCli) CmdLoad(args ...string) error {
 	}
 
 	if err := cli.stream("POST", "/images/load?"+v.Encode(), in, cli.out, nil); err != nil {
-		if remoteDocker {
-			v.Set("fromSrc", strings.Replace(src, "https://", "http://", -1))
+		if u.Scheme == "docker" {
+			v.Set("fromSrc", "http://"+u.Host+"/images"+u.RequestURI()+"/get")
 			if err2 := cli.stream("POST", "/images/load?"+v.Encode(), in, cli.out, nil); err2 != nil {
 				return err2
 			}

--- a/commands.go
+++ b/commands.go
@@ -2182,11 +2182,16 @@ func (cli *DockerCli) CmdLoad(args ...string) error {
 	}
 
 	v := url.Values{}
-	v.Set("fromSrc", cmd.Arg(0))
+	src := cmd.Arg(0)
+	if strings.HasPrefix(src, "docker://") {
+		src = strings.TrimPrefix(src, "docker://")
+		src = "http://" + src[:strings.Index(src, "/")] + "/images" + src[strings.Index(src, "/"):] + "/get"
+	}
+	v.Set("fromSrc", src)
 
 	var in io.Reader
 
-	if cmd.Arg(0) == "-" {
+	if src == "-" {
 		in = cli.in
 	}
 

--- a/docs/sources/api/docker_remote_api.rst
+++ b/docs/sources/api/docker_remote_api.rst
@@ -63,6 +63,10 @@ What's new
   to get the current value and the total of the progress without having to
   parse the string.
 
+.. http:post:: /images/load
+
+  **New!** It's now possible to load an image from a remote url.
+
 v1.7
 ****
 

--- a/docs/sources/api/docker_remote_api_v1.8.rst
+++ b/docs/sources/api/docker_remote_api_v1.8.rst
@@ -1235,6 +1235,7 @@ Load a tarball with a set of images and tags into docker
 
           HTTP/1.1 200 OK
 
+        :query fromSrc: source to load, - means stdin
         :statuscode 200: no error
         :statuscode 500: server error
 

--- a/docs/sources/api/docker_remote_api_v1.8.rst
+++ b/docs/sources/api/docker_remote_api_v1.8.rst
@@ -1235,6 +1235,11 @@ Load a tarball with a set of images and tags into docker
 
           HTTP/1.1 200 OK
 
+          {"status":"Loading","progressDetail":{"current":1,"total":100},"progress":"1 B/100 B"}
+          {"status":"Loading","progressDetail":{"current":5,"total":100},"progress":"5 B/100 B"}
+          {"status":"Loading","progressDetail":{"current":10,"total":100},"progress":"10 B/100 B"}
+          {"status":"Loaded: ubuntu:12.04"}
+
         :query fromSrc: source to load, - means stdin
         :statuscode 200: no error
         :statuscode 500: server error

--- a/docs/sources/api/docker_remote_api_v1.8.rst
+++ b/docs/sources/api/docker_remote_api_v1.8.rst
@@ -1203,16 +1203,17 @@ Get a tarball containing all images and tags in a repository
   
            GET /images/ubuntu/get
 
-       **Example response**:
+  **Example response**:
 
-       .. sourcecode:: http
+  .. sourcecode:: http
 
           HTTP/1.1 200 OK
-    Content-Type: application/x-tar
+	  Content-Type: application/x-tar
 
-    Binary data stream
-        :statuscode 200: no error
-        :statuscode 500: server error
+	  Binary data stream
+        
+  :statuscode 200: no error
+  :statuscode 500: server error
 
 Load a tarball with a set of images and tags into docker
 ********************************************************
@@ -1225,13 +1226,13 @@ Load a tarball with a set of images and tags into docker
 
   .. sourcecode:: http
 
-           POST /images/load
+         POST /images/load
 
          Tarball in body
 
-       **Example response**:
+  **Example response**:
 
-       .. sourcecode:: http
+  .. sourcecode:: http
 
           HTTP/1.1 200 OK
 
@@ -1240,9 +1241,9 @@ Load a tarball with a set of images and tags into docker
           {"status":"Loading","progressDetail":{"current":10,"total":100},"progress":"10 B/100 B"}
           {"status":"Loaded: ubuntu:12.04"}
 
-        :query fromSrc: source to load, - means stdin
-        :statuscode 200: no error
-        :statuscode 500: server error
+  :query fromSrc: source to load, - means stdin
+  :statuscode 200: no error
+  :statuscode 500: server error
 
 3. Going further
 ================

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -737,8 +737,8 @@ Known Issues (kill)
     or a remote url.
     Restores both images and tags.
 
-        Use "docker://[OTHER_DOCKER_HOST]/[IMAGE]" to load
-        an image directly from another docker daemon
+    Use "docker://[OTHER_DOCKER_HOST]/[IMAGE]" to load
+    an image directly from another docker daemon
 
 Examples:
 ~~~~~~~~~
@@ -753,11 +753,18 @@ located at ``1.2.3.4``.
 
 .. code-block:: bash
 
-    $ docker load docker://my_docker_host.com/e9aa60c60128A
+    $ docker load docker://my_docker_host.com/e9aa60c60128
 
 
 This will load the image ``e9aa60c60128 (busybox)`` from the docker
 daemon located at ``my_docker_host``.
+
+.. code-block:: bash
+
+    $ docker load - < my_image.tar
+
+
+This will load the image from ``my_image.tar`` using stdin..
 
 .. _cli_login:
 

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -734,8 +734,30 @@ Known Issues (kill)
     Usage: docker load URL|-
 
     Loads a tarred repository from the standard input stream
-    or from a remote url.
+    or a remote url.
     Restores both images and tags.
+
+        Use "docker://[OTHER_DOCKER_HOST]/[IMAGE]" to load
+        an image directly from another docker daemon
+
+Examples:
+~~~~~~~~~
+
+.. code-block:: bash
+
+    $ docker load docker://1.2.3.4:4243/busybox
+
+
+This will load the image ``busybox`` from the docker daemon
+located at ``1.2.3.4``.
+
+.. code-block:: bash
+
+    $ docker load docker://my_docker_host.com/e9aa60c60128A
+
+
+This will load the image ``e9aa60c60128 (busybox)`` from the docker
+daemon located at ``my_docker_host``.
 
 .. _cli_login:
 

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -731,9 +731,10 @@ Known Issues (kill)
 
 ::
 
-    Usage: docker load < repository.tar
+    Usage: docker load URL|-
 
-    Loads a tarred repository from the standard input stream.
+    Loads a tarred repository from the standard input stream
+    or from a remote url.
     Restores both images and tags.
 
 .. _cli_login:

--- a/server.go
+++ b/server.go
@@ -387,6 +387,7 @@ func (srv *Server) ImageLoad(src string, in io.Reader, out io.Writer, sf *utils.
 
 		for imageName, tagMap := range repositories {
 			for tag, address := range tagMap {
+				out.Write(sf.FormatStatus("", "Loaded: "+imageName+":"+tag))
 				if err := srv.runtime.repositories.Set(imageName, tag, address, true); err != nil {
 					return err
 				}

--- a/server.go
+++ b/server.go
@@ -325,7 +325,15 @@ func (srv *Server) exportImage(image *Image, tempdir string) error {
 
 // Loads a set of images into the repository. This is the complementary of ImageExport.
 // The input stream is an uncompressed tar ball containing images and metadata.
-func (srv *Server) ImageLoad(in io.Reader) error {
+func (srv *Server) ImageLoad(src string, in io.Reader, out io.Writer, sf *utils.StreamFormatter) error {
+	if src != "" && src != "-" {
+		resp, err := utils.Download(src)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		in = utils.ProgressReader(resp.Body, int(resp.ContentLength), out, sf, false, "", "Loading")
+	}
 	tmpImageDir, err := ioutil.TempDir("", "docker-import-")
 	if err != nil {
 		return err

--- a/utils/jsonmessage.go
+++ b/utils/jsonmessage.go
@@ -122,7 +122,6 @@ func DisplayJSONMessagesStream(in io.Reader, out io.Writer, terminalFd uintptr, 
 			}
 			return err
 		}
-
 		if jm.Progress != nil {
 			jm.Progress.terminalFd = terminalFd
 		}


### PR DESCRIPTION
This PR adds the ability to load an image from a remote location, and so, to load an image from another docker daemon.

Let's say you have a daemon running at `10.43.6.67`, you can now do:

`docker load http://10.43.6.67/images/<your_image>/get`
or 
`docker load docker://10.43.6.67/<your_image>`
