### PR TITLE
Add new cover bundlescript for giving a nice report across all the coverprofiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,9 @@ RUN	git clone https://git.fedorahosted.org/git/lvm2.git /usr/local/lvm2 && cd /u
 RUN	cd /usr/local/lvm2 && ./configure --enable-static_link && make device-mapper && make install_device-mapper
 # see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
+# Grab Go's cover tool for dead-simple code coverage testing
+RUN	go get code.google.com/p/go.tools/cmd/cover
+
 VOLUME	/var/lib/docker
 WORKDIR	/go/src/github.com/dotcloud/docker
 

--- a/hack/make/cover
+++ b/hack/make/cover
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+DEST="$1"
+
+bundle_cover() {
+	coverprofiles=( "$DEST/../"*"/coverprofiles/"* )
+	for p in "${coverprofiles[@]}"; do
+		echo
+		(
+			set -x
+			go tool cover -func="$p"
+		)
+	done
+}
+
+if [ "$HAVE_GO_TEST_COVER" ]; then
+	bundle_cover 2>&1 | tee "$DEST/report.log"
+else
+	echo >&2 'warning: the current version of go does not support -cover'
+	echo >&2 '  skipping test coverage report'
+fi


### PR DESCRIPTION
... generated by the test scripts

Also, make sure that any version of go that supports -cover gets -cover added to "go test" and an appropriate -coverprofile for our reporting script.
