### PR TITLE
fix docker stop with lxc already stopped

### DIFF
--- a/runtime/container.go
+++ b/runtime/container.go
@@ -902,7 +902,7 @@ func (container *Container) Stop(seconds int) error {
 	}
 
 	// 1. Send a SIGTERM
-	if err := container.KillSig(15); err != nil {
+	if err := container.KillSig(15); err != nil && !strings.Contains(err.Error(), "is not running") {
 		return err
 	}
 


### PR DESCRIPTION
It's hard to reproduce, with I was in a situation where the state of my container was `running`, but the container actually wasn't, so I couldn't remove it, even with `-f`

I propose to ignore the stop error if it's `xxxxxxx is not running`
