### PR TITLE
Fix lxc

### DIFF
--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -168,6 +168,9 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 	// Poll lxc for RUNNING status
 	pid, err := d.waitForStart(c, waitLock)
 	if err != nil {
+		if c.Process != nil {
+			c.Process.Kill()
+		}
 		return -1, err
 	}
 	c.ContainerPid = pid

--- a/execdriver/lxc/info.go
+++ b/execdriver/lxc/info.go
@@ -36,7 +36,7 @@ func parseLxcInfo(raw string) (*lxcInfo, error) {
 		if len(parts) < 2 {
 			continue
 		}
-		switch strings.TrimSpace(parts[0]) {
+		switch strings.ToLower(strings.TrimSpace(parts[0])) {
 		case "state":
 			info.Running = strings.TrimSpace(parts[1]) == "RUNNING"
 		case "pid":

--- a/server.go
+++ b/server.go
@@ -2384,7 +2384,13 @@ func (srv *Server) IsRunning() bool {
 }
 
 func (srv *Server) Close() error {
+	if srv == nil {
+		return nil
+	}
 	srv.SetRunning(false)
+	if srv.runtime == nil {
+		return nil
+	}
 	return srv.runtime.Close()
 }
 


### PR DESCRIPTION
Fix issue causing lxc to start and stop after 5 sec with `Can't start container` error.

In lxc 1.0, the lxc-info is not capitalized.
