### PR TITLE
Fix container attach API to stop silently ignoring errors

### DIFF
--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -909,9 +909,8 @@ func TestPostContainersAttach(t *testing.T) {
 	}()
 
 	// Acknowledge hijack
-	setTimeout(t, "hijack acknowledge timed out", 2*time.Second, func() {
+	setTimeout(t, "hijack acknowledge timed out", 10*time.Second, func() {
 		stdout.Read([]byte{})
-		stdout.Read(make([]byte, 4096))
 	})
 
 	setTimeout(t, "read/write assertion timed out", 2*time.Second, func() {
@@ -987,9 +986,8 @@ func TestPostContainersAttachStderr(t *testing.T) {
 	}()
 
 	// Acknowledge hijack
-	setTimeout(t, "hijack acknowledge timed out", 2*time.Second, func() {
+	setTimeout(t, "hijack acknowledge timed out", 10*time.Second, func() {
 		stdout.Read([]byte{})
-		stdout.Read(make([]byte, 4096))
 	})
 
 	setTimeout(t, "read/write assertion timed out", 2*time.Second, func() {

--- a/integration/commands_test.go
+++ b/integration/commands_test.go
@@ -267,7 +267,7 @@ func TestRunWorkdirExistsAndIsFile(t *testing.T) {
 		}
 	}()
 
-	setTimeout(t, "CmdRun timed out", 5*time.Second, func() {
+	setTimeout(t, "CmdRun timed out", 10*time.Second, func() {
 		<-c
 	})
 }


### PR DESCRIPTION
This patchset fixes several issues regarding `/containers/{id}/attach`, where no error code is returned when trying to attach to a stopped container (rather, the error was ignored silently).

It should be noted that this patchset does change the API, and will break older clients (so after building, ensure that both the docker daemon and client are the same version -- otherwise `docker run -i` won't function normally).

Docker-DCO-1.1-Signed-off-by: Aleksa Sarai cyphar@cyphar.com (github: cyphar)

Fixes #6108

/ping @vieux @shykes
