### PR TITLE
Fix data space reporting from Kb/Mb to KB/MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ Under the hood, Docker is built on the following components:
 Contributing to Docker
 ======================
 
+[![GoDoc](https://godoc.org/github.com/docker/docker?status.png)](https://godoc.org/github.com/docker/docker)
+[![Travis](https://travis-ci.org/docker/docker.svg?branch=master)](https://travis-ci.org/docker/docker)
+
 Want to hack on Docker? Awesome! There are instructions to get you
 started [here](CONTRIBUTING.md).
 

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -62,7 +62,6 @@ func (d *Driver) Status() [][2]string {
 		{"Data Space Total", fmt.Sprintf("%s", units.HumanSize(int64(s.Data.Total)))},
 		{"Metadata Space Used", fmt.Sprintf("%s", units.HumanSize(int64(s.Metadata.Used)))},
 		{"Metadata Space Total", fmt.Sprintf("%s", units.HumanSize(int64(s.Metadata.Total)))},
-
 	}
 	return status
 }

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/log"
 	"github.com/docker/docker/pkg/mount"
+	"github.com/docker/docker/pkg/units"
 )
 
 func init() {
@@ -54,13 +55,14 @@ func (d *Driver) Status() [][2]string {
 
 	status := [][2]string{
 		{"Pool Name", s.PoolName},
-		{"Pool Blocksize", fmt.Sprintf("%d Kb", s.SectorSize/1024)},
+		{"Pool Blocksize", fmt.Sprintf("%s", units.HumanSize(int64(s.SectorSize)))},
 		{"Data file", s.DataLoopback},
 		{"Metadata file", s.MetadataLoopback},
-		{"Data Space Used", fmt.Sprintf("%.1f Mb", float64(s.Data.Used)/(1024*1024))},
-		{"Data Space Total", fmt.Sprintf("%.1f Mb", float64(s.Data.Total)/(1024*1024))},
-		{"Metadata Space Used", fmt.Sprintf("%.1f Mb", float64(s.Metadata.Used)/(1024*1024))},
-		{"Metadata Space Total", fmt.Sprintf("%.1f Mb", float64(s.Metadata.Total)/(1024*1024))},
+		{"Data Space Used", fmt.Sprintf("%s", units.HumanSize(int64(s.Data.Used)))},
+		{"Data Space Total", fmt.Sprintf("%s", units.HumanSize(int64(s.Data.Total)))},
+		{"Metadata Space Used", fmt.Sprintf("%s", units.HumanSize(int64(s.Metadata.Used)))},
+		{"Metadata Space Total", fmt.Sprintf("%s", units.HumanSize(int64(s.Metadata.Total)))},
+
 	}
 	return status
 }

--- a/docs/man/docker-ps.1.md
+++ b/docs/man/docker-ps.1.md
@@ -8,6 +8,7 @@ docker-ps - List containers
 **docker ps**
 [**-a**|**--all**[=*false*]]
 [**--before**[=*BEFORE*]]
+[**-f**|**--filter**[=*[]*]]
 [**-l**|**--latest**[=*false*]]
 [**-n**[=*-1*]]
 [**--no-trunc**[=*false*]]
@@ -27,6 +28,10 @@ the running containers.
 
 **--before**=""
    Show only container created before Id or Name, include non-running ones.
+
+**-f**, **--filter**=[]
+   Provide filter values. Valid filters:
+                          exited=<int> - containers with exit code of <int>
 
 **-l**, **--latest**=*true*|*false*
    Show only the latest created container, include non-running ones. The default is *false*.
@@ -68,3 +73,4 @@ the running containers.
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+August 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/docs/man/docker-rm.1.md
+++ b/docs/man/docker-rm.1.md
@@ -6,8 +6,8 @@ docker-rm - Remove one or more containers
 
 # SYNOPSIS
 **docker rm**
-[**-l**|**--link**[=*false*]]
 [**-f**|**--force**[=*false*]]
+[**-l**|**--link**[=*false*]]
 [**-v**|**--volumes**[=*false*]]
  CONTAINER [CONTAINER...]
 
@@ -19,11 +19,12 @@ remove a running container unless you use the \fB-f\fR option. To see all
 containers on a host use the **docker ps -a** command.
 
 # OPTIONS
+**-f**, **--force**=*true*|*false*
+   Force the removal of a running container (uses SIGKILL). The default is *false*.
+
 **-l**, **--link**=*true*|*false*
    Remove the specified link and not the underlying container. The default is *false*.
 
-**-f**, **--force**=*true*|*false*
-  Allows removing of a running container by first killing it with SIGKILL.
 **-v**, **--volumes**=*true*|*false*
    Remove the volumes associated with the container. The default is *false*.
 
@@ -49,3 +50,4 @@ April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 July 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+August 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -65,7 +65,7 @@ expect an integer, and they can only be specified once.
       -H, --host=[]                              The socket(s) to bind to in daemon mode
                                                    specified using one or more tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.
       --icc=true                                 Enable inter-container communication
-      --ip="0.0.0.0"                             Default IP address to use when binding container ports
+      --ip=0.0.0.0                               Default IP address to use when binding container ports
       --ip-forward=true                          Enable net.ipv4.ip_forward
       --iptables=true                            Enable Docker's addition of iptables rules
       --mtu=0                                    Set the containers network MTU
@@ -792,7 +792,8 @@ further details.
 
       -a, --all=false       Show all containers. Only running containers are shown by default.
       --before=""           Show only container created before Id or Name, include non-running ones.
-      -f, --filter=[]       Provide filter values (i.e. 'exited=0')
+      -f, --filter=[]       Provide filter values. Valid filters:
+                              exited=<int> - containers with exit code of <int>
       -l, --latest=false    Show only the latest created container, include non-running ones.
       -n=-1                 Show n last created containers, include non-running ones.
       --no-trunc=false      Don't truncate output
@@ -882,7 +883,7 @@ registry or to a self-hosted one.
 
     Remove one or more containers
 
-      -f, --force=false      Force removal of a running container. Uses SIGKILL to stop the container.
+      -f, --force=false      Force the removal of a running container (uses SIGKILL)
       -l, --link=false       Remove the specified link and not the underlying container
       -v, --volumes=false    Remove the volumes associated with the container
 

--- a/pkg/tarsum/tarsum.go
+++ b/pkg/tarsum/tarsum.go
@@ -23,6 +23,7 @@ type TarSum struct {
 	gz                 writeCloseFlusher
 	bufTar             *bytes.Buffer
 	bufGz              *bytes.Buffer
+	bufData            [8192]byte
 	h                  hash.Hash
 	sums               map[string]string
 	currentFile        string
@@ -92,7 +93,12 @@ func (ts *TarSum) Read(buf []byte) (int, error) {
 	if ts.finished {
 		return ts.bufGz.Read(buf)
 	}
-	buf2 := make([]byte, len(buf), cap(buf))
+	var buf2 []byte
+	if len(buf) > 8192 {
+		buf2 = make([]byte, len(buf), cap(buf))
+	} else {
+		buf2 = ts.bufData[:len(buf)-1]
+	}
 
 	n, err := ts.tarR.Read(buf2)
 	if err != nil {


### PR DESCRIPTION
Fix data space reporting from Kb/Mb to KB/MB. Currently "docker info" reports data/metadata space using "Kb/Mb" instead of the expected "KB/MB". Used pkg/units. Mentioned in issue #7429 .

Signed-off-by: Vivek Dasgupta vdasgupt@redhat.com
