### PR TITLE
Enable `docker search` on private docker registry.

### DIFF
--- a/registry/service.go
+++ b/registry/service.go
@@ -82,6 +82,14 @@ func (s *Service) Search(job *engine.Job) engine.Status {
 	job.GetenvJson("authConfig", authConfig)
 	job.GetenvJson("metaHeaders", metaHeaders)
 
+	hostname, term, err := ResolveRepositoryName(term)
+	if err != nil {
+		return job.Error(err)
+	}
+	hostname, err = ExpandAndVerifyRegistryUrl(hostname)
+	if err != nil {
+		return job.Error(err)
+	}
 	r, err := NewSession(authConfig, HTTPRequestFactory(metaHeaders), IndexServerAddress(), true)
 	if err != nil {
 		return job.Error(err)

--- a/registry/service.go
+++ b/registry/service.go
@@ -90,7 +90,7 @@ func (s *Service) Search(job *engine.Job) engine.Status {
 	if err != nil {
 		return job.Error(err)
 	}
-	r, err := NewSession(authConfig, HTTPRequestFactory(metaHeaders), IndexServerAddress(), true)
+	r, err := NewSession(authConfig, HTTPRequestFactory(metaHeaders), hostname, true)
 	if err != nil {
 		return job.Error(err)
 	}

--- a/registry/service.go
+++ b/registry/service.go
@@ -82,7 +82,11 @@ func (s *Service) Search(job *engine.Job) engine.Status {
 	job.GetenvJson("authConfig", authConfig)
 	job.GetenvJson("metaHeaders", metaHeaders)
 
-	r, err := NewRegistry(authConfig, HTTPRequestFactory(metaHeaders), IndexServerAddress(), true)
+	hostname, term, err := ResolveRepositoryName(term)
+	if err != nil {
+		return job.Error(err)
+	}
+	r, err := NewRegistry(authConfig, HTTPRequestFactory(metaHeaders), hostname, true)
 	if err != nil {
 		return job.Error(err)
 	}

--- a/registry/service.go
+++ b/registry/service.go
@@ -86,6 +86,10 @@ func (s *Service) Search(job *engine.Job) engine.Status {
 	if err != nil {
 		return job.Error(err)
 	}
+	hostname, err = ExpandAndVerifyRegistryUrl(hostname)
+	if err != nil {
+		return job.Error(err)
+	}
 	r, err := NewRegistry(authConfig, HTTPRequestFactory(metaHeaders), hostname, true)
 	if err != nil {
 		return job.Error(err)


### PR DESCRIPTION
The cli interface works similar to other registry related commands:

``` bash
docker search foo # ... searches for foo on the official hub
docker search localhost:5000/foo # ... does the same for the private reg at localhost:5000
```

Signed-off-by: Daniel Menet membership@sontags.ch
