### PR TITLE
use /etc/default/docker in systemd just like upstart/sysvinit

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -4,8 +4,9 @@ Documentation=http://docs.docker.io
 After=network.target
 
 [Service]
+EnvironmentFile=-/etc/default/docker
 ExecStartPre=/bin/mount --make-rprivate /
-ExecStart=/usr/bin/docker -d
+ExecStart=/usr/bin/docker -d $DOCKER_OPTS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
allow use of /etc/default/docker in systemd service file for additional options just like the upstart and sysvinit versions
