### PR TITLE
Updated Introduction link

### DIFF
--- a/docs/sources/index.rst
+++ b/docs/sources/index.rst
@@ -25,7 +25,7 @@ currently in active development, so this documentation will change
 frequently.
 
 For an overview of Docker, please see the `Introduction
-<http://www.docker.io>`_. When you're ready to start working with
+<http://www.docker.io/learn_more/>`_. When you're ready to start working with
 Docker, we have a `quick start <http://www.docker.io/gettingstarted>`_
 and a more in-depth guide to :ref:`ubuntu_linux` and other
 :ref:`installation_list` paths including prebuilt binaries,


### PR DESCRIPTION
Previously the introduction link pointed to www.docker.io. That
did not seem to make a lot of sense to me so instead I pointed it
at:

http://www.docker.io/learn_more/
