### PR TITLE
builder: properly communicate onbuild trigger information during subsequent builds.

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -377,7 +377,7 @@ func (b *Builder) processImageFrom(img *imagepkg.Image) error {
 	// FIXME rewrite this so that builder/parser is used; right now steps in
 	// onbuild are muted because we have no good way to represent the step
 	// number
-	for _, step := range onBuildTriggers {
+	for stepN, step := range onBuildTriggers {
 		splitStep := strings.Split(step, " ")
 		stepInstruction := strings.ToUpper(strings.Trim(splitStep[0], " "))
 		switch stepInstruction {
@@ -392,6 +392,7 @@ func (b *Builder) processImageFrom(img *imagepkg.Image) error {
 		// longer be necessary.
 
 		if f, ok := evaluateTable[strings.ToLower(stepInstruction)]; ok {
+			fmt.Fprintf(b.OutStream, "Trigger %d, %s\n", stepN, step)
 			if err := f(b, splitStep[1:], nil); err != nil {
 				return err
 			}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2142,3 +2142,25 @@ func TestBuildEmptyCmd(t *testing.T) {
 	}
 	logDone("build - empty cmd")
 }
+
+func TestBuildOnBuildOutput(t *testing.T) {
+	name := "testbuildonbuildparent"
+	defer deleteImages(name)
+	if _, err := buildImage(name, "FROM busybox\nONBUILD RUN echo foo\n", true); err != nil {
+		t.Fatal(err)
+	}
+
+	childname := "testbuildonbuildchild"
+	defer deleteImages(childname)
+
+	_, out, err := buildImageWithOut(name, "FROM "+name+"\nMAINTAINER quux\n", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(out, "Trigger 0, run echo foo") {
+		t.Fatal("failed to find the ONBUILD output")
+	}
+
+	logDone("build - onbuild output")
+}


### PR DESCRIPTION
closes #8078
fixes #8078

/cc @tianon @tiborvass 
