### PR TITLE
Allow 'docker run' to create without starting a container

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -1805,6 +1805,11 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		}
 	}
 
+	if hostConfig.CreateOnly {
+		fmt.Fprintf(cli.out, "%s\n", runResult.Get("Id"))
+		return nil
+	}
+
 	if sigProxy {
 		sigc := cli.forwardAllSignals(runResult.Get("Id"))
 		defer utils.StopCatch(sigc)

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -13,6 +13,7 @@ type HostConfig struct {
 	PortBindings    nat.PortMap
 	Links           []string
 	PublishAllPorts bool
+	CreateOnly      bool
 }
 
 type KeyValuePair struct {
@@ -25,6 +26,7 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 		ContainerIDFile: job.Getenv("ContainerIDFile"),
 		Privileged:      job.GetenvBool("Privileged"),
 		PublishAllPorts: job.GetenvBool("PublishAllPorts"),
+		CreateOnly:      job.GetenvBool("CreateOnly"),
 	}
 	job.GetenvJson("LxcConf", &hostConfig.LxcConf)
 	job.GetenvJson("PortBindings", &hostConfig.PortBindings)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -46,6 +46,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flLxcOpts     opts.ListOpts
 
 		flAutoRemove      = cmd.Bool([]string{"#rm", "-rm"}, false, "Automatically remove the container when it exits (incompatible with -d)")
+		flCreateOnly      = cmd.Bool([]string{"#create-only", "-create-only"}, false, "Create the container but do not start it")
 		flDetach          = cmd.Bool([]string{"d", "-detach"}, false, "Detached mode: Run container in the background, print new container id")
 		flNetwork         = cmd.Bool([]string{"n", "-networking"}, true, "Enable networking for this container")
 		flPrivileged      = cmd.Bool([]string{"#privileged", "-privileged"}, false, "Give extended privileges to this container")
@@ -211,6 +212,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		PortBindings:    portBindings,
 		Links:           flLinks.GetAll(),
 		PublishAllPorts: *flPublishAll,
+		CreateOnly:      *flCreateOnly,
 	}
 
 	if sysInfo != nil && flMemory > 0 && !sysInfo.SwapLimit {


### PR DESCRIPTION
Adds a -create-only flag to 'docker run' that stops prior to starting the container and outputs the created container id.

Closes #4384
