### PR TITLE
fix curl error

### DIFF
--- a/contrib/mkimage-alpine.sh
+++ b/contrib/mkimage-alpine.sh
@@ -49,6 +49,7 @@ save() {
 	[ $SAVE -eq 1 ] || return
 
 	tar --numeric-owner -C $ROOTFS -c . | xz > rootfs.tar.xz
+	printf 'saved:%s/rootfs.tar.xz\n' $(pwd)
 }
 
 while getopts "hr:m:s" opt; do

--- a/contrib/mkimage-alpine.sh
+++ b/contrib/mkimage-alpine.sh
@@ -30,7 +30,7 @@ getapk() {
 
 mkbase() {
 	$TMP/sbin/apk.static --repository $REPO --update-cache --allow-untrusted \
-		--root $ROOTFS --initdb add alpine-base
+		--root $ROOTFS --initdb add alpine-base bash
 }
 
 conf() {

--- a/contrib/mkimage-alpine.sh
+++ b/contrib/mkimage-alpine.sh
@@ -19,7 +19,7 @@ tmp() {
 }
 
 apkv() {
-	curl -sSL $REPO/$ARCH/APKINDEX.tar.gz | tar -Oxz |
+	curl -sSL $REPO/$ARCH/APKINDEX.tar.gz | tar -Oxz --exclude=*.pub |
 		grep '^P:apk-tools-static$' -A1 | tail -n1 | cut -d: -f2
 }
 


### PR DESCRIPTION
The APKINDEX.tar.gz file contains a binary RSA public key that causes a "curl: (23) Failed writing body" error when running the script on Lubuntu 14.04.
