### PR TITLE
devmapper: include the version in `info`

### DIFF
--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -63,6 +63,9 @@ func (d *Driver) Status() [][2]string {
 		{"Metadata Space Used", fmt.Sprintf("%s", units.HumanSize(int64(s.Metadata.Used)))},
 		{"Metadata Space Total", fmt.Sprintf("%s", units.HumanSize(int64(s.Metadata.Total)))},
 	}
+	if vStr, err := GetLibraryVersion(); err == nil {
+		status = append(status, [2]string{"Library Version", vStr})
+	}
 	return status
 }
 


### PR DESCRIPTION
Information for the information gods

```
Containers: 0
Images: 36
Storage Driver: devicemapper
 Pool Name: docker-253:6-131075-pool
 Pool Blocksize: 65.54 kB
 Data file: /home/docker/devicemapper/devicemapper/data
 Metadata file: /home/docker/devicemapper/devicemapper/metadata
 Data Space Used: 1.72 GB
 Data Space Total: 107.4 GB
 Metadata Space Used: 2.732 MB
 Metadata Space Total: 2.147 GB
 Library Version: 1.02.79 (2013-08-13)
Execution Driver: native-0.2
Kernel Version: 3.14.18
Operating System: Slackware 14.1
Debug mode (server): true
Debug mode (client): false
Fds: 10
Goroutines: 9
EventsListeners: 0
Init SHA1: 0f8b72ff80ecfc8ac1d4e036e45f25578fada83e
Init Path: /home/vbatts/src/docker/docker/bundles/1.2.0-dev/dynbinary/dockerinit
```
