### PR TITLE
Fix #6509: Interactive container hangs when redirecting stdout

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -94,7 +94,7 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, proto, addr string, tlsC
 	}
 
 	if in != nil {
-		if file, ok := out.(*os.File); ok {
+		if file, ok := in.(*os.File); ok {
 			terminalFd = file.Fd()
 			isTerminal = term.IsTerminal(terminalFd)
 		}

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -689,7 +689,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 	}
 
 	if *openStdin || *attach {
-		if tty && cli.isTerminal {
+		if tty && cli.isTerminalOut {
 			if err := cli.monitorTtySize(cmd.Arg(0)); err != nil {
 				log.Errorf("Error monitoring TTY size: %s", err)
 			}
@@ -1841,7 +1841,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 		tty    = config.GetBool("Tty")
 	)
 
-	if tty && cli.isTerminal {
+	if tty && cli.isTerminalOut {
 		if err := cli.monitorTtySize(cmd.Arg(0)); err != nil {
 			log.Debugf("Error monitoring TTY size: %s", err)
 		}
@@ -2172,7 +2172,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		return err
 	}
 
-	if (config.AttachStdin || config.AttachStdout || config.AttachStderr) && config.Tty && cli.isTerminal {
+	if (config.AttachStdin || config.AttachStdout || config.AttachStderr) && config.Tty && cli.isTerminalOut {
 		if err := cli.monitorTtySize(runResult.Get("Id")); err != nil {
 			log.Errorf("Error monitoring TTY size: %s", err)
 		}

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -157,7 +157,7 @@ func (cli *DockerCli) streamHelper(method, path string, setRawTerminal bool, in 
 	}
 
 	if api.MatchesContentType(resp.Header.Get("Content-Type"), "application/json") {
-		return utils.DisplayJSONMessagesStream(resp.Body, stdout, cli.terminalFd, cli.isTerminal)
+		return utils.DisplayJSONMessagesStream(resp.Body, stdout, cli.terminalFdOut, cli.isTerminalOut)
 	}
 	if stdout != nil || stderr != nil {
 		// When TTY is ON, use regular copy
@@ -233,10 +233,10 @@ func (cli *DockerCli) monitorTtySize(id string) error {
 }
 
 func (cli *DockerCli) getTtySize() (int, int) {
-	if !cli.isTerminal {
+	if !cli.isTerminalOut {
 		return 0, 0
 	}
-	ws, err := term.GetWinsize(cli.terminalFd)
+	ws, err := term.GetWinsize(cli.terminalFdOut)
 	if err != nil {
 		log.Debugf("Error getting size: %s", err)
 		if ws == nil {


### PR DESCRIPTION
These two commits fix both:
- `docker run --rm -i ubuntu cat /etc/passwd | grep root` should not hang (issue #6509)
- `docker events > /tmp/out` should not print control characters to non-terminal STDOUT (commit 26b4a4920adca614f6be17a96f254f331271faf0)
