### PR TITLE
Remove "root" and "" special cases in libcontainer

### DIFF
--- a/pkg/libcontainer/nsinit/init.go
+++ b/pkg/libcontainer/nsinit/init.go
@@ -83,31 +83,18 @@ func (ns *linuxNs) Init(container *libcontainer.Container, uncleanRootfs, consol
 }
 
 func setupUser(container *libcontainer.Container) error {
-	switch container.User {
-	case "root", "":
-		if err := system.Setgroups(nil); err != nil {
-			return err
-		}
-		if err := system.Setresgid(0, 0, 0); err != nil {
-			return err
-		}
-		if err := system.Setresuid(0, 0, 0); err != nil {
-			return err
-		}
-	default:
-		uid, gid, suppGids, err := user.GetUserGroupSupplementary(container.User, syscall.Getuid(), syscall.Getgid())
-		if err != nil {
-			return err
-		}
-		if err := system.Setgroups(suppGids); err != nil {
-			return err
-		}
-		if err := system.Setgid(gid); err != nil {
-			return err
-		}
-		if err := system.Setuid(uid); err != nil {
-			return err
-		}
+	uid, gid, suppGids, err := user.GetUserGroupSupplementary(container.User, syscall.Getuid(), syscall.Getgid())
+	if err != nil {
+		return fmt.Errorf("GetUserGroupSupplementary %s", err)
+	}
+	if err := system.Setgroups(suppGids); err != nil {
+		return fmt.Errorf("setgroups %s", err)
+	}
+	if err := system.Setgid(gid); err != nil {
+		return fmt.Errorf("setgid %s", err)
+	}
+	if err := system.Setuid(uid); err != nil {
+		return fmt.Errorf("setuid %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
These are unnecessary since the user package handles these cases properly already (as evidenced by the LXC backend not having these special cases).

I also updated the errors returned to match the other libcontainer error messages in this same file.

Also, switching from Setresuid to Setuid directly isn't a problem, because the "setuid" system call will automatically do that if our own effective UID is root currently: (from `man 2 setuid`)

```
setuid() sets the effective user ID of the calling process.  If the
effective UID of the caller is root, the real UID and saved set-user-
ID are also set.
```
