### PR TITLE
use a numbered list for maintainers responsibility

### DIFF
--- a/hack/MAINTAINERS.md
+++ b/hack/MAINTAINERS.md
@@ -24,12 +24,12 @@ speak up!
 
 It is every maintainer's responsibility to:
 
-* 1) Expose a clear roadmap for improving their component.
-* 2) Deliver prompt feedback and decisions on pull requests.
-* 3) Be available to anyone with questions, bug reports, criticism etc.
+1. Expose a clear roadmap for improving their component.
+2. Deliver prompt feedback and decisions on pull requests.
+3. Be available to anyone with questions, bug reports, criticism etc.
   on their component. This includes IRC, GitHub requests and the mailing
   list.
-* 4) Make sure their component respects the philosophy, design and
+4. Make sure their component respects the philosophy, design and
   roadmap of the project.
 
 ## How are decisions made?


### PR DESCRIPTION
At the moment maintainers responsibility are spelled out with a hybrid list. I.e. an unordered list with an associated number.

In this commit I the number list proper is used.
