### PR TITLE
update arch-linux installation instructions with the correct url

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -68,6 +68,7 @@ Francisco Souza <f@souza.cc>
 Frederick F. Kautz IV <fkautz@alumni.cmu.edu>
 Gabriel Monroy <gabriel@opdemand.com>
 Gareth Rushgrove <gareth@morethanseven.net>
+George Papanikolaou <g3orge.app@gmail.com>
 Greg Thornton <xdissent@me.com>
 Guillaume J. Charmes <guillaume.charmes@dotcloud.com>
 Gurjeet Singh <gurjeet@singh.im>

--- a/docs/sources/installation/archlinux.rst
+++ b/docs/sources/installation/archlinux.rst
@@ -12,15 +12,11 @@ Arch Linux
 .. include:: install_unofficial.inc
 
 Installing on Arch Linux is not officially supported but can be handled via 
-one of the following AUR packages:
+the following AUR package:
 
-* `lxc-docker <https://aur.archlinux.org/packages/lxc-docker/>`_
-* `lxc-docker-git <https://aur.archlinux.org/packages/lxc-docker-git/>`_
-* `lxc-docker-nightly <https://aur.archlinux.org/packages/lxc-docker-nightly/>`_
+* `docker-git <https://aur.archlinux.org/packages/docker-git/>`_
 
-The lxc-docker package will install the latest tagged version of docker. 
-The lxc-docker-git package will build from the current master branch.
-The lxc-docker-nightly package will install the latest build.
+This package will build from the current master branch.
 
 Dependencies
 ------------
@@ -44,7 +40,7 @@ done so before.
 
 ::
 
-    yaourt -S lxc-docker
+    yaourt -S docker-git
 
 
 Starting Docker


### PR DESCRIPTION
There is a new docker package available in the Arch Linux User Repository.
This PR changes the urls to the correct form
