### PR TITLE
Clarify manpages on docker start

### DIFF
--- a/contrib/man/md/docker-start.1.md
+++ b/contrib/man/md/docker-start.1.md
@@ -20,6 +20,10 @@ the process
 **-i**, **--interactive**=*true*|*false*
    When true attach to container's stdin
 
+# NOTES
+If run on a started container, start takes no action and succeeds
+unconditionally.
+
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.io source material and internal work.

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1139,6 +1139,9 @@ more details on finding shared images from the commandline.
       -a, --attach=false         Attach container's stdout/stderr and forward all signals to the process
       -i, --interactive=false    Attach container's stdin
 
+When run on a container that has already been started, 
+takes no action and succeeds unconditionally.
+
 ## stop
 
     Usage: docker stop [OPTIONS] CONTAINER [CONTAINER...]


### PR DESCRIPTION
Prior to Docker v0.10, when docker start was run on an already-started container, it failed with an error. This was changed in v0.10 (commit a03f83e3370f3859ebff172d504cc29817863b17), which caused some confusion from people accustomed to the previous behaviour. This patch clarifies in the man pages that this change is intentional.
