### PR TITLE
Move doc section in Remote API about removing insert from v1.11 to v1.12

### DIFF
--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -50,6 +50,9 @@ All the JSON keys are now in CamelCase
 **New!**
 Trusted builds are now Automated Builds - `is_trusted` is now `is_automated`.
 
+**Removed Insert Endpoint**
+The insert endpoint has been removed.
+
 ## v1.11
 
 ### Full Documentation
@@ -62,9 +65,6 @@ Trusted builds are now Automated Builds - `is_trusted` is now `is_automated`.
 
 **New!**
 You can now ping the server via the `_ping` endpoint.
-
-**Removed Insert Endpoint**
-The insert endpoint has been removed.
 
 `GET /events`
 


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Tibor Vass teabee89@gmail.com (github: tiborvass)
