### PR TITLE
integcli: fix failures caused by tiny map randomization

### DIFF
--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -93,16 +93,30 @@ func TestIpTablesRulesWhenLinkAndUnlink(t *testing.T) {
 }
 
 func TestInspectLinksStarted(t *testing.T) {
+	var (
+		expected = map[string]struct{}{"/container1:/testinspectlink/alias1": {}, "/container2:/testinspectlink/alias2": {}}
+		result   []string
+	)
 	defer deleteAllContainers()
 	cmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
 	cmd(t, "run", "-d", "--name", "container2", "busybox", "sleep", "10")
 	cmd(t, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "sleep", "10")
-	links, err := inspectField("testinspectlink", "HostConfig.Links")
+	links, err := inspectFieldJSON("testinspectlink", "HostConfig.Links")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if expected := "[/container1:/testinspectlink/alias1 /container2:/testinspectlink/alias2]"; links != expected {
-		t.Fatalf("Links %s, but expected %s", links, expected)
+
+	err = unmarshalJSON([]byte(links), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output := convertSliceOfStringsToMap(result)
+
+	equal := deepEqual(expected, output)
+
+	if !equal {
+		t.Fatalf("Links %s, expected %s", result, expected)
 	}
 	logDone("link - links in started container inspect")
 }

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -211,6 +211,16 @@ func inspectField(name, field string) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
+func inspectFieldJSON(name, field string) (string, error) {
+	format := fmt.Sprintf("{{json .%s}}", field)
+	inspectCmd := exec.Command(dockerBinary, "inspect", "-f", format, name)
+	out, exitCode, err := runCommandWithOutput(inspectCmd)
+	if err != nil || exitCode != 0 {
+		return "", fmt.Errorf("failed to inspect %s: %s", name, out)
+	}
+	return strings.TrimSpace(out), nil
+}
+
 func getIDByName(name string) (string, error) {
 	return inspectField(name, "Id")
 }

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os/exec"
+	"reflect"
 	"strings"
 	"syscall"
 	"testing"
@@ -110,4 +112,25 @@ func errorOutOnNonNilError(err error, t *testing.T, message string) {
 
 func nLines(s string) int {
 	return strings.Count(s, "\n")
+}
+
+func unmarshalJSON(data []byte, result interface{}) error {
+	err := json.Unmarshal(data, result)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deepEqual(expected interface{}, result interface{}) bool {
+	return reflect.DeepEqual(result, expected)
+}
+
+func convertSliceOfStringsToMap(input []string) map[string]struct{} {
+	output := make(map[string]struct{})
+	for _, v := range input {
+		output[v] = struct{}{}
+	}
+	return output
 }


### PR DESCRIPTION
This PR adds some functions to the cli integration tests to be used with JSON output. 

The PR is also modifying the code to use these newly added functions to work around the new tiny map randomization feature of Go 1.3.
