### PR TITLE
Properly handle 0 being passed as a signal number

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -229,10 +229,10 @@ func (srv *Server) ContainerKill(job *engine.Job) engine.Status {
 		if err != nil {
 			// The signal is not a number, treat it as a string (either like "KILL" or like "SIGKILL")
 			sig = uint64(signal.SignalMap[strings.TrimPrefix(job.Args[1], "SIG")])
-			if sig == 0 {
-				return job.Errorf("Invalid signal: %s", job.Args[1])
-			}
+		}
 
+		if sig == 0 {
+			return job.Errorf("Invalid signal: %s", job.Args[1])
 		}
 	}
 


### PR DESCRIPTION
At present, "docker kill -s 0 $CONTAINER" is a valid, accepted command, which sends SIGKILL - which doesn't really make much sense, as 0 is not a valid signal, and SIGKILL is not signal 0.

This patch adds another condition to the parsing of the signal number to ensure that not only is it a valid integer from 0 to 31, it is also nonzero.
