### PR TITLE
add explicit limit nofile in the upstart config

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -5,6 +5,8 @@ stop on runlevel [!2345]
 
 respawn
 
+limit nofile 65536 65536
+
 script
 	DOCKER=/usr/bin/$UPSTART_JOB
 	DOCKER_OPTS=


### PR DESCRIPTION
Hi,

Like [this post](https://coderwall.com/p/myodcq), I had some `ulimit` errors in docker container in Ubuntu box.

This patch of `/etc/init/upstart.conf` helps me.

Thanks,
riywo
