### PR TITLE
Docs: add some example log lines that indicate a lack of memory when running the test suite

### DIFF
--- a/docs/sources/contributing/devenvironment.rst
+++ b/docs/sources/contributing/devenvironment.rst
@@ -127,6 +127,15 @@ You can use this to select certain tests to run, eg.
 
     TESTFLAGS='-run ^TestBuild$' make test
 
+If the output indicates "FAIL" and you see errors like this:
+
+.. code-block:: text
+
+  server.go:1302 Error: Insertion failed because database is full: database or disk is full
+
+  utils_test.go:179: Error copy: exit status 1 (cp: writing '/tmp/docker-testd5c9-[...]': No space left on device
+
+Then you likely don't have enough memory available the test suite. 2GB is recommended.
 
 Step 6: Use Docker
 -------------------


### PR DESCRIPTION
This may seem obvious when you know, but I spent one hour on the second one, thinking that "/tmp" was a "tmpfs" with a fixed size and trying to increase it somehow... Thankfully @crosbymichael found the problem immediately on IRC and advised I give more RAM to my VM.

I think having that kind of help in the doc will help newcomers to focus on more interesting problems.

Thanks
