### PR TITLE
Extract the .dockercfg code 

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/dotcloud/docker/config"
 	flag "github.com/dotcloud/docker/pkg/mflag"
 	"github.com/dotcloud/docker/pkg/term"
-	"github.com/dotcloud/docker/registry"
 )
 
 var funcMap = template.FuncMap{
@@ -57,7 +57,7 @@ func (cli *DockerCli) Subcmd(name, signature, description string) *flag.FlagSet 
 }
 
 func (cli *DockerCli) LoadConfigFile() (err error) {
-	cli.configFile, err = registry.LoadConfig(os.Getenv("HOME"))
+	cli.configFile, err = config.LoadConfig(os.Getenv("HOME"))
 	if err != nil {
 		fmt.Fprintf(cli.err, "WARNING: %s\n", err)
 	}
@@ -101,7 +101,7 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, proto, addr string, tlsC
 type DockerCli struct {
 	proto      string
 	addr       string
-	configFile *registry.ConfigFile
+	configFile *config.ConfigFile
 	in         io.ReadCloser
 	out        io.Writer
 	err        io.Writer

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/dotcloud/docker/api"
 	"github.com/dotcloud/docker/archive"
+	"github.com/dotcloud/docker/config"
 	"github.com/dotcloud/docker/dockerversion"
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/nat"
@@ -251,9 +252,9 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	}
 
 	cli.LoadConfigFile()
-	authconfig, ok := cli.configFile.Configs[serverAddress]
-	if !ok {
-		authconfig = registry.AuthConfig{}
+	authconfig, err := registry.GetAuth(cli.configFile, serverAddress)
+	if err != nil {
+		authconfig = &registry.AuthConfig{}
 	}
 
 	if username == "" {
@@ -293,12 +294,14 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	authconfig.Password = password
 	authconfig.Email = email
 	authconfig.ServerAddress = serverAddress
-	cli.configFile.Configs[serverAddress] = authconfig
+	err = registry.PutAuth(cli.configFile, serverAddress, authconfig)
+	authconfig, err = registry.GetAuth(cli.configFile, serverAddress)
 
-	stream, statusCode, err := cli.call("POST", "/auth", cli.configFile.Configs[serverAddress], false)
+	stream, statusCode, err := cli.call("POST", "/auth", authconfig, false)
 	if statusCode == 401 {
+		//SVEN: FIXME - either config.DeleteContig(serverAddress) or registry...
 		delete(cli.configFile.Configs, serverAddress)
-		registry.SaveConfig(cli.configFile)
+		config.SaveConfig(cli.configFile)
 		return err
 	}
 	if err != nil {
@@ -307,10 +310,10 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	var out2 engine.Env
 	err = out2.Decode(stream)
 	if err != nil {
-		cli.configFile, _ = registry.LoadConfig(os.Getenv("HOME"))
+		cli.configFile, _ = config.LoadConfig(os.Getenv("HOME"))
 		return err
 	}
-	registry.SaveConfig(cli.configFile)
+	config.SaveConfig(cli.configFile)
 	if out2.Get("Status") != "" {
 		fmt.Fprintf(cli.out, "%s\n", out2.Get("Status"))
 	}
@@ -443,7 +446,11 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 
 	if len(remoteInfo.GetList("IndexServerAddress")) != 0 {
 		cli.LoadConfigFile()
-		u := cli.configFile.Configs[remoteInfo.Get("IndexServerAddress")].Username
+		authconfig, err := registry.GetAuth(cli.configFile, remoteInfo.Get("IndexServerAddress"))
+		if err != nil {
+			return err
+		}
+		u := authconfig.Username
 		if len(u) > 0 {
 			fmt.Fprintf(cli.out, "Username: %v\n", u)
 			fmt.Fprintf(cli.out, "Registry: %v\n", remoteInfo.GetList("IndexServerAddress"))
@@ -1069,13 +1076,17 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 		return err
 	}
 	// Resolve the Auth config relevant for this server
-	authConfig := cli.configFile.ResolveAuthConfig(hostname)
+	authConfig := registry.ResolveAuthConfig(cli.configFile, hostname)
 	// If we're not using a custom registry, we know the restrictions
 	// applied to repository names and can warn the user in advance.
 	// Custom repositories can have different rules, and we must also
 	// allow pushing by image ID.
 	if len(strings.SplitN(name, "/", 2)) == 1 {
-		username := cli.configFile.Configs[registry.IndexServerAddress()].Username
+		authconfig, err := registry.GetAuth(cli.configFile, registry.IndexServerAddress())
+		if err != nil {
+			return err
+		}
+		username := authconfig.Username
 		if username == "" {
 			username = "<user>"
 		}
@@ -1104,7 +1115,7 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 			if err := cli.CmdLogin(hostname); err != nil {
 				return err
 			}
-			authConfig := cli.configFile.ResolveAuthConfig(hostname)
+			authConfig := registry.ResolveAuthConfig(cli.configFile, hostname)
 			return push(authConfig)
 		}
 		return err
@@ -1138,7 +1149,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 	cli.LoadConfigFile()
 
 	// Resolve the Auth config relevant for this server
-	authConfig := cli.configFile.ResolveAuthConfig(hostname)
+	authConfig := registry.ResolveAuthConfig(cli.configFile, hostname)
 	v := url.Values{}
 	v.Set("fromImage", remote)
 	v.Set("tag", *tag)
@@ -1163,7 +1174,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 			if err := cli.CmdLogin(hostname); err != nil {
 				return err
 			}
-			authConfig := cli.configFile.ResolveAuthConfig(hostname)
+			authConfig := registry.ResolveAuthConfig(cli.configFile, hostname)
 			return pull(authConfig)
 		}
 		return err
@@ -1942,7 +1953,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		cli.LoadConfigFile()
 
 		// Resolve the Auth config relevant for this server
-		authConfig := cli.configFile.ResolveAuthConfig(hostname)
+		authConfig := registry.ResolveAuthConfig(cli.configFile, hostname)
 		buf, err := json.Marshal(authConfig)
 		if err != nil {
 			return err

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -64,7 +64,7 @@ func (cli *DockerCli) call(method, path string, data interface{}, passAuthInfo b
 	if passAuthInfo {
 		cli.LoadConfigFile()
 		// Resolve the Auth config relevant for this server
-		authConfig := cli.configFile.ResolveAuthConfig(registry.IndexServerAddress())
+		authConfig := registry.ResolveAuthConfig(cli.configFile, registry.IndexServerAddress())
 		getHeaders := func(authConfig registry.AuthConfig) (map[string][]string, error) {
 			buf, err := json.Marshal(authConfig)
 			if err != nil {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -23,6 +23,7 @@ import (
 	"code.google.com/p/go.net/websocket"
 
 	"github.com/dotcloud/docker/api"
+	"github.com/dotcloud/docker/config"
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/pkg/listenbuffer"
 	"github.com/dotcloud/docker/pkg/systemd"
@@ -881,7 +882,7 @@ func postBuild(eng *engine.Engine, version version.Version, w http.ResponseWrite
 		authEncoded       = r.Header.Get("X-Registry-Auth")
 		authConfig        = &registry.AuthConfig{}
 		configFileEncoded = r.Header.Get("X-Registry-Config")
-		configFile        = &registry.ConfigFile{}
+		configFile        = &config.ConfigFile{}
 		job               = eng.Job("build")
 	)
 
@@ -903,7 +904,7 @@ func postBuild(eng *engine.Engine, version version.Version, w http.ResponseWrite
 		if err := json.NewDecoder(configFileJson).Decode(configFile); err != nil {
 			// for a pull it is not an error if no auth was given
 			// to increase compatibility with the existing api it is defaulting to be empty
-			configFile = &registry.ConfigFile{}
+			configFile = &config.ConfigFile{}
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+// Where we store the config file
+const CONFIGFILE = ".dockercfg"
+
+var (
+	ErrConfigFileMissing = errors.New("The Auth config file is missing")
+)
+
+type ConfigFile struct {
+	Configs  map[string]interface{}
+	rootPath string
+}
+
+func (config *ConfigFile) GetConfig(key string) (interface{}, error) {
+	if config == nil {
+		return nil, fmt.Errorf("config not initialised")
+	}
+	c, found := config.Configs[key]
+	if found {
+		return c, nil
+	} else {
+		return nil, fmt.Errorf("no config found for %s", key)
+	}
+}
+
+func (config *ConfigFile) PutConfig(key string, data interface{}) error {
+	if config == nil {
+		return fmt.Errorf("config not initialised")
+	}
+	config.Configs[key] = data
+	return SaveConfig(config)
+}
+
+// load up the auth config information and return values
+// FIXME: use the internal golang config parser
+func LoadConfig(rootPath string) (*ConfigFile, error) {
+	configFile := ConfigFile{Configs: make(map[string]interface{}), rootPath: rootPath}
+	confFile := path.Join(rootPath, CONFIGFILE)
+	if _, err := os.Stat(confFile); err != nil {
+		return &configFile, nil //missing file is not an error
+	}
+	b, err := ioutil.ReadFile(confFile)
+	if err != nil {
+		return &configFile, err
+	}
+
+	if err := json.Unmarshal(b, &configFile.Configs); err != nil {
+		arr := strings.Split(string(b), "\n")
+		if len(arr) < 2 {
+			return &configFile, fmt.Errorf("The Auth config file is empty")
+		}
+		return &configFile, fmt.Errorf("Invalid Auth config file")
+	}
+	return &configFile, nil
+}
+
+// save the auth config
+func SaveConfig(configFile *ConfigFile) error {
+	confFile := path.Join(configFile.rootPath, CONFIGFILE)
+	if len(configFile.Configs) == 0 {
+		os.Remove(confFile)
+		return nil
+	}
+
+	b, err := json.Marshal(configFile)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(confFile, b, 0600)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dotcloud/docker/api"
 	"github.com/dotcloud/docker/api/client"
 	"github.com/dotcloud/docker/builtins"
+	"github.com/dotcloud/docker/config"
 	"github.com/dotcloud/docker/dockerversion"
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/opts"
@@ -82,8 +83,16 @@ func main() {
 		defaultHost := os.Getenv("DOCKER_HOST")
 
 		if defaultHost == "" || *flDaemon {
-			// If we do not have a host, default to unix socket
-			defaultHost = fmt.Sprintf("unix://%s", api.DEFAULTUNIXSOCKET)
+			if configFile, err := config.LoadConfig(os.Getenv("HOME")); err == nil {
+				if c, err := configFile.GetConfig("DOCKER_HOST"); err == nil {
+					defaultHost = c.(string)
+				}
+			}
+
+			if defaultHost == "" {
+				// If we do not have a host, default to unix socket
+				defaultHost = fmt.Sprintf("unix://%s", api.DEFAULTUNIXSOCKET)
+			}
 		}
 		if _, err := api.ValidateHost(defaultHost); err != nil {
 			log.Fatal(err)

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -224,7 +224,7 @@ func ResolveAuthConfig(config *config.ConfigFile, hostname string) AuthConfig {
 	}
 
 	normalizedHostename := convertToHostname(hostname)
-	for index, _ := range config.Configs {
+	for index := range config.Configs {
 		if registryHostname := convertToHostname(index); registryHostname == normalizedHostename {
 			if c, err := GetAuth(config, index); err == nil {
 				return *c

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -3,28 +3,20 @@ package registry
 import (
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
+	"github.com/dotcloud/docker/config"
+	"github.com/dotcloud/docker/utils"
 	"io/ioutil"
 	"net/http"
-	"os"
-	"path"
 	"strings"
 
 	"github.com/dotcloud/docker/utils"
 )
 
-// Where we store the config file
-const CONFIGFILE = ".dockercfg"
-
 // Only used for user auth + account creation
 const INDEXSERVER = "https://index.docker.io/v1/"
 
 //const INDEXSERVER = "https://indexstaging-docker.dotcloud.com/v1/"
-
-var (
-	ErrConfigFileMissing = errors.New("The Auth config file is missing")
-)
 
 type AuthConfig struct {
 	Username      string `json:"username,omitempty"`
@@ -32,11 +24,6 @@ type AuthConfig struct {
 	Auth          string `json:"auth"`
 	Email         string `json:"email"`
 	ServerAddress string `json:"serveraddress,omitempty"`
-}
-
-type ConfigFile struct {
-	Configs  map[string]AuthConfig `json:"configs,omitempty"`
-	rootPath string
 }
 
 func IndexServerAddress() string {
@@ -72,82 +59,35 @@ func decodeAuth(authStr string) (string, string, error) {
 	return arr[0], password, nil
 }
 
-// load up the auth config information and return values
-// FIXME: use the internal golang config parser
-func LoadConfig(rootPath string) (*ConfigFile, error) {
-	configFile := ConfigFile{Configs: make(map[string]AuthConfig), rootPath: rootPath}
-	confFile := path.Join(rootPath, CONFIGFILE)
-	if _, err := os.Stat(confFile); err != nil {
-		return &configFile, nil //missing file is not an error
-	}
-	b, err := ioutil.ReadFile(confFile)
+func GetAuth(config *config.ConfigFile, key string) (*AuthConfig, error) {
+	a, err := config.GetConfig(key)
 	if err != nil {
-		return &configFile, err
+		return nil, err
 	}
-
-	if err := json.Unmarshal(b, &configFile.Configs); err != nil {
-		arr := strings.Split(string(b), "\n")
-		if len(arr) < 2 {
-			return &configFile, fmt.Errorf("The Auth config file is empty")
-		}
-		authConfig := AuthConfig{}
-		origAuth := strings.Split(arr[0], " = ")
-		if len(origAuth) != 2 {
-			return &configFile, fmt.Errorf("Invalid Auth config file")
-		}
-		authConfig.Username, authConfig.Password, err = decodeAuth(origAuth[1])
+	authConfig, found := a.(*AuthConfig)
+	if !found {
+		return &AuthConfig{}, fmt.Errorf("%s value is invalid type", key)
+	}
+	if authConfig.Auth != "" {
+		authConfig.Username, authConfig.Password, err = decodeAuth(authConfig.Auth)
 		if err != nil {
-			return &configFile, err
-		}
-		origEmail := strings.Split(arr[1], " = ")
-		if len(origEmail) != 2 {
-			return &configFile, fmt.Errorf("Invalid Auth config file")
-		}
-		authConfig.Email = origEmail[1]
-		authConfig.ServerAddress = IndexServerAddress()
-		configFile.Configs[IndexServerAddress()] = authConfig
-	} else {
-		for k, authConfig := range configFile.Configs {
-			authConfig.Username, authConfig.Password, err = decodeAuth(authConfig.Auth)
-			if err != nil {
-				return &configFile, err
-			}
-			authConfig.Auth = ""
-			configFile.Configs[k] = authConfig
-			authConfig.ServerAddress = k
+			return authConfig, err
 		}
 	}
-	return &configFile, nil
+	authConfig.Auth = ""
+	authConfig.ServerAddress = key
+	return authConfig, nil
 }
 
-// save the auth config
-func SaveConfig(configFile *ConfigFile) error {
-	confFile := path.Join(configFile.rootPath, CONFIGFILE)
-	if len(configFile.Configs) == 0 {
-		os.Remove(confFile)
-		return nil
-	}
+func PutAuth(config *config.ConfigFile, key string, authConfig *AuthConfig) error {
+	authCopy := authConfig
 
-	configs := make(map[string]AuthConfig, len(configFile.Configs))
-	for k, authConfig := range configFile.Configs {
-		authCopy := authConfig
+	authCopy.Auth = encodeAuth(authCopy)
+	authCopy.Username = ""
+	authCopy.Password = ""
+	authCopy.ServerAddress = ""
 
-		authCopy.Auth = encodeAuth(&authCopy)
-		authCopy.Username = ""
-		authCopy.Password = ""
-		authCopy.ServerAddress = ""
-		configs[k] = authCopy
-	}
-
-	b, err := json.Marshal(configs)
-	if err != nil {
-		return err
-	}
-	err = ioutil.WriteFile(confFile, b, 0600)
-	if err != nil {
-		return err
-	}
-	return nil
+	return config.PutConfig(key, authCopy)
 }
 
 // try to register/login to the registry server
@@ -259,15 +199,15 @@ func Login(authConfig *AuthConfig, factory *utils.HTTPRequestFactory) (string, e
 }
 
 // this method matches a auth configuration to a server address or a url
-func (config *ConfigFile) ResolveAuthConfig(hostname string) AuthConfig {
-	if hostname == IndexServerAddress() || len(hostname) == 0 {
+func ResolveAuthConfig(config *config.ConfigFile, hostname string) AuthConfig {
+	if len(hostname) == 0 {
 		// default to the index server
-		return config.Configs[IndexServerAddress()]
+		hostname = IndexServerAddress()
 	}
 
 	// First try the happy case
-	if c, found := config.Configs[hostname]; found {
-		return c
+	if c, err := GetAuth(config, hostname); err == nil {
+		return *c
 	}
 
 	convertToHostname := func(url string) string {
@@ -283,12 +223,12 @@ func (config *ConfigFile) ResolveAuthConfig(hostname string) AuthConfig {
 		return nameParts[0]
 	}
 
-	// Maybe they have a legacy config file, we will iterate the keys converting
-	// them to the new format and testing
 	normalizedHostename := convertToHostname(hostname)
-	for registry, config := range config.Configs {
-		if registryHostname := convertToHostname(registry); registryHostname == normalizedHostename {
-			return config
+	for index, _ := range config.Configs {
+		if registryHostname := convertToHostname(index); registryHostname == normalizedHostename {
+			if c, err := GetAuth(config, index); err == nil {
+				return *c
+			}
 		}
 	}
 

--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 
 	"github.com/dotcloud/docker/archive"
+	"github.com/dotcloud/docker/config"
 	"github.com/dotcloud/docker/daemon"
 	"github.com/dotcloud/docker/nat"
 	"github.com/dotcloud/docker/pkg/symlink"
@@ -55,7 +56,7 @@ type buildFile struct {
 	forceRm      bool
 
 	authConfig *registry.AuthConfig
-	configFile *registry.ConfigFile
+	configFile *config.ConfigFile
 
 	tmpContainers map[string]struct{}
 	tmpImages     map[string]struct{}
@@ -92,7 +93,7 @@ func (b *buildFile) CmdFrom(name string) error {
 				if err != nil {
 					return err
 				}
-				resolvedAuth := b.configFile.ResolveAuthConfig(endpoint)
+				resolvedAuth := registry.ResolveAuthConfig(b.configFile, endpoint)
 				pullRegistryAuth = &resolvedAuth
 			}
 			job := b.srv.Eng.Job("pull", remote, tag)
@@ -884,7 +885,7 @@ func fixPermissions(destination string, uid, gid int) error {
 	})
 }
 
-func NewBuildFile(srv *Server, outStream, errStream io.Writer, verbose, utilizeCache, rm bool, forceRm bool, outOld io.Writer, sf *utils.StreamFormatter, auth *registry.AuthConfig, authConfigFile *registry.ConfigFile) BuildFile {
+func NewBuildFile(srv *Server, outStream, errStream io.Writer, verbose, utilizeCache, rm bool, forceRm bool, outOld io.Writer, sf *utils.StreamFormatter, auth *registry.AuthConfig, authConfigFile *config.ConfigFile) BuildFile {
 	return &buildFile{
 		daemon:        srv.daemon,
 		srv:           srv,

--- a/server/server.go
+++ b/server/server.go
@@ -44,6 +44,7 @@ import (
 	"time"
 
 	"github.com/dotcloud/docker/archive"
+	"github.com/dotcloud/docker/config"
 	"github.com/dotcloud/docker/daemon"
 	"github.com/dotcloud/docker/daemonconfig"
 	"github.com/dotcloud/docker/dockerversion"
@@ -449,7 +450,7 @@ func (srv *Server) Build(job *engine.Job) engine.Status {
 		rm             = job.GetenvBool("rm")
 		forceRm        = job.GetenvBool("forcerm")
 		authConfig     = &registry.AuthConfig{}
-		configFile     = &registry.ConfigFile{}
+		configFile     = &config.ConfigFile{}
 		tag            string
 		context        io.ReadCloser
 	)


### PR DESCRIPTION
from registry/auth.go to a new config.config.go

I've also removed some legacy conversion from a format pre 0.5.3.

The second commit is the reason I've done this - we need a way for boot2docker to be able to default the DOCKER_HOST setting - and on discussion with @shykes, modifying our config file is a better option than modifying the profile and setting an ENV.
