### PR TITLE
Revert "Support hairpin NAT without going through docker server"

### DIFF
--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -66,6 +66,7 @@ func (c *Chain) Forward(action Action, ip net.IP, port int, proto, dest_addr str
 		"-p", proto,
 		"-d", daddr,
 		"--dport", strconv.Itoa(port),
+		"!", "-i", c.Bridge,
 		"-j", "DNAT",
 		"--to-destination", net.JoinHostPort(dest_addr, strconv.Itoa(dest_port))); err != nil {
 		return err


### PR DESCRIPTION
This reverts commit b39d02b611f1cc0af283f417b73bf0d36f26277a.

Fixes #5111

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
