### PR TITLE
Allow ctrl-p ctrl-q customization

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -477,6 +477,9 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	if !remoteInfo.GetBool("IPv4Forwarding") {
 		fmt.Fprintf(cli.err, "WARNING: IPv4 forwarding is disabled.\n")
 	}
+	if detachKeys := remoteInfo.Get("DetachKeys"); detachKeys != "" {
+		fmt.Fprintf(cli.out, "Key(s) to detach from `docker run -t`: \"%s\"\n", remoteInfo.Get("DetachKeys"))
+	}
 	return nil
 }
 

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -35,7 +35,7 @@ func (daemon *Daemon) Attach(container *Container, stdin io.ReadCloser, stdinClo
 					}()
 				}
 				if container.Config.Tty {
-					_, err = utils.CopyEscapable(cStdin, stdin)
+					_, err = utils.CopyEscapable(cStdin, stdin, daemon.config.DetachKeys)
 				} else {
 					_, err = io.Copy(cStdin, stdin)
 				}

--- a/daemonconfig/config.go
+++ b/daemonconfig/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	EnableSelinuxSupport        bool
 	Context                     map[string][]string
 	DetachKeys                  []byte
+	DetachKeysStr               string
 }
 
 // ConfigFromJob creates and returns a new DaemonConfig object
@@ -54,6 +55,7 @@ func ConfigFromJob(job *engine.Job) (*Config, error) {
 			GraphDriver:                 job.Getenv("GraphDriver"),
 			ExecDriver:                  job.Getenv("ExecDriver"),
 			EnableSelinuxSupport:        job.GetenvBool("EnableSelinuxSupport"),
+			DetachKeysStr:               job.Getenv("DetachKeys"),
 		}
 	)
 	if graphOpts := job.GetenvList("GraphOptions"); graphOpts != nil {
@@ -73,7 +75,7 @@ func ConfigFromJob(job *engine.Job) (*Config, error) {
 	}
 	config.DisableNetwork = config.BridgeIface == DisableNetworkBridge
 
-	config.DetachKeys, err = term.ToBytes(job.Getenv("DetachKeys"))
+	config.DetachKeys, err = term.ToBytes(config.DetachKeysStr)
 
 	return config, err
 }

--- a/daemonconfig/config.go
+++ b/daemonconfig/config.go
@@ -1,9 +1,11 @@
 package daemonconfig
 
 import (
+	"net"
+
 	"github.com/dotcloud/docker/daemon/networkdriver"
 	"github.com/dotcloud/docker/engine"
-	"net"
+	"github.com/dotcloud/docker/pkg/term"
 )
 
 const (
@@ -31,25 +33,29 @@ type Config struct {
 	DisableNetwork              bool
 	EnableSelinuxSupport        bool
 	Context                     map[string][]string
+	DetachKeys                  []byte
 }
 
 // ConfigFromJob creates and returns a new DaemonConfig object
 // by parsing the contents of a job's environment.
-func ConfigFromJob(job *engine.Job) *Config {
-	config := &Config{
-		Pidfile:                     job.Getenv("Pidfile"),
-		Root:                        job.Getenv("Root"),
-		AutoRestart:                 job.GetenvBool("AutoRestart"),
-		EnableIptables:              job.GetenvBool("EnableIptables"),
-		EnableIpForward:             job.GetenvBool("EnableIpForward"),
-		BridgeIP:                    job.Getenv("BridgeIP"),
-		BridgeIface:                 job.Getenv("BridgeIface"),
-		DefaultIp:                   net.ParseIP(job.Getenv("DefaultIp")),
-		InterContainerCommunication: job.GetenvBool("InterContainerCommunication"),
-		GraphDriver:                 job.Getenv("GraphDriver"),
-		ExecDriver:                  job.Getenv("ExecDriver"),
-		EnableSelinuxSupport:        job.GetenvBool("EnableSelinuxSupport"),
-	}
+func ConfigFromJob(job *engine.Job) (*Config, error) {
+	var (
+		err    error
+		config = &Config{
+			Pidfile:                     job.Getenv("Pidfile"),
+			Root:                        job.Getenv("Root"),
+			AutoRestart:                 job.GetenvBool("AutoRestart"),
+			EnableIptables:              job.GetenvBool("EnableIptables"),
+			EnableIpForward:             job.GetenvBool("EnableIpForward"),
+			BridgeIP:                    job.Getenv("BridgeIP"),
+			BridgeIface:                 job.Getenv("BridgeIface"),
+			DefaultIp:                   net.ParseIP(job.Getenv("DefaultIp")),
+			InterContainerCommunication: job.GetenvBool("InterContainerCommunication"),
+			GraphDriver:                 job.Getenv("GraphDriver"),
+			ExecDriver:                  job.Getenv("ExecDriver"),
+			EnableSelinuxSupport:        job.GetenvBool("EnableSelinuxSupport"),
+		}
+	)
 	if graphOpts := job.GetenvList("GraphOptions"); graphOpts != nil {
 		config.GraphOptions = graphOpts
 	}
@@ -67,7 +73,9 @@ func ConfigFromJob(job *engine.Job) *Config {
 	}
 	config.DisableNetwork = config.BridgeIface == DisableNetworkBridge
 
-	return config
+	config.DetachKeys, err = term.ToBytes(job.Getenv("DetachKeys"))
+
+	return config, err
 }
 
 func GetDefaultNetworkMtu() int {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -66,6 +66,7 @@ func main() {
 		flCert               = flag.String([]string{"-tlscert"}, dockerConfDir+defaultCertFile, "Path to TLS certificate file")
 		flKey                = flag.String([]string{"-tlskey"}, dockerConfDir+defaultKeyFile, "Path to TLS key file")
 		flSelinuxEnabled     = flag.Bool([]string{"-selinux-enabled"}, false, "Enable selinux support")
+		flDetachKeys         = flag.String([]string{"-detach-keys"}, "ctrl-p,ctrl-q", "Key to detach in TTY mode")
 	)
 	flag.Var(&flDns, []string{"#dns", "-dns"}, "Force docker to use specific DNS servers")
 	flag.Var(&flDnsSearch, []string{"-dns-search"}, "Force Docker to use specific DNS search domains")
@@ -162,6 +163,7 @@ func main() {
 			job.Setenv("ExecDriver", *flExecDriver)
 			job.SetenvInt("Mtu", *flMtu)
 			job.SetenvBool("EnableSelinuxSupport", *flSelinuxEnabled)
+			job.Setenv("DetachKeys", *flDetachKeys)
 			if err := job.Run(); err != nil {
 				log.Fatal(err)
 			}

--- a/pkg/term/ascii.go
+++ b/pkg/term/ascii.go
@@ -51,7 +51,11 @@ next:
 					continue next
 				}
 			}
-			return nil, fmt.Errorf("Unknown character: '%s'", key)
+			if key == "DEL" {
+				codes = append(codes, 127)
+			} else {
+				return nil, fmt.Errorf("Unknown character: '%s'", key)
+			}
 		} else {
 			codes = append(codes, byte(key[0]))
 		}

--- a/pkg/term/ascii.go
+++ b/pkg/term/ascii.go
@@ -1,0 +1,60 @@
+package term
+
+import (
+	"fmt"
+	"strings"
+)
+
+var ASCII = []string{
+	"ctrl-@",
+	"ctrl-a",
+	"ctrl-b",
+	"ctrl-c",
+	"ctrl-d",
+	"ctrl-e",
+	"ctrl-f",
+	"ctrl-g",
+	"ctrl-h",
+	"ctrl-i",
+	"ctrl-j",
+	"ctrl-k",
+	"ctrl-l",
+	"ctrl-m",
+	"ctrl-n",
+	"ctrl-o",
+	"ctrl-p",
+	"ctrl-q",
+	"ctrl-r",
+	"ctrl-s",
+	"ctrl-t",
+	"ctrl-u",
+	"ctrl-v",
+	"ctrl-w",
+	"ctrl-x",
+	"ctrl-y",
+	"ctrl-z",
+	"ctrl-[",
+	"ctrl-\\",
+	"ctrl-]",
+	"ctrl-^",
+	"ctrl-_",
+}
+
+func ToBytes(keys string) ([]byte, error) {
+	codes := []byte{}
+next:
+	for _, key := range strings.Split(keys, ",") {
+		if len(key) != 1 {
+			for code, ctrl := range ASCII {
+				if ctrl == key {
+					codes = append(codes, byte(code))
+					continue next
+				}
+			}
+			return nil, fmt.Errorf("Unknown character: '%s'", key)
+		} else {
+			codes = append(codes, byte(key[0]))
+		}
+	}
+	return codes, nil
+}

--- a/pkg/term/ascii_test.go
+++ b/pkg/term/ascii_test.go
@@ -1,0 +1,32 @@
+package term
+
+import "testing"
+
+func TestToBytes(t *testing.T) {
+	codes, err := ToBytes("ctrl-a,a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(codes) != 2 {
+		t.Fatalf("Expected 2 codes, got %d", len(codes))
+	}
+	if codes[0] != 1 || codes[1] != 97 {
+		t.Fatalf("Expected '1' '97', got '%d' '%d'", codes[0], codes[1])
+	}
+
+	codes, err = ToBytes("shift-z")
+	if err == nil {
+		t.Fatalf("Expected error, got none")
+	}
+
+	codes, err = ToBytes("ctrl-@,ctrl-[,~,ctrl-o")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(codes) != 4 {
+		t.Fatalf("Expected 4 codes, got %d", len(codes))
+	}
+	if codes[0] != 0 || codes[1] != 27 || codes[2] != 126 || codes[3] != 15 {
+		t.Fatalf("Expected '0' '27' '126', '15', got '%d' '%d' '%d' '%d'", codes[0], codes[1], codes[2], codes[3])
+	}
+}

--- a/pkg/term/ascii_test.go
+++ b/pkg/term/ascii_test.go
@@ -29,4 +29,15 @@ func TestToBytes(t *testing.T) {
 	if codes[0] != 0 || codes[1] != 27 || codes[2] != 126 || codes[3] != 15 {
 		t.Fatalf("Expected '0' '27' '126', '15', got '%d' '%d' '%d' '%d'", codes[0], codes[1], codes[2], codes[3])
 	}
+
+	codes, err = ToBytes("DEL,+")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(codes) != 2 {
+		t.Fatalf("Expected 2 codes, got %d", len(codes))
+	}
+	if codes[0] != 127 || codes[1] != 43 {
+		t.Fatalf("Expected '127 '43'', got '%d' '%d'", codes[0], codes[1])
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -784,6 +784,7 @@ func (srv *Server) DockerInfo(job *engine.Job) engine.Status {
 	v.Set("IndexServerAddress", registry.IndexServerAddress())
 	v.Set("InitSha1", dockerversion.INITSHA1)
 	v.Set("InitPath", initPath)
+	v.Set("DetachKeys", srv.daemon.Config().DetachKeysStr)
 	if _, err := v.WriteTo(job.Stdout); err != nil {
 		return job.Error(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -74,7 +74,11 @@ func (srv *Server) handlerWrap(h engine.Handler) engine.Handler {
 // The signals SIGINT, SIGQUIT and SIGTERM are intercepted for cleanup.
 func InitServer(job *engine.Job) engine.Status {
 	job.Logf("Creating server")
-	srv, err := NewServer(job.Eng, daemonconfig.ConfigFromJob(job))
+	config, err := daemonconfig.ConfigFromJob(job)
+	if err != nil {
+		return job.Error(err)
+	}
+	srv, err := NewServer(job.Eng, config)
 	if err != nil {
 		return job.Error(err)
 	}


### PR DESCRIPTION
Closes #3519

@jamtur01 @SvenDowideit: documentation is coming, I want to make sure everyone agrees on the feature first.

This PR allows you to change the set of keys you have to type to detach in TTY mode, it can be less or more that two.

The basic ASCII table is supported, for example you can do: `docker -d --detach-keys="ctrl-@"` and detach in one keystroke or `docker -d --detach-keys="DEL,+"` if you don't like to have a  `ctrl` key :smile: 
