### PR TITLE
Fix spurious mtab symlink error when /etc doesn't exist yet

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -272,15 +272,15 @@ func SetupInitLayer(initLayer string) error {
 
 		if _, err := os.Stat(path.Join(initLayer, pth)); err != nil {
 			if os.IsNotExist(err) {
+				if err := os.MkdirAll(path.Join(initLayer, path.Dir(pth)), 0755); err != nil {
+					return err
+				}
 				switch typ {
 				case "dir":
 					if err := os.MkdirAll(path.Join(initLayer, pth), 0755); err != nil {
 						return err
 					}
 				case "file":
-					if err := os.MkdirAll(path.Join(initLayer, path.Dir(pth)), 0755); err != nil {
-						return err
-					}
 					f, err := os.OpenFile(path.Join(initLayer, pth), os.O_CREATE, 0755)
 					if err != nil {
 						return err


### PR DESCRIPTION
symlink /proc/mounts /var/lib/docker/btrfs/subvolumes/1763d6602b8b871f0a79754f1cb0a31b3928bb95de5232b1b8c15c60fa1017f6-init/etc/mtab: no such file or directory
