### PR TITLE
Ignore unknown dockerfile instructions

### DIFF
--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -45,21 +45,20 @@ var evaluateTable map[string]func(*Builder, []string, map[string]bool) error
 
 func init() {
 	evaluateTable = map[string]func(*Builder, []string, map[string]bool) error{
-		"env":            env,
-		"maintainer":     maintainer,
-		"add":            add,
-		"copy":           dispatchCopy, // copy() is a go builtin
-		"from":           from,
-		"onbuild":        onbuild,
-		"workdir":        workdir,
-		"docker-version": nullDispatch, // we don't care about docker-version
-		"run":            run,
-		"cmd":            cmd,
-		"entrypoint":     entrypoint,
-		"expose":         expose,
-		"volume":         volume,
-		"user":           user,
-		"insert":         insert,
+		"env":        env,
+		"maintainer": maintainer,
+		"add":        add,
+		"copy":       dispatchCopy, // copy() is a go builtin
+		"from":       from,
+		"onbuild":    onbuild,
+		"workdir":    workdir,
+		"run":        run,
+		"cmd":        cmd,
+		"entrypoint": entrypoint,
+		"expose":     expose,
+		"volume":     volume,
+		"user":       user,
+		"insert":     insert,
 	}
 }
 

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -43,21 +43,20 @@ func init() {
 	// functions. Errors are propogated up by Parse() and the resulting AST can
 	// be incorporated directly into the existing AST as a next.
 	dispatch = map[string]func(string) (*Node, map[string]bool, error){
-		"user":           parseString,
-		"onbuild":        parseSubCommand,
-		"workdir":        parseString,
-		"env":            parseEnv,
-		"maintainer":     parseString,
-		"docker-version": parseString,
-		"from":           parseString,
-		"add":            parseStringsWhitespaceDelimited,
-		"copy":           parseStringsWhitespaceDelimited,
-		"run":            parseMaybeJSON,
-		"cmd":            parseMaybeJSON,
-		"entrypoint":     parseMaybeJSON,
-		"expose":         parseStringsWhitespaceDelimited,
-		"volume":         parseMaybeJSONToList,
-		"insert":         parseIgnore,
+		"user":       parseString,
+		"onbuild":    parseSubCommand,
+		"workdir":    parseString,
+		"env":        parseEnv,
+		"maintainer": parseString,
+		"from":       parseString,
+		"add":        parseStringsWhitespaceDelimited,
+		"copy":       parseStringsWhitespaceDelimited,
+		"run":        parseMaybeJSON,
+		"cmd":        parseMaybeJSON,
+		"entrypoint": parseMaybeJSON,
+		"expose":     parseStringsWhitespaceDelimited,
+		"volume":     parseMaybeJSONToList,
+		"insert":     parseIgnore,
 	}
 }
 

--- a/builder/parser/testfiles/docker/result
+++ b/builder/parser/testfiles/docker/result
@@ -1,4 +1,4 @@
-(docker-version "0.6.1")
+(docker-version)
 (from "ubuntu:14.04")
 (maintainer "Tianon Gravi <admwiggin@gmail.com> (@tianon)")
 (run "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq 	apt-utils 	aufs-tools 	automake 	btrfs-tools 	build-essential 	curl 	dpkg-sig 	git 	iptables 	libapparmor-dev 	libcap-dev 	libsqlite3-dev 	lxc=1.0* 	mercurial 	pandoc 	parallel 	reprepro 	ruby1.9.1 	ruby1.9.1-dev 	s3cmd=1.1.0* 	--no-install-recommends")

--- a/builder/parser/utils.go
+++ b/builder/parser/utils.go
@@ -1,9 +1,6 @@
 package parser
 
-import (
-	"fmt"
-	"strings"
-)
+import "strings"
 
 // QuoteString walks characters (after trimming), escapes any quotes and
 // escapes, then wraps the whole thing in quotes. Very useful for generating
@@ -52,11 +49,14 @@ func (node *Node) Dump() string {
 // performs the dispatch based on the two primal strings, cmd and args. Please
 // look at the dispatch table in parser.go to see how these dispatchers work.
 func fullDispatch(cmd, args string) (*Node, map[string]bool, error) {
-	if _, ok := dispatch[cmd]; !ok {
-		return nil, nil, fmt.Errorf("'%s' is not a valid dockerfile command", cmd)
+	fn := dispatch[cmd]
+
+	// Ignore invalid Dockerfile instructions
+	if fn == nil {
+		fn = parseIgnore
 	}
 
-	sexp, attrs, err := dispatch[cmd](args)
+	sexp, attrs, err := fn(args)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2423,3 +2423,15 @@ func TestBuildCmdJSONNoShDashC(t *testing.T) {
 
 	logDone("build - cmd should not have /bin/sh -c for json")
 }
+
+func TestBuildIgnoreInvalidInstruction(t *testing.T) {
+	name := "testbuildignoreinvalidinstruction"
+	defer deleteImages(name)
+
+	out, _, err := buildImageWithOut(name, "FROM busybox\nfoo bar", true)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	logDone("build - ignore invalid Dockerfile instruction")
+}


### PR DESCRIPTION
With the new parser we started considering unknown instructions as errors (which can be desirable) but we don't want to break this behavior right now. I'll leave the debate for another time (can't find the issue).

Ping @erikh @crosbymichael @aluzzardi @jfrazelle 
