### PR TITLE
Update Travis to use pretty Docker-based workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@
 
 language: go
 
-go: 1.2
+# This should match the version in the Dockerfile.
+go: 1.2.1
+
+# Let us have pretty experimental Docker-based Travis workers.
+# (These spin up much faster than the VM-based ones.)
+sudo: false
 
 # Disable the normal go build.
 install: true


### PR DESCRIPTION
These start up much faster and the only caveat is that we can't use "sudo" (which we don't currently use anyhow).

Also, I've updated the Go version here to match what's in the Dockerfile.

This is possible thanks to @joshk for adding us to his opt-in Docker-based testing group. :)
