### PR TITLE
This reduces the amount of logging in the integration tests

### DIFF
--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -101,16 +101,13 @@ func InitDriver(job *engine.Job) engine.Status {
 	if err != nil {
 		// If we're not using the default bridge, fail without trying to create it
 		if !usingDefaultBridge {
-			job.Logf("bridge not found: %s", bridgeIface)
 			return job.Error(err)
 		}
 		// If the iface is not found, try to create it
-		job.Logf("creating new bridge for %s", bridgeIface)
 		if err := createBridge(bridgeIP); err != nil {
 			return job.Error(err)
 		}
 
-		job.Logf("getting iface addr")
 		addr, err = networkdriver.GetIfaceAddr(bridgeIface)
 		if err != nil {
 			return job.Error(err)

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -178,6 +178,7 @@ func newTestEngine(t log.Fataler, autorestart bool, root string) *engine.Engine 
 	os.MkdirAll(root, 0700)
 
 	eng := engine.New()
+	eng.Logging = false
 	// Load default plugins
 	builtins.Register(eng)
 	// (This is manually copied and modified from main() until we have a more generic plugin system)


### PR DESCRIPTION
There were a new areas in the brige driver that did not need to have log
output.  Those were removed.  Also set the engine's logging to false
when running the integration tests.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
