### PR TITLE
contrib/init/systemd: add philips as MAINTAINER

### DIFF
--- a/contrib/init/systemd/MAINTAINERS
+++ b/contrib/init/systemd/MAINTAINERS
@@ -1,1 +1,2 @@
 Lokesh Mandvekar <lsm5@fedoraproject.org> (@lsm5)
+Brandon Philips <brandon.philips@coreos.com> (@philips)


### PR DESCRIPTION
As requested after #7021 add me as a maintainer alongside the sword toting
@lsm5.

Docker-DCO-1.1-Signed-off-by: Brandon Philips brandon.philips@coreos.com
(github: philips)
