### PR TITLE
Error if Docker daemon starts with BTRFS graph driver and SELinux enabled

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -778,6 +778,11 @@ func NewDaemonFromDirectory(config *daemonconfig.Config, eng *engine.Engine) (*D
 	}
 	utils.Debugf("Using graph driver %s", driver)
 
+	// As Docker on btrfs and SELinux are incompatible at present, error on both being enabled
+	if config.EnableSelinuxSupport && driver.String() == "btrfs" {
+		return nil, fmt.Errorf("SELinux is not supported with the BTRFS graph driver!")
+	}
+
 	daemonRepo := path.Join(config.Root, "containers")
 
 	if err := os.MkdirAll(daemonRepo, 0700); err != nil && !os.IsExist(err) {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -66,7 +66,7 @@ func main() {
 		flCa                 = flag.String([]string{"-tlscacert"}, dockerConfDir+defaultCaFile, "Trust only remotes providing a certificate signed by the CA given here")
 		flCert               = flag.String([]string{"-tlscert"}, dockerConfDir+defaultCertFile, "Path to TLS certificate file")
 		flKey                = flag.String([]string{"-tlskey"}, dockerConfDir+defaultKeyFile, "Path to TLS key file")
-		flSelinuxEnabled     = flag.Bool([]string{"-selinux-enabled"}, false, "Enable selinux support")
+		flSelinuxEnabled     = flag.Bool([]string{"-selinux-enabled"}, false, "Enable selinux support. SELinux does not presently support the BTRFS storage driver")
 	)
 	flag.Var(&flDns, []string{"#dns", "-dns"}, "Force Docker to use specific DNS servers")
 	flag.Var(&flDnsSearch, []string{"-dns-search"}, "Force Docker to use specific DNS search domains")

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -74,7 +74,7 @@ unix://[/path/to/socket] to use.
   Print version information and quit. Default is false.
 
 **--selinux-enabled**=*true*|*false*
-  Enable selinux support. Default is false.
+  Enable selinux support. Default is false. SELinux does not presently support the BTRFS storage driver.
 
 # COMMANDS
 **docker-attach(1)**

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -73,7 +73,7 @@ expect an integer, and they can only be specified once.
       -p, --pidfile="/var/run/docker.pid"        Path to use for daemon PID file
       -r, --restart=true                         Restart previously running containers
       -s, --storage-driver=""                    Force the Docker runtime to use a specific storage driver
-      --selinux-enabled=false                    Enable selinux support
+      --selinux-enabled=false                    Enable selinux support. SELinux does not presently support the BTRFS storage driver
       --storage-opt=[]                           Set storage driver options
       --tls=false                                Use TLS; implied by tls-verify flags
       --tlscacert="/home/sven/.docker/ca.pem"    Trust only remotes providing a certificate signed by the CA given here


### PR DESCRIPTION
At present, BTRFS and SELinux do not interact particularly well with regards to labelling. SELinux labels are assigned at the inode level, but BTRFS inodes may appear in multiple contexts - and, at present, there's no way for SELinux to distinguish between these.

Practical effect of this: On an SELinux enforcing machine with SELinux-aware Docker and the BTRFS graph driver active, core libraries - like libc.so.6 - will not be appropriately labelled so that containers can access them. Starting without SELinux container isolation should still be fine.

This is being worked on upstream, and hopefully should be fixed soon. In the meantime, this patch prevents the Docker daemon from starting in a BTRFS configuration with SELinux isolation enabled, which isn't a functional configuration at present.
