### PR TITLE
Fix build auth by adding config to the build job environment

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -912,6 +912,8 @@ func postBuild(eng *engine.Engine, version float64, w http.ResponseWriter, r *ht
 	job.Setenv("q", r.FormValue("q"))
 	job.Setenv("nocache", r.FormValue("nocache"))
 	job.Setenv("rm", r.FormValue("rm"))
+	job.SetenvJson("authConfig", authConfig)
+	job.SetenvJson("configFile", configFile)
 
 	if err := job.Run(); err != nil {
 		if !job.Stdout.Used() {


### PR DESCRIPTION
This re-fixes the work that was done for pull request #3442 and then broken in commit SHA: 415379e45dadb32385771ceae701d8b9f204f2b8
