### PR TITLE
Replace dashes in link name with underscores

### DIFF
--- a/links/links.go
+++ b/links/links.go
@@ -49,7 +49,7 @@ func (l *Link) Alias() string {
 
 func (l *Link) ToEnv() []string {
 	env := []string{}
-	alias := strings.ToUpper(l.Alias())
+	alias := strings.Replace(strings.ToUpper(l.Alias()), "-", "_", -1)
 
 	if p := l.getDefaultPort(); p != nil {
 		env = append(env, fmt.Sprintf("%s_PORT=%s://%s:%s", alias, p.Proto(), l.ChildIP, p.Port()))

--- a/links/links_test.go
+++ b/links/links_test.go
@@ -6,6 +6,36 @@ import (
 	"testing"
 )
 
+func TestLinkNaming(t *testing.T) {
+	ports := make(nat.PortSet)
+	ports[nat.Port("6379/tcp")] = struct{}{}
+
+	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, ports, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rawEnv := link.ToEnv()
+	env := make(map[string]string, len(rawEnv))
+	for _, e := range rawEnv {
+		parts := strings.Split(e, "=")
+		if len(parts) != 2 {
+			t.FailNow()
+		}
+		env[parts[0]] = parts[1]
+	}
+
+	value, ok := env["DOCKER_1_PORT"]
+
+	if !ok {
+		t.Fatalf("DOCKER_1_PORT not found in env")
+	}
+
+	if value != "tcp://172.0.17.2:6379" {
+		t.Fatalf("Expected 172.0.17.2:6379, got %s", env["DOCKER_1_PORT"])
+	}
+}
+
 func TestLinkNew(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[nat.Port("6379/tcp")] = struct{}{}


### PR DESCRIPTION
This PR sanitizes environmental variables derived from link names. Since link names are allowed to contain dashes, the environmental variables would be invalid.

Closes https://github.com/dotcloud/docker/issues/5418

Docker-DCO-1.1-Signed-off-by: Jonathan Camp jonathan@irondojo.com (github: kung-foo)
