### PR TITLE
network: GetDefaultNetworkMtu from eth0

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,7 +45,7 @@ func ConfigFromJob(job *engine.Job) *DaemonConfig {
 	if mtu := job.GetenvInt("Mtu"); mtu != -1 {
 		config.Mtu = mtu
 	} else {
-		config.Mtu = DefaultNetworkMtu
+		config.Mtu = GetDefaultNetworkMtu()
 	}
 	return &config
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -40,7 +40,7 @@ func main() {
 		flInterContainerComm = flag.Bool("icc", true, "Enable inter-container communication")
 		flGraphDriver        = flag.String("s", "", "Force the docker runtime to use a specific storage driver")
 		flHosts              = docker.NewListOpts(docker.ValidateHost)
-		flMtu                = flag.Int("mtu", docker.DefaultNetworkMtu, "Set the containers network mtu")
+		flMtu                = flag.Int("mtu", docker.GetDefaultNetworkMtu(), "Set the containers network mtu")
 	)
 	flag.Var(&flDns, "dns", "Force docker to use specific DNS servers")
 	flag.Var(&flHosts, "H", "Multiple tcp://host:port or unix://path/to/socket to bind in daemon mode, single connection otherwise")

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -32,7 +32,7 @@ func mkRuntime(f utils.Fataler) *docker.Runtime {
 	config := &docker.DaemonConfig{
 		Root:        root,
 		AutoRestart: false,
-		Mtu:         docker.DefaultNetworkMtu,
+		Mtu:         docker.GetDefaultNetworkMtu(),
 	}
 	r, err := docker.NewRuntimeFromDirectory(config)
 	if err != nil {

--- a/network.go
+++ b/network.go
@@ -19,11 +19,18 @@ import (
 const (
 	DefaultNetworkBridge = "docker0"
 	DisableNetworkBridge = "none"
-	DefaultNetworkMtu    = 1500
+	defaultNetworkMtu    = 1500
 	portRangeStart       = 49153
 	portRangeEnd         = 65535
 	siocBRADDBR          = 0x89a0
 )
+
+func GetDefaultNetworkMtu() int {
+	if iface, err := net.InterfaceByName("eth0"); err == nil {
+		return iface.MTU
+	}
+	return defaultNetworkMtu
+}
 
 // Calculates the first and last IP addresses in an IPNet
 func networkRange(network *net.IPNet) (net.IP, net.IP) {


### PR DESCRIPTION
get the default -mtu flag value from eth0's MTU, fallback on `1500` in case of error.

Not a fan of hardwiring `eth0` there, let me know if there is a better way (tm).

Docker-DCO-1.0-Signed-off-by: Johan Euphrosine proppy@google.com (github: proppy)
