### PR TITLE
Fix ADD remote issue. Different file's content hit the same cache (#3847)

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -416,7 +416,17 @@ func (b *buildFile) CmdAdd(args string) error {
 		if err != nil {
 			return err
 		}
-		tarSum := utils.TarSum{Reader: r, DisableCompression: true}
+
+    tarSum := utils.TarSum{Reader: r, DisableCompression: true, IgnoreHeaders: true}
+    tmpDirPath, err := ioutil.TempDir("", "docker-remote-probe")
+    if err != nil {
+      return err
+    }
+    if err := archive.Untar(&tarSum, tmpDirPath, nil); err != nil {
+      return err
+    }
+    defer os.RemoveAll(tmpDirPath)
+
 		remoteHash = tarSum.Sum(nil)
 
 		// If the destination is a directory, figure out the filename.

--- a/buildfile.go
+++ b/buildfile.go
@@ -417,15 +417,15 @@ func (b *buildFile) CmdAdd(args string) error {
 			return err
 		}
 
-    tarSum := utils.TarSum{Reader: r, DisableCompression: true, IgnoreHeaders: true}
-    tmpDirPath, err := ioutil.TempDir("", "docker-remote-probe")
-    if err != nil {
-      return err
-    }
-    if err := archive.Untar(&tarSum, tmpDirPath, nil); err != nil {
-      return err
-    }
-    defer os.RemoveAll(tmpDirPath)
+		tarSum := utils.TarSum{Reader: r, DisableCompression: true, IgnoreHeaders: true}
+		tmpDirPath, err := ioutil.TempDir("", "docker-remote-probe")
+		if err != nil {
+			return err
+		}
+		if err := archive.Untar(&tarSum, tmpDirPath, nil); err != nil {
+			return err
+		}
+		defer os.RemoveAll(tmpDirPath)
 
 		remoteHash = tarSum.Sum(nil)
 

--- a/utils/tarsum.go
+++ b/utils/tarsum.go
@@ -26,6 +26,7 @@ type TarSum struct {
 	finished           bool
 	first              bool
 	DisableCompression bool
+	IgnoreHeaders      bool
 }
 
 type writeCloseFlusher interface {
@@ -46,6 +47,9 @@ func (n *nopCloseFlusher) Flush() error {
 }
 
 func (ts *TarSum) encodeHeader(h *tar.Header) error {
+	if ts.IgnoreHeaders {
+		return nil
+	}
 	for _, elem := range [][2]string{
 		{"name", h.Name},
 		{"mode", strconv.Itoa(int(h.Mode))},


### PR DESCRIPTION
Force reading of downloaded file contents to obtain the checksum used by cache validation.

Docker-DCO-1.1-Signed-off-by: German Del Zotto germ@ndz.com.ar (github: GermanDZ)
