### PR TITLE
Add explicit "fpm" version for now so our package build works like it's ...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN	cd /usr/local/go/src && bash -xc 'for platform in $DOCKER_CROSSPLATFORMS; do
 RUN	go get code.google.com/p/go.tools/cmd/cover
 
 # TODO replace FPM with some very minimal debhelper stuff
-RUN	gem install --no-rdoc --no-ri fpm
+RUN	gem install --no-rdoc --no-ri fpm --version 0.4.42
 
 # Setup s3cmd config
 RUN	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_KEY' > /.s3cfg


### PR DESCRIPTION
...supposed to.

This is a stop-gap until I can fix what broke in 1.0.1 (which I'll work on right after I finish typing this).  Regardless, having an explicit version on our "gem install" here is a very good idea and will stay (just like we're explicit about s3cmd because we need very specific features from it).
