### PR TITLE
Make it startable on CentOS6.5

### DIFF
--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -46,7 +46,7 @@ start() {
         prestart
         printf "Starting $prog:\t"
         echo "\n$(date)\n" >> $logfile
-        $exec -d $other_args &>> $logfile &
+        $exec -d $other_args >> $logfile 2>&1 &
         pid=$!
         touch $lockfile
         # wait up to 10 seconds for the pidfile to exist.  see


### PR DESCRIPTION
On CentOS6.5 start error:

$ sudo service docker restart
/etc/init.d/docker: line 49: syntax error near unexpected token `>'
/etc/init.d/docker: line 49:`        $exec -d $other_args &>> $logfile &'
