### PR TITLE
Enable signal proxying with TTY

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -645,10 +645,8 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 		config := env.GetSubEnv("Config")
 		tty = config.GetBool("Tty")
 
-		if !tty {
-			sigc := cli.forwardAllSignals(cmd.Arg(0))
-			defer signal.StopCatch(sigc)
-		}
+		sigc := cli.forwardAllSignals(cmd.Arg(0))
+		defer signal.StopCatch(sigc)
 
 		var in io.ReadCloser
 
@@ -1775,7 +1773,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 	var (
 		cmd     = cli.Subcmd("attach", "[OPTIONS] CONTAINER", "Attach to a running container")
 		noStdin = cmd.Bool([]string{"#nostdin", "-no-stdin"}, false, "Do not attach STDIN")
-		proxy   = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxy all received signals to the process (even in non-TTY mode). SIGCHLD, SIGKILL, and SIGSTOP are not proxied.")
+		proxy   = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxy all received signals to the process (even in non-TTY mode). In TTY mode, SIGTSTP, SIGTTIN, SIGTTOU, and SIGINT are not proxied. SIGCHLD, SIGKILL, and SIGSTOP are never proxied.")
 	)
 
 	if err := cmd.Parse(args); err != nil {
@@ -1825,7 +1823,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 	v.Set("stdout", "1")
 	v.Set("stderr", "1")
 
-	if *proxy && !tty {
+	if *proxy {
 		sigc := cli.forwardAllSignals(cmd.Arg(0))
 		defer signal.StopCatch(sigc)
 	}
@@ -1987,11 +1985,6 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		autoRemove, _ = strconv.ParseBool(flRm.Value.String())
 		sigProxy, _   = strconv.ParseBool(flSigProxy.Value.String())
 	)
-
-	// Disable sigProxy in case on TTY
-	if config.Tty {
-		sigProxy = false
-	}
 
 	var containerIDFile io.WriteCloser
 	if len(hostConfig.ContainerIDFile) > 0 {

--- a/docs/man/docker-attach.1.md
+++ b/docs/man/docker-attach.1.md
@@ -25,7 +25,7 @@ the client.
    Do not attach STDIN. The default is *false*.
 
 **--sig-proxy**=*true*|*false*
-   Proxy all received signals to the process (even in non-TTY mode). SIGCHLD, SIGKILL, and SIGSTOP are not proxied. The default is *true*.
+   Proxy all received signals to the process (even in non-TTY mode). In TTY mode, SIGTSTP, SIGTTIN, SIGTTOU, and SIGINT are not proxied. SIGCHLD, SIGKILL, and SIGSTOP are never proxied.
 
 # EXAMPLES
 

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -204,7 +204,7 @@ outside of a container on the host.
    Automatically remove the container when it exits (incompatible with -d). The default is *false*.
 
 **--sig-proxy**=*true*|*false*
-   Proxy received signals to the process (even in non-TTY mode). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true*.
+   Proxy all received signals to the process (even in non-TTY mode). In TTY mode, SIGTSTP, SIGTTIN, SIGTTOU, and SIGINT are not proxied. SIGCHLD, SIGKILL, and SIGSTOP are never proxied.
 
 **-t**, **--tty**=*true*|*false*
    When set to true Docker can allocate a pseudo-tty and attach to the standard

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -134,7 +134,7 @@ Docker supports softlinks for the Docker data directory
     Attach to a running container
 
       --no-stdin=false    Do not attach STDIN
-      --sig-proxy=true    Proxy all received signals to the process (even in non-TTY mode). SIGCHLD, SIGKILL, and SIGSTOP are not proxied.
+      --sig-proxy=true    Proxy all received signals to the process (even in non-TTY mode). In TTY mode, SIGTSTP, SIGTTIN, SIGTTOU, and SIGINT are not proxied. SIGCHLD, SIGKILL, and SIGSTOP are never proxied.
 
 The `attach` command will allow you to view or
 interact with any running container, detached (`-d`)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -72,7 +72,7 @@ func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Conf
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.")
 		// For documentation purpose
-		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxy received signals to the process (even in non-TTY mode). SIGCHLD, SIGSTOP, and SIGKILL are not proxied.")
+		_ = cmd.Bool([]string{"#sig-proxy", "-sig-proxy"}, true, "Proxy all received signals to the process (even in non-TTY mode). In TTY mode, SIGTSTP, SIGTTIN, SIGTTOU, and SIGINT are not proxied. SIGCHLD, SIGKILL, and SIGSTOP are never proxied.")
 		_ = cmd.String([]string{"#name", "-name"}, "", "Assign a name to the container")
 	)
 


### PR DESCRIPTION
Fixes  #5547

At present, documentation indicates you can use signal proxying in TTY mode, but it's explicitly disabled in the code.

Removing the explicit checks to prevent proxying in TTY mode does not produce any bugs I can find, makes the behavior consistent with documentation, and makes the Docker client a bit more usable than it was before.

Of note: in TTY mode, SIGTTIN, SIGTTOU, SIGTSTP, and SIGINT are not proxied. SIGTTIN, SIGTTOU, and SIGTSTP are handled by the TTY allocated to the process, and consequently not being able to proxy them is not a significant issue. SIGINT is used by the TTY code to cause a graceful exit of the client, which seems to be a good behavior to maintain.

As mentioned previously, I can't find any bugs with this code. The only potential issue I can see is that SIGTERM will no longer stop the client by default, but will instead be proxied through to the container; however, SIGINT will still close only the client, if that is desired.
