### PR TITLE
Use a more defensive vendored archive/tar import path to make it clear this isn't upstream's released archive/tar

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -2,12 +2,12 @@ package archive
 
 import (
 	"bytes"
-	"code.google.com/p/go/src/pkg/archive/tar"
 	"compress/bzip2"
 	"compress/gzip"
 	"errors"
 	"fmt"
 	"github.com/dotcloud/docker/utils"
+	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 	"io"
 	"io/ioutil"
 	"os"

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -2,8 +2,8 @@ package archive
 
 import (
 	"bytes"
-	"code.google.com/p/go/src/pkg/archive/tar"
 	"fmt"
+	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 	"io"
 	"io/ioutil"
 	"os"

--- a/archive/changes.go
+++ b/archive/changes.go
@@ -2,9 +2,9 @@ package archive
 
 import (
 	"bytes"
-	"code.google.com/p/go/src/pkg/archive/tar"
 	"fmt"
 	"github.com/dotcloud/docker/utils"
+	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 	"io"
 	"os"
 	"path/filepath"

--- a/archive/diff.go
+++ b/archive/diff.go
@@ -1,8 +1,8 @@
 package archive
 
 import (
-	"code.google.com/p/go/src/pkg/archive/tar"
 	"fmt"
+	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 	"io"
 	"io/ioutil"
 	"os"

--- a/archive/wrap.go
+++ b/archive/wrap.go
@@ -2,7 +2,7 @@ package archive
 
 import (
 	"bytes"
-	"code.google.com/p/go/src/pkg/archive/tar"
+	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 	"io/ioutil"
 )
 

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -3,7 +3,6 @@ package docker
 import (
 	"bufio"
 	"bytes"
-	"code.google.com/p/go/src/pkg/archive/tar"
 	"encoding/json"
 	"fmt"
 	"github.com/dotcloud/docker"
@@ -12,6 +11,7 @@ import (
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/runconfig"
 	"github.com/dotcloud/docker/utils"
+	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 	"io"
 	"io/ioutil"
 	"net"

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -2,8 +2,8 @@ package docker
 
 import (
 	"bytes"
-	"code.google.com/p/go/src/pkg/archive/tar"
 	"fmt"
+	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 	"io"
 	"io/ioutil"
 	"net/http"

--- a/utils/tarsum.go
+++ b/utils/tarsum.go
@@ -2,10 +2,10 @@ package utils
 
 import (
 	"bytes"
-	"code.google.com/p/go/src/pkg/archive/tar"
 	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
+	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 	"hash"
 	"io"
 	"sort"

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,7 +2,7 @@ package docker
 
 import (
 	"bytes"
-	"code.google.com/p/go/src/pkg/archive/tar"
+	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 	"io"
 )
 


### PR DESCRIPTION
/cc @creack @vieux
