### PR TITLE
Force flag to prevent file already exists error.

### DIFF
--- a/docs/sources/examples/mongodb.rst
+++ b/docs/sources/examples/mongodb.rst
@@ -47,7 +47,7 @@ divert ``/sbin/initctl`` to ``/bin/true`` so it thinks everything is working.
 
     # Hack for initctl not being available in Ubuntu
     RUN dpkg-divert --local --rename --add /sbin/initctl
-    RUN ln -s /bin/true /sbin/initctl
+    RUN ln -sf /bin/true /sbin/initctl
 
 Afterwards we'll be able to update our apt repositories and install MongoDB
 

--- a/docs/sources/examples/running_riak_service.rst
+++ b/docs/sources/examples/running_riak_service.rst
@@ -88,7 +88,7 @@ Almost there. Next, we add a hack to get us by the lack of ``initctl``:
     # Hack for initctl
     # See: https://github.com/dotcloud/docker/issues/1024
     RUN dpkg-divert --local --rename --add /sbin/initctl
-    RUN ln -s /bin/true /sbin/initctl
+    RUN ln -sf /bin/true /sbin/initctl
 
 Then, we expose the Riak Protocol Buffers and HTTP interfaces, along with SSH:
 


### PR DESCRIPTION
I had been getting this error... 

```
ln: failed to create symbolic link `/sbin/initctl': File exists
2014/03/25 10:30:36 The command [/bin/sh -c ln -s /bin/true /sbin/initctl] returned a non-zero code: 1
```

Docker-DCO-1.1-Signed-off-by: No Ducks onemannoducks@gmail.com (github: noducks)
