### PR TITLE
Add DESCRIPTION to build instructions, presented in the JSON result of

### DIFF
--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -440,6 +440,22 @@ instruction. For example:
 The output of the final `pwd` command in this
 Dockerfile would be `/a/b/c`.
 
+## DESCRIPTION
+
+DESCRIPTION [STRING]
+
+The `DESCRIPTION` instruction allows you to describe your Dockerfile. If you
+want a multiline string, supply `\` at the end of the line.
+
+For example:
+
+    DESCRIPTION This is a Dockerfile, of course! \
+    It does some neat things!
+
+This is yielded from the API as well; from the output of `docker inspect [IMAGE]`, 
+in the "Config" section, there is a "Description" element that corresponds to
+this string.
+
 ## ONBUILD
 
     ONBUILD [INSTRUCTION]

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -13,6 +13,30 @@ import (
 	"github.com/dotcloud/docker/archive"
 )
 
+func TestBuildDescription(t *testing.T) {
+	name := "testbuilddescription"
+	defer deleteImages(name)
+
+	_, err := buildImage(name, `
+  FROM busybox
+  DESCRIPTION hello, is there anyone in there?
+  `, true)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := inspectField(name, "Config.Description")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res != "hello, is there anyone in there?" {
+		t.Fatal("Description did not match the one provided.")
+	}
+}
+
 func TestBuildCacheADD(t *testing.T) {
 	buildDirectory := filepath.Join(workingDirectory, "build_tests", "TestBuildCacheADD", "1")
 	buildCmd := exec.Command(dockerBinary, "build", "-t", "testcacheadd1", ".")

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Entrypoint      []string
 	NetworkDisabled bool
 	OnBuild         []string
+	Description     string
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {

--- a/server/buildfile.go
+++ b/server/buildfile.go
@@ -81,6 +81,11 @@ func (b *buildFile) clearTmp(containers map[string]struct{}) {
 	}
 }
 
+func (b *buildFile) CmdDescription(desc string) error {
+	b.config.Description = desc
+	return b.commit("", []string{}, desc)
+}
+
 func (b *buildFile) CmdFrom(name string) error {
 	image, err := b.daemon.Repositories().LookupImage(name)
 	if err != nil {
@@ -793,6 +798,7 @@ func (b *buildFile) Build(context io.Reader) (string, error) {
 	if len(fileBytes) == 0 {
 		return "", ErrDockerfileEmpty
 	}
+
 	var (
 		dockerfile = lineContinuation.ReplaceAllString(stripComments(fileBytes), "")
 		stepN      = 0


### PR DESCRIPTION
This adds a new instruction to the dockerfile, `DESCRIPTION`, which was proposed in #2167. I figured this would be a fun way to learn about how Dockerfiles are handled, so here you go. **bonus feature**: tests!

It also adds Config.Description to the inspect output which should make the hub people happy.
