### PR TITLE
Update canonical e-mail address and re-run generate-authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -93,3 +93,4 @@ Nathan LeClaire <nathan.leclaire@docker.com> <nathanleclaire@gmail.com>
 <marc@marc-abramowitz.com> <msabramo@gmail.com>
 Matthew Heon <mheon@redhat.com> <mheon@mheonlaptop.redhat.com>
 <bernat@luffy.cx> <vincent@bernat.im>
+<p@pwaller.net> <peter@scraperwiki.com>

--- a/.mailmap
+++ b/.mailmap
@@ -94,3 +94,6 @@ Nathan LeClaire <nathan.leclaire@docker.com> <nathanleclaire@gmail.com>
 Matthew Heon <mheon@redhat.com> <mheon@mheonlaptop.redhat.com>
 <bernat@luffy.cx> <vincent@bernat.im>
 <p@pwaller.net> <peter@scraperwiki.com>
+<andrew.weiss@outlook.com> <andrew.weiss@microsoft.com>
+Francisco Carriedo <fcarriedo@gmail.com>
+<julienbordellier@gmail.com> <git@julienbordellier.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -421,7 +421,7 @@ Paul Nasrat <pnasrat@gmail.com>
 Paul <paul9869@gmail.com>
 Paul Weaver <pauweave@cisco.com>
 Peter Braden <peterbraden@peterbraden.co.uk>
-Peter Waller <peter@scraperwiki.com>
+Peter Waller <p@pwaller.net>
 Phillip Alexander <git@phillipalexander.io>
 Phil Spitler <pspitler@gmail.com>
 Phil <underscorephil@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -37,7 +37,6 @@ Andrew France <andrew@avito.co.uk>
 Andrew Macgregor <andrew.macgregor@agworld.com.au>
 Andrew Munsell <andrew@wizardapps.net>
 Andrews Medina <andrewsmedina@gmail.com>
-Andrew Weiss <andrew.weiss@microsoft.com>
 Andrew Weiss <andrew.weiss@outlook.com>
 Andrew Williams <williams.andrew@gmail.com>
 Andy Chambers <anchambers@paypal.com>
@@ -180,7 +179,6 @@ Fabio Rehm <fgrehm@gmail.com>
 Fabrizio Regini <freegenie@gmail.com>
 Faiz Khan <faizkhan00@gmail.com>
 Fareed Dudhia <fareeddudhia@googlemail.com>
-fcarriedo <fcarriedo@gmail.com>
 Felix Rabe <felix@rabe.io>
 Fernando <fermayo@gmail.com>
 Flavio Castelli <fcastelli@suse.com>
@@ -292,7 +290,6 @@ Josh <jokajak@gmail.com>
 Josh Poimboeuf <jpoimboe@redhat.com>
 JP <jpellerin@leapfrogonline.com>
 Julien Barbier <write0@gmail.com>
-Julien Bordellier <git@julienbordellier.com>
 Julien Bordellier <julienbordellier@gmail.com>
 Julien Dubois <julien.dubois@gmail.com>
 Justin Force <justin.force@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -38,6 +38,7 @@ Andrew Macgregor <andrew.macgregor@agworld.com.au>
 Andrew Munsell <andrew@wizardapps.net>
 Andrews Medina <andrewsmedina@gmail.com>
 Andrew Weiss <andrew.weiss@microsoft.com>
+Andrew Weiss <andrew.weiss@outlook.com>
 Andrew Williams <williams.andrew@gmail.com>
 Andy Chambers <anchambers@paypal.com>
 andy diller <dillera@gmail.com>
@@ -142,6 +143,7 @@ David Röthlisberger <david@rothlis.net>
 David Sissitka <me@dsissitka.com>
 Deni Bertovic <deni@kset.org>
 Derek <crq@kernel.org>
+Deric Crago <deric.crago@gmail.com>
 Dinesh Subhraveti <dineshs@altiscale.com>
 Djibril Koné <kone.djibril@gmail.com>
 dkumor <daniel@dkumor.com>
@@ -178,6 +180,7 @@ Fabio Rehm <fgrehm@gmail.com>
 Fabrizio Regini <freegenie@gmail.com>
 Faiz Khan <faizkhan00@gmail.com>
 Fareed Dudhia <fareeddudhia@googlemail.com>
+fcarriedo <fcarriedo@gmail.com>
 Felix Rabe <felix@rabe.io>
 Fernando <fermayo@gmail.com>
 Flavio Castelli <fcastelli@suse.com>
@@ -289,6 +292,7 @@ Josh <jokajak@gmail.com>
 Josh Poimboeuf <jpoimboe@redhat.com>
 JP <jpellerin@leapfrogonline.com>
 Julien Barbier <write0@gmail.com>
+Julien Bordellier <git@julienbordellier.com>
 Julien Bordellier <julienbordellier@gmail.com>
 Julien Dubois <julien.dubois@gmail.com>
 Justin Force <justin.force@gmail.com>
@@ -312,6 +316,7 @@ kim0 <email.ahmedkamal@googlemail.com>
 Kim BKC Carlbacker <kim.carlbacker@gmail.com>
 Kimbro Staken <kstaken@kstaken.com>
 Kiran Gangadharan <kiran.daredevil@gmail.com>
+knappe <tyler.knappe@gmail.com>
 Kohei Tsuruta <coheyxyz@gmail.com>
 Konstantin Pelykh <kpelykh@zettaset.com>
 Kyle Conroy <kyle.j.conroy@gmail.com>
@@ -370,6 +375,7 @@ Michael Neale <michael.neale@gmail.com>
 Michaël Pailloncy <mpapo.dev@gmail.com>
 Michael Prokop <github@michael-prokop.at>
 Michael Stapelberg <michael+gh@stapelberg.de>
+Michiel@unhosted <michiel@unhosted.org>
 Miguel Angel Fernández <elmendalerenda@gmail.com>
 Mike Chelen <michael.chelen@gmail.com>
 Mike Gaffney <mike@uberu.com>
@@ -418,11 +424,13 @@ Peter Braden <peterbraden@peterbraden.co.uk>
 Peter Waller <peter@scraperwiki.com>
 Phillip Alexander <git@phillipalexander.io>
 Phil Spitler <pspitler@gmail.com>
+Phil <underscorephil@gmail.com>
 Piergiuliano Bossi <pgbossi@gmail.com>
 Pierre-Alain RIVIERE <pariviere@ippon.fr>
 Piotr Bogdan <ppbogdan@gmail.com>
 pysqz <randomq@126.com>
 Quentin Brossard <qbrossard@gmail.com>
+r0n22 <cameron.regan@gmail.com>
 Rafal Jeczalik <rjeczalik@gmail.com>
 Rajat Pandit <rp@rajatpandit.com>
 Ralph Bean <rbean@redhat.com>
@@ -465,6 +473,8 @@ Scott Bessler <scottbessler@gmail.com>
 Scott Collier <emailscottcollier@gmail.com>
 Sean Cronin <seancron@gmail.com>
 Sean P. Kane <skane@newrelic.com>
+Sebastiaan van Stijn <thaJeztah@users.noreply.github.com>
+Sébastien Luttringer <seblu@seblu.net>
 Sébastien <sebastien@yoozio.com>
 Sébastien Stormacq <sebsto@users.noreply.github.com>
 Senthil Kumar Selvaraj <senthil.thecoder@gmail.com>
@@ -489,7 +499,7 @@ Steeve Morin <steeve.morin@gmail.com>
 Stefan Praszalowicz <stefan@greplin.com>
 Steven Burgess <steven.a.burgess@hotmail.com>
 sudosurootdev <sudosurootdev@gmail.com>
-Sven Dowideit <SvenDowideit@home.org.au>
+Sven Dowideit <svendowideit@home.org.au>
 Sylvain Bellemare <sylvain.bellemare@ezeep.com>
 tang0th <tang0th@gmx.com>
 Tatsuki Sugiura <sugi@nemui.org>


### PR DESCRIPTION
(Edited to add description): This primarily updates my long-term contact e-mail address. There was some collateral when running the `generate-authors` script was run which I tried to tidy up.
