### PR TITLE
New implementation of /run support

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -197,6 +197,7 @@ func populateCommand(c *Container, env []string) error {
 	c.command = &execdriver.Command{
 		ID:                 c.ID,
 		Privileged:         c.hostConfig.Privileged,
+		RunFs:              !c.hostConfig.NoRunFs,
 		Rootfs:             c.RootfsPath(),
 		InitPath:           "/.dockerinit",
 		Entrypoint:         c.Path,

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -138,6 +138,7 @@ type Command struct {
 	Config             map[string][]string `json:"config"` //  generic values that specific drivers can consume
 	Resources          *Resources          `json:"resources"`
 	Mounts             []Mount             `json:"mounts"`
+	RunFs              bool                `json:"runfs"`
 	AllowedDevices     []*devices.Device   `json:"allowed_devices"`
 	AutoCreatedDevices []*devices.Device   `json:"autocreated_devices"`
 

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -39,6 +39,14 @@ func (d *driver) createContainer(c *execdriver.Command) (*libcontainer.Container
 			return nil, err
 		}
 	}
+	if c.RunFs {
+		// Prepend to allow other mounts under /run
+		container.Mounts = append([]libcontainer.Mount{{
+			Type:        "tmpfs",
+			Destination: "/run",
+			CopyContent: true,
+		}}, container.Mounts...)
+	}
 	if err := d.setupCgroups(container, c); err != nil {
 		return nil, err
 	}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -257,6 +257,7 @@ func SetupInitLayer(initLayer string) error {
 		"/dev/pts":         "dir",
 		"/dev/shm":         "dir",
 		"/proc":            "dir",
+		"/run":             "dir",
 		"/sys":             "dir",
 		"/.dockerinit":     "file",
 		"/.dockerenv":      "file",

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -31,6 +31,7 @@ type HostConfig struct {
 	DnsSearch       []string
 	VolumesFrom     []string
 	NetworkMode     NetworkMode
+	NoRunFs         bool
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {

--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -662,6 +662,9 @@ func (b *buildFile) create() (*daemon.Container, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	c.SetHostConfig(&runconfig.HostConfig{NoRunFs: true})
+
 	b.tmpContainers[c.ID] = struct{}{}
 	fmt.Fprintf(b.outStream, " ---> Running in %s\n", utils.TruncateID(c.ID))
 


### PR DESCRIPTION
This mounts a /run tmpfs into the container, with the initial contents
copies from the /run in the base image, unless NoRunFs is set in the
HostConfig.

Additionally NoRunFs is always set during a docker build, which means
any setup of /run in a Dockerfile is saved in the image to be copied
into the final /run tmpfs when a container is started.
