### PR TITLE
Add MTU to lxc conf to make host and container MTU match

### DIFF
--- a/execdriver/lxc/lxc_template.go
+++ b/execdriver/lxc/lxc_template.go
@@ -12,6 +12,7 @@ const LxcTemplate = `
 lxc.network.type = veth
 lxc.network.link = {{.Network.Bridge}}
 lxc.network.name = eth0
+lxc.network.mtu = {{.Network.Mtu}}
 {{else}}
 # network is disabled (-n=false)
 lxc.network.type = empty


### PR DESCRIPTION
If you are using jumbo frames the host side of the veth was being set to
1500.  Docker would set the MTU of the container side of the veth to 9001.
This would lead to a situation in which the two sides of the veth had
different MTU sizes causing issues in network traffic.

Docker-DCO-1.1-Signed-off-by: Darren Shepherd darren.s.shepherd@gmail.com (github: ibuildthecloud)
