### PR TITLE
Add a conditional to contrib/init/sysvinit-debian/docker for Dash vs Bash support

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -89,7 +89,11 @@ case "$1" in
 		chgrp docker "$DOCKER_LOGFILE"
 
 		ulimit -n 1048576
-		ulimit -u 1048576
+		if [ "$BASH" ]; then
+			ulimit -u 1048576
+		else
+			ulimit -p 1048576
+		fi
 
 		log_begin_msg "Starting $DOCKER_DESC: $BASE"
 		start-stop-daemon --start --background \


### PR DESCRIPTION
Yeah...
