### PR TITLE
Add --net=netns:<name> option to use a given netns

### DIFF
--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -69,6 +69,7 @@ type Network struct {
 	Mtu            int               `json:"mtu"`
 	ContainerID    string            `json:"container_id"` // id of the container to join network.
 	HostNetworking bool              `json:"host_networking"`
+	NetNs          string            `json:"netns"` // netns to join
 }
 
 type NetworkInterface struct {

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -121,6 +121,13 @@ func (d *driver) createNetwork(container *libcontainer.Config, c *execdriver.Com
 		})
 	}
 
+	if c.Network.NetNs != "" {
+		container.Networks = append(container.Networks, &libcontainer.Network{
+			Type:   "netns",
+			NsPath: c.Network.NetNs,
+		})
+	}
+
 	return nil
 }
 

--- a/daemon/network_settings.go
+++ b/daemon/network_settings.go
@@ -14,6 +14,7 @@ type NetworkSettings struct {
 	MacAddress  string
 	Gateway     string
 	Bridge      string
+	NetNs       string
 	PortMapping map[string]PortMapping // Deprecated
 	Ports       nat.PortMap
 }

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -105,6 +105,7 @@ docker-create - Create a new container
                                'none': no networking for this container
                                'container:<name|id>': reuses another container network stack
                                'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+                               'netns:<path>': use the specified network namespace
 
 **-P**, **--publish-all**=*true*|*false*
    Publish all exposed ports to the host interfaces. The default is *false*.

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -187,6 +187,7 @@ and foreground Docker containers.
                                'none': no networking for this container
                                'container:<name|id>': reuses another container network stack
                                'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+                               'netns:<path>': use the specified network namespace
 
 **--mac-address**=*macaddress*
    Set the MAC address for the container's Ethernet device:

--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -302,7 +302,8 @@ Return low-level information on the container `id`
                              "IpPrefixLen": 0,
                              "Gateway": "",
                              "Bridge": "",
-                             "PortMapping": null
+                             "PortMapping": null,
+                             "NetNs": ""
                      },
                      "SysInitPath": "/home/kitty/go/src/github.com/docker/docker/bin/docker",
                      "ResolvConfPath": "/etc/resolv.conf",

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -522,6 +522,7 @@ Creates a new container.
                                    'none': no networking for this container
                                    'container:<name|id>': reuses another container network stack
                                    'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+                                   'netns:<path>': use the specified network namespace
       -P, --publish-all=false    Publish all exposed ports to the host interfaces
       -p, --publish=[]           Publish a container's port to the host
                                    format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
@@ -1236,6 +1237,7 @@ removed before the image is removed.
                                    'none': no networking for this container
                                    'container:<name|id>': reuses another container network stack
                                    'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+                                   'netns:<path>': use the specified network namespace
       -P, --publish-all=false    Publish all exposed ports to the host interfaces
       -p, --publish=[]           Publish a container's port to the host
                                    format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -58,7 +58,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		flWorkingDir      = cmd.String([]string{"w", "-workdir"}, "", "Working directory inside the container")
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
-		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.")
+		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the Docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.\n'netns:<path>': use the specified network namespace")
 		flMacAddress      = cmd.String([]string{"-mac-address"}, "", "Container MAC address (e.g. 92:d0:c6:0a:29:33)")
 		flRestartPolicy   = cmd.String([]string{"-restart"}, "", "Restart policy to apply when a container exits (no, on-failure[:max-retry], always)")
 	)
@@ -384,7 +384,11 @@ func parseNetMode(netMode string) (NetworkMode, error) {
 	case "bridge", "none", "host":
 	case "container":
 		if len(parts) < 2 || parts[1] == "" {
-			return "", fmt.Errorf("invalid container format container:<name|id>")
+			return "", fmt.Errorf("Invalid container format container:<name|id>")
+		}
+	case "netns":
+		if len(parts) < 2 || parts[1] == "" {
+			return "", fmt.Errorf("Invalid netns format netns:<path>")
 		}
 	default:
 		return "", fmt.Errorf("invalid --net: %s", netMode)

--- a/runconfig/parse_test.go
+++ b/runconfig/parse_test.go
@@ -58,3 +58,9 @@ func TestNetHostname(t *testing.T) {
 		t.Fatalf("Expected error ErrConflictNetworkHostname, got: %s", err)
 	}
 }
+
+func TestNetNs(t *testing.T) {
+	if _, _, _, err := parseRun([]string{"--net=netns:mynetns", "img", "cmd"}, nil); err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+}


### PR DESCRIPTION
Allow external configuration of a container's network namespace.

Addresses #7455
