### PR TITLE
Use the drone build status instead of travis-ci.

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Contributing to Docker
 ======================
 
 [![GoDoc](https://godoc.org/github.com/docker/docker?status.png)](https://godoc.org/github.com/docker/docker)
-[![Travis](https://travis-ci.org/docker/docker.svg?branch=master)](https://travis-ci.org/docker/docker)
+[![Build Status](http://drone.docker.com/github.com/docker/docker/status.svg?branch=master)](http://drone.docker.com/github.com/docker/docker)
 
 Want to hack on Docker? Awesome! There are instructions to get you
 started [here](CONTRIBUTING.md).


### PR DESCRIPTION
Signed-off-by: Andrea Luzzardi aluzzardi@gmail.com
