### PR TITLE
Make sure dev/fuse is created in container

### DIFF
--- a/pkg/libcontainer/mount/init.go
+++ b/pkg/libcontainer/mount/init.go
@@ -48,8 +48,11 @@ func InitializeMountNamespace(rootfs, console string, container *libcontainer.Co
 	if err := setupBindmounts(rootfs, container.Mounts); err != nil {
 		return fmt.Errorf("bind mounts %s", err)
 	}
-	if err := nodes.CopyN(rootfs, nodes.DefaultNodes); err != nil {
+	if err := nodes.CopyN(rootfs, nodes.DefaultNodes, true); err != nil {
 		return fmt.Errorf("copy dev nodes %s", err)
+	}
+	if err := nodes.CopyN(rootfs, nodes.AdditionalNodes, false); err != nil {
+		return fmt.Errorf("copy additional dev nodes %s", err)
 	}
 	if err := SetupPtmx(rootfs, console, container.Context["mount_label"]); err != nil {
 		return err


### PR DESCRIPTION
Fixes #5849

If the host system does not have fuse enabled in the kernel config we
will ignore the is not exist errors when trying to copy the device node
from the host system into the container.

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
