### PR TITLE
remove unneeded sysctl changes in sysvinit-redhat init script

### DIFF
--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -37,11 +37,6 @@ prestart() {
         service cgconfig start
     fi
 
-    preexec="/sbin/sysctl"
-    [ -x $preexec ] || exit 6
-    $preexec -w net.ipv4.ip_forward=1 > /dev/null 2>&1
-    $preexec -w net.ipv6.conf.all.forwarding=1 > /dev/null 2>&1
-
 }
 
 start() {


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Adam Miller admiller@redhat.com (github: maxamillion)

We don't need these sysctl params.
The ipv4 one is no longer needed as per https://github.com/dotcloud/docker/pull/3801
The ipv6 one isn't necessary since there's no ipv6 support for docker.
