### PR TITLE
Fix installation instructions to avoid piping curl to a shell.

### DIFF
--- a/docs/sources/installation/google.rst
+++ b/docs/sources/installation/google.rst
@@ -47,7 +47,7 @@
 
 .. code-block:: bash
 
-    docker-playground:~$ curl get.docker.io | bash
+    docker-playground:~$ curl -s -S -o /tmp/installdocker.sh https://get.docker.io/ && bash /tmp/installdocker.sh
     docker-playground:~$ sudo update-rc.d docker defaults
 
 6. Start a new container:

--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -93,7 +93,7 @@ continue installation.*
 
     .. code-block:: bash
 
-        curl -s https://get.docker.io/ubuntu/ | sudo sh
+        curl -s -S -o /tmp/installdocker.sh https://get.docker.io/ubuntu/ && sudo sh /tmp/installdocker.sh
 
 Now verify that the installation has worked by downloading the ``ubuntu`` image
 and launching a container.


### PR DESCRIPTION
curl http://foo | sh is common but quite dangerous. If the connection is interrupted in the middle of the transfer, sh may run incomplete commands (and `rm /tmp/blah` becomes `rm /`).

Using curl -o ... && sh ... helps as curl will fail if the server sends a content-length header and the response size differs.
