### PR TITLE
Update for Ubuntu 13.10

### DIFF
--- a/docs/sources/examples/running_ssh_service.rst
+++ b/docs/sources/examples/running_ssh_service.rst
@@ -94,5 +94,8 @@ The password is ``screencast``.
          $ ifconfig
          $ ssh root@192.168.33.10 -p 49154
          # Thanks for watching, Thatcher thatcher@dotcloud.com
+         # For Ubuntu 13.10 using stackbrew/ubuntu, I had do these additional steps:
+         # change /etc/pam.d/sshd, pam_loginuid line 'required' to 'optional'
+         # echo LANG=\"en_US.UTF-8\" > /etc/default/locale
 
 


### PR DESCRIPTION
With two additional commands, this procedure will work for Ubuntu 13.10 using the image stackbrew/ubuntu:13.10.

1) change /etc/pam.d/sshd, pam_loginuid line 'required' to 'optional'
2) echo LANG=\"en_US.UTF-8\" > /etc/default/locale
