### PR TITLE
Chaining FROM ./path in Dockerfile

### DIFF
--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -124,6 +124,10 @@ Or
 
     FROM <image>:<tag>
 
+Or
+
+    FROM ./<path>
+
 The `FROM` instruction sets the [*Base Image*](/terms/image/#base-image-def)
 for subsequent instructions. As such, a valid `Dockerfile` must have `FROM` as
 its first instruction. The image can be any valid image – it is especially easy
@@ -131,6 +135,12 @@ to start by **pulling an image** from the [*Public Repositories*](
 /userguide/dockerrepos/#using-public-repositories).
 
 `FROM` must be the first non-comment instruction in the `Dockerfile`.
+
+The `<path>` must be a directory within current build's context that contains 
+a `Dockerfile`. The leading slash, `./`, is necessary if you want to specify the
+`<path>` option. This will build the image specified in the `./<path>/Dockerfile`
+and when that build is complete use the resulting image as the source of the
+`FROM` instruction.
 
 `FROM` can appear multiple times within a single `Dockerfile` in order to create
 multiple images. Simply make a note of the last image ID output by the commit

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -1189,6 +1189,44 @@ func TestNoContext(t *testing.T) {
 }
 
 // TODO: TestCaching
+func TestChainBuildFromPath(t *testing.T) {
+	name := "testchainbuildfrompath"
+	defer deleteImages(name)
+	ctx, err := fakeContext(`FROM ./chain
+		RUN [ -f /first ]`,
+		map[string]string{
+			"chain/Dockerfile": `FROM busybox
+							RUN touch /first`,
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctx.Close()
+	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+		t.Fatal(err)
+	}
+	logDone("build - build chained Dockerfiles from path")
+}
+
+func TestChainBuildFromAmbiguous(t *testing.T) {
+	name := "testchainbuildfromambiguous"
+	defer deleteImages(name)
+	ctx, err := fakeContext(`FROM ./busybox
+			RUN [ -f /first ]`,
+		map[string]string{
+			"busybox/Dockerfile": `FROM busybox
+								RUN touch /first`,
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctx.Close()
+	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+		t.Fatal(err)
+	}
+	logDone("build - build chained Dockerfiles from ambiguos path and image")
+}
+
 func TestBuildADDLocalAndRemoteFilesWithoutCache(t *testing.T) {
 	name := "testbuildaddlocalandremotefilewithoutcache"
 	defer deleteImages(name)

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
 	"os/exec"
 	"reflect"
 	"strings"


### PR DESCRIPTION
[lk4d4math@gmail.com: add support for `FROM ./path`, `FROM git://url` and `FROM http://url/to/Dockerfile`]
Docker-DCO-1.1-Signed-off-by: Alexandr Morozov lk4d4math@gmail.com (github: LK4D4)

[teabee89@gmail.com: remove git:// and dockerfile-url support for Dockerfile FROM keyword]
[teabee89@gmail.com: rebase + gofmt]
Docker-DCO-1.1-Signed-off-by: Tibor Vass teabee89@gmail.com (github: tiborvass)
