### PR TITLE
network: remove unnecessary links iptables rule for return traffic

### DIFF
--- a/links.go
+++ b/links.go
@@ -131,18 +131,6 @@ func (l *Link) toggle(action string, ignoreErrors bool) error {
 		} else if len(output) != 0 {
 			return fmt.Errorf("Error toggle iptables forward: %s", output)
 		}
-
-		if output, err := iptables.Raw(action, "FORWARD",
-			"-i", l.BridgeInterface, "-o", l.BridgeInterface,
-			"-p", p.Proto(),
-			"-s", l.ChildIP,
-			"--sport", p.Port(),
-			"-d", l.ParentIP,
-			"-j", "ACCEPT"); !ignoreErrors && err != nil {
-			return err
-		} else if len(output) != 0 {
-			return fmt.Errorf("Error toggle iptables forward: %s", output)
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
This at least partially fixes #3416.

Currently there are two iptables rules per port for each link: one to 
allow the parent to connect to the child's port, and another one to
allow return traffic from the child back to the parent.  The second rule
shouldn't be needed because the "ctstate RELATED,ESTABLISHED" rule can
already allow all established traffic.

So this patch does the following:
1. Move the RELATED,ESTABLISHED rule to be _before_ the potential
   inter-container communication DROP rule so it will work for
   inter-container traffic as well.  Since we're inserting, everything
   is reversed chronologically so it should be inserted _after_ we
   insert the DROP.  This also has a small performance benefit because
   it will be processed earlier and it's generally one of the most
   commonly used rules.
2. Get rid of the unnecessary return traffic rule per link.
3. Also move the other "Accept all non-intercontainer outgoing packets"
   rule to earlier.  This gives a small performance benefit since it's
   also a commonly used rule, and it makes sense to logically group it
   next to the ctstate rule.
