### PR TITLE
Some tweaks to the docs UI

### DIFF
--- a/docs/theme/mkdocs/base.html
+++ b/docs/theme/mkdocs/base.html
@@ -12,6 +12,7 @@
     <link href="/css/base.css" rel="stylesheet">
     <link href="/tipuesearch/tipuesearch.css" rel="stylesheet">
     <link rel="shortcut icon" href="{{ site_favicon }}">
+    <link href='//fonts.googleapis.com/css?family=Cabin:400,700,400italic' rel='stylesheet' type='text/css'>
     <title>{% if page_title != '**HIDDEN** - Docker' %}{{ page_title }}{% else %}{{ site_name }}{% endif %}</title>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/docs/theme/mkdocs/css/base.css
+++ b/docs/theme/mkdocs/css/base.css
@@ -8,6 +8,25 @@ body {
   font-family: "Cabin", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  font-family: "Cabin", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 500;
+  line-height: 1.1;
+  color: inherit;
+}
+
+
 /* Content rendering styles */
 #content {
   font-size: 1.2em;
@@ -91,6 +110,11 @@ body {
 .row > [class^="col-"]:last-child,
 .row > [class*=" col-"]:last-child{
     padding-right: 0px;
+}
+
+
+.navbar {
+    border: none;
 }
 
 /* Previous & Next floating navigation */
@@ -177,9 +201,7 @@ body {
   color: #777777;
 }
 #header .navbar-nav {
-    right: 0px;
-    top: 0px;
-    position: absolute;
+    float: right;
 }
 #header .navbar-inner {
   padding-right: 0px;
@@ -201,7 +223,7 @@ body {
   text-align: right;
   padding: 5px 10px;
 }
-#horizontal_thin_menu > a {
+#horizontal_thin_menu a {
   display: inline-block;
   color: white;
   padding: 0px 10px;
@@ -534,7 +556,7 @@ ol.breadcrumb {
 *****************************/
 
 /* Horizontal nav. (menu & thin menu) convenience fix for Tablets */
-@media (min-width: 768px) and (max-width: 999px) {
+@media (min-width: 768px) and (max-width: 952px) {
 
   #docsnav, #horizontal_thin_menu {
     width: 100% !important;
@@ -582,8 +604,11 @@ ol.breadcrumb {
 .container {
   width: 100% !important;
 }
+.container-standard-sized {
+  max-width: 1050px;
+}
 .container-better {
-  max-width: 1100px;
+  max-width: 1050px;
 }
 
 @media (max-width: 900px) {
@@ -674,23 +699,12 @@ ol.breadcrumb {
   /* Thin menu (login - signup) */
   #horizontal_thin_menu { display: none; }
 
-}
-
-@media (max-width: 850px) {
-  /* Docker IO Navigation */
-  #header {
-    display: block;
-    height: 50px;
-  }
   #header #nav_docker_io {
     display: none;
   }
-  #header .brand {
+
+  #header #condensed_docker_io_nav {
     display: block;
-    text-align: center;
-  }
-  #header .brand > img {
-    height: 50px;
   }
 }
 

--- a/docs/theme/mkdocs/docker_io_nav.html
+++ b/docs/theme/mkdocs/docker_io_nav.html
@@ -1,9 +1,11 @@
-<div id="header" class="navbar-collapse collapse navbar-static-top">
-  <div class="navbar-inner">
+<div id="header" class="navbar navbar-collapse collapse navbar-static-top">
+    <!--class="navbar navbar-default navbar-static-top affix"-->
+
+  <div class="navbar-inner container container-standard-sized">
     <a class="brand" href="https://www.docker.io" title="{{ site_name }}">
-      <img src="/img/logo_compressed.png">
+      <img src="https://www.docker.io/static/img/docker-top-logo.png">
     </a>
-    <ul id="nav_docker_io" class="nav navbar-nav">
+    <ul id="nav_docker_io" class="nav navbar-nav navbar-collapse">
       <li>
         <a href="https://www.docker.io/" title="Docker IO Home">Home</a>
       </li>
@@ -25,10 +27,12 @@
       <li>
         <a href="https://index.docker.io" title="Docker Image Index, find images here">INDEX</a>
       </li>
-     </ul>
-   </div>
+    </ul>
+  </div>
 </div>
-<div id="horizontal_thin_menu" class="container">
-  <a href="https://www.docker.io/account/signup/">sign up</a>
-  <a href="https://www.docker.io/account/login/">login</a>
+<div id="horizontal_thin_menu" >
+  <div class="container container-standard-sized">
+      <a href="https://www.docker.io/account/signup/">sign up</a>
+      <a href="https://www.docker.io/account/login/">login</a>
+  </div>
 </div>


### PR DESCRIPTION
- updated image to use standard one
- added usage of cabin font
  ( Gave the main body and header a max-width of 1050. I'm going to make the docker.io navigation (but not body) also stretch to that width.

One of the things I still want to do is add a collapsing menu like on the blog to this when it is resized to under 900px.
