### PR TITLE
Freeze server/server.go for deprecation

### DIFF
--- a/server/MAINTAINERS
+++ b/server/MAINTAINERS
@@ -1,0 +1,1 @@
+Solomon Hykes <solomon@docker.com>

--- a/server/server.go
+++ b/server/server.go
@@ -1,3 +1,24 @@
+// DEPRECATION NOTICE. PLEASE DO NOT ADD ANYTHING TO THIS FILE.
+//
+// server/server.go is deprecated. We are working on breaking it up into smaller, cleaner
+// pieces which will be easier to find and test. This will help make the code less
+// redundant and more readable.
+//
+// Contributors, please don't add anything to server/server.go, unless it has the explicit
+// goal of helping the deprecation effort.
+//
+// Maintainers, please refuse patches which add code to server/server.go.
+//
+// Instead try the following files:
+// * For code related to local image management, try graph/
+// * For code related to image downloading, uploading, remote search etc, try registry/
+// * For code related to the docker daemon, try daemon/
+// * For small utilities which could potentially be useful outside of Docker, try pkg/
+// * For miscalleneous "util" functions which are docker-specific, try encapsulating them
+//     inside one of the subsystems above. If you really think they should be more widely
+//     available, are you sure you can't remove the docker dependencies and move them to
+//     pkg? In last resort, you can add them to utils/ (but please try not to).
+
 package server
 
 import (


### PR DESCRIPTION
- Add notice in server/server.go explaining not to add stuff there, and
  what to do instead.
- Make myself a sole maintainer of server/ to avoid concurrent edits
  while refactoring.

Docker-DCO-1.1-Signed-off-by: Solomon Hykes solomon@docker.com (github: shykes)
