### PR TITLE
improve numeric only id detection

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -514,7 +514,7 @@ func GenerateRandomID() string {
 		// if we try to parse the truncated for as an int and we don't have
 		// an error then the value is all numberic and causes issues when
 		// used as a hostname. ref #3869
-		if _, err := strconv.Atoi(TruncateID(value)); err == nil {
+		if _, err := strconv.ParseInt(TruncateID(value), 10, 64); err == nil {
 			continue
 		}
 		return value


### PR DESCRIPTION
We used `strconv.Atoi` to see if the truncated (12 first chars) on the ID was numeric only.

It works only for small numbers like `strconv.Atoi(001456718841)` won't return any error, so this mean is't a number and we retry generation an ID.

The issue is with big numbers like `strconv.Atoi(901456718841)` will return an error, because it can't fit inside an int, but we will consider it's not a number.

We should make sure it can't fit into an `int64`.

I believe it'll fix #4557
