### PR TITLE
Fix symlink mounting issues

### DIFF
--- a/container.go
+++ b/container.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -645,7 +646,14 @@ func (container *Container) Start() (err error) {
 			mountAs = "rw"
 		}
 
-		if err := mount.Mount(v, path.Join(root, r), "none", fmt.Sprintf("bind,%s", mountAs)); err != nil {
+		r = path.Join(root, r)
+		if p, err := utils.FollowSymlinkInScope(r, root); err != nil {
+			return err
+		} else {
+			r = p
+		}
+
+		if err := mount.Mount(v, r, "none", fmt.Sprintf("bind,%s", mountAs)); err != nil {
 			return err
 		}
 	}
@@ -806,7 +814,7 @@ func (container *Container) createVolumes() error {
 			if strings.ToLower(bindMap.Mode) == "rw" {
 				srcRW = true
 			}
-			if stat, err := os.Lstat(bindMap.SrcPath); err != nil {
+			if stat, err := os.Stat(bindMap.SrcPath); err != nil {
 				return err
 			} else {
 				volIsDir = stat.IsDir()
@@ -827,6 +835,13 @@ func (container *Container) createVolumes() error {
 			}
 			srcRW = true // RW by default
 		}
+
+		if p, err := filepath.EvalSymlinks(srcPath); err != nil {
+			return err
+		} else {
+			srcPath = p
+		}
+
 		container.Volumes[volPath] = srcPath
 		container.VolumesRW[volPath] = srcRW
 


### PR DESCRIPTION
... by evaluating symlinks directly on the LHS of a bind-mount -v and by FollowSymlinkInScope on the RHS just before mounting

Tested successfully with variations around mounting /var/run and /var/run/docker.sock inside a "debian" container directly at /var/run/docker.sock where /var/run is a symlink to "/run" on both the host and in the container.

Fixes #3262
