### PR TITLE
Fix several minor issues with Debian sysvinit script

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 ### BEGIN INIT INFO
 # Provides:           docker
@@ -130,7 +131,7 @@ case "$1" in
 		;;
 
 	status)
-		status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DOCKER" docker
+		status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DOCKER" "$DOCKER_DESC"
 		;;
 
 	*)
@@ -138,5 +139,3 @@ case "$1" in
 		exit 1
 		;;
 esac
-
-exit 0


### PR DESCRIPTION
- add `set -e` to make failing commands bail the script
- remove trailing `exit 0` which is just extraneous anyhow
- adjust `status_of_proc` options to pass in `$DOCKER_DESC` so we get consistently styled messages like `Docker is running` or `Docker is not running` or `could not access PID file for Docker`

Fixes #7424
Closes #7177
