### PR TITLE
Adding basic implementation of lmctfy exec driver.

### DIFF
--- a/runtime/execdriver/execdrivers/execdrivers.go
+++ b/runtime/execdriver/execdrivers/execdrivers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/dotcloud/docker/pkg/sysinfo"
 	"github.com/dotcloud/docker/runtime/execdriver"
+	"github.com/dotcloud/docker/runtime/execdriver/lmctfy"
 	"github.com/dotcloud/docker/runtime/execdriver/lxc"
 	"github.com/dotcloud/docker/runtime/execdriver/native"
 	"path"
@@ -18,6 +19,8 @@ func NewDriver(name, root, initPath string, sysInfo *sysinfo.SysInfo) (execdrive
 		return lxc.NewDriver(root, sysInfo.AppArmor)
 	case "native":
 		return native.NewDriver(path.Join(root, "execdriver", "native"), initPath)
+	case "lmctfy":
+		return lmctfy.NewDriver()
 	}
 	return nil, fmt.Errorf("unknown exec driver %s", name)
 }

--- a/runtime/execdriver/lmctfy/config.go
+++ b/runtime/execdriver/lmctfy/config.go
@@ -1,0 +1,144 @@
+package lmctfy
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/runtime/execdriver"
+	"path"
+	"os/exec"
+	"strings"
+)
+
+func buildUserCmd(c *execdriver.Command) []string {
+	cmd := []string{c.Entrypoint}
+	for _, arg := range c.Arguments {
+		cmd = append(cmd, arg)
+	}
+	return cmd
+}
+
+func addFlag(args *[]string, flagName, value string) {
+	*args = append(*args, flagName, value)
+}
+
+func buildDockerInitCmd(c *execdriver.Command) []string {
+	args := []string{"./" + path.Base(c.InitPath)}
+	if c.User != "" {
+		addFlag(&args, "-u", c.User)
+	}
+	if c.WorkingDir != "" {
+		addFlag(&args, "-w", c.WorkingDir)
+	}
+	if c.Privileged {
+		addFlag(&args, "-privileged", "")
+	}
+	addFlag(&args, "-driver", DriverName)
+	if c.ConfigPath != "" {
+		addFlag(&args, "-root", c.ConfigPath)
+	}
+	args = append(args, buildUserCmd(c)...)
+	return args
+}
+
+func getCustomInit(c *execdriver.Command) string {
+	customInit := "init: { init_argv: '"
+	customInit += strings.Join(buildDockerInitCmd(c), "' init_argv: '")
+	customInit += "' "
+	if c.Console != "" {
+		runSpec := fmt.Sprintf("run_spec: { console: { slave_pty: '%s' } }", path.Base(c.Console))
+		customInit += runSpec
+	}
+	return customInit + "}"
+}
+
+func getNetworkConfig(c *execdriver.Command) string {
+	if c.Network == nil || c.Network.Interface == nil {
+		return ""
+	}
+	vethId := c.ID
+	if len(vethId) > 10 {
+		vethId = vethId[0:10]
+	}
+	vethPair := fmt.Sprintf("veth_pair: { outside: 'veth%s' inside: 'eth0' }", vethId)
+	bridge := fmt.Sprintf("bridge: {name: 'docker0'}")
+	virtualIp := fmt.Sprintf("virtual_ip: { ip: '%s' netmask: '%d' gateway: '%s' mtu:%d }",
+		c.Network.Interface.IPAddress, c.Network.Interface.IPPrefixLen, c.Network.Interface.Gateway, c.Network.Mtu)
+
+	return fmt.Sprintf("network: { connection: {%s %s} %s}", vethPair, bridge, virtualIp)
+}
+
+func getVirtualHostSpec(c *execdriver.Command) string {
+	return fmt.Sprintf("virtual_host: { %s %s }", getCustomInit(c), getNetworkConfig(c))
+}
+
+func getLmctfyFilesystemConfig(c *execdriver.Command) string {
+	var output []string
+	for _, mount := range(c.Mounts) {
+		mountEntry := fmt.Sprintf("source: '%s' target: '%s' ", mount.Source, mount.Destination)
+		if mount.Private {
+			mountEntry += "private: true "
+		}
+		if !mount.Writable {
+			mountEntry += "read_only: true "
+		}
+		output = append(output, mountEntry)
+	}
+	if c.Console != "" {
+		mountEntry := fmt.Sprintf("source: '%s' target: '%s' private: true", c.Console, "dev/console")
+		output = append(output, mountEntry)
+	}
+	rootfsPath := fmt.Sprintf("rootfs: '%s'", c.Rootfs) 
+	return fmt.Sprintf("filesystem: { %s mounts: { mount: { %s } } }", rootfsPath, strings.Join(output, " } mount: { "))
+}
+
+func getContainerConfig(c *execdriver.Command) string {
+	var output []string
+	if c.Resources == nil {
+		return ""
+	}
+	// Use proto buf here
+	var memoryArgs []string
+	if c.Resources.Memory > 0 {
+		memoryArgs = append(memoryArgs, fmt.Sprintf("limit: %d", c.Resources.Memory))
+	}
+	if c.Resources.MemorySwap > 0 {
+		memoryArgs = append(memoryArgs, fmt.Sprintf("swap_limit: %d", c.Resources.MemorySwap))
+	}
+	if len(memoryArgs) > 0 {
+		output = append(output, fmt.Sprintf("memory: { %s }", strings.Join(memoryArgs, " ")))
+	}
+	if c.Resources.CpuShares > 0 {
+		output = append(output, fmt.Sprintf("cpu: {limit: %d}", c.Resources.CpuShares/CpuSharesPerCpu))
+	}
+	return fmt.Sprintf("%s %s", getLmctfyFilesystemConfig(c), strings.Join(output, " "))
+}
+
+func getLmctfyConfig(c *execdriver.Command) string {
+	return fmt.Sprintf("%s %s", getContainerConfig(c), getVirtualHostSpec(c))
+}
+
+func getCreaperCmd(c *execdriver.Command) []string {	
+	cmd := []string{
+		CreaperBinary,
+	}
+	cmd = append(cmd, c.ID)
+	return append(cmd, getLmctfyConfig(c))
+}
+
+func setupExecCmd(c *execdriver.Command, pipes *execdriver.Pipes) error {
+	term, err := setupTerminal(c, pipes)
+	if err != nil {
+		return err
+	}
+	c.Terminal = term
+	cmd := getCreaperCmd(c)
+	c.Path, err = exec.LookPath(cmd[0])
+	if err != nil {
+		return err
+	}
+	c.Args = append([]string{cmd[0]}, cmd[1:]...)
+	c.Cmd.Env = c.Env
+	if err := term.Attach(&c.Cmd); err != nil {
+		return err
+	}
+	return nil
+}

--- a/runtime/execdriver/lmctfy/driver.go
+++ b/runtime/execdriver/lmctfy/driver.go
@@ -1,0 +1,300 @@
+package lmctfy
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/runtime/execdriver"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+const (
+	DriverName    = "lmctfy"
+	LmctfyBinary  = "lmctfy"
+	CreaperBinary = "lmctfy-creaper"
+)
+
+type driver struct {
+}
+
+func init() {
+	// This method gets invoked from docker init.
+	execdriver.RegisterInitFunc(DriverName, func(args *execdriver.InitArgs) error {
+		log := log.New(os.Stderr, "", log.Lshortfile)
+		if err := setupHostname(args); err != nil {
+			log.Println(err)
+			return err
+		}
+		if err := setupCapabilities(args); err != nil {
+			log.Println(err)
+			return err
+		}
+
+		if err := setupWorkingDirectory(args); err != nil {
+			log.Println(err)
+			return err
+		}
+		if err := changeUser(args); err != nil {
+			log.Println(err)
+			return err
+		}
+
+		if len(args.Args) == 0 {
+			log.Printf("Input Args missing. Error!")
+			os.Exit(127)
+		}
+		path, err := exec.LookPath(args.Args[0])
+		if err != nil {
+			log.Printf("Unable to locate %v", args.Args[0])
+			os.Exit(127)
+		}
+		if err := syscall.Exec(path, args.Args, os.Environ()); err != nil {
+			errorMsg := fmt.Errorf("dockerinit unable to execute %s - %s", path, err)
+			log.Println(errorMsg)
+			return errorMsg
+		}
+		panic("Unreachable")
+	})
+}
+
+func NewDriver() (*driver, error) {
+	if output, err := exec.Command(LmctfyBinary, "init", "").CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("Err: lmctfy init failed with: %s and output: %s", err, output)
+	}
+	return &driver{}, nil
+}
+
+func (d *driver) Name() string {
+	return DriverName
+}
+
+func addFlag(args *[]string, flagName, value string) {
+	*args = append(*args, flagName, value)
+}
+
+func buildDockerInitCmd(c *execdriver.Command, pipes *execdriver.Pipes) []string {
+	args := []string{"./" + path.Base(c.InitPath)}
+	if c.User != "" {
+		addFlag(&args, "-u", c.User)
+	}
+	if c.Network != nil && c.Network.Interface != nil {
+		addFlag(&args, "-mtu", strconv.Itoa(c.Network.Mtu))
+		addFlag(&args, "-g", c.Network.Interface.Gateway)
+		addFlag(&args, "-i", fmt.Sprintf("%s/%d", c.Network.Interface.IPAddress, c.Network.Interface.IPPrefixLen))
+	}
+	if c.WorkingDir != "" {
+		addFlag(&args, "-w", c.WorkingDir)
+	}
+	if c.Privileged {
+		addFlag(&args, "-privileged", "")
+	}
+	addFlag(&args, "-driver", DriverName)
+
+	if c.Console != "" {
+		addFlag(&args, "-console", c.Console)
+	}
+	if c.ConfigPath != "" {
+		addFlag(&args, "-root", c.ConfigPath)
+	}
+	args = append(args, c.Entrypoint+" "+strings.Join(c.Arguments, " "))
+	return args
+}
+
+func buildLmctfyConfig(c *execdriver.Command) string {
+	var output []string
+	if c.Resources == nil {
+		return ""
+	}
+	// Use proto buf here
+	var memoryArgs []string
+	if c.Resources.Memory > 0 {
+		memoryArgs = append(memoryArgs, fmt.Sprintf("limit: %d", c.Resources.Memory))
+	}
+	if c.Resources.MemorySwap > 0 {
+		memoryArgs = append(memoryArgs, fmt.Sprintf("swap_limit: %d", c.Resources.MemorySwap))
+	}
+	if len(memoryArgs) > 0 {
+		output = append(output, fmt.Sprintf("memory: { %s }", strings.Join(memoryArgs, " ")))
+	}
+	if c.Resources.CpuShares > 0 {
+		output = append(output, fmt.Sprintf("cpu: {limit: %d}", c.Resources.CpuShares))
+	}
+	return strings.Join(output, " ")
+}
+
+func buildMountCommand(source, destination string, rw, private bool) []string {
+	cmd := []string{fmt.Sprintf("mount --rbind %s %s &&", source, destination)}
+	if !rw {
+		cmd = append(cmd, fmt.Sprintf("mount --rbind %s %s -o remount,ro &&", destination, destination))
+	}
+	var mountType string
+	if private {
+		mountType = "--make-rprivate"
+	} else {
+		mountType = "--make-rslave"
+	}
+	cmd = append(cmd, fmt.Sprintf("mount %s %s &&", mountType, destination))
+	return cmd
+}
+
+func buildMountWrapper(c *execdriver.Command) []string {
+	cmd := []string{}
+	for _, mount := range c.Mounts {
+		absDestinationPath := filepath.Join(c.Rootfs, mount.Destination)
+		cmd = append(cmd, buildMountCommand(mount.Source, absDestinationPath, mount.Writable, mount.Private)...)
+	}
+	cmd = append(cmd, fmt.Sprintf("mount --move $(cat /proc/mounts | grep shm | awk '{print $2}') %s &&", filepath.Join(c.Rootfs, "dev/shm")))
+	cmd = append(cmd, fmt.Sprintf("mount --move /sys %s &&", filepath.Join(c.Rootfs, "sys")))
+	cmd = append(cmd, fmt.Sprintf("mount --move /proc %s &&", filepath.Join(c.Rootfs, "proc")))
+	return cmd
+}
+
+func buildPivotRootWrapper(c *execdriver.Command, origCmd []string) []string {
+	cmd := []string{}
+	cmd = append(cmd, buildMountWrapper(c)...)
+	cmd = append(cmd, fmt.Sprintf("cd %s &&", c.Rootfs))
+	cmd = append(cmd, "mkdir old-root &&")
+	cmd = append(cmd, "pivot_root . old-root &&")
+	cmd = append(cmd, "cd / &&")
+	cmd = append(cmd, "umount -l old-root &&")
+	cmd = append(cmd, "exec")
+	cmd = append(cmd, "chroot . "+strings.Join(origCmd, " "))
+	return cmd
+}
+
+func buildNetworkConfig(veth_id string, network *execdriver.Network) string {
+	if network == nil || network.Interface == nil {
+		return ""
+	}
+	veth_pair_str := fmt.Sprintf("veth_pair: { outside: \"veth%s\" inside: \"eth0\" }", veth_id)
+	virtual_ip_str := fmt.Sprintf("virtual_ip: { ip: \"%s\" netmask: \"%d\" gateway: \"%s\" mtu:%d }",
+		network.Interface.IPAddress, network.Interface.IPPrefixLen, network.Interface.Gateway, network.Mtu)
+	return fmt.Sprintf("network: { %s %s }", veth_pair_str, virtual_ip_str)
+}
+
+func buildCreaperCmd(c *execdriver.Command, pipes *execdriver.Pipes) []string {
+	dockerCmd := buildDockerInitCmd(c, pipes)
+	realCmd := buildPivotRootWrapper(c, dockerCmd)
+	veth_id := c.ID
+	if len(veth_id) > 10 {
+		veth_id = veth_id[0:10]
+	}
+	lmctfy_command := fmt.Sprintf("%s virtual_host: { %s }", buildLmctfyConfig(c), buildNetworkConfig(veth_id, c.Network))
+	cmd := []string{
+		CreaperBinary,
+	}
+	if c.Network != nil && c.Network.Interface != nil && c.Network.Interface.Bridge != "" {
+		cmd = append(cmd, fmt.Sprintf("--networkSetup=brctl addif docker0 veth%s;\n /sbin/ifconfig veth%s up", veth_id, veth_id))
+	}
+	cmd = append(cmd, c.ID)
+	cmd = append(cmd, lmctfy_command)
+	cmd = append(cmd, strings.Join(realCmd, " "))
+	return cmd
+}
+
+func setupExecCmd(c *execdriver.Command, pipes *execdriver.Pipes) error {
+	var err error
+	cmd := buildCreaperCmd(c, pipes)
+	c.Path, err = exec.LookPath(cmd[0])
+	if err != nil {
+		return err
+	}
+	c.Args = append([]string{cmd[0]}, cmd[1:]...)
+	return nil
+}
+
+func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
+	var err error
+	if err = execdriver.SetTerminal(c, pipes); err != nil {
+		return -1, err
+	}
+	message := make(chan error)
+	if err = setupExecCmd(c, pipes); err != nil {
+		return -1, err
+	}
+	go func() {
+		if err := c.Run(); err != nil {
+			message <- fmt.Errorf("container creation failed. error: %s\ncommand:%s", err, c.Args)
+		} else {
+			message <- nil
+		}
+	}()
+
+	if startCallback != nil {
+		startCallback(c)
+	}
+
+	err = <-message
+	return 0, err
+}
+
+func removeContainer(id string) error {
+	if output, err := exec.Command(LmctfyBinary, "destroy", id).CombinedOutput(); err != nil {
+		return fmt.Errorf("Err: lmctfy create failed with: %s and output: %s", err, output)
+	}
+	return nil
+}
+
+/// Return the exit code of the process
+// if the process has not exited -1 will be returned
+func getExitCode(c *execdriver.Command) int {
+	if c.ProcessState == nil {
+		return -1
+	}
+	return c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+}
+
+func (d *driver) Kill(c *execdriver.Command, sig int) error {
+	pids, err := JustGetPidsForContainer(c.ID)
+	if err != nil {
+		return err
+	}
+	for _, pid := range pids {
+		if err := syscall.Kill(pid, syscall.Signal(sig)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type info struct {
+	id string
+}
+
+func (i *info) IsRunning() bool {
+	if pids, err := JustGetPidsForContainer(i.id); err != nil {
+		return false
+	} else {
+		return len(pids) > 0
+	}
+}
+
+func (d *driver) Info(id string) execdriver.Info {
+	return &info{id}
+}
+
+func JustGetPidsForContainer(id string) ([]int, error) {
+	pids := []int{}
+	output, err := exec.Command(LmctfyBinary, "-v", "list", "tids", id).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("Err: lmctfy list pids failed with: %s and output: %s", err, output)
+	}
+	tid_strings := strings.Split(string(output), "\n")
+	for _, tid_string := range tid_strings[0 : len(tid_strings)-1] {
+		tid, err := strconv.ParseInt(tid_string, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("Err %s: Couldn't parse a pid: %s for a container %s. Whole output: %s", err, tid_string, id, output)
+		}
+		pids = append(pids, int(tid))
+	}
+	return pids, nil
+}
+
+func (d *driver) GetPidsForContainer(id string) ([]int, error) {
+	return JustGetPidsForContainer(id)
+}

--- a/runtime/execdriver/lmctfy/driver.go
+++ b/runtime/execdriver/lmctfy/driver.go
@@ -2,13 +2,10 @@ package lmctfy
 
 import (
 	"fmt"
-	"github.com/dotcloud/docker/pkg/system"
 	"github.com/dotcloud/docker/runtime/execdriver"
 	"log"
 	"os"
 	"os/exec"
-	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -52,23 +49,6 @@ func init() {
 			return err
 		}
 
-		if args.Console != "" {
-			slave, err := system.OpenTerminal(args.Console, syscall.O_RDWR)
-			if err != nil {
-				return fmt.Errorf("open terminal %s", err)
-			}
-			if err := dupSlave(slave); err != nil {
-				return fmt.Errorf("dup2 slave %s", err)
-			}
-		}
-		if _, err := system.Setsid(); err != nil {
-			return fmt.Errorf("setsid %s", err)
-		}
-		if args.Console != "" {
-			if err := system.Setctty(); err != nil {
-				return fmt.Errorf("setctty %s", err)
-			}
-		}
 		if len(args.Args) == 0 {
 			log.Printf("Input Args missing. Error!")
 			os.Exit(127)
@@ -97,187 +77,13 @@ func (d *driver) Name() string {
 	return DriverName
 }
 
-func addFlag(args *[]string, flagName, value string) {
-	*args = append(*args, flagName, value)
-}
-
-func buildUserCmd(c *execdriver.Command) string {
-	cmd := []string{c.Entrypoint}
-	for _, arg := range c.Arguments {
-		cmd = append(cmd, strconv.Quote(arg))
-	}
-	return strings.Join(cmd, " ")
-}
-
-func buildDockerInitCmd(c *execdriver.Command, pipes *execdriver.Pipes) []string {
-	args := []string{"./" + path.Base(c.InitPath)}
-	if c.User != "" {
-		addFlag(&args, "-u", c.User)
-	}
-	if c.Network != nil && c.Network.Interface != nil {
-		addFlag(&args, "-mtu", strconv.Itoa(c.Network.Mtu))
-		addFlag(&args, "-g", c.Network.Interface.Gateway)
-		addFlag(&args, "-i", fmt.Sprintf("%s/%d", c.Network.Interface.IPAddress, c.Network.Interface.IPPrefixLen))
-	}
-	if c.WorkingDir != "" {
-		addFlag(&args, "-w", c.WorkingDir)
-	}
-	if c.Privileged {
-		addFlag(&args, "-privileged", "")
-	}
-	addFlag(&args, "-driver", DriverName)
-	if c.Console != "" {
-		addFlag(&args, "-console", "/dev/console")
-	}
-	if c.ConfigPath != "" {
-		addFlag(&args, "-root", c.ConfigPath)
-	}
-	args = append(args, buildUserCmd(c))
-	return args
-}
-
-func buildLmctfyConfig(c *execdriver.Command) string {
-	var output []string
-	if c.Resources == nil {
-		return ""
-	}
-	// Use proto buf here
-	var memoryArgs []string
-	if c.Resources.Memory > 0 {
-		memoryArgs = append(memoryArgs, fmt.Sprintf("limit: %d", c.Resources.Memory))
-	}
-	if c.Resources.MemorySwap > 0 {
-		memoryArgs = append(memoryArgs, fmt.Sprintf("swap_limit: %d", c.Resources.MemorySwap))
-	}
-	if len(memoryArgs) > 0 {
-		output = append(output, fmt.Sprintf("memory: { %s }", strings.Join(memoryArgs, " ")))
-	}
-	if c.Resources.CpuShares > 0 {
-		output = append(output, fmt.Sprintf("cpu: {limit: %d}", c.Resources.CpuShares/CpuSharesPerCpu))
-	}
-	return strings.Join(output, " ")
-}
-
-func buildConsoleSetupWrapper(c *execdriver.Command) []string {
-	var cmd []string
-	if c.Console == "" {
-		return cmd
-	}
-	cmd = append(cmd, fmt.Sprintf("mount -t devpts devpts %s -o %s &&", filepath.Join(c.Rootfs, "dev/pts"), "nosuid,noexec,relatime,ptmxmode=0666"))
-	ptmx := filepath.Join(c.Rootfs, "dev/ptmx")
-	cmd = append(cmd, fmt.Sprintf("rm %s &&", ptmx))
-	cmd = append(cmd, fmt.Sprintf("ln -s %s %s &&", "pts/ptmx", ptmx))
-
-	cmd = append(cmd, fmt.Sprintf("chmod 0600 %s &&", c.Console))
-	cmd = append(cmd, fmt.Sprintf("chown root %s &&", c.Console))
-	cmd = append(cmd, fmt.Sprintf("mount --bind %s %s -o %s &&", c.Console, filepath.Join(c.Rootfs, "dev/console"), "nosuid,noexec,relatime"))
-
-	return cmd
-}
-
-func buildMountCommand(source, destination string, rw, private bool) []string {
-	cmd := []string{fmt.Sprintf("mount --rbind %s %s &&", source, destination)}
-	if !rw {
-		cmd = append(cmd, fmt.Sprintf("mount --rbind %s %s -o remount,ro &&", destination, destination))
-	}
-	var mountType string
-	if private {
-		mountType = "--make-rprivate"
-	} else {
-		mountType = "--make-rslave"
-	}
-	cmd = append(cmd, fmt.Sprintf("mount %s %s &&", mountType, destination))
-	return cmd
-}
-
-func buildMountWrapper(c *execdriver.Command) []string {
-	cmd := []string{}
-	for _, mount := range c.Mounts {
-		absDestinationPath := filepath.Join(c.Rootfs, mount.Destination)
-		cmd = append(cmd, buildMountCommand(mount.Source, absDestinationPath, mount.Writable, mount.Private)...)
-	}
-	const mountOpts = "nosuid,nodev,noexec,relatime"
-	cmd = append(cmd, fmt.Sprintf("mount -t tmpfs shm %s -o %s &&", filepath.Join(c.Rootfs, "dev/shm"), "size=65536k,"+mountOpts))
-	cmd = append(cmd, "umount /sys &&")
-	cmd = append(cmd, fmt.Sprintf("mount -t sysfs sysfs %s -o %s &&", filepath.Join(c.Rootfs, "sys"), mountOpts))
-	cmd = append(cmd, "umount /proc &&")
-	cmd = append(cmd, fmt.Sprintf("mount -t proc proc %s -o %s &&", filepath.Join(c.Rootfs, "proc"), mountOpts))
-	return cmd
-}
-
-func buildPivotRootWrapper(c *execdriver.Command, origCmd []string) []string {
-	cmd := []string{}
-	cmd = append(cmd, buildMountWrapper(c)...)
-	cmd = append(cmd, buildConsoleSetupWrapper(c)...)
-	cmd = append(cmd, fmt.Sprintf("cd %s &&", c.Rootfs))
-	cmd = append(cmd, "mkdir old-root &&")
-	cmd = append(cmd, "pivot_root . old-root &&")
-	cmd = append(cmd, "cd / &&")
-	cmd = append(cmd, "umount -l old-root &&")
-	cmd = append(cmd, "exec")
-	cmd = append(cmd, "chroot . "+strings.Join(origCmd, " "))
-	return cmd
-}
-
-func buildNetworkConfig(veth_id string, network *execdriver.Network) string {
-	if network == nil || network.Interface == nil {
-		return ""
-	}
-	veth_pair_str := fmt.Sprintf("veth_pair: { outside: \"veth%s\" inside: \"eth0\" }", veth_id)
-	virtual_ip_str := fmt.Sprintf("virtual_ip: { ip: \"%s\" netmask: \"%d\" gateway: \"%s\" mtu:%d }",
-		network.Interface.IPAddress, network.Interface.IPPrefixLen, network.Interface.Gateway, network.Mtu)
-	return fmt.Sprintf("network: { %s %s }", veth_pair_str, virtual_ip_str)
-}
-
-func buildCreaperCmd(c *execdriver.Command, pipes *execdriver.Pipes) []string {
-	dockerCmd := buildDockerInitCmd(c, pipes)
-	realCmd := buildPivotRootWrapper(c, dockerCmd)
-	veth_id := c.ID
-	if len(veth_id) > 10 {
-		veth_id = veth_id[0:10]
-	}
-	lmctfy_command := fmt.Sprintf("%s virtual_host: { %s }", buildLmctfyConfig(c), buildNetworkConfig(veth_id, c.Network))
-	cmd := []string{
-		CreaperBinary,
-	}
-	if c.Network != nil && c.Network.Interface != nil && c.Network.Interface.Bridge != "" {
-		cmd = append(cmd, fmt.Sprintf("--networkSetup=brctl addif docker0 veth%s;\n /sbin/ifconfig veth%s up", veth_id, veth_id))
-	}
-	cmd = append(cmd, c.ID)
-	cmd = append(cmd, lmctfy_command)
-	cmd = append(cmd, strings.Join(realCmd, " "))
-	return cmd
-}
-
-func setupExecCmd(c *execdriver.Command, pipes *execdriver.Pipes) error {
-	term, err := setupTerminal(c, pipes)
-	if err != nil {
-		return err
-	}
-	c.Terminal = term
-	cmd := buildCreaperCmd(c, pipes)
-	c.Path, err = exec.LookPath(cmd[0])
-	if err != nil {
-		return err
-	}
-	c.Args = append([]string{cmd[0]}, cmd[1:]...)
-	c.Cmd.Env = c.Env
-	if err := term.Attach(&c.Cmd); err != nil {
-		return err
-	}
-	return nil
-}
-
 func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
 	var err error
-	if err = setupExecCmd(c, pipes); err != nil {
+	if err = performFsSetup(c); err != nil {
 		return -1, err
 	}
-	if c.Cmd.Stdout == nil {
-		c.Cmd.Stdout = os.Stdout
-	}
-	if c.Cmd.Stderr == nil {
-		c.Cmd.Stderr = os.Stderr
+	if err = setupExecCmd(c, pipes); err != nil {
+		return -1, err
 	}
 	if err = c.Start(); err != nil {
 		return -1, err
@@ -295,13 +101,13 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 }
 
 func removeContainer(id string) error {
-	if output, err := exec.Command(LmctfyBinary, "destroy", id).CombinedOutput(); err != nil {
+	if output, err := exec.Command(LmctfyBinary, "destroy", "-f", id).CombinedOutput(); err != nil {
 		return fmt.Errorf("Err: lmctfy create failed with: %s and output: %s", err, output)
 	}
 	return nil
 }
 
-/// Return the exit code of the process
+// Return the exit code of the process
 // if the process has not exited -1 will be returned
 func getExitCode(c *execdriver.Command) int {
 	if c.ProcessState == nil {

--- a/runtime/execdriver/lmctfy/driver.go
+++ b/runtime/execdriver/lmctfy/driver.go
@@ -323,6 +323,10 @@ func (d *driver) Kill(c *execdriver.Command, sig int) error {
 	return nil
 }
 
+func (d *driver) Terminate(c *execdriver.Command) error {
+	return d.Kill(c, 9)
+}
+
 type info struct {
 	id string
 }

--- a/runtime/execdriver/lmctfy/filesystem.go
+++ b/runtime/execdriver/lmctfy/filesystem.go
@@ -1,0 +1,100 @@
+package lmctfy
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/pkg/system"
+	"github.com/dotcloud/docker/runtime/execdriver"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+func createDefaultPaths(rootfs string) error {
+	// make /proc, /sysfs, /dev/shm, /dev/pts, /dev/ptmx
+	for _, dir := range []string{
+		"/proc",
+		"/sysfs",
+		"/dev/shm",
+		"/dev/pts",
+	} {
+		if err := os.MkdirAll(filepath.Join(rootfs, dir), 0700); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// copyDevNodes mknods the hosts devices so the new container has access to them
+func copyDevNodes(rootfs string) error {
+	oldMask := system.Umask(0000)
+	defer system.Umask(oldMask)
+
+	for _, node := range []string{
+		"null",
+		"zero",
+		"full",
+		"ptmx",
+		"random",
+		"urandom",
+		"tty",
+	} {
+		if err := copyDevNode(rootfs, node); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyDevNode(rootfs, node string) error {
+	stat, err := os.Stat(filepath.Join("/dev", node))
+	if err != nil {
+		return err
+	}
+	var (
+		dest = filepath.Join(rootfs, "dev", node)
+		st   = stat.Sys().(*syscall.Stat_t)
+	)
+	if err := system.Mknod(dest, st.Mode, int(st.Rdev)); err != nil && !os.IsExist(err) {
+		return fmt.Errorf("copy %s %s", node, err)
+	}
+	return nil
+}
+
+func createDevConsole(rootfs, console string) error {
+	stat, err := os.Stat(console)
+	if err != nil {
+		return fmt.Errorf("stat console %s %s", console, err)
+	}
+	var (
+		st   = stat.Sys().(*syscall.Stat_t)
+		dest = filepath.Join(rootfs, "dev/console")
+	)
+	if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove %s %s", dest, err)
+	}
+	if err := os.Chmod(console, 0600); err != nil {
+		return err
+	}
+	if err := os.Chown(console, 0, 0); err != nil {
+		return err
+	}
+	if err := system.Mknod(dest, (st.Mode&^07777)|0600, int(st.Rdev)); err != nil {
+		return fmt.Errorf("mknod %s %s", dest, err)
+	}
+	return nil
+}
+
+func performFsSetup(c *execdriver.Command) error {
+	if err := createDefaultPaths(c.Rootfs); err != nil {
+		return err
+	}
+	if err := copyDevNodes(c.Rootfs); err != nil {
+		return err
+	}
+	if c.Console != "" {
+		if err := createDevConsole(c.Rootfs, c.Console); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/runtime/execdriver/lmctfy/init.go
+++ b/runtime/execdriver/lmctfy/init.go
@@ -1,0 +1,99 @@
+package lmctfy
+
+import (
+	"fmt"
+	"github.com/dotcloud/docker/pkg/user"
+	"github.com/dotcloud/docker/runtime/execdriver"
+	"github.com/syndtr/gocapability/capability"
+	"os"
+	"strings"
+	"syscall"
+)
+
+func setupHostname(args *execdriver.InitArgs) error {
+	hostname := getEnv(args, "HOSTNAME")
+	if hostname == "" {
+		return nil
+	}
+	return syscall.Sethostname([]byte(hostname))
+}
+
+// Setup working directory
+func setupWorkingDirectory(args *execdriver.InitArgs) error {
+	if args.WorkDir == "" {
+		return nil
+	}
+	if err := syscall.Chdir(args.WorkDir); err != nil {
+		return fmt.Errorf("Unable to change dir to %v: %v", args.WorkDir, err)
+	}
+	return nil
+}
+
+// Takes care of dropping privileges to the desired user
+func changeUser(args *execdriver.InitArgs) error {
+	uid, gid, suppGids, err := user.GetUserGroupSupplementary(
+		args.User,
+		syscall.Getuid(), syscall.Getgid(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := syscall.Setgroups(suppGids); err != nil {
+		return fmt.Errorf("Setgroups failed: %v", err)
+	}
+	if err := syscall.Setgid(gid); err != nil {
+		return fmt.Errorf("Setgid failed: %v", err)
+	}
+	if err := syscall.Setuid(uid); err != nil {
+		return fmt.Errorf("Setuid failed: %v", err)
+	}
+
+	return nil
+}
+
+func setupCapabilities(args *execdriver.InitArgs) error {
+	if args.Privileged {
+		return nil
+	}
+
+	drop := []capability.Cap{
+		capability.CAP_SETPCAP,
+		capability.CAP_SYS_MODULE,
+		capability.CAP_SYS_RAWIO,
+		capability.CAP_SYS_PACCT,
+		capability.CAP_SYS_ADMIN,
+		capability.CAP_SYS_NICE,
+		capability.CAP_SYS_RESOURCE,
+		capability.CAP_SYS_TIME,
+		capability.CAP_SYS_TTY_CONFIG,
+		capability.CAP_MKNOD,
+		capability.CAP_AUDIT_WRITE,
+		capability.CAP_AUDIT_CONTROL,
+		capability.CAP_MAC_OVERRIDE,
+		capability.CAP_MAC_ADMIN,
+		capability.CAP_NET_ADMIN,
+	}
+
+	c, err := capability.NewPid(os.Getpid())
+	if err != nil {
+		return err
+	}
+
+	c.Unset(capability.CAPS|capability.BOUNDS, drop...)
+
+	if err := c.Apply(capability.CAPS | capability.BOUNDS); err != nil {
+		return err
+	}
+	return nil
+}
+
+func getEnv(args *execdriver.InitArgs, key string) string {
+	for _, kv := range args.Env {
+		parts := strings.SplitN(kv, "=", 2)
+		if parts[0] == key && len(parts) == 2 {
+			return parts[1]
+		}
+	}
+	return ""
+}

--- a/runtime/execdriver/lmctfy/term.go
+++ b/runtime/execdriver/lmctfy/term.go
@@ -1,0 +1,80 @@
+package lmctfy
+
+import (
+	"github.com/dotcloud/docker/pkg/system"
+	"github.com/dotcloud/docker/pkg/term"
+	"github.com/dotcloud/docker/runtime/execdriver"
+	"io"
+	"os"
+	"os/exec"
+)
+
+type Terminal interface {
+	io.Closer
+	SetMaster(*os.File)
+	Attach(*exec.Cmd) error
+	Resize(h, w int) error
+}
+
+func setupTerminal(c *execdriver.Command, pipes *execdriver.Pipes) (Terminal, error) {
+	if !c.Tty {
+		return &stdTerm{pipes: pipes}, nil
+	}
+	master, console, err := system.CreateMasterAndConsole()
+	if err != nil {
+		return nil, err
+	}
+	var term = ttyTerm{pipes: pipes}
+	term.SetMaster(master)
+	c.Console = console
+	return &term, nil
+}
+
+type stdTerm struct {
+	execdriver.StdConsole
+	pipes *execdriver.Pipes
+}
+
+func (t *stdTerm) Attach(cmd *exec.Cmd) error {
+	return t.AttachPipes(cmd, t.pipes)
+}
+
+func (t *stdTerm) SetMaster(master *os.File) {
+	// do nothing
+}
+
+func (t *stdTerm) Resize(h, w int) error {
+	return nil
+}
+
+func (t *stdTerm) Close() error {
+	return nil
+}
+
+type ttyTerm struct {
+	execdriver.TtyConsole
+	pipes   *execdriver.Pipes
+	console string
+}
+
+func (t *ttyTerm) Attach(cmd *exec.Cmd) error {
+	go io.Copy(t.pipes.Stdout, t.MasterPty)
+	if t.pipes.Stdin != nil {
+		go io.Copy(t.MasterPty, t.pipes.Stdin)
+	}
+	return nil
+}
+
+func (t *ttyTerm) SetMaster(master *os.File) {
+	t.MasterPty = master
+}
+
+func (t *ttyTerm) Resize(h, w int) error {
+	err := term.SetWinsize(t.MasterPty.Fd(), &term.Winsize{Height: uint16(h), Width: uint16(w)})
+	return err
+}
+
+func (t *ttyTerm) Close() error {
+	t.SlavePty.Close()
+	return t.MasterPty.Close()
+}

--- a/sysinit/sysinit.go
+++ b/sysinit/sysinit.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/dotcloud/docker/runtime/execdriver"
+	_ "github.com/dotcloud/docker/runtime/execdriver/lmctfy"
 	_ "github.com/dotcloud/docker/runtime/execdriver/lxc"
 	_ "github.com/dotcloud/docker/runtime/execdriver/native"
 	"log"


### PR DESCRIPTION
This adds a new execution driver for Docker which will use lmctfy. Docker can be
instructed to use lmctfy driver by passing the flag ‘-e lmctfy’ on startup of
the docker daemon.
This driver requires lmctfy version 0.4.5 or greater to be
installed. (https://github.com/google/lmctfy).

Docker-DCO-1.1-Signed-off-by: Vishnu Kannan vishnuk@google.com (github: vishh)
