### PR TITLE
Add more error info to TestDockerRunEchoStdoutWithMemoryLimit

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -41,8 +41,10 @@ func TestDockerRunEchoStdoutWithMemoryLimit(t *testing.T) {
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	errorOut(err, t, out)
 
-	if out != "test\n" {
-		t.Errorf("container should've printed 'test'")
+	out = strings.Trim(out, "\r\n")
+
+	if expected := "test"; out != expected {
+		t.Errorf("container should've printed %q but printed %q", expected, out)
 
 	}
 


### PR DESCRIPTION
This test fails on my CI server often so we need more info when it does
happen with this test.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
