### PR TITLE
Fix DCO parsing for numeric github handles like cpuguy83

### DIFF
--- a/hack/make/validate-dco
+++ b/hack/make/validate-dco
@@ -10,7 +10,7 @@ notDocs="$(validate_diff --numstat | awk '$3 !~ /^docs\// { print $3 }')"
 : ${dels:=0}
 
 # "Username may only contain alphanumeric characters or dashes and cannot begin with a dash"
-githubUsernameRegex='[a-zA-Z][a-zA-Z-]+'
+githubUsernameRegex='[a-zA-Z0-9][a-zA-Z0-9-]+'
 
 # https://github.com/dotcloud/docker/blob/master/CONTRIBUTING.md#sign-your-work
 dcoPrefix='Docker-DCO-1.1-Signed-off-by:'


### PR DESCRIPTION
Turns out, "alphanumeric" actually means both "alpha" AND "numeric". Dur.
