### PR TITLE
Fix libcontainer network support on rhel6

### DIFF
--- a/pkg/libcontainer/network/network.go
+++ b/pkg/libcontainer/network/network.go
@@ -50,7 +50,7 @@ func SetInterfaceMaster(name, master string) error {
 	if err != nil {
 		return err
 	}
-	return netlink.NetworkSetMaster(iface, masterIface)
+	return netlink.AddToBridge(iface, masterIface)
 }
 
 func SetDefaultGateway(ip string) error {

--- a/pkg/netlink/netlink_unsupported.go
+++ b/pkg/netlink/netlink_unsupported.go
@@ -63,3 +63,7 @@ func NetworkLinkDown(iface *net.Interface) error {
 func CreateBridge(name string, setMacAddr bool) error {
 	return ErrNotImplemented
 }
+
+func AddToBridge(iface, master *net.Interface) error {
+	return ErrNotImplemented
+}


### PR DESCRIPTION
It seems that netlink in older kernels, including RHEL6, does not
support RTM_SETLINK with IFLA_MASTER. It just silently ignores it, reporting
no error, causing netlink.NetworkSetMaster() to not do anything yet
return no error.

We fix this by introducing and using AddToBridge() in a very similar manner
to CreateBridge(), which use the old ioctls directly.

This fixes https://github.com/dotcloud/docker/issues/4668

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
