### PR TITLE
Don't exit on eof in header reading in stdcopy

### DIFF
--- a/utils/stdcopy.go
+++ b/utils/stdcopy.go
@@ -82,13 +82,14 @@ func StdCopy(dstout, dsterr io.Writer, src io.Reader) (written int64, err error)
 		for nr < StdWriterPrefixLen {
 			var nr2 int
 			nr2, er = src.Read(buf[nr:])
-			if er == io.EOF {
-				return written, nil
-			}
-			if er != nil {
+			// Don't exit on EOF, because we can have some more input
+			if er != nil && er != io.EOF {
 				return 0, er
 			}
 			nr += nr2
+			if nr == 0 {
+				return written, nil
+			}
 		}
 
 		// Check the first byte to know where to write


### PR DESCRIPTION
There was random lines drops in docker logs because of this
For example you can reproduce this with next lines:

```
docker run -d --name test ubuntu ping google.com && sleep 10 && docker kill test
for i in $(seq 1 100); do docker logs profit_logstash | wc -l; done
```

@creack said something about nat and boot2docker :) But I'm not very sure what it was.
