### PR TITLE
Add test for PR 6701

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -971,3 +971,15 @@ func TestAllowBindMountingRoot(t *testing.T) {
 
 	logDone("run - bind mount / as volume")
 }
+
+func TestDisallowBindMountingRootToRoot(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "-v", "/:/", "busybox", "ls", "/host")
+	out, _, err := runCommandWithOutput(cmd)
+	if err == nil {
+		t.Fatal(out, err)
+	}
+
+	deleteAllContainers()
+
+	logDone("run - bind mount /:/ as volume should fail")
+}

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -133,7 +133,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	for bind := range flVolumes.GetMap() {
 		if arr := strings.Split(bind, ":"); len(arr) > 1 {
 			if arr[1] == "/" {
-				return nil, nil, cmd, fmt.Errorf("Invalid bind mount: desination can't be '/'")
+				return nil, nil, cmd, fmt.Errorf("Invalid bind mount: destination can't be '/'")
 			}
 			// after creating the bind mount we want to delete it from the flVolumes values because
 			// we do not want bind mounts being committed to image configs


### PR DESCRIPTION
This PR adds a test for PR #6701 to ensure we're not allowing `-v /:/`.

It also fixes a minor typo in a separate commit.
