### PR TITLE
Don't shell out to tar for ExportChanges

### DIFF
--- a/archive/changes.go
+++ b/archive/changes.go
@@ -361,8 +361,8 @@ func ExportChanges(dir string, changes []Change) (Archive, error) {
 					Mode:       int64(stat.Mode & 07777),
 					Uid:        int(stat.Uid),
 					Gid:        int(stat.Gid),
-					ModTime:    time.Unix(mtim.Sec, mtim.Nsec),
-					AccessTime: time.Unix(atim.Sec, atim.Nsec),
+					ModTime:    time.Unix(int64(mtim.Sec), int64(mtim.Nsec)),
+					AccessTime: time.Unix(int64(atim.Sec), int64(atim.Nsec)),
 				}
 
 				if stat.Mode&syscall.S_IFDIR == syscall.S_IFDIR {
@@ -382,8 +382,8 @@ func ExportChanges(dir string, changes []Change) (Archive, error) {
 					} else {
 						hdr.Typeflag = tar.TypeChar
 					}
-					hdr.Devmajor = int64(major(stat.Rdev))
-					hdr.Devminor = int64(minor(stat.Rdev))
+					hdr.Devmajor = int64(major(uint64(stat.Rdev)))
+					hdr.Devminor = int64(minor(uint64(stat.Rdev)))
 				} else if stat.Mode&syscall.S_IFIFO == syscall.S_IFIFO ||
 					stat.Mode&syscall.S_IFSOCK == syscall.S_IFSOCK {
 					hdr.Typeflag = tar.TypeFifo


### PR DESCRIPTION
This changes ExportChanges to use the go tar support so we can directly create tar layer files. This has several advantages:
- We don't have to create the whiteout files on disk to get them added to the layer
- We can later guarantee specific features (such as xattrs) being supported by the tar implementation.

I also included a separate commit that removes a bunch of now unused complexities from the code that shells out to tar.
