### PR TITLE
CONTRIBUTING.md: wrap DCO to 78 chars per line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,16 +115,28 @@ can certify the below:
 ```
 Docker Developer Grant and Certificate of Origin 1.1
 
-By making a contribution to the Docker Project ("Project"), I represent and warrant that:
+By making a contribution to the Docker Project ("Project"), I represent and
+warrant that:
 
-a. The contribution was created in whole or in part by me and I have the right to submit the contribution on my own behalf or on behalf of a third party who has authorized me to submit this contribution to the Project; or
+a. The contribution was created in whole or in part by me and I have the right
+to submit the contribution on my own behalf or on behalf of a third party who
+has authorized me to submit this contribution to the Project; or
 
-b. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right and authorization to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license) that I have identified in the contribution; or
+b. The contribution is based upon previous work that, to the best of my
+knowledge, is covered under an appropriate open source license and I have the
+right and authorization to submit that work with modifications, whether
+created in whole or in part by me, under the same open source license (unless
+I am permitted to submit under a different license) that I have identified in
+the contribution; or
 
-c. The contribution was provided directly to me by some other person who represented and warranted (a) or (b) and I have not modified it.
+c. The contribution was provided directly to me by some other person who
+represented and warranted (a) or (b) and I have not modified it.
 
-d. I understand and agree that this Project and the contribution are publicly known and that a record of the contribution (including all personal information I submit with it, including my sign-off record) is maintained indefinitely and may be redistributed consistent with this Project or the open source license(s) involved.
-
+d. I understand and agree that this Project and the contribution are publicly
+known and that a record of the contribution (including all personal
+information I submit with it, including my sign-off record) is maintained
+indefinitely and may be redistributed consistent with this Project or the open
+source license(s) involved.
 ```
 
 then you just add a line to every git commit message:


### PR DESCRIPTION
The DCO is a bit hard to read on Github right now because there is lots of
horizontal scrolling. Reformat it to 78 chars per line like the rest of the
file.

Example: http://imgur.com/LtJEIsl
