### PR TITLE
That Systemd example URL isn't there anymore

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -124,7 +124,7 @@ you can also specify individual sockets too `docker -d -H fd://3`. If the
 specified socket activated files aren't found then docker will exit. You
 can find examples of using systemd socket activation with docker and
 systemd in the [docker source tree](
-https://github.com/docker/docker/blob/master/contrib/init/systemd/socket-activation/).
+https://github.com/docker/docker/tree/master/contrib/init/systemd/).
 
 Docker supports softlinks for the Docker data directory
 (`/var/lib/docker`) and for `/var/lib/docker/tmp`. The `DOCKER_TMPDIR` and the data directory can be set like this:


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@docker.com (github: SvenDowideit)
