### PR TITLE
Added missing HostPath to "copy" API.

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.10.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.10.rst
@@ -619,6 +619,7 @@ Copy files or folders from a container
            Content-Type: application/json
 
            {
+                "HostPath":".",
                 "Resource":"test.txt"
            }
 


### PR DESCRIPTION
Using the "copy" command of Docker 0.9.0 Remote API requires the "HostPath" to be specified.
