### PR TITLE
Fix --volumes-from mount failure

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -272,6 +272,24 @@ func TestDockerRunWithVolumesAsFiles(t *testing.T) {
 	logDone("run - regression test for #4741 - volumes from as files")
 }
 
+// Regression test for #4979
+func TestDockerRunWithVolumesFromExited(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "--name", "test-data", "--volume", "/some/dir", "busybox", "touch", "/some/dir/file")
+	out, stderr, exitCode, err := runCommandWithStdoutStderr(runCmd)
+	if err != nil && exitCode != 0 {
+		t.Fatal("1", out, stderr, err)
+	}
+
+	runCmd = exec.Command(dockerBinary, "run", "--volumes-from", "test-data", "busybox", "cat", "/some/dir/file")
+	out, stderr, exitCode, err = runCommandWithStdoutStderr(runCmd)
+	if err != nil && exitCode != 0 {
+		t.Fatal("2", out, stderr, err)
+	}
+	deleteAllContainers()
+
+	logDone("run - regression test for #4979 - volumes-from on exited container")
+}
+
 // Regression test for #4830
 func TestDockerRunWithRelativePath(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-v", "tmp:/other-tmp", "busybox", "true")

--- a/runtime/volumes.go
+++ b/runtime/volumes.go
@@ -81,8 +81,13 @@ func applyVolumesFrom(container *Container) error {
 
 			c := container.runtime.Get(specParts[0])
 			if c == nil {
-				return fmt.Errorf("Container %s not found. Impossible to mount its volumes", container.ID)
+				return fmt.Errorf("Container %s not found. Impossible to mount its volumes", specParts[0])
 			}
+
+			if err := c.Mount(); err != nil {
+				return fmt.Errorf("Container %s failed to mount. Impossible to mount its volumes", specParts[0])
+			}
+			defer c.Unmount()
 
 			for volPath, id := range c.Volumes {
 				if _, exists := container.Volumes[volPath]; exists {


### PR DESCRIPTION
As explained in https://github.com/dotcloud/docker/issues/4979
--volumes-from fails with ENOFILE errors.

This is because the code tries to look at the "from" volume without
ensuring that it is mounted yet. We fix this by mounting the containers
before stating in it.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
