### PR TITLE
fix progressbar in docker push

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -448,6 +448,11 @@ func (r *Registry) PushImageLayerRegistry(imgID string, layer io.Reader, registr
 	if err != nil {
 		return "", fmt.Errorf("Failed to upload layer: %s", err)
 	}
+	if rc, ok := layer.(io.Closer); ok {
+		if err := rc.Close(); err != nil {
+			return "", err
+		}
+	}
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {

--- a/server.go
+++ b/server.go
@@ -1272,6 +1272,7 @@ func (srv *Server) pushImage(r *registry.Registry, out io.Writer, remote, imgID,
 		return "", err
 	}
 
+	out.Write(sf.FormatProgress(utils.TruncateID(imgData.ID), "Image successfully pushed", nil))
 	return imgData.Checksum, nil
 }
 

--- a/utils/jsonmessage.go
+++ b/utils/jsonmessage.go
@@ -52,7 +52,7 @@ func (p *JSONProgress) String() string {
 	}
 	numbersBox = fmt.Sprintf("%8v/%v", current, total)
 
-	if p.Start > 0 {
+	if p.Start > 0 && percentage < 50 {
 		fromStart := time.Now().UTC().Sub(time.Unix(int64(p.Start), 0))
 		perEntry := fromStart / time.Duration(p.Current)
 		left := time.Duration(p.Total-p.Current) * perEntry


### PR DESCRIPTION
Fixes #3260

Changes:
- The registry code will now try to close the "layer" after a successful `PUT`
- The API will send a JSON says 100% on "layer" close

In addition to have a nicer display, 
- ProgressBar code cleaned up a little (removed commented code and useless `io.ReadCloser` cast)
- Server send `Image successfully pushed` 
- Don't display time left when it's 100%
