### PR TITLE
Change libcontainer to drop all capabilities by default.

### DIFF
--- a/daemon/execdriver/native/template/default_template.go
+++ b/daemon/execdriver/native/template/default_template.go
@@ -26,6 +26,11 @@ func New() *libcontainer.Container {
 			"NET_ADMIN":      false,
 			"MKNOD":          true,
 			"SYSLOG":         false,
+			"SETUID":         true,
+			"SETGID":         true,
+			"CHOWN":          true,
+			"NET_RAW":        true,
+			"DAC_OVERRIDE":   true,
 		},
 		Namespaces: map[string]bool{
 			"NEWNS":  true,

--- a/pkg/libcontainer/security/capabilities/capabilities.go
+++ b/pkg/libcontainer/security/capabilities/capabilities.go
@@ -7,32 +7,34 @@ import (
 	"github.com/syndtr/gocapability/capability"
 )
 
-// DropCapabilities drops capabilities for the current process based
-// on the container's configuration.
-func DropCapabilities(container *libcontainer.Container) error {
-	if drop := getCapabilitiesMask(container); len(drop) > 0 {
-		c, err := capability.NewPid(os.Getpid())
-		if err != nil {
-			return err
-		}
-		c.Unset(capability.CAPS|capability.BOUNDS, drop...)
+const allCapabilityTypes = capability.CAPS | capability.BOUNDS
 
-		if err := c.Apply(capability.CAPS | capability.BOUNDS); err != nil {
-			return err
-		}
+// DropCapabilities drops all capabilities for the current process expect those specified in the container configuration.
+func DropCapabilities(container *libcontainer.Container) error {
+	c, err := capability.NewPid(os.Getpid())
+	if err != nil {
+		return err
+	}
+
+	keep := getEnabledCapabilities(container)
+	c.Clear(allCapabilityTypes)
+	c.Set(allCapabilityTypes, keep...)
+
+	if err := c.Apply(allCapabilityTypes); err != nil {
+		return err
 	}
 	return nil
 }
 
-// getCapabilitiesMask returns the specific cap mask values for the libcontainer types
-func getCapabilitiesMask(container *libcontainer.Container) []capability.Cap {
-	drop := []capability.Cap{}
+// getCapabilitiesMask returns the capabilities that should not be dropped by the container.
+func getEnabledCapabilities(container *libcontainer.Container) []capability.Cap {
+	keep := []capability.Cap{}
 	for key, enabled := range container.CapabilitiesMask {
-		if !enabled {
+		if enabled {
 			if c := libcontainer.GetCapability(key); c != nil {
-				drop = append(drop, c.Value)
+				keep = append(keep, c.Value)
 			}
 		}
 	}
-	return drop
+	return keep
 }

--- a/pkg/libcontainer/types.go
+++ b/pkg/libcontainer/types.go
@@ -55,6 +55,11 @@ var (
 		{Key: "MAC_ADMIN", Value: capability.CAP_MAC_ADMIN},
 		{Key: "NET_ADMIN", Value: capability.CAP_NET_ADMIN},
 		{Key: "SYSLOG", Value: capability.CAP_SYSLOG},
+		{Key: "SETUID", Value: capability.CAP_SETUID},
+		{Key: "SETGID", Value: capability.CAP_SETGID},
+		{Key: "CHOWN", Value: capability.CAP_CHOWN},
+		{Key: "NET_RAW", Value: capability.CAP_NET_RAW},
+		{Key: "DAC_OVERRIDE", Value: capability.CAP_DAC_OVERRIDE},
 	}
 )
 


### PR DESCRIPTION
Only keeps those that were specified in the config. This commit also explicitly
adds a set of capabilities that we were silently not dropping and were
assumed by the tests.

Closes #5661 

Docker-DCO-1.1-Signed-off-by: Victor Marmol vmarmol@google.com (github: vmarmol)
