### PR TITLE
Replace 'commit --run' with 'commit --change'

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dotcloud/docker/dockerversion"
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/nat"
+	"github.com/dotcloud/docker/opts"
 	"github.com/dotcloud/docker/pkg/signal"
 	"github.com/dotcloud/docker/pkg/term"
 	"github.com/dotcloud/docker/registry"
@@ -1435,6 +1436,8 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	flAuthor := cmd.String([]string{"a", "#author", "-author"}, "", "Author (eg. \"John Hannibal Smith <hannibal@a-team.com>\"")
 	// FIXME: --run is deprecated, it will be replaced with inline Dockerfile commands.
 	flConfig := cmd.String([]string{"#run", "#-run"}, "", "this option is deprecated and will be removed in a future version in favor of inline Dockerfile-compatible commands")
+	flChanges := opts.NewListOpts(nil)
+	cmd.Var(&flChanges, []string{"c", "-change"}, "Apply a modification before committing the image")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -1467,10 +1470,12 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	v.Set("tag", tag)
 	v.Set("comment", *flComment)
 	v.Set("author", *flAuthor)
+	v.Set("changes", strings.Join(flChanges.GetAll(), "\n"))
 	var (
 		config *runconfig.Config
 		env    engine.Env
 	)
+	// FIXME: --run is deprecated in favor of --set and --unset
 	if *flConfig != "" {
 		config = &runconfig.Config{}
 		if err := json.Unmarshal([]byte(*flConfig), config); err != nil {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dotcloud/docker/pkg/user"
 	"github.com/dotcloud/docker/pkg/version"
 	"github.com/dotcloud/docker/registry"
+	"github.com/dotcloud/docker/runconfig"
 	"github.com/dotcloud/docker/utils"
 	"github.com/gorilla/mux"
 )
@@ -349,19 +350,20 @@ func postCommit(eng *engine.Engine, version version.Version, w http.ResponseWrit
 		return err
 	}
 	var (
-		config engine.Env
-		env    engine.Env
-		job    = eng.Job("commit", r.Form.Get("container"))
+		legacyconfig runconfig.Config
+		env          engine.Env
+		job          = eng.Job("commit", r.Form.Get("container"))
 	)
-	if err := config.Decode(r.Body); err != nil {
-		utils.Errorf("%s", err)
-	}
-
 	job.Setenv("repo", r.Form.Get("repo"))
 	job.Setenv("tag", r.Form.Get("tag"))
 	job.Setenv("author", r.Form.Get("author"))
 	job.Setenv("comment", r.Form.Get("comment"))
-	job.SetenvSubEnv("config", &config)
+	job.Setenv("changes", r.Form.Get("changes"))
+	// Prepend fields from legacy config object, for reverse compatibility.
+	if err := json.NewDecoder(r.Body).Decode(&legacyconfig); err != nil {
+		return err
+	}
+	job.Setenv("changes", legacyconfig.AsScript()+"\n"+job.Getenv("changes"))
 
 	var id string
 	job.Stdout.AddString(&id)

--- a/api/server/server_unit_test.go
+++ b/api/server/server_unit_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/dotcloud/docker/api"
 	"github.com/dotcloud/docker/engine"
+	"github.com/dotcloud/docker/runconfig"
 	"github.com/dotcloud/docker/utils"
 	"io"
 	"net/http"
@@ -13,6 +14,34 @@ import (
 	"os"
 	"testing"
 )
+
+func TestPostCommit(t *testing.T) {
+	eng := tmpEngine(t)
+	defer rmEngine(eng)
+	var called bool
+	eng.Register("commit", func(job *engine.Job) engine.Status {
+		if job.Getenv("changes") != "user solomon\nentrypoint [\"awesome\",\"command\"]\nenv foo bar\nentrypoint echo" {
+			t.Fatalf("%#v\n", job.Getenv("changes"))
+		}
+		if job.Getenv("repo") != "myimage" {
+			t.Fatalf("%#v\n", job.Getenv("repo"))
+		}
+		if job.Getenv("tag") != "mytag" {
+			t.Fatalf("%#v\n", job.Getenv("tag"))
+		}
+		called = true
+		return engine.StatusOK
+	})
+	// legacy config object
+	cfg := &runconfig.Config{}
+	cfg.User = "solomon"
+	cfg.Entrypoint = []string{"awesome", "command"}
+	r := serveRequest("POST", "/commit?repo=myimage&tag=mytag&changes=env foo bar\nentrypoint echo", toJson(cfg, t), eng, t)
+	if !called {
+		t.Fatalf("handler was not called")
+	}
+	readEnv(r.Body, t)
+}
 
 func TestGetBoolParam(t *testing.T) {
 	if ret, err := getBoolParam("true"); err != nil || !ret {

--- a/engine/env.go
+++ b/engine/env.go
@@ -246,6 +246,15 @@ func (env *Env) Import(src interface{}) (err error) {
 	return nil
 }
 
+func (env *Env) ToScript() string {
+	var s string
+	for _, kv := range *env {
+		parts := strings.SplitN(kv, "=", 2)
+		s = fmt.Sprintf("%senv %s %s\n", s, parts[0], parts[1])
+	}
+	return s
+}
+
 func (env *Env) Map() map[string]string {
 	m := make(map[string]string)
 	for _, kv := range *env {

--- a/engine/env.go
+++ b/engine/env.go
@@ -137,8 +137,17 @@ func (env *Env) SetList(key string, value []string) error {
 	return env.SetJson(key, value)
 }
 
-func (env *Env) Set(key, value string) {
-	*env = append(*env, key+"="+value)
+// FIXME: Set and Add are not distinguished (Set always appends).
+// We still implement both to allow the caller to specify intent.
+// This should make things easier later.
+func (env *Env) Set(key string, values ...string) {
+	env.Add(key, values...)
+}
+
+func (env *Env) Add(key string, values ...string) {
+	for _, value := range values {
+		*env = append(*env, key+"="+value)
+	}
 }
 
 func NewDecoder(src io.Reader) *Decoder {

--- a/engine/env_test.go
+++ b/engine/env_test.go
@@ -95,3 +95,17 @@ func TestEnviron(t *testing.T) {
 		t.Fatalf("bar not found in the environ")
 	}
 }
+
+func TestExpand(t *testing.T) {
+	env := &Env{}
+	env.Set("foo", "bar")
+	env.Set("letters", "a", "b", "c", "d")
+	env.Set("empty", "")
+	result, err := env.Expand("foo=$foo, the last letter is $letters, empty:<$empty>\nnon-existent key: '$nonexistent'")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "foo=bar, the last letter is d, empty:<>\nnon-existent key: ''" {
+		t.Fatalf("%v\n", result)
+	}
+}

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -533,45 +533,6 @@ func TestGetContainersByName(t *testing.T) {
 	}
 }
 
-func TestPostCommit(t *testing.T) {
-	eng := NewTestEngine(t)
-	defer mkRuntimeFromEngine(eng, t).Nuke()
-	srv := mkServerFromEngine(eng, t)
-
-	// Create a container and remove a file
-	containerID := createTestContainer(eng,
-		&runconfig.Config{
-			Image: unitTestImageID,
-			Cmd:   []string{"touch", "/test"},
-		},
-		t,
-	)
-
-	containerRun(eng, containerID, t)
-
-	req, err := http.NewRequest("POST", "/commit?repo=testrepo&testtag=tag&container="+containerID, bytes.NewReader([]byte{}))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	r := httptest.NewRecorder()
-	if err := server.ServeRequest(eng, api.APIVERSION, r, req); err != nil {
-		t.Fatal(err)
-	}
-	assertHttpNotError(r, t)
-	if r.Code != http.StatusCreated {
-		t.Fatalf("%d Created expected, received %d\n", http.StatusCreated, r.Code)
-	}
-
-	var env engine.Env
-	if err := env.Decode(r.Body); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := srv.ImageInspect(env.Get("Id")); err != nil {
-		t.Fatalf("The image has not been committed")
-	}
-}
-
 func TestPostContainersCreate(t *testing.T) {
 	eng := NewTestEngine(t)
 	defer mkRuntimeFromEngine(eng, t).Nuke()

--- a/pkg/dockerfile/dockerfile.go
+++ b/pkg/dockerfile/dockerfile.go
@@ -1,0 +1,63 @@
+package dockerfile
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type Handler interface {
+	Handle(stepname, cmd, arg string) error
+}
+
+// Long lines can be split with a backslash
+var lineContinuation = regexp.MustCompile(`\s*\\\s*\n`)
+
+func stripComments(raw []byte) string {
+	var (
+		out   []string
+		lines = strings.Split(string(raw), "\n")
+	)
+	for _, l := range lines {
+		if len(l) == 0 || l[0] == '#' {
+			continue
+		}
+		out = append(out, l)
+	}
+	return strings.Join(out, "\n")
+}
+
+func ParseScript(src []byte, handler Handler) error {
+	var (
+		ppSrc = lineContinuation.ReplaceAllString(stripComments(src), "")
+		stepN = 0
+	)
+	for _, line := range strings.Split(ppSrc, "\n") {
+		line = strings.Trim(strings.Replace(line, "\t", " ", -1), " \t\r\n")
+		if len(line) == 0 {
+			continue
+		}
+		if err := ParseExpr(fmt.Sprintf("%d", stepN), line, handler); err != nil {
+			return fmt.Errorf("%s: %v", line, err)
+		}
+		stepN += 1
+	}
+	return nil
+
+}
+
+func ParseExpr(n string, expression string, handler Handler) error {
+	tmp := strings.SplitN(expression, " ", 2)
+	if len(tmp) != 2 {
+		return fmt.Errorf("invalid format %s", expression)
+	}
+	instruction := strings.ToLower(strings.Trim(tmp[0], " "))
+	if len(instruction) == 0 {
+		return fmt.Errorf("invalid format: %s", expression)
+	}
+	arg := strings.Trim(tmp[1], " ")
+	if handler == nil {
+		return nil
+	}
+	return handler.Handle(n, instruction, arg)
+}

--- a/pkg/dockerfile/reflector.go
+++ b/pkg/dockerfile/reflector.go
@@ -1,0 +1,30 @@
+package dockerfile
+
+import (
+	"fmt"
+	"strings"
+	"reflect"
+)
+
+func ReflectorHandler(b interface{}) Handler {
+	return reflectorHandler{b}
+}
+
+type reflectorHandler struct {
+	b interface{}
+}
+
+func (r reflectorHandler) Handle(stepname, cmd, arg string) error {
+	if len(cmd) == 0 {
+		return fmt.Errorf("empty command")
+	}
+	method, exists := reflect.TypeOf(r.b).MethodByName("Cmd" + strings.ToUpper(cmd[:1]) + strings.ToLower(cmd[1:]))
+	if !exists {
+		return fmt.Errorf("No such command: %s", cmd)
+	}
+	ret := method.Func.Call([]reflect.Value{reflect.ValueOf(r.b), reflect.ValueOf(arg)})[0].Interface()
+	if ret != nil {
+		return ret.(error)
+	}
+	return nil
+}

--- a/runconfig/script.go
+++ b/runconfig/script.go
@@ -134,3 +134,38 @@ func (cfg *Config) CmdVolume(args string) error {
 	}
 	return nil
 }
+
+// Print a config back as a script
+
+func (cfg *Config) AsScript() string {
+	var ops []string
+	if cfg.User != "" {
+		ops = append(ops, fmt.Sprintf("user %s", cfg.User))
+	}
+	for port := range cfg.ExposedPorts {
+		ops = append(ops, fmt.Sprintf("expose %s", port))
+	}
+	if len(cfg.Env) != 0 {
+		ops = append(ops, (*engine.Env)(&cfg.Env).ToScript())
+	}
+	if len(cfg.Cmd) != 0 {
+		if j, err := json.Marshal(cfg.Cmd); err == nil {
+			ops = append(ops, fmt.Sprintf("cmd %s", j))
+		}
+	}
+	for volume := range cfg.Volumes {
+		ops = append(ops, fmt.Sprintf("volume %s", volume))
+	}
+	if cfg.WorkingDir != "" {
+		ops = append(ops, fmt.Sprintf("workdir %s", cfg.WorkingDir))
+	}
+	if len(cfg.Entrypoint) != 0 {
+		if j, err := json.Marshal(cfg.Entrypoint); err == nil {
+			ops = append(ops, fmt.Sprintf("entrypoint %s", j))
+		}
+	}
+	for _, trigger := range cfg.OnBuild {
+		ops = append(ops, fmt.Sprintf("onbuild %s", trigger))
+	}
+	return strings.Join(ops, "\n")
+}

--- a/runconfig/script.go
+++ b/runconfig/script.go
@@ -54,16 +54,16 @@ func (cfg *Config) FindEnvKey(key string) int {
 }
 
 func (cfg *Config) CmdCmd(args string) error {
-	cfg.Cmd = parseArgCommand(args)
+	cfg.Cmd = ParseArgCommand(args)
 	return nil
 }
 
 func (cfg *Config) CmdEntrypoint(args string) error {
-	cfg.Entrypoint = parseArgCommand(args)
+	cfg.Entrypoint = ParseArgCommand(args)
 	return nil
 }
 
-// parseArgCommand parses a command from a single string. The syntax is as follows:
+// ParseArgCommand parses a command from a single string. The syntax is as follows:
 // 1) If the string is a valid json-encoded array of strings, the decoded array is returned.
 // 2) Otherwise, the 3-part array {"/bin/sh", "-c", <input>} is returned.
 //
@@ -73,7 +73,7 @@ func (cfg *Config) CmdEntrypoint(args string) error {
 //
 // FIXME: the aforementioned shell syntax is still not implemented. The additional difficulty
 // is that we must now support the current syntax, which in certain cases conflicts with shell.
-func parseArgCommand(input string) []string {
+func ParseArgCommand(input string) []string {
 	var cmd []string
 	if err := json.Unmarshal([]byte(input), &cmd); err != nil {
 		cmd = []string{"/bin/sh", "-c", input}

--- a/runconfig/script.go
+++ b/runconfig/script.go
@@ -1,0 +1,171 @@
+package runconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/dotcloud/docker/nat"
+	"github.com/dotcloud/docker/pkg/dockerfile"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Handle implements the dockerfile.Handler interface to allow scripting.
+// FIXME:... and we could also output the contents of a config as a Dockerfile :-)
+func (cfg *Config) Handle(stepname, cmd, arg string) error {
+	return dockerfile.ReflectorHandler(cfg).Handle(stepname, cmd, arg)
+}
+
+// The ONBUILD command declares a build instruction to be executed in any future build
+// using the current image as a base.
+func (cfg *Config) CmdOnbuild(trigger string) error {
+	splitTrigger := strings.Split(trigger, " ")
+	triggerInstruction := strings.ToUpper(strings.Trim(splitTrigger[0], " "))
+	switch triggerInstruction {
+	case "ONBUILD":
+		return fmt.Errorf("Chaining ONBUILD via `ONBUILD ONBUILD` isn't allowed")
+	case "MAINTAINER", "FROM":
+		return fmt.Errorf("%s isn't allowed as an ONBUILD trigger", triggerInstruction)
+	}
+	cfg.OnBuild = append(cfg.OnBuild, trigger)
+	return nil
+}
+
+func (cfg *Config) CmdEnv(args string) error {
+	tmp := strings.SplitN(args, " ", 2)
+	if len(tmp) != 2 {
+		return fmt.Errorf("Invalid ENV format")
+	}
+	key := strings.Trim(tmp[0], " \t")
+	value := strings.Trim(tmp[1], " \t")
+
+	envKey := cfg.FindEnvKey(key)
+	replacedValue, err := cfg.ExpandVars(value)
+	if err != nil {
+		return err
+	}
+	replacedVar := fmt.Sprintf("%s=%s", key, replacedValue)
+
+	if envKey >= 0 {
+		cfg.Env[envKey] = replacedVar
+	} else {
+		cfg.Env = append(cfg.Env, replacedVar)
+	}
+	return nil
+}
+
+func (cfg *Config) FindEnvKey(key string) int {
+	for k, envVar := range cfg.Env {
+		envParts := strings.SplitN(envVar, "=", 2)
+		if key == envParts[0] {
+			return k
+		}
+	}
+	return -1
+}
+
+func (cfg *Config) ExpandVars(value string) (string, error) {
+	exp, err := regexp.Compile("(\\\\\\\\+|[^\\\\]|\\b|\\A)\\$({?)([[:alnum:]_]+)(}?)")
+	if err != nil {
+		return value, err
+	}
+	matches := exp.FindAllString(value, -1)
+	for _, match := range matches {
+		match = match[strings.Index(match, "$"):]
+		matchKey := strings.Trim(match, "${}")
+
+		for _, envVar := range cfg.Env {
+			envParts := strings.SplitN(envVar, "=", 2)
+			envKey := envParts[0]
+			envValue := envParts[1]
+
+			if envKey == matchKey {
+				value = strings.Replace(value, match, envValue, -1)
+				break
+			}
+		}
+	}
+	return value, nil
+}
+
+func (cfg *Config) CmdCmd(args string) error {
+	cfg.Cmd = parseArgCommand(args)
+	return nil
+}
+
+func (cfg *Config) CmdEntrypoint(args string) error {
+	cfg.Entrypoint = parseArgCommand(args)
+	return nil
+}
+
+// parseArgCommand parses a command from a single string. The syntax is as follows:
+// 1) If the string is a valid json-encoded array of strings, the decoded array is returned.
+// 2) Otherwise, the 3-part array {"/bin/sh", "-c", <input>} is returned.
+//
+// Historical note: command parsing was implemented in this way as a stopgap while waiting for
+// the correct solution: parsing a shell-like syntax for word separation (single quotes,
+// double quotes and backquotes).
+//
+// FIXME: the aforementioned shell syntax is still not implemented. The additional difficulty
+// is that we must now support the current syntax, which in certain cases conflicts with shell.
+func parseArgCommand(input string) []string {
+	var cmd []string
+	if err := json.Unmarshal([]byte(input), &cmd); err != nil {
+		cmd = []string{"/bin/sh", "-c", input}
+	}
+	return cmd
+}
+
+func (cfg *Config) CmdExpose(args string) error {
+	portsTab := strings.Split(args, " ")
+
+	if cfg.ExposedPorts == nil {
+		cfg.ExposedPorts = make(nat.PortSet)
+	}
+	ports, _, err := nat.ParsePortSpecs(append(portsTab, cfg.PortSpecs...))
+	if err != nil {
+		return err
+	}
+	for port := range ports {
+		if _, exists := cfg.ExposedPorts[port]; !exists {
+			cfg.ExposedPorts[port] = struct{}{}
+		}
+	}
+	cfg.PortSpecs = nil // Unset deprecated field
+	return nil
+}
+
+func (cfg *Config) CmdUser(args string) error {
+	cfg.User = args
+	return nil
+}
+
+func (cfg *Config) CmdWorkdir(workdir string) error {
+	if workdir[0] == '/' {
+		cfg.WorkingDir = workdir
+	} else {
+		if cfg.WorkingDir == "" {
+			cfg.WorkingDir = "/"
+		}
+		cfg.WorkingDir = filepath.Join(cfg.WorkingDir, workdir)
+	}
+	return nil
+}
+
+func (cfg *Config) CmdVolume(args string) error {
+	if args == "" {
+		return fmt.Errorf("Volume cannot be empty")
+	}
+
+	var volume []string
+	if err := json.Unmarshal([]byte(args), &volume); err != nil {
+		volume = []string{args}
+	}
+	if cfg.Volumes == nil {
+		cfg.Volumes = map[string]struct{}{}
+	}
+	for _, v := range volume {
+		cfg.Volumes[v] = struct{}{}
+	}
+	return nil
+}

--- a/runconfig/script.go
+++ b/runconfig/script.go
@@ -13,7 +13,7 @@ import (
 // Handle implements the dockerfile.Handler interface to allow scripting.
 // FIXME:... and we could also output the contents of a config as a Dockerfile :-)
 func (cfg *Config) Handle(stepname, cmd, arg string) error {
-	return dockerfile.ReflectorHandler(cfg).Handle(stepname, cmd, arg)
+	return dockerfile.ReflectorHandler(cfg, nil).Handle(stepname, cmd, arg)
 }
 
 // The ONBUILD command declares a build instruction to be executed in any future build

--- a/runconfig/script_test.go
+++ b/runconfig/script_test.go
@@ -1,0 +1,153 @@
+package runconfig
+
+import (
+	df "github.com/dotcloud/docker/pkg/dockerfile"
+	"strings"
+	"testing"
+)
+
+func mkTest(script string, tester func(*Config) bool) func(*testing.T) {
+	return func(t *testing.T) {
+		var cfg Config
+		err := df.ParseScript([]byte(script), &cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ok := tester(&cfg); !ok {
+			t.Fatalf("'%s': %#v\n", script, cfg)
+		}
+	}
+}
+
+func TestScriptEnv(t *testing.T) {
+	mkTest("env foo bar", func(cfg *Config) bool {
+		if strings.Join(cfg.Env, "\n") != "foo=bar" {
+			return false
+		}
+		return true
+	})(t)
+}
+
+func TestScriptOnBuild(t *testing.T) {
+	mkTest("onbuild add . /src\nonbuild run echo hello world", func(cfg *Config) bool {
+		if cfg.OnBuild[0] != "add . /src" {
+			return false
+		}
+		if cfg.OnBuild[1] != "run echo hello world" {
+			return false
+		}
+		return true
+	})(t)
+}
+
+func TestScriptCmdJSON(t *testing.T) {
+	mkTest("cmd [\"echo\", \"hello\", \"world\"]", func(cfg *Config) bool {
+		if len(cfg.Cmd) != 3 {
+			return false
+		}
+		if cfg.Cmd[0] != "echo" {
+			return false
+		}
+		if cfg.Cmd[1] != "hello" {
+			return false
+		}
+		if cfg.Cmd[2] != "world" {
+			return false
+		}
+		return true
+	})(t)
+}
+
+func TestScriptCmdPlain(t *testing.T) {
+	mkTest("cmd command --arg", func(cfg *Config) bool {
+		if len(cfg.Cmd) != 3 {
+			return false
+		}
+		if cfg.Cmd[0] != "/bin/sh" {
+			return false
+		}
+		if cfg.Cmd[1] != "-c" {
+			return false
+		}
+		if cfg.Cmd[2] != "command --arg" {
+			return false
+		}
+		return true
+	})(t)
+}
+
+func TestScriptEntrypointJSON(t *testing.T) {
+	mkTest("entrypoint [\"echo\", \"hello\", \"world\"]", func(cfg *Config) bool {
+		if len(cfg.Entrypoint) != 3 {
+			return false
+		}
+		if cfg.Entrypoint[0] != "echo" {
+			return false
+		}
+		if cfg.Entrypoint[1] != "hello" {
+			return false
+		}
+		if cfg.Entrypoint[2] != "world" {
+			return false
+		}
+		return true
+	})(t)
+}
+
+func TestScriptEntrypointPlain(t *testing.T) {
+	mkTest("entrypoint command --arg", func(cfg *Config) bool {
+		if len(cfg.Entrypoint) != 3 {
+			return false
+		}
+		if cfg.Entrypoint[0] != "/bin/sh" {
+			return false
+		}
+		if cfg.Entrypoint[1] != "-c" {
+			return false
+		}
+		if cfg.Entrypoint[2] != "command --arg" {
+			return false
+		}
+		return true
+	})(t)
+}
+
+func TestScriptExpose(t *testing.T) {
+	mkTest("expose 8080 80 53/udp", func(cfg *Config) bool {
+		if len(cfg.ExposedPorts) != 3 {
+			return false
+		}
+		if _, exists := cfg.ExposedPorts["8080/tcp"]; !exists {
+			return false
+		}
+		if _, exists := cfg.ExposedPorts["80/tcp"]; !exists {
+			return false
+		}
+		if _, exists := cfg.ExposedPorts["53/udp"]; !exists {
+			return false
+		}
+		// Check that deprecated field is not set
+		if len(cfg.PortSpecs) != 0 {
+			return false
+		}
+		return true
+	})(t)
+}
+
+func TestScriptUserNumerical(t *testing.T) {
+	mkTest("user 4242", func(cfg *Config) bool {
+		if cfg.User != "4242" {
+			return false
+		}
+		return true
+	})(t)
+}
+
+func TestScriptUserLetters(t *testing.T) {
+	mkTest("user solomon", func(cfg *Config) bool {
+		if cfg.User != "solomon" {
+			return false
+		}
+		return true
+	})(t)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/graph"
 	"github.com/dotcloud/docker/image"
+	"github.com/dotcloud/docker/pkg/dockerfile"
 	"github.com/dotcloud/docker/pkg/graphdb"
 	"github.com/dotcloud/docker/pkg/signal"
 	"github.com/dotcloud/docker/registry"
@@ -1088,17 +1089,13 @@ func (srv *Server) ContainerCommit(job *engine.Job) engine.Status {
 	if container == nil {
 		return job.Errorf("No such container: %s", name)
 	}
-	var config = container.Config
-	var newConfig runconfig.Config
-	if err := job.GetenvJson("config", &newConfig); err != nil {
-		return job.Error(err)
+	// Create a copy of the container original config
+	config := *container.Config
+	err := dockerfile.ParseScript([]byte(job.Env().Get("changes")), &config)
+	if err != nil {
+		return job.Errorf("can't apply changes: %v", err)
 	}
-
-	if err := runconfig.Merge(&newConfig, config); err != nil {
-		return job.Error(err)
-	}
-
-	img, err := srv.runtime.Commit(container, job.Getenv("repo"), job.Getenv("tag"), job.Getenv("comment"), job.Getenv("author"), &newConfig)
+	img, err := srv.runtime.Commit(container, job.Getenv("repo"), job.Getenv("tag"), job.Getenv("comment"), job.Getenv("author"), &config)
 	if err != nil {
 		return job.Error(err)
 	}


### PR DESCRIPTION
`docker commit --change` allows specifying standard changes to be applied to the new image. It deprecates the less user-friendly and less stable _commit --run_.

Changes are expressed in the Dockerfile syntax, and can be used  to modify the image metadata. For example:

`docker commit --change 'WORKDIR /home/bob'` will commit the image with _/home/bob_ as the default working directory.

`docker commit --change 'EXPOSE 80 53/udp'` will commit the image with network ports _80/tcp_ and _53/udp_ marked as exposed.

`docker commit --change 'VOLUME /var/data'` will commit the image with _/var/data_ marked as a volume.

And so on.

The following Dockerfile instructions can be used as a change:
- ENTRYPOINT
- CMD
- USER
- WORKDIR
- ENV
- VOLUME
- EXPOSE
- ONBUILD

The syntax for these commands is identical in _--change_ and in a
Dockerfile. See the Dockerfile reference for a complete syntax reference.

Note that some fields which could be changed directly with the deprecated `--run` can no longer be changed with the new `--change`. This is by design, for 2 reasons:

1) Not every field in the underlying Config object should be automatically exposed for modification. This gives us a stable indirection to control the exact set of allowed modifications.

2) If the Dockerfile syntax does not allow a legitimate modification, we can simply enrich the syntax, fixing the problem in a unified way both in Dockerfile and _docker commit_.
