### PR TITLE
docker daemon: show info about the server

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -157,6 +157,13 @@ func main() {
 			}
 		}()
 
+		// TODO actually have a resolved graphdriver to show?
+		log.Printf("docker daemon: %s %s; execdriver: %s; graphdriver: %s",
+			dockerversion.VERSION,
+			dockerversion.GITCOMMIT,
+			*flExecDriver,
+			*flGraphDriver)
+
 		// Serve api
 		job := eng.Job("serveapi", flHosts.GetAll()...)
 		job.SetenvBool("Logging", true)


### PR DESCRIPTION
For combing through logs, have an intro line with information about the
running instance of the docker daemon.

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
