### PR TITLE
refactor commit

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -640,26 +640,6 @@ func (container *Container) Resize(h, w int) error {
 	return container.command.Terminal.Resize(h, w)
 }
 
-func (container *Container) ExportRw() (archive.Archive, error) {
-	if err := container.Mount(); err != nil {
-		return nil, err
-	}
-	if container.daemon == nil {
-		return nil, fmt.Errorf("Can't load storage driver for unregistered container %s", container.ID)
-	}
-	archive, err := container.daemon.Diff(container)
-	if err != nil {
-		container.Unmount()
-		return nil, err
-	}
-	return utils.NewReadCloserWrapper(archive, func() error {
-			err := archive.Close()
-			container.Unmount()
-			return err
-		}),
-		nil
-}
-
 func (container *Container) Export() (archive.Archive, error) {
 	if err := container.Mount(); err != nil {
 		return nil, err

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/daemon/graphdriver"
 	"github.com/dotcloud/docker/pkg/mount"
 )
@@ -183,6 +184,50 @@ func (d *Driver) Create(id string, parent string) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func (d *Driver) CreateWithParent(newID, parentID, startID, endID string) error {
+	var (
+		layerData archive.Archive
+		err       error
+	)
+	cDir, err := d.Get(endID, "")
+	if err != nil {
+		return fmt.Errorf("Error getting container rootfs %s from driver %s: %s", endID, d, err)
+	}
+	defer d.Put(endID)
+
+	initDir, err := d.Get(startID, "")
+	if err != nil {
+		return fmt.Errorf("Error getting container init rootfs %s from driver %s: %s", startID, d, err)
+	}
+	defer d.Put(startID)
+
+	changes, err := archive.ChangesDirs(cDir, initDir)
+	if err != nil {
+		return fmt.Errorf("Error getting changes between %s and %s from driver %s: %s", initDir, cDir, d, err)
+	}
+
+	layerData, err = archive.ExportChanges(cDir, changes)
+	if err != nil {
+		return fmt.Errorf("Error getting the archive with changes from %s from driver %s: %s", cDir, d, err)
+	}
+
+	defer layerData.Close()
+	if err := d.Create(newID, parentID); err != nil {
+		return fmt.Errorf("Driver %s failed to create image rootfs %s: %s", d, newID, err)
+	}
+	newImagePath, err := d.Get(newID, "")
+	if err != nil {
+		return fmt.Errorf("Error getting image rootfs %s from driver %s: %s", newID, d, err)
+	}
+	defer d.Put(newID)
+
+	if err = archive.ApplyLayer(newImagePath, layerData); err != nil {
+		return fmt.Errorf("Error applying changes from %s to %s from driver %s: %s", cDir, newID, d, err)
+	}
+
 	return nil
 }
 

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -23,6 +23,8 @@ type Driver interface {
 	String() string
 
 	Create(id, parent string) error
+	CreateWithParent(newID, parentID, startID, endID string) error
+
 	Remove(id string) error
 
 	Get(id, mountLabel string) (dir string, err error)

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -2,10 +2,12 @@ package vfs
 
 import (
 	"fmt"
-	"github.com/dotcloud/docker/daemon/graphdriver"
 	"os"
 	"os/exec"
 	"path"
+
+	"github.com/dotcloud/docker/archive"
+	"github.com/dotcloud/docker/daemon/graphdriver"
 )
 
 func init() {
@@ -60,6 +62,50 @@ func (d *Driver) Create(id, parent string) error {
 	if err := copyDir(parentDir, dir); err != nil {
 		return err
 	}
+	return nil
+}
+
+func (d *Driver) CreateWithParent(newID, parentID, startID, endID string) error {
+	var (
+		layerData archive.Archive
+		err       error
+	)
+	cDir, err := d.Get(endID, "")
+	if err != nil {
+		return fmt.Errorf("Error getting container rootfs %s from driver %s: %s", endID, d, err)
+	}
+	defer d.Put(endID)
+
+	initDir, err := d.Get(startID, "")
+	if err != nil {
+		return fmt.Errorf("Error getting container init rootfs %s from driver %s: %s", startID, d, err)
+	}
+	defer d.Put(startID)
+
+	changes, err := archive.ChangesDirs(cDir, initDir)
+	if err != nil {
+		return fmt.Errorf("Error getting changes between %s and %s from driver %s: %s", initDir, cDir, d, err)
+	}
+
+	layerData, err = archive.ExportChanges(cDir, changes)
+	if err != nil {
+		return fmt.Errorf("Error getting the archive with changes from %s from driver %s: %s", cDir, d, err)
+	}
+
+	defer layerData.Close()
+	if err := d.Create(newID, parentID); err != nil {
+		return fmt.Errorf("Driver %s failed to create image rootfs %s: %s", d, newID, err)
+	}
+	newImagePath, err := d.Get(newID, "")
+	if err != nil {
+		return fmt.Errorf("Error getting image rootfs %s from driver %s: %s", newID, d, err)
+	}
+	defer d.Put(newID)
+
+	if err = archive.ApplyLayer(newImagePath, layerData); err != nil {
+		return fmt.Errorf("Error applying changes from %s to %s from driver %s: %s", cDir, newID, d, err)
+	}
+
 	return nil
 }
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -193,11 +193,17 @@ func (graph *Graph) Register(jsonData []byte, layerData archive.ArchiveReader, i
 		return fmt.Errorf("Mktemp failed: %s", err)
 	}
 
-	// Create root filesystem in the driver
-	if err := graph.driver.Create(img.ID, img.Parent); err != nil {
-		return fmt.Errorf("Driver %s failed to create image rootfs %s: %s", graph.driver, img.ID, err)
+	startId := fmt.Sprintf("%s-init", img.Container)
+	if graph.driver.Exists(img.Container) && layerData == nil && graph.driver.Exists(startId) {
+		if err := graph.driver.CreateWithParent(img.ID, img.Parent, startId, img.Container); err != nil {
+			return fmt.Errorf("failed to commit container: %s", err)
+		}
+	} else {
+		// Create root filesystem in the driver
+		if err := graph.driver.Create(img.ID, img.Parent); err != nil {
+			return fmt.Errorf("Driver %s failed to create image rootfs %s: %s", graph.driver, img.ID, err)
+		}
 	}
-	// Mount the root filesystem so we can apply the diff/layer
 	rootfs, err := graph.driver.Get(img.ID, "")
 	if err != nil {
 		return fmt.Errorf("Driver %s failed to get image rootfs %s: %s", graph.driver, img.ID, err)


### PR DESCRIPTION
This PR optimizes commit for btrfs so that Docker is using btrfs snapshotting.

This speeds up the final commit during `make build` from 1.6s to 0.007s on a system. It also removes the need to read and write any data during commit if we're using btrfs.
