### PR TITLE
switch from default libcontainer to lxc driver for rhel6

### DIFF
--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -46,7 +46,7 @@ start() {
         prestart
         printf "Starting $prog:\t"
         echo "\n$(date)\n" >> $logfile
-        $exec -d $other_args &>> $logfile &
+        $exec -d -e lxc $other_args &>> $logfile &
         pid=$!
         touch $lockfile
         success


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Adam Miller admiller@redhat.com (github: maxamillion)
