### PR TITLE
Replace amd64 build tags with cgo as appropriate

### DIFF
--- a/daemon/execdriver/lxc/lxc_init_linux.go
+++ b/daemon/execdriver/lxc/lxc_init_linux.go
@@ -1,5 +1,3 @@
-// +build amd64
-
 package lxc
 
 import (

--- a/daemon/execdriver/lxc/lxc_init_unsupported.go
+++ b/daemon/execdriver/lxc/lxc_init_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux !amd64
+// +build !linux
 
 package lxc
 

--- a/daemon/graphdriver/aufs/mount_linux.go
+++ b/daemon/graphdriver/aufs/mount_linux.go
@@ -1,5 +1,3 @@
-// +build amd64
-
 package aufs
 
 import "syscall"

--- a/daemon/graphdriver/aufs/mount_unsupported.go
+++ b/daemon/graphdriver/aufs/mount_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux !amd64
+// +build !linux
 
 package aufs
 

--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -1,4 +1,4 @@
-// +build linux,amd64
+// +build linux
 
 package btrfs
 

--- a/daemon/graphdriver/btrfs/dummy_unsupported.go
+++ b/daemon/graphdriver/btrfs/dummy_unsupported.go
@@ -1,3 +1,3 @@
-// +build !linux !amd64
+// +build !linux !cgo
 
 package btrfs

--- a/daemon/graphdriver/devmapper/attach_loopback.go
+++ b/daemon/graphdriver/devmapper/attach_loopback.go
@@ -1,4 +1,4 @@
-// +build linux,amd64
+// +build linux
 
 package devmapper
 

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1,4 +1,4 @@
-// +build linux,amd64
+// +build linux
 
 package devmapper
 

--- a/daemon/graphdriver/devmapper/devmapper.go
+++ b/daemon/graphdriver/devmapper/devmapper.go
@@ -1,4 +1,4 @@
-// +build linux,amd64
+// +build linux
 
 package devmapper
 

--- a/daemon/graphdriver/devmapper/devmapper_log.go
+++ b/daemon/graphdriver/devmapper/devmapper_log.go
@@ -1,4 +1,4 @@
-// +build linux,amd64
+// +build linux
 
 package devmapper
 

--- a/daemon/graphdriver/devmapper/devmapper_test.go
+++ b/daemon/graphdriver/devmapper/devmapper_test.go
@@ -1,4 +1,4 @@
-// +build linux,amd64
+// +build linux
 
 package devmapper
 

--- a/daemon/graphdriver/devmapper/devmapper_wrapper.go
+++ b/daemon/graphdriver/devmapper/devmapper_wrapper.go
@@ -1,4 +1,4 @@
-// +build linux,amd64
+// +build linux
 
 package devmapper
 

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -1,4 +1,4 @@
-// +build linux,amd64
+// +build linux
 
 package devmapper
 

--- a/daemon/graphdriver/devmapper/ioctl.go
+++ b/daemon/graphdriver/devmapper/ioctl.go
@@ -1,4 +1,4 @@
-// +build linux,amd64
+// +build linux
 
 package devmapper
 

--- a/daemon/graphdriver/devmapper/mount.go
+++ b/daemon/graphdriver/devmapper/mount.go
@@ -1,4 +1,4 @@
-// +build linux,amd64
+// +build linux
 
 package devmapper
 

--- a/pkg/mount/flags_linux.go
+++ b/pkg/mount/flags_linux.go
@@ -1,5 +1,3 @@
-// +build amd64
-
 package mount
 
 import (

--- a/pkg/mount/flags_unsupported.go
+++ b/pkg/mount/flags_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!freebsd linux,!amd64 freebsd,!cgo
+// +build !linux,!freebsd freebsd,!cgo
 
 package mount
 

--- a/pkg/mount/mounter_linux.go
+++ b/pkg/mount/mounter_linux.go
@@ -1,5 +1,3 @@
-// +build amd64
-
 package mount
 
 import (

--- a/pkg/mount/mounter_unsupported.go
+++ b/pkg/mount/mounter_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!freebsd linux,!amd64 freebsd,!cgo
+// +build !linux,!freebsd freebsd,!cgo
 
 package mount
 

--- a/pkg/parsers/kernel/uname_linux.go
+++ b/pkg/parsers/kernel/uname_linux.go
@@ -1,5 +1,3 @@
-// +build amd64
-
 package kernel
 
 import (

--- a/pkg/parsers/kernel/uname_unsupported.go
+++ b/pkg/parsers/kernel/uname_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux !amd64
+// +build !linux
 
 package kernel
 


### PR DESCRIPTION
This requires #7377 in order to actually compile properly in `make cross` (hence that commit being included here), so please review that one first.

Essentially, this removes _all_ our explicit "amd64" build tags in favor of more specific tags that actually apply to the buildability of the relevant code (ie, just `+build linux` or `+build linux,cgo` as necessary).
