### PR TITLE
We need to umount /var/lib/docker when the daemon exits.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -900,6 +900,10 @@ func (daemon *Daemon) Close() error {
 		utils.Errorf("daemon.containerGraph.Close(): %s", err.Error())
 		errorsStrings = append(errorsStrings, err.Error())
 	}
+	if err := mount.Unmount(daemon.config.Root); err != nil {
+		utils.Errorf("daemon.Umount(%s): %s", daemon.config.Root, err.Error())
+		errorsStrings = append(errorsStrings, err.Error())
+	}
 	if len(errorsStrings) > 0 {
 		return fmt.Errorf("%s", strings.Join(errorsStrings, ", "))
 	}


### PR DESCRIPTION
Currently we are leaving it bind mounted on stop.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
