### PR TITLE
graph: remove obsolete comments

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -90,7 +90,6 @@ func (graph *Graph) Get(name string) (*image.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	// FIXME: return nil when the image doesn't exist, instead of an error
 	img, err := image.LoadImage(graph.ImageRoot(id))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Graph.Get function already returns nil when the image doesn't exist so
following comment is obsolete.
FIXME: return nil when the image doesn't exist, instead of an error

Signed-off-by: Daehyeok.Mun daehyeok@gmail.com
