### PR TITLE
Mainly s/form/notation/ for RUN/CMD/...

### DIFF
--- a/docs/man/Dockerfile.5.md
+++ b/docs/man/Dockerfile.5.md
@@ -24,7 +24,7 @@ FROM image
 
 # DESCRIPTION
 
-A Dockerfile is a file that automates the steps of creating a Docker image. 
+A Dockerfile is a file that automates the steps of creating a Docker image.
 A Dockerfile is similar to a Makefile.
 
 # USAGE
@@ -32,19 +32,19 @@ A Dockerfile is similar to a Makefile.
 **sudo docker build .**
  -- runs the steps and commits them, building a final image
     The path to the source repository defines where to find the context of the
-    build. The build is run by the docker daemon, not the CLI. The whole 
-    context must be transferred to the daemon. The Docker CLI reports 
+    build. The build is run by the docker daemon, not the CLI. The whole
+    context must be transferred to the daemon. The Docker CLI reports
     "Sending build context to Docker daemon" when the context is sent to the daemon.
-    
+
 **sudo docker build -t repository/tag .**
- -- specifies a repository and tag at which to save the new image if the build 
-    succeeds. The Docker daemon runs the steps one-by-one, committing the result 
-    to a new image if necessary before finally outputting the ID of the new 
+ -- specifies a repository and tag at which to save the new image if the build
+    succeeds. The Docker daemon runs the steps one-by-one, committing the result
+    to a new image if necessary before finally outputting the ID of the new
     image. The Docker daemon automatically cleans up the context it is given.
 
-Docker re-uses intermediate images whenever possible. This significantly 
+Docker re-uses intermediate images whenever possible. This significantly
 accelerates the *docker build* process.
- 
+
 # FORMAT
 
 **FROM image**
@@ -65,41 +65,43 @@ or
  --The MAINTAINER instruction sets the Author field for the generated images.
 
 **RUN**
- --RUN has two forms:
+ --RUN has two notations:
  **RUN <command>**
  -- (the command is run in a shell - /bin/sh -c)
  **RUN ["executable", "param1", "param2"]**
- --The above is executable form.
+ --The above is the executable notation.
  --The RUN instruction executes any commands in a new layer on top of the
  current image and commits the results. The committed image is used for the next
  step in Dockerfile.
  --Layering RUN instructions and generating commits conforms to the core
  concepts of Docker where commits are cheap and containers can be created from
  any point in the history of an image. This is similar to source control.  The
- exec form makes it possible to avoid shell string munging. The exec form makes
+ exec notation makes it possible to avoid shell string munging. It also makes
  it possible to RUN commands using a base image that does not contain /bin/sh.
 
 **CMD**
- --CMD has three forms:
-  **CMD ["executable", "param1", "param2"]** This is the preferred form, the
-  exec form.
-  **CMD ["param1", "param2"]** This command provides default parameters to
-  ENTRYPOINT)
-  **CMD command param1 param2** This command is run as a shell.
-  --There can be only one CMD in a Dockerfile. If more than one CMD is listed, only
-  the last CMD takes effect.
+ --CMD has three notations:
+  **CMD ["executable", "param1", "param2"]** This is the preferred notation, the
+  exec notation.
+  **CMD ["param1", "param2"]** This is the parameter notation and provides
+  default parameters to ENTRYPOINT)
+  **CMD command param1 param2** This is the shell notation and the command is 
+  run as a shell.
+  --There can be only one CMD in a Dockerfile. If more than one CMD is listed,
+  only the last CMD takes effect.
   The main purpose of a CMD is to provide defaults for an executing container.
   These defaults may include an executable, or they can omit the executable. If
   they omit the executable, an ENTRYPOINT must be specified.
   When used in the shell or exec formats, the CMD instruction sets the command to
   be executed when running the image.
-  If you use the shell form of the CMD, the <command> executes in /bin/sh -c:
+  If you use the shell notation of the CMD, the <command> executes in
+  /bin/sh -c:
   **FROM ubuntu**
   **CMD echo "This is a test." | wc -**
   If you run <command> without a shell, then you must express the command as a
-  JSON array and give the full path to the executable. This array form is the
-  preferred form of CMD. All additional parameters must be individually expressed
-  as strings in the array:
+  JSON array and give the full path to the executable. This array notation is
+  the preferred form of CMD. All additional parameters must be individually
+  expressed as strings in the array:
   **FROM ubuntu**
   **CMD ["/usr/bin/wc","--help"]**
   To make the container run the same executable every time, use ENTRYPOINT in
@@ -132,16 +134,17 @@ or
 
 **ADD**
  --**ADD <src>... <dest>** The ADD instruction copies new files, directories
- or remote file URLs to the filesystem of the container at path <dest>.  
+ or remote file URLs to the filesystem of the container at path <dest>.
  Mutliple <src> resources may be specified but if they are files or directories
- then they must be relative to the source directory that is being built 
+ then they must be relative to the source directory that is being built
  (the context of the build).  <dest> is the absolute path to
  which the source is copied inside the target container.  All new files and
  directories are created with mode 0755, with uid and gid 0.
 
 **ENTRYPOINT**
- --**ENTRYPOINT** has two forms: ENTRYPOINT ["executable", "param1", "param2"]
- (This is like an exec, and is the preferred form.) ENTRYPOINT command param1
+ --**ENTRYPOINT** has two notations:
+ ENTRYPOINT ["executable", "param1", "param2"]
+ (This is the exec notation and is preferred.) ENTRYPOINT command param1
  param2 (This is running as a shell.) An ENTRYPOINT helps you configure a
  container that can be run as an executable. When you specify an ENTRYPOINT,
  the whole container runs as if it was only that executable.  The ENTRYPOINT
@@ -149,11 +152,11 @@ or
  passed to docker run. This is different from the behavior of CMD. This allows
  arguments to be passed to the entrypoint, for instance docker run <image> -d
  passes the -d argument to the ENTRYPOINT.  Specify parameters either in the
- ENTRYPOINT JSON array (as in the preferred exec form above), or by using a CMD
- statement.  Parameters in the ENTRYPOINT are not overwritten by the docker run
- arguments.  Parameters specifies via CMD are overwritten by docker run
- arguments.  Specify a plain string for the ENTRYPOINT, and it will execute in
- /bin/sh -c, like a CMD instruction:
+ ENTRYPOINT JSON array (as in the preferred exec notation above), or by using
+ a CMD statement.  Parameters in the ENTRYPOINT are not overwritten by the
+ docker run arguments.  Parameters specifies via CMD are overwritten by docker
+ run arguments.  Specify a plain string for the ENTRYPOINT, and it will
+ execute in /bin/sh -c, like a CMD instruction:
  FROM ubuntu
  ENTRYPOINT wc -l -
  This means that the Dockerfile's image always takes stdin as input (that's
@@ -164,7 +167,7 @@ or
  ENTRYPOINT ["/usr/bin/wc"]
 
 **VOLUME**
- --**VOLUME ["/data"]** 
+ --**VOLUME ["/data"]**
  The VOLUME instruction creates a mount point with the specified name and marks
  it as holding externally-mounted volumes from the native host or from other
  containers.
@@ -178,12 +181,12 @@ or
  -- **WORKDIR /path/to/workdir**
  The WORKDIR instruction sets the working directory for the **RUN**, **CMD**, and **ENTRYPOINT** Dockerfile commands that follow it.
  It can be used multiple times in a single Dockerfile. Relative paths are defined relative to the path of the previous **WORKDIR** instruction. For example:
- **WORKDIR /a WORKDIR b WORKDIR c RUN pwd** 
+ **WORKDIR /a WORKDIR b WORKDIR c RUN pwd**
  In the above example, the output of the **pwd** command is **a/b/c**.
 
 **ONBUILD**
  -- **ONBUILD [INSTRUCTION]**
- The ONBUILD instruction adds a trigger instruction to the image, which is 
+ The ONBUILD instruction adds a trigger instruction to the image, which is
  executed at a later time, when the image is used as the base for another
  build. The trigger is executed in the context of the downstream build, as
  if it had been inserted immediately after the FROM instruction in the
@@ -195,13 +198,13 @@ or
  application builder, it requires application source code to be
  added in a particular directory, and might require a build script
  to be called after that. You can't just call ADD and RUN now, because
- you don't yet have access to the application source code, and it 
- is different for each application build. Providing  
+ you don't yet have access to the application source code, and it
+ is different for each application build. Providing
  application developers with a boilerplate Dockerfile to copy-paste
  into their application is inefficient, error-prone, and
  difficult to update because it mixes with application-specific code.
  The solution is to use **ONBUILD** to register instructions in advance, to
- run later, during the next build stage.  
+ run later, during the next build stage.
 
 # HISTORY
 *May 2014, Compiled by Zac Dover (zdover at redhat dot com) based on docker.com Dockerfile documentation.

--- a/docs/sources/articles/dockerfile_best-practices.md
+++ b/docs/sources/articles/dockerfile_best-practices.md
@@ -204,13 +204,14 @@ The `CMD` instruction should be used to run the software contained by your
 image, along with any arguments. `CMD` should almost always be used in the
 form of `CMD [“executable”, “param1”, “param2”…]`. Thus, if the image is for a
 service (Apache, Rails, etc.), you would run something like
-`CMD ["apache2","-DFOREGROUND"]`. Indeed, this form of the instruction is
+`CMD ["apache2","-DFOREGROUND"]`. Indeed, this notation of the instruction is
 recommended for any service-based image.
 
 In most other cases, `CMD` should be given an interactive shell (bash, python,
 perl, etc), for example, `CMD ["perl", "-de0"]`, `CMD ["python"]`, or
-`CMD [“php”, “-a”]`. Using this form means that when you execute something like
-`docker run -it python`, you’ll get dropped into a usable shell, ready to go.
+`CMD [“php”, “-a”]`. Using this notation means that when you execute 
+something like `docker run -it python`, you’ll get dropped into a usable 
+shell, ready to go.
 `CMD` should rarely be used in the manner of `CMD [“param”, “param”]` in
 conjunction with [`ENTRYPOINT`](https://docs.docker.com/reference/builder/#entrypoint), unless
 you and your expected users are already quite familiar with how `ENTRYPOINT`

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -33,17 +33,18 @@ whole context must be transferred to the daemon. The Docker CLI reports
 "Sending build context to Docker daemon" when the context is sent to the daemon.
 
 > **Warning**
-> Avoid using your root directory, `/`, as the root of the source repository. The 
-> `docker build` command will use whatever directory contains the Dockerfile as the build
-> context (including all of its subdirectories). The build context will be sent to the
-> Docker daemon before building the image, which means if you use `/` as the source
-> repository, the entire contents of your hard drive will get sent to the daemon (and
+> Avoid using your root directory, `/`, as the root of the source repository. 
+> The `docker build` command will use whatever directory contains the 
+> Dockerfile as the build context (including all of its subdirectories). The 
+> build context will be sent to the Docker daemon before building the image, 
+> which means if you use `/` as the source repository, the entire contents of 
+> your hard drive will get sent to the daemon (and
 > thus to the machine running the daemon). You probably don't want that.
 
-In most cases, it's best to put each Dockerfile in an empty directory, and then add only
-the files needed for building that Dockerfile to that directory. To further speed up the
-build, you can exclude files and directories by adding a `.dockerignore` file to the same
-directory.
+In most cases, it's best to put each Dockerfile in an empty directory, and 
+then add only the files needed for building that Dockerfile to that directory. 
+To further speed up the build, you can exclude files and directories by adding 
+a `.dockerignore` file to the same directory.
 
 You can specify a repository and tag at which to save the new image if
 the build succeeds:
@@ -168,10 +169,11 @@ generated images.
 
 ## RUN
 
-RUN has 2 forms:
+RUN has 2 notations:
 
-- `RUN <command>` (the command is run in a shell - `/bin/sh -c` - *shell* form)
-- `RUN ["executable", "param1", "param2"]` (*exec* form)
+- `RUN <command>` (the command is run in a shell - `/bin/sh -c` - 
+   *shell* notation)
+- `RUN ["executable", "param1", "param2"]` (*exec* notation)
 
 The `RUN` instruction will execute any commands in a new layer on top of the
 current image and commit the results. The resulting committed image will be
@@ -181,28 +183,28 @@ Layering `RUN` instructions and generating commits conforms to the core
 concepts of Docker where commits are cheap and containers can be created from
 any point in an image's history, much like source control.
 
-The *exec* form makes it possible to avoid shell string munging, and to `RUN`
-commands using a base image that does not contain `/bin/sh`.
+The *exec* notation makes it possible to avoid shell string munging, and to 
+`RUN` commands using a base image that does not contain `/bin/sh`.
 
 > **Note**:
-> To use a different shell, other than '/bin/sh', use the *exec* form
+> To use a different shell, other than '/bin/sh', use the *exec* notation
 > passing in the desired shell. For example,
 > `RUN ["/bin/bash", "-c", "echo hello"]`
 
 > **Note**:
-> The *exec* form is parsed as a JSON array, which means that
+> The *exec* notation is parsed as a JSON array, which means that
 > you must use double-quotes (") around words not single-quotes (').
 
 > **Note**:
-> Unlike the *shell* form, the *exec* form does not invoke a command shell.
-> This means that normal shell processing does not happen. For example,
+> Unlike the *shell* notation, the *exec* notation does not invoke a command 
+> shell. This means that normal shell processing does not happen. For example,
 > `CMD [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
-> If you want shell processing then either use the *shell* form or execute 
+> If you want shell processing then either use the *shell* notation or execute 
 > a shell directly, for example: `CMD [ "sh", "-c", "echo", "$HOME" ]`.
 
 The cache for `RUN` instructions isn't invalidated automatically during
 the next build. The cache for an instruction like 
-`RUN apt-get dist-upgrade -y` will be reused during the next build.  The 
+`RUN apt-get dist-upgrade -y` will be reused during the next build. The 
 cache for `RUN` instructions can be invalidated by using the `--no-cache` 
 flag, for example `docker build --no-cache`.
 
@@ -221,14 +223,15 @@ The cache for `RUN` instructions can be invalidated by `ADD` instructions. See
 
 ## CMD
 
-The `CMD` instruction has three forms:
+The `CMD` instruction has three notations:
 
-- `CMD ["executable","param1","param2"]` (*exec* form, this is the preferred form)
+- `CMD ["executable","param1","param2"]` (*exec* notation, this is the 
+   preferred notation)
 - `CMD ["param1","param2"]` (as *default parameters to ENTRYPOINT*)
-- `CMD command param1 param2` (*shell* form)
+- `CMD command param1 param2` (*shell* notation)
 
-There can only be one `CMD` instruction in a `Dockerfile`. If you list more than one `CMD`
-then only the last `CMD` will take effect.
+There can only be one `CMD` instruction in a `Dockerfile`. If you list more 
+than one `CMD` then only the last `CMD` will take effect.
 
 **The main purpose of a `CMD` is to provide defaults for an executing
 container.** These defaults can include an executable, or they can omit
@@ -241,29 +244,29 @@ instruction as well.
 > with the JSON array format.
 
 > **Note**:
-> The *exec* form is parsed as a JSON array, which means that
+> The *exec* notation is parsed as a JSON array, which means that
 > you must use double-quotes (") around words not single-quotes (').
 
 > **Note**:
-> Unlike the *shell* form, the *exec* form does not invoke a command shell.
-> This means that normal shell processing does not happen. For example,
+> Unlike the *shell* notation, the *exec* notation does not invoke a command 
+> shell. This means that normal shell processing does not happen. For example,
 > `CMD [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
-> If you want shell processing then either use the *shell* form or execute 
+> If you want shell processing then either use the *shell* notation or execute 
 > a shell directly, for example: `CMD [ "sh", "-c", "echo", "$HOME" ]`.
 
 When used in the shell or exec formats, the `CMD` instruction sets the command
 to be executed when running the image.
 
-If you use the *shell* form of the `CMD`, then the `<command>` will execute in
-`/bin/sh -c`:
+If you use the *shell* notation of the `CMD`, then the `<command>` will 
+execute in `/bin/sh -c`:
 
     FROM ubuntu
     CMD echo "This is a test." | wc -
 
 If you want to **run your** `<command>` **without a shell** then you must
 express the command as a JSON array and give the full path to the executable.
-**This array form is the preferred format of `CMD`.** Any additional parameters
-must be individually expressed as strings in the array:
+**This array notation is the preferred format of `CMD`.** Any additional 
+parameters must be individually expressed as strings in the array:
 
     FROM ubuntu
     CMD ["/usr/bin/wc","--help"]
@@ -315,7 +318,7 @@ change them using `docker run --env <key>=<value>`.
 
 The `ADD` instruction copies new files,directories or remote file URLs to 
 the filesystem of the container  from `<src>` and add them to the at 
-path `<dest>`.  
+path `<dest>`.
 
 Multiple `<src>` resource may be specified but if they are files or 
 directories then they must be relative to the source directory that is 
@@ -457,12 +460,12 @@ The copy obeys the following rules:
 
 ## ENTRYPOINT
 
-ENTRYPOINT has two forms:
+ENTRYPOINT has two notation:
 
 - `ENTRYPOINT ["executable", "param1", "param2"]`
-  (*exec* form, the preferred form)
+  (*exec* notation, the preferred notation)
 - `ENTRYPOINT command param1 param2`
-  (*shell* form)
+  (*shell* notation)
 
 There can only be one `ENTRYPOINT` in a `Dockerfile`. If you have more
 than one `ENTRYPOINT`, then only the last one in the `Dockerfile` will
@@ -475,7 +478,7 @@ container runs as if it was just that executable.
 Unlike the behavior of the `CMD` instruction, The `ENTRYPOINT`
 instruction adds an entry command that will **not** be overwritten when
 arguments are passed to `docker run`. This allows arguments to be passed
-to the entry point, i.e.  `docker run <image> -d` will pass the `-d`
+to the entry point, i.e. `docker run <image> -d` will pass the `-d`
 argument to the entry point.
 
 You can specify parameters either in the `ENTRYPOINT` JSON array (as in
@@ -499,14 +502,14 @@ optional but default, you could use a `CMD` instruction:
     ENTRYPOINT ["ls"]
 
 > **Note**:
-> The *exec* form is parsed as a JSON array, which means that
+> The *exec* notation is parsed as a JSON array, which means that
 > you must use double-quotes (") around words not single-quotes (').
 
 > **Note**:
-> Unlike the *shell* form, the *exec* form does not invoke a command shell.
-> This means that normal shell processing does not happen. For example,
+> Unlike the *shell* notation, the *exec* notation does not invoke a command 
+> shell. This means that normal shell processing does not happen. For example,
 > `CMD [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
-> If you want shell processing then either use the *shell* form or execute 
+> If you want shell processing then either use the *shell* notation or execute 
 > a shell directly, for example: `CMD [ "sh", "-c", "echo", "$HOME" ]`.
 
 > **Note**:
@@ -521,8 +524,9 @@ The `VOLUME` instruction will create a mount point with the specified name
 and mark it as holding externally mounted volumes from native host or other
 containers. The value can be a JSON array, `VOLUME ["/var/log/"]`, or a plain
 string with multiple arguments, such as `VOLUME /var/log` or `VOLUME /var/log
-/var/db`.  For more information/examples and mounting instructions via the
-Docker client, refer to [*Share Directories via Volumes*](/userguide/dockervolumes/#volume-def)
+/var/db`. For more information/examples and mounting instructions via the
+Docker client, refer to 
+[*Share Directories via Volumes*](/userguide/dockervolumes/#volume-def)
 documentation.
 
 > **Note**:
@@ -609,9 +613,9 @@ For example you might add something like this:
     ONBUILD RUN /usr/local/bin/python-build --dir /app/src
     [...]
 
-> **Warning**: Chaining `ONBUILD` instructions using `ONBUILD ONBUILD` isn't allowed.
-
-> **Warning**: The `ONBUILD` instruction may not trigger `FROM` or `MAINTAINER` instructions.
+> **Warning**: The `ONBUILD` instruction may not trigger `FROM` or `MAINTAINER`
+> instructions. Also, chaining `ONBUILD` instructions using `ONBUILD ONBUILD`
+> isn't allowed.
 
 ## Dockerfile Examples
 


### PR DESCRIPTION
This is a follow-on from @jamtur01's comment in #8360
However, while I was in there I also did some other minor things:
- s/.  /. /   Just single space after periods
- s/  *$//    Removed trailing spaces
- for builder.md, tried to wrap things at 80 columns

Signed-off-by: Doug Davis dug@us.ibm.com
