### PR TITLE
Set hostname and IP address from dockerinit

### DIFF
--- a/container.go
+++ b/container.go
@@ -574,7 +574,11 @@ func (container *Container) Start() (err error) {
 
 	// Networking
 	if !container.Config.NetworkDisabled {
-		params = append(params, "-g", container.network.Gateway.String())
+		network := container.NetworkSettings
+		params = append(params,
+			"-g", network.Gateway,
+			"-i", fmt.Sprintf("%s/%d", network.IPAddress, network.IPPrefixLen),
+		)
 	}
 
 	// User

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -12,11 +12,9 @@ lxc.network.type = empty
 {{else}}
 # network configuration
 lxc.network.type = veth
-lxc.network.flags = up
 lxc.network.link = {{.NetworkSettings.Bridge}}
 lxc.network.name = eth0
 lxc.network.mtu = 1500
-lxc.network.ipv4 = {{.NetworkSettings.IPAddress}}/{{.NetworkSettings.IPPrefixLen}}
 {{end}}
 
 # root filesystem

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -6,13 +6,6 @@ import (
 )
 
 const LxcTemplate = `
-# hostname
-{{if .Config.Hostname}}
-lxc.utsname = {{.Config.Hostname}}
-{{else}}
-lxc.utsname = {{.Id}}
-{{end}}
-
 {{if .Config.NetworkDisabled}}
 # network is disabled (-n=false)
 lxc.network.type = empty

--- a/lxc_template_unit_test.go
+++ b/lxc_template_unit_test.go
@@ -29,7 +29,6 @@ func TestLXCConfig(t *testing.T) {
 	container := &Container{
 		root: root,
 		Config: &Config{
-			Hostname:        "foobar",
 			Memory:          int64(mem),
 			CpuShares:       int64(cpu),
 			NetworkDisabled: true,
@@ -41,7 +40,6 @@ func TestLXCConfig(t *testing.T) {
 	if err := container.generateLXCConfig(); err != nil {
 		t.Fatal(err)
 	}
-	grepFile(t, container.lxcConfigPath(), "lxc.utsname = foobar")
 	grepFile(t, container.lxcConfigPath(),
 		fmt.Sprintf("lxc.cgroup.memory.limit_in_bytes = %d", mem))
 	grepFile(t, container.lxcConfigPath(),

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -20,6 +20,7 @@ import (
 type DockerInitArgs struct {
 	user       string
 	gateway    string
+	ip         string
 	workDir    string
 	privileged bool
 	env        []string
@@ -36,17 +37,41 @@ func setupHostname(args *DockerInitArgs) error {
 
 // Setup networking
 func setupNetworking(args *DockerInitArgs) error {
-	if args.gateway == "" {
-		return nil
-	}
+	if args.ip != "" {
+		// eth0
+		iface, err := net.InterfaceByName("eth0")
+		if err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+		ip, ipNet, err := net.ParseCIDR(args.ip)
+		if err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+		if err := netlink.NetworkLinkAddIp(iface, ip, ipNet); err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+		if err := netlink.NetworkLinkUp(iface); err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
 
-	ip := net.ParseIP(args.gateway)
-	if ip == nil {
-		return fmt.Errorf("Unable to set up networking, %s is not a valid IP", args.gateway)
+		// loopback
+		iface, err = net.InterfaceByName("lo")
+		if err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+		if err := netlink.NetworkLinkUp(iface); err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
 	}
+	if args.gateway != "" {
+		gw := net.ParseIP(args.gateway)
+		if gw == nil {
+			return fmt.Errorf("Unable to set up networking, %s is not a valid gateway IP", args.gateway)
+		}
 
-	if err := netlink.AddDefaultGw(ip); err != nil {
-		return fmt.Errorf("Unable to set up networking: %v", err)
+		if err := netlink.AddDefaultGw(gw); err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
 	}
 
 	return nil
@@ -199,6 +224,7 @@ func SysInit() {
 	// Get cmdline arguments
 	user := flag.String("u", "", "username or uid")
 	gateway := flag.String("g", "", "gateway address")
+	ip := flag.String("i", "", "ip address")
 	workDir := flag.String("w", "", "workdir")
 	privileged := flag.Bool("privileged", false, "privileged mode")
 	flag.Parse()
@@ -216,6 +242,7 @@ func SysInit() {
 	args := &DockerInitArgs{
 		user:       *user,
 		gateway:    *gateway,
+		ip:         *ip,
 		workDir:    *workDir,
 		privileged: *privileged,
 		env:        env,


### PR DESCRIPTION
As requested by @crosbymichael, this is split out from #3015. This moves the hostname and IP address setup out of the lxc tools and into dockerinit.
