### PR TITLE
Add ability to customize volumes-from which get pulled in.

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1039,13 +1039,21 @@ optionally suffixed with `:ro` or `:rw` to mount the volumes in read-only
 or read-write mode, respectively. By default, the volumes are mounted in
 the same mode (read write or read only) as the reference container.
 
+To mount a single volume from a container instead of all volumes, suffix the
+container ID with the volume path desired. Optionally add a custom mount point in
+container. In the below example the `/foo` volume will be mounted into `/bar` in
+the new container. To mount multiple volumes but not all, use `--volumes-from`
+multiple times with the individual volumes needed.
+
+    $ sudo docker run --volumes-from 777f7dc92da7:/foo:/bar -i -t ubuntu pwd
+
 The `-a` flag tells `docker run` to bind to the container's stdin, stdout or
 stderr. This makes it possible to manipulate the output and input as needed.
 
     $ echo "test" | sudo docker run -i -a stdin ubuntu cat -
 
 This pipes data into a container and prints the container's ID by attaching
-only to the container'sstdin.
+only to the container's stdin.
 
     $ sudo docker run -a stderr ubuntu echo test
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -407,6 +407,43 @@ func TestMultipleVolumesFrom(t *testing.T) {
 	logDone("run - multiple volumes from")
 }
 
+func TestCustomVolumesFromSelectIndividualVolume(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "--name", "parent1", "-v", "/test", "-v", "/foo", "busybox", "touch", "/test/stuff")
+	if _, err := runCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--volumes-from", "parent1:/test", "busybox", "cat", "/test/stuff")
+	if _, err := runCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--volumes-from", "parent1:/test", "busybox", "touch", "/foo/foo")
+	if _, err := runCommand(cmd); err == nil {
+		t.Fatal("Expected /foo to not exist, but it does")
+	}
+
+	deleteAllContainers()
+
+	logDone("run - mount volumes from individually")
+}
+
+func TestCustomVolumesFromCustomMountPoint(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "--name", "parent1", "-v", "/test", "busybox", "touch", "/test/stuff")
+	if _, err := runCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--volumes-from", "parent1:/test:/foo", "busybox", "cat", "/foo/stuff")
+	if _, err := runCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	deleteAllContainers()
+
+	logDone("run - mount volumes from to custom mount point")
+}
+
 // this tests verifies the ID format for the container
 func TestVerifyContainerID(t *testing.T) {
 	cmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")


### PR DESCRIPTION
This includes supporting:
  "--volumes-from foo:/some/vol" - which only pulls in "/some/vol"
  instead of all volumes

  "--volumes-from foo:/some/vol:/my/vol" - Provides a custom mount point
  for the pulled in volume

  the :ro :rw options still work and would get tacked onto the end in
  all cases
  This does not break any existing behavior or syntax.

Docker-DCO-1.1-Signed-off-by: Brian Goff cpuguy83@gmail.com (github: cpuguy83)
