### PR TITLE
apparmor: write & load the profile on every start

### DIFF
--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -21,9 +21,8 @@ import (
 )
 
 const (
-	DriverName                = "native"
-	Version                   = "0.2"
-	BackupApparmorProfilePath = "apparmor/docker.back" // relative to docker root
+	DriverName = "native"
+	Version    = "0.2"
 )
 
 func init() {
@@ -72,7 +71,7 @@ func NewDriver(root, initPath string) (*driver, error) {
 	}
 
 	// native driver root is at docker_root/execdriver/native. Put apparmor at docker_root
-	if err := apparmor.InstallDefaultProfile(filepath.Join(root, "../..", BackupApparmorProfilePath)); err != nil {
+	if err := apparmor.InstallDefaultProfile(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/apparmor/setup.go
+++ b/pkg/apparmor/setup.go
@@ -2,7 +2,6 @@ package apparmor
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -12,40 +11,9 @@ const (
 	DefaultProfilePath = "/etc/apparmor.d/docker"
 )
 
-func InstallDefaultProfile(backupPath string) error {
+func InstallDefaultProfile() error {
 	if !IsEnabled() {
 		return nil
-	}
-
-	// If the profile already exists, check if we already have a backup
-	// if not, do the backup and override it. (docker 0.10 upgrade changed the apparmor profile)
-	// see gh#5049, apparmor blocks signals in ubuntu 14.04
-	if _, err := os.Stat(DefaultProfilePath); err == nil {
-		if _, err := os.Stat(backupPath); err == nil {
-			// If both the profile and the backup are present, do nothing
-			return nil
-		}
-		// Make sure the directory exists
-		if err := os.MkdirAll(path.Dir(backupPath), 0755); err != nil {
-			return err
-		}
-
-		// Create the backup file
-		f, err := os.Create(backupPath)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-
-		src, err := os.Open(DefaultProfilePath)
-		if err != nil {
-			return err
-		}
-		defer src.Close()
-
-		if _, err := io.Copy(f, src); err != nil {
-			return err
-		}
 	}
 
 	// Make sure /etc/apparmor.d exists


### PR DESCRIPTION
This PR makes Docker write and load the apparmor on every start, even if the file exists on disk.

Fixes #5788
