### PR TITLE
docs: remove ip_forward enabling step

### DIFF
--- a/docs/sources/installation/archlinux.rst
+++ b/docs/sources/installation/archlinux.rst
@@ -71,21 +71,3 @@ To start on system boot:
 ::
 
     sudo systemctl enable docker
-    
-Network Configuration
----------------------
-
-IPv4 packet forwarding is disabled by default on Arch, so internet access from inside
-the container may not work.
-
-To enable the forwarding, run as root on the host system:
-
-::
-
-    sysctl net.ipv4.ip_forward=1
-    
-And, to make it persistent across reboots, enable it on the host's **/etc/sysctl.d/docker.conf**:
-
-::
-
-    net.ipv4.ip_forward=1

--- a/docs/sources/installation/frugalware.rst
+++ b/docs/sources/installation/frugalware.rst
@@ -60,21 +60,3 @@ To start on system boot:
 ::
 
     sudo systemctl enable lxc-docker
-    
-Network Configuration
----------------------
-
-IPv4 packet forwarding is disabled by default on FrugalWare, so Internet access from inside
-the container may not work.
-
-To enable packet forwarding, run the following command as the ``root`` user on the host system:
-
-::
-
-    sysctl net.ipv4.ip_forward=1
-    
-And, to make it persistent across reboots, add the following to a file named **/etc/sysctl.d/docker.conf**:
-
-::
-
-    net.ipv4.ip_forward=1

--- a/docs/sources/installation/gentoolinux.rst
+++ b/docs/sources/installation/gentoolinux.rst
@@ -82,19 +82,3 @@ To start on system boot:
 .. code-block:: bash
 
    sudo systemctl enable docker.service
-
-Network Configuration
-^^^^^^^^^^^^^^^^^^^^^
-
-IPv4 packet forwarding is disabled by default, so internet access from inside
-the container will not work unless ``net.ipv4.ip_forward`` is enabled:
-
-.. code-block:: bash
-
-   sudo sysctl -w net.ipv4.ip_forward=1
-
-Or, to enable it more permanently:
-
-.. code-block:: bash
-
-   echo net.ipv4.ip_forward = 1 | sudo tee /etc/sysctl.d/docker.conf

--- a/docs/sources/installation/google.rst
+++ b/docs/sources/installation/google.rst
@@ -43,21 +43,14 @@
     $ gcutil ssh docker-playground
     docker-playground:~$ 
 
-5. Enable IP forwarding:
-
-.. code-block:: bash
-
-    docker-playground:~$ echo net.ipv4.ip_forward=1 | sudo tee /etc/sysctl.d/99-docker.conf 
-    docker-playground:~$ sudo sysctl --system
-
-6. Install the latest Docker release and configure it to start when the instance boots:
+5. Install the latest Docker release and configure it to start when the instance boots:
 
 .. code-block:: bash
 
     docker-playground:~$ curl get.docker.io | bash
     docker-playground:~$ sudo update-rc.d docker defaults
 
-7. If running in zones: ``us-central1-a``, ``europe-west1-1``, and ``europe-west1-b``, the docker daemon must be started with the ``-mtu`` flag. Without the flag, you may experience intermittent network pauses. 
+6. If running in zones: ``us-central1-a``, ``europe-west1-1``, and ``europe-west1-b``, the docker daemon must be started with the ``-mtu`` flag. Without the flag, you may experience intermittent network pauses. 
 `See this issue <https://code.google.com/p/google-compute-engine/issues/detail?id=57>`_ for more details.
 
 .. code-block:: bash
@@ -65,7 +58,7 @@
     docker-playground:~$ echo 'DOCKER_OPTS="$DOCKER_OPTS -mtu 1460"' | sudo tee -a /etc/default/docker
     docker-playground:~$ sudo service docker restart
 
-8. Start a new container:
+7. Start a new container:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Now that docker sets /proc/sys/net/ipv4/ip_forward by default, remove
the step to enable it in the installation docs.

Docker-DCO-1.1-Signed-off-by: Josh Poimboeuf jpoimboe@redhat.com (github: jpoimboe)
