### PR TITLE
Update Makefile to use "docker:GIT_BRANCH" as the generated image name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: all binary build cross default docs shell test
 
-DOCKER_RUN_DOCKER := docker run -rm -i -t -privileged -e TESTFLAGS -v $(CURDIR)/bundles:/go/src/github.com/dotcloud/docker/bundles docker
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+DOCKER_IMAGE := docker:$(GIT_BRANCH)
+DOCKER_DOCS_IMAGE := docker-docs:$(GIT_BRANCH)
+DOCKER_RUN_DOCKER := docker run -rm -i -t -privileged -e TESTFLAGS -v $(CURDIR)/bundles:/go/src/github.com/dotcloud/docker/bundles "$(DOCKER_IMAGE)"
 
 default: binary
 
@@ -14,7 +17,8 @@ cross: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary cross
 
 docs:
-	docker build -t docker-docs docs && docker run -p 8000:8000 docker-docs
+	docker build -rm -t "$(DOCKER_DOCS_IMAGE)" docs
+	docker run -rm -i -t -p 8000:8000 "$(DOCKER_DOCS_IMAGE)"
 
 test: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh test test-integration
@@ -23,7 +27,7 @@ shell: build
 	$(DOCKER_RUN_DOCKER) bash
 
 build: bundles
-	docker build -t docker .
+	docker build -rm -t "$(DOCKER_IMAGE)" .
 
 bundles:
 	mkdir bundles


### PR DESCRIPTION
... for increased versatility

... and other minor Makefile improvements :)

See also #3471 for more discussion on this.
