### PR TITLE
Separate out graphdriver mount and container root

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -328,7 +328,7 @@ func (b *buildFile) checkPathForAddition(orig string) error {
 func (b *buildFile) addContext(container *Container, orig, dest string) error {
 	var (
 		origPath = path.Join(b.contextPath, orig)
-		destPath = path.Join(container.RootfsPath(), dest)
+		destPath = path.Join(container.BasefsPath(), dest)
 	)
 	// Preserve the trailing '/'
 	if strings.HasSuffix(dest, "/") {

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -75,7 +75,7 @@ func containerFileExists(eng *engine.Engine, id, dir string, t utils.Fataler) bo
 		t.Fatal(err)
 	}
 	defer c.Unmount()
-	if _, err := os.Stat(path.Join(c.RootfsPath(), dir)); err != nil {
+	if _, err := os.Stat(path.Join(c.BasefsPath(), dir)); err != nil {
 		if os.IsNotExist(err) {
 			return false
 		}

--- a/pkg/mount/flags_linux.go
+++ b/pkg/mount/flags_linux.go
@@ -38,6 +38,7 @@ func parseOptions(options string) (int, string) {
 		"nodiratime":    {false, syscall.MS_NODIRATIME},
 		"bind":          {false, syscall.MS_BIND},
 		"rbind":         {false, syscall.MS_BIND | syscall.MS_REC},
+		"private":       {false, syscall.MS_PRIVATE},
 		"relatime":      {false, syscall.MS_RELATIME},
 		"norelatime":    {true, syscall.MS_RELATIME},
 		"strictatime":   {false, syscall.MS_STRICTATIME},

--- a/runtime.go
+++ b/runtime.go
@@ -131,12 +131,12 @@ func (runtime *Runtime) Register(container *Container) error {
 	}
 
 	// Get the root filesystem from the driver
-	rootfs, err := runtime.driver.Get(container.ID)
+	basefs, err := runtime.driver.Get(container.ID)
 	if err != nil {
 		return fmt.Errorf("Error getting container filesystem %s from driver %s: %s", container.ID, runtime.driver, err)
 	}
 	defer runtime.driver.Put(container.ID)
-	container.rootfs = rootfs
+	container.basefs = basefs
 
 	container.runtime = runtime
 
@@ -764,11 +764,11 @@ func (runtime *Runtime) Mount(container *Container) error {
 	if err != nil {
 		return fmt.Errorf("Error getting container %s from driver %s: %s", container.ID, runtime.driver, err)
 	}
-	if container.rootfs == "" {
-		container.rootfs = dir
-	} else if container.rootfs != dir {
+	if container.basefs == "" {
+		container.basefs = dir
+	} else if container.basefs != dir {
 		return fmt.Errorf("Error: driver %s is returning inconsistent paths for container %s ('%s' then '%s')",
-			runtime.driver, container.ID, container.rootfs, dir)
+			runtime.driver, container.ID, container.basefs, dir)
 	}
 	return nil
 }


### PR DESCRIPTION
This separates out the directory as returned from the graphdriver (the "base" fs) from the root filesystem of the live container. This is necessary as the "diff" operation needs access to the base filesystem without all the mounts that the running container needs (/.dockerinit, volumes, etc).

We change container in the following way:

Container.RootfsPath() returns the the directory which will be used as the root in a running container. It is always of the form `/var/lib/docker/container/<id>/root` and is a private bind mount to the base filesystem. It is only available while the container is running.

Container.BasefsPath() returns the raw directory from the graph driver without the container runtime mounts. It is availible whenever the container is mounted (in between a container.Mount()/Unmount() pair, which are properly refcounted).

This fixes issue https://github.com/dotcloud/docker/issues/3840

EDIT @shykes: fixed formatting of example path
