### PR TITLE
Move DNS options to hostconfig

### DIFF
--- a/runconfig/compare.go
+++ b/runconfig/compare.go
@@ -19,8 +19,6 @@ func Compare(a, b *Config) bool {
 		return false
 	}
 	if len(a.Cmd) != len(b.Cmd) ||
-		len(a.Dns) != len(b.Dns) ||
-		len(a.DnsSearch) != len(b.DnsSearch) ||
 		len(a.Env) != len(b.Env) ||
 		len(a.PortSpecs) != len(b.PortSpecs) ||
 		len(a.ExposedPorts) != len(b.ExposedPorts) ||
@@ -31,16 +29,6 @@ func Compare(a, b *Config) bool {
 
 	for i := 0; i < len(a.Cmd); i++ {
 		if a.Cmd[i] != b.Cmd[i] {
-			return false
-		}
-	}
-	for i := 0; i < len(a.Dns); i++ {
-		if a.Dns[i] != b.Dns[i] {
-			return false
-		}
-	}
-	for i := 0; i < len(a.DnsSearch); i++ {
-		if a.DnsSearch[i] != b.DnsSearch[i] {
 			return false
 		}
 	}

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -25,8 +25,6 @@ type Config struct {
 	StdinOnce       bool // If true, close stdin after the 1 attached client disconnects.
 	Env             []string
 	Cmd             []string
-	Dns             []string
-	DnsSearch       []string
 	Image           string // Name of the image as it was passed by the operator (eg. could be symbolic)
 	Volumes         map[string]struct{}
 	VolumesFrom     string
@@ -65,12 +63,6 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 	}
 	if Cmd := job.GetenvList("Cmd"); Cmd != nil {
 		config.Cmd = Cmd
-	}
-	if Dns := job.GetenvList("Dns"); Dns != nil {
-		config.Dns = Dns
-	}
-	if DnsSearch := job.GetenvList("DnsSearch"); DnsSearch != nil {
-		config.DnsSearch = DnsSearch
 	}
 	if Entrypoint := job.GetenvList("Entrypoint"); Entrypoint != nil {
 		config.Entrypoint = Entrypoint

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -163,32 +163,18 @@ func TestCompare(t *testing.T) {
 	volumes1 := make(map[string]struct{})
 	volumes1["/test1"] = struct{}{}
 	config1 := Config{
-		Dns:         []string{"1.1.1.1", "2.2.2.2"},
-		DnsSearch:   []string{"foo", "bar"},
-		PortSpecs:   []string{"1111:1111", "2222:2222"},
-		Env:         []string{"VAR1=1", "VAR2=2"},
-		VolumesFrom: "11111111",
-		Volumes:     volumes1,
-	}
-	config2 := Config{
-		Dns:         []string{"0.0.0.0", "2.2.2.2"},
-		DnsSearch:   []string{"foo", "bar"},
 		PortSpecs:   []string{"1111:1111", "2222:2222"},
 		Env:         []string{"VAR1=1", "VAR2=2"},
 		VolumesFrom: "11111111",
 		Volumes:     volumes1,
 	}
 	config3 := Config{
-		Dns:         []string{"1.1.1.1", "2.2.2.2"},
-		DnsSearch:   []string{"foo", "bar"},
 		PortSpecs:   []string{"0000:0000", "2222:2222"},
 		Env:         []string{"VAR1=1", "VAR2=2"},
 		VolumesFrom: "11111111",
 		Volumes:     volumes1,
 	}
 	config4 := Config{
-		Dns:         []string{"1.1.1.1", "2.2.2.2"},
-		DnsSearch:   []string{"foo", "bar"},
 		PortSpecs:   []string{"0000:0000", "2222:2222"},
 		Env:         []string{"VAR1=1", "VAR2=2"},
 		VolumesFrom: "22222222",
@@ -197,23 +183,10 @@ func TestCompare(t *testing.T) {
 	volumes2 := make(map[string]struct{})
 	volumes2["/test2"] = struct{}{}
 	config5 := Config{
-		Dns:         []string{"1.1.1.1", "2.2.2.2"},
-		DnsSearch:   []string{"foo", "bar"},
 		PortSpecs:   []string{"0000:0000", "2222:2222"},
 		Env:         []string{"VAR1=1", "VAR2=2"},
 		VolumesFrom: "11111111",
 		Volumes:     volumes2,
-	}
-	config6 := Config{
-		Dns:         []string{"1.1.1.1", "2.2.2.2"},
-		DnsSearch:   []string{"foos", "bars"},
-		PortSpecs:   []string{"1111:1111", "2222:2222"},
-		Env:         []string{"VAR1=1", "VAR2=2"},
-		VolumesFrom: "11111111",
-		Volumes:     volumes1,
-	}
-	if Compare(&config1, &config2) {
-		t.Fatalf("Compare should return false, Dns are different")
 	}
 	if Compare(&config1, &config3) {
 		t.Fatalf("Compare should return false, PortSpecs are different")
@@ -223,9 +196,6 @@ func TestCompare(t *testing.T) {
 	}
 	if Compare(&config1, &config5) {
 		t.Fatalf("Compare should return false, Volumes are different")
-	}
-	if Compare(&config1, &config6) {
-		t.Fatalf("Compare should return false, DnsSearch are different")
 	}
 	if !Compare(&config1, &config1) {
 		t.Fatalf("Compare should return true")
@@ -237,7 +207,6 @@ func TestMerge(t *testing.T) {
 	volumesImage["/test1"] = struct{}{}
 	volumesImage["/test2"] = struct{}{}
 	configImage := &Config{
-		Dns:         []string{"1.1.1.1", "2.2.2.2"},
 		PortSpecs:   []string{"1111:1111", "2222:2222"},
 		Env:         []string{"VAR1=1", "VAR2=2"},
 		VolumesFrom: "1111",
@@ -247,7 +216,6 @@ func TestMerge(t *testing.T) {
 	volumesUser := make(map[string]struct{})
 	volumesUser["/test3"] = struct{}{}
 	configUser := &Config{
-		Dns:       []string{"2.2.2.2", "3.3.3.3"},
 		PortSpecs: []string{"3333:2222", "3333:3333"},
 		Env:       []string{"VAR2=3", "VAR3=3"},
 		Volumes:   volumesUser,
@@ -255,15 +223,6 @@ func TestMerge(t *testing.T) {
 
 	if err := Merge(configUser, configImage); err != nil {
 		t.Error(err)
-	}
-
-	if len(configUser.Dns) != 3 {
-		t.Fatalf("Expected 3 dns, 1.1.1.1, 2.2.2.2 and 3.3.3.3, found %d", len(configUser.Dns))
-	}
-	for _, dns := range configUser.Dns {
-		if dns != "1.1.1.1" && dns != "2.2.2.2" && dns != "3.3.3.3" {
-			t.Fatalf("Expected 1.1.1.1 or 2.2.2.2 or 3.3.3.3, found %s", dns)
-		}
 	}
 
 	if len(configUser.ExposedPorts) != 3 {

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -14,6 +14,8 @@ type HostConfig struct {
 	PortBindings    nat.PortMap
 	Links           []string
 	PublishAllPorts bool
+	Dns             []string
+	DnsSearch       []string
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
@@ -30,6 +32,11 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 	if Links := job.GetenvList("Links"); Links != nil {
 		hostConfig.Links = Links
 	}
-
+	if Dns := job.GetenvList("Dns"); Dns != nil {
+		hostConfig.Dns = Dns
+	}
+	if DnsSearch := job.GetenvList("DnsSearch"); DnsSearch != nil {
+		hostConfig.DnsSearch = DnsSearch
+	}
 	return hostConfig
 }

--- a/runconfig/merge.go
+++ b/runconfig/merge.go
@@ -94,25 +94,6 @@ func Merge(userConf, imageConf *Config) error {
 	if userConf.Cmd == nil || len(userConf.Cmd) == 0 {
 		userConf.Cmd = imageConf.Cmd
 	}
-	if userConf.Dns == nil || len(userConf.Dns) == 0 {
-		userConf.Dns = imageConf.Dns
-	} else {
-		dnsSet := make(map[string]struct{}, len(userConf.Dns))
-		for _, dns := range userConf.Dns {
-			dnsSet[dns] = struct{}{}
-		}
-		for _, dns := range imageConf.Dns {
-			if _, exists := dnsSet[dns]; !exists {
-				userConf.Dns = append(userConf.Dns, dns)
-			}
-		}
-	}
-	if userConf.DnsSearch == nil || len(userConf.DnsSearch) == 0 {
-		userConf.DnsSearch = imageConf.DnsSearch
-	} else {
-		//duplicates aren't an issue here
-		userConf.DnsSearch = append(userConf.DnsSearch, imageConf.DnsSearch...)
-	}
 	if userConf.Entrypoint == nil || len(userConf.Entrypoint) == 0 {
 		userConf.Entrypoint = imageConf.Entrypoint
 	}

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -213,8 +213,6 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		AttachStderr:    flAttach.Get("stderr"),
 		Env:             envVariables,
 		Cmd:             runCmd,
-		Dns:             flDns.GetAll(),
-		DnsSearch:       flDnsSearch.GetAll(),
 		Image:           image,
 		Volumes:         flVolumes.GetMap(),
 		VolumesFrom:     strings.Join(flVolumesFrom.GetAll(), ","),
@@ -230,6 +228,8 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		PortBindings:    portBindings,
 		Links:           flLinks.GetAll(),
 		PublishAllPorts: *flPublishAll,
+		Dns:             flDns.GetAll(),
+		DnsSearch:       flDnsSearch.GetAll(),
 	}
 
 	if sysInfo != nil && flMemory > 0 && !sysInfo.SwapLimit {

--- a/runtime/container.go
+++ b/runtime/container.go
@@ -430,6 +430,12 @@ func (container *Container) Start() (err error) {
 		}
 	}()
 
+	if container.ResolvConfPath == "" {
+		if err := container.setupContainerDns(); err != nil {
+			return err
+		}
+	}
+
 	if err := container.Mount(); err != nil {
 		return err
 	}
@@ -1173,4 +1179,51 @@ func (container *Container) DisableLink(name string) {
 			utils.Debugf("Could not find active link for %s", name)
 		}
 	}
+}
+
+func (container *Container) setupContainerDns() error {
+	var (
+		config  = container.hostConfig
+		runtime = container.runtime
+	)
+	resolvConf, err := utils.GetResolvConf()
+	if err != nil {
+		return err
+	}
+	// If custom dns exists, then create a resolv.conf for the container
+	if len(config.Dns) > 0 || len(runtime.config.Dns) > 0 || len(config.DnsSearch) > 0 || len(runtime.config.DnsSearch) > 0 {
+		var (
+			dns       = utils.GetNameservers(resolvConf)
+			dnsSearch = utils.GetSearchDomains(resolvConf)
+		)
+		if len(config.Dns) > 0 {
+			dns = config.Dns
+		} else if len(runtime.config.Dns) > 0 {
+			dns = runtime.config.Dns
+		}
+		if len(config.DnsSearch) > 0 {
+			dnsSearch = config.DnsSearch
+		} else if len(runtime.config.DnsSearch) > 0 {
+			dnsSearch = runtime.config.DnsSearch
+		}
+		container.ResolvConfPath = path.Join(container.root, "resolv.conf")
+		f, err := os.Create(container.ResolvConfPath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		for _, dns := range dns {
+			if _, err := f.Write([]byte("nameserver " + dns + "\n")); err != nil {
+				return err
+			}
+		}
+		if len(dnsSearch) > 0 {
+			if _, err := f.Write([]byte("search " + strings.Join(dnsSearch, " ") + "\n")); err != nil {
+				return err
+			}
+		}
+	} else {
+		container.ResolvConfPath = "/etc/resolv.conf"
+	}
+	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1731,15 +1731,6 @@ func (srv *Server) ContainerCreate(job *engine.Job) engine.Status {
 		job.Errorf("Your kernel does not support swap limit capabilities. Limitation discarded.\n")
 		config.MemorySwap = -1
 	}
-	resolvConf, err := utils.GetResolvConf()
-	if err != nil {
-		return job.Error(err)
-	}
-	if !config.NetworkDisabled && len(config.Dns) == 0 && len(srv.runtime.Config().Dns) == 0 && utils.CheckLocalDns(resolvConf) {
-		job.Errorf("Local (127.0.0.1) DNS resolver found in resolv.conf and containers can't use it. Using default external servers : %v\n", runtime.DefaultDns)
-		config.Dns = runtime.DefaultDns
-	}
-
 	container, buildWarnings, err := srv.runtime.Create(config, name)
 	if err != nil {
 		if srv.runtime.Graph().IsNotExist(err) {


### PR DESCRIPTION
There is actually no need to merge anything with this PR.  Because prior to this change, a container's resolv.conf is generated at create with the values from the server or config and the file is written to disk we don't need to migrate the values into the host config because they will never be used and we already have the existing data in the final resolv.conf file in the container's dir.  

The other change is to make the local resolver warning display in the daemon instead of at create time.  Because we set a default value the user cannot do anything about it.  We don't have the needed data to display a warning at create because we don't have the host config.  This seems like a good option because the local resolver is checked at startup and the runtime dns config is set with the default values.  We still print the warning to the daemon logs so the user knows that happened.  

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
