### PR TITLE
API for supported parameters

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -148,6 +148,37 @@ func getVersion(eng *engine.Engine, version version.Version, w http.ResponseWrit
 	return nil
 }
 
+//"/help
+func getHelpInfo(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := parseForm(r); err != nil {
+		return err
+	}
+	var job = eng.Job("help_info")
+	streamJSON(job, w, true)
+	return job.Run()
+}
+func getHelpInfoCommand(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := parseForm(r); err != nil {
+		return err
+	}
+	var job = eng.Job("help_info")
+	streamJSON(job, w, true)
+	job.Setenv("command", vars["command"])
+	return job.Run()
+}
+
+// /help/<command>/<flag>
+func getHelpInfoFlag(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := parseForm(r); err != nil {
+		return err
+	}
+	var job = eng.Job("help_info")
+	streamJSON(job, w, true)
+	job.Setenv("command", vars["command"])
+	job.Setenv("flag", vars["flag"])
+	return job.Run()
+}
+
 func postContainersKill(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -1102,6 +1133,9 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 			"/events":                         getEvents,
 			"/info":                           getInfo,
 			"/version":                        getVersion,
+			"/help/{command}/{flag}":          getHelpInfoFlag,
+			"/help/{command}":                 getHelpInfoCommand,
+			"/help":                           getHelpInfo,
 			"/images/json":                    getImagesJSON,
 			"/images/viz":                     getImagesViz,
 			"/images/search":                  getImagesSearch,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -123,6 +123,7 @@ func (daemon *Daemon) Install(eng *engine.Engine) error {
 		"top":               daemon.ContainerTop,
 		"unpause":           daemon.ContainerUnpause,
 		"wait":              daemon.ContainerWait,
+		"help_info":         daemon.CmdHelpInfo,
 		"image_delete":      daemon.ImageDelete, // FIXME: see above
 	} {
 		if err := eng.Register(name, method); err != nil {

--- a/daemon/help.go
+++ b/daemon/help.go
@@ -1,0 +1,27 @@
+package daemon
+
+import (
+	"github.com/docker/docker/engine"
+	"github.com/docker/docker/pkg/helpinfo"
+)
+
+func (daemon *Daemon) CmdHelpInfo(job *engine.Job) engine.Status {
+	v := &engine.Env{}
+	if len(job.Getenv("command")) > 0 {
+		v.Set("command", job.Getenv("command"))
+		if len(job.Getenv("flag")) > 0 {
+			v.Set("flag", job.Getenv("flag"))
+		} else {
+			v.SetJson("flags", helpinfo.Flags(job.Getenv("command")))
+		}
+	} else {
+		v.SetJson("commands", helpinfo.Commands())
+	}
+	if len(job.Getenv("command")) > 0 && len(job.Getenv("flag")) > 0 {
+		v.SetJson("blurbs", helpinfo.Blurbs(job.Getenv("command"), job.Getenv("flag")))
+	}
+	if _, err := v.WriteTo(job.Stdout); err != nil {
+		return job.Error(err)
+	}
+	return engine.StatusOK
+}

--- a/daemon/help_test.go
+++ b/daemon/help_test.go
@@ -1,0 +1,16 @@
+package daemon
+
+import (
+	"testing"
+)
+
+func TestHelpInfo(t *testing.T) {
+	testInfo := HelpInfo{}
+	testInfo.Add("images", "filter", Blurb{"dangling=<true|false>", "shows only images with no name", "(would show in the list as <none>)"})
+	if len(testInfo.Commands()) != 1 || testInfo.Commands()[0] != "images" {
+		t.Fatalf("expected only 1 command, got %d. %#v", len(testInfo.Commands()), testInfo)
+	}
+	if len(testInfo.Flags("images")) != 1 || testInfo.Flags("images")[0] != "filter" {
+		t.Fatalf("expected only 1 flag for images, got %d. %#v", len(testInfo.Flags("images")), testInfo)
+	}
+}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -9,12 +9,17 @@ import (
 	"github.com/docker/docker/pkg/graphdb"
 
 	"github.com/docker/docker/engine"
+	"github.com/docker/docker/pkg/helpinfo"
 	"github.com/docker/docker/pkg/parsers/filters"
 )
 
 // List returns an array of all containers registered in the daemon.
 func (daemon *Daemon) List() []*Container {
 	return daemon.containers.List()
+}
+
+func init() {
+	helpinfo.RegisterHelpInfo("ps", "filter", helpinfo.Blurb{"exited = <int>", "containers with exit code of <int>"})
 }
 
 func (daemon *Daemon) Containers(job *engine.Job) engine.Status {

--- a/graph/list.go
+++ b/graph/list.go
@@ -8,8 +8,13 @@ import (
 
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/pkg/helpinfo"
 	"github.com/docker/docker/pkg/parsers/filters"
 )
+
+func init() {
+	helpinfo.RegisterHelpInfo("images", "filter", helpinfo.Blurb{"dangling = <true>", "shows only images with no name", "(would show in the list as <none>)"})
+}
 
 func (s *TagStore) CmdImages(job *engine.Job) engine.Status {
 	var (

--- a/pkg/helpinfo/help.go
+++ b/pkg/helpinfo/help.go
@@ -1,0 +1,115 @@
+package helpinfo
+
+import (
+	"strings"
+	"sync"
+)
+
+/*
+The idea being for relaying to a client, the options available for particular
+flags, where there is a free form argument allowed, but only expected args will
+be parsed. This way the usae can be dynamically access, even if the client does
+not have the same options compiled as the server.
+
+  --storage-opt=[]                             Set storage driver options:      _                    _
+                                                * foo.bar = blah blah blah blah |  2 lines, 1 blurb  |
+                                                  blah blah blah blah blah blah _                    |
+                                                * foo.bar = blah blah blah blah                      |  2 blurbs
+                                                  blah blah blah blah blah blah                      _
+                                                  |---------------------------|
+
+                                                ^ asterisk would be added in client formating if desired
+
+*/
+
+func RegisterHelpInfo(command, flag string, blurb Blurb) error {
+	return DefaultHelpInfo.Add(command, flag, blurb)
+}
+func Commands() []string {
+	return DefaultHelpInfo.Commands()
+}
+func Flags(command string) []string {
+	return DefaultHelpInfo.Flags(command)
+}
+func Blurbs(command, flag string) []Blurb {
+	return DefaultHelpInfo.Blurbs(command, flag)
+}
+
+type Blurb []string
+type FlagBlurbs map[string][]Blurb
+type CommandFlagBlurbs map[string]FlagBlurbs
+
+var UsageBlurbPrefix = "- "
+
+func UsageFormat(blurbs []Blurb) string {
+	if len(blurbs) == 0 {
+		return ""
+	}
+	buf := ""
+	indent := len(UsageBlurbPrefix)
+	lastBlurb := len(blurbs) - 1
+	for i, blurb := range blurbs {
+		if len(blurb) == 0 {
+			continue
+		}
+		buf = buf + UsageBlurbPrefix + blurb[0] + "\n"
+		lastLine := len(blurb[1:]) - 1
+		for j, line := range blurb[1:] {
+			buf = buf + strings.Repeat(" ", indent) + line
+			if j < lastLine {
+				buf = buf + "\n"
+			}
+		}
+		if i < lastBlurb {
+			buf = buf + "\n"
+		}
+	}
+	return buf
+}
+
+var DefaultHelpInfo = HelpInfo{}
+
+type HelpInfo struct {
+	c          CommandFlagBlurbs `json:"flags"`
+	sync.Mutex `json:"-"`
+}
+
+// Names of the commands with information added
+func (hi HelpInfo) Commands() (commands []string) {
+	hi.Lock()
+	defer hi.Unlock()
+	for k := range hi.c {
+		commands = append(commands, k)
+	}
+	return commands
+}
+
+func (hi HelpInfo) Flags(command string) (flags []string) {
+	hi.Lock()
+	defer hi.Unlock()
+	for k := range hi.c[command] {
+		flags = append(flags, k)
+	}
+	return flags
+}
+func (hi HelpInfo) Blurbs(command, flag string) []Blurb {
+	return hi.c[command][flag]
+}
+
+func (hi *HelpInfo) Add(command, flag string, blurb Blurb) error {
+	hi.Lock()
+	defer hi.Unlock()
+	if hi.c == nil {
+		hi.c = CommandFlagBlurbs{}
+	}
+	if _, ok := hi.c[command]; !ok {
+		hi.c[command] = FlagBlurbs{flag: []Blurb{blurb}}
+		return nil
+	}
+	if _, ok := hi.c[command][flag]; !ok {
+		hi.c[command][flag] = []Blurb{blurb}
+		return nil
+	}
+	hi.c[command][flag] = append(hi.c[command][flag], blurb)
+	return nil
+}

--- a/pkg/helpinfo/help_test.go
+++ b/pkg/helpinfo/help_test.go
@@ -1,0 +1,45 @@
+package helpinfo
+
+import (
+	"testing"
+)
+
+func TestHelpInfo(t *testing.T) {
+	testInfo := HelpInfo{}
+	testInfo.Add("images", "filter", Blurb{"dangling = <true>", "shows only images with no name", "(would show in the list as <none>)"})
+	if len(testInfo.Commands()) != 1 || testInfo.Commands()[0] != "images" {
+		t.Fatalf("expected only 1 command, got %d. %#v", len(testInfo.Commands()), testInfo)
+	}
+	if len(testInfo.Flags("images")) != 1 || testInfo.Flags("images")[0] != "filter" {
+		t.Fatalf("expected only 1 flag for images, got %d. %#v", len(testInfo.Flags("images")), testInfo)
+	}
+	testInfo.Add("ps", "filter", Blurb{"exited = <int>", "some text here"})
+	if len(testInfo.Commands()) != 2 {
+		t.Fatalf("expected 2 commands, got %d. %#v", len(testInfo.Commands()), testInfo)
+	}
+	if len(testInfo.Flags("ps")) != 1 || testInfo.Flags("ps")[0] != "filter" {
+		t.Fatalf("expected only 1 flag for images, got %d. %#v", len(testInfo.Flags("ps")), testInfo)
+	}
+}
+
+func TestFormat(t *testing.T) {
+	testInfo := HelpInfo{}
+	for i := 0; i < 3; i++ {
+		testInfo.Add("images", "filter", Blurb{"dangling = <true>", "shows only images with no name", "(would show in the list as <none>)"})
+	}
+
+	expected := `- dangling = <true>
+  shows only images with no name
+  (would show in the list as <none>)
+- dangling = <true>
+  shows only images with no name
+  (would show in the list as <none>)
+- dangling = <true>
+  shows only images with no name
+  (would show in the list as <none>)`
+	got := UsageFormat(testInfo.Blurbs("images", "filter"))
+	if expected != got {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+
+}


### PR DESCRIPTION
This adds a daemon API for supported parameters, as they correlate to
text arguments to client commands. This way the client can display
accurate options even if it is a different version than the daemon. Or
interaction with only the API could access parameter information.

fixes https://github.com/docker/docker/issues/6889

For example, in the following, the usage of `--filter` includes parameters enumerated from the server.

```
vbatts@noyee ~ (master) $ /home/vbatts/src/docker/docker/bundles/1.1.2-dev/dynbinary/docker-1.1.2-dev images -h

Usage: docker images [OPTIONS] [NAME]

List images

  -a, --all=false      Show all images (by default filter out the intermediate image layers)
  -f, --filter=[]      Provide filter values. Filters include:
                         - dangling = <true|false>
                           shows only images with no name
                           (would show in the list as <none>)
  --no-trunc=false     Don't truncate output
  -q, --quiet=false    Only show numeric IDs
vbatts@noyee ~ (master) $ /home/vbatts/src/docker/docker/bundles/1.1.2-dev/dynbinary/docker-1.1.2-dev ps -h

Usage: docker ps [OPTIONS]

List containers

  -a, --all=false       Show all containers. Only running containers are shown by default.
  --before=""           Show only container created before Id or Name, include non-running ones.
  -f, --filter=[]       Provide filter values. Filters include:
                          - exited = <int>
                            containers with exit code of <int>
  -l, --latest=false    Show only the latest created container, include non-running ones.
  -n=-1                 Show n last created containers, include non-running ones.
  --no-trunc=false      Don't truncate output
  -q, --quiet=false     Only display numeric IDs
  -s, --size=false      Display sizes
  --since=""            Show only containers created since Id or Name, include non-running ones.

```
