### PR TITLE
Update docs on --sig-proxy

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1751,7 +1751,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 	var (
 		cmd     = cli.Subcmd("attach", "[OPTIONS] CONTAINER", "Attach to a running container")
 		noStdin = cmd.Bool([]string{"#nostdin", "-no-stdin"}, false, "Do not attach STDIN")
-		proxy   = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify all received signals to the process (even in non-TTY mode). SIGCHLD is not proxied.")
+		proxy   = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxy all received signals to the process (even in non-TTY mode). SIGCHLD, SIGKILL, and SIGSTOP are not proxied.")
 	)
 
 	if err := cmd.Parse(args); err != nil {

--- a/docs/man/docker-attach.1.md
+++ b/docs/man/docker-attach.1.md
@@ -25,7 +25,7 @@ the client.
    Do not attach STDIN. The default is *false*.
 
 **--sig-proxy**=*true*|*false*
-   Proxify all received signals to the process (even in non-TTY mode). SIGCHLD is not proxied. The default is *true*.
+   Proxy all received signals to the process (even in non-TTY mode). SIGCHLD, SIGKILL, and SIGSTOP are not proxied. The default is *true*.
 
 # EXAMPLES
 

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -195,8 +195,8 @@ default is *false*. This option is incompatible with **-d**.
 
 
 **--sig-proxy**=*true*|*false*
-   When set to true, proxify received signals to the process (even in
-non-tty mode). SIGCHLD is not proxied. The default is *true*.
+   When set to true, proxy received signals to the process (even in
+non-tty mode). SIGCHLD, SIGKILL, and SIGSTOP are not proxied. The default is *true*.
 
 
 **-t**, **-tty**=*true*|*false*

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -135,7 +135,7 @@ like this:
     Attach to a running container
 
       --no-stdin=false    Do not attach STDIN
-      --sig-proxy=true    Proxify all received signals to the process (even in non-TTY mode). SIGCHLD is not proxied.
+      --sig-proxy=true    Proxy all received signals to the process (even in non-TTY mode). SIGCHLD, SIGKILL, and SIGSTOP are not proxied.
 
 The `attach` command will allow you to view or
 interact with any running container, detached (`-d`)
@@ -972,7 +972,7 @@ removed before the image is removed.
                                    (use 'docker port' to see the actual mapping)
       --privileged=false         Give extended privileges to this container
       --rm=false                 Automatically remove the container when it exits (incompatible with -d)
-      --sig-proxy=true           Proxify received signals to the process (even in non-tty mode). SIGCHLD is not proxied.
+      --sig-proxy=true           Proxy received signals to the process (even in non-tty mode). SIGCHLD, SIGKILL, and SIGSTOP are not proxied.
       -t, --tty=false            Allocate a pseudo-tty
       -u, --user=""              Username or UID
       -v, --volume=[]            Bind mount a volume (e.g., from the host: -v /host:/container, from docker: -v /container)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -71,7 +71,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.")
 		// For documentation purpose
-		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify received signals to the process (even in non-TTY mode). SIGCHLD is not proxied.")
+		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxy received signals to the process (even in non-TTY mode). SIGCHLD, SIGSTOP, and SIGKILL are not proxied.")
 		_ = cmd.String([]string{"#name", "-name"}, "", "Assign a name to the container")
 	)
 


### PR DESCRIPTION
Docker deliberately does not proxy SIGCHLD. SIGSTOP and SIGKILL are also not proxied, given they cannot be caught and always affect the receiving process. SIGKILL in particular is a frequently-used signal, and it is likely confusing that it is not proxied to the container, and instead just kills the client process. Update docs to note this behavior to prevent confusion.
