### PR TITLE
Make -a and -t CLI flags conflict

### DIFF
--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -202,7 +202,8 @@ non-tty mode). SIGCHLD is not proxied. The default is *true*.
 **-t**, **-tty**=*true*|*false*
    When set to true Docker can allocate a pseudo-tty and attach to the standard
 input of any container. This can be used, for example, to run a throwaway
-interactive shell. The default is value is false.
+interactive shell. The default is value is false. This option is incompatible
+with **-a**.
 
 
 **-u**, **-user**=*username*,*uid*

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -942,7 +942,7 @@ removed before the image is removed.
       --privileged=false         Give extended privileges to this container
       --rm=false                 Automatically remove the container when it exits (incompatible with -d)
       --sig-proxy=true           Proxify received signals to the process (even in non-tty mode). SIGCHLD is not proxied.
-      -t, --tty=false            Allocate a pseudo-tty
+      -t, --tty=false            Allocate a pseudo-tty (incompatible with -a)
       -u, --user=""              Username or UID
       -v, --volume=[]            Bind mount a volume (e.g., from the host: -v /host:/container, from docker: -v /container)
       --volumes-from=[]          Mount volumes from the specified container(s)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -17,6 +17,7 @@ import (
 var (
 	ErrInvalidWorkingDirectory  = fmt.Errorf("The working directory is invalid. It needs to be an absolute path.")
 	ErrConflictAttachDetach     = fmt.Errorf("Conflicting options: -a and -d")
+	ErrConflictAttachTty        = fmt.Errorf("Conflicting options: -a and -t")
 	ErrConflictDetachAutoRemove = fmt.Errorf("Conflicting options: --rm and -d")
 	ErrConflictNetworkHostname  = fmt.Errorf("Conflicting options: -h and the network mode (--net)")
 )
@@ -56,7 +57,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flPrivileged      = cmd.Bool([]string{"#privileged", "-privileged"}, false, "Give extended privileges to this container")
 		flPublishAll      = cmd.Bool([]string{"P", "-publish-all"}, false, "Publish all exposed ports to the host interfaces")
 		flStdin           = cmd.Bool([]string{"i", "-interactive"}, false, "Keep STDIN open even if not attached")
-		flTty             = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
+		flTty             = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY (incompatible with -a)")
 		flContainerIDFile = cmd.String([]string{"#cidfile", "-cidfile"}, "", "Write the container ID to the file")
 		flEntrypoint      = cmd.String([]string{"#entrypoint", "-entrypoint"}, "", "Overwrite the default ENTRYPOINT of the image")
 		flHostname        = cmd.String([]string{"h", "-hostname"}, "", "Container host name")
@@ -96,6 +97,9 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	// Validate input params
 	if *flDetach && flAttach.Len() > 0 {
 		return nil, nil, cmd, ErrConflictAttachDetach
+	}
+	if *flTty && flAttach.Len() > 0 {
+		return nil, nil, cmd, ErrConflictAttachTty
 	}
 	if *flWorkingDir != "" && !path.IsAbs(*flWorkingDir) {
 		return nil, nil, cmd, ErrInvalidWorkingDirectory


### PR DESCRIPTION
Fixes #6736

I can't think of any scenarios where the -a and -t flags for "docker run" should be used together, and using both can cause bugs (see issue). This patch makes the two options conflict.
