### PR TITLE
ADD - extract only files with tarball extensions

### DIFF
--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -439,8 +439,11 @@ func (b *buildFile) addContext(container *daemon.Container, orig, dest string, r
 		return copyAsDirectory(origPath, destPath, destExists)
 	}
 
+	// extract only tarballs with known extensions
+	tarballExtensions := []string{".tar", ".tgz", ".tbz2", ".tar.gz", ".tar.bz2", ".tar.xz", ".txz"}
 	// If we are adding a remote file, do not try to untar it
-	if !remote {
+	// Attempt to extract only files with valid tarball suffixes
+	if !remote && utils.HasSuffixFromArray(orig, tarballExtensions) {
 		// First try to unpack the source as an archive
 		// to support the untar feature we need to clean up the path a little bit
 		// because tar is very forgiving.  First we need to strip off the archive's

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1088,3 +1088,14 @@ func ValidateContextDirectory(srcPath string) error {
 	})
 	return finalError
 }
+
+// HasSuffixFromArray checks if a string has a suffix from an array and
+// returns true if it does
+func HasSuffixFromArray(s string, suffixes []string) bool {
+	for _, val := range suffixes {
+		if strings.HasSuffix(s, val) {
+			return true
+		}
+	}
+	return false
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -493,3 +493,14 @@ func TestReadSymlinkedDirectoryToFile(t *testing.T) {
 		t.Errorf("failed to remove symlink: %s", err)
 	}
 }
+
+func TestHasSuffixFromArray(t *testing.T) {
+	suffixes := []string{".foo", ".bar.baz", ".boo"}
+	if !HasSuffixFromArray("blah.foo", suffixes) {
+		t.Fatalf("HasSuffixArray should have returned true")
+	}
+	if HasSuffixFromArray("blah.baz", suffixes) {
+		t.Fatalf("HasSuffixArray shouldn't have returned false")
+	}
+
+}


### PR DESCRIPTION
This makes `docker build` try to extract tarballs when ADDing a file only if the file has one of the known tarball extensions.

Fixes #5935
