### PR TITLE
Stable Networking: Keep the same network settings during the entire container lifecycle.

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -441,7 +441,7 @@ func (container *Container) buildHostnameAndHostsFiles(IP string) error {
 	return container.buildHostsFiles(IP)
 }
 
-func (container *Container) allocateNetwork() error {
+func (container *Container) AllocateNetwork() error {
 	mode := container.hostConfig.NetworkMode
 	if container.Config.NetworkDisabled || !mode.IsPrivate() {
 		return nil
@@ -514,7 +514,7 @@ func (container *Container) allocateNetwork() error {
 	return nil
 }
 
-func (container *Container) releaseNetwork() {
+func (container *Container) ReleaseNetwork() {
 	if container.Config.NetworkDisabled {
 		return
 	}
@@ -527,7 +527,7 @@ func (container *Container) releaseNetwork() {
 // cleanup releases any network resources allocated to the container along with any rules
 // around how containers are linked together.  It also unmounts the container's root filesystem.
 func (container *Container) cleanup() {
-	container.releaseNetwork()
+	container.ReleaseNetwork()
 
 	// Disable all active links
 	if container.activeLinks != nil {
@@ -972,7 +972,7 @@ func (container *Container) initializeNetworking() error {
 		container.Config.NetworkDisabled = true
 		return container.buildHostnameAndHostsFiles("127.0.1.1")
 	}
-	if err := container.allocateNetwork(); err != nil {
+	if err := container.AllocateNetwork(); err != nil {
 		return err
 	}
 	return container.buildHostnameAndHostsFiles(container.NetworkSettings.IPAddress)

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -463,10 +463,12 @@ func (container *Container) allocateNetwork() error {
 
 	if container.Config.PortSpecs != nil {
 		if err := migratePortMappings(container.Config, container.hostConfig); err != nil {
+			eng.Job("release_interface", container.ID).Run()
 			return err
 		}
 		container.Config.PortSpecs = nil
 		if err := container.WriteHostConfig(); err != nil {
+			eng.Job("release_interface", container.ID).Run()
 			return err
 		}
 	}
@@ -496,6 +498,7 @@ func (container *Container) allocateNetwork() error {
 
 	for port := range portSpecs {
 		if err := container.allocatePort(eng, port, bindings); err != nil {
+			eng.Job("release_interface", container.ID).Run()
 			return err
 		}
 	}
@@ -1149,7 +1152,6 @@ func (container *Container) allocatePort(eng *engine.Engine, port nat.Port, bind
 			return err
 		}
 		if err := job.Run(); err != nil {
-			eng.Job("release_interface", container.ID).Run()
 			return err
 		}
 		b.HostIp = portEnv.Get("HostIP")

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -544,9 +544,10 @@ func (container *Container) RestoreNetwork() error {
 
 	eng := container.daemon.eng
 
-	// Re-allocate the interface with the same IP address.
+	// Re-allocate the interface with the same IP and MAC address.
 	job := eng.Job("allocate_interface", container.ID)
 	job.Setenv("RequestedIP", container.NetworkSettings.IPAddress)
+	job.Setenv("RequestedMac", container.NetworkSettings.MacAddress)
 	if err := job.Run(); err != nil {
 		return err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -367,6 +367,16 @@ func (daemon *Daemon) restore() error {
 		registeredContainers = append(registeredContainers, container)
 	}
 
+	// Restore networking of registered containers.
+	// This must be performed prior to any IP allocation, otherwise we might
+	// end up giving away an already allocated address.
+	for _, container := range registeredContainers {
+		if err := container.RestoreNetwork(); err != nil {
+			log.Errorf("Failed to restore network for %v: %v", container.Name, err)
+			continue
+		}
+	}
+
 	// check the restart policy on the containers and restart any container with
 	// the restart policy of "always"
 	if daemon.config.AutoRestart {

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -94,6 +94,8 @@ func (daemon *Daemon) Destroy(container *Container) error {
 		return err
 	}
 
+	container.ReleaseNetwork()
+
 	// Deregister the container before removing its directory, to avoid race conditions
 	daemon.idIndex.Delete(container.ID)
 	daemon.containers.Delete(container.ID)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1870,7 +1870,7 @@ func TestRunMutableNetworkFiles(t *testing.T) {
 
 func TestRunStableIPAndPort(t *testing.T) {
 	const nContainers = 2
-	var ids, ips, ports [nContainers]string
+	var ids, ips, macs, ports [nContainers]string
 
 	// Setup: Create a couple of containers and collect their IPs and public ports.
 	for i := 0; i < nContainers; i++ {
@@ -1880,11 +1880,15 @@ func TestRunStableIPAndPort(t *testing.T) {
 			t.Fatal(err)
 		}
 		ids[i] = strings.TrimSpace(out)
+
 		ips[i], err = inspectField(ids[i], "NetworkSettings.IPAddress")
 		errorOut(err, t, out)
 		if ips[i] == "" {
 			t.Fatal("IP allocation failed")
 		}
+
+		macs[i], err = inspectField(ids[i], "NetworkSettings.MacAddress")
+		errorOut(err, t, out)
 
 		portCmd := exec.Command(dockerBinary, "port", ids[i], "1234")
 		ports[i], _, err = runCommandWithOutput(portCmd)
@@ -1927,7 +1931,7 @@ func TestRunStableIPAndPort(t *testing.T) {
 		}
 	}
 
-	// Start the containers back, and ensure they are getting the same IPs and ports.
+	// Start the containers back, and ensure they are getting the same IPs, MACs and ports.
 	for i, id := range ids {
 		runCmd := exec.Command(dockerBinary, "start", id)
 		out, _, err := runCommandWithOutput(runCmd)
@@ -1935,12 +1939,19 @@ func TestRunStableIPAndPort(t *testing.T) {
 
 		ip, err := inspectField(id, "NetworkSettings.IPAddress")
 		errorOut(err, t, out)
+
+		mac, err := inspectField(id, "NetworkSettings.MacAddress")
+		errorOut(err, t, out)
+
 		portCmd := exec.Command(dockerBinary, "port", ids[i], "1234")
 		port, _, err := runCommandWithOutput(portCmd)
 		errorOut(err, t, out)
 
 		if ips[i] != ip {
 			t.Fatalf("Container started with a different IP: %s != %s", ip, ips[i])
+		}
+		if macs[i] != mac {
+			t.Fatalf("Container started with a different MAC: %s != %s", mac, macs[i])
 		}
 		if ports[i] != port {
 			t.Fatalf("Container started with a different port: %s != %s", port, ports[i])

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1868,57 +1868,87 @@ func TestRunMutableNetworkFiles(t *testing.T) {
 	}
 }
 
-func TestRunHostsLinkedContainerUpdate(t *testing.T) {
+func TestRunStableIPAndPort(t *testing.T) {
+	const nContainers = 2
+	var ids, ips, ports [nContainers]string
+
+	// Setup: Create a couple of containers and collect their IPs and public ports.
+	for i := 0; i < nContainers; i++ {
+		runCmd := exec.Command(dockerBinary, "run", "-d", "-p", "1234", "busybox", "top")
+		out, _, err := runCommandWithOutput(runCmd)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids[i] = strings.TrimSpace(out)
+		ips[i], err = inspectField(ids[i], "NetworkSettings.IPAddress")
+		errorOut(err, t, out)
+		if ips[i] == "" {
+			t.Fatal("IP allocation failed")
+		}
+
+		portCmd := exec.Command(dockerBinary, "port", ids[i], "1234")
+		ports[i], _, err = runCommandWithOutput(portCmd)
+		errorOut(err, t, out)
+		if ports[i] == "" {
+			t.Fatal("Port allocation failed")
+		}
+	}
+
+	// Stop them all.
+	for _, id := range ids {
+		cmd := exec.Command(dockerBinary, "stop", id)
+		out, _, err := runCommandWithOutput(cmd)
+		if err != nil {
+			t.Fatal(err, out)
+		}
+	}
+
+	// Create a new container and ensure it's not getting the IP or port of some stopped container.
+	{
+		runCmd := exec.Command(dockerBinary, "run", "-d", "-p", "1234", "busybox", "top")
+		out, _, err := runCommandWithOutput(runCmd)
+		errorOut(err, t, out)
+
+		id := strings.TrimSpace(out)
+		ip, err := inspectField(id, "NetworkSettings.IPAddress")
+		errorOut(err, t, out)
+
+		portCmd := exec.Command(dockerBinary, "port", id, "1234")
+		port, _, err := runCommandWithOutput(portCmd)
+		errorOut(err, t, out)
+
+		for i := range ids {
+			if ip == ips[i] {
+				t.Fatalf("Conflicting IP: %s", ip)
+			}
+			if port == ports[i] {
+				t.Fatalf("Conflicting port: %s", port)
+			}
+		}
+	}
+
+	// Start the containers back, and ensure they are getting the same IPs and ports.
+	for i, id := range ids {
+		runCmd := exec.Command(dockerBinary, "start", id)
+		out, _, err := runCommandWithOutput(runCmd)
+		errorOut(err, t, out)
+
+		ip, err := inspectField(id, "NetworkSettings.IPAddress")
+		errorOut(err, t, out)
+		portCmd := exec.Command(dockerBinary, "port", ids[i], "1234")
+		port, _, err := runCommandWithOutput(portCmd)
+		errorOut(err, t, out)
+
+		if ips[i] != ip {
+			t.Fatalf("Container started with a different IP: %s != %s", ip, ips[i])
+		}
+		if ports[i] != port {
+			t.Fatalf("Container started with a different port: %s != %s", port, ports[i])
+		}
+	}
+
 	deleteAllContainers()
-	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "--name", "c1", "busybox", "sh", "-c", "while true; do sleep 1; done"))
-	if err != nil {
-		t.Fatal(err, out)
-	}
-
-	// TODO fix docker cp and /etc/hosts
-	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "--link", "c1:c1", "--name", "c2", "busybox", "sh", "-c", "while true;do sleep 1; done"))
-	if err != nil {
-		t.Fatal(err, out)
-	}
-
-	contID := strings.TrimSpace(out)
-
-	f, err := os.Open(filepath.Join("/var/lib/docker/containers", contID, "hosts"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	originalContent, err := ioutil.ReadAll(f)
-	f.Close()
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "restart", "-t", "0", "c1"))
-	if err != nil {
-		t.Fatal(err, out)
-	}
-
-	f, err = os.Open(filepath.Join("/var/lib/docker/containers", contID, "hosts"))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	newContent, err := ioutil.ReadAll(f)
-	f.Close()
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if strings.TrimSpace(string(originalContent)) == strings.TrimSpace(string(newContent)) {
-		t.Fatalf("expected /etc/hosts to be updated, but wasn't")
-	}
-
-	deleteAllContainers()
-
-	logDone("run - /etc/hosts updated in parent when restart")
+	logDone("run - ips and ports must not change")
 }
 
 // Ensure that CIDFile gets deleted if it's empty


### PR DESCRIPTION
This change will allocate network settings (IP and public ports) at container creation rather than start and keep them throughout the lifetime of the container (i.e. until it gets destroyed) instead of discarding them when the container is stopped.

It will also restore network settings upon daemon restart in order to guarantee that IPs and ports will remain stable all the time (regardless of daemon restarts) and will prevent new containers from obtaining the same IPs or public ports.
