### PR TITLE
Build multiple tagged images per Dockerfile

### DIFF
--- a/docs/sources/use/builder.rst
+++ b/docs/sources/use/builder.rst
@@ -94,6 +94,10 @@ Or
 
     ``FROM <image>:<tag>``
 
+Or (after the first ``TAG`` instruction)
+
+    ``FROM :<tag>``
+
 The ``FROM`` instruction sets the :ref:`base_image_def` for subsequent
 instructions. As such, a valid Dockerfile must have ``FROM`` as its
 first instruction. The image can be any valid image -- it is
@@ -109,6 +113,9 @@ output by the commit before each new ``FROM`` command.
 
 If no ``tag`` is given to the ``FROM`` instruction, ``latest`` is
 assumed. If the used tag does not exist, an error will be returned.
+If no ``image`` is given to the ``FROM`` instruction, the builder
+will try to lookup the tag from the current build environment, based
+on :ref:`dockerfile_tag`.
 
 .. _dockerfile_maintainer:
 
@@ -369,6 +376,22 @@ the image.
 The ``WORKDIR`` instruction sets the working directory in which
 the command given by ``CMD`` is executed.
 
+.. _dockerfile_tag:
+
+3.12 TAG
+--------
+    ``TAG :<tag>``
+
+The ``TAG`` instruction saves the current image to the specified tag at the end of the build process.
+``TAG`` can appear multiple times within a single Dockerfile.
+
+``TAG`` is useful with the ``FROM :<tag>`` instruction, which allows building multiple images from 
+the current build environment.
+This facilitates creation of multiple image "flavors" based off a single Dockerfile, each of which
+can have different ``ENV``, ``ENTRYPOINT``, ``RUN`` or other build instructions.
+
+Tags must start with a ``:``.
+
 .. _dockerfile_examples:
 
 4. Dockerfile Examples
@@ -427,3 +450,28 @@ the command given by ``CMD`` is executed.
 
     # You'll now have two images, 907ad6c2736f with /bar, and 695d7793cbe4 with
     # /oink.
+
+.. code-block:: bash
+
+    # Multiple image flavors using tags
+    #
+    # VERSION               0.0.1
+    FROM ubuntu
+    ENV DEFAULT value
+    TAG :latest
+    # Will mark the current image as "latest" for use by future FROM statements
+
+    # Reset the build environment to "latest" to create a new flavor
+    FROM :latest
+    ENV WEB 1
+    ENTRYPOINT ["/bin/echo", "web"]
+    TAG :web
+    # Will output the current image as <image>:web
+
+    # Reset the build environment to "latest" to create a new flavor
+    FROM :latest
+    ENV WORKER 1
+    ENTRYPOINT ["/bin/echo", "worker"]
+    TAG :worker
+    # Will output the current image as <image>:worker
+


### PR DESCRIPTION
As discussed with @creack, the goal of this PR is to allow a single `Dockerfile` to build multiple flavors of an image using the current build environment.  This is useful for:
- Creating lightweight image layers that customize metadata (ENV, ENTRYPOINT, etc)
- Adding layers to a base image from arbitrary points in the current build
- Modeling Heroku-style process types as specified in a `Procfile`
## Example Usage

A developer is creating a `Dockerfile` to deploy a web application.  The application has 3 main flavors of usage:
1. Run an interactive shell
2. Run a web server
3. Run a worker

With the TAG instruction, developers can create multiple tagged images for each flavor from a single `Dockerfile`:

```
FROM stackbrew/ubuntu:12.04
ENV DEFAULT value
TAG :latest

FROM :latest
ENV WEB 1
ENTRYPOINT ["/bin/echo", "web"]
TAG :web

FROM :latest
ENV WORKER 1
ENTRYPOINT ["/bin/echo", "worker"]
TAG :worker
```

Building the `Dockerfile` results in the following output:

```
# docker build -t gabrtv/test .
Uploading context 204.8 kB
Step 1 : FROM stackbrew/ubuntu:12.04
 ---> 4fc5ba8a5b33
Step 2 : ENV DEFAULT value
 ---> Running in 0787811a7674
 ---> e2e373ff1a73
Step 3 : TAG :latest
 ---> e2e373ff1a73
Step 4 : FROM :latest
 ---> e2e373ff1a73
Step 5 : ENV WEB 1
 ---> Running in 715022e443a5
 ---> be2cd6668a56
Step 6 : ENTRYPOINT ["/bin/echo", "web"]
 ---> Running in ba94a225079b
 ---> 09484a63e190
Step 7 : TAG :web
 ---> 09484a63e190
Step 8 : FROM :latest
 ---> e2e373ff1a73
Step 9 : ENV WORKER 1
 ---> Running in a0d0154804af
 ---> 76cb1d83b7bd
Step 10 : ENTRYPOINT ["/bin/echo", "worker"]
 ---> Running in f370e833e660
 ---> 2ff2d5c7942b
Step 11 : TAG :worker
 ---> 2ff2d5c7942b
Successfully built 2ff2d5c7942b
```

.. which results in the following new images:

```
# docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
gabrtv/test         latest              e2e373ff1a73        38 seconds ago      93.66 MB
gabrtv/test         worker              2ff2d5c7942b        38 seconds ago      93.66 MB
gabrtv/test         web                 09484a63e190        38 seconds ago      93.66 MB
```

Playing with the images demonstrates their unique flavors:

```
# docker run -t -i gabrtv/test bash
root@3b527e5a0c8c:/# echo $DEFAULT
value

# docker run gabrtv/test:web
web

# docker run gabrtv/test:worker
worker

# docker run -entrypoint=/usr/bin/env gabrtv/test:worker
HOME=/
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=af87e9b3306e
DEFAULT=value
WORKER=1
container=lxc
```

The PR includes documentation, integration tests and should be backwards compatible.
