### PR TITLE
network: insert masq rule

### DIFF
--- a/network.go
+++ b/network.go
@@ -327,7 +327,7 @@ func newNetworkManager(config *DaemonConfig) (*NetworkManager, error) {
 		natArgs := []string{"POSTROUTING", "-t", "nat", "-s", addr.String(), "!", "-d", addr.String(), "-j", "MASQUERADE"}
 
 		if !iptables.Exists(natArgs...) {
-			if output, err := iptables.Raw(append([]string{"-A"}, natArgs...)...); err != nil {
+			if output, err := iptables.Raw(append([]string{"-I"}, natArgs...)...); err != nil {
 				return nil, fmt.Errorf("Unable to enable network bridge NAT: %s", err)
 			} else if len(output) != 0 {
 				return nil, fmt.Errorf("Error iptables postrouting: %s", output)


### PR DESCRIPTION
Fixes #3193.

This fixes IP masquerading on systems with reject rules at the end of
the POSTROUTING table, by inserting the rule at the beginning of the
table instead of adding it at the end.

Docker-DCO-1.1-Signed-off-by: Josh Poimboeuf jpoimboe@redhat.com (github: jpoimboe)
