### PR TITLE
Container log truncation

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -713,6 +713,18 @@ func deleteImages(eng *engine.Engine, version version.Version, w http.ResponseWr
 	return job.Run()
 }
 
+func deleteLogs(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if vars == nil {
+		return fmt.Errorf("Missing parameter")
+	}
+	job := eng.Job("truncate_logs", vars["name"])
+	if err := job.Run(); err != nil {
+		return err
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
 func postContainersStart(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -1141,8 +1153,9 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 			"/containers/{name:.*}/copy":    postContainersCopy,
 		},
 		"DELETE": {
-			"/containers/{name:.*}": deleteContainers,
-			"/images/{name:.*}":     deleteImages,
+			"/containers/{name:.*}/logs": deleteLogs,
+			"/containers/{name:.*}":      deleteContainers,
+			"/images/{name:.*}":          deleteImages,
 		},
 		"OPTIONS": {
 			"": optionsHandler,

--- a/api/server/server_unit_test.go
+++ b/api/server/server_unit_test.go
@@ -498,6 +498,26 @@ func TestDeleteContainersWithStopAndKill(t *testing.T) {
 	}
 }
 
+func TestTruncateLogs(t *testing.T) {
+	eng := engine.New()
+	var truncate_logs bool
+	eng.Register("truncate_logs", func(job *engine.Job) engine.Status {
+		truncate_logs = true
+		return engine.StatusOK
+	})
+	r := serveRequest("DELETE", "/containers/test/logs", nil, eng, t)
+	if r.Code != http.StatusNoContent {
+		t.Fatalf("Got status %d, expected %d", r.Code, http.StatusNoContent)
+	}
+	if !truncate_logs {
+		t.Fatal("truncate_logs job was not called")
+	}
+	res := r.Body.String()
+	if len(res) > 0 {
+		t.Fatalf("Output %s, expected no output", res)
+	}
+}
+
 func serveRequest(method, target string, body io.Reader, eng *engine.Engine, t *testing.T) *httptest.ResponseRecorder {
 	return serveRequestUsingVersion(method, target, api.APIVERSION, body, eng, t)
 }

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -84,6 +84,16 @@ daemon is configured to listen on.
 **New!**
 Added a `pause` parameter (default `true`) to pause the container during commit
 
+`GET /containers/json?size=1`
+
+**New!**
+Now reports the size of the log file.
+
+`DELETE /containers/(id)/logs`
+
+**New!**
+You can now truncate the logs for a container.
+
 ## v1.12
 
 ### Full Documentation

--- a/docs/sources/reference/api/docker_remote_api_v1.13.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.13.md
@@ -42,6 +42,7 @@ List containers
                      "Status": "Exit 0",
                      "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
                      "SizeRw":12288,
+                     "SizeLogs": 1712.
                      "SizeRootFs":0
              },
              {
@@ -52,6 +53,7 @@ List containers
                      "Status": "Exit 0",
                      "Ports":[],
                      "SizeRw":12288,
+                     "SizeLogs": 1712.
                      "SizeRootFs":0
              },
              {
@@ -62,6 +64,7 @@ List containers
                      "Status": "Exit 0",
                      "Ports":[],
                      "SizeRw":12288,
+                     "SizeLogs": 1712.
                      "SizeRootFs":0
              },
              {
@@ -72,6 +75,7 @@ List containers
                      "Status": "Exit 0",
                      "Ports":[],
                      "SizeRw":12288,
+                     "SizeLogs": 1712.
                      "SizeRootFs":0
              }
         ]
@@ -329,6 +333,27 @@ Get stdout and stderr logs from the container ``id``
     Status Codes:
 
     -   **200** – no error
+    -   **404** – no such container
+    -   **500** – server error
+
+### Truncate container logs
+
+`DELETE /containers/(id)/logs`
+
+Truncate the STDOUT and STDERR logs for the container ``id``
+
+    **Example request**:
+
+       DELETE /containers/4fa6e0f0c678/logs HTTP/1.1
+
+    **Example response**:
+
+        HTTP/1.1 204 No Content
+        Content-Type: text/plain
+
+    Status Codes:
+
+    -   **204** – no error
     -   **404** – no such container
     -   **500** – server error
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -751,6 +751,7 @@ For example:
       -f, --follow=false        Follow log output
       -t, --timestamps=false    Show timestamps
       --tail="all"              Output the specified number of lines at the end of logs (defaults to all logs)
+      --truncate=false          Truncate the logs
 
 The `docker logs` command batch-retrieves logs present at the time of execution.
 
@@ -763,6 +764,9 @@ value is set to `all` in that case. This behavior may change in the future.
 The `docker logs --timestamp` commands will add an RFC3339Nano
 timestamp, for example `2014-05-10T17:42:14.999999999Z07:00`, to each
 log entry.
+
+The `docker logs --truncate` command will truncate all existing logs before
+returning any logs (for example, when combined with --follow)
 
 ## port
 

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -213,3 +213,36 @@ func TestLogsTail(t *testing.T) {
 	deleteContainer(cleanedContainerID)
 	logDone("logs - logs tail")
 }
+
+func TestLogsTruncate(t *testing.T) {
+	msg := "hello world"
+	runCmd := exec.Command(dockerBinary, "run", "-d", "-t", "busybox", "sh", "-c", fmt.Sprintf("echo %s", msg))
+	logsCmd := exec.Command(dockerBinary, "logs", "--truncate", cleanedContainerID)
+	stdout, stderr, _, err := runCommandWithStdoutStderr(logsCmd)
+	errorOut(err, t, fmt.Sprintf("failed to log container: %v %v", out, err))
+
+	if stderr != "" {
+		t.Fatalf("Expected empty stderr stream, got %v", stderr)
+	}
+
+	stdout = strings.TrimSpace(stdout)
+	if stdout != msg {
+		t.Fatalf("Expected %v in stdout stream, got %v", msg, stdout)
+	}
+
+	logsCmd = exec.Command(dockerBinary, "logs", "--truncate", cleanedContainerID)
+	stdout, stderr, _, err = runCommandWithStdoutStderr(logsCmd)
+	errorOut(err, t, fmt.Sprintf("failed to log container: %v %v", out, err))
+
+	if stderr != "" {
+		t.Fatalf("Expected empty stderr stream, got %v", stderr)
+	}
+
+	if stdout != "" {
+		t.Fatalf("Expected empty stdout stream, got %v", stdout)
+	}
+
+	deleteContainer(cleanedContainerID)
+
+	logDone("logs - truncate, output first time, no output second time ")
+}

--- a/server/server.go
+++ b/server/server.go
@@ -150,6 +150,7 @@ func InitServer(job *engine.Job) engine.Status {
 		"container_copy":   srv.ContainerCopy,
 		"attach":           srv.ContainerAttach,
 		"logs":             srv.ContainerLogs,
+		"truncate_logs":    srv.ContainerTruncateLogs,
 		"changes":          srv.ContainerChanges,
 		"top":              srv.ContainerTop,
 		"load":             srv.ImageLoad,
@@ -1040,9 +1041,10 @@ func (srv *Server) Containers(job *engine.Job) engine.Status {
 		}
 		out.Set("Ports", str)
 		if size {
-			sizeRw, sizeRootFs := container.GetSize()
+			sizeRw, sizeRootFs, sizeLogs := container.GetSize()
 			out.SetInt64("SizeRw", sizeRw)
 			out.SetInt64("SizeRootFs", sizeRootFs)
+			out.SetInt64("SizeLogs", sizeLogs)
 		}
 		outs.Add(out)
 		return nil
@@ -2322,6 +2324,36 @@ func (srv *Server) ContainerLogs(job *engine.Job) engine.Status {
 		if err != nil {
 			utils.Errorf("%s", err)
 		}
+	}
+	return engine.StatusOK
+}
+
+func (srv *Server) ContainerTruncateLogs(job *engine.Job) engine.Status {
+	if len(job.Args) != 1 {
+		return job.Errorf("Usage: %s CONTAINER\n", job.Name)
+	}
+
+	var (
+		name = job.Args[0]
+	)
+	container := srv.daemon.Get(name)
+	if container == nil {
+		return job.Errorf("No such container: %s", name)
+	}
+	err := container.TruncateLog("json")
+	if err != nil && os.IsNotExist(err) {
+		// Legacy logs
+		utils.Debugf("Old logs format")
+		err := container.TruncateLog("stdout")
+		if err != nil {
+			utils.Errorf("Error truncating logs (stdout): %s", err)
+		}
+		err = container.TruncateLog("stderr")
+		if err != nil {
+			utils.Errorf("Error truncating logs (stderr): %s", err)
+		}
+	} else if err != nil {
+		utils.Errorf("Error truncating logs (json): %s", err)
 	}
 	return engine.StatusOK
 }


### PR DESCRIPTION
Server, API, CLI command to truncate the logs of a container

Fixes #6630

Docker-DCO-1.1-Signed-off-by: Shannon Wynter docker.github@fremnet.net (github: freman)
