### PR TITLE
Increase the tag length limit from 30 to 128

### DIFF
--- a/graph/tags.go
+++ b/graph/tags.go
@@ -19,7 +19,7 @@ import (
 const DEFAULTTAG = "latest"
 
 var (
-	validTagName = regexp.MustCompile(`^[\w][\w.-]{0,29}$`)
+	validTagName = regexp.MustCompile(`^[\w][\w.-]{0,127}$`)
 )
 
 type TagStore struct {


### PR DESCRIPTION
128 is an arbitrary choice, but I don't see any particular reason to use a smaller limit than this.

Re: https://github.com/docker/docker/issues/8445

_[this PR started as 1024, but I reduced the limit to 128. I'm okay with anything in the range of `[128,∞)`]_
