### PR TITLE
Improve docs with note about registry frontend web app

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -105,6 +105,7 @@ pages:
 - ['reference/api/index.md', '**HIDDEN**']
 - ['reference/api/docker-io_api.md', 'Reference', 'Docker Hub API']
 - ['reference/api/registry_api.md', 'Reference', 'Docker Registry API']
+- ['reference/api/registry_api_client_libraries.md', 'Reference', 'Docker Registry API Client Libraries']
 - ['reference/api/hub_registry_spec.md', 'Reference', 'Docker Hub and Registry Spec']
 - ['reference/api/docker_remote_api.md', 'Reference', 'Docker Remote API']
 - ['reference/api/docker_remote_api_v1.15.md', 'Reference', 'Docker Remote API v1.15']

--- a/docs/sources/reference/api/registry_api_client_libraries.md
+++ b/docs/sources/reference/api/registry_api_client_libraries.md
@@ -1,0 +1,35 @@
+page_title: Registry API Client Libraries
+page_description: Various client libraries available to use with the Docker registry API
+page_keywords: API, Docker, index, registry, REST, documentation, clients, C#, Erlang, Go, Groovy, Java, JavaScript, Perl, PHP, Python, Ruby, Rust, Scala
+
+# Docker Registry API Client Libraries
+
+These libraries have not been tested by the Docker Maintainers for
+compatibility. Please file issues with the library owners. If you find
+more library implementations, please list them in Docker doc bugs and we
+will add the libraries here.
+
+
+<table border="1" class="docutils">
+  <colgroup>
+    <col width="24%">
+    <col width="17%">
+    <col width="48%">
+    <col width="11%">
+  </colgroup>
+  <thead valign="bottom">
+    <tr class="row-odd"><th class="head">Language/Framework</th>
+      <th class="head">Name</th>
+      <th class="head">Repository</th>
+      <th class="head">Status</th>
+    </tr>
+  </thead>
+  <tbody valign = "top">
+    <tr class="row-even">
+      <td>JavaScript (AngularJS) <strong>WebUI</strong></td>
+      <td>docker-registry-frontend</td>
+      <td><a class="reference external" href="https://github.com/kwk/docker-registry-frontend">https://github.com/kwk/docker-registry-frontend</a></td>
+      <td>Active</td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/sources/reference/api/registry_api_client_libraries.md
+++ b/docs/sources/reference/api/registry_api_client_libraries.md
@@ -4,7 +4,7 @@ page_keywords: API, Docker, index, registry, REST, documentation, clients, C#, E
 
 # Docker Registry API Client Libraries
 
-These libraries have not been tested by the Docker Maintainers for
+These libraries have not been tested by the Docker maintainers for
 compatibility. Please file issues with the library owners. If you find
 more library implementations, please list them in Docker doc bugs and we
 will add the libraries here.

--- a/docs/sources/reference/api/remote_api_client_libraries.md
+++ b/docs/sources/reference/api/remote_api_client_libraries.md
@@ -4,7 +4,7 @@ page_keywords: API, Docker, index, registry, REST, documentation, clients, C#, E
 
 # Docker Remote API Client Libraries
 
-These libraries have not been tested by the Docker Maintainers for
+These libraries have not been tested by the Docker maintainers for
 compatibility. Please file issues with the library owners. If you find
 more library implementations, please list them in Docker doc bugs and we
 will add the libraries here.


### PR DESCRIPTION
Hi,

I am the author of the [docker-registry-frontend](http://github.com/kwk/docker-registry-frontend) web app. It is a web application for browsing and manipulating a Docker registry by using the **Docker _Registry_ API** and not the Docker _Remote_ API. That is why I've create an extra page in the Docker documentation under "Reference -> Docker **Registry** API Client Libraries". This is where I started listing libraries and webapps just like on the "Reference -> Docker **Remote** API Client Libraries". The only exception is that those libraries deal with the Docker _Registry_ API.

Please, accept my pull request or let me know what else I can do for the PR to be accepted. Since I only edited a few lines in the documentation, I consider my changes [an exception](https://github.com/docker/docker/blob/master/CONTRIBUTING.md#small-patch-exception) to the normal contribution guidelines. But let me know if you think different.

Thank you in advance
Konrad
