### PR TITLE
runconfig: add -net container:name option

### DIFF
--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -89,8 +89,9 @@ type Driver interface {
 
 // Network settings of the container
 type Network struct {
-	Interface *NetworkInterface `json:"interface"` // if interface is nil then networking is disabled
-	Mtu       int               `json:"mtu"`
+	Interface   *NetworkInterface `json:"interface"` // if interface is nil then networking is disabled
+	Mtu         int               `json:"mtu"`
+	ContainerID string            `json:"container_id"` // id of the container to join network.
 }
 
 type NetworkInterface struct {

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -3,6 +3,7 @@ package native
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/dotcloud/docker/daemon/execdriver"
 	"github.com/dotcloud/docker/daemon/execdriver/native/configuration"
@@ -75,6 +76,21 @@ func (d *driver) createNetwork(container *libcontainer.Container, c *execdriver.
 		}
 		container.Networks = append(container.Networks, &vethNetwork)
 	}
+
+	if c.Network.ContainerID != "" {
+		cmd := d.activeContainers[c.Network.ContainerID]
+		if cmd == nil || cmd.Process == nil {
+			return fmt.Errorf("%s is not a valid running container to join", c.Network.ContainerID)
+		}
+		nspath := filepath.Join("/proc", fmt.Sprint(cmd.Process.Pid), "ns", "net")
+		container.Networks = append(container.Networks, &libcontainer.Network{
+			Type: "netns",
+			Context: libcontainer.Context{
+				"nspath": nspath,
+			},
+		})
+	}
+
 	return nil
 }
 

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -7,16 +7,17 @@ import (
 )
 
 type HostConfig struct {
-	Binds           []string
-	ContainerIDFile string
-	LxcConf         []utils.KeyValuePair
-	Privileged      bool
-	PortBindings    nat.PortMap
-	Links           []string
-	PublishAllPorts bool
-	Dns             []string
-	DnsSearch       []string
-	VolumesFrom     []string
+	Binds               []string
+	ContainerIDFile     string
+	LxcConf             []utils.KeyValuePair
+	Privileged          bool
+	PortBindings        nat.PortMap
+	Links               []string
+	PublishAllPorts     bool
+	Dns                 []string
+	DnsSearch           []string
+	VolumesFrom         []string
+	UseContainerNetwork string
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
@@ -41,6 +42,9 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 	}
 	if VolumesFrom := job.GetenvList("VolumesFrom"); VolumesFrom != nil {
 		hostConfig.VolumesFrom = VolumesFrom
+	}
+	if UseContainerNetwork := job.Getenv("UseContainerNetwork"); UseContainerNetwork != "" {
+		hostConfig.UseContainerNetwork = UseContainerNetwork
 	}
 	return hostConfig
 }

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -284,16 +284,17 @@ func parseKeyValueOpts(opts opts.ListOpts) ([]utils.KeyValuePair, error) {
 
 func parseNetMode(netMode string) (string, string, error) {
 	parts := strings.Split(netMode, ":")
-	if len(parts) < 1 {
-		return "", "", fmt.Errorf("'netmode' cannot be empty", netMode)
-	}
-	mode := parts[0]
-	var container string
-	if mode == "container" {
-		if len(parts) < 2 {
+	switch mode := parts[0]; mode {
+	case "bridge", "disable":
+		return mode, "", nil
+	case "container":
+		var container string
+		if len(parts) < 2 || parts[1] == "" {
 			return "", "", fmt.Errorf("'container:' netmode requires a container id or name", netMode)
 		}
 		container = parts[1]
+		return mode, container, nil
+	default:
+		return "", "", fmt.Errorf("invalid netmode: %q", netMode)
 	}
-	return mode, container, nil
 }

--- a/runconfig/parse_test.go
+++ b/runconfig/parse_test.go
@@ -1,8 +1,9 @@
 package runconfig
 
 import (
-	"github.com/dotcloud/docker/utils"
 	"testing"
+
+	"github.com/dotcloud/docker/utils"
 )
 
 func TestParseLxcConfOpt(t *testing.T) {
@@ -18,6 +19,36 @@ func TestParseLxcConfOpt(t *testing.T) {
 		}
 		if v != "docker" {
 			t.Fail()
+		}
+	}
+}
+
+func TestParseNetMode(t *testing.T) {
+	testFlags := []struct {
+		flag      string
+		mode      string
+		container string
+		err       bool
+	}{
+		{"", "", "", true},
+		{"bridge", "bridge", "", false},
+		{"disable", "disable", "", false},
+		{"container:foo", "container", "foo", false},
+		{"container:", "", "", true},
+		{"container", "", "", true},
+		{"unknown", "", "", true},
+	}
+
+	for _, to := range testFlags {
+		mode, container, err := parseNetMode(to.flag)
+		if mode != to.mode {
+			t.Fatalf("-net %s: expected net mode: %q, got: %q", to.flag, to.mode, mode)
+		}
+		if container != to.container {
+			t.Fatalf("-net %s: expected net container: %q, got: %q", to.flag, to.container, container)
+		}
+		if (err != nil) != to.err {
+			t.Fatal("-net %s: expected an error got none", to.flag)
 		}
 	}
 }


### PR DESCRIPTION
usage:

```
docker run -net container:name_or_id
docker run -net bridge
docker run -net disable
```

Example:

```
proppy@noir:~/mygo/src/github.com/dotcloud/docker$ bundles/0.10.0-dev/binary/docker-0.10.0-dev -H :4244 run -d -name netcat_server aanand/netcat nc -l 9999
Warning: '-name' is deprecated, it will be replaced by '--name' soon. See usage.
6a1573e9033810c71c3b28a1a4e34f6b10ab8add0437d6943a60a85279cc881c
proppy@noir:~/mygo/src/github.com/dotcloud/docker$ bundles/0.10.0-dev/binary/docker-0.10.0-dev -H :4244 ps
CONTAINER ID        IMAGE                  COMMAND             CREATED             STATUS              PORTS               NAMES
6a1573e90338        aanand/netcat:latest   nc -l 9999          4 seconds ago       Up 4 seconds                            netcat_server       
proppy@noir:~/mygo/src/github.com/dotcloud/docker$ bundles/0.10.0-dev/binary/docker-0.10.0-dev -H :4244 run -net container:netcat_server aanand/netcat bash -c 'echo coucou | nc localhost 9999'
Warning: '-net' is deprecated, it will be replaced by '--net' soon. See usage.
proppy@noir:~/mygo/src/github.com/dotcloud/docker$ bundles/0.10.0-dev/binary/docker-0.10.0-dev -H :4244 logs netcat_server
coucou
```

Related: #4441 
