### PR TITLE
Add DOCKER_API_VERSION to set arbitrary version (ex: newer client on older server)

### DIFF
--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -25,6 +25,7 @@ import (
 	"github.com/dotcloud/docker/dockerversion"
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/pkg/term"
+	"github.com/dotcloud/docker/pkg/version"
 	"github.com/dotcloud/docker/registry"
 	"github.com/dotcloud/docker/utils"
 )
@@ -32,6 +33,12 @@ import (
 var (
 	ErrConnectionRefused = errors.New("Cannot connect to the Docker daemon. Is 'docker -d' running on this host?")
 )
+
+func init() {
+	if apiVersion := os.Getenv("DOCKER_API_VERSION"); apiVersion != "" {
+		api.APIVERSION = version.Version(apiVersion)
+	}
+}
 
 func (cli *DockerCli) dial() (net.Conn, error) {
 	if cli.tlsConfig != nil && cli.proto != "unix" {

--- a/api/common.go
+++ b/api/common.go
@@ -3,13 +3,17 @@ package api
 import (
 	"fmt"
 	"github.com/dotcloud/docker/engine"
+	"github.com/dotcloud/docker/pkg/version"
 	"github.com/dotcloud/docker/utils"
 	"mime"
 	"strings"
 )
 
+var (
+	APIVERSION version.Version = "1.10"
+)
+
 const (
-	APIVERSION        = "1.10"
 	DEFAULTHTTPHOST   = "127.0.0.1"
 	DEFAULTUNIXSOCKET = "/var/run/docker.sock"
 )

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -940,7 +940,7 @@ func makeHttpHandler(eng *engine.Engine, logging bool, localMethod string, local
 
 		if strings.Contains(r.Header.Get("User-Agent"), "Docker-Client/") {
 			userAgent := strings.Split(r.Header.Get("User-Agent"), "/")
-			if len(userAgent) == 2 && !dockerVersion.Equal(userAgent[1]) {
+			if len(userAgent) == 2 && !dockerVersion.Equal(version.Version(userAgent[1])) {
 				utils.Debugf("Warning: client and server don't have the same version (client: %s, server: %s)", userAgent[1], dockerVersion)
 			}
 		}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -7,10 +7,10 @@ import (
 
 type Version string
 
-func (me Version) compareTo(other string) int {
+func (me Version) compareTo(other Version) int {
 	var (
 		meTab    = strings.Split(string(me), ".")
-		otherTab = strings.Split(other, ".")
+		otherTab = strings.Split(string(other), ".")
 	)
 	for i, s := range meTab {
 		var meInt, otherInt int
@@ -31,22 +31,22 @@ func (me Version) compareTo(other string) int {
 	return 0
 }
 
-func (me Version) LessThan(other string) bool {
+func (me Version) LessThan(other Version) bool {
 	return me.compareTo(other) == -1
 }
 
-func (me Version) LessThanOrEqualTo(other string) bool {
+func (me Version) LessThanOrEqualTo(other Version) bool {
 	return me.compareTo(other) <= 0
 }
 
-func (me Version) GreaterThan(other string) bool {
+func (me Version) GreaterThan(other Version) bool {
 	return me.compareTo(other) == 1
 }
 
-func (me Version) GreaterThanOrEqualTo(other string) bool {
+func (me Version) GreaterThanOrEqualTo(other Version) bool {
 	return me.compareTo(other) >= 0
 }
 
-func (me Version) Equal(other string) bool {
+func (me Version) Equal(other Version) bool {
 	return me.compareTo(other) == 0
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func assertVersion(t *testing.T, a, b string, result int) {
-	if r := Version(a).compareTo(b); r != result {
+	if r := Version(a).compareTo(Version(b)); r != result {
 		t.Fatalf("Unexpected version comparison result. Found %d, expected %d", r, result)
 	}
 }


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Guillaume J. Charmes guillaume.charmes@docker.com (github: creack)
