### PR TITLE
Support for consistent MAC address.

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -215,6 +215,7 @@ func populateCommand(c *Container, env []string) error {
 				Bridge:      network.Bridge,
 				IPAddress:   network.IPAddress,
 				IPPrefixLen: network.IPPrefixLen,
+				MacAddress:  network.MacAddress,
 			}
 		}
 	case "container":
@@ -504,6 +505,7 @@ func (container *Container) allocateNetwork() error {
 	container.NetworkSettings.Bridge = env.Get("Bridge")
 	container.NetworkSettings.IPAddress = env.Get("IP")
 	container.NetworkSettings.IPPrefixLen = env.GetInt("IPPrefixLen")
+	container.NetworkSettings.MacAddress = env.Get("MacAddress")
 	container.NetworkSettings.Gateway = env.Get("Gateway")
 
 	return nil

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -65,8 +65,9 @@ type Network struct {
 type NetworkInterface struct {
 	Gateway     string `json:"gateway"`
 	IPAddress   string `json:"ip"`
-	Bridge      string `json:"bridge"`
 	IPPrefixLen int    `json:"ip_prefix_len"`
+	MacAddress  string `json:"mac_address"`
+	Bridge      string `json:"bridge"`
 }
 
 type Resources struct {

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -95,6 +95,7 @@ func (d *driver) createNetwork(container *libcontainer.Config, c *execdriver.Com
 		vethNetwork := libcontainer.Network{
 			Mtu:        c.Network.Mtu,
 			Address:    fmt.Sprintf("%s/%d", c.Network.Interface.IPAddress, c.Network.Interface.IPPrefixLen),
+			MacAddress: c.Network.Interface.MacAddress,
 			Gateway:    c.Network.Interface.Gateway,
 			Type:       "veth",
 			Bridge:     c.Network.Interface.Bridge,

--- a/daemon/network_settings.go
+++ b/daemon/network_settings.go
@@ -11,6 +11,7 @@ type PortMapping map[string]string // Deprecated
 type NetworkSettings struct {
 	IPAddress   string
 	IPPrefixLen int
+	MacAddress  string
 	Gateway     string
 	Bridge      string
 	PortMapping map[string]PortMapping // Deprecated

--- a/daemon/networkdriver/bridge/driver_test.go
+++ b/daemon/networkdriver/bridge/driver_test.go
@@ -102,3 +102,19 @@ func TestHostnameFormatChecking(t *testing.T) {
 		t.Fatal("Failed to check invalid HostIP")
 	}
 }
+
+func TestMacAddrGeneration(t *testing.T) {
+	ip := net.ParseIP("192.168.0.1")
+	mac := generateMacAddr(ip).String()
+
+	// Should be consistent.
+	if generateMacAddr(ip).String() != mac {
+		t.Fatal("Inconsistent MAC address")
+	}
+
+	// Should be unique.
+	ip2 := net.ParseIP("192.168.0.2")
+	if generateMacAddr(ip2).String() == mac {
+		t.Fatal("Non-unique MAC address")
+	}
+}


### PR DESCRIPTION
Right now, MAC addresses are randomly generated by the kernel when
creating the veth interfaces.

This causes different issues related to ARP, such as #4581, #5737 and #8269.

This change adds support for consistent MAC addresses, guaranteeing that
an IP address will always end up with the same MAC address, no matter
what.

Since IP addresses are already guaranteed to be unique by the
IPAllocator, MAC addresses will inherit this property as well for free.

Consistent mac addresses is also a requirement for stable networking (#8297)
since re-using the same IP address on a different MAC address triggers the ARP
issue.

Finally, this change makes the MAC address accessible through docker
inspect, which fixes #4033.

Signed-off-by: Andrea Luzzardi aluzzardi@gmail.com
