### PR TITLE
gocapability: upstream fix for unsporrted caps

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -45,7 +45,7 @@ clone git github.com/gorilla/context 708054d61e5
 
 clone git github.com/gorilla/mux 9b36453141c
 
-clone git github.com/syndtr/gocapability 3454319be2
+clone git github.com/syndtr/gocapability 3c85049eae
 
 clone hg code.google.com/p/go.net 84a4013f96e0
 

--- a/vendor/src/github.com/syndtr/gocapability/capability/capability_linux.go
+++ b/vendor/src/github.com/syndtr/gocapability/capability/capability_linux.go
@@ -388,6 +388,11 @@ func (c *capsV3) Apply(kind CapType) (err error) {
 				}
 				err = prctl(syscall.PR_CAPBSET_DROP, uintptr(i), 0, 0, 0)
 				if err != nil {
+					// Ignore EINVAL since the capability may not be supported in this system.
+					if errno, ok := err.(syscall.Errno); ok && errno == syscall.EINVAL {
+						err = nil
+						continue
+					}
 					return
 				}
 			}


### PR DESCRIPTION
@vmarmol has made the fix upstream for not failing if the capability
being dropped is returned as invalid from the syscall, which is the case
when the capability is not supported on the host.
This is a blocker presently for RHEL6.5 on CAP_SYSLOG. We have patched
around this in our RPM for the time being, but this is the proper fix.

See also https://github.com/dotcloud/docker/pull/5810

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
