### PR TITLE
Adding docker-cli run param to set MAC address

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -457,6 +457,7 @@ func (container *Container) AllocateNetwork() error {
 	)
 
 	job := eng.Job("allocate_interface", container.ID)
+	job.Setenv("RequestedMac", container.Config.MacAddress)
 	if env, err = job.Stdout.AddEnv(); err != nil {
 		return err
 	}

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -192,7 +192,7 @@ and foreground Docker containers.
    Set the MAC address for the container's ethernet device:
     --mac-address=12:34:56:78:9a:bc
 
-Remember that the MAC address in an ethernet network must be unique.
+Remember that the MAC address in an Ethernet network must be unique.
 The IPv6 link-local address will be based on the device's MAC address
 according to RFC4862.
 

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -29,6 +29,7 @@ docker-run - Run a command in a new container
 [**-m**|**--memory**[=*MEMORY*]]
 [**--name**[=*NAME*]]
 [**--net**[=*"bridge"*]]
+[**--mac-address**[=*MACADDRESS*]]
 [**-P**|**--publish-all**[=*false*]]
 [**-p**|**--publish**[=*[]*]]
 [**--privileged**[=*false*]]
@@ -186,6 +187,14 @@ and foreground Docker containers.
                                'none': no networking for this container
                                'container:<name|id>': reuses another container network stack
                                'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+
+**--mac-address**=*macaddress*
+   Set the MAC address for the container's ethernet device:
+    --mac-address=12:34:56:78:9a:bc
+
+Remember that the MAC address in an ethernet network must be unique.
+The IPv6 link-local address will be based on the device's MAC address
+according to RFC4862.
 
 **-P**, **--publish-all**=*true*|*false*
    When set to true publish all exposed ports to the host interfaces. The

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -189,7 +189,7 @@ and foreground Docker containers.
                                'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
 
 **--mac-address**=*macaddress*
-   Set the MAC address for the container's ethernet device:
+   Set the MAC address for the container's Ethernet device:
     --mac-address=12:34:56:78:9a:bc
 
 Remember that the MAC address in an Ethernet network must be unique.

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -104,6 +104,9 @@ Finally, several networking options can only be provided when calling
  *  `--net=bridge|none|container:NAME_or_ID|host` — see
     [How Docker networks a container](#container-networking)
 
+ *  `--mac-address=MACADDRESS...` — see
+    [How docker networks a container](#container-networking)
+
  *  `-p SPEC` or `--publish=SPEC` — see
     [Binding container ports](#binding-ports)
 
@@ -537,9 +540,15 @@ The steps with which Docker configures a container are:
     separate and unique network interface namespace, there are no
     physical interfaces with which this name could collide.
 
-4.  Give the container's `eth0` a new IP address from within the
+4.  Set the interface's mac address according to the `--mac-address`
+    parameter or generate a random one.
+
+5.  Give the container's `eth0` a new IP address from within the
     bridge's range of network addresses, and set its default route to
-    the IP address that the Docker host owns on the bridge.
+    the IP address that the Docker host owns on the bridge. If available
+    the IP address is generated from the MAC address. This prevents arp
+    cache invalidation problems, when a new container comes up with an
+    IP used in the past by another container with another MAC.
 
 With these steps complete, the container now possesses an `eth0`
 (virtual) network card and will find itself able to communicate with
@@ -621,6 +630,7 @@ Docker do all of the configuration:
 
     $ sudo ip link set B netns $pid
     $ sudo ip netns exec $pid ip link set dev B name eth0
+    $ sudo ip netns exec $pid ip link set eth0 address 12:34:56:78:9a:bc
     $ sudo ip netns exec $pid ip link set eth0 up
     $ sudo ip netns exec $pid ip addr add 172.17.42.99/16 dev eth0
     $ sudo ip netns exec $pid ip route add default via 172.17.42.1

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -105,7 +105,7 @@ Finally, several networking options can only be provided when calling
     [How Docker networks a container](#container-networking)
 
  *  `--mac-address=MACADDRESS...` — see
-    [How docker networks a container](#container-networking)
+    [How Docker networks a container](#container-networking)
 
  *  `-p SPEC` or `--publish=SPEC` — see
     [Binding container ports](#binding-ports)
@@ -540,13 +540,13 @@ The steps with which Docker configures a container are:
     separate and unique network interface namespace, there are no
     physical interfaces with which this name could collide.
 
-4.  Set the interface's mac address according to the `--mac-address`
+4.  Set the interface's MAC address according to the `--mac-address`
     parameter or generate a random one.
 
 5.  Give the container's `eth0` a new IP address from within the
     bridge's range of network addresses, and set its default route to
     the IP address that the Docker host owns on the bridge. If available
-    the IP address is generated from the MAC address. This prevents arp
+    the IP address is generated from the MAC address. This prevents ARP
     cache invalidation problems, when a new container comes up with an
     IP used in the past by another container with another MAC.
 

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -54,7 +54,7 @@ total memory available (`MemTotal`).
 
 `POST /containers/create`
 **New!**
-You can define the container's MAC address by providing a MacAddress key-value pair.
+You can set the new container's MAC address explicitly.
 
 ## v1.15
 

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -52,6 +52,10 @@ You can still call an old version of the API using
 `info` now returns the number of CPUs available on the machine (`NCPU`) and
 total memory available (`MemTotal`).
 
+`POST /containers/create`
+**New!**
+You can define the container's MAC address by providing a MacAddress key-value pair.
+
 ## v1.15
 
 ### Full Documentation

--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -131,6 +131,7 @@ Create a container
              },
              "WorkingDir":"",
              "NetworkDisabled": false,
+             "MacAddress":"12:34:56:78:9a:bc",
              "ExposedPorts":{
                      "22/tcp": {}
              },

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -131,6 +131,7 @@ Create a container
              },
              "WorkingDir":"",
              "NetworkDisabled": false,
+             "MacAddress":"12:34:56:78:9a:bc",
              "ExposedPorts":{
                      "22/tcp": {}
              },

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -516,6 +516,7 @@ Creates a new container.
       --lxc-conf=[]              (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
       -m, --memory=""            Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
       --name=""                  Assign a name to the container
+      --mac-address=""           Set the container's MAC address
       --net="bridge"             Set the Network mode for the container
                                    'bridge': creates a new network stack for the container on the docker bridge
                                    'none': no networking for this container
@@ -866,6 +867,13 @@ For the most part, you can pick out any field from the JSON in a fairly
 straightforward manner.
 
     $ sudo docker inspect --format='{{.NetworkSettings.IPAddress}}' $INSTANCE_ID
+
+**Get an instance's MAC Address:**
+
+For the most part, you can pick out any field from the JSON in a fairly
+straightforward manner.
+
+    $ sudo docker inspect --format='{{.NetworkSettings.MacAddress}}' $INSTANCE_ID
 
 **List All Port Bindings:**
 

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -140,7 +140,7 @@ example, `docker run ubuntu:14.04`.
                                   'container:<name|id>': reuses another container network stack
                                   'host': use the host network stack inside the container
     --add-host=""    : Add a line to /etc/hosts (host:IP)
-    --mac-address="" : Sets the container's ethernet device's MAC address
+    --mac-address="" : Sets the container's Ethernet device's MAC address
 
 By default, all containers have networking enabled and they can make any
 outgoing connections. The operator can completely disable networking

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -140,7 +140,7 @@ example, `docker run ubuntu:14.04`.
                                   'container:<name|id>': reuses another container network stack
                                   'host': use the host network stack inside the container
     --add-host=""    : Add a line to /etc/hosts (host:IP)
-    --mac-address="" : Sets the container's ethernet device's mac address
+    --mac-address="" : Sets the container's ethernet device's MAC address
 
 By default, all containers have networking enabled and they can make any
 outgoing connections. The operator can completely disable networking
@@ -151,9 +151,9 @@ networking. In cases like this, you would perform I/O through files or
 Your container will use the same DNS servers as the host by default, but
 you can override this with `--dns`.
 
-By default a random mac is generated. You can set the container's mac address
-explicitly by providing a mac via the `--mac-address` parameter (format:
-12:34:56:78:9a:bc).
+By default a random MAC is generated. You can set the container's MAC address
+explicitly by providing a MAC via the `--mac-address` parameter (format:
+`12:34:56:78:9a:bc`).
 
 Supported networking modes are:
 

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -133,13 +133,14 @@ example, `docker run ubuntu:14.04`.
 
 ## Network settings
 
-    --dns=[]        : Set custom dns servers for the container
-    --net="bridge"  : Set the Network mode for the container
-                                 'bridge': creates a new network stack for the container on the docker bridge
-                                 'none': no networking for this container
-                                 'container:<name|id>': reuses another container network stack
-                                 'host': use the host network stack inside the container
-    --add-host=""   : Add a line to /etc/hosts (host:IP)
+    --dns=[]         : Set custom dns servers for the container
+    --net="bridge"   : Set the Network mode for the container
+                                  'bridge': creates a new network stack for the container on the docker bridge
+                                  'none': no networking for this container
+                                  'container:<name|id>': reuses another container network stack
+                                  'host': use the host network stack inside the container
+    --add-host=""    : Add a line to /etc/hosts (host:IP)
+    --mac-address="" : Sets the container's ethernet device's mac address
 
 By default, all containers have networking enabled and they can make any
 outgoing connections. The operator can completely disable networking
@@ -149,6 +150,10 @@ networking. In cases like this, you would perform I/O through files or
 
 Your container will use the same DNS servers as the host by default, but
 you can override this with `--dns`.
+
+By default a random mac is generated. You can set the container's mac address
+explicitly by providing a mac via the `--mac-address` parameter (format:
+12:34:56:78:9a:bc).
 
 Supported networking modes are:
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2027,11 +2027,11 @@ func TestRunSetMacAddress(t *testing.T) {
 	}
 	actualMac := strings.TrimSpace(out)
 	if actualMac != mac {
-		t.Fatalf("Set Mac Address with --mac-address failed. The container has an incorrect MAC address: %q, expected: %q", actualMac, mac)
+		t.Fatalf("Set MAC address with --mac-address failed. The container has an incorrect MAC address: %q, expected: %q", actualMac, mac)
 	}
 
 	deleteAllContainers()
-	logDone("run - setting Mac Address with --mac-address")
+	logDone("run - setting MAC address with --mac-address")
 }
 
 func TestRunInspectMacAddress(t *testing.T) {
@@ -2047,10 +2047,10 @@ func TestRunInspectMacAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 	if inspectedMac != mac {
-		t.Fatalf("Inspecting Mac Address with failed. docker inspect shows incorrect MacAddress: %q, actual Mac: %q", inspectedMac, mac)
+		t.Fatalf("docker inspect outputs wrong MAC address: %q, should be: %q", inspectedMac, mac)
 	}
 	deleteAllContainers()
-	logDone("run - inspecting Mac Address")
+	logDone("run - inspecting MAC address")
 }
 
 func TestRunDeallocatePortOnMissingIptablesRule(t *testing.T) {

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	WorkingDir      string
 	Entrypoint      []string
 	NetworkDisabled bool
+	MacAddress      string
 	OnBuild         []string
 	SecurityOpt     []string
 }
@@ -53,6 +54,7 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 		Image:           job.Getenv("Image"),
 		WorkingDir:      job.Getenv("WorkingDir"),
 		NetworkDisabled: job.GetenvBool("NetworkDisabled"),
+		MacAddress:      job.Getenv("MacAddress"),
 	}
 	job.GetenvJson("ExposedPorts", &config.ExposedPorts)
 	job.GetenvJson("Volumes", &config.Volumes)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -59,7 +59,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.")
-		flMacAddress      = cmd.String([]string{"-mac-address"}, "", "Container MAC address (ex: 92:d0:c6:0a:29:33)")
+		flMacAddress      = cmd.String([]string{"-mac-address"}, "", "Container MAC address (e.g. 92:d0:c6:0a:29:33)")
 		flRestartPolicy   = cmd.String([]string{"-restart"}, "", "Restart policy to apply when a container exits (no, on-failure[:max-retry], always)")
 	)
 

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -59,6 +59,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.")
+		flMacAddress      = cmd.String([]string{"-mac-address"}, "", "Container MAC address (ex: 92:d0:c6:0a:29:33)")
 		flRestartPolicy   = cmd.String([]string{"-restart"}, "", "Restart policy to apply when a container exits (no, on-failure[:max-retry], always)")
 	)
 
@@ -269,6 +270,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		Cmd:             runCmd,
 		Image:           image,
 		Volumes:         flVolumes.GetMap(),
+		MacAddress:      *flMacAddress,
 		Entrypoint:      entrypoint,
 		WorkingDir:      *flWorkingDir,
 		SecurityOpt:     flSecurityOpt.GetAll(),


### PR DESCRIPTION
Follow-up to #8308 and #8371 
Fixes #4918 

I have implemented a functionality to set the container's mac address explicitly via docker-run CLI.

```
$ docker run -i -t --mac-address=26:99:7c:50:d8:20 --name=my-container ubuntu bash

$ docker inspect my-container
...
"NetworkSettings": {
    "Bridge": "docker0",
    "Gateway": "172.17.42.1",
    "IPAddress": "172.17.0.2",
    "IPPrefixLen": 16,
    "MacAddress": "26:99:7c:50:d8:20",
    "PortMapping": null,
    "Ports": {}
},
...
```
