### PR TITLE
added capabilities needed by new sysinit

### DIFF
--- a/contrib/mkseccomp.pl
+++ b/contrib/mkseccomp.pl
@@ -41,7 +41,7 @@ use warnings;
 
 if( -t ) {
     print STDERR "Helper script to make seccomp filters for Docker/LXC.\n";
-    print STDERR "Usage: mkseccomp.pl [files...]\n";
+    print STDERR "Usage: mkseccomp.pl < [files...]\n";
     exit 1;
 }
 

--- a/contrib/mkseccomp.sample
+++ b/contrib/mkseccomp.sample
@@ -195,6 +195,7 @@ shutdown
 socket                 // (*)
 socketcall
 socketpair
+sethostname            // (*)
 
 // Signal related
 pause
@@ -261,7 +262,7 @@ vmsplice
 
 // Process control
 capget
-//capset
+capset                 // (*)
 clone                  // (*)
 execve                 // (*)
 exit                   // (*)
@@ -401,7 +402,6 @@ tkill
 //quotactl
 //reboot
 //setdomainname
-//sethostname
 //setns
 //settimeofday
 //sgetmask             // Obsolete


### PR DESCRIPTION
The new sysinit now drops capabilities and sets the hostname instead of LXC - updated sample seccomp list of allowed syscalls for this to work. Also minor fix to help message for correct usage.

Docker-DCO-1.0-Signed-off-by: Fernando Mayo fernando@tutum.co (github: fermayo)
