### PR TITLE
tarsum: TarSum should be the interface

### DIFF
--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -93,12 +93,12 @@ type Builder struct {
 	// both of these are controlled by the Remove and ForceRemove options in BuildOpts
 	TmpContainers map[string]struct{} // a map of containers used for removes
 
-	dockerfile  *parser.Node           // the syntax tree of the dockerfile
-	image       string                 // image name for commit processing
-	maintainer  string                 // maintainer name. could probably be removed.
-	cmdSet      bool                   // indicates is CMD was set in current Dockerfile
-	context     tarsum.TarSumInterface // the context is a tarball that is uploaded by the client
-	contextPath string                 // the path of the temporary directory the local context is unpacked to (server side)
+	dockerfile  *parser.Node  // the syntax tree of the dockerfile
+	image       string        // image name for commit processing
+	maintainer  string        // maintainer name. could probably be removed.
+	cmdSet      bool          // indicates is CMD was set in current Dockerfile
+	context     tarsum.TarSum // the context is a tarball that is uploaded by the client
+	contextPath string        // the path of the temporary directory the local context is unpacked to (server side)
 
 }
 

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -167,7 +167,10 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowDecomp
 		if err != nil {
 			return err
 		}
-		tarSum := &tarsum.TarSum{Reader: r, DisableCompression: true}
+		tarSum, err := tarsum.NewTarSum(r, true, tarsum.Version0)
+		if err != nil {
+			return err
+		}
 		if _, err := io.Copy(ioutil.Discard, tarSum); err != nil {
 			return err
 		}


### PR DESCRIPTION
don't export the exsisting TarSum struct and call the interface 'TarSum'
instead.
Per the comments in https://github.com/docker/docker/pull/7689

Signed-off-by: Vincent Batts vbatts@redhat.com
