### PR TITLE
Save start error into State.Error when the container fails to start

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -297,6 +297,8 @@ func (container *Container) Start() (err error) {
 	// setup has been cleaned up properly
 	defer func() {
 		if err != nil {
+			container.setError(err)
+			container.toDisk()
 			container.cleanup()
 		}
 	}()

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -15,6 +15,7 @@ type State struct {
 	Restarting bool
 	Pid        int
 	ExitCode   int
+	Error      string // contains last known error when starting the container
 	StartedAt  time.Time
 	FinishedAt time.Time
 	waitChan   chan struct{}
@@ -137,6 +138,7 @@ func (s *State) SetRunning(pid int) {
 }
 
 func (s *State) setRunning(pid int) {
+	s.Error = ""
 	s.Running = true
 	s.Paused = false
 	s.Restarting = false
@@ -177,6 +179,13 @@ func (s *State) SetRestarting(exitCode int) {
 	close(s.waitChan) // fire waiters for stop
 	s.waitChan = make(chan struct{})
 	s.Unlock()
+}
+
+// setError sets the container's error state. This is useful when we want to
+// know the error that occurred when container transits to another state
+// when inspecting it
+func (s *State) setError(err error) {
+	s.Error = err.Error()
 }
 
 func (s *State) IsRestarting() bool {


### PR DESCRIPTION
When a container failed to start, in addition to returning the error message in output, we also save that error message into `State.Error` so it can be read from `docker inspect` again by user without having to start the container again / read from the logs.

This is particularly helpful for container management systems where we don't want to save last error message returned in `POST /containers/:id/start` output, but still want to let users read it later so they can resolve it.

Docker-DCO-1.1-Signed-off-by: Daniel, Dao Quang Minh dqminh89@gmail.com (github: dqminh)
