### PR TITLE
daemon/logs: avoid JSONLog struct alloc in loop

### DIFF
--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -88,9 +88,8 @@ func (daemon *Daemon) ContainerLogs(job *engine.Job) engine.Status {
 				cLog = tmp
 			}
 			dec := json.NewDecoder(cLog)
+			l := &jsonlog.JSONLog{}
 			for {
-				l := &jsonlog.JSONLog{}
-
 				if err := dec.Decode(l); err == io.EOF {
 					break
 				} else if err != nil {
@@ -102,11 +101,12 @@ func (daemon *Daemon) ContainerLogs(job *engine.Job) engine.Status {
 					logLine = fmt.Sprintf("%s %s", l.Created.Format(format), logLine)
 				}
 				if l.Stream == "stdout" && stdout {
-					fmt.Fprintf(job.Stdout, "%s", logLine)
+					io.WriteString(job.Stdout, logLine)
 				}
 				if l.Stream == "stderr" && stderr {
-					fmt.Fprintf(job.Stderr, "%s", logLine)
+					io.WriteString(job.Stderr, logLine)
 				}
+				l.Reset()
 			}
 		}
 	}

--- a/pkg/jsonlog/jsonlog.go
+++ b/pkg/jsonlog/jsonlog.go
@@ -25,11 +25,16 @@ func (jl *JSONLog) Format(format string) (string, error) {
 	return fmt.Sprintf("[%s] %s", jl.Created.Format(format), jl.Log), nil
 }
 
+func (jl *JSONLog) Reset() {
+	jl.Log = ""
+	jl.Stream = ""
+	jl.Created = time.Time{}
+}
+
 func WriteLog(src io.Reader, dst io.Writer, format string) error {
 	dec := json.NewDecoder(src)
+	l := &JSONLog{}
 	for {
-		l := &JSONLog{}
-
 		if err := dec.Decode(l); err == io.EOF {
 			return nil
 		} else if err != nil {
@@ -43,5 +48,6 @@ func WriteLog(src io.Reader, dst io.Writer, format string) error {
 		if _, err := io.WriteString(dst, line); err != nil {
 			return err
 		}
+		l.Reset()
 	}
 }


### PR DESCRIPTION
This PR avoids allocating a new JSONLog struct in a for loop. I've sent this PR because I had this show up with 189 MB of memory for a torture test.
