### PR TITLE
Fixes "note" blockquote too long [doc, minor]

### DIFF
--- a/docs/sources/introduction/understanding-docker.md
+++ b/docs/sources/introduction/understanding-docker.md
@@ -157,7 +157,7 @@ this as the base of all your web application images.
 
 > **Note:** Docker usually gets these base images from
 > [Docker Hub](https://hub.docker.com).
-> 
+
 Docker images are then built from these base images using a simple, descriptive
 set of steps we call *instructions*. Each instruction creates a new layer in our
 image. Instructions include actions like:


### PR DESCRIPTION
A "note" block includes too much text, so if you skip over it the next paragraph makes zero sense.
