### PR TITLE
import sha512 to make sha512 ssl certs work

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"bytes"
 	"crypto/sha256"
+	_ "crypto/sha512"
 	"encoding/json"
 	"errors"
 	"fmt"


### PR DESCRIPTION
This tiny PR makes Docker work with private registries which use SSL certs which use sha512 for hashing.

Fixes #5173.
