### PR TITLE
lxc-start-unconfined softlink can go bad

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -868,7 +868,7 @@ func linkLxcStart(root string) error {
 	}
 	targetPath := path.Join(root, "lxc-start-unconfined")
 
-	if _, err := os.Stat(targetPath); err != nil && !os.IsNotExist(err) {
+	if _, err := os.Lstat(targetPath); err != nil && !os.IsNotExist(err) {
 		return err
 	} else if err == nil {
 		if err := os.Remove(targetPath); err != nil {


### PR DESCRIPTION
when sharing a /var/lib/docker dir with more than one distribution, an existing lxc-start-unconfined softlink may point to a non-existant path, following that link (as Stat does) will cause the daemon to fail to start

for eg, I'm swapping between my original ubuntu install and booting from a boot2docker sd-card (finally found a use for my 10 year old 32Meg SD cards!!)

boot2docker has /bin/lxc-startup, ubuntu has /usr/bin/lxc-startup
