### PR TITLE
fix console attribute in lxc template

### DIFF
--- a/daemon/execdriver/lxc/lxc_template.go
+++ b/daemon/execdriver/lxc/lxc_template.go
@@ -67,7 +67,7 @@ lxc.mount.entry = proc {{escapeFstabSpaces $ROOTFS}}/proc proc nosuid,nodev,noex
 lxc.mount.entry = sysfs {{escapeFstabSpaces $ROOTFS}}/sys sysfs nosuid,nodev,noexec 0 0
 
 {{if .ProcessConfig.Tty}}
-lxc.mount.entry = {{.Console}} {{escapeFstabSpaces $ROOTFS}}/dev/console none bind,rw 0 0
+lxc.mount.entry = {{.ProcessConfig.Console}} {{escapeFstabSpaces $ROOTFS}}/dev/console none bind,rw 0 0
 {{end}}
 
 lxc.mount.entry = devpts {{escapeFstabSpaces $ROOTFS}}/dev/pts devpts {{formatMountLabel "newinstance,ptmxmode=0666,nosuid,noexec" $MOUNTLABEL}} 0 0


### PR DESCRIPTION
commit 4aa5da278f49c889d43191f82ff42d3a95266d62 moves `Console` from Command to
ProcessConfig, but missed the change in lxc_template. Therefore creating a
container with tty using lxc driver with fail with error

```
template: lxc:60:20: executing "lxc" at <.Console>: Console is not a field of
struct type struct { *execdriver.Command; AppArmor bool; ProcessLabel string; MountLabel string }
```

This changes lxc_console template to refers to `.ProcessConfig.Console`

Docker-DCO-1.1-Signed-off-by: Daniel, Dao Quang Minh dqminh89@gmail.com (github: dqminh)
