### PR TITLE
builder: Fix CMD to inject /bin/sh -c when provided with a non-json value

### DIFF
--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -234,7 +234,7 @@ func cmd(b *Builder, args []string, attributes map[string]bool) error {
 	b.Config.Cmd = handleJsonArgs(args, attributes)
 
 	if !attributes["json"] && len(b.Config.Entrypoint) == 0 {
-		b.Config.Entrypoint = []string{"/bin/sh", "-c"}
+		b.Config.Cmd = append([]string{"/bin/sh", "-c"}, b.Config.Cmd...)
 	}
 
 	if err := b.commit("", b.Config.Cmd, fmt.Sprintf("CMD %v", b.Config.Cmd)); err != nil {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2250,3 +2250,45 @@ func TestBuildInvalidTag(t *testing.T) {
 	}
 	logDone("build - invalid tag")
 }
+
+func TestBuildCmdShDashC(t *testing.T) {
+	name := "testbuildcmdshc"
+	defer deleteImages(name)
+	if _, err := buildImage(name, "FROM busybox\nCMD echo cmd\n", true); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := inspectFieldJSON(name, "Config.Cmd")
+	if err != nil {
+		t.Fatal(err, res)
+	}
+
+	expected := `["/bin/sh","-c","echo cmd"]`
+
+	if res != expected {
+		t.Fatalf("Expected value %s not in Config.Cmd: %s", expected, res)
+	}
+
+	logDone("build - cmd should have sh -c for non-json")
+}
+
+func TestBuildCmdJSONNoShDashC(t *testing.T) {
+	name := "testbuildcmdjson"
+	defer deleteImages(name)
+	if _, err := buildImage(name, "FROM busybox\nCMD [\"echo\", \"cmd\"]", true); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := inspectFieldJSON(name, "Config.Cmd")
+	if err != nil {
+		t.Fatal(err, res)
+	}
+
+	expected := `["echo","cmd"]`
+
+	if res != expected {
+		t.Fatalf("Expected value %s not in Config.Cmd: %s", expected, res)
+	}
+
+	logDone("build - cmd should not have /bin/sh -c for json")
+}


### PR DESCRIPTION
closes #8264 

/cc @aanand @tiborvass 
