### PR TITLE
FIX: Linux mint troubleshooting tip

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -220,12 +220,12 @@ To install the latest version of docker, use the standard ``apt-get`` method:
 Troubleshooting
 ^^^^^^^^^^^^^^^
 
-On Linux Mint, the ``cgroups-lite`` package is not installed by default.
+On Linux Mint, the ``cgroup-lite`` package is not installed by default.
 Before Docker will work correctly, you will need to install this via:
 
 .. code-block:: bash
 
-    sudo apt-get update && sudo apt-get install cgroups-lite
+    sudo apt-get update && sudo apt-get install cgroup-lite
 
 .. _ufw:
 


### PR DESCRIPTION
Package is called 'cgroup-lite' not 'cgroups-lite'. Verified on Linux Mint 16.

Ref http://packages.ubuntu.com/search?keywords=cgroup-lite
