### PR TITLE
forbid chained onbuild, from & maintainer triggers

### DIFF
--- a/docs/sources/reference/builder.rst
+++ b/docs/sources/reference/builder.rst
@@ -466,6 +466,8 @@ For example you might add something like this:
     ONBUILD RUN /usr/local/bin/python-build --dir /app/src
     [...]
 
+.. warning:: Chaining ONBUILD instructions using `ONBUILD ONBUILD` isn't allowed.
+.. warning:: ONBUILD may not trigger FROM or MAINTAINER instructions.
 
 .. _dockerfile_examples:
 

--- a/integration/buildfile_test.go
+++ b/integration/buildfile_test.go
@@ -924,3 +924,45 @@ func TestBuildOnBuildTrigger(t *testing.T) {
 	}
 	// FIXME: test that the 'foobar' file was created in the final build.
 }
+
+func TestBuildOnBuildForbiddenChainedTrigger(t *testing.T) {
+	_, err := buildImage(testContextTemplate{`
+	from {IMAGE}
+	onbuild onbuild run echo test
+	`,
+		nil, nil,
+	},
+		t, nil, true,
+	)
+	if err == nil {
+		t.Fatal("Error should not be nil")
+	}
+}
+
+func TestBuildOnBuildForbiddenFromTrigger(t *testing.T) {
+	_, err := buildImage(testContextTemplate{`
+	from {IMAGE}
+	onbuild from {IMAGE}
+	`,
+		nil, nil,
+	},
+		t, nil, true,
+	)
+	if err == nil {
+		t.Fatal("Error should not be nil")
+	}
+}
+
+func TestBuildOnBuildForbiddenMaintainerTrigger(t *testing.T) {
+	_, err := buildImage(testContextTemplate{`
+	from {IMAGE}
+	onbuild maintainer test
+	`,
+		nil, nil,
+	},
+		t, nil, true,
+	)
+	if err == nil {
+		t.Fatal("Error should not be nil")
+	}
+}


### PR DESCRIPTION
This changes the way onbuild works:
- forbids the chaining of onbuild instructions (`onbuild onbuild run foo`)
- forbids the use of `onbuild from`
- forbids the use of `onbuild maintainer`

It also makes docker throw errors when encountering such triggers when executing the triggers during `FROM`.

Three tests have been added:
- ensure that chained onbuild (`onbuild onbuild`) is forbidden
- ensure that `onbuild from` is forbidden
- ensure that `onbuild maintainer` is forbidden

Fixes #4244
