### PR TITLE
Add simple command-based execdriver.

### DIFF
--- a/daemonconfig/config.go
+++ b/daemonconfig/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	InterContainerCommunication bool
 	GraphDriver                 string
 	ExecDriver                  string
+	ExecOptions                 string
 	Mtu                         int
 	DisableNetwork              bool
 }
@@ -45,6 +46,7 @@ func ConfigFromJob(job *engine.Job) *Config {
 		InterContainerCommunication: job.GetenvBool("InterContainerCommunication"),
 		GraphDriver:                 job.Getenv("GraphDriver"),
 		ExecDriver:                  job.Getenv("ExecDriver"),
+		ExecOptions:                 job.Getenv("ExecOptions"),
 	}
 	if dns := job.GetenvList("Dns"); dns != nil {
 		config.Dns = dns

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -41,6 +41,7 @@ func main() {
 		flInterContainerComm = flag.Bool([]string{"#icc", "-icc"}, true, "Enable inter-container communication")
 		flGraphDriver        = flag.String([]string{"s", "-storage-driver"}, "", "Force the docker runtime to use a specific storage driver")
 		flExecDriver         = flag.String([]string{"e", "-exec-driver"}, "native", "Force the docker runtime to use a specific exec driver")
+		flExecOptions        = flag.String([]string{"o", "-exec-options"}, "", "Provide options to the given exec driver")
 		flHosts              = opts.NewListOpts(api.ValidateHost)
 		flMtu                = flag.Int([]string{"#mtu", "-mtu"}, 0, "Set the containers network MTU; if no value is provided: default to the default route MTU or 1500 if no default route is available")
 	)
@@ -123,6 +124,7 @@ func main() {
 			job.SetenvBool("InterContainerCommunication", *flInterContainerComm)
 			job.Setenv("GraphDriver", *flGraphDriver)
 			job.Setenv("ExecDriver", *flExecDriver)
+			job.Setenv("ExecOptions", *flExecOptions)
 			job.SetenvInt("Mtu", *flMtu)
 			if err := job.Run(); err != nil {
 				log.Fatal(err)

--- a/execdriver/driver.go
+++ b/execdriver/driver.go
@@ -51,6 +51,7 @@ type InitArgs struct {
 	Args       []string
 	Mtu        int
 	Driver     string
+	Options    string
 	Console    string
 	Pipe       int
 	Root       string

--- a/execdriver/execdrivers/execdrivers.go
+++ b/execdriver/execdrivers/execdrivers.go
@@ -5,6 +5,7 @@ import (
 	"github.com/dotcloud/docker/execdriver"
 	"github.com/dotcloud/docker/execdriver/lxc"
 	"github.com/dotcloud/docker/execdriver/native"
+	"github.com/dotcloud/docker/execdriver/shell"
 	"github.com/dotcloud/docker/pkg/sysinfo"
 	"path"
 )
@@ -18,6 +19,8 @@ func NewDriver(name, root, options string, sysInfo *sysinfo.SysInfo) (execdriver
 		return lxc.NewDriver(root, options, sysInfo.AppArmor)
 	case "native":
 		return native.NewDriver(path.Join(root, "execdriver", "native"), options)
+	case "shell":
+		return shell.NewDriver(root, options)
 	}
 	return nil, fmt.Errorf("unknown exec driver %s", name)
 }

--- a/execdriver/execdrivers/execdrivers.go
+++ b/execdriver/execdrivers/execdrivers.go
@@ -9,15 +9,15 @@ import (
 	"path"
 )
 
-func NewDriver(name, root string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
+func NewDriver(name, root, options string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
 	switch name {
 	case "lxc":
 		// we want to five the lxc driver the full docker root because it needs
 		// to access and write config and template files in /var/lib/docker/containers/*
 		// to be backwards compatible
-		return lxc.NewDriver(root, sysInfo.AppArmor)
+		return lxc.NewDriver(root, options, sysInfo.AppArmor)
 	case "native":
-		return native.NewDriver(path.Join(root, "execdriver", "native"))
+		return native.NewDriver(path.Join(root, "execdriver", "native"), options)
 	}
 	return nil, fmt.Errorf("unknown exec driver %s", name)
 }

--- a/execdriver/lxc/driver.go
+++ b/execdriver/lxc/driver.go
@@ -55,11 +55,12 @@ func init() {
 
 type driver struct {
 	root       string // root path for the driver to use
+	options    string
 	apparmor   bool
 	sharedRoot bool
 }
 
-func NewDriver(root string, apparmor bool) (*driver, error) {
+func NewDriver(root, options string, apparmor bool) (*driver, error) {
 	// setup unconfined symlink
 	if err := linkLxcStart(root); err != nil {
 		return nil, err
@@ -67,6 +68,7 @@ func NewDriver(root string, apparmor bool) (*driver, error) {
 	return &driver{
 		apparmor:   apparmor,
 		root:       root,
+		options:    options,
 		sharedRoot: rootIsShared(),
 	}, nil
 }
@@ -92,6 +94,8 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 		c.InitPath,
 		"-driver",
 		DriverName,
+		"-options",
+		d.options,
 	}
 
 	if c.Network != nil {

--- a/execdriver/native/driver.go
+++ b/execdriver/native/driver.go
@@ -55,10 +55,11 @@ func init() {
 }
 
 type driver struct {
-	root string
+	root    string
+	options string
 }
 
-func NewDriver(root string) (*driver, error) {
+func NewDriver(root, options string) (*driver, error) {
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, err
 	}
@@ -66,7 +67,8 @@ func NewDriver(root string) (*driver, error) {
 		return nil, err
 	}
 	return &driver{
-		root: root,
+		root:    root,
+		options: options,
 	}, nil
 }
 
@@ -214,6 +216,7 @@ func (d *dockerCommandFactory) Create(container *libcontainer.Container, console
 	d.c.Args = append([]string{
 		initPath,
 		"-driver", DriverName,
+		"-options", d.driver.options,
 		"-console", console,
 		"-pipe", "3",
 		"-root", filepath.Join(d.driver.root, d.c.ID),

--- a/execdriver/shell/driver.go
+++ b/execdriver/shell/driver.go
@@ -1,0 +1,313 @@
+package shell
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/execdriver"
+	"io"
+	"os"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+const DriverName = "shell"
+
+const (
+	CommandInit  = "init"
+	CommandStart = "start"
+)
+
+type driver struct {
+	root    string
+	options string
+	args    []string
+	pids    map[string]int
+	sync.RWMutex
+}
+
+type info struct {
+	id     string
+	driver *driver
+}
+
+func (d *driver) do_wait(cmd *exec.Cmd, exit_chan chan int) {
+	for {
+		// NOTE: The Wait() function will also take
+		// care of closing stdin, stdout & stderr pipes
+		// once the process exits.
+		err := cmd.Wait()
+
+		if err != nil {
+			_, ok := err.(*exec.ExitError)
+			if ok {
+				// Wut? It seems we can't actually get the
+				// exit code when we use the exec interface.
+				// Woah, that sucks. For the moment, we'll
+				// use 1 as a stand-in for all error codes.
+				exit_chan <- 1
+				break
+			} else {
+				// A different problem?
+				// Maybe I/O related? We need to make sure
+				// the process is cleaned up, so wait until
+				// we catch the exit properly.
+				continue
+			}
+		} else {
+			// Success.
+			exit_chan <- 0
+			break
+		}
+	}
+}
+
+func (d *driver) do_exec(
+	command string,
+	args []string,
+	workDir string,
+	env []string,
+	stdin io.ReadCloser,
+	stdout io.Writer,
+	stderr io.Writer) (int, chan int, error) {
+
+	new_args := d.args[:]
+	new_args = append(new_args, command)
+	new_args = append(new_args, args...)
+
+	cmd := exec.Command(new_args[0], new_args[1:]...)
+	cmd.Dir = workDir
+	cmd.Env = env
+
+	var err error
+	var cmd_stdin io.WriteCloser
+	var cmd_stdout io.ReadCloser
+	var cmd_stderr io.ReadCloser
+
+	if stdin != nil {
+		cmd_stdin, err = cmd.StdinPipe()
+		if err != nil {
+			return -1, nil, err
+		}
+		go io.Copy(cmd_stdin, stdin)
+	}
+
+	if stdout != nil {
+		cmd_stdout, err = cmd.StdoutPipe()
+		if err != nil {
+			if cmd_stdin != nil {
+				cmd_stdin.Close()
+			}
+			return -1, nil, err
+		}
+		go io.Copy(stdout, cmd_stdout)
+	}
+
+	if stderr != nil {
+		cmd_stderr, err = cmd.StderrPipe()
+		if err != nil {
+			if cmd_stdin != nil {
+				cmd_stdin.Close()
+			}
+			if cmd_stdout != nil {
+				cmd_stdout.Close()
+			}
+			return -1, nil, err
+		}
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		if cmd_stdin != nil {
+			cmd_stdin.Close()
+		}
+		if cmd_stdout != nil {
+			cmd_stdout.Close()
+		}
+		if cmd_stderr != nil {
+			cmd_stderr.Close()
+		}
+		return -1, nil, err
+	}
+
+	// Make sure we don't leave zombies.
+	exit_chan := make(chan int, 1)
+	go d.do_wait(cmd, exit_chan)
+
+	// Done.
+	return cmd.Process.Pid, exit_chan, err
+}
+
+func init() {
+	execdriver.RegisterInitFunc(DriverName, func(args *execdriver.InitArgs) error {
+		// This function is only called when we are run from dockerinit,
+		// during which we are potentially already inside a container.
+		// We simply execute the function as given.
+		path, err := exec.LookPath(args.Args[0])
+		if err != nil {
+			return err
+		}
+
+		// Move into our working directory.
+		if args.WorkDir != "" {
+			err = os.Chdir(args.WorkDir)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Set our user.
+		if args.User != "" {
+			user, err := user.Lookup(args.User)
+			if err != nil {
+				return err
+			}
+			userid, err := strconv.ParseInt(user.Uid, 0, 64)
+			if err != nil {
+				return err
+			}
+			err = syscall.Setuid(int(userid))
+			if err != nil {
+				return err
+			}
+		}
+
+		// Execute the new process.
+		return syscall.Exec(path, args.Args, args.Env)
+	})
+}
+
+func NewDriver(root, options string) (*driver, error) {
+	args := strings.Split(options, " ")
+	if len(args) == 0 {
+		return nil, fmt.Errorf("no arguments provided?")
+	}
+
+	// Our driver.
+	d := &driver{
+		root:    root,
+		options: options,
+		args:    args,
+		pids:    make(map[string]int),
+	}
+
+	// Run our external init.
+	_, exit_chan, err := d.do_exec(CommandInit, []string{}, root, nil, nil, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wait for init to finish.
+	exit_code := <-exit_chan
+	if exit_code != 0 {
+		return nil, fmt.Errorf("shell process returned '%d' for init", exit_code)
+	}
+
+	return d, nil
+}
+
+func (d *driver) Name() string {
+	return DriverName
+}
+
+func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
+
+	// Allocate our terminal.
+	err := execdriver.SetTerminal(c, pipes)
+	if err != nil {
+		return -1, err
+	}
+
+	// Export our configuration.
+	extra_env := make([]string, 0, 0)
+	extra_env = append(extra_env, fmt.Sprintf("DOCKER_ID=%s", c.ID))
+	extra_env = append(extra_env, fmt.Sprintf("DOCKER_ROOTFS=%s", c.Rootfs))
+	extra_env = append(extra_env, c.Config...)
+
+	args := make([]string, 0, 0)
+	args = append(args, c.InitPath)
+	args = append(args, "-driver", DriverName)
+	args = append(args, "-options", d.options)
+
+	if c.Network != nil {
+		extra_env = append(extra_env, fmt.Sprintf("DOCKER_BRIDGE=%s", c.Network.Bridge))
+		extra_env = append(extra_env, fmt.Sprintf("DOCKER_MTU=%d", c.Network.Mtu))
+		args = append(args, "-g", c.Network.Gateway)
+		args = append(args, "-i", fmt.Sprintf("%s/%d", c.Network.IPAddress, c.Network.IPPrefixLen))
+		args = append(args, "-mtu", strconv.Itoa(c.Network.Mtu))
+	}
+	if c.User != "" {
+		args = append(args, "-u", c.User)
+	}
+	if c.WorkingDir != "" {
+		args = append(args, "-w", c.WorkingDir)
+	}
+
+	args = append(args, "--")
+	args = append(args, c.Entrypoint)
+	args = append(args, c.Arguments...)
+
+	// Start our process.
+	pid, exit_chan, err := d.do_exec(
+		CommandStart,
+		args,
+		d.root,
+		extra_env,
+		pipes.Stdin,
+		pipes.Stdout,
+		pipes.Stderr)
+	if err != nil {
+		return pid, err
+	}
+
+	// Remember that this is running.
+	d.RWMutex.Lock()
+	d.pids[c.ID] = pid
+	d.RWMutex.Unlock()
+
+	// Save our pid, and notify of startup.
+	c.ContainerPid = pid
+	if startCallback != nil {
+		startCallback(c)
+	}
+
+	// Wait for exit.
+	exit_code := <-exit_chan
+
+	// We're not running.
+	d.RWMutex.Lock()
+	delete(d.pids, c.ID)
+	d.RWMutex.Unlock()
+
+	return exit_code, err
+}
+
+func (d *driver) Kill(c *execdriver.Command, sig int) error {
+	return syscall.Kill(c.ContainerPid, syscall.Signal(sig))
+}
+
+func (d *driver) Info(id string) execdriver.Info {
+	return &info{
+		id:     id,
+		driver: d,
+	}
+}
+
+func (d *driver) GetPidsForContainer(id string) ([]int, error) {
+	d.RWMutex.RLock()
+	defer d.RWMutex.RUnlock()
+	pids := make([]int, 0, 0)
+	for _, pid := range d.pids {
+		pids = append(pids, pid)
+	}
+	return pids, nil
+}
+
+func (i *info) IsRunning() bool {
+	i.driver.RWMutex.RLock()
+	defer i.driver.RWMutex.RUnlock()
+	_, ok := i.driver.pids[i.id]
+	return ok
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -733,7 +733,7 @@ func NewRuntimeFromDirectory(config *daemonconfig.Config, eng *engine.Engine) (*
 	}
 
 	sysInfo := sysinfo.New(false)
-	ed, err := execdrivers.NewDriver(config.ExecDriver, config.Root, sysInfo)
+	ed, err := execdrivers.NewDriver(config.ExecDriver, config.Root, config.ExecOptions, sysInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dotcloud/docker/execdriver"
 	_ "github.com/dotcloud/docker/execdriver/lxc"
 	_ "github.com/dotcloud/docker/execdriver/native"
+	_ "github.com/dotcloud/docker/execdriver/shell"
 	"io/ioutil"
 	"log"
 	"os"

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -53,6 +53,7 @@ func SysInit() {
 		privileged = flag.Bool("privileged", false, "privileged mode")
 		mtu        = flag.Int("mtu", 1500, "interface mtu")
 		driver     = flag.String("driver", "", "exec driver")
+		options    = flag.String("options", "", "exec driver options")
 		pipe       = flag.Int("pipe", 0, "sync pipe fd")
 		console    = flag.String("console", "", "console (pty slave) path")
 		root       = flag.String("root", ".", "root path for configuration files")
@@ -81,6 +82,7 @@ func SysInit() {
 		Args:       flag.Args(),
 		Mtu:        *mtu,
 		Driver:     *driver,
+		Options:    *options,
 		Console:    *console,
 		Pipe:       *pipe,
 		Root:       *root,


### PR DESCRIPTION
This was done pretty quickly (and is my first docker patch), so it may need refinement and definitely needs a bit more testing prior to merging. I'm sending the PR right away in order to get feedback!

These patches do two things:
1) Plumb through options (a simple string) to the exec driver. This may be necessary for future drivers (perhaps even slightly more complex).
2) Enable a very simple backend that will allows one to specify a command to run for initialization (on NewDriver) and for starting docker instances. In the long run, I think this will be very valuable in building out new execdrivers and enables writing execdrivers as plugins (by writing a wrapper, then using the shell execdriver).
