### PR TITLE
Add generic /cmd entrypoint w/ cli support

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -38,6 +38,12 @@ func (cli *DockerCli) ParseCommands(args ...string) error {
 	if len(args) > 0 {
 		method, exists := cli.getMethod(args[0])
 		if !exists {
+			// Look for generic methods of form "plugin:operation"
+			op := strings.SplitN(args[0], ":", 2)
+			if len(op) == 2 {
+				return cli.GenericCmd(op[0], op[1], args[1:]...)
+			}
+
 			fmt.Println("Error: Command not found:", args[0])
 			return cli.CmdHelp(args[1:]...)
 		}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -118,6 +118,36 @@ func getBoolParam(value string) (bool, error) {
 	return ret, nil
 }
 
+func getCmdOperation(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if vars == nil {
+		return fmt.Errorf("Missing parameter")
+	}
+	if err := parseForm(r); err != nil {
+		return err
+	}
+
+	jobname := vars["plugin"] + ":" + vars["operation"]
+
+	var args []string
+
+	if v, ok := r.Form["args"]; ok {
+		args = v
+	}
+
+	job := eng.Job(jobname, args...)
+
+	for key, value := range r.Form {
+		if key != "args" {
+			job.Setenv(key, value[0])
+		}
+	}
+	if err := job.Run(); err != nil {
+		return err
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
 func postAuth(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	var (
 		authConfig, err = ioutil.ReadAll(r.Body)
@@ -1067,6 +1097,7 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 			"/containers/{name:.*}/top":       getContainersTop,
 			"/containers/{name:.*}/logs":      getContainersLogs,
 			"/containers/{name:.*}/attach/ws": wsContainersAttach,
+			"/cmd/{plugin:.*}/{operation:.*}": getCmdOperation,
 		},
 		"POST": {
 			"/auth":                         postAuth,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -893,6 +893,11 @@ func NewDaemonFromDirectory(config *daemonconfig.Config, eng *engine.Engine) (*D
 	if err := daemon.restore(); err != nil {
 		return nil, err
 	}
+
+	if installer, ok := daemon.driver.(engine.Installer); ok {
+		installer.Install(eng)
+	}
+
 	return daemon, nil
 }
 

--- a/engine/hack.go
+++ b/engine/hack.go
@@ -3,6 +3,9 @@ package engine
 type Hack map[string]interface{}
 
 func (eng *Engine) Hack_GetGlobalVar(key string) interface{} {
+	eng.RLock()
+	defer eng.RUnlock()
+
 	if eng.hack == nil {
 		return nil
 	}
@@ -14,6 +17,9 @@ func (eng *Engine) Hack_GetGlobalVar(key string) interface{} {
 }
 
 func (eng *Engine) Hack_SetGlobalVar(key string, val interface{}) {
+	eng.Lock()
+	defer eng.Unlock()
+
 	if eng.hack == nil {
 		eng.hack = make(Hack)
 	}


### PR DESCRIPTION
If you do

```
   docker devmapper:resize -o Key=Value -o Foo=Bar plugin:op arg1 arg2
```

This will do a GET http request to /cmd/devmapper/resize with the arguments and options as keys. This will then try to spawn a job on the engine called "devmapper:resize" with the arg1, arg2, etc as arguments and the -o options as environment.

Also, any graph driver implementing the engine.Installer interface  will get installed on the engine when the daemon is created.

This will be used by e.g. the devicemapper to allow driver-specific  operations like pool resizing.

This PR is a break out from https://github.com/dotcloud/docker/pull/4202, see comment there for the design input for this PR.
