### PR TITLE
Fix contrib/man/md/docker-import.1.md warning ("macro `tar.gz,' not defined")

### DIFF
--- a/contrib/man/md/docker-import.1.md
+++ b/contrib/man/md/docker-import.1.md
@@ -9,8 +9,8 @@ of the tarball into it.
 **docker import** URL|- [REPOSITORY[:TAG]]
 
 # DESCRIPTION
-Create a new filesystem image from the contents of a tarball (.tar,
-.tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then optionally tag it.
+Create a new filesystem image from the contents of a tarball (`.tar`,
+`.tar.gz`, `.tgz`, `.bzip`, `.tar.xz`, `.txz`) into it, then optionally tag it.
 
 # EXAMPLES
 


### PR DESCRIPTION
Before:

``` groff
.SH DESCRIPTION
.PP
Create a new filesystem image from the contents of a tarball (.tar,
.tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then optionally
tag it.
.SH EXAMPLES
.SS Import from a remote location
```

After:

``` groff
.SH DESCRIPTION
.PP
Create a new filesystem image from the contents of a tarball (\f[C]\&.tar\f[],
\f[C]\&.tar.gz\f[], \f[C]\&.tgz\f[], \f[C]\&.bzip\f[], \f[C]\&.tar.xz\f[], \f[C]\&.txz\f[]) into it, then optionally
tag it.
.SH EXAMPLES
.SS Import from a remote location
```
