### PR TITLE
Volunteer to port tests away from ./integration

### DIFF
--- a/integration/MAINTAINERS
+++ b/integration/MAINTAINERS
@@ -1,4 +1,5 @@
 Solomon Hykes <s@docker.com> (@shykes)
+Adrien Folie <folie.adrien@gmail.com> (@folieadrien)
 # WE ARE LOOKING FOR VOLUNTEERS TO HELP CLEAN THIS UP.
 # TO VOLUNTEER PLEASE OPEN A PULL REQUEST ADDING YOURSELF TO THIS FILE.
 # WE WILL HELP YOU GET STARTED. THANKS!


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Adrien Folie folie.adrien@gmail.com (github: folieadrien)
