### PR TITLE
Fix streaming JSON Content-type for postBuild

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -993,6 +993,9 @@ func postBuild(eng *engine.Engine, version version.Version, w http.ResponseWrite
 		}
 	}
 
+	// This needs to be set before calls to streamJSON
+	job.SetenvBool("lineDelim", version.GreaterThanOrEqualTo("1.15"))
+
 	if version.GreaterThanOrEqualTo("1.8") {
 		job.SetenvBool("json", true)
 		streamJSON(job, w, true)
@@ -1013,7 +1016,6 @@ func postBuild(eng *engine.Engine, version version.Version, w http.ResponseWrite
 	job.Setenv("q", r.FormValue("q"))
 	job.Setenv("nocache", r.FormValue("nocache"))
 	job.Setenv("forcerm", r.FormValue("forcerm"))
-	job.SetenvBool("lineDelim", version.GreaterThanOrEqualTo("1.15"))
 	job.SetenvJson("authConfig", authConfig)
 	job.SetenvJson("configFile", configFile)
 


### PR DESCRIPTION
Sorry for no test but the whole `postBuild()` does not seem to have any.
This also needs #8408 on the client side to properly work.

lineDelim is used by streamJSON() so it needs to be set
before its called.

Signed-off-by: Tõnis Tiigi tonistiigi@gmail.com (github: tonistiigi)

/cc @jfrazelle
