### PR TITLE
Update contrib/mkimage/debootstrap to remove /var/lib/apt/lists

### DIFF
--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -164,9 +164,13 @@ if [ -z "$DONT_TOUCH_SOURCES_LIST" ]; then
 	esac
 fi
 
-# make sure we're fully up-to-date, too
 (
 	set -x
-	chroot "$rootfsDir" apt-get update
-	chroot "$rootfsDir" apt-get dist-upgrade -y
+	
+	# make sure we're fully up-to-date
+	chroot "$rootfsDir" bash -c 'apt-get update && apt-get dist-upgrade -y'
+	
+	# delete all the apt list files since they're big and get stale quickly
+	rm -rf "$rootfsDir/var/lib/apt/lists"/*
+	# this forces "apt-get update" in dependent images, which is also good
 )


### PR DESCRIPTION
(trimming at least 40MB and forcing "apt-get update" in dependent images before packages can be installed)

Closes #6217

The `rm` is safe since we've been careful about our use of `$rootfsDir` (which, if isn't set properly, this whole script will cause all kinds of fun damage, so it behooves us to make sure `mkimage.sh`, which is the only way to correctly invoke this script, correctly passes the proper rootfs directory).
