### PR TITLE
Add Dockerfile instructions to reset properties inherited from parent image

### DIFF
--- a/builder/command/command.go
+++ b/builder/command/command.go
@@ -3,6 +3,7 @@ package command
 
 const (
 	Env        = "env"
+	Unsetenv   = "unsetenv"
 	Maintainer = "maintainer"
 	Add        = "add"
 	Copy       = "copy"
@@ -21,6 +22,7 @@ const (
 // Commands is list of all Dockerfile commands
 var Commands = map[string]struct{}{
 	Env:        {},
+	Unsetenv:   {},
 	Maintainer: {},
 	Add:        {},
 	Copy:       {},

--- a/builder/command/command.go
+++ b/builder/command/command.go
@@ -14,6 +14,7 @@ const (
 	Cmd        = "cmd"
 	Entrypoint = "entrypoint"
 	Expose     = "expose"
+	Unexpose   = "unexpose"
 	Volume     = "volume"
 	User       = "user"
 	Insert     = "insert"
@@ -33,6 +34,7 @@ var Commands = map[string]struct{}{
 	Cmd:        {},
 	Entrypoint: {},
 	Expose:     {},
+	Unexpose:   {},
 	Volume:     {},
 	User:       {},
 	Insert:     {},

--- a/builder/command/command.go
+++ b/builder/command/command.go
@@ -16,6 +16,7 @@ const (
 	Expose     = "expose"
 	Unexpose   = "unexpose"
 	Volume     = "volume"
+	Novolume   = "novolume"
 	User       = "user"
 	Insert     = "insert"
 )
@@ -36,6 +37,7 @@ var Commands = map[string]struct{}{
 	Expose:     {},
 	Unexpose:   {},
 	Volume:     {},
+	Novolume:   {},
 	User:       {},
 	Insert:     {},
 }

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -73,6 +73,18 @@ func env(b *Builder, args []string, attributes map[string]bool, original string)
 	return b.commit("", b.Config.Cmd, commitStr)
 }
 
+// UNSETENV env1 env2
+//
+// Unsets the environment variable env1 and env2.
+//
+func unsetEnv(b *Builder, args []string, attributes map[string]bool, original string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("UNSETENV requires at least one argument")
+	}
+	b.Config.UnsetEnv = append(b.Config.UnsetEnv, args...)
+	return b.commit("", b.Config.Cmd, fmt.Sprintf("UNSETENV %v", args))
+}
+
 // MAINTAINER some text <maybe@an.email.address>
 //
 // Sets the maintainer metadata.

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -381,6 +381,33 @@ func expose(b *Builder, args []string, attributes map[string]bool, original stri
 	return b.commit("", b.Config.Cmd, fmt.Sprintf("EXPOSE %s", strings.Join(portList, " ")))
 }
 
+// UNEXPOSE 6666/tcp 7000/tcp
+//
+// Remove exposed ports 6666/tcp and 7000/tcp
+//
+func unexpose(b *Builder, args []string, attributes map[string]bool, original string) error {
+	portsTab := args
+	if len(args) == 0 {
+		return fmt.Errorf("UNEXPOSE requires at least one argument")
+	}
+	if b.Config.UnsetPorts == nil {
+		b.Config.UnsetPorts = make(nat.PortSet)
+	}
+
+	ports, _, err := nat.ParsePortSpecs(portsTab)
+	if err != nil {
+		return err
+	}
+
+	for port := range ports {
+		if _, exists := b.Config.UnsetPorts[port]; !exists {
+			b.Config.UnsetPorts[port] = struct{}{}
+		}
+	}
+
+	return b.commit("", b.Config.Cmd, fmt.Sprintf("UNEXPOSE %v", ports))
+}
+
 // USER foo
 //
 // Set the user to 'foo' for future commands and when running the

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -443,6 +443,22 @@ func volume(b *Builder, args []string, attributes map[string]bool, original stri
 	return nil
 }
 
+// NOVOLUME /foo
+//
+// Remove volume /foo. Will also accept the JSON array form.
+//
+func noVolume(b *Builder, args []string, attributes map[string]bool, original string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("NOVOLUME requires at least one argument")
+	}
+
+	b.Config.UnsetVolumes = map[string]struct{}{}
+	for _, v := range args {
+		b.Config.UnsetVolumes[v] = struct{}{}
+	}
+	return b.commit("", b.Config.Cmd, fmt.Sprintf("NOVOLUME %s", args))
+}
+
 // INSERT is no longer accepted, but we still parse it.
 func insert(b *Builder, args []string, attributes map[string]bool, original string) error {
 	return fmt.Errorf("INSERT has been deprecated. Please use ADD instead")

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -56,6 +56,7 @@ var replaceEnvAllowed = map[string]struct{}{
 	command.Volume:   {},
 	command.User:     {},
 	command.Unsetenv: {},
+	command.Unexpose: {},
 }
 
 var evaluateTable map[string]func(*Builder, []string, map[string]bool, string) error
@@ -77,6 +78,7 @@ func init() {
 		command.User:       user,
 		command.Insert:     insert,
 		command.Unsetenv:   unsetEnv,
+		command.Unexpose:   unexpose,
 	}
 }
 

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -48,13 +48,14 @@ var (
 
 // Environment variable interpolation will happen on these statements only.
 var replaceEnvAllowed = map[string]struct{}{
-	command.Env:     {},
-	command.Add:     {},
-	command.Copy:    {},
-	command.Workdir: {},
-	command.Expose:  {},
-	command.Volume:  {},
-	command.User:    {},
+	command.Env:      {},
+	command.Add:      {},
+	command.Copy:     {},
+	command.Workdir:  {},
+	command.Expose:   {},
+	command.Volume:   {},
+	command.User:     {},
+	command.Unsetenv: {},
 }
 
 var evaluateTable map[string]func(*Builder, []string, map[string]bool, string) error
@@ -75,6 +76,7 @@ func init() {
 		command.Volume:     volume,
 		command.User:       user,
 		command.Insert:     insert,
+		command.Unsetenv:   unsetEnv,
 	}
 }
 

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -57,6 +57,7 @@ var replaceEnvAllowed = map[string]struct{}{
 	command.User:     {},
 	command.Unsetenv: {},
 	command.Unexpose: {},
+	command.Novolume: {},
 }
 
 var evaluateTable map[string]func(*Builder, []string, map[string]bool, string) error
@@ -79,6 +80,7 @@ func init() {
 		command.Insert:     insert,
 		command.Unsetenv:   unsetEnv,
 		command.Unexpose:   unexpose,
+		command.Novolume:   noVolume,
 	}
 }
 

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -61,6 +61,7 @@ func init() {
 		command.Volume:     parseMaybeJSONToList,
 		command.Insert:     parseIgnore,
 		command.Unsetenv:   parseStringsWhitespaceDelimited,
+		command.Unexpose:   parseStringsWhitespaceDelimited,
 	}
 }
 

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -60,6 +60,7 @@ func init() {
 		command.Expose:     parseStringsWhitespaceDelimited,
 		command.Volume:     parseMaybeJSONToList,
 		command.Insert:     parseIgnore,
+		command.Unsetenv:   parseStringsWhitespaceDelimited,
 	}
 }
 

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -62,6 +62,7 @@ func init() {
 		command.Insert:     parseIgnore,
 		command.Unsetenv:   parseStringsWhitespaceDelimited,
 		command.Unexpose:   parseStringsWhitespaceDelimited,
+		command.Novolume:   parseMaybeJSONToList,
 	}
 }
 

--- a/docs/man/Dockerfile.5.md
+++ b/docs/man/Dockerfile.5.md
@@ -150,6 +150,11 @@ A Dockerfile is similar to a Makefile.
   interconnect containers using links, and to set up port redirection on the host
   system.
 
+**UNEXPOSE**
+ --**UNEXPOSE <port> [<port>...]**
+ The **UNEXPOSE** instruction informs Docker that the container will no longer
+ listen on the specified network ports at runtime.
+
 **ENV**
   -- `ENV <key> <value>`
   The **ENV** instruction sets the environment variable <key> to
@@ -163,6 +168,12 @@ A Dockerfile is similar to a Makefile.
   Note that setting "`ENV DEBIAN_FRONTEND noninteractive`" may cause
   unintended consequences, because it will persist when the container is run
   interactively, as with the following command: `docker run -t -i image bash`
+
+**UNSETENV**
+ --**UNSETENV <key> [<key>...]**
+ The **UNSETENV** instruction removes the specified environment variables from
+ the list of available environment variables of the image and future build
+ instructions.
 
 **ADD**
   -- **ADD** has two forms:
@@ -245,6 +256,11 @@ A Dockerfile is similar to a Makefile.
   The **VOLUME** instruction creates a mount point with the specified name and marks
   it as holding externally-mounted volumes from the native host or from other
   containers.
+
+**NOVOLUME**
+ --**NOVOLUME ["/data"]**
+ The **NOVOLUME** instruction informs Docker that the image will not
+ create externally mounted volumes at the specified mount points.
 
 **USER**
   -- `USER daemon`

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -142,6 +142,9 @@ The instructions that handle environment variables in the `Dockerfile` are:
 * `EXPOSE`
 * `VOLUME`
 * `USER`
+* `UNSETENV`
+* `UNEXPOSE`
+* `NOVOLUME`
 
 `ONBUILD` instructions are **NOT** supported for environment replacement, even
 the instructions above.
@@ -344,6 +347,27 @@ host when [using the -P flag](/reference/run/#expose-incoming-ports).
 > [use the `-p` flag](/userguide/dockerlinks) or
 > [the -P flag](/reference/run/#expose-incoming-ports).
 
+## UNEXPOSE
+
+    UNEXPOSE <port> [<port>...]
+
+The `UNEXPOSE` instruction informs Docker that the container will no longer
+listen on the specified network ports at runtime.
+
+For example, given an image named `debug-app` defined with the following
+`Dockerfile`:
+
+    # docker build -t debug-app .
+    FROM debian:wheezy
+    EXPOSE 3000 8080
+
+You want to create a new image which exposes only port 3000. The
+`Dockerfile` for new image can be written as:
+
+    # docker build -t prod-app .
+    FROM debug-app
+    UNEXPOSE 8080
+
 ## ENV
 
     ENV <key> <value>
@@ -386,6 +410,28 @@ change them using `docker run --env <key>=<value>`.
 > setting `ENV DEBIAN_FRONTEND noninteractive` may confuse apt-get
 > users on a Debian-based image. To set a value for a single command, use
 > `RUN <key>=<value> <command>`.
+
+## UNSETENV
+
+    UNSETENV <key> [<key>...]
+
+The `UNSETENV` instruction removes the specified environment variables from
+the list of available environment variables of the image and future build
+instructions.
+
+For example, given an image named `debug-app` defined with the following
+`Dockerfile`:
+
+    # docker build -t debug-app .
+    FROM debian:wheezy
+    ENV DEBUG true
+
+You want to create a new image without the `DEBUG` environment variable. The
+`Dockerfile` for the new image can be written as:
+
+    # docker build -t prod-app .
+    FROM debug-app
+    UNSETENV DEBUG
 
 ## ADD
 
@@ -802,6 +848,33 @@ into the newly created volume.
 > **Note**:
 > The list is parsed as a JSON array, which means that
 > you must use double-quotes (") around words not single-quotes (').
+
+## NOVOLUME
+
+    NOVOLUME ["/data"]
+
+The `NOVOLUME` instruction informs Docker that the image will not create
+externally mounted volumes at the specified mount points. The value can
+be a JSON array, `NOVOLUME ["/var/log"]`, or a plain string with multiple
+arguments, such as `NOVOLUME /var/log` or `NOVOLUME /var/log /var/db`.
+
+> **Note**:
+> The list is parsed as a JSON array, which means that
+> you must use double-quotes (") around words not single-quotes (').
+
+For example, given an image named `debug-app` defined with the following
+`Dockerfile`:
+
+    # docker build -t debug-app .
+    FROM debian:wheezy
+    VOLUME ["/data", "/var/log"]
+
+You want to create a new image without the `/var/log` volume. The
+`Dockerfile` for the new image can be written as:
+
+    # docker build -t prod-app .
+    FROM debug-app
+    NOVOLUME ["/var/log"]
 
 ## USER
 

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	// properties that should be removed from the parent image
 	// we dont want these to appear in the config's serialized output
 	UnsetEnv     []string              `json:"-"`
+	UnsetPorts   map[nat.Port]struct{} `json:"-"`
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -33,6 +33,9 @@ type Config struct {
 	NetworkDisabled bool
 	MacAddress      string
 	OnBuild         []string
+	// properties that should be removed from the parent image
+	// we dont want these to appear in the config's serialized output
+	UnsetEnv     []string              `json:"-"`
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -33,10 +33,12 @@ type Config struct {
 	NetworkDisabled bool
 	MacAddress      string
 	OnBuild         []string
+
 	// properties that should be removed from the parent image
 	// we dont want these to appear in the config's serialized output
 	UnsetEnv     []string              `json:"-"`
 	UnsetPorts   map[nat.Port]struct{} `json:"-"`
+	UnsetVolumes map[string]struct{}   `json:"-"`
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {

--- a/runconfig/merge.go
+++ b/runconfig/merge.go
@@ -124,5 +124,11 @@ func Merge(userConf, imageConf *Config) error {
 			userConf.Volumes[k] = v
 		}
 	}
+	if len(userConf.UnsetVolumes) > 0 {
+		for k := range userConf.UnsetVolumes {
+			delete(userConf.Volumes, k)
+		}
+	}
+
 	return nil
 }

--- a/runconfig/merge.go
+++ b/runconfig/merge.go
@@ -83,6 +83,22 @@ func Merge(userConf, imageConf *Config) error {
 			}
 		}
 	}
+	if len(userConf.UnsetEnv) > 0 {
+		userEnvs := []string{}
+		for _, env := range userConf.Env {
+			found := false
+			envKey := strings.Split(env, "=")[0]
+			for _, rmEnv := range userConf.UnsetEnv {
+				if envKey == rmEnv {
+					found = true
+				}
+			}
+			if !found {
+				userEnvs = append(userEnvs, env)
+			}
+		}
+		userConf.Env = userEnvs
+	}
 
 	if len(userConf.Entrypoint) == 0 {
 		if len(userConf.Cmd) == 0 {

--- a/runconfig/merge.go
+++ b/runconfig/merge.go
@@ -65,6 +65,11 @@ func Merge(userConf, imageConf *Config) error {
 			}
 		}
 	}
+	if len(userConf.UnsetPorts) > 0 {
+		for port := range userConf.UnsetPorts {
+			delete(userConf.ExposedPorts, port)
+		}
+	}
 
 	if len(userConf.Env) == 0 {
 		userConf.Env = imageConf.Env

--- a/runconfig/merge_test.go
+++ b/runconfig/merge_test.go
@@ -1,0 +1,21 @@
+package runconfig
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMergeUnsetEnv(t *testing.T) {
+	conf := &Config{UnsetEnv: []string{"DEBUG"}}
+	imgConf := &Config{Env: []string{"DEBUG=true", "PATH=/bin"}}
+
+	err := Merge(conf, imgConf)
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+	expected := []string{"PATH=/bin"}
+	if !reflect.DeepEqual(conf.Env, expected) {
+		t.Errorf("Env(%v), want %v", imgConf.Env, expected)
+	}
+}
+

--- a/runconfig/merge_test.go
+++ b/runconfig/merge_test.go
@@ -3,6 +3,8 @@ package runconfig
 import (
 	"reflect"
 	"testing"
+
+	"github.com/docker/docker/nat"
 )
 
 func TestMergeUnsetEnv(t *testing.T) {
@@ -19,3 +21,27 @@ func TestMergeUnsetEnv(t *testing.T) {
 	}
 }
 
+func TestMergeUnsetPorts(t *testing.T) {
+	portSpecs := []string{"3000/tcp", "8080/tcp"}
+	ports, _, err := nat.ParsePortSpecs(portSpecs)
+	if err != nil {
+		t.Errorf("Failed to parse port specs %v, err %s", portSpecs, err)
+	}
+	rmPortSpecs := []string{"3000/tcp"}
+	rmPorts, _, err := nat.ParsePortSpecs(rmPortSpecs)
+	if err != nil {
+		t.Errorf("Failed to parse port specs %v, err %s", rmPortSpecs, err)
+	}
+
+	conf := &Config{UnsetPorts: rmPorts}
+	imgConf := &Config{ExposedPorts: ports}
+
+	err = Merge(conf, imgConf)
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+
+	if _, exists := conf.ExposedPorts["3000/tcp"]; exists {
+		t.Errorf("ExposedPorts(%v) should not have %s", conf.ExposedPorts, "3000/tcp")
+	}
+}

--- a/runconfig/merge_test.go
+++ b/runconfig/merge_test.go
@@ -45,3 +45,22 @@ func TestMergeUnsetPorts(t *testing.T) {
 		t.Errorf("ExposedPorts(%v) should not have %s", conf.ExposedPorts, "3000/tcp")
 	}
 }
+
+func TestMergeUnsetVolumes(t *testing.T) {
+	conf := &Config{UnsetVolumes: map[string]struct{}{
+		"/test1": {},
+	}}
+	imgConf := &Config{Volumes: map[string]struct{}{
+		"/test1": {},
+		"/test2": {},
+	}}
+
+	err := Merge(conf, imgConf)
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+
+	if _, exists := conf.Volumes["/test1"]; exists {
+		t.Errorf("Volumes(%v) should not have %s", conf.Volumes, "/test1")
+	}
+}


### PR DESCRIPTION
This is an attemp to fix https://github.com/docker/docker/issues/3465. I've been working on this yesterday and figure that the design can be reviewed at this stage.

New added instructions are:
- `UNSETENV ENV1 ENV2 ...` unset environment variables inherited from parent image
- `UNEXPOSE PORT ...`  remove exposed ports inherited from parent image
- `NOVOLUME PATH` remove volume mountpoints from parent image
