### PR TITLE
Fix dynbinary so that dockerinit can still be properly static even if it has to link against libapparmor for Ubuntu

### DIFF
--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -181,6 +181,12 @@ the file "./VERSION". This binary is usually installed somewhere like
 
 ### Dynamic Daemon / Client-only Binary
 
+If you are only interested in a Docker client binary, set `DOCKER_CLIENTONLY` to a non-empty value using something similar to the following: (which will prevent the extra step of compiling dockerinit)
+
+```bash
+export DOCKER_CLIENTONLY=1
+```
+
 If you need to (due to distro policy, distro library availability, or for other
 reasons) create a dynamically compiled daemon binary, or if you are only
 interested in creating a client binary for Docker, use something similar to the

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -82,9 +82,23 @@ if [ ! "$GOPATH" ]; then
 fi
 
 # Use these flags when compiling the tests and final binary
-LDFLAGS='-X github.com/dotcloud/docker/dockerversion.GITCOMMIT "'$GITCOMMIT'" -X github.com/dotcloud/docker/dockerversion.VERSION "'$VERSION'" -w'
-LDFLAGS_STATIC='-X github.com/dotcloud/docker/dockerversion.IAMSTATIC true -linkmode external -extldflags "-lpthread -static -Wl,--unresolved-symbols=ignore-in-object-files"'
+LDFLAGS='
+	-w
+	-X github.com/dotcloud/docker/dockerversion.GITCOMMIT "'$GITCOMMIT'"
+	-X github.com/dotcloud/docker/dockerversion.VERSION "'$VERSION'"
+'
+LDFLAGS_STATIC='-linkmode external'
+EXTLDFLAGS_STATIC='-static'
 BUILDFLAGS=( -a -tags "netgo $DOCKER_BUILDTAGS" )
+
+# A few more flags that are specific just to building a completely-static binary (see hack/make/binary)
+# PLEASE do not use these anywhere else.
+EXTLDFLAGS_STATIC_DOCKER="$EXTLDFLAGS_STATIC -lpthread -Wl,--unresolved-symbols=ignore-in-object-files"
+LDFLAGS_STATIC_DOCKER="
+	$LDFLAGS_STATIC
+	-X github.com/dotcloud/docker/dockerversion.IAMSTATIC true
+	-extldflags \"$EXTLDFLAGS_STATIC_DOCKER\"
+"
 
 HAVE_GO_TEST_COVER=
 if \

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -2,5 +2,12 @@
 
 DEST=$1
 
-go build -o $DEST/docker-$VERSION -ldflags "$LDFLAGS $LDFLAGS_STATIC" "${BUILDFLAGS[@]}" ./docker
+go build \
+	-o $DEST/docker-$VERSION \
+	"${BUILDFLAGS[@]}" \
+	-ldflags "
+		$LDFLAGS
+		$LDFLAGS_STATIC_DOCKER
+	" \
+	./docker
 echo "Created binary: $DEST/docker-$VERSION"

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -17,7 +17,7 @@ for platform in $DOCKER_CROSSPLATFORMS; do
 		mkdir -p "$DEST/$platform" # bundles/VERSION/cross/GOOS/GOARCH/docker-VERSION
 		export GOOS=${platform%/*}
 		export GOARCH=${platform##*/}
-		export LDFLAGS_STATIC="" # we just need a simple client for these platforms (TODO this might change someday)
+		export LDFLAGS_STATIC_DOCKER="" # we just need a simple client for these platforms (TODO this might change someday)
 		source "$(dirname "$BASH_SOURCE")/binary" "$DEST/$platform"
 	)
 done

--- a/hack/make/dynbinary
+++ b/hack/make/dynbinary
@@ -2,32 +2,37 @@
 
 DEST=$1
 
-# dockerinit still needs to be a static binary, even if docker is dynamic
-go build \
-	-o $DEST/dockerinit-$VERSION \
-	"${BUILDFLAGS[@]}" \
-	-ldflags "
-		$LDFLAGS
-		$LDFLAGS_STATIC
-		-extldflags \"$EXTLDFLAGS_STATIC\"
-	" \
-	./dockerinit
-echo "Created binary: $DEST/dockerinit-$VERSION"
-ln -sf dockerinit-$VERSION $DEST/dockerinit
-
-sha1sum=
-if command -v sha1sum &> /dev/null; then
-	sha1sum=sha1sum
-elif command -v shasum &> /dev/null; then
-	# Mac OS X - why couldn't they just use the same command name and be happy?
-	sha1sum=shasum
+if [ -z "$DOCKER_CLIENTONLY" ]; then
+	# dockerinit still needs to be a static binary, even if docker is dynamic
+	go build \
+		-o $DEST/dockerinit-$VERSION \
+		"${BUILDFLAGS[@]}" \
+		-ldflags "
+			$LDFLAGS
+			$LDFLAGS_STATIC
+			-extldflags \"$EXTLDFLAGS_STATIC\"
+		" \
+		./dockerinit
+	echo "Created binary: $DEST/dockerinit-$VERSION"
+	ln -sf dockerinit-$VERSION $DEST/dockerinit
+	
+	sha1sum=
+	if command -v sha1sum &> /dev/null; then
+		sha1sum=sha1sum
+	elif command -v shasum &> /dev/null; then
+		# Mac OS X - why couldn't they just use the same command name and be happy?
+		sha1sum=shasum
+	else
+		echo >&2 'error: cannot find sha1sum command or equivalent'
+		exit 1
+	fi
+	
+	# sha1 our new dockerinit to ensure separate docker and dockerinit always run in a perfect pair compiled for one another
+	export DOCKER_INITSHA1="$($sha1sum $DEST/dockerinit-$VERSION | cut -d' ' -f1)"
 else
-	echo >&2 'error: cannot find sha1sum command or equivalent'
-	exit 1
+	# DOCKER_CLIENTONLY must be truthy, so we don't need to bother with dockerinit :)
+	export DOCKER_INITSHA1=""
 fi
-
-# sha1 our new dockerinit to ensure separate docker and dockerinit always run in a perfect pair compiled for one another
-export DOCKER_INITSHA1="$($sha1sum $DEST/dockerinit-$VERSION | cut -d' ' -f1)"
 # exported so that "dyntest" can easily access it later without recalculating it
 
 (

--- a/hack/make/dynbinary
+++ b/hack/make/dynbinary
@@ -3,7 +3,15 @@
 DEST=$1
 
 # dockerinit still needs to be a static binary, even if docker is dynamic
-CGO_ENABLED=0 go build -o $DEST/dockerinit-$VERSION -ldflags "$LDFLAGS -d" "${BUILDFLAGS[@]}" ./dockerinit
+go build \
+	-o $DEST/dockerinit-$VERSION \
+	"${BUILDFLAGS[@]}" \
+	-ldflags "
+		$LDFLAGS
+		$LDFLAGS_STATIC
+		-extldflags \"$EXTLDFLAGS_STATIC\"
+	" \
+	./dockerinit
 echo "Created binary: $DEST/dockerinit-$VERSION"
 ln -sf dockerinit-$VERSION $DEST/dockerinit
 
@@ -23,6 +31,6 @@ export DOCKER_INITSHA1="$($sha1sum $DEST/dockerinit-$VERSION | cut -d' ' -f1)"
 # exported so that "dyntest" can easily access it later without recalculating it
 
 (
-	export LDFLAGS_STATIC="-X github.com/dotcloud/docker/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\" -X github.com/dotcloud/docker/dockerversion.INITPATH \"$DOCKER_INITPATH\""
+	export LDFLAGS_STATIC_DOCKER="-X github.com/dotcloud/docker/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\" -X github.com/dotcloud/docker/dockerversion.INITPATH \"$DOCKER_INITPATH\""
 	source "$(dirname "$BASH_SOURCE")/binary"
 )

--- a/hack/make/dyntest
+++ b/hack/make/dyntest
@@ -12,6 +12,8 @@ fi
 
 (
 	export TEST_DOCKERINIT_PATH="$INIT"
-	export LDFLAGS_STATIC="-X github.com/dotcloud/docker/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\""
+	export LDFLAGS_STATIC_DOCKER="
+		-X github.com/dotcloud/docker/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\"
+	"
 	source "$(dirname "$BASH_SOURCE")/test"
 )

--- a/hack/make/dyntest-integration
+++ b/hack/make/dyntest-integration
@@ -12,6 +12,8 @@ fi
 
 (
 	export TEST_DOCKERINIT_PATH="$INIT"
-	export LDFLAGS_STATIC="-X github.com/dotcloud/docker/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\""
+	export LDFLAGS_STATIC_DOCKER="
+		-X github.com/dotcloud/docker/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\"
+	"
 	source "$(dirname "$BASH_SOURCE")/test-integration"
 )

--- a/hack/make/test
+++ b/hack/make/test
@@ -4,9 +4,9 @@ DEST=$1
 
 set -e
 
-TEXTRESET=$'\033[0m' # reset the foreground colour
 RED=$'\033[31m'
 GREEN=$'\033[32m'
+TEXTRESET=$'\033[0m' # reset the foreground colour
 
 # Run Docker's test suite, including sub-packages, and store their output as a bundle
 # If $TESTFLAGS is set in the environment, it is passed as extra arguments to 'go test'.
@@ -22,7 +22,7 @@ bundle_test() {
 		for test_dir in $(find_dirs '*_test.go'); do
 			echo
 
-			if ! LDFLAGS="$LDFLAGS $LDFLAGS_STATIC" go_test_dir "$test_dir"; then
+			if ! LDFLAGS="$LDFLAGS $LDFLAGS_STATIC_DOCKER" go_test_dir "$test_dir"; then
 				TESTS_FAILED+=("$test_dir")
 				echo
 				echo "${RED}Tests failed: $test_dir${TEXTRESET}"

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -5,7 +5,7 @@ DEST=$1
 set -e
 
 bundle_test_integration() {
-	LDFLAGS="$LDFLAGS $LDFLAGS_STATIC" go_test_dir ./integration \
+	LDFLAGS="$LDFLAGS $LDFLAGS_STATIC_DOCKER" go_test_dir ./integration \
 		"-coverpkg $(find_dirs '*.go' | sed 's,^\.,github.com/dotcloud/docker,g' | paste -d, -s)"
 }
 


### PR DESCRIPTION
Without apparmor, on my host:

``` console
$ AUTO_GOPATH=1 ./hack/make.sh dynbinary
# WARNING! I don't seem to be running in the Docker container.
# The result of this command might be an incorrect build, and will not be
#   officially supported.
#
# Try this instead: make all
#

---> Making bundle: dynbinary (in bundles/0.8.1-dev/dynbinary)
Created binary: /home/tianon/downloads/docker/bundles/0.8.1-dev/dynbinary/dockerinit-0.8.1-dev
Created binary: /home/tianon/downloads/docker/bundles/0.8.1-dev/dynbinary/docker-0.8.1-dev
```

And then inside `make shell`:

``` console
root@614124614fe4:/go/src/github.com/dotcloud/docker# ./hack/make.sh dynbinary binary cross binary

bundles/0.8.1-dev already exists. Removing.

---> Making bundle: dynbinary (in bundles/0.8.1-dev/dynbinary)
Created binary: /go/src/github.com/dotcloud/docker/bundles/0.8.1-dev/dynbinary/dockerinit-0.8.1-dev
Created binary: /go/src/github.com/dotcloud/docker/bundles/0.8.1-dev/dynbinary/docker-0.8.1-dev

---> Making bundle: binary (in bundles/0.8.1-dev/binary)
Created binary: /go/src/github.com/dotcloud/docker/bundles/0.8.1-dev/binary/docker-0.8.1-dev

---> Making bundle: cross (in bundles/0.8.1-dev/cross)
Created symlinks: /go/src/github.com/dotcloud/docker/bundles/0.8.1-dev/cross/linux/amd64/docker-0.8.1-dev
Created binary: /go/src/github.com/dotcloud/docker/bundles/0.8.1-dev/cross/linux/386/docker-0.8.1-dev
Created binary: /go/src/github.com/dotcloud/docker/bundles/0.8.1-dev/cross/linux/arm/docker-0.8.1-dev
Created binary: /go/src/github.com/dotcloud/docker/bundles/0.8.1-dev/cross/darwin/amd64/docker-0.8.1-dev
Created binary: /go/src/github.com/dotcloud/docker/bundles/0.8.1-dev/cross/darwin/386/docker-0.8.1-dev

---> Making bundle: binary (in bundles/0.8.1-dev/binary)
Created binary: /go/src/github.com/dotcloud/docker/bundles/0.8.1-dev/binary/docker-0.8.1-dev
```

(with intentional duplicity of the binary bundlescript to make sure we don't clobber any of those important build env vars permanently in any of the bundlescripts)

I'd appreciate if the `test*` bundles could be tested more - I haven't vetted those nearly as thoroughly to make sure they're good, but they should be fine since I made all the same changes to them and did test them briefly (`dyntest*` appears to be working fine in my tests).
