### PR TITLE
Improve libcontainer namespace and cap format

### DIFF
--- a/daemon/execdriver/native/configuration/parse.go
+++ b/daemon/execdriver/native/configuration/parse.go
@@ -2,12 +2,13 @@ package configuration
 
 import (
 	"fmt"
-	"github.com/dotcloud/docker/pkg/libcontainer"
-	"github.com/dotcloud/docker/utils"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/dotcloud/docker/pkg/libcontainer"
+	"github.com/dotcloud/docker/utils"
 )
 
 type Action func(*libcontainer.Container, interface{}, string) error
@@ -97,38 +98,22 @@ func memorySwap(container *libcontainer.Container, context interface{}, value st
 }
 
 func addCap(container *libcontainer.Container, context interface{}, value string) error {
-	c := container.CapabilitiesMask.Get(value)
-	if c == nil {
-		return fmt.Errorf("%s is not a valid capability", value)
-	}
-	c.Enabled = true
+	container.CapabilitiesMask[value] = true
 	return nil
 }
 
 func dropCap(container *libcontainer.Container, context interface{}, value string) error {
-	c := container.CapabilitiesMask.Get(value)
-	if c == nil {
-		return fmt.Errorf("%s is not a valid capability", value)
-	}
-	c.Enabled = false
+	container.CapabilitiesMask[value] = false
 	return nil
 }
 
 func addNamespace(container *libcontainer.Container, context interface{}, value string) error {
-	ns := container.Namespaces.Get(value)
-	if ns == nil {
-		return fmt.Errorf("%s is not a valid namespace", value[1:])
-	}
-	ns.Enabled = true
+	container.Namespaces[value] = true
 	return nil
 }
 
 func dropNamespace(container *libcontainer.Container, context interface{}, value string) error {
-	ns := container.Namespaces.Get(value)
-	if ns == nil {
-		return fmt.Errorf("%s is not a valid namespace", value[1:])
-	}
-	ns.Enabled = false
+	container.Namespaces[value] = false
 	return nil
 }
 

--- a/daemon/execdriver/native/configuration/parse_test.go
+++ b/daemon/execdriver/native/configuration/parse_test.go
@@ -1,8 +1,9 @@
 package configuration
 
 import (
-	"github.com/dotcloud/docker/daemon/execdriver/native/template"
 	"testing"
+
+	"github.com/dotcloud/docker/daemon/execdriver/native/template"
 )
 
 func TestSetReadonlyRootFs(t *testing.T) {
@@ -38,10 +39,10 @@ func TestConfigurationsDoNotConflict(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !container1.CapabilitiesMask.Get("NET_ADMIN").Enabled {
+	if !container1.CapabilitiesMask["NET_ADMIN"] {
 		t.Fatal("container one should have NET_ADMIN enabled")
 	}
-	if container2.CapabilitiesMask.Get("NET_ADMIN").Enabled {
+	if container2.CapabilitiesMask["NET_ADMIN"] {
 		t.Fatal("container two should not have NET_ADMIN enabled")
 	}
 }
@@ -137,10 +138,10 @@ func TestAddCap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !container.CapabilitiesMask.Get("MKNOD").Enabled {
+	if !container.CapabilitiesMask["MKNOD"] {
 		t.Fatal("container should have MKNOD enabled")
 	}
-	if !container.CapabilitiesMask.Get("SYS_ADMIN").Enabled {
+	if !container.CapabilitiesMask["SYS_ADMIN"] {
 		t.Fatal("container should have SYS_ADMIN enabled")
 	}
 }
@@ -153,14 +154,14 @@ func TestDropCap(t *testing.T) {
 		}
 	)
 	// enabled all caps like in privileged mode
-	for _, c := range container.CapabilitiesMask {
-		c.Enabled = true
+	for key := range container.CapabilitiesMask {
+		container.CapabilitiesMask[key] = true
 	}
 	if err := ParseConfiguration(container, nil, opts); err != nil {
 		t.Fatal(err)
 	}
 
-	if container.CapabilitiesMask.Get("MKNOD").Enabled {
+	if container.CapabilitiesMask["MKNOD"] {
 		t.Fatal("container should not have MKNOD enabled")
 	}
 }
@@ -176,7 +177,7 @@ func TestDropNamespace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if container.Namespaces.Get("NEWNET").Enabled {
+	if container.Namespaces["NEWNET"] {
 		t.Fatal("container should not have NEWNET enabled")
 	}
 }

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -79,8 +79,8 @@ func (d *driver) createNetwork(container *libcontainer.Container, c *execdriver.
 }
 
 func (d *driver) setPrivileged(container *libcontainer.Container) error {
-	for _, c := range container.CapabilitiesMask {
-		c.Enabled = true
+	for key := range container.CapabilitiesMask {
+		container.CapabilitiesMask[key] = true
 	}
 	container.Cgroups.DeviceAccess = true
 

--- a/daemon/execdriver/native/template/default_template.go
+++ b/daemon/execdriver/native/template/default_template.go
@@ -9,30 +9,30 @@ import (
 // New returns the docker default configuration for libcontainer
 func New() *libcontainer.Container {
 	container := &libcontainer.Container{
-		CapabilitiesMask: libcontainer.Capabilities{
-			libcontainer.GetCapability("SETPCAP"),
-			libcontainer.GetCapability("SYS_MODULE"),
-			libcontainer.GetCapability("SYS_RAWIO"),
-			libcontainer.GetCapability("SYS_PACCT"),
-			libcontainer.GetCapability("SYS_ADMIN"),
-			libcontainer.GetCapability("SYS_NICE"),
-			libcontainer.GetCapability("SYS_RESOURCE"),
-			libcontainer.GetCapability("SYS_TIME"),
-			libcontainer.GetCapability("SYS_TTY_CONFIG"),
-			libcontainer.GetCapability("AUDIT_WRITE"),
-			libcontainer.GetCapability("AUDIT_CONTROL"),
-			libcontainer.GetCapability("MAC_OVERRIDE"),
-			libcontainer.GetCapability("MAC_ADMIN"),
-			libcontainer.GetCapability("NET_ADMIN"),
-			libcontainer.GetCapability("MKNOD"),
-			libcontainer.GetCapability("SYSLOG"),
+		CapabilitiesMask: map[string]bool{
+			"SETPCAP":        false,
+			"SYS_MODULE":     false,
+			"SYS_RAWIO":      false,
+			"SYS_PACCT":      false,
+			"SYS_ADMIN":      false,
+			"SYS_NICE":       false,
+			"SYS_RESOURCE":   false,
+			"SYS_TIME":       false,
+			"SYS_TTY_CONFIG": false,
+			"AUDIT_WRITE":    false,
+			"AUDIT_CONTROL":  false,
+			"MAC_OVERRIDE":   false,
+			"MAC_ADMIN":      false,
+			"NET_ADMIN":      false,
+			"MKNOD":          true,
+			"SYSLOG":         false,
 		},
-		Namespaces: libcontainer.Namespaces{
-			libcontainer.GetNamespace("NEWNS"),
-			libcontainer.GetNamespace("NEWUTS"),
-			libcontainer.GetNamespace("NEWIPC"),
-			libcontainer.GetNamespace("NEWPID"),
-			libcontainer.GetNamespace("NEWNET"),
+		Namespaces: map[string]bool{
+			"NEWNS":  true,
+			"NEWUTS": true,
+			"NEWIPC": true,
+			"NEWPID": true,
+			"NEWNET": true,
 		},
 		Cgroups: &cgroups.Cgroup{
 			Parent:       "docker",
@@ -40,7 +40,6 @@ func New() *libcontainer.Container {
 		},
 		Context: libcontainer.Context{},
 	}
-	container.CapabilitiesMask.Get("MKNOD").Enabled = true
 	if apparmor.IsEnabled() {
 		container.Context["apparmor_profile"] = "docker-default"
 	}

--- a/pkg/libcontainer/container.go
+++ b/pkg/libcontainer/container.go
@@ -18,8 +18,8 @@ type Container struct {
 	WorkingDir       string          `json:"working_dir,omitempty"`       // current working directory
 	Env              []string        `json:"environment,omitempty"`       // environment to set
 	Tty              bool            `json:"tty,omitempty"`               // setup a proper tty or not
-	Namespaces       Namespaces      `json:"namespaces,omitempty"`        // namespaces to apply
-	CapabilitiesMask Capabilities    `json:"capabilities_mask,omitempty"` // capabilities to drop
+	Namespaces       map[string]bool `json:"namespaces,omitempty"`        // namespaces to apply
+	CapabilitiesMask map[string]bool `json:"capabilities_mask,omitempty"` // capabilities to drop
 	Networks         []*Network      `json:"networks,omitempty"`          // nil for host's network stack
 	Cgroups          *cgroups.Cgroup `json:"cgroups,omitempty"`           // cgroups
 	Context          Context         `json:"context,omitempty"`           // generic context for specific options (apparmor, selinux)

--- a/pkg/libcontainer/container.json
+++ b/pkg/libcontainer/container.json
@@ -1,151 +1,62 @@
 {
-   "mounts" : [
-      {
-         "type" : "devtmpfs"
-      }
-   ],
-   "tty" : true,
-   "environment" : [
-      "HOME=/",
-      "PATH=PATH=$PATH:/bin:/usr/bin:/sbin:/usr/sbin",
-      "container=docker",
-      "TERM=xterm-256color"
-   ],
-   "hostname" : "koye",
-   "cgroups" : {
-      "parent" : "docker",
-      "name" : "docker-koye"
-   },
-   "capabilities_mask" : [
-      {
-         "value" : 8,
-         "key" : "SETPCAP",
-         "enabled" : false
+  "namespaces": {
+    "NEWNET": true,
+    "NEWPID": true,
+    "NEWIPC": true,
+    "NEWUTS": true,
+    "NEWNS": true
+  },
+  "networks": [
+    {
+      "gateway": "localhost",
+      "type": "loopback",
+      "address": "127.0.0.1/0",
+      "mtu": 1500
+    },
+    {
+      "gateway": "172.17.42.1",
+      "context": {
+        "prefix": "veth",
+        "bridge": "docker0"
       },
-      {
-         "enabled" : false,
-         "value" : 16,
-         "key" : "SYS_MODULE"
-      },
-      {
-         "value" : 17,
-         "key" : "SYS_RAWIO",
-         "enabled" : false
-      },
-      {
-         "key" : "SYS_PACCT",
-         "value" : 20,
-         "enabled" : false
-      },
-      {
-         "value" : 21,
-         "key" : "SYS_ADMIN",
-         "enabled" : false
-      },
-      {
-         "value" : 23,
-         "key" : "SYS_NICE",
-         "enabled" : false
-      },
-      {
-         "value" : 24,
-         "key" : "SYS_RESOURCE",
-         "enabled" : false
-      },
-      {
-         "key" : "SYS_TIME",
-         "value" : 25,
-         "enabled" : false
-      },
-      {
-         "enabled" : false,
-         "value" : 26,
-         "key" : "SYS_TTY_CONFIG"
-      },
-      {
-         "key" : "AUDIT_WRITE",
-         "value" : 29,
-         "enabled" : false
-      },
-      {
-         "value" : 30,
-         "key" : "AUDIT_CONTROL",
-         "enabled" : false
-      },
-      {
-         "enabled" : false,
-         "key" : "MAC_OVERRIDE",
-         "value" : 32
-      },
-      {
-         "enabled" : false,
-         "key" : "MAC_ADMIN",
-         "value" : 33
-      },
-      {
-         "key" : "NET_ADMIN",
-         "value" : 12,
-         "enabled" : false
-      },
-      {
-         "value" : 27,
-         "key" : "MKNOD",
-         "enabled" : true
-      },
-      {
-         "value" : 34,
-         "key" : "SYSLOG",
-         "enabled" : false
-      }
-   ],
-   "networks" : [
-      {
-         "mtu" : 1500,
-         "address" : "127.0.0.1/0",
-         "type" : "loopback",
-         "gateway" : "localhost"
-      },
-      {
-         "mtu" : 1500,
-         "address" : "172.17.42.2/16",
-         "type" : "veth",
-         "context" : {
-            "bridge" : "docker0",
-            "prefix" : "veth"
-         },
-         "gateway" : "172.17.42.1"
-      }
-   ],
-   "namespaces" : [
-      {
-         "key" : "NEWNS",
-         "value" : 131072,
-         "enabled" : true,
-         "file" : "mnt"
-      },
-      {
-         "key" : "NEWUTS",
-         "value" : 67108864,
-         "enabled" : true,
-         "file" : "uts"
-      },
-      {
-         "enabled" : true,
-         "file" : "ipc",
-         "key" : "NEWIPC",
-         "value" : 134217728
-      },
-      {
-         "file" : "pid",
-         "enabled" : true,
-         "value" : 536870912,
-         "key" : "NEWPID"
-      },
-      {
-         "enabled" : true,
-         "file" : "net",
-         "key" : "NEWNET",
-         "value" : 1073741824
-      }
-   ]
+      "type": "veth",
+      "address": "172.17.42.2/16",
+      "mtu": 1500
+    }
+  ],
+  "capabilities_mask": {
+    "SYSLOG": false,
+    "MKNOD": true,
+    "NET_ADMIN": false,
+    "MAC_ADMIN": false,
+    "MAC_OVERRIDE": false,
+    "AUDIT_CONTROL": false,
+    "AUDIT_WRITE": false,
+    "SYS_TTY_CONFIG": false,
+    "SETPCAP": false,
+    "SYS_MODULE": false,
+    "SYS_RAWIO": false,
+    "SYS_PACCT": false,
+    "SYS_ADMIN": false,
+    "SYS_NICE": false,
+    "SYS_RESOURCE": false,
+    "SYS_TIME": false
+  },
+  "cgroups": {
+    "name": "docker-koye",
+    "parent": "docker"
+  },
+  "hostname": "koye",
+  "environment": [
+    "HOME=/",
+    "PATH=PATH=$PATH:/bin:/usr/bin:/sbin:/usr/sbin",
+    "container=docker",
+    "TERM=xterm-256color"
+  ],
+  "tty": true,
+  "mounts": [
+    {
+      "type": "devtmpfs"
+    }
+  ]
 }

--- a/pkg/libcontainer/container_test.go
+++ b/pkg/libcontainer/container_test.go
@@ -15,7 +15,7 @@ func TestContainerJsonFormat(t *testing.T) {
 
 	var container *Container
 	if err := json.NewDecoder(f).Decode(&container); err != nil {
-		t.Fatal("failed to decode container config")
+		t.Fatalf("failed to decode container config: %s", err)
 	}
 	if container.Hostname != "koye" {
 		t.Log("hostname is not set")
@@ -27,32 +27,32 @@ func TestContainerJsonFormat(t *testing.T) {
 		t.Fail()
 	}
 
-	if !container.Namespaces.Contains("NEWNET") {
+	if !container.Namespaces["NEWNET"] {
 		t.Log("namespaces should contain NEWNET")
 		t.Fail()
 	}
 
-	if container.Namespaces.Contains("NEWUSER") {
+	if container.Namespaces["NEWUSER"] {
 		t.Log("namespaces should not contain NEWUSER")
 		t.Fail()
 	}
 
-	if !container.CapabilitiesMask.Contains("SYS_ADMIN") {
+	if _, exists := container.CapabilitiesMask["SYS_ADMIN"]; !exists {
 		t.Log("capabilities mask should contain SYS_ADMIN")
 		t.Fail()
 	}
 
-	if container.CapabilitiesMask.Get("SYS_ADMIN").Enabled {
+	if container.CapabilitiesMask["SYS_ADMIN"] {
 		t.Log("SYS_ADMIN should not be enabled in capabilities mask")
 		t.Fail()
 	}
 
-	if !container.CapabilitiesMask.Get("MKNOD").Enabled {
+	if !container.CapabilitiesMask["MKNOD"] {
 		t.Log("MKNOD should be enabled in capabilities mask")
 		t.Fail()
 	}
 
-	if container.CapabilitiesMask.Contains("SYS_CHROOT") {
+	if container.CapabilitiesMask["SYS_CHROOT"] {
 		t.Log("capabilities mask should not contain SYS_CHROOT")
 		t.Fail()
 	}

--- a/pkg/libcontainer/nsinit/exec.go
+++ b/pkg/libcontainer/nsinit/exec.go
@@ -159,10 +159,12 @@ func InitializeNetworking(container *libcontainer.Container, nspid int, pipe *Sy
 
 // GetNamespaceFlags parses the container's Namespaces options to set the correct
 // flags on clone, unshare, and setns
-func GetNamespaceFlags(namespaces libcontainer.Namespaces) (flag int) {
-	for _, ns := range namespaces {
-		if ns.Enabled {
-			flag |= ns.Value
+func GetNamespaceFlags(namespaces map[string]bool) (flag int) {
+	for key, enabled := range namespaces {
+		if enabled {
+			if ns := libcontainer.GetNamespace(key); ns != nil {
+				flag |= ns.Value
+			}
 		}
 	}
 	return flag

--- a/pkg/libcontainer/nsinit/unsupported.go
+++ b/pkg/libcontainer/nsinit/unsupported.go
@@ -23,6 +23,6 @@ func SetupCgroups(container *libcontainer.Container, nspid int) (cgroups.ActiveC
 	return nil, libcontainer.ErrUnsupported
 }
 
-func GetNamespaceFlags(namespaces libcontainer.Namespaces) (flag int) {
+func GetNamespaceFlags(namespaces map[string]bool) (flag int) {
 	return 0
 }

--- a/pkg/libcontainer/security/capabilities/capabilities.go
+++ b/pkg/libcontainer/security/capabilities/capabilities.go
@@ -1,9 +1,10 @@
 package capabilities
 
 import (
+	"os"
+
 	"github.com/dotcloud/docker/pkg/libcontainer"
 	"github.com/syndtr/gocapability/capability"
-	"os"
 )
 
 // DropCapabilities drops capabilities for the current process based
@@ -26,9 +27,11 @@ func DropCapabilities(container *libcontainer.Container) error {
 // getCapabilitiesMask returns the specific cap mask values for the libcontainer types
 func getCapabilitiesMask(container *libcontainer.Container) []capability.Cap {
 	drop := []capability.Cap{}
-	for _, c := range container.CapabilitiesMask {
-		if !c.Enabled {
-			drop = append(drop, c.Value)
+	for key, enabled := range container.CapabilitiesMask {
+		if !enabled {
+			if c := libcontainer.GetCapability(key); c != nil {
+				drop = append(drop, c.Value)
+			}
 		}
 	}
 	return drop

--- a/pkg/libcontainer/types.go
+++ b/pkg/libcontainer/types.go
@@ -2,6 +2,7 @@ package libcontainer
 
 import (
 	"errors"
+
 	"github.com/syndtr/gocapability/capability"
 )
 
@@ -38,31 +39,30 @@ var (
 	namespaceList = Namespaces{}
 
 	capabilityList = Capabilities{
-		{Key: "SETPCAP", Value: capability.CAP_SETPCAP, Enabled: false},
-		{Key: "SYS_MODULE", Value: capability.CAP_SYS_MODULE, Enabled: false},
-		{Key: "SYS_RAWIO", Value: capability.CAP_SYS_RAWIO, Enabled: false},
-		{Key: "SYS_PACCT", Value: capability.CAP_SYS_PACCT, Enabled: false},
-		{Key: "SYS_ADMIN", Value: capability.CAP_SYS_ADMIN, Enabled: false},
-		{Key: "SYS_NICE", Value: capability.CAP_SYS_NICE, Enabled: false},
-		{Key: "SYS_RESOURCE", Value: capability.CAP_SYS_RESOURCE, Enabled: false},
-		{Key: "SYS_TIME", Value: capability.CAP_SYS_TIME, Enabled: false},
-		{Key: "SYS_TTY_CONFIG", Value: capability.CAP_SYS_TTY_CONFIG, Enabled: false},
-		{Key: "MKNOD", Value: capability.CAP_MKNOD, Enabled: false},
-		{Key: "AUDIT_WRITE", Value: capability.CAP_AUDIT_WRITE, Enabled: false},
-		{Key: "AUDIT_CONTROL", Value: capability.CAP_AUDIT_CONTROL, Enabled: false},
-		{Key: "MAC_OVERRIDE", Value: capability.CAP_MAC_OVERRIDE, Enabled: false},
-		{Key: "MAC_ADMIN", Value: capability.CAP_MAC_ADMIN, Enabled: false},
-		{Key: "NET_ADMIN", Value: capability.CAP_NET_ADMIN, Enabled: false},
-		{Key: "SYSLOG", Value: capability.CAP_SYSLOG, Enabled: false},
+		{Key: "SETPCAP", Value: capability.CAP_SETPCAP},
+		{Key: "SYS_MODULE", Value: capability.CAP_SYS_MODULE},
+		{Key: "SYS_RAWIO", Value: capability.CAP_SYS_RAWIO},
+		{Key: "SYS_PACCT", Value: capability.CAP_SYS_PACCT},
+		{Key: "SYS_ADMIN", Value: capability.CAP_SYS_ADMIN},
+		{Key: "SYS_NICE", Value: capability.CAP_SYS_NICE},
+		{Key: "SYS_RESOURCE", Value: capability.CAP_SYS_RESOURCE},
+		{Key: "SYS_TIME", Value: capability.CAP_SYS_TIME},
+		{Key: "SYS_TTY_CONFIG", Value: capability.CAP_SYS_TTY_CONFIG},
+		{Key: "MKNOD", Value: capability.CAP_MKNOD},
+		{Key: "AUDIT_WRITE", Value: capability.CAP_AUDIT_WRITE},
+		{Key: "AUDIT_CONTROL", Value: capability.CAP_AUDIT_CONTROL},
+		{Key: "MAC_OVERRIDE", Value: capability.CAP_MAC_OVERRIDE},
+		{Key: "MAC_ADMIN", Value: capability.CAP_MAC_ADMIN},
+		{Key: "NET_ADMIN", Value: capability.CAP_NET_ADMIN},
+		{Key: "SYSLOG", Value: capability.CAP_SYSLOG},
 	}
 )
 
 type (
 	Namespace struct {
-		Key     string `json:"key,omitempty"`
-		Enabled bool   `json:"enabled,omitempty"`
-		Value   int    `json:"value,omitempty"`
-		File    string `json:"file,omitempty"`
+		Key   string `json:"key,omitempty"`
+		Value int    `json:"value,omitempty"`
+		File  string `json:"file,omitempty"`
 	}
 	Namespaces []*Namespace
 )
@@ -98,9 +98,8 @@ func (n Namespaces) Get(ns string) *Namespace {
 
 type (
 	Capability struct {
-		Key     string         `json:"key,omitempty"`
-		Enabled bool           `json:"enabled"`
-		Value   capability.Cap `json:"value,omitempty"`
+		Key   string         `json:"key,omitempty"`
+		Value capability.Cap `json:"value,omitempty"`
 	}
 	Capabilities []*Capability
 )

--- a/pkg/libcontainer/types_linux.go
+++ b/pkg/libcontainer/types_linux.go
@@ -6,11 +6,11 @@ import (
 
 func init() {
 	namespaceList = Namespaces{
-		{Key: "NEWNS", Value: syscall.CLONE_NEWNS, File: "mnt", Enabled: true},
-		{Key: "NEWUTS", Value: syscall.CLONE_NEWUTS, File: "uts", Enabled: true},
-		{Key: "NEWIPC", Value: syscall.CLONE_NEWIPC, File: "ipc", Enabled: true},
-		{Key: "NEWUSER", Value: syscall.CLONE_NEWUSER, File: "user", Enabled: true},
-		{Key: "NEWPID", Value: syscall.CLONE_NEWPID, File: "pid", Enabled: true},
-		{Key: "NEWNET", Value: syscall.CLONE_NEWNET, File: "net", Enabled: true},
+		{Key: "NEWNS", Value: syscall.CLONE_NEWNS, File: "mnt"},
+		{Key: "NEWUTS", Value: syscall.CLONE_NEWUTS, File: "uts"},
+		{Key: "NEWIPC", Value: syscall.CLONE_NEWIPC, File: "ipc"},
+		{Key: "NEWUSER", Value: syscall.CLONE_NEWUSER, File: "user"},
+		{Key: "NEWPID", Value: syscall.CLONE_NEWPID, File: "pid"},
+		{Key: "NEWNET", Value: syscall.CLONE_NEWNET, File: "net"},
 	}
 }


### PR DESCRIPTION
This changes the format from using the Capability and Namespace types to using a map[string]bool so that the json output is simpler and easier to use.

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
