### PR TITLE
Docs fix: correct /commit info

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Andrew Munsell <andrew@wizardapps.net>
 Andrews Medina <andrewsmedina@gmail.com>
 Andy Chambers <anchambers@paypal.com>
 andy diller <dillera@gmail.com>
+Andy Goldstein <agoldste@redhat.com>
 Andy Rothfusz <github@metaliveblog.com>
 Andy Smith <github@anarkystic.com>
 Anthony Bishopric <git@anthonybishopric.com>

--- a/docs/sources/reference/api/docker_remote_api_v1.10.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.10.md
@@ -131,7 +131,6 @@ Create a container
              "WorkingDir":"",
              "DisableNetwork": false,
              "ExposedPorts":{
-             "DisableNetwork": false,
                      "22/tcp": {}
              }
         }
@@ -1132,6 +1131,33 @@ Create a new image from a container's changes
     **Example request**:
 
         POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+        Content-Type: application/json
+
+        {
+             "Hostname":"",
+             "User":"",
+             "Memory":0,
+             "MemorySwap":0,
+             "AttachStdin":false,
+             "AttachStdout":true,
+             "AttachStderr":true,
+             "PortSpecs":null,
+             "Tty":false,
+             "OpenStdin":false,
+             "StdinOnce":false,
+             "Env":null,
+             "Cmd":[
+                     "date"
+             ],
+             "Volumes":{
+                     "/tmp": {}
+             },
+             "WorkingDir":"",
+             "DisableNetwork": false,
+             "ExposedPorts":{
+                     "22/tcp": {}
+             }
+        }
 
     **Example response**:
 
@@ -1139,6 +1165,13 @@ Create a new image from a container's changes
             Content-Type: application/vnd.docker.raw-stream
 
         {"Id":"596069db4bf5"}
+
+
+    Json Parameters:
+
+
+
+    -  **config** - the container's configuration
 
     Query Parameters:
 
@@ -1150,8 +1183,6 @@ Create a new image from a container's changes
     -   **m** – commit message
     -   **author** – author (eg. "John Hannibal Smith
         <[hannibal@a-team.com](mailto:hannibal%40a-team.com)>")
-    -   **run** – config automatically applied when the image is run.
-        (ex: {"Cmd": ["cat", "/world"], "PortSpecs":["22"]})
 
     Status Codes:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.11.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.11.md
@@ -1135,6 +1135,33 @@ Create a new image from a container's changes
     **Example request**:
 
         POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+        Content-Type: application/json
+
+        {
+             "Hostname":"",
+             "User":"",
+             "Memory":0,
+             "MemorySwap":0,
+             "AttachStdin":false,
+             "AttachStdout":true,
+             "AttachStderr":true,
+             "PortSpecs":null,
+             "Tty":false,
+             "OpenStdin":false,
+             "StdinOnce":false,
+             "Env":null,
+             "Cmd":[
+                     "date"
+             ],
+             "Volumes":{
+                     "/tmp": {}
+             },
+             "WorkingDir":"",
+             "DisableNetwork": false,
+             "ExposedPorts":{
+                     "22/tcp": {}
+             }
+        }
 
     **Example response**:
 
@@ -1142,6 +1169,12 @@ Create a new image from a container's changes
             Content-Type: application/vnd.docker.raw-stream
 
         {"Id":"596069db4bf5"}
+
+    Json Parameters:
+
+
+
+    -  **config** - the container's configuration
 
     Query Parameters:
 
@@ -1153,8 +1186,6 @@ Create a new image from a container's changes
     -   **m** – commit message
     -   **author** – author (eg. "John Hannibal Smith
         <[hannibal@a-team.com](mailto:hannibal%40a-team.com)>")
-    -   **run** – config automatically applied when the image is run.
-        (ex: {"Cmd": ["cat", "/world"], "PortSpecs":["22"]})
 
     Status Codes:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.9.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.9.md
@@ -1146,6 +1146,33 @@ Create a new image from a container's changes
     **Example request**:
 
         POST /commit?container=44c004db4b17&m=message&repo=myrepo HTTP/1.1
+        Content-Type: application/json
+
+        {
+             "Hostname":"",
+             "User":"",
+             "Memory":0,
+             "MemorySwap":0,
+             "AttachStdin":false,
+             "AttachStdout":true,
+             "AttachStderr":true,
+             "PortSpecs":null,
+             "Tty":false,
+             "OpenStdin":false,
+             "StdinOnce":false,
+             "Env":null,
+             "Cmd":[
+                     "date"
+             ],
+             "Volumes":{
+                     "/tmp": {}
+             },
+             "WorkingDir":"",
+             "DisableNetwork": false,
+             "ExposedPorts":{
+                     "22/tcp": {}
+             }
+        }
 
     **Example response**:
 
@@ -1153,6 +1180,12 @@ Create a new image from a container's changes
             Content-Type: application/vnd.docker.raw-stream
 
         {"Id":"596069db4bf5"}
+
+    Json Parameters:
+
+
+
+    -  **config** - the container's configuration
 
     Query Parameters:
 
@@ -1164,8 +1197,6 @@ Create a new image from a container's changes
     -   **m** – commit message
     -   **author** – author (eg. "John Hannibal Smith
         <[hannibal@a-team.com](mailto:hannibal%40a-team.com)>")
-    -   **run** – config automatically applied when the image is run.
-        (ex: {"Cmd": ["cat", "/world"], "PortSpecs":["22"]})
 
     Status Codes:
 


### PR DESCRIPTION
Correct documentation for POST /commit to reflect that the container's
configuration is supplied in the request body, and not as a query
parameter.

Also correct a small typo in the example JSON for create container.

Docker-DCO-1.1-Signed-off-by: Andy Goldstein agoldste@redhat.com (github: ncdc)
