### PR TITLE
Don't error when trying to start a running container

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -549,9 +549,11 @@ func (cli *DockerCli) forwardAllSignals(cid string) chan os.Signal {
 }
 
 func (cli *DockerCli) CmdStart(args ...string) error {
-	cmd := cli.Subcmd("start", "CONTAINER [CONTAINER...]", "Restart a stopped container")
-	attach := cmd.Bool([]string{"a", "-attach"}, false, "Attach container's stdout/stderr and forward all signals to the process")
-	openStdin := cmd.Bool([]string{"i", "-interactive"}, false, "Attach container's stdin")
+	var (
+		cmd       = cli.Subcmd("start", "CONTAINER [CONTAINER...]", "Restart a stopped container")
+		attach    = cmd.Bool([]string{"a", "-attach"}, false, "Attach container's stdout/stderr and forward all signals to the process")
+		openStdin = cmd.Bool([]string{"i", "-interactive"}, false, "Attach container's stdin")
+	)
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -560,8 +562,10 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 		return nil
 	}
 
-	var cErr chan error
-	var tty bool
+	var (
+		cErr chan error
+		tty  bool
+	)
 	if *attach || *openStdin {
 		if cmd.NArg() > 1 {
 			return fmt.Errorf("You cannot start and attach multiple containers at once.")

--- a/integration/container_test.go
+++ b/integration/container_test.go
@@ -350,7 +350,7 @@ func TestStart(t *testing.T) {
 	if !container.State.IsRunning() {
 		t.Errorf("Container should be running")
 	}
-	if err := container.Start(); err == nil {
+	if err := container.Start(); err != nil {
 		t.Fatalf("A running container should be able to be started")
 	}
 
@@ -385,7 +385,7 @@ func TestCpuShares(t *testing.T) {
 	if !container.State.IsRunning() {
 		t.Errorf("Container should be running")
 	}
-	if err := container.Start(); err == nil {
+	if err := container.Start(); err != nil {
 		t.Fatalf("A running container should be able to be started")
 	}
 

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -426,7 +426,7 @@ func (container *Container) Start() (err error) {
 	defer container.Unlock()
 
 	if container.State.IsRunning() {
-		return fmt.Errorf("The container %s is already running.", container.ID)
+		return nil
 	}
 
 	defer func() {

--- a/server/server.go
+++ b/server/server.go
@@ -2064,9 +2064,11 @@ func (srv *Server) ContainerStart(job *engine.Job) engine.Status {
 	if len(job.Args) < 1 {
 		return job.Errorf("Usage: %s container_id", job.Name)
 	}
-	name := job.Args[0]
-	runtime := srv.runtime
-	container := runtime.Get(name)
+	var (
+		name      = job.Args[0]
+		runtime   = srv.runtime
+		container = runtime.Get(name)
+	)
 
 	if container == nil {
 		return job.Errorf("No such container: %s", name)


### PR DESCRIPTION
This changes the behavior of `docker start`. Now, it does not fail when trying to start a running container.
This was already expected but was not the case (see integration/container_test.go l353 and l389).

The idea is to allow `docker start -a <container name>` to work all the time without having to do check if the container exists, if yes attach if no start then attach.

I could have simply updated `start -a` to not error if the container were already started, but as we already expect to be able to start a started container, I changed it for the whole command.
