### PR TITLE
This check was backwards.

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -76,7 +76,7 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, proto, addr string, tlsC
 	}
 
 	if in != nil {
-		if file, ok := in.(*os.File); ok {
+		if file, ok := out.(*os.File); ok {
 			terminalFd = file.Fd()
 			isTerminal = term.IsTerminal(terminalFd)
 		}


### PR DESCRIPTION
If I do a

docker events  > /tmp/out

I do not want the control characters getting written to the file.
The check should check the output file not the input file.

 Docker-DCO-1.1-Signed-off-by: Daniel Walsh dwalsh@redhat.com (github: rhatdan)
