### PR TITLE
Fix version number comparison

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,9 +12,17 @@ func (me Version) compareTo(other Version) int {
 		meTab    = strings.Split(string(me), ".")
 		otherTab = strings.Split(string(other), ".")
 	)
-	for i, s := range meTab {
+
+	max := len(meTab)
+	if len(otherTab) > max {
+		max = len(otherTab)
+	}
+	for i := 0; i < max; i++ {
 		var meInt, otherInt int
-		meInt, _ = strconv.Atoi(s)
+
+		if len(meTab) > i {
+			meInt, _ = strconv.Atoi(meTab[i])
+		}
 		if len(otherTab) > i {
 			otherInt, _ = strconv.Atoi(otherTab[i])
 		}
@@ -24,9 +32,6 @@ func (me Version) compareTo(other Version) int {
 		if otherInt > meInt {
 			return -1
 		}
-	}
-	if len(otherTab) > len(meTab) {
-		return -1
 	}
 	return 0
 }

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -12,6 +12,8 @@ func assertVersion(t *testing.T, a, b string, result int) {
 
 func TestCompareVersion(t *testing.T) {
 	assertVersion(t, "1.12", "1.12", 0)
+	assertVersion(t, "1.0.0", "1", 0)
+	assertVersion(t, "1", "1.0.0", 0)
 	assertVersion(t, "1.05.00.0156", "1.0.221.9289", 1)
 	assertVersion(t, "1", "1.0.1", -1)
 	assertVersion(t, "1.0.1", "1", 1)


### PR DESCRIPTION
version numbers `1` and `1.0.0` should equal in both direction.

```
    assertVersion(t, "1.0.0", "1", 0)
    assertVersion(t, "1", "1.0.0", 0)
```

The second tests fails on master. This PR fixes this issue.
