### PR TITLE
Add "Conflicts" to our lxc-docker package

### DIFF
--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -119,6 +119,8 @@ EOF
 		    --deb-recommends xz-utils \
 		    --description "$PACKAGE_DESCRIPTION" \
 		    --maintainer "$PACKAGE_MAINTAINER" \
+		    --conflicts docker \
+		    --conflicts docker.io \
 		    --conflicts lxc-docker-virtual-package \
 		    --provides lxc-docker \
 		    --provides lxc-docker-virtual-package \


### PR DESCRIPTION
... to make it more clear that we can't/shouldn't be installed alongside either "docker" or "docker.io"
