### PR TITLE
graph: add VirtualSize for inspect output

### DIFF
--- a/graph/service.go
+++ b/graph/service.go
@@ -149,6 +149,7 @@ func (s *TagStore) CmdLookup(job *engine.Job) engine.Status {
 		out.Set("Architecture", image.Architecture)
 		out.Set("Os", image.OS)
 		out.SetInt64("Size", image.Size)
+		out.SetInt64("VirtualSize", image.GetParentsSize(0)+image.Size)
 		if _, err = out.WriteTo(job.Stdout); err != nil {
 			return job.Error(err)
 		}


### PR DESCRIPTION
Currently inspect output just shows Size info, and that usally be
very small and even 0 which is confusing.

Fixes #8016

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
