### PR TITLE
Revert back to the default stop functionality of SIGKILL after timeout

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -498,8 +498,8 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 }
 
 func (cli *DockerCli) CmdStop(args ...string) error {
-	cmd := cli.Subcmd("stop", "[OPTIONS] CONTAINER [CONTAINER...]", "Stop a running container (Send SIGTERM)")
-	nSeconds := cmd.Int([]string{"t", "-time"}, 10, "Number of seconds to wait for the container to stop.")
+	cmd := cli.Subcmd("stop", "[OPTIONS] CONTAINER [CONTAINER...]", "Stop a running container (Send SIGTERM, and then SIGKILL after grace period)")
+	nSeconds := cmd.Int([]string{"t", "-time"}, 10, "Number of seconds to wait for the container to stop before killing it.")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -526,7 +526,7 @@ func (cli *DockerCli) CmdStop(args ...string) error {
 
 func (cli *DockerCli) CmdRestart(args ...string) error {
 	cmd := cli.Subcmd("restart", "[OPTIONS] CONTAINER [CONTAINER...]", "Restart a running container")
-	nSeconds := cmd.Int([]string{"t", "-time"}, 10, "Number of seconds to wait for the container to stop. Default=10")
+	nSeconds := cmd.Int([]string{"t", "-time"}, 10, "Number of seconds to try to stop for before killing the container. Once killed it will then be restarted. Default=10")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}

--- a/docs/sources/reference/api/docker_remote_api_v1.9.rst
+++ b/docs/sources/reference/api/docker_remote_api_v1.9.rst
@@ -432,7 +432,7 @@ Stop a container
 
            HTTP/1.1 204 OK
 
-        :query t: number of seconds to wait for the container to stop
+        :query t: number of seconds to wait before killing the container
         :statuscode 204: no error
         :statuscode 404: no such container
         :statuscode 500: server error
@@ -457,7 +457,7 @@ Restart a container
 
            HTTP/1.1 204 OK
 
-        :query t: number of seconds to wait for the container to stop
+        :query t: number of seconds to wait before killing the container
         :statuscode 204: no error
         :statuscode 404: no such container
         :statuscode 500: server error

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -1360,11 +1360,11 @@ This example shows 5 containers that might be set up to test a web application c
 
     Usage: docker stop [OPTIONS] CONTAINER [CONTAINER...]
 
-    Stop a running container (Send SIGTERM)
+    Stop a running container (Send SIGTERM, and then SIGKILL after grace period)
 
-      -t, --time=10: Number of seconds to wait for the container to stop.
+      -t, --time=10: Number of seconds to wait for the container to stop before killing it.
 
-The main process inside the container will receive SIGTERM.
+The main process inside the container will receive SIGTERM, and after a grace period, SIGKILL
 
 .. _cli_tag:
 

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -416,7 +416,7 @@ func TestRestartKillWait(t *testing.T) {
 	})
 }
 
-func TestCreateStartRestartKillStartKillRm(t *testing.T) {
+func TestCreateStartRestartStopStartKillRm(t *testing.T) {
 	eng := NewTestEngine(t)
 	srv := mkServerFromEngine(eng, t)
 	defer mkRuntimeFromEngine(eng, t).Nuke()
@@ -456,7 +456,8 @@ func TestCreateStartRestartKillStartKillRm(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	job = eng.Job("kill", id)
+	job = eng.Job("stop", id)
+	job.SetenvInt("t", 15)
 	if err := job.Run(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
After careful discussion we decided we are not happy with the breaking change and will be making this configurable at the daemon level for users that do not want it to be sigkilled.
