### PR TITLE
Fixed error in group add example

### DIFF
--- a/docs/sources/use/basics.rst
+++ b/docs/sources/use/basics.rst
@@ -78,11 +78,11 @@ client commands.
   # Add the docker group if it doesn't already exist.
   sudo groupadd docker
 
-  # Add the connected user "${USERNAME}" to the docker group.
+  # Add the connected user "${USER}" to the docker group.
   # Change the user name to match your preferred user.
   # You may have to logout and log back in again for
   # this to take effect.
-  sudo gpasswd -a ${USERNAME} docker
+  sudo gpasswd -a ${USER} docker
 
   # Restart the docker daemon.
   sudo service docker restart


### PR DESCRIPTION
There is no ${USERNAME} in bash, only ${USER}
