### PR TITLE
Fix `docker cp` trying to untar files that do not exist.

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -894,6 +894,9 @@ func postContainersCopy(eng *engine.Engine, version version.Version, w http.Resp
 	if copyData.Get("Resource") == "" {
 		return fmt.Errorf("Path cannot be empty")
 	}
+
+	origResource := copyData.Get("Resource")
+
 	if copyData.Get("Resource")[0] == '/' {
 		copyData.Set("Resource", copyData.Get("Resource")[1:])
 	}
@@ -904,6 +907,8 @@ func postContainersCopy(eng *engine.Engine, version version.Version, w http.Resp
 		utils.Errorf("%s", err.Error())
 		if strings.Contains(err.Error(), "No such container") {
 			w.WriteHeader(http.StatusNotFound)
+		} else if strings.Contains(err.Error(), "no such file or directory") {
+			return fmt.Errorf("Could not find the file %s in container %s", origResource, vars["name"])
 		}
 	}
 	return nil


### PR DESCRIPTION
The problem was just this scanner on about line 910, it wasn't finding the error message.
