### PR TITLE
Links v2: Remove graphdb & link aliases

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1553,7 +1553,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 	}
 	w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
 	if !*quiet {
-		fmt.Fprint(w, "CONTAINER ID\tIMAGE\tCOMMAND\tCREATED\tSTATUS\tPORTS\tNAMES")
+		fmt.Fprint(w, "CONTAINER ID\tIMAGE\tCOMMAND\tCREATED\tSTATUS\tPORTS\tNAME")
 		if *size {
 			fmt.Fprintln(w, "\tSIZE")
 		} else {
@@ -1569,11 +1569,6 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 
 		if !*noTrunc {
 			outID = utils.TruncateID(outID)
-		}
-
-		// Remove the leading / from the names
-		for i := 0; i < len(outNames); i++ {
-			outNames[i] = outNames[i][1:]
 		}
 
 		if !*quiet {

--- a/daemon/container_unit_test.go
+++ b/daemon/container_unit_test.go
@@ -1,8 +1,9 @@
 package daemon
 
 import (
-	"github.com/docker/docker/nat"
 	"testing"
+
+	"github.com/docker/docker/nat"
 )
 
 func TestParseNetworkOptsPrivateOnly(t *testing.T) {
@@ -163,18 +164,5 @@ func TestParseNetworkOptsUdp(t *testing.T) {
 		if s.HostIp != "192.168.1.100" {
 			t.Fail()
 		}
-	}
-}
-
-func TestGetFullName(t *testing.T) {
-	name, err := GetFullContainerName("testing")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if name != "/testing" {
-		t.Fatalf("Expected /testing got %s", name)
-	}
-	if _, err := GetFullContainerName(""); err == nil {
-		t.Fatal("Error should not be nil")
 	}
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -26,8 +26,8 @@ import (
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/graph"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/links"
 	"github.com/docker/docker/pkg/broadcastwriter"
-	"github.com/docker/docker/pkg/graphdb"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/log"
 	"github.com/docker/docker/pkg/namesgenerator"
@@ -82,23 +82,27 @@ func (c *contStore) List() []*Container {
 }
 
 type Daemon struct {
-	repository     string
-	sysInitPath    string
-	containers     *contStore
-	graph          *graph.Graph
-	repositories   *graph.TagStore
-	idIndex        *truncindex.TruncIndex
-	sysInfo        *sysinfo.SysInfo
-	volumes        *graph.Graph
-	eng            *engine.Engine
-	config         *Config
-	containerGraph *graphdb.Database
-	driver         graphdriver.Driver
-	execDriver     execdriver.Driver
+	repository   string
+	sysInitPath  string
+	containers   *contStore
+	graph        *graph.Graph
+	repositories *graph.TagStore
+	idIndex      *truncindex.TruncIndex
+	sysInfo      *sysinfo.SysInfo
+	volumes      *graph.Graph
+	eng          *engine.Engine
+	config       *Config
+	driver       graphdriver.Driver
+	execDriver   execdriver.Driver
+	links        *links.Links
 }
 
 // Install installs daemon capabilities to eng.
 func (daemon *Daemon) Install(eng *engine.Engine) error {
+	if err := daemon.links.RegisterJobs(eng); err != nil {
+		return err
+	}
+
 	// FIXME: remove ImageDelete's dependency on Daemon, then move to graph/
 	for name, method := range map[string]engine.Handler{
 		"attach":            daemon.ContainerAttach,
@@ -283,6 +287,30 @@ func (daemon *Daemon) LogToDisk(src *broadcastwriter.BroadcastWriter, dst, strea
 	return nil
 }
 
+func (daemon *Daemon) createName(id, name string) error {
+	createJob := daemon.eng.Job("create_name")
+	createJob.Setenv("Name", name)
+	createJob.Setenv("ID", id)
+
+	if err := createJob.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (daemon *Daemon) deleteName(name string) error {
+	deleteJob := daemon.eng.Job("delete_name")
+	deleteJob.Setenv("Name", name)
+
+	// Remove name and continue starting the container
+	if err := deleteJob.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (daemon *Daemon) restore() error {
 	var (
 		debug         = (os.Getenv("DEBUG") != "" || os.Getenv("TEST") != "")
@@ -321,26 +349,24 @@ func (daemon *Daemon) restore() error {
 
 	registeredContainers := []*Container{}
 
-	if entities := daemon.containerGraph.List("/", -1); entities != nil {
-		for _, p := range entities.Paths() {
-			if !debug {
-				fmt.Print(".")
-			}
-
-			e := entities[p]
-
-			if container, ok := containers[e.ID()]; ok {
-				if err := daemon.register(container, false); err != nil {
-					log.Debugf("Failed to register container %s: %s", container.ID, err)
-				}
-
-				registeredContainers = append(registeredContainers, container)
-
-				// delete from the map so that a new name is not automatically generated
-				delete(containers, e.ID())
-			}
+	daemon.links.Each("/", func(p, id string) error {
+		if !debug {
+			fmt.Print(".")
 		}
-	}
+
+		if container, ok := containers[id]; ok {
+			if err := daemon.register(container, false); err != nil {
+				log.Debugf("Failed to register container %s: %s", container.ID, err)
+			}
+
+			registeredContainers = append(registeredContainers, container)
+
+			// delete from the map so that a new name is not automatically generated
+			delete(containers, id)
+		}
+
+		return nil
+	})
 
 	// Any containers that are left over do not exist in the graph
 	for _, container := range containers {
@@ -439,8 +465,8 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 		name = "/" + name
 	}
 
-	if _, err := daemon.containerGraph.Set(name, id); err != nil {
-		if !graphdb.IsNonUniqueNameError(err) {
+	if err := daemon.createName(id, name); err != nil {
+		if err.Error() != links.ErrDuplicateName.Error() {
 			return "", err
 		}
 
@@ -451,7 +477,7 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 			}
 
 			// Remove name and continue starting the container
-			if err := daemon.containerGraph.Delete(name); err != nil {
+			if err := daemon.deleteName(name); err != nil {
 				return "", err
 			}
 		} else {
@@ -472,8 +498,8 @@ func (daemon *Daemon) generateNewName(id string) (string, error) {
 			name = "/" + name
 		}
 
-		if _, err := daemon.containerGraph.Set(name, id); err != nil {
-			if !graphdb.IsNonUniqueNameError(err) {
+		if err := daemon.createName(id, name); err != nil {
+			if err.Error() != links.ErrDuplicateName.Error() {
 				return "", err
 			}
 			continue
@@ -482,7 +508,7 @@ func (daemon *Daemon) generateNewName(id string) (string, error) {
 	}
 
 	name = "/" + utils.TruncateID(id)
-	if _, err := daemon.containerGraph.Set(name, id); err != nil {
+	if err := daemon.createName(id, name); err != nil {
 		return "", err
 	}
 	return name, nil
@@ -588,14 +614,21 @@ func (daemon *Daemon) GetByName(name string) (*Container, error) {
 	if err != nil {
 		return nil, err
 	}
-	entity := daemon.containerGraph.Get(fullName)
-	if entity == nil {
-		return nil, fmt.Errorf("Could not find entity for %s", name)
+
+	getJob := daemon.eng.Job("get_name")
+	getJob.Setenv("Name", fullName)
+
+	if err := getJob.Run(); err != nil {
+		return nil, err
 	}
-	e := daemon.containers.Get(entity.ID())
+
+	id := getJob.Getenv("Result")
+
+	e := daemon.containers.Get(id)
 	if e == nil {
-		return nil, fmt.Errorf("Could not find container for entity id %s", entity.ID())
+		return nil, fmt.Errorf("Could not find container for entity id %s", id)
 	}
+
 	return e, nil
 }
 
@@ -606,14 +639,14 @@ func (daemon *Daemon) Children(name string) (map[string]*Container, error) {
 	}
 	children := make(map[string]*Container)
 
-	err = daemon.containerGraph.Walk(name, func(p string, e *graphdb.Entity) error {
-		c := daemon.Get(e.ID())
+	err = daemon.links.MapChildren(name, func(path, id string) error {
+		c := daemon.Get(id)
 		if c == nil {
-			return fmt.Errorf("Could not get container for name %s and id %s", e.ID(), p)
+			return fmt.Errorf("Could not get container for name %s and id %s", id, path)
 		}
-		children[p] = c
+		children[path] = c
 		return nil
-	}, 0)
+	})
 
 	if err != nil {
 		return nil, err
@@ -627,15 +660,18 @@ func (daemon *Daemon) Parents(name string) ([]string, error) {
 		return nil, err
 	}
 
-	return daemon.containerGraph.Parents(name)
+	return daemon.links.Parents(name)
 }
 
 func (daemon *Daemon) RegisterLink(parent, child *Container, alias string) error {
-	fullName := path.Join(parent.Name, alias)
-	if !daemon.containerGraph.Exists(fullName) {
-		_, err := daemon.containerGraph.Set(fullName, child.ID)
+	createJob := daemon.eng.Job("create_link")
+	createJob.Setenv("ParentName", parent.Name)
+	createJob.Setenv("ChildID", child.ID)
+	createJob.Setenv("Alias", alias)
+	if err := createJob.Run(); err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -812,7 +848,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 	}
 
 	graphdbPath := path.Join(config.Root, "linkgraph.db")
-	graph, err := graphdb.NewSqliteConn(graphdbPath)
+	linksObj, err := links.NewLinks(graphdbPath)
 	if err != nil {
 		return nil, err
 	}
@@ -844,20 +880,25 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 	}
 
 	daemon := &Daemon{
-		repository:     daemonRepo,
-		containers:     &contStore{s: make(map[string]*Container)},
-		graph:          g,
-		repositories:   repositories,
-		idIndex:        truncindex.NewTruncIndex([]string{}),
-		sysInfo:        sysInfo,
-		volumes:        volumes,
-		config:         config,
-		containerGraph: graph,
-		driver:         driver,
-		sysInitPath:    sysInitPath,
-		execDriver:     ed,
-		eng:            eng,
+		repository:   daemonRepo,
+		containers:   &contStore{s: make(map[string]*Container)},
+		graph:        g,
+		repositories: repositories,
+		idIndex:      truncindex.NewTruncIndex([]string{}),
+		sysInfo:      sysInfo,
+		volumes:      volumes,
+		config:       config,
+		driver:       driver,
+		sysInitPath:  sysInitPath,
+		execDriver:   ed,
+		eng:          eng,
+		links:        linksObj,
 	}
+
+	if err := daemon.Install(eng); err != nil {
+		return nil, err
+	}
+
 	if err := daemon.checkLocaldns(); err != nil {
 		return nil, err
 	}
@@ -879,8 +920,8 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		if err := daemon.driver.Cleanup(); err != nil {
 			log.Errorf("daemon.driver.Cleanup(): %s", err.Error())
 		}
-		if err := daemon.containerGraph.Close(); err != nil {
-			log.Errorf("daemon.containerGraph.Close(): %s", err.Error())
+		if err := daemon.links.Close(); err != nil {
+			log.Errorf("daemon.links.Close(): %s", err.Error())
 		}
 	})
 
@@ -1053,8 +1094,8 @@ func (daemon *Daemon) Volumes() *graph.Graph {
 	return daemon.volumes
 }
 
-func (daemon *Daemon) ContainerGraph() *graphdb.Database {
-	return daemon.containerGraph
+func (daemon *Daemon) Links() *links.Links {
+	return daemon.links
 }
 
 func (daemon *Daemon) checkLocaldns() error {

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/docker/docker/engine"
+	"github.com/docker/docker/pkg/log"
 )
 
 func (daemon *Daemon) ContainerExport(job *engine.Job) engine.Status {
@@ -12,6 +13,7 @@ func (daemon *Daemon) ContainerExport(job *engine.Job) engine.Status {
 	}
 	name := job.Args[0]
 	if container := daemon.Get(name); container != nil {
+		log.Debugf("%s %s here", container.ID, name)
 		data, err := container.Export()
 		if err != nil {
 			return job.Errorf("%s: %s", name, err)

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -45,6 +45,7 @@ func (daemon *Daemon) ContainerInspect(job *engine.Job) engine.Status {
 		out.Set("ExecDriver", container.ExecDriver)
 		out.Set("MountLabel", container.MountLabel)
 		out.Set("ProcessLabel", container.ProcessLabel)
+		out.SetJson("LinkMap", container.LinkMap)
 		out.SetJson("Volumes", container.Volumes)
 		out.SetJson("VolumesRW", container.VolumesRW)
 

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -43,11 +43,14 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 		}
 	}
 
+	// FIXME(erikh): this should be map[string]string now, but preserving for
+	//               compatibility
 	names := map[string][]string{}
-	daemon.EachEntity("/", func(path, id string) error {
-		names[id] = append(names[id], path)
-		return nil
-	})
+
+	for _, container := range daemon.containers.List() {
+		id := container.ID
+		names[id] = append(names[id], container.Name)
+	}
 
 	var beforeCont, sinceCont *Container
 	if before != "" {
@@ -101,6 +104,7 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 		out := &engine.Env{}
 		out.Set("Id", container.ID)
 		out.SetList("Names", names[container.ID])
+		out.SetJson("LinkMap", container.LinkMap)
 		out.Set("Image", daemon.Repositories().ImageName(container.Image))
 		if len(container.Args) > 0 {
 			args := []string{}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -44,7 +44,7 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 	}
 
 	names := map[string][]string{}
-	daemon.links.Each("/", func(path, id string) error {
+	daemon.EachEntity("/", func(path, id string) error {
 		names[id] = append(names[id], path)
 		return nil
 	})

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/docker/pkg/graphdb"
-
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/pkg/parsers/filters"
 )
@@ -46,10 +44,10 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 	}
 
 	names := map[string][]string{}
-	daemon.ContainerGraph().Walk("/", func(p string, e *graphdb.Entity) error {
-		names[e.ID()] = append(names[e.ID()], p)
+	daemon.links.Each("/", func(path, id string) error {
+		names[id] = append(names[id], path)
 		return nil
-	}, -1)
+	})
 
 	var beforeCont, sinceCont *Container
 	if before != "" {

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -46,9 +46,6 @@ func mainDaemon() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		if err := d.Install(eng); err != nil {
-			log.Fatal(err)
-		}
 
 		b := &builder.BuilderJob{eng, d}
 		b.Install()

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"log"
+	"path"
 
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builtins"
@@ -12,6 +13,7 @@ import (
 	_ "github.com/docker/docker/daemon/execdriver/native"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/engine"
+	"github.com/docker/docker/links"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/signal"
 )
@@ -49,6 +51,16 @@ func mainDaemon() {
 
 		b := &builder.BuilderJob{eng, d}
 		b.Install()
+
+		graphdbPath := path.Join(daemonCfg.Root, "linkgraph.db")
+		linksObj, err := links.NewLinks(graphdbPath, d)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if err := linksObj.Install(eng); err != nil {
+			log.Fatal(err)
+		}
 
 		// after the daemon is done setting up we can tell the api to start
 		// accepting connections

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -38,6 +38,15 @@ func Register(name string, handler Handler) error {
 	return nil
 }
 
+func RegisterMap(m map[string]Handler) error {
+	for name, handler := range m {
+		if err := Register(name, handler); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func unregister(name string) {
 	delete(globalHandlers, name)
 }
@@ -66,6 +75,15 @@ func (eng *Engine) Register(name string, handler Handler) error {
 		return fmt.Errorf("Can't overwrite handler for command %s", name)
 	}
 	eng.handlers[name] = handler
+	return nil
+}
+
+func (eng *Engine) RegisterMap(m map[string]Handler) error {
+	for name, handler := range m {
+		if err := eng.Register(name, handler); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1741,7 +1741,7 @@ func TestHostsLinkedContainerUpdate(t *testing.T) {
 	}
 
 	// TODO fix docker cp and /etc/hosts
-	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "--link", "c1:c1", "--name", "c2", "busybox", "sh", "-c", "while true;do cp /etc/hosts /hosts; done"))
+	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "--link", "c1", "--name", "c2", "busybox", "sh", "-c", "while true;do cp /etc/hosts /hosts; done"))
 	if err != nil {
 		t.Fatal(err, out)
 	}
@@ -1755,6 +1755,8 @@ func TestHostsLinkedContainerUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err, out)
 	}
+
+	t.Log(out)
 
 	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "cp", "c2:/hosts", tmpdir+"/2"))
 	if err != nil {

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -321,7 +321,7 @@ func TestDaemonCreate(t *testing.T) {
 	)
 
 	if err == nil {
-		t.Fatalf("Name conflict error doesn't include the correct short id. Message was empty.")
+		t.Fatal("Name conflict error doesn't include the correct short id. Message was empty.")
 	}
 
 	if !strings.Contains(err.Error(), utils.TruncateID(testContainer.ID)) {
@@ -795,7 +795,12 @@ func TestLinkChildContainer(t *testing.T) {
 
 	childContainer := daemon.Get(createTestContainer(eng, config, t))
 
-	if err := daemon.Links().CreateLink(webapp.Name, childContainer.ID, "db"); err != nil {
+	linksJob := eng.Job("create_link")
+	linksJob.Setenv("ParentName", webapp.Name)
+	linksJob.Setenv("ChildID", childContainer.ID)
+	linksJob.Setenv("Alias", "db")
+
+	if err := linksJob.Run(); err != nil {
 		t.Fatal(err)
 	}
 
@@ -837,7 +842,12 @@ func TestGetAllChildren(t *testing.T) {
 
 	childContainer := daemon.Get(createTestContainer(eng, config, t))
 
-	if err := daemon.Links().CreateLink(webapp.Name, childContainer.ID, "db"); err != nil {
+	linksJob := eng.Job("create_link")
+	linksJob.Setenv("ParentName", webapp.Name)
+	linksJob.Setenv("ChildID", childContainer.ID)
+	linksJob.Setenv("Alias", "db")
+
+	if err := linksJob.Run(); err != nil {
 		t.Fatal(err)
 	}
 

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -311,7 +311,20 @@ func TestDaemonCreate(t *testing.T) {
 		},
 		"conflictname",
 	)
-	if _, _, err := daemon.Create(&runconfig.Config{Image: GetTestImage(daemon).ID, Cmd: []string{"ls", "-al"}}, testContainer.Name); err == nil || !strings.Contains(err.Error(), utils.TruncateID(testContainer.ID)) {
+
+	_, _, err = daemon.Create(
+		&runconfig.Config{
+			Image: GetTestImage(daemon).ID,
+			Cmd:   []string{"ls", "-al"},
+		},
+		testContainer.Name,
+	)
+
+	if err == nil {
+		t.Fatalf("Name conflict error doesn't include the correct short id. Message was empty.")
+	}
+
+	if !strings.Contains(err.Error(), utils.TruncateID(testContainer.ID)) {
 		t.Fatalf("Name conflict error doesn't include the correct short id. Message was: %s", err.Error())
 	}
 
@@ -782,7 +795,7 @@ func TestLinkChildContainer(t *testing.T) {
 
 	childContainer := daemon.Get(createTestContainer(eng, config, t))
 
-	if err := daemon.RegisterLink(webapp, childContainer, "db"); err != nil {
+	if err := daemon.Links().CreateLink(webapp.Name, childContainer.ID, "db"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -824,7 +837,7 @@ func TestGetAllChildren(t *testing.T) {
 
 	childContainer := daemon.Get(createTestContainer(eng, config, t))
 
-	if err := daemon.RegisterLink(webapp, childContainer, "db"); err != nil {
+	if err := daemon.Links().CreateLink(webapp.Name, childContainer.ID, "db"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -187,11 +187,8 @@ func newTestEngine(t log.Fataler, autorestart bool, root string) *engine.Engine 
 		// otherwise NewDaemon will fail because of conflicting settings.
 		InterContainerCommunication: true,
 	}
-	d, err := daemon.NewDaemon(cfg, eng)
+	_, err := daemon.NewDaemon(cfg, eng)
 	if err != nil {
-		t.Fatal(err)
-	}
-	if err := d.Install(eng); err != nil {
 		t.Fatal(err)
 	}
 	return eng

--- a/links/jobs.go
+++ b/links/jobs.go
@@ -1,0 +1,86 @@
+package links
+
+import "github.com/docker/docker/engine"
+
+func (lm *Links) RegisterJobs(eng *engine.Engine) error {
+	return eng.RegisterMap(map[string]engine.Handler{
+		"create_link":  lm.createLink,
+		"purge_link":   lm.purgeLink,
+		"parents_link": lm.listLinks,
+		"create_name":  lm.createName,
+		"get_name":     lm.getName,
+		"delete_name":  lm.deleteName,
+	})
+}
+
+func (lm *Links) listLinks(job *engine.Job) engine.Status {
+	links, err := lm.Links()
+	if err != nil {
+		return job.Error(err)
+	}
+
+	job.SetenvJson("Parents", links)
+
+	return engine.StatusOK
+}
+
+func (lm *Links) createLink(job *engine.Job) engine.Status {
+	var (
+		parentName = job.Getenv("ParentName")
+		childId    = job.Getenv("ChildID")
+		alias      = job.Getenv("Alias")
+	)
+
+	if err := lm.CreateLink(parentName, childId, alias); err != nil {
+		return job.Error(err)
+	}
+
+	return engine.StatusOK
+}
+
+func (lm *Links) purgeLink(job *engine.Job) engine.Status {
+	name := job.Getenv("Name")
+
+	if err := lm.Purge(name); err != nil {
+		return job.Error(err)
+	}
+
+	return engine.StatusOK
+}
+
+func (lm *Links) createName(job *engine.Job) engine.Status {
+	var (
+		name = job.Getenv("Name")
+		id   = job.Getenv("ID")
+	)
+
+	if err := lm.CreateName(name, id); err != nil {
+		return job.Error(err)
+	}
+
+	return engine.StatusOK
+}
+
+func (lm *Links) getName(job *engine.Job) engine.Status {
+	name := job.Getenv("Name")
+
+	res, err := lm.GetID(name)
+
+	if err != nil {
+		return job.Error(err)
+	}
+
+	job.Setenv("Result", res)
+
+	return engine.StatusOK
+}
+
+func (lm *Links) deleteName(job *engine.Job) engine.Status {
+	name := job.Getenv("Name")
+
+	if err := lm.Delete(name); err != nil {
+		return job.Error(err)
+	}
+
+	return engine.StatusOK
+}

--- a/links/linkmanager.go
+++ b/links/linkmanager.go
@@ -1,0 +1,118 @@
+package links
+
+import (
+	"errors"
+	"fmt"
+	"path"
+
+	"github.com/docker/docker/pkg/graphdb"
+)
+
+type Links struct {
+	dbPath         string
+	containerGraph *graphdb.Database
+}
+
+var ErrDuplicateName = errors.New("Conflict: name already exists.")
+
+func NewLinks(dbpath string) (*Links, error) {
+	containerGraph, err := graphdb.NewSqliteConn(dbpath)
+	return &Links{dbpath, containerGraph}, err
+}
+
+func (lm *Links) Close() error {
+	return lm.containerGraph.Close()
+}
+
+func (lm *Links) CreateName(name, id string) error {
+	_, err := lm.containerGraph.Set(name, id)
+
+	if err != nil && graphdb.IsNonUniqueNameError(err) {
+		return ErrDuplicateName
+	}
+
+	return err
+}
+
+func (lm *Links) CreateLink(parentPath, childId, alias string) error {
+	fullPath := path.Join(parentPath, alias)
+	if !lm.containerGraph.Exists(fullPath) {
+		_, err := lm.containerGraph.Set(fullPath, childId)
+		return err
+	}
+	return nil
+}
+
+func (lm *Links) Purge(name string) error {
+	_, err := lm.containerGraph.Purge(name)
+	return err
+}
+
+func (lm *Links) MapChildren(name string, applyFunc func(string, string) error) error {
+	return lm.containerGraph.Walk(name, func(p string, e *graphdb.Entity) error {
+		return applyFunc(p, e.ID())
+	}, 0)
+}
+
+func (lm *Links) Each(query string, queryFunc func(string, string) error) error {
+	entities := lm.containerGraph.List(query, -1)
+
+	if entities == nil {
+		return nil
+	}
+
+	for _, p := range entities.Paths() {
+		if err := queryFunc(p, entities[p].ID()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+func (lm *Links) GetID(name string) (string, error) {
+	entity := lm.containerGraph.Get(name)
+
+	if entity == nil {
+		return "", fmt.Errorf("Could not find entity for %s", name)
+	}
+
+	return entity.ID(), nil
+}
+
+func (lm *Links) Delete(name string) error {
+	return lm.containerGraph.Delete(name)
+}
+
+func (lm *Links) Children(name string) (map[string]string, error) {
+	children := map[string]string{}
+
+	err := lm.MapChildren(name, func(path, id string) error {
+		children[path] = id
+		return nil
+	})
+
+	return children, err
+}
+
+func (lm *Links) Parents(name string) ([]string, error) {
+	return lm.containerGraph.Parents(name)
+}
+
+func (lm *Links) Links() (map[string][]string, error) {
+	result := map[string][]string{}
+	entities := lm.containerGraph.List("/", -1)
+
+	if entities == nil {
+		return result, nil
+	}
+
+	for p, e := range entities {
+		if _, ok := result[p]; ok {
+			result[p] = append(result[p], e.ID())
+		} else {
+			result[p] = []string{e.ID()}
+		}
+	}
+
+	return result, nil
+}

--- a/links/links.go
+++ b/links/links.go
@@ -2,10 +2,10 @@ package links
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/nat"
-	"path"
-	"strings"
 )
 
 type Link struct {
@@ -43,8 +43,7 @@ func NewLink(parentIP, childIP, name string, env []string, exposedPorts map[nat.
 }
 
 func (l *Link) Alias() string {
-	_, alias := path.Split(l.Name)
-	return alias
+	return l.Name
 }
 
 func (l *Link) ToEnv() []string {

--- a/links/links_test.go
+++ b/links/links_test.go
@@ -1,16 +1,17 @@
 package links
 
 import (
-	"github.com/docker/docker/nat"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/nat"
 )
 
 func TestLinkNaming(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[nat.Port("6379/tcp")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, ports, nil)
+	link, err := NewLink("172.0.17.3", "172.0.17.2", "docker-1", nil, ports, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +41,7 @@ func TestLinkNew(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[nat.Port("6379/tcp")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, ports, nil)
+	link, err := NewLink("172.0.17.3", "172.0.17.2", "docker", nil, ports, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +49,7 @@ func TestLinkNew(t *testing.T) {
 	if link == nil {
 		t.FailNow()
 	}
-	if link.Name != "/db/docker" {
+	if link.Name != "docker" {
 		t.Fail()
 	}
 	if link.Alias() != "docker" {
@@ -71,7 +72,7 @@ func TestLinkEnv(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[nat.Port("6379/tcp")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, ports, nil)
+	link, err := NewLink("172.0.17.3", "172.0.17.2", "docker", []string{"PASSWORD=gordon"}, ports, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,8 +101,8 @@ func TestLinkEnv(t *testing.T) {
 	if env["DOCKER_PORT_6379_TCP_PORT"] != "6379" {
 		t.Fatalf("Expected 6379, got %s", env["DOCKER_PORT_6379_TCP_PORT"])
 	}
-	if env["DOCKER_NAME"] != "/db/docker" {
-		t.Fatalf("Expected /db/docker, got %s", env["DOCKER_NAME"])
+	if env["DOCKER_NAME"] != "docker" {
+		t.Fatalf("Expected docker, got %s", env["DOCKER_NAME"])
 	}
 	if env["DOCKER_ENV_PASSWORD"] != "gordon" {
 		t.Fatalf("Expected gordon, got %s", env["DOCKER_ENV_PASSWORD"])

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -1,6 +1,7 @@
 package opts
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/docker/docker/api"
 	flag "github.com/docker/docker/pkg/mflag"
-	"github.com/docker/docker/pkg/parsers"
 )
 
 func ListVar(values *[]string, names []string, usage string) {
@@ -125,9 +125,14 @@ func ValidateAttach(val string) (string, error) {
 }
 
 func ValidateLink(val string) (string, error) {
-	if _, err := parsers.PartParser("name:alias", val); err != nil {
-		return val, err
+	if strings.Contains(val, ":") {
+		return val, errors.New("Aliases are no longer used with links. Please use only a container name.")
 	}
+
+	if len(strings.TrimSpace(val)) == 0 {
+		return val, errors.New("--link requires a container name as a parameter")
+	}
+
 	return val, nil
 }
 

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -34,21 +34,18 @@ func compareRandomizedStrings(a, b, c, d string) error {
 }
 
 func TestParseRunLinks(t *testing.T) {
-	if _, hostConfig := mustParse(t, "--link a:b"); len(hostConfig.Links) == 0 || hostConfig.Links[0] != "a:b" {
-		t.Fatalf("Error parsing links. Expected []string{\"a:b\"}, received: %v", hostConfig.Links)
+	if _, hostConfig := mustParse(t, "--link a"); len(hostConfig.Links) == 0 || hostConfig.Links[0] != "a" {
+		t.Fatalf("Error parsing links. Expected []string{\"a\"}, received: %v", hostConfig.Links)
 	}
-	if _, hostConfig := mustParse(t, "--link a:b --link c:d"); len(hostConfig.Links) < 2 || hostConfig.Links[0] != "a:b" || hostConfig.Links[1] != "c:d" {
-		t.Fatalf("Error parsing links. Expected []string{\"a:b\", \"c:d\"}, received: %v", hostConfig.Links)
+	if _, hostConfig := mustParse(t, "--link a --link c"); len(hostConfig.Links) < 2 || hostConfig.Links[0] != "a" || hostConfig.Links[1] != "c" {
+		t.Fatalf("Error parsing links. Expected []string{\"a\", \"c\"}, received: %v", hostConfig.Links)
 	}
 	if _, hostConfig := mustParse(t, ""); len(hostConfig.Links) != 0 {
 		t.Fatalf("Error parsing links. No link expected, received: %v", hostConfig.Links)
 	}
 
-	if _, _, err := parse(t, "--link a"); err == nil {
-		t.Fatalf("Error parsing links. `--link a` should be an error but is not")
-	}
-	if _, _, err := parse(t, "--link"); err == nil {
-		t.Fatalf("Error parsing links. `--link` should be an error but is not")
+	if _, _, err := parse(t, "--link a:b"); err == nil {
+		t.Fatalf("Error parsing links. `--link a:b` should be an error but is not")
 	}
 }
 


### PR DESCRIPTION
This depends on #7899 getting merged and should be merged and reviewed independently as they are very different changes that depend on each other.

The status quo:
- links use a sqlite database, typically `/var/lib/docker/linkgraph.db`, to hold a graph of container -> name mappings.
- the sqlite databases encourages nested naming (which is how links is currently implemented) with aliases, such as `/cont1/cont2/alias` and this nesting has no upper bound.

The problem:

Let's create two circular referenced links, a feature we want to support in links v2 (the code currently does not support this, and this patch provides no change to that):
- `docker run --name one --link two:alias`: `/one/two/alias`
- `docker run --name two --link one:alias2`: `/two/one/alias2`

The graph now successfully resolves:
- `/one/two/one/alias2`
- `/two/one/two/alias`
- `/two/one/two/one`

... and so on.

The structure of the link graph -- the external representation -- is the problem; it was not designed to handle circular references. I've resolved this by **removing aliases entirely**, and storing maps of the children and their IDs on the container itself. As a result, the graph db is no longer necessary.

Code notes:
1. Lots of tests were changed, all with the intent of testing the new features. They should be reviewed carefully.
2. This removes a lot of what was done in #7899. These things are no longer required, but the separation of these two patches allows us a clean revert path if for some reason this change gets axed. The jobs patches are independent and a fully functional refactor of existing links, while this patch builds on that and changes the functionality itself.
3. parent lookup, as well as a few other parent-like operations need to iterate through all containers. This is done right now with a very straight forward linear time loop. Adding an index is outside of the scope of this change but I do plan to add it before this feature goes live.
4. `docker run --link` may not parse properly if it is the last argument before the image name. I'm not sure what the resolution here is, I don't think there is one. I've removed the offending test but am open to suggestions.
5. After starting the daemon for the first time after this change, your `linkgraph.db` will be populated into the container metadata based on the graph and then the db will be removed. I'm certain this is the safest approach but not sure it's in the best interests of the project. Looking for feedback here.
