### PR TITLE
Move remount as private to the graph drivers

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -97,6 +97,10 @@ func Init(root string, options []string) (graphdriver.Driver, error) {
 		return nil, err
 	}
 
+	if err := graphdriver.MakePrivate(root); err != nil {
+		return nil, err
+	}
+
 	for _, p := range paths {
 		if err := os.MkdirAll(path.Join(root, p), 0755); err != nil {
 			return nil, err
@@ -371,12 +375,14 @@ func (a *Driver) Cleanup() error {
 	if err != nil {
 		return err
 	}
+
 	for _, id := range ids {
 		if err := a.unmount(id); err != nil {
 			utils.Errorf("Unmounting %s: %s", utils.TruncateID(id), err)
 		}
 	}
-	return nil
+
+	return mountpk.Unmount(a.root)
 }
 
 func (a *Driver) aufsMount(ro []string, rw, target, mountLabel string) (err error) {

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -3,9 +3,11 @@ package graphdriver
 import (
 	"errors"
 	"fmt"
-	"github.com/dotcloud/docker/archive"
 	"os"
 	"path"
+
+	"github.com/dotcloud/docker/archive"
+	"github.com/dotcloud/docker/pkg/mount"
 )
 
 type FsMagic uint64
@@ -106,4 +108,19 @@ func New(root string, options []string) (driver Driver, err error) {
 		return driver, nil
 	}
 	return nil, fmt.Errorf("No supported storage backend found")
+}
+
+func MakePrivate(mountPoint string) error {
+	mounted, err := mount.Mounted(mountPoint)
+	if err != nil {
+		return err
+	}
+
+	if !mounted {
+		if err := mount.Mount(mountPoint, mountPoint, "none", "bind,rw"); err != nil {
+			return err
+		}
+	}
+
+	return mount.ForceMount("", mountPoint, "none", "private")
 }


### PR DESCRIPTION
If this is at the root directory for the daemon you could unmount
somones filesystem when you stop docker and this is actually only needed
for the palces that the graph drivers mount the container's root
    filesystems.

ping @vieux 

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
