### PR TITLE
Fix for #3345: Add Content-Type Header "application/json" to GET /version response in remote API

### DIFF
--- a/api.go
+++ b/api.go
@@ -140,6 +140,7 @@ func postAuth(srv *Server, version float64, w http.ResponseWriter, r *http.Reque
 }
 
 func getVersion(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	w.Header().Set("Content-Type", "application/json")
 	srv.Eng.ServeHTTP(w, r)
 	return nil
 }
@@ -216,6 +217,7 @@ func getImagesViz(srv *Server, version float64, w http.ResponseWriter, r *http.R
 }
 
 func getInfo(srv *Server, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	w.Header().Set("Content-Type", "application/json")
 	srv.Eng.ServeHTTP(w, r)
 	return nil
 }

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -49,6 +49,10 @@ func TestGetVersion(t *testing.T) {
 	if result := v.Get("Version"); result != expected {
 		t.Errorf("Expected version %s, %s found", expected, result)
 	}
+	expected = "application/json"
+	if result := r.HeaderMap.Get("Content-Type"); result != expected {
+		t.Errorf("Expected Content-Type %s, %s found", expected, result)
+	}
 }
 
 func TestGetInfo(t *testing.T) {
@@ -83,6 +87,10 @@ func TestGetInfo(t *testing.T) {
 	out.Close()
 	if images := i.GetInt("Images"); images != len(initialImages) {
 		t.Errorf("Expected images: %d, %d found", len(initialImages), images)
+	}
+	expected := "application/json"
+	if result := r.HeaderMap.Get("Content-Type"); result != expected {
+		t.Errorf("Expected Content-Type %s, %s found", expected, result)
 	}
 }
 


### PR DESCRIPTION
Simple, quick fix for #3345. Let me know if there's anything missing.

Fixes #3345
