### PR TITLE
Warn about host possibly being rooted by a DNS spoofer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ editors have plugins that do this automatically, and there's also a git
 pre-commit hook:
 
 ```
-curl -o .git/hooks/pre-commit https://raw.github.com/edsrzf/gofmt-git-hook/master/fmt-check && chmod +x .git/hooks/pre-commit
+curl -sSo .git/hooks/pre-commit https://raw.github.com/edsrzf/gofmt-git-hook/master/fmt-check && chmod +x .git/hooks/pre-commit
 ```
 
 Pull requests descriptions should be as clear as possible and include a

--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -95,7 +95,7 @@ continue installation.*
 
     .. warning::
     
-        Only run this when you trust you DNS and your OS' certificate chain.
+        Only run this when you trust your DNS and your OS's certificate chain.
 
     .. code-block:: bash
 

--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -93,9 +93,13 @@ continue installation.*
 
     There is also a simple ``curl`` script available to help with this process.
 
+    .. warning::
+    
+        Only run this when you trust you DNS and your OS' certificate chain.
+
     .. code-block:: bash
 
-        curl -s https://get.docker.io/ubuntu/ | sudo sh
+        curl -sS https://get.docker.io/ubuntu/ | sudo sh
 
 Now verify that the installation has worked by downloading the ``ubuntu`` image
 and launching a container.

--- a/hack/infrastructure/docker-ci/deployment.py
+++ b/hack/infrastructure/docker-ci/deployment.py
@@ -143,7 +143,7 @@ sudo('pip install -r {}/requirements.txt'.format(CFG_PATH))
 
 # Install docker and testing dependencies
 sudo('apt-get install -y -q lxc-docker')
-sudo('curl -s https://phantomjs.googlecode.com/files/'
+sudo('curl -sS https://phantomjs.googlecode.com/files/'
     'phantomjs-1.9.1-linux-x86_64.tar.bz2 | tar jx -C /usr/bin'
     ' --strip-components=2 phantomjs-1.9.1-linux-x86_64/bin/phantomjs')
 

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -2,7 +2,7 @@
 set -e
 #
 # This script is meant for quick & easy install via:
-#   'curl -sL https://get.docker.io/ | sh'
+#   'curl -sSL https://get.docker.io/ | sh'
 # or:
 #   'wget -qO- https://get.docker.io/ | sh'
 #
@@ -52,7 +52,7 @@ fi
 
 curl=''
 if command_exists curl; then
-	curl='curl -sL'
+	curl='curl -sSL'
 elif command_exists wget; then
 	curl='wget -qO-'
 elif command_exists busybox && busybox --list-modules | grep -q wget; then
@@ -104,7 +104,7 @@ case "$lsb_dist" in
 		if [ -z "$curl" ]; then
 			apt_get_update
 			( set -x; $sh_c 'sleep 3; apt-get install -y -q curl' )
-			curl='curl -sL'
+			curl='curl -sSL'
 		fi
 		(
 			set -x


### PR DESCRIPTION
When the installer runs the given command blindly, without looking at the payload being `curl`ed, an attacker could run any command as root by spoofing the host's DNS.

SSL may not prove save at this point, as the local cert chain is not always kept under a keen eye and may contain certs from questionable or outdated CAs.

Saving it temporarily to a file, looking at it and running it manually may be an option for the healthy paranoid admin.

Better warn the careless and let curl blerch when SSL smells.
