### PR TITLE
Prevent false positive for remote ADD cache hits

### DIFF
--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -571,6 +571,9 @@ func (b *buildFile) CmdAdd(args string) error {
 			return err
 		}
 		tarSum := utils.TarSum{Reader: r, DisableCompression: true}
+		if _, err := io.Copy(ioutil.Discard, &tarSum); err != nil {
+			return err
+		}
 		remoteHash = tarSum.Sum(nil)
 		r.Close()
 


### PR DESCRIPTION
As far as I can see, caching for remote `ADD` instructions is working a bit "too well":

```
echo -e 'FROM busybox\nADD https://www.docker.io/static/img/homepage-docker-logo.png /foo' | \
  docker build -t remoteadd - && \
  docker history --no-trunc remoteadd
```

```
IMAGE                                                              CREATED             CREATED BY                                                                                                     SIZE
375e914957043bd9c3eff0926c4a51e187e7cadf1e09aebfe53e0aaa851fdb65   5 seconds ago       /bin/sh -c #(nop) ADD tarsum+sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 in /foo   2.31 kB
...
```

Notice the sha256 of the `ADD` instruction: whatever remote file you link to, it will remain the same (the hash for `/dev/null`), triggering an incorrect cache hit as long as the target file remains the same, forcing the use of `--no-cache`. You can also find errors related to the streams in the debug log.

This fix has the (intended) side effect of making the hash actually depend on the content downloaded, which means that you won't get any cache hit anymore since mtime is considered as part of the hash. That's probably another discussion (what happened to https://github.com/dotcloud/docker/pull/4194?), but for now, I'd say this is sneaky enough to consider this as a first step.
