### PR TITLE
Update ubuntulinux.rst

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -225,7 +225,7 @@ Before Docker will work correctly, you will need to install this via:
 
 .. code-block:: bash
 
-    sudo apt-get update && sudo apt-get install cgroups-lite
+    sudo apt-get update && sudo apt-get install cgroup-lite
 
 .. _ufw:
 


### PR DESCRIPTION
fixed cgroup-lite package name.
