### PR TITLE
Consistently use 'sudo docker' in examples

### DIFF
--- a/docs/sources/articles/ambassador_pattern_linking.md
+++ b/docs/sources/articles/ambassador_pattern_linking.md
@@ -34,23 +34,23 @@ controlled entirely from the `docker run` parameters.
 
 Start actual Redis server on one Docker host
 
-    big-server $ docker run -d --name redis crosbymichael/redis
+    big-server $ sudo docker run -d --name redis crosbymichael/redis
 
 Then add an ambassador linked to the Redis server, mapping a port to the
 outside world
 
-    big-server $ docker run -d --link redis:redis --name redis_ambassador -p 6379:6379 svendowideit/ambassador
+    big-server $ sudo docker run -d --link redis:redis --name redis_ambassador -p 6379:6379 svendowideit/ambassador
 
 On the other host, you can set up another ambassador setting environment
 variables for each remote port we want to proxy to the `big-server`
 
-    client-server $ docker run -d --name redis_ambassador --expose 6379 -e REDIS_PORT_6379_TCP=tcp://192.168.1.52:6379 svendowideit/ambassador
+    client-server $ sudo docker run -d --name redis_ambassador --expose 6379 -e REDIS_PORT_6379_TCP=tcp://192.168.1.52:6379 svendowideit/ambassador
 
 Then on the `client-server` host, you can use a Redis client container
 to talk to the remote Redis server, just by linking to the local Redis
 ambassador.
 
-    client-server $ docker run -i -t --rm --link redis_ambassador:redis relateiq/redis-cli
+    client-server $ sudo docker run -i -t --rm --link redis_ambassador:redis relateiq/redis-cli
     redis 172.17.0.160:6379> ping
     PONG
 
@@ -62,19 +62,19 @@ does automatically (with a tiny amount of `sed`)
 On the Docker host (192.168.1.52) that Redis will run on:
 
     # start actual redis server
-    $ docker run -d --name redis crosbymichael/redis
+    $ sudo docker run -d --name redis crosbymichael/redis
 
     # get a redis-cli container for connection testing
-    $ docker pull relateiq/redis-cli
+    $ sudo docker pull relateiq/redis-cli
 
     # test the redis server by talking to it directly
-    $ docker run -t -i --rm --link redis:redis relateiq/redis-cli
+    $ sudo docker run -t -i --rm --link redis:redis relateiq/redis-cli
     redis 172.17.0.136:6379> ping
     PONG
     ^D
 
     # add redis ambassador
-    $ docker run -t -i --link redis:redis --name redis_ambassador -p 6379:6379 busybox sh
+    $ sudo docker run -t -i --link redis:redis --name redis_ambassador -p 6379:6379 busybox sh
 
 In the `redis_ambassador` container, you can see the linked Redis
 containers `env`:
@@ -96,9 +96,9 @@ containers `env`:
 This environment is used by the ambassador `socat` script to expose Redis
 to the world (via the `-p 6379:6379` port mapping):
 
-    $ docker rm redis_ambassador
+    $ sudo docker rm redis_ambassador
     $ sudo ./contrib/mkimage-unittest.sh
-    $ docker run -t -i --link redis:redis --name redis_ambassador -p 6379:6379 docker-ut sh
+    $ sudo docker run -t -i --link redis:redis --name redis_ambassador -p 6379:6379 docker-ut sh
 
     $ socat TCP4-LISTEN:6379,fork,reuseaddr TCP4:172.17.0.136:6379
 
@@ -107,14 +107,14 @@ Now ping the Redis server via the ambassador:
 Now go to a different server:
 
     $ sudo ./contrib/mkimage-unittest.sh
-    $ docker run -t -i --expose 6379 --name redis_ambassador docker-ut sh
+    $ sudo docker run -t -i --expose 6379 --name redis_ambassador docker-ut sh
 
     $ socat TCP4-LISTEN:6379,fork,reuseaddr TCP4:192.168.1.52:6379
 
 And get the `redis-cli` image so we can talk over the ambassador bridge.
 
-    $ docker pull relateiq/redis-cli
-    $ docker run -i -t --rm --link redis_ambassador:redis relateiq/redis-cli
+    $ sudo docker pull relateiq/redis-cli
+    $ sudo docker run -i -t --rm --link redis_ambassador:redis relateiq/redis-cli
     redis 172.17.0.160:6379> ping
     PONG
 

--- a/docs/sources/articles/basics.md
+++ b/docs/sources/articles/basics.md
@@ -10,7 +10,7 @@ This guide assumes you have a working installation of Docker. To check
 your Docker install, run the following command:
 
     # Check that you have a working install
-    $ docker info
+    $ sudo docker info
 
 If you get `docker: command not found` or something like
 `/var/lib/docker/repositories: permission denied` you may have an
@@ -126,20 +126,20 @@ TCP and a Unix socket
     $ JOB=$(sudo docker run -d ubuntu /bin/sh -c "while true; do echo Hello world; sleep 1; done")
 
     # Stop the container
-    $ docker stop $JOB
+    $ sudo docker stop $JOB
 
     # Start the container
-    $ docker start $JOB
+    $ sudo docker start $JOB
 
     # Restart the container
-    $ docker restart $JOB
+    $ sudo docker restart $JOB
 
     # SIGKILL a container
-    $ docker kill $JOB
+    $ sudo docker kill $JOB
 
     # Remove a container
-    $ docker stop $JOB # Container must be stopped to remove it
-    $ docker rm $JOB
+    $ sudo docker stop $JOB # Container must be stopped to remove it
+    $ sudo docker rm $JOB
 
 ## Bind a service on a TCP port
 

--- a/docs/sources/articles/cfengine_process_management.md
+++ b/docs/sources/articles/cfengine_process_management.md
@@ -94,7 +94,7 @@ your image with the docker build command, e.g.,
 Start the container with `apache2` and `sshd` running and managed, forwarding
 a port to our SSH instance:
 
-    $ docker run -p 127.0.0.1:222:22 -d managed_image "/usr/sbin/sshd" "/etc/init.d/apache2 start"
+    $ sudo docker run -p 127.0.0.1:222:22 -d managed_image "/usr/sbin/sshd" "/etc/init.d/apache2 start"
 
 We now clearly see one of the benefits of the cfe-docker integration: it
 allows to start several processes as part of a normal `docker run` command.

--- a/docs/sources/articles/chef.md
+++ b/docs/sources/articles/chef.md
@@ -43,7 +43,7 @@ The next step is to pull a Docker image. For this, we have a resource:
 
 This is equivalent to running:
 
-    $ docker pull samalba/docker-registry
+    $ sudo docker pull samalba/docker-registry
 
 There are attributes available to control how long the cookbook will
 allow for downloading (5 minute default).
@@ -68,7 +68,7 @@ managed by Docker.
 
 This is equivalent to running the following command, but under upstart:
 
-    $ docker run --detach=true --publish='5000:5000' --env='SETTINGS_FLAVOR=local' --volume='/mnt/docker:/docker-storage' samalba/docker-registry
+    $ sudo docker run --detach=true --publish='5000:5000' --env='SETTINGS_FLAVOR=local' --volume='/mnt/docker:/docker-storage' samalba/docker-registry
 
 The resources will accept a single string or an array of values for any
 Docker flags that allow multiple values.

--- a/docs/sources/articles/https.md
+++ b/docs/sources/articles/https.md
@@ -122,7 +122,7 @@ providing a certificate trusted by our CA:
 To be able to connect to Docker and validate its certificate, you now
 need to provide your client keys, certificates and trusted CA:
 
-    $ docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem \
+    $ sudo docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem \
       -H=dns-name-of-docker-host:2376 version
 
 > **Note**:
@@ -148,7 +148,7 @@ the files to the `.docker` directory in your home directory - and set the
 
 Then you can run Docker with the `--tlsverify` option.
 
-    $ docker --tlsverify ps
+    $ sudo docker --tlsverify ps
 
 ## Other modes
 
@@ -175,4 +175,4 @@ if you want to store your keys in another location, you can specify that
 location using the environment variable `DOCKER_CERT_PATH`.
 
     $ export DOCKER_CERT_PATH=${HOME}/.docker/zone1/
-    $ docker --tlsverify ps
+    $ sudo docker --tlsverify ps

--- a/docs/sources/articles/puppet.md
+++ b/docs/sources/articles/puppet.md
@@ -47,7 +47,7 @@ defined type which can be used like so:
 
 This is equivalent to running:
 
-    $ docker pull ubuntu
+    $ sudo docker pull ubuntu
 
 Note that it will only be downloaded if an image of that name does not
 already exist. This is downloading a large binary so on first run can
@@ -71,7 +71,7 @@ managed by Docker.
 
 This is equivalent to running the following command, but under upstart:
 
-    $ docker run -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done"
+    $ sudo docker run -d ubuntu /bin/sh -c "while true; do echo hello world; sleep 1; done"
 
 Run also contains a number of optional parameters:
 

--- a/docs/sources/articles/registry_mirror.md
+++ b/docs/sources/articles/registry_mirror.md
@@ -67,7 +67,7 @@ With your mirror running, pull an image that you haven't pulled before (using
 
 Now, remove the image from your local machine:
 
-    $ docker rmi node:latest
+    $ sudo docker rmi node:latest
 
 Finally, re-pull the image:
 

--- a/docs/sources/docker-hub/repos.md
+++ b/docs/sources/docker-hub/repos.md
@@ -11,7 +11,7 @@ page_keywords: Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub
 You can `search` for all the publicly available repositories and images using
 Docker.
 
-    $ docker search ubuntu
+    $ sudo docker search ubuntu
 
 This will show you a list of the currently available repositories on the
 Docker Hub which match the provided keyword.

--- a/docs/sources/examples/postgresql_service.md
+++ b/docs/sources/examples/postgresql_service.md
@@ -104,7 +104,7 @@ host-mapped port to test as well. You need to use `docker ps`
 to find out what local host port the container is mapped to
 first:
 
-    $ docker ps
+    $ sudo docker ps
     CONTAINER ID        IMAGE                  COMMAND                CREATED             STATUS              PORTS                                      NAMES
     5e24362f27f6        eg_postgresql:latest   /usr/lib/postgresql/   About an hour ago   Up About an hour    0.0.0.0:49153->5432/tcp                    pg_test
     $ psql -h localhost -p 49153 -d docker -U docker --password
@@ -135,7 +135,7 @@ prompt, you can create a table and populate it.
 You can use the defined volumes to inspect the PostgreSQL log files and
 to backup your configuration and data:
 
-    $ docker run --rm --volumes-from pg_test -t -i busybox sh
+    $ sudo docker run --rm --volumes-from pg_test -t -i busybox sh
 
     / # ls
     bin      etc      lib      linuxrc  mnt      proc     run      sys      usr

--- a/docs/sources/examples/running_riak_service.md
+++ b/docs/sources/examples/running_riak_service.md
@@ -101,7 +101,7 @@ Populate it with the following program definitions:
 
 Now you should be able to build a Docker image for Riak:
 
-    $ docker build -t "<yourname>/riak" .
+    $ sudo docker build -t "<yourname>/riak" .
 
 ## Next steps
 

--- a/docs/sources/introduction/understanding-docker.md
+++ b/docs/sources/introduction/understanding-docker.md
@@ -198,7 +198,7 @@ then run.
 Either by using the `docker` binary or via the API, the Docker client tells the Docker
 daemon to run a container.
 
-    $ docker run -i -t ubuntu /bin/bash
+    $ sudo docker run -i -t ubuntu /bin/bash
 
 Let's break down this command. The Docker client is launched using the `docker`
 binary with the `run` option telling it to launch a new container. The bare

--- a/docs/sources/reference/api/hub_registry_spec.md
+++ b/docs/sources/reference/api/hub_registry_spec.md
@@ -111,7 +111,7 @@ supports:
 
 It's possible to run:
 
-    $ docker pull https://<registry>/repositories/samalba/busybox
+    $ sudo docker pull https://<registry>/repositories/samalba/busybox
 
 In this case, Docker bypasses the Docker Hub. However the security is not
 guaranteed (in case Registry A is corrupted) because there won't be any

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -57,7 +57,7 @@ instructions.
 Whenever possible, Docker will re-use the intermediate images,
 accelerating `docker build` significantly (indicated by `Using cache`):
 
-    $ docker build -t SvenDowideit/ambassador .
+    $ sudo docker build -t SvenDowideit/ambassador .
     Uploading context 10.24 kB
     Uploading context
     Step 1 : FROM docker-ut
@@ -109,7 +109,7 @@ The following example shows the use of the `.dockerignore` file to exclude the
 `.git` directory from the context. Its effect can be seen in the changed size of
 the uploaded context.
 
-    $ docker build .
+    $ sudo docker build .
     Uploading context 18.829 MB
     Uploading context
     Step 0 : FROM busybox
@@ -119,7 +119,7 @@ the uploaded context.
      ---> 99cc1ad10469
     Successfully built 99cc1ad10469
     $ echo ".git" > .dockerignore
-    $ docker build .
+    $ sudo docker build .
     Uploading context  6.76 MB
     Uploading context
     Step 0 : FROM busybox

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -35,11 +35,11 @@ will set the value to the opposite of the default value.
 
 Options like `-a=[]` indicate they can be specified multiple times:
 
-    $ docker run -a stdin -a stdout -a stderr -i -t ubuntu /bin/bash
+    $ sudo docker run -a stdin -a stdout -a stderr -i -t ubuntu /bin/bash
 
 Sometimes this can use a more complex value string, as for `-v`:
 
-    $ docker run -v /host:/container example/mysql
+    $ sudo docker run -v /host:/container example/mysql
 
 ### Strings and Integers
 
@@ -104,10 +104,10 @@ To use lxc as the execution driver, use `docker -d -e lxc`.
 The docker client will also honor the `DOCKER_HOST` environment variable to set
 the `-H` flag for the client.
 
-    $ docker -H tcp://0.0.0.0:2375 ps
+    $ sudo docker -H tcp://0.0.0.0:2375 ps
     # or
     $ export DOCKER_HOST="tcp://0.0.0.0:2375"
-    $ docker ps
+    $ sudo docker ps
     # both are equal
 
 To run the daemon with [systemd socket activation](
@@ -271,7 +271,7 @@ If you wish to keep the intermediate containers after the build is
 complete, you must use `--rm=false`. This does not
 affect the build cache.
 
-    $ docker build .
+    $ sudo docker build .
     Uploading context 18.829 MB
     Uploading context
     Step 0 : FROM busybox
@@ -281,7 +281,7 @@ affect the build cache.
      ---> 99cc1ad10469
     Successfully built 99cc1ad10469
     $ echo ".git" > .dockerignore
-    $ docker build .
+    $ sudo docker build .
     Uploading context  6.76 MB
     Uploading context
     Step 0 : FROM busybox
@@ -355,9 +355,9 @@ If this behavior is undesired, set the 'p' option to false.
     ID                  IMAGE               COMMAND             CREATED             STATUS              PORTS
     c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours
     197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours
-    $ docker commit c3f279d17e0a  SvenDowideit/testimage:version3
+    $ sudo docker commit c3f279d17e0a  SvenDowideit/testimage:version3
     f5283438590d
-    $ docker images | head
+    $ sudo docker images | head
     REPOSITORY                        TAG                 ID                  CREATED             VIRTUAL SIZE
     SvenDowideit/testimage            version3            f5283438590d        16 seconds ago      335.7 MB
 
@@ -464,7 +464,7 @@ For example:
 
 To see how the `docker:latest` image was built:
 
-    $ docker history docker
+    $ sudo docker history docker
     IMAGE                                                              CREATED             CREATED BY                                                                                                                                                 SIZE
     3e23a5875458790b7a806f95f7ec0d0b2a5c1659bfc899c89f939f6d5b8f7094   8 days ago          /bin/sh -c #(nop) ENV LC_ALL=C.UTF-8                                                                                                                       0 B
     8578938dd17054dce7993d21de79e96a037400e8d28e15e7290fea4f65128a36   8 days ago          /bin/sh -c dpkg-reconfigure locales &&    locale-gen C.UTF-8 &&    /usr/sbin/update-locale LANG=C.UTF-8                                                    1.245 MB
@@ -729,7 +729,7 @@ If you want to login to a self-hosted registry you can
 specify this by adding the server name.
 
     example:
-    $ docker login localhost:8080
+    $ sudo docker login localhost:8080
 
 ## logout
 
@@ -739,7 +739,7 @@ specify this by adding the server name.
 
 For example:
 
-    $ docker logout localhost:8080
+    $ sudo docker logout localhost:8080
 
 ## logs
 
@@ -772,17 +772,17 @@ log entry.
 You can find out all the ports mapped by not specifying a `PRIVATE_PORT`, or
 just a specific mapping:
 
-    $ docker ps test
+    $ sudo docker ps test
     CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                                            NAMES
     b650456536c7        busybox:latest      top                 54 minutes ago      Up 54 minutes       0.0.0.0:1234->9876/tcp, 0.0.0.0:4321->7890/tcp   test
-    $ docker port test
+    $ sudo docker port test
     7890/tcp -> 0.0.0.0:4321
     9876/tcp -> 0.0.0.0:1234
-    $ docker port test 7890/tcp
+    $ sudo docker port test 7890/tcp
     0.0.0.0:4321
-    $ docker port test 7890/udp
+    $ sudo docker port test 7890/udp
     2014/06/24 11:53:36 Error: No public port '7890/udp' published for test
-    $ docker port test 7890
+    $ sudo docker port test 7890
     0.0.0.0:4321
 
 ## pause
@@ -820,7 +820,7 @@ further details.
 
 Running `docker ps` showing 2 linked containers.
 
-    $ docker ps
+    $ sudo docker ps
     CONTAINER ID        IMAGE                        COMMAND                CREATED              STATUS              PORTS               NAMES
     4c01db0b339c        ubuntu:12.04                 bash                   17 seconds ago       Up 16 seconds                           webapp
     d7886598dbe2        crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db
@@ -869,15 +869,15 @@ a protocol specifier (https://, for example).
 To download a particular image, or set of images (i.e., a repository),
 use `docker pull`:
 
-    $ docker pull debian
+    $ sudo docker pull debian
     # will pull only the debian:latest image and its intermediate layers 
-    $ docker pull debian:testing
+    $ sudo docker pull debian:testing
     # will pull only the image named debian:testing and any intermediate layers
     # it is based on. (Typically the empty `scratch` image, a MAINTAINER layer,
     # and the un-tarred base).
-    $ docker pull --all-tags centos
+    $ sudo docker pull --all-tags centos
     # will pull all the images from the centos repository
-    $ docker pull registry.hub.docker.com/debian
+    $ sudo docker pull registry.hub.docker.com/debian
     # manually specifies the path to the default Docker registry. This could
     # be replaced with the path to a local registry to pull from another source.
 

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -18,7 +18,7 @@ other `docker` command.
 
 The basic `docker run` command takes this form:
 
-    $ docker run [OPTIONS] IMAGE[:TAG] [COMMAND] [ARG...]
+    $ sudo docker run [OPTIONS] IMAGE[:TAG] [COMMAND] [ARG...]
 
 To learn how to interpret the types of `[OPTIONS]`,
 see [*Option types*](/reference/commandline/cli/#option-types).
@@ -91,7 +91,7 @@ streams]( https://github.com/docker/docker/blob/
 specify to which of the three standard streams (`STDIN`, `STDOUT`,
 `STDERR`) you'd like to connect instead, as in:
 
-    $ docker run -a stdin -a stdout -i -t ubuntu /bin/bash
+    $ sudo docker run -a stdin -a stdout -i -t ubuntu /bin/bash
 
 For interactive processes (like a shell) you will typically want a tty
 as well as persistent standard input (`STDIN`), so you'll use `-i -t`
@@ -192,9 +192,9 @@ Example running a Redis container with Redis binding to `localhost` then
 running the `redis-cli` command and connecting to the Redis server over the
 `localhost` interface.
 
-    $ docker run -d --name redis example/redis --bind 127.0.0.1
+    $ sudo docker run -d --name redis example/redis --bind 127.0.0.1
     $ # use the redis container's network stack to access localhost
-    $ docker run --rm -ti --net container:redis example/redis-cli -h 127.0.0.1
+    $ sudo docker run --rm -ti --net container:redis example/redis-cli -h 127.0.0.1
 
 ## Clean Up (–-rm)
 
@@ -253,14 +253,14 @@ If you want to limit access to a specific device or devices you can use
 the `--device` flag. It allows you to specify one or more devices that
 will be accessible within the container.
 
-    $ docker run --device=/dev/snd:/dev/snd ...
+    $ sudo docker run --device=/dev/snd:/dev/snd ...
 
 In addition to `--privileged`, the operator can have fine grain control over the
 capabilities using `--cap-add` and `--cap-drop`. By default, Docker has a default
 list of capabilities that are kept. Both flags support the value `all`, so if the
 operator wants to have all capabilities but `MKNOD` they could use:
 
-    $ docker run --cap-add=ALL --cap-drop=MKNOD ...
+    $ sudo docker run --cap-add=ALL --cap-drop=MKNOD ...
 
 For interacting with the network stack, instead of using `--privileged` they
 should use `--cap-add=NET_ADMIN` to modify the network interfaces.
@@ -299,7 +299,7 @@ Dockerfile instruction and how the operator can override that setting.
 Recall the optional `COMMAND` in the Docker
 commandline:
 
-    $ docker run [OPTIONS] IMAGE[:TAG] [COMMAND] [ARG...]
+    $ sudo docker run [OPTIONS] IMAGE[:TAG] [COMMAND] [ARG...]
 
 This command is optional because the person who created the `IMAGE` may
 have already provided a default `COMMAND` using the Dockerfile `CMD`
@@ -326,12 +326,12 @@ runtime by using a string to specify the new `ENTRYPOINT`. Here is an
 example of how to run a shell in a container that has been set up to
 automatically run something else (like `/usr/bin/redis-server`):
 
-    $ docker run -i -t --entrypoint /bin/bash example/redis
+    $ sudo docker run -i -t --entrypoint /bin/bash example/redis
 
 or two examples of how to pass more parameters to that ENTRYPOINT:
 
-    $ docker run -i -t --entrypoint /bin/bash example/redis -c ls -l
-    $ docker run -i -t --entrypoint /usr/bin/redis-cli example/redis --help
+    $ sudo docker run -i -t --entrypoint /bin/bash example/redis -c ls -l
+    $ sudo docker run -i -t --entrypoint /usr/bin/redis-cli example/redis --help
 
 ## EXPOSE (Incoming Ports)
 
@@ -378,7 +378,7 @@ The operator can **set any environment variable** in the container by
 using one or more `-e` flags, even overriding those already defined by
 the developer with a Dockerfile `ENV`:
 
-    $ docker run -e "deep=purple" --rm ubuntu /bin/bash -c export
+    $ sudo docker run -e "deep=purple" --rm ubuntu /bin/bash -c export
     declare -x HOME="/"
     declare -x HOSTNAME="85bc26a0e200"
     declare -x OLDPWD
@@ -396,23 +396,23 @@ information for connecting to the service container. Let's imagine we have a
 container running Redis:
 
     # Start the service container, named redis-name
-    $ docker run -d --name redis-name dockerfiles/redis
+    $ sudo docker run -d --name redis-name dockerfiles/redis
     4241164edf6f5aca5b0e9e4c9eccd899b0b8080c64c0cd26efe02166c73208f3
 
     # The redis-name container exposed port 6379
-    $ docker ps
+    $ sudo docker ps
     CONTAINER ID        IMAGE                      COMMAND                CREATED             STATUS              PORTS               NAMES
     4241164edf6f        $ dockerfiles/redis:latest   /redis-stable/src/re   5 seconds ago       Up 4 seconds        6379/tcp            redis-name
 
     # Note that there are no public ports exposed since we didn᾿t use -p or -P
-    $ docker port 4241164edf6f 6379
+    $ sudo docker port 4241164edf6f 6379
     2014/01/25 00:55:38 Error: No public port '6379' published for 4241164edf6f
 
 Yet we can get information about the Redis container's exposed ports
 with `--link`. Choose an alias that will form a
 valid environment variable!
 
-    $ docker run --rm --link redis-name:redis_alias --entrypoint /bin/bash dockerfiles/redis -c export
+    $ sudo docker run --rm --link redis-name:redis_alias --entrypoint /bin/bash dockerfiles/redis -c export
     declare -x HOME="/"
     declare -x HOSTNAME="acda7f7b1cdc"
     declare -x OLDPWD
@@ -429,15 +429,15 @@ valid environment variable!
 
 And we can use that information to connect from another container as a client:
 
-    $ docker run -i -t --rm --link redis-name:redis_alias --entrypoint /bin/bash dockerfiles/redis -c '/redis-stable/src/redis-cli -h $REDIS_ALIAS_PORT_6379_TCP_ADDR -p $REDIS_ALIAS_PORT_6379_TCP_PORT'
+    $ sudo docker run -i -t --rm --link redis-name:redis_alias --entrypoint /bin/bash dockerfiles/redis -c '/redis-stable/src/redis-cli -h $REDIS_ALIAS_PORT_6379_TCP_ADDR -p $REDIS_ALIAS_PORT_6379_TCP_PORT'
     172.17.0.32:6379>
 
 Docker will also map the private IP address to the alias of a linked
 container by inserting an entry into `/etc/hosts`.  You can use this
 mechanism to communicate with a linked container by its alias:
 
-    $ docker run -d --name servicename busybox sleep 30
-    $ docker run -i -t --link servicename:servicealias busybox ping -c 1 servicealias
+    $ sudo docker run -d --name servicename busybox sleep 30
+    $ sudo docker run -i -t --link servicename:servicealias busybox ping -c 1 servicealias
 
 If you restart the source container (`servicename` in this case), the recipient
 container's `/etc/hosts` entry will be automatically updated.

--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -66,7 +66,7 @@ current port bindings. This is also useful for showing you specific port
 configurations. For example, if you've bound the container port to the
 `localhost` on the host machine, then the `docker port` output will reflect that.
 
-    $ docker port nostalgic_morse 5000
+    $ sudo docker port nostalgic_morse 5000
     127.0.0.1:49155
 
 > **Note:** 
@@ -137,7 +137,7 @@ image, which contains a PostgreSQL database.
 Now, you need to delete the `web` container you created previously so you can replace it
 with a linked one:
 
-    $ docker rm -f web
+    $ sudo docker rm -f web
 
 Now, create a new `web` container and link it with your `db` container.
 
@@ -153,7 +153,7 @@ alias for the link name. You'll see how that alias gets used shortly.
 
 Next, look at your linked containers using `docker ps`.
 
-    $ docker ps
+    $ sudo docker ps
     CONTAINER ID  IMAGE                     COMMAND               CREATED             STATUS             PORTS                    NAMES
     349169744e49  training/postgres:latest  su postgres -c '/usr  About a minute ago  Up About a minute  5432/tcp                 db, web/db
     aed84ee21bde  training/webapp:latest    python app.py         16 hours ago        Up 2 minutes       0.0.0.0:49154->5000/tcp  web

--- a/docs/sources/userguide/usingdocker.md
+++ b/docs/sources/userguide/usingdocker.md
@@ -27,7 +27,7 @@ flags and arguments.
 
     # Usage:  [sudo] docker [flags] [command] [arguments] ..
     # Example:
-    $ docker run -i -t ubuntu /bin/bash
+    $ sudo docker run -i -t ubuntu /bin/bash
 
 Let's see this in action by using the `docker version` command to return
 version information on the currently installed Docker client and daemon.


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@docker.com (github: SvenDowideit)

Closes #7515

Current policy is to try to re-enforce that access to the docker socket is the same as having root access by using sudo everywhere.
