### PR TITLE
Don't drop CAP_FOWNER in the container.

### DIFF
--- a/daemon/execdriver/native/template/default_template.go
+++ b/daemon/execdriver/native/template/default_template.go
@@ -10,12 +10,13 @@ import (
 func New() *libcontainer.Container {
 	container := &libcontainer.Container{
 		Capabilities: []string{
-			"MKNOD",
-			"SETUID",
-			"SETGID",
 			"CHOWN",
-			"NET_RAW",
 			"DAC_OVERRIDE",
+			"FOWNER",
+			"MKNOD",
+			"NET_RAW",
+			"SETGID",
+			"SETUID",
 		},
 		Namespaces: map[string]bool{
 			"NEWNS":  true,


### PR DESCRIPTION
 Also sorts the list of allowed capabilities.

Fixes #5887

Docker-DCO-1.1-Signed-off-by: Victor Marmol vmarmol@google.com (github: vmarmol)
