### PR TITLE
execdriver flag for docker daemon

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type DaemonConfig struct {
 	BridgeIP                    string
 	InterContainerCommunication bool
 	GraphDriver                 string
+	ExecDriver                  string
 	Mtu                         int
 	DisableNetwork              bool
 }
@@ -43,6 +44,7 @@ func DaemonConfigFromJob(job *engine.Job) *DaemonConfig {
 		DefaultIp:                   net.ParseIP(job.Getenv("DefaultIp")),
 		InterContainerCommunication: job.GetenvBool("InterContainerCommunication"),
 		GraphDriver:                 job.Getenv("GraphDriver"),
+		ExecDriver:                  job.Getenv("ExecDriver"),
 	}
 	if dns := job.GetenvList("Dns"); dns != nil {
 		config.Dns = dns

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -39,6 +39,7 @@ func main() {
 		flDefaultIp          = flag.String([]string{"#ip", "-ip"}, "0.0.0.0", "Default IP address to use when binding container ports")
 		flInterContainerComm = flag.Bool([]string{"#icc", "-icc"}, true, "Enable inter-container communication")
 		flGraphDriver        = flag.String([]string{"s", "-storage-driver"}, "", "Force the docker runtime to use a specific storage driver")
+		flExecDriver         = flag.String([]string{"e", "-exec-driver"}, "", "Force the docker runtime to use a specific exec driver")
 		flHosts              = opts.NewListOpts(api.ValidateHost)
 		flMtu                = flag.Int([]string{"#mtu", "-mtu"}, 0, "Set the containers network MTU; if no value is provided: default to the default route MTU or 1500 if not default route is available")
 	)
@@ -98,6 +99,7 @@ func main() {
 			job.Setenv("DefaultIp", *flDefaultIp)
 			job.SetenvBool("InterContainerCommunication", *flInterContainerComm)
 			job.Setenv("GraphDriver", *flGraphDriver)
+			job.Setenv("ExecDriver", *flExecDriver)
 			job.SetenvInt("Mtu", *flMtu)
 			if err := job.Run(); err != nil {
 				log.Fatal(err)

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -79,6 +79,7 @@ Commands
       -p, --pidfile="/var/run/docker.pid": Path to use for daemon PID file
       -r, --restart=true: Restart previously running containers
       -s, --storage-driver="": Force the docker runtime to use a specific storage driver
+      -e, --exec-driver="": Force the docker runtime to use a specific exec driver
       -v, --version=false: Print version information and quit
       -mtu, --mtu=0: Set the containers network MTU; if no value is provided: default to the default route MTU or 1500 if not default route is available
 

--- a/runtime.go
+++ b/runtime.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dotcloud/docker/dockerversion"
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/execdriver"
+	"github.com/dotcloud/docker/execdriver/chroot"
 	"github.com/dotcloud/docker/execdriver/lxc"
 	"github.com/dotcloud/docker/graphdriver"
 	"github.com/dotcloud/docker/graphdriver/aufs"
@@ -703,7 +704,16 @@ func NewRuntimeFromDirectory(config *DaemonConfig, eng *engine.Engine) (*Runtime
 
 	sysInfo := sysinfo.New(false)
 
-	ed, err := lxc.NewDriver(config.Root, sysInfo.AppArmor)
+	var ed execdriver.Driver
+	utils.Debugf("execDriver: provided %s", config.ExecDriver)
+	if config.ExecDriver == "chroot" && false {
+		// chroot is presently a noop driver https://github.com/dotcloud/docker/pull/4189#issuecomment-35330655
+		ed, err = chroot.NewDriver()
+		utils.Debugf("execDriver: using chroot")
+	} else {
+		ed, err = lxc.NewDriver(config.Root, sysInfo.AppArmor)
+		utils.Debugf("execDriver: using lxc")
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
  like the storage-driver flag, this implements a flag for choosing the
  execdriver to be used, defaulting to lxc.

as referred to from #4184 and #3745

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
