### PR TITLE
ExecStartPre commands updated

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -1,11 +1,13 @@
 [Unit]
-Description=Docker Application Container Engine 
+Description=Docker Application Container Engine
 Documentation=http://docs.docker.io
 After=network.target
 
 [Service]
-ExecStartPre=/bin/mount --make-rprivate /
+Type=simple
+ExecStartPre=/usr/sbin/sysctl -w net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1
 ExecStart=/usr/bin/docker -d
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -4,8 +4,6 @@ Documentation=http://docs.docker.io
 After=network.target
 
 [Service]
-Type=simple
-ExecStartPre=/usr/sbin/sysctl -w net.ipv4.ip_forward=1 net.ipv6.conf.all.forwarding=1
 ExecStart=/usr/bin/docker -d
 Restart=on-failure
 


### PR DESCRIPTION
systemd service no longer does '/bin/mount/ --make-rprivate /'.
Core issue fixed by Alex Larsson.

ip forwarding enabled.
