### PR TITLE
cgroups: Update systemd to match fs backend

### DIFF
--- a/daemon/execdriver/native/configuration/parse.go
+++ b/daemon/execdriver/native/configuration/parse.go
@@ -27,6 +27,8 @@ var actions = map[string]Action{
 	"cgroups.memory_swap":        memorySwap,        // set the memory swap limit
 	"cgroups.cpuset.cpus":        cpusetCpus,        // set the cpus used
 
+	"systemd.slice": systemdSlice, // set parent Slice used for systemd unit
+
 	"apparmor_profile": apparmorProfile, // set the apparmor profile to apply
 
 	"fs.readonly": readonlyFs, // make the rootfs of the container read only
@@ -37,6 +39,15 @@ func cpusetCpus(container *libcontainer.Container, context interface{}, value st
 		return fmt.Errorf("cannot set cgroups when they are disabled")
 	}
 	container.Cgroups.CpusetCpus = value
+
+	return nil
+}
+
+func systemdSlice(container *libcontainer.Container, context interface{}, value string) error {
+	if container.Cgroups == nil {
+		return fmt.Errorf("cannot set slice when cgroups are disabled")
+	}
+	container.Cgroups.Slice = value
 
 	return nil
 }

--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -22,7 +22,7 @@ type Cgroup struct {
 	CpusetCpus        string `json:"cpuset_cpus,omitempty"`        // CPU to use
 	Freezer           string `json:"freezer,omitempty"`            // set the freeze value for the process
 
-	UnitProperties [][2]string `json:"unit_properties,omitempty"` // systemd unit properties
+	Slice string `json:"slice,omitempty"` // Parent slice to use for systemd
 }
 
 type ActiveCgroup interface {

--- a/pkg/cgroups/systemd/apply_nosystemd.go
+++ b/pkg/cgroups/systemd/apply_nosystemd.go
@@ -11,6 +11,6 @@ func UseSystemd() bool {
 	return false
 }
 
-func systemdApply(c *Cgroup, pid int) (cgroups.ActiveCgroup, error) {
+func Apply(c *Cgroup, pid int) (cgroups.ActiveCgroup, error) {
 	return nil, fmt.Errorf("Systemd not supported")
 }


### PR DESCRIPTION
This updates systemd.Apply to match the fs backend by:
- Always join blockio controller (for stats)
- Support CpusetCpus
- Support MemorySwap

Also, it removes the generic UnitProperties in favour of a single
option to set the slice.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
