### PR TITLE
Fix odd issues with "make docs", add "make docs-shell", and canonicalize...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all binary build cross default docs shell test
+.PHONY: all binary build cross default docs docs-build docs-shell shell test
 
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 DOCKER_IMAGE := docker:$(GIT_BRANCH)
@@ -16,9 +16,11 @@ binary: build
 cross: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary cross
 
-docs:
-	docker build -rm -t "$(DOCKER_DOCS_IMAGE)" docs
+docs: docs-build
 	docker run -rm -i -t -p 8000:8000 "$(DOCKER_DOCS_IMAGE)"
+
+docs-shell: docs-build
+	docker run -rm -i -t -p 8000:8000 "$(DOCKER_DOCS_IMAGE)" bash
 
 test: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh test test-integration
@@ -28,6 +30,9 @@ shell: build
 
 build: bundles
 	docker build -rm -t "$(DOCKER_IMAGE)" .
+
+docs-build:
+	docker build -rm -t "$(DOCKER_DOCS_IMAGE)" docs
 
 bundles:
 	mkdir bundles

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,20 +1,19 @@
-from ubuntu:12.04
-maintainer Nick Stinemates
+FROM stackbrew/ubuntu:12.04
+MAINTAINER Nick Stinemates
 #
 #    docker build -t docker:docs . && docker run -p 8000:8000 docker:docs
 #
 
-run apt-get update
-run apt-get install -y python-setuptools make
-run easy_install pip
-#from docs/requirements.txt, but here to increase cacheability
-run pip install --no-use-wheel Sphinx==1.1.3
-run pip install --no-use-wheel sphinxcontrib-httpdomain==1.1.9
-add . /docs
-run cd /docs; make docs
+# TODO switch to http://packages.ubuntu.com/trusty/python-sphinxcontrib-httpdomain once trusty is released
 
-expose 8000
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq make python-pip python-setuptools
+# pip installs from docs/requirements.txt, but here to increase cacheability
+RUN pip install Sphinx==1.1.3
+RUN pip install sphinxcontrib-httpdomain==1.1.9
+ADD . /docs
+RUN make -C /docs clean docs
 
-workdir /docs/_build/html
-
-entrypoint ["python", "-m", "SimpleHTTPServer"]
+WORKDIR /docs/_build/html
+CMD ["python", "-m", "SimpleHTTPServer"]
+# note, EXPOSE is only last because of https://github.com/dotcloud/docker/issues/3525
+EXPOSE 8000


### PR DESCRIPTION
... our docs Dockerfile a bit more

/cc @vieux

For reference, here's the error @vieux and I were running into when running `make docs` twice (from SimpleHTTPServer itself of all things - not even Sphinx):

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/usr/lib/python2.7/SimpleHTTPServer.py", line 220, in <module>
    test()
  File "/usr/lib/python2.7/SimpleHTTPServer.py", line 216, in test
    BaseHTTPServer.test(HandlerClass, ServerClass)
  File "/usr/lib/python2.7/BaseHTTPServer.py", line 589, in test
    port = int(sys.argv[1])
ValueError: invalid literal for int() with base 10: '/bin/sh'
```
