### PR TITLE
List all port mappings when no port is specified

### DIFF
--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -146,7 +146,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from logs' -s f -l follow -d
 complete -c docker -A -f -n '__fish_seen_subcommand_from logs' -a '(__fish_print_docker_containers running)' -d "Container"
 
 # port
-complete -c docker -f -n '__fish_docker_no_subcommand' -a port -d 'Lookup the public-facing port which is NAT-ed to PRIVATE_PORT'
+complete -c docker -f -n '__fish_docker_no_subcommand' -a port -d 'Display container:host mappings of ports, if PRIVATE_PORT is specified, only those NAT-ed to PRIVATE_PORT will be showed'
 complete -c docker -A -f -n '__fish_seen_subcommand_from port' -a '(__fish_print_docker_containers running)' -d "Container"
 
 # ps

--- a/contrib/man/md/docker-port.1.md
+++ b/contrib/man/md/docker-port.1.md
@@ -2,13 +2,13 @@
 % William Henry
 % APRIL 2014
 # NAME
-docker-port - Lookup the public-facing port which is NAT-ed to PRIVATE_PORT
+docker-port - Display container:host mappings of ports
 
 # SYNOPSIS
 **docker port** CONTAINER PRIVATE_PORT
 
 # DESCRIPTION
-Lookup the public-facing port which is NAT-ed to PRIVATE_PORT
+Display container:host mappings of ports, if PRIVATE_PORT is specified, only those NAT-ed to PRIVATE_PORT will be showed
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/contrib/man/md/docker.1.md
+++ b/contrib/man/md/docker.1.md
@@ -128,7 +128,7 @@ inside it)
   Fetch the logs of a container
 
 **docker-port(1)**
-  Lookup the public-facing port which is NAT-ed to PRIVATE_PORT
+  Display container:host mappings of ports
 
 **docker-ps(1)**
   List containers

--- a/contrib/man/old-man/docker.1
+++ b/contrib/man/old-man/docker.1
@@ -118,7 +118,7 @@ Register or Login to a Docker registry server
 Fetch the logs of a container
 .TP
 .B port 
-Lookup the public-facing port which is NAT-ed to PRIVATE_PORT
+Display container:host mappings of ports
 .TP
 .B ps 
 List containers

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -709,9 +709,9 @@ and stderr.
 
 ## port
 
-    Usage: docker port CONTAINER PRIVATE_PORT
+    Usage: docker port CONTAINER [PRIVATE_PORT]
 
-    Lookup the public-facing port which is NAT-ed to PRIVATE_PORT
+    Display container:host mappings of ports, if PRIVATE_PORT is specified, only those NAT-ed to PRIVATE_PORT will be showed
 
 ## ps
 


### PR DESCRIPTION
Make `PRIVATE_PORT` argument of the `docker port` command optional.

When no port is specified, all ports mapping will be listed, for example:

``` bash
$ docker port focused_darwin
7070/tcp
        0.0.0.0:7171
80/tcp
        0.0.0.0:80
        0.0.0.0:81
$ docker port focused_darwin 80
0.0.0.0:80
0.0.0.0:81
```
