### PR TITLE
Remove custom http dial (causes push that take over 1 minute to fail)

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -791,17 +791,7 @@ func AddRequiredHeadersToRedirectedRequests(req *http.Request, via []*http.Reque
 }
 
 func NewRegistry(authConfig *AuthConfig, factory *utils.HTTPRequestFactory, indexEndpoint string) (r *Registry, err error) {
-	httpDial := func(proto string, addr string) (net.Conn, error) {
-		conn, err := net.Dial(proto, addr)
-		if err != nil {
-			return nil, err
-		}
-		conn = utils.NewTimeoutConn(conn, time.Duration(1)*time.Minute)
-		return conn, nil
-	}
-
 	httpTransport := &http.Transport{
-		Dial:              httpDial,
 		DisableKeepAlives: true,
 		Proxy:             http.ProxyFromEnvironment,
 	}


### PR DESCRIPTION
Fixes #6250 
See also: dotcloud/docker-registry#417
Partial revert of 02f4ae6c56474b1f4e747916812b38134d503349

cc @crosbymichael @vbatts @vieux 
