### PR TITLE
Expose PID of running containers in /containers/json remote API

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,7 @@ Alexis THOMAS <fr.alexisthomas@gmail.com>
 almoehi <almoehi@users.noreply.github.com>
 Al Tobey <al@ooyala.com>
 amangoel <amangoel@gmail.com>
+Amir Malik <amir@amirmalik.net>
 Andrea Luzzardi <aluzzardi@gmail.com>
 Andreas Savvides <andreas@editd.com>
 Andreas Tiefenthaler <at@an-ti.eu>

--- a/docs/sources/reference/api/docker_remote_api_v1.12.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.12.md
@@ -67,9 +67,10 @@ List containers
              {
                      "Id": "4cb07b47f9fb",
                      "Image": "base:latest",
-                     "Command": "echo 444444444444444444444444444444444",
+                     "Command": "sleep 1337",
                      "Created": 1367854152,
-                     "Status": "Exit 0",
+                     "Status": "Up 10 seconds",
+                     "Pid":6667,
                      "Ports":[],
                      "SizeRw":12288,
                      "SizeRootFs":0

--- a/server/server.go
+++ b/server/server.go
@@ -1008,6 +1008,9 @@ func (srv *Server) Containers(job *engine.Job) engine.Status {
 		}
 		out.SetInt64("Created", container.Created.Unix())
 		out.Set("Status", container.State.String())
+		if container.State.IsRunning() {
+			out.SetInt("Pid", container.State.Pid)
+		}
 		str, err := container.NetworkSettings.PortMappingAPI().ToListString()
 		if err != nil {
 			return job.Error(err)


### PR DESCRIPTION
this change is useful for third-party tools that need to know the PIDs of running containers without resorting to inspecting every one :)
