### PR TITLE
Return error if bad `Content-Type`

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -728,6 +728,8 @@ func postContainersStart(eng *engine.Engine, version version.Version, w http.Res
 			if err := job.DecodeEnv(r.Body); err != nil {
 				return err
 			}
+		} else {
+			return fmt.Errorf("Content-Type not supported: %s", r.Header.Get("Content-Type"))
 		}
 	}
 	if err := job.Run(); err != nil {


### PR DESCRIPTION
There should be an error on `postContainersStart` if a bad `Content-Type` is submitted, just like for copying containers. This is should remove some frustration for people trying to write libraries to interact with the API.
