### PR TITLE
devmapper: `docker info` devices hard coded

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -466,7 +466,13 @@ func minor(device uint64) uint64 {
 func (devices *DeviceSet) ResizePool(size int64) error {
 	dirname := devices.loopbackDir()
 	datafilename := path.Join(dirname, "data")
+	if len(devices.dataDevice) > 0 {
+		datafilename = devices.dataDevice
+	}
 	metadatafilename := path.Join(dirname, "metadata")
+	if len(devices.metadataDevice) > 0 {
+		metadatafilename = devices.metadataDevice
+	}
 
 	datafile, err := os.OpenFile(datafilename, os.O_RDWR, 0)
 	if datafile == nil {

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1134,8 +1134,16 @@ func (devices *DeviceSet) Status() *Status {
 	status := &Status{}
 
 	status.PoolName = devices.getPoolName()
-	status.DataLoopback = path.Join(devices.loopbackDir(), "data")
-	status.MetadataLoopback = path.Join(devices.loopbackDir(), "metadata")
+	if len(devices.dataDevice) > 0 {
+		status.DataLoopback = devices.dataDevice
+	} else {
+		status.DataLoopback = path.Join(devices.loopbackDir(), "data")
+	}
+	if len(devices.metadataDevice) > 0 {
+		status.MetadataLoopback = devices.metadataDevice
+	} else {
+		status.MetadataLoopback = path.Join(devices.loopbackDir(), "metadata")
+	}
 
 	totalSizeInSectors, _, dataUsed, dataTotal, metadataUsed, metadataTotal, err := devices.poolStatus()
 	if err == nil {


### PR DESCRIPTION
If `--storage-opt dm.datadev=/dev/loop0 --storage-opt
dm.metadatadev=/dev/loop1` were provided, the information was not
reflected in the information output.

Closes: #7137

Signed-off-by: Vincent Batts vbatts@redhat.com
