### PR TITLE
Selinux

### DIFF
--- a/daemonconfig/config.go
+++ b/daemonconfig/config.go
@@ -1,10 +1,9 @@
 package daemonconfig
 
 import (
-	"net"
-
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/runtime/networkdriver"
+	"net"
 )
 
 const (

--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -21,3 +21,6 @@ func SetFileLabel(path string, fileLabel string) error {
 func GetPidCon(pid int) (string, error) {
 	return "", nil
 }
+
+func Init() {
+}

--- a/pkg/label/label_selinux.go
+++ b/pkg/label/label_selinux.go
@@ -67,3 +67,7 @@ func SetFileLabel(path string, fileLabel string) error {
 func GetPidCon(pid int) (string, error) {
 	return selinux.Getpidcon(pid)
 }
+
+func Init() {
+	selinux.SelinuxEnabled()
+}

--- a/pkg/libcontainer/nsinit/init.go
+++ b/pkg/libcontainer/nsinit/init.go
@@ -58,6 +58,8 @@ func (ns *linuxNs) Init(container *libcontainer.Container, uncleanRootfs, consol
 	if err := system.ParentDeathSignal(uintptr(syscall.SIGTERM)); err != nil {
 		return fmt.Errorf("parent death signal %s", err)
 	}
+
+	label.Init()
 	ns.logger.Println("setup mount namespace")
 	if err := setupNewMountNamespace(rootfs, container.Mounts, console, container.ReadonlyFs, container.NoPivotRoot, container.Context["mount_label"]); err != nil {
 		return fmt.Errorf("setup mount namespace %s", err)

--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -312,13 +312,10 @@ func GetLxcContexts() (processLabel string, fileLabel string) {
 	if !SelinuxEnabled() {
 		return "", ""
 	}
-	lxcPath := fmt.Sprintf("%s/content/lxc_contexts", GetSELinuxPolicyRoot())
-	fileLabel = "system_u:object_r:svirt_sandbox_file_t:s0"
-	processLabel = "system_u:system_r:svirt_lxc_net_t:s0"
-
+	lxcPath := fmt.Sprintf("%s/contexts/lxc_contexts", GetSELinuxPolicyRoot())
 	in, err := os.Open(lxcPath)
 	if err != nil {
-		goto exit
+		return "", ""
 	}
 	defer in.Close()
 
@@ -352,6 +349,11 @@ func GetLxcContexts() (processLabel string, fileLabel string) {
 			}
 		}
 	}
+
+	if processLabel == "" || fileLabel == "" {
+		return "", ""
+	}
+
 exit:
 	mcs := IntToMcs(os.Getpid(), 1024)
 	scon := NewContext(processLabel)

--- a/runtime/execdriver/lxc/lxc_template.go
+++ b/runtime/execdriver/lxc/lxc_template.go
@@ -32,8 +32,8 @@ lxc.pts = 1024
 lxc.console = none
 {{if getProcessLabel .Context}}
 lxc.se_context = {{ getProcessLabel .Context}}
-{{$MOUNTLABEL := getMountLabel .Context}}
 {{end}}
+{{$MOUNTLABEL := getMountLabel .Context}}
 
 # no controlling tty at all
 lxc.tty = 1
@@ -90,8 +90,8 @@ lxc.mount.entry = sysfs {{escapeFstabSpaces $ROOTFS}}/sys sysfs nosuid,nodev,noe
 lxc.mount.entry = {{.Console}} {{escapeFstabSpaces $ROOTFS}}/dev/console none bind,rw 0 0
 {{end}}
 
-lxc.mount.entry = devpts {{escapeFstabSpaces $ROOTFS}}/dev/pts devpts {{formatMountLabel "newinstance,ptmxmode=0666,nosuid,noexec" "$MOUNTLABEL"}} 0 0
-lxc.mount.entry = shm {{escapeFstabSpaces $ROOTFS}}/dev/shm tmpfs {{formatMountLabel "size=65536k,nosuid,nodev,noexec" "$MOUNTLABEL"}} 0 0
+lxc.mount.entry = devpts {{escapeFstabSpaces $ROOTFS}}/dev/pts devpts {{formatMountLabel "newinstance,ptmxmode=0666,nosuid,noexec" $MOUNTLABEL}} 0 0
+lxc.mount.entry = shm {{escapeFstabSpaces $ROOTFS}}/dev/shm tmpfs {{formatMountLabel "size=65536k,nosuid,nodev,noexec" $MOUNTLABEL}} 0 0
 
 {{range $value := .Mounts}}
 {{if $value.Writable}}


### PR DESCRIPTION
This patch set will fix SELinux issues.  The biggest one is the breakage of lxc containers whether or not SELinux is enabled.

We also do not want to attempt to setup labels if the system does not have policy for the labels, even if the system has SELinux turned on.
