### PR TITLE
Fixed typo in Dockerfile example

### DIFF
--- a/docs/sources/use/working_with_volumes.rst
+++ b/docs/sources/use/working_with_volumes.rst
@@ -50,7 +50,7 @@ volumes to any container created from that image::
   # RUN-USING:          docker run -name DATA data 
   FROM          busybox
   VOLUME        ["/var/volume1", "/var/volume2"]
-  CMD           ["/usr/bin/true"]
+  CMD           ["/bin/true"]
 
 Creating and mounting a Data Volume Container
 ---------------------------------------------


### PR DESCRIPTION
The 'true' command is located in /bin not /usr/bin in the busybox image.
