### PR TITLE
Links v2

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -73,6 +73,7 @@ func (cli *DockerCli) CmdLinks(args ...string) error {
 	description := "Manage Docker hosts\n\nCommands:\n"
 	for _, command := range [][]string{
 		{"add", "Add a Link"},
+		{"remove", "Remove a Link"},
 	} {
 		description += fmt.Sprintf("    %-10.10s%s\n", command[0], command[1])
 	}
@@ -96,7 +97,7 @@ func (cli *DockerCli) CmdLinksAdd(args ...string) error {
 		return err
 	}
 
-	if cmd.NArg() < 3 {
+	if cmd.NArg() != 3 {
 		cmd.Usage()
 		return nil
 	}
@@ -109,6 +110,36 @@ func (cli *DockerCli) CmdLinksAdd(args ...string) error {
 	_, _, err := cli.call(
 		"POST",
 		"/links/add?"+v.Encode(),
+		nil,
+		false,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (cli *DockerCli) CmdLinksRemove(args ...string) error {
+	cmd := cli.Subcmd("remove", "[parent] [child] [alias]", "Remove a link from parent->child")
+	if err := cmd.Parse(args); err != nil {
+		return err
+	}
+
+	if cmd.NArg() != 3 {
+		cmd.Usage()
+		return nil
+	}
+
+	v := url.Values{}
+	v.Set("parent", cmd.Arg(0))
+	v.Set("child", cmd.Arg(1))
+	v.Set("alias", cmd.Arg(2))
+
+	_, _, err := cli.call(
+		"POST",
+		"/links/remove?"+v.Encode(),
 		nil,
 		false,
 	)

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -69,6 +69,27 @@ func (cli *DockerCli) CmdHelp(args ...string) error {
 	return nil
 }
 
+func (cli *DockerCli) CmdLinks(args ...string) error {
+	description := "Manage Docker hosts\n\nCommands:\n"
+	for _, command := range [][]string{
+		{"add", "Add a Link"},
+	} {
+		description += fmt.Sprintf("    %-10.10s%s\n", command[0], command[1])
+	}
+
+	cmd := cli.Subcmd("links", "[COMMAND]", description)
+
+	if err := cmd.Parse(args); err != nil {
+		return err
+	}
+
+	if cmd.NArg() < 1 {
+		cmd.Usage()
+	}
+
+	return nil
+}
+
 func (cli *DockerCli) CmdBuild(args ...string) error {
 	cmd := cli.Subcmd("build", "PATH | URL | -", "Build a new image from the source code at PATH")
 	tag := cmd.String([]string{"t", "-tag"}, "", "Repository name (and optionally a tag) to be applied to the resulting image in case of success")

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -90,6 +90,36 @@ func (cli *DockerCli) CmdLinks(args ...string) error {
 	return nil
 }
 
+func (cli *DockerCli) CmdLinksAdd(args ...string) error {
+	cmd := cli.Subcmd("add", "[parent] [child] [alias]", "Create a new link from parent->child with an alias")
+	if err := cmd.Parse(args); err != nil {
+		return err
+	}
+
+	if cmd.NArg() < 3 {
+		cmd.Usage()
+		return nil
+	}
+
+	v := url.Values{}
+	v.Set("parent", cmd.Arg(0))
+	v.Set("child", cmd.Arg(1))
+	v.Set("alias", cmd.Arg(2))
+
+	_, _, err := cli.call(
+		"POST",
+		"/links/add?"+v.Encode(),
+		nil,
+		false,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (cli *DockerCli) CmdBuild(args ...string) error {
 	cmd := cli.Subcmd("build", "PATH | URL | -", "Build a new image from the source code at PATH")
 	tag := cmd.String([]string{"t", "-tag"}, "", "Repository name (and optionally a tag) to be applied to the resulting image in case of success")

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1557,11 +1557,6 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 			outID = utils.TruncateID(outID)
 		}
 
-		// Remove the leading / from the names
-		for i := 0; i < len(outNames); i++ {
-			outNames[i] = outNames[i][1:]
-		}
-
 		if !*quiet {
 			var (
 				outCommand   = out.Get("Command")

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -469,6 +469,22 @@ func postLinksAdd(eng *engine.Engine, version version.Version, w http.ResponseWr
 	return nil
 }
 
+func postLinksRemove(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := parseForm(r); err != nil {
+		return err
+	}
+
+	job := eng.Job("link_remove")
+	job.Args = []string{r.Form.Get("parent"), r.Form.Get("child"), r.Form.Get("alias")}
+	if err := job.Run(); err != nil {
+		w.WriteHeader(http.StatusConflict)
+		return err
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	return nil
+}
+
 func postCommit(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -1288,6 +1304,7 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 			"/images/{name:.*}/push":        postImagesPush,
 			"/images/{name:.*}/tag":         postImagesTag,
 			"/links/add":                    postLinksAdd,
+			"/links/remove":                 postLinksRemove,
 			"/containers/create":            postContainersCreate,
 			"/containers/{name:.*}/kill":    postContainersKill,
 			"/containers/{name:.*}/pause":   postContainersPause,

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -453,6 +453,22 @@ func postImagesTag(eng *engine.Engine, version version.Version, w http.ResponseW
 	return nil
 }
 
+func postLinksAdd(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := parseForm(r); err != nil {
+		return err
+	}
+
+	job := eng.Job("link_add")
+	job.Args = []string{r.Form.Get("parent"), r.Form.Get("child"), r.Form.Get("alias")}
+	if err := job.Run(); err != nil {
+		w.WriteHeader(http.StatusConflict)
+		return err
+	}
+
+	w.WriteHeader(http.StatusCreated)
+	return nil
+}
+
 func postCommit(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -1271,6 +1287,7 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 			"/images/load":                  postImagesLoad,
 			"/images/{name:.*}/push":        postImagesPush,
 			"/images/{name:.*}/tag":         postImagesTag,
+			"/links/add":                    postLinksAdd,
 			"/containers/create":            postContainersCreate,
 			"/containers/{name:.*}/kill":    postContainersKill,
 			"/containers/{name:.*}/pause":   postContainersPause,

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -365,6 +365,7 @@ func getContainersJSON(eng *engine.Engine, version version.Version, w http.Respo
 	job.Setenv("before", r.Form.Get("before"))
 	job.Setenv("limit", r.Form.Get("limit"))
 	job.Setenv("filters", r.Form.Get("filters"))
+	job.Setenv("version", string(version))
 
 	if version.GreaterThanOrEqualTo("1.5") {
 		streamJSON(job, w, false)

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1014,10 +1014,6 @@ func (container *Container) setupLinkedContainers() ([]string, error) {
 				alias = child.Name
 			}
 
-			if !child.IsRunning() {
-				return nil, fmt.Errorf("Cannot link to a non running container: %s AS %s", child.Name, alias)
-			}
-
 			link, err := links.NewLink(
 				container.NetworkSettings.IPAddress,
 				child.NetworkSettings.IPAddress,

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -902,7 +902,7 @@ func (container *Container) UpdateParentsHosts() error {
 
 	for _, c := range parents {
 		if !container.daemon.config.DisableNetwork && container.hostConfig.NetworkMode.IsPrivate() {
-			if err := etchosts.Update(c.HostsPath, container.NetworkSettings.IPAddress, container.Name); err != nil {
+			if err := etchosts.Update(c.HostsPath, container.NetworkSettings.IPAddress, container.daemon.AliasFor(c, container)); err != nil {
 				return fmt.Errorf("Failed to update /etc/hosts in parent container: %v", err)
 			}
 		}

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -897,6 +897,14 @@ func (container *Container) setupContainerDns() error {
 	return ioutil.WriteFile(container.ResolvConfPath, resolvConf, 0644)
 }
 
+func (container *Container) RemoveLink(alias string) error {
+	if err := etchosts.Remove(container.HostsPath, alias); err != nil {
+		return fmt.Errorf("Failed to update /etc/hosts in parent container: %v", err)
+	}
+
+	return nil
+}
+
 func (container *Container) UpdateParentsHosts() error {
 	parents := container.daemon.Parents(container.Name)
 

--- a/daemon/container_unit_test.go
+++ b/daemon/container_unit_test.go
@@ -1,8 +1,9 @@
 package daemon
 
 import (
-	"github.com/docker/docker/nat"
 	"testing"
+
+	"github.com/docker/docker/nat"
 )
 
 func TestParseNetworkOptsPrivateOnly(t *testing.T) {
@@ -163,19 +164,6 @@ func TestParseNetworkOptsUdp(t *testing.T) {
 		if s.HostIp != "192.168.1.100" {
 			t.Fail()
 		}
-	}
-}
-
-func TestGetFullName(t *testing.T) {
-	name, err := GetFullContainerName("testing")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if name != "/testing" {
-		t.Fatalf("Expected /testing got %s", name)
-	}
-	if _, err := GetFullContainerName(""); err == nil {
-		t.Fatal("Error should not be nil")
 	}
 }
 

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -90,6 +90,10 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 		if err := daemon.setHostConfig(container, hostConfig); err != nil {
 			return nil, nil, err
 		}
+		// Register any links from the host config before starting the container
+		if err := daemon.RegisterLinks(container, hostConfig); err != nil {
+			return nil, nil, err
+		}
 	}
 	if err := container.ToDisk(); err != nil {
 		return nil, nil, err

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -544,6 +544,11 @@ func (daemon *Daemon) RegisterLink(parent, child *Container, alias string) error
 	return nil
 }
 
+func (daemon *Daemon) UnregisterLink(parent, child *Container, alias string) error {
+	defer daemon.containers.RemoveLink(parent, child, alias)
+	return parent.RemoveLink(alias)
+}
+
 func (daemon *Daemon) RegisterLinks(container *Container, hostConfig *runconfig.HostConfig) error {
 	if hostConfig != nil && hostConfig.Links != nil {
 		for _, l := range hostConfig.Links {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -540,8 +540,7 @@ func (daemon *Daemon) RegisterLink(parent, child *Container, alias string) error
 		return err
 	}
 
-	daemon.containers.Link(parent, child)
-	return nil
+	return daemon.containers.Link(parent, child)
 }
 
 func (daemon *Daemon) UnregisterLink(parent, child *Container, alias string) error {
@@ -552,6 +551,8 @@ func (daemon *Daemon) UnregisterLink(parent, child *Container, alias string) err
 func (daemon *Daemon) RegisterLinks(container *Container, hostConfig *runconfig.HostConfig) error {
 	if hostConfig != nil && hostConfig.Links != nil {
 		for _, l := range hostConfig.Links {
+			log.Debugf("%#v", l)
+
 			parts, err := parsers.PartParser("name:alias", l)
 			if err != nil {
 				return err

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -94,6 +94,11 @@ func (daemon *Daemon) Install(eng *engine.Engine) error {
 			return err
 		}
 	}
+
+	if err := daemon.RegisterLinkJobs(eng); err != nil {
+		return err
+	}
+
 	if err := daemon.Repositories().Install(eng); err != nil {
 		return err
 	}

--- a/daemon/index.go
+++ b/daemon/index.go
@@ -1,0 +1,554 @@
+/*
+The container index is a set of simple maps used to handle:
+* naming containers
+* aliasing containers
+* managing the parent/child relationship of containers
+* Persisting this information to disk safely.
+
+It is a replacement for pkg/graphdb which will be retired hopefully soon.
+*/
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/docker/docker/pkg/graphdb"
+	"github.com/docker/docker/pkg/truncindex"
+)
+
+const (
+	containerIndexFileName = "container_index.json"
+	tickInterval           = time.Second
+)
+
+type containerIndex struct {
+	// child name -> parent name -> id
+	NameToParents map[string]map[string]string
+
+	// parent name -> child name -> id
+	NameToChildren map[string]map[string]string
+
+	// container name -> alias -> id
+	Aliases map[string]map[string]string
+
+	// container name -> child names -> id
+	AliasChildMap map[string]map[string]string
+
+	// container name -> id
+	NameToID map[string]string
+
+	// container id -> name
+	IDToName map[string]string
+
+	// container id -> container
+	idToContainer map[string]*Container
+
+	daemon     *Daemon
+	indexPath  string // fully qualified containerIndexFileName
+	truncIndex *truncindex.TruncIndex
+	mutex      *sync.Mutex
+	syncTicker *time.Ticker
+}
+
+// migrate the linkgraph graphdb to the new containerIndex format.
+func migrateIndex(root string, daemon *Daemon) (*containerIndex, error) {
+	graphdbPath := filepath.Join(root, "linkgraph.db")
+	c := emptyContainerIndex(root, daemon)
+
+	// bail only if we can find the file but there's problems otherwise loading
+	// the graphdb. If the file does not exist, we have migrated successfully.
+	if _, err := os.Stat(graphdbPath); err != nil {
+		return nil, err
+	}
+
+	graph, err := graphdb.NewSqliteConn(graphdbPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// this is extremely hairy code. What it's doing here is mining the graphdb
+	// for names, and aliases. In the event it finds a name, it will attempt to
+	// load the container. Docker reloads these containers on startup, so as long
+	// as this is done first (as it is currently) there should be no issue.
+	// Otherwise, certain runtime things will not be attached like
+	// BroadcastWriter and Daemon. In the event it finds a link, it will set up a
+	// parent/child relationship, and also relate the last portion (the alias) as
+	// the container's alias.
+
+	// used for building the parent/child mappings
+	relationships := map[string]string{}
+	aliases := map[string]string{}
+
+	for p, e := range graph.List("/", 3) {
+		parts := strings.Split(p, "/")
+		parts = parts[1:] // remove leading slash
+
+		switch len(parts) {
+		case 1: // only a name
+			cont, err := c.daemon.Load(e.ID())
+			if err != nil {
+				continue
+			}
+			c.NameToID[parts[0]] = e.ID()
+			c.IDToName[e.ID()] = parts[0]
+			if cont.Name[0] == '/' {
+				cont.Name = cont.Name[1:]
+				cont.ToDisk()
+			}
+			c.idToContainer[e.ID()] = cont
+		case 2: // parent -> alias link.
+			relationships[parts[0]] = e.ID()
+			aliases[e.ID()] = parts[1]
+		}
+	}
+
+	for parent, childID := range relationships {
+		child := c.idToContainer[childID]
+		if child == nil {
+			continue
+		}
+
+		c.NameToParents[child.Name] = map[string]string{parent: c.NameToID[parent]}
+		c.NameToChildren[parent] = map[string]string{child.Name: childID}
+		c.addAlias(parent, child.Name, aliases[childID])
+	}
+
+	if err = c.ToDisk(); err == nil {
+		graph.Close()
+		os.Remove(graphdbPath)
+	}
+
+	return c, err
+}
+
+func getIndexFilename(root string) string {
+	return filepath.Join(root, containerIndexFileName)
+}
+
+func (c *containerIndex) startSync() {
+	for _ = range c.syncTicker.C {
+		c.ToDisk()
+	}
+}
+
+// This is what is used to load the container index. It also happens to do
+// several other things via function dispatch:
+// * migrates graphdb
+// * creates an empty container index if needed
+func containerIndexFromDisk(root string, daemon *Daemon) (*containerIndex, error) {
+	var c *containerIndex
+
+	if _, err := os.Stat(getIndexFilename(root)); err != nil {
+		c, err = migrateIndex(root, daemon)
+		if err != nil && !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+
+	if c == nil {
+		c = emptyContainerIndex(root, daemon)
+	}
+
+	content, err := ioutil.ReadFile(c.indexPath)
+
+	if err != nil {
+		// file does not exist, or there was a permission error. Start from scratch.
+		go c.startSync()
+		return c, nil
+	}
+
+	if err := json.Unmarshal(content, c); err != nil {
+		return nil, err
+	}
+
+	for id := range c.IDToName {
+		c.truncIndex.Add(id)
+	}
+
+	go c.startSync()
+	return c, nil
+}
+
+func emptyContainerIndex(root string, daemon *Daemon) *containerIndex {
+	return &containerIndex{
+		NameToParents:  map[string]map[string]string{},
+		NameToChildren: map[string]map[string]string{},
+		Aliases:        map[string]map[string]string{},
+		AliasChildMap:  map[string]map[string]string{},
+		NameToID:       map[string]string{},
+		IDToName:       map[string]string{},
+
+		idToContainer: map[string]*Container{},
+		daemon:        daemon,
+		indexPath:     getIndexFilename(root),
+		truncIndex:    truncindex.NewTruncIndex([]string{}),
+		mutex:         new(sync.Mutex),
+		syncTicker:    time.NewTicker(tickInterval),
+	}
+}
+
+func (c *containerIndex) lock() {
+	c.mutex.Lock()
+}
+
+func (c *containerIndex) unlock() {
+	c.mutex.Unlock()
+}
+
+func (c *containerIndex) ToDisk() error {
+	c.lock()
+	defer c.unlock()
+
+	f, err := ioutil.TempFile("", "container_index")
+	if err != nil {
+		return err
+	}
+
+	// the file is closed later if there are no errors. this is a noop at that point.
+	defer f.Close()
+
+	content, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	if _, err := f.Write(content); err != nil {
+		return err
+	}
+
+	f.Close()
+
+	if err := os.Rename(f.Name(), c.indexPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *containerIndex) Add(cont *Container) error {
+	c.lock()
+	c.add(cont)
+	c.unlock()
+
+	return nil
+}
+
+func (c *containerIndex) add(cont *Container) {
+	// this is to fix a migration issue where the containers would be assigned a name starting with /
+	if cont.Name[0] == '/' {
+		cont.Name = cont.Name[1:]
+	}
+
+	if _, ok := c.NameToParents[cont.Name]; !ok {
+		c.NameToParents[cont.Name] = map[string]string{}
+	}
+
+	if _, ok := c.NameToChildren[cont.Name]; !ok {
+		c.NameToChildren[cont.Name] = map[string]string{}
+	}
+
+	c.NameToID[cont.Name] = cont.ID
+	c.IDToName[cont.ID] = cont.Name
+	c.truncIndex.Add(cont.ID)
+	c.idToContainer[cont.ID] = cont
+}
+
+func (c *containerIndex) Delete(cont *Container) {
+	c.lock()
+	c.doDelete(cont)
+	c.unlock()
+}
+
+func (c *containerIndex) Unlink(cont *Container) {
+	c.lock()
+	c.removeParents(cont)
+	c.unlock()
+}
+
+func (c *containerIndex) removeParents(cont *Container) {
+	for name := range c.NameToParents[cont.Name] {
+		delete(c.NameToChildren[name], cont.Name)
+		delete(c.Aliases[name], cont.Name)
+		delete(c.AliasChildMap[name], cont.Name)
+	}
+
+	delete(c.NameToParents, cont.Name)
+}
+
+func (c *containerIndex) doDelete(cont *Container) {
+	delete(c.NameToParents, cont.Name)
+	delete(c.NameToChildren, cont.Name)
+	delete(c.Aliases, cont.Name)
+	delete(c.AliasChildMap, cont.Name)
+	delete(c.NameToID, cont.Name)
+	delete(c.IDToName, cont.ID)
+	delete(c.idToContainer, cont.ID)
+}
+
+func (c *containerIndex) Link(parent *Container, child *Container) {
+	c.lock()
+	c.cleanChildParent(parent, child)
+	c.addChild(parent, child)
+	c.addParent(parent, child)
+	c.unlock()
+}
+
+func (c *containerIndex) cleanChildParent(parent, child *Container) {
+	delete(c.NameToChildren[parent.Name], child.Name)
+	delete(c.NameToParents[child.Name], parent.Name)
+}
+
+func (c *containerIndex) addChild(parent, child *Container) {
+	if c.NameToChildren[parent.Name] == nil {
+		c.NameToChildren[parent.Name] = map[string]string{}
+	}
+
+	c.NameToChildren[parent.Name][child.Name] = child.ID
+}
+
+func (c *containerIndex) addParent(parent, child *Container) {
+	if c.NameToParents[child.Name] == nil {
+		c.NameToParents[child.Name] = map[string]string{}
+	}
+
+	c.NameToParents[child.Name][parent.Name] = parent.ID
+}
+
+func (c *containerIndex) ParentsByName(name string) map[string]*Container {
+	c.lock()
+
+	result := map[string]*Container{}
+
+	for name, id := range c.NameToParents[name] {
+		result[name] = c.idToContainer[id]
+	}
+
+	c.unlock()
+	return result
+}
+
+func (c *containerIndex) ChildrenByName(name string) map[string]*Container {
+	c.lock()
+
+	result := map[string]*Container{}
+
+	for name, id := range c.NameToChildren[name] {
+		result[name] = c.idToContainer[id]
+	}
+
+	c.unlock()
+
+	return result
+}
+
+func (c *containerIndex) SetAlias(parent, child *Container, alias string) error {
+	c.lock()
+	defer c.unlock()
+
+	// locks are already used in AliasInUse and AddAlias
+
+	if c.aliasInUse(parent, child, alias) {
+		return fmt.Errorf("Alias %s cannot be set for container ID %s, parent %s: name conflict", alias, child.ID, parent.ID)
+	}
+
+	if err := c.addAlias(parent.Name, child.Name, alias); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *containerIndex) aliasInUse(parent, child *Container, alias string) bool {
+	// lock is acquired in caller
+	if _, ok := c.Aliases[parent.Name]; ok {
+		_, aliasok := c.Aliases[parent.Name][child.Name]
+		_, childok := c.AliasChildMap[parent.Name][alias]
+		return aliasok || childok
+	}
+
+	return false
+}
+
+func (c *containerIndex) GetByID(id string) (*Container, error) {
+	c.lock()
+	defer c.unlock()
+
+	if _, ok := c.IDToName[id]; ok {
+		if cont, ok := c.idToContainer[id]; ok {
+			return cont, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Container for %s cannot be located", id)
+}
+
+func (c *containerIndex) GetByTruncName(name string) (*Container, error) {
+	c.lock()
+	defer c.unlock()
+
+	id, err := c.truncIndex.Get(name)
+	if err == nil {
+		if cont, ok := c.idToContainer[id]; ok {
+			return cont, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Container for %s cannot be located", name)
+}
+
+func (c *containerIndex) GetByName(name string) (*Container, error) {
+	c.lock()
+	defer c.unlock()
+
+	if id, ok := c.NameToID[name]; ok {
+		if cont, ok := c.idToContainer[id]; ok {
+			return cont, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Container for %s cannot be located", name)
+}
+
+func (c *containerIndex) GetNameForID(id string) string {
+	c.lock()
+	defer c.unlock()
+	return c.IDToName[id]
+}
+
+// This function can be used *before* containers are loaded to map names to
+// identifiers. This is needed because of (*Daemon).ensureName()
+func (c *containerIndex) AssignNameForID(name, id string) error {
+	if c.NameInUse(name) {
+		return fmt.Errorf("Name %s is already in use", name)
+	}
+
+	c.lock()
+	c.IDToName[id] = name
+	c.unlock()
+
+	return nil
+}
+
+func (c *containerIndex) NameInUse(name string) bool {
+	c.lock()
+	_, nameok := c.NameToID[name]
+	c.unlock()
+
+	return nameok
+}
+
+func (c *containerIndex) List() []*Container {
+	containers := new(History)
+	c.lock()
+	for _, id := range c.NameToID {
+		cont, ok := c.idToContainer[id]
+		if !ok {
+			continue
+		}
+
+		containers.Add(cont)
+	}
+	c.unlock()
+	containers.Sort()
+	return *containers
+}
+
+// Pulls this structure apart: /parent/child/alias into two containers and an alias
+func (c *containerIndex) DeconstructPath(path string) (*Container, *Container, string, error) {
+	c.lock()
+	defer c.unlock()
+
+	parts := strings.Split(path, "/")
+
+	if parts[0] == "" {
+		parts = parts[1:]
+	}
+
+	if len(parts) < 2 {
+		return nil, nil, "", fmt.Errorf("Invalid path (missing entities)")
+	}
+
+	var parent, child *Container
+	var alias string
+
+	if id, ok := c.NameToID[parts[0]]; ok {
+		parent = c.idToContainer[id]
+		if id, ok := c.NameToID[parts[1]]; ok {
+			child = c.idToContainer[id]
+		}
+	}
+
+	if parent == nil {
+		return nil, nil, "", fmt.Errorf("Could not locate parent container %s", parts[0])
+	}
+
+	if child == nil {
+		return nil, nil, "", fmt.Errorf("Could not locate child container %s", parts[1])
+	}
+
+	if len(parts) > 2 && parts[2] != "" {
+		alias = parts[2]
+	} else {
+		alias = child.Name
+	}
+
+	return parent, child, alias, nil
+}
+
+func (c *containerIndex) ChildFor(parent *Container, alias string) *Container {
+	c.lock()
+	defer c.unlock()
+
+	if childname, ok := c.AliasChildMap[parent.Name][alias]; ok {
+		if childid, ok := c.NameToID[childname]; ok {
+			if child, ok := c.idToContainer[childid]; ok {
+				return child
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *containerIndex) AliasFor(parent, child *Container) string {
+	c.lock()
+	defer c.unlock()
+
+	alias := c.Aliases[parent.Name][child.Name]
+	if alias != "" {
+		return alias
+	}
+
+	return child.Name
+}
+
+func (c *containerIndex) addAlias(parent, child, alias string) error {
+	// lock is acquired in caller
+	if _, ok := c.Aliases[parent]; !ok {
+		c.Aliases[parent] = map[string]string{}
+	}
+
+	if _, ok := c.AliasChildMap[parent]; !ok {
+		c.AliasChildMap[parent] = map[string]string{}
+	}
+
+	if _, ok := c.Aliases[parent][child]; ok {
+		return fmt.Errorf("Alias already set for parent %s, child %s", parent, child)
+	}
+
+	if _, ok := c.AliasChildMap[parent][alias]; ok {
+		return fmt.Errorf("Alias already set for parent %s, alias %s", parent, alias)
+	}
+
+	c.Aliases[parent][child] = alias
+	c.AliasChildMap[parent][alias] = child
+
+	return nil
+}

--- a/daemon/index.go
+++ b/daemon/index.go
@@ -272,6 +272,15 @@ func (c *containerIndex) Unlink(cont *Container) {
 	c.unlock()
 }
 
+func (c *containerIndex) RemoveLink(parent, child *Container, alias string) {
+	c.lock()
+	delete(c.NameToChildren[parent.Name], child.Name)
+	delete(c.Aliases[parent.Name], child.Name)
+	delete(c.AliasChildMap[parent.Name], alias)
+	delete(c.NameToParents[child.Name], parent.Name)
+	c.unlock()
+}
+
 func (c *containerIndex) removeParents(cont *Container) {
 	for name := range c.NameToParents[cont.Name] {
 		delete(c.NameToChildren[name], cont.Name)

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -48,10 +48,8 @@ func (daemon *Daemon) ContainerInspect(job *engine.Job) engine.Status {
 		out.SetJson("Volumes", container.Volumes)
 		out.SetJson("VolumesRW", container.VolumesRW)
 
-		if children, err := daemon.Children(container.Name); err == nil {
-			for linkAlias, child := range children {
-				container.hostConfig.Links = append(container.hostConfig.Links, fmt.Sprintf("%s:%s", child.Name, linkAlias))
-			}
+		for _, child := range daemon.Children(name) {
+			container.hostConfig.Links = append(container.hostConfig.Links, fmt.Sprintf("%s:%s", child.Name, daemon.containers.AliasFor(container, child)))
 		}
 
 		out.SetJson("HostConfig", container.hostConfig)

--- a/daemon/links.go
+++ b/daemon/links.go
@@ -1,0 +1,10 @@
+package daemon
+
+import (
+	"github.com/docker/docker/engine"
+)
+
+func (d *Daemon) RegisterLinkJobs(job *engine.Job) engine.Status {
+	// register calls here
+	return engine.StatusOK
+}

--- a/daemon/links.go
+++ b/daemon/links.go
@@ -31,5 +31,7 @@ func (d *Daemon) linkAddJob(job *engine.Job) engine.Status {
 		return job.Error(err)
 	}
 
+	child.UpdateParentsHosts()
+
 	return engine.StatusOK
 }

--- a/daemon/links.go
+++ b/daemon/links.go
@@ -1,10 +1,35 @@
 package daemon
 
 import (
+	"errors"
+
 	"github.com/docker/docker/engine"
 )
 
-func (d *Daemon) RegisterLinkJobs(job *engine.Job) engine.Status {
-	// register calls here
+func (d *Daemon) RegisterLinkJobs(eng *engine.Engine) error {
+	eng.Register("link_add", d.linkAddJob)
+	return nil
+}
+
+func (d *Daemon) linkAddJob(job *engine.Job) engine.Status {
+	if len(job.Args) < 3 {
+		return job.Error(errors.New("`docker links add`: not enough arguments"))
+	}
+
+	parent := d.Get(job.Args[0])
+	child := d.Get(job.Args[1])
+
+	if parent == nil || child == nil {
+		return job.Error(errors.New("`docker links add`: invalid container name specified"))
+	}
+
+	if job.Args[2] == "" {
+		return job.Error(errors.New("Alias cannot be empty"))
+	}
+
+	if err := d.RegisterLink(parent, child, job.Args[2]); err != nil {
+		return job.Error(err)
+	}
+
 	return engine.StatusOK
 }

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -6,8 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/docker/docker/pkg/graphdb"
-
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/pkg/parsers/filters"
 )
@@ -46,10 +44,9 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 	}
 
 	names := map[string][]string{}
-	daemon.ContainerGraph().Walk("/", func(p string, e *graphdb.Entity) error {
-		names[e.ID()] = append(names[e.ID()], p)
-		return nil
-	}, -1)
+	for _, container := range daemon.containers.List() {
+		names[container.ID] = append(names[container.ID], container.Name)
+	}
 
 	var beforeCont, sinceCont *Container
 	if before != "" {

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/pkg/parsers/filters"
+	"github.com/docker/docker/pkg/version"
 )
 
 // List returns an array of all containers registered in the daemon.
@@ -24,6 +25,7 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 		before      = job.Getenv("before")
 		n           = job.GetenvInt("limit")
 		size        = job.GetenvBool("size")
+		ver         = version.Version(job.Getenv("version"))
 		psFilters   filters.Args
 		filt_exited []int
 	)
@@ -45,7 +47,11 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 
 	names := map[string][]string{}
 	for _, container := range daemon.containers.List() {
-		names[container.ID] = append(names[container.ID], container.Name)
+		name := container.Name
+		if ver.LessThan("1.15") {
+			name = "/" + name
+		}
+		names[container.ID] = append(names[container.ID], name)
 	}
 
 	var beforeCont, sinceCont *Container

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -59,10 +59,6 @@ func (daemon *Daemon) setHostConfig(container *Container, hostConfig *runconfig.
 			}
 		}
 	}
-	// Register any links from the host config before starting the container
-	if err := daemon.RegisterLinks(container, hostConfig); err != nil {
-		return err
-	}
 	container.SetHostConfig(hostConfig)
 	container.ToDisk()
 

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -10,12 +10,8 @@ import (
 func TestStartAttachReturnsOnError(t *testing.T) {
 	defer deleteAllContainers()
 
-	cmd(t, "run", "-d", "--name", "test", "busybox")
-	cmd(t, "stop", "test")
-
-	// Expect this to fail because the above container is stopped, this is what we want
-	if _, err := runCommand(exec.Command(dockerBinary, "run", "-d", "--name", "test2", "--link", "test:test", "busybox")); err == nil {
-		t.Fatal("Expected error but got none")
+	if _, err := runCommand(exec.Command(dockerBinary, "run", "-d", "--name", "test", "busybox", "/")); err == nil {
+		t.Fatal("Container started even though it should not have")
 	}
 
 	ch := make(chan struct{})

--- a/links/links.go
+++ b/links/links.go
@@ -2,10 +2,10 @@ package links
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/nat"
-	"path"
-	"strings"
 )
 
 type Link struct {
@@ -43,8 +43,7 @@ func NewLink(parentIP, childIP, name string, env []string, exposedPorts map[nat.
 }
 
 func (l *Link) Alias() string {
-	_, alias := path.Split(l.Name)
-	return alias
+	return l.Name
 }
 
 func (l *Link) ToEnv() []string {

--- a/links/links_test.go
+++ b/links/links_test.go
@@ -1,16 +1,17 @@
 package links
 
 import (
-	"github.com/docker/docker/nat"
 	"strings"
 	"testing"
+
+	"github.com/docker/docker/nat"
 )
 
 func TestLinkNaming(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[nat.Port("6379/tcp")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, ports, nil)
+	link, err := NewLink("172.0.17.3", "172.0.17.2", "docker-1", nil, ports, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +41,7 @@ func TestLinkNew(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[nat.Port("6379/tcp")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, ports, nil)
+	link, err := NewLink("172.0.17.3", "172.0.17.2", "docker", nil, ports, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +49,7 @@ func TestLinkNew(t *testing.T) {
 	if link == nil {
 		t.FailNow()
 	}
-	if link.Name != "/db/docker" {
+	if link.Name != "docker" {
 		t.Fail()
 	}
 	if link.Alias() != "docker" {
@@ -71,7 +72,7 @@ func TestLinkEnv(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[nat.Port("6379/tcp")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, ports, nil)
+	link, err := NewLink("172.0.17.3", "172.0.17.2", "docker", []string{"PASSWORD=gordon"}, ports, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,8 +101,8 @@ func TestLinkEnv(t *testing.T) {
 	if env["DOCKER_PORT_6379_TCP_PORT"] != "6379" {
 		t.Fatalf("Expected 6379, got %s", env["DOCKER_PORT_6379_TCP_PORT"])
 	}
-	if env["DOCKER_NAME"] != "/db/docker" {
-		t.Fatalf("Expected /db/docker, got %s", env["DOCKER_NAME"])
+	if env["DOCKER_NAME"] != "docker" {
+		t.Fatalf("Expected docker, got %s", env["DOCKER_NAME"])
 	}
 	if env["DOCKER_ENV_PASSWORD"] != "gordon" {
 		t.Fatalf("Expected gordon, got %s", env["DOCKER_ENV_PASSWORD"])

--- a/pkg/networkfs/etchosts/etchosts.go
+++ b/pkg/networkfs/etchosts/etchosts.go
@@ -43,11 +43,24 @@ func Build(path, IP, hostname, domainname string, extraContent *map[string]strin
 	return ioutil.WriteFile(path, content.Bytes(), 0644)
 }
 
+func Add(path, IP, hostname string) error {
+	old, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path, append(old, []byte(hostname+" "+IP+"\n")...), 0644)
+}
+
 func Update(path, IP, hostname string) error {
 	old, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
 	}
 	var re = regexp.MustCompile(fmt.Sprintf("(\\S*)(\\t%s)", regexp.QuoteMeta(hostname)))
+
+	if !re.Match(old) {
+		return Add(path, IP, hostname)
+	}
+
 	return ioutil.WriteFile(path, re.ReplaceAll(old, []byte(IP+"$2")), 0644)
 }

--- a/pkg/networkfs/etchosts/etchosts.go
+++ b/pkg/networkfs/etchosts/etchosts.go
@@ -52,7 +52,7 @@ func Add(path, IP, hostname string) error {
 }
 
 func makeHostRegexp(hostname string) *regexp.Regexp {
-	return regexp.MustCompile(fmt.Sprintf("(\\S*)(\\t%s)\n", regexp.QuoteMeta(hostname)))
+	return regexp.MustCompile(fmt.Sprintf("(\\S*)(\t[^ ]* ?%s\n)", regexp.QuoteMeta(hostname)))
 }
 
 func Remove(path, hostname string) error {

--- a/pkg/networkfs/etchosts/etchosts.go
+++ b/pkg/networkfs/etchosts/etchosts.go
@@ -55,6 +55,21 @@ func makeHostRegexp(hostname string) *regexp.Regexp {
 	return regexp.MustCompile(fmt.Sprintf("(\\S*)(\\t%s)\n", regexp.QuoteMeta(hostname)))
 }
 
+func Remove(path, hostname string) error {
+	old, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	re := makeHostRegexp(hostname)
+
+	if !re.Match(old) {
+		return fmt.Errorf("Did not find the appropriate host '%s' while editing /etc/hosts", hostname)
+	}
+
+	return ioutil.WriteFile(path, re.ReplaceAll(old, []byte{}), 0644)
+}
+
 func Update(path, IP, hostname string) error {
 	old, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/pkg/networkfs/etchosts/etchosts.go
+++ b/pkg/networkfs/etchosts/etchosts.go
@@ -48,7 +48,11 @@ func Add(path, IP, hostname string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, append(old, []byte(hostname+" "+IP+"\n")...), 0644)
+	return ioutil.WriteFile(path, append(old, []byte(IP+"\t"+hostname+"\n")...), 0644)
+}
+
+func makeHostRegexp(hostname string) *regexp.Regexp {
+	return regexp.MustCompile(fmt.Sprintf("(\\S*)(\\t%s)\n", regexp.QuoteMeta(hostname)))
 }
 
 func Update(path, IP, hostname string) error {
@@ -56,7 +60,8 @@ func Update(path, IP, hostname string) error {
 	if err != nil {
 		return err
 	}
-	var re = regexp.MustCompile(fmt.Sprintf("(\\S*)(\\t%s)", regexp.QuoteMeta(hostname)))
+
+	re := makeHostRegexp(hostname)
 
 	if !re.Match(old) {
 		return Add(path, IP, hostname)

--- a/pkg/networkfs/etchosts/etchosts_test.go
+++ b/pkg/networkfs/etchosts/etchosts_test.go
@@ -106,3 +106,50 @@ func TestUpdate(t *testing.T) {
 		t.Fatalf("Expected to find '%s' got '%s'", expected, content)
 	}
 }
+
+func TestAddRemove(t *testing.T) {
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	if err := Build(file.Name(), "10.11.12.13", "testhostname", "testdomainname", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := ioutil.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected := "10.11.12.13\ttesthostname.testdomainname testhostname\n"; !bytes.Contains(content, []byte(expected)) {
+		t.Fatalf("Expected to find '%s' got '%s'", expected, content)
+	}
+
+	if err := Add(file.Name(), "1.1.1.1", "anothertesthostname"); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err = ioutil.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected := "1.1.1.1\tanothertesthostname\n"; !bytes.Contains(content, []byte(expected)) {
+		t.Fatalf("Expected to find '%s' got '%s'", expected, content)
+	}
+
+	if err := Remove(file.Name(), "anothertesthostname"); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err = ioutil.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected := "1.1.1.1\tanothertesthostname\n"; bytes.Contains(content, []byte(expected)) {
+		t.Fatalf("Expected to not find '%s', found it", expected, content)
+	}
+}


### PR DESCRIPTION
This includes the patches from #8050 and they need to be merged (And this branch be rebased if necessary) before merging this one. Review should probably also wait since the underlying patch is so large.

This adds `docker links add` according to the proposal @ https://github.com/docker/docker/issues/7468 and a integration-cli test for it.

It does not change the semantics and works almost exactly like `docker run --link` at the moment. I will be providing another patch atop this which will tear down some of our guards against linking to non-running containers, etc.
