### PR TITLE
fpm - Use '-s empty' instead of '-s dir'

### DIFF
--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -125,8 +125,7 @@ EOF
 		    --config-files /etc/default/docker \
 		    --deb-compression gz \
 		    -t deb .
-		mkdir empty
-		fpm -s dir -C empty \
+		fpm -s empty \
 		    --name lxc-docker --version $PKGVERSION \
 		    --architecture "$PACKAGE_ARCHITECTURE" \
 		    --depends lxc-docker-$VERSION \
@@ -135,7 +134,7 @@ EOF
 		    --url "$PACKAGE_URL" \
 		    --license "$PACKAGE_LICENSE" \
 		    --deb-compression gz \
-		    -t deb .
+		    -t deb
 	)
 }
 


### PR DESCRIPTION
This _should_ have the same effect as the previous strategy:

Instead of 'mkdir empty; fpm -s dir -C empty ...' we can simply do 'fpm -s empty'
