### PR TITLE
Use "docker load" to create "scratch" in hack/make/test-integration-cli (instead of implicitly pulling it from the index)

### DIFF
--- a/hack/make/.ensure-busybox
+++ b/hack/make/.ensure-busybox
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if ! docker inspect busybox &> /dev/null; then
+	if [ -d /docker-busybox ]; then
+		source "$(dirname "$BASH_SOURCE")/.ensure-scratch"
+		( set -x; docker build -t busybox /docker-busybox )
+	else
+		( set -x; docker pull busybox )
+	fi
+fi

--- a/hack/make/.ensure-scratch
+++ b/hack/make/.ensure-scratch
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if ! docker inspect scratch &> /dev/null; then
+	# let's build a "docker save" tarball for "scratch"
+	# see https://github.com/dotcloud/docker/pull/5262
+	# and also https://github.com/dotcloud/docker/issues/4242
+	mkdir -p /docker-scratch
+	(
+		cd /docker-scratch
+		echo '{"scratch":{"latest":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158"}}' > repositories
+		mkdir -p 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158
+		(
+			cd 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158
+			echo '{"id":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158","comment":"Imported from -","created":"2013-06-13T14:03:50.821769-07:00","container_config":{"Hostname":"","Domainname":"","User":"","Memory":0,"MemorySwap":0,"CpuShares":0,"AttachStdin":false,"AttachStdout":false,"AttachStderr":false,"PortSpecs":null,"ExposedPorts":null,"Tty":false,"OpenStdin":false,"StdinOnce":false,"Env":null,"Cmd":null,"Image":"","Volumes":null,"WorkingDir":"","Entrypoint":null,"NetworkDisabled":false,"OnBuild":null},"docker_version":"0.4.0","architecture":"x86_64","Size":0}' > json
+			echo '1.0' > VERSION
+			tar -cf layer.tar --files-from /dev/null
+		)
+	)
+	( set -x; tar -cf /docker-scratch.tar -C /docker-scratch . )
+	( set -x; docker load --input /docker-scratch.tar )
+fi

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -30,13 +30,7 @@ bundle_test_integration_cli() {
 	# pull the busybox image before running the tests
 	sleep 2
 
-	if ! docker inspect busybox &> /dev/null; then
-		if [ -d /docker-busybox ]; then
-			( set -x; docker build -t busybox /docker-busybox )
-		else
-			( set -x; docker pull busybox )
-		fi
-	fi
+	source "$(dirname "$BASH_SOURCE")/.ensure-busybox"
 
 	bundle_test_integration_cli
 

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -13,12 +13,12 @@ bundle_test_integration_cli() {
 # subshell so that we can export PATH without breaking other things
 (
 	export PATH="$DEST/../binary:$DEST/../dynbinary:$PATH"
-	
+
 	if ! command -v docker &> /dev/null; then
 		echo >&2 'error: binary or dynbinary must be run before test-integration-cli'
 		false
 	fi
-	
+
 	( set -x; exec \
 		docker --daemon --debug \
 		--storage-driver "$DOCKER_GRAPHDRIVER" \
@@ -26,10 +26,10 @@ bundle_test_integration_cli() {
 		--pidfile "$DEST/docker.pid" \
 			&> "$DEST/docker.log"
 	) &
-	
+
 	# pull the busybox image before running the tests
 	sleep 2
-	
+
 	if ! docker inspect busybox &> /dev/null; then
 		if [ -d /docker-busybox ]; then
 			( set -x; docker build -t busybox /docker-busybox )
@@ -39,7 +39,7 @@ bundle_test_integration_cli() {
 	fi
 
 	bundle_test_integration_cli
-	
+
 	DOCKERD_PID=$(set -x; cat $DEST/docker.pid)
 	( set -x; kill $DOCKERD_PID )
 	wait $DOCKERD_PID || true


### PR DESCRIPTION
Creating the "docker save" tarball for "scratch" is pretty simple.  I've also extrapolated the "docker build -t busybox ." logic into a separate "hack/make/.ensure-busybox" file so that it can eventually be reused easier.

Just for you, @creack. ♥
