### PR TITLE
Handle compressed tars in ApplyLayer

### DIFF
--- a/archive/diff.go
+++ b/archive/diff.go
@@ -34,6 +34,11 @@ func ApplyLayer(dest string, layer Archive) error {
 	oldmask := syscall.Umask(0)
 	defer syscall.Umask(oldmask)
 
+	layer, err := DecompressStream(layer)
+	if err != nil {
+		return err
+	}
+
 	tr := tar.NewReader(layer)
 
 	var dirs []*tar.Header


### PR DESCRIPTION
When pulling from a registry we get a compressed tar archive, so
we need to wrap the stream in the right kind of compress reader.

Unfortunately go doesn't have an Xz decompression method, but I
don't think any docker layers use that atm anyway.

This fixes a regression from https://github.com/dotcloud/docker/pull/3207
