### PR TITLE
support for `docker run` environment variables file (--env-file)

### DIFF
--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1152,7 +1152,7 @@ image is removed.
       --cidfile="": Write the container ID to the file
       -d, --detach=false: Detached mode: Run container in the background, print new container id
       -e, --env=[]: Set environment variables
-      --envfile="": Read in a line delimited file of ENV variables
+      --env-file="": Read in a line delimited file of ENV variables
       -h, --hostname="": Container host name
       -i, --interactive=false: Keep stdin open even if not attached
       --privileged=false: Give extended privileges to this container

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1289,12 +1289,47 @@ explains in detail how to manipulate ports in Docker.
 
     $ sudo docker run -e MYVAR1 --env MYVAR2=foo --env-file ./env.list ubuntu bash
 
-This sets environmental variables to the container. For illustration all three
-flags are shown here. Where -e and --env can be repeated, take an environment 
-variable and value, or if no "=" is provided, then that variable's current
-value is passed through (i.e. $MYVAR1 from the host is set to $MYVAR1 in the
-container). The --env-file flag takes a filename as an argument and expects each
-line to be a VAR=VAL format.
+This sets environmental variables in the container. For illustration all three
+flags are shown here. Where ``-e``, ``--env`` take an environment variable and
+value, or if no "=" is provided, then that variable's current value is passed
+through (i.e. $MYVAR1 from the host is set to $MYVAR1 in the container). All
+three flags, ``-e``, ``--env``  and ``--env-file`` can be repeated.
+
+Regardless of the order of these three flags, the ``--env-file`` are processed
+first, and then ``-e``/``--env`` flags. So that they can override VAR as needed.
+
+.. code-block:: bash
+
+    $ cat ./env.list
+    TEST_FOO=BAR
+    $ sudo docker run --env TEST_FOO="This is a test" --env-file ./env.list busybox env | grep TEST_FOO
+    TEST_FOO=This is a test
+
+The ``--env-file`` flag takes a filename as an argument and expects each line
+to be in the VAR=VAL format.  The VAL is Unquoted, so if you need a multi-line
+value, then use `\n` escape characters inside of a double quoted VAL. Single
+quotes are literal. An example of a file passed with ``--env-file``
+
+.. code-block:: bash
+
+    $ cat ./env.list
+    TEST_FOO=BAR
+    TEST_APP_DEST_HOST=10.10.0.127
+    TEST_APP_DEST_PORT=8888
+    TEST_SOME_MULTILINE_VAR="this is first line\nthis is second line"
+    TEST_SOME_LITERAL_VAR='this\nwill\nall\nbe\none\nline'
+    $ sudo docker run --env-file ./env.list busybox env
+    HOME=/
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    HOSTNAME=215d54a814bc
+    TEST_FOO=BAR
+    TEST_APP_DEST_HOST=10.10.0.127
+    TEST_APP_DEST_PORT=8888
+    TEST_SOME_MULTILINE_VAR=this is first line
+    this is second line
+    TEST_SOME_LITERAL_VAR='this\nwill\nall\nbe\none\nline'
+    container=lxc
+
 
 .. code-block:: bash
 

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1287,13 +1287,13 @@ explains in detail how to manipulate ports in Docker.
 
 .. code-block:: bash
 
-    $ sudo docker run -e MYVAR1 --env MYVAR2=foo --envfile ./env.list ubuntu bash
+    $ sudo docker run -e MYVAR1 --env MYVAR2=foo --env-file ./env.list ubuntu bash
 
 This sets environmental variables to the container. For illustration all three
 flags are shown here. Where -e and --env can be repeated, take an environment 
 variable and value, or if no "=" is provided, then that variable's current
 value is passed through (i.e. $MYVAR1 from the host is set to $MYVAR1 in the
-container). The --envfile flag takes a filename as an argument and expects each
+container). The --env-file flag takes a filename as an argument and expects each
 line to be a VAR=VAL format.
 
 .. code-block:: bash

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1296,7 +1296,8 @@ through (i.e. $MYVAR1 from the host is set to $MYVAR1 in the container). All
 three flags, ``-e``, ``--env``  and ``--env-file`` can be repeated.
 
 Regardless of the order of these three flags, the ``--env-file`` are processed
-first, and then ``-e``/``--env`` flags. So that they can override VAR as needed.
+first, and then ``-e``/``--env`` flags. This way, the ``-e`` or ``--env`` will
+override variables as needed.
 
 .. code-block:: bash
 
@@ -1306,29 +1307,30 @@ first, and then ``-e``/``--env`` flags. So that they can override VAR as needed.
     TEST_FOO=This is a test
 
 The ``--env-file`` flag takes a filename as an argument and expects each line
-to be in the VAR=VAL format.  The VAL is Unquoted, so if you need a multi-line
-value, then use `\n` escape characters inside of a double quoted VAL. Single
-quotes are literal. An example of a file passed with ``--env-file``
+to be in the VAR=VAL format, mimicking the argument passed to ``--env``.
+Comment lines need only be prefixed with ``#``
+
+An example of a file passed with ``--env-file``
 
 .. code-block:: bash
 
     $ cat ./env.list
     TEST_FOO=BAR
+
+    # this is a comment
     TEST_APP_DEST_HOST=10.10.0.127
     TEST_APP_DEST_PORT=8888
-    TEST_SOME_MULTILINE_VAR="this is first line\nthis is second line"
-    TEST_SOME_LITERAL_VAR='this\nwill\nall\nbe\none\nline'
-    $ sudo docker run --env-file ./env.list busybox env
+
+    # pass through this variable from the caller
+    TEST_PASSTHROUGH
+    $ sudo TEST_PASSTHROUGH=howdy docker run --env-file ./env.list busybox env
     HOME=/
     PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    HOSTNAME=215d54a814bc
+    HOSTNAME=5198e0745561
     TEST_FOO=BAR
     TEST_APP_DEST_HOST=10.10.0.127
     TEST_APP_DEST_PORT=8888
-    TEST_SOME_MULTILINE_VAR=this is first line
-    this is second line
-    TEST_SOME_LITERAL_VAR='this\nwill\nall\nbe\none\nline'
-    container=lxc
+    TEST_PASSTHROUGH=howdy
 
 
 .. code-block:: bash

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1152,6 +1152,7 @@ image is removed.
       --cidfile="": Write the container ID to the file
       -d, --detach=false: Detached mode: Run container in the background, print new container id
       -e, --env=[]: Set environment variables
+      --envfile="": Read in a line delimited file of ENV variables
       -h, --hostname="": Container host name
       -i, --interactive=false: Keep stdin open even if not attached
       --privileged=false: Give extended privileges to this container
@@ -1283,6 +1284,17 @@ in Docker.
 This exposes port ``80`` of the container for use within a link without
 publishing the port to the host system's interfaces. :ref:`port_redirection`
 explains in detail how to manipulate ports in Docker.
+
+.. code-block:: bash
+
+    $ sudo docker run -e MYVAR1 --env MYVAR2=foo --envfile ./env.list ubuntu bash
+
+This sets environmental variables to the container. For illustration all three
+flags are shown here. Where -e and --env can be repeated, take an environment 
+variable and value, or if no "=" is provided, then that variable's current
+value is passed through (i.e. $MYVAR1 from the host is set to $MYVAR1 in the
+container). The --envfile flag takes a filename as an argument and expects each
+line to be a VAR=VAL format.
 
 .. code-block:: bash
 

--- a/opts/envfile.go
+++ b/opts/envfile.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 )
 
@@ -23,14 +22,13 @@ func ParseEnvFile(filename string) ([]string, error) {
 	for scanner.Scan() {
 		line := scanner.Text()
 		// line is not empty, and not starting with '#'
-		if len(line) > 0 && !strings.HasPrefix(line, "#") && strings.Contains(line, "=") {
-			data := strings.SplitN(line, "=", 2)
-			key := data[0]
-			val := data[1]
-			if str, err := strconv.Unquote(data[1]); err == nil {
-				val = str
+		if len(line) > 0 && !strings.HasPrefix(line, "#") {
+			if strings.Contains(line, "=") {
+				data := strings.SplitN(line, "=", 2)
+				lines = append(lines, fmt.Sprintf("%s=%s", data[0], data[1]))
+			} else {
+				lines = append(lines, fmt.Sprintf("%s=%s", line, os.Getenv(line)))
 			}
-			lines = append(lines, fmt.Sprintf("%s=%s", key, val))
 		}
 	}
 	return lines, nil

--- a/pkg/opts/envfile.go
+++ b/pkg/opts/envfile.go
@@ -15,6 +15,8 @@ func ParseEnvFile(filename string) ([]string, error) {
 	if err != nil {
 		return []string{}, err
 	}
+  defer fh.Close()
+
 	var (
 		lines       []string = []string{}
 		line, chunk []byte

--- a/pkg/opts/envfile.go
+++ b/pkg/opts/envfile.go
@@ -15,7 +15,7 @@ func ParseEnvFile(filename string) ([]string, error) {
 	if err != nil {
 		return []string{}, err
 	}
-  defer fh.Close()
+	defer fh.Close()
 
 	var (
 		lines       []string = []string{}

--- a/pkg/opts/envfile.go
+++ b/pkg/opts/envfile.go
@@ -1,0 +1,44 @@
+package opts
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+)
+
+/*
+Read in a line delimited file with environment variables enumerated
+*/
+func ParseEnvFile(filename string) ([]string, error) {
+	fh, err := os.Open(filename)
+	if err != nil {
+		return []string{}, err
+	}
+	var (
+		lines       []string = []string{}
+		line, chunk []byte
+	)
+	reader := bufio.NewReader(fh)
+	line, isPrefix, err := reader.ReadLine()
+
+	for err == nil {
+		if isPrefix {
+			chunk = append(chunk, line...)
+		} else if !isPrefix && len(chunk) > 0 {
+			line = chunk
+			chunk = []byte{}
+		} else {
+			chunk = []byte{}
+		}
+
+		if !isPrefix && len(line) > 0 && bytes.Contains(line, []byte("=")) {
+			lines = append(lines, string(line))
+		}
+		line, isPrefix, err = reader.ReadLine()
+	}
+	if err != nil && err != io.EOF {
+		return []string{}, err
+	}
+	return lines, nil
+}

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -68,7 +68,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flWorkingDir      = cmd.String([]string{"w", "-workdir"}, "", "Working directory inside the container")
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flLabelOptions    = cmd.String([]string{"Z", "-label"}, "", "Options to pass to underlying labeling system")
-		flEnvFile         = cmd.String([]string{"#envfile", "-envfile"}, "", "Read in a line delimited file of ENV variables")
+		flEnvFile         = cmd.String([]string{"#env-file", "-env-file"}, "", "Read in a line delimited file of ENV variables")
 
 		// For documentation purpose
 		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify all received signal to the process (even in non-tty mode)")

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -203,7 +203,6 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 
 	// collect all the environment variables for the container
 	envVariables := []string{}
-	envVariables = append(envVariables, flEnv.GetAll()...)
 	for _, ef := range flEnvFile.GetAll() {
 		parsedVars, err := opts.ParseEnvFile(ef)
 		if err != nil {
@@ -211,6 +210,8 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		}
 		envVariables = append(envVariables, parsedVars...)
 	}
+	// parse the '-e' and '--env' after, to allow override
+	envVariables = append(envVariables, flEnv.GetAll()...)
 	// boo, there's no debug output for docker run
 	//utils.Debugf("Environment variables for the container: %#v", envVariables)
 

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -79,7 +79,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	cmd.Var(&flVolumes, []string{"v", "-volume"}, "Bind mount a volume (e.g. from the host: -v /host:/container, from docker: -v /container)")
 	cmd.Var(&flLinks, []string{"#link", "-link"}, "Add link to another container (name:alias)")
 	cmd.Var(&flEnv, []string{"e", "-env"}, "Set environment variables")
-	cmd.Var(&flEnvFile, []string{"#env-file", "-env-file"}, "Read in a line delimited file of ENV variables")
+	cmd.Var(&flEnvFile, []string{"-env-file"}, "Read in a line delimited file of ENV variables")
 
 	cmd.Var(&flPublish, []string{"p", "-publish"}, fmt.Sprintf("Publish a container's port to the host (format: %s) (use 'docker port' to see the actual mapping)", nat.PortSpecTemplateFormat))
 	cmd.Var(&flExpose, []string{"#expose", "-expose"}, "Expose a port from the container without publishing it to your host")


### PR DESCRIPTION
With many environment variables individually added with -e/--env can/will overflow the shell argument max length $(getconf ARG_MAX). Having a file to declare environment variables will reduce this, as well as allow for automation of known/static environment variables.

```
$ cat e.list
FOO=BAR
BAZ=BIFF
$ ./bundles/0.8.0-dev/dynbinary/docker-0.8.0-dev run -i -t -envfile ./e.list -envfile ./e.list busybox sh
/ # echo $FOO $BAZ
BAR BIF
```

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
