### PR TITLE
Check standalone header when pinging a registry server.

### DIFF
--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -23,10 +23,11 @@ func spawnTestRegistry(t *testing.T) *Registry {
 }
 
 func TestPingRegistryEndpoint(t *testing.T) {
-	err := pingRegistryEndpoint(makeURL("/v1/"))
+	standalone, err := pingRegistryEndpoint(makeURL("/v1/"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	assertEqual(t, standalone, true, "Expected standalone to be true (default)")
 }
 
 func TestGetRemoteHistory(t *testing.T) {


### PR DESCRIPTION
Standalone has to be true to use basic auth (in addition to previous requirements)

Fixes https://github.com/dotcloud/docker-index/issues/236
