### PR TITLE
fix(daemon): prepend host /etc/hosts instead of bind mounting

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -879,9 +879,17 @@ func (container *Container) initializeNetworking() error {
 			container.Config.Hostname = parts[0]
 			container.Config.Domainname = parts[1]
 		}
-		container.HostsPath = "/etc/hosts"
 
-		return container.buildHostnameFile()
+		content, err := ioutil.ReadFile("/etc/hosts")
+		if os.IsNotExist(err) {
+			return container.buildHostnameAndHostsFiles("")
+		}
+		if err != nil {
+			return err
+		}
+
+		container.HostsPath = container.getRootResourcePath("hosts")
+		return ioutil.WriteFile(container.HostsPath, content, 0644)
 	} else if container.hostConfig.NetworkMode.IsContainer() {
 		// we need to get the hosts files from the container to join
 		nc, err := container.getNetworkedContainer()

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -40,8 +40,11 @@ func setupMountsForContainer(container *Container) error {
 		{container.ResolvConfPath, "/etc/resolv.conf", false, true},
 	}
 
-	if container.HostnamePath != "" && container.HostsPath != "" {
+	if container.HostnamePath != "" {
 		mounts = append(mounts, execdriver.Mount{container.HostnamePath, "/etc/hostname", false, true})
+	}
+
+	if container.HostsPath != "" {
 		mounts = append(mounts, execdriver.Mount{container.HostsPath, "/etc/hosts", false, true})
 	}
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -438,7 +438,7 @@ func TestCreateVolume(t *testing.T) {
 
 	deleteAllContainers()
 
-	logDone("run - create docker mangaed volume")
+	logDone("run - create docker managed volume")
 }
 
 // Test that creating a volume with a symlink in its path works correctly. Test for #5152.


### PR DESCRIPTION
systemd systems do not require a /etc/hosts file exists since an nss
module is shipped that creates localhost implicitly. So, mounting
/etc/hosts can fail on these sorts of systems, as was reported on CoreOS
in issue #5812.

Instead of trying to bind mount just prepend the hosts entries onto the
containers private /etc/hosts. Maybe this will fix #5857 too?
