### PR TITLE
Update Ubuntu release used for builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 #
 
 docker-version	0.6.1
-FROM	ubuntu:13.10
+FROM	ubuntu:14.04
 MAINTAINER	Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # Packaged dependencies


### PR DESCRIPTION
This PR just revs the Ubuntu release used for builds from 13.10
to 14.04, and update the stated docker-version to the current
version (i.e. 0.11.1).

/cc @tianon
/cc @shykes @creack @vieux @crosbymichael
