### PR TITLE
API documentation update for Privileged

### DIFF
--- a/docs/sources/api/docker_remote_api_v1.7.rst
+++ b/docs/sources/api/docker_remote_api_v1.7.rst
@@ -122,7 +122,6 @@ Create a container
 		"AttachStdout":true,
 		"AttachStderr":true,
 		"PortSpecs":null,
-		"Privileged": false,
 		"Tty":false,
 		"OpenStdin":false,
 		"StdinOnce":false,
@@ -364,7 +363,8 @@ Start a container
            {
                 "Binds":["/tmp:/tmp"],
                 "LxcConf":{"lxc.utsname":"docker"},
-                "PortBindings":null
+                "PortBindings":null,
+                "Privileged":false,
                 "PublishAllPorts":false
            }
            


### PR DESCRIPTION
The 1.7 API docs show the ability to pass Privileged
when creating a container. This is not supported as.
Privileged is now part of hostConfig and can only be
passed when starting a container.

This fixes the documentation issue.
