### PR TITLE
nat: Fix --expose protocol parsing

### DIFF
--- a/nat/nat.go
+++ b/nat/nat.go
@@ -69,7 +69,7 @@ func SplitProtoPort(rawPort string) (string, string) {
 	if l == 1 {
 		return "tcp", rawPort
 	}
-	return parts[0], parts[1]
+	return parts[1], parts[0]
 }
 
 // We will receive port specs in the format of ip:public:private/proto and these need to be


### PR DESCRIPTION
A command like:
 docker run --expose 5353/tcp -P fedora sleep 10

Currently fails with:
Error: Cannot start container 5c558de5f0bd85ff14e13e3691aefbe531346297a27d4b3562732baa8785b34a: unknown protocol

This is because nat.SplitProtoPort() confuses the order of the port and
proto in 5353/tcp, assuming the protocol is first. However, in all other
places in docker the protocol is last, so the fix is just to swap these.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
