### PR TITLE
Updating LxcConf to match Docker command line

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.14.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.14.md
@@ -407,7 +407,7 @@ Start the container `id`
         {
              "Binds":["/tmp:/tmp"],
              "Links":["redis3:redis"],
-             "LxcConf":{"lxc.utsname":"docker"},
+             "LxcConf":[{"Key":"lxc.utsname","Value":"docker"}],
              "PortBindings":{ "22/tcp": [{ "HostPort": "11022" }] },
              "PublishAllPorts":false,
              "Privileged":false,


### PR DESCRIPTION
I've changed LxcConf on a previous API document. Not sure why it keeps getting changed back. I'm seeing Docker 1.2.0 command-line calls are still using the array of key/values.
