### PR TITLE
Ensure Docker client uses exit codes when errors occur

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -730,8 +730,7 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 		var err error
 		if tmpl, err = template.New("").Funcs(funcMap).Parse(*tmplStr); err != nil {
 			fmt.Fprintf(cli.err, "Template parsing error: %v\n", err)
-			return &utils.StatusError{StatusCode: 64,
-				Status: "Template parsing error: " + err.Error()}
+			return utils.StatusErrorf(64, "Template parsing error: %s", err.Error())
 		}
 	}
 

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -241,7 +241,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		if jerr.Code == 0 {
 			jerr.Code = 1
 		}
-		return &utils.StatusError{Status: jerr.Message, StatusCode: jerr.Code}
+		return utils.StatusError{Status: jerr.Message, StatusCode: jerr.Code}
 	}
 	return err
 }
@@ -789,7 +789,7 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 	}
 
 	if status != 0 {
-		return &utils.StatusError{StatusCode: status}
+		return utils.StatusError{StatusCode: status}
 	}
 	return nil
 }
@@ -1802,7 +1802,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 		return err
 	}
 	if status != 0 {
-		return &utils.StatusError{StatusCode: status}
+		return utils.StatusError{StatusCode: status}
 	}
 
 	return nil
@@ -2152,7 +2152,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		}
 	}
 	if status != 0 {
-		return &utils.StatusError{StatusCode: status}
+		return utils.StatusError{StatusCode: status}
 	}
 	return nil
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -251,13 +251,14 @@ func main() {
 		}
 
 		if err := cli.ParseCommands(flag.Args()...); err != nil {
-			if sterr, ok := err.(*utils.StatusError); ok {
-				if sterr.Status != "" {
-					log.Println(sterr.Status)
-				}
-				os.Exit(sterr.StatusCode)
+			// All errors from cli.ParseCommands are StatusErrors.
+			sterr := err.(utils.StatusError)
+
+			if sterr.Status != "" {
+				log.Println(sterr.Status)
 			}
-			log.Fatal(err)
+
+			os.Exit(sterr.StatusCode)
 		}
 	}
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -660,8 +660,16 @@ type StatusError struct {
 	StatusCode int
 }
 
-func (e *StatusError) Error() string {
+func (e StatusError) Error() string {
 	return fmt.Sprintf("Status: %s, Code: %d", e.Status, e.StatusCode)
+}
+
+// Like fmt.Errorf, except return a StatusError with the given error code.
+func StatusErrorf(code int, format string, args ...interface{}) StatusError {
+	return StatusError{
+		Status:     fmt.Sprintf(format, args...),
+		StatusCode: code,
+	}
 }
 
 func quote(word string, buf *bytes.Buffer) {


### PR DESCRIPTION
This patchset essentially ensures that the Docker client actually exits with error codes if an error is encountered.

Docker-DCO-1.1-Signed-off-by: Aleksa Sarai cyphar@cyphar.com (github: cyphar)

/cc @shykes @vieux @crosbymichael
