### PR TITLE
Adds HOSTNAME env value, if set, to /etc/hosts extra

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -383,6 +383,13 @@ func (container *Container) buildHostnameAndHostsFiles(IP string) error {
 		extraContent[alias] = child.NetworkSettings.IPAddress
 	}
 
+	for _, e := range container.Config.Env {
+		parts := strings.SplitN(e, "=", 2)
+		if parts[0] == "HOSTNAME" {
+			extraContent[parts[1]] = container.NetworkSettings.IPAddress
+		}
+	}
+
 	return etchosts.Build(container.HostsPath, IP, container.Config.Hostname, container.Config.Domainname, &extraContent)
 }
 


### PR DESCRIPTION
When a user sets HOSTNAME environment var, that can be accessed via $(hostname) (that is common, and works now),
however, it is not a resolvable hostname.

This adds the HOSTNAME value, if it appears, to the /etc/hosts extras section (with the network IP address) so that it will resolve, should anyone need it.
(I needed it). Does not interfere with -h or any other options.

Docker-DCO-1.1-Signed-off-by: Michael Neale michael.neale@gmail.com (github: michaelneale)
