### PR TITLE
docs.css: distinguish h2 from body

### DIFF
--- a/docs/theme/mkdocs/css/docs.css
+++ b/docs/theme/mkdocs/css/docs.css
@@ -197,7 +197,16 @@ ol li {
   margin-top: 6px;
 }
 
-.content-body h2, .content-body h3 {
+.content-body h2 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #394d54;
+  line-height: 1.7;
+  margin-bottom: 4px;
+  margin-top: 10px;
+}
+
+.content-body h3 {
   font-size: 14px;
   font-weight: 500;
   color: #394d54;


### PR DESCRIPTION
Currently it is very hard to tell the h2 headers from body text in the docs pages.

Change h2 font-size to 16 and font-weight to 600 (both between h1 and p)
