### PR TITLE
Start adding ports at right order of magnitude

### DIFF
--- a/docs/sources/installation/mac.rst
+++ b/docs/sources/installation/mac.rst
@@ -126,7 +126,7 @@ with our containers as if they were running locally:
 .. code-block:: bash
 
    # vm must be powered off
-   for i in {4900..49900}; do
+   for i in {49000..49900}; do
     VBoxManage modifyvm "boot2docker-vm" --natpf1 "tcp-port$i,tcp,,$i,,$i";
     VBoxManage modifyvm "boot2docker-vm" --natpf1 "udp-port$i,udp,,$i,,$i";
    done


### PR DESCRIPTION
The documentation says to start at 4900, which if you copy/paste on a brand new MacBook Pro retina with SSD takes over an hour. Oops.
