### PR TITLE
Closes 6937. Allows setting of docker config dir.

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -29,10 +30,13 @@ const (
 )
 
 var (
-	dockerConfDir = os.Getenv("HOME") + "/.docker/"
+	dockerConfDir = os.Getenv("DOCKER_CONFIG")
 )
 
 func main() {
+	if len(dockerConfDir) == 0 {
+		dockerConfDir = filepath.Join(os.Getenv("HOME"), ".docker")
+	}
 	if selfPath := utils.SelfPath(); strings.Contains(selfPath, ".dockerinit") {
 		// Running in init mode
 		sysinit.SysInit()
@@ -63,9 +67,9 @@ func main() {
 		flMtu                = flag.Int([]string{"#mtu", "-mtu"}, 0, "Set the containers network MTU\nif no value is provided: default to the default route MTU or 1500 if no default route is available")
 		flTls                = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by tls-verify flags")
 		flTlsVerify          = flag.Bool([]string{"-tlsverify"}, false, "Use TLS and verify the remote (daemon: verify client, client: verify daemon)")
-		flCa                 = flag.String([]string{"-tlscacert"}, dockerConfDir+defaultCaFile, "Trust only remotes providing a certificate signed by the CA given here")
-		flCert               = flag.String([]string{"-tlscert"}, dockerConfDir+defaultCertFile, "Path to TLS certificate file")
-		flKey                = flag.String([]string{"-tlskey"}, dockerConfDir+defaultKeyFile, "Path to TLS key file")
+		flCa                 = flag.String([]string{"-tlscacert"}, filepath.Join(dockerConfDir, defaultCaFile), "Trust only remotes providing a certificate signed by the CA given here")
+		flCert               = flag.String([]string{"-tlscert"}, filepath.Join(dockerConfDir, defaultCertFile), "Path to TLS certificate file")
+		flKey                = flag.String([]string{"-tlskey"}, filepath.Join(dockerConfDir, defaultKeyFile), "Path to TLS key file")
 		flSelinuxEnabled     = flag.Bool([]string{"-selinux-enabled"}, false, "Enable selinux support. SELinux does not presently support the BTRFS storage driver")
 	)
 	flag.Var(&flDns, []string{"#dns", "-dns"}, "Force Docker to use specific DNS servers")

--- a/docs/sources/articles/https.md
+++ b/docs/sources/articles/https.md
@@ -125,4 +125,9 @@ Docker in various other modes by mixing the flags.
    certificate, authenticate server based on given CA
 
 The client will send its client certificate if found, so you just need
-to drop your keys into ~/.docker/<ca, cert or key>.pem
+to drop your keys into ~/.docker/<ca, cert or key>.pem. Alternatively, if you
+want to store your keys in another location, you can specify that location
+using the environment variable `DOCKER_CONFIG`.
+
+    $ export DOCKER_CONFIG=${HOME}/.dockers/zone1/
+    $ docker --tlsverify ps


### PR DESCRIPTION
Closes #6937 

Can now dynamically set the docker config directory through an
environment variable.

export DOCKER_CONFIG=/path/to/docker_config/

Default behavior remains the same, e.g. ~/.docker

Documentation for change added to the https.md docs.
