### PR TITLE
5648 Docker CLI Enhancements (Remotes and Plugins)

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -13,6 +13,7 @@ import (
 	flag "github.com/dotcloud/docker/pkg/mflag"
 	"github.com/dotcloud/docker/pkg/term"
 	"github.com/dotcloud/docker/registry"
+	"github.com/dotcloud/docker/utils"
 )
 
 var funcMap = template.FuncMap{
@@ -25,46 +26,87 @@ var funcMap = template.FuncMap{
 func (cli *DockerCli) getMethod(name string) (func(...string) error, bool) {
 	methodName := "Cmd" + strings.ToUpper(name[:1]) + strings.ToLower(name[1:])
 	method := reflect.ValueOf(cli).MethodByName(methodName)
+
 	if !method.IsValid() {
 		return nil, false
 	}
+
 	return method.Interface().(func(...string) error), true
 }
 
 func (cli *DockerCli) ParseCommands(args ...string) error {
 	if len(args) > 0 {
-		method, exists := cli.getMethod(args[0])
+		cmdStr := args[0]
+		args_slice := args[1:]
+		method, exists := cli.getMethod(cmdStr)
+
 		if !exists {
-			fmt.Println("Error: Command not found:", args[0])
-			return cli.CmdHelp(args[1:]...)
+			fmt.Println("Error: Command not found:", cmdStr)
+			return cli.CmdHelp(args_slice...)
 		}
-		return method(args[1:]...)
+
+		// Hook for calling the plugins before a command method is executed
+		for name, plugin := range cli.Plugins {
+			utils.Debugf("Calling Plugin(%s).Before(...)", name)
+
+			result, err := plugin.Before(cli, cmdStr, args_slice)
+
+			switch result.Action {
+			case PLUGIN_ARGS_REWRITE:
+				if new_args, convertedOkay := result.Payload.([]string); convertedOkay {
+					args_slice = new_args
+				} else {
+					return fmt.Errorf("Plugin Error: Unable to convert %s into type []string.")
+				}
+
+			case PLUGIN_EXIT_CMD:
+				return err
+			}
+		}
+
+		callErr := method(args_slice...)
+
+		// Hook for calling the plugins after a command method is executed
+		for name, plugin := range cli.Plugins {
+			utils.Debugf("Calling Plugin(%s).After(...)", name)
+
+			if err := plugin.After(cli, callErr, cmdStr, args_slice); err != nil {
+				utils.Errorf("Plugin(%s) failed execution: %s.", name, err)
+			}
+		}
+
+		return callErr
 	}
+
 	return cli.CmdHelp(args...)
 }
 
 func (cli *DockerCli) Subcmd(name, signature, description string) *flag.FlagSet {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	flags.Usage = func() {
-		fmt.Fprintf(cli.err, "\nUsage: docker %s %s\n\n%s\n\n", name, signature, description)
+		fmt.Fprintf(cli.Err, "\nUsage: docker %s %s\n\n%s\n\n", name, signature, description)
 		flags.PrintDefaults()
 		os.Exit(2)
 	}
 	return flags
 }
 
-func (cli *DockerCli) LoadConfigFile() (err error) {
-	cli.configFile, err = registry.LoadConfig(os.Getenv("HOME"))
-	if err != nil {
-		fmt.Fprintf(cli.err, "WARNING: %s\n", err)
+func (cli *DockerCli) LoadConfigFile() (*registry.ConfigFile, error) {
+	userHome := os.Getenv("HOME")
+
+	if configFile, err := registry.LoadConfig(userHome); err == nil {
+		return configFile, nil
+	} else {
+		return nil, err
 	}
-	return err
 }
 
 func NewDockerCli(in io.ReadCloser, out, err io.Writer, proto, addr string, tlsConfig *tls.Config) *DockerCli {
 	var (
 		isTerminal = false
 		terminalFd uintptr
+		cliRemote  CliRemote
+		cliPlugins = make(map[string]CliPlugin)
 		scheme     = "http"
 	)
 
@@ -82,28 +124,65 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, proto, addr string, tlsC
 	if err == nil {
 		err = out
 	}
+
+	// Figure out which remote should be active, if any.
+	if cliRemoteEnv := os.Getenv("DOCKER_CLI_REMOTE"); cliRemoteEnv != "" {
+		cliRemoteName := strings.Trim(cliRemoteEnv, " \t\r\n")
+
+		if remoteInstance, err := NewCliRemote(cliRemoteName); err == nil {
+			cliRemote = remoteInstance
+		} else {
+			utils.Errorf("Unable to init CLI remote: %s", cliRemoteName)
+		}
+	}
+
+	// Use the default remote if no remote was specified by the user.
+	if cliRemote == nil {
+		if remoteInstance, err := NewCliRemote("http"); err == nil {
+			cliRemote = remoteInstance
+		} else {
+			utils.Errorf("Unable to init the default CLI remote: http.")
+		}
+	}
+
+	if cliPluginEnv := os.Getenv("DOCKER_CLI_PLUGINS"); cliPluginEnv != "" {
+		for _, str := range strings.Split(cliPluginEnv, ",") {
+			cliPluginName := strings.Trim(str, " \t\r\n")
+
+			if pluginInstance, err := NewCliPlugin(cliPluginName); err == nil {
+				cliPlugins[cliPluginName] = pluginInstance
+			} else {
+				utils.Errorf("Unable to init CLI plugin: %s", cliPluginName)
+			}
+		}
+	}
+
 	return &DockerCli{
-		proto:      proto,
-		addr:       addr,
-		in:         in,
-		out:        out,
-		err:        err,
-		isTerminal: isTerminal,
-		terminalFd: terminalFd,
-		tlsConfig:  tlsConfig,
-		scheme:     scheme,
+		Proto:      proto,
+		Address:    addr,
+		Remote:     cliRemote,
+		Plugins:    cliPlugins,
+		In:         in,
+		Out:        out,
+		Err:        err,
+		IsTerminal: isTerminal,
+		TerminalFd: terminalFd,
+		TlsConfig:  tlsConfig,
+		Scheme:     scheme,
 	}
 }
 
 type DockerCli struct {
-	proto      string
-	addr       string
-	configFile *registry.ConfigFile
-	in         io.ReadCloser
-	out        io.Writer
-	err        io.Writer
-	isTerminal bool
-	terminalFd uintptr
-	tlsConfig  *tls.Config
-	scheme     string
+	Proto      string
+	Address    string
+	Remote     CliRemote
+	Plugins    map[string]CliPlugin
+	ConfigFile *registry.ConfigFile
+	In         io.ReadCloser
+	Out        io.Writer
+	Err        io.Writer
+	IsTerminal bool
+	TerminalFd uintptr
+	TlsConfig  *tls.Config
+	Scheme     string
 }

--- a/api/client/plugin.go
+++ b/api/client/plugin.go
@@ -1,0 +1,85 @@
+package client
+
+import (
+	"fmt"
+)
+
+const (
+	// Continuing the command allows the flow of the command to continue
+	// once the flow exits the plugin.
+	PLUGIN_CONTINUE_CMD = 0
+
+	// Rewriting the command arguments allows the plugin to influence the
+	// command being executed. This is useful for things such as naming,
+	// addresses and more. Plugins further down the chain will see the
+	// modified args.
+	//
+	// The payload of the associated PluginResult is expected to be of type
+	// string[].
+	PLUGIN_ARGS_REWRITE = 1
+
+	// Exiting the command allows a plugin to cancel the flow of a command
+	// and returning to the user. This is useful in error conditions.
+	PLUGIN_EXIT_CMD = 2
+)
+
+// A PluginResult is a type for communicating actions a plugin wishes to be
+// taken as well as any required information for the action in the form of
+// a payload of type interface{}.
+type PluginResult struct {
+	Action  int
+	Payload interface{}
+}
+
+// A CliPlugin type implements two methods that represent call hooks that
+// may be executed either before or after the execution of the command
+// being invoked by the CLI user.
+type CliPlugin interface {
+	Before(cli *DockerCli, cmd string, args []string) (result *PluginResult, err error)
+	After(cli *DockerCli, callError error, cmd string, args []string) (err error)
+}
+
+// A CliPlugin needs a portable initialization method to allow for easier
+// registration and management.
+type CliPluginInit func() (plugin CliPlugin, err error)
+
+var (
+	// All registered plugins
+	plugins map[string]CliPluginInit
+)
+
+func init() {
+	plugins = make(map[string]CliPluginInit)
+}
+
+// Finds a CliPlugin with a given name. If there is no regisitered plugin
+// with a matching name then an error is returned.
+func findPlugin(name string) (CliPluginInit, error) {
+	if initFunc, exists := plugins[name]; exists {
+		return initFunc, nil
+	}
+
+	return nil, fmt.Errorf("No such plugin: %s", name)
+}
+
+// Registers a CliPlugin in order to make it available for activation and
+// use.
+func RegisterPlugin(name string, initFunc CliPluginInit) error {
+	if _, exists := plugins[name]; exists {
+		return fmt.Errorf("Name already registered %s", name)
+	}
+
+	plugins[name] = initFunc
+	return nil
+}
+
+// Creates a new CliPlugin instance of the registered plugin with a name
+// matching the user supplied name argument. If no plugin is found with
+// a matching name, an error is returned.
+func NewCliPlugin(name string) (CliPlugin, error) {
+	if initFunc, err := findPlugin(name); err == nil {
+		return initFunc()
+	} else {
+		return nil, err
+	}
+}

--- a/api/client/remote.go
+++ b/api/client/remote.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"net"
+)
+
+// A CallDetails type contains all of the information necessarry to
+// to communicate CLI user intent to a remote Docker system.
+type CallDetails struct {
+	Method       string
+	Path         string
+	Data         interface{}
+	PassAuthInfo bool
+}
+
+// A CliRemote type represents a plugable component that can both create
+// network connections via the Dial method and act upon them via the Call
+// method.
+//
+// By implementing the hooks, a remote plugin can successfully route and
+// manage the outgoing command.
+type CliRemote interface {
+	Call(cli *DockerCli, callDetails *CallDetails) (io.ReadCloser, int, error)
+	Dial(cli *DockerCli) (net.Conn, error)
+}
+
+// A CliRemote needs a portable initialization method to allow for easier
+// registration and management.
+type CliRemoteInit func() (CliRemote, error)
+
+var (
+	// All registered remotes
+	remotes map[string]CliRemoteInit
+)
+
+func init() {
+	remotes = make(map[string]CliRemoteInit)
+}
+
+// Finds a CliRemote with a given name. If there is no regisitered remote
+// with a matching name then an error is returned.
+func findRemote(name string) (CliRemoteInit, error) {
+	if initFunc, exists := remotes[name]; exists {
+		return initFunc, nil
+	}
+
+	return nil, fmt.Errorf("No such remote: %s", name)
+}
+
+// Registers a CliRemote in order to make it available for activation and
+// use.
+func RegisterRemote(name string, initFunc CliRemoteInit) error {
+	if _, exists := remotes[name]; exists {
+		return fmt.Errorf("Name already registered %s", name)
+	}
+
+	remotes[name] = initFunc
+	return nil
+}
+
+// Creates a new CliRemote instance of the registered remote with a name
+// matching the user supplied name argument. If no remote is found with
+// a matching name, an error is returned.
+func NewCliRemote(name string) (CliRemote, error) {
+	if initFunc, err := findRemote(name); err == nil {
+		return initFunc()
+	} else {
+		return nil, err
+	}
+}

--- a/api/client_extensions/http/remote.go
+++ b/api/client_extensions/http/remote.go
@@ -1,0 +1,122 @@
+package http
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/dotcloud/docker/api"
+	"github.com/dotcloud/docker/api/client"
+	"github.com/dotcloud/docker/dockerversion"
+	"github.com/dotcloud/docker/engine"
+	"github.com/dotcloud/docker/registry"
+)
+
+var (
+	ErrConnectionRefused = errors.New("Cannot connect to the Docker daemon. Is 'docker -d' running on this host?")
+)
+
+func init() {
+	client.RegisterRemote("http", Init)
+}
+
+type HttpRemote struct {
+	name string
+}
+
+var Init = func() (client.CliRemote, error) {
+	return &HttpRemote{
+		name: "base",
+	}, nil
+}
+
+func (hr *HttpRemote) Dial(cli *client.DockerCli) (net.Conn, error) {
+	if cli.TlsConfig != nil && cli.Proto != "unix" {
+		return tls.Dial(cli.Proto, cli.Address, cli.TlsConfig)
+	}
+
+	return net.Dial(cli.Proto, cli.Address)
+}
+
+func (hr *HttpRemote) Call(cli *client.DockerCli, callDetails *client.CallDetails) (io.ReadCloser, int, error) {
+	params := bytes.NewBuffer(nil)
+	if callDetails.Data != nil {
+		if env, ok := callDetails.Data.(engine.Env); ok {
+			if err := env.Encode(params); err != nil {
+				return nil, -1, err
+			}
+		} else {
+			buf, err := json.Marshal(callDetails.Data)
+			if err != nil {
+				return nil, -1, err
+			}
+			if _, err := params.Write(buf); err != nil {
+				return nil, -1, err
+			}
+		}
+	}
+
+	req, err := http.NewRequest(callDetails.Method, fmt.Sprintf("/v%s%s", api.APIVERSION, callDetails.Path), params)
+	if err != nil {
+		return nil, -1, err
+	}
+	if callDetails.PassAuthInfo {
+		cli.LoadConfigFile()
+		// Resolve the Auth config relevant for this server
+		authConfig := cli.ConfigFile.ResolveAuthConfig(registry.IndexServerAddress())
+		getHeaders := func(authConfig registry.AuthConfig) (map[string][]string, error) {
+			buf, err := json.Marshal(authConfig)
+			if err != nil {
+				return nil, err
+			}
+			registryAuthHeader := []string{
+				base64.URLEncoding.EncodeToString(buf),
+			}
+			return map[string][]string{"X-Registry-Auth": registryAuthHeader}, nil
+		}
+		if headers, err := getHeaders(authConfig); err == nil && headers != nil {
+			for k, v := range headers {
+				req.Header[k] = v
+			}
+		}
+	}
+	req.Header.Set("User-Agent", "Docker-Client/"+dockerversion.VERSION)
+	req.URL.Host = cli.Address
+	req.URL.Scheme = cli.Scheme
+	if callDetails.Data != nil {
+		req.Header.Set("Content-Type", "application/json")
+	} else if callDetails.Method == "POST" {
+		req.Header.Set("Content-Type", "plain/text")
+	}
+	resp, err := cli.HTTPClient().Do(req)
+	if err != nil {
+		if strings.Contains(err.Error(), "connection refused") {
+			return nil, -1, ErrConnectionRefused
+		}
+		return nil, -1, err
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, -1, err
+		}
+		if len(body) == 0 {
+			return nil, resp.StatusCode, fmt.Errorf("Error: request returned %s for API route and version %s, check if the server supports the requested API version", http.StatusText(resp.StatusCode), req.URL)
+		}
+		return nil, resp.StatusCode, fmt.Errorf("Error: %s", bytes.TrimSpace(body))
+	}
+	return resp.Body, resp.StatusCode, nil
+}
+
+func (hr *HttpRemote) String() string {
+	return hr.name
+}

--- a/api/client_extensions/plugins.go
+++ b/api/client_extensions/plugins.go
@@ -1,0 +1,3 @@
+package client_extensions
+
+import ()

--- a/api/client_extensions/remotes.go
+++ b/api/client_extensions/remotes.go
@@ -1,0 +1,5 @@
+package client_extensions
+
+import (
+	_ "github.com/dotcloud/docker/api/client_extensions/http"
+)

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dotcloud/docker/api"
 	"github.com/dotcloud/docker/api/client"
+	_ "github.com/dotcloud/docker/api/client_extensions"
 	"github.com/dotcloud/docker/builtins"
 	"github.com/dotcloud/docker/dockerversion"
 	"github.com/dotcloud/docker/engine"

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -140,3 +140,4 @@ pages:
 - ['contributing/index.md', '**HIDDEN**']
 - ['contributing/contributing.md', 'Contribute', 'Contributing']
 - ['contributing/devenvironment.md', 'Contribute', 'Development environment']
+- ['contributing/cli-extension-development.md', 'Contribute', 'CLI Extension Development']

--- a/docs/sources/contributing.md
+++ b/docs/sources/contributing.md
@@ -4,4 +4,5 @@
 
  - [Contributing to Docker](contributing/)
  - [Setting Up a Dev Environment](devenvironment/)
+ - [Docker CLI Extensions](cli-extension-development/)
 

--- a/docs/sources/contributing/cli-extension-development.md
+++ b/docs/sources/contributing/cli-extension-development.md
@@ -1,0 +1,255 @@
+page_title: Writing CLI Extensions
+page_description: Guides on how to write and contribute Docker CLI extensions
+page_keywords: Docker, documentation, developers, contributing, plugins, remotes, extensions, cli
+
+# Writing a Docker CLI Extensions
+
+## Writing Docker CLI Plugins
+
+Docker CLI plugins allow developers to extend the client side behaviour of
+Docker by hooking into a command before and after it executes. This allows
+for the addition of functionality such as scheduling of resources.
+
+Plugins are organized into an array and are executed in the order they are
+specified by the user. When executed, each plugin's hook is called and its
+result or error handled accordingly.
+
+Plugin writing begins with the two plugin interfaces:
+
+    // A CliPlugin type implements two methods that represent call hooks that
+    // may be executed either before or after the execution of the command
+    // being invoked by the CLI user.
+
+    type CliPlugin interface {
+        Before(cli *DockerCli, cmd string, args []string) (result *PluginResult, err error)
+        After(cli *DockerCli, callError error, cmd string, args []string) (err error)
+    }
+
+    // A CliPlugin needs a portable initialization method to allow for easier
+    // registration and management.
+    type CliPluginInit func() (plugin *CliPlugin, err error)
+
+## Plugin Registration
+
+Before a plugin can be referenced and used, it must be registered with the
+Docker CLI. This is done by first adding the plugin to an imports file
+located at [api/client_extensions/plugins.go](https://github.com/dotcloud/docker/api/client_extensions/plugins.go).
+This will pull in the plugin code during compile time.
+
+## Plugin - Init
+
+After the package import for the plugin has been added to Docker, the plugin
+must register itself. This may be done easily from an init function.
+
+    package example
+
+    import (
+        client "github.com/dotcloud/docker/api/client"
+    )
+
+    type MyPlugin struct {}
+
+    func init() {
+        client.RegisterPlugin("my_plugin", &MyPlugin {})
+    }
+
+## Plugin - Before
+
+The Before method returns a PluginResult, a type that allows a plugin to
+inform Docker of its desired impact on the command execution life cycle. The
+following actions are available to developers.
+
+#### client.PLUGIN_CONTINUE_CMD
+
+    func (mp *MyPlugin) Before(cli *client.DockerCli, cmd string, args []string) (result *PluginResult, err error) {
+        return &client.PluginResult {
+            Action: PLUGIN_CONTINUE_CMD,
+        }
+    }
+
+Continues the command execution normally. If there are plugins after this
+one then their hooks are also called normally.
+
+#### client.PLUGIN_ARGS_REWRITE
+
+    func (mp *MyPlugin) Before(cli *client.DockerCli, cmd string, args []string) (result *PluginResult, err error) {
+        return &client.PluginResult {
+            Action: client.PLUGIN_ARGS_REWRITE,
+            Payload: append(args, "-v")
+        }
+    }
+
+Rewrites the arguments slice with the returned payload of the plugin result.
+
+#### client.PLUGIN_EXIT_CMD
+
+    func (mp *MyPlugin) Before(cli *client.DockerCli, cmd string, args []string) (result *PluginResult, err error) {
+        return &client.PluginResult {
+            Action: PLUGIN_EXIT_CMD,
+        }, fmt.Errorf("MyPlugin failed.")
+    }
+
+Exits the command and returns an error, if any.
+
+## Plugin - After
+
+The After method returns only an error. The effects of this method are more
+limited than Before simply due to the fact that After happens after the
+command has executed. The After method is given the results of the command
+execution as well as the command and arguments involved.
+
+    func (mp *MyPlugin) After(cli *DockerCli, callError error, cmd string, args []string) (err error) {
+        return nil
+    }
+
+## Complete Plugin Example
+
+Putting everything together from the previous sections gives us a nice, complete example plugin.
+
+    package example
+
+    import (
+        client "github.com/dotcloud/docker/api/client"
+    )
+
+    type MyPlugin struct {}
+
+    func init() {
+        client.RegisterPlugin("my_plugin", &MyPlugin {})
+    }
+
+    func (mp *MyPlugin) Before(cli *client.DockerCli, cmd string, args []string) (result *PluginResult, err error) {
+        return &client.PluginResult {
+            Action: client.PLUGIN_ARGS_REWRITE,
+            Payload: append(args, "-v")
+        }
+    }
+
+
+    func (mp *MyPlugin) After(cli *DockerCli, callError error, cmd string, args []string) (err error) {
+        return nil
+    }
+
+The plugin can then be enabled by calling the Docker CLI binary with the
+`DOCKER_CLI_PLUGINS` environment variable set.
+
+    $ DOCKER_CLI_PLUGINS="my_plugin" docker ps
+
+
+## Writing Docker CLI Remotes
+
+Docker CLI Remotes are pluggable components that abstract away both the
+connection and communication logic for command execution in the Docker CLI.
+By writing your own remote implementation, you can control how the Docker CLI
+connects to remote daemon instances and how it communicates its intent.
+
+## Registration
+
+Before a remote can be referenced and used, it must be registered with the
+Docker CLI. This is done by first adding the remote to an imports file
+located at [api/client_extensions/remotes.go](https://github.com/dotcloud/docker/api/client_extensions/remotes.go).
+This will pull in the remote code during compile time.
+
+Remote writing begins with the two plugin interfaces:
+
+    // A CliRemote type represents a plugable component that can both create
+    // network connections via the Dial method and act upon them via the Call
+    // method.
+    //
+    // By implementing the hooks, a remote plugin can successfully route and
+    // manage the outgoing command.
+    type CliRemote interface {
+        Call(cli *DockerCli, callDetails *CallDetails) (io.ReadCloser, int, error)
+        Dial(cli *DockerCli) (net.Conn, error)
+    }
+
+    // A CliRemote needs a portable initialization method to allow for easier
+    // registration and management.
+    type CliRemoteInit func() (CliRemote, error)
+
+## Remote - Init
+
+After the package import for the remote has been added to Docker, the remote
+must register itself. This may be done easily from an init function.
+
+    package example
+
+    import (
+        "io"
+        "net"
+        myproto "github.com/me/myproject/myproto"
+        client "github.com/dotcloud/docker/api/client"
+    )
+
+    type MyRemote struct {}
+
+    func init() {
+        client.RegisterRemote("my_remote", &MyRemote {})
+    }
+
+## Remote - Dial
+
+The Dial method of a remote returns a live network connection or an error.
+This allows for custom connection logic, wrapping and other options that
+have an interest in controlling how the outgoing connection for the command
+is made.
+
+This method may be deprecated in the future when more responsibility is
+refactored from the Docker CLI to plugins and remotes.
+
+    func (mr *MyRemote) Dial(cli *client.DockerCli) (net.Conn, error) {
+        if cli.TlsConfig != nil && cli.Proto != "unix" {
+            return tls.Dial(cli.Proto, cli.Address, cli.TlsConfig)
+        }
+
+        return net.Dial(cli.Proto, cli.Address)
+    }
+
+## Remote - Call
+
+The Call method of a remote handles the actual execution of the command on
+behalf of the Docker CLI. The Call method receives all of the call details
+through a struct that packages them up nicely.
+
+    func (mr *MyRemote) Call(cli *client.DockerCli, callDetails *client.CallDetails) (io.ReadCloser, int, error) {
+        call := myproto.Prepare(cli, callDetails)
+        return call.Execute()
+    }
+
+## Complete Remote Example
+
+Putting everything together from the previous sections gives us a nice,
+complete example remote.
+
+    package example
+
+    import (
+        "io"
+        "net"
+        myproto "github.com/me/myproject/myproto"
+        client "github.com/dotcloud/docker/api/client"
+    )
+
+    type MyRemote struct {}
+
+    func init() {
+        client.RegisterRemote("my_remote", &MyRemote {})
+    }
+
+    func (mr *MyRemote) Dial(cli *client.DockerCli) (net.Conn, error) {
+        if cli.TlsConfig != nil && cli.Proto != "unix" {
+            return tls.Dial(cli.Proto, cli.Address, cli.TlsConfig)
+        }
+
+        return net.Dial(cli.Proto, cli.Address)
+    }
+
+    func (mr *MyRemote) Call(cli *client.DockerCli, callDetails *client.CallDetails) (io.ReadCloser, int, error) {
+        call := myproto.Prepare(cli, callDetails)
+        return call.Execute()
+    }
+
+The remote can then be enabled by calling the Docker CLI binary with the
+`DOCKER_CLI_REMOTE` environment variable set.
+
+    $ DOCKER_CLI_REMOTE="my_remote" docker ps

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -47,6 +47,34 @@ Options like `--name=""` expect a string, and they
 can only be specified once. Options like `-c=0`
 expect an integer, and they can only be specified once.
 
+## Extensibility Features
+
+The Docker CLI allows for certain extensions to be activated by the user
+at runtime.
+
+### Remotes
+
+The Docker CLI allows you to contact a remote Docker daemon through the
+Remote Docker API. However, in the future more protocol options may become
+available. In order to switch between available remote call implementations
+a user may specify the `DOCKER_CLI_REMOTE` environment variable.
+
+    $ DOCKER_CLI_REMOTE="http" docker run ubuntu bash
+
+### Plugins
+
+The Docker CLI allows for users to specify and enable extended functionality
+and behaviors for commands by enabling CLI plugins. CLI plugins are enabled
+by specifying the registered name of the plugin in a list of comma delimited
+plugins assigned to the `DOCKER_CLI_PLUGINS` environment variable.
+
+#### Single Plugin
+    $ DOCKER_CLI_PLUGINS="cluster" docker run ubuntu bash
+
+#### Multiple Plugins
+    $ DOCKER_CLI_PLUGINS="oauth,cluster" docker run ubuntu bash
+
+
 ## daemon
 
     Usage of docker:


### PR DESCRIPTION
## Docker CLI Enhancements
### Docker CLI Remotes

[Docker CLI Remotes](https://github.com/zinic/docker/blob/5648-docker-remotes-and-plugins/api/client/remote.go) are pluggable components that abstract away both the connection and communication logic for command execution. A Docker CLI Remote must implement the following:
- A Dial method for establishing a network connection to a remote target.
- A Call method for executing the command against a network connection to a remote target.

[The default (HTTP) remote is available for reference.](https://github.com/zinic/docker/blob/5648-docker-remotes-and-plugins/api/plugins/http/remote.go)
### Docker CLI Plugins

[Docker CLI Plugins](https://github.com/zinic/docker/blob/5648-docker-remotes-and-plugins/api/client/plugin.go) are pluggable components that allow for uniform client-side extension of Docker commands. This is accomplished by the addition of a before and after hook in the [CLI command lookup and execution code](https://github.com/zinic/docker/blob/5648-docker-remotes-and-plugins/api/client/cli.go#L120-L147).
### Including Remotes and Plugins

Plugins and remotes are managed by the [inclusion](https://github.com/zinic/docker/blob/5648-docker-remotes-and-plugins/docker/docker.go#L15) of the [plugins package](https://github.com/zinic/docker/blob/5648-docker-remotes-and-plugins/api/plugins/plugins.go).
### Documentation

Documentation may be found at the following locations:
- [User usage docs](https://github.com/zinic/docker/blob/5648-docker-remotes-and-plugins/docs/sources/reference/commandline/cli.md)
- [Developer docs](https://github.com/zinic/docker/blob/5648-docker-remotes-and-plugins/docs/sources/contributing/cli-extension-development.md)
### Minor Refactorings
- [Members of the DockerCli struct made public for use in remotes and plugins.](https://github.com/zinic/docker/blob/5648-docker-remotes-and-plugins/api/client/cli.go#L164-L177)
- [Relocation of HTTP call logic to its own HTTP remote implementation.](https://github.com/zinic/docker/blob/5648-docker-remotes-and-plugins/api/plugins/http/remote.go)
