### PR TITLE
Move LXC into a sub pkg and provide initial execution driver interface

### DIFF
--- a/api.go
+++ b/api.go
@@ -657,16 +657,16 @@ func postContainersCreate(srv *Server, version float64, w http.ResponseWriter, r
 	for scanner.Scan() {
 		out.Warnings = append(out.Warnings, scanner.Text())
 	}
-	if job.GetenvInt("Memory") > 0 && !srv.runtime.capabilities.MemoryLimit {
+	if job.GetenvInt("Memory") > 0 && !srv.runtime.sysInfo.MemoryLimit {
 		log.Println("WARNING: Your kernel does not support memory limit capabilities. Limitation discarded.")
 		out.Warnings = append(out.Warnings, "Your kernel does not support memory limit capabilities. Limitation discarded.")
 	}
-	if job.GetenvInt("Memory") > 0 && !srv.runtime.capabilities.SwapLimit {
+	if job.GetenvInt("Memory") > 0 && !srv.runtime.sysInfo.SwapLimit {
 		log.Println("WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.")
 		out.Warnings = append(out.Warnings, "Your kernel does not support memory swap capabilities. Limitation discarded.")
 	}
 
-	if !job.GetenvBool("NetworkDisabled") && srv.runtime.capabilities.IPv4ForwardingDisabled {
+	if !job.GetenvBool("NetworkDisabled") && srv.runtime.sysInfo.IPv4ForwardingDisabled {
 		log.Println("Warning: IPv4 forwarding is disabled.")
 		out.Warnings = append(out.Warnings, "IPv4 forwarding is disabled.")
 	}

--- a/cgroups/cgroups.go
+++ b/cgroups/cgroups.go
@@ -12,8 +12,13 @@ import (
 	"strings"
 )
 
-// https://www.kernel.org/doc/Documentation/cgroups/cgroups.txt
+type Values struct {
+	Memory     int64 `json:"memory"`
+	MemorySwap int64 `json:"memory_swap"`
+	CpuShares  int64 `json:"cpu_shares"`
+}
 
+// https://www.kernel.org/doc/Documentation/cgroups/cgroups.txt
 func FindCgroupMountpoint(subsystem string) (string, error) {
 	mounts, err := mount.GetMounts()
 	if err != nil {

--- a/commands.go
+++ b/commands.go
@@ -471,7 +471,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		fmt.Fprintf(cli.out, "Debug mode (client): %v\n", os.Getenv("DEBUG") != "")
 		fmt.Fprintf(cli.out, "Fds: %d\n", remoteInfo.GetInt("NFd"))
 		fmt.Fprintf(cli.out, "Goroutines: %d\n", remoteInfo.GetInt("NGoroutines"))
-		fmt.Fprintf(cli.out, "LXC Version: %s\n", remoteInfo.Get("LXCVersion"))
+		fmt.Fprintf(cli.out, "Execution Driver: %s\n", remoteInfo.Get("ExecutionDriver"))
 		fmt.Fprintf(cli.out, "EventsListeners: %d\n", remoteInfo.GetInt("NEventsListener"))
 		fmt.Fprintf(cli.out, "Kernel Version: %s\n", remoteInfo.Get("KernelVersion"))
 

--- a/commands.go
+++ b/commands.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dotcloud/docker/auth"
 	"github.com/dotcloud/docker/engine"
 	flag "github.com/dotcloud/docker/pkg/mflag"
+	"github.com/dotcloud/docker/pkg/sysinfo"
 	"github.com/dotcloud/docker/pkg/term"
 	"github.com/dotcloud/docker/registry"
 	"github.com/dotcloud/docker/utils"
@@ -1745,14 +1746,14 @@ func (cli *DockerCli) CmdTag(args ...string) error {
 }
 
 //FIXME Only used in tests
-func ParseRun(args []string, capabilities *Capabilities) (*Config, *HostConfig, *flag.FlagSet, error) {
+func ParseRun(args []string, sysInfo *sysinfo.SysInfo) (*Config, *HostConfig, *flag.FlagSet, error) {
 	cmd := flag.NewFlagSet("run", flag.ContinueOnError)
 	cmd.SetOutput(ioutil.Discard)
 	cmd.Usage = nil
-	return parseRun(cmd, args, capabilities)
+	return parseRun(cmd, args, sysInfo)
 }
 
-func parseRun(cmd *flag.FlagSet, args []string, capabilities *Capabilities) (*Config, *HostConfig, *flag.FlagSet, error) {
+func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config, *HostConfig, *flag.FlagSet, error) {
 	var (
 		// FIXME: use utils.ListOpts for attach and volumes?
 		flAttach  = NewListOpts(ValidateAttach)
@@ -1802,7 +1803,7 @@ func parseRun(cmd *flag.FlagSet, args []string, capabilities *Capabilities) (*Co
 	}
 
 	// Check if the kernel supports memory limit cgroup.
-	if capabilities != nil && *flMemoryString != "" && !capabilities.MemoryLimit {
+	if sysInfo != nil && *flMemoryString != "" && !sysInfo.MemoryLimit {
 		*flMemoryString = ""
 	}
 
@@ -1934,7 +1935,7 @@ func parseRun(cmd *flag.FlagSet, args []string, capabilities *Capabilities) (*Co
 		PublishAllPorts: *flPublishAll,
 	}
 
-	if capabilities != nil && flMemory > 0 && !capabilities.SwapLimit {
+	if sysInfo != nil && flMemory > 0 && !sysInfo.SwapLimit {
 		//fmt.Fprintf(stdout, "WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.\n")
 		config.MemorySwap = -1
 	}

--- a/container.go
+++ b/container.go
@@ -1171,7 +1171,6 @@ func (container *Container) monitor() {
 	exitCode := container.process.GetExitCode()
 	container.State.SetStopped(exitCode)
 
-	close(container.waitLock)
 	if err := container.ToDisk(); err != nil {
 		// FIXME: there is a race condition here which causes this to fail during the unit tests.
 		// If another goroutine was waiting for Wait() to return before removing the container's root
@@ -1181,6 +1180,7 @@ func (container *Container) monitor() {
 		// FIXME: why are we serializing running state to disk in the first place?
 		//log.Printf("%s: Failed to dump configuration to the disk: %s", container.ID, err)
 	}
+	close(container.waitLock)
 }
 
 func (container *Container) cleanup() {

--- a/container.go
+++ b/container.go
@@ -329,6 +329,7 @@ func (container *Container) startPty() error {
 	// stdin
 	if container.Config.OpenStdin {
 		container.process.Stdin = ptySlave
+		container.process.SysProcAttr.Setctty = true
 		go func() {
 			defer container.stdin.Close()
 			utils.Debugf("startPty: begin of stdin pipe")

--- a/container.go
+++ b/container.go
@@ -761,6 +761,8 @@ func (container *Container) Start() (err error) {
 		return err
 	}
 
+	container.State.SetRunning(container.process.Pid())
+
 	// Init the lock
 	container.waitLock = make(chan struct{})
 
@@ -1160,6 +1162,9 @@ func (container *Container) monitor() {
 	if container.Config.OpenStdin {
 		container.stdin, container.stdinPipe = io.Pipe()
 	}
+
+	exitCode := container.process.GetExitCode()
+	container.State.SetStopped(exitCode)
 
 	// Release the lock
 	close(container.waitLock)

--- a/container.go
+++ b/container.go
@@ -726,7 +726,7 @@ func (container *Container) Start() (err error) {
 	}
 
 	var en *execdriver.Network
-	if !container.runtime.networkManager.disabled {
+	if !container.Config.NetworkDisabled {
 		network := container.NetworkSettings
 		en = &execdriver.Network{
 			Gateway:     network.Gateway,

--- a/container.go
+++ b/container.go
@@ -379,12 +379,14 @@ func (container *Container) Attach(stdin io.ReadCloser, stdinCloser io.Closer, s
 				if container.Config.StdinOnce && !container.Config.Tty {
 					defer cStdin.Close()
 				} else {
-					if cStdout != nil {
-						defer cStdout.Close()
-					}
-					if cStderr != nil {
-						defer cStderr.Close()
-					}
+					defer func() {
+						if cStdout != nil {
+							cStdout.Close()
+						}
+						if cStderr != nil {
+							cStderr.Close()
+						}
+					}()
 				}
 				if container.Config.Tty {
 					_, err = utils.CopyEscapable(cStdin, stdin)
@@ -480,12 +482,15 @@ func (container *Container) Attach(stdin io.ReadCloser, stdinCloser io.Closer, s
 	}
 
 	return utils.Go(func() error {
-		if cStdout != nil {
-			defer cStdout.Close()
-		}
-		if cStderr != nil {
-			defer cStderr.Close()
-		}
+		defer func() {
+			if cStdout != nil {
+				cStdout.Close()
+			}
+			if cStderr != nil {
+				cStderr.Close()
+			}
+		}()
+
 		// FIXME: how to clean up the stdin goroutine without the unwanted side effect
 		// of closing the passed stdin? Add an intermediary io.Pipe?
 		for i := 0; i < nJobs; i += 1 {

--- a/container.go
+++ b/container.go
@@ -708,7 +708,7 @@ func (container *Container) Start() (err error) {
 	}
 
 	waitLock := make(chan struct{})
-	f := func(process *execdriver.Process) {
+	callback := func(process *execdriver.Process) {
 		container.State.SetRunning(process.Pid())
 		if process.Tty {
 			// The callback is called after the process Start()
@@ -724,7 +724,9 @@ func (container *Container) Start() (err error) {
 		close(waitLock)
 	}
 
-	go container.monitor(f)
+	// We use a callback here instead of a goroutine and an chan for
+	// syncronization purposes
+	go container.monitor(callback)
 
 	// Start should not return until the process is actually running
 	<-waitLock

--- a/container.go
+++ b/container.go
@@ -1,11 +1,11 @@
 package docker
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/dotcloud/docker/archive"
+	"github.com/dotcloud/docker/execdriver"
 	"github.com/dotcloud/docker/graphdriver"
 	"github.com/dotcloud/docker/mount"
 	"github.com/dotcloud/docker/pkg/term"
@@ -16,7 +16,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"os/exec"
 	"path"
 	"strconv"
 	"strings"
@@ -55,7 +54,7 @@ type Container struct {
 	Name           string
 	Driver         string
 
-	cmd       *exec.Cmd
+	process   *execdriver.Process
 	stdout    *utils.WriteBroadcaster
 	stderr    *utils.WriteBroadcaster
 	stdin     io.ReadCloser
@@ -235,10 +234,6 @@ func (container *Container) Inject(file io.Reader, pth string) error {
 	return nil
 }
 
-func (container *Container) Cmd() *exec.Cmd {
-	return container.cmd
-}
-
 func (container *Container) When() time.Time {
 	return container.Created
 }
@@ -320,8 +315,8 @@ func (container *Container) startPty() error {
 		return err
 	}
 	container.ptyMaster = ptyMaster
-	container.cmd.Stdout = ptySlave
-	container.cmd.Stderr = ptySlave
+	container.process.Stdout = ptySlave
+	container.process.Stderr = ptySlave
 
 	// Copy the PTYs to our broadcasters
 	go func() {
@@ -333,8 +328,7 @@ func (container *Container) startPty() error {
 
 	// stdin
 	if container.Config.OpenStdin {
-		container.cmd.Stdin = ptySlave
-		container.cmd.SysProcAttr.Setctty = true
+		container.process.Stdin = ptySlave
 		go func() {
 			defer container.stdin.Close()
 			utils.Debugf("startPty: begin of stdin pipe")
@@ -342,7 +336,7 @@ func (container *Container) startPty() error {
 			utils.Debugf("startPty: end of stdin pipe")
 		}()
 	}
-	if err := container.cmd.Start(); err != nil {
+	if err := container.runtime.execDriver.Start(container.process); err != nil {
 		return err
 	}
 	ptySlave.Close()
@@ -350,10 +344,10 @@ func (container *Container) startPty() error {
 }
 
 func (container *Container) start() error {
-	container.cmd.Stdout = container.stdout
-	container.cmd.Stderr = container.stderr
+	container.process.Stdout = container.stdout
+	container.process.Stderr = container.stderr
 	if container.Config.OpenStdin {
-		stdin, err := container.cmd.StdinPipe()
+		stdin, err := container.process.StdinPipe()
 		if err != nil {
 			return err
 		}
@@ -364,7 +358,7 @@ func (container *Container) start() error {
 			utils.Debugf("start: end of stdin pipe")
 		}()
 	}
-	return container.cmd.Start()
+	return container.runtime.execDriver.Start(container.process)
 }
 
 func (container *Container) Attach(stdin io.ReadCloser, stdinCloser io.Closer, stdout io.Writer, stderr io.Writer) chan error {
@@ -653,8 +647,9 @@ func (container *Container) Start() (err error) {
 		return err
 	}
 
+	var workingDir string
 	if container.Config.WorkingDir != "" {
-		workingDir := path.Clean(container.Config.WorkingDir)
+		workingDir = path.Clean(container.Config.WorkingDir)
 		utils.Debugf("[working dir] working dir is %s", workingDir)
 
 		if err := os.MkdirAll(path.Join(container.RootfsPath(), workingDir), 0755); err != nil {
@@ -713,7 +708,6 @@ func (container *Container) Start() (err error) {
 	}
 
 	// Mount user specified volumes
-
 	for r, v := range container.Volumes {
 		mountAs := "ro"
 		if container.VolumesRW[r] {
@@ -725,7 +719,30 @@ func (container *Container) Start() (err error) {
 		}
 	}
 
-	container.cmd = exec.Command(params[0], params[1:]...)
+	var en *execdriver.Network
+	if !container.runtime.networkManager.disabled {
+		network := container.NetworkSettings
+		en = &execdriver.Network{
+			Gateway:     network.Gateway,
+			IPAddress:   network.IPAddress,
+			IPPrefixLen: network.IPPrefixLen,
+			Mtu:         container.runtime.config.Mtu,
+		}
+	}
+
+	container.process = &execdriver.Process{
+		Name:       container.ID,
+		Privileged: container.hostConfig.Privileged,
+		Dir:        root,
+		InitPath:   "/.dockerinit",
+		Entrypoint: container.Path,
+		Args:       container.Args,
+		WorkingDir: workingDir,
+		ConfigPath: container.lxcConfigPath(),
+		Network:    en,
+		Tty:        container.Config.Tty,
+		User:       container.Config.User,
+	}
 
 	// Setup logging of stdout and stderr to disk
 	if err := container.runtime.LogToDisk(container.stdout, container.logPath("json"), "stdout"); err != nil {
@@ -735,8 +752,6 @@ func (container *Container) Start() (err error) {
 		return err
 	}
 
-	container.cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-
 	if container.Config.Tty {
 		err = container.startPty()
 	} else {
@@ -745,48 +760,13 @@ func (container *Container) Start() (err error) {
 	if err != nil {
 		return err
 	}
-	// FIXME: save state on disk *first*, then converge
-	// this way disk state is used as a journal, eg. we can restore after crash etc.
-	container.State.SetRunning(container.cmd.Process.Pid)
 
 	// Init the lock
 	container.waitLock = make(chan struct{})
 
 	container.ToDisk()
 	go container.monitor()
-
-	defer utils.Debugf("Container running: %v", container.State.IsRunning())
-	// We wait for the container to be fully running.
-	// Timeout after 5 seconds. In case of broken pipe, just retry.
-	// Note: The container can run and finish correctly before
-	//       the end of this loop
-	for now := time.Now(); time.Since(now) < 5*time.Second; {
-		// If the container dies while waiting for it, just return
-		if !container.State.IsRunning() {
-			return nil
-		}
-		output, err := exec.Command("lxc-info", "-s", "-n", container.ID).CombinedOutput()
-		if err != nil {
-			utils.Debugf("Error with lxc-info: %s (%s)", err, output)
-
-			output, err = exec.Command("lxc-info", "-s", "-n", container.ID).CombinedOutput()
-			if err != nil {
-				utils.Debugf("Second Error with lxc-info: %s (%s)", err, output)
-				return err
-			}
-
-		}
-		if strings.Contains(string(output), "RUNNING") {
-			return nil
-		}
-		utils.Debugf("Waiting for the container to start (running: %v): %s", container.State.IsRunning(), bytes.TrimSpace(output))
-		time.Sleep(50 * time.Millisecond)
-	}
-
-	if container.State.IsRunning() {
-		return ErrContainerStartTimeout
-	}
-	return ErrContainerStart
+	return nil
 }
 
 func (container *Container) getBindMap() (map[string]BindMap, error) {
@@ -1159,47 +1139,18 @@ func (container *Container) releaseNetwork() {
 	container.NetworkSettings = &NetworkSettings{}
 }
 
-// FIXME: replace this with a control socket within dockerinit
-func (container *Container) waitLxc() error {
-	for {
-		output, err := exec.Command("lxc-info", "-n", container.ID).CombinedOutput()
-		if err != nil {
-			return err
-		}
-		if !strings.Contains(string(output), "RUNNING") {
-			return nil
-		}
-		time.Sleep(500 * time.Millisecond)
-	}
-}
-
 func (container *Container) monitor() {
 	// Wait for the program to exit
-
-	// If the command does not exist, try to wait via lxc
-	// (This probably happens only for ghost containers, i.e. containers that were running when Docker started)
-	if container.cmd == nil {
-		utils.Debugf("monitor: waiting for container %s using waitLxc", container.ID)
-		if err := container.waitLxc(); err != nil {
-			utils.Errorf("monitor: while waiting for container %s, waitLxc had a problem: %s", container.ID, err)
-		}
-	} else {
-		utils.Debugf("monitor: waiting for container %s using cmd.Wait", container.ID)
-		if err := container.cmd.Wait(); err != nil {
-			// Since non-zero exit status and signal terminations will cause err to be non-nil,
-			// we have to actually discard it. Still, log it anyway, just in case.
-			utils.Debugf("monitor: cmd.Wait reported exit status %s for container %s", err, container.ID)
-		}
+	if container.process == nil {
+		panic("Container process is nil")
 	}
-	utils.Debugf("monitor: container %s finished", container.ID)
-
-	exitCode := -1
-	if container.cmd != nil {
-		exitCode = container.cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
-	}
-
-	if container.runtime != nil && container.runtime.srv != nil {
-		container.runtime.srv.LogEvent("die", container.ID, container.runtime.repositories.ImageName(container.Image))
+	if err := container.runtime.execDriver.Wait(container.process, time.Duration(0)); err != nil {
+		// Since non-zero exit status and signal terminations will cause err to be non-nil,
+		// we have to actually discard it. Still, log it anyway, just in case.
+		utils.Debugf("monitor: cmd.Wait reported exit status %s for container %s", err, container.ID)
+		if container.runtime != nil && container.runtime.srv != nil {
+			container.runtime.srv.LogEvent("die", container.ID, container.runtime.repositories.ImageName(container.Image))
+		}
 	}
 
 	// Cleanup
@@ -1209,9 +1160,6 @@ func (container *Container) monitor() {
 	if container.Config.OpenStdin {
 		container.stdin, container.stdinPipe = io.Pipe()
 	}
-
-	// Report status back
-	container.State.SetStopped(exitCode)
 
 	// Release the lock
 	close(container.waitLock)
@@ -1267,13 +1215,7 @@ func (container *Container) kill(sig int) error {
 	if !container.State.IsRunning() {
 		return nil
 	}
-
-	if output, err := exec.Command("lxc-kill", "-n", container.ID, strconv.Itoa(sig)).CombinedOutput(); err != nil {
-		log.Printf("error killing container %s (%s, %s)", utils.TruncateID(container.ID), output, err)
-		return err
-	}
-
-	return nil
+	return container.runtime.execDriver.Kill(container.process, sig)
 }
 
 func (container *Container) Kill() error {
@@ -1288,11 +1230,11 @@ func (container *Container) Kill() error {
 
 	// 2. Wait for the process to die, in last resort, try to kill the process directly
 	if err := container.WaitTimeout(10 * time.Second); err != nil {
-		if container.cmd == nil {
+		if container.process == nil {
 			return fmt.Errorf("lxc-kill failed, impossible to kill the container %s", utils.TruncateID(container.ID))
 		}
 		log.Printf("Container %s failed to exit within 10 seconds of lxc-kill %s - trying direct SIGKILL", "SIGKILL", utils.TruncateID(container.ID))
-		if err := container.cmd.Process.Kill(); err != nil {
+		if err := container.runtime.execDriver.Kill(container.process, 9); err != nil {
 			return err
 		}
 	}

--- a/container.go
+++ b/container.go
@@ -623,30 +623,10 @@ func (container *Container) Start() (err error) {
 	var workingDir string
 	if container.Config.WorkingDir != "" {
 		workingDir = path.Clean(container.Config.WorkingDir)
-		utils.Debugf("[working dir] working dir is %s", workingDir)
-
 		if err := os.MkdirAll(path.Join(container.RootfsPath(), workingDir), 0755); err != nil {
 			return nil
 		}
 	}
-
-	/*
-		if RootIsShared() {
-			// lxc-start really needs / to be non-shared, or all kinds of stuff break
-			// when lxc-start unmount things and those unmounts propagate to the main
-			// mount namespace.
-			// What we really want is to clone into a new namespace and then
-			// mount / MS_REC|MS_SLAVE, but since we can't really clone or fork
-			// without exec in go we have to do this horrible shell hack...
-			shellString :=
-				"mount --make-rslave /; exec " +
-					utils.ShellQuoteArguments(params)
-
-			params = []string{
-				"unshare", "-m", "--", "/bin/sh", "-c", shellString,
-			}
-		}
-	*/
 
 	root := container.RootfsPath()
 	envPath, err := container.EnvConfigPath()

--- a/container.go
+++ b/container.go
@@ -527,16 +527,16 @@ func (container *Container) Start() (err error) {
 	}
 
 	// Make sure the config is compatible with the current kernel
-	if container.Config.Memory > 0 && !container.runtime.capabilities.MemoryLimit {
+	if container.Config.Memory > 0 && !container.runtime.sysInfo.MemoryLimit {
 		log.Printf("WARNING: Your kernel does not support memory limit capabilities. Limitation discarded.\n")
 		container.Config.Memory = 0
 	}
-	if container.Config.Memory > 0 && !container.runtime.capabilities.SwapLimit {
+	if container.Config.Memory > 0 && !container.runtime.sysInfo.SwapLimit {
 		log.Printf("WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.\n")
 		container.Config.MemorySwap = -1
 	}
 
-	if container.runtime.capabilities.IPv4ForwardingDisabled {
+	if container.runtime.sysInfo.IPv4ForwardingDisabled {
 		log.Printf("WARNING: IPv4 forwarding is disabled. Networking will not work")
 	}
 

--- a/container.go
+++ b/container.go
@@ -733,10 +733,10 @@ func (container *Container) Start() (err error) {
 	container.process = &execdriver.Process{
 		Name:       container.ID,
 		Privileged: container.hostConfig.Privileged,
-		Dir:        root,
+		Rootfs:     root,
 		InitPath:   "/.dockerinit",
 		Entrypoint: container.Path,
-		Args:       container.Args,
+		Arguments:  container.Args,
 		WorkingDir: workingDir,
 		ConfigPath: container.lxcConfigPath(),
 		Network:    en,

--- a/container.go
+++ b/container.go
@@ -678,18 +678,19 @@ func (container *Container) Start() (err error) {
 	}
 
 	container.process = &execdriver.Process{
-		ID:         container.ID,
-		Privileged: container.hostConfig.Privileged,
-		Rootfs:     root,
-		InitPath:   "/.dockerinit",
-		Entrypoint: container.Path,
-		Arguments:  container.Args,
-		WorkingDir: workingDir,
-		ConfigPath: container.lxcConfigPath(),
-		Network:    en,
-		Tty:        container.Config.Tty,
-		User:       container.Config.User,
-		WaitLock:   make(chan struct{}),
+		ID:          container.ID,
+		Privileged:  container.hostConfig.Privileged,
+		Rootfs:      root,
+		InitPath:    "/.dockerinit",
+		Entrypoint:  container.Path,
+		Arguments:   container.Args,
+		WorkingDir:  workingDir,
+		ConfigPath:  container.lxcConfigPath(),
+		Network:     en,
+		Tty:         container.Config.Tty,
+		User:        container.Config.User,
+		WaitLock:    make(chan struct{}),
+		SysInitPath: runtime.sysInitPath,
 	}
 	container.process.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 

--- a/container.go
+++ b/container.go
@@ -675,18 +675,17 @@ func (container *Container) Start() (err error) {
 	}
 
 	container.process = &execdriver.Process{
-		ID:          container.ID,
-		Privileged:  container.hostConfig.Privileged,
-		Rootfs:      root,
-		InitPath:    "/.dockerinit",
-		Entrypoint:  container.Path,
-		Arguments:   container.Args,
-		WorkingDir:  workingDir,
-		ConfigPath:  container.lxcConfigPath(),
-		Network:     en,
-		Tty:         container.Config.Tty,
-		User:        container.Config.User,
-		SysInitPath: runtime.sysInitPath,
+		ID:         container.ID,
+		Privileged: container.hostConfig.Privileged,
+		Rootfs:     root,
+		InitPath:   "/.dockerinit",
+		Entrypoint: container.Path,
+		Arguments:  container.Args,
+		WorkingDir: workingDir,
+		ConfigPath: container.lxcConfigPath(),
+		Network:    en,
+		Tty:        container.Config.Tty,
+		User:       container.Config.User,
 	}
 	container.process.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 

--- a/container.go
+++ b/container.go
@@ -1115,7 +1115,7 @@ func (container *Container) monitor(callback execdriver.StartCallback) error {
 
 	if container.process == nil {
 		// This happends when you have a GHOST container with lxc
-		err = container.runtime.Wait(container, 0)
+		err = container.runtime.WaitGhost(container)
 	} else {
 		exitCode, err = container.runtime.Run(container, callback)
 	}

--- a/execdriver/MAINTAINERS
+++ b/execdriver/MAINTAINERS
@@ -1,0 +1,2 @@
+Michael Crosby <michael@crosbymichael.com> (@crosbymichael)
+Guillaume Charmes <guillaume@dotcloud.com> (@creack)

--- a/execdriver/chroot/driver.go
+++ b/execdriver/chroot/driver.go
@@ -13,7 +13,7 @@ const (
 )
 
 func init() {
-	execdriver.RegisterDockerInitFct(DriverName, func(args *execdriver.DockerInitArgs) error {
+	execdriver.RegisterInitFunc(DriverName, func(args *execdriver.InitArgs) error {
 		if err := mount.ForceMount("proc", "proc", "proc", ""); err != nil {
 			return err
 		}

--- a/execdriver/chroot/driver.go
+++ b/execdriver/chroot/driver.go
@@ -1,11 +1,8 @@
 package chroot
 
 import (
-	"fmt"
 	"github.com/dotcloud/docker/execdriver"
-	"io/ioutil"
 	"os/exec"
-	"path"
 	"time"
 )
 
@@ -16,15 +13,18 @@ func NewDriver() (execdriver.Driver, error) {
 	return &driver{}, nil
 }
 
+func (d *driver) String() string {
+	return "chroot"
+}
+
 func (d *driver) Start(c *execdriver.Process) error {
-	data, _ := ioutil.ReadFile(c.SysInitPath)
-	ioutil.WriteFile(path.Join(c.Rootfs, ".dockerinit"), data, 0644)
 	params := []string{
 		"chroot",
 		c.Rootfs,
 		"/.dockerinit",
+		"-driver",
+		d.String(),
 	}
-	// need to mount proc
 	params = append(params, c.Entrypoint)
 	params = append(params, c.Arguments...)
 

--- a/execdriver/chroot/driver.go
+++ b/execdriver/chroot/driver.go
@@ -1,0 +1,66 @@
+package chroot
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/execdriver"
+	"io/ioutil"
+	"os/exec"
+	"path"
+	"time"
+)
+
+type driver struct {
+}
+
+func NewDriver() (execdriver.Driver, error) {
+	return &driver{}, nil
+}
+
+func (d *driver) Start(c *execdriver.Process) error {
+	data, _ := ioutil.ReadFile(c.SysInitPath)
+	ioutil.WriteFile(path.Join(c.Rootfs, ".dockerinit"), data, 0644)
+	params := []string{
+		"chroot",
+		c.Rootfs,
+		"/.dockerinit",
+	}
+	// need to mount proc
+	params = append(params, c.Entrypoint)
+	params = append(params, c.Arguments...)
+
+	var (
+		name = params[0]
+		arg  = params[1:]
+	)
+	aname, err := exec.LookPath(name)
+	if err != nil {
+		aname = name
+	}
+	c.Path = aname
+	c.Args = append([]string{name}, arg...)
+
+	if err := c.Start(); err != nil {
+		return err
+	}
+
+	go func() {
+		if err := c.Wait(); err != nil {
+			c.WaitError = err
+		}
+		close(c.WaitLock)
+	}()
+
+	return nil
+}
+
+func (d *driver) Kill(p *execdriver.Process, sig int) error {
+	return p.Process.Kill()
+}
+
+func (d *driver) Wait(id string, duration time.Duration) error {
+	panic("No Implemented")
+}
+
+func (d *driver) Version() string {
+	return "0.1"
+}

--- a/execdriver/chroot/driver.go
+++ b/execdriver/chroot/driver.go
@@ -3,7 +3,6 @@ package chroot
 import (
 	"github.com/dotcloud/docker/execdriver"
 	"os/exec"
-	"time"
 )
 
 type driver struct {
@@ -55,8 +54,8 @@ func (d *driver) Kill(p *execdriver.Process, sig int) error {
 	return p.Process.Kill()
 }
 
-func (d *driver) Wait(id string, duration time.Duration) error {
-	panic("No Implemented")
+func (d *driver) Wait(id string) error {
+	panic("Not Implemented")
 }
 
 func (d *driver) Version() string {

--- a/execdriver/chroot/driver.go
+++ b/execdriver/chroot/driver.go
@@ -7,7 +7,10 @@ import (
 	"os/exec"
 )
 
-const DriverName = "chroot"
+const (
+	DriverName = "chroot"
+	Version    = "0.1"
+)
 
 func init() {
 	execdriver.RegisterDockerInitFct(DriverName, func(args *execdriver.DockerInitArgs) error {
@@ -30,10 +33,6 @@ type driver struct {
 
 func NewDriver() (*driver, error) {
 	return &driver{}, nil
-}
-
-func (d *driver) Name() string {
-	return DriverName
 }
 
 func (d *driver) Run(c *execdriver.Process, startCallback execdriver.StartCallback) (int, error) {
@@ -78,6 +77,14 @@ func (d *driver) Wait(id string) error {
 	panic("Not Implemented")
 }
 
+func (d *driver) Info(id string) execdriver.Info {
+	panic("Not implemented")
+}
+
+func (d *driver) Name() string {
+	return DriverName
+}
+
 func (d *driver) Version() string {
-	return "0.1"
+	return Version
 }

--- a/execdriver/chroot/driver.go
+++ b/execdriver/chroot/driver.go
@@ -1,6 +1,7 @@
 package chroot
 
 import (
+	"fmt"
 	"github.com/dotcloud/docker/execdriver"
 	"github.com/dotcloud/docker/mount"
 	"os"
@@ -82,9 +83,5 @@ func (d *driver) Info(id string) execdriver.Info {
 }
 
 func (d *driver) Name() string {
-	return DriverName
-}
-
-func (d *driver) Version() string {
-	return Version
+	return fmt.Sprintf("%s-%s", DriverName, Version)
 }

--- a/execdriver/chroot/driver.go
+++ b/execdriver/chroot/driver.go
@@ -42,7 +42,7 @@ func (d *driver) Run(c *execdriver.Process, startCallback execdriver.StartCallba
 		c.Rootfs,
 		"/.dockerinit",
 		"-driver",
-		d.Name(),
+		DriverName,
 	}
 	params = append(params, c.Entrypoint)
 	params = append(params, c.Arguments...)

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -1,9 +1,25 @@
 package execdriver
 
 import (
+	"errors"
 	"io"
 	"net"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
 )
+
+var (
+	ErrCommandIsNil = errors.New("Process's cmd is nil")
+)
+
+type Driver interface {
+	Start(c *Process) error
+	Stop(c *Process) error
+	Kill(c *Process, sig int) error
+	Wait(c *Process, duration time.Duration) error
+}
 
 // Network settings of the container
 type Network struct {
@@ -13,12 +29,44 @@ type Network struct {
 	Mtu         int
 }
 
+type State struct {
+	sync.RWMutex
+	running    bool
+	pid        int
+	exitCode   int
+	startedAt  time.Time
+	finishedAt time.Time
+}
+
+func (s *State) IsRunning() bool {
+	s.RLock()
+	defer s.RUnlock()
+	return s.running
+}
+
+func (s *State) SetRunning() error {
+	s.Lock()
+	defer s.Unlock()
+	s.running = true
+	return nil
+}
+
+func (s *State) SetStopped(exitCode int) error {
+	s.Lock()
+	defer s.Unlock()
+	s.exitCode = exitCode
+	s.running = false
+	return nil
+}
+
 // Container / Process / Whatever, we can redefine the conatiner here
 // to be what it should be and not have to carry the baggage of the
 // container type in the core with backward compat.  This is what a
 // driver needs to execute a process inside of a conatiner.  This is what
 // a container is at it's core.
-type Container struct {
+type Process struct {
+	State State
+
 	Name        string // unique name for the conatienr
 	Privileged  bool
 	User        string
@@ -28,19 +76,45 @@ type Container struct {
 	Args        []string
 	Environment map[string]string
 	WorkingDir  string
+	ConfigPath  string
 	Network     *Network // if network is nil then networking is disabled
 	Stdin       io.Reader
 	Stdout      io.Writer
 	Stderr      io.Writer
 
-	Context interface{}
+	cmd *exec.Cmd
 }
 
-// State can be handled internally in the drivers
-type Driver interface {
-	Start(c *Container) error
-	Stop(c *Container) error
-	Kill(c *Container, sig int) error
-	Running(c *Container) (bool, error)
-	Wait(c *Container, seconds int) error
+func (c *Process) SetCmd(cmd *exec.Cmd) error {
+	c.cmd = cmd
+	cmd.Stdout = c.Stdout
+	cmd.Stderr = c.Stderr
+	cmd.Stdin = c.Stdin
+	return nil
+}
+
+func (c *Process) StdinPipe() (io.WriteCloser, error) {
+	return c.cmd.StdinPipe()
+}
+
+func (c *Process) StderrPipe() (io.ReadCloser, error) {
+	return c.cmd.StderrPipe()
+}
+
+func (c *Process) StdoutPipe() (io.ReadCloser, error) {
+	return c.cmd.StdoutPipe()
+}
+
+func (c *Process) GetExitCode() int {
+	if c.cmd != nil {
+		return c.cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+	}
+	return -1
+}
+
+func (c *Process) Wait() error {
+	if c.cmd != nil {
+		return c.cmd.Wait()
+	}
+	return ErrCommandIsNil
 }

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -6,10 +6,13 @@ import (
 	"time"
 )
 
+type StartCallback func(*Process)
+
 type Driver interface {
-	Start(c *Process) error
+	Run(c *Process, startCallback StartCallback) (int, error) // Run executes the process and blocks until the process exits and returns the exit code
 	Kill(c *Process, sig int) error
-	Wait(id string, duration time.Duration) error // Wait on an out of process option - lxc ghosts
+	// TODO: @crosbymichael @creack wait should probably return the exit code
+	Wait(id string, duration time.Duration) error // Wait on an out of process...process - lxc ghosts
 	Version() string
 	String() string
 }
@@ -38,8 +41,6 @@ type Process struct {
 	Tty         bool
 	Network     *Network // if network is nil then networking is disabled
 	SysInitPath string
-	WaitLock    chan struct{}
-	WaitError   error
 }
 
 func (c *Process) Pid() int {

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -51,6 +51,10 @@ type DockerInitArgs struct {
 	Driver     string
 }
 
+type Info interface {
+	IsRunning() bool
+}
+
 type Driver interface {
 	Run(c *Process, startCallback StartCallback) (int, error) // Run executes the process and blocks until the process exits and returns the exit code
 	Kill(c *Process, sig int) error
@@ -58,6 +62,8 @@ type Driver interface {
 	Wait(id string) error // Wait on an out of process...process - lxc ghosts
 	Version() string
 	Name() string
+
+	Info(id string) Info // "temporary" hack (until we move state from core to plugins)
 }
 
 // Network settings of the container

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -2,7 +2,6 @@ package execdriver
 
 import (
 	"errors"
-	"io"
 	"os/exec"
 	"syscall"
 	"time"
@@ -28,59 +27,26 @@ type Network struct {
 }
 
 type Process struct {
+	exec.Cmd
+
 	Name       string // unique name for the conatienr
 	Privileged bool
 	User       string
-	Dir        string // root fs of the container
+	Rootfs     string // root fs of the container
 	InitPath   string // dockerinit
 	Entrypoint string
-	Args       []string
-	//	Environment map[string]string // we don't use this right now because we use an env file
+	Arguments  []string
 	WorkingDir string
 	ConfigPath string
 	Tty        bool
 	Network    *Network // if network is nil then networking is disabled
-	Stdin      io.Reader
-	Stdout     io.Writer
-	Stderr     io.Writer
-
-	cmd *exec.Cmd
-}
-
-func (c *Process) SetCmd(cmd *exec.Cmd) error {
-	c.cmd = cmd
-	cmd.Stdout = c.Stdout
-	cmd.Stderr = c.Stderr
-	cmd.Stdin = c.Stdin
-	return nil
 }
 
 func (c *Process) Pid() int {
-	return c.cmd.Process.Pid
-}
-
-func (c *Process) StdinPipe() (io.WriteCloser, error) {
-	return c.cmd.StdinPipe()
-}
-
-func (c *Process) StderrPipe() (io.ReadCloser, error) {
-	return c.cmd.StderrPipe()
-}
-
-func (c *Process) StdoutPipe() (io.ReadCloser, error) {
-	return c.cmd.StdoutPipe()
+	return c.Process.Pid
 }
 
 func (c *Process) GetExitCode() int {
-	if c.cmd != nil {
-		return c.cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
-	}
+	return c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
 	return -1
-}
-
-func (c *Process) Wait() error {
-	if c.cmd != nil {
-		return c.cmd.Wait()
-	}
-	return ErrCommandIsNil
 }

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -11,6 +11,7 @@ type Driver interface {
 	Kill(c *Process, sig int) error
 	Wait(id string, duration time.Duration) error // Wait on an out of process option - lxc ghosts
 	Version() string
+	String() string
 }
 
 // Network settings of the container

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -13,7 +13,6 @@ var (
 
 type Driver interface {
 	Start(c *Process) error
-	Stop(c *Process) error
 	Kill(c *Process, sig int) error
 	Wait(c *Process, duration time.Duration) error
 }
@@ -26,10 +25,11 @@ type Network struct {
 	Mtu         int
 }
 
+// Process wrapps an os/exec.Cmd to add more metadata
 type Process struct {
 	exec.Cmd
 
-	Name       string // unique name for the conatienr
+	ID         string
 	Privileged bool
 	User       string
 	Rootfs     string // root fs of the container

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -1,9 +1,15 @@
 package execdriver
 
 import (
+	"errors"
 	"os/exec"
 	"syscall"
 	"time"
+)
+
+var (
+	ErrNotRunning         = errors.New("Process could not be started")
+	ErrWaitTimeoutReached = errors.New("Wait timeout reached")
 )
 
 type StartCallback func(*Process)
@@ -19,29 +25,31 @@ type Driver interface {
 
 // Network settings of the container
 type Network struct {
-	Gateway     string
-	IPAddress   string
-	IPPrefixLen int
-	Mtu         int
+	Gateway     string `json:"gateway"`
+	IPAddress   string `json:"ip"`
+	IPPrefixLen int    `json:"ip_prefix_len"`
+	Mtu         int    `json:"mtu"`
 }
 
 // Process wrapps an os/exec.Cmd to add more metadata
 type Process struct {
 	exec.Cmd
 
-	ID         string
-	Privileged bool
-	User       string
-	Rootfs     string // root fs of the container
-	InitPath   string // dockerinit
-	Entrypoint string
-	Arguments  []string
-	WorkingDir string
-	ConfigPath string
-	Tty        bool
-	Network    *Network // if network is nil then networking is disabled
+	ID         string   `json:"id"`
+	Privileged bool     `json:"privileged"`
+	User       string   `json:"user"`
+	Rootfs     string   `json:"rootfs"`   // root fs of the container
+	InitPath   string   `json:"initpath"` // dockerinit
+	Entrypoint string   `json:"entrypoint"`
+	Arguments  []string `json:"arguments"`
+	WorkingDir string   `json:"working_dir"`
+	ConfigPath string   `json:"config_path"` // This should be able to be removed when the lxc template is moved into the driver
+	Tty        bool     `json:"tty"`
+	Network    *Network `json:"network"` // if network is nil then networking is disabled
 }
 
+// Return the pid of the process
+// If the process is nil -1 will be returned
 func (c *Process) Pid() int {
 	if c.Process == nil {
 		return -1
@@ -49,6 +57,8 @@ func (c *Process) Pid() int {
 	return c.Process.Pid
 }
 
+// Return the exit code of the process
+// if the process has not exited -1 will be returned
 func (c *Process) GetExitCode() int {
 	if c.ProcessState == nil {
 		return -1

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -3,7 +3,6 @@ package execdriver
 import (
 	"errors"
 	"io"
-	"net"
 	"os/exec"
 	"sync"
 	"syscall"
@@ -24,7 +23,7 @@ type Driver interface {
 // Network settings of the container
 type Network struct {
 	Gateway     string
-	IPAddress   net.IPAddr
+	IPAddress   string
 	IPPrefixLen int
 	Mtu         int
 }
@@ -67,20 +66,21 @@ func (s *State) SetStopped(exitCode int) error {
 type Process struct {
 	State State
 
-	Name        string // unique name for the conatienr
-	Privileged  bool
-	User        string
-	Dir         string // root fs of the container
-	InitPath    string // dockerinit
-	Entrypoint  string
-	Args        []string
-	Environment map[string]string
-	WorkingDir  string
-	ConfigPath  string
-	Network     *Network // if network is nil then networking is disabled
-	Stdin       io.Reader
-	Stdout      io.Writer
-	Stderr      io.Writer
+	Name       string // unique name for the conatienr
+	Privileged bool
+	User       string
+	Dir        string // root fs of the container
+	InitPath   string // dockerinit
+	Entrypoint string
+	Args       []string
+	//	Environment map[string]string // we don't use this right now because we use an env file
+	WorkingDir string
+	ConfigPath string
+	Tty        bool
+	Network    *Network // if network is nil then networking is disabled
+	Stdin      io.Reader
+	Stdout     io.Writer
+	Stderr     io.Writer
 
 	cmd *exec.Cmd
 }

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -10,6 +10,7 @@ type Driver interface {
 	Start(c *Process) error
 	Kill(c *Process, sig int) error
 	Wait(id string, duration time.Duration) error // Wait on an out of process option - lxc ghosts
+	Version() string
 }
 
 // Network settings of the container

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"os/exec"
-	"sync"
 	"syscall"
 	"time"
 )
@@ -28,44 +27,7 @@ type Network struct {
 	Mtu         int
 }
 
-type State struct {
-	sync.RWMutex
-	running    bool
-	pid        int
-	exitCode   int
-	startedAt  time.Time
-	finishedAt time.Time
-}
-
-func (s *State) IsRunning() bool {
-	s.RLock()
-	defer s.RUnlock()
-	return s.running
-}
-
-func (s *State) SetRunning() error {
-	s.Lock()
-	defer s.Unlock()
-	s.running = true
-	return nil
-}
-
-func (s *State) SetStopped(exitCode int) error {
-	s.Lock()
-	defer s.Unlock()
-	s.exitCode = exitCode
-	s.running = false
-	return nil
-}
-
-// Container / Process / Whatever, we can redefine the conatiner here
-// to be what it should be and not have to carry the baggage of the
-// container type in the core with backward compat.  This is what a
-// driver needs to execute a process inside of a conatiner.  This is what
-// a container is at it's core.
 type Process struct {
-	State State
-
 	Name       string // unique name for the conatienr
 	Privileged bool
 	User       string
@@ -91,6 +53,10 @@ func (c *Process) SetCmd(cmd *exec.Cmd) error {
 	cmd.Stderr = c.Stderr
 	cmd.Stdin = c.Stdin
 	return nil
+}
+
+func (c *Process) Pid() int {
+	return c.cmd.Process.Pid
 }
 
 func (c *Process) StdinPipe() (io.WriteCloser, error) {

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -29,18 +29,17 @@ type Network struct {
 type Process struct {
 	exec.Cmd
 
-	ID          string
-	Privileged  bool
-	User        string
-	Rootfs      string // root fs of the container
-	InitPath    string // dockerinit
-	Entrypoint  string
-	Arguments   []string
-	WorkingDir  string
-	ConfigPath  string
-	Tty         bool
-	Network     *Network // if network is nil then networking is disabled
-	SysInitPath string
+	ID         string
+	Privileged bool
+	User       string
+	Rootfs     string // root fs of the container
+	InitPath   string // dockerinit
+	Entrypoint string
+	Arguments  []string
+	WorkingDir string
+	ConfigPath string
+	Tty        bool
+	Network    *Network // if network is nil then networking is disabled
 }
 
 func (c *Process) Pid() int {

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"os/exec"
 	"syscall"
-	"time"
 )
 
 var (
@@ -18,7 +17,7 @@ type Driver interface {
 	Run(c *Process, startCallback StartCallback) (int, error) // Run executes the process and blocks until the process exits and returns the exit code
 	Kill(c *Process, sig int) error
 	// TODO: @crosbymichael @creack wait should probably return the exit code
-	Wait(id string, duration time.Duration) error // Wait on an out of process...process - lxc ghosts
+	Wait(id string) error // Wait on an out of process...process - lxc ghosts
 	Version() string
 	Name() string
 }

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -25,19 +25,20 @@ type Network struct {
 type Process struct {
 	exec.Cmd
 
-	ID         string
-	Privileged bool
-	User       string
-	Rootfs     string // root fs of the container
-	InitPath   string // dockerinit
-	Entrypoint string
-	Arguments  []string
-	WorkingDir string
-	ConfigPath string
-	Tty        bool
-	Network    *Network // if network is nil then networking is disabled
-	WaitLock   chan struct{}
-	WaitError  error
+	ID          string
+	Privileged  bool
+	User        string
+	Rootfs      string // root fs of the container
+	InitPath    string // dockerinit
+	Entrypoint  string
+	Arguments   []string
+	WorkingDir  string
+	ConfigPath  string
+	Tty         bool
+	Network     *Network // if network is nil then networking is disabled
+	SysInitPath string
+	WaitLock    chan struct{}
+	WaitError   error
 }
 
 func (c *Process) Pid() int {

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -1,0 +1,46 @@
+package execdriver
+
+import (
+	"io"
+	"net"
+)
+
+// Network settings of the container
+type Network struct {
+	Gateway     string
+	IPAddress   net.IPAddr
+	IPPrefixLen int
+	Mtu         int
+}
+
+// Container / Process / Whatever, we can redefine the conatiner here
+// to be what it should be and not have to carry the baggage of the
+// container type in the core with backward compat.  This is what a
+// driver needs to execute a process inside of a conatiner.  This is what
+// a container is at it's core.
+type Container struct {
+	Name        string // unique name for the conatienr
+	Privileged  bool
+	User        string
+	Dir         string // root fs of the container
+	InitPath    string // dockerinit
+	Entrypoint  string
+	Args        []string
+	Environment map[string]string
+	WorkingDir  string
+	Network     *Network // if network is nil then networking is disabled
+	Stdin       io.Reader
+	Stdout      io.Writer
+	Stderr      io.Writer
+
+	Context interface{}
+}
+
+// State can be handled internally in the drivers
+type Driver interface {
+	Start(c *Container) error
+	Stop(c *Container) error
+	Kill(c *Container, sig int) error
+	Running(c *Container) (bool, error)
+	Wait(c *Container, seconds int) error
+}

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -1,20 +1,15 @@
 package execdriver
 
 import (
-	"errors"
 	"os/exec"
 	"syscall"
 	"time"
 )
 
-var (
-	ErrCommandIsNil = errors.New("Process's cmd is nil")
-)
-
 type Driver interface {
 	Start(c *Process) error
 	Kill(c *Process, sig int) error
-	Wait(c *Process, duration time.Duration) error
+	Wait(id string, duration time.Duration) error // Wait on an out of process option - lxc ghosts
 }
 
 // Network settings of the container
@@ -40,6 +35,8 @@ type Process struct {
 	ConfigPath string
 	Tty        bool
 	Network    *Network // if network is nil then networking is disabled
+	WaitLock   chan struct{}
+	WaitError  error
 }
 
 func (c *Process) Pid() int {

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -44,6 +44,8 @@ func (c *Process) Pid() int {
 }
 
 func (c *Process) GetExitCode() int {
+	if c.ProcessState == nil {
+		return -1
+	}
 	return c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
-	return -1
 }

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -14,7 +14,7 @@ type Driver interface {
 	// TODO: @crosbymichael @creack wait should probably return the exit code
 	Wait(id string, duration time.Duration) error // Wait on an out of process...process - lxc ghosts
 	Version() string
-	String() string
+	Name() string
 }
 
 // Network settings of the container
@@ -43,6 +43,9 @@ type Process struct {
 }
 
 func (c *Process) Pid() int {
+	if c.Process == nil {
+		return -1
+	}
 	return c.Process.Pid
 }
 

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -63,7 +63,6 @@ type Driver interface {
 	Run(c *Process, startCallback StartCallback) (int, error) // Run executes the process and blocks until the process exits and returns the exit code
 	Kill(c *Process, sig int) error
 	Wait(id string) error // Wait on an out of process...process - lxc ghosts
-	Version() string      // Driver version number
 	Name() string         // Driver name
 	Info(id string) Info  // "temporary" hack (until we move state from core to plugins)
 }
@@ -89,10 +88,10 @@ type Process struct {
 	Entrypoint string          `json:"entrypoint"`
 	Arguments  []string        `json:"arguments"`
 	WorkingDir string          `json:"working_dir"`
-	ConfigPath string          `json:"config_path"` // This should be able to be removed when the lxc template is moved into the driver
+	ConfigPath string          `json:"config_path"` // this should be able to be removed when the lxc template is moved into the driver
 	Tty        bool            `json:"tty"`
 	Network    *Network        `json:"network"` // if network is nil then networking is disabled
-	Config     []string        `json:"config"`
+	Config     []string        `json:"config"`  //  generic values that specific drivers can consume
 	Cgroups    *cgroups.Values `json:"cgroups"`
 }
 

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -2,6 +2,7 @@ package execdriver
 
 import (
 	"errors"
+	"github.com/dotcloud/docker/cgroups"
 	"os/exec"
 	"syscall"
 )
@@ -71,6 +72,7 @@ type Driver interface {
 type Network struct {
 	Gateway     string `json:"gateway"`
 	IPAddress   string `json:"ip"`
+	Bridge      string `json:"bridge"`
 	IPPrefixLen int    `json:"ip_prefix_len"`
 	Mtu         int    `json:"mtu"`
 }
@@ -79,17 +81,19 @@ type Network struct {
 type Process struct {
 	exec.Cmd
 
-	ID         string   `json:"id"`
-	Privileged bool     `json:"privileged"`
-	User       string   `json:"user"`
-	Rootfs     string   `json:"rootfs"`   // root fs of the container
-	InitPath   string   `json:"initpath"` // dockerinit
-	Entrypoint string   `json:"entrypoint"`
-	Arguments  []string `json:"arguments"`
-	WorkingDir string   `json:"working_dir"`
-	ConfigPath string   `json:"config_path"` // This should be able to be removed when the lxc template is moved into the driver
-	Tty        bool     `json:"tty"`
-	Network    *Network `json:"network"` // if network is nil then networking is disabled
+	ID         string          `json:"id"`
+	Privileged bool            `json:"privileged"`
+	User       string          `json:"user"`
+	Rootfs     string          `json:"rootfs"`   // root fs of the container
+	InitPath   string          `json:"initpath"` // dockerinit
+	Entrypoint string          `json:"entrypoint"`
+	Arguments  []string        `json:"arguments"`
+	WorkingDir string          `json:"working_dir"`
+	ConfigPath string          `json:"config_path"` // This should be able to be removed when the lxc template is moved into the driver
+	Tty        bool            `json:"tty"`
+	Network    *Network        `json:"network"` // if network is nil then networking is disabled
+	Config     []string        `json:"config"`
+	Cgroups    *cgroups.Values `json:"cgroups"`
 }
 
 // Return the pid of the process

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -62,7 +62,7 @@ type Info interface {
 type Driver interface {
 	Run(c *Process, startCallback StartCallback) (int, error) // Run executes the process and blocks until the process exits and returns the exit code
 	Kill(c *Process, sig int) error
-	Wait(id string) error // Wait on an out of process...process - lxc ghosts
+	Wait(id string) error // Wait on an out of process...process - lxc ghosts TODO: Rename to reattach, reconnect
 	Name() string         // Driver name
 	Info(id string) Info  // "temporary" hack (until we move state from core to plugins)
 }
@@ -77,6 +77,7 @@ type Network struct {
 }
 
 // Process wrapps an os/exec.Cmd to add more metadata
+// TODO: Rename to Command
 type Process struct {
 	exec.Cmd
 

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -42,13 +42,6 @@ func (d *driver) Start(c *execdriver.Process) error {
 		return nil
 	}
 
-	/*
-		configPath, err := d.generateConfig(c)
-		if err != nil {
-			return err
-		}
-	*/
-
 	params := []string{
 		startPath,
 		"-n", c.Name,
@@ -82,6 +75,7 @@ func (d *driver) Start(c *execdriver.Process) error {
 
 	cmd := exec.Command(params[0], params[1:]...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.SysProcAttr.Setctty = true
 
 	if err := c.SetCmd(cmd); err != nil {
 		return err
@@ -111,10 +105,7 @@ func (d *driver) Stop(c *execdriver.Process) error {
 		}
 	}
 	exitCode := c.GetExitCode()
-	if err := c.State.SetStopped(exitCode); err != nil {
-		return err
-	}
-	return nil
+	return c.State.SetStopped(exitCode)
 }
 
 func (d *driver) Kill(c *execdriver.Process, sig int) error {
@@ -155,7 +146,8 @@ begin:
 			return err
 		}
 	}
-	return nil
+	exitCode := c.GetExitCode()
+	return c.State.SetStopped(exitCode)
 }
 
 func (d *driver) kill(c *execdriver.Process, sig int) error {

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -81,7 +81,6 @@ func (d *driver) Start(c *execdriver.Process) error {
 	c.Args = append([]string{name}, arg...)
 
 	c.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
-	c.SysProcAttr.Setctty = true
 
 	if err := c.Start(); err != nil {
 		return err

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -1,0 +1,144 @@
+package lxc
+
+import (
+	"github.com/dotcloud/docker/execdriver"
+	"os/exec"
+	"strconv"
+	"sync"
+	"syscall"
+)
+
+const (
+	startPath = "lxc-start"
+)
+
+type driver struct {
+	containerLock map[string]*sync.Mutex
+}
+
+func NewDriver() (execdriver.Driver, error) {
+	// setup unconfined symlink
+}
+
+func (d *driver) Start(c *execdriver.Container) error {
+	l := d.getLock(c)
+	l.Lock()
+	defer l.Unlock()
+
+	running, err := d.running(c)
+	if err != nil {
+		return err
+	}
+	if running {
+		return nil
+	}
+
+	configPath, err := d.generateConfig(c)
+	if err != nil {
+		return err
+	}
+
+	params := []string{
+		startPath,
+		"-n", c.Name,
+		"-f", configPath,
+		"--",
+		c.InitPath,
+	}
+
+	if c.Network != nil {
+		params = append(params,
+			"-g", c.Network.Gateway,
+			"-i", fmt.Sprintf("%s/%d", c.Network.IPAddress, c.Network, IPPrefixLen),
+			"-mtu", c.Network.Mtu,
+		)
+	}
+
+	if c.User != "" {
+		params = append(params, "-u", c.User)
+	}
+
+	if c.Privileged {
+		params = append(params, "-privileged")
+	}
+
+	if c.WorkingDir != "" {
+		params = append(params, "-w", c.WorkingDir)
+	}
+
+	params = append(params, "--", c.Entrypoint)
+	params = append(params, c.Args...)
+
+	cmd := exec.Command(params[0], params[1:]...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	cmd.Stdout = c.Stdout
+	cmd.Stderr = c.Stderr
+	cmd.Stdin = c.Stdin
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	// Poll for running
+	if err := d.waitForStart(cmd, c); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (d *driver) Stop(c *execdriver.Container) error {
+	l := d.getLock(c)
+	l.Lock()
+	defer l.Unlock()
+
+	if err := d.kill(c, 15); err != nil {
+		if err := d.kill(c, 9); err != nil {
+			return err
+		}
+	}
+
+	if err := d.wait(c, 10); err != nil {
+		return d.kill(c, 9)
+	}
+	return nil
+}
+
+func (d *driver) Wait(c *execdriver.Container, seconds int) error {
+	l := d.getLock(c)
+	l.Lock()
+	defer l.Unlock()
+
+	return d.wait(c, seconds)
+}
+
+// If seconds < 0 then wait forever
+func (d *driver) wait(c *execdriver.Container, seconds int) error {
+
+}
+
+func (d *driver) kill(c *execdriver.Container, sig int) error {
+	return exec.Command("lxc-kill", "-n", c.Name, strconv.Itoa(sig)).Run()
+}
+
+func (d *driver) running(c *execdriver.Container) (bool, error) {
+
+}
+
+// Generate the lxc configuration and return the path to the file
+func (d *driver) generateConfig(c *execdriver.Container) (string, error) {
+
+}
+
+func (d *driver) waitForStart(cmd *exec.Cmd, c *execdriver.Container) error {
+
+}
+
+func (d *driver) getLock(c *execdriver.Container) *sync.Mutex {
+	l, ok := d.containerLock[c.Name]
+	if !ok {
+		l = &sync.Mutex{}
+		d.containerLock[c.Name] = l
+	}
+	return l
+}

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -17,6 +17,7 @@ const (
 var (
 	ErrNotRunning         = errors.New("Process could not be started")
 	ErrWaitTimeoutReached = errors.New("Wait timeout reached")
+	Debug                 bool
 )
 
 func init() {
@@ -120,7 +121,12 @@ func (d *driver) Wait(id string, duration time.Duration) error {
 }
 
 func (d *driver) kill(c *execdriver.Process, sig int) error {
-	return exec.Command("lxc-kill", "-n", c.ID, strconv.Itoa(sig)).Run()
+	output, err := exec.Command("lxc-kill", "-n", c.ID, strconv.Itoa(sig)).CombinedOutput()
+	if err != nil {
+		fmt.Printf("--->%s\n", output)
+		return fmt.Errorf("Err: %s Output: %s", err, output)
+	}
+	return nil
 }
 
 func (d *driver) waitForStart(c *execdriver.Process) error {

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -38,10 +38,6 @@ func NewDriver(root string) (execdriver.Driver, error) {
 }
 
 func (d *driver) Start(c *execdriver.Process) error {
-	if c.State.IsRunning() {
-		return nil
-	}
-
 	params := []string{
 		startPath,
 		"-n", c.Name,
@@ -104,13 +100,10 @@ func (d *driver) Stop(c *execdriver.Process) error {
 			return err
 		}
 	}
-	exitCode := c.GetExitCode()
-	return c.State.SetStopped(exitCode)
+	return nil
 }
 
 func (d *driver) Kill(c *execdriver.Process, sig int) error {
-	c.State.Lock()
-	defer c.State.Unlock()
 	return d.kill(c, sig)
 }
 
@@ -146,8 +139,7 @@ begin:
 			return err
 		}
 	}
-	exitCode := c.GetExitCode()
-	return c.State.SetStopped(exitCode)
+	return nil
 }
 
 func (d *driver) kill(c *execdriver.Process, sig int) error {
@@ -177,9 +169,11 @@ func (d *driver) waitForStart(cmd *exec.Cmd, c *execdriver.Process) error {
 	// the end of this loop
 	for now := time.Now(); time.Since(now) < 5*time.Second; {
 		// If the container dies while waiting for it, just return
-		if !c.State.IsRunning() {
-			return nil
-		}
+		/*
+			if !c.State.IsRunning() {
+				return nil
+			}
+		*/
 		output, err := exec.Command("lxc-info", "-s", "-n", c.Name).CombinedOutput()
 		if err != nil {
 			output, err = exec.Command("lxc-info", "-s", "-n", c.Name).CombinedOutput()

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -41,6 +41,10 @@ func NewDriver(root string, apparmor bool) (execdriver.Driver, error) {
 	}, nil
 }
 
+func (d *driver) String() string {
+	return "lxc"
+}
+
 func (d *driver) Start(c *execdriver.Process) error {
 	params := []string{
 		startPath,
@@ -48,6 +52,8 @@ func (d *driver) Start(c *execdriver.Process) error {
 		"-f", c.ConfigPath,
 		"--",
 		c.InitPath,
+		"-driver",
+		d.String(),
 	}
 
 	if c.Network != nil {

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -256,6 +256,7 @@ func linkLxcStart(root string) error {
 	return os.Symlink(sourcePath, targetPath)
 }
 
+// TODO: This can be moved to the mountinfo reader in the mount pkg
 func rootIsShared() bool {
 	if data, err := ioutil.ReadFile("/proc/self/mountinfo"); err == nil {
 		for _, line := range strings.Split(string(data), "\n") {

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -88,7 +88,6 @@ func (d *driver) Start(c *execdriver.Process) error {
 		params = []string{
 			"unshare", "-m", "--", "/bin/sh", "-c", shellString,
 		}
-
 	}
 
 	params = append(params, "--", c.Entrypoint)

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -139,9 +139,13 @@ func (d *driver) waitForStart(c *execdriver.Process) error {
 	// Note: The container can run and finish correctly before
 	// the end of this loop
 	for now := time.Now(); time.Since(now) < 5*time.Second; {
-		// If the process dies while waiting for it, just return
-		if c.ProcessState != nil && c.ProcessState.Exited() {
-			return nil
+		select {
+		case <-c.WaitLock:
+			// If the process dies while waiting for it, just return
+			if c.ProcessState != nil && c.ProcessState.Exited() {
+				return nil
+			}
+		default:
 		}
 
 		output, err = d.getInfo(c)

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -123,7 +123,6 @@ func (d *driver) Wait(id string, duration time.Duration) error {
 func (d *driver) kill(c *execdriver.Process, sig int) error {
 	output, err := exec.Command("lxc-kill", "-n", c.ID, strconv.Itoa(sig)).CombinedOutput()
 	if err != nil {
-		fmt.Printf("--->%s\n", output)
 		return fmt.Errorf("Err: %s Output: %s", err, output)
 	}
 	return nil

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -1,7 +1,6 @@
 package lxc
 
 import (
-	"errors"
 	"fmt"
 	"github.com/dotcloud/docker/execdriver"
 	"github.com/dotcloud/docker/utils"
@@ -12,15 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-)
-
-const (
-	startPath = "lxc-start"
-)
-
-var (
-	ErrNotRunning         = errors.New("Process could not be started")
-	ErrWaitTimeoutReached = errors.New("Wait timeout reached")
 )
 
 type driver struct {
@@ -47,7 +37,7 @@ func (d *driver) Name() string {
 
 func (d *driver) Run(c *execdriver.Process, startCallback execdriver.StartCallback) (int, error) {
 	params := []string{
-		startPath,
+		"lxc-start",
 		"-n", c.ID,
 		"-f", c.ConfigPath,
 		"--",
@@ -155,7 +145,7 @@ func (d *driver) Wait(id string, duration time.Duration) error {
 			return err
 		case <-time.After(duration):
 			killer = true
-			return ErrWaitTimeoutReached
+			return execdriver.ErrWaitTimeoutReached
 		}
 	} else {
 		return <-done
@@ -214,7 +204,7 @@ func (d *driver) waitForStart(c *execdriver.Process, waitLock chan struct{}) err
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	return ErrNotRunning
+	return execdriver.ErrNotRunning
 }
 
 func (d *driver) waitLxc(id string, kill *bool) <-chan error {

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -18,7 +18,7 @@ import (
 const DriverName = "lxc"
 
 func init() {
-	execdriver.RegisterDockerInitFct(DriverName, func(args *execdriver.DockerInitArgs) error {
+	execdriver.RegisterInitFunc(DriverName, func(args *execdriver.InitArgs) error {
 		if err := setupHostname(args); err != nil {
 			return err
 		}

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -29,7 +29,7 @@ type driver struct {
 	sharedRoot bool
 }
 
-func NewDriver(root string, apparmor bool) (execdriver.Driver, error) {
+func NewDriver(root string, apparmor bool) (*driver, error) {
 	// setup unconfined symlink
 	if err := linkLxcStart(root); err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func NewDriver(root string, apparmor bool) (execdriver.Driver, error) {
 	}, nil
 }
 
-func (d *driver) String() string {
+func (d *driver) Name() string {
 	return "lxc"
 }
 
@@ -53,7 +53,7 @@ func (d *driver) Run(c *execdriver.Process, startCallback execdriver.StartCallba
 		"--",
 		c.InitPath,
 		"-driver",
-		d.String(),
+		d.Name(),
 	}
 
 	if c.Network != nil {
@@ -195,6 +195,7 @@ func (d *driver) waitForStart(c *execdriver.Process, waitLock chan struct{}) err
 		select {
 		case <-waitLock:
 			// If the process dies while waiting for it, just return
+			return nil
 			if c.ProcessState != nil && c.ProcessState.Exited() {
 				return nil
 			}

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -68,7 +68,8 @@ func NewDriver(root string, apparmor bool) (*driver, error) {
 }
 
 func (d *driver) Name() string {
-	return DriverName
+	version := d.version()
+	return fmt.Sprintf("%s-%s", DriverName, version)
 }
 
 func (d *driver) Run(c *execdriver.Process, startCallback execdriver.StartCallback) (int, error) {
@@ -186,7 +187,7 @@ func (d *driver) Wait(id string) error {
 	}
 }
 
-func (d *driver) Version() string {
+func (d *driver) version() string {
 	version := ""
 	if output, err := exec.Command("lxc-version").CombinedOutput(); err == nil {
 		outputStr := string(output)

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -84,7 +84,7 @@ func (d *driver) Run(c *execdriver.Process, startCallback execdriver.StartCallba
 		"--",
 		c.InitPath,
 		"-driver",
-		d.Name(),
+		DriverName,
 	}
 
 	if c.Network != nil {

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -43,7 +43,7 @@ func init() {
 			os.Exit(127)
 		}
 		if err := syscall.Exec(path, args.Args, os.Environ()); err != nil {
-			panic(err)
+			return fmt.Errorf("dockerinit unable to execute %s - %s", path, err)
 		}
 		panic("Unreachable")
 	})

--- a/execdriver/lxc/init.go
+++ b/execdriver/lxc/init.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 )
 
-func setupHostname(args *execdriver.DockerInitArgs) error {
+func setupHostname(args *execdriver.InitArgs) error {
 	hostname := getEnv(args, "HOSTNAME")
 	if hostname == "" {
 		return nil
@@ -22,7 +22,7 @@ func setupHostname(args *execdriver.DockerInitArgs) error {
 }
 
 // Setup networking
-func setupNetworking(args *execdriver.DockerInitArgs) error {
+func setupNetworking(args *execdriver.InitArgs) error {
 	if args.Ip != "" {
 		// eth0
 		iface, err := net.InterfaceByName("eth0")
@@ -67,7 +67,7 @@ func setupNetworking(args *execdriver.DockerInitArgs) error {
 }
 
 // Setup working directory
-func setupWorkingDirectory(args *execdriver.DockerInitArgs) error {
+func setupWorkingDirectory(args *execdriver.InitArgs) error {
 	if args.WorkDir == "" {
 		return nil
 	}
@@ -78,7 +78,7 @@ func setupWorkingDirectory(args *execdriver.DockerInitArgs) error {
 }
 
 // Takes care of dropping privileges to the desired user
-func changeUser(args *execdriver.DockerInitArgs) error {
+func changeUser(args *execdriver.InitArgs) error {
 	if args.User == "" {
 		return nil
 	}
@@ -106,7 +106,7 @@ func changeUser(args *execdriver.DockerInitArgs) error {
 	return nil
 }
 
-func setupCapabilities(args *execdriver.DockerInitArgs) error {
+func setupCapabilities(args *execdriver.InitArgs) error {
 
 	if args.Privileged {
 		return nil
@@ -142,7 +142,7 @@ func setupCapabilities(args *execdriver.DockerInitArgs) error {
 	return nil
 }
 
-func getEnv(args *execdriver.DockerInitArgs, key string) string {
+func getEnv(args *execdriver.InitArgs, key string) string {
 	for _, kv := range args.Env {
 		parts := strings.SplitN(kv, "=", 2)
 		if parts[0] == key && len(parts) == 2 {

--- a/execdriver/lxc/init.go
+++ b/execdriver/lxc/init.go
@@ -1,0 +1,153 @@
+package lxc
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/execdriver"
+	"github.com/dotcloud/docker/pkg/netlink"
+	"github.com/dotcloud/docker/utils"
+	"github.com/syndtr/gocapability/capability"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func setupHostname(args *execdriver.DockerInitArgs) error {
+	hostname := getEnv(args, "HOSTNAME")
+	if hostname == "" {
+		return nil
+	}
+	return setHostname(hostname)
+}
+
+// Setup networking
+func setupNetworking(args *execdriver.DockerInitArgs) error {
+	if args.Ip != "" {
+		// eth0
+		iface, err := net.InterfaceByName("eth0")
+		if err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+		ip, ipNet, err := net.ParseCIDR(args.Ip)
+		if err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+		if err := netlink.NetworkLinkAddIp(iface, ip, ipNet); err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+		if err := netlink.NetworkSetMTU(iface, args.Mtu); err != nil {
+			return fmt.Errorf("Unable to set MTU: %v", err)
+		}
+		if err := netlink.NetworkLinkUp(iface); err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+
+		// loopback
+		iface, err = net.InterfaceByName("lo")
+		if err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+		if err := netlink.NetworkLinkUp(iface); err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+	}
+	if args.Gateway != "" {
+		gw := net.ParseIP(args.Gateway)
+		if gw == nil {
+			return fmt.Errorf("Unable to set up networking, %s is not a valid gateway IP", args.Gateway)
+		}
+
+		if err := netlink.AddDefaultGw(gw); err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Setup working directory
+func setupWorkingDirectory(args *execdriver.DockerInitArgs) error {
+	if args.WorkDir == "" {
+		return nil
+	}
+	if err := syscall.Chdir(args.WorkDir); err != nil {
+		return fmt.Errorf("Unable to change dir to %v: %v", args.WorkDir, err)
+	}
+	return nil
+}
+
+// Takes care of dropping privileges to the desired user
+func changeUser(args *execdriver.DockerInitArgs) error {
+	if args.User == "" {
+		return nil
+	}
+	userent, err := utils.UserLookup(args.User)
+	if err != nil {
+		return fmt.Errorf("Unable to find user %v: %v", args.User, err)
+	}
+
+	uid, err := strconv.Atoi(userent.Uid)
+	if err != nil {
+		return fmt.Errorf("Invalid uid: %v", userent.Uid)
+	}
+	gid, err := strconv.Atoi(userent.Gid)
+	if err != nil {
+		return fmt.Errorf("Invalid gid: %v", userent.Gid)
+	}
+
+	if err := syscall.Setgid(gid); err != nil {
+		return fmt.Errorf("setgid failed: %v", err)
+	}
+	if err := syscall.Setuid(uid); err != nil {
+		return fmt.Errorf("setuid failed: %v", err)
+	}
+
+	return nil
+}
+
+func setupCapabilities(args *execdriver.DockerInitArgs) error {
+
+	if args.Privileged {
+		return nil
+	}
+
+	drop := []capability.Cap{
+		capability.CAP_SETPCAP,
+		capability.CAP_SYS_MODULE,
+		capability.CAP_SYS_RAWIO,
+		capability.CAP_SYS_PACCT,
+		capability.CAP_SYS_ADMIN,
+		capability.CAP_SYS_NICE,
+		capability.CAP_SYS_RESOURCE,
+		capability.CAP_SYS_TIME,
+		capability.CAP_SYS_TTY_CONFIG,
+		capability.CAP_MKNOD,
+		capability.CAP_AUDIT_WRITE,
+		capability.CAP_AUDIT_CONTROL,
+		capability.CAP_MAC_OVERRIDE,
+		capability.CAP_MAC_ADMIN,
+	}
+
+	c, err := capability.NewPid(os.Getpid())
+	if err != nil {
+		return err
+	}
+
+	c.Unset(capability.CAPS|capability.BOUNDS, drop...)
+
+	if err := c.Apply(capability.CAPS | capability.BOUNDS); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getEnv(args *execdriver.DockerInitArgs, key string) string {
+	for _, kv := range args.Env {
+		parts := strings.SplitN(kv, "=", 2)
+		if parts[0] == key && len(parts) == 2 {
+			return parts[1]
+		}
+	}
+	return ""
+}

--- a/execdriver/lxc/lxc_init_darwin.go
+++ b/execdriver/lxc/lxc_init_darwin.go
@@ -1,4 +1,4 @@
-package sysinit
+package lxc
 
 func setHostname(hostname string) error {
 	panic("Not supported on darwin")

--- a/execdriver/lxc/lxc_init_linux.go
+++ b/execdriver/lxc/lxc_init_linux.go
@@ -1,4 +1,4 @@
-package sysinit
+package lxc
 
 import (
 	"syscall"

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -38,7 +38,6 @@ func mkRuntime(f utils.Fataler) *docker.Runtime {
 	if err != nil {
 		f.Fatal(err)
 	}
-	r.UpdateCapabilities(true)
 	return r
 }
 

--- a/lxc_template.go
+++ b/lxc_template.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"github.com/dotcloud/docker/pkg/sysinfo"
 	"strings"
 	"text/template"
 )
@@ -31,7 +32,7 @@ lxc.console = none
 lxc.tty = 1
 
 {{if (getHostConfig .).Privileged}}
-lxc.cgroup.devices.allow = a 
+lxc.cgroup.devices.allow = a
 {{else}}
 # no implicit access to devices
 lxc.cgroup.devices.deny = a
@@ -82,7 +83,7 @@ lxc.mount.entry = devpts {{escapeFstabSpaces $ROOTFS}}/dev/pts devpts newinstanc
 lxc.mount.entry = shm {{escapeFstabSpaces $ROOTFS}}/dev/shm tmpfs size=65536k,nosuid,nodev,noexec 0 0
 
 {{if (getHostConfig .).Privileged}}
-{{if (getCapabilities .).AppArmor}}
+{{if (getSysInfo .).AppArmor}}
 lxc.aa_profile = unconfined
 {{else}}
 #lxc.aa_profile = unconfined
@@ -129,8 +130,8 @@ func getHostConfig(container *Container) *HostConfig {
 	return container.hostConfig
 }
 
-func getCapabilities(container *Container) *Capabilities {
-	return container.runtime.capabilities
+func getSysInfo(container *Container) *sysinfo.SysInfo {
+	return container.runtime.sysInfo
 }
 
 func init() {
@@ -138,7 +139,7 @@ func init() {
 	funcMap := template.FuncMap{
 		"getMemorySwap":     getMemorySwap,
 		"getHostConfig":     getHostConfig,
-		"getCapabilities":   getCapabilities,
+		"getSysInfo":        getSysInfo,
 		"escapeFstabSpaces": escapeFstabSpaces,
 	}
 	LxcTemplateCompiled, err = template.New("lxc").Funcs(funcMap).Parse(LxcTemplate)

--- a/mount/mount.go
+++ b/mount/mount.go
@@ -25,27 +25,37 @@ func Mounted(mountpoint string) (bool, error) {
 	return false, nil
 }
 
-// Mount the specified options at the target path
+// Mount the specified options at the target path only if
+// the target is not mounted
 // Options must be specified as fstab style
 func Mount(device, target, mType, options string) error {
 	if mounted, err := Mounted(target); err != nil || mounted {
 		return err
 	}
+	return ForceMount(device, target, mType, options)
+}
 
+// Mount the specified options at the target path
+// reguardless if the target is mounted or not
+// Options must be specified as fstab style
+func ForceMount(device, target, mType, options string) error {
 	flag, data := parseOptions(options)
 	if err := mount(device, target, mType, uintptr(flag), data); err != nil {
 		return err
 	}
 	return nil
-
 }
 
 // Unmount the target only if it is mounted
-func Unmount(target string) (err error) {
+func Unmount(target string) error {
 	if mounted, err := Mounted(target); err != nil || !mounted {
 		return err
 	}
+	return ForceUnmount(target)
+}
 
+// Unmount the target reguardless if it is mounted or not
+func ForceUnmount(target string) (err error) {
 	// Simple retry logic for unmount
 	for i := 0; i < 10; i++ {
 		if err = unmount(target, 0); err == nil {

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -1,0 +1,55 @@
+package sysinfo
+
+import (
+	"github.com/dotcloud/docker/cgroups"
+	"github.com/dotcloud/docker/utils"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+)
+
+type SysInfo struct {
+	MemoryLimit            bool
+	SwapLimit              bool
+	IPv4ForwardingDisabled bool
+	AppArmor               bool
+}
+
+func New(quiet bool) *SysInfo {
+	sysInfo := &SysInfo{}
+	if cgroupMemoryMountpoint, err := cgroups.FindCgroupMountpoint("memory"); err != nil {
+		if !quiet {
+			log.Printf("WARNING: %s\n", err)
+		}
+	} else {
+		_, err1 := ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.limit_in_bytes"))
+		_, err2 := ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.soft_limit_in_bytes"))
+		sysInfo.MemoryLimit = err1 == nil && err2 == nil
+		if !sysInfo.MemoryLimit && !quiet {
+			log.Printf("WARNING: Your kernel does not support cgroup memory limit.")
+		}
+
+		_, err = ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.memsw.limit_in_bytes"))
+		sysInfo.SwapLimit = err == nil
+		if !sysInfo.SwapLimit && !quiet {
+			log.Printf("WARNING: Your kernel does not support cgroup swap limit.")
+		}
+	}
+
+	content, err3 := ioutil.ReadFile("/proc/sys/net/ipv4/ip_forward")
+	sysInfo.IPv4ForwardingDisabled = err3 != nil || len(content) == 0 || content[0] != '1'
+	if sysInfo.IPv4ForwardingDisabled && !quiet {
+		log.Printf("WARNING: IPv4 forwarding is disabled.")
+	}
+
+	// Check if AppArmor seems to be enabled on this system.
+	if _, err := os.Stat("/sys/kernel/security/apparmor"); os.IsNotExist(err) {
+		utils.Debugf("/sys/kernel/security/apparmor not found; assuming AppArmor is not enabled.")
+		sysInfo.AppArmor = false
+	} else {
+		utils.Debugf("/sys/kernel/security/apparmor found; assuming AppArmor is enabled.")
+		sysInfo.AppArmor = true
+	}
+	return sysInfo
+}

--- a/runtime.go
+++ b/runtime.go
@@ -849,8 +849,8 @@ func (runtime *Runtime) Kill(c *Container, sig int) error {
 	return runtime.execDriver.Kill(c.process, sig)
 }
 
-func (runtime *Runtime) Wait(c *Container, duration time.Duration) error {
-	return runtime.execDriver.Wait(c.ID, duration)
+func (runtime *Runtime) WaitGhost(c *Container) error {
+	return runtime.execDriver.Wait(c.ID)
 }
 
 // Nuke kills all containers then removes all content

--- a/runtime.go
+++ b/runtime.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/cgroups"
 	"github.com/dotcloud/docker/execdriver"
+	"github.com/dotcloud/docker/execdriver/chroot"
 	"github.com/dotcloud/docker/execdriver/lxc"
 	"github.com/dotcloud/docker/graphdriver"
 	"github.com/dotcloud/docker/graphdriver/aufs"
@@ -735,7 +736,12 @@ func NewRuntimeFromDirectory(config *DaemonConfig) (*Runtime, error) {
 	}
 
 	capabilities := NewRuntimeCapabilities(false)
-	ed, err := lxc.NewDriver(config.Root, capabilities.AppArmor)
+	var ed execdriver.Driver
+	if driver := os.Getenv("EXEC_DRIVER"); driver == "lxc" {
+		ed, err = lxc.NewDriver(config.Root, capabilities.AppArmor)
+	} else {
+		ed, err = chroot.NewDriver()
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/runtime.go
+++ b/runtime.go
@@ -838,6 +838,18 @@ func (runtime *Runtime) Diff(container *Container) (archive.Archive, error) {
 	return archive.ExportChanges(cDir, changes)
 }
 
+func (runtime *Runtime) Start(c *Container) error {
+	return runtime.execDriver.Start(c.process)
+}
+
+func (runtime *Runtime) Kill(c *Container, sig int) error {
+	return runtime.execDriver.Kill(c.process, sig)
+}
+
+func (runtime *Runtime) Wait(c *Container, duration time.Duration) error {
+	return runtime.execDriver.Wait(c.process, duration)
+}
+
 // Nuke kills all containers then removes all content
 // from the content root, including images, volumes and
 // container filesystems.

--- a/runtime.go
+++ b/runtime.go
@@ -192,7 +192,7 @@ func (runtime *Runtime) Register(container *Container) error {
 			}
 
 			container.waitLock = make(chan struct{})
-			go container.monitor()
+			go container.monitor(nil)
 		}
 	}
 	return nil
@@ -841,8 +841,8 @@ func (runtime *Runtime) Diff(container *Container) (archive.Archive, error) {
 	return archive.ExportChanges(cDir, changes)
 }
 
-func (runtime *Runtime) Start(c *Container) error {
-	return runtime.execDriver.Start(c.process)
+func (runtime *Runtime) Run(c *Container, startCallback execdriver.StartCallback) (int, error) {
+	return runtime.execDriver.Run(c.process, startCallback)
 }
 
 func (runtime *Runtime) Kill(c *Container, sig int) error {

--- a/runtime.go
+++ b/runtime.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/cgroups"
+	"github.com/dotcloud/docker/execdriver"
+	"github.com/dotcloud/docker/execdriver/lxc"
 	"github.com/dotcloud/docker/graphdriver"
 	"github.com/dotcloud/docker/graphdriver/aufs"
 	_ "github.com/dotcloud/docker/graphdriver/devmapper"
@@ -56,6 +58,7 @@ type Runtime struct {
 	config         *DaemonConfig
 	containerGraph *graphdb.Database
 	driver         graphdriver.Driver
+	execDriver     execdriver.Driver
 }
 
 // List returns an array of all containers registered in the runtime.
@@ -735,6 +738,11 @@ func NewRuntimeFromDirectory(config *DaemonConfig) (*Runtime, error) {
 		sysInitPath = localCopy
 	}
 
+	ed, err := lxc.NewDriver("")
+	if err != nil {
+		return nil, err
+	}
+
 	runtime := &Runtime{
 		repository:     runtimeRepo,
 		containers:     list.New(),
@@ -748,6 +756,7 @@ func NewRuntimeFromDirectory(config *DaemonConfig) (*Runtime, error) {
 		containerGraph: graph,
 		driver:         driver,
 		sysInitPath:    sysInitPath,
+		execDriver:     ed,
 	}
 
 	if err := runtime.restore(); err != nil {

--- a/runtime.go
+++ b/runtime.go
@@ -847,7 +847,7 @@ func (runtime *Runtime) Kill(c *Container, sig int) error {
 }
 
 func (runtime *Runtime) Wait(c *Container, duration time.Duration) error {
-	return runtime.execDriver.Wait(c.process, duration)
+	return runtime.execDriver.Wait(c.ID, duration)
 }
 
 // Nuke kills all containers then removes all content

--- a/server.go
+++ b/server.go
@@ -661,13 +661,6 @@ func (srv *Server) DockerInfo(job *engine.Job) engine.Status {
 	} else {
 		imgcount = len(images)
 	}
-	lxcVersion := ""
-	if output, err := exec.Command("lxc-version").CombinedOutput(); err == nil {
-		outputStr := string(output)
-		if len(strings.SplitN(outputStr, ":", 2)) == 2 {
-			lxcVersion = strings.TrimSpace(strings.SplitN(string(output), ":", 2)[1])
-		}
-	}
 	kernelVersion := "<unknown>"
 	if kv, err := utils.GetKernelVersion(); err == nil {
 		kernelVersion = kv.String()
@@ -691,7 +684,7 @@ func (srv *Server) DockerInfo(job *engine.Job) engine.Status {
 	v.SetBool("Debug", os.Getenv("DEBUG") != "")
 	v.SetInt("NFd", utils.GetTotalUsedFds())
 	v.SetInt("NGoroutines", runtime.NumGoroutine())
-	v.Set("LXCVersion", lxcVersion)
+	v.Set("LXCVersion", srv.runtime.execDriver.Version())
 	v.SetInt("NEventsListener", len(srv.events))
 	v.Set("KernelVersion", kernelVersion)
 	v.Set("IndexServerAddress", auth.IndexServerAddress())

--- a/server.go
+++ b/server.go
@@ -516,7 +516,7 @@ func (srv *Server) ImageInsert(job *engine.Job) engine.Status {
 	}
 	defer file.Body.Close()
 
-	config, _, _, err := ParseRun([]string{img.ID, "echo", "insert", url, path}, srv.runtime.capabilities)
+	config, _, _, err := ParseRun([]string{img.ID, "echo", "insert", url, path}, srv.runtime.sysInfo)
 	if err != nil {
 		job.Error(err)
 		return engine.StatusErr
@@ -678,9 +678,9 @@ func (srv *Server) DockerInfo(job *engine.Job) engine.Status {
 	v.SetInt("Images", imgcount)
 	v.Set("Driver", srv.runtime.driver.String())
 	v.SetJson("DriverStatus", srv.runtime.driver.Status())
-	v.SetBool("MemoryLimit", srv.runtime.capabilities.MemoryLimit)
-	v.SetBool("SwapLimit", srv.runtime.capabilities.SwapLimit)
-	v.SetBool("IPv4Forwarding", !srv.runtime.capabilities.IPv4ForwardingDisabled)
+	v.SetBool("MemoryLimit", srv.runtime.sysInfo.MemoryLimit)
+	v.SetBool("SwapLimit", srv.runtime.sysInfo.SwapLimit)
+	v.SetBool("IPv4Forwarding", !srv.runtime.sysInfo.IPv4ForwardingDisabled)
 	v.SetBool("Debug", os.Getenv("DEBUG") != "")
 	v.SetInt("NFd", utils.GetTotalUsedFds())
 	v.SetInt("NGoroutines", runtime.NumGoroutine())
@@ -1470,10 +1470,10 @@ func (srv *Server) ContainerCreate(job *engine.Job) engine.Status {
 		job.Errorf("Minimum memory limit allowed is 512k")
 		return engine.StatusErr
 	}
-	if config.Memory > 0 && !srv.runtime.capabilities.MemoryLimit {
+	if config.Memory > 0 && !srv.runtime.sysInfo.MemoryLimit {
 		config.Memory = 0
 	}
-	if config.Memory > 0 && !srv.runtime.capabilities.SwapLimit {
+	if config.Memory > 0 && !srv.runtime.sysInfo.SwapLimit {
 		config.MemorySwap = -1
 	}
 	container, buildWarnings, err := srv.runtime.Create(&config, name)

--- a/server.go
+++ b/server.go
@@ -684,7 +684,7 @@ func (srv *Server) DockerInfo(job *engine.Job) engine.Status {
 	v.SetBool("Debug", os.Getenv("DEBUG") != "")
 	v.SetInt("NFd", utils.GetTotalUsedFds())
 	v.SetInt("NGoroutines", runtime.NumGoroutine())
-	v.Set("LXCVersion", srv.runtime.execDriver.Version())
+	v.Set("ExecutionDriver", srv.runtime.execDriver.Name())
 	v.SetInt("NEventsListener", len(srv.events))
 	v.Set("KernelVersion", kernelVersion)
 	v.Set("IndexServerAddress", auth.IndexServerAddress())

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -4,169 +4,17 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/dotcloud/docker/mount"
-	"github.com/dotcloud/docker/pkg/netlink"
-	"github.com/dotcloud/docker/utils"
-	"github.com/syndtr/gocapability/capability"
+	"github.com/dotcloud/docker/execdriver"
 	"io/ioutil"
 	"log"
-	"net"
 	"os"
-	"os/exec"
-	"strconv"
 	"strings"
-	"syscall"
 )
 
-type DockerInitArgs struct {
-	user       string
-	gateway    string
-	ip         string
-	workDir    string
-	privileged bool
-	env        []string
-	args       []string
-	mtu        int
-	driver     string
-}
-
-func setupHostname(args *DockerInitArgs) error {
-	hostname := getEnv(args, "HOSTNAME")
-	if hostname == "" {
-		return nil
-	}
-	return setHostname(hostname)
-}
-
-// Setup networking
-func setupNetworking(args *DockerInitArgs) error {
-	if args.ip != "" {
-		// eth0
-		iface, err := net.InterfaceByName("eth0")
-		if err != nil {
-			return fmt.Errorf("Unable to set up networking: %v", err)
-		}
-		ip, ipNet, err := net.ParseCIDR(args.ip)
-		if err != nil {
-			return fmt.Errorf("Unable to set up networking: %v", err)
-		}
-		if err := netlink.NetworkLinkAddIp(iface, ip, ipNet); err != nil {
-			return fmt.Errorf("Unable to set up networking: %v", err)
-		}
-		if err := netlink.NetworkSetMTU(iface, args.mtu); err != nil {
-			return fmt.Errorf("Unable to set MTU: %v", err)
-		}
-		if err := netlink.NetworkLinkUp(iface); err != nil {
-			return fmt.Errorf("Unable to set up networking: %v", err)
-		}
-
-		// loopback
-		iface, err = net.InterfaceByName("lo")
-		if err != nil {
-			return fmt.Errorf("Unable to set up networking: %v", err)
-		}
-		if err := netlink.NetworkLinkUp(iface); err != nil {
-			return fmt.Errorf("Unable to set up networking: %v", err)
-		}
-	}
-	if args.gateway != "" {
-		gw := net.ParseIP(args.gateway)
-		if gw == nil {
-			return fmt.Errorf("Unable to set up networking, %s is not a valid gateway IP", args.gateway)
-		}
-
-		if err := netlink.AddDefaultGw(gw); err != nil {
-			return fmt.Errorf("Unable to set up networking: %v", err)
-		}
-	}
-
-	return nil
-}
-
-// Setup working directory
-func setupWorkingDirectory(args *DockerInitArgs) error {
-	if args.workDir == "" {
-		return nil
-	}
-	if err := syscall.Chdir(args.workDir); err != nil {
-		return fmt.Errorf("Unable to change dir to %v: %v", args.workDir, err)
-	}
-	return nil
-}
-
-func setupMounts(args *DockerInitArgs) error {
-	return mount.ForceMount("proc", "proc", "proc", "")
-}
-
-// Takes care of dropping privileges to the desired user
-func changeUser(args *DockerInitArgs) error {
-	if args.user == "" {
-		return nil
-	}
-	userent, err := utils.UserLookup(args.user)
-	if err != nil {
-		return fmt.Errorf("Unable to find user %v: %v", args.user, err)
-	}
-
-	uid, err := strconv.Atoi(userent.Uid)
-	if err != nil {
-		return fmt.Errorf("Invalid uid: %v", userent.Uid)
-	}
-	gid, err := strconv.Atoi(userent.Gid)
-	if err != nil {
-		return fmt.Errorf("Invalid gid: %v", userent.Gid)
-	}
-
-	if err := syscall.Setgid(gid); err != nil {
-		return fmt.Errorf("setgid failed: %v", err)
-	}
-	if err := syscall.Setuid(uid); err != nil {
-		return fmt.Errorf("setuid failed: %v", err)
-	}
-
-	return nil
-}
-
-func setupCapabilities(args *DockerInitArgs) error {
-
-	if args.privileged {
-		return nil
-	}
-
-	drop := []capability.Cap{
-		capability.CAP_SETPCAP,
-		capability.CAP_SYS_MODULE,
-		capability.CAP_SYS_RAWIO,
-		capability.CAP_SYS_PACCT,
-		capability.CAP_SYS_ADMIN,
-		capability.CAP_SYS_NICE,
-		capability.CAP_SYS_RESOURCE,
-		capability.CAP_SYS_TIME,
-		capability.CAP_SYS_TTY_CONFIG,
-		capability.CAP_MKNOD,
-		capability.CAP_AUDIT_WRITE,
-		capability.CAP_AUDIT_CONTROL,
-		capability.CAP_MAC_OVERRIDE,
-		capability.CAP_MAC_ADMIN,
-	}
-
-	c, err := capability.NewPid(os.Getpid())
-	if err != nil {
-		return err
-	}
-
-	c.Unset(capability.CAPS|capability.BOUNDS, drop...)
-
-	if err := c.Apply(capability.CAPS | capability.BOUNDS); err != nil {
-		return err
-	}
-	return nil
-}
-
 // Clear environment pollution introduced by lxc-start
-func setupEnv(args *DockerInitArgs) {
+func setupEnv(args *execdriver.DockerInitArgs) {
 	os.Clearenv()
-	for _, kv := range args.env {
+	for _, kv := range args.Env {
 		parts := strings.SplitN(kv, "=", 2)
 		if len(parts) == 1 {
 			parts = append(parts, "")
@@ -175,66 +23,18 @@ func setupEnv(args *DockerInitArgs) {
 	}
 }
 
-func getEnv(args *DockerInitArgs, key string) string {
-	for _, kv := range args.env {
-		parts := strings.SplitN(kv, "=", 2)
-		if parts[0] == key && len(parts) == 2 {
-			return parts[1]
-		}
-	}
-	return ""
-}
-
-func executeProgram(args *DockerInitArgs) error {
+func executeProgram(args *execdriver.DockerInitArgs) error {
 	setupEnv(args)
-
-	if args.driver == "lxc" {
-		if err := setupHostname(args); err != nil {
-			return err
-		}
-
-		if err := setupNetworking(args); err != nil {
-			return err
-		}
-
-		if err := setupCapabilities(args); err != nil {
-			return err
-		}
-		if err := setupWorkingDirectory(args); err != nil {
-			return err
-		}
-
-		if err := changeUser(args); err != nil {
-			return err
-		}
-	} else if args.driver == "chroot" {
-		if err := setupMounts(args); err != nil {
-			return err
-		}
-		defer mount.ForceUnmount("proc")
-	}
-
-	path, err := exec.LookPath(args.args[0])
+	dockerInitFct, err := execdriver.GetDockerInitFct(args.Driver)
 	if err != nil {
-		log.Printf("Unable to locate %v", args.args[0])
-		os.Exit(127)
+		panic(err)
 	}
+	return dockerInitFct(args)
 
-	if args.driver == "lxc" {
-		if err := syscall.Exec(path, args.args, os.Environ()); err != nil {
-			panic(err)
-		}
+	if args.Driver == "lxc" {
 		// Will never reach
-	} else if args.driver == "chroot" {
-		cmd := exec.Command(path, args.args[1:]...)
-
-		cmd.Stderr = os.Stderr
-		cmd.Stdout = os.Stdout
-		cmd.Stdin = os.Stdin
-
-		return cmd.Run()
+	} else if args.Driver == "chroot" {
 	}
-	panic("Should not be here")
 
 	return nil
 }
@@ -271,16 +71,16 @@ func SysInit() {
 	// Propagate the plugin-specific container env variable
 	env = append(env, "container="+os.Getenv("container"))
 
-	args := &DockerInitArgs{
-		user:       *user,
-		gateway:    *gateway,
-		ip:         *ip,
-		workDir:    *workDir,
-		privileged: *privileged,
-		env:        env,
-		args:       flag.Args(),
-		mtu:        *mtu,
-		driver:     *driver,
+	args := &execdriver.DockerInitArgs{
+		User:       *user,
+		Gateway:    *gateway,
+		Ip:         *ip,
+		WorkDir:    *workDir,
+		Privileged: *privileged,
+		Env:        env,
+		Args:       flag.Args(),
+		Mtu:        *mtu,
+		Driver:     *driver,
 	}
 
 	if err := executeProgram(args); err != nil {

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -182,24 +182,25 @@ func getEnv(args *DockerInitArgs, key string) string {
 func executeProgram(args *DockerInitArgs) error {
 	setupEnv(args)
 
-	if err := setupHostname(args); err != nil {
-		return err
-	}
+	if false {
+		if err := setupHostname(args); err != nil {
+			return err
+		}
 
-	if err := setupNetworking(args); err != nil {
-		return err
-	}
+		if err := setupNetworking(args); err != nil {
+			return err
+		}
 
-	if err := setupCapabilities(args); err != nil {
-		return err
-	}
+		if err := setupCapabilities(args); err != nil {
+			return err
+		}
+		if err := setupWorkingDirectory(args); err != nil {
+			return err
+		}
 
-	if err := setupWorkingDirectory(args); err != nil {
-		return err
-	}
-
-	if err := changeUser(args); err != nil {
-		return err
+		if err := changeUser(args); err != nil {
+			return err
+		}
 	}
 
 	path, err := exec.LookPath(args.args[0])

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Clear environment pollution introduced by lxc-start
-func setupEnv(args *execdriver.DockerInitArgs) {
+func setupEnv(args *execdriver.InitArgs) {
 	os.Clearenv()
 	for _, kv := range args.Env {
 		parts := strings.SplitN(kv, "=", 2)
@@ -23,9 +23,9 @@ func setupEnv(args *execdriver.DockerInitArgs) {
 	}
 }
 
-func executeProgram(args *execdriver.DockerInitArgs) error {
+func executeProgram(args *execdriver.InitArgs) error {
 	setupEnv(args)
-	dockerInitFct, err := execdriver.GetDockerInitFct(args.Driver)
+	dockerInitFct, err := execdriver.GetInitFunc(args.Driver)
 	if err != nil {
 		panic(err)
 	}
@@ -71,7 +71,7 @@ func SysInit() {
 	// Propagate the plugin-specific container env variable
 	env = append(env, "container="+os.Getenv("container"))
 
-	args := &execdriver.DockerInitArgs{
+	args := &execdriver.InitArgs{
 		User:       *user,
 		Gateway:    *gateway,
 		Ip:         *ip,

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -5,6 +5,8 @@ import (
 	"flag"
 	"fmt"
 	"github.com/dotcloud/docker/execdriver"
+	_ "github.com/dotcloud/docker/execdriver/chroot"
+	_ "github.com/dotcloud/docker/execdriver/lxc"
 	"io/ioutil"
 	"log"
 	"os"

--- a/utils.go
+++ b/utils.go
@@ -5,7 +5,6 @@ import (
 	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/pkg/namesgenerator"
 	"github.com/dotcloud/docker/utils"
-	"io/ioutil"
 	"strconv"
 	"strings"
 )
@@ -326,20 +325,6 @@ func migratePortMappings(config *Config, hostConfig *HostConfig) error {
 // name:alias
 func parseLink(rawLink string) (map[string]string, error) {
 	return utils.PartParser("name:alias", rawLink)
-}
-
-func RootIsShared() bool {
-	if data, err := ioutil.ReadFile("/proc/self/mountinfo"); err == nil {
-		for _, line := range strings.Split(string(data), "\n") {
-			cols := strings.Split(line, " ")
-			if len(cols) >= 6 && cols[4] == "/" {
-				return strings.HasPrefix(cols[6], "shared")
-			}
-		}
-	}
-
-	// No idea, probably safe to assume so
-	return true
 }
 
 type checker struct {


### PR DESCRIPTION
This is phase one migrating the lxc code outside of the docker core.  It is not the final driver interface but makes it easier to move toward the final result.
