### PR TITLE
Improve documentation around -H option:

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -46,7 +46,7 @@ func main() {
 		flMtu                = flag.Int([]string{"#mtu", "-mtu"}, 0, "Set the containers network MTU; if no value is provided: default to the default route MTU or 1500 if not default route is available")
 	)
 	flag.Var(&flDns, []string{"#dns", "-dns"}, "Force docker to use specific DNS servers")
-	flag.Var(&flHosts, []string{"H", "-host"}, "tcp://host:port, unix://path/to/socket, fd://* or fd://socketfd to use in daemon mode. Multiple sockets can be specified")
+	flag.Var(&flHosts, []string{"H", "-host"}, "The socket to bind to in daemon mode, specified using tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.")
 
 	flag.Parse()
 

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -64,9 +64,9 @@ Commands
 
 ::
 
-    Usage of docker:
+    Usage:
       -D, --debug=false: Enable debug mode
-      -H, --host=[]: Multiple tcp://host:port or unix://path/to/socket to bind in daemon mode, single connection otherwise. systemd socket activation can be used with fd://[socketfd].
+      -H, --host=[]: The socket to bind to in daemon mode, specified using tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.
       --api-enable-cors=false: Enable CORS headers in the remote API
       -b, --bridge="": Attach containers to a pre-existing network bridge; use 'none' to disable container networking
       --bip="": Use this CIDR notation address for the network bridge's IP, not compatible with -b
@@ -82,7 +82,9 @@ Commands
       -v, --version=false: Print version information and quit
       -mtu, --mtu=0: Set the containers network MTU; if no value is provided: default to the default route MTU or 1500 if not default route is available
 
-The Docker daemon is the persistent process that manages containers.  Docker uses the same binary for both the 
+    Options with [] may be specified multiple times.
+
+The Docker daemon is the persistent process that manages containers.  Docker uses the same binary for both the
 daemon and client.  To run the daemon you provide the ``-d`` flag.
 
 To force Docker to use devicemapper as the storage driver, use ``docker -d -s devicemapper``.


### PR DESCRIPTION
- unix://path/to/socket should read unix:///path/to/socket like the rest of the documentation (a slash was missing)
- Explicitly mention that the -H option itself may be specified multiple times, rather than the value being specified multiple times for a single -H option.

Docker-DCO-1.1-Signed-off-by: Mike MacCana mike.maccana@gmail.com (github: mikemaccana)
