### PR TITLE
Optionalize the "hg clone" of Go, since it takes forever

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -53,11 +53,14 @@ clone hg code.google.com/p/gosqlite 74691fb6f837
 
 # get Go tip's archive/tar, for xattr support and improved performance
 # TODO after Go 1.4 drops, bump our minimum supported version and drop this vendored dep
-clone hg code.google.com/p/go 1b17b3426e3c
-mv src/code.google.com/p/go/src/pkg/archive/tar tmp-tar
-rm -rf src/code.google.com/p/go
-mkdir -p src/code.google.com/p/go/src/pkg/archive
-mv tmp-tar src/code.google.com/p/go/src/pkg/archive/tar
+if [ "$1" = '--go' ]; then
+	# Go takes forever and a half to clone, so we only redownload it when explicitly requested via the "--go" flag to this script.
+	clone hg code.google.com/p/go 1b17b3426e3c
+	mv src/code.google.com/p/go/src/pkg/archive/tar tmp-tar
+	rm -rf src/code.google.com/p/go
+	mkdir -p src/code.google.com/p/go/src/pkg/archive
+	mv tmp-tar src/code.google.com/p/go/src/pkg/archive/tar
+fi
 
 clone git github.com/docker/libcontainer db65c35051d05f3fb218a0e84a11267e0894fe0a
 # see src/github.com/docker/libcontainer/update-vendor.sh which is the "source of truth" for libcontainer deps (just like this file)


### PR DESCRIPTION
(now, to update our Go version too, we need to explicitly "./hack/vendor.sh --go")
