### PR TITLE
Cli integration: add docker options & fix the wait at the end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DOCKER_IMAGE := docker$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 DOCKER_DOCS_IMAGE := docker-docs$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 DOCKER_MOUNT := $(if $(BINDDIR),-v "$(CURDIR)/$(BINDDIR):/go/src/github.com/dotcloud/docker/$(BINDDIR)")
 
-DOCKER_RUN_DOCKER := docker run --rm -it --privileged -e TESTFLAGS $(DOCKER_MOUNT) "$(DOCKER_IMAGE)"
+DOCKER_RUN_DOCKER := docker run --rm -it --privileged -e TESTFLAGS -e DOCKER_GRAPHDRIVER -e DOCKER_EXECDRIVER $(DOCKER_MOUNT) "$(DOCKER_IMAGE)"
 DOCKER_RUN_DOCS := docker run --rm -it -p $(if $(DOCSPORT),$(DOCSPORT):)8000 "$(DOCKER_DOCS_IMAGE)"
 
 default: binary

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -7,6 +7,8 @@ set -e
 # subshell so that we can export PATH without breaking other things
 (
 export PATH="$DEST/../binary:$DEST/../dynbinary:$PATH"
+DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
+DOCKER_EXECDRIVER=${DOCKER_EXECDRIVER:-native}
 
 bundle_test_integration_cli() {
 	go_test_dir ./integration-cli
@@ -17,7 +19,8 @@ if ! command -v docker &> /dev/null; then
 	false
 fi
 
-docker -d -D -p $DEST/docker.pid &> $DEST/docker.log &
+echo "running cli integration tests using graphdriver: '$DOCKER_GRAPHDRIVER' and execdriver: '$DOCKER_EXECDRIVER'" 
+docker -d -D -s $DOCKER_GRAPHDRIVER -e $DOCKER_EXECDRIVER -p $DEST/docker.pid &> $DEST/docker.log &
 
 # pull the busybox image before running the tests
 sleep 2

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -31,5 +31,5 @@ bundle_test_integration_cli 2>&1 \
 
 DOCKERD_PID=$(cat $DEST/docker.pid)
 kill $DOCKERD_PID
-wait $DOCKERD_PID
+wait $DOCKERD_PID || true
 )


### PR DESCRIPTION
This adds support for setting DOCKER_GRAPHDRIVER and DOCKER_EXECDRIVER to select the graph driver and the execution driver for the cli integration tests.

This PR also fixes a race at the end of the test-integration-cli which makes the tests always fail on some systems.
