### PR TITLE
Hold connections until the daemon has fully loaded

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"github.com/dotcloud/docker/auth"
 	"github.com/dotcloud/docker/engine"
-	"github.com/dotcloud/docker/pkg/socketactivation"
+	"github.com/dotcloud/docker/pkg/listenbuffer"
 	"github.com/dotcloud/docker/pkg/systemd"
 	"github.com/dotcloud/docker/utils"
 	"github.com/gorilla/mux"
@@ -1163,7 +1163,7 @@ func ListenAndServe(proto, addr string, eng *engine.Engine, logging, enableCors 
 		}
 	}
 
-	l, err := socketactivation.NewActivationListener(proto, addr, activationLock, 15*time.Minute)
+	l, err := listenbuffer.NewListenBuffer(proto, addr, activationLock, 15*time.Minute)
 	if err != nil {
 		return err
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -52,7 +52,6 @@ type HttpApiFunc func(eng *engine.Engine, version float64, w http.ResponseWriter
 
 func init() {
 	engine.Register("serveapi", ServeApi)
-	engine.Register("acceptconnections", AcceptConnections)
 }
 
 func hijackServer(w http.ResponseWriter) (io.ReadCloser, io.Writer, error) {
@@ -1210,6 +1209,10 @@ func ServeApi(job *engine.Job) engine.Status {
 		chErrors   = make(chan error, len(protoAddrs))
 	)
 	activationLock = make(chan struct{})
+
+	if err := job.Eng.Register("acceptconnections", AcceptConnections); err != nil {
+		return job.Error(err)
+	}
 
 	for _, protoAddr := range protoAddrs {
 		protoAddrParts := strings.SplitN(protoAddr, "://", 2)

--- a/api/api.go
+++ b/api/api.go
@@ -1219,8 +1219,6 @@ func ServeApi(job *engine.Job) engine.Status {
 		}()
 	}
 
-	AcceptConnections(nil)
-
 	for i := 0; i < len(protoAddrs); i += 1 {
 		err := <-chErrors
 		if err != nil {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -78,25 +78,36 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		// Load plugin: httpapi
-		job := eng.Job("initserver")
-		job.Setenv("Pidfile", *pidfile)
-		job.Setenv("Root", *flRoot)
-		job.SetenvBool("AutoRestart", *flAutoRestart)
-		job.SetenvList("Dns", flDns.GetAll())
-		job.SetenvBool("EnableIptables", *flEnableIptables)
-		job.SetenvBool("EnableIpForward", *flEnableIpForward)
-		job.Setenv("BridgeIface", *bridgeName)
-		job.Setenv("BridgeIP", *bridgeIp)
-		job.Setenv("DefaultIp", *flDefaultIp)
-		job.SetenvBool("InterContainerCommunication", *flInterContainerComm)
-		job.Setenv("GraphDriver", *flGraphDriver)
-		job.SetenvInt("Mtu", *flMtu)
-		if err := job.Run(); err != nil {
-			log.Fatal(err)
-		}
+		// load the daemon in the background so we can immediately start
+		// the http api so that connections don't fail while the daemon
+		// is booting
+		go func() {
+			// Load plugin: httpapi
+			job := eng.Job("initserver")
+			job.Setenv("Pidfile", *pidfile)
+			job.Setenv("Root", *flRoot)
+			job.SetenvBool("AutoRestart", *flAutoRestart)
+			job.SetenvList("Dns", flDns.GetAll())
+			job.SetenvBool("EnableIptables", *flEnableIptables)
+			job.SetenvBool("EnableIpForward", *flEnableIpForward)
+			job.Setenv("BridgeIface", *bridgeName)
+			job.Setenv("BridgeIP", *bridgeIp)
+			job.Setenv("DefaultIp", *flDefaultIp)
+			job.SetenvBool("InterContainerCommunication", *flInterContainerComm)
+			job.Setenv("GraphDriver", *flGraphDriver)
+			job.SetenvInt("Mtu", *flMtu)
+			if err := job.Run(); err != nil {
+				log.Fatal(err)
+			}
+			// after the daemon is done setting up we can tell the api to start
+			// accepting connections
+			if err := eng.Job("acceptconnections").Run(); err != nil {
+				log.Fatal(err)
+			}
+		}()
+
 		// Serve api
-		job = eng.Job("serveapi", flHosts.GetAll()...)
+		job := eng.Job("serveapi", flHosts.GetAll()...)
 		job.SetenvBool("Logging", true)
 		job.SetenvBool("EnableCors", *flEnableCors)
 		job.Setenv("Version", dockerversion.VERSION)

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -171,9 +171,14 @@ func spawnGlobalDaemon() {
 			log.Fatalf("Unable to spawn the test daemon: %s", err)
 		}
 	}()
+
 	// Give some time to ListenAndServer to actually start
 	// FIXME: use inmem transports instead of tcp
 	time.Sleep(time.Second)
+
+	if err := eng.Job("acceptconnections").Run(); err != nil {
+		log.Fatalf("Unable to accept connections for test api: %s", err)
+	}
 }
 
 // FIXME: test that ImagePull(json=true) send correct json output

--- a/pkg/listenbuffer/buffer.go
+++ b/pkg/listenbuffer/buffer.go
@@ -3,7 +3,7 @@
    listening on a socket, unix, tcp, udp but hold connections
    until the application has booted and is ready to accept them
 */
-package socketactivation
+package listenbuffer
 
 import (
 	"fmt"
@@ -11,9 +11,9 @@ import (
 	"time"
 )
 
-// NewActivationListener returns a listener listening on addr with the protocol.  It sets the
+// NewListenBuffer returns a listener listening on addr with the protocol.  It sets the
 // timeout to wait on first connection before an error is returned
-func NewActivationListener(proto, addr string, activate chan struct{}, timeout time.Duration) (net.Listener, error) {
+func NewListenBuffer(proto, addr string, activate chan struct{}, timeout time.Duration) (net.Listener, error) {
 	wrapped, err := net.Listen(proto, addr)
 	if err != nil {
 		return nil, err

--- a/pkg/socketactivation/activation.go
+++ b/pkg/socketactivation/activation.go
@@ -1,0 +1,61 @@
+/*
+   Package to allow go applications to immediately start
+   listening on a socket, unix, tcp, udp but hold connections
+   until the application has booted and is ready to accept them
+*/
+package socketactivation
+
+import (
+	"fmt"
+	"net"
+	"time"
+)
+
+// NewActivationListener returns a listener listening on addr with the protocol.  It sets the
+// timeout to wait on first connection before an error is returned
+func NewActivationListener(proto, addr string, activate chan struct{}, timeout time.Duration) (net.Listener, error) {
+	wrapped, err := net.Listen(proto, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &defaultListener{
+		wrapped:  wrapped,
+		activate: activate,
+		timeout:  timeout,
+	}, nil
+}
+
+type defaultListener struct {
+	wrapped  net.Listener // the real listener to wrap
+	ready    bool         // is the listner ready to start accpeting connections
+	activate chan struct{}
+	timeout  time.Duration // how long to wait before we consider this an error
+}
+
+func (l *defaultListener) Close() error {
+	return l.wrapped.Close()
+}
+
+func (l *defaultListener) Addr() net.Addr {
+	return l.wrapped.Addr()
+}
+
+func (l *defaultListener) Accept() (net.Conn, error) {
+	// if the listen has been told it is ready then we can go ahead and
+	// start returning connections
+	if l.ready {
+		return l.wrapped.Accept()
+	}
+
+	select {
+	case <-time.After(l.timeout):
+		// close the connection so any clients are disconnected
+		l.Close()
+		return nil, fmt.Errorf("timeout (%s) reached waiting for listener to become ready", l.timeout.String())
+	case <-l.activate:
+		l.ready = true
+		return l.Accept()
+	}
+	panic("unreachable")
+}


### PR DESCRIPTION
The PRs adds a new pkg, `listenbuffer` that wraps the net.Listener interface so that the connection, unix socket, tcp, etc can be opened immediately but holds connections until the docker daemon has fully loaded and is ready.  

This fixes the errors where the docker daemon is still booting but someone tries to make a request and receives the unix socket does not exist or other error messages like that.

This solves the same problem that the systemd socket activation pr did.
