### PR TITLE
Restrict length of repository names

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -23,6 +23,7 @@ var (
 	ErrAlreadyExists         = errors.New("Image already exists")
 	ErrInvalidRepositoryName = errors.New("Invalid repository name (ex: \"registry.domain.tld/myrepos\")")
 	errLoginRequired         = errors.New("Authentication is required.")
+	validHex                 = regexp.MustCompile(`^([a-f0-9]{64})$`)
 )
 
 type TimeoutType uint32
@@ -218,6 +219,10 @@ func validateRepositoryName(repositoryName string) error {
 	if len(nameParts) < 2 {
 		namespace = "library"
 		name = nameParts[0]
+
+		if validHex.MatchString(name) {
+			return fmt.Errorf("Invalid repository name (%s), cannot specify 64-byte hexadecimal strings", name)
+		}
 	} else {
 		namespace = nameParts[0]
 		name = nameParts[1]

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -224,12 +224,20 @@ func TestValidRepositoryName(t *testing.T) {
 	if err := validateRepositoryName("docker/docker"); err != nil {
 		t.Fatal(err)
 	}
+	// Support 64-byte non-hexadecimal names (hexadecimal names are forbidden)
+	if err := validateRepositoryName("thisisthesongthatneverendsitgoesonandonandonthisisthesongthatnev"); err != nil {
+		t.Fatal(err)
+	}
 	if err := validateRepositoryName("docker/Docker"); err == nil {
 		t.Log("Repository name should be invalid")
 		t.Fail()
 	}
 	if err := validateRepositoryName("docker///docker"); err == nil {
 		t.Log("Repository name should be invalid")
+		t.Fail()
+	}
+	if err := validateRepositoryName("1a3f5e7d9c1b3a5f7e9d1c3b5a7f9e1d3c5b7a9f1e3d5d7c9b1a3f5e7d9c1b3a"); err == nil {
+		t.Log("Repository name should be invalid, 64-byte hexadecimal names forbidden")
 		t.Fail()
 	}
 }


### PR DESCRIPTION
The registry restricts the length of repository names
to <64 characters. If a repository has a namespace (i.e. user), this
only applies to the name right of the /.

For instance both of the following would be considered 64 characters:
- 123456789012345678901234567890123456789012345678901234567890123
- ewindisch/123456789012345678901234567890123456789012345678901234567890123

Signed-off-by: Eric Windisch eric@windisch.us
