### PR TITLE
Allow re-mounting an existing mount with "remount"

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -29,8 +29,11 @@ func Mounted(mountpoint string) (bool, error) {
 // the target is not mounted
 // Options must be specified as fstab style
 func Mount(device, target, mType, options string) error {
-	if mounted, err := Mounted(target); err != nil || mounted {
-		return err
+	flag, _ := parseOptions(options)
+	if flag&REMOUNT != REMOUNT {
+		if mounted, err := Mounted(target); err != nil || mounted {
+			return err
+		}
 	}
 	return ForceMount(device, target, mType, options)
 }


### PR DESCRIPTION
Without this line of code, if a volume is present in /proc/mounts, it cannot
be remounted with new mount options.

Docker-DCO-1.1-Signed-off-by: Peter Waller p@pwaller.net (github: pwaller)

Fix #6652

Tested to the extent that I see the syscall through strace with `remount`
and this new code but not without.
