### PR TITLE
Don't set the MTU for loopback interfaces.

### DIFF
--- a/vendor/src/github.com/docker/libcontainer/network/loopback.go
+++ b/vendor/src/github.com/docker/libcontainer/network/loopback.go
@@ -15,9 +15,7 @@ func (l *Loopback) Create(n *Network, nspid int, networkState *NetworkState) err
 }
 
 func (l *Loopback) Initialize(config *Network, networkState *NetworkState) error {
-	if err := SetMtu("lo", config.Mtu); err != nil {
-		return fmt.Errorf("set lo mtu to %d %s", config.Mtu, err)
-	}
+	// Do not set the MTU on the loopback interface - use the default.
 	if err := InterfaceUp("lo"); err != nil {
 		return fmt.Errorf("lo up %s", err)
 	}


### PR DESCRIPTION
Setting the MTU for loopback has a huge performance impact on intra-container
traffic.  The loopback interface is not an ethernet interface and does not need
the same limit.  with this change I see a 4x speedup for loopback throughput.

Docker-DCO-1.1-Signed-off-by: Tim Hockin thockin@google.com (github: thockin)
