### PR TITLE
Adding "stats" and "spec" option to nsinit CLI

### DIFF
--- a/pkg/libcontainer/cgroups/fs/cpu.go
+++ b/pkg/libcontainer/cgroups/fs/cpu.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"syscall"
 
 	"github.com/dotcloud/docker/pkg/libcontainer/cgroups"
 )
@@ -49,6 +50,9 @@ func (s *cpuGroup) GetStats(d *data, stats *cgroups.Stats) error {
 
 	f, err := os.Open(filepath.Join(path, "cpu.stat"))
 	if err != nil {
+		if pathErr, ok := err.(*os.PathError); ok && pathErr.Err == syscall.ENOENT {
+			return nil
+		}
 		return err
 	}
 	defer f.Close()


### PR DESCRIPTION
Adding "stats" and "spec" option to nsinit CLI which will print the stats and spec(cgroups config) respectively.

Docker-DCO-1.1-Signed-off-by: Vishnu Kannan vishnuk@google.com (github: vishh)
