### PR TITLE
Avoid erasing line for non-progress messages

### DIFF
--- a/utils/jsonmessage.go
+++ b/utils/jsonmessage.go
@@ -87,7 +87,7 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 		return jm.Error
 	}
 	var endl string
-	if isTerminal && jm.Stream == "" {
+	if isTerminal && jm.Stream == "" && jm.Progress != nil {
 		// <ESC>[2K = erase entire current line
 		fmt.Fprintf(out, "%c[2K\r", 27)
 		endl = "\r"


### PR DESCRIPTION
The `JSONMessage.Display` method erases the entire line by outputting the `<ESC>[2K\r` sequence before displaying the message content. This is not necessary for messages other than progress indicators, and introduces unwanted characters in the /events output.

I can't find an example where we would want to keep overriding the same line besides a progress indicator, but tbh I could have missed it.

Fix #6203
