### PR TITLE
Fixes permissions on volumes when dir in container is empty

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -246,22 +246,22 @@ func createVolumes(container *Container) error {
 					if err := archive.CopyWithTar(rootVolPath, srcPath); err != nil {
 						return err
 					}
+				}
+			}
 
-					var stat syscall.Stat_t
-					if err := syscall.Stat(rootVolPath, &stat); err != nil {
-						return err
-					}
-					var srcStat syscall.Stat_t
-					if err := syscall.Stat(srcPath, &srcStat); err != nil {
-						return err
-					}
-					// Change the source volume's ownership if it differs from the root
-					// files that were just copied
-					if stat.Uid != srcStat.Uid || stat.Gid != srcStat.Gid {
-						if err := os.Chown(srcPath, int(stat.Uid), int(stat.Gid)); err != nil {
-							return err
-						}
-					}
+			var stat syscall.Stat_t
+			if err := syscall.Stat(rootVolPath, &stat); err != nil {
+				return err
+			}
+			var srcStat syscall.Stat_t
+			if err := syscall.Stat(srcPath, &srcStat); err != nil {
+				return err
+			}
+			// Change the source volume's ownership if it differs from the root
+			// files that were just copied
+			if stat.Uid != srcStat.Uid || stat.Gid != srcStat.Gid {
+				if err := os.Chown(srcPath, int(stat.Uid), int(stat.Gid)); err != nil {
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
When creating a volume and the volume inside the container is empty, currently the uid/gid is just set to root.  If you want the volume to have the permissions from inside the container you must put a file inside the dir. This resolves this problem
#5080

Docker-DCO-1.1-Signed-off-by: Brian Goff cpuguy83@gmail.com (github: cpuguy83)
