### PR TITLE
Engine: optional Logging field to disable custom logging in engine.

### DIFF
--- a/engine/job.go
+++ b/engine/job.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 )
@@ -189,11 +188,8 @@ func (job *Job) Environ() map[string]string {
 }
 
 func (job *Job) Logf(format string, args ...interface{}) (n int, err error) {
-	if os.Getenv("TEST") == "" {
-		prefixedFormat := fmt.Sprintf("[%s] %s\n", job, strings.TrimRight(format, "\n"))
-		return fmt.Fprintf(job.Stderr, prefixedFormat, args...)
-	}
-	return 0, nil
+	prefixedFormat := fmt.Sprintf("[%s] %s\n", job, strings.TrimRight(format, "\n"))
+	return fmt.Fprintf(job.Stderr, prefixedFormat, args...)
 }
 
 func (job *Job) Printf(format string, args ...interface{}) (n int, err error) {


### PR DESCRIPTION
- The default behavior is preserved
- This disables the use of the `TEST` environment variable in engine.

Docker-DCO-1.1-Signed-off-by: Solomon Hykes solomon@docker.com (github: shykes)
