### PR TITLE
reduce cache time to 1 hours so future docs releases update the cloudfront caches faster

### DIFF
--- a/docs/release.sh
+++ b/docs/release.sh
@@ -54,7 +54,7 @@ upload_current_documentation() {
 	echo "  to $dst"
 	echo
 	#s3cmd --recursive --follow-symlinks --preserve --acl-public sync "$src" "$dst"
-	aws s3 sync --acl public-read --exclude "*.rej" --exclude "*.rst" --exclude "*.orig" --exclude "*.py" "$src" "$dst"
+	aws s3 sync --cache-control "max-age=3600" --acl public-read --exclude "*.rej" --exclude "*.rst" --exclude "*.orig" --exclude "*.py" "$src" "$dst"
 }
 
 setup_s3


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@fosiki.com (github: SvenDowideit)

This should mean publishing to docs.docker.io updates the caches faster (atm, its somewhere in the 24 hours default max-age)

@jamtur01 @ostezer
