### PR TITLE
Adds info on how to get env vars from container

### DIFF
--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -171,14 +171,11 @@ child container in two ways:
 * Environment variables,
 * Updating the `/etc/host` file.
 
-Let's look first at the environment variables Docker sets. Inside the `web`
-container let's run the `env` command to list the container's environment
-variables.
-
-    root@aed84ee21bde:/opt/webapp# env
-    HOSTNAME=aed84ee21bde
+Let's look first at the environment variables Docker sets. Let's run the `env`
+command to list the container's environment variables.
+    $docker run --rm --link --name web2 db:db training/webapp env
     . . .
-    DB_NAME=/web/db
+    DB_NAME=/web2/db
     DB_PORT=tcp://172.17.0.5:5432
     DB_PORT_5000_TCP=tcp://172.17.0.5:5432
     DB_PORT_5000_TCP_PROTO=tcp


### PR DESCRIPTION
Currently the docs just say "let's go into the container and look at the
env vars", but doesn't show how to do it.  It is also not currently
possible to enter the container as it is written in the doc
( container started with app.py and then somehow later on we have a
shell in the same container )

Docker-DCO-1.1-Signed-off-by: Brian Goff cpuguy83@gmail.com (github: cpuguy83)
