### PR TITLE
Allow for Dockerfile to be named something else

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -970,6 +970,7 @@ func postBuild(eng *engine.Engine, version version.Version, w http.ResponseWrite
 	}
 	job.Stdin.Add(r.Body)
 	job.Setenv("remote", r.FormValue("remote"))
+	job.Setenv("d", r.FormValue("d"))
 	job.Setenv("t", r.FormValue("t"))
 	job.Setenv("q", r.FormValue("q"))
 	job.Setenv("nocache", r.FormValue("nocache"))

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -93,6 +93,8 @@ type Builder struct {
 	// both of these are controlled by the Remove and ForceRemove options in BuildOpts
 	TmpContainers map[string]struct{} // a map of containers used for removes
 
+	dockerfileName string // name of Dockerfile
+
 	dockerfile  *parser.Node           // the syntax tree of the dockerfile
 	image       string                 // image name for commit processing
 	maintainer  string                 // maintainer name. could probably be removed.
@@ -119,7 +121,7 @@ func (b *Builder) Run(context io.Reader) (string, error) {
 		return "", err
 	}
 
-	filename := path.Join(b.contextPath, "Dockerfile")
+	filename := path.Join(b.contextPath, b.dockerfileName)
 
 	fi, err := os.Stat(filename)
 	if os.IsNotExist(err) {


### PR DESCRIPTION
This adds a '-d' option to the "docker build" command to allow you to specify the name of the Dockerfile to use.
e.g.
docker build -d dev.dock -t myapp .
docker build -d prod.dock -t myapp .
This is really  handy when you have a docker context (dir tree) that is built multiple times/ways and the really only difference is the contents of the Dockerfile. 

While I think its functionally complete, I haven't updated the docs (just the cli help text) nor added testcases yet - as those will probably be a bigger job than the actual code changes :-) . I plan to do both but only if the idea of this PR is acceptable to folks.  If so, I'll then go back and finish the PR properly.

Comments?
