### PR TITLE
Fix potential int overflow in due to vague type

### DIFF
--- a/pkg/beam/beam.go
+++ b/pkg/beam/beam.go
@@ -30,11 +30,11 @@ type ReceiveSender interface {
 }
 
 const (
-	R int = 1 << (32 - 1 - iota)
+	R int64 = 1 << (32 - 1 - iota)
 	W
 )
 
-func sendPipe(dst Sender, data []byte, mode int) (*os.File, error) {
+func sendPipe(dst Sender, data []byte, mode int64) (*os.File, error) {
 	r, w, err := os.Pipe()
 	if err != nil {
 		return nil, err
@@ -117,8 +117,8 @@ func ReceiveConn(src Receiver) ([]byte, *UnixConn, error) {
 	return nil, nil, nil
 }
 
-func Copy(dst Sender, src Receiver) (int, error) {
-	var n int
+func Copy(dst Sender, src Receiver) (int64, error) {
+	var n int64
 	for {
 		payload, attachment, err := src.Receive()
 		if err == io.EOF {


### PR DESCRIPTION
This patch fixes the beam package so that the `int` type used isn't vague
(i.e. it is consistently `int64` on all platforms). This is a patch which
makes it easier to port docker to ARM (as this is the only error when
trying to compile docker on my ARMv7 machine). It is a simple patch
which makes no effect on amd64 machines, but is one less thing to fix
on 32-bit machines.

Docker-DCO-1.1-Signed-off-by: Aleksa Sarai cyphar@cyphar.com (github: cyphar)

/cc @shykes 
