### PR TITLE
Updated docker logs timestamp to RFC3339Nano

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1507,7 +1507,7 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 		loc = time.FixedZone(time.Now().Zone())
 	)
 	var setTime = func(key, value string) {
-		format := "2006-01-02 15:04:05 -0700 MST"
+		format := time.RFC3339Nano
 		if len(value) < len(format) {
 			format = format[:len(value)]
 		}

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -383,24 +383,24 @@ You'll need two shells for this example.
 
 **Shell 1: (Again .. now showing events):**
 
-    [2013-09-03 15:49:26 +0200 CEST] 4386fb97867d: (from 12de384bfb10) start
-    [2013-09-03 15:49:29 +0200 CEST] 4386fb97867d: (from 12de384bfb10) die
-    [2013-09-03 15:49:29 +0200 CEST] 4386fb97867d: (from 12de384bfb10) stop
+    2014-05-10T17:42:14.999999999Z07:00 4386fb97867d: (from 12de384bfb10) start
+    2014-05-10T17:42:14.999999999Z07:00 4386fb97867d: (from 12de384bfb10) die
+    2014-05-10T17:42:14.999999999Z07:00 4386fb97867d: (from 12de384bfb10) stop
 
 **Show events in the past from a specified time:**
 
     $ sudo docker events --since 1378216169
-    [2013-09-03 15:49:29 +0200 CEST] 4386fb97867d: (from 12de384bfb10) die
-    [2013-09-03 15:49:29 +0200 CEST] 4386fb97867d: (from 12de384bfb10) stop
+    2014-03-10T17:42:14.999999999Z07:00 4386fb97867d: (from 12de384bfb10) die
+    2014-03-10T17:42:14.999999999Z07:00 4386fb97867d: (from 12de384bfb10) stop
 
     $ sudo docker events --since '2013-09-03'
-    [2013-09-03 15:49:26 +0200 CEST] 4386fb97867d: (from 12de384bfb10) start
-    [2013-09-03 15:49:29 +0200 CEST] 4386fb97867d: (from 12de384bfb10) die
-    [2013-09-03 15:49:29 +0200 CEST] 4386fb97867d: (from 12de384bfb10) stop
+    2014-09-03T17:42:14.999999999Z07:00 4386fb97867d: (from 12de384bfb10) start
+    2014-09-03T17:42:14.999999999Z07:00 4386fb97867d: (from 12de384bfb10) die
+    2014-09-03T17:42:14.999999999Z07:00 4386fb97867d: (from 12de384bfb10) stop
 
     $ sudo docker events --since '2013-09-03 15:49:29 +0200 CEST'
-    [2013-09-03 15:49:29 +0200 CEST] 4386fb97867d: (from 12de384bfb10) die
-    [2013-09-03 15:49:29 +0200 CEST] 4386fb97867d: (from 12de384bfb10) stop
+    2014-09-03T15:49:29.999999999Z07:00 4386fb97867d: (from 12de384bfb10) die
+    2014-09-03T15:49:29.999999999Z07:00 4386fb97867d: (from 12de384bfb10) stop
 
 ## export
 
@@ -665,8 +665,12 @@ The `docker logs` command batch-retrieves all logs
 present at the time of execution.
 
 The ``docker logs --follow`` command will first return all logs from the
-beginning and then continue streaming new output from the container's stdout
-and stderr.
+beginning and then continue streaming new output from the container's
+stdout and stderr.
+
+The ``docker logs --timestamp`` commands will add an RFC3339Nano
+timestamp, for example ``2014-05-10T17:42:14.999999999Z07:00``, to each
+log entry.
 
 ## port
 

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -98,11 +98,11 @@ func TestLogsTimestamps(t *testing.T) {
 		t.Fatalf("Expected log %d lines, received %d\n", testLen+1, len(lines))
 	}
 
-	ts := regexp.MustCompile(`^\[.*?\]`)
+	ts := regexp.MustCompile(`^.*\s`)
 
 	for _, l := range lines {
 		if l != "" {
-			_, err := time.Parse("["+time.StampMilli+"]", ts.FindString(l))
+			_, err := time.Parse(time.RFC3339Nano+" ", ts.FindString(l))
 			if err != nil {
 				t.Fatalf("Failed to parse timestamp from %v: %v", l, err)
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -2164,7 +2164,7 @@ func (srv *Server) ContainerLogs(job *engine.Job) engine.Status {
 		return job.Errorf("You must choose at least one stream")
 	}
 	if times {
-		format = time.StampMilli
+		format = time.RFC3339Nano
 	}
 	container := srv.daemon.Get(name)
 	if container == nil {
@@ -2205,7 +2205,7 @@ func (srv *Server) ContainerLogs(job *engine.Job) engine.Status {
 			}
 			logLine := l.Log
 			if times {
-				logLine = fmt.Sprintf("[%s] %s", l.Created.Format(format), logLine)
+				logLine = fmt.Sprintf("%s %s", l.Created.Format(format), logLine)
 			}
 			if l.Stream == "stdout" && stdout {
 				fmt.Fprintf(job.Stdout, "%s", logLine)


### PR DESCRIPTION
Currently the docker logs timestamp flag generates log entries like:

```
$ sudo docker logs -ft daemon_dave
[May 10 13:06:17.934] hello world
```

It uses Go's StampMilli timestamp to generate the timestamp. The entry
is also wrapped in [ ].

This is non-standard operational timestamp and one that will require
custom parsing.

The new timestamp is RFC3999Nano and generates entries like:

```
2014-05-10T17:42:14.999999999Z07:00 hello world
```

These are readily parsed by tools like ELK.

Docker-DCO-1.1-Signed-off-by: James Turnbull james@lovedthanlost.net (github: jamtur01)
