### PR TITLE
Path fixes in md2man script and README

### DIFF
--- a/docs/man/README.md
+++ b/docs/man/README.md
@@ -51,7 +51,7 @@ saving you from dealing with Pandoc and dependencies on your own computer.
 
 ## Building the Fedora / Pandoc image
 
-There is a Dockerfile provided in the `docker/contrib/man/md` directory.
+There is a Dockerfile provided in the `docker/docs/man` directory.
 
 Using this Dockerfile, create a Docker image tagged `fedora/pandoc`:
 
@@ -61,11 +61,11 @@ Using this Dockerfile, create a Docker image tagged `fedora/pandoc`:
 
 Once the image is built, run a container using the image with *volumes*:
 
-    docker run -v /<path-to-git-dir>/docker/contrib/man:/pandoc:rw \
-    -w /pandoc -i fedora/pandoc /pandoc/md/md2man-all.sh
+    docker run -v /<path-to-git-dir>/docker/docs/man:/pandoc:rw \
+    -w /pandoc -i fedora/pandoc /pandoc/md2man-all.sh
 
 The Pandoc Docker container will process the Markdown files and generate
-the man pages inside the `docker/contrib/man/man1` directory using
+the man pages inside the `docker/docs/man/man1` directory using
 Docker volumes. For more information on Docker volumes see the man page for
 `docker run` and also look at the article [Sharing Directories via Volumes]
 (http://docs.docker.io/use/working_with_volumes/).

--- a/docs/man/md2man-all.sh
+++ b/docs/man/md2man-all.sh
@@ -17,6 +17,6 @@ for FILE in *.md; do
 		# skip files that aren't of the format xxxx.N.md (like README.md)
 		continue
 	fi
-	mkdir -p "../man${num}"
-	pandoc -s -t man "$FILE" -o "../man${num}/${name}"
+	mkdir -p "./man${num}"
+	pandoc -s -t man "$FILE" -o "./man${num}/${name}"
 done

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -50,7 +50,7 @@ bundle_ubuntu() {
 	docs/man/md2man-all.sh -q
 	manRoot="$DIR/usr/share/man"
 	mkdir -p "$manRoot"
-	for manDir in docs/man?; do
+	for manDir in docs/man/man?; do
 		manBase="$(basename "$manDir")" # "man1"
 		for manFile in "$manDir"/*; do
 			manName="$(basename "$manFile")" # "docker-build.1"


### PR DESCRIPTION
The move of the manpages to docs/man left a few trailing ends. This patch cleans a few of these up. Paths in the manpage readme are updated to reflect the new path. The md2man script has been updated to generate the manpages in subdirectories of docs/man/
