### PR TITLE
add unprivilegeduser via the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,9 @@ RUN	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_
 # Set user.email so crosbymichael's in-container merge commits go smoothly
 RUN	git config --global user.email 'docker-dummy@example.com'
 
+# Add an unprivileged user to be used for tests which need it
+RUN adduser unprivilegeduser
+
 VOLUME	/var/lib/docker
 WORKDIR	/go/src/github.com/dotcloud/docker
 ENV	DOCKER_BUILDTAGS	apparmor selinux

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -125,16 +125,13 @@ func TestAddWholeDirToRoot(t *testing.T) {
 // when we can't access files in the context.
 func TestBuildWithInaccessibleFilesInContext(t *testing.T) {
 	buildDirectory := filepath.Join(workingDirectory, "build_tests", "TestBuildWithInaccessibleFilesInContext")
-	addUserCmd := exec.Command("adduser", "unprivilegeduser")
-	out, _, err := runCommandWithOutput(addUserCmd)
-	errorOut(err, t, fmt.Sprintf("failed to add user: %v %v", out, err))
 
 	{
 		// This is used to ensure we detect inaccessible files early during build in the cli client
 		pathToInaccessibleFileBuildDirectory := filepath.Join(buildDirectory, "inaccessiblefile")
 		pathToFileWithoutReadAccess := filepath.Join(pathToInaccessibleFileBuildDirectory, "fileWithoutReadAccess")
 
-		err = os.Chown(pathToFileWithoutReadAccess, 0, 0)
+		err := os.Chown(pathToFileWithoutReadAccess, 0, 0)
 		errorOut(err, t, fmt.Sprintf("failed to chown file to root: %s", err))
 		err = os.Chmod(pathToFileWithoutReadAccess, 0700)
 		errorOut(err, t, fmt.Sprintf("failed to chmod file to 700: %s", err))
@@ -162,7 +159,7 @@ func TestBuildWithInaccessibleFilesInContext(t *testing.T) {
 		pathToDirectoryWithoutReadAccess := filepath.Join(pathToInaccessibleDirectoryBuildDirectory, "directoryWeCantStat")
 		pathToFileInDirectoryWithoutReadAccess := filepath.Join(pathToDirectoryWithoutReadAccess, "bar")
 
-		err = os.Chown(pathToDirectoryWithoutReadAccess, 0, 0)
+		err := os.Chown(pathToDirectoryWithoutReadAccess, 0, 0)
 		errorOut(err, t, fmt.Sprintf("failed to chown directory to root: %s", err))
 		err = os.Chmod(pathToDirectoryWithoutReadAccess, 0444)
 		errorOut(err, t, fmt.Sprintf("failed to chmod directory to 755: %s", err))


### PR DESCRIPTION
This changes the test TestBuildWithInaccessibleFilesInContext to not add the user 'unprivilegeduser' and add it via the Dockerfile instead.

Fixes #5912
