### PR TITLE
Add a 'docker fingerprint' command for signing images

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -60,6 +60,7 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 		{"diff", "Inspect changes on a container's filesystem"},
 		{"events", "Get real time events from the server"},
 		{"export", "Stream the contents of a container as a tar archive"},
+		{"fingerprint", "Show an image fingerprint for signing"},
 		{"history", "Show the history of an image"},
 		{"images", "List images"},
 		{"import", "Create a new filesystem image from the contents of a tarball"},
@@ -920,6 +921,31 @@ func (cli *DockerCli) CmdRmi(args ...string) error {
 		}
 	}
 	return encounteredError
+}
+
+func (cli *DockerCli) CmdFingerprint(args ...string) error {
+	cmd := cli.Subcmd("fingerprint", "IMAGE", "Show the image fingerprint")
+
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+
+	if cmd.NArg() != 1 {
+		cmd.Usage()
+		return nil
+	}
+
+	body, _, err := readBody(cli.call("GET", "/images/"+cmd.Arg(0)+"/fingerprint", nil, false))
+	if err != nil {
+		return err
+	}
+
+	_, err := cli.out.Write(body)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (cli *DockerCli) CmdHistory(args ...string) error {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -283,6 +283,20 @@ func getEvents(eng *engine.Engine, version version.Version, w http.ResponseWrite
 	return job.Run()
 }
 
+func getImagesFingerprint(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if vars == nil {
+		return fmt.Errorf("Missing parameter")
+	}
+
+	var job = eng.Job("fingerprint", vars["name"])
+	streamJSON(job, w, false)
+
+	if err := job.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func getImagesHistory(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -1092,6 +1106,7 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 			"/images/viz":                     getImagesViz,
 			"/images/search":                  getImagesSearch,
 			"/images/{name:.*}/get":           getImagesGet,
+			"/images/{name:.*}/fingerprint":   getImagesFingerprint,
 			"/images/{name:.*}/history":       getImagesHistory,
 			"/images/{name:.*}/json":          getImagesByName,
 			"/containers/ps":                  getContainersJSON,

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -260,6 +260,11 @@ _docker_help()
 	fi
 }
 
+_docker_fingerprint()
+{
+	__docker_image_repos_and_tags_and_ids
+}
+
 _docker_history()
 {
 	case "$cur" in
@@ -630,6 +635,7 @@ _docker()
 			diff
 			events
 			export
+			fingerprint
 			history
 			images
 			import

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -16,7 +16,7 @@
 
 function __fish_docker_no_subcommand --description 'Test if docker has yet to be given the subcommand'
     for i in (commandline -opc)
-        if contains -- $i attach build commit cp diff events export history images import info insert inspect kill load login logs port ps pull push restart rm rmi run save search start stop tag top version wait
+        if contains -- $i attach build commit cp diff events export fingerprint history images import info insert inspect kill load login logs port ps pull push restart rm rmi run save search start stop tag top version wait
             return 1
         end
     end
@@ -98,6 +98,10 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from events' -l since -d 'Sh
 # export
 complete -c docker -f -n '__fish_docker_no_subcommand' -a export -d 'Stream the contents of a container as a tar archive'
 complete -c docker -A -f -n '__fish_seen_subcommand_from export' -a '(__fish_print_docker_containers all)' -d "Container"
+
+# fingerprint
+complete -c docker -f -n '__fish_docker_no_subcommand' -a fingerprint -d 'Show the image fingerprint'
+complete -c docker -A -f -n '__fish_seen_subcommand_from fingerprint' -a '(__fish_print_docker_images)' -d "Image"
 
 # history
 complete -c docker -f -n '__fish_docker_no_subcommand' -a history -d 'Show the history of an image'

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -125,6 +125,9 @@ __docker_subcommand () {
         (diff|export|logs)
             _arguments '*:containers:__docker_containers'
             ;;
+        (fingerprint)
+            _arguments ':images:__docker_images'
+            ;;
         (history)
             _arguments '*:images:__docker_images'
             ;;

--- a/contrib/man/md/docker-fingerprint.1.md
+++ b/contrib/man/md/docker-fingerprint.1.md
@@ -1,0 +1,40 @@
+% DOCKER(1) Docker User Manuals
+% W. Trevor King
+% MAY 2014
+# NAME
+docker-fingerprint - Show the fingerprint of an image
+
+# SYNOPSIS
+**docker fingerprint** IMAGE
+
+# DESCRIPTION
+
+Show the fingerprint of an image.  You can use this fingerprint for
+signing images, and for verifying signatures made by others.  The
+format of a fingerprint is:
+
+    <namespace>/<name>:<tag>
+    <metadata>
+    <tarsum>
+
+signing the fingerprint asserts that that `<namespace>/<name>:<tag>`
+name applies to the image with that metadata and tarsum.
+
+# EXAMPLE
+
+Sign with:
+
+    $ docker fingerprint debian:7.4 | gpg --detach-sign --armor > debian-7.4.sig
+
+After transmitting the detached signature and image layers however you
+like (possibly through insecure channels), you can verify the
+signature with:
+
+    $ docker fingerprint debian:7.4 | gpg --verify debian-7.4.sig -
+
+which will use your web of trust to verify the image.
+
+# HISTORY
+
+May 2014.  Originally compiled by W. Trevor King (wking at
+tremily.us).

--- a/docs/man/README.md
+++ b/docs/man/README.md
@@ -15,6 +15,7 @@ Markdown (*.md) files.
     docker-diff.md
     docker-events.md
     docker-export.md
+    docker-fingerprint.md
     docker-history.md
     docker-images.md
     docker-import.md

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -99,6 +99,9 @@ unix://[/path/to/socket] to use.
 **docker-export(1)**
   Stream the contents of a container as a tar archive
 
+**docker-fingerprint(1)**
+  Show the fingerprint of an image
+
 **docker-history(1)**
   Show the history of an image
 

--- a/docs/sources/http-routingtable.md
+++ b/docs/sources/http-routingtable.md
@@ -55,6 +55,7 @@
      [`GET /images/(format)`](../reference/api/archive/docker_remote_api_v1.6/#get--images-(format))                                                               **
      [`DELETE /images/(name)`](../reference/api/docker_remote_api_v1.9/#delete--images-(name))                                                                     **
      [`GET /images/(name)/get`](../reference/api/docker_remote_api_v1.9/#get--images-(name)-get)                                                                   **
+     [`GET /images/(name)/fingerprint`](../reference/api/docker_remote_api_v1.9/#get--images-(name)-fingerprint)                                                   **
      [`GET /images/(name)/history`](../reference/api/docker_remote_api_v1.9/#get--images-(name)-history)                                                           **
      [`POST /images/(name)/insert`](../reference/api/docker_remote_api_v1.9/#post--images-(name)-insert)                                                           **
      [`GET /images/(name)/json`](../reference/api/docker_remote_api_v1.9/#get--images-(name)-json)                                                                 **

--- a/docs/sources/reference/api/docker_remote_api_v1.11.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.11.md
@@ -807,6 +807,40 @@ Return low-level information on the image `name`
     -   **404** – no such image
     -   **500** – server error
 
+### Get the fingerprint of an image
+
+`GET /images/(name)/fingerprint`
+
+Return the fingerprint of the image `name`
+
+    **Example request**:
+
+        GET /images/debian/fingerprint HTTP/1.1
+
+    **Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+             {
+                     "Id":"b750fe79269d",
+                     "Created":1364102658,
+                     "CreatedBy":"/bin/bash"
+             },
+             {
+                     "Id":"27cf78414709",
+                     "Created":1364068391,
+                     "CreatedBy":""
+             }
+        ]
+
+    Status Codes:
+
+    -   **200** – no error
+    -   **404** – no such image
+    -   **500** – server error
+
 ### Get the history of an image
 
 `GET /images/(name)/history`

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -454,6 +454,33 @@ For example:
 
     $ sudo docker export red_panda > latest.tar
 
+## fingerprint
+
+    Usage: docker fingerprint IMAGE
+
+    Show the fingerprint an image
+
+You can use this fingerprint for signing images, and for verifying
+signatures made by others.  The format of a fingerprint is:
+
+    <namespace>/<name>:<tag>
+    <metadata>
+    <tarsum>
+
+signing the fingerprint asserts that that `<namespace>/<name>:<tag>`
+name applies to the image with that metadata and tarsum.  You can sign
+with:
+
+    $ docker fingerprint debian:7.4 | gpg --detach-sign --armor > debian-7.4.sig 
+
+After transmitting the detached signature and image layers however you
+like (possibly through insecure channels), you can verify the
+signature with:
+
+    $ docker fingerprint debian:7.4 | gpg --verify debian-7.4.sig -
+
+which will use your web of trust to verify the image.
+
 ## history
 
     Usage: docker history [OPTIONS] IMAGE

--- a/fingerprint/fingerprint.go
+++ b/fingerprint/fingerprint.go
@@ -1,0 +1,22 @@
+package fingerprint
+
+import (
+	"github.com/dotcloud/docker/image"
+	"github.com/dotcloud/docker/utils"
+)
+
+type Fingerprint struct {
+	name            string            `json:"name"`
+	metadata        *Image            `json:"metadata"`
+	tarsum          string            `json:"tarsum"`
+}
+
+
+func getImageFingerprint(name string, img *image.Image) (fingerprint Fingerprint, error) {
+	fingerprint := Fingerprint{}
+	fingerprint.name = name
+	fingerprint.metadata = img
+	layer := img.TarLayer()
+	fingerprint.tarsum = layer.tarsum
+	return fingerprint, nil
+}

--- a/fingerprint/service.go
+++ b/fingerprint/service.go
@@ -1,0 +1,35 @@
+package fingerprint
+
+import (
+	"github.com/dotcloud/docker/engine"
+	"github.com/dotcloud/docker/graph"
+)
+
+func (s *graph.TagStore) Install(eng *engine.Engine) error {
+	eng.Register("image_fingerprint", s.CmdFingerprint)
+	return nil
+}
+
+func (s *graph.TagStore) CmdFingerprint(job *engine.Job) engine.Status {
+	if n := len(job.Args); n != 1 {
+		return job.Errorf("Usage: %s IMAGE", job.Name)
+	}
+	name := job.Args[0]
+
+	foundImage, err := s.LookupImage(name)
+	if err != nil {
+		return job.Error(err)
+	}
+
+	_, err := fmt.Fprintf(job.Stdout, "%s\n", name)
+	if err != nill {
+		return job.Error(err)
+	}
+
+	_, err := fmt.Fprintf(job.Stdout, "%s\n", img.ID)
+	if err != nill {
+		return job.Error(err)
+	}
+
+	return engine.StatusOK
+}

--- a/server/server.go
+++ b/server/server.go
@@ -137,6 +137,7 @@ func InitServer(job *engine.Job) engine.Status {
 		"container_delete": srv.ContainerDestroy,
 		"image_export":     srv.ImageExport,
 		"images":           srv.Images,
+		"fingerprint":      srv.ImageFingerprint,
 		"history":          srv.ImageHistory,
 		"viz":              srv.ImagesViz,
 		"container_copy":   srv.ContainerCopy,


### PR DESCRIPTION
The "should we do this" discussion starts in #2700 [1](where it still
hasn't reached a consensus).  The goal here is to implement:

```
 $ docker fingerprint <namespace>/<name>[:<tag>]
 <namespace>/<name>:<tag>
 <metadata>
 <own tarsums> 
```

The tarsum should be the tarsum of the assembled image (squashing all
layers), not the tarsum of the tip layer.

The current implementation is a work in progress.  I'm still not clear
on how the whole server/job API is supposed to get wired together, and
have been basically pattern-matching off 'git grep -i history'.  I'm
posting the WIP branch because I won't have time to work on it for the
next few days, and wanted to open it up in case anyone else wanted to
chip in.

https://github.com/dotcloud/docker/issues/2700#issuecomment-42474265
