### PR TITLE
Device mapper was creating an invalid cgroup name.

### DIFF
--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -193,6 +193,9 @@ func (d *driver) GetPidsForContainer(id string) ([]int, error) {
 	filename := filepath.Join(cgroupRoot, cgroupDir, id, "tasks")
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		filename = filepath.Join(cgroupRoot, cgroupDir, "docker", id, "tasks")
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			filename = filepath.Join(cgroupRoot, cgroupDir, fmt.Sprintf("docker-%s.scope", id), "tasks")
+		}
 	}
 
 	output, err := ioutil.ReadFile(filename)


### PR DESCRIPTION
This was breaking docker top CONTAINER

Docker-DCO-1.1-Signed-off-by: Daniel Walsh dwalsh@redhat.com (github: rhatdan)
