### PR TITLE
don't update Suffixarray for every Register during startup

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -141,7 +141,13 @@ func (daemon *Daemon) load(id string) (*Container, error) {
 }
 
 // Register makes a container object usable by the daemon as <container.ID>
+// This is a wrapper for register
 func (daemon *Daemon) Register(container *Container) error {
+	return daemon.register(container, true)
+}
+
+// register makes a container object usable by the daemon as <container.ID>
+func (daemon *Daemon) register(container *Container, updateSuffixarray bool) error {
 	if container.daemon != nil || daemon.Exists(container.ID) {
 		return fmt.Errorf("Container is already loaded")
 	}
@@ -165,7 +171,14 @@ func (daemon *Daemon) Register(container *Container) error {
 	}
 	// done
 	daemon.containers.PushBack(container)
-	daemon.idIndex.Add(container.ID)
+
+	// don't update the Suffixarray if we're starting up
+	// we'll waste time if we update it for every container
+	if updateSuffixarray {
+		daemon.idIndex.Add(container.ID)
+	} else {
+		daemon.idIndex.AddWithoutSuffixarrayUpdate(container.ID)
+	}
 
 	// FIXME: if the container is supposed to be running but is not, auto restart it?
 	//        if so, then we need to restart monitor and init a new lock
@@ -329,8 +342,8 @@ func (daemon *Daemon) restore() error {
 		}
 	}
 
-	register := func(container *Container) {
-		if err := daemon.Register(container); err != nil {
+	registerContainer := func(container *Container) {
+		if err := daemon.register(container, false); err != nil {
 			utils.Debugf("Failed to register container %s: %s", container.ID, err)
 		}
 	}
@@ -342,7 +355,7 @@ func (daemon *Daemon) restore() error {
 			}
 			e := entities[p]
 			if container, ok := containers[e.ID()]; ok {
-				register(container)
+				registerContainer(container)
 				delete(containers, e.ID())
 			}
 		}
@@ -359,9 +372,10 @@ func (daemon *Daemon) restore() error {
 		if _, err := daemon.containerGraph.Set(container.Name, container.ID); err != nil {
 			utils.Debugf("Setting default id - %s", err)
 		}
-		register(container)
+		registerContainer(container)
 	}
 
+	daemon.idIndex.UpdateSuffixarray()
 	if os.Getenv("DEBUG") == "" && os.Getenv("TEST") == "" {
 		fmt.Printf(": done.\n")
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -493,9 +493,7 @@ func NewTruncIndex(ids []string) (idx *TruncIndex) {
 	return
 }
 
-func (idx *TruncIndex) Add(id string) error {
-	idx.Lock()
-	defer idx.Unlock()
+func (idx *TruncIndex) addId(id string) error {
 	if strings.Contains(id, " ") {
 		return fmt.Errorf("Illegal character: ' '")
 	}
@@ -504,8 +502,29 @@ func (idx *TruncIndex) Add(id string) error {
 	}
 	idx.ids[id] = true
 	idx.bytes = append(idx.bytes, []byte(id+" ")...)
+	return nil
+}
+
+func (idx *TruncIndex) Add(id string) error {
+	idx.Lock()
+	defer idx.Unlock()
+	if err := idx.addId(id); err != nil {
+		return err
+	}
 	idx.index = suffixarray.New(idx.bytes)
 	return nil
+}
+
+func (idx *TruncIndex) AddWithoutSuffixarrayUpdate(id string) error {
+	idx.Lock()
+	defer idx.Unlock()
+	return idx.addId(id)
+}
+
+func (idx *TruncIndex) UpdateSuffixarray() {
+	idx.Lock()
+	defer idx.Unlock()
+	idx.index = suffixarray.New(idx.bytes)
 }
 
 func (idx *TruncIndex) Delete(id string) error {


### PR DESCRIPTION
This refactors TruncIndex so that we can add items to it without updating the Suffixarray. This refactored TruncIndex is used in daemon/daemon.go to speed up the daemon's startup by calling UpdateSuffixarray only when we're done registering containers during startup.

This fixes the slow startup encountered with a large number of containers.

Here are the numbers from a system with 2006 containers:

```
unpatched: restore() - 38.26s
patched: restore() - 764.7ms
50x improvement for 2006 containers

unpatched: restore() - 2m45.6s
patched: restore() - 1.46s
113x improvement for 4009 containers

patched: restore() - 3.4s for 10009 containers
```

This has reduced the total startup time down to around one second.

Fixes #1073
Fixes #4694 
Fixes #5084
