### PR TITLE
Makes sure the GPG fingerprint is inlined in the doc everywhere.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,7 @@ if [ -z "$user" ]; then
 fi
 
 # Adding an apt gpg key is idempotent.
-wget -q -O - https://get.docker.io/gpg | apt-key add -
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
 # Creating the docker.list file is idempotent, but it may overwrite desired
 # settings if it already exists.  This could be solved with md5sum but it

--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -68,13 +68,11 @@ easy. **See the :ref:`installmirrors` section below if you are not in
 the United States.** Other sources of the Debian packages may be
 faster for you to install.
 
-First add the Docker repository key to your local keychain. You can use the
-``apt-key`` command to check the fingerprint matches: ``36A1 D786 9245 C895 0F96
-6E92 D857 6A8B A88D 21E9``
+First add the Docker repository key to your local keychain.
 
 .. code-block:: bash
 
-   sudo sh -c "wget -qO- https://get.docker.io/gpg | apt-key add -"
+   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
 Add the Docker repository to your apt sources list, update and install the
 ``lxc-docker`` package.
@@ -142,13 +140,11 @@ Docker is available as a Debian package, which makes installation easy.
     Please note that these instructions have changed for 0.6. If you are upgrading from an earlier version, you will need
     to follow them again.
 
-First add the Docker repository key to your local keychain. You can use the
-``apt-key`` command to check the fingerprint matches: ``36A1 D786 9245 C895 0F96
-6E92 D857 6A8B A88D 21E9``
+First add the Docker repository key to your local keychain.
 
 .. code-block:: bash
 
-   sudo sh -c "wget -qO- https://get.docker.io/gpg | apt-key add -"
+   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
 Add the Docker repository to your apt sources list, update and install the
 ``lxc-docker`` package.

--- a/docs/sources/installation/upgrading.rst
+++ b/docs/sources/installation/upgrading.rst
@@ -26,7 +26,7 @@ use ``apt-get`` to upgrade.
 .. code-block:: bash
 
    # Add the Docker repository key to your local keychain
-   sudo sh -c "curl https://get.docker.io/gpg | apt-key add -"
+   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
    # Add the Docker repository to your apt sources list.
    sudo sh -c "echo deb https://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"

--- a/hack/infrastructure/docker-ci/deployment.py
+++ b/hack/infrastructure/docker-ci/deployment.py
@@ -127,7 +127,7 @@ call('/usr/bin/rsync -aH {} {}@{}:{}'.format(DOCKER_CI_PATH, DO_IMAGE_USER, ip,
 
 # Install Docker and Buildbot dependencies
 sudo('mkdir /mnt/docker; ln -s /mnt/docker /var/lib/docker')
-sudo('wget -q -O - https://get.docker.io/gpg | apt-key add -')
+sudo('apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9')
 sudo('echo deb https://get.docker.io/ubuntu docker main >'
     ' /etc/apt/sources.list.d/docker.list')
 sudo('echo -e "deb http://archive.ubuntu.com/ubuntu raring main universe\n'

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -108,7 +108,7 @@ case "$lsb_dist" in
 		fi
 		(
 			set -x
-			$sh_c "$curl ${url}gpg | apt-key add -"
+			$sh_c "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
 			$sh_c "echo deb ${url}ubuntu docker main > /etc/apt/sources.list.d/docker.list"
 			$sh_c 'sleep 3; apt-get update; apt-get install -y -q lxc-docker'
 		)

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -108,7 +108,11 @@ case "$lsb_dist" in
 		fi
 		(
 			set -x
-			$sh_c "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
+			if [ "https://get.docker.io/" = "$url" ]; then
+				$sh_c "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
+			else
+				$sh_c "$curl ${url}gpg | apt-key add -"
+			fi
 			$sh_c "echo deb ${url}ubuntu docker main > /etc/apt/sources.list.d/docker.list"
 			$sh_c 'sleep 3; apt-get update; apt-get install -y -q lxc-docker'
 		)

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -245,7 +245,7 @@ EOF
 # Add the repository to your APT sources
 echo deb $(s3_url)/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 # Then import the repository key
-curl $(s3_url)/gpg | apt-key add -
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 # Install docker
 apt-get update ; apt-get install -y lxc-docker
 


### PR DESCRIPTION
Instead of `curl $url | apt-get add -` use the ubuntu keyserver and a full
fingerprint to retreive the key.

This is a follow-up on #1644 and #3346 .

I'm also asking the question on Launchpad to see any consensus can be gained: https://answers.launchpad.net/ubuntu/+source/apt/+question/241343
