### PR TITLE
Do not apply volumes during build

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -179,6 +179,18 @@ func createVolumes(container *Container) error {
 		}
 	}
 
+	// Create the dirs for BuildVolumes for backwards compatability
+	for _, volPath := range container.Config.BuildVolumes {
+		// Create the mountpoint
+		source, err := symlink.FollowSymlinkInScope(filepath.Join(container.basefs, volPath), container.basefs)
+		if err != nil {
+			return err
+		}
+		if err := createIfNotExists(source, true); err != nil {
+			return err
+		}
+	}
+
 	for volPath := range binds {
 		if err := initializeVolume(container, volPath, binds); err != nil {
 			return err

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Entrypoint      []string
 	NetworkDisabled bool
 	OnBuild         []string
+	BuildVolumes    []string
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {


### PR DESCRIPTION
Referenced the wrong issue# in the branch.
Fixes part of #3639

FYI, this does not work when inheriting an image with volumes since the volumes are already commited to the image and there is no way currently to remove the config.

Docker-DCO-1.1-Signed-off-by: Brian Goff cpuguy83@gmail.com (github: cpuguy83)
