### PR TITLE
libcontainer: Use pivot_root instead of chroot

### DIFF
--- a/pkg/libcontainer/nsinit/mount.go
+++ b/pkg/libcontainer/nsinit/mount.go
@@ -5,6 +5,7 @@ package nsinit
 import (
 	"fmt"
 	"github.com/dotcloud/docker/pkg/system"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -51,14 +52,27 @@ func setupNewMountNamespace(rootfs, console string, readonly bool) error {
 	if err := system.Chdir(rootfs); err != nil {
 		return fmt.Errorf("chdir into %s %s", rootfs, err)
 	}
-	if err := system.Mount(rootfs, "/", "", syscall.MS_MOVE, ""); err != nil {
-		return fmt.Errorf("mount move %s into / %s", rootfs, err)
+
+	pivotDir, err := ioutil.TempDir(rootfs, ".pivot_root")
+	if err != nil {
+		return fmt.Errorf("can't create pivot_root dir %s", pivotDir, err)
 	}
-	if err := system.Chroot("."); err != nil {
-		return fmt.Errorf("chroot . %s", err)
+	if err := system.Pivotroot(rootfs, pivotDir); err != nil {
+		return fmt.Errorf("pivot_root %s", err)
 	}
 	if err := system.Chdir("/"); err != nil {
 		return fmt.Errorf("chdir / %s", err)
+	}
+
+	// path to pivot dir now changed, update
+	pivotDir = filepath.Join("/", filepath.Base(pivotDir))
+
+	if err := system.Unmount(pivotDir, syscall.MNT_DETACH); err != nil {
+		return fmt.Errorf("unmount pivot_root dir %s", err)
+	}
+
+	if err := os.Remove(pivotDir); err != nil {
+		return fmt.Errorf("remove pivot_root dir %s", err)
 	}
 
 	system.Umask(0022)


### PR DESCRIPTION
Instead of keeping all the old mounts in the container namespace and
just using subtree as root we pivot_root so that the actual root in
the namespace is the root we want, and then we unmount the previous
mounts.

This has multiple advantages:
- The namespace mount tree is smaller (in the kernel)
- If you break out of the chroot you could previously access the host
  filesystem. Now the host filesystem is fully invisible to the namespace.
- We get rid of all unrelated mounts from the parent namespace, which means
  we don't hog these. This is important if we later switch to MS_PRIVATE instead
  of MS_SLAVE as otherwise these mounts would be impossible to unmount from the
  parent namespace.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
