### PR TITLE
apparmor: docker-default: Include base abstraction

### DIFF
--- a/pkg/libcontainer/apparmor/setup.go
+++ b/pkg/libcontainer/apparmor/setup.go
@@ -11,13 +11,8 @@ import (
 const DefaultProfilePath = "/etc/apparmor.d/docker"
 const DefaultProfile = `
 # AppArmor profile from lxc for containers.
-@{HOME}=@{HOMEDIRS}/*/ /root/
-@{HOMEDIRS}=/home/
-#@{HOMEDIRS}+=
-@{multiarch}=*-linux-gnu*
-@{PROC}=/proc/
-@{pid}=self
 
+#include <tunables/global>
 profile docker-default flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
   network,

--- a/pkg/libcontainer/apparmor/setup.go
+++ b/pkg/libcontainer/apparmor/setup.go
@@ -16,6 +16,7 @@ const DefaultProfile = `
 #@{HOMEDIRS}+=
 @{multiarch}=*-linux-gnu*
 @{PROC}=/proc/
+@{pid}=self
 
 profile docker-default flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>

--- a/pkg/libcontainer/apparmor/setup.go
+++ b/pkg/libcontainer/apparmor/setup.go
@@ -18,6 +18,7 @@ const DefaultProfile = `
 @{PROC}=/proc/
 
 profile docker-default flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
   network,
   capability,
   file,


### PR DESCRIPTION
Encountered problems on 14.04 relating to signals between container
processes being blocked by apparmor. The base abstraction contains
appropriate rules to allow this communication.
