### PR TITLE
Make Jerome Petazzoni a maintainer for dind

### DIFF
--- a/hack/MAINTAINERS
+++ b/hack/MAINTAINERS
@@ -1,1 +1,2 @@
 Tianon Gravi <admwiggin@gmail.com> (@tianon)
+dind: Jerome Petazzoni <jerome@docker.com> (@jpetazzo)


### PR DESCRIPTION
In the spirit of getting more contributors to maintain their
components.. I nominate @jpetazzo ot maintain dind (he's the original
author).

@jpetazzo I don't expect this to be too much load, but it's a good and
symbolic start :)

Docker-DCO-1.1-Signed-off-by: Solomon Hykes solomon@docker.com (github: shykes)
