### PR TITLE
Fix #7843 start -a can cause frozen term

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -664,7 +664,6 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 	if encounteredError != nil {
 		if *openStdin || *attach {
 			cli.in.Close()
-			<-cErr
 		}
 		return encounteredError
 	}

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// Regression test for https://github.com/docker/docker/issues/7843
+func TestStartAttachReturnsOnError(t *testing.T) {
+	defer deleteAllContainers()
+
+	cmd(t, "run", "-d", "--name", "test", "busybox")
+	cmd(t, "stop", "test")
+
+	// Expect this to fail because the above container is stopped, this is what we want
+	if _, err := runCommand(exec.Command(dockerBinary, "run", "-d", "--name", "test2", "--link", "test:test", "busybox")); err == nil {
+		t.Fatal("Expected error but got none")
+	}
+
+	ch := make(chan struct{})
+	go func() {
+		// Attempt to start attached to the container that won't start
+		// This should return an error immediately since the container can't be started
+		if _, err := runCommand(exec.Command(dockerBinary, "start", "-a", "test2")); err == nil {
+			t.Fatal("Expected error but got none")
+		}
+		close(ch)
+	}()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatalf("Attach did not exit properly")
+	}
+
+	logDone("start - error on start with attach exits")
+}


### PR DESCRIPTION
When doing `docker start -a` on a container that won't start, terminal
was getting stuck on the attach, even after container removal.

Fixes #7843
Docker-DCO-1.1-Signed-off-by: Brian Goff cpuguy83@gmail.com (github: cpuguy83)
