### PR TITLE
Remove Docs viewport tag to fix iPhone scaling

### DIFF
--- a/docs/theme/mkdocs/base.html
+++ b/docs/theme/mkdocs/base.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
   {% if meta.page_description %}<meta name="description" content="{{ meta.page_description[0] }}">{% endif %}
   {% if meta.page_keywords %}<meta name="keywords" content="{{ meta.page_keywords[0] }}">{% endif %}
   {% if site_author %}<meta name="author" content="{{ site_author }}">{% endif %}


### PR DESCRIPTION
The docs pages on iPhone are not scalable and are set to the wrong device width and scale. To conform with the main docker site, I've just removed the viewport tag, since non exists on the main site (www.docker.com).

![img_4576](https://cloud.githubusercontent.com/assets/689046/3379229/228b67d4-fbee-11e3-8ee9-17ea38caaafe.PNG)
![img_4575](https://cloud.githubusercontent.com/assets/689046/3379230/228bd160-fbee-11e3-87c7-e5158f2cc1d2.PNG)
