### PR TITLE
registry: adding vbatts to the MAINTAINERS

### DIFF
--- a/registry/MAINTAINERS
+++ b/registry/MAINTAINERS
@@ -1,3 +1,4 @@
 Sam Alba <sam@dotcloud.com> (@samalba)
 Joffrey Fuhrer <joffrey@dotcloud.com> (@shin-)
 Ken Cochrane <ken@dotcloud.com> (@kencochrane)
+Vincent Batts <vbatts@redhat.com> (@vbatts)


### PR DESCRIPTION
Per conversation with @crosbymichael

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
