### PR TITLE
Make all cgroup stats output int64s instead of float64.

### DIFF
--- a/pkg/libcontainer/cgroups/fs/apply_raw.go
+++ b/pkg/libcontainer/cgroups/fs/apply_raw.go
@@ -26,7 +26,7 @@ var (
 type subsystem interface {
 	Set(*data) error
 	Remove(*data) error
-	Stats(*data) (map[string]float64, error)
+	Stats(*data) (map[string]int64, error)
 }
 
 type data struct {
@@ -74,7 +74,7 @@ func Apply(c *cgroups.Cgroup, pid int) (cgroups.ActiveCgroup, error) {
 	return d, nil
 }
 
-func GetStats(c *cgroups.Cgroup, subsystem string, pid int) (map[string]float64, error) {
+func GetStats(c *cgroups.Cgroup, subsystem string, pid int) (map[string]int64, error) {
 	cgroupRoot, err := cgroups.FindCgroupMountpoint("cpu")
 	if err != nil {
 		return nil, err

--- a/pkg/libcontainer/cgroups/fs/blkio.go
+++ b/pkg/libcontainer/cgroups/fs/blkio.go
@@ -57,9 +57,9 @@ examples:
     8:0 Total 0
     Total 0
 */
-func (s *blkioGroup) Stats(d *data) (map[string]float64, error) {
+func (s *blkioGroup) Stats(d *data) (map[string]int64, error) {
 	var (
-		paramData = make(map[string]float64)
+		paramData = make(map[string]int64)
 		params    = []string{
 			"io_service_bytes_recursive",
 			"io_serviced_recursive",
@@ -91,7 +91,7 @@ func (s *blkioGroup) Stats(d *data) (map[string]float64, error) {
 			fields := strings.Fields(sc.Text())
 			switch len(fields) {
 			case 3:
-				v, err := strconv.ParseFloat(fields[2], 64)
+				v, err := strconv.ParseInt(fields[2], 10, 64)
 				if err != nil {
 					return nil, err
 				}
@@ -106,7 +106,7 @@ func (s *blkioGroup) Stats(d *data) (map[string]float64, error) {
 	return paramData, nil
 }
 
-func (s *blkioGroup) getSectors(path string) (string, float64, error) {
+func (s *blkioGroup) getSectors(path string) (string, int64, error) {
 	f, err := os.Open(filepath.Join(path, "blkio.sectors_recursive"))
 	if err != nil {
 		return "", 0, err

--- a/pkg/libcontainer/cgroups/fs/blkio_test.go
+++ b/pkg/libcontainer/cgroups/fs/blkio_test.go
@@ -43,29 +43,29 @@ func TestBlkioStats(t *testing.T) {
 	}
 
 	// Verify expected stats.
-	expectedStats := map[string]float64{
-		"blkio.sectors_recursive:8:0": 1024.0,
+	expectedStats := map[string]int64{
+		"blkio.sectors_recursive:8:0": 1024,
 
 		// Serviced bytes.
-		"io_service_bytes_recursive:8:0:Read":  100.0,
-		"io_service_bytes_recursive:8:0:Write": 400.0,
-		"io_service_bytes_recursive:8:0:Sync":  200.0,
-		"io_service_bytes_recursive:8:0:Async": 300.0,
-		"io_service_bytes_recursive:8:0:Total": 500.0,
+		"io_service_bytes_recursive:8:0:Read":  100,
+		"io_service_bytes_recursive:8:0:Write": 400,
+		"io_service_bytes_recursive:8:0:Sync":  200,
+		"io_service_bytes_recursive:8:0:Async": 300,
+		"io_service_bytes_recursive:8:0:Total": 500,
 
 		// Serviced requests.
-		"io_serviced_recursive:8:0:Read":  10.0,
-		"io_serviced_recursive:8:0:Write": 40.0,
-		"io_serviced_recursive:8:0:Sync":  20.0,
-		"io_serviced_recursive:8:0:Async": 30.0,
-		"io_serviced_recursive:8:0:Total": 50.0,
+		"io_serviced_recursive:8:0:Read":  10,
+		"io_serviced_recursive:8:0:Write": 40,
+		"io_serviced_recursive:8:0:Sync":  20,
+		"io_serviced_recursive:8:0:Async": 30,
+		"io_serviced_recursive:8:0:Total": 50,
 
 		// Queued requests.
-		"io_queued_recursive:8:0:Read":  1.0,
-		"io_queued_recursive:8:0:Write": 4.0,
-		"io_queued_recursive:8:0:Sync":  2.0,
-		"io_queued_recursive:8:0:Async": 3.0,
-		"io_queued_recursive:8:0:Total": 5.0,
+		"io_queued_recursive:8:0:Read":  1,
+		"io_queued_recursive:8:0:Write": 4,
+		"io_queued_recursive:8:0:Sync":  2,
+		"io_queued_recursive:8:0:Async": 3,
+		"io_queued_recursive:8:0:Total": 5,
 	}
 	expectStats(t, expectedStats, stats)
 }

--- a/pkg/libcontainer/cgroups/fs/cpu.go
+++ b/pkg/libcontainer/cgroups/fs/cpu.go
@@ -39,8 +39,8 @@ func (s *cpuGroup) Remove(d *data) error {
 	return removePath(d.path("cpu"))
 }
 
-func (s *cpuGroup) Stats(d *data) (map[string]float64, error) {
-	paramData := make(map[string]float64)
+func (s *cpuGroup) Stats(d *data) (map[string]int64, error) {
+	paramData := make(map[string]int64)
 	path, err := d.path("cpu")
 	if err != nil {
 		return nil, err

--- a/pkg/libcontainer/cgroups/fs/cpu_test.go
+++ b/pkg/libcontainer/cgroups/fs/cpu_test.go
@@ -20,10 +20,10 @@ func TestCpuStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected_stats := map[string]float64{
-		"nr_periods":     2000.0,
-		"nr_throttled":   200.0,
-		"throttled_time": 42424242424.0,
+	expected_stats := map[string]int64{
+		"nr_periods":     2000,
+		"nr_throttled":   200,
+		"throttled_time": 42424242424,
 	}
 	expectStats(t, expected_stats, stats)
 }

--- a/pkg/libcontainer/cgroups/fs/cpuset.go
+++ b/pkg/libcontainer/cgroups/fs/cpuset.go
@@ -38,7 +38,7 @@ func (s *cpusetGroup) Remove(d *data) error {
 	return removePath(d.path("cpuset"))
 }
 
-func (s *cpusetGroup) Stats(d *data) (map[string]float64, error) {
+func (s *cpusetGroup) Stats(d *data) (map[string]int64, error) {
 	return nil, ErrNotSupportStat
 }
 

--- a/pkg/libcontainer/cgroups/fs/devices.go
+++ b/pkg/libcontainer/cgroups/fs/devices.go
@@ -55,6 +55,6 @@ func (s *devicesGroup) Remove(d *data) error {
 	return removePath(d.path("devices"))
 }
 
-func (s *devicesGroup) Stats(d *data) (map[string]float64, error) {
+func (s *devicesGroup) Stats(d *data) (map[string]int64, error) {
 	return nil, ErrNotSupportStat
 }

--- a/pkg/libcontainer/cgroups/fs/freezer.go
+++ b/pkg/libcontainer/cgroups/fs/freezer.go
@@ -35,9 +35,9 @@ func (s *freezerGroup) Remove(d *data) error {
 	return removePath(d.path("freezer"))
 }
 
-func (s *freezerGroup) Stats(d *data) (map[string]float64, error) {
+func (s *freezerGroup) Stats(d *data) (map[string]int64, error) {
 	var (
-		paramData = make(map[string]float64)
+		paramData = make(map[string]int64)
 		params    = []string{
 			"parent_freezing",
 			"self_freezing",
@@ -50,6 +50,7 @@ func (s *freezerGroup) Stats(d *data) (map[string]float64, error) {
 		return nil, err
 	}
 
+	// TODO(vmarmol): This currently outputs nothing since the output is a string, fix.
 	for _, param := range params {
 		f, err := os.Open(filepath.Join(path, fmt.Sprintf("freezer.%s", param)))
 		if err != nil {
@@ -62,7 +63,7 @@ func (s *freezerGroup) Stats(d *data) (map[string]float64, error) {
 			return nil, err
 		}
 
-		v, err := strconv.ParseFloat(strings.TrimSuffix(string(data), "\n"), 64)
+		v, err := strconv.ParseInt(strings.TrimSuffix(string(data), "\n"), 10, 64)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/libcontainer/cgroups/fs/memory.go
+++ b/pkg/libcontainer/cgroups/fs/memory.go
@@ -50,8 +50,8 @@ func (s *memoryGroup) Remove(d *data) error {
 	return removePath(d.path("memory"))
 }
 
-func (s *memoryGroup) Stats(d *data) (map[string]float64, error) {
-	paramData := make(map[string]float64)
+func (s *memoryGroup) Stats(d *data) (map[string]int64, error) {
+	paramData := make(map[string]int64)
 	path, err := d.path("memory")
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (s *memoryGroup) Stats(d *data) (map[string]float64, error) {
 		"max_usage_in_bytes",
 	}
 	for _, param := range params {
-		value, err := getCgroupParamFloat64(path, fmt.Sprintf("memory.%s", param))
+		value, err := getCgroupParamInt(path, fmt.Sprintf("memory.%s", param))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/libcontainer/cgroups/fs/memory_test.go
+++ b/pkg/libcontainer/cgroups/fs/memory_test.go
@@ -25,7 +25,7 @@ func TestMemoryStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedStats := map[string]float64{"cache": 512.0, "rss": 1024.0, "usage_in_bytes": 2048.0, "max_usage_in_bytes": 4096.0}
+	expectedStats := map[string]int64{"cache": 512, "rss": 1024, "usage_in_bytes": 2048, "max_usage_in_bytes": 4096}
 	expectStats(t, expectedStats, stats)
 }
 

--- a/pkg/libcontainer/cgroups/fs/perf_event.go
+++ b/pkg/libcontainer/cgroups/fs/perf_event.go
@@ -19,6 +19,6 @@ func (s *perfEventGroup) Remove(d *data) error {
 	return removePath(d.path("perf_event"))
 }
 
-func (s *perfEventGroup) Stats(d *data) (map[string]float64, error) {
+func (s *perfEventGroup) Stats(d *data) (map[string]int64, error) {
 	return nil, ErrNotSupportStat
 }

--- a/pkg/libcontainer/cgroups/fs/test_util.go
+++ b/pkg/libcontainer/cgroups/fs/test_util.go
@@ -61,7 +61,7 @@ func (c *cgroupTestUtil) writeFileContents(fileContents map[string]string) {
 }
 
 // Expect the specified stats.
-func expectStats(t *testing.T, expected, actual map[string]float64) {
+func expectStats(t *testing.T, expected, actual map[string]int64) {
 	for stat, expectedValue := range expected {
 		actualValue, ok := actual[stat]
 		if !ok {

--- a/pkg/libcontainer/cgroups/fs/utils.go
+++ b/pkg/libcontainer/cgroups/fs/utils.go
@@ -16,25 +16,25 @@ var (
 
 // Parses a cgroup param and returns as name, value
 //  i.e. "io_service_bytes 1234" will return as io_service_bytes, 1234
-func getCgroupParamKeyValue(t string) (string, float64, error) {
+func getCgroupParamKeyValue(t string) (string, int64, error) {
 	parts := strings.Fields(t)
 	switch len(parts) {
 	case 2:
-		value, err := strconv.ParseFloat(parts[1], 64)
+		value, err := strconv.ParseInt(parts[1], 10, 64)
 		if err != nil {
-			return "", 0.0, fmt.Errorf("Unable to convert param value to float: %s", err)
+			return "", 0, fmt.Errorf("Unable to convert param value to int: %s", err)
 		}
 		return parts[0], value, nil
 	default:
-		return "", 0.0, ErrNotValidFormat
+		return "", 0, ErrNotValidFormat
 	}
 }
 
-// Gets a single float64 value from the specified cgroup file.
-func getCgroupParamFloat64(cgroupPath, cgroupFile string) (float64, error) {
+// Gets a single int64 value from the specified cgroup file.
+func getCgroupParamInt(cgroupPath, cgroupFile string) (int64, error) {
 	contents, err := ioutil.ReadFile(filepath.Join(cgroupPath, cgroupFile))
 	if err != nil {
-		return -1.0, err
+		return -1, err
 	}
-	return strconv.ParseFloat(strings.TrimSpace(string(contents)), 64)
+	return strconv.ParseInt(strings.TrimSpace(string(contents)), 10, 64)
 }

--- a/pkg/libcontainer/cgroups/fs/utils_test.go
+++ b/pkg/libcontainer/cgroups/fs/utils_test.go
@@ -13,7 +13,7 @@ const (
 	floatString = "2048"
 )
 
-func TestGetCgroupParamsFloat64(t *testing.T) {
+func TestGetCgroupParamsInt(t *testing.T) {
 	// Setup tempdir.
 	tempDir, err := ioutil.TempDir("", "cgroup_utils_test")
 	if err != nil {
@@ -27,7 +27,7 @@ func TestGetCgroupParamsFloat64(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	value, err := getCgroupParamFloat64(tempDir, cgroupFile)
+	value, err := getCgroupParamInt(tempDir, cgroupFile)
 	if err != nil {
 		t.Fatal(err)
 	} else if value != floatValue {
@@ -39,7 +39,7 @@ func TestGetCgroupParamsFloat64(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	value, err = getCgroupParamFloat64(tempDir, cgroupFile)
+	value, err = getCgroupParamInt(tempDir, cgroupFile)
 	if err != nil {
 		t.Fatal(err)
 	} else if value != floatValue {
@@ -51,7 +51,7 @@ func TestGetCgroupParamsFloat64(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = getCgroupParamFloat64(tempDir, cgroupFile)
+	_, err = getCgroupParamInt(tempDir, cgroupFile)
 	if err == nil {
 		t.Fatal("Expecting error, got none")
 	}
@@ -61,7 +61,7 @@ func TestGetCgroupParamsFloat64(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = getCgroupParamFloat64(tempDir, cgroupFile)
+	_, err = getCgroupParamInt(tempDir, cgroupFile)
 	if err == nil {
 		t.Fatal("Expecting error, got none")
 	}


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Victor Marmol vmarmol@google.com (github: vmarmol)
