### PR TITLE
Fix hanging on tests failing

### DIFF
--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -10,6 +10,6 @@ bundle_test_integration() {
 
 # this "grep" hides some really irritating warnings that "go test -coverpkg"
 # spews when it is given packages that aren't used
+exec > >(tee -a $DEST/test.log) 2>&1
 bundle_test_integration 2>&1 \
-	| grep --line-buffered -v '^warning: no packages being tested depend on ' \
-	| tee $DEST/test.log
+	| grep --line-buffered -v '^warning: no packages being tested depend on '

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -11,6 +11,7 @@ bundle_test_integration_cli() {
 }
 
 # subshell so that we can export PATH without breaking other things
+exec > >(tee -a $DEST/test.log) 2>&1
 (
 	export PATH="$DEST/../binary:$DEST/../dynbinary:$PATH"
 
@@ -40,4 +41,4 @@ bundle_test_integration_cli() {
 	DOCKERD_PID=$(set -x; cat $DEST/docker.pid)
 	( set -x; kill $DOCKERD_PID )
 	wait $DOCKERD_PID || true
-) 2>&1 | tee $DEST/test.log
+)

--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -49,7 +49,8 @@ bundle_test_unit() {
 			echo
 			true
 		fi
-	} 2>&1 | tee $DEST/test.log
+	}
 }
 
+exec > >(tee -a $DEST/test.log) 2>&1
 bundle_test_unit


### PR DESCRIPTION
Tee hanging when `go test` exit with non-zero code.
Fixes #5672
