### PR TITLE
Update --sig-proxy documentation

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1714,7 +1714,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 	var (
 		cmd     = cli.Subcmd("attach", "[OPTIONS] CONTAINER", "Attach to a running container")
 		noStdin = cmd.Bool([]string{"#nostdin", "-no-stdin"}, false, "Do not attach stdin")
-		proxy   = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify all received signal to the process (even in non-tty mode)")
+		proxy   = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify received signals to the process (even in non-tty mode). SIGCHLD is not proxied")
 	)
 
 	if err := cmd.Parse(args); err != nil {

--- a/docs/man/docker-attach.1.md
+++ b/docs/man/docker-attach.1.md
@@ -22,8 +22,8 @@ the client.
 When set to true, do not attach to stdin. The default is *false*.
 
 **--sig-proxy**=*true*|*false*:
-When set to true, proxify all received signal to the process (even in non-tty
-mode). The default is *true*.
+When set to true, proxify received signals to the process (even in non-tty
+mode). SIGCHLD is not proxied. The default is *true*.
 
 # EXAMPLES
 

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -179,8 +179,8 @@ default is *false*. This option is incompatible with **-d**.
 
 
 **--sig-proxy**=*true*|*false*
-   When set to true, proxify all received signals to the process (even in
-non-tty mode). The default is true.
+   When set to true, proxify received signals to the process (even in
+non-tty mode). SIGCHLD is not proxied. The default is *true*.
 
 
 **-t**, **-tty**=*true*|*false*

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -135,7 +135,7 @@ like this:
     Attach to a running container
 
       --no-stdin=false    Do not attach stdin
-      --sig-proxy=true    Proxify all received signal to the process (even in non-tty mode)
+      --sig-proxy=true    Proxify received signals to the process (even in non-tty mode). SIGCHLD is not proxied.
 
 The `attach` command will allow you to view or
 interact with any running container, detached (`-d`)
@@ -898,7 +898,7 @@ removed before the image is removed.
       -P, --publish-all=false    Publish all exposed ports to the host interfaces
       --privileged=false         Give extended privileges to this container
       --rm=false                 Automatically remove the container when it exits (incompatible with -d)
-      --sig-proxy=true           Proxify all received signal to the process (even in non-tty mode)
+      --sig-proxy=true           Proxify received signals to the process (even in non-tty mode). SIGCHLD is not proxied.
       -t, --tty=false            Allocate a pseudo-tty
       -u, --user=""              Username or UID
       -v, --volume=[]            Bind mount a volume (e.g. from the host: -v /host:/container, from docker: -v /container)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -67,7 +67,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.")
 		// For documentation purpose
-		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify all received signal to the process (even in non-tty mode)")
+		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify received signals to the process (even in non-tty mode). SIGCHLD is not proxied.")
 		_ = cmd.String([]string{"#name", "-name"}, "", "Assign a name to the container")
 	)
 


### PR DESCRIPTION
Docker's --sig-proxy documentation presently states that it forwards all signals to the container. This isn't actually true; 440422a96346072a0a9016c4db78ff7599a702aa prevents the forwarding of SIGCHLD. This updates the documentation to reflect this.
