### PR TITLE
portallocator: combine find port / add port semantics, with locking.

### DIFF
--- a/daemon/networkdriver/portallocator/portallocator.go
+++ b/daemon/networkdriver/portallocator/portallocator.go
@@ -100,7 +100,6 @@ func ReleaseAll() error {
 }
 
 func registerDynamicPort(ip net.IP, proto string) (int, error) {
-
 	if !equalsDefault(ip) {
 		registerIP(ip)
 
@@ -114,14 +113,12 @@ func registerDynamicPort(ip net.IP, proto string) (int, error) {
 		return port, nil
 
 	} else {
-
 		allocated := defaultAllocatedPorts[proto]
 
 		port, err := findNextPort(proto, allocated)
 		if err != nil {
 			return 0, err
 		}
-		allocated.Push(port)
 		return port, nil
 	}
 }
@@ -159,6 +156,8 @@ func findNextPort(proto string, allocated *collections.OrderedIntSet) (int, erro
 			return 0, ErrAllPortsAllocated
 		}
 	}
+
+	allocated.Push(port)
 	return port, nil
 }
 


### PR DESCRIPTION
sorry for the dirty whitespace in this patch.

This locking allows the port allocator to perform the port allocation atomically; before there was the opportunity for findNextPort to race against itself from a variety of usage scenarios.

Tested with docker-stress:

```
$ sudo ./docker-stress -d /home/erikh/docker/bundles/0.11.1-dev/binary/docker-0.11.1-dev -c 50
```

And `docker -d` running against a recent build of master.

This potentially resolves #5738 
