### PR TITLE
Fix more instances of "dotcloud/docker" in hack/

### DIFF
--- a/hack/make/dynbinary
+++ b/hack/make/dynbinary
@@ -39,7 +39,7 @@ fi
 # exported so that "dyntest" can easily access it later without recalculating it
 
 (
-	export LDFLAGS_STATIC_DOCKER="-X github.com/docker/docker/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\" -X github.com/docker/docker/dockerversion.INITPATH \"$DOCKER_INITPATH\""
+	export LDFLAGS_STATIC_DOCKER="-X $DOCKER_PKG/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\" -X $DOCKER_PKG/dockerversion.INITPATH \"$DOCKER_INITPATH\""
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
 	source "$(dirname "$BASH_SOURCE")/binary"
 )

--- a/hack/make/dyntest-integration
+++ b/hack/make/dyntest-integration
@@ -12,7 +12,7 @@ fi
 (
 	export TEST_DOCKERINIT_PATH="$INIT"
 	export LDFLAGS_STATIC_DOCKER="
-		-X github.com/docker/docker/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\"
+		-X $DOCKER_PKG/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\"
 	"
 	source "$(dirname "$BASH_SOURCE")/test-integration"
 )

--- a/hack/make/dyntest-unit
+++ b/hack/make/dyntest-unit
@@ -12,7 +12,7 @@ fi
 (
 	export TEST_DOCKERINIT_PATH="$INIT"
 	export LDFLAGS_STATIC_DOCKER="
-		-X github.com/docker/docker/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\"
+		-X $DOCKER_PKG/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\"
 	"
 	source "$(dirname "$BASH_SOURCE")/test-unit"
 )

--- a/hack/make/test-integration
+++ b/hack/make/test-integration
@@ -5,7 +5,7 @@ DEST=$1
 
 bundle_test_integration() {
 	LDFLAGS="$LDFLAGS $LDFLAGS_STATIC_DOCKER" go_test_dir ./integration \
-		"-coverpkg $(find_dirs '*.go' | sed 's,^\.,github.com/docker/docker,g' | paste -d, -s)"
+		"-coverpkg $(find_dirs '*.go' | sed 's,^\.,'$DOCKER_PKG',g' | paste -d, -s)"
 }
 
 # this "grep" hides some really irritating warnings that "go test -coverpkg"

--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -54,7 +54,7 @@ go_run_test_dir() {
 	TESTS_FAILED=()
 	while read dir; do
 		echo
-		echo '+ go test' $TESTFLAGS "github.com/dotcloud/docker${dir#.}"
+		echo '+ go test' $TESTFLAGS "${DOCKER_PKG}${dir#.}"
 		precompiled="$DEST/precompiled/$dir.test"
 		if ! ( cd "$dir" && "$precompiled" ); then
 			TESTS_FAILED+=("$dir")


### PR DESCRIPTION
... and add a `DOCKER_PKG` environment variable to simplify references to our "package path" in our bundlescripts

cc @tiborvass
