### PR TITLE
Fix for user kicked off after login on some hosts

### DIFF
--- a/docs/sources/examples/running_ssh_service.Dockerfile
+++ b/docs/sources/examples/running_ssh_service.Dockerfile
@@ -10,6 +10,9 @@ RUN mkdir /var/run/sshd
 RUN echo 'root:screencast' | chpasswd
 RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
 ENV NOTVISIBLE "in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 

--- a/docs/sources/examples/running_ssh_service.md
+++ b/docs/sources/examples/running_ssh_service.md
@@ -22,6 +22,9 @@ quick access to a test container.
     RUN echo 'root:screencast' | chpasswd
     RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
 
+    # SSH login fix. Otherwise user is kicked off after login
+    RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
     ENV NOTVISIBLE "in users profile"
     RUN echo "export VISIBLE=now" >> /etc/profile
 


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: SvenDowideit SvenDowideit@home.org.au (github: SvenDowideit)

I didn't need it for my boot2docker, but a debian test system confirmed the need

from https://groups.google.com/forum/#!topic/docker-user/NsCZMrUf-k0
