### PR TITLE
add linux amd64 build tags to the lxc driver

### DIFF
--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -1,3 +1,5 @@
+// +build linux,amd64
+
 package lxc
 
 import (

--- a/daemon/execdriver/lxc/driver_unsupported.go
+++ b/daemon/execdriver/lxc/driver_unsupported.go
@@ -1,0 +1,17 @@
+// +build !linux !amd64
+
+package lxc
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/daemon/execdriver"
+)
+
+func NewDriver(root, initPath string, apparmor bool) (execdriver.Driver, error) {
+	return nil, fmt.Errorf("lxc driver not supported on non-linux")
+}
+
+func KillLxc(id string, sig int) error {
+	return fmt.Errorf("not implemented on non-linux")
+}


### PR DESCRIPTION
This makes it possible to avoid building the lxc driver on anything which isn't linux amd64. This change is important because Docker doesn't need to build `kr/pty` for lxc on unsupported platforms.

```
# github.com/docker/docker/pkg/term
pkg/term/term.go:16: undefined: Termios
# github.com/docker/docker/pkg/system
pkg/system/stat_unsupported.go:7: undefined: syscall.Stat_t
pkg/system/stat_unsupported.go:11: undefined: syscall.Stat_t
# github.com/kr/pty
vendor/src/github.com/kr/pty/ioctl.go:6: undefined: syscall.SYS_IOCTL
vendor/src/github.com/kr/pty/ioctl.go:6: not enough arguments in call to syscall.Syscall
vendor/src/github.com/kr/pty/run.go:21: unknown syscall.SysProcAttr field 'Setctty' in struct literal
vendor/src/github.com/kr/pty/run.go:21: unknown syscall.SysProcAttr field 'Setsid' in struct literal
vendor/src/github.com/kr/pty/util.go:26: undefined: syscall.SYS_IOCTL
vendor/src/github.com/kr/pty/util.go:28: undefined: syscall.TIOCGWINSZ
vendor/src/github.com/kr/pty/util.go:30: not enough arguments in call to syscall.Syscall
```

ends up looking like this after the PR

```
# github.com/docker/docker/pkg/term
pkg/term/term.go:16: undefined: Termios
# github.com/docker/docker/pkg/system
pkg/system/stat_unsupported.go:7: undefined: syscall.Stat_t
pkg/system/stat_unsupported.go:11: undefined: syscall.Stat_t
```
