### PR TITLE
Update contrib/mkimage/debootstrap to add "sqeeze-lts" to "oldstable" as well

### DIFF
--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -123,9 +123,9 @@ if [ -z "$DONT_TOUCH_SOURCES_LIST" ]; then
 					" "$rootfsDir/etc/apt/sources.list"
 					echo "deb http://security.debian.org $suite/updates main" >> "$rootfsDir/etc/apt/sources.list"
 					# LTS
-					if [ "$suite" = 'squeeze' ]; then
+					if [ "$suite" = 'squeeze' -o "$suite" = 'oldstable' ]; then
 						head -1 "$rootfsDir/etc/apt/sources.list" \
-							| sed "s/ $suite / ${suite}-lts /" \
+							| sed "s/ $suite / squeeze-lts /" \
 								>> "$rootfsDir/etc/apt/sources.list"
 					fi
 				)


### PR DESCRIPTION
Note that the archive does _not_ have a symlink from oldstable-lts to squeeze-lts, hence the change from using "${suite}" to not using it in here and just using the string "squeeze-lts" directly regardless of whether we're building a "squeeze" image or an "oldstable" image.
