### PR TITLE
add a little prose to tell the user that run creates a container, and then starts it

### DIFF
--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -930,6 +930,9 @@ containers will not be deleted.
       -link="": Add link to another container (name:alias)
       -name="": Assign the specified name to the container. If no name is specific docker will generate a random name
       -P=false: Publish all exposed ports to the host interfaces
+      
+``docker run`` ``creates`` a writeable container layer over the specified image, and then 
+``start``s it using the specified command (ie. is equivalent to the API ``/containers/create`` then ``/containers/(id)/start``). 
 
 Known Issues (run -volumes-from)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
one last little gem inspired by (Closes #2149)

@metalivedev @kencochrane @jamtur01 

<div class="discussion-labels">doc</div>
