### PR TITLE
Fix error paring null JSON - Issue7941

### DIFF
--- a/engine/env.go
+++ b/engine/env.go
@@ -187,6 +187,12 @@ func (env *Env) Decode(src io.Reader) error {
 }
 
 func (env *Env) SetAuto(k string, v interface{}) {
+	// Issue 7941 - if the value in the incoming JSON is null then treat it
+	// as if they never specified the property at all.
+	if v == nil {
+		return
+	}
+
 	// FIXME: we fix-convert float values to int, because
 	// encoding/json decodes integers to float64, but cannot encode them back.
 	// (See http://golang.org/src/pkg/encoding/json/decode.go#L46)


### PR DESCRIPTION
Closes #7941

Treat a null in JSON, when reading the config of a container, as if the
property was never included.  W/o this fix the null would be saved in the
property as a string with a value of "null".

Signed-off-by: Doug Davis dug@us.ibm.com
