### PR TITLE
Update usingdocker.md

### DIFF
--- a/docs/sources/userguide/usingdocker.md
+++ b/docs/sources/userguide/usingdocker.md
@@ -179,7 +179,7 @@ see the application.
 Our Python application is live!
 
 > **Note:**
-> If you have used boot2docker on OSX you'll need to get the IP of the virtual
+> If you have used boot2docker on OSX, or Windows, you'll need to get the IP of the virtual
 > host instead of using localhost. You can do this by running the following in
 > the boot2docker shell.
 > 


### PR DESCRIPTION
boot2docker on windows also uses an IP of its own.
