### PR TITLE
Update ubuntulinux.md

### DIFF
--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -203,6 +203,7 @@ than `docker` should own the Unix socket with the
     $ sudo gpasswd -a ${USER} docker
 
     # Restart the Docker daemon.
+    # If you are in Ubuntu 14.04, use docker.io instead of docker
     $ sudo service docker restart
 
 ### Upgrade


### PR DESCRIPTION
In Ubuntu 14.04, we should use

```
$ sudo service docker.io restart
```

instead of

```
$ sudo service docker restart
```
