### PR TITLE
Fix typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ pass it on as an open-source patch.  The rules are pretty simple: if you
 can certify the below:
 
 ```
-Docker Developer Grant and Certificate of Origin 1.1
+Docker Developer Certificate of Origin 1.1
 
 By making a contribution to the Docker Project ("Project"), I represent and
 warrant that:

--- a/docs/sources/examples/using_supervisord.rst
+++ b/docs/sources/examples/using_supervisord.rst
@@ -112,7 +112,7 @@ Once we've got a built image we can launch a container from it.
 
 .. code-block:: bash
 
-    sudo docker run -p 22 -p 80 -t -i <yourname>/supervisor
+    sudo docker run -p 22 -p 80 -t -i <yourname>/supervisord
     2013-11-25 18:53:22,312 CRIT Supervisor running as root (no user in config file)
     2013-11-25 18:53:22,312 WARN Included extra file "/etc/supervisor/conf.d/supervisord.conf" during parsing
     2013-11-25 18:53:22,342 INFO supervisord started with pid 1


### PR DESCRIPTION
I think there's a typo regarding which image to run. `<yourname>/supervisord` should be triggered since it's created in the previous section.
