### PR TITLE
Extend run config to let users specify an IP

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -396,7 +396,7 @@ func (container *Container) allocateNetwork() error {
 		err error
 		eng = container.daemon.eng
 	)
-	
+
 	job := eng.Job("allocate_interface", container.ID)
 	if container.Config.IP != "" {
 		job.Setenv("RequestedIP", container.Config.IP)

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -396,8 +396,11 @@ func (container *Container) allocateNetwork() error {
 		err error
 		eng = container.daemon.eng
 	)
-
+	
 	job := eng.Job("allocate_interface", container.ID)
+	if container.Config.IP != "" {
+		job.Setenv("RequestedIP", container.Config.IP)
+	}
 	if env, err = job.Stdout.AddEnv(); err != nil {
 		return err
 	}

--- a/daemon/networkdriver/ipallocator/allocator_test.go
+++ b/daemon/networkdriver/ipallocator/allocator_test.go
@@ -128,18 +128,27 @@ func TestIPAllocator(t *testing.T) {
 		0: net.IPv4(127, 0, 0, 2),
 		1: net.IPv4(127, 0, 0, 3),
 		2: net.IPv4(127, 0, 0, 4),
-		3: net.IPv4(127, 0, 0, 5),
-		4: net.IPv4(127, 0, 0, 6),
+		3: net.IPv4(127, 0, 0, 6),
+		4: net.IPv4(127, 0, 0, 7),
 	}
+	expectedStaticIP := net.IPv4(127, 0, 0, 5)
 
 	gwIP, n, _ := net.ParseCIDR("127.0.0.1/29")
 	network := &net.IPNet{IP: gwIP, Mask: n.Mask}
 	// Pool after initialisation (f = free, u = used)
-	// 2(f) - 3(f) - 4(f) - 5(f) - 6(f)
+	// 2(f) - 3(f) - 4(f) - 5(f) - 6(f) - 7(f)
 	//  ↑
 
-	// Check that we get 5 IPs, from 127.0.0.2–127.0.0.6, in that
-	// order.
+	// Allocate a pre-determined IP.
+	// 2(f) - 3(f) - 4(f) - 5(u) - 6(f) - 7(f)
+	//  ↑
+	if ip, err := RequestIP(network, expectedStatic); err != nil {
+		t.Fatal(err)
+	}
+	assertIPEquals(t, expectedStatic, ip)
+
+	// Check that we get 5 IPs, from 127.0.0.2–127.0.0.7, in that
+	// order, skipping 127.0.0.5
 	for i := 0; i < 5; i++ {
 		ip, err := RequestIP(network, nil)
 		if err != nil {
@@ -149,27 +158,27 @@ func TestIPAllocator(t *testing.T) {
 		assertIPEquals(t, &expectedIPs[i], ip)
 	}
 	// Before loop begin
-	// 2(f) - 3(f) - 4(f) - 5(f) - 6(f)
+	// 2(f) - 3(f) - 4(f) - 5(u) - 6(f) - 7(f)
 	//  ↑
 
 	// After i = 0
-	// 2(u) - 3(f) - 4(f) - 5(f) - 6(f)
+	// 2(u) - 3(f) - 4(f) - 5(u) - 6(f) - 7(f)
 	//         ↑
 
 	// After i = 1
-	// 2(u) - 3(u) - 4(f) - 5(f) - 6(f)
+	// 2(u) - 3(u) - 4(f) - 5(u) - 6(f) - 7(f)
 	//                ↑
 
 	// After i = 2
-	// 2(u) - 3(u) - 4(u) - 5(f) - 6(f)
-	//                       ↑
-
-	// After i = 3
-	// 2(u) - 3(u) - 4(u) - 5(u) - 6(f)
+	// 2(u) - 3(u) - 4(u) - 5(u) - 6(f) - 7(f)
 	//                              ↑
 
+	// After i = 3
+	// 2(u) - 3(u) - 4(u) - 5(u) - 6(u) - 7(f)
+	//                                     ↑
+
 	// After i = 4
-	// 2(u) - 3(u) - 4(u) - 5(u) - 6(u)
+	// 2(u) - 3(u) - 4(u) - 5(u) - 6(u) - 7(u)
 	//  ↑
 
 	// Check that there are no more IPs
@@ -182,25 +191,30 @@ func TestIPAllocator(t *testing.T) {
 	if err := ReleaseIP(network, &expectedIPs[3]); err != nil {
 		t.Fatal(err)
 	}
-	// 2(u) - 3(u) - 4(u) - 5(f) - 6(u)
-	//                       ↑
+	// 2(u) - 3(u) - 4(u) - 5(u) - 6(f) - 7(u)
+	//  ↑
 
 	if err := ReleaseIP(network, &expectedIPs[2]); err != nil {
 		t.Fatal(err)
 	}
-	// 2(u) - 3(u) - 4(f) - 5(f) - 6(u)
-	//                       ↑
+	// 2(u) - 3(u) - 4(f) - 5(u) - 6(f) - 7(u)
+	//  ↑
 
 	if err := ReleaseIP(network, &expectedIPs[4]); err != nil {
 		t.Fatal(err)
 	}
-	// 2(u) - 3(u) - 4(f) - 5(f) - 6(f)
-	//                       ↑
+	// 2(u) - 3(u) - 4(f) - 5(u) - 6(f) - 7(f)
+	//  ↑
+	if err := ReleaseIP(network, &expectedStaticIP); err != nil {
+		t.Fatal(err)
+	}
+	// 2(u) - 3(u) - 4(f) - 5(f) - 6(f) - 7(f)
+	//  ↑
 
 	// Make sure that IPs are reused in sequential order, starting
 	// with the first released IP
 	newIPs := make([]*net.IP, 3)
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		ip, err := RequestIP(network, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -209,8 +223,9 @@ func TestIPAllocator(t *testing.T) {
 		newIPs[i] = ip
 	}
 	assertIPEquals(t, &expectedIPs[2], newIPs[0])
-	assertIPEquals(t, &expectedIPs[3], newIPs[1])
-	assertIPEquals(t, &expectedIPs[4], newIPs[2])
+	assertIPEquals(t, &expectedStaticIP, newIPs[1])
+	assertIPEquals(t, &expectedIPs[3], newIPs[2])
+	assertIPEquals(t, &expectedIPs[4], newIPs[3])
 
 	_, err = RequestIP(network, nil)
 	if err == nil {

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	WorkingDir      string
 	Entrypoint      []string
 	NetworkDisabled bool
-	OnBuild         []string	
+	OnBuild         []string
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	Hostname        string
 	Domainname      string
+	IP              string
 	User            string
 	Memory          int64  // Memory limit (in bytes)
 	MemorySwap      int64  // Total memory usage (memory + swap); set `-1' to disable swap
@@ -31,13 +32,14 @@ type Config struct {
 	WorkingDir      string
 	Entrypoint      []string
 	NetworkDisabled bool
-	OnBuild         []string
+	OnBuild         []string	
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {
 	config := &Config{
 		Hostname:        job.Getenv("Hostname"),
 		Domainname:      job.Getenv("Domainname"),
+		IP:              job.Getenv("IP"),
 		User:            job.Getenv("User"),
 		Memory:          job.GetenvInt64("Memory"),
 		MemorySwap:      job.GetenvInt64("MemorySwap"),

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -19,6 +19,19 @@ func mustParse(t *testing.T, args string) (*Config, *HostConfig) {
 	return config, hostConfig
 }
 
+func TestParseRunIP(t *testing.T) {
+	if _, hostConfig := mustParse(t, ""); len(hostConfig.IP) > 0 {
+		t.Fatalf("Config must not contain an IP address when none is specified in the input")
+	}
+	if _, hostConfig := mustParse(t, "--ip 1.2.3"); len(hostConfig.IP) > 0 {
+		t.Fatalf("Expected failure but instead received ip: %v", hostConfig.IP)
+	}
+
+	if _, hostConfig := mustParse(t, "--ip 1.2.3.4"); len(hostConfig.IP) == 0 || hostConfig.IP != "1.2.3.4" {
+		t.Fatalf("Error parsing IP address. Expected []string{\"1.2.3.4\"}, recieved: %v", hostConfig.IP)
+	}
+}
+
 func TestParseRunLinks(t *testing.T) {
 	if _, hostConfig := mustParse(t, "--link a:b"); len(hostConfig.Links) == 0 || hostConfig.Links[0] != "a:b" {
 		t.Fatalf("Error parsing links. Expected []string{\"a:b\"}, received: %v", hostConfig.Links)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -3,6 +3,7 @@ package runconfig
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"path"
 	"strings"
 
@@ -65,6 +66,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flWorkingDir      = cmd.String([]string{"w", "-workdir"}, "", "Working directory inside the container")
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
+		flIP              = cmd.String([]string{"ip", "-ip"}, "", "IP address for the container. If not specified, and networking is enabled for the container, docker will automatically assign an IP.")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the contaner")
 		// For documentation purpose
 		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify all received signal to the process (even in non-tty mode)")
@@ -99,7 +101,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	}
 	if *flWorkingDir != "" && !path.IsAbs(*flWorkingDir) {
 		return nil, nil, cmd, ErrInvalidWorkingDirectory
-	}
+	}	
 	if *flDetach && *flAutoRemove {
 		return nil, nil, cmd, ErrConflictDetachAutoRemove
 	}
@@ -210,9 +212,16 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		return nil, nil, cmd, fmt.Errorf("--net: invalid net mode: %v", err)
 	}
 
+	if *flIP != "" {
+		if parsedIP := net.ParseIP(*flIP); parsedIP == nil {
+			return nil, nil, cmd, fmt.Errorf("--ip: invalid ip: %s", *flIP)
+		}
+	}
+
 	config := &Config{
 		Hostname:        hostname,
 		Domainname:      domainname,
+		IP:              *flIP,
 		PortSpecs:       nil, // Deprecated
 		ExposedPorts:    ports,
 		User:            *flUser,

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -66,7 +66,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flWorkingDir      = cmd.String([]string{"w", "-workdir"}, "", "Working directory inside the container")
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
-		flIP              = cmd.String([]string{"ip", "-ip"}, "", "IP address for the container. If not specified, and networking is enabled for the container, docker will automatically assign an IP.")
+		flIP              = cmd.String([]string{"ip", "-ip"}, "", "Optional IP address for the container. The IP must be from the docker bridge interface subnet.")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the contaner")
 		// For documentation purpose
 		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify all received signal to the process (even in non-tty mode)")
@@ -101,7 +101,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	}
 	if *flWorkingDir != "" && !path.IsAbs(*flWorkingDir) {
 		return nil, nil, cmd, ErrInvalidWorkingDirectory
-	}	
+	}
 	if *flDetach && *flAutoRemove {
 		return nil, nil, cmd, ErrConflictDetachAutoRemove
 	}


### PR DESCRIPTION
Added an option '--ip' to 'docker run' to be able to statically specify the IP for a container. This change helps get around the problem of IP changing across container restarts.
@thockin.
