### PR TITLE
fix goroutines leak and exit code

### DIFF
--- a/daemon/execdriver/native/init.go
+++ b/daemon/execdriver/native/init.go
@@ -62,4 +62,5 @@ func initializer() {
 
 func writeError(err error) {
 	fmt.Sprint(os.Stderr, err)
+	os.Exit(1)
 }

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -114,28 +114,24 @@ func (s *State) GetExitCode() int {
 
 func (s *State) SetRunning(pid int) {
 	s.Lock()
-	if !s.Running {
-		s.Running = true
-		s.Paused = false
-		s.ExitCode = 0
-		s.Pid = pid
-		s.StartedAt = time.Now().UTC()
-		close(s.waitChan) // fire waiters for start
-		s.waitChan = make(chan struct{})
-	}
+	s.Running = true
+	s.Paused = false
+	s.ExitCode = 0
+	s.Pid = pid
+	s.StartedAt = time.Now().UTC()
+	close(s.waitChan) // fire waiters for start
+	s.waitChan = make(chan struct{})
 	s.Unlock()
 }
 
 func (s *State) SetStopped(exitCode int) {
 	s.Lock()
-	if s.Running {
-		s.Running = false
-		s.Pid = 0
-		s.FinishedAt = time.Now().UTC()
-		s.ExitCode = exitCode
-		close(s.waitChan) // fire waiters for stop
-		s.waitChan = make(chan struct{})
-	}
+	s.Running = false
+	s.Pid = 0
+	s.FinishedAt = time.Now().UTC()
+	s.ExitCode = exitCode
+	close(s.waitChan) // fire waiters for stop
+	s.waitChan = make(chan struct{})
 	s.Unlock()
 }
 


### PR DESCRIPTION
two issues:
- `docker run ubuntu rtyuioyu` fails with and ugly message, after when do you `docker ps -l` you don't see any status of exit code
- `docker run ubuntu rtyuioyu` leaks a goroutine (can you check with `docker info -D`)

This PR depends on https://github.com/docker/libcontainer/pull/132
