### PR TITLE
Fix for #3674 Can't `rm` containers when disk full

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -231,6 +231,7 @@ Paul Morie <pmorie@gmail.com>
 Paul Nasrat <pnasrat@gmail.com>
 Paul <paul9869@gmail.com>
 Peter Braden <peterbraden@peterbraden.co.uk>
+Peter Waller <p@pwaller.net>
 Phil Spitler <pspitler@gmail.com>
 Pierre-Alain RIVIERE <pariviere@ippon.fr>
 Piotr Bogdan <ppbogdan@gmail.com>


### PR DESCRIPTION
Rather than creating a new directory and moving it there before deleting that
new directory, just move the directory we intend to delete.

In the old way, the Mkdirall could fail, which meant that you couldn't delete
containers when the disk was full.

Tested.

Docker-DCO-1.1-Signed-off-by: Peter Waller p@pwaller.net (github: pwaller)

Fixes #3674

/cc @drj11
