### PR TITLE
contrib/init/upstart: start on mounted

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -1,6 +1,6 @@
 description "Docker daemon"
 
-start on filesystem
+start on local-filesystems
 stop on runlevel [!2345]
 limit nofile 524288 1048576
 limit nproc 524288 1048576


### PR DESCRIPTION
This changes the upstart init script to start on `mounted`.

Fixes #4774
