### PR TITLE
Fix pkg/graphdb build for darwin/amd64

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,6 +44,7 @@ Brian Olsen <brian@maven-group.org>
 Brian Shumate <brian@couchbase.com>
 Briehan Lombaard <briehan.lombaard@gmail.com>
 Bruno Bigras <bigras.bruno@gmail.com>
+Bryan Matsuo <bryan.matsuo@gmail.com>
 Caleb Spare <cespare@gmail.com>
 Calen Pennington <cale@edx.org>
 Carl X. Su <bcbcarl@gmail.com>

--- a/pkg/graphdb/conn_sqlite3.go
+++ b/pkg/graphdb/conn_sqlite3.go
@@ -1,4 +1,4 @@
-// +build linux,amd64 freebsd,cgo
+// +build cgo
 
 package graphdb
 

--- a/pkg/graphdb/conn_unsupported.go
+++ b/pkg/graphdb/conn_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!freebsd linux,!amd64 freebsd,!cgo
+// +build !cgo
 
 package graphdb
 


### PR DESCRIPTION
Fixes #5398 by adjusting the build constraints.

I just followed suit with the build constraints that were already defined, allowing `conn_sqlite3.go` to be built on darwin/amd64.
