### PR TITLE
Add support for multiple level CLI commands

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -46,6 +46,13 @@ const (
 )
 
 func (cli *DockerCli) CmdHelp(args ...string) error {
+	if len(args) > 1 {
+		method, exists := cli.getMethod(args[:2]...)
+		if exists {
+			method("--help")
+			return nil
+		}
+	}
 	if len(args) > 0 {
 		method, exists := cli.getMethod(args[0])
 		if !exists {


### PR DESCRIPTION
E.g. `docker groups create` will attempt to call the function `CmdGroupsCreate` on `DockerCli`. Also, `docker help groups create` behaves the same as `docker groups create --help`.

[Works a bit like this.](https://github.com/bfirsh/docker/blob/ba7d30c27389e0ad44f9cfe505eb72df97f626c0/api/client/commands.go#L2504-L2725)
