### PR TITLE
Add docker daemon command instead of -d 

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	"github.com/docker/docker/api"
+	"github.com/docker/docker/archive"
+	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/graph"
@@ -1951,6 +1953,33 @@ func (cli *DockerCli) CmdTag(args ...string) error {
 	if _, _, err := readBody(cli.call("POST", "/images/"+cmd.Arg(0)+"/tag?"+v.Encode(), nil, false)); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (cli *DockerCli) CmdDaemon(args ...string) error {
+	config := daemon.Config{}
+
+	cmd := cli.Subcmd("daemon", "[OPTIONS]", "Enable Daemon Mode")
+	cmd.StringVar(&config.Pidfile, []string{"p", "-pidfile"}, "/var/run/docker.pid", "Path to use for daemon PID file")
+	cmd.StringVar(&config.Root, []string{"g", "-graph"}, "/var/lib/docker", "Path to use as the root of the Docker runtime")
+	cmd.BoolVar(&config.AutoRestart, []string{"#r", "#-restart"}, true, "--restart on the daemon has been deprecated in favor of --restart policies on docker run")
+	cmd.BoolVar(&config.EnableIptables, []string{"#iptables", "-iptables"}, true, "Enable Docker's addition of iptables rules")
+	cmd.BoolVar(&config.EnableIpForward, []string{"#ip-forward", "-ip-forward"}, true, "Enable net.ipv4.ip_forward")
+	cmd.BoolVar(&config.EnableIpMasq, []string{"-ip-masq"}, true, "Enable IP masquerading for bridge's IP range")
+	cmd.StringVar(&config.BridgeIP, []string{"#bip", "-bip"}, "", "Use this CIDR notation address for the network bridge's IP, not compatible with -b")
+	cmd.StringVar(&config.BridgeIface, []string{"b", "-bridge"}, "", "Attach containers to a pre-existing network bridge\nuse 'none' to disable container networking")
+	cmd.StringVar(&config.FixedCIDR, []string{"-fixed-cidr"}, "", "IPv4 subnet for fixed IPs (ex: 10.20.0.0/16)\nthis subnet must be nested in the bridge subnet (which is defined by -b or --bip)")
+	cmd.BoolVar(&config.InterContainerCommunication, []string{"#icc", "-icc"}, true, "Enable inter-container communication")
+	cmd.StringVar(&config.GraphDriver, []string{"s", "-storage-driver"}, "", "Force the Docker runtime to use a specific storage driver")
+	cmd.StringVar(&config.ExecDriver, []string{"e", "-exec-driver"}, "native", "Force the Docker runtime to use a specific exec driver")
+	cmd.BoolVar(&config.EnableSelinuxSupport, []string{"-selinux-enabled"}, false, "Enable selinux support. SELinux does not presently support the BTRFS storage driver")
+	cmd.IntVar(&config.Mtu, []string{"#mtu", "-mtu"}, 0, "Set the containers network MTU\nif no value is provided: default to the default route MTU or 1500 if no default route is available")
+	opts.IPVar(&config.DefaultIp, []string{"#ip", "-ip"}, "0.0.0.0", "Default IP address to use when binding container ports")
+	opts.ListVar(&config.GraphOptions, []string{"-storage-opt"}, "Set storage driver options")
+	// FIXME: why the inconsistency between "hosts" and "sockets"?
+	opts.IPListVar(&config.Dns, []string{"#dns", "-dns"}, "Force Docker to use specific DNS servers")
+	opts.DnsSearchListVar(&config.DnsSearch, []string{"-dns-search"}, "Force Docker to use specific DNS search domains")
+	opts.MirrorListVar(&config.Mirrors, []string{"-registry-mirror"}, "Specify a preferred Docker registry mirror")
 	return nil
 }
 

--- a/contrib/init/openrc/docker.initd
+++ b/contrib/init/openrc/docker.initd
@@ -20,7 +20,7 @@ start() {
 		--pidfile "$DOCKER_PIDFILE" \
 		--stdout "$DOCKER_LOGFILE" \
 		--stderr "$DOCKER_LOGFILE" \
-		-- -d -p "$DOCKER_PIDFILE" \
+		-- daemon -p "$DOCKER_PIDFILE" \
 		$DOCKER_OPTS
 	eend $?
 }

--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -5,7 +5,15 @@ After=network.target docker.socket
 Requires=docker.socket
 
 [Service]
+<<<<<<< HEAD
 ExecStart=/usr/bin/docker -d -H fd://
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+ExecStart=/usr/bin/docker -d -H fd://
+Restart=on-failure
+=======
+ExecStart=/usr/bin/docker daemon -H fd://
+Restart=on-failure
+>>>>>>> af6ac83... Use docker daemon command instead of -d
 LimitNOFILE=1048576
 LimitNPROC=1048576
 

--- a/contrib/init/systemd/socket-activation/docker.service
+++ b/contrib/init/systemd/socket-activation/docker.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=http://docs.docker.io
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/docker daemon -H fd://
+Restart=on-failure
+LimitNOFILE=1048576
+LimitNPROC=1048576
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -103,7 +103,7 @@ case "$1" in
 			--pidfile "$DOCKER_SSD_PIDFILE" \
 			--make-pidfile \
 			-- \
-				-d -p "$DOCKER_PIDFILE" \
+				daemon -p "$DOCKER_PIDFILE" \
 				$DOCKER_OPTS \
 					>> "$DOCKER_LOGFILE" 2>&1
 		log_end_msg $?

--- a/contrib/init/sysvinit-redhat/docker.sysconfig
+++ b/contrib/init/sysvinit-redhat/docker.sysconfig
@@ -2,6 +2,6 @@
 # 
 # Other arguments to pass to the docker daemon process
 # These will be parsed by the sysv initscript and appended
-# to the arguments list passed to docker -d
+# to the arguments list passed to docker daemon
 
 other_args=""

--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -37,5 +37,5 @@ script
 	if [ -f /etc/default/$UPSTART_JOB ]; then
 		. /etc/default/$UPSTART_JOB
 	fi
-	exec "$DOCKER" -d $DOCKER_OPTS
+	exec "$DOCKER" daemon $DOCKER_OPTS
 end script

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -7,9 +7,18 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+<<<<<<< HEAD
 	"path"
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+	"path/filepath"
+	"runtime"
+=======
+	"path/filepath"
+	"strconv"
+>>>>>>> af6ac83... Use docker daemon command instead of -d
 	"strings"
 
+<<<<<<< HEAD
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/client"
 	"github.com/docker/docker/dockerversion"
@@ -17,8 +26,28 @@ import (
 	"github.com/docker/docker/reexec"
 	"github.com/docker/docker/utils"
 	"github.com/docker/libtrust"
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+	"github.com/dotcloud/docker/api"
+	"github.com/dotcloud/docker/api/client"
+	"github.com/dotcloud/docker/builtins"
+	"github.com/dotcloud/docker/dockerversion"
+	"github.com/dotcloud/docker/engine"
+	"github.com/dotcloud/docker/opts"
+	flag "github.com/dotcloud/docker/pkg/mflag"
+	"github.com/dotcloud/docker/sysinit"
+	"github.com/dotcloud/docker/utils"
+=======
+	"github.com/dotcloud/docker/api"
+	"github.com/dotcloud/docker/api/client"
+	"github.com/dotcloud/docker/dockerversion"
+	"github.com/dotcloud/docker/opts"
+	flag "github.com/dotcloud/docker/pkg/mflag"
+	"github.com/dotcloud/docker/sysinit"
+	"github.com/dotcloud/docker/utils"
+>>>>>>> af6ac83... Use docker daemon command instead of -d
 )
 
+<<<<<<< HEAD
 const (
 	defaultTrustKeyFile = "key.json"
 	defaultCaFile       = "ca.pem"
@@ -26,10 +55,99 @@ const (
 	defaultCertFile     = "cert.pem"
 )
 
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+const (
+	defaultCaFile   = "ca.pem"
+	defaultKeyFile  = "key.pem"
+	defaultCertFile = "cert.pem"
+)
+
+var (
+	dockerConfDir = os.Getenv("DOCKER_CONFIG")
+)
+
+=======
+>>>>>>> af6ac83... Use docker daemon command instead of -d
 func main() {
+<<<<<<< HEAD
 	if reexec.Init() {
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+	if len(dockerConfDir) == 0 {
+		dockerConfDir = filepath.Join(os.Getenv("HOME"), ".docker")
+	}
+	if selfPath := utils.SelfPath(); strings.Contains(selfPath, ".dockerinit") {
+		// Running in init mode
+		sysinit.SysInit()
+=======
+	for j := 1; j < len(os.Args); j++ {
+		if os.Args[j] == "-d" || os.Args[j] == "--daemon" {
+			log.Println("-d is deprecated. Please use daemon command")
+			os.Args[j] = "daemon"
+		}
+	}
+
+	if len(client.DockerConfDir) == 0 {
+		client.DockerConfDir = filepath.Join(os.Getenv("HOME"), ".docker")
+	}
+
+	if selfPath := utils.SelfPath(); strings.Contains(selfPath, ".dockerinit") {
+		// Running in init mode
+		sysinit.SysInit()
+>>>>>>> af6ac83... Use docker daemon command instead of -d
 		return
 	}
+<<<<<<< HEAD
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+
+	var (
+		flVersion            = flag.Bool([]string{"v", "-version"}, false, "Print version information and quit")
+		flDaemon             = flag.Bool([]string{"d", "-daemon"}, false, "Enable daemon mode")
+		flGraphOpts          opts.ListOpts
+		flDebug              = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
+		flAutoRestart        = flag.Bool([]string{"r", "-restart"}, true, "Restart previously running containers")
+		bridgeName           = flag.String([]string{"b", "-bridge"}, "", "Attach containers to a pre-existing network bridge\nuse 'none' to disable container networking")
+		bridgeIp             = flag.String([]string{"#bip", "-bip"}, "", "Use this CIDR notation address for the network bridge's IP, not compatible with -b")
+		pidfile              = flag.String([]string{"p", "-pidfile"}, "/var/run/docker.pid", "Path to use for daemon PID file")
+		flRoot               = flag.String([]string{"g", "-graph"}, "/var/lib/docker", "Path to use as the root of the Docker runtime")
+		flSocketGroup        = flag.String([]string{"G", "-group"}, "docker", "Group to assign the unix socket specified by -H when running in daemon mode\nuse '' (the empty string) to disable setting of a group")
+		flEnableCors         = flag.Bool([]string{"#api-enable-cors", "-api-enable-cors"}, false, "Enable CORS headers in the remote API")
+		flDns                = opts.NewListOpts(opts.ValidateIPAddress)
+		flDnsSearch          = opts.NewListOpts(opts.ValidateDnsSearch)
+		flEnableIptables     = flag.Bool([]string{"#iptables", "-iptables"}, true, "Enable Docker's addition of iptables rules")
+		flEnableIpForward    = flag.Bool([]string{"#ip-forward", "-ip-forward"}, true, "Enable net.ipv4.ip_forward")
+		flDefaultIp          = flag.String([]string{"#ip", "-ip"}, "0.0.0.0", "Default IP address to use when binding container ports")
+		flInterContainerComm = flag.Bool([]string{"#icc", "-icc"}, true, "Enable inter-container communication")
+		flGraphDriver        = flag.String([]string{"s", "-storage-driver"}, "", "Force the Docker runtime to use a specific storage driver")
+		flExecDriver         = flag.String([]string{"e", "-exec-driver"}, "native", "Force the Docker runtime to use a specific exec driver")
+		flHosts              = opts.NewListOpts(api.ValidateHost)
+		flMtu                = flag.Int([]string{"#mtu", "-mtu"}, 0, "Set the containers network MTU\nif no value is provided: default to the default route MTU or 1500 if no default route is available")
+		flTls                = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by tls-verify flags")
+		flTlsVerify          = flag.Bool([]string{"-tlsverify"}, false, "Use TLS and verify the remote (daemon: verify client, client: verify daemon)")
+		flCa                 = flag.String([]string{"-tlscacert"}, filepath.Join(dockerConfDir, defaultCaFile), "Trust only remotes providing a certificate signed by the CA given here")
+		flCert               = flag.String([]string{"-tlscert"}, filepath.Join(dockerConfDir, defaultCertFile), "Path to TLS certificate file")
+		flKey                = flag.String([]string{"-tlskey"}, filepath.Join(dockerConfDir, defaultKeyFile), "Path to TLS key file")
+		flSelinuxEnabled     = flag.Bool([]string{"-selinux-enabled"}, false, "Enable selinux support. SELinux does not presently support the BTRFS storage driver")
+	)
+	flag.Var(&flDns, []string{"#dns", "-dns"}, "Force Docker to use specific DNS servers")
+	flag.Var(&flDnsSearch, []string{"-dns-search"}, "Force Docker to use specific DNS search domains")
+	flag.Var(&flHosts, []string{"H", "-host"}, "The socket(s) to bind to in daemon mode\nspecified using one or more tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.")
+	flag.Var(&flGraphOpts, []string{"-storage-opt"}, "Set storage driver options")
+
+=======
+
+	var (
+		flHosts     = opts.NewListOpts(api.ValidateHost)
+		flVersion   = flag.Bool([]string{"v", "-version"}, false, "Print version information and quit")
+		flDebug     = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
+		flTls       = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by tls-verify flags")
+		flTlsVerify = flag.Bool([]string{"-tlsverify"}, false, "Use TLS and verify the remote (daemon: verify client, client: verify daemon)")
+		flCa        = flag.String([]string{"-tlscacert"}, filepath.Join(client.DockerConfDir, client.DefaultCaFile), "Trust only remotes providing a certificate signed by the CA given here")
+		flCert      = flag.String([]string{"-tlscert"}, filepath.Join(client.DockerConfDir, client.DefaultCertFile), "Path to TLS certificate file")
+		flKey       = flag.String([]string{"-tlskey"}, filepath.Join(client.DockerConfDir, client.DefaultKeyFile), "Path to TLS key file")
+	)
+	flag.Var(&flHosts, []string{"H", "-host"}, "The socket(s) to bind to in daemon mode\nspecified using one or more tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.")
+
+>>>>>>> af6ac83... Use docker daemon command instead of -d
 	flag.Parse()
 	// FIXME: validate daemon flags here
 
@@ -41,9 +159,15 @@ func main() {
 		os.Setenv("DEBUG", "1")
 	}
 
+<<<<<<< HEAD
 	if len(flHosts) == 0 {
 		defaultHost := os.Getenv("DOCKER_HOST")
 		if defaultHost == "" || *flDaemon {
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+		if defaultHost == "" || *flDaemon {
+=======
+		if defaultHost == "" {
+>>>>>>> af6ac83... Use docker daemon command instead of -d
 			// If we do not have a host, default to unix socket
 			defaultHost = fmt.Sprintf("unix://%s", api.DEFAULTUNIXSOCKET)
 		}
@@ -54,6 +178,7 @@ func main() {
 		flHosts = append(flHosts, defaultHost)
 	}
 
+<<<<<<< HEAD
 	if *flDaemon {
 		mainDaemon()
 		return
@@ -67,7 +192,27 @@ func main() {
 	err := os.MkdirAll(path.Dir(*flTrustKey), 0700)
 	if err != nil {
 		log.Fatal(err)
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+	if *bridgeName != "" && *bridgeIp != "" {
+		log.Fatal("You specified -b & --bip, mutually exclusive options. Please specify only one.")
 	}
+
+	if !*flEnableIptables && !*flInterContainerComm {
+		log.Fatal("You specified --iptables=false with --icc=false. ICC uses iptables to function. Please set --icc or --iptables to true.")
+	}
+
+	if net.ParseIP(*flDefaultIp) == nil {
+		log.Fatalf("Specified --ip=%s is not in correct format \"0.0.0.0\".", *flDefaultIp)
+	}
+
+	if *flDebug {
+		os.Setenv("DEBUG", "1")
+=======
+	if *flDebug {
+		os.Setenv("DEBUG", "1")
+>>>>>>> af6ac83... Use docker daemon command instead of -d
+	}
+<<<<<<< HEAD
 	trustKey, keyErr := libtrust.LoadKeyFile(*flTrustKey)
 	if keyErr == libtrust.ErrKeyFileDoesNotExist {
 		trustKey, keyErr = libtrust.GenerateECP256PrivateKey()
@@ -102,6 +247,168 @@ func main() {
 		_, errCert := os.Stat(*flCert)
 		_, errKey := os.Stat(*flKey)
 		if errCert == nil && errKey == nil {
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+
+	if *flDaemon {
+		if runtime.GOOS != "linux" {
+			log.Fatalf("The Docker daemon is only supported on linux")
+		}
+		if os.Geteuid() != 0 {
+			log.Fatalf("The Docker daemon needs to be run as root")
+		}
+
+		if flag.NArg() != 0 {
+			flag.Usage()
+			return
+		}
+
+		// set up the TempDir to use a canonical path
+		tmp := os.TempDir()
+		realTmp, err := utils.ReadSymlinkedDirectory(tmp)
+		if err != nil {
+			log.Fatalf("Unable to get the full path to the TempDir (%s): %s", tmp, err)
+		}
+		os.Setenv("TMPDIR", realTmp)
+
+		// get the canonical path to the Docker root directory
+		root := *flRoot
+		var realRoot string
+		if _, err := os.Stat(root); err != nil && os.IsNotExist(err) {
+			realRoot = root
+		} else {
+			realRoot, err = utils.ReadSymlinkedDirectory(root)
+			if err != nil {
+				log.Fatalf("Unable to get the full path to root (%s): %s", root, err)
+			}
+		}
+		if err := checkKernelAndArch(); err != nil {
+			log.Fatal(err)
+		}
+
+		eng := engine.New()
+		// Load builtins
+		if err := builtins.Register(eng); err != nil {
+			log.Fatal(err)
+		}
+
+		// handle the pidfile early. https://github.com/dotcloud/docker/issues/6973
+		if len(*pidfile) > 0 {
+			job := eng.Job("initserverpidfile", *pidfile)
+			if err := job.Run(); err != nil {
+				log.Fatal(err)
+			}
+		}
+
+		// load the daemon in the background so we can immediately start
+		// the http api so that connections don't fail while the daemon
+		// is booting
+		go func() {
+			// Load plugin: httpapi
+			job := eng.Job("initserver")
+			// include the variable here too, for the server config
+			job.Setenv("Pidfile", *pidfile)
+			job.Setenv("Root", realRoot)
+			job.SetenvBool("AutoRestart", *flAutoRestart)
+			job.SetenvList("Dns", flDns.GetAll())
+			job.SetenvList("DnsSearch", flDnsSearch.GetAll())
+			job.SetenvBool("EnableIptables", *flEnableIptables)
+			job.SetenvBool("EnableIpForward", *flEnableIpForward)
+			job.Setenv("BridgeIface", *bridgeName)
+			job.Setenv("BridgeIP", *bridgeIp)
+			job.Setenv("DefaultIp", *flDefaultIp)
+			job.SetenvBool("InterContainerCommunication", *flInterContainerComm)
+			job.Setenv("GraphDriver", *flGraphDriver)
+			job.SetenvList("GraphOptions", flGraphOpts.GetAll())
+			job.Setenv("ExecDriver", *flExecDriver)
+			job.SetenvInt("Mtu", *flMtu)
+			job.SetenvBool("EnableSelinuxSupport", *flSelinuxEnabled)
+			job.SetenvList("Sockets", flHosts.GetAll())
+			if err := job.Run(); err != nil {
+				log.Fatal(err)
+			}
+			// after the daemon is done setting up we can tell the api to start
+			// accepting connections
+			if err := eng.Job("acceptconnections").Run(); err != nil {
+				log.Fatal(err)
+			}
+		}()
+
+		// TODO actually have a resolved graphdriver to show?
+		log.Printf("docker daemon: %s %s; execdriver: %s; graphdriver: %s",
+			dockerversion.VERSION,
+			dockerversion.GITCOMMIT,
+			*flExecDriver,
+			*flGraphDriver)
+
+		// Serve api
+		job := eng.Job("serveapi", flHosts.GetAll()...)
+		job.SetenvBool("Logging", true)
+		job.SetenvBool("EnableCors", *flEnableCors)
+		job.Setenv("Version", dockerversion.VERSION)
+		job.Setenv("SocketGroup", *flSocketGroup)
+
+		job.SetenvBool("Tls", *flTls)
+		job.SetenvBool("TlsVerify", *flTlsVerify)
+		job.Setenv("TlsCa", *flCa)
+		job.Setenv("TlsCert", *flCert)
+		job.Setenv("TlsKey", *flKey)
+		job.SetenvBool("BufferRequests", true)
+		if err := job.Run(); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		if flHosts.Len() > 1 {
+			log.Fatal("Please specify only one -H")
+		}
+		protoAddrParts := strings.SplitN(flHosts.GetAll()[0], "://", 2)
+
+		var (
+			cli       *client.DockerCli
+			tlsConfig tls.Config
+		)
+		tlsConfig.InsecureSkipVerify = true
+
+		// If we should verify the server, we need to load a trusted ca
+		if *flTlsVerify {
+=======
+	os.Setenv("Tls", strconv.FormatBool(*flTls))
+	os.Setenv("TlsVerify", strconv.FormatBool(*flTlsVerify))
+	os.Setenv("TlsCa", *flCa)
+	os.Setenv("TlsCert", *flCert)
+	os.Setenv("TlsCert", *flKey)
+
+	os.Setenv("flCA", "1")
+
+	if flHosts.Len() > 1 {
+		log.Fatal("Please specify only one -H")
+	}
+	protoAddrParts := strings.SplitN(flHosts.GetAll()[0], "://", 2)
+
+	var (
+		cli       *client.DockerCli
+		tlsConfig tls.Config
+	)
+	tlsConfig.InsecureSkipVerify = true
+
+	// If we should verify the server, we need to load a trusted ca
+	if *flTlsVerify {
+		*flTls = true
+		certPool := x509.NewCertPool()
+		file, err := ioutil.ReadFile(*flCa)
+		if err != nil {
+			log.Fatalf("Couldn't read ca cert %s: %s", *flCa, err)
+		}
+		certPool.AppendCertsFromPEM(file)
+		tlsConfig.RootCAs = certPool
+		tlsConfig.InsecureSkipVerify = false
+	}
+
+	// If tls is enabled, try to load and send client certificates
+	if *flTls || *flTlsVerify {
+		_, errCert := os.Stat(*flCert)
+		_, errKey := os.Stat(*flKey)
+		if errCert == nil && errKey == nil {
+>>>>>>> af6ac83... Use docker daemon command instead of -d
 			*flTls = true
 			cert, err := tls.LoadX509KeyPair(*flCert, *flKey)
 			if err != nil {
@@ -111,16 +418,44 @@ func main() {
 		}
 	}
 
+<<<<<<< HEAD
 	if *flTls || *flTlsVerify {
 		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, trustKey, protoAddrParts[0], protoAddrParts[1], &tlsConfig)
 	} else {
 		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, trustKey, protoAddrParts[0], protoAddrParts[1], nil)
 	}
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+		if *flTls || *flTlsVerify {
+			cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, protoAddrParts[0], protoAddrParts[1], &tlsConfig)
+		} else {
+			cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, protoAddrParts[0], protoAddrParts[1], nil)
+		}
+=======
+	if *flTls || *flTlsVerify {
+		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, protoAddrParts[0], protoAddrParts[1], &tlsConfig)
+	} else {
+		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, protoAddrParts[0], protoAddrParts[1], nil)
+	}
+>>>>>>> af6ac83... Use docker daemon command instead of -d
 
+<<<<<<< HEAD
 	if err := cli.Cmd(flag.Args()...); err != nil {
 		if sterr, ok := err.(*utils.StatusError); ok {
 			if sterr.Status != "" {
 				log.Println(sterr.Status)
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+		if err := cli.ParseCommands(flag.Args()...); err != nil {
+			if sterr, ok := err.(*utils.StatusError); ok {
+				if sterr.Status != "" {
+					log.Println(sterr.Status)
+				}
+				os.Exit(sterr.StatusCode)
+=======
+	if err := cli.ParseCommands(flag.Args()...); err != nil {
+		if sterr, ok := err.(*utils.StatusError); ok {
+			if sterr.Status != "" {
+				log.Println(sterr.Status)
+>>>>>>> af6ac83... Use docker daemon command instead of -d
 			}
 			os.Exit(sterr.StatusCode)
 		}

--- a/docs/man/docker-daemon.1.md
+++ b/docs/man/docker-daemon.1.md
@@ -1,0 +1,72 @@
+% DOCKER(1) Docker User Manuals
+% Dan Walsh
+% JUNE  2014
+# NAME
+docker-daemon \- Run the Docker daemon
+
+# SYNOPSIS
+**docker daemon** [OPTIONS]
+
+# DESCRIPTION
+Run the docker daemon.  Docker daemon is usually run within the init system in 
+either an init script or in a systemd unit file.
+
+# OPTIONS
+
+**-H**, **--host**=[unix:///var/run/docker.sock]: tcp://[host:port] to bind or
+unix://[/path/to/socket] to use.
+   The socket(s) to bind to in daemon mode specified using one or more
+   tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.
+
+**--api-enable-cors**=*true*|*false*
+  Enable CORS headers in the remote API. Default is false.
+
+**-b**=""
+  Attach containers to a pre\-existing network bridge; use 'none' to disable container networking
+
+**--bip**=""
+  Use the provided CIDR notation address for the dynamically created bridge (docker0); Mutually exclusive of \-b
+
+**-d**=*true*|*false*
+  Enable daemon mode. Default is false.
+
+**--dns**=""
+  Force Docker to use specific DNS servers
+
+**-g**=""
+  Path to use as the root of the Docker runtime. Default is `/var/lib/docker`.
+
+**--icc**=*true*|*false*
+  Enable inter\-container communication. Default is true.
+
+**--ip**=""
+  Default IP address to use when binding container ports. Default is `0.0.0.0`.
+
+**--iptables**=*true*|*false*
+  Disable Docker's addition of iptables rules. Default is true.
+
+**--mtu**=VALUE
+  Set the containers network mtu. Default is `1500`.
+
+**-p**=""
+  Path to use for daemon PID file. Default is `/var/run/docker.pid`
+
+**-r**=*true*|*false*
+  Restart previously running containers. Default is true.
+
+**-s**=""
+  Force the Docker runtime to use a specific storage driver.
+
+**--selinux-enabled**=*true*|*false*
+  Enable selinux support. Default is false.
+
+# EXAMPLES
+
+For specific examples please see the man page for the specific Docker command.
+For example:
+
+    man docker run
+
+# HISTORY
+June 2014, Originally compiled by Dan Walsh (dwalsh at redhat dot com) based
+ on docker.io source material and internal work.

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -13,9 +13,7 @@ daemon and to run the CLI (i.e., to command the daemon to manage images,
 containers etc.) So **docker** is both a server, as a daemon, and a client
 to the daemon, through the CLI.
 
-To run the Docker daemon you do not specify any of the commands listed below but
-must specify the **-d** option.  The other options listed below are for the
-daemon only.
+To run the Docker daemon you specify the **daemon** command.
 
 The Docker CLI has over 30 commands. The commands are listed below and each has
 its own man page which explain usage and arguments.
@@ -26,6 +24,7 @@ To see the man page for a command run **man docker <command>**.
 **-D**=*true*|*false*
    Enable debug mode. Default is false.
 
+<<<<<<< HEAD
 **-H**, **--host**=[unix:///var/run/docker.sock]: tcp://[host:port] to bind or
 unix://[/path/to/socket] to use.
    The socket(s) to bind to in daemon mode specified using one or more
@@ -77,11 +76,55 @@ unix://[/path/to/socket] to use.
 **-s**=""
   Force the Docker runtime to use a specific storage driver.
 
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+**-H**, **--host**=[unix:///var/run/docker.sock]: tcp://[host:port] to bind or
+unix://[/path/to/socket] to use.
+   The socket(s) to bind to in daemon mode specified using one or more
+   tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.
+
+**--api-enable-cors**=*true*|*false*
+  Enable CORS headers in the remote API. Default is false.
+
+**-b**=""
+  Attach containers to a pre\-existing network bridge; use 'none' to disable container networking
+
+**--bip**=""
+  Use the provided CIDR notation address for the dynamically created bridge (docker0); Mutually exclusive of \-b
+
+**-d**=*true*|*false*
+  Enable daemon mode. Default is false.
+
+**--dns**=""
+  Force Docker to use specific DNS servers
+
+**-g**=""
+  Path to use as the root of the Docker runtime. Default is `/var/lib/docker`.
+
+**--icc**=*true*|*false*
+  Enable inter\-container communication. Default is true.
+
+**--ip**=""
+  Default IP address to use when binding container ports. Default is `0.0.0.0`.
+
+**--iptables**=*true*|*false*
+  Disable Docker's addition of iptables rules. Default is true.
+
+**--mtu**=VALUE
+  Set the containers network mtu. Default is `1500`.
+
+**-p**=""
+  Path to use for daemon PID file. Default is `/var/run/docker.pid`
+
+**-r**=*true*|*false*
+  Restart previously running containers. Default is true.
+
+**-s**=""
+  Force the Docker runtime to use a specific storage driver.
+
+=======
+>>>>>>> af6ac83... Use docker daemon command instead of -d
 **-v**=*true*|*false*
   Print version information and quit. Default is false.
-
-**--selinux-enabled**=*true*|*false*
-  Enable selinux support. Default is false. SELinux does not presently support the BTRFS storage driver.
 
 # COMMANDS
 **docker-attach(1)**
@@ -96,9 +139,16 @@ unix://[/path/to/socket] to use.
 **docker-cp(1)**
   Copy files/folders from a container's filesystem to the host at path
 
+<<<<<<< HEAD
 **docker-create(1)**
   Create a new container
 
+||||||| parent of af6ac83... Use docker daemon command instead of -d
+=======
+**docker-daemon(1)**
+  Enable Daemon Mode
+
+>>>>>>> af6ac83... Use docker daemon command instead of -d
 **docker-diff(1)**
   Inspect changes on a container's filesystem
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -49,7 +49,7 @@ expect an integer, and they can only be specified once.
 
 ## daemon
 
-    Usage: docker [OPTIONS] COMMAND [arg...]
+    Usage: docker daemon [OPTIONS]
 
     A self-sufficient runtime for linux containers.
 
@@ -93,20 +93,20 @@ Options with [] may be specified multiple times.
 
 The Docker daemon is the persistent process that manages containers.
 Docker uses the same binary for both the daemon and client. To run the
-daemon you provide the `-d` flag.
+daemon you provide the daemon command.
 
 To force Docker to use devicemapper as the storage driver, use
-`docker -d -s devicemapper`.
+`docker daemon -s devicemapper`.
 
 To set the DNS server for all Docker containers, use
-`docker -d --dns 8.8.8.8`.
+`docker daemon --dns 8.8.8.8`.
 
 To set the DNS search domain for all Docker containers, use
-`docker -d --dns-search example.com`.
+`docker daemon --dns-search example.com`.
 
-To run the daemon with debug output, use `docker -d -D`.
+To run the daemon with debug output, use `docker daemon -D`.
 
-To use lxc as the execution driver, use `docker -d -e lxc`.
+To use lxc as the execution driver, use `docker daemon -e lxc`.
 
 The docker client will also honor the `DOCKER_HOST` environment variable to set
 the `-H` flag for the client.
@@ -123,8 +123,8 @@ can be disabled with --ip-masq=false.
 
 To run the daemon with [systemd socket activation](
 http://0pointer.de/blog/projects/socket-activation.html), use
-`docker -d -H fd://`. Using `fd://` will work perfectly for most setups but
-you can also specify individual sockets too `docker -d -H fd://3`. If the
+`docker daemon -H fd://`. Using `fd://` will work perfectly for most setups but
+you can also specify individual sockets too `docker daemon -H fd://3`. If the
 specified socket activated files aren't found then docker will exit. You
 can find examples of using systemd socket activation with docker and
 systemd in the [docker source tree](
@@ -133,10 +133,10 @@ https://github.com/docker/docker/tree/master/contrib/init/systemd/).
 Docker supports softlinks for the Docker data directory
 (`/var/lib/docker`) and for `/var/lib/docker/tmp`. The `DOCKER_TMPDIR` and the data directory can be set like this:
 
-    DOCKER_TMPDIR=/mnt/disk2/tmp /usr/local/bin/docker -d -D -g /var/lib/docker -H unix:// > /var/lib/boot2docker/docker.log 2>&1
+    TMPDIR=/mnt/disk2/tmp /usr/local/bin/docker daemon -D -g /var/lib/docker -H unix:// > /var/lib/boot2docker/docker.log 2>&1
     # or
     export DOCKER_TMPDIR=/mnt/disk2/tmp
-    /usr/local/bin/docker -d -D -g /var/lib/docker -H unix:// > /var/lib/boot2docker/docker.log 2>&1
+    /usr/local/bin/docker daemon -D -g /var/lib/docker -H unix:// > /var/lib/boot2docker/docker.log 2>&1
 
 ## attach
 


### PR DESCRIPTION
QE Reports that you can put lots of bogus options on the cli before the command
which are ignored if you specify a command.  We should report a usage error
if a user does this.

I believe a better long term solution would be to remove the -d options and add a daemon command.  This would make the handling of options the same for all use
cases.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
