### PR TITLE
add gosqlite to vendor.sh

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -6,7 +6,7 @@ if [[ ! -d vendor ]]; then
 fi
 vendor_dir=${PWD}/vendor
 
-git_clone () {
+rm_pkg_dir () {
   PKG=$1
   REV=$2
   (
@@ -16,8 +16,28 @@ git_clone () {
       echo "src/$PKG already exists. Removing."
       rm -fr src/$PKG
     fi
+  )
+}
+
+git_clone () {
+  PKG=$1
+  REV=$2
+  (
+    set -e
+    rm_pkg_dir $PKG $REV
     cd $vendor_dir && git clone http://$PKG src/$PKG
     cd src/$PKG && git checkout -f $REV && rm -fr .git
+  )
+}
+
+hg_clone () {
+  PKG=$1
+  REV=$2
+  (
+    set -e
+    rm_pkg_dir $PKG $REV
+    cd $vendor_dir && hg clone http://$PKG src/$PKG
+    cd src/$PKG && hg checkout -r $REV && rm -fr .hg
   )
 }
 
@@ -29,13 +49,6 @@ git_clone github.com/gorilla/mux/ 9b36453141c
 
 git_clone github.com/syndtr/gocapability 3454319be2
 
-# Docker requires code.google.com/p/go.net/websocket
-PKG=code.google.com/p/go.net REV=84a4013f96e0
-(
-  set -e
-  cd $vendor_dir
-  if [[ ! -d src/$PKG ]]; then
-    hg clone https://$PKG src/$PKG
-  fi
-  cd src/$PKG && hg checkout -r $REV
-)
+hg_clone code.google.com/p/go.net 84a4013f96e0
+
+hg_clone code.google.com/p/gosqlite 74691fb6f837


### PR DESCRIPTION
Add gosqlite and its latest revision to vendor.sh so that the vendor
directory can be reliably recreated.
