### PR TITLE
fix panic in monitor

### DIFF
--- a/runtime/container.go
+++ b/runtime/container.go
@@ -785,7 +785,7 @@ func (container *Container) monitor(callback execdriver.StartCallback) error {
 		utils.Errorf("Error running container: %s", err)
 	}
 
-	if container.runtime.srv.IsRunning() {
+	if container.runtime != nil && container.runtime.srv != nil && container.runtime.srv.IsRunning() {
 		container.State.SetStopped(exitCode)
 
 		// FIXME: there is a race condition here which causes this to fail during the unit tests.


### PR DESCRIPTION
If you do a `while true; do docker run ubuntu ls; done` let it run for a while and `<ctrl-c>` the daemon.

When you restart the daemon you'll get a panic.

We already fixed a bug like this in https://github.com/vieux/docker/blob/1dfc44073399aadb226c1b4c1909fb15c033d44a/runtime/container.go#L811
