### PR TITLE
Make blank -H option default to the same as no -H was sent

### DIFF
--- a/docs/sources/use/basics.rst
+++ b/docs/sources/use/basics.rst
@@ -115,6 +115,11 @@ For example:
 * ``tcp://host:4243`` -> tcp connection on host:4243
 * ``unix://path/to/socket`` -> unix socket located at ``path/to/socket``
 
+``-H``, when empty, will default to the same value as when no ``-H`` was passed in.
+
+``-H`` also accepts short form for TCP bindings:
+``host[:port]`` or ``:port``
+
 .. code-block:: bash
 
    # Run docker in daemon mode

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -803,7 +803,7 @@ func ParseHost(defaultHost string, defaultPort int, defaultUnix, addr string) (s
 		host  string
 		port  int
 	)
-
+  addr = strings.TrimSpace(addr)
 	switch {
 	case strings.HasPrefix(addr, "unix://"):
 		proto = "unix"
@@ -814,6 +814,9 @@ func ParseHost(defaultHost string, defaultPort int, defaultUnix, addr string) (s
 	case strings.HasPrefix(addr, "tcp://"):
 		proto = "tcp"
 		addr = strings.TrimPrefix(addr, "tcp://")
+	case addr == "":
+		proto = "unix"
+		addr = defaultUnix
 	default:
 		if strings.Contains(addr, "://") {
 			return "", fmt.Errorf("Invalid bind address protocol: %s", addr)

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -316,6 +316,9 @@ func TestParseHost(t *testing.T) {
 	if addr, err := ParseHost(defaultHttpHost, defaultHttpPort, defaultUnix, "tcp://:7777"); err != nil || addr != "tcp://127.0.0.1:7777" {
 		t.Errorf("tcp://:7777 -> expected tcp://127.0.0.1:7777, got %s", addr)
 	}
+  if addr, err := ParseHost(defaultHttpHost, defaultHttpPort, defaultUnix, ""); err != nil || addr != "unix:///var/run/docker.sock" {
+    t.Errorf("empty argument -> expected unix:///var/run/docker.sock, got %s", addr)
+  }
 	if addr, err := ParseHost(defaultHttpHost, defaultHttpPort, defaultUnix, "unix:///var/run/docker.sock"); err != nil || addr != "unix:///var/run/docker.sock" {
 		t.Errorf("unix:///var/run/docker.sock -> expected unix:///var/run/docker.sock, got %s", addr)
 	}


### PR DESCRIPTION
Fixes https://github.com/dotcloud/docker/issues/3333
