### PR TITLE
Update documentation for docker pull

### DIFF
--- a/contrib/man/md/docker-pull.1.md
+++ b/contrib/man/md/docker-pull.1.md
@@ -5,17 +5,18 @@
 docker-pull - Pull an image or a repository from the registry
 
 # SYNOPSIS
-**docker pull** NAME[:TAG]
+**docker pull** [REGISTRY_PATH/]NAME[:TAG]
 
 # DESCRIPTION
 
 This command pulls down an image or a repository from the registry. If
 there is more than one image for a repository (e.g. fedora) then all
 images for that repository name are pulled down including any tags.
+It is also possible to specify a non-default registry to pull from.
 
-# EXAMPLE
+# EXAMPLES
 
-# Pull a reposiotry with multiple images
+# Pull a repository with multiple images
 
     $ sudo docker pull fedora
     Pulling repository fedora
@@ -30,6 +31,19 @@ images for that repository name are pulled down including any tags.
     fedora       20          105182bb5e8b    5 days ago   372.7 MB
     fedora       heisenbug   105182bb5e8b    5 days ago   372.7 MB
     fedora       latest      105182bb5e8b    5 days ago   372.7 MB
+
+# Pull an image, manually specifying path to the registry and tag
+
+    $ sudo docker pull registry.hub.docker.com/fedora:20
+    Pulling repository fedora
+    3f2fed40e4b0: Download complete 
+    511136ea3c5a: Download complete 
+    fd241224e9cf: Download complete 
+
+    $ sudo docker images
+    REPOSITORY   TAG         IMAGE ID        CREATED      VIRTUAL SIZE
+    fedora       20          3f2fed40e4b0    4 days ago   372.7 MB
+
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -735,7 +735,7 @@ Running `docker ps` showing 2 linked containers.
 
 ## pull
 
-    Usage: docker pull NAME[:TAG]
+    Usage: docker pull [REGISTRY_PATH/]NAME[:TAG]
 
     Pull an image or a repository from the registry
 
@@ -745,6 +745,11 @@ Most of your images will be created on top of a base image from the
 [Docker Hub](https://hub.docker.com) contains many pre-built images that you
 can `pull` and try without needing to define and configure your own.
 
+It is also possible to manually specify the path of a registry to pull from.
+For example, if you have set up a local registry, you can specify its path to
+pull from it. A repository path is similar to a URL, but does not contain
+a protocol specifier (https://, for example).
+
 To download a particular image, or set of images (i.e., a repository),
 use `docker pull`:
 
@@ -752,8 +757,11 @@ use `docker pull`:
     # will pull all the images in the debian repository
     $ docker pull debian:testing
     # will pull only the image named debian:testing and any intermediate layers
-    # it is based on. (typically the empty `scratch` image, a MAINTAINERs layer,
-    # and the un-tared base.
+    # it is based on. (Typically the empty `scratch` image, a MAINTAINERs layer,
+    # and the un-tarred base).
+    $ docker pull registry.hub.docker.com/debian
+    # manually specifies the path to the default Docker registry. This could
+    # be replaced with the path to a local registry to pull from another source.
 
 ## push
 


### PR DESCRIPTION
The docker pull command can be used with a URL specifier to indicate a specific registry to pull from. This was previously undocumented in manpages and CLI documentation; these patches remedy this, documenting the feature.
