### PR TITLE
Add ls & cat commands to browse container filesystem

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -50,6 +50,7 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 	for _, command := range [][]string{
 		{"attach", "Attach to a running container"},
 		{"build", "Build an image from a Dockerfile"},
+		{"cat", "Run cat on a file in a container's filesystem"},
 		{"commit", "Create a new image from a container's changes"},
 		{"cp", "Copy files/folders from the containers filesystem to the host path"},
 		{"diff", "Inspect changes on a container's filesystem"},
@@ -61,6 +62,7 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 		{"info", "Display system-wide information"},
 		{"inspect", "Return low-level information on a container"},
 		{"kill", "Kill a running container"},
+		{"ls", "Run ls in a container's filesystem"},
 		{"load", "Load an image from a tar archive"},
 		{"login", "Register or Login to the docker registry server"},
 		{"logs", "Fetch the logs of a container"},
@@ -2171,6 +2173,64 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func (cli *DockerCli) CmdLs(args ...string) error {
+	cmd := cli.Subcmd("ls", "CONTAINER:PATH", "Run ls on PATH in the container")
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+
+	if cmd.NArg() != 1 {
+		cmd.Usage()
+		return nil
+	}
+
+	var shexecData engine.Env
+	info := strings.Split(cmd.Arg(0), ":")
+
+	if len(info) != 2 {
+		return fmt.Errorf("Error: Path not specified")
+	}
+
+	shexecData.Set("Resource", info[1])
+
+	stream, _, err := cli.call("POST", "/containers/"+info[0]+"/ls", shexecData, false)
+	if err != nil {
+		return err
+	}
+
+	_, err = utils.StdCopy(cli.out, cli.err, stream)
+	return nil
+}
+
+func (cli *DockerCli) CmdCat(args ...string) error {
+	cmd := cli.Subcmd("cat", "CONTAINER:PATH", "Run ls on PATH in the container")
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+
+	if cmd.NArg() != 1 {
+		cmd.Usage()
+		return nil
+	}
+
+	var shexecData engine.Env
+	info := strings.Split(cmd.Arg(0), ":")
+
+	if len(info) != 2 {
+		return fmt.Errorf("Error: Path not specified")
+	}
+
+	shexecData.Set("Resource", info[1])
+
+	stream, _, err := cli.call("POST", "/containers/"+info[0]+"/cat", shexecData, false)
+	if err != nil {
+		return err
+	}
+
+	_, err = utils.StdCopy(cli.out, cli.err, stream)
 	return nil
 }
 

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2177,24 +2177,26 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 }
 
 func (cli *DockerCli) CmdLs(args ...string) error {
-	cmd := cli.Subcmd("ls", "CONTAINER:PATH", "Run ls on PATH in the container")
-	if err := cmd.Parse(args); err != nil {
-		return nil
-	}
+	cmd := cli.Subcmd("ls", " [LS_OPTIONS] CONTAINER:PATH", "Run ls on PATH in the container")
 
-	if cmd.NArg() != 1 {
+	argsLen := len(args)
+
+	if argsLen < 1 {
 		cmd.Usage()
 		return nil
 	}
 
+	resource := args[argsLen-1]
+
 	var shexecData engine.Env
-	info := strings.Split(cmd.Arg(0), ":")
+	info := strings.Split(resource, ":")
 
 	if len(info) != 2 {
 		return fmt.Errorf("Error: Path not specified")
 	}
 
 	shexecData.Set("Resource", info[1])
+	shexecData.Set("Options", strings.Join(args[:argsLen-1], " "))
 
 	stream, _, err := cli.call("POST", "/containers/"+info[0]+"/ls", shexecData, false)
 	if err != nil {
@@ -2206,7 +2208,7 @@ func (cli *DockerCli) CmdLs(args ...string) error {
 }
 
 func (cli *DockerCli) CmdCat(args ...string) error {
-	cmd := cli.Subcmd("cat", "CONTAINER:PATH", "Run ls on PATH in the container")
+	cmd := cli.Subcmd("cat", "CONTAINER:PATH", "Run cat on PATH in the container")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -791,6 +792,65 @@ func (container *Container) Copy(resource string) (io.ReadCloser, error) {
 			return err
 		}),
 		nil
+}
+
+func (container *Container) Shexec(command []string) (string, string, error) {
+  var err error
+
+	if err = container.Mount(); err != nil {
+		return "", "", err
+	}
+
+  cmdLength := len(command)
+  resource := command[cmdLength - 1]
+
+	resPath := container.getResourcePath(resource)
+  basePath := resPath
+  if resPath == "" {
+	  basePath, err = symlink.FollowSymlinkInScope(resPath, container.basefs)
+	  if err != nil {
+		  container.Unmount()
+		  return "", "", err
+	  }
+  }
+
+  _, err = os.Stat(basePath)
+	if err != nil {
+		container.Unmount()
+		return "", "", err
+	}
+
+  command[cmdLength - 1] = basePath
+
+  cmd := exec.Command(command[0], command[1:]...)
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		container.Unmount()
+		return "", "", err
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		container.Unmount()
+		return "", "", err
+	}
+
+  if err = cmd.Start(); err != nil {
+		container.Unmount()
+		return "", "", err
+  }
+
+  stdout, err := ioutil.ReadAll(stdoutPipe)
+  if err != nil {
+		return "", "", err
+  }
+
+  stderr, err := ioutil.ReadAll(stderrPipe)
+  if err != nil {
+		return "", "", err
+  }
+
+	return string(stdout), string(stderr), cmd.Wait()
 }
 
 // Returns true if the container exposes a certain port

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -795,34 +795,34 @@ func (container *Container) Copy(resource string) (io.ReadCloser, error) {
 }
 
 func (container *Container) Shexec(command []string) (string, string, error) {
-  var err error
+	var err error
 
 	if err = container.Mount(); err != nil {
 		return "", "", err
 	}
 
-  cmdLength := len(command)
-  resource := command[cmdLength - 1]
+	cmdLength := len(command)
+	resource := command[cmdLength-1]
 
 	resPath := container.getResourcePath(resource)
-  basePath := resPath
-  if resPath == "" {
-	  basePath, err = symlink.FollowSymlinkInScope(resPath, container.basefs)
-	  if err != nil {
-		  container.Unmount()
-		  return "", "", err
-	  }
-  }
+	basePath := resPath
+	if resPath == "" {
+		basePath, err = symlink.FollowSymlinkInScope(resPath, container.basefs)
+		if err != nil {
+			container.Unmount()
+			return "", "", err
+		}
+	}
 
-  _, err = os.Stat(basePath)
+	_, err = os.Stat(basePath)
 	if err != nil {
 		container.Unmount()
 		return "", "", err
 	}
 
-  command[cmdLength - 1] = basePath
+	command[cmdLength-1] = basePath
 
-  cmd := exec.Command(command[0], command[1:]...)
+	cmd := exec.Command(command[0], command[1:]...)
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
@@ -835,22 +835,30 @@ func (container *Container) Shexec(command []string) (string, string, error) {
 		return "", "", err
 	}
 
-  if err = cmd.Start(); err != nil {
+	if err = cmd.Start(); err != nil {
 		container.Unmount()
 		return "", "", err
-  }
+	}
 
-  stdout, err := ioutil.ReadAll(stdoutPipe)
-  if err != nil {
+	stdout, err := ioutil.ReadAll(stdoutPipe)
+	if err != nil {
 		return "", "", err
-  }
+	}
 
-  stderr, err := ioutil.ReadAll(stderrPipe)
-  if err != nil {
+	containerBase := container.basefs
+	if !strings.HasSuffix(containerBase, "/") {
+		containerBase = containerBase + "/"
+	}
+
+	stdoutStr := strings.Replace(string(stdout), containerBase, "", -1)
+
+	stderr, err := ioutil.ReadAll(stderrPipe)
+	if err != nil {
 		return "", "", err
-  }
+	}
+	stderrStr := strings.Replace(string(stderr), containerBase, "", -1)
 
-	return string(stdout), string(stderr), cmd.Wait()
+	return stdoutStr, stderrStr, cmd.Wait()
 }
 
 // Returns true if the container exposes a certain port


### PR DESCRIPTION
Browsing the file system would be very helpful rather than relying on cp which can take longer & use more resources on both sides. Also, sometimes you don't know what your copying out...

Also implemented cat to cat any file from the filesystem, especially useful for things like /etc/resolv.conf to diagnose DNS issues, etc.
