### PR TITLE
Full width documentation

### DIFF
--- a/docs/theme/docker/layout.html
+++ b/docs/theme/docker/layout.html
@@ -86,13 +86,13 @@
     </div>
 </div>
 
-<div class="container">
+<div class="container-fluid">
 
     <!-- Docs nav
      ================================================== -->
-    <div class="row main-row">
+    <div class="row-fluid main-row">
 
-        <div class="span3 sidebar bs-docs-sidebar">
+        <div class="span2 sidebar bs-docs-sidebar">
             <div class="page-title" >
                 <h4>DOCUMENTATION</h4>
             </div>
@@ -105,7 +105,7 @@
         </div>
 
         <!-- body block -->
-        <div class="span9 main-content">
+        <div class="span10 main-content">
 
             <!-- Main section
             ================================================== -->

--- a/docs/theme/docker/layout.html
+++ b/docs/theme/docker/layout.html
@@ -92,7 +92,7 @@
      ================================================== -->
     <div class="row-fluid main-row">
 
-        <div class="span2 sidebar bs-docs-sidebar">
+        <div class="sidebar bs-docs-sidebar">
             <div class="page-title" >
                 <h4>DOCUMENTATION</h4>
             </div>
@@ -105,7 +105,7 @@
         </div>
 
         <!-- body block -->
-        <div class="span10 main-content">
+        <div class="main-content">
 
             <!-- Main section
             ================================================== -->

--- a/docs/theme/docker/static/css/main.css
+++ b/docs/theme/docker/static/css/main.css
@@ -186,8 +186,15 @@ body {
 .main-row {
   margin-top: 40px;
 }
+.sidebar {
+  width: 215px;
+  float: left;
+}
 .main-content {
   padding: 16px 18px inherit;
+  margin-left: 230px;
+  /* space for sidebar */
+
 }
 /* =======================
    Social footer
@@ -410,7 +417,7 @@ dt:hover > a.headerlink {
 .admonition.seealso {
   border-color: #23cb1f;
 }
-
+/* Add styles for other types of comments */
 .versionchanged,
 .versionadded,
 .versionmodified,
@@ -418,15 +425,12 @@ dt:hover > a.headerlink {
   font-size: larger;
   font-weight: bold;
 }
-
 .versionchanged {
   color: lightseagreen;
 }
-
 .versionadded {
   color: mediumblue;
 }
-
 .deprecated {
   color: orangered;
 }

--- a/docs/theme/docker/static/css/main.less
+++ b/docs/theme/docker/static/css/main.less
@@ -98,7 +98,6 @@ p a {
 }
 
 
-
 .navbar .brand {
 	margin-left: 0px;
 	float: left;
@@ -317,9 +316,17 @@ body {
   margin-top: 40px;
 }
 
+.sidebar {
+  width: 215px;
+  float: left;
+}
+
 .main-content {
   padding: 16px 18px inherit;
+  margin-left: 230px; /* space for sidebar */
 }
+
+
 
 /* =======================
    Social footer
@@ -611,4 +618,27 @@ dt:hover > a.headerlink {
   }
 
 }
+
+/* Add styles for other types of comments */
+
+.versionchanged,
+.versionadded,
+.versionmodified,
+.deprecated {
+   font-size: larger;
+   font-weight: bold;
+}
+
+.versionchanged {
+  color: lightseagreen;
+}
+
+.versionadded {
+   color: mediumblue;
+}
+
+.deprecated {
+   color: orangered;
+}
+
 


### PR DESCRIPTION
Thanks @SvenDowideit for your suggestion in using the full width for the documentation while not changing the width of the Navigation. 

I've made some changes here to use a fixed width for the sidebar so it doesn't become too narrow for some lines. 

Not related, but required to keep a previous change from falling out: I've moved the .versionchanged, .versionadded, .versionmodified, in the .less file. - the .css is generated from that.

Please note that this PR supersedes PR #3226
