### PR TITLE
Truncate the names list on ps

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1565,15 +1565,17 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 
 		if !*quiet {
 			var (
-				outCommand = out.Get("Command")
-				ports      = engine.NewTable("", 0)
+				outCommand   = out.Get("Command")
+				ports        = engine.NewTable("", 0)
+				outNamesList = strings.Join(outNames, ",")
 			)
 			outCommand = strconv.Quote(outCommand)
 			if !*noTrunc {
 				outCommand = utils.Trunc(outCommand, 20)
+				outNamesList = outNames[0]
 			}
 			ports.ReadListFrom([]byte(out.Get("Ports")))
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\t%s\t%s\t%s\t", outID, out.Get("Image"), outCommand, units.HumanDuration(time.Now().UTC().Sub(time.Unix(out.GetInt64("Created"), 0))), out.Get("Status"), api.DisplayablePorts(ports), strings.Join(outNames, ","))
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\t%s\t%s\t%s\t", outID, out.Get("Image"), outCommand, units.HumanDuration(time.Now().UTC().Sub(time.Unix(out.GetInt64("Created"), 0))), out.Get("Status"), api.DisplayablePorts(ports), outNamesList)
 			if *size {
 				if out.GetInt("SizeRootFs") > 0 {
 					fmt.Fprintf(w, "%s (virtual %s)\n", units.HumanSize(out.GetInt64("SizeRw")), units.HumanSize(out.GetInt64("SizeRootFs")))


### PR DESCRIPTION
This keeps the output readable even when a container has a lot of names.  This can easily happen if you are developing with a testing image that links to another image.  I see this happen all the time while using [fig](http://www.fig.sh/).

For example if you are running a test build that requires a mongo image:
After the first run you're names list on the mongo image is `build_1/mongo,mongo`
After the second run you're names list on the mongo image is `build_2/mongo,build_1/mongo,mongo`
After the 100th run running `docker ps` is very difficult to read.

This pull request simply truncates the names list by default the same way that the id and command are already truncated.  If you need to see the whole list you just run `docker ps --no-trunc`.
