### PR TITLE
Docker should use /var/lib/docker/tmp for large temporary files.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -678,7 +678,10 @@ func NewDaemonFromDirectory(config *daemonconfig.Config, eng *engine.Engine) (*D
 	}
 
 	// set up the TempDir to use a canonical path
-	tmp := os.TempDir()
+	tmp, err := utils.TempDir(config.Root)
+	if err != nil {
+		log.Fatalf("Unable to get the TempDir under %s: %s", config.Root, err)
+	}
 	realTmp, err := utils.ReadSymlinkedDirectory(tmp)
 	if err != nil {
 		log.Fatalf("Unable to get the full path to the TempDir (%s): %s", tmp, err)

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -120,12 +120,11 @@ systemd in the [docker source tree](
 https://github.com/docker/docker/blob/master/contrib/init/systemd/socket-activation/).
 
 Docker supports softlinks for the Docker data directory
-(`/var/lib/docker`) and for `/tmp`. TMPDIR and the data directory can be set
-like this:
+(`/var/lib/docker`) and for `/var/lib/docker/tmp`. The `DOCKER_TMPDIR` and the data directory can be set like this:
 
-    TMPDIR=/mnt/disk2/tmp /usr/local/bin/docker -d -D -g /var/lib/docker -H unix:// > /var/lib/boot2docker/docker.log 2>&1
+    DOCKER_TMPDIR=/mnt/disk2/tmp /usr/local/bin/docker -d -D -g /var/lib/docker -H unix:// > /var/lib/boot2docker/docker.log 2>&1
     # or
-    export TMPDIR=/mnt/disk2/tmp
+    export DOCKER_TMPDIR=/mnt/disk2/tmp
     /usr/local/bin/docker -d -D -g /var/lib/docker -H unix:// > /var/lib/boot2docker/docker.log 2>&1
 
 ## attach

--- a/utils/tmpdir.go
+++ b/utils/tmpdir.go
@@ -1,0 +1,12 @@
+// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd
+
+package utils
+
+import (
+	"os"
+)
+
+// TempDir returns the default directory to use for temporary files.
+func TempDir(rootdir string) (string error) {
+	return os.TempDir(), nil
+}

--- a/utils/tmpdir_unix.go
+++ b/utils/tmpdir_unix.go
@@ -1,0 +1,18 @@
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// TempDir returns the default directory to use for temporary files.
+func TempDir(rootDir string) (string, error) {
+	var tmpDir string
+	if tmpDir = os.Getenv("DOCKER_TMPDIR"); tmpDir == "" {
+		tmpDir = filepath.Join(rootDir, "tmp")
+	}
+	err := os.MkdirAll(tmpDir, 0700)
+	return tmpDir, err
+}


### PR DESCRIPTION
/tmp is often a tmpfs file system and large temporary files could cause
docker commands to fail.

Fixes #4396

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
