### PR TITLE
Fix search integration-cli test

### DIFF
--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -9,7 +9,7 @@ import (
 
 // search for repos named  "registry" on the central registry
 func TestSearchOnCentralRegistry(t *testing.T) {
-	searchCmd := exec.Command(dockerBinary)
+	searchCmd := exec.Command(dockerBinary, "search", "stackbrew/busybox")
 	out, exitCode, err := runCommandWithOutput(searchCmd)
 	errorOut(err, t, fmt.Sprintf("encountered error while searching: %v", err))
 
@@ -17,9 +17,9 @@ func TestSearchOnCentralRegistry(t *testing.T) {
 		t.Fatal("failed to search on the central registry")
 	}
 
-	if !strings.Contains(out, "registry") {
-		t.Fatal("couldn't find any repository named (or containing) 'registry'")
+	if !strings.Contains(out, "Busybox base image.") {
+		t.Fatal("couldn't find any repository named (or containing) 'Busybox base image.'")
 	}
 
-	logDone("search - search for repositories named (or containing) 'registry'")
+	logDone("search - search for repositories named (or containing) 'Busybox base image.'")
 }


### PR DESCRIPTION
@unclejack, can you please take a look at this one. There is something weird.

Before the change, the test was not actually testing anything. It was calling `docker`, so it displayed the usage and looked for registry inside.

This test was the longest, I don't understand why.

Now I changed, it performs a search, this search is quite fast (only one result), but the test is still very long.

Do you have any idea ?
