### PR TITLE
Skip lxc_template_unit_test.go on non-Linux platforms

### DIFF
--- a/daemon/execdriver/lxc/lxc_template_unit_test.go
+++ b/daemon/execdriver/lxc/lxc_template_unit_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package lxc
 
 import (


### PR DESCRIPTION
It doesn't work without lxc-start.

Docker-DCO-1.1-Signed-off-by: Kato Kazuyoshi kato.kazuyoshi@gmail.com (github: kzys)
