### PR TITLE
devmapper: use 'user_xattr' as mountoption for ext4 - fixes #6189

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -989,10 +989,17 @@ func (devices *DeviceSet) MountDevice(hash, path, mountLabel string) error {
 		options = joinMountOptions(options, "nouuid")
 	}
 
+	if fstype == "ext4" {
+		// ext4 needs to enable explicit support user xattrs
+		// user_xattr - support 'user.<namespace>' extended attributes
+		options = joinMountOptions(options, "user_xattr")
+	}
+
 	options = joinMountOptions(options, devices.mountOptions)
 	options = joinMountOptions(options, label.FormatMountLabel("", mountLabel))
 
 	err = syscall.Mount(info.DevName(), path, fstype, flags, joinMountOptions("discard", options))
+
 	if err != nil && err == syscall.EINVAL {
 		err = syscall.Mount(info.DevName(), path, fstype, flags, options)
 	}

--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -5,6 +5,31 @@ import (
 	"unsafe"
 )
 
+var _zero uintptr
+
+func Llistxattr(path string, dest []byte) (size int, err error) {
+	pathBytes, err := syscall.BytePtrFromString(path)
+
+	if err != nil {
+		return -1, err
+	}
+	var newpathBytes unsafe.Pointer
+
+	if len(dest) > 0 {
+		newpathBytes = unsafe.Pointer(&dest[0])
+	} else {
+		newpathBytes = unsafe.Pointer(&_zero)
+	}
+
+	_size, _, errno := syscall.Syscall6(syscall.SYS_LLISTXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(newpathBytes), uintptr(len(dest)), 0, 0, 0)
+	size = int(_size)
+	if errno != 0 {
+		return -1, errno
+	}
+
+	return size, nil
+}
+
 // Returns a nil slice and nil error if the xattr is not set
 func Lgetxattr(path string, attr string) ([]byte, error) {
 	pathBytes, err := syscall.BytePtrFromString(path)
@@ -19,22 +44,24 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 	dest := make([]byte, 128)
 	destBytes := unsafe.Pointer(&dest[0])
 	sz, _, errno := syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
-	if errno == syscall.ENODATA {
-		return nil, nil
-	}
-	if errno == syscall.ERANGE {
+
+	switch {
+	case errno == syscall.ENODATA:
+		return nil, errno
+	case errno == syscall.ENOTSUP:
+		return nil, errno
+	case errno == syscall.ERANGE:
 		dest = make([]byte, sz)
 		destBytes := unsafe.Pointer(&dest[0])
 		sz, _, errno = syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
-	}
-	if errno != 0 {
+		if errno != 0 {
+			return nil, errno
+		}
+	case errno != 0:
 		return nil, errno
 	}
-
 	return dest[:sz], nil
 }
-
-var _zero uintptr
 
 func Lsetxattr(path string, attr string, data []byte, flags int) error {
 	pathBytes, err := syscall.BytePtrFromString(path)

--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -7,6 +7,8 @@ import (
 
 var _zero uintptr
 
+// Returns the size of xattrs and nil error
+// Requires path, takes allocated []byte or nil as last argument
 func Llistxattr(path string, dest []byte) (size int, err error) {
 	pathBytes, err := syscall.BytePtrFromString(path)
 
@@ -30,8 +32,10 @@ func Llistxattr(path string, dest []byte) (size int, err error) {
 	return size, nil
 }
 
-// Returns a nil slice and nil error if the xattr is not set
+// Returns a []byte slice if the xattr is set and nil otherwise
+// Requires path and its attribute as arguments
 func Lgetxattr(path string, attr string) ([]byte, error) {
+	var sz int
 	pathBytes, err := syscall.BytePtrFromString(path)
 	if err != nil {
 		return nil, err
@@ -41,9 +45,12 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 		return nil, err
 	}
 
-	dest := make([]byte, 128)
+	// Start with a 128 length byte array
+	sz = 128
+	dest := make([]byte, sz)
+
 	destBytes := unsafe.Pointer(&dest[0])
-	sz, _, errno := syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+	_sz, _, errno := syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
 
 	switch {
 	case errno == syscall.ENODATA:
@@ -51,15 +58,24 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 	case errno == syscall.ENOTSUP:
 		return nil, errno
 	case errno == syscall.ERANGE:
+		// 128 byte array might just not be good enough,
+		// A dummy buffer is used ``uintptr(0)`` to get real size
+		// of the xattrs on disk
+		_sz, _, errno = syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(unsafe.Pointer(nil)), uintptr(0), 0, 0)
+		sz = int(_sz)
+		if sz < 0 {
+			return nil, errno
+		}
 		dest = make([]byte, sz)
 		destBytes := unsafe.Pointer(&dest[0])
-		sz, _, errno = syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+		_sz, _, errno = syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
 		if errno != 0 {
 			return nil, errno
 		}
 	case errno != 0:
 		return nil, errno
 	}
+	sz = int(_sz)
 	return dest[:sz], nil
 }
 

--- a/pkg/system/xattrs_unsupported.go
+++ b/pkg/system/xattrs_unsupported.go
@@ -2,6 +2,10 @@
 
 package system
 
+func Llistxattr(path string, dest []byte) (size int, err error) {
+	return -1, ErrNotSupportedPlatform
+}
+
 func Lgetxattr(path string, attr string) ([]byte, error) {
 	return nil, ErrNotSupportedPlatform
 }


### PR DESCRIPTION
```
># docker pull centos
># docker run -i -t centos /bin/bash

bash-4.1# touch file
bash-4.1# setfattr -n user.attr -v 1 file
setfattr: file: Operation not permitted
```

With 'user_xattr' as mount option

```
bash-4.1# touch file
bash-4.1# setfattr -n user.attr -v 1 file
bash-4.1# getfattr -d -m. file
>#file: file
user.xattr="1"
```
