### PR TITLE
Updated mac.md to include workaround for volumes

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -96,6 +96,24 @@ then you should be able to access that Nginx server using the IP address reporte
 Typically, it is 192.168.59.103:2375, but VirtualBox's DHCP implementation might change
 this address in the future.
 
+## Container volume support
+
+In OS X, `boot2docker` doesn’t support volumes (i.e. -v /Users/yourname/project1:/data/project1) out of the box since it doesn’t include VirtualBox Guest Additions.  To obtain the
+
+    $ cd ~/.boot2docker
+    $ curl http://static.dockerfiles.io/boot2docker-v1.1.2-virtualbox-guest-additions-v4.3.12.iso > .boot2docker.iso
+    $ boot2docker init
+    $ VBoxManage sharedfolder add boot2docker-vm -name home -hostpath /Users
+    $ boot2docker up
+    
+Once the machine is up, we need to mount the shared folder inside the VM:
+
+    $ boot2docker ssh "sudo modprobe vboxsf && mkdir -v -p /Users && sudo mount -v -t vboxsf  -o uid=0,gid=0 home /Users"
+
+And this should be it. Now you can ...
+
+    docker run -i -t -v /Users/yourname/project1:/data/project1 ubuntu /bin/bash
+
 # Further details
 
 If you are curious, the username for the boot2docker default user is `docker` and the

--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -98,7 +98,7 @@ this address in the future.
 
 ## Container volume support
 
-In OS X, `boot2docker` doesn’t support volumes (i.e. -v /Users/yourname/project1:/data/project1) out of the box since it doesn’t include VirtualBox Guest Additions.  To obtain the
+In OS X, `boot2docker` doesn’t support volumes (i.e. -v /Users/yourname/project1:/data/project1) out of the box since it doesn’t include VirtualBox Guest Additions.  To obtain them:
 
     $ cd ~/.boot2docker
     $ curl http://static.dockerfiles.io/boot2docker-v1.1.2-virtualbox-guest-additions-v4.3.12.iso > .boot2docker.iso


### PR DESCRIPTION
Updated the documentation to include an explanation for handling volume support in Mac OS X.  This was quite a hinderance to a first-timer, and I feel it is exceedingly important.

Credits to:
https://coderwall.com/p/fvfjyg
https://medium.com/boot2docker-lightweight-linux-for-docker/boot2docker-together-with-virtualbox-guest-additions-da1e3ab2465c
