### PR TITLE
Adjust Travis to also compile, to test that compilation still succeeds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ go: 1.2.1
 sudo: false
 
 # Disable the normal go build.
-install: true
+install:
+  - export DOCKER_BUILDTAGS='exclude_graphdriver_btrfs exclude_graphdriver_devicemapper' # btrfs and devicemapper fail to compile thanks to a couple missing headers (which we can't install thanks to "sudo: false")
 
 before_script:
   - env | sort
@@ -19,5 +20,6 @@ before_script:
 script:
   - hack/make.sh validate-dco
   - hack/make.sh validate-gofmt
+  - AUTO_GOPATH=1 ./hack/make.sh dynbinary
 
 # vim:set sw=2 ts=2:


### PR DESCRIPTION
For now, I've got it excluding the btrfs and devicemapper graph drivers, since they pull in headers we can't install thanks to our use of the fancy Docker-based Travis workers, but testing to ensure that everything else still compiles properly is nice. :)
