### PR TITLE
Clean up and clarify the Mac install docs

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -56,9 +56,7 @@ and install VirtualBox.
 > Do not simply copy the package without running the
 > installer.
 
-## Installing boot2docker manually
-
-### Downloading the boot2docker script
+## Installing boot2docker
 
 [boot2docker](https://github.com/boot2docker/boot2docker) provides a
 handy script to manage the VM running the Docker daemon. It also takes
@@ -74,7 +72,7 @@ $ curl -L https://github.com/boot2docker/boot2docker/raw/master/boot2docker -o ~
 $ chmod +x ~/bin/boot2docker
 ```
 
-### Installing the Docker OS X Client
+## Installing the Docker Client
 
 The Docker daemon is accessed using the `docker` binary.
 
@@ -93,20 +91,7 @@ local boot2docker virtual machine as the value of that variable.
 export DOCKER_HOST=tcp://127.0.0.1:4243
 ```
 
-## Installing boot2docker with Homebrew
-
-If you are using Homebrew on your machine, simply run the following
-command to install `boot2docker`:
-
-    $ brew install boot2docker
-
-Run the following command to install the Docker client:
-
-    $ brew install docker
-
-And that's it! Let's check out how to use it.
-
-# How To Use Docker On Mac OS X
+# Using Docker on Mac OS X
 
 ## Running the Docker daemon via boot2docker
 

--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -28,6 +28,21 @@ that virtual machine and run our Docker daemon.
 VirtualBox to create the virtual machine so we'll need to install that
 first.
 
+## Preparing your home directory
+
+First, we recommend creating a `bin` directory in your home to install new
+binaries without messing with your system installation.
+
+This will create a new directory for binaries, and make sure its contents
+are accessible from the shell.
+
+```
+$ mkdir -p ~/bin
+$ export PATH=~/bin:$PATH
+$ echo 'export PATH=~/bin:$PATH' >> ~/.bash_profile
+```
+
+
 ## Installing VirtualBox
 
 Docker on OS X needs VirtualBox to run. To begin with, head over to
@@ -52,15 +67,12 @@ care of the installation of that VM.
 Open up a new terminal window and run the following commands to get
 boot2docker:
 
-    # Enter the installation directory
-    $ mkdir -p ~/bin
-    $ cd ~/bin
 
-    # Get the file
-    $ curl https://raw.githubusercontent.com/boot2docker/boot2docker/master/boot2docker > boot2docker
-
-    # Mark it executable
-    $ chmod +x boot2docker
+```
+$ mkdir -p ~/bin &&\
+$ curl -L https://github.com/boot2docker/boot2docker/raw/master/boot2docker -o ~/bin/boot2docker &&\
+$ chmod +x ~/bin/boot2docker
+```
 
 ### Installing the Docker OS X Client
 
@@ -68,24 +80,18 @@ The Docker daemon is accessed using the `docker` binary.
 
 Run the following commands to get it downloaded and set up:
 
-    # Get the docker binary
-    $ DIR=$(mktemp -d ${TMPDIR:-/tmp}/dockerdl.XXXXXXX) && \
-      curl -f -o $DIR/ld.tgz https://get.docker.io/builds/Darwin/x86_64/docker-latest.tgz && \
-      gunzip $DIR/ld.tgz && \
-      tar xvf $DIR/ld.tar -C $DIR/ && \
-      cp $DIR/usr/local/bin/docker ./docker
-
-    # Copy the executable file
-    $ sudo mkdir -p /usr/local/bin
-    $ sudo cp docker /usr/local/bin/
-
-### Configure the Docker OS X Client
+```
+$ curl https://get.docker.io/builds/Darwin/x86_64/docker-latest.tgz | tar -z -x --strip-components=3 -C ~/bin
+```
 
 The Docker client, `docker`, uses an environment variable `DOCKER_HOST`
 to specify the location of the Docker daemon to connect to. Specify your
 local boot2docker virtual machine as the value of that variable.
 
-    $ export DOCKER_HOST=tcp://127.0.0.1:4243
+
+```
+export DOCKER_HOST=tcp://127.0.0.1:4243
+```
 
 ## Installing boot2docker with Homebrew
 

--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -24,10 +24,6 @@ easier we've designed a helper application called
 [boot2docker](https://github.com/boot2docker/boot2docker) to install
 that virtual machine and run our Docker daemon.
 
-[boot2docker](https://github.com/boot2docker/boot2docker) uses
-VirtualBox to create the virtual machine so we'll need to install that
-first.
-
 ## Preparing your home directory
 
 First, we recommend creating a `bin` directory in your home to install new
@@ -45,7 +41,7 @@ $ echo 'export PATH=~/bin:$PATH' >> ~/.bash_profile
 
 ## Installing VirtualBox
 
-Docker on OS X needs VirtualBox to run. To begin with, head over to
+Boot2docker on OS X needs VirtualBox to run. To begin with, head over to
 [VirtualBox Download Page](https://www.virtualbox.org/wiki/Downloads)
 and get the tool for `OS X hosts x86/amd64`.
 


### PR DESCRIPTION
## Fix commands to copy-paste in Mac install docs
- The commands were quite complicated. They are now much simpler to understand.
- Commands were hard to copy-paste because of parasite prompt characters. Those have been removed.
## Clarify flow of Mac install docs

This removes a highly confusing paragraph about installing Docker with
Homebrew (a completely different install path) in the middle of the
main install path.

The Homebrew install path is removed entirely. The rationale is that
1) the mac install is complicated enough without confusing people with
an alternative, and 2) people who already have homebrew will simply
'brew search' and shouldn't need this doc in the first place.
