### PR TITLE
Added back OAuth and Accounts API docs pages

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -106,6 +106,8 @@ pages:
 - ['reference/api/docker_remote_api_v1.10.md', 'Reference', 'Docker Remote API v1.10']
 - ['reference/api/docker_remote_api_v1.9.md', 'Reference', 'Docker Remote API v1.9']
 - ['reference/api/remote_api_client_libraries.md', 'Reference', 'Docker Remote API Client Libraries']
+- ['reference/api/docker_io_oauth_api.md', 'Reference', 'Docker IO OAuth API']
+- ['reference/api/docker_io_accounts_api.md', 'Reference', 'Docker IO Accounts API']
 
 # Contribute:
 - ['contributing/index.md', '**HIDDEN**']

--- a/docs/sources/index/accounts.md
+++ b/docs/sources/index/accounts.md
@@ -14,7 +14,7 @@ to need a [Docker IO](https://www.docker.io) account.
 ### Registration for a Docker IO Account
 
 You can get a Docker IO account by [signing up for one here](
-https://index.docker.io/account/signup/). A valid email address is required to
+https://www.docker.io/account/signup/). A valid email address is required to
 register, which you will need to verify for account activation.
 
 ### Email activation process
@@ -22,7 +22,7 @@ register, which you will need to verify for account activation.
 You need to have at least one verified email address to be able to use your
 Docker IO account. If you can't find the validation email, you can request
 another by visiting the [Resend Email Confirmation](
-https://index.docker.io/account/resend-email-confirmation/) page.
+https://www.docker.io/account/resend-email-confirmation/) page.
 
 ### Password reset process
 

--- a/docs/sources/reference/api/docker_io_accounts_api.md
+++ b/docs/sources/reference/api/docker_io_accounts_api.md
@@ -237,78 +237,7 @@ automatically sent.
             "primary": false
         }
 
-### 1.5 Update an email address for a user
-
-`PATCH /api/v1.1/users/:username/emails/`
-
-Update an email address for the specified user to either verify an
-email address or set it as the primary email for the user. You
-cannot use this endpoint to un-verify an email address. You cannot
-use this endpoint to unset the primary email, only set another as
-the primary.
-
-    Parameters:
-
-    -   **username** – username of the user whose email info is being
-        updated.
-
-    Json Parameters:
-
-     
-
-    -   **email** (*string*) – the email address to be updated.
-    -   **verified** (*boolean*) – (optional) whether the email address
-        is verified, must be `true` or absent.
-    -   **primary** (*boolean*) – (optional) whether to set the email
-        address as the primary email, must be `true`
-        or absent.
-
-    Request Headers:
-
-     
-
-    -   **Authorization** – required authentication credentials of
-        either type HTTP Basic or OAuth Bearer Token.
-    -   **Content-Type** – MIME Type of post data. JSON, url-encoded
-        form data, etc.
-
-    Status Codes:
-
-    -   **200** – success, user's email updated.
-    -   **400** – data validation error.
-    -   **401** – authentication error.
-    -   **403** – permission error, authenticated user must be the user
-        whose data is being updated, OAuth access tokens must have
-        `email_write` scope.
-    -   **404** – the specified username or email address does not
-        exist.
-
-    **Example request**:
-
-    Once you have independently verified an email address.
-
-        PATCH /api/v1.1/users/janedoe/emails/ HTTP/1.1
-        Host: www.docker.io
-        Accept: application/json
-        Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
-
-        {
-            "email": "jane.doe+other@example.com",
-            "verified": true,
-        }
-
-    **Example response**:
-
-        HTTP/1.1 200 OK
-        Content-Type: application/json
-
-        {
-            "email": "jane.doe+other@example.com",
-            "verified": true,
-            "primary": false
-        }
-
-### 1.6 Delete email address for a user
+### 1.5 Delete email address for a user
 
 `DELETE /api/v1.1/users/:username/emails/`
 


### PR DESCRIPTION
Removed a now unused endpoint from the accounts API.
Updated some of the accounts links to point to www.docker.io
as the account signup and resend-email-confirmation links should
no longer point to the index.

Docker-DCO-1.1-Signed-off-by: Josh Hawn josh.hawn@docker.com (github: jlhawn)
