### PR TITLE
provide more information when TestTop tests fail

### DIFF
--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -18,14 +18,22 @@ func TestTopNonPrivileged(t *testing.T) {
 	out, _, err = runCommandWithOutput(topCmd)
 	errorOut(err, t, fmt.Sprintf("failed to run top: %v %v", out, err))
 
+	topCmd = exec.Command(dockerBinary, "top", cleanedContainerID)
+	out2, _, err2 := runCommandWithOutput(topCmd)
+	errorOut(err, t, fmt.Sprintf("failed to run top: %v %v", out2, err2))
+
 	killCmd := exec.Command(dockerBinary, "kill", cleanedContainerID)
 	_, err = runCommand(killCmd)
 	errorOut(err, t, fmt.Sprintf("failed to kill container: %v", err))
 
 	deleteContainer(cleanedContainerID)
 
-	if !strings.Contains(out, "sleep 20") {
-		t.Fatal("top should've listed sleep 20 in the process list")
+	if !strings.Contains(out, "sleep 20") && !strings.Contains(out2, "sleep 20") {
+		t.Fatal("top should've listed `sleep 20` in the process list, but failed twice")
+	} else if !strings.Contains(out, "sleep 20") {
+		t.Fatal("top should've listed `sleep 20` in the process list, but failed the first time")
+	} else if !strings.Contains(out2, "sleep 20") {
+		t.Fatal("top should've listed `sleep 20` in the process list, but failed the second itime")
 	}
 
 	logDone("top - sleep process should be listed in non privileged mode")
@@ -42,14 +50,22 @@ func TestTopPrivileged(t *testing.T) {
 	out, _, err = runCommandWithOutput(topCmd)
 	errorOut(err, t, fmt.Sprintf("failed to run top: %v %v", out, err))
 
+	topCmd = exec.Command(dockerBinary, "top", cleanedContainerID)
+	out2, _, err2 := runCommandWithOutput(topCmd)
+	errorOut(err, t, fmt.Sprintf("failed to run top: %v %v", out2, err2))
+
 	killCmd := exec.Command(dockerBinary, "kill", cleanedContainerID)
 	_, err = runCommand(killCmd)
 	errorOut(err, t, fmt.Sprintf("failed to kill container: %v", err))
 
 	deleteContainer(cleanedContainerID)
 
-	if !strings.Contains(out, "sleep 20") {
-		t.Fatal("top should've listed sleep 20 in the process list")
+	if !strings.Contains(out, "sleep 20") && !strings.Contains(out2, "sleep 20") {
+		t.Fatal("top should've listed `sleep 20` in the process list, but failed twice")
+	} else if !strings.Contains(out, "sleep 20") {
+		t.Fatal("top should've listed `sleep 20` in the process list, but failed the first time")
+	} else if !strings.Contains(out2, "sleep 20") {
+		t.Fatal("top should've listed `sleep 20` in the process list, but failed the second itime")
 	}
 
 	logDone("top - sleep process should be listed in privileged mode")


### PR DESCRIPTION
This PR makes the cli integration tests print more useful information when the TestTop tests fail.

```
--- FAIL: TestTopNonPrivileged (0.30 seconds)
        docker_cli_top_test.go:34: top should've listed `sleep 20` in the process list, but failed the first time
```
