### PR TITLE
block aufs on incompatible file systems

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -44,8 +44,9 @@ var (
 		"vfs",
 	}
 
-	ErrNotSupported  = errors.New("driver not supported")
-	ErrPrerequisites = errors.New("Prerequisites for driver not satisfied (wrong filesystem?)")
+	ErrNotSupported   = errors.New("driver not supported")
+	ErrPrerequisites  = errors.New("prerequisites for driver not satisfied (wrong filesystem?)")
+	ErrIncompatibleFS = fmt.Errorf("backing file system is unsupported for this graph driver")
 )
 
 func init() {
@@ -79,7 +80,7 @@ func New(root string) (driver Driver, err error) {
 	for _, name := range priority {
 		driver, err = GetDriver(name, root)
 		if err != nil {
-			if err == ErrNotSupported || err == ErrPrerequisites {
+			if err == ErrNotSupported || err == ErrPrerequisites || err == ErrIncompatibleFS {
 				continue
 			}
 			return nil, err
@@ -90,7 +91,7 @@ func New(root string) (driver Driver, err error) {
 	// Check all registered drivers if no priority driver is found
 	for _, initFunc := range drivers {
 		if driver, err = initFunc(root); err != nil {
-			if err == ErrNotSupported || err == ErrPrerequisites {
+			if err == ErrNotSupported || err == ErrPrerequisites || err == ErrIncompatibleFS {
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
AUFS doesn't work properly on top of btrfs, AUFS and some other file systems. We shouldn't use aufs on these file systems.
