### PR TITLE
Properly handle copying of absolute symlinks

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -743,7 +743,7 @@ func (container *Container) GetSize() (int64, int64) {
 }
 
 func isSymlink(mode os.FileMode) bool {
-	return (mode & os.ModeSymlink) != 0
+	return (mode & os.ModeSymlink) == os.ModeSymlink
 }
 
 func (container *Container) Copy(resource string) (io.ReadCloser, error) {


### PR DESCRIPTION
This PR is a fix for #5619.

Before this patch, a symbolic link pointing to an absolute path (such as
/etc/shadow, etc) would be copied from the _host_ system, leading to
information disclosure. Since the docker daemon runs as root, this
symlink bug could cause essentially _any_ file to be copied from the
host system (and the file mode was changed to be owned by the user which
copied the file). This vulnerability was caused by the container.Copy
method not properly accounting for absolute paths in symlinks.

This patch fixes the above vulnerability by ensuring that, when copying
files, if the file is a symlink, the symlink is repeatedly resolved
(and converted into a relative path) until the final target is found,
when regular copying will continue. This both fixes the original
vulnerability, and fixes other potential vulnerabilities (such as
chaining of symlinks to try to attempt the above vulnerability).

N.B. This patch means that the output filename when copying symlinks is
now the final target, not the link name.

Docker-DCO-1.1-Signed-off-by: Aleksa Sarai cyphar@cyphar.com (github: cyphar)

/cc @shykes
/cc @creack @vieux @crosbymichael
