### PR TITLE
Fix OS X builds

### DIFF
--- a/pkg/libcontainer/namespaces/nsenter.go
+++ b/pkg/libcontainer/namespaces/nsenter.go
@@ -1,3 +1,5 @@
+// +build !darwin
+
 package namespaces
 
 /*


### PR DESCRIPTION
This fixes the client build on OS X.

Reference: #6256 homebrew/homebrew#29961

This seems like a total hack and I would love direction on how to fix this in a better way. I'm am open to feedback and suggestions.
