### PR TITLE
add mkimage support for mageia using urpmi

### DIFF
--- a/contrib/mkimage.sh
+++ b/contrib/mkimage.sh
@@ -9,6 +9,8 @@ usage() {
 	echo >&2 "       $mkimg -t someuser/ubuntu debootstrap --include=ubuntu-minimal trusty"
 	echo >&2 "       $mkimg -t someuser/busybox busybox-static"
 	echo >&2 "       $mkimg -t someuser/centos:5 rinse --distribution centos-5"
+	echo >&2 "       $mkimg -t someuser/mageia:4 mageia-urpmi --version=4"
+	echo >&2 "       $mkimg -t someuser/mageia:4 mageia-urpmi --version=4 --mirror=http://somemirror/"
 	exit 1
 }
 

--- a/contrib/mkimage/.febootstrap-minimize
+++ b/contrib/mkimage/.febootstrap-minimize
@@ -13,7 +13,7 @@ shift
 	#  docs
 	rm -rf usr/share/{man,doc,info,gnome/help}
 	#  cracklib
-	#rm -rf usr/share/cracklib
+	rm -rf usr/share/cracklib
 	#  i18n
 	rm -rf usr/share/i18n
 	#  yum cache

--- a/contrib/mkimage/mageia-urpmi
+++ b/contrib/mkimage/mageia-urpmi
@@ -53,25 +53,7 @@ fi
 		--root "$rootfsDir"
 )
 
-(
-	# Clean cruft to reduce image size - stolen and modifed from .febootstrap-minimize
-	set -x
-	cd "$rootfsDir"
-	#  locales
-	rm -rf usr/{{lib,share}/locale,{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive}
-	#  docs
-	rm -rf usr/share/{man,doc,info,gnome/help}
-	#  cracklib
-	rm -rf usr/share/cracklib
-	#  i18n
-	rm -rf usr/share/i18n
-	#  sln
-	rm -rf sbin/sln
-	#  ldconfig
-	#rm -rf sbin/ldconfig
-	rm -rf etc/ld.so.cache var/cache/ldconfig
-	mkdir -p --mode=0755 var/cache/ldconfig
-)
+"$(dirname "$BASH_SOURCE")/.febootstrap-minimize" "$rootfsDir"
 
 if [ -d "$rootfsDir/etc/sysconfig" ]; then
 	# allow networking init scripts inside the container to work without extra steps

--- a/contrib/mkimage/mageia-urpmi
+++ b/contrib/mkimage/mageia-urpmi
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Needs to be run from Mageia 4 or greater for kernel support for docker.
+#
+# Mageia 4 does not have docker available in official repos, so please
+# install and run the docker binary manually.
+#
+# Tested working versions are for Mageia 2 onwards (inc. cauldron).
+#
+set -e
+
+rootfsDir="$1"
+shift
+
+optTemp=$(getopt --options '+v:,m:' --longoptions 'version:,mirror:' --name mageia-urpmi -- "$@")
+eval set -- "$optTemp"
+unset optTemp
+
+installversion=
+mirror=
+while true; do
+	case "$1" in
+		-v|--version) installversion="$2" ; shift 2 ;;
+		-m|--mirror) mirror="$2" ; shift 2 ;;
+		--) shift ; break ;;
+	esac
+done
+
+if [ -z $installversion ]; then
+	# Attempt to match host version
+	if [ -r /etc/mageia-release ]; then
+		installversion="$(sed 's/^[^0-9\]*\([0-9.]\+\).*$/\1/' /etc/mageia-release)"
+	else
+		echo "Error: no version supplied and unable to detect host mageia version"
+		exit 1
+	fi
+fi
+
+if [ -z $mirror ]; then
+	# No mirror provided, default to mirrorlist
+	mirror="--mirrorlist https://mirrors.mageia.org/api/mageia.$installversion.x86_64.list"
+fi
+
+(
+	set -x
+	urpmi.addmedia --distrib \
+		$mirror \
+		--urpmi-root "$rootfsDir"
+	urpmi basesystem-minimal urpmi \
+		--auto \
+		--no-suggests \
+		--urpmi-root "$rootfsDir" \
+		--root "$rootfsDir"
+)
+
+(
+	# Clean cruft to reduce image size - stolen and modifed from .febootstrap-minimize
+	set -x
+	cd "$rootfsDir"
+	#  locales
+	rm -rf usr/{{lib,share}/locale,{lib,lib64}/gconv,bin/localedef,sbin/build-locale-archive}
+	#  docs
+	rm -rf usr/share/{man,doc,info,gnome/help}
+	#  cracklib
+	rm -rf usr/share/cracklib
+	#  i18n
+	rm -rf usr/share/i18n
+	#  sln
+	rm -rf sbin/sln
+	#  ldconfig
+	#rm -rf sbin/ldconfig
+	rm -rf etc/ld.so.cache var/cache/ldconfig
+	mkdir -p --mode=0755 var/cache/ldconfig
+)
+
+if [ -d "$rootfsDir/etc/sysconfig" ]; then
+	# allow networking init scripts inside the container to work without extra steps
+	echo 'NETWORKING=yes' > "$rootfsDir/etc/sysconfig/network"
+fi


### PR DESCRIPTION
- host needs to be Mageia 4 or greater for docker kernel requirements
- Mageia 4 missing docker in repo, so install docker binary manually
- tested successfully installing Mageia versions 2, 3, 4 and cauldron (5) from a Mageia 4 host
