### PR TITLE
Fix graph tags test on freebsd

### DIFF
--- a/archive/diff.go
+++ b/archive/diff.go
@@ -61,7 +61,7 @@ func ApplyLayer(dest string, layer ArchiveReader) error {
 			parent := filepath.Dir(hdr.Name)
 			parentPath := filepath.Join(dest, parent)
 			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
-				err = os.MkdirAll(parentPath, 0700)
+				err = os.MkdirAll(parentPath, 0600)
 				if err != nil {
 					return err
 				}

--- a/archive/diff.go
+++ b/archive/diff.go
@@ -61,7 +61,7 @@ func ApplyLayer(dest string, layer ArchiveReader) error {
 			parent := filepath.Dir(hdr.Name)
 			parentPath := filepath.Join(dest, parent)
 			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
-				err = os.MkdirAll(parentPath, 0600)
+				err = os.MkdirAll(parentPath, 0700)
 				if err != nil {
 					return err
 				}

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -19,11 +19,19 @@ const (
 )
 
 func fakeTar() (io.Reader, error) {
+	uid := os.Getuid()
+	gid := os.Getgid()
+
 	content := []byte("Hello world!\n")
 	buf := new(bytes.Buffer)
 	tw := tar.NewWriter(buf)
 	for _, name := range []string{"/etc/postgres/postgres.conf", "/etc/passwd", "/var/log/postgres/postgres.conf"} {
 		hdr := new(tar.Header)
+
+		// Leaving these fields blank requires root privileges
+		hdr.Uid = uid
+		hdr.Gid = gid
+
 		hdr.Size = int64(len(content))
 		hdr.Name = name
 		if err := tw.WriteHeader(hdr); err != nil {
@@ -53,8 +61,6 @@ func mkTestTagStore(root string, t *testing.T) *TagStore {
 		t.Fatal(err)
 	}
 	img := &image.Image{ID: testImageID}
-	// FIXME: this fails on Darwin with:
-	// tags_unit_test.go:36: mkdir /var/folders/7g/b3ydb5gx4t94ndr_cljffbt80000gq/T/docker-test569b-tRunner-075013689/vfs/dir/foo/etc/postgres: permission denied
 	if err := graph.Register(nil, archive, img); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is an update of #5437 and removes changing the dir permissions from 0600 to 0700.  It just includes setting the gid and uid in the tests. 

I remove the dir permission change because it's a very risky change that will touch every image and most of these tests and functions need to be run as root anyways. 

This had one prior LGTM so I'm merging this to keep things moving. 

Closes #5437
