### PR TITLE
Update docs with concept of hosting providers

### DIFF
--- a/docs/sources/use/index.rst
+++ b/docs/sources/use/index.rst
@@ -23,3 +23,4 @@ Contents:
    working_with_links_names
    ambassador_pattern_linking
    puppet
+   service_providers

--- a/docs/sources/use/service_providers.rst
+++ b/docs/sources/use/service_providers.rst
@@ -1,0 +1,32 @@
+:title: Service Providers
+:description: Groups that offer docker services.
+:keywords: repo, repositories, service, hosting
+
+.. _service_providers:
+   
+Service Providers
+=================
+
+Several groups in the docker community have sprung up in response for the need
+for docker services.  This include companies that provider container hosting,
+repository hosting, and a variety of other services.  As the docker community
+expands we expect that this list will continue to grow.
+
+.. note::
+
+    This list is alphabetical and definitely not complete. We do not promote 
+    or endorse any specific providers on this list.  It is only provided as
+    a starting point for your own research.  If you see any missing providers,
+    please edit this article on GitHub to provide a patch.
+
+
+* Repository Hosting
+
+  * `Dockify.io <http://dockify.io>`_
+  * `Quay.io <http://quay.io>`_
+
+* Container Hosting
+
+  * `Orchard <https://orchardup.com/>`_
+  * `StackDock <https://stackdock.com/>`_
+

--- a/docs/sources/use/workingwithrepository.rst
+++ b/docs/sources/use/workingwithrepository.rst
@@ -194,7 +194,8 @@ Sometimes what you want is a private repository that lets you keep your images
 private, host them locally, or simply somewhere other than the central index.
 Fortunately the docker community has several ways to accomplish this.
 
-1) Host your own
+Host your own
++++++++++++++
 
 The first option is to host your own registry using the `docker-registry project
 <https://github.com/dotcloud/docker-registry>`_.  To push or pull to a
@@ -226,7 +227,8 @@ function completely independently from the Central Index.
 .. seealso:: `Docker Blog: How to use your own registry 
    <http://blog.docker.io/2013/07/how-to-use-your-own-registry/>`_
    
-2) Use a hosting service
+Use a hosting service
++++++++++++++++++++++
 
 Several groups in the docker community have responded to the need for private 
 repositories and now offer repository hosting services.  These can be a great
@@ -236,8 +238,8 @@ to grow and offer users more capabilities.
 
 The following sites offer docker hosting:
 
-#) __ http://quay.io
-#) __ http://dockify.io
+* `Quay.io <http://quay.io>`_
+* `Dockify.io <http://dockify.io>`_
 
 .. note::
 

--- a/docs/sources/use/workingwithrepository.rst
+++ b/docs/sources/use/workingwithrepository.rst
@@ -194,6 +194,17 @@ Sometimes what you want is a private repository that lets you keep your images
 private, host them locally, or simply somewhere other than the central index.
 Fortunately the docker community has several ways to accomplish this.
 
+Use a hosting service
++++++++++++++++++++++
+
+Several groups in the docker community have responded to the need for private 
+repositories and now offer repository hosting services.  These can be a great
+option if you want to let someone else handle the details of the hosting.
+
+You can find some of these options by searching on the web or looking at the
+partial list in :ref:`service_providers`.
+
+
 Host your own
 +++++++++++++
 
@@ -226,27 +237,7 @@ function completely independently from the Central Index.
 
 .. seealso:: `Docker Blog: How to use your own registry 
    <http://blog.docker.io/2013/07/how-to-use-your-own-registry/>`_
-   
-Use a hosting service
-+++++++++++++++++++++
-
-Several groups in the docker community have responded to the need for private 
-repositories and now offer repository hosting services.  These can be a great
-option if you want to let someone else handle the details of the hosting.  As
-the docker community expands we expect that services like this will continue
-to grow and offer users more capabilities.
-
-The following sites offer docker hosting:
-
-* `Quay.io <http://quay.io>`_
-* `Dockify.io <http://dockify.io>`_
-
-.. note::
-
-    This list is probably not complete but is provided as a starting point
-    for a search.  We do not promote or endorse any specific repository 
-    hosting providers.
-    
+       
 
 Authentication file
 -------------------

--- a/docs/sources/use/workingwithrepository.rst
+++ b/docs/sources/use/workingwithrepository.rst
@@ -190,8 +190,13 @@ point to specific ``Dockerfile``'s or Git branches.
 Private Repositories
 --------------------
 
-Right now (version 0.6), private repositories are only possible by
-hosting `your own registry
+Sometimes what you want is a private repository that lets you keep your images
+private, host them locally, or simply somewhere other than the central index.
+Fortunately the docker community has several ways to accomplish this.
+
+1) Host your own
+
+The first option is to host your own registry using the `docker-registry project
 <https://github.com/dotcloud/docker-registry>`_.  To push or pull to a
 repository on your own registry, you must prefix the tag with the
 address of the registry's host, like this:
@@ -220,6 +225,26 @@ function completely independently from the Central Index.
 
 .. seealso:: `Docker Blog: How to use your own registry 
    <http://blog.docker.io/2013/07/how-to-use-your-own-registry/>`_
+   
+2) Use a hosting service
+
+Several groups in the docker community have responded to the need for private 
+repositories and now offer repository hosting services.  These can be a great
+option if you want to let someone else handle the details of the hosting.  As
+the docker community expands we expect that services like this will continue
+to grow and offer users more capabilities.
+
+The following sites offer docker hosting:
+
+#) __ http://quay.io
+#) __ http://dockify.io
+
+.. note::
+
+    This list is probably not complete but is provided as a starting point
+    for a search.  We do not promote or endorse any specific repository 
+    hosting providers.
+    
 
 Authentication file
 -------------------


### PR DESCRIPTION
As a user this is something I would have found _very_ useful the first time I read about docker.  The documentation current says the only way to have private repos is to setup your own registry.  It took me several weeks of using docker before I found out there are hosting providers in the community.  Seems like a good idea to point this out to both help new users and to point people to some of the companies supporting the docker community.

Note: I debated putting the links to the companies, but I think it gives user a better experience so they can go directly to a couple of them and it seems inline with how the installation section shows how to install on EC2, Rackspace, Google, etc.
