### PR TITLE
introduce a --remove-broken-containers

### DIFF
--- a/daemonconfig/config.go
+++ b/daemonconfig/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Mtu                         int
 	DisableNetwork              bool
 	EnableSelinuxSupport        bool
+	RemoveBroken                bool
 }
 
 // ConfigFromJob creates and returns a new DaemonConfig object
@@ -47,6 +48,7 @@ func ConfigFromJob(job *engine.Job) *Config {
 		GraphDriver:                 job.Getenv("GraphDriver"),
 		ExecDriver:                  job.Getenv("ExecDriver"),
 		EnableSelinuxSupport:        false, // FIXME: hardcoded default to disable selinux for .10 release
+		RemoveBroken:                job.GetenvBool("RemoveBroken"),
 	}
 	if dns := job.GetenvList("Dns"); dns != nil {
 		config.Dns = dns

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -63,6 +63,7 @@ func main() {
 		flCa                 = flag.String([]string{"-tlscacert"}, dockerConfDir+defaultCaFile, "Trust only remotes providing a certificate signed by the CA given here")
 		flCert               = flag.String([]string{"-tlscert"}, dockerConfDir+defaultCertFile, "Path to TLS certificate file")
 		flKey                = flag.String([]string{"-tlskey"}, dockerConfDir+defaultKeyFile, "Path to TLS key file")
+		flRemoveBroken       = flag.Bool([]string{"-remove-broken-containers"}, false, "Remove broken containers on daemon startup")
 	)
 	flag.Var(&flDns, []string{"#dns", "-dns"}, "Force docker to use specific DNS servers")
 	flag.Var(&flDnsSearch, []string{"-dns-search"}, "Force Docker to use specific DNS search domains")
@@ -147,6 +148,7 @@ func main() {
 			job.Setenv("GraphDriver", *flGraphDriver)
 			job.Setenv("ExecDriver", *flExecDriver)
 			job.SetenvInt("Mtu", *flMtu)
+			job.SetenvBool("RemoveBroken", *flRemoveBroken)
 			if err := job.Run(); err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
When one of your container has a wrong `config`, or `hostconfig` format,
you'll see an error when the docker daemon starts like `[error] runtime.go:321 Failed to load container 86fca1ecde43b7ab3a2d99f82025c998b8c6f420b4d1ff10d348279d6ce45b9b: json: cannot unmarshal string into Go value of type bool` 
The container won't appear anywhere, so there is no way to delete it. Even if you go to the fs and remove the directory, it can leave some name or links behind.

I propose to add a `--remove-broken-containers` to automatically cleanly remove the broken containers.

I wait to see if this feature is worth something before doing docs
