### PR TITLE
disallow tcp:// from defaulting to 127.0.0.1:4243

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -31,12 +31,11 @@ import (
 const (
 	APIVERSION        = 1.9
 	DEFAULTHTTPHOST   = "127.0.0.1"
-	DEFAULTHTTPPORT   = 4243
 	DEFAULTUNIXSOCKET = "/var/run/docker.sock"
 )
 
 func ValidateHost(val string) (string, error) {
-	host, err := utils.ParseHost(DEFAULTHTTPHOST, DEFAULTHTTPPORT, DEFAULTUNIXSOCKET, val)
+	host, err := utils.ParseHost(DEFAULTHTTPHOST, DEFAULTUNIXSOCKET, val)
 	if err != nil {
 		return val, err
 	}

--- a/docs/sources/installation/mac.rst
+++ b/docs/sources/installation/mac.rst
@@ -72,7 +72,7 @@ Run the following commands to get it downloaded and set up:
     chmod +x docker
 
     # Set the environment variable for the docker daemon
-    export DOCKER_HOST=tcp://
+    export DOCKER_HOST=tcp://127.0.0.1:4243
 
     # Copy the executable file
     sudo cp docker /usr/local/bin/

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -12,7 +12,7 @@ To list available commands, either run ``docker`` with no parameters or execute
 
   $ sudo docker
     Usage: docker [OPTIONS] COMMAND [arg...]
-      -H=[unix:///var/run/docker.sock]: tcp://[host[:port]] to bind/connect to or unix://[/path/to/socket] to use. When host=[0.0.0.0], port=[4243] or path=[/var/run/docker.sock] is omitted, default values are used.
+      -H=[unix:///var/run/docker.sock]: tcp://[host]:port to bind/connect to or unix://[/path/to/socket] to use. When host=[127.0.0.1] is omitted for tcp or path=[/var/run/docker.sock] is omitted for unix sockets, default values are used.
 
     A self-sufficient runtime for linux containers.
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -301,34 +301,36 @@ func assertRAMInBytes(t *testing.T, size string, expectError bool, expectedBytes
 func TestParseHost(t *testing.T) {
 	var (
 		defaultHttpHost = "127.0.0.1"
-		defaultHttpPort = 4243
 		defaultUnix     = "/var/run/docker.sock"
 	)
-	if addr, err := ParseHost(defaultHttpHost, defaultHttpPort, defaultUnix, "0.0.0.0"); err != nil || addr != "tcp://0.0.0.0:4243" {
-		t.Errorf("0.0.0.0 -> expected tcp://0.0.0.0:4243, got %s", addr)
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "0.0.0.0"); err == nil {
+		t.Errorf("tcp 0.0.0.0 address expected error return, but err == nil, got %s", addr)
 	}
-	if addr, err := ParseHost(defaultHttpHost, defaultHttpPort, defaultUnix, "0.0.0.1:5555"); err != nil || addr != "tcp://0.0.0.1:5555" {
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "tcp://"); err == nil {
+		t.Errorf("default tcp:// address expected error return, but err == nil, got %s", addr)
+	}
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "0.0.0.1:5555"); err != nil || addr != "tcp://0.0.0.1:5555" {
 		t.Errorf("0.0.0.1:5555 -> expected tcp://0.0.0.1:5555, got %s", addr)
 	}
-	if addr, err := ParseHost(defaultHttpHost, defaultHttpPort, defaultUnix, ":6666"); err != nil || addr != "tcp://127.0.0.1:6666" {
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, ":6666"); err != nil || addr != "tcp://127.0.0.1:6666" {
 		t.Errorf(":6666 -> expected tcp://127.0.0.1:6666, got %s", addr)
 	}
-	if addr, err := ParseHost(defaultHttpHost, defaultHttpPort, defaultUnix, "tcp://:7777"); err != nil || addr != "tcp://127.0.0.1:7777" {
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "tcp://:7777"); err != nil || addr != "tcp://127.0.0.1:7777" {
 		t.Errorf("tcp://:7777 -> expected tcp://127.0.0.1:7777, got %s", addr)
 	}
-	if addr, err := ParseHost(defaultHttpHost, defaultHttpPort, defaultUnix, ""); err != nil || addr != "unix:///var/run/docker.sock" {
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, ""); err != nil || addr != "unix:///var/run/docker.sock" {
 		t.Errorf("empty argument -> expected unix:///var/run/docker.sock, got %s", addr)
 	}
-	if addr, err := ParseHost(defaultHttpHost, defaultHttpPort, defaultUnix, "unix:///var/run/docker.sock"); err != nil || addr != "unix:///var/run/docker.sock" {
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "unix:///var/run/docker.sock"); err != nil || addr != "unix:///var/run/docker.sock" {
 		t.Errorf("unix:///var/run/docker.sock -> expected unix:///var/run/docker.sock, got %s", addr)
 	}
-	if addr, err := ParseHost(defaultHttpHost, defaultHttpPort, defaultUnix, "unix://"); err != nil || addr != "unix:///var/run/docker.sock" {
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "unix://"); err != nil || addr != "unix:///var/run/docker.sock" {
 		t.Errorf("unix:///var/run/docker.sock -> expected unix:///var/run/docker.sock, got %s", addr)
 	}
-	if addr, err := ParseHost(defaultHttpHost, defaultHttpPort, defaultUnix, "udp://127.0.0.1"); err == nil {
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "udp://127.0.0.1"); err == nil {
 		t.Errorf("udp protocol address expected error return, but err == nil. Got %s", addr)
 	}
-	if addr, err := ParseHost(defaultHttpHost, defaultHttpPort, defaultUnix, "udp://127.0.0.1:4243"); err == nil {
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "udp://127.0.0.1:4243"); err == nil {
 		t.Errorf("udp protocol address expected error return, but err == nil. Got %s", addr)
 	}
 }


### PR DESCRIPTION
This stops docker from accepting tcp:// as a valid bind address.

This makes Docker accept only addresses such as:

```
tcp://:5111
tcp://127.0.0.1:5111
```

This also contains 2 documentation related changes.
