### PR TITLE
Fetch the "busybox" image source so we can build locally instead of pulling during the integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,9 @@ RUN	go get code.google.com/p/go.tools/cmd/cover
 # TODO replace FPM with some very minimal debhelper stuff
 RUN	gem install --no-rdoc --no-ri fpm --version 1.0.2
 
+# Get the "busybox" image source so we can build locally instead of pulling
+RUN	git clone https://github.com/jpetazzo/docker-busybox.git /docker-busybox
+
 # Setup s3cmd config
 RUN	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_KEY' > /.s3cfg
 

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -31,7 +31,11 @@ bundle_test_integration_cli() {
 	sleep 2
 	
 	if ! docker inspect busybox &> /dev/null; then
-		( set -x; docker pull busybox )
+		if [ -d /docker-busybox ]; then
+			( set -x; docker build -t busybox /docker-busybox )
+		else
+			( set -x; docker pull busybox )
+		fi
 	fi
 
 	bundle_test_integration_cli


### PR DESCRIPTION
/cc @unclejack @creack @crosbymichael @vieux
