### PR TITLE
Dockerfile add NOCACHE instruction to specification

### DIFF
--- a/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
+++ b/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
@@ -12,7 +12,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>^\s*(ONBUILD\s+)?(FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|USER|WORKDIR|COPY)\s</string>
+			<string>^\s*(ONBUILD\s+)?(FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|USER|WORKDIR|COPY|NOCACHE)\s</string>
 			<key>captures</key>
 			<dict>
 				<key>0</key>

--- a/contrib/syntax/vim/syntax/dockerfile.vim
+++ b/contrib/syntax/vim/syntax/dockerfile.vim
@@ -11,7 +11,7 @@ let b:current_syntax = "dockerfile"
 
 syntax case ignore
 
-syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|VOLUME|WORKDIR|COPY)\s/
+syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|VOLUME|WORKDIR|COPY|NOCACHE)\s/
 highlight link dockerfileKeyword Keyword
 
 syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -461,6 +461,15 @@ For example you might add something like this:
 
 > **Warning**: ONBUILD may not trigger FROM or MAINTAINER instructions.
 
+## NOCACHE
+
+    NOCACHE
+
+The `NOCACHE` instruction tells Docker to run all subsequent instructions
+without using the instruction cache. This can be used to ensure that certain
+build commands (such as package updates) happen on *EACH* build of the
+Dockerfile.
+
 ## Dockerfile Examples
 
     # Nginx

--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -376,6 +376,15 @@ func (b *buildFile) CmdVolume(args string) error {
 	return nil
 }
 
+func (b *buildFile) CmdNocache(args string) error {
+	if len(strings.Fields(args)) != 0 {
+		return fmt.Errorf("Non-zero number of arguments passed to NOCACHE")
+	}
+
+	b.utilizeCache = false
+	return nil
+}
+
 func (b *buildFile) checkPathForAddition(orig string) error {
 	origPath := path.Join(b.contextPath, orig)
 	if p, err := filepath.EvalSymlinks(origPath); err != nil {
@@ -817,12 +826,17 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 // BuildStep parses a single build step from `instruction` and executes it in the current context.
 func (b *buildFile) BuildStep(name, expression string) error {
 	fmt.Fprintf(b.outStream, "Step %s : %s\n", name, expression)
+
 	tmp := strings.SplitN(expression, " ", 2)
-	if len(tmp) != 2 {
+	if len(tmp) == 0 {
 		return fmt.Errorf("Invalid Dockerfile format")
 	}
+
 	instruction := strings.ToLower(strings.Trim(tmp[0], " "))
-	arguments := strings.Trim(tmp[1], " ")
+	var arguments string
+	if len(tmp) == 2 {
+		arguments = strings.Trim(tmp[1], " ")
+	}
 
 	method, exists := reflect.TypeOf(b).MethodByName("Cmd" + strings.ToUpper(instruction[:1]) + strings.ToLower(instruction[1:]))
 	if !exists {


### PR DESCRIPTION
This patchset adds support for the `NOCACHE` instruction (and the relevant docs). Basically, the `NOCACHE` instruction tags a certain instruction as being "uncachable", and causes the build to stop using the cache from that instruction onward. This patchset implements #1996.

Docker-DCO-1.1-Signed-off-by: Aleksa Sarai cyphar@cyphar.com (github: cyphar)

Closes #1996.

/cc @shykes 
/cc @jamtur01 @SvenDowideit @OSTezer
