### PR TITLE
Purge more hack references to Go 1.1.2

### DIFF
--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -36,7 +36,7 @@ To build docker, you will need the following system dependencies
 
 * An amd64 machine
 * A recent version of git and mercurial
-* Go version 1.2 or later (see notes below regarding using Go 1.1.2 and dynbinary)
+* Go version 1.2 or later
 * SQLite version 3.7.9 or later
 * A clean checkout of the source must be added to a valid Go [workspace](http://golang.org/doc/code.html#Workspaces)
 under the path *src/github.com/dotcloud/docker*.
@@ -91,8 +91,7 @@ You would do the users of your distro a disservice and "void the docker warranty
 A good comparison is Busybox: all distros package it as a statically linked binary, because it just
 makes sense. Docker is the same way.
 
-If you *must* have a non-static Docker binary, or require Go 1.1.2 (since Go 1.2 is still freshly released
-at the time of this writing), please use:
+If you *must* have a non-static Docker binary, please use:
 
 ```bash
 ./hack/make.sh dynbinary

--- a/hack/infrastructure/docker-ci/deployment.py
+++ b/hack/infrastructure/docker-ci/deployment.py
@@ -136,7 +136,7 @@ sudo('echo -e "deb http://archive.ubuntu.com/ubuntu raring main universe\n'
 sudo('DEBIAN_FRONTEND=noninteractive apt-get install -q -y wget python-dev'
     ' python-pip supervisor git mercurial linux-image-extra-$(uname -r)'
     ' aufs-tools make libfontconfig libevent-dev libsqlite3-dev libssl-dev')
-sudo('wget -O - https://go.googlecode.com/files/go1.1.2.linux-amd64.tar.gz | '
+sudo('wget -O - https://go.googlecode.com/files/go1.2.linux-amd64.tar.gz | '
     'tar -v -C /usr/local -xz; ln -s /usr/local/go/bin/go /usr/bin/go')
 sudo('GOPATH=/go go get -d github.com/dotcloud/docker')
 sudo('pip install -r {}/requirements.txt'.format(CFG_PATH))


### PR DESCRIPTION
since it requires backported archive/tar patches now, and Go 1.2 is _widely_ packaged successfully
