### PR TITLE
Add an environment variable with container's ID to the running container

### DIFF
--- a/container.go
+++ b/container.go
@@ -587,6 +587,7 @@ func (container *Container) Start() (err error) {
 		"HOME=/",
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"container=lxc",
+		"docker.id=" + utils.TruncateID(container.ID),
 		"HOSTNAME=" + container.Config.Hostname,
 	}
 

--- a/integration/container_test.go
+++ b/integration/container_test.go
@@ -1015,6 +1015,7 @@ func TestEnv(t *testing.T) {
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"HOME=/",
 		"container=lxc",
+		"docker.id=" + utils.TruncateID(container.ID),
 		"HOSTNAME=" + utils.TruncateID(container.ID),
 		"FALSE=true",
 		"TRUE=false",


### PR DESCRIPTION
This adds and environment variable to each started container that contains the ID assigned to the container. The name of the variable is:

```
docker.id=<container-id>
```

The format and name of the environment variable is following the current thinking outlined in #2939.
