### PR TITLE
Avoid "invalid memory address or nil pointer dereference" panic

### DIFF
--- a/pkg/libcontainer/types.go
+++ b/pkg/libcontainer/types.go
@@ -68,7 +68,7 @@ func (n Namespaces) Contains(ns string) bool {
 
 func (n Namespaces) Get(ns string) *Namespace {
 	for _, nsp := range n {
-		if nsp.Key == ns {
+		if nsp != nil && nsp.Key == ns {
 			return nsp
 		}
 	}

--- a/pkg/libcontainer/types_test.go
+++ b/pkg/libcontainer/types_test.go
@@ -18,6 +18,15 @@ func TestNamespacesContains(t *testing.T) {
 	if !ns.Contains("NEWPID") {
 		t.Fatal("namespaces should contain NEWPID but does not")
 	}
+
+	withNil := Namespaces{
+		GetNamespace("UNDEFINED"), // this element will be nil
+		GetNamespace("NEWPID"),
+	}
+
+	if !withNil.Contains("NEWPID") {
+		t.Fatal("namespaces should contain NEWPID but does not")
+	}
 }
 
 func TestCapabilitiesContains(t *testing.T) {


### PR DESCRIPTION
libcontainer.GetNamespace returns nil on FreeBSD because
libcontainer.namespaceList is empty. In this case, Namespaces#Get should
return nil instead of being panic.

Docker-DCO-1.1-Signed-off-by: Kato Kazuyoshi kato.kazuyoshi@gmail.com (github: kzys)
