### PR TITLE
integ-cli: increase verbosity for mem & cpu test

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -75,7 +75,7 @@ func TestDockerRunEchoStdoutWithCPUAndMemoryLimit(t *testing.T) {
 	errorOut(err, t, out)
 
 	if out != "test\n" {
-		t.Errorf("container should've printed 'test'")
+		t.Errorf("container should've printed 'test', got %q instead", out)
 	}
 
 	deleteAllContainers()


### PR DESCRIPTION
This PR makes TestDockerRunEchoStdoutWithCPUAndMemoryLimit verbose so that we can figure out what's failing.
