### PR TITLE
go build -a

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN	apt-get install -y -q build-essential libsqlite3-dev
 RUN	curl -s https://go.googlecode.com/files/go1.2.src.tar.gz | tar -v -C /usr/local -xz
 ENV	PATH	/usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
 ENV	GOPATH	/go:/go/src/github.com/dotcloud/docker/vendor
-RUN	cd /usr/local/go/src && ./make.bash && go install -ldflags '-w -linkmode external -extldflags "-static -Wl,--unresolved-symbols=ignore-in-shared-libs"' -tags netgo -a std
+RUN	cd /usr/local/go/src && ./make.bash
 
 # Ubuntu stuff
 RUN	apt-get install -y -q ruby1.9.3 rubygems libffi-dev

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -2,5 +2,5 @@
 
 DEST=$1
 
-go build -o $DEST/docker-$VERSION -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS ./docker
+go build -a -o $DEST/docker-$VERSION -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS ./docker
 echo "Created binary: $DEST/docker-$VERSION"


### PR DESCRIPTION
Since most of us use the Dockerfile/Makefile to rebuild, this will change the actual build time for only a small handful of people, and not by much.  In return, we get _much_ more consistent builds, especially when running tests (which do a `go test -i`) and then building afterwards with GOPATH/pkg directories around (yes, this has bitten me several times, one of them very recent and prompting this change).
