### PR TITLE
Fix command line for setting the MTU

### DIFF
--- a/docs/sources/installation/google.rst
+++ b/docs/sources/installation/google.rst
@@ -62,7 +62,7 @@
 
 .. code-block:: bash
 
-    docker-playground:~$ echo 'DOCKER_OPTS="$DOCKER_OPTS -mtu 1460"' | sudo tee -a /etc/default/docker
+    docker-playground:~$ echo "DOCKER_OPTS=\"\$DOCKER_OPTS -mtu 1460\"" | sudo tee -a /etc/default/docker
     docker-playground:~$ sudo service docker restart
 
 8. Start a new container:


### PR DESCRIPTION
There seemed to be syntax errors in this command line: the quotes are wrong and the configuration file path is wrong.
