### PR TITLE
Fixes the new testcase for PR #8230

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -296,17 +296,8 @@ func TestBuildCopyWildcardNoFind(t *testing.T) {
 func TestBuildCopyWildcardCache(t *testing.T) {
 	name := "testcopywildcardcache"
 	defer deleteImages(name)
-	server, err := fakeStorage(map[string]string{
-		"robots.txt": "hello",
-		"index.html": "world",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer server.Close()
 	ctx, err := fakeContext(`FROM busybox
-	COPY file1.txt /tmp/
-	`,
+	COPY file1.txt /tmp/`,
 		map[string]string{
 			"file1.txt": "test1",
 		})
@@ -315,30 +306,17 @@ func TestBuildCopyWildcardCache(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err != nil {
-		t.Fatal(err)
-	}
 	id1, err := buildImageFromContext(name, ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Now make sure we use a cache the 2nd time even with wild card
-	ctx2, err := fakeContext(`FROM busybox
-	COPY file*.txt /tmp/
-	`,
-		map[string]string{
-			"file1.txt": "test1",
-		})
-	defer ctx2.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
+	// Now make sure we use a cache the 2nd time even with wild cards.
+	// Use the same context so the file is the same and the checksum will match
+	ctx.Add("Dockerfile", `FROM busybox
+	COPY file*.txt /tmp/`)
 
-	if err != nil {
-		t.Fatal(err)
-	}
-	id2, err := buildImageFromContext(name, ctx2, true)
+	id2, err := buildImageFromContext(name, ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This new version makes sure that the same context is used for the two
builds run in the test.  If you don't use the same build then about 1/2 the
time the file copied into the container will look like a different file,
probably due to timestamp differences.  But reusing the same context we
re-use the same file on disk and therefore avoid the change in timestamps,
and we use the cache on the 2nd build.

relates to https://github.com/moby/moby/pull/8230

Signed-off-by: Doug Davis dug@us.ibm.com
