### PR TITLE
Work around issue #6247 on OSX docker client whereby call of tcpc.CloseW...

### DIFF
--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -109,7 +109,7 @@ func (cli *DockerCli) hijack(method, path string, setRawTerminal bool, in io.Rea
 					utils.Debugf("Couldn't send EOF: %s\n", err)
 				}
 			} else {
-			       utils.Debugf("[hijack] Skipped CloseWrite");
+				utils.Debugf("[hijack] Skipped CloseWrite")
 			}
 		} else if unixc, ok := rwc.(*net.UnixConn); ok {
 			if err := unixc.CloseWrite(); err != nil {

--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -104,8 +104,12 @@ func (cli *DockerCli) hijack(method, path string, setRawTerminal bool, in io.Rea
 			utils.Debugf("[hijack] End of stdin")
 		}
 		if tcpc, ok := rwc.(*net.TCPConn); ok {
-			if err := tcpc.CloseWrite(); err != nil {
-				utils.Debugf("Couldn't send EOF: %s\n", err)
+			if os.Getenv("DOCKER_DO_NOT_CLOSE_WRITE") == "" {
+				if err := tcpc.CloseWrite(); err != nil {
+					utils.Debugf("Couldn't send EOF: %s\n", err)
+				}
+			} else {
+			       utils.Debugf("[hijack] Skipped CloseWrite");
 			}
 		} else if unixc, ok := rwc.(*net.UnixConn); ok {
 			if err := unixc.CloseWrite(); err != nil {


### PR DESCRIPTION
...rite() prevents receipt of all output under some circumstances.

For example:

   docker run busybox sh -c 'echo err 1>&1; sleep 1; echo out'

produces 'err' on stderr and no output on stdout whereas it should produce 'out'.

The same example produces the expected output on Linux systems.

With this workaround:

   DOCKER_DO_NOT_CLOSE_WRITE=t docker run busybox sh -c 'echo err 1>&1; sleep 1; echo out'

will allow correct behaviour on OSX without affecting behaviour on other systems.

Docker-DCO-1.1-Signed-off-by: Jon Seymour jon.seymour@gmail.com (github: jonseymour)
