### PR TITLE
Create directories for tar files with relaxed permissions

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -403,7 +403,7 @@ func Untar(archive io.Reader, dest string, options *TarOptions) error {
 			parent := filepath.Dir(hdr.Name)
 			parentPath := filepath.Join(dest, parent)
 			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
-				err = os.MkdirAll(parentPath, 600)
+				err = os.MkdirAll(parentPath, 0777)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This fixes #4068 by recreating the AUFS directories without explicitly restricting permissions, just like the `tar` command does by default (both will still follow the set umask value).

It's still not perfect - the explicitly set directory permissions in the parent image are lost - but better than completely broken images.

P.S. As you can see, `600 != 0600`.
