### PR TITLE
pkg/tarsum: avoid buf2 allocation in Read

### DIFF
--- a/pkg/tarsum/tarsum.go
+++ b/pkg/tarsum/tarsum.go
@@ -23,6 +23,7 @@ type TarSum struct {
 	gz                 writeCloseFlusher
 	bufTar             *bytes.Buffer
 	bufGz              *bytes.Buffer
+	bufData            [8192]byte
 	h                  hash.Hash
 	sums               map[string]string
 	currentFile        string
@@ -92,7 +93,12 @@ func (ts *TarSum) Read(buf []byte) (int, error) {
 	if ts.finished {
 		return ts.bufGz.Read(buf)
 	}
-	buf2 := make([]byte, len(buf), cap(buf))
+	var buf2 []byte
+	if len(buf) > 8192 {
+		buf2 = make([]byte, len(buf), cap(buf))
+	} else {
+		buf2 = ts.bufData[:len(buf)-1]
+	}
 
 	n, err := ts.tarR.Read(buf2)
 	if err != nil {


### PR DESCRIPTION
This PR helps lower the amount of garbage generated by TarSum. Lowering the amount of memory allocations helps speed up the computation of the checksum during push.

Please note that the gzip results from the benchmark are skewed by gzip because it generates a lot of garbage. The results are also slightly skewed because the buffer is now allocated statically.

```
benchmark                         old ns/op     new ns/op     delta
Benchmark9kTar                    8379          6607          -21.15%
Benchmark9kTarGzip                184908        171621        -7.19%
Benchmark1mbSingleFileTar         6632180       6197622       -6.55%
Benchmark1mbSingleFileTarGzip     18460760      18809325      +1.89%
Benchmark1kFilesTar               37462144      25597058      -31.67%
Benchmark1kFilesTarGzip           68058501      63030372      -7.39%

benchmark                         old MB/s     new MB/s     speedup
Benchmark9kTar                    1099.83      1394.76      1.27x
Benchmark9kTarGzip                49.84        53.70        1.08x
Benchmark1mbSingleFileTar         158.10       169.19       1.07x
Benchmark1mbSingleFileTarGzip     56.80        55.75        0.98x
Benchmark1kFilesTar               27.99        40.96        1.46x
Benchmark1kFilesTarGzip           15.41        16.64        1.08x

benchmark                         old allocs     new allocs     delta
Benchmark9kTar                    16             15             -6.25%
Benchmark9kTarGzip                40             39             -2.50%
Benchmark1mbSingleFileTar         469            339            -27.72%
Benchmark1mbSingleFileTarGzip     3487           3358           -3.70%
Benchmark1kFilesTar               68640          66573          -3.01%
Benchmark1kFilesTarGzip           138226         136254         -1.43%

benchmark                         old bytes     new bytes     delta
Benchmark9kTar                    10890         11050         +1.47%
Benchmark9kTarGzip                1464594       1464737       +0.01%
Benchmark1mbSingleFileTar         1096992       41000         -96.26%
Benchmark1mbSingleFileTarGzip     2959182       1905550       -35.61%
Benchmark1kFilesTar               18466189      1731351       -90.62%
Benchmark1kFilesTarGzip           27068070      10477820      -61.29%
```
