### PR TITLE
Preserve extended attributes and acls on archlinux build

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -60,6 +60,6 @@ mknod -m 600 $DEV/initctl p
 mknod -m 666 $DEV/ptmx c 5 2
 ln -sf /proc/self/fd $DEV/fd
 
-tar --numeric-owner -C $ROOTFS -c . | docker import - archlinux
+tar --numeric-owner --xattrs --acls -C $ROOTFS -c . | docker import - archlinux
 docker run -i -t archlinux echo Success.
 rm -rf $ROOTFS


### PR DESCRIPTION
Failure to do this means that file capabilites are not preserved in the image.
Ping fails to work as a non-root user if cap_net_raw is capability is not set

Signed-off-by: Dan Griffin dgriffin@peer1.com
