### PR TITLE
network: fix a typo in udp cleanup path

### DIFF
--- a/docs/sources/commandline/cli.rst
+++ b/docs/sources/commandline/cli.rst
@@ -952,7 +952,7 @@ image is removed.
     test2                     latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
 
     $ sudo docker rmi fd484f19954f
-    Error: Conflict, fd484f19954f wasn't deleted
+    Error: Conflict, cannot delete image fd484f19954f because it is tagged in multiple repositories
     2013/12/11 05:47:16 Error: failed to remove one or more images
 
     $ sudo docker rmi test1

--- a/network.go
+++ b/network.go
@@ -628,7 +628,7 @@ func (iface *NetworkInterface) Release() {
 				log.Printf("Unable to release port %s", nat)
 			}
 		} else if nat.Port.Proto() == "udp" {
-			if err := iface.manager.tcpPortAllocator.Release(ip, hostPort); err != nil {
+			if err := iface.manager.udpPortAllocator.Release(ip, hostPort); err != nil {
 				log.Printf("Unable to release port %s: %s", nat, err)
 			}
 		}

--- a/server.go
+++ b/server.go
@@ -1586,7 +1586,7 @@ func (srv *Server) deleteImage(img *Image, repoName, tag string) ([]APIRmi, erro
 			} else if repoName != parsedRepo {
 				// the id belongs to multiple repos, like base:latest and user:test,
 				// in that case return conflict
-				return imgs, nil
+				return nil, fmt.Errorf("Conflict, cannot delete image %s because it is tagged in multiple repositories", utils.TruncateID(img.ID))
 			}
 		}
 	} else {


### PR DESCRIPTION
```
network: fix a typo in udp cleanup path

Fix #3224 - Port already in use error when running a container
```
