### PR TITLE
on systems where lazy_journal_init doesn't exist,

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -305,6 +305,9 @@ func (devices *DeviceSet) createFilesystem(info *DevInfo) error {
 		err = exec.Command("mkfs.ext4", append([]string{"-E", "nodiscard,lazy_itable_init=0,lazy_journal_init=0"}, args...)...).Run()
 		if err != nil {
 			err = exec.Command("mkfs.ext4", append([]string{"-E", "nodiscard,lazy_itable_init=0"}, args...)...).Run()
+			// platforms that lack lazy_journal_init typically also have the old defaults
+			// for max mount count and mount interval
+			err = exec.Command("tune2fs", append([]string{"-c", "-1", "-i", "0"}, args...)...).Run()
 		}
 	default:
 		err = fmt.Errorf("Unsupported filesystem type %s", devices.filesystem)


### PR DESCRIPTION
use tune2fs to disable ext4 mount counts and mount intervals.

This prevents kernel messages later on:
`EXT4-fs (dm-2): warning: maximal mount count reached, running e2fsck is recommended`

Signed-off-by: Marc Tamsky mtamsky@gmail.com (github: tamsky)
