### PR TITLE
Add generic daemon --opt and use it for some devmapper options

### DIFF
--- a/daemonconfig/config.go
+++ b/daemonconfig/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	ExecDriver                  string
 	Mtu                         int
 	DisableNetwork              bool
+	Options                     map[string][]string
 }
 
 // ConfigFromJob creates and returns a new DaemonConfig object
@@ -47,6 +48,8 @@ func ConfigFromJob(job *engine.Job) *Config {
 		GraphDriver:                 job.Getenv("GraphDriver"),
 		ExecDriver:                  job.Getenv("ExecDriver"),
 	}
+	job.GetenvJson("Options", &config.Options)
+
 	if dns := job.GetenvList("Dns"); dns != nil {
 		config.Dns = dns
 	}

--- a/docs/sources/reference/commandline/cli.rst
+++ b/docs/sources/reference/commandline/cli.rst
@@ -83,6 +83,7 @@ Commands
       --ip="0.0.0.0": Default IP address to use when binding container ports
       --ip-forward=true: Enable net.ipv4.ip_forward
       --iptables=true: Enable Docker's addition of iptables rules
+      -o, --opt=[]: Set custom daemon options
       -p, --pidfile="/var/run/docker.pid": Path to use for daemon PID file
       -r, --restart=true: Restart previously running containers
       -s, --storage-driver="": Force the docker runtime to use a specific storage driver

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -36,7 +36,7 @@ func fakeTar() (io.Reader, error) {
 }
 
 func mkTestTagStore(root string, t *testing.T) *TagStore {
-	driver, err := graphdriver.New(root)
+	driver, err := graphdriver.New(root, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/graph_test.go
+++ b/integration/graph_test.go
@@ -293,7 +293,7 @@ func tempGraph(t *testing.T) (*graph.Graph, graphdriver.Driver) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	driver, err := graphdriver.New(tmp)
+	driver, err := graphdriver.New(tmp, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -60,6 +60,24 @@ func (opts *ListOpts) GetMap() map[string]struct{} {
 	return ret
 }
 
+func (opts *ListOpts) SplitAtDot() (map[string][]string, error) {
+	out := make(map[string][]string, len(opts.GetAll()))
+	for _, o := range opts.GetAll() {
+		parts := strings.SplitN(o, ".", 2)
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("invalid opt format %s, missing '.'", o)
+		} else if strings.TrimSpace(parts[0]) == "" {
+			return nil, fmt.Errorf("key cannot be empty %s", o)
+		}
+		values, exists := out[parts[0]]
+		if !exists {
+			values = []string{}
+		}
+		out[parts[0]] = append(values, parts[1])
+	}
+	return out, nil
+}
+
 // GetAll returns the values' slice.
 // FIXME: Can we remove this?
 func (opts *ListOpts) GetAll() []string {

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -224,7 +224,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		WorkingDir:      *flWorkingDir,
 	}
 
-	driverOptions, err := parseDriverOpts(flDriverOpts)
+	driverOptions, err := flDriverOpts.SplitAtDot()
 	if err != nil {
 		return nil, nil, cmd, err
 	}
@@ -250,25 +250,6 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		config.StdinOnce = true
 	}
 	return config, hostConfig, cmd, nil
-}
-
-// options will come in the format of name.key=value or name.option
-func parseDriverOpts(opts opts.ListOpts) (map[string][]string, error) {
-	out := make(map[string][]string, len(opts.GetAll()))
-	for _, o := range opts.GetAll() {
-		parts := strings.SplitN(o, ".", 2)
-		if len(parts) < 2 {
-			return nil, fmt.Errorf("invalid opt format %s", o)
-		} else if strings.TrimSpace(parts[0]) == "" {
-			return nil, fmt.Errorf("key cannot be empty %s", o)
-		}
-		values, exists := out[parts[0]]
-		if !exists {
-			values = []string{}
-		}
-		out[parts[0]] = append(values, parts[1])
-	}
-	return out, nil
 }
 
 func parseKeyValueOpts(opts opts.ListOpts) ([]utils.KeyValuePair, error) {

--- a/runtime/graphdriver/aufs/aufs.go
+++ b/runtime/graphdriver/aufs/aufs.go
@@ -53,7 +53,7 @@ type Driver struct {
 func Init(root string, options map[string][]string) (graphdriver.Driver, error) {
 	// Try to load the aufs kernel module
 	if err := supportsAufs(); err != nil {
-		return nil, err
+		return nil, graphdriver.ErrNotSupported
 	}
 	paths := []string{
 		"mnt",

--- a/runtime/graphdriver/aufs/aufs.go
+++ b/runtime/graphdriver/aufs/aufs.go
@@ -50,7 +50,7 @@ type Driver struct {
 
 // New returns a new AUFS driver.
 // An error is returned if AUFS is not supported.
-func Init(root string) (graphdriver.Driver, error) {
+func Init(root string, options map[string][]string) (graphdriver.Driver, error) {
 	// Try to load the aufs kernel module
 	if err := supportsAufs(); err != nil {
 		return nil, err

--- a/runtime/graphdriver/aufs/aufs_test.go
+++ b/runtime/graphdriver/aufs/aufs_test.go
@@ -17,7 +17,7 @@ var (
 )
 
 func testInit(dir string, t *testing.T) graphdriver.Driver {
-	d, err := Init(dir)
+	d, err := Init(dir, nil)
 	if err != nil {
 		if err == ErrAufsNotSupported {
 			t.Skip(err)

--- a/runtime/graphdriver/aufs/aufs_test.go
+++ b/runtime/graphdriver/aufs/aufs_test.go
@@ -19,7 +19,7 @@ var (
 func testInit(dir string, t *testing.T) graphdriver.Driver {
 	d, err := Init(dir, nil)
 	if err != nil {
-		if err == ErrAufsNotSupported {
+		if err == graphdriver.ErrNotSupported {
 			t.Skip(err)
 		} else {
 			t.Fatal(err)

--- a/runtime/graphdriver/btrfs/btrfs.go
+++ b/runtime/graphdriver/btrfs/btrfs.go
@@ -31,7 +31,7 @@ func Init(home string, options map[string][]string) (graphdriver.Driver, error) 
 	}
 
 	if buf.Type != 0x9123683E {
-		return nil, fmt.Errorf("%s is not a btrfs filesystem", rootdir)
+		return nil, graphdriver.ErrNotSupported
 	}
 
 	return &Driver{

--- a/runtime/graphdriver/btrfs/btrfs.go
+++ b/runtime/graphdriver/btrfs/btrfs.go
@@ -22,7 +22,7 @@ func init() {
 	graphdriver.Register("btrfs", Init)
 }
 
-func Init(home string) (graphdriver.Driver, error) {
+func Init(home string, options map[string][]string) (graphdriver.Driver, error) {
 	rootdir := path.Dir(home)
 
 	var buf syscall.Statfs_t

--- a/runtime/graphdriver/devmapper/README.md
+++ b/runtime/graphdriver/devmapper/README.md
@@ -1,0 +1,73 @@
+## devicemapper - a storage backend based on Device Mapper
+
+### Theory of operation
+
+The device mapper graphdriver uses the device mapper thin provisioning
+module (dm-thinp) to implement CoW snapshots. For each devicemapper
+graph locaion (typically `/var/lib/docker/devicemapper`, $graph below)
+a thin pool is created based on two block devices, one for data and
+one for metadata.  By default these block devices are created
+automatically by using loopback mounts of automatically creates sparse
+files.
+
+The default loopback files used are `$graph/devicemapper/data` and
+`$graph/devicemapper/metadata`. Additional metadata required to map
+from docker entities to the corresponding devicemapper volumes is
+stored in the `$graph/devicemapper/json` file (encoded as Json).
+
+In order to support multiple devicemapper graphs on a system the thin
+pool will be named something like: `docker-0:33-19478248-pool`, where
+the `0:30` part is the minor/major device nr and `19478248` is the
+inode number of the $graph directory.
+
+On the thin pool docker automatically creates a base thin device,
+called something like `docker-0:33-19478248-base` of a fixed
+size. This is automatically formated on creation and contains just an
+empty filesystem. This device is the base of all docker images and
+containers. All base images are snapshots of this device and those
+images are then in turn used as snapshots for other images and
+eventually containers.
+
+### options
+
+The devicemapper backend supports some options that you can specify
+when starting the docker daemon using the -o / --opt flags.
+This uses the `dm` prefix and would be used somthing like `docker -d -o dm.foo=bar`.
+
+Here is the list of supported options:
+
+ *  `dm.basesize`
+
+    Specifies the size to use when creating the base device, which
+    limits the size of images and containers. The default value is
+    10G. Note, thin devices are inherently "sparse", so a 10G device
+    which is mostly empty doesn't use 10 GB of space on the
+    pool. However, the filesystem will use more space for the empty
+    case the larger the device is.
+
+    Example use:
+
+    ``docker -d -o dm.basesize=20G``
+
+ *  `dm.loopdatasize`
+
+    Specifies the size to use when creating the loopback file for the
+    "data" device which is used for the thin pool. The default size is
+    100G. Note that the file is sparse, so it will not initially take
+    up this much space.
+
+    Example use:
+
+    ``docker -d -o dm.loopdatasize=200G``
+
+ *  `dm.loopmetadatasize`
+
+    Specifies the size to use when creating the loopback file for the
+    "metadadata" device which is used for the thin pool. The default size is
+    2G. Note that the file is sparse, so it will not initially take
+    up this much space.
+
+    Example use:
+
+    ``docker -d -o dm.loopmetadatasize=4G``
+

--- a/runtime/graphdriver/devmapper/deviceset.go
+++ b/runtime/graphdriver/devmapper/deviceset.go
@@ -70,6 +70,11 @@ type DeviceSet struct {
 	NewTransactionId uint64
 	nextFreeDevice   int
 	sawBusy          bool
+
+	// Options
+	dataLoopbackSize     int64
+	metaDataLoopbackSize int64
+	baseFsSize           uint64
 }
 
 type DiskUsage struct {
@@ -353,8 +358,8 @@ func (devices *DeviceSet) setupBaseImage() error {
 		return err
 	}
 
-	utils.Debugf("Registering base device (id %v) with FS size %v", id, DefaultBaseFsSize)
-	info, err := devices.registerDevice(id, "", DefaultBaseFsSize)
+	utils.Debugf("Registering base device (id %v) with FS size %v", id, devices.baseFsSize)
+	info, err := devices.registerDevice(id, "", devices.baseFsSize)
 	if err != nil {
 		_ = deleteDevice(devices.getPoolDevName(), id)
 		utils.Debugf("\n--->Err: %s\n", err)
@@ -507,12 +512,12 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 	}
 
 	createdLoopback := !hasData || !hasMetadata
-	data, err := devices.ensureImage("data", DefaultDataLoopbackSize)
+	data, err := devices.ensureImage("data", devices.dataLoopbackSize)
 	if err != nil {
 		utils.Debugf("Error device ensureImage (data): %s\n", err)
 		return err
 	}
-	metadata, err := devices.ensureImage("metadata", DefaultMetaDataLoopbackSize)
+	metadata, err := devices.ensureImage("metadata", devices.metaDataLoopbackSize)
 	if err != nil {
 		utils.Debugf("Error device ensureImage (metadata): %s\n", err)
 		return err
@@ -1113,12 +1118,45 @@ func (devices *DeviceSet) Status() *Status {
 	return status
 }
 
-func NewDeviceSet(root string, doInit bool) (*DeviceSet, error) {
+func NewDeviceSet(root string, doInit bool, options []string) (*DeviceSet, error) {
 	SetDevDir("/dev")
 
 	devices := &DeviceSet{
-		root:     root,
-		MetaData: MetaData{Devices: make(map[string]*DevInfo)},
+		root:                 root,
+		MetaData:             MetaData{Devices: make(map[string]*DevInfo)},
+		dataLoopbackSize:     DefaultDataLoopbackSize,
+		metaDataLoopbackSize: DefaultMetaDataLoopbackSize,
+		baseFsSize:           DefaultBaseFsSize,
+	}
+
+	for _, option := range options {
+		key, val, err := utils.ParseKeyValueOpt(option)
+		if err != nil {
+			return nil, err
+		}
+		key = strings.ToLower(key)
+		switch key {
+		case "basesize":
+			size, err := utils.FromHumanSize(val)
+			if err != nil {
+				return nil, err
+			}
+			devices.baseFsSize = uint64(size)
+		case "loopdatasize":
+			size, err := utils.FromHumanSize(val)
+			if err != nil {
+				return nil, err
+			}
+			devices.dataLoopbackSize = size
+		case "loopmetadatasize":
+			size, err := utils.FromHumanSize(val)
+			if err != nil {
+				return nil, err
+			}
+			devices.metaDataLoopbackSize = size
+		default:
+			return nil, fmt.Errorf("Unknown option %s\n", key)
+		}
 	}
 
 	if err := devices.initDevmapper(doInit); err != nil {

--- a/runtime/graphdriver/devmapper/deviceset.go
+++ b/runtime/graphdriver/devmapper/deviceset.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/dotcloud/docker/pkg/label"
+	"github.com/dotcloud/docker/runtime/graphdriver"
 	"github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"

--- a/runtime/graphdriver/devmapper/deviceset.go
+++ b/runtime/graphdriver/devmapper/deviceset.go
@@ -486,6 +486,12 @@ func (devices *DeviceSet) ResizePool(size int64) error {
 func (devices *DeviceSet) initDevmapper(doInit bool) error {
 	logInit(devices)
 
+	_, err := getDriverVersion()
+	if err != nil {
+		// Can't even get driver version, assume not supported
+		return graphdriver.ErrNotSupported
+	}
+
 	// Make sure the sparse images exist in <root>/devicemapper/data and
 	// <root>/devicemapper/metadata
 

--- a/runtime/graphdriver/devmapper/devmapper.go
+++ b/runtime/graphdriver/devmapper/devmapper.go
@@ -50,6 +50,7 @@ var (
 	ErrTaskAddTarget          = errors.New("dm_task_add_target failed")
 	ErrTaskSetSector          = errors.New("dm_task_set_sector failed")
 	ErrTaskGetInfo            = errors.New("dm_task_get_info failed")
+	ErrTaskGetDriverVersion   = errors.New("dm_task_get_driver_version failed")
 	ErrTaskSetCookie          = errors.New("dm_task_set_cookie failed")
 	ErrNilCookie              = errors.New("cookie ptr can't be nil")
 	ErrAttachLoopbackDevice   = errors.New("loopback mounting failed")
@@ -170,6 +171,14 @@ func (t *Task) GetInfo() (*Info, error) {
 		return nil, ErrTaskGetInfo
 	}
 	return info, nil
+}
+
+func (t *Task) GetDriverVersion() (string, error) {
+	res := DmTaskGetDriverVersion(t.unmanaged)
+	if res == "" {
+		return "", ErrTaskGetDriverVersion
+	}
+	return res, nil
 }
 
 func (t *Task) GetNextTarget(next uintptr) (nextPtr uintptr, start uint64,
@@ -386,6 +395,17 @@ func getInfo(name string) (*Info, error) {
 		return nil, err
 	}
 	return task.GetInfo()
+}
+
+func getDriverVersion() (string, error) {
+	task := TaskCreate(DeviceVersion)
+	if task == nil {
+		return "", fmt.Errorf("Can't create DeviceVersion task")
+	}
+	if err := task.Run(); err != nil {
+		return "", err
+	}
+	return task.GetDriverVersion()
 }
 
 func getStatus(name string) (uint64, uint64, string, string, error) {

--- a/runtime/graphdriver/devmapper/devmapper_wrapper.go
+++ b/runtime/graphdriver/devmapper/devmapper_wrapper.go
@@ -85,23 +85,24 @@ const (
 )
 
 var (
-	DmGetLibraryVersion = dmGetLibraryVersionFct
-	DmGetNextTarget     = dmGetNextTargetFct
-	DmLogInitVerbose    = dmLogInitVerboseFct
-	DmSetDevDir         = dmSetDevDirFct
-	DmTaskAddTarget     = dmTaskAddTargetFct
-	DmTaskCreate        = dmTaskCreateFct
-	DmTaskDestroy       = dmTaskDestroyFct
-	DmTaskGetInfo       = dmTaskGetInfoFct
-	DmTaskRun           = dmTaskRunFct
-	DmTaskSetAddNode    = dmTaskSetAddNodeFct
-	DmTaskSetCookie     = dmTaskSetCookieFct
-	DmTaskSetMessage    = dmTaskSetMessageFct
-	DmTaskSetName       = dmTaskSetNameFct
-	DmTaskSetRo         = dmTaskSetRoFct
-	DmTaskSetSector     = dmTaskSetSectorFct
-	DmUdevWait          = dmUdevWaitFct
-	LogWithErrnoInit    = logWithErrnoInitFct
+	DmGetLibraryVersion    = dmGetLibraryVersionFct
+	DmGetNextTarget        = dmGetNextTargetFct
+	DmLogInitVerbose       = dmLogInitVerboseFct
+	DmSetDevDir            = dmSetDevDirFct
+	DmTaskAddTarget        = dmTaskAddTargetFct
+	DmTaskCreate           = dmTaskCreateFct
+	DmTaskDestroy          = dmTaskDestroyFct
+	DmTaskGetInfo          = dmTaskGetInfoFct
+	DmTaskGetDriverVersion = dmTaskGetDriverVersionFct
+	DmTaskRun              = dmTaskRunFct
+	DmTaskSetAddNode       = dmTaskSetAddNodeFct
+	DmTaskSetCookie        = dmTaskSetCookieFct
+	DmTaskSetMessage       = dmTaskSetMessageFct
+	DmTaskSetName          = dmTaskSetNameFct
+	DmTaskSetRo            = dmTaskSetRoFct
+	DmTaskSetSector        = dmTaskSetSectorFct
+	DmUdevWait             = dmUdevWaitFct
+	LogWithErrnoInit       = logWithErrnoInitFct
 )
 
 func free(p *C.char) {
@@ -182,6 +183,16 @@ func dmTaskGetInfoFct(task *CDmTask, info *Info) int {
 		info.TargetCount = int32(Cinfo.target_count)
 	}()
 	return int(C.dm_task_get_info((*C.struct_dm_task)(task), &Cinfo))
+}
+
+func dmTaskGetDriverVersionFct(task *CDmTask) string {
+	buffer := C.malloc(128)
+	defer C.free(buffer)
+	res := C.dm_task_get_driver_version((*C.struct_dm_task)(task), (*C.char)(buffer), 128)
+	if res == 0 {
+		return ""
+	}
+	return C.GoString((*C.char)(buffer))
 }
 
 func dmGetNextTargetFct(task *CDmTask, next uintptr, start, length *uint64, target, params *string) uintptr {

--- a/runtime/graphdriver/devmapper/driver.go
+++ b/runtime/graphdriver/devmapper/driver.go
@@ -27,7 +27,7 @@ type Driver struct {
 }
 
 var Init = func(home string, options map[string][]string) (graphdriver.Driver, error) {
-	deviceSet, err := NewDeviceSet(home, true)
+	deviceSet, err := NewDeviceSet(home, true, options["dm"])
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/graphdriver/devmapper/driver.go
+++ b/runtime/graphdriver/devmapper/driver.go
@@ -26,7 +26,7 @@ type Driver struct {
 	MountLabel string
 }
 
-var Init = func(home string) (graphdriver.Driver, error) {
+var Init = func(home string, options map[string][]string) (graphdriver.Driver, error) {
 	deviceSet, err := NewDeviceSet(home, true)
 	if err != nil {
 		return nil, err

--- a/runtime/graphdriver/devmapper/driver_test.go
+++ b/runtime/graphdriver/devmapper/driver_test.go
@@ -120,7 +120,7 @@ func mkTestDirectory(t *testing.T) string {
 
 func newDriver(t *testing.T) *Driver {
 	home := mkTestDirectory(t)
-	d, err := Init(home)
+	d, err := Init(home, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -289,7 +289,7 @@ func TestInit(t *testing.T) {
 			}
 			return nil
 		}
-		driver, err := Init(home)
+		driver, err := Init(home, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -325,9 +325,9 @@ func TestInit(t *testing.T) {
 	taskMessages.Assert(t, "create_thin 0", "set_transaction_id 0 1")
 }
 
-func fakeInit() func(home string) (graphdriver.Driver, error) {
+func fakeInit() func(home string, options map[string][]string) (graphdriver.Driver, error) {
 	oldInit := Init
-	Init = func(home string) (graphdriver.Driver, error) {
+	Init = func(home string, options map[string][]string) (graphdriver.Driver, error) {
 		return &Driver{
 			home: home,
 		}, nil
@@ -335,7 +335,7 @@ func fakeInit() func(home string) (graphdriver.Driver, error) {
 	return oldInit
 }
 
-func restoreInit(init func(home string) (graphdriver.Driver, error)) {
+func restoreInit(init func(home string, options map[string][]string) (graphdriver.Driver, error)) {
 	Init = init
 }
 
@@ -780,7 +780,7 @@ func TestInitCleanedDriver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	driver, err := Init(d.home)
+	driver, err := Init(d.home, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/runtime/graphdriver/devmapper/driver_test.go
+++ b/runtime/graphdriver/devmapper/driver_test.go
@@ -54,6 +54,9 @@ func denyAllDevmapper() {
 	DmTaskGetInfo = func(task *CDmTask, info *Info) int {
 		panic("DmTaskGetInfo: this method should not be called here")
 	}
+	DmTaskGetDriverVersion = func(task *CDmTask) string {
+		panic("DmTaskGetDriverVersion: this method should not be called here")
+	}
 	DmGetNextTarget = func(task *CDmTask, next uintptr, start, length *uint64, target, params *string) uintptr {
 		panic("DmGetNextTarget: this method should not be called here")
 	}
@@ -210,6 +213,14 @@ func TestInit(t *testing.T) {
 			info.Exists = 0
 			return 1
 		}
+		DmTaskGetDriverVersion = func(task *CDmTask) string {
+			calls["DmTaskGetDriverVersion"] = true
+			expectedTask := &task1
+			if task != expectedTask {
+				t.Fatalf("Wrong libdevmapper call\nExpected: DmTaskGetDriverVersion(%v)\nReceived: DmTaskGetDriverVersion(%v)\n", expectedTask, task)
+			}
+			return "1.1.1"
+		}
 		DmTaskSetSector = func(task *CDmTask, sector uint64) int {
 			calls["DmTaskSetSector"] = true
 			expectedTask := &task1
@@ -311,6 +322,7 @@ func TestInit(t *testing.T) {
 		"DmTaskSetName",
 		"DmTaskRun",
 		"DmTaskGetInfo",
+		"DmTaskGetDriverVersion",
 		"DmTaskDestroy",
 		"execRun",
 		"DmTaskCreate",
@@ -321,7 +333,7 @@ func TestInit(t *testing.T) {
 		"DmTaskSetMessage",
 		"DmTaskSetAddNode",
 	)
-	taskTypes.Assert(t, "0", "6", "17")
+	taskTypes.Assert(t, "0", "6", "9", "17")
 	taskMessages.Assert(t, "create_thin 0", "set_transaction_id 0 1")
 }
 
@@ -362,6 +374,10 @@ func mockAllDevmapper(calls Set) {
 	DmTaskGetInfo = func(task *CDmTask, info *Info) int {
 		calls["DmTaskGetInfo"] = true
 		return 1
+	}
+	DmTaskGetDriverVersion = func(task *CDmTask) string {
+		calls["DmTaskGetDriverVersion"] = true
+		return "1.1.1"
 	}
 	DmTaskSetSector = func(task *CDmTask, sector uint64) int {
 		calls["DmTaskSetSector"] = true
@@ -479,6 +495,7 @@ func TestDriverCreate(t *testing.T) {
 			"DmTaskSetName",
 			"DmTaskRun",
 			"DmTaskGetInfo",
+			"DmTaskGetDriverVersion",
 			"execRun",
 			"DmTaskCreate",
 			"DmTaskSetTarget",
@@ -597,6 +614,7 @@ func TestDriverRemove(t *testing.T) {
 			"DmTaskSetName",
 			"DmTaskRun",
 			"DmTaskGetInfo",
+			"DmTaskGetDriverVersion",
 			"execRun",
 			"DmTaskCreate",
 			"DmTaskSetTarget",

--- a/runtime/graphdriver/driver.go
+++ b/runtime/graphdriver/driver.go
@@ -1,9 +1,9 @@
 package graphdriver
 
 import (
+	"errors"
 	"fmt"
 	"github.com/dotcloud/docker/archive"
-	"github.com/dotcloud/docker/utils"
 	"os"
 	"path"
 )
@@ -43,6 +43,8 @@ var (
 		"devicemapper",
 		"vfs",
 	}
+
+	ErrNotSupported = errors.New("driver not supported")
 )
 
 func init() {
@@ -62,7 +64,7 @@ func GetDriver(name, home string, options map[string][]string) (Driver, error) {
 	if initFunc, exists := drivers[name]; exists {
 		return initFunc(path.Join(home, name), options)
 	}
-	return nil, fmt.Errorf("No such driver: %s", name)
+	return nil, ErrNotSupported
 }
 
 func New(root string, options map[string][]string) (driver Driver, err error) {
@@ -74,9 +76,12 @@ func New(root string, options map[string][]string) (driver Driver, err error) {
 
 	// Check for priority drivers first
 	for _, name := range priority {
-		if driver, err = GetDriver(name, root, options); err != nil {
-			utils.Debugf("Error loading driver %s: %s", name, err)
-			continue
+		driver, err = GetDriver(name, root, options)
+		if err != nil {
+			if err == ErrNotSupported {
+				continue
+			}
+			return nil, err
 		}
 		return driver, nil
 	}
@@ -84,9 +89,12 @@ func New(root string, options map[string][]string) (driver Driver, err error) {
 	// Check all registered drivers if no priority driver is found
 	for _, initFunc := range drivers {
 		if driver, err = initFunc(root, options); err != nil {
-			continue
+			if err == ErrNotSupported {
+				continue
+			}
+			return nil, err
 		}
 		return driver, nil
 	}
-	return nil, err
+	return nil, fmt.Errorf("No supported storage backend found")
 }

--- a/runtime/graphdriver/driver.go
+++ b/runtime/graphdriver/driver.go
@@ -8,7 +8,7 @@ import (
 	"path"
 )
 
-type InitFunc func(root string) (Driver, error)
+type InitFunc func(root string, options map[string][]string) (Driver, error)
 
 type Driver interface {
 	String() string
@@ -58,23 +58,23 @@ func Register(name string, initFunc InitFunc) error {
 	return nil
 }
 
-func GetDriver(name, home string) (Driver, error) {
+func GetDriver(name, home string, options map[string][]string) (Driver, error) {
 	if initFunc, exists := drivers[name]; exists {
-		return initFunc(path.Join(home, name))
+		return initFunc(path.Join(home, name), options)
 	}
 	return nil, fmt.Errorf("No such driver: %s", name)
 }
 
-func New(root string) (driver Driver, err error) {
+func New(root string, options map[string][]string) (driver Driver, err error) {
 	for _, name := range []string{os.Getenv("DOCKER_DRIVER"), DefaultDriver} {
 		if name != "" {
-			return GetDriver(name, root)
+			return GetDriver(name, root, options)
 		}
 	}
 
 	// Check for priority drivers first
 	for _, name := range priority {
-		if driver, err = GetDriver(name, root); err != nil {
+		if driver, err = GetDriver(name, root, options); err != nil {
 			utils.Debugf("Error loading driver %s: %s", name, err)
 			continue
 		}
@@ -83,7 +83,7 @@ func New(root string) (driver Driver, err error) {
 
 	// Check all registered drivers if no priority driver is found
 	for _, initFunc := range drivers {
-		if driver, err = initFunc(root); err != nil {
+		if driver, err = initFunc(root, options); err != nil {
 			continue
 		}
 		return driver, nil

--- a/runtime/graphdriver/vfs/driver.go
+++ b/runtime/graphdriver/vfs/driver.go
@@ -12,7 +12,7 @@ func init() {
 	graphdriver.Register("vfs", Init)
 }
 
-func Init(home string) (graphdriver.Driver, error) {
+func Init(home string, options map[string][]string) (graphdriver.Driver, error) {
 	d := &Driver{
 		home: home,
 	}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -680,7 +680,7 @@ func NewRuntimeFromDirectory(config *daemonconfig.Config, eng *engine.Engine) (*
 	graphdriver.DefaultDriver = config.GraphDriver
 
 	// Load storage driver
-	driver, err := graphdriver.New(config.Root)
+	driver, err := graphdriver.New(config.Root, config.Options)
 	if err != nil {
 		return nil, err
 	}
@@ -709,7 +709,7 @@ func NewRuntimeFromDirectory(config *daemonconfig.Config, eng *engine.Engine) (*
 
 	// We don't want to use a complex driver like aufs or devmapper
 	// for volumes, just a plain filesystem
-	volumesDriver, err := graphdriver.GetDriver("vfs", config.Root)
+	volumesDriver, err := graphdriver.GetDriver("vfs", config.Root, config.Options)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -121,6 +121,42 @@ func HumanSize(size int64) string {
 	return fmt.Sprintf("%.4g %s", sizef, units[i])
 }
 
+// FromHumanSize returns an integer from a human-readable specification of a size
+// using SI standard (eg. "44kB", "17MB")
+func FromHumanSize(size string) (int64, error) {
+	re, error := regexp.Compile("^(\\d+)([kKmMgGtTpP])?[bB]?$")
+	if error != nil {
+		return -1, fmt.Errorf("%s does not specify not a size", size)
+	}
+
+	matches := re.FindStringSubmatch(size)
+
+	if len(matches) != 3 {
+		return -1, fmt.Errorf("Invalid size: '%s'", size)
+	}
+
+	theSize, error := strconv.ParseInt(matches[1], 10, 0)
+	if error != nil {
+		return -1, error
+	}
+
+	unit := strings.ToLower(matches[2])
+
+	if unit == "k" {
+		theSize *= 1000
+	} else if unit == "m" {
+		theSize *= 1000 * 1000
+	} else if unit == "g" {
+		theSize *= 1000 * 1000 * 1000
+	} else if unit == "t" {
+		theSize *= 1000 * 1000 * 1000 * 1000
+	} else if unit == "p" {
+		theSize *= 1000 * 1000 * 1000 * 1000 * 1000
+	}
+
+	return theSize, nil
+}
+
 // Parses a human-readable string representing an amount of RAM
 // in bytes, kibibytes, mebibytes or gibibytes, and returns the
 // number of bytes, or -1 if the string is unparseable.

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -266,6 +266,41 @@ func TestHumanSize(t *testing.T) {
 	}
 }
 
+func TestFromHumanSize(t *testing.T) {
+	assertFromHumanSize(t, "32", false, 32)
+	assertFromHumanSize(t, "32b", false, 32)
+	assertFromHumanSize(t, "32B", false, 32)
+	assertFromHumanSize(t, "32k", false, 32*1000)
+	assertFromHumanSize(t, "32K", false, 32*1000)
+	assertFromHumanSize(t, "32kb", false, 32*1000)
+	assertFromHumanSize(t, "32Kb", false, 32*1000)
+	assertFromHumanSize(t, "32Mb", false, 32*1000*1000)
+	assertFromHumanSize(t, "32Gb", false, 32*1000*1000*1000)
+	assertFromHumanSize(t, "32Tb", false, 32*1000*1000*1000*1000)
+	assertFromHumanSize(t, "8Pb", false, 8*1000*1000*1000*1000*1000)
+
+	assertFromHumanSize(t, "", true, -1)
+	assertFromHumanSize(t, "hello", true, -1)
+	assertFromHumanSize(t, "-32", true, -1)
+	assertFromHumanSize(t, " 32 ", true, -1)
+	assertFromHumanSize(t, "32 mb", true, -1)
+	assertFromHumanSize(t, "32m b", true, -1)
+	assertFromHumanSize(t, "32bm", true, -1)
+}
+
+func assertFromHumanSize(t *testing.T, size string, expectError bool, expectedBytes int64) {
+	actualBytes, err := FromHumanSize(size)
+	if (err != nil) && !expectError {
+		t.Errorf("Unexpected error parsing '%s': %s", size, err)
+	}
+	if (err == nil) && expectError {
+		t.Errorf("Expected to get an error parsing '%s', but got none (bytes=%d)", size, actualBytes)
+	}
+	if actualBytes != expectedBytes {
+		t.Errorf("Expected '%s' to parse as %d bytes, got %d", size, expectedBytes, actualBytes)
+	}
+}
+
 func TestRAMInBytes(t *testing.T) {
 	assertRAMInBytes(t, "32", false, 32)
 	assertRAMInBytes(t, "32b", false, 32)


### PR DESCRIPTION
This adds a generic --opt used when starting the daemon which can be used for generic backend switches.
To prove this it also implements setting some devicemapper options:
    devmapper.basesize
    devmapper.loopbackdatasize
    devmapper.loopbackmetadatasize

Furthermore is makes failure during the initialization of a storage backend fatal, except for
when the backend is not supported. This is generally what you want as if you e.g. mistype
an option name you want the parse error reported, not have it silently use to the vfs backend.
