### PR TITLE
Linking containers added to API example

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.12.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.12.md
@@ -406,6 +406,7 @@ Start the container `id`
 
         {
              "Binds":["/tmp:/tmp"],
+             "Links":["redis3:redis"],
              "LxcConf":{"lxc.utsname":"docker"},
              "PortBindings":{ "22/tcp": [{ "HostPort": "11022" }] },
              "PublishAllPorts":false,


### PR DESCRIPTION
Linking containers was not covered in the API documentation. I looked it up in the client source code and testing it manually.

Docker-DCO-1.1-Signed-off-by: Erwin van der Koogh <github at koogh dot com> (github: evanderkoogh)
