### PR TITLE
Add MAINTAINER and remove docker/utils dep from pkg/sysinfo

### DIFF
--- a/pkg/sysinfo/MAINTAINERS
+++ b/pkg/sysinfo/MAINTAINERS
@@ -1,0 +1,2 @@
+Michael Crosby <michael@crosbymichael.com> (@crosbymichael)
+Guillaume J. Charmes <guillaume.charmes@docker.com> (@creack)

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -1,8 +1,7 @@
 package sysinfo
 
 import (
-	"github.com/dotcloud/docker/cgroups"
-	"github.com/dotcloud/docker/utils"
+	"github.com/dotcloud/docker/cgroups" // FIXME: move cgroups in pkg
 	"io/ioutil"
 	"log"
 	"os"
@@ -45,10 +44,8 @@ func New(quiet bool) *SysInfo {
 
 	// Check if AppArmor seems to be enabled on this system.
 	if _, err := os.Stat("/sys/kernel/security/apparmor"); os.IsNotExist(err) {
-		utils.Debugf("/sys/kernel/security/apparmor not found; assuming AppArmor is not enabled.")
 		sysInfo.AppArmor = false
 	} else {
-		utils.Debugf("/sys/kernel/security/apparmor found; assuming AppArmor is enabled.")
 		sysInfo.AppArmor = true
 	}
 	return sysInfo


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Guillaume J. Charmes guillaume.charmes@docker.com (github: creack)
