### PR TITLE
Better example for data container

### DIFF
--- a/docs/sources/userguide/dockervolumes.md
+++ b/docs/sources/userguide/dockervolumes.md
@@ -98,7 +98,7 @@ it.
 
 Let's create a new named container with a volume to share.
 
-    $ sudo docker run -d -v /dbdata --name dbdata training/postgres
+    $ sudo docker run -d -v /dbdata --name dbdata training/postgres echo Data-only container for postgres
 
 You can then use the `--volumes-from` flag to mount the `/dbdata` volume in another container.
 


### PR DESCRIPTION
Run sleep in data container so it doesn't default to the CMD which would mean running another unnecessary/potentially problematic instance of the actual application/service.
