### PR TITLE
integration: lower timeout for stop/restart tests

### DIFF
--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -193,13 +193,13 @@ func TestCreateStartRestartStopStartKillRm(t *testing.T) {
 	}
 
 	job = eng.Job("restart", id)
-	job.SetenvInt("t", 15)
+	job.SetenvInt("t", 2)
 	if err := job.Run(); err != nil {
 		t.Fatal(err)
 	}
 
 	job = eng.Job("stop", id)
-	job.SetenvInt("t", 15)
+	job.SetenvInt("t", 2)
 	if err := job.Run(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR lowers the execution time of the integration test suite by 26 seconds.
