### PR TITLE
Change 'Uploading context' wording

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -172,9 +172,9 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	// FIXME: ProgressReader shouldn't be this annoying to use
 	if context != nil {
 		sf := utils.NewStreamFormatter(false)
-		body = utils.ProgressReader(context, 0, cli.err, sf, true, "", "Uploading context")
+		body = utils.ProgressReader(context, 0, cli.err, sf, true, "", "Sending build context to Docker daemon")
 	}
-	// Upload the build context
+	// Send the build context
 	v := &url.Values{}
 
 	//Check if the given image name can be resolved

--- a/contrib/man/md/Dockerfile.5.md
+++ b/contrib/man/md/Dockerfile.5.md
@@ -34,7 +34,7 @@ A Dockerfile is similar to a Makefile.
     The path to the source repository defines where to find the context of the
     build. The build is run by the docker daemon, not the CLI. The whole 
     context must be transferred to the daemon. The Docker CLI reports 
-    "Uploading context" when the context is sent to the daemon.
+    "Sending build context to Docker daemon" when the context is sent to the daemon.
     
 **sudo docker build -t repository/tag .**
  -- specifies a repository and tag at which to save the new image if the build 

--- a/contrib/man/md/docker-build.1.md
+++ b/contrib/man/md/docker-build.1.md
@@ -17,7 +17,7 @@ be used by **ADD** commands found within the Dockerfile.
 Warning, this will send a lot of data to the Docker daemon depending
 on the contents of the current directory. The build is run by the Docker 
 daemon, not by the CLI, so the whole context must be transferred to the daemon. 
-The Docker CLI reports "Uploading context" when the context is sent to 
+The Docker CLI reports "Sending build context to Docker daemon" when the context is sent to 
 the daemon.
 
 When a single Dockerfile is given as the URL, then no context is set.

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -23,7 +23,7 @@ Then call `docker build` with the path of you source repository as argument
 The path to the source repository defines where to find the *context* of
 the build. The build is run by the Docker daemon, not by the CLI, so the
 whole context must be transferred to the daemon. The Docker CLI reports
-"Uploading context" when the context is sent to the daemon.
+"Sending build context to Docker daemon" when the context is sent to the daemon.
 
 You can specify a repository and tag at which to save the new image if
 the build succeeds:

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -259,7 +259,7 @@ happens at the client side (where you're running
 
 The transfer of context from the local machine to the Docker daemon is
 what the `docker` client means when you see the
-"Uploading context" message.
+"Sending build context" message.
 
 If you wish to keep the intermediate containers after the build is
 complete, you must use `--rm=false`. This does not


### PR DESCRIPTION
This changes the wording in the docker build output from "Uploading context" to the less ambiguous "Sending build context to docker daemon". As discussed in #2342, "Uploading" has negative connotations when the daemon is running locally and what is being sent isn't altogether clear from output alone. Fixes #2342

Docker-DCO-1.1-Signed-off-by: Ryan Stelly ryan.stelly@live.com (github: FLGMwt)
