### PR TITLE
Ensure `docker cp` cannot traverse outside container rootfs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@
 Aanand Prasad <aanand.prasad@gmail.com>
 Aaron Feng <aaron.feng@gmail.com>
 Abel Muiño <amuino@gmail.com>
+Aleksa Sarai <cyphar@cyphar.com>
 Alexander Larsson <alexl@redhat.com>
 Alexey Shamrin <shamrin@gmail.com>
 Alex Gaynor <alex.gaynor@gmail.com>

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -745,8 +745,13 @@ func (container *Container) Copy(resource string) (io.ReadCloser, error) {
 	if err := container.Mount(); err != nil {
 		return nil, err
 	}
+
 	var filter []string
+
+	// Ensure path is local to container basefs
+	resource = path.Join("/", resource)
 	basePath := path.Join(container.basefs, resource)
+
 	stat, err := os.Stat(basePath)
 	if err != nil {
 		container.Unmount()

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -94,11 +94,11 @@ func applyVolumesFrom(container *Container) error {
 				if _, exists := container.Volumes[volPath]; exists {
 					continue
 				}
-				stat, err := os.Stat(filepath.Join(c.basefs, volPath))
+				stat, err := os.Stat(c.getResourcePath(volPath))
 				if err != nil {
 					return err
 				}
-				if err := createIfNotExists(filepath.Join(container.basefs, volPath), stat.IsDir()); err != nil {
+				if err := createIfNotExists(container.getResourcePath(volPath), stat.IsDir()); err != nil {
 					return err
 				}
 				container.Volumes[volPath] = id

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	cpTestPathParent = "/some"
+	cpTestPath       = "/some/path"
+	cpTestName       = "test"
+	cpFullPath       = "/some/path/test"
+
+	cpContainerContents = "holla, i am the container"
+	cpHostContents      = "hello, i am the host"
+)
+
+// Test for #5656
+// Check that garbage paths don't escape the container's rootfs
+func TestCpGarbagePath(t *testing.T) {
+	out, exitCode, err := cmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
+	if err != nil || exitCode != 0 {
+		t.Fatal("failed to create a container", out, err)
+	}
+
+	cleanedContainerID := stripTrailingCharacters(out)
+	defer deleteContainer(cleanedContainerID)
+
+	out, _, err = cmd(t, "wait", cleanedContainerID)
+	if err != nil || stripTrailingCharacters(out) != "0" {
+		t.Fatal("failed to set up container", out, err)
+	}
+
+	if err := os.MkdirAll(cpTestPath, os.ModeDir); err != nil {
+		t.Fatal(err)
+	}
+
+	hostFile, err := os.Create(cpFullPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer hostFile.Close()
+	defer os.RemoveAll(cpTestPathParent)
+
+	fmt.Fprintf(hostFile, "%s", cpHostContents)
+
+	tmpdir, err := ioutil.TempDir("", "docker-integration")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpname := filepath.Join(tmpdir, cpTestName)
+	defer os.RemoveAll(tmpdir)
+
+	path := filepath.Join("../../../../../../../../../../../../", cpFullPath)
+
+	_, _, err = cmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
+	if err != nil {
+		t.Fatalf("couldn't copy from garbage path: %s:%s %s", cleanedContainerID, path, err)
+	}
+
+	file, _ := os.Open(tmpname)
+	defer file.Close()
+
+	test, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(test) == cpHostContents {
+		t.Errorf("output matched host file -- garbage path can escape container rootfs")
+	}
+
+	if string(test) != cpContainerContents {
+		t.Errorf("output doesn't match the input for garbage path")
+	}
+
+	logDone("cp - garbage paths relative to container's rootfs")
+}
+
+// Check that relative paths are relative to the container's rootfs
+func TestCpRelativePath(t *testing.T) {
+	out, exitCode, err := cmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
+	if err != nil || exitCode != 0 {
+		t.Fatal("failed to create a container", out, err)
+	}
+
+	cleanedContainerID := stripTrailingCharacters(out)
+	defer deleteContainer(cleanedContainerID)
+
+	out, _, err = cmd(t, "wait", cleanedContainerID)
+	if err != nil || stripTrailingCharacters(out) != "0" {
+		t.Fatal("failed to set up container", out, err)
+	}
+
+	if err := os.MkdirAll(cpTestPath, os.ModeDir); err != nil {
+		t.Fatal(err)
+	}
+
+	hostFile, err := os.Create(cpFullPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer hostFile.Close()
+	defer os.RemoveAll(cpTestPathParent)
+
+	fmt.Fprintf(hostFile, "%s", cpHostContents)
+
+	tmpdir, err := ioutil.TempDir("", "docker-integration")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpname := filepath.Join(tmpdir, cpTestName)
+	defer os.RemoveAll(tmpdir)
+
+	path, _ := filepath.Rel("/", cpFullPath)
+
+	_, _, err = cmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
+	if err != nil {
+		t.Fatalf("couldn't copy from relative path: %s:%s %s", cleanedContainerID, path, err)
+	}
+
+	file, _ := os.Open(tmpname)
+	defer file.Close()
+
+	test, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(test) == cpHostContents {
+		t.Errorf("output matched host file -- relative path can escape container rootfs")
+	}
+
+	if string(test) != cpContainerContents {
+		t.Errorf("output doesn't match the input for relative path")
+	}
+
+	logDone("cp - relative paths relative to container's rootfs")
+}
+
+// Check that absolute paths are relative to the container's rootfs
+func TestCpAbsolutePath(t *testing.T) {
+	out, exitCode, err := cmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
+	if err != nil || exitCode != 0 {
+		t.Fatal("failed to create a container", out, err)
+	}
+
+	cleanedContainerID := stripTrailingCharacters(out)
+	defer deleteContainer(cleanedContainerID)
+
+	out, _, err = cmd(t, "wait", cleanedContainerID)
+	if err != nil || stripTrailingCharacters(out) != "0" {
+		t.Fatal("failed to set up container", out, err)
+	}
+
+	if err := os.MkdirAll(cpTestPath, os.ModeDir); err != nil {
+		t.Fatal(err)
+	}
+
+	hostFile, err := os.Create(cpFullPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer hostFile.Close()
+	defer os.RemoveAll(cpTestPathParent)
+
+	fmt.Fprintf(hostFile, "%s", cpHostContents)
+
+	tmpdir, err := ioutil.TempDir("", "docker-integration")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpname := filepath.Join(tmpdir, cpTestName)
+	defer os.RemoveAll(tmpdir)
+
+	path := cpFullPath
+
+	_, _, err = cmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
+	if err != nil {
+		t.Fatalf("couldn't copy from absolute path: %s:%s %s", cleanedContainerID, path, err)
+	}
+
+	file, _ := os.Open(tmpname)
+	defer file.Close()
+
+	test, err := ioutil.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(test) == cpHostContents {
+		t.Errorf("output matched host file -- absolute path can escape container rootfs")
+	}
+
+	if string(test) != cpContainerContents {
+		t.Errorf("output doesn't match the input for absolute path")
+	}
+
+	logDone("cp - absolute paths relative to container's rootfs")
+}


### PR DESCRIPTION
This patch fixes the bug (#5656) that allowed cp to copy files outside of the containers rootfs, by passing a relative path (such as `../../../../../../../../etc/shadow`). This is fixed by first converting the path to an absolute path (relative to /) and then appending it to the container's rootfs before continuing.

Docker-DCO-1.1-Signed-off-by: Aleksa Sarai cyphar@cyphar.com (github: cyphar)

EDIT: I want to point out that while the issue (#5656) is closed, the vulnerability still works. The problem is that the docker socket can, even when running in multi-tenant situations, be used to read files as root since paths aren't sanitised properly. This problem has yet to be fixed.

EDIT 2: This patch also now includes fixes to general path generation in the `daemon` subsystem, in order to try and prevent future exploits in the same vein as this one.

Fixes #5656 

/cc @shykes @creack @vieux @crosbymichael
