### PR TITLE
add a little space above h2->h6 - it gets a bit dense in there when there are lots of steps

### DIFF
--- a/docs/theme/docker/static/css/main.css
+++ b/docs/theme/docker/static/css/main.css
@@ -428,6 +428,9 @@ dt:hover > a.headerlink {
   float: right;
   visibility: hidden;
 }
+h2, h3, h4, h5, h6 {
+  margin-top: 0.7em;
+}
 /* =====================================
   Miscellaneous information
 ====================================== */

--- a/docs/theme/docker/static/css/main.less
+++ b/docs/theme/docker/static/css/main.less
@@ -631,6 +631,10 @@ dt:hover > a.headerlink {
   visibility: hidden;
 }
 
+h2, h3, h4, h5, h6 {
+  margin-top: 0.7em;
+}
+
 /* =====================================
   Miscellaneous information
 ====================================== */


### PR DESCRIPTION
@dhrp - I'm also wondering if we can reduce the size of the h2's - when we use them for each step of an example, things get very heavy fast..

Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@home.org.au (github: SvenDowideit)
