### PR TITLE
graphdriver: Add generic test framework for graph drivers

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -54,7 +54,7 @@ type Driver struct {
 func Init(root string) (graphdriver.Driver, error) {
 	// Try to load the aufs kernel module
 	if err := supportsAufs(); err != nil {
-		return nil, err
+		return nil, graphdriver.ErrNotSupported
 	}
 	paths := []string{
 		"mnt",

--- a/daemon/graphdriver/aufs/aufs_test.go
+++ b/daemon/graphdriver/aufs/aufs_test.go
@@ -19,7 +19,7 @@ var (
 func testInit(dir string, t *testing.T) graphdriver.Driver {
 	d, err := Init(dir)
 	if err != nil {
-		if err == ErrAufsNotSupported {
+		if err == graphdriver.ErrNotSupported {
 			t.Skip(err)
 		} else {
 			t.Fatal(err)

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -31,7 +31,7 @@ func Init(home string) (graphdriver.Driver, error) {
 	}
 
 	if buf.Type != 0x9123683E {
-		return nil, fmt.Errorf("%s is not a btrfs filesystem", rootdir)
+		return nil, graphdriver.ErrNotSupported
 	}
 
 	return &Driver{

--- a/daemon/graphdriver/btrfs/btrfs_test.go
+++ b/daemon/graphdriver/btrfs/btrfs_test.go
@@ -1,0 +1,28 @@
+package btrfs
+
+import (
+	"github.com/dotcloud/docker/daemon/graphdriver/graphtest"
+	"testing"
+)
+
+// This avoids creating a new driver for each test if all tests are run
+// Make sure to put new tests between TestBtrfsSetup and TestBtrfsTeardown
+func TestBtrfsSetup(t *testing.T) {
+	graphtest.GetDriver(t, "btrfs")
+}
+
+func TestBtrfsCreateEmpty(t *testing.T) {
+	graphtest.DriverTestCreateEmpty(t, "btrfs")
+}
+
+func TestBtrfsCreateBase(t *testing.T) {
+	graphtest.DriverTestCreateBase(t, "btrfs")
+}
+
+func TestBtrfsCreateSnap(t *testing.T) {
+	graphtest.DriverTestCreateSnap(t, "btrfs")
+}
+
+func TestBtrfsTeardown(t *testing.T) {
+	graphtest.PutDriver(t)
+}

--- a/daemon/graphdriver/devmapper/driver_test.go
+++ b/daemon/graphdriver/devmapper/driver_test.go
@@ -5,6 +5,7 @@ package devmapper
 import (
 	"fmt"
 	"github.com/dotcloud/docker/daemon/graphdriver"
+	"github.com/dotcloud/docker/daemon/graphdriver/graphtest"
 	"io/ioutil"
 	"path"
 	"runtime"
@@ -913,4 +914,26 @@ func assertMap(t *testing.T, m map[string]bool, keys ...string) {
 	if len(m) != 0 {
 		t.Fatalf("Unexpected keys: %v", m)
 	}
+}
+
+// This avoids creating a new driver for each test if all tests are run
+// Make sure to put new tests between TestDevmapperSetup and TestDevmapperTeardown
+func TestDevmapperSetup(t *testing.T) {
+	graphtest.GetDriver(t, "devicemapper")
+}
+
+func TestDevmapperCreateEmpty(t *testing.T) {
+	graphtest.DriverTestCreateEmpty(t, "devicemapper")
+}
+
+func TestDevmapperCreateBase(t *testing.T) {
+	graphtest.DriverTestCreateBase(t, "devicemapper")
+}
+
+func TestDevmapperCreateSnap(t *testing.T) {
+	graphtest.DriverTestCreateSnap(t, "devicemapper")
+}
+
+func TestDevmapperTeardown(t *testing.T) {
+	graphtest.PutDriver(t)
 }

--- a/daemon/graphdriver/devmapper/driver_test.go
+++ b/daemon/graphdriver/devmapper/driver_test.go
@@ -20,8 +20,16 @@ func init() {
 	DefaultBaseFsSize = 300 * 1024 * 1024
 }
 
+// We use assignment here to get the right type
+var (
+	oldMounted = Mounted
+	oldExecRun = execRun
+)
+
 // denyAllDevmapper mocks all calls to libdevmapper in the unit tests, and denies them by default
 func denyAllDevmapper() {
+	oldExecRun = execRun
+
 	// Hijack all calls to libdevmapper with default panics.
 	// Authorized calls are selectively hijacked in each tests.
 	DmTaskCreate = func(t int) *CDmTask {
@@ -77,7 +85,29 @@ func denyAllDevmapper() {
 	}
 }
 
+func restoreAllDevmapper() {
+	DmGetLibraryVersion = dmGetLibraryVersionFct
+	DmGetNextTarget = dmGetNextTargetFct
+	DmLogInitVerbose = dmLogInitVerboseFct
+	DmSetDevDir = dmSetDevDirFct
+	DmTaskAddTarget = dmTaskAddTargetFct
+	DmTaskCreate = dmTaskCreateFct
+	DmTaskDestroy = dmTaskDestroyFct
+	DmTaskGetInfo = dmTaskGetInfoFct
+	DmTaskRun = dmTaskRunFct
+	DmTaskSetAddNode = dmTaskSetAddNodeFct
+	DmTaskSetCookie = dmTaskSetCookieFct
+	DmTaskSetMessage = dmTaskSetMessageFct
+	DmTaskSetName = dmTaskSetNameFct
+	DmTaskSetRo = dmTaskSetRoFct
+	DmTaskSetSector = dmTaskSetSectorFct
+	DmUdevWait = dmUdevWaitFct
+	LogWithErrnoInit = logWithErrnoInitFct
+	execRun = oldExecRun
+}
+
 func denyAllSyscall() {
+	oldMounted = Mounted
 	sysMount = func(source, target, fstype string, flags uintptr, data string) (err error) {
 		panic("sysMount: this method should not be called here")
 	}
@@ -108,6 +138,14 @@ func denyAllSyscall() {
 	// execRun = func(name string, args ...string) error {
 	// 	return exec.Command(name, args...).Run()
 	// }
+}
+
+func restoreAllSyscall() {
+	sysMount = syscall.Mount
+	sysUnmount = syscall.Unmount
+	sysCloseOnExec = syscall.CloseOnExec
+	sysSyscall = syscall.Syscall
+	Mounted = oldMounted
 }
 
 func mkTestDirectory(t *testing.T) string {
@@ -160,8 +198,10 @@ func TestInit(t *testing.T) {
 	)
 	defer osRemoveAll(home)
 
+	denyAllDevmapper()
+	defer restoreAllDevmapper()
+
 	func() {
-		denyAllDevmapper()
 		DmSetDevDir = func(dir string) int {
 			calls["DmSetDevDir"] = true
 			expectedDir := "/dev"
@@ -398,7 +438,7 @@ func mockAllDevmapper(calls Set) {
 
 func TestDriverName(t *testing.T) {
 	denyAllDevmapper()
-	defer denyAllDevmapper()
+	defer restoreAllDevmapper()
 
 	oldInit := fakeInit()
 	defer restoreInit(oldInit)
@@ -412,8 +452,8 @@ func TestDriverName(t *testing.T) {
 func TestDriverCreate(t *testing.T) {
 	denyAllDevmapper()
 	denyAllSyscall()
-	defer denyAllSyscall()
-	defer denyAllDevmapper()
+	defer restoreAllSyscall()
+	defer restoreAllDevmapper()
 
 	calls := make(Set)
 	mockAllDevmapper(calls)
@@ -524,8 +564,8 @@ func TestDriverCreate(t *testing.T) {
 func TestDriverRemove(t *testing.T) {
 	denyAllDevmapper()
 	denyAllSyscall()
-	defer denyAllSyscall()
-	defer denyAllDevmapper()
+	defer restoreAllSyscall()
+	defer restoreAllDevmapper()
 
 	calls := make(Set)
 	mockAllDevmapper(calls)

--- a/daemon/graphdriver/graphtest/graphtest.go
+++ b/daemon/graphdriver/graphtest/graphtest.go
@@ -1,0 +1,225 @@
+package graphtest
+
+import (
+	"github.com/dotcloud/docker/daemon/graphdriver"
+	"io/ioutil"
+	"os"
+	"path"
+	"syscall"
+	"testing"
+)
+
+var (
+	drv *Driver
+)
+
+type Driver struct {
+	graphdriver.Driver
+	root     string
+	refCount int
+}
+
+func newDriver(t *testing.T, name string) *Driver {
+	root, err := ioutil.TempDir("/var/tmp", "docker-graphtest-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	d, err := graphdriver.GetDriver(name, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Driver{d, root, 1}
+}
+
+func cleanup(t *testing.T, d *Driver) {
+	if err := drv.Cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	os.RemoveAll(d.root)
+}
+
+func GetDriver(t *testing.T, name string) graphdriver.Driver {
+	if drv == nil {
+		drv = newDriver(t, name)
+	} else {
+		drv.refCount++
+	}
+	return drv
+}
+
+func PutDriver(t *testing.T) {
+	if drv == nil {
+		t.Fatal("No driver to put!")
+	}
+	drv.refCount--
+	if drv.refCount == 0 {
+		cleanup(t, drv)
+		drv = nil
+	}
+}
+
+func verifyFile(t *testing.T, path string, mode os.FileMode, uid, gid uint32) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fi.Mode()&os.ModeType != mode&os.ModeType {
+		t.Fatalf("Expected %s type 0x%x, got 0x%x", path, mode&os.ModeType, fi.Mode()&os.ModeType)
+	}
+
+	if fi.Mode()&os.ModePerm != mode&os.ModePerm {
+		t.Fatalf("Expected %s mode %o, got %o", path, mode&os.ModePerm, fi.Mode()&os.ModePerm)
+	}
+
+	if fi.Mode()&os.ModeSticky != mode&os.ModeSticky {
+		t.Fatalf("Expected %s sticky 0x%x, got 0x%x", path, mode&os.ModeSticky, fi.Mode()&os.ModeSticky)
+	}
+
+	if fi.Mode()&os.ModeSetuid != mode&os.ModeSetuid {
+		t.Fatalf("Expected %s setuid 0x%x, got 0x%x", path, mode&os.ModeSetuid, fi.Mode()&os.ModeSetuid)
+	}
+
+	if fi.Mode()&os.ModeSetgid != mode&os.ModeSetgid {
+		t.Fatalf("Expected %s setgid 0x%x, got 0x%x", path, mode&os.ModeSetgid, fi.Mode()&os.ModeSetgid)
+	}
+
+	if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
+		if stat.Uid != uid {
+			t.Fatal("%s no owned by uid %d", path, uid)
+		}
+		if stat.Gid != gid {
+			t.Fatal("%s not owned by gid %d", path, gid)
+		}
+	}
+
+}
+
+// Creates an new image and verifies it is empty and the right metadata
+func DriverTestCreateEmpty(t *testing.T, drivername string) {
+	driver := GetDriver(t, drivername)
+	defer PutDriver(t)
+
+	if err := driver.Create("empty", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	if !driver.Exists("empty") {
+		t.Fatal("Newly created image doesn't exist")
+	}
+
+	dir, err := driver.Get("empty", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	verifyFile(t, dir, 0755|os.ModeDir, 0, 0)
+
+	// Verify that the directory is empty
+	fis, err := ioutil.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fis) != 0 {
+		t.Fatal("New directory not empty")
+	}
+
+	driver.Put("empty")
+
+	if err := driver.Remove("empty"); err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func createBase(t *testing.T, driver graphdriver.Driver, name string) {
+	// We need to be able to set any perms
+	oldmask := syscall.Umask(0)
+	defer syscall.Umask(oldmask)
+
+	if err := driver.Create(name, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	dir, err := driver.Get(name, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer driver.Put(name)
+
+	subdir := path.Join(dir, "a subdir")
+	if err := os.Mkdir(subdir, 0705|os.ModeSticky); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chown(subdir, 1, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	file := path.Join(dir, "a file")
+	if err := ioutil.WriteFile(file, []byte("Some data"), 0222|os.ModeSetuid); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func verifyBase(t *testing.T, driver graphdriver.Driver, name string) {
+	dir, err := driver.Get(name, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer driver.Put(name)
+
+	subdir := path.Join(dir, "a subdir")
+	verifyFile(t, subdir, 0705|os.ModeDir|os.ModeSticky, 1, 2)
+
+	file := path.Join(dir, "a file")
+	verifyFile(t, file, 0222|os.ModeSetuid, 0, 0)
+
+	fis, err := ioutil.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(fis) != 2 {
+		t.Fatal("Unexpected files in base image")
+	}
+
+}
+
+func DriverTestCreateBase(t *testing.T, drivername string) {
+	driver := GetDriver(t, drivername)
+	defer PutDriver(t)
+
+	createBase(t, driver, "Base")
+	verifyBase(t, driver, "Base")
+
+	if err := driver.Remove("Base"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func DriverTestCreateSnap(t *testing.T, drivername string) {
+	driver := GetDriver(t, drivername)
+	defer PutDriver(t)
+
+	createBase(t, driver, "Base")
+
+	if err := driver.Create("Snap", "Base"); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyBase(t, driver, "Snap")
+
+	if err := driver.Remove("Snap"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := driver.Remove("Base"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/daemon/graphdriver/graphtest/graphtest.go
+++ b/daemon/graphdriver/graphtest/graphtest.go
@@ -31,6 +31,9 @@ func newDriver(t *testing.T, name string) *Driver {
 
 	d, err := graphdriver.GetDriver(name, root)
 	if err != nil {
+		if err == graphdriver.ErrNotSupported {
+			t.Skip("Driver %s not supported", name)
+		}
 		t.Fatal(err)
 	}
 	return &Driver{d, root, 1}
@@ -54,7 +57,7 @@ func GetDriver(t *testing.T, name string) graphdriver.Driver {
 
 func PutDriver(t *testing.T) {
 	if drv == nil {
-		t.Fatal("No driver to put!")
+		t.Skip("No driver to put!")
 	}
 	drv.refCount--
 	if drv.refCount == 0 {

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -47,7 +47,7 @@ func (d *Driver) Create(id, parent string) error {
 	if err := os.MkdirAll(path.Dir(dir), 0700); err != nil {
 		return err
 	}
-	if err := os.Mkdir(dir, 0700); err != nil {
+	if err := os.Mkdir(dir, 0755); err != nil {
 		return err
 	}
 	if parent == "" {

--- a/daemon/graphdriver/vfs/vfs_test.go
+++ b/daemon/graphdriver/vfs/vfs_test.go
@@ -1,0 +1,28 @@
+package vfs
+
+import (
+	"github.com/dotcloud/docker/daemon/graphdriver/graphtest"
+	"testing"
+)
+
+// This avoids creating a new driver for each test if all tests are run
+// Make sure to put new tests between TestVfsSetup and TestVfsTeardown
+func TestVfsSetup(t *testing.T) {
+	graphtest.GetDriver(t, "vfs")
+}
+
+func TestVfsCreateEmpty(t *testing.T) {
+	graphtest.DriverTestCreateEmpty(t, "vfs")
+}
+
+func TestVfsCreateBase(t *testing.T) {
+	graphtest.DriverTestCreateBase(t, "vfs")
+}
+
+func TestVfsCreateSnap(t *testing.T) {
+	graphtest.DriverTestCreateSnap(t, "vfs")
+}
+
+func TestVfsTeardown(t *testing.T) {
+	graphtest.PutDriver(t)
+}


### PR DESCRIPTION
This adds daemon/graphdriver/graphtest/graphtest which has a few generic tests for all graph drivers, and then uses these from the btrs, devicemapper and vfs backends. There are also some fixes to the existing tests and drivers to make the tests pass.

I've not yet added the aufs backend, because i can't test that here atm. It should work though. I also plan to add more tests, but I'll be away for a while, so might as well get this out there before that.
