### PR TITLE
docker load: add --input flag

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -2075,6 +2075,8 @@ func (cli *DockerCli) CmdSave(args ...string) error {
 
 func (cli *DockerCli) CmdLoad(args ...string) error {
 	cmd := cli.Subcmd("load", "", "Load an image from a tar archive on STDIN")
+	infile := cmd.String([]string{"i", "-input"}, "", "Read from a tar archive file, instead of STDIN")
+
 	if err := cmd.Parse(args); err != nil {
 		return err
 	}
@@ -2084,7 +2086,17 @@ func (cli *DockerCli) CmdLoad(args ...string) error {
 		return nil
 	}
 
-	if err := cli.stream("POST", "/images/load", cli.in, cli.out, nil); err != nil {
+	var (
+		input io.Reader = cli.in
+		err   error
+	)
+	if *infile != "" {
+		input, err = os.Open(*infile)
+		if err != nil {
+			return err
+		}
+	}
+	if err := cli.stream("POST", "/images/load", input, cli.out, nil); err != nil {
 		return err
 	}
 	return nil

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -885,9 +885,9 @@ Known Issues (kill)
 
     Load an image from a tar archive on STDIN
 
-      -i, --input"": Read from a tar archive file, instead of STDIN
+      -i, --input="": Read from a tar archive file, instead of STDIN
 
-Loads a tarred repository from the standard input stream.
+Loads a tarred repository from a file or the standard input stream.
 Restores both images and tags.
 
 .. code-block:: bash

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -892,8 +892,21 @@ Restores both images and tags.
 
 .. code-block:: bash
 
+   $ sudo docker images
+   REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
    $ sudo docker load < busybox.tar
-   $ sudo docker load --input busybox.tar
+   $ sudo docker images
+   REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+   busybox             latest              769b9341d937        7 weeks ago         2.489 MB
+   $ sudo docker load --input fedora.tar
+   $ sudo docker images
+   REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+   busybox             latest              769b9341d937        7 weeks ago         2.489 MB
+   fedora              rawhide             0d20aec6529d        7 weeks ago         387 MB
+   fedora              20                  58394af37342        7 weeks ago         385.5 MB
+   fedora              heisenbug           58394af37342        7 weeks ago         385.5 MB
+   fedora              latest              58394af37342        7 weeks ago         385.5 MB
+
 
 .. _cli_login:
 

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -881,10 +881,19 @@ Known Issues (kill)
 
 ::
 
-    Usage: docker load < repository.tar
+    Usage: docker load 
 
-    Loads a tarred repository from the standard input stream.
-    Restores both images and tags.
+    Load an image from a tar archive on STDIN
+
+      -i, --input"": Read from a tar archive file, instead of STDIN
+
+Loads a tarred repository from the standard input stream.
+Restores both images and tags.
+
+.. code-block:: bash
+
+   $ sudo docker load < busybox.tar
+   $ sudo docker load --input busybox.tar
 
 .. _cli_login:
 


### PR DESCRIPTION
for those that do not care to read from redirected stdin.
(per #4778)

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
