### PR TITLE
Fix edge case in bind mount absolute path detection

### DIFF
--- a/runtime/volumes.go
+++ b/runtime/volumes.go
@@ -177,12 +177,8 @@ func createVolumes(container *Container) error {
 		if bindMap, exists := binds[volPath]; exists {
 			isBindMount = true
 			srcPath = bindMap.SrcPath
-			srcAbs, err := filepath.Abs(srcPath)
-			if err != nil {
-				return err
-			}
-			if srcPath != srcAbs {
-				return fmt.Errorf("%s should be an absolute path", srcPath)
+			if !filepath.IsAbs(srcPath) {
+				return fmt.Errorf("%s must be an absolute path", srcPath)
 			}
 			if strings.ToLower(bindMap.Mode) == "rw" {
 				srcRW = true


### PR DESCRIPTION
`filepath.Abs` does more than just `filepath.IsAbs` - namely, `filepath.Clean`, which resolves things like `.../.` or `.../../...`, and causes even an absolute path like `/some/path/../absolute` to fail (or, in my case, `/path/to/docker/.`)

Just using `filepath.IsAbs` directly is a much cheaper check, too. :)
