### PR TITLE
Add --registry-append and --registry-replace qualifier to docker daemon

### DIFF
--- a/contrib/man/md/docker.1.md
+++ b/contrib/man/md/docker.1.md
@@ -73,6 +73,12 @@ port=[4243] or path =[/var/run/docker.sock] is omitted, default values are used.
 **-v**=*true*|*false*
   Print version information and quit. Default is false.
 
+**--registry-append**=""
+  Comma separated list of registries to append to default registry. Registries will be searched in reverse order.
+
+**--registry-replace**=""
+Comma separated list of registries to replace the default registry. Registries will be searched in reverse order
+
 **--selinux-enabled**=*true*|*false*
   Enable selinux support. Default is false.
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/opts"
 	flag "github.com/dotcloud/docker/pkg/mflag"
+	"github.com/dotcloud/docker/server"
 	"github.com/dotcloud/docker/sysinit"
 	"github.com/dotcloud/docker/utils"
 )
@@ -64,6 +65,8 @@ func main() {
 		flCa                 = flag.String([]string{"-tlscacert"}, dockerConfDir+defaultCaFile, "Trust only remotes providing a certificate signed by the CA given here")
 		flCert               = flag.String([]string{"-tlscert"}, dockerConfDir+defaultCertFile, "Path to TLS certificate file")
 		flKey                = flag.String([]string{"-tlskey"}, dockerConfDir+defaultKeyFile, "Path to TLS key file")
+		flAppendRegistry     = flag.String([]string{"-registry-append"}, "", "Comma separated list of registries to append to default registry. Registries will be searched in reverse order.")
+		flDefaultRegistry    = flag.String([]string{"-registry-replace"}, "", "Comma separated list of registries to replace the default registry. Registries will be searched in reverse order.")
 		flSelinuxEnabled     = flag.Bool([]string{"-selinux-enabled"}, false, "Enable selinux support")
 	)
 	flag.Var(&flDns, []string{"#dns", "-dns"}, "Force docker to use specific DNS servers")
@@ -75,6 +78,24 @@ func main() {
 	if *flVersion {
 		showVersion()
 		return
+	}
+	if *flDefaultRegistry != "" {
+		regs := strings.Split(*flAppendRegistry, ",")
+		for r := range regs {
+			if regs[r] != "" && !strings.HasSuffix(regs[r], "/") {
+				regs[r] = fmt.Sprintf("%s/", regs[r])
+			}
+		}
+		server.RegistryList = regs
+	}
+	if *flAppendRegistry != "" {
+		regs := strings.Split(*flAppendRegistry, ",")
+		for r := range regs {
+			if regs[r] != "" && !strings.HasSuffix(regs[r], "/") {
+				regs[r] = fmt.Sprintf("%s/", regs[r])
+			}
+			server.RegistryList = append(server.RegistryList, regs[r])
+		}
 	}
 	if flHosts.Len() == 0 {
 		defaultHost := os.Getenv("DOCKER_HOST")


### PR DESCRIPTION
These options setup a search list of registries from which to pull images.

Registries will be searched in reverse order.

--registry-append will allow you to add additional registries to docker.io to
pull images from.

For example

--registry-append="foo.com/registry,bar.com/registry"

Would cause a
docker pull myapp

to search
bar.com/registry/myapp
foo.com/registry/myapp
docker.io.../myapp

This would allow companies and vendors to specify registries which contain
content that the companies will not allowed to be stored at docker.io

--registry-replace="foo.com/registry,bar.com/registry"
Would do the same, but not search the docker.io registry.

This would allow a customer to control which sites that images can be pulled from.

```
Docker-DCO-1.1-Signed-off-by: Daniel Walsh <dwalsh@redhat.com> (github: rhatdan)
```
