### PR TITLE
graphdriver: build tags

### DIFF
--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -157,6 +157,23 @@ AppArmor, you will need to set `DOCKER_BUILDTAGS` as follows:
 export DOCKER_BUILDTAGS='apparmor'
 ```
 
+There are build tags for disabling graphdrivers as well. By default, support
+for all graphdrivers are built in.
+
+To disable vfs
+```bash
+export DOCKER_BUILDTAGS='exclude_graphdriver_vfs'
+```
+
+To disable devicemapper
+```bash
+export DOCKER_BUILDTAGS='exclude_graphdriver_devicemapper'
+```
+To disable aufs
+```bash
+export DOCKER_BUILDTAGS='exclude_graphdriver_aufs'
+```
+
 ### Static Daemon
 
 If it is feasible within the constraints of your distribution, you should

--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -160,11 +160,6 @@ export DOCKER_BUILDTAGS='apparmor'
 There are build tags for disabling graphdrivers as well. By default, support
 for all graphdrivers are built in.
 
-To disable vfs
-```bash
-export DOCKER_BUILDTAGS='exclude_graphdriver_vfs'
-```
-
 To disable devicemapper
 ```bash
 export DOCKER_BUILDTAGS='exclude_graphdriver_devicemapper'

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dotcloud/docker/runtime/execdriver/lxc"
 	"github.com/dotcloud/docker/runtime/graphdriver"
 	_ "github.com/dotcloud/docker/runtime/graphdriver/btrfs"
+	_ "github.com/dotcloud/docker/runtime/graphdriver/vfs"
 	_ "github.com/dotcloud/docker/runtime/networkdriver/lxc"
 	"github.com/dotcloud/docker/runtime/networkdriver/portallocator"
 	"github.com/dotcloud/docker/utils"

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -16,10 +16,7 @@ import (
 	"github.com/dotcloud/docker/runtime/execdriver/execdrivers"
 	"github.com/dotcloud/docker/runtime/execdriver/lxc"
 	"github.com/dotcloud/docker/runtime/graphdriver"
-	"github.com/dotcloud/docker/runtime/graphdriver/aufs"
 	_ "github.com/dotcloud/docker/runtime/graphdriver/btrfs"
-	_ "github.com/dotcloud/docker/runtime/graphdriver/devmapper"
-	_ "github.com/dotcloud/docker/runtime/graphdriver/vfs"
 	_ "github.com/dotcloud/docker/runtime/networkdriver/lxc"
 	"github.com/dotcloud/docker/runtime/networkdriver/portallocator"
 	"github.com/dotcloud/docker/utils"
@@ -652,11 +649,9 @@ func NewRuntimeFromDirectory(config *daemonconfig.Config, eng *engine.Engine) (*
 		return nil, err
 	}
 
-	if ad, ok := driver.(*aufs.Driver); ok {
-		utils.Debugf("Migrating existing containers")
-		if err := ad.Migrate(config.Root, graph.SetupInitLayer); err != nil {
-			return nil, err
-		}
+	// Migrate the container if it is aufs and aufs is enabled
+	if err = migrateIfAufs(driver, config.Root); err != nil {
+		return nil, err
 	}
 
 	utils.Debugf("Creating images graph")

--- a/runtime/runtime_aufs.go
+++ b/runtime/runtime_aufs.go
@@ -1,0 +1,22 @@
+// +build !exclude_graphdriver_aufs
+
+package runtime
+
+import (
+	"github.com/dotcloud/docker/graph"
+	"github.com/dotcloud/docker/runtime/graphdriver"
+	"github.com/dotcloud/docker/runtime/graphdriver/aufs"
+	"github.com/dotcloud/docker/utils"
+)
+
+// Given the graphdriver ad, if it is aufs, then migrate it.
+// If aufs driver is not built, this func is a noop.
+func migrateIfAufs(driver graphdriver.Driver, root string) error {
+	if ad, ok := driver.(*aufs.Driver); ok {
+		utils.Debugf("Migrating existing containers")
+		if err := ad.Migrate(root, graph.SetupInitLayer); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/runtime/runtime_devicemapper.go
+++ b/runtime/runtime_devicemapper.go
@@ -1,0 +1,7 @@
+// +build !exclude_graphdriver_devicemapper
+
+package runtime
+
+import (
+	_ "github.com/dotcloud/docker/runtime/graphdriver/devmapper"
+)

--- a/runtime/runtime_no_aufs.go
+++ b/runtime/runtime_no_aufs.go
@@ -1,0 +1,11 @@
+// +build exclude_graphdriver_aufs
+
+package runtime
+
+import (
+	"github.com/dotcloud/docker/runtime/graphdriver"
+)
+
+func migrateIfAufs(driver graphdriver.Driver, root string) error {
+	return nil
+}

--- a/runtime/runtime_vfs.go
+++ b/runtime/runtime_vfs.go
@@ -1,0 +1,7 @@
+// +build !exclude_graphdriver_vfs
+
+package runtime
+
+import (
+	_ "github.com/dotcloud/docker/runtime/graphdriver/vfs"
+)

--- a/runtime/runtime_vfs.go
+++ b/runtime/runtime_vfs.go
@@ -1,7 +1,0 @@
-// +build !exclude_graphdriver_vfs
-
-package runtime
-
-import (
-	_ "github.com/dotcloud/docker/runtime/graphdriver/vfs"
-)


### PR DESCRIPTION
Enable build tags for all the graphdrivers to be excludable. This is the follow-up to #4650

As an example:

```
$ go build
$ ls -l docker
-rwxr-xr-x 1 vbatts vbatts 18400158 Mar 14 14:22 docker*
$ go build -tags "exclude_graphdriver_aufs exclude_graphdriver_vfs exclude_graphdriver_devicemapper"
$ ls -l docker
-rwxr-xr-x 1 vbatts vbatts 17467068 Mar 14 14:22 docker*
```

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
