### PR TITLE
cleanup container.stop

### DIFF
--- a/runtime/container.go
+++ b/runtime/container.go
@@ -886,11 +886,8 @@ func (container *Container) Kill() error {
 
 	// 2. Wait for the process to die, in last resort, try to kill the process directly
 	if err := container.WaitTimeout(10 * time.Second); err != nil {
-		if container.command == nil {
-			return fmt.Errorf("lxc-kill failed, impossible to kill the container %s", utils.TruncateID(container.ID))
-		}
-		log.Printf("Container %s failed to exit within 10 seconds of lxc-kill %s - trying direct SIGKILL", "SIGKILL", utils.TruncateID(container.ID))
-		if err := container.runtime.Kill(container, 9); err != nil {
+		log.Printf("Container %s failed to exit within 10 seconds of kill - trying direct SIGKILL", utils.TruncateID(container.ID))
+		if err := syscall.Kill(container.State.Pid, 9); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
`container.runtime.Kill(container, 9)` is the same thing as `container.KillSig(9)` no need to do it twice.
- replaced the useless kill after 10s timeout by a sigkill
- removed reference to lxc-kill
