### PR TITLE
Remove superfluous reptition from usingdocker.md

### DIFF
--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -192,7 +192,7 @@ command to list the container's environment variables.
 > will scrub them when spawning shells for connection.
 
 We can see that Docker has created a series of environment variables with
-useful information about our `db` container. Each variables is prefixed with
+useful information about our `db` container. Each variable is prefixed with
 `DB_` which is populated from the `alias` we specified above. If our `alias`
 were `db1` the variables would be prefixed with `DB1_`. You can use these
 environment variables to configure your applications to connect to the database

--- a/docs/sources/userguide/usingdocker.md
+++ b/docs/sources/userguide/usingdocker.md
@@ -87,11 +87,6 @@ This will display the help text and all available flags:
       --no-stdin=false: Do not attach stdin
       --sig-proxy=true: Proxify all received signal to the process (even in non-tty mode)
 
-
-None of the containers we've run did anything particularly useful
-though. So let's build on that experience by running an example web
-application in Docker.
-
 > **Note:** 
 > You can see a full list of Docker's commands
 > [here](/reference/commandline/cli/).
@@ -140,8 +135,8 @@ command. This tells the `docker ps` command to return the details of the
 *last* container started.
 
 > **Note:** 
-> The `docker ps` command only shows running containers. If you want to
-> see stopped containers too use the `-a` flag.
+> By default, the `docker ps` command only shows information about running
+> containers. If you want to see stopped containers too use the `-a` flag.
 
 We can see the same details we saw [when we first Dockerized a
 container](/userguide/dockerizing) with one important addition in the `PORTS`


### PR DESCRIPTION
Reading through the usingdocker ("Working with Containers") tutorial I noticed a little bit of unnecessary repetition between two sections. I think this reads better - see what you think.
