### PR TITLE
upstart: use exec here so upstart can monitor the process and not just the spawning shell

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -37,5 +37,5 @@ script
 	if [ -f /etc/default/$UPSTART_JOB ]; then
 		. /etc/default/$UPSTART_JOB
 	fi
-	"$DOCKER" -d $DOCKER_OPTS
+	exec "$DOCKER" -d $DOCKER_OPTS
 end script


### PR DESCRIPTION
Here is how the example docker upstart script (which seems to be bundled in the deb) runs docker:

```
$ sudo start docker
docker start/running, process 10150

$ ps uax | grep docker
root     10151  2.0  0.1 207452  6548 ?        Sl   10:23   0:00 /usr/bin/docker -d

$ ps aux | grep 10150
root     10150  0.0  0.0   4404   612 ?        Ss   10:23   0:00 /bin/sh -e /proc/self/fd/9
```

In this example, we can see that `upstart` believes that the pid it should be monitoring is 10150.  Upon inspection, we see that maps to the shell that spawns everything.  `docker` is actually on pid 10151.

If we use `exec`, things behave properly.  This is how things look on this branch:

```
ubuntu@docker-test5-pe1-prd:~$ sudo start docker
docker start/running, process 11394

ubuntu@docker-test5-pe1-prd:~$ ps aux | grep 11394
root     11394  2.2  0.1 272984  6380 ?        Ssl  10:28   0:00 /usr/bin/docker -d
```
