### PR TITLE
Save "META" field in Dockerfile into image content.

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1080,7 +1080,8 @@ func (cli *DockerCli) CmdKill(args ...string) error {
 }
 
 func (cli *DockerCli) CmdImport(args ...string) error {
-	cmd := cli.Subcmd("import", "URL|- [REPOSITORY[:TAG]]", "Create an empty filesystem image and import the contents of the tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then optionally tag it.")
+	cmd := cli.Subcmd("import", "URL|- [OPTIONS] [REPOSITORY[:TAG]]", "Create an empty filesystem image and import the contents of the tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then optionally tag it.")
+	flMeta := cmd.String([]string{"#META", "-meta"}, "", "Meta data about the image, must be specified in JSON format")
 
 	if err := cmd.Parse(args); err != nil {
 		return nil
@@ -1098,6 +1099,7 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 
 	v.Set("fromSrc", src)
 	v.Set("repo", repository)
+	v.Set("meta", *flMeta)
 
 	if cmd.NArg() == 3 {
 		fmt.Fprintf(cli.err, "[DEPRECATED] The format 'URL|- [REPOSITORY [TAG]]' as been deprecated. Please use URL|- [REPOSITORY[:TAG]]\n")
@@ -1640,6 +1642,7 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	cmd := cli.Subcmd("commit", "CONTAINER [REPOSITORY[:TAG]]", "Create a new image from a container's changes")
 	flPause := cmd.Bool([]string{"p", "-pause"}, true, "Pause container during commit")
 	flComment := cmd.String([]string{"m", "-message"}, "", "Commit message")
+	flMeta := cmd.String([]string{"#META", "-meta"}, "", "Meta data about the image, must be specified in JSON format")
 	flAuthor := cmd.String([]string{"a", "#author", "-author"}, "", "Author (e.g., \"John Hannibal Smith <hannibal@a-team.com>\")")
 	// FIXME: --run is deprecated, it will be replaced with inline Dockerfile commands.
 	flConfig := cmd.String([]string{"#run", "#-run"}, "", "This option is deprecated and will be removed in a future version in favor of inline Dockerfile-compatible commands")
@@ -1663,12 +1666,12 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 			return err
 		}
 	}
-
 	v := url.Values{}
 	v.Set("container", name)
 	v.Set("repo", repository)
 	v.Set("tag", tag)
 	v.Set("comment", *flComment)
+	v.Set("meta", *flMeta)
 	v.Set("author", *flAuthor)
 
 	if *flPause != true {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/engine"
+	images "github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/listenbuffer"
 	"github.com/docker/docker/pkg/log"
 	"github.com/docker/docker/pkg/parsers"
@@ -495,6 +496,7 @@ func postImagesCreate(eng *engine.Engine, version version.Version, w http.Respon
 
 	var (
 		image = r.Form.Get("fromImage")
+		meta  images.MetaData
 		repo  = r.Form.Get("repo")
 		tag   = r.Form.Get("tag")
 		job   *engine.Job
@@ -528,6 +530,13 @@ func postImagesCreate(eng *engine.Engine, version version.Version, w http.Respon
 			repo, tag = parsers.ParseRepositoryTag(repo)
 		}
 		job = eng.Job("import", r.Form.Get("fromSrc"), repo, tag)
+
+		if r.Form.Get("meta") != "" {
+			if err := json.Unmarshal([]byte(r.Form.Get("meta")), &meta); err != nil {
+				return fmt.Errorf("META Data must be specified in valid json format: %s", err)
+			}
+			job.SetenvJson("meta", meta)
+		}
 		job.Stdin.Add(r.Body)
 	}
 

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -8,6 +8,7 @@ package builder
 // package.
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -58,6 +59,21 @@ func maintainer(b *Builder, args []string, attributes map[string]bool, original 
 
 	b.maintainer = args[0]
 	return b.commit("", b.Config.Cmd, fmt.Sprintf("MAINTAINER %s", b.maintainer))
+}
+
+// META some json data describing the image
+//
+// Sets the image metadata.
+func meta(b *Builder, args []string, attributes map[string]bool, original string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("META requires only one argument")
+	}
+	meta := args[0]
+	if err := json.Unmarshal([]byte(meta), &b.meta); err != nil {
+		return fmt.Errorf("META Data must be specified in valid json format: %s", err)
+	}
+
+	return b.commit("", b.Config.Cmd, fmt.Sprintf("META %s", meta))
 }
 
 // ADD foo /path

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/docker/builder/parser"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/engine"
+	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/log"
 	"github.com/docker/docker/pkg/tarsum"
 	"github.com/docker/docker/registry"
@@ -47,6 +48,7 @@ func init() {
 	evaluateTable = map[string]func(*Builder, []string, map[string]bool, string) error{
 		"env":        env,
 		"maintainer": maintainer,
+		"meta":       meta,
 		"add":        add,
 		"copy":       dispatchCopy, // copy() is a go builtin
 		"from":       from,
@@ -92,12 +94,13 @@ type Builder struct {
 	// both of these are controlled by the Remove and ForceRemove options in BuildOpts
 	TmpContainers map[string]struct{} // a map of containers used for removes
 
-	dockerfile  *parser.Node  // the syntax tree of the dockerfile
-	image       string        // image name for commit processing
-	maintainer  string        // maintainer name. could probably be removed.
-	cmdSet      bool          // indicates is CMD was set in current Dockerfile
-	context     tarsum.TarSum // the context is a tarball that is uploaded by the client
-	contextPath string        // the path of the temporary directory the local context is unpacked to (server side)
+	dockerfile  *parser.Node   // the syntax tree of the dockerfile
+	image       string         // image name for commit processing
+	maintainer  string         // maintainer name. could probably be removed.
+	meta        image.MetaData // meta data about the image. Json format data descibing the image.
+	cmdSet      bool           // indicates is CMD was set in current Dockerfile
+	context     tarsum.TarSum  // the context is a tarball that is uploaded by the client
+	contextPath string         // the path of the temporary directory the local context is unpacked to (server side)
 
 }
 

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -92,7 +92,7 @@ func (b *Builder) commit(id string, autoCmd []string, comment string) error {
 	autoConfig.Cmd = autoCmd
 
 	// Commit the container
-	image, err := b.Daemon.Commit(container, "", "", "", b.maintainer, true, &autoConfig)
+	image, err := b.Daemon.Commit(container, "", "", "", b.maintainer, true, &autoConfig, &b.meta)
 	if err != nil {
 		return err
 	}

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -49,6 +49,7 @@ func init() {
 		"workdir":    parseString,
 		"env":        parseEnv,
 		"maintainer": parseString,
+		"meta":       parseMaybeJSON,
 		"from":       parseString,
 		"add":        parseStringsWhitespaceDelimited,
 		"copy":       parseStringsWhitespaceDelimited,

--- a/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
+++ b/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
@@ -12,7 +12,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>^\s*(ONBUILD\s+)?(FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|USER|WORKDIR|COPY)\s</string>
+			<string>^\s*(ONBUILD\s+)?(FROM|MAINTAINER|META|RUN|EXPOSE|ENV|ADD|VOLUME|USER|WORKDIR|COPY)\s</string>
 			<key>captures</key>
 			<dict>
 				<key>0</key>

--- a/contrib/syntax/vim/syntax/dockerfile.vim
+++ b/contrib/syntax/vim/syntax/dockerfile.vim
@@ -11,7 +11,7 @@ let b:current_syntax = "dockerfile"
 
 syntax case ignore
 
-syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|VOLUME|WORKDIR|COPY)\s/
+syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|META|RUN|USER|VOLUME|WORKDIR|COPY)\s/
 highlight link dockerfileKeyword Keyword
 
 syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/

--- a/docs/man/Dockerfile.5.md
+++ b/docs/man/Dockerfile.5.md
@@ -110,6 +110,15 @@ or
   executes nothing at build time, but specifies the intended command for the
   image.
 
+**META**
+ --The `META` instruction allows you to describe the image your Dockerfile
+is building. META Data has to be specified in the JSON format.  This data can 
+be retrieved using the docker inspect command
+
+META { "Description" : "This image is used to start the foobar executable", \
+       "vendor" : "ACME Products", \
+       "Version" : "1.0" }
+
 **EXPOSE**
  --**EXPOSE <port> [<port>...]**
  The **EXPOSE** instruction informs Docker that the container listens on the

--- a/docs/man/docker-commit.1.md
+++ b/docs/man/docker-commit.1.md
@@ -8,6 +8,7 @@ docker-commit - Create a new image from a container's changes
 **docker commit**
 [**-a**|**--author**[=*AUTHOR*]]
 [**-m**|**--message**[=*MESSAGE*]]
+[**--meta**[=*JSONMETADATA*]]
 [**-p**|**--pause**[=*true*]]
  CONTAINER [REPOSITORY[:TAG]]
 
@@ -21,6 +22,9 @@ Using an existing container's name or ID you can create a new image.
 **-m**, **--message**=""
    Commit message
 
+**--meta**=""
+   META data about the image, must be specified in json format
+
 **-p**, **--pause**=*true*|*false*
    Pause container during commit. The default is *true*.
 
@@ -32,6 +36,7 @@ in interactive mode with the bash shell. Apache is also running. To
 create a new image run docker ps to find the container's ID and then run:
 
     # docker commit -m="Added Apache to Fedora base image" \
+      --meta '{ "Application" : "Apache", "Version" : "2.0" }' \
       -a="A D Ministrator" 98bd7fc99854 fedora/fedora_httpd:20
 
 # HISTORY

--- a/docs/man/docker-import.1.md
+++ b/docs/man/docker-import.1.md
@@ -6,6 +6,7 @@ docker-import - Create an empty filesystem image and import the contents of the 
 
 # SYNOPSIS
 **docker import**
+[**--meta**[=*JSONMETADATA*]]
 URL|- [REPOSITORY[:TAG]]
 
 # DESCRIPTION
@@ -13,7 +14,8 @@ Create a new filesystem image from the contents of a tarball (`.tar`,
 `.tar.gz`, `.tgz`, `.bzip`, `.tar.xz`, `.txz`) into it, then optionally tag it.
 
 # OPTIONS
-There are no available options.
+**--meta**=""
+   META data about the image, must be specified in json format
 
 # EXAMPLES
 
@@ -32,6 +34,12 @@ Import to docker via pipe and stdin:
 Import to docker via pipe and stdin:
 
     # cat exampleimageV2.tgz | docker import - example/imagelocal:V-2.0
+
+Import to docker via pipe and stdin:
+
+    # cat exampleimageV2.tgz | docker import \
+      --meta '{ "Application" : "example", "Version" : "2.0" }' \
+      - example/imagelocal:V-2.0
 
 ## Import from a local directory
 

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -280,6 +280,22 @@ default specified in `CMD`.
 > the result; `CMD` does not execute anything at build time, but specifies
 > the intended command for the image.
 
+## META
+   META [JSON]
+
+ --The `META` instruction allows you to describe the image your Dockerfile
+is building. META Data has to be specified in the JSON format. This data can 
+be retrieved using the docker inspect command
+
+
+META { "Description" : "This image is used to start the foobar executable", \
+       "vendor" : "ACME Products", \
+       "Version" : "1.0" }
+
+This is yielded from the API as well; from the output of `docker inspect [IMAGE]`,
+in the "Config" section, there is a "Description" element that corresponds to 
+this string.
+
 ## EXPOSE
 
     EXPOSE <port> [<port>...]
@@ -631,6 +647,10 @@ For example you might add something like this:
 
     FROM      ubuntu
     MAINTAINER Victor Vieux <victor@docker.com>
+
+    META { "Description" : "This image is used to start the foobar executable", \
+    	    "vendor" : "ACME Products", \
+   	    "Version" : "1.0" }
 
     RUN apt-get update && apt-get install -y inotify-tools nginx apache2 openssh-server
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -438,6 +438,7 @@ schema.
 
       -a, --author=""     Author (e.g., "John Hannibal Smith <hannibal@a-team.com>")
       -m, --message=""    Commit message
+      --meta=             META data about the image, must be specified in json format
       -p, --pause=true    Pause container during commit
 
 It can be useful to commit a container's file changes or settings into a
@@ -764,7 +765,7 @@ NOTE: Docker will warn you if any containers exist that are using these untagged
 
 ## import
 
-    Usage: docker import URL|- [REPOSITORY[:TAG]]
+    Usage: docker import [OPTIONS] URL|- [REPOSITORY[:TAG]]
 
     Create an empty filesystem image and import the contents of the tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then optionally tag it.
 
@@ -772,6 +773,8 @@ URLs must start with `http` and point to a single file archive (.tar,
 .tar.gz, .tgz, .bzip, .tar.xz, or .txz) containing a root filesystem. If
 you would like to import from a local directory or archive, you can use
 the `-` parameter to take the data from `STDIN`.
+
+      --meta=             META data about the image, must be specified in json format
 
 #### Examples
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -114,10 +114,11 @@ func (graph *Graph) Get(name string) (*image.Image, error) {
 }
 
 // Create creates a new image and registers it in the graph.
-func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, containerImage, comment, author string, containerConfig, config *runconfig.Config) (*image.Image, error) {
+func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, containerImage, comment, author string, containerConfig, config *runconfig.Config, meta *image.MetaData) (*image.Image, error) {
 	img := &image.Image{
 		ID:            utils.GenerateRandomID(),
 		Comment:       comment,
+		Meta:          meta,
 		Created:       time.Now().UTC(),
 		DockerVersion: dockerversion.VERSION,
 		Author:        author,

--- a/graph/import.go
+++ b/graph/import.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/docker/docker/engine"
+	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/utils"
 )
@@ -20,6 +21,7 @@ func (s *TagStore) CmdImport(job *engine.Job) engine.Status {
 		sf      = utils.NewStreamFormatter(job.GetenvBool("json"))
 		archive archive.ArchiveReader
 		resp    *http.Response
+		meta    *image.MetaData
 	)
 	if len(job.Args) > 2 {
 		tag = job.Args[2]
@@ -46,7 +48,9 @@ func (s *TagStore) CmdImport(job *engine.Job) engine.Status {
 		defer progressReader.Close()
 		archive = progressReader
 	}
-	img, err := s.graph.Create(archive, "", "", "Imported from "+src, "", nil, nil)
+	job.GetenvJson("meta", &meta)
+
+	img, err := s.graph.Create(archive, "", "", "Imported from "+src, "", nil, nil, meta)
 	if err != nil {
 		return job.Error(err)
 	}

--- a/graph/service.go
+++ b/graph/service.go
@@ -110,6 +110,7 @@ func (s *TagStore) CmdGet(job *engine.Job) engine.Status {
 		//		generic description field which it isn't. On deprecation shortlist.
 		res.SetAuto("Created", img.Created)
 		res.Set("Author", img.Author)
+		res.SetJson("Meta", img.Meta)
 		res.Set("Os", img.OS)
 		res.Set("Architecture", img.Architecture)
 		res.Set("DockerVersion", img.DockerVersion)
@@ -140,6 +141,7 @@ func (s *TagStore) CmdLookup(job *engine.Job) engine.Status {
 		out.Set("Id", image.ID)
 		out.Set("Parent", image.Parent)
 		out.Set("Comment", image.Comment)
+		out.SetJson("Meta", image.Meta)
 		out.SetAuto("Created", image.Created)
 		out.Set("Container", image.Container)
 		out.SetJson("ContainerConfig", image.ContainerConfig)

--- a/image/image.go
+++ b/image/image.go
@@ -20,10 +20,13 @@ import (
 // For more information see: http://sourceforge.net/p/aufs/aufs3-standalone/ci/aufs3.12/tree/config.mk
 const MaxImageDepth = 127
 
+type MetaData map[string]string
+
 type Image struct {
 	ID              string            `json:"id"`
 	Parent          string            `json:"parent,omitempty"`
 	Comment         string            `json:"comment,omitempty"`
+	Meta            *MetaData         `json:"meta,omitempty"`
 	Created         time.Time         `json:"created"`
 	Container       string            `json:"container,omitempty"`
 	ContainerConfig runconfig.Config  `json:"container_config,omitempty"`

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -15,6 +15,39 @@ import (
 	"github.com/docker/docker/pkg/archive"
 )
 
+func TestBuildMeta(t *testing.T) {
+	var (
+		result map[string]string
+		name   = "testbuildmeta"
+		value  = "Hello, is there anyone in there?"
+	)
+	defer deleteImages(name)
+	meta := fmt.Sprintf("{ \"%s\" : \"%s\" }", name, value)
+
+	_, err := buildImage(name, fmt.Sprintf(`
+FROM busybox
+META %s
+`, meta), true)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := inspectFieldJSON(name, "Meta")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = unmarshalJSON([]byte(res), &result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result[name] != value {
+		t.Fatal("Meta did not match the one provided.", result)
+	}
+}
+
 func TestBuildOnBuildLowercase(t *testing.T) {
 	name := "testbuildonbuildlowercase"
 	name2 := "testbuildonbuildlowercase2"

--- a/integration/graph_test.go
+++ b/integration/graph_test.go
@@ -25,7 +25,7 @@ func TestMount(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	image, err := graph.Create(archive, "", "", "Testing", "", nil, nil)
+	image, err := graph.Create(archive, "", "", "Testing", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestGraphCreate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	img, err := graph.Create(archive, "", "", "Testing", "", nil, nil)
+	img, err := graph.Create(archive, "", "", "Testing", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -170,7 +170,7 @@ func createTestImage(graph *graph.Graph, t *testing.T) *image.Image {
 	if err != nil {
 		t.Fatal(err)
 	}
-	img, err := graph.Create(archive, "", "", "Test image", "", nil, nil)
+	img, err := graph.Create(archive, "", "", "Test image", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +185,7 @@ func TestDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	assertNImages(graph, t, 0)
-	img, err := graph.Create(archive, "", "", "Bla bla", "", nil, nil)
+	img, err := graph.Create(archive, "", "", "Bla bla", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +200,7 @@ func TestDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Test 2 create (same name) / 1 delete
-	img1, err := graph.Create(archive, "", "", "Testing", "", nil, nil)
+	img1, err := graph.Create(archive, "", "", "Testing", "", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,7 +208,7 @@ func TestDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err = graph.Create(archive, "", "", "Testing", "", nil, nil); err != nil {
+	if _, err = graph.Create(archive, "", "", "Testing", "", nil, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 	assertNImages(graph, t, 2)

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -331,7 +331,7 @@ func TestDaemonCreate(t *testing.T) {
 	}
 	container, _, err = daemon.Create(config, &runconfig.HostConfig{}, "")
 
-	_, err = daemon.Commit(container, "testrepo", "testtag", "", "", true, config)
+	_, err = daemon.Commit(container, "testrepo", "testtag", "", "", true, config, nil)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
This will allow a user to save META data into an image, which
can later be retrieved using:

docker inspect IMAGEID

I have copied this from the "Comment" handling in docker images.

We want to be able to add json data to an image to describe the image, and
then be able to use other tools to look at this data, to be able to do
security checks based on this data.

We are thinking about adding version names, Perhaps listing the content of the dockerfile.
Descriptions of where the code came from etc.

One option is to call this flag Meta, another would be to call it Vendor.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
