### PR TITLE
install.sh (get.docker.io) aufs comment updated.

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -85,7 +85,7 @@ case "$lsb_dist" in
 			fi
 		}
 		
-		# TODO remove this section once device-mapper lands
+		# aufs is preferred over devicemapper; try to ensure the driver is available.
 		if ! grep -q aufs /proc/filesystems && ! $sh_c 'modprobe aufs'; then
 			kern_extras="linux-image-extra-$(uname -r)"
 			


### PR DESCRIPTION
devicemapper has landed, but the TODO hasn't been actioned presumably because [aufs is still preferred over devicemapper when available](https://github.com/crosbymichael/docker/blob/267ca39921c35826ccbdb84fbbc0690bfef385d7/runtime/graphdriver/driver.go#L40-L46), and [looks like it will continue to be](https://github.com/dotcloud/docker/pull/4838/files).

This fixes the comments in http://get.docker.io/ and presumably http://test.docker.io/
