### PR TITLE
Revert "Add cgroup-bin dependency to our Ubuntu package"

### DIFF
--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -96,7 +96,6 @@ EOF
 		    --depends lxc \
 		    --depends aufs-tools \
 		    --depends iptables \
-		    --depends cgroup-bin \
 		    --description "$PACKAGE_DESCRIPTION" \
 		    --maintainer "$PACKAGE_MAINTAINER" \
 		    --conflicts lxc-docker-virtual-package \


### PR DESCRIPTION
This reverts commit c81bb20f5b2b5d86059c6004e60ba23b03d30fe0.

After re-reading the documentation: "The Recommends field should list packages that would be found together with this one in all but unusual installations."

Thus, "Recommends" is an acceptable place for this dep, and anyone disabling that gets to keep the pieces.

The main crux of why this needs to be reverted is because it breaks Debian completely because "lxc" and "cgroup-bin" can't be installed concurrently.

Referencing #2990 for the backlink/context.

This needs to be cherry-picked into release and thus v0.7.1 (many apologies).
