### PR TITLE
devmapper: Enable skip_block_zeroing

### DIFF
--- a/graphdriver/devmapper/devmapper.go
+++ b/graphdriver/devmapper/devmapper.go
@@ -324,7 +324,7 @@ func createPool(poolName string, dataFile, metadataFile *osFile) error {
 		return fmt.Errorf("Can't get data size")
 	}
 
-	params := metadataFile.Name() + " " + dataFile.Name() + " 128 32768"
+	params := metadataFile.Name() + " " + dataFile.Name() + " 128 32768 1 skip_block_zeroing"
 	if err := task.AddTarget(0, size/512, "thin-pool", params); err != nil {
 		return fmt.Errorf("Can't add target")
 	}


### PR DESCRIPTION
This makes the device mapper not zero out blocks allocated on the
thinp device. This is safe in our use case, as we access the device
via a filesystem that doesn't leak any uninitialized data to userspace.

This partially helps with https://github.com/dotcloud/docker/issues/3280
and should generally improve preformance on the devicemapper backend.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
