### PR TITLE
Post-commit hook URL fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ editors have plugins that do this automatically, and there's also a git
 pre-commit hook:
 
 ```
-curl -o .git/hooks/pre-commit https://raw.github.com/edsrzf/gofmt-git-hook/master/fmt-check && chmod +x .git/hooks/pre-commit
+curl -o .git/hooks/pre-commit https://raw.githubusercontent.com/edsrzf/gofmt-git-hook/master/fmt-check && chmod +x .git/hooks/pre-commit
 ```
 
 Pull requests descriptions should be as clear as possible and include a


### PR DESCRIPTION
Updating CONTRIBUTING to include the correct URL for the post-commit hook.

Docker-DCO-1.1-Signed-off-by: Aaron Huslage huslage@gmail.com (github:
huslage)
