### PR TITLE
Adding color to blocquote links in documentation dotcloud/docker/issues/...

### DIFF
--- a/docs/theme/mkdocs/css/docs.css
+++ b/docs/theme/mkdocs/css/docs.css
@@ -238,6 +238,14 @@ ol li {
   color: #394d54;
 }
 
+.content-body blockquote a {
+  color: #008BB8;
+}
+
+.content-body blockquote a:hover {
+  color: #2F55CD;
+}
+
 .content-body ul {
   margin-top: 0px !important;
 }


### PR DESCRIPTION
...6377

We still want the inside of the blockquote to be fully colored with only one color... except for links that hev to be a bit different to spot them out.
