### PR TITLE
Fix #905 : insert files

### DIFF
--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -722,7 +722,7 @@ Use the specified ``IMAGE`` as the parent for a new image which adds a
 :ref:`layer <layer_def>` containing the new file. The ``insert`` command does
 not modify the original image, and the new image has the contents of the parent
 image, plus the new file.
-
+The URL can be of the form: http://xxx.xx/xxx,  or file:///path/to/my/file
 
 Examples
 ~~~~~~~~

--- a/server.go
+++ b/server.go
@@ -643,11 +643,33 @@ func (srv *Server) ImageInsert(job *engine.Job) engine.Status {
 		return job.Error(err)
 	}
 
-	file, err := utils.Download(url)
-	if err != nil {
-		return job.Error(err)
+	var body io.ReadCloser
+	var size int64
+
+	if strings.HasPrefix(url, "file:///") {
+		file, err := os.Open(url[7:])
+		if err != nil {
+			return job.Error(err)
+		}
+		defer file.Close()
+
+		fstat, err := file.Stat()
+		if err != nil {
+			return job.Error(err)
+		}
+		size = fstat.Size()
+		body = file
+
+	} else {
+		file, err := utils.Download(url)
+		if err != nil {
+			return job.Error(err)
+		}
+		body = file.Body
+		size = file.ContentLength
+		defer body.Close()
+
 	}
-	defer file.Body.Close()
 
 	config, _, _, err := ParseRun([]string{img.ID, "echo", "insert", url, path}, srv.runtime.sysInfo)
 	if err != nil {
@@ -659,7 +681,7 @@ func (srv *Server) ImageInsert(job *engine.Job) engine.Status {
 		return job.Error(err)
 	}
 
-	if err := c.Inject(utils.ProgressReader(file.Body, int(file.ContentLength), out, sf, false, utils.TruncateID(img.ID), "Downloading"), path); err != nil {
+	if err := c.Inject(utils.ProgressReader(body, int(size), out, sf, false, utils.TruncateID(img.ID), "Downloading"), path); err != nil {
 		return job.Error(err)
 	}
 	// FIXME: Handle custom repo, tag comment, author


### PR DESCRIPTION
by adding support for adding file url support to
the "docker insert" command

Docker-DCO-1.1-Signed-off-by: Julien Vermillard jvermillar@sierrawireless.com (github: jvermillard)
