### PR TITLE
fix temporary directory removal for TempArchive

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -230,6 +230,11 @@ func (graph *Graph) TempLayerArchive(id string, compression archive.Compression,
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		if err != nil {
+			os.RemoveAll(tmp)
+		}
+	}()
 	a, err := image.TarLayer()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes the removal of the directories created for TempArchive during push from the graph/_tmp/\* directories.
