### PR TITLE
Fix dynamic port allocation limit

### DIFF
--- a/runtime/networkdriver/portallocator/portallocator.go
+++ b/runtime/networkdriver/portallocator/portallocator.go
@@ -18,8 +18,8 @@ type (
 )
 
 var (
+	ErrAllPortsAllocated    = errors.New("all ports are allocated")
 	ErrPortAlreadyAllocated = errors.New("port has already been allocated")
-	ErrPortExceedsRange     = errors.New("port exceeds upper range")
 	ErrUnknownProtocol      = errors.New("unknown protocol")
 )
 
@@ -152,17 +152,21 @@ func equalsDefault(ip net.IP) bool {
 
 func findNextPort(proto string, allocated *collections.OrderedIntSet) (int, error) {
 	port := nextPort(proto)
+	startSearchPort := port
 	for allocated.Exists(port) {
 		port = nextPort(proto)
-	}
-	if port > EndPortRange {
-		return 0, ErrPortExceedsRange
+		if startSearchPort == port {
+			return 0, ErrAllPortsAllocated
+		}
 	}
 	return port, nil
 }
 
 func nextPort(proto string) int {
 	c := currentDynamicPort[proto] + 1
+	if c > EndPortRange {
+		c = BeginPortRange
+	}
 	currentDynamicPort[proto] = c
 	return c
 }

--- a/runtime/networkdriver/portallocator/portallocator_test.go
+++ b/runtime/networkdriver/portallocator/portallocator_test.go
@@ -110,8 +110,8 @@ func TestAllocateAllPorts(t *testing.T) {
 		}
 	}
 
-	if _, err := RequestPort(defaultIP, "tcp", 0); err != ErrPortExceedsRange {
-		t.Fatalf("Expected error %s got %s", ErrPortExceedsRange, err)
+	if _, err := RequestPort(defaultIP, "tcp", 0); err != ErrAllPortsAllocated {
+		t.Fatalf("Expected error %s got %s", ErrAllPortsAllocated, err)
 	}
 
 	_, err := RequestPort(defaultIP, "udp", 0)


### PR DESCRIPTION
I made `findNextPort` search circularly rather than ending at `EndPortRange`. `findNextPort` will continue to search for a port until it determines that all the ports are allocated and return `ErrAllPortsAllocated`.
