### PR TITLE
btrfs: build tags

### DIFF
--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -175,7 +175,7 @@ To disable aufs:
 export DOCKER_BUILDTAGS='exclude_graphdriver_aufs'
 ```
 
-NOTE: if you need to set more than one build tag, space seperate them.
+NOTE: if you need to set more than one build tag, space separate them.
 
 ### Static Daemon
 

--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -160,14 +160,22 @@ export DOCKER_BUILDTAGS='apparmor'
 There are build tags for disabling graphdrivers as well. By default, support
 for all graphdrivers are built in.
 
-To disable devicemapper
+To disable btrfs:
+```bash
+export DOCKER_BUILDTAGS='exclude_graphdriver_btrfs'
+```
+
+To disable devicemapper:
 ```bash
 export DOCKER_BUILDTAGS='exclude_graphdriver_devicemapper'
 ```
-To disable aufs
+
+To disable aufs:
 ```bash
 export DOCKER_BUILDTAGS='exclude_graphdriver_aufs'
 ```
+
+NOTE: if you need to set more than one build tag, space seperate them.
 
 ### Static Daemon
 

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -16,7 +16,6 @@ import (
 	"github.com/dotcloud/docker/runtime/execdriver/execdrivers"
 	"github.com/dotcloud/docker/runtime/execdriver/lxc"
 	"github.com/dotcloud/docker/runtime/graphdriver"
-	_ "github.com/dotcloud/docker/runtime/graphdriver/btrfs"
 	_ "github.com/dotcloud/docker/runtime/graphdriver/vfs"
 	_ "github.com/dotcloud/docker/runtime/networkdriver/lxc"
 	"github.com/dotcloud/docker/runtime/networkdriver/portallocator"

--- a/runtime/runtime_btfs.go
+++ b/runtime/runtime_btfs.go
@@ -1,0 +1,7 @@
+// +build !no_btrfs
+
+package runtime
+
+import (
+	_ "github.com/dotcloud/docker/runtime/graphdriver/btrfs"
+)

--- a/runtime/runtime_btrfs.go
+++ b/runtime/runtime_btrfs.go
@@ -1,4 +1,4 @@
-// +build !no_btrfs
+// +build !exclude_graphdriver_btrfs
 
 package runtime
 


### PR DESCRIPTION
Default to the same build behavior, but allow a go build tag to disable
building of the btrfs graphdriver

```
$ go build
$ objdump -S docker | grep btrfs | wc -l
194
$ go build -tags no_btrfs
$ objdump -S docker | grep btrfs | wc -l
1
```

that is a comment ;-)

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
