### PR TITLE
systemd: EnvironmentFile for additional options

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -5,7 +5,8 @@ After=network.target
 Requires=docker.socket
 
 [Service]
-ExecStart=/usr/bin/docker -d -H fd://
+EnvironmentFile=-/etc/sysconfig/docker
+ExecStart=/usr/bin/docker -d -H fd:// $OPTIONS
 Restart=on-failure
 LimitNOFILE=1048576
 LimitNPROC=1048576

--- a/contrib/init/systemd/docker.sysconfig
+++ b/contrib/init/systemd/docker.sysconfig
@@ -1,0 +1,3 @@
+# This file specifies additional options for docker daemon.
+# To be installed as /etc/sysconfig/docker
+OPTIONS=


### PR DESCRIPTION
This commit allows the systemd unitfile to use additional options
for docker daemon.

```
modified:   contrib/init/systemd/docker.service
new file:   contrib/init/systemd/docker.sysconfig
```

Docker-DCO-1.1-Signed-off-by: Lokesh Mandvekar lsm5@fedoraproject.org (github: lsm5)
