### PR TITLE
Fix #8259 - Can't reuse symlink'd bindmount

### DIFF
--- a/volumes/repository.go
+++ b/volumes/repository.go
@@ -97,12 +97,16 @@ func (r *Repository) restore() error {
 
 func (r *Repository) Get(path string) *Volume {
 	r.lock.Lock()
-	vol := r.volumes[path]
+	vol := r.get(path)
 	r.lock.Unlock()
 	return vol
 }
 
 func (r *Repository) get(path string) *Volume {
+	path, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return nil
+	}
 	return r.volumes[path]
 }
 
@@ -129,6 +133,10 @@ func (r *Repository) remove(volume *Volume) {
 func (r *Repository) Delete(path string) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
+	path, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return err
+	}
 	volume := r.get(path)
 	if volume == nil {
 		return fmt.Errorf("Volume %s does not exist", path)


### PR DESCRIPTION
Fixes #8259

volumes.Get was not checking for symlinked paths meanwhile when adding a
new volume it was following the symlink.
So when trying to use a bind-mount that is a symlink, the volume is
added with the correct path, but when another container tries to use the
same volume it got a "Volume exists" error because volumes.Get returned
nil and as such attempted to create a new volume.
