### PR TITLE
--ignore-permissions flag to `docker build` now ignores files that cannot be accessed.

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -100,6 +100,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	noCache := cmd.Bool([]string{"#no-cache", "-no-cache"}, false, "Do not use cache when building the image")
 	rm := cmd.Bool([]string{"#rm", "-rm"}, true, "Remove intermediate containers after a successful build")
 	forceRm := cmd.Bool([]string{"-force-rm"}, false, "Always remove intermediate containers, even after unsuccessful builds")
+	ignorePerms := cmd.Bool([]string{"-ignore-permissions"}, false, "Always remove intermediate containers, even after unsuccessful builds")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -160,10 +161,10 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		if _, err = os.Stat(filename); os.IsNotExist(err) {
 			return fmt.Errorf("no Dockerfile found in %s", cmd.Arg(0))
 		}
-		if err = utils.ValidateContextDirectory(root); err != nil {
+		if err = utils.ValidateContextDirectory(root, *ignorePerms); err != nil {
 			return fmt.Errorf("Error checking context is accessible: '%s'. Please check permissions and try again.", err)
 		}
-		context, err = archive.Tar(root, archive.Uncompressed)
+		context, err = archive.Tar(root, archive.Uncompressed, *ignorePerms)
 	}
 	var body io.Reader
 	// Setup an upload progress bar

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -64,7 +64,7 @@ func TestCmdStreamGood(t *testing.T) {
 }
 
 func tarUntar(t *testing.T, origin string, compression Compression) error {
-	archive, err := Tar(origin, compression)
+	archive, err := Tar(origin, compression, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -665,7 +665,7 @@ func (container *Container) Export() (archive.Archive, error) {
 		return nil, err
 	}
 
-	archive, err := archive.Tar(container.basefs, archive.Uncompressed)
+	archive, err := archive.Tar(container.basefs, archive.Uncompressed, false)
 	if err != nil {
 		container.Unmount()
 		return nil, err
@@ -816,7 +816,7 @@ func (container *Container) Copy(resource string) (io.ReadCloser, error) {
 	archive, err := archive.TarFilter(basePath, &archive.TarOptions{
 		Compression: archive.Uncompressed,
 		Includes:    filter,
-	})
+	}, false)
 	if err != nil {
 		container.Unmount()
 		return nil, err

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -297,7 +297,7 @@ func (a *Driver) Put(id string) {
 func (a *Driver) Diff(id string) (archive.Archive, error) {
 	return archive.TarFilter(path.Join(a.rootPath(), "diff", id), &archive.TarOptions{
 		Compression: archive.Uncompressed,
-	})
+	}, false)
 }
 
 func (a *Driver) ApplyDiff(id string, diff archive.ArchiveReader) error {

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -315,7 +315,7 @@ func copyExistingContents(source, destination string) error {
 
 		if len(srcList) == 0 {
 			// If the source volume is empty copy files from the root into the volume
-			if err := archive.CopyWithTar(source, destination); err != nil {
+			if err := archive.CopyWithTar(source, destination, false); err != nil {
 				return err
 			}
 		}

--- a/image/image.go
+++ b/image/image.go
@@ -187,7 +187,7 @@ func (img *Image) TarLayer() (arch archive.Archive, err error) {
 	}()
 
 	if img.Parent == "" {
-		archive, err := archive.Tar(imgFs, archive.Uncompressed)
+		archive, err := archive.Tar(imgFs, archive.Uncompressed, false)
 		if err != nil {
 			return nil, err
 		}

--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -465,7 +465,7 @@ func (b *buildFile) addContext(container *daemon.Container, orig, dest string, d
 	if err := os.MkdirAll(path.Dir(destPath), 0755); err != nil {
 		return err
 	}
-	if err := archive.CopyWithTar(origPath, destPath); err != nil {
+	if err := archive.CopyWithTar(origPath, destPath, false); err != nil {
 		return err
 	}
 
@@ -548,7 +548,7 @@ func (b *buildFile) runContextCommand(args string, allowRemote bool, allowDecomp
 		origPath = path.Join(filepath.Base(tmpDirName), filepath.Base(tmpFileName))
 
 		// Process the checksum
-		r, err := archive.Tar(tmpFileName, archive.Uncompressed)
+		r, err := archive.Tar(tmpFileName, archive.Uncompressed, false)
 		if err != nil {
 			return err
 		}
@@ -858,7 +858,7 @@ func stripComments(raw []byte) string {
 }
 
 func copyAsDirectory(source, destination string, destinationExists bool) error {
-	if err := archive.CopyWithTar(source, destination); err != nil {
+	if err := archive.CopyWithTar(source, destination, false); err != nil {
 		return err
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -373,7 +373,7 @@ func (srv *Server) ImageExport(job *engine.Job) engine.Status {
 		}
 	}
 
-	fs, err := archive.Tar(tempdir, archive.Uncompressed)
+	fs, err := archive.Tar(tempdir, archive.Uncompressed, false)
 	if err != nil {
 		return job.Error(err)
 	}
@@ -474,7 +474,7 @@ func (srv *Server) Build(job *engine.Job) engine.Status {
 			return job.Errorf("Error trying to use git: %s (%s)", err, output)
 		}
 
-		c, err := archive.Tar(root, archive.Uncompressed)
+		c, err := archive.Tar(root, archive.Uncompressed, false)
 		if err != nil {
 			return job.Error(err)
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1055,7 +1055,7 @@ func TreeSize(dir string) (size int64, err error) {
 // ValidateContextDirectory checks if all the contents of the directory
 // can be read and returns an error if some files can't be read
 // symlinks which point to non-existing files don't trigger an error
-func ValidateContextDirectory(srcPath string) error {
+func ValidateContextDirectory(srcPath string, ignorePerms bool) error {
 	var finalError error
 
 	filepath.Walk(filepath.Join(srcPath, "."), func(filePath string, f os.FileInfo, err error) error {
@@ -1077,9 +1077,11 @@ func ValidateContextDirectory(srcPath string) error {
 
 		if !f.IsDir() {
 			currentFile, err := os.Open(filePath)
-			if err != nil && os.IsPermission(err) {
+			if err != nil && os.IsPermission(err) && !ignorePerms {
 				finalError = fmt.Errorf("no permission to read from '%s'", filePath)
 				return err
+			} else if err != nil && ignorePerms {
+				return nil
 			} else {
 				currentFile.Close()
 			}


### PR DESCRIPTION
Adds an `--ignore-permissions` flag to `docker build` to ignore permissions errors while creating the context to upload.

Resolves #6521.
