### PR TITLE
server/buildfile.go -> builder/builder.go

### DIFF
--- a/builder/MAINTAINERS
+++ b/builder/MAINTAINERS
@@ -1,0 +1,2 @@
+Tibor Vass <teabee89@gmail.com> (@tiborvass)
+Erik Hollensbe <github@hollensbe.org> (@erikh)

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -513,7 +513,7 @@ func (container *Container) monitor(callback execdriver.StartCallback) error {
 	if container.daemon != nil && container.daemon.srv != nil && container.daemon.srv.IsRunning() {
 		// FIXME: here is race condition between two RUN instructions in Dockerfile
 		// because they share same runconfig and change image. Must be fixed
-		// in server/buildfile.go
+		// in builder/builder.go
 		if err := container.toDisk(); err != nil {
 			utils.Errorf("Error dumping container %s state to disk: %s\n", container.ID, err)
 		}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1099,3 +1099,35 @@ func (daemon *Daemon) checkLocaldns() error {
 	}
 	return nil
 }
+
+func (daemon *Daemon) ImageGetCached(imgID string, config *runconfig.Config) (*image.Image, error) {
+	// Retrieve all images
+	images, err := daemon.Graph().Map()
+	if err != nil {
+		return nil, err
+	}
+
+	// Store the tree in a map of map (map[parentId][childId])
+	imageMap := make(map[string]map[string]struct{})
+	for _, img := range images {
+		if _, exists := imageMap[img.Parent]; !exists {
+			imageMap[img.Parent] = make(map[string]struct{})
+		}
+		imageMap[img.Parent][img.ID] = struct{}{}
+	}
+
+	// Loop on the children of the given image and check the config
+	var match *image.Image
+	for elem := range imageMap[imgID] {
+		img, err := daemon.Graph().Get(elem)
+		if err != nil {
+			return nil, err
+		}
+		if runconfig.Compare(&img.ContainerConfig, config) {
+			if match == nil || match.Created.Before(img.Created) {
+				match = img
+			}
+		}
+	}
+	return match, nil
+}

--- a/server/server.go
+++ b/server/server.go
@@ -46,6 +46,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/archive"
+	"github.com/docker/docker/builder"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/daemonconfig"
 	"github.com/docker/docker/dockerversion"
@@ -534,7 +535,7 @@ func (srv *Server) Build(job *engine.Job) engine.Status {
 	defer context.Close()
 
 	sf := utils.NewStreamFormatter(job.GetenvBool("json"))
-	b := NewBuildFile(srv,
+	b := builder.NewBuildFile(srv.daemon, srv.Eng,
 		&utils.StdoutFormater{
 			Writer:          job.Stdout,
 			StreamFormatter: sf,
@@ -2056,38 +2057,6 @@ func (srv *Server) canDeleteImage(imgID string, force, untagged bool) error {
 		}
 	}
 	return nil
-}
-
-func (srv *Server) ImageGetCached(imgID string, config *runconfig.Config) (*image.Image, error) {
-	// Retrieve all images
-	images, err := srv.daemon.Graph().Map()
-	if err != nil {
-		return nil, err
-	}
-
-	// Store the tree in a map of map (map[parentId][childId])
-	imageMap := make(map[string]map[string]struct{})
-	for _, img := range images {
-		if _, exists := imageMap[img.Parent]; !exists {
-			imageMap[img.Parent] = make(map[string]struct{})
-		}
-		imageMap[img.Parent][img.ID] = struct{}{}
-	}
-
-	// Loop on the children of the given image and check the config
-	var match *image.Image
-	for elem := range imageMap[imgID] {
-		img, err := srv.daemon.Graph().Get(elem)
-		if err != nil {
-			return nil, err
-		}
-		if runconfig.Compare(&img.ContainerConfig, config) {
-			if match == nil || match.Created.Before(img.Created) {
-				match = img
-			}
-		}
-	}
-	return match, nil
 }
 
 func (srv *Server) setHostConfig(container *daemon.Container, hostConfig *runconfig.HostConfig) error {


### PR DESCRIPTION
Moves the buildfile out of the doomed `server/` directory into its own package.

Portability notes:

NewBuildFile now takes instances of daemon and engine, because passing the server was causing a circular dependency. FWIW, it doesn't need the server object itself.

server.ImageGetCached did not need a server object either, but was the only additional dependency in the buildfile for a server object. Moved to Daemon and now accepts a daemon object instead of the server object.

All tests pass. Please let me know if there are any concerns.
