### PR TITLE
fix(CONTRIBUTING): Developer Certificate of Origin w/o Grant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ pass it on as an open-source patch.  The rules are pretty simple: if you
 can certify the below:
 
 ```
-Docker Developer Grant and Certificate of Origin 1.1
+Docker Developer Certificate of Origin 1.1
 
 By making a contribution to the Docker Project ("Project"), I represent and
 warrant that:


### PR DESCRIPTION
In 7fb55f77250a9b52b0515a7e655ecc605ae452ca the DCO lost the grant so change
the title back to just DCO.

Docker-DCO-1.1-Signed-off-by: Brandon Philips brandon.philips@coreos.com
(github: philips)
