### PR TITLE
Use plain HTTP transport for APT package delivery.

### DIFF
--- a/docs/sources/installation/upgrading.rst
+++ b/docs/sources/installation/upgrading.rst
@@ -29,7 +29,7 @@ use ``apt-get`` to upgrade.
    sudo sh -c "curl https://get.docker.io/gpg | apt-key add -"
 
    # Add the Docker repository to your apt sources list.
-   sudo sh -c "echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
+   sudo sh -c "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
 
    # update your sources list
    sudo apt-get update

--- a/hack/infrastructure/docker-ci/deployment.py
+++ b/hack/infrastructure/docker-ci/deployment.py
@@ -128,7 +128,7 @@ call('/usr/bin/rsync -aH {} {}@{}:{}'.format(DOCKER_CI_PATH, DO_IMAGE_USER, ip,
 # Install Docker and Buildbot dependencies
 sudo('mkdir /mnt/docker; ln -s /mnt/docker /var/lib/docker')
 sudo('wget -q -O - https://get.docker.io/gpg | apt-key add -')
-sudo('echo deb https://get.docker.io/ubuntu docker main >'
+sudo('echo deb http://get.docker.io/ubuntu docker main >'
     ' /etc/apt/sources.list.d/docker.list')
 sudo('echo -e "deb http://archive.ubuntu.com/ubuntu raring main universe\n'
     'deb http://us.archive.ubuntu.com/ubuntu/ raring-security main universe\n"'


### PR DESCRIPTION
Package integrity is already verified by the GPG key so SSL is not necessary
to prevent MITM.

Some flavors of Ubuntu don't have the https transport available in APT which
makes the installation more difficult. It also impacts installation speed
since SSL requires at least one additional handshake.

The main Vagrantfile already uses http instead of https in the sources.list
