### PR TITLE
Fix for broken IMG source for logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It benefits directly from the experience accumulated over several years
 of large-scale operation and support of hundreds of thousands of
 applications and databases.
 
-![Docker L](docs/theme/docker/static/img/dockerlogo-h.png "Docker")
+![Docker L](docs/theme/mkdocs/img/logo_compressed.png "Docker")
 
 ## Better than VMs
 


### PR DESCRIPTION
The original image didn't seem to exist anymore within the repository, so I found a newer logo. Hopefully it's the correct one. If not, then disregard this change request.
