### PR TITLE
Make it extra clear that the `docker` group is root-equivalent.

### DIFF
--- a/docs/sources/use/basics.rst
+++ b/docs/sources/use/basics.rst
@@ -67,7 +67,7 @@ daemon will make the ownership of the Unix socket read/writable by the
 *docker* group when the daemon starts. The ``docker`` daemon must
 always run as root, but if you run the ``docker`` client as a user in
 the *docker* group then you don't need to add ``sudo`` to all the
-client commands.
+client commands.  Warning: the *docker* group is root-equivalent.
 
 **Example:**
 


### PR DESCRIPTION
The following section on TCP access to docker has a warning that docker is root-equivalent.  Unfortunately, people who were interested in local but not TCP access (like me) won't read that section and therefore won't read that warning that applies to the docker group too.  If you think it's better to copy that warning to the "sudo and the docker Group" section, that'd be fine with me too. (Each section should have at least a sentence of warning in it, IMHO.)
