### PR TITLE
Allow volumes from to be individual files

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -253,3 +253,21 @@ func TestDockerRunWithoutNetworking(t *testing.T) {
 	logDone("run - disable networking with --networking=false")
 	logDone("run - disable networking with -n=false")
 }
+
+// Regression test for #4741
+func TestDockerRunWithVolumesAsFiles(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "--name", "test-data", "--volume", "/etc/hosts:/target-file", "busybox", "true")
+	out, stderr, exitCode, err := runCommandWithStdoutStderr(runCmd)
+	if err != nil && exitCode != 0 {
+		t.Fatal("1", out, stderr, err)
+	}
+
+	runCmd = exec.Command(dockerBinary, "run", "--volumes-from", "test-data", "busybox", "cat", "/target-file")
+	out, stderr, exitCode, err = runCommandWithStdoutStderr(runCmd)
+	if err != nil && exitCode != 0 {
+		t.Fatal("2", out, stderr, err)
+	}
+	deleteAllContainers()
+
+	logDone("run - regression test for #4741 - volumes from as files")
+}


### PR DESCRIPTION
Fixes #4741
Right now volumes from expected a dir and not a file so when the drivers
 tried to do the bind mount, the destination was a dir, not a file so it
 fails to run.
Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
