### PR TITLE
Fix a few packaging bugs, including and especially a temporary patch to our upstart script to mount cgroups

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -14,13 +14,15 @@
 #  VMs, bare metal, OpenStack clusters, public clouds and more.
 ### END INIT INFO
 
+export PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
+
 BASE=$(basename $0)
 
+# modify these in /etc/default/$BASE (/etc/default/docker)
 DOCKER=/usr/bin/$BASE
 DOCKER_PIDFILE=/var/run/$BASE.pid
 DOCKER_OPTS=
-
-PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/sbin:/usr/local/bin
+DOCKER_DESC="Docker"
 
 # Get lsb functions
 . /lib/lsb/init-functions
@@ -30,8 +32,8 @@ if [ -f /etc/default/$BASE ]; then
 fi
 
 # see also init_is_upstart in /lib/lsb/init-functions (which isn't available in Ubuntu 12.04, or we'd use it)
-if [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | /bin/grep -q upstart; then
-	log_failure_msg "Docker is managed via upstart, try using service $BASE $1"
+if [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; then
+	log_failure_msg "$DOCKER_DESC is managed via upstart, try using service $BASE $1"
 	exit 1
 fi
 
@@ -43,7 +45,7 @@ fi
 
 fail_unless_root() {
 	if [ "$(id -u)" != '0' ]; then
-		log_failure_msg "Docker must be run as root"
+		log_failure_msg "$DOCKER_DESC must be run as root"
 		exit 1
 	fi
 }
@@ -51,21 +53,37 @@ fail_unless_root() {
 case "$1" in
 	start)
 		fail_unless_root
-		log_begin_msg "Starting Docker: $BASE"
-		mount | grep cgroup >/dev/null || mount -t cgroup none /sys/fs/cgroup 2>/dev/null
+
+		if ! grep -q cgroup /proc/mounts; then
+			# rough approximation of cgroupfs-mount
+			mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+			for sys in $(cut -d'	' -f1 /proc/cgroups); do
+				mkdir -p /sys/fs/cgroup/$sys
+				if ! mount -n -t cgroup -o $sys cgroup /sys/fs/cgroup/$sys 2>/dev/null; then
+					rmdir /sys/fs/cgroup/$sys 2>/dev/null || true
+				fi
+			done
+		fi
+
+		touch /var/log/docker.log
+		chgrp docker /var/log/docker.log
+
+		log_begin_msg "Starting $DOCKER_DESC: $BASE"
 		start-stop-daemon --start --background \
+			--no-close \
 			--exec "$DOCKER" \
 			--pidfile "$DOCKER_PIDFILE" \
-			-- -d -p "$DOCKER_PIDFILE" \
-			$DOCKER_OPTS
+			-- \
+				-d -p "$DOCKER_PIDFILE" \
+				$DOCKER_OPTS \
+					> /var/log/docker.log 2>&1
 		log_end_msg $?
 		;;
 
 	stop)
 		fail_unless_root
-		log_begin_msg "Stopping Docker: $BASE"
-		start-stop-daemon --stop \
-			--pidfile "$DOCKER_PIDFILE"
+		log_begin_msg "Stopping $DOCKER_DESC: $BASE"
+		start-stop-daemon --stop --pidfile "$DOCKER_PIDFILE"
 		log_end_msg $?
 		;;
 

--- a/contrib/init/sysvinit-debian/docker.default
+++ b/contrib/init/sysvinit-debian/docker.default
@@ -1,0 +1,13 @@
+# Docker Upstart and SysVinit configuration file
+
+# Customize location of Docker binary (especially for development testing).
+#DOCKER="/usr/local/bin/docker"
+
+# Use DOCKER_OPTS to modify the daemon startup options.
+#DOCKER_OPTS="-dns 8.8.8.8 -dns 8.8.4.4"
+
+# If you need Docker to use an HTTP proxy, it can also be specified here.
+#export http_proxy="http://127.0.0.1:3128/"
+
+# This is also a handy place to tweak where Docker's temporary files go.
+#export TMPDIR="/mnt/bigdrive/docker-tmp"

--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -1,15 +1,26 @@
 description "Docker daemon"
 
-start on filesystem and started lxc-net
+start on filesystem
 stop on runlevel [!2345]
 
 respawn
 
 script
+	# modify these in /etc/default/$UPSTART_JOB (/etc/default/docker)
 	DOCKER=/usr/bin/$UPSTART_JOB
 	DOCKER_OPTS=
 	if [ -f /etc/default/$UPSTART_JOB ]; then
 		. /etc/default/$UPSTART_JOB
+	fi
+	if ! grep -q cgroup /proc/mounts; then
+		# rough approximation of cgroupfs-mount
+		mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+		for sys in $(cut -d'	' -f1 /proc/cgroups); do
+			mkdir -p /sys/fs/cgroup/$sys
+			if ! mount -n -t cgroup -o $sys cgroup /sys/fs/cgroup/$sys 2>/dev/null; then
+				rmdir /sys/fs/cgroup/$sys 2>/dev/null || true
+			fi
+		done
 	fi
 	"$DOCKER" -d $DOCKER_OPTS
 end script

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -29,42 +29,36 @@ bundle_ubuntu() {
 	cp contrib/udev/80-docker.rules $DIR/etc/udev/rules.d/
 
 	# Include our init scripts
-	mkdir -p $DIR/etc
-	cp -R contrib/init/upstart $DIR/etc/init
-	cp -R contrib/init/sysvinit $DIR/etc/init.d
-	mkdir -p $DIR/lib/systemd
-	cp -R contrib/init/systemd $DIR/lib/systemd/system
-
+	mkdir -p $DIR/etc/init
+	cp contrib/init/upstart/docker.conf $DIR/etc/init/
+	mkdir -p $DIR/etc/init.d
+	cp contrib/init/sysvinit-debian/docker $DIR/etc/init.d/
 	mkdir -p $DIR/etc/default
-	cat > $DIR/etc/default/docker <<'EOF'
-# Docker Upstart and SysVinit configuration file
-
-# Customize location of Docker binary (especially for development testing).
-#DOCKER="/usr/local/bin/docker"
-
-# Use DOCKER_OPTS to modify the daemon startup options.
-#DOCKER_OPTS="-dns 8.8.8.8"
-
-# If you need Docker to use an HTTP proxy, it can also be specified here.
-#export http_proxy=http://127.0.0.1:3128/
-EOF
+	cp contrib/init/sysvinit-debian/docker.default $DIR/etc/default/docker
+	mkdir -p $DIR/lib/systemd/system
+	cp contrib/init/systemd/docker.service $DIR/lib/systemd/system/
 
 	# Copy the binary
 	# This will fail if the binary bundle hasn't been built
 	mkdir -p $DIR/usr/bin
-	# Copy the binary
-	# This will fail if the binary bundle hasn't been built
 	cp $DEST/../binary/docker-$VERSION $DIR/usr/bin/docker
 
 	# Generate postinst/prerm/postrm scripts
-	cat > /tmp/postinst <<'EOF'
+	cat > $DEST/postinst <<'EOF'
 #!/bin/sh
 set -e
 set -u
 
-getent group docker > /dev/null || groupadd --system docker || true
+if [ "$1" = 'configure' ] && [ -z "$2" ]; then
+	if ! getent group docker > /dev/null; then
+		groupadd --system docker
+	fi
+fi
 
-update-rc.d docker defaults > /dev/null || true
+if ! { [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; }; then
+	# we only need to do this if upstart isn't in charge
+	update-rc.d docker defaults > /dev/null || true
+fi
 if [ -n "$2" ]; then
 	_dh_action=restart
 else
@@ -74,7 +68,7 @@ service docker $_dh_action 2>/dev/null || true
 
 #DEBHELPER#
 EOF
-	cat > /tmp/prerm <<'EOF'
+	cat > $DEST/prerm <<'EOF'
 #!/bin/sh
 set -e
 set -u
@@ -83,7 +77,7 @@ service docker stop 2>/dev/null || true
 
 #DEBHELPER#
 EOF
-	cat > /tmp/postrm <<'EOF'
+	cat > $DEST/postrm <<'EOF'
 #!/bin/sh
 set -e
 set -u
@@ -101,50 +95,61 @@ fi
 #DEBHELPER#
 EOF
 	# TODO swaths of these were borrowed from debhelper's auto-inserted stuff, because we're still using fpm - we need to use debhelper instead, and somehow reconcile Ubuntu that way
-	chmod +x /tmp/postinst /tmp/prerm
+	chmod +x $DEST/postinst $DEST/prerm $DEST/postrm
 
 	(
+		# switch directories so we create *.deb in the right folder
 		cd $DEST
+
+		# create lxc-docker-VERSION package
 		fpm -s dir -C $DIR \
-		    --name lxc-docker-$VERSION --version $PKGVERSION \
-		    --after-install /tmp/postinst \
-		    --before-remove /tmp/prerm \
-		    --after-remove /tmp/postrm \
-		    --architecture "$PACKAGE_ARCHITECTURE" \
-		    --prefix / \
-		    --depends iptables \
-		    --deb-recommends aufs-tools \
-		    --deb-recommends ca-certificates \
-		    --deb-recommends git \
-		    --deb-recommends xz-utils \
-		    --description "$PACKAGE_DESCRIPTION" \
-		    --maintainer "$PACKAGE_MAINTAINER" \
-		    --conflicts docker \
-		    --conflicts docker.io \
-		    --conflicts lxc-docker-virtual-package \
-		    --provides lxc-docker \
-		    --provides lxc-docker-virtual-package \
-		    --replaces lxc-docker \
-		    --replaces lxc-docker-virtual-package \
-		    --url "$PACKAGE_URL" \
-		    --license "$PACKAGE_LICENSE" \
-		    --config-files /etc/udev/rules.d/80-docker.rules \
-		    --config-files /etc/init/docker.conf \
-		    --config-files /etc/init.d/docker \
-		    --config-files /etc/default/docker \
-		    --deb-compression gz \
-		    -t deb .
+			--name lxc-docker-$VERSION --version $PKGVERSION \
+			--after-install $DEST/postinst \
+			--before-remove $DEST/prerm \
+			--after-remove $DEST/postrm \
+			--architecture "$PACKAGE_ARCHITECTURE" \
+			--prefix / \
+			--depends iptables \
+			--deb-recommends aufs-tools \
+			--deb-recommends ca-certificates \
+			--deb-recommends git \
+			--deb-recommends xz-utils \
+			--deb-suggests cgroup-lite \
+			--description "$PACKAGE_DESCRIPTION" \
+			--maintainer "$PACKAGE_MAINTAINER" \
+			--conflicts docker \
+			--conflicts docker.io \
+			--conflicts lxc-docker-virtual-package \
+			--provides lxc-docker \
+			--provides lxc-docker-virtual-package \
+			--replaces lxc-docker \
+			--replaces lxc-docker-virtual-package \
+			--url "$PACKAGE_URL" \
+			--license "$PACKAGE_LICENSE" \
+			--config-files /etc/udev/rules.d/80-docker.rules \
+			--config-files /etc/init/docker.conf \
+			--config-files /etc/init.d/docker \
+			--config-files /etc/default/docker \
+			--deb-compression gz \
+			-t deb .
+		# TODO replace "Suggests: cgroup-lite" with "Recommends: cgroupfs-mount | cgroup-lite" once cgroupfs-mount is available
+
+		# create empty lxc-docker wrapper package
 		fpm -s empty \
-		    --name lxc-docker --version $PKGVERSION \
-		    --architecture "$PACKAGE_ARCHITECTURE" \
-		    --depends lxc-docker-$VERSION \
-		    --description "$PACKAGE_DESCRIPTION" \
-		    --maintainer "$PACKAGE_MAINTAINER" \
-		    --url "$PACKAGE_URL" \
-		    --license "$PACKAGE_LICENSE" \
-		    --deb-compression gz \
-		    -t deb
+			--name lxc-docker --version $PKGVERSION \
+			--architecture "$PACKAGE_ARCHITECTURE" \
+			--depends lxc-docker-$VERSION \
+			--description "$PACKAGE_DESCRIPTION" \
+			--maintainer "$PACKAGE_MAINTAINER" \
+			--url "$PACKAGE_URL" \
+			--license "$PACKAGE_LICENSE" \
+			--deb-compression gz \
+			-t deb
 	)
+
+	# clean up after ourselves so we have a clean output directory
+	rm $DEST/postinst $DEST/prerm $DEST/postrm
+	rm -r $DIR
 }
 
 bundle_ubuntu


### PR DESCRIPTION
This needs to get into 0.9.0 if possible (to make sure cgroups work properly).

One of the other major additions here is that Debian will actually get "/var/log/docker.log" as it should - the only reason we didn't have this before is because Ubuntu 12.04's start-stop-daemon is too old to have `--no-close`, but we use upstart on Ubuntu so it doesn't actually matter! :)
