### PR TITLE
Filter containers by status.

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1485,7 +1485,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 	last := cmd.Int([]string{"n"}, -1, "Show n last created containers, include non-running ones.")
 
 	flFilter := opts.NewListOpts(nil)
-	cmd.Var(&flFilter, []string{"f", "-filter"}, "Provide filter values. Valid filters:\nexited=<int> - containers with exit code of <int>")
+	cmd.Var(&flFilter, []string{"f", "-filter"}, "Provide filter values. Valid filters:\nexited=<int> - containers with exit code of <int>\nstatus=(restarting|running|paused|exited)")
 
 	if err := cmd.Parse(args); err != nil {
 		return nil

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -28,6 +28,7 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 		size        = job.GetenvBool("size")
 		psFilters   filters.Args
 		filt_exited []int
+		filt_status []string
 	)
 	outs := engine.NewTable("Created", 0)
 
@@ -44,6 +45,8 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 			filt_exited = append(filt_exited, code)
 		}
 	}
+
+	filt_status, _ = psFilters["status"]
 
 	names := map[string][]string{}
 	daemon.ContainerGraph().Walk("/", func(p string, e *graphdb.Entity) error {
@@ -96,6 +99,11 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 				}
 			}
 			if should_skip {
+				return nil
+			}
+		}
+		for _, status := range filt_status {
+			if container.State.StateString() != strings.ToLower(status) {
 				return nil
 			}
 		}

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -46,6 +46,20 @@ func (s *State) String() string {
 	return fmt.Sprintf("Exited (%d) %s ago", s.ExitCode, units.HumanDuration(time.Now().UTC().Sub(s.FinishedAt)))
 }
 
+// StateString returns a single string to describe state
+func (s *State) StateString() string {
+	if s.Running {
+		if s.Paused {
+			return "paused"
+		}
+		if s.Restarting {
+			return "restarting"
+		}
+		return "running"
+	}
+	return "exited"
+}
+
 func wait(waitChan <-chan struct{}, timeout time.Duration) error {
 	if timeout < 0 {
 		<-waitChan

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -241,14 +241,15 @@ as the root. Wildcards are allowed but the search is not recursive.
     temp?
 
 The first line above `*/temp*`, would ignore all files with names starting with
-`temp` from any subdirectory below the root directory, for example file named 
-`/somedir/temporary.txt` will be ignored. The second line `*/*/temp*`, will  
+`temp` from any subdirectory below the root directory. For example, a file named
+`/somedir/temporary.txt` would be ignored. The second line `*/*/temp*`, will
 ignore files starting with name `temp` from any subdirectory that is two levels
-below the root directory, for example a file `/somedir/subdir/temporary.txt` is 
-ignored in this case. The last line in the above example `temp?`, will ignore 
-the files that match the pattern from the root directory, for example files 
-`tempa`, `tempb` are ignored from the root directory. Currently  there is no
-support for regular expressions, formats like `[^temp*]` are ignored.
+below the root directory. For example, the file `/somedir/subdir/temporary.txt`
+would get ignored in this case. The last line in the above example `temp?`
+will ignore the files that match the pattern from the root directory.
+For example, the files `tempa`, `tempb` are ignored from the root directory.
+Currently there is no support for regular expressions. Formats
+like `[^temp*]` are ignored.
 
 
 See also:
@@ -943,6 +944,7 @@ further details.
       --before=""           Show only container created before Id or Name, include non-running ones.
       -f, --filter=[]       Provide filter values. Valid filters:
                               exited=<int> - containers with exit code of <int>
+                              status=(restarting|running|paused|exited)
       -l, --latest=false    Show only the latest created container, include non-running ones.
       -n=-1                 Show n last created containers, include non-running ones.
       --no-trunc=false      Don't truncate output


### PR DESCRIPTION
A continuation of #7616.
Closes #7616.
Adds `docker ps --filter=status=(restarting|running|paused|exited)` option.

Docker-DCO-1.1-Signed-off-by: Jessica Frazelle jess@docker.com (github: jfrazelle)
