### PR TITLE
Allow passing allocation subnet to `docker run`

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -396,7 +396,7 @@ func (container *Container) allocateNetwork() error {
 		err error
 		eng = container.daemon.eng
 	)
-	
+
 	job := eng.Job("allocate_interface", container.ID)
 	if container.Config.IP != "" {
 		job.Setenv("RequestedIP", container.Config.IP)

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -396,8 +396,11 @@ func (container *Container) allocateNetwork() error {
 		err error
 		eng = container.daemon.eng
 	)
-
+	
 	job := eng.Job("allocate_interface", container.ID)
+	if container.Config.IP != "" {
+		job.Setenv("RequestedIP", container.Config.IP)
+	}
 	if env, err = job.Stdout.AddEnv(); err != nil {
 		return err
 	}

--- a/daemon/networkdriver/ipallocator/allocator.go
+++ b/daemon/networkdriver/ipallocator/allocator.go
@@ -79,15 +79,15 @@ func (allocated *allocatedMap) checkIP(network *net.IPNet, ip *net.IP) (*net.IP,
 // return an available ip if one is currently available.
 func (allocated *allocatedMap) getNextIP(network *net.IPNet, ipReqRange *net.IPNet) (*net.IP, error) {
 	var (
-		ownIPInt           = ipToInt(&network.IP)
-		base, broadcast    = networkdriver.NetworkRange(network)
-		baseInt            = ipToInt(&base)
-		networkFirstInt    = baseInt + 1
-		networkLastInt     = ipToInt(&broadcast) - 1
-		rangeFirstInt      = networkFirstInt
-		rangeLastInt       = networkLastInt
-		subnetAllocatedPos = allocated.last
-		pos                = subnetAllocatedPos - (rangeFirstInt - baseInt) // relative to the start of available addresses
+		ownIPInt        = ipToInt(&network.IP)
+		base, broadcast = networkdriver.NetworkRange(network)
+		baseInt         = ipToInt(&base)
+		networkFirstInt = baseInt + 1
+		networkLastInt  = ipToInt(&broadcast) - 1
+		rangeFirstInt   = networkFirstInt
+		rangeLastInt    = networkLastInt
+		allocatedPos    = allocated.last
+		pos             = allocatedPos - (rangeFirstInt - baseInt) // relative to the start of available addresses
 	)
 
 	if ipReqRange != nil {

--- a/daemon/networkdriver/ipallocator/allocator.go
+++ b/daemon/networkdriver/ipallocator/allocator.go
@@ -34,7 +34,7 @@ var (
 // will return the next available ip if the ip provided is nil.  If the
 // ip provided is not nil it will validate that the provided ip is available
 // for use or return an error
-func RequestIP(network *net.IPNet, ip *net.IP) (*net.IP, error) {
+func RequestIP(network *net.IPNet, ipRange *net.IPNet) (*net.IP, error) {
 	lock.Lock()
 	defer lock.Unlock()
 	key := network.String()
@@ -44,10 +44,7 @@ func RequestIP(network *net.IPNet, ip *net.IP) (*net.IP, error) {
 		allocatedIPs[key] = allocated
 	}
 
-	if ip == nil {
-		return allocated.getNextIP(network)
-	}
-	return allocated.checkIP(network, ip)
+	return allocated.getNextIP(network, ipRange)
 }
 
 // ReleaseIP adds the provided ip back into the pool of
@@ -79,36 +76,53 @@ func (allocated *allocatedMap) checkIP(network *net.IPNet, ip *net.IP) (*net.IP,
 	return ip, nil
 }
 
-// return an available ip if one is currently available.  If not,
-// return the next available ip for the nextwork
-func (allocated *allocatedMap) getNextIP(network *net.IPNet) (*net.IP, error) {
+// return an available ip if one is currently available.
+func (allocated *allocatedMap) getNextIP(network *net.IPNet, ipReqRange *net.IPNet) (*net.IP, error) {
 	var (
-		ownIP    = ipToInt(&network.IP)
-		first, _ = networkdriver.NetworkRange(network)
-		base     = ipToInt(&first)
-		size     = int(networkdriver.NetworkSize(network.Mask))
-		max      = int32(size - 2) // size -1 for the broadcast network, -1 for the gateway network
-		pos      = allocated.last
+		ownIPInt           = ipToInt(&network.IP)
+		base, broadcast    = networkdriver.NetworkRange(network)
+		baseInt            = ipToInt(&base)
+		networkFirstInt    = baseInt + 1
+		networkLastInt     = ipToInt(&broadcast) - 1
+		rangeFirstInt      = networkFirstInt
+		rangeLastInt       = networkLastInt
+		subnetAllocatedPos = allocated.last
+		pos                = subnetAllocatedPos - (rangeFirstInt - baseInt) // relative to the start of available addresses
 	)
 
-	var (
-		firstNetIP = network.IP.To4().Mask(network.Mask)
-		firstAsInt = ipToInt(&firstNetIP) + 1
-	)
+	if ipReqRange != nil {
+		ipReqRangeFirst, ipReqRangeLast := networkdriver.NetworkRange(ipReqRange)
+		ipReqRangeFirstInt := ipToInt(&ipReqRangeFirst)
+		ipReqRangeLastInt := ipToInt(&ipReqRangeLast)
 
-	for i := int32(0); i < max; i++ {
-		pos = pos%max + 1
-		next := int32(base + pos)
+		if rangeFirstInt < ipReqRangeFirstInt {
+			rangeFirstInt = ipReqRangeFirstInt
+		}
+		if rangeLastInt > ipReqRangeLastInt {
+			rangeLastInt = ipReqRangeLastInt
+		}
 
-		if next == ownIP || next == firstAsInt {
+		pos = pos - (ipReqRangeFirstInt - networkFirstInt) // make relative to the new range
+	}
+
+	size := rangeLastInt - rangeFirstInt + 1
+	if pos < 0 || pos > size { // outside of range
+		pos = 0
+	}
+	for i := int32(0); i < size; i++ {
+		pos = (pos + 1) % size
+		ipInt := int32(rangeFirstInt + pos)
+
+		if ipInt == ownIPInt {
 			continue
 		}
-		if _, ok := allocated.p[pos]; ok {
+		allocatedPos := pos + (rangeFirstInt - baseInt)
+		if _, ok := allocated.p[allocatedPos]; ok {
 			continue
 		}
-		allocated.p[pos] = struct{}{}
-		allocated.last = pos
-		return intToIP(next), nil
+		allocated.p[allocatedPos] = struct{}{}
+		allocated.last = allocatedPos
+		return intToIP(ipInt), nil
 	}
 	return nil, ErrNoAvailableIPs
 }

--- a/daemon/networkdriver/ipallocator/allocator_test.go
+++ b/daemon/networkdriver/ipallocator/allocator_test.go
@@ -128,18 +128,27 @@ func TestIPAllocator(t *testing.T) {
 		0: net.IPv4(127, 0, 0, 2),
 		1: net.IPv4(127, 0, 0, 3),
 		2: net.IPv4(127, 0, 0, 4),
-		3: net.IPv4(127, 0, 0, 5),
-		4: net.IPv4(127, 0, 0, 6),
+		3: net.IPv4(127, 0, 0, 6),
+		4: net.IPv4(127, 0, 0, 7),
 	}
+	expectedStaticIP := net.IPv4(127, 0, 0, 5)
 
 	gwIP, n, _ := net.ParseCIDR("127.0.0.1/29")
 	network := &net.IPNet{IP: gwIP, Mask: n.Mask}
 	// Pool after initialisation (f = free, u = used)
-	// 2(f) - 3(f) - 4(f) - 5(f) - 6(f)
+	// 2(f) - 3(f) - 4(f) - 5(f) - 6(f) - 7(f)
 	//  ↑
 
-	// Check that we get 5 IPs, from 127.0.0.2–127.0.0.6, in that
-	// order.
+	// Allocate a pre-determined IP.
+	// 2(f) - 3(f) - 4(f) - 5(u) - 6(f) - 7(f)
+	//  ↑
+	if ip, err := RequestIP(network, expectedStatic); err != nil {
+		t.Fatal(err)
+	}
+	assertIPEquals(t, expectedStatic, ip)
+
+	// Check that we get 5 IPs, from 127.0.0.2–127.0.0.7, in that
+	// order, skipping 127.0.0.5
 	for i := 0; i < 5; i++ {
 		ip, err := RequestIP(network, nil)
 		if err != nil {
@@ -149,27 +158,27 @@ func TestIPAllocator(t *testing.T) {
 		assertIPEquals(t, &expectedIPs[i], ip)
 	}
 	// Before loop begin
-	// 2(f) - 3(f) - 4(f) - 5(f) - 6(f)
+	// 2(f) - 3(f) - 4(f) - 5(u) - 6(f) - 7(f)
 	//  ↑
 
 	// After i = 0
-	// 2(u) - 3(f) - 4(f) - 5(f) - 6(f)
+	// 2(u) - 3(f) - 4(f) - 5(u) - 6(f) - 7(f)
 	//         ↑
 
 	// After i = 1
-	// 2(u) - 3(u) - 4(f) - 5(f) - 6(f)
+	// 2(u) - 3(u) - 4(f) - 5(u) - 6(f) - 7(f)
 	//                ↑
 
 	// After i = 2
-	// 2(u) - 3(u) - 4(u) - 5(f) - 6(f)
-	//                       ↑
-
-	// After i = 3
-	// 2(u) - 3(u) - 4(u) - 5(u) - 6(f)
+	// 2(u) - 3(u) - 4(u) - 5(u) - 6(f) - 7(f)
 	//                              ↑
 
+	// After i = 3
+	// 2(u) - 3(u) - 4(u) - 5(u) - 6(u) - 7(f)
+	//                                     ↑
+
 	// After i = 4
-	// 2(u) - 3(u) - 4(u) - 5(u) - 6(u)
+	// 2(u) - 3(u) - 4(u) - 5(u) - 6(u) - 7(u)
 	//  ↑
 
 	// Check that there are no more IPs
@@ -182,25 +191,30 @@ func TestIPAllocator(t *testing.T) {
 	if err := ReleaseIP(network, &expectedIPs[3]); err != nil {
 		t.Fatal(err)
 	}
-	// 2(u) - 3(u) - 4(u) - 5(f) - 6(u)
-	//                       ↑
+	// 2(u) - 3(u) - 4(u) - 5(u) - 6(f) - 7(u)
+	//  ↑
 
 	if err := ReleaseIP(network, &expectedIPs[2]); err != nil {
 		t.Fatal(err)
 	}
-	// 2(u) - 3(u) - 4(f) - 5(f) - 6(u)
-	//                       ↑
+	// 2(u) - 3(u) - 4(f) - 5(u) - 6(f) - 7(u)
+	//  ↑
 
 	if err := ReleaseIP(network, &expectedIPs[4]); err != nil {
 		t.Fatal(err)
 	}
-	// 2(u) - 3(u) - 4(f) - 5(f) - 6(f)
-	//                       ↑
+	// 2(u) - 3(u) - 4(f) - 5(u) - 6(f) - 7(f)
+	//  ↑
+	if err := ReleaseIP(network, &expectedStaticIP); err != nil {
+		t.Fatal(err)
+	}
+	// 2(u) - 3(u) - 4(f) - 5(f) - 6(f) - 7(f)
+	//  ↑
 
 	// Make sure that IPs are reused in sequential order, starting
 	// with the first released IP
 	newIPs := make([]*net.IP, 3)
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		ip, err := RequestIP(network, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -209,8 +223,9 @@ func TestIPAllocator(t *testing.T) {
 		newIPs[i] = ip
 	}
 	assertIPEquals(t, &expectedIPs[2], newIPs[0])
-	assertIPEquals(t, &expectedIPs[3], newIPs[1])
-	assertIPEquals(t, &expectedIPs[4], newIPs[2])
+	assertIPEquals(t, &expectedStaticIP, newIPs[1])
+	assertIPEquals(t, &expectedIPs[3], newIPs[2])
+	assertIPEquals(t, &expectedIPs[4], newIPs[3])
 
 	_, err = RequestIP(network, nil)
 	if err == nil {

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -101,6 +101,9 @@ Finally, several networking options can only be provided when calling
  *  `--net=bridge|none|container:NAME_or_ID|host` — see
     [How Docker networks a container](#container-networking)
 
+ *  `--ip=IP_RANGE` — see
+    [How Docker networks a container](#container-networking)
+
  *  `-p SPEC` or `--publish=SPEC` — see
     [Binding container ports](#binding-ports)
 
@@ -523,8 +526,9 @@ The steps with which Docker configures a container are:
     physical interfaces with which this name could collide.
 
 4.  Give the container's `eth0` a new IP address from within the
-    bridge's range of network addresses, and set its default route to
-    the IP address that the Docker host owns on the bridge.
+    bridge's range of network addresses, potentially restricted by the
+    `--ip` run flag, and set its default route to the IP address that the
+    Docker host owns on the bridge.
 
 With these steps complete, the container now possesses an `eth0`
 (virtual) network card and will find itself able to communicate with
@@ -612,6 +616,20 @@ Docker do all of the configuration:
 
 At this point your container should be able to perform networking
 operations as usual.
+
+As mentioned briefly above, `docker run` accepts a `--ip` flag which
+limits the IP pool Docker will use to pick the container's IP address
+from. The value can either be a single IP, or a range specified in CIDR
+notation.  
+For example, the following command would result in Docker using
+`172.17.42.16` through `172.17.42.19` (inclusive) when looking for an
+address to assign to the container:
+
+    $ sudo docker run --ip=172.17.42.16/30 ubuntu bash
+
+Note that the IP range must be within the `docker0` bridge subnet.
+If there is no overlap between the subnet and the provided range, the
+allocator will fail to find an address, and the container will not start.
 
 When you finally exit the shell and Docker cleans up the container, the
 network namespace is destroyed along with our virtual `eth0` — whose

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -978,6 +978,7 @@ removed before the image is removed.
       --expose=[]                Expose a port from the container without publishing it to your host
       -h, --hostname=""          Container host name
       -i, --interactive=false    Keep STDIN open even if not attached
+      --ip=""                    Restrict the IP range used to pick the container IP address from
       --link=[]                  Add link to another container in the form of name:alias
       --lxc-conf=[]              (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
       -m, --memory=""            Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
@@ -1133,8 +1134,26 @@ An example of a file passed with `--env-file`
 
     $ sudo docker run --name console -t -i ubuntu bash
 
-This will create and run a new container with the container name being
-`console`.
+The `--ip` flag lets you restrict the range of IPs docker will pick from when
+determining what IP to allocate to a new container. This can be a single IP,
+or a range specified in CIDR notation.
+
+Note that the address (range) specified must be within Docker's subnet. If it
+isn't, the allocator will not be able to find a suitable IP address, and the
+container will fail to start.  
+This also does not change the subnet that the container will be assigned, only
+the IP address. The container will still receive the default Docker subnet.
+
+Example usage:
+
+    $ sudo docker run --ip 172.17.200.10 ubuntu bash
+
+    $ sudo docker run --ip 172.17.200.10/32 ubuntu bash
+
+    $ sudo docker run --ip 172.17.200.0/24 ubuntu bash
+
+The `--name` flag will create and run a new container with the provided name.  
+The following example will start a container named `console`.
 
     $ sudo docker run --link /redis:redis --name console ubuntu bash
 

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -32,7 +32,7 @@ type Config struct {
 	WorkingDir      string
 	Entrypoint      []string
 	NetworkDisabled bool
-	OnBuild         []string	
+	OnBuild         []string
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -11,6 +11,7 @@ import (
 type Config struct {
 	Hostname        string
 	Domainname      string
+	IP              string
 	User            string
 	Memory          int64  // Memory limit (in bytes)
 	MemorySwap      int64  // Total memory usage (memory + swap); set `-1' to disable swap
@@ -31,13 +32,14 @@ type Config struct {
 	WorkingDir      string
 	Entrypoint      []string
 	NetworkDisabled bool
-	OnBuild         []string
+	OnBuild         []string	
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {
 	config := &Config{
 		Hostname:        job.Getenv("Hostname"),
 		Domainname:      job.Getenv("Domainname"),
+		IP:              job.Getenv("IP"),
 		User:            job.Getenv("User"),
 		Memory:          job.GetenvInt64("Memory"),
 		MemorySwap:      job.GetenvInt64("MemorySwap"),

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -37,7 +37,7 @@ func TestParseRunIP(t *testing.T) {
 	if _, hostConfig := mustParse(t, ""); len(hostConfig.IP) > 0 {
 		t.Fatalf("Config must not contain an IP address when none is specified in the input")
 	}
-	if _, hostConfig := mustParse(t, "--ip 1.2.3"); len(hostConfig.IP) > 0 {
+	if _, hostConfig, err := parse(t, "--ip 1.2.3"); err == nil {
 		t.Fatalf("Expected failure but instead received ip: %v", hostConfig.IP)
 	}
 

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -19,6 +19,19 @@ func mustParse(t *testing.T, args string) (*Config, *HostConfig) {
 	return config, hostConfig
 }
 
+func TestParseRunIP(t *testing.T) {
+	if _, hostConfig := mustParse(t, ""); len(hostConfig.IP) > 0 {
+		t.Fatalf("Config must not contain an IP address when none is specified in the input")
+	}
+	if _, hostConfig := mustParse(t, "--ip 1.2.3"); len(hostConfig.IP) > 0 {
+		t.Fatalf("Expected failure but instead received ip: %v", hostConfig.IP)
+	}
+
+	if _, hostConfig := mustParse(t, "--ip 1.2.3.4"); len(hostConfig.IP) == 0 || hostConfig.IP != "1.2.3.4" {
+		t.Fatalf("Error parsing IP address. Expected []string{\"1.2.3.4\"}, recieved: %v", hostConfig.IP)
+	}
+}
+
 func TestParseRunLinks(t *testing.T) {
 	if _, hostConfig := mustParse(t, "--link a:b"); len(hostConfig.Links) == 0 || hostConfig.Links[0] != "a:b" {
 		t.Fatalf("Error parsing links. Expected []string{\"a:b\"}, received: %v", hostConfig.Links)

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -35,6 +35,7 @@ type HostConfig struct {
 	ContainerIDFile string
 	LxcConf         []utils.KeyValuePair
 	Privileged      bool
+	IP              string
 	PortBindings    nat.PortMap
 	Links           []string
 	PublishAllPorts bool
@@ -54,6 +55,7 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 		Privileged:      job.GetenvBool("Privileged"),
 		PublishAllPorts: job.GetenvBool("PublishAllPorts"),
 		NetworkMode:     NetworkMode(job.Getenv("NetworkMode")),
+		IP:              job.Getenv("IP"),
 	}
 
 	job.GetenvJson("LxcConf", &hostConfig.LxcConf)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -3,6 +3,7 @@ package runconfig
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"path"
 	"strings"
 
@@ -65,6 +66,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flWorkingDir      = cmd.String([]string{"w", "-workdir"}, "", "Working directory inside the container")
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
+		flIP              = cmd.String([]string{"ip", "-ip"}, "", "IP address for the container. If not specified, and networking is enabled for the container, docker will automatically assign an IP.")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the contaner")
 		// For documentation purpose
 		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify all received signal to the process (even in non-tty mode)")
@@ -99,7 +101,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	}
 	if *flWorkingDir != "" && !path.IsAbs(*flWorkingDir) {
 		return nil, nil, cmd, ErrInvalidWorkingDirectory
-	}
+	}	
 	if *flDetach && *flAutoRemove {
 		return nil, nil, cmd, ErrConflictDetachAutoRemove
 	}
@@ -210,9 +212,16 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		return nil, nil, cmd, fmt.Errorf("--net: invalid net mode: %v", err)
 	}
 
+	if *flIP != "" {
+		if parsedIP := net.ParseIP(*flIP); parsedIP == nil {
+			return nil, nil, cmd, fmt.Errorf("--ip: invalid ip: %s", *flIP)
+		}
+	}
+
 	config := &Config{
 		Hostname:        hostname,
 		Domainname:      domainname,
+		IP:              *flIP,
 		PortSpecs:       nil, // Deprecated
 		ExposedPorts:    ports,
 		User:            *flUser,

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -66,7 +66,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flWorkingDir      = cmd.String([]string{"w", "-workdir"}, "", "Working directory inside the container")
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
-		flIP              = cmd.String([]string{"ip", "-ip"}, "", "IP address for the container. If not specified, and networking is enabled for the container, docker will automatically assign an IP.")
+		flIP              = cmd.String([]string{"ip", "-ip"}, "", "Optional IP address for the container. The IP must be from the docker bridge interface subnet.")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the contaner")
 		// For documentation purpose
 		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxify all received signal to the process (even in non-tty mode)")
@@ -101,7 +101,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	}
 	if *flWorkingDir != "" && !path.IsAbs(*flWorkingDir) {
 		return nil, nil, cmd, ErrInvalidWorkingDirectory
-	}	
+	}
 	if *flDetach && *flAutoRemove {
 		return nil, nil, cmd, ErrConflictDetachAutoRemove
 	}

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -237,8 +237,11 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 	}
 
 	if *flIP != "" {
-		if parsedIP := net.ParseIP(*flIP); parsedIP == nil {
-			return nil, nil, cmd, fmt.Errorf("--ip: invalid ip: %s", *flIP)
+		_, _, err := net.ParseCIDR(*flIP) // first see if it's a CIDR
+		if err != nil {
+			if parsedIP := net.ParseIP(*flIP); parsedIP == nil { // see if it's a plain addr instead
+				return nil, nil, cmd, fmt.Errorf("--ip: invalid ip: %s", *flIP)
+			}
 		}
 	}
 
@@ -280,6 +283,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		ContainerIDFile: *flContainerIDFile,
 		LxcConf:         lxcConf,
 		Privileged:      *flPrivileged,
+		IP:              *flIP,
 		PortBindings:    portBindings,
 		Links:           flLinks.GetAll(),
 		PublishAllPorts: *flPublishAll,


### PR DESCRIPTION
This is an extension of PR #5829. This PR allows passing a range of addresses to `docker run` for the IP allocator to pick an address from.

Example usage:

```
docker run --ip 172.42.44.10 myimage
docker run --ip 172.42.44.10/32 myimage
docker run --ip 172.42.44.0/24 myimage
```

This obsoletes #5829 as you can pass a specific IP in addition to a subnet/range.

I haven't added anything in the way of documentation. I wanted to put this out in its current form and make requested changes first.

---

The purpose of this PR is for multi-tenant solutions, where you have multiple products or customers running on a docker host, and you want to be able to add firewall rules per customer. With this, when starting a customer's container, you could pass a subnet, and ensure that their container gets an IP that will be properly matched by a firewall rule or routing policy.

---

_Related: #2801 #6743_
