### PR TITLE
don't skip cert check for an example & use HTTPS

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -39,7 +39,7 @@ arch-chroot $ROOTFS /bin/sh -c "haveged -w 1024; pacman-key --init; pkill havege
 arch-chroot $ROOTFS /bin/sh -c "ln -s /usr/share/zoneinfo/UTC /etc/localtime"
 echo 'en_US.UTF-8 UTF-8' > $ROOTFS/etc/locale.gen
 arch-chroot $ROOTFS locale-gen
-arch-chroot $ROOTFS /bin/sh -c 'echo "Server = http://mirrors.kernel.org/archlinux/\$repo/os/\$arch" > /etc/pacman.d/mirrorlist'
+arch-chroot $ROOTFS /bin/sh -c 'echo "Server = https://mirrors.kernel.org/archlinux/\$repo/os/\$arch" > /etc/pacman.d/mirrorlist'
 
 # udev doesn't work in containers, rebuild /dev
 DEV=$ROOTFS/dev

--- a/docs/sources/examples/cfengine_process_management.rst
+++ b/docs/sources/examples/cfengine_process_management.rst
@@ -55,7 +55,7 @@ The first two steps can be done as part of a Dockerfile, as follows.
     FROM ubuntu
     MAINTAINER Eystein Måløy Stenberg <eytein.stenberg@gmail.com>
 
-    RUN apt-get -y install wget lsb-release unzip
+    RUN apt-get -y install wget lsb-release unzip ca-certificates
 
     # install latest CFEngine
     RUN wget -qO- http://cfengine.com/pub/gpg.key | apt-key add -
@@ -64,7 +64,7 @@ The first two steps can be done as part of a Dockerfile, as follows.
     RUN apt-get install cfengine-community
 
     # install cfe-docker process management policy
-    RUN wget --no-check-certificate https://github.com/estenberg/cfe-docker/archive/master.zip -P /tmp/ && unzip /tmp/master.zip -d /tmp/
+    RUN wget https://github.com/estenberg/cfe-docker/archive/master.zip -P /tmp/ && unzip /tmp/master.zip -d /tmp/
     RUN cp /tmp/cfe-docker-master/cfengine/bin/* /var/cfengine/bin/
     RUN cp /tmp/cfe-docker-master/cfengine/inputs/* /var/cfengine/inputs/
     RUN rm -rf /tmp/cfe-docker-master /tmp/master.zip

--- a/docs/sources/reference/api/docker_remote_api.rst
+++ b/docs/sources/reference/api/docker_remote_api.rst
@@ -2,7 +2,7 @@
 :description: API Documentation for Docker
 :keywords: API, Docker, rcli, REST, documentation
 
-.. COMMENT use http://pythonhosted.org/sphinxcontrib-httpdomain/ to
+.. COMMENT use https://pythonhosted.org/sphinxcontrib-httpdomain/ to
 .. document the REST API.
 
 =================


### PR DESCRIPTION
This changes two URLs from http to https and it fixes a Dockerfile to stop skipping certificate validation. It also adds the ca-certificates package to that Dockerfile example to make certificate validation work properly.

/cc @SvenDowideit (because the PR touches docs)
/cc @tianon (because the PR touches `contrib/mkimage-arch.sh`)
