### PR TITLE
#7017 - Add container pinning

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -58,6 +58,9 @@ func (daemon *Daemon) ContainerRm(job *engine.Job) engine.Status {
 				return job.Errorf("You cannot remove a running container. Stop the container before attempting removal or use -f")
 			}
 		}
+		if container.HostConfig().Pinned && !forceRemove {
+			return job.Errorf("Container `%s` is pinned. You must remove with the `force` option", name)
+		}
 		if err := daemon.Destroy(container); err != nil {
 			return job.Errorf("Cannot destroy container %s: %s", name, err)
 		}

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -31,6 +31,7 @@ docker-run - Run a command in a new container
 [**--net**[=*"bridge"*]]
 [**-P**|**--publish-all**[=*false*]]
 [**-p**|**--publish**[=*[]*]]
+[**--pin**[=*false*]]
 [**--privileged**[=*false*]]
 [**--restart**[=*POLICY*]]
 [**--rm**[=*false*]]
@@ -202,6 +203,10 @@ mapping between the host ports and the exposed ports, use **docker port**.
    Publish a container's port to the host (format: ip:hostPort:containerPort |
 ip::containerPort | hostPort:containerPort | containerPort) (use **docker port** to see the
 actual mapping)
+
+**--pin**=*true*|*false*
+  The `--pin` flag tells `docker run` to pin the container.  This makes it
+impossible to remove the container without using the `--force` option.
 
 **--privileged**=*true*|*false*
    Give extended privileges to this container. By default, Docker containers are

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -57,6 +57,15 @@ Setup an exec command in a running container `id`.
 **New!**
 Start an exec command.
 
+**New!**
+Must use `force` to remove a container which has been pinned.
+
+`POST /containers/(id)/start`
+
+The `hostConfig` option now accepts the field `Pinned`, which is a flag that
+allows you to `pin` a container, making it impossible to remove without also
+using `force`
+
 ## v1.14
 
 ### Full Documentation
@@ -69,6 +78,7 @@ Start an exec command.
 
 **New!**
 When using `force`, the container will be immediately killed with SIGKILL.
+
 
 `POST /containers/(id)/start`
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1150,6 +1150,7 @@ removed before the image is removed.
       -p, --publish=[]           Publish a container's port to the host
                                    format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
                                    (use 'docker port' to see the actual mapping)
+      --pin=false                Pin the container, making it impossible to remove without using --force
       --privileged=false         Give extended privileges to this container
       --restart=""               Restart policy to apply when a container exits (no, on-failure[:max-retry], always)
       --rm=false                 Automatically remove the container when it exits (incompatible with -d)
@@ -1311,6 +1312,11 @@ argument. The container ID may be optionally suffixed with `:ro` or `:rw` to
 mount the volumes in read-only or read-write mode, respectively. By default,
 the volumes are mounted in the same mode (read write or read only) as
 the reference container.
+
+  $ sudo docker run --pin -v /foo --entrypoint /bin/echo mydata
+
+The `--pin` flag tells `docker run` to pin the container. This makes it
+impossible to remove the container without using the `--force` option.
 
 The `-a` flag tells `docker run` to bind to the container's `STDIN`, `STDOUT` or
 `STDERR`. This makes it possible to manipulate the output and input as needed.

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -337,6 +337,17 @@ Dockerfile instruction and how the operator can override that setting.
  - [USER](#user)
  - [WORKDIR](#workdir)
 
+## Container pinning (--pin)
+
+  --pin=false: Pin the container, making it impossible to remove without using `--force`
+
+Use container pinning to ensure a container is not accidentally removed. This is
+useful when using data-only containers which stay in a stopped state. The only
+way to remove pinned containers is with the `--force` option.
+
+  $ docker run --pin --name pinnned-container IMAGE [COMMAND]
+  $ docekr rm --force pinned-container
+
 ## CMD (Default Command or Options)
 
 Recall the optional `COMMAND` in the Docker

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -140,3 +140,25 @@ func createRunningContainer(t *testing.T, name string) {
 		t.Fatal(err)
 	}
 }
+
+func TestRmPinnedContainer(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "-d", "--name", "pinned", "--pin", "busybox", "echo")
+	if _, err := runCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test removing without force.  Expect this to fail
+	cmdRm := exec.Command(dockerBinary, "rm", "pinned")
+	if _, err := runCommand(cmdRm); err == nil {
+		t.Fatalf("Expected rm to fail for pinned container with no --force")
+	}
+
+	// Test removing with force. Expect to work
+	cmdRmF := exec.Command(dockerBinary, "rm", "--force", "pinned")
+	if out, _, err := runCommandWithOutput(cmdRmF); err != nil {
+		t.Fatalf(out, err)
+	}
+
+	deleteAllContainers()
+	logDone("rm - can only remove pinned container only with --force")
+}

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -56,6 +56,7 @@ type HostConfig struct {
 	CapAdd          []string
 	CapDrop         []string
 	RestartPolicy   RestartPolicy
+	Pinned          bool
 }
 
 // This is used by the create command when you want to set both the
@@ -84,6 +85,7 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 		Privileged:      job.GetenvBool("Privileged"),
 		PublishAllPorts: job.GetenvBool("PublishAllPorts"),
 		NetworkMode:     NetworkMode(job.Getenv("NetworkMode")),
+		Pinned:          job.GetenvBool("Pinned"),
 	}
 
 	job.GetenvJson("LxcConf", &hostConfig.LxcConf)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -60,6 +60,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.")
 		flRestartPolicy   = cmd.String([]string{"-restart"}, "", "Restart policy to apply when a container exits (no, on-failure[:max-retry], always)")
+		flPin             = cmd.Bool([]string{"-pin"}, false, "Pin the container, making it impossible to remove without using --force")
 	)
 
 	cmd.Var(&flAttach, []string{"a", "-attach"}, "Attach to STDIN, STDOUT or STDERR.")
@@ -276,6 +277,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		CapAdd:          flCapAdd.GetAll(),
 		CapDrop:         flCapDrop.GetAll(),
 		RestartPolicy:   restartPolicy,
+		Pinned:          *flPin,
 	}
 
 	if sysInfo != nil && flMemory > 0 && !sysInfo.SwapLimit {


### PR DESCRIPTION
Addresses #7017
Makes it so you can pass `--pin` to `docker run` so that you can't `docker rm` that container without also using `--force`
For example:

```
docker run -d -v /myData --pin --name my_data tianon/true
docker stop my_data # This isn't running, but for showcasing this, stop it
docker rm my_data # this will fail even though it's not running
docker rm --force my_data # this will work
```

Docker-DCO-1.1-Signed-off-by: Brian Goff cpuguy83@gmail.com (github: cpuguy83)
