### PR TITLE
Links v2: Migrate Links to Jobs, with supporting API.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -26,8 +26,8 @@ import (
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/graph"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/links"
 	"github.com/docker/docker/pkg/broadcastwriter"
-	"github.com/docker/docker/pkg/graphdb"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/log"
 	"github.com/docker/docker/pkg/namesgenerator"
@@ -82,23 +82,27 @@ func (c *contStore) List() []*Container {
 }
 
 type Daemon struct {
-	repository     string
-	sysInitPath    string
-	containers     *contStore
-	graph          *graph.Graph
-	repositories   *graph.TagStore
-	idIndex        *truncindex.TruncIndex
-	sysInfo        *sysinfo.SysInfo
-	volumes        *graph.Graph
-	eng            *engine.Engine
-	config         *Config
-	containerGraph *graphdb.Database
-	driver         graphdriver.Driver
-	execDriver     execdriver.Driver
+	repository   string
+	sysInitPath  string
+	containers   *contStore
+	graph        *graph.Graph
+	repositories *graph.TagStore
+	idIndex      *truncindex.TruncIndex
+	sysInfo      *sysinfo.SysInfo
+	volumes      *graph.Graph
+	eng          *engine.Engine
+	config       *Config
+	driver       graphdriver.Driver
+	execDriver   execdriver.Driver
+	links        *links.Links
 }
 
 // Install installs daemon capabilities to eng.
 func (daemon *Daemon) Install(eng *engine.Engine) error {
+	if err := daemon.links.RegisterJobs(eng); err != nil {
+		return err
+	}
+
 	// FIXME: remove ImageDelete's dependency on Daemon, then move to graph/
 	for name, method := range map[string]engine.Handler{
 		"attach":            daemon.ContainerAttach,
@@ -283,6 +287,30 @@ func (daemon *Daemon) LogToDisk(src *broadcastwriter.BroadcastWriter, dst, strea
 	return nil
 }
 
+func (daemon *Daemon) createName(id, name string) error {
+	createJob := daemon.eng.Job("create_name")
+	createJob.Setenv("Name", name)
+	createJob.Setenv("ID", id)
+
+	if err := createJob.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (daemon *Daemon) deleteName(name string) error {
+	deleteJob := daemon.eng.Job("delete_name")
+	deleteJob.Setenv("Name", name)
+
+	// Remove name and continue starting the container
+	if err := deleteJob.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (daemon *Daemon) restore() error {
 	var (
 		debug         = (os.Getenv("DEBUG") != "" || os.Getenv("TEST") != "")
@@ -321,26 +349,24 @@ func (daemon *Daemon) restore() error {
 
 	registeredContainers := []*Container{}
 
-	if entities := daemon.containerGraph.List("/", -1); entities != nil {
-		for _, p := range entities.Paths() {
-			if !debug {
-				fmt.Print(".")
-			}
-
-			e := entities[p]
-
-			if container, ok := containers[e.ID()]; ok {
-				if err := daemon.register(container, false); err != nil {
-					log.Debugf("Failed to register container %s: %s", container.ID, err)
-				}
-
-				registeredContainers = append(registeredContainers, container)
-
-				// delete from the map so that a new name is not automatically generated
-				delete(containers, e.ID())
-			}
+	daemon.links.Each("/", func(p, id string) error {
+		if !debug {
+			fmt.Print(".")
 		}
-	}
+
+		if container, ok := containers[id]; ok {
+			if err := daemon.register(container, false); err != nil {
+				log.Debugf("Failed to register container %s: %s", container.ID, err)
+			}
+
+			registeredContainers = append(registeredContainers, container)
+
+			// delete from the map so that a new name is not automatically generated
+			delete(containers, id)
+		}
+
+		return nil
+	})
 
 	// Any containers that are left over do not exist in the graph
 	for _, container := range containers {
@@ -439,8 +465,8 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 		name = "/" + name
 	}
 
-	if _, err := daemon.containerGraph.Set(name, id); err != nil {
-		if !graphdb.IsNonUniqueNameError(err) {
+	if err := daemon.createName(id, name); err != nil {
+		if err.Error() != links.ErrDuplicateName.Error() {
 			return "", err
 		}
 
@@ -451,7 +477,7 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 			}
 
 			// Remove name and continue starting the container
-			if err := daemon.containerGraph.Delete(name); err != nil {
+			if err := daemon.deleteName(name); err != nil {
 				return "", err
 			}
 		} else {
@@ -472,8 +498,8 @@ func (daemon *Daemon) generateNewName(id string) (string, error) {
 			name = "/" + name
 		}
 
-		if _, err := daemon.containerGraph.Set(name, id); err != nil {
-			if !graphdb.IsNonUniqueNameError(err) {
+		if err := daemon.createName(id, name); err != nil {
+			if err.Error() != links.ErrDuplicateName.Error() {
 				return "", err
 			}
 			continue
@@ -482,7 +508,7 @@ func (daemon *Daemon) generateNewName(id string) (string, error) {
 	}
 
 	name = "/" + utils.TruncateID(id)
-	if _, err := daemon.containerGraph.Set(name, id); err != nil {
+	if err := daemon.createName(id, name); err != nil {
 		return "", err
 	}
 	return name, nil
@@ -588,14 +614,21 @@ func (daemon *Daemon) GetByName(name string) (*Container, error) {
 	if err != nil {
 		return nil, err
 	}
-	entity := daemon.containerGraph.Get(fullName)
-	if entity == nil {
-		return nil, fmt.Errorf("Could not find entity for %s", name)
+
+	getJob := daemon.eng.Job("get_name")
+	getJob.Setenv("Name", fullName)
+
+	if err := getJob.Run(); err != nil {
+		return nil, err
 	}
-	e := daemon.containers.Get(entity.ID())
+
+	id := getJob.Getenv("Result")
+
+	e := daemon.containers.Get(id)
 	if e == nil {
-		return nil, fmt.Errorf("Could not find container for entity id %s", entity.ID())
+		return nil, fmt.Errorf("Could not find container for entity id %s", id)
 	}
+
 	return e, nil
 }
 
@@ -606,14 +639,14 @@ func (daemon *Daemon) Children(name string) (map[string]*Container, error) {
 	}
 	children := make(map[string]*Container)
 
-	err = daemon.containerGraph.Walk(name, func(p string, e *graphdb.Entity) error {
-		c := daemon.Get(e.ID())
+	err = daemon.links.MapChildren(name, func(path, id string) error {
+		c := daemon.Get(id)
 		if c == nil {
-			return fmt.Errorf("Could not get container for name %s and id %s", e.ID(), p)
+			return fmt.Errorf("Could not get container for name %s and id %s", id, path)
 		}
-		children[p] = c
+		children[path] = c
 		return nil
-	}, 0)
+	})
 
 	if err != nil {
 		return nil, err
@@ -627,15 +660,18 @@ func (daemon *Daemon) Parents(name string) ([]string, error) {
 		return nil, err
 	}
 
-	return daemon.containerGraph.Parents(name)
+	return daemon.links.Parents(name)
 }
 
 func (daemon *Daemon) RegisterLink(parent, child *Container, alias string) error {
-	fullName := path.Join(parent.Name, alias)
-	if !daemon.containerGraph.Exists(fullName) {
-		_, err := daemon.containerGraph.Set(fullName, child.ID)
+	createJob := daemon.eng.Job("create_link")
+	createJob.Setenv("ParentName", parent.Name)
+	createJob.Setenv("ChildID", child.ID)
+	createJob.Setenv("Alias", alias)
+	if err := createJob.Run(); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -812,7 +848,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 	}
 
 	graphdbPath := path.Join(config.Root, "linkgraph.db")
-	graph, err := graphdb.NewSqliteConn(graphdbPath)
+	linksObj, err := links.NewLinks(graphdbPath)
 	if err != nil {
 		return nil, err
 	}
@@ -844,20 +880,25 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 	}
 
 	daemon := &Daemon{
-		repository:     daemonRepo,
-		containers:     &contStore{s: make(map[string]*Container)},
-		graph:          g,
-		repositories:   repositories,
-		idIndex:        truncindex.NewTruncIndex([]string{}),
-		sysInfo:        sysInfo,
-		volumes:        volumes,
-		config:         config,
-		containerGraph: graph,
-		driver:         driver,
-		sysInitPath:    sysInitPath,
-		execDriver:     ed,
-		eng:            eng,
+		repository:   daemonRepo,
+		containers:   &contStore{s: make(map[string]*Container)},
+		graph:        g,
+		repositories: repositories,
+		idIndex:      truncindex.NewTruncIndex([]string{}),
+		sysInfo:      sysInfo,
+		volumes:      volumes,
+		config:       config,
+		driver:       driver,
+		sysInitPath:  sysInitPath,
+		execDriver:   ed,
+		eng:          eng,
+		links:        linksObj,
 	}
+
+	if err := daemon.Install(eng); err != nil {
+		return nil, err
+	}
+
 	if err := daemon.checkLocaldns(); err != nil {
 		return nil, err
 	}
@@ -879,8 +920,8 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		if err := daemon.driver.Cleanup(); err != nil {
 			log.Errorf("daemon.driver.Cleanup(): %s", err.Error())
 		}
-		if err := daemon.containerGraph.Close(); err != nil {
-			log.Errorf("daemon.containerGraph.Close(): %s", err.Error())
+		if err := daemon.links.Close(); err != nil {
+			log.Errorf("daemon.links.Close(): %s", err.Error())
 		}
 	})
 
@@ -1053,8 +1094,8 @@ func (daemon *Daemon) Volumes() *graph.Graph {
 	return daemon.volumes
 }
 
-func (daemon *Daemon) ContainerGraph() *graphdb.Database {
-	return daemon.containerGraph
+func (daemon *Daemon) Links() *links.Links {
+	return daemon.links
 }
 
 func (daemon *Daemon) checkLocaldns() error {

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -44,7 +44,7 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 	}
 
 	names := map[string][]string{}
-	daemon.links.Each("/", func(path, id string) error {
+	daemon.EachEntity("/", func(path, id string) error {
 		names[id] = append(names[id], path)
 		return nil
 	})

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/docker/pkg/graphdb"
-
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/pkg/parsers/filters"
 )
@@ -46,10 +44,10 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 	}
 
 	names := map[string][]string{}
-	daemon.ContainerGraph().Walk("/", func(p string, e *graphdb.Entity) error {
-		names[e.ID()] = append(names[e.ID()], p)
+	daemon.links.Each("/", func(path, id string) error {
+		names[id] = append(names[id], path)
 		return nil
-	}, -1)
+	})
 
 	var beforeCont, sinceCont *Container
 	if before != "" {

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -46,9 +46,6 @@ func mainDaemon() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if err := d.Install(eng); err != nil {
-			log.Fatal(err)
-		}
 
 		b := &builder.BuilderJob{eng, d}
 		b.Install()

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -38,6 +38,15 @@ func Register(name string, handler Handler) error {
 	return nil
 }
 
+func RegisterMap(m map[string]Handler) error {
+	for name, handler := range m {
+		if err := Register(name, handler); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func unregister(name string) {
 	delete(globalHandlers, name)
 }
@@ -66,6 +75,15 @@ func (eng *Engine) Register(name string, handler Handler) error {
 		return fmt.Errorf("Can't overwrite handler for command %s", name)
 	}
 	eng.handlers[name] = handler
+	return nil
+}
+
+func (eng *Engine) RegisterMap(m map[string]Handler) error {
+	for name, handler := range m {
+		if err := eng.Register(name, handler); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -321,7 +321,7 @@ func TestDaemonCreate(t *testing.T) {
 	)
 
 	if err == nil {
-		t.Fatalf("Name conflict error doesn't include the correct short id. Message was empty.")
+		t.Fatal("Name conflict error doesn't include the correct short id. Message was empty.")
 	}
 
 	if !strings.Contains(err.Error(), utils.TruncateID(testContainer.ID)) {
@@ -795,7 +795,12 @@ func TestLinkChildContainer(t *testing.T) {
 
 	childContainer := daemon.Get(createTestContainer(eng, config, t))
 
-	if err := daemon.Links().CreateLink(webapp.Name, childContainer.ID, "db"); err != nil {
+	linksJob := eng.Job("create_link")
+	linksJob.Setenv("ParentName", webapp.Name)
+	linksJob.Setenv("ChildID", childContainer.ID)
+	linksJob.Setenv("Alias", "db")
+
+	if err := linksJob.Run(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -837,7 +842,12 @@ func TestGetAllChildren(t *testing.T) {
 
 	childContainer := daemon.Get(createTestContainer(eng, config, t))
 
-	if err := daemon.Links().CreateLink(webapp.Name, childContainer.ID, "db"); err != nil {
+	linksJob := eng.Job("create_link")
+	linksJob.Setenv("ParentName", webapp.Name)
+	linksJob.Setenv("ChildID", childContainer.ID)
+	linksJob.Setenv("Alias", "db")
+
+	if err := linksJob.Run(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -311,7 +311,20 @@ func TestDaemonCreate(t *testing.T) {
 		},
 		"conflictname",
 	)
-	if _, _, err := daemon.Create(&runconfig.Config{Image: GetTestImage(daemon).ID, Cmd: []string{"ls", "-al"}}, testContainer.Name); err == nil || !strings.Contains(err.Error(), utils.TruncateID(testContainer.ID)) {
+
+	_, _, err = daemon.Create(
+		&runconfig.Config{
+			Image: GetTestImage(daemon).ID,
+			Cmd:   []string{"ls", "-al"},
+		},
+		testContainer.Name,
+	)
+
+	if err == nil {
+		t.Fatalf("Name conflict error doesn't include the correct short id. Message was empty.")
+	}
+
+	if !strings.Contains(err.Error(), utils.TruncateID(testContainer.ID)) {
 		t.Fatalf("Name conflict error doesn't include the correct short id. Message was: %s", err.Error())
 	}
 
@@ -782,7 +795,7 @@ func TestLinkChildContainer(t *testing.T) {
 
 	childContainer := daemon.Get(createTestContainer(eng, config, t))
 
-	if err := daemon.RegisterLink(webapp, childContainer, "db"); err != nil {
+	if err := daemon.Links().CreateLink(webapp.Name, childContainer.ID, "db"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -824,7 +837,7 @@ func TestGetAllChildren(t *testing.T) {
 
 	childContainer := daemon.Get(createTestContainer(eng, config, t))
 
-	if err := daemon.RegisterLink(webapp, childContainer, "db"); err != nil {
+	if err := daemon.Links().CreateLink(webapp.Name, childContainer.ID, "db"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -187,11 +187,8 @@ func newTestEngine(t log.Fataler, autorestart bool, root string) *engine.Engine 
 		// otherwise NewDaemon will fail because of conflicting settings.
 		InterContainerCommunication: true,
 	}
-	d, err := daemon.NewDaemon(cfg, eng)
+	_, err := daemon.NewDaemon(cfg, eng)
 	if err != nil {
-		t.Fatal(err)
-	}
-	if err := d.Install(eng); err != nil {
 		t.Fatal(err)
 	}
 	return eng

--- a/links/jobs.go
+++ b/links/jobs.go
@@ -1,0 +1,86 @@
+package links
+
+import "github.com/docker/docker/engine"
+
+func (lm *Links) RegisterJobs(eng *engine.Engine) error {
+	return eng.RegisterMap(map[string]engine.Handler{
+		"create_link":  lm.createLink,
+		"purge_link":   lm.purgeLink,
+		"parents_link": lm.listLinks,
+		"create_name":  lm.createName,
+		"get_name":     lm.getName,
+		"delete_name":  lm.deleteName,
+	})
+}
+
+func (lm *Links) listLinks(job *engine.Job) engine.Status {
+	links, err := lm.Links()
+	if err != nil {
+		return job.Error(err)
+	}
+
+	job.SetenvJson("Parents", links)
+
+	return engine.StatusOK
+}
+
+func (lm *Links) createLink(job *engine.Job) engine.Status {
+	var (
+		parentName = job.Getenv("ParentName")
+		childId    = job.Getenv("ChildID")
+		alias      = job.Getenv("Alias")
+	)
+
+	if err := lm.CreateLink(parentName, childId, alias); err != nil {
+		return job.Error(err)
+	}
+
+	return engine.StatusOK
+}
+
+func (lm *Links) purgeLink(job *engine.Job) engine.Status {
+	name := job.Getenv("Name")
+
+	if err := lm.Purge(name); err != nil {
+		return job.Error(err)
+	}
+
+	return engine.StatusOK
+}
+
+func (lm *Links) createName(job *engine.Job) engine.Status {
+	var (
+		name = job.Getenv("Name")
+		id   = job.Getenv("ID")
+	)
+
+	if err := lm.CreateName(name, id); err != nil {
+		return job.Error(err)
+	}
+
+	return engine.StatusOK
+}
+
+func (lm *Links) getName(job *engine.Job) engine.Status {
+	name := job.Getenv("Name")
+
+	res, err := lm.GetID(name)
+
+	if err != nil {
+		return job.Error(err)
+	}
+
+	job.Setenv("Result", res)
+
+	return engine.StatusOK
+}
+
+func (lm *Links) deleteName(job *engine.Job) engine.Status {
+	name := job.Getenv("Name")
+
+	if err := lm.Delete(name); err != nil {
+		return job.Error(err)
+	}
+
+	return engine.StatusOK
+}

--- a/links/linkmanager.go
+++ b/links/linkmanager.go
@@ -1,0 +1,118 @@
+package links
+
+import (
+	"errors"
+	"fmt"
+	"path"
+
+	"github.com/docker/docker/pkg/graphdb"
+)
+
+type Links struct {
+	dbPath         string
+	containerGraph *graphdb.Database
+}
+
+var ErrDuplicateName = errors.New("Conflict: name already exists.")
+
+func NewLinks(dbpath string) (*Links, error) {
+	containerGraph, err := graphdb.NewSqliteConn(dbpath)
+	return &Links{dbpath, containerGraph}, err
+}
+
+func (lm *Links) Close() error {
+	return lm.containerGraph.Close()
+}
+
+func (lm *Links) CreateName(name, id string) error {
+	_, err := lm.containerGraph.Set(name, id)
+
+	if err != nil && graphdb.IsNonUniqueNameError(err) {
+		return ErrDuplicateName
+	}
+
+	return err
+}
+
+func (lm *Links) CreateLink(parentPath, childId, alias string) error {
+	fullPath := path.Join(parentPath, alias)
+	if !lm.containerGraph.Exists(fullPath) {
+		_, err := lm.containerGraph.Set(fullPath, childId)
+		return err
+	}
+	return nil
+}
+
+func (lm *Links) Purge(name string) error {
+	_, err := lm.containerGraph.Purge(name)
+	return err
+}
+
+func (lm *Links) MapChildren(name string, applyFunc func(string, string) error) error {
+	return lm.containerGraph.Walk(name, func(p string, e *graphdb.Entity) error {
+		return applyFunc(p, e.ID())
+	}, 0)
+}
+
+func (lm *Links) Each(query string, queryFunc func(string, string) error) error {
+	entities := lm.containerGraph.List(query, -1)
+
+	if entities == nil {
+		return nil
+	}
+
+	for _, p := range entities.Paths() {
+		if err := queryFunc(p, entities[p].ID()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+func (lm *Links) GetID(name string) (string, error) {
+	entity := lm.containerGraph.Get(name)
+
+	if entity == nil {
+		return "", fmt.Errorf("Could not find entity for %s", name)
+	}
+
+	return entity.ID(), nil
+}
+
+func (lm *Links) Delete(name string) error {
+	return lm.containerGraph.Delete(name)
+}
+
+func (lm *Links) Children(name string) (map[string]string, error) {
+	children := map[string]string{}
+
+	err := lm.MapChildren(name, func(path, id string) error {
+		children[path] = id
+		return nil
+	})
+
+	return children, err
+}
+
+func (lm *Links) Parents(name string) ([]string, error) {
+	return lm.containerGraph.Parents(name)
+}
+
+func (lm *Links) Links() (map[string][]string, error) {
+	result := map[string][]string{}
+	entities := lm.containerGraph.List("/", -1)
+
+	if entities == nil {
+		return result, nil
+	}
+
+	for p, e := range entities {
+		if _, ok := result[p]; ok {
+			result[p] = append(result[p], e.ID())
+		} else {
+			result[p] = []string{e.ID()}
+		}
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
This migrates almost all links operations to jobs. There were a couple of places I haven't been able to resolve cleanly in `daemon/daemon.go`, but these will need an independent evaluation.

This passes all tests, is exercised (hopefully) fully, and should be suitable for merge after review. PTAL, thanks.
