### PR TITLE
TarSum: versioning

### DIFF
--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -93,12 +93,12 @@ type Builder struct {
 	// both of these are controlled by the Remove and ForceRemove options in BuildOpts
 	TmpContainers map[string]struct{} // a map of containers used for removes
 
-	dockerfile  *parser.Node   // the syntax tree of the dockerfile
-	image       string         // image name for commit processing
-	maintainer  string         // maintainer name. could probably be removed.
-	cmdSet      bool           // indicates is CMD was set in current Dockerfile
-	context     *tarsum.TarSum // the context is a tarball that is uploaded by the client
-	contextPath string         // the path of the temporary directory the local context is unpacked to (server side)
+	dockerfile  *parser.Node           // the syntax tree of the dockerfile
+	image       string                 // image name for commit processing
+	maintainer  string                 // maintainer name. could probably be removed.
+	cmdSet      bool                   // indicates is CMD was set in current Dockerfile
+	context     tarsum.TarSumInterface // the context is a tarball that is uploaded by the client
+	contextPath string                 // the path of the temporary directory the local context is unpacked to (server side)
 
 }
 

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -41,7 +41,9 @@ func (b *Builder) readContext(context io.Reader) error {
 		return err
 	}
 
-	b.context = &tarsum.TarSum{Reader: decompressedStream, DisableCompression: true}
+	if b.context, err = tarsum.NewTarSum(decompressedStream, true, tarsum.Version0); err != nil {
+		return err
+	}
 	if err := archive.Untar(b.context, tmpdirPath, nil); err != nil {
 		return err
 	}

--- a/pkg/tarsum/versioning.go
+++ b/pkg/tarsum/versioning.go
@@ -1,0 +1,56 @@
+package tarsum
+
+import (
+	"errors"
+	"strings"
+)
+
+// versioning of the TarSum algorithm
+// based on the prefix of the hash used
+// i.e. "tarsum+sha256:e58fcf7418d4390dec8e8fb69d88c06ec07039d651fedd3aa72af9972e7d046b"
+type Version int
+
+const (
+	// Prefix of "tarsum"
+	Version0 Version = iota
+	// Prefix of "tarsum.dev"
+	// NOTE: this variable will be of an unsettled next-version of the TarSum calculation
+	VersionDev
+)
+
+// Get a list of all known tarsum Version
+func GetVersions() []Version {
+	v := []Version{}
+	for k := range tarSumVersions {
+		v = append(v, k)
+	}
+	return v
+}
+
+var tarSumVersions = map[Version]string{
+	0: "tarsum",
+	1: "tarsum.dev",
+}
+
+func (tsv Version) String() string {
+	return tarSumVersions[tsv]
+}
+
+// GetVersionFromTarsum returns the Version from the provided string
+func GetVersionFromTarsum(tarsum string) (Version, error) {
+	tsv := tarsum
+	if strings.Contains(tarsum, "+") {
+		tsv = strings.SplitN(tarsum, "+", 2)[0]
+	}
+	for v, s := range tarSumVersions {
+		if s == tsv {
+			return v, nil
+		}
+	}
+	return -1, ErrNotVersion
+}
+
+var (
+	ErrNotVersion            = errors.New("string does not include a TarSum Version")
+	ErrVersionNotImplemented = errors.New("TarSum Version is not yet implemented")
+)

--- a/pkg/tarsum/versioning_test.go
+++ b/pkg/tarsum/versioning_test.go
@@ -1,0 +1,49 @@
+package tarsum
+
+import (
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	expected := "tarsum"
+	var v Version
+	if v.String() != expected {
+		t.Errorf("expected %q, got %q", expected, v.String())
+	}
+
+	expected = "tarsum.dev"
+	v = 1
+	if v.String() != expected {
+		t.Errorf("expected %q, got %q", expected, v.String())
+	}
+}
+
+func TestGetVersion(t *testing.T) {
+	testSet := []struct {
+		Str      string
+		Expected Version
+	}{
+		{"tarsum+sha256:e58fcf7418d4390dec8e8fb69d88c06ec07039d651fedd3aa72af9972e7d046b", Version0},
+		{"tarsum+sha256", Version0},
+		{"tarsum", Version0},
+		{"tarsum.dev", VersionDev},
+		{"tarsum.dev+sha256:deadbeef", VersionDev},
+	}
+
+	for _, ts := range testSet {
+		v, err := GetVersionFromTarsum(ts.Str)
+		if err != nil {
+			t.Fatalf("%q : %s", err, ts.Str)
+		}
+		if v != ts.Expected {
+			t.Errorf("expected %d (%q), got %d (%q)", ts.Expected, ts.Expected, v, v)
+		}
+	}
+
+	// test one that does not exist, to ensure it errors
+	str := "weak+md5:abcdeabcde"
+	_, err := GetVersionFromTarsum(str)
+	if err != ErrNotVersion {
+		t.Fatalf("%q : %s", err, str)
+	}
+}

--- a/pkg/tarsum/writercloser.go
+++ b/pkg/tarsum/writercloser.go
@@ -1,0 +1,22 @@
+package tarsum
+
+import (
+	"io"
+)
+
+type writeCloseFlusher interface {
+	io.WriteCloser
+	Flush() error
+}
+
+type nopCloseFlusher struct {
+	io.Writer
+}
+
+func (n *nopCloseFlusher) Close() error {
+	return nil
+}
+
+func (n *nopCloseFlusher) Flush() error {
+	return nil
+}

--- a/registry/session.go
+++ b/registry/session.go
@@ -407,7 +407,10 @@ func (r *Session) PushImageLayerRegistry(imgID string, layer io.Reader, registry
 
 	log.Debugf("[registry] Calling PUT %s", registry+"images/"+imgID+"/layer")
 
-	tarsumLayer := &tarsum.TarSum{Reader: layer}
+	tarsumLayer, err := tarsum.NewTarSum(layer, false, tarsum.Version0)
+	if err != nil {
+		return "", "", err
+	}
 	h := sha256.New()
 	h.Write(jsonRaw)
 	h.Write([]byte{'\n'})


### PR DESCRIPTION
This introduces Versions for TarSum checksums.

Fixes: https://github.com/docker/docker/issues/7526

It preserves current functionality and abstracts the interface for future flexibility. As a POC, the Version1 Tarsum does not include the mtime in the checksum calculation, and would solve https://github.com/docker/docker/issues/7387

Signed-off-by: Vincent Batts vbatts@redhat.com
