### PR TITLE
improve deprecation message

### DIFF
--- a/pkg/mflag/example/example.go
+++ b/pkg/mflag/example/example.go
@@ -13,7 +13,8 @@ var (
 
 func init() {
 	flag.Bool([]string{"#hp", "#-halp"}, false, "display the halp")
-	flag.BoolVar(&b, []string{"b"}, false, "a simple bool")
+	flag.BoolVar(&b, []string{"b", "#bal", "#bol", "-bal"}, false, "a simple bool")
+	flag.BoolVar(&b, []string{"g", "#gil"}, false, "a simple bool")
 	flag.BoolVar(&b2, []string{"#-bool"}, false, "a simple bool")
 	flag.IntVar(&i, []string{"-integer", "-number"}, -1, "a simple integer")
 	flag.StringVar(&str, []string{"s", "#hidden", "-string"}, "", "a simple string") //-s -hidden and --string will work, but -hidden won't be in the usage

--- a/pkg/mflag/flag.go
+++ b/pkg/mflag/flag.go
@@ -820,9 +820,20 @@ func (f *FlagSet) parseOne() (bool, string, error) {
 		f.actual = make(map[string]*Flag)
 	}
 	f.actual[name] = flag
-	for _, n := range flag.Names {
+	for i, n := range flag.Names {
 		if n == fmt.Sprintf("#%s", name) {
-			fmt.Fprintf(f.out(), "Warning: '-%s' is deprecated, it will be removed soon. See usage.\n", name)
+			replacement := ""
+			for j := i; j < len(flag.Names); j++ {
+				if flag.Names[j][0] != '#' {
+					replacement = flag.Names[j]
+					break
+				}
+			}
+			if replacement != "" {
+				fmt.Fprintf(f.out(), "Warning: '-%s' is deprecated, it will be replaced by '-%s' soon. See usage.\n", name, replacement)
+			} else {
+				fmt.Fprintf(f.out(), "Warning: '-%s' is deprecated, it will be removed soon. See usage.\n", name)
+			}
 		}
 	}
 	return true, "", nil


### PR DESCRIPTION
We you hit a deprecated flag, it'll try to find a valid replacement in the next ones.

```
docker pull -t ubuntu 
Warning: '-t' is deprecated, it will be removed soon. See usage.
....
```

because `-t` will be removed, to replaced.

---

```
docker run -name ls ubuntu ls
Warning: '-name' is deprecated, it will be replaced by '--name' soon. See usage.
...
```
