### PR TITLE
Add more specific lvm2 version to PACKAGERS document

### DIFF
--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -38,7 +38,7 @@ To build docker, you will need the following system dependencies
 * A recent version of git and mercurial
 * Go version 1.2 or later
 * SQLite version 3.7.9 or later
-* libdevmapper from lvm2 version 1.02.77 or later (http://www.sourceware.org/lvm2/)
+* libdevmapper version 1.02.68-cvs (2012-01-26) or later from lvm2 version 2.02.89 or later
 * A clean checkout of the source must be added to a valid Go [workspace](http://golang.org/doc/code.html#Workspaces)
 under the path *src/github.com/dotcloud/docker*.
 


### PR DESCRIPTION
I personally tested this using our container, and this was the lowest version that compiles and runs properly.
