### PR TITLE
Cleanly shutdown docker

### DIFF
--- a/pkg/libcontainer/nsinit/exec.go
+++ b/pkg/libcontainer/nsinit/exec.go
@@ -50,8 +50,13 @@ func (ns *linuxNs) Exec(container *libcontainer.Container, term Terminal, args [
 	if err := command.Start(); err != nil {
 		return -1, err
 	}
+
+	started, err := system.GetProcessStartTime(command.Process.Pid)
+	if err != nil {
+		return -1, err
+	}
 	ns.logger.Printf("writting pid %d to file\n", command.Process.Pid)
-	if err := ns.stateWriter.WritePid(command.Process.Pid); err != nil {
+	if err := ns.stateWriter.WritePid(command.Process.Pid, started); err != nil {
 		command.Process.Kill()
 		return -1, err
 	}

--- a/pkg/libcontainer/nsinit/init.go
+++ b/pkg/libcontainer/nsinit/init.go
@@ -54,11 +54,6 @@ func (ns *linuxNs) Init(container *libcontainer.Container, uncleanRootfs, consol
 			return fmt.Errorf("setctty %s", err)
 		}
 	}
-	// this is our best effort to let the process know that the parent has died and that it
-	// should it should act on it how it sees fit
-	if err := system.ParentDeathSignal(uintptr(syscall.SIGTERM)); err != nil {
-		return fmt.Errorf("parent death signal %s", err)
-	}
 	if err := setupNetwork(container, context); err != nil {
 		return fmt.Errorf("setup networking %s", err)
 	}

--- a/pkg/libcontainer/nsinit/state.go
+++ b/pkg/libcontainer/nsinit/state.go
@@ -10,7 +10,7 @@ import (
 // StateWriter handles writing and deleting the pid file
 // on disk
 type StateWriter interface {
-	WritePid(pid int) error
+	WritePid(pid int, startTime string) error
 	DeletePid() error
 }
 
@@ -19,10 +19,18 @@ type DefaultStateWriter struct {
 }
 
 // writePidFile writes the namespaced processes pid to pid in the rootfs for the container
-func (d *DefaultStateWriter) WritePid(pid int) error {
-	return ioutil.WriteFile(filepath.Join(d.Root, "pid"), []byte(fmt.Sprint(pid)), 0655)
+func (d *DefaultStateWriter) WritePid(pid int, startTime string) error {
+	err := ioutil.WriteFile(filepath.Join(d.Root, "pid"), []byte(fmt.Sprint(pid)), 0655)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(filepath.Join(d.Root, "start"), []byte(startTime), 0655)
 }
 
 func (d *DefaultStateWriter) DeletePid() error {
-	return os.Remove(filepath.Join(d.Root, "pid"))
+	err := os.Remove(filepath.Join(d.Root, "pid"))
+	if serr := os.Remove(filepath.Join(d.Root, "start")); err == nil {
+		err = serr
+	}
+	return err
 }

--- a/pkg/system/proc.go
+++ b/pkg/system/proc.go
@@ -1,0 +1,26 @@
+package system
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// look in /proc to find the process start time so that we can verify
+// that this pid has started after ourself
+func GetProcessStartTime(pid int) (string, error) {
+	data, err := ioutil.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "stat"))
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(string(data), " ")
+	// the starttime is located at pos 22
+	// from the man page
+	//
+	// starttime %llu (was %lu before Linux 2.6)
+	// (22)  The  time the process started after system boot.  In kernels before Linux 2.6, this
+	// value was expressed in jiffies.  Since Linux 2.6, the value is expressed in  clock  ticks
+	// (divide by sysconf(_SC_CLK_TCK)).
+	return parts[22-1], nil // starts at 1
+}

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -915,7 +915,6 @@ func (container *Container) Stop(seconds int) error {
 
 	// 1. Send a SIGTERM
 	if err := container.KillSig(15); err != nil {
-		utils.Debugf("Error sending kill SIGTERM: %s", err)
 		log.Print("Failed to send SIGTERM to the process, force killing")
 		if err := container.KillSig(9); err != nil {
 			return err

--- a/runtime/execdriver/driver.go
+++ b/runtime/execdriver/driver.go
@@ -84,6 +84,7 @@ type Driver interface {
 	Name() string                                 // Driver name
 	Info(id string) Info                          // "temporary" hack (until we move state from core to plugins)
 	GetPidsForContainer(id string) ([]int, error) // Returns a list of pids for the given container.
+	Terminate(c *Command) error                   // kill it with fire
 }
 
 // Network settings of the container

--- a/runtime/execdriver/lxc/driver.go
+++ b/runtime/execdriver/lxc/driver.go
@@ -204,6 +204,10 @@ func (d *driver) Kill(c *execdriver.Command, sig int) error {
 	return KillLxc(c.ID, sig)
 }
 
+func (d *driver) Terminate(c *execdriver.Command) error {
+	return KillLxc(c.ID, 9)
+}
+
 func (d *driver) version() string {
 	var (
 		version string

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -192,7 +192,7 @@ func (runtime *Runtime) Register(container *Container) error {
 				if err != nil {
 					utils.Debugf("cannot find existing process for %d", existingPid)
 				}
-				runtime.execDriver.Kill(cmd, 9)
+				runtime.execDriver.Terminate(cmd)
 			}
 			if err := container.Unmount(); err != nil {
 				utils.Debugf("ghost unmount error %s", err)

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -797,13 +797,18 @@ func (runtime *Runtime) shutdown() error {
 	group := sync.WaitGroup{}
 	utils.Debugf("starting clean shutdown of all containers...")
 	for _, container := range runtime.List() {
-		if container.State.IsRunning() {
-			utils.Debugf("stopping %s", container.ID)
+		c := container
+		if c.State.IsRunning() {
+			utils.Debugf("stopping %s", c.ID)
 			group.Add(1)
 
 			go func() {
 				defer group.Done()
-				container.Stop(10)
+				if err := c.KillSig(15); err != nil {
+					utils.Debugf("kill 15 error for %s - %s", c.ID, err)
+				}
+				c.Wait()
+				utils.Debugf("container stopped %s", c.ID)
 			}()
 		}
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -197,6 +197,9 @@ func (runtime *Runtime) Register(container *Container) error {
 			if err := container.Unmount(); err != nil {
 				utils.Debugf("ghost unmount error %s", err)
 			}
+			if err := container.ToDisk(); err != nil {
+				utils.Debugf("saving ghost state to disk %s", err)
+			}
 		}
 
 		info := runtime.execDriver.Info(container.ID)

--- a/server/server.go
+++ b/server/server.go
@@ -54,7 +54,7 @@ func InitServer(job *engine.Job) engine.Status {
 	gosignal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 	go func() {
 		sig := <-c
-		log.Printf("Received signal '%v', exiting\n", sig)
+		log.Printf("Received signal '%v', starting shutdown of docker...\n", sig)
 		utils.RemovePidFile(srv.runtime.Config().Pidfile)
 		srv.Close()
 		os.Exit(0)


### PR DESCRIPTION
Ok, so here is what we will do when you stop docker.
### SIGKILL

Nothing we can do here.  However, when we restart we will find all ghosts containers and SIGKILL them because we are in an inconsistent state and they cannot be trusted.  We will then iterate though the state of the containers that were running and restart them for you.  
### SIGTERM, SIGINT, etc

When you shutdown docker we will send a SIGTERM to all running containers and wait until they stop before returning. If a container never stops then docker does not stop. It is up to the sysadmin to handle this. If the sysadmin SIGKILLs docker because it is not returning then they will end up with real ghost containers when docker is started again and we will SIGKILL them when docker reboots.  Any containers that were running will be restarted when docker starts again.
#### Implementation Details

1) We discussed keeping the prctl parent death signal to containers when docker dies unexpectedly but I think for consistence across the drivers we should not do this for native even if it is just a SIGTERM or whatever.  It makes the shutdown logic much cleaner and consistent in the long run.

2) Because the native driver still needs to kill ghosts ( because we don't deliver the prctl sig) but we don't want to be issuing SIGKILLS to pids that were not our own we now save the start time along with the pid in the native driver so that in the event of a system reboot, we can verify that the pid and it's start time are consistent with what we have on disk.
#### Side effects

The only side effect is the the docker daemon will take longer to shutdown.  We launch the stop of containers concurrently so the stop time will increase to the stop timeout configured ( ~10sec ).
#### Issues fixed

Fixes #4766 
Fixes #4767 
Fixes #4677 
Fixes #4641 
Fixes #4376 
Fixes #4141
