### PR TITLE
Cr

### DIFF
--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -31,6 +31,7 @@ func (d *driver) createContainer(c *execdriver.Command) (*libcontainer.Config, e
 	container.Cgroups.Name = c.ID
 	container.Cgroups.AllowedDevices = c.AllowedDevices
 	container.MountConfig.DeviceNodes = c.AutoCreatedDevices
+	container.RootFs = c.Rootfs
 
 	// check to see if we are running in ramdisk to disable pivot root
 	container.MountConfig.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -100,7 +100,7 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 		return -1, err
 	}
 
-	return namespaces.Exec(container, c.ProcessConfig.Stdin, c.ProcessConfig.Stdout, c.ProcessConfig.Stderr, c.ProcessConfig.Console, c.Rootfs, dataPath, args, func(container *libcontainer.Config, console, rootfs, dataPath, init string, child *os.File, args []string) *exec.Cmd {
+	return namespaces.Exec(container, c.ProcessConfig.Stdin, c.ProcessConfig.Stdout, c.ProcessConfig.Stderr, c.ProcessConfig.Console, dataPath, args, func(container *libcontainer.Config, console, rootfs, dataPath, init string, child *os.File, args []string) *exec.Cmd {
 		c.ProcessConfig.Path = d.initPath
 		c.ProcessConfig.Args = append([]string{
 			DriverName,

--- a/vendor/src/github.com/docker/libcontainer/config.go
+++ b/vendor/src/github.com/docker/libcontainer/config.go
@@ -14,6 +14,9 @@ type Network network.Network
 type Config struct {
 	// Mount specific options.
 	MountConfig *MountConfig `json:"mount_config,omitempty"`
+	
+	// Pathname to container's root filesystem
+	RootFs string `json:"root_fs,omitempty"`
 
 	// Hostname optionally sets the container's hostname if provided
 	Hostname string `json:"hostname,omitempty"`

--- a/vendor/src/github.com/docker/libcontainer/namespaces/exec.go
+++ b/vendor/src/github.com/docker/libcontainer/namespaces/exec.go
@@ -21,7 +21,7 @@ import (
 // Move this to libcontainer package.
 // Exec performs setup outside of a namespace so that a container can be
 // executed.  Exec is a high level function for working with container namespaces.
-func Exec(container *libcontainer.Config, stdin io.Reader, stdout, stderr io.Writer, console string, rootfs, dataPath string, args []string, createCommand CreateCommand, startCallback func()) (int, error) {
+func Exec(container *libcontainer.Config, stdin io.Reader, stdout, stderr io.Writer, console string, dataPath string, args []string, createCommand CreateCommand, startCallback func()) (int, error) {
 	var (
 		err error
 	)
@@ -34,7 +34,7 @@ func Exec(container *libcontainer.Config, stdin io.Reader, stdout, stderr io.Wri
 	}
 	defer syncPipe.Close()
 
-	command := createCommand(container, console, rootfs, dataPath, os.Args[0], syncPipe.Child(), args)
+	command := createCommand(container, console, container.RootFs, dataPath, os.Args[0], syncPipe.Child(), args)
 	// Note: these are only used in non-tty mode
 	// if there is a tty for the container it will be opened within the namespace and the
 	// fds will be duped to stdin, stdiout, and stderr


### PR DESCRIPTION
Add RootFs field to container's Config struct.

The container.json file is currently missing the pathname to the container's root filesystem.  This patch adds a new field to address this issue.  The container's root filesystem pathname is needed for checkpoint and restore operations using external utilities such as criu(8).
