### PR TITLE
Fix utils.FollowSymlinkInScope's infinite loops bug

### DIFF
--- a/utils/fs.go
+++ b/utils/fs.go
@@ -62,6 +62,15 @@ func FollowSymlinkInScope(link, root string) (string, error) {
 		prev = filepath.Clean(prev)
 
 		for {
+			if !strings.HasPrefix(prev, root) {
+				// Don't resolve symlinks outside of root. For example,
+				// we don't have to check /home in the below.
+				//
+				//   /home -> usr/home
+				//   FollowSymlinkInScope("/home/bob/foo/bar", "/home/bob/foo")
+				break
+			}
+
 			stat, err := os.Lstat(prev)
 			if err != nil {
 				if os.IsNotExist(err) {

--- a/utils/fs_test.go
+++ b/utils/fs_test.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -23,6 +25,29 @@ func TestFollowSymLinkNormal(t *testing.T) {
 
 	if expected := abs(t, "testdata/b/c/data"); expected != rewrite {
 		t.Fatalf("Expected %s got %s", expected, rewrite)
+	}
+}
+
+func TestFollowSymLinkUnderLinkedDir(t *testing.T) {
+	dir, err := ioutil.TempDir("", "docker-fs-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	os.Mkdir(filepath.Join(dir, "realdir"), 0700)
+	os.Symlink("realdir", filepath.Join(dir, "linkdir"))
+
+	linkDir := filepath.Join(dir, "linkdir", "foo")
+	dirUnderLinkDir := filepath.Join(dir, "linkdir", "foo", "bar")
+	os.MkdirAll(dirUnderLinkDir, 0700)
+
+	rewrite, err := FollowSymlinkInScope(dirUnderLinkDir, linkDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rewrite != dirUnderLinkDir {
+		t.Fatalf("Expected %s got %s", dirUnderLinkDir, rewrite)
 	}
 }
 


### PR DESCRIPTION
fs_test.go doesn't finish if Docker's code is placed under a directory
which has symlinks between / and the directory.
For example, the below doesn't finish before the change.

  /home -> usr/home
  FollowSymlinkInScope("/home/bob/foo/bar", "/home/bob/foo")

Docker-DCO-1.1-Signed-off-by: Kato Kazuyoshi kato.kazuyoshi@gmail.com (github: kzys)
