### PR TITLE
Abstract out the crypto packages used

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -1,13 +1,13 @@
 package docker
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/auth"
+	"github.com/dotcloud/docker/pkg/crypto"
 	"github.com/dotcloud/docker/registry"
 	"github.com/dotcloud/docker/utils"
 	"io"
@@ -480,7 +480,7 @@ func (b *buildFile) CmdAdd(args string) error {
 				}
 			}
 			sort.Strings(subfiles)
-			hasher := sha256.New()
+			hasher := crypto.NewSHA256()
 			hasher.Write([]byte(strings.Join(subfiles, ",")))
 			hash = "dir:" + hex.EncodeToString(hasher.Sum(nil))
 		} else {

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/dotcloud/docker/execdriver"
 	"github.com/dotcloud/docker/pkg/cgroups"
-	"github.com/dotcloud/docker/utils"
+	"github.com/dotcloud/docker/pkg/shell"
 	"io/ioutil"
 	"log"
 	"os"
@@ -127,7 +127,7 @@ func (d *driver) Run(c *execdriver.Command, startCallback execdriver.StartCallba
 		// without exec in go we have to do this horrible shell hack...
 		shellString :=
 			"mount --make-rslave /; exec " +
-				utils.ShellQuoteArguments(params)
+				shell.QuoteArguments(params)
 
 		params = []string{
 			"unshare", "-m", "--", "/bin/sh", "-c", shellString,

--- a/execdriver/lxc/init.go
+++ b/execdriver/lxc/init.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/dotcloud/docker/execdriver"
 	"github.com/dotcloud/docker/pkg/netlink"
-	"github.com/dotcloud/docker/utils"
+	"github.com/dotcloud/docker/utils/host"
 	"github.com/syndtr/gocapability/capability"
 	"net"
 	"os"
@@ -82,7 +82,7 @@ func changeUser(args *execdriver.InitArgs) error {
 	if args.User == "" {
 		return nil
 	}
-	userent, err := utils.UserLookup(args.User)
+	userent, err := host.UserLookup(args.User)
 	if err != nil {
 		return fmt.Errorf("Unable to find user %v: %v", args.User, err)
 	}

--- a/graphdriver/aufs/aufs_test.go
+++ b/graphdriver/aufs/aufs_test.go
@@ -1,10 +1,10 @@
 package aufs
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"github.com/dotcloud/docker/archive"
+	"github.com/dotcloud/docker/pkg/crypto"
 	"io/ioutil"
 	"os"
 	"path"
@@ -627,7 +627,7 @@ func TestApplyDiff(t *testing.T) {
 }
 
 func hash(c string) string {
-	h := sha256.New()
+	h := crypto.NewSHA256()
 	fmt.Fprint(h, c)
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/image.go
+++ b/image.go
@@ -1,12 +1,12 @@
 package docker
 
 import (
-	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/graphdriver"
+	"github.com/dotcloud/docker/pkg/crypto"
 	"github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"
@@ -205,7 +205,7 @@ func ValidateID(id string) error {
 func GenerateID() string {
 	for {
 		id := make([]byte, 32)
-		if _, err := io.ReadFull(rand.Reader, id); err != nil {
+		if _, err := io.ReadFull(crypto.RandReader, id); err != nil {
 			panic(err) // This shouldn't happen
 		}
 		value := hex.EncodeToString(id)

--- a/integration/auth_test.go
+++ b/integration/auth_test.go
@@ -1,10 +1,10 @@
 package docker
 
 import (
-	"crypto/rand"
 	"encoding/hex"
 	"fmt"
 	"github.com/dotcloud/docker/auth"
+	"github.com/dotcloud/docker/pkg/crypto"
 	"os"
 	"strings"
 	"testing"
@@ -35,7 +35,7 @@ func TestLogin(t *testing.T) {
 
 func TestCreateAccount(t *testing.T) {
 	tokenBuffer := make([]byte, 16)
-	_, err := rand.Read(tokenBuffer)
+	_, err := crypto.RandRead(tokenBuffer)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/crypto/crypto_golang.go
+++ b/pkg/crypto/crypto_golang.go
@@ -1,0 +1,16 @@
+// +build !openssl
+
+package crypto
+
+import (
+	"crypto/rand"
+	"crypto/sha1"
+	"crypto/sha256"
+)
+
+var (
+	RandReader = rand.Reader
+	RandRead   = rand.Read
+	NewSHA1    = sha1.New
+	NewSHA256  = sha256.New
+)

--- a/pkg/crypto/crypto_openssl.go
+++ b/pkg/crypto/crypto_openssl.go
@@ -1,0 +1,16 @@
+// +build openssl
+
+package crypto
+
+import (
+	"github.com/vbatts/gossl/rand"
+	"github.com/vbatts/gossl/sha1"
+	"github.com/vbatts/gossl/sha256"
+)
+
+var (
+	RandReader = rand.Reader
+	RandRead   = rand.Read
+	NewSHA1    = sha1.New
+	NewSHA256  = sha256.New
+)

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -1,0 +1,41 @@
+package shell
+
+import (
+	"bytes"
+	"strings"
+)
+
+func quote(word string, buf *bytes.Buffer) {
+	// Bail out early for "simple" strings
+	if word != "" && !strings.ContainsAny(word, "\\'\"`${[|&;<>()~*?! \t\n") {
+		buf.WriteString(word)
+		return
+	}
+
+	buf.WriteString("'")
+
+	for i := 0; i < len(word); i++ {
+		b := word[i]
+		if b == '\'' {
+			// Replace literal ' with a close ', a \', and a open '
+			buf.WriteString("'\\''")
+		} else {
+			buf.WriteByte(b)
+		}
+	}
+
+	buf.WriteString("'")
+}
+
+// Take a list of strings and escape them so they will be handled right
+// when passed as arguments to an program via a shell
+func QuoteArguments(args []string) string {
+	var buf bytes.Buffer
+	for i, arg := range args {
+		if i != 0 {
+			buf.WriteByte(' ')
+		}
+		quote(arg, &buf)
+	}
+	return buf.String()
+}

--- a/utils/host/user.go
+++ b/utils/host/user.go
@@ -1,0 +1,38 @@
+package host
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// UserLookup check if the given username or uid is present in /etc/passwd
+// and returns the user struct.
+// If the username is not found, an error is returned.
+func UserLookup(uid string) (*User, error) {
+	file, err := ioutil.ReadFile("/etc/passwd")
+	if err != nil {
+		return nil, err
+	}
+	for _, line := range strings.Split(string(file), "\n") {
+		data := strings.Split(line, ":")
+		if len(data) > 5 && (data[0] == uid || data[2] == uid) {
+			return &User{
+				Uid:      data[2],
+				Gid:      data[3],
+				Username: data[0],
+				Name:     data[4],
+				HomeDir:  data[5],
+			}, nil
+		}
+	}
+	return nil, fmt.Errorf("User not found in /etc/passwd")
+}
+
+type User struct {
+	Uid      string // user id
+	Gid      string // primary group id
+	Username string
+	Name     string
+	HomeDir  string
+}

--- a/utils/random.go
+++ b/utils/random.go
@@ -1,14 +1,14 @@
 package utils
 
 import (
-	"crypto/rand"
 	"encoding/hex"
+	"github.com/dotcloud/docker/pkg/crypto"
 	"io"
 )
 
 func RandomString() string {
 	id := make([]byte, 32)
-	_, err := io.ReadFull(rand.Reader, id)
+	_, err := io.ReadFull(crypto.RandReader, id)
 	if err != nil {
 		panic(err) // This shouldn't happen
 	}

--- a/utils/tarsum.go
+++ b/utils/tarsum.go
@@ -4,8 +4,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"crypto/sha256"
 	"encoding/hex"
+	"github.com/dotcloud/docker/pkg/crypto"
 	"hash"
 	"io"
 	"sort"
@@ -80,7 +80,7 @@ func (ts *TarSum) Read(buf []byte) (int, error) {
 		} else {
 			ts.gz = &nopCloseFlusher{Writer: ts.bufGz}
 		}
-		ts.h = sha256.New()
+		ts.h = crypto.NewSHA256()
 		ts.h.Reset()
 		ts.first = true
 		ts.sums = make(map[string]string)
@@ -163,7 +163,7 @@ func (ts *TarSum) Sum(extra []byte) string {
 		sums = append(sums, sum)
 	}
 	sort.Strings(sums)
-	h := sha256.New()
+	h := crypto.NewSHA256()
 	if extra != nil {
 		h.Write(extra)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -835,37 +835,6 @@ func ParseRepositoryTag(repos string) (string, string) {
 	return repos, ""
 }
 
-type User struct {
-	Uid      string // user id
-	Gid      string // primary group id
-	Username string
-	Name     string
-	HomeDir  string
-}
-
-// UserLookup check if the given username or uid is present in /etc/passwd
-// and returns the user struct.
-// If the username is not found, an error is returned.
-func UserLookup(uid string) (*User, error) {
-	file, err := ioutil.ReadFile("/etc/passwd")
-	if err != nil {
-		return nil, err
-	}
-	for _, line := range strings.Split(string(file), "\n") {
-		data := strings.Split(line, ":")
-		if len(data) > 5 && (data[0] == uid || data[2] == uid) {
-			return &User{
-				Uid:      data[2],
-				Gid:      data[3],
-				Username: data[0],
-				Name:     data[4],
-				HomeDir:  data[5],
-			}, nil
-		}
-	}
-	return nil, fmt.Errorf("User not found in /etc/passwd")
-}
-
 // An StatusError reports an unsuccessful exit by a command.
 type StatusError struct {
 	Status     string
@@ -874,41 +843,6 @@ type StatusError struct {
 
 func (e *StatusError) Error() string {
 	return fmt.Sprintf("Status: %s, Code: %d", e.Status, e.StatusCode)
-}
-
-func quote(word string, buf *bytes.Buffer) {
-	// Bail out early for "simple" strings
-	if word != "" && !strings.ContainsAny(word, "\\'\"`${[|&;<>()~*?! \t\n") {
-		buf.WriteString(word)
-		return
-	}
-
-	buf.WriteString("'")
-
-	for i := 0; i < len(word); i++ {
-		b := word[i]
-		if b == '\'' {
-			// Replace literal ' with a close ', a \', and a open '
-			buf.WriteString("'\\''")
-		} else {
-			buf.WriteByte(b)
-		}
-	}
-
-	buf.WriteString("'")
-}
-
-// Take a list of strings and escape them so they will be handled right
-// when passed as arguments to an program via a shell
-func ShellQuoteArguments(args []string) string {
-	var buf bytes.Buffer
-	for i, arg := range args {
-		if i != 0 {
-			buf.WriteByte(' ')
-		}
-		quote(arg, &buf)
-	}
-	return buf.String()
 }
 
 func IsClosedError(err error) bool {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,12 +2,11 @@ package utils
 
 import (
 	"bytes"
-	"crypto/sha1"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/dotcloud/docker/pkg/crypto"
 	"index/suffixarray"
 	"io"
 	"io/ioutil"
@@ -189,7 +188,7 @@ func dockerInitSha1(target string) string {
 		return ""
 	}
 	defer f.Close()
-	h := sha1.New()
+	h := crypto.NewSHA1()
 	_, err = io.Copy(h, f)
 	if err != nil {
 		return ""
@@ -542,7 +541,7 @@ func CopyEscapable(dst io.Writer, src io.ReadCloser) (written int64, err error) 
 }
 
 func HashData(src io.Reader) (string, error) {
-	h := sha256.New()
+	h := crypto.NewSHA256()
 	if _, err := io.Copy(h, src); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
  Seperating out none docker specific calls to the golang stdlib
  crypto/..., then we provide ourselves with an ability to have drop-in
  replacements of backends.
  I've included the openssl drop-in replacement. To use it, install
  openssl devel packages and  include the build flag:

```
    cd ./docker
    go build -tags "net openssl" .
```

  and the binary will be linked to libssl and libcrypto for these
  functions.
  Best to install the static development bits for openssl, as dockerinit
  links as well.

Note: This is just a milestone for having switchable backends for crypto, as some uses are indirect (e.g. net/http.RoundTripper uses crypto/tls)
