### PR TITLE
Travis CI does not allow for "small patch exceptions"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,13 +170,6 @@ curl -o .git/hooks/prepare-commit-msg https://raw.github.com/dotcloud/docker/mas
 
 * Note: the above script expects to find your GitHub user name in ``git config --get github.user``
 
-#### Small patch exception
-
-There are several exceptions to the signing requirement. Currently these are:
-
-* Your patch fixes spelling or grammar errors.
-* Your patch is a single line change to documentation.
-
 If you have any questions, please refer to the FAQ in the [docs](http://docs.docker.io)
 
 ### How can I become a maintainer?


### PR DESCRIPTION
The DCO job run by hack/travis/dco.py in Travis CI enforces the presence
of a commit sign-off regardless of the contents of the patch, making
this documentation out date. It's not really feasible for CI to enforce
the subjective meaning of "small," so it seems the only solution is to
remove the possibility of "exceptions" from the documentation.
