### PR TITLE
Bind-mount container's config.json for introspection

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -61,6 +61,12 @@ func setupMountsForContainer(container *Container) error {
 		mounts = append(mounts, execdriver.Mount{container.HostsPath, "/etc/hosts", true, true})
 	}
 
+	containerJson, err := container.getRootResourcePath("config.json")
+	if err != nil {
+		return err
+	}
+	mounts = append(mounts, execdriver.Mount{containerJson, "/.container.json", false, true})
+
 	// Mount user specified volumes
 	// Note, these are not private because you may want propagation of (un)mounts from host
 	// volumes. For instance if you use -v /usr:/usr and the host later mounts /usr/share you


### PR DESCRIPTION
Use this for introspection.

Closes #1270 #7255

I looked at doing things like mounting a socket into each container for introspection, and even have a project @ github.com/cpuguy83/lestrade that does just this.
But this would require lots and lots of design discussion, and a lot of complexity, when really all that's needed is the json data, which is already there in the container's root config path, so let's just bind-mount that in.

Docker-DCO-1.1-Signed-off-by: Brian Goff cpuguy83@gmail.com (github: cpuguy83)
