### PR TITLE
speed up archive

### DIFF
--- a/archive/changes.go
+++ b/archive/changes.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io"
@@ -343,6 +344,7 @@ func ExportChanges(dir string, changes []Change) (Archive, error) {
 	tw := tar.NewWriter(writer)
 
 	go func() {
+		twBuf := bufio.NewWriterSize(nil, twBufSize)
 		// In general we log errors here but ignore them because
 		// during e.g. a diff operation the container can continue
 		// mutating the filesystem and we can see transient errors
@@ -365,7 +367,7 @@ func ExportChanges(dir string, changes []Change) (Archive, error) {
 				}
 			} else {
 				path := filepath.Join(dir, change.Path)
-				if err := addTarFile(path, change.Path[1:], tw); err != nil {
+				if err := addTarFile(path, change.Path[1:], tw, twBuf); err != nil {
 					utils.Debugf("Can't add file %s to tar: %s\n", path, err)
 				}
 			}

--- a/archive/common.go
+++ b/archive/common.go
@@ -1,0 +1,4 @@
+package archive
+
+const twBufSize = 32 * 1024
+const trBufSize = 32 * 1024

--- a/archive/diff.go
+++ b/archive/diff.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -32,6 +33,7 @@ func ApplyLayer(dest string, layer ArchiveReader) error {
 	}
 
 	tr := tar.NewReader(layer)
+	trBuf := bufio.NewReaderSize(nil, trBufSize)
 
 	var dirs []*tar.Header
 
@@ -108,7 +110,8 @@ func ApplyLayer(dest string, layer ArchiveReader) error {
 				}
 			}
 
-			srcData := io.Reader(tr)
+			trBuf.Reset(tr)
+			srcData := io.Reader(trBuf)
 			srcHdr := hdr
 
 			// Hard links into /.wh..wh.plnk don't work, as we don't extract that directory, so


### PR DESCRIPTION
This PR speeds up archive and lowers the amount of allocated memory by allocating buffer memory for io.Copy operations. This lowers the GC churn during context upload, commit, pull, push, ADD, export, import, load and save.

The PR also adds a benchmark for TarUntar.

```
benchmark             old ns/op      new ns/op      delta       
BenchmarkTarUntar     9248497406     6671318507     -27.87%     

benchmark             old allocs     new allocs     delta      
BenchmarkTarUntar     11757110       11561722       -1.66%     

benchmark             old bytes      new bytes     delta       
BenchmarkTarUntar     6964905904     412317168     -94.08%
```
