### PR TITLE
Support hairpin NAT without going through docker server

### DIFF
--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -66,7 +66,6 @@ func (c *Chain) Forward(action Action, ip net.IP, port int, proto, dest_addr str
 		"-p", proto,
 		"-d", daddr,
 		"--dport", strconv.Itoa(port),
-		"!", "-i", c.Bridge,
 		"-j", "DNAT",
 		"--to-destination", net.JoinHostPort(dest_addr, strconv.Itoa(dest_port))); err != nil {
 		return err


### PR DESCRIPTION
Hairpin NAT is currently done by passing through the docker server.  If
two containers on the same box try to access each other through exposed
ports and using the host IP the current iptables rules will not match the
DNAT and thus the traffic goes to 'docker -d'

This change drops the restriction that DNAT traffic must not originate
from docker0.  It should be safe to drop this restriction because the
DOCKER chain is already gated by jumps that check for the destination
address to be a local address.

Docker-DCO-1.1-Signed-off-by: Darren Shepherd darren.s.shepherd@gmail.com (github: ibuildthecloud)
