### PR TITLE
Fix unclear error message when deleting container

### DIFF
--- a/server.go
+++ b/server.go
@@ -1909,7 +1909,7 @@ func (srv *Server) ContainerDestroy(job *engine.Job) engine.Status {
 					continue
 				}
 				if err := srv.runtime.volumes.Delete(volumeId); err != nil {
-					job.Error(err)
+					job.Errorf("Error calling volumes.Delete(%q): %v", volumeId, err)
 					return engine.StatusErr
 				}
 			}


### PR DESCRIPTION
I was getting the following error:

```
$ bundles/0.7.6-dev/binary/docker-0.7.6-dev run -rm -v=/var/run:/foo base
echo hi hi 2014/01/28 14:24:46 Error: container_delete: No such id: run
```

This commit makes the true origin of the error clearer. Issue #3806 is 
tracking the cause of the error.

Docker-DCO-1.1-Signed-off-by: Peter Waller p@pwaller.net (github: pwaller)
