### PR TITLE
Relax dns search to accept empty domain

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -52,7 +52,7 @@ func main() {
 		flSocketGroup        = flag.String([]string{"G", "-group"}, "docker", "Group to assign the unix socket specified by -H when running in daemon mode\nuse '' (the empty string) to disable setting of a group")
 		flEnableCors         = flag.Bool([]string{"#api-enable-cors", "-api-enable-cors"}, false, "Enable CORS headers in the remote API")
 		flDns                = opts.NewListOpts(opts.ValidateIp4Address)
-		flDnsSearch          = opts.NewListOpts(opts.ValidateDomain)
+		flDnsSearch          = opts.NewListOpts(opts.ValidateDnsSearch)
 		flEnableIptables     = flag.Bool([]string{"#iptables", "-iptables"}, true, "Enable Docker's addition of iptables rules")
 		flEnableIpForward    = flag.Bool([]string{"#ip-forward", "-ip-forward"}, true, "Enable net.ipv4.ip_forward")
 		flDefaultIp          = flag.String([]string{"#ip", "-ip"}, "0.0.0.0", "Default IP address to use when binding container ports")

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -137,7 +137,16 @@ func ValidateIp4Address(val string) (string, error) {
 	return "", fmt.Errorf("%s is not an ip4 address", val)
 }
 
-func ValidateDomain(val string) (string, error) {
+// Validates domain for resolvconf search configuration.
+// A zero length domain is represented by .
+func ValidateDnsSearch(val string) (string, error) {
+	if val = strings.Trim(val, " "); val == "." {
+		return val, nil
+	}
+	return validateDomain(val)
+}
+
+func validateDomain(val string) (string, error) {
 	alpha := regexp.MustCompile(`[a-zA-Z]`)
 	if alpha.FindString(val) == "" {
 		return "", fmt.Errorf("%s is not a valid domain", val)

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -23,8 +23,9 @@ func TestValidateIP4(t *testing.T) {
 
 }
 
-func TestValidateDomain(t *testing.T) {
+func TestValidateDnsSearch(t *testing.T) {
 	valid := []string{
+		`.`,
 		`a`,
 		`a.`,
 		`1.foo`,
@@ -49,7 +50,8 @@ func TestValidateDomain(t *testing.T) {
 
 	invalid := []string{
 		``,
-		`.`,
+		` `,
+		`  `,
 		`17`,
 		`17.`,
 		`.17`,
@@ -65,14 +67,14 @@ func TestValidateDomain(t *testing.T) {
 	}
 
 	for _, domain := range valid {
-		if ret, err := ValidateDomain(domain); err != nil || ret == "" {
-			t.Fatalf("ValidateDomain(`"+domain+"`) got %s %s", ret, err)
+		if ret, err := ValidateDnsSearch(domain); err != nil || ret == "" {
+			t.Fatalf("ValidateDnsSearch(`"+domain+"`) got %s %s", ret, err)
 		}
 	}
 
 	for _, domain := range invalid {
-		if ret, err := ValidateDomain(domain); err == nil || ret != "" {
-			t.Fatalf("ValidateDomain(`"+domain+"`) got %s %s", ret, err)
+		if ret, err := ValidateDnsSearch(domain); err == nil || ret != "" {
+			t.Fatalf("ValidateDnsSearch(`"+domain+"`) got %s %s", ret, err)
 		}
 	}
 }

--- a/pkg/networkfs/resolvconf/resolvconf.go
+++ b/pkg/networkfs/resolvconf/resolvconf.go
@@ -78,8 +78,10 @@ func Build(path string, dns, dnsSearch []string) error {
 		}
 	}
 	if len(dnsSearch) > 0 {
-		if _, err := content.WriteString("search " + strings.Join(dnsSearch, " ") + "\n"); err != nil {
-			return err
+		if searchString := strings.Join(dnsSearch, " "); strings.Trim(searchString, " ") != "." {
+			if _, err := content.WriteString("search " + searchString + "\n"); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/networkfs/resolvconf/resolvconf_test.go
+++ b/pkg/networkfs/resolvconf/resolvconf_test.go
@@ -131,3 +131,28 @@ func TestBuild(t *testing.T) {
 		t.Fatalf("Expected to find '%s' got '%s'", expected, content)
 	}
 }
+
+func TestBuildWithZeroLengthDomainSearch(t *testing.T) {
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	err = Build(file.Name(), []string{"ns1", "ns2", "ns3"}, []string{"."})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := ioutil.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected := "nameserver ns1\nnameserver ns2\nnameserver ns3\n"; !bytes.Contains(content, []byte(expected)) {
+		t.Fatalf("Expected to find '%s' got '%s'", expected, content)
+	}
+	if notExpected := "search ."; bytes.Contains(content, []byte(notExpected)) {
+		t.Fatalf("Expected to not find '%s' got '%s'", notExpected, content)
+	}
+}

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -45,7 +45,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flPublish     opts.ListOpts
 		flExpose      opts.ListOpts
 		flDns         opts.ListOpts
-		flDnsSearch   = opts.NewListOpts(opts.ValidateDomain)
+		flDnsSearch   = opts.NewListOpts(opts.ValidateDnsSearch)
 		flVolumesFrom opts.ListOpts
 		flLxcOpts     opts.ListOpts
 		flEnvFile     opts.ListOpts


### PR DESCRIPTION
So now dns options can achieve all these scenarios related to `search` instruction on `resolv.conf`:
- Use host `resolv.conf` search, if no option is used.
- Use a custom search if `--dns-search=mysearch` is used.
- Do not include a search on `resolv.conf` if `--dns-search=''` is used.

The third scenario is the fix.
