### PR TITLE
Fix line delimited JSON response

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -278,6 +278,8 @@ func getEvents(eng *engine.Engine, version version.Version, w http.ResponseWrite
 	}
 
 	var job = eng.Job("events")
+	// lineDelimited JSON events was added #7047
+	job.SetenvBool("lineDelim", version.GreaterThanOrEqualTo("1.15"))
 	streamJSON(job, w, true)
 	job.Setenv("since", r.Form.Get("since"))
 	job.Setenv("until", r.Form.Get("until"))

--- a/events/events.go
+++ b/events/events.go
@@ -101,6 +101,11 @@ func writeEvent(job *engine.Job, event *utils.JSONMessage) error {
 	// When sending an event JSON serialization errors are ignored, but all
 	// other errors lead to the eviction of the listener.
 	if b, err := json.Marshal(event); err == nil {
+
+		if job.GetenvBool("lineDelim") {
+			b = append(b, []byte("\r\n")...)
+		}
+
 		if _, err = job.Stdout.Write(b); err != nil {
 			return err
 		}

--- a/integration-cli/docker_api_events_test.go
+++ b/integration-cli/docker_api_events_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestGetEventsLineDelim(t *testing.T) {
+	name := "testimageevents"
+	defer deleteImages(name)
+	_, err := buildImage(name,
+		`FROM scratch
+        MAINTAINER "docker"`,
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := deleteImages(name); err != nil {
+		t.Fatal(err)
+	}
+
+	endpoint := fmt.Sprintf("/events?since=1&until=%d", time.Now().Unix())
+	body, err := sockRequest("GET", endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	linesRead := 0
+	scanner := bufio.NewScanner(bytes.NewReader(body))
+	for scanner.Scan() && linesRead < 2 {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		// make sure line delimited json
+		res := make(map[string]interface{})
+		if err := json.Unmarshal(line, &res); err != nil {
+			t.Fatalf("Unmarshaling the line as JSON failed: %v", err)
+		}
+
+		linesRead++
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("Scanner failed: %v", err)
+	}
+
+	if linesRead < 2 {
+		t.Fatalf("Only %d lines were read from the stream", linesRead)
+	}
+
+	logDone("events - test the api response is line delimited json")
+}


### PR DESCRIPTION
For GET /events, line delimit JSON.
Fixes #7047

Signed-off-by: Jessica Frazelle jfrazelle@users.noreply.github.com
