### PR TITLE
#3449 - fix `docker build` on devicemapper

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,7 +48,6 @@ Daniel YC Lin <dlin.tw@gmail.com>
 Darren Coxall <darren@darrencoxall.com>
 David Calavera <david.calavera@gmail.com>
 David Sissitka <me@dsissitka.com>
-Dinesh Subhraveti <dineshs@altiscale.com>
 Deni Bertovic <deni@kset.org>
 Dominik Honnef <dominik@honnef.co>
 Don Spaulding <donspauldingii@gmail.com>

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -149,7 +149,7 @@ func escapeName(name string) string {
 // Tar creates an archive from the directory at `path`, only including files whose relative
 // paths are included in `filter`. If `filter` is nil, then all files are included.
 func TarFilter(path string, options *TarOptions) (io.Reader, error) {
-	args := []string{"tar", "-S", "--numeric-owner", "-f", "-", "-C", path, "-T", "-"}
+	args := []string{"tar", "--numeric-owner", "-f", "-", "-C", path, "-T", "-"}
 	if options.Includes == nil {
 		options.Includes = []string{"."}
 	}
@@ -228,7 +228,7 @@ func Untar(archive io.Reader, path string, options *TarOptions) error {
 	compression := DetectCompression(buf)
 
 	utils.Debugf("Archive compression detected: %s", compression.Extension())
-	args := []string{"-S", "--numeric-owner", "-f", "-", "-C", path, "-x" + compression.Flag()}
+	args := []string{"--numeric-owner", "-f", "-", "-C", path, "-x" + compression.Flag()}
 
 	if options != nil {
 		for _, exclude := range options.Excludes {


### PR DESCRIPTION
This reverts commit 733bf5d3ddbfb6dba7c2c0996c4af47a765e4593.

This is needed to fix "no such file" errors `docker build` errors for
devicemapper.

This fixes issue #3449.
