### PR TITLE
Remove useless code in client implementation of 'run'.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -1993,12 +1993,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	stream, statusCode, err := cli.call("POST", "/containers/create?"+containerValues.Encode(), config, false)
 	//if image not found try to pull it
 	if statusCode == 404 {
-		_, tag := utils.ParseRepositoryTag(config.Image)
-		if tag == "" {
-			tag = DEFAULTTAG
-		}
-
-		fmt.Fprintf(cli.err, "Unable to find image '%s' (tag: %s) locally\n", config.Image, tag)
+		fmt.Fprintf(cli.err, "Unable to find image '%s' locally\n", config.Image)
 
 		v := url.Values{}
 		repos, tag := utils.ParseRepositoryTag(config.Image)


### PR DESCRIPTION
This facilitates refactoring commands.go.

Docker-DCO-1.1-Signed-off-by: Solomon Hykes solomon@docker.com (github: shykes)
