### PR TITLE
remove races by adding syncs

### DIFF
--- a/pkg/libcontainer/nsinit/mount.go
+++ b/pkg/libcontainer/nsinit/mount.go
@@ -100,6 +100,7 @@ func rootPivot(rootfs string) error {
 	}
 	// path to pivot dir now changed, update
 	pivotDir = filepath.Join("/", filepath.Base(pivotDir))
+	syscall.Sync()
 	if err := system.Unmount(pivotDir, syscall.MNT_DETACH); err != nil {
 		return fmt.Errorf("unmount pivot_root dir %s", err)
 	}

--- a/pkg/mount/mounter_linux.go
+++ b/pkg/mount/mounter_linux.go
@@ -19,5 +19,6 @@ func mount(device, target, mType string, flag uintptr, data string) error {
 }
 
 func unmount(target string, flag int) error {
+	syscall.Sync()
 	return syscall.Unmount(target, flag)
 }

--- a/runtime/graphdriver/aufs/mount.go
+++ b/runtime/graphdriver/aufs/mount.go
@@ -10,6 +10,7 @@ func Unmount(target string) error {
 	if err := exec.Command("auplink", target, "flush").Run(); err != nil {
 		utils.Errorf("[warning]: couldn't run auplink before unmount: %s", err)
 	}
+	syscall.Sync()
 	if err := syscall.Unmount(target, 0); err != nil {
 		return err
 	}


### PR DESCRIPTION
Adding those `syncs` remove some races in the tests for me. `TestMultipleAttachRestart` passes and it was failling for 2 weeks now.
