### PR TITLE
exexdriver: Make Command.GetExitCode an internal call

### DIFF
--- a/execdriver/chroot/driver.go
+++ b/execdriver/chroot/driver.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dotcloud/docker/pkg/mount"
 	"os"
 	"os/exec"
+	"syscall"
 )
 
 const (
@@ -67,7 +68,16 @@ func (d *driver) Run(c *execdriver.Command, startCallback execdriver.StartCallba
 	}
 
 	err = c.Wait()
-	return c.GetExitCode(), err
+	return getExitCode(c), err
+}
+
+/// Return the exit code of the process
+// if the process has not exited -1 will be returned
+func getExitCode(c *execdriver.Command) int {
+	if c.ProcessState == nil {
+		return -1
+	}
+	return c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
 }
 
 func (d *driver) Kill(p *execdriver.Command, sig int) error {

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -3,7 +3,6 @@ package execdriver
 import (
 	"errors"
 	"os/exec"
-	"syscall"
 )
 
 var (
@@ -108,13 +107,4 @@ func (c *Command) Pid() int {
 		return -1
 	}
 	return c.Process.Pid
-}
-
-// Return the exit code of the process
-// if the process has not exited -1 will be returned
-func (c *Command) GetExitCode() int {
-	if c.ProcessState == nil {
-		return -1
-	}
-	return c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
 }

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -169,7 +169,16 @@ func (d *driver) Run(c *execdriver.Command, startCallback execdriver.StartCallba
 
 	<-waitLock
 
-	return c.GetExitCode(), waitErr
+	return getExitCode(c), waitErr
+}
+
+/// Return the exit code of the process
+// if the process has not exited -1 will be returned
+func getExitCode(c *execdriver.Command) int {
+	if c.ProcessState == nil {
+		return -1
+	}
+	return c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
 }
 
 func (d *driver) Kill(c *execdriver.Command, sig int) error {


### PR DESCRIPTION
This code only works for backends that directly spawn the child
via the Command. It will not work for the libvirt backend. So
we move this code into the individual backends that need it.
