### PR TITLE
Match docs to actual port range used in code.

### DIFF
--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -310,13 +310,13 @@ page.  There are two approaches.
 First, you can supply `-P` or `--publish-all=true|false` to `docker run`
 which is a blanket operation that identifies every port with an `EXPOSE`
 line in the image's `Dockerfile` and maps it to a host port somewhere in
-the range 49000–49900.  This tends to be a bit inconvenient, since you
+the range 49153–65535.  This tends to be a bit inconvenient, since you
 then have to run other `docker` sub-commands to learn which external
 port a given service was mapped to.
 
 More convenient is the `-p SPEC` or `--publish=SPEC` option which lets
 you be explicit about exactly which external port on the Docker server —
-which can be any port at all, not just those in the 49000–49900 block —
+which can be any port at all, not just those in the 49153-65535 block —
 you want mapped to which port in the container.
 
 Either way, you should be able to peek at what Docker has accomplished

--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -26,8 +26,8 @@ container that ran a Python Flask application:
 > information on Docker networking [here](/articles/networking/).
 
 When that container was created, the `-P` flag was used to automatically map any
-network ports inside it to a random high port from the range 49000
-to 49900 on our Docker host.  Next, when `docker ps` was run, you saw that
+network ports inside it to a random high port from the range 49153
+to 65535 on our Docker host.  Next, when `docker ps` was run, you saw that
 port 5000 in the container was bound to port 49155 on the host.
 
     $ sudo docker ps nostalgic_morse

--- a/docs/sources/userguide/usingdocker.md
+++ b/docs/sources/userguide/usingdocker.md
@@ -157,7 +157,7 @@ port) on port 49155.
 
 Network port bindings are very configurable in Docker. In our last
 example the `-P` flag is a shortcut for `-p 5000` that maps port 5000
-inside the container to a high port (from the range 49000 to 49900) on
+inside the container to a high port (from the range 49153 to 65535) on
 the local Docker host. We can also bind Docker containers to specific
 ports using the `-p` flag, for example:
 


### PR DESCRIPTION
Addresses #7985

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
