### PR TITLE
Fix merge issue tty

### DIFF
--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -62,3 +62,24 @@ func TestCommitNewFile(t *testing.T) {
 
 	logDone("commit - commit file and read")
 }
+
+func TestCommitTTY(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "-t", "--name", "tty", "busybox", "/bin/ls")
+
+	if _, err := runCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd = exec.Command(dockerBinary, "commit", "tty", "ttytest")
+	imageId, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	imageId = strings.Trim(imageId, "\r\n")
+
+	cmd = exec.Command(dockerBinary, "run", "ttytest", "/bin/ls")
+
+	if _, err := runCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/integration/commands_test.go
+++ b/integration/commands_test.go
@@ -3,12 +3,6 @@ package docker
 import (
 	"bufio"
 	"fmt"
-	"github.com/dotcloud/docker/api/client"
-	"github.com/dotcloud/docker/daemon"
-	"github.com/dotcloud/docker/engine"
-	"github.com/dotcloud/docker/image"
-	"github.com/dotcloud/docker/pkg/term"
-	"github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"
 	"os"
@@ -19,6 +13,13 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/dotcloud/docker/api/client"
+	"github.com/dotcloud/docker/daemon"
+	"github.com/dotcloud/docker/engine"
+	"github.com/dotcloud/docker/image"
+	"github.com/dotcloud/docker/pkg/term"
+	"github.com/dotcloud/docker/utils"
 )
 
 func closeWrap(args ...io.Closer) error {
@@ -1162,28 +1163,4 @@ func TestCmdKill(t *testing.T) {
 	})
 
 	closeWrap(stdin, stdinPipe, stdout, stdoutPipe)
-}
-
-func TestRunTTYCommitRun(t *testing.T) {
-	cli := api.NewDockerCli(nil, ioutil.Discard, ioutil.Discard, testDaemonProto, testDaemonAddr, nil)
-
-	defer cleanup(globalEngine, t)
-
-	ch := make(chan struct{})
-	go func() {
-		defer close(ch)
-		cli.CmdRun("-t", unitTestImageID, "/bin/ls")
-	}()
-
-	container := waitContainerStart(t, 10*time.Second)
-	time.Sleep(500 * time.Millisecond)
-	setTimeout(t, "Waiting for container timedout", 5*time.Second, func() {
-		<-ch
-	})
-
-	cli.CmdCommit(container.ID, "ttytest")
-
-	if err := cli.CmdRun("ttytest", "/bin/ls"); err != nil {
-		t.Fatal(err)
-	}
 }

--- a/runconfig/merge.go
+++ b/runconfig/merge.go
@@ -65,15 +65,6 @@ func Merge(userConf, imageConf *Config) error {
 		}
 	}
 
-	if !userConf.Tty {
-		userConf.Tty = imageConf.Tty
-	}
-	if !userConf.OpenStdin {
-		userConf.OpenStdin = imageConf.OpenStdin
-	}
-	if !userConf.StdinOnce {
-		userConf.StdinOnce = imageConf.StdinOnce
-	}
 	if userConf.Env == nil || len(userConf.Env) == 0 {
 		userConf.Env = imageConf.Env
 	} else {


### PR DESCRIPTION
fix #4857
If you run a container with `-t` and then commit it. If you start to run an another container based on this image without `-t` you'll get an error, because the client will expect a `no-tty` communication, but the container will inherit from the image `tty` 

One solution (this PR) is to not merge the -i and -tty stuff from parent.

Another solution would be to fall back to display a warning and prevent the run if the client/deamon aren't in the same mode.

/cc @creack @shykes @crosbymichael
