### PR TITLE
Don't compress the archive made from git's output.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -148,6 +148,7 @@ odk- <github@odkurzacz.org>
 Pascal Borreli <pascal@borreli.com>
 Paul Bowsher <pbowsher@globalpersonals.co.uk>
 Paul Hammond <paul@paulhammond.org>
+Paul Liétar <paul@lietar.net>
 Paul Nasrat <pnasrat@gmail.com>
 Phil Spitler <pspitler@gmail.com>
 Piotr Bogdan <ppbogdan@gmail.com>

--- a/api.go
+++ b/api.go
@@ -929,7 +929,7 @@ func postBuild(srv *Server, version float64, w http.ResponseWriter, r *http.Requ
 			return fmt.Errorf("Error trying to use git: %s (%s)", err, output)
 		}
 
-		c, err := archive.Tar(root, archive.Bzip2)
+		c, err := archive.Tar(root, archive.Uncompressed)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Commit 894d4a23fba made BuildFile use TarSum, which doesn't supportcompressed tar archives.
This breaks builds from git url, which compressed it with bzip2.
Instead, just pass it uncompressed.

Fixes #3457.
