### PR TITLE
Add more stats to libcontainer.

### DIFF
--- a/pkg/libcontainer/cgroups/fs/memory.go
+++ b/pkg/libcontainer/cgroups/fs/memory.go
@@ -84,6 +84,11 @@ func (s *memoryGroup) GetStats(d *data, stats *cgroups.Stats) error {
 		return err
 	}
 	stats.MemoryStats.MaxUsage = value
+	value, err = getCgroupParamInt(path, "memory.failcnt")
+	if err != nil {
+		return err
+	}
+	stats.MemoryStats.Failcnt = value
 
 	return nil
 }

--- a/pkg/libcontainer/cgroups/fs/memory_test.go
+++ b/pkg/libcontainer/cgroups/fs/memory_test.go
@@ -11,6 +11,7 @@ const (
 rss 1024`
 	memoryUsageContents    = "2048\n"
 	memoryMaxUsageContents = "4096\n"
+	memoryFailcnt          = "100\n"
 )
 
 func TestMemoryStats(t *testing.T) {
@@ -20,6 +21,7 @@ func TestMemoryStats(t *testing.T) {
 		"memory.stat":               memoryStatContents,
 		"memory.usage_in_bytes":     memoryUsageContents,
 		"memory.max_usage_in_bytes": memoryMaxUsageContents,
+		"memory.failcnt":            memoryFailcnt,
 	})
 
 	memory := &memoryGroup{}
@@ -27,7 +29,7 @@ func TestMemoryStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedStats := cgroups.MemoryStats{Usage: 2048, MaxUsage: 4096, Stats: map[string]uint64{"cache": 512, "rss": 1024}}
+	expectedStats := cgroups.MemoryStats{Usage: 2048, MaxUsage: 4096, Failcnt: 100, Stats: map[string]uint64{"cache": 512, "rss": 1024}}
 	expectMemoryStatEquals(t, expectedStats, actualStats.MemoryStats)
 }
 

--- a/pkg/libcontainer/cgroups/stats.go
+++ b/pkg/libcontainer/cgroups/stats.go
@@ -15,6 +15,10 @@ type CpuUsage struct {
 	// nanoseconds of cpu time consumed over the last 100 ms.
 	CurrentUsage uint64   `json:"current_usage,omitempty"`
 	PercpuUsage  []uint64 `json:"percpu_usage,omitempty"`
+	// Time spent by tasks of the cgroup in kernel mode. Units: nanoseconds.
+	UsageInKernelmode uint64 `json:"usage_in_kernelmode"`
+	// Time spent by tasks of the cgroup in user mode. Units: nanoseconds.
+	UsageInUsermode uint64 `json:"usage_in_usermode"`
 }
 
 type CpuStats struct {
@@ -30,6 +34,8 @@ type MemoryStats struct {
 	// TODO(vishh): Export these as stronger types.
 	// all the stats exported via memory.stat.
 	Stats map[string]uint64 `json:"stats,omitempty"`
+	// number of times memory usage hits limits.
+	Failcnt uint64 `json:"failcnt"`
 }
 
 type BlkioStatEntry struct {


### PR DESCRIPTION
Adding cgroup stats for memory allocation failure count and instantaneous cpu usage in the usermode and kernelmode.

Docker-DCO-1.1-Signed-off-by: Vishnu Kannan vishnuk@google.com (github: vishh)
