### PR TITLE
detect compressed archives in API /build call

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -630,7 +630,13 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	b.context = &utils.TarSum{Reader: context, DisableCompression: true}
+
+	decompressedStream, err := archive.DecompressStream(context)
+	if err != nil {
+		return "", err
+	}
+
+	b.context = &utils.TarSum{Reader: decompressedStream, DisableCompression: true}
 	if err := archive.Untar(b.context, tmpdirPath, nil); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
AFAIK in some previous version it was possible to give a compressed docker file
to the API's build command and that was handled properly (aka compression was
detected and archive uncompressed accordingly). Fails with at least 0.7.5.

Fixed this using the DecompressStream method from the archive package.
