### PR TITLE
Update Makefile to default BINDDIR to nothing if DOCKER_HOST is set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: all binary build cross default docs docs-build docs-shell shell test test-unit test-integration test-integration-cli validate
 
 # to allow `make BINDDIR=. shell` or `make BINDDIR= test`
-BINDDIR := bundles
+# (default to no bind mount if DOCKER_HOST is set)
+BINDDIR := $(if $(DOCKER_HOST),,bundles)
 # to allow `make DOCSPORT=9000 docs`
 DOCSPORT := 8000
 


### PR DESCRIPTION
If "DOCKER_HOST" is set, we can usually assume the user is connecting to a remote Docker and thus not bind mount anything by default (meaning the Makefile will more often DWIM for our users).

Just for you, @SvenDowideit.
