### PR TITLE
Add support for tcps:// URLs

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1265,10 +1265,15 @@ func ListenAndServe(proto, addr string, job *engine.Job) error {
 		oldmask = syscall.Umask(0777)
 	}
 
+	listenProto := proto
+	if proto == "tcps" {
+		listenProto = "tcp"
+	}
+
 	if job.GetenvBool("BufferRequests") {
-		l, err = listenbuffer.NewListenBuffer(proto, addr, activationLock)
+		l, err = listenbuffer.NewListenBuffer(listenProto, addr, activationLock)
 	} else {
-		l, err = net.Listen(proto, addr)
+		l, err = net.Listen(listenProto, addr)
 	}
 
 	if proto == "unix" {
@@ -1278,7 +1283,7 @@ func ListenAndServe(proto, addr string, job *engine.Job) error {
 		return err
 	}
 
-	if proto != "unix" && (job.GetenvBool("Tls") || job.GetenvBool("TlsVerify")) {
+	if proto != "unix" && (job.GetenvBool("Tls") || job.GetenvBool("TlsVerify") || proto == "tcps") {
 		tlsCert := job.Getenv("TlsCert")
 		tlsKey := job.Getenv("TlsKey")
 		cert, err := tls.LoadX509KeyPair(tlsCert, tlsKey)

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -95,6 +95,8 @@ func main() {
 
 	if *flTls || *flTlsVerify {
 		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, protoAddrParts[0], protoAddrParts[1], &tlsConfig)
+	} else if protoAddrParts[0] == "tcps" {
+		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, "tcp", protoAddrParts[1], &tlsConfig)
 	} else {
 		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, protoAddrParts[0], protoAddrParts[1], nil)
 	}

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -58,6 +58,6 @@ func init() {
 
 	flag.Var(&flDns, []string{"#dns", "-dns"}, "Force Docker to use specific DNS servers")
 	flag.Var(&flDnsSearch, []string{"-dns-search"}, "Force Docker to use specific DNS search domains")
-	flag.Var(&flHosts, []string{"H", "-host"}, "The socket(s) to bind to in daemon mode\nspecified using one or more tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.")
+	flag.Var(&flHosts, []string{"H", "-host"}, "The socket(s) to bind to in daemon mode\nspecified using one or more tcp://host:port, tcps://host:port, unix:///path/to/socket, fd://* or fd://socketfd.")
 	flag.Var(&flGraphOpts, []string{"-storage-opt"}, "Set storage driver options")
 }

--- a/docs/sources/articles/https.md
+++ b/docs/sources/articles/https.md
@@ -138,17 +138,17 @@ need to provide your client keys, certificates and trusted CA:
 ## Secure by default
 
 If you want to secure your Docker client connections by default, you can move 
-the files to the `.docker` directory in your home directory - and set the
-`DOCKER_HOST` variable as well.
+the files to the `.docker` directory in your home directory and set the
+`DOCKER_HOST` with the `tcps://` protocol.
 
     $ cp ca.pem ~/.docker/ca.pem
     $ cp cert.pem ~/.docker/cert.pem
     $ cp key.pem ~/.docker/key.pem
-    $ export DOCKER_HOST=tcp://:2376
+    $ export DOCKER_HOST=tcps://:2376
 
-Then you can run Docker with the `--tlsverify` option.
+Then you can run Docker as usual:
 
-    $ docker --tlsverify ps
+    $ docker ps
 
 ## Other modes
 

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -26,6 +26,9 @@ func ParseHost(defaultHost string, defaultUnix, addr string) (string, error) {
 	case strings.HasPrefix(addr, "tcp://"):
 		proto = "tcp"
 		addr = strings.TrimPrefix(addr, "tcp://")
+	case strings.HasPrefix(addr, "tcps://"):
+		proto = "tcps"
+		addr = strings.TrimPrefix(addr, "tcps://")
 	case strings.HasPrefix(addr, "fd://"):
 		return addr, nil
 	case addr == "":

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -39,6 +39,9 @@ func TestParseHost(t *testing.T) {
 	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "udp://127.0.0.1:2375"); err == nil {
 		t.Errorf("udp protocol address expected error return, but err == nil. Got %s", addr)
 	}
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "tcps://127.0.0.1:7777"); err != nil || addr != "tcps://127.0.0.1:7777" {
+		t.Errorf("tcps://127.0.0.1:7777 -> expected tcps://127.0.0.1:7777, got %s", addr)
+	}
 }
 
 func TestParseRepositoryTag(t *testing.T) {


### PR DESCRIPTION
This makes it possible to enable TLS support on the client without having to pass any command line options -- you can use `DOCKER_HOST` with a `tcps://` URL.

On the client, this will behave as if the `--tlsverify` flag has been passed. On the server, the `--tls` flag. The difference between `--tls` and `--tlsverify` on the client seem a bit odd, and I _think_ this makes sense for what you'd normally want to do.

In terms of tests, there are no unit tests that cover any of this code, and it seems wasteful to add an integration test to just check a single command-line option. My Go-fu is the limiting factor here, so any advice on how to write a good unit test would be appreciated.

This is an implementation of the proposal in #7415.
