### PR TITLE
Increase size of buffer for signal forwarding with --sig-proxy

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -535,7 +535,7 @@ func (cli *DockerCli) CmdRestart(args ...string) error {
 }
 
 func (cli *DockerCli) forwardAllSignals(cid string) chan os.Signal {
-	sigc := make(chan os.Signal, 1)
+	sigc := make(chan os.Signal, 128)
 	signal.CatchAll(sigc)
 	go func() {
 		for s := range sigc {


### PR DESCRIPTION
Sending signals rapidly to a container (for example, through a script) frequently results in some signals being dropped. Root cause of this seems to be the chan for holding signals to be forwarded has a buffer size of 1, and if 2 or more new signals arrived while one was being forwarded, signals were lost. Increasing the buffer should fix this.

The value 128 here is somewhat arbitrary, but seems reasonable for normal use cases. Open to adjusting this up or down.
