### PR TITLE
Implement foreground execution mode

### DIFF
--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -15,13 +15,28 @@ type HostConfig struct {
 	Links           []string
 	PublishAllPorts bool
 	DriverOptions   map[string][]string
+	CliAddress      string
 }
 
-func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
+type HostConfigForeground struct {
+	CliAddressOnly string
+}
+
+func ContainerHostConfigFromJob(job *engine.Job, oldHostConfig *HostConfig) *HostConfig {
+	if job.EnvExists("CliAddressOnly") {
+		hostConfig := HostConfig{}
+		if oldHostConfig != nil {
+			hostConfig = *oldHostConfig
+		}
+		hostConfig.CliAddress = job.Getenv("CliAddressOnly")
+		return &hostConfig
+	}
+
 	hostConfig := &HostConfig{
 		ContainerIDFile: job.Getenv("ContainerIDFile"),
 		Privileged:      job.GetenvBool("Privileged"),
 		PublishAllPorts: job.GetenvBool("PublishAllPorts"),
+		CliAddress:      job.Getenv("CliAddress"),
 	}
 	job.GetenvJson("LxcConf", &hostConfig.LxcConf)
 	job.GetenvJson("PortBindings", &hostConfig.PortBindings)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -66,6 +66,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		// For documentation purpose
 		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify all received signal to the process (even in non-tty mode)")
 		_ = cmd.String([]string{"#name", "-name"}, "", "Assign a name to the container")
+		_ = cmd.Bool([]string{"#foreground", "-foreground"}, false, "Run in foreground")
 	)
 
 	cmd.Var(&flAttach, []string{"a", "-attach"}, "Attach to stdin, stdout or stderr.")

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -38,6 +38,8 @@ type Container struct {
 	root   string // Path to the "home" of the container, including metadata.
 	basefs string // Path to the graphdriver mountpoint
 
+	execDriver execdriver.Driver
+
 	ID string
 
 	Created time.Time
@@ -808,7 +810,7 @@ func (container *Container) monitor(callback execdriver.StartCallback) error {
 	)
 
 	pipes := execdriver.NewPipes(container.stdin, container.stdout, container.stderr, container.Config.OpenStdin)
-	exitCode, err = container.runtime.Run(container, pipes, callback)
+	exitCode, err = container.execDriver.Run(container.command, pipes, callback)
 	if err != nil {
 		utils.Errorf("Error running container: %s", err)
 	}
@@ -883,7 +885,7 @@ func (container *Container) KillSig(sig int) error {
 	if !container.State.IsRunning() {
 		return nil
 	}
-	return container.runtime.Kill(container, sig)
+	return container.execDriver.Kill(container.command, sig)
 }
 
 func (container *Container) Kill() error {

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dotcloud/docker/nat"
 	"github.com/dotcloud/docker/runconfig"
 	"github.com/dotcloud/docker/runtime/execdriver"
+	"github.com/dotcloud/docker/runtime/execdriver/foreground"
 	"github.com/dotcloud/docker/runtime/graphdriver"
 	"github.com/dotcloud/docker/utils"
 	"io"
@@ -574,6 +575,10 @@ func (container *Container) Start() (err error) {
 		return err
 	}
 	container.waitLock = make(chan struct{})
+
+	if container.hostConfig.CliAddress != "" {
+		container.execDriver = foreground.NewDriver(container.hostConfig.CliAddress, runtime.config.Root, runtime.sysInitPath, runtime.execDriver)
+	}
 
 	callbackLock := make(chan struct{})
 	callback := func(command *execdriver.Command) {

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -578,6 +578,18 @@ func (container *Container) Start() (err error) {
 
 	if container.hostConfig.CliAddress != "" {
 		container.execDriver = foreground.NewDriver(container.hostConfig.CliAddress, runtime.config.Root, runtime.sysInitPath, runtime.execDriver)
+	} else {
+		// For non-foreground launches the ReuseCurrent option is dangerous, so we skip it
+		if unitConf, ok := container.command.Config["unit"]; ok {
+			var newUnitConf []string
+			for _, opt := range unitConf {
+				if strings.HasPrefix(strings.ToLower(opt), "reusecurrent") {
+					continue
+				}
+				newUnitConf = append(newUnitConf, opt)
+			}
+			container.command.Config["unit"] = newUnitConf
+		}
 	}
 
 	callbackLock := make(chan struct{})

--- a/runtime/execdriver/foreground/cmd.go
+++ b/runtime/execdriver/foreground/cmd.go
@@ -1,0 +1,311 @@
+package foreground
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/pkg/sysinfo"
+	"github.com/dotcloud/docker/runtime/execdriver"
+	"github.com/dotcloud/docker/runtime/execdriver/execdrivers"
+	"github.com/dotcloud/docker/utils"
+	"io/ioutil"
+	"net"
+	"net/rpc"
+	"os"
+	"path"
+	"syscall"
+)
+
+// This is a copy of execdriver.Command, which unfortunately doesn't can't be marshalled
+// since it contains public os.File members that have no exported fields
+// This could be done nicer if we change Command to not inherit from exec.Cmd
+type CommandWrapper struct {
+	// From exec.Cmd:
+	Path        string
+	Args        []string
+	Env         []string
+	Dir         string
+	SysProcAttr *syscall.SysProcAttr
+
+	// From execdriver.Command:
+	ID         string
+	Privileged bool
+	User       string
+	Rootfs     string
+	InitPath   string
+	Entrypoint string
+	Arguments  []string
+	WorkingDir string
+	ConfigPath string
+	Tty        bool
+	Network    *execdriver.Network
+	Config     map[string][]string
+	Resources  *execdriver.Resources
+	Mounts     []execdriver.Mount
+
+	// Extra info
+	RealDriver        string
+	DockerRoot        string
+	DockerSysInitPath string
+}
+
+func (wrapper *CommandWrapper) Unwrap() *execdriver.Command {
+	d := &execdriver.Command{
+		// From execdriver.Command:
+		ID:         wrapper.ID,
+		Privileged: wrapper.Privileged,
+		User:       wrapper.User,
+		Rootfs:     wrapper.Rootfs,
+		InitPath:   wrapper.InitPath,
+		Entrypoint: wrapper.Entrypoint,
+		Arguments:  wrapper.Arguments,
+		WorkingDir: wrapper.WorkingDir,
+		ConfigPath: wrapper.ConfigPath,
+		Tty:        wrapper.Tty,
+		Network:    wrapper.Network,
+		Config:     wrapper.Config,
+		Resources:  wrapper.Resources,
+		Mounts:     wrapper.Mounts,
+	}
+
+	// From exec.Cmd:
+	d.Path = wrapper.Path
+	d.Args = wrapper.Args
+	d.Env = wrapper.Env
+	d.Dir = wrapper.Dir
+	d.SysProcAttr = wrapper.SysProcAttr
+
+	return d
+}
+
+func WrapCommand(cmd *execdriver.Command) *CommandWrapper {
+	return &CommandWrapper{
+		// From exec.Cmd:
+		Path:        cmd.Path,
+		Args:        cmd.Args,
+		Env:         cmd.Env,
+		Dir:         cmd.Dir,
+		SysProcAttr: cmd.SysProcAttr,
+
+		// From execdriver.Command:
+		ID:         cmd.ID,
+		Privileged: cmd.Privileged,
+		User:       cmd.User,
+		Rootfs:     cmd.Rootfs,
+		InitPath:   cmd.InitPath,
+		Entrypoint: cmd.Entrypoint,
+		Arguments:  cmd.Arguments,
+		WorkingDir: cmd.WorkingDir,
+		ConfigPath: cmd.ConfigPath,
+		Tty:        cmd.Tty,
+		Network:    cmd.Network,
+		Config:     cmd.Config,
+		Resources:  cmd.Resources,
+		Mounts:     cmd.Mounts,
+	}
+}
+
+type CmdDriver struct {
+	Address    string
+	socketDir  string
+	stdin      bool
+	listener   *net.UnixListener
+	realDriver execdriver.Driver
+	numClients *Refcount
+
+	cmd         *execdriver.Command
+	startedLock chan int
+	exitedLock  chan int
+	err         error // if exit code is -1
+	exitCode    int
+}
+
+func NewCmdDriver(stdin bool) (*CmdDriver, error) {
+	baseDir := "/var/run/docker-client"
+	if err := os.MkdirAll(baseDir, 0600); err != nil {
+		return nil, err
+	}
+
+	socketDir, err := ioutil.TempDir(baseDir, "cli")
+	if err != nil {
+		return nil, err
+	}
+
+	address := path.Join(socketDir, "socket")
+	addr := &net.UnixAddr{Net: "unix", Name: address}
+	listener, err := net.ListenUnix("unix", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	d := &CmdDriver{
+		Address:     address,
+		socketDir:   socketDir,
+		stdin:       stdin,
+		listener:    listener,
+		startedLock: make(chan int),
+		exitedLock:  make(chan int),
+		numClients:  NewRefcount(),
+	}
+
+	if err := rpc.Register(d); err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+func Serve(d *CmdDriver) error {
+	for {
+		conn, err := d.listener.AcceptUnix()
+		if err != nil {
+			utils.Debugf("rpc socket accept error: %s", err)
+			continue
+		}
+
+		d.numClients.Ref()
+
+		go func() {
+			rpc.ServeConn(conn)
+			conn.Close()
+			d.numClients.Unref()
+		}()
+	}
+
+	return nil
+}
+
+// Can't expose this as a public method, because it does not fit
+// the rpc method profile
+func WaitForExit(d *CmdDriver) (int, error) {
+	exitCode, err := d.waitForExit()
+
+	// Wait for all existing rpc clients to finish
+	// so that we allow time for the exit code to
+	// be returned from the Wait call
+	d.numClients.WaitForZero()
+
+	os.RemoveAll(d.socketDir)
+
+	return exitCode, err
+}
+
+func (d *CmdDriver) waitForExit() (int, error) {
+	// block on exited
+	<-d.exitedLock
+
+	if d.err != nil {
+		return -1, d.err
+	}
+
+	return d.exitCode, nil
+}
+
+func (d *CmdDriver) started() {
+	close(d.startedLock)
+}
+
+func (d *CmdDriver) exited() {
+	close(d.exitedLock)
+}
+
+func (d *CmdDriver) Start(wrapper *CommandWrapper, res *int) error {
+	if d.realDriver != nil {
+		return fmt.Errorf("Can't start container twice\n")
+	}
+
+	var err error
+	d.realDriver, err = execdrivers.NewDriver(wrapper.RealDriver, wrapper.DockerRoot, wrapper.DockerSysInitPath, sysinfo.New(false))
+	if err != nil {
+		return err
+	}
+
+	cmd := wrapper.Unwrap()
+
+	d.cmd = cmd
+
+	// We want neither a separate session nor a
+	// tty that we control in forground mode, so
+	// just always set these to false and inherit
+	// std* and tty from the caller
+	cmd.SysProcAttr.Setctty = false
+	cmd.SysProcAttr.Setsid = false
+	cmd.Tty = false
+	cmd.Console = ""
+
+	// We manually set Stdin here, to avoid SetTerminal overriding it with a pipe
+	// as we really want to inherit *the* stdin fd
+	if d.stdin {
+		cmd.Stdin = os.Stdin
+	}
+	pipes := execdriver.NewPipes(nil, os.Stdout, os.Stderr, false)
+
+	go func() {
+		d.exitCode, d.err = d.realDriver.Run(cmd, pipes, func(*execdriver.Command) {
+			d.started()
+		})
+		d.exited()
+
+		if d.err != nil {
+			fmt.Fprintf(os.Stderr, "Can't start container: %s\n", d.err)
+		}
+	}()
+
+	// block on started or exited (error)
+	select {
+	case <-d.startedLock:
+	case <-d.exitedLock:
+	}
+
+	*res = -1
+	if cmd.Process != nil {
+		*res = cmd.Process.Pid
+	}
+
+	return nil
+}
+
+func (d *CmdDriver) Wait(_ int, res *int) error {
+	exitCode, err := d.waitForExit()
+	*res = exitCode
+	return err
+}
+
+func (d *CmdDriver) Kill(sig int, dummy *int) error {
+	if d.cmd == nil {
+		return fmt.Errorf("container not started yet")
+	}
+
+	return d.realDriver.Kill(d.cmd, sig)
+}
+
+func (d *CmdDriver) Terminate(dummy1 int, dummy2 *int) error {
+	if d.cmd == nil {
+		return fmt.Errorf("container not started yet")
+	}
+
+	return d.realDriver.Terminate(d.cmd)
+}
+
+func (d *CmdDriver) GetPids(dummy int, res *[]int) error {
+	if d.cmd == nil {
+		return fmt.Errorf("container not started yet")
+	}
+
+	pids, err := d.realDriver.GetPidsForContainer(d.cmd.ID)
+	if err != nil {
+		return err
+	}
+	*res = pids
+	return nil
+}
+
+func (d *CmdDriver) IsRunning(_ int, res *bool) error {
+	*res = true
+
+	// block on started or exited (error)
+	select {
+	case <-d.exitedLock:
+		*res = false
+	}
+
+	return nil
+}

--- a/runtime/execdriver/foreground/driver.go
+++ b/runtime/execdriver/foreground/driver.go
@@ -1,0 +1,155 @@
+package foreground
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/runtime/execdriver"
+	"net"
+	"net/rpc"
+	"os"
+	"strings"
+)
+
+const DriverName = "foreground"
+
+type driver struct {
+	address     string
+	root        string
+	sysInitPath string
+	realDriver  execdriver.Driver
+}
+
+func NewDriver(address, root, sysInitPath string, realDriver execdriver.Driver) *driver {
+	return &driver{address: address, root: root, sysInitPath: sysInitPath, realDriver: realDriver}
+}
+
+func (d *driver) getClient() (*rpc.Client, error) {
+	addr, err := net.ResolveUnixAddr("unix", d.address)
+	if err != nil {
+		return nil, err
+	}
+	socket, err := net.DialUnix("unix", nil, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return rpc.NewClient(socket), nil
+}
+
+func (d *driver) Name() string {
+	return fmt.Sprintf("%s", DriverName)
+}
+
+func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
+	client, err := d.getClient()
+	if err != nil {
+		return -1, err
+	}
+
+	defer client.Close()
+
+	driverName := strings.Split(d.realDriver.Name(), "-")[0]
+
+	wrapper := WrapCommand(c)
+	wrapper.RealDriver = driverName
+	wrapper.DockerRoot = d.root
+	wrapper.DockerSysInitPath = d.sysInitPath
+	var pid, exitCode, dummy int
+	err = client.Call("CmdDriver.Start", wrapper, &pid)
+	if pid != -1 {
+		c.ContainerPid = pid
+		c.Process, _ = os.FindProcess(pid)
+		if startCallback != nil {
+			startCallback(c)
+		}
+	}
+	err = client.Call("CmdDriver.Wait", dummy, &exitCode)
+	return exitCode, err
+}
+
+func (d *driver) Kill(c *execdriver.Command, sig int) error {
+	client, err := d.getClient()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	var dummy int
+	err = client.Call("CmdDriver.Kill", sig, &dummy)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *driver) Terminate(c *execdriver.Command) error {
+	client, err := d.getClient()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	var dummy int
+	err = client.Call("CmdDriver.Terminate", dummy, &dummy)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *driver) Restore(c *execdriver.Command) error {
+	client, err := d.getClient()
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	var exitCode int
+	err = client.Call("CmdDriver.Wait", 0, &exitCode)
+	return err
+}
+
+type info struct {
+	ID     string
+	driver *driver
+}
+
+func (i *info) IsRunning() (r bool) {
+	client, err := i.driver.getClient()
+	if err != nil {
+		return false
+	}
+	defer client.Close()
+
+	var running bool
+	err = client.Call("CmdDriver.IsRunning", 0, &running)
+	if err != nil {
+		return false
+	}
+
+	return running
+}
+
+func (d *driver) Info(id string) execdriver.Info {
+	return &info{
+		ID:     id,
+		driver: d,
+	}
+}
+
+func (d *driver) GetPidsForContainer(id string) ([]int, error) {
+	client, err := d.getClient()
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	var pids []int
+	err = client.Call("CmdDriver.GetPids", 0, &pids)
+	if err != nil {
+		return nil, err
+	}
+
+	return pids, nil
+}

--- a/runtime/execdriver/foreground/refcount.go
+++ b/runtime/execdriver/foreground/refcount.go
@@ -1,0 +1,42 @@
+package foreground
+
+import (
+	"sync"
+)
+
+type Refcount struct {
+	count int
+	lock  sync.Mutex
+	cond  *sync.Cond
+}
+
+func NewRefcount() *Refcount {
+	r := &Refcount{}
+	r.cond = sync.NewCond(&r.lock)
+	return r
+}
+
+func (r *Refcount) Ref() {
+	r.lock.Lock()
+	r.count++
+	r.lock.Unlock()
+}
+
+func (r *Refcount) Unref() {
+	r.lock.Lock()
+	r.count--
+	r.cond.Broadcast()
+	r.lock.Unlock()
+}
+
+// Wait until the reference count is zero. Note that it may reach zero
+// and then increase before this function returns. However, at least
+// it is guaranteed that all Refs called before the wait are Unrefed,
+// which is all we need.
+func (r *Refcount) WaitForZero() {
+	r.lock.Lock()
+	for r.count != 0 {
+		r.cond.Wait()
+	}
+	r.lock.Unlock()
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -152,6 +152,7 @@ func (runtime *Runtime) Register(container *Container) error {
 		return err
 	}
 
+	container.execDriver = runtime.execDriver
 	container.runtime = runtime
 
 	// Attach to stdout and stderr
@@ -901,14 +902,6 @@ func (runtime *Runtime) Diff(container *Container) (archive.Archive, error) {
 		runtime.driver.Put(container.ID)
 		return err
 	}), nil
-}
-
-func (runtime *Runtime) Run(c *Container, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
-	return runtime.execDriver.Run(c.command, pipes, startCallback)
-}
-
-func (runtime *Runtime) Kill(c *Container, sig int) error {
-	return runtime.execDriver.Kill(c.command, sig)
 }
 
 // Nuke kills all containers then removes all content

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dotcloud/docker/runconfig"
 	"github.com/dotcloud/docker/runtime/execdriver"
 	"github.com/dotcloud/docker/runtime/execdriver/execdrivers"
+	"github.com/dotcloud/docker/runtime/execdriver/foreground"
 	"github.com/dotcloud/docker/runtime/execdriver/lxc"
 	"github.com/dotcloud/docker/runtime/graphdriver"
 	_ "github.com/dotcloud/docker/runtime/graphdriver/vfs"
@@ -154,6 +155,10 @@ func (runtime *Runtime) Register(container *Container) error {
 
 	container.execDriver = runtime.execDriver
 	container.runtime = runtime
+
+	if container.hostConfig.CliAddress != "" {
+		container.execDriver = foreground.NewDriver(container.hostConfig.CliAddress, runtime.config.Root, runtime.sysInitPath, runtime.execDriver)
+	}
 
 	// Attach to stdout and stderr
 	container.stderr = utils.NewWriteBroadcaster()

--- a/server/server.go
+++ b/server/server.go
@@ -2114,7 +2114,7 @@ func (srv *Server) ContainerStart(job *engine.Job) engine.Status {
 	}
 	// If no environment was set, then no hostconfig was passed.
 	if len(job.Environ()) > 0 {
-		hostConfig := runconfig.ContainerHostConfigFromJob(job)
+		hostConfig := runconfig.ContainerHostConfigFromJob(job, container.HostConfig())
 		// Validate the HostConfig binds. Make sure that:
 		// 1) the source of a bind mount isn't /
 		//         The bind mount "/:/foo" isn't allowed.


### PR DESCRIPTION
This implements a "-f" switch for docker run, so you can do something like:
docker run -f fedora echo hello

This will run the echo command as a direct decendant of the docker client process, rather than a child of the docker daemon. It will also pass stdin/out/err directly from the docker client to the container. 

This is particularly interesting when you're integrating docker containers with some other form of execution manager, such as systemd. Systemd can via cgroups and the normal process hierarchy completely control the container processes, and implement things like restart-on-exit, stdout logging, cgroup containment, integration with systemd unit (so you can e.g. systemctl stop the container).

The way it works is by calling out to the docker daemon which fully sets up the container, but uses a custom execdriver, that when started calls into the docker client via golang rpc calls. The client then creates a real execdriver and proxies the request to that, which starts the container. The client then stays around monitoring the container and exits with the right exit status, as well as telling the docker daamon that the container exited.

Additionally the client accepts a few other RPC calls so that the other daemon side execdriver requests (docker stop, docker ps, docker top, etc) still works. We also implement Restore by reconnecting to the client, so the docker containers survive the daamon restarting.
