### PR TITLE
Note btrfs+SELinux support issue in docs

### DIFF
--- a/docs/sources/installation/centos.md
+++ b/docs/sources/installation/centos.md
@@ -1,6 +1,6 @@
 page_title: Installation on CentOS
 page_description: Instructions for installing Docker on CentOS
-page_keywords: Docker, Docker documentation, requirements, linux, centos, epel, docker.io, docker-io
+page_keywords: Docker, Docker documentation, requirements, linux, centos, epel, docker.io, docker-io, SELinux, btrfs
 
 # CentOS
 
@@ -110,6 +110,20 @@ The CentOS Project provides a number of sample Dockerfiles which you may use
 either as templates or to familiarize yourself with docker. These templates
 are available on github at [https://github.com/CentOS/CentOS-Dockerfiles](
 https://github.com/CentOS/CentOS-Dockerfiles)
+
+## SELinux + btrfs
+
+Btrfs currently [doesn't support](https://bugzilla.redhat.com/show_bug.cgi?id=1128041) Docker when SELinux is in Enforce mode.
+
+You can view your filesystem types with:
+
+    $ df -T
+
+If you're using btrfs, you'll need to put SELinux in Permissive mode:
+
+    $ sudo setenforce 0
+    $ getenforce
+    Permissive
 
 **Done!** You can either continue with the [Docker User
 Guide](/userguide/) or explore and build on the images yourself.

--- a/docs/sources/installation/fedora.md
+++ b/docs/sources/installation/fedora.md
@@ -1,6 +1,6 @@
 page_title: Installation on Fedora
 page_description: Installation instructions for Docker on Fedora.
-page_keywords: Docker, Docker documentation, Fedora, requirements, virtualbox, vagrant, git, ssh, putty, cygwin, linux
+page_keywords: Docker, Docker documentation, Fedora, requirements, virtualbox, vagrant, git, ssh, putty, cygwin, linux, SELinux, btrfs
 
 # Fedora
 
@@ -85,8 +85,21 @@ Flush changes:
 Restart Docker:
 
     $ systemctl start docker
+ 
+## SELinux + btrfs
+
+Btrfs currently [doesn't support](https://bugzilla.redhat.com/show_bug.cgi?id=1128041) Docker when SELinux is in Enforce mode.
+
+You can view your filesystem types with:
+
+    $ df -T
+
+If you're using btrfs, you'll need to put SELinux in Permissive mode:
+
+    $ sudo setenforce 0
+    $ getenforce
+    Permissive
 
 ## What next?
 
 Continue with the [User Guide](/userguide/).
-

--- a/docs/sources/installation/rhel.md
+++ b/docs/sources/installation/rhel.md
@@ -1,6 +1,6 @@
 page_title: Installation on Red Hat Enterprise Linux
 page_description: Installation instructions for Docker on Red Hat Enterprise Linux.
-page_keywords: Docker, Docker documentation, requirements, linux, rhel, centos
+page_keywords: Docker, Docker documentation, requirements, linux, rhel, centos, SELinux, btrfs
 
 # Red Hat Enterprise Linux 7
 
@@ -78,6 +78,20 @@ Now let's verify that Docker is working.
 **Done!**
 
 Continue with the [User Guide](/userguide/).
+
+## SELinux + btrfs
+
+Btrfs currently [doesn't support](https://bugzilla.redhat.com/show_bug.cgi?id=1128041) Docker when SELinux is in Enforce mode.
+
+You can view your filesystem types with:
+
+    $ df -T
+
+If you're using btrfs, you'll need to put SELinux in Permissive mode:
+
+    $ sudo setenforce 0
+    $ getenforce
+    Permissive
 
 ## Issues?
 


### PR DESCRIPTION
I've added sections to the Fedora/CentOS/RHEL docs that document the [current incompatibility](https://bugzilla.redhat.com/show_bug.cgi?id=1128041) of btrfs and SELinux with Docker. I picked those three distros because I've observed/documented this behavior on Fedora (#7952), issue #7318 documented it on CentOS and the RHEL Bugzilla linked above implies it's present for RHEL.
