### PR TITLE
Fix for issue #3786 `docker rm` unmounts in the wrong order

### DIFF
--- a/container.go
+++ b/container.go
@@ -1365,9 +1365,9 @@ func (container *Container) Unmount() error {
 		mounts = append(mounts, path.Join(root, r))
 	}
 
-	for _, m := range mounts {
-		if lastError := mount.Unmount(m); lastError != nil {
-			err = lastError
+	for i := len(mounts) - 1; i >= 0; i-- {
+		if lastError := mount.Unmount(mounts[i]); lastError != nil {
+			err = fmt.Errorf("Failed to umount %v: %v", mounts[i], lastError)
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
This is a fix for the case that one mount is inside another mount and docker
can't then delete the resulting container.

Docker-DCO-1.1-Signed-off-by: Peter Waller p@pwaller.net (github: pwaller)

Fixes #3786

/cc @drj11

I've tested this, and it fixes the issue for the case reported in the original
bug.
