### PR TITLE
Fix ADD remote issue. Different file's content hit the same cache (#3847)

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -478,7 +478,6 @@ func (b *buildFile) CmdAdd(args string) error {
 		}
 		for {
 			n, err := resp.Body.Read(buf)
-			fmt.Println("Buffer: ", n, buf[:n])
 			if err != nil && err != io.EOF {
 				return err
 			}

--- a/buildfile.go
+++ b/buildfile.go
@@ -472,7 +472,6 @@ func (b *buildFile) CmdAdd(args string) error {
 		defer os.RemoveAll(tmpDirName)
 		buf := make([]byte, 65536)
 		h := sha256.New()
-		resp, err = utils.Download(orig)
 		if err != nil {
 			return err
 		}

--- a/buildfile.go
+++ b/buildfile.go
@@ -482,7 +482,17 @@ func (b *buildFile) CmdAdd(args string) error {
 		if err != nil {
 			return err
 		}
-		tarSum := utils.TarSum{Reader: r, DisableCompression: true}
+
+		tarSum := utils.TarSum{Reader: r, DisableCompression: true, IgnoreHeaders: true}
+		tmpDirPath, err := ioutil.TempDir("", "docker-remote-probe")
+		if err != nil {
+			return err
+		}
+		if err := archive.Untar(&tarSum, tmpDirPath, nil); err != nil {
+			return err
+		}
+		defer os.RemoveAll(tmpDirPath)
+
 		remoteHash = tarSum.Sum(nil)
 		r.Close()
 

--- a/integration/buildfile_test.go
+++ b/integration/buildfile_test.go
@@ -584,6 +584,28 @@ func checkCacheBehaviorFromEngime(t *testing.T, template testContextTemplate, ex
 	return
 }
 
+func checkCacheBehaviorForMultiplesTemplates(t *testing.T, template testContextTemplate, templateNew testContextTemplate, expectHit bool) (imageId string) {
+	eng := NewTestEngine(t)
+	defer nuke(mkRuntimeFromEngine(eng, t))
+
+	img, err := buildImage(template, t, eng, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	imageId = img.ID
+
+	img, err = buildImage(templateNew, t, eng, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hit := imageId == img.ID; hit != expectHit {
+		t.Fatalf("Cache misbehavior, got hit=%t, expected hit=%t: (first: %s, second %s)", hit, expectHit, imageId, img.ID)
+	}
+	return
+}
+
 func TestBuildImageWithCache(t *testing.T) {
 	template := testContextTemplate{`
         from {IMAGE}
@@ -722,6 +744,50 @@ func TestBuildADDRemoteFileWithoutCache(t *testing.T) {
 		nil,
 		[][2]string{{"/baz", "world!"}}}
 	checkCacheBehavior(t, template, false)
+}
+
+func TestBuildADDSameRemoteFileWithCache(t *testing.T) {
+	template := testContextTemplate{`
+        from {IMAGE}
+        maintainer dockerio
+        run echo "first"
+        add http://{SERVERADDR}/baz /usr/lib/baz/quux
+        run echo "second"
+        `,
+		nil,
+		[][2]string{{"/baz", "world!"}}}
+	templateNew := testContextTemplate{`
+        from {IMAGE}
+        maintainer dockerio
+        run echo "first"
+        add http://{SERVERADDR}/baz /usr/lib/baz/quux
+        run echo "second"
+        `,
+		nil,
+		[][2]string{{"/baz", "world!"}}}
+	checkCacheBehaviorForMultiplesTemplates(t, template, templateNew, true)
+}
+
+func TestBuildADDDifferentRemoteFileWithCache(t *testing.T) {
+	template := testContextTemplate{`
+        from {IMAGE}
+        maintainer dockerio
+        run echo "first"
+        add http://{SERVERADDR}/fooz /usr/lib/fooz/quux
+        run echo "second"
+        `,
+		nil,
+		[][2]string{{"/fooz", "world!"}}}
+	templateNew := testContextTemplate{`
+        from {IMAGE}
+        maintainer dockerio
+        run echo "first"
+        add http://{SERVERADDR}/fooz /usr/lib/fooz/quux
+        run echo "second"
+        `,
+		nil,
+		[][2]string{{"/fooz", "aliens!"}}}
+	checkCacheBehaviorForMultiplesTemplates(t, template, templateNew, false)
 }
 
 func TestBuildADDLocalAndRemoteFilesWithCache(t *testing.T) {

--- a/utils/tarsum.go
+++ b/utils/tarsum.go
@@ -26,6 +26,7 @@ type TarSum struct {
 	finished           bool
 	first              bool
 	DisableCompression bool
+	IgnoreHeaders      bool
 }
 
 type writeCloseFlusher interface {
@@ -46,6 +47,9 @@ func (n *nopCloseFlusher) Flush() error {
 }
 
 func (ts *TarSum) encodeHeader(h *tar.Header) error {
+	if ts.IgnoreHeaders {
+		return nil
+	}
 	for _, elem := range [][2]string{
 		{"name", h.Name},
 		{"mode", strconv.Itoa(int(h.Mode))},

--- a/utils/tarsum.go
+++ b/utils/tarsum.go
@@ -26,7 +26,6 @@ type TarSum struct {
 	finished           bool
 	first              bool
 	DisableCompression bool
-	IgnoreHeaders      bool
 }
 
 type writeCloseFlusher interface {
@@ -47,9 +46,6 @@ func (n *nopCloseFlusher) Flush() error {
 }
 
 func (ts *TarSum) encodeHeader(h *tar.Header) error {
-	if ts.IgnoreHeaders {
-		return nil
-	}
 	for _, elem := range [][2]string{
 		{"name", h.Name},
 		{"mode", strconv.Itoa(int(h.Mode))},


### PR DESCRIPTION
Force reading of downloaded file contents to obtain the checksum used by cache validation.

Docker-DCO-1.1-Signed-off-by: German Del Zotto germ@ndz.com.ar (github: GermanDZ)
