### PR TITLE
Like signal_linux.go, we don't have import os and os/signal

### DIFF
--- a/pkg/signal/signal_freebsd.go
+++ b/pkg/signal/signal_freebsd.go
@@ -1,8 +1,6 @@
 package signal
 
 import (
-	"os"
-	"os/signal"
 	"syscall"
 )
 


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Kato Kazuyoshi kato.kazuyoshi@gmail.com (github: kzys)
