### PR TITLE
Add missing -- when we run dockerinit from native

### DIFF
--- a/execdriver/native/driver.go
+++ b/execdriver/native/driver.go
@@ -246,6 +246,7 @@ func (d *dockerCommandFactory) Create(container *libcontainer.Container, console
 		"-console", console,
 		"-pipe", fmt.Sprint(syncFd),
 		"-root", filepath.Join(d.driver.root, d.c.ID),
+		"--",
 	}, args...)
 
 	// set this to nil so that when we set the clone flags anything else is reset


### PR DESCRIPTION
It fixes a small issue, `docker run ubuntu -p test` displays `dockerinit` usage

ping @crosbymichael @unclejack
