### PR TITLE
hack: TIMEOUT (for controlling test timeout) and forwarding of BUILDFLAGS to binary/dynbinary.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ DOCKER_IMAGE := docker$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 DOCKER_DOCS_IMAGE := docker-docs$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 DOCKER_MOUNT := $(if $(BINDDIR),-v "$(CURDIR)/$(BINDDIR):/go/src/github.com/docker/docker/$(BINDDIR)")
 
-DOCKER_RUN_DOCKER := docker run --rm -it --privileged -e TESTFLAGS -e TESTDIRS -e DOCKER_GRAPHDRIVER -e DOCKER_EXECDRIVER $(DOCKER_MOUNT) "$(DOCKER_IMAGE)"
+DOCKER_RUN_DOCKER := docker run --rm -it --privileged -e TIMEOUT -e BUILDFLAGS -e TESTFLAGS -e TESTDIRS -e DOCKER_GRAPHDRIVER -e DOCKER_EXECDRIVER $(DOCKER_MOUNT) "$(DOCKER_IMAGE)"
 # to allow `make DOCSDIR=docs docs-shell`
 DOCKER_RUN_DOCS := docker run --rm -it $(if $(DOCSDIR),-v $(CURDIR)/$(DOCSDIR):/$(DOCSDIR)) -e AWS_S3_BUCKET
 

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -102,7 +102,13 @@ LDFLAGS='
 '
 LDFLAGS_STATIC='-linkmode external'
 EXTLDFLAGS_STATIC='-static'
-BUILDFLAGS=( -a -tags "netgo static_build $DOCKER_BUILDTAGS" )
+# ORIG_BUILDFLAGS is necessary for the cross target which cannot always build
+# with options like -race.
+ORIG_BUILDFLAGS=( -a -tags "netgo static_build $DOCKER_BUILDTAGS" )
+BUILDFLAGS=( $BUILDFLAGS "${ORIG_BUILDFLAGS[@]}" )
+# Test timeout.
+: ${TIMEOUT:=30m}
+TESTFLAGS+=" -test.timeout=${TIMEOUT}"
 
 # A few more flags that are specific just to building a completely-static binary (see hack/make/binary)
 # PLEASE do not use these anywhere else.

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -26,7 +26,7 @@ for platform in $DOCKER_CROSSPLATFORMS; do
 		export GOARCH=${platform##*/}
 		if [ -z "${daemonSupporting[$platform]}" ]; then
 			export LDFLAGS_STATIC_DOCKER="" # we just need a simple client for these platforms
-			export BUILDFLAGS=( "${BUILDFLAGS[@]/ daemon/}" ) # remove the "daemon" build tag from platforms that aren't supported
+			export BUILDFLAGS=( "${ORIG_BUILDFLAGS[@]/ daemon/}" ) # remove the "daemon" build tag from platforms that aren't supported
 		fi
 		source "$(dirname "$BASH_SOURCE")/binary" "$DEST/$platform"
 	)


### PR DESCRIPTION
BUILDFLAGS is automatically appended with ORIG_BUILDFLAGS (see comments) so you can just specify what you want. Removing parts of ORIG_BUILDFLAGS is an exercise for the reader.

Note that BUILDFLAGS=-race cannot be used with `make cross` reliably, so I don't use it there and forward ORIG_BUILDFLAGS instead.

already found a few races with BUILDFLAGS=-race. :)

/cc @tianon @tiborvass 
