### PR TITLE
Add GzipFastest & use it for the context

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -160,7 +160,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		if _, err = os.Stat(filename); os.IsNotExist(err) {
 			return fmt.Errorf("no Dockerfile found in %s", cmd.Arg(0))
 		}
-		context, err = archive.Tar(root, archive.Uncompressed)
+		context, err = archive.Tar(root, archive.GzipFastest)
 	}
 	var body io.Reader
 	// Setup an upload progress bar

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -37,6 +37,7 @@ const (
 	Uncompressed Compression = iota
 	Bzip2
 	Gzip
+	GzipFastest
 	Xz
 )
 
@@ -111,6 +112,12 @@ func CompressStream(dest io.WriteCloser, compression Compression) (io.WriteClose
 		return utils.NopWriteCloser(dest), nil
 	case Gzip:
 		return gzip.NewWriter(dest), nil
+	case GzipFastest:
+		if gzipWriter, err := gzip.NewWriterLevel(dest, 1); err != nil {
+			return nil, fmt.Errorf("Failed to create compressor: %s", err)
+		} else {
+			return gzipWriter, nil
+		}
 	case Bzip2, Xz:
 		// archive/bzip2 does not support writing, and there is no xz support at all
 		// However, this is not a problem as docker only currently generates gzipped tars


### PR DESCRIPTION
This PR adds a GzipFastest compression type which is used by CompressStream to set the gzip compression to level 1.
This PR makes `docker build` compress the context using GzipFastest to reduce the size of the uploaded context without affecting performance.

This lowers the amount of data `make build` has to upload from ~48 MB down to ~29 MB. This should give a small speed boost for small contexts and a bigger one for large contexts.
