### PR TITLE
Doc: Remove uneeded wording in Dockerfile format

### DIFF
--- a/docs/sources/reference/builder.rst
+++ b/docs/sources/reference/builder.rst
@@ -74,7 +74,7 @@ When you're done with your build, you're ready to look into
 2. Format
 =========
 
-The Dockerfile format is quite simple:
+Here is the format of the Dockerfile:
 
 ::
 


### PR DESCRIPTION
"The Dockerfile format is quite simple:"

This wording is both subjective and can be offensive, especially in technical writing.
If the reader does not fully understand the concept then they are left feeling inadequate.  It also doesn't really add anything to the actual meat of the document.
