### PR TITLE
Avoid temporarily unmounting the container when restarting it

### DIFF
--- a/container.go
+++ b/container.go
@@ -1256,6 +1256,13 @@ func (container *Container) Stop(seconds int) error {
 }
 
 func (container *Container) Restart(seconds int) error {
+	// Avoid unnecessarily unmounting and then directly mounting
+	// the container when the container stops and then starts
+	// again
+	if err := container.Mount(); err == nil {
+		defer container.Unmount()
+	}
+
 	if err := container.Stop(seconds); err != nil {
 		return err
 	}


### PR DESCRIPTION
- addresses / fixes https://github.com/moby/moby/issues/4036

Stopping the container will typicall cause it to unmount, to keep it mounted
over the stop/start cycle we aquire a temporary reference to it during this time.

This helps with https://github.com/dotcloud/docker/issues/4036

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
