### PR TITLE
Add new consolidated mkimage scripts

### DIFF
--- a/contrib/mkimage-busybox.sh
+++ b/contrib/mkimage-busybox.sh
@@ -2,6 +2,10 @@
 # Generate a very minimal filesystem based on busybox-static,
 # and load it into the local docker under the name "busybox".
 
+echo >&2
+echo >&2 'warning: this script is deprecated - see mkimage.sh and mkimage/busybox-static'
+echo >&2
+
 BUSYBOX=$(which busybox)
 [ "$BUSYBOX" ] || {
     echo "Sorry, I could not locate busybox."

--- a/contrib/mkimage-debootstrap.sh
+++ b/contrib/mkimage-debootstrap.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+echo >&2
+echo >&2 'warning: this script is deprecated - see mkimage.sh and mkimage/debootstrap'
+echo >&2
+
 variant='minbase'
 include='iproute,iputils-ping'
 arch='amd64' # intentionally undocumented for now

--- a/contrib/mkimage-rinse.sh
+++ b/contrib/mkimage-rinse.sh
@@ -8,6 +8,10 @@
 
 set -e
 
+echo >&2
+echo >&2 'warning: this script is deprecated - see mkimage.sh and mkimage/rinse'
+echo >&2
+
 repo="$1"
 distro="$2"
 mirror="$3"

--- a/contrib/mkimage.sh
+++ b/contrib/mkimage.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -e
+
+mkimg="$(basename "$0")"
+
+usage() {
+	echo >&2 "usage: $mkimg [-d dir] [-t tag] script [script-args]"
+	echo >&2 "   ie: $mkimg -t someuser/debian debootstrap --variant=minbase jessie"
+	echo >&2 "       $mkimg -t someuser/ubuntu debootstrap --include=ubuntu-minimal trusty"
+	echo >&2 "       $mkimg -t someuser/busybox busybox-static"
+	echo >&2 "       $mkimg -t someuser/centos:5 rinse --distribution centos-5"
+	exit 1
+}
+
+scriptDir="$(dirname "$(readlink -f "$BASH_SOURCE")")/mkimage"
+
+optTemp=$(getopt --options '+d:t:h' --longoptions 'dir:,tag:,help' --name "$mkimg" -- "$@")
+eval set -- "$optTemp"
+unset optTemp
+
+dir=
+tag=
+while true; do
+	case "$1" in
+		-d|--dir) dir="$2" ; shift 2 ;;
+		-t|--tag) tag="$2" ; shift 2 ;;
+		-h|--help) usage ;;
+		--) shift ; break ;;
+	esac
+done
+
+script="$1"
+[ "$script" ] || usage
+shift
+
+if [ ! -x "$scriptDir/$script" ]; then
+	echo >&2 "error: $script does not exist or is not executable"
+	echo >&2 "  see $scriptDir for possible scripts"
+	exit 1
+fi
+
+# don't mistake common scripts like .febootstrap-minimize as image-creators
+if [[ "$script" == .* ]]; then
+	echo >&2 "error: $script is a script helper, not a script"
+	echo >&2 "  see $scriptDir for possible scripts"
+	exit 1
+fi
+
+delDir=
+if [ -z "$dir" ]; then
+	dir="$(mktemp -d ${TMPDIR:-/tmp}/docker-mkimage.XXXXXXXXXX)"
+	delDir=1
+fi
+
+rootfsDir="$dir/rootfs"
+( set -x; mkdir -p "$rootfsDir" )
+
+# pass all remaining arguments to $script
+"$scriptDir/$script" "$rootfsDir" "$@"
+
+# Docker mounts tmpfs at /dev and procfs at /proc so we can remove them
+rm -rf "$rootfsDir/dev" "$rootfsDir/proc"
+mkdir -p "$rootfsDir/dev" "$rootfsDir/proc"
+
+# make sure /etc/resolv.conf has something useful in it
+mkdir -p "$rootfsDir/etc"
+cat > "$rootfsDir/etc/resolv.conf" <<'EOF'
+nameserver 8.8.8.8
+nameserver 8.8.4.4
+EOF
+
+tarFile="$dir/rootfs.tar.xz"
+touch "$tarFile"
+
+(
+	set -x
+	tar --numeric-owner -caf "$tarFile" -C "$rootfsDir" --transform='s,^./,,' .
+)
+
+echo >&2 "+ cat > '$dir/Dockerfile'"
+cat > "$dir/Dockerfile" <<'EOF'
+FROM scratch
+ADD rootfs.tar.xz /
+EOF
+
+# if our generated image has a decent shell, let's set a default command
+for shell in /bin/bash /usr/bin/fish /usr/bin/zsh /bin/sh; do
+	if [ -x "$rootfsDir/$shell" ]; then
+		( set -x; echo 'CMD ["'"$shell"'"]' >> "$dir/Dockerfile" )
+		break
+	fi
+done
+
+( set -x; rm -rf "$rootfsDir" )
+
+if [ "$tag" ]; then
+	( set -x; docker build -t "$tag" "$dir" )
+elif [ "$delDir" ]; then
+	# if we didn't specify a tag and we're going to delete our dir, let's just build an untagged image so that we did _something_
+	( set -x; docker build "$dir" )
+fi
+
+if [ "$delDir" ]; then
+	( set -x; rm -rf "$dir" )
+fi

--- a/contrib/mkimage/.febootstrap-minimize
+++ b/contrib/mkimage/.febootstrap-minimize
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+rootfsDir="$1"
+shift
+
+(
+	cd "$rootfsDir"
+
+	# effectively: febootstrap-minimize --keep-zoneinfo --keep-rpmdb --keep-services "$target"
+	#  locales
+	rm -rf usr/{{lib,share}/locale,{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive}
+	#  docs
+	rm -rf usr/share/{man,doc,info,gnome/help}
+	#  cracklib
+	#rm -rf usr/share/cracklib
+	#  i18n
+	rm -rf usr/share/i18n
+	#  yum cache
+	rm -rf var/cache/yum
+	mkdir -p --mode=0755 var/cache/yum
+	#  sln
+	rm -rf sbin/sln
+	#  ldconfig
+	#rm -rf sbin/ldconfig
+	rm -rf etc/ld.so.cache var/cache/ldconfig
+	mkdir -p --mode=0755 var/cache/ldconfig
+)

--- a/contrib/mkimage/busybox-static
+++ b/contrib/mkimage/busybox-static
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+rootfsDir="$1"
+shift
+
+busybox="$(which busybox 2>/dev/null || true)"
+if [ -z "$busybox" ]; then
+	echo >&2 'error: busybox: not found'
+	echo >&2 '  install it with your distribution "busybox-static" package'
+	exit 1
+fi
+if ! ldd "$busybox" 2>&1 | grep -q 'not a dynamic executable'; then
+	echo >&2 "error: '$busybox' appears to be a dynamic executable"
+	echo >&2 '  you should install your distribution "busybox-static" package instead'
+	exit 1
+fi
+
+mkdir -p "$rootfsDir/bin"
+rm -f "$rootfsDir/bin/busybox" # just in case
+cp "$busybox" "$rootfsDir/bin/busybox"
+
+(
+	cd "$rootfsDir"
+
+	IFS=$'\n'
+	modules=( $(bin/busybox --list-modules) )
+	unset IFS
+
+	for module in "${modules[@]}"; do
+		mkdir -p "$(dirname "$module")"
+		ln -sf /bin/busybox "$module"
+	done
+)

--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -e
+
+rootfsDir="$1"
+shift
+
+# we have to do a little fancy footwork to make sure "rootfsDir" becomes the second non-option argument to debootstrap
+
+before=()
+while [ $# -gt 0 ] && [[ "$1" == -* ]]; do
+	before+=( "$1" )
+	shift
+done
+
+suite="$1"
+shift
+
+(
+	set -x
+	debootstrap "${before[@]}" "$suite" "$rootfsDir" "$@"
+)
+
+# now for some Docker-specific tweaks
+
+# prevent init scripts from running during install/update
+echo >&2 "+ cat > '$rootfsDir/usr/sbin/policy-rc.d'"
+cat > "$rootfsDir/usr/sbin/policy-rc.d" <<'EOF'
+#!/bin/sh
+exit 101
+EOF
+chmod +x "$rootfsDir/usr/sbin/policy-rc.d"
+
+# prevent upstart scripts from running during install/update
+(
+	set -x
+	chroot "$rootfsDir" dpkg-divert --local --rename --add /sbin/initctl
+	ln -sf /bin/true "$rootfsDir/sbin/initctl"
+)
+
+# shrink the image, since apt makes us fat (wheezy: ~157.5MB vs ~120MB)
+( set -x; chroot "$rootfsDir" apt-get clean )
+
+# Ubuntu 10.04 sucks... :)
+if strings "$rootfsDir/usr/bin/dpkg" | grep -q unsafe-io; then
+	# force dpkg not to call sync() after package extraction (speeding up installs)
+	echo >&2 "+ echo force-unsafe-io > '$rootfsDir/etc/dpkg/dpkg.cfg.d/docker-apt-speedup'"
+	echo 'force-unsafe-io' > "$rootfsDir/etc/dpkg/dpkg.cfg.d/docker-apt-speedup"
+fi
+
+if [ -d /etc/apt/apt.conf.d ]; then
+	# _keep_ us lean by effectively running "apt-get clean" after every install
+	aptGetClean='"rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin || true";'
+	echo >&2 "+ cat > '$rootfsDir/etc/apt/apt.conf.d/docker-clean'"
+	cat > "$rootfsDir/etc/apt/apt.conf.d/docker-clean" <<-EOF
+		DPkg::Post-Invoke { ${aptGetClean} };
+		APT::Update::Post-Invoke { ${aptGetClean} };
+
+		Dir::Cache::pkgcache "";
+		Dir::Cache::srcpkgcache "";
+	EOF
+
+	# remove apt-cache translations for fast "apt-get update"
+	echo >&2 "+ cat > '$rootfsDir/etc/apt/apt.conf.d/docker-no-languages'"
+	echo 'Acquire::Languages "none";' > "$rootfsDir/etc/apt/apt.conf.d/docker-no-languages"
+fi
+
+if [ -z "$DONT_TOUCH_SOURCES_LIST" ]; then
+	# tweak sources.list, where appropriate
+	lsbDist=
+	if [ -z "$lsbDist" -a -r "$rootfsDir/etc/os-release" ]; then
+		lsbDist="$(. "$rootfsDir/etc/os-release" && echo "$ID")"
+	fi
+	if [ -z "$lsbDist" -a -r "$rootfsDir/etc/lsb-release" ]; then
+		lsbDist="$(. "$rootfsDir/etc/lsb-release" && echo "$DISTRIB_ID")"
+	fi
+	if [ -z "$lsbDist" -a -r "$rootfsDir/etc/debian_version" ]; then
+		lsbDist='Debian'
+	fi
+	case "$lsbDist" in
+		debian|Debian)
+			# updates and security!
+			if [ "$suite" != 'sid' -a "$suite" != 'unstable' ]; then
+				(
+					set -x
+					sed -i "p; s/ $suite main$/ ${suite}-updates main/" "$rootfsDir/etc/apt/sources.list"
+					echo "deb http://security.debian.org $suite/updates main" >> "$rootfsDir/etc/apt/sources.list"
+				)
+			fi
+			;;
+		ubuntu|Ubuntu)
+			# add the universe, updates, and security repositories
+			(
+				set -x
+				sed -i "
+					s/ $suite main$/ $suite main universe/; p;
+					s/ $suite main/ ${suite}-updates main/; p;
+					s/ $suite-updates main/ ${suite}-security main/
+				" "$rootfsDir/etc/apt/sources.list"
+			)
+			;;
+		tanglu|Tanglu)
+			# add the updates repository
+			if [ "$suite" != 'devel' ]; then
+				(
+					set -x
+					sed -i "p; s/ $suite main$/ ${suite}-updates main/" "$rootfsDir/etc/apt/sources.list"
+				)
+			fi
+			;;
+		steamos|SteamOS)
+			# add contrib and non-free
+			(
+				set -x
+				sed -i "s/ $suite main$/ $suite main contrib non-free/" "$rootfsDir/etc/apt/sources.list"
+			)
+			;;
+	esac
+fi
+
+# make sure we're fully up-to-date, too
+(
+	set -x
+	chroot "$rootfsDir" apt-get update
+	chroot "$rootfsDir" apt-get dist-upgrade -y
+)

--- a/contrib/mkimage/rinse
+++ b/contrib/mkimage/rinse
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+rootfsDir="$1"
+shift
+
+# specifying --arch below is safe because "$@" can override it and the "latest" one wins :)
+
+(
+	set -x
+	rinse --directory "$rootfsDir" --arch amd64 "$@"
+)
+
+"$(dirname "$BASH_SOURCE")/.febootstrap-minimize" "$rootfsDir"
+
+if [ -d "$rootfsDir/etc/sysconfig" ]; then
+	# allow networking init scripts inside the container to work without extra steps
+	echo 'NETWORKING=yes' > "$rootfsDir/etc/sysconfig/network"
+fi
+
+# make sure we're fully up-to-date, too
+(
+	set -x
+	chroot "$rootfsDir" yum update -y
+)


### PR DESCRIPTION
These new scripts are streamlined such that, for example, "contrib/mkimage/debootstrap" is _only_ responsible for filling a directory with the results of running debootstrap, and it can accept any arbitrary arguments.  This gives us a nice clean separation of concerns, makes these scripts trivially easy to write, and allows them to accept any arbitrary arguments (like "before-post-install" as a rinse argument, for example).

Fixes #2442
Fixes #4496
Closes #4807
