### PR TITLE
Fix the parent/child relationship in the docs

### DIFF
--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -149,16 +149,16 @@ Let's look at our linked containers using `docker ps`.
 
     $ docker ps
     CONTAINER ID  IMAGE                     COMMAND               CREATED             STATUS             PORTS                    NAMES
-    349169744e49  training/postgres:latest  su postgres -c '/usr  About a minute ago  Up About a minute  5432/tcp                 db
-    aed84ee21bde  training/webapp:latest    python app.py         16 hours ago        Up 2 minutes       0.0.0.0:49154->5000/tcp  db/web,web
+    349169744e49  training/postgres:latest  su postgres -c '/usr  About a minute ago  Up About a minute  5432/tcp                 db, web/db
+    aed84ee21bde  training/webapp:latest    python app.py         16 hours ago        Up 2 minutes       0.0.0.0:49154->5000/tcp  web
 
-We can see our named containers, `db` and `web`, and we can see that the `web`
-containers also shows `db/web` in the `NAMES` column. This tells us that the
+We can see our named containers, `db` and `web`, and we can see that the `db`
+containers also shows `web/db` in the `NAMES` column. This tells us that the
 `web` container is linked to the `db` container in a parent/child relationship.
 
 So what does linking the containers do? Well we've discovered the link creates
 a parent-child relationship between the two containers. The parent container,
-here `db`, can access information on the child container `web`. To do this
+here `web`, can access information on the child container `db`. To do this
 Docker creates a secure tunnel between the containers without the need to
 expose any ports externally on the container. You'll note when we started the
 `db` container we did not use either of the `-P` or `-p` flags. As we're


### PR DESCRIPTION
In the Docker Linking Docs, the parent child relationship was backwards. The Web container should be able to access the DB, not other way around. Furthermore, the output of 'docker ps' was wrong (it showed that the DB could access the Web). This fixes both typos.
