### PR TITLE
[docs] Fix for wrong version warning on master instead of latest.

### DIFF
--- a/docs/theme/docker/static/js/docs.js
+++ b/docs/theme/docker/static/js/docs.js
@@ -92,7 +92,7 @@ $(function(){
         $('.version-flyer ul').html('<li class="alternative active-slug"><a href="" title="Switch to local">Local</a></li>');
     }
 
-    if (doc_version == "master") {
+    if (doc_version == "latest") {
         $('.version-flyer .version-note').hide();
     }
 


### PR DESCRIPTION
Unfortunately I had made an error the last time. We want people to go to 'latest' and feel good. 
