### PR TITLE
Fix port collision with dynamically allocated ports

### DIFF
--- a/runtime/networkdriver/portallocator/portallocator.go
+++ b/runtime/networkdriver/portallocator/portallocator.go
@@ -151,8 +151,9 @@ func equalsDefault(ip net.IP) bool {
 }
 
 func findNextPort(proto string, allocated *collections.OrderedIntSet) (int, error) {
-	port := 0
-	for port = nextPort(proto); allocated.Exists(port); port = nextPort(proto) {
+	port := nextPort(proto)
+	for allocated.Exists(port) {
+		port = nextPort(proto)
 	}
 	if port > EndPortRange {
 		return 0, ErrPortExceedsRange

--- a/runtime/networkdriver/portallocator/portallocator_test.go
+++ b/runtime/networkdriver/portallocator/portallocator_test.go
@@ -186,6 +186,6 @@ func TestPortAllocation(t *testing.T) {
 	port2, err := RequestPort(ip, "tcp", port+1)
 	port3, err := RequestPort(ip, "tcp", 0)
 	if port3 == port2 {
-		t.Fatal("A dynamic port should never allocate a used port")
+		t.Fatal("Requesting a dynamic port should never allocate a used port")
 	}
 }

--- a/runtime/networkdriver/portallocator/portallocator_test.go
+++ b/runtime/networkdriver/portallocator/portallocator_test.go
@@ -181,4 +181,11 @@ func TestPortAllocation(t *testing.T) {
 	if _, err := RequestPort(ip, "tcp", 80); err != nil {
 		t.Fatal(err)
 	}
+
+	port, err = RequestPort(ip, "tcp", 0)
+	port2, err := RequestPort(ip, "tcp", port+1)
+	port3, err := RequestPort(ip, "tcp", 0)
+	if port3 == port2 {
+		t.Fatal("A dynamic port should never allocate a used port")
+	}
 }

--- a/runtime/networkdriver/portallocator/portallocator_test.go
+++ b/runtime/networkdriver/portallocator/portallocator_test.go
@@ -183,8 +183,17 @@ func TestPortAllocation(t *testing.T) {
 	}
 
 	port, err = RequestPort(ip, "tcp", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	port2, err := RequestPort(ip, "tcp", port+1)
+	if err != nil {
+		t.Fatal(err)
+	}
 	port3, err := RequestPort(ip, "tcp", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if port3 == port2 {
 		t.Fatal("Requesting a dynamic port should never allocate a used port")
 	}


### PR DESCRIPTION
Currently its possible for a container to fail to start because the portallocator can allocate a dynamic port that is currently in use. This PR fixes the issue by ensuring that a dynamically allocated port is not in use before assigning it.

This is most likely to happen when you have running containers and restart the docker daemon. Docker will start the containers back up on their previously allocated port(s), but new containers will still attempt to allocate these ports and fail to start. Looks to be a problem since 0.8.0 (no issues in 0.7.6 and earlier).

Steps to reproduce:

```
$ docker run -t -i -d -p :8000 base 
27627ddc8084093cee8c6adc9eecaadc19fe9153b41bbc47d8882227a0593464

$ sudo service docker restart
docker stop/waiting
docker start/running, process 5945

$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                     NAMES
27627ddc8084        base:latest         bash                16 seconds ago      Up 3 seconds        0.0.0.0:49153->8000/tcp   lonely_mccarthy

$ docker run -t -i -d -p :8000 base bash
8d9face480f2774f528b7f7e338fde9c039b57ec7ebe6f09815e53884fbae2ea
2014/03/12 17:54:11 Error: start: Cannot start container 8d9face480f2774f528b7f7e338fde9c039b57ec7ebe6f09815e53884fbae2ea: allocate_port: port is already mapped to ip
```
