### PR TITLE
Fix expect script in mkimage-arch

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -9,13 +9,31 @@ hash pacstrap &>/dev/null || {
     exit 1
 }
 
+hash expect &>/dev/null || {
+    echo "Could not find expect. Run pacman -S expect"
+    exit 1
+}
+
 ROOTFS=$(mktemp -d ${TMPDIR:-/var/tmp}/rootfs-archlinux-XXXXXXXXXX)
 chmod 755 $ROOTFS
 
 # packages to ignore for space savings
 PKGIGNORE=linux,jfsutils,lvm2,cryptsetup,groff,man-db,man-pages,mdadm,pciutils,pcmciautils,reiserfsprogs,s-nail,xfsprogs
 
-pacstrap -C ./mkimage-arch-pacman.conf -c -d -G -i $ROOTFS base haveged --ignore $PKGIGNORE
+expect <<EOF
+  set timeout 60
+  set send_slow {1 1}
+  spawn pacstrap -C ./mkimage-arch-pacman.conf -c -d -G -i $ROOTFS base haveged --ignore $PKGIGNORE
+  expect {
+    "Install anyway?" { send n\r; exp_continue }
+    "(default=all)" { send \r; exp_continue }
+    "Proceed with installation?" { send "\r"; exp_continue }
+    "skip the above package" {send "y\r"; exp_continue }
+    "checking" { exp_continue }
+    "loading" { exp_continue }
+    "installing" { exp_continue }
+  }
+EOF
 
 arch-chroot $ROOTFS /bin/sh -c "haveged -w 1024; pacman-key --init; pkill haveged; pacman -Rs --noconfirm haveged; pacman-key --populate archlinux"
 arch-chroot $ROOTFS /bin/sh -c "ln -s /usr/share/zoneinfo/UTC /etc/localtime"

--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -5,13 +5,13 @@
 set -e
 
 hash pacstrap &>/dev/null || {
-    echo "Could not find pacstrap. Run pacman -S arch-install-scripts"
-    exit 1
+	echo "Could not find pacstrap. Run pacman -S arch-install-scripts"
+	exit 1
 }
 
 hash expect &>/dev/null || {
-    echo "Could not find expect. Run pacman -S expect"
-    exit 1
+	echo "Could not find expect. Run pacman -S expect"
+	exit 1
 }
 
 ROOTFS=$(mktemp -d ${TMPDIR:-/var/tmp}/rootfs-archlinux-XXXXXXXXXX)
@@ -21,18 +21,19 @@ chmod 755 $ROOTFS
 PKGIGNORE=linux,jfsutils,lvm2,cryptsetup,groff,man-db,man-pages,mdadm,pciutils,pcmciautils,reiserfsprogs,s-nail,xfsprogs
 
 expect <<EOF
-  set timeout 60
-  set send_slow {1 1}
-  spawn pacstrap -C ./mkimage-arch-pacman.conf -c -d -G -i $ROOTFS base haveged --ignore $PKGIGNORE
-  expect {
-    "Install anyway?" { send n\r; exp_continue }
-    "(default=all)" { send \r; exp_continue }
-    "Proceed with installation?" { send "\r"; exp_continue }
-    "skip the above package" {send "y\r"; exp_continue }
-    "checking" { exp_continue }
-    "loading" { exp_continue }
-    "installing" { exp_continue }
-  }
+	set send_slow {1 .1}
+	proc send {ignore arg} {
+		sleep .1
+		exp_send -s -- \$arg
+	}
+	set timeout 60
+
+	spawn pacstrap -C ./mkimage-arch-pacman.conf -c -d -G -i $ROOTFS base haveged --ignore $PKGIGNORE
+	expect {
+		-exact "anyway? \[Y/n\] " { send -- "n\r"; exp_continue }
+		-exact "(default=all): " { send -- "\r"; exp_continue }
+		-exact "installation? \[Y/n\]" { send -- "y\r"; exp_continue }
+	}
 EOF
 
 arch-chroot $ROOTFS /bin/sh -c "haveged -w 1024; pacman-key --init; pkill haveged; pacman -Rs --noconfirm haveged; pacman-key --populate archlinux"


### PR DESCRIPTION
# Overview

The previously removed expect snippet hung after an arbitrary number of matches, because the input ended up being sent sometimes between `pacstrap` finishing output and waiting for input (wrong), and sometimes after waiting for input (right). The problem is `pacstap` seem to discard keystrokes sent before it waits for input. This patch adds a 0.1 second delay before starting every input. This should be sufficient to make expect succeed on today's computers.
# Details

The arbitrary hangs are due to a common **timing issue**. From `autoexpect(1)`:

> A surprisingly large number of programs (rn, ksh, zsh, telnet, etc.) and devices (e.g., modems) ignore keystrokes that arrive "too quickly" after prompts. If you find your new script hanging up at one spot, try adding a short sleep just before the previous send.

This seems to be the case with `pacstrap` too.

Usual tactics don't work:
- `set send_slow {1 1}` alone does not change the situation, as it only adds delay _between_ characters instead of _before_ the whole input, thus protecting from buffer over-runs and not early sends.
- Matching until the end of the buffer, e.g. `-re "Install anyway. .Y/n. $"`, does not help either as the input may still arrive between `pacstrap` outputting the matched string and accepting input.

The **solution** is to add a short delay before sending input. This patch defines a new `send` procedure that adds a 0.1 second delay before sending input. This implementation was taken from `autoexpect`, but explicitely adding `sleep .1` before every send would work just as well.
