### PR TITLE
Fix login message to say pull instead of push.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1100,7 +1100,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 
 	if err := pull(authConfig); err != nil {
 		if err.Error() == registry.ErrLoginRequired.Error() {
-			fmt.Fprintln(cli.out, "\nPlease login prior to push:")
+			fmt.Fprintln(cli.out, "\nPlease login prior to pull:")
 			if err := cli.CmdLogin(endpoint); err != nil {
 				return err
 			}


### PR DESCRIPTION
```
# docker pull localhost:8001/rigprog
Pulling repository localhost:8001/rigprog

Please login prior to push:
Login against server at http://localhost:8001/v1/
Username: 
```

It should be pull not push.
