### PR TITLE
Fix network mode for lxc 1.0

### DIFF
--- a/daemon/execdriver/lxc/lxc_template.go
+++ b/daemon/execdriver/lxc/lxc_template.go
@@ -15,7 +15,9 @@ lxc.network.type = veth
 lxc.network.link = {{.Network.Interface.Bridge}}
 lxc.network.name = eth0
 lxc.network.mtu = {{.Network.Mtu}}
-{{else if not .Network.HostNetworking}}
+{{else if .Network.HostNetworking}}
+lxc.network.type = none
+{{else}}
 # network is disabled (-n=false)
 lxc.network.type = empty
 lxc.network.flags = up


### PR DESCRIPTION
Fixes #5692

This change requires lxc 1.0+ to work and breaks lxc versions less than
1.0 for host networking.  We think that this is a find tradeoff by
bumping docker to only support lxc 1.0

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
