### PR TITLE
Simplify the output of 'docker images'

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1222,29 +1222,38 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 
 		w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
 		if !*quiet {
-			fmt.Fprintln(w, "REPOSITORY\tTAG\tIMAGE ID\tCREATED\tVIRTUAL SIZE")
+			fmt.Fprintln(w, "NAME\tTAG\tCREATED\tVIRTUAL SIZE\tLAYER ID")
 		}
-
-		for _, out := range outs.Data {
-			for _, repotag := range out.GetList("RepoTags") {
-
-				repo, tag := utils.ParseRepositoryTag(repotag)
-				outID := out.Get("Id")
-				if !*noTrunc {
-					outID = utils.TruncateID(outID)
+		for _, e := range outs.Data {
+			id := e.Get("Id")
+			if !*noTrunc {
+				id = utils.TruncateID(id)
+			}
+			if !*quiet {
+				name := e.Get("Name")
+				if name == "" {
+					name = "<none>"
 				}
-
-				if !*quiet {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\t%s\n", repo, tag, outID, utils.HumanDuration(time.Now().UTC().Sub(time.Unix(out.GetInt64("Created"), 0))), utils.HumanSize(out.GetInt64("VirtualSize")))
+				tag := e.Get("Tag")
+				if tag == "" {
+					tag = "<none>"
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s ago\t%s\t%s\n",
+					name,
+					tag,
+					utils.HumanDuration(time.Now().UTC().Sub(time.Unix(e.GetInt64("Created"), 0))),
+					utils.HumanSize(e.GetInt64("VirtualSize")),
+					id,
+				)
+			} else {
+				if name := e.Get("Name"); name != "" {
+					fmt.Fprintf(w, "%s:%s\n", name, e.Get("Tag"))
 				} else {
-					fmt.Fprintln(w, outID)
+					fmt.Fprintf(w, "%s\n", id)
 				}
 			}
 		}
-
-		if !*quiet {
-			w.Flush()
-		}
+		w.Flush()
 	}
 	return nil
 }
@@ -1292,9 +1301,9 @@ func (cli *DockerCli) printVizNode(noTrunc bool, image *engine.Env, prefix strin
 	} else {
 		fmt.Fprintf(cli.out, " \"%s\" -> \"%s\"\n", parentID, imageID)
 	}
-	if image.GetList("RepoTags")[0] != "<none>:<none>" {
-		fmt.Fprintf(cli.out, " \"%s\" [label=\"%s\\n%s\",shape=box,fillcolor=\"paleturquoise\",style=\"filled,rounded\"];\n",
-			imageID, imageID, strings.Join(image.GetList("RepoTags"), "\\n"))
+	if name := image.Get("Name"); name != "" {
+		entryName := fmt.Sprintf("%s:%s", image.Get("Name"), image.Get("Tag"))
+		fmt.Fprintf(cli.out, " \"%s\" [label=\"%s\",shape=box,fillcolor=\"paleturquoise\",style=\"filled,rounded\"];\n", imageID, entryName)
 	}
 }
 
@@ -1306,12 +1315,13 @@ func (cli *DockerCli) printTreeNode(noTrunc bool, image *engine.Env, prefix stri
 		imageID = utils.TruncateID(image.Get("Id"))
 	}
 
-	fmt.Fprintf(cli.out, "%s%s Virtual Size: %s", prefix, imageID, utils.HumanSize(image.GetInt64("VirtualSize")))
-	if image.GetList("RepoTags")[0] != "<none>:<none>" {
-		fmt.Fprintf(cli.out, " Tags: %s\n", strings.Join(image.GetList("RepoTags"), ", "))
+	var entryName string
+	if name := image.Get("Name"); name != "" {
+		entryName = fmt.Sprintf("%s:%s", image.Get("Name"), image.Get("Tag"))
 	} else {
-		fmt.Fprint(cli.out, "\n")
+		entryName = imageID
 	}
+	fmt.Fprintf(cli.out, "%s%s Virtual Size: %s\n", prefix, entryName, utils.HumanSize(image.GetInt64("VirtualSize")))
 }
 
 func (cli *DockerCli) CmdPs(args ...string) error {

--- a/server/server.go
+++ b/server/server.go
@@ -708,70 +708,50 @@ func (srv *Server) ImagesViz(job *engine.Job) engine.Status {
 }
 
 func (srv *Server) Images(job *engine.Job) engine.Status {
-	var (
-		allImages map[string]*image.Image
-		err       error
-	)
-	if job.GetenvBool("all") {
-		allImages, err = srv.runtime.Graph().Map()
-	} else {
-		allImages, err = srv.runtime.Graph().Heads()
-	}
-	if err != nil {
-		return job.Error(err)
-	}
-	lookup := make(map[string]*engine.Env)
-	for name, repository := range srv.runtime.Repositories().Repositories {
+	// What we currently call 'Repository' is what should really be used as the image.
+	entries := engine.NewTable("Name", 0)
+	for name, repo := range srv.runtime.Repositories().Repositories {
 		if job.Getenv("filter") != "" {
 			if match, _ := path.Match(job.Getenv("filter"), name); !match {
 				continue
 			}
 		}
-		for tag, id := range repository {
-			image, err := srv.runtime.Graph().Get(id)
+		for version, id := range repo {
+			img, err := srv.runtime.Graph().Get(id)
 			if err != nil {
-				log.Printf("Warning: couldn't load %s from %s/%s: %s", id, name, tag, err)
+				log.Printf("Warning: couldn't load %s from %s/%s: %s", id, name, version, err)
 				continue
 			}
-
-			if out, exists := lookup[id]; exists {
-				out.SetList("RepoTags", append(out.GetList("RepoTags"), fmt.Sprintf("%s:%s", name, tag)))
-			} else {
-				out := &engine.Env{}
-				delete(allImages, id)
-				out.Set("ParentId", image.Parent)
-				out.SetList("RepoTags", []string{fmt.Sprintf("%s:%s", name, tag)})
-				out.Set("Id", image.ID)
-				out.SetInt64("Created", image.Created.Unix())
-				out.SetInt64("Size", image.Size)
-				out.SetInt64("VirtualSize", image.GetParentsSize(0)+image.Size)
-				lookup[id] = out
-			}
-
+			entry := &engine.Env{}
+			entry.Set("Name", name)
+			entry.Set("Tag", version)
+			entry.Set("Id", id)
+			entry.Set("ParentId", img.Parent)
+			entry.SetInt64("Created", img.Created.Unix())
+			entry.SetInt64("Size", img.Size)
+			entry.SetInt64("VirtualSize", img.GetParentsSize(0)+img.Size)
+			entries.Add(entry)
 		}
 	}
-
-	outs := engine.NewTable("Created", len(lookup))
-	for _, value := range lookup {
-		outs.Add(value)
-	}
-
-	// Display images which aren't part of a repository/tag
-	if job.Getenv("filter") == "" {
-		for _, image := range allImages {
-			out := &engine.Env{}
-			out.Set("ParentId", image.Parent)
-			out.SetList("RepoTags", []string{"<none>:<none>"})
-			out.Set("Id", image.ID)
-			out.SetInt64("Created", image.Created.Unix())
-			out.SetInt64("Size", image.Size)
-			out.SetInt64("VirtualSize", image.GetParentsSize(0)+image.Size)
-			outs.Add(out)
+	entries.Sort()
+	if job.GetenvBool("all") {
+		allImages, err := srv.runtime.Graph().Map()
+		if err != nil {
+			return job.Error(err)
 		}
-	}
+		for id, img := range allImages {
+			entry := &engine.Env{}
+			entry.Set("Name", "")
+			entry.Set("Tag", "")
+			entry.Set("Id", id)
+			entry.SetInt64("Created", img.Created.Unix())
+			entry.SetInt64("Size", img.Size)
+			entry.SetInt64("VirtualSize", img.GetParentsSize(0)+img.Size)
+			entries.Add(entry)
+		}
 
-	outs.ReverseSort()
-	if _, err := outs.WriteListTo(job.Stdout); err != nil {
+	}
+	if _, err := entries.WriteListTo(job.Stdout); err != nil {
 		return job.Error(err)
 	}
 	return engine.StatusOK


### PR DESCRIPTION
This is a UI change only, but paves the way for future internals changes.

An image is presented to the user like a package: it has a name, and can have multiple versions.

What is internally known as "repository" is presented to the user as "image".

Layer IDs are still exposed but de-emphasized, and implicitly presented as an implementation detail

Unnamed images are not shown by default. They can still be shown with 'images -a' but this is a
first step towards hiding them altogether as a top-level construct. This
is necessary to implement frequently requested features such as image squashing.

Docker-DCO-1.1-Signed-off-by: Solomon Hykes solomon@docker.com (github: shykes)
