### PR TITLE
Make lxc driver rbind all user specified mounts.

### DIFF
--- a/daemon/execdriver/lxc/lxc_template.go
+++ b/daemon/execdriver/lxc/lxc_template.go
@@ -75,9 +75,9 @@ lxc.mount.entry = shm {{escapeFstabSpaces $ROOTFS}}/dev/shm tmpfs {{formatMountL
 
 {{range $value := .Mounts}}
 {{if $value.Writable}}
-lxc.mount.entry = {{$value.Source}} {{escapeFstabSpaces $ROOTFS}}/{{escapeFstabSpaces $value.Destination}} none bind,rw 0 0
+lxc.mount.entry = {{$value.Source}} {{escapeFstabSpaces $ROOTFS}}/{{escapeFstabSpaces $value.Destination}} none rbind,rw 0 0
 {{else}}
-lxc.mount.entry = {{$value.Source}} {{escapeFstabSpaces $ROOTFS}}/{{escapeFstabSpaces $value.Destination}} none bind,ro 0 0
+lxc.mount.entry = {{$value.Source}} {{escapeFstabSpaces $ROOTFS}}/{{escapeFstabSpaces $value.Destination}} none rbind,ro 0 0
 {{end}}
 {{end}}
 

--- a/integration/container_test.go
+++ b/integration/container_test.go
@@ -6,12 +6,10 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/runconfig"
 )
 
@@ -385,21 +383,6 @@ func TestBindMounts(t *testing.T) {
 	stdout, _ := runContainer(eng, r, []string{"-v", fmt.Sprintf("%s:/tmp:ro", tmpDir), "_", "ls", "/tmp"}, t)
 	if !strings.Contains(stdout, "touch-me") {
 		t.Fatal("Container failed to read from bind mount")
-	}
-
-	// Test recursive bind mount works by default
-	// Create a temporary tmpfs mount.
-	tmpfsDir := filepath.Join(tmpDir, "tmpfs")
-	if err := os.MkdirAll(tmpfsDir, 0777); err != nil {
-		t.Fatalf("failed to mkdir at %s - %s", tmpfsDir, err)
-	}
-	if err := mount.Mount("tmpfs", tmpfsDir, "tmpfs", ""); err != nil {
-		t.Fatalf("failed to create a tmpfs mount at %s - %s", tmpfsDir, err)
-	}
-	writeFile(path.Join(tmpfsDir, "touch-me-again"), "", t)
-	stdout, _ = runContainer(eng, r, []string{"-v", fmt.Sprintf("%s:/tmp:ro", tmpDir), "_", "ls", "/tmp/tmpfs"}, t)
-	if !strings.Contains(stdout, "touch-me-again") {
-		t.Fatal("Container recursive bind mount test failed. Expected file not found")
 	}
 
 	// test writing to bind mount


### PR DESCRIPTION
This is required for running cadvisor with lxc driver.

Fixes #3782
