### PR TITLE
Fix the bug of docker import command when import a image with a tag use format 'URL|- [REPOSITORY[:TAG]]'

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1101,7 +1101,8 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 
 	if repository != "" {
 		//Check if the given image name can be resolved
-		if _, _, err := registry.ResolveRepositoryName(repository); err != nil {
+		repo, _ := parsers.ParseRepositoryTag(repository)
+		if _, _, err := registry.ResolveRepositoryName(repo); err != nil {
 			return err
 		}
 	}

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1101,8 +1101,7 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 
 	if repository != "" {
 		//Check if the given image name can be resolved
-		repo, _ := parsers.ParseRepositoryTag(repository)
-		if _, _, err := registry.ResolveRepositoryName(repo); err != nil {
+		if _, _, err := registry.ResolveRepositoryName(repository); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
In latest version 1.1.2,when use command 'docker import' to import a image with a tag use format  'URL|- [REPOSITORY[:TAG]]',it will return a error message shows that the repository name is invalid,for example:

[root@localhost images]# tar -c . | docker import - test:v1
2014/08/21 08:12:33 Invalid repository name (test:v1), only [a-z0-9-_.] are allowed

In previous version,it will parse the Arg[1] which value is 'REPOSITORY:TAG' ,get the REPOSITORY and TAG,then check if REPOSITORY can be resolved,but in the 1.1.2 version when import a image with a tag use format  'URL|- [REPOSITORY[:TAG]]',it will check the variable 'repository' which value is Arg[1] directly,but in fact the value of variable 'repository' is 'REPOSITORY:TAG' which contains a colon and colon is not in character set  [a-z0-9-_.],so the error occurred.
I add codes to call parsers.ParseRepositoryTag function to parse variable 'repository' and return the REPOSITORY which store in variable 'repo',then check the variable 'repo'.
