### PR TITLE
Remove trailing slash from host parameter in docker init for Vagrant

### DIFF
--- a/contrib/vagrant-docker/README.md
+++ b/contrib/vagrant-docker/README.md
@@ -31,7 +31,7 @@ stop on runlevel [!2345]
 respawn
 
 script
-    /usr/bin/docker -d -H=tcp://0.0.0.0:4243/
+    /usr/bin/docker -d -H=tcp://0.0.0.0:4243
 end script
 ```
 


### PR DESCRIPTION
The recommended configuration for a Vagrant-based Docker host contains a trailing slash, which will cause Docker to not start on 0.8.
