### PR TITLE
fix issue #2606

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1781,6 +1781,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flUser            = cmd.String([]string{"u", "-username"}, "", "Username or UID")
 		flWorkingDir      = cmd.String([]string{"w", "-workdir"}, "", "Working directory inside the container")
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
+		flShmString       = cmd.String([]string{"#shm", "-shm"}, "65536k", "/dev/shm size (format: <number><optional unit>, where unit = b, k, m or g)")
 
 		// For documentation purpose
 		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify all received signal to the process (even in non-tty mode)")
@@ -1836,6 +1837,15 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 			return nil, nil, cmd, err
 		}
 		flMemory = parsedMemory
+	}
+
+	var flShm int64
+	if *flShmString != "" {
+		parsedShm, err := utils.RAMInBytes(*flShmString)
+		if err != nil {
+			return nil, nil, cmd, err
+		}
+		flShm = parsedShm
 	}
 
 	var binds []string
@@ -1921,6 +1931,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		Image:           image,
 		Volumes:         flVolumes.GetMap(),
 		VolumesFrom:     strings.Join(flVolumesFrom.GetAll(), ","),
+		Shm:             flShm,
 		Entrypoint:      entrypoint,
 		WorkingDir:      *flWorkingDir,
 	}

--- a/container.go
+++ b/container.go
@@ -94,6 +94,7 @@ type Config struct {
 	Env             []string
 	Cmd             []string
 	Dns             []string
+	Shm             int64  // Size of /dev/shm (in bytes)
 	Image           string // Name of the image as it was passed by the operator (eg. could be symbolic)
 	Volumes         map[string]struct{}
 	VolumesFrom     string

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1009,6 +1009,7 @@ image is removed.
       -n, --networking=true: Enable networking for this container
       -p, --publish=[]: Map a network port to the container
       --rm=false: Automatically remove the container when it exits (incompatible with -d)
+      --shm="65536k": /dev/shm size (format: <number><optional unit>, where unit = b, k, m or g)
       -t, --tty=false: Allocate a pseudo-tty
       -u, --username="": Username or UID
       --dns=[]: Set custom dns servers for the container

--- a/execdriver/lxc/lxc_template.go
+++ b/execdriver/lxc/lxc_template.go
@@ -80,7 +80,7 @@ lxc.mount.entry = proc {{escapeFstabSpaces $ROOTFS}}/proc proc nosuid,nodev,noex
 lxc.mount.entry = sysfs {{escapeFstabSpaces $ROOTFS}}/sys sysfs nosuid,nodev,noexec 0 0
 
 lxc.mount.entry = devpts {{escapeFstabSpaces $ROOTFS}}/dev/pts devpts newinstance,ptmxmode=0666,nosuid,noexec 0 0
-lxc.mount.entry = shm {{escapeFstabSpaces $ROOTFS}}/dev/shm tmpfs size=65536k,nosuid,nodev,noexec 0 0
+lxc.mount.entry = shm {{escapeFstabSpaces $ROOTFS}}/dev/shm tmpfs size={{.Config.Shm}},nosuid,nodev,noexec 0 0
 
 {{if .Privileged}}
 {{if .AppArmor}}


### PR DESCRIPTION
Added a "docker run" option for sizing /dev/shm which is actually
hardcoded to 64M.

The option is -shm="xxx" where xxx is the size in bytes using k,m,g
notation.

Docker-DCO-1.0-Signed-off-by: Julien Vermillard jvermillar@sierrawireless.com (github: jvermillard)
