### PR TITLE
Do not ping registry from the cli

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -151,12 +151,15 @@ func SaveConfig(configFile *ConfigFile) error {
 
 // try to register/login to the registry server
 func Login(authConfig *AuthConfig, factory *utils.HTTPRequestFactory) (string, error) {
-	client := &http.Client{}
-	reqStatusCode := 0
-	var status string
-	var reqBody []byte
+	var (
+		status        string
+		reqBody       []byte
+		err           error
+		client        = &http.Client{}
+		reqStatusCode = 0
+		serverAddress = authConfig.ServerAddress
+	)
 
-	serverAddress := authConfig.ServerAddress
 	if serverAddress == "" {
 		serverAddress = IndexServerAddress()
 	}

--- a/commands.go
+++ b/commands.go
@@ -266,11 +266,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	}
 	serverAddress := auth.IndexServerAddress()
 	if len(cmd.Args()) > 0 {
-		serverAddress, err = registry.ExpandAndVerifyRegistryUrl(cmd.Arg(0))
-		if err != nil {
-			return err
-		}
-		fmt.Fprintf(cli.out, "Login against server at %s\n", serverAddress)
+		serverAddress = cmd.Arg(0)
 	}
 
 	promptDefault := func(prompt string, configDefault string) {


### PR DESCRIPTION
Fixes #3683

This a problem because the cli was pinging the registry to inspect the transport if not provided.  I moved this to the daemon so that all requests to the registries flow thought the daemon.  This is true for every command, even login, expect for this first ping if a registry was provided. 

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
