### PR TITLE
Move duplicated FS "magic" values to the graphdriver package so they can be shared

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -39,7 +39,10 @@ import (
 
 var (
 	ErrAufsNotSupported = fmt.Errorf("AUFS was not found in /proc/filesystems")
-	IncompatibleFSMagic = []int64{0x9123683E /*btrfs*/, 0x61756673 /*AUFS*/}
+	incompatibleFsMagic = []graphdriver.FsMagic{
+		graphdriver.FsMagicBtrfs,
+		graphdriver.FsMagicAufs,
+	}
 )
 
 func init() {
@@ -67,8 +70,8 @@ func Init(root string) (graphdriver.Driver, error) {
 		return nil, fmt.Errorf("Couldn't stat the root directory: %s", err)
 	}
 
-	for _, magic := range IncompatibleFSMagic {
-		if int64(buf.Type) == magic {
+	for _, magic := range incompatibleFsMagic {
+		if graphdriver.FsMagic(buf.Type) == magic {
 			return nil, graphdriver.ErrIncompatibleFS
 		}
 	}

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -18,10 +18,6 @@ import (
 	"unsafe"
 )
 
-const (
-	btrfsSuperMagic = 0x9123683E
-)
-
 func init() {
 	graphdriver.Register("btrfs", Init)
 }
@@ -34,7 +30,7 @@ func Init(home string) (graphdriver.Driver, error) {
 		return nil, err
 	}
 
-	if buf.Type != btrfsSuperMagic {
+	if graphdriver.FsMagic(buf.Type) != graphdriver.FsMagicBtrfs {
 		return nil, graphdriver.ErrPrerequisites
 	}
 

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -8,6 +8,13 @@ import (
 	"path"
 )
 
+type FsMagic uint64
+
+const (
+	FsMagicBtrfs = FsMagic(0x9123683E)
+	FsMagicAufs  = FsMagic(0x61756673)
+)
+
 type InitFunc func(root string) (Driver, error)
 
 type Driver interface {


### PR DESCRIPTION
We had the BTRFS "magic" value in two separate graph drivers, so this moves them both to "daemon/graphdriver" so they can be shared instead. :)
