### PR TITLE
Fix fedora tests

### DIFF
--- a/graphdriver/aufs/aufs.go
+++ b/graphdriver/aufs/aufs.go
@@ -34,6 +34,10 @@ import (
 	"sync"
 )
 
+var (
+	ErrAufsNotSupported = fmt.Errorf("AUFS was not found in /proc/filesystems")
+)
+
 func init() {
 	graphdriver.Register("aufs", Init)
 }
@@ -100,7 +104,7 @@ func supportsAufs() error {
 			return nil
 		}
 	}
-	return fmt.Errorf("AUFS was not found in /proc/filesystems")
+	return ErrAufsNotSupported
 }
 
 func (a Driver) rootPath() string {

--- a/runtime.go
+++ b/runtime.go
@@ -396,7 +396,7 @@ func (runtime *Runtime) Create(config *runconfig.Config, name string) (*Containe
 
 	// Set the enitity in the graph using the default name specified
 	if _, err := runtime.containerGraph.Set(name, id); err != nil {
-		if !strings.HasSuffix(err.Error(), "name are not unique") {
+		if !graphdb.IsNonUniqueNameError(err) {
 			return nil, nil, err
 		}
 


### PR DESCRIPTION
This fixes test failures i see on fedora:
1) skip AUFS tests if not supported on kernel
2) Handle different error string in newer sqlite versions
