### PR TITLE
5923-fix-leaking-go-routine

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -652,7 +652,7 @@ func (container *Container) Export() (archive.Archive, error) {
 }
 
 func (container *Container) WaitTimeout(timeout time.Duration) error {
-	done := make(chan bool)
+	done := make(chan bool, 1)
 	go func() {
 		container.Wait()
 		done <- true


### PR DESCRIPTION
use buffered channel so goroutine does not get blocked on done <- true when a timeout occurs.

should fix issue https://github.com/dotcloud/docker/issues/5923
