### PR TITLE
Removed goto statements in pkg

### DIFF
--- a/pkg/libcontainer/selinux/selinux.go
+++ b/pkg/libcontainer/selinux/selinux.go
@@ -327,13 +327,15 @@ func GetLxcContexts() (processLabel string, fileLabel string) {
 
 	bufin = bufio.NewReader(in)
 
+	var quit = false
 	for done := false; !done; {
 		var line string
 		if line, err = bufin.ReadString('\n'); err != nil {
 			if err == io.EOF {
 				done = true
 			} else {
-				goto exit
+				quit = true
+				break
 			}
 		}
 		line = strings.TrimSpace(line)
@@ -356,12 +358,10 @@ func GetLxcContexts() (processLabel string, fileLabel string) {
 		}
 	}
 
-	if processLabel == "" || fileLabel == "" {
+	if !quit && (processLabel == "" || fileLabel == "") {
 		return "", ""
 	}
 
-exit:
-	//	mcs := IntToMcs(os.Getpid(), 1024)
 	mcs := uniqMcs(1024)
 	scon := NewContext(processLabel)
 	scon["level"] = mcs
@@ -369,6 +369,7 @@ exit:
 	scon = NewContext(fileLabel)
 	scon["level"] = mcs
 	fileLabel = scon.Get()
+
 	return processLabel, fileLabel
 }
 

--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -78,14 +78,20 @@ var (
 func GetRandomName(retry int) string {
 	rand.Seed(time.Now().UnixNano())
 
-begin:
-	name := fmt.Sprintf("%s_%s", left[rand.Intn(len(left))], right[rand.Intn(len(right))])
-	if name == "boring_wozniak" /* Steve Wozniak is not boring */ {
-		goto begin
+	badNames := map[string]struct{}{
+		// Wozniak is never boring.
+		"boring_wozniak": {},
+	}
+
+	// Make sure that the generated name isn't a "badName".
+	var name string
+	for bad := true; bad; _, bad = badNames[name] {
+		name = fmt.Sprintf("%s_%s", left[rand.Intn(len(left))], right[rand.Intn(len(right))])
 	}
 
 	if retry > 0 {
 		name = fmt.Sprintf("%s%d", name, rand.Intn(10))
 	}
+
 	return name
 }


### PR DESCRIPTION
This patch replaces all occurences of the goto statement in the
Docker project (except in the `vendor` directory), replacing them
with `for` loops instead.

Closes #6332

Docker-DCO-1.1-Signed-off-by: Aleksa Sarai cyphar@cyphar.com (github: cyphar)

/cc @shykes @crosbymichael @rjnagal @vmarmol @vieux
