### PR TITLE
don't call sort for every add in daemon/history

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -85,6 +85,7 @@ func (daemon *Daemon) List() []*Container {
 	for e := daemon.containers.Front(); e != nil; e = e.Next() {
 		containers.Add(e.Value.(*Container))
 	}
+	containers.Sort()
 	return *containers
 }
 

--- a/daemon/history.go
+++ b/daemon/history.go
@@ -26,5 +26,8 @@ func (history *History) Swap(i, j int) {
 
 func (history *History) Add(container *Container) {
 	*history = append(*history, container)
+}
+
+func (history *History) Sort() {
 	sort.Sort(history)
 }


### PR DESCRIPTION
This moves the call to sort in daemon/history to a function to be called explicitly when we're done adding elements to the list.

This speeds up `docker ps`.

Here are the numbers from a system with 2006 containers:

```
unpatched List() - 183.966515ms
patched List() - 601.514us
305.99x improvement
```

Fixes #5297
