### PR TITLE
Pull: print some data instead of newlines when output is not a terminal

### DIFF
--- a/utils/jsonmessage.go
+++ b/utils/jsonmessage.go
@@ -97,7 +97,7 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 		// <ESC>[2K = erase entire current line
 		fmt.Fprintf(out, "%c[2K\r", 27)
 		endl = "\r"
-	} else if jm.Progress != nil { //disable progressbar in non-terminal
+	} else if jm.Progress != nil && jm.Progress.String() != "" { //disable progressbar in non-terminal
 		return nil
 	}
 	if jm.Time != 0 {
@@ -109,7 +109,7 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 	if jm.From != "" {
 		fmt.Fprintf(out, "(from %s) ", jm.From)
 	}
-	if jm.Progress != nil {
+	if jm.Progress != nil && isTerminal {
 		fmt.Fprintf(out, "%s %s%s", jm.Status, jm.Progress.String(), endl)
 	} else if jm.ProgressMessage != "" { //deprecated
 		fmt.Fprintf(out, "%s %s%s", jm.Status, jm.ProgressMessage, endl)


### PR DESCRIPTION
This improves `docker pull` output when stdout is not a terminal which should fix #8140.
~~I had to change some logic for displaying json message output to fix some differences between handling terminal/non-terminal output, so some more testing should be best.~~

The pull output when running in cli should be the same, while new output when stdout is not a terminal looks like:

```
root@ff5a78202988:/go/src/github.com/docker/docker: ./bundles/1.2.0-dev/binary/docker pull busybox > test.txt
root@ff5a78202988:/go/src/github.com/docker/docker: cat test.txt
Pulling repository busybox
a9eb17255234: Pulling image (latest) from busybox
a9eb17255234: Pulling image (latest) from busybox, endpoint: https://registry-1.docker.io/v1/
a9eb17255234: Pulling dependent layers
511136ea3c5a: Download complete
42eed7f1bf2a: Download complete
120e218dd395: Download complete
a9eb17255234: Download complete
a9eb17255234: Download complete
```
