### PR TITLE
Replace to single space for line continuation

### DIFF
--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -757,7 +757,7 @@ func (b *buildFile) commit(id string, autoCmd []string, comment string) error {
 }
 
 // Long lines can be split with a backslash
-var lineContinuation = regexp.MustCompile(`\s*\\\s*\n`)
+var lineContinuation = regexp.MustCompile(`\s*\\\s*\n\s*`)
 
 func (b *buildFile) Build(context io.Reader) (string, error) {
 	tmpdirPath, err := ioutil.TempDir("", "docker-build")
@@ -789,7 +789,7 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 		return "", ErrDockerfileEmpty
 	}
 	var (
-		dockerfile = lineContinuation.ReplaceAllString(stripComments(fileBytes), "")
+		dockerfile = lineContinuation.ReplaceAllString(stripComments(fileBytes), " ")
 		stepN      = 0
 	)
 	for _, line := range strings.Split(dockerfile, "\n") {


### PR DESCRIPTION
For line continuation, the line end space and next line beginning space
should be considered as a single space, because different editors might
change tab to space or reverse; this way replaced to a single space can
avoid to be considered as different case, and reuse build cache at most.

Docker-DCO-1.1-Signed-off-by: Derek crq@kernel.org (@crquan)
