### PR TITLE
Links v2: Execin & Ethernet move

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -29,6 +31,7 @@ import (
 	"github.com/docker/docker/pkg/networkfs/etchosts"
 	"github.com/docker/docker/pkg/networkfs/resolvconf"
 	"github.com/docker/docker/pkg/symlink"
+	"github.com/docker/docker/reexec"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
 )
@@ -88,6 +91,43 @@ type Container struct {
 
 	activeLinks map[string]*links.Link
 	monitor     *containerMonitor
+}
+
+func (container *Container) MoveEthernetDevice(c2 *Container, deviceName string) error {
+	if deviceName == "" {
+		return fmt.Errorf("Please supply a deviceName to MoveEthernetDevice")
+	}
+
+	if !container.State.IsRunning() {
+		return fmt.Errorf("Tried to move an ethernet device from a stopped container")
+	}
+
+	if !c2.State.IsRunning() {
+		return fmt.Errorf("Tried to move an ethernet device to a stopped container")
+	}
+
+	var (
+		ip      = fmt.Sprintf("%s/%s", container.NetworkSettings.IPAddress, strconv.Itoa(container.NetworkSettings.IPPrefixLen))
+		gateway = container.NetworkSettings.Gateway
+	)
+
+	cmd := exec.Cmd{
+		Path: reexec.Self(),
+		Args: []string{
+			"docker-network-movens",
+			"-frompid", strconv.Itoa(container.State.Pid),
+			"-topid", strconv.Itoa(c2.State.Pid),
+			"-ip", ip,
+			"-gateway", gateway,
+			"-device", deviceName,
+		},
+	}
+
+	// FIXME(erikh): this probably shouldn't be done here.
+	c2.NetworkSettings = container.NetworkSettings
+	c2.command.Network = container.command.Network
+	container.command.Network = nil
+	return cmd.Run()
 }
 
 func (container *Container) FromDisk() error {

--- a/links/reexec_hooks.go
+++ b/links/reexec_hooks.go
@@ -1,0 +1,54 @@
+package links
+
+import (
+	"flag"
+	"log"
+	"os"
+	"syscall"
+
+	"github.com/docker/docker/pkg/execin"
+	"github.com/docker/docker/reexec"
+)
+
+func init() {
+	reexec.Register("docker-network-movens", networkMoveNS)
+}
+
+func networkMoveNS() {
+	var (
+		frompid = flag.String("frompid", "", "")
+		topid   = flag.String("topid", "", "")
+		ipaddr  = flag.String("ip", "", "")
+		gateway = flag.String("gateway", "", "")
+		device  = flag.String("device", "eth0", "")
+	)
+
+	flag.Parse()
+
+	f1, err := netNamespace(*frompid)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	f2, err := netNamespace(*topid)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = execin.ExecIn(
+		f1,
+		syscall.CLONE_NEWNET,
+		moveVethDevice(
+			f1, f2,
+			NetworkSettings{
+				IpNet:      *ipaddr,
+				Gateway:    *gateway,
+				DeviceName: *device,
+			}))
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Exit(0)
+}

--- a/links/reexec_support.go
+++ b/links/reexec_support.go
@@ -1,0 +1,55 @@
+package links
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/docker/libcontainer/network"
+	"github.com/docker/libcontainer/system"
+)
+
+type NetworkSettings struct {
+	DeviceName string
+	IpNet      string
+	Gateway    string
+}
+
+func netNamespace(pid string) (*os.File, error) {
+	f, err := os.Open(fmt.Sprintf("/proc/%s/ns/net", pid))
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+func moveVethDevice(enterFd *os.File, targetFd *os.File, netSettings NetworkSettings) func() error {
+	return func() error {
+		if err := network.InterfaceDown(netSettings.DeviceName); err != nil {
+			return err
+		}
+
+		if err := network.SetInterfaceInNamespaceFd(netSettings.DeviceName, targetFd.Fd()); err != nil {
+			return err
+		}
+
+		if err := system.Setns(targetFd.Fd(), syscall.CLONE_NEWNET); err != nil {
+			return err
+		}
+
+		if err := network.SetInterfaceIp(netSettings.DeviceName, netSettings.IpNet); err != nil {
+			return err
+		}
+
+		if err := network.SetDefaultGateway(netSettings.Gateway, netSettings.DeviceName); err != nil {
+			return err
+		}
+
+		if err := network.InterfaceUp(netSettings.DeviceName); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}

--- a/pkg/execin/execin.go
+++ b/pkg/execin/execin.go
@@ -1,0 +1,19 @@
+package execin
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/docker/libcontainer/system"
+)
+
+func ExecIn(execFile *os.File, cloneOpts uintptr, enterFunc func() error) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	if err := system.Setns(execFile.Fd(), cloneOpts); err != nil {
+		return err
+	}
+
+	return enterFunc()
+}


### PR DESCRIPTION
This is a part of linksv2. This provides two sets of coupled functionality. `execin` provides a way to execute operations within a namespace (via libcontainer) and `MoveEthernetDevice` is hopefully self-explanatory.

I don't currently have tests because the bits required to get integration-cli to play well are not there yet. So, please do not merge, but review carefully. Thanks!
