### PR TITLE
Improve error message when using a wrong Content-Type on container creation

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -558,6 +558,9 @@ func postContainersCreate(eng *engine.Engine, version version.Version, w http.Re
 	if err := parseForm(r); err != nil {
 		return nil
 	}
+	if contentType := r.Header.Get("Content-Type"); !api.MatchesContentType(contentType, "application/json") {
+		return fmt.Errorf("Content-Type not supported: %s", contentType)
+	}
 	var (
 		out         engine.Env
 		job         = eng.Job("create", r.Form.Get("name"))


### PR DESCRIPTION
This is a proposal for improving error message on container creation, as requested in #2515

As a first contribution, I'd be happy if someone told me:
- if this should be put elsewhere ? (for instance factored in `makeHttpHandler` ?)
- if this can be tested easily ; I didn't found tests for error messages in `api/server/server_unit_test.go` but if you have any pointer I'd be happy to add unit tests for this...

Thanks
