### PR TITLE
Fix duplicate ip allocation

### DIFF
--- a/daemon/networkdriver/ipallocator/allocator_test.go
+++ b/daemon/networkdriver/ipallocator/allocator_test.go
@@ -8,7 +8,6 @@ import (
 
 func reset() {
 	allocatedIPs = networkSet{}
-	availableIPS = networkSet{}
 }
 
 func TestRequestNewIps(t *testing.T) {
@@ -18,8 +17,10 @@ func TestRequestNewIps(t *testing.T) {
 		Mask: []byte{255, 255, 255, 0},
 	}
 
+	var ip *net.IP
+	var err error
 	for i := 2; i < 10; i++ {
-		ip, err := RequestIP(network, nil)
+		ip, err = RequestIP(network, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -27,6 +28,17 @@ func TestRequestNewIps(t *testing.T) {
 		if expected := fmt.Sprintf("192.168.0.%d", i); ip.String() != expected {
 			t.Fatalf("Expected ip %s got %s", expected, ip.String())
 		}
+	}
+	value := intToIP(ipToInt(ip) + 1).String()
+	if err := ReleaseIP(network, ip); err != nil {
+		t.Fatal(err)
+	}
+	ip, err = RequestIP(network, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ip.String() != value {
+		t.Fatalf("Expected to receive the next ip %s got %s", value, ip.String())
 	}
 }
 
@@ -62,6 +74,17 @@ func TestGetReleasedIp(t *testing.T) {
 	value := ip.String()
 	if err := ReleaseIP(network, ip); err != nil {
 		t.Fatal(err)
+	}
+
+	for i := 0; i < 252; i++ {
+		_, err = RequestIP(network, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = ReleaseIP(network, ip)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	ip, err = RequestIP(network, nil)
@@ -185,24 +208,6 @@ func TestIPAllocator(t *testing.T) {
 
 		newIPs[i] = ip
 	}
-	// Before loop begin
-	// 2(u) - 3(u) - 4(f) - 5(f) - 6(f)
-	//                       ↑
-
-	// After i = 0
-	// 2(u) - 3(u) - 4(f) - 5(u) - 6(f)
-	//                              ↑
-
-	// After i = 1
-	// 2(u) - 3(u) - 4(f) - 5(u) - 6(u)
-	//                ↑
-
-	// After i = 2
-	// 2(u) - 3(u) - 4(u) - 5(u) - 6(u)
-	//                       ↑
-
-	// Reordered these because the new set will always return the
-	// lowest ips first and not in the order that they were released
 	assertIPEquals(t, &expectedIPs[2], newIPs[0])
 	assertIPEquals(t, &expectedIPs[3], newIPs[1])
 	assertIPEquals(t, &expectedIPs[4], newIPs[2])
@@ -232,6 +237,86 @@ func TestAllocateFirstIP(t *testing.T) {
 	if allocated == first {
 		t.Fatalf("allocated ip should not equal first ip: %d == %d", first, allocated)
 	}
+}
+
+func TestAllocateAllIps(t *testing.T) {
+	defer reset()
+	network := &net.IPNet{
+		IP:   []byte{192, 168, 0, 1},
+		Mask: []byte{255, 255, 255, 0},
+	}
+
+	var (
+		current, first *net.IP
+		err            error
+		isFirst        = true
+	)
+
+	for err == nil {
+		current, err = RequestIP(network, nil)
+		if isFirst {
+			first = current
+			isFirst = false
+		}
+	}
+
+	if err != ErrNoAvailableIPs {
+		t.Fatal(err)
+	}
+
+	if _, err := RequestIP(network, nil); err != ErrNoAvailableIPs {
+		t.Fatal(err)
+	}
+
+	if err := ReleaseIP(network, first); err != nil {
+		t.Fatal(err)
+	}
+
+	again, err := RequestIP(network, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertIPEquals(t, first, again)
+}
+
+func TestAllocateDifferentSubnets(t *testing.T) {
+	defer reset()
+	network1 := &net.IPNet{
+		IP:   []byte{192, 168, 0, 1},
+		Mask: []byte{255, 255, 255, 0},
+	}
+	network2 := &net.IPNet{
+		IP:   []byte{127, 0, 0, 1},
+		Mask: []byte{255, 255, 255, 0},
+	}
+	expectedIPs := []net.IP{
+		0: net.IPv4(192, 168, 0, 2),
+		1: net.IPv4(192, 168, 0, 3),
+		2: net.IPv4(127, 0, 0, 2),
+		3: net.IPv4(127, 0, 0, 3),
+	}
+
+	ip11, err := RequestIP(network1, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ip12, err := RequestIP(network1, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ip21, err := RequestIP(network2, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ip22, err := RequestIP(network2, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertIPEquals(t, &expectedIPs[0], ip11)
+	assertIPEquals(t, &expectedIPs[1], ip12)
+	assertIPEquals(t, &expectedIPs[2], ip21)
+	assertIPEquals(t, &expectedIPs[3], ip22)
 }
 
 func assertIPEquals(t *testing.T, ip1, ip2 *net.IP) {

--- a/pkg/collections/orderedintset_test.go
+++ b/pkg/collections/orderedintset_test.go
@@ -1,0 +1,71 @@
+package collections
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkPush(b *testing.B) {
+	var testSet []int
+	for i := 0; i < 1000; i++ {
+		testSet = append(testSet, rand.Int())
+	}
+	s := NewOrderedIntSet()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, elem := range testSet {
+			s.Push(elem)
+		}
+	}
+}
+
+func BenchmarkPop(b *testing.B) {
+	var testSet []int
+	for i := 0; i < 1000; i++ {
+		testSet = append(testSet, rand.Int())
+	}
+	s := NewOrderedIntSet()
+	for _, elem := range testSet {
+		s.Push(elem)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 1000; j++ {
+			s.Pop()
+		}
+	}
+}
+
+func BenchmarkExist(b *testing.B) {
+	var testSet []int
+	for i := 0; i < 1000; i++ {
+		testSet = append(testSet, rand.Intn(2000))
+	}
+	s := NewOrderedIntSet()
+	for _, elem := range testSet {
+		s.Push(elem)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 1000; j++ {
+			s.Exists(j)
+		}
+	}
+}
+
+func BenchmarkRemove(b *testing.B) {
+	var testSet []int
+	for i := 0; i < 1000; i++ {
+		testSet = append(testSet, rand.Intn(2000))
+	}
+	s := NewOrderedIntSet()
+	for _, elem := range testSet {
+		s.Push(elem)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 1000; j++ {
+			s.Remove(j)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #5737 
Here the trick on border - there is non-zero probability to allocate just released ip from range beginning, when allocations overflow.
