### PR TITLE
rename goruntime import to runtime

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -13,7 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	goruntime "runtime"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -359,7 +359,7 @@ func (cli *DockerCli) CmdVersion(args ...string) error {
 		fmt.Fprintf(cli.out, "Client version: %s\n", dockerversion.VERSION)
 	}
 	fmt.Fprintf(cli.out, "Client API version: %s\n", api.APIVERSION)
-	fmt.Fprintf(cli.out, "Go version (client): %s\n", goruntime.Version())
+	fmt.Fprintf(cli.out, "Go version (client): %s\n", runtime.Version())
 	if dockerversion.GITCOMMIT != "" {
 		fmt.Fprintf(cli.out, "Git commit (client): %s\n", dockerversion.GITCOMMIT)
 	}

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -16,7 +16,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	goruntime "runtime"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -127,7 +127,7 @@ func init() {
 	spawnGlobalDaemon()
 	spawnLegitHttpsDaemon()
 	spawnRogueHttpsDaemon()
-	startFds, startGoroutines = utils.GetTotalUsedFds(), goruntime.NumGoroutine()
+	startFds, startGoroutines = utils.GetTotalUsedFds(), runtime.NumGoroutine()
 }
 
 func setupBaseImage() {

--- a/server/server.go
+++ b/server/server.go
@@ -34,7 +34,7 @@ import (
 	gosignal "os/signal"
 	"path"
 	"path/filepath"
-	goruntime "runtime"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -789,7 +789,7 @@ func (srv *Server) DockerInfo(job *engine.Job) engine.Status {
 	v.SetBool("IPv4Forwarding", !srv.daemon.SystemConfig().IPv4ForwardingDisabled)
 	v.SetBool("Debug", os.Getenv("DEBUG") != "")
 	v.SetInt("NFd", utils.GetTotalUsedFds())
-	v.SetInt("NGoroutines", goruntime.NumGoroutine())
+	v.SetInt("NGoroutines", runtime.NumGoroutine())
 	v.Set("ExecutionDriver", srv.daemon.ExecutionDriver().Name())
 	v.SetInt("NEventsListener", len(srv.listeners))
 	v.Set("KernelVersion", kernelVersion)
@@ -807,9 +807,9 @@ func (srv *Server) DockerVersion(job *engine.Job) engine.Status {
 	v.Set("Version", dockerversion.VERSION)
 	v.SetJson("ApiVersion", api.APIVERSION)
 	v.Set("GitCommit", dockerversion.GITCOMMIT)
-	v.Set("GoVersion", goruntime.Version())
-	v.Set("Os", goruntime.GOOS)
-	v.Set("Arch", goruntime.GOARCH)
+	v.Set("GoVersion", runtime.Version())
+	v.Set("Os", runtime.GOOS)
+	v.Set("Arch", runtime.GOARCH)
 	if kernelVersion, err := utils.GetKernelVersion(); err == nil {
 		v.Set("KernelVersion", kernelVersion.String())
 	}


### PR DESCRIPTION
This minor cleanup PR renames the goruntime import of the runtime package back to runtime.

The former runtime Docker package is now called daemon, so we can make this change.
