### PR TITLE
SETUID/SETGID not required for changing user

### DIFF
--- a/pkg/libcontainer/security/capabilities/capabilities.go
+++ b/pkg/libcontainer/security/capabilities/capabilities.go
@@ -9,6 +9,25 @@ import (
 
 const allCapabilityTypes = capability.CAPS | capability.BOUNDS
 
+// DropBoundingSet drops the capability bounding set to those specified in the
+// container configuration.
+func DropBoundingSet(container *libcontainer.Container) error {
+	c, err := capability.NewPid(os.Getpid())
+	if err != nil {
+		return err
+	}
+
+	keep := getEnabledCapabilities(container)
+	c.Clear(capability.BOUNDS)
+	c.Set(capability.BOUNDS, keep...)
+
+	if err := c.Apply(capability.BOUNDS); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // DropCapabilities drops all capabilities for the current process expect those specified in the container configuration.
 func DropCapabilities(container *libcontainer.Container) error {
 	c, err := capability.NewPid(os.Getpid())

--- a/pkg/system/calls_linux.go
+++ b/pkg/system/calls_linux.go
@@ -135,6 +135,22 @@ func GetParentDeathSignal() (int, error) {
 	return sig, nil
 }
 
+func SetKeepCaps() error {
+	if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_SET_KEEPCAPS, 1, 0); err != 0 {
+		return err
+	}
+
+	return nil
+}
+
+func ClearKeepCaps() error {
+	if _, _, err := syscall.RawSyscall(syscall.SYS_PRCTL, syscall.PR_SET_KEEPCAPS, 0, 0); err != 0 {
+		return err
+	}
+
+	return nil
+}
+
 func Setctty() error {
 	if _, _, err := syscall.RawSyscall(syscall.SYS_IOCTL, 0, uintptr(syscall.TIOCSCTTY), 0); err != 0 {
 		return err


### PR DESCRIPTION
With this changeset, providing a user in container configuration does not require that you also grant SETUID and SETGID capabilities to the contained process.

It accomplishes this by:
- dropping the bounding set while still fully privileged
- calling prctl(PR_SET_KEEPCAPS, 1), to preserve capabilities while changing users
- changing user (unchanged)
- calling prctl(PR_SET_KEEPCAPS, 0) to clear the setting
- dropping capabilities (unchanged)

---
### before

```
> grep capabilities container.json
  "capabilities": ["SETUID", "SETGID"],
> sudo nsinit exec /bin/grep Cap /proc/self/status
CapInh: 00000000000000c0
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapBnd: 00000000000000c0

> grep capabilities container.json
  "capabilities": [],
>  sudo nsinit exec /bin/grep Cap /proc/self/status
2014/05/28 15:00:43 unable to initialize for container: finalize namespace setup user setgroups operation not permitted
```
### after

```
> grep capabilities container.json
  "capabilities": ["SETUID", "SETGID"],
> sudo nsinit exec /bin/grep Cap /proc/self/status
CapInh: 00000000000000c0
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapBnd: 00000000000000c0

> grep capabilities container.json
  "capabilities": [],

> sudo nsinit exec /bin/grep Cap /proc/self/status
CapInh: 0000000000000000
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapBnd: 0000000000000000
```

Fixes #4556
