### PR TITLE
Use more Go like Close method instead of CloseWriters

### DIFF
--- a/container.go
+++ b/container.go
@@ -225,7 +225,7 @@ func (container *Container) setupPty() error {
 
 	// Copy the PTYs to our broadcasters
 	go func() {
-		defer container.stdout.CloseWriters()
+		defer container.stdout.Close()
 		utils.Debugf("startPty: begin of stdout pipe")
 		io.Copy(container.stdout, ptyMaster)
 		utils.Debugf("startPty: end of stdout pipe")
@@ -893,10 +893,10 @@ func (container *Container) cleanup() {
 			utils.Errorf("%s: Error close stdin: %s", container.ID, err)
 		}
 	}
-	if err := container.stdout.CloseWriters(); err != nil {
+	if err := container.stdout.Close(); err != nil {
 		utils.Errorf("%s: Error close stdout: %s", container.ID, err)
 	}
-	if err := container.stderr.CloseWriters(); err != nil {
+	if err := container.stderr.Close(); err != nil {
 		utils.Errorf("%s: Error close stderr: %s", container.ID, err)
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -388,7 +388,7 @@ func (w *WriteBroadcaster) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-func (w *WriteBroadcaster) CloseWriters() error {
+func (w *WriteBroadcaster) Close() error {
 	w.Lock()
 	defer w.Unlock()
 	for sw := range w.writers {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -110,7 +110,7 @@ func TestWriteBroadcaster(t *testing.T) {
 		t.Errorf("Buffer contains %v", bufferC.String())
 	}
 
-	writer.CloseWriters()
+	writer.Close()
 }
 
 type devNullCloser int


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
