### PR TITLE
Add a -s option to the kill command to specify a signal.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -942,7 +942,9 @@ func (cli *DockerCli) CmdRm(args ...string) error {
 
 // 'docker kill NAME' kills a running container
 func (cli *DockerCli) CmdKill(args ...string) error {
-	cmd := cli.Subcmd("kill", "CONTAINER [CONTAINER...]", "Kill a running container (send SIGKILL)")
+	cmd := cli.Subcmd("kill", "[OPTIONS] CONTAINER [CONTAINER...]", "Kill a running container (send SIGKILL, or specified signal)")
+	signal := cmd.String([]string{"s", "-signal"}, "KILL", "Signal to send to the container")
+
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -952,8 +954,8 @@ func (cli *DockerCli) CmdKill(args ...string) error {
 	}
 
 	var encounteredError error
-	for _, name := range args {
-		if _, _, err := readBody(cli.call("POST", "/containers/"+name+"/kill", nil, false)); err != nil {
+	for _, name := range cmd.Args() {
+		if _, _, err := readBody(cli.call("POST", fmt.Sprintf("/containers/%s/kill?signal=%s", name, *signal), nil, false)); err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			encounteredError = fmt.Errorf("Error: failed to kill one or more containers")
 		} else {

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -754,11 +754,13 @@ we ask for the ``HostPort`` field to get the public address.
 
 ::
 
-    Usage: docker kill CONTAINER [CONTAINER...]
+    Usage: docker kill [OPTIONS] CONTAINER [CONTAINER...]
 
-    Kill a running container (Send SIGKILL)
+    Kill a running container (send SIGKILL, or specified signal)
 
-The main process inside the container will be sent SIGKILL.
+      -s, --signal="KILL": Signal to send to the container
+
+The main process inside the container will be sent SIGKILL, or any signal specified with option ``--signal``.
 
 Known Issues (kill)
 ~~~~~~~~~~~~~~~~~~~

--- a/integration/commands_test.go
+++ b/integration/commands_test.go
@@ -12,7 +12,9 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -90,17 +92,24 @@ func setTimeout(t *testing.T, msg string, d time.Duration, f func()) {
 	}
 }
 
+func expectPipe(expected string, r io.Reader) error {
+	o, err := bufio.NewReader(r).ReadString('\n')
+	if err != nil {
+		return err
+	}
+	if strings.Trim(o, " \r\n") != expected {
+		return fmt.Errorf("Unexpected output. Expected [%s], received [%s]", expected, o)
+	}
+	return nil
+}
+
 func assertPipe(input, output string, r io.Reader, w io.Writer, count int) error {
 	for i := 0; i < count; i++ {
 		if _, err := w.Write([]byte(input)); err != nil {
 			return err
 		}
-		o, err := bufio.NewReader(r).ReadString('\n')
-		if err != nil {
+		if err := expectPipe(output, r); err != nil {
 			return err
-		}
-		if strings.Trim(o, " \r\n") != output {
-			return fmt.Errorf("Unexpected output. Expected [%s], received [%s]", output, o)
 		}
 	}
 	return nil
@@ -1030,4 +1039,67 @@ func TestContainerOrphaning(t *testing.T) {
 		}
 	}
 
+}
+
+func TestCmdKill(t *testing.T) {
+	stdin, stdinPipe := io.Pipe()
+	stdout, stdoutPipe := io.Pipe()
+
+	cli := docker.NewDockerCli(stdin, stdoutPipe, ioutil.Discard, testDaemonProto, testDaemonAddr)
+	cli2 := docker.NewDockerCli(nil, ioutil.Discard, ioutil.Discard, testDaemonProto, testDaemonAddr)
+	defer cleanup(globalEngine, t)
+
+	ch := make(chan struct{})
+	go func() {
+		defer close(ch)
+		cli.CmdRun("-i", "-t", unitTestImageID, "sh", "-c", "trap 'echo SIGUSR1' USR1; trap 'echo SIGUSR2' USR2; echo Ready; while true; do read; done")
+	}()
+
+	container := waitContainerStart(t, 10*time.Second)
+
+	setTimeout(t, "Read Ready timed out", 3*time.Second, func() {
+		if err := expectPipe("Ready", stdout); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	setTimeout(t, "SIGUSR1 timed out", 2*time.Second, func() {
+		for i := 0; i < 10; i++ {
+			if err := cli2.CmdKill("-s", strconv.Itoa(int(syscall.SIGUSR1)), container.ID); err != nil {
+				t.Fatal(err)
+			}
+			if err := expectPipe("SIGUSR1", stdout); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+
+	setTimeout(t, "SIGUSR2 timed out", 2*time.Second, func() {
+		for i := 0; i < 10; i++ {
+			if err := cli2.CmdKill("--signal=USR2", container.ID); err != nil {
+				t.Fatal(err)
+			}
+			if err := expectPipe("SIGUSR2", stdout); err != nil {
+				t.Fatal(err)
+			}
+		}
+	})
+
+	time.Sleep(500 * time.Millisecond)
+	if !container.State.IsRunning() {
+		t.Fatal("The container should be still running")
+	}
+
+	setTimeout(t, "Waiting for container timedout", 5*time.Second, func() {
+		if err := cli2.CmdKill(container.ID); err != nil {
+			t.Fatal(err)
+		}
+
+		<-ch
+		if err := cli2.CmdWait(container.ID); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	closeWrap(stdin, stdinPipe, stdout, stdoutPipe)
 }


### PR DESCRIPTION
This PR adds a `-s`/`--signal` option to the kill command.
I realized after writing it that this had already be done in #2416. However my PR supports signal names and has tests.

```
docker kill -s HUP f242b566d9f5
docker kill -s 10 f242b566d9f5
```
