### PR TITLE
Fix check for terminal output.

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -89,7 +89,7 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, proto, addr string, tlsC
 		scheme = "https"
 	}
 
-	if in != nil {
+	if out != nil {
 		if file, ok := out.(*os.File); ok {
 			terminalFd = file.Fd()
 			isTerminal = term.IsTerminal(terminalFd)


### PR DESCRIPTION
Previously, 26b4a492 fixed which stream was being checked, but the
surrounding check for whether it is nil was testing the wrong
variable.

Signed-off-by: Ewen Cheslack-Postava me@ewencp.org
