### PR TITLE
Clean `apt` repo before updating.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ ENV	DEBIAN_FRONTEND noninteractive
 
 # Build dependencies
 RUN	echo 'deb http://archive.ubuntu.com/ubuntu precise main universe' > /etc/apt/sources.list
+RUN	apt-get clean
 RUN	apt-get update
 RUN	apt-get install -y -q apt-utils
 RUN	apt-get install -y -q curl


### PR DESCRIPTION
If there is a network error during downloading of packages
you can end up with a repo cache that will be continually
reused but is missing packages. This dumps the repo and
forces the update to get the latest information.
