### PR TITLE
Append instead of replace file contents

### DIFF
--- a/docs/sources/articles/host_integration.md
+++ b/docs/sources/articles/host_integration.md
@@ -42,7 +42,7 @@ it:
 Next, we have to configure docker so that it's run with the option
 `-r=false`. Run the following command:
 
-    $ sudo sh -c "echo 'DOCKER_OPTS=\"-r=false\"' > /etc/default/docker"
+    $ sudo sh -c "echo 'DOCKER_OPTS=\"-r=false\"' >> /etc/default/docker"
 
 ## Sample systemd Script
 


### PR DESCRIPTION
I think the `DOCKER_OPTS` should be appended to `/etc/default/docker` and not replace the entire contents.
