### PR TITLE
add docker- prefix to generated hostnames

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -492,7 +492,7 @@ func (daemon *Daemon) generateHostname(id string, config *runconfig.Config) {
 	// Generate default hostname
 	// FIXME: the lxc template no longer needs to set a default hostname
 	if config.Hostname == "" {
-		config.Hostname = id[:12]
+		config.Hostname = "docker-" + id[:12]
 	}
 }
 


### PR DESCRIPTION
this ensures rfc-compliant hostnames by ensuring that are (a) not all
numeric and (b) start with an alpha.

Given a command like:

```
docker run -it fedora /bin/bash
```

This will result in something like:

```
bash-4.2# hostname
docker-6d41d2951bd7
```

this addresses docker issue #7756
