### PR TITLE
Fix expose cache

### DIFF
--- a/integration/buildfile_test.go
+++ b/integration/buildfile_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/image"
+	"github.com/dotcloud/docker/nat"
 	"github.com/dotcloud/docker/utils"
 	"io/ioutil"
 	"net"
@@ -492,7 +493,7 @@ func TestBuildExpose(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if img.Config.PortSpecs[0] != "4243" {
+	if _, exists := img.Config.ExposedPorts[nat.NewPort("tcp", "4243")]; !exists {
 		t.Fail()
 	}
 }
@@ -589,6 +590,17 @@ func TestBuildImageWithCache(t *testing.T) {
 	template := testContextTemplate{`
         from {IMAGE}
         maintainer dockerio
+        `,
+		nil, nil}
+	checkCacheBehavior(t, template, true)
+}
+
+func TestBuildExposeWithCache(t *testing.T) {
+	template := testContextTemplate{`
+        from {IMAGE}
+        maintainer dockerio
+	expose 80
+	run echo hello
         `,
 		nil, nil}
 	checkCacheBehavior(t, template, true)
@@ -877,7 +889,7 @@ func TestBuildInheritance(t *testing.T) {
 	}
 
 	// from parent
-	if img.Config.PortSpecs[0] != "4243" {
+	if _, exists := img.Config.ExposedPorts[nat.NewPort("tcp", "4243")]; !exists {
 		t.Fail()
 	}
 }

--- a/runconfig/merge.go
+++ b/runconfig/merge.go
@@ -64,6 +64,7 @@ func Merge(userConf, imageConf *Config) error {
 			}
 		}
 	}
+
 	if !userConf.Tty {
 		userConf.Tty = imageConf.Tty
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -542,7 +542,6 @@ func (runtime *Runtime) Create(config *runconfig.Config, name string) (*Containe
 // The image can optionally be tagged into a repository
 func (runtime *Runtime) Commit(container *Container, repository, tag, comment, author string, config *runconfig.Config) (*image.Image, error) {
 	// FIXME: freeze the container before copying it to avoid data corruption?
-	// FIXME: this shouldn't be in commands.
 	if err := container.Mount(); err != nil {
 		return nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -1970,7 +1970,6 @@ func (srv *Server) canDeleteImage(imgID string) error {
 }
 
 func (srv *Server) ImageGetCached(imgID string, config *runconfig.Config) (*image.Image, error) {
-
 	// Retrieve all images
 	images, err := srv.runtime.Graph().Map()
 	if err != nil {


### PR DESCRIPTION
This is not the proper way to go, however it does the trick.

The issue is with retrocompatiblity. runconfig.Merge should actually merge and not adapt for retrocompatiblity.
