### PR TITLE
Fix graph/tags_unit_test.go on FreeBSD

### DIFF
--- a/archive/diff.go
+++ b/archive/diff.go
@@ -58,7 +58,7 @@ func ApplyLayer(dest string, layer ArchiveReader) error {
 			parent := filepath.Dir(hdr.Name)
 			parentPath := filepath.Join(dest, parent)
 			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
-				err = os.MkdirAll(parentPath, 0600)
+				err = os.MkdirAll(parentPath, 0700)
 				if err != nil {
 					return err
 				}

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -19,11 +19,19 @@ const (
 )
 
 func fakeTar() (io.Reader, error) {
+	uid := os.Getuid()
+	gid := os.Getgid()
+
 	content := []byte("Hello world!\n")
 	buf := new(bytes.Buffer)
 	tw := tar.NewWriter(buf)
 	for _, name := range []string{"/etc/postgres/postgres.conf", "/etc/passwd", "/var/log/postgres/postgres.conf"} {
 		hdr := new(tar.Header)
+
+		// Leaving these fields blank requires root privileges
+		hdr.Uid = uid
+		hdr.Gid = gid
+
 		hdr.Size = int64(len(content))
 		hdr.Name = name
 		if err := tw.WriteHeader(hdr); err != nil {
@@ -53,8 +61,6 @@ func mkTestTagStore(root string, t *testing.T) *TagStore {
 		t.Fatal(err)
 	}
 	img := &image.Image{ID: testImageID}
-	// FIXME: this fails on Darwin with:
-	// tags_unit_test.go:36: mkdir /var/folders/7g/b3ydb5gx4t94ndr_cljffbt80000gq/T/docker-test569b-tRunner-075013689/vfs/dir/foo/etc/postgres: permission denied
 	if err := graph.Register(nil, archive, img); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
- Directories should have u+x (0600 -> 0700)
- Don't chown to root.root by default because it requires root privilege

Docker-DCO-1.1-Signed-off-by: Kato Kazuyoshi kato.kazuyoshi@gmail.com (github: kzys)
