### PR TITLE
Added documentation for special case in run command

### DIFF
--- a/contrib/man/md/docker-run.1.md
+++ b/contrib/man/md/docker-run.1.md
@@ -100,8 +100,8 @@ container can be started with the **--link**.
 **-m**, **-memory**=*memory-limit*
    Allows you to constrain the memory available to a container. If the host
 supports swap memory, then the -m memory setting can be larger than physical
-RAM. The memory limit format: <number><optional unit>, where unit = b, k, m or
-g.
+RAM. If a limit of 0 is specified, the container's memory is not limited. The 
+memory limit format: <number><optional unit>, where unit = b, k, m or g.
 
 **-P**, **-publish-all**=*true*|*false*
    When set to true publish all exposed ports to the host interfaces. The

--- a/contrib/man/old-man/docker-run.1
+++ b/contrib/man/old-man/docker-run.1
@@ -39,7 +39,7 @@ CPU shares in relative weight. You can increase the priority of a container with
 
 .TP
 .B -m, --memory=\fImemory-limit\fR: 
-Allows you to constrain the memory available to a container. If the host supports swap memory, then the -m memory setting can be larger than physical RAM. The memory limit format: <number><optional unit>, where unit = b, k, m or g.
+Allows you to constrain the memory available to a container. If the host supports swap memory, then the -m memory setting can be larger than physical RAM. If a limit of 0 is specified, the container's memory is not limited. The memory limit format: <number><optional unit>, where unit = b, k, m or g.
 
 .TP
 .B --cidfile=\fIfile\fR: 


### PR DESCRIPTION
At present, starting a Docker container with a memory limit of 0 (docker run -m 0) does not apply a memory limit. This could be fixed, but it's fairly harmless behaviour and may even be desirable in some cases (make it explicit that a container can use as much memory as is available). This documents the behaviour in the man pages, to alleviate any confusion that could arise from this special case.
