### PR TITLE
New implementation of /run support

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dotcloud/docker/pkg/networkfs/etchosts"
 	"github.com/dotcloud/docker/pkg/networkfs/resolvconf"
 	"github.com/dotcloud/docker/pkg/symlink"
+	"github.com/dotcloud/docker/pkg/system"
 	"github.com/dotcloud/docker/runconfig"
 	"github.com/dotcloud/docker/utils"
 )
@@ -298,7 +299,17 @@ func (container *Container) Start() (err error) {
 	}
 	container.waitLock = make(chan struct{})
 
-	return container.waitForStart()
+	if err := container.waitForStart(); err != nil {
+		return err
+	}
+
+	if !container.hostConfig.NoRunFs {
+		if err := system.Unmount(container.runPath(), syscall.MNT_DETACH); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (container *Container) Run() error {
@@ -529,6 +540,11 @@ func (container *Container) cleanup() {
 		}
 	}
 
+	// Ignore errors here as it may not be mounted anymore
+	if !container.hostConfig.NoRunFs {
+		system.Unmount(container.runPath(), syscall.MNT_DETACH)
+	}
+
 	if err := container.Unmount(); err != nil {
 		log.Printf("%v: Failed to umount filesystem: %v", container.ID, err)
 	}
@@ -698,6 +714,10 @@ func (container *Container) logPath(name string) string {
 
 func (container *Container) ReadLog(name string) (io.Reader, error) {
 	return os.Open(container.logPath(name))
+}
+
+func (container *Container) runPath() string {
+	return container.getRootResourcePath("run")
 }
 
 func (container *Container) hostConfigPath() string {

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -257,6 +257,7 @@ func SetupInitLayer(initLayer string) error {
 		"/dev/pts":         "dir",
 		"/dev/shm":         "dir",
 		"/proc":            "dir",
+		"/run":             "dir",
 		"/sys":             "dir",
 		"/.dockerinit":     "file",
 		"/.dockerenv":      "file",

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -31,6 +31,7 @@ type HostConfig struct {
 	DnsSearch       []string
 	VolumesFrom     []string
 	NetworkMode     NetworkMode
+	NoRunFs         bool
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {

--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -662,6 +662,9 @@ func (b *buildFile) create() (*daemon.Container, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	c.SetHostConfig(&runconfig.HostConfig{NoRunFs: true})
+
 	b.tmpContainers[c.ID] = struct{}{}
 	fmt.Fprintf(b.outStream, " ---> Running in %s\n", utils.TruncateID(c.ID))
 


### PR DESCRIPTION
This is an alternative implementation of https://github.com/dotcloud/docker/pull/5991 that uses a tmpfs
set up on the host which is then moved into the container, rather than mounting it inside the container
and copying the files there via libcontainer.

This mounts a /run tmpfs into the container, with the initial contents
copies from the /run in the base image, unless NoRunFs is set in the
HostConfig.

Additionally NoRunFs is always set during a docker build, which means
any setup of /run in a Dockerfile is saved in the image to be copied
into the final /run tmpfs when a container is started.
