### PR TITLE
use correct apt-key for test.docker.io/ubuntu

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -274,6 +274,11 @@ EOF
 	gpg --armor --export releasedocker > bundles/$VERSION/ubuntu/gpg
 	s3cmd --acl-public put bundles/$VERSION/ubuntu/gpg s3://$BUCKET/gpg
 
+	local gpgFingerprint=36A1D7869245C8950F966E92D8576A8BA88D21E9
+	if [[ $BUCKET == test* ]]; then
+		gpgFingerprint=740B314AE3941731B942C66ADF4FD13717AAD7D6
+	fi
+
 	# Upload repo
 	s3cmd --acl-public sync $APTDIR/ s3://$BUCKET/ubuntu/
 	cat <<EOF | write_to_s3 s3://$BUCKET/ubuntu/index
@@ -287,7 +292,7 @@ fi
 echo deb $(s3_url)/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 
 # Then import the repository key
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $gpgFingerprint
 
 # Install docker
 apt-get update


### PR DESCRIPTION
Currently the apt-key at test.docker.io is the apt-key for get.docker.io. This corrects that.

Docker-DCO-1.1-Signed-off-by: Jessica Frazelle jess@docker.com (github: jfrazelle)
