### PR TITLE
fix help message for mkimage debootstrap with components

### DIFF
--- a/contrib/mkimage.sh
+++ b/contrib/mkimage.sh
@@ -6,7 +6,7 @@ mkimg="$(basename "$0")"
 usage() {
 	echo >&2 "usage: $mkimg [-d dir] [-t tag] script [script-args]"
 	echo >&2 "   ie: $mkimg -t someuser/debian debootstrap --variant=minbase jessie"
-	echo >&2 "       $mkimg -t someuser/ubuntu debootstrap --include=ubuntu-minimal --components main,universe trusty"
+	echo >&2 "       $mkimg -t someuser/ubuntu debootstrap --include=ubuntu-minimal --components=main,universe trusty"
 	echo >&2 "       $mkimg -t someuser/busybox busybox-static"
 	echo >&2 "       $mkimg -t someuser/centos:5 rinse --distribution centos-5"
 	echo >&2 "       $mkimg -t someuser/mageia:4 mageia-urpmi --version=4"


### PR DESCRIPTION
debootstrap needs the suite as the second argument, for this the script
reorders arguments beginning with a minus but components separated by
space, as stated by the help message, is not handled and will lead to
the rootfs being passed as suite to debootstrap.
The poor mans solution is to fix the help message to pass the long
option as one argument.
