### PR TITLE
Move get pid into cgroup implementation

### DIFF
--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -7,14 +7,14 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 
 	"github.com/dotcloud/docker/daemon/execdriver"
 	"github.com/dotcloud/docker/pkg/apparmor"
 	"github.com/dotcloud/docker/pkg/libcontainer"
-	"github.com/dotcloud/docker/pkg/libcontainer/cgroups"
+	"github.com/dotcloud/docker/pkg/libcontainer/cgroups/fs"
+	"github.com/dotcloud/docker/pkg/libcontainer/cgroups/systemd"
 	"github.com/dotcloud/docker/pkg/libcontainer/nsinit"
 	"github.com/dotcloud/docker/pkg/system"
 )
@@ -53,24 +53,31 @@ func init() {
 	})
 }
 
+type activeContainer struct {
+	container *libcontainer.Container
+	cmd       *exec.Cmd
+}
+
 type driver struct {
 	root             string
 	initPath         string
-	activeContainers map[string]*exec.Cmd
+	activeContainers map[string]*activeContainer
 }
 
 func NewDriver(root, initPath string) (*driver, error) {
 	if err := os.MkdirAll(root, 0700); err != nil {
 		return nil, err
 	}
+
 	// native driver root is at docker_root/execdriver/native. Put apparmor at docker_root
 	if err := apparmor.InstallDefaultProfile(filepath.Join(root, "../..", BackupApparmorProfilePath)); err != nil {
 		return nil, err
 	}
+
 	return &driver{
 		root:             root,
 		initPath:         initPath,
-		activeContainers: make(map[string]*exec.Cmd),
+		activeContainers: make(map[string]*activeContainer),
 	}, nil
 }
 
@@ -80,7 +87,10 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 	if err != nil {
 		return -1, err
 	}
-	d.activeContainers[c.ID] = &c.Cmd
+	d.activeContainers[c.ID] = &activeContainer{
+		container: container,
+		cmd:       &c.Cmd,
+	}
 
 	var (
 		dataPath = filepath.Join(d.root, c.ID)
@@ -175,41 +185,18 @@ func (d *driver) Name() string {
 	return fmt.Sprintf("%s-%s", DriverName, Version)
 }
 
-// TODO: this can be improved with our driver
-// there has to be a better way to do this
 func (d *driver) GetPidsForContainer(id string) ([]int, error) {
-	pids := []int{}
+	active := d.activeContainers[id]
 
-	subsystem := "devices"
-	cgroupRoot, err := cgroups.FindCgroupMountpoint(subsystem)
-	if err != nil {
-		return pids, err
+	if active == nil {
+		return nil, fmt.Errorf("active container for %s does not exist", id)
 	}
-	cgroupDir, err := cgroups.GetThisCgroupDir(subsystem)
-	if err != nil {
-		return pids, err
-	}
+	c := active.container.Cgroups
 
-	filename := filepath.Join(cgroupRoot, cgroupDir, id, "tasks")
-	if _, err := os.Stat(filename); os.IsNotExist(err) {
-		filename = filepath.Join(cgroupRoot, cgroupDir, "docker", id, "tasks")
+	if systemd.UseSystemd() {
+		return systemd.GetPids(c)
 	}
-
-	output, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return pids, err
-	}
-	for _, p := range strings.Split(string(output), "\n") {
-		if len(p) == 0 {
-			continue
-		}
-		pid, err := strconv.Atoi(p)
-		if err != nil {
-			return pids, fmt.Errorf("Invalid pid '%s': %s", p, err)
-		}
-		pids = append(pids, pid)
-	}
-	return pids, nil
+	return fs.GetPids(c)
 }
 
 func (d *driver) writeContainerFile(container *libcontainer.Container, id string) error {
@@ -225,6 +212,8 @@ func (d *driver) createContainerRoot(id string) error {
 }
 
 func (d *driver) removeContainerRoot(id string) error {
+	delete(d.activeContainers, id)
+
 	return os.RemoveAll(filepath.Join(d.root, id))
 }
 

--- a/pkg/libcontainer/cgroups/fs/devices.go
+++ b/pkg/libcontainer/cgroups/fs/devices.go
@@ -1,9 +1,5 @@
 package fs
 
-import (
-	"os"
-)
-
 type devicesGroup struct {
 }
 
@@ -12,11 +8,6 @@ func (s *devicesGroup) Set(d *data) error {
 	if err != nil {
 		return err
 	}
-	defer func() {
-		if err != nil {
-			os.RemoveAll(dir)
-		}
-	}()
 
 	if !d.c.DeviceAccess {
 		if err := writeFile(dir, "devices.deny", "a"); err != nil {

--- a/pkg/libcontainer/cgroups/systemd/apply_nosystemd.go
+++ b/pkg/libcontainer/cgroups/systemd/apply_nosystemd.go
@@ -12,6 +12,10 @@ func UseSystemd() bool {
 	return false
 }
 
-func Apply(c *Cgroup, pid int) (cgroups.ActiveCgroup, error) {
+func Apply(c *cgroups.Cgroup, pid int) (cgroups.ActiveCgroup, error) {
+	return nil, fmt.Errorf("Systemd not supported")
+}
+
+func GetPids(c *cgroups.Cgroup) ([]int, error) {
 	return nil, fmt.Errorf("Systemd not supported")
 }

--- a/pkg/libcontainer/cgroups/utils.go
+++ b/pkg/libcontainer/cgroups/utils.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"io"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/dotcloud/docker/pkg/mount"
@@ -47,6 +49,30 @@ func GetInitCgroupDir(subsystem string) (string, error) {
 	defer f.Close()
 
 	return parseCgroupFile(subsystem, f)
+}
+
+func ReadProcsFile(dir string) ([]int, error) {
+	f, err := os.Open(filepath.Join(dir, "cgroup.procs"))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var (
+		s   = bufio.NewScanner(f)
+		out = []int{}
+	)
+
+	for s.Scan() {
+		if t := s.Text(); t != "" {
+			pid, err := strconv.Atoi(t)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, pid)
+		}
+	}
+	return out, nil
 }
 
 func parseCgroupFile(subsystem string, r io.Reader) (string, error) {


### PR DESCRIPTION
This PR moves the logic to get the pids from the cgroup system into the cgroup implementations for systemd and raw filesystem.  

Tested on both raw filesystem and a systemd system with privileged and unprivileged containers. 

Closes #5964
Fixes #5666

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
