### PR TITLE
Exit cleanly when SIGTERM is intercepted

### DIFF
--- a/server/init.go
+++ b/server/init.go
@@ -70,6 +70,7 @@ func InitServer(job *engine.Job) engine.Status {
 						if atomic.LoadUint32(&interruptCount) == 1 {
 							utils.RemovePidFile(srv.daemon.Config().Pidfile)
 							srv.Close()
+							os.Exit(0)
 						} else {
 							return
 						}


### PR DESCRIPTION
Currently when SIGTERM is intercepted Docker exits with code 143. Due to this Systemd marks it as failed.

With this patch Docker exits cleanly with code 0.
