### PR TITLE
Use lxc-stop -k instead of lxc-kill

### DIFF
--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -212,7 +212,16 @@ func (d *driver) version() string {
 }
 
 func (d *driver) kill(c *execdriver.Command, sig int) error {
-	output, err := exec.Command("lxc-kill", "-n", c.ID, strconv.Itoa(sig)).CombinedOutput()
+	var (
+		err    error
+		output []byte
+	)
+	_, err = exec.LookPath("lxc-kill")
+	if err == nil {
+		output, err = exec.Command("lxc-kill", "-n", c.ID, strconv.Itoa(sig)).CombinedOutput()
+	} else {
+		output, err = exec.Command("lxc-stop", "-k", "-n", c.ID, strconv.Itoa(sig)).CombinedOutput()
+	}
 	if err != nil {
 		return fmt.Errorf("Err: %s Output: %s", err, output)
 	}


### PR DESCRIPTION
lxc-kill was removed in lxc/lxc@33ddfc2

Docker-DCO-1.1-Signed-off-by: Chia-liang Kao clkao@clkao.org (github: clkao)
