### PR TITLE
docker daemon: initialize the daemon pidfile early

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -50,6 +50,9 @@ func remote(eng *engine.Engine) error {
 // These components should be broken off into plugins of their own.
 //
 func daemon(eng *engine.Engine) error {
+	if err := eng.Register("initserverpidfile", server.InitPidfile); err != nil {
+		return err
+	}
 	if err := eng.Register("initserver", server.InitServer); err != nil {
 		return err
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -149,12 +149,22 @@ func main() {
 		if err := builtins.Register(eng); err != nil {
 			log.Fatal(err)
 		}
+
+		// handle the pidfile early. https://github.com/dotcloud/docker/issues/6973
+		if len(*pidfile) > 0 {
+			job := eng.Job("initserverpidfile", *pidfile)
+			if err := job.Run(); err != nil {
+				log.Fatal(err)
+			}
+		}
+
 		// load the daemon in the background so we can immediately start
 		// the http api so that connections don't fail while the daemon
 		// is booting
 		go func() {
 			// Load plugin: httpapi
 			job := eng.Job("initserver")
+			// include the variable here too, for the server config
 			job.Setenv("Pidfile", *pidfile)
 			job.Setenv("Root", realRoot)
 			job.SetenvBool("AutoRestart", *flAutoRestart)


### PR DESCRIPTION
fixes https://github.com/dotcloud/docker/issues/6973

This way there are no races on iptables, etc. before there is a discovery of existing daemon pidfile

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
