### PR TITLE
Cleanup cgroups on Set failures

### DIFF
--- a/pkg/cgroups/fs/apply_raw.go
+++ b/pkg/cgroups/fs/apply_raw.go
@@ -67,6 +67,7 @@ func Apply(c *cgroups.Cgroup, pid int) (cgroups.ActiveCgroup, error) {
 	}
 	for _, sys := range subsystems {
 		if err := sys.Set(d); err != nil {
+			d.Cleanup()
 			return nil, err
 		}
 	}


### PR DESCRIPTION
When using libcontainer directly, failures to write some of the cgroup files leaves behind a partially created cgroup.
Docker daemon might be cleaning it up somewhere, but its nice to have cgroup library cleanup on failures.

Docker-DCO-1.1-Signed-off-by: Rohit Jnagal jnagal@google.com (github: rjnagal)
