### PR TITLE
fix misuse of blockquotes

### DIFF
--- a/docs/sources/introduction/understanding-docker.md
+++ b/docs/sources/introduction/understanding-docker.md
@@ -155,9 +155,8 @@ or `fedora`, a base Fedora image. You can also use images of your own as the
 basis for a new image, for example if you have a base Apache image you could use
 this as the base of all your web application images.
 
-> **Note:** Docker usually gets these base images from
-> [Docker Hub](https://hub.docker.com).
-> 
+**Note:** Docker usually gets these base images from [Docker Hub](https://hub.docker.com).
+
 Docker images are then built from these base images using a simple, descriptive
 set of steps we call *instructions*. Each instruction creates a new layer in our
 image. Instructions include actions like:


### PR DESCRIPTION
"Docker images are then built from..." was rendered in the blockquotes, which should be in a separated paragraph. Besides, blockquote is removed to make "Note" look consistent throughout the doc.
