### PR TITLE
Use HTTPS for newsletter signup form

### DIFF
--- a/docs/theme/mkdocs/footer.html
+++ b/docs/theme/mkdocs/footer.html
@@ -56,7 +56,7 @@
         <span class="footer-title">Connect</span>
         <div class="search">
           <span>Subscribe to our newsletter</span>
-          <form action="http://www.docker.com/subscribe_newsletter/" method="post">
+          <form action="https://www.docker.com/subscribe_newsletter/" method="post">
             <input type='hidden' name='csrfmiddlewaretoken' value='aWL78QXQkY8DSKNYh6cl08p5eTLl7sOa' />
             <tr><th><label for="id_email">Email:</label></th><td><input class="form-control" id="id_email" name="email" placeholder="Enter your email" type="text" /></td></tr>
             


### PR DESCRIPTION
This is causing an insecure HTTPS error in Chrome 37.

![screenshot 2014-08-19 15 43 27](https://cloud.githubusercontent.com/assets/40906/3974276/48272598-27f2-11e4-9ceb-d98d5267c80e.png)
