### PR TITLE
contrib: systemd: make socket-activation Restart=always

### DIFF
--- a/contrib/init/systemd/socket-activation/docker.service
+++ b/contrib/init/systemd/socket-activation/docker.service
@@ -5,6 +5,7 @@ After=network.target
 
 [Service]
 ExecStart=/usr/bin/docker -d -H fd://
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Do as was done to f09a78cd219b24d4308034c8dd13410cfe5fbec7 in the 
socket-activation example.

Docker-DCO-1.1-Signed-off-by: Brandon Philips brandon.philips@coreos.com
(github: philips)
