### PR TITLE
Fix bogus variable reference in mkimage-yum.sh

### DIFF
--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -51,7 +51,7 @@ done
 
 yum -c "$yum_config" --installroot="$target" --setopt=tsflags=nodocs \
     --setopt=group_package_types=mandatory -y groupinstall Core
-yum -c "$yum_config" --installroot="$mount" -y clean all
+yum -c "$yum_config" --installroot="$target" -y clean all
 
 cat > "$target"/etc/sysconfig/network <<EOF
 NETWORKING=yes


### PR DESCRIPTION
Fixes this: https://github.com/dotcloud/docker/commit/d419da7227826e84e9375ece4fd9d4978a42cbf7#commitcomment-5344982

cc @bbense
