### PR TITLE
Fix races in tests

### DIFF
--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ensure that an added file shows up in docker diff
@@ -70,6 +71,8 @@ func TestDiffEnsureOnlyKmsgAndPtmx(t *testing.T) {
 	cid, _, err := runCommandWithOutput(runCmd)
 	errorOut(err, t, fmt.Sprintf("%s", err))
 	cleanCID := stripTrailingCharacters(cid)
+
+	time.Sleep(300 * time.Millisecond)
 
 	diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
 	out, _, err := runCommandWithOutput(diffCmd)

--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestTopNonPrivileged(t *testing.T) {
@@ -13,6 +14,8 @@ func TestTopNonPrivileged(t *testing.T) {
 	errorOut(err, t, fmt.Sprintf("failed to start the container: %v", err))
 
 	cleanedContainerID := stripTrailingCharacters(out)
+
+	time.Sleep(300 * time.Millisecond)
 
 	topCmd := exec.Command(dockerBinary, "top", cleanedContainerID)
 	out, _, err = runCommandWithOutput(topCmd)
@@ -45,6 +48,8 @@ func TestTopPrivileged(t *testing.T) {
 	errorOut(err, t, fmt.Sprintf("failed to start the container: %v", err))
 
 	cleanedContainerID := stripTrailingCharacters(out)
+
+	time.Sleep(300 * time.Millisecond)
 
 	topCmd := exec.Command(dockerBinary, "top", cleanedContainerID)
 	out, _, err = runCommandWithOutput(topCmd)


### PR DESCRIPTION
I sometimes had fails for `TestDiffEnsureOnlyKmsgAndPtmx`, `TestTopNonPrivileged` and `TestTopPrivileged`. After this fix I have no fails for this tests at all.
