### PR TITLE
Add options for the filesystem used for devicemapper

### DIFF
--- a/runtime/graphdriver/devmapper/deviceset.go
+++ b/runtime/graphdriver/devmapper/deviceset.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -250,14 +251,36 @@ func (devices *DeviceSet) activateDeviceIfNeeded(hash string) error {
 func (devices *DeviceSet) createFilesystem(info *DevInfo) error {
 	devname := info.DevName()
 
-	err := execRun("mkfs.ext4", "-E", "discard,lazy_itable_init=0,lazy_journal_init=0", devname)
-	if err != nil {
-		err = execRun("mkfs.ext4", "-E", "discard,lazy_itable_init=0", devname)
+	fsType := os.Getenv("DOCKER_FILESYSTEM")
+	if fsType == "" {
+		fsType = "ext4"
+	}
+
+	args := []string{}
+	mkfsArgs := os.Getenv("DOCKER_MKFS_ARGS")
+	if mkfsArgs != "" {
+		args = strings.Split(mkfsArgs, " ")
+	}
+
+	args = append(args, devname)
+
+	var err error
+	switch fsType {
+	case "xfs":
+		err = execRun("mkfs.xfs", args...)
+	case "ext4":
+		err = execRun("mkfs.ext4", append([]string{"-E", "discard,lazy_itable_init=0,lazy_journal_init=0"}, args...)...)
+		if err != nil {
+			err = execRun("mkfs.ext4", append([]string{"-E", "discard,lazy_itable_init=0"}, args...)...)
+		}
+	default:
+		err = fmt.Errorf("Unsupported filesystem type %s", fsType)
 	}
 	if err != nil {
 		utils.Debugf("\n--->Err: %s\n", err)
 		return err
 	}
+
 	return nil
 }
 
@@ -863,9 +886,21 @@ func (devices *DeviceSet) MountDevice(hash, path string) error {
 		return err
 	}
 
-	err = sysMount(info.DevName(), path, fstype, flags, "discard")
+	options := []string{}
+
+	if fstype == "xfs" {
+		// XFS needs nouuid or it can't mount filesystems with the same fs
+		options = append(options, "nouuid")
+	}
+
+	extraOptions := os.Getenv("DOCKER_FS_OPTIONS")
+	if extraOptions != "" {
+		options = append(options, strings.Split(extraOptions, ",")...)
+	}
+
+	err = sysMount(info.DevName(), path, fstype, flags, strings.Join(append([]string{"discard"}, options...), ","))
 	if err != nil && err == sysEInval {
-		err = sysMount(info.DevName(), path, fstype, flags, "")
+		err = sysMount(info.DevName(), path, fstype, flags, strings.Join(options, ","))
 	}
 	if err != nil {
 		return fmt.Errorf("Error mounting '%s' on '%s': %s", info.DevName(), path, err)

--- a/runtime/graphdriver/devmapper/deviceset.go
+++ b/runtime/graphdriver/devmapper/deviceset.go
@@ -858,9 +858,14 @@ func (devices *DeviceSet) MountDevice(hash, path string) error {
 
 	var flags uintptr = sysMsMgcVal
 
-	err := sysMount(info.DevName(), path, "ext4", flags, "discard")
+	fstype, err := ProbeFsType(info.DevName())
+	if err != nil {
+		return err
+	}
+
+	err = sysMount(info.DevName(), path, fstype, flags, "discard")
 	if err != nil && err == sysEInval {
-		err = sysMount(info.DevName(), path, "ext4", flags, "")
+		err = sysMount(info.DevName(), path, fstype, flags, "")
 	}
 	if err != nil {
 		return fmt.Errorf("Error mounting '%s' on '%s': %s", info.DevName(), path, err)

--- a/runtime/graphdriver/devmapper/driver_test.go
+++ b/runtime/graphdriver/devmapper/driver_test.go
@@ -436,6 +436,10 @@ func TestDriverCreate(t *testing.T) {
 		return nil
 	}
 
+	ProbeFsType = func(device string) (string, error) {
+		return "ext4", nil
+	}
+
 	Mounted = func(mnt string) (bool, error) {
 		calls["Mounted"] = true
 		if !strings.HasPrefix(mnt, "/tmp/docker-test-devmapper-") || !strings.HasSuffix(mnt, "/mnt/1") {
@@ -556,6 +560,9 @@ func TestDriverRemove(t *testing.T) {
 			t.Fatalf("Wrong syscall call\nExpected: Mount(%v)\nReceived: Mount(%v)\n", expectedFlags, flags)
 		}
 		return nil
+	}
+	ProbeFsType = func(device string) (string, error) {
+		return "ext4", nil
 	}
 	Mounted = func(mnt string) (bool, error) {
 		calls["Mounted"] = true

--- a/runtime/graphdriver/devmapper/mount.go
+++ b/runtime/graphdriver/devmapper/mount.go
@@ -3,6 +3,8 @@
 package devmapper
 
 import (
+	"bytes"
+	"fmt"
 	"path/filepath"
 )
 
@@ -24,4 +26,49 @@ var Mounted = func(mountpoint string) (bool, error) {
 	mntpointSt := toSysStatT(mntpoint.Sys())
 	parentSt := toSysStatT(parent.Sys())
 	return mntpointSt.Dev != parentSt.Dev, nil
+}
+
+type probeData struct {
+	fsName string
+	magic  string
+	offset uint64
+}
+
+var ProbeFsType = func(device string) (string, error) {
+	probes := []probeData{
+		{"btrfs", "_BHRfS_M", 0x10040},
+		{"ext4", "\123\357", 0x438},
+		{"xfs", "XFSB", 0},
+	}
+
+	maxLen := uint64(0)
+	for _, p := range probes {
+		l := p.offset + uint64(len(p.magic))
+		if l > maxLen {
+			maxLen = l
+		}
+	}
+
+	file, err := osOpen(device)
+	if err != nil {
+		return "", err
+	}
+
+	buffer := make([]byte, maxLen)
+	l, err := file.Read(buffer)
+	if err != nil {
+		return "", err
+	}
+	file.Close()
+	if uint64(l) != maxLen {
+		return "", fmt.Errorf("unable to detect filesystem type of %s, short read", device)
+	}
+
+	for _, p := range probes {
+		if bytes.Equal([]byte(p.magic), buffer[p.offset:p.offset+uint64(len(p.magic))]) {
+			return p.fsName, nil
+		}
+	}
+
+	return "", fmt.Errorf("Unknown filesystem type on %s", device)
 }


### PR DESCRIPTION
This adds some env vars to allow you to control what filesystem docker uses for the device mapper devices.
DOCKER_FILESYSTEM: Controls what filesystem to use, atm ext4 and xfs is supported
DOCKER_MKFS_ARGS: Lets you pass extra arguments to mkfs that creates the base device
DOCKER_FS_OPTIONS: Allows you to pass extra runtime mount options for the thin devices.
