### PR TITLE
Make sure COPY/ADD on dirs doesn't grab too many files

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -293,9 +293,17 @@ func calcCopyInfo(b *Builder, cmdName string, ci *copyInfo, allowRemote bool, al
 			return err
 		} else if fi.IsDir() {
 			var subfiles []string
+			absOrigPath := path.Join(b.contextPath, ci.origPath)
+
+			// Add a trailing / to make sure we only
+			// pick up nested files under the dir and
+			// not sibling files of the dir that just
+			// happen to start with the same chars
+			if !strings.HasSuffix(absOrigPath, "/") {
+				absOrigPath += "/"
+			}
 			for _, fileInfo := range sums {
 				absFile := path.Join(b.contextPath, fileInfo.Name())
-				absOrigPath := path.Join(b.contextPath, ci.origPath)
 				if strings.HasPrefix(absFile, absOrigPath) {
 					subfiles = append(subfiles, fileInfo.Sum())
 				}


### PR DESCRIPTION
While working on #6820 I noticed that the algorithm used to calculate the hash/cache had this line in builder/internals.go - around line 628:

---

```
if strings.HasPrefix(absFile, absOrigPath) {
```

---

which means that if you're asking for a dir called "foo" to be copied, it would also treat a sibling file named "foo_bar" to also be included in the hash calculation.  To fix this I simply added a "/" to the end of the absOrigPath.

To verify this I'm also including a testcase to ensure that adding a new sibling file with a similar name as a the dir doesn't invalidate the cache from a previous build.

I also moved the path.Join() out of the for-loop since its a static value that doesn't change during the loop.

To be honest, I would love to revamp a lot of this code.  I'm very uncomfortable with the idea that we calculate the list of things to copy twice, once for the hash calculation and once during the copy/tar process.  This leaves it very open to the two processes being different and inconsistent.  I would prefer to just calc the total list of files once and use that list during both times but I'll leave that for another PR.  However, I wouldn't mind some feedback on this idea because perhaps I'm missing something.

Signed-off-by: Doug Davis dug@us.ibm.com
