### PR TITLE
Add logout command

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -67,7 +67,7 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 		{"kill", "Kill a running container"},
 		{"load", "Load an image from a tar archive"},
 		{"login", "Register or Login to the docker registry server"},
-		{"logout", "Logout of the docker registry server"},
+		{"logout", "Log out from a Docker registry"},
 		{"logs", "Fetch the logs of a container"},
 		{"port", "Lookup the public-facing port which is NAT-ed to PRIVATE_PORT"},
 		{"pause", "Pause all processes within a container"},
@@ -331,9 +331,9 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	return nil
 }
 
-// logout of a registry service
+// log out from a Docker registry
 func (cli *DockerCli) CmdLogout(args ...string) error {
-	cmd := cli.Subcmd("logout", "[SERVER]", "Logout of a docker registry server, if no server is specified \""+registry.IndexServerAddress()+"\" is the default.")
+	cmd := cli.Subcmd("logout", "[SERVER]", "Log out from a Docker registry, if no server is specified \""+registry.IndexServerAddress()+"\" is the default.")
 
 	if err := cmd.Parse(args); err != nil {
 		return nil

--- a/docs/man/docker-logout.1.md
+++ b/docs/man/docker-logout.1.md
@@ -1,0 +1,24 @@
+% DOCKER(1) Docker User Manuals
+% William Henry
+% APRIL 2014
+# NAME
+docker-logout - Log the user out of a Docker registry server
+
+# SYNOPSIS
+**docker logout** [SERVER]
+
+# DESCRIPTION
+Log the user out of a docker registry server, , if no server is
+specified "https://index.docker.io/v1/" is the default. If you want to
+logout of a private registry you can specify this by adding the server name.
+
+# EXAMPLE
+
+## Logout of a local registry
+
+    # docker logout localhost:8080
+
+# HISTORY
+April 2014, Originally compiled by William Henry (whenry at redhat dot com)
+based on docker.io source material and internal work.
+

--- a/docs/man/docker-logout.1.md
+++ b/docs/man/docker-logout.1.md
@@ -1,24 +1,23 @@
 % DOCKER(1) Docker User Manuals
-% William Henry
-% APRIL 2014
+% Daniel, Dao Quang Minh
+% JUNE 2014
 # NAME
-docker-logout - Log the user out of a Docker registry server
+docker-logout - Log out from a Docker registry
 
 # SYNOPSIS
 **docker logout** [SERVER]
 
 # DESCRIPTION
-Log the user out of a docker registry server, , if no server is
+Log the user out from a Docker registry, if no server is
 specified "https://index.docker.io/v1/" is the default. If you want to
-logout of a private registry you can specify this by adding the server name.
+log out from a private registry you can specify this by adding the server name.
 
 # EXAMPLE
 
-## Logout of a local registry
+## Log out from a local registry
 
     # docker logout localhost:8080
 
 # HISTORY
-April 2014, Originally compiled by William Henry (whenry at redhat dot com)
-based on docker.io source material and internal work.
+June 2014, Originally compiled by Daniel, Dao Quang Minh (daniel at nitrous dot io)
 

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -124,6 +124,9 @@ inside it)
 **docker-login(1)**
   Register or Login to a Docker registry server
 
+**docker-logout(1)**
+  Log the user out of a Docker registry server
+
 **docker-logs(1)**
   Fetch the logs of a container
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -696,6 +696,15 @@ specify this by adding the server name.
     example:
     $ docker login localhost:8080
 
+## logout
+
+    Usage: docker logout [SERVER]
+
+    Log the user out of a docker registry server, if no server is specified "https://index.docker.io/v1/" is the default.
+
+    example:
+    $ docker logout localhost:8080
+
 ## logs
 
     Usage: docker logs CONTAINER

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -700,7 +700,7 @@ specify this by adding the server name.
 
     Usage: docker logout [SERVER]
 
-    Log the user out of a docker registry server, if no server is specified "https://index.docker.io/v1/" is the default.
+    Log out from a Docker registry, if no server is specified "https://index.docker.io/v1/" is the default.
 
     example:
     $ docker logout localhost:8080


### PR DESCRIPTION
"docker logout [SERVER]" will remove the registry server' credentials from
.dockercfg file. If a server is not specified, it will log user out of the
default docker registry server

Docker-DCO-1.1-Signed-off-by: Daniel, Dao Quang Minh dqminh89@gmail.com (github: dqminh)
