### PR TITLE
Fix broken images API for version <1.7

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -222,7 +222,7 @@ func getImagesJSON(eng *engine.Engine, version float64, w http.ResponseWriter, r
 				outLegacy := &engine.Env{}
 				outLegacy.Set("Repository", parts[0])
 				outLegacy.Set("Tag", parts[1])
-				outLegacy.Set("ID", out.Get("ID"))
+				outLegacy.Set("Id", out.Get("Id"))
 				outLegacy.SetInt64("Created", out.GetInt64("Created"))
 				outLegacy.SetInt64("Size", out.GetInt64("Size"))
 				outLegacy.SetInt64("VirtualSize", out.GetInt64("VirtualSize"))


### PR DESCRIPTION
Simple typo, "ID" should be "Id".  This is causing the images response to not have IDs in it.

This has effectively broken anything that is using docker-py which uses the 1.6 version of the API
