### PR TITLE
ignore non-numeric characters when parsing kernel version

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -553,10 +553,11 @@ type KernelVersionInfo struct {
 	Kernel int
 	Major  int
 	Minor  int
+	Flavor string
 }
 
 func (k *KernelVersionInfo) String() string {
-	return fmt.Sprintf("%d.%d.%d", k.Kernel, k.Major, k.Minor)
+	return fmt.Sprintf("%d.%d.%d%s", k.Kernel, k.Major, k.Minor, k.Flavor)
 }
 
 // Compare two KernelVersionInfo struct.
@@ -610,13 +611,10 @@ func GetKernelVersion() (*KernelVersionInfo, error) {
 func ParseRelease(release string) (*KernelVersionInfo, error) {
 	var (
 		kernel, major, minor, parsed int
-		err                          error
+		flavor                       string
 	)
 
-	parsed, err = fmt.Sscanf(release, "%d.%d.%d", &kernel, &major, &minor)
-	if err != nil {
-		return nil, err
-	}
+	parsed, _ = fmt.Sscanf(release, "%d.%d.%d%s", &kernel, &major, &minor, &flavor)
 	if parsed < 3 {
 		return nil, errors.New("Can't parse kernel version " + release)
 	}
@@ -625,6 +623,7 @@ func ParseRelease(release string) (*KernelVersionInfo, error) {
 		Kernel: kernel,
 		Major:  major,
 		Minor:  minor,
+		Flavor: flavor,
 	}, nil
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -560,7 +560,7 @@ func (k *KernelVersionInfo) String() string {
 }
 
 // Compare two KernelVersionInfo struct.
-// Returns -1 if a < b, = if a == b, 1 it a > b
+// Returns -1 if a < b, 0 if a == b, 1 it a > b
 func CompareKernelVersion(a, b *KernelVersionInfo) int {
 	if a.Kernel < b.Kernel {
 		return -1

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -614,6 +614,8 @@ func ParseRelease(release string) (*KernelVersionInfo, error) {
 		flavor                       string
 	)
 
+	// Ignore error from Sscanf to allow an empty flavor.  Instead, just
+	// make sure we got all the version numbers.
 	parsed, _ = fmt.Sscanf(release, "%d.%d.%d%s", &kernel, &major, &minor, &flavor)
 	if parsed < 3 {
 		return nil, errors.New("Can't parse kernel version " + release)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -609,28 +609,22 @@ func GetKernelVersion() (*KernelVersionInfo, error) {
 
 func ParseRelease(release string) (*KernelVersionInfo, error) {
 	var (
-		parts [3]int
-		err   error
+		kernel, major, minor, parsed int
+		err                          error
 	)
 
-	re := regexp.MustCompile(`^([0-9]+)\.([0-9]+)\.([0-9]+)`)
-	subs := re.FindStringSubmatch(release)
-
-	if len(subs) < 4 {
+	parsed, err = fmt.Sscanf(release, "%d.%d.%d", &kernel, &major, &minor)
+	if err != nil {
+		return nil, err
+	}
+	if parsed < 3 {
 		return nil, errors.New("Can't parse kernel version " + release)
 	}
 
-	for i := 0; i < 3; i++ {
-		parts[i], err = strconv.Atoi(subs[i+1])
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return &KernelVersionInfo{
-		Kernel: parts[0],
-		Major:  parts[1],
-		Minor:  parts[2],
+		Kernel: kernel,
+		Major:  major,
+		Minor:  minor,
 	}, nil
 }
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -237,16 +237,16 @@ func TestCompareKernelVersion(t *testing.T) {
 		&KernelVersionInfo{Kernel: 2, Major: 6, Minor: 0},
 		1)
 	assertKernelVersion(t,
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "0"},
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "16"},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
 		0)
 	assertKernelVersion(t,
 		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 5},
 		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
 		1)
 	assertKernelVersion(t,
-		&KernelVersionInfo{Kernel: 3, Major: 0, Minor: 20, Flavor: "25"},
-		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "0"},
+		&KernelVersionInfo{Kernel: 3, Major: 0, Minor: 20},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
 		-1)
 }
 
@@ -412,9 +412,9 @@ func assertParseRelease(t *testing.T, release string, b *KernelVersionInfo, resu
 func TestParseRelease(t *testing.T) {
 	assertParseRelease(t, "3.8.0", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0}, 0)
 	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54}, 0)
-	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54, Flavor: "1"}, 0)
-	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "19-generic"}, 0)
-	assertParseRelease(t, "3.12.8tag", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 8, Flavor: "tag"}, 0)
+	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54}, 0)
+	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0}, 0)
+	assertParseRelease(t, "3.12.8tag", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 8}, 0)
 }
 
 func TestParsePortMapping(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -407,14 +407,17 @@ func assertParseRelease(t *testing.T, release string, b *KernelVersionInfo, resu
 	if r := CompareKernelVersion(a, b); r != result {
 		t.Fatalf("Unexpected kernel version comparison result. Found %d, expected %d", r, result)
 	}
+	if a.Flavor != b.Flavor {
+		t.Fatalf("Unexpected parsed kernel flavor.  Found %s, expected %s", a.Flavor, b.Flavor)
+	}
 }
 
 func TestParseRelease(t *testing.T) {
 	assertParseRelease(t, "3.8.0", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0}, 0)
-	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54}, 0)
-	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54}, 0)
-	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0}, 0)
-	assertParseRelease(t, "3.12.8tag", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 8}, 0)
+	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54, Flavor: ".longterm-1"}, 0)
+	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54, Flavor: ".longterm-1"}, 0)
+	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "-19-generic"}, 0)
+	assertParseRelease(t, "3.12.8tag", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 8, Flavor: "tag"}, 0)
 }
 
 func TestParsePortMapping(t *testing.T) {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -414,6 +414,7 @@ func TestParseRelease(t *testing.T) {
 	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54}, 0)
 	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54, Flavor: "1"}, 0)
 	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "19-generic"}, 0)
+	assertParseRelease(t, "3.12.8tag", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 8, Flavor: "tag"}, 0)
 }
 
 func TestParsePortMapping(t *testing.T) {


### PR DESCRIPTION
This fixes parsing unconventional kernel versions by just grabbing the digits from the version string.  #3628 is the immediate bug fixed here, but this should also make the version parsing more robust from future bugs similar to the already-fixed #455 and #1643.

In this patch, I just removed the Flavor string from KernelVersionInfo, as it didn't seem to be used anywhere, and if it was supposed to be informative, it didn't seem to contain useful info in many cases (e.g. 1.2.3+-flavor or 1.2.3flavor).  Parsing the version string now just grabs the first 3 digit groupings, ignoring anything non-numeric that comes after it.  If it's desirable to keep the Flavor around, it wouldn't be too hard to re-add it, but it would seem that we need to define how it should look given all the different separators (or lack thereof) possible in kernel version strings in the wild.

Also I snuck in a typo fix.  :)
