### PR TITLE
Fix init script cgroup mounting workarounds to be more similar to cgroupfs-mount...

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -21,6 +21,7 @@ BASE=$(basename $0)
 # modify these in /etc/default/$BASE (/etc/default/docker)
 DOCKER=/usr/bin/$BASE
 DOCKER_PIDFILE=/var/run/$BASE.pid
+DOCKER_LOGFILE=/var/log/$BASE.log
 DOCKER_OPTS=
 DOCKER_DESC="Docker"
 
@@ -79,8 +80,8 @@ case "$1" in
 
 		cgroupfs_mount
 
-		touch /var/log/docker.log
-		chgrp docker /var/log/docker.log
+		touch "$DOCKER_LOGFILE"
+		chgrp docker "$DOCKER_LOGFILE"
 
 		log_begin_msg "Starting $DOCKER_DESC: $BASE"
 		start-stop-daemon --start --background \
@@ -90,7 +91,7 @@ case "$1" in
 			-- \
 				-d -p "$DOCKER_PIDFILE" \
 				$DOCKER_OPTS \
-					> /var/log/docker.log 2>&1
+					>> "$DOCKER_LOGFILE" 2>&1
 		log_end_msg $?
 		;;
 

--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -50,20 +50,34 @@ fail_unless_root() {
 	fi
 }
 
+cgroupfs_mount() {
+	# see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
+	if grep -v '^#' /etc/fstab | grep -q cgroup \
+		|| [ ! -e /proc/cgroups ] \
+		|| [ ! -d /sys/fs/cgroup ]; then
+		return
+	fi
+	if ! mountpoint -q /sys/fs/cgroup; then
+		mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+	fi
+	(
+		cd /sys/fs/cgroup
+		for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
+			mkdir -p $sys
+			if ! mountpoint -q $sys; then
+				if ! mount -n -t cgroup -o $sys cgroup $sys; then
+					rmdir $sys || true
+				fi
+			fi
+		done
+	)
+}
+
 case "$1" in
 	start)
 		fail_unless_root
 
-		if ! grep -q cgroup /proc/mounts; then
-			# rough approximation of cgroupfs-mount
-			mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
-			for sys in $(cut -d'	' -f1 /proc/cgroups); do
-				mkdir -p /sys/fs/cgroup/$sys
-				if ! mount -n -t cgroup -o $sys cgroup /sys/fs/cgroup/$sys 2>/dev/null; then
-					rmdir /sys/fs/cgroup/$sys 2>/dev/null || true
-				fi
-			done
-		fi
+		cgroupfs_mount
 
 		touch /var/log/docker.log
 		chgrp docker /var/log/docker.log

--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -5,22 +5,35 @@ stop on runlevel [!2345]
 
 respawn
 
+pre-start script
+	# see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
+	if grep -v '^#' /etc/fstab | grep -q cgroup \
+		|| [ ! -e /proc/cgroups ] \
+		|| [ ! -d /sys/fs/cgroup ]; then
+		exit 0
+	fi
+	if ! mountpoint -q /sys/fs/cgroup; then
+		mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+	fi
+	(
+		cd /sys/fs/cgroup
+		for sys in $(awk '!/^#/ { if ($4 == 1) print $1 }' /proc/cgroups); do
+			mkdir -p $sys
+			if ! mountpoint -q $sys; then
+				if ! mount -n -t cgroup -o $sys cgroup $sys; then
+					rmdir $sys || true
+				fi
+			fi
+		done
+	)
+end script
+
 script
 	# modify these in /etc/default/$UPSTART_JOB (/etc/default/docker)
 	DOCKER=/usr/bin/$UPSTART_JOB
 	DOCKER_OPTS=
 	if [ -f /etc/default/$UPSTART_JOB ]; then
 		. /etc/default/$UPSTART_JOB
-	fi
-	if ! grep -q cgroup /proc/mounts; then
-		# rough approximation of cgroupfs-mount
-		mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
-		for sys in $(cut -d'	' -f1 /proc/cgroups); do
-			mkdir -p /sys/fs/cgroup/$sys
-			if ! mount -n -t cgroup -o $sys cgroup /sys/fs/cgroup/$sys 2>/dev/null; then
-				rmdir /sys/fs/cgroup/$sys 2>/dev/null || true
-			fi
-		done
 	fi
 	"$DOCKER" -d $DOCKER_OPTS
 end script


### PR DESCRIPTION
... and thus work properly

/cc @crosbymichael

For anyone looking to help out by testing this, install the lxc-docker-0.9.0 package from our get.docker.io repo, and then:

Ubuntu:

``` bash
sudo wget -O /etc/init/docker.conf https://raw.github.com/dotcloud/docker/master/contrib/init/upstart/docker.conf
sudo service docker restart
```

Debian:

``` bash
sudo wget -O /etc/init.d/docker https://raw.github.com/dotcloud/docker/master/contrib/init/sysvinit-debian/docker
sudo chmod +x /etc/init.d/docker
sudo service docker restart
```

Don't be shy about commenting if this fixes your issues but even more especially if it doesn't fix them.
