### PR TITLE
Docker register command

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -118,6 +118,29 @@ func getBoolParam(value string) (bool, error) {
 	return ret, nil
 }
 
+func postRegister(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	var (
+		authConfig, err = ioutil.ReadAll(r.Body)
+		job             = eng.Job("register")
+		stdoutBuffer    = bytes.NewBuffer(nil)
+	)
+	if err != nil {
+		return err
+	}
+	job.Setenv("authConfig", string(authConfig))
+	job.Stdout.Add(stdoutBuffer)
+	if err = job.Run(); err != nil {
+		return err
+	}
+	if status := engine.Tail(stdoutBuffer, 1); status != "" {
+		var env engine.Env
+		env.Set("Status", status)
+		return writeJSON(w, http.StatusOK, env)
+	}
+	w.WriteHeader(http.StatusNoContent)
+	return nil
+}
+
 func postAuth(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	var (
 		authConfig, err = ioutil.ReadAll(r.Body)
@@ -1122,6 +1145,7 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 		},
 		"POST": {
 			"/auth":                         postAuth,
+			"/register":                     postRegister,
 			"/commit":                       postCommit,
 			"/build":                        postBuild,
 			"/images/create":                postImagesCreate,

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -135,7 +135,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from kill' -a '(__fish_print
 complete -c docker -f -n '__fish_docker_no_subcommand' -a load -d 'Load an image from a tar archive'
 
 # login
-complete -c docker -f -n '__fish_docker_no_subcommand' -a login -d 'Register or Login to the docker registry server'
+complete -c docker -f -n '__fish_docker_no_subcommand' -a login -d 'Log in to the Docker registry server'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -s e -l email -d 'Email'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -s p -l password -d 'Password'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -s u -l username -d 'Username'
@@ -170,6 +170,12 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from pull' -a '(__fish_print
 complete -c docker -f -n '__fish_docker_no_subcommand' -a push -d 'Push an image or a repository to the docker registry server'
 complete -c docker -A -f -n '__fish_seen_subcommand_from push' -a '(__fish_print_docker_images)' -d "Image"
 complete -c docker -A -f -n '__fish_seen_subcommand_from push' -a '(__fish_print_docker_repositories)' -d "Repository"
+
+# register
+complete -c docker -f -n '__fish_docker_no_subcommand' -a register -d 'Create a new Docker account'
+complete -c docker -A -f -n '__fish_seen_subcommand_from register' -s e -l email -d 'Email'
+complete -c docker -A -f -n '__fish_seen_subcommand_from register' -s p -l password -d 'Password'
+complete -c docker -A -f -n '__fish_seen_subcommand_from register' -s u -l username -d 'Username'
 
 # restart
 complete -c docker -f -n '__fish_docker_no_subcommand' -a restart -d 'Restart a running container'

--- a/registry/service.go
+++ b/registry/service.go
@@ -24,6 +24,7 @@ func NewService() *Service {
 // Install installs registry capabilities to eng.
 func (s *Service) Install(eng *engine.Engine) error {
 	eng.Register("auth", s.Auth)
+	eng.Register("register", s.Register)
 	eng.Register("search", s.Search)
 	return nil
 }
@@ -47,6 +48,21 @@ func (s *Service) Auth(job *engine.Job) engine.Status {
 		authConfig.ServerAddress = addr
 	}
 	status, err := Login(authConfig, HTTPRequestFactory(nil))
+	if err != nil {
+		return job.Error(err)
+	}
+	job.Printf("%s\n", status)
+	return engine.StatusOK
+}
+
+func (s *Service) Register(job *engine.Job) engine.Status {
+	var (
+		err        error
+		authConfig = &AuthConfig{}
+	)
+
+	job.GetenvJson("authConfig", authConfig)
+	status, err := Register(authConfig, HTTPRequestFactory(nil))
 	if err != nil {
 		return job.Error(err)
 	}


### PR DESCRIPTION
- New API endpoint /register
- `docker login` doesn't prompt for password anymore, doesn't create accounts anymore
- new `docker register` command that uses the /register endpoint
- Clearer status messages (especially when using private registry servers)

Fixes #6902

Docker-DCO-1.1-Signed-off-by: Joffrey F joffrey@docker.com (github: shin-)
