### PR TITLE
it seems on MSWindows MSYS bash, echo n puts a literal \n (not a newline...

### DIFF
--- a/contrib/prepare-commit-msg.hook
+++ b/contrib/prepare-commit-msg.hook
@@ -4,4 +4,4 @@
 #
 GH_USER=$(git config --get github.user)
 SOB=$(git var GIT_AUTHOR_IDENT | sed -n "s/^\(.*>\).*$/Docker-DCO-1.1-Signed-off-by: \1 \(github: $GH_USER\)/p")
-grep -qs "^$SOB" "$1" || echo "\n$SOB" >> "$1"
+grep -qs "^$SOB" "$1" || echo -e "\n$SOB" >> "$1"


### PR DESCRIPTION
...) into the commit message, so lets get more primitive

this is presumably because its being run as bash, not sh / POSIX

Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@home.org.au (github: )
