### PR TITLE
Add per cpu usage to libcontainer  stats 

### DIFF
--- a/pkg/libcontainer/cgroups/fs/utils.go
+++ b/pkg/libcontainer/cgroups/fs/utils.go
@@ -22,7 +22,7 @@ func getCgroupParamKeyValue(t string) (string, uint64, error) {
 	case 2:
 		value, err := strconv.ParseUint(parts[1], 10, 64)
 		if err != nil {
-			return "", 0, fmt.Errorf("Unable to convert param value to int: %s", err)
+			return "", 0, fmt.Errorf("Unable to convert param value to uint64: %s", err)
 		}
 		return parts[0], value, nil
 	default:

--- a/pkg/libcontainer/cgroups/stats.go
+++ b/pkg/libcontainer/cgroups/stats.go
@@ -13,7 +13,8 @@ type CpuUsage struct {
 	// percentage of available CPUs currently being used.
 	PercentUsage uint64 `json:"percent_usage,omitempty"`
 	// nanoseconds of cpu time consumed over the last 100 ms.
-	CurrentUsage uint64 `json:"current_usage,omitempty"`
+	CurrentUsage uint64   `json:"current_usage,omitempty"`
+	PercpuUsage  []uint64 `json:"percpu_usage,omitempty"`
 }
 
 type CpuStats struct {


### PR DESCRIPTION
Extended cgroup.Stats to include percpu usage. 
