### PR TITLE
Update debian.md

### DIFF
--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -24,7 +24,6 @@ To install the latest Debian package (may not be the latest Docker release):
     $ sudo apt-get update
     $ sudo apt-get install docker.io
     $ sudo ln -sf /usr/bin/docker.io /usr/local/bin/docker
-    $ sudo sed -i '$acomplete -F _docker docker' /etc/bash_completion.d/docker.io
 
 To verify that everything has worked as expected:
 


### PR DESCRIPTION
In Docker 1.0 for Debian the `complete -F _docker docker` line is already included. It should therfore not be added as documented here.
