### PR TITLE
Consistent help messages

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/docker/nat"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/log"
+	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/parsers/filters"
 	"github.com/docker/docker/pkg/signal"
@@ -53,47 +54,9 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 			return nil
 		}
 	}
-	help := fmt.Sprintf("Usage: docker [OPTIONS] COMMAND [arg...]\n -H=[unix://%s]: tcp://host:port to bind/connect to or unix://path/to/socket to use\n\nA self-sufficient runtime for linux containers.\n\nCommands:\n", api.DEFAULTUNIXSOCKET)
-	for _, command := range [][]string{
-		{"attach", "Attach to a running container"},
-		{"build", "Build an image from a Dockerfile"},
-		{"commit", "Create a new image from a container's changes"},
-		{"cp", "Copy files/folders from a container's filesystem to the host path"},
-		{"diff", "Inspect changes on a container's filesystem"},
-		{"events", "Get real time events from the server"},
-		{"export", "Stream the contents of a container as a tar archive"},
-		{"history", "Show the history of an image"},
-		{"images", "List images"},
-		{"import", "Create a new filesystem image from the contents of a tarball"},
-		{"info", "Display system-wide information"},
-		{"inspect", "Return low-level information on a container"},
-		{"kill", "Kill a running container"},
-		{"load", "Load an image from a tar archive"},
-		{"login", "Register or log in to a Docker registry server"},
-		{"logout", "Log out from a Docker registry server"},
-		{"logs", "Fetch the logs of a container"},
-		{"port", "Lookup the public-facing port that is NAT-ed to PRIVATE_PORT"},
-		{"pause", "Pause all processes within a container"},
-		{"ps", "List containers"},
-		{"pull", "Pull an image or a repository from a Docker registry server"},
-		{"push", "Push an image or a repository to a Docker registry server"},
-		{"restart", "Restart a running container"},
-		{"rm", "Remove one or more containers"},
-		{"rmi", "Remove one or more images"},
-		{"run", "Run a command in a new container"},
-		{"save", "Save an image to a tar archive"},
-		{"search", "Search for an image on the Docker Hub"},
-		{"start", "Start a stopped container"},
-		{"stop", "Stop a running container"},
-		{"tag", "Tag an image into a repository"},
-		{"top", "Lookup the running processes of a container"},
-		{"unpause", "Unpause a paused container"},
-		{"version", "Show the Docker version information"},
-		{"wait", "Block until a container stops, then print its exit code"},
-	} {
-		help += fmt.Sprintf("    %-10.10s%s\n", command[0], command[1])
-	}
-	fmt.Fprintf(cli.err, "%s\n", help)
+
+	flag.Usage()
+
 	return nil
 }
 

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -40,10 +39,10 @@ func init() {
 	flCa = flag.String([]string{"-tlscacert"}, filepath.Join(dockerCertPath, defaultCaFile), "Trust only remotes providing a certificate signed by the CA given here")
 	flCert = flag.String([]string{"-tlscert"}, filepath.Join(dockerCertPath, defaultCertFile), "Path to TLS certificate file")
 	flKey = flag.String([]string{"-tlskey"}, filepath.Join(dockerCertPath, defaultKeyFile), "Path to TLS key file")
-	opts.HostListVar(&flHosts, []string{"H", "-host"}, "The socket(s) to bind to in daemon mode\nspecified using one or more tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.")
+	opts.HostListVar(&flHosts, []string{"H", "-host"}, "The socket(s) to bind to in daemon mode or connect to in client mode, specified using one or more tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.")
 
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: docker [OPTIONS] COMMAND [arg...]\n -H=[unix://%s]: tcp://host:port to bind/connect to or unix://path/to/socket to use\n\nA self-sufficient runtime for linux containers.\n\nOptions:\n", api.DEFAULTUNIXSOCKET)
+		fmt.Fprint(os.Stderr, "Usage: docker [OPTIONS] COMMAND [arg...]\n\nA self-sufficient runtime for linux containers.\n\nOptions:\n")
 
 		flag.PrintDefaults()
 

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -39,4 +41,53 @@ func init() {
 	flCert = flag.String([]string{"-tlscert"}, filepath.Join(dockerCertPath, defaultCertFile), "Path to TLS certificate file")
 	flKey = flag.String([]string{"-tlskey"}, filepath.Join(dockerCertPath, defaultKeyFile), "Path to TLS key file")
 	opts.HostListVar(&flHosts, []string{"H", "-host"}, "The socket(s) to bind to in daemon mode\nspecified using one or more tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.")
+
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: docker [OPTIONS] COMMAND [arg...]\n -H=[unix://%s]: tcp://host:port to bind/connect to or unix://path/to/socket to use\n\nA self-sufficient runtime for linux containers.\n\nOptions:\n", api.DEFAULTUNIXSOCKET)
+
+		flag.PrintDefaults()
+
+		help := "\nCommands:\n"
+
+		for _, command := range [][]string{
+			{"attach", "Attach to a running container"},
+			{"build", "Build an image from a Dockerfile"},
+			{"commit", "Create a new image from a container's changes"},
+			{"cp", "Copy files/folders from a container's filesystem to the host path"},
+			{"diff", "Inspect changes on a container's filesystem"},
+			{"events", "Get real time events from the server"},
+			{"export", "Stream the contents of a container as a tar archive"},
+			{"history", "Show the history of an image"},
+			{"images", "List images"},
+			{"import", "Create a new filesystem image from the contents of a tarball"},
+			{"info", "Display system-wide information"},
+			{"inspect", "Return low-level information on a container"},
+			{"kill", "Kill a running container"},
+			{"load", "Load an image from a tar archive"},
+			{"login", "Register or log in to a Docker registry server"},
+			{"logout", "Log out from a Docker registry server"},
+			{"logs", "Fetch the logs of a container"},
+			{"port", "Lookup the public-facing port that is NAT-ed to PRIVATE_PORT"},
+			{"pause", "Pause all processes within a container"},
+			{"ps", "List containers"},
+			{"pull", "Pull an image or a repository from a Docker registry server"},
+			{"push", "Push an image or a repository to a Docker registry server"},
+			{"restart", "Restart a running container"},
+			{"rm", "Remove one or more containers"},
+			{"rmi", "Remove one or more images"},
+			{"run", "Run a command in a new container"},
+			{"save", "Save an image to a tar archive"},
+			{"search", "Search for an image on the Docker Hub"},
+			{"start", "Start a stopped container"},
+			{"stop", "Stop a running container"},
+			{"tag", "Tag an image into a repository"},
+			{"top", "Lookup the running processes of a container"},
+			{"unpause", "Unpause a paused container"},
+			{"version", "Show the Docker version information"},
+			{"wait", "Block until a container stops, then print its exit code"},
+		} {
+			help += fmt.Sprintf("    %-10.10s%s\n", command[0], command[1])
+		}
+		fmt.Fprintf(os.Stderr, "%s\n", help)
+	}
 }

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -88,6 +88,7 @@ func init() {
 		} {
 			help += fmt.Sprintf("    %-10.10s%s\n", command[0], command[1])
 		}
+		help += "\nRun 'docker COMMAND --help' for more information on a command."
 		fmt.Fprintf(os.Stderr, "%s\n", help)
 	}
 }


### PR DESCRIPTION
Currently, `docker help` prints the commands, `docker --help` prints the options. This doesn't make sense.

This pull request makes `docker`, `docker help`, `docker --help` and `docker -h` all print the same, much more helpful thing:

```
Usage: docker [OPTIONS] COMMAND [arg...]

A self-sufficient runtime for linux containers.

Options:
  --api-enable-cors=false                Enable CORS headers in the remote API
  -b, --bridge=""                        Attach containers to a pre-existing network bridge
                                           use 'none' to disable container networking
  --bip=""                               Use this CIDR notation address for the network bridge's IP, not compatible with -b
  -D, --debug=false                      Enable debug mode
  -d, --daemon=false                     Enable daemon mode
  --dns=[]                               Force Docker to use specific DNS servers
  --dns-search=[]                        Force Docker to use specific DNS search domains
  -e, --exec-driver="native"             Force the Docker runtime to use a specific exec driver
  -G, --group="docker"                   Group to assign the unix socket specified by -H when running in daemon mode
                                           use '' (the empty string) to disable setting of a group
  -g, --graph="/var/lib/docker"          Path to use as the root of the Docker runtime
  -H, --host=[]                          The socket(s) to bind to in daemon mode or connect to in client mode, specified using one or more tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.
  --icc=true                             Enable inter-container communication
  --ip=0.0.0.0                           Default IP address to use when binding container ports
  --ip-forward=true                      Enable net.ipv4.ip_forward
  --iptables=true                        Enable Docker's addition of iptables rules
  --mtu=0                                Set the containers network MTU
                                           if no value is provided: default to the default route MTU or 1500 if no default route is available
  -p, --pidfile="/var/run/docker.pid"    Path to use for daemon PID file
  -s, --storage-driver=""                Force the Docker runtime to use a specific storage driver
  --selinux-enabled=false                Enable selinux support. SELinux does not presently support the BTRFS storage driver
  --storage-opt=[]                       Set storage driver options
  --tls=false                            Use TLS; implied by tls-verify flags
  --tlscacert="/.docker/ca.pem"          Trust only remotes providing a certificate signed by the CA given here
  --tlscert="/.docker/cert.pem"          Path to TLS certificate file
  --tlskey="/.docker/key.pem"            Path to TLS key file
  --tlsverify=false                      Use TLS and verify the remote (daemon: verify client, client: verify daemon)
  -v, --version=false                    Print version information and quit

Commands:
    attach    Attach to a running container
    build     Build an image from a Dockerfile
    commit    Create a new image from a container's changes
    cp        Copy files/folders from a container's filesystem to the host path
    diff      Inspect changes on a container's filesystem
    events    Get real time events from the server
    export    Stream the contents of a container as a tar archive
    history   Show the history of an image
    images    List images
    import    Create a new filesystem image from the contents of a tarball
    info      Display system-wide information
    inspect   Return low-level information on a container
    kill      Kill a running container
    load      Load an image from a tar archive
    login     Register or log in to a Docker registry server
    logout    Log out from a Docker registry server
    logs      Fetch the logs of a container
    port      Lookup the public-facing port that is NAT-ed to PRIVATE_PORT
    pause     Pause all processes within a container
    ps        List containers
    pull      Pull an image or a repository from a Docker registry server
    push      Push an image or a repository to a Docker registry server
    restart   Restart a running container
    rm        Remove one or more containers
    rmi       Remove one or more images
    run       Run a command in a new container
    save      Save an image to a tar archive
    search    Search for an image on the Docker Hub
    start     Start a stopped container
    stop      Stop a running container
    tag       Tag an image into a repository
    top       Lookup the running processes of a container
    unpause   Unpause a paused container
    version   Show the Docker version information
    wait      Block until a container stops, then print its exit code

Run 'docker COMMAND --help' for more information on a command.
```

It's quite long, but will become shorter when we get a `docker daemon` command. It'll also be less-able when we get #7887.

Some more work is needed to make this 80 characters wide, probably by moving the defaults for the options to the right-hand column ([this is a start](https://github.com/bfirsh/docker/commit/452ecd362805af132dd07fed9a03a7d70d522481)).

Fixes #1131.
