### PR TITLE
Cleanup: Remove useless Server.IsRunning and Server.SetRunning

### DIFF
--- a/daemon/server.go
+++ b/daemon/server.go
@@ -6,5 +6,4 @@ import (
 
 type Server interface {
 	LogEvent(action, id, from string) *utils.JSONMessage
-	IsRunning() bool // returns true if the server is currently in operation
 }

--- a/server/init.go
+++ b/server/init.go
@@ -20,9 +20,6 @@ import (
 
 func (srv *Server) handlerWrap(h engine.Handler) engine.Handler {
 	return func(job *engine.Job) engine.Status {
-		if !srv.IsRunning() {
-			return job.Errorf("Server is not running")
-		}
 		srv.tasks.Add(1)
 		defer srv.tasks.Done()
 		return h(job)
@@ -115,7 +112,6 @@ func InitServer(job *engine.Job) engine.Status {
 	if err := srv.daemon.Install(job.Eng); err != nil {
 		return job.Error(err)
 	}
-	srv.SetRunning(true)
 	return engine.StatusOK
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -92,24 +92,10 @@ func (srv *Server) DockerInfo(job *engine.Job) engine.Status {
 	return engine.StatusOK
 }
 
-func (srv *Server) SetRunning(status bool) {
-	srv.Lock()
-	defer srv.Unlock()
-
-	srv.running = status
-}
-
-func (srv *Server) IsRunning() bool {
-	srv.RLock()
-	defer srv.RUnlock()
-	return srv.running
-}
-
 func (srv *Server) Close() error {
 	if srv == nil {
 		return nil
 	}
-	srv.SetRunning(false)
 	done := make(chan struct{})
 	go func() {
 		srv.tasks.Wait()
@@ -134,6 +120,5 @@ type Server struct {
 	events         []utils.JSONMessage
 	eventPublisher *utils.JSONMessagePublisher
 	Eng            *engine.Engine
-	running        bool
 	tasks          sync.WaitGroup
 }


### PR DESCRIPTION
The only side-effect is that it makes an existing race condition
slightly more likely to happen. The difference in impact is negligible
whereas the impact on code cleanup is significant. The actual fix
for the race condition is to implement a better auto-restart system.
There is a patch under a review which does just that.

Signed-off-by: Solomon Hykes solomon@docker.com
