### PR TITLE
DeviceMapper: Succeed immediately when removing non-existant devices

### DIFF
--- a/graphdriver/devmapper/driver.go
+++ b/graphdriver/devmapper/driver.go
@@ -90,6 +90,13 @@ func (d *Driver) Create(id, parent string) error {
 }
 
 func (d *Driver) Remove(id string) error {
+	if !d.DeviceSet.HasDevice(id) {
+		// Consider removing a non-existing device a no-op
+		// This is useful to be able to progress on container removal
+		// if the underlying device has gone away due to earlier errors
+		return nil
+	}
+
 	// Sink the float from create in case no Get() call was made
 	if err := d.DeviceSet.UnmountDevice(id, UnmountSink); err != nil {
 		return err


### PR DESCRIPTION
We've seen situations where removal of "ID-init" failed during
container deletion (EBUSY), after removal of "ID" has succeeded. This
caused the container delete operation to fail, and on the next delete
attempt the removal of "ID" failed immediately with "does not exist".

Ideally we should not fail the ID-init removal, but its also non-ideal
to allow a state where the container is half-removed and we cannot
make progress deleting the container. So, we silently ignore not-exist
errors on device removal.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
