### PR TITLE
Update verification instruction.

### DIFF
--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -34,7 +34,7 @@ To install the latest Ubuntu package (may not be the latest Docker release):
 
 To verify that everything has worked as expected:
 
-    $ sudo docker run -i -t ubuntu /bin/bash
+    $ sudo docker.io run -i -t ubuntu /bin/bash
 
 Which should download the `ubuntu` image, and then start `bash` in a container.
 


### PR DESCRIPTION
I just upgraded to Ubuntu 14.04LTS and installed docker;
the program that is installed is called `docker.io`.

Perhaps there should be a `docker` symlink to `docker.io` but for now
the instructions should be changed to use `docker.io` as the command.
