### PR TITLE
Fix docker commit output

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1472,7 +1472,7 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 		return err
 	}
 
-	fmt.Fprintf(cli.out, "%s\n", env.Get("ID"))
+	fmt.Fprintf(cli.out, "%s\n", env.Get("Id"))
 	return nil
 }
 


### PR DESCRIPTION
The id is returned as Id, not ID, so print the right thing.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
