### PR TITLE
Document "name" query parameter for "POST /containers/create" in Remote API v1.8

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -115,6 +115,7 @@ Kyle Conroy <kyle.j.conroy@gmail.com>
 Laurie Voss <github@seldo.com>
 Louis Opter <kalessin@kalessin.fr>
 Manuel Meurer <manuel@krautcomputing.com>
+Manuel Woelker <docker@manuel.woelker.org>
 Marco Hennings <marco.hennings@freiheit.com>
 Marcus Farkas <toothlessgear@finitebox.com>
 Marcus Ramberg <marcus@nordaaker.com>

--- a/docs/sources/api/docker_remote_api_v1.8.rst
+++ b/docs/sources/api/docker_remote_api_v1.8.rst
@@ -151,6 +151,7 @@ Create a container
 	   }
 	
 	:jsonparam config: the container's configuration
+	:query name: Assign the specified name to the container. Must match ``/?[a-zA-Z0-9_-]+``.
 	:statuscode 201: no error
 	:statuscode 404: no such container
 	:statuscode 406: impossible to attach (container not running)


### PR DESCRIPTION
Small fix, took me a while and wireshark to find out what I did wrong.
