### PR TITLE
Stop server from leaking events (allocating & never freeing)

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -39,7 +39,7 @@ func TestCLILimitEvents(t *testing.T) {
 	out, _, _ := runCommandWithOutput(eventsCmd)
 	events := strings.Split(out, "\n")
 	n_events := len(events) - 1
-	if n_events > 64 {
+	if n_events != 64 {
 		t.Fatalf("events should be limited to 64, but received %d", n_events)
 	}
 	logDone("events - limited to 64 entries")

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCLIGetEvents(t *testing.T) {
@@ -26,4 +29,18 @@ func TestCLIGetEvents(t *testing.T) {
 		}
 	}
 	logDone("events - untags are logged")
+}
+
+func TestCLILimitEvents(t *testing.T) {
+	for i := 0; i < 30; i++ {
+		cmd(t, "run", "busybox", "echo", strconv.Itoa(i))
+	}
+	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", time.Now().Unix()))
+	out, _, _ := runCommandWithOutput(eventsCmd)
+	events := strings.Split(out, "\n")
+	n_events := len(events) - 1
+	if n_events > 64 {
+		t.Fatalf("events should be limited to 64, but received %d", n_events)
+	}
+	logDone("events - limited to 64 entries")
 }

--- a/server/server.go
+++ b/server/server.go
@@ -2430,8 +2430,14 @@ func (srv *Server) LogEvent(action, id, from string) *utils.JSONMessage {
 
 func (srv *Server) AddEvent(jm utils.JSONMessage) {
 	srv.Lock()
-	defer srv.Unlock()
-	srv.events = append(srv.events, jm)
+	if len(srv.events) == cap(srv.events) {
+		// discard oldest event
+		copy(srv.events, srv.events[1:])
+		srv.events[len(srv.events)-1] = jm
+	} else {
+		srv.events = append(srv.events, jm)
+	}
+	srv.Unlock()
 }
 
 func (srv *Server) GetEvents() []utils.JSONMessage {


### PR DESCRIPTION
Fixes #6843
Related to #5923

Solves #6843 by dropping the oldest event when the event list has reached it's capacity.
