### PR TITLE
Support unix domain socket paths as exposed port for linking

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -56,6 +56,43 @@ func setupMountsForContainer(container *Container) error {
 		mounts = append(mounts, execdriver.Mount{v, r, container.VolumesRW[r], false})
 	}
 
+	for _, link := range container.activeLinks {
+		c := container.daemon.Get(link.Name)
+		if c == nil {
+			return fmt.Errorf("Container %s not found. Impossible to link to it", link.Name)
+		}
+
+		for _, p := range link.Ports {
+			proto := p.Proto()
+			if proto == "unix" {
+				port := p.Port()
+				src, err := symlink.FollowSymlinkInScope(filepath.Join(c.basefs, port), c.basefs)
+				if err != nil {
+					return fmt.Errorf("Source unix port %s error: %s", port, err)
+				}
+
+				stat, err := os.Stat(src)
+				if err != nil {
+					if os.IsNotExist(err) {
+						return fmt.Errorf("Source unix port %s does not exist in %s", port, link.Name)
+					}
+					return fmt.Errorf("Source unix port %s error: %s", port, err)
+				}
+				if stat.Mode()&os.ModeSocket == 0 {
+					return fmt.Errorf("Source unix port %s is not a socket", port)
+				}
+
+				dst := filepath.Join(container.basefs, port)
+
+				if err := createIfNotExists(dst, false); err != nil {
+					return err
+				}
+
+				mounts = append(mounts, execdriver.Mount{src, port, false, false})
+			}
+		}
+	}
+
 	container.command.Mounts = mounts
 
 	return nil

--- a/links/links.go
+++ b/links/links.go
@@ -57,10 +57,12 @@ func (l *Link) ToEnv() []string {
 
 	// Load exposed ports into the environment
 	for _, p := range l.Ports {
-		env = append(env, fmt.Sprintf("%s_PORT_%s_%s=%s://%s:%s", alias, p.Port(), strings.ToUpper(p.Proto()), p.Proto(), l.ChildIP, p.Port()))
-		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_ADDR=%s", alias, p.Port(), strings.ToUpper(p.Proto()), l.ChildIP))
-		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_PORT=%s", alias, p.Port(), strings.ToUpper(p.Proto()), p.Port()))
-		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_PROTO=%s", alias, p.Port(), strings.ToUpper(p.Proto()), p.Proto()))
+		// Escape / as _ to handle unix domain socket ports being paths
+		portName := strings.Replace(strings.Trim(p.Port(), "/"), "/", "_", -1)
+		env = append(env, fmt.Sprintf("%s_PORT_%s_%s=%s://%s:%s", alias, portName, strings.ToUpper(p.Proto()), p.Proto(), l.ChildIP, p.Port()))
+		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_ADDR=%s", alias, portName, strings.ToUpper(p.Proto()), l.ChildIP))
+		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_PORT=%s", alias, portName, strings.ToUpper(p.Proto()), p.Port()))
+		env = append(env, fmt.Sprintf("%s_PORT_%s_%s_PROTO=%s", alias, portName, strings.ToUpper(p.Proto()), p.Proto()))
 	}
 
 	// Load the linked container's name into the environment


### PR DESCRIPTION
If you expose a port of the "unix" protocol that like this:

docker run --expose /some/dir/socket_file/unix image

Then the port (/some/dir/socket_file in the above) will be mounted into any container that links to the container. If the socket file does not exist or is not a socket the linked container will fail to start.

This is interesting as it allows containerized version of local services like dbus, nscd, sssd, etc to be used by
other containers with a simple --link option.

Here is an example of using this:
    docker run -d --name test --expose /socket/unix fedora dbus-daemon --session --address unix:path=/socket
    docker run -t -i --link test:test fedora dbus-monitor --address unix:path=/socket
