### PR TITLE
Add aliases for exposed ports

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -305,6 +305,7 @@ Thomas LEVEIL <thomasleveil@gmail.com>
 Tianon Gravi <admwiggin@gmail.com>
 Tim Bosse <maztaim@users.noreply.github.com>
 Tim Terhorst <mynamewastaken+git@gmail.com>
+Tim Toomey <tim@toomey.co.nz>
 Tobias Bieniek <Tobias.Bieniek@gmx.de>
 Tobias Schmidt <ts@soundcloud.com>
 Tobias Schwab <tobias.schwab@dynport.de>

--- a/commands.go
+++ b/commands.go
@@ -1895,7 +1895,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		if strings.Contains(e, ":") {
 			return nil, nil, cmd, fmt.Errorf("Invalid port format for --expose: %s", e)
 		}
-		p := NewPort(splitProtoPort(e))
+		p := NewPort(splitPortEntry(e))
 		if _, exists := ports[p]; !exists {
 			ports[p] = struct{}{}
 		}

--- a/container.go
+++ b/container.go
@@ -194,7 +194,7 @@ type PortBinding struct {
 	HostPort string
 }
 
-// 80/tcp
+// 80/tcp/alias
 type Port string
 
 func (p Port) Proto() string {
@@ -209,6 +209,14 @@ func (p Port) Port() string {
 	return strings.Split(string(p), "/")[0]
 }
 
+func (p Port) Alias() string {
+	parts := strings.Split(string(p), "/")
+	if len(parts) != 3 {
+		return ""
+	}
+	return parts[2]
+}
+
 func (p Port) Int() int {
 	i, err := parsePort(p.Port())
 	if err != nil {
@@ -217,8 +225,12 @@ func (p Port) Int() int {
 	return i
 }
 
-func NewPort(proto, port string) Port {
-	return Port(fmt.Sprintf("%s/%s", port, proto))
+func NewPort(proto, port, alias string) Port {
+	portStr := fmt.Sprintf("%s/%s", port, proto)
+	if alias != "" {
+		portStr = fmt.Sprintf("%s/%s/%s", port, proto, alias)
+	}
+	return Port(portStr)
 }
 
 type PortMapping map[string]string // Deprecated

--- a/links.go
+++ b/links.go
@@ -51,22 +51,28 @@ func (l *Link) Alias() string {
 
 func (l *Link) ToEnv() []string {
 	env := []string{}
-	alias := strings.ToUpper(l.Alias())
+	linkAlias := strings.ToUpper(l.Alias())
 
 	if p := l.getDefaultPort(); p != nil {
-		env = append(env, fmt.Sprintf("%s_PORT=%s://%s:%s", alias, p.Proto(), l.ChildIP, p.Port()))
+		env = append(env, fmt.Sprintf("%s_PORT=%s://%s:%s", linkAlias, p.Proto(), l.ChildIP, p.Port()))
 	}
 
 	// Load exposed ports into the environment
 	for _, p := range l.Ports {
-		env = append(env, fmt.Sprintf("%s_PORT_%s_%s=%s://%s:%s", alias, p.Port(), strings.ToUpper(p.Proto()), p.Proto(), l.ChildIP, p.Port()))
-		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_ADDR=%s", alias, p.Port(), strings.ToUpper(p.Proto()), l.ChildIP))
-		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_PORT=%s", alias, p.Port(), strings.ToUpper(p.Proto()), p.Port()))
-		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_PROTO=%s", alias, p.Port(), strings.ToUpper(p.Proto()), p.Proto()))
+		env = append(env, fmt.Sprintf("%s_PORT_%s_%s=%s://%s:%s", linkAlias, p.Port(), strings.ToUpper(p.Proto()), p.Proto(), l.ChildIP, p.Port()))
+		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_ADDR=%s", linkAlias, p.Port(), strings.ToUpper(p.Proto()), l.ChildIP))
+		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_PORT=%s", linkAlias, p.Port(), strings.ToUpper(p.Proto()), p.Port()))
+		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_PROTO=%s", linkAlias, p.Port(), strings.ToUpper(p.Proto()), p.Proto()))
+		if portAlias := p.Alias(); portAlias != "" {
+			env = append(env, fmt.Sprintf("%s_%s=%s://%s:%s", linkAlias, strings.ToUpper(portAlias), p.Proto(), l.ChildIP, p.Port()))
+			env = append(env, fmt.Sprintf("%s_%s_ADDR=%s", linkAlias, strings.ToUpper(portAlias), l.ChildIP))
+			env = append(env, fmt.Sprintf("%s_%s_PORT=%s", linkAlias, strings.ToUpper(portAlias), p.Port()))
+			env = append(env, fmt.Sprintf("%s_%s_PROTO=%s", linkAlias, strings.ToUpper(portAlias), p.Proto()))
+		}
 	}
 
 	// Load the linked container's name into the environment
-	env = append(env, fmt.Sprintf("%s_NAME=%s", alias, l.Name))
+	env = append(env, fmt.Sprintf("%s_NAME=%s", linkAlias, l.Name))
 
 	if l.ChildEnvironment != nil {
 		for _, v := range l.ChildEnvironment {
@@ -78,7 +84,7 @@ func (l *Link) ToEnv() []string {
 			if parts[0] == "HOME" || parts[0] == "PATH" {
 				continue
 			}
-			env = append(env, fmt.Sprintf("%s_ENV_%s=%s", alias, parts[0], parts[1]))
+			env = append(env, fmt.Sprintf("%s_ENV_%s=%s", linkAlias, parts[0], parts[1]))
 		}
 	}
 	return env

--- a/links_test.go
+++ b/links_test.go
@@ -66,7 +66,7 @@ func TestLinkEnv(t *testing.T) {
 	from.State = State{Running: true}
 	ports := make(map[Port]struct{})
 
-	ports[Port("6379/tcp")] = struct{}{}
+	ports[Port("6379/tcp/testalias")] = struct{}{}
 
 	from.Config.ExposedPorts = ports
 
@@ -100,6 +100,21 @@ func TestLinkEnv(t *testing.T) {
 	}
 	if env["DOCKER_PORT_6379_TCP_PORT"] != "6379" {
 		t.Fatalf("Expected 6379, got %s", env["DOCKER_PORT_6379_TCP_PORT"])
+	}
+	if env["DOCKER_TESTALIAS"] != "tcp://172.0.17.2:6379" {
+		t.Fatalf("Expected 172.0.17.2:6379, got %s", env["DOCKER_TESTALIAS"])
+	}
+	if env["DOCKER_TESTALIAS"] != "tcp://172.0.17.2:6379" {
+		t.Fatalf("Expected tcp://172.0.17.2:6379, got %s", env["DOCKER_TESTALIAS"])
+	}
+	if env["DOCKER_TESTALIAS_PROTO"] != "tcp" {
+		t.Fatalf("Expected tcp, got %s", env["DOCKER_TESTALIAS_PROTO"])
+	}
+	if env["DOCKER_TESTALIAS_ADDR"] != "172.0.17.2" {
+		t.Fatalf("Expected 172.0.17.2, got %s", env["DOCKER_TESTALIAS_ADDR"])
+	}
+	if env["DOCKER_TESTALIAS_PORT"] != "6379" {
+		t.Fatalf("Expected 6379, got %s", env["DOCKER_TESTALIAS_PORT"])
 	}
 	if env["DOCKER_NAME"] != "/db/docker" {
 		t.Fatalf("Expected /db/docker, got %s", env["DOCKER_NAME"])


### PR DESCRIPTION
Provides the ability to name any ports that are exposed through `-p`, `-expose` or `EXPOSE`, implementing https://github.com/dotcloud/docker/issues/2435.

The addition lets you declare aliases as;

```
# Manually declared
docker run -p 80#webserver <image> <cmd>
docker run -expose 80/tcp#webserver <image> <cmd>

# In a Dockerfile
EXPOSE 80#webserver
```

and any linked containers will then have the additional env vars exposed as;

```
<link name>_WEBSERVER=tcp://172.17.0.2:80
<link name>_WEBSERVER_ADDR=172.17.0.2
<link name>_WEBSERVER_PORT=80
<link name>_WEBSERVER_PROTO=tcp
```

Docker-DCO-1.1-Signed-off-by: Tim Toomey tim@toomey.co.nz (github: tim-mit)
