### PR TITLE
copy from image to host (`docker cp -image <image>:…`)

### DIFF
--- a/api.go
+++ b/api.go
@@ -372,6 +372,36 @@ func postImagesTag(srv *Server, version float64, w http.ResponseWriter, r *http.
 	return nil
 }
 
+func postImagesCopy(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if vars == nil {
+		return fmt.Errorf("Missing parameter")
+	}
+	name := vars["name"]
+
+	copyData := &APICopy{}
+	contentType := r.Header.Get("Content-Type")
+	if contentType == "application/json" {
+		if err := json.NewDecoder(r.Body).Decode(copyData); err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("Content-Type not supported: %s", contentType)
+	}
+
+	if copyData.Resource == "" {
+		return fmt.Errorf("Path cannot be empty")
+	}
+	if copyData.Resource[0] == '/' {
+		copyData.Resource = copyData.Resource[1:]
+	}
+
+	if err := srv.ImageCopy(name, copyData.Resource, w); err != nil {
+		utils.Errorf("%s", err.Error())
+		return err
+	}
+	return nil
+}
+
 func postCommit(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -1121,6 +1151,7 @@ func createRouter(srv *Server, logging bool) (*mux.Router, error) {
 			"/images/load":                  postImagesLoad,
 			"/images/{name:.*}/push":        postImagesPush,
 			"/images/{name:.*}/tag":         postImagesTag,
+			"/images/{name:.*}/copy":        postImagesCopy,
 			"/containers/create":            postContainersCreate,
 			"/containers/{name:.*}/kill":    postContainersKill,
 			"/containers/{name:.*}/restart": postContainersRestart,

--- a/commands.go
+++ b/commands.go
@@ -83,7 +83,7 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 		{"attach", "Attach to a running container"},
 		{"build", "Build a container from a Dockerfile"},
 		{"commit", "Create a new image from a container's changes"},
-		{"cp", "Copy files/folders from the containers filesystem to the host path"},
+		{"cp", "Copy files/folders from the container's/image's filesystem to the host path"},
 		{"diff", "Inspect changes on a container's filesystem"},
 		{"events", "Get real time events from the server"},
 		{"export", "Stream the contents of a container as a tar archive"},
@@ -2154,9 +2154,14 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 }
 
 func (cli *DockerCli) CmdCp(args ...string) error {
-	cmd := cli.Subcmd("cp", "CONTAINER:PATH HOSTPATH", "Copy files/folders from the PATH to the HOSTPATH")
+	cmd := cli.Subcmd("cp", "[OPTIONS] NAME:PATH HOSTPATH", "Copy files/folders from the PATH on the container NAME to the HOSTPATH")
+	image := cmd.Bool("image", false, "Treat NAME as an image (and not a container).")
 	if err := cmd.Parse(args); err != nil {
 		return nil
+	}
+	endpoint := "/containers/"
+	if *image {
+		endpoint = "/images/"
 	}
 
 	if cmd.NArg() != 2 {
@@ -2174,7 +2179,7 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 	copyData.Resource = info[1]
 	copyData.HostPath = cmd.Arg(1)
 
-	data, statusCode, err := cli.call("POST", "/containers/"+info[0]+"/copy", copyData)
+	data, statusCode, err := cli.call("POST", endpoint+info[0]+"/copy", copyData)
 	if err != nil {
 		return err
 	}

--- a/docs/sources/api/docker_remote_api_v1.8.rst
+++ b/docs/sources/api/docker_remote_api_v1.8.rst
@@ -935,6 +935,38 @@ Remove an image
         :statuscode 500: server error
 
 
+Copy files or folders from an image
+***********************************
+
+.. http:post:: /images/(name)/copy
+
+	Copy files or folders of image ``name``
+
+	**Example request**:
+
+	.. sourcecode:: http
+
+	   POST /images/test/copy HTTP/1.1
+	   Content-Type: application/json
+
+	   {
+		"Resource":"test.txt"
+	   }
+
+	**Example response**:
+
+	.. sourcecode:: http
+
+	   HTTP/1.1 200 OK
+	   Content-Type: application/octet-stream
+
+	   {{ STREAM }}
+
+	:statuscode 200: no error
+	:statuscode 404: no such image
+	:statuscode 500: server error
+
+
 Search images
 *************
 

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -323,15 +323,18 @@ or ``config`` when running ``docker inspect IMAGEID``.
 
 ::
 
-    Usage: docker cp CONTAINER:PATH HOSTPATH
+    Usage: docker cp [OPTIONS] NAME:PATH HOSTPATH
 
-    Copy files/folders from the containers filesystem to the host
+    Copy files/folders from the PATH on the container NAME to the host
     path.  Paths are relative to the root of the filesystem.
 
+      -image=false: Treat NAME as an image (and not a container).
+    
 .. code-block:: bash
 
     $ sudo docker cp 7bb0e258aefe:/etc/debian_version .
     $ sudo docker cp blue_frog:/etc/hosts .
+    $ sudo docker cp -image ubuntu:/etc/debian_version .
 
 .. _cli_diff:
 

--- a/image.go
+++ b/image.go
@@ -175,6 +175,11 @@ func (img *Image) TarLayer() (archive.Archive, error) {
 	}
 }
 
+func (img *Image) Copy(resource string) (archive.Archive, error) {
+	// TODO: extract only 'resource'
+	return img.TarLayer();
+}
+
 func ValidateID(id string) error {
 	if id == "" {
 		return fmt.Errorf("Image id can't be empty")

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -1187,6 +1187,52 @@ func TestDeleteImages(t *testing.T) {
 	}
 }
 
+func TestPostImagesCopy(t *testing.T) {
+	eng := NewTestEngine(t)
+	defer mkRuntimeFromEngine(eng, t).Nuke()
+	srv := mkServerFromEngine(eng, t)
+
+	r := httptest.NewRecorder()
+	copyData := docker.APICopy{HostPath: ".", Resource: "/bin/sh"}
+
+	jsonData, err := json.Marshal(copyData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("POST", "/images/"+unitTestImageName+"/copy", bytes.NewReader(jsonData))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("Content-Type", "application/json")
+	if err := docker.ServeRequest(srv, docker.APIVERSION, r, req); err != nil {
+		t.Fatal(err)
+	}
+	assertHttpNotError(r, t)
+
+	if r.Code != http.StatusOK {
+		t.Fatalf("%d OK expected, received %d\n", http.StatusOK, r.Code)
+	}
+
+	found := false
+	for tarReader := tar.NewReader(r.Body); ; {
+		h, err := tarReader.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatal(err)
+		}
+		if h.Name == "sh" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("The requested file has not been found in the copied output")
+	}
+}
+
 func TestPostContainersCopy(t *testing.T) {
 	eng := NewTestEngine(t)
 	defer mkRuntimeFromEngine(eng, t).Nuke()

--- a/server.go
+++ b/server.go
@@ -882,6 +882,34 @@ func (srv *Server) ImageTag(job *engine.Job) engine.Status {
 	return engine.StatusOK
 }
 
+func (srv *Server) ImageCopy(name string, resource string, out io.Writer) error {
+	rootRepo, err := srv.runtime.repositories.Get(name)
+	if err != nil {
+		return err
+	}
+	if rootRepo != nil {
+		// raise error about inexact name?
+		for _, id := range rootRepo {
+			name = id
+			break
+		}
+	}
+	image, err := srv.ImageInspect(name)
+	if err != nil {
+		return err
+	}
+
+	data, err := image.Copy(resource)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, data); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (srv *Server) pullImage(r *registry.Registry, out io.Writer, imgID, endpoint string, token []string, sf *utils.StreamFormatter) error {
 	history, err := r.GetRemoteHistory(imgID, endpoint, token)
 	if err != nil {


### PR DESCRIPTION
It would be nice if we didn't have to spin up a container just to extract a file or directory from an image.  We can currently accomplish this with:

```
$ CONTAINER=$(docker run -v ${HOSTPATH}:/tmp ${IMAGE} cp -rp ${PATH} /tmp/)
$ docker rm "${CONTAINER}"
```

On `#docker`, `bkc_` suggesed an `-i[mage]` flag for disambiguating container-vs-image for `docker cp`:

```
$ docker cp ${CONTAINER}:${PATH} ${HOSTPATH}
$ docker cp -image ${IMAGE}:${PATH} ${HOSTPATH}
```

This would involve an API extension (`/images/(name)/copy`, mirroring `/containers/(id)/copy`), and the `-i[mage]` flag would swap the client between API URLs.  I'll take a stab at implementing this if it sounds reasonable.
