### PR TITLE
Remove -o cli flag and DriverConfig from HostConfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN	git config --global user.email 'docker-dummy@example.com'
 
 VOLUME	/var/lib/docker
 WORKDIR	/go/src/github.com/dotcloud/docker
-ENV	DOCKER_BUILDTAGS	apparmor
+ENV	DOCKER_BUILDTAGS	apparmor selinux
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT	["hack/dind"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN	git config --global user.email 'docker-dummy@example.com'
 
 VOLUME	/var/lib/docker
 WORKDIR	/go/src/github.com/dotcloud/docker
-ENV	DOCKER_BUILDTAGS	apparmor selinux
+ENV	DOCKER_BUILDTAGS	apparmor
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT	["hack/dind"]

--- a/daemonconfig/config.go
+++ b/daemonconfig/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	ExecDriver                  string
 	Mtu                         int
 	DisableNetwork              bool
+	EnableSelinuxSupport        bool
 }
 
 // ConfigFromJob creates and returns a new DaemonConfig object
@@ -45,6 +46,7 @@ func ConfigFromJob(job *engine.Job) *Config {
 		InterContainerCommunication: job.GetenvBool("InterContainerCommunication"),
 		GraphDriver:                 job.Getenv("GraphDriver"),
 		ExecDriver:                  job.Getenv("ExecDriver"),
+		EnableSelinuxSupport:        false, // FIXME: hardcoded default to disable selinux for .10 release
 	}
 	if dns := job.GetenvList("Dns"); dns != nil {
 		config.Dns = dns

--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -39,6 +39,11 @@ var (
 
 type SELinuxContext map[string]string
 
+// SetDisabled disables selinux support for the package
+func SetDisabled() {
+	selinuxEnabled, selinuxEnabledChecked = false, true
+}
+
 func GetSelinuxMountPoint() string {
 	if selinuxfs != "unknown" {
 		return selinuxfs
@@ -140,15 +145,6 @@ func Setfilecon(path string, scon string) error {
 	return system.Lsetxattr(path, xattrNameSelinux, []byte(scon), 0)
 }
 
-func Getfilecon(path string) (string, error) {
-	var scon []byte
-
-	cnt, err := syscall.Getxattr(path, xattrNameSelinux, scon)
-	scon = make([]byte, cnt)
-	cnt, err = syscall.Getxattr(path, xattrNameSelinux, scon)
-	return string(scon), err
-}
-
 func Setfscreatecon(scon string) error {
 	return writeCon("/proc/self/attr/fscreate", scon)
 }
@@ -188,7 +184,7 @@ func writeCon(name string, val string) error {
 }
 
 func Setexeccon(scon string) error {
-	return writeCon(fmt.Sprintf("/proc/self/task/%d/attr/exec", syscall.Gettid()), scon)
+	return writeCon(fmt.Sprintf("/proc/self/task/%d/attr/exec", system.Gettid()), scon)
 }
 
 func (c SELinuxContext) Get() string {

--- a/pkg/selinux/selinux.go
+++ b/pkg/selinux/selinux.go
@@ -44,7 +44,7 @@ func SetDisabled() {
 	selinuxEnabled, selinuxEnabledChecked = false, true
 }
 
-func GetSelinuxMountPoint() string {
+func getSelinuxMountPoint() string {
 	if selinuxfs != "unknown" {
 		return selinuxfs
 	}
@@ -75,15 +75,15 @@ func SelinuxEnabled() bool {
 		return selinuxEnabled
 	}
 	selinuxEnabledChecked = true
-	if fs := GetSelinuxMountPoint(); fs != "" {
-		if con, _ := Getcon(); con != "kernel" {
+	if fs := getSelinuxMountPoint(); fs != "" {
+		if con, _ := getcon(); con != "kernel" {
 			selinuxEnabled = true
 		}
 	}
 	return selinuxEnabled
 }
 
-func ReadConfig(target string) (value string) {
+func readConfig(target string) (value string) {
 	var (
 		val, key string
 		bufin    *bufio.Reader
@@ -124,8 +124,8 @@ func ReadConfig(target string) (value string) {
 	return ""
 }
 
-func GetSELinuxPolicyRoot() string {
-	return selinuxDir + ReadConfig(selinuxTypeTag)
+func getSELinuxPolicyRoot() string {
+	return selinuxDir + readConfig(selinuxTypeTag)
 }
 
 func readCon(name string) (string, error) {
@@ -153,7 +153,7 @@ func Getfscreatecon() (string, error) {
 	return readCon("/proc/self/attr/fscreate")
 }
 
-func Getcon() (string, error) {
+func getcon() (string, error) {
 	return readCon("/proc/self/attr/current")
 }
 
@@ -220,7 +220,7 @@ func SelinuxGetEnforce() int {
 }
 
 func SelinuxGetEnforceMode() int {
-	switch ReadConfig(selinuxTag) {
+	switch readConfig(selinuxTag) {
 	case "enforcing":
 		return Enforcing
 	case "permissive":
@@ -292,13 +292,6 @@ func uniqMcs(catRange uint32) string {
 	return mcs
 }
 
-func FreeContext(con string) {
-	if con != "" {
-		scon := NewContext(con)
-		mcsDelete(scon["level"])
-	}
-}
-
 func GetLxcContexts() (processLabel string, fileLabel string) {
 	var (
 		val, key string
@@ -308,7 +301,7 @@ func GetLxcContexts() (processLabel string, fileLabel string) {
 	if !SelinuxEnabled() {
 		return "", ""
 	}
-	lxcPath := fmt.Sprintf("%s/contexts/lxc_contexts", GetSELinuxPolicyRoot())
+	lxcPath := fmt.Sprintf("%s/contexts/lxc_contexts", getSELinuxPolicyRoot())
 	in, err := os.Open(lxcPath)
 	if err != nil {
 		return "", ""

--- a/pkg/selinux/selinux_test.go
+++ b/pkg/selinux/selinux_test.go
@@ -12,9 +12,7 @@ func testSetfilecon(t *testing.T) {
 		out, _ := os.OpenFile(tmp, os.O_WRONLY, 0)
 		out.Close()
 		err := selinux.Setfilecon(tmp, "system_u:object_r:bin_t:s0")
-		if err == nil {
-			t.Log(selinux.Getfilecon(tmp))
-		} else {
+		if err != nil {
 			t.Log("Setfilecon failed")
 			t.Fatal(err)
 		}
@@ -41,7 +39,6 @@ func TestSELinux(t *testing.T) {
 		pid := os.Getpid()
 		t.Log("PID:%d MCS:%s\n", pid, selinux.IntToMcs(pid, 1023))
 		t.Log(selinux.Getcon())
-		t.Log(selinux.Getfilecon("/etc/passwd"))
 		err = selinux.Setfscreatecon("unconfined_u:unconfined_r:unconfined_t:s0")
 		if err == nil {
 			t.Log(selinux.Getfscreatecon())

--- a/pkg/selinux/selinux_test.go
+++ b/pkg/selinux/selinux_test.go
@@ -38,7 +38,6 @@ func TestSELinux(t *testing.T) {
 		t.Log("getenforcemode ", selinux.SelinuxGetEnforceMode())
 		pid := os.Getpid()
 		t.Log("PID:%d MCS:%s\n", pid, selinux.IntToMcs(pid, 1023))
-		t.Log(selinux.Getcon())
 		err = selinux.Setfscreatecon("unconfined_u:unconfined_r:unconfined_t:s0")
 		if err == nil {
 			t.Log(selinux.Getfscreatecon())
@@ -54,7 +53,6 @@ func TestSELinux(t *testing.T) {
 			t.Fatal(err)
 		}
 		t.Log(selinux.Getpidcon(1))
-		t.Log(selinux.GetSelinuxMountPoint())
 	} else {
 		t.Log("Disabled")
 	}

--- a/pkg/system/calls_linux.go
+++ b/pkg/system/calls_linux.go
@@ -143,3 +143,7 @@ func SetCloneFlags(cmd *exec.Cmd, flag uintptr) {
 	}
 	cmd.SysProcAttr.Cloneflags = flag
 }
+
+func Gettid() int {
+	return syscall.Gettid()
+}

--- a/pkg/system/unsupported.go
+++ b/pkg/system/unsupported.go
@@ -13,3 +13,7 @@ func SetCloneFlags(cmd *exec.Cmd, flag uintptr) {
 func UsetCloseOnExec(fd uintptr) error {
 	return ErrNotSupportedPlatform
 }
+
+func Gettid() int {
+	return 0
+}

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -14,7 +14,6 @@ type HostConfig struct {
 	PortBindings    nat.PortMap
 	Links           []string
 	PublishAllPorts bool
-	DriverOptions   map[string][]string
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
@@ -25,7 +24,6 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 	}
 	job.GetenvJson("LxcConf", &hostConfig.LxcConf)
 	job.GetenvJson("PortBindings", &hostConfig.PortBindings)
-	job.GetenvJson("DriverOptions", &hostConfig.DriverOptions)
 	if Binds := job.GetenvList("Binds"); Binds != nil {
 		hostConfig.Binds = Binds
 	}

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -45,7 +45,6 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flDnsSearch   = opts.NewListOpts(opts.ValidateDomain)
 		flVolumesFrom opts.ListOpts
 		flLxcOpts     opts.ListOpts
-		flDriverOpts  opts.ListOpts
 		flEnvFile     opts.ListOpts
 
 		flAutoRemove      = cmd.Bool([]string{"#rm", "-rm"}, false, "Automatically remove the container when it exits (incompatible with -d)")
@@ -79,8 +78,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	cmd.Var(&flDns, []string{"#dns", "-dns"}, "Set custom dns servers")
 	cmd.Var(&flDnsSearch, []string{"-dns-search"}, "Set custom dns search domains")
 	cmd.Var(&flVolumesFrom, []string{"#volumes-from", "-volumes-from"}, "Mount volumes from the specified container(s)")
-	cmd.Var(&flLxcOpts, []string{"#lxc-conf", "#-lxc-conf"}, "(lxc exec-driver only) Add custom lxc options --lxc-conf=\"lxc.cgroup.cpuset.cpus = 0,1\"")
-	cmd.Var(&flDriverOpts, []string{"o", "-opt"}, "Add custom driver options")
+	cmd.Var(&flLxcOpts, []string{"#lxc-conf", "-lxc-conf"}, "(lxc exec-driver only) Add custom lxc options --lxc-conf=\"lxc.cgroup.cpuset.cpus = 0,1\"")
 
 	if err := cmd.Parse(args); err != nil {
 		return nil, nil, cmd, err
@@ -224,11 +222,6 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		WorkingDir:      *flWorkingDir,
 	}
 
-	driverOptions, err := parseDriverOpts(flDriverOpts)
-	if err != nil {
-		return nil, nil, cmd, err
-	}
-
 	hostConfig := &HostConfig{
 		Binds:           binds,
 		ContainerIDFile: *flContainerIDFile,
@@ -237,7 +230,6 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		PortBindings:    portBindings,
 		Links:           flLinks.GetAll(),
 		PublishAllPorts: *flPublishAll,
-		DriverOptions:   driverOptions,
 	}
 
 	if sysInfo != nil && flMemory > 0 && !sysInfo.SwapLimit {

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -361,12 +361,8 @@ func (container *Container) Attach(stdin io.ReadCloser, stdinCloser io.Closer, s
 func populateCommand(c *Container) {
 	var (
 		en           *execdriver.Network
-		driverConfig = c.hostConfig.DriverOptions
-	)
-
-	if driverConfig == nil {
 		driverConfig = make(map[string][]string)
-	}
+	)
 
 	en = &execdriver.Network{
 		Mtu:       c.runtime.config.Mtu,

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dotcloud/docker/image"
 	"github.com/dotcloud/docker/pkg/graphdb"
 	"github.com/dotcloud/docker/pkg/mount"
+	"github.com/dotcloud/docker/pkg/selinux"
 	"github.com/dotcloud/docker/pkg/sysinfo"
 	"github.com/dotcloud/docker/runconfig"
 	"github.com/dotcloud/docker/runtime/execdriver"
@@ -723,6 +724,9 @@ func NewRuntime(config *daemonconfig.Config, eng *engine.Engine) (*Runtime, erro
 }
 
 func NewRuntimeFromDirectory(config *daemonconfig.Config, eng *engine.Engine) (*Runtime, error) {
+	if !config.EnableSelinuxSupport {
+		selinux.SetDisabled()
+	}
 
 	// Set the default driver
 	graphdriver.DefaultDriver = config.GraphDriver


### PR DESCRIPTION
Because we are still working on the UI for plugins we want to make sure anything new that is introduced to docker works with the plan going ahead.  We are currently remove the -o flag for the UI so that it cannot be used.  This disables selinux, systemd units/slices, and configuration for the native driver right now.  These will all be supported once we approve the final UI for this flag and the plugin api.  

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
