### PR TITLE
Fixed broken tests for pkg/networkfs/etchosts

### DIFF
--- a/pkg/networkfs/etchosts/etchosts_test.go
+++ b/pkg/networkfs/etchosts/etchosts_test.go
@@ -14,7 +14,7 @@ func TestBuildHostnameDomainname(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 
-	err = Build(file.Name(), "10.11.12.13", "testhostname", "testdomainname")
+	err = Build(file.Name(), "10.11.12.13", "testhostname", "testdomainname", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func TestBuildHostname(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 
-	err = Build(file.Name(), "10.11.12.13", "testhostname", "")
+	err = Build(file.Name(), "10.11.12.13", "testhostname", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestBuildNoIP(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 
-	err = Build(file.Name(), "", "testhostname", "")
+	err = Build(file.Name(), "", "testhostname", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The tests for `pkg/networkfs/etchosts` don't build properly:

```
+ go test github.com/dotcloud/docker/pkg/networkfs/etchosts
# github.com/dotcloud/docker/pkg/networkfs/etchosts
./etchosts_test.go:17: not enough arguments in call to Build
./etchosts_test.go:39: not enough arguments in call to Build
./etchosts_test.go:61: not enough arguments in call to Build
FAIL    github.com/dotcloud/docker/pkg/networkfs/etchosts [build failed]

Tests failed: ./pkg/networkfs/etchosts
```

This pull request fixes the above issue, which was caused by a change to the `pkg/networkfs/etchosts` `Build` signature in 53f38a14 and the tests not being updated.

/cc @vieux
