### PR TITLE
Update pkg/apparmor to provide a better error message when apparmor_parser cannot be found

### DIFF
--- a/pkg/apparmor/setup.go
+++ b/pkg/apparmor/setup.go
@@ -69,15 +69,8 @@ func InstallDefaultProfile(backupPath string) error {
 	cmd.Dir = "/etc/apparmor.d"
 
 	output, err := cmd.CombinedOutput()
-	if err != nil && !os.IsNotExist(err) {
-		if e, ok := err.(*exec.Error); ok {
-			// keeping with the current profile load code, if the parser does not
-			// exist then just return
-			if e.Err == exec.ErrNotFound || os.IsNotExist(e.Err) {
-				return nil
-			}
-		}
-		return fmt.Errorf("Error loading docker profile: %s (%s)", err, output)
+	if err != nil {
+		return fmt.Errorf("Error loading docker apparmor profile: %s (%s)", err, output)
 	}
 	return nil
 }


### PR DESCRIPTION
Before: `no such file or directory` (no hints of what's actually missing)
After: `Error loading docker apparmor profile: exec: "/sbin/apparmor_parser": stat /sbin/apparmor_parser: no such file or directory ()` (clearly missing "apparmor_parser")
