### PR TITLE
Allow overwrite in archive.Untar

### DIFF
--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -176,6 +176,9 @@ func TestTarUntarFile(t *testing.T) {
 	if err := ioutil.WriteFile(path.Join(origin, "before", "file"), []byte("hello world"), 0700); err != nil {
 		t.Fatal(err)
 	}
+	if err := ioutil.WriteFile(path.Join(origin, "after", "file2"), []byte("please overwrite me"), 0700); err != nil {
+		t.Fatal(err)
+	}
 
 	tar, err := TarWithOptions(path.Join(origin, "before"), &TarOptions{Compression: Uncompressed, Includes: []string{"file"}})
 	if err != nil {


### PR DESCRIPTION
This will _by default_ overwrite all non-directory files in `Untar`, to mimic the tar cli:

```
$ mkdir foo
$ echo overwrite me > foo/nomercy
$ touch nomercy
$ tar -f archive.tar -c nomercy
$ cd foo && tar -x -f ../archive.tar
$ cat nomercy
$
```

All tests pass for me, I couldn't see bad side effects in image layers from this. Let me know if you have concerns.

Docker-DCO-1.1-Signed-off-by: Tibor Vass teabee89@gmail.com (github: tiborvass)
