### PR TITLE
integ-cli: fix TestImportDisplay & add FileServer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,9 @@ RUN mkdir -p /go/src/github.com/cpuguy83 \
 # Get the "busybox" image source so we can build locally instead of pulling
 RUN	git clone -b buildroot-2014.02 https://github.com/jpetazzo/docker-busybox.git /docker-busybox
 
+# Get the "cirros" image source so we can import it instead of fetching it during tests
+RUN	curl -sSL -o /cirros.tar.gz https://github.com/ewindisch/docker-cirros/raw/1cded459668e8b9dbf4ef976c94c05add9bbd8e9/cirros-0.3.0-x86_64-lxc.tar.gz
+
 # Setup s3cmd config
 RUN	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_KEY' > /.s3cfg
 

--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -1,13 +1,22 @@
 package main
 
 import (
+	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
 )
 
 func TestImportDisplay(t *testing.T) {
-	importCmd := exec.Command(dockerBinary, "import", "https://github.com/ewindisch/docker-cirros/raw/master/cirros-0.3.0-x86_64-lxc.tar.gz")
+	server, err := fileServer(map[string]string{
+		"/cirros.tar.gz": "/cirros.tar.gz",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+	fileUrl := fmt.Sprintf("%s/cirros.tar.gz", server.URL)
+	importCmd := exec.Command(dockerBinary, "import", fileUrl)
 	out, _, err := runCommandWithOutput(importCmd)
 	if err != nil {
 		t.Errorf("import failed with errors: %v, output: %q", err, out)


### PR DESCRIPTION
This PR fixes TestImportDisplay. HTTPS handshakes are failing erratically sometimes and that's breaking TestImportDisplay.

This PR moves the download of the file to the Dockerfile and TestImportDisplay simply imports it from a local server which serves files over HTTP.
