### PR TITLE
Add missing changes to BTRFS+SELinux to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 + Use /var/lib/docker/tmp for large temporary files
 + `--cap-add` and `--cap-drop` to tweak what linux capability you want
 + `--device` to use devices in containers
++ Breaking: Disallow using both BTRFS graph driver and SELinux
 
 #### Client
 + `docker search` on private registries


### PR DESCRIPTION
Breaking changes made to BTRFS+SELinux support for the docker daemon were missing from the change log.

https://github.com/docker/docker/commit/4318802f645cdd4fa63a894160f153a69a97af59#commitcomment-7505815
