### PR TITLE
integcli: pull scratch for pull test

### DIFF
--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -8,7 +8,7 @@ import (
 
 // pulling an image from the central registry should work
 func TestPullImageFromCentralRegistry(t *testing.T) {
-	pullCmd := exec.Command(dockerBinary, "pull", "busybox:latest")
+	pullCmd := exec.Command(dockerBinary, "pull", "scratch")
 	out, exitCode, err := runCommandWithOutput(pullCmd)
 	errorOut(err, t, fmt.Sprintf("%s %s", out, err))
 


### PR DESCRIPTION
This PR speeds up the `docker pull` for TestPullImageFromCentralRegistry. I've seen this test take 12 seconds. It should now take only 2-4 seconds.
