### PR TITLE
Use Timeout Conn wrapper to set read deadline for downloading layer

### DIFF
--- a/utils/timeoutconn.go
+++ b/utils/timeoutconn.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"net"
+	"time"
+)
+
+func NewTimeoutConn(conn net.Conn, timeout time.Duration) net.Conn {
+	return &TimeoutConn{conn, timeout}
+}
+
+// A net.Conn that sets a deadline for every Read or Write operation
+type TimeoutConn struct {
+	net.Conn
+	timeout time.Duration
+}
+
+func (c *TimeoutConn) Read(b []byte) (int, error) {
+	if c.timeout > 0 {
+		err := c.Conn.SetReadDeadline(time.Now().Add(c.timeout))
+		if err != nil {
+			return 0, err
+		}
+	}
+	return c.Conn.Read(b)
+}


### PR DESCRIPTION
#2461 is about CDN server side connection lost and #5848 fix that by resume downloading, but sometimes with client side unstable network (like public wifi), the docker server may be waiting this connection for long time, the Conn.Read(p) by default is blocking mode, I observed sometimes it doesn't timeout over 30 minutes, or may block for ever, the only way to recover from such scenario is to restart docker server which is bad.

This fixed first part of #6024, I believe this is different issue with #2461.

Docker-DCO-1.1-Signed-off-by: Derek crq@kernel.org (@crquan)
