### PR TITLE
Ignore the filesystem package for Arch Linux.

### DIFF
--- a/contrib/mkimage-arch-pacman.conf
+++ b/contrib/mkimage-arch-pacman.conf
@@ -22,7 +22,7 @@ HoldPkg     = pacman glibc
 Architecture = auto
 
 # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
-#IgnorePkg   =
+IgnorePkg   = filesystem
 #IgnoreGroup =
 
 #NoUpgrade   =


### PR DESCRIPTION
The filesystem package cannot typically be updated in a docker image
because of the read-only `/etc/resolv.conf` and `/etc/hosts`.  I don't
see a reason not to remove it from the standard sysupgrade (pacman -Syu)
command.

Fixes #7075

Docker-DCO-1.1-Signed-off-by: Spencer Rinehart anubis@overthemonkey.com (github: nubs)
