### PR TITLE
Update nodejs_web_app.md

### DIFF
--- a/docs/sources/examples/nodejs_web_app.md
+++ b/docs/sources/examples/nodejs_web_app.md
@@ -66,10 +66,10 @@ requires to build (this example uses Docker 0.3.4):
 
 Next, define the parent image you want to use to build your own image on
 top of. Here, we'll use
-[CentOS](https://registry.hub.docker.com/_/centos/) (tag: `6.4`)
+[CentOS](https://registry.hub.docker.com/_/centos/) (tag: `centos6`)
 available on the [Docker Hub](https://hub.docker.com/):
 
-    FROM    tutum/centos-6.4
+    FROM    centos:centos6
 
 Since we're building a Node.js app, you'll have to install Node.js as
 well as npm on your CentOS image. Node.js is required to run your app
@@ -109,7 +109,7 @@ defines your runtime, i.e. `node`, and the path to our app, i.e. `src/index.js`
 Your `Dockerfile` should now look like this:
 
     # DOCKER-VERSION 0.3.4
-    FROM    tutum/centos-6.4
+    FROM    centos:centos6
 
     # Enable EPEL for Node.js
     RUN     rpm -Uvh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
@@ -137,9 +137,9 @@ Your image will now be listed by Docker:
     $ sudo docker images
 
     # Example
-    REPOSITORY                            TAG        ID              CREATED
-    tutum                                 centos-6.4 539c0211cd76    8 weeks ago
-    <your username>/centos-node-hello     latest     d64d3505b0d2    2 hours ago
+    REPOSITORY                          TAG        ID              CREATED
+    centos                              centos6    539c0211cd76    8 weeks ago
+    <your username>/centos-node-hello   latest     d64d3505b0d2    2 hours ago
 
 ## Run the image
 

--- a/docs/sources/examples/nodejs_web_app.md
+++ b/docs/sources/examples/nodejs_web_app.md
@@ -69,7 +69,7 @@ top of. Here, we'll use
 [CentOS](https://registry.hub.docker.com/_/centos/) (tag: `6.4`)
 available on the [Docker Hub](https://hub.docker.com/):
 
-    FROM    centos:6.4
+    FROM    tutum/centos-6.4
 
 Since we're building a Node.js app, you'll have to install Node.js as
 well as npm on your CentOS image. Node.js is required to run your app
@@ -109,7 +109,7 @@ defines your runtime, i.e. `node`, and the path to our app, i.e. `src/index.js`
 Your `Dockerfile` should now look like this:
 
     # DOCKER-VERSION 0.3.4
-    FROM    centos:6.4
+    FROM    tutum/centos-6.4
 
     # Enable EPEL for Node.js
     RUN     rpm -Uvh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
@@ -137,9 +137,9 @@ Your image will now be listed by Docker:
     $ sudo docker images
 
     # Example
-    REPOSITORY                            TAG       ID              CREATED
-    centos                                6.4       539c0211cd76    8 weeks ago
-    <your username>/centos-node-hello     latest    d64d3505b0d2    2 hours ago
+    REPOSITORY                            TAG        ID              CREATED
+    tutum                                 centos-6.4 539c0211cd76    8 weeks ago
+    <your username>/centos-node-hello     latest     d64d3505b0d2    2 hours ago
 
 ## Run the image
 


### PR DESCRIPTION
The image centos:centos6.4 doesn't exist. Instead you have to choose between the official centos6 or centos7. Both images does not work together with de yum npm install. When choosing an centos6.5 from another distributor (tutum) it works.
