### PR TITLE
Fix parsing of proto/port - issue 6447

### DIFF
--- a/nat/nat.go
+++ b/nat/nat.go
@@ -61,21 +61,25 @@ func (p Port) Int() int {
 	return i
 }
 
-// Splits a port in the format of port/proto
+// Splits a port in the format of proto/port
 func SplitProtoPort(rawPort string) (string, string) {
-	parts := strings.Split(rawPort, "/")
-	l := len(parts)
-	if l == 0 {
-		return "", ""
-	}
-	if l == 1 {
-		if rawPort == "" {
-			return "", "" // ""/tcp is not valid, ever
-		}
+	var port string
+	var proto string
 
-		return "tcp", rawPort
+	parts := strings.Split(rawPort, "/")
+
+	if len(parts) == 0 || parts[0] == "" { // we have "" or ""/
+		port = ""
+		proto = ""
+	} else { // we have # or #/  or #/...
+		port = parts[0]
+		if len(parts) > 1 && parts[1] != "" {
+			proto = parts[1] // we have #/...
+		} else {
+			proto = "tcp" // we have # or #/
+		}
 	}
-	return parts[1], parts[0]
+	return proto, port
 }
 
 func validateProto(proto string) bool {

--- a/nat/nat_test.go
+++ b/nat/nat_test.go
@@ -84,6 +84,18 @@ func TestSplitProtoPort(t *testing.T) {
 	if proto != "tcp" || port != "1234" {
 		t.Fatal("tcp is not the default protocol for portspec '1234'")
 	}
+
+	proto, port = SplitProtoPort("1234/")
+
+	if proto != "tcp" || port != "1234" {
+		t.Fatal("parsing '1234/' yielded:" + port + "/" + proto)
+	}
+
+	proto, port = SplitProtoPort("/tcp")
+
+	if proto != "" || port != "" {
+		t.Fatal("parsing '/tcp' yielded:" + port + "/" + proto)
+	}
 }
 
 func TestParsePortSpecs(t *testing.T) {


### PR DESCRIPTION
Fixes #6447
Here's what I think is going on.  Using the old code at: https://github.com/docker/docker/blob/master/nat/nat.go#L65   I think the parsing is a bit off.  The old parse would do this (  "old string" -> port / protocol ):
123/tcp -> 123/tcp
123/ -> 123/""    (#6447 issue)
/tcp -> tcp/""    (error)
/ -> ""/""
"" -> ""/""

And I think its the 123/ -> 123/"" case that is the cause of the issue in #6447, it should return 123/tcp.
With this change the parser now returns:
123/tcp -> tcp/123
123/  ->  123/tcp  (now it'll default to tcp to fix #6447)
/tcp  -> ""/""   (treat the same as / and "")
/  -> ""/""
"" ->  ""/""

I also added some new tests to enforce this.

Signed-off-by: Doug Davis dug@us.ibm.com
