### PR TITLE
Fixed some typos for '--' Vs '-' in docker-run-1.md

### DIFF
--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -82,7 +82,7 @@ run**.
 **--cpuset**=""
    CPUs in which to allow execution (0-3, 0,1)
 
-**-d**, **-detach**=*true*|*false*
+**-d**, **--detach**=*true*|*false*
    Detached mode. This runs the container in the background. It outputs the new
 container's ID and any error messages. At any time you can run **docker ps** in
 the other shell to view a list of the running containers. You can reattach to a
@@ -101,12 +101,9 @@ stopping the process by pressing the keys CTRL-P CTRL-Q.
    Set custom DNS servers. This option can be used to override the DNS
 configuration passed to the container. Typically this is necessary when the
 host DNS configuration is invalid for the container (e.g., 127.0.0.1). When this
-is the case the **-dns** flags is necessary for every run.
+is the case the **--dns** flags is necessary for every run.
 
-**-e**, **--env**=[]
-   Set environment variables
-
-**-e**, **-env**=*environment*
+**-e**, **--env**=*environment*
    Set environment variables. This option allows you to specify arbitrary
 environment variables that are available for the process that will be launched
 inside of the container.
@@ -123,6 +120,7 @@ pass in more options via the COMMAND. But, sometimes an operator may want to run
 something else inside the container, so you can override the default ENTRYPOINT
 at runtime by using a **--entrypoint** and a string to specify the new
 ENTRYPOINT.
+
 **--env-file**=[]
    Read in a line delimited file of environment variables
 
@@ -133,10 +131,10 @@ developer can expose the port using the EXPOSE parameter of the Dockerfile, 2)
 the operator can use the **--expose** option with **docker run**, or 3) the
 container can be started with the **--link**.
 
-**-h**, **-hostname**=*hostname*
+**-h**, **--hostname**=*hostname*
    Sets the container host name that is available inside the container.
 
-**-i**, **-interactive**=*true*|*false*
+**-i**, **--interactive**=*true*|*false*
    When set to true, keep stdin open even if not attached. The default is false.
 
 **--link**=*name*:*alias*
@@ -149,7 +147,7 @@ which interface and port to use.
 **--lxc-conf**=[]
    (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
 
-**-m**, **-memory**=*memory-limit*
+**-m**, **--memory**=*memory-limit*
    Allows you to constrain the memory available to a container. If the host
 supports swap memory, then the -m memory setting can be larger than physical
 RAM. If a limit of 0 is specified, the container's memory is not limited. The
@@ -178,14 +176,14 @@ and foreground Docker containers.
                                'container:<name|id>': reuses another container network stack
                                'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
 
-**-P**, **-publish-all**=*true*|*false*
+**-P**, **--publish-all**=*true*|*false*
    When set to true publish all exposed ports to the host interfaces. The
 default is false. If the operator uses -P (or -p) then Docker will make the
 exposed port accessible on the host and the ports will be available to any
 client that can reach the host. To find the map between the host ports and the
 exposed ports, use **docker port**.
 
-**-p**, **-publish**=[]
+**-p**, **--publish**=[]
    Publish a container's port to the host (format: ip:hostPort:containerPort |
 ip::containerPort | hostPort:containerPort) (use **docker port** to see the
 actual mapping)
@@ -217,7 +215,7 @@ interactive shell. The default is value is false.
    Username or UID
 
 
-**-v**, **-volume**=*volume*[:ro|:rw]
+**-v**, **--volume**=*volume*[:ro|:rw]
    Bind mount a volume to the container. 
 
 The **-v** option can be used one or
@@ -241,7 +239,7 @@ default, the volumes are mounted in the same mode (read write or read only) as
 the reference container.
 
 
-**-w**, **-workdir**=*directory*
+**-w**, **--workdir**=*directory*
    Working directory inside the container. The default working directory for
 running binaries within a container is the root directory (/). The developer can
 set a different default with the Dockerfile WORKDIR instruction. The operator


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: William Henry whenry@redhat.com (github: ipbabble)
