### PR TITLE
Remove the 'TABLE OF CONTENTS' header

### DIFF
--- a/docs/theme/mkdocs/toc.html
+++ b/docs/theme/mkdocs/toc.html
@@ -1,4 +1,3 @@
-      <span class="menu-caption eyebrow">TABLE OF CONTENTS</span>
   {% for toc_item in toc %}
     {% for toc_item in toc_item.children %}
       <li class=""><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>


### PR DESCRIPTION
Its tricked a number of readers, as its not a TOC, its just local to the
current topic. Now that the docs are not mobile responsive its not an
active UI element either.

Docker-DCO-1.1-Signed-off-by: SvenDowideit SvenDowideit@home.org.au (github: SvenDowideit)
