### PR TITLE
add missing docker commit parens (update 6310)

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1520,7 +1520,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 func (cli *DockerCli) CmdCommit(args ...string) error {
 	cmd := cli.Subcmd("commit", "[OPTIONS] CONTAINER [REPOSITORY[:TAG]]", "Create a new image from a container's changes")
 	flComment := cmd.String([]string{"m", "-message"}, "", "Commit message")
-	flAuthor := cmd.String([]string{"a", "#author", "-author"}, "", "Author (eg. \"John Hannibal Smith <hannibal@a-team.com>\"")
+	flAuthor := cmd.String([]string{"a", "#author", "-author"}, "", "Author (eg. \"John Hannibal Smith <hannibal@a-team.com>\")")
 	// FIXME: --run is deprecated, it will be replaced with inline Dockerfile commands.
 	flConfig := cmd.String([]string{"#run", "#-run"}, "", "this option is deprecated and will be removed in a future version in favor of inline Dockerfile-compatible commands")
 	if err := cmd.Parse(args); err != nil {

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -306,7 +306,7 @@ schema.
 
     Create a new image from a container's changes
 
-      -a, --author=""     Author (eg. "John Hannibal Smith <hannibal@a-team.com>"
+      -a, --author=""     Author (eg. "John Hannibal Smith <hannibal@a-team.com>")
       -m, --message=""    Commit message
 
 It can be useful to commit a container's file changes or settings into a


### PR DESCRIPTION
I've added a commit for the docs

Replaces #6310
