### PR TITLE
Mount-bind the PTY as container console - allow for tmux/screen to run

### DIFF
--- a/container.go
+++ b/container.go
@@ -231,6 +231,7 @@ func (container *Container) setupPty() error {
 	container.ptyMaster = ptyMaster
 	container.command.Stdout = ptySlave
 	container.command.Stderr = ptySlave
+	container.command.Console = ptySlave.Name()
 
 	// Copy the PTYs to our broadcasters
 	go func() {

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -99,6 +99,8 @@ type Command struct {
 	Network    *Network   `json:"network"` // if network is nil then networking is disabled
 	Config     []string   `json:"config"`  //  generic values that specific drivers can consume
 	Resources  *Resources `json:"resources"`
+
+	Console string `json:"-"`
 }
 
 // Return the pid of the process

--- a/execdriver/lxc/lxc_template.go
+++ b/execdriver/lxc/lxc_template.go
@@ -80,6 +80,10 @@ lxc.mount.entry = proc {{escapeFstabSpaces $ROOTFS}}/proc proc nosuid,nodev,noex
 # if your userspace allows it. eg. see http://bit.ly/T9CkqJ
 lxc.mount.entry = sysfs {{escapeFstabSpaces $ROOTFS}}/sys sysfs nosuid,nodev,noexec 0 0
 
+{{if .Tty}}
+lxc.mount.entry = {{.Console}} {{escapeFstabSpaces $ROOTFS}}/dev/console none bind,rw 0 0
+{{end}}
+
 lxc.mount.entry = devpts {{escapeFstabSpaces $ROOTFS}}/dev/pts devpts newinstance,ptmxmode=0666,nosuid,noexec 0 0
 lxc.mount.entry = shm {{escapeFstabSpaces $ROOTFS}}/dev/shm tmpfs size=65536k,nosuid,nodev,noexec 0 0
 


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Guillaume J. Charmes guillaume.charmes@docker.com (github: creack)
