### PR TITLE
Inverted layer checksum and tarsum.

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -438,10 +438,10 @@ func (r *Registry) PushImageLayerRegistry(imgID string, layer io.Reader, registr
 	utils.Debugf("[registry] Calling PUT %s", registry+"images/"+imgID+"/layer")
 
 	h := sha256.New()
-	checksumLayer := &utils.CheckSum{Reader: layer, Hash: h}
-	tarsumLayer := &utils.TarSum{Reader: checksumLayer}
+	tarsumLayer := &utils.TarSum{Reader: layer}
+	checksumLayer := &utils.CheckSum{Reader: tarsumLayer, Hash: h}
 
-	req, err := r.reqFactory.NewRequest("PUT", registry+"images/"+imgID+"/layer", tarsumLayer)
+	req, err := r.reqFactory.NewRequest("PUT", registry+"images/"+imgID+"/layer", checksumLayer)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
The checksum of the payload has to be computed on the Gzip'ed content.
