### PR TITLE
Add support for 'commit --change'

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1632,6 +1632,8 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	flPause := cmd.Bool([]string{"p", "-pause"}, true, "Pause container during commit")
 	flComment := cmd.String([]string{"m", "-message"}, "", "Commit message")
 	flAuthor := cmd.String([]string{"a", "#author", "-author"}, "", "Author (e.g., \"John Hannibal Smith <hannibal@a-team.com>\")")
+	flChanges := opts.NewListOpts(nil)
+	cmd.Var(&flChanges, []string{"c", "-change"}, "Apply a modification before committing the image")
 	// FIXME: --run is deprecated, it will be replaced with inline Dockerfile commands.
 	flConfig := cmd.String([]string{"#run", "#-run"}, "", "This option is deprecated and will be removed in a future version in favor of inline Dockerfile-compatible commands")
 	if err := cmd.Parse(args); err != nil {
@@ -1661,6 +1663,7 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	v.Set("tag", tag)
 	v.Set("comment", *flComment)
 	v.Set("author", *flAuthor)
+	v.Set("changes", strings.Join(flChanges.GetAll(), "\n"))
 
 	if *flPause != true {
 		v.Set("pause", "0")

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -476,6 +476,7 @@ func postCommit(eng *engine.Engine, version version.Version, w http.ResponseWrit
 	job.Setenv("tag", r.Form.Get("tag"))
 	job.Setenv("author", r.Form.Get("author"))
 	job.Setenv("comment", r.Form.Get("comment"))
+	job.Setenv("changes", r.Form.Get("changes"))
 	job.SetenvSubEnv("config", &config)
 
 	job.Stdout.Add(stdoutBuffer)

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -80,6 +80,11 @@ type Builder struct {
 	Remove      bool
 	ForceRemove bool
 
+	// set this to true if we want the builder to not commit between steps.
+	// This is useful when we only want to use the evaluator table to generate
+	// the final configs of the Dockerfile but dont want the layers
+	disableCommit bool
+
 	AuthConfig     *registry.AuthConfig
 	AuthConfigFile *registry.ConfigFile
 

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -54,6 +54,9 @@ func (b *Builder) readContext(context io.Reader) error {
 }
 
 func (b *Builder) commit(id string, autoCmd []string, comment string) error {
+	if b.disableCommit {
+		return nil
+	}
 	if b.image == "" {
 		return fmt.Errorf("Please provide a source image with `from` prior to commit")
 	}

--- a/builder/job.go
+++ b/builder/job.go
@@ -1,18 +1,23 @@
 package builder
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
 
+	"github.com/docker/docker/builder/parser"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/graph"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/registry"
+	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
 )
 
@@ -23,6 +28,7 @@ type BuilderJob struct {
 
 func (b *BuilderJob) Install() {
 	b.Engine.Register("build", b.CmdBuild)
+	b.Engine.Register("build_config", b.CmdBuildConfig)
 }
 
 func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
@@ -125,6 +131,61 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 
 	if repoName != "" {
 		b.Daemon.Repositories().Set(repoName, tag, id, true)
+	}
+	return engine.StatusOK
+}
+
+func (b *BuilderJob) CmdBuildConfig(job *engine.Job) engine.Status {
+	if len(job.Args) != 0 {
+		return job.Errorf("Usage: %s\n", job.Name)
+	}
+	var (
+		validCmd = map[string]struct{}{
+			"entrypoint": {},
+			"cmd":        {},
+			"user":       {},
+			"workdir":    {},
+			"env":        {},
+			"volume":     {},
+			"expose":     {},
+			"onbuild":    {},
+		}
+
+		changes   = job.Getenv("changes")
+		newConfig runconfig.Config
+	)
+
+	if err := job.GetenvJson("config", &newConfig); err != nil {
+		return job.Error(err)
+	}
+
+	ast, err := parser.Parse(bytes.NewBufferString(changes))
+	if err != nil {
+		return job.Error(err)
+	}
+
+	builder := &Builder{
+		Daemon:        b.Daemon,
+		Engine:        b.Engine,
+		Config:        &newConfig,
+		OutStream:     ioutil.Discard,
+		ErrStream:     ioutil.Discard,
+		disableCommit: true,
+	}
+
+	for i, n := range ast.Children {
+		cmd := n.Value
+		if _, ok := validCmd[cmd]; ok {
+			if err := builder.dispatch(i, n); err != nil {
+				return job.Error(err)
+			}
+		} else {
+			fmt.Fprintf(builder.ErrStream, "# Skipping serialization of instruction %s\n", strings.ToUpper(cmd))
+		}
+	}
+
+	if err := json.NewEncoder(job.Stdout).Encode(builder.Config); err != nil {
+		return job.Error(err)
 	}
 	return engine.StatusOK
 }

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -147,3 +147,36 @@ func TestCommitWithHostBindMount(t *testing.T) {
 
 	logDone("commit - commit bind mounted file")
 }
+
+func TestCommitChange(t *testing.T) {
+	defer deleteAllContainers()
+	cmd(t, "run", "--name", "test", "busybox", "true")
+
+	cmd := exec.Command(dockerBinary, "commit",
+		"--change", "EXPOSE 8080",
+		"--change", "ENV DEBUG true",
+		"test", "test-commit")
+	imageId, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(imageId, err)
+	}
+	imageId = strings.Trim(imageId, "\r\n")
+	defer deleteImages(imageId)
+
+	expected := map[string]string{
+		"Config.ExposedPorts": "map[8080/tcp:map[]]",
+		"Config.Env":          "[DEBUG=true PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin]",
+	}
+
+	for conf, value := range expected {
+		res, err := inspectField(imageId, conf)
+		if err != nil {
+			t.Errorf("failed to get value %s, error: %s", conf, err)
+		}
+		if res != value {
+			t.Errorf("%s('%s'), expected %s", conf, res, value)
+		}
+	}
+
+	logDone("commit - commit --change")
+}

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/server"
+	"github.com/docker/docker/builder"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
@@ -170,6 +171,8 @@ func TestGetContainersTop(t *testing.T) {
 
 func TestPostCommit(t *testing.T) {
 	eng := NewTestEngine(t)
+	b := &builder.BuilderJob{Engine: eng}
+	b.Install()
 	defer mkDaemonFromEngine(eng, t).Nuke()
 
 	// Create a container and remove a file

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/builder"
 	"github.com/docker/docker/engine"
 )
 
@@ -22,6 +23,8 @@ func TestCreateNumberHostname(t *testing.T) {
 
 func TestCommit(t *testing.T) {
 	eng := NewTestEngine(t)
+	b := &builder.BuilderJob{Engine: eng}
+	b.Install()
 	defer mkDaemonFromEngine(eng, t).Nuke()
 
 	config, _, _, err := parseRun([]string{unitTestImageID, "/bin/cat"}, nil)
@@ -42,6 +45,8 @@ func TestCommit(t *testing.T) {
 
 func TestMergeConfigOnCommit(t *testing.T) {
 	eng := NewTestEngine(t)
+	b := &builder.BuilderJob{Engine: eng}
+	b.Install()
 	runtime := mkDaemonFromEngine(eng, t)
 	defer runtime.Nuke()
 


### PR DESCRIPTION
The spec for `commit --change` can be found at  https://github.com/docker/docker/pull/5105
This PR changes the original pull request to use new builder for generating `runconfig.Config`

Supported Dockerfile instructions for `--change` are:

```
- ENTRYPOINT
- CMD
- USER
- WORKDIR
- ENV
- VOLUME
- EXPOSE
- ONBUILD
```

Example command:

```
> docker run --name test busybox true
> docker commit --change "EXPOSE 8080 3000" --change "ENV DEBUG true" --change "VOLUME /test1 /test2" --change "WORKDIR /test1" test test-commit
> docker inspect test-commit
"Config": {
  "Env": [
    "DEBUG=true",
    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
  ],
  "ExposedPorts": {
    "3000/tcp": {},
    "8080/tcp": {}
  },
  "Volumes": {
    "/test1": {},
    "/test2": {}
  },
  "WorkingDir": "/test1"
},
```
