### PR TITLE
Make unprivileged systemd work in docker

### DIFF
--- a/pkg/libcontainer/cgroups/utils.go
+++ b/pkg/libcontainer/cgroups/utils.go
@@ -2,6 +2,7 @@ package cgroups
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -28,6 +29,80 @@ func FindCgroupMountpoint(subsystem string) (string, error) {
 		}
 	}
 	return "", ErrNotFound
+}
+
+type Mount struct {
+	Mountpoint string
+	Subsystems []string
+}
+
+func (m Mount) GetThisCgroupDir() (string, error) {
+	if len(m.Subsystems) == 0 {
+		return "", fmt.Errorf("No subsystemd for mount")
+	}
+
+	return GetThisCgroupDir(m.Subsystems[0])
+}
+
+func GetMounts() ([]Mount, error) {
+	mounts, err := mount.GetMounts()
+	if err != nil {
+		return nil, err
+	}
+
+	all, err := GetAllSubsystems()
+	if err != nil {
+		return nil, err
+	}
+
+	allMap := make(map[string]bool)
+	for _, s := range all {
+		allMap[s] = true
+	}
+
+	res := []Mount{}
+	for _, mount := range mounts {
+		if mount.Fstype == "cgroup" {
+			m := Mount{Mountpoint: mount.Mountpoint}
+
+			for _, opt := range strings.Split(mount.VfsOpts, ",") {
+				if strings.HasPrefix(opt, "name=") {
+					m.Subsystems = append(m.Subsystems, opt)
+				}
+				if allMap[opt] {
+					m.Subsystems = append(m.Subsystems, opt)
+				}
+			}
+			res = append(res, m)
+		}
+	}
+	return res, nil
+}
+
+// Returns all the cgroup subsystems supported by the kernel
+func GetAllSubsystems() ([]string, error) {
+	f, err := os.Open("/proc/cgroups")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	subsystems := []string{}
+
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		if err := s.Err(); err != nil {
+			return nil, err
+		}
+		text := s.Text()
+		if text[0] != '#' {
+			parts := strings.Fields(text)
+			if len(parts) > 0 {
+				subsystems = append(subsystems, parts[0])
+			}
+		}
+	}
+	return subsystems, nil
 }
 
 // Returns the relative path to the cgroup docker is running in.

--- a/pkg/libcontainer/mount/init.go
+++ b/pkg/libcontainer/mount/init.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/dotcloud/docker/pkg/label"
 	"github.com/dotcloud/docker/pkg/libcontainer"
+	"github.com/dotcloud/docker/pkg/libcontainer/cgroups"
 	"github.com/dotcloud/docker/pkg/libcontainer/mount/nodes"
 	"github.com/dotcloud/docker/pkg/symlink"
 	"github.com/dotcloud/docker/pkg/system"
@@ -95,6 +97,69 @@ func mountSystem(rootfs string, container *libcontainer.Container) error {
 			return fmt.Errorf("mounting %s into %s %s", m.source, m.path, err)
 		}
 	}
+
+	// Mount all cgroup subsystems into the container, read-only. Create symlinks for each
+	// subsystem if any subsystems are merged
+	cgroupMounts, err := cgroups.GetMounts()
+	if err != nil {
+		return err
+	}
+
+	cgroupsDir := filepath.Join(rootfs, "/sys/fs/cgroup")
+
+	for _, m := range cgroupMounts {
+		dir := filepath.Base(m.Mountpoint)
+		mountpoint := filepath.Join(cgroupsDir, dir)
+
+		if err := os.MkdirAll(mountpoint, 0755); err != nil && !os.IsExist(err) {
+			return fmt.Errorf("mkdirall %s %s", mountpoint, err)
+		}
+
+		// Bind-mount the cgroup to /sys/fs/cgroup with the same name as the outer mount
+		if err := system.Mount(m.Mountpoint, mountpoint, "bind", uintptr(syscall.MS_BIND|defaultMountFlags), ""); err != nil {
+			return fmt.Errorf("mounting %s into %s %s", m.Mountpoint, mountpoint, err)
+		}
+		// Make it read-only
+		if err := system.Mount(mountpoint, mountpoint, "bind", uintptr(syscall.MS_BIND|syscall.MS_REMOUNT|syscall.MS_RDONLY|defaultMountFlags), ""); err != nil {
+			return fmt.Errorf("remounting %s into %s %s", mountpoint, mountpoint, err)
+		}
+
+		hasName := false
+		for _, subsys := range m.Subsystems {
+			isName := strings.HasPrefix(subsys, "name=")
+			canonicalName := subsys
+			if isName {
+				hasName = true
+				canonicalName = subsys[5:]
+			}
+
+			// For the merged case dir will be something like "cpu,cpuacct", so
+			// we make symlinks for all the pure subsystem names "cpu -> cpu,cpuacct", etc
+			if canonicalName != dir {
+				if err := os.Symlink(dir, filepath.Join(cgroupsDir, canonicalName)); err != nil {
+					return fmt.Errorf("creating cgroup symlink for %s: %s", dir, err)
+				}
+			}
+		}
+
+		// For named cgroups, such as name=systemd we mount a read-write subset at the
+		// current cgroup path. This lets e.g. systemd work inside a container, as it can create subcgroups inside the
+		// current cgroup, while not being able to do anything dangerous in the real cgroups
+		if hasName {
+			cgroupPath, _ := m.GetThisCgroupDir()
+			if cgroupPath != "" && cgroupPath != "/" {
+				if err := system.Mount(filepath.Join(m.Mountpoint, cgroupPath), filepath.Join(mountpoint, cgroupPath), "bind", uintptr(syscall.MS_BIND|defaultMountFlags), ""); err != nil {
+					return fmt.Errorf("mounting %s into %s %s", filepath.Join(m.Mountpoint, cgroupPath), filepath.Join(mountpoint, cgroupPath), err)
+				}
+			}
+		}
+	}
+
+	// Make /sys/fs/cgroup read-only
+	if err := system.Mount(cgroupsDir, cgroupsDir, "bind", uintptr(syscall.MS_REMOUNT|syscall.MS_RDONLY|defaultMountFlags), ""); err != nil {
+		return fmt.Errorf("remounting %s read-only %s", cgroupsDir, err)
+	}
+
 	return nil
 }
 
@@ -196,6 +261,7 @@ func newSystemMounts(rootfs, mountLabel string, mounts libcontainer.Mounts) []mo
 		{source: "proc", path: filepath.Join(rootfs, "proc"), device: "proc", flags: defaultMountFlags},
 		{source: "sysfs", path: filepath.Join(rootfs, "sys"), device: "sysfs", flags: defaultMountFlags},
 		{source: "tmpfs", path: filepath.Join(rootfs, "dev"), device: "tmpfs", flags: syscall.MS_NOSUID | syscall.MS_STRICTATIME, data: label.FormatMountLabel("mode=755", mountLabel)},
+		{source: "tmpfs", path: filepath.Join(rootfs, "sys/fs/cgroup"), device: "tmpfs", flags: defaultMountFlags},
 		{source: "shm", path: filepath.Join(rootfs, "dev", "shm"), device: "tmpfs", flags: defaultMountFlags, data: label.FormatMountLabel("mode=1777,size=65536k", mountLabel)},
 		{source: "devpts", path: filepath.Join(rootfs, "dev", "pts"), device: "devpts", flags: syscall.MS_NOSUID | syscall.MS_NOEXEC, data: label.FormatMountLabel("newinstance,ptmxmode=0666,mode=620,gid=5", mountLabel)},
 	}


### PR DESCRIPTION
Currently systemd doesn't work inside a docker container without privileges. It requires CAP_SYS_ADMIN or it will fail to mount the name=systemd cgroup hierarchy, and without this there is just no way to have systemd work.

However, granting CAP_SYS_ADMIN is a very dangerous thing. It allows mounting cgroups, procfs, sysfs or other non-namespaced filesystems which can then be used to get host privileges. For instance, its possible to mount the cgroup device filesystem and move pid 1 out of the devices container, then mknod a /dev/kmem and read arbitrary kernel memory.

Systemd will however work pretty well without any extra privileges if /sys/fs/cgroup/systemd is already mounted, even if no other cgroups are available. This can be done in a pretty safe way, which this patch implements:

First of all we mount a tmpfs on /sys/fs/cgroup (where we can then create the dirs to mount cgroupfs:es). Then we loop over all named cgroup hierarchies in the host (typically only systemd) and bind-mount them read-only into the container. Then, if the container itself is inside a non-root directory in one those filesystems we bind mount that particular subdirectory read-write. For example, we mount `/sys/fs/cgroup/systemd` read-only, and  `/sys/fs/cgroup/systemd/system.slice/docker-3a7bd888f18a9fbc66b55114c71be94d72b10b9ffd02f1b12e6551f9c5f87520.scope` read-write. This allows the systemd inside the container to create sub-cgroups and move processes into them, but it does not allow it to escape from the container.

The only weakness with the above is that some features, like PrivateTmp don't work, because they require systemd to mount a /tmp, and that requires CAP_SYS_ADMIN. As long as your container avoids such features it just works.
