### PR TITLE
refactor($hack,$docs): be consistent in apt-key keyserver URI usage

### DIFF
--- a/docs/sources/examples/postgresql_service.Dockerfile
+++ b/docs/sources/examples/postgresql_service.Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER SvenDowideit@docker.com
 
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
 # Add PostgreSQL's repository. It contains the most recent stable release
 #     of PostgreSQL, ``9.3``.

--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -144,7 +144,7 @@ First add the Docker repository key to your local keychain.
 
 .. code-block:: bash
 
-   sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+   sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
 Add the Docker repository to your apt sources list, update and install the
 ``lxc-docker`` package.

--- a/hack/infrastructure/docker-ci/Dockerfile
+++ b/hack/infrastructure/docker-ci/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get install -y --no-install-recommends  python2.7 python-dev \
 RUN cd /tmp; wget http://python-distribute.org/distribute_setup.py
 RUN cd /tmp; python distribute_setup.py; easy_install pip; rm distribute_setup.py
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 RUN echo 'deb http://get.docker.io/ubuntu docker main' > \
       /etc/apt/sources.list.d/docker.list; apt-get update
 RUN apt-get install -y lxc-docker-0.8.0

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -111,9 +111,9 @@ case "$lsb_dist" in
 		(
 			set -x
 			if [ "https://get.docker.io/" = "$url" ]; then
-				$sh_c "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
+				$sh_c "apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
 			elif [ "https://test.docker.io/" = "$url" ]; then
-				$sh_c "apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 740B314AE3941731B942C66ADF4FD13717AAD7D6"
+				$sh_c "apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 740B314AE3941731B942C66ADF4FD13717AAD7D6"
 			else
 				$sh_c "$curl ${url}gpg | apt-key add -"
 			fi

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -246,7 +246,7 @@ EOF
 # Add the repository to your APT sources
 echo deb $(s3_url)/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 # Then import the repository key
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 # Install docker
 apt-get update ; apt-get install -y lxc-docker
 


### PR DESCRIPTION
In #4740, the apt-key call in docs is changed to use the keyserver port 80 instead of
port 11371, as the previous call would fail with a restrictive firewall or proxy.
This commit extends the change to all apt-key calls in the repository.
