### PR TITLE
Fix /dev/console

### DIFF
--- a/pkg/libcontainer/console/console.go
+++ b/pkg/libcontainer/console/console.go
@@ -17,29 +17,26 @@ func Setup(rootfs, consolePath, mountLabel string) error {
 	oldMask := system.Umask(0000)
 	defer system.Umask(oldMask)
 
-	stat, err := os.Stat(consolePath)
-	if err != nil {
-		return fmt.Errorf("stat console %s %s", consolePath, err)
-	}
-	var (
-		st   = stat.Sys().(*syscall.Stat_t)
-		dest = filepath.Join(rootfs, "dev/console")
-	)
-	if err := os.Remove(dest); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("remove %s %s", dest, err)
-	}
 	if err := os.Chmod(consolePath, 0600); err != nil {
 		return err
 	}
 	if err := os.Chown(consolePath, 0, 0); err != nil {
 		return err
 	}
-	if err := system.Mknod(dest, (st.Mode&^07777)|0600, int(st.Rdev)); err != nil {
-		return fmt.Errorf("mknod %s %s", dest, err)
-	}
 	if err := label.SetFileLabel(consolePath, mountLabel); err != nil {
-		return fmt.Errorf("set file label %s %s", dest, err)
+		return fmt.Errorf("set file label %s %s", consolePath, err)
 	}
+
+	dest := filepath.Join(rootfs, "dev/console")
+
+	f, err := os.Create(dest)
+	if err != nil && !os.IsExist(err) {
+		return fmt.Errorf("create %s %s", dest, err)
+	}
+	if f != nil {
+		f.Close()
+	}
+
 	if err := system.Mount(consolePath, dest, "bind", syscall.MS_BIND, ""); err != nil {
 		return fmt.Errorf("bind %s to %s %s", consolePath, dest, err)
 	}

--- a/pkg/libcontainer/console/console.go
+++ b/pkg/libcontainer/console/console.go
@@ -40,6 +40,9 @@ func Setup(rootfs, consolePath, mountLabel string) error {
 	if err := label.SetFileLabel(consolePath, mountLabel); err != nil {
 		return fmt.Errorf("set file label %s %s", dest, err)
 	}
+	if err := system.Mount(consolePath, dest, "bind", syscall.MS_BIND, ""); err != nil {
+		return fmt.Errorf("bind %s to %s %s", consolePath, dest, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
The change in https://github.com/dotcloud/docker/commit/ae85dd54582e94d36b146ab1688844ed58cc8df3 broke /dev/console support:

```
docker run -ti fedora bash -c "echo foo > /dev/console"
bash: /dev/console: Input/output error
```

This is because the /dev/console mknod doesn't work, pts files have to be on a devpts filesystem.
This PR reverts the above and then cleans up the code so that we just use a regular file to bind mount over.
