### PR TITLE
Add docker search all images for private registry.Fixes#7719

### DIFF
--- a/docs/man/docker-search.1.md
+++ b/docs/man/docker-search.1.md
@@ -2,7 +2,7 @@
 % Docker Community
 % JUNE 2014
 # NAME
-docker-search - Search the Docker Hub for images
+docker-search - Search the registry for images
 
 # SYNOPSIS
 **docker search**
@@ -13,10 +13,14 @@ TERM
 
 # DESCRIPTION
 
-Search an index for an image with that matches the term TERM. The table
-of images returned displays the name, description (truncated by default),
-number of stars awarded, whether the image is official, and whether it
-is automated.
+Search the registry for an index for an image with that matches the term TERM.
+The default registry is the Docker Hub located at [hub.docker.com]
+(https://hub.docker.com/).However the registry can be another, perhaps private,
+registry as demonstrated in the example below.The table of images returned
+displays the name, description (truncated by default),number of stars awarded,
+whether the image is official, and whether it is automated.If the TERM is
+a registry address without a image name, it will return all the images in the
+registry.
 
 # OPTIONS
 **--automated**=*true*|*false*
@@ -51,6 +55,25 @@ ranked 1 or higher:
     NAME               DESCRIPTION                                     STARS OFFICIAL  AUTOMATED
     goldmann/wildfly   A WildFly application server running on a ...   3               [OK]
     tutum/fedora-20    Fedora 20 image with SSH access. For the r...   1               [OK]
+
+## Search the private registry for images
+
+Search the private registry for the term 'fedora',the private registry is localhost:5000
+
+    $ sudo docker search localhost:5000/fedora
+    NAME             DESCRIPTION   STARS     OFFICIAL   AUTOMATED
+    library/fedora                 0
+
+## Search all the images in private registry
+
+The search term is '' and dispaly all the images in the private registry,
+the private registry is localhost:5000
+
+    $ sudo docker search localhost:5000/
+    NAME             DESCRIPTION   STARS     OFFICIAL   AUTOMATED
+    library/fedora                 0
+    library/ubuntu                 0
+    library/test                   0
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -246,7 +246,11 @@ func ResolveRepositoryName(reposName string) (string, string, error) {
 		return "", "", fmt.Errorf("Invalid repository name, try \"%s\" instead", reposName)
 	}
 	if err := validateRepositoryName(reposName); err != nil {
-		return "", "", err
+		if reposName == "" {
+			return hostname, "", err
+		} else {
+			return "", "", err
+		}
 	}
 
 	return hostname, reposName, nil

--- a/registry/service.go
+++ b/registry/service.go
@@ -83,7 +83,7 @@ func (s *Service) Search(job *engine.Job) engine.Status {
 	job.GetenvJson("metaHeaders", metaHeaders)
 
 	hostname, term, err := ResolveRepositoryName(term)
-	if err != nil {
+	if err != nil && hostname == "" {
 		return job.Error(err)
 	}
 	hostname, err = ExpandAndVerifyRegistryUrl(hostname)


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

The docker-registry support xxx/v1/search
for query all the images in the private registry，
if the name="", docker should return all the images in the private registry.
