### PR TITLE
Sven Dowideit 	Update export, copy and build API to say 'TAR STREAM' for all versions.

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.0.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.0.md
@@ -256,7 +256,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -564,7 +564,7 @@ Insert a file from `url` in the image `name` at `path`
 
         HTTP/1.1 200 OK
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
 	Query Parameters:
 
@@ -777,7 +777,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.10.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.10.md
@@ -345,7 +345,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -624,7 +624,7 @@ Copy files or folders of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -1011,7 +1011,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.11.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.11.md
@@ -385,7 +385,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -664,7 +664,7 @@ Copy files or folders of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -1020,7 +1020,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.12.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.12.md
@@ -390,7 +390,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -710,7 +710,7 @@ Copy files or folders of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -1078,7 +1078,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.13.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.13.md
@@ -386,7 +386,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -708,7 +708,7 @@ Copy files or folders of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -1076,7 +1076,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.14.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.14.md
@@ -388,7 +388,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -1080,7 +1080,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.14.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.14.md
@@ -712,7 +712,7 @@ Copy files or folders of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -388,7 +388,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -712,7 +712,7 @@ Copy files or folders of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -1080,7 +1080,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.2.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.2.md
@@ -268,7 +268,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -815,7 +815,7 @@ Build an image from Dockerfile
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.3.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.3.md
@@ -306,7 +306,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -864,7 +864,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.4.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.4.md
@@ -323,7 +323,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -546,7 +546,7 @@ Copy files or folders of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -909,7 +909,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.5.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.5.md
@@ -320,7 +320,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -543,7 +543,7 @@ Copy files or folders of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -921,7 +921,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.6.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.6.md
@@ -370,7 +370,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -650,7 +650,7 @@ Copy files or folders of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -1018,7 +1018,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.7.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.7.md
@@ -326,7 +326,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -599,7 +599,7 @@ Copy files or folders of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -965,7 +965,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.8.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.8.md
@@ -362,7 +362,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -641,7 +641,7 @@ Copy files or folders of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -1007,7 +1007,7 @@ Build an image from Dockerfile via stdin
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.9.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.9.md
@@ -362,7 +362,7 @@ Export the contents of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -645,7 +645,7 @@ Copy files or folders of container `id`
         HTTP/1.1 200 OK
         Content-Type: application/octet-stream
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     Status Codes:
 
@@ -1010,7 +1010,7 @@ Build an image from Dockerfile using a POST body.
 
         POST /build HTTP/1.1
 
-        {{ STREAM }}
+        {{ TAR STREAM }}
 
     **Example response**:
 


### PR DESCRIPTION
I've added `{{ TAR STREAM }}` for export, copy and build

This continues #7882
