### PR TITLE
devicemapper: Fix tests on fedora

### DIFF
--- a/graphdriver/devmapper/driver_test.go
+++ b/graphdriver/devmapper/driver_test.go
@@ -136,7 +136,12 @@ type Set map[string]bool
 
 func (r Set) Assert(t *testing.T, names ...string) {
 	for _, key := range names {
-		if _, exists := r[key]; !exists {
+		required := true
+		if strings.HasPrefix(key, "?") {
+			key = key[1:]
+			required = false
+		}
+		if _, exists := r[key]; !exists && required {
 			t.Fatalf("Key not set: %s", key)
 		}
 		delete(r, key)
@@ -486,6 +491,7 @@ func TestDriverCreate(t *testing.T) {
 			"ioctl.blkgetsize",
 			"ioctl.loopsetfd",
 			"ioctl.loopsetstatus",
+			"?ioctl.loopctlgetfree",
 		)
 
 		if err := d.Create("1", ""); err != nil {
@@ -603,6 +609,7 @@ func TestDriverRemove(t *testing.T) {
 			"ioctl.blkgetsize",
 			"ioctl.loopsetfd",
 			"ioctl.loopsetstatus",
+			"?ioctl.loopctlgetfree",
 		)
 
 		if err := d.Create("1", ""); err != nil {


### PR DESCRIPTION
If /dev/loop-control exists on the system running the test then
ioctlLoopCtlGetFree() will be called, but if not it won't.  It does
not exist in the standard docker build environment, so the tests
currently require this to not be called. This makes it instead
optional, allowing the tests to run on e.g. Fedora.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
