### PR TITLE
Version 1.2.0 set root:root permissions on /var/run/docker.socket

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -5,9 +5,10 @@ After=network.target docker.socket
 Requires=docker.socket
 
 [Service]
-ExecStart=/usr/bin/docker -d -H fd://
+ExecStart=/usr/bin/docker -d
 LimitNOFILE=1048576
 LimitNPROC=1048576
 
 [Install]
+WantedBy=multi-user.target
 Also=docker.socket


### PR DESCRIPTION
Version 1.2.0 set root:root permissions on /var/run/docker.socket instead of root:docker for Debian Jessie. 
This change fixes that.

Signed-off-by: Jessica Frazelle jfrazelle@users.noreply.github.com
