### PR TITLE
Allow setting of environment variables when importing docker images

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1071,7 +1071,13 @@ func (cli *DockerCli) CmdKill(args ...string) error {
 }
 
 func (cli *DockerCli) CmdImport(args ...string) error {
+	var (
+		flEnv     = opts.NewListOpts(opts.ValidateEnv)
+		flEnvFile = opts.NewListOpts(nil)
+	)
 	cmd := cli.Subcmd("import", "URL|- [REPOSITORY[:TAG]]", "Create an empty filesystem image and import the contents of the tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then optionally tag it.")
+	cmd.Var(&flEnv, []string{"e", "-env"}, "Set environment variables")
+	cmd.Var(&flEnvFile, []string{"-env-file"}, "Read in a line delimited file of environment variables")
 
 	if err := cmd.Parse(args); err != nil {
 		return nil
@@ -1087,6 +1093,18 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 		repository = cmd.Arg(1)
 	)
 
+	// collect all the environment variables for the container
+	envVariables := []string{}
+	for _, ef := range flEnvFile.GetAll() {
+		parsedVars, err := opts.ParseEnvFile(ef)
+		if err != nil {
+			return err
+		}
+		envVariables = append(envVariables, parsedVars...)
+	}
+	// parse the '-e' and '--env' after, to allow override
+	envVariables = append(envVariables, flEnv.GetAll()...)
+	v.Set("env", strings.Join(envVariables, " "))
 	v.Set("fromSrc", src)
 	v.Set("repo", repository)
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -527,6 +527,7 @@ func postImagesCreate(eng *engine.Engine, version version.Version, w http.Respon
 			repo, tag = parsers.ParseRepositoryTag(repo)
 		}
 		job = eng.Job("import", r.Form.Get("fromSrc"), repo, tag)
+		job.SetenvList("env", strings.Split(r.Form.Get("env"), " "))
 		job.Stdin.Add(r.Body)
 	}
 

--- a/docs/man/docker-import.1.md
+++ b/docs/man/docker-import.1.md
@@ -6,6 +6,8 @@ docker-import - Create an empty filesystem image and import the contents of the 
 
 # SYNOPSIS
 **docker import**
+[**-e**|**--env**[=*[]*]]
+[**--env-file**[=*[]*]]
 URL|- [REPOSITORY[:TAG]]
 
 # DESCRIPTION
@@ -13,7 +15,13 @@ Create a new filesystem image from the contents of a tarball (`.tar`,
 `.tar.gz`, `.tgz`, `.bzip`, `.tar.xz`, `.txz`) into it, then optionally tag it.
 
 # OPTIONS
-There are no available options.
+**-e**, **--env**=*environment*
+   Set environment variables. This option allows you to specify arbitrary
+environment variables that are available for the process that will be launched
+inside of the container.
+
+**--env-file**=[]
+   Read in a line delimited file of environment variables
 
 # EXAMPLES
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -764,7 +764,7 @@ NOTE: Docker will warn you if any containers exist that are using these untagged
 
 ## import
 
-    Usage: docker import URL|- [REPOSITORY[:TAG]]
+    Usage: docker import [OPTIONS] URL|- [REPOSITORY[:TAG]]
 
     Create an empty filesystem image and import the contents of the tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then optionally tag it.
 
@@ -772,6 +772,11 @@ URLs must start with `http` and point to a single file archive (.tar,
 .tar.gz, .tgz, .bzip, .tar.xz, or .txz) containing a root filesystem. If
 you would like to import from a local directory or archive, you can use
 the `-` parameter to take the data from `STDIN`.
+
+    -e, --env=[]
+       Set environment variables. Define arbitrary environment variables for the initial processes launched within the container.
+    --env-file=[]
+       Read in a line delimited file of environment variables
 
 #### Examples
 

--- a/graph/import.go
+++ b/graph/import.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
 )
 
@@ -46,7 +47,12 @@ func (s *TagStore) CmdImport(job *engine.Job) engine.Status {
 		defer progressReader.Close()
 		archive = progressReader
 	}
-	img, err := s.graph.Create(archive, "", "", "Imported from "+src, "", nil, nil)
+	var config runconfig.Config
+	if len(job.GetenvList("env")) > 0 {
+		config.Env = job.GetenvList("env")
+	}
+
+	img, err := s.graph.Create(archive, "", "", "Imported from "+src, "", nil, &config)
 	if err != nil {
 		return job.Error(err)
 	}


### PR DESCRIPTION
We want to be able to set the container=docker environment
variable when we build RHEL docker images.  I believe there
will be other use cases where you might want to set
environment in base images.

Since you can do this in layered image, I see no reason not
to allow it in base images.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
