### PR TITLE
Docs conditional beta warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ build: bundles
 	docker build -t "$(DOCKER_IMAGE)" .
 
 docs-build:
+	cp ./VERSION docs/VERSION
+	echo "$(GIT_BRANCH)" > docs/GIT_BRANCH
+	echo "$(AWS_S3_BUCKET)" > docs/AWS_S3_BUCKET
 	docker build -t "$(DOCKER_DOCS_IMAGE)" docs
 
 bundles:

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -39,6 +39,11 @@ WORKDIR	/docs
 #convert to markdown
 #RUN	./convert.sh
 
+RUN	VERSION=$(cat /docs/VERSION)								&&\
+	GIT_BRANCH=$(cat /docs/GIT_BRANCH)							&&\
+	AWS_S3_BUCKET=$(cat /docs/AWS_S3_BUCKET)						&&\
+	echo "{% set docker_version = \"${VERSION}\" %}{% set docker_branch = \"${GIT_BRANCH}\" %}{% set aws_bucket = \"${AWS_S3_BUCKET}\" %}{% include \"beta_warning.html\" %}" > /docs/theme/mkdocs/version.html
+
 # note, EXPOSE is only last because of https://github.com/dotcloud/docker/issues/3525
 EXPOSE	8000
 

--- a/docs/theme/mkdocs/base.html
+++ b/docs/theme/mkdocs/base.html
@@ -48,7 +48,7 @@
             <div class="col-sm-8" role="main">
               {% include "breadcrumbs.html" %}
               <main id="content" role="main">
-                {% include "beta_warning.html" %}
+		{% include "version.html" %}
                 {{ content }}
               </main>
             </div>

--- a/docs/theme/mkdocs/base.html
+++ b/docs/theme/mkdocs/base.html
@@ -48,6 +48,7 @@
             <div class="col-sm-8" role="main">
               {% include "breadcrumbs.html" %}
               <main id="content" role="main">
+                {% include "beta_warning.html" %}
                 {{ content }}
               </main>
             </div>

--- a/docs/theme/mkdocs/beta_warning.html
+++ b/docs/theme/mkdocs/beta_warning.html
@@ -1,3 +1,4 @@
+{% if aws_bucket != "docs.docker.io" %}
 <style>
 .bs-callout {
   padding: 20px;
@@ -22,6 +23,10 @@
 }
 </style>
 <div class="bs-callout bs-callout-danger">
-<h4>You are looking at the <span>beta</span> docs for the development version of Docker.</h4>
-There is a chance of them being different from the prior versions.
+	<h4>This is the
+		<span>{% if docker_version != docker_version|replace("-dev", "bingo") %}{{ docker_branch }} development branch{% else %}beta{% endif %}</span>
+		documentation for Docker version {{ docker_version }}.</h4>
+	Please go to <a href="http://docs.docker.io">http://docs.docker.io</a> for the current Docker release documentation.
+	{{ aws_bucket }}
 </div>
+{% endif %}

--- a/docs/theme/mkdocs/beta_warning.html
+++ b/docs/theme/mkdocs/beta_warning.html
@@ -1,0 +1,27 @@
+<style>
+.bs-callout {
+  padding: 20px;
+  border-left: 3px solid rgb(238, 238, 238);
+  width: 100% !important;
+}
+.bs-callout p {
+  margin-bottom: 0 !important;
+}
+.bs-callout h4 span {
+  font-style: italic;
+  font-weight: bold;
+}
+.bs-callout-danger {
+  background-color: rgb(253, 247, 247);
+  border-color: rgb(217, 83, 79);
+}
+.bs-callout h4 {
+  margin-top: 0;
+  margin-bottom: 5px;
+  color: rgb(217, 83, 79);
+}
+</style>
+<div class="bs-callout bs-callout-danger">
+<h4>You are looking at the <span>beta</span> docs for the development version of Docker.</h4>
+There is a chance of them being different from the prior versions.
+</div>


### PR DESCRIPTION
make the non-release doc warning conditional and add version info …
use the beta-warning area to tell the user what VERSION of docker, git
branch, and links to the official release version docs are.

requires / extends /subsumes PR #5272
