### PR TITLE
Improved X-Registry-Auth content instructions

### DIFF
--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -15,8 +15,11 @@ page_keywords: API, Docker, rcli, REST, documentation
  - Since API version 1.2, the auth configuration is now handled client
    side, so the client has to send the `authConfig` as a `POST` in `/images/(name)/push`.
  - authConfig, set as the `X-Registry-Auth` header, is currently a Base64
-   encoded (JSON) string with credentials:
-   `{'username': string, 'password': string, 'email': string, 'serveraddress' : string}`
+   encoded (JSON) string with the following structure: 
+   `{"username": "string", "password": "string", "email": "string",
+   "serveraddress" : "string", "auth": ""}`. Notice that `auth` is to be left 
+   empty, `serveraddress` is a domain/ip without protocol, and that double 
+   quotes (instead of single ones) are required.
 
 The current version of the API is v1.15
 


### PR DESCRIPTION
Hi,

this is a small contribution to fix some slightly unprecise information about the `X-Registry-Auth` header required to pull from private registries through the remote API. After a lot of trial and I error I managed to find that the documentation indications had this issues:
- Apparently single quotes cannot be used and double quotes (regular JSON) is required.
- Also the `auth` key must be passed even if empty or a 403 will result.
- It was not clear what the `serveraddress` had to be.

I added some small clarifications for anyone taking a look at the docs to keep them from the problems I've encountered. Hope this is helpful.

Thanks to all the contributors for bringing so much awesomeness to the linux world. :)
