### PR TITLE
Add daemon opt to set default restart policies

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/docker/daemon/networkdriver"
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/runconfig"
 )
 
 const (
@@ -39,6 +40,8 @@ type Config struct {
 	DisableNetwork              bool
 	EnableSelinuxSupport        bool
 	Context                     map[string][]string
+	DefaultRestartPolicySpec    string
+	DefaultRestartPolicy        runconfig.RestartPolicy
 }
 
 // InstallFlags adds command-line options to the top-level flag parser for
@@ -60,12 +63,14 @@ func (config *Config) InstallFlags() {
 	flag.StringVar(&config.ExecDriver, []string{"e", "-exec-driver"}, "native", "Force the Docker runtime to use a specific exec driver")
 	flag.BoolVar(&config.EnableSelinuxSupport, []string{"-selinux-enabled"}, false, "Enable selinux support. SELinux does not presently support the BTRFS storage driver")
 	flag.IntVar(&config.Mtu, []string{"#mtu", "-mtu"}, 0, "Set the containers network MTU\nif no value is provided: default to the default route MTU or 1500 if no default route is available")
+	flag.StringVar(&config.DefaultRestartPolicySpec, []string{"-default-restart-policy"}, "", "Set the default restart policy for containers")
 	opts.IPVar(&config.DefaultIp, []string{"#ip", "-ip"}, "0.0.0.0", "Default IP address to use when binding container ports")
 	opts.ListVar(&config.GraphOptions, []string{"-storage-opt"}, "Set storage driver options")
 	// FIXME: why the inconsistency between "hosts" and "sockets"?
 	opts.IPListVar(&config.Dns, []string{"#dns", "-dns"}, "Force Docker to use specific DNS servers")
 	opts.DnsSearchListVar(&config.DnsSearch, []string{"-dns-search"}, "Force Docker to use specific DNS search domains")
 	opts.MirrorListVar(&config.Mirrors, []string{"-registry-mirror"}, "Specify a preferred Docker registry mirror")
+
 }
 
 func GetDefaultNetworkMtu() int {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1113,7 +1113,11 @@ func (container *Container) startLoggingToDisk() error {
 }
 
 func (container *Container) waitForStart() error {
-	container.monitor = newContainerMonitor(container, container.hostConfig.RestartPolicy)
+	restartPolicy := container.hostConfig.RestartPolicy
+	if restartPolicy.Name == "" {
+		restartPolicy = container.daemon.config.DefaultRestartPolicy
+	}
+	container.monitor = newContainerMonitor(container, restartPolicy)
 
 	// block until we either receive an error from the initial start of the container's
 	// process or until the process is running in the container

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -230,7 +230,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		return nil, nil, cmd, fmt.Errorf("--net: invalid net mode: %v", err)
 	}
 
-	restartPolicy, err := parseRestartPolicy(*flRestartPolicy)
+	restartPolicy, err := ParseRestartPolicy(*flRestartPolicy)
 	if err != nil {
 		return nil, nil, cmd, err
 	}
@@ -290,8 +290,8 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 	return config, hostConfig, cmd, nil
 }
 
-// parseRestartPolicy returns the parsed policy or an error indicating what is incorrect
-func parseRestartPolicy(policy string) (RestartPolicy, error) {
+// ParseRestartPolicy returns the parsed policy or an error indicating what is incorrect
+func ParseRestartPolicy(policy string) (RestartPolicy, error) {
 	p := RestartPolicy{}
 
 	if policy == "" {


### PR DESCRIPTION
Sets a daemon flag `--default-restart-policy`.
Current implementation does not actually set the policy on a container.

Checks on container.Start if the restart policy on the container is not set, uses the default policy for the monitor if so.
On daemon restart checks if the restart policy on the container is not set, uses the default policy if not to determine if the container should be restarted.

Alternative implementation would be to actually set the container's policy if none was specified.

Current implementation allows flexibility to change the policy (on daemon restart) and be able to effect already created containers.
