### PR TITLE
Correct Docker run --host param to --hostname

### DIFF
--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1096,7 +1096,7 @@ image is removed.
       --cidfile="": Write the container ID to the file
       -d, --detach=false: Detached mode: Run container in the background, print new container id
       -e, --env=[]: Set environment variables
-      -h, --host="": Container host name
+      -h, --hostname="": Container host name
       -i, --interactive=false: Keep stdin open even if not attached
       --privileged=false: Give extended privileges to this container
       -m, --memory="": Memory limit (format: <number><optional unit>, where unit = b, k, m or g)


### PR DESCRIPTION
Fix for documentation of the `docker run` command.

URL of documenation page: http://docs.docker.io/en/latest/reference/commandline/cli/#run

If you use `--host` with `docker run` you get a error. Using `--hostname` works fine.

Error is:

> flag provided but not defined: --host
> 
> Usage: docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
> 
> Run a command in a new container
> 
> -P, --publish-all=false: Publish all exposed ports to the host interfaces
> -a, --attach=[]: Attach to stdin, stdout or stderr.
> -c, --cpu-shares=0: CPU shares (relative weight)
> --cidfile="": Write the container ID to the file
> -d, --detach=false: Detached mode: Run container in the background, print new container id
> --dns=[]: Set custom dns servers
> -e, --env=[]: Set environment variables
> --entrypoint="": Overwrite the default entrypoint of the image
> --expose=[]: Expose a port from the container without publishing it to your host
> -h, --hostname="": Container host name
> -i, --interactive=false: Keep stdin open even if not attached
> --link=[]: Add link to another container (name:alias)
> --lxc-conf=[]: Add custom lxc options -lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
> -m, --memory="": Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
> -n, --networking=true: Enable networking for this container
> --name="": Assign a name to the container
> -p, --publish=[]: Publish a container's port to the host (format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort) (use 'docker port' to see the actual mapping)
> --privileged=false: Give extended privileges to this container
> --rm=false: Automatically remove the container when it exits (incompatible with -d)
> --sig-proxy=true: Proxify all received signal to the process (even in non-tty mode)
> -t, --tty=false: Allocate a pseudo-tty
> -u, --user="": Username or UID
> -v, --volume=[]: Bind mount a volume (e.g. from the host: -v /host:/container, from docker: -v /container)
> --volumes-from=[]: Mount volumes from the specified container(s)
> -w, --workdir="": Working directory inside the container
