### PR TITLE
Added missing 't' from the end of the /images/{{id}}/get eg.

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.10.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.10.md
@@ -1245,7 +1245,7 @@ Get a tarball containing all images and metadata for the repository
 
 **Example request**
 
-        GET /images/ubuntu/ge
+        GET /images/ubuntu/get
 
 **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.11.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.11.md
@@ -1279,7 +1279,7 @@ specified by `name`.
 
 **Example request**
 
-        GET /images/ubuntu/ge
+        GET /images/ubuntu/get
 
 **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.12.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.12.md
@@ -1344,7 +1344,7 @@ specified by `name`.
 
 **Example request**
 
-        GET /images/ubuntu/ge
+        GET /images/ubuntu/get
 
 **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.13.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.13.md
@@ -1342,7 +1342,7 @@ specified by `name`.
 
 **Example request**
 
-        GET /images/ubuntu/ge
+        GET /images/ubuntu/get
 
 **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.14.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.14.md
@@ -1346,7 +1346,7 @@ specified by `name`.
 
 **Example request**
 
-        GET /images/ubuntu/ge
+        GET /images/ubuntu/get
 
 **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -1353,7 +1353,7 @@ image (and its parents) are returned, but with the exclusion of the
 
 **Example request**
 
-        GET /images/ubuntu/ge
+        GET /images/ubuntu/get
 
 **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.7.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.7.md
@@ -1155,7 +1155,7 @@ specified by `name`.
 
 **Example request**
 
-               GET /images/ubuntu/ge
+               GET /images/ubuntu/get
 
 **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.8.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.8.md
@@ -1208,7 +1208,7 @@ specified by `name`.
 
 **Example request**
 
-        GET /images/ubuntu/ge
+        GET /images/ubuntu/get
 
 **Example response**:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.9.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.9.md
@@ -1242,7 +1242,7 @@ Get a tarball containing all images and metadata for the repository specified by
 
 **Example request**
 
-        GET /images/ubuntu/ge
+        GET /images/ubuntu/get
 
 **Example response**:
 


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@docker.com (github: SvenDowideit)
