### PR TITLE
remove ip_forward warning

### DIFF
--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -36,12 +36,6 @@ func New(quiet bool) *SysInfo {
 		}
 	}
 
-	content, err3 := ioutil.ReadFile("/proc/sys/net/ipv4/ip_forward")
-	sysInfo.IPv4ForwardingDisabled = err3 != nil || len(content) == 0 || content[0] != '1'
-	if sysInfo.IPv4ForwardingDisabled && !quiet {
-		log.Printf("WARNING: IPv4 forwarding is disabled.")
-	}
-
 	// Check if AppArmor seems to be enabled on this system.
 	if _, err := os.Stat("/sys/kernel/security/apparmor"); os.IsNotExist(err) {
 		sysInfo.AppArmor = false


### PR DESCRIPTION
Now that docker sets /proc/sys/net/ipv4/ip_forward by default (unless
the user manually specifies "-ip-forward=false"), there's no need to
warn if its disabled.

Docker-DCO-1.1-Signed-off-by: Josh Poimboeuf jpoimboe@redhat.com (github: jpoimboe)
