### PR TITLE
Escape control and nonprintable characters in docker ps

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1476,6 +1476,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 				outCommand = out.Get("Command")
 				ports      = engine.NewTable("", 0)
 			)
+			outCommand = strconv.Quote(outCommand)
 			if !*noTrunc {
 				outCommand = utils.Trunc(outCommand, 20)
 			}


### PR DESCRIPTION
At present, docker ps will literally interpret any control characters in the command when printing - for example, a \n in the command will actually print a newline in the output of docker ps. This makes things less readable for the user, especially when newlines are involved. It could also potentially be used to hide information from docker ps through the use of the backspace sequence (\b). This patch escapes control sequences to remove this potential issue.
