### PR TITLE
Add "Should-Start" cgroupfs-mount and cgroup-lite to sysvinit-debian init script

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -4,6 +4,8 @@
 # Provides:           docker
 # Required-Start:     $syslog $remote_fs
 # Required-Stop:      $syslog $remote_fs
+# Should-Start:       cgroupfs-mount cgroup-lite
+# Should-Stop:        cgroupfs-mount cgroup-lite
 # Default-Start:      2 3 4 5
 # Default-Stop:       0 1 6
 # Short-Description:  Create lightweight, portable, self-sufficient containers.


### PR DESCRIPTION
It's fine to list both here because "Should-Start" is a loose binding (ie, if the listed service exists, it'll be started first, but otherwise, this one will start without it).

This fixes a fun race condition that @paultag noticed, where cgroupfs-mount has a block of code that does basically `mountpount /sys/fs/cgroup || mount ... /sys/fs/cgroup`, but docker contains the same block, so during the time of that `||`, they could both see that it's not a mountpoint, and then both mount tmpfs on it (which is a very hard race to hit, and is mostly harmless, but irritating and wrong nonetheless).

For the curious about "Should-Start", see also https://wiki.debian.org/LSBInitScripts#line-79.
