### PR TITLE
retry to retrieve layer metadata on failure during pull

### DIFF
--- a/server.go
+++ b/server.go
@@ -1086,16 +1086,32 @@ func (srv *Server) pullImage(r *registry.Registry, out io.Writer, imgID, endpoin
 
 		if !srv.runtime.Graph().Exists(id) {
 			out.Write(sf.FormatProgress(utils.TruncateID(id), "Pulling metadata", nil))
-			imgJSON, imgSize, err := r.GetRemoteImageJSON(id, endpoint, token)
-			if err != nil {
-				out.Write(sf.FormatProgress(utils.TruncateID(id), "Error pulling dependent layers", nil))
-				// FIXME: Keep going in case of error?
-				return err
-			}
-			img, err := image.NewImgJSON(imgJSON)
-			if err != nil {
-				out.Write(sf.FormatProgress(utils.TruncateID(id), "Error pulling dependent layers", nil))
-				return fmt.Errorf("Failed to parse json: %s", err)
+			var (
+				imgJSON []byte
+				imgSize int
+				err     error
+				img     *image.Image
+			)
+			retries := 5
+			for j := 1; j <= retries; j++ {
+				imgJSON, imgSize, err = r.GetRemoteImageJSON(id, endpoint, token)
+				if err != nil && j == retries {
+					out.Write(sf.FormatProgress(utils.TruncateID(id), "Error pulling dependent layers", nil))
+					return err
+				} else if err != nil {
+					time.Sleep(time.Duration(j) * 500 * time.Millisecond)
+					continue
+				}
+				img, err = image.NewImgJSON(imgJSON)
+				if err != nil && j == retries {
+					out.Write(sf.FormatProgress(utils.TruncateID(id), "Error pulling dependent layers", nil))
+					return fmt.Errorf("Failed to parse json: %s", err)
+				} else if err != nil {
+					time.Sleep(time.Duration(j) * 500 * time.Millisecond)
+					continue
+				} else {
+					break
+				}
 			}
 
 			// Get the layer


### PR DESCRIPTION
This PR is complete and needs review.

This makes `docker pull` retry to retrieve the layer metadata. This is the first step towards making the needed changes to fix #2461.

This requires some more changes, but the code should work properly as it is right now. Please test it and provide feedback.

To do:
- [x] add a delay between retries
- [x] test against the central registry
