### PR TITLE
Move all bind-mounts in the container inside the namespace

### DIFF
--- a/buildfile.go
+++ b/buildfile.go
@@ -374,7 +374,7 @@ func (b *buildFile) checkPathForAddition(orig string) error {
 func (b *buildFile) addContext(container *runtime.Container, orig, dest string, remote bool) error {
 	var (
 		origPath = path.Join(b.contextPath, orig)
-		destPath = path.Join(container.BasefsPath(), dest)
+		destPath = path.Join(container.RootfsPath(), dest)
 	)
 	// Preserve the trailing '/'
 	if strings.HasSuffix(dest, "/") {

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -97,6 +97,13 @@ type Resources struct {
 	CpuShares  int64 `json:"cpu_shares"`
 }
 
+type Mount struct {
+	Source      string `json:"source"`
+	Destination string `json:"destination"`
+	Writable    bool   `json:"writable"`
+	Private     bool   `json:"private"`
+}
+
 // Process wrapps an os/exec.Cmd to add more metadata
 type Command struct {
 	exec.Cmd `json:"-"`
@@ -114,6 +121,7 @@ type Command struct {
 	Network    *Network   `json:"network"` // if network is nil then networking is disabled
 	Config     []string   `json:"config"`  //  generic values that specific drivers can consume
 	Resources  *Resources `json:"resources"`
+	Mounts     []Mount    `json:"mounts"`
 
 	Terminal     Terminal `json:"-"`             // standard or tty terminal
 	Console      string   `json:"-"`             // dev/console path

--- a/execdriver/execdrivers/execdrivers.go
+++ b/execdriver/execdrivers/execdrivers.go
@@ -9,7 +9,7 @@ import (
 	"path"
 )
 
-func NewDriver(name, root string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
+func NewDriver(name, root, initPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
 	switch name {
 	case "lxc":
 		// we want to five the lxc driver the full docker root because it needs
@@ -17,7 +17,7 @@ func NewDriver(name, root string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, 
 		// to be backwards compatible
 		return lxc.NewDriver(root, sysInfo.AppArmor)
 	case "native":
-		return native.NewDriver(path.Join(root, "execdriver", "native"))
+		return native.NewDriver(path.Join(root, "execdriver", "native"), initPath)
 	}
 	return nil, fmt.Errorf("unknown exec driver %s", name)
 }

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -21,6 +21,10 @@ const DriverName = "lxc"
 
 func init() {
 	execdriver.RegisterInitFunc(DriverName, func(args *execdriver.InitArgs) error {
+		if err := setupEnv(args); err != nil {
+			return err
+		}
+
 		if err := setupHostname(args); err != nil {
 			return err
 		}

--- a/execdriver/lxc/lxc_template.go
+++ b/execdriver/lxc/lxc_template.go
@@ -88,6 +88,14 @@ lxc.mount.entry = {{.Console}} {{escapeFstabSpaces $ROOTFS}}/dev/console none bi
 lxc.mount.entry = devpts {{escapeFstabSpaces $ROOTFS}}/dev/pts devpts newinstance,ptmxmode=0666,nosuid,noexec 0 0
 lxc.mount.entry = shm {{escapeFstabSpaces $ROOTFS}}/dev/shm tmpfs size=65536k,nosuid,nodev,noexec 0 0
 
+{{range $value := .Mounts}}
+{{if $value.Writable}}
+lxc.mount.entry = {{$value.Source}} {{escapeFstabSpaces $ROOTFS}}/{{escapeFstabSpaces $value.Destination}} none bind,rw 0 0
+{{else}}
+lxc.mount.entry = {{$value.Source}} {{escapeFstabSpaces $ROOTFS}}/{{escapeFstabSpaces $value.Destination}} none bind,ro 0 0
+{{end}}
+{{end}}
+
 {{if .Privileged}}
 {{if .AppArmor}}
 lxc.aa_profile = unconfined

--- a/execdriver/native/default_template.go
+++ b/execdriver/native/default_template.go
@@ -48,6 +48,10 @@ func createContainer(c *execdriver.Command) *libcontainer.Container {
 	// check to see if we are running in ramdisk to disable pivot root
 	container.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""
 
+	for _, m := range c.Mounts {
+		container.Mounts = append(container.Mounts, libcontainer.Mount{m.Source, m.Destination, m.Writable, m.Private})
+	}
+
 	return container
 }
 

--- a/execdriver/native/driver.go
+++ b/execdriver/native/driver.go
@@ -55,10 +55,11 @@ func init() {
 }
 
 type driver struct {
-	root string
+	root     string
+	initPath string
 }
 
-func NewDriver(root string) (*driver, error) {
+func NewDriver(root, initPath string) (*driver, error) {
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, err
 	}
@@ -66,7 +67,8 @@ func NewDriver(root string) (*driver, error) {
 		return nil, err
 	}
 	return &driver{
-		root: root,
+		root:     root,
+		initPath: initPath,
 	}, nil
 }
 
@@ -210,7 +212,7 @@ func (d *dockerCommandFactory) Create(container *libcontainer.Container, console
 	// we need to join the rootfs because nsinit will setup the rootfs and chroot
 	initPath := filepath.Join(d.c.Rootfs, d.c.InitPath)
 
-	d.c.Path = initPath
+	d.c.Path = d.driver.initPath
 	d.c.Args = append([]string{
 		initPath,
 		"-driver", DriverName,

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -71,7 +71,7 @@ func containerFileExists(eng *engine.Engine, id, dir string, t utils.Fataler) bo
 		t.Fatal(err)
 	}
 	defer c.Unmount()
-	if _, err := os.Stat(path.Join(c.BasefsPath(), dir)); err != nil {
+	if _, err := os.Stat(path.Join(c.RootfsPath(), dir)); err != nil {
 		if os.IsNotExist(err) {
 			return false
 		}

--- a/pkg/libcontainer/container.go
+++ b/pkg/libcontainer/container.go
@@ -23,6 +23,7 @@ type Container struct {
 	Networks     []*Network      `json:"networks,omitempty"`      // nil for host's network stack
 	Cgroups      *cgroups.Cgroup `json:"cgroups,omitempty"`       // cgroups
 	Context      Context         `json:"context,omitempty"`       // generic context for specific options (apparmor, selinux)
+	Mounts       []Mount         `json:"mounts,omitempty"`
 }
 
 // Network defines configuration for a container's networking stack
@@ -35,4 +36,13 @@ type Network struct {
 	Address string  `json:"address,omitempty"`
 	Gateway string  `json:"gateway,omitempty"`
 	Mtu     int     `json:"mtu,omitempty"`
+}
+
+// Bind mounts from the host system to the container
+//
+type Mount struct {
+	Source      string `json:"source"`      // Source path, in the host namespace
+	Destination string `json:"destination"` // Destination path, in the container
+	Writable    bool   `json:"writable"`
+	Private     bool   `json:"private"`
 }

--- a/pkg/libcontainer/nsinit/init.go
+++ b/pkg/libcontainer/nsinit/init.go
@@ -51,7 +51,7 @@ func (ns *linuxNs) Init(container *libcontainer.Container, uncleanRootfs, consol
 	if err := system.ParentDeathSignal(); err != nil {
 		return fmt.Errorf("parent death signal %s", err)
 	}
-	if err := setupNewMountNamespace(rootfs, console, container.ReadonlyFs, container.NoPivotRoot); err != nil {
+	if err := setupNewMountNamespace(rootfs, container.Mounts, console, container.ReadonlyFs, container.NoPivotRoot); err != nil {
 		return fmt.Errorf("setup mount namespace %s", err)
 	}
 	if err := setupNetwork(container, context); err != nil {

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -532,7 +532,7 @@ func (container *Container) Start() (err error) {
 	populateCommand(container)
 	container.command.Env = env
 
-	if err := mountVolumesForContainer(container, envPath); err != nil {
+	if err := setupMountsForContainer(container, envPath); err != nil {
 		return err
 	}
 
@@ -843,8 +843,6 @@ func (container *Container) cleanup() {
 		}
 	}
 
-	unmountVolumesForContainer(container)
-
 	if err := container.Unmount(); err != nil {
 		log.Printf("%v: Failed to umount filesystem: %v", container.ID, err)
 	}
@@ -1039,12 +1037,6 @@ func (container *Container) EnvConfigPath() (string, error) {
 // This method must be exported to be used from the lxc template
 // This directory is only usable when the container is running
 func (container *Container) RootfsPath() string {
-	return path.Join(container.root, "root")
-}
-
-// This is the stand-alone version of the root fs, without any additional mounts.
-// This directory is usable whenever the container is mounted (and not unmounted)
-func (container *Container) BasefsPath() string {
 	return container.basefs
 }
 

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -529,12 +529,12 @@ func (container *Container) Start() (err error) {
 		return err
 	}
 
+	populateCommand(container)
+	container.command.Env = env
+
 	if err := mountVolumesForContainer(container, envPath); err != nil {
 		return err
 	}
-
-	populateCommand(container)
-	container.command.Env = env
 
 	// Setup logging of stdout and stderr to disk
 	if err := container.runtime.LogToDisk(container.stdout, container.logPath("json"), "stdout"); err != nil {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -174,7 +174,6 @@ func (runtime *Runtime) Register(container *Container) error {
 				runtime.execDriver.Kill(command, 9)
 			}
 			// ensure that the filesystem is also unmounted
-			unmountVolumesForContainer(container)
 			if err := container.Unmount(); err != nil {
 				utils.Debugf("ghost unmount error %s", err)
 			}
@@ -185,7 +184,6 @@ func (runtime *Runtime) Register(container *Container) error {
 			utils.Debugf("Container %s was supposed to be running but is not.", container.ID)
 			if runtime.config.AutoRestart {
 				utils.Debugf("Restarting")
-				unmountVolumesForContainer(container)
 				if err := container.Unmount(); err != nil {
 					utils.Debugf("restart unmount error %s", err)
 				}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -733,7 +733,7 @@ func NewRuntimeFromDirectory(config *daemonconfig.Config, eng *engine.Engine) (*
 	}
 
 	sysInfo := sysinfo.New(false)
-	ed, err := execdrivers.NewDriver(config.ExecDriver, config.Root, sysInfo)
+	ed, err := execdrivers.NewDriver(config.ExecDriver, config.Root, sysInitPath, sysInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -1,33 +1,16 @@
 package sysinit
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"github.com/dotcloud/docker/execdriver"
 	_ "github.com/dotcloud/docker/execdriver/lxc"
 	_ "github.com/dotcloud/docker/execdriver/native"
-	"io/ioutil"
 	"log"
 	"os"
-	"strings"
 )
 
-// Clear environment pollution introduced by lxc-start
-func setupEnv(args *execdriver.InitArgs) {
-	os.Clearenv()
-	for _, kv := range args.Env {
-		parts := strings.SplitN(kv, "=", 2)
-		if len(parts) == 1 {
-			parts = append(parts, "")
-		}
-		os.Setenv(parts[0], parts[1])
-	}
-}
-
 func executeProgram(args *execdriver.InitArgs) error {
-	setupEnv(args)
-
 	dockerInitFct, err := execdriver.GetInitFunc(args.Driver)
 	if err != nil {
 		panic(err)
@@ -59,25 +42,12 @@ func SysInit() {
 	)
 	flag.Parse()
 
-	// Get env
-	var env []string
-	content, err := ioutil.ReadFile(".dockerenv")
-	if err != nil {
-		log.Fatalf("Unable to load environment variables: %v", err)
-	}
-	if err := json.Unmarshal(content, &env); err != nil {
-		log.Fatalf("Unable to unmarshal environment variables: %v", err)
-	}
-	// Propagate the plugin-specific container env variable
-	env = append(env, "container="+os.Getenv("container"))
-
 	args := &execdriver.InitArgs{
 		User:       *user,
 		Gateway:    *gateway,
 		Ip:         *ip,
 		WorkDir:    *workDir,
 		Privileged: *privileged,
-		Env:        env,
 		Args:       flag.Args(),
 		Mtu:        *mtu,
 		Driver:     *driver,


### PR DESCRIPTION
This moves the bind mounts like /.dockerinit, /etc/hostname, volumes,
etc into the container namespace, by setting them up using lxc.

This is useful to avoid littering the global namespace with a lot of
mounts that are internal to each container and are not generally
needed on the outside. In particular, it seems that having a lot of
mounts is problematic wrt scaling to a lot of containers on systems
where the root filesystem is mounted --rshared.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
