### PR TITLE
Update dockerizing.md

### DIFF
--- a/docs/sources/userguide/dockerizing.md
+++ b/docs/sources/userguide/dockerizing.md
@@ -179,7 +179,7 @@ has just stopped.
 
 Let's check it worked with the `docker ps` command.
 
-    $ docker ps
+    $ sudo docker ps
     CONTAINER ID  IMAGE         COMMAND               CREATED        STATUS       PORTS NAMES
 
 Excellent. Our container has been stopped.


### PR DESCRIPTION
Just noticed `sudo` wasn't noted in the final `docker ps` command at the end of the page.  
