### PR TITLE
Engine: clearer job error reporting

### DIFF
--- a/engine/job.go
+++ b/engine/job.go
@@ -74,7 +74,7 @@ func (job *Job) Run() error {
 		return err
 	}
 	if job.status != 0 {
-		return fmt.Errorf("%s: %s", job.Name, errorMessage)
+		return fmt.Errorf("%s", errorMessage)
 	}
 	return nil
 }
@@ -197,11 +197,14 @@ func (job *Job) Printf(format string, args ...interface{}) (n int, err error) {
 }
 
 func (job *Job) Errorf(format string, args ...interface{}) Status {
+	if format[len(format)-1] != '\n' {
+		format = format + "\n"
+	}
 	fmt.Fprintf(job.Stderr, format, args...)
 	return StatusErr
 }
 
 func (job *Job) Error(err error) Status {
-	fmt.Fprintf(job.Stderr, "%s", err)
+	fmt.Fprintf(job.Stderr, "%s\n", err)
 	return StatusErr
 }


### PR DESCRIPTION
- Job.Error and Job.Errorf always print a newline.
- Avoid redundant prefixing of error messages.
