### PR TITLE
upgrade packages after debootstrap

### DIFF
--- a/contrib/mkimage-debootstrap.sh
+++ b/contrib/mkimage-debootstrap.sh
@@ -219,6 +219,7 @@ if [ -z "$strictDebootstrap" ]; then
 	
 	# make sure our packages lists are as up to date as we can get them
 	sudo chroot . apt-get update
+	sudo chroot . apt-get dist-upgrade -y
 fi
 
 if [ "$justTar" ]; then


### PR DESCRIPTION
This makes mkimage-debootstrap upgrade packages after retrieving updated lists of packages.

Fixes #4268
Fixes #4500
