### PR TITLE
Added new mkimage-yum.sh script to create CentOS base images

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -145,6 +145,10 @@ func addTarFile(path, name string, tw *tar.Writer) error {
 		return err
 	}
 
+	if fi.IsDir() && !strings.HasSuffix(name, "/") {
+		name = name + "/"
+	}
+
 	hdr.Name = name
 
 	stat, ok := fi.Sys().(*syscall.Stat_t)

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 )
 
 type Archive io.Reader
@@ -121,6 +122,70 @@ func (compression *Compression) Extension() string {
 		return "tar.xz"
 	}
 	return ""
+}
+
+func addTarFile(path, name string, tw *tar.Writer) error {
+	var stat syscall.Stat_t
+	if err := syscall.Lstat(path, &stat); err != nil {
+		return err
+	}
+
+	mtim := getLastModification(&stat)
+	atim := getLastAccess(&stat)
+	hdr := &tar.Header{
+		Name:       name,
+		Mode:       int64(stat.Mode & 07777),
+		Uid:        int(stat.Uid),
+		Gid:        int(stat.Gid),
+		ModTime:    time.Unix(int64(mtim.Sec), int64(mtim.Nsec)),
+		AccessTime: time.Unix(int64(atim.Sec), int64(atim.Nsec)),
+	}
+
+	if stat.Mode&syscall.S_IFDIR == syscall.S_IFDIR {
+		hdr.Typeflag = tar.TypeDir
+	} else if stat.Mode&syscall.S_IFLNK == syscall.S_IFLNK {
+		hdr.Typeflag = tar.TypeSymlink
+		if link, err := os.Readlink(path); err != nil {
+			return err
+		} else {
+			hdr.Linkname = link
+		}
+	} else if stat.Mode&syscall.S_IFBLK == syscall.S_IFBLK ||
+		stat.Mode&syscall.S_IFCHR == syscall.S_IFCHR {
+		if stat.Mode&syscall.S_IFBLK == syscall.S_IFBLK {
+			hdr.Typeflag = tar.TypeBlock
+		} else {
+			hdr.Typeflag = tar.TypeChar
+		}
+		hdr.Devmajor = int64(major(uint64(stat.Rdev)))
+		hdr.Devminor = int64(minor(uint64(stat.Rdev)))
+	} else if stat.Mode&syscall.S_IFIFO == syscall.S_IFIFO ||
+		stat.Mode&syscall.S_IFSOCK == syscall.S_IFSOCK {
+		hdr.Typeflag = tar.TypeFifo
+	} else if stat.Mode&syscall.S_IFREG == syscall.S_IFREG {
+		hdr.Typeflag = tar.TypeReg
+		hdr.Size = stat.Size
+	} else {
+		return fmt.Errorf("Unknown file type: %s\n", path)
+	}
+
+	if err := tw.WriteHeader(hdr); err != nil {
+		return err
+	}
+
+	if hdr.Typeflag == tar.TypeReg {
+		if file, err := os.Open(path); err != nil {
+			return err
+		} else {
+			_, err := io.Copy(tw, file)
+			if err != nil {
+				return err
+			}
+			file.Close()
+		}
+	}
+
+	return nil
 }
 
 func createTarFile(path, extractDir string, hdr *tar.Header, reader *tar.Reader) error {

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestCmdStreamLargeStderr(t *testing.T) {
 	cmd := exec.Command("/bin/sh", "-c", "dd if=/dev/zero bs=1k count=1000 of=/dev/stderr; echo hello")
-	out, err := CmdStream(cmd, nil, nil)
+	out, err := CmdStream(cmd, nil)
 	if err != nil {
 		t.Fatalf("Failed to start command: %s", err)
 	}
@@ -35,7 +35,7 @@ func TestCmdStreamLargeStderr(t *testing.T) {
 
 func TestCmdStreamBad(t *testing.T) {
 	badCmd := exec.Command("/bin/sh", "-c", "echo hello; echo >&2 error couldn\\'t reverse the phase pulser; exit 1")
-	out, err := CmdStream(badCmd, nil, nil)
+	out, err := CmdStream(badCmd, nil)
 	if err != nil {
 		t.Fatalf("Failed to start command: %s", err)
 	}
@@ -50,7 +50,7 @@ func TestCmdStreamBad(t *testing.T) {
 
 func TestCmdStreamGood(t *testing.T) {
 	cmd := exec.Command("/bin/sh", "-c", "echo hello; exit 0")
-	out, err := CmdStream(cmd, nil, nil)
+	out, err := CmdStream(cmd, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -89,6 +89,16 @@ func tarUntar(t *testing.T, origin string, compression Compression) error {
 	if _, err := os.Stat(tmp); err != nil {
 		return err
 	}
+
+	changes, err := ChangesDirs(origin, tmp)
+	if err != nil {
+		return err
+	}
+
+	if len(changes) != 0 {
+		t.Fatalf("Unexpected differences after tarUntar: %v", changes)
+	}
+
 	return nil
 }
 
@@ -108,8 +118,6 @@ func TestTarUntar(t *testing.T) {
 	for _, c := range []Compression{
 		Uncompressed,
 		Gzip,
-		Bzip2,
-		Xz,
 	} {
 		if err := tarUntar(t, origin, c); err != nil {
 			t.Fatalf("Error tar/untar for compression %s: %s", c.Extension(), err)

--- a/buildfile.go
+++ b/buildfile.go
@@ -488,7 +488,7 @@ func (b *buildFile) CmdAdd(args string) error {
 	}
 	b.tmpContainers[container.ID] = struct{}{}
 
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return err
 	}
 	defer container.Unmount()
@@ -610,7 +610,7 @@ func (b *buildFile) commit(id string, autoCmd []string, comment string) error {
 		b.tmpContainers[container.ID] = struct{}{}
 		fmt.Fprintf(b.outStream, " ---> Running in %s\n", utils.TruncateID(container.ID))
 		id = container.ID
-		if err := container.EnsureMounted(); err != nil {
+		if err := container.Mount(); err != nil {
 			return err
 		}
 		defer container.Unmount()

--- a/buildfile.go
+++ b/buildfile.go
@@ -124,7 +124,7 @@ func (b *buildFile) CmdRun(args string) error {
 	if b.image == "" {
 		return fmt.Errorf("Please provide a source image with `from` prior to run")
 	}
-	config, _, _, err := ParseRun([]string{b.image, "/bin/sh", "-c", args}, nil)
+	config, _, _, err := ParseRun(append([]string{b.image}, b.buildCmdFromJson(args)...), nil)
 	if err != nil {
 		return err
 	}

--- a/commands.go
+++ b/commands.go
@@ -942,7 +942,9 @@ func (cli *DockerCli) CmdRm(args ...string) error {
 
 // 'docker kill NAME' kills a running container
 func (cli *DockerCli) CmdKill(args ...string) error {
-	cmd := cli.Subcmd("kill", "CONTAINER [CONTAINER...]", "Kill a running container (send SIGKILL)")
+	cmd := cli.Subcmd("kill", "[OPTIONS] CONTAINER [CONTAINER...]", "Kill a running container (send SIGKILL, or specified signal)")
+	signal := cmd.String([]string{"s", "-signal"}, "KILL", "Signal to send to the container")
+
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -952,8 +954,8 @@ func (cli *DockerCli) CmdKill(args ...string) error {
 	}
 
 	var encounteredError error
-	for _, name := range args {
-		if _, _, err := readBody(cli.call("POST", "/containers/"+name+"/kill", nil, false)); err != nil {
+	for _, name := range cmd.Args() {
+		if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/containers/%s/kill?signal=%s", name, *signal), nil, false)); err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			encounteredError = fmt.Errorf("Error: failed to kill one or more containers")
 		} else {

--- a/container.go
+++ b/container.go
@@ -1457,7 +1457,6 @@ func (container *Container) Copy(resource string) (archive.Archive, error) {
 	return archive.TarFilter(basePath, &archive.TarOptions{
 		Compression: archive.Uncompressed,
 		Includes:    filter,
-		Recursive:   true,
 	})
 }
 

--- a/container.go
+++ b/container.go
@@ -200,7 +200,7 @@ func (settings *NetworkSettings) PortMappingAPI() []APIPort {
 
 // Inject the io.Reader at the given path. Note: do not close the reader
 func (container *Container) Inject(file io.Reader, pth string) error {
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return fmt.Errorf("inject: error mounting container %s: %s", container.ID, err)
 	}
 	defer container.Unmount()
@@ -505,7 +505,7 @@ func (container *Container) Start() (err error) {
 			container.cleanup()
 		}
 	}()
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return err
 	}
 	if container.runtime.networkManager.disabled {
@@ -1271,7 +1271,7 @@ func (container *Container) Resize(h, w int) error {
 }
 
 func (container *Container) ExportRw() (archive.Archive, error) {
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return nil, err
 	}
 	if container.runtime == nil {
@@ -1283,7 +1283,7 @@ func (container *Container) ExportRw() (archive.Archive, error) {
 }
 
 func (container *Container) Export() (archive.Archive, error) {
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return nil, err
 	}
 
@@ -1307,12 +1307,6 @@ func (container *Container) WaitTimeout(timeout time.Duration) error {
 	case <-done:
 		return nil
 	}
-}
-
-func (container *Container) EnsureMounted() error {
-	// FIXME: EnsureMounted is deprecated because drivers are now responsible
-	// for re-entrant mounting in their Get() method.
-	return container.Mount()
 }
 
 func (container *Container) Mount() error {
@@ -1412,7 +1406,7 @@ func (container *Container) GetSize() (int64, int64) {
 		driver             = container.runtime.driver
 	)
 
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		utils.Errorf("Warning: failed to compute size of container rootfs %s: %s", container.ID, err)
 		return sizeRw, sizeRootfs
 	}
@@ -1444,7 +1438,7 @@ func (container *Container) GetSize() (int64, int64) {
 }
 
 func (container *Container) Copy(resource string) (archive.Archive, error) {
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return nil, err
 	}
 	var filter []string

--- a/contrib/mkimage-rinse.sh
+++ b/contrib/mkimage-rinse.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+#
+# Create a base CentOS Docker image.
+
+# This script is useful on systems with rinse available (e.g.,
+# building a CentOS image on Debian).  See contrib/mkimage-yum.sh for
+# a way to build CentOS images on systems with yum installed.
+
 set -e
 
 repo="$1"

--- a/contrib/mkimage-rinse.sh
+++ b/contrib/mkimage-rinse.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+#
+# Create a base CentOS Docker image.
+
+# This script is useful on systems with rinse available (e.g.,
+# building a CentOS image on Debian).  See contrib/mkimage-yum.sh for
+# a way to build CentOS images on systems with yum installed.
+
 set -e
 
 repo="$1"

--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#
+# Create a base CentOS Docker image.
+#
+# This script is useful on systems with yum installed (e.g., building
+# a CentOS image on CentOS).  See contrib/mkimage-rinse.sh for a way
+# to build CentOS images on other systems.
+
+usage() {
+    cat <<EOOPTS
+$(basename $0) [OPTIONS] <name>
+OPTIONS:
+  -y <yumconf>  The path to the yum config to install packages from. The
+                default is /etc/yum.conf.
+EOOPTS
+    exit 1
+}
+
+# option defaults
+yum_config=/etc/yum.conf
+while getopts ":y:h" opt; do
+    case $opt in
+        y)
+            yum_config=$OPTARG
+            ;;
+        h)
+            usage
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG"
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND - 1))
+name=$1
+
+if [[ -z $name ]]; then
+    usage
+fi
+
+#--------------------
+
+target=$(mktemp -d --tmpdir $(basename $0).XXXXXX)
+
+set -x
+
+for dev in console null zero urandom; do
+    /sbin/MAKEDEV -d "$target"/dev -x $dev
+done
+
+yum -c "$yum_config" --installroot="$target" --setopt=tsflags=nodocs \
+    --setopt=group_package_types=mandatory -y groupinstall Core
+yum -c "$yum_config" --installroot="$mount" -y clean all
+
+cat > "$target"/etc/sysconfig/network <<EOF
+NETWORKING=yes
+HOSTNAME=localhost.localdomain
+EOF
+
+# effectively: febootstrap-minimize --keep-zoneinfo --keep-rpmdb
+# --keep-services "$target".  Stolen from mkimage-rinse.sh
+#  locales
+rm -rf "$target"/usr/{{lib,share}/locale,{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive}
+#  docs
+rm -rf "$target"/usr/share/{man,doc,info,gnome/help}
+#  cracklib
+rm -rf "$target"/usr/share/cracklib
+#  i18n
+rm -rf "$target"/usr/share/i18n
+#  sln
+rm -rf "$target"/sbin/sln
+#  ldconfig
+rm -rf "$target"/etc/ld.so.cache
+rm -rf "$target"/var/cache/ldconfig/*
+
+version=
+if [ -r "$target"/etc/redhat-release ]; then
+    version="$(sed 's/^[^0-9\]*\([0-9.]\+\).*$/\1/' /etc/redhat-release)"
+fi
+
+if [ -z "$version" ]; then
+    echo >&2 "warning: cannot autodetect OS version, using '$name' as tag"
+    version=$name
+fi
+
+tar --numeric-owner -c -C "$target" . | docker import - $name:$version
+docker run -i -t $name:$version echo success
+
+rm -rf "$target"

--- a/docs/sources/articles/baseimages.rst
+++ b/docs/sources/articles/baseimages.rst
@@ -37,7 +37,10 @@ There are more example scripts for creating base images in the
 Docker Github Repo:
 
 * `BusyBox <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-busybox.sh>`_
-* `CentOS / Scientific Linux CERN (SLC)
+* CentOS / Scientific Linux CERN (SLC) `on Debian/Ubuntu
   <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-rinse.sh>`_
+  or
+  `on CentOS/RHEL/SLC/etc.
+  <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-yum.sh>`_
 * `Debian / Ubuntu
   <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-debootstrap.sh>`_

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -754,11 +754,13 @@ we ask for the ``HostPort`` field to get the public address.
 
 ::
 
-    Usage: docker kill CONTAINER [CONTAINER...]
+    Usage: docker kill [OPTIONS] CONTAINER [CONTAINER...]
 
-    Kill a running container (Send SIGKILL)
+    Kill a running container (send SIGKILL, or specified signal)
 
-The main process inside the container will be sent SIGKILL.
+      -s, --signal="KILL": Signal to send to the container
+
+The main process inside the container will be sent SIGKILL, or any signal specified with option ``--signal``.
 
 Known Issues (kill)
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1015,7 +1015,7 @@ image is removed.
       -t, --tty=false: Allocate a pseudo-tty
       -u, --user="": Username or UID
       --dns=[]: Set custom dns servers for the container
-      -v, --volume=[]: Create a bind mount with: [host-dir]:[container-dir]:[rw|ro]. If "container-dir" is missing, then docker creates a new volume.
+      -v, --volume=[]: Create a bind mount to a directory or file with: [host-path]:[container-path]:[rw|ro]. If a directory "container-path" is missing, then docker creates a new volume.
       --volumes-from="": Mount all volumes from the given container(s)
       --entrypoint="": Overwrite the default entrypoint set by the image
       -w, --workdir="": Working directory inside the container
@@ -1100,12 +1100,20 @@ using the container, but inside the current working directory.
 
 .. code-block:: bash
 
-    $ sudo docker run -v /dont/exist:/foo -w /foo -i -t ubuntu bash
+    $ sudo docker run -v /doesnt/exist:/foo -w /foo -i -t ubuntu bash
 
 When the host directory of a bind-mounted volume doesn't exist, Docker
 will automatically create this directory on the host for you. In the
-example above, Docker will create the ``/dont/exist`` folder before
+example above, Docker will create the ``/doesnt/exist`` folder before
 starting your container.
+
+.. code-block:: bash
+
+   $ sudo docker run -t -i -v /var/run/docker.sock:/var/run/docker.sock -v ./static-docker:/usr/bin/docker busybox sh
+
+By bind-mounting the docker unix socket and statically linked docker binary 
+(such as that provided by https://get.docker.io), you give the container 
+the full access to create and manipulate the host's docker daemon.
 
 .. code-block:: bash
 

--- a/docs/sources/use/baseimages.rst
+++ b/docs/sources/use/baseimages.rst
@@ -37,7 +37,10 @@ There are more example scripts for creating base images in the
 Docker Github Repo:
 
 * `BusyBox <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-busybox.sh>`_
-* `CentOS / Scientific Linux CERN (SLC)
+* CentOS / Scientific Linux CERN (SLC) `on Debian/Ubuntu
   <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-rinse.sh>`_
+  or
+  `on CentOS/RHEL/SLC/etc.
+  <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-yum.sh>`_
 * `Debian / Ubuntu
   <https://github.com/dotcloud/docker/blob/master/contrib/mkimage-debootstrap.sh>`_

--- a/docs/sources/use/networking.rst
+++ b/docs/sources/use/networking.rst
@@ -8,7 +8,7 @@ Configure Networking
 
 Docker uses Linux bridge capabilities to provide network connectivity
 to containers. The ``docker0`` bridge interface is managed by Docker
-itself for this purpose. Thus, when the Docker daemon starts it :
+for this purpose. When the Docker daemon starts it :
 
 - creates the ``docker0`` bridge if not present
 - searches for an IP address range which doesn't overlap with an existing route
@@ -34,7 +34,7 @@ At runtime, a :ref:`specific kind of virtual
 interface<vethxxxx-device>` is given to each container which is then
 bonded to the ``docker0`` bridge.  Each container also receives a
 dedicated IP address from the same range as ``docker0``. The
-``docker0`` IP address is then used as the default gateway for the
+``docker0`` IP address is used as the default gateway for the
 container.
 
 .. code-block:: bash
@@ -55,8 +55,8 @@ which is dedicated to the 52f811c5d3d6 container.
 How to use a specific IP address range
 ---------------------------------------
 
-Docker will try hard to find an IP range which is not used by the
-host.  Even if it works for most cases, it's not bullet-proof and
+Docker will try hard to find an IP range that is not used by the
+host.  Even though it works for most cases, it's not bullet-proof and
 sometimes you need to have more control over the IP addressing scheme.
 
 For this purpose, Docker allows you to manage the ``docker0`` bridge
@@ -118,25 +118,25 @@ In this scenario:
 Container intercommunication
 -------------------------------
 
-Containers can communicate with each other according to the ``icc``
-parameter value of the Docker daemon.
+The value of the Docker daemon's ``icc`` parameter determines whether
+containers can communicate with each other over the bridge network.
 
 - The default, ``-icc=true`` allows containers to communicate with each other.
 - ``-icc=false`` means containers are isolated from each other.
 
-Under the hood, ``iptables`` is used by Docker to either accept or
+Docker uses ``iptables`` under the hood to either accept or
 drop communication between containers.
 
 
 .. _vethxxxx-device:
 
-What's about the vethXXXX device?
+What is the vethXXXX device?
 -----------------------------------
 Well. Things get complicated here.
 
 The ``vethXXXX`` interface is the host side of a point-to-point link
 between the host and the corresponding container; the other side of
-the link being materialized by the container's ``eth0``
+the link is the container's ``eth0``
 interface. This pair (host ``vethXXX`` and container ``eth0``) are
 connected like a tube. Everything that comes in one side will come out
 the other side.

--- a/docs/sources/use/networking.rst
+++ b/docs/sources/use/networking.rst
@@ -31,11 +31,11 @@ itself for this purpose. Thus, when the Docker daemon starts it :
 
 
 At runtime, a :ref:`specific kind of virtual
-interface<vethxxxx-device>` is given to each containers which is then
-bonded to the ``docker0`` bridge.  Each containers also receives a
+interface<vethxxxx-device>` is given to each container which is then
+bonded to the ``docker0`` bridge.  Each container also receives a
 dedicated IP address from the same range as ``docker0``. The
 ``docker0`` IP address is then used as the default gateway for the
-containers.
+container.
 
 .. code-block:: bash
 
@@ -135,7 +135,7 @@ What's about the vethXXXX device?
 Well. Things get complicated here.
 
 The ``vethXXXX`` interface is the host side of a point-to-point link
-between the host and the corresponding container, the other side of
+between the host and the corresponding container; the other side of
 the link being materialized by the container's ``eth0``
 interface. This pair (host ``vethXXX`` and container ``eth0``) are
 connected like a tube. Everything that comes in one side will come out

--- a/graph.go
+++ b/graph.go
@@ -97,6 +97,7 @@ func (graph *Graph) Get(name string) (*Image, error) {
 		if err != nil {
 			return nil, fmt.Errorf("Driver %s failed to get image rootfs %s: %s", graph.driver, img.ID, err)
 		}
+		defer graph.driver.Put(img.ID)
 
 		var size int64
 		if img.Parent == "" {
@@ -193,6 +194,7 @@ func (graph *Graph) Register(jsonData []byte, layerData archive.Archive, img *Im
 	if err != nil {
 		return fmt.Errorf("Driver %s failed to get image rootfs %s: %s", graph.driver, img.ID, err)
 	}
+	defer graph.driver.Put(img.ID)
 	img.graph = graph
 	if err := StoreImage(img, jsonData, layerData, tmp, rootfs); err != nil {
 		return err

--- a/graphdriver/aufs/aufs.go
+++ b/graphdriver/aufs/aufs.go
@@ -225,7 +225,6 @@ func (a *Driver) Get(id string) (string, error) {
 // Returns an archive of the contents for the id
 func (a *Driver) Diff(id string) (archive.Archive, error) {
 	return archive.TarFilter(path.Join(a.rootPath(), "diff", id), &archive.TarOptions{
-		Recursive:   true,
 		Compression: archive.Uncompressed,
 	})
 }

--- a/graphdriver/aufs/aufs.go
+++ b/graphdriver/aufs/aufs.go
@@ -222,6 +222,9 @@ func (a *Driver) Get(id string) (string, error) {
 	return out, nil
 }
 
+func (a *Driver) Put(id string) {
+}
+
 // Returns an archive of the contents for the id
 func (a *Driver) Diff(id string) (archive.Archive, error) {
 	return archive.TarFilter(path.Join(a.rootPath(), "diff", id), &archive.TarOptions{

--- a/graphdriver/aufs/aufs.go
+++ b/graphdriver/aufs/aufs.go
@@ -31,6 +31,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"sync"
 )
 
 func init() {
@@ -38,7 +39,9 @@ func init() {
 }
 
 type Driver struct {
-	root string
+	root       string
+	sync.Mutex // Protects concurrent modification to active
+	active     map[string]int
 }
 
 // New returns a new AUFS driver.
@@ -54,12 +57,17 @@ func Init(root string) (graphdriver.Driver, error) {
 		"layers",
 	}
 
+	a := &Driver{
+		root:   root,
+		active: make(map[string]int),
+	}
+
 	// Create the root aufs driver dir and return
 	// if it already exists
 	// If not populate the dir structure
 	if err := os.MkdirAll(root, 0755); err != nil {
 		if os.IsExist(err) {
-			return &Driver{root}, nil
+			return a, nil
 		}
 		return nil, err
 	}
@@ -69,7 +77,7 @@ func Init(root string) (graphdriver.Driver, error) {
 			return nil, err
 		}
 	}
-	return &Driver{root}, nil
+	return a, nil
 }
 
 // Return a nil error if the kernel supports aufs
@@ -167,6 +175,14 @@ func (a *Driver) createDirsFor(id string) error {
 
 // Unmount and remove the dir information
 func (a *Driver) Remove(id string) error {
+	// Protect the a.active from concurrent access
+	a.Lock()
+	defer a.Unlock()
+
+	if a.active[id] != 0 {
+		utils.Errorf("Warning: removing active id %s\n", id)
+	}
+
 	// Make sure the dir is umounted first
 	if err := a.unmount(id); err != nil {
 		return err
@@ -210,19 +226,45 @@ func (a *Driver) Get(id string) (string, error) {
 		ids = []string{}
 	}
 
+	// Protect the a.active from concurrent access
+	a.Lock()
+	defer a.Unlock()
+
+	count := a.active[id]
+
 	// If a dir does not have a parent ( no layers )do not try to mount
 	// just return the diff path to the data
 	out := path.Join(a.rootPath(), "diff", id)
 	if len(ids) > 0 {
 		out = path.Join(a.rootPath(), "mnt", id)
-		if err := a.mount(id); err != nil {
-			return "", err
+
+		if count == 0 {
+			if err := a.mount(id); err != nil {
+				return "", err
+			}
 		}
 	}
+
+	a.active[id] = count + 1
+
 	return out, nil
 }
 
 func (a *Driver) Put(id string) {
+	// Protect the a.active from concurrent access
+	a.Lock()
+	defer a.Unlock()
+
+	if count := a.active[id]; count > 1 {
+		a.active[id] = count - 1
+	} else {
+		ids, _ := getParentIds(a.rootPath(), id)
+		// We only mounted if there are any parents
+		if ids != nil && len(ids) > 0 {
+			a.unmount(id)
+		}
+		delete(a.active, id)
+	}
 }
 
 // Returns an archive of the contents for the id

--- a/graphdriver/devmapper/driver.go
+++ b/graphdriver/devmapper/driver.go
@@ -5,8 +5,10 @@ package devmapper
 import (
 	"fmt"
 	"github.com/dotcloud/docker/graphdriver"
+	"github.com/dotcloud/docker/utils"
 	"io/ioutil"
 	"path"
+	"sync"
 )
 
 func init() {
@@ -20,7 +22,9 @@ func init() {
 
 type Driver struct {
 	*DeviceSet
-	home string
+	home       string
+	sync.Mutex // Protects concurrent modification to active
+	active     map[string]int
 }
 
 var Init = func(home string) (graphdriver.Driver, error) {
@@ -31,6 +35,7 @@ var Init = func(home string) (graphdriver.Driver, error) {
 	d := &Driver{
 		DeviceSet: deviceSet,
 		home:      home,
+		active:    make(map[string]int),
 	}
 	return d, nil
 }
@@ -82,6 +87,14 @@ func (d *Driver) Create(id, parent string) error {
 }
 
 func (d *Driver) Remove(id string) error {
+	// Protect the d.active from concurrent access
+	d.Lock()
+	defer d.Unlock()
+
+	if d.active[id] != 0 {
+		utils.Errorf("Warning: removing active id %s\n", id)
+	}
+
 	mp := path.Join(d.home, "mnt", id)
 	if err := d.unmount(id, mp); err != nil {
 		return err
@@ -90,14 +103,36 @@ func (d *Driver) Remove(id string) error {
 }
 
 func (d *Driver) Get(id string) (string, error) {
+	// Protect the d.active from concurrent access
+	d.Lock()
+	defer d.Unlock()
+
+	count := d.active[id]
+
 	mp := path.Join(d.home, "mnt", id)
-	if err := d.mount(id, mp); err != nil {
-		return "", err
+	if count == 0 {
+		if err := d.mount(id, mp); err != nil {
+			return "", err
+		}
 	}
+
+	d.active[id] = count + 1
+
 	return path.Join(mp, "rootfs"), nil
 }
 
 func (d *Driver) Put(id string) {
+	// Protect the d.active from concurrent access
+	d.Lock()
+	defer d.Unlock()
+
+	if count := d.active[id]; count > 1 {
+		d.active[id] = count - 1
+	} else {
+		mp := path.Join(d.home, "mnt", id)
+		d.unmount(id, mp)
+		delete(d.active, id)
+	}
 }
 
 func (d *Driver) mount(id, mountPoint string) error {

--- a/graphdriver/devmapper/driver.go
+++ b/graphdriver/devmapper/driver.go
@@ -97,6 +97,9 @@ func (d *Driver) Get(id string) (string, error) {
 	return path.Join(mp, "rootfs"), nil
 }
 
+func (d *Driver) Put(id string) {
+}
+
 func (d *Driver) mount(id, mountPoint string) error {
 	// Create the target directories if they don't exist
 	if err := osMkdirAll(mountPoint, 0755); err != nil && !osIsExist(err) {

--- a/graphdriver/driver.go
+++ b/graphdriver/driver.go
@@ -17,6 +17,7 @@ type Driver interface {
 	Remove(id string) error
 
 	Get(id string) (dir string, err error)
+	Put(id string)
 	Exists(id string) bool
 
 	Status() [][2]string

--- a/graphdriver/vfs/driver.go
+++ b/graphdriver/vfs/driver.go
@@ -84,6 +84,11 @@ func (d *Driver) Get(id string) (string, error) {
 	return dir, nil
 }
 
+func (d *Driver) Put(id string) {
+	// The vfs driver has no runtime resources (e.g. mounts)
+	// to clean up, so we don't need anything here
+}
+
 func (d *Driver) Exists(id string) bool {
 	_, err := os.Stat(d.dir(id))
 	return err == nil

--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -120,7 +120,6 @@ The test suite will also download a small test container, so you will need inter
 
 To run properly, docker needs the following software to be installed at runtime:
 
-* GNU Tar version 1.26 or later
 * iproute2 version 3.5 or later (build after 2012-05-21), and specifically the "ip" utility
 * iptables version 1.4 or later
 * The LXC utility scripts (http://lxc.sourceforge.net) version 0.8 or later

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -374,7 +374,7 @@ func TestGetContainersExport(t *testing.T) {
 			}
 			t.Fatal(err)
 		}
-		if h.Name == "./test" {
+		if h.Name == "test" {
 			found = true
 			break
 		}

--- a/integration/buildfile_test.go
+++ b/integration/buildfile_test.go
@@ -223,6 +223,31 @@ run    [ "$(cat /bar/withfile)" = "test2" ]
 		},
 		nil,
 	},
+
+	// JSON!
+	{
+		`
+FROM {IMAGE}
+RUN ["/bin/echo","hello","world"]
+CMD ["/bin/true"]
+ENTRYPOINT ["/bin/echo","your command -->"]
+`,
+		nil,
+		nil,
+	},
+	{
+		`
+FROM {IMAGE}
+ADD test /test
+RUN ["chmod","+x","/test"]
+RUN ["/test"]
+RUN [ "$(cat /testfile)" = 'test!' ]
+`,
+		[][2]string{
+			{"test", "#!/bin/sh\necho 'test!' > /testfile"},
+		},
+		nil,
+	},
 }
 
 // FIXME: test building with 2 successive overlapping ADD commands

--- a/integration/commands_test.go
+++ b/integration/commands_test.go
@@ -12,7 +12,9 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -90,17 +92,24 @@ func setTimeout(t *testing.T, msg string, d time.Duration, f func()) {
 	}
 }
 
+func expectPipe(expected string, r io.Reader) error {
+	o, err := bufio.NewReader(r).ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if strings.Trim(o, " \r\n") != expected {
+		return fmt.Errorf("Unexpected output. Expected [%s], received [%s]", expected, o)
+	}
+	return nil
+}
+
 func assertPipe(input, output string, r io.Reader, w io.Writer, count int) error {
 	for i := 0; i < count; i++ {
 		if _, err := w.Write([]byte(input)); err != nil {
 			return err
 		}
-		o, err := bufio.NewReader(r).ReadString('\n')
-		if err != nil {
+		if err := expectPipe(output, r); err != nil {
 			return err
-		}
-		if strings.Trim(o, " \r\n") != output {
-			return fmt.Errorf("Unexpected output. Expected [%s], received [%s]", output, o)
 		}
 	}
 	return nil
@@ -1030,4 +1039,67 @@ func TestContainerOrphaning(t *testing.T) {
 		}
 	}
 
+}
+
+func TestCmdKill(t *testing.T) {
+	stdin, stdinPipe := io.Pipe()
+	stdout, stdoutPipe := io.Pipe()
+
+	cli := docker.NewDockerCli(stdin, stdoutPipe, ioutil.Discard, testDaemonProto, testDaemonAddr)
+	cli2 := docker.NewDockerCli(nil, ioutil.Discard, ioutil.Discard, testDaemonProto, testDaemonAddr)
+	defer cleanup(globalEngine, t)
+
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		cli.CmdRun("-i", "-t", unitTestImageID, "sh", "-c", "trap 'echo SIGUSR1' USR1; trap 'echo SIGUSR2' USR2; echo Ready; while true; do read; done")
+	}()
+
+	container := waitContainerStart(t, 10*time.Second)
+
+	setTimeout(t, "Read Ready timed out", 3*time.Second, func() {
+		if err := expectPipe("Ready", stdout); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	setTimeout(t, "SIGUSR1 timed out", 2*time.Second, func() {
+		for i := 0; i < 10; i++ {
+			if err := cli2.CmdKill("-s", strconv.Itoa(int(syscall.SIGUSR1)), container.ID); err != nil {
+				t.Fatal(err)
+			}
+			if err := expectPipe("SIGUSR1", stdout); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+
+	setTimeout(t, "SIGUSR2 timed out", 2*time.Second, func() {
+		for i := 0; i < 10; i++ {
+			if err := cli2.CmdKill("--signal=USR2", container.ID); err != nil {
+				t.Fatal(err)
+			}
+			if err := expectPipe("SIGUSR2", stdout); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+
+	time.Sleep(500 * time.Millisecond)
+	if !container.State.IsRunning() {
+		t.Fatal("The container should be still running")
+	}
+
+	setTimeout(t, "Waiting for container timedout", 5*time.Second, func() {
+		if err := cli2.CmdKill(container.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		<-ch
+		if err := cli2.CmdWait(container.ID); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	closeWrap(stdin, stdinPipe, stdout, stdoutPipe)
 }

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -71,7 +71,7 @@ func containerRun(eng *engine.Engine, id string, t utils.Fataler) {
 
 func containerFileExists(eng *engine.Engine, id, dir string, t utils.Fataler) bool {
 	c := getContainer(eng, id, t)
-	if err := c.EnsureMounted(); err != nil {
+	if err := c.Mount(); err != nil {
 		t.Fatal(err)
 	}
 	defer c.Unmount()

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -74,6 +74,7 @@ func containerFileExists(eng *engine.Engine, id, dir string, t utils.Fataler) bo
 	if err := c.EnsureMounted(); err != nil {
 		t.Fatal(err)
 	}
+	defer c.Unmount()
 	if _, err := os.Stat(path.Join(c.RootfsPath(), dir)); err != nil {
 		if os.IsNotExist(err) {
 			return false

--- a/runtime.go
+++ b/runtime.go
@@ -520,7 +520,7 @@ func (runtime *Runtime) Create(config *Config, name string) (*Container, []strin
 func (runtime *Runtime) Commit(container *Container, repository, tag, comment, author string, config *Config) (*Image, error) {
 	// FIXME: freeze the container before copying it to avoid data corruption?
 	// FIXME: this shouldn't be in commands.
-	if err := container.EnsureMounted(); err != nil {
+	if err := container.Mount(); err != nil {
 		return nil, err
 	}
 	defer container.Unmount()

--- a/utils.go
+++ b/utils.go
@@ -5,8 +5,10 @@ import (
 	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/pkg/namesgenerator"
 	"github.com/dotcloud/docker/utils"
+	"io"
 	"strconv"
 	"strings"
+	"sync/atomic"
 )
 
 type Change struct {
@@ -338,4 +340,29 @@ func (c *checker) Exists(name string) bool {
 // Generate a random and unique name
 func generateRandomName(runtime *Runtime) (string, error) {
 	return namesgenerator.GenerateRandomName(&checker{runtime})
+}
+
+// Read an io.Reader and call a function when it returns EOF
+func EofReader(r io.Reader, callback func()) *eofReader {
+	return &eofReader{
+		Reader:   r,
+		callback: callback,
+	}
+}
+
+type eofReader struct {
+	io.Reader
+	gotEOF   int32
+	callback func()
+}
+
+func (r *eofReader) Read(p []byte) (n int, err error) {
+	n, err = r.Reader.Read(p)
+	if err == io.EOF {
+		// Use atomics to make the gotEOF check threadsafe
+		if atomic.CompareAndSwapInt32(&r.gotEOF, 0, 1) {
+			r.callback()
+		}
+	}
+	return
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -553,10 +553,11 @@ type KernelVersionInfo struct {
 	Kernel int
 	Major  int
 	Minor  int
+	Flavor string
 }
 
 func (k *KernelVersionInfo) String() string {
-	return fmt.Sprintf("%d.%d.%d", k.Kernel, k.Major, k.Minor)
+	return fmt.Sprintf("%d.%d.%d%s", k.Kernel, k.Major, k.Minor, k.Flavor)
 }
 
 // Compare two KernelVersionInfo struct.
@@ -610,13 +611,10 @@ func GetKernelVersion() (*KernelVersionInfo, error) {
 func ParseRelease(release string) (*KernelVersionInfo, error) {
 	var (
 		kernel, major, minor, parsed int
-		err                          error
+		flavor                       string
 	)
 
-	parsed, err = fmt.Sscanf(release, "%d.%d.%d", &kernel, &major, &minor)
-	if err != nil {
-		return nil, err
-	}
+	parsed, _ = fmt.Sscanf(release, "%d.%d.%d%s", &kernel, &major, &minor, &flavor)
 	if parsed < 3 {
 		return nil, errors.New("Can't parse kernel version " + release)
 	}
@@ -625,6 +623,7 @@ func ParseRelease(release string) (*KernelVersionInfo, error) {
 		Kernel: kernel,
 		Major:  major,
 		Minor:  minor,
+		Flavor: flavor,
 	}, nil
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -560,7 +560,7 @@ func (k *KernelVersionInfo) String() string {
 }
 
 // Compare two KernelVersionInfo struct.
-// Returns -1 if a < b, = if a == b, 1 it a > b
+// Returns -1 if a < b, 0 if a == b, 1 it a > b
 func CompareKernelVersion(a, b *KernelVersionInfo) int {
 	if a.Kernel < b.Kernel {
 		return -1

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -614,6 +614,8 @@ func ParseRelease(release string) (*KernelVersionInfo, error) {
 		flavor                       string
 	)
 
+	// Ignore error from Sscanf to allow an empty flavor.  Instead, just
+	// make sure we got all the version numbers.
 	parsed, _ = fmt.Sscanf(release, "%d.%d.%d%s", &kernel, &major, &minor, &flavor)
 	if parsed < 3 {
 		return nil, errors.New("Can't parse kernel version " + release)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -609,28 +609,22 @@ func GetKernelVersion() (*KernelVersionInfo, error) {
 
 func ParseRelease(release string) (*KernelVersionInfo, error) {
 	var (
-		parts [3]int
-		err   error
+		kernel, major, minor, parsed int
+		err                          error
 	)
 
-	re := regexp.MustCompile(`^([0-9]+)\.([0-9]+)\.([0-9]+)`)
-	subs := re.FindStringSubmatch(release)
-
-	if len(subs) < 4 {
+	parsed, err = fmt.Sscanf(release, "%d.%d.%d", &kernel, &major, &minor)
+	if err != nil {
+		return nil, err
+	}
+	if parsed < 3 {
 		return nil, errors.New("Can't parse kernel version " + release)
 	}
 
-	for i := 0; i < 3; i++ {
-		parts[i], err = strconv.Atoi(subs[i+1])
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return &KernelVersionInfo{
-		Kernel: parts[0],
-		Major:  parts[1],
-		Minor:  parts[2],
+		Kernel: kernel,
+		Major:  major,
+		Minor:  minor,
 	}, nil
 }
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -237,16 +237,16 @@ func TestCompareKernelVersion(t *testing.T) {
 		&KernelVersionInfo{Kernel: 2, Major: 6, Minor: 0},
 		1)
 	assertKernelVersion(t,
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "0"},
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "16"},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
 		0)
 	assertKernelVersion(t,
 		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 5},
 		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
 		1)
 	assertKernelVersion(t,
-		&KernelVersionInfo{Kernel: 3, Major: 0, Minor: 20, Flavor: "25"},
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "0"},
+		&KernelVersionInfo{Kernel: 3, Major: 0, Minor: 20},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
 		-1)
 }
 
@@ -412,9 +412,9 @@ func assertParseRelease(t *testing.T, release string, b *KernelVersionInfo, resu
 func TestParseRelease(t *testing.T) {
 	assertParseRelease(t, "3.8.0", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0}, 0)
 	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54}, 0)
-	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54, Flavor: "1"}, 0)
-	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "19-generic"}, 0)
-	assertParseRelease(t, "3.12.8tag", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 8, Flavor: "tag"}, 0)
+	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54}, 0)
+	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0}, 0)
+	assertParseRelease(t, "3.12.8tag", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 8}, 0)
 }
 
 func TestParsePortMapping(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -407,14 +407,17 @@ func assertParseRelease(t *testing.T, release string, b *KernelVersionInfo, resu
 	if r := CompareKernelVersion(a, b); r != result {
 		t.Fatalf("Unexpected kernel version comparison result. Found %d, expected %d", r, result)
 	}
+	if a.Flavor != b.Flavor {
+		t.Fatalf("Unexpected parsed kernel flavor.  Found %s, expected %s", a.Flavor, b.Flavor)
+	}
 }
 
 func TestParseRelease(t *testing.T) {
 	assertParseRelease(t, "3.8.0", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0}, 0)
-	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54}, 0)
-	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54}, 0)
-	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0}, 0)
-	assertParseRelease(t, "3.12.8tag", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 8}, 0)
+	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54, Flavor: ".longterm-1"}, 0)
+	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54, Flavor: ".longterm-1"}, 0)
+	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "-19-generic"}, 0)
+	assertParseRelease(t, "3.12.8tag", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 8, Flavor: "tag"}, 0)
 }
 
 func TestParsePortMapping(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -414,6 +414,7 @@ func TestParseRelease(t *testing.T) {
 	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54}, 0)
 	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54, Flavor: "1"}, 0)
 	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "19-generic"}, 0)
+	assertParseRelease(t, "3.12.8tag", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 8, Flavor: "tag"}, 0)
 }
 
 func TestParsePortMapping(t *testing.T) {


### PR DESCRIPTION
mkimage-rinse.sh requires rinse, which is not readily available on CentOS or Fedora.  Plus, creating a base image is trivial with yum alone.
