### PR TITLE
enabled search against private registry

### DIFF
--- a/registry/service.go
+++ b/registry/service.go
@@ -82,7 +82,11 @@ func (s *Service) Search(job *engine.Job) engine.Status {
 	job.GetenvJson("authConfig", authConfig)
 	job.GetenvJson("metaHeaders", metaHeaders)
 
-	r, err := NewRegistry(authConfig, HTTPRequestFactory(metaHeaders), IndexServerAddress(), true)
+	hostname, term, err := ResolveRepositoryName(term)
+	if err != nil {
+		return job.Error(err)
+	}
+	r, err := NewRegistry(authConfig, HTTPRequestFactory(metaHeaders), hostname, true)
 	if err != nil {
 		return job.Error(err)
 	}


### PR DESCRIPTION
Allows to docker search a private registry. The interface matches other registry related commands such as pull:

``` bash
docker search foo # search for foo in hub.docker.com
docker search localhost:5000/foo # search for foo in localhost:5000
```

Signed-off-by: sontags (Daniel Menet) daniel4sontags@gmail.com
