### PR TITLE
Release tgz and binaries for cross-compiled platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ binary: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary
 
 cross: build
-	$(DOCKER_RUN_DOCKER) hack/make.sh cross
+	$(DOCKER_RUN_DOCKER) hack/make.sh binary cross
 
 docs:
 	docker build -t docker-docs docs && docker run -p 8000:8000 docker-docs

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -2,12 +2,22 @@
 
 DEST=$1
 
+# if we have our linux/amd64 version compiled, let's symlink it in
+if [ -x "$DEST/../binary/docker-$VERSION" ]; then
+	mkdir -p "$DEST/linux/amd64"
+	(
+		cd "$DEST/linux/amd64"
+		ln -s ../../../binary/* ./
+	)
+	echo "Created symlinks:" "$DEST/linux/amd64/"*
+fi
+
 for platform in $DOCKER_CROSSPLATFORMS; do
 	(
+		mkdir -p "$DEST/$platform" # bundles/VERSION/cross/GOOS/GOARCH/docker-VERSION
 		export GOOS=${platform%/*}
 		export GOARCH=${platform##*/}
-		export VERSION="$GOOS-$GOARCH-$VERSION" # for a nice filename
 		export LDFLAGS_STATIC="" # we just need a simple client for these platforms (TODO this might change someday)
-		source "$(dirname "$BASH_SOURCE")/binary"
+		source "$(dirname "$BASH_SOURCE")/binary" "$DEST/$platform"
 	)
 done

--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -1,23 +1,29 @@
 #!/bin/bash
 
 DEST="$1"
-BINARY="$DEST/../binary/docker-$VERSION"
-TGZ="$DEST/docker-$VERSION.tgz"
+CROSS="$DEST/../cross"
 
 set -e
 
-if [ ! -x "$BINARY" ]; then
-	echo >&2 'error: binary must be run before tgz'
+if [ ! -d "$CROSS/linux/amd64" ]; then
+	echo >&2 'error: binary and cross must be run before tgz'
 	false
 fi
 
-mkdir -p "$DEST/build"
-
-mkdir -p "$DEST/build/usr/local/bin"
-cp -L "$BINARY" "$DEST/build/usr/local/bin/docker"
-
-tar --numeric-owner --owner 0 -C "$DEST/build" -czf "$TGZ" usr
-
-rm -rf "$DEST/build"
-
-echo "Created tgz: $TGZ"
+for d in "$CROSS/"*/*; do
+	GOARCH="$(basename "$d")"
+	GOOS="$(basename "$(dirname "$d")")"
+	mkdir -p "$DEST/$GOOS/$GOARCH"
+	TGZ="$DEST/$GOOS/$GOARCH/docker-$VERSION.tgz"
+	
+	mkdir -p "$DEST/build"
+	
+	mkdir -p "$DEST/build/usr/local/bin"
+	cp -L "$d/docker-$VERSION" "$DEST/build/usr/local/bin/docker"
+	
+	tar --numeric-owner --owner 0 -C "$DEST/build" -czf "$TGZ" usr
+	
+	rm -rf "$DEST/build"
+	
+	echo "Created tgz: $TGZ"
+done


### PR DESCRIPTION
Fixes #1616

For examples, see:
- http://tianon-docker.s3-website-us-west-2.amazonaws.com/builds/Linux/x86_64/docker-latest
- http://tianon-docker.s3-website-us-west-2.amazonaws.com/builds/Linux/x86_64/docker-latest.tgz
- http://tianon-docker.s3-website-us-west-2.amazonaws.com/builds/Darwin/x86_64/docker-latest
- http://tianon-docker.s3-website-us-west-2.amazonaws.com/builds/Darwin/x86_64/docker-latest.tgz
- http://tianon-docker.s3-website-us-west-2.amazonaws.com/builds/Darwin/i386/docker-latest
- http://tianon-docker.s3-website-us-west-2.amazonaws.com/builds/Darwin/i386/docker-latest.tgz

Or:
- http://tianon-docker.s3-website-us-west-2.amazonaws.com/builds/Linux/x86_64/docker-0.7.2-dev
- http://tianon-docker.s3-website-us-west-2.amazonaws.com/builds/Linux/x86_64/docker-0.7.2-dev.tgz
- http://tianon-docker.s3-website-us-west-2.amazonaws.com/builds/Darwin/x86_64/docker-0.7.2-dev
- http://tianon-docker.s3-website-us-west-2.amazonaws.com/builds/Darwin/x86_64/docker-0.7.2-dev.tgz
- http://tianon-docker.s3-website-us-west-2.amazonaws.com/builds/Darwin/i386/docker-0.7.2-dev
- http://tianon-docker.s3-website-us-west-2.amazonaws.com/builds/Darwin/i386/docker-0.7.2-dev.tgz
