### PR TITLE
registry: Added simple checksums (sha256) for layers

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -389,7 +389,7 @@ func (r *Registry) PushImageChecksumRegistry(imgData *ImgData, registry string, 
 	}
 	setTokenAuth(req, token)
 	req.Header.Set("X-Docker-Checksum", imgData.Checksum)
-	req.Header.Set("X-Docker-Checksum-Payload", imgData.ChecksumPayload)
+	req.Header.Set("X-Docker-Checksum-Payload", imgData.checksumPayload)
 
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
@@ -679,8 +679,8 @@ type RepositoryData struct {
 type ImgData struct {
 	ID              string `json:"id"`
 	Checksum        string `json:"checksum,omitempty"`
-	ChecksumPayload string `json:"checksum,omitempty"`
 	Tag             string `json:",omitempty"`
+	checksumPayload string
 }
 
 type Registry struct {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -388,6 +389,7 @@ func (r *Registry) PushImageChecksumRegistry(imgData *ImgData, registry string, 
 	}
 	setTokenAuth(req, token)
 	req.Header.Set("X-Docker-Checksum", imgData.Checksum)
+	req.Header.Set("X-Docker-Checksum-Payload", imgData.ChecksumPayload)
 
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
@@ -446,26 +448,28 @@ func (r *Registry) PushImageJSONRegistry(imgData *ImgData, jsonRaw []byte, regis
 	return nil
 }
 
-func (r *Registry) PushImageLayerRegistry(imgID string, layer io.Reader, registry string, token []string, jsonRaw []byte) (checksum string, err error) {
+func (r *Registry) PushImageLayerRegistry(imgID string, layer io.Reader, registry string, token []string, jsonRaw []byte) (checksum string, checksumPayload string, err error) {
 
 	utils.Debugf("[registry] Calling PUT %s", registry+"images/"+imgID+"/layer")
 
-	tarsumLayer := &utils.TarSum{Reader: layer}
+	h := sha256.New()
+	checksumLayer := &utils.CheckSum{Reader: layer, Hash: h}
+	tarsumLayer := &utils.TarSum{Reader: checksumLayer}
 
 	req, err := r.reqFactory.NewRequest("PUT", registry+"images/"+imgID+"/layer", tarsumLayer)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	req.ContentLength = -1
 	req.TransferEncoding = []string{"chunked"}
 	setTokenAuth(req, token)
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
-		return "", fmt.Errorf("Failed to upload layer: %s", err)
+		return "", "", fmt.Errorf("Failed to upload layer: %s", err)
 	}
 	if rc, ok := layer.(io.Closer); ok {
 		if err := rc.Close(); err != nil {
-			return "", err
+			return "", "", err
 		}
 	}
 	defer res.Body.Close()
@@ -473,11 +477,13 @@ func (r *Registry) PushImageLayerRegistry(imgID string, layer io.Reader, registr
 	if res.StatusCode != 200 {
 		errBody, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return "", utils.NewHTTPRequestError(fmt.Sprintf("HTTP code %d while uploading metadata and error when trying to parse response body: %s", res.StatusCode, err), res)
+			return "", "", utils.NewHTTPRequestError(fmt.Sprintf("HTTP code %d while uploading metadata and error when trying to parse response body: %s", res.StatusCode, err), res)
 		}
-		return "", utils.NewHTTPRequestError(fmt.Sprintf("Received HTTP code %d while uploading layer: %s", res.StatusCode, errBody), res)
+		return "", "", utils.NewHTTPRequestError(fmt.Sprintf("Received HTTP code %d while uploading layer: %s", res.StatusCode, errBody), res)
 	}
-	return tarsumLayer.Sum(jsonRaw), nil
+
+	checksumPayload = "sha256:" + checksumLayer.Sum()
+	return tarsumLayer.Sum(jsonRaw), checksumPayload, nil
 }
 
 // push a tag on the registry.
@@ -671,9 +677,10 @@ type RepositoryData struct {
 }
 
 type ImgData struct {
-	ID       string `json:"id"`
-	Checksum string `json:"checksum,omitempty"`
-	Tag      string `json:",omitempty"`
+	ID              string `json:"id"`
+	Checksum        string `json:"checksum,omitempty"`
+	ChecksumPayload string `json:"checksum,omitempty"`
+	Tag             string `json:",omitempty"`
 }
 
 type Registry struct {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -389,7 +389,7 @@ func (r *Registry) PushImageChecksumRegistry(imgData *ImgData, registry string, 
 	}
 	setTokenAuth(req, token)
 	req.Header.Set("X-Docker-Checksum", imgData.Checksum)
-	req.Header.Set("X-Docker-Checksum-Payload", imgData.checksumPayload)
+	req.Header.Set("X-Docker-Checksum-Payload", imgData.ChecksumPayload)
 
 	res, err := doWithCookies(r.client, req)
 	if err != nil {
@@ -679,8 +679,8 @@ type RepositoryData struct {
 type ImgData struct {
 	ID              string `json:"id"`
 	Checksum        string `json:"checksum,omitempty"`
+	ChecksumPayload string `json:"-"`
 	Tag             string `json:",omitempty"`
-	checksumPayload string
 }
 
 type Registry struct {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -124,7 +124,7 @@ func TestPushImageJSONRegistry(t *testing.T) {
 func TestPushImageLayerRegistry(t *testing.T) {
 	r := spawnTestRegistry(t)
 	layer := strings.NewReader("")
-	_, err := r.PushImageLayerRegistry(IMAGE_ID, layer, makeURL("/v1/"), TOKEN, []byte{})
+	_, _, err := r.PushImageLayerRegistry(IMAGE_ID, layer, makeURL("/v1/"), TOKEN, []byte{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server.go
+++ b/server.go
@@ -1504,11 +1504,12 @@ func (srv *Server) pushImage(r *registry.Registry, out io.Writer, remote, imgID,
 	defer os.RemoveAll(layerData.Name())
 
 	// Send the layer
-	checksum, err = r.PushImageLayerRegistry(imgData.ID, utils.ProgressReader(layerData, int(layerData.Size), out, sf, false, utils.TruncateID(imgData.ID), "Pushing"), ep, token, jsonRaw)
+	checksum, checksumPayload, err := r.PushImageLayerRegistry(imgData.ID, utils.ProgressReader(layerData, int(layerData.Size), out, sf, false, utils.TruncateID(imgData.ID), "Pushing"), ep, token, jsonRaw)
 	if err != nil {
 		return "", err
 	}
 	imgData.Checksum = checksum
+	imgData.ChecksumPayload = checksumPayload
 	// Send the checksum
 	if err := r.PushImageChecksumRegistry(imgData, ep, token); err != nil {
 		return "", err

--- a/server.go
+++ b/server.go
@@ -1509,7 +1509,7 @@ func (srv *Server) pushImage(r *registry.Registry, out io.Writer, remote, imgID,
 		return "", err
 	}
 	imgData.Checksum = checksum
-	imgData.checksumPayload = checksumPayload
+	imgData.ChecksumPayload = checksumPayload
 	// Send the checksum
 	if err := r.PushImageChecksumRegistry(imgData, ep, token); err != nil {
 		return "", err

--- a/server.go
+++ b/server.go
@@ -1509,7 +1509,7 @@ func (srv *Server) pushImage(r *registry.Registry, out io.Writer, remote, imgID,
 		return "", err
 	}
 	imgData.Checksum = checksum
-	imgData.ChecksumPayload = checksumPayload
+	imgData.checksumPayload = checksumPayload
 	// Send the checksum
 	if err := r.PushImageChecksumRegistry(imgData, ep, token); err != nil {
 		return "", err

--- a/utils/checksum.go
+++ b/utils/checksum.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"encoding/hex"
+	"hash"
+	"io"
+)
+
+type CheckSum struct {
+	io.Reader
+	Hash hash.Hash
+}
+
+func (cs *CheckSum) Read(buf []byte) (int, error) {
+	n, err := cs.Reader.Read(buf)
+	if err == nil {
+		cs.Hash.Write(buf[:n])
+	}
+	return n, err
+}
+
+func (cs *CheckSum) Sum() string {
+	return hex.EncodeToString(cs.Hash.Sum(nil))
+}


### PR DESCRIPTION
This adds a simple checksums to when pushing each layer. Both checksums (tarsum and simple) are now pushed.

This will allow the registry to check only simple the checksum (much faster on push) while the Index will keep storing the tarsum for security. The Registry won't store the simple checksum, it will use it only to validate the transfer.
