### PR TITLE
Added a note about a networking work-around.

### DIFF
--- a/docs/sources/installation/google.rst
+++ b/docs/sources/installation/google.rst
@@ -57,18 +57,17 @@
     docker-playground:~$ curl get.docker.io | bash
     docker-playground:~$ sudo update-rc.d docker defaults
 
-7. Start a new container:
-
-.. code-block:: bash
-
-    docker-playground:~$ sudo docker run busybox echo 'docker on GCE \o/'
-    docker on GCE \o/
-
-**The -lxc-conf flag below is required** when running docker images in zones: us-central1-a, europe-west1-1, and europe-west1-b. Without the MTU flag, you may experience intermittent network pauses. 
+7. If running in zones: us-central1-a, europe-west1-1, and europe-west1-b, the docker daemon must be started with the `-mtu` flag. Without the flag, you may experience intermittent network pauses. 
 `See this issue <https://code.google.com/p/google-compute-engine/issues/detail?id=57>`_ for more details.
 
 .. code-block:: bash
 
-    docker-playground:~$ sudo docker run -lxc-conf="lxc.network.mtu = 1460" busybox echo 'docker on GCE \o/'
+    docker -d -mtu 1460
+
+8. Start a new container:
+
+.. code-block:: bash
+
+    docker-playground:~$ sudo docker run busybox echo 'docker on GCE \o/'
     docker on GCE \o/
 

--- a/docs/sources/installation/google.rst
+++ b/docs/sources/installation/google.rst
@@ -63,3 +63,12 @@
 
     docker-playground:~$ sudo docker run busybox echo 'docker on GCE \o/'
     docker on GCE \o/
+
+**The -lxc-conf flag below is required** when running docker images in zones: us-central1-a, europe-west1-1, and europe-west1-b. Without the MTU flag, you may experience intermittent network pauses. 
+`See this issue <https://code.google.com/p/google-compute-engine/issues/detail?id=57>`_ for more details.
+
+.. code-block:: bash
+
+    docker-playground:~$ sudo docker run -lxc-conf="lxc.network.mtu = 1460" busybox echo 'docker on GCE \o/'
+    docker on GCE \o/
+


### PR DESCRIPTION
An additional flag to limit the networking MTU is required in three Compute Engine zones for reliable networking from inside the docker container. Added a warning to that effect to the QuickStart guide.
