### PR TITLE
Update dockerlinks.md for consistency

### DIFF
--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -80,7 +80,7 @@ Network port mappings are not the only way Docker containers can connect
 to one another. Docker also has a linking system that allows you to link
 multiple containers together and share connection information between
 them. Docker linking will create a parent child relationship where the
-parent container can see selected information about its child.
+child container can see selected information about its parent.
 
 ## Container naming
 
@@ -159,11 +159,11 @@ Let's look at our linked containers using `docker ps`.
 
 We can see our named containers, `db` and `web`, and we can see that the `db`
 containers also shows `web/db` in the `NAMES` column. This tells us that the
-`web` container is linked to the `db` container in a parent/child relationship.
+`db` container is linked to the `web` container in a parent/child relationship.
 
 So what does linking the containers do? Well we've discovered the link creates
-a parent-child relationship between the two containers. The parent container,
-here `web`, can access information on the child container `db`. To do this
+a parent-child relationship between the two containers. The child container,
+here `web`, can access information on the parent container `db`. To do this
 Docker creates a secure tunnel between the containers without the need to
 expose any ports externally on the container. You'll note when we started the
 `db` container we did not use either of the `-P` or `-p` flags. As we're


### PR DESCRIPTION
The parent/child metaphor should be consistent. If db is the parent (after all, it was created first), then the child is accessing information of the parent, not the other way around. I believe these edits make the text more clear/readable.
