### PR TITLE
Vagrantfile: Verify integrity of the VirtualBox Guest Additions.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,6 +80,7 @@ if [ ! -d /opt/VBoxGuestAdditions-4.3.2/ ]; then
 
     echo 'Downloading VBox Guest Additions...'
     wget -cq http://dlc.sun.com.edgesuite.net/virtualbox/4.3.2/VBoxGuestAdditions_4.3.2.iso
+    echo "f0b8fec99c65231641d5d01558abb53fe8b81f131dc71519cb7994c9e297300d  VBoxGuestAdditions_4.3.2.iso" | sha256sum --check || exit 1
 
     mount -o loop,ro /home/vagrant/VBoxGuestAdditions_4.3.2.iso /mnt
     /mnt/VBoxLinuxAdditions.run --nox11


### PR DESCRIPTION
VBoxGuestAdditions_4.3.2.iso is downloaded over HTTP, which provides
no integrity guarantees.  This should make it safer to provision a
Vagrant box over an untrusted network connection.
