### PR TITLE
git clone should use https URL in devenvironment.md

### DIFF
--- a/docs/sources/contributing/devenvironment.md
+++ b/docs/sources/contributing/devenvironment.md
@@ -32,7 +32,7 @@ Again, you can do it in other ways but you need to do more work.
 
 ## Check out the Source
 
-    $ git clone http://git@github.com/dotcloud/docker
+    $ git clone https://git@github.com/dotcloud/docker
     $ cd docker
 
 To checkout a different revision just use `git checkout`


### PR DESCRIPTION
`git clone` should use `https` URL.

Before:

```
hybrid@node002:~$ git clone http://git@github.com/dotcloud/docker
Cloning into 'docker'...
error: The requested URL returned error: 403 while accessing http://git@github.com/dotcloud/docker/info/refs
fatal: HTTP request failed
```

After:

```
hybrid@node002:~$ git clone https://git@github.com/dotcloud/docker
Cloning into 'docker'...
remote: Reusing existing pack: 40213, done.
remote: Counting objects: 120, done.
remote: Compressing objects: 100% (109/109), done.
Receiving objects: 100% (40333/40333), 21.81 MiB | 978 KiB/s, done.
remote: Total 40333 (delta 61), reused 37 (delta 11)
Resolving deltas: 100% (25061/25061), done.
hybrid@node002:~$ 
```
