### PR TITLE
explained what authConfig actually is

### DIFF
--- a/docs/sources/reference/api/docker_remote_api.rst
+++ b/docs/sources/reference/api/docker_remote_api.rst
@@ -22,6 +22,8 @@ Docker Remote API
 - Since API version 1.2, the auth configuration is now handled client
   side, so the client has to send the authConfig as POST in
   /images/(name)/push
+- authConfig, set as the ``X-Registry-Auth`` header, is currently a Base64 encoded (json) string with credentials:  
+  ``{'username': string, 'password': string, 'email': string, 'serveraddress' : string}``
 
 2. Versions
 ===========


### PR DESCRIPTION
Timo trawled through the code to find out what the authConfig object in the header really is. 

As per: https://groups.google.com/forum/#!topic/docker-user/vXcA8fsCNZM
