### PR TITLE
Links v2: Mutable network files

### DIFF
--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -78,6 +78,7 @@ type Mount struct {
 	Destination string `json:"destination"`
 	Writable    bool   `json:"writable"`
 	Private     bool   `json:"private"`
+	Slave       bool   `json:"slave"`
 }
 
 // Describes a process that will be run inside a container.

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -167,6 +167,7 @@ func (d *driver) setupMounts(container *libcontainer.Config, c *execdriver.Comma
 			Destination: m.Destination,
 			Writable:    m.Writable,
 			Private:     m.Private,
+			Slave:       m.Slave,
 		})
 	}
 

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -43,15 +43,30 @@ func prepareVolumesForContainer(container *Container) error {
 
 func setupMountsForContainer(container *Container) error {
 	mounts := []execdriver.Mount{
-		{container.ResolvConfPath, "/etc/resolv.conf", true, true},
+		{
+			Source:      container.ResolvConfPath,
+			Destination: "/etc/resolv.conf",
+			Writable:    true,
+			Slave:       true,
+		},
 	}
 
 	if container.HostnamePath != "" {
-		mounts = append(mounts, execdriver.Mount{container.HostnamePath, "/etc/hostname", true, true})
+		mounts = append(mounts, execdriver.Mount{
+			Source:      container.HostnamePath,
+			Destination: "/etc/hostname",
+			Writable:    true,
+			Private:     true,
+		})
 	}
 
 	if container.HostsPath != "" {
-		mounts = append(mounts, execdriver.Mount{container.HostsPath, "/etc/hosts", true, true})
+		mounts = append(mounts, execdriver.Mount{
+			Source:      container.HostsPath,
+			Destination: "/etc/hosts",
+			Writable:    true,
+			Slave:       true,
+		})
 	}
 
 	// Mount user specified volumes
@@ -59,7 +74,11 @@ func setupMountsForContainer(container *Container) error {
 	// volumes. For instance if you use -v /usr:/usr and the host later mounts /usr/share you
 	// want this new mount in the container
 	for r, v := range container.Volumes {
-		mounts = append(mounts, execdriver.Mount{v, r, container.VolumesRW[r], false})
+		mounts = append(mounts, execdriver.Mount{
+			Source:      v,
+			Destination: r,
+			Writable:    container.VolumesRW[r],
+		})
 	}
 
 	container.command.Mounts = mounts


### PR DESCRIPTION
This exploits the new MS_SLAVE support in libcontainer to make `/etc/resolv.conf` and `/etc/hosts` mutable.

This also fixes the /etc/hosts test and adds a few of its own.

Caveat: restarting a container (currently) does not keep /etc/hosts intact. I'm still torn on whether this is a feature or not.
