### PR TITLE
Fix panic when `ENV ARG=ARG` is used.

### DIFF
--- a/builder/parser/line_parsers.go
+++ b/builder/parser/line_parsers.go
@@ -9,6 +9,7 @@ package parser
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -43,6 +44,11 @@ func parseEnv(rest string) (*Node, map[string]bool, error) {
 	node := &Node{}
 	rootnode := node
 	strs := TOKEN_WHITESPACE.Split(rest, 2)
+
+	if len(strs) < 2 {
+		return nil, nil, fmt.Errorf("ENV must have two arguments")
+	}
+
 	node.Value = strs[0]
 	node.Next = &Node{}
 	node.Next.Value = strs[1]

--- a/builder/parser/testfiles-negative/env_equals_env/Dockerfile
+++ b/builder/parser/testfiles-negative/env_equals_env/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+
+ENV PATH=PATH


### PR DESCRIPTION
Closes #7813 
