### PR TITLE
devmapper: revert the default dm-thin-pool blocksize back to 64K

### DIFF
--- a/daemon/graphdriver/devmapper/README.md
+++ b/daemon/graphdriver/devmapper/README.md
@@ -129,11 +129,11 @@ Here is the list of supported options:
  *  `dm.blocksize`
 
     Specifies a custom blocksize to use for the thin pool.  The default
-    blocksize is 512K.
+    blocksize is 64K.
 
     Example use:
 
-    ``docker -d --storage-opt dm.blocksize=64K``
+    ``docker -d --storage-opt dm.blocksize=512K``
 
  *  `dm.blkdiscard`
 

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -28,7 +28,7 @@ var (
 	DefaultDataLoopbackSize     int64  = 100 * 1024 * 1024 * 1024
 	DefaultMetaDataLoopbackSize int64  = 2 * 1024 * 1024 * 1024
 	DefaultBaseFsSize           uint64 = 10 * 1024 * 1024 * 1024
-	DefaultThinpBlockSize       uint32 = 1024 // 512K = 1024 512b sectors
+	DefaultThinpBlockSize       uint32 = 128 // 64K = 128 512b sectors
 )
 
 type DevInfo struct {


### PR DESCRIPTION
Commit 09ee269d ("devmapper: Add option for specifying the thin pool
blocksize") also switched the default dm-thin-pool blocksize from 64K to
512K.  That change unfortunately breaks the activation of dm-thin-pool
devices that were previously created using a 64K blocksize.  Here is an
example of the dm-thin-pool activation failure users may experience:

 device-mapper: thin: 253:4: pool target (204800 blocks) too small: expected 1638400
 device-mapper: table: 253:4: thin-pool: preresume failed, error = -22

The reason for this is docker is passing 512K as the blocksize for a
dm-thin-pool that was previously created using a 64K blocksize.  Docker
doesn't record the blocksize the is used when it creates a dm-thin-pool.
Until now it never had a need to do so because the blocksize was always
hardcoded.  The dm-thin-pool blocksize must be the same every time a
dm-thin-pool is activated.

As a stop-gap fix, revert to using 64K for the default blocksize.

But we do need a proper fix for this now that 'dm.blocksize' is exposed
as a proper storage option.  One possible fix would be to record the
blocksize for each dm-thin-pool that docker creates and to pass that
recorded blocksize down in the dmsetup table load each time the
dm-thin-pool is activated (this would be comparable to what lvm2 does).

Docker-DCO-1.1-Signed-off-by: Mike Snitzer snitzer@redhat.com (github: snitm)
