### PR TITLE
Disable netgo for dynbinary builds

### DIFF
--- a/hack/make/dynbinary
+++ b/hack/make/dynbinary
@@ -40,5 +40,6 @@ fi
 
 (
 	export LDFLAGS_STATIC_DOCKER="-X github.com/dotcloud/docker/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\" -X github.com/dotcloud/docker/dockerversion.INITPATH \"$DOCKER_INITPATH\""
+	export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
 	source "$(dirname "$BASH_SOURCE")/binary"
 )


### PR DESCRIPTION
It's not necessary to use the netgo implementation for non-static builds. :)

Fixes #5813
