### PR TITLE
integcli: fix TestInspectLinksStopped with Go1.3

### DIFF
--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -122,16 +122,31 @@ func TestInspectLinksStarted(t *testing.T) {
 }
 
 func TestInspectLinksStopped(t *testing.T) {
+	var (
+		expected = map[string]struct{}{"/container1:/testinspectlink/alias1": {}, "/container2:/testinspectlink/alias2": {}}
+		result   []string
+	)
 	defer deleteAllContainers()
 	cmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
 	cmd(t, "run", "-d", "--name", "container2", "busybox", "sleep", "10")
 	cmd(t, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "true")
-	links, err := inspectField("testinspectlink", "HostConfig.Links")
+	links, err := inspectFieldJSON("testinspectlink", "HostConfig.Links")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if expected := "[/container1:/testinspectlink/alias1 /container2:/testinspectlink/alias2]"; links != expected {
-		t.Fatalf("Links %s, but expected %s", links, expected)
+
+	err = unmarshalJSON([]byte(links), &result)
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	output := convertSliceOfStringsToMap(result)
+
+	equal := deepEqual(expected, output)
+
+	if !equal {
+		t.Fatalf("Links %s, but expected %s", result, expected)
+	}
+
 	logDone("link - links in stopped container inspect")
 }


### PR DESCRIPTION
This fixes TestInspectLinksStopped to make it work with Go 1.3. This test had to be fixed for map randomization as well.

This is required for #6520.
