### PR TITLE
Consistent help messages

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/docker/nat"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/log"
+	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/parsers/filters"
 	"github.com/docker/docker/pkg/signal"
@@ -53,47 +54,9 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 			return nil
 		}
 	}
-	help := fmt.Sprintf("Usage: docker [OPTIONS] COMMAND [arg...]\n -H=[unix://%s]: tcp://host:port to bind/connect to or unix://path/to/socket to use\n\nA self-sufficient runtime for linux containers.\n\nCommands:\n", api.DEFAULTUNIXSOCKET)
-	for _, command := range [][]string{
-		{"attach", "Attach to a running container"},
-		{"build", "Build an image from a Dockerfile"},
-		{"commit", "Create a new image from a container's changes"},
-		{"cp", "Copy files/folders from a container's filesystem to the host path"},
-		{"diff", "Inspect changes on a container's filesystem"},
-		{"events", "Get real time events from the server"},
-		{"export", "Stream the contents of a container as a tar archive"},
-		{"history", "Show the history of an image"},
-		{"images", "List images"},
-		{"import", "Create a new filesystem image from the contents of a tarball"},
-		{"info", "Display system-wide information"},
-		{"inspect", "Return low-level information on a container"},
-		{"kill", "Kill a running container"},
-		{"load", "Load an image from a tar archive"},
-		{"login", "Register or log in to a Docker registry server"},
-		{"logout", "Log out from a Docker registry server"},
-		{"logs", "Fetch the logs of a container"},
-		{"port", "Lookup the public-facing port that is NAT-ed to PRIVATE_PORT"},
-		{"pause", "Pause all processes within a container"},
-		{"ps", "List containers"},
-		{"pull", "Pull an image or a repository from a Docker registry server"},
-		{"push", "Push an image or a repository to a Docker registry server"},
-		{"restart", "Restart a running container"},
-		{"rm", "Remove one or more containers"},
-		{"rmi", "Remove one or more images"},
-		{"run", "Run a command in a new container"},
-		{"save", "Save an image to a tar archive"},
-		{"search", "Search for an image on the Docker Hub"},
-		{"start", "Start a stopped container"},
-		{"stop", "Stop a running container"},
-		{"tag", "Tag an image into a repository"},
-		{"top", "Lookup the running processes of a container"},
-		{"unpause", "Unpause a paused container"},
-		{"version", "Show the Docker version information"},
-		{"wait", "Block until a container stops, then print its exit code"},
-	} {
-		help += fmt.Sprintf("    %-10.10s%s\n", command[0], command[1])
-	}
-	fmt.Fprintf(cli.err, "%s\n", help)
+
+	flag.Usage()
+
 	return nil
 }
 

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -39,4 +41,53 @@ func init() {
 	flCert = flag.String([]string{"-tlscert"}, filepath.Join(dockerCertPath, defaultCertFile), "Path to TLS certificate file")
 	flKey = flag.String([]string{"-tlskey"}, filepath.Join(dockerCertPath, defaultKeyFile), "Path to TLS key file")
 	opts.HostListVar(&flHosts, []string{"H", "-host"}, "The socket(s) to bind to in daemon mode\nspecified using one or more tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: docker [OPTIONS] COMMAND [arg...]\n -H=[unix://%s]: tcp://host:port to bind/connect to or unix://path/to/socket to use\n\nA self-sufficient runtime for linux containers.\n\nOptions:\n", api.DEFAULTUNIXSOCKET)
+
+		flag.PrintDefaults()
+
+		help := "\nCommands:\n"
+
+		for _, command := range [][]string{
+			{"attach", "Attach to a running container"},
+			{"build", "Build an image from a Dockerfile"},
+			{"commit", "Create a new image from a container's changes"},
+			{"cp", "Copy files/folders from a container's filesystem to the host path"},
+			{"diff", "Inspect changes on a container's filesystem"},
+			{"events", "Get real time events from the server"},
+			{"export", "Stream the contents of a container as a tar archive"},
+			{"history", "Show the history of an image"},
+			{"images", "List images"},
+			{"import", "Create a new filesystem image from the contents of a tarball"},
+			{"info", "Display system-wide information"},
+			{"inspect", "Return low-level information on a container"},
+			{"kill", "Kill a running container"},
+			{"load", "Load an image from a tar archive"},
+			{"login", "Register or log in to a Docker registry server"},
+			{"logout", "Log out from a Docker registry server"},
+			{"logs", "Fetch the logs of a container"},
+			{"port", "Lookup the public-facing port that is NAT-ed to PRIVATE_PORT"},
+			{"pause", "Pause all processes within a container"},
+			{"ps", "List containers"},
+			{"pull", "Pull an image or a repository from a Docker registry server"},
+			{"push", "Push an image or a repository to a Docker registry server"},
+			{"restart", "Restart a running container"},
+			{"rm", "Remove one or more containers"},
+			{"rmi", "Remove one or more images"},
+			{"run", "Run a command in a new container"},
+			{"save", "Save an image to a tar archive"},
+			{"search", "Search for an image on the Docker Hub"},
+			{"start", "Start a stopped container"},
+			{"stop", "Stop a running container"},
+			{"tag", "Tag an image into a repository"},
+			{"top", "Lookup the running processes of a container"},
+			{"unpause", "Unpause a paused container"},
+			{"version", "Show the Docker version information"},
+			{"wait", "Block until a container stops, then print its exit code"},
+		} {
+			help += fmt.Sprintf("    %-10.10s%s\n", command[0], command[1])
+		}
+		fmt.Fprintf(os.Stderr, "%s\n", help)
+	}
 }

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -88,6 +88,7 @@ func init() {
 		} {
 			help += fmt.Sprintf("    %-10.10s%s\n", command[0], command[1])
 		}
+		help += "\nRun 'docker COMMAND --help' for more information on a command."
 		fmt.Fprintf(os.Stderr, "%s\n", help)
 	}
 }

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -24,10 +24,10 @@ var (
 	flVersion     = flag.Bool([]string{"v", "-version"}, false, "Print version information and quit")
 	flDaemon      = flag.Bool([]string{"d", "-daemon"}, false, "Enable daemon mode")
 	flDebug       = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
-	flSocketGroup = flag.String([]string{"G", "-group"}, "docker", "Group to assign the unix socket specified by -H when running in daemon mode\nuse '' (the empty string) to disable setting of a group")
+	flSocketGroup = flag.String([]string{"G", "-group"}, "docker", "Group to assign the unix socket specified by -H when\nrunning in daemon mode. Use \"\" (the empty string) to\ndisable setting a group. (default: \"docker\")")
 	flEnableCors  = flag.Bool([]string{"#api-enable-cors", "-api-enable-cors"}, false, "Enable CORS headers in the remote API")
 	flTls         = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by tls-verify flags")
-	flTlsVerify   = flag.Bool([]string{"-tlsverify"}, false, "Use TLS and verify the remote (daemon: verify client, client: verify daemon)")
+	flTlsVerify   = flag.Bool([]string{"-tlsverify"}, false, "Use TLS and verify the remote\n(daemon: verify client, client: verify daemon)")
 
 	// these are initialized in init() below since their default values depend on dockerCertPath which isn't fully initialized until init() runs
 	flCa    *string
@@ -37,13 +37,16 @@ var (
 )
 
 func init() {
-	flCa = flag.String([]string{"-tlscacert"}, filepath.Join(dockerCertPath, defaultCaFile), "Trust only remotes providing a certificate signed by the CA given here")
-	flCert = flag.String([]string{"-tlscert"}, filepath.Join(dockerCertPath, defaultCertFile), "Path to TLS certificate file")
-	flKey = flag.String([]string{"-tlskey"}, filepath.Join(dockerCertPath, defaultKeyFile), "Path to TLS key file")
-	opts.HostListVar(&flHosts, []string{"H", "-host"}, "The socket(s) to bind to in daemon mode\nspecified using one or more tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.")
+	defaultCaFilePath := filepath.Join(dockerCertPath, defaultCaFile)
+	flCa = flag.String([]string{"-tlscacert"}, defaultCaFilePath, fmt.Sprintf("Only trust remotes providing certificate signed by CA\n(default: %q)", defaultCaFilePath))
+	defaultCertFilePath := filepath.Join(dockerCertPath, defaultCertFile)
+	flCert = flag.String([]string{"-tlscert"}, defaultCaFilePath, fmt.Sprintf("Path to TLS certificate file\n(default: %q)", defaultCertFilePath))
+	defaultKeyFilePath := filepath.Join(dockerCertPath, defaultKeyFile)
+	flKey = flag.String([]string{"-tlskey"}, defaultKeyFilePath, fmt.Sprintf("Path to TLS key file\n(default: %q)", defaultKeyFilePath))
+	opts.HostListVar(&flHosts, []string{"H", "-host"}, fmt.Sprintf("The socket(s) to bind to in daemon mode or connect to in\nclient mode. Specified using one or more tcp://host:port,\nunix:///path/to/socket, fd://* or fd://socketfd.\n(default: %q)", api.DEFAULTUNIXSOCKET))
 
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: docker [OPTIONS] COMMAND [arg...]\n -H=[unix://%s]: tcp://host:port to bind/connect to or unix://path/to/socket to use\n\nA self-sufficient runtime for linux containers.\n\nOptions:\n", api.DEFAULTUNIXSOCKET)
+		fmt.Fprint(os.Stderr, "Usage: docker [OPTIONS] COMMAND [arg...]\n\nA self-sufficient runtime for linux containers.\n\nOptions:\n")
 
 		flag.PrintDefaults()
 

--- a/pkg/mflag/flag.go
+++ b/pkg/mflag/flag.go
@@ -427,11 +427,6 @@ func Set(name, value string) error {
 func (f *FlagSet) PrintDefaults() {
 	writer := tabwriter.NewWriter(f.out(), 20, 1, 3, ' ', 0)
 	f.VisitAll(func(flag *Flag) {
-		format := "  -%s=%s"
-		if _, ok := flag.Value.(*stringValue); ok {
-			// put quotes on the value
-			format = "  -%s=%q"
-		}
 		names := []string{}
 		for _, name := range flag.Names {
 			if name[0] != '#' {
@@ -439,11 +434,8 @@ func (f *FlagSet) PrintDefaults() {
 			}
 		}
 		if len(names) > 0 {
-			fmt.Fprintf(writer, format, strings.Join(names, ", -"), flag.DefValue)
-			for i, line := range strings.Split(flag.Usage, "\n") {
-				if i != 0 {
-					line = "  " + line
-				}
+			fmt.Fprintf(writer, "-%s", strings.Join(names, ", -"))
+			for _, line := range strings.Split(flag.Usage, "\n") {
 				fmt.Fprintln(writer, "\t", line)
 			}
 		}


### PR DESCRIPTION
Currently, `docker help` prints the commands, `docker --help` prints the options. This doesn't make sense. Also:

![screenshot 2014-09-08 17 23 15](https://cloud.githubusercontent.com/assets/40906/4195046/94fa7c42-37b7-11e4-997b-d785516a5428.png)

This pull requests makes `docker`, `docker help`, `docker --help` and `docker -h` all print the same, much more helpful, 80-character width thing:

```
Usage: docker [OPTIONS] COMMAND [arg...]

A self-sufficient runtime for linux containers.

Options:
--api-enable-cors    Enable CORS headers in the remote API
-D, --debug          Enable debug mode
-d, --daemon         Enable daemon mode
-G, --group          Group to assign the unix socket specified by -H when
                     running in daemon mode. Use "" (the empty string) to
                     disable setting a group. (default: "docker")
-H, --host           The socket(s) to bind to in daemon mode or connect to in
                     client mode. Specified using one or more tcp://host:port,
                     unix:///path/to/socket, fd://* or fd://socketfd.
                     (default: "/var/run/docker.sock")
--tls                Use TLS; implied by tls-verify flags
--tlscacert          Only trust remotes providing certificate signed by CA
                     (default: "/Users/ben/.docker/ca.pem")
--tlscert            Path to TLS certificate file
                     (default: "/Users/ben/.docker/cert.pem")
--tlskey             Path to TLS key file
                     (default: "/Users/ben/.docker/key.pem")
--tlsverify          Use TLS and verify the remote
                     (daemon: verify client, client: verify daemon)
-v, --version        Print version information and quit

Commands:
    attach    Attach to a running container
    build     Build an image from a Dockerfile
    commit    Create a new image from a container's changes
    cp        Copy files/folders from a container's filesystem to the host path
    diff      Inspect changes on a container's filesystem
    events    Get real time events from the server
    export    Stream the contents of a container as a tar archive
    history   Show the history of an image
    images    List images
    import    Create a new filesystem image from the contents of a tarball
    info      Display system-wide information
    inspect   Return low-level information on a container
    kill      Kill a running container
    load      Load an image from a tar archive
    login     Register or log in to a Docker registry server
    logout    Log out from a Docker registry server
    logs      Fetch the logs of a container
    port      Lookup the public-facing port that is NAT-ed to PRIVATE_PORT
    pause     Pause all processes within a container
    ps        List containers
    pull      Pull an image or a repository from a Docker registry server
    push      Push an image or a repository to a Docker registry server
    restart   Restart a running container
    rm        Remove one or more containers
    rmi       Remove one or more images
    run       Run a command in a new container
    save      Save an image to a tar archive
    search    Search for an image on the Docker Hub
    start     Start a stopped container
    stop      Stop a running container
    tag       Tag an image into a repository
    top       Lookup the running processes of a container
    unpause   Unpause a paused container
    version   Show the Docker version information
    wait      Block until a container stops, then print its exit code

Run 'docker COMMAND --help' for more information on a command.
```

It's quite long, but will become much shorter when we get a `docker daemon` command. It'll also be less-able when we get #7887.

Fixes #1131.
