### PR TITLE
Use DOCKER_TMPDIR=/var/lib/docker/tmp for large temp files (rebase/fix of 6456)

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -125,14 +125,6 @@ func main() {
 			return
 		}
 
-		// set up the TempDir to use a canonical path
-		tmp := os.TempDir()
-		realTmp, err := utils.ReadSymlinkedDirectory(tmp)
-		if err != nil {
-			log.Fatalf("Unable to get the full path to the TempDir (%s): %s", tmp, err)
-		}
-		os.Setenv("TMPDIR", realTmp)
-
 		// get the canonical path to the Docker root directory
 		root := *flRoot
 		var realRoot string
@@ -144,6 +136,15 @@ func main() {
 				log.Fatalf("Unable to get the full path to root (%s): %s", root, err)
 			}
 		}
+
+		// set up the TempDir to use a canonical path
+		tmp := utils.TempDir(realRoot)
+		realTmp, err := utils.ReadSymlinkedDirectory(tmp)
+		if err != nil {
+			log.Fatalf("Unable to get the full path to the TempDir (%s): %s", tmp, err)
+		}
+		os.Setenv("TMPDIR", realTmp)
+
 		if err := checkKernelAndArch(); err != nil {
 			log.Fatal(err)
 		}

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -120,12 +120,12 @@ systemd in the [docker source tree](
 https://github.com/docker/docker/blob/master/contrib/init/systemd/socket-activation/).
 
 Docker supports softlinks for the Docker data directory
-(`/var/lib/docker`) and for `/tmp`. TMPDIR and the data directory can be set
+(`/var/lib/docker`) and for `/var/lib/docker/tmp`. DOCKER_TMPDIR and the data directory can be set
 like this:
 
-    TMPDIR=/mnt/disk2/tmp /usr/local/bin/docker -d -D -g /var/lib/docker -H unix:// > /var/lib/boot2docker/docker.log 2>&1
+    DOCKER_TMPDIR=/mnt/disk2/tmp /usr/local/bin/docker -d -D -g /var/lib/docker -H unix:// > /var/lib/boot2docker/docker.log 2>&1
     # or
-    export TMPDIR=/mnt/disk2/tmp
+    export DOCKER_TMPDIR=/mnt/disk2/tmp
     /usr/local/bin/docker -d -D -g /var/lib/docker -H unix:// > /var/lib/boot2docker/docker.log 2>&1
 
 ## attach

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -1292,7 +1292,7 @@ func TestBuildEntrypointRunCleanup(t *testing.T) {
 	logDone("build - cleanup cmd after RUN")
 }
 
-func TestBuldForbiddenContextPath(t *testing.T) {
+func TestBuildForbiddenContextPath(t *testing.T) {
 	name := "testbuildforbidpath"
 	defer deleteImages(name)
 	ctx, err := fakeContext(`FROM scratch
@@ -1302,18 +1302,16 @@ func TestBuldForbiddenContextPath(t *testing.T) {
 			"test.txt":  "test1",
 			"other.txt": "other",
 		})
-
 	defer ctx.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
-		if !strings.Contains(err.Error(), "Forbidden path outside the build context: ../../ (/)") {
-			t.Fatal("Wrong error, must be about forbidden ../../ path")
-		}
-	} else {
-		t.Fatal("Error must not be nil")
+
+	expected := "Forbidden path outside the build context: ../../ "
+	if _, err := buildImageFromContext(name, ctx, true); err == nil || !strings.Contains(err.Error(), expected) {
+		t.Fatalf("Wrong error: (should contain \"%s\") got:\n%v", expected, err)
 	}
+
 	logDone("build - forbidden context path")
 }
 

--- a/utils/tmpdir.go
+++ b/utils/tmpdir.go
@@ -1,0 +1,12 @@
+// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd
+
+package utils
+
+import (
+	"os"
+)
+
+// TempDir returns the default directory to use for temporary files.
+func TempDir(rootdir string) string {
+	return os.TempDir()
+}

--- a/utils/tmpdir_unix.go
+++ b/utils/tmpdir_unix.go
@@ -1,0 +1,19 @@
+// +build darwin dragonfly freebsd linux netbsd openbsd
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// TempDir returns the default directory to use for temporary files.
+func TempDir(rootdir string) string {
+
+	var tmpDir string
+	if tmpDir = os.Getenv("DOCKER_TMPDIR"); tmpDir == "" {
+		tmpDir = filepath.Join(rootdir, "tmp")
+	}
+	os.MkdirAll(tmpDir, 0700)
+	return tmpDir
+}


### PR DESCRIPTION
Closes #6456

Thanks @rhatdan

Ping @crosbymichael or @vieux.
