### PR TITLE
Add exported status code from a job

### DIFF
--- a/engine/job.go
+++ b/engine/job.go
@@ -208,3 +208,7 @@ func (job *Job) Error(err error) Status {
 	fmt.Fprintf(job.Stderr, "%s\n", err)
 	return StatusErr
 }
+
+func (job *Job) StatusCode() int {
+	return int(job.status)
+}


### PR DESCRIPTION
This allows the job's status code to be consumed externally so that we
can use it as an exit code or saving to a state file.
Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
