### PR TITLE
API: Provide the HostConfig during "run".

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -173,7 +173,7 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowDecomp
 		return nil
 	}
 
-	container, _, err := b.Daemon.Create(b.Config, "")
+	container, _, err := b.Daemon.Create(b.Config, nil, "")
 	if err != nil {
 		return err
 	}
@@ -442,7 +442,7 @@ func (b *Builder) create() (*daemon.Container, error) {
 	config := *b.Config
 
 	// Create the container
-	c, warnings, err := b.Daemon.Create(b.Config, "")
+	c, warnings, err := b.Daemon.Create(b.Config, nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -27,6 +27,8 @@ func (daemon *Daemon) ContainerStart(job *engine.Job) engine.Status {
 	}
 
 	// If no environment was set, then no hostconfig was passed.
+	// This is kept for backward compatibility - hostconfig should be passed when
+	// creating a container, not during start.
 	if len(job.Environ()) > 0 {
 		hostConfig := runconfig.ContainerHostConfigFromJob(job)
 		if err := daemon.setHostConfig(container, hostConfig); err != nil {

--- a/integration/container_test.go
+++ b/integration/container_test.go
@@ -18,6 +18,7 @@ func TestRestartStdin(t *testing.T) {
 
 		OpenStdin: true,
 	},
+		&runconfig.HostConfig{},
 		"",
 	)
 	if err != nil {
@@ -94,6 +95,7 @@ func TestStdin(t *testing.T) {
 
 		OpenStdin: true,
 	},
+		&runconfig.HostConfig{},
 		"",
 	)
 	if err != nil {
@@ -139,6 +141,7 @@ func TestTty(t *testing.T) {
 
 		OpenStdin: true,
 	},
+		&runconfig.HostConfig{},
 		"",
 	)
 	if err != nil {
@@ -183,6 +186,7 @@ func BenchmarkRunSequential(b *testing.B) {
 			Image: GetTestImage(daemon).ID,
 			Cmd:   []string{"echo", "-n", "foo"},
 		},
+			&runconfig.HostConfig{},
 			"",
 		)
 		if err != nil {
@@ -216,6 +220,7 @@ func BenchmarkRunParallel(b *testing.B) {
 				Image: GetTestImage(daemon).ID,
 				Cmd:   []string{"echo", "-n", "foo"},
 			},
+				&runconfig.HostConfig{},
 				"",
 			)
 			if err != nil {

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -266,6 +266,7 @@ func TestDaemonCreate(t *testing.T) {
 		Image: GetTestImage(daemon).ID,
 		Cmd:   []string{"ls", "-al"},
 	},
+		&runconfig.HostConfig{},
 		"",
 	)
 	if err != nil {
@@ -309,14 +310,15 @@ func TestDaemonCreate(t *testing.T) {
 			Image: GetTestImage(daemon).ID,
 			Cmd:   []string{"ls", "-al"},
 		},
+		&runconfig.HostConfig{},
 		"conflictname",
 	)
-	if _, _, err := daemon.Create(&runconfig.Config{Image: GetTestImage(daemon).ID, Cmd: []string{"ls", "-al"}}, testContainer.Name); err == nil || !strings.Contains(err.Error(), utils.TruncateID(testContainer.ID)) {
+	if _, _, err := daemon.Create(&runconfig.Config{Image: GetTestImage(daemon).ID, Cmd: []string{"ls", "-al"}}, &runconfig.HostConfig{}, testContainer.Name); err == nil || !strings.Contains(err.Error(), utils.TruncateID(testContainer.ID)) {
 		t.Fatalf("Name conflict error doesn't include the correct short id. Message was: %s", err.Error())
 	}
 
 	// Make sure create with bad parameters returns an error
-	if _, _, err = daemon.Create(&runconfig.Config{Image: GetTestImage(daemon).ID}, ""); err == nil {
+	if _, _, err = daemon.Create(&runconfig.Config{Image: GetTestImage(daemon).ID}, &runconfig.HostConfig{}, ""); err == nil {
 		t.Fatal("Builder.Create should throw an error when Cmd is missing")
 	}
 
@@ -325,6 +327,7 @@ func TestDaemonCreate(t *testing.T) {
 			Image: GetTestImage(daemon).ID,
 			Cmd:   []string{},
 		},
+		&runconfig.HostConfig{},
 		"",
 	); err == nil {
 		t.Fatal("Builder.Create should throw an error when Cmd is empty")
@@ -335,7 +338,7 @@ func TestDaemonCreate(t *testing.T) {
 		Cmd:       []string{"/bin/ls"},
 		PortSpecs: []string{"80"},
 	}
-	container, _, err = daemon.Create(config, "")
+	container, _, err = daemon.Create(config, &runconfig.HostConfig{}, "")
 
 	_, err = daemon.Commit(container, "testrepo", "testtag", "", "", true, config)
 	if err != nil {
@@ -348,6 +351,7 @@ func TestDaemonCreate(t *testing.T) {
 		Cmd:       []string{"ls", "-al"},
 		PortSpecs: []string{"80:8000"},
 	},
+		&runconfig.HostConfig{},
 		"",
 	)
 	if err != nil {
@@ -365,7 +369,9 @@ func TestDestroy(t *testing.T) {
 	container, _, err := daemon.Create(&runconfig.Config{
 		Image: GetTestImage(daemon).ID,
 		Cmd:   []string{"ls", "-al"},
-	}, "")
+	},
+		&runconfig.HostConfig{},
+		"")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -857,7 +863,9 @@ func TestDestroyWithInitLayer(t *testing.T) {
 	container, _, err := daemon.Create(&runconfig.Config{
 		Image: GetTestImage(daemon).ID,
 		Cmd:   []string{"ls", "-al"},
-	}, "")
+	},
+		&runconfig.HostConfig{},
+		"")
 
 	if err != nil {
 		t.Fatal(err)

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -263,7 +263,7 @@ func mkContainer(r *daemon.Daemon, args []string, t *testing.T) (*daemon.Contain
 	if config.Image == "_" {
 		config.Image = GetTestImage(r).ID
 	}
-	c, _, err := r.Create(config, "")
+	c, _, err := r.Create(config, nil, "")
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Currently, the HostConfig is only passed from the CLI to Docker only
when issuing a docker create, but not when doing a docker run.

In the near future, in order to allocate ports at creation time rather
than start time, we will need to have the HostConfig readily available
at container creation.

This PR makes the client always pass the HostConfig when creating a
container (regardless of whether it's for a run or create).

Signed-off-by: Andrea Luzzardi aluzzardi@gmail.com
