### PR TITLE
Check if the command exists before dereference

### DIFF
--- a/container.go
+++ b/container.go
@@ -839,7 +839,7 @@ func (container *Container) cleanup() {
 	if err := container.stderr.CloseWriters(); err != nil {
 		utils.Errorf("%s: Error close stderr: %s", container.ID, err)
 	}
-	if container.command.Terminal != nil {
+	if container.command != nil && container.command.Terminal != nil {
 		if err := container.command.Terminal.Close(); err != nil {
 			utils.Errorf("%s: Error closing terminal: %s", container.ID, err)
 		}


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Guillaume J. Charmes guillaume.charmes@docker.com (github: creack)
