### PR TITLE
Disable compression for build. More space usage but much faster upload

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -594,11 +594,12 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	b.context = &utils.TarSum{Reader: context}
+	b.context = &utils.TarSum{Reader: context, DisableCompression: true}
 	if err := archive.Untar(b.context, tmpdirPath, nil); err != nil {
 		return "", err
 	}
 	defer os.RemoveAll(tmpdirPath)
+
 	b.contextPath = tmpdirPath
 	filename := path.Join(tmpdirPath, "Dockerfile")
 	if _, err := os.Stat(filename); os.IsNotExist(err) {


### PR DESCRIPTION
It does not increase the bandwidth load. It was already uncompressed. It just increase the disk space used by the server's tmp dir.

The slowness appears only in local. With a remote host, the bandwidth would be the bottleneck and with or without compression it would be the same speed.
