### PR TITLE
Allow IPC namespace to be shared between containers or with the host

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -1,10 +1,12 @@
 package daemon
 
 import (
+	"fmt"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/graph"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/runconfig"
+	"github.com/docker/libcontainer/label"
 )
 
 func (daemon *Daemon) ContainerCreate(job *engine.Job) engine.Status {
@@ -80,6 +82,12 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 	if warnings, err = daemon.mergeAndVerifyConfig(config, img); err != nil {
 		return nil, nil, err
 	}
+	if hostConfig != nil && config.SecurityOpt == nil {
+		config.SecurityOpt, err = daemon.GenerateSecurityOpt(hostConfig.IpcMode)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
 	if container, err = daemon.newContainer(name, config, img); err != nil {
 		return nil, nil, err
 	}
@@ -98,4 +106,22 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 		return nil, nil, err
 	}
 	return container, warnings, nil
+}
+
+func (daemon *Daemon) GenerateSecurityOpt(ipcMode runconfig.IpcMode) ([]string, error) {
+	if ipcMode.IsHost() {
+		return label.DisableSecOpt(), nil
+	}
+	if ipcContainer := ipcMode.Container(); ipcContainer != "" {
+		c := daemon.Get(ipcContainer)
+		if c == nil {
+			return nil, fmt.Errorf("no such container to join IPC: %s", ipcContainer)
+		}
+		if !c.IsRunning() {
+			return nil, fmt.Errorf("cannot join IPC of a non running container: %s", ipcContainer)
+		}
+
+		return label.DupSecOpt(c.ProcessLabel), nil
+	}
+	return nil, nil
 }

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -62,6 +62,12 @@ type Network struct {
 	HostNetworking bool              `json:"host_networking"`
 }
 
+// Network settings of the container
+type Ipc struct {
+	ContainerID string `json:"container_id"` // id of the container to join ipc.
+	HostIpc     bool   `json:"host_ipc"`
+}
+
 type NetworkInterface struct {
 	Gateway     string `json:"gateway"`
 	IPAddress   string `json:"ip"`
@@ -106,6 +112,7 @@ type Command struct {
 	WorkingDir         string            `json:"working_dir"`
 	ConfigPath         string            `json:"config_path"` // this should be able to be removed when the lxc template is moved into the driver
 	Network            *Network          `json:"network"`
+	Ipc                *Ipc              `json:"ipc"`
 	Resources          *Resources        `json:"resources"`
 	Mounts             []Mount           `json:"mounts"`
 	AllowedDevices     []*devices.Device `json:"allowed_devices"`

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -36,6 +36,10 @@ func (d *driver) createContainer(c *execdriver.Command) (*libcontainer.Config, e
 	container.MountConfig.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""
 	container.RestrictSys = true
 
+	if err := d.createIpc(container, c); err != nil {
+		return nil, err
+	}
+
 	if err := d.createNetwork(container, c); err != nil {
 		return nil, err
 	}
@@ -119,6 +123,28 @@ func (d *driver) createNetwork(container *libcontainer.Config, c *execdriver.Com
 			Type:   "netns",
 			NsPath: nspath,
 		})
+	}
+
+	return nil
+}
+
+func (d *driver) createIpc(container *libcontainer.Config, c *execdriver.Command) error {
+	if c.Ipc.HostIpc {
+		container.Namespaces["NEWIPC"] = false
+		return nil
+	}
+
+	if c.Ipc.ContainerID != "" {
+		d.Lock()
+		active := d.activeContainers[c.Ipc.ContainerID]
+		d.Unlock()
+
+		if active == nil || active.cmd.Process == nil {
+			return fmt.Errorf("%s is not a valid running container to join", c.Ipc.ContainerID)
+		}
+		cmd := active.cmd
+
+		container.IpcNsPath = filepath.Join("/proc", fmt.Sprint(cmd.Process.Pid), "ns", "ipc")
 	}
 
 	return nil

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -23,6 +23,7 @@ docker-run - Run a command in a new container
 [**--expose**[=*[]*]]
 [**-h**|**--hostname**[=*HOSTNAME*]]
 [**-i**|**--interactive**[=*false*]]
+[**--ipc**[=*[]*]]
 [**--security-opt**[=*[]*]]
 [**--link**[=*[]*]]
 [**--lxc-conf**[=*[]*]]
@@ -145,6 +146,12 @@ container can be started with the **--link**.
 **-i**, **--interactive**=*true*|*false*
    When set to true, keep stdin open even if not attached. The default is false.
 
+**--ipc**=[]
+   Set the IPC mode for the container
+     **container**:<*name*|*id*>: reuses another container's IPC stack
+     **host**: use the host IPC stack inside the container.  
+     Note: the host mode gives the container full access to local IPC and is therefore considered insecure.
+
 **--security-opt**=*secdriver*:*name*:*value*
     "label:user:USER"   : Set the label user for the container
     "label:role:ROLE"   : Set the label role for the container
@@ -186,10 +193,11 @@ and foreground Docker containers.
 
 **--net**="bridge"
    Set the Network mode for the container
-                               'bridge': creates a new network stack for the container on the docker bridge
-                               'none': no networking for this container
-                               'container:<name|id>': reuses another container network stack
-                               'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+   **bridge**: creates a new network stack for the container on the docker bridge
+   **none**: no networking for this container
+   **container**:<*name*|*id*>: reuses another container's network stack
+   **host**: use the host network stack inside the container.  
+   Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
 
 **-P**, **--publish-all**=*true*|*false*
    When set to true publish all exposed ports to the host interfaces. The
@@ -304,6 +312,64 @@ If you do not specify -a then Docker will attach everything (stdin,stdout,stderr
 you’d like to connect instead, as in:
 
     # docker run -a stdin -a stdout -i -t fedora /bin/bash
+
+## Sharing IPC between containers
+
+Using shm_server.c available here: http://www.cs.cf.ac.uk/Dave/C/node27.html
+
+Testing --ipc=host mode:
+
+Host shows a shared memory segment with 7 pids attached, happens to be from httpd:
+
+ # ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+ 0x01128e25 0          root       600        1000       7                       
+
+
+Now run a regular container, and it correctly does NOT see the shared memory segment from the host:
+
+ # docker run -it shm ipcs -m
+
+ ------ Shared Memory Segments --------	
+ key        shmid      owner      perms      bytes      nattch     status      
+
+Run a container with the new --ipc=host option, and it now sees the shared memory segment from the host httpd:
+
+ # docker run -it --ipc=host shm ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+ 0x01128e25 0          root       600        1000       7                   
+
+Testing --ipc=container:CONTAINERID mode:
+
+Start a container with a program to create a shared memory segment:
+
+ # docker run -it shm bash
+ # shm/shm_server &
+ # ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+ 0x0000162e 0          root       666        27         1                       
+
+Create a 2nd container correctly shows no shared memory segment from 1st container:
+
+ # docker run shm ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+
+Create a 3rd container using the new --ipc=container:CONTAINERID option, now it shows the shared memory segment from the first:
+
+ # docker run -it --ipc=container:ed735b2264ac shm ipcs -m
+ # ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+ 0x0000162e 0          root       666        27         1
 
 ## Linking Containers
 

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -50,6 +50,7 @@ following options.
  - [Container Identification](#container-identification)
      - [Name (--name)](#name-name)
      - [PID Equivalent](#pid-equivalent)
+ - [IPC Settings](#ipc-settings)
  - [Network Settings](#network-settings)
  - [Clean Up (--rm)](#clean-up-rm)
  - [Runtime Constraints on CPU and Memory](#runtime-constraints-on-cpu-and-memory)
@@ -131,13 +132,25 @@ While not strictly a means of identifying a container, you can specify a version
 image you'd like to run the container with by adding `image[:tag]` to the command. For
 example, `docker run ubuntu:14.04`.
 
-## Network settings
+## IPC Settings
+    --ipc=""  : Set the IPC mode for the container,
+                                 'container:<name|id>': reuses another container's IPC stack
+                                 'host': use the host IPC stack inside the container
+By default, all containers have IPC enabled 
+
+Shared memory segments are used to accelerate inter-process communication at memory speed, rather than through 
+pipes or through the network stack. Shared memory is commonly used by databases and custom-built (typically C/OpenMPI, 
+C++/using boost libraries) high performance applications for scientific computing and financial services industries.
+If these types of applications are broken into multiple containers, you might need to share the IPC mechansims of the 
+containers.
+
+## Network Settings
 
     --dns=[]        : Set custom dns servers for the container
     --net="bridge"  : Set the Network mode for the container
                                  'bridge': creates a new network stack for the container on the docker bridge
                                  'none': no networking for this container
-                                 'container:<name|id>': reuses another container network stack
+                                 'container:<name|id>': reuses another container's network stack
                                  'host': use the host network stack inside the container
     --add-host=""   : Add a line to /etc/hosts (host:IP)
 

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -59,6 +59,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.")
+		flIpcMode         = cmd.String([]string{"-ipc"}, "", "Default it to createa private IPC namespace for the container\n'container:<name|id>': reuses another container shared memory\n'host': use the host shared memory inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.")
 		flRestartPolicy   = cmd.String([]string{"-restart"}, "", "Restart policy to apply when a container exits (no, on-failure[:max-retry], always)")
 	)
 
@@ -225,6 +226,11 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 	// parse the '-e' and '--env' after, to allow override
 	envVariables = append(envVariables, flEnv.GetAll()...)
 
+	ipcMode, err := parseIpcMode(*flIpcMode)
+	if err != nil {
+		return nil, nil, cmd, fmt.Errorf("--ipc: invalid IPC mode: %v", err)
+	}
+
 	netMode, err := parseNetMode(*flNetMode)
 	if err != nil {
 		return nil, nil, cmd, fmt.Errorf("--net: invalid net mode: %v", err)
@@ -272,6 +278,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		ExtraHosts:      flExtraHosts.GetAll(),
 		VolumesFrom:     flVolumesFrom.GetAll(),
 		NetworkMode:     netMode,
+		IpcMode:         ipcMode,
 		Devices:         deviceMappings,
 		CapAdd:          flCapAdd.GetAll(),
 		CapDrop:         flCapDrop.GetAll(),
@@ -359,6 +366,20 @@ func parseKeyValueOpts(opts opts.ListOpts) ([]utils.KeyValuePair, error) {
 		out[i] = utils.KeyValuePair{Key: k, Value: v}
 	}
 	return out, nil
+}
+
+func parseIpcMode(ipcMode string) (IpcMode, error) {
+	parts := strings.Split(ipcMode, ":")
+	switch mode := parts[0]; mode {
+	case "", "host":
+	case "container":
+		if len(parts) < 2 || parts[1] == "" {
+			return "", fmt.Errorf("invalid container format container:<name|id>")
+		}
+	default:
+		return "", fmt.Errorf("invalid --ipc: %s", ipcMode)
+	}
+	return IpcMode(ipcMode), nil
 }
 
 func parseNetMode(netMode string) (NetworkMode, error) {

--- a/vendor/src/github.com/docker/libcontainer/config.go
+++ b/vendor/src/github.com/docker/libcontainer/config.go
@@ -47,6 +47,9 @@ type Config struct {
 	// Networks specifies the container's network setup to be created
 	Networks []*Network `json:"networks,omitempty"`
 
+	// Ipc specifies the container's ipc setup to be created
+	IpcNsPath string `json:"ipc,omitempty"`
+
 	// Routes can be specified to create entries in the route table as the container is started
 	Routes []*Route `json:"routes,omitempty"`
 

--- a/vendor/src/github.com/docker/libcontainer/ipc/ipc.go
+++ b/vendor/src/github.com/docker/libcontainer/ipc/ipc.go
@@ -1,0 +1,31 @@
+package ipc
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/docker/libcontainer/system"
+)
+
+// Join the IPC Namespace of specified ipc path if it exists.
+// If the path does not exist then you are not joining a container.
+func Initialize(nsPath string) error {
+
+	if nsPath == "" {
+		return nil
+	}
+	f, err := os.OpenFile(nsPath, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed get IPC namespace fd: %v", err)
+	}
+
+	err = system.Setns(f.Fd(), syscall.CLONE_NEWIPC)
+	f.Close()
+
+	if err != nil {
+		return fmt.Errorf("failed to setns current IPC namespace: %v", err)
+	}
+
+	return nil
+}

--- a/vendor/src/github.com/docker/libcontainer/label/label.go
+++ b/vendor/src/github.com/docker/libcontainer/label/label.go
@@ -43,3 +43,15 @@ func ReserveLabel(label string) error {
 func UnreserveLabel(label string) error {
 	return nil
 }
+
+// DupSecOpt takes an process label and returns security options that
+// can be used to set duplicate labels on future container processes
+func DupSecOpt(src string) []string {
+	return nil
+}
+
+// DisableSecOpt returns a security opt that can disable labeling
+// support for future container processes
+func DisableSecOpt() []string {
+	return nil
+}

--- a/vendor/src/github.com/docker/libcontainer/label/label_selinux.go
+++ b/vendor/src/github.com/docker/libcontainer/label/label_selinux.go
@@ -17,7 +17,6 @@ func InitLabels(options []string) (string, string, error) {
 	if !selinux.SelinuxEnabled() {
 		return "", "", nil
 	}
-	var err error
 	processLabel, mountLabel := selinux.GetLxcContexts()
 	if processLabel != "" {
 		pcon := selinux.NewContext(processLabel)
@@ -38,7 +37,7 @@ func InitLabels(options []string) (string, string, error) {
 		processLabel = pcon.Get()
 		mountLabel = mcon.Get()
 	}
-	return processLabel, mountLabel, err
+	return processLabel, mountLabel, nil
 }
 
 // DEPRECATED: The GenLabels function is only to be used during the transition to the official API.
@@ -129,4 +128,16 @@ func ReserveLabel(label string) error {
 func UnreserveLabel(label string) error {
 	selinux.FreeLxcContexts(label)
 	return nil
+}
+
+// DupSecOpt takes an process label and returns security options that
+// can be used to set duplicate labels on future container processes
+func DupSecOpt(src string) []string {
+	return selinux.DupSecOpt(src)
+}
+
+// DisableSecOpt returns a security opt that can disable labeling
+// support for future container processes
+func DisableSecOpt() []string {
+	return selinux.DisableSecOpt()
 }

--- a/vendor/src/github.com/docker/libcontainer/label/label_selinux_test.go
+++ b/vendor/src/github.com/docker/libcontainer/label/label_selinux_test.go
@@ -33,7 +33,7 @@ func TestInit(t *testing.T) {
 			t.Fatal(err)
 		}
 		if plabel != "user_u:user_r:user_t:s0:c1,c15" || mlabel != "user_u:object_r:svirt_sandbox_file_t:s0:c1,c15" {
-			t.Log("InitLabels User Failed")
+			t.Log("InitLabels User Match Failed")
 			t.Log(plabel, mlabel)
 			t.Fatal(err)
 		}
@@ -44,5 +44,19 @@ func TestInit(t *testing.T) {
 			t.Log("InitLabels Bad Failed")
 			t.Fatal(err)
 		}
+	}
+}
+func TestDuplicateLabel(t *testing.T) {
+	secopt := DupSecOpt("system_u:system_r:svirt_lxc_net_t:s0:c1,c2")
+	t.Log(secopt)
+	if secopt[0] != "label:type:svirt_lxc_net_t" {
+		t.Errorf("DupSecOpt Failed type incorrect")
+	}
+	if secopt[1] != "label:level:s0:c1,c2" {
+		t.Errorf("DupSecOpt Failed level incorrect")
+	}
+	secopt = DisableSecOpt()
+	if secopt[0] != "label:disable" {
+		t.Errorf("DisableSecOpt Failed level incorrect")
 	}
 }

--- a/vendor/src/github.com/docker/libcontainer/namespaces/init.go
+++ b/vendor/src/github.com/docker/libcontainer/namespaces/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/libcontainer"
 	"github.com/docker/libcontainer/apparmor"
 	"github.com/docker/libcontainer/console"
+	"github.com/docker/libcontainer/ipc"
 	"github.com/docker/libcontainer/label"
 	"github.com/docker/libcontainer/mount"
 	"github.com/docker/libcontainer/netlink"
@@ -65,6 +66,9 @@ func Init(container *libcontainer.Config, uncleanRootfs, consolePath string, syn
 		if err := system.Setctty(); err != nil {
 			return fmt.Errorf("setctty %s", err)
 		}
+	}
+	if err := ipc.Initialize(container.IpcNsPath); err != nil {
+		return fmt.Errorf("setup IPC %s", err)
 	}
 	if err := setupNetwork(container, networkState); err != nil {
 		return fmt.Errorf("setup networking %s", err)

--- a/vendor/src/github.com/docker/libcontainer/selinux/selinux.go
+++ b/vendor/src/github.com/docker/libcontainer/selinux/selinux.go
@@ -434,3 +434,22 @@ func Chcon(fpath string, scon string, recurse bool) error {
 
 	return Setfilecon(fpath, scon)
 }
+
+// DupSecOpt takes an SELinux process label and returns security options that
+// can will set the SELinux Type and Level for future container processes
+func DupSecOpt(src string) []string {
+	if src == "" {
+		return nil
+	}
+	con := NewContext(src)
+	if con["type"] == "" || con["level"] == "" {
+		return nil
+	}
+	return []string{"label:type:" + con["type"], "label:level:" + con["level"]}
+}
+
+// DisableSecOpt returns a security opt that can be used to disabling SELinux
+// labeling support for future container processes
+func DisableSecOpt() []string {
+	return []string{"label:disable"}
+}


### PR DESCRIPTION
Some workloads rely on IPC for communications with other processes.  We
would like to split workloads between two container but still allow them
to communicate though shared IPC.

This patch mimics the --net code to allow --ipc=host to not split off
the IPC Namespace.  ipc=container:CONTAINERID to share ipc between containers

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
