### PR TITLE
Change untar behavior to use root:root ownership for all created files

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -236,7 +236,9 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader *tar.Reader)
 		return fmt.Errorf("Unhandled tar header type %d\n", hdr.Typeflag)
 	}
 
-	if err := syscall.Lchown(path, hdr.Uid, hdr.Gid); err != nil {
+	// Use root:root ownership for untarred files, like --same-owner
+	// behavior in GNU tar, or just -x in BSD tar
+	if err := syscall.Lchown(path, 0, 0); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Docker documentation, as noted in #3950

Am happy to make this a parameter for other use cases, if that is desired
and considered cleaner.

Docker-DCO-1.1-Signed-off-by: George Lewis schvin@schvin.net (github: schvin)
