### PR TITLE
Convert integration/api_test:TestGetEvents into a unit test and a CLI test

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCLIGetEvents(t *testing.T) {
+	out, _, _ := cmd(t, "images", "-q")
+	image := strings.Split(out, "\n")[0]
+	cmd(t, "tag", image, "utest:tag1")
+	cmd(t, "tag", image, "utest:tag2")
+	cmd(t, "rmi", "utest:tag1")
+	cmd(t, "rmi", "utest:tag2")
+	eventsCmd := exec.Command("timeout", "0.2", dockerBinary, "events", "--since=1")
+	out, _, _ = runCommandWithOutput(eventsCmd)
+	events := strings.Split(out, "\n")
+	n_events := len(events)
+	// The last element after the split above will be an empty string, so we
+	// get the two elements before the last, which are the untags we're
+	// looking for.
+	for _, v := range events[n_events-3 : n_events-1] {
+		if !strings.Contains(v, "untag") {
+			t.Fatalf("event should be untag, not %#v", v)
+		}
+	}
+	logDone("events - untags are logged")
+}

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -19,55 +19,8 @@ import (
 	"github.com/dotcloud/docker/engine"
 	"github.com/dotcloud/docker/image"
 	"github.com/dotcloud/docker/runconfig"
-	"github.com/dotcloud/docker/utils"
 	"github.com/dotcloud/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 )
-
-func TestGetEvents(t *testing.T) {
-	eng := NewTestEngine(t)
-	srv := mkServerFromEngine(eng, t)
-	// FIXME: we might not need daemon, why not simply nuke
-	// the engine?
-	daemon := mkDaemonFromEngine(eng, t)
-	defer nuke(daemon)
-
-	var events []*utils.JSONMessage
-	for _, parts := range [][3]string{
-		{"fakeaction", "fakeid", "fakeimage"},
-		{"fakeaction2", "fakeid", "fakeimage"},
-	} {
-		action, id, from := parts[0], parts[1], parts[2]
-		ev := srv.LogEvent(action, id, from)
-		events = append(events, ev)
-	}
-
-	req, err := http.NewRequest("GET", "/events?since=1", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	r := httptest.NewRecorder()
-	setTimeout(t, "", 500*time.Millisecond, func() {
-		if err := server.ServeRequest(eng, api.APIVERSION, r, req); err != nil {
-			t.Fatal(err)
-		}
-		assertHttpNotError(r, t)
-	})
-
-	dec := json.NewDecoder(r.Body)
-	for i := 0; i < 2; i++ {
-		var jm utils.JSONMessage
-		if err := dec.Decode(&jm); err == io.EOF {
-			break
-		} else if err != nil {
-			t.Fatal(err)
-		}
-		if jm != *events[i] {
-			t.Fatalf("Event received it different than expected")
-		}
-	}
-
-}
 
 func TestGetImagesJSON(t *testing.T) {
 	eng := NewTestEngine(t)


### PR DESCRIPTION
In this specific case replacing the existing test with a single unit test would mean loss of code coverage, so I created both a unit test for the api-specific bits and an integration-cli test for the 'events' command.
