### PR TITLE
Try to avoid issues when the Docker daemon restarts or stops on RHEL/CentOS 6

### DIFF
--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -68,7 +68,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $prog: "
-    killproc -p $pidfile $prog
+    killproc -p $pidfile -d 300 $prog
     retval=$?
     echo
     [ $retval -eq 0 ] && rm -f $lockfile


### PR DESCRIPTION
This change will allow the Docker daemon's init script to wait up to 5
minutes before being forcibly terminated by the initscript. Many
non-trivial containers will take more than the default 3 seconds to
stop, which can result in containers whose rootfs is still mounted and
will not restart when the daemon starts up again, or worse, orphan
processes that are still running.
