### PR TITLE
add merge volumes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,6 +45,7 @@ Caleb Spare <cespare@gmail.com>
 Calen Pennington <cale@edx.org>
 Carl X. Su <bcbcarl@gmail.com>
 Charles Hooper <charles.hooper@dotcloud.com>
+Cheney Deng <cheneydeng@qq.com>
 Christopher Currie <codemonkey+github@gmail.com>
 Christopher Rigor <crigor@gmail.com>
 Christophe Troestler <christophe.Troestler@umons.ac.be>

--- a/commands.go
+++ b/commands.go
@@ -1765,11 +1765,12 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flLinks   = NewListOpts(ValidateLink)
 		flEnv     = NewListOpts(ValidateEnv)
 
-		flPublish     ListOpts
-		flExpose      ListOpts
-		flDns         ListOpts
-		flVolumesFrom ListOpts
-		flLxcOpts     ListOpts
+		flPublish      ListOpts
+		flExpose       ListOpts
+		flDns          ListOpts
+		flVolumesFrom  ListOpts
+		flVolumesMerge = ListOpts
+		flLxcOpts      ListOpts
 
 		flAutoRemove      = cmd.Bool([]string{"#rm", "-rm"}, false, "Automatically remove the container when it exits (incompatible with -d)")
 		flDetach          = cmd.Bool([]string{"d", "-detach"}, false, "Detached mode: Run container in the background, print new container id")
@@ -1800,6 +1801,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	cmd.Var(&flExpose, []string{"#expose", "-expose"}, "Expose a port from the container without publishing it to your host")
 	cmd.Var(&flDns, []string{"#dns", "-dns"}, "Set custom dns servers")
 	cmd.Var(&flVolumesFrom, []string{"#volumes-from", "-volumes-from"}, "Mount volumes from the specified container(s)")
+	cmd.Var(&flVolumesMerge, []string{"#volumes-merge", "-volumes-merge"}, "Merge host directory and container directory")
 	cmd.Var(&flLxcOpts, []string{"#lxc-conf", "-lxc-conf"}, "Add custom lxc options -lxc-conf=\"lxc.cgroup.cpuset.cpus = 0,1\"")
 
 	if err := cmd.Parse(args); err != nil {
@@ -1925,6 +1927,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		Image:           image,
 		Volumes:         flVolumes.GetMap(),
 		VolumesFrom:     strings.Join(flVolumesFrom.GetAll(), ","),
+		VolumesMerge:    strings.Join(flVolumesMerge.GetAll(), ","),
 		Entrypoint:      entrypoint,
 		WorkingDir:      *flWorkingDir,
 	}

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1018,7 +1018,8 @@ image is removed.
       -u, --user="": Username or UID
       --dns=[]: Set custom dns servers for the container
       -v, --volume=[]: Create a bind mount to a directory or file with: [host-path]:[container-path]:[rw|ro]. If a directory "container-path" is missing, then docker creates a new volume.
-      --volumes-from="": Mount all volumes from the given container(s)
+      --volumes-from="": Mount all volumes from the given container(s) with: [containerID1]:[ro|rw],[containerID2]:[ro|rw].
+      --volumes-merge="": Merge host directory with the given directory in container with: [host-dir]:[container-dir].
       --entrypoint="": Overwrite the default entrypoint set by the image
       -w, --workdir="": Working directory inside the container
       --lxc-conf=[]: Add custom lxc options -lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"

--- a/integration/container_test.go
+++ b/integration/container_test.go
@@ -1712,7 +1712,7 @@ func TestVolumesMerge(t *testing.T) {
 		&docker.Config{
 			Image:        GetTestImage(runtime).ID,
 			Cmd:          []string{"/bin/echo", "-n", "foobar"},
-			VolumesMerge: mergeSourceDir + ":" + "/",
+			VolumesMerge: mergeSourceDir + ":/",
 		},
 		"",
 	)

--- a/utils/fs.go
+++ b/utils/fs.go
@@ -51,7 +51,8 @@ func FollowSymlinkInScope(link, root string) (string, error) {
 		return "", err
 	}
 
-	if !strings.HasPrefix(filepath.Dir(link), root) {
+	//in the rootfs or is the "/"
+	if !strings.HasPrefix(filepath.Dir(link), root) && root != link {
 		return "", fmt.Errorf("%s is not within %s", link, root)
 	}
 


### PR DESCRIPTION
the docker version now is not support that merge one source directory's contents with the target directory's contents in the container,you can only bind mount the source into the target directory while the target directory contents hidden with "bind" or mount the source directory in another fresh new directory in the container with "volumes-from".

this issue fixes this problem,it merges the source contents with the target contents.

here is the issue 3710
