### PR TITLE
add a link to the security documentation when we mention the docker group (or -G)

### DIFF
--- a/docs/sources/articles/security.rst
+++ b/docs/sources/articles/security.rst
@@ -82,6 +82,8 @@ when some applications start to misbehave.
 Control Groups have been around for a while as well: the code was
 started in 2006, and initially merged in kernel 2.6.24.
 
+.. _dockersecurity_daemon:
+
 Docker Daemon Attack Surface
 ----------------------------
 

--- a/docs/sources/installation/binaries.rst
+++ b/docs/sources/installation/binaries.rst
@@ -77,7 +77,8 @@ always run as the root user, but if you run the ``docker`` client as a
 user in the *docker* group then you don't need to add ``sudo`` to all
 the client commands.
 
-.. warning:: The *docker* group is root-equivalent.
+.. warning:: The *docker* group (or the group specified with ``-G``) is
+   root-equivalent; see :ref:`dockersecurity_daemon` details.
 
 
 Upgrades

--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -186,7 +186,7 @@ client commands. As of 0.9.0, you can specify that a group other than ``docker``
 should own the Unix socket with the ``-G`` option.
 
 .. warning:: The *docker* group (or the group specified with ``-G``) is
-   root-equivalent.
+   root-equivalent; see :ref:`dockersecurity_daemon` details.
 
 
 **Example:**


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@fosiki.com (github: SvenDowideit)

Closes #4177
