### PR TITLE
dockerinit: propagate "container" env variable from lxc

### DIFF
--- a/container.go
+++ b/container.go
@@ -586,7 +586,6 @@ func (container *Container) Start() (err error) {
 	env := []string{
 		"HOME=/",
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-		"container=lxc",
 		"HOSTNAME=" + container.Config.Hostname,
 	}
 

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -191,6 +191,9 @@ func SysInit() {
 		log.Fatalf("Unable to unmarshal environment variables: %v", err)
 	}
 
+	// Propagate the plugin-specific container env variable
+	env = append(env, "container="+os.Getenv("container"))
+
 	args := &DockerInitArgs{
 		user:       *user,
 		gateway:    *gateway,


### PR DESCRIPTION
Lxc (and libvirt) already set the "container" env variable
appropriately[1], so just use that.

[1] http://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/
