### PR TITLE
Commit merges config from image, not container.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1064,7 +1064,13 @@ func (srv *Server) ContainerCommit(job *engine.Job) engine.Status {
 	if container == nil {
 		return job.Errorf("No such container: %s", name)
 	}
-	var config = container.Config
+
+	image, err := container.GetImage()
+	if err != nil {
+		return job.Error(err)
+	}
+
+	var config = image.Config
 	var newConfig runconfig.Config
 	if err := job.GetenvJson("config", &newConfig); err != nil {
 		return job.Error(err)


### PR DESCRIPTION
## Background
#1141 reported that `docker commit` drops the entire config in the resulting image. Specifically, the wording was “the configuration **the image had** is not kept.”
#4000 landed in v0.9.1, which uses the container config as the base config for `docker commit`, and merges in any additional config passed by `docker commit --run=…`.
## Problem

Any command specified on the `docker run` command line will clobber the default command configured in the original image (`config.Cmd`). For example, given `$image` built with `CMD /bin/true`, running `docker run $image touch /hello` and then `docker commit $container new_image`, the resulting image will have `touch /hello` instead of `/bin/true`.
## Proposal

The image created by `docker commit $container $image` should have its config based on `$container`'s image, not on `$container`'s own config.

This is more in line with the original request, to keep the config that “the image had”. It also makes it more useful for preserving `Cmd`, which is a prime use-case for the config-merge.

If a user wants config changes introduced by the `docker run` command to land in the committed image, they can pass them to `docker commit --run=…`. It's preferable to have to do this, compared to Dockerfile-declared configuration being clobbered.
## Example

``` sh
#!/bin/bash -e

docker --version

echo "Building 'clock' image with CMD /bin/date"
cat >Dockerfile <<END
FROM busybox:latest
CMD /bin/date
END
docker build --tag=clock . &>/dev/null

echo "Committing 'clock_committed' as result of 'docker run clock touch /hello'"
if [ -e cid ]; then rm cid; fi
docker run --cidfile=cid clock touch /hello
docker commit $(cat cid) clock_committed >/dev/null

echo -n "Cmd in 'clock build':  "
docker inspect --format='{{json .config.Cmd}}' clock

echo -n "Cmd in 'clock_committed': "
docker inspect --format='{{json .config.Cmd}}' clock_committed
```

Output (before this PR):

```
Docker version 0.9.1, build 3600720
Building 'clock' image with CMD /bin/date
Committing 'clock_committed' as result of 'docker run clock touch /hello'
Cmd in 'clock build':  ["/bin/sh","-c","/bin/date"]
Cmd in 'clock_committed': ["touch","/hello"]
```

Output (after this PR):

```
Docker version 0.9.1-dev, build 7767e78
Building 'clock' image with CMD /bin/date
Committing 'clock_committed' as result of 'docker run clock touch /hello'
Cmd in 'clock build':  ["/bin/sh","-c","/bin/date"]
Cmd in 'clock_committed': ["/bin/sh","-c","/bin/date"]
```
## TODO
- [x] Ensure unit tests pass.
- [ ] Ensure `TestMergeConfigOnCommit` in `integration/server_test.go` reflects this change.
- [ ] Ensure integration tests pass.
