### PR TITLE
Docker default-conf-file for systemd service

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -4,8 +4,9 @@ Documentation=http://docs.docker.io
 After=network.target
 
 [Service]
+EnvironmentFile=-/etc/conf.d/docker
 ExecStartPre=/bin/mount --make-rprivate /
-ExecStart=/usr/bin/docker -d
+ExecStart=/usr/bin/docker -d $DOCKER_OPTS
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As you can find in other init-systems, here are some tiny changes to set default parameters (_in the file /etc/conf.d/docker_) in the systemd service file for docker daemon.
