### PR TITLE
Attach devices during container creation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -74,6 +74,7 @@ Charles Lindsay <chaz@chazomatic.us>
 Charles Merriam <charles.merriam@gmail.com>
 Charlie Lewis <charliel@lab41.org>
 Chia-liang Kao <clkao@clkao.org>
+Chris Alfonso <calfonso@redhat.com>
 Chris St. Pierre <chris.a.st.pierre@gmail.com>
 Christopher Currie <codemonkey+github@gmail.com>
 Christopher Rigor <crigor@gmail.com>
@@ -171,6 +172,7 @@ Harley Laue <losinggeneration@gmail.com>
 Hector Castro <hectcastro@gmail.com>
 Hobofan <goisser94@gmail.com>
 Hunter Blanks <hunter@twilio.com>
+Ian Main <imain@redhat.com>
 Ian Truslove <ian.truslove@gmail.com>
 ILYA Khlopotov <ilya.khlopotov@gmail.com>
 inglesp <peter.inglesby@gmail.com>

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -275,7 +275,6 @@ func (container *Container) createDevices() error {
 		if err != nil {
 			return err
 		}
-		dst = path.Join(container.RootfsPath(), dst)
 
 		stat, err := os.Stat(src)
 		if err != nil {
@@ -303,18 +302,9 @@ func (container *Container) createDevices() error {
 			return fmt.Errorf("Cannot determine the device major and minor numbers")
 		}
 
-		oldMask := syscall.Umask(int(0))
-		if err := os.MkdirAll(path.Dir(dst), 0755); err != nil {
-			return err
-		}
-		if err := syscall.Mknod(dst, uint32(perm), devNumber); err != nil {
-			return err
-		}
-		syscall.Umask(oldMask)
-
 		devMajor := int64((devNumber >> 8) & 0xfff)
 		devMinor := int64((devNumber & 0xff) | ((devNumber >> 12) & 0xfff00))
-		if err := container.daemon.execDriver.AddDevice(container.command, devType, devMajor, devMinor); err != nil {
+		if err := container.daemon.execDriver.AddDevice(container.command, dst, devType, devMajor, devMinor); err != nil {
 			return err
 		}
 	}

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -262,7 +262,64 @@ func (container *Container) Start() (err error) {
 	}
 	container.waitLock = make(chan struct{})
 
+	if err := container.createDevices(); err != nil {
+		return err
+	}
+
 	return container.waitForStart()
+}
+
+func (container *Container) createDevices() error {
+	for _, device := range container.hostConfig.Devices {
+		src, dst, err := utils.ParseDevice(device)
+		if err != nil {
+			return err
+		}
+		dst = path.Join(container.RootfsPath(), dst)
+
+		stat, err := os.Stat(src)
+		if err != nil {
+			return err
+		}
+
+		devType := 'c'
+		mode := stat.Mode()
+		perm := os.FileMode.Perm(mode)
+		switch {
+		case (mode & os.ModeDevice) == 0:
+			return fmt.Errorf("%s is not a device", src)
+		case (mode & os.ModeCharDevice) != 0:
+			perm |= syscall.S_IFCHR
+		default:
+			perm |= syscall.S_IFBLK
+			devType = 'b'
+		}
+
+		devNumber := 0
+		sys, ok := stat.Sys().(*syscall.Stat_t)
+		if ok {
+			devNumber = int(sys.Rdev)
+		} else {
+			return fmt.Errorf("Cannot determine the device major and minor numbers")
+		}
+
+		oldMask := syscall.Umask(int(0))
+		if err := os.MkdirAll(path.Dir(dst), 0755); err != nil {
+			return err
+		}
+		if err := syscall.Mknod(dst, uint32(perm), devNumber); err != nil {
+			return err
+		}
+		syscall.Umask(oldMask)
+
+		devMajor := int64((devNumber >> 8) & 0xfff)
+		devMinor := int64((devNumber & 0xff) | ((devNumber >> 12) & 0xfff00))
+		if err := container.daemon.execDriver.AddDevice(container.command, devType, devMajor, devMinor); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (container *Container) Run() error {

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -89,6 +89,7 @@ type Driver interface {
 	Info(id string) Info                          // "temporary" hack (until we move state from core to plugins)
 	GetPidsForContainer(id string) ([]int, error) // Returns a list of pids for the given container.
 	Terminate(c *Command) error                   // kill it with fire
+	AddDevice(c *Command, devType rune, devMajor int64, devMinor int64) error
 }
 
 // Network settings of the container

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -89,7 +89,7 @@ type Driver interface {
 	Info(id string) Info                          // "temporary" hack (until we move state from core to plugins)
 	GetPidsForContainer(id string) ([]int, error) // Returns a list of pids for the given container.
 	Terminate(c *Command) error                   // kill it with fire
-	AddDevice(c *Command, devType rune, devMajor int64, devMinor int64) error
+	AddDevice(c *Command, path string, devType rune, devMajor int64, devMinor int64) error
 }
 
 // Network settings of the container

--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -85,6 +85,13 @@ func (d *driver) Name() string {
 	return fmt.Sprintf("%s-%s", DriverName, version)
 }
 
+func (d *driver) AddDevice(c *execdriver.Command, devType rune, devMajor int64, devMinor int64) error {
+	c.Config["lxc"] = append(c.Config["lxc"], fmt.Sprintf("cgroup.devices.allow = %c %d:%d rwm",
+		devType, devMajor, devMinor))
+
+	return nil
+}
+
 func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
 	if err := execdriver.SetTerminal(c, pipes); err != nil {
 		return -1, err

--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dotcloud/docker/daemon/execdriver"
 	"github.com/dotcloud/docker/pkg/label"
 	"github.com/dotcloud/docker/pkg/libcontainer/cgroups"
+	"github.com/dotcloud/docker/pkg/libcontainer/devices"
 	"github.com/dotcloud/docker/pkg/libcontainer/mount/nodes"
 	"github.com/dotcloud/docker/pkg/system"
 	"github.com/dotcloud/docker/utils"
@@ -85,7 +86,17 @@ func (d *driver) Name() string {
 	return fmt.Sprintf("%s-%s", DriverName, version)
 }
 
-func (d *driver) AddDevice(c *execdriver.Command, devType rune, devMajor int64, devMinor int64) error {
+func (d *driver) AddDevice(c *execdriver.Command, path string, devType rune, devMajor int64, devMinor int64) error {
+	device := &devices.Device{
+		Type:              devType,
+		Path:              path,
+		MajorNumber:       devMajor,
+		MinorNumber:       devMinor,
+		CgroupPermissions: "rwm",
+		FileMode:          0644,
+	}
+	c.AutoCreatedDevices = append(c.AutoCreatedDevices, device)
+
 	c.Config["lxc"] = append(c.Config["lxc"], fmt.Sprintf("cgroup.devices.allow = %c %d:%d rwm",
 		devType, devMajor, devMinor))
 

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dotcloud/docker/pkg/libcontainer"
 	"github.com/dotcloud/docker/pkg/libcontainer/cgroups/fs"
 	"github.com/dotcloud/docker/pkg/libcontainer/cgroups/systemd"
+	"github.com/dotcloud/docker/pkg/libcontainer/devices"
 	"github.com/dotcloud/docker/pkg/libcontainer/namespaces"
 	"github.com/dotcloud/docker/pkg/system"
 )
@@ -82,7 +83,19 @@ func NewDriver(root, initPath string) (*driver, error) {
 	}, nil
 }
 
-func (d *driver) AddDevice(c *execdriver.Command, devType rune, devMajor int64, devMinor int64) error {
+func (d *driver) AddDevice(c *execdriver.Command, path string, devType rune, devMajor int64, devMinor int64) error {
+	device := &devices.Device{
+		Type:              devType,
+		Path:              path,
+		MajorNumber:       devMajor,
+		MinorNumber:       devMinor,
+		CgroupPermissions: "rwm",
+		FileMode:          0644,
+	}
+
+	c.AllowedDevices = append(c.AllowedDevices, device)
+	c.AutoCreatedDevices = append(c.AutoCreatedDevices, device)
+
 	return nil
 }
 

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -82,6 +82,10 @@ func NewDriver(root, initPath string) (*driver, error) {
 	}, nil
 }
 
+func (d *driver) AddDevice(c *execdriver.Command, devType rune, devMajor int64, devMinor int64) error {
+	return nil
+}
+
 func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
 	// take the Command and populate the libcontainer.Container from it
 	container, err := d.createContainer(c)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -885,3 +885,19 @@ func TestRunUnprivilegedWithChroot(t *testing.T) {
 
 	logDone("run - unprivileged with chroot")
 }
+
+func TestDevice(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "--device", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "ls /dev/nulo")
+
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	if actual := strings.Trim(out, "\r\n"); actual != "/dev/nulo" {
+		t.Fatalf("expected output /dev/nulo, received %s", actual)
+	}
+	deleteAllContainers()
+
+	logDone("run - test device")
+}

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -67,5 +67,6 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 	if Entrypoint := job.GetenvList("Entrypoint"); Entrypoint != nil {
 		config.Entrypoint = Entrypoint
 	}
+
 	return config
 }

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -31,6 +31,7 @@ type HostConfig struct {
 	DnsSearch       []string
 	VolumesFrom     []string
 	NetworkMode     NetworkMode
+	Devices         []string
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
@@ -56,6 +57,9 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 	}
 	if VolumesFrom := job.GetenvList("VolumesFrom"); VolumesFrom != nil {
 		hostConfig.VolumesFrom = VolumesFrom
+	}
+	if Devices := job.GetenvList("Devices"); Devices != nil {
+		hostConfig.Devices = Devices
 	}
 	return hostConfig
 }

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -41,6 +41,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flVolumes = opts.NewListOpts(opts.ValidatePath)
 		flLinks   = opts.NewListOpts(opts.ValidateLink)
 		flEnv     = opts.NewListOpts(opts.ValidateEnv)
+		flDevices = opts.NewListOpts(opts.ValidatePath)
 
 		flPublish     opts.ListOpts
 		flExpose      opts.ListOpts
@@ -74,6 +75,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	cmd.Var(&flAttach, []string{"a", "-attach"}, "Attach to stdin, stdout or stderr.")
 	cmd.Var(&flVolumes, []string{"v", "-volume"}, "Bind mount a volume (e.g. from the host: -v /host:/container, from docker: -v /container)")
 	cmd.Var(&flLinks, []string{"#link", "-link"}, "Add link to another container (name:alias)")
+	cmd.Var(&flDevices, []string{"device", "-device"}, "Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc)")
 	cmd.Var(&flEnv, []string{"e", "-env"}, "Set environment variables")
 	cmd.Var(&flEnvFile, []string{"-env-file"}, "Read in a line delimited file of ENV variables")
 
@@ -245,6 +247,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		DnsSearch:       flDnsSearch.GetAll(),
 		VolumesFrom:     flVolumesFrom.GetAll(),
 		NetworkMode:     netMode,
+		Devices:         flDevices.GetAll(),
 	}
 
 	if sysInfo != nil && flMemory > 0 && !sysInfo.SwapLimit {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1088,3 +1088,24 @@ func ValidateContextDirectory(srcPath string) error {
 	})
 	return finalError
 }
+
+func ParseDevice(device string) (string, string, error) {
+	src := ""
+	dst := ""
+	arr := strings.Split(device, ":")
+	switch len(arr) {
+	case 2:
+		dst = arr[1]
+		fallthrough
+	case 1:
+		src = arr[0]
+	default:
+		return "", "", fmt.Errorf("Invalid device specification: %s", device)
+	}
+
+	if dst == "" {
+		dst = src
+	}
+
+	return src, dst, nil
+}


### PR DESCRIPTION
Attach devices during container creation

This patch builds on Dinesh Subhraveti's great work on adding a --device argument to docker run.  This adds a native driver implementation and fixes device node creation within the container by adding it to the list of created devices.
