### PR TITLE
6509-fixed interactive container hangs before exit

### DIFF
--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -98,7 +98,7 @@ func (cli *DockerCli) hijack(method, path string, setRawTerminal bool, in io.Rea
 		})
 	}
 
-	sendStdin := utils.Go(func() error {
+	utils.Go(func() error {
 		if in != nil {
 			io.Copy(rwc, in)
 			utils.Debugf("[hijack] End of stdin")
@@ -122,12 +122,7 @@ func (cli *DockerCli) hijack(method, path string, setRawTerminal bool, in io.Rea
 			return err
 		}
 	}
+	
 
-	if !cli.isTerminal {
-		if err := <-sendStdin; err != nil {
-			utils.Debugf("Error sendStdin: %s", err)
-			return err
-		}
-	}
 	return nil
 }

--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -122,7 +122,6 @@ func (cli *DockerCli) hijack(method, path string, setRawTerminal bool, in io.Rea
 			return err
 		}
 	}
-	
 
 	return nil
 }


### PR DESCRIPTION
when redirecting stdout

If Cli.isTerminal  is false at api/client/cli.go,   it cause waiting terminal input by user .(api/client/hijack.go)

So i removed  waiting  user input 
