### PR TITLE
make docker pull only the latest tag by default

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -271,6 +271,9 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowDecomp
 
 func (b *Builder) pullImage(name string) (*imagepkg.Image, error) {
 	remote, tag := parsers.ParseRepositoryTag(name)
+	if tag == "" {
+		tag = "latest"
+	}
 	pullRegistryAuth := b.AuthConfig
 	if len(b.AuthConfigFile.Configs) > 0 {
 		// The request came with a full auth config file, we prefer to use that

--- a/docs/man/docker-pull.1.md
+++ b/docs/man/docker-pull.1.md
@@ -6,6 +6,7 @@ docker-pull - Pull an image or a repository from the registry
 
 # SYNOPSIS
 **docker pull**
+[**-a**|**--all-tags**[=*false*]]
 NAME[:TAG]
 
 # DESCRIPTION
@@ -16,7 +17,8 @@ images for that repository name are pulled down including any tags.
 It is also possible to specify a non-default registry to pull from.
 
 # OPTIONS
-There are no available options.
+**-a**, **--all-tags**=*true*|*false*
+   Download all tagged images in the repository. The default is *false*.
 
 # EXAMPLES
 
@@ -53,3 +55,4 @@ There are no available options.
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+August 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -852,6 +852,8 @@ This shows all the containers that have exited with status of '0'
 
     Pull an image or a repository from the registry
 
+      -a, --all-tags=false    Download all tagged images in the repository
+
 Most of your images will be created on top of a base image from the
 [Docker Hub](https://hub.docker.com) registry.
 
@@ -867,11 +869,13 @@ To download a particular image, or set of images (i.e., a repository),
 use `docker pull`:
 
     $ docker pull debian
-    # will pull all the images in the debian repository
+    # will pull only the debian:latest image and its intermediate layers 
     $ docker pull debian:testing
     # will pull only the image named debian:testing and any intermediate layers
-    # it is based on. (Typically the empty `scratch` image, a MAINTAINERs layer,
+    # it is based on. (Typically the empty `scratch` image, a MAINTAINER layer,
     # and the un-tarred base).
+    $ docker pull --all-tags centos
+    # will pull all the images from the centos repository
     $ docker pull registry.hub.docker.com/debian
     # manually specifies the path to the default Docker registry. This could
     # be replaced with the path to a local registry to pull from another source.


### PR DESCRIPTION
This PR changes `docker pull` to add a flag called `--all-tags` (`-a` for the short version) to make Docker pull only the latest tag of a repository by default.

These changes are limited to the Docker CLI. The API and the daemon aren't modified for this change.

This will help speed up pulls. This PR is also removing the --tag flag because it doesn't make sense to keep it around any more.

The docs have been added, thanks to @SvenDowideit.
