### PR TITLE
make higher level heading specify that instructions are for manual installation

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -41,9 +41,9 @@ and install VirtualBox.
 > Do not simply copy the package without running the
 > installer.
 
-## Installing boot2docker
+## Installing boot2docker manually
 
-### Installing manually
+### Downloading the boot2docker script
 
 [boot2docker](https://github.com/boot2docker/boot2docker) provides a
 handy script to manage the VM running the Docker daemon. It also takes


### PR DESCRIPTION
Here's a doc fix. Please look at the change and let me know if you need clarification.
