### PR TITLE
install instructions use unprefixed fedora image

### DIFF
--- a/docs/sources/installation/fedora.rst
+++ b/docs/sources/installation/fedora.rst
@@ -67,7 +67,7 @@ Now let's verify that Docker is working.
 
 .. code-block:: bash
 
-   sudo docker run -i -t mattdm/fedora /bin/bash
+   sudo docker run -i -t fedora /bin/bash
 
 **Done!**, now continue with the :ref:`hello_world` example.
 

--- a/docs/sources/installation/rhel.rst
+++ b/docs/sources/installation/rhel.rst
@@ -65,7 +65,7 @@ Now let's verify that Docker is working.
 
 .. code-block:: bash
 
-   sudo docker run -i -t mattdm/fedora /bin/bash
+   sudo docker run -i -t fedora /bin/bash
 
 **Done!**, now continue with the :ref:`hello_world` example.
 


### PR DESCRIPTION
Once the unprefixed fedora image is available, it would be preferable to use it instead of the current default mattdm/fedora in the install instructions for fedora and rhel (and binary compatible distros)
