### PR TITLE
Dmthinp devel

### DIFF
--- a/daemon/graphdriver/devmapper/README.md
+++ b/daemon/graphdriver/devmapper/README.md
@@ -128,7 +128,8 @@ Here is the list of supported options:
 
  *  `dm.blocksize`
 
-    Specifies a custom blocksize to use for the thin pool.
+    Specifies a custom blocksize to use for the thin pool.  The default
+    blocksize is 512K.
 
     Example use:
 

--- a/daemon/graphdriver/devmapper/README.md
+++ b/daemon/graphdriver/devmapper/README.md
@@ -126,6 +126,14 @@ Here is the list of supported options:
 
     ``docker -d --storage-opt dm.datadev=/dev/sdb1 --storage-opt dm.metadatadev=/dev/sdc1``
 
+ *  `dm.blocksize`
+
+    Specifies a custom blocksize to use for the thin pool.
+
+    Example use:
+
+    ``docker -d --storage-opt dm.blocksize=64K``
+
  *  `dm.blkdiscard`
 
     Enables or disables the use of blkdiscard when removing

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -28,7 +28,7 @@ var (
 	DefaultDataLoopbackSize     int64  = 100 * 1024 * 1024 * 1024
 	DefaultMetaDataLoopbackSize int64  = 2 * 1024 * 1024 * 1024
 	DefaultBaseFsSize           uint64 = 10 * 1024 * 1024 * 1024
-	DefaultThinpBlockSize       uint32  = 1024 // 512K = 1024 512b sectors
+	DefaultThinpBlockSize       uint32 = 1024 // 512K = 1024 512b sectors
 )
 
 type DevInfo struct {

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1170,19 +1170,19 @@ func NewDeviceSet(root string, doInit bool, options []string) (*DeviceSet, error
 		key = strings.ToLower(key)
 		switch key {
 		case "dm.basesize":
-			size, err := units.FromHumanSize(val)
+			size, err := units.RAMInBytes(val)
 			if err != nil {
 				return nil, err
 			}
 			devices.baseFsSize = uint64(size)
 		case "dm.loopdatasize":
-			size, err := units.FromHumanSize(val)
+			size, err := units.RAMInBytes(val)
 			if err != nil {
 				return nil, err
 			}
 			devices.dataLoopbackSize = size
 		case "dm.loopmetadatasize":
-			size, err := units.FromHumanSize(val)
+			size, err := units.RAMInBytes(val)
 			if err != nil {
 				return nil, err
 			}

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -28,6 +28,7 @@ var (
 	DefaultDataLoopbackSize     int64  = 100 * 1024 * 1024 * 1024
 	DefaultMetaDataLoopbackSize int64  = 2 * 1024 * 1024 * 1024
 	DefaultBaseFsSize           uint64 = 10 * 1024 * 1024 * 1024
+	DefaultThinpBlockSize       uint32  = 1024 // 512K = 1024 512b sectors
 )
 
 type DevInfo struct {
@@ -78,6 +79,7 @@ type DeviceSet struct {
 	dataDevice           string
 	metadataDevice       string
 	doBlkDiscard         bool
+	thinpBlockSize       uint32
 }
 
 type DiskUsage struct {
@@ -510,7 +512,7 @@ func (devices *DeviceSet) ResizePool(size int64) error {
 	}
 
 	// Reload with the new block sizes
-	if err := reloadPool(devices.getPoolName(), dataloopback, metadataloopback); err != nil {
+	if err := reloadPool(devices.getPoolName(), dataloopback, metadataloopback, devices.thinpBlockSize); err != nil {
 		return fmt.Errorf("Unable to reload pool: %s", err)
 	}
 
@@ -640,7 +642,7 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 		}
 		defer metadataFile.Close()
 
-		if err := createPool(devices.getPoolName(), dataFile, metadataFile); err != nil {
+		if err := createPool(devices.getPoolName(), dataFile, metadataFile, devices.thinpBlockSize); err != nil {
 			return err
 		}
 	}
@@ -1159,6 +1161,7 @@ func NewDeviceSet(root string, doInit bool, options []string) (*DeviceSet, error
 		baseFsSize:           DefaultBaseFsSize,
 		filesystem:           "ext4",
 		doBlkDiscard:         true,
+		thinpBlockSize:       DefaultThinpBlockSize,
 	}
 
 	foundBlkDiscard := false
@@ -1206,6 +1209,13 @@ func NewDeviceSet(root string, doInit bool, options []string) (*DeviceSet, error
 			if err != nil {
 				return nil, err
 			}
+		case "dm.blocksize":
+			size, err := units.RAMInBytes(val)
+			if err != nil {
+				return nil, err
+			}
+			// convert to 512b sectors
+			devices.thinpBlockSize = uint32(size) >> 9
 		default:
 			return nil, fmt.Errorf("Unknown option %s\n", key)
 		}

--- a/daemon/graphdriver/devmapper/devmapper.go
+++ b/daemon/graphdriver/devmapper/devmapper.go
@@ -369,7 +369,7 @@ func reloadPool(poolName string, dataFile, metadataFile *os.File) error {
 		return fmt.Errorf("Can't get data size %s", err)
 	}
 
-	params := metadataFile.Name() + " " + dataFile.Name() + " 128 32768"
+	params := metadataFile.Name() + " " + dataFile.Name() + " 128 32768 1 skip_block_zeroing"
 	if err := task.AddTarget(0, size/512, "thin-pool", params); err != nil {
 		return fmt.Errorf("Can't add target %s", err)
 	}

--- a/daemon/graphdriver/devmapper/devmapper.go
+++ b/daemon/graphdriver/devmapper/devmapper.go
@@ -328,7 +328,7 @@ func BlockDeviceDiscard(path string) error {
 }
 
 // This is the programmatic example of "dmsetup create"
-func createPool(poolName string, dataFile, metadataFile *os.File) error {
+func createPool(poolName string, dataFile, metadataFile *os.File, poolBlockSize uint32) error {
 	task, err := createTask(DeviceCreate, poolName)
 	if task == nil {
 		return err
@@ -339,7 +339,7 @@ func createPool(poolName string, dataFile, metadataFile *os.File) error {
 		return fmt.Errorf("Can't get data size %s", err)
 	}
 
-	params := metadataFile.Name() + " " + dataFile.Name() + " 128 32768 1 skip_block_zeroing"
+	params := fmt.Sprintf("%s %s %d 32768 1 skip_block_zeroing", metadataFile.Name(), dataFile.Name(), poolBlockSize)
 	if err := task.AddTarget(0, size/512, "thin-pool", params); err != nil {
 		return fmt.Errorf("Can't add target %s", err)
 	}
@@ -358,7 +358,7 @@ func createPool(poolName string, dataFile, metadataFile *os.File) error {
 	return nil
 }
 
-func reloadPool(poolName string, dataFile, metadataFile *os.File) error {
+func reloadPool(poolName string, dataFile, metadataFile *os.File, poolBlockSize uint32) error {
 	task, err := createTask(DeviceReload, poolName)
 	if task == nil {
 		return err
@@ -369,7 +369,7 @@ func reloadPool(poolName string, dataFile, metadataFile *os.File) error {
 		return fmt.Errorf("Can't get data size %s", err)
 	}
 
-	params := metadataFile.Name() + " " + dataFile.Name() + " 128 32768 1 skip_block_zeroing"
+	params := fmt.Sprintf("%s %s %d 32768 1 skip_block_zeroing", metadataFile.Name(), dataFile.Name(), poolBlockSize)
 	if err := task.AddTarget(0, size/512, "thin-pool", params); err != nil {
 		return fmt.Errorf("Can't add target %s", err)
 	}

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -54,6 +54,7 @@ func (d *Driver) Status() [][2]string {
 
 	status := [][2]string{
 		{"Pool Name", s.PoolName},
+		{"Pool Blocksize", fmt.Sprintf("%d Kb", s.SectorSize/1024)},
 		{"Data file", s.DataLoopback},
 		{"Metadata file", s.MetadataLoopback},
 		{"Data Space Used", fmt.Sprintf("%.1f Mb", float64(s.Data.Used)/(1024*1024))},

--- a/pkg/units/size.go
+++ b/pkg/units/size.go
@@ -58,11 +58,11 @@ func FromHumanSize(size string) (int64, error) {
 }
 
 // Parses a human-readable string representing an amount of RAM
-// in bytes, kibibytes, mebibytes or gibibytes, and returns the
-// number of bytes, or -1 if the string is unparseable.
+// in bytes, kibibytes, mebibytes, gibibytes, or tebibytes and
+// returns the number of bytes, or -1 if the string is unparseable.
 // Units are case-insensitive, and the 'b' suffix is optional.
 func RAMInBytes(size string) (bytes int64, err error) {
-	re, error := regexp.Compile("^(\\d+)([kKmMgG])?[bB]?$")
+	re, error := regexp.Compile("^(\\d+)([kKmMgGtT])?[bB]?$")
 	if error != nil {
 		return -1, error
 	}
@@ -86,6 +86,8 @@ func RAMInBytes(size string) (bytes int64, err error) {
 		memLimit *= 1024 * 1024
 	} else if unit == "g" {
 		memLimit *= 1024 * 1024 * 1024
+	} else if unit == "t" {
+		memLimit *= 1024 * 1024 * 1024 * 1024
 	}
 
 	return memLimit, nil

--- a/pkg/units/size_test.go
+++ b/pkg/units/size_test.go
@@ -64,7 +64,10 @@ func TestRAMInBytes(t *testing.T) {
 	assertRAMInBytes(t, "32kb", false, 32*1024)
 	assertRAMInBytes(t, "32Kb", false, 32*1024)
 	assertRAMInBytes(t, "32Mb", false, 32*1024*1024)
+	assertRAMInBytes(t, "32MB", false, 32*1024*1024)
 	assertRAMInBytes(t, "32Gb", false, 32*1024*1024*1024)
+	assertRAMInBytes(t, "32G", false, 32*1024*1024*1024)
+	assertRAMInBytes(t, "32Tb", false, 32*1024*1024*1024*1024)
 
 	assertRAMInBytes(t, "", true, -1)
 	assertRAMInBytes(t, "hello", true, -1)


### PR DESCRIPTION
This is my first pull request for docker.  I have my flame retardant pants on ;)

I am an upstream kernel maintainer for the Device Mapper (DM) subsystem.
I've been tasked with helping understand docker on dm-thinp performance using enterprise workloads.  The first step in being able to do that is to allow control of the blocksize that is used for docker's underlying dm-thin-pool.

While adding the new 'dm.blocksize' storage option I fixed a few issues along the way.
