### PR TITLE
Set container MAC with run parameter and show link-local IPv6 at inspect

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -209,10 +209,12 @@ func populateCommand(c *Container, env []string) error {
 		if !c.Config.NetworkDisabled {
 			network := c.NetworkSettings
 			en.Interface = &execdriver.NetworkInterface{
-				Gateway:     network.Gateway,
-				Bridge:      network.Bridge,
-				IPAddress:   network.IPAddress,
-				IPPrefixLen: network.IPPrefixLen,
+				MacAddress:           network.MacAddress,
+				Gateway:              network.Gateway,
+				Bridge:               network.Bridge,
+				IPAddress:            network.IPAddress,
+				IPPrefixLen:          network.IPPrefixLen,
+				LinkLocalIPv6Address: network.LinkLocalIPv6Address,
 			}
 		}
 	case "container":
@@ -450,6 +452,7 @@ func (container *Container) allocateNetwork() error {
 	)
 
 	job := eng.Job("allocate_interface", container.ID)
+	job.Setenv("MacAddress", container.Config.MacAddress)
 	if env, err = job.Stdout.AddEnv(); err != nil {
 		return err
 	}
@@ -502,6 +505,9 @@ func (container *Container) allocateNetwork() error {
 	container.NetworkSettings.IPAddress = env.Get("IP")
 	container.NetworkSettings.IPPrefixLen = env.GetInt("IPPrefixLen")
 	container.NetworkSettings.Gateway = env.Get("Gateway")
+	container.NetworkSettings.MacAddress = env.Get("MacAddress")
+	container.NetworkSettings.LinkLocalIPv6Address = env.Get("LinkLocalIPv6")
+	container.NetworkSettings.LinkLocalIPv6PrefixLen = 64
 
 	return nil
 }

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -63,10 +63,12 @@ type Network struct {
 }
 
 type NetworkInterface struct {
-	Gateway     string `json:"gateway"`
-	IPAddress   string `json:"ip"`
-	Bridge      string `json:"bridge"`
-	IPPrefixLen int    `json:"ip_prefix_len"`
+	MacAddress           string `json:"mac"`
+	Gateway              string `json:"gateway"`
+	IPAddress            string `json:"ip"`
+	Bridge               string `json:"bridge"`
+	IPPrefixLen          int    `json:"ip_prefix_len"`
+	LinkLocalIPv6Address string `json:"link_local_ipv6"`
 }
 
 type Resources struct {

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -90,6 +90,7 @@ func (d *driver) createNetwork(container *libcontainer.Config, c *execdriver.Com
 	if c.Network.Interface != nil {
 		vethNetwork := libcontainer.Network{
 			Mtu:        c.Network.Mtu,
+			MacAddress: c.Network.Interface.MacAddress,
 			Address:    fmt.Sprintf("%s/%d", c.Network.Interface.IPAddress, c.Network.Interface.IPPrefixLen),
 			Gateway:    c.Network.Interface.Gateway,
 			Type:       "veth",

--- a/daemon/network_settings.go
+++ b/daemon/network_settings.go
@@ -9,12 +9,15 @@ import (
 type PortMapping map[string]string // Deprecated
 
 type NetworkSettings struct {
-	IPAddress   string
-	IPPrefixLen int
-	Gateway     string
-	Bridge      string
-	PortMapping map[string]PortMapping // Deprecated
-	Ports       nat.PortMap
+	MacAddress             string
+	IPAddress              string
+	IPPrefixLen            int
+	LinkLocalIPv6Address   string
+	LinkLocalIPv6PrefixLen int
+	Gateway                string
+	Bridge                 string
+	PortMapping            map[string]PortMapping // Deprecated
+	Ports                  nat.PortMap
 }
 
 func (settings *NetworkSettings) PortMappingAPI() *engine.Table {

--- a/daemon/networkdriver/bridge/driver_test.go
+++ b/daemon/networkdriver/bridge/driver_test.go
@@ -102,3 +102,19 @@ func TestHostnameFormatChecking(t *testing.T) {
 		t.Fatal("Failed to check invalid HostIP")
 	}
 }
+
+func TestMacAddrGeneration(t *testing.T) {
+	ip := net.ParseIP("192.168.0.1")
+	mac := generateMacAddr(ip).String()
+
+	// Should be consistent.
+	if generateMacAddr(ip).String() != mac {
+		t.Fatal("Inconsistent MAC address")
+	}
+
+	// Should be unique.
+	ip2 := net.ParseIP("192.168.0.2")
+	if generateMacAddr(ip2).String() == mac {
+		t.Fatal("Non-unque MAC address")
+	}
+}

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	WorkingDir      string
 	Entrypoint      []string
 	NetworkDisabled bool
+	MacAddress      string
 	OnBuild         []string
 }
 
@@ -52,6 +53,7 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 		Image:           job.Getenv("Image"),
 		WorkingDir:      job.Getenv("WorkingDir"),
 		NetworkDisabled: job.GetenvBool("NetworkDisabled"),
+		MacAddress:      job.Getenv("MacAddress"),
 	}
 	job.GetenvJson("ExposedPorts", &config.ExposedPorts)
 	job.GetenvJson("Volumes", &config.Volumes)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -58,6 +58,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.")
+		flMacAddress      = cmd.String([]string{"-mac-address"}, "", "Container MAC address (ex: 92:d0:c6:0a:29:33)")
 		flRestartPolicy   = cmd.String([]string{"-restart"}, "", "Restart policy to apply when a container exits (no, on-failure[:max-retry], always)")
 	)
 
@@ -252,6 +253,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		Cmd:             runCmd,
 		Image:           image,
 		Volumes:         flVolumes.GetMap(),
+		MacAddress:      *flMacAddress,
 		Entrypoint:      entrypoint,
 		WorkingDir:      *flWorkingDir,
 	}

--- a/vendor/src/github.com/docker/libcontainer/netlink/netlink_linux_test.go
+++ b/vendor/src/github.com/docker/libcontainer/netlink/netlink_linux_test.go
@@ -328,7 +328,7 @@ func TestCreateBridgeWithMac(t *testing.T) {
 	}
 }
 
-func TestSetMACAddress(t *testing.T) {
+func TestSetMacAddress(t *testing.T) {
 	if testing.Short() {
 		return
 	}

--- a/vendor/src/github.com/docker/libcontainer/network/network.go
+++ b/vendor/src/github.com/docker/libcontainer/network/network.go
@@ -68,6 +68,14 @@ func SetDefaultGateway(ip, ifaceName string) error {
 	return netlink.AddDefaultGw(ip, ifaceName)
 }
 
+func SetInterfaceMac(name string, macaddr string) error {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.NetworkSetMacAddress(iface, macaddr)
+}
+
 func SetInterfaceIp(name string, rawIp string) error {
 	iface, err := net.InterfaceByName(name)
 	if err != nil {

--- a/vendor/src/github.com/docker/libcontainer/network/types.go
+++ b/vendor/src/github.com/docker/libcontainer/network/types.go
@@ -17,6 +17,9 @@ type Network struct {
 	// Prefix for the veth interfaces.
 	VethPrefix string `json:"veth_prefix,omitempty"`
 
+	// MacAddress contains the MAC address to set on the network interface
+	MacAddress string `json:"mac_address,omitempty"`
+
 	// Address contains the IPv4 and mask to set on the network interface
 	Address string `json:"address,omitempty"`
 

--- a/vendor/src/github.com/docker/libcontainer/network/veth.go
+++ b/vendor/src/github.com/docker/libcontainer/network/veth.go
@@ -60,6 +60,11 @@ func (v *Veth) Initialize(config *Network, networkState *NetworkState) error {
 	if err := ChangeInterfaceName(vethChild, defaultDevice); err != nil {
 		return fmt.Errorf("change %s to %s %s", vethChild, defaultDevice, err)
 	}
+	if config.MacAddress != "" {
+		if err := SetInterfaceMac(defaultDevice, config.MacAddress); err != nil {
+			return fmt.Errorf("set %s mac %s", defaultDevice, err)
+		}
+	}
 	if err := SetInterfaceIp(defaultDevice, config.Address); err != nil {
 		return fmt.Errorf("set %s ip %s", defaultDevice, err)
 	}

--- a/vendor/src/github.com/docker/libtrust/tlsdemo/client.go
+++ b/vendor/src/github.com/docker/libtrust/tlsdemo/client.go
@@ -57,7 +57,7 @@ func main() {
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				Certificates: []tls.Certificate{
-					tls.Certificate{
+					{
 						Certificate: [][]byte{selfSignedClientCert.Raw},
 						PrivateKey:  clientKey.CryptoPrivateKey(),
 						Leaf:        selfSignedClientCert,

--- a/vendor/src/github.com/docker/libtrust/tlsdemo/server.go
+++ b/vendor/src/github.com/docker/libtrust/tlsdemo/server.go
@@ -54,7 +54,7 @@ func main() {
 	// Create TLS config, requiring client certificates.
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{
-			tls.Certificate{
+			{
 				Certificate: [][]byte{selfSignedServerCert.Raw},
 				PrivateKey:  serverKey.CryptoPrivateKey(),
 				Leaf:        selfSignedServerCert,


### PR DESCRIPTION
This Pull Request depends on https://github.com/docker/libcontainer/pull/208
Related Issues: https://github.com/docker/docker/issues/4918, https://github.com/docker/docker/issues/4033, https://github.com/docker/docker/issues/3609, https://github.com/docker/docker/issues/7042

I have implemented a functionality to set the container's mac address explicitly.
Further docker inspect will display the MAC address as well as the container's link-local IPv6 address.

```
# host$ docker run -i -t --mac-address=26:99:7c:50:d8:20 --name=my-container ubuntu bash

# my-container$ ifconfig eth0
eth0      Link encap:Ethernet  HWaddr 26:99:7c:50:d8:20
          inet addr:172.17.0.4  Bcast:0.0.0.0  Mask:255.255.0.0
          inet6 addr: fe80::2499:7cff:fe50:d820/64 Scope:Link
          UP BROADCAST  MTU:1500  Metric:1
          RX packets:1 errors:0 dropped:0 overruns:0 frame:0
          TX packets:1 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:90 (90.0 B)  TX bytes:90 (90.0 B)

# host$ docker inspect my-container
...
"NetworkSettings": {
    "Bridge": "docker0",
    "Gateway": "172.17.42.1",
    "IPAddress": "172.17.0.2",
    "IPPrefixLen": 16,
    "LinkLocalIPv6Address": "fe80::2499:7cff:fe50:d820",
    "LinkLocalIPv6PrefixLen": 64,
    "MacAddress": "26:99:7c:50:d8:20",
    "PortMapping": null,
    "Ports": {}
},
...
```

I am not sure what is the problem with Travis. It says `mkdir: cannot create directory '/precompiled': Permission denied`. On my machine `make test-unit` and `make test-integration` work fine. I would appreciate your help. Ohh, the drone results are green. So everything OK?

This is one of the first steps of full IPv6 integration in docker.
Currently I have a running IPv6 implementation that I am breaking down into multiple Pull-Requests to simplify review and merging.

I would like to get some feedback.
