### PR TITLE
Add "test-integration-cli" to our DEFAULT_BUNDLES list (make all)

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -43,6 +43,7 @@ DEFAULT_BUNDLES=(
 	binary
 	test
 	test-integration
+	test-integration-cli
 	dynbinary
 	dyntest
 	dyntest-integration


### PR DESCRIPTION
Whoops, forgot all about this in the main PR for the cli tests. :)
