### PR TITLE
devmapper: include dm_deps information in debug

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -771,9 +771,14 @@ func (devices *DeviceSet) deactivatePool() error {
 	log.Debugf("[devmapper] deactivatePool()")
 	defer log.Debugf("[devmapper] deactivatePool END")
 	devname := devices.getPoolDevName()
+
 	devinfo, err := getInfo(devname)
 	if err != nil {
 		return err
+	}
+	if d, err := getDeps(devname); err == nil {
+		// Access to more Debug output
+		log.Debugf("[devmapper] getDeps() %s: %#v", devname, d)
 	}
 	if devinfo.Exists != 0 {
 		return removeDevice(devname)

--- a/daemon/graphdriver/devmapper/devmapper_test.go
+++ b/daemon/graphdriver/devmapper/devmapper_test.go
@@ -3,8 +3,9 @@
 package devmapper
 
 import (
-	"github.com/docker/docker/daemon/graphdriver/graphtest"
 	"testing"
+
+	"github.com/docker/docker/daemon/graphdriver/graphtest"
 )
 
 func init() {

--- a/daemon/graphdriver/devmapper/devmapper_wrapper.go
+++ b/daemon/graphdriver/devmapper/devmapper_wrapper.go
@@ -38,9 +38,7 @@ static void	log_with_errno_init()
 */
 import "C"
 
-import (
-	"unsafe"
-)
+import "unsafe"
 
 type (
 	CDmTask C.struct_dm_task
@@ -92,6 +90,7 @@ var (
 	DmTaskAddTarget        = dmTaskAddTargetFct
 	DmTaskCreate           = dmTaskCreateFct
 	DmTaskDestroy          = dmTaskDestroyFct
+	DmTaskGetDeps          = dmTaskGetDepsFct
 	DmTaskGetInfo          = dmTaskGetInfoFct
 	DmTaskGetDriverVersion = dmTaskGetDriverVersionFct
 	DmTaskRun              = dmTaskRunFct
@@ -166,6 +165,21 @@ func dmTaskAddTargetFct(task *CDmTask,
 	defer free(Cparams)
 
 	return int(C.dm_task_add_target((*C.struct_dm_task)(task), C.uint64_t(start), C.uint64_t(size), Cttype, Cparams))
+}
+
+func dmTaskGetDepsFct(task *CDmTask) *Deps {
+	Cdeps := C.dm_task_get_deps((*C.struct_dm_task)(task))
+	if Cdeps == nil {
+		return nil
+	}
+	deps := &Deps{
+		Count:  uint32(Cdeps.count),
+		Filler: uint32(Cdeps.filler),
+	}
+	for _, device := range Cdeps.device {
+		deps.Device = append(deps.Device, (uint64)(device))
+	}
+	return deps
 }
 
 func dmTaskGetInfoFct(task *CDmTask, info *Info) int {


### PR DESCRIPTION
Enabling more devmapper information to determine device dependencies.

Signed-off-by: Vincent Batts vbatts@redhat.com
