### PR TITLE
Improvements in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all binary build cross default docs shell test
 
-DOCKER_RUN_DOCKER := docker run -rm -i -t -privileged -e TESTFLAGS -v $(CURDIR)/bundles:/go/src/github.com/dotcloud/docker/bundles docker
+DOCKER_RUN_DOCKER := docker run -rm -i -t -privileged -e TESTFLAGS -v $(CURDIR)/bundles:/go/src/github.com/dotcloud/docker/bundles docker_dev_img
 
 default: binary
 
@@ -23,7 +23,7 @@ shell: build
 	$(DOCKER_RUN_DOCKER) bash
 
 build: bundles
-	docker build -t docker .
+	docker images | awk '{print $1}' | grep docker_dev_img || docker build -t docker_dev_img .
 
 bundles:
-	mkdir bundles
+	mkdir -p bundles


### PR DESCRIPTION
Currently, target `build` is nearly dependency of every other target. In target `build`, `docker build` is called to create a new docker image based on `Dockerfile`. The result is that, every time `make` is used, a new docker image named `docker` is built.

My understanding is that, the target `build` is meant to ensure that the image `docker` exists. That means if the image `docker` is already there, it should not build again.

Since `docker build` would "steal" repository name if an image with the same name already exists, this behavior also assumes that the image `docker` is only used for docker development. Otherwise, user's original `docker` image will lost its name.

This PR proposes three changes:
1. Rename the image `docker` to `docker_dev_img`, which is a less common name, to avoid naming conflict.
2. Run `docker build` only if the image `docker_dev_img` does not exist. In this way, the purpose of target `build` in `Makefile` is (correctly) to ensure the image exists.
3. Using `mkdir -p` instead of `mkdir` in target `bundle`.
