### PR TITLE
Add ca-certificates to our package Recommends

### DIFF
--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -111,6 +111,7 @@ EOF
 		    --depends lxc \
 		    --depends aufs-tools \
 		    --depends iptables \
+		    --deb-recommends ca-certificates \
 		    --description "$PACKAGE_DESCRIPTION" \
 		    --maintainer "$PACKAGE_MAINTAINER" \
 		    --conflicts lxc-docker-virtual-package \


### PR DESCRIPTION
It's only in "Recommends" because it's only required for all but the esoteric configurations (since you can't "docker pull" from the index without it, but that's about it).
