### PR TITLE
Add PDEATHSIG support to nsinit library

### DIFF
--- a/pkg/libcontainer/nsinit/exec.go
+++ b/pkg/libcontainer/nsinit/exec.go
@@ -123,6 +123,7 @@ func DefaultCreateCommand(container *libcontainer.Container, console, rootfs, da
 	command.Env = append(os.Environ(), env...)
 
 	system.SetCloneFlags(command, uintptr(GetNamespaceFlags(container.Namespaces)))
+	command.SysProcAttr.Pdeathsig = syscall.SIGKILL
 	command.ExtraFiles = []*os.File{pipe}
 
 	return command

--- a/pkg/system/calls_linux.go
+++ b/pkg/system/calls_linux.go
@@ -3,6 +3,7 @@ package system
 import (
 	"os/exec"
 	"syscall"
+	"unsafe"
 )
 
 func Chroot(dir string) error {
@@ -120,6 +121,18 @@ func ParentDeathSignal(sig uintptr) error {
 		return err
 	}
 	return nil
+}
+
+func GetParentDeathSignal() (int, error) {
+	var sig int
+
+	_, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_GET_PDEATHSIG, uintptr(unsafe.Pointer(&sig)), 0)
+
+	if err != 0 {
+		return -1, err
+	}
+
+	return sig, nil
 }
 
 func Setctty() error {


### PR DESCRIPTION
When using the "nsinit" executable, I expect the container process to die if the "nsinit exec" process unexpectedly dies.

This can partly be addressed by setting `Pdeathsig` in the init command's `SysProcAttr`. However, pdeathsig is reset after calls to setgid/setuid (e.g., when container.User is set). So for full support of parent death signals, the "init" process needs to know how to restore the signal.

I've broken this into three logical commits:
1. Add `GetParentDeathSignal` to "pkg/system"
2. Add `RestoreParentDeathSignal` to nsinit, called after finalizing the namespace (when user/group changes happen).
3. `DefaultCreateCommand` sets the parent death signal to SIGKILL.
