### PR TITLE
docker save: fix filemode permissions

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -340,7 +340,7 @@ func (srv *Server) ImageExport(job *engine.Job) engine.Status {
 		rootRepoMap[name] = rootRepo
 		rootRepoJson, _ := json.Marshal(rootRepoMap)
 
-		if err := ioutil.WriteFile(path.Join(tempdir, "repositories"), rootRepoJson, os.ModeAppend); err != nil {
+		if err := ioutil.WriteFile(path.Join(tempdir, "repositories"), rootRepoJson, os.FileMode(0644)); err != nil {
 			return job.Error(err)
 		}
 	} else {
@@ -369,7 +369,7 @@ func (srv *Server) exportImage(img *image.Image, tempdir string) error {
 	for i := img; i != nil; {
 		// temporary directory
 		tmpImageDir := path.Join(tempdir, i.ID)
-		if err := os.Mkdir(tmpImageDir, os.ModeDir); err != nil {
+		if err := os.Mkdir(tmpImageDir, os.FileMode(0755)); err != nil {
 			if os.IsExist(err) {
 				return nil
 			}
@@ -379,7 +379,7 @@ func (srv *Server) exportImage(img *image.Image, tempdir string) error {
 		var version = "1.0"
 		var versionBuf = []byte(version)
 
-		if err := ioutil.WriteFile(path.Join(tmpImageDir, "VERSION"), versionBuf, os.ModeAppend); err != nil {
+		if err := ioutil.WriteFile(path.Join(tmpImageDir, "VERSION"), versionBuf, os.FileMode(0644)); err != nil {
 			return err
 		}
 
@@ -388,7 +388,7 @@ func (srv *Server) exportImage(img *image.Image, tempdir string) error {
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile(path.Join(tmpImageDir, "json"), b, os.ModeAppend); err != nil {
+		if err := ioutil.WriteFile(path.Join(tmpImageDir, "json"), b, os.FileMode(0644)); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
currently the files created are not readable. This makes the files and
directories permissions more sane.

```
vbatts@jellyroll ~ (master *) $ docker save b | tar tv                             
drwx------ 0/0               0 2014-04-08 12:34 ./                                 
d--------- 0/0               0 2014-04-08 12:34 c44ffa1befab47e7242c5982512cf843d9040a639a2aaa9464acdaa7683055f0/
---------- 0/0               3 2014-04-08 12:34 c44ffa1befab47e7242c5982512cf843d9040a639a2aaa9464acdaa7683055f0/VERSION
---------- 0/0             638 2014-04-08 12:34 c44ffa1befab47e7242c5982512cf843d9040a639a2aaa9464acdaa7683055f0/json
-rw-r--r-- 0/0         2684416 2014-04-08 12:34 c44ffa1befab47e7242c5982512cf843d9040a639a2aaa9464acdaa7683055f0/layer.tar
---------- 0/0              83 2014-04-08 12:34 repositories                       
vbatts@jellyroll ~ (master *) $ /home/vbatts/src/docker/docker/bundles/0.9.1-dev/dynbinary/docker-0.9.1-dev save b | tar tv
drwx------ 0/0               0 2014-04-08 12:38 ./                                 
drwxr-xr-x 0/0               0 2014-04-08 12:38 c44ffa1befab47e7242c5982512cf843d9040a639a2aaa9464acdaa7683055f0/
-rw-r--r-- 0/0               3 2014-04-08 12:38 c44ffa1befab47e7242c5982512cf843d9040a639a2aaa9464acdaa7683055f0/VERSION
-rw-r--r-- 0/0             638 2014-04-08 12:38 c44ffa1befab47e7242c5982512cf843d9040a639a2aaa9464acdaa7683055f0/json
-rw-r--r-- 0/0         2684416 2014-04-08 12:38 c44ffa1befab47e7242c5982512cf843d9040a639a2aaa9464acdaa7683055f0/layer.tar
-rw-r--r-- 0/0              83 2014-04-08 12:38 repositories                       
```

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
