### PR TITLE
Replaced fs.Stats() interface with fs.GetStats() which returns a cgroups.Stats strong type

### DIFF
--- a/pkg/libcontainer/cgroups/fs/cpuset.go
+++ b/pkg/libcontainer/cgroups/fs/cpuset.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/dotcloud/docker/pkg/libcontainer/cgroups"
 )
 
 type cpusetGroup struct {
@@ -38,8 +40,8 @@ func (s *cpusetGroup) Remove(d *data) error {
 	return removePath(d.path("cpuset"))
 }
 
-func (s *cpusetGroup) Stats(d *data) (map[string]int64, error) {
-	return nil, ErrNotSupportStat
+func (s *cpusetGroup) GetStats(d *data, stats *cgroups.Stats) error {
+	return nil
 }
 
 func (s *cpusetGroup) getSubsystemSettings(parent string) (cpus []byte, mems []byte, err error) {

--- a/pkg/libcontainer/cgroups/fs/devices.go
+++ b/pkg/libcontainer/cgroups/fs/devices.go
@@ -1,5 +1,7 @@
 package fs
 
+import "github.com/dotcloud/docker/pkg/libcontainer/cgroups"
+
 type devicesGroup struct {
 }
 
@@ -55,6 +57,6 @@ func (s *devicesGroup) Remove(d *data) error {
 	return removePath(d.path("devices"))
 }
 
-func (s *devicesGroup) Stats(d *data) (map[string]int64, error) {
-	return nil, ErrNotSupportStat
+func (s *devicesGroup) GetStats(d *data, stats *cgroups.Stats) error {
+	return nil
 }

--- a/pkg/libcontainer/cgroups/fs/freezer.go
+++ b/pkg/libcontainer/cgroups/fs/freezer.go
@@ -1,11 +1,8 @@
 package fs
 
 import (
-	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/dotcloud/docker/pkg/libcontainer/cgroups"
@@ -35,39 +32,25 @@ func (s *freezerGroup) Remove(d *data) error {
 	return removePath(d.path("freezer"))
 }
 
-func (s *freezerGroup) Stats(d *data) (map[string]int64, error) {
-	var (
-		paramData = make(map[string]int64)
-		params    = []string{
-			"parent_freezing",
-			"self_freezing",
-			// comment out right now because this is string "state",
-		}
-	)
+func getFreezerFileData(path string) (string, error) {
+	data, err := ioutil.ReadFile(path)
+	return strings.TrimSuffix(string(data), "\n"), err
+}
 
+func (s *freezerGroup) GetStats(d *data, stats *cgroups.Stats) error {
 	path, err := d.path("freezer")
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	// TODO(vmarmol): This currently outputs nothing since the output is a string, fix.
-	for _, param := range params {
-		f, err := os.Open(filepath.Join(path, fmt.Sprintf("freezer.%s", param)))
-		if err != nil {
-			return nil, err
-		}
-		defer f.Close()
-
-		data, err := ioutil.ReadAll(f)
-		if err != nil {
-			return nil, err
-		}
-
-		v, err := strconv.ParseInt(strings.TrimSuffix(string(data), "\n"), 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		paramData[param] = v
+	var data string
+	if data, err = getFreezerFileData(filepath.Join(path, "freezer.parent_freezing")); err != nil {
+		return err
 	}
-	return paramData, nil
+	stats.FreezerStats.ParentState = data
+	if data, err = getFreezerFileData(filepath.Join(path, "freezer.self_freezing")); err != nil {
+		return err
+	}
+	stats.FreezerStats.SelfState = data
+
+	return nil
 }

--- a/pkg/libcontainer/cgroups/fs/memory.go
+++ b/pkg/libcontainer/cgroups/fs/memory.go
@@ -2,10 +2,11 @@ package fs
 
 import (
 	"bufio"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	"github.com/dotcloud/docker/pkg/libcontainer/cgroups"
 )
 
 type memoryGroup struct {
@@ -50,17 +51,16 @@ func (s *memoryGroup) Remove(d *data) error {
 	return removePath(d.path("memory"))
 }
 
-func (s *memoryGroup) Stats(d *data) (map[string]int64, error) {
-	paramData := make(map[string]int64)
+func (s *memoryGroup) GetStats(d *data, stats *cgroups.Stats) error {
 	path, err := d.path("memory")
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	// Set stats from memory.stat.
 	statsFile, err := os.Open(filepath.Join(path, "memory.stat"))
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer statsFile.Close()
 
@@ -68,23 +68,22 @@ func (s *memoryGroup) Stats(d *data) (map[string]int64, error) {
 	for sc.Scan() {
 		t, v, err := getCgroupParamKeyValue(sc.Text())
 		if err != nil {
-			return nil, err
+			return err
 		}
-		paramData[t] = v
+		stats.MemoryStats.Stats[t] = v
 	}
 
 	// Set memory usage and max historical usage.
-	params := []string{
-		"usage_in_bytes",
-		"max_usage_in_bytes",
+	value, err := getCgroupParamInt(path, "memory.usage_in_bytes")
+	if err != nil {
+		return err
 	}
-	for _, param := range params {
-		value, err := getCgroupParamInt(path, fmt.Sprintf("memory.%s", param))
-		if err != nil {
-			return nil, err
-		}
-		paramData[param] = value
+	stats.MemoryStats.Usage = value
+	value, err = getCgroupParamInt(path, "memory.max_usage_in_bytes")
+	if err != nil {
+		return err
 	}
+	stats.MemoryStats.MaxUsage = value
 
-	return paramData, nil
+	return nil
 }

--- a/pkg/libcontainer/cgroups/fs/memory_test.go
+++ b/pkg/libcontainer/cgroups/fs/memory_test.go
@@ -2,6 +2,8 @@ package fs
 
 import (
 	"testing"
+
+	"github.com/dotcloud/docker/pkg/libcontainer/cgroups"
 )
 
 const (
@@ -21,12 +23,12 @@ func TestMemoryStats(t *testing.T) {
 	})
 
 	memory := &memoryGroup{}
-	stats, err := memory.Stats(helper.CgroupData)
+	err := memory.GetStats(helper.CgroupData, &actualStats)
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedStats := map[string]int64{"cache": 512, "rss": 1024, "usage_in_bytes": 2048, "max_usage_in_bytes": 4096}
-	expectStats(t, expectedStats, stats)
+	expectedStats := cgroups.MemoryStats{Usage: 2048, MaxUsage: 4096, Stats: map[string]uint64{"cache": 512, "rss": 1024}}
+	expectMemoryStatEquals(t, expectedStats, actualStats.MemoryStats)
 }
 
 func TestMemoryStatsNoStatFile(t *testing.T) {
@@ -38,7 +40,7 @@ func TestMemoryStatsNoStatFile(t *testing.T) {
 	})
 
 	memory := &memoryGroup{}
-	_, err := memory.Stats(helper.CgroupData)
+	err := memory.GetStats(helper.CgroupData, &actualStats)
 	if err == nil {
 		t.Fatal("Expected failure")
 	}
@@ -53,7 +55,7 @@ func TestMemoryStatsNoUsageFile(t *testing.T) {
 	})
 
 	memory := &memoryGroup{}
-	_, err := memory.Stats(helper.CgroupData)
+	err := memory.GetStats(helper.CgroupData, &actualStats)
 	if err == nil {
 		t.Fatal("Expected failure")
 	}
@@ -68,7 +70,7 @@ func TestMemoryStatsNoMaxUsageFile(t *testing.T) {
 	})
 
 	memory := &memoryGroup{}
-	_, err := memory.Stats(helper.CgroupData)
+	err := memory.GetStats(helper.CgroupData, &actualStats)
 	if err == nil {
 		t.Fatal("Expected failure")
 	}
@@ -84,7 +86,7 @@ func TestMemoryStatsBadStatFile(t *testing.T) {
 	})
 
 	memory := &memoryGroup{}
-	_, err := memory.Stats(helper.CgroupData)
+	err := memory.GetStats(helper.CgroupData, &actualStats)
 	if err == nil {
 		t.Fatal("Expected failure")
 	}
@@ -100,7 +102,7 @@ func TestMemoryStatsBadUsageFile(t *testing.T) {
 	})
 
 	memory := &memoryGroup{}
-	_, err := memory.Stats(helper.CgroupData)
+	err := memory.GetStats(helper.CgroupData, &actualStats)
 	if err == nil {
 		t.Fatal("Expected failure")
 	}
@@ -116,7 +118,7 @@ func TestMemoryStatsBadMaxUsageFile(t *testing.T) {
 	})
 
 	memory := &memoryGroup{}
-	_, err := memory.Stats(helper.CgroupData)
+	err := memory.GetStats(helper.CgroupData, &actualStats)
 	if err == nil {
 		t.Fatal("Expected failure")
 	}

--- a/pkg/libcontainer/cgroups/fs/perf_event.go
+++ b/pkg/libcontainer/cgroups/fs/perf_event.go
@@ -19,6 +19,6 @@ func (s *perfEventGroup) Remove(d *data) error {
 	return removePath(d.path("perf_event"))
 }
 
-func (s *perfEventGroup) Stats(d *data) (map[string]int64, error) {
-	return nil, ErrNotSupportStat
+func (s *perfEventGroup) GetStats(d *data, stats *cgroups.Stats) error {
+	return nil
 }

--- a/pkg/libcontainer/cgroups/fs/stats_test_util.go
+++ b/pkg/libcontainer/cgroups/fs/stats_test_util.go
@@ -1,0 +1,73 @@
+package fs
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/dotcloud/docker/pkg/libcontainer/cgroups"
+)
+
+func blkioStatEntryEquals(expected, actual []cgroups.BlkioStatEntry) error {
+	if len(expected) != len(actual) {
+		return fmt.Errorf("blkioStatEntries length do not match")
+	}
+	for i, expValue := range expected {
+		actValue := actual[i]
+		if expValue != actValue {
+			return fmt.Errorf("Expected blkio stat entry %v but found %v", expValue, actValue)
+		}
+	}
+	return nil
+}
+
+func expectBlkioStatsEquals(t *testing.T, expected, actual cgroups.BlkioStats) {
+	if err := blkioStatEntryEquals(expected.IoServiceBytesRecursive, actual.IoServiceBytesRecursive); err != nil {
+		log.Printf("blkio IoServiceBytesRecursive do not match - %s\n", err)
+		t.Fail()
+	}
+
+	if err := blkioStatEntryEquals(expected.IoServicedRecursive, actual.IoServicedRecursive); err != nil {
+		log.Printf("blkio IoServicedRecursive do not match - %s\n", err)
+		t.Fail()
+	}
+
+	if err := blkioStatEntryEquals(expected.IoQueuedRecursive, actual.IoQueuedRecursive); err != nil {
+		log.Printf("blkio IoQueuedRecursive do not match - %s\n", err)
+		t.Fail()
+	}
+
+	if err := blkioStatEntryEquals(expected.SectorsRecursive, actual.SectorsRecursive); err != nil {
+		log.Printf("blkio SectorsRecursive do not match - %s\n", err)
+		t.Fail()
+	}
+}
+
+func expectThrottlingDataEquals(t *testing.T, expected, actual cgroups.ThrottlingData) {
+	if expected != actual {
+		log.Printf("Expected throttling data %v but found %v\n", expected, actual)
+		t.Fail()
+	}
+}
+
+func expectMemoryStatEquals(t *testing.T, expected, actual cgroups.MemoryStats) {
+	if expected.Usage != actual.Usage {
+		log.Printf("Expected memory usage %d but found %d\n", expected.Usage, actual.Usage)
+		t.Fail()
+	}
+	if expected.MaxUsage != actual.MaxUsage {
+		log.Printf("Expected memory max usage %d but found %d\n", expected.MaxUsage, actual.MaxUsage)
+		t.Fail()
+	}
+	for key, expValue := range expected.Stats {
+		actValue, ok := actual.Stats[key]
+		if !ok {
+			log.Printf("Expected memory stat key %s not found\n", key)
+			t.Fail()
+		}
+		if expValue != actValue {
+			log.Printf("Expected memory stat value %d but found %d\n", expValue, actValue)
+			t.Fail()
+		}
+	}
+}

--- a/pkg/libcontainer/cgroups/fs/test_util.go
+++ b/pkg/libcontainer/cgroups/fs/test_util.go
@@ -8,7 +8,6 @@ package fs
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"testing"
 )
@@ -56,20 +55,6 @@ func (c *cgroupTestUtil) writeFileContents(fileContents map[string]string) {
 		err := writeFile(c.CgroupPath, file, contents)
 		if err != nil {
 			c.t.Fatal(err)
-		}
-	}
-}
-
-// Expect the specified stats.
-func expectStats(t *testing.T, expected, actual map[string]int64) {
-	for stat, expectedValue := range expected {
-		actualValue, ok := actual[stat]
-		if !ok {
-			log.Printf("Expected stat %s to exist: %s", stat, actual)
-			t.Fail()
-		} else if actualValue != expectedValue {
-			log.Printf("Expected stats %s to have value %f but had %f instead", stat, expectedValue, actualValue)
-			t.Fail()
 		}
 	}
 }

--- a/pkg/libcontainer/cgroups/fs/utils.go
+++ b/pkg/libcontainer/cgroups/fs/utils.go
@@ -16,11 +16,11 @@ var (
 
 // Parses a cgroup param and returns as name, value
 //  i.e. "io_service_bytes 1234" will return as io_service_bytes, 1234
-func getCgroupParamKeyValue(t string) (string, int64, error) {
+func getCgroupParamKeyValue(t string) (string, uint64, error) {
 	parts := strings.Fields(t)
 	switch len(parts) {
 	case 2:
-		value, err := strconv.ParseInt(parts[1], 10, 64)
+		value, err := strconv.ParseUint(parts[1], 10, 64)
 		if err != nil {
 			return "", 0, fmt.Errorf("Unable to convert param value to int: %s", err)
 		}
@@ -31,10 +31,10 @@ func getCgroupParamKeyValue(t string) (string, int64, error) {
 }
 
 // Gets a single int64 value from the specified cgroup file.
-func getCgroupParamInt(cgroupPath, cgroupFile string) (int64, error) {
+func getCgroupParamInt(cgroupPath, cgroupFile string) (uint64, error) {
 	contents, err := ioutil.ReadFile(filepath.Join(cgroupPath, cgroupFile))
 	if err != nil {
-		return -1, err
+		return 0, err
 	}
-	return strconv.ParseInt(strings.TrimSpace(string(contents)), 10, 64)
+	return strconv.ParseUint(strings.TrimSpace(string(contents)), 10, 64)
 }

--- a/pkg/libcontainer/cgroups/stats.go
+++ b/pkg/libcontainer/cgroups/stats.go
@@ -2,18 +2,18 @@ package cgroups
 
 type ThrottlingData struct {
 	// Number of periods with throttling active
-	Periods int64 `json:"periods,omitempty"`
+	Periods uint64 `json:"periods,omitempty"`
 	// Number of periods when the container hit its throttling limit.
-	ThrottledPeriods int64 `json:"throttled_periods,omitempty"`
+	ThrottledPeriods uint64 `json:"throttled_periods,omitempty"`
 	// Aggregate time the container was throttled for in nanoseconds.
-	ThrottledTime int64 `json:"throttled_time,omitempty"`
+	ThrottledTime uint64 `json:"throttled_time,omitempty"`
 }
 
 type CpuUsage struct {
 	// percentage of available CPUs currently being used.
-	PercentUsage int64 `json:"percent_usage,omitempty"`
+	PercentUsage uint64 `json:"percent_usage,omitempty"`
 	// nanoseconds of cpu time consumed over the last 100 ms.
-	CurrentUsage int64 `json:"current_usage,omitempty"`
+	CurrentUsage uint64 `json:"current_usage,omitempty"`
 }
 
 type CpuStats struct {
@@ -23,26 +23,27 @@ type CpuStats struct {
 
 type MemoryStats struct {
 	// current res_counter usage for memory
-	Usage int64 `json:"usage,omitempty"`
+	Usage uint64 `json:"usage,omitempty"`
 	// maximum usage ever recorded.
-	MaxUsage int64 `json:"max_usage,omitempty"`
+	MaxUsage uint64 `json:"max_usage,omitempty"`
 	// TODO(vishh): Export these as stronger types.
 	// all the stats exported via memory.stat.
-	Stats map[string]int64 `json:"stats,omitempty"`
+	Stats map[string]uint64 `json:"stats,omitempty"`
 }
 
 type BlkioStatEntry struct {
-	Major int64  `json:"major,omitempty"`
-	Minor int64  `json:"minor,omitempty"`
+	Major uint64 `json:"major,omitempty"`
+	Minor uint64 `json:"minor,omitempty"`
 	Op    string `json:"op,omitempty"`
-	Value int64  `json:"value,omitempty"`
+	Value uint64 `json:"value,omitempty"`
 }
 
-type BlockioStats struct {
+type BlkioStats struct {
 	// number of bytes tranferred to and from the block device
 	IoServiceBytesRecursive []BlkioStatEntry `json:"io_service_bytes_recursive,omitempty"`
 	IoServicedRecursive     []BlkioStatEntry `json:"io_serviced_recusrive,omitempty"`
 	IoQueuedRecursive       []BlkioStatEntry `json:"io_queue_recursive,omitempty"`
+	SectorsRecursive        []BlkioStatEntry `json:"sectors_recursive,omitempty"`
 }
 
 // TODO(Vishh): Remove freezer from stats since it does not logically belong in stats.
@@ -54,6 +55,11 @@ type FreezerStats struct {
 type Stats struct {
 	CpuStats     CpuStats     `json:"cpu_stats,omitempty"`
 	MemoryStats  MemoryStats  `json:"memory_stats,omitempty"`
-	BlockioStats BlockioStats `json:"blockio_stats,omitempty"`
+	BlkioStats   BlkioStats   `json:"blkio_stats,omitempty"`
 	FreezerStats FreezerStats `json:"freezer_stats,omitempty"`
+}
+
+func NewStats() *Stats {
+	memoryStats := MemoryStats{Stats: make(map[string]uint64)}
+	return &Stats{MemoryStats: memoryStats}
 }


### PR DESCRIPTION
Added a new method cgroups.GetStats() which will return a cgroups.Stats object which will contain all the available cgroup Stats.

Remove old Stats interface in libcontainers cgroups package.

Updated unit tests.

Docker-DCO-1.1-Signed-off-by: Vishnu Kannan vishnuk@google.com (github: vishh)
