### PR TITLE
add NoIndex option to daemon

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -117,6 +117,12 @@ func (daemon *Daemon) Get(name string) *Container {
 		return c
 	}
 
+	if len(name) == 64 {
+		if c := daemon.containers.Get(name); c != nil {
+			return c
+		}
+	}
+
 	id, err := daemon.idIndex.Get(name)
 	if err != nil {
 		return nil
@@ -182,7 +188,9 @@ func (daemon *Daemon) register(container *Container, updateSuffixarray bool, con
 
 	// don't update the Suffixarray if we're starting up
 	// we'll waste time if we update it for every container
-	daemon.idIndex.Add(container.ID)
+	if !container.Config.NoIndex {
+		daemon.idIndex.Add(container.ID)
+	}
 
 	// FIXME: if the container is supposed to be running but is not, auto restart it?
 	//        if so, then we need to restart monitor and init a new lock

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Entrypoint      []string
 	NetworkDisabled bool
 	OnBuild         []string
+	NoIndex         bool // If true, don't put container id into TruncIndex
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {
@@ -52,6 +53,7 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 		Image:           job.Getenv("Image"),
 		WorkingDir:      job.Getenv("WorkingDir"),
 		NetworkDisabled: job.GetenvBool("NetworkDisabled"),
+		NoIndex:         job.GetenvBool("NoIndex"),
 	}
 	job.GetenvJson("ExposedPorts", &config.ExposedPorts)
 	job.GetenvJson("Volumes", &config.Volumes)


### PR DESCRIPTION
While investigating #5923, it became clear that for our specific use-case, namely creating/starting/removing containers in a rapid fashion, the TruncIndex is a source of short-lived allocations which bloat memory usage and degrade performance.

This patch adds a option `NoIndex` to be passed for container creation, which prevents the container from getting added to the TruncIndex.
