### PR TITLE
Add check-config to docker info

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -526,6 +526,9 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	if !remoteInfo.GetBool("IPv4Forwarding") {
 		fmt.Fprintf(cli.err, "WARNING: IPv4 forwarding is disabled.\n")
 	}
+	if checkConfig := remoteInfo.Get("CheckConfig"); len(checkConfig) > 0 {
+		fmt.Fprintf(cli.err, "WARNING: %s\n", checkConfig)
+	}
 	return nil
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -719,6 +719,10 @@ func NewDaemon(config *Config, eng *engine.Engine) (*Daemon, error) {
 }
 
 func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error) {
+	if err := utils.CheckConfig(); err != nil {
+		log.Error(err)
+	}
+
 	// Apply configuration defaults
 	if config.Mtu == 0 {
 		// FIXME: GetDefaultNetwork Mtu doesn't need to be public anymore

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -75,6 +75,10 @@ func (daemon *Daemon) CmdInfo(job *engine.Job) engine.Status {
 	v.Set("InitPath", initPath)
 	v.SetInt("NCPU", runtime.NumCPU())
 	v.SetInt64("MemTotal", meminfo.MemTotal)
+	if err := utils.CheckConfig(); err != nil {
+		v.Set("CheckConfig", err.Error())
+	}
+
 	if _, err := v.WriteTo(job.Stdout); err != nil {
 		return job.Error(err)
 	}

--- a/utils/check-config.go
+++ b/utils/check-config.go
@@ -1,0 +1,211 @@
+// +build linux
+
+package utils
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/parsers/kernel"
+)
+
+var (
+	procMounts = "/proc/mounts"
+
+	possibleKernelConfigs = func() []string {
+		configs := make([]string, 0, 5)
+		config := os.Getenv("CONFIG")
+		if len(config) > 0 {
+			configs = append(configs, config)
+		}
+
+		configs = append(configs,
+			"/proc/config.gz",
+			"/usr/src/linux/.config",
+		)
+
+		if kv, err := kernel.GetKernelVersion(); err == nil {
+			configs = append(configs,
+				fmt.Sprintf("/boot/config-%s", kv),
+				fmt.Sprintf("/usr/src/linux-%s/.config", kv))
+		}
+		return configs
+	}
+)
+
+type checkConfigError []string
+
+func (err checkConfigError) Error() string {
+	return fmt.Sprintf("Missing kernel configs: %s", strings.Join([]string(err), " "))
+}
+
+func checkCGroupConfig() error {
+	cgroups := []string{"cpu", "cpuacct", "cpuset", "devices", "freezer", "memory"}
+	cgroupRegex := regexp.MustCompile(fmt.Sprintf(`^\S+\s+(\S+)\s+cgroup\s+.*[, ](?:%s)[, ]`, strings.Join(cgroups, "|")))
+	b, err := ioutil.ReadFile(procMounts)
+	if err != nil {
+		return fmt.Errorf("Cannot check kernel config: %v", err)
+	}
+
+	var (
+		cgroupDir          string
+		cgroupSubsystemDir string
+	)
+	for _, line := range bytes.Split(b, []byte{'\n'}) {
+		if sm := cgroupRegex.FindSubmatch(line); len(sm) >= 2 {
+			cgroupSubsystemDir = string(sm[1])
+			cgroupDir = filepath.Dir(cgroupSubsystemDir)
+			break
+		}
+	}
+
+	if len(cgroupDir) == 0 {
+		return fmt.Errorf("Cannot detect cgroup dir")
+	}
+
+	properlyMounted := false
+	for _, subdir := range cgroups {
+		st, err := os.Stat(filepath.Join(cgroupDir, subdir))
+		if !os.IsNotExist(err) && st != nil && st.IsDir() {
+			properlyMounted = true
+			break
+		}
+	}
+	if !properlyMounted {
+		var s string
+		if len(cgroupSubsystemDir) > 0 {
+			s = "Single cgroup hierarchy mountpoint"
+		} else {
+			s = "Non-existent cgroup hierarchy mountpoint"
+		}
+		return fmt.Errorf("%s: (see https://github.com/tianon/cgroupfs-mount)", s)
+	}
+
+	return nil
+}
+
+func checkKernelConfig() error {
+
+	possibleConfigs := possibleKernelConfigs()
+
+	r := bufio.NewReader(nil)
+	for _, config := range possibleConfigs {
+		var (
+			f   *os.File
+			gzr *gzip.Reader
+			err error
+		)
+
+		f, err = os.Open(config)
+		if err != nil {
+			continue
+		}
+
+		gz := strings.HasSuffix(config, ".gz")
+		if gz {
+			gzr, err = gzip.NewReader(f)
+			if err != nil {
+				log.Debugf("Cannot open kernel config %s: %v", config, err)
+				f.Close()
+				continue
+			}
+		}
+
+		// From here on, we assume we found THE kernel config.
+		// So we'll return errors and not move on to the next config path.
+		defer func() {
+			if gz {
+				gzr.Close()
+			}
+			f.Close()
+		}()
+
+		var checkConfigErr checkConfigError
+
+		for _, fl := range []string{
+			"NAMESPACES",
+			"NET_NS",
+			"PID_NS",
+			"IPC_NS",
+			"UTS_NS",
+			"DEVPTS_MULTIPLE_INSTANCES",
+			"CGROUPS",
+			"CGROUP_CPUACCT",
+			"CGROUP_DEVICE",
+			"CGROUP_FREEZER",
+			"CGROUP_SCHED",
+			"MACVLAN",
+			"VETH",
+			"BRIDGE",
+			"NF_NAT_IPV4",
+			"IP_NF_TARGET_MASQUERADE",
+			"NETFILTER_XT_MATCH_ADDRTYPE",
+			"NETFILTER_XT_MATCH_CONNTRACK",
+			"NF_NAT",
+			"NF_NAT_NEEDED",
+		} {
+			f.Seek(0, 0)
+			if gz {
+				gzr.Close()
+				gzr, err = gzip.NewReader(f)
+				if err != nil {
+					return fmt.Errorf("Cannot open kernel config %s: %v", config, err)
+				}
+				r.Reset(gzr)
+			} else {
+				r.Reset(f)
+			}
+			s := fmt.Sprintf(`CONFIG_%s=[ym]`, regexp.QuoteMeta(fl))
+			if !regexp.MustCompile(s).MatchReader(r) {
+				checkConfigErr = append(checkConfigErr, fl)
+			}
+		}
+
+		if len(checkConfigErr) > 0 {
+			return checkConfigErr
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("Cannot find kernel config. Looked at %s. Try specyfing CONFIG=/path/to/kernel/config", strings.Join(possibleConfigs, ", "))
+}
+
+func checkApparmor() error {
+	if b, err := ioutil.ReadFile("/sys/module/apparmor/parameters/enabled"); err == nil && len(b) == 1 && b[0] == 'Y' {
+		if _, err := exec.LookPath("apparmor_parser"); err != nil {
+			s := "enabled but apparmor_parser missing"
+			if _, err := exec.LookPath("apt-get"); err == nil {
+				return fmt.Errorf("%s: (use 'apt-get install apparmor' to fix this)", s)
+			}
+			if _, err := exec.LookPath("yum"); err == nil {
+				return fmt.Errorf("%s: (your best bet is 'yum install apparmor-parser' to fix this)", s)
+			}
+			return fmt.Errorf("%s: (look for an 'apparmor' package for your distribution)", s)
+		}
+	}
+	return nil
+}
+
+func CheckConfig() error {
+	if err := checkKernelConfig(); err != nil {
+		return fmt.Errorf("kernel config: %v", err)
+	}
+	if err := checkCGroupConfig(); err != nil {
+		return fmt.Errorf("cgroup config: %v", err)
+	}
+	if err := checkApparmor(); err != nil {
+		return fmt.Errorf("apparmor: %v", err)
+	}
+
+	return nil
+}

--- a/utils/check-config.go
+++ b/utils/check-config.go
@@ -87,7 +87,7 @@ func checkCGroupConfig() error {
 		} else {
 			s = "Non-existent cgroup hierarchy mountpoint"
 		}
-		return fmt.Errorf("%s: (see https://github.com/tianon/cgroupfs-mount)", s)
+		return fmt.Errorf("%s (see https://github.com/tianon/cgroupfs-mount)", s)
 	}
 
 	return nil
@@ -185,12 +185,12 @@ func checkApparmor() error {
 		if _, err := exec.LookPath("apparmor_parser"); err != nil {
 			s := "enabled but apparmor_parser missing"
 			if _, err := exec.LookPath("apt-get"); err == nil {
-				return fmt.Errorf("%s: (use 'apt-get install apparmor' to fix this)", s)
+				return fmt.Errorf("%s (use 'apt-get install apparmor' to fix this)", s)
 			}
 			if _, err := exec.LookPath("yum"); err == nil {
-				return fmt.Errorf("%s: (your best bet is 'yum install apparmor-parser' to fix this)", s)
+				return fmt.Errorf("%s (your best bet is 'yum install apparmor-parser' to fix this)", s)
 			}
-			return fmt.Errorf("%s: (look for an 'apparmor' package for your distribution)", s)
+			return fmt.Errorf("%s (look for an 'apparmor' package for your distribution)", s)
 		}
 	}
 	return nil

--- a/utils/check-config_test.go
+++ b/utils/check-config_test.go
@@ -1,0 +1,185 @@
+// +build linux
+
+package utils
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCheckKernelConfig(t *testing.T) {
+	var (
+		backup  = possibleKernelConfigs
+		configs = map[string][]byte{
+			"noMatch": []byte(`CONFIG_DQL=y
+CONFIG_NLATTR=y
+CONFIG_ARCH_HAS_ATOMIC64_DEC_IF_POSITIVE=y
+CONFIG_AVERAGE=y
+CONFIG_CORDIC=m
+# CONFIG_DDR is not set
+CONFIG_OID_REGISTRY=y
+CONFIG_UCS2_STRING=y
+CONFIG_FONT_SUPPORT=y
+# CONFIG_FONTS is not set
+CONFIG_FONT_8x8=y
+CONFIG_FONT_8x16=y`),
+			"fewMatches": []byte(`CONFIG_NLATTR=y
+CONFIG_NAMESPACES=y
+CONFIG_AVERAGE=y
+CONFIG_NET_NS=m
+# CONFIG_FONTS is not set
+`),
+			"allMatches": []byte(`CONFIG_FONT_SUPPORT=y
+CONFIG_NAMESPACES=y
+CONFIG_OID_REGISTRY=y
+CONFIG_NET_NS=y
+CONFIG_PID_NS=y
+CONFIG_IPC_NS=y
+CONFIG_DQL=y
+CONFIG_UTS_NS=y
+CONFIG_DEVPTS_MULTIPLE_INSTANCES=m
+CONFIG_CGROUPS=y
+CONFIG_CGROUP_CPUACCT=y
+CONFIG_CGROUP_DEVICE=y
+CONFIG_CGROUP_FREEZER=y
+CONFIG_CGROUP_SCHED=y
+CONFIG_MACVLAN=y
+CONFIG_VETH=y
+CONFIG_BRIDGE=y
+CONFIG_NF_NAT_IPV4=y
+CONFIG_FONT_8x8=y
+CONFIG_IP_NF_TARGET_MASQUERADE=y
+CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
+CONFIG_NF_NAT=y
+CONFIG_NF_NAT_NEEDED=y`),
+		}
+	)
+
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		possibleKernelConfigs = backup
+		os.RemoveAll(dir)
+	}()
+
+	var config string
+
+	testConfigs := func(compressed bool) error {
+		for name, data := range configs {
+			if !compressed {
+				if err := ioutil.WriteFile(config, data, 0600); err != nil {
+					return err
+				}
+			} else {
+				f, err := os.Create(config)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				w := gzip.NewWriter(f)
+				defer w.Close()
+				if _, err := w.Write(data); err != nil {
+					return err
+				}
+				w.Flush()
+			}
+
+			if err := checkKernelConfig(); (err == nil) != (name == "allMatches") {
+				var expected string
+				if err != nil {
+					expected = "no"
+				} else {
+					expected = "an"
+				}
+				return fmt.Errorf("Expected %s error(s) for %s, but got: %#v", expected, name, err)
+			}
+		}
+
+		return nil
+	}
+
+	// test text kernel configs
+	config = filepath.Join(dir, "config")
+	possibleKernelConfigs = func() []string {
+		// test skipping nonexistent files
+		return []string{filepath.Join(dir, "nonexistent"), config}
+	}
+	if err := testConfigs(false); err != nil {
+		t.Errorf("text kernel config: %v", err)
+	}
+
+	// test gzipped kernel configs
+	config = filepath.Join(dir, "config.gz")
+	possibleKernelConfigs = func() []string {
+		// test skipping corrupt gzip file
+		corrupt := filepath.Join(dir, "corrupt.gz")
+		f, _ := os.Create(corrupt)
+		if f != nil {
+			f.Close()
+		}
+		return []string{corrupt, config}
+	}
+	if err := testConfigs(true); err != nil {
+		t.Errorf("gzipped kernel config: %v", err)
+	}
+}
+
+func TestCGroupConfig(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		backup       = procMounts
+		cGroupMounts = []byte(fmt.Sprintf(`rootfs / rootfs rw,size=2015968k,nr_inodes=503992 0 0
+tmpfs / tmpfs rw,relatime,size=3648284k 0 0
+cgroup /sys/fs/cgroup tmpfs rw,relatime,mode=755 0 0
+cgroup %s/cpuset cgroup rw,relatime,cpuset 0 0
+cgroup %s/cpu cgroup rw,relatime,cpu 0 0`, dir, dir))
+		noCGroupMounts = []byte(`rootfs / rootfs rw,size=2015968k,nr_inodes=503992 0 0
+tmpfs / tmpfs rw,relatime,size=3648284k 0 0`)
+	)
+
+	defer func() {
+		procMounts = backup
+		os.RemoveAll(dir)
+	}()
+
+	procMounts = filepath.Join(dir, "nonexistent")
+	if err := checkCGroupConfig(); err == nil {
+		t.Error("Expected an error reading nonexistent mounts file but got nil")
+	}
+
+	procMounts = filepath.Join(dir, "mounts")
+	if err := ioutil.WriteFile(procMounts, noCGroupMounts, 0600); err != nil {
+		t.Error("Could not write file %s: %v", procMounts, err)
+	}
+	if err := checkCGroupConfig(); err == nil {
+		t.Error("Expected an error reading mounts without cgroups, but got nil")
+	}
+
+	if err := ioutil.WriteFile(procMounts, cGroupMounts, 0600); err != nil {
+		t.Error("Could not write file %s: %v", procMounts, err)
+	}
+	f, _ := os.Create(filepath.Join(dir, "cpuset"))
+	if f != nil {
+		f.Close()
+	}
+	if err := checkCGroupConfig(); err == nil {
+		t.Error("Expected an error reading mounts with invalid cgroup mountpoints, but got nil")
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "cpu"), 0700); err != nil {
+		t.Error(err)
+	}
+	if err := checkCGroupConfig(); err != nil {
+		t.Errorf("Expected no error, but got %v", err)
+	}
+}


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Tibor Vass teabee89@gmail.com (github: tiborvass)

This PR rewrites check-config.sh in Go. The optional configs that are specific to storage drivers have been intentionally left out (@tianon).

This is again towards having a single `docker info` command that helps simple debugging.

If something's caught by CheckConfig it will be displayed as a WARNING at the end of `docker info`.

Ping @unclejack @tianon @crosbymichael @vieux 
