### PR TITLE
Add an option to disable IP masquerading

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Mirrors                     []string
 	EnableIptables              bool
 	EnableIpForward             bool
+	EnableIpMasq                bool
 	DefaultIp                   net.IP
 	BridgeIface                 string
 	BridgeIP                    string
@@ -49,6 +50,7 @@ func (config *Config) InstallFlags() {
 	flag.BoolVar(&config.AutoRestart, []string{"#r", "#-restart"}, true, "--restart on the daemon has been deprecated in favor of --restart policies on docker run")
 	flag.BoolVar(&config.EnableIptables, []string{"#iptables", "-iptables"}, true, "Enable Docker's addition of iptables rules")
 	flag.BoolVar(&config.EnableIpForward, []string{"#ip-forward", "-ip-forward"}, true, "Enable net.ipv4.ip_forward")
+	flag.BoolVar(&config.EnableIpMasq, []string{"-ip-masq"}, true, "Enable IP masquerading for bridge's IP range")
 	flag.StringVar(&config.BridgeIP, []string{"#bip", "-bip"}, "", "Use this CIDR notation address for the network bridge's IP, not compatible with -b")
 	flag.StringVar(&config.BridgeIface, []string{"b", "-bridge"}, "", "Attach containers to a pre-existing network bridge\nuse 'none' to disable container networking")
 	flag.BoolVar(&config.InterContainerCommunication, []string{"#icc", "-icc"}, true, "Enable inter-container communication")

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -695,6 +695,9 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 	if !config.EnableIptables && !config.InterContainerCommunication {
 		return nil, fmt.Errorf("You specified --iptables=false with --icc=false. ICC uses iptables to function. Please set --icc or --iptables to true.")
 	}
+	if !config.EnableIptables && config.EnableIpMasq {
+		return nil, fmt.Errorf("You specified --iptables=false with --ipmasq=true. IP masquerading uses iptables to function. Please set --ipmasq to false or --iptables to true.")
+	}
 	config.DisableNetwork = config.BridgeIface == disableNetworkBridge
 
 	// Claim the pidfile first, to avoid any and all unexpected race conditions.
@@ -805,6 +808,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		job.SetenvBool("EnableIptables", config.EnableIptables)
 		job.SetenvBool("InterContainerCommunication", config.InterContainerCommunication)
 		job.SetenvBool("EnableIpForward", config.EnableIpForward)
+		job.SetenvBool("EnableIpMasq", config.EnableIpMasq)
 		job.Setenv("BridgeIface", config.BridgeIface)
 		job.Setenv("BridgeIP", config.BridgeIP)
 		job.Setenv("DefaultBindingIP", config.DefaultIp.String())

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -55,6 +55,9 @@ unix://[/path/to/socket] to use.
 **--ip**=""
   Default IP address to use when binding container ports. Default is `0.0.0.0`.
 
+**--ip-masq**=*true*|*false*
+  Enable IP masquerading for bridge's IP range. Default is true.
+
 **--iptables**=*true*|*false*
   Disable Docker's addition of iptables rules. Default is true.
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -67,6 +67,7 @@ expect an integer, and they can only be specified once.
       --icc=true                                 Enable inter-container communication
       --ip=0.0.0.0                               Default IP address to use when binding container ports
       --ip-forward=true                          Enable net.ipv4.ip_forward
+      --ip-masq=true                             Enable IP masquerading for bridge's IP range.
       --iptables=true                            Enable Docker's addition of iptables rules
       --mtu=0                                    Set the containers network MTU
                                                    if no value is provided: default to the default route MTU or 1500 if no default route is available
@@ -109,6 +110,10 @@ the `-H` flag for the client.
     $ export DOCKER_HOST="tcp://0.0.0.0:2375"
     $ sudo docker ps
     # both are equal
+
+IP masquerading uses address translation to allow containers without a public IP to talk
+to other machines on the Internet. This may interfere with some network topologies and
+can be disabled with --ip-masq=false.
 
 To run the daemon with [systemd socket activation](
 http://0pointer.de/blog/projects/socket-activation.html), use


### PR DESCRIPTION
For the cases where --bip option is used it is sometimes best to disable IP masquerading as the provided bridge IP range may be routable.
