### PR TITLE
add client OS and arch to docker version

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -391,6 +391,7 @@ func (cli *DockerCli) CmdVersion(args ...string) error {
 	if dockerversion.GITCOMMIT != "" {
 		fmt.Fprintf(cli.out, "Git commit (client): %s\n", dockerversion.GITCOMMIT)
 	}
+	fmt.Fprintf(cli.out, "OS/Arch (client): %s/%s\n", runtime.GOOS, runtime.GOARCH)
 
 	body, _, err := readBody(cli.call("GET", "/version", nil, false))
 	if err != nil {


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@docker.com (github: SvenDowideit)

inspired by #6760

to help with OS X or other client platform diagnosis:

`docker info` tells us that its 64bit linux - and in this case b2d, and with this PR, we then know they're talking to it using the darwin client.

```
bash-3.2$ ./docker-1.1.0-dev version
Client version: 1.1.0-dev
Client API version: 1.13
Go version (client): go1.2.1
Git commit (client): 44d7377-dirty
OS/Arch (client): darwin/amd64
Server version: 1.1.0
Server API version: 1.13
Go version (server): go1.2.1
Git commit (server): 79812000
bash-3.2$ ./docker-1.1.0-dev info
Containers: 0
Images: 96
Storage Driver: aufs
 Root Dir: /var/lib/docker/aufs
 Dirs: 96
Execution Driver: native-0.2
Kernel Version: 3.15.3-tinycore64
Debug mode (server): true
Debug mode (client): false
Fds: 10
Goroutines: 11
EventsListeners: 0
Init Path: /usr/local/bin/docker
Sockets: [unix:///var/run/docker.sock tcp://0.0.0.0:2375]
```
