### PR TITLE
Fix TOC for Articles

### DIFF
--- a/docs/sources/articles/index.rst
+++ b/docs/sources/articles/index.rst
@@ -4,7 +4,8 @@
 
 .. _articles_list:
 
-Contents:
+Articles
+========
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Sample build running here: http://metalivedoc.readthedocs.org/en/fixarticles/
Compare entries in TOC after "Glossary" to what is currently on Master: http://docs.docker.io/en/master/
