### PR TITLE
Update mkimage-arch.sh

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -15,6 +15,7 @@ hash expect &>/dev/null || {
 }
 
 ROOTFS=$(mktemp -d /tmp/rootfs-archlinux-XXXXXXXXXX)
+chmod 755 $ROOTFS
 
 # packages to ignore for space savings
 PKGIGNORE=linux,jfsutils,lvm2,cryptsetup,groff,man-db,man-pages,mdadm,pciutils,pcmciautils,reiserfsprogs,s-nail,xfsprogs


### PR DESCRIPTION
mktemp creates a root directory ("/") with permissions set to 700. Default should be 755 so other users in the container can access its subdirs (e.g http user for nginx for /srv/http/test/index.html).
