### PR TITLE
Docker fedora conflict

### DIFF
--- a/docs/sources/installation/fedora.rst
+++ b/docs/sources/installation/fedora.rst
@@ -20,6 +20,7 @@ Installation
 
 The ``docker-io`` package provides Docker on fedora.
 
+
 If you already have the (unrelated) ``docker`` package installed, it will
 conflict with ``docker-io``. There's a `bug report`_ filed for it.
 To proceed with ``docker-io`` installation on fedora 19, please remove
@@ -71,3 +72,4 @@ Now let's verify that Docker is working.
 **Done!**, now continue with the :ref:`hello_world` example.
 
 .. _bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1043676
+

--- a/docs/sources/installation/fedora.rst
+++ b/docs/sources/installation/fedora.rst
@@ -1,6 +1,6 @@
 :title: Requirements and Installation on Fedora
 :description: Please note this project is currently under heavy development. It should not be used in production.
-:keywords: Docker, Docker documentation, fedora, requirements, virtualbox, vagrant, git, ssh, putty, cygwin, linux
+:keywords: Docker, Docker documentation, Fedora, requirements, virtualbox, vagrant, git, ssh, putty, cygwin, linux
 
 .. _fedora:
 
@@ -18,20 +18,20 @@ architecture.
 Installation
 ------------
 
-The ``docker-io`` package provides Docker on fedora.
+The ``docker-io`` package provides Docker on Fedora.
 
 
-If you already have the (unrelated) ``docker`` package installed, it will
+If you have the (unrelated) ``docker`` package installed already, it will
 conflict with ``docker-io``. There's a `bug report`_ filed for it.
-To proceed with ``docker-io`` installation on fedora 19, please remove
+To proceed with ``docker-io`` installation on Fedora 19, please remove
 ``docker`` first.
 
 .. code-block:: bash
 
    sudo yum -y remove docker
 
-For fedora 20 and above, the ``wmdocker`` package will provide the same
-functionality as ``docker`` and will also not conflict with ``docker-io``
+For Fedora 20 and later, the ``wmdocker`` package will provide the same
+functionality as ``docker`` and will also not conflict with ``docker-io``.
 
 .. code-block:: bash
 
@@ -45,7 +45,7 @@ Install the ``docker-io`` package which will install Docker on our host.
    sudo yum -y install docker-io
 
 
-To update the ``docker-io`` package
+To update the ``docker-io`` package:
 
 .. code-block:: bash
 

--- a/docs/sources/installation/fedora.rst
+++ b/docs/sources/installation/fedora.rst
@@ -18,11 +18,31 @@ architecture.
 Installation
 ------------
 
+The ``docker-io`` package provides Docker on fedora.
+
+If you already have the (unrelated) ``docker`` package installed, it will
+conflict with ``docker-io``. There's a `bug report`_ filed for it.
+To proceed with ``docker-io`` installation on fedora 19, please remove
+``docker`` first.
+
+.. code-block:: bash
+
+   sudo yum -y remove docker
+
+For fedora 20 and above, the ``wmdocker`` package will provide the same
+functionality as ``docker`` and will also not conflict with ``docker-io``
+
+.. code-block:: bash
+
+   sudo yum -y install wmdocker
+   sudo yum -y remove docker
+
 Install the ``docker-io`` package which will install Docker on our host.
 
 .. code-block:: bash
 
    sudo yum -y install docker-io
+
 
 To update the ``docker-io`` package
 
@@ -50,3 +70,4 @@ Now let's verify that Docker is working.
 
 **Done!**, now continue with the :ref:`hello_world` example.
 
+.. _bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1043676

--- a/docs/sources/installation/rhel.rst
+++ b/docs/sources/installation/rhel.rst
@@ -28,6 +28,15 @@ Installation
 Firstly, you need to install the EPEL repository. Please follow the `EPEL installation instructions`_.
 
 
+The ``docker-io`` package provides Docker on EPEL.
+
+
+If you already have the (unrelated) ``docker`` package installed, it will
+conflict with ``docker-io``. There's a `bug report`_ filed for it.
+To proceed with ``docker-io`` installation, please remove
+``docker`` first.
+
+
 Next, let's install the ``docker-io`` package which will install Docker on our host.
 
 .. code-block:: bash
@@ -68,4 +77,5 @@ If you have any issues - please report them directly in the `Red Hat Bugzilla fo
 .. _Extra Packages for Enterprise Linux (EPEL): https://fedoraproject.org/wiki/EPEL
 .. _EPEL installation instructions: https://fedoraproject.org/wiki/EPEL#How_can_I_use_these_extra_packages.3F
 .. _Red Hat Bugzilla for docker-io component : https://bugzilla.redhat.com/enter_bug.cgi?product=Fedora%20EPEL&component=docker-io
+.. _bug report: https://bugzilla.redhat.com/show_bug.cgi?id=1043676
 


### PR DESCRIPTION
this update addresses the conflict between docker and docker-io packages on fedora and rhel. More info: https://bugzilla.redhat.com/show_bug.cgi?id=1043676
