### PR TITLE
Add -bip flag: allow specification of dynamic bridge IP via CIDR

### DIFF
--- a/config.go
+++ b/config.go
@@ -14,6 +14,7 @@ type DaemonConfig struct {
 	Dns                         []string
 	EnableIptables              bool
 	BridgeIface                 string
+	BridgeIp                    string
 	DefaultIp                   net.IP
 	InterContainerCommunication bool
 	GraphDriver                 string
@@ -36,6 +37,7 @@ func ConfigFromJob(job *engine.Job) *DaemonConfig {
 	} else {
 		config.BridgeIface = DefaultNetworkBridge
 	}
+	config.BridgeIp = job.Getenv("BridgeIp")
 	config.DefaultIp = net.ParseIP(job.Getenv("DefaultIp"))
 	config.InterContainerCommunication = job.GetenvBool("InterContainerCommunication")
 	config.GraphDriver = job.Getenv("GraphDriver")

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -30,6 +30,7 @@ func main() {
 		flDebug              = flag.Bool("D", false, "Enable debug mode")
 		flAutoRestart        = flag.Bool("r", true, "Restart previously running containers")
 		bridgeName           = flag.String("b", "", "Attach containers to a pre-existing network bridge; use 'none' to disable container networking")
+		bridgeIp             = flag.String("bip", "", "Use this CIDR notation address for the network bridge's IP, not compatible with -b")
 		pidfile              = flag.String("p", "/var/run/docker.pid", "Path to use for daemon PID file")
 		flRoot               = flag.String("g", "/var/lib/docker", "Path to use as the root of the docker runtime")
 		flEnableCors         = flag.Bool("api-enable-cors", false, "Enable CORS headers in the remote API")
@@ -52,6 +53,10 @@ func main() {
 	if flHosts.Len() == 0 {
 		// If we do not have a host, default to unix socket
 		flHosts.Set(fmt.Sprintf("unix://%s", docker.DEFAULTUNIXSOCKET))
+	}
+
+	if *bridgeName != "" && *bridgeIp != "" {
+		log.Fatal("You specified -b & -bip, mutually exclusive options. Please specify only one.")
 	}
 
 	if *flDebug {
@@ -77,6 +82,7 @@ func main() {
 		job.SetenvList("Dns", flDns.GetAll())
 		job.SetenvBool("EnableIptables", *flEnableIptables)
 		job.Setenv("BridgeIface", *bridgeName)
+		job.Setenv("BridgeIp", *bridgeIp)
 		job.Setenv("DefaultIp", *flDefaultIp)
 		job.SetenvBool("InterContainerCommunication", *flInterContainerComm)
 		job.Setenv("GraphDriver", *flGraphDriver)

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -30,6 +30,7 @@ To list available commands, either run ``docker`` with no parameters or execute
       -H=[unix:///var/run/docker.sock]: Multiple tcp://host:port or unix://path/to/socket to bind in daemon mode, single connection otherwise
       -api-enable-cors=false: Enable CORS headers in the remote API
       -b="": Attach containers to a pre-existing network bridge; use 'none' to disable container networking
+      -bip="": Use the provided CIDR notation address for the dynamically created bridge (docker0); Mutually exclusive of -b
       -d=false: Enable daemon mode
       -dns="": Force docker to use specific DNS servers
       -g="/var/lib/docker": Path to use as the root of the docker runtime


### PR DESCRIPTION
e.g.:

```
docker -d -bip "10.10.0.1/16"
```

If set and valid, use provided in place of trial and error from pre-defined array in network.go.
Mutually exclusive of -b option.

Replacing PR https://github.com/dotcloud/docker/pull/3178
