### PR TITLE
Improve name generation on concurrent requests

### DIFF
--- a/daemon/utils.go
+++ b/daemon/utils.go
@@ -2,10 +2,10 @@ package daemon
 
 import (
 	"fmt"
-	"github.com/dotcloud/docker/nat"
-	"github.com/dotcloud/docker/pkg/namesgenerator"
-	"github.com/dotcloud/docker/runconfig"
 	"strings"
+
+	"github.com/dotcloud/docker/nat"
+	"github.com/dotcloud/docker/runconfig"
 )
 
 func migratePortMappings(config *runconfig.Config, hostConfig *runconfig.HostConfig) error {
@@ -48,17 +48,4 @@ func mergeLxcConfIntoOptions(hostConfig *runconfig.HostConfig, driverConfig map[
 		}
 		driverConfig["lxc"] = lxc
 	}
-}
-
-type checker struct {
-	daemon *Daemon
-}
-
-func (c *checker) Exists(name string) bool {
-	return c.daemon.containerGraph.Exists("/" + name)
-}
-
-// Generate a random and unique name
-func generateRandomName(daemon *Daemon) (string, error) {
-	return namesgenerator.GenerateRandomName(&checker{daemon})
 }

--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -6,10 +6,6 @@ import (
 	"time"
 )
 
-type NameChecker interface {
-	Exists(name string) bool
-}
-
 var (
 	left = [...]string{"happy", "jolly", "dreamy", "sad", "angry", "pensive", "focused", "sleepy", "grave", "distracted", "determined", "stoic", "stupefied", "sharp", "agitated", "cocky", "tender", "goofy", "furious", "desperate", "hopeful", "compassionate", "silly", "lonely", "condescending", "naughty", "kickass", "drunk", "boring", "nostalgic", "ecstatic", "insane", "cranky", "mad", "jovial", "sick", "hungry", "thirsty", "elegant", "backstabbing", "clever", "trusting", "loving", "suspicious", "berserk", "high", "romantic", "prickly", "evil"}
 	// Docker 0.7.x generates names from notable scientists and hackers.
@@ -79,16 +75,17 @@ var (
 	right = [...]string{"lovelace", "franklin", "tesla", "einstein", "bohr", "davinci", "pasteur", "nobel", "curie", "darwin", "turing", "ritchie", "torvalds", "pike", "thompson", "wozniak", "galileo", "euclid", "newton", "fermat", "archimedes", "poincare", "heisenberg", "feynman", "hawking", "fermi", "pare", "mccarthy", "engelbart", "babbage", "albattani", "ptolemy", "bell", "wright", "lumiere", "morse", "mclean", "brown", "bardeen", "brattain", "shockley", "goldstine", "hoover", "hopper", "bartik", "sammet", "jones", "perlman", "wilson", "kowalevski", "hypatia", "goodall", "mayer", "elion", "blackwell", "lalande", "kirch", "ardinghelli", "colden", "almeida", "leakey", "meitner", "mestorf", "rosalind", "sinoussi", "carson", "mcclintock", "yonath"}
 )
 
-func GenerateRandomName(checker NameChecker) (string, error) {
-	retry := 5
+func GetRandomName(retry int) string {
 	rand.Seed(time.Now().UnixNano())
+
+begin:
 	name := fmt.Sprintf("%s_%s", left[rand.Intn(len(left))], right[rand.Intn(len(right))])
-	for checker != nil && checker.Exists(name) && retry > 0 || name == "boring_wozniak" /* Steve Wozniak is not boring */ {
+	if name == "boring_wozniak" /* Steve Wozniak is not boring */ {
+		goto begin
+	}
+
+	if retry > 0 {
 		name = fmt.Sprintf("%s%d", name, rand.Intn(10))
-		retry = retry - 1
 	}
-	if retry == 0 {
-		return name, fmt.Errorf("Error generating random name")
-	}
-	return name, nil
+	return name
 }

--- a/pkg/namesgenerator/names-generator_test.go
+++ b/pkg/namesgenerator/names-generator_test.go
@@ -4,35 +4,9 @@ import (
 	"testing"
 )
 
-type FalseChecker struct{}
-
-func (n *FalseChecker) Exists(name string) bool {
-	return false
-}
-
-type TrueChecker struct{}
-
-func (n *TrueChecker) Exists(name string) bool {
-	return true
-}
-
-func TestGenerateRandomName(t *testing.T) {
-	if _, err := GenerateRandomName(&FalseChecker{}); err != nil {
-		t.Error(err)
-	}
-
-	if _, err := GenerateRandomName(&TrueChecker{}); err == nil {
-		t.Error("An error was expected")
-	}
-
-}
-
 // Make sure the generated names are awesome
 func TestGenerateAwesomeNames(t *testing.T) {
-	name, err := GenerateRandomName(&FalseChecker{})
-	if err != nil {
-		t.Error(err)
-	}
+	name := GetRandomName(0)
 	if !isAwesome(name) {
 		t.Fatalf("Generated name '%s' is not awesome.", name)
 	}


### PR DESCRIPTION
Fixes #2586

This fixes a few races where the name generator asks if a name is free
but another container takes the name before it can be reserved.  This
solves this by generating the name and setting it.  If the set fails
with a non unique error then we try again.
Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
