### PR TITLE
ExpandEnv for ENTRYPOINT and CMD in runtime

### DIFF
--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -27,6 +27,10 @@ func setupEnv(args *execdriver.InitArgs) {
 
 func executeProgram(args *execdriver.InitArgs) error {
 	setupEnv(args)
+	//After setting the Environment, evaluate env variables in args
+	for i, arg := range args.Args {
+		args.Args[i] = os.ExpandEnv(arg)
+	}
 	dockerInitFct, err := execdriver.GetInitFunc(args.Driver)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
The issues are discussed here,
https://groups.google.com/forum/#!topic/docker-user/tnscIyLxXVA
and here,
https://groups.google.com/forum/#!topic/docker-user/Hrt5SQgiB5E

> Feature: Evaluate Env variables before a command (from Cmd or Entrypoint) is invoked inside a container.

ENTRYPOINT ["./executable", "$VAR"]
CMD ["--host=$VAR"]

`$VAR` gets evaluated to it's corresponding value in the container's `env` during `runtime`. 

With this we can do things like, 

```
docker run imagename ./executable --host \$VAR
```

with the `$` escaped in the host, and it will be executed in the container's environment. 

Tried tracing how a command is invoked within the container. But failed somewhere and ended up modifying the code responsible for building - buildfile.go - the function `buildCmdFromJson()` and included `os.ExpandEnv(args)` which converts the `env` vars in the string `args` to their corresponding values.
