### PR TITLE
removing grep command that depends on perl, better for boot2docker

### DIFF
--- a/docs/sources/examples/couchdb_data_volumes.md
+++ b/docs/sources/examples/couchdb_data_volumes.md
@@ -28,7 +28,7 @@ We're assuming your Docker host is reachable at `localhost`. If not,
 replace `localhost` with the public IP of your Docker host.
 
     $ HOST=localhost
-    $ URL="http://$HOST:$(sudo docker port $COUCH1 5984 | grep -Po '\d+$')/_utils/"
+    $ URL="http://$HOST:$(sudo docker port $COUCH1 5984 | grep -o '[1-9][0-9]*$')/_utils/"
     $ echo "Navigate to $URL in your browser, and use the couch interface to add data"
 
 ## Create second database
@@ -40,7 +40,7 @@ This time, we're requesting shared access to `$COUCH1`'s volumes.
 ## Browse data on the second database
 
     $ HOST=localhost
-    $ URL="http://$HOST:$(sudo docker port $COUCH2 5984 | grep -Po '\d+$')/_utils/"
+    $ URL="http://$HOST:$(sudo docker port $COUCH2 5984 | grep -o '[1-9][0-9]*$')/_utils/"
     $ echo "Navigate to $URL in your browser. You should see the same data as in the first database"'!'
 
 Congratulations, you are now running two Couchdb containers, completely


### PR DESCRIPTION
fwiw copy and paste of this documentation does not work. Will file another bug for it. 
Docker-DCO-1.1-Signed-off-by: Adam Singer financeCoding@gmail.com (github: financeCoding)
