### PR TITLE
Fix cap drop issues with lxc

### DIFF
--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -123,11 +123,11 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 	}
 
 	if len(c.CapAdd) > 0 {
-		params = append(params, "-cap-add", strings.Join(c.CapAdd, " "))
+		params = append(params, "-cap-add", strings.Join(c.CapAdd, ","))
 	}
 
 	if len(c.CapDrop) > 0 {
-		params = append(params, "-cap-drop", strings.Join(c.CapDrop, " "))
+		params = append(params, "-cap-drop", strings.Join(c.CapDrop, ","))
 	}
 
 	params = append(params, "--", c.Entrypoint)

--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -123,11 +123,11 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 	}
 
 	if len(c.CapAdd) > 0 {
-		params = append(params, "-cap-add", strings.Join(c.CapAdd, ","))
+		params = append(params, fmt.Sprintf("-cap-add=%s", strings.Join(c.CapAdd, ":")))
 	}
 
 	if len(c.CapDrop) > 0 {
-		params = append(params, "-cap-drop", strings.Join(c.CapDrop, ","))
+		params = append(params, fmt.Sprintf("-cap-drop=%s", strings.Join(c.CapDrop, ":")))
 	}
 
 	params = append(params, "--", c.Entrypoint)

--- a/daemon/execdriver/lxc/lxc_init_linux.go
+++ b/daemon/execdriver/lxc/lxc_init_linux.go
@@ -49,7 +49,19 @@ func finalizeNamespace(args *execdriver.InitArgs) error {
 			return fmt.Errorf("clear keep caps %s", err)
 		}
 
-		caps, err := execdriver.TweakCapabilities(container.Capabilities, strings.Split(args.CapAdd, " "), strings.Split(args.CapDrop, " "))
+		var (
+			adds  []string
+			drops []string
+		)
+
+		if args.CapAdd != "" {
+			adds = strings.Split(args.CapAdd, ",")
+		}
+		if args.CapDrop != "" {
+			drops = strings.Split(args.CapDrop, ",")
+		}
+
+		caps, err := execdriver.TweakCapabilities(container.Capabilities, adds, drops)
 		if err != nil {
 			return err
 		}

--- a/daemon/execdriver/lxc/lxc_init_linux.go
+++ b/daemon/execdriver/lxc/lxc_init_linux.go
@@ -55,10 +55,10 @@ func finalizeNamespace(args *execdriver.InitArgs) error {
 		)
 
 		if args.CapAdd != "" {
-			adds = strings.Split(args.CapAdd, ",")
+			adds = strings.Split(args.CapAdd, ":")
 		}
 		if args.CapDrop != "" {
-			drops = strings.Split(args.CapDrop, ",")
+			drops = strings.Split(args.CapDrop, ":")
 		}
 
 		caps, err := execdriver.TweakCapabilities(container.Capabilities, adds, drops)

--- a/daemon/execdriver/utils.go
+++ b/daemon/execdriver/utils.go
@@ -20,7 +20,7 @@ func TweakCapabilities(basics, adds, drops []string) ([]string, error) {
 			continue
 		}
 		if !utils.StringsContainsNoCase(allCaps, cap) {
-			return nil, fmt.Errorf("Unknown capability: %s", cap)
+			return nil, fmt.Errorf("Unknown capability drop: %q", cap)
 		}
 	}
 
@@ -49,9 +49,8 @@ func TweakCapabilities(basics, adds, drops []string) ([]string, error) {
 			continue
 		}
 
-		// look for invalid cap in the drop list
 		if !utils.StringsContainsNoCase(allCaps, cap) {
-			return nil, fmt.Errorf("Unknown capability: %s", cap)
+			return nil, fmt.Errorf("Unknown capability to add: %q", cap)
 		}
 
 		// add cap if not already in the list
@@ -59,5 +58,6 @@ func TweakCapabilities(basics, adds, drops []string) ([]string, error) {
 			newCaps = append(newCaps, cap)
 		}
 	}
+
 	return newCaps, nil
 }


### PR DESCRIPTION
This uses ":" instead of spaces so that the flags are parsed correctly
and also does not do a strings.Split on an empty string because
strings.Split will return a slice with one element, and empty string
causing parsing to fail when it validates that the cap exists.

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@docker.com (github: crosbymichael)
