### PR TITLE
Update hack/dind to mount cgroups on "/cgroup" instead of "/sys/fs/cgroup" for better compatibility

### DIFF
--- a/hack/dind
+++ b/hack/dind
@@ -10,7 +10,7 @@
 # Usage: dind CMD [ARG...]
 
 # First, make sure that cgroups are mounted correctly.
-CGROUP=/sys/fs/cgroup
+CGROUP=/cgroup
 
 [ -d $CGROUP ] || 
 	mkdir $CGROUP


### PR DESCRIPTION
Fixes #5122
