### PR TITLE
Proposal: WIP: Pull image by ID via the tag field if no tag found

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1236,7 +1236,12 @@ func (srv *Server) pullRepository(r *registry.Registry, out io.Writer, localName
 		// Otherwise, check that the tag exists and use only that one
 		id, exists := tagsList[askedTag]
 		if !exists {
-			return fmt.Errorf("Tag %s not found in repository %s", askedTag, localName)
+			if _, exists := repoData.ImgList[askedTag]; !exists {
+				return fmt.Errorf("Tag %s not found in repository %s", askedTag, localName)
+			}
+			utils.Debugf("Image with ID matching tag (%s) exists", askedTag)
+			id = askedTag
+			tagsList[askedTag] = id
 		}
 		repoData.ImgList[id].Tag = askedTag
 	}


### PR DESCRIPTION
Issue #4106 is an issue lots of people who want to automate deployment processes around docker images will eventually hit.  In general, since tags are mutable it would be desirable to allow clients to pull an image by an immutable identifier and pass those identifiers around - as long as the image remained in the registry, a client would be able to get the image they previously requested.  The current workaround is to tag an image with the value of the ID manually, which introduces a layer of 

This pull is a prototype of a minimal backward-compatible change that would perform an additional check when pulling an image - if the requested tag is not found and an id in that repository matches the requested tag, pull that image and give it a tag equal to its ID:

```
docker pull localhost:5000/test/image:e244e638e26e77a8b08da462b1cb92811ed6d3d2874286368afcef7717ed9475
```

would check first for a tag named `e244e6...`.  If not found, it would then look for an image in that repository with that ID.  If found, it would pull the image locally and then tag it with `e244e6...`.  On a push, the tag would be preserved for subsequent pulls.

This change does not break existing tags for users - a tag with a value is always preferred over the ID.  It does raise a minor issue - another registry user could tag a different image under this ID, which violates the spirit, if not the letter, of the intent of the change.  An alternate implementation is [here](https://github.com/smarterclayton/docker/commit/59b50b6e7b33c66791bb4f9f147e225422812142) and checks the ID first, then the tag.  This though would break any user who has tagged an image with a value matching a real ID of a different image, so it's not truly backwards compatible.

Other discussions (#6959) are ongoing about making image ID's be content-addressable (a hash of the image json + hash of the layers in the image) - this pull would be future compatible with that since the ID still has to be stored in the registry.  A future change to split retrieval in the CLI and API by ID would be complicated by this change unless backwards CLI compatibility was preserved.  To scope this further, it would be possible to add a command line flag like `--check-for-id-on-pull` to the daemon - I expect folks who want to use docker across many machines would be likely to set this flag.

No tests or doc changes are in these commits yet pending comments.
