### PR TITLE
Line up tag, push, build and commit's tag patterns with each other.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -162,6 +162,12 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 
 	_, err = exec.LookPath("git")
 	hasGit := err == nil
+
+	if err := utils.ValidTag(*tag); err != nil {
+		fmt.Println(err)
+		return nil
+	}
+
 	if cmd.Arg(0) == "-" {
 		// As a special case, 'docker build -' will build from an empty context with the
 		// contents of stdin as a Dockerfile
@@ -1043,6 +1049,11 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 		return nil
 	}
 
+	if err := utils.ValidTag(name); err != nil {
+		fmt.Println(err)
+		return nil
+	}
+
 	cli.LoadConfigFile()
 
 	// Resolve the Repository name from fqn to hostname + name
@@ -1473,6 +1484,11 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 		return err
 	}
 
+	if err := utils.ValidTags(name, repository, tag); err != nil {
+		fmt.Println(err)
+		return nil
+	}
+
 	v := url.Values{}
 	v.Set("container", name)
 	v.Set("repo", repository)
@@ -1760,6 +1776,11 @@ func (cli *DockerCli) CmdTag(args ...string) error {
 		repository, tag = utils.ParseRepositoryTag(cmd.Arg(1))
 	}
 
+	if err := utils.ValidTags(cmd.Arg(0), repository, tag); err != nil {
+		fmt.Println(err)
+		return nil
+	}
+
 	v := url.Values{}
 
 	//Check if the given image name can be resolved
@@ -1782,11 +1803,18 @@ func (cli *DockerCli) CmdTag(args ...string) error {
 func (cli *DockerCli) CmdRun(args ...string) error {
 	// FIXME: just use runconfig.Parse already
 	config, hostConfig, cmd, err := runconfig.ParseSubcommand(cli.Subcmd("run", "[OPTIONS] IMAGE [COMMAND] [ARG...]", "Run a command in a new container"), args, nil)
+
 	if err != nil {
 		return err
 	}
+
 	if config.Image == "" {
 		cmd.Usage()
+		return nil
+	}
+
+	if err := utils.ValidTag(config.Image); err != nil {
+		fmt.Println(err)
 		return nil
 	}
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -84,9 +84,8 @@ func validateRepositoryName(repositoryName string) error {
 	if !validNamespace.MatchString(namespace) {
 		return fmt.Errorf("Invalid namespace name (%s), only [a-z0-9_] are allowed, size between 4 and 30", namespace)
 	}
-	validRepo := regexp.MustCompile(`^([a-z0-9-_.]+)$`)
-	if !validRepo.MatchString(name) {
-		return fmt.Errorf("Invalid repository name (%s), only [a-z0-9-_.] are allowed", name)
+	if err := utils.ValidTag(name); err != nil {
+		return err
 	}
 	return nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -25,6 +25,11 @@ import (
 	"time"
 )
 
+var (
+	validTagNameChars   = `[a-z0-9-_.]`
+	validTagNamePattern = regexp.MustCompile(`^` + validTagNameChars + `+$`)
+)
+
 // A common interface to access the Fatal method of
 // both testing.B and testing.T.
 type Fataler interface {
@@ -877,6 +882,37 @@ func GetReleaseVersion() string {
 		return ""
 	}
 	return strings.TrimSpace(string(body))
+}
+
+// Check a tag name for validity. Uses validTagNameChars and
+// validTagNamePattern to determine eligibility.
+//
+// Returns a formatted error if the tag name is invalid, otherwise nil.
+//
+func ValidTag(imageName string) error {
+	// these come from runtime.go
+	if !validTagNamePattern.MatchString(imageName) {
+		return fmt.Errorf("Invalid image or tag name (%s), only %s are allowed", imageName, validTagNameChars)
+	}
+
+	return nil
+}
+
+// Plural of ValidTag() -- checks multiple strings. Note that empty strings are
+// valid in this call, which is the only way (other than the multiple
+// arguments) it differs from ValidTag().
+//
+// Returns a formatted error if any tag name is invalid, otherwise nil.
+//
+
+func ValidTags(imageNames ...string) error {
+	for _, img := range imageNames {
+		if err := ValidTag(img); img != "" && err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // Get a repos name and returns the right reposName + tag

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -625,3 +625,36 @@ func TestReadSymlinkedDirectoryToFile(t *testing.T) {
 		t.Errorf("failed to remove symlink: %s", err)
 	}
 }
+
+func TestValidTag(t *testing.T) {
+
+	passing_strings := []string{
+		"alpha",
+		"012345678",
+		"0.123456",
+		"_-.-09az",
+	}
+
+	failing_strings := []string{
+		"FAIL",
+		"fAIL",
+		"0-9FAIL",
+		"fAil",
+		"F.R.E.A.M",
+		"fail!!!",
+		"fail:fail",
+		"fail/fail",
+	}
+
+	for _, str := range passing_strings {
+		if err := ValidTag(str); err != nil {
+			t.Error(err)
+		}
+	}
+
+	for _, str := range failing_strings {
+		if err := ValidTag(str); err == nil {
+			t.Errorf("%s was considered a valid tag/repository name", str)
+		}
+	}
+}


### PR DESCRIPTION
Please note before anything that this is my first serious foray into the docker source, so please just be aware I'm happy to accept criticism or requests for rewrites.

I think this solves #4340 -- it unifies tag and image name validation into a single regex, which is then applied to the tag, build, push, and commit's command functions. Additionally the function used is generalized in utils.ValidTag and utils.ValidTags (a list version to do multiple comparisons at once).

Please let me know if I can / need to change anything!
