### PR TITLE
Save "COMMENT" field in Dockerfile into image content.

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1071,7 +1071,8 @@ func (cli *DockerCli) CmdKill(args ...string) error {
 }
 
 func (cli *DockerCli) CmdImport(args ...string) error {
-	cmd := cli.Subcmd("import", "URL|- [REPOSITORY[:TAG]]", "Create an empty filesystem image and import the contents of the tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then optionally tag it.")
+	cmd := cli.Subcmd("import", "URL|- [OPTIONS] [REPOSITORY[:TAG]]", "Create an empty filesystem image and import the contents of the tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then optionally tag it.")
+	flComment := cmd.String([]string{"m", "-message"}, "", "Commit message")
 
 	if err := cmd.Parse(args); err != nil {
 		return nil
@@ -1089,6 +1090,7 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 
 	v.Set("fromSrc", src)
 	v.Set("repo", repository)
+	v.Set("comment", *flComment)
 
 	if cmd.NArg() == 3 {
 		fmt.Fprintf(cli.err, "[DEPRECATED] The format 'URL|- [REPOSITORY [TAG]]' as been deprecated. Please use URL|- [REPOSITORY[:TAG]]\n")

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -527,6 +527,7 @@ func postImagesCreate(eng *engine.Engine, version version.Version, w http.Respon
 			repo, tag = parsers.ParseRepositoryTag(repo)
 		}
 		job = eng.Job("import", r.Form.Get("fromSrc"), repo, tag)
+		job.Setenv("comment", r.Form.Get("comment"))
 		job.Stdin.Add(r.Body)
 	}
 

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -47,6 +47,18 @@ func env(b *Builder, args []string, attributes map[string]bool, original string)
 	return b.commit("", b.Config.Cmd, fmt.Sprintf("ENV %s", fullEnv))
 }
 
+// COMMENT some text
+//
+// Sets the comment metadata.
+func comment(b *Builder, args []string, attributes map[string]bool, original string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("COMMENT requires only one argument")
+	}
+
+	b.comment = args[0]
+	return b.commit("", b.Config.Cmd, fmt.Sprintf("COMMENT %s", b.comment))
+}
+
 // MAINTAINER some text <maybe@an.email.address>
 //
 // Sets the maintainer metadata.

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -49,6 +49,7 @@ func init() {
 		"maintainer": maintainer,
 		"add":        add,
 		"copy":       dispatchCopy, // copy() is a go builtin
+		"comment":    comment,
 		"from":       from,
 		"onbuild":    onbuild,
 		"workdir":    workdir,
@@ -95,6 +96,7 @@ type Builder struct {
 	dockerfile  *parser.Node  // the syntax tree of the dockerfile
 	image       string        // image name for commit processing
 	maintainer  string        // maintainer name. could probably be removed.
+	comment     string        // Comment describing the image.
 	cmdSet      bool          // indicates is CMD was set in current Dockerfile
 	context     tarsum.TarSum // the context is a tarball that is uploaded by the client
 	contextPath string        // the path of the temporary directory the local context is unpacked to (server side)

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -93,7 +93,7 @@ func (b *Builder) commit(id string, autoCmd []string, comment string) error {
 	autoConfig.Cmd = autoCmd
 
 	// Commit the container
-	image, err := b.Daemon.Commit(container, "", "", "", b.maintainer, true, &autoConfig)
+	image, err := b.Daemon.Commit(container, "", "", b.comment, b.maintainer, true, &autoConfig)
 	if err != nil {
 		return err
 	}

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -44,6 +44,7 @@ func init() {
 	// functions. Errors are propogated up by Parse() and the resulting AST can
 	// be incorporated directly into the existing AST as a next.
 	dispatch = map[string]func(string) (*Node, map[string]bool, error){
+		"comment":    parseString,
 		"user":       parseString,
 		"onbuild":    parseSubCommand,
 		"workdir":    parseString,

--- a/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
+++ b/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
@@ -12,7 +12,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>^\s*(ONBUILD\s+)?(FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|USER|WORKDIR|COPY)\s</string>
+			<string>^\s*(ONBUILD\s+)?(FROM|COMMENT|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|USER|WORKDIR|COPY)\s</string>
 			<key>captures</key>
 			<dict>
 				<key>0</key>

--- a/contrib/syntax/vim/syntax/dockerfile.vim
+++ b/contrib/syntax/vim/syntax/dockerfile.vim
@@ -11,7 +11,7 @@ let b:current_syntax = "dockerfile"
 
 syntax case ignore
 
-syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|VOLUME|WORKDIR|COPY)\s/
+syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|COMMENT|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|VOLUME|WORKDIR|COPY)\s/
 highlight link dockerfileKeyword Keyword
 
 syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/

--- a/docs/man/Dockerfile.5.md
+++ b/docs/man/Dockerfile.5.md
@@ -110,6 +110,9 @@ or
   executes nothing at build time, but specifies the intended command for the
   image.
 
+**COMMENT**
+ --The COMMENT instruction sets the Comment field for the generated images.
+
 **EXPOSE**
  --**EXPOSE <port> [<port>...]**
  The **EXPOSE** instruction informs Docker that the container listens on the

--- a/docs/man/docker-import.1.md
+++ b/docs/man/docker-import.1.md
@@ -6,6 +6,7 @@ docker-import - Create an empty filesystem image and import the contents of the 
 
 # SYNOPSIS
 **docker import**
+[**-m**|**--message**[=*MESSAGE*]]
 URL|- [REPOSITORY[:TAG]]
 
 # DESCRIPTION
@@ -13,7 +14,8 @@ Create a new filesystem image from the contents of a tarball (`.tar`,
 `.tar.gz`, `.tgz`, `.bzip`, `.tar.xz`, `.txz`) into it, then optionally tag it.
 
 # OPTIONS
-There are no available options.
+**-m**, **--message**=""
+   Commit message
 
 # EXAMPLES
 

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -280,6 +280,21 @@ default specified in `CMD`.
 > the result; `CMD` does not execute anything at build time, but specifies
 > the intended command for the image.
 
+## COMMENT
+   COMMENT [STRING]
+
+The `COMMENT` instruction allows you to describe your Dockerfile. If
+you want a multiline string, supply `\` at the end of the line.
+
+For example:
+
+  COMMENT This is a Dockerfile, of course! \
+  It does some neat things!
+
+This is yielded from the API as well; from the output of `docker inspect [IMAGE]`,
+in the "Config" section, there is a "Description" element that corresponds to 
+this string.
+
 ## EXPOSE
 
     EXPOSE <port> [<port>...]
@@ -631,6 +646,8 @@ For example you might add something like this:
 
     FROM      ubuntu
     MAINTAINER Victor Vieux <victor@docker.com>
+
+    COMMENT This image runs Nginx on an Ubuntu base
 
     RUN apt-get update && apt-get install -y inotify-tools nginx apache2 openssh-server
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -764,7 +764,7 @@ NOTE: Docker will warn you if any containers exist that are using these untagged
 
 ## import
 
-    Usage: docker import URL|- [REPOSITORY[:TAG]]
+    Usage: docker import [OPTIONS] URL|- [REPOSITORY[:TAG]]
 
     Create an empty filesystem image and import the contents of the tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then optionally tag it.
 
@@ -773,7 +773,15 @@ URLs must start with `http` and point to a single file archive (.tar,
 you would like to import from a local directory or archive, you can use
 the `-` parameter to take the data from `STDIN`.
 
+<<<<<<< HEAD
 #### Examples
+||||||| parent of ec85865... Allow docker import -m to specify the COMMENT field.
+### Examples
+=======
+      -m, --message=""    Commit message
+
+### Examples
+>>>>>>> ec85865... Allow docker import -m to specify the COMMENT field.
 
 **Import from a remote location:**
 

--- a/graph/import.go
+++ b/graph/import.go
@@ -46,7 +46,11 @@ func (s *TagStore) CmdImport(job *engine.Job) engine.Status {
 		defer progressReader.Close()
 		archive = progressReader
 	}
-	img, err := s.graph.Create(archive, "", "", "Imported from "+src, "", nil, nil)
+	comment := job.Getenv("comment")
+	if comment == "" {
+		comment = "Imported from " + src
+	}
+	img, err := s.graph.Create(archive, "", "", comment, "", nil, nil)
 	if err != nil {
 		return job.Error(err)
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -15,6 +15,27 @@ import (
 	"github.com/docker/docker/pkg/archive"
 )
 
+func TestBuildComment(t *testing.T) {
+	name := "testbuildcomment"
+	expected := "hello, is there anyone in there?"
+	defer deleteImages(name)
+	_, err := buildImage(name,
+		`FROM scratch
+        COMMENT hello, is there anyone in there?`,
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := inspectField(name, "Comment")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != expected {
+		t.Fatalf("Comment %s, expected %s", res, expected)
+	}
+	logDone("build - comment")
+}
+
 func TestBuildOnBuildForbiddenMaintainerInSourceImage(t *testing.T) {
 	name := "testbuildonbuildforbiddenmaintainerinsourceimage"
 	defer deleteImages(name)


### PR DESCRIPTION
This will allow a user to save COMMENT data into an image, which
can later be retrieved using:

docker inspect IMAGEID
