### PR TITLE
Update lxc_template.go

### DIFF
--- a/execdriver/lxc/lxc_template.go
+++ b/execdriver/lxc/lxc_template.go
@@ -15,6 +15,7 @@ lxc.network.name = eth0
 {{else}}
 # network is disabled (-n=false)
 lxc.network.type = empty
+lxc.network.flags = up
 {{end}}
 
 # root filesystem


### PR DESCRIPTION
If networking is disabled, but then pipework is used later to add nics, the network still doesn't function. Using flags=up for empty networking fixes this.
