### PR TITLE
Adjust kernel version parsing to be more lenient of strange things like "3.12-1-amd64"

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -606,14 +606,20 @@ func GetKernelVersion() (*KernelVersionInfo, error) {
 func ParseRelease(release string) (*KernelVersionInfo, error) {
 	var (
 		kernel, major, minor, parsed int
-		flavor                       string
+		flavor, partial              string
 	)
 
 	// Ignore error from Sscanf to allow an empty flavor.  Instead, just
 	// make sure we got all the version numbers.
-	parsed, _ = fmt.Sscanf(release, "%d.%d.%d%s", &kernel, &major, &minor, &flavor)
-	if parsed < 3 {
+	parsed, _ = fmt.Sscanf(release, "%d.%d%s", &kernel, &major, &partial)
+	if parsed < 2 {
 		return nil, errors.New("Can't parse kernel version " + release)
+	}
+
+	// sometimes we have 3.12.25-gentoo, but sometimes we just have 3.12-1-amd64
+	parsed, _ = fmt.Sscanf(partial, ".%d%s", &minor, &flavor)
+	if parsed < 1 {
+		flavor = partial
 	}
 
 	return &KernelVersionInfo{

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -420,6 +420,7 @@ func TestParseRelease(t *testing.T) {
 	assertParseRelease(t, "3.4.54.longterm-1", &KernelVersionInfo{Kernel: 3, Major: 4, Minor: 54, Flavor: ".longterm-1"}, 0)
 	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "-19-generic"}, 0)
 	assertParseRelease(t, "3.12.8tag", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 8, Flavor: "tag"}, 0)
+	assertParseRelease(t, "3.12-1-amd64", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 0, Flavor: "-1-amd64"}, 0)
 }
 
 func TestParsePortMapping(t *testing.T) {


### PR DESCRIPTION
Fixes #4310
