### PR TITLE
[WIP] Add ZFS graphdriver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,11 @@ RUN	apt-get update && apt-get install -y \
 	ruby1.9.1 \
 	ruby1.9.1-dev \
 	s3cmd=1.1.0* \
+	software-properties-common \
 	--no-install-recommends
+
+# Install zfs
+RUN	apt-add-repository -y ppa:zfs-native/stable && apt-get update && apt-get install -y ubuntu-zfs
 
 # Get lvm2 source for compiling statically
 RUN	git clone --no-checkout https://git.fedorahosted.org/git/lvm2.git /usr/local/lvm2 && cd /usr/local/lvm2 && git checkout -q v2_02_103

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -40,7 +40,7 @@ func remote(eng *engine.Engine) error {
 // daemon: a default execution and storage backend for Docker on Linux,
 // with the following underlying components:
 //
-// * Pluggable storage drivers including aufs, vfs, lvm and btrfs.
+// * Pluggable storage drivers including aufs, zfs, vfs, lvm and btrfs.
 // * Pluggable execution drivers including lxc and chroot.
 //
 // In practice `daemon` still includes most core Docker components, including:

--- a/daemon/daemon_zfs.go
+++ b/daemon/daemon_zfs.go
@@ -1,0 +1,7 @@
+// +build !exclude_graphdriver_zfs
+
+package daemon
+
+import (
+	_ "github.com/docker/docker/daemon/graphdriver/zfs"
+)

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -42,6 +42,7 @@ var (
 	ErrAufsNotSupported = fmt.Errorf("AUFS was not found in /proc/filesystems")
 	incompatibleFsMagic = []graphdriver.FsMagic{
 		graphdriver.FsMagicBtrfs,
+		graphdriver.FsMagicZfs,
 		graphdriver.FsMagicAufs,
 	}
 )

--- a/daemon/graphdriver/devmapper/mount.go
+++ b/daemon/graphdriver/devmapper/mount.go
@@ -4,6 +4,7 @@ package devmapper
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -72,7 +73,55 @@ func ProbeFsType(device string) (string, error) {
 		}
 	}
 
+	isZFS, err := probeZFS(device)
+	if err != nil {
+		return "", err
+	}
+	if isZFS {
+		return "zfs", nil
+	}
+
 	return "", fmt.Errorf("Unknown filesystem type on %s", device)
+}
+
+const (
+	zfsUberBlockBigEndian    = 0x00BAB10C
+	zfsUberBlockLittleEndian = 0x0CB1BA00
+)
+
+// ZFS doesn't really have magic bytes at the start of the device like most
+// other FSes do, but it does store an "Uberblock" quite early on the volume,
+// which is guaranteed to start with the uint32 0x00BAB1OC ("oo-ba-bl-oc") in
+// native endianness. Each Uberblock slot is 1024 bytes, and the first 4 bytes
+// thereof are the magic constant. However, it's not totally predictable where
+// we'll find this constant, so we scan the first 4 bytes of each of the first
+// 2048 1024-byte aligned chunks (2MB).
+//
+// It's VERY likely that there's a smaller range we could scan and get the same
+// results. This code plays it on the safe side.
+func probeZFS(device string) (bool, error) {
+	file, err := os.Open(device)
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+
+	blocksize := 1024
+	count := 2048
+
+	buffer := make([]byte, 4)
+	for i := 0; i < count; i++ {
+		offset := i * blocksize
+		_, err := file.ReadAt(buffer, int64(offset))
+		if err != nil {
+			return false, err
+		}
+		oobabloc := binary.BigEndian.Uint32(buffer)
+		if oobabloc == zfsUberBlockLittleEndian || oobabloc == zfsUberBlockBigEndian {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func joinMountOptions(a, b string) string {

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -14,6 +14,7 @@ type FsMagic uint64
 
 const (
 	FsMagicBtrfs = FsMagic(0x9123683E)
+	FsMagicZfs   = FsMagic(0x2FC12FC1)
 	FsMagicAufs  = FsMagic(0x61756673)
 )
 
@@ -78,6 +79,7 @@ var (
 	// Slice of drivers that should be used in an order
 	priority = []string{
 		"aufs",
+		"zfs",
 		"btrfs",
 		"devicemapper",
 		"vfs",

--- a/daemon/graphdriver/zfs/fs.go
+++ b/daemon/graphdriver/zfs/fs.go
@@ -1,0 +1,97 @@
+package zfs
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"os/exec"
+	"strings"
+)
+
+// TODO(burke): Return output instead of "exit status 1"
+
+// TODO(burke): debug logging in a more sane way here...
+func zfsCommand(args ...string) *exec.Cmd {
+	log.Println("zfsCommand:", args)
+	return exec.Command("zfs", args...)
+}
+
+func zfsGetPool(path string) (poolName, mountPoint string, err error) {
+	args := []string{"list", "-Ho", "name,mountpoint", "-t", "filesystem", path}
+	out, err := zfsCommand(args...).Output()
+	if err != nil {
+		return "", "", err
+	}
+	line := strings.TrimSpace(string(out))
+	fields := strings.Split(line, "\t")
+	return fields[0], fields[1], nil
+}
+
+func zfsCreateAutomountingDataset(path string) error {
+	return zfsCommand("create", "-o", path).Run()
+}
+
+func zfsCreateDataset(path string) error {
+	// Note that we instruct ZFS not to mount these datasets automatically. It
+	// would not be sensible for the OS to attempt to mount all docker volumes on
+	// startup.
+	return zfsCommand("create", "-o", "canmount=noauto", path).Run()
+}
+
+func zfsMountDataset(id, mlsLabel string) error {
+	// First, check if it's already mounted, and return if it is.
+	out, err := zfsCommand("list", "-Ho", "mounted", id).Output()
+	if err == nil && string(out) == "yes\n" {
+		return nil
+	}
+
+	if mlsLabel == "" {
+		return zfsCommand("mount", id).Run()
+	}
+	label := fmt.Sprintf("mlslabel=%s", mlsLabel)
+	return zfsCommand("mount", "-o", label, id).Run()
+}
+
+func zfsUnmountDataset(id string) error {
+	return zfsCommand("unmount", id).Run()
+}
+
+func zfsDatasetExists(id string) bool {
+	// here we just interpret any error as non-existence. This isn't ideal, but
+	// we're forced into a binary return by Driver.Exists() anyway, so it's ok.
+	err := zfsCommand("list", "-Ho", "mounted", id)
+	return err == nil
+}
+
+// zfsCloneDataset clones a dataset using the following procedure:
+//  1. Create a snapshot of the source dataset;
+//  2. Clone the snapshot as the destination dataset;
+//  3. Destroy the snapshot.
+func zfsCloneDataset(src, dest string) error {
+	// default rand source is ok here.
+	snapshot := fmt.Sprintf("%s@docker_%x", src, rand.Int31())
+
+	// 1. Create the snapshot
+	if err := zfsCommand("snapshot", snapshot).Run(); err != nil {
+		return err
+	}
+
+	// 2. Clone the snapshot
+	args := []string{"clone", "-o", "canmount=noauto", snapshot, dest}
+	if err := zfsCommand(args...).Run(); err != nil {
+		return err
+	}
+
+	// 3. Destroy the snapshot
+	if err := zfsCommand("destroy", "-d", snapshot).Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// We *may* want to go through the trouble to promote a clone first here. See:
+// https://github.com/gurjeet/docker/blob/00cb6818/graphdriver/zfs/zfs.go#L182-L221
+func zfsDestroyDataset(id string) error {
+	return zfsCommand("destroy", "-r", id).Run()
+}

--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -1,0 +1,193 @@
+// Package zfs implements a graphdriver for ZFS-on-Linux.
+package zfs
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/pkg/mount"
+)
+
+func init() {
+	_ = graphdriver.Register("zfs", Init)
+}
+
+// Driver represents an initialized ZFS graphdriver.
+type Driver struct {
+	home          string
+	poolName      string
+	rootDataset   string
+	openDatasetsM sync.Mutex
+	openDatasets  map[string]struct{}
+}
+
+func (d *Driver) checkout(id string) {
+	d.openDatasetsM.Lock()
+	defer d.openDatasetsM.Unlock()
+	d.openDatasets[id] = struct{}{}
+}
+
+func (d *Driver) checkin(id string) {
+	d.openDatasetsM.Lock()
+	defer d.openDatasetsM.Unlock()
+	delete(d.openDatasets, id)
+}
+
+// Init initializes the graphdriver on a given mountpoint. It performs few
+// sanity checks to make sure the specified path is actually a ZFS pool before
+// initializing and returning the data structure.
+func Init(home string, options []string) (graphdriver.Driver, error) {
+	rootdir := path.Dir(home)
+
+	var buf syscall.Statfs_t
+	if err := syscall.Statfs(rootdir, &buf); err != nil {
+		return nil, err
+	}
+
+	if graphdriver.FsMagic(buf.Type) != graphdriver.FsMagicZfs {
+		return nil, graphdriver.ErrPrerequisites
+	}
+
+	if err := os.MkdirAll(home, 0700); err != nil {
+		return nil, err
+	}
+
+	poolName, mountPoint, err := zfsGetPool(home)
+	if err != nil {
+		return nil, err
+	}
+
+	rootDataset := poolName + strings.TrimPrefix(home, mountPoint)
+	if err := createParentDatasets(rootDataset); err != nil {
+		return nil, err
+	}
+
+	if err := graphdriver.MakePrivate(home); err != nil {
+		return nil, err
+	}
+
+	driver := &Driver{
+		home:         home,
+		poolName:     poolName,
+		rootDataset:  rootDataset,
+		openDatasets: make(map[string]struct{}),
+	}
+
+	// cd into the mountpoint. As long as the daemon doesn't cd anywhere
+	// else later, this prevents the pool from being unmounted.
+	if err := os.Chdir(home); err != nil {
+		return nil, fmt.Errorf("zfs-Init: Could not change to the mount point '%s'", home)
+	}
+
+	return graphdriver.NaiveDiffDriver(driver), nil
+}
+
+// If we're given, e.g. --storage-path=/zpool/docker, then the home is
+// /zpool/docker/zfs. If the ZFS mountpoint is actually /zpool, then we have to
+// ensure that /zpool/docker/zfs and /zpool/docker are both mounted ZFS
+// datasets, else deeper-nested dataset creation will fail.
+func createParentDatasets(target string) error {
+	parts := strings.Split(target, "/")
+	for {
+		parts = parts[0 : len(parts)-1]
+		if len(parts) == 1 {
+			// We've reached the pool, which certainly exists.
+			return nil
+		}
+		ds := strings.Join(parts, "/")
+		if zfsDatasetExists(ds) {
+			continue
+		}
+		if err := zfsMountDataset(ds, ""); err != nil {
+			if err := zfsCreateAutomountingDataset(ds); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// String returns a string representation of this driver.
+func (d *Driver) String() string {
+	return "zfs"
+}
+
+// Status returns a set of key-value pairs which give low level diagnostic
+// status about this driver. Root Dir and Pool Name are the path and name of the
+// pool, respectively, and "Open Datasets" is the number of open references per
+// dataset tracked.
+func (d *Driver) Status() [][2]string {
+	d.openDatasetsM.Lock()
+	defer d.openDatasetsM.Unlock()
+	return [][2]string{
+		{"Root Dir", d.home},
+		{"Pool Name", d.poolName},
+		{"Open Datasets", fmt.Sprintf("%v", d.openDatasets)},
+	}
+}
+
+// Cleanup performs necessary tasks to release resources held by the driver:
+// In this case, that means unmounting all mounted datasets.
+func (d *Driver) Cleanup() error {
+	d.openDatasetsM.Lock()
+	defer d.openDatasetsM.Unlock()
+	for id := range d.openDatasets {
+		// we have to ignore this elsewhere, so we might as well here.
+		_ = zfsUnmountDataset(d.getDataset(id))
+	}
+	return mount.Unmount(d.home)
+}
+
+func (d *Driver) getDataset(id string) string {
+	return path.Join(d.rootDataset, id)
+}
+
+func (d *Driver) getPath(id string) string {
+	return path.Join(d.home, id)
+}
+
+// Create creates a new, empty, filesystem layer with the specified id and
+// parent. Parent may be "".
+func (d *Driver) Create(id string, parent string) error {
+	if parent == "" {
+		return zfsCreateDataset(d.getDataset(id))
+	}
+	parentDir, err := d.Get(parent, "")
+	if err != nil {
+		return err
+	}
+	_ = parentDir
+	return zfsCloneDataset(d.getDataset(parent), d.getDataset(id))
+}
+
+// Remove attempts to remove the dataset with this ID.
+func (d *Driver) Remove(id string) error {
+	return zfsDestroyDataset(d.getDataset(id))
+}
+
+// Get returns the mountpoint for the layered filesystem referred to by this
+// id, optionally with the given SELinux label. If the given dataset is already
+// mounted with a different label, the label will not be changed.
+func (d *Driver) Get(id, mountLabel string) (string, error) {
+	err := zfsMountDataset(d.getDataset(id), mountLabel)
+	if err != nil {
+		return "", err
+	}
+	return d.getPath(id), nil
+}
+
+// Put unmounts the underlying dataset when it has been called as many times as
+// Get (i.e.: reference counting is used).
+func (d *Driver) Put(id string) {
+	d.checkin(id)
+	_ = zfsUnmountDataset(d.getDataset(id))
+}
+
+// Exists returns whether a dataset with this ID exists.
+func (d *Driver) Exists(id string) bool {
+	return zfsDatasetExists(id)
+}

--- a/daemon/graphdriver/zfs/zfs_test.go
+++ b/daemon/graphdriver/zfs/zfs_test.go
@@ -1,0 +1,28 @@
+package zfs
+
+import (
+	"github.com/docker/docker/daemon/graphdriver/graphtest"
+	"testing"
+)
+
+// This avoids creating a new driver for each test if all tests are run
+// Make sure to put new tests between TestZFSSetup and TestZFSTeardown
+func TestZFSSetup(t *testing.T) {
+	graphtest.GetDriver(t, "zfs")
+}
+
+func TestZFSCreateEmpty(t *testing.T) {
+	graphtest.DriverTestCreateEmpty(t, "zfs")
+}
+
+func TestZFSCreateBase(t *testing.T) {
+	graphtest.DriverTestCreateBase(t, "zfs")
+}
+
+func TestZFSCreateSnap(t *testing.T) {
+	graphtest.DriverTestCreateSnap(t, "zfs")
+}
+
+func TestZFSTeardown(t *testing.T) {
+	graphtest.PutDriver(t)
+}

--- a/docs/sources/introduction/understanding-docker.md
+++ b/docs/sources/introduction/understanding-docker.md
@@ -267,7 +267,7 @@ limiting the memory available to a specific container.
 Union file systems, or UnionFS, are file systems that operate by creating layers,
 making them very lightweight and fast. Docker uses union file systems to provide
 the building blocks for containers. Docker can make use of several union file system variants
-including: AUFS, btrfs, vfs, and DeviceMapper.
+including: AUFS, btrfs, zfs, vfs, and DeviceMapper.
 
 ### Container format 
 Docker combines these components into a wrapper we call a container format. The

--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -59,6 +59,7 @@ To build the Docker daemon, you will additionally need:
   2.02.89 or later
 * btrfs-progs version 3.8 or later (including commit e5cb128 from 2013-01-07)
   for the necessary btrfs headers
+* ZFS on Linux 0.6.3 or later
 
 Be sure to also check out Docker's Dockerfile for the most up-to-date list of
 these build-time dependencies.
@@ -168,6 +169,11 @@ for all graphdrivers are built in.
 To disable btrfs:
 ```bash
 export DOCKER_BUILDTAGS='exclude_graphdriver_btrfs'
+```
+
+To disable zfs:
+```bash
+export DOCKER_BUILDTAGS='exclude_graphdriver_zfs'
 ```
 
 To disable devicemapper:


### PR DESCRIPTION
I haven't even tried this code yet, but I want to solicit comments. It occurred to me yesterday that ZFS support would actually be _really_ easy to implement. Is this a path you want to go down? At Shopify, most of us have more trust in ZFS than in BTRFS, and I get the sense that's a pretty common sentiment. 

Any pitfalls, concerns, etc.? Should I polish this up and test it, or will it be rejected? If so, why?

Thanks!

---

This work is largely based on the BTRFS graphdriver, and I used @gurjeet's earlier work at https://github.com/gurjeet/docker/tree/00cb6818/graphdriver/zfs for reference.

The current implementation shells out to the `zfs` tool. I debated implementing this with the semi-private `libzfs` and `cgo`, but decided that:

1) The API of the command-line tool will be more stable; and
2) This was a simpler first step.

If it is desired to implement on `libzfs` directly, all the actual integration is squared away in `fs.go`, which should make for a very easy refactor.

Note that this does add a pretty hairy dependency to the dev Dockerfile.  `ubuntu-zfs` takes a while to install, and makes some implicit assertions about the host kernel, which is fairly unique within the context of what's there presently. I'm not totally sure how/whether to work around this.

/cc FYI @graemej @Sirupsen @marc-barry @n1koo @dalehamel
