### PR TITLE
libcontainer: Setup standard /dev symlinks

### DIFF
--- a/pkg/libcontainer/mount/init.go
+++ b/pkg/libcontainer/mount/init.go
@@ -53,6 +53,9 @@ func InitializeMountNamespace(rootfs, console string, container *libcontainer.Co
 	if err := SetupPtmx(rootfs, console, container.Context["mount_label"]); err != nil {
 		return err
 	}
+	if err := setupDevSymlinks(rootfs); err != nil {
+		return fmt.Errorf("dev symlinks %s", err)
+	}
 	if err := system.Chdir(rootfs); err != nil {
 		return fmt.Errorf("chdir into %s %s", rootfs, err)
 	}
@@ -88,6 +91,34 @@ func mountSystem(rootfs string, container *libcontainer.Container) error {
 			return fmt.Errorf("mounting %s into %s %s", m.source, m.path, err)
 		}
 	}
+	return nil
+}
+
+func setupDevSymlinks(rootfs string) error {
+	var links = [][2]string{
+		{"/proc/self/fd", "/dev/fd"},
+		{"/proc/self/fd/0", "/dev/stdin"},
+		{"/proc/self/fd/1", "/dev/stdout"},
+		{"/proc/self/fd/2", "/dev/stderr"},
+	}
+
+	// kcore support can be toggled with CONFIG_PROC_KCORE; only create a symlink
+	// in /dev if it exists in /proc.
+	if _, err := os.Stat("/proc/kcore"); err == nil {
+		links = append(links, [2]string{"/proc/kcore", "/dev/kcore"})
+	}
+
+	for _, link := range links {
+		var (
+			src = link[0]
+			dst = filepath.Join(rootfs, link[1])
+		)
+
+		if err := os.Symlink(src, dst); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("symlink %s %s %s", src, dst, err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When a new mount namespace is initialized, `/dev/fd`, `/dev/stdin`, `/dev/stdout`, and `/dev/stderr` should be set up as well.

Open questions:
1. The list of default dev symlinks is currently package local; should it be exported?
2. Should a `/dev/kcore` symlink also be set up? `systemd` does, `lxc` doesn't.

Fixes #2356
Fixes #5510
