### PR TITLE
Add !cgo as buildflags for dynbinary compat

### DIFF
--- a/pkg/libcontainer/apparmor/apparmor_disabled.go
+++ b/pkg/libcontainer/apparmor/apparmor_disabled.go
@@ -1,4 +1,4 @@
-// +build !apparmor !linux !amd64
+// +build !cgo !apparmor !linux !amd64
 
 package apparmor
 


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Guillaume J. Charmes guillaume.charmes@docker.com (github: creack)
