### PR TITLE
Add new test-unit make rule which only runs the unit tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all binary build cross default docs docs-build docs-shell shell test test-integration test-integration-cli validate
+.PHONY: all binary build cross default docs docs-build docs-shell shell test test-unit test-integration test-integration-cli validate
 
 # to allow `make BINDDIR=. shell` or `make BINDDIR= test`
 BINDDIR := bundles
@@ -35,7 +35,10 @@ docs-release: docs-build
 	$(DOCKER_RUN_DOCS) "$(DOCKER_DOCS_IMAGE)" ./release.sh
 
 test: build
-	$(DOCKER_RUN_DOCKER) hack/make.sh binary test test-integration test-integration-cli
+	$(DOCKER_RUN_DOCKER) hack/make.sh binary test-unit test-integration test-integration-cli
+
+test-unit: build
+	$(DOCKER_RUN_DOCKER) hack/make.sh test-unit
 
 test-integration: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh test-integration

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -45,7 +45,7 @@ DEFAULT_BUNDLES=(
 	
 	binary
 	
-	test
+	test-unit
 	test-integration
 	test-integration-cli
 	

--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -11,9 +11,9 @@ TEXTRESET=$'\033[0m' # reset the foreground colour
 # If $TESTFLAGS is set in the environment, it is passed as extra arguments to 'go test'.
 # You can use this to select certain tests to run, eg.
 #
-#   TESTFLAGS='-run ^TestBuild$' ./hack/make.sh test
+#   TESTFLAGS='-run ^TestBuild$' ./hack/make.sh test-unit
 #
-bundle_test() {
+bundle_test_unit() {
 	{
 		date
 
@@ -52,4 +52,4 @@ bundle_test() {
 	} 2>&1 | tee $DEST/test.log
 }
 
-bundle_test
+bundle_test_unit

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -54,7 +54,7 @@ RELEASE_BUNDLES=(
 
 if [ "$1" != '--release-regardless-of-test-failure' ]; then
 	RELEASE_BUNDLES=(
-		test test-integration
+		test-unit test-integration
 		"${RELEASE_BUNDLES[@]}"
 		test-integration-cli
 	)


### PR DESCRIPTION
Renames test bundle to test-unit.

Docker-DCO-1.1-Signed-off-by: Victor Marmol vmarmol@google.com (github: vmarmol)
