### PR TITLE
Fix borken /dev/fd in mkimage-arch.sh

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -57,6 +57,7 @@ mknod -m 666 $DEV/tty0 c 4 0
 mknod -m 666 $DEV/full c 1 7
 mknod -m 600 $DEV/initctl p
 mknod -m 666 $DEV/ptmx c 5 2
+ln -sf /proc/self/fd $DEV/fd
 
 tar --numeric-owner -C $ROOTFS -c . | docker import - archlinux
 docker run -i -t archlinux echo Success.


### PR DESCRIPTION
Exactly the same problem as dotcloud/docker#2356
