### PR TITLE
Add missing port NAT configuration

### DIFF
--- a/docs/sources/examples/mongodb.rst
+++ b/docs/sources/examples/mongodb.rst
@@ -86,10 +86,10 @@ the local port!
 .. code-block:: bash
 
     # Regular style
-    MONGO_ID=$(sudo docker run -d <yourname>/mongodb)
+    MONGO_ID=$(sudo docker run -P -d <yourname>/mongodb)
 
     # Lean and mean
-    MONGO_ID=$(sudo docker run -d <yourname>/mongodb --noprealloc --smallfiles)
+    MONGO_ID=$(sudo docker run -P -d <yourname>/mongodb --noprealloc --smallfiles)
 
     # Check the logs out
     sudo docker logs $MONGO_ID


### PR DESCRIPTION
Missing port translation causes last line to fail

Docker-DCO-1.1-Signed-off-by: James Fisher jameshfisher@gmail.com (github: jameshfisher)
