### PR TITLE
Some minor fixes for cli docs

### DIFF
--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -608,8 +608,8 @@ To see how the ``docker:latest`` image was built:
       -a, --all=false: Show all images (by default filter out the intermediate images used to build)
       --no-trunc=false: Don't truncate output
       -q, --quiet=false: Only show numeric IDs
-      --tree=false: Output graph in tree format
-      --viz=false: Output graph in graphviz format
+      -t, --tree=false: Output graph in tree format
+      -v, --viz=false: Output graph in graphviz format
 
 Listing the most recently created images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -82,7 +82,6 @@ Commands
       --ip="0.0.0.0": Default IP address to use when binding container ports
       --ip-forward=true: Enable net.ipv4.ip_forward
       --iptables=true: Enable Docker's addition of iptables rules
-      --mtu=0: Set the containers network MTU; if no value is provided: default to the default route MTU or 1500 if not default route is available
       -p, --pidfile="/var/run/docker.pid": Path to use for daemon PID file
       -r, --restart=true: Restart previously running containers
       -s, --storage-driver="": Force the docker runtime to use a specific storage driver


### PR DESCRIPTION
This Pull Request includes following 2 commits

**Fix duplication of --mtu option's description of daemon doc**

--mtu option's description was duplicated by commit baa70e9 like

```
  --mtu=0: Set the containers network MTU; if no value is provided: default to the default route MTU or 1500 if not default route is available
  -p, --pidfile="/var/run/docker.pid": Path to use for daemon PID file
  -r, --restart=true: Restart previously running containers
  -s, --storage-driver="": Force the docker runtime to use a specific storage driver
  -e, --exec-driver="native": Force the docker runtime to use a specific exec driver
  -v, --version=false: Print version information and quit
  --mtu=0: Set the containers network MTU; if no value is provided: default to the default route MTU or 1500 if no default route is available
```

**Add -t and -v option to images subcommand doc**

Images subcommand has -t option as synonym of --tree and -v option as synonym of --viz.
The doc described --tree and --viz but there were no -t and -v.
