### PR TITLE
Fix support for registry auth with Dockerfile build.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -227,12 +227,14 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		v.Set("rm", "1")
 	}
 
+	cli.LoadConfigFile()
+
 	headers := http.Header(make(map[string][]string))
 	buf, err := json.Marshal(cli.configFile)
 	if err != nil {
 		return err
 	}
-	headers.Add("X-Registry-Auth", base64.URLEncoding.EncodeToString(buf))
+	headers.Add("X-Registry-Config", base64.URLEncoding.EncodeToString(buf))
 
 	if context != nil {
 		headers.Set("Content-Type", "application/tar")

--- a/docs/sources/reference/api/docker_remote_api.rst
+++ b/docs/sources/reference/api/docker_remote_api.rst
@@ -54,6 +54,13 @@ What's new
 
    **New!** This endpoint now returns a list of json message, like the events endpoint
 
+.. http:post:: /build
+
+   **New!** This endpoint now takes a serialized ConfigFile which it uses to
+   resolve the proper registry auth credentials for pulling the base image.
+   Clients which previously implemented the version accepting an AuthConfig
+   object must be updated.
+
 v1.8
 ****
 

--- a/docs/sources/reference/api/docker_remote_api_v1.9.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.9.rst
@@ -1025,7 +1025,7 @@ Build an image from Dockerfile via stdin
    :query q: suppress verbose build output
    :query nocache: do not use the cache when building the image
    :reqheader Content-type: should be set to ``"application/tar"``.
-   :reqheader X-Registry-Auth: base64-encoded AuthConfig object
+   :reqheader X-Registry-Config: base64-encoded ConfigFile object
    :statuscode 200: no error
    :statuscode 500: server error
 

--- a/integration/buildfile_test.go
+++ b/integration/buildfile_test.go
@@ -296,7 +296,7 @@ func buildImage(context testContextTemplate, t *testing.T, eng *engine.Engine, u
 	}
 	dockerfile := constructDockerfile(context.dockerfile, ip, port)
 
-	buildfile := docker.NewBuildFile(srv, ioutil.Discard, ioutil.Discard, false, useCache, false, ioutil.Discard, utils.NewStreamFormatter(false), nil)
+	buildfile := docker.NewBuildFile(srv, ioutil.Discard, ioutil.Discard, false, useCache, false, ioutil.Discard, utils.NewStreamFormatter(false), nil, nil)
 	id, err := buildfile.Build(mkTestContext(dockerfile, context.files, t))
 	if err != nil {
 		return nil, err
@@ -700,7 +700,7 @@ func TestForbiddenContextPath(t *testing.T) {
 	}
 	dockerfile := constructDockerfile(context.dockerfile, ip, port)
 
-	buildfile := docker.NewBuildFile(srv, ioutil.Discard, ioutil.Discard, false, true, false, ioutil.Discard, utils.NewStreamFormatter(false), nil)
+	buildfile := docker.NewBuildFile(srv, ioutil.Discard, ioutil.Discard, false, true, false, ioutil.Discard, utils.NewStreamFormatter(false), nil, nil)
 	_, err = buildfile.Build(mkTestContext(dockerfile, context.files, t))
 
 	if err == nil {
@@ -746,7 +746,7 @@ func TestBuildADDFileNotFound(t *testing.T) {
 	}
 	dockerfile := constructDockerfile(context.dockerfile, ip, port)
 
-	buildfile := docker.NewBuildFile(mkServerFromEngine(eng, t), ioutil.Discard, ioutil.Discard, false, true, false, ioutil.Discard, utils.NewStreamFormatter(false), nil)
+	buildfile := docker.NewBuildFile(mkServerFromEngine(eng, t), ioutil.Discard, ioutil.Discard, false, true, false, ioutil.Discard, utils.NewStreamFormatter(false), nil, nil)
 	_, err = buildfile.Build(mkTestContext(dockerfile, context.files, t))
 
 	if err == nil {


### PR DESCRIPTION
Finishes the work from #3099. The original implementation attempted to pass the entire ConfigFile block and then parsed it as an AuthConfig. I believe this isn't feasible because we haven't parsed the Dockerfile in the CLI in order to determine which AuthConfig block is appropriate.

There were two choices, parse the Dockerfile in the CLI and select the proper AuthConfig, or send and parse the entire ConfigFile block and select the proper credentials on the daemon. Since the daemon necessarily has to parse the Dockerfile anyway, I chose the latter.
