### PR TITLE
Add new "cross" bundle to cross-compile the Docker client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,12 @@ RUN	apt-get install -y -q build-essential libsqlite3-dev
 RUN	curl -s https://go.googlecode.com/files/go1.2.src.tar.gz | tar -v -C /usr/local -xz
 ENV	PATH	/usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
 ENV	GOPATH	/go:/go/src/github.com/dotcloud/docker/vendor
-RUN	cd /usr/local/go/src && ./make.bash
+RUN	cd /usr/local/go/src && ./make.bash --no-clean 2>&1
+
+# Cross compilation
+ENV	DOCKER_CROSSPLATFORMS	darwin/amd64 darwin/386
+# TODO add linux/386 and linux/arm
+RUN	cd /usr/local/go/src && bash -xc 'for platform in $DOCKER_CROSSPLATFORMS; do GOOS=${platform%/*} GOARCH=${platform##*/} ./make.bash --no-clean 2>&1; done'
 
 # Ubuntu stuff
 RUN	apt-get install -y -q ruby1.9.3 rubygems libffi-dev

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all binary build default docs shell test
+.PHONY: all binary build cross default docs shell test
 
 DOCKER_RUN_DOCKER := docker run -rm -i -t -privileged -e TESTFLAGS -v $(CURDIR)/bundles:/go/src/github.com/dotcloud/docker/bundles docker
 
@@ -9,6 +9,9 @@ all: build
 
 binary: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary
+
+cross: build
+	$(DOCKER_RUN_DOCKER) hack/make.sh cross
 
 docs:
 	docker build -t docker-docs docs && docker run -p 8000:8000 docker-docs

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -40,6 +40,7 @@ DEFAULT_BUNDLES=(
 	dyntest
 	dyntest-integration
 	cover
+	cross
 	tgz
 	ubuntu
 )

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+DEST=$1
+
+for platform in $DOCKER_CROSSPLATFORMS; do
+	(
+		export GOOS=${platform%/*}
+		export GOARCH=${platform##*/}
+		export VERSION="$GOOS-$GOARCH-$VERSION" # for a nice filename
+		export LDFLAGS_STATIC="" # we just need a simple client for these platforms (TODO this might change someday)
+		source "$(dirname "$BASH_SOURCE")/binary"
+	)
+done

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -47,6 +47,7 @@ cd /go/src/github.com/dotcloud/docker
 
 RELEASE_BUNDLES=(
 	binary
+	cross
 	tgz
 	ubuntu
 )
@@ -233,6 +234,16 @@ EOF
 	fi
 }
 
+# Upload a cross-compiled client binaries to S3
+release_cross() {
+	[ -e bundles/$VERSION/cross ] || {
+		echo >&2 './hack/make.sh must be run before release_binary'
+		exit 1
+	}
+	
+	# TODO find out from @shykes what URLs he'd like to use here
+}
+
 # Upload the index script
 release_index() {
 	sed "s,https://get.docker.io/,$(s3_url)/," hack/install.sh | write_to_s3 s3://$BUCKET/index
@@ -247,6 +258,7 @@ release_test() {
 main() {
 	setup_s3
 	release_binary
+	release_cross
 	release_tgz
 	release_ubuntu
 	release_index


### PR DESCRIPTION
This PR depends on #3275 (hopefully for very obvious reasons).

We currently only do darwin/386 and darwin/amd64, but I hope to add linux/386 and linux/arm in the near future (especially since it'd be mostly as easy as converting our _linux and _darwin files to be _supported and _unsupported with nice os/arch build tags), and then look to adding windows/386 and windows/amd64 and eventually get the BSDs going on too.

This is much better than my previous PR (#2010) that did something similar because it preserves our Dockerfile cache by enumerating our supported cross-platforms in an ENV in the Dockerfile directly and always working from that variable when we need to do something with the individual platforms.
