### PR TITLE
network: fix a typo in udp cleanup path

### DIFF
--- a/network.go
+++ b/network.go
@@ -628,7 +628,7 @@ func (iface *NetworkInterface) Release() {
 				log.Printf("Unable to release port %s", nat)
 			}
 		} else if nat.Port.Proto() == "udp" {
-			if err := iface.manager.tcpPortAllocator.Release(ip, hostPort); err != nil {
+			if err := iface.manager.udpPortAllocator.Release(ip, hostPort); err != nil {
 				log.Printf("Unable to release port %s: %s", nat, err)
 			}
 		}


### PR DESCRIPTION
Fixes #3224 - Port already in use error when running a container

Signed-off-by: Tzu-Jung Lee roylee17@gmail.com
