### PR TITLE
Fix #7944 add check/test for localhost in ParseHost

### DIFF
--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -43,7 +43,7 @@ func ParseHost(defaultHost string, defaultUnix, addr string) (string, error) {
 		if len(hostParts) != 2 {
 			return "", fmt.Errorf("Invalid bind address format: %s", addr)
 		}
-		if hostParts[0] != "" {
+		if hostParts[0] != "" && hostParts[0] != "localhost" {
 			host = hostParts[0]
 		} else {
 			host = defaultHost

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -18,6 +18,9 @@ func TestParseHost(t *testing.T) {
 	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "0.0.0.1:5555"); err != nil || addr != "tcp://0.0.0.1:5555" {
 		t.Errorf("0.0.0.1:5555 -> expected tcp://0.0.0.1:5555, got %s", addr)
 	}
+	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "localhost:5000"); err != nil || addr != "tcp://127.0.0.1:5000" {
+		t.Errorf("localhost:5000 -> expected tcp://127.0.0.1:5000, got %s", addr)
+	}
 	if addr, err := ParseHost(defaultHttpHost, defaultUnix, ":6666"); err != nil || addr != "tcp://127.0.0.1:6666" {
 		t.Errorf(":6666 -> expected tcp://127.0.0.1:6666, got %s", addr)
 	}


### PR DESCRIPTION
Fixes #7944, adds a test case for `addr` set to `localhost:5000`.

Docker-DCO-1.1-Signed-off-by: Jessica Frazelle jess@docker.com (github: jfrazelle)
