### PR TITLE
Transition usage of `libcontainer/user` to use new interface

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1220,7 +1220,13 @@ func ServeFd(addr string, handle http.Handler) error {
 }
 
 func lookupGidByName(nameOrGid string) (int, error) {
-	groups, err := user.ParseGroupFilter(func(g *user.Group) bool {
+	group, err := os.Open("/etc/group")
+	if err != nil {
+		return -1, err
+	}
+	defer group.Close()
+
+	groups, err := user.ParseGroupFilter(group, func(g user.Group) bool {
 		return g.Name == nameOrGid || strconv.Itoa(g.Gid) == nameOrGid
 	})
 	if err != nil {


### PR DESCRIPTION
This patchset transitions the use of the old `libcontainer/user` interface
to the new and improved `libcontainer/user` interface (also updating the
`hack/vendor.sh` script to use libcontainer:4ae31b6ceb2c2557c9f05f42da61b0b808faa5a4).

Signed-off-by: Aleksa Sarai cyphar@cyphar.com (github: cyphar)

/cc @vieux @tianon @crosbymichael
