### PR TITLE
devmapper: Remove directory when removing devicemapper device

### DIFF
--- a/graphdriver/devmapper/driver.go
+++ b/graphdriver/devmapper/driver.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dotcloud/docker/graphdriver"
 	"github.com/dotcloud/docker/utils"
 	"io/ioutil"
+	"os"
 	"path"
 )
 
@@ -94,7 +95,16 @@ func (d *Driver) Remove(id string) error {
 		return err
 	}
 	// This assumes the device has been properly Get/Put:ed and thus is unmounted
-	return d.DeviceSet.DeleteDevice(id)
+	if err := d.DeviceSet.DeleteDevice(id); err != nil {
+		return err
+	}
+
+	mp := path.Join(d.home, "mnt", id)
+	if err := os.RemoveAll(mp); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
 }
 
 func (d *Driver) Get(id string) (string, error) {


### PR DESCRIPTION
We're currently leaving around lots of empty directories in
/var/lib/docker/devicemapper/mnt/ for removed images and containers.
Fix this by removing the directory when the device is removed.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
