### PR TITLE
Fix getImagesJSON output for api less than 1.7

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -237,10 +237,10 @@ func getImagesJSON(eng *engine.Engine, version version.Version, w http.ResponseW
 		outsLegacy := engine.NewTable("Created", 0)
 		for _, out := range outs.Data {
 			for _, repoTag := range out.GetList("RepoTags") {
-				parts := strings.Split(repoTag, ":")
+				repo, tag := utils.ParseRepositoryTag(repoTag)
 				outLegacy := &engine.Env{}
-				outLegacy.Set("Repository", parts[0])
-				outLegacy.Set("Tag", parts[1])
+				outLegacy.Set("Repository", repo)
+				outLegacy.SetJson("Tag", tag)
 				outLegacy.Set("Id", out.Get("Id"))
 				outLegacy.SetInt64("Created", out.GetInt64("Created"))
 				outLegacy.SetInt64("Size", out.GetInt64("Size"))


### PR DESCRIPTION
If you try to list images, using on the client API < 1.7, like docker-0.6.6 and on the server the latest one (1.13):

```
$ ./docker-0.6.6 images
2014/07/03 11:49:26 json: cannot unmarshal number into Go value of type string
```

Because docker is sending:

```
    {
        "Created": 1364804458,
        "Id": "539c0211cd76cdeaedbecf9f023ef774612e331137ce7ebe4ae1b61088e7edbe",
        "Repository": "centos",
        "Size": 313801147,
        "Tag": 6,
        "VirtualSize": 313801147
    }
```

Tag should be handled like a string, with quotation marks:

```
"Tag": "6.4",
```

So the fix is to use `env.SetJson` instead of `env.Set`, which will add quotation marks and will not convert from float to int.

Additionally fix repository names using `ParseRepositoryTag` so it parses names with more than one `:` properly.

From:

```
    {
        "Created": 1396610402,
        "Id": "4ef43eb26f24ca029cfe668815d3c30cdceaadee78b4f72726a55a0a25669e92",
        "Repository": "mybox",
        "Size": 365,
        "Tag": "5000/mysql/dev",
        "VirtualSize": 1509036908
    }
```

To:

```
    {
        "Created": 1396610402,
        "Id": "4ef43eb26f24ca029cfe668815d3c30cdceaadee78b4f72726a55a0a25669e92",
        "Repository": "mybox:5000/mysql/dev",
        "Size": 365,
        "Tag": "latest",
        "VirtualSize": 1509036908
    }
```

Fixing the output from:

```
mybox               5000/mysql/dev       4ef43eb26f24        12 weeks ago        365 B (virtual 1.509 GB)
```

To:

```
mybox:5000/mysql/dev   latest         4ef43eb26f24        12 weeks ago         365 B (virtual 1.509 GB)
```

I can see only a place to create a regression test for this: `integration/api_test.go` but we're not including more tests on integration, right?
