### PR TITLE
cgroups: Add more systemd unit --opt options to control cgroups

### DIFF
--- a/pkg/cgroups/apply_systemd.go
+++ b/pkg/cgroups/apply_systemd.go
@@ -3,16 +3,19 @@
 package cgroups
 
 import (
-	"fmt"
 	systemd1 "github.com/coreos/go-systemd/dbus"
 	"github.com/dotcloud/docker/pkg/systemd"
 	"github.com/godbus/dbus"
+	"io/ioutil"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 )
 
 type systemdCgroup struct {
+	cleanupDirs []string
 }
 
 var (
@@ -67,19 +70,52 @@ func getIfaceForUnit(unitName string) string {
 	return "Unit"
 }
 
+type KeyValue struct {
+	Key   string
+	Value string
+}
+
 func systemdApply(c *Cgroup, pid int) (ActiveCgroup, error) {
 	unitName := c.Parent + "-" + c.Name + ".scope"
 	slice := "system.slice"
 
 	var properties []systemd1.Property
 
-	for _, v := range c.UnitProperties {
-		switch v[0] {
-		case "Slice":
-			slice = v[1]
-		default:
-			return nil, fmt.Errorf("Unknown unit propery %s", v[0])
+	var (
+		cpuArgs    []KeyValue
+		cpusetArgs []KeyValue
+		memoryArgs []KeyValue
+		res        systemdCgroup
+	)
+
+	// First set up things not supported by systemd
+
+	// -1 disables memorySwap
+	if c.MemorySwap >= 0 && (c.Memory != 0 || c.MemorySwap > 0) {
+		memorySwap := c.MemorySwap
+
+		if memorySwap == 0 {
+			// By default, MemorySwap is set to twice the size of RAM.
+			memorySwap = c.Memory * 2
 		}
+
+		memoryArgs = append(memoryArgs, KeyValue{"memory.memsw.limit_in_bytes", strconv.FormatInt(memorySwap, 10)})
+	}
+
+	if c.CpuQuota != 0 {
+		cpuArgs = append(cpuArgs, KeyValue{"cpu.cfs_quota_us", strconv.FormatInt(c.CpuQuota, 10)})
+	}
+
+	if c.CpusetCpus != "" {
+		cpusetArgs = append(cpusetArgs, KeyValue{"cpuset.cpus", c.CpusetCpus})
+	}
+
+	if c.CpusetMems != "" {
+		cpusetArgs = append(cpusetArgs, KeyValue{"cpuset.mems", c.CpusetMems})
+	}
+
+	if c.Slice != "" {
+		slice = c.Slice
 	}
 
 	properties = append(properties,
@@ -107,11 +143,22 @@ func systemdApply(c *Cgroup, pid int) (ActiveCgroup, error) {
 			})})
 	}
 
+	// Ensure we have a memory cgroup if we have any memory args
+	if c.MemoryAccounting || len(memoryArgs) != 0 {
+		properties = append(properties,
+			systemd1.Property{"MemoryAccounting", dbus.MakeVariant(true)})
+	}
+
+	// Ensure we have a cpu cgroup if we have any cpu args
+	if c.CpuAccounting || len(cpuArgs) != 0 {
+		properties = append(properties,
+			systemd1.Property{"CPUAccounting", dbus.MakeVariant(true)})
+	}
+
 	if c.Memory != 0 {
 		properties = append(properties,
 			systemd1.Property{"MemoryLimit", dbus.MakeVariant(uint64(c.Memory))})
 	}
-	// TODO: MemorySwap not available in systemd
 
 	if c.CpuShares != 0 {
 		properties = append(properties,
@@ -149,10 +196,113 @@ func systemdApply(c *Cgroup, pid int) (ActiveCgroup, error) {
 		}
 	}
 
-	return &systemdCgroup{}, nil
+	if len(cpuArgs) != 0 {
+		mountpoint, err := FindCgroupMountpoint("cpu")
+		if err != nil {
+			return nil, err
+		}
+
+		path := filepath.Join(mountpoint, cgroup)
+
+		for _, kv := range cpuArgs {
+			if err := writeFile(path, kv.Key, kv.Value); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if len(memoryArgs) != 0 {
+		mountpoint, err := FindCgroupMountpoint("memory")
+		if err != nil {
+			return nil, err
+		}
+
+		path := filepath.Join(mountpoint, cgroup)
+
+		for _, kv := range memoryArgs {
+			if err := writeFile(path, kv.Key, kv.Value); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	if len(cpusetArgs) != 0 {
+		// systemd does not atm set up the cpuset controller, so we must manually
+		// join it. Additionally that is a very finicky controller where each
+		// level must have a full setup as the default for a new directory is "no cpus",
+		// so we avoid using any hierarchies here, creating a toplevel directory.
+		mountpoint, err := FindCgroupMountpoint("cpuset")
+		if err != nil {
+			return nil, err
+		}
+		initPath, err := GetInitCgroupDir("cpuset")
+		if err != nil {
+			return nil, err
+		}
+
+		rootPath := filepath.Join(mountpoint, initPath)
+
+		path := filepath.Join(mountpoint, initPath, c.Parent+"-"+c.Name)
+
+		res.cleanupDirs = append(res.cleanupDirs, path)
+
+		if err := os.MkdirAll(path, 0755); err != nil && !os.IsExist(err) {
+			return nil, err
+		}
+
+		foundCpus := false
+		foundMems := false
+
+		for _, kv := range cpusetArgs {
+			if kv.Key == "cpuset.cpus" {
+				foundCpus = true
+			}
+			if kv.Key == "cpuset.mems" {
+				foundMems = true
+			}
+			if err := writeFile(path, kv.Key, kv.Value); err != nil {
+				return nil, err
+			}
+		}
+
+		// These are required, if not specified inherit from parent
+		if !foundCpus {
+			s, err := ioutil.ReadFile(filepath.Join(rootPath, "cpuset.cpus"))
+			if err != nil {
+				return nil, err
+			}
+
+			if err := writeFile(path, "cpuset.cpus", string(s)); err != nil {
+				return nil, err
+			}
+		}
+
+		// These are required, if not specified inherit from parent
+		if !foundMems {
+			s, err := ioutil.ReadFile(filepath.Join(rootPath, "cpuset.mems"))
+			if err != nil {
+				return nil, err
+			}
+
+			if err := writeFile(path, "cpuset.mems", string(s)); err != nil {
+				return nil, err
+			}
+		}
+
+		if err := writeFile(path, "cgroup.procs", strconv.Itoa(pid)); err != nil {
+			return nil, err
+		}
+	}
+
+	return &res, nil
 }
 
 func (c *systemdCgroup) Cleanup() error {
-	// systemd cleans up, we don't need to do anything
+	// systemd cleans up, we don't need to do much
+
+	for _, path := range c.cleanupDirs {
+		os.RemoveAll(path)
+	}
+
 	return nil
 }

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -15,13 +15,18 @@ type Cgroup struct {
 	Name   string `json:"name,omitempty"`
 	Parent string `json:"parent,omitempty"`
 
+	MemoryAccounting bool `json:"memory_accounting,omitempty"` // Enable memory accounting
+	CpuAccounting    bool `json:"cpu_accounting,omitempty"`    // Enable CPU accounting
+
 	DeviceAccess bool   `json:"device_access,omitempty"` // name of parent cgroup or slice
 	Memory       int64  `json:"memory,omitempty"`        // Memory limit (in bytes)
 	MemorySwap   int64  `json:"memory_swap,omitempty"`   // Total memory usage (memory + swap); set `-1' to disable swap
 	CpuShares    int64  `json:"cpu_shares,omitempty"`    // CPU shares (relative weight vs. other containers)
+	CpuQuota     int64  `json:"cpu_quota,omitempty"`     // Max runtime in a period (in usec), 0 to disable
 	CpusetCpus   string `json:"cpuset_cpus,omitempty"`   // CPU to use
+	CpusetMems   string `json:"cpuset_mems,omitempty"`   // Memory to use
 
-	UnitProperties [][2]string `json:"unit_properties,omitempty"` // systemd unit properties
+	Slice string `json:"slice,omitempty"` // Parent slice to use for systemd
 }
 
 type ActiveCgroup interface {

--- a/runtime/execdriver/native/configuration/parse.go
+++ b/runtime/execdriver/native/configuration/parse.go
@@ -21,14 +21,46 @@ var actions = map[string]Action{
 
 	"net.join": joinNetNamespace, // join another containers net namespace
 
-	"cgroups.cpu_shares":  cpuShares,  // set the cpu shares
-	"cgroups.memory":      memory,     // set the memory limit
-	"cgroups.memory_swap": memorySwap, // set the memory swap limit
-	"cgroups.cpuset.cpus": cpusetCpus, // set the cpus used
+	"cgroups.cpu_accounting":    accountingCpu,    // Enable memory accounting
+	"cgroups.cpu_shares":        cpuShares,        // set the cpu shares
+	"cgroups.cpu_quota":         cpuQuota,         // set the cpu quota
+	"cgroups.cpuset.cpus":       cpusetCpus,       // set the cpus used
+	"cgroups.cpuset.mems":       cpusetMems,       // set the memoy used
+	"cgroups.memory":            memory,           // set the memory limit
+	"cgroups.memory_accounting": accountingMemory, // Enable memory accounting
+	"cgroups.memory_swap":       memorySwap,       // set the memory swap limit
+
+	"systemd.slice": systemdSlice, // set the cpus used
 
 	"apparmor_profile": apparmorProfile, // set the apparmor profile to apply
 
 	"fs.readonly": readonlyFs, // make the rootfs of the container read only
+}
+
+func accountingCpu(container *libcontainer.Container, context interface{}, value string) error {
+	if container.Cgroups == nil {
+		return fmt.Errorf("cannot set cgroups when they are disabled")
+	}
+	v, err := strconv.ParseBool(value)
+	if err != nil {
+		return err
+	}
+	container.Cgroups.CpuAccounting = v
+
+	return nil
+}
+
+func accountingMemory(container *libcontainer.Container, context interface{}, value string) error {
+	if container.Cgroups == nil {
+		return fmt.Errorf("cannot set cgroups when they are disabled")
+	}
+	v, err := strconv.ParseBool(value)
+	if err != nil {
+		return err
+	}
+	container.Cgroups.MemoryAccounting = v
+
+	return nil
 }
 
 func cpusetCpus(container *libcontainer.Container, context interface{}, value string) error {
@@ -36,6 +68,24 @@ func cpusetCpus(container *libcontainer.Container, context interface{}, value st
 		return fmt.Errorf("cannot set cgroups when they are disabled")
 	}
 	container.Cgroups.CpusetCpus = value
+
+	return nil
+}
+
+func cpusetMems(container *libcontainer.Container, context interface{}, value string) error {
+	if container.Cgroups == nil {
+		return fmt.Errorf("cannot set cgroups when they are disabled")
+	}
+	container.Cgroups.CpusetMems = value
+
+	return nil
+}
+
+func systemdSlice(container *libcontainer.Container, context interface{}, value string) error {
+	if container.Cgroups == nil {
+		return fmt.Errorf("cannot set slice when cgroups are disabled")
+	}
+	container.Cgroups.Slice = value
 
 	return nil
 }
@@ -54,6 +104,18 @@ func cpuShares(container *libcontainer.Container, context interface{}, value str
 		return err
 	}
 	container.Cgroups.CpuShares = v
+	return nil
+}
+
+func cpuQuota(container *libcontainer.Container, context interface{}, value string) error {
+	if container.Cgroups == nil {
+		return fmt.Errorf("cannot set cgroups when they are disabled")
+	}
+	v, err := strconv.ParseInt(value, 10, 0)
+	if err != nil {
+		return err
+	}
+	container.Cgroups.CpuQuota = v
 	return nil
 }
 

--- a/runtime/execdriver/native/create.go
+++ b/runtime/execdriver/native/create.go
@@ -90,6 +90,7 @@ func (d *driver) setupCgroups(container *libcontainer.Container, c *execdriver.C
 		container.Cgroups.Memory = c.Resources.Memory
 		container.Cgroups.MemorySwap = c.Resources.MemorySwap
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This makes the existing unit.slice property work, and adds options
for the normal cgroup settings for cpu._, cpuset._, memory.*.

The cpu and memory ones use systemd to set up the cgroups, and then
manually tweak the properties from there. The cpuset cgroup is not
supported in systemd, and is a bit weird, so we do that ourself.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
