### PR TITLE
Add cgroup-lite because lxc,docker don't depend on it

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -154,7 +154,7 @@ Add the Docker repository to your apt sources list, update and install the
    sudo sh -c "echo deb http://get.docker.io/ubuntu docker main\
    > /etc/apt/sources.list.d/docker.list"
    sudo apt-get update
-   sudo apt-get install lxc-docker
+   sudo apt-get install lxc-docker cgroup-lite
 
 Now verify that the installation has worked by downloading the ``ubuntu`` image
 and launching a container.


### PR DESCRIPTION
```
➤ apt-cache depends lxc 
lxc
  Depends on: adduser
  Depends on: apparmor
  Depends on: bridge-utils
    bridge-utils:i386
  Depends on: dnsmasq-base
  Depends on: iptables
  Depends on: liblxc0
  Depends on: python3
  Depends on: python3-lxc
  Depends on: rsync
    rsync:i386
 |Depends on: sysv-rc
  Depends on: <file-rc>
  Depends on: libc6
  Recommends: btrfs-tools
  Recommends: lvm2
    lvm2:i386
  Recommends: lxctl
 |Recommends: cgroup-lite
  Recommends: cgroup-bin
  Recommends: libcap2-bin
  Recommends: lxc-templates
  Recommends: openssl
```

```
➤ apt-cache depends lxc-docker-0.7.5
lxc-docker-0.7.5
  Depends on: lxc
  Depends on: aufs-tools
  Depends on: iptables
```

```
➤ apt-cache policy lxc lxc-docker
lxc:
  Installed: 1.0.0~alpha1-0ubuntu14
  Candidate: 1.0.0~alpha1-0ubuntu14
  Versions:
 *** 1.0.0~alpha1-0ubuntu14 0
        500 http://si.archive.ubuntu.com/ubuntu/ saucy-updates/main amd64 Packages
        100 /var/lib/dpkg/status
     1.0.0~alpha1-0ubuntu11 0
        500 http://si.archive.ubuntu.com/ubuntu/ saucy/main amd64 Packages
lxc-docker:
  Installed: 0.7.5
  Candidate: 0.7.5
  Versions:
 *** 0.7.5 0
        500 https://get.docker.io/ubuntu/ docker/main amd64 Packages
        100 /var/lib/dpkg/status


```
