### PR TITLE
Add missing error check

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -188,6 +188,9 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 			}
 		}
 		context, err = archive.TarWithOptions(root, options)
+		if err != nil {
+			return err
+		}
 	}
 	var body io.Reader
 	// Setup an upload progress bar


### PR DESCRIPTION
Noticed that an error check for this function was missing, so I added it.

Docker-DCO-1.1-Signed-off-by: Nathan LeClaire nathan.leclaire@docker.com (github: nathanleclaire)
