### PR TITLE
Fixes bad validMountMode check

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -235,7 +235,7 @@ func parseVolumesFromSpec(daemon *Daemon, spec string) (map[string]*Mount, error
 
 	if len(specParts) == 2 {
 		mode := specParts[1]
-		if validMountMode(mode) {
+		if !validMountMode(mode) {
 			return nil, fmt.Errorf("Invalid mode for volumes-from: %s", mode)
 		}
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -389,7 +389,7 @@ func TestRunVolumesFromInReadWriteMode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd = exec.Command(dockerBinary, "run", "--volumes-from", "parent", "busybox", "touch", "/test/file")
+	cmd = exec.Command(dockerBinary, "run", "--volumes-from", "parent:rw", "busybox", "touch", "/test/file")
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Needed to check if the mode was invalid and return error, not valid and
return error.

This didn't get picked up because the existing integration-cli tests
were all either expecting errors when a valid mode was passed in (e.g.
"ro" passed in, we expected an error because it was testing write).  So
modified a test which was testing for "rw" to actually pass in "rw"
instead of assuming the "rw"

ping @crosbymichael @vieux 
This needs to be merged before release!
