### PR TITLE
Fix "go tool cover" detection to only add -cover and -coverprofile if we...

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -66,7 +66,10 @@ LDFLAGS_STATIC='-X github.com/dotcloud/docker/utils.IAMSTATIC true -linkmode ext
 BUILDFLAGS='-tags netgo'
 
 HAVE_GO_TEST_COVER=
-if go help testflag | grep -q -- -cover; then
+if \
+	go help testflag | grep -q -- -cover \
+	&& go tool -n cover > /dev/null 2>&1 \
+; then
 	HAVE_GO_TEST_COVER=1
 fi
 


### PR DESCRIPTION
... both have cover support in Go, and if we have the cover tool downloaded

Otherwise we get lots of false negatives because we don't have the cover tool installed.
