### PR TITLE
back from camping, and making fred the docs 'guy in charge'

### DIFF
--- a/docs/MAINTAINERS
+++ b/docs/MAINTAINERS
@@ -1,4 +1,4 @@
-James Turnbull <james@lovedthanlost.net> (@jamtur01)
-#PTO til 6 Oct 2014 Sven Dowideit <SvenDowideit@fosiki.com> (@SvenDowideit)
-O.S. Tezer <ostezer@gmail.com> (@OSTezer)
 Fred Lifton <fred.lifton@docker.com> (@fredlf)
+James Turnbull <james@lovedthanlost.net> (@jamtur01)
+Sven Dowideit <SvenDowideit@fosiki.com> (@SvenDowideit)
+O.S. Tezer <ostezer@gmail.com> (@OSTezer)


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@docker.com (github: SvenDowideit)
