### PR TITLE
devmapper: Increase sleep times and unlock while sleeping

### DIFF
--- a/graphdriver/devmapper/deviceset.go
+++ b/graphdriver/devmapper/deviceset.go
@@ -701,7 +701,7 @@ func (devices *DeviceSet) deactivateDevice(hash string) error {
 func (devices *DeviceSet) removeDeviceAndWait(devname string) error {
 	var err error
 
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 1000; i++ {
 		devices.sawBusy = false
 		err = removeDevice(devname)
 		if err == nil {
@@ -713,7 +713,9 @@ func (devices *DeviceSet) removeDeviceAndWait(devname string) error {
 
 		// If we see EBUSY it may be a transient error,
 		// sleep a bit a retry a few times.
-		time.Sleep(5 * time.Millisecond)
+		devices.Unlock()
+		time.Sleep(10 * time.Millisecond)
+		devices.Lock()
 	}
 	if err != nil {
 		return err
@@ -746,7 +748,9 @@ func (devices *DeviceSet) waitRemove(devname string) error {
 			break
 		}
 
-		time.Sleep(1 * time.Millisecond)
+		devices.Unlock()
+		time.Sleep(10 * time.Millisecond)
+		devices.Lock()
 	}
 	if i == 1000 {
 		return fmt.Errorf("Timeout while waiting for device %s to be removed", devname)


### PR DESCRIPTION
We've seen some cases in the wild where waiting for unmount/deactivate
of devmapper devices taking a long time (several seconds). So, we increase
the sleeps to 10 seconds before we timeout. For instance:

https://github.com/dotcloud/docker/issues/4389

But, in order to not keep other processes blocked we unlock the global
dm lock while waiting to allow other devices to continue working.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
