### PR TITLE
fix diffs->diff typo in aufs.go

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -7,7 +7,7 @@ aufs driver directory structure
 │   ├── 1
 │   ├── 2
 │   └── 3
-├── diffs  // Content of the layer
+├── diff  // Content of the layer
 │   ├── 1  // Contains layers that need to be mounted for the id
 │   ├── 2
 │   └── 3


### PR DESCRIPTION
Closes #6071
#6071 lacks the required DCO.
