### PR TITLE
FIX #3783: Release the push lock after the image push is completed

### DIFF
--- a/server.go
+++ b/server.go
@@ -1643,6 +1643,8 @@ func (srv *Server) ImagePush(job *engine.Job) engine.Status {
 		job.Error(err)
 		return engine.StatusErr
 	}
+	defer srv.poolRemove("push", localName)
+
 	// Resolve the Repository name from fqn to endpoint + name
 	endpoint, remoteName, err := registry.ResolveRepositoryName(localName)
 	if err != nil {


### PR DESCRIPTION
This PR just mimics the implementation used for image pull: https://github.com/dotcloud/docker/blob/master/server.go#L1428-L1439

Fixes #3783
