### PR TITLE
Fix formatting for docs.docker.com

### DIFF
--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -174,7 +174,6 @@ child container in two ways:
 Let's look first at the environment variables Docker sets. Let's run the `env`
 command to list the container's environment variables.
 
-```
     $ sudo docker run --rm --name web2 --link db:db training/webapp env
     . . .
     DB_NAME=/web2/db
@@ -184,7 +183,6 @@ command to list the container's environment variables.
     DB_PORT_5000_TCP_PORT=5432
     DB_PORT_5000_TCP_ADDR=172.17.0.5
     . . .
-```
 
 > **Note**:
 > These Environment variables are only set for the first process in the


### PR DESCRIPTION
I'm not sure what's going on with the rendering on docs.docker.com,
but this section is being smashed into the prior paragraph.

You don't need both indentation and the triple-backticks anyways, so
removing the backticks for consistency with the rest of the doc.
