### PR TITLE
Removing myself from doc maintainers

### DIFF
--- a/docs/MAINTAINERS
+++ b/docs/MAINTAINERS
@@ -1,3 +1,2 @@
-Andy Rothfusz <andy@dotcloud.com> (@metalivedev)
 James Turnbull <james@lovedthanlost.net> (@jamtur01)
 Sven Dowideit <SvenDowideit@fosiki.com> (@SvenDowideit)


### PR DESCRIPTION
I won't be able to give sufficient time to maintain the Docker docs due to other Docker Inc. obligations, at least for the next few months.

Docker-DCO-1.1-Signed-off-by: Andy Rothfusz github@developersupport.net (github: metalivedev)
