### PR TITLE
Fix race condition in CLI tests: diff was not acquiring a container lock

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -672,6 +672,8 @@ func (container *Container) Mount() error {
 }
 
 func (container *Container) Changes() ([]archive.Change, error) {
+	container.Lock()
+	defer container.Unlock()
 	return container.daemon.Changes(container)
 }
 


### PR DESCRIPTION
The diff tests in the CLI could execute before the container started, ending up in a diff that contains some of the metadata docker peppers in the container on start.

This adds a lock around the changes job which conflicts with the lock in Start() and thusly avoids this issue.
