### PR TITLE
Removed runconfig.ParseSubcommand

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2000,8 +2000,7 @@ func (cli *DockerCli) pullImage(image string) error {
 }
 
 func (cli *DockerCli) CmdRun(args ...string) error {
-	// FIXME: just use runconfig.Parse already
-	config, hostConfig, cmd, err := runconfig.ParseSubcommand(cli.Subcmd("run", "IMAGE [COMMAND] [ARG...]", "Run a command in a new container"), args, nil)
+	config, hostConfig, cmd, err := runconfig.Parse(cli.Subcmd("run", "IMAGE [COMMAND] [ARG...]", "Run a command in a new container"), args, nil)
 	if err != nil {
 		return err
 	}

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -9,11 +9,13 @@ package builder
 
 import (
 	"fmt"
+	"io/ioutil"
 	"path/filepath"
 	"strings"
 
 	"github.com/docker/docker/nat"
 	"github.com/docker/docker/pkg/log"
+	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/runconfig"
 )
 
@@ -172,7 +174,11 @@ func run(b *Builder, args []string, attributes map[string]bool) error {
 		return fmt.Errorf("Please provide a source image with `from` prior to run")
 	}
 
-	config, _, _, err := runconfig.Parse(append([]string{b.image}, args...), nil)
+	runCmd := flag.NewFlagSet("run", flag.ContinueOnError)
+	runCmd.SetOutput(ioutil.Discard)
+	runCmd.Usage = nil
+
+	config, _, _, err := runconfig.Parse(runCmd, append([]string{b.image}, args...), nil)
 	if err != nil {
 		return err
 	}

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -663,7 +663,7 @@ func TestDefaultContainerName(t *testing.T) {
 	daemon := mkDaemonFromEngine(eng, t)
 	defer nuke(daemon)
 
-	config, _, _, err := runconfig.Parse([]string{unitTestImageID, "echo test"}, nil)
+	config, _, _, err := parseRun([]string{unitTestImageID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -687,7 +687,7 @@ func TestRandomContainerName(t *testing.T) {
 	daemon := mkDaemonFromEngine(eng, t)
 	defer nuke(daemon)
 
-	config, _, _, err := runconfig.Parse([]string{GetTestImage(daemon).ID, "echo test"}, nil)
+	config, _, _, err := parseRun([]string{GetTestImage(daemon).ID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -718,7 +718,7 @@ func TestContainerNameValidation(t *testing.T) {
 		{"abc-123_AAA.1", true},
 		{"\000asdf", false},
 	} {
-		config, _, _, err := runconfig.Parse([]string{unitTestImageID, "echo test"}, nil)
+		config, _, _, err := parseRun([]string{unitTestImageID, "echo test"}, nil)
 		if err != nil {
 			if !test.Valid {
 				continue
@@ -759,7 +759,7 @@ func TestLinkChildContainer(t *testing.T) {
 	daemon := mkDaemonFromEngine(eng, t)
 	defer nuke(daemon)
 
-	config, _, _, err := runconfig.Parse([]string{unitTestImageID, "echo test"}, nil)
+	config, _, _, err := parseRun([]string{unitTestImageID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -775,7 +775,7 @@ func TestLinkChildContainer(t *testing.T) {
 		t.Fatalf("Expect webapp id to match container id: %s != %s", webapp.ID, container.ID)
 	}
 
-	config, _, _, err = runconfig.Parse([]string{GetTestImage(daemon).ID, "echo test"}, nil)
+	config, _, _, err = parseRun([]string{GetTestImage(daemon).ID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -801,7 +801,7 @@ func TestGetAllChildren(t *testing.T) {
 	daemon := mkDaemonFromEngine(eng, t)
 	defer nuke(daemon)
 
-	config, _, _, err := runconfig.Parse([]string{unitTestImageID, "echo test"}, nil)
+	config, _, _, err := parseRun([]string{unitTestImageID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -817,7 +817,7 @@ func TestGetAllChildren(t *testing.T) {
 		t.Fatalf("Expect webapp id to match container id: %s != %s", webapp.ID, container.ID)
 	}
 
-	config, _, _, err = runconfig.Parse([]string{unitTestImageID, "echo test"}, nil)
+	config, _, _, err = parseRun([]string{unitTestImageID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -6,14 +6,13 @@ import (
 	"time"
 
 	"github.com/docker/docker/engine"
-	"github.com/docker/docker/runconfig"
 )
 
 func TestCreateNumberHostname(t *testing.T) {
 	eng := NewTestEngine(t)
 	defer mkDaemonFromEngine(eng, t).Nuke()
 
-	config, _, _, err := runconfig.Parse([]string{"-h", "web.0", unitTestImageID, "echo test"}, nil)
+	config, _, _, err := parseRun([]string{"-h", "web.0", unitTestImageID, "echo test"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +24,7 @@ func TestCommit(t *testing.T) {
 	eng := NewTestEngine(t)
 	defer mkDaemonFromEngine(eng, t).Nuke()
 
-	config, _, _, err := runconfig.Parse([]string{unitTestImageID, "/bin/cat"}, nil)
+	config, _, _, err := parseRun([]string{unitTestImageID, "/bin/cat"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +48,7 @@ func TestMergeConfigOnCommit(t *testing.T) {
 	container1, _, _ := mkContainer(runtime, []string{"-e", "FOO=bar", unitTestImageID, "echo test > /tmp/foo"}, t)
 	defer runtime.Destroy(container1)
 
-	config, _, _, err := runconfig.Parse([]string{container1.ID, "cat /tmp/foo"}, nil)
+	config, _, _, err := parseRun([]string{container1.ID, "cat /tmp/foo"}, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -103,7 +102,7 @@ func TestRestartKillWait(t *testing.T) {
 	runtime := mkDaemonFromEngine(eng, t)
 	defer runtime.Nuke()
 
-	config, hostConfig, _, err := runconfig.Parse([]string{"-i", unitTestImageID, "/bin/cat"}, nil)
+	config, hostConfig, _, err := parseRun([]string{"-i", unitTestImageID, "/bin/cat"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -164,7 +163,7 @@ func TestCreateStartRestartStopStartKillRm(t *testing.T) {
 	eng := NewTestEngine(t)
 	defer mkDaemonFromEngine(eng, t).Nuke()
 
-	config, hostConfig, _, err := runconfig.Parse([]string{"-i", unitTestImageID, "/bin/cat"}, nil)
+	config, hostConfig, _, err := parseRun([]string{"-i", unitTestImageID, "/bin/cat"}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/pkg/log"
+	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
 )
@@ -248,7 +250,7 @@ func readFile(src string, t *testing.T) (content string) {
 // The caller is responsible for destroying the container.
 // Call t.Fatal() at the first error.
 func mkContainer(r *daemon.Daemon, args []string, t *testing.T) (*daemon.Container, *runconfig.HostConfig, error) {
-	config, hc, _, err := runconfig.Parse(args, nil)
+	config, hc, _, err := parseRun(args, nil)
 	defer func() {
 		if err != nil && t != nil {
 			t.Fatal(err)
@@ -347,4 +349,11 @@ func getImages(eng *engine.Engine, t *testing.T, all bool, filter string) *engin
 	}
 	return images
 
+}
+
+func parseRun(args []string, sysInfo *sysinfo.SysInfo) (*runconfig.Config, *runconfig.HostConfig, *flag.FlagSet, error) {
+	cmd := flag.NewFlagSet("run", flag.ContinueOnError)
+	cmd.SetOutput(ioutil.Discard)
+	cmd.Usage = nil
+	return runconfig.Parse(cmd, args, sysInfo)
 }

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func parse(t *testing.T, args string) (*Config, *HostConfig, error) {
-	config, hostConfig, _, err := Parse(strings.Split(args+" ubuntu bash", " "), nil)
+	config, hostConfig, _, err := parseRun(strings.Split(args+" ubuntu bash", " "), nil)
 	return config, hostConfig, err
 }
 

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -2,7 +2,6 @@ package runconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"path"
 	"strconv"
 	"strings"
@@ -28,20 +27,7 @@ var (
 	ErrConflictRestartPolicyAndAutoRemove = fmt.Errorf("Conflicting options: --restart and --rm")
 )
 
-//FIXME Only used in tests
-func Parse(args []string, sysInfo *sysinfo.SysInfo) (*Config, *HostConfig, *flag.FlagSet, error) {
-	cmd := flag.NewFlagSet("run", flag.ContinueOnError)
-	cmd.SetOutput(ioutil.Discard)
-	cmd.Usage = nil
-	return parseRun(cmd, args, sysInfo)
-}
-
-// FIXME: this maps the legacy commands.go code. It should be merged with Parse to only expose a single parse function.
-func ParseSubcommand(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config, *HostConfig, *flag.FlagSet, error) {
-	return parseRun(cmd, args, sysInfo)
-}
-
-func parseRun(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config, *HostConfig, *flag.FlagSet, error) {
+func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config, *HostConfig, *flag.FlagSet, error) {
 	var (
 		// FIXME: use utils.ListOpts for attach and volumes?
 		flAttach  = opts.NewListOpts(opts.ValidateAttach)

--- a/runconfig/parse_test.go
+++ b/runconfig/parse_test.go
@@ -1,10 +1,20 @@
 package runconfig
 
 import (
+	"io/ioutil"
 	"testing"
 
+	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/parsers"
+	"github.com/docker/docker/pkg/sysinfo"
 )
+
+func parseRun(args []string, sysInfo *sysinfo.SysInfo) (*Config, *HostConfig, *flag.FlagSet, error) {
+	cmd := flag.NewFlagSet("run", flag.ContinueOnError)
+	cmd.SetOutput(ioutil.Discard)
+	cmd.Usage = nil
+	return Parse(cmd, args, sysInfo)
+}
 
 func TestParseLxcConfOpt(t *testing.T) {
 	opts := []string{"lxc.utsname=docker", "lxc.utsname = docker "}
@@ -24,27 +34,27 @@ func TestParseLxcConfOpt(t *testing.T) {
 }
 
 func TestNetHostname(t *testing.T) {
-	if _, _, _, err := Parse([]string{"-h=name", "img", "cmd"}, nil); err != nil {
+	if _, _, _, err := parseRun([]string{"-h=name", "img", "cmd"}, nil); err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
-	if _, _, _, err := Parse([]string{"--net=host", "img", "cmd"}, nil); err != nil {
+	if _, _, _, err := parseRun([]string{"--net=host", "img", "cmd"}, nil); err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
-	if _, _, _, err := Parse([]string{"-h=name", "--net=bridge", "img", "cmd"}, nil); err != nil {
+	if _, _, _, err := parseRun([]string{"-h=name", "--net=bridge", "img", "cmd"}, nil); err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
-	if _, _, _, err := Parse([]string{"-h=name", "--net=none", "img", "cmd"}, nil); err != nil {
+	if _, _, _, err := parseRun([]string{"-h=name", "--net=none", "img", "cmd"}, nil); err != nil {
 		t.Fatalf("Unexpected error: %s", err)
 	}
 
-	if _, _, _, err := Parse([]string{"-h=name", "--net=host", "img", "cmd"}, nil); err != ErrConflictNetworkHostname {
+	if _, _, _, err := parseRun([]string{"-h=name", "--net=host", "img", "cmd"}, nil); err != ErrConflictNetworkHostname {
 		t.Fatalf("Expected error ErrConflictNetworkHostname, got: %s", err)
 	}
 
-	if _, _, _, err := Parse([]string{"-h=name", "--net=container:other", "img", "cmd"}, nil); err != ErrConflictNetworkHostname {
+	if _, _, _, err := parseRun([]string{"-h=name", "--net=container:other", "img", "cmd"}, nil); err != ErrConflictNetworkHostname {
 		t.Fatalf("Expected error ErrConflictNetworkHostname, got: %s", err)
 	}
 }


### PR DESCRIPTION
Removed runconfig.ParseSubcommand,
changed it to runconfig.Parse
and editted related tests and modules.

Signed-off-by: Oh Jinkyun tintypemolly@gmail.com
