### PR TITLE
reapply Cmd value even if CmdAdd returns early

### DIFF
--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -482,6 +482,7 @@ func (b *buildFile) CmdAdd(args string) error {
 
 	cmd := b.config.Cmd
 	b.config.Cmd = []string{"/bin/sh", "-c", fmt.Sprintf("#(nop) ADD %s in %s", orig, dest)}
+	defer func(cmd []string) { b.config.Cmd = cmd }(cmd)
 	b.config.Image = b.image
 
 	var (
@@ -617,7 +618,6 @@ func (b *buildFile) CmdAdd(args string) error {
 	if err := b.commit(container.ID, cmd, fmt.Sprintf("ADD %s in %s", orig, dest)); err != nil {
 		return err
 	}
-	b.config.Cmd = cmd
 	return nil
 }
 


### PR DESCRIPTION
Fixes #3762

If an image is built while using the cache and the file of an ADD directive is changed, the CmdAdd function returned early. This will result in an overwriten CMD value of the container, since the value is not reset to it's original value.

This was already handled correctly in the CmdRun and commit function with the same defer function.

Docker-DCO-1.1-Signed-off-by: Maximilian Goisser goisser94@gmail.com (github:
hobofan)
