### PR TITLE
Ignore file headers from add sums

### DIFF
--- a/archive/wrap.go
+++ b/archive/wrap.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"code.google.com/p/go/src/pkg/archive/tar"
 	"io/ioutil"
+	"time"
 )
 
 // Generate generates a new archive from the content provided
@@ -31,6 +32,7 @@ func Generate(input ...string) (Archive, error) {
 		hdr := &tar.Header{
 			Name: name,
 			Size: int64(len(content)),
+			ModTime: time.Now(),
 		}
 		if err := tw.WriteHeader(hdr); err != nil {
 			return nil, err

--- a/archive/wrap.go
+++ b/archive/wrap.go
@@ -30,8 +30,8 @@ func Generate(input ...string) (Archive, error) {
 	for _, file := range files {
 		name, content := file[0], file[1]
 		hdr := &tar.Header{
-			Name: name,
-			Size: int64(len(content)),
+			Name:    name,
+			Size:    int64(len(content)),
 			ModTime: time.Now(),
 		}
 		if err := tw.WriteHeader(hdr); err != nil {

--- a/buildfile.go
+++ b/buildfile.go
@@ -724,7 +724,7 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 		return "", err
 	}
 
-	b.context = &utils.TarSum{Reader: decompressedStream, DisableCompression: true}
+	b.context = &utils.TarSum{Reader: decompressedStream, DisableCompression: true, IgnoreHeaders: true}
 	if err := archive.Untar(b.context, tmpdirPath, nil); err != nil {
 		return "", err
 	}

--- a/utils/tarsum.go
+++ b/utils/tarsum.go
@@ -26,7 +26,7 @@ type TarSum struct {
 	finished           bool
 	first              bool
 	DisableCompression bool
-	IgnoreHeaders     bool
+	IgnoreHeaders      bool
 }
 
 type writeCloseFlusher interface {
@@ -47,7 +47,7 @@ func (n *nopCloseFlusher) Flush() error {
 }
 
 func (ts *TarSum) encodeHeader(h *tar.Header) error {
- 	if ts.IgnoreHeaders {
+	if ts.IgnoreHeaders {
 		return nil
 	}
 	for _, elem := range [][2]string{

--- a/utils/tarsum.go
+++ b/utils/tarsum.go
@@ -26,6 +26,7 @@ type TarSum struct {
 	finished           bool
 	first              bool
 	DisableCompression bool
+	IgnoreHeaders     bool
 }
 
 type writeCloseFlusher interface {
@@ -46,6 +47,9 @@ func (n *nopCloseFlusher) Flush() error {
 }
 
 func (ts *TarSum) encodeHeader(h *tar.Header) error {
+ 	if ts.IgnoreHeaders {
+		return nil
+	}
 	for _, elem := range [][2]string{
 		{"name", h.Name},
 		{"mode", strconv.Itoa(int(h.Mode))},


### PR DESCRIPTION
There are several issues and comments regarding the caching (or not) of ADDed files.

For us it was a problem that all the metadata in the files was being used (which includes not only timestamps, but also things like permissions, user names, device…).

Looking at the tests, it looks like this was never the intention, but the existing test setup did not reveal the issue.

The first commit in the PR is used to make the test fail (just add a non-constant timestamp to the test data files).
The second commit is the actual fix.

Fixes #3699
