### PR TITLE
fix whitespace that precedes the escape in a multiline string.

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -1490,3 +1490,27 @@ func TestBuildAddToSymlinkDest(t *testing.T) {
 	}
 	logDone("build - add to symlink destination")
 }
+
+func TestBuildEscapeWhitespace(t *testing.T) {
+	name := "testbuildescaping"
+	defer deleteImages(name)
+
+	_, err := buildImage(name, `
+  FROM busybox
+  MAINTAINER "Docker \
+IO <io@\
+docker.com>"
+  `, true)
+
+	res, err := inspectField(name, "Author")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res != "Docker IO <io@docker.com>" {
+		t.Fatal("Parsed string did not match the escaped string")
+	}
+
+	logDone("build - validate escaping whitespace")
+}

--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -761,7 +761,7 @@ func (b *buildFile) commit(id string, autoCmd []string, comment string) error {
 }
 
 // Long lines can be split with a backslash
-var lineContinuation = regexp.MustCompile(`\s*\\\s*\n`)
+var lineContinuation = regexp.MustCompile(`\\\s*\n`)
 
 func (b *buildFile) Build(context io.Reader) (string, error) {
 	tmpdirPath, err := ioutil.TempDir("", "docker-build")


### PR DESCRIPTION
While working on #2167 I noticed that whitespace preceding the escape character would get swallowed. Example:

```
FROM foo
DESCRIPTION "he is a horse of \
course of \
course"
```

The `description` line would say:

```
he is a horse ofcourse ofcourse
```

This patch makes it so the whitespace is normal preceding the escape, but swallowed after (+ newline). Tests included.
