### PR TITLE
Standardize api keys to CamelCase

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -848,6 +848,9 @@ func getContainersByName(eng *engine.Engine, version version.Version, w http.Res
 		return fmt.Errorf("Missing parameter")
 	}
 	var job = eng.Job("container_inspect", vars["name"])
+	if version.LessThan("1.12") {
+		job.SetenvBool("dirty", true)
+	}
 	streamJSON(job, w, false)
 	return job.Run()
 }
@@ -857,6 +860,9 @@ func getImagesByName(eng *engine.Engine, version version.Version, w http.Respons
 		return fmt.Errorf("Missing parameter")
 	}
 	var job = eng.Job("image_inspect", vars["name"])
+	if version.LessThan("1.12") {
+		job.SetenvBool("dirty", true)
+	}
 	streamJSON(job, w, false)
 	return job.Run()
 }

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -13,14 +13,40 @@ func (daemon *Daemon) ContainerInspect(job *engine.Job) engine.Status {
 	}
 	name := job.Args[0]
 	if container := daemon.Get(name); container != nil {
-		b, err := json.Marshal(&struct {
-			*Container
-			HostConfig *runconfig.HostConfig
-		}{container, container.HostConfig()})
-		if err != nil {
+		if job.GetenvBool("dirty") {
+			b, err := json.Marshal(&struct {
+				*Container
+				HostConfig *runconfig.HostConfig
+			}{container, container.HostConfig()})
+			if err != nil {
+				return job.Error(err)
+			}
+			job.Stdout.Write(b)
+			return engine.StatusOK
+		}
+
+		out := &engine.Env{}
+		out.Set("Id", container.ID)
+		out.SetAuto("Created", container.Created)
+		out.Set("Path", container.Path)
+		out.SetList("Args", container.Args)
+		out.SetJson("Config", container.Config)
+		out.SetJson("State", container.State)
+		out.Set("Image", container.Image)
+		out.SetJson("NetworkSettings", container.NetworkSettings)
+		out.Set("ResolvConfPath", container.ResolvConfPath)
+		out.Set("HostnamePath", container.HostnamePath)
+		out.Set("HostsPath", container.HostsPath)
+		out.Set("Name", container.Name)
+		out.Set("Driver", container.Driver)
+		out.Set("ExecDriver", container.ExecDriver)
+		out.Set("MountLabel", container.MountLabel)
+		out.Set("ProcessLabel", container.ProcessLabel)
+		out.SetJson("VolumesRW", container.VolumesRW)
+		out.SetJson("HostConfig", container.hostConfig)
+		if _, err := out.WriteTo(job.Stdout); err != nil {
 			return job.Error(err)
 		}
-		job.Stdout.Write(b)
 		return engine.StatusOK
 	}
 	return job.Errorf("No such container: %s", name)

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -36,7 +36,16 @@ You can still call an old version of the api using
 
 ### What's new
 
-docker build now has support for the `forcerm` parameter to always remove containers
+`POST /build`
+
+**New!**
+Build now has support for the `forcerm` parameter to always remove containers
+
+`GET /containers/(name)/json`
+`GET /images/(name)/json`
+
+**New!**
+All the JSON keys are now in CamelCase
 
 ## v1.11
 

--- a/docs/sources/reference/api/docker_remote_api_v1.12.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.12.md
@@ -798,11 +798,9 @@ Return low-level information on the image `name`
         Content-Type: application/json
 
         {
-             "id":"b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
-             "parent":"27cf784147099545",
-             "created":"2013-03-23T22:24:18.818426-07:00",
-             "container":"3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
-             "container_config":
+             "Created":"2013-03-23T22:24:18.818426-07:00",
+             "Container":"3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
+             "ContainerConfig":
                      {
                              "Hostname":"",
                              "User":"",
@@ -823,6 +821,8 @@ Return low-level information on the image `name`
                              "VolumesFrom":"",
                              "WorkingDir":""
                      },
+             "Id":"b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+             "Parent":"27cf784147099545",
              "Size": 6824592
         }
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -439,7 +439,7 @@ func TestBuildWithVolume(t *testing.T) {
 		VOLUME /test
 		`,
 		"testbuildimg",
-		"{{json .config.Volumes}}",
+		"{{json .Config.Volumes}}",
 		`{"/test":{}}`)
 
 	deleteImages("testbuildimg")
@@ -453,7 +453,7 @@ func TestBuildMaintainer(t *testing.T) {
         MAINTAINER dockerio
 		`,
 		"testbuildimg",
-		"{{json .author}}",
+		"{{json .Author}}",
 		`"dockerio"`)
 
 	deleteImages("testbuildimg")
@@ -469,7 +469,7 @@ func TestBuildUser(t *testing.T) {
 		RUN [ $(whoami) = 'dockerio' ]
 		`,
 		"testbuildimg",
-		"{{json .config.User}}",
+		"{{json .Config.User}}",
 		`"dockerio"`)
 
 	deleteImages("testbuildimg")
@@ -489,7 +489,7 @@ func TestBuildRelativeWorkdir(t *testing.T) {
 		RUN [ "$PWD" = '/test2/test3' ]
 		`,
 		"testbuildimg",
-		"{{json .config.WorkingDir}}",
+		"{{json .Config.WorkingDir}}",
 		`"/test2/test3"`)
 
 	deleteImages("testbuildimg")
@@ -504,7 +504,7 @@ func TestBuildEnv(t *testing.T) {
 		RUN [ $(env | grep PORT) = 'PORT=4243' ]
         `,
 		"testbuildimg",
-		"{{json .config.Env}}",
+		"{{json .Config.Env}}",
 		`["HOME=/","PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin","PORT=4243"]`)
 
 	deleteImages("testbuildimg")
@@ -518,7 +518,7 @@ func TestBuildCmd(t *testing.T) {
         CMD ["/bin/echo", "Hello World"]
         `,
 		"testbuildimg",
-		"{{json .config.Cmd}}",
+		"{{json .Config.Cmd}}",
 		`["/bin/echo","Hello World"]`)
 
 	deleteImages("testbuildimg")
@@ -533,7 +533,7 @@ func TestBuildExpose(t *testing.T) {
         `,
 
 		"testbuildimg",
-		"{{json .config.ExposedPorts}}",
+		"{{json .Config.ExposedPorts}}",
 		`{"4243/tcp":{}}`)
 
 	deleteImages("testbuildimg")
@@ -547,7 +547,7 @@ func TestBuildEntrypoint(t *testing.T) {
         ENTRYPOINT ["/bin/echo"]
         `,
 		"testbuildimg",
-		"{{json .config.Entrypoint}}",
+		"{{json .Config.Entrypoint}}",
 		`["/bin/echo"]`)
 
 	deleteImages("testbuildimg")

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -27,7 +27,7 @@ func TestTagUnprefixedRepoByName(t *testing.T) {
 
 // tagging an image by ID in a new unprefixed repo should work
 func TestTagUnprefixedRepoByID(t *testing.T) {
-	getIDCmd := exec.Command(dockerBinary, "inspect", "-f", "{{.id}}", "busybox")
+	getIDCmd := exec.Command(dockerBinary, "inspect", "-f", "{{.Id}}", "busybox")
 	out, _, err := runCommandWithOutput(getIDCmd)
 	errorOut(err, t, fmt.Sprintf("failed to get the image ID of busybox: %v", err))
 

--- a/integration/commands_test.go
+++ b/integration/commands_test.go
@@ -1057,7 +1057,7 @@ func TestContainerOrphaning(t *testing.T) {
 		if err := job.Run(); err != nil {
 			t.Fatal(err)
 		}
-		return info.Get("ID")
+		return info.Get("Id")
 	}
 
 	// build an image


### PR DESCRIPTION
Fix #1011

Instead of dumping JSON, we now select which keys we want to send.
Right now I put the same as before, all the exported variables but with the keys in CamelCase.

If you think we should hide some keys from inspect, now is the time to say so :) @crosbymichael @unclejack

This is a `"breaking"` change. I used `""` because we say to people not to rely to much on inspect as it might break :) Hopefully with this change, I'll become more stable.

We didn't break compatibility, if you hit with `/v.1.11` or lower, you'll get the old keys. /cc @discordianfish :smile:  
