### PR TITLE
ADD enhancement: allow adding from another image

### DIFF
--- a/docs/sources/reference/builder.rst
+++ b/docs/sources/reference/builder.rst
@@ -326,6 +326,35 @@ The copy obeys the following rules:
   written at ``<dest>``.
 * If ``<dest>`` doesn't exist, it is created along with all missing
   directories in its path.
+* If ``<src>`` is a URI with the scheme prefix of ``image://``, then followed
+  by the image name (including registry and/or tag, if needed), and has a
+  suffix of ``:`` and the path to be copied from. (i.e.
+  image://[registry[:port]]<name>[:tag]:<path> )
+
+A couple of examples on the usage of this ``image://`` in ``<src>``
+
+.. code-block:: bash
+
+    FROM scratch
+    ADD image://vbatts/fat-buildtime:/build/runtime/ /
+    ENTRYPOINT ["/runtime/bin/myapp"]
+
+Will copy the entire ``/build/runtime/`` directory, from the image
+``vbatts/fat-build``, to the root filesystem of the image being built.
+
+.. note::
+    If you build such a thin runtime, that does not provide ``/bin/sh``, then
+    the ``CMD`` instruction will fail
+
+.. code-block:: bash
+
+    FROM busybox
+    ADD image://my.registry.lan:5000/vbatts/fat-buildtime:stable:/build/runtime/bin/myapp /
+    CMD "/myapp"
+
+Will copy the file ``/build/runtime/bin/myapp`` from
+``my.registry.lan:5000/vbatts/fat-buildtime:stable`` image, to the root
+filesystem of the image being built.
 
 .. _dockerfile_entrypoint:
 

--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -494,6 +494,7 @@ func (b *buildFile) CmdAdd(args string) error {
 
 		srcConfig := &runconfig.Config{
 			Image: srcInfo["name"],
+			Cmd:   []string{"/bin/sh", "-c", fmt.Sprintf("#(nop) ADD %s in %s", orig, dest)},
 		}
 		srcContainer, _, err := b.runtime.Create(srcConfig, "")
 		if err != nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -709,6 +709,35 @@ func NewHTTPRequestError(msg string, res *http.Response) error {
 	}
 }
 
+// hardly keeping with RFC3986, but the docker ns/name:tag layout with a
+// "image://" prefix, and :<path> suffix. Like:
+//    image://[registry[:port]]<name>[:tag]:<path>
+func ParseImageURI(str string) (map[string]string, error) {
+	values := make(map[string]string)
+
+	if !IsIMAGE(str) || strings.Count(str, ":") < 2 {
+		return values, ErrImageUriFormat
+	}
+
+	base_str := strings.TrimPrefix(str, "image://")
+	i := strings.LastIndex(base_str, ":")
+	values["name"] = base_str[:i]
+	if len(values["name"]) == 0 {
+		return values, ErrImageUriFormat
+	}
+	values["path"] = base_str[i+1:]
+	if len(values["path"]) == 0 {
+		values["path"] = "/"
+	}
+	return values, nil
+}
+
+var ErrImageUriFormat = errors.New("image:// URI not properly formatted (image://[registry[:port]]<name>[:tag]:<path>)")
+
+func IsIMAGE(str string) bool {
+	return strings.HasPrefix(str, "image://")
+}
+
 func IsURL(str string) bool {
 	return strings.HasPrefix(str, "http://") || strings.HasPrefix(str, "https://")
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -675,6 +675,12 @@ func TestImageURI(t *testing.T) {
 		{"image://registry.com:5000/namespace/name:/build/file", map[string]string{"name": "registry.com:5000/namespace/name", "path": "/build/file"}, false},
 		{"image://registry.com:5000/namespace/name:/build/dir/", map[string]string{"name": "registry.com:5000/namespace/name", "path": "/build/dir/"}, false},
 		{"namespace/name:/build/file", map[string]string{}, true},
+    {"image://[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/namespace/name:/build/dir/", map[string]string{"name": "[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/namespace/name", "path": "/build/dir/"}, false},
+    {"image://[::192.9.5.5]/namespace/name:/build/dir/", map[string]string{"name": "[::192.9.5.5]/namespace/name", "path": "/build/dir/"}, false},
+    {"image://[2060::1]/namespace/name:/build/dir/", map[string]string{"name": "[2060::1]/namespace/name", "path": "/build/dir/"}, false},
+    {"image://[2060::1]:5000/namespace/name:/build/dir/", map[string]string{"name": "[2060::1]:5000/namespace/name", "path": "/build/dir/"}, false},
+    {"[2060::1]/namespace/name:/build/dir/", map[string]string{"name": "[2060::1]/namespace/name", "path": "/build/dir/"}, true},
+    {"[2060::1]:5000/namespace/name:/build/dir/", map[string]string{"name": "[2060::1]:5000/namespace/name", "path": "/build/dir/"}, true},
 	}
 
 	for _, item := range set {


### PR DESCRIPTION
Rather than adding an additional buildfile instruction, this enhancement
will use a mock-URI prefix of "image://", followed by a image name, and
a ":<path>" suffix. (i.e. image://[registry[:port]]<name>[:tag]:<path> )

Such that if you have a container that has a built artifact, you can
copy it over to a new/different image.

```
FROM vbatts/minimal-runtime

ADD image://vbatts/fat-buildtime:/build/server /server

CMD "/server"
```

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
