### PR TITLE
Added to small patch exemption to cover Markdown/syntax errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,10 @@ curl -o .git/hooks/prepare-commit-msg https://raw.github.com/dotcloud/docker/mas
 There are several exceptions to the signing requirement. Currently these are:
 
 * Your patch fixes spelling or grammar errors.
-* Your patch is a single line change to documentation.
+* Your patch is a single line change to documentation contained in the
+  `docs` directory.
+* Your patch fixes Markdown formatting or syntax errors in the
+  documentation contained in the `docs` directory.
 
 If you have any questions, please refer to the FAQ in the [docs](http://docs.docker.io)
 


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: James Turnbull james@lovedthanlost.net (github: jamtur01)
