### PR TITLE
Use exec to replace bash with apache2 after environment is set up

### DIFF
--- a/docs/sources/examples/using_supervisord.rst
+++ b/docs/sources/examples/using_supervisord.rst
@@ -70,7 +70,7 @@ Let's see what is inside our ``supervisord.conf`` file.
     command=/usr/sbin/sshd -D
 
     [program:apache2]
-    command=/bin/bash -c "source /etc/apache2/envvars && /usr/sbin/apache2 -DFOREGROUND"
+    command=/bin/bash -c "source /etc/apache2/envvars && exec /usr/sbin/apache2 -DFOREGROUND"
 
 The ``supervisord.conf`` configuration file contains directives that configure
 Supervisor and the processes it manages. The first block ``[supervisord]``


### PR DESCRIPTION
In the example, bash is used to run a script that populates the environment and then to spawn apache2.  The result of the original command is that bash stays running as a child of supervisord, and apache2 is a child of bash.  

This change adds `exec` so that after bash does its work of setting up the environment, the bash process is replaced with apache2.  This allows supervisord to manage apache2 directly.  This page isn't intended as a comprehensive guide to configuring Supervisor but making this change wouldn't hurt either.
