### PR TITLE
add a simple note to suggest to the user to use RUN curl/wget/tool if the URL they need is behind auth

### DIFF
--- a/docs/sources/use/builder.rst
+++ b/docs/sources/use/builder.rst
@@ -251,6 +251,11 @@ All new files and directories are created with mode 0755, uid and gid
    if you build using STDIN (``docker build - < somefile``), there is no build 
    context, so the Dockerfile can only contain an URL based ADD statement.
 
+.. note::
+   if your URL files are protected using authentication, you will need to use
+   an ``RUN wget`` , ``RUN curl`` or other tool from within the container as
+   ADD does not support authentication.
+
 The copy obeys the following rules:
 
 * The ``<src>`` path must be inside the *context* of the build; you cannot 


### PR DESCRIPTION
as suggested by `paul_andrew` in irc in response to a question 

<div class="discussion-labels">doc</div> @metalivedev @kencochrane @jamtur01 
