### PR TITLE
Fix AB-BA deadlock in devicemapper backend

### DIFF
--- a/runtime/graphdriver/devmapper/deviceset.go
+++ b/runtime/graphdriver/devmapper/deviceset.go
@@ -864,7 +864,7 @@ func (devices *DeviceSet) MountDevice(hash, path string, mountLabel string) erro
 	info.mountPath = path
 	info.floating = false
 
-	return devices.setInitialized(hash)
+	return devices.setInitialized(info)
 }
 
 func (devices *DeviceSet) UnmountDevice(hash string, mode UnmountMode) error {
@@ -955,12 +955,7 @@ func (devices *DeviceSet) HasActivatedDevice(hash string) bool {
 	return devinfo != nil && devinfo.Exists != 0
 }
 
-func (devices *DeviceSet) setInitialized(hash string) error {
-	info := devices.Devices[hash]
-	if info == nil {
-		return fmt.Errorf("Unknown device %s", hash)
-	}
-
+func (devices *DeviceSet) setInitialized(info *DevInfo) error {
 	info.Initialized = true
 	if err := devices.saveMetadata(); err != nil {
 		info.Initialized = false

--- a/runtime/graphdriver/devmapper/deviceset.go
+++ b/runtime/graphdriver/devmapper/deviceset.go
@@ -235,12 +235,8 @@ func (devices *DeviceSet) registerDevice(id int, hash string, size uint64) (*Dev
 	return info, nil
 }
 
-func (devices *DeviceSet) activateDeviceIfNeeded(hash string) error {
-	utils.Debugf("activateDeviceIfNeeded(%v)", hash)
-	info := devices.Devices[hash]
-	if info == nil {
-		return fmt.Errorf("Unknown device %s", hash)
-	}
+func (devices *DeviceSet) activateDeviceIfNeeded(info *DevInfo) error {
+	utils.Debugf("activateDeviceIfNeeded(%v)", info.Hash)
 
 	if devinfo, _ := getInfo(info.Name()); devinfo != nil && devinfo.Exists != 0 {
 		return nil
@@ -343,7 +339,7 @@ func (devices *DeviceSet) setupBaseImage() error {
 
 	utils.Debugf("Creating filesystem on base device-manager snapshot")
 
-	if err = devices.activateDeviceIfNeeded(""); err != nil {
+	if err = devices.activateDeviceIfNeeded(info); err != nil {
 		utils.Debugf("\n--->Err: %s\n", err)
 		return err
 	}
@@ -605,7 +601,7 @@ func (devices *DeviceSet) deleteDevice(hash string) error {
 	// This is a workaround for the kernel not discarding block so
 	// on the thin pool when we remove a thinp device, so we do it
 	// manually
-	if err := devices.activateDeviceIfNeeded(hash); err == nil {
+	if err := devices.activateDeviceIfNeeded(info); err == nil {
 		if err := BlockDeviceDiscard(info.DevName()); err != nil {
 			utils.Debugf("Error discarding block on device: %s (ignoring)\n", err)
 		}
@@ -858,7 +854,7 @@ func (devices *DeviceSet) MountDevice(hash, path string, mountLabel string) erro
 		return nil
 	}
 
-	if err := devices.activateDeviceIfNeeded(hash); err != nil {
+	if err := devices.activateDeviceIfNeeded(info); err != nil {
 		return fmt.Errorf("Error activating devmapper device for '%s': %s", hash, err)
 	}
 
@@ -1028,7 +1024,7 @@ func (devices *DeviceSet) GetDeviceStatus(hash string) (*DevStatus, error) {
 		TransactionId: info.TransactionId,
 	}
 
-	if err := devices.activateDeviceIfNeeded(hash); err != nil {
+	if err := devices.activateDeviceIfNeeded(info); err != nil {
 		return nil, fmt.Errorf("Error activating devmapper device for '%s': %s", hash, err)
 	}
 

--- a/runtime/graphdriver/devmapper/deviceset.go
+++ b/runtime/graphdriver/devmapper/deviceset.go
@@ -313,7 +313,7 @@ func (devices *DeviceSet) setupBaseImage() error {
 
 	if oldInfo != nil && !oldInfo.Initialized {
 		utils.Debugf("Removing uninitialized base image")
-		if err := devices.deleteDevice(""); err != nil {
+		if err := devices.deleteDevice(oldInfo); err != nil {
 			utils.Debugf("\n--->Err: %s\n", err)
 			return err
 		}
@@ -592,12 +592,7 @@ func (devices *DeviceSet) AddDevice(hash, baseHash string) error {
 	return nil
 }
 
-func (devices *DeviceSet) deleteDevice(hash string) error {
-	info := devices.Devices[hash]
-	if info == nil {
-		return fmt.Errorf("hash %s doesn't exists", hash)
-	}
-
+func (devices *DeviceSet) deleteDevice(info *DevInfo) error {
 	// This is a workaround for the kernel not discarding block so
 	// on the thin pool when we remove a thinp device, so we do it
 	// manually
@@ -652,7 +647,7 @@ func (devices *DeviceSet) DeleteDevice(hash string) error {
 	info.lock.Lock()
 	defer info.lock.Unlock()
 
-	return devices.deleteDevice(hash)
+	return devices.deleteDevice(info)
 }
 
 func (devices *DeviceSet) deactivatePool() error {


### PR DESCRIPTION
We currently drop the global lock while holding a per-device lock when we are e.g sleeping for device removal, and then we re-aquire it when the sleep is done. This is causing a AB-BA deadlock if anyone at the same time tries to do any operation on that device like this:

```
thread A:             thread B
grabs global lock
grabs device lock
releases global lock
sleeps
                          grabs global lock
                          blocks on device lock
wakes up
blocks on global lock
```

To trigger this you can for instance do:

```
ID=`docker run -d fedora sleep 5`
cd /var/lib/docker/devicemapper/mnt/$ID
docker wait $ID
docker rm $ID &
docker rm $ID
```

The unmount will fail due to the mount being busy thus causing the timeout and the second rm will then trigger the deadlock.

This series of commit fixes this by first cleaning up the use of the Devices map, then introducing a separate lock for it so that it can be accessed independently of the global lock. Then we define (and use) a lock ordering such that the device locks are always grabbed before the global lock. 
