### PR TITLE
Image tag endpoint HTTP code typo

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.0.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.0.rst
@@ -732,11 +732,11 @@ Tag an image into a repository
 
         .. sourcecode:: http
 
-           HTTP/1.1 200 OK
+           HTTP/1.1 201 OK
 
 	:query repo: The repository to tag in
 	:query force: 1/True/true or 0/False/false, default false
-	:statuscode 200: no error
+	:statuscode 201: no error
 	:statuscode 400: bad parameter
 	:statuscode 404: no such image
         :statuscode 500: server error

--- a/docs/sources/reference/api/docker_remote_api_v1.1.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.1.rst
@@ -742,11 +742,11 @@ Tag an image into a repository
 
         .. sourcecode:: http
 
-           HTTP/1.1 200 OK
+           HTTP/1.1 201 OK
 
 	:query repo: The repository to tag in
 	:query force: 1/True/true or 0/False/false, default false
-	:statuscode 200: no error
+	:statuscode 201: no error
 	:statuscode 400: bad parameter
 	:statuscode 404: no such image
 	:statuscode 409: conflict

--- a/docs/sources/reference/api/docker_remote_api_v1.2.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.2.rst
@@ -761,11 +761,11 @@ Tag an image into a repository
 
         .. sourcecode:: http
 
-           HTTP/1.1 200 OK
+           HTTP/1.1 201 OK
 
 	:query repo: The repository to tag in
 	:query force: 1/True/true or 0/False/false, default false
-	:statuscode 200: no error
+	:statuscode 201: no error
 	:statuscode 400: bad parameter
 	:statuscode 404: no such image
 	:statuscode 409: conflict

--- a/docs/sources/reference/api/docker_remote_api_v1.3.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.3.rst
@@ -808,11 +808,11 @@ Tag an image into a repository
 
         .. sourcecode:: http
 
-           HTTP/1.1 200 OK
+           HTTP/1.1 201 OK
 
 	:query repo: The repository to tag in
 	:query force: 1/True/true or 0/False/false, default false
-	:statuscode 200: no error
+	:statuscode 201: no error
 	:statuscode 400: bad parameter
 	:statuscode 404: no such image
 	:statuscode 409: conflict

--- a/docs/sources/reference/api/docker_remote_api_v1.4.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.4.rst
@@ -852,11 +852,11 @@ Tag an image into a repository
 
         .. sourcecode:: http
 
-           HTTP/1.1 200 OK
+           HTTP/1.1 201 OK
 
 	:query repo: The repository to tag in
 	:query force: 1/True/true or 0/False/false, default false
-	:statuscode 200: no error
+	:statuscode 201: no error
 	:statuscode 400: bad parameter
 	:statuscode 404: no such image
 	:statuscode 409: conflict

--- a/docs/sources/reference/api/docker_remote_api_v1.5.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.5.rst
@@ -831,11 +831,11 @@ Tag an image into a repository
 
   .. sourcecode:: http
 
-    HTTP/1.1 200 OK
+    HTTP/1.1 201 OK
 
   :query repo: The repository to tag in
   :query force: 1/True/true or 0/False/false, default false
-  :statuscode 200: no error
+  :statuscode 201: no error
   :statuscode 400: bad parameter
   :statuscode 404: no such image
   :statuscode 409: conflict

--- a/docs/sources/reference/api/docker_remote_api_v1.6.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.6.rst
@@ -958,11 +958,11 @@ Tag an image into a repository
 
         .. sourcecode:: http
 
-           HTTP/1.1 200 OK
+           HTTP/1.1 201 OK
 
 	:query repo: The repository to tag in
 	:query force: 1/True/true or 0/False/false, default false
-	:statuscode 200: no error
+	:statuscode 201: no error
 	:statuscode 400: bad parameter
 	:statuscode 404: no such image
 	:statuscode 409: conflict

--- a/docs/sources/reference/api/docker_remote_api_v1.7.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.7.rst
@@ -877,11 +877,11 @@ Tag an image into a repository
 
         .. sourcecode:: http
 
-           HTTP/1.1 200 OK
+           HTTP/1.1 201 OK
 
 	:query repo: The repository to tag in
 	:query force: 1/True/true or 0/False/false, default false
-	:statuscode 200: no error
+	:statuscode 201: no error
 	:statuscode 400: bad parameter
 	:statuscode 404: no such image
 	:statuscode 409: conflict

--- a/docs/sources/reference/api/docker_remote_api_v1.8.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.8.rst
@@ -892,11 +892,11 @@ Tag an image into a repository
 
         .. sourcecode:: http
 
-           HTTP/1.1 200 OK
+           HTTP/1.1 201 OK
 
         :query repo: The repository to tag in
         :query force: 1/True/true or 0/False/false, default false
-        :statuscode 200: no error
+        :statuscode 201: no error
         :statuscode 400: bad parameter
         :statuscode 404: no such image
         :statuscode 409: conflict

--- a/docs/sources/reference/api/docker_remote_api_v1.9.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.9.rst
@@ -892,11 +892,11 @@ Tag an image into a repository
 
         .. sourcecode:: http
 
-           HTTP/1.1 200 OK
+           HTTP/1.1 201 OK
 
         :query repo: The repository to tag in
         :query force: 1/True/true or 0/False/false, default false
-        :statuscode 200: no error
+        :statuscode 201: no error
         :statuscode 400: bad parameter
         :statuscode 404: no such image
         :statuscode 409: conflict


### PR DESCRIPTION
Documentation says success is 200 for this endpoint, but source is sending 201.

https://github.com/dotcloud/docker/blob/master/api/api.go#L366
