### PR TITLE
tarsum: fix panic with dynamic buffer

### DIFF
--- a/pkg/tarsum/tarsum.go
+++ b/pkg/tarsum/tarsum.go
@@ -179,7 +179,7 @@ func (ts *tarSum) Read(buf []byte) (int, error) {
 	if ts.finished {
 		return ts.bufWriter.Read(buf)
 	}
-	if ts.bufData == nil {
+	if len(ts.bufData) < len(buf) {
 		switch {
 		case len(buf) <= buf8K:
 			ts.bufData = make([]byte, buf8K)
@@ -191,7 +191,7 @@ func (ts *tarSum) Read(buf []byte) (int, error) {
 			ts.bufData = make([]byte, len(buf))
 		}
 	}
-	buf2 := ts.bufData[:len(buf)-1]
+	buf2 := ts.bufData[:len(buf)]
 
 	n, err := ts.tarR.Read(buf2)
 	if err != nil {

--- a/pkg/tarsum/tarsum_test.go
+++ b/pkg/tarsum/tarsum_test.go
@@ -274,6 +274,22 @@ func TestTarSums(t *testing.T) {
 			t.Errorf("%q :: %q", err, layer.filename)
 			continue
 		}
+
+		// Read variable number of bytes to test dynamic buffer
+		dBuf := make([]byte, 1)
+		_, err = ts.Read(dBuf)
+		if err != nil {
+			t.Errorf("failed to read 1B from %s: %s", layer.filename, err)
+			continue
+		}
+		dBuf = make([]byte, 16*1024)
+		_, err = ts.Read(dBuf)
+		if err != nil {
+			t.Errorf("failed to read 16KB from %s: %s", layer.filename, err)
+			continue
+		}
+
+		// Read and discard remaining bytes
 		_, err = io.Copy(ioutil.Discard, ts)
 		if err != nil {
 			t.Errorf("failed to copy from %s: %s", layer.filename, err)


### PR DESCRIPTION
When read is called on a tarsum with a two different read sizes, specifically the second call larger than the first, the dynamic buffer does not get reallocated causing a slice read error.
