### PR TITLE
Register built-in engine commands at runtime instead of compile-time

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -50,10 +50,6 @@ func ValidateHost(val string) (string, error) {
 
 type HttpApiFunc func(eng *engine.Engine, version float64, w http.ResponseWriter, r *http.Request, vars map[string]string) error
 
-func init() {
-	engine.Register("serveapi", ServeApi)
-}
-
 func hijackServer(w http.ResponseWriter) (io.ReadCloser, io.Writer, error) {
 	conn, _, err := w.(http.Hijacker).Hijack()
 	if err != nil {

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -1,0 +1,40 @@
+package builtins
+
+import (
+	"github.com/dotcloud/docker/engine"
+
+	"github.com/dotcloud/docker"
+	"github.com/dotcloud/docker/api"
+	"github.com/dotcloud/docker/networkdriver/lxc"
+)
+
+func Register(eng *engine.Engine) {
+	daemon(eng)
+	remote(eng)
+}
+
+// remote: a RESTful api for cross-docker communication
+func remote(eng *engine.Engine) {
+	eng.Register("serveapi", api.ServeApi)
+}
+
+// daemon: a default execution and storage backend for Docker on Linux,
+// with the following underlying components:
+//
+// * Pluggable storage drivers including aufs, vfs, lvm and btrfs.
+// * Pluggable execution drivers including lxc and chroot.
+//
+// In practice `daemon` still includes most core Docker components, including:
+//
+// * The reference registry client implementation
+// * Image management
+// * The build facility
+// * Logging
+//
+// These components should be broken off into plugins of their own.
+//
+func daemon(eng *engine.Engine) {
+	eng.Register("initserver", docker.InitServer)
+	eng.Register("init_networkdriver", lxc.InitDriver)
+	eng.Register("version", docker.GetVersion)
+}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	_ "github.com/dotcloud/docker"
 	"github.com/dotcloud/docker/api"
+	"github.com/dotcloud/docker/builtins"
 	"github.com/dotcloud/docker/dockerversion"
 	"github.com/dotcloud/docker/engine"
 	flag "github.com/dotcloud/docker/pkg/mflag"
@@ -81,6 +81,8 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		// Load builtins
+		builtins.Register(eng)
 		// load the daemon in the background so we can immediately start
 		// the http api so that connections don't fail while the daemon
 		// is booting

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -2,7 +2,6 @@ package docker
 
 import (
 	"github.com/dotcloud/docker"
-	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/runconfig"
 	"strings"
 	"testing"
@@ -258,20 +257,7 @@ func TestRestartKillWait(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	eng, err = engine.New(eng.Root())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	job = eng.Job("initserver")
-	job.Setenv("Root", eng.Root())
-	job.SetenvBool("AutoRestart", false)
-	// TestGetEnabledCors and TestOptionsRoute require EnableCors=true
-	job.SetenvBool("EnableCors", true)
-	if err := job.Run(); err != nil {
-		t.Fatal(err)
-	}
-
+	eng = newTestEngine(t, false, eng.Root())
 	srv = mkServerFromEngine(eng, t)
 
 	job = srv.Eng.Job("containers")

--- a/networkdriver/lxc/driver.go
+++ b/networkdriver/lxc/driver.go
@@ -57,12 +57,6 @@ var (
 	currentInterfaces = make(map[string]*networkInterface)
 )
 
-func init() {
-	if err := engine.Register("init_networkdriver", InitDriver); err != nil {
-		panic(err)
-	}
-}
-
 func InitDriver(job *engine.Job) engine.Status {
 	var (
 		network        *net.IPNet

--- a/server.go
+++ b/server.go
@@ -34,14 +34,10 @@ func (srv *Server) Close() error {
 	return srv.runtime.Close()
 }
 
-func init() {
-	engine.Register("initserver", jobInitServer)
-}
-
 // jobInitApi runs the remote api server `srv` as a daemon,
 // Only one api server can run at the same time - this is enforced by a pidfile.
 // The signals SIGINT, SIGQUIT and SIGTERM are intercepted for cleanup.
-func jobInitServer(job *engine.Job) engine.Status {
+func InitServer(job *engine.Job) engine.Status {
 	job.Logf("Creating server")
 	srv, err := NewServer(job.Eng, DaemonConfigFromJob(job))
 	if err != nil {

--- a/version.go
+++ b/version.go
@@ -7,11 +7,7 @@ import (
 	"runtime"
 )
 
-func init() {
-	engine.Register("version", jobVersion)
-}
-
-func jobVersion(job *engine.Job) engine.Status {
+func GetVersion(job *engine.Job) engine.Status {
 	if _, err := dockerVersion().WriteTo(job.Stdout); err != nil {
 		job.Errorf("%s", err)
 		return engine.StatusErr


### PR DESCRIPTION
This allows selective loading of commands, and paves the way to dynamic
plugins.

Docker-DCO-1.1-Signed-off-by: Solomon Hykes solomon@docker.com (github: shykes)
