### PR TITLE
Hello World: fix detach behavior

### DIFF
--- a/docs/sources/examples/hello_world.rst
+++ b/docs/sources/examples/hello_world.rst
@@ -125,12 +125,14 @@ Check the logs make sure it is working correctly.
 
 .. code-block:: bash
 
-    sudo docker attach $CONTAINER_ID
+    sudo docker attach -sig-proxy=false $CONTAINER_ID
 
 Attach to the container to see the results in real-time.
 
 - **"docker attach**" This will allow us to attach to a background
   process to see what is going on.
+- "-sig-proxy=false" Do not forward signals to the container; allows
+  us to exit the attachment using Control-C without stopping the container.
 - **$CONTAINER_ID** The Id of the container we want to attach too.
 
 Exit from the container attachment by pressing Control-C.

--- a/docs/sources/examples/hello_world.rst
+++ b/docs/sources/examples/hello_world.rst
@@ -131,7 +131,7 @@ Attach to the container to see the results in real-time.
 
 - **"docker attach**" This will allow us to attach to a background
   process to see what is going on.
-- "-sig-proxy=false" Do not forward signals to the container; allows
+- **"-sig-proxy=false"** Do not forward signals to the container; allows
   us to exit the attachment using Control-C without stopping the container.
 - **$CONTAINER_ID** The Id of the container we want to attach too.
 


### PR DESCRIPTION
The hello world example relies on being able to exit the container attachment using Control-C without stopping it. According to this thread (and my own experience), this doesn't work anymore:

https://groups.google.com/forum/#!msg/docker-user/nWXAnyLP9-M/kbv-FZpF4rUJ

Added -sig-proxy=false to the attach command.

Docker-DCO-1.0-Signed-off-by: Gert van Valkenhoef g.h.m.van.valkenhoef@rug.nl (github: gertvv)
