### PR TITLE
Update fedora.rst

### DIFF
--- a/docs/sources/installation/fedora.rst
+++ b/docs/sources/installation/fedora.rst
@@ -23,15 +23,15 @@ The ``docker-io`` package provides Docker on Fedora.
 
 If you have the (unrelated) ``docker`` package installed already, it will
 conflict with ``docker-io``. There's a `bug report`_ filed for it.
-To proceed with ``docker-io`` installation on Fedora 19, please remove
-``docker`` first.
+To proceed with ``docker-io`` installation on Fedora 19 or Fedora 20, please
+remove ``docker`` first.
 
 .. code-block:: bash
 
    sudo yum -y remove docker
 
-For Fedora 20 and later, the ``wmdocker`` package will provide the same
-functionality as ``docker`` and will also not conflict with ``docker-io``.
+For Fedora 21 and later, the ``wmdocker`` package will provide the same
+functionality as the old ``docker`` and will also not conflict with ``docker-io``.
 
 .. code-block:: bash
 


### PR DESCRIPTION
It looks like `wmdocker` does not have an update for Fedora 20:

```
~❯ pkgwat releases wmdocker
Starting new HTTPS connection (1): apps.fedoraproject.org
+---------------+----------------+-----------------+
| release       | stable_version | testing_version |
+---------------+----------------+-----------------+
| Rawhide       | 1.5-12.fc21    | None            |
| Fedora 20     | None           | None            |
| Fedora 19     | None           | None            |
| Fedora EPEL 7 | None           | None            |
| Fedora EPEL 6 | None           | None            |
| Fedora EPEL 5 | None           | None            |
+---------------+----------------+-----------------+
```

I'm not sure if the owner awjb is intending to create an F20 update or not, but either way -- these docs are incorrect as currently written.
