### PR TITLE
devmapper: Ensure we shut down thin pool cleanly.

### DIFF
--- a/runtime/graphdriver/devmapper/deviceset.go
+++ b/runtime/graphdriver/devmapper/deviceset.go
@@ -821,6 +821,10 @@ func (devices *DeviceSet) Shutdown() error {
 		info.lock.Unlock()
 	}
 
+	if err := devices.deactivateDevice(""); err != nil {
+		utils.Debugf("Shutdown deactivate base , error: %s\n", err)
+	}
+
 	if err := devices.deactivatePool(); err != nil {
 		utils.Debugf("Shutdown deactivate pool , error: %s\n", err)
 	}


### PR DESCRIPTION
The change in commit a9fa1a13c3b0a654a96be01ff7ec19e8009b2094
made us only deactivate devices that were mounted. Unfortunately
this made us not deactivate the base device. Which caused
us to not be able to deactivate the pool.

This fixes that by always just deactivating the base device.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
