### PR TITLE
Issue #5766 - Check channel closed state in /events loop

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,7 @@ Anthony Bishopric <git@anthonybishopric.com>
 Anton Nikitin <anton.k.nikitin@gmail.com>
 Antony Messerli <amesserl@rackspace.com>
 apocas <petermdias@gmail.com>
+Arnaud Porterie <arnaud.porterie@gmail.com>
 Asbjørn Enge <asbjorn@hanafjedle.net>
 Barry Allard <barry.allard@gmail.com>
 Bartłomiej Piotrowski <b@bpiotrowski.pl>

--- a/server/server.go
+++ b/server/server.go
@@ -259,7 +259,10 @@ func (srv *Server) Events(job *engine.Job) engine.Status {
 	}
 	for {
 		select {
-		case event := <-listener:
+		case event, ok := <-listener:
+			if !ok { // Channel is closed: listener was evicted
+				return engine.StatusOK
+			}
 			err := sendEvent(&event)
 			if err != nil && err.Error() == "JSON error" {
 				continue


### PR DESCRIPTION
When listener channel is closed, it becomes always available for reading: select becomes an active loop which writes default-constructed events (i.e: empty strings).

Sorry for the lack of test, but I have a hard time writing a unit test for `/events` (un-terminating API call)

Fixes #5766

Docker-DCO-1.1-Signed-off-by: Arnaud Porterie arnaud.porterie@gmail.com (github: icecrime)
