### PR TITLE
Add a --add-host host:ip flag which appends lines to /etc/hosts.

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -494,6 +494,11 @@ ff02::2		ip6-allrouters
 		hostsContent = append([]byte(fmt.Sprintf("%s\t%s\n", IP, container.Config.Hostname)), hostsContent...)
 	}
 
+	for _,extraHost := range container.Config.ExtraHosts {
+		parts := strings.Split(extraHost, ":")
+		hostsContent = append(hostsContent, []byte(fmt.Sprintf("%s\t%s\n", parts[1], parts[0]))...)
+	}
+
 	ioutil.WriteFile(container.HostsPath, hostsContent, 0644)
 }
 

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -494,7 +494,7 @@ ff02::2		ip6-allrouters
 		hostsContent = append([]byte(fmt.Sprintf("%s\t%s\n", IP, container.Config.Hostname)), hostsContent...)
 	}
 
-	for _,extraHost := range container.Config.ExtraHosts {
+	for _, extraHost := range container.Config.ExtraHosts {
 		parts := strings.Split(extraHost, ":")
 		hostsContent = append(hostsContent, []byte(fmt.Sprintf("%s\t%s\n", parts[1], parts[0]))...)
 	}

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -136,8 +136,9 @@ PID files):
 
 ## Network Settings
 
-    -n=true   : Enable networking for this container
-    --dns=[]  : Set custom dns servers for the container
+    -n=true        : Enable networking for this container
+    --dns=[]       : Set custom dns servers for the container
+    --add-host=""  : Add a line to /etc/hosts (host:IP)
 
 By default, all containers have networking enabled and they can make any
 outgoing connections. The operator can completely disable networking

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -130,10 +130,10 @@ func ValidateEnv(val string) (string, error) {
 
 func ValidateExtraHost(val string) (string, error) {
 	arr := strings.Split(val, ":")
-	if len(arr) == 2 {
-		return val, nil
+	if len(arr) != 2 {
+		return val, fmt.Errorf("bad format for add-host: %s", val)
 	}
-	return val, fmt.Errorf("bad format for add-host: %s", val)
+	return val, nil
 }
 
 func ValidateIp4Address(val string) (string, error) {

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -136,7 +136,6 @@ func ValidateExtraHost(val string) (string, error) {
 	return val, fmt.Errorf("bad format for add-host: %s", val)
 }
 
-
 func ValidateIp4Address(val string) (string, error) {
 	re := regexp.MustCompile(`^(([0-9]+\.){3}([0-9]+))\s*$`)
 	var ns = re.FindSubmatch([]byte(val))

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -128,6 +128,15 @@ func ValidateEnv(val string) (string, error) {
 	return fmt.Sprintf("%s=%s", val, os.Getenv(val)), nil
 }
 
+func ValidateExtraHost(val string) (string, error) {
+	arr := strings.Split(val, ":")
+	if len(arr) == 2 {
+		return val, nil
+	}
+	return val, fmt.Errorf("bad format for add-host: %s", val)
+}
+
+
 func ValidateIp4Address(val string) (string, error) {
 	re := regexp.MustCompile(`^(([0-9]+\.){3}([0-9]+))\s*$`)
 	var ns = re.FindSubmatch([]byte(val))

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	OpenStdin       bool // Open stdin
 	StdinOnce       bool // If true, close stdin after the 1 attached client disconnects.
 	Env             []string
+	ExtraHosts      []string // Hosts to append to /etc/hosts
 	Cmd             []string
 	Image           string // Name of the image as it was passed by the operator (eg. could be symbolic)
 	Volumes         map[string]struct{}
@@ -58,6 +59,9 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 	}
 	if Env := job.GetenvList("Env"); Env != nil {
 		config.Env = Env
+	}
+	if ExtraHosts := job.GetenvList("ExtraHosts"); ExtraHosts != nil {
+		config.ExtraHosts = ExtraHosts
 	}
 	if Cmd := job.GetenvList("Cmd"); Cmd != nil {
 		config.Cmd = Cmd

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -34,11 +34,11 @@ func ParseSubcommand(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo)
 func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config, *HostConfig, *flag.FlagSet, error) {
 	var (
 		// FIXME: use utils.ListOpts for attach and volumes?
-		flAttach      = opts.NewListOpts(opts.ValidateAttach)
-		flVolumes     = opts.NewListOpts(opts.ValidatePath)
-		flLinks       = opts.NewListOpts(opts.ValidateLink)
-		flEnv         = opts.NewListOpts(opts.ValidateEnv)
-		flExtraHosts  = opts.NewListOpts(opts.ValidateExtraHost)
+		flAttach     = opts.NewListOpts(opts.ValidateAttach)
+		flVolumes    = opts.NewListOpts(opts.ValidatePath)
+		flLinks      = opts.NewListOpts(opts.ValidateLink)
+		flEnv        = opts.NewListOpts(opts.ValidateEnv)
+		flExtraHosts = opts.NewListOpts(opts.ValidateExtraHost)
 
 		flPublish     opts.ListOpts
 		flExpose      opts.ListOpts

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -200,8 +200,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	//utils.Debugf("Environment variables for the container: %#v", envVariables)
 
 	// parse the '--add-host' flag
-	extraHosts := []string{}
-	extraHosts = append(extraHosts, flExtraHosts.GetAll()...)
+	extraHosts = append([]string{}, flExtraHosts.GetAll()...)
 	//utils.Debugf("Extra hosts for the container: %#v", extraHosts)
 
 	config := &Config{


### PR DESCRIPTION
As per https://github.com/dotcloud/docker/issues/2335 and https://github.com/dotcloud/docker/issues/2267 and maybe others, this adds a simple flag to append lines to /etc/hosts.

This is my first foray into go and Docker code, so I'm happy to be told where I screwed it up.  I mostly followed the example of the Env flag.
