### PR TITLE
 daemon: rename from "delete" job to "rm"

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -679,7 +679,7 @@ func deleteContainers(eng *engine.Engine, version version.Version, w http.Respon
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
 	}
-	job := eng.Job("delete", vars["name"])
+	job := eng.Job("rm", vars["name"])
 
 	job.Setenv("forceRemove", r.Form.Get("force"))
 

--- a/api/server/server_unit_test.go
+++ b/api/server/server_unit_test.go
@@ -455,7 +455,7 @@ func TestDeleteContainers(t *testing.T) {
 	eng := engine.New()
 	name := "foo"
 	var called bool
-	eng.Register("delete", func(job *engine.Job) engine.Status {
+	eng.Register("rm", func(job *engine.Job) engine.Status {
 		called = true
 		if len(job.Args) == 0 {
 			t.Fatalf("Job arguments is empty")

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -98,8 +98,6 @@ type Daemon struct {
 
 // Install installs daemon capabilities to eng.
 func (daemon *Daemon) Install(eng *engine.Engine) error {
-	// FIXME: rename "delete" to "rm" for consistency with the CLI command
-	// FIXME: rename ContainerDestroy to ContainerRm for consistency with the CLI command
 	// FIXME: remove ImageDelete's dependency on Daemon, then move to graph/
 	for name, method := range map[string]engine.Handler{
 		"attach":            daemon.ContainerAttach,
@@ -110,7 +108,7 @@ func (daemon *Daemon) Install(eng *engine.Engine) error {
 		"container_inspect": daemon.ContainerInspect,
 		"containers":        daemon.Containers,
 		"create":            daemon.ContainerCreate,
-		"delete":            daemon.ContainerDestroy,
+		"rm":                daemon.ContainerRm,
 		"export":            daemon.ContainerExport,
 		"info":              daemon.CmdInfo,
 		"kill":              daemon.ContainerKill,

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -11,8 +11,7 @@ import (
 	"github.com/docker/docker/pkg/log"
 )
 
-// FIXME: rename to ContainerRemove for consistency with the CLI command.
-func (daemon *Daemon) ContainerDestroy(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerRm(job *engine.Job) engine.Status {
 	if len(job.Args) != 1 {
 		return job.Errorf("Not enough arguments. Usage: %s CONTAINER\n", job.Name)
 	}

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -218,7 +218,7 @@ func TestCreateStartRestartStopStartKillRm(t *testing.T) {
 	}
 
 	// FIXME: this failed once with a race condition ("Unable to remove filesystem for xxx: directory not empty")
-	job = eng.Job("delete", id)
+	job = eng.Job("rm", id)
 	job.SetenvBool("removeVolume", true)
 	if err := job.Run(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This commit fixes following FIXMEs:

// FIXME: rename "delete" to "rm" for consistency with the CLI command
// FIXME: rename ContainerDestroy to ContainerRm for consistency with the CLI command

Signed-off-by: lim seong yeol seongyeol37@gmail.com
