### PR TITLE
Replace get.docker.io -> get.docker.com and test.docker.io -> test.docker.com

### DIFF
--- a/docs/sources/articles/dsc.md
+++ b/docs/sources/articles/dsc.md
@@ -45,7 +45,7 @@ The Docker installation configuration is equivalent to running:
 ```
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys\
 36A1D7869245C8950F966E92D8576A8BA88D21E9
-sh -c "echo deb https://get.docker.io/ubuntu docker main\
+sh -c "echo deb https://get.docker.com/ubuntu docker main\
 > /etc/apt/sources.list.d/docker.list"
 apt-get update
 apt-get install lxc-docker

--- a/docs/sources/installation/amazon.md
+++ b/docs/sources/installation/amazon.md
@@ -32,7 +32,7 @@ course.**
    - When you're on the "Configure Instance Details" step, expand the
      "Advanced Details" section.
    - Under "User data", select "As text".
-   - Enter `#include https://get.docker.io` into
+   - Enter `#include https://get.docker.com` into
      the instance *User Data*.
      [CloudInit](https://help.ubuntu.com/community/CloudInit) is part
      of the Ubuntu image you chose; it will bootstrap Docker by
@@ -46,7 +46,7 @@ Security Group to allow SSH.** By default all incoming ports to your new
 instance will be blocked by the AWS Security Group, so you might just
 get timeouts when you try to connect.
 
-Installing with `get.docker.io` (as above) will
+Installing with `get.docker.com` (as above) will
 create a service named `lxc-docker`. It will also
 set up a [*docker group*](../binaries/#dockergroup) and you may want to
 add the *ubuntu* user to it so that you don't have to use

--- a/docs/sources/installation/binaries.md
+++ b/docs/sources/installation/binaries.md
@@ -46,14 +46,14 @@ Linux kernel (it even builds on OS X!).
 
 ## Get the docker binary:
 
-    $ wget https://get.docker.io/builds/Linux/x86_64/docker-latest -O docker
+    $ wget https://get.docker.com/builds/Linux/x86_64/docker-latest -O docker
     $ chmod +x docker
 
 > **Note**:
 > If you have trouble downloading the binary, you can also get the smaller
 > compressed release file:
-> [https://get.docker.io/builds/Linux/x86_64/docker-latest.tgz](
-> https://get.docker.io/builds/Linux/x86_64/docker-latest.tgz)
+> [https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz](
+> https://get.docker.com/builds/Linux/x86_64/docker-latest.tgz)
 
 ## Run the docker daemon
 

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -59,9 +59,9 @@ which is officially supported by Docker.
         $ sudo apt-get update
         $ sudo apt-get install -t wheezy-backports linux-image-amd64
 
-2. Install Docker using the get.docker.io script:
+2. Install Docker using the get.docker.com script:
  
-    `curl -sSL https://get.docker.io/ | sh`
+    `curl -sSL https://get.docker.com/ | sh`
 
 ## Giving non-root access
 

--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -54,7 +54,7 @@ the `lxc-docker` package.
 *You may receive a warning that the package isn't trusted. Answer yes to
 continue installation.*
 
-    $ sudo sh -c "echo deb https://get.docker.io/ubuntu docker main\
+    $ sudo sh -c "echo deb https://get.docker.com/ubuntu docker main\
     > /etc/apt/sources.list.d/docker.list"
     $ sudo apt-get update
     $ sudo apt-get install lxc-docker
@@ -63,7 +63,7 @@ continue installation.*
 >
 > There is also a simple `curl` script available to help with this process.
 >
->     $ curl -sSL https://get.docker.io/ubuntu/ | sudo sh
+>     $ curl -sSL https://get.docker.com/ubuntu/ | sudo sh
 
 To verify that everything has worked as expected:
 
@@ -134,7 +134,7 @@ the `lxc-docker` package.
 *You may receive a warning that the package isn't trusted. Answer yes to
 continue installation.*
 
-    $ sudo sh -c "echo deb https://get.docker.io/ubuntu docker main\
+    $ sudo sh -c "echo deb https://get.docker.com/ubuntu docker main\
     > /etc/apt/sources.list.d/docker.list"
     $ sudo apt-get update
     $ sudo apt-get install lxc-docker
@@ -143,7 +143,7 @@ continue installation.*
 > 
 > There is also a simple `curl` script available to help with this process.
 > 
->     $ curl -sSL https://get.docker.io/ubuntu/ | sudo sh
+>     $ curl -sSL https://get.docker.com/ubuntu/ | sudo sh
 
 Now verify that the installation has worked by downloading the
 `ubuntu` image and launching a container.
@@ -187,7 +187,7 @@ First add the Docker repository key to your local keychain.
 Add the Docker repository to your apt sources list, update and install
 the `lxc-docker` package.
 
-    $ sudo sh -c "echo deb http://get.docker.io/ubuntu docker main\
+    $ sudo sh -c "echo deb http://get.docker.com/ubuntu docker main\
     > /etc/apt/sources.list.d/docker.list"
     $ sudo apt-get update
     $ sudo apt-get install lxc-docker
@@ -356,7 +356,7 @@ NetworkManager and Docker need to be restarted afterwards:
 
 ## Mirrors
 
-You should `ping get.docker.io` and compare the
+You should `ping get.docker.com` and compare the
 latency to the following mirrors, and pick whichever one is best for
 you.
 
@@ -365,7 +365,7 @@ you.
 [Yandex](http://yandex.ru/) in Russia is mirroring the Docker Debian
 packages, updating every 6 hours.
 Substitute `http://mirror.yandex.ru/mirrors/docker/` for
-`http://get.docker.io/ubuntu` in the instructions above.
+`http://get.docker.com/ubuntu` in the instructions above.
 For example:
 
     $ sudo sh -c "echo deb http://mirror.yandex.ru/mirrors/docker/ docker main\

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1191,8 +1191,8 @@ folder before starting your container.
     $ sudo docker run -t -i -v /var/run/docker.sock:/var/run/docker.sock -v ./static-docker:/usr/bin/docker busybox sh
 
 By bind-mounting the docker unix socket and statically linked docker
-binary (such as that provided by [https://get.docker.io](
-https://get.docker.io)), you give the container the full access to create and
+binary (such as that provided by [https://get.docker.com](
+https://get.docker.com)), you give the container the full access to create and
 manipulate the host's docker daemon.
 
     $ sudo docker run -p 127.0.0.1:80:8080 ubuntu bash

--- a/hack/RELEASE-CHECKLIST.md
+++ b/hack/RELEASE-CHECKLIST.md
@@ -173,7 +173,7 @@ Replace "..." with the respective credentials:
 ```bash
 docker build -t docker .
 docker run \
-       -e AWS_S3_BUCKET=test.docker.io \
+       -e AWS_S3_BUCKET=test.docker.com \
        -e AWS_ACCESS_KEY="..." \
        -e AWS_SECRET_KEY="..." \
        -e GPG_PASSPHRASE="..." \
@@ -183,11 +183,11 @@ docker run \
 ```
 
 It will run the test suite, build the binaries and packages,
-and upload to the specified bucket (you should use test.docker.io for
-general testing, and once everything is fine, switch to get.docker.io as
+and upload to the specified bucket (you should use test.docker.com for
+general testing, and once everything is fine, switch to get.docker.com as
 noted below).
 
-After the binaries and packages are uploaded to test.docker.io, make sure
+After the binaries and packages are uploaded to test.docker.com, make sure
 they get tested in both Ubuntu and Debian for any obvious installation
 issues or runtime issues.
 
@@ -195,19 +195,19 @@ Announcing on IRC in both `#docker` and `#docker-dev` is a great way to get
 help testing!  An easy way to get some useful links for sharing:
 
 ```bash
-echo "Ubuntu/Debian: https://test.docker.io/ubuntu or curl -sSL https://test.docker.io/ | sh"
-echo "Linux 64bit binary: https://test.docker.io/builds/Linux/x86_64/docker-${VERSION#v}"
-echo "Darwin/OSX 64bit client binary: https://test.docker.io/builds/Darwin/x86_64/docker-${VERSION#v}"
-echo "Darwin/OSX 32bit client binary: https://test.docker.io/builds/Darwin/i386/docker-${VERSION#v}"
-echo "Linux 64bit tgz: https://test.docker.io/builds/Linux/x86_64/docker-${VERSION#v}.tgz"
+echo "Ubuntu/Debian: https://test.docker.com/ubuntu or curl -sSL https://test.docker.com/ | sh"
+echo "Linux 64bit binary: https://test.docker.com/builds/Linux/x86_64/docker-${VERSION#v}"
+echo "Darwin/OSX 64bit client binary: https://test.docker.com/builds/Darwin/x86_64/docker-${VERSION#v}"
+echo "Darwin/OSX 32bit client binary: https://test.docker.com/builds/Darwin/i386/docker-${VERSION#v}"
+echo "Linux 64bit tgz: https://test.docker.com/builds/Linux/x86_64/docker-${VERSION#v}.tgz"
 ```
 
 Once they're tested and reasonably believed to be working, run against
-get.docker.io:
+get.docker.com:
 
 ```bash
 docker run \
-       -e AWS_S3_BUCKET=get.docker.io \
+       -e AWS_S3_BUCKET=get.docker.com \
        -e AWS_ACCESS_KEY="..." \
        -e AWS_SECRET_KEY="..." \
        -e GPG_PASSPHRASE="..." \
@@ -235,7 +235,7 @@ documented and give appropriate warnings.
 ### 9. Apply tag
 
 It's very important that we don't make the tag until after the official
-release is uploaded to get.docker.io!
+release is uploaded to get.docker.com!
 
 ```bash
 git tag -a $VERSION -m $VERSION bump_$VERSION

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -2,19 +2,19 @@
 set -e
 #
 # This script is meant for quick & easy install via:
-#   'curl -sSL https://get.docker.io/ | sh'
+#   'curl -sSL https://get.docker.com/ | sh'
 # or:
-#   'wget -qO- https://get.docker.io/ | sh'
+#   'wget -qO- https://get.docker.com/ | sh'
 #
 #
 # Docker Maintainers:
-#   To update this script on https://get.docker.io,
+#   To update this script on https://get.docker.com,
 #   use hack/release.sh during a normal release,
 #   or the following one-liner for script hotfixes:
-#     s3cmd put --acl-public -P hack/install.sh s3://get.docker.io/index
+#     s3cmd put --acl-public -P hack/install.sh s3://get.docker.com/index
 #
 
-url='https://get.docker.io/'
+url='https://get.docker.com/'
 
 command_exists() {
 	command -v "$@" > /dev/null 2>&1
@@ -149,9 +149,9 @@ case "$lsb_dist" in
 		fi
 		(
 			set -x
-			if [ "https://get.docker.io/" = "$url" ]; then
+			if [ "https://get.docker.com/" = "$url" ]; then
 				$sh_c "apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
-			elif [ "https://test.docker.io/" = "$url" ]; then
+			elif [ "https://test.docker.com/" = "$url" ]; then
 				$sh_c "apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 740B314AE3941731B942C66ADF4FD13717AAD7D6"
 			else
 				$sh_c "$curl ${url}gpg | apt-key add -"
@@ -179,7 +179,7 @@ case "$lsb_dist" in
 		;;
 
 	Gentoo)
-		if [ "$url" = "https://test.docker.io/" ]; then
+		if [ "$url" = "https://test.docker.com/" ]; then
 			echo >&2
 			echo >&2 '  You appear to be trying to install the latest nightly build in Gentoo.'
 			echo >&2 '  The portage tree should contain the latest stable release of Docker, but'

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -27,10 +27,10 @@ To run, I need:
 - a generous amount of good will and nice manners.
 The canonical way to run me is to run the image produced by the Dockerfile: e.g.:"
 
-docker run -e AWS_S3_BUCKET=get-staging.docker.io \
-           -e AWS_ACCESS_KEY=AKI1234... \
-           -e AWS_SECRET_KEY=sEs4mE... \
-           -e GPG_PASSPHRASE=m0resEs4mE... \
+docker run -e AWS_S3_BUCKET=test.docker.com \
+           -e AWS_ACCESS_KEY=... \
+           -e AWS_SECRET_KEY=... \
+           -e GPG_PASSPHRASE=... \
            -i -t --privileged \
            docker ./hack/release.sh
 EOF
@@ -64,9 +64,9 @@ VERSION=$(cat VERSION)
 BUCKET=$AWS_S3_BUCKET
 
 # These are the 2 keys we've used to sign the deb's
-#   release (get.docker.io)
+#   release (get.docker.com)
 #	GPG_KEY="36A1D7869245C8950F966E92D8576A8BA88D21E9"
-#   test    (test.docker.io)
+#   test    (test.docker.com)
 #	GPG_KEY="740B314AE3941731B942C66ADF4FD13717AAD7D6"
 
 setup_s3() {
@@ -92,7 +92,7 @@ write_to_s3() {
 
 s3_url() {
 	case "$BUCKET" in
-		get.docker.io|test.docker.io)
+		get.docker.com|test.docker.com)
 			echo "https://$BUCKET"
 			;;
 		*)
@@ -344,7 +344,7 @@ EOF
 
 # Upload the index script
 release_index() {
-	sed "s,url='https://get.docker.io/',url='$(s3_url)/'," hack/install.sh | write_to_s3 s3://$BUCKET/index
+	sed "s,url='https://get.docker.com/',url='$(s3_url)/'," hack/install.sh | write_to_s3 s3://$BUCKET/index
 }
 
 release_test() {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -243,14 +243,14 @@ func TestValidRepositoryName(t *testing.T) {
 }
 
 func TestTrustedLocation(t *testing.T) {
-	for _, url := range []string{"http://example.com", "https://example.com:7777", "http://docker.io", "http://test.docker.io", "https://fakedocker.com"} {
+	for _, url := range []string{"http://example.com", "https://example.com:7777", "http://docker.io", "http://test.docker.com", "https://fakedocker.com"} {
 		req, _ := http.NewRequest("GET", url, nil)
 		if trustedLocation(req) == true {
 			t.Fatalf("'%s' shouldn't be detected as a trusted location", url)
 		}
 	}
 
-	for _, url := range []string{"https://docker.io", "https://test.docker.io:80"} {
+	for _, url := range []string{"https://docker.io", "https://test.docker.com:80"} {
 		req, _ := http.NewRequest("GET", url, nil)
 		if trustedLocation(req) == false {
 			t.Fatalf("'%s' should be detected as a trusted location", url)


### PR DESCRIPTION
Signed-off-by: Tibor Vass teabee89@gmail.com

This is in the context of migrating to get.docker.com.

Ping @tianon @crosbymichael @vieux @SvenDowideit @jamtur01 @fredlf 
