### PR TITLE
check if the daemon is run as root on startup

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -97,6 +97,10 @@ func main() {
 	}
 
 	if *flDaemon {
+		if os.Geteuid() != 0 {
+			log.Fatalf("The Docker daemon needs to be run as root")
+		}
+
 		if flag.NArg() != 0 {
 			flag.Usage()
 			return


### PR DESCRIPTION
This PR makes Docker throw an error if the daemon isn't started as root.

Fixes #5366
