### PR TITLE
Proposal: default --tlsverify=true if talking to :2376

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -192,6 +192,11 @@ func main() {
 			log.Fatal("Please specify only one -H")
 		}
 		protoAddrParts := strings.SplitN(flHosts.GetAll()[0], "://", 2)
+		if strings.HasSuffix(flHosts.GetAll()[0], ":2376") {
+			// TODO: detect if the key was defaulted, or was intentionally set to false
+			*flTlsVerify = true
+			log.Print("defaulting --tlsverify=true")
+		}
 
 		var (
 			cli       *client.DockerCli


### PR DESCRIPTION
2376 is registered as the encrypted Docker API port - so defaulting to that would simplify the UI and the user documentation.

if someone can tell me how to resolve the TODO, and if the UX is acceptable, I'll go make it happen.... 

Docker-DCO-1.1-Signed-off-by: SvenDowideit SvenDowideit@home.org.au (github: SvenDowideit)
