### PR TITLE
Add Go 1.2 to Travis so we make sure we keep retrocompat for a little while

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,11 @@
 
 language: go
 
+go:
 # This should match the version in the Dockerfile.
-go: 1.3
+  - 1.3
+# Test against older versions too, just for a little extra retrocompat.
+  - 1.2
 
 # Let us have pretty experimental Docker-based Travis workers.
 # (These spin up much faster than the VM-based ones.)


### PR DESCRIPTION
This is as discussed at the tail-end of #6520.  Turns out it currently works as-is (which is a good sign, of course).
