### PR TITLE
Adapt to binary name 'docker.io' in debian

### DIFF
--- a/contrib/mkimage-debootstrap.sh
+++ b/contrib/mkimage-debootstrap.sh
@@ -95,6 +95,12 @@ elif sudo docker version > /dev/null 2>&1; then
 	docker='sudo docker'
 elif command -v docker > /dev/null 2>&1; then
 	docker='docker'
+elif docker.io version > /dev/null 2>&1; then
+	docker='docker.io'
+elif sudo docker.io version > /dev/null 2>&1; then
+	docker='sudo docker.io'
+elif command -v docker.io > /dev/null 2>&1; then
+	docker='docker.io'
 else
 	echo >&2 "warning: either docker isn't installed, or your current user cannot run it;"
 	echo >&2 "         this script is not likely to work as expected"


### PR DESCRIPTION
The (unstable) debian repository holds docker under the name 'docker.io'. This patch aims to make the script work with that.
