### PR TITLE
Fix #8262: check tag's validity before building.

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -26,6 +26,7 @@ import (
 	"github.com/docker/docker/archive"
 	"github.com/docker/docker/dockerversion"
 	"github.com/docker/docker/engine"
+	"github.com/docker/docker/graph"
 	"github.com/docker/docker/nat"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/log"
@@ -174,9 +175,14 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 
 	//Check if the given image name can be resolved
 	if *tag != "" {
-		repository, _ := parsers.ParseRepositoryTag(*tag)
+		repository, tag := parsers.ParseRepositoryTag(*tag)
 		if _, _, err := registry.ResolveRepositoryName(repository); err != nil {
 			return err
+		}
+		if len(tag) > 0 {
+			if err := graph.ValidateTagName(tag); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -209,7 +209,7 @@ func (store *TagStore) Set(repoName, tag, imageName string, force bool) error {
 	if err := validateRepoName(repoName); err != nil {
 		return err
 	}
-	if err := validateTagName(tag); err != nil {
+	if err := ValidateTagName(tag); err != nil {
 		return err
 	}
 	if err := store.reload(); err != nil {
@@ -285,7 +285,7 @@ func validateRepoName(name string) error {
 }
 
 // Validate the name of a tag
-func validateTagName(name string) error {
+func ValidateTagName(name string) error {
 	if name == "" {
 		return fmt.Errorf("Tag name can't be empty")
 	}

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -118,7 +118,7 @@ func TestLookupImage(t *testing.T) {
 func TestValidTagName(t *testing.T) {
 	validTags := []string{"9", "foo", "foo-test", "bar.baz.boo"}
 	for _, tag := range validTags {
-		if err := validateTagName(tag); err != nil {
+		if err := ValidateTagName(tag); err != nil {
 			t.Errorf("'%s' should've been a valid tag", tag)
 		}
 	}
@@ -127,7 +127,7 @@ func TestValidTagName(t *testing.T) {
 func TestInvalidTagName(t *testing.T) {
 	validTags := []string{"-9", ".foo", "-test", ".", "-"}
 	for _, tag := range validTags {
-		if err := validateTagName(tag); err == nil {
+		if err := ValidateTagName(tag); err == nil {
 			t.Errorf("'%s' shouldn't have been a valid tag", tag)
 		}
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2237,3 +2237,16 @@ func TestBuildOnBuildOutput(t *testing.T) {
 
 	logDone("build - onbuild output")
 }
+
+func TestBuildInvalidTag(t *testing.T) {
+	name := "abcd:A0123456789B0123456789C0123456789"
+	defer deleteImages(name)
+	_, out, err := buildImageWithOut(name, "FROM scratch\nMAINTAINER quux\n", true)
+	// if the error doesnt check for illegal tag name, or the image is built
+	// then this should fail
+	if !strings.Contains(err.Error(), "Illegal tag name") ||
+		strings.Contains(out, "Sending build context to Docker daemon") {
+		t.Fatalf("failed to stop before building. Error: %s, Output: %s", err, out)
+	}
+	logDone("build - invalid tag")
+}


### PR DESCRIPTION
When user passes an invalid tag to `docker build`, check the tag first and terminate-early so user can specify the tag again.

Docker-DCO-1.1-Signed-off-by: Daniel, Dao Quang Minh dqminh89@gmail.com (github: dqminh)
