### PR TITLE
drop CAP_SYSLOG capability

### DIFF
--- a/daemon/execdriver/lxc/init.go
+++ b/daemon/execdriver/lxc/init.go
@@ -149,6 +149,7 @@ func setupCapabilities(args *execdriver.InitArgs) error {
 		capability.CAP_MAC_OVERRIDE,
 		capability.CAP_MAC_ADMIN,
 		capability.CAP_NET_ADMIN,
+		capability.CAP_SYSLOG,
 	}
 
 	c, err := capability.NewPid(os.Getpid())

--- a/daemon/execdriver/native/template/default_template.go
+++ b/daemon/execdriver/native/template/default_template.go
@@ -25,6 +25,7 @@ func New() *libcontainer.Container {
 			libcontainer.GetCapability("MAC_ADMIN"),
 			libcontainer.GetCapability("NET_ADMIN"),
 			libcontainer.GetCapability("MKNOD"),
+			libcontainer.GetCapability("SYSLOG"),
 		},
 		Namespaces: libcontainer.Namespaces{
 			libcontainer.GetNamespace("NEWNS"),

--- a/pkg/libcontainer/container.json
+++ b/pkg/libcontainer/container.json
@@ -91,6 +91,11 @@
          "value" : 27,
          "key" : "MKNOD",
          "enabled" : true
+      },
+      {
+         "value" : 34,
+         "key" : "SYSLOG",
+         "enabled" : false
       }
    ],
    "networks" : [

--- a/pkg/libcontainer/types.go
+++ b/pkg/libcontainer/types.go
@@ -53,6 +53,7 @@ var (
 		{Key: "MAC_OVERRIDE", Value: capability.CAP_MAC_OVERRIDE, Enabled: false},
 		{Key: "MAC_ADMIN", Value: capability.CAP_MAC_ADMIN, Enabled: false},
 		{Key: "NET_ADMIN", Value: capability.CAP_NET_ADMIN, Enabled: false},
+		{Key: "SYSLOG", Value: capability.CAP_SYSLOG, Enabled: false},
 	}
 )
 


### PR DESCRIPTION
Kernel capabilities for privileged syslog operations are currently splitted into
CAP_SYS_ADMIN and CAP_SYSLOG since the following commit:
http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=ce6ada35bdf710d16582cc4869c26722547e6f11

This patch drops CAP_SYSLOG to prevent containers from messing with
host's syslog (e.g. `dmesg -c` clears up host's printk ring buffer).

Closes #5491
Closes #5492

Docker-DCO-1.1-Signed-off-by: Eiichi Tsukata devel@etsukata.com (github: Etsukata)
Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
