### PR TITLE
Fix install failure when busybox can't be downloaded

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -116,7 +116,7 @@ case "$lsb_dist" in
 			(
 				set -x
 				$sh_c 'docker run busybox echo "Docker has been successfully installed!"'
-			)
+			) || true
 		fi
 		exit 0
 		;;


### PR DESCRIPTION
Whether or not the "busybox" image downloads and runs properly at the end of the build, we don't want to have the script return a failing exit code, especially since at that point, Docker is successfully installed, and we're just tooting our own horn for good measure.
