### PR TITLE
Fix bug on LXC container start. Fixes #5718

### DIFF
--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -268,18 +268,14 @@ func (d *driver) waitForStart(c *execdriver.Command, waitLock chan struct{}) (in
 		}
 
 		output, err = d.getInfo(c.ID)
-		if err != nil {
-			output, err = d.getInfo(c.ID)
+		if err == nil {
+			info, err := parseLxcInfo(string(output))
 			if err != nil {
 				return -1, err
 			}
-		}
-		info, err := parseLxcInfo(string(output))
-		if err != nil {
-			return -1, err
-		}
-		if info.Running {
-			return info.Pid, nil
+			if info.Running {
+				return info.Pid, nil
+			}
 		}
 		time.Sleep(50 * time.Millisecond)
 	}


### PR DESCRIPTION
`lxc-info` now (`lxc-1.0.3`) returns an error exit code (1) if it cannot find the given container ID.
This fixes the issue by not failing if the `lxc-info` lookup fails, but continue asking `lxc-info` until the container is up and running.
Fixes #5718 
