### PR TITLE
Fix Host header on stream commands

### DIFF
--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -131,7 +131,7 @@ func (cli *DockerCli) streamHelper(method, path string, setRawTerminal bool, in 
 		in = bytes.NewReader([]byte{})
 	}
 
-	req, err := http.NewRequest(method, fmt.Sprintf("http://v%s%s", api.APIVERSION, path), in)
+	req, err := http.NewRequest(method, fmt.Sprintf("/v%s%s", api.APIVERSION, path), in)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #8407

Setting Host on URL only works if the Request does not
already have its Host property set.

Note that the API version was also swallowed.

Signed-off-by: Tõnis Tiigi tonistiigi@gmail.com (github: tonistiigi)
