### PR TITLE
Update centos.md

### DIFF
--- a/docs/sources/installation/centos.md
+++ b/docs/sources/installation/centos.md
@@ -76,7 +76,7 @@ will install Docker on our host.
 In some cases the EPEL repository has to be explicitly declared within the command as follows:
     
     $ sudo yum --enablerepo=epel install docker-io
-
+    
 ## Using Docker
 
 Once Docker is installed, you will need to start the docker daemon.

--- a/docs/sources/installation/centos.md
+++ b/docs/sources/installation/centos.md
@@ -72,6 +72,10 @@ Next, let's install the `docker-io` package which
 will install Docker on our host.
 
     $ sudo yum install docker-io
+    
+In some cases the EPEL repository has to be explicitly declared within the command as follows:
+    
+    $ sudo yum --enablerepo=epel install docker-io
 
 ## Using Docker
 


### PR DESCRIPTION
Added the flag '--enablerepo=epel' within the CentOS 6 instructions, as I had problems installing on a CentOS 6.5 box.  Although the EPEL repository had been successfully added to the list, I had to explicitly include it in the 'yum' command in order to search it.
