### PR TITLE
fixed error check using the wrong error value

### DIFF
--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -20,7 +20,7 @@ func TestTopNonPrivileged(t *testing.T) {
 
 	topCmd = exec.Command(dockerBinary, "top", cleanedContainerID)
 	out2, _, err2 := runCommandWithOutput(topCmd)
-	errorOut(err, t, fmt.Sprintf("failed to run top: %v %v", out2, err2))
+	errorOut(err2, t, fmt.Sprintf("failed to run top: %v %v", out2, err2))
 
 	killCmd := exec.Command(dockerBinary, "kill", cleanedContainerID)
 	_, err = runCommand(killCmd)


### PR DESCRIPTION
errorOut was using the err from the previous test.
