### PR TITLE
libcontainer: Don't use UsetCloseOnExec, it is racy

### DIFF
--- a/pkg/libcontainer/nsinit/exec.go
+++ b/pkg/libcontainer/nsinit/exec.go
@@ -35,7 +35,7 @@ func (ns *linuxNs) Exec(container *libcontainer.Container, term Terminal, args [
 		term.SetMaster(master)
 	}
 
-	command := ns.commandFactory.Create(container, console, syncPipe.child.Fd(), args)
+	command := ns.commandFactory.Create(container, console, syncPipe.child, args)
 	if err := term.Attach(command); err != nil {
 		return -1, err
 	}

--- a/pkg/libcontainer/nsinit/sync_pipe.go
+++ b/pkg/libcontainer/nsinit/sync_pipe.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/dotcloud/docker/pkg/libcontainer"
-	"github.com/dotcloud/docker/pkg/system"
 	"io/ioutil"
 	"os"
 )
@@ -22,7 +21,6 @@ func NewSyncPipe() (s *SyncPipe, err error) {
 	if err != nil {
 		return nil, err
 	}
-	system.UsetCloseOnExec(s.child.Fd())
 	return s, nil
 }
 


### PR DESCRIPTION
We can't keep file descriptors without close-on-exec except with
syscall.ForkLock held, as otherwise they could leak by accident into
other children from forks in other threads.

Instead we just use Cmd.ExtraFiles which handles all this for us.

This fixes https://github.com/dotcloud/docker/issues/4493

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
