### PR TITLE
Correct port number forwarding bash script

### DIFF
--- a/docs/sources/installation/mac.rst
+++ b/docs/sources/installation/mac.rst
@@ -126,7 +126,7 @@ with our containers as if they were running locally:
 .. code-block:: bash
 
    # vm must be powered off
-   for i in {4900..49900}; do
+   for i in {49000..49900}; do
     VBoxManage modifyvm "boot2docker-vm" --natpf1 "tcp-port$i,tcp,,$i,,$i";
     VBoxManage modifyvm "boot2docker-vm" --natpf1 "udp-port$i,udp,,$i,,$i";
    done


### PR DESCRIPTION
The documentation states that the VM port range that docker uses is 49000 - 49900. However, the included bash script was incorrectly mapping 4900 - 49900.

Docker-DCO-1.1-Signed-off-by: Michael Italia michael.italia@gmail.com (github: mitalia)
