### PR TITLE
Fix issue dotcloud#1141

### DIFF
--- a/server.go
+++ b/server.go
@@ -1035,7 +1035,8 @@ func (srv *Server) ContainerCommit(job *engine.Job) engine.Status {
 	if err := job.GetenvJson("config", &newConfig); err != nil {
 		return job.Error(err)
 	}
-	if newConfig != (Config{}) { // doesn't work; can't compare slices for equality
+
+	if false { // What to do here?
 		config = &newConfig
 	}
 

--- a/server.go
+++ b/server.go
@@ -1036,11 +1036,12 @@ func (srv *Server) ContainerCommit(job *engine.Job) engine.Status {
 		return job.Error(err)
 	}
 
-	if false { // What to do here?
-		config = &newConfig
+	if err := MergeConfig(&newConfig, config); err != nil {
+		job.Error(err)
+		return engine.StatusErr
 	}
 
-	img, err := srv.runtime.Commit(container, job.Getenv("repo"), job.Getenv("tag"), job.Getenv("comment"), job.Getenv("author"), config)
+	img, err := srv.runtime.Commit(container, job.Getenv("repo"), job.Getenv("tag"), job.Getenv("comment"), job.Getenv("author"), &newConfig)
 	if err != nil {
 		return job.Error(err)
 	}

--- a/server.go
+++ b/server.go
@@ -1030,12 +1030,16 @@ func (srv *Server) ContainerCommit(job *engine.Job) engine.Status {
 	if container == nil {
 		return job.Errorf("No such container: %s", name)
 	}
-	var config Config
-	if err := job.GetenvJson("config", &config); err != nil {
+	var config = container.Config
+	var newConfig Config
+	if err := job.GetenvJson("config", &newConfig); err != nil {
 		return job.Error(err)
 	}
+	if newConfig != (Config{}) { // doesn't work; can't compare slices for equality
+		config = &newConfig
+	}
 
-	img, err := srv.runtime.Commit(container, job.Getenv("repo"), job.Getenv("tag"), job.Getenv("comment"), job.Getenv("author"), &config)
+	img, err := srv.runtime.Commit(container, job.Getenv("repo"), job.Getenv("tag"), job.Getenv("comment"), job.Getenv("author"), config)
 	if err != nil {
 		return job.Error(err)
 	}

--- a/server.go
+++ b/server.go
@@ -1037,8 +1037,7 @@ func (srv *Server) ContainerCommit(job *engine.Job) engine.Status {
 	}
 
 	if err := MergeConfig(&newConfig, config); err != nil {
-		job.Error(err)
-		return engine.StatusErr
+		return job.Error(err)
 	}
 
 	img, err := srv.runtime.Commit(container, job.Getenv("repo"), job.Getenv("tag"), job.Getenv("comment"), job.Getenv("author"), &newConfig)


### PR DESCRIPTION
This merges any config supplied on the commit command line with the original container's config. Without a -run option, you just inherit the original container's config.
