### PR TITLE
Trivial Documentation Change: The Go template is a better pattern for documentation.

### DIFF
--- a/docs/sources/use/port_redirection.md
+++ b/docs/sources/use/port_redirection.md
@@ -11,7 +11,7 @@ port. When this service runs inside a container, one can connect to the
 port after finding the IP address of the container as follows:
 
     # Find IP address of container with ID <container_id>
-    $ docker inspect <container_id> | grep IPAddress | cut -d '"' -f 4
+    $ docker inspect --format='{{.NetworkSettings.IPAddress}}' <container_id>
 
 However, this IP address is local to the host system and the container
 port is not reachable by the outside world. Furthermore, even if the


### PR DESCRIPTION
Noticed that this would better fit the pattern of using the built in --format instead of grep/cut.
