### PR TITLE
Separate Integration Tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ doc:
 	docker build -t docker-docs docs && docker run -p 8000:8000 docker-docs
 
 test: build
-	$(DOCKER_RUN_DOCKER) hack/make.sh test
+	$(DOCKER_RUN_DOCKER) hack/make.sh test test-integration
 
 shell: build
 	$(DOCKER_RUN_DOCKER) bash

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -35,8 +35,10 @@ grep -q "$RESOLVCONF" /proc/mounts || {
 DEFAULT_BUNDLES=(
 	binary
 	test
+	test-integration
 	dynbinary
 	dyntest
+	dyntest-integration
 	tgz
 	ubuntu
 )

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -62,6 +62,24 @@ LDFLAGS='-X main.GITCOMMIT "'$GITCOMMIT'" -X main.VERSION "'$VERSION'" -w'
 LDFLAGS_STATIC='-X github.com/dotcloud/docker/utils.IAMSTATIC true -linkmode external -extldflags "-lpthread -static -Wl,--unresolved-symbols=ignore-in-object-files"'
 BUILDFLAGS='-tags netgo'
 
+# If $TESTFLAGS is set in the environment, it is passed as extra arguments to 'go test'.
+# You can use this to select certain tests to run, eg.
+#
+#   TESTFLAGS='-run ^TestBuild$' ./hack/make.sh test
+#
+go_test_dir() {
+	dir=$1
+	( # we run "go test -i" ouside the "set -x" to provde cleaner output
+		cd "$dir"
+		go test -i -ldflags "$LDFLAGS" $BUILDFLAGS
+	)
+	(
+		set -x
+		cd "$dir"
+		go test -ldflags "$LDFLAGS" $BUILDFLAGS $TESTFLAGS
+	)
+}
+
 bundle() {
 	bundlescript=$1
 	bundle=$(basename $bundlescript)

--- a/hack/make/dynbinary
+++ b/hack/make/dynbinary
@@ -11,5 +11,7 @@ ln -sf dockerinit-$VERSION $DEST/dockerinit
 export DOCKER_INITSHA1="$(sha1sum $DEST/dockerinit-$VERSION | cut -d' ' -f1)"
 # exported so that "dyntest" can easily access it later without recalculating it
 
-go build -o $DEST/docker-$VERSION -ldflags "$LDFLAGS -X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\"" $BUILDFLAGS ./docker
-echo "Created binary: $DEST/docker-$VERSION"
+(
+	export LDFLAGS_STATIC="-X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\""
+	source "$(dirname "$BASH_SOURCE")/binary"
+)

--- a/hack/make/dyntest
+++ b/hack/make/dyntest
@@ -10,7 +10,8 @@ if [ ! -x "$INIT" ]; then
 	false
 fi
 
-export TEST_DOCKERINIT_PATH="$INIT"
-
-LDFLAGS_STATIC="-X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\"" \
+(
+	export TEST_DOCKERINIT_PATH="$INIT"
+	export LDFLAGS_STATIC="-X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\""
 	source "$(dirname "$BASH_SOURCE")/test"
+)

--- a/hack/make/dyntest
+++ b/hack/make/dyntest
@@ -61,9 +61,10 @@ bundle_test() {
 # holding Go test files, and prints their paths on standard output, one per
 # line.
 find_test_dirs() {
-       find . -name '*_test.go' | grep -v '^./vendor' |
-               { while read f; do dirname $f; done; } |
-               sort -u
+	find -not \( \
+		\( -wholename './vendor' -o -wholename './integration' \) \
+		-prune \
+	\) -name '*_test.go' -print0 | xargs -0n1 dirname | sort -u
 }
 
 bundle_test

--- a/hack/make/dyntest
+++ b/hack/make/dyntest
@@ -10,61 +10,7 @@ if [ ! -x "$INIT" ]; then
 	false
 fi
 
-TEXTRESET=$'\033[0m' # reset the foreground colour
-RED=$'\033[31m'
-GREEN=$'\033[32m'
+export TEST_DOCKERINIT_PATH="$INIT"
 
-# Run Docker's test suite, including sub-packages, and store their output as a bundle
-# If $TESTFLAGS is set in the environment, it is passed as extra arguments to 'go test'.
-# You can use this to select certain tests to run, eg.
-#
-#   TESTFLAGS='-run ^TestBuild$' ./hack/make.sh test
-#
-bundle_test() {
-	{
-		date
-
-		export TEST_DOCKERINIT_PATH=$DEST/../dynbinary/dockerinit-$VERSION
-
-		TESTS_FAILED=()
-		for test_dir in $(find_test_dirs); do
-			echo
-
-			if ! LDFLAGS="$LDFLAGS -X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\"" go_test_dir "$test_dir"; then
-				TESTS_FAILED+=("$test_dir")
-				echo
-				echo "${RED}Tests failed: $test_dir${TEXTRESET}"
-				sleep 1 # give it a second, so observers watching can take note
-			fi
-		done
-
-		echo
-		echo
-		echo
-
-		# if some tests fail, we want the bundlescript to fail, but we want to
-		# try running ALL the tests first, hence TESTS_FAILED
-		if [ "${#TESTS_FAILED[@]}" -gt 0 ]; then
-			echo "${RED}Test failures in: ${TESTS_FAILED[@]}${TEXTRESET}"
-			echo
-			false
-		else
-			echo "${GREEN}Test success${TEXTRESET}"
-			echo
-			true
-		fi
-	} 2>&1 | tee $DEST/test.log
-}
-
-
-# This helper function walks the current directory looking for directories
-# holding Go test files, and prints their paths on standard output, one per
-# line.
-find_test_dirs() {
-	find -not \( \
-		\( -wholename './vendor' -o -wholename './integration' \) \
-		-prune \
-	\) -name '*_test.go' -print0 | xargs -0n1 dirname | sort -u
-}
-
-bundle_test
+LDFLAGS_STATIC="-X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\"" \
+	source "$(dirname "$BASH_SOURCE")/test"

--- a/hack/make/dyntest
+++ b/hack/make/dyntest
@@ -10,6 +10,10 @@ if [ ! -x "$INIT" ]; then
 	false
 fi
 
+TEXTRESET=$'\033[0m' # reset the foreground colour
+RED=$'\033[31m'
+GREEN=$'\033[32m'
+
 # Run Docker's test suite, including sub-packages, and store their output as a bundle
 # If $TESTFLAGS is set in the environment, it is passed as extra arguments to 'go test'.
 # You can use this to select certain tests to run, eg.
@@ -37,16 +41,26 @@ bundle_test() {
 				go test -ldflags "$LDFLAGS -X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\"" $BUILDFLAGS $TESTFLAGS
 			); then
 				TESTS_FAILED+=("$test_dir")
+				echo
+				echo "${RED}Tests failed: $test_dir${TEXTRESET}"
 				sleep 1 # give it a second, so observers watching can take note
 			fi
 		done
-		
+
+		echo
+		echo
+		echo
+
 		# if some tests fail, we want the bundlescript to fail, but we want to
 		# try running ALL the tests first, hence TESTS_FAILED
 		if [ "${#TESTS_FAILED[@]}" -gt 0 ]; then
+			echo "${RED}Test failures in: ${TESTS_FAILED[@]}${TEXTRESET}"
 			echo
-			echo "Test failures in: ${TESTS_FAILED[@]}"
 			false
+		else
+			echo "${GREEN}Test success${TEXTRESET}"
+			echo
+			true
 		fi
 	} 2>&1 | tee $DEST/test.log
 }

--- a/hack/make/dyntest
+++ b/hack/make/dyntest
@@ -17,29 +17,20 @@ GREEN=$'\033[32m'
 # Run Docker's test suite, including sub-packages, and store their output as a bundle
 # If $TESTFLAGS is set in the environment, it is passed as extra arguments to 'go test'.
 # You can use this to select certain tests to run, eg.
-# 
-# 	TESTFLAGS='-run ^TestBuild$' ./hack/make.sh test
+#
+#   TESTFLAGS='-run ^TestBuild$' ./hack/make.sh test
 #
 bundle_test() {
 	{
 		date
-		
+
+		export TEST_DOCKERINIT_PATH=$DEST/../dynbinary/dockerinit-$VERSION
+
 		TESTS_FAILED=()
 		for test_dir in $(find_test_dirs); do
 			echo
-			
-			if ! (
-				set -x
-				cd $test_dir
-				
-				# Install packages that are dependencies of the tests.
-				#   Note: Does not run the tests.
-				go test -i -ldflags "$LDFLAGS" $BUILDFLAGS
-				
-				# Run the tests with the optional $TESTFLAGS.
-				export TEST_DOCKERINIT_PATH=$DEST/../dynbinary/dockerinit-$VERSION
-				go test -ldflags "$LDFLAGS -X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\"" $BUILDFLAGS $TESTFLAGS
-			); then
+
+			if ! LDFLAGS="$LDFLAGS -X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\"" go_test_dir "$test_dir"; then
 				TESTS_FAILED+=("$test_dir")
 				echo
 				echo "${RED}Tests failed: $test_dir${TEXTRESET}"

--- a/hack/make/dyntest-integration
+++ b/hack/make/dyntest-integration
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+DEST=$1
+INIT=$DEST/../dynbinary/dockerinit-$VERSION
+
+set -e
+
+if [ ! -x "$INIT" ]; then
+	echo >&2 'error: dynbinary must be run before dyntest-integration'
+	false
+fi
+
+(
+	export TEST_DOCKERINIT_PATH="$INIT"
+	export LDFLAGS_STATIC="-X github.com/dotcloud/docker/utils.INITSHA1 \"$DOCKER_INITSHA1\""
+	source "$(dirname "$BASH_SOURCE")/test-integration"
+)

--- a/hack/make/test
+++ b/hack/make/test
@@ -35,21 +35,24 @@ bundle_test() {
 			); then
 				TESTS_FAILED+=("$test_dir")
 				echo
-				echo "${RED}Test Failed: $test_dir${TEXTRESET}"
-				echo
+				echo "${RED}Tests failed: $test_dir${TEXTRESET}"
 				sleep 1 # give it a second, so observers watching can take note
 			fi
 		done
 
+		echo
+		echo
+		echo
+
 		# if some tests fail, we want the bundlescript to fail, but we want to
 		# try running ALL the tests first, hence TESTS_FAILED
 		if [ "${#TESTS_FAILED[@]}" -gt 0 ]; then
-			echo
 			echo "${RED}Test failures in: ${TESTS_FAILED[@]}${TEXTRESET}"
+			echo
 			false
 		else
-			echo
 			echo "${GREEN}Test success${TEXTRESET}"
+			echo
 			true
 		fi
 	} 2>&1 | tee $DEST/test.log

--- a/hack/make/test
+++ b/hack/make/test
@@ -53,9 +53,10 @@ bundle_test() {
 # holding Go test files, and prints their paths on standard output, one per
 # line.
 find_test_dirs() {
-       find . -name '*_test.go' | grep -v '^./vendor' |
-               { while read f; do dirname $f; done; } |
-               sort -u
+	find -not \( \
+		\( -wholename './vendor' -o -wholename './integration' \) \
+		-prune \
+	\) -name '*_test.go' -print0 | xargs -0n1 dirname | sort -u
 }
 
 bundle_test

--- a/hack/make/test
+++ b/hack/make/test
@@ -12,7 +12,7 @@ GREEN=$'\033[32m'
 # If $TESTFLAGS is set in the environment, it is passed as extra arguments to 'go test'.
 # You can use this to select certain tests to run, eg.
 #
-# 	TESTFLAGS='-run ^TestBuild$' ./hack/make.sh test
+#   TESTFLAGS='-run ^TestBuild$' ./hack/make.sh test
 #
 bundle_test() {
 	{
@@ -22,17 +22,7 @@ bundle_test() {
 		for test_dir in $(find_test_dirs); do
 			echo
 
-			if ! (
-				set -x
-				cd $test_dir
-
-				# Install packages that are dependencies of the tests.
-				#   Note: Does not run the tests.
-				go test -i -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS
-
-				# Run the tests with the optional $TESTFLAGS.
-				go test -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS $TESTFLAGS
-			); then
+			if ! LDFLAGS="$LDFLAGS $LDFLAGS_STATIC" go_test_dir "$test_dir"; then
 				TESTS_FAILED+=("$test_dir")
 				echo
 				echo "${RED}Tests failed: $test_dir${TEXTRESET}"

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DEST=$1
+
+set -e
+
+bundle_test_integration() {
+	LDFLAGS="$LDFLAGS $LDFLAGS_STATIC" go_test_dir ./integration
+}
+
+bundle_test_integration 2>&1 | tee $DEST/test.log


### PR DESCRIPTION
This reorganizes our tests a bit (especially making sure the dyn\* bundles stay perfectly in sync with the non-dyn bundles by running them directly), and in the process includes an updated `find_test_dirs()` that excludes integration and a separate `test-integration` bundlescript to run the integration tests.

It's worth noting here that the storage driver tests for aufs and device-mapper are technically integration tests, and thus need to be moved into that directory.
