### PR TITLE
Updated Ubuntu Upstart service name to docker.io

### DIFF
--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -297,7 +297,7 @@ Docker daemon for the containers:
 
 The Docker daemon has to be restarted:
 
-    $ sudo restart docker
+    $ sudo restart docker.io
 
 > **Warning**: 
 > If you're doing this on a laptop which connects to various networks,


### PR DESCRIPTION
Under the "Docker and local DNS server warnings" section for Ubuntu the restart daemon command should be "docker.io", not "docker".
