### PR TITLE
lxc: Drop NET_ADMIN capability in non-privileged containers

### DIFF
--- a/execdriver/lxc/init.go
+++ b/execdriver/lxc/init.go
@@ -127,6 +127,7 @@ func setupCapabilities(args *execdriver.InitArgs) error {
 		capability.CAP_AUDIT_CONTROL,
 		capability.CAP_MAC_OVERRIDE,
 		capability.CAP_MAC_ADMIN,
+		capability.CAP_NET_ADMIN,
 	}
 
 	c, err := capability.NewPid(os.Getpid())


### PR DESCRIPTION
With this capability set the container can e.g. change the ip address
of his devices to that of another container on the docker0 bridge. In
a quick test I was able to listen to a port on a different ip than the
one docker assigned me, but was not able to hijack an open port
redirection that another container had open. Maybe its possible with
some more knowledge of networking though.

Anyway, network setup is meant to be handled by docker, not the apps,
so I believe denying this is generally in the spirit of docker, and
it closes down potential security issues.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
