### PR TITLE
Update binaries.rst

### DIFF
--- a/docs/sources/installation/binaries.rst
+++ b/docs/sources/installation/binaries.rst
@@ -21,6 +21,11 @@ Check Your Kernel
 
 Your host's Linux kernel must meet the Docker :ref:`kernel`
 
+Check for User Space Tools
+--------------------------
+
+You must have a working installation of the `lxc <http://linuxcontainers.org>`_ utilities and library.
+
 Get the docker binary:
 ----------------------
 


### PR DESCRIPTION
Along with the kernel requirement, you need a working copy of lxc.  When trying to start using "/docker -d", received error 'initapi: exec: "lxc-start": executable file not found in $PATH'
