### PR TITLE
Add test on building an image with a sparse file.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Caleb Spare <cespare@gmail.com>
 Calen Pennington <cale@edx.org>
 Charles Hooper <charles.hooper@dotcloud.com>
 Christopher Currie <codemonkey+github@gmail.com>
+Christopher Rigor <crigor@gmail.com>
 Colin Dunklau <colin.dunklau@gmail.com>
 Colin Rice <colin@daedrum.net>
 Dan Buch <d.buch@modcloth.com>

--- a/integration/buildfile_test.go
+++ b/integration/buildfile_test.go
@@ -223,6 +223,16 @@ run    [ "$(cat /bar/withfile)" = "test2" ]
 		},
 		nil,
 	},
+
+	// Sparse file
+	{
+		`
+from   {IMAGE}
+run    busybox dd if=/dev/zero of=/tmp/sparse bs=1 count=0 seek=1M
+`,
+		nil,
+		nil,
+	},
 }
 
 // FIXME: test building with 2 successive overlapping ADD commands


### PR DESCRIPTION
-S was added to the tar command on 0.7.3 and was reverted on 0.7.4 when it broke `docker build` on devicemapper. The tests didn't fail and I spent time investigating this. (Perhaps too much time, but I learned a lot reading the docker code! :)

The commit that reverted -S is https://github.com/unclejack/docker/commit/d003cfea25c276904dbe1e972c0cf71d5c25e689.

This pull request is for adding a test that will fail if in case -S gets added again. Or at least this can serve as documentation on what went wrong.

Running docker -D, the error on the daemon when running docker build is `unhandled type 83`.

```
[debug] image.go:92 Start untar layer
[debug] archive.go:82 [tar autodetect] n: 10
[debug] diff.go:151 unhandled type 83
```

The whole output is at https://gist.github.com/crigor/c9f0f9872d23fb58c743. The Dockerfile is 

```
FROM ubuntu
RUN apt-get update
```

After rebuilding docker to print the filename I found out the file is var/cache/apt/pkgcache.bin. Knowing that the fix is to revert tar -S, I checked if that file is a sparse file.

```
ls -alsh var/cache/apt/pkgcache.bin
8.2M -rw-r--r-- 1 root root 8.3M Jan 12 09:10 var/cache/apt/pkgcache.bin
```

archive/tar in go doesn't work with sparse files as mentioned on https://code.google.com/p/go/issues/detail?id=3864.

Can this be the problem? I don't fully understand ApplyLayer on diff.go.

I was looking at the tests which uses docker-test-image. The simplest Dockerfile I came up with that shows the problem on 0.7.3 is

```
FROM docker-test-image
RUN busybox dd if=/dev/zero of=/tmp/sparse bs=1 count=0 seek=1M
```

Does the pull request look correct? I'm open to working on this more if there are changes needed. I appreciate any feedback.
