### PR TITLE
Fix TestHostsLinkedContainerUpdate races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test-integration: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh test-integration
 
 test-integration-cli: build
-	$(DOCKER_RUN_DOCKER) hack/make.sh binary test-integration-cli
+	$(DOCKER_RUN_DOCKER) hack/make.sh binary nsinit test-integration-cli
 
 validate: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh validate-gofmt validate-dco

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -46,6 +46,7 @@ DEFAULT_BUNDLES=(
 	validate-gofmt
 
 	binary
+	nsinit
 
 	test-unit
 	test-integration

--- a/hack/make/nsinit
+++ b/hack/make/nsinit
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+DEST=$1
+
+go get github.com/codegangsta/cli
+
+go build \
+	-o "$DEST/nsinit" \
+	"${BUILDFLAGS[@]}" \
+	-ldflags "
+		$LDFLAGS
+	" \
+	github.com/docker/libcontainer/nsinit
+echo "Created binary: $DEST/nsinit"

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -13,7 +13,7 @@ bundle_test_integration_cli() {
 # subshell so that we can export PATH without breaking other things
 exec > >(tee -a $DEST/test.log) 2>&1
 (
-	export PATH="$DEST/../binary:$DEST/../dynbinary:$PATH"
+	export PATH="$DEST/../binary:$DEST/../dynbinary:$DEST/../nsinit:$PATH"
 
 	if ! command -v docker &> /dev/null; then
 		echo >&2 'error: binary or dynbinary must be run before test-integration-cli'

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -9,6 +9,9 @@ import (
 // the docker binary to use
 var dockerBinary = "docker"
 
+// the nsinit binary to use
+var nsinitBinary = "nsinit"
+
 // the private registry image to use for tests involving the registry
 var registryImageName = "registry"
 

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -618,3 +618,18 @@ func readFile(src string, t *testing.T) (content string) {
 	}
 	return string(data)
 }
+
+// execIn executes arbitrary command inside container
+func execIn(id string, args ...string) (string, error) {
+	// resolve possibly name
+	id, err := inspectField(id, "Id")
+	if err != nil {
+		return "", err
+	}
+	statePath := filepath.Join("/var/lib/docker/execdriver/native", id)
+	args = append([]string{"exec"}, args...)
+	cmd := exec.Command(nsinitBinary, args...)
+	cmd.Dir = statePath
+	out, _, err := runCommandWithOutput(cmd)
+	return out, err
+}


### PR DESCRIPTION
Also here I've introduced new binary in integration-cli container - `nsinit`.
One suspicious place is that I need to `go get github.com/codegangsta/cli` for compiling `nsinit`. I personally think that this is okay, because we use it only in `integration-cli`.
This test survived ~500 runs for me with this patch.
