### PR TITLE
fix the problem when setting existing file as working dir

### DIFF
--- a/integration/commands_test.go
+++ b/integration/commands_test.go
@@ -252,6 +252,25 @@ func TestRunWorkdirExists(t *testing.T) {
 	}
 }
 
+// TestRunWorkdirExistsAndIsFile checks that if 'docker run -w' with existing file can be detected
+func TestRunWorkdirExistsAndIsFile(t *testing.T) {
+
+	cli := api.NewDockerCli(nil, nil, ioutil.Discard, testDaemonProto, testDaemonAddr, nil)
+	defer cleanup(globalEngine, t)
+
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		if err := cli.CmdRun("-w", "/bin/cat", unitTestImageID, "pwd"); err == nil {
+			t.Fatal("should have failed to run when using /bin/cat as working dir.")
+		}
+	}()
+
+	setTimeout(t, "CmdRun timed out", 5*time.Second, func() {
+		<-c
+	})
+}
+
 func TestRunExit(t *testing.T) {
 	stdin, stdinPipe := io.Pipe()
 	stdout, stdoutPipe := io.Pipe()


### PR DESCRIPTION
This PR is proposed to check if the working dir is a directory. If it is an existing file, an error is returned.
For example, when given -w=/bin/cat, original codes would cause docker to halt.
