### PR TITLE
All caps variables in normal bash should be avoided not to accidentally collide with environment variables.

### DIFF
--- a/docs/sources/examples/hello_world.rst
+++ b/docs/sources/examples/hello_world.rst
@@ -52,8 +52,8 @@ This command will run a simple ``echo`` command, that will echo ``hello world`` 
 
 **Explanation:**
 
-- **"sudo"** execute the following commands as user *root* 
-- **"docker run"** run a command in a new container 
+- **"sudo"** execute the following commands as user *root*
+- **"docker run"** run a command in a new container
 - **"busybox"** is the image we are running the command in.
 - **"/bin/echo"** is the command we want to run in the container
 - **"hello world"** is the input for the echo command
@@ -67,9 +67,9 @@ See the example in action
 .. raw:: html
 
    <iframe width="560" height="400" frameborder="0"
-           sandbox="allow-same-origin allow-scripts" 
-   srcdoc="<body><script type=&quot;text/javascript&quot; 
-           src=&quot;https://asciinema.org/a/7658.js&quot; 
+           sandbox="allow-same-origin allow-scripts"
+   srcdoc="<body><script type=&quot;text/javascript&quot;
+           src=&quot;https://asciinema.org/a/7658.js&quot;
            id=&quot;asciicast-7658&quot; async></script></body>">
    </iframe>
 
@@ -92,7 +92,7 @@ we stop it.
 
 .. code-block:: bash
 
-    CONTAINER_ID=$(sudo docker run -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done")
+    container_id=$(sudo docker run -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done")
 
 We are going to run a simple hello world daemon in a new container
 made from the ``ubuntu`` image.
@@ -104,22 +104,22 @@ made from the ``ubuntu`` image.
 - **"while true; do echo hello world; sleep 1; done"** is the mini
   script we want to run, that will just print hello world once a
   second until we stop it.
-- **$CONTAINER_ID** the output of the run command will return a
+- **$container_id** the output of the run command will return a
   container id, we can use in future commands to see what is going on
   with this process.
 
 .. code-block:: bash
 
-    sudo docker logs $CONTAINER_ID
+    sudo docker logs $container_id
 
 Check the logs make sure it is working correctly.
 
 - **"docker logs**" This will return the logs for a container
-- **$CONTAINER_ID** The Id of the container we want the logs for.
+- **$container_id** The Id of the container we want the logs for.
 
 .. code-block:: bash
 
-    sudo docker attach -sig-proxy=false $CONTAINER_ID
+    sudo docker attach -sig-proxy=false $container_id
 
 Attach to the container to see the results in real-time.
 
@@ -127,7 +127,7 @@ Attach to the container to see the results in real-time.
   process to see what is going on.
 - **"-sig-proxy=false"** Do not forward signals to the container; allows
   us to exit the attachment using Control-C without stopping the container.
-- **$CONTAINER_ID** The Id of the container we want to attach too.
+- **$container_id** The Id of the container we want to attach too.
 
 Exit from the container attachment by pressing Control-C.
 
@@ -141,12 +141,12 @@ Check the process list to make sure it is running.
 
 .. code-block:: bash
 
-    sudo docker stop $CONTAINER_ID
+    sudo docker stop $container_id
 
 Stop the container, since we don't need it anymore.
 
 - **"docker stop"** This stops a container
-- **$CONTAINER_ID** The Id of the container we want to stop.
+- **$container_id** The Id of the container we want to stop.
 
 .. code-block:: bash
 
@@ -162,9 +162,9 @@ See the example in action
 .. raw:: html
 
    <iframe width="560" height="400" frameborder="0"
-           sandbox="allow-same-origin allow-scripts" 
-   srcdoc="<body><script type=&quot;text/javascript&quot; 
-           src=&quot;https://asciinema.org/a/2562.js&quot; 
+           sandbox="allow-same-origin allow-scripts"
+   srcdoc="<body><script type=&quot;text/javascript&quot;
+           src=&quot;https://asciinema.org/a/2562.js&quot;
            id=&quot;asciicast-2562&quot; async></script></body>">
    </iframe>
 


### PR DESCRIPTION
No biggie. Just that all caps variable names should only be used for environment variables in bash and not for normal variable names. It also seems like my emacs removed some trailing whitespaces.
