### PR TITLE
fix(api): serve until the "acceptconnections" job

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -1079,6 +1079,11 @@ func ServeFd(addr string, handle http.Handler) error {
 
 	chErrors := make(chan error, len(ls))
 
+	// We don't want to start serving on these sockets until the
+	// "initserver" job has completed. Otherwise required handlers
+	// won't be ready.
+	<-activationLock
+
 	// Since ListenFD will return one or more sockets we have
 	// to create a go func to spawn off multiple serves
 	for i := range ls {


### PR DESCRIPTION
This fixes a bug that I encountered when using socket activation with docker
0.8.1. When running the first `docker run` it would return:
"create: command not found".

The root cause was the socket activation code path was starting to listen
before the "initserver" job had finished. This meant that the
"create" handler hand't been registered yet leading to the command not found
error.

In log format it looks like this:

```
[/var/lib/docker|9d2e78e9] +job initserver() 2014/03/01 04:05:35 Listening for
HTTP on fd ()
[/var/lib/docker|0d71c177] +job create() create: command not found
[/var/lib/docker|0d71c177] -job create()
[/var/lib/docker|0d71c177] +job acceptconnections()
[/var/lib/docker|0d71c177] -job initserver() = OK (0)
```

To fix the issue select on the activationLock and block until the
"acceptconnections" job has ran.

Docker-DCO-1.1-Signed-off-by: Brandon Philips brandon.philips@coreos.com (github: philips)
