### PR TITLE
Docs: apache image on installation

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -74,9 +74,9 @@ access to the container's ports.
 
 If you run a container with an exposed port,
 
-    $ docker run --rm -i -t -p 80:80 apache
+    $ docker run --rm -i -t -p 80:80 nginx
 
-then you should be able to access that Apache server using the IP address reported by:
+then you should be able to access that Nginx server using the IP address reported by:
 
     $ boot2docker ssh ip addr show dev eth1
 

--- a/docs/sources/installation/windows.md
+++ b/docs/sources/installation/windows.md
@@ -72,9 +72,9 @@ The latest version of `boot2docker` sets up a host only network adaptor which pr
 
 If you run a container with an exposed port:
 
-    docker run --rm -i -t -p 80:80 apache
+    docker run --rm -i -t -p 80:80 nginx
 
-Then you should be able to access that Apache server using the IP address reported
+Then you should be able to access that nginx server using the IP address reported
 to you using:
 
     boot2docker ip


### PR DESCRIPTION
I'm looking through the docs and this file docs/sources/installation/mac.md does specify this command:
docker run --rm -i -t -p 80:80 apache but no apache container exists on the hub right now.

This commit fixes #6374

(sorry for all the mess I created for few issues and pull requests)
