### PR TITLE
make /.dockerinit bind mount driver specific

### DIFF
--- a/daemon/execdriver/execdrivers/execdrivers.go
+++ b/daemon/execdriver/execdrivers/execdrivers.go
@@ -15,7 +15,7 @@ func NewDriver(name, root, initPath string, sysInfo *sysinfo.SysInfo) (execdrive
 		// we want to give the lxc driver the full docker root because it needs
 		// to access and write config and template files in /var/lib/docker/containers/*
 		// to be backwards compatible
-		return lxc.NewDriver(root, sysInfo.AppArmor)
+		return lxc.NewDriver(root, initPath, sysInfo.AppArmor)
 	case "native":
 		return native.NewDriver(path.Join(root, "execdriver", "native"), initPath)
 	}

--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -54,11 +54,12 @@ func init() {
 
 type driver struct {
 	root       string // root path for the driver to use
+	initPath   string
 	apparmor   bool
 	sharedRoot bool
 }
 
-func NewDriver(root string, apparmor bool) (*driver, error) {
+func NewDriver(root, initPath string, apparmor bool) (*driver, error) {
 	// setup unconfined symlink
 	if err := linkLxcStart(root); err != nil {
 		return nil, err
@@ -66,6 +67,7 @@ func NewDriver(root string, apparmor bool) (*driver, error) {
 	return &driver{
 		apparmor:   apparmor,
 		root:       root,
+		initPath:   initPath,
 		sharedRoot: rootIsShared(),
 	}, nil
 }
@@ -79,6 +81,7 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 	if err := execdriver.SetTerminal(c, pipes); err != nil {
 		return -1, err
 	}
+	c.Mounts = append(c.Mounts, execdriver.Mount{d.initPath, c.InitPath, false, true})
 	if err := d.generateEnvConfig(c); err != nil {
 		return -1, err
 	}

--- a/daemon/execdriver/lxc/lxc_template_unit_test.go
+++ b/daemon/execdriver/lxc/lxc_template_unit_test.go
@@ -35,7 +35,7 @@ func TestLXCConfig(t *testing.T) {
 		cpu    = cpuMin + rand.Intn(cpuMax-cpuMin)
 	)
 
-	driver, err := NewDriver(root, false)
+	driver, err := NewDriver(root, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestCustomLxcConfig(t *testing.T) {
 
 	os.MkdirAll(path.Join(root, "containers", "1"), 0777)
 
-	driver, err := NewDriver(root, false)
+	driver, err := NewDriver(root, "", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -36,7 +36,6 @@ func prepareVolumesForContainer(container *Container) error {
 
 func setupMountsForContainer(container *Container) error {
 	mounts := []execdriver.Mount{
-		{container.daemon.sysInitPath, "/.dockerinit", false, true},
 		{container.ResolvConfPath, "/etc/resolv.conf", false, true},
 	}
 


### PR DESCRIPTION
mount of /.dockerinit is not needed for native driver, so move it into lxc driver
