### PR TITLE
`docker cp` error when container doesn't exist

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -943,6 +943,9 @@ func postContainersCopy(eng *engine.Engine, version float64, w http.ResponseWrit
 	streamJSON(job, w, false)
 	if err := job.Run(); err != nil {
 		utils.Errorf("%s", err.Error())
+		if strings.Contains(err.Error(), "No such container") {
+			w.WriteHeader(http.StatusNotFound)
+		}
 	}
 	return nil
 }

--- a/api/client.go
+++ b/api/client.go
@@ -1961,6 +1961,9 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 	if stream != nil {
 		defer stream.Close()
 	}
+	if statusCode == 404 {
+		return fmt.Errorf("No such container: %v", info[0])
+	}
 	if err != nil {
 		return err
 	}

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -1217,6 +1217,34 @@ func TestPostContainersCopy(t *testing.T) {
 	}
 }
 
+func TestPostContainersCopyWhenContainerNotFound(t *testing.T) {
+	eng := NewTestEngine(t)
+	defer mkRuntimeFromEngine(eng, t).Nuke()
+
+	r := httptest.NewRecorder()
+
+	var copyData engine.Env
+	copyData.Set("Resource", "/test.txt")
+	copyData.Set("HostPath", ".")
+
+	jsonData := bytes.NewBuffer(nil)
+	if err := copyData.Encode(jsonData); err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest("POST", "/containers/id_not_found/copy", jsonData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Add("Content-Type", "application/json")
+	if err := api.ServeRequest(eng, api.APIVERSION, r, req); err != nil {
+		t.Fatal(err)
+	}
+	if r.Code != http.StatusNotFound {
+		t.Fatalf("404 expected for id_not_found Container, received %v", r.Code)
+	}
+}
+
 // Mocked types for tests
 type NopConn struct {
 	io.ReadCloser


### PR DESCRIPTION
Fix cp api to return a 404 notfound if container doesn't exist.
Fixes #4119.
