### PR TITLE
Reliably stop containers during Daemon shutdown

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -896,8 +896,8 @@ func (daemon *Daemon) shutdown() error {
 
 			go func() {
 				defer group.Done()
-				if err := c.KillSig(15); err != nil {
-					utils.Debugf("kill 15 error for %s - %s", c.ID, err)
+				if err := c.Stop(5); err != nil {
+					utils.Debugf("stop error for %s - %s", c.ID, err)
 				}
 				c.State.WaitStop(-1 * time.Second)
 				utils.Debugf("container stopped %s", c.ID)


### PR DESCRIPTION
At present, when shutting down the Docker daemon, SIGTERM is sent to all containers, and the daemon will then wait for them to stop. SIGTERM is not a reliable way of stopping containers, however - it can be caught and ignored. Use Stop instead, which sends SIGKILL after a timeout to ensure that containers actually stop.
