### PR TITLE
Add slightly better GOPATH detection/handling

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -68,6 +68,19 @@ else
 	exit 1
 fi
 
+if [ "$AUTO_GOPATH" ]; then
+	rm -rf .gopath
+	mkdir -p .gopath/src/github.com/dotcloud
+	ln -sf ../../../.. .gopath/src/github.com/dotcloud/docker
+	export GOPATH="$(pwd)/.gopath:$(pwd)/vendor"
+fi
+
+if [ ! "$GOPATH" ]; then
+	echo >&2 'error: missing GOPATH; please see http://golang.org/doc/code.html#GOPATH'
+	echo >&2 '  alternatively, set AUTO_GOPATH=1'
+	exit 1
+fi
+
 # Use these flags when compiling the tests and final binary
 LDFLAGS='-X main.GITCOMMIT "'$GITCOMMIT'" -X main.VERSION "'$VERSION'" -w'
 LDFLAGS_STATIC='-X github.com/dotcloud/docker/utils.IAMSTATIC true -linkmode external -extldflags "-lpthread -static -Wl,--unresolved-symbols=ignore-in-object-files"'


### PR DESCRIPTION
This also adds a new "AUTO_GOPATH" environment variable that will create an appropriate GOPATH as part of the build process.

Setting up the GOPATH in a sane way automatically is something that has been requested many, many times over, including and especially by packagers (see also https://github.com/Homebrew/homebrew/pull/26488#issuecomment-34573742 for the most recent request that I'm aware of).

Since this isn't something that everyone will universally want (ie, `GOPATH` is a very personal thing, and some people want to have absolute control over that and we respect them for it), this is not the default (especially since our own Dockerfile environment sets this up properly in a sane way).
