### PR TITLE
Added info re: image[:tag] to make docs consistent. 

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1877,7 +1877,7 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 type ports []int
 
 func (cli *DockerCli) CmdTag(args ...string) error {
-	cmd := cli.Subcmd("tag", "[OPTIONS] IMAGE [REGISTRYHOST/][USERNAME/]NAME[:TAG]", "Tag an image into a repository")
+	cmd := cli.Subcmd("tag", "[OPTIONS] IMAGE[:TAG] [REGISTRYHOST/][USERNAME/]NAME[:TAG]", "Tag an image into a repository")
 	force := cmd.Bool([]string{"f", "#force", "-force"}, false, "Force")
 	if err := cmd.Parse(args); err != nil {
 		return nil

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -34,7 +34,7 @@ docker-run - Run a command in a new container
 [**-v**|**--volume**[=*[]*]]
 [**--volumes-from**[=*[]*]]
 [**-w**|**--workdir**[=*WORKDIR*]]
- IMAGE [COMMAND] [ARG...]
+ IMAGE[:TAG] [COMMAND] [ARG...]
 
 # DESCRIPTION
 
@@ -241,7 +241,10 @@ can override the working directory by using the **-w** option.
 
 
 **IMAGE**
-   The image name or ID.
+   The image name or ID. You can specify a version of an image you'd like to run
+   the container with by adding image:tag to the command. For example,
+   `docker run ubuntu:14.04`.
+
 
 
 **COMMAND**

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -26,18 +26,16 @@ see [*Option types*](/reference/commandline/cli/#option-types).
 The list of `[OPTIONS]` breaks down into two groups:
 
 1. Settings exclusive to operators, including:
-
- - Detached or Foreground running,
- - Container Identification,
- - Network settings, and
- - Runtime Constraints on CPU and Memory
- - Privileges and LXC Configuration
-
-2. Setting shared between operators and developers, where operators can
+     * Detached or Foreground running,
+     * Container Identification,
+     * Network settings, and
+     * Runtime Constraints on CPU and Memory
+     * Privileges and LXC Configuration
+2. Settings shared between operators and developers, where operators can
    override defaults developers set in images at build time.
 
-Together, the `docker run [OPTIONS]` give complete control over runtime
-behavior to the operator, allowing them to override all defaults set by
+Together, the `docker run [OPTIONS]` give the operator complete control over runtime
+behavior, allowing them to override all defaults set by
 the developer during `docker build` and nearly all the defaults set by
 the Docker runtime itself.
 
@@ -126,6 +124,12 @@ programs might write out their process ID to a file (you've seen them as
 PID files):
 
     --cidfile="": Write the container ID to the file
+    
+### Image[:tag]
+
+While not strictly a means of identifying a container, you can specify a version of an
+image you'd like to run the container with by adding `image[:tag]` to the command. For
+example, `docker run ubuntu:14.04`.
 
 ## Network Settings
 


### PR DESCRIPTION
Also fixed a markdown issue.

Closes issue #6833

Docker-DCO-1.1-Signed-off-by: Fred Lifton fred.lifton@docker.com (github: fredlf)
