### PR TITLE
Make V2 code more defensive against malformed content

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -463,7 +463,7 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 	}
 
 	if verified {
-		out.Write(sf.FormatStatus(localName+":"+tag, "The image you are pulling has been digitally signed by Docker, Inc."))
+		out.Write(sf.FormatStatus(localName+":"+tag, "The image you are pulling has been verified"))
 	} else {
 		out.Write(sf.FormatStatus(tag, "Pulling from %s", localName))
 	}

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -453,9 +453,10 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 	}
 
 	if verified {
-		out.Write(sf.FormatStatus("", "The image you are pulling has been digitally signed by Docker, Inc."))
+		out.Write(sf.FormatStatus(localName+":"+tag, "The image you are pulling has been digitally signed by Docker, Inc."))
+	} else {
+		out.Write(sf.FormatStatus(tag, "Pulling from %s", localName))
 	}
-	out.Write(sf.FormatStatus(tag, "Pulling from %s", localName))
 
 	if len(manifest.BlobSums) == 0 {
 		return fmt.Errorf("no blobSums in manifest")
@@ -489,7 +490,7 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 		out.Write(sf.FormatProgress(utils.TruncateID(img.ID), "Pulling fs layer", nil))
 
 		downloadFunc := func(di *downloadInfo) error {
-			log.Infof("pulling blob %q to V1 img %s", sumStr, img.ID)
+			log.Debugf("pulling blob %q to V1 img %s", sumStr, img.ID)
 
 			if c, err := s.poolAdd("pull", "img:"+img.ID); err != nil {
 				if c != nil {

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -458,7 +458,7 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 		return false, fmt.Errorf("error verifying manifest: %s", err)
 	}
 
-	if len(manifest.BlobSums) != len(manifest.History) {
+	if len(manifest.FSLayers) != len(manifest.History) {
 		return false, fmt.Errorf("length of history not equal to number of layers")
 	}
 
@@ -468,16 +468,16 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 		out.Write(sf.FormatStatus(tag, "Pulling from %s", localName))
 	}
 
-	if len(manifest.BlobSums) == 0 {
+	if len(manifest.FSLayers) == 0 {
 		return false, fmt.Errorf("no blobSums in manifest")
 	}
 
-	downloads := make([]downloadInfo, len(manifest.BlobSums))
+	downloads := make([]downloadInfo, len(manifest.FSLayers))
 
-	for i := len(manifest.BlobSums) - 1; i >= 0; i-- {
+	for i := len(manifest.FSLayers) - 1; i >= 0; i-- {
 		var (
-			sumStr  = manifest.BlobSums[i]
-			imgJSON = []byte(manifest.History[i])
+			sumStr  = manifest.FSLayers[i].BlobSum
+			imgJSON = []byte(manifest.History[i].V1Compatibility)
 		)
 
 		img, err := image.NewImgJSON(imgJSON)

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -14,13 +14,16 @@ import (
 	"github.com/docker/docker/utils"
 )
 
-// Where we store the config file
-const CONFIGFILE = ".dockercfg"
+const (
+	// Where we store the config file
+	CONFIGFILE = ".dockercfg"
 
-// Only used for user auth + account creation
-const INDEXSERVER = "https://index.docker.io/v1/"
+	// Only used for user auth + account creation
+	INDEXSERVER    = "https://index.docker.io/v1/"
+	REGISTRYSERVER = "https://registry-1.docker.io/v1/"
 
-//const INDEXSERVER = "https://registry-stage.hub.docker.com/v1/"
+	// INDEXSERVER = "https://registry-stage.hub.docker.com/v1/"
+)
 
 var (
 	ErrConfigFileMissing = errors.New("The Auth config file is missing")

--- a/registry/session_v2.go
+++ b/registry/session_v2.go
@@ -28,13 +28,13 @@ func newV2RegistryRouter() *mux.Router {
 	v2Router.Path("/tags/{imagename:[a-z0-9-._/]+}").Name("tags")
 
 	// Download a blob
-	v2Router.Path("/blob/{imagename:[a-z0-9-._/]+}/{sumtype:[a-z0-9_+-]+}/{sum:[a-fA-F0-9]{4,}}").Name("downloadBlob")
+	v2Router.Path("/blob/{imagename:[a-z0-9-._/]+}/{sumtype:[a-z0-9._+-]+}/{sum:[a-fA-F0-9]{4,}}").Name("downloadBlob")
 
 	// Upload a blob
-	v2Router.Path("/blob/{imagename:[a-z0-9-._/]+}/{sumtype:[a-z0-9_+-]+}").Name("uploadBlob")
+	v2Router.Path("/blob/{imagename:[a-z0-9-._/]+}/{sumtype:[a-z0-9._+-]+}").Name("uploadBlob")
 
 	// Mounting a blob in an image
-	v2Router.Path("/mountblob/{imagename:[a-z0-9-._/]+}/{sumtype:[a-z0-9_+-]+}/{sum:[a-fA-F0-9]{4,}}").Name("mountBlob")
+	v2Router.Path("/mountblob/{imagename:[a-z0-9-._/]+}/{sumtype:[a-z0-9._+-]+}/{sum:[a-fA-F0-9]{4,}}").Name("mountBlob")
 
 	return router
 }

--- a/registry/session_v2.go
+++ b/registry/session_v2.go
@@ -57,10 +57,14 @@ func getV2URL(e *Endpoint, routeName string, vars map[string]string) (*url.URL, 
 	if err != nil {
 		return nil, fmt.Errorf("unable to make registry route %q with vars %v: %s", routeName, vars, err)
 	}
+	u, err := url.Parse(REGISTRYSERVER)
+	if err != nil {
+		return nil, fmt.Errorf("invalid registry url: %s", err)
+	}
 
 	return &url.URL{
-		Scheme: e.URL.Scheme,
-		Host:   e.URL.Host,
+		Scheme: u.Scheme,
+		Host:   u.Host,
 		Path:   routePath.Path,
 	}, nil
 }

--- a/registry/types.go
+++ b/registry/types.go
@@ -32,13 +32,21 @@ type RegistryInfo struct {
 	Standalone bool   `json:"standalone"`
 }
 
+type FSLayer struct {
+	BlobSum string `json:"blobSum"`
+}
+
+type ManifestHistory struct {
+	V1Compatibility string `json:"v1Compatibility"`
+}
+
 type ManifestData struct {
-	Name          string   `json:"name"`
-	Tag           string   `json:"tag"`
-	Architecture  string   `json:"architecture"`
-	BlobSums      []string `json:"blobSums"`
-	History       []string `json:"history"`
-	SchemaVersion int      `json:"schemaVersion"`
+	Name          string             `json:"name"`
+	Tag           string             `json:"tag"`
+	Architecture  string             `json:"architecture"`
+	FSLayers      []*FSLayer         `json:"fsLayers"`
+	History       []*ManifestHistory `json:"history"`
+	SchemaVersion int                `json:"schemaVersion"`
 }
 
 type APIVersion int


### PR DESCRIPTION
Added more checks in the V2 code against possible malformed or changed content.  This code will only be hit when pulling from the V2 registry, which is still only for official images.

Ping @crosbymichael
