### PR TITLE
Auto restart containers based on restart policy

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -45,7 +45,7 @@ type Config struct {
 func (config *Config) InstallFlags() {
 	flag.StringVar(&config.Pidfile, []string{"p", "-pidfile"}, "/var/run/docker.pid", "Path to use for daemon PID file")
 	flag.StringVar(&config.Root, []string{"g", "-graph"}, "/var/lib/docker", "Path to use as the root of the Docker runtime")
-	flag.BoolVar(&config.AutoRestart, []string{"r", "-restart"}, true, "Restart previously running containers")
+	flag.BoolVar(&config.AutoRestart, []string{"#r", "#-restart"}, true, "--restart on the daemon has been deprecated infavor of --restart policies on docker run")
 	flag.BoolVar(&config.EnableIptables, []string{"#iptables", "-iptables"}, true, "Enable Docker's addition of iptables rules")
 	flag.BoolVar(&config.EnableIpForward, []string{"#ip-forward", "-ip-forward"}, true, "Enable net.ipv4.ip_forward")
 	flag.StringVar(&config.BridgeIP, []string{"#bip", "-bip"}, "", "Use this CIDR notation address for the network bridge's IP, not compatible with -b")

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -530,6 +530,13 @@ func (container *Container) KillSig(sig int) error {
 	// after we send the kill signal
 	container.monitor.ExitOnNext()
 
+	// if the container is currently restarting we do not need to send the signal
+	// to the process.  Telling the monitor that it should exit on it's next event
+	// loop is enough
+	if container.State.IsRestarting() {
+		return nil
+	}
+
 	return container.daemon.Kill(container, sig)
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -370,7 +370,8 @@ func (daemon *Daemon) restore() error {
 		log.Debugf("Restarting containers...")
 
 		for _, container := range registeredContainers {
-			if container.hostConfig.RestartPolicy.Name == "always" {
+			if container.hostConfig.RestartPolicy.Name == "always" ||
+				(container.hostConfig.RestartPolicy.Name == "on-failure" && container.State.ExitCode != 0) {
 				utils.Debugf("Starting container %s", container.ID)
 
 				if err := container.Start(); err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -372,10 +372,10 @@ func (daemon *Daemon) restore() error {
 		for _, container := range registeredContainers {
 			if container.hostConfig.RestartPolicy.Name == "always" ||
 				(container.hostConfig.RestartPolicy.Name == "on-failure" && container.State.ExitCode != 0) {
-				utils.Debugf("Starting container %s", container.ID)
+				log.Debugf("Starting container %s", container.ID)
 
 				if err := container.Start(); err != nil {
-					utils.Debugf("Failed to start container %s: %s", container.ID, err)
+					log.Debugf("Failed to start container %s: %s", container.ID, err)
 				}
 			}
 		}

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -62,15 +62,13 @@ func (m *containerMonitor) Close() error {
 	// Cleanup networking and mounts
 	m.container.cleanup()
 
-	if m.container.daemon != nil && m.container.daemon.srv != nil && m.container.daemon.srv.IsRunning() {
-		// FIXME: here is race condition between two RUN instructions in Dockerfile
-		// because they share same runconfig and change image. Must be fixed
-		// in builder/builder.go
-		if err := m.container.toDisk(); err != nil {
-			utils.Errorf("Error dumping container %s state to disk: %s\n", m.container.ID, err)
+	// FIXME: here is race condition between two RUN instructions in Dockerfile
+	// because they share same runconfig and change image. Must be fixed
+	// in builder/builder.go
+	if err := m.container.toDisk(); err != nil {
+		utils.Errorf("Error dumping container %s state to disk: %s\n", m.container.ID, err)
 
-			return err
-		}
+		return err
 	}
 
 	return nil

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -105,7 +105,7 @@ func (m *containerMonitor) reset(successful bool) {
 	}
 
 	if container.daemon != nil && container.daemon.srv != nil {
-		container.daemon.srv.LogEvent("die", container.ID, container.daemon.repositories.ImageName(container.Image))
+		container.LogEvent("die")
 	}
 
 	c := container.command.Cmd

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -104,9 +104,7 @@ func (m *containerMonitor) reset(successful bool) {
 		container.stdin, container.stdinPipe = io.Pipe()
 	}
 
-	if container.daemon != nil && container.daemon.srv != nil {
-		container.LogEvent("die")
-	}
+	container.LogEvent("die")
 
 	c := container.command.Cmd
 
@@ -159,6 +157,8 @@ func (m *containerMonitor) Start() error {
 		}
 
 		pipes := execdriver.NewPipes(m.container.stdin, m.container.stdout, m.container.stderr, m.container.Config.OpenStdin)
+
+		m.container.LogEvent("start")
 
 		if exitStatus, err = m.container.daemon.Run(m.container, pipes, m.callback); err != nil {
 			utils.Errorf("Error running container: %s", err)

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -164,12 +164,15 @@ func (m *containerMonitor) Start() error {
 			utils.Errorf("Error running container: %s", err)
 		}
 
-		// We still wait to set the state as stopped and ensure that the locks were released
+		// we still wait to set the state as stopped and ensure that the locks were released
 		m.container.State.SetStopped(exitStatus)
 
+		// pass if we exited successfully
 		m.reset(err == nil && exitStatus == 0)
 
 		if m.shouldRestart(exitStatus) {
+			// sleep with a small time increment between each restart to help avoid issues cased by quickly
+			// restarting the container because of some types of errors ( networking cut out, etc... )
 			time.Sleep(time.Duration(m.timeIncrement) * time.Millisecond)
 
 			continue

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -1,0 +1,189 @@
+package daemon
+
+import (
+	"io"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/daemon/execdriver"
+	"github.com/docker/docker/runconfig"
+	"github.com/docker/docker/utils"
+)
+
+// containerMonitor monitors the execution of a container's main process.
+// If a restart policy is specified for the cotnainer the monitor will ensure that the
+// process is restarted based on the rules of the policy.  When the container is finally stopped
+// the monitor will reset and cleanup any of the container resources such as networking allocations
+// and the rootfs
+type containerMonitor struct {
+	mux sync.Mutex
+
+	container     *Container
+	restartPolicy runconfig.RestartPolicy
+	failureCount  int
+	shouldStop    bool
+}
+
+func newContainerMonitor(container *Container, policy runconfig.RestartPolicy) *containerMonitor {
+	return &containerMonitor{
+		container:     container,
+		restartPolicy: policy,
+	}
+}
+
+// Stop signals to the container monitor that it should stop monitoring the container
+// for exits the next time the process dies
+func (m *containerMonitor) ExitOnNext() {
+	m.mux.Lock()
+	m.shouldStop = true
+	m.mux.Unlock()
+}
+
+// Close closes the container's resources such as networking allocations and
+// unmounts the contatiner's root filesystem
+func (m *containerMonitor) Close() error {
+	// Cleanup networking and mounts
+	m.container.cleanup()
+
+	if m.container.daemon != nil && m.container.daemon.srv != nil && m.container.daemon.srv.IsRunning() {
+		// FIXME: here is race condition between two RUN instructions in Dockerfile
+		// because they share same runconfig and change image. Must be fixed
+		// in builder/builder.go
+		if err := m.container.toDisk(); err != nil {
+			utils.Errorf("Error dumping container %s state to disk: %s\n", m.container.ID, err)
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+// reset resets the container's IO and ensures that the command is able to be executed again
+// by copying the data into a new struct
+func (m *containerMonitor) reset() {
+	container := m.container
+
+	if container.Config.OpenStdin {
+		if err := container.stdin.Close(); err != nil {
+			utils.Errorf("%s: Error close stdin: %s", container.ID, err)
+		}
+	}
+
+	if err := container.stdout.Clean(); err != nil {
+		utils.Errorf("%s: Error close stdout: %s", container.ID, err)
+	}
+
+	if err := container.stderr.Clean(); err != nil {
+		utils.Errorf("%s: Error close stderr: %s", container.ID, err)
+	}
+
+	if container.command != nil && container.command.Terminal != nil {
+		if err := container.command.Terminal.Close(); err != nil {
+			utils.Errorf("%s: Error closing terminal: %s", container.ID, err)
+		}
+	}
+
+	// Re-create a brand new stdin pipe once the container exited
+	if container.Config.OpenStdin {
+		container.stdin, container.stdinPipe = io.Pipe()
+	}
+
+	if container.daemon != nil && container.daemon.srv != nil {
+		container.daemon.srv.LogEvent("die", container.ID, container.daemon.repositories.ImageName(container.Image))
+	}
+
+	c := container.command.Cmd
+
+	container.command.Cmd = exec.Cmd{
+		Stdin:       c.Stdin,
+		Stdout:      c.Stdout,
+		Stderr:      c.Stderr,
+		Path:        c.Path,
+		Env:         c.Env,
+		ExtraFiles:  c.ExtraFiles,
+		Args:        c.Args,
+		Dir:         c.Dir,
+		SysProcAttr: c.SysProcAttr,
+	}
+}
+
+// Start starts the containers process and monitors it according to the restart policy
+func (m *containerMonitor) Start() error {
+	var (
+		err      error
+		exitCode int
+	)
+	defer m.Close()
+
+	// reset the restart count
+	m.container.RestartCount = -1
+
+	for !m.shouldStop {
+		m.container.RestartCount++
+		if err := m.container.startLoggingToDisk(); err != nil {
+			m.reset()
+
+			return err
+		}
+
+		pipes := execdriver.NewPipes(m.container.stdin, m.container.stdout, m.container.stderr, m.container.Config.OpenStdin)
+
+		if exitCode, err = m.container.daemon.Run(m.container, pipes, m.callback); err != nil {
+			m.failureCount++
+
+			if m.failureCount == m.restartPolicy.MaximumRetryCount {
+				m.ExitOnNext()
+			}
+
+			utils.Errorf("Error running container: %s", err)
+		}
+
+		// We still wait to set the state as stopped and ensure that the locks were released
+		m.container.State.SetStopped(exitCode)
+
+		m.reset()
+
+		if m.shouldRestart(exitCode) {
+			time.Sleep(1 * time.Second)
+
+			continue
+		}
+
+		break
+	}
+
+	return err
+}
+
+func (m *containerMonitor) shouldRestart(exitCode int) bool {
+	m.mux.Lock()
+
+	shouldRestart := (m.restartPolicy.Name == "always" ||
+		(m.restartPolicy.Name == "on-failure" && exitCode != 0)) &&
+		!m.shouldStop
+
+	m.mux.Unlock()
+
+	return shouldRestart
+}
+
+// callback ensures that the container's state is properly updated after we
+// received ack from the execution drivers
+func (m *containerMonitor) callback(command *execdriver.Command) {
+	if command.Tty {
+		// The callback is called after the process Start()
+		// so we are in the parent process. In TTY mode, stdin/out/err is the PtySlace
+		// which we close here.
+		if c, ok := command.Stdout.(io.Closer); ok {
+			c.Close()
+		}
+	}
+
+	m.container.State.SetRunning(command.Pid())
+
+	if err := m.container.ToDisk(); err != nil {
+		utils.Debugf("%s", err)
+	}
+}

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -116,15 +116,14 @@ func (m *containerMonitor) Start() error {
 			time.Sleep(time.Duration(m.timeIncrement) * time.Millisecond)
 
 			continue
-		} else {
-			// we still wait to set the state as stopped and ensure that the locks were released
-			m.container.State.SetStopped(exitStatus)
-
-			m.resetContainer()
 		}
 
 		break
 	}
+
+	m.container.State.SetStopped(exitStatus)
+
+	m.resetContainer()
 
 	return err
 }

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -36,7 +36,7 @@ func (daemon *Daemon) ContainerStart(job *engine.Job) engine.Status {
 	if err := container.Start(); err != nil {
 		return job.Errorf("Cannot start container %s: %s", name, err)
 	}
-	container.LogEvent("start")
+
 	return engine.StatusOK
 }
 

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -30,6 +30,7 @@ docker-run - Run a command in a new container
 [**-P**|**--publish-all**[=*false*]]
 [**-p**|**--publish**[=*[]*]]
 [**--privileged**[=*false*]]
+[**--restart**[=*POLICY*]]
 [**--rm**[=*false*]]
 [**--sig-proxy**[=*true*]]
 [**-t**|**--tty**[=*false*]]

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -64,9 +64,6 @@ unix://[/path/to/socket] to use.
 **-p**=""
   Path to use for daemon PID file. Default is `/var/run/docker.pid`
 
-**-r**=*true*|*false*
-  Restart previously running containers. Default is true.
-
 **-s**=""
   Force the Docker runtime to use a specific storage driver.
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -71,7 +71,6 @@ expect an integer, and they can only be specified once.
       --mtu=0                                    Set the containers network MTU
                                                    if no value is provided: default to the default route MTU or 1500 if no default route is available
       -p, --pidfile="/var/run/docker.pid"        Path to use for daemon PID file
-      -r, --restart=true                         Restart previously running containers
       -s, --storage-driver=""                    Force the Docker runtime to use a specific storage driver
       --selinux-enabled=false                    Enable selinux support. SELinux does not presently support the BTRFS storage driver
       --storage-opt=[]                           Set storage driver options

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1223,7 +1223,7 @@ application change:
 
 #### Restart Policies
 
-Using the `--restart` flag on docker run you can specify a restart policy for 
+Using the `--restart` flag on Docker run you can specify a restart policy for 
 how a container should or should not be restarted on exit.
 
 ** no ** - Do not restart the container when it exits.
@@ -1232,19 +1232,19 @@ how a container should or should not be restarted on exit.
 
 ** always ** - Always restart the container reguardless of the exit status.
 
-You can also specify the maximum amount of times docker will try to restart the 
-container when using the ** on-failure ** policy.  The default is that docker will try forever to restart the container.
+You can also specify the maximum amount of times Docker will try to restart the 
+container when using the ** on-failure ** policy.  The default is that Docker will try forever to restart the container.
 
     $ sudo docker run --restart=always redis
 
-This will run the redis container with a restart policy of ** always ** so that if 
-the container exits, docker will restart it.
+This will run the `redis` container with a restart policy of ** always ** so that if 
+the container exits, Docker will restart it.
 
     $ sudo docker run --restart=on-failure:10 redis
 
-This will run the redis container with a restart policy of ** on-failure ** and a 
-maximum restart count of 10.  If the redis container exits with a non-zero exit 
-status more than 10 times in a row docker will abort trying to restart the container.
+This will run the `redis` container with a restart policy of ** on-failure ** and a 
+maximum restart count of 10.  If the `redis` container exits with a non-zero exit 
+status more than 10 times in a row Docker will abort trying to restart the container.
 
 ## save
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -993,6 +993,7 @@ removed before the image is removed.
                                    format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort
                                    (use 'docker port' to see the actual mapping)
       --privileged=false         Give extended privileges to this container
+      --restart=""               Restart policy to apply when a container exits (no, on-failure, always)
       --rm=false                 Automatically remove the container when it exits (incompatible with -d)
       --sig-proxy=true           Proxy received signals to the process (even in non-TTY mode). SIGCHLD, SIGSTOP, and SIGKILL are not proxied.
       -t, --tty=false            Allocate a pseudo-TTY
@@ -1219,6 +1220,31 @@ application change:
    volume from the `web` container, setting the workdir to `/var/log/httpd`. The
    `--rm` option means that when the container exits, the container's layer is
    removed.
+
+#### Restart Policies
+
+Using the `--restart` flag on docker run you can specify a restart policy for 
+how a container should or should not be restarted on exit.
+
+** no ** - Do not restart the container when it exits.
+
+** on-failure ** - Restart the container only if it exits with a non zero exit status.
+
+** always ** - Always restart the container reguardless of the exit status.
+
+You can also specify the maximum amount of times docker will try to restart the 
+container when using the ** on-failure ** policy.  The default is that docker will try forever to restart the container.
+
+    $ sudo docker run --restart=always redis
+
+This will run the redis container with a restart policy of ** always ** so that if 
+the container exits, docker will restart it.
+
+    $ sudo docker run --restart=on-failure:10 redis
+
+This will run the redis container with a restart policy of ** on-failure ** and a 
+maximum restart count of 10.  If the redis container exits with a non-zero exit 
+status more than 10 times in a row docker will abort trying to restart the container.
 
 ## save
 

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -40,6 +40,7 @@ type HostConfig struct {
 	NetworkMode     NetworkMode
 	CapAdd          []string
 	CapDrop         []string
+	RestartPolicy   string
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
@@ -48,6 +49,7 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 		Privileged:      job.GetenvBool("Privileged"),
 		PublishAllPorts: job.GetenvBool("PublishAllPorts"),
 		NetworkMode:     NetworkMode(job.Getenv("NetworkMode")),
+		RestartPolicy:   job.Getenv("RestartPolicy"),
 	}
 	job.GetenvJson("LxcConf", &hostConfig.LxcConf)
 	job.GetenvJson("PortBindings", &hostConfig.PortBindings)

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -25,6 +25,11 @@ type DeviceMapping struct {
 	CgroupPermissions string
 }
 
+type RestartPolicy struct {
+	Name              string
+	MaximumRetryCount int
+}
+
 type HostConfig struct {
 	Binds           []string
 	ContainerIDFile string
@@ -40,7 +45,7 @@ type HostConfig struct {
 	NetworkMode     NetworkMode
 	CapAdd          []string
 	CapDrop         []string
-	RestartPolicy   string
+	RestartPolicy   RestartPolicy
 }
 
 func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
@@ -49,11 +54,12 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 		Privileged:      job.GetenvBool("Privileged"),
 		PublishAllPorts: job.GetenvBool("PublishAllPorts"),
 		NetworkMode:     NetworkMode(job.Getenv("NetworkMode")),
-		RestartPolicy:   job.Getenv("RestartPolicy"),
 	}
+
 	job.GetenvJson("LxcConf", &hostConfig.LxcConf)
 	job.GetenvJson("PortBindings", &hostConfig.PortBindings)
 	job.GetenvJson("Devices", &hostConfig.Devices)
+	job.GetenvJson("RestartPolicy", &hostConfig.RestartPolicy)
 	if Binds := job.GetenvList("Binds"); Binds != nil {
 		hostConfig.Binds = Binds
 	}
@@ -75,5 +81,6 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 	if CapDrop := job.GetenvList("CapDrop"); CapDrop != nil {
 		hostConfig.CapDrop = CapDrop
 	}
+
 	return hostConfig
 }

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -71,6 +71,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.")
+		flRestartPolicy   = cmd.String([]string{"-restart"}, "", "Restart policy when the dies")
 		// For documentation purpose
 		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxy received signals to the process (even in non-TTY mode). SIGCHLD, SIGSTOP, and SIGKILL are not proxied.")
 		_ = cmd.String([]string{"#name", "-name"}, "", "Assign a name to the container")
@@ -271,6 +272,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		Devices:         deviceMappings,
 		CapAdd:          flCapAdd.GetAll(),
 		CapDrop:         flCapDrop.GetAll(),
+		RestartPolicy:   *flRestartPolicy,
 	}
 
 	if sysInfo != nil && flMemory > 0 && !sysInfo.SwapLimit {


### PR DESCRIPTION
This implements the proposal in #7226

Closes #7226
Closes #7521
#### Restart Policies

Using the `--restart` flag on docker run you can specify a restart policy for
how a container should or should not be restarted on exit.

**no** - Do not restart the container when it exits.

**on-failure** - Restart the container only if it exits with a non zero exit status.

**always** - Always restart the container regardless of the exit status.

You can also specify the maximum amount of times docker will try to restart the
container when using the **on-failure** policy.  The default is that docker will try forever to restart the container.

```
$ sudo docker run --restart=always redis
```

This will run the redis container with a restart policy of **always** so that if
the container exits, docker will restart it.

```
$ sudo docker run --restart=on-failure:10 redis
```

This will run the redis container with a restart policy of **on-failure** and a
maximum restart count of 10.  If the redis container exits with a non-zero exit
status more than 10 times in a row docker will abort trying to restart the container.
