### PR TITLE
Allow dev/shm size to be configurable in the native driver

### DIFF
--- a/pkg/libcontainer/container.go
+++ b/pkg/libcontainer/container.go
@@ -11,19 +11,20 @@ type Context map[string]string
 // Container defines configuration options for how a
 // container is setup inside a directory and how a process should be executed
 type Container struct {
-	Hostname         string          `json:"hostname,omitempty"`          // hostname
-	ReadonlyFs       bool            `json:"readonly_fs,omitempty"`       // set the containers rootfs as readonly
-	NoPivotRoot      bool            `json:"no_pivot_root,omitempty"`     // this can be enabled if you are running in ramdisk
-	User             string          `json:"user,omitempty"`              // user to execute the process as
-	WorkingDir       string          `json:"working_dir,omitempty"`       // current working directory
-	Env              []string        `json:"environment,omitempty"`       // environment to set
-	Tty              bool            `json:"tty,omitempty"`               // setup a proper tty or not
-	Namespaces       Namespaces      `json:"namespaces,omitempty"`        // namespaces to apply
-	CapabilitiesMask Capabilities    `json:"capabilities_mask,omitempty"` // capabilities to drop
-	Networks         []*Network      `json:"networks,omitempty"`          // nil for host's network stack
-	Cgroups          *cgroups.Cgroup `json:"cgroups,omitempty"`           // cgroups
-	Context          Context         `json:"context,omitempty"`           // generic context for specific options (apparmor, selinux)
-	Mounts           []Mount         `json:"mounts,omitempty"`
+	Hostname         string                       `json:"hostname,omitempty"`          // hostname
+	ReadonlyFs       bool                         `json:"readonly_fs,omitempty"`       // set the containers rootfs as readonly
+	NoPivotRoot      bool                         `json:"no_pivot_root,omitempty"`     // this can be enabled if you are running in ramdisk
+	User             string                       `json:"user,omitempty"`              // user to execute the process as
+	WorkingDir       string                       `json:"working_dir,omitempty"`       // current working directory
+	Env              []string                     `json:"environment,omitempty"`       // environment to set
+	Tty              bool                         `json:"tty,omitempty"`               // setup a proper tty or not
+	Namespaces       Namespaces                   `json:"namespaces,omitempty"`        // namespaces to apply
+	CapabilitiesMask Capabilities                 `json:"capabilities_mask,omitempty"` // capabilities to drop
+	Networks         []*Network                   `json:"networks,omitempty"`          // nil for host's network stack
+	Cgroups          *cgroups.Cgroup              `json:"cgroups,omitempty"`           // cgroups
+	Context          Context                      `json:"context,omitempty"`           // generic context for specific options (apparmor, selinux)
+	Mounts           []Mount                      `json:"mounts,omitempty"`
+	SystemMountData  map[string]map[string]string `json:"system_mount_data,omitempty"`
 }
 
 // Network defines configuration for a container's networking stack

--- a/pkg/libcontainer/nsinit/init.go
+++ b/pkg/libcontainer/nsinit/init.go
@@ -59,8 +59,9 @@ func (ns *linuxNs) Init(container *libcontainer.Container, uncleanRootfs, consol
 	}
 
 	label.Init()
+
 	ns.logger.Println("setup mount namespace")
-	if err := setupNewMountNamespace(rootfs, container.Mounts, console, container.ReadonlyFs, container.NoPivotRoot, container.Context["mount_label"]); err != nil {
+	if err := setupNewMountNamespace(container, rootfs, console); err != nil {
 		return fmt.Errorf("setup mount namespace %s", err)
 	}
 	if err := system.Sethostname(container.Hostname); err != nil {

--- a/runtime/execdriver/native/configuration/parse.go
+++ b/runtime/execdriver/native/configuration/parse.go
@@ -28,7 +28,8 @@ var actions = map[string]Action{
 
 	"apparmor_profile": apparmorProfile, // set the apparmor profile to apply
 
-	"fs.readonly": readonlyFs, // make the rootfs of the container read only
+	"fs.readonly":        readonlyFs, // make the rootfs of the container read only
+	"fs.system.shm.size": shmSize,    // dev/shm size
 }
 
 func cpusetCpus(container *libcontainer.Container, context interface{}, value string) error {
@@ -159,6 +160,17 @@ func vethMacAddress(container *libcontainer.Container, context interface{}, valu
 		return fmt.Errorf("not veth configured for container")
 	}
 	veth.Context["mac"] = value
+	return nil
+}
+
+func shmSize(container *libcontainer.Container, context interface{}, value string) error {
+	if container.SystemMountData == nil {
+		container.SystemMountData = make(map[string]map[string]string)
+	}
+
+	container.SystemMountData["shm"] = map[string]string{
+		"size": value,
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes #2606

Right now it's hard coded to a -o option.  I don't know if this is the
best way to do it because the hard coding fs.system.shm.size=512m could
lead to duplication but I like being explicit and with this way we can
easily see all the commands that are supported by the drivers.

I'm up to suggestions on how to handle this?

Can be configured by `docker run -o native.fs.system.shm.size=512m busybox mount`

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
