### PR TITLE
Add missing exit(1) after writing error

### DIFF
--- a/daemon/execdriver/native/init.go
+++ b/daemon/execdriver/native/init.go
@@ -62,4 +62,5 @@ func initializer() {
 
 func writeError(err error) {
 	fmt.Sprint(os.Stderr, err)
+	os.Exit(1)
 }


### PR DESCRIPTION
Signed-off-by: Michael Crosby michael@docker.com
