### PR TITLE
Add CAP_KILL to unprivileged containers

### DIFF
--- a/daemon/execdriver/native/template/default_template.go
+++ b/daemon/execdriver/native/template/default_template.go
@@ -21,6 +21,7 @@ func New() *libcontainer.Container {
 			"SETPCAP",
 			"NET_BIND_SERVICE",
 			"SYS_CHROOT",
+			"KILL",
 		},
 		Namespaces: map[string]bool{
 			"NEWNS":  true,


### PR DESCRIPTION
Fixes #6245

I tested this with the example in the issue and agist the Discourse install.

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@crosbymichael.com (github: crosbymichael)
