### PR TITLE
add merge volumes feature

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,6 +45,7 @@ Caleb Spare <cespare@gmail.com>
 Calen Pennington <cale@edx.org>
 Carl X. Su <bcbcarl@gmail.com>
 Charles Hooper <charles.hooper@dotcloud.com>
+Cheney Deng <cheneydeng@qq.com>
 Christopher Currie <codemonkey+github@gmail.com>
 Christopher Rigor <crigor@gmail.com>
 Christophe Troestler <christophe.Troestler@umons.ac.be>

--- a/commands.go
+++ b/commands.go
@@ -1765,11 +1765,12 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flLinks   = NewListOpts(ValidateLink)
 		flEnv     = NewListOpts(ValidateEnv)
 
-		flPublish     ListOpts
-		flExpose      ListOpts
-		flDns         ListOpts
-		flVolumesFrom ListOpts
-		flLxcOpts     ListOpts
+		flPublish      ListOpts
+		flExpose       ListOpts
+		flDns          ListOpts
+		flVolumesFrom  ListOpts
+		flVolumesMerge = ListOpts
+		flLxcOpts      ListOpts
 
 		flAutoRemove      = cmd.Bool([]string{"#rm", "-rm"}, false, "Automatically remove the container when it exits (incompatible with -d)")
 		flDetach          = cmd.Bool([]string{"d", "-detach"}, false, "Detached mode: Run container in the background, print new container id")
@@ -1800,6 +1801,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	cmd.Var(&flExpose, []string{"#expose", "-expose"}, "Expose a port from the container without publishing it to your host")
 	cmd.Var(&flDns, []string{"#dns", "-dns"}, "Set custom dns servers")
 	cmd.Var(&flVolumesFrom, []string{"#volumes-from", "-volumes-from"}, "Mount volumes from the specified container(s)")
+	cmd.Var(&flVolumesMerge, []string{"#volumes-merge", "-volumes-merge"}, "Merge host directory and container directory")
 	cmd.Var(&flLxcOpts, []string{"#lxc-conf", "-lxc-conf"}, "Add custom lxc options -lxc-conf=\"lxc.cgroup.cpuset.cpus = 0,1\"")
 
 	if err := cmd.Parse(args); err != nil {
@@ -1925,6 +1927,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		Image:           image,
 		Volumes:         flVolumes.GetMap(),
 		VolumesFrom:     strings.Join(flVolumesFrom.GetAll(), ","),
+		VolumesMerge:    strings.Join(flVolumesMerge.GetAll(), ","),
 		Entrypoint:      entrypoint,
 		WorkingDir:      *flWorkingDir,
 	}

--- a/commands.go
+++ b/commands.go
@@ -1769,7 +1769,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flExpose       ListOpts
 		flDns          ListOpts
 		flVolumesFrom  ListOpts
-		flVolumesMerge = ListOpts
+		flVolumesMerge ListOpts
 		flLxcOpts      ListOpts
 
 		flAutoRemove      = cmd.Bool([]string{"#rm", "-rm"}, false, "Automatically remove the container when it exits (incompatible with -d)")

--- a/container.go
+++ b/container.go
@@ -982,7 +982,7 @@ func (container *Container) mergeVolumes() error {
 				}
 
 				for vpath, _ := range c.Volumes {
-					srcPath = path.Join(c.RootfsPath(), vpath)
+					srcPath = vpath
 					if err := archive.CopyWithTar(srcPath, rootVolPath); err != nil {
 						return err
 					}

--- a/container.go
+++ b/container.go
@@ -957,6 +957,7 @@ func (container *Container) mergeVolumes() error {
 		}
 
 		for volPath, source := range container.VolumesMerge {
+			shortVolPath := volPath
 			volPath = path.Join(container.RootfsPath(), volPath)
 			rootVolPath, err := utils.FollowSymlinkInScope(volPath, container.RootfsPath())
 			if err != nil {
@@ -970,7 +971,7 @@ func (container *Container) mergeVolumes() error {
 			}
 
 			srcPath := source
-			if !mergeContainer[volPath] {
+			if !mergeContainer[shortVolPath] {
 				if err := archive.CopyWithTar(srcPath, rootVolPath); err != nil {
 					return err
 				}

--- a/container.go
+++ b/container.go
@@ -981,8 +981,8 @@ func (container *Container) mergeVolumes() error {
 					return fmt.Errorf("Container %s not found. Impossible to merge its volumes", source)
 				}
 
-				for vpath, _ := range c.Volumes {
-					srcPath = vpath
+				for _, id := range c.Volumes {
+					srcPath = id
 					if err := archive.CopyWithTar(srcPath, rootVolPath); err != nil {
 						return err
 					}

--- a/container.go
+++ b/container.go
@@ -975,12 +975,12 @@ func (container *Container) mergeVolumes() error {
 					return err
 				}
 			} else {
-				c, err := container.runtime.Get(source)
-				if err != nil {
+				c := container.runtime.Get(source)
+				if c == nil {
 					return fmt.Errorf("Container %s not found. Impossible to merge its volumes", source)
 				}
 
-				for vpath, id := range c.Volumes {
+				for vpath, _ := range c.Volumes {
 					srcPath = path.Join(c.RootfsPath(), vpath)
 					if err := archive.CopyWithTar(srcPath, rootVolPath); err != nil {
 						return err

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1019,7 +1019,7 @@ image is removed.
       --dns=[]: Set custom dns servers for the container
       -v, --volume=[]: Create a bind mount to a directory or file with: [host-path]:[container-path]:[rw|ro]. If a directory "container-path" is missing, then docker creates a new volume.
       --volumes-from="": Mount all volumes from the given container(s) with: [containerID1]:[ro|rw],[containerID2]:[ro|rw].
-      --volumes-merge="": Merge host directory with the given directory in container with: [host-dir]:[container-dir].
+      --volumes-merge="": Merge host contents or other containers' volumes with the given directory: [host-path|containerID]:[container-path]:[dir|container].
       --entrypoint="": Overwrite the default entrypoint set by the image
       -w, --workdir="": Working directory inside the container
       --lxc-conf=[]: Add custom lxc options -lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1018,7 +1018,8 @@ image is removed.
       -u, --user="": Username or UID
       --dns=[]: Set custom dns servers for the container
       -v, --volume=[]: Create a bind mount to a directory or file with: [host-path]:[container-path]:[rw|ro]. If a directory "container-path" is missing, then docker creates a new volume.
-      --volumes-from="": Mount all volumes from the given container(s)
+      --volumes-from="": Mount all volumes from the given container(s) with: [containerID1]:[ro|rw],[containerID2]:[ro|rw].
+      --volumes-merge="": Merge host directory with the given directory in container with: [host-dir]:[container-dir].
       --entrypoint="": Overwrite the default entrypoint set by the image
       -w, --workdir="": Working directory inside the container
       --lxc-conf=[]: Add custom lxc options -lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"

--- a/integration/container_test.go
+++ b/integration/container_test.go
@@ -1691,6 +1691,48 @@ func TestMultipleVolumesFrom(t *testing.T) {
 	}
 }
 
+func TestVolumesMerge(t *testing.T) {
+	runtime := mkRuntime(t)
+	defer nuke(runtime)
+
+	mergeSourceDir := "/tmp/mergevolumes"
+	if err := os.MkdirAll(mergeSourceDir, 0700); err != nil {
+		t.Fatal(err)
+	} else {
+		if _, err := os.OpenFile(mergeSourceDir+"test", os.O_CREATE|os.O_RDWR, 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	defer func() {
+		os.RemoveAll(mergeSourceDir)
+	}()
+
+	//merge into "/"
+	container, _, err := runtime.Create(
+		&docker.Config{
+			Image:        GetTestImage(runtime).ID,
+			Cmd:          []string{"/bin/echo", "-n", "foobar"},
+			VolumesMerge: mergeSourceDir + ":/",
+		},
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer runtime.Destroy(container)
+
+	out, err := container.Output()
+	if err != nil {
+		t.Fatal(err)
+	} else if string(out) != "foobar" {
+		t.Fail()
+	}
+
+	if container.VolumesMerge["/"] != mergeSourceDir {
+		t.Fail()
+	}
+}
+
 func TestRestartGhost(t *testing.T) {
 	runtime := mkRuntime(t)
 	defer nuke(runtime)

--- a/utils/fs.go
+++ b/utils/fs.go
@@ -51,7 +51,8 @@ func FollowSymlinkInScope(link, root string) (string, error) {
 		return "", err
 	}
 
-	if !strings.HasPrefix(filepath.Dir(link), root) {
+	//in the rootfs or is the "/"
+	if !strings.HasPrefix(filepath.Dir(link), root) && root != link {
 		return "", fmt.Errorf("%s is not within %s", link, root)
 	}
 


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: cheneydeng cheneydeng@qq.com (github: cheneydeng)

the docker version now does not support to merge one source directory's contents with the target directory's contents in the container,we can only bind mount the source into the target while the target directory contents be hidden with "bind" or mount the whole volumes of another container in a fresh new directory in the container with "volumes-from".

this issue fixes this problem,it merges the source contents with the target contents.
here is the issue #3710
