### PR TITLE
Generic /cmd endpoint and dm specific operations (resize/resize-pool/trim-pool)

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -38,6 +38,12 @@ func (cli *DockerCli) ParseCommands(args ...string) error {
 	if len(args) > 0 {
 		method, exists := cli.getMethod(args[0])
 		if !exists {
+			// Look for generic methods of form "plugin:operation"
+			op := strings.SplitN(args[0], ":", 2)
+			if len(op) == 2 {
+				return cli.GenericCmd(op[0], op[1], args[1:]...)
+			}
+
 			fmt.Println("Error: Command not found:", args[0])
 			return cli.CmdHelp(args[1:]...)
 		}

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2232,3 +2232,44 @@ func (cli *DockerCli) CmdLoad(args ...string) error {
 	}
 	return nil
 }
+
+func validateGenericOpt(val string) (string, error) {
+	if val == "args" {
+		return "", fmt.Errorf("options names args are not allowed")
+	}
+	if strings.Count(val, "=") == 0 {
+		return "", fmt.Errorf("%s is not a key-value option", val)
+	}
+	return val, nil
+}
+
+func (cli *DockerCli) GenericCmd(target, op string, args ...string) error {
+	cmd := cli.Subcmd(target+":"+op, "[ARGUMENTS]", "Plugin specific operation")
+
+	flOpts := opts.NewListOpts(validateGenericOpt)
+	cmd.Var(&flOpts, []string{"o"}, "Set operation specific env var -o \"DEBUG=1\"")
+
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+
+	val := url.Values{}
+	for _, arg := range cmd.Args() {
+		val.Add("args", arg)
+	}
+
+	for _, o := range flOpts.GetAll() {
+		k, v, err := utils.ParseKeyValueOpt(o)
+		if err != nil {
+			return err
+		}
+		val.Add(k, v)
+	}
+
+	_, _, err := readBody(cli.call("GET", "/cmd/"+target+"/"+op+"?"+val.Encode(), nil, false))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -118,6 +118,36 @@ func getBoolParam(value string) (bool, error) {
 	return ret, nil
 }
 
+func getCmdOperation(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if vars == nil {
+		return fmt.Errorf("Missing parameter")
+	}
+	if err := parseForm(r); err != nil {
+		return err
+	}
+
+	jobname := vars["plugin"] + ":" + vars["operation"]
+
+	var args []string
+
+	if v, ok := r.Form["args"]; ok {
+		args = v
+	}
+
+	job := eng.Job(jobname, args...)
+
+	for key, value := range r.Form {
+		if key != "args" {
+			job.Setenv(key, value[0])
+		}
+	}
+	if err := job.Run(); err != nil {
+		return err
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
 func postAuth(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	var (
 		authConfig, err = ioutil.ReadAll(r.Body)
@@ -1079,6 +1109,7 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 			"/containers/{name:.*}/top":       getContainersTop,
 			"/containers/{name:.*}/logs":      getContainersLogs,
 			"/containers/{name:.*}/attach/ws": wsContainersAttach,
+			"/cmd/{plugin:.*}/{operation:.*}": getCmdOperation,
 		},
 		"POST": {
 			"/auth":                         postAuth,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -884,6 +884,11 @@ func NewDaemonFromDirectory(config *daemonconfig.Config, eng *engine.Engine) (*D
 	if err := daemon.restore(); err != nil {
 		return nil, err
 	}
+
+	if installer, ok := daemon.driver.(engine.Installer); ok {
+		installer.Install(eng)
+	}
+
 	return daemon, nil
 }
 

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -457,6 +457,9 @@ func minor(device uint64) uint64 {
 }
 
 func (devices *DeviceSet) ResizePool(size int64) error {
+	devices.Lock()
+	defer devices.Unlock()
+
 	dirname := devices.loopbackDir()
 	datafilename := path.Join(dirname, "data")
 	metadatafilename := path.Join(dirname, "metadata")

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -707,7 +707,7 @@ func (devices *DeviceSet) deleteDevice(info *DevInfo) error {
 		// on the thin pool when we remove a thinp device, so we do it
 		// manually
 		if err := devices.activateDeviceIfNeeded(info); err == nil {
-			if err := BlockDeviceDiscard(info.DevName()); err != nil {
+			if err := BlockDeviceDiscardAll(info.DevName()); err != nil {
 				utils.Debugf("Error discarding block on device: %s (ignoring)\n", err)
 			}
 		}

--- a/daemon/graphdriver/devmapper/devmapper.go
+++ b/daemon/graphdriver/devmapper/devmapper.go
@@ -304,7 +304,7 @@ func GetBlockDeviceSize(file *os.File) (uint64, error) {
 	return uint64(size), nil
 }
 
-func BlockDeviceDiscard(path string) error {
+func BlockDeviceDiscardAll(path string) error {
 	file, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return err
@@ -316,13 +316,21 @@ func BlockDeviceDiscard(path string) error {
 		return err
 	}
 
-	if err := ioctlBlkDiscard(file.Fd(), 0, size); err != nil {
+	if err := BlockDeviceDiscard(file, 0, size); err != nil {
 		return err
 	}
 
 	// Without this sometimes the remove of the device that happens after
 	// discard fails with EBUSY.
 	syscall.Sync()
+
+	return nil
+}
+
+func BlockDeviceDiscard(file *os.File, offset, length uint64) error {
+	if err := ioctlBlkDiscard(file.Fd(), offset, length); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -184,8 +184,24 @@ func (d *Driver) resizePool(job *engine.Job) engine.Status {
 	return engine.StatusOK
 }
 
+func (d *Driver) trimPool(job *engine.Job) engine.Status {
+	args := job.Args
+
+	if len(args) != 0 {
+		return job.Errorf("Usage: trim-pool")
+	}
+
+	err := d.DeviceSet.TrimPool()
+	if err != nil {
+		return job.Errorf("Error trimming pool: %s", err.Error())
+	}
+
+	return engine.StatusOK
+}
+
 func (d *Driver) Install(eng *engine.Engine) error {
 	eng.Register("dm:resize-pool", d.resizePool)
 	eng.Register("dm:resize", d.resize)
+	eng.Register("dm:trim-pool", d.trimPool)
 	return nil
 }

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -146,6 +146,25 @@ func (d *Driver) Exists(id string) bool {
 	return d.DeviceSet.HasDevice(id)
 }
 
+func (d *Driver) resize(job *engine.Job) engine.Status {
+	args := job.Args
+	if len(args) != 2 {
+		return job.Errorf("Usage: resize IMAGE/CONTAINER NEW_SIZE")
+	}
+
+	size, err := units.FromHumanSize(args[1])
+	if err != nil {
+		return job.Errorf("Invalid size: %s", args[0])
+	}
+
+	err = d.DeviceSet.ResizeDevice(args[0], size)
+	if err != nil {
+		return job.Errorf("Error resizing %s: %s", args[0], err.Error())
+	}
+
+	return engine.StatusOK
+}
+
 func (d *Driver) resizePool(job *engine.Job) engine.Status {
 	args := job.Args
 	if len(args) != 1 {
@@ -167,5 +186,6 @@ func (d *Driver) resizePool(job *engine.Job) engine.Status {
 
 func (d *Driver) Install(eng *engine.Engine) error {
 	eng.Register("dm:resize-pool", d.resizePool)
+	eng.Register("dm:resize", d.resize)
 	return nil
 }

--- a/daemon/graphdriver/devmapper/metadata.go
+++ b/daemon/graphdriver/devmapper/metadata.go
@@ -1,0 +1,166 @@
+// +build linux,amd64
+
+package devmapper
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+)
+
+type MetadataDecoder struct {
+	d      *xml.Decoder
+	ranges *Ranges
+}
+
+func NewMetadataDecoder(reader io.Reader) *MetadataDecoder {
+	m := &MetadataDecoder{
+		d:      xml.NewDecoder(reader),
+		ranges: NewRanges(),
+	}
+
+	return m
+}
+
+func (m *MetadataDecoder) parseRange(start *xml.StartElement) error {
+	var begin, length uint64
+	var err error
+	for _, attr := range start.Attr {
+		switch attr.Name.Local {
+		case "data_begin":
+			begin, err = strconv.ParseUint(attr.Value, 10, 64)
+			if err != nil {
+				return err
+			}
+		case "length":
+			length, err = strconv.ParseUint(attr.Value, 10, 64)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	m.ranges.Add(begin, begin+length)
+
+	m.d.Skip()
+	return nil
+}
+
+func (m *MetadataDecoder) parseSingle(start *xml.StartElement) error {
+	for _, attr := range start.Attr {
+		switch attr.Name.Local {
+		case "data_block":
+			block, err := strconv.ParseUint(attr.Value, 10, 64)
+			if err != nil {
+				return err
+			}
+			m.ranges.Add(block, block+1)
+		}
+	}
+
+	m.d.Skip()
+
+	return nil
+}
+
+func (m *MetadataDecoder) parseDevice(start *xml.StartElement) error {
+	for {
+		tok, err := m.d.Token()
+		if err != nil {
+			return err
+		}
+		switch tok := tok.(type) {
+		case xml.StartElement:
+			switch tok.Name.Local {
+			case "range_mapping":
+				if err := m.parseRange(&tok); err != nil {
+					return err
+				}
+			case "single_mapping":
+				if err := m.parseSingle(&tok); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("Unknown tag type %s\n", tok.Name)
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
+func (m *MetadataDecoder) readStart() (*xml.StartElement, error) {
+	for {
+		tok, err := m.d.Token()
+		if err != nil {
+			return nil, err
+		}
+
+		switch tok := tok.(type) {
+		case xml.StartElement:
+			return &tok, nil
+
+		case xml.EndElement:
+			return nil, fmt.Errorf("Unbalanced tags")
+		}
+	}
+}
+
+func (m *MetadataDecoder) parseMetadata() error {
+	start, err := m.readStart()
+	if err != nil {
+		return err
+	}
+	if start.Name.Local != "superblock" {
+		return fmt.Errorf("Unexpected tag type %s", start.Name)
+	}
+
+	for {
+		tok, err := m.d.Token()
+		if err != nil {
+			return err
+		}
+		switch tok := tok.(type) {
+		case xml.StartElement:
+			switch tok.Name.Local {
+			case "device":
+				m.parseDevice(&tok)
+			default:
+				return fmt.Errorf("Unknown tag type %s\n", tok.Name)
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
+func readMetadataRanges(file string) (*Ranges, error) {
+	cmd := exec.Command("thin_dump", file)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+
+	m := NewMetadataDecoder(stdout)
+
+	errChan := make(chan error)
+
+	go func() {
+		err = m.parseMetadata()
+		errChan <- err
+	}()
+
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	err = <-errChan
+	if err != nil {
+		return nil, err
+	}
+
+	return m.ranges, nil
+}

--- a/daemon/graphdriver/devmapper/ranges.go
+++ b/daemon/graphdriver/devmapper/ranges.go
@@ -1,0 +1,98 @@
+// +build linux,amd64
+
+package devmapper
+
+import (
+	"container/list"
+	"fmt"
+)
+
+type Range struct {
+	begin uint64
+	end   uint64
+}
+
+type Ranges struct {
+	*list.List
+}
+
+func NewRanges() *Ranges {
+	return &Ranges{list.New()}
+}
+
+func (r *Ranges) ToString() string {
+	s := ""
+	for e := r.Front(); e != nil; e = e.Next() {
+		r := e.Value.(*Range)
+		if s != "" {
+			s = s + ","
+		}
+		s = fmt.Sprintf("%s%d-%d", s, r.begin, r.end)
+	}
+	return s
+}
+
+func (r *Ranges) Clear() {
+	r.Init()
+}
+
+func (r *Ranges) Add(begin, end uint64) {
+	var next *list.Element
+	for e := r.Front(); e != nil; e = next {
+		next = e.Next()
+
+		existing := e.Value.(*Range)
+
+		// If existing range is fully to the left, skip
+		if existing.end < begin {
+			continue
+		}
+
+		// If new range is fully to the left, just insert
+		if end < existing.begin {
+			r.InsertBefore(&Range{begin, end}, e)
+			return
+		}
+
+		// Now we know the two ranges somehow intersect (or at least touch)
+
+		// Extend existing range with the new range
+		if begin < existing.begin {
+			existing.begin = begin
+		}
+
+		// If the new range is completely covered by existing range, we're done
+		if end <= existing.end {
+			return
+		}
+
+		// Otherwise strip r from new range
+		begin = existing.end
+
+		// We're now touching r at the end, and so we need to either extend r
+		// or merge with next
+
+		if next == nil {
+			// Nothing after, extend
+			existing.end = end
+			return
+		}
+
+		nextR := next.Value.(*Range)
+		if end < nextR.begin {
+			// Fits, Just extend
+			existing.end = end
+			return
+		}
+
+		// The new region overlaps the next, merge the two
+		nextR.begin = existing.begin
+		r.Remove(e)
+	}
+
+	// nothing in list or everything to the left, just append the rest
+	if begin < end {
+		r.PushBack(&Range{begin, end})
+		return
+	}
+}

--- a/daemon/graphdriver/devmapper/ranges_test.go
+++ b/daemon/graphdriver/devmapper/ranges_test.go
@@ -1,0 +1,54 @@
+// +build linux,amd64
+
+package devmapper
+
+import (
+	"fmt"
+	"testing"
+)
+
+func assert(t *testing.T, r *Ranges, res string) {
+	s := r.ToString()
+	if s != res {
+		t.Fatalf(fmt.Sprintf("error: got %s, expecting %s\n", s, res))
+	}
+}
+
+func TestRanges(t *testing.T) {
+	r := NewRanges()
+	assert(t, r, "")
+	r.Clear()
+	assert(t, r, "")
+	r.Add(5, 6)
+	assert(t, r, "5-6")
+	r.Add(5, 6)
+	assert(t, r, "5-6")
+	r.Add(5, 7)
+	assert(t, r, "5-7")
+	r.Add(7, 8)
+	assert(t, r, "5-8")
+	r.Add(4, 6)
+	assert(t, r, "4-8")
+	r.Add(5, 6)
+	assert(t, r, "4-8")
+	r.Add(3, 4)
+	assert(t, r, "3-8")
+	r.Add(1, 2)
+	assert(t, r, "1-2,3-8")
+	r.Add(15, 20)
+	assert(t, r, "1-2,3-8,15-20")
+	r.Add(30, 40)
+	assert(t, r, "1-2,3-8,15-20,30-40")
+	r.Add(8, 9)
+	assert(t, r, "1-2,3-9,15-20,30-40")
+	r.Add(8, 10)
+	assert(t, r, "1-2,3-10,15-20,30-40")
+	r.Add(8, 25)
+	assert(t, r, "1-2,3-25,30-40")
+	r.Add(0, 27)
+	assert(t, r, "0-27,30-40")
+	r.Add(29, 41)
+	assert(t, r, "0-27,29-41")
+	r.Add(27, 29)
+	assert(t, r, "0-41")
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/dotcloud/docker/utils"
 )
@@ -43,6 +44,7 @@ func unregister(name string) {
 // It acts as a store for *containers*, and allows manipulation of these
 // containers by executing *jobs*.
 type Engine struct {
+	sync.RWMutex
 	handlers map[string]Handler
 	catchall Handler
 	hack     Hack // data for temporary hackery (see hack.go)
@@ -54,6 +56,9 @@ type Engine struct {
 }
 
 func (eng *Engine) Register(name string, handler Handler) error {
+	eng.Lock()
+	defer eng.Unlock()
+
 	_, exists := eng.handlers[name]
 	if exists {
 		return fmt.Errorf("Can't overwrite handler for command %s", name)
@@ -63,6 +68,9 @@ func (eng *Engine) Register(name string, handler Handler) error {
 }
 
 func (eng *Engine) RegisterCatchall(catchall Handler) {
+	eng.Lock()
+	defer eng.Unlock()
+
 	eng.catchall = catchall
 }
 
@@ -96,6 +104,9 @@ func (eng *Engine) String() string {
 // Commands returns a list of all currently registered commands,
 // sorted alphabetically.
 func (eng *Engine) commands() []string {
+	eng.RLock()
+	defer eng.RUnlock()
+
 	names := make([]string, 0, len(eng.handlers))
 	for name := range eng.handlers {
 		names = append(names, name)
@@ -119,6 +130,8 @@ func (eng *Engine) Job(name string, args ...string) *Job {
 	if eng.Logging {
 		job.Stderr.Add(utils.NopWriteCloser(eng.Stderr))
 	}
+	eng.RLock()
+	defer eng.RUnlock()
 
 	// Catchall is shadowed by specific Register.
 	if handler, exists := eng.handlers[name]; exists {

--- a/engine/hack.go
+++ b/engine/hack.go
@@ -3,6 +3,9 @@ package engine
 type Hack map[string]interface{}
 
 func (eng *Engine) Hack_GetGlobalVar(key string) interface{} {
+	eng.RLock()
+	defer eng.RUnlock()
+
 	if eng.hack == nil {
 		return nil
 	}
@@ -14,6 +17,9 @@ func (eng *Engine) Hack_GetGlobalVar(key string) interface{} {
 }
 
 func (eng *Engine) Hack_SetGlobalVar(key string, val interface{}) {
+	eng.Lock()
+	defer eng.Unlock()
+
 	if eng.hack == nil {
 		eng.hack = make(Hack)
 	}


### PR DESCRIPTION
This series adds a generic /cmd endpoint and cli support for it, so that drivers and other form of plugins can add arbitrary new operations, which are accessible as "docker <plugin>:<operation> args..." .

Additionally it adds devicemapper specific operations `dm:resize-pool`, `dm:resize` and `dm:trim-pool`. These allow resizeing the devicemapper pool, indivdual devicemapper devices (like images and containers) and finally allows you to return unused space in the pool to the host root filesystem (when using loopback).

The last one is interesting because it lets you get space back if the discard trick we're using on delete doesn't work (older kernel) or is disabled (because its very slow).
