### PR TITLE
Fix incorrect path in ENTRYPOINT example

### DIFF
--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -409,7 +409,7 @@ optional but default, you could use a `CMD` instruction:
 
     FROM ubuntu
     CMD ["-l"]
-    ENTRYPOINT ["/usr/bin/ls"]
+    ENTRYPOINT ["ls"]
 
 > **Note**:
 > It is preferable to use the JSON array format for specifying


### PR DESCRIPTION
The ENTRYPOINT example uses "/usr/bin/ls" as path, but `ls` is located at `/bin/ls`.

Docker-DCO-1.1-Signed-off-by: Sebastiaan van Stijn github@gone.nl (github: thaJeztah)
