### PR TITLE
Enable engine to take Stderr and Stdout for mocking in tests

### DIFF
--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -185,6 +185,8 @@ func NewTestEngine(t utils.Fataler) *engine.Engine {
 	if err != nil {
 		t.Fatal(err)
 	}
+	eng.Stdout = ioutil.Discard
+	eng.Stderr = ioutil.Discard
 	// Load default plugins
 	// (This is manually copied and modified from main() until we have a more generic plugin system)
 	job := eng.Job("initapi")


### PR DESCRIPTION
This fixes the verbose output in the unit tests by providing the engine ioutil.Discard as the writer.
