### PR TITLE
boot2docker shellinit will set any and all env vars needed.

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -34,7 +34,7 @@ VirtualBox VM, Docker itself, and the Boot2Docker management tool.
 
 	     $ boot2docker init
 	     $ boot2docker start
-	     $ export DOCKER_HOST=tcp://$(boot2docker ip 2>/dev/null):2375
+	     $ $(boot2docker shellinit)
 
 A terminal window will open and you'll see the virtual machine starting up. 
 Once you have an initialized virtual machine, you can control it with `boot2docker stop`


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@docker.com (github: SvenDowideit)

for https://github.com/boot2docker/osx-installer/issues/68
