### PR TITLE
Add overlayfs backend

### DIFF
--- a/archive/changes.go
+++ b/archive/changes.go
@@ -293,10 +293,17 @@ func collectFileInfo(sourceDir string) (*FileInfo, error) {
 
 // Compare two directories and generate an array of Change objects describing the changes
 func ChangesDirs(newDir, oldDir string) ([]Change, error) {
-	oldRoot, err := collectFileInfo(oldDir)
-	if err != nil {
-		return nil, err
+	var oldRoot *FileInfo
+	var err error
+	if oldDir != "" {
+		oldRoot, err = collectFileInfo(oldDir)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		oldRoot = newRootFileInfo()
 	}
+
 	newRoot, err := collectFileInfo(newDir)
 	if err != nil {
 		return nil, err

--- a/graphdriver/driver.go
+++ b/graphdriver/driver.go
@@ -43,6 +43,7 @@ var (
 		"vfs",
 		// experimental, has to be enabled manually for now
 		"btrfs",
+		"overlayfs",
 	}
 )
 

--- a/graphdriver/overlayfs/copy.go
+++ b/graphdriver/overlayfs/copy.go
@@ -1,0 +1,148 @@
+// +build linux
+
+package overlayfs
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/pkg/system"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+type CopyFlags int
+
+const (
+	CopyHardlink CopyFlags = 1 << iota
+)
+
+func copyRegular(srcPath, dstPath string, mode os.FileMode) error {
+	srcFile, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE, mode)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+
+	return err
+}
+
+func copyXattr(srcPath, dstPath, attr string) error {
+	data, err := system.Lgetxattr(srcPath, attr)
+	if err != nil {
+		return err
+	}
+	if data != nil {
+		if err := system.Lsetxattr(dstPath, attr, data, 0); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyDir(srcDir, dstDir string, flags CopyFlags) error {
+	err := filepath.Walk(srcDir, func(srcPath string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Rebase path
+		relPath, err := filepath.Rel(srcDir, srcPath)
+		if err != nil {
+			return err
+		}
+
+		dstPath := filepath.Join(dstDir, relPath)
+		if err != nil {
+			return err
+		}
+
+		stat, ok := f.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("Unable to get raw syscall.Stat_t data for %s", srcPath)
+		}
+
+		switch f.Mode() & os.ModeType {
+		case 0: // Regular file
+			if flags&CopyHardlink != 0 {
+				if err := os.Link(srcPath, dstPath); err != nil {
+					return err
+				}
+			} else {
+				if err := copyRegular(srcPath, dstPath, f.Mode()); err != nil {
+					return err
+				}
+			}
+
+		case os.ModeDir:
+			if err := os.Mkdir(dstPath, f.Mode()); err != nil && !os.IsExist(err) {
+				return err
+			}
+
+		case os.ModeSymlink:
+			link, err := os.Readlink(srcPath)
+			if err != nil {
+				return err
+			}
+
+			if err := os.Symlink(link, dstPath); err != nil {
+				return err
+			}
+
+		case os.ModeNamedPipe:
+			fallthrough
+		case os.ModeSocket:
+			if err := syscall.Mkfifo(dstPath, stat.Mode); err != nil {
+				return err
+			}
+
+		case os.ModeDevice:
+			if err := syscall.Mknod(dstPath, stat.Mode, int(stat.Rdev)); err != nil {
+				return err
+			}
+
+		default:
+			return fmt.Errorf("Unknown file type for %s\n", srcPath)
+		}
+
+		if err := os.Lchown(dstPath, int(stat.Uid), int(stat.Gid)); err != nil {
+			return err
+		}
+
+		if err := copyXattr(srcPath, dstPath, "trusted.overlay.whiteout"); err != nil {
+			return err
+		}
+
+		isSymlink := f.Mode()&os.ModeSymlink != 0
+
+		// There is no LChmod, so ignore mode for symlink. Also, this
+		// must happen after chown, as that can modify the file mode
+		if !isSymlink {
+			if err := os.Chmod(dstPath, f.Mode()); err != nil {
+				return err
+			}
+		}
+
+		ts := []syscall.Timespec{stat.Atim, stat.Mtim}
+		// syscall.UtimesNano doesn't support a NOFOLLOW flag atm, and
+		if !isSymlink {
+			if err := system.UtimesNano(dstPath, ts); err != nil {
+				return err
+			}
+		} else {
+			if err := system.LUtimesNano(dstPath, ts); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return err
+}

--- a/graphdriver/overlayfs/overlayfs.go
+++ b/graphdriver/overlayfs/overlayfs.go
@@ -1,0 +1,354 @@
+// +build linux
+
+package overlayfs
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/archive"
+	"github.com/dotcloud/docker/graphdriver"
+	"github.com/dotcloud/docker/utils"
+	"io/ioutil"
+	"os"
+	"path"
+	"sync"
+	"syscall"
+)
+
+type ActiveMount struct {
+	count   int
+	path    string
+	mounted bool
+}
+
+type Driver struct {
+	home       string
+	sync.Mutex // Protects concurrent modification to active
+	active     map[string]*ActiveMount
+}
+
+func init() {
+	graphdriver.Register("overlayfs", Init)
+}
+func Init(home string) (graphdriver.Driver, error) {
+	// Create the driver home dir
+	if err := os.MkdirAll(home, 0755); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
+	d := &Driver{
+		home:   home,
+		active: make(map[string]*ActiveMount),
+	}
+
+	return d, nil
+}
+
+func (d *Driver) String() string {
+	return "overlayfs"
+}
+
+func (d *Driver) Status() [][2]string {
+	return nil
+}
+
+func (d *Driver) Cleanup() error {
+	return nil
+}
+
+func (d *Driver) Create(id string, parent string) (retErr error) {
+	dir := d.dir(id)
+	if err := os.MkdirAll(path.Dir(dir), 0700); err != nil {
+		return err
+	}
+	if err := os.Mkdir(dir, 0700); err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(path.Join(dir, "parent"), []byte(parent), 0666); err != nil {
+		return err
+	}
+
+	defer func() {
+		// Clean up on failure
+		if retErr != nil {
+			os.RemoveAll(dir)
+		}
+	}()
+
+	// Toplevel images are just a "root" dir
+	if parent == "" {
+		if err := os.Mkdir(path.Join(dir, "root"), 0700); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	parentDir := d.dir(parent)
+
+	// Ensure parent exists
+	if _, err := os.Lstat(parentDir); err != nil {
+		return err
+	}
+
+	// If parent has a root, just do a overlayfs to it
+	parentRoot := path.Join(parentDir, "root")
+
+	if s, err := os.Lstat(parentRoot); err == nil {
+		if err := os.Mkdir(path.Join(dir, "rw"), s.Mode()); err != nil {
+			return err
+		}
+		if err := os.Mkdir(path.Join(dir, "overlay"), 0700); err != nil {
+			return err
+		}
+		if err := ioutil.WriteFile(path.Join(dir, "rw-parent"), []byte(parent), 0666); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// Otherwise, copy the rw and the parent-id from the parent
+
+	rwParent, err := ioutil.ReadFile(path.Join(parentDir, "rw-parent"))
+	if err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(path.Join(dir, "rw-parent"), rwParent, 0666); err != nil {
+		return err
+	}
+
+	rwDir := path.Join(dir, "rw")
+	if err := os.Mkdir(rwDir, 0700); err != nil {
+		return err
+	}
+	if err := os.Mkdir(path.Join(dir, "overlay"), 0700); err != nil {
+		return err
+	}
+
+	parentRwDir := path.Join(parentDir, "rw")
+	return copyDir(parentRwDir, rwDir, 0)
+}
+
+func (d *Driver) dir(id string) string {
+	return path.Join(d.home, id)
+}
+
+func (d *Driver) Remove(id string) error {
+	dir := d.dir(id)
+	if _, err := os.Stat(dir); err != nil {
+		return err
+	}
+	return os.RemoveAll(dir)
+}
+
+func (d *Driver) Get(id string) (string, error) {
+	// Protect the d.active from concurrent access
+	d.Lock()
+	defer d.Unlock()
+
+	mount := d.active[id]
+	if mount != nil {
+		mount.count++
+		return mount.path, nil
+	} else {
+		mount = &ActiveMount{count: 1}
+	}
+
+	dir := d.dir(id)
+	if _, err := os.Stat(dir); err != nil {
+		return "", err
+	}
+
+	// If id has a root, just return it
+	rootDir := path.Join(dir, "root")
+	if _, err := os.Stat(rootDir); err == nil {
+		mount.path = rootDir
+		d.active[id] = mount
+		return mount.path, nil
+	}
+
+	rwParent, err := ioutil.ReadFile(path.Join(dir, "rw-parent"))
+	if err != nil {
+		return "", err
+	}
+	rwParentRoot := path.Join(d.dir(string(rwParent)), "root")
+	rwDir := path.Join(dir, "rw")
+	overlayDir := path.Join(dir, "overlay")
+
+	if err := syscall.Mount("overlayfs", overlayDir, "overlayfs", 0, fmt.Sprintf("lowerdir=%s,upperdir=%s", rwParentRoot, rwDir)); err != nil {
+		return "", err
+	}
+	mount.path = overlayDir
+	mount.mounted = true
+	d.active[id] = mount
+
+	return mount.path, nil
+}
+
+func (d *Driver) Put(id string) {
+	// Protect the d.active from concurrent access
+	d.Lock()
+	defer d.Unlock()
+
+	mount := d.active[id]
+	if mount == nil {
+		utils.Debugf("Put on a non-mounted device %s", id)
+		return
+	}
+
+	mount.count--
+	if mount.count > 0 {
+		return
+	}
+
+	if mount.mounted {
+		if err := syscall.Unmount(mount.path, 0); err != nil {
+			utils.Debugf("Failed to unmount %s overlayfs: %v", id, err)
+		}
+	}
+
+	delete(d.active, id)
+}
+
+func (d *Driver) Diff(id string) (retArchive archive.Archive, retErr error) {
+	overlayDir, err := d.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr != nil {
+			d.Put(id)
+		}
+	}()
+
+	changes, err := d.Changes(id)
+	if err != nil {
+		return nil, err
+	}
+
+	archive, err := archive.ExportChanges(overlayDir, changes)
+	if err != nil {
+		return nil, err
+	}
+
+	return utils.NewReadCloserWrapper(archive, func() error {
+		err := archive.Close()
+		d.Put(id)
+		return err
+	}), nil
+}
+
+func (d *Driver) ApplyDiff(id string, diff archive.ArchiveReader) (retErr error) {
+	dir := d.dir(id)
+
+	parent, err := ioutil.ReadFile(path.Join(dir, "parent"))
+	if err != nil {
+		return err
+	}
+
+	hasParentRootDir := false
+	parentRootDir := ""
+
+	if string(parent) != "" {
+		parentDir := d.dir(string(parent))
+
+		// If parent has a root, we can just hardlink it and apply the
+		// layer. This relies on two things:
+		// 1) ApplyDiff is only run once on a clean (no rw data) container
+		// 2) ApplyDiff doesn't do any in-place writes to files (would break hardlinks)
+		// These are all currently true
+		parentRootDir = path.Join(parentDir, "root")
+		if _, err := os.Stat(parentRootDir); err == nil {
+			hasParentRootDir = true
+		}
+	}
+
+	if hasParentRootDir || string(parent) == "" {
+		tmpRootDir, err := ioutil.TempDir(dir, "tmproot")
+		if err != nil {
+			return err
+		}
+		defer func() {
+			if retErr != nil {
+				os.RemoveAll(tmpRootDir)
+			}
+		}()
+
+		if hasParentRootDir {
+			if err := copyDir(parentRootDir, tmpRootDir, CopyHardlink); err != nil {
+				return err
+			}
+		}
+
+		if err := archive.ApplyLayer(tmpRootDir, diff); err != nil {
+			return err
+		}
+
+		rootDir := path.Join(dir, "root")
+		if err := os.Rename(tmpRootDir, rootDir); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Otherwise apply as normal
+
+	overlayDir, err := d.Get(id)
+	if err != nil {
+		return err
+	}
+	defer d.Put(id)
+
+	if err := archive.ApplyLayer(overlayDir, diff); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Driver) DiffSize(id string) (int64, error) {
+	overlayDir, err := d.Get(id)
+	if err != nil {
+		return -1, err
+	}
+	defer d.Put(id)
+
+	changes, err := d.Changes(id)
+	if err != nil {
+		return -1, err
+	}
+
+	return archive.ChangesSize(overlayDir, changes), nil
+}
+
+func (d *Driver) Changes(id string) ([]archive.Change, error) {
+	dir := d.dir(id)
+
+	parent, err := ioutil.ReadFile(path.Join(dir, "parent"))
+	if err != nil {
+		return nil, err
+	}
+
+	overlayDir, err := d.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	defer d.Put(id)
+
+	parentOverlayDir := ""
+	if string(parent) != "" {
+		parentOverlayDir, err = d.Get(string(parent))
+		if err != nil {
+			return nil, err
+		}
+		defer d.Put(string(parent))
+	}
+
+	return archive.ChangesDirs(overlayDir, parentOverlayDir)
+}
+
+func (d *Driver) Exists(id string) bool {
+	_, err := os.Stat(d.dir(id))
+	return err == nil
+}

--- a/runtime.go
+++ b/runtime.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dotcloud/docker/graphdriver/aufs"
 	_ "github.com/dotcloud/docker/graphdriver/btrfs"
 	_ "github.com/dotcloud/docker/graphdriver/devmapper"
+	_ "github.com/dotcloud/docker/graphdriver/overlayfs"
 	_ "github.com/dotcloud/docker/graphdriver/vfs"
 	_ "github.com/dotcloud/docker/networkdriver/lxc"
 	"github.com/dotcloud/docker/networkdriver/portallocator"


### PR DESCRIPTION
This backend uses the overlayfs union filesystem for containers
plus hard link file sharing for images.

Each container/image can have a "root" subdirectory which is a plain
filesystem hierarchy, or they can use overlayfs.

If they use overlayfs there is a "rw" directory and a "rw-parent"
file, as well as an "overlay" directory. The "rw" directory has the
upper layer of the overlay, and "rw-parent" contains the id of the
parent whose "root" directory shal be used as the lower layer in the
overlay. The overlay itself is mounted in the "overlay" directory.

When a overlay layer is created there are two cases, either the
parent has a "root" dir, then we start out with a empty "rw"
directory overlaid on the parents root. This is typically the
case with the $container-init layer which is based on an image.
If there is no "root" in the parent, we inherit the rw-root from
the parent and start by making a copy if the parents "rw" dir.
This is typically the case for a container layer which copies
its parent -init rw layer.

Additionally we also have a custom implementation of ApplyLayer
which makes a recursive copy of the parent "root" layer using
hardlinks to share file data, and then applies the layer on top
of that. This means all images share file (but not directory)
data.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
