### PR TITLE
refactor(libcontainer): rename to CapabilitiesMask

### DIFF
--- a/execdriver/native/default_template.go
+++ b/execdriver/native/default_template.go
@@ -36,7 +36,7 @@ func createContainer(c *execdriver.Command) *libcontainer.Container {
 
 	container.Cgroups.Name = c.ID
 	if c.Privileged {
-		container.Capabilities = nil
+		container.CapabilitiesMask = nil
 		container.Cgroups.DeviceAccess = true
 		container.Context["apparmor_profile"] = "unconfined"
 	}
@@ -59,7 +59,7 @@ func createContainer(c *execdriver.Command) *libcontainer.Container {
 // the libcontainer configuration file
 func getDefaultTemplate() *libcontainer.Container {
 	return &libcontainer.Container{
-		Capabilities: libcontainer.Capabilities{
+		CapabilitiesMask: libcontainer.Capabilities{
 			libcontainer.GetCapability("SETPCAP"),
 			libcontainer.GetCapability("SYS_MODULE"),
 			libcontainer.GetCapability("SYS_RAWIO"),

--- a/pkg/libcontainer/README.md
+++ b/pkg/libcontainer/README.md
@@ -40,7 +40,7 @@ Sample `container.json` file:
       "HOSTNAME=11bb30683fb0",
       "TERM=xterm"
    ],
-   "capabilities" : [
+   "capabilities_mask" : [
       "SETPCAP",
       "SYS_MODULE",
       "SYS_RAWIO",

--- a/pkg/libcontainer/capabilities/capabilities.go
+++ b/pkg/libcontainer/capabilities/capabilities.go
@@ -9,7 +9,7 @@ import (
 // DropCapabilities drops capabilities for the current process based
 // on the container's configuration.
 func DropCapabilities(container *libcontainer.Container) error {
-	if drop := getCapabilities(container); len(drop) > 0 {
+	if drop := getCapabilitiesMask(container); len(drop) > 0 {
 		c, err := capability.NewPid(os.Getpid())
 		if err != nil {
 			return err
@@ -23,10 +23,10 @@ func DropCapabilities(container *libcontainer.Container) error {
 	return nil
 }
 
-// getCapabilities returns the specific cap values for the libcontainer types
-func getCapabilities(container *libcontainer.Container) []capability.Cap {
+// getCapabilitiesMask returns the specific cap mask values for the libcontainer types
+func getCapabilitiesMask(container *libcontainer.Container) []capability.Cap {
 	drop := []capability.Cap{}
-	for _, c := range container.Capabilities {
+	for _, c := range container.CapabilitiesMask {
 		drop = append(drop, c.Value)
 	}
 	return drop

--- a/pkg/libcontainer/container.go
+++ b/pkg/libcontainer/container.go
@@ -11,19 +11,19 @@ type Context map[string]string
 // Container defines configuration options for how a
 // container is setup inside a directory and how a process should be executed
 type Container struct {
-	Hostname     string          `json:"hostname,omitempty"`      // hostname
-	ReadonlyFs   bool            `json:"readonly_fs,omitempty"`   // set the containers rootfs as readonly
-	NoPivotRoot  bool            `json:"no_pivot_root,omitempty"` // this can be enabled if you are running in ramdisk
-	User         string          `json:"user,omitempty"`          // user to execute the process as
-	WorkingDir   string          `json:"working_dir,omitempty"`   // current working directory
-	Env          []string        `json:"environment,omitempty"`   // environment to set
-	Tty          bool            `json:"tty,omitempty"`           // setup a proper tty or not
-	Namespaces   Namespaces      `json:"namespaces,omitempty"`    // namespaces to apply
-	Capabilities Capabilities    `json:"capabilities,omitempty"`  // capabilities to drop
-	Networks     []*Network      `json:"networks,omitempty"`      // nil for host's network stack
-	Cgroups      *cgroups.Cgroup `json:"cgroups,omitempty"`       // cgroups
-	Context      Context         `json:"context,omitempty"`       // generic context for specific options (apparmor, selinux)
-	Mounts       []Mount         `json:"mounts,omitempty"`
+	Hostname         string          `json:"hostname,omitempty"`          // hostname
+	ReadonlyFs       bool            `json:"readonly_fs,omitempty"`       // set the containers rootfs as readonly
+	NoPivotRoot      bool            `json:"no_pivot_root,omitempty"`     // this can be enabled if you are running in ramdisk
+	User             string          `json:"user,omitempty"`              // user to execute the process as
+	WorkingDir       string          `json:"working_dir,omitempty"`       // current working directory
+	Env              []string        `json:"environment,omitempty"`       // environment to set
+	Tty              bool            `json:"tty,omitempty"`               // setup a proper tty or not
+	Namespaces       Namespaces      `json:"namespaces,omitempty"`        // namespaces to apply
+	CapabilitiesMask Capabilities    `json:"capabilities_mask,omitempty"` // capabilities to drop
+	Networks         []*Network      `json:"networks,omitempty"`          // nil for host's network stack
+	Cgroups          *cgroups.Cgroup `json:"cgroups,omitempty"`           // cgroups
+	Context          Context         `json:"context,omitempty"`           // generic context for specific options (apparmor, selinux)
+	Mounts           []Mount         `json:"mounts,omitempty"`
 }
 
 // Network defines configuration for a container's networking stack

--- a/pkg/libcontainer/container.json
+++ b/pkg/libcontainer/container.json
@@ -14,7 +14,7 @@
         "NEWUTS",
         "NEWNET"
     ],
-    "capabilities": [
+    "capabilities_mask": [
         "SETPCAP",
         "SYS_MODULE",
         "SYS_RAWIO",

--- a/pkg/libcontainer/types_test.go
+++ b/pkg/libcontainer/types_test.go
@@ -30,6 +30,6 @@ func TestCapabilitiesContains(t *testing.T) {
 		t.Fatal("capabilities should not contain SYS_ADMIN")
 	}
 	if !caps.Contains("MKNOD") {
-		t.Fatal("capabilities should container MKNOD but does not")
+		t.Fatal("capabilities should contain MKNOD but does not")
 	}
 }


### PR DESCRIPTION
The Capabilities field on libcontainer is actually used as a mask. Rename the
field so that this is more clear.

NOTE: This is completely untested, wanted to make sure @creack agreed
with me first.

Docker-DCO-1.1-Signed-off-by: Brandon Philips brandon.philips@coreos.com (github: philips)
