### PR TITLE
Allow custom dockerinit path

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -469,6 +469,13 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		fmt.Fprintf(cli.out, "LXC Version: %s\n", remoteInfo.Get("LXCVersion"))
 		fmt.Fprintf(cli.out, "EventsListeners: %d\n", remoteInfo.GetInt("NEventsListener"))
 		fmt.Fprintf(cli.out, "Kernel Version: %s\n", remoteInfo.Get("KernelVersion"))
+
+		if initSha1 := remoteInfo.Get("InitSha1"); initSha1 != "" {
+			fmt.Fprintf(cli.out, "Init SHA1: %s\n", initSha1)
+		}
+		if initPath := remoteInfo.Get("InitPath"); initPath != "" {
+			fmt.Fprintf(cli.out, "Init Path: %s\n", initPath)
+		}
 	}
 
 	if len(remoteInfo.GetList("IndexServerAddress")) != 0 {

--- a/hack/make/dynbinary
+++ b/hack/make/dynbinary
@@ -12,6 +12,6 @@ export DOCKER_INITSHA1="$(sha1sum $DEST/dockerinit-$VERSION | cut -d' ' -f1)"
 # exported so that "dyntest" can easily access it later without recalculating it
 
 (
-	export LDFLAGS_STATIC="-X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\""
+	export LDFLAGS_STATIC="-X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\" -X github.com/dotcloud/docker/utils.INITPATH \"$DOCKER_INITPATH\""
 	source "$(dirname "$BASH_SOURCE")/binary"
 )

--- a/runtime.go
+++ b/runtime.go
@@ -734,18 +734,18 @@ func NewRuntimeFromDirectory(config *DaemonConfig) (*Runtime, error) {
 		return nil, fmt.Errorf("Could not locate dockerinit: This usually means docker was built incorrectly. See http://docs.docker.io/en/latest/contributing/devenvironment for official build instructions.")
 	}
 
-	if !utils.IAMSTATIC {
-		if err := os.Mkdir(path.Join(config.Root, fmt.Sprintf("init")), 0700); err != nil && !os.IsExist(err) {
+	if sysInitPath != localCopy {
+		// When we find a suitable dockerinit binary (even if it's our local binary), we copy it into config.Root at localCopy for future use (so that the original can go away without that being a problem, for example during a package upgrade).
+		if err := os.Mkdir(path.Dir(localCopy), 0700); err != nil && !os.IsExist(err) {
 			return nil, err
 		}
-
 		if _, err := utils.CopyFile(sysInitPath, localCopy); err != nil {
 			return nil, err
 		}
-		sysInitPath = localCopy
-		if err := os.Chmod(sysInitPath, 0700); err != nil {
+		if err := os.Chmod(localCopy, 0700); err != nil {
 			return nil, err
 		}
+		sysInitPath = localCopy
 	}
 
 	runtime := &Runtime{

--- a/server.go
+++ b/server.go
@@ -634,6 +634,13 @@ func (srv *Server) DockerInfo(job *engine.Job) engine.Status {
 		kernelVersion = kv.String()
 	}
 
+	// if we still have the original dockerinit binary from before we copied it locally, let's return the path to that, since that's more intuitive (the copied path is trivial to derive by hand given VERSION)
+	initPath := utils.DockerInitPath("")
+	if initPath == "" {
+		// if that fails, we'll just return the path from the runtime
+		initPath = srv.runtime.sysInitPath
+	}
+
 	v := &engine.Env{}
 	v.SetInt("Containers", len(srv.runtime.List()))
 	v.SetInt("Images", imgcount)
@@ -649,6 +656,8 @@ func (srv *Server) DockerInfo(job *engine.Job) engine.Status {
 	v.SetInt("NEventsListener", len(srv.events))
 	v.Set("KernelVersion", kernelVersion)
 	v.Set("IndexServerAddress", auth.IndexServerAddress())
+	v.Set("InitSha1", utils.INITSHA1)
+	v.Set("InitPath", initPath)
 	if _, err := v.WriteTo(job.Stdout); err != nil {
 		job.Error(err)
 		return engine.StatusErr

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -26,6 +26,7 @@ import (
 var (
 	IAMSTATIC bool   // whether or not Docker itself was compiled statically via ./hack/make.sh binary
 	INITSHA1  string // sha1sum of separate static dockerinit, if Docker itself was compiled dynamically via ./hack/make.sh dynbinary
+	INITPATH  string // custom location to search for a valid dockerinit binary (available for packagers as a last resort escape hatch)
 )
 
 // A common interface to access the Fatal method of
@@ -231,6 +232,7 @@ func DockerInitPath(localCopy string) string {
 	}
 	var possibleInits = []string{
 		localCopy,
+		INITPATH,
 		filepath.Join(filepath.Dir(selfPath), "dockerinit"),
 
 		// FHS 3.0 Draft: "/usr/libexec includes internal binaries that are not intended to be executed directly by users or shell scripts. Applications may use a single subdirectory under /usr/libexec."


### PR DESCRIPTION
This PR includes a couple tweaks to our dockerinit handling, but they all laid the groundwork for allowing packagers to specify an explicit dockerinit search path when invoking dynbinary (to only be used when absolutely necessary - ie, one of the paths we provide in "utils/utils.go" is not sufficient already).

As a side effect of this, I found a bug where we could still have a dynamic docker in the container.  In the current code, if we install a system-wide static docker and start it up, then remove that binary file from disk and replace it with a docker+dockerinit dynamic combo, docker will see that it was compiled with IAMSTATIC and just automatically mount that dynamic docker that's at the correct path into the container, which is _not_ correct.  Overcoming this was deceptively simple - we just need to unconditionally copy our docker binary, regardless of whether we're static.

Also, as discussed with @shykes, I've added the dockerinit path and SHA1 to `docker info`, but they only display when either the client or the daemon are in debug mode (like all the other platform-ish info, like LXC Version and Kernel Version).

See also https://github.com/dotcloud/docker/pull/2924#issuecomment-29543032.

As always, I'm happy to make changes if necessary. :)
