### PR TITLE
Links v2: Remove the graphdb. Replace with code and json structure.

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1557,11 +1557,6 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 			outID = utils.TruncateID(outID)
 		}
 
-		// Remove the leading / from the names
-		for i := 0; i < len(outNames); i++ {
-			outNames[i] = outNames[i][1:]
-		}
-
 		if !*quiet {
 			var (
 				outCommand   = out.Get("Command")

--- a/daemon/container_unit_test.go
+++ b/daemon/container_unit_test.go
@@ -1,8 +1,9 @@
 package daemon
 
 import (
-	"github.com/docker/docker/nat"
 	"testing"
+
+	"github.com/docker/docker/nat"
 )
 
 func TestParseNetworkOptsPrivateOnly(t *testing.T) {
@@ -163,19 +164,6 @@ func TestParseNetworkOptsUdp(t *testing.T) {
 		if s.HostIp != "192.168.1.100" {
 			t.Fail()
 		}
-	}
-}
-
-func TestGetFullName(t *testing.T) {
-	name, err := GetFullContainerName("testing")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if name != "/testing" {
-		t.Fatalf("Expected /testing got %s", name)
-	}
-	if _, err := GetFullContainerName(""); err == nil {
-		t.Fatal("Error should not be nil")
 	}
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -27,7 +27,6 @@ import (
 	"github.com/docker/docker/graph"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/broadcastwriter"
-	"github.com/docker/docker/pkg/graphdb"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/log"
 	"github.com/docker/docker/pkg/namesgenerator"
@@ -35,7 +34,6 @@ import (
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/sysinfo"
-	"github.com/docker/docker/pkg/truncindex"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
 	"github.com/docker/docker/volumes"
@@ -47,56 +45,19 @@ var (
 	validContainerNamePattern = regexp.MustCompile(`^/?` + validContainerNameChars + `+$`)
 )
 
-type contStore struct {
-	s map[string]*Container
-	sync.Mutex
-}
-
-func (c *contStore) Add(id string, cont *Container) {
-	c.Lock()
-	c.s[id] = cont
-	c.Unlock()
-}
-
-func (c *contStore) Get(id string) *Container {
-	c.Lock()
-	res := c.s[id]
-	c.Unlock()
-	return res
-}
-
-func (c *contStore) Delete(id string) {
-	c.Lock()
-	delete(c.s, id)
-	c.Unlock()
-}
-
-func (c *contStore) List() []*Container {
-	containers := new(History)
-	c.Lock()
-	for _, cont := range c.s {
-		containers.Add(cont)
-	}
-	c.Unlock()
-	containers.Sort()
-	return *containers
-}
-
 type Daemon struct {
-	repository     string
-	sysInitPath    string
-	containers     *contStore
-	execCommands   *execStore
-	graph          *graph.Graph
-	repositories   *graph.TagStore
-	idIndex        *truncindex.TruncIndex
-	sysInfo        *sysinfo.SysInfo
-	volumes        *volumes.Repository
-	eng            *engine.Engine
-	config         *Config
-	containerGraph *graphdb.Database
-	driver         graphdriver.Driver
-	execDriver     execdriver.Driver
+	repository   string
+	sysInitPath  string
+	execCommands *execStore
+	graph        *graph.Graph
+	repositories *graph.TagStore
+	sysInfo      *sysinfo.SysInfo
+	volumes      *volumes.Repository
+	eng          *engine.Engine
+	config       *Config
+	containers   *containerIndex
+	driver       graphdriver.Driver
+	execDriver   execdriver.Driver
 }
 
 // Install installs daemon capabilities to eng.
@@ -144,13 +105,25 @@ func (daemon *Daemon) Install(eng *engine.Engine) error {
 // Get looks for a container by the specified ID or name, and returns it.
 // If the container is not found, or if an error occurs, nil is returned.
 func (daemon *Daemon) Get(name string) *Container {
-	if id, err := daemon.idIndex.Get(name); err == nil {
-		return daemon.containers.Get(id)
+	container, err := daemon.containers.GetByTruncName(name)
+	if err != nil || container == nil {
+		var err error
+		container, err = daemon.containers.GetByName(name)
+		if err != nil {
+			return nil
+		}
 	}
-	if c, _ := daemon.GetByName(name); c != nil {
-		return c
+
+	return container
+}
+
+func (daemon *Daemon) GetByName(name string) *Container {
+	cont, err := daemon.containers.GetByName(name)
+	if err != nil {
+		return nil
 	}
-	return nil
+
+	return cont
 }
 
 // Exists returns a true if a container of the specified ID or name exists,
@@ -165,7 +138,7 @@ func (daemon *Daemon) containerRoot(id string) string {
 
 // Load reads the contents of a container from disk
 // This is typically done at startup.
-func (daemon *Daemon) load(id string) (*Container, error) {
+func (daemon *Daemon) Load(id string) (*Container, error) {
 	container := &Container{
 		root:         daemon.containerRoot(id),
 		State:        NewState(),
@@ -214,11 +187,9 @@ func (daemon *Daemon) register(container *Container, updateSuffixarray bool) err
 		container.stdinPipe = ioutils.NopWriteCloser(ioutil.Discard) // Silently drop stdin
 	}
 	// done
-	daemon.containers.Add(container.ID, container)
-
-	// don't update the Suffixarray if we're starting up
-	// we'll waste time if we update it for every container
-	daemon.idIndex.Add(container.ID)
+	if err := daemon.containers.Add(container); err != nil {
+		return err
+	}
 
 	// FIXME: if the container is supposed to be running but is not, auto restart it?
 	//        if so, then we need to restart monitor and init a new lock
@@ -309,7 +280,7 @@ func (daemon *Daemon) restore() error {
 
 	for _, v := range dir {
 		id := v.Name()
-		container, err := daemon.load(id)
+		container, err := daemon.Load(id)
 		if !debug {
 			fmt.Print(".")
 		}
@@ -328,42 +299,21 @@ func (daemon *Daemon) restore() error {
 		}
 	}
 
-	registeredContainers := []*Container{}
-
-	if entities := daemon.containerGraph.List("/", -1); entities != nil {
-		for _, p := range entities.Paths() {
-			if !debug {
-				fmt.Print(".")
-			}
-
-			e := entities[p]
-
-			if container, ok := containers[e.ID()]; ok {
-				if err := daemon.register(container, false); err != nil {
-					log.Debugf("Failed to register container %s: %s", container.ID, err)
-				}
-
-				registeredContainers = append(registeredContainers, container)
-
-				// delete from the map so that a new name is not automatically generated
-				delete(containers, e.ID())
-			}
-		}
-	}
-
 	// Any containers that are left over do not exist in the graph
 	for _, container := range containers {
-		// Try to set the default name for a container if it exists prior to links
-		container.Name, err = daemon.generateNewName(container.ID)
-		if err != nil {
-			log.Debugf("Setting default id - %s", err)
+		if container.Name == "" {
+			// Try to set the default name for a container if it exists prior to links
+			container.Name, err = daemon.generateNewName(container.ID)
+			if err != nil {
+				log.Debugf("Setting default id - %s", err)
+			}
 		}
+
+		log.Debugf("registering %s %s", container.ID, container.Name)
 
 		if err := daemon.register(container, false); err != nil {
 			log.Debugf("Failed to register container %s: %s", container.ID, err)
 		}
-
-		registeredContainers = append(registeredContainers, container)
 	}
 
 	// check the restart policy on the containers and restart any container with
@@ -371,7 +321,7 @@ func (daemon *Daemon) restore() error {
 	if daemon.config.AutoRestart {
 		log.Debugf("Restarting containers...")
 
-		for _, container := range registeredContainers {
+		for _, container := range containers {
 			if container.hostConfig.RestartPolicy.Name == "always" ||
 				(container.hostConfig.RestartPolicy.Name == "on-failure" && container.ExitCode != 0) {
 				log.Debugf("Starting container %s", container.ID)
@@ -383,7 +333,7 @@ func (daemon *Daemon) restore() error {
 		}
 	}
 
-	for _, c := range registeredContainers {
+	for _, c := range containers {
 		for _, mnt := range c.VolumeMounts() {
 			daemon.volumes.Add(mnt.volume)
 		}
@@ -450,32 +400,15 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 		return "", fmt.Errorf("Invalid container name (%s), only %s are allowed", name, validContainerNameChars)
 	}
 
-	if name[0] != '/' {
-		name = "/" + name
-	}
-
-	if _, err := daemon.containerGraph.Set(name, id); err != nil {
-		if !graphdb.IsNonUniqueNameError(err) {
-			return "", err
-		}
-
-		conflictingContainer, err := daemon.GetByName(name)
-		if err != nil {
-			if strings.Contains(err.Error(), "Could not find entity") {
-				return "", err
-			}
-
-			// Remove name and continue starting the container
-			if err := daemon.containerGraph.Delete(name); err != nil {
-				return "", err
-			}
-		} else {
-			nameAsKnownByUser := strings.TrimPrefix(name, "/")
+	if err := daemon.containers.AssignNameForID(name, id); err != nil {
+		container, _ := daemon.containers.GetByName(name)
+		if daemon.containers.NameInUse(name) {
 			return "", fmt.Errorf(
-				"Conflict, The name %s is already assigned to %s. You have to delete (or rename) that container to be able to assign %s to a container again.", nameAsKnownByUser,
-				utils.TruncateID(conflictingContainer.ID), nameAsKnownByUser)
+				"Conflict, The name %s is already assigned to %s. You have to delete (or rename) that container to be able to assign %s to a container again.",
+				name, container.ID, name)
 		}
 	}
+
 	return name, nil
 }
 
@@ -483,21 +416,16 @@ func (daemon *Daemon) generateNewName(id string) (string, error) {
 	var name string
 	for i := 0; i < 6; i++ {
 		name = namesgenerator.GetRandomName(i)
-		if name[0] != '/' {
-			name = "/" + name
-		}
 
-		if _, err := daemon.containerGraph.Set(name, id); err != nil {
-			if !graphdb.IsNonUniqueNameError(err) {
-				return "", err
-			}
+		if _, err := daemon.reserveName(id, name); err != nil {
 			continue
 		}
+
 		return name, nil
 	}
 
-	name = "/" + utils.TruncateID(id)
-	if _, err := daemon.containerGraph.Set(name, id); err != nil {
+	name = utils.TruncateID(id)
+	if _, err := daemon.reserveName(id, name); err != nil {
 		return "", err
 	}
 	return name, nil
@@ -589,69 +517,24 @@ func (daemon *Daemon) createRootfs(container *Container, img *image.Image) error
 	return nil
 }
 
-func GetFullContainerName(name string) (string, error) {
-	if name == "" {
-		return "", fmt.Errorf("Container name cannot be empty")
-	}
-	if name[0] != '/' {
-		name = "/" + name
-	}
-	return name, nil
+func (daemon *Daemon) Children(name string) map[string]*Container {
+	return daemon.containers.ChildrenByName(name)
 }
 
-func (daemon *Daemon) GetByName(name string) (*Container, error) {
-	fullName, err := GetFullContainerName(name)
-	if err != nil {
-		return nil, err
-	}
-	entity := daemon.containerGraph.Get(fullName)
-	if entity == nil {
-		return nil, fmt.Errorf("Could not find entity for %s", name)
-	}
-	e := daemon.containers.Get(entity.ID())
-	if e == nil {
-		return nil, fmt.Errorf("Could not find container for entity id %s", entity.ID())
-	}
-	return e, nil
+func (daemon *Daemon) Parents(name string) map[string]*Container {
+	return daemon.containers.ParentsByName(name)
 }
 
-func (daemon *Daemon) Children(name string) (map[string]*Container, error) {
-	name, err := GetFullContainerName(name)
-	if err != nil {
-		return nil, err
-	}
-	children := make(map[string]*Container)
-
-	err = daemon.containerGraph.Walk(name, func(p string, e *graphdb.Entity) error {
-		c := daemon.Get(e.ID())
-		if c == nil {
-			return fmt.Errorf("Could not get container for name %s and id %s", e.ID(), p)
-		}
-		children[p] = c
-		return nil
-	}, 0)
-
-	if err != nil {
-		return nil, err
-	}
-	return children, nil
-}
-
-func (daemon *Daemon) Parents(name string) ([]string, error) {
-	name, err := GetFullContainerName(name)
-	if err != nil {
-		return nil, err
-	}
-
-	return daemon.containerGraph.Parents(name)
+func (daemon *Daemon) AliasFor(parent, child *Container) string {
+	return daemon.containers.AliasFor(parent, child)
 }
 
 func (daemon *Daemon) RegisterLink(parent, child *Container, alias string) error {
-	fullName := path.Join(parent.Name, alias)
-	if !daemon.containerGraph.Exists(fullName) {
-		_, err := daemon.containerGraph.Set(fullName, child.ID)
+	if err := daemon.containers.SetAlias(parent, child, alias); err != nil {
 		return err
 	}
+
+	daemon.containers.Link(parent, child)
 	return nil
 }
 
@@ -662,13 +545,16 @@ func (daemon *Daemon) RegisterLinks(container *Container, hostConfig *runconfig.
 			if err != nil {
 				return err
 			}
-			child, err := daemon.GetByName(parts["name"])
+
+			child, err := daemon.containers.GetByName(parts["name"])
 			if err != nil {
 				return err
 			}
+
 			if child == nil {
 				return fmt.Errorf("Could not get container for %s", parts["name"])
 			}
+
 			if err := daemon.RegisterLink(container, child, parts["alias"]); err != nil {
 				return err
 			}
@@ -829,12 +715,6 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		}
 	}
 
-	graphdbPath := path.Join(config.Root, "linkgraph.db")
-	graph, err := graphdb.NewSqliteConn(graphdbPath)
-	if err != nil {
-		return nil, err
-	}
-
 	localCopy := path.Join(config.Root, "init", fmt.Sprintf("dockerinit-%s", dockerversion.VERSION))
 	sysInitPath := utils.DockerInitPath(localCopy)
 	if sysInitPath == "" {
@@ -862,21 +742,26 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 	}
 
 	daemon := &Daemon{
-		repository:     daemonRepo,
-		containers:     &contStore{s: make(map[string]*Container)},
-		execCommands:   newExecStore(),
-		graph:          g,
-		repositories:   repositories,
-		idIndex:        truncindex.NewTruncIndex([]string{}),
-		sysInfo:        sysInfo,
-		volumes:        volumes,
-		config:         config,
-		containerGraph: graph,
-		driver:         driver,
-		sysInitPath:    sysInitPath,
-		execDriver:     ed,
-		eng:            eng,
+		repository:   daemonRepo,
+		execCommands: newExecStore(),
+		graph:        g,
+		repositories: repositories,
+		sysInfo:      sysInfo,
+		volumes:      volumes,
+		config:       config,
+		driver:       driver,
+		sysInitPath:  sysInitPath,
+		execDriver:   ed,
+		eng:          eng,
 	}
+
+	containers, err := containerIndexFromDisk(config.Root, daemon)
+	if err != nil {
+		return nil, err
+	}
+
+	daemon.containers = containers
+
 	if err := daemon.checkLocaldns(); err != nil {
 		return nil, err
 	}
@@ -898,8 +783,9 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		if err := daemon.driver.Cleanup(); err != nil {
 			log.Errorf("daemon.driver.Cleanup(): %s", err.Error())
 		}
-		if err := daemon.containerGraph.Close(); err != nil {
-			log.Errorf("daemon.containerGraph.Close(): %s", err.Error())
+
+		if err := daemon.containers.ToDisk(); err != nil {
+			log.Errorf("ContainerIndex todisk: %s", err.Error())
 		}
 	})
 
@@ -1033,10 +919,6 @@ func (daemon *Daemon) GraphDriver() graphdriver.Driver {
 
 func (daemon *Daemon) ExecutionDriver() execdriver.Driver {
 	return daemon.execDriver
-}
-
-func (daemon *Daemon) ContainerGraph() *graphdb.Database {
-	return daemon.containerGraph
 }
 
 func (daemon *Daemon) checkLocaldns() error {

--- a/daemon/index.go
+++ b/daemon/index.go
@@ -1,0 +1,554 @@
+/*
+The container index is a set of simple maps used to handle:
+* naming containers
+* aliasing containers
+* managing the parent/child relationship of containers
+* Persisting this information to disk safely.
+
+It is a replacement for pkg/graphdb which will be retired hopefully soon.
+*/
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/pkg/graphdb"
+	"github.com/docker/docker/pkg/truncindex"
+)
+
+const (
+	containerIndexFileName = "container_index.json"
+	tickInterval           = time.Second
+)
+
+type containerIndex struct {
+	// child name -> parent name -> id
+	NameToParents map[string]map[string]string
+
+	// parent name -> child name -> id
+	NameToChildren map[string]map[string]string
+
+	// container name -> alias -> id
+	Aliases map[string]map[string]string
+
+	// container name -> child names -> id
+	AliasChildMap map[string]map[string]string
+
+	// container name -> id
+	NameToID map[string]string
+
+	// container id -> name
+	IDToName map[string]string
+
+	// container id -> container
+	idToContainer map[string]*Container
+
+	daemon     *Daemon
+	indexPath  string // fully qualified containerIndexFileName
+	truncIndex *truncindex.TruncIndex
+	mutex      *sync.Mutex
+	syncTicker *time.Ticker
+}
+
+// migrate the linkgraph graphdb to the new containerIndex format.
+func migrateIndex(root string, daemon *Daemon) (*containerIndex, error) {
+	graphdbPath := filepath.Join(root, "linkgraph.db")
+	c := emptyContainerIndex(root, daemon)
+
+	// bail only if we can find the file but there's problems otherwise loading
+	// the graphdb. If the file does not exist, we have migrated successfully.
+	if _, err := os.Stat(graphdbPath); err != nil {
+		return nil, err
+	}
+
+	graph, err := graphdb.NewSqliteConn(graphdbPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// this is extremely hairy code. What it's doing here is mining the graphdb
+	// for names, and aliases. In the event it finds a name, it will attempt to
+	// load the container. Docker reloads these containers on startup, so as long
+	// as this is done first (as it is currently) there should be no issue.
+	// Otherwise, certain runtime things will not be attached like
+	// BroadcastWriter and Daemon. In the event it finds a link, it will set up a
+	// parent/child relationship, and also relate the last portion (the alias) as
+	// the container's alias.
+
+	// used for building the parent/child mappings
+	relationships := map[string]string{}
+	aliases := map[string]string{}
+
+	for p, e := range graph.List("/", 3) {
+		parts := strings.Split(p, "/")
+		parts = parts[1:] // remove leading slash
+
+		switch len(parts) {
+		case 1: // only a name
+			cont, err := c.daemon.Load(e.ID())
+			if err != nil {
+				continue
+			}
+			c.NameToID[parts[0]] = e.ID()
+			c.IDToName[e.ID()] = parts[0]
+			if cont.Name[0] == '/' {
+				cont.Name = cont.Name[1:]
+				cont.ToDisk()
+			}
+			c.idToContainer[e.ID()] = cont
+		case 2: // parent -> alias link.
+			relationships[parts[0]] = e.ID()
+			aliases[e.ID()] = parts[1]
+		}
+	}
+
+	for parent, childID := range relationships {
+		child := c.idToContainer[childID]
+		if child == nil {
+			continue
+		}
+
+		c.NameToParents[child.Name] = map[string]string{parent: c.NameToID[parent]}
+		c.NameToChildren[parent] = map[string]string{child.Name: childID}
+		c.addAlias(parent, child.Name, aliases[childID])
+	}
+
+	if err = c.ToDisk(); err == nil {
+		graph.Close()
+		os.Remove(graphdbPath)
+	}
+
+	return c, err
+}
+
+func getIndexFilename(root string) string {
+	return filepath.Join(root, containerIndexFileName)
+}
+
+func (c *containerIndex) startSync() {
+	for _ = range c.syncTicker.C {
+		c.ToDisk()
+	}
+}
+
+// This is what is used to load the container index. It also happens to do
+// several other things via function dispatch:
+// * migrates graphdb
+// * creates an empty container index if needed
+func containerIndexFromDisk(root string, daemon *Daemon) (*containerIndex, error) {
+	var c *containerIndex
+
+	if _, err := os.Stat(getIndexFilename(root)); err != nil {
+		c, err = migrateIndex(root, daemon)
+		if err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+
+	if c == nil {
+		c = emptyContainerIndex(root, daemon)
+	}
+
+	content, err := ioutil.ReadFile(c.indexPath)
+
+	if err != nil {
+		// file does not exist, or there was a permission error. Start from scratch.
+		go c.startSync()
+		return c, nil
+	}
+
+	if err := json.Unmarshal(content, c); err != nil {
+		return nil, err
+	}
+
+	for id := range c.IDToName {
+		c.truncIndex.Add(id)
+	}
+
+	go c.startSync()
+	return c, nil
+}
+
+func emptyContainerIndex(root string, daemon *Daemon) *containerIndex {
+	return &containerIndex{
+		NameToParents:  map[string]map[string]string{},
+		NameToChildren: map[string]map[string]string{},
+		Aliases:        map[string]map[string]string{},
+		AliasChildMap:  map[string]map[string]string{},
+		NameToID:       map[string]string{},
+		IDToName:       map[string]string{},
+
+		idToContainer: map[string]*Container{},
+		daemon:        daemon,
+		indexPath:     getIndexFilename(root),
+		truncIndex:    truncindex.NewTruncIndex([]string{}),
+		mutex:         new(sync.Mutex),
+		syncTicker:    time.NewTicker(tickInterval),
+	}
+}
+
+func (c *containerIndex) lock() {
+	c.mutex.Lock()
+}
+
+func (c *containerIndex) unlock() {
+	c.mutex.Unlock()
+}
+
+func (c *containerIndex) ToDisk() error {
+	c.lock()
+	defer c.unlock()
+
+	f, err := ioutil.TempFile("", "container_index")
+	if err != nil {
+		return err
+	}
+
+	// the file is closed later if there are no errors. this is a noop at that point.
+	defer f.Close()
+
+	content, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	if _, err := f.Write(content); err != nil {
+		return err
+	}
+
+	f.Close()
+
+	if err := os.Rename(f.Name(), c.indexPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *containerIndex) Add(cont *Container) error {
+	c.lock()
+	c.add(cont)
+	c.unlock()
+
+	return nil
+}
+
+func (c *containerIndex) add(cont *Container) {
+	// this is to fix a migration issue where the containers would be assigned a name starting with /
+	if cont.Name[0] == '/' {
+		cont.Name = cont.Name[1:]
+	}
+
+	if _, ok := c.NameToParents[cont.Name]; !ok {
+		c.NameToParents[cont.Name] = map[string]string{}
+	}
+
+	if _, ok := c.NameToChildren[cont.Name]; !ok {
+		c.NameToChildren[cont.Name] = map[string]string{}
+	}
+
+	c.NameToID[cont.Name] = cont.ID
+	c.IDToName[cont.ID] = cont.Name
+	c.truncIndex.Add(cont.ID)
+	c.idToContainer[cont.ID] = cont
+}
+
+func (c *containerIndex) Delete(cont *Container) {
+	c.lock()
+	c.doDelete(cont)
+	c.unlock()
+}
+
+func (c *containerIndex) Unlink(cont *Container) {
+	c.lock()
+	c.removeParents(cont)
+	c.unlock()
+}
+
+func (c *containerIndex) removeParents(cont *Container) {
+	for name := range c.NameToParents[cont.Name] {
+		delete(c.NameToChildren[name], cont.Name)
+		delete(c.Aliases[name], cont.Name)
+		delete(c.AliasChildMap[name], cont.Name)
+	}
+
+	delete(c.NameToParents, cont.Name)
+}
+
+func (c *containerIndex) doDelete(cont *Container) {
+	delete(c.NameToParents, cont.Name)
+	delete(c.NameToChildren, cont.Name)
+	delete(c.Aliases, cont.Name)
+	delete(c.AliasChildMap, cont.Name)
+	delete(c.NameToID, cont.Name)
+	delete(c.IDToName, cont.ID)
+	delete(c.idToContainer, cont.ID)
+}
+
+func (c *containerIndex) Link(parent *Container, child *Container) {
+	c.lock()
+	c.cleanChildParent(parent, child)
+	c.addChild(parent, child)
+	c.addParent(parent, child)
+	c.unlock()
+}
+
+func (c *containerIndex) cleanChildParent(parent, child *Container) {
+	delete(c.NameToChildren[parent.Name], child.Name)
+	delete(c.NameToParents[child.Name], parent.Name)
+}
+
+func (c *containerIndex) addChild(parent, child *Container) {
+	if c.NameToChildren[parent.Name] == nil {
+		c.NameToChildren[parent.Name] = map[string]string{}
+	}
+
+	c.NameToChildren[parent.Name][child.Name] = child.ID
+}
+
+func (c *containerIndex) addParent(parent, child *Container) {
+	if c.NameToParents[child.Name] == nil {
+		c.NameToParents[child.Name] = map[string]string{}
+	}
+
+	c.NameToParents[child.Name][parent.Name] = parent.ID
+}
+
+func (c *containerIndex) ParentsByName(name string) map[string]*Container {
+	c.lock()
+
+	result := map[string]*Container{}
+
+	for name, id := range c.NameToParents[name] {
+		result[name] = c.idToContainer[id]
+	}
+
+	c.unlock()
+	return result
+}
+
+func (c *containerIndex) ChildrenByName(name string) map[string]*Container {
+	c.lock()
+
+	result := map[string]*Container{}
+
+	for name, id := range c.NameToChildren[name] {
+		result[name] = c.idToContainer[id]
+	}
+
+	c.unlock()
+
+	return result
+}
+
+func (c *containerIndex) SetAlias(parent, child *Container, alias string) error {
+	c.lock()
+	defer c.unlock()
+
+	// locks are already used in AliasInUse and AddAlias
+
+	if c.aliasInUse(parent, child, alias) {
+		return fmt.Errorf("Alias %s cannot be set for container ID %s, parent %s: name conflict", alias, child.ID, parent.ID)
+	}
+
+	if err := c.addAlias(parent.Name, child.Name, alias); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *containerIndex) aliasInUse(parent, child *Container, alias string) bool {
+	// lock is acquired in caller
+	if _, ok := c.Aliases[parent.Name]; ok {
+		_, aliasok := c.Aliases[parent.Name][child.Name]
+		_, childok := c.AliasChildMap[parent.Name][alias]
+		return aliasok || childok
+	}
+
+	return false
+}
+
+func (c *containerIndex) GetByID(id string) (*Container, error) {
+	c.lock()
+	defer c.unlock()
+
+	if _, ok := c.IDToName[id]; ok {
+		if cont, ok := c.idToContainer[id]; ok {
+			return cont, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Container for %s cannot be located", id)
+}
+
+func (c *containerIndex) GetByTruncName(name string) (*Container, error) {
+	c.lock()
+	defer c.unlock()
+
+	id, err := c.truncIndex.Get(name)
+	if err == nil {
+		if cont, ok := c.idToContainer[id]; ok {
+			return cont, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Container for %s cannot be located", name)
+}
+
+func (c *containerIndex) GetByName(name string) (*Container, error) {
+	c.lock()
+	defer c.unlock()
+
+	if id, ok := c.NameToID[name]; ok {
+		if cont, ok := c.idToContainer[id]; ok {
+			return cont, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Container for %s cannot be located", name)
+}
+
+func (c *containerIndex) GetNameForID(id string) string {
+	c.lock()
+	defer c.unlock()
+	return c.IDToName[id]
+}
+
+// This function can be used *before* containers are loaded to map names to
+// identifiers. This is needed because of (*Daemon).ensureName()
+func (c *containerIndex) AssignNameForID(name, id string) error {
+	if c.NameInUse(name) {
+		return fmt.Errorf("Name %s is already in use", name)
+	}
+
+	c.lock()
+	c.IDToName[id] = name
+	c.unlock()
+
+	return nil
+}
+
+func (c *containerIndex) NameInUse(name string) bool {
+	c.lock()
+	_, nameok := c.NameToID[name]
+	c.unlock()
+
+	return nameok
+}
+
+func (c *containerIndex) List() []*Container {
+	containers := new(History)
+	c.lock()
+	for _, id := range c.NameToID {
+		cont, ok := c.idToContainer[id]
+		if !ok {
+			continue
+		}
+
+		containers.Add(cont)
+	}
+	c.unlock()
+	containers.Sort()
+	return *containers
+}
+
+// Pulls this structure apart: /parent/child/alias into two containers and an alias
+func (c *containerIndex) DeconstructPath(path string) (*Container, *Container, string, error) {
+	c.lock()
+	defer c.unlock()
+
+	parts := strings.Split(path, "/")
+
+	if parts[0] == "" {
+		parts = parts[1:]
+	}
+
+	if len(parts) < 2 {
+		return nil, nil, "", fmt.Errorf("Invalid path (missing entities)")
+	}
+
+	var parent, child *Container
+	var alias string
+
+	if id, ok := c.NameToID[parts[0]]; ok {
+		parent = c.idToContainer[id]
+		if id, ok := c.NameToID[parts[1]]; ok {
+			child = c.idToContainer[id]
+		}
+	}
+
+	if parent == nil {
+		return nil, nil, "", fmt.Errorf("Could not locate parent container %s", parts[0])
+	}
+
+	if child == nil {
+		return nil, nil, "", fmt.Errorf("Could not locate child container %s", parts[1])
+	}
+
+	if len(parts) > 2 && parts[2] != "" {
+		alias = parts[2]
+	} else {
+		alias = child.Name
+	}
+
+	return parent, child, alias, nil
+}
+
+func (c *containerIndex) ChildFor(parent *Container, alias string) *Container {
+	c.lock()
+	defer c.unlock()
+
+	if childname, ok := c.AliasChildMap[parent.Name][alias]; ok {
+		if childid, ok := c.NameToID[childname]; ok {
+			if child, ok := c.idToContainer[childid]; ok {
+				return child
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *containerIndex) AliasFor(parent, child *Container) string {
+	c.lock()
+	defer c.unlock()
+
+	alias := c.Aliases[parent.Name][child.Name]
+	if alias != "" {
+		return alias
+	}
+
+	return child.Name
+}
+
+func (c *containerIndex) addAlias(parent, child, alias string) error {
+	// lock is acquired in caller
+	if _, ok := c.Aliases[parent]; !ok {
+		c.Aliases[parent] = map[string]string{}
+	}
+
+	if _, ok := c.AliasChildMap[parent]; !ok {
+		c.AliasChildMap[parent] = map[string]string{}
+	}
+
+	if _, ok := c.Aliases[parent][child]; ok {
+		return fmt.Errorf("Alias already set for parent %s, child %s", parent, child)
+	}
+
+	if _, ok := c.AliasChildMap[parent][alias]; ok {
+		return fmt.Errorf("Alias already set for parent %s, alias %s", parent, alias)
+	}
+
+	c.Aliases[parent][child] = alias
+	c.AliasChildMap[parent][alias] = child
+
+	return nil
+}

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -48,10 +48,8 @@ func (daemon *Daemon) ContainerInspect(job *engine.Job) engine.Status {
 		out.SetJson("Volumes", container.Volumes)
 		out.SetJson("VolumesRW", container.VolumesRW)
 
-		if children, err := daemon.Children(container.Name); err == nil {
-			for linkAlias, child := range children {
-				container.hostConfig.Links = append(container.hostConfig.Links, fmt.Sprintf("%s:%s", child.Name, linkAlias))
-			}
+		for _, child := range daemon.Children(name) {
+			container.hostConfig.Links = append(container.hostConfig.Links, fmt.Sprintf("%s:%s", child.Name, daemon.containers.AliasFor(container, child)))
 		}
 
 		out.SetJson("HostConfig", container.hostConfig)

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/docker/pkg/graphdb"
-
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/pkg/parsers/filters"
 )
@@ -46,10 +44,9 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 	}
 
 	names := map[string][]string{}
-	daemon.ContainerGraph().Walk("/", func(p string, e *graphdb.Entity) error {
-		names[e.ID()] = append(names[e.ID()], p)
-		return nil
-	}, -1)
+	for _, container := range daemon.containers.List() {
+		names[container.ID] = append(names[container.ID], container.Name)
+	}
 
 	var beforeCont, sinceCont *Container
 	if before != "" {

--- a/links/links.go
+++ b/links/links.go
@@ -2,10 +2,10 @@ package links
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/nat"
-	"path"
-	"strings"
 )
 
 type Link struct {
@@ -43,8 +43,7 @@ func NewLink(parentIP, childIP, name string, env []string, exposedPorts map[nat.
 }
 
 func (l *Link) Alias() string {
-	_, alias := path.Split(l.Name)
-	return alias
+	return l.Name
 }
 
 func (l *Link) ToEnv() []string {

--- a/links/links_test.go
+++ b/links/links_test.go
@@ -1,16 +1,17 @@
 package links
 
 import (
-	"github.com/docker/docker/nat"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/nat"
 )
 
 func TestLinkNaming(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[nat.Port("6379/tcp")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, ports, nil)
+	link, err := NewLink("172.0.17.3", "172.0.17.2", "docker-1", nil, ports, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +41,7 @@ func TestLinkNew(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[nat.Port("6379/tcp")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, ports, nil)
+	link, err := NewLink("172.0.17.3", "172.0.17.2", "docker", nil, ports, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +49,7 @@ func TestLinkNew(t *testing.T) {
 	if link == nil {
 		t.FailNow()
 	}
-	if link.Name != "/db/docker" {
+	if link.Name != "docker" {
 		t.Fail()
 	}
 	if link.Alias() != "docker" {
@@ -71,7 +72,7 @@ func TestLinkEnv(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[nat.Port("6379/tcp")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, ports, nil)
+	link, err := NewLink("172.0.17.3", "172.0.17.2", "docker", []string{"PASSWORD=gordon"}, ports, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,8 +101,8 @@ func TestLinkEnv(t *testing.T) {
 	if env["DOCKER_PORT_6379_TCP_PORT"] != "6379" {
 		t.Fatalf("Expected 6379, got %s", env["DOCKER_PORT_6379_TCP_PORT"])
 	}
-	if env["DOCKER_NAME"] != "/db/docker" {
-		t.Fatalf("Expected /db/docker, got %s", env["DOCKER_NAME"])
+	if env["DOCKER_NAME"] != "docker" {
+		t.Fatalf("Expected docker, got %s", env["DOCKER_NAME"])
 	}
 	if env["DOCKER_ENV_PASSWORD"] != "gordon" {
 		t.Fatalf("Expected gordon, got %s", env["DOCKER_ENV_PASSWORD"])


### PR DESCRIPTION
This is a rewrite of the graphdb and replaces all naming and aliasing functionality. The new architecture is called a "container index" and was based 

**Bugs**: notably `docker ps -a` from earlier versions will panic if there are containers to list, because of a string handling bug. I really don't want to lose this patch over this, so suggestions for a workable fix are welcome.

More patches will likely need to be filed to deal with alias management and links. The focus here is to replace graphdb in a backwards-compatible fashion.

This code still imports graphdb for the purposes of the migrating data from one format to another. At some point this code should be removed, maybe in 1.5 or 1.6. It will improve build time dramatically. :)

The migration is not tested but many other features are. Tests for the index itself are largely a side-effect of the integration-cli tests and other integrations.

Many tests were rewritten to accommodate the new naming system (which contains no syntax) but otherwise are unchanged to preserve the tests. In a few minor cases tests were removed because they were no longer relevant, e.g., tests that turn the links structure into a graphdb path and then test that path.

Don't merge this until links is completely ready. Please let me know if you have any other questions.
