### PR TITLE
Fix test import display

### DIFF
--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -12,8 +12,8 @@ func TestImportDisplay(t *testing.T) {
 	out, _, err := runCommandWithOutput(importCmd)
 	errorOut(err, t, fmt.Sprintf("import failed with errors: %v", err))
 
-	if n := len(strings.Split(out, "\n")); n != 3 {
-		t.Fatalf("display is messed up: %d '\\n' instead of 3", n)
+	if n := strings.Count(out, "\n"); n != 2 {
+		t.Fatalf("display is messed up: %d '\\n' instead of 2", n)
 	}
 
 	logDone("import - cirros was imported and display is fine")

--- a/server/server.go
+++ b/server/server.go
@@ -1701,8 +1701,6 @@ func (srv *Server) ImageImport(job *engine.Job) engine.Status {
 			u.Path = ""
 		}
 		job.Stdout.Write(sf.FormatStatus("", "Downloading from %s", u))
-		// Download with curl (pretty progress bar)
-		// If curl is not available, fallback to http.Get()
 		resp, err = utils.Download(u.String())
 		if err != nil {
 			return job.Error(err)

--- a/utils/progressreader.go
+++ b/utils/progressreader.go
@@ -32,7 +32,7 @@ func (r *progressReader) Read(p []byte) (n int, err error) {
 		r.lastUpdate = r.progress.Current
 	}
 	// Send newline when complete
-	if r.newLine && err != nil {
+	if r.newLine && err != nil && read == 0 {
 		r.output.Write(r.sf.FormatStatus("", ""))
 	}
 	return read, err


### PR DESCRIPTION
This PR should solve the last issue related with #6520 (Go 1.3 bump).

[This change in Go 1.3](https://code.google.com/p/go/source/detail?r=d92b32d188ec18b61690d3c8e74c02e03da66105&name=go1.3) revealed in [progressreader.go](https://github.com/docker/docker/blob/master/utils/progressreader.go#L35) an `io.Reader` ambiguity on EOF.

From the docs of `io.Reader`:

> When Read encounters an error or end-of-file condition after successfully reading n > 0 bytes, it returns the number of bytes read. It may return the (non-nil) error from the same call or return the error (and n == 0) from a subsequent call. An instance of this general case is that a Reader returning a non-zero number of bytes at the end of the input stream may return either err == EOF or err == nil.
