### PR TITLE
If the Rename during an image delete fails, just delete the original dir  - Issue #7309

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -302,13 +302,17 @@ func (graph *Graph) Delete(name string) error {
 		return err
 	}
 	tmp, err := graph.Mktemp("")
-	if err != nil {
-		return err
-	}
 	graph.idIndex.Delete(id)
-	err = os.Rename(graph.ImageRoot(id), tmp)
-	if err != nil {
-		return err
+	if err == nil {
+		err = os.Rename(graph.ImageRoot(id), tmp)
+		// On err make tmp point to old dir and cleanup unused tmp dir
+		if err != nil {
+			os.RemoveAll(tmp)
+			tmp = graph.ImageRoot(id)
+		}
+	} else {
+		// On err make tmp point to old dir for cleanup
+		tmp = graph.ImageRoot(id)
 	}
 	// Remove rootfs data from the driver
 	graph.driver.Remove(id)


### PR DESCRIPTION
During an image delete the old image's directory is being renamed before it is deleted. Not 100% sure but I suspect this was done to make it unavailable to any process that's trying to access it.  However, I would think that removing it from the idIndex and driver should be sufficient.  Plus, it is immediately followed by the os.RemoveAll().  The problem with the os.Rename(), as noted in Issue 7309, is that if you're out of disk space the rename will fail, leaving the user in a state that they can't seem to recover from w/o hacking away at the server FS.  With this fix I was able to delete the image even if my FS is full.
#7309

Signed-off-by: Doug Davis dug@us.ibm.com
