### PR TITLE
Refcount driver mounts

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -488,7 +488,7 @@ func (b *buildFile) CmdAdd(args string) error {
 	}
 	b.tmpContainers[container.ID] = struct{}{}
 
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return err
 	}
 	defer container.Unmount()
@@ -610,7 +610,7 @@ func (b *buildFile) commit(id string, autoCmd []string, comment string) error {
 		b.tmpContainers[container.ID] = struct{}{}
 		fmt.Fprintf(b.outStream, " ---> Running in %s\n", utils.TruncateID(container.ID))
 		id = container.ID
-		if err := container.EnsureMounted(); err != nil {
+		if err := container.Mount(); err != nil {
 			return err
 		}
 		defer container.Unmount()

--- a/container.go
+++ b/container.go
@@ -200,7 +200,7 @@ func (settings *NetworkSettings) PortMappingAPI() []APIPort {
 
 // Inject the io.Reader at the given path. Note: do not close the reader
 func (container *Container) Inject(file io.Reader, pth string) error {
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return fmt.Errorf("inject: error mounting container %s: %s", container.ID, err)
 	}
 	defer container.Unmount()
@@ -505,7 +505,7 @@ func (container *Container) Start() (err error) {
 			container.cleanup()
 		}
 	}()
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return err
 	}
 	if container.runtime.networkManager.disabled {
@@ -1271,7 +1271,7 @@ func (container *Container) Resize(h, w int) error {
 }
 
 func (container *Container) ExportRw() (archive.Archive, error) {
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return nil, err
 	}
 	if container.runtime == nil {
@@ -1283,7 +1283,7 @@ func (container *Container) ExportRw() (archive.Archive, error) {
 }
 
 func (container *Container) Export() (archive.Archive, error) {
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return nil, err
 	}
 
@@ -1307,12 +1307,6 @@ func (container *Container) WaitTimeout(timeout time.Duration) error {
 	case <-done:
 		return nil
 	}
-}
-
-func (container *Container) EnsureMounted() error {
-	// FIXME: EnsureMounted is deprecated because drivers are now responsible
-	// for re-entrant mounting in their Get() method.
-	return container.Mount()
 }
 
 func (container *Container) Mount() error {
@@ -1412,7 +1406,7 @@ func (container *Container) GetSize() (int64, int64) {
 		driver             = container.runtime.driver
 	)
 
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		utils.Errorf("Warning: failed to compute size of container rootfs %s: %s", container.ID, err)
 		return sizeRw, sizeRootfs
 	}
@@ -1444,7 +1438,7 @@ func (container *Container) GetSize() (int64, int64) {
 }
 
 func (container *Container) Copy(resource string) (archive.Archive, error) {
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return nil, err
 	}
 	var filter []string

--- a/graph.go
+++ b/graph.go
@@ -97,6 +97,7 @@ func (graph *Graph) Get(name string) (*Image, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Driver %s failed to get image rootfs %s: %s", graph.driver, img.ID, err)
 		}
+		defer graph.driver.Put(img.ID)
 
 		var size int64
 		if img.Parent == "" {
@@ -193,6 +194,7 @@ func (graph *Graph) Register(jsonData []byte, layerData archive.Archive, img *Im
 	if err != nil {
 		return fmt.Errorf("Driver %s failed to get image rootfs %s: %s", graph.driver, img.ID, err)
 	}
+	defer graph.driver.Put(img.ID)
 	img.graph = graph
 	if err := StoreImage(img, jsonData, layerData, tmp, rootfs); err != nil {
 		return err

--- a/graphdriver/aufs/aufs.go
+++ b/graphdriver/aufs/aufs.go
@@ -222,6 +222,9 @@ func (a *Driver) Get(id string) (string, error) {
 	return out, nil
 }
 
+func (a *Driver) Put(id string) {
+}
+
 // Returns an archive of the contents for the id
 func (a *Driver) Diff(id string) (archive.Archive, error) {
 	return archive.TarFilter(path.Join(a.rootPath(), "diff", id), &archive.TarOptions{

--- a/graphdriver/aufs/aufs.go
+++ b/graphdriver/aufs/aufs.go
@@ -31,6 +31,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"sync"
 )
 
 func init() {
@@ -38,7 +39,9 @@ func init() {
 }
 
 type Driver struct {
-	root string
+	root       string
+	sync.Mutex // Protects concurrent modification to active
+	active     map[string]int
 }
 
 // New returns a new AUFS driver.
@@ -54,12 +57,17 @@ func Init(root string) (graphdriver.Driver, error) {
 		"layers",
 	}
 
+	a := &Driver{
+		root:   root,
+		active: make(map[string]int),
+	}
+
 	// Create the root aufs driver dir and return
 	// if it already exists
 	// If not populate the dir structure
 	if err := os.MkdirAll(root, 0755); err != nil {
 		if os.IsExist(err) {
-			return &Driver{root}, nil
+			return a, nil
 		}
 		return nil, err
 	}
@@ -69,7 +77,7 @@ func Init(root string) (graphdriver.Driver, error) {
 			return nil, err
 		}
 	}
-	return &Driver{root}, nil
+	return a, nil
 }
 
 // Return a nil error if the kernel supports aufs
@@ -167,6 +175,14 @@ func (a *Driver) createDirsFor(id string) error {
 
 // Unmount and remove the dir information
 func (a *Driver) Remove(id string) error {
+	// Protect the a.active from concurrent access
+	a.Lock()
+	defer a.Unlock()
+
+	if a.active[id] != 0 {
+		utils.Errorf("Warning: removing active id %s\n", id)
+	}
+
 	// Make sure the dir is umounted first
 	if err := a.unmount(id); err != nil {
 		return err
@@ -210,19 +226,45 @@ func (a *Driver) Get(id string) (string, error) {
 		ids = []string{}
 	}
 
+	// Protect the a.active from concurrent access
+	a.Lock()
+	defer a.Unlock()
+
+	count := a.active[id]
+
 	// If a dir does not have a parent ( no layers )do not try to mount
 	// just return the diff path to the data
 	out := path.Join(a.rootPath(), "diff", id)
 	if len(ids) > 0 {
 		out = path.Join(a.rootPath(), "mnt", id)
-		if err := a.mount(id); err != nil {
-			return "", err
+
+		if count == 0 {
+			if err := a.mount(id); err != nil {
+				return "", err
+			}
 		}
 	}
+
+	a.active[id] = count + 1
+
 	return out, nil
 }
 
 func (a *Driver) Put(id string) {
+	// Protect the a.active from concurrent access
+	a.Lock()
+	defer a.Unlock()
+
+	if count := a.active[id]; count > 1 {
+		a.active[id] = count - 1
+	} else {
+		ids, _ := getParentIds(a.rootPath(), id)
+		// We only mounted if there are any parents
+		if ids != nil && len(ids) > 0 {
+			a.unmount(id)
+		}
+		delete(a.active, id)
+	}
 }
 
 // Returns an archive of the contents for the id

--- a/graphdriver/devmapper/driver.go
+++ b/graphdriver/devmapper/driver.go
@@ -5,8 +5,10 @@ package devmapper
 import (
 	"fmt"
 	"github.com/dotcloud/docker/graphdriver"
+	"github.com/dotcloud/docker/utils"
 	"io/ioutil"
 	"path"
+	"sync"
 )
 
 func init() {
@@ -20,7 +22,9 @@ func init() {
 
 type Driver struct {
 	*DeviceSet
-	home string
+	home       string
+	sync.Mutex // Protects concurrent modification to active
+	active     map[string]int
 }
 
 var Init = func(home string) (graphdriver.Driver, error) {
@@ -31,6 +35,7 @@ var Init = func(home string) (graphdriver.Driver, error) {
 	d := &Driver{
 		DeviceSet: deviceSet,
 		home:      home,
+		active:    make(map[string]int),
 	}
 	return d, nil
 }
@@ -82,6 +87,14 @@ func (d *Driver) Create(id, parent string) error {
 }
 
 func (d *Driver) Remove(id string) error {
+	// Protect the d.active from concurrent access
+	d.Lock()
+	defer d.Unlock()
+
+	if d.active[id] != 0 {
+		utils.Errorf("Warning: removing active id %s\n", id)
+	}
+
 	mp := path.Join(d.home, "mnt", id)
 	if err := d.unmount(id, mp); err != nil {
 		return err
@@ -90,14 +103,36 @@ func (d *Driver) Remove(id string) error {
 }
 
 func (d *Driver) Get(id string) (string, error) {
+	// Protect the d.active from concurrent access
+	d.Lock()
+	defer d.Unlock()
+
+	count := d.active[id]
+
 	mp := path.Join(d.home, "mnt", id)
-	if err := d.mount(id, mp); err != nil {
-		return "", err
+	if count == 0 {
+		if err := d.mount(id, mp); err != nil {
+			return "", err
+		}
 	}
+
+	d.active[id] = count + 1
+
 	return path.Join(mp, "rootfs"), nil
 }
 
 func (d *Driver) Put(id string) {
+	// Protect the d.active from concurrent access
+	d.Lock()
+	defer d.Unlock()
+
+	if count := d.active[id]; count > 1 {
+		d.active[id] = count - 1
+	} else {
+		mp := path.Join(d.home, "mnt", id)
+		d.unmount(id, mp)
+		delete(d.active, id)
+	}
 }
 
 func (d *Driver) mount(id, mountPoint string) error {

--- a/graphdriver/devmapper/driver.go
+++ b/graphdriver/devmapper/driver.go
@@ -97,6 +97,9 @@ func (d *Driver) Get(id string) (string, error) {
 	return path.Join(mp, "rootfs"), nil
 }
 
+func (d *Driver) Put(id string) {
+}
+
 func (d *Driver) mount(id, mountPoint string) error {
 	// Create the target directories if they don't exist
 	if err := osMkdirAll(mountPoint, 0755); err != nil && !osIsExist(err) {

--- a/graphdriver/driver.go
+++ b/graphdriver/driver.go
@@ -17,6 +17,7 @@ type Driver interface {
 	Remove(id string) error
 
 	Get(id string) (dir string, err error)
+	Put(id string)
 	Exists(id string) bool
 
 	Status() [][2]string

--- a/graphdriver/vfs/driver.go
+++ b/graphdriver/vfs/driver.go
@@ -84,6 +84,11 @@ func (d *Driver) Get(id string) (string, error) {
 	return dir, nil
 }
 
+func (d *Driver) Put(id string) {
+	// The vfs driver has no runtime resources (e.g. mounts)
+	// to clean up, so we don't need anything here
+}
+
 func (d *Driver) Exists(id string) bool {
 	_, err := os.Stat(d.dir(id))
 	return err == nil

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -71,7 +71,7 @@ func containerRun(eng *engine.Engine, id string, t utils.Fataler) {
 
 func containerFileExists(eng *engine.Engine, id, dir string, t utils.Fataler) bool {
 	c := getContainer(eng, id, t)
-	if err := c.EnsureMounted(); err != nil {
+	if err := c.Mount(); err != nil {
 		t.Fatal(err)
 	}
 	defer c.Unmount()

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -74,6 +74,7 @@ func containerFileExists(eng *engine.Engine, id, dir string, t utils.Fataler) bo
 	if err := c.EnsureMounted(); err != nil {
 		t.Fatal(err)
 	}
+	defer c.Unmount()
 	if _, err := os.Stat(path.Join(c.RootfsPath(), dir)); err != nil {
 		if os.IsNotExist(err) {
 			return false

--- a/runtime.go
+++ b/runtime.go
@@ -520,7 +520,7 @@ func (runtime *Runtime) Create(config *Config, name string) (*Container, []strin
 func (runtime *Runtime) Commit(container *Container, repository, tag, comment, author string, config *Config) (*Image, error) {
 	// FIXME: freeze the container before copying it to avoid data corruption?
 	// FIXME: this shouldn't be in commands.
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return nil, err
 	}
 	defer container.Unmount()

--- a/utils.go
+++ b/utils.go
@@ -5,8 +5,10 @@ import (
 	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/pkg/namesgenerator"
 	"github.com/dotcloud/docker/utils"
+	"io"
 	"strconv"
 	"strings"
+	"sync/atomic"
 )
 
 type Change struct {
@@ -338,4 +340,29 @@ func (c *checker) Exists(name string) bool {
 // Generate a random and unique name
 func generateRandomName(runtime *Runtime) (string, error) {
 	return namesgenerator.GenerateRandomName(&checker{runtime})
+}
+
+// Read an io.Reader and call a function when it returns EOF
+func EofReader(r io.Reader, callback func()) *eofReader {
+	return &eofReader{
+		Reader:   r,
+		callback: callback,
+	}
+}
+
+type eofReader struct {
+	io.Reader
+	gotEOF   int32
+	callback func()
+}
+
+func (r *eofReader) Read(p []byte) (n int, err error) {
+	n, err = r.Reader.Read(p)
+	if err == io.EOF {
+		// Use atomics to make the gotEOF check threadsafe
+		if atomic.CompareAndSwapInt32(&r.gotEOF, 0, 1) {
+			r.callback()
+		}
+	}
+	return
 }


### PR DESCRIPTION
This adds a Put() operation to the driver API which pairs with the Get() call.
All callers of Get() are changed to have a corresponding Put() which lets us balance the uses of a particular ID.
We then use this in the devicemapper driver to avoid leaving mounts around. 

For instance, we almost never need any images of init layers mounted, only when e.g. diffing or calculating sizes. We also don't want to leave stray mounts for every container that was ever run (we currently even mount old ones on daemon start!).
