### PR TITLE
Flag 'docker-js' as outdated (Fix #4467)

### DIFF
--- a/docs/sources/reference/api/remote_api_client_libraries.rst
+++ b/docs/sources/reference/api/remote_api_client_libraries.rst
@@ -27,7 +27,7 @@ and we will add the libraries here.
 | JavaScript (NodeJS)  | docker.io      | https://github.com/appersonlabs/docker.io  | Active   |
 |                      |                | Install via NPM: `npm install docker.io`   |          |
 +----------------------+----------------+--------------------------------------------+----------+
-| JavaScript           | docker-js      | https://github.com/dgoujard/docker-js      | Active   |
+| JavaScript           | docker-js      | https://github.com/dgoujard/docker-js      | Outdated |
 +----------------------+----------------+--------------------------------------------+----------+
 | JavaScript (Angular) | docker-cp      | https://github.com/13W/docker-cp           | Active   |
 | **WebUI**            |                |                                            |          |


### PR DESCRIPTION
'docker-js' is outdated since the last commit was 9 months ago.
