### PR TITLE
Fix an issue where already allocated ports will not trigger an allocation error

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"path"
@@ -1845,4 +1846,22 @@ func TestRunNetworkNotInitializedNoneMode(t *testing.T) {
 	}
 	deleteAllContainers()
 	logDone("run - network must not be initialized in 'none' mode")
+}
+
+func TestRunPortInUse(t *testing.T) {
+	port := "1234"
+	l, err := net.Listen("tcp", ":"+port)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	cmd := exec.Command(dockerBinary, "run", "-p", port+":80", "busybox", "true")
+	out, _, err := runCommandWithOutput(cmd)
+	if err == nil {
+		t.Fatalf("Host port %s already in use, has been allocated by docker: %q", port, out)
+	}
+
+	deleteAllContainers()
+
+	logDone("run - port in use")
 }


### PR DESCRIPTION
This is because the `docker-proxy` reexec does not communicate its exit status back to the parent. I have wrapped the `cmd.Start()` call with some stdio communication to facilitate propagating errors.

This IMO is less than ideal. I think we should implement a small protocol for reexec that would allow error propagation.

Also includes @tiborvass's test that now passes. :)

/cc @LK4D4 @crosbymichael @jfrazelle 
