### PR TITLE
daemon/attach: avoid mem alloc for interface

### DIFF
--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"time"
@@ -69,10 +68,10 @@ func (daemon *Daemon) ContainerAttach(job *engine.Job) engine.Status {
 					break
 				}
 				if l.Stream == "stdout" && stdout {
-					fmt.Fprintf(job.Stdout, "%s", l.Log)
+					io.WriteString(job.Stdout, l.Log)
 				}
 				if l.Stream == "stderr" && stderr {
-					fmt.Fprintf(job.Stderr, "%s", l.Log)
+					io.WriteString(job.Stderr, l.Log)
 				}
 			}
 		}


### PR DESCRIPTION
This makes the same changes as #8109 for daemon/attach.go.
