### PR TITLE
docker save: fix the 'repositories' file

### DIFF
--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -59,6 +59,63 @@ func TestSaveAndLoadRepoStdout(t *testing.T) {
 	logDone("load - load a repo using stdout")
 }
 
+func TestSaveSingleTag(t *testing.T) {
+	repoName := "foobar-save-single-tag-test"
+
+	tagCmdFinal := fmt.Sprintf("%v tag busybox:latest %v:latest", dockerBinary, repoName)
+	tagCmd := exec.Command("bash", "-c", tagCmdFinal)
+	out, _, err := runCommandWithOutput(tagCmd)
+	errorOut(err, t, fmt.Sprintf("failed to tag repo: %v %v", out, err))
+
+	idCmdFinal := fmt.Sprintf("%v images -q --no-trunc %v", dockerBinary, repoName)
+	idCmd := exec.Command("bash", "-c", idCmdFinal)
+	out, _, err = runCommandWithOutput(idCmd)
+	errorOut(err, t, fmt.Sprintf("failed to get repo ID: %v %v", out, err))
+
+	cleanedImageID := stripTrailingCharacters(out)
+
+	saveCmdFinal := fmt.Sprintf("%v save %v:latest | tar t | grep -E '(^repositories$|%v)'", dockerBinary, repoName, cleanedImageID)
+	saveCmd := exec.Command("bash", "-c", saveCmdFinal)
+	out, _, err = runCommandWithOutput(saveCmd)
+	errorOut(err, t, fmt.Sprintf("failed to save repo with image ID and 'repositories' file: %v %v", out, err))
+
+	deleteImages(repoName)
+
+	logDone("save - save a specific image:tag")
+}
+
+func TestSaveImageId(t *testing.T) {
+	repoName := "foobar-save-image-id-test"
+
+	tagCmdFinal := fmt.Sprintf("%v tag scratch:latest %v:latest", dockerBinary, repoName)
+	tagCmd := exec.Command("bash", "-c", tagCmdFinal)
+	out, _, err := runCommandWithOutput(tagCmd)
+	errorOut(err, t, fmt.Sprintf("failed to tag repo: %v %v", out, err))
+
+	idLongCmdFinal := fmt.Sprintf("%v images -q --no-trunc %v", dockerBinary, repoName)
+	idLongCmd := exec.Command("bash", "-c", idLongCmdFinal)
+	out, _, err = runCommandWithOutput(idLongCmd)
+	errorOut(err, t, fmt.Sprintf("failed to get repo ID: %v %v", out, err))
+
+	cleanedLongImageID := stripTrailingCharacters(out)
+
+	idShortCmdFinal := fmt.Sprintf("%v images -q %v", dockerBinary, repoName)
+	idShortCmd := exec.Command("bash", "-c", idShortCmdFinal)
+	out, _, err = runCommandWithOutput(idShortCmd)
+	errorOut(err, t, fmt.Sprintf("failed to get repo short ID: %v %v", out, err))
+
+	cleanedShortImageID := stripTrailingCharacters(out)
+
+	saveCmdFinal := fmt.Sprintf("%v save %v | tar t | grep %v", dockerBinary, cleanedShortImageID, cleanedLongImageID)
+	saveCmd := exec.Command("bash", "-c", saveCmdFinal)
+	out, _, err = runCommandWithOutput(saveCmd)
+	errorOut(err, t, fmt.Sprintf("failed to save repo with image ID: %v %v", out, err))
+
+	deleteImages(repoName)
+
+	logDone("save - save a image by ID")
+}
+
 // save a repo and try to load it using flags
 func TestSaveAndLoadRepoFlags(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")


### PR DESCRIPTION
For various use cases, the 'repositories' file does not match expected
behavior.

Like,

```
docker save busybox:latest | tar t
```

Before:

```
[...]
busybox:latest/
busybox:latest/VERSION
busybox:latest/json
busybox:latest/layer.tar
# note, the layer name, and lack of 'repositories' file
```

Now:

```
[...]
a9eb172552348a9a49180694790b33a1097f546456d041b6e82e4d7716ddb721/
a9eb172552348a9a49180694790b33a1097f546456d041b6e82e4d7716ddb721/VERSION
a9eb172552348a9a49180694790b33a1097f546456d041b6e82e4d7716ddb721/json
a9eb172552348a9a49180694790b33a1097f546456d041b6e82e4d7716ddb721/layer.tar
repositories
# and the repositories file is correct for the single tagged
# image.
#> {"busybox":{"latest":"a9eb172552348a9a49180694790b33a1097f546456d041b6e82e4d7716ddb721"}}
```

and

```
docker save a9eb17255234 | tar t
```

Before:

```
[...]
a9eb17255234/
a9eb17255234/VERSION
a9eb17255234/json
a9eb17255234/layer.tar
# Note the truncated layer name
```

Now:

```
[...]
a9eb172552348a9a49180694790b33a1097f546456d041b6e82e4d7716ddb721/
a9eb172552348a9a49180694790b33a1097f546456d041b6e82e4d7716ddb721/VERSION
a9eb172552348a9a49180694790b33a1097f546456d041b6e82e4d7716ddb721/json
a9eb172552348a9a49180694790b33a1097f546456d041b6e82e4d7716ddb721/layer.tar
# There is no 'repositories' file, because there is no named repo
```

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
