### PR TITLE
Add support for relative ADD (which becomes relative to the current WORKDIR)

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -506,7 +506,12 @@ func (b *buildFile) runContextCommand(args string, allowRemote bool, allowDecomp
 	}
 
 	if !filepath.IsAbs(dest) {
-		dest = filepath.Join("/", b.config.WorkingDir, dest)
+		newDest := filepath.Join("/", b.config.WorkingDir, dest)
+		if strings.HasSuffix(dest, "/") {
+			// preserve trailing slash
+			newDest += "/"
+		}
+		dest = newDest
 	}
 
 	cmd := b.config.Cmd

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -361,14 +361,10 @@ func (b *buildFile) CmdCopy(args string) error {
 }
 
 func (b *buildFile) CmdWorkdir(workdir string) error {
-	if workdir[0] == '/' {
-		b.config.WorkingDir = workdir
-	} else {
-		if b.config.WorkingDir == "" {
-			b.config.WorkingDir = "/"
-		}
-		b.config.WorkingDir = filepath.Join(b.config.WorkingDir, workdir)
+	if !filepath.IsAbs(workdir) {
+		workdir = filepath.Join("/", b.config.WorkingDir, workdir)
 	}
+	b.config.WorkingDir = workdir
 	return b.commit("", b.config.Cmd, fmt.Sprintf("WORKDIR %v", workdir))
 }
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -505,6 +505,10 @@ func (b *buildFile) runContextCommand(args string, allowRemote bool, allowDecomp
 		return err
 	}
 
+	if !filepath.IsAbs(dest) {
+		dest = filepath.Join("/", b.config.WorkingDir, dest)
+	}
+
 	cmd := b.config.Cmd
 	b.config.Cmd = []string{"/bin/sh", "-c", fmt.Sprintf("#(nop) %s %s in %s", cmdName, orig, dest)}
 	defer func(cmd []string) { b.config.Cmd = cmd }(cmd)

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -261,8 +261,9 @@ container's filesystem at path `<dest>`.
 `<src>` must be the path to a file or directory relative to the source directory
 being built (also called the *context* of the build) or a remote file URL.
 
-`<dest>` is the absolute path to which the source will be copied inside the
-destination container.
+`<dest>` can be an absolute path, or relative to the current `WORKDIR`. The
+`<source>` will be copied to that location in the destination container and
+resulting image.
 
 All new files and directories are created with a UID and GID of 0.
 

--- a/integration-cli/build_tests/TestBuildAddRelative/Dockerfile
+++ b/integration-cli/build_tests/TestBuildAddRelative/Dockerfile
@@ -1,15 +1,13 @@
 FROM	busybox
-ADD	add1	.
-RUN	ls /add1 && rm /add1
+
 RUN	mkdir /src
 WORKDIR	/src
+
 ADD	add1	./
 RUN	ls ./add1 && rm ./add1
-ADD	add1	.
-RUN	ls ./add1 && rm ./add1
-ADD	add1	/src
-RUN	ls ./add1 && rm ./add1
+
 ADD	add1	/src/
 RUN	ls ./add1 && rm ./add1
-ADD	add1 	add2
+
+ADD	add1	add2
 RUN	ls /src/add2 && rm /src/add2

--- a/integration-cli/build_tests/TestBuildAddRelative/Dockerfile
+++ b/integration-cli/build_tests/TestBuildAddRelative/Dockerfile
@@ -1,0 +1,15 @@
+FROM	busybox
+ADD	add1	.
+RUN	ls /add1 && rm /add1
+RUN	mkdir /src
+WORKDIR	/src
+ADD	add1	./
+RUN	ls ./add1 && rm ./add1
+ADD	add1	.
+RUN	ls ./add1 && rm ./add1
+ADD	add1	/src
+RUN	ls ./add1 && rm ./add1
+ADD	add1	/src/
+RUN	ls ./add1 && rm ./add1
+ADD	add1 	add2
+RUN	ls /src/add2 && rm /src/add2

--- a/integration-cli/build_tests/TestBuildAddRelative/add1
+++ b/integration-cli/build_tests/TestBuildAddRelative/add1
@@ -1,0 +1,1 @@
+hello world

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -616,6 +616,22 @@ func TestBuildWithVolumes(t *testing.T) {
 	logDone("build - with volumes")
 }
 
+// Test regression for gh#3960, gh#4848
+func TestBuildAddRelative(t *testing.T) {
+	buildDirectory := filepath.Join(workingDirectory, "build_tests", "TestBuildAddRelative")
+	buildCmd := exec.Command(dockerBinary, "build", "-t", "foobuildaddrelative", ".")
+	buildCmd.Dir = buildDirectory
+	out, exitCode, err := runCommandWithOutput(buildCmd)
+	errorOut(err, t, fmt.Sprintf("build failed to complete: %v %v", out, err))
+
+	if err != nil || exitCode != 0 {
+		t.Fatal("failed to build the image")
+	}
+	go deleteImages("foobuiladdrelative")
+
+	logDone("build - add relative to workdir")
+}
+
 func TestBuildMaintainer(t *testing.T) {
 	name := "testbuildmaintainer"
 	expected := "dockerio"


### PR DESCRIPTION
Fixes #3936

I also included a new test to verify this behavior and a minor improvement to the empty string logic in the relative WORKDIR code (which is very similar to this new code).
