### PR TITLE
Allow dot in repo name

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -101,16 +101,11 @@ func ResolveRepositoryName(reposName string) (string, string, error) {
 		return "", "", ErrInvalidRepositoryName
 	}
 	nameParts := strings.SplitN(reposName, "/", 2)
-	if !strings.Contains(nameParts[0], ".") && !strings.Contains(nameParts[0], ":") &&
-		nameParts[0] != "localhost" {
+	if len(nameParts) == 1 || (!strings.Contains(nameParts[0], ".") && !strings.Contains(nameParts[0], ":") &&
+		nameParts[0] != "localhost") {
 		// This is a Docker Index repos (ex: samalba/hipache or ubuntu)
 		err := validateRepositoryName(reposName)
 		return IndexServerAddress(), reposName, err
-	}
-	if len(nameParts) < 2 {
-		// There is a dot in repos name (and no registry address)
-		// Is it a Registry address without repos name?
-		return "", "", ErrInvalidRepositoryName
 	}
 	hostname := nameParts[0]
 	reposName = nameParts[1]

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -146,6 +146,13 @@ func TestResolveRepositoryName(t *testing.T) {
 	}
 	assertEqual(t, ep, u, "Expected endpoint to be "+u)
 	assertEqual(t, repo, "private/moonbase", "Expected endpoint to be private/moonbase")
+
+	ep, repo, err = ResolveRepositoryName("ubuntu-12.04-base")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEqual(t, ep, IndexServerAddress(), "Expected endpoint to be "+IndexServerAddress())
+	assertEqual(t, repo, "ubuntu-12.04-base", "Expected endpoint to be ubuntu-12.04-base")
 }
 
 func TestPushRegistryTag(t *testing.T) {


### PR DESCRIPTION
`tianon/test.bad` is a valide name, therefore
`library/test.bad` is a valide name, therefore
`test.bad` should be a valide name.

See #5103 for more information.

Fixes #5103
