### PR TITLE
Don't close the response Body if it's nil

### DIFF
--- a/registry/session.go
+++ b/registry/session.go
@@ -167,7 +167,9 @@ func (r *Session) GetRemoteImageLayer(imgID, registry string, token []string, im
 	for i := 1; i <= retries; i++ {
 		res, client, err = r.doRequest(req)
 		if err != nil {
-			res.Body.Close()
+			if res != nil && res.Body != nil {
+				res.Body.Close()
+			}
 			if i == retries {
 				return nil, fmt.Errorf("Server error: Status %d while fetching image layer (%s)",
 					res.StatusCode, imgID)


### PR DESCRIPTION
When an http error is returned, the response body may be nil.  Don't try to close it in that case.
