### PR TITLE
runconfig/parse: Properly disallow system root bind mount

### DIFF
--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
+	filepath "path/filepath"
 	"strings"
 
 	"github.com/dotcloud/docker/nat"
@@ -132,8 +133,8 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	// add any bind targets to the list of container volumes
 	for bind := range flVolumes.GetMap() {
 		if arr := strings.Split(bind, ":"); len(arr) > 1 {
-			if arr[0] == "/" {
-				return nil, nil, cmd, fmt.Errorf("Invalid bind mount: source can't be '/'")
+			if filepath.Clean(arr[0]) == "/" {
+				return nil, nil, cmd, fmt.Errorf("Invalid bind mount: source can't be system root")
 			}
 			// after creating the bind mount we want to delete it from the flVolumes values because
 			// we do not want bind mounts being committed to image configs


### PR DESCRIPTION
Before you could do something like:

```
docker run --rm -it -v /./:/host busybox /bin/sh
```

and get the system root mounted in `/host`. This uses the
`path/filepath.Clean` function to properly check for and prevent other
weird things users could do to try to mess with the host filesystem.
