### PR TITLE
Add versioning to docs output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ BINDDIR := bundles
 DOCSPORT := 8000
 
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+GITCOMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 DOCKER_IMAGE := docker$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 DOCKER_DOCS_IMAGE := docker-docs$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 DOCKER_MOUNT := $(if $(BINDDIR),-v "$(CURDIR)/$(BINDDIR):/go/src/github.com/dotcloud/docker/$(BINDDIR)")
@@ -59,6 +60,7 @@ docs-build:
 	cp ./VERSION docs/VERSION
 	echo "$(GIT_BRANCH)" > docs/GIT_BRANCH
 	echo "$(AWS_S3_BUCKET)" > docs/AWS_S3_BUCKET
+	echo "$(GITCOMMIT)" > docs/GITCOMMIT
 	docker build -t "$(DOCKER_DOCS_IMAGE)" docs
 
 bundles:

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -28,8 +28,12 @@ WORKDIR	/docs
 
 RUN	VERSION=$(cat /docs/VERSION)								&&\
 	GIT_BRANCH=$(cat /docs/GIT_BRANCH)							&&\
+	GITCOMMIT=$(cat /docs/GITCOMMIT)							&&\
 	AWS_S3_BUCKET=$(cat /docs/AWS_S3_BUCKET)						&&\
-	echo "{% set docker_version = \"${VERSION}\" %}{% set docker_branch = \"${GIT_BRANCH}\" %}{% set aws_bucket = \"${AWS_S3_BUCKET}\" %}{% include \"beta_warning.html\" %}" > /docs/theme/mkdocs/version.html
+	sed -i "s/\$VERSION/$VERSION/g" /docs/theme/mkdocs/base.html				&&\
+	sed -i "s/\$GITCOMMIT/$GITCOMMIT/g" /docs/theme/mkdocs/base.html			&&\
+	sed -i "s/\$GIT_BRANCH/$GIT_BRANCH/g" /docs/theme/mkdocs/base.html			&&\
+	sed -i "s/\$AWS_S3_BUCKET/$AWS_S3_BUCKET/g" /docs/theme/mkdocs/base.html
 
 # note, EXPOSE is only last because of https://github.com/dotcloud/docker/issues/3525
 EXPOSE	8000

--- a/docs/release.sh
+++ b/docs/release.sh
@@ -18,7 +18,15 @@ EOF
 
 [ "$AWS_S3_BUCKET" ] || usage
 
-#VERSION=$(cat VERSION)
+VERSION=$(cat VERSION)
+
+if [ "$$AWS_S3_BUCKET" == "docs.docker.com" ]; then
+	if [ "${VERSION%-dev}" != "$VERSION" ]; then
+		echo "Please do not push '-dev' documentation to docs.docker.com ($VERSION)"
+		exit 1
+	fi
+fi
+
 export BUCKET=$AWS_S3_BUCKET
 
 export AWS_CONFIG_FILE=$(pwd)/awsconfig
@@ -50,7 +58,7 @@ build_current_documentation() {
 
 upload_current_documentation() {
 	src=site/
-	dst=s3://$BUCKET
+	dst=s3://$BUCKET$1
 
 	echo
 	echo "Uploading $src"
@@ -61,7 +69,7 @@ upload_current_documentation() {
 
 	# a really complicated way to send only the files we want
 	# if there are too many in any one set, aws s3 sync seems to fall over with 2 files to go
-	endings=( json html xml css js gif png JPG )
+	endings=( json html xml css js gif png JPG ttf svg woff)
 	for i in ${endings[@]}; do
 		include=""
 		for j in ${endings[@]}; do
@@ -78,11 +86,8 @@ upload_current_documentation() {
 			--exclude *.DS_Store \
 			--exclude *.psd \
 			--exclude *.ai \
-			--exclude *.svg \
 			--exclude *.eot \
 			--exclude *.otf \
-			--exclude *.ttf \
-			--exclude *.woff \
 			--exclude *.rej \
 			--exclude *.rst \
 			--exclude *.orig \
@@ -99,3 +104,10 @@ setup_s3
 build_current_documentation
 upload_current_documentation
 
+# Remove the last version - 1.0.2-dev -> 1.0
+MAJOR_MINOR="v${VERSION%.*}"
+
+#build again with /v1.0/ prefix
+sed -i "s/^site_url:.*/site_url: \/$MAJOR_MINOR\//" mkdocs.yml
+build_current_documentation
+upload_current_documentation "/$MAJOR_MINOR/"

--- a/docs/theme/mkdocs/base.html
+++ b/docs/theme/mkdocs/base.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+{% set docker_version = "$VERSION" %}{% set docker_commit = "$GITCOMMIT" %}{% set docker_branch = "$GIT_BRANCH" %}{% set aws_bucket = "$AWS_S3_BUCKET" %}
+  <meta name="docker_version" content="{{ docker_version }}">
+  <meta name="docker_git_branch" content="{{ docker_branch }}">
+  <meta name="docker_git_commit" content="{{ docker_commit }}">
+
   {% if meta.page_description %}<meta name="description" content="{{ meta.page_description[0] }}">{% endif %}
   {% if meta.page_keywords %}<meta name="keywords" content="{{ meta.page_keywords[0] }}">{% endif %}
   {% if site_author %}<meta name="author" content="{{ site_author }}">{% endif %}
@@ -59,7 +65,7 @@
         </div>
       </div>
       <div class="span9 content-body">
-        {% include "version.html" %}
+        {% include "beta_warning.html" %}
         {{ content }}
       </div>
     </div>


### PR DESCRIPTION
With this PR, the `make AWS_S3_BUCKET=docs-stage.docker.com docs-release` will push both to the root of the site, and to `/v1.0/` - it needs to run the generation twice, as all the links need to be prefixed.

I have not made a UI for it yet - that comes in a later PR - for now, I want to ensure that we have a `/v1.0/` before we make a `/v1.1/`
