### PR TITLE
Cleanup: Remove unnecessary job "initserverpidfile"

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -50,9 +50,6 @@ func remote(eng *engine.Engine) error {
 // These components should be broken off into plugins of their own.
 //
 func daemon(eng *engine.Engine) error {
-	if err := eng.Register("initserverpidfile", server.InitPidfile); err != nil {
-		return err
-	}
 	if err := eng.Register("initserver", server.InitServer); err != nil {
 		return err
 	}

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -44,14 +44,6 @@ func mainDaemon() {
 		log.Fatal(err)
 	}
 
-	// handle the pidfile early. https://github.com/docker/docker/issues/6973
-	if len(*pidfile) > 0 {
-		job := eng.Job("initserverpidfile", *pidfile)
-		if err := job.Run(); err != nil {
-			log.Fatal(err)
-		}
-	}
-
 	// load the daemon in the background so we can immediately start
 	// the http api so that connections don't fail while the daemon
 	// is booting


### PR DESCRIPTION
That job was a hacky solution to a real race condition. This removes the hack without re-introducing the race.

Signed-off-by: Solomon Hykes solomon@docker.com
