### PR TITLE
Avoid extra mount/unmount during container registration

### DIFF
--- a/runtime.go
+++ b/runtime.go
@@ -133,14 +133,6 @@ func (runtime *Runtime) Register(container *Container) error {
 		return err
 	}
 
-	// Get the root filesystem from the driver
-	basefs, err := runtime.driver.Get(container.ID)
-	if err != nil {
-		return fmt.Errorf("Error getting container filesystem %s from driver %s: %s", container.ID, runtime.driver, err)
-	}
-	defer runtime.driver.Put(container.ID)
-	container.basefs = basefs
-
 	container.runtime = runtime
 
 	// Attach to stdout and stderr


### PR DESCRIPTION
Runtime.Register() called driver.Get()/Put() in order to read back the
basefs of the container. However, this is not needed, as the basefs
is read during container.Mount() anyway, and basefs is only valid
while mounted (and all current calls satisfy this).

This seems minor, but this is actually problematic, as the Get/Put
pair will create a spurious mount/unmount cycle that is not needed and
slows things down. Additionally it will create a supurious
devicemapper activate/deactivate cycle that causes races with udev as
seen in https://github.com/dotcloud/docker/issues/4036.

With this change devicemapper is now race-free, and container startup
is slightly faster.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
