### PR TITLE
Added value format description for VOLUME instruction in builder doc

### DIFF
--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -325,8 +325,9 @@ optional but default, you could use a CMD:
 
 The `VOLUME` instruction will create a mount point with the specified name
 and mark it as holding externally mounted volumes from native host or other
-containers. For more information/examples and mounting instructions via docker
-client, refer to [*Share Directories via Volumes*](
+containers. The value can be a JSON array, `VOLUME ["/var/log/"]`, or a plain
+string, `VOLUME /var/log`. For more information/examples and mounting
+instructions via the Docker client, refer to [*Share Directories via Volumes*](
 /use/working_with_volumes/#volume-def) documentation.
 
 ## USER


### PR DESCRIPTION
Hi,

This is a simple pull request to improve the documentation.

In the documentation was not mentioned explicitly that VOLUME value
shoud be a valid JSON array. Because of this I spent time to discovering
the problem with my image where I put `VOLUME ['/data']` (with single quotes).
The `['/data']` mount point was parsed and mounted whole as a string without
any errors and warnings.

( In accordance with [current implementation](https://github.com/dotcloud/docker/blob/master/server/buildfile.go#L359-L362) )

Thanks,
Max
