### PR TITLE
cli integration: sync container & image deletion

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -18,7 +18,7 @@ func TestBuildSixtySteps(t *testing.T) {
 		t.Fatal("failed to build the image")
 	}
 
-	go deleteImages("foobuildsixtysteps")
+	deleteImages("foobuildsixtysteps")
 
 	logDone("build - build an image with sixty build steps")
 }

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -27,8 +27,8 @@ func TestCommitAfterContainerIsDone(t *testing.T) {
 	out, _, err = runCommandWithOutput(inspectCmd)
 	errorOut(err, t, fmt.Sprintf("failed to inspect image: %v %v", out, err))
 
-	go deleteContainer(cleanedContainerID)
-	go deleteImages(cleanedImageID)
+	deleteContainer(cleanedContainerID)
+	deleteImages(cleanedImageID)
 
 	logDone("commit - echo foo and commit the image")
 }

--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -30,7 +30,7 @@ func TestDiffFilenameShownInOutput(t *testing.T) {
 	if !found {
 		t.Errorf("couldn't find the new file in docker diff's output: %v", out)
 	}
-	go deleteContainer(cleanCID)
+	deleteContainer(cleanCID)
 
 	logDone("diff - check if created file shows up")
 }
@@ -53,7 +53,7 @@ func TestDiffEnsureDockerinitFilesAreIgnored(t *testing.T) {
 		out, _, err := runCommandWithOutput(diffCmd)
 		errorOut(err, t, fmt.Sprintf("failed to run diff: %v %v", out, err))
 
-		go deleteContainer(cleanCID)
+		deleteContainer(cleanCID)
 
 		for _, filename := range dockerinitFiles {
 			if strings.Contains(out, filename) {
@@ -74,7 +74,7 @@ func TestDiffEnsureOnlyKmsgAndPtmx(t *testing.T) {
 	diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
 	out, _, err := runCommandWithOutput(diffCmd)
 	errorOut(err, t, fmt.Sprintf("failed to run diff: %v %v", out, err))
-	go deleteContainer(cleanCID)
+	deleteContainer(cleanCID)
 
 	expected := map[string]bool{
 		"C /dev":      true,

--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -40,8 +40,8 @@ func TestExportContainerAndImportImage(t *testing.T) {
 	out, _, err = runCommandWithOutput(inspectCmd)
 	errorOut(err, t, fmt.Sprintf("output should've been an image id: %v %v", out, err))
 
-	go deleteImages("testexp")
-	go deleteContainer(cleanedContainerID)
+	deleteContainer(cleanedContainerID)
+	deleteImages("testexp")
 
 	os.Remove("/tmp/testexp.tar")
 

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -30,7 +30,7 @@ func TestKillContainer(t *testing.T) {
 		t.Fatal("killed container is still running")
 	}
 
-	go deleteContainer(cleanedContainerID)
+	deleteContainer(cleanedContainerID)
 
 	logDone("kill - kill container running sleep 10")
 }

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -24,7 +24,7 @@ func TestLogsContainerSmallerThanPage(t *testing.T) {
 		t.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
 	}
 
-	go deleteContainer(cleanedContainerID)
+	deleteContainer(cleanedContainerID)
 
 	logDone("logs - logs container running echo smaller than page size")
 }
@@ -47,7 +47,7 @@ func TestLogsContainerBiggerThanPage(t *testing.T) {
 		t.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
 	}
 
-	go deleteContainer(cleanedContainerID)
+	deleteContainer(cleanedContainerID)
 
 	logDone("logs - logs container running echo bigger than page size")
 }
@@ -70,7 +70,7 @@ func TestLogsContainerMuchBiggerThanPage(t *testing.T) {
 		t.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
 	}
 
-	go deleteContainer(cleanedContainerID)
+	deleteContainer(cleanedContainerID)
 
 	logDone("logs - logs container running echo much bigger than page size")
 }

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -26,7 +26,7 @@ func TestPushBusyboxImage(t *testing.T) {
 	out, exitCode, err = runCommandWithOutput(pushCmd)
 	errorOut(err, t, fmt.Sprintf("%v %v", out, err))
 
-	go deleteImages(repoName)
+	deleteImages(repoName)
 
 	if err != nil || exitCode != 0 {
 		t.Fatal("pushing the image to the private registry has failed")

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -42,8 +42,8 @@ func TestSaveAndLoadRepo(t *testing.T) {
 	out, _, err = runCommandWithOutput(inspectCmd)
 	errorOut(err, t, fmt.Sprintf("the repo should exist after loading it: %v %v", out, err))
 
-	go deleteImages(repoName)
-	go deleteContainer(cleanedContainerID)
+	deleteContainer(cleanedContainerID)
+	deleteImages(repoName)
 
 	os.Remove("/tmp/foobar-save-load-test.tar")
 

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -79,7 +79,7 @@ func TestTagValidPrefixedRepo(t *testing.T) {
 			t.Errorf("tag busybox %v should have worked: %s", repo, err)
 			continue
 		}
-		go deleteImages(repo)
+		deleteImages(repo)
 		logMessage := fmt.Sprintf("tag - busybox %v", repo)
 		logDone(logMessage)
 	}

--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -22,7 +22,7 @@ func TestTop(t *testing.T) {
 	_, err = runCommand(killCmd)
 	errorOut(err, t, fmt.Sprintf("failed to kill container: %v", err))
 
-	go deleteContainer(cleanedContainerID)
+	deleteContainer(cleanedContainerID)
 
 	if !strings.Contains(out, "sleep 20") {
 		t.Fatal("top should've listed sleep 20 in the process list")


### PR DESCRIPTION
This makes container and image removal operations in the tests run synchronously.
This should fix and avoid some potential races in the cli integration tests.
