### PR TITLE
Log containers which fail to stop during daemon shutdown

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -905,7 +905,10 @@ func (daemon *Daemon) shutdown() error {
 				if err := c.KillSig(15); err != nil {
 					utils.Debugf("kill 15 error for %s - %s", c.ID, err)
 				}
-				c.State.WaitStop(-1 * time.Second)
+				if _, err := c.State.WaitStop(60 * time.Second); err != nil {
+					log.Printf("Container %s did not stop in 60 seconds", c.ID)
+					c.State.WaitStop(-1 * time.Second)
+				}
 				utils.Debugf("container stopped %s", c.ID)
 			}()
 		}


### PR DESCRIPTION
Followup to #6815

There are good reasons why we should not kill containers on a daemon shutdown - killing production-critical containers, for example. However, it's still not a good thing that daemon shutdown silently hangs if containers do not stop on a SIGTERM - this is potentially very confusing.

This patch causes containers which fail to stop after a SIGTERM to log this failure after a period of time, so it's clear why Docker is not stopping, and which containers would need to be stopped to permit a clean shutdown. Period of time is presently 1 minute, which is somewhat arbitrary - up for discussion on what a reasonable value is.
