### PR TITLE
fix jsonmessage in build

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -375,7 +375,7 @@ type StdoutFormater struct {
 }
 
 func (sf *StdoutFormater) Write(buf []byte) (int, error) {
-	formattedBuf := sf.StreamFormatter.FormatStatus("", "%s", string(buf))
+	formattedBuf := sf.StreamFormatter.FormatStream(string(buf))
 	n, err := sf.Writer.Write(formattedBuf)
 	if n != len(formattedBuf) {
 		return n, io.ErrShortWrite
@@ -389,7 +389,7 @@ type StderrFormater struct {
 }
 
 func (sf *StderrFormater) Write(buf []byte) (int, error) {
-	formattedBuf := sf.StreamFormatter.FormatStatus("", "%s", "\033[91m"+string(buf)+"\033[0m")
+	formattedBuf := sf.StreamFormatter.FormatStream("\033[91m" + string(buf) + "\033[0m")
 	n, err := sf.Writer.Write(formattedBuf)
 	if n != len(formattedBuf) {
 		return n, io.ErrShortWrite

--- a/commands.go
+++ b/commands.go
@@ -229,8 +229,6 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	if context != nil {
 		headers.Set("Content-Type", "application/tar")
 	}
-	// Temporary hack to fix displayJSON behavior
-	cli.isTerminal = false
 	err = cli.stream("POST", fmt.Sprintf("/build?%s", v.Encode()), body, cli.out, headers)
 	if jerr, ok := err.(*utils.JSONError); ok {
 		return &utils.StatusError{Status: jerr.Message, StatusCode: jerr.Code}

--- a/docs/sources/api/docker_remote_api_v1.8.rst
+++ b/docs/sources/api/docker_remote_api_v1.8.rst
@@ -1008,8 +1008,8 @@ Build an image from Dockerfile via stdin
       HTTP/1.1 200 OK
       Content-Type: application/json
 
-      {"status":"Step 1..."}
-      {"status":"..."}
+      {"stream":"Step 1..."}
+      {"stream":"..."}
       {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
 
 

--- a/utils/jsonmessage.go
+++ b/utils/jsonmessage.go
@@ -66,6 +66,7 @@ func (p *JSONProgress) String() string {
 }
 
 type JSONMessage struct {
+	Stream          string        `json:"stream,omitempty"`
 	Status          string        `json:"status,omitempty"`
 	Progress        *JSONProgress `json:"progressDetail,omitempty"`
 	ProgressMessage string        `json:"progress,omitempty"` //deprecated
@@ -87,7 +88,7 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 	if isTerminal {
 		// <ESC>[2K = erase entire current line
 		fmt.Fprintf(out, "%c[2K\r", 27)
-		endl = "\r\n"
+		endl = "\r"
 	}
 	if jm.Time != 0 {
 		fmt.Fprintf(out, "[%s] ", time.Unix(jm.Time, 0))
@@ -102,8 +103,10 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 		fmt.Fprintf(out, "%s %s%s", jm.Status, jm.Progress.String(), endl)
 	} else if jm.ProgressMessage != "" { //deprecated
 		fmt.Fprintf(out, "%s %s%s", jm.Status, jm.ProgressMessage, endl)
+	} else if jm.Stream != "" {
+		fmt.Fprintf(out, "%s%s", jm.Stream, endl)
 	} else {
-		fmt.Fprintf(out, "%s%s", jm.Status, endl)
+		fmt.Fprintf(out, "%s%s\n", jm.Status, endl)
 	}
 	return nil
 }

--- a/utils/jsonmessage.go
+++ b/utils/jsonmessage.go
@@ -89,6 +89,8 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 		// <ESC>[2K = erase entire current line
 		fmt.Fprintf(out, "%c[2K\r", 27)
 		endl = "\r"
+	} else if jm.Progress != nil { //disable progressbar in non-terminal
+		return nil
 	}
 	if jm.Time != 0 {
 		fmt.Fprintf(out, "[%s] ", time.Unix(jm.Time, 0))

--- a/utils/streamformatter.go
+++ b/utils/streamformatter.go
@@ -14,6 +14,18 @@ func NewStreamFormatter(json bool) *StreamFormatter {
 	return &StreamFormatter{json, false}
 }
 
+func (sf *StreamFormatter) FormatStream(str string) []byte {
+	sf.used = true
+	if sf.json {
+		b, err := json.Marshal(&JSONMessage{Stream: str})
+		if err != nil {
+			return sf.FormatError(err)
+		}
+		return b
+	}
+	return []byte(str + "\r")
+}
+
 func (sf *StreamFormatter) FormatStatus(id, format string, a ...interface{}) []byte {
 	sf.used = true
 	str := fmt.Sprintf(format, a...)


### PR DESCRIPTION
@creack You won't probably like this, but I think while waiting for a complete rewrite, it's the best way to do it.

I left `Status` for small message, most of the time, linked to an id and I added a `Stream` to do exactly as you want, only use JSON as transport.

This fixes the display in the build and remove the isTerminal hack.
