### PR TITLE
Add --net flag to docker run and allow host network stack

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -341,6 +341,8 @@ func populateCommand(c *Container, env []string) error {
 	parts := strings.SplitN(c.hostConfig.NetworkMode, ":", 2)
 	switch parts[0] {
 	case "none":
+	case "host":
+		en.HostNetworking = true
 	case "bridge":
 		if !c.Config.NetworkDisabled {
 			network := c.NetworkSettings

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -89,8 +89,9 @@ type Driver interface {
 
 // Network settings of the container
 type Network struct {
-	Interface *NetworkInterface `json:"interface"` // if interface is nil then networking is disabled
-	Mtu       int               `json:"mtu"`
+	Interface   *NetworkInterface `json:"interface"` // if interface is nil then networking is disabled
+	Mtu         int               `json:"mtu"`
+	ContainerID string            `json:"container_id"` // id of the container to join network.
 }
 
 type NetworkInterface struct {

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -89,9 +89,10 @@ type Driver interface {
 
 // Network settings of the container
 type Network struct {
-	Interface   *NetworkInterface `json:"interface"` // if interface is nil then networking is disabled
-	Mtu         int               `json:"mtu"`
-	ContainerID string            `json:"container_id"` // id of the container to join network.
+	Interface      *NetworkInterface `json:"interface"` // if interface is nil then networking is disabled
+	Mtu            int               `json:"mtu"`
+	ContainerID    string            `json:"container_id"` // id of the container to join network.
+	HostNetworking bool              `json:"host_networking"`
 }
 
 type NetworkInterface struct {

--- a/daemon/execdriver/lxc/init.go
+++ b/daemon/execdriver/lxc/init.go
@@ -3,15 +3,16 @@ package lxc
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/dotcloud/docker/daemon/execdriver"
-	"github.com/dotcloud/docker/pkg/netlink"
-	"github.com/dotcloud/docker/pkg/user"
-	"github.com/syndtr/gocapability/capability"
 	"io/ioutil"
 	"net"
 	"os"
 	"strings"
 	"syscall"
+
+	"github.com/dotcloud/docker/daemon/execdriver"
+	"github.com/dotcloud/docker/pkg/netlink"
+	"github.com/dotcloud/docker/pkg/user"
+	"github.com/syndtr/gocapability/capability"
 )
 
 // Clear environment pollution introduced by lxc-start

--- a/daemon/execdriver/lxc/lxc_template.go
+++ b/daemon/execdriver/lxc/lxc_template.go
@@ -14,12 +14,13 @@ const LxcTemplate = `
 lxc.network.type = veth
 lxc.network.link = {{.Network.Interface.Bridge}}
 lxc.network.name = eth0
-{{else}}
+lxc.network.mtu = {{.Network.Mtu}}
+{{else if not .Network.HostNetworking}}
 # network is disabled (-n=false)
 lxc.network.type = empty
 lxc.network.flags = up
-{{end}}
 lxc.network.mtu = {{.Network.Mtu}}
+{{end}}
 
 # root filesystem
 {{$ROOTFS := .Rootfs}}

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -53,6 +53,10 @@ func (d *driver) createContainer(c *execdriver.Command) (*libcontainer.Container
 }
 
 func (d *driver) createNetwork(container *libcontainer.Container, c *execdriver.Command) error {
+	if c.Network.HostNetworking {
+		container.Namespaces.Get("NEWNET").Enabled = false
+		return nil
+	}
 	container.Networks = []*libcontainer.Network{
 		{
 			Mtu:     c.Network.Mtu,
@@ -90,7 +94,6 @@ func (d *driver) createNetwork(container *libcontainer.Container, c *execdriver.
 			},
 		})
 	}
-
 	return nil
 }
 

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -3,6 +3,7 @@ package native
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/dotcloud/docker/daemon/execdriver"
 	"github.com/dotcloud/docker/daemon/execdriver/native/configuration"
@@ -75,6 +76,21 @@ func (d *driver) createNetwork(container *libcontainer.Container, c *execdriver.
 		}
 		container.Networks = append(container.Networks, &vethNetwork)
 	}
+
+	if c.Network.ContainerID != "" {
+		cmd := d.activeContainers[c.Network.ContainerID]
+		if cmd == nil || cmd.Process == nil {
+			return fmt.Errorf("%s is not a valid running container to join", c.Network.ContainerID)
+		}
+		nspath := filepath.Join("/proc", fmt.Sprint(cmd.Process.Pid), "ns", "net")
+		container.Networks = append(container.Networks, &libcontainer.Network{
+			Type: "netns",
+			Context: libcontainer.Context{
+				"nspath": nspath,
+			},
+		})
+	}
+
 	return nil
 }
 

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -7,16 +7,17 @@ import (
 )
 
 type HostConfig struct {
-	Binds           []string
-	ContainerIDFile string
-	LxcConf         []utils.KeyValuePair
-	Privileged      bool
-	PortBindings    nat.PortMap
-	Links           []string
-	PublishAllPorts bool
-	Dns             []string
-	DnsSearch       []string
-	VolumesFrom     []string
+	Binds               []string
+	ContainerIDFile     string
+	LxcConf             []utils.KeyValuePair
+	Privileged          bool
+	PortBindings        nat.PortMap
+	Links               []string
+	PublishAllPorts     bool
+	Dns                 []string
+	DnsSearch           []string
+	VolumesFrom         []string
+	UseContainerNetwork string
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
@@ -41,6 +42,9 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 	}
 	if VolumesFrom := job.GetenvList("VolumesFrom"); VolumesFrom != nil {
 		hostConfig.VolumesFrom = VolumesFrom
+	}
+	if UseContainerNetwork := job.Getenv("UseContainerNetwork"); UseContainerNetwork != "" {
+		hostConfig.UseContainerNetwork = UseContainerNetwork
 	}
 	return hostConfig
 }

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -1,10 +1,23 @@
 package runconfig
 
 import (
+	"strings"
+
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/nat"
 	"github.com/dotcloud/docker/utils"
 )
+
+type NetworkMode string
+
+func (n NetworkMode) IsHost() bool {
+	return n == "host"
+}
+
+func (n NetworkMode) IsContainer() bool {
+	parts := strings.SplitN(string(n), ":", 2)
+	return len(parts) > 1 && parts[0] == "container"
+}
 
 type HostConfig struct {
 	Binds           []string
@@ -17,7 +30,7 @@ type HostConfig struct {
 	Dns             []string
 	DnsSearch       []string
 	VolumesFrom     []string
-	NetworkMode     string
+	NetworkMode     NetworkMode
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
@@ -25,7 +38,7 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 		ContainerIDFile: job.Getenv("ContainerIDFile"),
 		Privileged:      job.GetenvBool("Privileged"),
 		PublishAllPorts: job.GetenvBool("PublishAllPorts"),
-		NetworkMode:     job.Getenv("NetworkMode"),
+		NetworkMode:     NetworkMode(job.Getenv("NetworkMode")),
 	}
 	job.GetenvJson("LxcConf", &hostConfig.LxcConf)
 	job.GetenvJson("PortBindings", &hostConfig.PortBindings)

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -7,17 +7,17 @@ import (
 )
 
 type HostConfig struct {
-	Binds               []string
-	ContainerIDFile     string
-	LxcConf             []utils.KeyValuePair
-	Privileged          bool
-	PortBindings        nat.PortMap
-	Links               []string
-	PublishAllPorts     bool
-	Dns                 []string
-	DnsSearch           []string
-	VolumesFrom         []string
-	UseContainerNetwork string
+	Binds           []string
+	ContainerIDFile string
+	LxcConf         []utils.KeyValuePair
+	Privileged      bool
+	PortBindings    nat.PortMap
+	Links           []string
+	PublishAllPorts bool
+	Dns             []string
+	DnsSearch       []string
+	VolumesFrom     []string
+	NetworkMode     string
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
@@ -25,6 +25,7 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 		ContainerIDFile: job.Getenv("ContainerIDFile"),
 		Privileged:      job.GetenvBool("Privileged"),
 		PublishAllPorts: job.GetenvBool("PublishAllPorts"),
+		NetworkMode:     job.Getenv("NetworkMode"),
 	}
 	job.GetenvJson("LxcConf", &hostConfig.LxcConf)
 	job.GetenvJson("PortBindings", &hostConfig.PortBindings)
@@ -42,9 +43,6 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 	}
 	if VolumesFrom := job.GetenvList("VolumesFrom"); VolumesFrom != nil {
 		hostConfig.VolumesFrom = VolumesFrom
-	}
-	if UseContainerNetwork := job.Getenv("UseContainerNetwork"); UseContainerNetwork != "" {
-		hostConfig.UseContainerNetwork = UseContainerNetwork
 	}
 	return hostConfig
 }

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -284,16 +284,17 @@ func parseKeyValueOpts(opts opts.ListOpts) ([]utils.KeyValuePair, error) {
 
 func parseNetMode(netMode string) (string, string, error) {
 	parts := strings.Split(netMode, ":")
-	if len(parts) < 1 {
-		return "", "", fmt.Errorf("'netmode' cannot be empty", netMode)
-	}
-	mode := parts[0]
-	var container string
-	if mode == "container" {
-		if len(parts) < 2 {
+	switch mode := parts[0]; mode {
+	case "bridge", "disable":
+		return mode, "", nil
+	case "container":
+		var container string
+		if len(parts) < 2 || parts[1] == "" {
 			return "", "", fmt.Errorf("'container:' netmode requires a container id or name", netMode)
 		}
 		container = parts[1]
+		return mode, container, nil
+	default:
+		return "", "", fmt.Errorf("invalid netmode: %q", netMode)
 	}
-	return mode, container, nil
 }

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -292,6 +292,8 @@ func parseNetMode(netMode string) (string, error) {
 			return "", fmt.Errorf("'container:' netmode requires a container id or name", netMode)
 		}
 		return netMode, nil
+	case "host":
+		return netMode, nil
 	default:
 		return "", fmt.Errorf("invalid netmode: %q", netMode)
 	}

--- a/runconfig/parse_test.go
+++ b/runconfig/parse_test.go
@@ -40,7 +40,7 @@ func TestParseNetMode(t *testing.T) {
 	}
 
 	for _, to := range testFlags {
-		mode, container, err := parseNetMode(to.flag)
+		mode, err := parseNetMode(to.flag)
 		if mode != to.mode {
 			t.Fatalf("-net %s: expected net mode: %q, got: %q", to.flag, to.mode, mode)
 		}

--- a/runconfig/parse_test.go
+++ b/runconfig/parse_test.go
@@ -22,33 +22,3 @@ func TestParseLxcConfOpt(t *testing.T) {
 		}
 	}
 }
-
-func TestParseNetMode(t *testing.T) {
-	testFlags := []struct {
-		flag      string
-		mode      string
-		container string
-		err       bool
-	}{
-		{"", "", "", true},
-		{"bridge", "bridge", "", false},
-		{"disable", "disable", "", false},
-		{"container:foo", "container", "foo", false},
-		{"container:", "", "", true},
-		{"container", "", "", true},
-		{"unknown", "", "", true},
-	}
-
-	for _, to := range testFlags {
-		mode, err := parseNetMode(to.flag)
-		if mode != to.mode {
-			t.Fatalf("-net %s: expected net mode: %q, got: %q", to.flag, to.mode, mode)
-		}
-		if container != to.container {
-			t.Fatalf("-net %s: expected net container: %q, got: %q", to.flag, to.container, container)
-		}
-		if (err != nil) != to.err {
-			t.Fatal("-net %s: expected an error got none", to.flag)
-		}
-	}
-}

--- a/runconfig/parse_test.go
+++ b/runconfig/parse_test.go
@@ -1,8 +1,9 @@
 package runconfig
 
 import (
-	"github.com/dotcloud/docker/utils"
 	"testing"
+
+	"github.com/dotcloud/docker/utils"
 )
 
 func TestParseLxcConfOpt(t *testing.T) {
@@ -18,6 +19,36 @@ func TestParseLxcConfOpt(t *testing.T) {
 		}
 		if v != "docker" {
 			t.Fail()
+		}
+	}
+}
+
+func TestParseNetMode(t *testing.T) {
+	testFlags := []struct {
+		flag      string
+		mode      string
+		container string
+		err       bool
+	}{
+		{"", "", "", true},
+		{"bridge", "bridge", "", false},
+		{"disable", "disable", "", false},
+		{"container:foo", "container", "foo", false},
+		{"container:", "", "", true},
+		{"container", "", "", true},
+		{"unknown", "", "", true},
+	}
+
+	for _, to := range testFlags {
+		mode, container, err := parseNetMode(to.flag)
+		if mode != to.mode {
+			t.Fatalf("-net %s: expected net mode: %q, got: %q", to.flag, to.mode, mode)
+		}
+		if container != to.container {
+			t.Fatalf("-net %s: expected net container: %q, got: %q", to.flag, to.container, container)
+		}
+		if (err != nil) != to.err {
+			t.Fatal("-net %s: expected an error got none", to.flag)
 		}
 	}
 }


### PR DESCRIPTION
Closes #2900
Closes #5546

This allows for the follow options on docker run:

``` bash
docker run --net none busybox ip a # no network setup
docker run --net host busybox ip a # host networking configuration
docker run --net bridge busybox ip a # the default bridge setup
docker run --net container:redis busybox ip a # the network stack of the redis container - amazing
```

Using `-p`, `-P`, `-expose` are not compatible with the none and host network modes.

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
