### PR TITLE
systemd-nspawn execdriver

### DIFF
--- a/execdriver/systemd/driver.go
+++ b/execdriver/systemd/driver.go
@@ -56,7 +56,10 @@ func NewDriver() (*driver, error) {
 	return &driver{}, nil
 }
 
-func (d *driver) Run(c *execdriver.Command, startCallback execdriver.StartCallback) (int, error) {
+func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
+	if err := execdriver.SetTerminal(c, pipes); err != nil {
+		return -1, err
+	}
 
 	params := []string{
 		"systemd-nspawn",

--- a/execdriver/systemd/driver.go
+++ b/execdriver/systemd/driver.go
@@ -1,0 +1,186 @@
+package systemd
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/execdriver"
+	"log"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const DriverName = "systemd"
+
+func init() {
+	execdriver.RegisterInitFunc(DriverName, func(args *execdriver.InitArgs) error {
+		if err := setupHostname(args); err != nil {
+			return err
+		}
+
+		/*		if err := setupNetworking(args); err != nil {
+					return err
+				}
+		*/
+		if err := setupCapabilities(args); err != nil {
+			return err
+		}
+
+		if err := setupWorkingDirectory(args); err != nil {
+			return err
+		}
+
+		if err := changeUser(args); err != nil {
+			return err
+		}
+
+		path, err := exec.LookPath(args.Args[0])
+		if err != nil {
+			log.Printf("Unable to locate %v", args.Args[0])
+			os.Exit(127)
+		}
+		if err := syscall.Exec(path, args.Args, os.Environ()); err != nil {
+			return fmt.Errorf("dockerinit unable to execute %s - %s", path, err)
+		}
+		panic("Unreachable")
+	})
+}
+
+type driver struct {
+	root       string // root path for the driver to use
+	sharedRoot bool
+}
+
+func NewDriver() (*driver, error) {
+	return &driver{}, nil
+}
+
+func (d *driver) Run(c *execdriver.Command, startCallback execdriver.StartCallback) (int, error) {
+
+	params := []string{
+		"systemd-nspawn",
+		"-M", c.ID,
+		"-D", c.Rootfs,
+	}
+
+	params = append(params, c.InitPath)
+	params = append(params, "-driver", DriverName)
+
+	if c.Network != nil {
+		params = append(params,
+			"-g", c.Network.Gateway,
+			"-i", fmt.Sprintf("%s/%d", c.Network.IPAddress, c.Network.IPPrefixLen),
+			"-mtu", strconv.Itoa(c.Network.Mtu),
+		)
+	}
+
+	if c.User != "" {
+		params = append(params, "-u", c.User)
+	}
+
+	if c.Privileged {
+		params = append(params, "-privileged")
+	}
+
+	if c.WorkingDir != "" {
+		params = append(params, "-w", c.WorkingDir)
+	}
+
+	params = append(params, "--", c.Entrypoint)
+	params = append(params, c.Arguments...)
+
+	var (
+		name = params[0]
+		arg  = params[1:]
+	)
+	aname, err := exec.LookPath(name)
+	if err != nil {
+		aname = name
+	}
+	c.Path = aname
+	c.Args = append([]string{name}, arg...)
+
+	if err := c.Start(); err != nil {
+		return -1, err
+	}
+
+	var (
+		waitErr  error
+		waitLock = make(chan struct{})
+	)
+	go func() {
+		if err := c.Wait(); err != nil {
+			if _, ok := err.(*exec.ExitError); !ok { // Do not propagate the error if it's simply a status code != 0
+				waitErr = err
+			}
+		}
+		close(waitLock)
+	}()
+
+	if startCallback != nil {
+		startCallback(c)
+	}
+
+	<-waitLock
+
+	return getExitCode(c), waitErr
+}
+
+/// Return the exit code of the process
+// if the process has not exited -1 will be returned
+func getExitCode(c *execdriver.Command) int {
+	if c.ProcessState == nil {
+		return -1
+	}
+	return c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+}
+
+func (d *driver) Kill(c *execdriver.Command, sig int) error {
+	return c.Process.Kill()
+}
+
+func (d *driver) Restore(c *execdriver.Command) error {
+	panic("Restore Not Implemented")
+}
+
+func (d *driver) version() string {
+	version := ""
+	if output, err := exec.Command("systemd-nspawn", "--version").CombinedOutput(); err == nil {
+		outputStr := string(output)
+		if len(strings.SplitN(outputStr, " ", 2)) == 2 {
+			version = strings.TrimSpace(strings.SplitN(outputStr, " ", 2)[1])
+		}
+	}
+	return version
+}
+
+func (d *driver) getInfo(id string) ([]byte, error) {
+	panic("get Info Not implemented")
+}
+
+type info struct {
+	ID     string
+	driver *driver
+}
+
+func (i *info) IsRunning() bool {
+	fmt.Printf("Info Not implemented")
+	return false
+}
+
+func (d *driver) Info(id string) execdriver.Info {
+	return &info{
+		ID:     id,
+		driver: d,
+	}
+}
+
+func (d *driver) Name() string {
+	version := d.version()
+	return fmt.Sprintf("%s-%s", DriverName, version)
+}
+
+func (d *driver) GetPidsForContainer(id string) ([]int, error) {
+	return nil, fmt.Errorf("GetPidsForContainer Not supported")
+}

--- a/execdriver/systemd/init.go
+++ b/execdriver/systemd/init.go
@@ -1,0 +1,154 @@
+package systemd
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/execdriver"
+	"github.com/dotcloud/docker/pkg/netlink"
+	"github.com/dotcloud/docker/pkg/user"
+	"github.com/syndtr/gocapability/capability"
+	"net"
+	"os"
+	"strings"
+	"syscall"
+)
+
+func setHostname(hostname string) error {
+	return syscall.Sethostname([]byte(hostname))
+}
+
+func setupHostname(args *execdriver.InitArgs) error {
+	hostname := getEnv(args, "HOSTNAME")
+	if hostname == "" {
+		return nil
+	}
+	return setHostname(hostname)
+}
+
+// Setup networking
+func setupNetworking(args *execdriver.InitArgs) error {
+	if args.Ip != "" {
+		// eth0
+		iface, err := net.InterfaceByName("eth0")
+		if err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+		ip, ipNet, err := net.ParseCIDR(args.Ip)
+		if err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+		if err := netlink.NetworkLinkAddIp(iface, ip, ipNet); err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+		if err := netlink.NetworkSetMTU(iface, args.Mtu); err != nil {
+			return fmt.Errorf("Unable to set MTU: %v", err)
+		}
+		if err := netlink.NetworkLinkUp(iface); err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+
+		// loopback
+		iface, err = net.InterfaceByName("lo")
+		if err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+		if err := netlink.NetworkLinkUp(iface); err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+	}
+	if args.Gateway != "" {
+		gw := net.ParseIP(args.Gateway)
+		if gw == nil {
+			return fmt.Errorf("Unable to set up networking, %s is not a valid gateway IP", args.Gateway)
+		}
+
+		if err := netlink.AddDefaultGw(gw); err != nil {
+			return fmt.Errorf("Unable to set up networking: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// Setup working directory
+func setupWorkingDirectory(args *execdriver.InitArgs) error {
+	if args.WorkDir == "" {
+		return nil
+	}
+	if err := syscall.Chdir(args.WorkDir); err != nil {
+		return fmt.Errorf("Unable to change dir to %v: %v", args.WorkDir, err)
+	}
+	return nil
+}
+
+// Takes care of dropping privileges to the desired user
+func changeUser(args *execdriver.InitArgs) error {
+	if args.User == "" {
+		return nil
+	}
+
+	uid, gid, suppGids, err := user.GetUserGroupSupplementary(
+		args.User,
+		syscall.Getuid(), syscall.Getgid(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := syscall.Setgroups(suppGids); err != nil {
+		return fmt.Errorf("Setgroups failed: %v", err)
+	}
+	if err := syscall.Setgid(gid); err != nil {
+		return fmt.Errorf("setgid failed: %v", err)
+	}
+	if err := syscall.Setuid(uid); err != nil {
+		return fmt.Errorf("setuid failed: %v", err)
+	}
+
+	return nil
+}
+
+func setupCapabilities(args *execdriver.InitArgs) error {
+
+	if args.Privileged {
+		return nil
+	}
+
+	drop := []capability.Cap{
+		capability.CAP_SETPCAP,
+		capability.CAP_SYS_MODULE,
+		capability.CAP_SYS_RAWIO,
+		capability.CAP_SYS_PACCT,
+		capability.CAP_SYS_ADMIN,
+		capability.CAP_SYS_NICE,
+		capability.CAP_SYS_RESOURCE,
+		capability.CAP_SYS_TIME,
+		capability.CAP_SYS_TTY_CONFIG,
+		capability.CAP_MKNOD,
+		capability.CAP_AUDIT_WRITE,
+		capability.CAP_AUDIT_CONTROL,
+		capability.CAP_MAC_OVERRIDE,
+		capability.CAP_MAC_ADMIN,
+	}
+
+	c, err := capability.NewPid(os.Getpid())
+	if err != nil {
+		return err
+	}
+
+	c.Unset(capability.CAPS|capability.BOUNDS, drop...)
+
+	if err := c.Apply(capability.CAPS | capability.BOUNDS); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getEnv(args *execdriver.InitArgs, key string) string {
+	for _, kv := range args.Env {
+		parts := strings.SplitN(kv, "=", 2)
+		if parts[0] == key && len(parts) == 2 {
+			return parts[1]
+		}
+	}
+	return ""
+}

--- a/runtime.go
+++ b/runtime.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dotcloud/docker/execdriver"
 	"github.com/dotcloud/docker/execdriver/chroot"
 	"github.com/dotcloud/docker/execdriver/lxc"
+	"github.com/dotcloud/docker/execdriver/systemd"
 	"github.com/dotcloud/docker/graphdriver"
 	"github.com/dotcloud/docker/graphdriver/aufs"
 	_ "github.com/dotcloud/docker/graphdriver/btrfs"
@@ -706,10 +707,16 @@ func NewRuntimeFromDirectory(config *DaemonConfig, eng *engine.Engine) (*Runtime
 
 	var ed execdriver.Driver
 	utils.Debugf("execDriver: provided %s", config.ExecDriver)
+	/*
+		Default to lxc, to not break current functionality
+	*/
 	if config.ExecDriver == "chroot" && false {
 		// chroot is presently a noop driver https://github.com/dotcloud/docker/pull/4189#issuecomment-35330655
 		ed, err = chroot.NewDriver()
 		utils.Debugf("execDriver: using chroot")
+  } else if config.ExecDriver == "systemd" {
+		ed, err = systemd.NewDriver()
+    utils.Debugf("execDriver: using systemd")
 	} else {
 		ed, err = lxc.NewDriver(config.Root, sysInfo.AppArmor)
 		utils.Debugf("execDriver: using lxc")

--- a/runtime.go
+++ b/runtime.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"regexp"
 	"sort"
@@ -715,6 +716,11 @@ func NewRuntimeFromDirectory(config *DaemonConfig, eng *engine.Engine) (*Runtime
 		ed, err = chroot.NewDriver()
 		utils.Debugf("execDriver: using chroot")
   } else if config.ExecDriver == "systemd" {
+		utils.Debugf("using systemd")
+		_, err := exec.LookPath("systemd-nspawn")
+		if err != nil {
+			return nil, err
+		}
 		ed, err = systemd.NewDriver()
     utils.Debugf("execDriver: using systemd")
 	} else {

--- a/runtime.go
+++ b/runtime.go
@@ -715,14 +715,14 @@ func NewRuntimeFromDirectory(config *DaemonConfig, eng *engine.Engine) (*Runtime
 		// chroot is presently a noop driver https://github.com/dotcloud/docker/pull/4189#issuecomment-35330655
 		ed, err = chroot.NewDriver()
 		utils.Debugf("execDriver: using chroot")
-  } else if config.ExecDriver == "systemd" {
+	} else if config.ExecDriver == "systemd" {
 		utils.Debugf("using systemd")
 		_, err := exec.LookPath("systemd-nspawn")
 		if err != nil {
 			return nil, err
 		}
 		ed, err = systemd.NewDriver()
-    utils.Debugf("execDriver: using systemd")
+		utils.Debugf("execDriver: using systemd")
 	} else {
 		ed, err = lxc.NewDriver(config.Root, sysInfo.AppArmor)
 		utils.Debugf("execDriver: using lxc")

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dotcloud/docker/execdriver"
 	_ "github.com/dotcloud/docker/execdriver/chroot"
 	_ "github.com/dotcloud/docker/execdriver/lxc"
+	_ "github.com/dotcloud/docker/execdriver/systemd"
 	"io/ioutil"
 	"log"
 	"os"


### PR DESCRIPTION
Allowing the docker daemon to use alternate to lxc execdriver.
  By starting as: EXEC_DRIVER=systemd docker -d
  or setting the variable in /etc/default/docker

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
