### PR TITLE
[beam] Use direct iota instead of binary shift

### DIFF
--- a/pkg/beam/beam.go
+++ b/pkg/beam/beam.go
@@ -30,7 +30,7 @@ type ReceiveSender interface {
 }
 
 const (
-	R int = 1 << (32 - 1 - iota)
+	R = iota
 	W
 )
 


### PR DESCRIPTION
This prevents issues on 32bit systems.
ping @shykes, @vieux 

Alternative to #5733 per @crosbymichael's comment.
