### PR TITLE
native driver: Don't drop SETFCAP

### DIFF
--- a/daemon/execdriver/native/template/default_template.go
+++ b/daemon/execdriver/native/template/default_template.go
@@ -17,6 +17,9 @@ func New() *libcontainer.Container {
 			"NET_RAW",
 			"SETGID",
 			"SETUID",
+			"SETFCAP",
+			"SETPCAP",
+			"NET_BIND_SERVICE",
 		},
 		Namespaces: map[string]bool{
 			"NEWNS":  true,


### PR DESCRIPTION
We used to grant this, and fedora needs it.
Closes #5928

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
