### PR TITLE
Add support for docker run -it or docker images -qa

### DIFF
--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -20,8 +20,12 @@ To list available commands, either run ``docker`` with no parameters or execute
 
 .. _cli_options:
 
-Types of Options
-----------------
+Options
+-------
+
+Single character commandline options can be combined, so rather than typing
+``docker run -t -i --name test busybox sh``, you can write
+``docker run -ti --name test busybox sh``.
 
 Boolean
 ~~~~~~~

--- a/docs/sources/use/basics.rst
+++ b/docs/sources/use/basics.rst
@@ -51,7 +51,7 @@ Running an interactive shell
   # To detach the tty without exiting the shell,
   # use the escape sequence Ctrl-p + Ctrl-q
   # note: This will continue to exist in a stopped state once exited (see "docker ps -a")
-  sudo docker run -i -t ubuntu /bin/bash
+  sudo docker run -it ubuntu /bin/bash
 
 .. _bind_docker:
 

--- a/pkg/mflag/example/example.go
+++ b/pkg/mflag/example/example.go
@@ -27,4 +27,5 @@ func main() {
 	fmt.Printf("b: %b\n", b)
 	fmt.Printf("-bool: %b\n", b2)
 	fmt.Printf("s/#hidden/-string(via lookup): %s\n", flag.Lookup("s").Value.String())
+	fmt.Printf("ARGS: %v\n", flag.Args())
 }


### PR DESCRIPTION
Please test this carefully!

This enables support for flag grouping.

How does it works ? 

When running `docker -it ...` the flag `it` will return an error, but instead of failing, it'll try `i` and if it's ok, try `t`.
