### PR TITLE
--selinux-enabled flag should be ignored on Disabled SELinux systems

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -775,7 +775,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 	log.Debugf("Using graph driver %s", driver)
 
 	// As Docker on btrfs and SELinux are incompatible at present, error on both being enabled
-	if config.EnableSelinuxSupport && driver.String() == "btrfs" {
+	if selinuxEnabled() && config.EnableSelinuxSupport && driver.String() == "btrfs" {
 		return nil, fmt.Errorf("SELinux is not supported with the BTRFS graph driver!")
 	}
 

--- a/daemon/utils_linux.go
+++ b/daemon/utils_linux.go
@@ -11,3 +11,7 @@ func selinuxSetDisabled() {
 func selinuxFreeLxcContexts(label string) {
 	selinux.FreeLxcContexts(label)
 }
+
+func selinuxEnabled() bool {
+	return selinux.SelinuxEnabled()
+}

--- a/daemon/utils_nolinux.go
+++ b/daemon/utils_nolinux.go
@@ -7,3 +7,7 @@ func selinuxSetDisabled() {
 
 func selinuxFreeLxcContexts(label string) {
 }
+
+func selinuxEnabled() bool {
+	return false
+}


### PR DESCRIPTION
We should ignore it and not block the use of BTRFS.  On Fedora and RHEL we ship selinux-enabled flag in the docker.service config, but if people setup the /var/lib/docker as btrfs and disable SELinux, we should not block the daemon from running.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
