### PR TITLE
Don't restrict lxc because of apparmor

### DIFF
--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -16,7 +16,6 @@ import (
 	"github.com/dotcloud/docker/daemon/execdriver"
 	"github.com/dotcloud/docker/pkg/cgroups"
 	"github.com/dotcloud/docker/pkg/label"
-	"github.com/dotcloud/docker/pkg/libcontainer/security/restrict"
 	"github.com/dotcloud/docker/pkg/system"
 	"github.com/dotcloud/docker/utils"
 )
@@ -33,11 +32,6 @@ func init() {
 		}
 		if err := setupNetworking(args); err != nil {
 			return err
-		}
-		if !args.Privileged {
-			if err := restrict.Restrict(); err != nil {
-				return err
-			}
 		}
 		if err := setupCapabilities(args); err != nil {
 			return err

--- a/pkg/libcontainer/nsinit/init.go
+++ b/pkg/libcontainer/nsinit/init.go
@@ -79,7 +79,7 @@ func Init(container *libcontainer.Container, uncleanRootfs, consolePath string, 
 		return fmt.Errorf("set process label %s", err)
 	}
 	if container.Context["restrictions"] != "" {
-		if err := restrict.Restrict(); err != nil {
+		if err := restrict.Restrict("proc", "sys"); err != nil {
 			return err
 		}
 	}

--- a/pkg/libcontainer/security/restrict/restrict.go
+++ b/pkg/libcontainer/security/restrict/restrict.go
@@ -11,9 +11,9 @@ import (
 
 // This has to be called while the container still has CAP_SYS_ADMIN (to be able to perform mounts).
 // However, afterwards, CAP_SYS_ADMIN should be dropped (otherwise the user will be able to revert those changes).
-func Restrict() error {
+func Restrict(mounts ...string) error {
 	// remount proc and sys as readonly
-	for _, dest := range []string{"proc", "sys"} {
+	for _, dest := range mounts {
 		if err := system.Mount("", dest, "", syscall.MS_REMOUNT|syscall.MS_RDONLY, ""); err != nil {
 			return fmt.Errorf("unable to remount %s readonly: %s", dest, err)
 		}


### PR DESCRIPTION
We don't have the flexibility to do extra things with lxc because it is
a black box and most fo the magic happens before we get a chance to
interact with it in dockerinit.
Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
