### PR TITLE
archive: preserve hardlinks in Tar and Untar

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -193,7 +193,6 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 			hdr.Devmajor = int64(major(uint64(stat.Rdev)))
 			hdr.Devminor = int64(minor(uint64(stat.Rdev)))
 		}
-
 	}
 
 	// if it's a regular file and has more than 1 link,
@@ -228,6 +227,7 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 		}
 
 		ta.Buffer.Reset(ta.TarWriter)
+		defer ta.Buffer.Reset(nil)
 		_, err = io.Copy(ta.Buffer, file)
 		file.Close()
 		if err != nil {
@@ -237,7 +237,6 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 		if err != nil {
 			return err
 		}
-		ta.Buffer.Reset(nil)
 	}
 
 	return nil

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -153,7 +153,15 @@ func (compression *Compression) Extension() string {
 	return ""
 }
 
-func addTarFile(path, name string, tw *tar.Writer, twBuf *bufio.Writer) error {
+type tarAppender struct {
+	TarWriter *tar.Writer
+	Buffer    *bufio.Writer
+
+	// for hardlink mapping
+	SeenFiles map[uint64]string
+}
+
+func (ta *tarAppender) addTarFile(path, name string) error {
 	fi, err := os.Lstat(path)
 	if err != nil {
 		return err
@@ -188,13 +196,28 @@ func addTarFile(path, name string, tw *tar.Writer, twBuf *bufio.Writer) error {
 
 	}
 
+	// if it's a regular file and has more than 1 link,
+	// it's hardlinked, so set the type flag accordingly
+	if fi.Mode().IsRegular() && stat.Nlink > 1 {
+		// a link should have a name that it links too
+		// and that linked name should be first in the tar archive
+		ino := uint64(stat.Ino)
+		if oldpath, ok := ta.SeenFiles[ino]; ok {
+			hdr.Typeflag = tar.TypeLink
+			hdr.Linkname = oldpath
+			hdr.Size = 0 // This Must be here for the writer math to add up!
+		} else {
+			ta.SeenFiles[ino] = name
+		}
+	}
+
 	capability, _ := system.Lgetxattr(path, "security.capability")
 	if capability != nil {
 		hdr.Xattrs = make(map[string]string)
 		hdr.Xattrs["security.capability"] = string(capability)
 	}
 
-	if err := tw.WriteHeader(hdr); err != nil {
+	if err := ta.TarWriter.WriteHeader(hdr); err != nil {
 		return err
 	}
 
@@ -204,17 +227,17 @@ func addTarFile(path, name string, tw *tar.Writer, twBuf *bufio.Writer) error {
 			return err
 		}
 
-		twBuf.Reset(tw)
-		_, err = io.Copy(twBuf, file)
+		ta.Buffer.Reset(ta.TarWriter)
+		_, err = io.Copy(ta.Buffer, file)
 		file.Close()
 		if err != nil {
 			return err
 		}
-		err = twBuf.Flush()
+		err = ta.Buffer.Flush()
 		if err != nil {
 			return err
 		}
-		twBuf.Reset(nil)
+		ta.Buffer.Reset(nil)
 	}
 
 	return nil
@@ -345,9 +368,15 @@ func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) 
 		return nil, err
 	}
 
-	tw := tar.NewWriter(compressWriter)
-
 	go func() {
+		ta := &tarAppender{
+			TarWriter: tar.NewWriter(compressWriter),
+			Buffer:    pools.BufioWriter32KPool.Get(nil),
+			SeenFiles: make(map[uint64]string),
+		}
+		// this buffer is needed for the duration of this piped stream
+		defer pools.BufioWriter32KPool.Put(ta.Buffer)
+
 		// In general we log errors here but ignore them because
 		// during e.g. a diff operation the container can continue
 		// mutating the filesystem and we can see transient errors
@@ -356,9 +385,6 @@ func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) 
 		if options.Includes == nil {
 			options.Includes = []string{"."}
 		}
-
-		twBuf := pools.BufioWriter32KPool.Get(nil)
-		defer pools.BufioWriter32KPool.Put(twBuf)
 
 		var renamedRelFilePath string // For when tar.Options.Name is set
 		for _, include := range options.Includes {
@@ -395,7 +421,7 @@ func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) 
 					relFilePath = strings.Replace(relFilePath, renamedRelFilePath, options.Name, 1)
 				}
 
-				if err := addTarFile(filePath, relFilePath, tw, twBuf); err != nil {
+				if err := ta.addTarFile(filePath, relFilePath); err != nil {
 					log.Debugf("Can't add file %s to tar: %s", srcPath, err)
 				}
 				return nil
@@ -403,7 +429,7 @@ func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) 
 		}
 
 		// Make sure to check the error on Close.
-		if err := tw.Close(); err != nil {
+		if err := ta.TarWriter.Close(); err != nil {
 			log.Debugf("Can't close tar writer: %s", err)
 		}
 		if err := compressWriter.Close(); err != nil {

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -333,6 +333,8 @@ func ChangesDirs(newDir, oldDir string) ([]Change, error) {
 		newRoot, err2 = collectFileInfo(newDir)
 		errs <- err2
 	}()
+
+	// block until both routines have returned
 	for i := 0; i < 2; i++ {
 		if err := <-errs; err != nil {
 			return nil, err
@@ -409,7 +411,9 @@ func ExportChanges(dir string, changes []Change) (Archive, error) {
 		if err := ta.TarWriter.Close(); err != nil {
 			log.Debugf("Can't close layer: %s", err)
 		}
-		writer.Close()
+		if err := writer.Close(); err != nil {
+			log.Debugf("failed close Changes writer: %s", err)
+		}
 	}()
 	return reader, nil
 }

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -368,11 +368,15 @@ func minor(device uint64) uint64 {
 // ExportChanges produces an Archive from the provided changes, relative to dir.
 func ExportChanges(dir string, changes []Change) (Archive, error) {
 	reader, writer := io.Pipe()
-	tw := tar.NewWriter(writer)
-
 	go func() {
-		twBuf := pools.BufioWriter32KPool.Get(nil)
-		defer pools.BufioWriter32KPool.Put(twBuf)
+		ta := &tarAppender{
+			TarWriter: tar.NewWriter(writer),
+			Buffer:    pools.BufioWriter32KPool.Get(nil),
+			SeenFiles: make(map[uint64]string),
+		}
+		// this buffer is needed for the duration of this piped stream
+		defer pools.BufioWriter32KPool.Put(ta.Buffer)
+
 		// In general we log errors here but ignore them because
 		// during e.g. a diff operation the container can continue
 		// mutating the filesystem and we can see transient errors
@@ -390,19 +394,19 @@ func ExportChanges(dir string, changes []Change) (Archive, error) {
 					AccessTime: timestamp,
 					ChangeTime: timestamp,
 				}
-				if err := tw.WriteHeader(hdr); err != nil {
+				if err := ta.TarWriter.WriteHeader(hdr); err != nil {
 					log.Debugf("Can't write whiteout header: %s", err)
 				}
 			} else {
 				path := filepath.Join(dir, change.Path)
-				if err := addTarFile(path, change.Path[1:], tw, twBuf); err != nil {
+				if err := ta.addTarFile(path, change.Path[1:]); err != nil {
 					log.Debugf("Can't add file %s to tar: %s", path, err)
 				}
 			}
 		}
 
 		// Make sure to check the error on Close.
-		if err := tw.Close(); err != nil {
+		if err := ta.TarWriter.Close(); err != nil {
 			log.Debugf("Can't close layer: %s", err)
 		}
 		writer.Close()

--- a/pkg/archive/example_changes.go
+++ b/pkg/archive/example_changes.go
@@ -1,0 +1,97 @@
+// +build ignore
+
+// Simple tool to create an archive stream from an old and new directory
+//
+// By default it will stream the comparison of two temporary directories with junk files
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/archive"
+)
+
+var (
+	flDebug  = flag.Bool("D", false, "debugging output")
+	flNewDir = flag.String("newdir", "", "")
+	flOldDir = flag.String("olddir", "", "")
+	log      = logrus.New()
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Println("Produce a tar from comparing two directory paths. By default a demo tar is created of around 200 files (including hardlinks)")
+		fmt.Printf("%s [OPTIONS]\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	log.Out = os.Stderr
+	if (len(os.Getenv("DEBUG")) > 0) || *flDebug {
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+	var newDir, oldDir string
+
+	if len(*flNewDir) == 0 {
+		var err error
+		newDir, err = ioutil.TempDir("", "docker-test-newDir")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer os.RemoveAll(newDir)
+		if _, err := prepareUntarSourceDirectory(100, newDir, true); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		newDir = *flNewDir
+	}
+
+	if len(*flOldDir) == 0 {
+		oldDir, err := ioutil.TempDir("", "docker-test-oldDir")
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer os.RemoveAll(oldDir)
+	} else {
+		oldDir = *flOldDir
+	}
+
+	changes, err := archive.ChangesDirs(newDir, oldDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	a, err := archive.ExportChanges(newDir, changes)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer a.Close()
+
+	i, err := io.Copy(os.Stdout, a)
+	if err != nil && err != io.EOF {
+		log.Fatal(err)
+	}
+	fmt.Fprintf(os.Stderr, "wrote archive of %d bytes", i)
+}
+
+func prepareUntarSourceDirectory(numberOfFiles int, targetPath string, makeLinks bool) (int, error) {
+	fileData := []byte("fooo")
+	for n := 0; n < numberOfFiles; n++ {
+		fileName := fmt.Sprintf("file-%d", n)
+		if err := ioutil.WriteFile(path.Join(targetPath, fileName), fileData, 0700); err != nil {
+			return 0, err
+		}
+		if makeLinks {
+			if err := os.Link(path.Join(targetPath, fileName), path.Join(targetPath, fileName+"-link")); err != nil {
+				return 0, err
+			}
+		}
+	}
+	totalSize := numberOfFiles * len(fileData)
+	return totalSize, nil
+}


### PR DESCRIPTION
```
benchmark             old ns/op     new ns/op     delta
BenchmarkTarUntar     5662243       5615513       -0.83%

benchmark             old MB/s     new MB/s     speedup
BenchmarkTarUntar     0.07         0.07         1.00x

benchmark             old allocs     new allocs     delta
BenchmarkTarUntar     10815          10815          +0.00%

benchmark             old bytes     new bytes     delta
BenchmarkTarUntar     520637        520216        -0.08%
```

ping @unclejack 

Signed-off-by: Vincent Batts vbatts@redhat.com
