### PR TITLE
Refactor b.tar -> busybox.tar

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1074,11 +1074,11 @@ It is used to create a backup that can then be used with
 `docker load`
 
     $ sudo docker save busybox > busybox.tar
-    $ ls -sh b.tar
-    2.7M b.tar
+    $ ls -sh busybox.tar
+    2.7M busybox.tar
     $ sudo docker save --output busybox.tar busybox
-    $ ls -sh b.tar
-    2.7M b.tar
+    $ ls -sh busybox.tar
+    2.7M busybox.tar
     $ sudo docker save -o fedora-all.tar fedora
     $ sudo docker save -o fedora-latest.tar fedora:latest
 


### PR DESCRIPTION
The file was saved as busybox.tar, but the ls commands named it b.tar.

Docker-DCO-1.1-Signed-off-by: Steven Burgess steven.a.burgess@hotmail.com (github: stevenburgess)
