### PR TITLE
Second pass on introductory materials

### DIFF
--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -8,16 +8,11 @@ page_keywords: docker, introduction, documentation, about, technology, understan
 
 ## Introduction
 
-Operating systems, like Linux or Windows, are what makes a computer
-usable. These collections of programs provide the *core functionality*
-that applications, from databases to graphics editors, depend and build
-upon on an *everything-shared* environment.
-
-[**Docker**](http://www.docker.io) leverages some key operating system
-features like process management and networking. It allows you to create
-containers holding all the core dependencies for an application to run
-on. Each container is kept isolated from any other, and
-nothing gets shared.
+[**Docker**](http://www.docker.io) is a container based virtualization
+framework. Unlike traditional virtualization Docker is fast, lightweight
+and easy to use. Docker allows you to create containers holding
+all the dependencies for an application. Each container is kept isolated
+from any other, and nothing gets shared.
 
 ## Docker highlights
 
@@ -39,8 +34,8 @@ And most importantly:
 
 ## About this guide
 
-In this introduction we will take you on a tour. Let us show you what
-makes Docker so amazing and help you to *get started*.
+In this introduction we will take you on a tour and show you what
+makes Docker tick.
 
 On the [**first page**](introduction/understanding-docker.md), which is
 **_informative_**:

--- a/docs/sources/introduction/get-docker.md
+++ b/docs/sources/introduction/get-docker.md
@@ -11,10 +11,7 @@ page_keywords: docker, introduction, documentation, about, technology, understan
 Once you are comfortable with your level of knowledge of Docker, and
 feel like actually trying the product, you can download and start using
 it by following the links listed below. There, you will find
-instructions, specifically tailored for your platform of choice.
-
-Docker is a flexible tool and tries to offers a unified experience across
-different systems.
+installation instructions, specifically tailored for your platform of choice.
 
 ## Installation Instructions
 
@@ -35,7 +32,7 @@ different systems.
  - **openSUSE:**  
  [Installation on openSUSE](../installation/openSUSE.md)
 
-### Mac OS X (Using VirtualBox)
+### Mac OS X (Using Boot2Docker)
 
 In order to work, Docker makes use of some Linux Kernel features which
 are not supported by Mac OS X. To run Docker on OS X we install and run
@@ -44,15 +41,15 @@ a lightweight virtual machine and run Docker on that.
  - **Mac OS X :**  
  [Installation on Mac OS X](../installation/mac.md)
 
-### Windows (Using VirtualBox)
+### Windows (Using Boot2Docker)
 
-Docker can run on Windows using a VM like VirtualBox. You then run Linux
-within the VM.
+Docker can also run on Windows using a virtual machine. You then run
+Linux and Docker inside that virtual machine.
 
  - **Windows:**  
  [Installation on Windows](../installation/windows.md)
 
-### Infrastructure-as-a-Service (IaaS)
+### Infrastructure-as-a-Service
 
  - **Amazon EC2:**  
  [Installation on Amazon EC2](../installation/amazon.md)

--- a/docs/sources/introduction/technology.md
+++ b/docs/sources/introduction/technology.md
@@ -10,9 +10,8 @@ page_keywords: docker, introduction, documentation, about, technology, understan
 
 When it comes to understanding Docker and its underlying technology
 there is no *magic* involved. Everything is based on tried and tested
-features of the *Linux kernel*. All the tools and parts either make use
-of those features directly, or, build upon them to provide the functionality
-*intelligently*, for example networking.
+features of the *Linux kernel*. Docker either makes use of those
+features directly or builds upon them to provide new functionality.
 
 Aside from the technology, one of the major factors that make Docker
 great is the way it is built. The project's core is very lightweight and
@@ -68,31 +67,29 @@ an intermediary: the Docker client.
 
 ### Docker client
 
-The Docker client is an application which can run either on the same
-computer as the Docker daemon, or elsewhere. It is tasked with accepting
-commands from the user (i.e. *you*) and communicating back and forth
-with a Docker daemon to manage container lifecycle on any host.
+The Docker client is the primary user interface to Docker. It is tasked
+with accepting commands from the user and communicating back and forth
+with a Docker daemon to manage the container lifecycle on any host.
 
 ### Docker Index, the central Docker registry
 
 The [Docker Index](http://index.docker.io) is the global archive (and
 directory) of user supplied Docker container images. It currently hosts
-a very large – in fact, rapidly growing – number of projects where you
+a large – in fact, rapidly growing – number of projects where you
 can find almost any popular application or deployment stack readily
-available to download and run with a single command (e.g. `docker pull`
-`[repository]/[application]`).
+available to download and run with a single command.
 
-As a social community project, Docker tries to provide all necessary tools for
-everyone to grow with other *Dockers*. By issuing a single command through the
-Docker client (i.e. `docker push [name]`), you can start sharing your own
+As a social community project, Docker tries to provide all necessary
+tools for everyone to grow with other *Dockers*. By issuing a single
+command through the Docker client you can start sharing your own
 creations with the rest of the world.
 
-However, knowing that not everything can be shared (e.g. proprietary
-code), Docker Index also offers private repositories. In order to see
-the available plans, you can click [here](https://index.docker.io/plans).
+However, knowing that not everything can be shared the Docker Index also
+offers private repositories. In order to see the available plans, you
+can click [here](https://index.docker.io/plans).
 
 Using the [Docker Registry](https://github.com/dotcloud/docker-registry), it is
-also possible to run your own private Docker Image registry service on your own
+also possible to run your own private Docker image registry service on your own
 servers.
 
 > **Note:** To learn more about the [*Docker Image Index*](
@@ -102,26 +99,24 @@ servers.
 ### Summary
 
  - **When you install Docker, you get all the components:**  
- i.e. the daemon, the client and access to the public image index.
- - **Alternatively, you can spread them across a collection of machines:**  
- e.g. Servers with the Docker daemon running, controlled by the Docker client.
+ The daemon, the client and access to the public image registry: the [Docker Index](http://index.docker.io).
+ - **You can run these components together or distributed:**  
+ Servers with the Docker daemon running, controlled by the Docker client.
  - **You can benefit form the public registry:**  
- e.g. `docker pull [user or repository]/[image name][:tag]`
- - **You can start a private one for proprietary use.**  
- i.e. Sign up for a [plan](https://index.docker.io/plans) or host your own
-[Docker registry](https://github.com/dotcloud/docker-registry).
+ Download and build upon images created by the community.
+ - **You can start a private repository for proprietary use.**  
+ Sign up for a [plan](https://index.docker.io/plans) or host your own [Docker registry](https://github.com/dotcloud/docker-registry).
 
 ## Elements of Docker
 
-Elements of Docker can be considered anything that the above mentioned tools
-(or parts) use. This includes the following:
+The basic elements of Docker are:
 
  - **Containers, which allow:**  
- Security, portability and resources management.
+ The run portion of Docker. Your applications run inside of containers.
  - **Images, which provide:**  
- The base for applications inside the containers to run, and;
+ The build portion of Docker. Your containers are built from images.
  - **The Dockerfile, which automates:**  
- Container and container image build-process.
+ A file that contains simple instructions that build Docker images.
 
 To get practical and learn what they are, and **_how to work_** with
 them, continue to [Working with Docker](working-with-docker.md). If you would like to
@@ -129,15 +124,15 @@ understand **_how they work_**, stay here and continue reading.
 
 ## The underlying technology
 
-The power of Docker comes from the underlying technology. A series of
-operating system features are carefully glued together to provide
-Docker's features and provide an easy to use interface to those
-features. In this section, we will see the main Linux kernel features
-that Docker uses to make easy containerization happen.
+The power of Docker comes from the underlying technology it is built
+from. A series of operating system features are carefully glued together
+to provide Docker's features and provide an easy to use interface to
+those features. In this section, we will see the main operating system
+features that Docker uses to make easy containerization happen.
 
 ### Namespaces
 
-Docker takes advantage of a technology called `namespsaces` to provide
+Docker takes advantage of a technology called `namespaces` to provide
 an isolated workspace we call a *container*.  When you run a container,
 Docker creates a set of *namespaces* for that container.
 
@@ -162,10 +157,10 @@ Some of the namespaces Docker uses are:
 Docker also makes use of another technology called `cgroups` or control
 groups. A key need to run applications in isolation is to have them
 contained, not just in terms of related filesystem and/or dependencies,
-but also, resources. Control groups allow the functionality to fairly
+but also, resources. Control groups allow Docker to fairly
 share available hardware resources to containers and if asked, set up to
-limits and constraints (e.g. limiting the memory to a maximum of 128
-MBs).
+limits and constraints, for example limiting the memory to a maximum of 128
+MBs.
 
 ### UnionFS
 
@@ -189,82 +184,80 @@ Let's see how it works!
 
 ### How does a container work?
 
-A container consists of operating system images, user added files and
-meta-data that hold some additional information such as the process
-(i.e. application) to start and the arguments to pass when you run it.
-Since images are always read-only, a read-write layer gets added on top
-through the union file system as well.
-
-This, together, provides a location for all sorts of dependencies to reside.
-They are operated by executing the process, providing it the container itself
-as the base of its system and by controlling it through Linux kernel features
-for the purposes of isolation, security and more.
+A container consists of an operating system, user added files and
+meta-data. Each container is built from an image. That image tells
+Docker what the container holds, what process to run when the container
+is launched and a variety of other configuration data. The Docker image
+is read-only. When Docker runs a container from an image it adds a
+read-write layer on top of the image (using the UnionFS technology we
+saw earlier) to run inside the container.
 
 ### What happens when you run a container?
 
-The Docker daemon accepts varying instructions to run containers.
-Depending on the commands passed, it can skip certain steps. To have
-an overall idea, let's take a look at a simple `Hello world` example.
+The Docker client (or the API!) tells the Docker daemon to run a
+container. Let's take a look at a simple `Hello world` example.
 
-Imagine running the following command: `docker run -i -t ubuntu /bin/bash`
+    $ docker run -i -t ubuntu /bin/bash
+
+Let's break down this command. The Docker client is launched using the
+`docker` binary. The bare minimum the Docker client needs to tell the
+Docker daemon is:
+
+* What Docker image to build the container from;
+* The command you want to run inside the container when it is launched.
+
+So what happens under the covers when we run this command?
 
 Docker begins with:
 
- - **Pulling the `ubuntu:latest` image:**  
- i.e. downloading it from the [Docker Index](https://index.docker.io)
+ - **Pulling the `ubuntu` image:**  
+ Docker checks for the presence of the `ubuntu` image and if it doesn't
+ exist locally on the host, then Docker downloads it from the [Docker Index](https://index.docker.io)
  - **Creates a new container:**  
- i.e. starts container creation procedure
+ Once Docker has the image it creates a container from it.
  - **Allocates a filesystem and mounts a read-write _layer_:**  
- i.e. makes use of the filesystem drivers and desired technology
+ The container is created in the filesystem and a read-write layer is added to the image.
  - **Allocates a network / bridge interface:**  
- i.e. `docker0`
+ Creates a network interface that allows the Docker container to talk to the local host.
  - **Sets up an IP address:**  
- i.e. intelligently find and attach an available IP address
+ Intelligently finds and attaches an available IP address from a pool.
  - **Executes _a_ process that you specify:**  
- i.e. runs your application, and;
+ Runs your application, and;
  - **Captures and provides application output:**  
- i.e. for you to see the application feedback.
-
-> **Tip:** If you do not specify a tag, Docker fetches the image tagged
-> ":latest" from the given repository, i.e., `repo_name/image_name` defaults
-> to `repo_name/image_name:latest`. Therefore, `ubuntu` is actually
-> `ubuntu:latest`. The Ubuntu repository contains several others, including
-> `12.04`, `13.10`, `lucid`, `precise` and more.
+ Connects and logs standard input, outputs and errors for you to see how your application is running.
 
 ### How does a Docker Image work?
 
-When you start building your container (e.g. install an application on
-`ubuntu:12.04` and commit the *difference*), technically, this does not
-change the parent Ubuntu image but adds a new logical *layer* that forms
-yet a new one.
+We've already seen that Docker images are read-only templates that
+Docker containers are launched from. When you launch that container it
+creates a read-write layer on top of that image that your application is
+run in.
 
-The term layer is used actively when referring to Docker, because all
-commands executed on an image during the build process forms a new layer on top
-of the parent, without modifying or changing what's underneath (e.g. the
-*base image*). 
+Docker images are built using a simple descriptive set of steps we
+call *instructions*. Instructions are stored in a file called a
+`Dockerfile`. Each instruction writes a new layer to an image using the
+UnionFS technology we saw earlier.
 
-The lowest-level, read-only images (i.e. Ubuntu) are referred to as
-*base-images*. They are supplied by Docker and can be trusted.
+Every image starts from a base image, for example `ubuntu` a base Ubuntu
+image or `fedora` a base Fedora image. Docker builds and provides these
+base images via the [Docker Index](http://index.docker.io).
 
-Therefore, technically, an image is a read-only layer that you can build upon. 
+### How does a Docker registry work?
 
-Through filesystems, drivers and by analysing which technology is available,
-Docker creates, manages and works with images depending on the system.
+The Docker registry is a store for your Docker images. Once you build a
+Docker image you can *push* it to the [Docker
+Index](http://index.docker.io) or to a private registry you run behind
+your firewall.
 
-### How does the image registry index work?
+Using the Docker client, you can search for already published images and
+then pull them down to your Docker host to build containers from them
+(or even build on these images).
 
-The Docker Index works by users submitting their committed images. A committed
-image is a read-only snapshot taken from a container after the build process
-that can be used as a base to run new containers or to build new images for new
-containers.
-
-Using the Docker client, you can search-and-find (`docker search [name]`
-and `docker pull [name]`) some already published images to start running
-containers or push one of your own images to share publicly.
-
-If you have a private repository which you'd like to share amongst those you
-designate, you can also use the central registry index, the Docker Index by
-[signing up for a plan](https://index.docker.io/plans).
+The [Docker Index](http://index.docker.io) provides both public and
+private storage for images. Public storage is searchable and can be
+downloaded by anyone. Private repositories are excluded from search
+results and only you and your users can pull them down and use them to
+build containers. You can [sign up for a plan here](https://index.docker.io/plans).
 
 To learn more, check out the [Working With Repositories](
 http://docs.docker.io/en/latest/use/workingwithrepository) section of our

--- a/docs/sources/introduction/understanding-docker.md
+++ b/docs/sources/introduction/understanding-docker.md
@@ -32,32 +32,37 @@ Docker has three major components:
 
 * Docker containers.
 * Docker images.
-* Docker Registries.
+* Docker registries.
 
 #### Docker containers
 
 Docker containers are like a directory. A Docker container holds
 everything that is needed for an application to run. Each container is
 created from a Docker image. Docker containers can be run, started,
-stopped, moved and deleted.
+stopped, moved and deleted. Each container is an isolated and secure
+application platform. You can consider Docker containers the *run*
+portion of the Docker framework.
 
 #### Docker images
 
-The Docker image is a read-only template, for example an Ubuntu
+The Docker image is a template, for example an Ubuntu
 operating system with Apache and your web application installed. Docker
 containers are launched from images. Docker provides a simple way to
-build new images or update existing images.
+build new images or update existing images. You can consider Docker
+images to be the *build* portion of the Docker framework.
 
 #### Docker Registries
 
 Docker registries hold images. These are public (or private!) stores
-that you can push or pull your own or others images to and from. Docker
-registries allow you to build simple and powerful development and
-deployment work flows.
+that you can upload or download images to and from. These images can be
+images you create yourself or you can make use of images that others
+have previously created. Docker registries allow you to build simple and
+powerful development and deployment work flows. You can consider Docker
+registries the *share* portion of the Docker framework.
 
 ### How does Docker work?
 
-Docker is a client-server application. The Docker *client* commands the Docker
+Docker is a client-server framework. The Docker *client* commands the Docker
 *daemon*, which in turn creates, builds and manages containers.
 
 The Docker daemon takes advantage of some neat Linux kernel and
@@ -72,24 +77,32 @@ technologies.
 
 ## Features of Docker
 
-In order to get a truly good grasp of full range of capabilities of Docker, one
-would need to take a look at its [User's Manual](http://docs.docker.io). Here,
-we will just attempt to summarize those features and give you an idea of what can be achieved with Docker.
+In order to get a good grasp of the capabilities of Docker you should
+read the [User's Manual](http://docs.docker.io). Let's look at a summary
+of Docker's features to give you an idea of how Docker might be useful
+to you.
 
 ### User centric and simple to use
 
 *Docker is made for humans.*
 
 It's easy to get started and easy to build and deploy applications with
-Docker: or as we say "*dockerise*" them!
+Docker: or as we say "*dockerise*" them! As much of Docker as possible
+uses plain English for commands and tries to be as lightweight and
+transparent as possible. We want to get out of the way so you can build
+and deploy your applications.
 
 ### Docker is Portable
 
 *Dockerise And Go!*
 
-Docker containers are highly portable.
+Docker containers are highly portable. Docker provides a standard
+container format to hold your applications:
 
-Any machine, be it bare-metal or virtualized can run any Docker
+* You take care of your applications inside the container, and;
+* Docker takes care of managing the container.
+
+Any machine, be it bare-metal or virtualized, can run any Docker
 container. The sole requirement is to have Docker installed.
 
 **This translates to:**
@@ -103,19 +116,21 @@ container. The sole requirement is to have Docker installed.
 *No more resources waste.*
 
 Containers are lightweight, in fact, they are extremely lightweight.
-Unlike VMs, which have the overhead of a hypervisor, Docker does not
-need to anything other than what the actual process requires to run.
+Unlike traditional virtual machines, which have the overhead of a
+hypervisor, Docker relies on operating system level features to provide
+isolation and security. A Docker container does not need anything more
+than what your application needs to run.
 
 This translates to:
 
  - Ability to deploy a large number of applications on a single system;
- - Literally lightening fast start up times and reduced overhead.
+ - Lightning fast start up times and reduced overhead.
 
 ### Docker can run anything
 
 *An amazing host! (again, pun intended.)*
 
-Docker isn't perspective about what applications or services you can run
+Docker isn't prescriptive about what applications or services you can run
 inside containers. We provide use cases and examples for running web
 services, databases, applications - just about anything you can imagine
 can run in a Docker container.
@@ -133,20 +148,22 @@ Today, it is possible to install and use Docker almost anywhere. Even on
 non-Linux systems such as Windows or Mac OS X thanks to a project called
 [Boot2Docker](http://boot2docker.io).
 
-**This translates to running Docker (therefore containers) _anywhere_:**
+**This translates to running Docker (and Docker containers!) _anywhere_:**
 
  - **Linux:**  
  Ubuntu, CentOS / RHEL, Fedora, Gentoo, openSUSE and more.
  - **Infrastructure-as-a-Service:**  
  Amazon AWS, Google GCE, Rackspace Cloud and probably, your favorite IaaS.
+ - **Microsoft Windows**  
+ - **OS X**  
 
-### Responsible (i.e., manages and limits resources)
+### Docker is Responsible
 
 *A tool that you can trust.*
 
 Docker does not just bring you a set of tools to isolate and run
-applications. It also allows you to put in restraints and set up
-constraints *and it keeps track*.
+applications. It also allows you to specify constraints and controls on
+those resources.
 
 **This translates to:**
 
@@ -155,7 +172,7 @@ constraints *and it keeps track*.
 
 Without dealing with complicated commands or third party applications.
 
-### Social (i.e., share containers and images)
+### Docker is Social
 
 *Docker knows that No One Is an Island.*
 
@@ -170,8 +187,8 @@ even run your own registry behind your firewall.
 **This translates to:**
 
  - No more wasting time building everything from scratch;
- - Easily save your application stack's *without* waiting 15 to 60 minutes;
- - Share and benefit with/from the rest of the Docker community.
+ - Easily and quickly save your application stack;
+ - Share and benefit from the depth of the Docker community.
 
 ## Docker versus Virtual Machines
 
@@ -183,9 +200,9 @@ even run your own registry behind your firewall.
 
  - Easy on the resources;
  - Extremely light to deal with;
- - Do not come with overheads;
+ - Do not come with substantial overhead;
  - Very easy to work with;
- - Agnostic in essence;
+ - Agnostic;
  - Can work *on* virtual machines;
  - Secure and isolated;
  - *Artful*, *social*, *fun*, and;
@@ -208,11 +225,11 @@ be used in a lot of different use cases.
  Build, test and ship applications with nothing but Docker and lean
  containers.
  - **Re-usable building blocks to create more:**  
- Any container can be a base for the next, and each command a new block.
+ Docker images are easily updated building blocks.
  - **Automatically build-able:**  
- It has never been this easy to instruct and build - *anything*.
- - **Built upon:**  
- Numerous third party tools and platforms are built on Docker, for your containers.
+ It has never been this easy to build - *anything*.
+ - **Easy to integrate:**  
+ A powerful, fully featured API allows you to integrate Docker into your tooling.
 
 ### For sysadmins
 
@@ -223,7 +240,7 @@ be used in a lot of different use cases.
  - **Improvements on speed and integration:**  
  Containers are almost nothing more than isolated, secure processes.
  - **Lowered costs of infrastructure:**  
- Containers are lightweight and heavy on resources compared to VMs.
+ Containers are lightweight and heavy on resources compared to virtual machines.
  - **Portable configurations:**  
  Issues and overheads with dealing with configurations and systems are eliminated.
 
@@ -233,7 +250,8 @@ be used in a lot of different use cases.
  Replacing VMs with containers provide security without additional
  hardware (or software).
  - **Portable:**  
- You can securely carry around applications, the exact way they exist.
+ You can easily move applications and workloads from different operating
+ systems and platforms.
 
 ## Where to go from here
 

--- a/docs/sources/introduction/working-with-docker.md
+++ b/docs/sources/introduction/working-with-docker.md
@@ -4,40 +4,37 @@ page_keywords: docker, introduction, documentation, about, technology, understan
 
 # Working with Docker and the Dockerfile
 
-*How to use and work with Docker and Docker's main element?*
+*How to use and work with Docker?*
 
 > **Warning! Don't let this long page bore you.**
-> If you prefer a summary and would like to get started **_very 
-> quickly_**, you can check out the glossary of all available client
+> If you prefer a summary and would like to see how a specific command
+> works, check out the glossary of all available client
 > commands on our [User's Manual: Commands Reference](
 > http://docs.docker.io/en/latest/reference/commandline/cli).
 
 ## Introduction
 
-On the last page (i.e., [Understanding the Technology](technology.md)) we covered the
-parts forming Docker (e.g. the client and the daemon), studied the
-underlying technology and *how* everything works (i.e., the underlying
-technology). It should be clear how beneficial containers are compared
-to virtual machines.
+On the last page, [Understanding the Technology](technology.md), we covered the
+components that make up Docker and learnt about the
+underlying technology and *how* everything works.
 
 Now, it is time to get practical and see *how to work with* the Docker client,
-Docker images and the `Dockerfile`.
+Docker containers and images and the `Dockerfile`.
 
 > **Note:** You are encouraged to take a good look at the container,
-> image and Dockerfile explanations here to have a better understanding
+> image and `Dockerfile` explanations here to have a better understanding
 > on what exactly they are and to get an overall idea on how to work with
 > them. On the next page (i.e., [Get Docker](get-docker.md)), you will be
-> able to find links for platform-centric installation instructions and
-> also, more goal-oriented usage tutorials based on `Dockerfile`s.
+> able to find links for platform-centric installation instructions.
 
 ## Elements of Docker
 
-As we mentioned on the previous page (i.e., [Understanding the Technology](technology.md)), main
+As we mentioned on the, [Understanding the Technology](technology.md) page, the main
 elements of Docker are:
 
  - Containers;
  - Images, and;
- - The Dockerfile.
+ - The `Dockerfile`.
 
 > **Note:** This page is more *practical* than *technical*. If you are
 > interested in understanding how these tools work behind the scenes
@@ -46,41 +43,38 @@ elements of Docker are:
 
 ## Working with the Docker client
 
-In order to work with the Docker client, you need to have a host
-set up with the Docker daemon (i.e., have Docker installed).
-
-> **Tip:** Depending on your platform and the way you choose to install
-> Docker, you might need to manually start the daemon: `sudo docker -d &`,
-> or, a VM running the Docker daemon (e.g. on 
-> [Mac OS X](http://docs.docker.io/en/latest/installation/mac)).
+In order to work with the Docker client, you need to have a host with
+the Docker daemon installed and running.
 
 ### How to use the client
 
-The client provides you a command-line interface (i.e., CLI) to use Docker
-and it works like almost any other regular command-line application.
+The client provides you a command-line interface to Docker. It is
+accessed by running the `docker` binary.
 
 > **Tip:** The below instructions can be considered a summary of our
 > *interactive tutorial*. If you prefer a more hands-on approach without
 > installing anything, why not give that a shot and check out the
 > [Docker Interactive Tutorial](http://www.docker.io/interactivetutorial).
 
-Usage consists of passing a chain of arguments:
+The `docker` client usage consists of passing a chain of arguments:
 
     # Usage:  [sudo] docker [option] [command] [arguments] ..
     # Example:
     docker run -i -t ubuntu /bin/bash
-    
-### Versions and status
 
-Perhaps the most performed operation with any application is to check 
-the version and status.
+### Our first Docker command
+
+Let's get started with our first Docker command by checking the
+version of the currently installed Docker client using the `docker
+version` command.
 
     # Usage: [sudo] docker version
     # Example:
     docker version
-    
-This command will not only provide you the version of Docker client 
-you are using, but also the version of Go (the programming language powering Docker).
+
+This command will not only provide you the version of Docker client you
+are using, but also the version of Go (the programming language powering
+Docker).
 
     Client version: 0.8.0
     Go version (client): go1.2
@@ -92,13 +86,14 @@ you are using, but also the version of Go (the programming language powering Doc
     Go version (server): go1.2
 
     Last stable version: 0.8.0
-    
+
 ### Finding out all available commands
 
 The user-centric nature of Docker means providing you a constant stream
 of helpful instructions. This begins with the client itself.
 
-In order to get a full list of available commands, call the client:
+In order to get a full list of available commands run the `docker`
+binary:
 
     # Usage: [sudo] docker
     # Example:
@@ -106,13 +101,11 @@ In order to get a full list of available commands, call the client:
 
 You will get an output with all currently available commands.
 
-    # Commands:
-    #     attach    Attach to a running container
-    #     build     Build a container from a Dockerfile
-    #     commit    Create a new image from a container's changes
-    # ..
-    # A good long list of commands are available ;-)
-    # .
+    Commands:
+         attach    Attach to a running container
+         build     Build a container from a Dockerfile
+         commit    Create a new image from a container's changes
+    . . .
 
 ### Command usage instructions
 
@@ -124,403 +117,277 @@ Try typing Docker followed with a `[command]` to see the instructions:
     # Usage: [sudo] docker [command] [--help]
     # Example:
     docker attach
-    
-    # Example:
-    
+    Help outputs . . .
+
+Or you can pass the `--help` flag to the `docker` binary.
+
     docker images --help
 
 You will get an output with all available options:
 
     Usage: docker attach [OPTIONS] CONTAINER
-    
+
     Attach to a running container
-    
+
       --no-stdin=false: Do not attach stdin
       --sig-proxy=true: Proxify all received signal to the process (even in non-tty mode)
-
-    # We do realise "proxify" is not a real word.
-    # We do though like keeping things concise and efficient for you. ;-)
 
 ## Working with images
 
 ### Docker Images
 
-In terms of IT, an image is a frozen-in-time collection of all files,
-folders, programs etc. of a computer. In fact, it is the entirety of
-everything important powering the computer.
-
-As we have explained in our [introduction](../index.md), applications
-inside the containers depend on libraries and tools supplied by
-the operating system to work. They also depend on drivers, again
-supplied by the OS to communicate with the hardware. This can mean
-writing or reading data from the disk, or communicating over a network.
-
-Any application running inside a container, therefore, needs to be
-based on a default image. Any Linux distribution can be used as a
-base (i.e., base Ubuntu), and any image can be used as a starting point
-to power a container (i.e., Nginx installed on Ubuntu).
-
-> **Tip:** Containing everything, including the base of an operating-system
-> is the key to isolation. This provides the application everything it
-> needs and allows blocking the outside access (i.e., isolation).
+As we've discovered a Docker image is a read-only template that we build
+containers from. Every Docker container is launched from an image and
+you can use both images provided by others, for example we've discovered
+the base `ubuntu` image provided by Docker, as well as images built by
+others. For example we can build an image that runs Apache and our own
+web application as a starting point to launch containers.
 
 ### Searching for images
 
-Searching for images consists of using the `docker search` command. Depending
-on what you are looking for, you might have a very long list returned,
-or an empty one. All image information is supplied with some additional
-ones, such as a *description*, *stars* and whether the image is *trusted*
-or not.
+To search for Docker image we use the `docker search` command. The
+`docker search` command returns a list of all images that match your
+search criteria together with additional, useful information about that
+image. This includes information such as social metrics like how many
+other people like the image - we call these "likes" *stars*. We also
+tell you if an image is *trusted*. A *trusted* image is built from a
+known source and allows you to introspect in greater detail how the
+image is constructed.
 
     # Usage: [sudo] docker search [image name]
     # Example:
     docker search nginx
-    
-Output:
 
-    # NAME                                     DESCRIPTION                                     STARS     OFFICIAL   TRUSTED
-    # dockerfile/nginx                         Trusted Nginx (http://nginx.org/) Build         6                    [OK]
-    # paintedfox/nginx-php5                    A docker image for running Nginx with PHP5.     3                    [OK]
-    # dockerfiles/django-uwsgi-nginx           Dockerfile and configuration files to buil...   2                    [OK]
-    # ..
-    
+    NAME                                     DESCRIPTION                                     STARS     OFFICIAL   TRUSTED
+    dockerfile/nginx                         Trusted Nginx (http://nginx.org/) Build         6                    [OK]
+    paintedfox/nginx-php5                    A docker image for running Nginx with PHP5.     3                    [OK]
+    dockerfiles/django-uwsgi-nginx           Dockerfile and configuration files to buil...   2                    [OK]
+    . . .
+
 > **Note:** To learn more about trusted builds, check out [this]
 (http://blog.docker.io/2013/11/introducing-trusted-builds) blog post.
 
 ### Downloading an image
 
-Downloading an image can be considered as *pulling* one from the repository.
-Therefore, the `pull` command is used.
+Downloading a Docker image is called *pulling*. To do this we hence use the
+`docker pull` command.
 
     # Usage: [sudo] docker pull [image name]
     # Example:
     docker pull dockerfile/nginx
 
-Output:
+    Pulling repository dockerfile/nginx
+    0ade68db1d05: Pulling dependent layers
+    27cf78414709: Download complete
+    b750fe79269d: Download complete
+    . . .
 
-    # Pulling repository dockerfile/nginx
-    # 0ade68db1d05: Pulling dependent layers 
-    # 27cf78414709: Download complete 
-    # b750fe79269d: Download complete 
-    # ..
-
-As you will see, Docker will download, one by one, all the layers forming
-the final image. This demonstrates the *building block* philosophy.
-
-### Committing an image
-
-Docker uses base images to create containers. However, when an application
-is running, a read-write mode enabled filesystem is also provided.
-
-Whenever you would like to take a snap-shot and save the changes of a
-container, you need to `commit`.
-
-    # Usage: [sudo] docker commit [container ID] [image name]
-    # Example:
-    docker commit 9565c1aeabea nginx
-
-If you plan to share an image, you need to commit it with a specified username
-which you can obtain by registering to the [Docker Index](https://index.docker.io).
-Your username acts like a repository where images are collected as a set.
-
-    # Usage: [sudo] docker commit [container ID] [user name]/[image name]
-    # Example:
-    docker commit 9565c1aeabea myUserName/nginx
-
-### Sharing an image
-
-Similar to Git, when you would like to share your commits, you can use
-the `push` command.
-
-    # Usage: [sudo] docker push [container ID] [user name]/[image name]
-    # Example:
-    docker push username/nginx
+As you can see, Docker will download, one by one, all the layers forming
+the final image. This demonstrates the *building block* philosophy of
+Docker.
 
 ### Listing available images
 
 In order to get a full list of available images, you can use the
-`images` command.
+`docker images` command.
 
     # Usage: [sudo] docker images
     # Example:
     docker images
 
-Output:
+    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    myUserName/nginx    latest              a0d6c70867d2        41 seconds ago      578.8 MB
+    nginx               latest              173c2dd28ab2        3 minutes ago       578.8 MB
+    dockerfile/nginx    latest              0ade68db1d05        3 weeks ago         578.8 MB
 
-    # REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
-    # myUserName/nginx    latest              a0d6c70867d2        41 seconds ago      578.8 MB
-    # nginx               latest              173c2dd28ab2        3 minutes ago       578.8 MB
-    # dockerfile/nginx    latest              0ade68db1d05        3 weeks ago         578.8 MB
-    
 ## Working with containers
 
 ### Docker Containers
 
-Docker containers are little more than an actual directory on your system.
-Yes, they do contain literally everything for an application to run. And
-yes, you can build them, extend them, manage their lifecycle and pull them
-apart and continue building from any saved (i.e., *committed*) stage.
-However, they still remain very lightweight, since Docker makes use of
-the Linux kernel features to provide all the important functionality to
-*decorate* the actual application running process (i.e., to contain, ship, 
-share, sand-box and isolate an application).
-
-> **Tip:** Containers, despite holding everything inside, are nothing like 
-> VMs. To learn more about their differences, see the detailed comparison 
-> in [*Docker Compared Against Virtual-Machines*](understanding-docker.md).
-
-In order to create or start a container, you need an image. This could be an
-empty Ubuntu instance, or, someone's *committed* personal image that is designed
-to run a web-application.
-
-Every action you take on an image immediately forms a new one. Working 
-with Docker images means working with building blocks where images are 
-*yours* to create anything, in any direction, from any point taken in time.
-
-**Note:** A container can exist in two main states – *running* and *stopped*. 
+Docker containers are directories on your Docker host that are built
+from Docker images. In order to create or start a container, you need an
+image. This could be the base `ubuntu` image or an image built and
+shared with you or an image you've built yourself.
 
 ### Running a new container from an image
 
-One way to create a new container is to directly use an image.
+The easiest way to create a new container is to *run* one from an image.
 
     # Usage: [sudo] docker run [arguments] ..
     # Example:
-    # docker run -name [new container name] -p [outside port:container port] -d [image name] 
-    docker run -name nginx -p 80:80 -d dockerfile/nginx
+    docker run -d --name nginx_web nginx /usr/sbin/nginx
 
-Upon the successful creation of a container, a new image gets created.
+This will create a new container from an image called `nginx` which will
+launch the command `/usr/sbin/nginx` when the container is run. We've
+also given our container a name, `nginx_web`.
 
-### Listing all available containers
+Containers can be run in two modes:
 
-Listing containers depends on the `ps` command. Obtaining a full list, including
-stopped containers requires the `-a` (or `--all`) flagged to be passed with the command.
+* Interactive;
+* Daemonized;
+
+An interactive container runs in the foreground and you can connect to
+it and interact with it. A daemonized container runs in the background.
+
+A container will run as long as the process you have launched inside it
+is running, for example if the `/usr/bin/nginx` process stops running
+the container will also stop.
+
+### Listing containers
+
+We can see a list of all the containers on our host using the `docker
+ps` command. By default the `docker ps` commands only shows running
+containers. But we can also add the `-a` flag to show *all* containers -
+both running and stopped.
 
     # Usage: [sudo] docker ps [-a]
     # Example:
     docker ps
 
-Output:
-
-    # CONTAINER ID        IMAGE                     COMMAND             CREATED             STATUS              PORTS                NAMES
-    # 842a50a13032        dockerfile/nginx:latest   nginx               35 minutes ago      Up 30 minutes       0.0.0.0:80->80/tcp   nginx_web1
+    CONTAINER ID        IMAGE                     COMMAND             CREATED             STATUS              PORTS                NAMES
+    842a50a13032        dockerfile/nginx:latest   nginx               35 minutes ago      Up 30 minutes       0.0.0.0:80->80/tcp   nginx_web
 
 ### Stopping a container
 
-You can use the `stop` command to stop an active container. This will gracefully
+You can use the `docker stop` command to stop an active container. This will gracefully
 end the active process.
 
     # Usage: [sudo] docker stop [container ID]
     # Example:
-    docker stop nginx_web1
+    docker stop nginx_web
+    nginx_web
 
-Output:
-    
-    # The output is the ID of the container stopped
-    # nginx_web1
+If the `docker stop` command succeeds it will return the name of
+the container it has stopped.
 
 ### Starting a Container
 
-Stopped containers can start back again. They will run the application specified
-during creation.
+Stopped containers can be started again.
 
     # Usage: [sudo] docker start [container ID]
     # Example:
-    docker start nginx_web1
+    docker start nginx_web
+    nginx_web
 
-Output:
-    
-    # The output is the ID of the container stopped
-    # nginx_web1
-
-### Saving the container state
-
-As we have also previously covered, in order to save the current state 
-of a container, the `commit` command must be used.
-
-> *Tip:* When you `stop` a container, its state does not get lost. However,
-> to form an image, it must be committed.
+If the `docker start` command succeeds it will return the name of the
+freshly started container.
 
 ## Working with the Dockerfile
 
-The Dockerfile provides an automation process to create and build new images 
-and containers. This procedure consists of *successively* describing the steps
-to be taken to build inside a text file, called `Dockerfile` and letting 
-Docker go through them one by one.
+The `Dockerfile` holds the set of instructions Docker uses to build a Docker image.
 
-> **Tip:** Below is a short summary of our full Dockerfile tutorial. 
-> In order to get a better-grasp of how to work with these automation 
-> scripts, check out the 
-> [Dockerfile step-by-step tutorial](http://www.docker.io/learn/dockerfile).
+> **Tip:** Below is a short summary of our full Dockerfile tutorial.  In
+> order to get a better-grasp of how to work with these automation
+> scripts, check out the [Dockerfile step-by-step
+> tutorial](http://www.docker.io/learn/dockerfile).
 
-### The Dockerfile
-
-You can streamline and automate the whole Docker image creation process
-successively, in a maintainable and predictable way by using Dockerfiles.
-
-A Dockerfile is a script (i.e., a set of instructions) to be read and 
-run by the Docker client to build a brand new container image with 
-your exact specifications.
-
-Dockerfiles are powerful. They allow you to attach/detach directories 
-from the host, copy files and specify which process to run when a 
-container gets started *from* the formed image and even link containers
-intelligently.
-
-> **Tip:** Dockerfiles are flexible and allow you to achieve a great 
-> deal of things through a collection of directives / commands. To learn 
-> about the Dockerfile auto-builder, check out the documentation page
-> [Dockerfile Reference](http://docs.docker.io/en/latest/reference/builder).
-
-### Dockerfile Format
-
-A `Dockerfile` contains instructions written in the below format:
+A `Dockerfile` contains instructions written in the following format:
 
     # Usage: Instruction [arguments / command] ..
     # Example:
     FROM ubuntu
 
-All arguments provided after an instruction, unless it is a Docker
-specific one (e.g. `FROM`), are passed directly to the container to be
-executed.
-
-Although there is not a script requirement, instructions are generally
-advised to be written in all capitals for the purposes of clarity.
-
-A `#` sign is used to comment-out text:
+A `#` sign is used to provide a comment:
 
     # Comments ..
 
+> **Tip:** The `Dockerfile` is very flexible and provides a powerful set
+> of instructions for building applications. To learn more about the
+> `Dockerfile` and it's instructions see the [Dockerfile
+> Reference](http://docs.docker.io/en/latest/reference/builder).
+
 ### First steps with the Dockerfile
 
-Dockerfiles shall be supplied with necessary explanations, instructions
-along with appropriate meta-data, such as the name of the creator
-(i.e., maintainer) of the document.
+It's a good idea to add some comments to the start of your `Dockerfile`
+to provide explanation and exposition to any future consumers, for
+example:
 
-Therefore, it is advisable to place a block of code, similar to the one
-below, at the beginning of each Dockerfile:
+    #
+    # Dockerfile to install Nginx
+    # VERSION 2 - EDITION 1
 
-    ###############################
-    # Dockerfile to install Nginx #
-    # VERSION 2 - EDITION 1       #
-    ###############################
-    
-As the first instruction, they should always state the name of the base
-image to be used with the `FROM` instruction, i.e.,
+The first instruction in any `Dockerfile` must be the `FROM` instruction. The `FROM` instruction specifies the image name that this new image is built from, it is often a base image like `ubuntu`.
 
     # Base image used is Ubuntu:
     FROM ubuntu
-    
-Next, for brevity, the name of the `Maintainer` can be declared by typing
-the name and an email address, separated by a comma, after the instruction:
+
+Next, we recommend you use the `MAINTAINER` instruction to tell people who manages this image.
 
     # Maintainer: O.S. Tezer <ostezer at gmail com> (@ostezer)
     MAINTAINER O.S. Tezer, ostezer@gmail.com
 
-Once the meta-data and the name of the base image is declared appropriately,
-it is time to start listing the commands (i.e., instructions).
+After this we can add additional instructions that represent the steps
+to build our actual image.
 
-### Listing instructions in a Dockerfile
+### Our Dockerfile so far
 
-Following up from the previous section, the current final state of our
-Dockerfile should be similar to:
+So far our `Dockerfile` will look like.
 
-    ###############################
-    # Dockerfile to install Nginx #
-    # VERSION 2 - EDITION 1       #
-    ###############################
-    
-    # Base image used is Ubuntu:
+    # Dockerfile to install Nginx
+    # VERSION 2 - EDITION 1
     FROM ubuntu
-
-    # Maintainer: O.S. Tezer <ostezer at gmail com> (@ostezer)
     MAINTAINER O.S. Tezer, ostezer@gmail.com
 
-Now we can continue adding instructions, which are to be executed successively.
-They should be added following the below example:
+Let's install a package and configure an application inside our image. To do this we use a new
+instruction: `RUN`. The `RUN` instruction executes commands inside our
+image, for example. The instruction is just like running a command on
+the command line inside a container.
 
-    # Instruction (command) explanation
-    # Instruction argument (command)
-
-Therefore;
-
-    # Install Nginx on Ubuntu
-    
-    # Add application repository
     RUN echo "deb http://archive.ubuntu.com/ubuntu/ raring main universe" >> /etc/apt/sources.list
-
-    # Update the server repository list
     RUN apt-get update
-    
-    # Install some necessary libraries and tools
-    RUN apt-get install -y net-tools wget nano curl dialog
-    
-    # Finally, download and install Nginx
     RUN apt-get install -y nginx
-    
-    # Turn daemon mode off
     RUN echo "\ndaemon off;" >> /etc/nginx/nginx.conf
-    
-    # Attach volumes
-    # Volumes are regular OS directories that are not 
-    # part of an image's layers.
-    # You can easily access them from the outside and
-    # keep them as they are.
-    # To learn more about volumes, visit:
-    # http://docs.docker.io/en/latest/use/working_with_volumes/
-    VOLUME /etc/nginx/sites-enabled
-    VOLUME /var/log/nginx
-    
-    # Or;
-    
-    # Alternatively, copy a custom nginx.conf
-    # RUN rm -v /etc/nginx/nginx.conf
-    # ADD nginx.conf /etc/nginx/
-    
-    # Expose ports
-    EXPOSE 80
 
-    # Set the command to be executed when
-    # running (i.e., creating) a new container
-    CMD service nginx start
+We can see here that we've *run* four instructions. Each time we run an
+instruction a new layer is added to our image. Here's we've added an
+Ubuntu package repository, updated the packages, installed the `nginx`
+package and then echo'ed some configuration to the default
+`/etc/nginx/nginx.conf` configuration file.
 
-You can now save this file and use it to build images and create containers.
+Let's specify another instruction, `CMD`, that tells Docker what command
+to run when a container is created from this image.
+
+    CMD /usr/sbin/nginx
+
+We can now save this file and use it build an image.
 
 ### Using a Dockerfile
 
-Docker uses the Dockerfile to build an image. Therefore, using a Dockerfile is
-achieved with the `build` command.
+Docker uses the `Dockerfile` to build images. The build process is initiated by the `docker build` command.
 
     # Use the Dockerfile at the current location
     # Usage: [sudo] docker build .
     # Example:
-    docker build -t my_nginx_img .
-    
-Output:
+    docker build -t="my_nginx_image" .
 
-    # Uploading context 25.09 kB
-    # Uploading context 
-    # Step 0 : FROM ubuntu
-    #  ---> 9cd978db300e
-    # Step 1 : MAINTAINER O.S. Tezer, ostezer@gmail.com
-    #  ---> Using cache
-    #  ---> 467542d0cdd3
-    # Step 2 : RUN echo "deb http://archive.ubuntu.com/ubuntu/ raring main universe" >> /etc/apt/sources.list
-    #  ---> Using cache
-    #  ---> 0a688bd2a48c
-    # Step 3 : RUN apt-get update
-    #  ---> Running in de2937e8915a
-    
-    # ..
-    # ..
-    # Step 10 : CMD service nginx start
-    #  ---> Running in b4908b9b9868
-    #  ---> 626e92c5fab1
-    # Successfully built 626e92c5fab1
+    Uploading context 25.09 kB
+    Uploading context
+    Step 0 : FROM ubuntu
+      ---> 9cd978db300e
+    Step 1 : MAINTAINER O.S. Tezer, ostezer@gmail.com
+      ---> Using cache
+      ---> 467542d0cdd3
+    Step 2 : RUN echo "deb http://archive.ubuntu.com/ubuntu/ raring main universe" >> /etc/apt/sources.list
+      ---> Using cache
+      ---> 0a688bd2a48c
+    Step 3 : RUN apt-get update
+     ---> Running in de2937e8915a
+    . . .
+    Step 10 : CMD /usr/sbin/nginx
+      ---> Running in b4908b9b9868
+      ---> 626e92c5fab1
+    Successfully built 626e92c5fab1
+
+Here we can see that Docker has executed each instruction in turn and
+each instruction has created a new layer in turn and each layer identified
+by a new ID. The `-t` flag allows us to specify a name for our new
+image, here `my_nginx_image`.
+
+We can see our new image using the `docker images` command.
 
     docker images
-    
-    # REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
-    # my_nginx_img       latest              626e92c5fab1        57 seconds ago      337.6 MB
+    REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
+    my_nginx_img        latest              626e92c5fab1        57 seconds ago      337.6 MB
 
 ## Where to go from here
 


### PR DESCRIPTION
This is a further edit of the introductory material.

Again focus is one removing the repetitive sections, making it more succinct and cleaning up some of the language. 

I think the Working with Docker page needs more work. It needs to tell a clearer story than it does now. I especially pulled the `docker commit` section - we want to de-emphasize this workflow in favor of `docker build` and Dockerfiles.
