### PR TITLE
Update bundlescripts to use "set -e" consistently

### DIFF
--- a/hack/make/binary
+++ b/hack/make/binary
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 DEST=$1
 

--- a/hack/make/cover
+++ b/hack/make/cover
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 DEST="$1"
 

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 DEST=$1
 

--- a/hack/make/dynbinary
+++ b/hack/make/dynbinary
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 DEST=$1
 

--- a/hack/make/dyntest
+++ b/hack/make/dyntest
@@ -1,9 +1,8 @@
 #!/bin/bash
+set -e
 
 DEST=$1
 INIT=$DEST/../dynbinary/dockerinit-$VERSION
-
-set -e
 
 if [ ! -x "$INIT" ]; then
 	echo >&2 'error: dynbinary must be run before dyntest'

--- a/hack/make/dyntest-integration
+++ b/hack/make/dyntest-integration
@@ -1,9 +1,8 @@
 #!/bin/bash
+set -e
 
 DEST=$1
 INIT=$DEST/../dynbinary/dockerinit-$VERSION
-
-set -e
 
 if [ ! -x "$INIT" ]; then
 	echo >&2 'error: dynbinary must be run before dyntest-integration'

--- a/hack/make/test
+++ b/hack/make/test
@@ -1,8 +1,7 @@
 #!/bin/bash
+set -e
 
 DEST=$1
-
-set -e
 
 RED=$'\033[31m'
 GREEN=$'\033[32m'

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -1,8 +1,7 @@
 #!/bin/bash
+set -e
 
 DEST=$1
-
-set -e
 
 bundle_test_integration() {
 	LDFLAGS="$LDFLAGS $LDFLAGS_STATIC_DOCKER" go_test_dir ./integration \

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -1,8 +1,7 @@
 #!/bin/bash
+set -e
 
 DEST=$1
-
-set -e
 
 DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
 DOCKER_EXECDRIVER=${DOCKER_EXECDRIVER:-native}


### PR DESCRIPTION
"set -e" is already inherited here from make.sh, but explicit is always better than implicit (hence the "set -e" in the first place!)

Some scripts had it, some didn't, and they were a little hodge-podge about _where_ in the script it was.  I like to put it right after the shebang as part of the "file pragmas", if you will so that it doesn't get forgotten.  "Standard Bash boilerplate", similar to having `use strict; use warnings;` at the top of a standard Perl boilerplate file. :)

Technically speaking, even the shebang on these files is unnecessary, since they get sourced and not run directly, but it's a good reminder that they're all written in bash for sure IMO. :)
