### PR TITLE
Fix Panic with -t and -a stderr

### DIFF
--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -88,7 +88,7 @@ func (cli *DockerCli) hijack(method, path string, setRawTerminal bool, in io.Rea
 			}()
 
 			// When TTY is ON, use regular copy
-			if setRawTerminal {
+			if setRawTerminal && stdout != nil {
 				_, err = io.Copy(stdout, br)
 			} else {
 				_, err = utils.StdCopy(stdout, stderr, br)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1218,3 +1218,51 @@ func TestDnsOptionsBasedOnHostResolvConf(t *testing.T) {
 
 	logDone("run - dns options based on host resolv.conf")
 }
+
+// Regression test for #6983
+func TestAttachStdErrOnlyTTYMode(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "-t", "-a", "stderr", "busybox", "true")
+
+	exitCode, err := runCommand(cmd)
+	if err != nil {
+		t.Fatal(err)
+	} else if exitCode != 0 {
+		t.Fatalf("Container should have exited with error code 0")
+	}
+
+	deleteAllContainers()
+
+	logDone("run - Attach stderr only with -t")
+}
+
+// Regression test for #6983
+func TestAttachStdOutOnlyTTYMode(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "-t", "-a", "stdout", "busybox", "true")
+
+	exitCode, err := runCommand(cmd)
+	if err != nil {
+		t.Fatal(err)
+	} else if exitCode != 0 {
+		t.Fatalf("Container should have exited with error code 0")
+	}
+
+	deleteAllContainers()
+
+	logDone("run - Attach stdout only with -t")
+}
+
+// Regression test for #6983
+func TestAttachStdOutAndErrTTYMode(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "-t", "-a", "stdout", "-a", "stderr", "busybox", "true")
+
+	exitCode, err := runCommand(cmd)
+	if err != nil {
+		t.Fatal(err)
+	} else if exitCode != 0 {
+		t.Fatalf("Container should have exited with error code 0")
+	}
+
+	deleteAllContainers()
+
+	logDone("run - Attach stderr and stdout with -t")
+}


### PR DESCRIPTION
Fixes #6983

At present, running docker with the -t and -a stderr flags (but no -a stdout) causes a panic. Adding a check to terminal hijack to ensure io.Copy is only used if STDOUT is attached fixes this.

Tested with all combinations of -a std(out|err|in) and -t, no regressions I can find.
