### PR TITLE
Add GoDoc and Travis build link/images to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ Under the hood, Docker is built on the following components:
 Contributing to Docker
 ======================
 
+[![GoDoc](https://godoc.org/github.com/docker/docker?status.png)](https://godoc.org/github.com/docker/docker)
+[![Travis](https://travis-ci.org/docker/docker.svg?branch=master)](https://travis-ci.org/docker/docker)
+
 Want to hack on Docker? Awesome! There are instructions to get you
 started [here](CONTRIBUTING.md).
 


### PR DESCRIPTION
Adds two little images (GoDoc ref. and Travis build) to Contrib section of README.

Preview: https://github.com/VojtechVitek/docker/blob/7cb68713552d2b153ed18bc6dcdcee5b69ef0a5f/README.md#contributing-to-docker
