### PR TITLE
Always download things over https

### DIFF
--- a/docs/sources/installation/mac.rst
+++ b/docs/sources/installation/mac.rst
@@ -66,7 +66,7 @@ Run the following commands to get it downloaded and set up:
 .. code-block:: bash
 
     # Get the file
-    curl -o docker http://get.docker.io/builds/Darwin/x86_64/docker-latest
+    curl -o docker https://get.docker.io/builds/Darwin/x86_64/docker-latest
     
     # Mark it executable
     chmod +x docker


### PR DESCRIPTION
Update the docs to pull `docker-latest` over https instead of http.
