### PR TITLE
Fix contrib/mkimage/debootstrap for Lucid

### DIFF
--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -188,4 +188,6 @@ fi
 	# delete all the apt list files since they're big and get stale quickly
 	rm -rf "$rootfsDir/var/lib/apt/lists"/*
 	# this forces "apt-get update" in dependent images, which is also good
+	
+	mkdir "$rootfsDir/var/lib/apt/lists/partial" # Lucid... "E: Lists directory /var/lib/apt/lists/partial is missing."
 )


### PR DESCRIPTION
Later versions of `apt` are smart enough to just create this directory if it's missing, but Lucid balks (just like `gnupg` and `gpgv` aren't in the Required set so don't come in a minbase -- good ol' Lucid).
