### PR TITLE
add manpages

### DIFF
--- a/contrib/man/man1/docker-attach.1
+++ b/contrib/man/man1/docker-attach.1
@@ -1,0 +1,56 @@
+.\" Process this file with
+.\" nroff -man -Tascii docker-run.1
+.\"
+.TH "DOCKER" "1" "APRIL 2014" "0.1" "Docker"
+.SH NAME
+docker-attach \- Attach to a running container
+.SH SYNOPSIS
+.B docker attach
+\fB--no-stdin\fR[=\fIfalse\fR] 
+\fB--sig-proxy\fR[=\fItrue\fR] 
+container
+.SH DESCRIPTION
+If you \fBdocker run\fR a container in detached mode (\fB-d\fR), you can reattach to the detached container with \fBdocker attach\fR using the containers ID.
+.sp
+You can detach from the container again (and leave it running) with CTRL-c (for a quiet exit) or CTRL-\ to get a stacktrace of the Docker client when it quits. When you detach from the container’s process the exit code will be returned to the client.
+.SH "OPTIONS"
+.TP
+.B --no-stdin=\fItrue\fR|\fIfalse\fR: 
+When set to true, do not attach to stdin. The default is \fIfalse\fR.
+.TP
+.B --sig-proxy=\fItrue\fR|\fIfalse\fR: 
+When set to true, proxify all received signal to the process (even in non-tty mode). The default is \fItrue\fR.
+.sp
+.SH EXAMPLES
+.sp
+.PP
+.B Attaching to a container
+.TP
+In this example the top command is run inside a fedora container in detached mode. The ID from the container is passed into the \fBdocker attach\fR command:
+.sp
+.nf
+.RS
+# ID=$(sudo docker run -d fedora /usr/bin/top -b)
+# sudo docker attach $ID
+top - 02:05:52 up  3:05,  0 users,  load average: 0.01, 0.02, 0.05
+Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
+Cpu(s):  0.1%us,  0.2%sy,  0.0%ni, 99.7%id,  0.0%wa,  0.0%hi,  0.0%si,  0.0%st
+Mem:    373572k total,   355560k used,    18012k free,    27872k buffers
+Swap:   786428k total,        0k used,   786428k free,   221740k cached
+
+PID USER      PR  NI  VIRT  RES  SHR S %CPU %MEM    TIME+  COMMAND
+1 root      20   0 17200 1116  912 R    0  0.3   0:00.03 top
+
+top - 02:05:55 up  3:05,  0 users,  load average: 0.01, 0.02, 0.05
+Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
+Cpu(s):  0.0%us,  0.2%sy,  0.0%ni, 99.8%id,  0.0%wa,  0.0%hi,  0.0%si,  0.0%st
+Mem:    373572k total,   355244k used,    18328k free,    27872k buffers
+Swap:   786428k total,        0k used,   786428k free,   221776k cached
+
+PID USER      PR  NI  VIRT  RES  SHR S %CPU %MEM    TIME+  COMMAND
+1 root      20   0 17208 1144  932 R    0  0.3   0:00.03 top
+.RE
+.fi
+.sp
+.SH HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com) based on dockier.io source material and internal work.

--- a/contrib/man/man1/docker-build.1
+++ b/contrib/man/man1/docker-build.1
@@ -1,0 +1,65 @@
+.\" Process this file with
+.\" nroff -man -Tascii docker-run.1
+.\"
+.TH "DOCKER" "1" "MARCH 2014" "0.1" "Docker"
+.SH NAME
+docker-build \- Build a container image from a Dockerfile source at PATH
+.SH SYNOPSIS
+.B docker build 
+[\fB--no-cache\fR[=\fIfalse\fR] 
+[\fB-q\fR|\fB--quiet\fR[=\fIfalse\fR] 
+[\fB-rm\fR]
+[\fB-t\fR|\fB--tag\fR=\fItag\fR] 
+PATH | URL | -
+.SH DESCRIPTION
+This will read the Dockerfile from the directory specified in \fBPATH\fR. It also sends any other files and directories found in the current directory to the docker daemon. The contents of this directory would be used by ADD commands found within the Dockerfile. 
+Warning, this will send a lot of data to the docker daemon if the current directory contains a lot of data.
+If the absolute path is provided instead of ‘.’, only the files and directories required by the ADD commands from the Dockerfile will be added to the context and transferred to the docker daemon.
+.sp
+When a single Dockerfile is given as URL, then no context is set. When a git repository is set as URL, the repository is used as context.
+.SH "OPTIONS"
+.TP
+.B -q, --quiet=\fItrue\fR|\fIfalse\fR: 
+When set to true, suppress verbose build output. Default is \fIfalse\fR.
+.TP
+.B -rm
+Remove intermediate containers that are created during the build process.
+.TP
+.B -t, --tag=\fItag\fR: 
+Tag to be applied to the resulting image on successful completion of the build.
+.TP
+.B --no-cache=\fItrue\fR|\fIfalse\fR
+When set to true, do not use a cache when building the image. The default is \fIfalse\fR.
+.sp
+.SH EXAMPLES
+.sp
+.sp
+.B Building an image container from current directory
+.TP
+Building an image container from the Dockerfile in the current directory is as simple as:
+.sp
+.RS
+docker build .
+.RE
+.sp
+It's recommended to remove the intermediate containers during the build. 
+.sp
+.RS
+docker build -rm .
+.sp
+.RE
+.sp
+A good practice is to make a subdirectory with an related name and create a Dockerfile in that directory. E.g. a directory called mongo may contain a Dockerfile for a MongoDB image, or a directory called httpd may container an Dockerfile for an Apache web server. 
+.sp
+It is also good practice to add the files required for the image to the subdirectory. These files will be then specified with the `ADD` instruction in the Dockerfile. Note: if you include a tar file, which is good practice, then docker will automatically extract the contents of the tar file specified in the `ADD` instruction into the specified target.  
+.sp
+.B Building an image container using a URL
+.TP
+This will clone the github repository and use it as context. The Dockerfile at the root of the repository is used as Dockerfile. This only works if the github repo is a dedicated repo. Note that you can specify an arbitrary git repository by using the ‘git://’ schema. 
+.sp
+.RS
+docker build github.com/scollier/Fedora-Dockerfiles/tree/master/apache
+.RE
+.sp
+.SH HISTORY
+March 2014, Originally compiled by William Henry (whenry at redhat dot com) based on dockier.io source material and internal work.

--- a/contrib/man/man1/docker-images.1
+++ b/contrib/man/man1/docker-images.1
@@ -1,0 +1,84 @@
+.\" Process this file with
+.\" nroff -man -Tascii docker-run.1
+.\"
+.TH "DOCKER" "1" "April 2014" "0.1" "Docker"
+.SH NAME
+docker-images \- List the images in the local repository 
+.SH SYNOPSIS
+.B docker images
+[\fB-a\fR|\fB--all\fR=\fIfalse\fR] 
+[\fB--no-trunc\fR[=\fIfalse\fR] 
+[\fB-q\fR|\fB--quiet\fR[=\fIfalse\fR] 
+[\fB-t\fR|\fB--tree\fR=\fIfalse\fR] 
+[\fB-v\fR|\fB--viz\fR=\fIfalse\fR] 
+[NAME]
+.SH DESCRIPTION
+This command lists the images stored in the local docker repository. 
+.sp
+By default, intermediate images, used during builds, are not listed. Some of the output, e.g. image ID, is truncated, for space reasons. However the truncated image ID, and often the first few characters, are enough to be used in other Docker commands that use the image ID. The output includes repository, tag, image ID, date created and the virtual size. 
+.sp
+The title REPOSITORY for the first title may seem confusing. It is essentially the image name.  However, because you can tag a specific image, and multiple tags (image instances) can be associated with a single name, the name is really a repository for all tagged images of the same name. 
+.SH "OPTIONS"
+.TP
+.B -a, --all=\fItrue\fR|\fIfalse\fR: 
+When set to true, also include all intermediate images in the list. The default is false.
+.TP
+.B --no-trunc=\fItrue\fR|\fIfalse\fR: 
+When set to true, list the . The default is false.
+.TP
+.B -q, --quiet=\fItrue\fR|\fIfalse\fR: 
+When set to true, list the complete image ID as part of the output. The default is false.
+.TP
+.B -t, --tree=\fItrue\fR|\fIfalse\fR: 
+When set to true, list the images in a tree dependency tree (hierarchy) format. The default is false.
+.TP
+.B -v, --viz=\fItrue\fR|\fIfalse\fR
+When set to true, list the graph in graphviz format. The default is \fIfalse\fR.
+.sp
+.SH EXAMPLES
+.sp
+.B Listing the images
+.TP
+To list the images in a local repository (not the registry) simply run:
+.sp
+.RS
+docker images
+.RE
+.sp
+The list will contain the image repository name, a tag for the image, and image ID, when it was created and its virtual size. Columns: REPOSITORY, TAG, IMAGE ID, CREATED, and VIRTUAL SIZE.
+.sp
+To get a verbose list of images which contains all the intermediate images used in builds use \fB-a\fR:
+.sp
+.RS
+docker images -a
+.RE
+.sp
+.B List images dependency tree hierarchy
+.TP
+To list the images in the local repository (not the registry) in a dependency tree, format then use the \fB-t\fR|\fB--tree=true\fR option. 
+.sp
+.RS
+docker images -t 
+.RE
+.sp
+This displays a staggered hierarchy tree where the less indented image is the oldest with dependent image layers branching inward (to the right) on subsequent lines. The newest or top level image layer is listed last in any tree branch. 
+.sp
+.B List images in GraphViz format
+.TP
+To display the list in a format consumable by a GraphViz tools run with \fB-v\fR|\fB--viz=true\fR. For example to produce a .png graph file of the hierarchy use: 
+.sp
+.RS
+docker images --viz | dot -Tpng -o docker.png
+.sp
+.RE
+.sp
+.B Listing only the shortened image IDs
+.TP
+Listing just the shortened image IDs. This can be useful for some automated tools.
+.sp
+.RS
+docker images -q
+.RE
+.sp
+.SH HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com) based on dockier.io source material and internal work.

--- a/contrib/man/man1/docker-info.1
+++ b/contrib/man/man1/docker-info.1
@@ -1,0 +1,39 @@
+.\" Process this file with
+.\" nroff -man -Tascii docker-run.1
+.\"
+.TH "DOCKER" "1" "APRIL 2014" "0.1" "Docker"
+.SH NAME
+docker-info \- Display system wide information
+.SH SYNOPSIS
+.B docker info
+.SH DESCRIPTION
+This command displays system wide information regarding the Docker installation. Information displayed includes the number of containers and images, Pool Name, Data File, Metadata File, Data Space Used, Total Data Space, Metadata Space Used, Total Metadata Space, Execution Driver, and the kernel version.
+.sp
+The Data File is where the images are stored and the Metadata file is where the meta data regarding those images are stored. When run for the first time Docker allocates a certain amount of data space and meta data space from the space available on the volume where /var/lib/docker is mounted.    
+.SH "OPTIONS"
+There are no available options.
+.sp
+.SH EXAMPLES
+.sp
+.B Display Docker system information
+.TP
+Here is example output:
+.sp
+.RS
+ # docker info
+ Containers: 18
+ Images: 95
+ Storage Driver: devicemapper
+  Pool Name: docker-8:1-170408448-pool
+  Data file: /var/lib/docker/devicemapper/devicemapper/data
+  Metadata file: /var/lib/docker/devicemapper/devicemapper/metadata
+  Data Space Used: 9946.3 Mb
+  Data Space Total: 102400.0 Mb
+  Metadata Space Used: 9.9 Mb
+  Metadata Space Total: 2048.0 Mb
+ Execution Driver: native-0.1
+ Kernel Version: 3.10.0-116.el7.x86_64
+.RE
+.sp
+.SH HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com) based on dockier.io source material and internal work.

--- a/contrib/man/man1/docker-rm.1
+++ b/contrib/man/man1/docker-rm.1
@@ -1,0 +1,45 @@
+.\" Process this file with
+.\" nroff -man -Tascii docker-run.1
+.\"
+.TH "DOCKER" "1" "MARCH 2014" "0.1" "Docker"
+.SH NAME
+docker-rm \- Remove one or more containers.
+.SH SYNOPSIS
+.B docker rm 
+[\fB-f\fR|\fB--force\fR[=\fIfalse\fR] 
+[\fB-l\fR|\fB--link\fR[=\fIfalse\fR] 
+[\fB-v\fR|\fB--volumes\fR[=\fIfalse\fR] 
+CONTAINER [CONTAINER...]
+.SH DESCRIPTION
+This will remove one or more containers from the host node. The container name or ID can be used. This does not remove images. You cannot remove a running container unless you use the \fB-f\fR option. To see all containers on a host use the \fBdocker ps -a\fR command.
+.SH "OPTIONS"
+.TP
+.B -f, --force=\fItrue\fR|\fIfalse\fR: 
+When set to true, force the removal of the container. The default is \fIfalse\fR.
+.TP
+.B -l, --link=\fItrue\fR|\fIfalse\fR: 
+When set to true, remove the specified link and not the underlying container. The default is \fIfalse\fR.
+.TP
+.B -v, --volumes=\fItrue\fR|\fIfalse\fR: 
+When set to true, remove the volumes associated to the container. The default is \fIfalse\fR.
+.SH EXAMPLES
+.sp
+.PP
+.B Removing a container using its ID
+.TP
+To remove a container using its ID, find either from a \fBdocker ps -a\fR command, or use the ID returned from the \fBdocker run\fR command, or retrieve it from a file used to store it using the \fBdocker run --cidfile\fR:
+.sp
+.RS
+docker rm abebf7571666
+.RE
+.sp
+.B Removing a container using the container name:
+.TP
+The name of the container can be found using the \fBdocker ps -a\fR command. The use that name as follows:
+.sp
+.RS
+docker rm hopeful_morse
+.RE
+.sp
+.SH HISTORY
+March 2014, Originally compiled by William Henry (whenry at redhat dot com) based on dockier.io source material and internal work.

--- a/contrib/man/man1/docker-rmi.1
+++ b/contrib/man/man1/docker-rmi.1
@@ -1,0 +1,29 @@
+.\" Process this file with
+.\" nroff -man -Tascii docker-run.1
+.\"
+.TH "DOCKER" "1" "MARCH 2014" "0.1" "Docker"
+.SH NAME
+docker-rmi \- Remove one or more images.
+.SH SYNOPSIS
+.B docker rmi
+[\fB-f\fR|\fB--force\fR[=\fIfalse\fR] 
+IMAGE [IMAGE...]
+.SH DESCRIPTION
+This will remove one or more images from the host node. This does not remove images from a registry. You cannot remove an image of a running container unless you use the \fB-f\fR option. To see all images on a host use the \fBdocker images\fR command.
+.SH "OPTIONS"
+.TP
+.B -f, --force=\fItrue\fR|\fIfalse\fR: 
+When set to true, force the removal of the image. The default is \fIfalse\fR.
+.SH EXAMPLES
+.sp
+.PP
+.B Removing an image
+.TP
+Here is an example of removing and image:
+.sp
+.RS
+docker rmi fedora/httpd
+.RE
+.sp
+.SH HISTORY
+March 2014, Originally compiled by William Henry (whenry at redhat dot com) based on dockier.io source material and internal work.

--- a/contrib/man/man1/docker-run.1
+++ b/contrib/man/man1/docker-run.1
@@ -1,0 +1,277 @@
+.\" Process this file with
+.\" nroff -man -Tascii docker-run.1
+.\"
+.TH "DOCKER" "1" "MARCH 2014" "0.1" "Docker"
+.SH NAME
+docker-run \- Run a process in an isolated container
+.SH SYNOPSIS
+.B docker run 
+[\fB-a\fR|\fB--attach\fR[=]] [\fB-c\fR|\fB--cpu-shares\fR[=0] [\fB-m\fR|\fB--memory\fR=\fImemory-limit\fR]
+[\fB--cidfile\fR=\fIfile\fR] [\fB-d\fR|\fB--detach\fR[=\fIfalse\fR]] [\fB--dns\fR=\fIIP-address\fR]
+[\fB--name\fR=\fIname\fR] [\fB-u\fR|\fB--user\fR=\fIusername\fR|\fIuid\fR]
+[\fB--link\fR=\fIname\fR:\fIalias\fR] 
+[\fB-e\fR|\fB--env\fR=\fIenvironment\fR] [\fB--entrypoint\fR=\fIcommand\fR] 
+[\fB--expose\fR=\fIport\fR] [\fB-P\fR|\fB--publish-all\fR[=\fIfalse\fR]]
+[\fB-p\fR|\fB--publish\fR=\fIport-mappping\fR] [\fB-h\fR|\fB--hostname\fR=\fIhostname\fR]
+[\fB--rm\fR[=\fIfalse\fR]] [\fB--priviledged\fR[=\fIfalse\fR]
+[\fB-i\fR|\fB--interactive\fR[=\fIfalse\fR] 
+[\fB-t\fR|\fB--tty\fR[=\fIfalse\fR]] [\fB--lxc-conf\fR=\fIoptions\fR]
+[\fB-n\fR|\fB--networking\fR[=\fItrue\fR]]
+[\fB-v\fR|\fB--volume\fR=\fIvolume\fR] [\fB--volumes-from\fR=\fIcontainer-id\fR]
+[\fB-w\fR|\fB--workdir\fR=\fIdirectory\fR] [\fB--sig-proxy\fR[=\fItrue\fR]]
+IMAGE [COMMAND] [ARG...]
+.SH DESCRIPTION
+.PP
+Run a process in a new container. \fBdocker run\fR starts a process with its own file system, its own networking, and its own isolated process tree. The \fIIMAGE\fR which starts the process may define defaults related to the process that will be run in the container, the networking to expose, and more, but \fBdocker run\fR gives final control to the operator or administrator who starts the container from the image. For that reason \fBdocker run\fR has more options than any other docker command.
+
+If the \fIIMAGE\fR is not already loaded then \fBdocker run\fR will pull the \fIIMAGE\fR, and all image dependencies, from the repository in the same way running \fBdocker pull\fR \fIIMAGE\fR, before it starts the container from that image.
+
+
+.SH "OPTIONS"
+
+.TP
+.B  -a, --attach=\fIstdin\fR|\fIstdout\fR|\fIstderr\fR: 
+Attach to stdin, stdout or stderr. In foreground mode (the default when -d is not specified), \fBdocker run\fR can start the process in the container and attach the console to the process’s standard input, output, and standard error. It can even pretend to be a TTY (this is what most commandline executables expect) and pass along signals. The \fB-a\fR option can be set for each of stdin, stdout, and stderr.  
+
+.TP
+.B  -c, --cpu-shares=0: 
+CPU shares in relative weight.  You can increase the priority of a container with the -c option. By default, all containers run at the same priority and get the same proportion of CPU cycles, but you can tell the kernel to give more shares of CPU time to one or more containers when you start them via \fBdocker run\fR.
+
+.TP
+.B -m, --memory=\fImemory-limit\fR: 
+Allows you to constrain the memory available to a container. If the host supports swap memory, then the -m memory setting can be larger than physical RAM. The memory limit format: <number><optional unit>, where unit = b, k, m or g.
+
+.TP
+.B --cidfile=\fIfile\fR: 
+Write the container ID to the file specified.
+
+.TP
+.B  -d, --detach=\fItrue\fR|\fIfalse\fR: 
+Detached mode. This runs the container in the background. It prints the new container's id and nothing else. At any time you can run \fBdocker ps\fR in the other shell to view a list of the running containers. You can reattach to a detached container with \fBdocker attach\fR. If you choose to run a container in the detached mode, then you cannot use the -rm option.
+
+.TP
+.B --dns=\fIIP-address\fR: 
+Set custom dns servers. This option can be used to override the dns configuration passed to the container. Typically this is necessary when the host dns configuration is invalid for the container (eg. 127.0.0.1). When this is the case the \fB-dns\fR flags is necessary for every run.
+
+.TP
+.B  -e, --env=\fIenvironment\fR: 
+Set environment variables. This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container. 
+
+.TP
+.B --entrypoint=\ficommand\fR: 
+This option allows you to overwrite the default entrypoint of the image that is set in the Dockerfile. The ENTRYPOINT of an image is similar to a COMMAND because it specifies what executable to run when the container starts, but it is (purposely) more difficult to override. The ENTRYPOINT gives a container its default nature or behavior, so that when you set an ENTRYPOINT you can run the container as if it were that binary, complete with default options, and you can pass in more options via the COMMAND. But, sometimes an operator may want to run something else inside the container, so you can override the default ENTRYPOINT at runtime by using a \fB--entrypoint\fR and a string to specify the new ENTRYPOINT. 
+
+.TP
+.B --expose=\fIport\fR: 
+Expose a port from the container without publishing it to your host. A containers port can be exposed to other containers in three ways: 1) The developer can expose the port using the EXPOSE parameter of the Dockerfile, 2) the operator can use the \fB--expose\fR option with \fBdocker run\fR, or 3) the container can be started with the \fB--link\fR.
+
+.TP
+.B  -P, --publish-all=\fItrue\fR|\fIfalse\fR: 
+When set to true publish all exposed ports to the host interfaces. The default is false. If the operator uses -P (or -p) then Docker will make the exposed port accessible on the host and the ports will be available to any client that can reach the host. To find the map between the host ports and the exposed ports, use \fBdocker port\fR. 
+
+.TP
+.B -p, --publish=[]: 
+Publish a container's port to the host (format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort) (use 'docker port' to see the actual mapping)
+
+.TP
+.B -h , --hostname=\fIhostname\fR: 
+Set's the container host name that is available inside the container.
+  
+.TP
+.B -i , --interactive=\fItrue\fR|\fIfalse\fR: 
+When set to true, keep stdin open even if not attached. The default is false.
+
+.TP
+.B --link=\fIname\fR:\fIalias\fR: 
+Add link to another container. The format is name:alias. If the operator uses \fB--link\fR when starting the new client container, then the client container can access the exposed port via a private networking interface. Docker will set some environment variables in the client container to help indicate which interface and port to use. 
+
+.TP
+.B -n, --networking=\fItrue\fR|\fIfalse\fR: 
+By default, all containers have networking enabled (true) and can make outgoing connections. The operator can disable networking with \fB--networking\fR to false. This disables all incoming and outgoing networking. In cases like this, I/O can only be performed through files or by using STDIN/STDOUT.
+
+Also, by default, the container will use the same DNS servers as the host. but you canThe operator may override this with \fB-dns\fR. 
+
+.TP
+.B  --name=\fIname\fR: 
+Assign a name to the container. The operator can identify a container in three ways:
+.sp
+.nf
+UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”)
+UUID short identifier (“f78375b1c487”)
+Name (“jonah”)
+.fi
+.sp
+The UUID identifiers come from the Docker daemon, and if a name is not assigned to the container with \fB--name\fR then the daemon will also generate a random string name. The name is useful when defining links (see \fB--link\fR) (or any other place you need to identify a container). This works for both background and foreground Docker containers.
+
+.TP
+.B --privileged=\fItrue\fR|\fIfalse\fR: 
+Give extended privileges to this container. By default, Docker containers are “unprivileged” (=false) and cannot, for example, run a Docker daemon inside the Docker container. This is because by default a container is not allowed to access any devices. A “privileged” container is given access to all devices.
+
+When the operator executes \fBdocker run -privileged\fR, Docker will enable access to all devices on the host as well as set some configuration in AppArmor (\fB???\fR) to allow the container nearly all the same access to the host as processes running outside of a container on the host.
+
+.TP
+.B --rm=\fItrue\fR|\fIfalse\fR: 
+If set to \fItrue\fR the container is automatically removed when it exits. The default is \fIfalse\fR. This option is incompatible with \fB-d\fR.
+
+.TP
+.B --sig-proxy=\fItrue\fR|\fIfalse\fR: 
+When set to true, proxify all received signals to the process (even in non-tty mode). The default is true.
+  
+.TP
+.B -t, --tty=\fItrue\fR|\fIfalse\fR: 
+When set to true Docker can allocate a pseudo-tty and attach to the standard input of any container. This can be used, for example, to run a throwaway interactive shell. The default is value is false.
+
+.TP
+.B -u, --user=\fIusername\fR,\fRuid\fR: 
+Set a username or UID for the container.
+
+.TP
+.B -v, --volume=\fIvolume\fR: 
+Bind mount a volume to the container. The \fB-v\fR option can be used one or more times to add one or more mounts to a container. These mounts can then be used in other containers using the \fB--volumes-from\fR option. See examples.
+
+.TP
+.B --volumes-from=\fIcontainer-id\fR: 
+Will mount volumes from the specified container identified by container-id. Once a volume is mounted in a one container it can be shared with other containers using the \fB--volumes-from\fR option when running those other containers. The volumes can be shared even if the original container with the mount is not running. 
+
+.TP
+.B -w, --workdir=\fIdirectory\fR: 
+Working directory inside the container. The default working directory for running binaries within a container is the root directory (/). The developer can set a different default with the Dockerfile WORKDIR instruction. The operator can override the working directory by using the \fB-w\fR option. 
+
+.TP
+.B IMAGE: 
+The image name or ID.
+
+.TP
+.B COMMAND: 
+The command or program to run inside the image.
+
+.TP
+.B ARG: 
+The arguments for the command to be run in the container.
+
+.SH EXAMPLES
+.sp
+.sp
+.B Exposing log messages from the container to the host's log
+.TP
+If you want messages that are logged in your container to show up in the host's syslog/journal then you should bind mount the /var/log directory as follows.
+.sp
+.RS
+docker run -v /dev/log:/dev/log -i -t fedora /bin/bash
+.RE
+.sp
+From inside the container you can test this by sending a message to the log.
+.sp
+.RS
+logger "Hello from my container"
+.sp
+.RE
+Then exit and check the journal.
+.RS
+.sp
+exit
+.sp
+journalctl -b | grep hello
+.RE
+.sp
+This should list the message sent to logger.
+.sp
+.B Attaching to one or more from STDIN, STDOUT, STDERR
+.TP
+If you do not specify -a then Docker will attach everything (stdin,stdout,stderr). You can specify to which of the three standard streams (stdin, stdout, stderr) you’d like to connect instead, as in:
+.sp
+.RS
+docker run -a stdin -a stdout -i -t fedora /bin/bash
+.RE
+.sp
+.B Linking Containers
+.TP
+The link feature allows multiple containers to communicate with each other. For example, a container whose Dockerfile has exposed port 80 can be run and named as follows: 
+.sp
+.RS
+docker run --name=link-test -d -i -t fedora/httpd
+.RE
+.sp
+.TP
+A second container, in this case called linker, can communicate with the httpd container, named link-test, by running with the \fB--link=<name>:<alias>\fR
+.sp
+.RS
+docker run -t -i --link=link-test:lt --name=linker fedora /bin/bash
+.RE
+.sp
+.TP
+Now the container linker is linked to container link-test with the alias lt. Running the \fBenv\fR command in the linker container shows environment variables with the LT (alias) context (\fBLT_\fR)
+.sp
+.nf
+.RS
+# env
+HOSTNAME=668231cb0978
+TERM=xterm
+LT_PORT_80_TCP=tcp://172.17.0.3:80
+LT_PORT_80_TCP_PORT=80
+LT_PORT_80_TCP_PROTO=tcp
+LT_PORT=tcp://172.17.0.3:80
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+PWD=/
+LT_NAME=/linker/lt
+SHLVL=1
+HOME=/
+LT_PORT_80_TCP_ADDR=172.17.0.3
+_=/usr/bin/env
+.RE
+.fi
+.sp
+.TP 
+When linking two containers Docker will use the exposed ports of the container to create a secure tunnel for the parent to access. 
+.TP
+.sp
+.B Mapping Ports for External Usage
+.TP
+The exposed port of an application can be mapped to a host port using the \fB-p\fR flag. For example a httpd port 80 can be mapped to the host port 8080 using the following:
+.sp
+.RS
+docker run -p 8080:80 -d -i -t fedora/httpd
+.RE
+.sp
+.TP
+.B Creating and Mounting a Data Volume Container
+.TP
+Many applications require the sharing of persistent data across several containers. Docker allows you to create a Data Volume Container that other containers can mount from. For example, create a named container that contains directories /var/volume1 and /tmp/volume2. The image will need to contain these directories so a couple of RUN mkdir instructions might be required for you fedora-data image: 
+.sp
+.RS
+docker run --name=data -v /var/volume1 -v /tmp/volume2 -i -t fedora-data true
+.sp
+docker run --volumes-from=data --name=fedora-container1 -i -t fedora bash
+.RE
+.sp
+.TP
+Multiple -volumes-from parameters will bring together multiple data volumes from multiple containers. And it's possible to mount the volumes that came from the DATA container in yet another container via the fedora-container1 intermidiery container, allowing to abstract the actual data source from users of that data:
+.sp
+.RS
+docker run --volumes-from=fedora-container1 --name=fedora-container2 -i -t fedora bash
+.RE
+.TP
+.sp
+.B Mounting External Volumes
+.TP
+To mount a host directory as a container volume, specify the absolute path to the directory and the absolute path for the container directory separated by a colon:  
+.sp
+.RS
+docker run -v /var/db:/data1 -i -t fedora bash
+.RE
+.sp
+.TP
+When using SELinux, be aware that the host has no knowledge of container SELinux policy. Therefore, in the above example, if SELinux policy is enforced, the /var/db directory is not writable to the container. A "Permission Denied" message will occur and an avc: message in the host's syslog. 
+.sp
+.TP
+To work around this, at time of writing this man page, the following command needs to be run in order for the proper SELinux policy type label to be attached to the host directory:  
+.sp
+.RS
+chcon -Rt svirt_sandbox_file_t /var/db
+.RE
+.sp
+.TP
+Now, writing to the /data1 volume in the container will be allowed and the changes will also be reflected on the host in /var/db.
+.sp 
+.SH HISTORY
+March 2014, Originally compiled by William Henry (whenry at redhat dot com) based on dockier.io source material and internal work.

--- a/contrib/man/man1/docker-tag.1
+++ b/contrib/man/man1/docker-tag.1
@@ -1,0 +1,49 @@
+.\" Process this file with
+.\" nroff -man -Tascii docker-run.1
+.\"
+.TH "DOCKER" "1" "APRIL 2014" "0.1" "Docker"
+.SH NAME
+docker-tag \- Tag an image in the repository
+.SH SYNOPSIS
+.B docker tag 
+[\fB-f\fR|\fB--force\fR[=\fIfalse\fR] 
+\fBIMAGE\fR [REGISTRYHOST/][USERNAME/]NAME[:TAG]
+.SH DESCRIPTION
+This will tag an image in the repository. 
+.SH "OPTIONS"
+.TP
+.B -f, --force=\fItrue\fR|\fIfalse\fR: 
+When set to true, force the tag name. The default is \fIfalse\fR.
+.TP
+.B REGISTRYHOST:
+The hostname of the registry if required. This may also include the port separated by a ':'
+.TP
+.B USERNAME:
+The username or other qualifying identifier for the image.
+.TP
+.B NAME:
+The image name. 
+.TP
+.B TAG:
+The tag you are assigning to the image.
+.SH EXAMPLES
+.sp
+.PP
+.B Tagging an image
+.TP
+Here is an example of tagging an image with the tag version1.0 :
+.sp
+.RS
+docker tag 0e5574283393 fedora/httpd:version1.0
+.RE
+.sp
+.B Tagging an image for a internal repository
+.TP
+To push an image to an internal Registry and not the default docker.io based registry you must tag it with the registry hostname and port (if needed).
+.sp
+.RS
+docker tag 0e5574283393 myregistryhost:5000/fedora/httpd:version1.0
+.RE
+.sp
+.SH HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com) based on dockier.io source material and internal work.

--- a/contrib/man/man1/docker.1
+++ b/contrib/man/man1/docker.1
@@ -1,0 +1,119 @@
+.\" Process this file with
+.\" nroff -man -Tascii docker-run.1
+.\"
+.TH "DOCKER" "1" "APRIL 2014" "0.1" "Docker"
+.SH NAME
+docker \- Docker image and container command line interface
+.SH SYNOPSIS
+.B docker COMMAND [arg...]
+.SH DESCRIPTION
+docker is a commmand line interface (CLI) for creating and managing Docker based images and containers. The docker CLI has over 30 commands. The commands are listed below and each has its own man page.
+.sp
+To see the man page for a command run \fBman docker <command>\fR.
+.SH "COMMANDS"
+.TP
+.B attach 
+Attach to a running container
+.TP
+.B build 
+Build a container from a Dockerfile
+.TP
+.B commit 
+Create a new image from a container's changes
+.TP
+.B cp 
+Copy files/folders from the containers filesystem to the host path
+.TP
+.B diff 
+Inspect changes on a container's filesystem
+    
+.TP
+.B events
+Get real time events from the server
+.TP
+.B export 
+Stream the contents of a container as a tar archive
+.TP
+.B history
+Show the history of an image
+.TP
+.B images
+List images
+.TP
+.B import 
+Create a new filesystem image from the contents of a tarball
+.TP
+.B info 
+Display system-wide information
+.TP
+.B insert 
+Insert a file in an image
+.TP
+.B inspect  
+Return low-level information on a container
+.TP
+.B kill 
+Kill a running container
+.TP
+.B load 
+Load an image from a tar archive
+.TP
+.B login 
+Register or Login to the docker registry server
+.TP
+.B logs 
+Fetch the logs of a container
+.TP
+.B port 
+Lookup the public-facing port which is NAT-ed to PRIVATE_PORT
+.TP
+.B ps 
+List containers
+.TP
+.B pull 
+Pull an image or a repository from the docker registry server
+.TP
+.B push 
+Push an image or a repository to the docker registry server
+.TP
+.B restart 
+Restart a running container
+.TP
+.B rm 
+Remove one or more containers
+.TP
+.B rmi 
+Remove one or more images
+.TP
+.B run 
+Run a command in a new container
+.TP
+.B save 
+Save an image to a tar archive
+.TP
+.B search 
+Search for an image in the docker index
+.TP
+.B start 
+Start a stopped container
+.TP
+.B stop 
+Stop a running container
+.TP
+.B tag 
+Tag an image into a repository
+.TP
+.B top 
+Lookup the running processes of a container
+.TP
+.B version
+Show the docker version information
+.TP
+.B wait 
+Block until a container stops, then print its exit code
+.SH EXAMPLES
+.sp
+For specific examples please see the man page for the specific docker command.
+.sp
+.SH HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com) based on dockier.io source material and internal work.


### PR DESCRIPTION
Original Author: William Henry whenry@redhat.com (github: ipbabble)

manpage repo: https://github.com/ipbabble/docker-man

Docker-DCO-1.1-Signed-off-by: Lokesh Mandvekarlsm5@redhat.com (github: lsm5)

```
new file:   contrib/man/man1/docker-attach.1
new file:   contrib/man/man1/docker-build.1
new file:   contrib/man/man1/docker-images.1
new file:   contrib/man/man1/docker-info.1
new file:   contrib/man/man1/docker-rm.1
new file:   contrib/man/man1/docker-rmi.1
new file:   contrib/man/man1/docker-run.1
new file:   contrib/man/man1/docker-tag.1
new file:   contrib/man/man1/docker.1
```
