### PR TITLE
Print the last image and temporary containers when docker build fails

### DIFF
--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -746,6 +746,14 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 			continue
 		}
 		if err := b.BuildStep(fmt.Sprintf("%d", stepN), line); err != nil {
+			if b.image != "" {
+				fmt.Fprintf(b.outStream, "Stopped at %s\n", utils.TruncateID(b.image))
+				if b.rm {
+					for c := range b.tmpContainers {
+						fmt.Fprintf(b.outStream, "Left behind intermediate container %s\n", utils.TruncateID(c))
+					}
+				}
+			}
 			return "", err
 		}
 		stepN += 1


### PR DESCRIPTION
`docker build` will leave behind the last image in the build along with
any temporary containers when a build fails. This is really helpful when
debugging why a build failed, but it also makes cleaning up the
containers and images in an automated way very difficult.

On a successful build, the resulting image is printed. This change
teaches `docker build` to print the last successful image in a build so
it's easier to cleanup the result.

Additionally, when `docker build -rm=true` is invoked, we've already
stated that we want the intermediate containers to be removed. On
failure, we still don't want to cleanup the containers, but we do want
to make it obvious that they weren't cleaned up. This teaches docker to
print the containers that are left behind when a build fails.

Fixes issue #4355.

Docker-DCO-1.1-Signed-off-by: Jonathan A. Sternberg
jonathansternberg@gmail.com (github: jsternberg)
