### PR TITLE
Issues #1691 Entry for VMWare's vagrant provisioning is breaking Vagrant...

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -143,7 +143,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
 
   config.vm.provider :vmware_fusion do |f, override|
     override.vm.box_url = VF_BOX_URI
-    override.vm.synced_folder ".", "/vagrant", disabled: true
+    override.vm.synced_folder ".", "/vagrant", :disabled => true
     override.vm.provision :shell, :inline => $script
     f.vmx["displayName"] = "docker"
   end


### PR DESCRIPTION
Issues #1691 Entry for VMWare's vagrant provisioning is breaking Vagrant usage. "disabled is a symbol and requires a colon"

I was attempting to run the following introduction guide http://docs.docker.io/en/latest/installation/vagrant/ and ran into the following issue https://github.com/dotcloud/docker/issues/1691. It has a listed fix and is closed but change was not added into the code base.

This is a small change to correct this issue.
