### PR TITLE
fix(runtime/networkdriver): don't fail on bridge

### DIFF
--- a/runtime/networkdriver/bridge/driver.go
+++ b/runtime/networkdriver/bridge/driver.go
@@ -300,6 +300,10 @@ func createBridgeIface(name string) error {
 	}
 
 	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, uintptr(s), siocBRADDBR, uintptr(unsafe.Pointer(nameBytePtr))); err != 0 {
+		if err == syscall.EEXIST {
+			utils.Debugf("Bridge socket creation failed with EEXIST, ignoring: %v", err)
+			return nil
+		}
 		return fmt.Errorf("Error creating bridge: %s", err)
 	}
 	return nil


### PR DESCRIPTION
This patch is untested but based on a user's feedback that docker 0.9.0 was
failing to restart. The backtrace from docker looked like this:

```
Started Docker Application Container Engine.
[/var/lib/docker|3500bf9c] +job serveapi(fd://)
[/var/lib/docker|3500bf9c] +job initserver()
[/var/lib/docker|3500bf9c.initserver()] Creating server 2014/03/31 22:06:15
Listening for HTTP on fd ()
[/var/lib/docker|3500bf9c] +job init_networkdriver()
[/var/lib/docker|3500bf9c.init_networkdriver()] creating new bridge for
docker0 Error creating bridge: file exists
[/var/lib/docker|3500bf9c] -job init_networkdriver() = ERR (1) Error creating
bridge: file exists
[/var/lib/docker|3500bf9c] -job initserver() = ERR (1) 2014/03/31 22:06:15
Error creating bridge: file exists
```

I can write a test case for this but before I got too far along I wanted to 
make sure that ignoring EEXIST was a reasonable approach.
