### PR TITLE
cgroups: Allow mknod for any device in systemd cgroup backend

### DIFF
--- a/pkg/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/pkg/libcontainer/cgroups/systemd/apply_systemd.go
@@ -174,13 +174,22 @@ func Apply(c *cgroups.Cgroup, pid int) (cgroups.ActiveCgroup, error) {
 
 		path := filepath.Join(mountpoint, cgroup)
 
-		// /dev/pts/*
-		if err := ioutil.WriteFile(filepath.Join(path, "devices.allow"), []byte("c 136:* rwm"), 0700); err != nil {
-			return nil, err
+		allow := []string{
+			// allow mknod for any device
+			"c *:* m",
+			"b *:* m",
+
+			// /dev/pts/ - pts namespaces are "coming soon"
+			"c 136:* rwm",
+
+			// tuntap
+			"c 10:200 rwm",
 		}
-		// tuntap
-		if err := ioutil.WriteFile(filepath.Join(path, "devices.allow"), []byte("c 10:200 rwm"), 0700); err != nil {
-			return nil, err
+
+		for _, val := range allow {
+			if err := ioutil.WriteFile(filepath.Join(path, "devices.allow"), []byte(val), 0700); err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Without this any container startup fails:
2014/05/20 09:20:36 setup mount namespace copy additional dev nodes mknod fuse operation not permitted

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
