### PR TITLE
Make ENV accept multiple vars for a single layer

### DIFF
--- a/daemon/build.go
+++ b/daemon/build.go
@@ -374,8 +374,8 @@ func (b *buildFile) CmdEnv(args string) error {
 		env     map[string]string
 		commits []string
 	)
-	if err := json.Unmarshal([]byte(args), &env); err != nil {
-		tmp := strings.SplitN(args, " ", 2)
+	tmp := strings.SplitN(args, " ", 2)
+	if !strings.Contains(tmp[0], "=") {
 		if len(tmp) != 2 {
 			return fmt.Errorf("Invalid ENV format")
 		}
@@ -390,7 +390,12 @@ func (b *buildFile) CmdEnv(args string) error {
 		}
 		commits = append(commits, fmt.Sprintf("%s=%s", key, value))
 	} else {
-		for key, value := range env {
+		var validAlphaNumeric = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
+		for i := range tmp {
+			key, value := strings.SplitN(tmp[i], "=", 2)
+			if !validAlphaNumeric.MatchString(key) || !validAlphaNumeric.MatchString(value) {
+				return fmt.Errorf("Invalid ENV format")
+			}
 			if err := b.buildCmdEnvVar(key, value); err != nil {
 				return err
 			}

--- a/daemon/build.go
+++ b/daemon/build.go
@@ -370,10 +370,7 @@ func (b *buildFile) buildCmdEnvVar(key, value string) error {
 }
 
 func (b *buildFile) CmdEnv(args string) error {
-	var (
-		env     map[string]string
-		commits []string
-	)
+	var commits []string
 	tmp := strings.SplitN(args, " ", 2)
 	if !strings.Contains(tmp[0], "=") {
 		if len(tmp) != 2 {
@@ -390,9 +387,14 @@ func (b *buildFile) CmdEnv(args string) error {
 		}
 		commits = append(commits, fmt.Sprintf("%s=%s", key, value))
 	} else {
+		tmp := strings.SplitN(args, " ", -1)
 		var validAlphaNumeric = regexp.MustCompile(`^[a-zA-Z0-9]+$`)
 		for i := range tmp {
-			key, value := strings.SplitN(tmp[i], "=", 2)
+			splitTmp := strings.SplitN(tmp[i], "=", 2)
+			var (
+                        key   = strings.Trim(splitTmp[0], " \t")
+                        value = strings.Trim(splitTmp[1], " \t")
+                        )
 			if !validAlphaNumeric.MatchString(key) || !validAlphaNumeric.MatchString(value) {
 				return fmt.Errorf("Invalid ENV format")
 			}

--- a/daemon/build.go
+++ b/daemon/build.go
@@ -353,14 +353,7 @@ func (b *buildFile) ReplaceEnvMatches(value string) (string, error) {
 	return value, nil
 }
 
-func (b *buildFile) CmdEnv(args string) error {
-	tmp := strings.SplitN(args, " ", 2)
-	if len(tmp) != 2 {
-		return fmt.Errorf("Invalid ENV format")
-	}
-	key := strings.Trim(tmp[0], " \t")
-	value := strings.Trim(tmp[1], " \t")
-
+func (b *buildFile) buildCmdEnvVar(key, value string) error {
 	envKey := b.FindEnvKey(key)
 	replacedValue, err := b.ReplaceEnvMatches(value)
 	if err != nil {
@@ -373,7 +366,38 @@ func (b *buildFile) CmdEnv(args string) error {
 	} else {
 		b.config.Env = append(b.config.Env, replacedVar)
 	}
-	return b.commit("", b.config.Cmd, fmt.Sprintf("ENV %s", replacedVar))
+	return nil
+}
+
+func (b *buildFile) CmdEnv(args string) error {
+	var (
+		env     map[string]string
+		commits []string
+	)
+	if err := json.Unmarshal([]byte(args), &env); err != nil {
+		tmp := strings.SplitN(args, " ", 2)
+		if len(tmp) != 2 {
+			return fmt.Errorf("Invalid ENV format")
+		}
+
+		var (
+			key   = strings.Trim(tmp[0], " \t")
+			value = strings.Trim(tmp[1], " \t")
+		)
+
+		if err := b.buildCmdEnvVar(key, value); err != nil {
+			return err
+		}
+		commits = append(commits, fmt.Sprintf("%s=%s", key, value))
+	} else {
+		for key, value := range env {
+			if err := b.buildCmdEnvVar(key, value); err != nil {
+				return err
+			}
+			commits = append(commits, fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+	return b.commit("", b.config.Env, fmt.Sprintf("ENV %s", strings.Join(commits, ", ")))
 }
 
 func (b *buildFile) buildCmdFromJson(args string) []string {

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -260,8 +260,9 @@ from the resulting image. You can view the values using `docker inspect`, and
 change them using `docker run --env <key>=<value>`.
 
 > **Note**:
-> *Please note that you can only use alphanumeric and a very restricted set of special characters(`_, -, $, :, ., /`) when
-> specifying multiple environment variables in a single line.*
+> *Please note that you can only use alphanumeric and a very restricted set of
+> special characters(`_, -, $, :, ., /`) when specifying multiple environment
+> variables in a single line.*
 
 
 

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -245,8 +245,11 @@ containers using links (see the [Docker User
 Guide](/userguide/dockerlinks)).
 
 ## ENV
+ENV has 2 forms:
 
-    ENV <key> <value>
+- `ENV <key> <value>` (only one environment variable can be declared in one line)
+- `ENV <key>=<value> [<key>=<value>...]` (multiple environment variables can be declared in a single line)
+
 
 The `ENV` instruction sets the environment variable `<key>` to the value
 `<value>`. This value will be passed to all future `RUN` instructions. This is
@@ -255,6 +258,12 @@ functionally equivalent to prefixing the command with `<key>=<value>`
 The environment variables set using `ENV` will persist when a container is run
 from the resulting image. You can view the values using `docker inspect`, and
 change them using `docker run --env <key>=<value>`.
+
+> **Note**:
+> *Please note that you can only use alphanumeric and a very restricted set of special characters(`_, -, $, :, ., /`) when
+> specifying multiple environment variables in a single line.*
+
+
 
 > **Note**:
 > One example where this can cause unexpected consequences, is setting

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -689,11 +689,12 @@ func TestBuildRelativeWorkdir(t *testing.T) {
 
 func TestBuildEnv(t *testing.T) {
 	name := "testbuildenv"
-	expected := "[PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PORT=2375]"
+	expected := "[PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PORT=2375 X=y=1]"
 	defer deleteImages(name)
 	_, err := buildImage(name,
 		`FROM busybox
         ENV PORT 2375
+	ENV X y=1
 		RUN [ $(env | grep PORT) = 'PORT=2375' ]`,
 		true)
 	if err != nil {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -709,6 +709,29 @@ func TestBuildEnv(t *testing.T) {
 	logDone("build - env")
 }
 
+func TestBuildMultipleEnv(t *testing.T) {
+        name := "testbuildmultipleenv"
+        expected := "[PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PORT=2375 DEBIAN_FRONTEND=noninteractive HOME=/root LC_ALL=en_US.UTF-8]"
+        defer deleteImages(name)
+        _, err := buildImage(name,
+                `FROM busybox
+        ENV PORT=2375 DEBIAN_FRONTEND=noninteractive HOME=/root LC_ALL=en_US.UTF-8
+                RUN [ $(env | grep PORT) = 'PORT=2375' ]`,
+                true)
+        if err != nil {
+                t.Fatal(err)
+        }
+        res, err := inspectField(name, "Config.Env")
+        if err != nil {
+                t.Fatal(err)
+        }
+        if res != expected {
+                t.Fatalf("Env %s, expected %s", res, expected)
+        }
+        logDone("build - multiple env")
+}
+
+
 func TestBuildCmd(t *testing.T) {
 	name := "testbuildcmd"
 	expected := "[/bin/echo Hello World]"
@@ -1733,6 +1756,30 @@ RUN    [ "$(cat $TO)" = "hello" ]`
 		t.Fatal(err)
 	}
 	logDone("build - environment variables usage")
+}
+
+func TestMultipleBuildEnvUsage(t *testing.T) {
+        name := "testbuildenvusage"
+        defer deleteImages(name)
+        dockerfile := `FROM busybox
+ENV    FOO=/foo/baz BAR=/bar FOOPATH=$PATH:$FOO
+ENV    BAZ $BAR
+RUN    [ "$BAR" = "$BAZ" ]
+RUN    [ "$FOOPATH" = "$PATH:/foo/baz" ]
+ENV        FROM=hello/docker/world TO=/docker/world/hello
+ADD    $FROM $TO
+RUN    [ "$(cat $TO)" = "hello" ]`
+        ctx, err := fakeContext(dockerfile, map[string]string{
+                "hello/docker/world": "hello",
+        })
+        if err != nil {
+                t.Fatal(err)
+        }
+        _, err = buildImageFromContext(name, ctx, true)
+        if err != nil {
+                t.Fatal(err)
+        }
+        logDone("build - multiple environment variables usage")
 }
 
 func TestBuildAddScript(t *testing.T) {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -710,27 +710,26 @@ func TestBuildEnv(t *testing.T) {
 }
 
 func TestBuildMultipleEnv(t *testing.T) {
-        name := "testbuildmultipleenv"
-        expected := "[PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PORT=2375 DEBIAN_FRONTEND=noninteractive HOME=/root LC_ALL=en_US.UTF-8]"
-        defer deleteImages(name)
-        _, err := buildImage(name,
-                `FROM busybox
+	name := "testbuildmultipleenv"
+	expected := "[PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PORT=2375 DEBIAN_FRONTEND=noninteractive HOME=/root LC_ALL=en_US.UTF-8]"
+	defer deleteImages(name)
+	_, err := buildImage(name,
+		`FROM busybox
         ENV PORT=2375 DEBIAN_FRONTEND=noninteractive HOME=/root LC_ALL=en_US.UTF-8
                 RUN [ $(env | grep PORT) = 'PORT=2375' ]`,
-                true)
-        if err != nil {
-                t.Fatal(err)
-        }
-        res, err := inspectField(name, "Config.Env")
-        if err != nil {
-                t.Fatal(err)
-        }
-        if res != expected {
-                t.Fatalf("Env %s, expected %s", res, expected)
-        }
-        logDone("build - multiple env")
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := inspectField(name, "Config.Env")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != expected {
+		t.Fatalf("Env %s, expected %s", res, expected)
+	}
+	logDone("build - multiple env")
 }
-
 
 func TestBuildCmd(t *testing.T) {
 	name := "testbuildcmd"
@@ -1759,9 +1758,9 @@ RUN    [ "$(cat $TO)" = "hello" ]`
 }
 
 func TestMultipleBuildEnvUsage(t *testing.T) {
-        name := "testbuildenvusage"
-        defer deleteImages(name)
-        dockerfile := `FROM busybox
+	name := "testbuildenvusage"
+	defer deleteImages(name)
+	dockerfile := `FROM busybox
 ENV    FOO=/foo/baz BAR=/bar FOOPATH=$PATH:$FOO
 ENV    BAZ $BAR
 RUN    [ "$BAR" = "$BAZ" ]
@@ -1769,17 +1768,17 @@ RUN    [ "$FOOPATH" = "$PATH:/foo/baz" ]
 ENV        FROM=hello/docker/world TO=/docker/world/hello
 ADD    $FROM $TO
 RUN    [ "$(cat $TO)" = "hello" ]`
-        ctx, err := fakeContext(dockerfile, map[string]string{
-                "hello/docker/world": "hello",
-        })
-        if err != nil {
-                t.Fatal(err)
-        }
-        _, err = buildImageFromContext(name, ctx, true)
-        if err != nil {
-                t.Fatal(err)
-        }
-        logDone("build - multiple environment variables usage")
+	ctx, err := fakeContext(dockerfile, map[string]string{
+		"hello/docker/world": "hello",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = buildImageFromContext(name, ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logDone("build - multiple environment variables usage")
 }
 
 func TestBuildAddScript(t *testing.T) {


### PR DESCRIPTION
This is a refactored version of @cpuguy83 's pull request to fix #2333.
I have made changes to meet @shykes's specification as per:
https://github.com/docker/docker/pull/3368#issuecomment-40855331

I have still allowed a very restricted set of special characters though as i have noted down in the docs.
