### PR TITLE
docker exe on Ubuntu is docker.io

### DIFF
--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -39,7 +39,7 @@ To install the latest Ubuntu package (may not be the latest Docker release):
 
 To verify that everything has worked as expected:
 
-    $ sudo docker run -i -t ubuntu /bin/bash
+    $ sudo docker.io run -i -t ubuntu /bin/bash
 
 Which should download the `ubuntu` image, and then start `bash` in a container.
 


### PR DESCRIPTION
I just installed docker on Ubuntu Trusty Server and the docker exe does not exists, it was renamed to docker.io
