### PR TITLE
Support for nested build steps

### DIFF
--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -10,13 +10,16 @@ package builder
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/nat"
+	"github.com/docker/docker/pkg/archive"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/runconfig"
 )
 
@@ -368,6 +371,98 @@ func volume(b *Builder, args []string, attributes map[string]bool, original stri
 	if err := b.commit("", b.Config.Cmd, fmt.Sprintf("VOLUME %v", args)); err != nil {
 		return err
 	}
+	return nil
+}
+
+// BUILD path
+//
+// Run new build process using the specified path as a new build context.
+//
+func build(b *Builder, args []string, attributes map[string]bool, original string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("Build configuration empty")
+	}
+
+	contextPath := args[0]
+	dockerfile := ""
+
+	if len(args) > 1 {
+		dockerfile = args[1]
+	}
+
+	// Set command for debugging/init. This is not commited.
+	b.Config.Cmd = []string{"/bin/sh", "-c", fmt.Sprintf("#(nop) build in %s", contextPath)}
+
+	c, err := b.create()
+	if err != nil {
+		return err
+	}
+
+	c.Mount()
+	defer c.Unmount()
+
+	contextPath = filepath.Join(c.RootfsPath(), contextPath)
+	contextPath, err = symlink.FollowSymlinkInScope(contextPath, c.RootfsPath())
+	if err != nil {
+		return err
+	}
+
+	dirInfo, err := os.Stat(contextPath)
+	if err != nil {
+		return err
+	}
+	if !dirInfo.IsDir() {
+		return fmt.Errorf("%s is not a directory", contextPath)
+	}
+
+	if len(dockerfile) > 1 {
+		dockerfilePath := filepath.Join(contextPath, "Dockerfile")
+		dockerfilePath, err := symlink.FollowSymlinkInScope(dockerfilePath, contextPath)
+		if err != nil {
+			return err
+		}
+		f, err := os.Create(dockerfilePath)
+		if err != nil {
+			return err
+		}
+		_, err = f.WriteString(dockerfile)
+		f.Close()
+		if err != nil {
+			return err
+		}
+
+		// Reset the modified times so the Dockerfile can't invalidate cache.
+		err = os.Chtimes(dockerfilePath, dirInfo.ModTime(), dirInfo.ModTime())
+		if err != nil {
+			return err
+		}
+		err = os.Chtimes(contextPath, dirInfo.ModTime(), dirInfo.ModTime())
+		if err != nil {
+			return err
+		}
+
+	}
+
+	archive, err := archive.Tar(contextPath, archive.Uncompressed)
+	if err != nil {
+		return err
+	}
+	defer archive.Close()
+
+	// Copy so the old image is not overwritten.
+	// builder.Config is reset by Run().
+	copy := *b
+	newBuilder := &copy
+
+	_, err = newBuilder.Run(archive)
+	if err != nil {
+		return err
+	}
+
+	if b.RepoName != "" {
+		b.RepoName = newBuilder.RepoName + "-builder"
+	}
+
 	return nil
 }
 

--- a/builder/job.go
+++ b/builder/job.go
@@ -39,14 +39,12 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 		pull           = job.GetenvBool("pull")
 		authConfig     = &registry.AuthConfig{}
 		configFile     = &registry.ConfigFile{}
-		tag            string
 		context        io.ReadCloser
 	)
 	job.GetenvJson("authConfig", authConfig)
 	job.GetenvJson("configFile", configFile)
 
-	repoName, tag = parsers.ParseRepositoryTag(repoName)
-	if repoName != "" {
+	if repoName, tag := parsers.ParseRepositoryTag(repoName); repoName != "" {
 		if _, _, err := registry.ResolveRepositoryName(repoName); err != nil {
 			return job.Error(err)
 		}
@@ -118,15 +116,13 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 		StreamFormatter: sf,
 		AuthConfig:      authConfig,
 		AuthConfigFile:  configFile,
+		RepoName:        repoName,
 	}
 
-	id, err := builder.Run(context)
+	_, err := builder.Run(context)
 	if err != nil {
 		return job.Error(err)
 	}
 
-	if repoName != "" {
-		b.Daemon.Repositories().Set(repoName, tag, id, true)
-	}
 	return engine.StatusOK
 }

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -57,6 +57,7 @@ func init() {
 		"entrypoint": parseMaybeJSON,
 		"expose":     parseStringsWhitespaceDelimited,
 		"volume":     parseMaybeJSONToList,
+		"build":      parseString,
 		"insert":     parseIgnore,
 	}
 }
@@ -135,6 +136,19 @@ func Parse(rwc io.Reader) (*Node, error) {
 
 		if child != nil {
 			root.Children = append(root.Children, child)
+
+			if child.Value == "build" {
+				rest := ""
+				for scanner.Scan() {
+					rest += scanner.Text() + "\n"
+				}
+				if node, err := Parse(strings.NewReader(rest)); err != nil {
+					return nil, err
+				} else if len(node.Children) > 0 {
+					child.Next.Next = &Node{Value: rest}
+				}
+				break
+			}
 		}
 	}
 

--- a/builder/parser/testfiles-negative/error_in_build_block/Dockerfile
+++ b/builder/parser/testfiles-negative/error_in_build_block/Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox
+
+BUILD /
+
+ENV PATH

--- a/builder/parser/testfiles/tonistiigi-dnsdock/Dockerfile
+++ b/builder/parser/testfiles/tonistiigi-dnsdock/Dockerfile
@@ -1,0 +1,17 @@
+FROM crosbymichael/golang
+
+ADD . /go/src/github.com/tonistiigi/dnsdock
+
+ENV CGO_ENABLED 0
+
+RUN cd /go/src/github.com/tonistiigi/dnsdock && \
+    go get -d ./... && \
+    go install -a ./...
+
+BUILD /go/bin
+
+FROM scratch
+
+ADD dnsdock .
+
+ENTRYPOINT ["/dnsdock"]

--- a/builder/parser/testfiles/tonistiigi-dnsdock/result
+++ b/builder/parser/testfiles/tonistiigi-dnsdock/result
@@ -1,0 +1,9 @@
+(from "crosbymichael/golang")
+(add "." "/go/src/github.com/tonistiigi/dnsdock")
+(env "CGO_ENABLED" "0")
+(run "cd /go/src/github.com/tonistiigi/dnsdock &&     go get -d ./... &&     go install -a ./...")
+(build "/go/bin" "FROM scratch
+
+ADD dnsdock .
+
+ENTRYPOINT [\"/dnsdock\"]")

--- a/builder/parser/testfiles/tonistiigi-empty-build-rule/Dockerfile
+++ b/builder/parser/testfiles/tonistiigi-empty-build-rule/Dockerfile
@@ -1,0 +1,9 @@
+FROM busybox
+
+ADD . /
+
+RUN /generate-new-dockerfile.sh > Dockerfile
+
+BUILD /
+
+# Inner build uses generated Dockerfile

--- a/builder/parser/testfiles/tonistiigi-empty-build-rule/result
+++ b/builder/parser/testfiles/tonistiigi-empty-build-rule/result
@@ -1,0 +1,4 @@
+(from "busybox")
+(add "." "/")
+(run "/generate-new-dockerfile.sh > Dockerfile")
+(build "/")

--- a/builder/parser/testfiles/tonistiigi-multiple-build-commands/Dockerfile
+++ b/builder/parser/testfiles/tonistiigi-multiple-build-commands/Dockerfile
@@ -1,0 +1,11 @@
+FROM busybox
+
+ADD . /
+
+BUILD /app
+
+FROM busybox
+
+ADD . /
+
+BUILD /app

--- a/builder/parser/testfiles/tonistiigi-multiple-build-commands/result
+++ b/builder/parser/testfiles/tonistiigi-multiple-build-commands/result
@@ -1,0 +1,7 @@
+(from "busybox")
+(add "." "/")
+(build "/app" "FROM busybox
+
+ADD . /
+
+BUILD /app")

--- a/docs/man/Dockerfile.5.md
+++ b/docs/man/Dockerfile.5.md
@@ -203,5 +203,15 @@ or
  The solution is to use **ONBUILD** to register instructions in advance, to
  run later, during the next build stage.  
 
+**BUILD**
+ -- **BUILD /path/to/build/context**
+ The BUILD instruction starts building a new image as if `docker build` would
+ have been run in the specified directory of the current image. Rest of the
+ instructions in the Dockerfile are now considered to be part of this new build
+ process. If there are no instructions and the context directory contains a
+ file called Dockerfile then this file is used instead. Files located in build
+ context directory are available as source paths to the ADD and COPY commands.
+ No previously set instruction has any effect to the new build.
+
 # HISTORY
 *May 2014, Compiled by Zac Dover (zdover at redhat dot com) based on docker.com Dockerfile documentation.

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3697,6 +3697,102 @@ func TestBuildRunShEntrypoint(t *testing.T) {
 	logDone("build - entrypoint with /bin/echo running successfully")
 }
 
+func TestBuildWithSubBuild(t *testing.T) {
+	name := "testbuildwithsubbuild"
+	defer deleteImages(name + " " + name + "-build")
+	dockerfile := `
+FROM busybox
+ADD test /test
+BUILD /test/hello
+FROM busybox
+ADD docker /docker
+RUN ["/bin/touch", "/docker/hello"]`
+	ctx, err := fakeContext(dockerfile, map[string]string{
+		"/test/hello/docker/world": "",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	id1, err := buildImageFromContext(name, ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(dockerBinary, "run", "--rm", name, "ls", "-1", "/docker")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "hello\nworld"
+	out = strings.TrimSpace(out)
+	if out != expected {
+		t.Fatalf("Subbuild ls %s, expected %s", out, expected)
+	}
+
+	// Try second build to test cache
+	id2, err := buildImageFromContext(name, ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if id1 != id2 {
+		t.Fatal("The cache should have been used but hasn't.")
+	}
+
+	logDone("build - subbuild support")
+}
+
+func TestBuildBuildWithGeneratedDockerfile(t *testing.T) {
+	name := "testbuildbuildwithgenerateddockerfile"
+	defer deleteImages(name + " " + name + "-build")
+
+	dockerfile := `
+FROM busybox
+ADD test /test
+WORKDIR /test
+RUN ["/bin/sh", "/test/build.sh"]
+BUILD /test`
+	ctx, err := fakeContext(dockerfile, map[string]string{
+		"test/build.sh": `#!/bin/sh
+BUILD_TIME=$(date)
+cat <<EOT > Dockerfile
+FROM busybox
+ENV BUILD_TIME $BUILD_TIME
+ADD check.sh .
+EOT
+
+cat <<EOT > check.sh
+#!/bin/sh
+if [ "$BUILD_TIME" == "\$BUILD_TIME" ]; then
+	echo "ok"
+fi
+EOT
+`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = buildImageFromContext(name, ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(dockerBinary, "run", "--rm", name, "/bin/sh", "/check.sh")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "ok"
+	out = strings.TrimSpace(out)
+	if out != expected {
+		t.Fatalf("Check returned %s, expected %s", out, expected)
+	}
+
+	logDone("build - subbuild with generated Dockerfile")
+}
+
 func TestBuildExoticShellInterpolation(t *testing.T) {
 	name := "testbuildexoticshellinterpolation"
 	defer deleteImages(name)


### PR DESCRIPTION
This is a nested build implementation roughly based on #7149 by @proppy
### `BUILD /path/to/build/context`

The `BUILD` instruction starts building a new image as if `docker build` would
have been run in the specified directory of the current image. Rest of the
instructions in the Dockerfile are now considered to be part of this new build
process. If there are no instructions and the context directory contains a
file called Dockerfile then this file is used instead. Files located in build
context directory are available as source paths to the ADD and COPY commands.
No previously set instruction has any effect to the new build.

Consider a Dockerfile:

```
FROM crosbymichael/golang
ADD . /go/src/github.com/tonistiigi/dnsdock
ENV CGO_ENABLED 0
RUN cd /go/src/github.com/tonistiigi/dnsdock && \
    go get -d ./... && \
    go install -a ./...

BUILD /go/bin

FROM scratch
ADD dnsdock /
ENTRYPOINT ["/dnsdock"]
```

Running `docker build -t tonistiigi/dnsdock .` will result in the creation of following images:

```
> docker images
tonistiigi/dnsdock          latest  3f7a44c4701a  6 seconds ago    7.844 MB
tonistiigi/dnsdock-builder  latest  dac44acfcdd9  10 seconds ago   474.7 MB
```

The final image is minimal, containing only a static binary compiled by previous image. Builder layers are kept to keep build cache working.

Parent build step can be also used for dynamic Dockerfile creation. In this case `BUILD` instruction needs to be the final instruction in the Dockerfile.

```
FROM ubuntu
ADD . /src
RUN /src/build-new-dockerfile.sh > /src/Dockerfile
BUILD /src
```

Number of build steps isn't limited. Last image gets the tag.

```
cat <<EOT > Dockerfile
FROM busybox
RUN /bin/mkdir -p /out && /bin/touch /out/a
BUILD /out

FROM busybox
ADD . /out
RUN /bin/mkdir -p /out && /bin/touch /out/b
BUILD /out

FROM busybox
ADD . /out
RUN /bin/mkdir -p /out && /bin/touch /out/c

EOT

docker build -t abc .
docker run abc /bin/ls /out

# prints:  a   b    c
```

I realize that the proposals with different solutions for fixing this problem have not yet been agreed on by the maintainers. Just hoping that having one implementation ready for testing/review brings the final solution for minimal containers closer for everybody.
