### PR TITLE
 Add troubleshooting for missing cgroups on mint 16

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -217,6 +217,15 @@ To install the latest version of docker, use the standard ``apt-get`` method:
    # install the latest
    sudo apt-get install lxc-docker
 
+Troubleshooting
+^^^^^^^^^^^^^^^
+
+On Linux Mint, the ``cgroups-lite`` package is not installed by default.
+Before Docker will work correctly, you will need to install this via:
+
+.. code-block:: bash
+
+    sudo apt-get update && sudo apt-get install cgroups-lite
 
 .. _ufw:
 


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@fosiki.com (github: SvenDowideit)

replaces #3602
