### PR TITLE
Fixes incorrect API spec for items moved to HostConfig

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.10.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.10.md
@@ -371,7 +371,7 @@ Start the container `id`
              "PublishAllPorts":false,
              "Privileged":false
              "Dns": ["8.8.8.8"],
-             "VolumesFrom: ["parent", "other:ro"]
+             "VolumesFrom": ["parent", "other:ro"]
         }
 
     **Example response**:

--- a/docs/sources/reference/api/docker_remote_api_v1.11.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.11.md
@@ -123,7 +123,6 @@ Create a container
              "Cmd":[
                      "date"
              ],
-             "Dns":null,
              "Image":"base",
              "Volumes":{
                      "/tmp": {}
@@ -410,7 +409,9 @@ Start the container `id`
              "LxcConf":{"lxc.utsname":"docker"},
              "PortBindings":{ "22/tcp": [{ "HostPort": "11022" }] },
              "PublishAllPorts":false,
-             "Privileged":false
+             "Privileged":false,
+             "Dns": ["8.8.8.8"],
+             "VolumesFrom": ["parent", "other:ro"]
         }
 
     **Example response**:

--- a/docs/sources/reference/api/docker_remote_api_v1.12.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.12.md
@@ -124,12 +124,10 @@ Create a container
              "Cmd":[
                      "date"
              ],
-             "Dns":null,
              "Image":"base",
              "Volumes":{
                      "/tmp": {}
              },
-             "VolumesFrom":"",
              "WorkingDir":"",
              "DisableNetwork": false,
              "ExposedPorts":{
@@ -411,7 +409,9 @@ Start the container `id`
              "LxcConf":{"lxc.utsname":"docker"},
              "PortBindings":{ "22/tcp": [{ "HostPort": "11022" }] },
              "PublishAllPorts":false,
-             "Privileged":false
+             "Privileged":false,
+             "Dns": ["8.8.8.8"],
+             "VolumesFrom": ["parent", "other:ro"]
         }
 
     **Example response**:


### PR DESCRIPTION
DNS and VolumesFrom were moved to HostConfig and as such are part of the
container start and not create.
For some reason 0.10 docs are correct (except for a missing quote in the
JSON") but 0.11 and latest are not.

Docker-DCO-1.1-Signed-off-by: cpuguy83 cpuguy83@gmail.com (github: cpuguy83)
