### PR TITLE
Inline the test.docker.io fingerprint in the install.sh script as well

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -110,6 +110,8 @@ case "$lsb_dist" in
 			set -x
 			if [ "https://get.docker.io/" = "$url" ]; then
 				$sh_c "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
+			elif [ "https://test.docker.io/" = "$url" ]; then
+				$sh_c "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 740B314AE3941731B942C66ADF4FD13717AAD7D6"
 			else
 				$sh_c "$curl ${url}gpg | apt-key add -"
 			fi


### PR DESCRIPTION
As long as we're doing it, we ought to do it for all the "official" Docker properties at least.
