### PR TITLE
Don't expose cgroups via the execdriver API.

### DIFF
--- a/container.go
+++ b/container.go
@@ -7,7 +7,6 @@ import (
 	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/execdriver"
 	"github.com/dotcloud/docker/graphdriver"
-	"github.com/dotcloud/docker/pkg/cgroups"
 	"github.com/dotcloud/docker/pkg/mount"
 	"github.com/dotcloud/docker/pkg/term"
 	"github.com/dotcloud/docker/utils"
@@ -671,7 +670,7 @@ func (container *Container) Start() (err error) {
 			driverConfig = append(driverConfig, fmt.Sprintf("%s = %s", pair.Key, pair.Value))
 		}
 	}
-	cgroupValues := &cgroups.Values{
+	resources := &execdriver.Resources{
 		Memory:     container.Config.Memory,
 		MemorySwap: container.Config.MemorySwap,
 		CpuShares:  container.Config.CpuShares,
@@ -689,7 +688,7 @@ func (container *Container) Start() (err error) {
 		Tty:        container.Config.Tty,
 		User:       container.Config.User,
 		Config:     driverConfig,
-		Cgroups:    cgroupValues,
+		Resources:  resources,
 	}
 	container.process.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -2,7 +2,6 @@ package execdriver
 
 import (
 	"errors"
-	"github.com/dotcloud/docker/pkg/cgroups"
 	"os/exec"
 	"syscall"
 )
@@ -76,24 +75,30 @@ type Network struct {
 	Mtu         int    `json:"mtu"`
 }
 
+type Resources struct {
+	Memory     int64 `json:"memory"`
+	MemorySwap int64 `json:"memory_swap"`
+	CpuShares  int64 `json:"cpu_shares"`
+}
+
 // Process wrapps an os/exec.Cmd to add more metadata
 // TODO: Rename to Command
 type Process struct {
 	exec.Cmd
 
-	ID         string          `json:"id"`
-	Privileged bool            `json:"privileged"`
-	User       string          `json:"user"`
-	Rootfs     string          `json:"rootfs"`   // root fs of the container
-	InitPath   string          `json:"initpath"` // dockerinit
-	Entrypoint string          `json:"entrypoint"`
-	Arguments  []string        `json:"arguments"`
-	WorkingDir string          `json:"working_dir"`
-	ConfigPath string          `json:"config_path"` // this should be able to be removed when the lxc template is moved into the driver
-	Tty        bool            `json:"tty"`
-	Network    *Network        `json:"network"` // if network is nil then networking is disabled
-	Config     []string        `json:"config"`  //  generic values that specific drivers can consume
-	Cgroups    *cgroups.Values `json:"cgroups"`
+	ID         string     `json:"id"`
+	Privileged bool       `json:"privileged"`
+	User       string     `json:"user"`
+	Rootfs     string     `json:"rootfs"`   // root fs of the container
+	InitPath   string     `json:"initpath"` // dockerinit
+	Entrypoint string     `json:"entrypoint"`
+	Arguments  []string   `json:"arguments"`
+	WorkingDir string     `json:"working_dir"`
+	ConfigPath string     `json:"config_path"` // this should be able to be removed when the lxc template is moved into the driver
+	Tty        bool       `json:"tty"`
+	Network    *Network   `json:"network"` // if network is nil then networking is disabled
+	Config     []string   `json:"config"`  //  generic values that specific drivers can consume
+	Resources  *Resources `json:"resources"`
 }
 
 // Return the pid of the process

--- a/execdriver/lxc/lxc_template.go
+++ b/execdriver/lxc/lxc_template.go
@@ -1,7 +1,7 @@
 package lxc
 
 import (
-	"github.com/dotcloud/docker/pkg/cgroups"
+	"github.com/dotcloud/docker/execdriver"
 	"strings"
 	"text/template"
 )
@@ -91,16 +91,16 @@ lxc.aa_profile = unconfined
 {{end}}
 
 # limits
-{{if .Cgroups}}
-{{if .Cgroups.Memory}}
-lxc.cgroup.memory.limit_in_bytes = {{.Cgroups.Memory}}
-lxc.cgroup.memory.soft_limit_in_bytes = {{.Cgroups.Memory}}
-{{with $memSwap := getMemorySwap .Cgroups}}
+{{if .Resources}}
+{{if .Resources.Memory}}
+lxc.cgroup.memory.limit_in_bytes = {{.Resources.Memory}}
+lxc.cgroup.memory.soft_limit_in_bytes = {{.Resources.Memory}}
+{{with $memSwap := getMemorySwap .Resources}}
 lxc.cgroup.memory.memsw.limit_in_bytes = {{$memSwap}}
 {{end}}
 {{end}}
-{{if .Cgroups.CpuShares}}
-lxc.cgroup.cpu.shares = {{.Cgroups.CpuShares}}
+{{if .Resources.CpuShares}}
+lxc.cgroup.cpu.shares = {{.Resources.CpuShares}}
 {{end}}
 {{end}}
 
@@ -119,7 +119,7 @@ func escapeFstabSpaces(field string) string {
 	return strings.Replace(field, " ", "\\040", -1)
 }
 
-func getMemorySwap(v *cgroups.Values) int64 {
+func getMemorySwap(v *execdriver.Resources) int64 {
 	// By default, MemorySwap is set to twice the size of RAM.
 	// If you want to omit MemorySwap, set it to `-1'.
 	if v.MemorySwap < 0 {

--- a/execdriver/lxc/lxc_template_unit_test.go
+++ b/execdriver/lxc/lxc_template_unit_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"github.com/dotcloud/docker/execdriver"
-	"github.com/dotcloud/docker/pkg/cgroups"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -40,7 +39,7 @@ func TestLXCConfig(t *testing.T) {
 	}
 	process := &execdriver.Process{
 		ID: "1",
-		Cgroups: &cgroups.Values{
+		Resources: &execdriver.Resources{
 			Memory:    int64(mem),
 			CpuShares: int64(cpu),
 		},

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -12,12 +12,6 @@ import (
 	"strings"
 )
 
-type Values struct {
-	Memory     int64 `json:"memory"`
-	MemorySwap int64 `json:"memory_swap"`
-	CpuShares  int64 `json:"cpu_shares"`
-}
-
 // https://www.kernel.org/doc/Documentation/cgroups/cgroups.txt
 func FindCgroupMountpoint(subsystem string) (string, error) {
 	mounts, err := mount.GetMounts()


### PR DESCRIPTION
Use Resources to represent container limits rather than a cgroup specific field.

Docker-DCO-1.1-Signed-off-by: Paul Nasrat pnasrat@gmail.com (github: pnasrat)
