### PR TITLE
Add notes about git commit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,10 @@ reference to all the issues that they address.
 
 Pull requests must not contain commits from other users or branches.
 
+Commit messages must start with a capitalized and short summary (max. 50
+chars) written in the imperative, followed by an optional, more detailed
+explanatory text which is separated from the summary by an empty line.
+
 Code review comments may be added to your pull request. Discuss, then make the
 suggested modifications and push additional commits to your feature branch. Be
 sure to post a comment after pushing. The new commits will show up in the pull


### PR DESCRIPTION
This was faster than kicking off a discussion in the ML, so just scrap it if you feel different:

This improves readability of commits a lot and is easy to
follow. I think most people follow those rules already. They are based
on http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
