### PR TITLE
Provide more information from the get containers endpoint

### DIFF
--- a/server/container.go
+++ b/server/container.go
@@ -316,6 +316,10 @@ func (srv *Server) Containers(job *engine.Job) engine.Status {
 			out.SetInt64("SizeRw", sizeRw)
 			out.SetInt64("SizeRootFs", sizeRootFs)
 		}
+		out.SetJson("Config", container.Config)
+		out.SetJson("State", container.State)
+		out.SetJson("NetworkSettings", container.NetworkSettings)
+		out.SetJson("HostConfig", container.HostConfig())
 		outs.Add(out)
 		return nil
 	}

--- a/server/container.go
+++ b/server/container.go
@@ -267,8 +267,6 @@ func (srv *Server) Containers(job *engine.Job) engine.Status {
 
 	errLast := errors.New("last container")
 	writeCont := func(container *daemon.Container) error {
-		container.Lock()
-		defer container.Unlock()
 		if !container.State.IsRunning() && !all && n <= 0 && since == "" && before == "" {
 			return nil
 		}


### PR DESCRIPTION
We are seeing a lot of ppl worried about performance when trying to get container information from docker.  This is because to get all the running containers and extra information about the config of the container they have to make a lot of individual requests.  One to `/containers/json` then for each container returned they need to make a request to `/containers/<id>/json` to get the data that they need.  

As a result most people will not do this and end up storing the information in a cache.  Redis, etcd, etc.... 

We can do this small change and it goes along way of getting the information to the people who need it and having a fast API endpoint to query so they do not have to have another method to cache this information and worry about TTLs or other ways that your cached information can get out of sync with reality.

Lets provide this information to the user in one request because docker is the only source to truth when it comes to running containers. 
