### PR TITLE
Add protocol and port to Ubuntu keyserver address

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -161,6 +161,7 @@ Julien Barbier <write0@gmail.com>
 Julien Dubois <julien.dubois@gmail.com>
 Justin Force <justin.force@gmail.com>
 Justin Plock <jplock@users.noreply.github.com>
+Jyrki Puttonen <jyrkiput@gmail.com>
 Karan Lyons <karan@karanlyons.com>
 Karl Grzeszczak <karlgrz@gmail.com>
 Kawsar Saiyeed <kawsar.saiyeed@projiris.com>

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,7 +32,7 @@ if [ -z "$user" ]; then
 fi
 
 # Adding an apt gpg key is idempotent.
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
 # Creating the docker.list file is idempotent, but it may overwrite desired
 # settings if it already exists.  This could be solved with md5sum but it


### PR DESCRIPTION
Without these, the connection to keyserver timed out. And
as the key was not added, apt refused to install lxc-docker.
This solution comes from
http://askubuntu.com/questions/134913/cant-add-repo-keys.

Another way to do this would be adding --force-yes to

  apt-get install -q -y lxc-docker

but this should a lot more secure.
