### PR TITLE
Mention lxc-checkconfig

### DIFF
--- a/docs/sources/installation/kernel.rst
+++ b/docs/sources/installation/kernel.rst
@@ -115,6 +115,8 @@ Then run ``update-grub``, and reboot.
 Details
 -------
 
+An easy way to check that the requirements below are met is to run `lxc-checkconfig`.
+
 Networking:
 
 - CONFIG_BRIDGE

--- a/docs/sources/installation/kernel.rst
+++ b/docs/sources/installation/kernel.rst
@@ -115,7 +115,7 @@ Then run ``update-grub``, and reboot.
 Details
 -------
 
-An easy way to check that the requirements below are met is to run `lxc-checkconfig`.
+To automatically check some of the requirements below, you can run `lxc-checkconfig`.
 
 Networking:
 


### PR DESCRIPTION
This is important because the list below is not complete when one build one's own kernel.  Plus it is more robust in the face of changes.
