### PR TITLE
Updated the command for adding key to keychain

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -72,7 +72,7 @@ First add the Docker repository key to your local keychain.
 
 .. code-block:: bash
 
-   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+   sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
 Add the Docker repository to your apt sources list, update and install the
 ``lxc-docker`` package.


### PR DESCRIPTION
When the user is behind a proxy or a firewall the user might not be able to correctly obtain a key as it is attempting to connect through port #11371. The default implementation in ubuntu is using port 80, unless overridden as in the sample.
