### PR TITLE
Updated the documentation to to clarify random port mapping when using -...

### DIFF
--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -186,8 +186,9 @@ and foreground Docker containers.
    When set to true publish all exposed ports to the host interfaces. The
 default is false. If the operator uses -P (or -p) then Docker will make the
 exposed port accessible on the host and the ports will be available to any
-client that can reach the host. To find the map between the host ports and the
-exposed ports, use **docker port**.
+client that can reach the host. When using -P, Docker will bind the exposed 
+ports to a random port on the host between 49153 and 65535. To find the 
+mapping between the host ports and the exposed ports, use **docker port**.
 
 **-p**, **--publish**=[]
    Publish a container's port to the host (format: ip:hostPort:containerPort |

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -381,8 +381,9 @@ with `-P` or `-p,` or start the client container with `--link`.
 
 If the operator uses `-P` or `-p` then Docker will make the exposed port
 accessible on the host and the ports will be available to any client
-that can reach the host. To find the map between the host ports and the
-exposed ports, use `docker port`)
+that can reach the host. When using `-P`, Docker will bind the exposed 
+ports to a random port on the host between 49153 and 65535. To find the
+mapping between the host ports and the exposed ports, use `docker port`.
 
 If the operator uses `--link` when starting the new client container,
 then the client container can access the exposed port via a private


### PR DESCRIPTION
The documentation for `docker run` does not clearly explain that using -P will map exposed ports to random high ports on the host.

Although this is documented in http://docs.docker.com/userguide/dockerlinks/#network-port-mapping-refresher, it should also be clearly specified in the docker run documentation as it can create confusion for users (see http://stackoverflow.com/q/25920723/1027148 as an example).
