### PR TITLE
Update ubuntulinux.md

### DIFF
--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -176,12 +176,12 @@ First add the Docker repository key to your local keychain.
     $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
 Add the Docker repository to your apt sources list, update and install
-the `lxc-docker` package.
+the `docker` package.
 
     $ sudo sh -c "echo deb http://get.docker.io/ubuntu docker main\
     > /etc/apt/sources.list.d/docker.list"
     $ sudo apt-get update
-    $ sudo apt-get install lxc-docker
+    $ sudo apt-get install docker
 
 Now verify that the installation has worked by downloading the
 `ubuntu` image and launching a container.


### PR DESCRIPTION
On ubuntu 13.10, the required package was not lxc-docker but docker
