### PR TITLE
Update openSUSE installation instructions

### DIFF
--- a/docs/sources/installation/openSUSE.md
+++ b/docs/sources/installation/openSUSE.md
@@ -47,7 +47,7 @@ The docker package creates a new group named docker. Users, other than
 root user, need to be part of this group in order to interact with the
 Docker daemon. You can add users with:
 
-    $ sudo usermod -a -G docker <username>
+    $ sudo /usr/sbin/usermod -a -G docker <username>
 
 To verify that everything has worked as expected:
 


### PR DESCRIPTION
Out of box, the 'sudo' command on openSUSE does not work similarly to other distros.  In this case, the path to usermod should be explicitly given, since /usr/sbin, where usermod is located, is not on the sudoing user's PATH.  The other sudo commands here should be fine.
