### PR TITLE
libcontainer/network: add netns strategy

### DIFF
--- a/pkg/libcontainer/network/netns.go
+++ b/pkg/libcontainer/network/netns.go
@@ -1,0 +1,42 @@
+package network
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/dotcloud/docker/pkg/libcontainer"
+	"github.com/dotcloud/docker/pkg/system"
+)
+
+//  crosbymichael: could make a network strategy that instead of returning veth pair names it returns a pid to an existing network namespace
+type NetNS struct {
+}
+
+func (v *NetNS) Create(n *libcontainer.Network, nspid int, context libcontainer.Context) error {
+	nsname, exists := n.Context["nsname"]
+
+	if !exists {
+		return fmt.Errorf("nspath does not exist in network context")
+	}
+
+	context["nspath"] = fmt.Sprintf("/var/run/netns/%s", nsname)
+	return nil
+}
+
+func (v *NetNS) Initialize(config *libcontainer.Network, context libcontainer.Context) error {
+	nspath, exists := context["nspath"]
+	if !exists {
+		return fmt.Errorf("nspath does not exist in network context")
+	}
+
+	f, err := os.OpenFile(nspath, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed get network namespace fd: %v", err)
+	}
+
+	if err := system.Setns(f.Fd(), syscall.CLONE_NEWNET); err != nil {
+		return fmt.Errorf("failed to setns current network namespace: %v", err)
+	}
+	return nil
+}

--- a/pkg/libcontainer/network/strategy.go
+++ b/pkg/libcontainer/network/strategy.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"errors"
+
 	"github.com/dotcloud/docker/pkg/libcontainer"
 )
 
@@ -12,6 +13,7 @@ var (
 var strategies = map[string]NetworkStrategy{
 	"veth":     &Veth{},
 	"loopback": &Loopback{},
+	"netns":    &NetNS{},
 }
 
 // NetworkStrategy represents a specific network configuration for

--- a/pkg/libcontainer/nsinit/exec.go
+++ b/pkg/libcontainer/nsinit/exec.go
@@ -3,12 +3,13 @@
 package nsinit
 
 import (
-	"github.com/dotcloud/docker/pkg/libcontainer"
-	"github.com/dotcloud/docker/pkg/libcontainer/network"
-	"github.com/dotcloud/docker/pkg/system"
 	"os"
 	"os/exec"
 	"syscall"
+
+	"github.com/dotcloud/docker/pkg/libcontainer"
+	"github.com/dotcloud/docker/pkg/libcontainer/network"
+	"github.com/dotcloud/docker/pkg/system"
 )
 
 // Exec performes setup outside of a namespace so that a container can be

--- a/pkg/libcontainer/nsinit/nsinit/main.go
+++ b/pkg/libcontainer/nsinit/nsinit/main.go
@@ -3,14 +3,18 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	"github.com/dotcloud/docker/pkg/libcontainer"
-	"github.com/dotcloud/docker/pkg/libcontainer/nsinit"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/dotcloud/docker/pkg/libcontainer"
+	"github.com/dotcloud/docker/pkg/libcontainer/nsinit"
+
+	"github.com/dotcloud/docker/pkg/libcontainer"
+	"github.com/dotcloud/docker/pkg/libcontainer/nsinit"
 )
 
 var (

--- a/pkg/libcontainer/nsinit/nsinit/main.go
+++ b/pkg/libcontainer/nsinit/nsinit/main.go
@@ -12,9 +12,6 @@ import (
 
 	"github.com/dotcloud/docker/pkg/libcontainer"
 	"github.com/dotcloud/docker/pkg/libcontainer/nsinit"
-
-	"github.com/dotcloud/docker/pkg/libcontainer"
-	"github.com/dotcloud/docker/pkg/libcontainer/nsinit"
 )
 
 var (


### PR DESCRIPTION
allows multiple container to share the same network namespace.
