### PR TITLE
Allow / as source of -v

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -960,3 +960,14 @@ func TestRootWorkdir(t *testing.T) {
 
 	logDone("run - workdir /")
 }
+
+func TestAllowBindMountingRoot(t *testing.T) {
+	s, _, err := cmd(t, "run", "-v", "/:/host", "busybox", "ls", "/host")
+	if err != nil {
+		t.Fatal(s, err)
+	}
+
+	deleteAllContainers()
+
+	logDone("run - bind mount / as volume")
+}

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -672,42 +672,6 @@ func TestPostContainersStart(t *testing.T) {
 	containerKill(eng, containerID, t)
 }
 
-// Expected behaviour: using / as a bind mount source should throw an error
-func TestRunErrorBindMountRootSource(t *testing.T) {
-	eng := NewTestEngine(t)
-	defer mkDaemonFromEngine(eng, t).Nuke()
-
-	containerID := createTestContainer(
-		eng,
-		&runconfig.Config{
-			Image:     unitTestImageID,
-			Cmd:       []string{"/bin/cat"},
-			OpenStdin: true,
-		},
-		t,
-	)
-
-	hostConfigJSON, err := json.Marshal(&runconfig.HostConfig{
-		Binds: []string{"/:/tmp"},
-	})
-
-	req, err := http.NewRequest("POST", "/containers/"+containerID+"/start", bytes.NewReader(hostConfigJSON))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	r := httptest.NewRecorder()
-	if err := server.ServeRequest(eng, api.APIVERSION, r, req); err != nil {
-		t.Fatal(err)
-	}
-	if r.Code != http.StatusInternalServerError {
-		containerKill(eng, containerID, t)
-		t.Fatal("should have failed to run when using / as a source for the bind mount")
-	}
-}
-
 func TestPostContainersStop(t *testing.T) {
 	eng := NewTestEngine(t)
 	defer mkDaemonFromEngine(eng, t).Nuke()

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -132,8 +132,8 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	// add any bind targets to the list of container volumes
 	for bind := range flVolumes.GetMap() {
 		if arr := strings.Split(bind, ":"); len(arr) > 1 {
-			if arr[0] == "/" {
-				return nil, nil, cmd, fmt.Errorf("Invalid bind mount: source can't be '/'")
+			if arr[1] == "/" {
+				return nil, nil, cmd, fmt.Errorf("Invalid bind mount: desination can't be '/'")
 			}
 			// after creating the bind mount we want to delete it from the flVolumes values because
 			// we do not want bind mounts being committed to image configs

--- a/server/server.go
+++ b/server/server.go
@@ -2055,18 +2055,10 @@ func (srv *Server) ContainerStart(job *engine.Job) engine.Status {
 	if len(job.Environ()) > 0 {
 		hostConfig := runconfig.ContainerHostConfigFromJob(job)
 		// Validate the HostConfig binds. Make sure that:
-		// 1) the source of a bind mount isn't /
-		//         The bind mount "/:/foo" isn't allowed.
-		// 2) Check that the source exists
-		//        The source to be bind mounted must exist.
+		// the source exists
 		for _, bind := range hostConfig.Binds {
 			splitBind := strings.Split(bind, ":")
 			source := splitBind[0]
-
-			// refuse to bind mount "/" to the container
-			if source == "/" {
-				return job.Errorf("Invalid bind mount '%s' : source can't be '/'", bind)
-			}
 
 			// ensure the source exists on the host
 			_, err := os.Stat(source)


### PR DESCRIPTION
We discussed this at the docker plumbers meetup and for tools and
working on the system for things like boot2docker and coreos this is
needed.  You can already bypass this check so we felt it is ok to start
allowing this feature.

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@docker.com (github: crosbymichael)
