### PR TITLE
Make devicemapper backend able to support multiple processes

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -588,7 +588,7 @@ func (devices *DeviceSet) AddDevice(hash, baseHash string) error {
 
 	deviceId := devices.allocateDeviceId()
 
-	if err := devices.createSnapDevice(devices.getPoolDevName(), deviceId, baseInfo.Name(), baseInfo.DeviceId); err != nil {
+	if err := createSnapDevice(devices.getPoolDevName(), deviceId, baseInfo.Name(), baseInfo.DeviceId); err != nil {
 		utils.Debugf("Error creating snap device: %s\n", err)
 		return err
 	}

--- a/daemon/graphdriver/devmapper/devmapper.go
+++ b/daemon/graphdriver/devmapper/devmapper.go
@@ -546,7 +546,7 @@ func activateDevice(poolName string, name string, deviceId int, size uint64) err
 	return nil
 }
 
-func (devices *DeviceSet) createSnapDevice(poolName string, deviceId int, baseName string, baseDeviceId int) error {
+func createSnapDevice(poolName string, deviceId int, baseName string, baseDeviceId int) error {
 	devinfo, _ := getInfo(baseName)
 	doSuspend := devinfo != nil && devinfo.Exists != 0
 

--- a/daemon/graphdriver/devmapper/devmapper.go
+++ b/daemon/graphdriver/devmapper/devmapper.go
@@ -62,6 +62,9 @@ var (
 	ErrInvalidAddNode         = errors.New("Invalide AddNoce type")
 	ErrGetLoopbackBackingFile = errors.New("Unable to get loopback backing file")
 	ErrLoopbackSetCapacity    = errors.New("Unable set loopback capacity")
+	ErrBusy                   = errors.New("Device is Busy")
+
+	dmSawBusy bool
 )
 
 type (
@@ -512,7 +515,11 @@ func removeDevice(name string) error {
 	if task == nil {
 		return err
 	}
+	dmSawBusy = false
 	if err = task.Run(); err != nil {
+		if dmSawBusy {
+			return ErrBusy
+		}
 		return fmt.Errorf("Error running removeDevice")
 	}
 	return nil

--- a/daemon/graphdriver/devmapper/devmapper_log.go
+++ b/daemon/graphdriver/devmapper/devmapper_log.go
@@ -4,12 +4,23 @@ package devmapper
 
 import "C"
 
+import (
+	"strings"
+)
+
 // Due to the way cgo works this has to be in a separate file, as devmapper.go has
 // definitions in the cgo block, which is incompatible with using "//export"
 
 //export DevmapperLogCallback
 func DevmapperLogCallback(level C.int, file *C.char, line C.int, dm_errno_or_class C.int, message *C.char) {
+	msg := C.GoString(message)
+	if level < 7 {
+		if strings.Contains(msg, "busy") {
+			dmSawBusy = true
+		}
+	}
+
 	if dmLogger != nil {
-		dmLogger.log(int(level), C.GoString(file), int(line), int(dm_errno_or_class), C.GoString(message))
+		dmLogger.log(int(level), C.GoString(file), int(line), int(dm_errno_or_class), msg)
 	}
 }

--- a/daemon/graphdriver/devmapper/devmapper_log.go
+++ b/daemon/graphdriver/devmapper/devmapper_log.go
@@ -18,6 +18,10 @@ func DevmapperLogCallback(level C.int, file *C.char, line C.int, dm_errno_or_cla
 		if strings.Contains(msg, "busy") {
 			dmSawBusy = true
 		}
+
+		if strings.Contains(msg, "File exists") {
+			dmSawExist = true
+		}
 	}
 
 	if dmLogger != nil {

--- a/daemon/graphdriver/devmapper/driver_test.go
+++ b/daemon/graphdriver/devmapper/driver_test.go
@@ -820,10 +820,6 @@ func TestGetReturnsValidDevice(t *testing.T) {
 	if !d.HasActivatedDevice("1") {
 		t.Fatalf("Expected id 1 to be activated")
 	}
-
-	if !d.HasInitializedDevice("1") {
-		t.Fatalf("Expected id 1 to be initialized")
-	}
 }
 
 func TestDriverGetSize(t *testing.T) {


### PR DESCRIPTION
This changes a few aspects of the devicemapper backend.
First of all it changes the allocation of device-ids to rely on the kernel to atomically say whether a device create succeeded. If not we get EEXIST, and try another.
Secondly, it changes the storage of the metadata (basically the mapping from docker id to device id on the pool) to be stored in one file per device, rather than in one single file. Also these files are read lazily when accessed. 
Third, it ensures we're never setting up the devicemapper loopback stuff if the right poo device already works.

The code migrates the existing metadata format the first time its run, so it is backwards compatible. However
once you've upgraded its not really possible to go back to an earlier version.

These together should make it possible to use the Get/Put operations of the driver outside of the docker daemon, assuming that the daemon already created the container devices, and that the daemon initialized the pool first.

I believe this should be enough to allow all current backends to use Get/Put in a separate runtime process.
