### PR TITLE
Validate the version when running docker version

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -827,7 +827,7 @@ func ParseHost(defaultHost string, defaultPort int, defaultUnix, addr string) (s
 }
 
 func GetReleaseVersion() string {
-	resp, err := http.Get("http://get.docker.io/latest")
+	resp, err := http.Get("https://get.docker.io/latest")
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
To avoid unexpected results since docker does a http get to return the
latest version.
For instance, my broadband doesn't return not found when it's down but
a html page saying that the internet is down. Docker is showing that
html instead of ignoring it.

```
$ sudo docker version
Client version: 0.7.2
Go version (client): go1.2
Git commit (client): 28b162e
Server version: 0.7.2
Git commit (server): 28b162e
Go version (server): go1.2
Last stable version: <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
...
</body>
</html>, please update docker
```
