### PR TITLE
Skip links to .wh..wh.

### DIFF
--- a/archive/diff.go
+++ b/archive/diff.go
@@ -74,6 +74,9 @@ func ApplyLayer(dest string, layer Archive) error {
 		if strings.HasPrefix(hdr.Name, ".wh..wh.") {
 			continue
 		}
+		if strings.HasPrefix(filepath.Clean(hdr.Linkname), ".wh..wh.") {
+			continue
+		}
 
 		path := filepath.Join(dest, hdr.Name)
 		base := filepath.Base(path)


### PR DESCRIPTION
When using btrfs or device mapper, we skip all the aufs metadata, starting with `.wh..wh*` ourselves; so the `.wh..wh.plnk` directory is skipped.
We should also skip all the links pointing to this directory.

@alexlarsson could you take a look ? It fixes an issue, but I'm not too familiar with the code. I don't know if we should also add some similar stuff in `archive/changes.go`

ping @jpetazzo @crosbymichael @creack

FYI @dhrp @jlhawn this fixes your issue.
