### PR TITLE
Explain ADD invalidation more accurately

### DIFF
--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -169,9 +169,8 @@ will be reused during the next build.
 The cache for `RUN` instructions can be invalidated by using the `--no-cache`
 flag, for example `docker build --no-cache`.
 
-The first encountered `ADD` instruction will invalidate the cache for all
-following instructions from the 'Dockerfile' if the contents of the context
-have changed. This will also invalidate the cache for `RUN` instructions.
+The cache for `RUN` instructions can be invalidated by `ADD` instructions. See
+[below](#add) for details.
 
 ### Known Issues (RUN)
 
@@ -284,6 +283,11 @@ In the case where `<src>` is a remote file URL, the destination will have permis
 > use `RUN wget` , `RUN curl`
 > or use another tool from within the container as ADD does not support
 > authentication.
+
+> **Note**:
+> The first encountered `ADD` instruction will invalidate the cache for all
+> following instructions from the Dockerfile if the contents of `<src>` have
+> changed. This includes invalidating the cache for `RUN` instructions.
 
 The copy obeys the following rules:
 


### PR DESCRIPTION
And also move it in to the `ADD` section, rather than being hidden in the `RUN` section.

Docker-DCO-1.1-Signed-off-by: Daniel Watkins daniel@daniel-watkins.co.uk (github: OddBloke)
