### PR TITLE
fix panic when passing empty environment

### DIFF
--- a/pkg/libcontainer/nsinit/init.go
+++ b/pkg/libcontainer/nsinit/init.go
@@ -152,6 +152,9 @@ func LoadContainerEnvironment(container *libcontainer.Container) error {
 	os.Clearenv()
 	for _, pair := range container.Env {
 		p := strings.SplitN(pair, "=", 2)
+		if len(p) < 2 {
+			return fmt.Errorf("invalid environment '%v'", pair)
+		}
 		if err := os.Setenv(p[0], p[1]); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix a potential panic (introduced on [Apr 30](https://github.com/dotcloud/docker/blame/master/pkg/libcontainer/nsinit/init.go#L154), released docker as 0.11.1) when starting containers via API:

```
panic: runtime error: index out of range

goroutine 1 [running]:
runtime.panic(0xa4d6c0, 0x1417cb7)
        /usr/local/go/src/pkg/runtime/panic.c:266 +0xb6
github.com/dotcloud/docker/pkg/libcontainer/nsinit.LoadContainerEnvironment(0xc2100f69a0, 0x59, 0xc210037780)
        /go/src/github.com/dotcloud/docker/pkg/libcontainer/nsinit/init.go:155 +0x126
github.com/dotcloud/docker/pkg/libcontainer/nsinit.Init(0xc2100f69a0, 0xc210037660, 0x59, 0x7fff64970eee, 0x0, ...)
        /go/src/github.com/dotcloud/docker/pkg/libcontainer/nsinit/init.go:35 +0x9a
github.com/dotcloud/docker/daemon/execdriver/native.func·001(0xc210079180, 0xc21001ef90, 0x7fff64970ede)
        /go/src/github.com/dotcloud/docker/daemon/execdriver/native/driver.go:49 +0x308
github.com/dotcloud/docker/sysinit.executeProgram(0xc210079180, 0xc210079180, 0xadef80)
        /go/src/github.com/dotcloud/docker/sysinit/sysinit.go:18 +0xbc
github.com/dotcloud/docker/sysinit.SysInit()
        /go/src/github.com/dotcloud/docker/sysinit/sysinit.go:59 +0x564
main.main()
        /go/src/github.com/dotcloud/docker/docker/docker.go:37 +0x67
```

To reproduce, pass empty environment via the API, eg:

``` Go
package main

import (
    "fmt"
    docker "github.com/fsouza/go-dockerclient"
    "io"
    "io/ioutil"
)

func main() {
    fmt.Println("begin repro")
    config := &docker.Config{
        Env:   []string{"", ""},
        Image: "ubuntu",
        Cmd:   []string{"echo Testing"},
    }

    endpoint := "unix:///var/run/docker.sock"
    d, err := docker.NewClient(endpoint)
    if err != nil {
        fmt.Printf("ERR newclient: %v", err)
        return
    }

    createOpts := docker.CreateContainerOptions{
        Name: "repro", Config: config}
    c, err := d.CreateContainer(createOpts)
    if err != nil {
        fmt.Printf("ERR createcontainer: %v", err)
        return
    }

    d.StartContainer(c.ID, &docker.HostConfig{})

    r, w := io.Pipe()

    go func() {
        fmt.Println("Reading...")
        data, _ := ioutil.ReadAll(r)
        fmt.Println(string(data))
        fmt.Println("all done.")
    }()

    err = d.AttachToContainer(
        docker.AttachToContainerOptions{
            Container:    c.ID,
            Logs:         true,
            Stream:       true,
            Stdout:       true,
            Stderr:       true,
            OutputStream: w,
            ErrorStream:  w,
        })
    if err != nil {
        fmt.Printf("ERR attachcontainer: %v", err)
        return
    }
    w.Close()

}
```
