### PR TITLE
Use the cpu cgroup subsystem instead of memory because its non optional

### DIFF
--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -301,9 +301,8 @@ func (d *driver) Info(id string) execdriver.Info {
 func (d *driver) GetPidsForContainer(id string) ([]int, error) {
 	pids := []int{}
 
-	// memory is chosen randomly, any cgroup used by docker works
-	subsystem := "memory"
-
+	// cpu is chosen because it is the only non optional subsystem in cgroups
+	subsystem := "cpu"
 	cgroupRoot, err := cgroups.FindCgroupMountpoint(subsystem)
 	if err != nil {
 		return pids, err


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
