### PR TITLE
Added specific error message when hitting 401 over HTTP on push

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -417,6 +417,9 @@ func (r *Registry) PushImageJSONRegistry(imgData *ImgData, jsonRaw []byte, regis
 		return fmt.Errorf("Failed to upload metadata: %s", err)
 	}
 	defer res.Body.Close()
+	if res.StatusCode == 401 && strings.HasPrefix(registry, "http://") {
+		return utils.NewHTTPRequestError("HTTP code 401, Docker will not send auth headers over HTTP.", res)
+	}
 	if res.StatusCode != 200 {
 		errBody, err := ioutil.ReadAll(res.Body)
 		if err != nil {


### PR DESCRIPTION
This clarifies the situation for people hitting the issue outline in #4343. Instead of

``` sh
$ docker push my.registry.io/ubuntu
The push refers to a repository [my.registry.io/ubuntu] (len: 1)
Sending image list
Pushing repository my.registry.io/ubuntu (1 tags)
511136ea3c5a: Pushing 
2014/04/08 14:55:57 HTTP code 401 while uploading metadata: invalid character '<' looking for beginning of value
```

People would now see 

``` sh
$ docker push my.registry.io/ubuntu
The push refers to a repository [my.registry.io/ubuntu] (len: 1)
Sending image list
Pushing repository my.registry.io/ubuntu (1 tags)
511136ea3c5a: Pushing 
2014/04/08 16:40:27 HTTP code 401, Docker will not send auth headers over HTTP.
```

More details on this issue: dotcloud/docker-registry#298
