### PR TITLE
improve the Vagrant VMs: bump RAM to 512 MB & correct forwarded ports

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,8 @@ PRIVATE_NETWORK = ENV['PRIVATE_NETWORK']
 # See http://docs.docker.io/en/latest/use/port_redirection/ for more
 # $ FORWARD_DOCKER_PORTS=1 vagrant [up|reload]
 FORWARD_DOCKER_PORTS = ENV['FORWARD_DOCKER_PORTS']
+VAGRANT_RAM = ENV['VAGRANT_RAM'] || 512
+VAGRANT_CORES = ENV['VAGRANT_CORES'] || 1
 
 # You may also provide a comma-separated list of ports
 # for Vagrant to forward. For example:
@@ -30,6 +32,10 @@ user="$1"
 if [ -z "$user" ]; then
     user=vagrant
 fi
+
+# Enable memory cgroup and swap accounting
+sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"/g' /etc/default/grub
+update-grub
 
 # Adding an apt gpg key is idempotent.
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
@@ -160,6 +166,8 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     override.vm.provision :shell, :inline => $vbox_script
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
     vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+    vb.customize ["modifyvm", :id, "--memory", VAGRANT_RAM]
+    vb.customize ["modifyvm", :id, "--cpus", VAGRANT_CORES]
   end
 end
 
@@ -170,7 +178,7 @@ Vagrant::VERSION < "1.1.0" and Vagrant::Config.run do |config|
 end
 
 # Setup port forwarding per loaded environment variables
-forward_ports = FORWARD_DOCKER_PORTS.nil? ? [] : [*49000..49900]
+forward_ports = FORWARD_DOCKER_PORTS.nil? ? [] : [*49153..49900]
 forward_ports += FORWARD_PORTS.split(',').map{|i| i.to_i } if FORWARD_PORTS
 if forward_ports.any?
   Vagrant::VERSION < "1.1.0" and Vagrant::Config.run do |config|
@@ -181,7 +189,7 @@ if forward_ports.any?
 
   Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     forward_ports.each do |port|
-      config.vm.network :forwarded_port, :host => port, :guest => port
+      config.vm.network :forwarded_port, :host => port, :guest => port, auto_correct: true
     end
   end
 end


### PR DESCRIPTION
This PR bumps the VM RAM to 512 MB and corrects forwarded ports when they're already used.

The bump to 512 MB of RAM is conservative. We could bump it higher to 640 MB or to 768 MB.

Thanks to @wouterd for the auto-correct of forwarded ports he proposed in #3042.
- [x] bump RAM to 512 MB
- [x] add an environment variable to set the amount of RAM the Vagrant VirtualBox VM should have
- [x] set auto_correct for forwarded ports to help with some conflicts
- [x] change the starting range of the forwarded ports from 49000 to 49153
- [x] enable memory cgroup and swap accounting
- [x] rebase after merging #3188
- [x] rebase after merging #3125
- [x] add support for setting the number of cores

~~come up with a workaround to the tmpfs problem to make it possible to test Docker with 512 MB of RAM~~ delayed for another PR
