### PR TITLE
Fix a few minor man formatting consistency issues

### DIFF
--- a/contrib/man/man1/docker-attach.1
+++ b/contrib/man/man1/docker-attach.1
@@ -15,10 +15,10 @@ If you \fBdocker run\fR a container in detached mode (\fB-d\fR), you can reattac
 You can detach from the container again (and leave it running) with CTRL-c (for a quiet exit) or CTRL-\ to get a stacktrace of the Docker client when it quits. When you detach from the container the exit code will be returned to the client.
 .SH "OPTIONS"
 .TP
-.B --no-stdin=\fItrue\fR|\fIfalse\fR: 
+.B --no-stdin=\fItrue\fR|\fIfalse\fR
 When set to true, do not attach to stdin. The default is \fIfalse\fR.
 .TP
-.B --sig-proxy=\fItrue\fR|\fIfalse\fR: 
+.B --sig-proxy=\fItrue\fR|\fIfalse\fR
 When set to true, proxify all received signal to the process (even in non-tty mode). The default is \fItrue\fR.
 .sp
 .SH EXAMPLES

--- a/contrib/man/man1/docker-build.1
+++ b/contrib/man/man1/docker-build.1
@@ -19,13 +19,13 @@ If the absolute path is provided instead of ‘.’, only the files and director
 When a single Dockerfile is given as URL, then no context is set. When a Git repository is set as URL, the repository is used as context.
 .SH "OPTIONS"
 .TP
-.B -q, --quiet=\fItrue\fR|\fIfalse\fR: 
+.B -q, --quiet=\fItrue\fR|\fIfalse\fR
 When set to true, suppress verbose build output. Default is \fIfalse\fR.
 .TP
-.B --rm=\fItrue\fr|\fIfalse\fR:
+.B --rm=\fItrue\fr|\fIfalse\fR
 When true, remove intermediate containers that are created during the build process. The default is true.
 .TP
-.B -t, --tag=\fItag\fR: 
+.B -t, --tag=\fItag\fR
 Tag to be applied to the resulting image on successful completion of the build.
 .TP
 .B --no-cache=\fItrue\fR|\fIfalse\fR

--- a/contrib/man/man1/docker-images.1
+++ b/contrib/man/man1/docker-images.1
@@ -20,16 +20,16 @@ By default, intermediate images, used during builds, are not listed. Some of the
 The title REPOSITORY for the first title may seem confusing. It is essentially the image name. However, because you can tag a specific image, and multiple tags (image instances) can be associated with a single name, the name is really a repository for all tagged images of the same name. 
 .SH "OPTIONS"
 .TP
-.B -a, --all=\fItrue\fR|\fIfalse\fR: 
+.B -a, --all=\fItrue\fR|\fIfalse\fR
 When set to true, also include all intermediate images in the list. The default is false.
 .TP
-.B --no-trunc=\fItrue\fR|\fIfalse\fR: 
+.B --no-trunc=\fItrue\fR|\fIfalse\fR
 When set to true, list the full image ID and not the truncated ID. The default is false.
 .TP
-.B -q, --quiet=\fItrue\fR|\fIfalse\fR: 
+.B -q, --quiet=\fItrue\fR|\fIfalse\fR
 When set to true, list the complete image ID as part of the output. The default is false.
 .TP
-.B -t, --tree=\fItrue\fR|\fIfalse\fR: 
+.B -t, --tree=\fItrue\fR|\fIfalse\fR
 When set to true, list the images in a tree dependency tree (hierarchy) format. The default is false.
 .TP
 .B -v, --viz=\fItrue\fR|\fIfalse\fR

--- a/contrib/man/man1/docker-inspect.1
+++ b/contrib/man/man1/docker-inspect.1
@@ -12,7 +12,7 @@ CONTAINER|IMAGE [CONTAINER|IMAGE...]
 This displays all the information available in Docker for a given container or image. By default, this will render all results in a JSON array. If a format is specified, the given template will be executed for each result. 
 .SH "OPTIONS"
 .TP
-.B -f, --format="": 
+.B -f, --format=""
 The text/template package of Go describes all the details of the format. See examples section
 .SH EXAMPLES
 .sp

--- a/contrib/man/man1/docker-rm.1
+++ b/contrib/man/man1/docker-rm.1
@@ -14,13 +14,13 @@ CONTAINER [CONTAINER...]
 This will remove one or more containers from the host node. The container name or ID can be used. This does not remove images. You cannot remove a running container unless you use the \fB-f\fR option. To see all containers on a host use the \fBdocker ps -a\fR command.
 .SH "OPTIONS"
 .TP
-.B -f, --force=\fItrue\fR|\fIfalse\fR: 
+.B -f, --force=\fItrue\fR|\fIfalse\fR
 When set to true, force the removal of the container. The default is \fIfalse\fR.
 .TP
-.B -l, --link=\fItrue\fR|\fIfalse\fR: 
+.B -l, --link=\fItrue\fR|\fIfalse\fR
 When set to true, remove the specified link and not the underlying container. The default is \fIfalse\fR.
 .TP
-.B -v, --volumes=\fItrue\fR|\fIfalse\fR: 
+.B -v, --volumes=\fItrue\fR|\fIfalse\fR
 When set to true, remove the volumes associated to the container. The default is \fIfalse\fR.
 .SH EXAMPLES
 .sp

--- a/contrib/man/man1/docker-rmi.1
+++ b/contrib/man/man1/docker-rmi.1
@@ -12,7 +12,7 @@ IMAGE [IMAGE...]
 This will remove one or more images from the host node. This does not remove images from a registry. You cannot remove an image of a running container unless you use the \fB-f\fR option. To see all images on a host use the \fBdocker images\fR command.
 .SH "OPTIONS"
 .TP
-.B -f, --force=\fItrue\fR|\fIfalse\fR: 
+.B -f, --force=\fItrue\fR|\fIfalse\fR
 When set to true, force the removal of the image. The default is \fIfalse\fR.
 .SH EXAMPLES
 .sp

--- a/contrib/man/man1/docker-run.1
+++ b/contrib/man/man1/docker-run.1
@@ -30,69 +30,69 @@ If the \fIIMAGE\fR is not already loaded then \fBdocker run\fR will pull the \fI
 .SH "OPTIONS"
 
 .TP
-.B  -a, --attach=\fIstdin\fR|\fIstdout\fR|\fIstderr\fR: 
+.B  -a, --attach=\fIstdin\fR|\fIstdout\fR|\fIstderr\fR
 Attach to stdin, stdout or stderr. In foreground mode (the default when -d is not specified), \fBdocker run\fR can start the process in the container and attach the console to the process’s standard input, output, and standard error. It can even pretend to be a TTY (this is what most commandline executables expect) and pass along signals. The \fB-a\fR option can be set for each of stdin, stdout, and stderr.  
 
 .TP
-.B  -c, --cpu-shares=0: 
+.B  -c, --cpu-shares=0
 CPU shares in relative weight. You can increase the priority of a container with the -c option. By default, all containers run at the same priority and get the same proportion of CPU cycles, but you can tell the kernel to give more shares of CPU time to one or more containers when you start them via \fBdocker run\fR.
 
 .TP
-.B -m, --memory=\fImemory-limit\fR: 
+.B -m, --memory=\fImemory-limit\fR
 Allows you to constrain the memory available to a container. If the host supports swap memory, then the -m memory setting can be larger than physical RAM. The memory limit format: <number><optional unit>, where unit = b, k, m or g.
 
 .TP
-.B --cidfile=\fIfile\fR: 
+.B --cidfile=\fIfile\fR
 Write the container ID to the file specified.
 
 .TP
-.B  -d, --detach=\fItrue\fR|\fIfalse\fR: 
+.B  -d, --detach=\fItrue\fR|\fIfalse\fR
 Detached mode. This runs the container in the background. It outputs the new container's id and and error messages. At any time you can run \fBdocker ps\fR in the other shell to view a list of the running containers. You can reattach to a detached container with \fBdocker attach\fR. If you choose to run a container in the detached mode, then you cannot use the -rm option.
 
 .TP
-.B --dns=\fIIP-address\fR: 
+.B --dns=\fIIP-address\fR
 Set custom DNS servers. This option can be used to override the DNS configuration passed to the container. Typically this is necessary when the host DNS configuration is invalid for the container (eg. 127.0.0.1). When this is the case the \fB-dns\fR flags is necessary for every run.
 
 .TP
-.B  -e, --env=\fIenvironment\fR: 
+.B  -e, --env=\fIenvironment\fR
 Set environment variables. This option allows you to specify arbitrary environment variables that are available for the process that will be launched inside of the container. 
 
 .TP
-.B --entrypoint=\ficommand\fR: 
+.B --entrypoint=\ficommand\fR
 This option allows you to overwrite the default entrypoint of the image that is set in the Dockerfile. The ENTRYPOINT of an image is similar to a COMMAND because it specifies what executable to run when the container starts, but it is (purposely) more difficult to override. The ENTRYPOINT gives a container its default nature or behavior, so that when you set an ENTRYPOINT you can run the container as if it were that binary, complete with default options, and you can pass in more options via the COMMAND. But, sometimes an operator may want to run something else inside the container, so you can override the default ENTRYPOINT at runtime by using a \fB--entrypoint\fR and a string to specify the new ENTRYPOINT. 
 
 .TP
-.B --expose=\fIport\fR: 
+.B --expose=\fIport\fR
 Expose a port from the container without publishing it to your host. A containers port can be exposed to other containers in three ways: 1) The developer can expose the port using the EXPOSE parameter of the Dockerfile, 2) the operator can use the \fB--expose\fR option with \fBdocker run\fR, or 3) the container can be started with the \fB--link\fR.
 
 .TP
-.B  -P, --publish-all=\fItrue\fR|\fIfalse\fR: 
+.B  -P, --publish-all=\fItrue\fR|\fIfalse\fR
 When set to true publish all exposed ports to the host interfaces. The default is false. If the operator uses -P (or -p) then Docker will make the exposed port accessible on the host and the ports will be available to any client that can reach the host. To find the map between the host ports and the exposed ports, use \fBdocker port\fR. 
 
 .TP
-.B -p, --publish=[]: 
+.B -p, --publish=[]
 Publish a container's port to the host (format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort) (use 'docker port' to see the actual mapping)
 
 .TP
-.B -h , --hostname=\fIhostname\fR: 
+.B -h , --hostname=\fIhostname\fR
 Sets the container host name that is available inside the container.
   
 .TP
-.B -i , --interactive=\fItrue\fR|\fIfalse\fR: 
+.B -i , --interactive=\fItrue\fR|\fIfalse\fR
 When set to true, keep stdin open even if not attached. The default is false.
 
 .TP
-.B --link=\fIname\fR:\fIalias\fR: 
+.B --link=\fIname\fR:\fIalias\fR
 Add link to another container. The format is name:alias. If the operator uses \fB--link\fR when starting the new client container, then the client container can access the exposed port via a private networking interface. Docker will set some environment variables in the client container to help indicate which interface and port to use. 
 
 .TP
-.B -n, --networking=\fItrue\fR|\fIfalse\fR: 
+.B -n, --networking=\fItrue\fR|\fIfalse\fR
 By default, all containers have networking enabled (true) and can make outgoing connections. The operator can disable networking with \fB--networking\fR to false. This disables all incoming and outgoing networking. In cases like this, I/O can only be performed through files or by using STDIN/STDOUT.
 
 Also by default, the container will use the same DNS servers as the host. but you canThe operator may override this with \fB-dns\fR. 
 
 .TP
-.B  --name=\fIname\fR: 
+.B  --name=\fIname\fR
 Assign a name to the container. The operator can identify a container in three ways:
 .sp
 .nf
@@ -104,37 +104,37 @@ Name (“jonah”)
 The UUID identifiers come from the Docker daemon, and if a name is not assigned to the container with \fB--name\fR then the daemon will also generate a random string name. The name is useful when defining links (see \fB--link\fR) (or any other place you need to identify a container). This works for both background and foreground Docker containers.
 
 .TP
-.B --privileged=\fItrue\fR|\fIfalse\fR: 
+.B --privileged=\fItrue\fR|\fIfalse\fR
 Give extended privileges to this container. By default, Docker containers are “unprivileged” (=false) and cannot, for example, run a Docker daemon inside the Docker container. This is because by default a container is not allowed to access any devices. A “privileged” container is given access to all devices.
 
 When the operator executes \fBdocker run -privileged\fR, Docker will enable access to all devices on the host as well as set some configuration in AppArmor (\fB???\fR) to allow the container nearly all the same access to the host as processes running outside of a container on the host.
 
 .TP
-.B --rm=\fItrue\fR|\fIfalse\fR: 
+.B --rm=\fItrue\fR|\fIfalse\fR
 If set to \fItrue\fR the container is automatically removed when it exits. The default is \fIfalse\fR. This option is incompatible with \fB-d\fR.
 
 .TP
-.B --sig-proxy=\fItrue\fR|\fIfalse\fR: 
+.B --sig-proxy=\fItrue\fR|\fIfalse\fR
 When set to true, proxify all received signals to the process (even in non-tty mode). The default is true.
   
 .TP
-.B -t, --tty=\fItrue\fR|\fIfalse\fR: 
+.B -t, --tty=\fItrue\fR|\fIfalse\fR
 When set to true Docker can allocate a pseudo-tty and attach to the standard input of any container. This can be used, for example, to run a throwaway interactive shell. The default is value is false.
 
 .TP
-.B -u, --user=\fIusername\fR,\fRuid\fR: 
+.B -u, --user=\fIusername\fR,\fRuid\fR
 Set a username or UID for the container.
 
 .TP
-.B -v, --volume=\fIvolume\fR: 
+.B -v, --volume=\fIvolume\fR
 Bind mount a volume to the container. The \fB-v\fR option can be used one or more times to add one or more mounts to a container. These mounts can then be used in other containers using the \fB--volumes-from\fR option. See examples.
 
 .TP
-.B --volumes-from=\fIcontainer-id\fR: 
+.B --volumes-from=\fIcontainer-id\fR
 Will mount volumes from the specified container identified by container-id. Once a volume is mounted in a one container it can be shared with other containers using the \fB--volumes-from\fR option when running those other containers. The volumes can be shared even if the original container with the mount is not running. 
 
 .TP
-.B -w, --workdir=\fIdirectory\fR: 
+.B -w, --workdir=\fIdirectory\fR
 Working directory inside the container. The default working directory for running binaries within a container is the root directory (/). The developer can set a different default with the Dockerfile WORKDIR instruction. The operator can override the working directory by using the \fB-w\fR option. 
 
 .TP

--- a/contrib/man/man1/docker-tag.1
+++ b/contrib/man/man1/docker-tag.1
@@ -12,7 +12,7 @@ docker-tag \- Tag an image in the repository
 This will tag an image in the repository. 
 .SH "OPTIONS"
 .TP
-.B -f, --force=\fItrue\fR|\fIfalse\fR: 
+.B -f, --force=\fItrue\fR|\fIfalse\fR
 When set to true, force the tag name. The default is \fIfalse\fR.
 .TP
 .B REGISTRYHOST:


### PR DESCRIPTION
Some flags ended with a colon, some didn't.  For man pages, the prevailing normal practice is not to end the flags lines with colons.
