### PR TITLE
Add tiborvass in MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,7 @@
 Solomon Hykes <solomon@docker.com> (@shykes)
 Victor Vieux <vieux@docker.com> (@vieux)
 Michael Crosby <michael@crosbymichael.com> (@crosbymichael)
+Tibor Vass <teabee89@gmail.com> (@tiborvass)
 .mailmap: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 .travis.yml: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 AUTHORS: Tianon Gravi <admwiggin@gmail.com> (@tianon)


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Tibor Vass teabee89@gmail.com (github: tiborvass)
