### PR TITLE
run: pull only latest when no tag specified

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1840,6 +1840,10 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 
 		v := url.Values{}
 		repos, tag := utils.ParseRepositoryTag(config.Image)
+		// pull only the image tagged 'latest' if no tag was specified
+		if tag == "" {
+			tag = "latest"
+		}
 		v.Set("fromImage", repos)
 		v.Set("tag", tag)
 


### PR DESCRIPTION
This PR makes Docker pull only the image tagged as latest when no tag has been specified. This makes Docker pull only the image it'll run.

Fixes #5047
