### PR TITLE
docs/builder: add trailing slash condition for ADD .tar.gz

### DIFF
--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -308,10 +308,12 @@ The copy obeys the following rules:
 - If `<src>` is a directory, the entire directory is copied, including
   filesystem metadata.
 
-- If `<src>` is a *local* tar archive in a recognized compression format
-  (identity, gzip, bzip2 or xz) then it is unpacked as a directory. Resources
-  from *remote* URLs are **not** decompressed. When a directory is copied or
-  unpacked, it has the same behavior as `tar -x`: the result is the union of:
+- If `<src>` is a *local* tar archive in a recognized compression
+  format (identity, gzip, bzip2 or xz) and `<dest>` end with a
+  trailing slash, then it is unpacked as a directory. Resources from
+  *remote* URLs are **not** decompressed. When a directory is copied
+  or unpacked, it has the same behavior as `tar -x`: the result is the
+  union of:
 
     1. Whatever existed at the destination path and
     2. The contents of the source tree, with conflicts resolved in favor


### PR DESCRIPTION
When `<dest>` doesn't end with a trailing `/`, I noticed that now (Server version: 1.1.0) `ADD foo.tar.gz dest` copy the tar to a file named `dest' instead of extracting. Clarifying the documention to be more explicit about this.

```
$ docker build .
Sending build context to Docker daemon 3.584 kB
Sending build context to Docker daemon 
Step 0 : FROM busybox
 ---> a9eb17255234
Step 1 : ADD foo.tar.gz /dest
 ---> Using cache
 ---> 66f077fdf0cc
Successfully built
$ docker run -ti 66f077fdf0cc
/ # ls -al dest
ls -al dest
-rw-r-----    1 root     root           156 Jul 14 23:17 dest
```
