### PR TITLE
pkg: systemd: add initial MAINTAINERS

### DIFF
--- a/pkg/systemd/MAINTAINERS
+++ b/pkg/systemd/MAINTAINERS
@@ -1,0 +1,1 @@
+Brandon Philips <brandon.philips@coreos.com> (@philips)


### PR DESCRIPTION
I volunteered for pkg/systemd MAINTAINER and there were no objections during
the #docker-dev meeting. For context I wrote most of the stuff in here and
wrote the dependent calls in api.go. Plus, I actively test the code via
CoreOS.
