### PR TITLE
include --releasever=/ in mkimage-yum.sh

### DIFF
--- a/contrib/mkimage-yum.sh
+++ b/contrib/mkimage-yum.sh
@@ -57,7 +57,7 @@ mknod -m 666 "$target"/dev/tty0 c 4 0
 mknod -m 666 "$target"/dev/urandom c 1 9
 mknod -m 666 "$target"/dev/zero c 1 5
 
-yum -c "$yum_config" --installroot="$target" --setopt=tsflags=nodocs \
+yum -c "$yum_config" --installroot="$target" --releasever=/ --setopt=tsflags=nodocs \
     --setopt=group_package_types=mandatory -y groupinstall Core
 yum -c "$yum_config" --installroot="$target" -y clean all
 


### PR DESCRIPTION
This script failed when trying to create a docker image based on centos 7. Adding "--releasever=/" fixed it. According to yum man page:

```
Note: You may also want to use the option --releasever=/ when creating the installroot as otherwise the $releasever value is  taken  from  the  rpmdb  within  the installroot (and thus. will be empty, before creation).
```

Docker-DCO-1.1-Signed-off-by: Matt Schurenko matt.schurenko@gmail.com (github: mschurenko)
