### PR TITLE
Update dockerimages.md

### DIFF
--- a/docs/sources/userguide/dockerimages.md
+++ b/docs/sources/userguide/dockerimages.md
@@ -180,6 +180,7 @@ we'd like to update.
 
 Inside our running container let's add the `json` gem.
 
+    root@0b2616b0e5a8:/# apt-get install build-essential
     root@0b2616b0e5a8:/# gem install json
 
 Once this has completed let's exit our container using the `exit`


### PR DESCRIPTION
Installing the json gem requires build tools, which weren't in the training/sinatra image.  Alternatively, update the training image.
