### PR TITLE
Trim branchname to 29 chars on `make` commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BINDDIR := $(if $(DOCKER_HOST),,bundles)
 # to allow `make DOCSPORT=9000 docs`
 DOCSPORT := 8000
 
-GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null | cut -b 1-29)
 GITCOMMIT := $(shell git rev-parse --short HEAD 2>/dev/null)
 DOCKER_IMAGE := docker$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 DOCKER_DOCS_IMAGE := docker-docs$(if $(GIT_BRANCH),:$(GIT_BRANCH))


### PR DESCRIPTION
I ran into this with a long branchname, it's more of an annoyance than anything else, but technically we could just make sure the branch names are less than 29 chars.
