### PR TITLE
make scratch a special case for build and pull

### DIFF
--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -32,6 +32,9 @@ the build succeeds:
 
 > `sudo docker build -t shykes/myapp .`
 
+"scratch" is the reserved name of a special empty image. This image is used when
+building new base images and it can't be used as a repository name.
+
 The Docker daemon will run your steps one-by-one, committing the result
 to a new image if necessary, before finally outputting the ID of your
 new image. The Docker daemon will automatically clean up the context you
@@ -112,6 +115,11 @@ command.
 If no `tag` is given to the `FROM`
 instruction, `latest` is assumed. If the
 used tag does not exist, an error will be returned.
+
+`FROM scratch` can be used to create new base images from scratch. "scratch"
+is a reserved name which makes Docker instantiate an embedded empty layer.
+This empty embedded layer is standard across registries and is never pulled by
+Docker.
 
 ## `MAINTAINER`
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -209,6 +209,10 @@ temporary directory on your local host, and then this is sent to the
 Docker daemon as the context. This way, your local user credentials and
 vpn’s etc can be used to access private repositories
 
+> **Note:**
+> "scratch" is a special reserved empty image name to be used when building new base images and
+> using it as a repository name isn't allowed.
+
 See also
 
 [*Dockerfile Reference*](../../builder/#dockerbuilder).
@@ -296,6 +300,10 @@ new image. This allows you debug a container by running an interactive
 shell, or to export a working dataset to another server. Generally, it
 is better to use Dockerfiles to manage your images in a documented and
 maintainable way.
+
+> **Note:**
+> "scratch" is a special reserved empty image name to be used when building new base images and
+> using it as a repository name isn't allowed.
 
 ### Commit an existing container
 
@@ -480,6 +488,10 @@ file archive (.tar, .tar.gz, .tgz, .bzip, .tar.xz, or .txz) containing a
 root filesystem. If you would like to import from a local directory or
 archive, you can use the `-` parameter to take the
 data from *stdin*.
+
+> **Note:**
+> "scratch" is a special reserved empty image name to be used when building new base images and
+> using it as a repository name isn't allowed.
 
 ### Examples
 
@@ -700,6 +712,10 @@ Most of your images will be created on top of a base image from the
 The Docker Index contains many pre-built images that you can
 `pull` and try without needing to define and
 configure your own.
+
+> **Note:**
+> "scratch" is a special reserved empty image name to be used when building new base images and
+> using it as a repository name isn't allowed.
 
 To download a particular image, or set of images (i.e., a repository),
 use `docker pull`:
@@ -1143,6 +1159,10 @@ grace period, SIGKILL
 You can group your images together using names and tags, and then upload
 them to [*Share Images via
 Repositories*](../../../use/workingwithrepository/#working-with-the-repository).
+
+> **Note:**
+> "scratch" is a special reserved empty image name to be used when building new base images and
+> using it as a repository name isn't allowed.
 
 ## `top`
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -75,6 +75,9 @@ func validateRepositoryName(repositoryName string) error {
 		namespace string
 		name      string
 	)
+	if repositoryName == "scratch" {
+		return fmt.Errorf("scratch is a reserved repository name and it may not be used")
+	}
 	nameParts := strings.SplitN(repositoryName, "/", 2)
 	if len(nameParts) < 2 {
 		namespace = "library"

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -217,4 +217,8 @@ func TestValidRepositoryName(t *testing.T) {
 		t.Log("Repository name should be invalid")
 		t.Fail()
 	}
+	if err := validateRepositoryName("scratch"); err == nil {
+		t.Log("Repository name `scratch` should be invalid")
+		t.Fail()
+	}
 }


### PR DESCRIPTION
This PR makes `from scratch` a special case for `docker build` and it makes Docker not pull the image with the scratch ID. `scratch` is handled in `docker build` as well because this avoids triggering any pull code.

In both cases, it will just create an empty image with the same ID if it doesn't exist already.

This PR doesn't change push because the image which has scratch's ID won't get pulled from the registry.

Fixes #4242
