### PR TITLE
Make debian init work when called quickly.

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -22,7 +22,10 @@ BASE=$(basename $0)
 
 # modify these in /etc/default/$BASE (/etc/default/docker)
 DOCKER=/usr/bin/$BASE
+# This is the pid file managed by docker itself
 DOCKER_PIDFILE=/var/run/$BASE.pid
+# This is the pid file created/managed by start-stop-daemon
+DOCKER_SSD_PIDFILE=/var/run/$BASE-ssd.pid
 DOCKER_LOGFILE=/var/log/$BASE.log
 DOCKER_OPTS=
 DOCKER_DESC="Docker"
@@ -89,7 +92,8 @@ case "$1" in
 		start-stop-daemon --start --background \
 			--no-close \
 			--exec "$DOCKER" \
-			--pidfile "$DOCKER_PIDFILE" \
+			--pidfile "$DOCKER_SSD_PIDFILE" \
+			--make-pidfile \
 			-- \
 				-d -p "$DOCKER_PIDFILE" \
 				$DOCKER_OPTS \
@@ -100,13 +104,13 @@ case "$1" in
 	stop)
 		fail_unless_root
 		log_begin_msg "Stopping $DOCKER_DESC: $BASE"
-		start-stop-daemon --stop --pidfile "$DOCKER_PIDFILE"
+		start-stop-daemon --stop --pidfile "$DOCKER_SSD_PIDFILE"
 		log_end_msg $?
 		;;
 
 	restart)
 		fail_unless_root
-		docker_pid=`cat "$DOCKER_PIDFILE" 2>/dev/null`
+		docker_pid=`cat "$DOCKER_SSD_PIDFILE" 2>/dev/null`
 		[ -n "$docker_pid" ] \
 			&& ps -p $docker_pid > /dev/null 2>&1 \
 			&& $0 stop
@@ -119,7 +123,7 @@ case "$1" in
 		;;
 
 	status)
-		status_of_proc -p "$DOCKER_PIDFILE" "$DOCKER" docker
+		status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DOCKER" docker
 		;;
 
 	*)


### PR DESCRIPTION
We use the start-stop-daemon pid creation mechanism in addition the intrinsic built into docker.  This means the pid file is guaranteed to be written out by the time the script exits.

Fixes #6184
