### PR TITLE
mkimage-debootstrap: set ubuntuLatestLTS as Trusty

### DIFF
--- a/contrib/mkimage-debootstrap.sh
+++ b/contrib/mkimage-debootstrap.sh
@@ -43,7 +43,7 @@ usage() {
 debianStable=wheezy
 debianUnstable=sid
 # this should match the name found at http://releases.ubuntu.com/
-ubuntuLatestLTS=precise
+ubuntuLatestLTS=trusty
 # this should match the name found at http://releases.tanglu.org/
 tangluLatest=aequorea
 


### PR DESCRIPTION
Ubuntu 14.04 LTS (Trusty Tahr) was released on Thu, 17 Apr 2014; Update
ubuntuLatestLTS accordingly.

Signed-off-by: Jonathan McCrohan jmccrohan@gmail.com
