### PR TITLE
add test for workdir env vars and add docs

### DIFF
--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -531,8 +531,18 @@ instruction. For example:
     WORKDIR c
     RUN pwd
 
-The output of the final `pwd` command in this Dockerfile would be
+The output of the final `pwd` command in this `Dockerfile` would be
 `/a/b/c`.
+
+The `WORKDIR` instruction can resolve environment variables previously set using
+`ENV`. You can only use environment variables explicitly set in the `Dockerfile`.
+For example:
+
+    ENV DIRPATH /path
+    WORKDIR $DIRPATH/$DIRNAME
+
+The output of the final `pwd` command in this `Dockerfile` would be
+`/path/$DIRNAME`
 
 ## ONBUILD
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -973,6 +973,30 @@ func TestBuildRelativeWorkdir(t *testing.T) {
 	logDone("build - relative workdir")
 }
 
+func TestBuildWorkdirWithEnvVariables(t *testing.T) {
+	name := "testbuildworkdirwithenvvariables"
+	expected := "/test1/test2/$MISSING_VAR"
+	defer deleteImages(name)
+	_, err := buildImage(name,
+		`FROM busybox
+		ENV DIRPATH /test1
+		ENV SUBDIRNAME test2
+		WORKDIR $DIRPATH
+		WORKDIR $SUBDIRNAME/$MISSING_VAR`,
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := inspectField(name, "Config.WorkingDir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != expected {
+		t.Fatalf("Workdir %s, expected %s", res, expected)
+	}
+	logDone("build - workdir with env variables")
+}
+
 func TestBuildEnv(t *testing.T) {
 	name := "testbuildenv"
 	expected := "[PATH=/test:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PORT=2375]"


### PR DESCRIPTION
This PR carries #7033 to master. The actual code changes to the builder aren't relevant any more, but the test and the documentation change are still relevant.
