### PR TITLE
Add missing -t for allocating a pseudo-tty

### DIFF
--- a/docs/sources/examples/running_ssh_service.rst
+++ b/docs/sources/examples/running_ssh_service.rst
@@ -26,7 +26,7 @@ port 22 is mapped to:
 
 .. code-block:: bash
 
-    $ sudo docker run -d -P --name test_sshd eg_sshd
+    $ sudo docker run -d -P -t --name test_sshd eg_sshd
     $ sudo docker port test_sshd 22
     0.0.0.0:49154
 


### PR DESCRIPTION
Without -t, the next ssh command to local binded port will complain with "stdin: is not a tty".
