### PR TITLE
Allow specifying --port-range-begin and --port-range-end

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -1,9 +1,11 @@
 package daemon
 
 import (
+	"fmt"
 	"net"
 
 	"github.com/docker/docker/daemon/networkdriver"
+	"github.com/docker/docker/daemon/networkdriver/portallocator"
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -39,6 +41,8 @@ type Config struct {
 	Mtu                         int
 	DisableNetwork              bool
 	EnableSelinuxSupport        bool
+	StartPortRange              int
+	EndPortRange                int
 	Context                     map[string][]string
 }
 
@@ -61,7 +65,9 @@ func (config *Config) InstallFlags() {
 	flag.StringVar(&config.GraphDriver, []string{"s", "-storage-driver"}, "", "Force the Docker runtime to use a specific storage driver")
 	flag.StringVar(&config.ExecDriver, []string{"e", "-exec-driver"}, "native", "Force the Docker runtime to use a specific exec driver")
 	flag.BoolVar(&config.EnableSelinuxSupport, []string{"-selinux-enabled"}, false, "Enable selinux support. SELinux does not presently support the BTRFS storage driver")
-	flag.IntVar(&config.Mtu, []string{"#mtu", "-mtu"}, 0, "Set the containers network MTU\nif no value is provided: default to the default route MTU or 1500 if no default route is available")
+	flag.IntVar(&config.Mtu, []string{"#mtu", "-mtu"}, 0, fmt.Sprintf("Set the containers network MTU\nif no value is provided: default to the default route MTU or %d if no default route is available", defaultNetworkMtu))
+	flag.IntVar(&config.StartPortRange, []string{"#prs", "-port-range-start"}, portallocator.DefaultStartPortRange, fmt.Sprintf("Set range start for dynamic port allocator\nif no value is provided: default to %d", portallocator.DefaultStartPortRange))
+	flag.IntVar(&config.EndPortRange, []string{"#pre", "-port-range-end"}, portallocator.DefaultEndPortRange, fmt.Sprintf("Set range end for dynamic port allocator\nif no value is provided: default to %d", portallocator.DefaultEndPortRange))
 	opts.IPVar(&config.DefaultIp, []string{"#ip", "-ip"}, "0.0.0.0", "Default IP address to use when binding container ports")
 	opts.ListVar(&config.GraphOptions, []string{"-storage-opt"}, "Set storage driver options")
 	// FIXME: why the inconsistency between "hosts" and "sockets"?

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -719,8 +719,13 @@ func NewDaemon(config *Config, eng *engine.Engine) (*Daemon, error) {
 }
 
 func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error) {
+	// Apply configuration defaults
 	if config.Mtu == 0 {
 		config.Mtu = getDefaultNetworkMtu()
+	}
+	if config.StartPortRange == 0 && config.EndPortRange == 0 {
+		config.StartPortRange = portallocator.DefaultStartPortRange
+		config.EndPortRange = portallocator.DefaultEndPortRange
 	}
 	// Check for mutually incompatible config options
 	if config.BridgeIface != "" && config.BridgeIP != "" {
@@ -745,6 +750,11 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 			utils.RemovePidFile(config.Pidfile)
 		})
 	}
+	if config.StartPortRange-config.EndPortRange >= 0 || config.EndPortRange-config.StartPortRange < 0 {
+		return nil, fmt.Errorf("Invalid port range specified.")
+	}
+	portallocator.StartPortRange = config.StartPortRange
+	portallocator.EndPortRange = config.EndPortRange
 
 	// Check that the system is supported and we have sufficient privileges
 	if runtime.GOOS != "linux" {

--- a/daemon/networkdriver/portallocator/portallocator.go
+++ b/daemon/networkdriver/portallocator/portallocator.go
@@ -28,23 +28,24 @@ func newProtoMap() protoMap {
 	}
 }
 
-type ipMapping map[string]protoMap
-
-const (
-	BeginPortRange = 49153
-	EndPortRange   = 65535
-)
-
 var (
 	ErrAllPortsAllocated = errors.New("all ports are allocated")
 	ErrUnknownProtocol   = errors.New("unknown protocol")
 )
 
-var (
-	mutex sync.Mutex
+type ipMapping map[string]protoMap
 
-	defaultIP = net.ParseIP("0.0.0.0")
-	globalMap = ipMapping{}
+const (
+	DefaultStartPortRange = 49153
+	DefaultEndPortRange   = 65535
+)
+
+var (
+	mutex          sync.Mutex
+	defaultIP      = net.ParseIP("0.0.0.0")
+	globalMap      = ipMapping{}
+	StartPortRange = DefaultStartPortRange
+	EndPortRange   = DefaultEndPortRange
 )
 
 type ErrPortAlreadyAllocated struct {
@@ -137,10 +138,10 @@ func ReleaseAll() error {
 
 func (pm *portMap) findPort() (int, error) {
 	port := pm.last
-	for i := 0; i <= EndPortRange-BeginPortRange; i++ {
+	for i := 0; i <= EndPortRange-StartPortRange; i++ {
 		port++
 		if port > EndPortRange {
-			port = BeginPortRange
+			port = StartPortRange
 		}
 
 		if _, ok := pm.p[port]; !ok {

--- a/daemon/networkdriver/portallocator/portallocator_test.go
+++ b/daemon/networkdriver/portallocator/portallocator_test.go
@@ -17,7 +17,7 @@ func TestRequestNewPort(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if expected := BeginPortRange; port != expected {
+	if expected := DefaultStartPortRange; port != expected {
 		t.Fatalf("Expected port %d got %d", expected, port)
 	}
 }
@@ -102,13 +102,13 @@ func TestUnknowProtocol(t *testing.T) {
 func TestAllocateAllPorts(t *testing.T) {
 	defer reset()
 
-	for i := 0; i <= EndPortRange-BeginPortRange; i++ {
+	for i := 0; i <= DefaultEndPortRange-DefaultStartPortRange; i++ {
 		port, err := RequestPort(defaultIP, "tcp", 0)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if expected := BeginPortRange + i; port != expected {
+		if expected := DefaultStartPortRange + i; port != expected {
 			t.Fatalf("Expected port %d got %d", expected, port)
 		}
 	}
@@ -123,7 +123,7 @@ func TestAllocateAllPorts(t *testing.T) {
 	}
 
 	// release a port in the middle and ensure we get another tcp port
-	port := BeginPortRange + 5
+	port := DefaultStartPortRange + 5
 	if err := ReleasePort(defaultIP, "tcp", port); err != nil {
 		t.Fatal(err)
 	}
@@ -153,13 +153,13 @@ func BenchmarkAllocatePorts(b *testing.B) {
 	defer reset()
 
 	for i := 0; i < b.N; i++ {
-		for i := 0; i <= EndPortRange-BeginPortRange; i++ {
+		for i := 0; i <= DefaultEndPortRange-DefaultStartPortRange; i++ {
 			port, err := RequestPort(defaultIP, "tcp", 0)
 			if err != nil {
 				b.Fatal(err)
 			}
 
-			if expected := BeginPortRange + i; port != expected {
+			if expected := DefaultStartPortRange + i; port != expected {
 				b.Fatalf("Expected port %d got %d", expected, port)
 			}
 		}
@@ -231,15 +231,15 @@ func TestPortAllocation(t *testing.T) {
 func TestNoDuplicateBPR(t *testing.T) {
 	defer reset()
 
-	if port, err := RequestPort(defaultIP, "tcp", BeginPortRange); err != nil {
+	if port, err := RequestPort(defaultIP, "tcp", StartPortRange); err != nil {
 		t.Fatal(err)
-	} else if port != BeginPortRange {
-		t.Fatalf("Expected port %d got %d", BeginPortRange, port)
+	} else if port != StartPortRange {
+		t.Fatalf("Expected port %d got %d", StartPortRange, port)
 	}
 
 	if port, err := RequestPort(defaultIP, "tcp", 0); err != nil {
 		t.Fatal(err)
-	} else if port == BeginPortRange {
+	} else if port == StartPortRange {
 		t.Fatalf("Acquire(0) allocated the same port twice: %d", port)
 	}
 }

--- a/daemon/networkdriver/portmapper/mapper_test.go
+++ b/daemon/networkdriver/portmapper/mapper_test.go
@@ -129,7 +129,7 @@ func TestMapAllPortsSingleInterface(t *testing.T) {
 	}()
 
 	for i := 0; i < 10; i++ {
-		for i := portallocator.BeginPortRange; i < portallocator.EndPortRange; i++ {
+		for i := portallocator.DefaultStartPortRange; i < portallocator.DefaultEndPortRange; i++ {
 			if host, err = Map(srcAddr1, dstIp1, 0); err != nil {
 				t.Fatal(err)
 			}
@@ -137,8 +137,8 @@ func TestMapAllPortsSingleInterface(t *testing.T) {
 			hosts = append(hosts, host)
 		}
 
-		if _, err := Map(srcAddr1, dstIp1, portallocator.BeginPortRange); err == nil {
-			t.Fatalf("Port %d should be bound but is not", portallocator.BeginPortRange)
+		if _, err := Map(srcAddr1, dstIp1, portallocator.DefaultStartPortRange); err == nil {
+			t.Fatalf("Port %d should be bound but is not", portallocator.DefaultStartPortRange)
 		}
 
 		for _, val := range hosts {

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -74,6 +74,12 @@ unix://[/path/to/socket] to use.
 **-p**=""
   Path to use for daemon PID file. Default is `/var/run/docker.pid`
 
+**--port-range-start**="49153"
+  Set range start for dynamic port allocator. Default is `49153`.
+
+**--port-range-end**="65535"
+  Set range end for dynamic port allocator. Default is `65535`.
+
 **--registry-mirror=<scheme>://<host>
   Prepend a registry mirror to be used for image pulls. May be specified multiple times.
 

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -317,13 +317,13 @@ page.  There are two approaches.
 First, you can supply `-P` or `--publish-all=true|false` to `docker run`
 which is a blanket operation that identifies every port with an `EXPOSE`
 line in the image's `Dockerfile` and maps it to a host port somewhere in
-the range 49153–65535.  This tends to be a bit inconvenient, since you
-then have to run other `docker` sub-commands to learn which external
-port a given service was mapped to.
+the configured port range (by default 49153–65535).  This tends to be a bit
+inconvenient, since you then have to run other `docker` sub-commands to
+learn which external port a given service was mapped to.
 
 More convenient is the `-p SPEC` or `--publish=SPEC` option which lets
 you be explicit about exactly which external port on the Docker server —
-which can be any port at all, not just those in the 49153-65535 block —
+which can be any port at all, not just those in the configured block —
 you want mapped to which port in the container.
 
 Either way, you should be able to peek at what Docker has accomplished

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -80,6 +80,10 @@ expect an integer, and they can only be specified once.
       --mtu=0                                    Set the containers network MTU
                                                    if no value is provided: default to the default route MTU or 1500 if no default route is available
       -p, --pidfile="/var/run/docker.pid"        Path to use for daemon PID file
+      --port-range-end=65535                     Set range end for dynamic port allocator
+                                                   if no value is provided: default to 65535
+      --port-range-start=49153                   Set range start for dynamic port allocator
+                                                   if no value is provided: default to 49153
       --registry-mirror=[]                       Specify a preferred Docker registry mirror
       -s, --storage-driver=""                    Force the Docker runtime to use a specific storage driver
       --selinux-enabled=false                    Enable selinux support. SELinux does not presently support the BTRFS storage driver


### PR DESCRIPTION
Options `--port-range-begin` and `--port-range-end` would allow customization of the ports range used by `portallocator`, and they keep current defaults as specified by constants. Closes #4736.

Some notes on this pull request:
- changes wording of "port range begin" to "port range start"
- uses `fmt.Sprintf` to inline real default values in the cli help output
