### PR TITLE
tarsum: correct close and finish reads

### DIFF
--- a/pkg/tarsum/tarsum.go
+++ b/pkg/tarsum/tarsum.go
@@ -148,6 +148,12 @@ func (ts *tarSum) Read(buf []byte) (int, error) {
 			currentHeader, err := ts.tarR.Next()
 			if err != nil {
 				if err == io.EOF {
+					if err := ts.tarW.Close(); err != nil {
+						return 0, err
+					}
+					if _, err := io.Copy(ts.gz, ts.bufTar); err != nil {
+						return 0, err
+					}
 					if err := ts.gz.Close(); err != nil {
 						return 0, err
 					}


### PR DESCRIPTION
Tarsum now correctly closes the internal TarWriter which appends
a block of 1024 zeros to the end of the returned archive.

~~Also a small refactor of the Read() method to use fewer levels of indentation; move initialization out to separate method.~~

fixes #5055
fixes https://github.com/docker/docker-registry/issues/310

Signed-off-by: Josh Hawn josh.hawn@docker.com
