### PR TITLE
Update Viewing the application

### DIFF
--- a/docs/sources/userguide/usingdocker.md
+++ b/docs/sources/userguide/usingdocker.md
@@ -183,6 +183,14 @@ see the application.
 
 Our Python application is live!
 
+Note: If you have used boot2docker on OSX you'll need to get the IP of the virtual host instead of using localhost. You can do this by running the following in the boot2docker shell.
+
+    $ boot2docker ip
+        
+    The VM's Host only interface IP address is: 192.168.59.103
+
+In this case you'd browse to http://192.168.59.103:49155 for the above example
+
 ## A Network Port Shortcut
 
 Using the `docker ps` command to return the mapped port is a bit clumsy so


### PR DESCRIPTION
Added section showing how to get IP if using boot2docker on OSX rather than browsing to localhost.
