### PR TITLE
please, don't use 30% of the documentation screen for whitespace

### DIFF
--- a/docs/theme/docker/layout.html
+++ b/docs/theme/docker/layout.html
@@ -86,13 +86,13 @@
     </div>
 </div>
 
-<div class="container">
+<div class="container-fluid">
 
     <!-- Docs nav
      ================================================== -->
-    <div class="row main-row">
+    <div class="row-fluid main-row">
 
-        <div class="span3 sidebar bs-docs-sidebar">
+        <div class="span2 sidebar bs-docs-sidebar">
             <div class="page-title" >
                 <h4>DOCUMENTATION</h4>
             </div>
@@ -105,7 +105,7 @@
         </div>
 
         <!-- body block -->
-        <div class="span9 main-content">
+        <div class="span10 main-content">
 
             <!-- Main section
             ================================================== -->


### PR DESCRIPTION
it compresses the examples so they are ~80 chars wide (on my 1400x900 px notebook) - the output of 'docker ps' and 'docker images' becomes needlessly unreadable

@dhrp
