### PR TITLE
Remove apt lists which take 40MB on a 220MB image

### DIFF
--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -122,4 +122,6 @@ fi
 	set -x
 	chroot "$rootfsDir" apt-get update
 	chroot "$rootfsDir" apt-get dist-upgrade -y
+	#use find because globs expand on the host, not in chroot
+	chroot "$rootfsDir" find /var/lib/apt/lists/ -type f -delete
 )


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Konrad Scherer kmscherer@gmail.com (github: kscherer)
