### PR TITLE
Include contributed bash completion in ubuntu PPA

### DIFF
--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -38,6 +38,14 @@ bundle_ubuntu() {
 	mkdir -p $DIR/lib/systemd/system
 	cp contrib/init/systemd/docker.service $DIR/lib/systemd/system/
 
+	# Include contributed completions
+	mkdir -p $DIR/etc/bash_completion.d
+	cp contrib/completion/bash/docker $DIR/etc/bash_completion.d/
+	mkdir -p $DIR/usr/share/zsh/vendor-completions
+	cp contrib/completion/zsh/_docker $DIR/usr/share/zsh/vendor-completions/
+	mkdir -p $DIR/etc/fish/completions
+	cp contrib/completion/fish/docker.fish $DIR/etc/fish/completions/
+
 	# Copy the binary
 	# This will fail if the binary bundle hasn't been built
 	mkdir -p $DIR/usr/bin


### PR DESCRIPTION
put bash completion file into the ubuntu package so it's kept up to date.
