### PR TITLE
3486 quiet cmds

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1016,7 +1016,8 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 }
 
 func (cli *DockerCli) CmdPush(args ...string) error {
-	cmd := cli.Subcmd("push", "NAME", "Push an image or a repository to the registry")
+	cmd := cli.Subcmd("push", "[OPTIONS] NAME", "Push an image or a repository to the registry")
+	suppressOutput := cmd.Bool([]string{"q", "-quiet"}, false, "Suppress verbose push output")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -1049,6 +1050,11 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 	}
 
 	v := url.Values{}
+
+	if *suppressOutput {
+		v.Set("q", "1")
+	}
+
 	push := func(authConfig registry.AuthConfig) error {
 		buf, err := json.Marshal(authConfig)
 		if err != nil {
@@ -1078,8 +1084,9 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 }
 
 func (cli *DockerCli) CmdPull(args ...string) error {
-	cmd := cli.Subcmd("pull", "NAME[:TAG]", "Pull an image or a repository from the registry")
+	cmd := cli.Subcmd("pull", "[OPTIONS] NAME[:TAG]", "Pull an image or a repository from the registry")
 	tag := cmd.String([]string{"#t", "#-tag"}, "", "Download tagged image in repository")
+	suppressOutput := cmd.Bool([]string{"q", "-quiet"}, false, "Suppress verbose pull output")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -1107,6 +1114,10 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 	v := url.Values{}
 	v.Set("fromImage", remote)
 	v.Set("tag", *tag)
+
+	if *suppressOutput {
+		v.Set("q", "1")
+	}
 
 	pull := func(authConfig registry.AuthConfig) error {
 		buf, err := json.Marshal(authConfig)

--- a/api/server.go
+++ b/api/server.go
@@ -400,6 +400,7 @@ func postImagesCreate(eng *engine.Engine, version version.Version, w http.Respon
 		job.SetenvBool("parallel", version.GreaterThan("1.3"))
 		job.SetenvJson("metaHeaders", metaHeaders)
 		job.SetenvJson("authConfig", authConfig)
+		job.Setenv("q", r.FormValue("q"))
 	} else { //import
 		job = eng.Job("import", r.Form.Get("fromSrc"), r.Form.Get("repo"), tag)
 		job.Stdin.Add(r.Body)
@@ -519,6 +520,7 @@ func postImagesPush(eng *engine.Engine, version version.Version, w http.Response
 	} else {
 		job.Stdout.Add(utils.NewWriteFlusher(w))
 	}
+	job.Setenv("q", r.FormValue("q"))
 
 	if err := job.Run(); err != nil {
 		if !job.Stdout.Used() {

--- a/docs/sources/reference/api/docker_remote_api_v1.10.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.10.rst
@@ -717,6 +717,7 @@ Create an image
         :query repo: repository
         :query tag: tag
         :query registry: the registry to pull from
+        :query q: suppress verbose pull output
         :reqheader X-Registry-Auth: base64-encoded AuthConfig object
         :statuscode 200: no error
         :statuscode 500: server error
@@ -869,7 +870,8 @@ Push an image on the registry
     {"error":"Invalid..."}
     ...
 
-   :query registry: the registry you wan to push, optional
+   :query registry: the registry you want to push, optional
+   :query q: suppress verbose push output
    :reqheader X-Registry-Auth: include a base64-encoded AuthConfig object.
    :statuscode 200: no error
    :statuscode 404: no such image

--- a/docs/sources/reference/api/docker_remote_api_v1.9.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.9.rst
@@ -729,6 +729,7 @@ Create an image
         :query repo: repository
         :query tag: tag
         :query registry: the registry to pull from
+        :query q: suppress verbose pull output
         :reqheader X-Registry-Auth: base64-encoded AuthConfig object
         :statuscode 200: no error
         :statuscode 500: server error
@@ -881,7 +882,8 @@ Push an image on the registry
     {"error":"Invalid..."}
     ...
 
-   :query registry: the registry you wan to push, optional
+   :query registry: the registry you want to push, optional
+   :query q: suppress verbose push output
    :reqheader X-Registry-Auth: include a base64-encoded AuthConfig object.
    :statuscode 200: no error
    :statuscode 404: no such image

--- a/docs/sources/reference/api/docker_remote_api_v1.9.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.9.rst
@@ -729,7 +729,6 @@ Create an image
         :query repo: repository
         :query tag: tag
         :query registry: the registry to pull from
-        :query q: suppress verbose pull output
         :reqheader X-Registry-Auth: base64-encoded AuthConfig object
         :statuscode 200: no error
         :statuscode 500: server error
@@ -882,8 +881,7 @@ Push an image on the registry
     {"error":"Invalid..."}
     ...
 
-   :query registry: the registry you want to push, optional
-   :query q: suppress verbose push output
+   :query registry: the registry you wan to push, optional
    :reqheader X-Registry-Auth: include a base64-encoded AuthConfig object.
    :statuscode 200: no error
    :statuscode 404: no such image

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -976,12 +976,12 @@ The last container is marked as a ``Ghost`` container. It is a container that wa
 
 ::
 
-    Usage: docker pull NAME
+    Usage: docker pull [OPTIONS] NAME
 
     Pull an image or a repository from the registry
 
+      -q, --quiet=false: Suppress verbose pull output
       -t, --tag="": Download tagged image in repository
-
 
 .. _cli_push:
 
@@ -990,10 +990,11 @@ The last container is marked as a ``Ghost`` container. It is a container that wa
 
 ::
 
-    Usage: docker push NAME
+    Usage: docker push [OPTIONS] NAME
 
     Push an image or a repository to the registry
 
+      -q, --quiet=false: Suppress verbose push output
 
 .. _cli_restart:
 

--- a/engine/streams.go
+++ b/engine/streams.go
@@ -40,7 +40,7 @@ func (o *Output) Add(dst io.Writer) {
 
 // Set closes and remove existing destination and then attaches a new destination to
 // the Output. Any data subsequently written to the output will be written to the new
-// destination in addition to all the others. This method is thread-safe.
+// destination only. This method is thread-safe.
 func (o *Output) Set(dst io.Writer) {
 	o.Close()
 	o.Lock()


### PR DESCRIPTION
Fixes #3486.

I added -q/--quiet CLI args to push and pull, and ?q=1 API query params to /images/(name)/push and /images/create, both modelled after the docker build args.  All it does is set the job's Stdout to a NopWriter if the parameter is found.  I'm not sure if this is the best way to handle suppressing output, but it seems to work just fine.

I didn't add any tests because I didn't see any similar existing tests, and this seemed too minor a change to warrant adding major CLI/API testing code.  I tested with pull and it seems to work just fine, including the exit code.  Sometime soon I'll test pushing on a private repo, when I get that set up.
