### PR TITLE
Add Wait() calls in the appropriate spots

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -584,6 +584,7 @@ func (container *Container) Stop(seconds int) error {
 		log.Printf("Container %v failed to exit within %d seconds of SIGTERM - using the force", container.ID, seconds)
 		// 3. If it doesn't, then send SIGKILL
 		if err := container.Kill(); err != nil {
+			container.Wait()
 			return err
 		}
 	}

--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -181,6 +181,7 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 	if err != nil {
 		if c.Process != nil {
 			c.Process.Kill()
+			c.Process.Wait()
 		}
 		return -1, err
 	}

--- a/pkg/libcontainer/nsinit/exec.go
+++ b/pkg/libcontainer/nsinit/exec.go
@@ -40,7 +40,9 @@ func Exec(container *libcontainer.Container, term Terminal, rootfs, dataPath str
 	}
 
 	command := createCommand(container, console, rootfs, dataPath, os.Args[0], syncPipe.child, args)
+
 	if err := term.Attach(command); err != nil {
+		command.Wait()
 		return -1, err
 	}
 	defer term.Close()
@@ -55,6 +57,7 @@ func Exec(container *libcontainer.Container, term Terminal, rootfs, dataPath str
 	}
 	if err := WritePid(dataPath, command.Process.Pid, started); err != nil {
 		command.Process.Kill()
+		command.Process.Wait()
 		return -1, err
 	}
 	defer DeletePid(dataPath)
@@ -64,6 +67,7 @@ func Exec(container *libcontainer.Container, term Terminal, rootfs, dataPath str
 	cleaner, err := SetupCgroups(container, command.Process.Pid)
 	if err != nil {
 		command.Process.Kill()
+		command.Process.Wait()
 		return -1, err
 	}
 	if cleaner != nil {
@@ -72,6 +76,7 @@ func Exec(container *libcontainer.Container, term Terminal, rootfs, dataPath str
 
 	if err := InitializeNetworking(container, command.Process.Pid, syncPipe); err != nil {
 		command.Process.Kill()
+		command.Process.Wait()
 		return -1, err
 	}
 

--- a/pkg/libcontainer/nsinit/exec.go
+++ b/pkg/libcontainer/nsinit/exec.go
@@ -42,7 +42,6 @@ func Exec(container *libcontainer.Container, term Terminal, rootfs, dataPath str
 	command := createCommand(container, console, rootfs, dataPath, os.Args[0], syncPipe.child, args)
 
 	if err := term.Attach(command); err != nil {
-		command.Wait()
 		return -1, err
 	}
 	defer term.Close()

--- a/pkg/libcontainer/nsinit/init.go
+++ b/pkg/libcontainer/nsinit/init.go
@@ -126,7 +126,9 @@ func RestoreParentDeathSignal(old int) error {
 	// Signal self if parent is already dead. Does nothing if running in a new
 	// PID namespace, as Getppid will always return 0.
 	if syscall.Getppid() == 1 {
-		return syscall.Kill(syscall.Getpid(), syscall.Signal(old))
+		err := syscall.Kill(syscall.Getpid(), syscall.Signal(old))
+		syscall.Wait4(syscall.Getpid(), nil, 0, nil)
+		return err
 	}
 
 	return nil

--- a/pkg/libcontainer/nsinit/tty_term.go
+++ b/pkg/libcontainer/nsinit/tty_term.go
@@ -28,10 +28,11 @@ func (t *TtyTerminal) Attach(command *exec.Cmd) error {
 	go io.Copy(t.master, t.stdin)
 
 	state, err := t.setupWindow(t.master, os.Stdin)
+
 	if err != nil {
-		command.Process.Kill()
 		return err
 	}
+
 	t.state = state
 	return err
 }


### PR DESCRIPTION
This adds Wait() (semantically appropriate versions) where appropriate.

**Note:** I cannot run the `buildfile_test.go` integrations test with passing results either with or without this patch. I spent a bit of time trying to diagnose that, but was unsuccessful at finding the cause. I will report a bug instead, but this patch should not be merged until someone can get the integrations to pass successfully.

Fixes #5971
