### PR TITLE
Container name lookups to prefer IDs over names

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -138,16 +138,13 @@ func (daemon *Daemon) Install(eng *engine.Engine) error {
 // Get looks for a container by the specified ID or name, and returns it.
 // If the container is not found, or if an error occurs, nil is returned.
 func (daemon *Daemon) Get(name string) *Container {
+	if id, err := daemon.idIndex.Get(name); err == nil {
+		return daemon.containers.Get(id)
+	}
 	if c, _ := daemon.GetByName(name); c != nil {
 		return c
 	}
-
-	id, err := daemon.idIndex.Get(name)
-	if err != nil {
-		return nil
-	}
-
-	return daemon.containers.Get(id)
+	return nil
 }
 
 // Exists returns a true if a container of the specified ID or name exists,


### PR DESCRIPTION
Lookups of container names should prefer the ID over
names assigned to containers by users.

Signed-off-by: Eric Windisch eric@windisch.us
