### PR TITLE
Adds container env variable for its own IP address

### DIFF
--- a/container.go
+++ b/container.go
@@ -456,6 +456,10 @@ func (container *Container) Start() (err error) {
 	if container.Config.Tty {
 		env = append(env, "TERM=xterm")
 	}
+	
+	if !container.runtime.config.DisableNetwork {
+ 		env = append(env, "HOST_ADDR=" + container.NetworkSettings.IPAddress)
+ 	}
 
 	// Init any links between the parent and children
 	runtime := container.runtime


### PR DESCRIPTION
Some processes need to know the ip address on which they will be be reachable (in my current example, its the graylog-server that exposes this address through an node advertising endpoint). It fails to detect its own _public_ IP since even the virtual interface (172...) is marked as loopback-interface.

A Workaround is to add something like 
`ENTRYPOINT export HOST_ADDR=`hostname --ip-address` && ...`
to the Dockerfile.

It would be really nice to have the _public_ reachable IP (e.g. _linked_ or _exposed_ iterface) an environment variable - the name `HOST_ADDR` is just a proposal and tbd.
