### PR TITLE
understanding-docker: Use consistent term

### DIFF
--- a/docs/sources/introduction/understanding-docker.md
+++ b/docs/sources/introduction/understanding-docker.md
@@ -79,7 +79,7 @@ Docker uses a client-server architecture. The Docker *client* talks to the
 Docker *daemon*, which does the heavy lifting of building, running, and
 distributing your Docker containers. Both the Docker client and the daemon *can*
 run on the same system, or you can connect a Docker client to a remote Docker
-daemon. The Docker client and service communicate via sockets or through a
+daemon. The Docker client and daemon communicate via sockets or through a
 RESTful API.
 
 ![Docker Architecture Diagram](/article-img/architecture.svg)


### PR DESCRIPTION
Term 'service' was used together with 'daemon'. It would be better to use the term 'daemon' solely because most part of documentation are using the term.
