### PR TITLE
Add support for `RUN [""]` in Dockerfiles

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -124,7 +124,7 @@ func (b *buildFile) CmdRun(args string) error {
 	if b.image == "" {
 		return fmt.Errorf("Please provide a source image with `from` prior to run")
 	}
-	config, _, _, err := ParseRun([]string{b.image, "/bin/sh", "-c", args}, nil)
+	config, _, _, err := ParseRun(append([]string{b.image}, b.buildCmdFromJson(args)...), nil)
 	if err != nil {
 		return err
 	}

--- a/integration/buildfile_test.go
+++ b/integration/buildfile_test.go
@@ -223,6 +223,31 @@ run    [ "$(cat /bar/withfile)" = "test2" ]
 		},
 		nil,
 	},
+
+	// JSON!
+	{
+		`
+FROM {IMAGE}
+RUN ["/bin/echo","hello","world"]
+CMD ["/bin/true"]
+ENTRYPOINT ["/bin/echo","your command -->"]
+`,
+		nil,
+		nil,
+	},
+	{
+		`
+FROM {IMAGE}
+ADD test /test
+RUN ["chmod","+x","/test"]
+RUN ["/test"]
+RUN [ "$(cat /testfile)" = 'test!' ]
+`,
+		[][2]string{
+			{"test", "#!/bin/sh\necho 'test!' > /testfile"},
+		},
+		nil,
+	},
 }
 
 // FIXME: test building with 2 successive overlapping ADD commands


### PR DESCRIPTION
Thanks to @cpuguy83's new `buildCmdFromJson`, this is very trivial to implement for better consistency from instruction to instruction.

Just to head off @svendowideit, I know it needs documentation and tests.  I'll get back to those hopefully soon. ;)
