### PR TITLE
registry/endpoint: make it testable

### DIFF
--- a/registry/endpoint.go
+++ b/registry/endpoint.go
@@ -35,16 +35,7 @@ func scanForAPIVersion(hostname string) (string, APIVersion) {
 }
 
 func NewEndpoint(hostname string) (*Endpoint, error) {
-	var (
-		endpoint        Endpoint
-		trimmedHostname string
-		err             error
-	)
-	if !strings.HasPrefix(hostname, "http") {
-		hostname = "https://" + hostname
-	}
-	trimmedHostname, endpoint.Version = scanForAPIVersion(hostname)
-	endpoint.URL, err = url.Parse(trimmedHostname)
+	endpoint, err := newEndpoint(hostname)
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +50,22 @@ func NewEndpoint(hostname string) (*Endpoint, error) {
 		}
 	}
 
+	return endpoint, nil
+}
+func newEndpoint(hostname string) (*Endpoint, error) {
+	var (
+		endpoint        Endpoint
+		trimmedHostname string
+		err             error
+	)
+	if !strings.HasPrefix(hostname, "http") {
+		hostname = "https://" + hostname
+	}
+	trimmedHostname, endpoint.Version = scanForAPIVersion(hostname)
+	endpoint.URL, err = url.Parse(trimmedHostname)
+	if err != nil {
+		return nil, err
+	}
 	return &endpoint, nil
 }
 

--- a/registry/endpoint_test.go
+++ b/registry/endpoint_test.go
@@ -1,0 +1,27 @@
+package registry
+
+import "testing"
+
+func TestEndpointParse(t *testing.T) {
+	testData := []struct {
+		str      string
+		expected string
+	}{
+		{IndexServerAddress(), IndexServerAddress()},
+		{"http://0.0.0.0:5000", "http://0.0.0.0:5000/v1/"},
+		{"0.0.0.0:5000", "https://0.0.0.0:5000/v1/"},
+	}
+	for _, td := range testData {
+		e, err := newEndpoint(td.str)
+		if err != nil {
+			t.Errorf("%q: %s", td.str, err)
+		}
+		if e == nil {
+			t.Logf("something's fishy, endpoint for %q is nil", td.str)
+			continue
+		}
+		if e.String() != td.expected {
+			t.Errorf("expected %q, got %q", td.expected, e.String())
+		}
+	}
+}


### PR DESCRIPTION
@crosbymichael  and @dmcgowan I know it's too late for 1.3, but this adds back the tests we started, and make the initializer more testable.

Signed-off-by: Vincent Batts vbatts@redhat.com
