### PR TITLE
fixes incorrect environment variable labeling in container linking guide

### DIFF
--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -186,10 +186,10 @@ command to list the specified container's environment variables.
     . . .
     DB_NAME=/web2/db
     DB_PORT=tcp://172.17.0.5:5432
-    DB_PORT_5000_TCP=tcp://172.17.0.5:5432
-    DB_PORT_5000_TCP_PROTO=tcp
-    DB_PORT_5000_TCP_PORT=5432
-    DB_PORT_5000_TCP_ADDR=172.17.0.5
+    DB_PORT_5432_TCP=tcp://172.17.0.5:5432
+    DB_PORT_5432_TCP_PROTO=tcp
+    DB_PORT_5432_TCP_PORT=5432
+    DB_PORT_5432_TCP_ADDR=172.17.0.5
     . . .
 ```
 


### PR DESCRIPTION
modified:   userguide/dockerlinks.md
fixes incorrect environment variable labeling in container linking guide
Signed-off-by: David Gebler davidgebler@gmail.com
