### PR TITLE
Give containers unique machine-id based off container ID

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -38,6 +38,7 @@ func setupMountsForContainer(container *Container) error {
 	mounts := []execdriver.Mount{
 		{container.daemon.sysInitPath, "/.dockerinit", false, true},
 		{container.ResolvConfPath, "/etc/resolv.conf", false, true},
+		{container.MachineIDPath, "/etc/machine-id", false, true},
 	}
 
 	if container.HostnamePath != "" {

--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -77,10 +77,12 @@ func TestDiffEnsureOnlyKmsgAndPtmx(t *testing.T) {
 	deleteContainer(cleanCID)
 
 	expected := map[string]bool{
-		"C /dev":      true,
-		"A /dev/full": true, // busybox
-		"C /dev/ptmx": true, // libcontainer
-		"A /dev/kmsg": true, // lxc
+		"C /dev":            true,
+		"A /dev/full":       true, // busybox
+		"C /dev/ptmx":       true, // libcontainer
+		"A /dev/kmsg":       true, // lxc
+		"C /etc":            true,
+		"A /etc/machine-id": true, // container UUID
 	}
 
 	for _, line := range strings.Split(out, "\n") {


### PR DESCRIPTION
Currently, all containers on a host share a single machine ID, accessible in /etc/machine-id. This patch adds a per-container unique ID (formed by truncating the container's ID). Programs which report information based off or identified by machine-id can now distinguish which container they are in.

Major application for this is logging with journald - these logs are distinguished based on machine-id, and with a unique per-container machine-id and a few symlinks, an in-container systemd instance can send logs (uniquely tied to the generating container) to the host.
