### PR TITLE
Add stubbed and commented "/etc/default/docker" to our deb package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN	cd /usr/local/go/src && bash -xc 'for platform in $DOCKER_CROSSPLATFORMS; do
 RUN	go get code.google.com/p/go.tools/cmd/cover
 
 # TODO replace FPM with some very minimal debhelper stuff
-RUN	gem install --no-rdoc --no-ri fpm
+RUN	gem install --no-rdoc --no-ri fpm --version 1.0.1
 
 # Setup s3cmd config
 RUN	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_KEY' > /.s3cfg

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -31,6 +31,20 @@ bundle_ubuntu() {
 	mkdir -p $DIR/lib/systemd
 	cp -R contrib/init/systemd $DIR/lib/systemd/system
 
+	mkdir -p $DIR/etc/default
+	cat > $DIR/etc/default/docker <<'EOF'
+# Docker Upstart and SysVinit configuration file
+
+# Customize location of Docker binary (especially for development testing).
+#DOCKER="/usr/local/bin/docker"
+
+# Use DOCKER_OPTS to modify the daemon startup options.
+#DOCKER_OPTS="-dns 8.8.8.8"
+
+# If you need Docker to use an HTTP proxy, it can also be specified here.
+#export http_proxy=http://127.0.0.1:3128/
+EOF
+
 	# Copy the binary
 	# This will fail if the binary bundle hasn't been built
 	mkdir -p $DIR/usr/bin
@@ -120,12 +134,8 @@ EOF
 		    --maintainer "$PACKAGE_MAINTAINER" \
 		    --url "$PACKAGE_URL" \
 		    --license "$PACKAGE_LICENSE" \
-		    --config-files /etc/init/docker.conf \
-		    --config-files /etc/init.d/docker \
-		    --config-files /etc/default/docker \
 		    --deb-compression xz \
 		    -t deb .
-		# note: the --config-files lines have to be duplicated to stop overwrite on package upgrade (since we have to use this funky virtual package)
 	)
 }
 


### PR DESCRIPTION
This is to especially fix FPM 1.0+ complaining that we told it we have an /etc/default/docker "config file", but didn't actually include one.
