### PR TITLE
Ensure networking is up before starting docker

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -1,6 +1,6 @@
 description "Docker daemon"
 
-start on local-filesystems
+start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 limit nofile 524288 1048576
 limit nproc 524288 1048576


### PR DESCRIPTION
This resolves a problem that I have been having where docker starts before networking is up. See issue #5944 for more details.
