### PR TITLE
Use https://get.docker.io/ubuntu consistently

### DIFF
--- a/docs/sources/installation/ubuntulinux.rst
+++ b/docs/sources/installation/ubuntulinux.rst
@@ -68,7 +68,18 @@ easy. **See the** :ref:`installmirrors` **section below if you are not in
 the United States.** Other sources of the Debian packages may be
 faster for you to install.
 
-First add the Docker repository key to your local keychain.
+First, check that your APT system can deal with ``https`` URLs:
+the file ``/usr/lib/apt/methods/https`` should exist. If it doesn't,
+you need to install the package ``apt-transport-https``.
+
+.. code-block:: bash
+
+   [ -e /usr/lib/apt/methods/https ] || {
+     apt-get update
+     apt-get install apt-transport-https
+   }
+
+Then, add the Docker repository key to your local keychain.
 
 .. code-block:: bash
 
@@ -82,7 +93,7 @@ continue installation.*
 
 .. code-block:: bash
 
-   sudo sh -c "echo deb http://get.docker.io/ubuntu docker main\
+   sudo sh -c "echo deb https://get.docker.io/ubuntu docker main\
    > /etc/apt/sources.list.d/docker.list"
    sudo apt-get update
    sudo apt-get install lxc-docker

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -273,6 +273,11 @@ EOF
 	# Upload repo
 	s3cmd --acl-public sync $APTDIR/ s3://$BUCKET/ubuntu/
 	cat <<EOF | write_to_s3 s3://$BUCKET/ubuntu/index
+# Check that HTTPS transport is available to APT
+if [ ! -e /usr/lib/apt/methods/https ]; then
+	apt-get update
+	apt-get install -y apt-transport-https
+fi
 # Add the repository to your APT sources
 echo deb $(s3_url)/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 # Then import the repository key


### PR DESCRIPTION
The install script (on https://get.docker.io/) installs an APT sources.list
entry referencing an HTTPS repository, and takes care of installing the
apt-transport-https package. However, the Debian/Ubuntu specific installation
script (on https://get.docker.io/ubuntu) used an HTTPS repository but without
installing that package, causing the installation to fail on some platforms.

This will use HTTPS everywhere, and updates the documentation accordingly.

Docker-DCO-1.1-Signed-off-by: Jérôme Petazzoni jerome@docker.com (github: jpetazzo)
