### PR TITLE
Generate md5 and sha265 hashes when building, and upload them in hack/release.sh

### DIFF
--- a/hack/make/binary
+++ b/hack/make/binary
@@ -11,3 +11,11 @@ go build \
 	" \
 	./docker
 echo "Created binary: $DEST/docker-$VERSION"
+
+if command -v md5sum &> /dev/null; then
+	md5sum "$DEST/docker-$VERSION" > "$DEST/docker-$VERSION.md5"
+fi
+if command -v sha256sum &> /dev/null; then
+	sha256sum "$DEST/docker-$VERSION" > "$DEST/docker-$VERSION.sha256"
+fi
+

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -18,4 +18,3 @@ fi
 if command -v sha256sum &> /dev/null; then
 	sha256sum "$DEST/docker-$VERSION" > "$DEST/docker-$VERSION.sha256"
 fi
-

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -60,7 +60,7 @@ VERSION=$(cat VERSION)
 BUCKET=$AWS_S3_BUCKET
 
 # These are the 2 keys we've used to sign the deb's
-#   release (get.docker.io
+#   release (get.docker.io)
 #	GPG_KEY="36A1D7869245C8950F966E92D8576A8BA88D21E9"
 #   test    (test.docker.io)
 #	GPG_KEY="740B314AE3941731B942C66ADF4FD13717AAD7D6"
@@ -341,7 +341,6 @@ main() {
 	release_index
 	release_test
 }
-
 
 main
 


### PR DESCRIPTION
@tianon, I moved the `make` into a function - it took me a while to realise that main() was not actually the code that did the work...

I also feel uneasy about the `gpg --gen-key --batch` I'd rather the release process fall over in a screaming mimi, and demand that the person running it set things up 

Issue #4675
