### PR TITLE
network: add publicly mapped ports to FORWARD table

### DIFF
--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -73,6 +73,23 @@ func (c *Chain) Forward(action Action, ip net.IP, port int, proto, dest_addr str
 	} else if len(output) != 0 {
 		return fmt.Errorf("Error iptables forward: %s", output)
 	}
+
+	fAction := action
+	if fAction == Add {
+		fAction = "-I"
+	}
+	if output, err := Raw(string(fAction), "FORWARD",
+		"!", "-i", c.Bridge,
+		"-o", c.Bridge,
+		"-p", proto,
+		"-d", daddr,
+		"--dport", strconv.Itoa(port),
+		"-j", "ACCEPT"); err != nil {
+		return err
+	} else if len(output) != 0 {
+		return fmt.Errorf("Error iptables forward: %s", output)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes #2840 
Fixes #3416.

Allow publicly mapped ports to be made public beyond the host.  This is
needed for distros like Fedora and RHEL which have a reject all rule at
the end of their FORWARD table.

Docker-DCO-1.1-Signed-off-by: Josh Poimboeuf jpoimboe@redhat.com (github: jpoimboe)
