### PR TITLE
Add process supervisor pkg for mananging and spawning multiple processes

### DIFF
--- a/pkg/libcontainer/nsinit/exec.go
+++ b/pkg/libcontainer/nsinit/exec.go
@@ -69,7 +69,7 @@ func (ns *linuxNs) Exec(container *libcontainer.Container, term Terminal, args [
 			return -1, err
 		}
 	}
-	return command.ProcessState.Sys().(syscall.WaitStatus).ExitStatus(), nil
+	return system.GetExitCode(command), nil
 }
 
 func (ns *linuxNs) SetupCgroups(container *libcontainer.Container, nspid int) error {

--- a/pkg/supervisor/README.md
+++ b/pkg/supervisor/README.md
@@ -1,0 +1,3 @@
+### Supervisor
+
+Supervisor is a small go pkg to manage one or many processes, handle signals to those processes, and allow proper cleanup.

--- a/pkg/supervisor/example/config.json
+++ b/pkg/supervisor/example/config.json
@@ -1,0 +1,2 @@
+[{"args":["sh"], "attach_std":true},
+{"args":["ps", "aux"], "attach_std":true}]

--- a/pkg/supervisor/example/main.go
+++ b/pkg/supervisor/example/main.go
@@ -1,0 +1,68 @@
+// Simple application to run multiple processes like supervisord
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/dotcloud/docker/pkg/signal"
+	"github.com/dotcloud/docker/pkg/supervisor"
+	"log"
+	"os"
+	"syscall"
+	"time"
+)
+
+type process struct {
+	Args      []string `json:"args"`
+	AttachStd bool     `json:"attach_std"`
+}
+
+func main() {
+	var processes []*process
+	f, err := os.Open("config.json")
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := json.NewDecoder(f).Decode(&processes); err != nil {
+		f.Close()
+		log.Fatal(err)
+	}
+	f.Close()
+
+	var (
+		s    = supervisor.New()
+		sigc = make(chan os.Signal, 1)
+	)
+
+	signal.CatchAll(sigc)
+	go func() {
+		var err error
+		for sig := range sigc {
+			log.Printf("received signal %v", sig)
+
+			switch sig {
+			case syscall.SIGCHLD:
+				continue
+			case syscall.SIGTERM, syscall.SIGINT:
+				err = s.Reap(sig, 10*time.Second)
+				os.Exit(0)
+			default:
+				err = s.Forward(sig)
+			}
+			if err != nil {
+				log.Printf("signal error %s\n", err)
+			}
+		}
+	}()
+
+	for i, p := range processes {
+		if err := s.Start(fmt.Sprint(i), p.AttachStd, os.Environ(), nil, p.Args...); err != nil {
+			s.Reap(syscall.SIGTERM, 10*time.Second)
+			log.Fatal(err)
+		}
+	}
+
+	if err := s.Wait(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/supervisor/process.go
+++ b/pkg/supervisor/process.go
@@ -1,0 +1,88 @@
+package supervisor
+
+import (
+	"github.com/dotcloud/docker/pkg/system"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+type Process struct {
+	cmd     *exec.Cmd
+	stopped bool
+}
+
+func NewProcess(args, env []string, attachStd bool) *Process {
+	cmd := exec.Command(args[0], args[1:]...)
+	if attachStd {
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		cmd.Stdin = os.Stdin
+	}
+	cmd.Env = env
+
+	return &Process{
+		cmd: cmd,
+	}
+}
+
+func (p *Process) Start() error {
+	return p.cmd.Start()
+}
+
+func (p *Process) Pid() int {
+	return p.cmd.Process.Pid
+}
+
+func (p *Process) Kill() error {
+	if p.stopped {
+		return nil
+	}
+	err := p.cmd.Process.Kill()
+	p.stopped = true
+	return err
+}
+
+func (p *Process) ExitCode() int {
+	return system.GetExitCode(p.cmd)
+}
+
+func (p *Process) Signal(sig os.Signal) error {
+	return p.cmd.Process.Signal(sig)
+}
+
+func (p *Process) Wait() error {
+	if err := p.cmd.Wait(); err != nil {
+		if _, ok := err.(*exec.ExitError); !ok {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Process) Reap() error {
+	if p.stopped {
+		return nil
+	}
+	err := p.Kill()
+
+	for {
+		pid, werr := syscall.Wait4(-1, nil, syscall.WNOHANG, nil)
+		if werr != nil {
+			switch werr {
+			case syscall.EAGAIN:
+				time.Sleep(10 * time.Millisecond)
+				continue
+			default:
+				if err == nil {
+					err = werr
+				}
+			}
+		}
+		if werr == nil && pid == p.Pid() {
+			break
+		}
+	}
+	return err
+}

--- a/pkg/supervisor/supervisor.go
+++ b/pkg/supervisor/supervisor.go
@@ -1,0 +1,112 @@
+package supervisor
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"time"
+)
+
+var (
+	ErrProcessAlreadyExists = errors.New("process already exists for given name")
+)
+
+type (
+	// ExitCallback is called with the exit code and any error encountered by the run
+	ExitCallback func(int, error)
+	Processes    map[string]*Process
+
+	Supervisor struct {
+		sync.Mutex
+		group sync.WaitGroup
+
+		processes Processes
+	}
+)
+
+// New creates a new process supervisor
+func New() *Supervisor {
+	return &Supervisor{
+		processes: Processes{},
+		group:     sync.WaitGroup{},
+	}
+}
+
+// Start a new processes under supervision
+//
+// name should be unique for all processes
+// args should be presented as argv[0], args[1:]...
+func (s *Supervisor) Start(name string, attachStd bool, env []string, callback ExitCallback, args ...string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if _, exists := s.processes[name]; exists {
+		return ErrProcessAlreadyExists
+	}
+	process := NewProcess(args, env, attachStd)
+
+	if err := process.Start(); err != nil {
+		return err
+	}
+
+	s.processes[name] = process
+	s.group.Add(1)
+	go func() {
+		var (
+			err  = process.Wait()
+			exit = process.ExitCode()
+		)
+		if callback != nil {
+			callback(exit, err)
+		}
+		s.Lock()
+		delete(s.processes, name)
+		s.Unlock()
+		s.group.Done()
+	}()
+	return nil
+}
+
+// Forward forwards signals to the child processes
+func (s *Supervisor) Forward(sig os.Signal) error {
+	s.Lock()
+	defer s.Unlock()
+
+	var err error
+	for _, process := range s.processes {
+		if perr := process.Signal(sig); err == nil {
+			err = perr
+		}
+	}
+	return err
+}
+
+// Wait will wait on all processes being supervised
+func (s *Supervisor) Wait() error {
+	s.group.Wait()
+	return nil
+}
+
+func (s *Supervisor) Reap(sig os.Signal, timeout time.Duration) error {
+	err := s.Forward(sig)
+	c := make(chan struct{})
+
+	go func() {
+		s.Wait()
+		c <- struct{}{}
+	}()
+	t := time.NewTicker(timeout)
+	defer t.Stop()
+
+	select {
+	case <-c:
+		return err
+	case <-t.C:
+		for _, p := range s.processes {
+			if perr := p.Reap(); err == nil {
+				err = perr
+			}
+		}
+	}
+	return err
+}

--- a/pkg/system/command.go
+++ b/pkg/system/command.go
@@ -1,0 +1,13 @@
+package system
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func GetExitCode(cmd *exec.Cmd) int {
+	if cmd.ProcessState == nil {
+		return -1
+	}
+	return cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+}


### PR DESCRIPTION
This is still a work in progress.  This will be used to manage a long running docker init and act as pid 1 and a process supervisor for multiple processes.  

ping @creack  I'll probably need you to review the signal forwarding and reaping code, i think you already did this once before but I could not find the PR. 

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
