### PR TITLE
Use gzip compression in Ubuntu packages to make it possible to install on Lucid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN	cd /usr/local/go/src && bash -xc 'for platform in $DOCKER_CROSSPLATFORMS; do
 RUN	go get code.google.com/p/go.tools/cmd/cover
 
 # TODO replace FPM with some very minimal debhelper stuff
-RUN	gem install --no-rdoc --no-ri fpm --version 1.0.1
+RUN	gem install --no-rdoc --no-ri fpm --version 1.0.2
 
 # Setup s3cmd config
 RUN	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_KEY' > /.s3cfg

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -123,7 +123,7 @@ EOF
 		    --config-files /etc/init/docker.conf \
 		    --config-files /etc/init.d/docker \
 		    --config-files /etc/default/docker \
-		    --deb-compression xz \
+		    --deb-compression gz \
 		    -t deb .
 		mkdir empty
 		fpm -s dir -C empty \
@@ -134,7 +134,7 @@ EOF
 		    --maintainer "$PACKAGE_MAINTAINER" \
 		    --url "$PACKAGE_URL" \
 		    --license "$PACKAGE_LICENSE" \
-		    --deb-compression xz \
+		    --deb-compression gz \
 		    -t deb .
 	)
 }


### PR DESCRIPTION
Lucid comes with an older version of dpkg which does not support xz compression. Much of the work done to make Docker compatible with RHEL 6 has also had the side effect of making it runnable on Ubuntu 10.04 Lucid.

This change makes the .deb files installable on Lucid. Gzip-compressed debs [should continue to work for future Ubuntu/Debian versions for a long time](https://botbot.me/freenode/docker-dev/msg/8532969)
