### PR TITLE
static registry support

### DIFF
--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -22,11 +22,11 @@ func spawnTestRegistry(t *testing.T) *Registry {
 }
 
 func TestPingRegistryEndpoint(t *testing.T) {
-	standalone, err := pingRegistryEndpoint(makeURL("/v1/"))
+	regInfo, err := pingRegistryEndpoint(makeURL("/v1/"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertEqual(t, standalone, true, "Expected standalone to be true (default)")
+	assertEqual(t, regInfo.Standalone, true, "Expected standalone to be true (default)")
 }
 
 func TestGetRemoteHistory(t *testing.T) {


### PR DESCRIPTION
For a pull-only, static registry, there only a couple of headers that
need to be optional (that are presently required.
- X-Docker-Registry-Version
- X-Docker-Size
- X-Docker-Endpoints

To support current behavior, and re-use API, let's put version and standalone
information into the _ping. And to support Headers they are checked after the
JSON is loaded (if there is anything to load). To stay backwards compatible, if
the _ping contents are not able to unmarshal to RegistryInfo, do not stop, but
continue with the same behavior.

Conversation was had on list as well. https://groups.google.com/forum/#!topic/docker-dev/8SOGjSzK5Hg
