### PR TITLE
Adding Rohit Jnagal and Victor Marmol to pkg/cgroups maintainers.

### DIFF
--- a/pkg/cgroups/MAINTAINERS
+++ b/pkg/cgroups/MAINTAINERS
@@ -1,1 +1,3 @@
 Michael Crosby <michael@crosbymichael.com> (@crosbymichael)
+Rohit Jnagal <jnagal@google.com> (@rjnagal)
+Victor Marmol <vmarmol@google.com> (@vmarmol)


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Victor Marmol vmarmol@google.com (github: vmarmol)
