### PR TITLE
Use boxes that have the raring kernel.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,9 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-BOX_NAME = ENV['BOX_NAME'] || "ubuntu"
-BOX_URI = ENV['BOX_URI'] || "http://files.vagrantup.com/precise64.box"
-VF_BOX_URI = ENV['BOX_URI'] || "http://files.vagrantup.com/precise64_vmware_fusion.box"
+BOX_NAME = ENV['BOX_NAME'] || "ubuntu-12-raring"
+BOX_URI = ENV['BOX_URI'] || "http://nitron-vagrant.s3-website-us-east-1.amazonaws.com/vagrant_ubuntu_12.04.3_amd64_virtualbox.box"
+VF_BOX_URI = ENV['BOX_URI'] || "http://nitron-vagrant.s3-website-us-east-1.amazonaws.com/vagrant_ubuntu_12.04.3_amd64_vmware.box"
 AWS_BOX_URI = ENV['BOX_URI'] || "https://github.com/mitchellh/vagrant-aws/raw/master/dummy.box"
 AWS_REGION = ENV['AWS_REGION'] || "us-east-1"
 AWS_AMI = ENV['AWS_AMI'] || "ami-69f5a900"
@@ -13,8 +13,7 @@ FORWARD_DOCKER_PORTS = ENV['FORWARD_DOCKER_PORTS']
 
 SSH_PRIVKEY_PATH = ENV["SSH_PRIVKEY_PATH"]
 
-# A script to upgrade from the 12.04 kernel to the raring backport kernel (3.8)
-# and install docker.
+# A script to install docker.
 $script = <<SCRIPT
 # The username to add to the docker group will be passed as the first argument
 # to the script.  If nothing is passed, default to "vagrant".
@@ -26,7 +25,7 @@ fi
 # Adding an apt gpg key is idempotent.
 wget -q -O - https://get.docker.io/gpg | apt-key add -
 
-# Creating the docker.list file is idempotent, but it may overrite desired
+# Creating the docker.list file is idempotent, but it may overwrite desired
 # settings if it already exists.  This could be solved with md5sum but it
 # doesn't seem worth it.
 echo 'deb http://get.docker.io/ubuntu docker main' > \
@@ -40,28 +39,6 @@ apt-get install -q -y lxc-docker
 
 usermod -a -G docker "$user"
 
-tmp=`mktemp -q` && {
-    # Only install the backport kernel, don't bother upgrade if the backport is
-    # already installed.  We want parse the output of apt so we need to save it
-    # with 'tee'.  NOTE: The installation of the kernel will trigger dkms to
-    # install vboxguest if needed.
-    apt-get install -q -y --no-upgrade linux-image-generic-lts-raring | \
-        tee "$tmp"
-
-    # Parse the number of installed packages from the output
-    NUM_INST=`awk '$2 == "upgraded," && $4 == "newly" { print $3 }' "$tmp"`
-    rm "$tmp"
-}
-
-# If the number of installed packages is greater than 0, we want to reboot (the
-# backport kernel was installed but is not running).
-if [ "$NUM_INST" -gt 0 ];
-then
-    echo "Rebooting down to activate new kernel."
-    echo "/vagrant will not be mounted.  Use 'vagrant halt' followed by"
-    echo "'vagrant up' to ensure /vagrant is mounted."
-    shutdown -r now
-fi
 SCRIPT
 
 # We need to install the virtualbox guest additions *before* we do the normal

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -146,7 +146,7 @@ if !FORWARD_DOCKER_PORTS.nil?
 
   Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     (49000..49900).each do |port|
-      config.vm.network :forwarded_port, :host => port, :guest => port
+      config.vm.network :forwarded_port, :host => port, :guest => port, auto_correct: true
     end
   end
 end


### PR DESCRIPTION
Using VMWare/Vbox images that already have the raring kernel for ubuntu 12 server.

Changed the name for the image to ubuntu-12-raring to prevent possible collisions with non-raring boxes.
Removed code that installs the back port kernel.
