### PR TITLE
Add Sven Dowideit to docs maintainers

### DIFF
--- a/docs/MAINTAINERS
+++ b/docs/MAINTAINERS
@@ -1,3 +1,4 @@
 Andy Rothfusz <andy@dotcloud.com> (@metalivedev)
 Ken Cochrane <ken@dotcloud.com> (@kencochrane)
 James Turnbull <james@lovedthanlost.net> (@jamesturnbull)
+Sven Dowideit <SvenDowideit@fosiki.com> (@SvenDowideit)


### PR DESCRIPTION
I would like to make @svendowideit a docs maintainer. He has been very proactive and willing to tackle many small issues. I think it would be helpful if he could participate in reviews and participate more in improving the docs.

/cc @metalivedev @crosbymichael @vieux @creack @tianon
