### PR TITLE
Fixed docker commit man page typos

### DIFF
--- a/contrib/man/md/docker-commit.1.md
+++ b/contrib/man/md/docker-commit.1.md
@@ -26,8 +26,8 @@ An existing Fedora based container has had Apache installed while running
 in interactive mode with the bash shell. Apache is also running. To
 create a new image run docker ps to find the container's ID and then run:
 
-    # docker commit -me= "Added Apache to Fedora base image" \
-      --a="A D Ministrator" 98bd7fc99854 fedora/fedora_httpd:20
+    # docker commit -m= "Added Apache to Fedora base image" \
+      -a="A D Ministrator" 98bd7fc99854 fedora/fedora_httpd:20
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)


### PR DESCRIPTION
This commit responds to https://bugzilla.redhat.com/show_bug.cgi?id=1104401
