### PR TITLE
Improve systemd units

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -6,7 +6,6 @@ Requires=docker.socket
 
 [Service]
 ExecStart=/usr/bin/docker -d -H fd://
-Restart=on-failure
 LimitNOFILE=1048576
 LimitNPROC=1048576
 

--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -11,4 +11,4 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 
 [Install]
-WantedBy=multi-user.target
+Also=docker.socket

--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=http://docs.docker.com
-After=network.target
+After=network.target docker.socket
 Requires=docker.socket
 
 [Service]


### PR DESCRIPTION
This come from the following Archlinux bug report: https://bugs.archlinux.org/task/41338

Basically it fixe start ordering between service and socket file, also install socket when you install service, and, finally doesn't restart by default the service on failure. Doing that is reserver to buggy service, which is not the case of docker.
