### PR TITLE
update vendored archive/tar to lower the number of memory allocations

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -53,9 +53,9 @@ clone hg code.google.com/p/go.net 84a4013f96e0
 
 clone hg code.google.com/p/gosqlite 74691fb6f837
 
-# get Go tip's archive/tar, for xattr support
-# TODO after Go 1.3 drops, bump our minimum supported version and drop this vendored dep
-clone hg code.google.com/p/go 3458ba248590
+# get Go tip's archive/tar, for xattr support and improved performance
+# TODO after Go 1.4 drops, bump our minimum supported version and drop this vendored dep
+clone hg code.google.com/p/go 17404efd6b02
 mv src/code.google.com/p/go/src/pkg/archive/tar tmp-tar
 rm -rf src/code.google.com/p/go
 mkdir -p src/code.google.com/p/go/src/pkg/archive

--- a/vendor/src/code.google.com/p/go/src/pkg/archive/tar/writer.go
+++ b/vendor/src/code.google.com/p/go/src/pkg/archive/tar/writer.go
@@ -37,8 +37,9 @@ type Writer struct {
 	nb         int64 // number of unwritten bytes for current file entry
 	pad        int64 // amount of padding to write after current file entry
 	closed     bool
-	usedBinary bool // whether the binary numeric field extension was used
-	preferPax  bool // use pax header instead of binary numeric header
+	usedBinary bool            // whether the binary numeric field extension was used
+	preferPax  bool            // use pax header instead of binary numeric header
+	hdrBuff    [blockSize]byte // buffer to use in writeHeader
 }
 
 // NewWriter creates a new Writer writing to w.
@@ -160,7 +161,8 @@ func (tw *Writer) writeHeader(hdr *Header, allowPax bool) error {
 	// subsecond time resolution, but for now let's just capture
 	// too long fields or non ascii characters
 
-	header := make([]byte, blockSize)
+	header := tw.hdrBuff[:]
+	copy(header, zeroBlock)
 	s := slicer(header)
 
 	// keep a reference to the filename to allow to overwrite it later if we detect that we can use ustar longnames instead of pax


### PR DESCRIPTION
This PR updates the vendored archive/tar to the latest version available in the main Go repository.
The changes made by this PR speed up archive/tar by avoiding the allocation of 512 bytes for every file which gets read or written.

archive/tar benchmark results with 100000 files with Go 1.3:

```
benchmark                  old ns/op     new ns/op     delta      
BenchmarkListFiles100k     559093963     509175171     -8.93%
BenchmarkWriteFiles100k     634622051     583810847     -8.01%     

benchmark                  old allocs     new allocs     delta      
BenchmarkListFiles100k     2104948        2005706        -4.71%
BenchmarkWriteFiles100k     2701920        2602621        -3.68%     

benchmark                  old bytes     new bytes     delta       
BenchmarkListFiles100k     105855768     54833570      -48.20%
BenchmarkWriteFiles100k     115383884     64349922      -44.23%
```

utils benchmark with Go 1.3:

```
benchmark                         old ns/op     new ns/op     delta      
Benchmark9kTar                    8262          8582          +3.87%     
Benchmark9kTarGzip                216425        216762        +0.16%     
Benchmark1mbSingleFileTar         6936674       7062174       +1.81%     
Benchmark1mbSingleFileTarGzip     19797914      19463825      -1.69%     
Benchmark1kFilesTar               38482089      37033734      -3.76%     
Benchmark1kFilesTarGzip           73375173      69700211      -5.01%     

benchmark                         old MB/s     new MB/s     speedup     
Benchmark9kTar                    1115.40      1073.86      0.96x       
Benchmark9kTarGzip                42.58        42.52        1.00x       
Benchmark1mbSingleFileTar         151.16       148.48       0.98x       
Benchmark1mbSingleFileTarGzip     52.96        53.87        1.02x       
Benchmark1kFilesTar               27.25        28.31        1.04x       
Benchmark1kFilesTarGzip           14.29        15.04        1.05x       

benchmark                         old allocs     new allocs     delta      
Benchmark9kTar                    18             17             -5.56%     
Benchmark9kTarGzip                42             41             -2.38%     
Benchmark1mbSingleFileTar         474            471            -0.63%     
Benchmark1mbSingleFileTarGzip     3490           3490           +0.00%     
Benchmark1kFilesTar               71482          69445          -2.85%     
Benchmark1kFilesTarGzip           141238         139068         -1.54%     

benchmark                         old bytes     new bytes     delta      
Benchmark9kTar                    9812          10332         +5.30%     
Benchmark9kTarGzip                1463523       1464034       +0.03%     
Benchmark1mbSingleFileTar         1096964       1096448       -0.05%     
Benchmark1mbSingleFileTarGzip     2959669       2959240       -0.01%     
Benchmark1kFilesTar               19470187      18428071      -5.35%     
Benchmark1kFilesTarGzip           28120800      27079195      -3.70%
```
