### PR TITLE
Move root symlink check to engine.New

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -9,7 +9,6 @@ import (
 	"github.com/dotcloud/docker/utils"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 )
 
@@ -69,19 +68,6 @@ func main() {
 		if flag.NArg() != 0 {
 			flag.Usage()
 			return
-		}
-
-		// Docker makes some assumptions about the "absoluteness" of flRoot
-		// ... so let's make sure it has no symlinks
-		if p, err := filepath.Abs(*flRoot); err != nil {
-			log.Fatalf("Unable to get absolute root (%s): %s", flRoot, err)
-		} else {
-			*flRoot = p
-		}
-		if p, err := filepath.EvalSymlinks(*flRoot); err != nil {
-			log.Fatalf("Unable to canonicalize root (%s): %s", flRoot, err)
-		} else {
-			*flRoot = p
 		}
 
 		eng, err := engine.New(*flRoot)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -79,9 +80,24 @@ func New(root string) (*Engine, error) {
 			}
 		}
 	}
+
 	if err := os.MkdirAll(root, 0700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
+
+	// Docker makes some assumptions about the "absoluteness" of root
+	// ... so let's make sure it has no symlinks
+	if p, err := filepath.Abs(root); err != nil {
+		log.Fatalf("Unable to get absolute root (%s): %s", root, err)
+	} else {
+		root = p
+	}
+	if p, err := filepath.EvalSymlinks(root); err != nil {
+		log.Fatalf("Unable to canonicalize root (%s): %s", root, err)
+	} else {
+		root = p
+	}
+
 	eng := &Engine{
 		root:     root,
 		handlers: make(map[string]Handler),


### PR DESCRIPTION
Since commit c91c365, when starting the docker daemon without an
existing /var/lib/docker directory, it fails with:

```
2013/12/18 23:39:36 Unable to canonicalize root (%!s(*string=0xc210077c80)): lstat /var/lib/docker: no such file or directory
```

Move the symlink checking code to engine.New after the root dir has been
created.
