### PR TITLE
mkimage: use /var/tmp by default instead of /tmp

### DIFF
--- a/contrib/mkimage-alpine.sh
+++ b/contrib/mkimage-alpine.sh
@@ -13,8 +13,8 @@ usage() {
 }
 
 tmp() {
-	TMP=$(mktemp -d /tmp/alpine-docker-XXXXXXXXXX)
-	ROOTFS=$(mktemp -d /tmp/alpine-docker-rootfs-XXXXXXXXXX)
+	TMP=$(mktemp -d ${TMPDIR:-/var/tmp}/alpine-docker-XXXXXXXXXX)
+	ROOTFS=$(mktemp -d ${TMPDIR:-/var/tmp}/alpine-docker-rootfs-XXXXXXXXXX)
 	trap "rm -rf $TMP $ROOTFS" EXIT TERM INT
 }
 

--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -14,7 +14,7 @@ hash expect &>/dev/null || {
     exit 1
 }
 
-ROOTFS=$(mktemp -d /tmp/rootfs-archlinux-XXXXXXXXXX)
+ROOTFS=$(mktemp -d ${TMPDIR:-/var/tmp}/rootfs-archlinux-XXXXXXXXXX)
 chmod 755 $ROOTFS
 
 # packages to ignore for space savings

--- a/contrib/mkimage-busybox.sh
+++ b/contrib/mkimage-busybox.sh
@@ -14,7 +14,7 @@ BUSYBOX=$(which busybox)
 }
 
 set -e
-ROOTFS=/tmp/rootfs-busybox-$$-$RANDOM
+ROOTFS=${TMPDIR:-/var/tmp}/rootfs-busybox-$$-$RANDOM
 mkdir $ROOTFS
 cd $ROOTFS
 

--- a/contrib/mkimage-crux.sh
+++ b/contrib/mkimage-crux.sh
@@ -14,9 +14,9 @@ die () {
 
 ISO=${1}
 
-ROOTFS=$(mktemp -d /tmp/rootfs-crux-XXXXXXXXXX)
-CRUX=$(mktemp -d /tmp/crux-XXXXXXXXXX)
-TMP=$(mktemp -d /tmp/XXXXXXXXXX)
+ROOTFS=$(mktemp -d ${TMPDIR:-/var/tmp}/rootfs-crux-XXXXXXXXXX)
+CRUX=$(mktemp -d ${TMPDIR:-/var/tmp}/crux-XXXXXXXXXX)
+TMP=$(mktemp -d ${TMPDIR:-/var/tmp}/XXXXXXXXXX)
 
 VERSION=$(basename --suffix=.iso $ISO | sed 's/[^0-9.]*\([0-9.]*\).*/\1/')
 

--- a/contrib/mkimage-debootstrap.sh
+++ b/contrib/mkimage-debootstrap.sh
@@ -118,7 +118,7 @@ fi
 # will be filled in later, if [ -z "$skipDetection" ]
 lsbDist=''
 
-target="/tmp/docker-rootfs-debootstrap-$suite-$$-$RANDOM"
+target="${TMPDIR:-/var/tmp}/docker-rootfs-debootstrap-$suite-$$-$RANDOM"
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 returnTo="$(pwd -P)"

--- a/contrib/mkimage-rinse.sh
+++ b/contrib/mkimage-rinse.sh
@@ -39,7 +39,7 @@ if [ ! "$repo" ] || [ ! "$distro" ]; then
 	exit 1
 fi
 
-target="/tmp/docker-rootfs-rinse-$distro-$$-$RANDOM"
+target="${TMPDIR:-/var/tmp}/docker-rootfs-rinse-$distro-$$-$RANDOM"
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 returnTo="$(pwd -P)"

--- a/contrib/mkimage-unittest.sh
+++ b/contrib/mkimage-unittest.sh
@@ -15,7 +15,7 @@ SOCAT=$(which socat)
 
 shopt -s extglob
 set -ex
-ROOTFS=`mktemp -d /tmp/rootfs-busybox.XXXXXXXXXX`
+ROOTFS=`mktemp -d ${TMPDIR:-/var/tmp}/rootfs-busybox.XXXXXXXXXX`
 trap "rm -rf $ROOTFS" INT QUIT TERM
 cd $ROOTFS
 

--- a/contrib/mkimage.sh
+++ b/contrib/mkimage.sh
@@ -50,7 +50,7 @@ fi
 
 delDir=
 if [ -z "$dir" ]; then
-	dir="$(mktemp -d ${TMPDIR:-/tmp}/docker-mkimage.XXXXXXXXXX)"
+	dir="$(mktemp -d ${TMPDIR:-/var/tmp}/docker-mkimage.XXXXXXXXXX)"
 	delDir=1
 fi
 


### PR DESCRIPTION
Additionally, this can be overridden by setting the TMPDIR variable,
like this was already the case for the generic `mkimage.sh` script.

As explained in #6456, the rationale to use `/var/tmp` instead of `/tmp`
is that `/tmp` is often a small tmpfs filesystem with more restricted
rights.

Docker-DCO-1.1-Signed-off-by: Vincent Bernat vincent@bernat.im (github: vincentbernat)
