### PR TITLE
Simplify the output of 'docker images'

### DIFF
--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -184,7 +183,7 @@ func TestGetImagesJSON(t *testing.T) {
 
 	found := false
 	for _, img := range images.Data {
-		if strings.Contains(img.GetList("RepoTags")[0], unitTestImageName) {
+		if img.Get("Name") == unitTestImageName {
 			found = true
 			break
 		}
@@ -1191,8 +1190,8 @@ func TestDeleteImages(t *testing.T) {
 
 	images := getImages(eng, t, true, "")
 
-	if len(images.Data[0].GetList("RepoTags")) != len(initialImages.Data[0].GetList("RepoTags"))+1 {
-		t.Errorf("Expected %d images, %d found", len(initialImages.Data[0].GetList("RepoTags"))+1, len(images.Data[0].GetList("RepoTags")))
+	if len(images.Data) != len(initialImages.Data) + 1 {
+		t.Errorf("Expected %d images, %d found", len(initialImages.Data) + 1, len(images.Data))
 	}
 
 	req, err := http.NewRequest("DELETE", "/images/"+unitTestImageID, nil)

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -1230,8 +1230,11 @@ func TestDeleteImages(t *testing.T) {
 	}
 	images = getImages(eng, t, false, "")
 
-	if images.Len() != initialImages.Len() {
-		t.Errorf("Expected %d image, %d found", initialImages.Len(), images.Len())
+	// 'docker images' lists names images only by default.
+	// So it doesn't matter anymore if the same underlying ID is named twice: that
+	// counts as 2 distinct images. Possible reuse of layers is an implementation detail.
+	if images.Len() != initialImages.Len() - 1 {
+		t.Errorf("Expected %d image, %d found", initialImages.Len(), images.Len() - 1)
 	}
 }
 

--- a/integration/commands_test.go
+++ b/integration/commands_test.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -820,105 +819,6 @@ func TestRunErrorBindNonExistingSource(t *testing.T) {
 
 	setTimeout(t, "CmdRun timed out", 5*time.Second, func() {
 		<-c
-	})
-}
-
-func TestImagesViz(t *testing.T) {
-	stdout, stdoutPipe := io.Pipe()
-
-	cli := client.NewDockerCli(nil, stdoutPipe, ioutil.Discard, testDaemonProto, testDaemonAddr, nil)
-	defer cleanup(globalEngine, t)
-
-	image := buildTestImages(t, globalEngine)
-
-	c := make(chan struct{})
-	go func() {
-		defer close(c)
-		if err := cli.CmdImages("--viz"); err != nil {
-			t.Fatal(err)
-		}
-		stdoutPipe.Close()
-	}()
-
-	setTimeout(t, "Reading command output time out", 2*time.Second, func() {
-		cmdOutputBytes, err := ioutil.ReadAll(bufio.NewReader(stdout))
-		if err != nil {
-			t.Fatal(err)
-		}
-		cmdOutput := string(cmdOutputBytes)
-
-		regexpStrings := []string{
-			"digraph docker {",
-			fmt.Sprintf("base -> \"%s\" \\[style=invis]", unitTestImageIDShort),
-			fmt.Sprintf("label=\"%s\\\\n%s:latest\"", unitTestImageIDShort, unitTestImageName),
-			fmt.Sprintf("label=\"%s\\\\n%s:%s\"", utils.TruncateID(image.ID), "test", "latest"),
-			"base \\[style=invisible]",
-		}
-
-		compiledRegexps := []*regexp.Regexp{}
-		for _, regexpString := range regexpStrings {
-			regexp, err := regexp.Compile(regexpString)
-			if err != nil {
-				fmt.Println("Error in regex string: ", err)
-				return
-			}
-			compiledRegexps = append(compiledRegexps, regexp)
-		}
-
-		for _, regexp := range compiledRegexps {
-			if !regexp.MatchString(cmdOutput) {
-				t.Fatalf("images --viz content '%s' did not match regexp '%s'", cmdOutput, regexp)
-			}
-		}
-	})
-}
-
-func TestImagesTree(t *testing.T) {
-	stdout, stdoutPipe := io.Pipe()
-
-	cli := client.NewDockerCli(nil, stdoutPipe, ioutil.Discard, testDaemonProto, testDaemonAddr, nil)
-	defer cleanup(globalEngine, t)
-
-	image := buildTestImages(t, globalEngine)
-
-	c := make(chan struct{})
-	go func() {
-		defer close(c)
-		if err := cli.CmdImages("--tree"); err != nil {
-			t.Fatal(err)
-		}
-		stdoutPipe.Close()
-	}()
-
-	setTimeout(t, "Reading command output time out", 2*time.Second, func() {
-		cmdOutputBytes, err := ioutil.ReadAll(bufio.NewReader(stdout))
-		if err != nil {
-			t.Fatal(err)
-		}
-		cmdOutput := string(cmdOutputBytes)
-		regexpStrings := []string{
-			fmt.Sprintf("└─%s Virtual Size: \\d+.\\d+ MB Tags: %s:latest", unitTestImageIDShort, unitTestImageName),
-			"(?m)   └─[0-9a-f]+.*",
-			"(?m)    └─[0-9a-f]+.*",
-			"(?m)      └─[0-9a-f]+.*",
-			fmt.Sprintf("(?m)^        └─%s Virtual Size: \\d+.\\d+ MB Tags: test:latest", utils.TruncateID(image.ID)),
-		}
-
-		compiledRegexps := []*regexp.Regexp{}
-		for _, regexpString := range regexpStrings {
-			regexp, err := regexp.Compile(regexpString)
-			if err != nil {
-				fmt.Println("Error in regex string: ", err)
-				return
-			}
-			compiledRegexps = append(compiledRegexps, regexp)
-		}
-
-		for _, regexp := range compiledRegexps {
-			if !regexp.MatchString(cmdOutput) {
-				t.Fatalf("images --tree content '%s' did not match regexp '%s'", cmdOutput, regexp)
-			}
-		}
 	})
 }
 

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -30,8 +30,8 @@ func TestImageTagImageDelete(t *testing.T) {
 
 	images := getAllImages(eng, t)
 
-	nExpected := len(initialImages.Data[0].GetList("RepoTags")) + 3
-	nActual := len(images.Data[0].GetList("RepoTags"))
+	nExpected := len(initialImages.Data) + 3
+	nActual := len(images.Data)
 	if nExpected != nActual {
 		t.Errorf("Expected %d images, %d found", nExpected, nActual)
 	}
@@ -42,8 +42,8 @@ func TestImageTagImageDelete(t *testing.T) {
 
 	images = getAllImages(eng, t)
 
-	nExpected = len(initialImages.Data[0].GetList("RepoTags")) + 2
-	nActual = len(images.Data[0].GetList("RepoTags"))
+	nExpected = len(initialImages.Data) + 2
+	nActual = len(images.Data)
 	if nExpected != nActual {
 		t.Errorf("Expected %d images, %d found", nExpected, nActual)
 	}
@@ -54,8 +54,8 @@ func TestImageTagImageDelete(t *testing.T) {
 
 	images = getAllImages(eng, t)
 
-	nExpected = len(initialImages.Data[0].GetList("RepoTags")) + 1
-	nActual = len(images.Data[0].GetList("RepoTags"))
+	nExpected = len(initialImages.Data) + 1
+	nActual = len(images.Data)
 
 	if err := srv.DeleteImage("utest:tag1", engine.NewTable("", 0), true, false, false); err != nil {
 		t.Fatal(err)
@@ -593,7 +593,7 @@ func TestRmi(t *testing.T) {
 		if strings.Contains(unitTestImageID, image.Get("Id")) {
 			continue
 		}
-		if image.GetList("RepoTags")[0] == "<none>:<none>" {
+		if image.Get("Name") == "" {
 			t.Fatalf("Expected tagged image, got untagged one.")
 		}
 	}
@@ -617,25 +617,25 @@ func TestImagesFilter(t *testing.T) {
 
 	images := getImages(eng, t, false, "utest*/*")
 
-	if len(images.Data[0].GetList("RepoTags")) != 2 {
+	if len(images.Data) != 2 {
 		t.Fatal("incorrect number of matches returned")
 	}
 
 	images = getImages(eng, t, false, "utest")
 
-	if len(images.Data[0].GetList("RepoTags")) != 1 {
+	if len(images.Data) != 1 {
 		t.Fatal("incorrect number of matches returned")
 	}
 
 	images = getImages(eng, t, false, "utest*")
 
-	if len(images.Data[0].GetList("RepoTags")) != 1 {
+	if len(images.Data) != 1 {
 		t.Fatal("incorrect number of matches returned")
 	}
 
 	images = getImages(eng, t, false, "*5000*/*")
 
-	if len(images.Data[0].GetList("RepoTags")) != 1 {
+	if len(images.Data) != 1 {
 		t.Fatal("incorrect number of matches returned")
 	}
 }

--- a/integration/sorter_test.go
+++ b/integration/sorter_test.go
@@ -39,7 +39,7 @@ func TestServerListOrderedImagesByCreationDateAndTag(t *testing.T) {
 
 	images := getImages(eng, t, true, "")
 
-	if repoTags := images.Data[0].GetList("RepoTags"); repoTags[0] != "repo:zed" && repoTags[0] != "repo:bar" {
+	if images.Data[0].Get("Tag") != "bar" && images.Data[0].Get("Tag") != "zed" {
 		t.Errorf("Expected Images to be ordered by most recent creation date.")
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -708,70 +708,50 @@ func (srv *Server) ImagesViz(job *engine.Job) engine.Status {
 }
 
 func (srv *Server) Images(job *engine.Job) engine.Status {
-	var (
-		allImages map[string]*image.Image
-		err       error
-	)
-	if job.GetenvBool("all") {
-		allImages, err = srv.runtime.Graph().Map()
-	} else {
-		allImages, err = srv.runtime.Graph().Heads()
-	}
-	if err != nil {
-		return job.Error(err)
-	}
-	lookup := make(map[string]*engine.Env)
-	for name, repository := range srv.runtime.Repositories().Repositories {
+	// What we currently call 'Repository' is what should really be used as the image.
+	entries := engine.NewTable("Name", 0)
+	for name, repo := range srv.runtime.Repositories().Repositories {
 		if job.Getenv("filter") != "" {
 			if match, _ := path.Match(job.Getenv("filter"), name); !match {
 				continue
 			}
 		}
-		for tag, id := range repository {
-			image, err := srv.runtime.Graph().Get(id)
+		for version, id := range repo {
+			img, err := srv.runtime.Graph().Get(id)
 			if err != nil {
-				log.Printf("Warning: couldn't load %s from %s/%s: %s", id, name, tag, err)
+				log.Printf("Warning: couldn't load %s from %s/%s: %s", id, name, version, err)
 				continue
 			}
-
-			if out, exists := lookup[id]; exists {
-				out.SetList("RepoTags", append(out.GetList("RepoTags"), fmt.Sprintf("%s:%s", name, tag)))
-			} else {
-				out := &engine.Env{}
-				delete(allImages, id)
-				out.Set("ParentId", image.Parent)
-				out.SetList("RepoTags", []string{fmt.Sprintf("%s:%s", name, tag)})
-				out.Set("Id", image.ID)
-				out.SetInt64("Created", image.Created.Unix())
-				out.SetInt64("Size", image.Size)
-				out.SetInt64("VirtualSize", image.GetParentsSize(0)+image.Size)
-				lookup[id] = out
-			}
-
+			entry := &engine.Env{}
+			entry.Set("Name", name)
+			entry.Set("Tag", version)
+			entry.Set("Id", id)
+			entry.Set("ParentId", img.Parent)
+			entry.SetInt64("Created", img.Created.Unix())
+			entry.SetInt64("Size", img.Size)
+			entry.SetInt64("VirtualSize", img.GetParentsSize(0)+img.Size)
+			entries.Add(entry)
 		}
 	}
-
-	outs := engine.NewTable("Created", len(lookup))
-	for _, value := range lookup {
-		outs.Add(value)
-	}
-
-	// Display images which aren't part of a repository/tag
-	if job.Getenv("filter") == "" {
-		for _, image := range allImages {
-			out := &engine.Env{}
-			out.Set("ParentId", image.Parent)
-			out.SetList("RepoTags", []string{"<none>:<none>"})
-			out.Set("Id", image.ID)
-			out.SetInt64("Created", image.Created.Unix())
-			out.SetInt64("Size", image.Size)
-			out.SetInt64("VirtualSize", image.GetParentsSize(0)+image.Size)
-			outs.Add(out)
+	entries.Sort()
+	if job.GetenvBool("all") {
+		allImages, err := srv.runtime.Graph().Map()
+		if err != nil {
+			return job.Error(err)
 		}
-	}
+		for id, img := range allImages {
+			entry := &engine.Env{}
+			entry.Set("Name", "")
+			entry.Set("Tag", "")
+			entry.Set("Id", id)
+			entry.SetInt64("Created", img.Created.Unix())
+			entry.SetInt64("Size", img.Size)
+			entry.SetInt64("VirtualSize", img.GetParentsSize(0)+img.Size)
+			entries.Add(entry)
+		}
 
-	outs.ReverseSort()
-	if _, err := outs.WriteListTo(job.Stdout); err != nil {
+	}
+	if _, err := entries.WriteListTo(job.Stdout); err != nil {
 		return job.Error(err)
 	}
 	return engine.StatusOK


### PR DESCRIPTION
This is a UI change only, but paves the way for future internals changes.

An image is presented to the user like a package: it has a name, and can
have multiple tags.

What is internally known as "repository" is presented to the user as "image".

Layer IDs are still exposed but de-emphasized, and implicitly presented as an implementation detail

Unnamed images are not shown by default. They can still be shown with 'images -a' but this is a
first step towards hiding them altogether as a top-level construct. This
is necessary to implement frequently requested features such as image squashing.

Docker-DCO-1.1-Signed-off-by: Solomon Hykes solomon@docker.com (github: shykes)
