### PR TITLE
Drop CAP_DAC_READ_SEARCH to prevent 6/18 vulnerability

### DIFF
--- a/daemon/execdriver/lxc/init.go
+++ b/daemon/execdriver/lxc/init.go
@@ -151,6 +151,7 @@ func setupCapabilities(args *execdriver.InitArgs) error {
 		capability.CAP_MAC_ADMIN,
 		capability.CAP_NET_ADMIN,
 		capability.CAP_SYSLOG,
+		capability.CAP_DAC_READ_SEARCH,
 	}
 
 	c, err := capability.NewPid(os.Getpid())


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Dinesh Subhraveti dineshs@altiscale.com (github: dineshs-altiscale)
