### PR TITLE
Validate container names on creation. Fixes #3138

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -27,7 +28,10 @@ import (
 // Set the max depth to the aufs restriction
 const MaxImageDepth = 42
 
-var defaultDns = []string{"8.8.8.8", "8.8.4.4"}
+var (
+	defaultDns         = []string{"8.8.8.8", "8.8.4.4"}
+	validContainerName = regexp.MustCompile(`^/?[a-zA-Z0-9_-]+$`)
+)
 
 type Capabilities struct {
 	MemoryLimit            bool
@@ -418,7 +422,12 @@ func (runtime *Runtime) Create(config *Config, name string) (*Container, []strin
 		if err != nil {
 			name = utils.TruncateID(id)
 		}
+	} else {
+		if !validContainerName.MatchString(name) {
+			return nil, nil, fmt.Errorf("Invalid container name (%s), only [a-zA-Z0-9_-] are allowed", name)
+		}
 	}
+
 	if name[0] != '/' {
 		name = "/" + name
 	}


### PR DESCRIPTION
This adds a check in the runtime when creating a container to make sure the name only contains alpha-numeric characters and underscore. Fixes #3138.
