### PR TITLE
Add DOCKER_HOST env var for client

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -52,8 +52,13 @@ func main() {
 		return
 	}
 	if flHosts.Len() == 0 {
-		// If we do not have a host, default to unix socket
-		flHosts.Set(fmt.Sprintf("unix://%s", docker.DEFAULTUNIXSOCKET))
+		defaultHost := os.Getenv("DOCKER_HOST")
+
+		if defaultHost == "" || *flDaemon {
+			// If we do not have a host, default to unix socket
+			defaultHost = fmt.Sprintf("unix://%s", docker.DEFAULTUNIXSOCKET)
+		}
+		flHosts.Set(defaultHost)
 	}
 
 	if *bridgeName != "" && *bridgeIp != "" {

--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -52,6 +52,18 @@ To set the dns server for all docker containers, use ``docker -d -dns 8.8.8.8``
 
 To run the daemon with debug output, use ``docker -d -D``
 
+The docker client will also honor the ``DOCKER_HOST`` environment variable to set
+the ``-H`` flag for the client.  
+
+::
+ 
+        docker -H tcp://0.0.0.0:4243 ps
+        # or
+        export DOCKER_HOST="tcp://0.0.0.0:4243"
+        docker ps
+        # both are equal
+
+
 .. _cli_attach:
 
 ``attach``


### PR DESCRIPTION
This env var will set the -H flag on the docker
client.

This is the same as doing:

``` bash
docker -H :4243 ps
# or
export DOCKER_HOST=":4243"
docker ps
```
