### PR TITLE
Adjust TestOnlyLoopbackExistsWhenUsingDisableNetworkOption to ignore "DOWN" interfaces

### DIFF
--- a/integration/container_test.go
+++ b/integration/container_test.go
@@ -1553,7 +1553,7 @@ func TestOnlyLoopbackExistsWhenUsingDisableNetworkOption(t *testing.T) {
 	runtime := mkRuntimeFromEngine(eng, t)
 	defer nuke(runtime)
 
-	config, hc, _, err := runconfig.Parse([]string{"-n=false", GetTestImage(runtime).ID, "ip", "addr", "show"}, nil)
+	config, hc, _, err := runconfig.Parse([]string{"-n=false", GetTestImage(runtime).ID, "ip", "addr", "show", "up"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This fixes the following test, which I've been seeing FAIL on all my machines for as long as I can remember:

``` console
$ make test-integration
...
--- FAIL: TestOnlyLoopbackExistsWhenUsingDisableNetworkOption (0.36 seconds)
    container_test.go:1597: Wrong interface count in test container: expected [*: lo], got [1: lo 2: sit0]
...
```

It seems that even inside namespaces, interfaces like "sit0" get copied in, but are down.  I don't know if this would be different if my host's "sit0" was up, but I would guess that it wouldn't get copied into the container network namespace if that were the case.  If someone has a simple method for me to bring sit0 up without disrupting the host machine too much, I'd definitely love to continue testing this further to make sure this really does fix the problem and not just hide it.
