### PR TITLE
Add newlines to the JSON stream functions

### DIFF
--- a/utils/streamformatter.go
+++ b/utils/streamformatter.go
@@ -14,6 +14,10 @@ func NewStreamFormatter(json bool) *StreamFormatter {
 	return &StreamFormatter{json, false}
 }
 
+const streamNewline = "\r\n"
+
+var streamNewlineBytes = []byte(streamNewline)
+
 func (sf *StreamFormatter) FormatStream(str string) []byte {
 	sf.used = true
 	if sf.json {
@@ -21,7 +25,7 @@ func (sf *StreamFormatter) FormatStream(str string) []byte {
 		if err != nil {
 			return sf.FormatError(err)
 		}
-		return b
+		return append(b, streamNewlineBytes...)
 	}
 	return []byte(str + "\r")
 }
@@ -34,9 +38,9 @@ func (sf *StreamFormatter) FormatStatus(id, format string, a ...interface{}) []b
 		if err != nil {
 			return sf.FormatError(err)
 		}
-		return b
+		return append(b, streamNewlineBytes...)
 	}
-	return []byte(str + "\r\n")
+	return []byte(str + streamNewline)
 }
 
 func (sf *StreamFormatter) FormatError(err error) []byte {
@@ -47,11 +51,11 @@ func (sf *StreamFormatter) FormatError(err error) []byte {
 			jsonError = &JSONError{Message: err.Error()}
 		}
 		if b, err := json.Marshal(&JSONMessage{Error: jsonError, ErrorMessage: err.Error()}); err == nil {
-			return b
+			return append(b, streamNewlineBytes...)
 		}
-		return []byte("{\"error\":\"format error\"}")
+		return []byte("{\"error\":\"format error\"}" + streamNewline)
 	}
-	return []byte("Error: " + err.Error() + "\r\n")
+	return []byte("Error: " + err.Error() + streamNewline)
 }
 
 func (sf *StreamFormatter) FormatProgress(id, action string, progress *JSONProgress) []byte {


### PR DESCRIPTION
This makes the JSON streams a _lot_ easier to parse in less well-baked JSON parsers, and no less so in better ones.

Line-based JSON streams are very, very common, where simply chunk-based is not very common at all.

If you want a really pretty way to test this, start the compiled daemon listening on a TCP socket and run something like this (and watch it stream all pretty-like, right before your very eyes):

``` console
$ echo -e 'FROM debian\nRUN apt-get update\n' | perl -w -MArchive::Tar -e 'my $tar = Archive::Tar->new; { local $/; $tar->add_data("Dockerfile", <>); } print $tar->write' | curl --data-binary @- --header 'Content-Type: application/x-tar' --dump-header - --no-buffer 'http://localhost:4243/build?rm=1&nocache=1'
HTTP/1.1 100 Continue

HTTP/1.1 200 OK
Content-Type: application/json
Date: Fri, 21 Feb 2014 07:02:54 GMT
Transfer-Encoding: chunked

{"stream":"Step 0 : FROM debian\n"}
{"stream":" ---\u003e b5fe16f2ccba\n"}
{"stream":"Step 1 : RUN apt-get update\n"}
{"stream":" ---\u003e Running in 2e05165d76ef\n"}
{"stream":"Get:1 http://security.debian.org wheezy/updates Release.gpg [836 B]\n"}
{"stream":"Get:2 http://security.debian.org wheezy/updates Release [102 kB]\n"}
{"stream":"Get:3 http://http.debian.net wheezy Release.gpg [1672 B]\n"}
{"stream":"Get:4 http://http.debian.net wheezy-updates Release.gpg [836 B]\n"}
{"stream":"Get:5 http://http.debian.net wheezy Release [168 kB]\n"}
{"stream":"Get:6 http://security.debian.org wheezy/updates/main amd64 Packages [161 kB]\n"}
{"stream":"Get:7 http://http.debian.net wheezy-updates Release [124 kB]\n"}
{"stream":"Get:8 http://http.debian.net wheezy/main amd64 Packages [5845 kB]\n"}
{"stream":"Get:9 http://http.debian.net wheezy-updates/main amd64 Packages/DiffIndex [643 B]\n"}
{"stream":"Get:10 http://http.debian.net wheezy-updates/main amd64 2014-02-15-1443.31.pdiff [547 B]\n"}
{"stream":"Get:11 http://http.debian.net wheezy-updates/main amd64 2014-02-15-1443.31.pdiff [547 B]\n"}
{"stream":"Fetched 6405 kB in 4s (1412 kB/s)\nReading package lists..."}
{"stream":"\n"}
{"stream":" ---\u003e 55f3253bb19d\n"}
{"stream":"Successfully built 55f3253bb19d\n"}
{"stream":"Removing intermediate container 2e05165d76ef\n"}
```

(see also https://gist.github.com/tianon/9129512 for more masochism along similar lines)

This came about from a discussion on IRC: https://botbot.me/freenode/docker/msg/11203433/

I also looked into swapping the Content-Type returned for these streams to something more like "application/x-json-stream", but that looked like it would be a bit more non-trivial (since the StreamFormatter is used in several places).
