### PR TITLE
Change default label of container volumes to shared SELinux Label

### DIFF
--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -3,10 +3,12 @@ package vfs
 import (
 	"bytes"
 	"fmt"
-	"github.com/docker/docker/daemon/graphdriver"
 	"os"
 	"os/exec"
 	"path"
+
+	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/libcontainer/label"
 )
 
 func init() {
@@ -66,6 +68,10 @@ func (d *Driver) Create(id, parent string) error {
 	}
 	if err := os.Mkdir(dir, 0755); err != nil {
 		return err
+	}
+	opts := []string{"level:s0"}
+	if _, mountLabel, err := label.InitLabels(opts); err == nil {
+		label.Relabel(dir, mountLabel, "")
 	}
 	if parent == "" {
 		return nil


### PR DESCRIPTION
Since these will be shared between containers we want to label
them as svirt_sandbox_file_t:s0.  That will allow multiple containers
to write to them.

Currently we are allowing container domains to read/write all content in
/var/lib/docker because of container volumes.  This is a big security hole
in our SELinux story.

This patch will allow us to tighten up the security of docker containers.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
