### PR TITLE
docker rmi -f works with stopped containers + revamped error messages

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -24,19 +24,6 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/dotcloud/docker/api"
-	"github.com/dotcloud/docker/archive"
-	"github.com/dotcloud/docker/daemon"
-	"github.com/dotcloud/docker/daemonconfig"
-	"github.com/dotcloud/docker/dockerversion"
-	"github.com/dotcloud/docker/engine"
-	"github.com/dotcloud/docker/graph"
-	"github.com/dotcloud/docker/image"
-	"github.com/dotcloud/docker/pkg/graphdb"
-	"github.com/dotcloud/docker/pkg/signal"
-	"github.com/dotcloud/docker/registry"
-	"github.com/dotcloud/docker/runconfig"
-	"github.com/dotcloud/docker/utils"
 	"io"
 	"io/ioutil"
 	"log"
@@ -53,6 +40,20 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/dotcloud/docker/api"
+	"github.com/dotcloud/docker/archive"
+	"github.com/dotcloud/docker/daemon"
+	"github.com/dotcloud/docker/daemonconfig"
+	"github.com/dotcloud/docker/dockerversion"
+	"github.com/dotcloud/docker/engine"
+	"github.com/dotcloud/docker/graph"
+	"github.com/dotcloud/docker/image"
+	"github.com/dotcloud/docker/pkg/graphdb"
+	"github.com/dotcloud/docker/pkg/signal"
+	"github.com/dotcloud/docker/registry"
+	"github.com/dotcloud/docker/runconfig"
+	"github.com/dotcloud/docker/utils"
 )
 
 // jobInitApi runs the remote api server `srv` as a daemon,
@@ -2063,7 +2064,7 @@ func (srv *Server) ImageDelete(job *engine.Job) engine.Status {
 func (srv *Server) canDeleteImage(imgID string, force, untagged bool) error {
 	var message string
 	if untagged {
-		message = " (but image was untagged)"
+		message = " (docker untagged the image)"
 	}
 	for _, container := range srv.daemon.List() {
 		parent, err := srv.daemon.Repositories().LookupImage(container.Image)


### PR DESCRIPTION
Fix #5042

*\* RUNNING CONTAINER *\* 

```
$> docker run -d busybox ping google.com
9c45b46f0aa17ddfabc76c20c9a3b158ad695dbd5df8e12c575c124d5dfda80d
```

if you try to remove `busybox` you'll get
`Error: Conflict, cannot delete 769b9341d937 because the running container 9c45b46f0aa1 is using it (but image was untagged), stop it and use -f to force`

if you use `-f` you'll get
`Error: Conflict, cannot force delete 769b9341d937 because the running container 9c45b46f0aa1 is using it (but image was untagged), stop it and retry`

*\* STOPPED CONTAINER *\*  

```
$>  docker run  busybox pwd
/
```

if you try to remove `busybox` you'll get
`Error: Conflict, cannot delete 769b9341d937 because the container 9c45b46f0aa1 is using it (but image was untagged), use -f to force`

if you use `-f` the image will be deleted
