### PR TITLE
Remove reference to <linux/btrfs.h>, and instead use <btrfs/ioctl.h> like we're supposed to (from btrfs-progs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN	apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
 	apt-utils \
 	aufs-tools \
 	automake \
+	btrfs-tools \
 	build-essential \
 	curl \
 	dpkg-sig \
@@ -40,7 +41,6 @@ RUN	apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq \
 	libapparmor-dev \
 	libcap-dev \
 	libsqlite3-dev \
-	linux-libc-dev \
 	mercurial \
 	reprepro \
 	ruby1.9.1 \

--- a/graphdriver/btrfs/btrfs.go
+++ b/graphdriver/btrfs/btrfs.go
@@ -4,15 +4,11 @@ package btrfs
 
 /*
 #include <stdlib.h>
-#include <sys/ioctl.h>
-#include <linux/fs.h>
-#include <errno.h>
-#include <sys/types.h>
 #include <dirent.h>
-#include <linux/btrfs.h>
-
+#include <btrfs/ioctl.h>
 */
 import "C"
+
 import (
 	"fmt"
 	"github.com/dotcloud/docker/graphdriver"

--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -39,6 +39,7 @@ To build docker, you will need the following system dependencies
 * Go version 1.2 or later
 * SQLite version 3.7.9 or later
 * libdevmapper version 1.02.68-cvs (2012-01-26) or later from lvm2 version 2.02.89 or later
+* btrfs-progs version 3.8 or later (including commit e5cb128 from 2013-01-07) for the necessary btrfs headers
 * A clean checkout of the source must be added to a valid Go [workspace](http://golang.org/doc/code.html#Workspaces)
 under the path *src/github.com/dotcloud/docker*.
 


### PR DESCRIPTION
This fixes compilation issues when btrfs.h isn't available (because we just need the relevant structs, which for userspace programs are supposed to come from btrfs-progs instead of from the kernel headers directly).
