### PR TITLE
Fix the bug of set an existed tag name of a repository

### DIFF
--- a/builder/job.go
+++ b/builder/job.go
@@ -112,7 +112,7 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 	}
 
 	if repoName != "" {
-		b.Daemon.Repositories().Set(repoName, tag, id, false)
+		b.Daemon.Repositories().Set(repoName, tag, id, true)
 	}
 	return engine.StatusOK
 }

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -218,11 +218,11 @@ func (store *TagStore) Set(repoName, tag, imageName string, force bool) error {
 	var repo Repository
 	if r, exists := store.Repositories[repoName]; exists {
 		repo = r
+		if _, exists := store.Repositories[repoName][tag]; exists && !force {
+			return fmt.Errorf("Conflict: Tag %s is already set to Image %s", tag, store.Repositories[repoName][tag])
+		}
 	} else {
 		repo = make(map[string]string)
-		if old, exists := store.Repositories[repoName]; exists && !force {
-			return fmt.Errorf("Conflict: Tag %s:%s is already set to %s", repoName, tag, old)
-		}
 		store.Repositories[repoName] = repo
 	}
 	repo[tag] = img.ID


### PR DESCRIPTION
When tag a image with a tag name which is existed in the repository,
docker should prompt it is conflicted and it will worked when with
a -f option.But the docker doesn't work like that,it will just
replace the image whether you have a -f option or not.View the
code you can find that if an repoName is existed,it will never go
to check if 'force' option is set or not.

Signed-off-by: Lei Jitang leijitang@huawei.com
