### PR TITLE
Change mustn't to must not

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ curl -o .git/hooks/pre-commit https://raw.github.com/edsrzf/gofmt-git-hook/maste
 Pull requests descriptions should be as clear as possible and include a
 reference to all the issues that they address.
 
-Pull requests mustn't contain commits from other users or branches.
+Pull requests must not contain commits from other users or branches.
 
 Code review comments may be added to your pull request. Discuss, then make the
 suggested modifications and push additional commits to your feature branch. Be


### PR DESCRIPTION
mustn't is ambiguous.  It may mean "you don't need to" even when it's not a tag question.  See prose:

http://books.google.cz/books?id=otFPvwLG524C&pg=PA241&lpg=PA241&dq=mustn%27t+trouble+yourself&source=bl&ots=vjgh7n-yyW&sig=LBQAwlZu3GxI5YzvRAXFow4hE1U&hl=en&sa=X&ei=a14XU9vxB4SBywOPz4HwDw&ved=0CDQQ6AEwAg#v=onepage&q=mustn%27t%20trouble%20yourself&f=false

http://www.nytimes.com/books/first/m/maynard-home.html (search for mustn't)

We mustn't argue over grammar.

See: https://github.com/dotcloud/docker/pull/4473

Docker-DCO-1.1-Signed-off-by: Timothy Hobbs timothyhobbs@seznam.cz (github: timthelion)
