### PR TITLE
hack/make: fix test-unit target to propogate TESTFLAGS properly

### DIFF
--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -56,7 +56,7 @@ go_run_test_dir() {
 		echo
 		echo '+ go test' $TESTFLAGS "${DOCKER_PKG}${dir#.}"
 		precompiled="$DEST/precompiled/$dir.test"
-		if ! ( cd "$dir" && "$precompiled" ); then
+		if ! ( cd "$dir" && "$precompiled" $TESTFLAGS ); then
 			TESTS_FAILED+=("$dir")
 			echo
 			echo "${RED}Tests failed: $dir${TEXTRESET}"


### PR DESCRIPTION
`TESTFLAGS=-test.v make test-unit` currently does not echo the (very useful) output of `go test -v`. This fixes it.

/cc @tianon 
