### PR TITLE
Cancel pull push

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -143,6 +143,18 @@ func getVersion(eng *engine.Engine, version version.Version, w http.ResponseWrit
 	return nil
 }
 
+func postJobsKill(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if vars == nil {
+		return fmt.Errorf("Missing parameter")
+	}
+	job := eng.GetJob(vars["name"])
+	if err := job.Kill(); err != nil {
+		return err
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
 func postContainersKill(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -1024,6 +1036,7 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 			"/containers/{name:.*}/resize":  postContainersResize,
 			"/containers/{name:.*}/attach":  postContainersAttach,
 			"/containers/{name:.*}/copy":    postContainersCopy,
+			"/jobs/{name:.*}/kill":          postJobsKill,
 		},
 		"DELETE": {
 			"/containers/{name:.*}": deleteContainers,

--- a/api/server.go
+++ b/api/server.go
@@ -401,6 +401,7 @@ func postImagesCreate(eng *engine.Engine, version version.Version, w http.Respon
 		job.SetenvBool("parallel", version.GreaterThan("1.3"))
 		job.SetenvJson("metaHeaders", metaHeaders)
 		job.SetenvJson("authConfig", authConfig)
+		w.Header().Set("Job-ID", fmt.Sprintf("%d", job.ID))
 	} else { //import
 		job = eng.Job("import", r.Form.Get("fromSrc"), r.Form.Get("repo"), tag)
 		job.Stdin.Add(r.Body)
@@ -514,6 +515,7 @@ func postImagesPush(eng *engine.Engine, version version.Version, w http.Response
 	job := eng.Job("push", vars["name"])
 	job.SetenvJson("metaHeaders", metaHeaders)
 	job.SetenvJson("authConfig", authConfig)
+	w.Header().Set("Job-ID", fmt.Sprintf("%d", job.ID))
 	if version.GreaterThan("1.0") {
 		job.SetenvBool("json", true)
 		streamJSON(job, w, true)

--- a/api/server.go
+++ b/api/server.go
@@ -147,9 +147,15 @@ func postJobsKill(eng *engine.Engine, version version.Version, w http.ResponseWr
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
 	}
-	job := eng.GetJob(vars["name"])
-	if err := job.Kill(); err != nil {
+	if err := parseForm(r); err != nil {
 		return err
+	}
+	if sig := r.Form.Get("signal"); sig == "2" || sig == "3" {
+		if job := eng.GetJob(vars["name"]); job != nil {
+			if err := job.Kill(); err != nil {
+				return err
+			}
+		}
 	}
 	w.WriteHeader(http.StatusNoContent)
 	return nil

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -40,6 +40,7 @@ func unregister(name string) {
 type Engine struct {
 	root     string
 	handlers map[string]Handler
+	jobs     map[string]*Job
 	hack     Hack // data for temporary hackery (see hack.go)
 	id       string
 	Stdout   io.Writer
@@ -93,6 +94,7 @@ func New(root string) (*Engine, error) {
 	eng := &Engine{
 		root:     root,
 		handlers: make(map[string]Handler),
+		jobs:     make(map[string]*Job),
 		id:       utils.RandomString(),
 		Stdout:   os.Stdout,
 		Stderr:   os.Stderr,
@@ -142,9 +144,14 @@ func (eng *Engine) Job(name string, args ...string) *Job {
 	job.Stderr.Add(utils.NopWriteCloser(eng.Stderr))
 	handler, exists := eng.handlers[name]
 	if exists {
+		eng.jobs[fmt.Sprintf("%d", job.ID)] = job
 		job.handler = handler
 	}
 	return job
+}
+
+func (eng *Engine) GetJob(name string) *Job {
+	return eng.jobs[name]
 }
 
 // ParseJob creates a new job from a text description using a shell-like syntax.

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dotcloud/docker/utils"
 	"io"
 	"log"
+	"math/rand"
 	"os"
 	"runtime"
 	"sort"
@@ -129,6 +130,7 @@ func (eng *Engine) commands() []string {
 // This function mimics `Command` from the standard os/exec package.
 func (eng *Engine) Job(name string, args ...string) *Job {
 	job := &Job{
+		ID:     rand.Int63(),
 		Eng:    eng,
 		Name:   name,
 		Args:   args,

--- a/engine/job.go
+++ b/engine/job.go
@@ -41,8 +41,14 @@ type Status int
 const (
 	StatusOK       Status = 0
 	StatusErr      Status = 1
+	StatusKilled   Status = 2
 	StatusNotFound Status = 127
 )
+
+func (job *Job) Kill() error {
+	job.status = StatusKilled
+	return nil
+}
 
 // Run executes the job and blocks until the job completes.
 // If the job returns a failure status, an error is returned
@@ -62,7 +68,7 @@ func (job *Job) Run() error {
 	job.Stderr.AddString(&errorMessage)
 	if job.handler == nil {
 		job.Errorf("%s: command not found", job.Name)
-		job.status = 127
+		job.status = StatusNotFound
 	} else {
 		job.status = job.handler(job)
 		job.end = time.Now()

--- a/engine/job.go
+++ b/engine/job.go
@@ -50,6 +50,10 @@ func (job *Job) Kill() error {
 	return nil
 }
 
+func (job *Job) Status() Status {
+	return job.status
+}
+
 // Run executes the job and blocks until the job completes.
 // If the job returns a failure status, an error is returned
 // which includes the status.

--- a/engine/job.go
+++ b/engine/job.go
@@ -22,6 +22,7 @@ import (
 // This allows for richer error reporting.
 //
 type Job struct {
+	ID      int64
 	Eng     *Engine
 	Name    string
 	Args    []string

--- a/server.go
+++ b/server.go
@@ -1155,7 +1155,7 @@ func (srv *Server) pullRepository(r *registry.Registry, out io.Writer, localName
 		repoData.ImgList[id].Tag = askedTag
 	}
 
-	errors := make(chan error)
+	errors := make(chan error, len(repoData.ImgList))
 	for _, image := range repoData.ImgList {
 		downloadImage := func(img *registry.ImgData) {
 			if askedTag != "" && img.Tag != askedTag {

--- a/server.go
+++ b/server.go
@@ -1065,7 +1065,7 @@ func (srv *Server) ImageTag(job *engine.Job) engine.Status {
 	return engine.StatusOK
 }
 
-func (srv *Server) pullImage(r *registry.Registry, out io.Writer, imgID, endpoint string, token []string, sf *utils.StreamFormatter) error {
+func (srv *Server) pullImage(job *engine.Job, r *registry.Registry, out io.Writer, imgID, endpoint string, token []string, sf *utils.StreamFormatter) error {
 	history, err := r.GetRemoteHistory(imgID, endpoint, token)
 	if err != nil {
 		return err
@@ -1076,6 +1076,10 @@ func (srv *Server) pullImage(r *registry.Registry, out io.Writer, imgID, endpoin
 
 	for i := len(history) - 1; i >= 0; i-- {
 		id := history[i]
+
+		if job.Status() == engine.StatusKilled {
+			return fmt.Errorf("Killed")
+		}
 
 		// ensure no two downloads of the same layer happen at the same time
 		if c, err := srv.poolAdd("pull", "layer:"+id); err != nil {
@@ -1117,7 +1121,7 @@ func (srv *Server) pullImage(r *registry.Registry, out io.Writer, imgID, endpoin
 	return nil
 }
 
-func (srv *Server) pullRepository(r *registry.Registry, out io.Writer, localName, remoteName, askedTag string, sf *utils.StreamFormatter, parallel bool) error {
+func (srv *Server) pullRepository(job *engine.Job, r *registry.Registry, out io.Writer, localName, remoteName, askedTag string, sf *utils.StreamFormatter, parallel bool) error {
 	out.Write(sf.FormatStatus("", "Pulling repository %s", localName))
 
 	repoData, err := r.GetRepositoryData(remoteName)
@@ -1195,7 +1199,7 @@ func (srv *Server) pullRepository(r *registry.Registry, out io.Writer, localName
 			var lastErr error
 			for _, ep := range repoData.Endpoints {
 				out.Write(sf.FormatProgress(utils.TruncateID(img.ID), fmt.Sprintf("Pulling image (%s) from %s, endpoint: %s", img.Tag, localName, ep), nil))
-				if err := srv.pullImage(r, out, img.ID, ep, repoData.Tokens, sf); err != nil {
+				if err := srv.pullImage(job, r, out, img.ID, ep, repoData.Tokens, sf); err != nil {
 					// Its not ideal that only the last error  is returned, it would be better to concatenate the errors.
 					// As the error is also given to the output stream the user will see the error.
 					lastErr = err
@@ -1208,7 +1212,7 @@ func (srv *Server) pullRepository(r *registry.Registry, out io.Writer, localName
 			if !success {
 				out.Write(sf.FormatProgress(utils.TruncateID(img.ID), fmt.Sprintf("Error pulling image (%s) from %s, %s", img.Tag, localName, lastErr), nil))
 				if parallel {
-					errors <- fmt.Errorf("Could not find repository on any of the indexed registries.")
+					errors <- fmt.Errorf("Error pulling the image")
 					return
 				}
 			}
@@ -1346,7 +1350,7 @@ func (srv *Server) ImagePull(job *engine.Job) engine.Status {
 		localName = remoteName
 	}
 
-	if err = srv.pullRepository(r, job.Stdout, localName, remoteName, tag, sf, job.GetenvBool("parallel")); err != nil {
+	if err = srv.pullRepository(job, r, job.Stdout, localName, remoteName, tag, sf, job.GetenvBool("parallel")); err != nil {
 		return job.Error(err)
 	}
 
@@ -1395,7 +1399,7 @@ func (srv *Server) getImageList(localRepo map[string]string) ([]string, map[stri
 	return imageList, tagsByImage, nil
 }
 
-func (srv *Server) pushRepository(r *registry.Registry, out io.Writer, localName, remoteName string, localRepo map[string]string, sf *utils.StreamFormatter) error {
+func (srv *Server) pushRepository(job *engine.Job, r *registry.Registry, out io.Writer, localName, remoteName string, localRepo map[string]string, sf *utils.StreamFormatter) error {
 	out = utils.NewWriteFlusher(out)
 	utils.Debugf("Local repo: %s", localRepo)
 	imgList, tagsByImage, err := srv.getImageList(localRepo)
@@ -1448,7 +1452,7 @@ func (srv *Server) pushRepository(r *registry.Registry, out io.Writer, localName
 			if r.LookupRemoteImage(imgId, ep, repoData.Tokens) {
 				out.Write(sf.FormatStatus("", "Image %s already pushed, skipping", utils.TruncateID(imgId)))
 			} else {
-				if _, err := srv.pushImage(r, out, remoteName, imgId, ep, repoData.Tokens, sf); err != nil {
+				if _, err := srv.pushImage(job, r, out, remoteName, imgId, ep, repoData.Tokens, sf); err != nil {
 					// FIXME: Continue on error?
 					return err
 				}
@@ -1471,7 +1475,7 @@ func (srv *Server) pushRepository(r *registry.Registry, out io.Writer, localName
 	return nil
 }
 
-func (srv *Server) pushImage(r *registry.Registry, out io.Writer, remote, imgID, ep string, token []string, sf *utils.StreamFormatter) (checksum string, err error) {
+func (srv *Server) pushImage(job *engine.Job, r *registry.Registry, out io.Writer, remote, imgID, ep string, token []string, sf *utils.StreamFormatter) (checksum string, err error) {
 	out = utils.NewWriteFlusher(out)
 	jsonRaw, err := ioutil.ReadFile(path.Join(srv.runtime.Graph().Root, imgID, "json"))
 	if err != nil {
@@ -1555,7 +1559,7 @@ func (srv *Server) ImagePush(job *engine.Job) engine.Status {
 		job.Stdout.Write(sf.FormatStatus("", "The push refers to a repository [%s] (len: %d)", localName, reposLen))
 		// If it fails, try to get the repository
 		if localRepo, exists := srv.runtime.Repositories().Repositories[localName]; exists {
-			if err := srv.pushRepository(r, job.Stdout, localName, remoteName, localRepo, sf); err != nil {
+			if err := srv.pushRepository(job, r, job.Stdout, localName, remoteName, localRepo, sf); err != nil {
 				return job.Error(err)
 			}
 			return engine.StatusOK
@@ -1565,7 +1569,7 @@ func (srv *Server) ImagePush(job *engine.Job) engine.Status {
 
 	var token []string
 	job.Stdout.Write(sf.FormatStatus("", "The push refers to an image: [%s]", localName))
-	if _, err := srv.pushImage(r, job.Stdout, remoteName, img.ID, endpoint, token, sf); err != nil {
+	if _, err := srv.pushImage(job, r, job.Stdout, remoteName, img.ID, endpoint, token, sf); err != nil {
 		return job.Error(err)
 	}
 	return engine.StatusOK


### PR DESCRIPTION
This is WIP, it add the ability to cancel a push or a pull, **please comment and criticise**.
- Each job now as an ID and the engine has a list of all his jobs.
- For pushes and pulls, the ID is sent in the http response, in the `Job-ID` header.
- A new endpoint was created to kill a job using it's id
- When a job is killed, is status is set ti `StatusKilled`
- Within the pull and push code, in some places, a check is done on the status, if it's err, we return an error.

The two last step needs to be improved, because if you are in the middle of a pull, it'll finish the current one before exiting.

I didn't do any doc for now.
