### PR TITLE
Keep ADD in the official Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,4 +101,4 @@ ENV	DOCKER_BUILDTAGS	apparmor selinux
 ENTRYPOINT	["hack/dind"]
 
 # Upload docker source
-COPY	.	/go/src/github.com/docker/docker
+ADD .	/go/src/github.com/docker/docker


### PR DESCRIPTION
This allows building docker on Docker 0.11 and earlier. There is no
reason to stop using ADD here, since the behavior is the same between
COPY and ADD when the source is a local directory.

Signed-off-by: Solomon Hykes solomon@docker.com
