### PR TITLE
remove dbus from apparmor profile for Ubuntu 12.04

### DIFF
--- a/pkg/libcontainer/apparmor/setup.go
+++ b/pkg/libcontainer/apparmor/setup.go
@@ -21,7 +21,6 @@ profile docker-default flags=(attach_disconnected,mediate_deleted) {
   capability,
   file,
   umount,
-  dbus,
 
   # ignore DENIED message on / remount
   deny mount options=(ro, remount) -> /,


### PR DESCRIPTION
This is meant to be a discussion and the PR is WIP.

This fixes the apparmor profile for Ubuntu 12.04.

```
sudo /lib/init/apparmor-profile-load docker
AppArmor parser error for /etc/apparmor.d/docker in /etc/apparmor.d/docker at line 14: syntax error, unexpected TOK_END_OF_RULE, expecting TOK_MODE
```

While the profile does get loaded, it doesn't work as intended. The tests fail.

Please don't merge this, it's just meant to be used for further discussion. It's missing the DCO on purpose.
