### PR TITLE
Use mknod instead of MAKEDEV in mkimage-yum.sh

### DIFF
--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -45,9 +45,16 @@ target=$(mktemp -d --tmpdir $(basename $0).XXXXXX)
 
 set -x
 
-for dev in console null zero urandom; do
-    /sbin/MAKEDEV -d "$target"/dev -x $dev
-done
+mknod -m 600 "$target"/dev/console c 5 1
+mknod -m 600 "$target"/dev/initctl p
+mknod -m 666 "$target"/dev/full c 1 7
+mknod -m 666 "$target"/dev/null c 1 3
+mknod -m 666 "$target"/dev/ptmx c 5 2
+mknod -m 666 "$target"/dev/random c 1 8
+mknod -m 666 "$target"/dev/tty c 5 0
+mknod -m 666 "$target"/dev/tty0 c 4 0
+mknod -m 666 "$target"/dev/urandom c 1 9
+mknod -m 666 "$target"/dev/zero c 1 5
 
 yum -c "$yum_config" --installroot="$target" --setopt=tsflags=nodocs \
     --setopt=group_package_types=mandatory -y groupinstall Core


### PR DESCRIPTION
Some distributions no longer include MAKEDEV script.  Stole from mkimage-rinse.sh

Docker-DCO-1.1-Signed-off-by: Tim Bosse taim@bosboot.org (github: maztaim)
