### PR TITLE
Add support for a --device flag. Refactor device handling code

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -295,7 +295,64 @@ func (container *Container) Start() (err error) {
 	}
 	container.waitLock = make(chan struct{})
 
+	if err := container.createDevices(); err != nil {
+		return err
+	}
+
 	return container.waitForStart()
+}
+
+func (container *Container) createDevices() error {
+	for _, device := range container.hostConfig.Devices {
+		src, dst, err := utils.ParseDevice(device)
+		if err != nil {
+			return err
+		}
+		dst = path.Join(container.RootfsPath(), dst)
+
+		stat, err := os.Stat(src)
+		if err != nil {
+			return err
+		}
+
+		devType := 'c'
+		mode := stat.Mode()
+		perm := os.FileMode.Perm(mode)
+		switch {
+		case (mode & os.ModeDevice) == 0:
+			return fmt.Errorf("%s is not a device", src)
+		case (mode & os.ModeCharDevice) != 0:
+			perm |= syscall.S_IFCHR
+		default:
+			perm |= syscall.S_IFBLK
+			devType = 'b'
+		}
+
+		devNumber := 0
+		sys, ok := stat.Sys().(*syscall.Stat_t)
+		if ok {
+			devNumber = int(sys.Rdev)
+		} else {
+			return fmt.Errorf("Cannot determine the device major and minor numbers")
+		}
+
+		oldMask := syscall.Umask(int(0))
+		if err := os.MkdirAll(path.Dir(dst), 0755); err != nil {
+			return err
+		}
+		if err := syscall.Mknod(dst, uint32(perm), devNumber); err != nil {
+			return err
+		}
+		syscall.Umask(oldMask)
+
+		devMajor := int64((devNumber >> 8) & 0xfff)
+		devMinor := int64((devNumber & 0xff) | ((devNumber >> 12) & 0xfff00))
+		if err := container.daemon.execDriver.AddDevice(container.command, devType, devMajor, devMinor); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (container *Container) Run() error {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dotcloud/docker/links"
 	"github.com/dotcloud/docker/nat"
 	"github.com/dotcloud/docker/pkg/label"
+	"github.com/dotcloud/docker/pkg/libcontainer/devices"
 	"github.com/dotcloud/docker/pkg/networkfs/etchosts"
 	"github.com/dotcloud/docker/pkg/networkfs/resolvconf"
 	"github.com/dotcloud/docker/pkg/symlink"
@@ -220,6 +221,25 @@ func populateCommand(c *Container, env []string) error {
 		return fmt.Errorf("invalid network mode: %s", c.hostConfig.NetworkMode)
 	}
 
+	// Build lists of devices allowed and created within the container.
+	userSpecifiedDevices := make([]devices.Device, len(c.hostConfig.Devices))
+	for i, thisDevice := range c.hostConfig.Devices {
+		src, dest, permissions, err := utils.ParseDevice(thisDevice)
+		if err != nil {
+			return err
+		}
+		device, err := devices.GetDevice(src, permissions)
+		device.Path = dest
+
+		if err != nil {
+			return err
+		}
+		userSpecifiedDevices[i] = device
+	}
+	allowedDevices := append(devices.DefaultAllowedDevices, userSpecifiedDevices...)
+
+	autoCreatedDevices := append(devices.DefaultAutoCreatedDevices, userSpecifiedDevices...)
+
 	// TODO: this can be removed after lxc-conf is fully deprecated
 	mergeLxcConfIntoOptions(c.hostConfig, context)
 
@@ -230,18 +250,20 @@ func populateCommand(c *Container, env []string) error {
 		Cpuset:     c.Config.Cpuset,
 	}
 	c.command = &execdriver.Command{
-		ID:         c.ID,
-		Privileged: c.hostConfig.Privileged,
-		Rootfs:     c.RootfsPath(),
-		InitPath:   "/.dockerinit",
-		Entrypoint: c.Path,
-		Arguments:  c.Args,
-		WorkingDir: c.Config.WorkingDir,
-		Network:    en,
-		Tty:        c.Config.Tty,
-		User:       c.Config.User,
-		Config:     context,
-		Resources:  resources,
+		ID:                 c.ID,
+		Privileged:         c.hostConfig.Privileged,
+		Rootfs:             c.RootfsPath(),
+		InitPath:           "/.dockerinit",
+		Entrypoint:         c.Path,
+		Arguments:          c.Args,
+		WorkingDir:         c.Config.WorkingDir,
+		Network:            en,
+		Tty:                c.Config.Tty,
+		User:               c.Config.User,
+		Config:             context,
+		Resources:          resources,
+		AllowedDevices:     allowedDevices,
+		AutoCreatedDevices: autoCreatedDevices,
 	}
 	c.command.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	c.command.Env = env
@@ -295,64 +317,7 @@ func (container *Container) Start() (err error) {
 	}
 	container.waitLock = make(chan struct{})
 
-	if err := container.createDevices(); err != nil {
-		return err
-	}
-
 	return container.waitForStart()
-}
-
-func (container *Container) createDevices() error {
-	for _, device := range container.hostConfig.Devices {
-		src, dst, err := utils.ParseDevice(device)
-		if err != nil {
-			return err
-		}
-		dst = path.Join(container.RootfsPath(), dst)
-
-		stat, err := os.Stat(src)
-		if err != nil {
-			return err
-		}
-
-		devType := 'c'
-		mode := stat.Mode()
-		perm := os.FileMode.Perm(mode)
-		switch {
-		case (mode & os.ModeDevice) == 0:
-			return fmt.Errorf("%s is not a device", src)
-		case (mode & os.ModeCharDevice) != 0:
-			perm |= syscall.S_IFCHR
-		default:
-			perm |= syscall.S_IFBLK
-			devType = 'b'
-		}
-
-		devNumber := 0
-		sys, ok := stat.Sys().(*syscall.Stat_t)
-		if ok {
-			devNumber = int(sys.Rdev)
-		} else {
-			return fmt.Errorf("Cannot determine the device major and minor numbers")
-		}
-
-		oldMask := syscall.Umask(int(0))
-		if err := os.MkdirAll(path.Dir(dst), 0755); err != nil {
-			return err
-		}
-		if err := syscall.Mknod(dst, uint32(perm), devNumber); err != nil {
-			return err
-		}
-		syscall.Umask(oldMask)
-
-		devMajor := int64((devNumber >> 8) & 0xfff)
-		devMinor := int64((devNumber & 0xff) | ((devNumber >> 12) & 0xfff00))
-		if err := container.daemon.execDriver.AddDevice(container.command, devType, devMajor, devMinor); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func (container *Container) Run() error {

--- a/daemon/execdriver/devices.go
+++ b/daemon/execdriver/devices.go
@@ -1,0 +1,10 @@
+package execdriver
+
+import (
+	"github.com/dotcloud/docker/pkg/libcontainer/devices"
+)
+
+var (
+	DefaultAllowedDevices     = devices.DefaultAllowedDevices
+	DefaultAutoCreatedDevices = devices.DefaultAutoCreatedDevices
+)

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -85,6 +85,7 @@ type Driver interface {
 	Info(id string) Info                          // "temporary" hack (until we move state from core to plugins)
 	GetPidsForContainer(id string) ([]int, error) // Returns a list of pids for the given container.
 	Terminate(c *Command) error                   // kill it with fire
+	AddDevice(c *Command, devType rune, devMajor int64, devMinor int64) error
 }
 
 // Network settings of the container

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"os"
 	"os/exec"
+
+	"github.com/dotcloud/docker/pkg/libcontainer/devices"
 )
 
 // Context is a generic key value pair that allows
@@ -85,7 +87,6 @@ type Driver interface {
 	Info(id string) Info                          // "temporary" hack (until we move state from core to plugins)
 	GetPidsForContainer(id string) ([]int, error) // Returns a list of pids for the given container.
 	Terminate(c *Command) error                   // kill it with fire
-	AddDevice(c *Command, devType rune, devMajor int64, devMinor int64) error
 }
 
 // Network settings of the container
@@ -121,20 +122,22 @@ type Mount struct {
 type Command struct {
 	exec.Cmd `json:"-"`
 
-	ID         string              `json:"id"`
-	Privileged bool                `json:"privileged"`
-	User       string              `json:"user"`
-	Rootfs     string              `json:"rootfs"`   // root fs of the container
-	InitPath   string              `json:"initpath"` // dockerinit
-	Entrypoint string              `json:"entrypoint"`
-	Arguments  []string            `json:"arguments"`
-	WorkingDir string              `json:"working_dir"`
-	ConfigPath string              `json:"config_path"` // this should be able to be removed when the lxc template is moved into the driver
-	Tty        bool                `json:"tty"`
-	Network    *Network            `json:"network"`
-	Config     map[string][]string `json:"config"` //  generic values that specific drivers can consume
-	Resources  *Resources          `json:"resources"`
-	Mounts     []Mount             `json:"mounts"`
+	ID                 string              `json:"id"`
+	Privileged         bool                `json:"privileged"`
+	User               string              `json:"user"`
+	Rootfs             string              `json:"rootfs"`   // root fs of the container
+	InitPath           string              `json:"initpath"` // dockerinit
+	Entrypoint         string              `json:"entrypoint"`
+	Arguments          []string            `json:"arguments"`
+	WorkingDir         string              `json:"working_dir"`
+	ConfigPath         string              `json:"config_path"` // this should be able to be removed when the lxc template is moved into the driver
+	Tty                bool                `json:"tty"`
+	Network            *Network            `json:"network"`
+	Config             map[string][]string `json:"config"` //  generic values that specific drivers can consume
+	Resources          *Resources          `json:"resources"`
+	Mounts             []Mount             `json:"mounts"`
+	AllowedDevices     []devices.Device    `json:"allowed_devices"`
+	AutoCreatedDevices []devices.Device    `json:"autocreated_devices"`
 
 	Terminal     Terminal `json:"-"`             // standard or tty terminal
 	Console      string   `json:"-"`             // dev/console path

--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -82,6 +82,13 @@ func (d *driver) Name() string {
 	return fmt.Sprintf("%s-%s", DriverName, version)
 }
 
+func (d *driver) AddDevice(c *execdriver.Command, devType rune, devMajor int64, devMinor int64) error {
+	c.Config["lxc"] = append(c.Config["lxc"], fmt.Sprintf("cgroup.devices.allow = %c %d:%d rwm",
+		devType, devMajor, devMinor))
+
+	return nil
+}
+
 func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
 	if err := execdriver.SetTerminal(c, pipes); err != nil {
 		return -1, err

--- a/daemon/execdriver/lxc/lxc_template.go
+++ b/daemon/execdriver/lxc/lxc_template.go
@@ -1,11 +1,13 @@
 package lxc
 
 import (
+	"fmt"
 	"strings"
 	"text/template"
 
 	"github.com/dotcloud/docker/daemon/execdriver"
 	"github.com/dotcloud/docker/pkg/label"
+	"github.com/dotcloud/docker/pkg/libcontainer/devices"
 )
 
 const LxcTemplate = `
@@ -48,36 +50,14 @@ lxc.cgroup.devices.allow = a
 # no implicit access to devices
 lxc.cgroup.devices.deny = a
 
-# but allow mknod for any device
-lxc.cgroup.devices.allow = c *:* m
-lxc.cgroup.devices.allow = b *:* m
+#Allow the devices passed to us in the AllowedDevices list.
 
-# /dev/null and zero
-lxc.cgroup.devices.allow = c 1:3 rwm
-lxc.cgroup.devices.allow = c 1:5 rwm
+{{range $allowedDevice := .AllowedDevices}}
 
-# consoles
-lxc.cgroup.devices.allow = c 5:1 rwm
-lxc.cgroup.devices.allow = c 5:0 rwm
-lxc.cgroup.devices.allow = c 4:0 rwm
-lxc.cgroup.devices.allow = c 4:1 rwm
+lxc.cgroup.devices.allow = {{runeToString $allowedDevice.Type}} {{getDeviceNumberString $allowedDevice.MajorNumber}}:{{getDeviceNumberString $allowedDevice.MinorNumber}} {{$allowedDevice.CgroupPermissions}}
 
-# /dev/urandom,/dev/random
-lxc.cgroup.devices.allow = c 1:9 rwm
-lxc.cgroup.devices.allow = c 1:8 rwm
+{{end}}
 
-# /dev/pts/ - pts namespaces are "coming soon"
-lxc.cgroup.devices.allow = c 136:* rwm
-lxc.cgroup.devices.allow = c 5:2 rwm
-
-# tuntap
-lxc.cgroup.devices.allow = c 10:200 rwm
-
-# fuse
-#lxc.cgroup.devices.allow = c 10:229 rwm
-
-# rtc
-#lxc.cgroup.devices.allow = c 254:0 rwm
 {{end}}
 
 # standard mount point
@@ -168,12 +148,18 @@ func getLabel(c map[string][]string, name string) string {
 	return ""
 }
 
+func runeToString(rune rune) string {
+	return fmt.Sprintf("%c", rune)
+}
+
 func init() {
 	var err error
 	funcMap := template.FuncMap{
-		"getMemorySwap":     getMemorySwap,
-		"escapeFstabSpaces": escapeFstabSpaces,
-		"formatMountLabel":  label.FormatMountLabel,
+		"getMemorySwap":         getMemorySwap,
+		"escapeFstabSpaces":     escapeFstabSpaces,
+		"formatMountLabel":      label.FormatMountLabel,
+		"getDeviceNumberString": devices.GetDeviceNumberString,
+		"runeToString":          runeToString,
 	}
 	LxcTemplateCompiled, err = template.New("lxc").Funcs(funcMap).Parse(LxcTemplate)
 	if err != nil {

--- a/daemon/execdriver/lxc/lxc_template_unit_test.go
+++ b/daemon/execdriver/lxc/lxc_template_unit_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/dotcloud/docker/pkg/libcontainer/devices"
 )
 
 func TestLXCConfig(t *testing.T) {
@@ -47,6 +49,7 @@ func TestLXCConfig(t *testing.T) {
 			Mtu:       1500,
 			Interface: nil,
 		},
+		AllowedDevices: make([]devices.Device, 0),
 	}
 	p, err := driver.generateLXCConfig(command)
 	if err != nil {

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dotcloud/docker/daemon/execdriver/native/template"
 	"github.com/dotcloud/docker/pkg/apparmor"
 	"github.com/dotcloud/docker/pkg/libcontainer"
-	"github.com/dotcloud/docker/pkg/libcontainer/mount/nodes"
 )
 
 // createContainer populates and configures the container type with the
@@ -25,6 +24,8 @@ func (d *driver) createContainer(c *execdriver.Command) (*libcontainer.Container
 	container.WorkingDir = c.WorkingDir
 	container.Env = c.Env
 	container.Cgroups.Name = c.ID
+	container.Cgroups.AllowedDevices = c.AllowedDevices
+	container.DeviceNodes = c.AutoCreatedDevices
 	// check to see if we are running in ramdisk to disable pivot root
 	container.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""
 	container.Context["restrictions"] = "true"
@@ -105,14 +106,13 @@ func (d *driver) createNetwork(container *libcontainer.Container, c *execdriver.
 
 func (d *driver) setPrivileged(container *libcontainer.Container) (err error) {
 	container.Capabilities = libcontainer.GetAllCapabilities()
-	container.Cgroups.DeviceAccess = true
+	container.Cgroups.UnlimitedDeviceAccess = true
 
 	delete(container.Context, "restrictions")
 
-	container.OptionalDeviceNodes = nil
-	if container.RequiredDeviceNodes, err = nodes.GetHostDeviceNodes(); err != nil {
+	/*	if container.DeviceNodes, err = nodes.GetHostDeviceNodes(); err != nil {
 		return err
-	}
+	}*/
 
 	if apparmor.IsEnabled() {
 		container.Context["apparmor_profile"] = "unconfined"

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -81,6 +81,10 @@ func NewDriver(root, initPath string) (*driver, error) {
 	}, nil
 }
 
+func (d *driver) AddDevice(c *execdriver.Command, devType rune, devMajor int64, devMinor int64) error {
+	return nil
+}
+
 func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
 	// take the Command and populate the libcontainer.Container from it
 	container, err := d.createContainer(c)

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -81,10 +81,6 @@ func NewDriver(root, initPath string) (*driver, error) {
 	}, nil
 }
 
-func (d *driver) AddDevice(c *execdriver.Command, devType rune, devMajor int64, devMinor int64) error {
-	return nil
-}
-
 func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
 	// take the Command and populate the libcontainer.Container from it
 	container, err := d.createContainer(c)

--- a/daemon/execdriver/native/template/default_template.go
+++ b/daemon/execdriver/native/template/default_template.go
@@ -4,7 +4,6 @@ import (
 	"github.com/dotcloud/docker/pkg/apparmor"
 	"github.com/dotcloud/docker/pkg/libcontainer"
 	"github.com/dotcloud/docker/pkg/libcontainer/cgroups"
-	"github.com/dotcloud/docker/pkg/libcontainer/mount/nodes"
 )
 
 // New returns the docker default configuration for libcontainer
@@ -30,12 +29,10 @@ func New() *libcontainer.Container {
 			"NEWNET": true,
 		},
 		Cgroups: &cgroups.Cgroup{
-			Parent:       "docker",
-			DeviceAccess: false,
+			Parent:                "docker",
+			UnlimitedDeviceAccess: false,
 		},
-		Context:             libcontainer.Context{},
-		RequiredDeviceNodes: nodes.DefaultNodes,
-		OptionalDeviceNodes: []string{"/dev/fuse"},
+		Context: libcontainer.Context{},
 	}
 	if apparmor.IsEnabled() {
 		container.Context["apparmor_profile"] = "docker-default"

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -852,6 +852,7 @@ removed before the image is removed.
       -u, --user=""              Username or UID
       -v, --volume=[]            Bind mount a volume (e.g. from the host: -v /host:/container, from docker: -v /container)
       --volumes-from=[]          Mount volumes from the specified container(s)
+      --device=[]                Add a host device to the container (e.g. --device=/dev/sdc[:/dev/xvdc])
       -w, --workdir=""           Working directory inside the container
 
 The `docker run` command first `creates` a writeable container layer over the
@@ -1030,7 +1031,17 @@ logs could be retrieved using `docker logs`. This is
 useful if you need to pipe a file or something else into a container and
 retrieve the container's ID once the container has finished running.
 
-**A complete example:**
+   $ sudo docker run --device=/dev/sdc:/dev/xvdc --device=/dev/sdd --device=/dev/zero:/dev/nulo -i -t ubuntu ls -l /dev/{xvdc,sdd,nulo}
+   brw-rw---- 1 root disk 8, 2 Feb  9 16:05 /dev/xvdc
+   brw-rw---- 1 root disk 8, 3 Feb  9 16:05 /dev/sdd
+   crw-rw-rw- 1 root root 1, 5 Feb  9 16:05 /dev/nulo
+
+It is often necessary to directly expose devices to a container.  ``--device``
+option enables that.  For example, a specific block storage device or loop
+device or audio device can be added to an otherwise 'unprivileged' container
+(without ``-privileged`` flag) and have the application directly access it.
+
+:A complete example:**
 
     $ sudo docker run -d --name static static-web-files sh
     $ sudo docker run -d --expose=8098 --name riak riakserver

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -852,7 +852,7 @@ removed before the image is removed.
       -u, --user=""              Username or UID
       -v, --volume=[]            Bind mount a volume (e.g. from the host: -v /host:/container, from docker: -v /container)
       --volumes-from=[]          Mount volumes from the specified container(s)
-      --device=[]                Add a host device to the container (e.g. --device=/dev/sdc[:/dev/xvdc])
+      --device=[]                Add a host device to the container (e.g. --device=/dev/sdc[:/dev/xvdc[:rwm]])
       -w, --workdir=""           Working directory inside the container
 
 The `docker run` command first `creates` a writeable container layer over the

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -836,7 +837,7 @@ func TestRunWithCpuset(t *testing.T) {
 	logDone("run - cpuset 0")
 }
 
-func TestDevice(t *testing.T) {
+func TestAddingOptionalDevices(t *testing.T) {
 	cmd := exec.Command(dockerBinary, "run", "--device", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "ls /dev/nulo")
 
 	out, _, err := runCommandWithOutput(cmd)
@@ -849,5 +850,42 @@ func TestDevice(t *testing.T) {
 	}
 	deleteAllContainers()
 
-	logDone("run - test device")
+	logDone("run - test --device argument")
+}
+
+func TestDeviceNumbers(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "busybox", "sh", "-c", "ls -l /dev/null")
+
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+	deviceLineFields := strings.Fields(out)
+	deviceLineFields[6] = ""
+	deviceLineFields[7] = ""
+	deviceLineFields[8] = ""
+	expected := []string{"crw-rw-rw-", "1", "root", "root", "1,", "3", "", "", "", "/dev/null"}
+
+	if !(reflect.DeepEqual(deviceLineFields, expected)) {
+		t.Fatalf("expected output\ncrw-rw-rw- 1 root root 1, 3 May 24 13:29 /dev/null\n received\n %s\n", out)
+	}
+	deleteAllContainers()
+
+	logDone("run - test device numbers")
+}
+
+func TestThatCharacterDevicesActLikeCharacterDevices(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "--device", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "dd if=/dev/zero of=/zero bs=1k count=5 2> /dev/null ; du -h /zero")
+
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	if actual := strings.Trim(out, "\r\n"); actual[0] == '0' {
+		t.Fatalf("expected a new file called /zero to be create that is greater than 0 bytes long, but du says: %s", actual)
+	}
+	deleteAllContainers()
+
+	logDone("run - test that character devices work.")
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -835,3 +835,19 @@ func TestRunWithCpuset(t *testing.T) {
 
 	logDone("run - cpuset 0")
 }
+
+func TestDevice(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "--device", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "ls /dev/nulo")
+
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	if actual := strings.Trim(out, "\r\n"); actual != "/dev/nulo" {
+		t.Fatalf("expected output /dev/nulo, received %s", actual)
+	}
+	deleteAllContainers()
+
+	logDone("run - test device")
+}

--- a/pkg/libcontainer/cgroups/cgroups.go
+++ b/pkg/libcontainer/cgroups/cgroups.go
@@ -2,6 +2,7 @@ package cgroups
 
 import (
 	"errors"
+	"github.com/dotcloud/docker/pkg/libcontainer/devices"
 )
 
 var (
@@ -10,17 +11,18 @@ var (
 
 type Cgroup struct {
 	Name   string `json:"name,omitempty"`
-	Parent string `json:"parent,omitempty"`
+	Parent string `json:"parent,omitempty"` // name of parent cgroup or slice
 
-	DeviceAccess      bool   `json:"device_access,omitempty"`      // name of parent cgroup or slice
-	Memory            int64  `json:"memory,omitempty"`             // Memory limit (in bytes)
-	MemoryReservation int64  `json:"memory_reservation,omitempty"` // Memory reservation or soft_limit (in bytes)
-	MemorySwap        int64  `json:"memory_swap,omitempty"`        // Total memory usage (memory + swap); set `-1' to disable swap
-	CpuShares         int64  `json:"cpu_shares,omitempty"`         // CPU shares (relative weight vs. other containers)
-	CpuQuota          int64  `json:"cpu_quota,omitempty"`          // CPU hardcap limit (in usecs). Allowed cpu time in a given period.
-	CpuPeriod         int64  `json:"cpu_period,omitempty"`         // CPU period to be used for hardcapping (in usecs). 0 to use system default.
-	CpusetCpus        string `json:"cpuset_cpus,omitempty"`        // CPU to use
-	Freezer           string `json:"freezer,omitempty"`            // set the freeze value for the process
+	UnlimitedDeviceAccess bool             `json:"unlimited_device_access,omitempty"` // If this is true allow access to any kind of device within the container.  If false, allow access only to devices explicitly listed in the allowed_devices list.
+	AllowedDevices        []devices.Device `json:"allowed_devices,omitempty"`
+	Memory                int64            `json:"memory,omitempty"`             // Memory limit (in bytes)
+	MemoryReservation     int64            `json:"memory_reservation,omitempty"` // Memory reservation or soft_limit (in bytes)
+	MemorySwap            int64            `json:"memory_swap,omitempty"`        // Total memory usage (memory + swap); set `-1' to disable swap
+	CpuShares             int64            `json:"cpu_shares,omitempty"`         // CPU shares (relative weight vs. other containers)
+	CpuQuota              int64            `json:"cpu_quota,omitempty"`          // CPU hardcap limit (in usecs). Allowed cpu time in a given period.
+	CpuPeriod             int64            `json:"cpu_period,omitempty"`         // CPU period to be used for hardcapping (in usecs). 0 to use system default.
+	CpusetCpus            string           `json:"cpuset_cpus,omitempty"`        // CPU to use
+	Freezer               string           `json:"freezer,omitempty"`            // set the freeze value for the process
 
 	Slice string `json:"slice,omitempty"` // Parent slice to use for systemd
 }

--- a/pkg/libcontainer/cgroups/fs/devices.go
+++ b/pkg/libcontainer/cgroups/fs/devices.go
@@ -1,5 +1,11 @@
 package fs
 
+import (
+	"fmt"
+
+	"github.com/dotcloud/docker/pkg/libcontainer/devices"
+)
+
 type devicesGroup struct {
 }
 
@@ -9,41 +15,14 @@ func (s *devicesGroup) Set(d *data) error {
 		return err
 	}
 
-	if !d.c.DeviceAccess {
+	if !d.c.UnlimitedDeviceAccess {
 		if err := writeFile(dir, "devices.deny", "a"); err != nil {
 			return err
 		}
 
-		allow := []string{
-			// allow mknod for any device
-			"c *:* m",
-			"b *:* m",
-
-			// /dev/null, zero, full
-			"c 1:3 rwm",
-			"c 1:5 rwm",
-			"c 1:7 rwm",
-
-			// consoles
-			"c 5:1 rwm",
-			"c 5:0 rwm",
-			"c 4:0 rwm",
-			"c 4:1 rwm",
-
-			// /dev/urandom,/dev/random
-			"c 1:9 rwm",
-			"c 1:8 rwm",
-
-			// /dev/pts/ - pts namespaces are "coming soon"
-			"c 136:* rwm",
-			"c 5:2 rwm",
-
-			// tuntap
-			"c 10:200 rwm",
-		}
-
-		for _, val := range allow {
-			if err := writeFile(dir, "devices.allow", val); err != nil {
+		for _, dev := range d.c.AllowedDevices {
+			deviceAllowString := fmt.Sprintf("%c %s:%s %s", dev.Type, devices.GetDeviceNumberString(dev.MajorNumber), devices.GetDeviceNumberString(dev.MinorNumber), dev.CgroupPermissions)
+			if err := writeFile(dir, "devices.allow", deviceAllowString); err != nil {
 				return err
 			}
 		}

--- a/pkg/libcontainer/container.go
+++ b/pkg/libcontainer/container.go
@@ -2,6 +2,7 @@ package libcontainer
 
 import (
 	"github.com/dotcloud/docker/pkg/libcontainer/cgroups"
+	"github.com/dotcloud/docker/pkg/libcontainer/devices"
 )
 
 // Context is a generic key value pair that allows arbatrary data to be sent
@@ -60,13 +61,8 @@ type Container struct {
 	// rootfs and mount namespace if specified
 	Mounts Mounts `json:"mounts,omitempty"`
 
-	// RequiredDeviceNodes are a list of device nodes that will be mknod into the container's rootfs at /dev
-	// If the host system does not support the device that the container requests an error is returned
-	RequiredDeviceNodes []string `json:"required_device_nodes,omitempty"`
-
-	// OptionalDeviceNodes are a list of device nodes that will be mknod into the container's rootfs at /dev
-	// If the host system does not support the device that the container requests the error is ignored
-	OptionalDeviceNodes []string `json:"optional_device_nodes,omitempty"`
+	// The device nodes that should be automatically created within the container upon container start.  Note, make sure that the node is marked as allowed in the
+	DeviceNodes []devices.Device `json:"device_nodes,omitempty"`
 }
 
 // Network defines configuration for a container's networking stack

--- a/pkg/libcontainer/container.json
+++ b/pkg/libcontainer/container.json
@@ -44,12 +44,54 @@
       "type": "devtmpfs"
     }
   ],
-  "required_device_nodes": [
-      "/dev/null",
-      "/dev/zero",
-      "/dev/full",
-      "/dev/random",
-      "/dev/urandom",
-      "/dev/tty"
+  "device_nodes": [
+		{
+			"path":  "/dev/null",
+			"type":        99,
+			"major_number": 1,
+			"minor_number": 3,
+			"cgroup_permissions": "rwm",
+			"file_mode": 438
+		},
+		{
+			"path":  "/dev/zero",
+			"type":        99,
+			"major_number": 1,
+			"minor_number": 5,
+			"cgroup_permissions": "rwm",
+			"file_mode": 438
+		},
+		{
+			"path":  "/dev/full",
+			"type":        99,
+			"major_number": 1,
+			"minor_number": 7,
+			"cgroup_permissions": "rwm",
+			"file_mode": 438
+		},
+		{
+			"path":  "/dev/tty",
+			"type":        99,
+			"major_number": 5,
+			"minor_number": 0,
+			"cgroup_permissions": "rwm",
+			"file_mode": 438
+		},
+		{
+			"path":  "/dev/urandom",
+			"type":        99,
+			"major_number": 1,
+			"minor_number": 9,
+			"cgroup_permissions": "rwm",
+			"file_mode": 438
+		},
+		{
+			"path":  "/dev/random",
+			"type":        99,
+			"major_number": 1,
+			"minor_number": 8,
+			"cgroup_permissions": "rwm",
+			"file_mode": 438
+		}
   ]
 }

--- a/pkg/libcontainer/container_test.go
+++ b/pkg/libcontainer/container_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"testing"
-
-	"github.com/dotcloud/docker/pkg/libcontainer/mount/nodes"
 )
 
 // Checks whether the expected capability is specified in the capabilities.
@@ -64,10 +62,10 @@ func TestContainerJsonFormat(t *testing.T) {
 		t.Fail()
 	}
 
-	for _, n := range nodes.DefaultNodes {
-		if !contains(n, container.RequiredDeviceNodes) {
-			t.Logf("devices should contain %s", n)
+	/*for _, n := range devices.DefaultAutoCreatedDevices {
+		if !contains(n, container.DeviceNodes) {
+			t.Logf("devices should contain %s", n.Path)
 			t.Fail()
 		}
-	}
+	}*/
 }

--- a/pkg/libcontainer/devices/deviceNumbers.go
+++ b/pkg/libcontainer/devices/deviceNumbers.go
@@ -1,0 +1,26 @@
+package devices
+
+/*
+
+This code provides support for manipulating linux device numbers.  It should be replaced by normal syscall functions once http://code.google.com/p/go/issues/detail?id=8106 is solved.
+
+You can read what they are here:
+
+ - http://www.makelinux.net/ldd3/chp-3-sect-2
+ - http://www.linux-tutorial.info/modules.php?name=MContent&pageid=94
+
+Note! These are NOT the same as the MAJOR(dev_t device);, MINOR(dev_t device); and MKDEV(int major, int minor); functions as defined in <linux/kdev_t.h> as the representation of device numbers used by go is different than the one used internally to the kernel! - https://github.com/torvalds/linux/blob/master/include/linux/kdev_t.h#L9
+
+*/
+
+func Major(devNumber int) int64 {
+	return int64((devNumber >> 8) & 0xfff)
+}
+
+func Minor(devNumber int) int64 {
+	return int64((devNumber & 0xff) | ((devNumber >> 12) & 0xfff00))
+}
+
+func Mkdev(majorNumber int64, minorNumber int64) int {
+	return int((majorNumber << 8) | (minorNumber & 0xff) | ((minorNumber & 0xfff00) << 12))
+}

--- a/pkg/libcontainer/devices/devices.go
+++ b/pkg/libcontainer/devices/devices.go
@@ -1,0 +1,253 @@
+package devices
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+const (
+	Wildcard = -1
+)
+
+type Device struct {
+	Type              rune        `json:"type"`
+	Path              string      `json:"path"`               // It is fine if this is an empty string in the case that you are using Wildcards
+	MajorNumber       int64       `json:"major_number"`       // Use the wildcard constant for wildcards.
+	MinorNumber       int64       `json:"minor_number"`       // Use the wildcard constant for wildcards.
+	CgroupPermissions string      `json:"cgroup_permissions"` // Typically just "rwm"
+	FileMode          os.FileMode `json:"file_mode"`          // The permission bits of the file's mode
+}
+
+func GetDeviceNumberString(deviceNumber int64) string {
+	if deviceNumber == Wildcard {
+		return "*"
+	} else {
+		return fmt.Sprintf("%d", deviceNumber)
+	}
+}
+
+func GetDevice(path string, cgroupPermissions string) (Device, error) { // Given the path to a device and it's cgroup_permissions(which cannot be easilly queried) look up the information about a linux device and return that information as a Device struct.
+	stat, err := os.Stat(path)
+	if err != nil {
+		return Device{}, err
+	}
+
+	devType := 'c'
+	mode := stat.Mode()
+	fileModePermissionBits := os.FileMode.Perm(mode)
+	switch {
+	case (mode & os.ModeDevice) == 0:
+		return Device{}, fmt.Errorf("%s is not a device", path)
+	case (mode & os.ModeCharDevice) != 0:
+		fileModePermissionBits |= syscall.S_IFCHR
+	default:
+		fileModePermissionBits |= syscall.S_IFBLK
+		devType = 'b'
+	}
+
+	devNumber := int(0)
+	sys, ok := stat.Sys().(*syscall.Stat_t)
+	if ok {
+		devNumber = int(sys.Rdev)
+	} else {
+		return Device{}, fmt.Errorf("Cannot determine the device major and minor numbers")
+	}
+
+	device := Device{
+		Type:              devType,
+		Path:              path,
+		MajorNumber:       Major(devNumber),
+		MinorNumber:       Minor(devNumber),
+		CgroupPermissions: cgroupPermissions,
+		FileMode:          fileModePermissionBits,
+	}
+	return device, nil
+}
+
+var (
+	DefaultAllowedDevices = []Device{
+		// allow mknod for any device
+		{
+			Type:              'c',
+			MajorNumber:       Wildcard,
+			MinorNumber:       Wildcard,
+			CgroupPermissions: "m",
+		},
+		{
+			Type:              'b',
+			MajorNumber:       Wildcard,
+			MinorNumber:       Wildcard,
+			CgroupPermissions: "m",
+		},
+
+		// /dev/null and zero
+		{
+			Path:              "/dev/null",
+			Type:              'c',
+			MajorNumber:       1,
+			MinorNumber:       3,
+			CgroupPermissions: "rwm",
+		},
+		{
+			Path:              "/dev/zero",
+			Type:              'c',
+			MajorNumber:       1,
+			MinorNumber:       5,
+			CgroupPermissions: "rwm",
+		},
+		{
+			Path:              "/dev/full",
+			Type:              'c',
+			MajorNumber:       1,
+			MinorNumber:       7,
+			CgroupPermissions: "rwm",
+		},
+		// consoles and ttys
+		{
+			Path:              "/dev/tty",
+			Type:              'c',
+			MajorNumber:       5,
+			MinorNumber:       0,
+			CgroupPermissions: "rwm",
+		},
+		{
+			Path:              "/dev/console",
+			Type:              'c',
+			MajorNumber:       5,
+			MinorNumber:       1,
+			CgroupPermissions: "rwm",
+		},
+		{
+			Path:              "/dev/tty0",
+			Type:              'c',
+			MajorNumber:       4,
+			MinorNumber:       0,
+			CgroupPermissions: "rwm",
+		},
+		{
+			Path:              "/dev/tty1",
+			Type:              'c',
+			MajorNumber:       4,
+			MinorNumber:       1,
+			CgroupPermissions: "rwm",
+		},
+
+		// /dev/urandom,/dev/random
+		{
+			Path:              "/dev/urandom",
+			Type:              'c',
+			MajorNumber:       1,
+			MinorNumber:       9,
+			CgroupPermissions: "rwm",
+		},
+		{
+			Path:              "/dev/random",
+			Type:              'c',
+			MajorNumber:       1,
+			MinorNumber:       8,
+			CgroupPermissions: "rwm",
+		},
+
+		// /dev/pts/ - pts namespaces are "coming soon"
+		{
+			Path:              "",
+			Type:              'c',
+			MajorNumber:       136,
+			MinorNumber:       Wildcard,
+			CgroupPermissions: "rwm",
+		},
+		{
+			Path:              "",
+			Type:              'c',
+			MajorNumber:       5,
+			MinorNumber:       2,
+			CgroupPermissions: "rwm",
+		},
+
+		// tuntap
+		{
+			Path:              "",
+			Type:              'c',
+			MajorNumber:       10,
+			MinorNumber:       200,
+			CgroupPermissions: "rwm",
+		},
+
+		/*// fuse
+		   {
+		    Path: "",
+		    Type: 'c',
+		    MajorNumber: 10,
+		    MinorNumber: 229,
+		    CgroupPermissions: "rwm",
+		   },
+
+		// rtc
+		   {
+		    Path: "",
+		    Type: 'c',
+		    MajorNumber: 254,
+		    MinorNumber: 0,
+		    CgroupPermissions: "rwm",
+		   },
+		*/
+	}
+
+	DefaultAutoCreatedDevices = []Device{
+		// /dev/null and zero
+		{
+			Path:              "/dev/null",
+			Type:              'c',
+			MajorNumber:       1,
+			MinorNumber:       3,
+			CgroupPermissions: "rwm",
+			FileMode:          0666,
+		},
+		{
+			Path:              "/dev/zero",
+			Type:              'c',
+			MajorNumber:       1,
+			MinorNumber:       5,
+			CgroupPermissions: "rwm",
+			FileMode:          0666,
+		},
+
+		{
+			Path:              "/dev/full",
+			Type:              'c',
+			MajorNumber:       1,
+			MinorNumber:       7,
+			CgroupPermissions: "rwm",
+			FileMode:          0666,
+		},
+
+		// consoles and ttys
+		{
+			Path:              "/dev/tty",
+			Type:              'c',
+			MajorNumber:       5,
+			MinorNumber:       0,
+			CgroupPermissions: "rwm",
+			FileMode:          0666,
+		},
+
+		// /dev/urandom,/dev/random
+		{
+			Path:              "/dev/urandom",
+			Type:              'c',
+			MajorNumber:       1,
+			MinorNumber:       9,
+			CgroupPermissions: "rwm",
+			FileMode:          0666,
+		},
+		{
+			Path:              "/dev/random",
+			Type:              'c',
+			MajorNumber:       1,
+			MinorNumber:       8,
+			CgroupPermissions: "rwm",
+			FileMode:          0666,
+		},
+	}
+)

--- a/pkg/libcontainer/mount/init.go
+++ b/pkg/libcontainer/mount/init.go
@@ -48,11 +48,8 @@ func InitializeMountNamespace(rootfs, console string, container *libcontainer.Co
 	if err := setupBindmounts(rootfs, container.Mounts); err != nil {
 		return fmt.Errorf("bind mounts %s", err)
 	}
-	if err := nodes.CopyN(rootfs, container.RequiredDeviceNodes, true); err != nil {
-		return fmt.Errorf("copy required dev nodes %s", err)
-	}
-	if err := nodes.CopyN(rootfs, container.OptionalDeviceNodes, false); err != nil {
-		return fmt.Errorf("copy optional dev nodes %s", err)
+	if err := nodes.CreateDeviceNodes(rootfs, container.DeviceNodes); err != nil {
+		return fmt.Errorf("Create device nodes %s", err)
 	}
 	if err := SetupPtmx(rootfs, console, container.Context["mount_label"]); err != nil {
 		return err

--- a/pkg/libcontainer/mount/nodes/nodes_unsupported.go
+++ b/pkg/libcontainer/mount/nodes/nodes_unsupported.go
@@ -2,10 +2,15 @@
 
 package nodes
 
-import "github.com/dotcloud/docker/pkg/libcontainer"
-
-var DefaultNodes = []string{}
+import (
+	"github.com/dotcloud/docker/pkg/libcontainer"
+	"github.com/dotcloud/docker/pkg/libcontainer/devices"
+)
 
 func GetHostDeviceNodes() ([]string, error) {
 	return nil, libcontainer.ErrUnsupported
+}
+
+func CreateDeviceNodes(rootfs string, nodesToCreate []devices.Device) error {
+	return libcontainer.ErrUnsupported
 }

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -67,5 +67,6 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 	if Entrypoint := job.GetenvList("Entrypoint"); Entrypoint != nil {
 		config.Entrypoint = Entrypoint
 	}
+
 	return config
 }

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -30,8 +30,8 @@ type HostConfig struct {
 	Dns             []string
 	DnsSearch       []string
 	VolumesFrom     []string
-	NetworkMode     NetworkMode
 	Devices         []string
+	NetworkMode     NetworkMode
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
@@ -59,7 +59,9 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 		hostConfig.VolumesFrom = VolumesFrom
 	}
 	if Devices := job.GetenvList("Devices"); Devices != nil {
+
 		hostConfig.Devices = Devices
+
 	}
 	return hostConfig
 }

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -31,6 +31,7 @@ type HostConfig struct {
 	DnsSearch       []string
 	VolumesFrom     []string
 	NetworkMode     NetworkMode
+	Devices         []string
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
@@ -56,6 +57,9 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 	}
 	if VolumesFrom := job.GetenvList("VolumesFrom"); VolumesFrom != nil {
 		hostConfig.VolumesFrom = VolumesFrom
+	}
+	if Devices := job.GetenvList("Devices"); Devices != nil {
+		hostConfig.Devices = Devices
 	}
 	return hostConfig
 }

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -41,6 +41,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flVolumes = opts.NewListOpts(opts.ValidatePath)
 		flLinks   = opts.NewListOpts(opts.ValidateLink)
 		flEnv     = opts.NewListOpts(opts.ValidateEnv)
+		flDevices = opts.NewListOpts(opts.ValidatePath)
 
 		flPublish     opts.ListOpts
 		flExpose      opts.ListOpts
@@ -74,6 +75,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	cmd.Var(&flAttach, []string{"a", "-attach"}, "Attach to stdin, stdout or stderr.")
 	cmd.Var(&flVolumes, []string{"v", "-volume"}, "Bind mount a volume (e.g. from the host: -v /host:/container, from docker: -v /container)")
 	cmd.Var(&flLinks, []string{"#link", "-link"}, "Add link to another container (name:alias)")
+	cmd.Var(&flDevices, []string{"device", "-device"}, "Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc)")
 	cmd.Var(&flEnv, []string{"e", "-env"}, "Set environment variables")
 	cmd.Var(&flEnvFile, []string{"-env-file"}, "Read in a line delimited file of ENV variables")
 
@@ -245,6 +247,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		DnsSearch:       flDnsSearch.GetAll(),
 		VolumesFrom:     flVolumesFrom.GetAll(),
 		NetworkMode:     netMode,
+		Devices:         flDevices.GetAll(),
 	}
 
 	if sysInfo != nil && flMemory > 0 && !sysInfo.SwapLimit {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1089,23 +1089,27 @@ func ValidateContextDirectory(srcPath string) error {
 	return finalError
 }
 
-func ParseDevice(device string) (string, string, error) {
+func ParseDevice(device string) (string, string, string, error) {
 	src := ""
 	dst := ""
+	permissions := "rwm"
 	arr := strings.Split(device, ":")
 	switch len(arr) {
+	case 3:
+		permissions = arr[2]
+		fallthrough
 	case 2:
 		dst = arr[1]
 		fallthrough
 	case 1:
 		src = arr[0]
 	default:
-		return "", "", fmt.Errorf("Invalid device specification: %s", device)
+		return "", "", "", fmt.Errorf("Invalid device specification: %s", device)
 	}
 
 	if dst == "" {
 		dst = src
 	}
 
-	return src, dst, nil
+	return src, dst, permissions, nil
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1088,3 +1088,24 @@ func ValidateContextDirectory(srcPath string) error {
 	})
 	return finalError
 }
+
+func ParseDevice(device string) (string, string, error) {
+	src := ""
+	dst := ""
+	arr := strings.Split(device, ":")
+	switch len(arr) {
+	case 2:
+		dst = arr[1]
+		fallthrough
+	case 1:
+		src = arr[0]
+	default:
+		return "", "", fmt.Errorf("Invalid device specification: %s", device)
+	}
+
+	if dst == "" {
+		dst = src
+	}
+
+	return src, dst, nil
+}


### PR DESCRIPTION
This is try number ? for https://github.com/dotcloud/docker/pull/4191

We add a `--device` flag that can be used for adding devices to containers.  We create a global list of devices that are allowed in containers, and devices that are to be created in containers.  We fix inconsistencies between the device handling of the lxc exec driver, native-fs exec driver and the native-systemd exec drivers.
