### PR TITLE
Tweak cli integration tests

### DIFF
--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -43,7 +43,7 @@ func TestRemoveContainerWithVolume(t *testing.T) {
 }
 
 func TestRemoveContainerRunning(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-d", "--name", "foo", "busybox", "sleep", "300")
+	cmd := exec.Command(dockerBinary, "run", "-dt", "--name", "foo", "busybox", "top")
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
 	}

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -8,16 +8,12 @@ import (
 
 // tagging a named image in a new unprefixed repo should work
 func TestTagUnprefixedRepoByName(t *testing.T) {
-	pullCmd := exec.Command(dockerBinary, "pull", "busybox")
-	out, exitCode, err := runCommandWithOutput(pullCmd)
-	errorOut(err, t, fmt.Sprintf("%s %s", out, err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("pulling the busybox image from the registry has failed")
+	if err := pullImageIfNotExist("busybox:latest"); err != nil {
+		t.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 
-	tagCmd := exec.Command(dockerBinary, "tag", "busybox", "testfoobarbaz")
-	out, _, err = runCommandWithOutput(tagCmd)
+	tagCmd := exec.Command(dockerBinary, "tag", "busybox:latest", "testfoobarbaz")
+	out, _, err := runCommandWithOutput(tagCmd)
 	errorOut(err, t, fmt.Sprintf("%v %v", out, err))
 
 	deleteImages("testfoobarbaz")
@@ -62,18 +58,14 @@ func TestTagInvalidUnprefixedRepo(t *testing.T) {
 
 // ensure we allow the use of valid tags
 func TestTagValidPrefixedRepo(t *testing.T) {
-	pullCmd := exec.Command(dockerBinary, "pull", "busybox")
-	out, exitCode, err := runCommandWithOutput(pullCmd)
-	errorOut(err, t, fmt.Sprintf("%s %s", out, err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("pulling the busybox image from the registry has failed")
+	if err := pullImageIfNotExist("busybox:latest"); err != nil {
+		t.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 
 	validRepos := []string{"fooo/bar", "fooaa/test"}
 
 	for _, repo := range validRepos {
-		tagCmd := exec.Command(dockerBinary, "tag", "busybox", repo)
+		tagCmd := exec.Command(dockerBinary, "tag", "busybox:latest", repo)
 		_, _, err := runCommandWithOutput(tagCmd)
 		if err != nil {
 			t.Errorf("tag busybox %v should have worked: %s", repo, err)

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -66,6 +66,15 @@ func deleteImages(images string) error {
 	return err
 }
 
+func imageExists(image string) error {
+	inspectCmd := exec.Command(dockerBinary, "inspect", image)
+	exitCode, err := runCommand(inspectCmd)
+	if exitCode != 0 && err == nil {
+		err = fmt.Errorf("couldn't find image '%s'", image)
+	}
+	return err
+}
+
 func cmd(t *testing.T, args ...string) (string, int, error) {
 	out, status, err := runCommandWithOutput(exec.Command(dockerBinary, args...))
 	errorOut(err, t, fmt.Sprintf("'%s' failed with errors: %v (%v)", strings.Join(args, " "), err, out))

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -75,6 +75,18 @@ func imageExists(image string) error {
 	return err
 }
 
+func pullImageIfNotExist(image string) (err error) {
+	if err := imageExists(image); err != nil {
+		pullCmd := exec.Command(dockerBinary, "pull", image)
+		_, exitCode, err := runCommandWithOutput(pullCmd)
+
+		if err != nil || exitCode != 0 {
+			err = fmt.Errorf("image '%s' wasn't found locally and it couldn't be pulled: %s", image, err)
+		}
+	}
+	return
+}
+
 func cmd(t *testing.T, args ...string) (string, int, error) {
 	out, status, err := runCommandWithOutput(exec.Command(dockerBinary, args...))
 	errorOut(err, t, fmt.Sprintf("'%s' failed with errors: %v (%v)", strings.Join(args, " "), err, out))


### PR DESCRIPTION
The changes made by this PR speed up the execution of the cli integration tests by approximately 28 seconds. This lowers the execution time of the cli integration tests from 170 seconds to 142 seconds on one machine.
