### PR TITLE
Fix Travis handling of a fully-numeric commit hash being YAML-converted ...

### DIFF
--- a/hack/travis/dco.py
+++ b/hack/travis/dco.py
@@ -5,7 +5,7 @@ import yaml
 
 from env import commit_range
 
-commit_format = '-%n hash: %h%n author: %aN <%aE>%n message: |%n%w(0,2,2)%B'
+commit_format = '-%n hash: "%h"%n author: %aN <%aE>%n message: |%n%w(0,2,2)%B'
 
 gitlog = subprocess.check_output([
 	'git', 'log', '--reverse',


### PR DESCRIPTION
...to a number instead of a string

/cc @crosbymichael
