### PR TITLE
hello_world.md - $container_id variable case sensitivity

### DIFF
--- a/docs/sources/examples/hello_world.md
+++ b/docs/sources/examples/hello_world.md
@@ -80,7 +80,7 @@ continue to do this until we stop it.
 
 **Steps:**
 
-    $ CONTAINER_ID=$(sudo docker run -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done")
+    $ container_id=$(sudo docker run -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done")
 
 We are going to run a simple hello world daemon in a new container made
 from the `ubuntu` image.


### PR DESCRIPTION
If you run the tutorial step-by-step, following error occurs:

```
$ sudo docker logs $container_id
Usage: docker logs CONTAINER
Fetch the logs of a container
  -f, --follow=false: Follow log output
```

This is obviously because bash variables are case-sensitive, so it mustn't be `CONTAINER_ID` above.
