### PR TITLE
Add cascading starts for linked containers

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -557,6 +557,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 		cmd       = cli.Subcmd("start", "CONTAINER [CONTAINER...]", "Restart a stopped container")
 		attach    = cmd.Bool([]string{"a", "-attach"}, false, "Attach container's stdout/stderr and forward all signals to the process")
 		openStdin = cmd.Bool([]string{"i", "-interactive"}, false, "Attach container's stdin")
+		cascade   = cmd.Bool([]string{"c", "-cascade"}, true, "Also start linked containers")
 	)
 	if err := cmd.Parse(args); err != nil {
 		return nil
@@ -569,7 +570,13 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 	var (
 		cErr chan error
 		tty  bool
+		val  = url.Values{}
 	)
+	if *cascade {
+		val.Set("cascade", "1")
+	}
+	var cErr chan error
+	var tty bool
 	if *attach || *openStdin {
 		if cmd.NArg() > 1 {
 			return fmt.Errorf("You cannot start and attach multiple containers at once.")
@@ -611,7 +618,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 
 	var encounteredError error
 	for _, name := range cmd.Args() {
-		_, _, err := readBody(cli.call("POST", "/containers/"+name+"/start", nil, false))
+		_, _, err := readBody(cli.call("POST", "/containers/"+name+"/start?"+val.Encode(), nil, false))
 		if err != nil {
 			if !*attach || !*openStdin {
 				fmt.Fprintf(cli.err, "%s\n", err)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -637,8 +637,12 @@ func postContainersStart(eng *engine.Engine, version version.Version, w http.Res
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
 	}
+	if err := parseForm(r); err != nil {
+		return err
+	}
 	name := vars["name"]
 	job := eng.Job("start", name)
+	job.Setenv("cascade", r.Form.Get("cascade"))
 	// allow a nil body for backwards compatibility
 	if r.Body != nil {
 		if api.MatchesContentType(r.Header.Get("Content-Type"), "application/json") {

--- a/docs/sources/examples/index.rst
+++ b/docs/sources/examples/index.rst
@@ -28,3 +28,4 @@ to more substantial services like those which you might find in production.
    python_web_app
    apt-cacher-ng
    https
+   managing_service_dependencies

--- a/docs/sources/examples/managing_service_dependencies.rst
+++ b/docs/sources/examples/managing_service_dependencies.rst
@@ -1,0 +1,60 @@
+:title: Managing Service Dependencies
+:description: Manage containers that rely on other containers
+:keywords: docker, example, service dependencies
+
+.. _managing_service_dependencies:
+
+Creating Dependent Services
+===========================
+
+.. include:: example_header.inc
+
+In many cases a container relies on services provided by other containers:
+a database, central authentication system, or other service.
+This requires us to make sure the depended-on containers are running, probably
+before the container that calls them is running.
+
+
+Linked Containers
++++++++++++++++++
+
+Docker provides a mechanism to link containers as a means of service discovery and
+inter-container communication.
+
+.. code-block:: bash
+
+  docker run -d --name foo busybox
+  docker run -d --link foo:foo busybox
+
+
+Using container links for service depencies
++++++++++++++++++++++++++++++++++++++++++++
+
+You can now also use these links to ensure dependent containers are started before
+your main container is, without leaving Docker.
+
+.. code-block:: bash
+
+  docker run -d --name foo busybox sleep 300
+  docker run -d --name bar --link foo:foo busybox sleep 300
+
+  docker kill foo
+  docker kill bar
+
+This creates two containers and links them together, then stops them, now lets fire
+them up.
+Normally you would start the "foo" container first, then the "bar" container, but
+here is what we will do instead:
+
+.. code-block:: bash
+
+  docker start --cascade bar
+
+The "--cascade" option will tell Docker to start the "foo" before it starts the
+"bar" container.
+
+Using this option you can always ensure that any and all containers your container
+depends on will be started first.
+
+
+Pretty nifty.

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1436,6 +1436,7 @@ Contains all parent layers, and all tags + versions, or specified repo:tag.
 
       -a, --attach=false: Attach container's stdout/stderr and forward all signals to the process
       -i, --interactive=false: Attach container's stdin
+      -c, --cascade=true: Start all linked containers first
 
 .. _cli_stop:
 

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -416,6 +416,39 @@ func TestRestartKillWait(t *testing.T) {
 	})
 }
 
+func TestCascadingContainerStart(t *testing.T) {
+	eng := NewTestEngine(t)
+	srv := mkServerFromEngine(eng, t)
+	runtime := mkRuntimeFromEngine(eng, t)
+	defer runtime.Nuke()
+
+	config, _, _, err := runconfig.Parse([]string{"-d", "--name", "test", unitTestImageID, "sleep 300"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createTestContainer(eng, config, t)
+
+	config2, _, _, err := runconfig.Parse([]string{"-d", "--link", "test:test", unitTestImageID, "sleep 300"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	test2ID := createTestContainer(eng, config2, t)
+
+	job := srv.Eng.Job("start", test2ID)
+	job.Setenv("cascade", "1")
+
+	if err := job.Run(); err != nil {
+		t.Fatal(err)
+	}
+
+	if !runtime.Get(test2ID).State.IsRunning() || !runtime.Get(test2ID).State.IsRunning() {
+		t.Errorf("Expected linked container to be running")
+	}
+
+}
+
 func TestCreateStartRestartStopStartKillRm(t *testing.T) {
 	eng := NewTestEngine(t)
 	srv := mkServerFromEngine(eng, t)


### PR DESCRIPTION
This will automatically start linked containers when --cascade=true on
docker start before starting the requested container

Docker-DCO-1.1-Signed-off-by: Brian Goff cpuguy83@gmail.com (github: cpuguy83)
