### PR TITLE
Backports for 0.9.1

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -480,8 +480,8 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 }
 
 func (cli *DockerCli) CmdStop(args ...string) error {
-	cmd := cli.Subcmd("stop", "[OPTIONS] CONTAINER [CONTAINER...]", "Stop a running container (Send SIGTERM, and then SIGKILL after grace period)")
-	nSeconds := cmd.Int([]string{"t", "-time"}, 10, "Number of seconds to wait for the container to stop before killing it.")
+	cmd := cli.Subcmd("stop", "[OPTIONS] CONTAINER [CONTAINER...]", "Stop a running container (Send SIGTERM)")
+	nSeconds := cmd.Int([]string{"t", "-time"}, 10, "Number of seconds to wait for the container to stop.")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -508,7 +508,7 @@ func (cli *DockerCli) CmdStop(args ...string) error {
 
 func (cli *DockerCli) CmdRestart(args ...string) error {
 	cmd := cli.Subcmd("restart", "[OPTIONS] CONTAINER [CONTAINER...]", "Restart a running container")
-	nSeconds := cmd.Int([]string{"t", "-time"}, 10, "Number of seconds to try to stop for before killing the container. Once killed it will then be restarted. Default=10")
+	nSeconds := cmd.Int([]string{"t", "-time"}, 10, "Number of seconds to wait for the container to stop. Default=10")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}

--- a/container.go
+++ b/container.go
@@ -895,20 +895,12 @@ func (container *Container) Stop(seconds int) error {
 
 	// 1. Send a SIGTERM
 	if err := container.kill(15); err != nil {
-		utils.Debugf("Error sending kill SIGTERM: %s", err)
-		log.Print("Failed to send SIGTERM to the process, force killing")
-		if err := container.kill(9); err != nil {
-			return err
-		}
+		return err
 	}
 
 	// 2. Wait for the process to exit on its own
 	if err := container.WaitTimeout(time.Duration(seconds) * time.Second); err != nil {
-		log.Printf("Container %v failed to exit within %d seconds of SIGTERM - using the force", container.ID, seconds)
-		// 3. If it doesn't, then send SIGKILL
-		if err := container.Kill(); err != nil {
-			return err
-		}
+		return err
 	}
 	return nil
 }

--- a/docs/sources/reference/api/docker_remote_api_v1.9.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.9.rst
@@ -432,7 +432,7 @@ Stop a container
 
            HTTP/1.1 204 OK
 
-        :query t: number of seconds to wait before killing the container
+        :query t: number of seconds to wait for the container to stop
         :statuscode 204: no error
         :statuscode 404: no such container
         :statuscode 500: server error
@@ -457,7 +457,7 @@ Restart a container
 
            HTTP/1.1 204 OK
 
-        :query t: number of seconds to wait before killing the container
+        :query t: number of seconds to wait for the container to stop
         :statuscode 204: no error
         :statuscode 404: no such container
         :statuscode 500: server error

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1354,11 +1354,11 @@ This example shows 5 containers that might be set up to test a web application c
 
     Usage: docker stop [OPTIONS] CONTAINER [CONTAINER...]
 
-    Stop a running container (Send SIGTERM, and then SIGKILL after grace period)
+    Stop a running container (Send SIGTERM)
 
-      -t, --time=10: Number of seconds to wait for the container to stop before killing it.
+      -t, --time=10: Number of seconds to wait for the container to stop.
 
-The main process inside the container will receive SIGTERM, and after a grace period, SIGKILL
+The main process inside the container will receive SIGTERM.
 
 .. _cli_tag:
 

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -404,7 +404,7 @@ func TestRestartKillWait(t *testing.T) {
 	})
 }
 
-func TestCreateStartRestartStopStartKillRm(t *testing.T) {
+func TestCreateStartRestartKillStartKillRm(t *testing.T) {
 	eng := NewTestEngine(t)
 	srv := mkServerFromEngine(eng, t)
 	defer mkRuntimeFromEngine(eng, t).Nuke()
@@ -444,8 +444,7 @@ func TestCreateStartRestartStopStartKillRm(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	job = eng.Job("stop", id)
-	job.SetenvInt("t", 15)
+	job = eng.Job("kill", id)
 	if err := job.Run(); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/libcontainer/nsinit/execin.go
+++ b/pkg/libcontainer/nsinit/execin.go
@@ -14,9 +14,12 @@ import (
 
 // ExecIn uses an existing pid and joins the pid's namespaces with the new command.
 func (ns *linuxNs) ExecIn(container *libcontainer.Container, nspid int, args []string) (int, error) {
-	for _, ns := range container.Namespaces {
-		if err := system.Unshare(ns.Value); err != nil {
-			return -1, err
+	for _, nsv := range container.Namespaces {
+		// skip the PID namespace on unshare because it it not supported
+		if nsv.Key != "NEWPID" {
+			if err := system.Unshare(nsv.Value); err != nil {
+				return -1, err
+			}
 		}
 	}
 	fds, err := ns.getNsFds(nspid, container)

--- a/pkg/term/termios_darwin.go
+++ b/pkg/term/termios_darwin.go
@@ -9,16 +9,24 @@ const (
 	getTermios = syscall.TIOCGETA
 	setTermios = syscall.TIOCSETA
 
-	ECHO   = 0x00000008
-	ONLCR  = 0x2
-	ISTRIP = 0x20
-	INLCR  = 0x40
-	ISIG   = 0x80
-	IGNCR  = 0x80
-	ICANON = 0x100
-	ICRNL  = 0x100
-	IXOFF  = 0x400
-	IXON   = 0x200
+	IGNBRK = syscall.IGNBRK
+	PARMRK = syscall.PARMRK
+	INLCR  = syscall.INLCR
+	IGNCR  = syscall.IGNCR
+	ECHONL = syscall.ECHONL
+	CSIZE  = syscall.CSIZE
+	ICRNL  = syscall.ICRNL
+	ISTRIP = syscall.ISTRIP
+	PARENB = syscall.PARENB
+	ECHO   = syscall.ECHO
+	ICANON = syscall.ICANON
+	ISIG   = syscall.ISIG
+	IXON   = syscall.IXON
+	BRKINT = syscall.BRKINT
+	INPCK  = syscall.INPCK
+	OPOST  = syscall.OPOST
+	CS8    = syscall.CS8
+	IEXTEN = syscall.IEXTEN
 )
 
 type Termios struct {
@@ -41,10 +49,13 @@ func MakeRaw(fd uintptr) (*State, error) {
 	}
 
 	newState := oldState.termios
-	newState.Iflag &^= (ISTRIP | INLCR | IGNCR | IXON | IXOFF)
-	newState.Iflag |= ICRNL
-	newState.Oflag |= ONLCR
-	newState.Lflag &^= (ECHO | ICANON | ISIG)
+	newState.Iflag &^= (IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON)
+	newState.Oflag &^= OPOST
+	newState.Lflag &^= (ECHO | ECHONL | ICANON | ISIG | IEXTEN)
+	newState.Cflag &^= (CSIZE | PARENB)
+	newState.Cflag |= CS8
+	newState.Cc[syscall.VMIN] = 1
+	newState.Cc[syscall.VTIME] = 0
 
 	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(setTermios), uintptr(unsafe.Pointer(&newState))); err != 0 {
 		return nil, err

--- a/server.go
+++ b/server.go
@@ -1067,16 +1067,32 @@ func (srv *Server) pullImage(r *registry.Registry, out io.Writer, imgID, endpoin
 
 		if !srv.runtime.graph.Exists(id) {
 			out.Write(sf.FormatProgress(utils.TruncateID(id), "Pulling metadata", nil))
-			imgJSON, imgSize, err := r.GetRemoteImageJSON(id, endpoint, token)
-			if err != nil {
-				out.Write(sf.FormatProgress(utils.TruncateID(id), "Error pulling dependent layers", nil))
-				// FIXME: Keep going in case of error?
-				return err
-			}
-			img, err := NewImgJSON(imgJSON)
-			if err != nil {
-				out.Write(sf.FormatProgress(utils.TruncateID(id), "Error pulling dependent layers", nil))
-				return fmt.Errorf("Failed to parse json: %s", err)
+			var (
+				imgJSON []byte
+				imgSize int
+				err     error
+				img     *Image
+			)
+			retries := 5
+			for j := 1; j <= retries; j++ {
+				imgJSON, imgSize, err = r.GetRemoteImageJSON(id, endpoint, token)
+				if err != nil && j == retries {
+					out.Write(sf.FormatProgress(utils.TruncateID(id), "Error pulling dependent layers", nil))
+					return err
+				} else if err != nil {
+					time.Sleep(time.Duration(j) * 500 * time.Millisecond)
+					continue
+				}
+				img, err = NewImgJSON(imgJSON)
+				if err != nil && j == retries {
+					out.Write(sf.FormatProgress(utils.TruncateID(id), "Error pulling dependent layers", nil))
+					return fmt.Errorf("Failed to parse json: %s", err)
+				} else if err != nil {
+					time.Sleep(time.Duration(j) * 500 * time.Millisecond)
+					continue
+				} else {
+					break
+				}
 			}
 
 			// Get the layer


### PR DESCRIPTION
This PR backports the following PRs to 0.9 for 0.9.1:
https://github.com/dotcloud/docker/pull/4387
https://github.com/dotcloud/docker/pull/4731
https://github.com/dotcloud/docker/pull/4648
https://github.com/dotcloud/docker/pull/4684
https://github.com/dotcloud/docker/pull/4782
