### PR TITLE
Update usingdocker.md

### DIFF
--- a/docs/sources/userguide/usingdocker.md
+++ b/docs/sources/userguide/usingdocker.md
@@ -181,6 +181,9 @@ see the application.
 
 ![Viewing the web application](/userguide/webapp1.png).
 
+If you're running this on Mac OS X or Windows, use 192.168.59.103:49155
+(or whatever IP address `boot2docker ip` tells you).
+
 Our Python application is live!
 
 ## A Network Port Shortcut


### PR DESCRIPTION
added a hint for Windows and Mac OS X users, where localhost:<port> won't work
