### PR TITLE
Add ErrPrerequisites to improve misleading errors

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -18,6 +18,10 @@ import (
 	"unsafe"
 )
 
+const (
+	btrfsSuperMagic = 0x9123683E
+)
+
 func init() {
 	graphdriver.Register("btrfs", Init)
 }
@@ -30,8 +34,8 @@ func Init(home string) (graphdriver.Driver, error) {
 		return nil, err
 	}
 
-	if buf.Type != 0x9123683E {
-		return nil, graphdriver.ErrNotSupported
+	if buf.Type != btrfsSuperMagic {
+		return nil, graphdriver.ErrPrerequisites
 	}
 
 	return &Driver{

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -44,7 +44,8 @@ var (
 		"vfs",
 	}
 
-	ErrNotSupported = errors.New("driver not supported")
+	ErrNotSupported  = errors.New("driver not supported")
+	ErrPrerequisites = errors.New("Prerequisites for driver not satisfied (wrong filesystem?)")
 )
 
 func init() {
@@ -78,7 +79,7 @@ func New(root string) (driver Driver, err error) {
 	for _, name := range priority {
 		driver, err = GetDriver(name, root)
 		if err != nil {
-			if err == ErrNotSupported {
+			if err == ErrNotSupported || err == ErrPrerequisites {
 				continue
 			}
 			return nil, err
@@ -89,7 +90,7 @@ func New(root string) (driver Driver, err error) {
 	// Check all registered drivers if no priority driver is found
 	for _, initFunc := range drivers {
 		if driver, err = initFunc(root); err != nil {
-			if err == ErrNotSupported {
+			if err == ErrNotSupported || err == ErrPrerequisites {
 				continue
 			}
 			return nil, err

--- a/daemon/graphdriver/graphtest/graphtest.go
+++ b/daemon/graphdriver/graphtest/graphtest.go
@@ -31,7 +31,7 @@ func newDriver(t *testing.T, name string) *Driver {
 
 	d, err := graphdriver.GetDriver(name, root)
 	if err != nil {
-		if err == graphdriver.ErrNotSupported {
+		if err == graphdriver.ErrNotSupported || err == graphdriver.ErrPrerequisites {
 			t.Skip("Driver %s not supported", name)
 		}
 		t.Fatal(err)


### PR DESCRIPTION
There are two cases where we can't use a graphdriver:

1) the graphdriver itself isn't supported by the system
2) the graphdriver is supported by some configuration/prerequisites are
missing

This introduces a new error for the 2) case and uses it when trying to
run docker with btrfs backend on a non-btrfs filesystem.

A bit background: Without the change you get 'driver not supported' which sounds (at least to me) as if either docker or the kernel isn't supporting btrfs where in fact both are but the mountpoint wasn't btrfs.
