### PR TITLE
Remove stackbrew prefix on ubuntu images now that they're reasonably up-to-date and stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 #
 
 docker-version	0.6.1
-FROM	stackbrew/ubuntu:13.10
+FROM	ubuntu:13.10
 MAINTAINER	Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # Packaged dependencies

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM stackbrew/ubuntu:12.04
+FROM ubuntu:12.04
 MAINTAINER Nick Stinemates
 #
 #    docker build -t docker:docs . && docker run -p 8000:8000 docker:docs


### PR DESCRIPTION
Everyone probably wants to run `docker pull ubuntu` before building with this change.
