### PR TITLE
Early deprecation warning for 'docker commit --run'

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1433,7 +1433,8 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	cmd := cli.Subcmd("commit", "[OPTIONS] CONTAINER [REPOSITORY[:TAG]]", "Create a new image from a container's changes")
 	flComment := cmd.String([]string{"m", "-message"}, "", "Commit message")
 	flAuthor := cmd.String([]string{"a", "#author", "-author"}, "", "Author (eg. \"John Hannibal Smith <hannibal@a-team.com>\"")
-	flConfig := cmd.String([]string{"#run", "-run"}, "", "Config automatically applied when the image is run. "+`(ex: --run='{"Cmd": ["cat", "/world"], "PortSpecs": ["22"]}')`)
+	// FIXME: --run is deprecated, it will be replaced with inline Dockerfile commands.
+	flConfig := cmd.String([]string{"#run", "#-run"}, "", "this option is deprecated and will be removed in a future version in favor of inline Dockerfile-compatible commands")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -1471,6 +1472,7 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 		env    engine.Env
 	)
 	if *flConfig != "" {
+		fmt.Fprintf(cli.err, "WARNING: 'commit --run' is deprecated and will be removed in a future version, in favor of inline Dockerfile-compatible commands.\n")
 		config = &runconfig.Config{}
 		if err := json.Unmarshal([]byte(*flConfig), config); err != nil {
 			return err

--- a/docs/sources/reference/builder.rst
+++ b/docs/sources/reference/builder.rst
@@ -188,9 +188,7 @@ omit the executable, in which case you must specify an ENTRYPOINT as
 well.
 
 When used in the shell or exec formats, the ``CMD`` instruction sets
-the command to be executed when running the image.  This is
-functionally equivalent to running ``docker commit --run '{"Cmd":
-<command>}'`` outside the builder.
+the command to be executed when running the image.
 
 If you use the *shell* form of the CMD, then the ``<command>`` will
 execute in ``/bin/sh -c``:
@@ -230,10 +228,10 @@ override the default specified in CMD.
 
     ``EXPOSE <port> [<port>...]``
 
-The ``EXPOSE`` instruction exposes ports for use within links. This is
-functionally equivalent to running ``docker commit --run '{"PortSpecs":
-["<port>", "<port2>"]}'`` outside the builder. Refer to
-:ref:`port_redirection` for detailed information.
+The ``EXPOSE`` instructions informs Docker that the container will listen
+on the specified network ports at runtime. Docker uses this information
+to interconnect containers using links (see :ref:`links <working_with_links_names>`),
+and to setup port redirection on the host system (see :ref:`port_redirection`).
 
 .. _dockerfile_env:
 


### PR DESCRIPTION
Warn users of the planned deprecation of 'docker commit --run', and hide
it from the docs and usage message. The option continues to work.

Note that an alternative to 'commit --run' is being implemented but is
not yet available. We are printing the warning anyway because on
the basis that it never hurts to give more advance warning.

The 'commit --run' flag is a leftover from the very early days of Docker,
and has several problems:

1) It is very user unfriendly. You have to pass a literal json dict
which is poorly documented and changes regularly (see PortSpecs vs
ExposedPorts). The merge behavior is not clear and also changes
regularly. it's not possible to unset a value.

2) It overlaps with the Dockerfile syntax. There are 2 ways to set
a default command, expose a port or change an env variable. Some
things can be done in a Dockerfile but not in --run. Some things
can be done in --run but not in a Dockerfile. It would be better
to push a single syntax, allow using it both in a file and via
the command line, and make improvements in a single place.

3) It exposes data structures which should not be publicly exposed.
There are several planned improvements to Docker which require moving
around the content and schema of the various Config, Image and Container
structures. The less of those we expose in public interfaces, the easier
it is to move things around without a reverse compatibility nightmare.

Docker-DCO-1.1-Signed-off-by: Solomon Hykes solomon@docker.com (github: shykes)
