### PR TITLE
archive: Handle aufs plink hardlinks in ApplyLayer

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -186,7 +186,7 @@ func addTarFile(path, name string, tw *tar.Writer) error {
 	return nil
 }
 
-func createTarFile(path, extractDir string, hdr *tar.Header, reader *tar.Reader) error {
+func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader) error {
 	switch hdr.Typeflag {
 	case tar.TypeDir:
 		// Create directory unless it exists as a directory already.


### PR DESCRIPTION
Files in the .wh..wh.plnk directory are ignored, but other files
inside the tarfile can be hardlinks to these files. This is not
something that normally happens, as on aufs unmount such files are
supposed to be dropped via the "auplink" too, yet images on the index
(such as shipyard/shipyard, e.g. layer
f73c835af6d58b6fc827b400569f79a8f28e54f5bb732be063e1aacefbc374d0)
contains such files.

We handle these by extracting these files to a temporary directory
and resolve such hardlinks via the temporary files.

This fixes https://github.com/dotcloud/docker/issues/3884

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
