### PR TITLE
Add delay when respawning upstart-controlled container

### DIFF
--- a/docs/sources/use/host_integration.rst
+++ b/docs/sources/use/host_integration.rst
@@ -42,6 +42,7 @@ into it:
    start on filesystem and started docker
    stop on runlevel [!2345]
    respawn
+   respawn limit 12 10
    script
      /usr/bin/docker start -a redis_server
    end script


### PR DESCRIPTION
After docker was successfully started by upstart, starting a container
will fail until the daemon has finished initializing, which can take a
while when many images/containers are present. By default, upstart will
retry right away, and will give up after 5 attemps in a row (default of
respawn limit). This patch adds some throttling, effectively giving
5*10s for the daemon to initialize.
