### PR TITLE
Allow "SIG" prefix on signal names in `docker kill` ("SIGKILL", etc)

### DIFF
--- a/integration/commands_test.go
+++ b/integration/commands_test.go
@@ -1129,8 +1129,13 @@ func TestCmdKill(t *testing.T) {
 	})
 
 	setTimeout(t, "SIGUSR2 timed out", 2*time.Second, func() {
-		for i := 0; i < 10; i++ {
-			if err := cli2.CmdKill("--signal=USR2", container.ID); err != nil {
+		for i := 0; i < 20; i++ {
+			sig := "USR2"
+			if i%2 != 0 {
+				// Swap to testing "SIGUSR2" for every odd iteration
+				sig = "SIGUSR2"
+			}
+			if err := cli2.CmdKill("--signal="+sig, container.ID); err != nil {
 				t.Fatal(err)
 			}
 			if err := expectPipe("SIGUSR2", stdout); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -144,6 +144,10 @@ func (srv *Server) ContainerKill(job *engine.Job) engine.Status {
 		if err != nil {
 			// The signal is not a number, treat it as a string
 			sig = uint64(signal.SignalMap[job.Args[1]])
+			if sig == 0 && strings.HasPrefix(job.Args[1], "SIG") {
+				// If signal is prefixed with SIG, try with it stripped (ie, "SIGKILL", etc)
+				sig = uint64(signal.SignalMap[job.Args[1][3:]])
+			}
 			if sig == 0 {
 				return job.Errorf("Invalid signal: %s", job.Args[1])
 			}


### PR DESCRIPTION
This way, we can use both `docker kill -s INT some_container` and `docker kill -s SIGINT some_container` and both will do nice things for us. :)
