### PR TITLE
Support submodules when building from a gh repo

### DIFF
--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -194,7 +194,8 @@ The files at ``PATH`` or ``URL`` are called the "context" of the build. The
 build process may refer to any of the files in the context, for example when
 using an :ref:`ADD <dockerfile_add>` instruction.  When a single ``Dockerfile``
 is given as ``URL``, then no context is set.  When a Git repository is set as
-``URL``, then the repository is used as the context
+``URL``, then the repository is used as the context. Git repositories are
+cloned with their submodules (`git clone --recursive`).
 
 .. _cli_build_examples:
 

--- a/server.go
+++ b/server.go
@@ -457,7 +457,7 @@ func (srv *Server) Build(job *engine.Job) engine.Status {
 		}
 		defer os.RemoveAll(root)
 
-		if output, err := exec.Command("git", "clone", remoteURL, root).CombinedOutput(); err != nil {
+		if output, err := exec.Command("git", "clone", "--recursive", remoteURL, root).CombinedOutput(); err != nil {
 			return job.Errorf("Error trying to use git: %s (%s)", err, output)
 		}
 


### PR DESCRIPTION
Hey, I was thinking if automatically cloning a repo is supported, submodules should be included if existed. `Dockerfile` might be using some files in submodule(s) in that repo.
