### PR TITLE
Fix since time exit display when s.FinishedAt is zero

### DIFF
--- a/runtime/state.go
+++ b/runtime/state.go
@@ -28,6 +28,9 @@ func (s *State) String() string {
 		}
 		return fmt.Sprintf("Up %s", utils.HumanDuration(time.Now().UTC().Sub(s.StartedAt)))
 	}
+	if s.FinishedAt.IsZero() {
+		return ""
+	}
 	return fmt.Sprintf("Exited (%d) %s ago", s.ExitCode, utils.HumanDuration(time.Now().UTC().Sub(s.FinishedAt)))
 }
 


### PR DESCRIPTION
When s.FinishedAt is zero, the since time exit in docker ps doesn't display correct time.
For example

```
Exited (0) 292.471209 years ago
```

This patch fixes the since time exit to display just "New" if s.FinishedAt is zero.

Docker-DCO-1.1-Signed-off-by: Ken ICHIKAWA ichikawa.ken@jp.fujitsu.com (github: ichik1)
