### PR TITLE
Make docker run in it's own mount and pid namespace

### DIFF
--- a/pkg/system/unsupported.go
+++ b/pkg/system/unsupported.go
@@ -10,6 +10,10 @@ func SetCloneFlags(cmd *exec.Cmd, flag uintptr) {
 
 }
 
+func ParentDeathSignal() error {
+	return ErrNotSupportedPlatform
+}
+
 func UsetCloseOnExec(fd uintptr) error {
 	return ErrNotSupportedPlatform
 }


### PR DESCRIPTION
This allows all child processes to be removed and mounts to be cleaned
automatically.  It also keeps the mounts from showing up on the host for
containers.

This needs testing with the devicemapper cleanup scripts.  It also allows us to remove the PID kill on boot for ghosts because it is impossible to get ghost containers with this.  

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
