### PR TITLE
Update the documentation to to clarify random port mapping when using -P on docker run

### DIFF
--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -381,8 +381,9 @@ with `-P` or `-p,` or start the client container with `--link`.
 
 If the operator uses `-P` or `-p` then Docker will make the exposed port
 accessible on the host and the ports will be available to any client
-that can reach the host. To find the map between the host ports and the
-exposed ports, use `docker port`)
+that can reach the host. Using `-P` will bind the exposed port to a random 
+high port from the range 49153 to 65535 on the docker host. To find the 
+map between the host ports and the exposed ports, use `docker port`)
 
 If the operator uses `--link` when starting the new client container,
 then the client container can access the exposed port via a private


### PR DESCRIPTION
The documentation for `docker run` does not clearly explain that using `-P` will map exposed ports to a random high port on the host.

Although this is documented in http://docs.docker.com/userguide/dockerlinks/#network-port-mapping-refresher, it should also be clearly specified in the `docker run` documentation as it's confusing for users (see  http://stackoverflow.com/q/25920723/1027148 as an example).
