### PR TITLE
Fix docs Dockerfile to install correctly again

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -8,8 +8,8 @@ run apt-get update
 run apt-get install -y python-setuptools make
 run easy_install pip
 #from docs/requirements.txt, but here to increase cacheability
-run pip install Sphinx==1.1.3
-run pip install sphinxcontrib-httpdomain==1.1.9
+run pip install --no-use-wheel Sphinx==1.1.3
+run pip install --no-use-wheel sphinxcontrib-httpdomain==1.1.9
 add . /docs
 run cd /docs; make docs
 


### PR DESCRIPTION
Previously we've been getting:

```
Step 6 : RUN pip install Sphinx==1.1.3
 ---> Running in 397eab32f57a
 Wheel installs require setuptools >= 0.8 for dist-info support.
 pip's wheel support requires setuptools >= 0.8 for dist-info support.
 Storing debug log for failure in /.pip/pip.log
 2014/01/13 18:01:34 The command [/bin/sh -c pip install Sphinx==1.1.3] returned a non-zero code: 1
 make: *** [docs] Error 1
```

This fixes that by telling pip not to use sudo to install (since we're already root).

/cc @vieux
