### PR TITLE
Update docker_remote_api_v1.8.rst

### DIFF
--- a/docs/sources/api/docker_remote_api.rst
+++ b/docs/sources/api/docker_remote_api.rst
@@ -139,7 +139,7 @@ What's new
       
       [
         {
-           "RepoTag": [
+           "RepoTags": [
              "ubuntu:12.04",
              "ubuntu:precise",
              "ubuntu:latest"
@@ -150,7 +150,7 @@ What's new
            "VirtualSize": 131506275
         },
         {
-           "RepoTag": [
+           "RepoTags": [
              "ubuntu:12.10",
              "ubuntu:quantal"
            ],

--- a/docs/sources/api/docker_remote_api_v1.7.rst
+++ b/docs/sources/api/docker_remote_api_v1.7.rst
@@ -643,7 +643,7 @@ List Images
 	   
 	   [
 	     {
-	   	"RepoTag": [
+	   	"RepoTags": [
 	   	  "ubuntu:12.04",
 	   	  "ubuntu:precise",
 	   	  "ubuntu:latest"
@@ -654,7 +654,7 @@ List Images
 	   	"VirtualSize": 131506275
 	     },
 	     {
-	   	"RepoTag": [
+	   	"RepoTags": [
 	   	  "ubuntu:12.10",
 	   	  "ubuntu:quantal"
 	   	],

--- a/docs/sources/api/docker_remote_api_v1.8.rst
+++ b/docs/sources/api/docker_remote_api_v1.8.rst
@@ -658,7 +658,7 @@ List Images
 	   
 	   [
 	     {
-	   	"RepoTag": [
+	   	"RepoTags": [
 	   	  "ubuntu:12.04",
 	   	  "ubuntu:precise",
 	   	  "ubuntu:latest"
@@ -669,7 +669,7 @@ List Images
 	   	"VirtualSize": 131506275
 	     },
 	     {
-	   	"RepoTag": [
+	   	"RepoTags": [
 	   	  "ubuntu:12.10",
 	   	  "ubuntu:quantal"
 	   	],


### PR DESCRIPTION
Remote api listing tags under RepoTags instead of RepoTag.

Docker-DCO-1.1-Signed-off-by: Jean-Baptiste Dalido jbdalido@gmail.com (github: jeandalido)
