### PR TITLE
add env to engine, remove all srv.runtime from the api

### DIFF
--- a/api.go
+++ b/api.go
@@ -563,7 +563,7 @@ func postContainersCreate(srv *Server, version float64, w http.ResponseWriter, r
 	if err != nil {
 		return err
 	}
-	if !job.GetenvBool("NetworkDisabled") && len(job.Getenv("Dns")) == 0 && len(srv.runtime.config.Dns) == 0 && utils.CheckLocalDns(resolvConf) {
+	if !job.GetenvBool("NetworkDisabled") && len(job.Getenv("Dns")) == 0 && len(srv.Eng.Env.GetList("config.Dns")) == 0 && utils.CheckLocalDns(resolvConf) {
 		out.Warnings = append(out.Warnings, fmt.Sprintf("Docker detected local DNS server on resolv.conf. Using default external servers: %v", defaultDns))
 		job.SetenvList("Dns", defaultDns)
 	}
@@ -580,16 +580,16 @@ func postContainersCreate(srv *Server, version float64, w http.ResponseWriter, r
 	for scanner.Scan() {
 		out.Warnings = append(out.Warnings, scanner.Text())
 	}
-	if job.GetenvInt("Memory") > 0 && !srv.runtime.sysInfo.MemoryLimit {
+	if job.GetenvInt("Memory") > 0 && !srv.Eng.Env.GetBool("sysInfo.MemoryLimit") {
 		log.Println("WARNING: Your kernel does not support memory limit capabilities. Limitation discarded.")
 		out.Warnings = append(out.Warnings, "Your kernel does not support memory limit capabilities. Limitation discarded.")
 	}
-	if job.GetenvInt("Memory") > 0 && !srv.runtime.sysInfo.SwapLimit {
+	if job.GetenvInt("Memory") > 0 && !srv.Eng.Env.GetBool("sysInfo.SwapLimit") {
 		log.Println("WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.")
 		out.Warnings = append(out.Warnings, "Your kernel does not support memory swap capabilities. Limitation discarded.")
 	}
 
-	if !job.GetenvBool("NetworkDisabled") && srv.runtime.sysInfo.IPv4ForwardingDisabled {
+	if !job.GetenvBool("NetworkDisabled") && srv.Eng.Env.GetBool("sysInfo.IPv4ForwardingDisabled") {
 		log.Println("Warning: IPv4 forwarding is disabled.")
 		out.Warnings = append(out.Warnings, "IPv4 forwarding is disabled.")
 	}
@@ -949,7 +949,7 @@ func makeHttpHandler(srv *Server, logging bool, localMethod string, localRoute s
 		if err != nil {
 			version = APIVERSION
 		}
-		if srv.runtime.config.EnableCors {
+		if srv.Eng.Env.GetBool("config.EnableCors") {
 			writeCorsHeaders(w, r)
 		}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -39,6 +39,7 @@ type Engine struct {
 	Stdout   io.Writer
 	Stderr   io.Writer
 	Stdin    io.Reader
+	Env      Env
 }
 
 func (eng *Engine) Root() string {

--- a/server.go
+++ b/server.go
@@ -65,8 +65,18 @@ func jobInitApi(job *engine.Job) engine.Status {
 		srv.Close()
 		os.Exit(0)
 	}()
+
+	//Variables used by the api endpoints
+	job.Eng.Env.SetList("config.Dns", srv.runtime.config.Dns)
+	job.Eng.Env.SetBool("sysInfo.MemoryLimit", srv.runtime.sysInfo.MemoryLimit)
+	job.Eng.Env.SetBool("sysInfo.SwapLimit", srv.runtime.sysInfo.SwapLimit)
+	job.Eng.Env.SetBool("sysInfo.IPv4ForwardingDisabled", srv.runtime.sysInfo.IPv4ForwardingDisabled)
+	job.Eng.Env.SetBool("config.EnableCors", srv.runtime.config.EnableCors)
+
+	//Only used my tests, TODO: remove
 	job.Eng.Hack_SetGlobalVar("httpapi.server", srv)
 	job.Eng.Hack_SetGlobalVar("httpapi.runtime", srv.runtime)
+
 	// https://github.com/dotcloud/docker/issues/2768
 	if srv.runtime.networkManager.bridgeNetwork != nil {
 		job.Eng.Hack_SetGlobalVar("httpapi.bridgeIP", srv.runtime.networkManager.bridgeNetwork.IP)


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Victor Vieux victor.vieux@docker.com (github: vieux)
