### PR TITLE
Align `docker run` entrypoint flag with Dockerfile syntax (array)

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -323,7 +323,7 @@ __docker_subcommand () {
                 '-d[Detached mode: leave the container running in the background]' \
                 '*--dns=-[Set custom dns servers]:dns server: ' \
                 '*-e=-[Set environment variables]:environment variable: ' \
-                '--entrypoint=-[Overwrite the default entrypoint of the image]:entry point: ' \
+                '*--entrypoint=-[Overwrite the default entrypoint of the image]:entry point: ' \
                 '*--expose=-[Expose a port from the container without publishing it]: ' \
                 '-h=-[Container host name]:hostname:_hosts' \
                 '-i[Keep stdin open even if not attached]' \

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -17,7 +17,7 @@ docker-run - Run a command in a new container
 [**--dns-search**[=*[]*]]
 [**--dns**[=*[]*]]
 [**-e**|**--env**[=*[]*]]
-[**--entrypoint**[=*ENTRYPOINT*]]
+[**--entrypoint**[=*[]*]]
 [**--env-file**[=*[]*]]
 [**--expose**[=*[]*]]
 [**-h**|**--hostname**[=*HOSTNAME*]]
@@ -109,7 +109,7 @@ environment variables that are available for the process that will be launched
 inside of the container.
 
 
-**--entrypoint**=*command*
+**--entrypoint**=[]
    This option allows you to overwrite the default entrypoint of the image that
 is set in the Dockerfile. The ENTRYPOINT of an image is similar to a COMMAND
 because it specifies what executable to run when the container starts, but it is

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -965,7 +965,7 @@ removed before the image is removed.
       --dns=[]                   Set custom DNS servers
       --dns-search=[]            Set custom DNS search domains
       -e, --env=[]               Set environment variables
-      --entrypoint=""            Overwrite the default ENTRYPOINT of the image
+      --entrypoint=[]            Overwrite the default ENTRYPOINT of the image
       --env-file=[]              Read in a line delimited file of environment variables
       --expose=[]                Expose a port from the container without publishing it to your host
       -h, --hostname=""          Container host name

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -305,7 +305,7 @@ get appended as arguments to the `ENTRYPOINT`.
 
 ## ENTRYPOINT (Default Command to Execute at Runtime)
 
-    --entrypoint="": Overwrite the default entrypoint set by the image
+    --entrypoint=[]: Overwrite the default ENTRYPOINT of the image
 
 The `ENTRYPOINT` of an image is similar to a `COMMAND` because it
 specifies what executable to run when the container starts, but it is

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -53,6 +53,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flEnvFile     opts.ListOpts
 		flCapAdd      opts.ListOpts
 		flCapDrop     opts.ListOpts
+		flEntrypoint  opts.ListOpts
 
 		flAutoRemove      = cmd.Bool([]string{"#rm", "-rm"}, false, "Automatically remove the container when it exits (incompatible with -d)")
 		flDetach          = cmd.Bool([]string{"d", "-detach"}, false, "Detached mode: run container in the background and print new container ID")
@@ -62,7 +63,6 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flStdin           = cmd.Bool([]string{"i", "-interactive"}, false, "Keep STDIN open even if not attached")
 		flTty             = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
 		flContainerIDFile = cmd.String([]string{"#cidfile", "-cidfile"}, "", "Write the container ID to the file")
-		flEntrypoint      = cmd.String([]string{"#entrypoint", "-entrypoint"}, "", "Overwrite the default ENTRYPOINT of the image")
 		flHostname        = cmd.String([]string{"h", "-hostname"}, "", "Container host name")
 		flMemoryString    = cmd.String([]string{"m", "-memory"}, "", "Memory limit (format: <number><optional unit>, where unit = b, k, m or g)")
 		flUser            = cmd.String([]string{"u", "-user"}, "", "Username or UID")
@@ -79,6 +79,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	cmd.Var(&flVolumes, []string{"v", "-volume"}, "Bind mount a volume (e.g., from the host: -v /host:/container, from Docker: -v /container)")
 	cmd.Var(&flLinks, []string{"#link", "-link"}, "Add link to another container in the form of name:alias")
 	cmd.Var(&flDevices, []string{"-device"}, "Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc)")
+	cmd.Var(&flEntrypoint, []string{"#entrypoint", "-entrypoint"}, "Overwrite the default ENTRYPOINT of the image")
 	cmd.Var(&flEnv, []string{"e", "-env"}, "Set environment variables")
 	cmd.Var(&flEnvFile, []string{"-env-file"}, "Read in a line delimited file of environment variables")
 
@@ -159,7 +160,6 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	var (
 		parsedArgs = cmd.Args()
 		runCmd     []string
-		entrypoint []string
 		image      string
 	)
 	if len(parsedArgs) >= 1 {
@@ -167,9 +167,6 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	}
 	if len(parsedArgs) > 1 {
 		runCmd = parsedArgs[1:]
-	}
-	if *flEntrypoint != "" {
-		entrypoint = []string{*flEntrypoint}
 	}
 
 	lxcConf, err := parseKeyValueOpts(flLxcOpts)
@@ -251,7 +248,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		Cmd:             runCmd,
 		Image:           image,
 		Volumes:         flVolumes.GetMap(),
-		Entrypoint:      entrypoint,
+		Entrypoint:      flEntrypoint.GetAll(),
 		WorkingDir:      *flWorkingDir,
 	}
 


### PR DESCRIPTION
Images built using the `Dockerfile` syntax can have several items as entrypoint. It should also be possible to pass several items by repeating the `--entrypoint` flag at runtime, when starting a container via the CLI client.
