### PR TITLE
Help new users if their SELinux is not-upgraded yet.

### DIFF
--- a/docs/sources/installation/fedora.md
+++ b/docs/sources/installation/fedora.md
@@ -48,6 +48,10 @@ Now let's verify that Docker is working.
 
     $ sudo docker run -i -t fedora /bin/bash
 
+> Note: If you get a `Cannot start container` error mentioning SELinux
+> or permission denied, you may need to update the SELinux policies.
+> This can be done using `sudo yum upgrade selinux-policy` and then rebooting.
+
 ## Granting rights to users to use Docker
 
 Fedora 19 and 20 shipped with Docker 0.11. The package has already been updated

--- a/docs/sources/installation/rhel.md
+++ b/docs/sources/installation/rhel.md
@@ -75,6 +75,10 @@ Now let's verify that Docker is working.
 
     $ sudo docker run -i -t fedora /bin/bash
 
+> Note: If you get a `Cannot start container` error mentioning SELinux
+> or permission denied, you may need to update the SELinux policies.
+> This can be done using `sudo yum upgrade selinux-policy` and then rebooting.
+
 **Done!**
 
 Continue with the [User Guide](/userguide/).


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@docker.com (github: SvenDowideit)

if you download the current fedora 20 iso, install then run `yum install docker-io` as per our docs, it will fail - this gives the new users some hint as to what next.
