### PR TITLE
fix(daemon): ensure the /var/lib/docker dir exists

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -680,6 +680,12 @@ func NewDaemonFromDirectory(config *daemonconfig.Config, eng *engine.Engine) (*D
 	if !config.EnableSelinuxSupport {
 		selinux.SetDisabled()
 	}
+
+	// Create the root directory if it doesn't exists
+	if err := os.MkdirAll(config.Root, 0700); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
 	// Set the default driver
 	graphdriver.DefaultDriver = config.GraphDriver
 


### PR DESCRIPTION
The btrfs driver attempts to stat the /var/lib/docker directory to ensure it
exists. If it doesn't exist then it bails with an unhelpful log line:

```
2014/05/10 00:51:30 no such file or directory
```

In 0.10 the directory was created but quickly digging through the logs I can't
tell what sort of re-ordering of code caused this regression.

Docker-DCO-1.1-Signed-off-by: Brandon Philips brandon.philips@coreos.com
(github: philips)
