### PR TITLE
allow utimes on mac os, only lutimes isn't supported

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -262,11 +262,11 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 	ts := []syscall.Timespec{timeToTimespec(hdr.AccessTime), timeToTimespec(hdr.ModTime)}
 	// syscall.UtimesNano doesn't support a NOFOLLOW flag atm, and
 	if hdr.Typeflag != tar.TypeSymlink {
-		if err := system.UtimesNano(path, ts); err != nil {
+		if err := system.UtimesNano(path, ts); err != nil && err != system.ErrNotSupportedPlatform {
 			return err
 		}
 	} else {
-		if err := system.LUtimesNano(path, ts); err != nil {
+		if err := system.LUtimesNano(path, ts); err != nil && err != system.ErrNotSupportedPlatform {
 			return err
 		}
 	}

--- a/pkg/system/utimes_darwin.go
+++ b/pkg/system/utimes_darwin.go
@@ -1,5 +1,3 @@
-// +build !linux,!freebsd,!darwin
-
 package system
 
 import "syscall"
@@ -9,5 +7,5 @@ func LUtimesNano(path string, ts []syscall.Timespec) error {
 }
 
 func UtimesNano(path string, ts []syscall.Timespec) error {
-	return ErrNotSupportedPlatform
+	return syscall.UtimesNano(path, ts)
 }

--- a/pkg/system/utimes_linux.go
+++ b/pkg/system/utimes_linux.go
@@ -24,8 +24,5 @@ func LUtimesNano(path string, ts []syscall.Timespec) error {
 }
 
 func UtimesNano(path string, ts []syscall.Timespec) error {
-	if err := syscall.UtimesNano(path, ts); err != nil {
-		return err
-	}
-	return nil
+	return syscall.UtimesNano(path, ts)
 }


### PR DESCRIPTION
Fix #6483
Fix https://github.com/boot2docker/boot2docker/issues/398

This will work most of the time, but will still fail on links.
Should we skip the error in `docker cp` for the `LUtimesNano` ?
