### PR TITLE
Remove volumes after build

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -555,9 +555,11 @@ func (b *Builder) clearTmp() {
 		tmp := b.Daemon.Get(c)
 		if err := b.Daemon.Destroy(tmp); err != nil {
 			fmt.Fprintf(b.OutStream, "Error removing intermediate container %s: %s\n", utils.TruncateID(c), err.Error())
-		} else {
-			delete(b.TmpContainers, c)
-			fmt.Fprintf(b.OutStream, "Removing intermediate container %s\n", utils.TruncateID(c))
+			return
 		}
+		volumes, _ := tmp.GetVolumes()
+		b.Daemon.RemoveVolumes(volumes)
+		delete(b.TmpContainers, c)
+		fmt.Fprintf(b.OutStream, "Removing intermediate container %s\n", utils.TruncateID(c))
 	}
 }

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1218,3 +1218,16 @@ func (container *Container) getBindMap() (map[string]*Volume, error) {
 	}
 	return volumes, nil
 }
+
+func (container *Container) derefVolumes() error {
+	volumes, err := container.GetVolumes()
+	if err != nil {
+		return err
+	}
+
+	for _, vol := range volumes {
+		container.daemon.volumes.RemoveRef(vol, container.ID)
+	}
+
+	return nil
+}

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -29,6 +29,10 @@ func (v *Volume) isDir() (bool, error) {
 	return stat.IsDir(), nil
 }
 
+func (v *Volume) Id() string {
+	return filepath.Base(v.HostPath)
+}
+
 func prepareVolumesForContainer(container *Container) error {
 	if container.Volumes == nil || len(container.Volumes) == 0 {
 		container.Volumes = make(map[string]string)
@@ -233,6 +237,8 @@ func (v *Volume) initialize(container *Container) error {
 
 	container.Volumes[v.VolPath] = hostPath
 	container.VolumesRW[v.VolPath] = v.isReadWrite
+	container.daemon.volumes.Add(v)
+	container.daemon.volumes.AddRef(v, container)
 
 	volIsDir, err := v.isDir()
 	if err != nil {
@@ -246,6 +252,7 @@ func (v *Volume) initialize(container *Container) error {
 	if v.isReadWrite && !v.isBindMount {
 		return copyExistingContents(fullVolPath, hostPath)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Since these volumes are both unreferencable, and should be completely
reproducible by subsequent builds, they can be safely removed.

Resolves #6993 which was closed but not dealt with.

In the original implementation we decided that the way `docker rm -v` was traversing the whole container graph to see if any of the containers were referencing the volume being deleted was not ideal, especially when it's called after each build step (or even just at the end of the build).
Instead this is now implemented with a volume->container mapping.
Incidentally this is also laying some of the groundwork for first class volumes.
