### PR TITLE
Remove volumes on docker run -rm

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -2138,7 +2138,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		if _, status, err = getExitCode(cli, runResult.ID); err != nil {
 			return err
 		}
-		if _, _, err := cli.call("DELETE", "/containers/"+runResult.ID, nil); err != nil {
+		if _, _, err := cli.call("DELETE", "/containers/"+runResult.ID+"?v=1", nil); err != nil {
 			return err
 		}
 	} else {


### PR DESCRIPTION
If we don't care about the container then we don't care about any
volumes created with the run of that container

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
