### PR TITLE
Fixed header image on docs.docker.io site

### DIFF
--- a/docs/theme/docker/static/css/main.css
+++ b/docs/theme/docker/static/css/main.css
@@ -62,8 +62,11 @@ p a.btn {
   -moz-box-shadow: 0 1px 4px rgba(0, 0, 0, 0.065);
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.065);
 }
-.brand.logo a {
+.brand-logo a {
   color: white;
+}
+.brand-logo a img {
+  width: auto;
 }
 .inline-icon {
   margin-bottom: 6px;

--- a/docs/theme/docker/static/css/main.less
+++ b/docs/theme/docker/static/css/main.less
@@ -125,9 +125,11 @@ p a {
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.065);
 }
 
-.brand.logo a {
+.brand-logo a {
 	color: white;
-
+  img {
+    width: auto;
+  }
 }
 
 .logo {


### PR DESCRIPTION
If you shrink the window, the responsive css styles blow up the header on desktop.

http://i.imgur.com/Lm7epqS.png

This should fix that. Also, there seem to be some dead styles in main.less, unless I'm not looking for their usage in the right places. For example, .brand.logo, which probably used to refer to .brand-logo but lost that connection at some point.
