### PR TITLE
sort flags with the same name in a consistent order

### DIFF
--- a/pkg/mflag/flag.go
+++ b/pkg/mflag/flag.go
@@ -303,12 +303,10 @@ type flagSlice []string
 
 func (p flagSlice) Len() int { return len(p) }
 func (p flagSlice) Less(i, j int) bool {
-	pi, pj := strings.ToLower(p[i]), strings.ToLower(p[j])
-	if pi[0] == '-' {
-		pi = pi[1:]
-	}
-	if pj[0] == '-' {
-		pj = pj[1:]
+	pi, pj := strings.TrimPrefix(p[i], "-"), strings.TrimPrefix(p[j], "-")
+	lpi, lpj := strings.ToLower(pi), strings.ToLower(pj)
+	if lpi != lpj {
+		return lpi < lpj
 	}
 	return pi < pj
 }
@@ -441,8 +439,6 @@ func (f *FlagSet) PrintDefaults() {
 				}
 				fmt.Fprintln(writer, "\t", line)
 			}
-			//			start := fmt.Sprintf(format, strings.Join(names, ", -"), flag.DefValue)
-			//			fmt.Fprintln(f.out(), start, strings.Replace(flag.Usage, "\n", "\n"+strings.Repeat(" ", len(start)+1), -1))
 		}
 	})
 	writer.Flush()
@@ -797,14 +793,12 @@ func (f *FlagSet) parseOne() (bool, string, error) {
 	f.args = f.args[1:]
 	has_value := false
 	value := ""
-	for i := 1; i < len(name); i++ { // equals cannot be first
-		if name[i] == '=' {
-			value = name[i+1:]
-			has_value = true
-			name = name[0:i]
-			break
-		}
+	if i := strings.Index(name, "="); i != -1 {
+		has_value = true
+		value = name[i+1:]
+		name = name[:i]
 	}
+
 	m := f.formal
 	flag, alreadythere := m[name] // BUG
 	if !alreadythere {


### PR DESCRIPTION
before:

```
: trevize docker master ; docker --help 2>&1 | fgrep -i -- '-g'
  -g, --graph="/var/lib/docker"             Path to use as the root of the docker runtime
  -G, --group="docker"                      Group to assign the unix socket specified by -H when running in daemon mode
: trevize docker master ; docker --help 2>&1 | fgrep -i -- '-g'
  -G, --group="docker"                      Group to assign the unix socket specified by -H when running in daemon mode
  -g, --graph="/var/lib/docker"             Path to use as the root of the docker runtime
: trevize docker master ; docker --help 2>&1 | fgrep -i -- '-g'
  -G, --group="docker"                      Group to assign the unix socket specified by -H when running in daemon mode
  -g, --graph="/var/lib/docker"             Path to use as the root of the docker runtime
```

after:

```
: trevize docker master ;  bundles/0.11.1-dev/binary/docker --help 2>&1 | fgrep -i -- '-g'
  -G, --group="docker"                      Group to assign the unix socket specified by -H when running in daemon mode
  -g, --graph="/var/lib/docker"             Path to use as the root of the docker runtime
: trevize docker master ;  bundles/0.11.1-dev/binary/docker --help 2>&1 | fgrep -i -- '-g'
  -G, --group="docker"                      Group to assign the unix socket specified by -H when running in daemon mode
  -g, --graph="/var/lib/docker"             Path to use as the root of the docker runtime
: trevize docker master ;  bundles/0.11.1-dev/binary/docker --help 2>&1 | fgrep -i -- '-g'
  -G, --group="docker"                      Group to assign the unix socket specified by -H when running in daemon mode
  -g, --graph="/var/lib/docker"             Path to use as the root of the docker runtime

```
