### PR TITLE
Add support for cpu hardcapping to cgroups.

### DIFF
--- a/pkg/cgroups/cgroups.go
+++ b/pkg/cgroups/cgroups.go
@@ -16,6 +16,8 @@ type Cgroup struct {
 	Memory       int64  `json:"memory,omitempty"`        // Memory limit (in bytes)
 	MemorySwap   int64  `json:"memory_swap,omitempty"`   // Total memory usage (memory + swap); set `-1' to disable swap
 	CpuShares    int64  `json:"cpu_shares,omitempty"`    // CPU shares (relative weight vs. other containers)
+	CpuQuota     int64  `json:"cpu_quota,omitempty"`     // CPU hardcap limit (in usecs). Allowed cpu time in a given period.
+	CpuPeriod    int64  `json:"cpu_period,omitempty"`    // CPU period to be used for hardcapping (in usecs). 0 to use system default.
 	CpusetCpus   string `json:"cpuset_cpus,omitempty"`   // CPU to use
 
 	UnitProperties [][2]string `json:"unit_properties,omitempty"` // systemd unit properties

--- a/pkg/cgroups/fs/cpu.go
+++ b/pkg/cgroups/fs/cpu.go
@@ -19,6 +19,16 @@ func (s *cpuGroup) Set(d *data) error {
 			return err
 		}
 	}
+	if d.c.CpuPeriod != 0 {
+		if err := writeFile(dir, "cpu.cfs_period_us", strconv.FormatInt(d.c.CpuPeriod, 10)); err != nil {
+			return err
+		}
+	}
+	if d.c.CpuQuota != 0 {
+		if err := writeFile(dir, "cpu.cfs_quota_us", strconv.FormatInt(d.c.CpuQuota, 10)); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Initial support for adding cpu hardcapping to cgroups. This PR just changes the cgroups library and adds the ability to set both period and quota for throttling cpu usage.

For exposing the feature to users, we can add a single knob - CpuHardcapLimit - instead of quota and period cgroup internals. A limit of 1.5 would hardcap the container to 1.5 cpu worth of usage over all available cpus (or 1500 milli-cpus if you don't like floats). We can use a default period of 100ms (default on most images). Maybe add a flag to configure default period.

Docker-DCO-1.1-Signed-off-by: Rohit Jnagal jnagal@google.com (github: rjnagal)
