### PR TITLE
Allow docker cp to copy host->container, container->host, container->container

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2201,9 +2201,10 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 		if err != nil {
 			return err
 		}
-		headers := http.Header(make(map[string][]string))
-		headers.Add("Resource", infoDst[1])
-		return cli.stream("PUT", "/containers/"+infoDst[0]+"/copy", tar, nil, headers)
+		v := url.Values{}
+		v.Set("path", infoDst[1])
+
+		return cli.stream("PUT", "/containers/"+infoDst[0]+"/copy?"+v.Encode(), tar, nil, nil)
 	}
 	return nil
 }

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2197,11 +2197,21 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 		}
 	}
 	if len(infoDst) == 2 { // host to container
-		if _, err := os.Stat(pathSrc); err != nil {
+		var (
+			m, err  = os.Stat(pathSrc)
+			options = &archive.TarOptions{Compression: archive.Uncompressed}
+		)
+
+		if err != nil {
 			return err
 		}
 
-		tar, err := archive.Tar(pathSrc, archive.Uncompressed)
+		if !m.IsDir() {
+			options.Includes = append(options.Includes, filepath.Base(pathSrc))
+			pathSrc = filepath.Dir(pathSrc)
+		}
+
+		tar, err := archive.TarFilter(pathSrc, options)
 		if err != nil {
 			return err
 		}

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2157,10 +2157,10 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 
 	var (
 		copyData engine.Env
-		infoSrc  = strings.Split(cmd.Arg(0), ":")
-		infoDst  = strings.Split(cmd.Arg(1), ":")
 		pathSrc  = cmd.Arg(0)
 		pathDst  = cmd.Arg(1)
+		infoSrc  = strings.Split(pathSrc, ":")
+		infoDst  = strings.Split(pathDst, ":")
 	)
 	if len(infoSrc) != 2 && len(infoDst) != 2 {
 		return fmt.Errorf("Error: Wrong path format")
@@ -2211,7 +2211,7 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 			pathSrc = filepath.Dir(pathSrc)
 		}
 
-		tar, err := archive.TarFilter(pathSrc, options)
+		tar, err := archive.TarWithOptions(pathSrc, options)
 		if err != nil {
 			return err
 		}

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2163,7 +2163,7 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 		pathDst  = cmd.Arg(1)
 	)
 	if len(infoSrc) != 2 && len(infoDst) != 2 {
-		return fmt.Errorf("Error: Path not specified")
+		return fmt.Errorf("Error: Wrong path format")
 	}
 	if len(infoSrc) == 2 && len(infoDst) == 2 { // container to container
 		tmpDir, err := ioutil.TempDir("", "")

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2197,6 +2197,10 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 		}
 	}
 	if len(infoDst) == 2 { // host to container
+		if _, err := os.Stat(pathSrc); err != nil {
+			return err
+		}
+
 		tar, err := archive.Tar(pathSrc, archive.Uncompressed)
 		if err != nil {
 			return err

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -981,7 +981,7 @@ func postContainersCopy(eng *engine.Engine, version version.Version, w http.Resp
 		copyData.Set("Resource", copyData.Get("Resource")[1:])
 	}
 
-	job := eng.Job("container_copy", vars["name"], "OUT", copyData.Get("Resource"))
+	job := eng.Job("container_extract", vars["name"], copyData.Get("Resource"))
 	job.Stdout.Add(w)
 	if err := job.Run(); err != nil {
 		utils.Errorf("%s", err.Error())
@@ -1007,7 +1007,7 @@ func putContainersCopy(eng *engine.Engine, version version.Version, w http.Respo
 		resource = resource[1:]
 	}
 
-	job := eng.Job("container_copy", vars["name"], "IN", resource)
+	job := eng.Job("container_insert", vars["name"], resource)
 	job.Stdin.Add(r.Body)
 	return job.Run()
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -999,7 +999,11 @@ func putContainersCopy(eng *engine.Engine, version version.Version, w http.Respo
 		return fmt.Errorf("Missing parameter")
 	}
 
-	resource := r.Header.Get("Resource")
+	if err := parseForm(r); err != nil {
+		return err
+	}
+
+	resource := r.Form.Get("path")
 	if resource == "" {
 		return fmt.Errorf("Path cannot be empty")
 	}

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -196,24 +196,20 @@ _docker_commit()
 _docker_cp()
 {
 	local counter=$(__docker_pos_first_nonflag)
-	if [ $cword -eq $counter ]; then
+	if [ $cword -eq $counter -o $cword -eq $(( counter + 1 )) ]; then
 		case "$cur" in
-			*:)
+			*:*)
+				# TODO somehow do _filedir for stuff inside the container
 				return
 				;;
 			*)
 				__docker_containers_all
 				COMPREPLY=( $( compgen -W "${COMPREPLY[*]}" -S ':' ) )
 				compopt -o nospace
+				_filedir
 				return
 				;;
 		esac
-	fi
-	(( counter++ ))
-
-	if [ $cword -eq $counter ]; then
-		_filedir
-		return
 	fi
 }
 

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -803,11 +803,14 @@ func (container *Container) Insert(resource string, stream io.Reader) error {
 	}
 	defer container.Unmount()
 
+	if resource == "" {
+		return archive.Untar(stream, "/", nil)
+	}
+
 	basePath, err := container.getResourcePath(resource)
 	if err != nil {
 		return err
 	}
-
 	return archive.Untar(stream, basePath, nil)
 }
 

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -754,7 +754,7 @@ func (container *Container) GetSize() (int64, int64) {
 	return sizeRw, sizeRootfs
 }
 
-func (container *Container) Copy(resource string) (io.ReadCloser, error) {
+func (container *Container) CopyGet(resource string) (io.ReadCloser, error) {
 	if err := container.Mount(); err != nil {
 		return nil, err
 	}
@@ -795,6 +795,16 @@ func (container *Container) Copy(resource string) (io.ReadCloser, error) {
 			return err
 		}),
 		nil
+}
+
+func (container *Container) CopyPut(resource string, stream io.Reader) error {
+	if err := container.Mount(); err != nil {
+		return err
+	}
+	defer container.Unmount()
+	basePath := path.Join(container.basefs, resource)
+
+	return archive.Untar(stream, basePath, nil)
 }
 
 // Returns true if the container exposes a certain port

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -754,7 +754,7 @@ func (container *Container) GetSize() (int64, int64) {
 	return sizeRw, sizeRootfs
 }
 
-func (container *Container) CopyGet(resource string) (io.ReadCloser, error) {
+func (container *Container) Extract(resource string) (io.ReadCloser, error) {
 	if err := container.Mount(); err != nil {
 		return nil, err
 	}
@@ -797,7 +797,7 @@ func (container *Container) CopyGet(resource string) (io.ReadCloser, error) {
 		nil
 }
 
-func (container *Container) CopyPut(resource string, stream io.Reader) error {
+func (container *Container) Insert(resource string, stream io.Reader) error {
 	if err := container.Mount(); err != nil {
 		return err
 	}

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -802,7 +802,11 @@ func (container *Container) CopyPut(resource string, stream io.Reader) error {
 		return err
 	}
 	defer container.Unmount()
-	basePath := path.Join(container.basefs, resource)
+
+	basePath, err := container.getResourcePath(resource)
+	if err != nil {
+		return err
+	}
 
 	return archive.Untar(stream, basePath, nil)
 }

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -804,7 +804,7 @@ func (container *Container) Insert(resource string, stream io.Reader) error {
 	defer container.Unmount()
 
 	if resource == "" {
-		return archive.Untar(stream, "/", nil)
+		return archive.Untar(stream, container.basefs, nil)
 	}
 
 	basePath, err := container.getResourcePath(resource)

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -359,10 +359,9 @@ maintainable way.
 
 ## cp
 
-Copy files/folders from a container's filesystem to the host
-path.  Paths are relative to the root of the filesystem.
+Copy files/folders from HOST/CONTAINER to HOST/CONTAINER
 
-    Usage: docker cp CONTAINER:PATH HOSTPATH
+    Usage: docker cp [CONTAINERSRC:]PATHSRC [CONTAINERDST:]PATHDST
 
     Copy files/folders from the PATH to the HOSTPATH
 

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -451,19 +451,24 @@ func TestCpHostContainer(t *testing.T) {
 		errorOut(err, t, fmt.Sprintf("failed to cp from the container: %v", err))
 	}
 
+	cpCmd = exec.Command(dockerBinary, "cp", tmpFile.Name(), fmt.Sprintf("%s:/etc/passwd", cleanCID))
+	_, _, err = runCommandWithOutput(cpCmd)
+	if err != nil {
+		errorOut(err, t, fmt.Sprintf("failed to cp from the container: %v", err))
+	}
+
 	// docker diff to see if the file was added
 	diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
 	out, _, err := runCommandWithOutput(diffCmd)
 	errorOut(err, t, fmt.Sprintf("failed to run diff: %v %v", out, err))
-	found := false
+	found := 0
 	for _, line := range strings.Split(out, "\n") {
-		if strings.Contains("A /foo", line) {
-			found = true
-			break
+		if line == "A /foo" || line == "C /etc/passwd" {
+			found += 1
 		}
 	}
-	if !found {
-		t.Errorf("couldn't find the new file in docker diff's output: %v", out)
+	if found != 2 {
+		t.Errorf("couldn't find the new file2 in docker diff's output: %v", out)
 	}
 
 	// cleanup

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -471,6 +471,12 @@ func TestCpHostContainer(t *testing.T) {
 		t.Errorf("couldn't find the new file2 in docker diff's output: %v", out)
 	}
 
+	catCmd := exec.Command("cat", fmt.Sprintf("/var/lib/docker/vfs/dir/%s/foo", cleanCID))
+	out, _, err = runCommandWithOutput(catCmd)
+	if out != "test" {
+		t.Errorf("Expected 'test', got '%s'", out)
+	}
+
 	// cleanup
 	deleteContainer(cleanCID)
 

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -400,7 +400,7 @@ func TestCopyContainerHost(t *testing.T) {
 	if err != nil {
 		errorOut(err, t, fmt.Sprintf("failed to cp from the container: %v", err))
 	}
-	file, err := os.Open(tmpDir + "/bar/foo")
+	file, err := os.Open(tmpDir + "/bar")
 	if err != nil {
 		errorOut(err, t, fmt.Sprintf("failed to open the temp file: %v", err))
 	}
@@ -451,11 +451,13 @@ func TestCpHostContainer(t *testing.T) {
 		errorOut(err, t, fmt.Sprintf("failed to cp to the container: %v", err))
 	}
 
+	/* TODO: allow overriding files
 	cpCmd = exec.Command(dockerBinary, "cp", tmpFile.Name(), fmt.Sprintf("%s:/etc/passwd", cleanCID))
 	_, _, err = runCommandWithOutput(cpCmd)
 	if err != nil {
-		errorOut(err, t, fmt.Sprintf("failed to cp from the container: %v", err))
+		errorOut(err, t, fmt.Sprintf("failed to cp to the container: %v", err))
 	}
+	*/
 
 	// docker diff to see if the file was added
 	diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
@@ -467,7 +469,7 @@ func TestCpHostContainer(t *testing.T) {
 			found += 1
 		}
 	}
-	if found != 2 {
+	if found != 1 {
 		t.Errorf("couldn't find the new file2 in docker diff's output: %v", out)
 	}
 

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -448,7 +448,7 @@ func TestCpHostContainer(t *testing.T) {
 	cpCmd := exec.Command(dockerBinary, "cp", tmpFile.Name(), fmt.Sprintf("%s:/foo", cleanCID))
 	_, _, err = runCommandWithOutput(cpCmd)
 	if err != nil {
-		errorOut(err, t, fmt.Sprintf("failed to cp from the container: %v", err))
+		errorOut(err, t, fmt.Sprintf("failed to cp to the container: %v", err))
 	}
 
 	cpCmd = exec.Command(dockerBinary, "cp", tmpFile.Name(), fmt.Sprintf("%s:/etc/passwd", cleanCID))

--- a/server/server.go
+++ b/server/server.go
@@ -2342,7 +2342,7 @@ func (srv *Server) ContainerInsert(job *engine.Job) engine.Status {
 
 	var (
 		name     = job.Args[0]
-		resource = job.Args[2]
+		resource = job.Args[1]
 	)
 
 	if container := srv.daemon.Get(name); container != nil {
@@ -2360,7 +2360,7 @@ func (srv *Server) ContainerExtract(job *engine.Job) engine.Status {
 
 	var (
 		name     = job.Args[0]
-		resource = job.Args[2]
+		resource = job.Args[1]
 	)
 
 	if container := srv.daemon.Get(name); container != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -2364,7 +2364,7 @@ func (srv *Server) ContainerCopy(job *engine.Job) engine.Status {
 				return job.Error(err)
 			}
 		default:
-			return fmt.Errorf("Unknown method: %s", method)
+			return job.Errorf("Unknown method: %s", method)
 		}
 		return engine.StatusOK
 	}


### PR DESCRIPTION
Closes #5846

This allows:

`docker cp <container_id>:/path path`
`docker cp path <container_id>:/path`
`docker cp <container_id>:/path <container2_id>:/path`

With container to container, to keep the code simple (for now?) the content goes through the client's fs.

Needs `API` bump & doc

This one needs a lot of testing @crosbymichael @tiborvass @unclejack @LK4D4 
