### PR TITLE
Add -a to our BUILDFLAGS directly, which fixes some fun test compilation issues

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -63,7 +63,7 @@ fi
 # Use these flags when compiling the tests and final binary
 LDFLAGS='-X main.GITCOMMIT "'$GITCOMMIT'" -X main.VERSION "'$VERSION'" -w'
 LDFLAGS_STATIC='-X github.com/dotcloud/docker/utils.IAMSTATIC true -linkmode external -extldflags "-lpthread -static -Wl,--unresolved-symbols=ignore-in-object-files"'
-BUILDFLAGS='-tags netgo'
+BUILDFLAGS='-tags netgo -a'
 
 HAVE_GO_TEST_COVER=
 if \
@@ -88,10 +88,6 @@ go_test_dir() {
 		coverprofile="$DEST/coverprofiles/${coverprofile//\//-}"
 		testcover=( -cover -coverprofile "$coverprofile" )
 	fi
-	( # we run "go test -i" ouside the "set -x" to provde cleaner output
-		cd "$dir"
-		go test -i -ldflags "$LDFLAGS" $BUILDFLAGS
-	)
 	(
 		set -x
 		cd "$dir"

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -2,5 +2,5 @@
 
 DEST=$1
 
-go build -a -o $DEST/docker-$VERSION -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS ./docker
+go build -o $DEST/docker-$VERSION -ldflags "$LDFLAGS $LDFLAGS_STATIC" $BUILDFLAGS ./docker
 echo "Created binary: $DEST/docker-$VERSION"

--- a/hack/make/dynbinary
+++ b/hack/make/dynbinary
@@ -3,7 +3,7 @@
 DEST=$1
 
 # dockerinit still needs to be a static binary, even if docker is dynamic
-CGO_ENABLED=0 go build -a -o $DEST/dockerinit-$VERSION -ldflags "$LDFLAGS -d" $BUILDFLAGS ./dockerinit
+CGO_ENABLED=0 go build -o $DEST/dockerinit-$VERSION -ldflags "$LDFLAGS -d" $BUILDFLAGS ./dockerinit
 echo "Created binary: $DEST/dockerinit-$VERSION"
 ln -sf dockerinit-$VERSION $DEST/dockerinit
 


### PR DESCRIPTION
/cc @crosbymichael @gabrtv
