### PR TITLE
Apply automatically to files named 'Dockerfile'

### DIFF
--- a/contrib/Dockerfile.tmLanguage/Dockerfile.tmLanguage
+++ b/contrib/Dockerfile.tmLanguage/Dockerfile.tmLanguage
@@ -4,6 +4,10 @@
 <dict>
 	<key>name</key>
 	<string>Dockerfile</string>
+	<key>fileTypes</key>
+	<array>
+		<string>Dockerfile</string>
+	</array>
 	<key>patterns</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Minor (but important) update for the Dockerfile.tmLanguage syntax highlighting. This will in supported editors set the syntax highlighting for files named Dockerfile automatically. It get's annoying having to set it manually whenever opening a Dockerfile.
