### PR TITLE
docker issue 6935: allow 'docker run' to specify ipaddress associated with hostname

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -938,7 +938,11 @@ func (container *Container) initializeNetworking() error {
 		if err := container.allocateNetwork(); err != nil {
 			return err
 		}
-		return container.buildHostnameAndHostsFiles(container.NetworkSettings.IPAddress)
+		if container.Config.IPAddress != "" {
+			return container.buildHostnameAndHostsFiles(container.Config.IPAddress)
+		} else {
+			return container.buildHostnameAndHostsFiles(container.NetworkSettings.IPAddress)
+		}
 	}
 	return nil
 }

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -20,7 +20,7 @@ docker-run - Run a command in a new container
 [**--entrypoint**[=*ENTRYPOINT*]]
 [**--env-file**[=*[]*]]
 [**--expose**[=*[]*]]
-[**-h**|**--hostname**[=*HOSTNAME*]]
+[**-h**|**--hostname**[=*HOSTNAME:IPADDRESS*]]
 [**-i**|**--interactive**[=*false*]]
 [**--link**[=*[]*]]
 [**--lxc-conf**[=*[]*]]
@@ -132,8 +132,9 @@ developer can expose the port using the EXPOSE parameter of the Dockerfile, 2)
 the operator can use the **--expose** option with **docker run**, or 3) the
 container can be started with the **--link**.
 
-**-h**, **--hostname**=*hostname*
-   Sets the container host name that is available inside the container.
+**-h**, **-hostname**=*hostname:ipaddress*
+   Sets the container host name and ipaddress that is available inside the container.
+If ipaddress is not set, the default interface will be used. 
 
 **-i**, **--interactive**=*true*|*false*
    When set to true, keep stdin open even if not attached. The default is false.

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -976,7 +976,8 @@ removed before the image is removed.
       --entrypoint=""            Overwrite the default ENTRYPOINT of the image
       --env-file=[]              Read in a line delimited file of environment variables
       --expose=[]                Expose a port from the container without publishing it to your host
-      -h, --hostname=""          Container host name
+      -h, --hostname=""          Container host name and ipaddress (optional)
+                                   format: hostname | hostname:ipaddress
       -i, --interactive=false    Keep STDIN open even if not attached
       --link=[]                  Add link to another container in the form of name:alias
       --lxc-conf=[]              (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
@@ -1166,6 +1167,11 @@ only to the container's `STDIN`.
 This isn't going to print anything unless there's an error because we've
 only attached to the `STDERR` of the container. The container's logs
 still store what's been written to `STDERR` and `STDOUT`.
+
+    $ sudo docker run -it -h docker.com:161.242.195.76 ubuntu:14.04 bash
+
+This shows how to specify the desired ipaddress in /etc/hosts, which allows
+using an alternate container interface (created through piework, for example)
 
     $ cat somefile | sudo docker run -i -a stdin mybuilder dobuild
 

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	Hostname        string
 	Domainname      string
+	IPAddress       string
 	User            string
 	Memory          int64  // Memory limit (in bytes)
 	MemorySwap      int64  // Total memory usage (memory + swap); set `-1' to disable swap
@@ -38,6 +39,7 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 	config := &Config{
 		Hostname:        job.Getenv("Hostname"),
 		Domainname:      job.Getenv("Domainname"),
+		IPAddress:       job.Getenv("IPAddress"),
 		User:            job.Getenv("User"),
 		Memory:          job.GetenvInt64("Memory"),
 		MemorySwap:      job.GetenvInt64("MemorySwap"),

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -3,6 +3,7 @@ package runconfig
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"path"
 	"strconv"
 	"strings"
@@ -184,11 +185,22 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	var (
 		domainname string
 		hostname   = *flHostname
-		parts      = strings.SplitN(hostname, ".", 2)
+		parts      = strings.SplitN(hostname, ":", 2)
+		ipaddress  string
+		hostparts  []string
 	)
+	// hostname could contain designated ipaddress
 	if len(parts) > 1 {
 		hostname = parts[0]
-		domainname = parts[1]
+		ip := net.ParseIP(parts[1])
+		if ip != nil {
+			ipaddress = parts[1]
+		}
+		hostparts = strings.SplitN(hostname, ".", 2)
+	}
+	if len(hostparts) > 1 {
+		hostname = hostparts[0]
+		domainname = hostparts[1]
 	}
 
 	ports, portBindings, err := nat.ParsePortSpecs(flPublish.GetAll())
@@ -246,6 +258,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	config := &Config{
 		Hostname:        hostname,
 		Domainname:      domainname,
+		IPAddress:       ipaddress,
 		PortSpecs:       nil, // Deprecated
 		ExposedPorts:    ports,
 		User:            *flUser,


### PR DESCRIPTION
the format for specifying the ipaddress is 
-h [hostname][:ipaddress]
for example, 
bundles/1.1.1-dev/binary/docker-1.1.1-dev run -it -h abcdefg:1.2.3.4 ubuntu:14.04 bash
will create a container with host name of abcdefg and /etc/hosts will contain a line of 
1.2.3.4 abcdefg

the current impl only parses the ipaddress to make sure it contains the correct format, and it is the caller's responsibility to make sure the ipaddress is valid and reachable
