### PR TITLE
Cleanup: runtime.getFullName is deprecated by getFullName

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -582,11 +582,6 @@ func (runtime *Runtime) Commit(container *Container, repository, tag, comment, a
 	return img, nil
 }
 
-// FIXME: this is deprecated by the getFullName *function*
-func (runtime *Runtime) getFullName(name string) (string, error) {
-	return getFullName(name)
-}
-
 func getFullName(name string) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("Container name cannot be empty")
@@ -598,7 +593,7 @@ func getFullName(name string) (string, error) {
 }
 
 func (runtime *Runtime) GetByName(name string) (*Container, error) {
-	fullName, err := runtime.getFullName(name)
+	fullName, err := getFullName(name)
 	if err != nil {
 		return nil, err
 	}
@@ -614,7 +609,7 @@ func (runtime *Runtime) GetByName(name string) (*Container, error) {
 }
 
 func (runtime *Runtime) Children(name string) (map[string]*Container, error) {
-	name, err := runtime.getFullName(name)
+	name, err := getFullName(name)
 	if err != nil {
 		return nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -1435,7 +1435,7 @@ func (srv *Server) ContainerDestroy(name string, removeVolume, removeLink bool) 
 		if container == nil {
 			return fmt.Errorf("No such link: %s", name)
 		}
-		name, err := srv.runtime.getFullName(name)
+		name, err := getFullName(name)
 		if err != nil {
 			return err
 		}

--- a/server.go
+++ b/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/dotcloud/docker/auth"
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/pkg/graphdb"
+	"github.com/dotcloud/docker/pkg/systemd"
 	"github.com/dotcloud/docker/registry"
 	"github.com/dotcloud/docker/utils"
 	"io"
@@ -26,6 +27,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+	"regexp"
+	"net"
 )
 
 func (srv *Server) Close() error {
@@ -136,8 +139,47 @@ func (srv *Server) ListenAndServe(job *engine.Job) engine.Status {
 			return engine.StatusErr
 		}
 		go func() {
-			// FIXME: merge Server.ListenAndServe with ListenAndServe
-			chErrors <- ListenAndServe(protoAddrParts[0], protoAddrParts[1], srv, job.GetenvBool("Logging"))
+			r, err := createRouter(srv, job.GetenvBool("Logging"))
+			if err != nil {
+				chErrors <- err
+				return
+			}
+			l, e := net.Listen(protoAddrParts[0], protoAddrParts[1])
+			if e != nil {
+				chErrors <- e
+				return
+			}
+			if protoAddrParts[0] == "unix" {
+				if err := os.Chmod(protoAddrParts[1], 0660); err != nil {
+					chErrors <- err
+					return
+				}
+
+				groups, err := ioutil.ReadFile("/etc/group")
+				if err != nil {
+					chErrors <- err
+					return
+				}
+				re := regexp.MustCompile("(^|\n)docker:.*?:([0-9]+)")
+				if gidMatch := re.FindStringSubmatch(string(groups)); gidMatch != nil {
+					gid, err := strconv.Atoi(gidMatch[2])
+					if err != nil {
+						chErrors <- err
+						return
+					}
+					utils.Debugf("docker group found. gid: %d", gid)
+					if err := os.Chown(protoAddrParts[1], 0, gid); err != nil {
+						chErrors <- err
+						return
+					}
+				}
+			}
+			httpSrv := http.Server{Addr: protoAddrParts[1], Handler: r}
+
+			log.Printf("Listening for HTTP on %s (%s)\n", protoAddrParts[1], protoAddrParts[0])
+			// Tell the init daemon we are accepting requests
+			go systemd.SdNotify("READY=1")
+			chErrors <- httpSrv.Serve(l)
 		}()
 	}
 	for i := 0; i < len(protoAddrs); i += 1 {


### PR DESCRIPTION
- Removed the function getFullName in the runtime in favor of the general one.
