### PR TITLE
If stdin is not attached, there is no need to issue a CloseWrite.

### DIFF
--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -102,12 +102,10 @@ func (cli *DockerCli) hijack(method, path string, setRawTerminal bool, in io.Rea
 		if in != nil {
 			io.Copy(rwc, in)
 			utils.Debugf("[hijack] End of stdin")
-			if tcpc, ok := rwc.(*net.TCPConn); ok {
-				if err := tcpc.CloseWrite(); err != nil {
-					utils.Debugf("Couldn't send EOF: %s\n", err)
-				}
-			} else if unixc, ok := rwc.(*net.UnixConn); ok {
-				if err := unixc.CloseWrite(); err != nil {
+			if close, ok := (rwc).(interface {
+				CloseWrite() error
+			}); ok {
+				if err := close.CloseWrite(); err != nil {
 					utils.Debugf("Couldn't send EOF: %s\n", err)
 				}
 			}

--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -102,17 +102,17 @@ func (cli *DockerCli) hijack(method, path string, setRawTerminal bool, in io.Rea
 		if in != nil {
 			io.Copy(rwc, in)
 			utils.Debugf("[hijack] End of stdin")
-		}
-		if tcpc, ok := rwc.(*net.TCPConn); ok {
-			if err := tcpc.CloseWrite(); err != nil {
-				utils.Debugf("Couldn't send EOF: %s\n", err)
+			if tcpc, ok := rwc.(*net.TCPConn); ok {
+				if err := tcpc.CloseWrite(); err != nil {
+					utils.Debugf("Couldn't send EOF: %s\n", err)
+				}
+			} else if unixc, ok := rwc.(*net.UnixConn); ok {
+				if err := unixc.CloseWrite(); err != nil {
+					utils.Debugf("Couldn't send EOF: %s\n", err)
+				}
 			}
-		} else if unixc, ok := rwc.(*net.UnixConn); ok {
-			if err := unixc.CloseWrite(); err != nil {
-				utils.Debugf("Couldn't send EOF: %s\n", err)
-			}
+			// Discard errors due to pipe interruption
 		}
-		// Discard errors due to pipe interruption
 		return nil
 	})
 


### PR DESCRIPTION
This provides a workaround for the issues documented in #6247, #6271
whereby if CloseWrite is called on a connection made via
an OSX loopback interface, the state of the TCP connection is corrupted
in a way that prevents acknowledgements for as yet unacknowledged
data ever being received by the server. This then prevents the server
from sending the remaining output it has to send.

If we avoid calling CloseWrite in this case, then we can avoid the resulting issues.
Since the server is not expecting to receive any input anyway, the
server doesn't need the EOF indication that this call would produce.

Docker-DCO-1.1-Signed-off-by: Jon Seymour jon.seymour@gmail.com (github: jonseymour)
