### PR TITLE
Do not consider iptables' output an error in case of xtables lock

### DIFF
--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -166,5 +166,10 @@ func Raw(args ...string) ([]byte, error) {
 		return nil, fmt.Errorf("iptables failed: iptables %v: %s (%s)", strings.Join(args, " "), output, err)
 	}
 
+	// ignore iptables' message about xtables lock
+	if strings.Contains(string(output), "waiting for it to exit") {
+		output = []byte("")
+	}
+
 	return output, err
 }


### PR DESCRIPTION
This solves errors starting containers in parallel and ignores this stdout message from iptables:

```
Another app is currently holding the xtables lock; waiting for it to exit...
```

NOTE: the real bug is that somebody considers iptables' stdout to be always a sign of error, however this patch is the minimum necessary to solve the problem at hand. Generally speaking it would be a good idea to _not_ consider any stdout from iptables an error (not only while linking containers).

Fixes #6010
