### PR TITLE
Upstart status check returns non-zero exit code if service is off

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -130,7 +130,7 @@ case "$1" in
 		;;
 
 	status)
-		status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DOCKER" docker
+		status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DOCKER" docker && exit 0 || exit $?
 		;;
 
 	*)


### PR DESCRIPTION
This PR makes `service docker status` return non-zero if docker is down.  Follows common convention of upstart scripts and useful for automated scripts.
