### PR TITLE
Fatal() doesn't take a format string like Fatalf()

### DIFF
--- a/runconfig/parse_test.go
+++ b/runconfig/parse_test.go
@@ -25,26 +25,26 @@ func TestParseLxcConfOpt(t *testing.T) {
 
 func TestNetHostname(t *testing.T) {
 	if _, _, _, err := Parse([]string{"-h=name", "img", "cmd"}, nil); err != nil {
-		t.Fatal("Unexpected error: %s", err)
+		t.Fatalf("Unexpected error: %s", err)
 	}
 
 	if _, _, _, err := Parse([]string{"--net=host", "img", "cmd"}, nil); err != nil {
-		t.Fatal("Unexpected error: %s", err)
+		t.Fatalf("Unexpected error: %s", err)
 	}
 
 	if _, _, _, err := Parse([]string{"-h=name", "--net=bridge", "img", "cmd"}, nil); err != nil {
-		t.Fatal("Unexpected error: %s", err)
+		t.Fatalf("Unexpected error: %s", err)
 	}
 
 	if _, _, _, err := Parse([]string{"-h=name", "--net=none", "img", "cmd"}, nil); err != nil {
-		t.Fatal("Unexpected error: %s", err)
+		t.Fatalf("Unexpected error: %s", err)
 	}
 
 	if _, _, _, err := Parse([]string{"-h=name", "--net=host", "img", "cmd"}, nil); err != ErrConflictNetworkHostname {
-		t.Fatal("Expected error ErrConflictNetworkHostname, got: %s", err)
+		t.Fatalf("Expected error ErrConflictNetworkHostname, got: %s", err)
 	}
 
 	if _, _, _, err := Parse([]string{"-h=name", "--net=container:other", "img", "cmd"}, nil); err != ErrConflictNetworkHostname {
-		t.Fatal("Expected error ErrConflictNetworkHostname, got: %s", err)
+		t.Fatalf("Expected error ErrConflictNetworkHostname, got: %s", err)
 	}
 }


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Kato Kazuyoshi kato.kazuyoshi@gmail.com (github: kzys)
