### PR TITLE
Update docker-run manpage

### DIFF
--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -103,8 +103,10 @@ container can be started with the **--link**.
 **-m**, **-memory**=*memory-limit*
    Allows you to constrain the memory available to a container. If the host
 supports swap memory, then the -m memory setting can be larger than physical
-RAM. If a limit of 0 is specified, the container's memory is not limited. The 
-memory limit format: <number><optional unit>, where unit = b, k, m or g.
+RAM. If a limit of 0 is specified, the container's memory is not limited. The
+actual limit may be rounded up to a multiple of the operating system's page
+size, if it is not already. The memory limit should be formatted as follows:
+`<number><optional unit>`, where unit = b, k, m or g.
 
 **-P**, **-publish-all**=*true*|*false*
    When set to true publish all exposed ports to the host interfaces. The


### PR DESCRIPTION
Update the manpage for docker run to document some slightly obscure behavior of cgroup memory limits, which must be even-sized multiples of OS page size. It's slightly confusing to see that your container's memory limit is higher than what was set via CLI, so document this in the manpage. Also, fix a small formatting issue (the <> characters were being parsed as markdown syntax, and not produced in the output).
