### PR TITLE
Update RELEASE_BUNDLES to include integration tests

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -53,9 +53,13 @@ RELEASE_BUNDLES=(
 )
 
 if [ "$1" != '--release-regardless-of-test-failure' ]; then
-	RELEASE_BUNDLES=( test "${RELEASE_BUNDLES[@]}" )
+	RELEASE_BUNDLES=(
+		test test-integration
+		"${RELEASE_BUNDLES[@]}"
+		test-integration-cli
+	)
 fi
-	
+
 VERSION=$(cat VERSION)
 BUCKET=$AWS_S3_BUCKET
 


### PR DESCRIPTION
Previously, running just "hack/release.sh" only ran the unit tests.  This updates that to run the unit tests, then the integration tests, then build the binaries, then run the cli integration tests (so we're literally testing the binary we're about to release, which is super freaking cool IMO <3).
