### PR TITLE
Package coverage when running integration tests

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -16,7 +16,7 @@ set -e
 #   in the Dockerfile at the root of the source. In other words:
 #   DO NOT CALL THIS SCRIPT DIRECTLY.
 # - The right way to call this script is to invoke "make" from
-#   your checkout of the Docker repository. 
+#   your checkout of the Docker repository.
 #   the Makefile will do a "docker build -t docker ." and then
 #   "docker run hack/make.sh" in the resulting container image.
 #
@@ -101,19 +101,30 @@ fi
 #
 go_test_dir() {
 	dir=$1
+	coverpkg=$2
 	testcover=()
 	if [ "$HAVE_GO_TEST_COVER" ]; then
 		# if our current go install has -cover, we want to use it :)
 		mkdir -p "$DEST/coverprofiles"
 		coverprofile="docker${dir#.}"
 		coverprofile="$DEST/coverprofiles/${coverprofile//\//-}"
-		testcover=( -cover -coverprofile "$coverprofile" )
+		testcover=( -cover -coverprofile "$coverprofile" $coverpkg )
 	fi
 	(
 		set -x
 		cd "$dir"
 		go test ${testcover[@]} -ldflags "$LDFLAGS" $BUILDFLAGS $TESTFLAGS
 	)
+}
+
+# This helper function walks the current directory looking for directories
+# holding certain files ($1 parameter), and prints their paths on standard
+# output, one per line.
+find_dirs() {
+	find -not \( \
+		\( -wholename './vendor' -o -wholename './integration' -o -wholename './contrib' -o -wholename './pkg/mflag/example' \) \
+		-prune \
+	\) -name "$1" -print0 | xargs -0n1 dirname | sort -u
 }
 
 bundle() {

--- a/hack/make/test
+++ b/hack/make/test
@@ -19,7 +19,7 @@ bundle_test() {
 		date
 
 		TESTS_FAILED=()
-		for test_dir in $(find_test_dirs); do
+		for test_dir in $(find_dirs '*_test.go'); do
 			echo
 
 			if ! LDFLAGS="$LDFLAGS $LDFLAGS_STATIC" go_test_dir "$test_dir"; then
@@ -46,17 +46,6 @@ bundle_test() {
 			true
 		fi
 	} 2>&1 | tee $DEST/test.log
-}
-
-
-# This helper function walks the current directory looking for directories
-# holding Go test files, and prints their paths on standard output, one per
-# line.
-find_test_dirs() {
-	find -not \( \
-		\( -wholename './vendor' -o -wholename './integration' \) \
-		-prune \
-	\) -name '*_test.go' -print0 | xargs -0n1 dirname | sort -u
 }
 
 bundle_test

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -5,7 +5,8 @@ DEST=$1
 set -e
 
 bundle_test_integration() {
-	LDFLAGS="$LDFLAGS $LDFLAGS_STATIC" go_test_dir ./integration
+	LDFLAGS="$LDFLAGS $LDFLAGS_STATIC" go_test_dir ./integration \
+		"-coverpkg $(find_dirs '*.go' | sed 's,^\.,github.com/dotcloud/docker,g' | paste -d, -s)"
 }
 
 bundle_test_integration 2>&1 | tee $DEST/test.log


### PR DESCRIPTION
If coverpkg is missing on `go test` command, only the current package
will be covered. That's the case of unit tests. For integration tests
we need to explicitly declare each package.
