### PR TITLE
container: Remove Ghost state

### DIFF
--- a/daemon/state.go
+++ b/daemon/state.go
@@ -14,7 +14,6 @@ type State struct {
 	ExitCode   int
 	StartedAt  time.Time
 	FinishedAt time.Time
-	Ghost      bool
 }
 
 // String returns a human-readable description of the state
@@ -23,9 +22,6 @@ func (s *State) String() string {
 	defer s.RUnlock()
 
 	if s.Running {
-		if s.Ghost {
-			return fmt.Sprintf("Ghost")
-		}
 		return fmt.Sprintf("Up %s", utils.HumanDuration(time.Now().UTC().Sub(s.StartedAt)))
 	}
 	if s.FinishedAt.IsZero() {
@@ -41,13 +37,6 @@ func (s *State) IsRunning() bool {
 	return s.Running
 }
 
-func (s *State) IsGhost() bool {
-	s.RLock()
-	defer s.RUnlock()
-
-	return s.Ghost
-}
-
 func (s *State) GetExitCode() int {
 	s.RLock()
 	defer s.RUnlock()
@@ -55,19 +44,11 @@ func (s *State) GetExitCode() int {
 	return s.ExitCode
 }
 
-func (s *State) SetGhost(val bool) {
-	s.Lock()
-	defer s.Unlock()
-
-	s.Ghost = val
-}
-
 func (s *State) SetRunning(pid int) {
 	s.Lock()
 	defer s.Unlock()
 
 	s.Running = true
-	s.Ghost = false
 	s.ExitCode = 0
 	s.Pid = pid
 	s.StartedAt = time.Now().UTC()


### PR DESCRIPTION
container.Register() checks both IsRunning() and IsGhost(), but at
this point IsGhost() is always true if IsRunning() is true. For a
newly created container both are false, and for a restored-from-disk
container Daemon.load() sets Ghost to true if IsRunning is true. So we
just drop the IsGhost check.

This was the last call to IsGhost, so we remove It and all other
traces of the ghost state.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
