### PR TITLE
Improve layer downloading

### DIFF
--- a/utils/resumablerequestreader.go
+++ b/utils/resumablerequestreader.go
@@ -24,6 +24,10 @@ func ResumableRequestReader(c *http.Client, r *http.Request, maxfail uint32, tot
 	return &resumableRequestReader{client: c, request: r, maxFailures: maxfail, totalSize: totalsize}
 }
 
+func ResumableRequestReaderWithInitialResponse(c *http.Client, r *http.Request, maxfail uint32, totalsize int64, initialResponse *http.Response) io.ReadCloser {
+	return &resumableRequestReader{client: c, request: r, maxFailures: maxfail, totalSize: totalsize, currentResponse: initialResponse}
+}
+
 func (r *resumableRequestReader) Read(p []byte) (n int, err error) {
 	if r.client == nil || r.request == nil {
 		return 0, fmt.Errorf("client and request can't be nil\n")


### PR DESCRIPTION
This PR fixes bytes range detection and removes the initial HEAD request which was being used to check if the server supports bytes range.

We're now making the request for the layer right away. We check if the server supports bytes range requests and pass the response to the ResumableRequestReader.

This saves 0.5-1s for the download of every layer.
