### PR TITLE
Update the "cgroup-lite" dep in our deb package from "Suggests" to "Recommends" and add "cgroupfs-mount" as another alternative

### DIFF
--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -135,7 +135,7 @@ EOF
 			--deb-recommends ca-certificates \
 			--deb-recommends git \
 			--deb-recommends xz-utils \
-			--deb-suggests cgroup-lite \
+			--deb-recommends 'cgroupfs-mount | cgroup-lite' \
 			--description "$PACKAGE_DESCRIPTION" \
 			--maintainer "$PACKAGE_MAINTAINER" \
 			--conflicts docker \


### PR DESCRIPTION
I tested to verify that if neither package is available (for example, on Debian Wheezy), apt still continues installing properly.
