### PR TITLE
no need to create a link to the docker binary

### DIFF
--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -23,7 +23,6 @@ To install the latest Debian package (may not be the latest Docker release):
 
     $ sudo apt-get update
     $ sudo apt-get install docker.io
-    $ sudo ln -sf /usr/bin/docker.io /usr/local/bin/docker
     $ sudo sed -i '$acomplete -F _docker docker' /etc/bash_completion.d/docker.io
 
 To verify that everything has worked as expected:


### PR DESCRIPTION
With Docker 1.0 and current Debian Jesse, the docker binary is placed in /usr/bin with -rwxr-xr-x, so a link is no longer required.
