### PR TITLE
Tests on logs api

### DIFF
--- a/api/server/server_unit_test.go
+++ b/api/server/server_unit_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/dotcloud/docker/api"
-	"github.com/dotcloud/docker/engine"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/dotcloud/docker/api"
+	"github.com/dotcloud/docker/engine"
 )
 
 func TestGetBoolParam(t *testing.T) {
@@ -148,6 +150,100 @@ func TestGetContainersByName(t *testing.T) {
 	}
 	if stdoutJson.(map[string]interface{})["dirty"].(float64) != 1 {
 		t.Fatalf("%#v", stdoutJson)
+	}
+}
+
+func TestLogs(t *testing.T) {
+	eng := engine.New()
+	var inspect bool
+	var logs bool
+	eng.Register("container_inspect", func(job *engine.Job) engine.Status {
+		inspect = true
+		if len(job.Args) == 0 {
+			t.Fatal("Job arguments is empty")
+		}
+		if job.Args[0] != "test" {
+			t.Fatalf("Container name %s, must be test", job.Args[0])
+		}
+		return engine.StatusOK
+	})
+	expected := "logs"
+	eng.Register("logs", func(job *engine.Job) engine.Status {
+		logs = true
+		if len(job.Args) == 0 {
+			t.Fatal("Job arguments is empty")
+		}
+		if job.Args[0] != "test" {
+			t.Fatalf("Container name %s, must be test", job.Args[0])
+		}
+		follow := job.Getenv("follow")
+		if follow != "1" {
+			t.Fatalf("follow: %s, must be 1", follow)
+		}
+		stdout := job.Getenv("stdout")
+		if stdout != "1" {
+			t.Fatalf("stdout %s, must be 1", stdout)
+		}
+		stderr := job.Getenv("stderr")
+		if stderr != "" {
+			t.Fatalf("stderr %s, must be empty", stderr)
+		}
+		timestamps := job.Getenv("timestamps")
+		if timestamps != "1" {
+			t.Fatalf("timestamps %s, must be 1", timestamps)
+		}
+		job.Stdout.Write([]byte(expected))
+		return engine.StatusOK
+	})
+	r := serveRequest("GET", "/containers/test/logs?follow=1&stdout=1&timestamps=1", nil, eng, t)
+	if r.Code != http.StatusOK {
+		t.Fatalf("Got status %d, expected %d", r.Code, http.StatusOK)
+	}
+	if !inspect {
+		t.Fatal("container_inspect job was not called")
+	}
+	if !logs {
+		t.Fatal("logs job was not called")
+	}
+	res := r.Body.String()
+	if res != expected {
+		t.Fatalf("Output %s, expected %s", res, expected)
+	}
+}
+
+func TestLogsError(t *testing.T) {
+	eng := engine.New()
+	var inspect bool
+	var logs bool
+	eng.Register("container_inspect", func(job *engine.Job) engine.Status {
+		inspect = true
+		if len(job.Args) == 0 {
+			t.Fatal("Job arguments is empty")
+		}
+		if job.Args[0] != "test" {
+			t.Fatalf("Container name %s, must be test", job.Args[0])
+		}
+		return engine.StatusOK
+	})
+	expected := "You must choose at least one stream"
+	eng.Register("logs", func(job *engine.Job) engine.Status {
+		logs = true
+		return job.Errorf(expected)
+	})
+	r := serveRequest("GET", "/containers/test/logs", nil, eng, t)
+	t.Log(r.Code)
+	if r.Code != http.StatusOK {
+		t.Fatalf("Got status %d, expected %d", r.Code, http.StatusOK)
+	}
+	if !inspect {
+		t.Fatal("container_inspect job was not called")
+	}
+	if !logs {
+		t.Fatal("logs job was not called")
+	}
+	res := r.Body.String()
+	if !strings.Contains(res, expected) {
+		t.Fatalf("Output %s, expected Error: %s in it", res, expected)
 	}
 }
 


### PR DESCRIPTION
Here is the bug, that very hard to fix: When we return job.Errorf in
"logs" job it writes to job.Stderr, to which connected ResponseWriter and on
this write w.WriteHeader(http.StatusOK) is called. So, we get 200 on error
from "logs" job.
