### PR TITLE
Use only unavailable image when load from Tarball

### DIFF
--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -109,6 +109,9 @@ func TestTarUntar(t *testing.T) {
 	if err := ioutil.WriteFile(path.Join(origin, "2"), []byte("welcome!"), 0700); err != nil {
 		t.Fatal(err)
 	}
+	if err := ioutil.WriteFile(path.Join(origin, "3"), []byte("will be ignored"), 0700); err != nil {
+		t.Fatal(err)
+	}
 
 	for _, c := range []Compression{
 		Uncompressed,
@@ -116,13 +119,14 @@ func TestTarUntar(t *testing.T) {
 	} {
 		changes, err := tarUntar(t, origin, &TarOptions{
 			Compression: c,
+			Excludes:    []string{"3"},
 		})
 
 		if err != nil {
 			t.Fatalf("Error tar/untar for compression %s: %s", c.Extension(), err)
 		}
 
-		if len(changes) != 0 {
+		if len(changes) != 1 || changes[0].Path != "/3" {
 			t.Fatalf("Unexpected differences after tarUntar: %v", changes)
 		}
 	}

--- a/graph/load.go
+++ b/graph/load.go
@@ -43,7 +43,17 @@ func (s *TagStore) CmdLoad(job *engine.Job) engine.Status {
 	if err := os.Mkdir(repoDir, os.ModeDir); err != nil {
 		return job.Error(err)
 	}
-	if err := archive.Untar(repoFile, repoDir, nil); err != nil {
+	images, err := s.graph.Map()
+	if err != nil {
+		return job.Error(err)
+	}
+	excludes := make([]string, len(images))
+	i := 0
+	for k := range images {
+		excludes[i] = k
+		i++
+	}
+	if err := archive.Untar(repoFile, repoDir, &archive.TarOptions{Excludes: excludes}); err != nil {
 		return job.Error(err)
 	}
 


### PR DESCRIPTION
Hi.

ML: https://groups.google.com/forum/?fromgroups#!topic/docker-dev/cHR0vH3G8Do
### Compare(with my tedious machine)

```
$ docker save foo > foo.tar
```

`foo.tar` is 531MB and it has 128 layers. 

Un-Patched:

```
$ docker rmi --no-prune foo
$ time docker load < foo.tar
0.37user 0.88system 0:21.68elapsed 5%CPU (0avgtext+0avgdata 4848maxresident)k
0inputs+0outputs (0major+1282minor)pagefaults 0swaps
```

Patched:

```
$ docker rmi --no-prune foo
$ time docker load < foo.tar
0.36user 0.83system 0:06.99elapsed 17%CPU (0avgtext+0avgdata 4876maxresident)k
0inputs+0outputs (0major+1589minor)pagefaults 0swaps
```

I'm beginner of Golang (and English), so don't mind to take review or indication.
It will make me growth.

Thank you.

Docker-DCO-1.1-Signed-off-by: Satoshi Amemiya satoshi_amemiya@voyagegroup.com (github: rail44)
