### PR TITLE
restart policy api docs

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.14.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.14.md
@@ -153,7 +153,7 @@ Json Parameters:
 
 -   **RestartPolicy** – The behavior to apply when the container exits.  The
         value is an object with a `Name` property of either `"always"` to
-        always restart or `"on-failure"` torestart only when the container
+        always restart or `"on-failure"` to restart only when the container
         exit code is non-zero.  If `on-failure` is used, `MaximumRetryCount`
         controls the number of times to retry before giving up.
         The default is not to restart. (optional)

--- a/docs/sources/reference/api/docker_remote_api_v1.14.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.14.md
@@ -133,7 +133,8 @@ Create a container
              "NetworkDisabled": false,
              "ExposedPorts":{
                      "22/tcp": {}
-             }
+             },
+             "RestartPolicy": { "Name": "always" },
         }
 
 **Example response**:
@@ -149,6 +150,13 @@ Create a container
 Json Parameters:
 
      
+
+-   **RestartPolicy** – The behavior to apply when the container exits.  The
+        value is an object with a `Name` property of either `"always"` to
+        always restart or `"on-failure"` torestart only when the container
+        exit code is non-zero.  If `on-failure` is used, `MaximumRetryCount`
+        controls the number of times to retry before giving up.
+        The default is not to restart. (optional)
 
 -   **config** – the container's configuration
 

--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -155,7 +155,7 @@ Json Parameters:
 
 -   **RestartPolicy** – The behavior to apply when the container exits.  The
         value is an object with a `Name` property of either `"always"` to
-        always restart or `"on-failure"` torestart only when the container
+        always restart or `"on-failure"` to restart only when the container
         exit code is non-zero.  If `on-failure` is used, `MaximumRetryCount`
         controls the number of times to retry before giving up.
         The default is not to restart. (optional)

--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -135,7 +135,8 @@ Create a container
              "NetworkDisabled": false,
              "ExposedPorts":{
                      "22/tcp": {}
-             }
+             },
+             "RestartPolicy": { "Name": "always" },
         }
 
 **Example response**:
@@ -151,6 +152,13 @@ Create a container
 Json Parameters:
 
      
+
+-   **RestartPolicy** – The behavior to apply when the container exits.  The
+        value is an object with a `Name` property of either `"always"` to
+        always restart or `"on-failure"` torestart only when the container
+        exit code is non-zero.  If `on-failure` is used, `MaximumRetryCount`
+        controls the number of times to retry before giving up.
+        The default is not to restart. (optional)
 
 -   **config** – the container's configuration
 


### PR DESCRIPTION
Fixes #7743

I didn't manage to figure out how the API is versioned.  My guess is that this functionality applies to 1.14/1.15... but just a guess.  I can adjust this if that's incorrect.  Just let me know how one would figure out which version of the API is associated with which version of Docker.
