### PR TITLE
Repaired broken links in docs/sources/faq.md

### DIFF
--- a/docs/sources/faq.md
+++ b/docs/sources/faq.md
@@ -122,8 +122,7 @@ functionalities:
 ### What is different between a Docker container and a VM?
 
 There's a great StackOverflow answer [showing the differences](
-http://stackoverflow.com/questions/16047306/
-how-is-docker-io-different-from-a-normal-virtual-machine).
+http://stackoverflow.com/questions/16047306/how-is-docker-io-different-from-a-normal-virtual-machine).
 
 ### Do I lose my data when the container exits?
 
@@ -185,8 +184,7 @@ this [mailbox](mailto:security@docker.com).
 ### Why do I need to sign my commits to Docker with the DCO?
 
 Please read [our blog post](
-http://blog.docker.io/2014/01/
-docker-code-contributions-require-developer-certificate-of-origin/)
+http://blog.docker.io/2014/01/docker-code-contributions-require-developer-certificate-of-origin/)
 on the introduction of the DCO.
 
 ### Can I help by adding some questions and answers?


### PR DESCRIPTION
I think that due to the line length limitation, two links were broken: the one to the StackOverflow answer showing the differences between Docker and a VM and the one to the blog post on the introduction of the DCO.
