### PR TITLE
Grammar fix

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2328,7 +2328,7 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 
 func (cli *DockerCli) CmdSave(args ...string) error {
 	cmd := cli.Subcmd("save", "IMAGE [IMAGE...]", "Save an image(s) to a tar archive (streamed to STDOUT by default)")
-	outfile := cmd.String([]string{"o", "-output"}, "", "Write to an file, instead of STDOUT")
+	outfile := cmd.String([]string{"o", "-output"}, "", "Write to a file, instead of STDOUT")
 
 	if err := cmd.Parse(args); err != nil {
 		return err

--- a/docs/man/docker-save.1.md
+++ b/docs/man/docker-save.1.md
@@ -17,7 +17,7 @@ Stream to a file instead of STDOUT by using **-o**.
 
 # OPTIONS
 **-o**, **--output**=""
-   Write to an file, instead of STDOUT
+   Write to a file, instead of STDOUT
 
 # EXAMPLES
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1333,7 +1333,7 @@ Providing a maximum restart limit is only valid for the ** on-failure ** policy.
 
     Save an image(s) to a tar archive (streamed to STDOUT by default)
 
-      -o, --output=""    Write to an file, instead of STDOUT
+      -o, --output=""    Write to a file, instead of STDOUT
 
 Produces a tarred repository to the standard output stream.
 Contains all parent layers, and all tags + versions, or specified repo:tag, for


### PR DESCRIPTION
Fixed 'an file' to 'a file'.
