### PR TITLE
Fix handling of shared roots

### DIFF
--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -111,6 +111,9 @@ func (d *driver) Run(c *execdriver.Process, startCallback execdriver.StartCallba
 		params = append(params, "-w", c.WorkingDir)
 	}
 
+	params = append(params, "--", c.Entrypoint)
+	params = append(params, c.Arguments...)
+
 	if d.sharedRoot {
 		// lxc-start really needs / to be non-shared, or all kinds of stuff break
 		// when lxc-start unmount things and those unmounts propagate to the main
@@ -126,9 +129,6 @@ func (d *driver) Run(c *execdriver.Process, startCallback execdriver.StartCallba
 			"unshare", "-m", "--", "/bin/sh", "-c", shellString,
 		}
 	}
-
-	params = append(params, "--", c.Entrypoint)
-	params = append(params, c.Arguments...)
 
 	var (
 		name = params[0]


### PR DESCRIPTION
If rootIsShared() is detected we apply the shell stuff to early, before
the real command and arguments are added to the parameters. This
means they get passed on to unshare rather than docker-init, breaking
docker on e.g. fedora like:

goroutine 1 [running]:
runtime.panic(0x678340, 0x9b3fd7)
    /usr/lib64/golang/src/pkg/runtime/panic.c:266 +0xb6
github.com/dotcloud/docker/execdriver/lxc.func·001(0xc21000a1b0, 0xc21001eab0, 0x7fff24715faf)
    /home/alex/vcs/go/src/github.com/dotcloud/docker/execdriver/lxc/driver.go:41 +0x525
github.com/dotcloud/docker/sysinit.executeProgram(0xc21000a1b0, 0xc21000a1b0, 0xa)
    /home/alex/vcs/go/src/github.com/dotcloud/docker/sysinit/sysinit.go:34 +0xca
github.com/dotcloud/docker/sysinit.SysInit()
    /home/alex/vcs/go/src/github.com/dotcloud/docker/sysinit/sysinit.go:88 +0x791
main.main()
    /home/alex/vcs/go/src/github.com/dotcloud/docker/dockerinit/dockerinit.go:14 +0x1a

The fix is to construct the full params array before escaping it.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
