### PR TITLE
Remove context from config

### DIFF
--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -1,10 +1,8 @@
 package runconfig
 
 import (
-	"encoding/json"
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/nat"
-	"github.com/dotcloud/docker/runtime/execdriver"
 )
 
 // Note: the Config structure should hold only portable information about the container.
@@ -36,17 +34,9 @@ type Config struct {
 	Entrypoint      []string
 	NetworkDisabled bool
 	OnBuild         []string
-	Context         execdriver.Context
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {
-	var context execdriver.Context
-	val := job.Getenv("Context")
-	if val != "" {
-		if err := json.Unmarshal([]byte(val), &context); err != nil {
-			panic(err)
-		}
-	}
 	config := &Config{
 		Hostname:        job.Getenv("Hostname"),
 		Domainname:      job.Getenv("Domainname"),
@@ -64,7 +54,6 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 		VolumesFrom:     job.Getenv("VolumesFrom"),
 		WorkingDir:      job.Getenv("WorkingDir"),
 		NetworkDisabled: job.GetenvBool("NetworkDisabled"),
-		Context:         context,
 	}
 	job.GetenvJson("ExposedPorts", &config.ExposedPorts)
 	job.GetenvJson("Volumes", &config.Volumes)
@@ -86,6 +75,5 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 	if Entrypoint := job.GetenvList("Entrypoint"); Entrypoint != nil {
 		config.Entrypoint = Entrypoint
 	}
-
 	return config
 }

--- a/runtime/graphdriver/devmapper/driver.go
+++ b/runtime/graphdriver/devmapper/driver.go
@@ -22,8 +22,7 @@ func init() {
 
 type Driver struct {
 	*DeviceSet
-	home       string
-	MountLabel string
+	home string
 }
 
 var Init = func(home string) (graphdriver.Driver, error) {
@@ -62,12 +61,11 @@ func (d *Driver) Cleanup() error {
 }
 
 func (d *Driver) Create(id, parent string, mountLabel string) error {
-	d.MountLabel = mountLabel
 	if err := d.DeviceSet.AddDevice(id, parent); err != nil {
 		return err
 	}
 	mp := path.Join(d.home, "mnt", id)
-	if err := d.mount(id, mp, d.MountLabel); err != nil {
+	if err := d.mount(id, mp); err != nil {
 		return err
 	}
 
@@ -117,7 +115,7 @@ func (d *Driver) Remove(id string) error {
 
 func (d *Driver) Get(id string) (string, error) {
 	mp := path.Join(d.home, "mnt", id)
-	if err := d.mount(id, mp, d.MountLabel); err != nil {
+	if err := d.mount(id, mp); err != nil {
 		return "", err
 	}
 
@@ -130,13 +128,13 @@ func (d *Driver) Put(id string) {
 	}
 }
 
-func (d *Driver) mount(id, mountPoint string, mountLabel string) error {
+func (d *Driver) mount(id, mountPoint string) error {
 	// Create the target directories if they don't exist
 	if err := osMkdirAll(mountPoint, 0755); err != nil && !osIsExist(err) {
 		return err
 	}
 	// Mount the device
-	return d.DeviceSet.MountDevice(id, mountPoint, mountLabel)
+	return d.DeviceSet.MountDevice(id, mountPoint, "")
 }
 
 func (d *Driver) Exists(id string) bool {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -499,7 +499,7 @@ func (runtime *Runtime) Create(config *runconfig.Config, name string) (*Containe
 	}
 
 	initID := fmt.Sprintf("%s-init", container.ID)
-	if err := runtime.driver.Create(initID, img.ID, config.Context["mount_label"]); err != nil {
+	if err := runtime.driver.Create(initID, img.ID, ""); err != nil {
 		return nil, nil, err
 	}
 	initPath, err := runtime.driver.Get(initID)
@@ -512,7 +512,7 @@ func (runtime *Runtime) Create(config *runconfig.Config, name string) (*Containe
 		return nil, nil, err
 	}
 
-	if err := runtime.driver.Create(container.ID, initID, config.Context["mount_label"]); err != nil {
+	if err := runtime.driver.Create(container.ID, initID, ""); err != nil {
 		return nil, nil, err
 	}
 	resolvConf, err := utils.GetResolvConf()


### PR DESCRIPTION
We cannot have these settings in the Config because it is pushed to the index.  

Also, i'm guessing that the labels need to be applied on a container per container basis and not across the board for a driver.  This is removing the functionality for now with the driver level mount labels.  Mount labels are still used for the containers rootfs.  
