### PR TITLE
Add docker squash command

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -448,6 +448,32 @@ func postCommit(eng *engine.Engine, version version.Version, w http.ResponseWrit
 	return writeJSON(w, http.StatusCreated, env)
 }
 
+func postImagesSquash(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := parseForm(r); err != nil {
+		return err
+	}
+	var (
+		config       engine.Env
+		env          engine.Env
+		job          = eng.Job("squash", r.Form.Get("base"), r.Form.Get("leaf"))
+		stdoutBuffer = bytes.NewBuffer(nil)
+	)
+	if err := config.Decode(r.Body); err != nil {
+		utils.Errorf("%s", err)
+	}
+
+	job.Setenv("repo", r.Form.Get("repo"))
+	job.Setenv("tag", r.Form.Get("tag"))
+	job.Setenv("comment", r.Form.Get("comment"))
+
+	job.Stdout.Add(stdoutBuffer)
+	if err := job.Run(); err != nil {
+		return err
+	}
+	env.Set("Id", engine.Tail(stdoutBuffer, 1))
+	return writeJSON(w, http.StatusCreated, env)
+}
+
 // Creates an image from Pull or from Import
 func postImagesCreate(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
@@ -1085,6 +1111,7 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 			"/commit":                       postCommit,
 			"/build":                        postBuild,
 			"/images/create":                postImagesCreate,
+			"/images/squash":                postImagesSquash,
 			"/images/load":                  postImagesLoad,
 			"/images/{name:.*}/push":        postImagesPush,
 			"/images/{name:.*}/tag":         postImagesTag,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -666,6 +666,53 @@ func (daemon *Daemon) Commit(container *Container, repository, tag, comment, aut
 	return img, nil
 }
 
+// Squash creates a new filesystem image by combining multiple layers
+// The image can optionally be tagged into a repository
+func (daemon *Daemon) Squash(baseID string, leaf *image.Image, repository, tag, comment string) (*image.Image, error) {
+	basePath, err := daemon.driver.Get(baseID, "")
+	if err != nil {
+		return nil, err
+	}
+	defer daemon.driver.Put(baseID)
+
+	leafPath, err := daemon.driver.Get(leaf.ID, "")
+	if err != nil {
+		return nil, err
+	}
+	defer daemon.driver.Put(leaf.ID)
+
+	changes, err := archive.ChangesDirs(leafPath, basePath)
+	if err != nil {
+		return nil, err
+	}
+
+	archive, err := archive.ExportChanges(leafPath, changes)
+	if err != nil {
+		return nil, err
+	}
+	defer archive.Close()
+
+	config := leaf.Config
+	// Make a copy of the config in case it is modified
+	if config != nil {
+		c := *config
+		config = &c
+	}
+
+	img, err := daemon.graph.Create(archive, "", baseID, comment, leaf.Author, nil, config)
+	if err != nil {
+		return nil, err
+	}
+
+	// Register the image if needed
+	if repository != "" {
+		if err := daemon.repositories.Set(repository, tag, img.ID, true); err != nil {
+			return img, err
+		}
+	}
+	return img, nil
+}
+
 func GetFullContainerName(name string) (string, error) {
 	if name == "" {
 		return "", fmt.Errorf("Container name cannot be empty")

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -51,6 +51,11 @@ Trusted builds are now Automated Builds - `is_trusted` is now `is_automated`.
 **Removed Insert Endpoint**
 The `insert` endpoint has been removed.
 
+`POST /images/squash`
+
+**New!**
+New request to create images that combine multiple layers in existing images
+
 ## v1.11
 
 ### Full Documentation

--- a/docs/sources/reference/api/docker_remote_api_v1.12.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.12.md
@@ -767,6 +767,41 @@ Create an image, either by pull it from the registry or by importing it
     -   **200** – no error
     -   **500** – server error
 
+### Squash an image
+
+`POST /images/squash`
+
+Create a new squashed image, by combining multiple layers in an
+already existing image, up to but not including a specified base image
+
+    **Example request**:
+
+        POST /images/squash?base=ubuntu%3A13.10&leaf=docker%3Asquash HTTP/1.1
+
+    **Example response**:
+
+        HTTP/1.1 201 OK
+        Content-Type: application/json
+
+        {
+             "Id":"20b6363a00634979c2fec7b9181d3e90a1b764d1976ba25ac2ca3f6fd516a6bc"
+        }
+
+    Query Parameters:
+
+     
+
+    -   **base** – Name of the base image to use for the new image
+    -   **leaf** – Name of the image to squash
+    -   **repo** – The repository to tag in
+    -   **tag**  – tag
+
+    Status Codes:
+
+    -   **201** – no error
+    -   **404** – no such image
+    -   **500** – server error
+
 ### Insert a file in an image
 
 `POST /images/(name)/insert`

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1154,6 +1154,61 @@ takes no action and succeeds unconditionally.
 The main process inside the container will receive SIGTERM, and after a
 grace period, SIGKILL
 
+## squash
+----------
+
+Create a new image by combining several layers
+
+    Usage: docker squash [OPTIONS] BASEIMAGE LEAFIMAGE [REPOSITORY[:TAG]]
+
+      -m, --message="": Commit message
+
+This creates a new image which the same contents as the leaf image, but with a single
+layer. This can be useful for instance if the intermediate layers contain a lot of
+temporary data such as builds artifacts which are later removed or replaced, as such data will
+not be downloaded when downloading the squashed image.
+
+### Example:
+
+    $ sudo docker history docker:latest
+    IMAGE               CREATED             CREATED BY                                      SIZE
+    a1cc2deea3ee        19 hours ago        /bin/sh -c #(nop) ADD dir:dd8dc6d1941aa8ae9aa   118.4 MB
+    6fac2b524be6        19 hours ago        /bin/sh -c #(nop) ENTRYPOINT [hack/dind]        0 B
+    15a073fcf699        19 hours ago        /bin/sh -c #(nop) ENV DOCKER_BUILDTAGS=apparm   0 B
+    421befe79573        19 hours ago        /bin/sh -c #(nop) WORKDIR /go/src/github.com/   0 B
+    78eb13b1bd69        19 hours ago        /bin/sh -c #(nop) VOLUME /var/lib/docker        0 B
+    aa348b9d0803        19 hours ago        /bin/sh -c git config --global user.email 'do   118 B
+    4b5e1b839f65        19 hours ago        /bin/sh -c /bin/echo -e '[default]\naccess_ke   141 B
+    43de78f065fa        19 hours ago        /bin/sh -c gem install --no-rdoc --no-ri fpm    21.13 MB
+    cb6b9593d1c4        19 hours ago        /bin/sh -c go get code.google.com/p/go.tools/   13.34 MB
+    5b6d67554a5a        19 hours ago        /bin/sh -c cd /usr/local/go/src && bash -xc '   598.2 MB
+    58bdd25c48c4        19 hours ago        /bin/sh -c #(nop) ENV GOARM=5                   0 B
+    06d075c923e4        19 hours ago        /bin/sh -c #(nop) ENV DOCKER_CROSSPLATFORMS=l   0 B
+    40c9f4daadc8        19 hours ago        /bin/sh -c cd /usr/local/go/src && ./make.bas   84.28 MB
+    061823118c15        19 hours ago        /bin/sh -c #(nop) ENV GOPATH=/go:/go/src/gith   0 B
+    5c81dc9fb457        19 hours ago        /bin/sh -c #(nop) ENV PATH=/usr/local/go/bin:   0 B
+    7789cf681cc5        19 hours ago        /bin/sh -c curl -s https://go.googlecode.com/   35.32 MB
+    af80d0b46fc1        19 hours ago        /bin/sh -c cd /usr/local/lvm2 && ./configure    5.046 MB
+    d629b2e0a695        19 hours ago        /bin/sh -c git clone --no-checkout https://gi   18.34 MB
+    ba40ca134a78        19 hours ago        /bin/sh -c cd /usr/local/lxc && ./autogen.sh    6.127 MB
+    8a8bdda54d9d        19 hours ago        /bin/sh -c git clone --no-checkout https://gi   10.14 MB
+    7c293c4e4ba2        19 hours ago        /bin/sh -c apt-get update && DEBIAN_FRONTEND=   225 MB
+    642fa6ca43fb        19 hours ago        /bin/sh -c #(nop) MAINTAINER Tianon Gravi <ad   0 B
+    9f676bd305a4        6 weeks ago         /bin/sh -c #(nop) ADD saucy.tar.xz in /         182.1 MB
+    1c7f181e78b9        6 weeks ago         /bin/sh -c #(nop) MAINTAINER Tianon Gravi <ad   0 B
+    511136ea3c5a        9 months ago                                                        0 B
+    # 9f676bd305a4 is tagged as ubuntu:13.10
+    # a1cc2deea3ee is tagged as docker:latest
+    $ sudo docker squash ubuntu:13.10 docker:latest docker-shrunk
+    106fcb1525f7d958edd8302b00e337ff77dbc9c69d5ada6f82c6292cc707c03e
+    $ sudo docker history docker-shrunk
+    IMAGE               CREATED              CREATED BY                                      SIZE
+    106fcb1525f7        About a minute ago                                                   1.058 GB
+    9f676bd305a4        6 weeks ago          /bin/sh -c #(nop) ADD saucy.tar.xz in /         182.1 MB
+    1c7f181e78b9        6 weeks ago          /bin/sh -c #(nop) MAINTAINER Tianon Gravi <ad   0 B
+    511136ea3c5a        9 months ago                                                         0 B
+
+
 ## tag
 
     Usage: docker tag [OPTIONS] IMAGE [REGISTRYHOST/][USERNAME/]NAME[:TAG]

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -131,9 +131,10 @@ func (graph *Graph) Get(name string) (*image.Image, error) {
 }
 
 // Create creates a new image and registers it in the graph.
-func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, containerImage, comment, author string, containerConfig, config *runconfig.Config) (*image.Image, error) {
+func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, parent, comment, author string, containerConfig, config *runconfig.Config) (*image.Image, error) {
 	img := &image.Image{
 		ID:            utils.GenerateRandomID(),
+		Parent:        parent,
 		Comment:       comment,
 		Created:       time.Now().UTC(),
 		DockerVersion: dockerversion.VERSION,
@@ -144,7 +145,6 @@ func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, contain
 	}
 
 	if containerID != "" {
-		img.Parent = containerImage
 		img.Container = containerID
 		img.ContainerConfig = *containerConfig
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -138,6 +138,7 @@ func InitServer(job *engine.Job) engine.Status {
 		"history":          srv.ImageHistory,
 		"viz":              srv.ImagesViz,
 		"container_copy":   srv.ContainerCopy,
+		"squash":           srv.ImageSquash,
 		"attach":           srv.ContainerAttach,
 		"logs":             srv.ContainerLogs,
 		"changes":          srv.ContainerChanges,
@@ -1061,6 +1062,45 @@ func (srv *Server) ContainerCommit(job *engine.Job) engine.Status {
 	}
 
 	img, err := srv.daemon.Commit(container, job.Getenv("repo"), job.Getenv("tag"), job.Getenv("comment"), job.Getenv("author"), &newConfig)
+	if err != nil {
+		return job.Error(err)
+	}
+	job.Printf("%s\n", img.ID)
+	return engine.StatusOK
+}
+
+func (srv *Server) ImageSquash(job *engine.Job) engine.Status {
+	if len(job.Args) != 2 {
+		return job.Errorf("Not enough arguments. Usage: %s BASEIMAGE IMAGE\n", job.Name)
+	}
+
+	base, err := srv.daemon.Repositories().LookupImage(job.Args[0])
+	if err != nil {
+		return job.Errorf("No such image: %s", job.Args[0])
+	}
+	leaf, err := srv.daemon.Repositories().LookupImage(job.Args[1])
+	if err != nil {
+		return job.Errorf("No such image: %s", job.Args[1])
+	}
+
+	foundBase := false
+	leaf.WalkHistory(func(img *image.Image) error {
+		if img.ID == base.ID {
+			foundBase = true
+		}
+		return nil
+	})
+
+	if !foundBase || base == leaf {
+		return job.Errorf("%s is not decendant from %s", job.Args[1], job.Args[0])
+	}
+
+	comment := job.Getenv("comment")
+	if comment == "" {
+		comment = "Squashed from " + leaf.ID
+	}
+
+	img, err := srv.daemon.Squash(base.ID, leaf, job.Getenv("repo"), job.Getenv("tag"), comment)
 	if err != nil {
 		return job.Error(err)
 	}


### PR DESCRIPTION
This adds a new cli command like:
docker squash baseimage leafimage

This command creates a new image that is a child of baseimage
and has the same content as leafimage. In other words, it combines
all the layers between baseimage and leafimage into a single
image.

There are several reasons why this is useful, for instance it is common
for intermediate layers to add extra files during execution which are
removed at the end (for instance build dependencies, or e.g. yum/apt-get
metadata). Removing these makes for a smaller final image.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
