### PR TITLE
Extract error related structs and funcs into errorutils

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -28,6 +28,7 @@ import (
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/nat"
 	"github.com/docker/docker/opts"
+	"github.com/docker/docker/pkg/errorutils"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/parsers/filters"
 	"github.com/docker/docker/pkg/signal"
@@ -242,12 +243,12 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		headers.Set("Content-Type", "application/tar")
 	}
 	err = cli.stream("POST", fmt.Sprintf("/build?%s", v.Encode()), body, cli.out, headers)
-	if jerr, ok := err.(*utils.JSONError); ok {
+	if jerr, ok := err.(*errorutils.JSONError); ok {
 		// If no error code is set, default to 1
 		if jerr.Code == 0 {
 			jerr.Code = 1
 		}
-		return &utils.StatusError{Status: jerr.Message, StatusCode: jerr.Code}
+		return &errorutils.StatusError{Status: jerr.Message, StatusCode: jerr.Code}
 	}
 	return err
 }
@@ -763,7 +764,7 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 		var err error
 		if tmpl, err = template.New("").Funcs(funcMap).Parse(*tmplStr); err != nil {
 			fmt.Fprintf(cli.err, "Template parsing error: %v\n", err)
-			return &utils.StatusError{StatusCode: 64,
+			return &errorutils.StatusError{StatusCode: 64,
 				Status: "Template parsing error: " + err.Error()}
 		}
 	}
@@ -822,7 +823,7 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 	}
 
 	if status != 0 {
-		return &utils.StatusError{StatusCode: status}
+		return &errorutils.StatusError{StatusCode: status}
 	}
 	return nil
 }
@@ -1839,7 +1840,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 		return err
 	}
 	if status != 0 {
-		return &utils.StatusError{StatusCode: status}
+		return &errorutils.StatusError{StatusCode: status}
 	}
 
 	return nil
@@ -2189,7 +2190,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		}
 	}
 	if status != 0 {
-		return &utils.StatusError{StatusCode: status}
+		return &errorutils.StatusError{StatusCode: status}
 	}
 	return nil
 }

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/nat"
+	"github.com/docker/docker/pkg/errorutils"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/pkg/system"
@@ -715,7 +716,7 @@ func (b *buildFile) run(c *daemon.Container) error {
 
 	// Wait for it to finish
 	if ret, _ := c.State.WaitStop(-1 * time.Second); ret != 0 {
-		err := &utils.JSONError{
+		err := &errorutils.JSONError{
 			Message: fmt.Sprintf("The command %v returned a non-zero code: %d", b.config.Cmd, ret),
 			Code:    ret,
 		}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/client"
 	"github.com/docker/docker/dockerversion"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/pkg/errorutils"
 	"github.com/docker/docker/utils"
 )
 
@@ -100,7 +101,7 @@ func main() {
 	}
 
 	if err := cli.ParseCommands(flag.Args()...); err != nil {
-		if sterr, ok := err.(*utils.StatusError); ok {
+		if sterr, ok := err.(*errorutils.StatusError); ok {
 			if sterr.Status != "" {
 				log.Println(sterr.Status)
 			}

--- a/pkg/errorutils/errors.go
+++ b/pkg/errorutils/errors.go
@@ -1,0 +1,32 @@
+package errorutils
+
+import (
+	"net/http"
+	"fmt"
+)
+
+type JSONError struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+func (e *JSONError) Error() string {
+	return e.Message
+}
+
+func NewHTTPRequestError(msg string, res *http.Response) error {
+	return &JSONError{
+		Message: msg,
+		Code:    res.StatusCode,
+	}
+}
+
+// An StatusError reports an unsuccessful exit by a command.
+type StatusError struct {
+	Status     string
+	StatusCode int
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("Status: %s, Code: %d", e.Status, e.StatusCode)
+}

--- a/utils/jsonmessage.go
+++ b/utils/jsonmessage.go
@@ -7,18 +7,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/pkg/errorutils"
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/docker/pkg/units"
 )
-
-type JSONError struct {
-	Code    int    `json:"code,omitempty"`
-	Message string `json:"message,omitempty"`
-}
-
-func (e *JSONError) Error() string {
-	return e.Message
-}
 
 type JSONProgress struct {
 	terminalFd uintptr
@@ -73,15 +65,15 @@ func (p *JSONProgress) String() string {
 }
 
 type JSONMessage struct {
-	Stream          string        `json:"stream,omitempty"`
-	Status          string        `json:"status,omitempty"`
-	Progress        *JSONProgress `json:"progressDetail,omitempty"`
-	ProgressMessage string        `json:"progress,omitempty"` //deprecated
-	ID              string        `json:"id,omitempty"`
-	From            string        `json:"from,omitempty"`
-	Time            int64         `json:"time,omitempty"`
-	Error           *JSONError    `json:"errorDetail,omitempty"`
-	ErrorMessage    string        `json:"error,omitempty"` //deprecated
+	Stream          string                `json:"stream,omitempty"`
+	Status          string                `json:"status,omitempty"`
+	Progress        *JSONProgress         `json:"progressDetail,omitempty"`
+	ProgressMessage string                `json:"progress,omitempty"` //deprecated
+	ID              string                `json:"id,omitempty"`
+	From            string                `json:"from,omitempty"`
+	Time            int64                 `json:"time,omitempty"`
+	Error           *errorutils.JSONError `json:"errorDetail,omitempty"`
+	ErrorMessage    string                `json:"error,omitempty"` //deprecated
 }
 
 func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {

--- a/utils/jsonmessage_test.go
+++ b/utils/jsonmessage_test.go
@@ -2,10 +2,12 @@ package utils
 
 import (
 	"testing"
+
+	"github.com/docker/docker/pkg/errorutils"
 )
 
 func TestError(t *testing.T) {
-	je := JSONError{404, "Not found"}
+	je := errorutils.JSONError{404, "Not found"}
 	if je.Error() != "Not found" {
 		t.Fatalf("Expected 'Not found' got '%s'", je.Error())
 	}

--- a/utils/streamformatter.go
+++ b/utils/streamformatter.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+
+	"github.com/docker/docker/pkg/errorutils"
 )
 
 type StreamFormatter struct {
@@ -43,9 +45,9 @@ func (sf *StreamFormatter) FormatStatus(id, format string, a ...interface{}) []b
 
 func (sf *StreamFormatter) FormatError(err error) []byte {
 	if sf.json {
-		jsonError, ok := err.(*JSONError)
+		jsonError, ok := err.(*errorutils.JSONError)
 		if !ok {
-			jsonError = &JSONError{Message: err.Error()}
+			jsonError = &errorutils.JSONError{Message: err.Error()}
 		}
 		if b, err := json.Marshal(&JSONMessage{Error: jsonError, ErrorMessage: err.Error()}); err == nil {
 			return append(b, streamNewlineBytes...)

--- a/utils/streamformatter_test.go
+++ b/utils/streamformatter_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/docker/docker/pkg/errorutils"
 )
 
 func TestFormatStream(t *testing.T) {
@@ -33,7 +35,7 @@ func TestFormatSimpleError(t *testing.T) {
 
 func TestFormatJSONError(t *testing.T) {
 	sf := NewStreamFormatter(true)
-	err := &JSONError{Code: 50, Message: "Json error"}
+	err := &errorutils.JSONError{Code: 50, Message: "Json error"}
 	res := sf.FormatError(err)
 	if string(res) != `{"errorDetail":{"code":50,"message":"Json error"},"error":"Json error"}`+"\r\n" {
 		t.Fatalf("%q", res)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -405,13 +405,6 @@ func NewWriteFlusher(w io.Writer) *WriteFlusher {
 	return &WriteFlusher{w: w, flusher: flusher}
 }
 
-func NewHTTPRequestError(msg string, res *http.Response) error {
-	return &JSONError{
-		Message: msg,
-		Code:    res.StatusCode,
-	}
-}
-
 func IsURL(str string) bool {
 	return strings.HasPrefix(str, "http://") || strings.HasPrefix(str, "https://")
 }
@@ -453,16 +446,6 @@ func GetLines(input []byte, commentMarker []byte) [][]byte {
 		}
 	}
 	return output
-}
-
-// An StatusError reports an unsuccessful exit by a command.
-type StatusError struct {
-	Status     string
-	StatusCode int
-}
-
-func (e *StatusError) Error() string {
-	return fmt.Sprintf("Status: %s, Code: %d", e.Status, e.StatusCode)
 }
 
 func quote(word string, buf *bytes.Buffer) {


### PR DESCRIPTION
This is the second of a few pull requests to break up utils into more discrete packages (#7222 is the first). My team needs this so we can import packages from Docker without inadvertently inheriting all the imports from utils.
