### PR TITLE
Fix system socket/service unit files

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -10,4 +10,4 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 
 [Install]
-Also=docker.socket
+WantedBy=multi-user.target

--- a/contrib/init/systemd/docker.socket
+++ b/contrib/init/systemd/docker.socket
@@ -1,5 +1,6 @@
 [Unit]
 Description=Docker Socket for the API
+PartOf=docker.service
 
 [Socket]
 ListenStream=/var/run/docker.sock


### PR DESCRIPTION
Two problems how they are today:

In the current systemd unit files it is impossible to have the
docker.service started at system boot.  Instead enableing docker.service
will actually enable docker.socket.  This is a problem, as that means
any container with --restart=always will not launch on reboot.  And of
course as soon as you log in and type docker ps, docker.service will be
launched and now your images are running.  Talk about a PITA to debug!
The fix is to just install docker.service when people ask docker.service
to be enabled.  If an admin wants to enable docker.socket instead, that
is fine and will work just as it does today.

The second problem is a common docker devel workflow, although not
something normal admins would hit.  In this case consider a dev doing
the following:

systemctl stop docker.service

docker -d
[run commands]
[^C]

systemctl start docker.service

Running docker -d (without -F fd://) will clean up the
/var/run/docker.sock when it exits.  Remember, you just ran the docker
daemon not telling it about socket actviation, so cleaning up its socket
makes sense!  The new docker, started by systemd will expect socket
activation, but the last one cleaned up the docker.sock.  So things are
just broken.  You can, today, work around this by restarting
docker.socket.  This fixes it by telling docker.socket that it is
PartOf=docker.service.  So when docker.service is
started/stopped/restarted docker.socket will also be
started/stopped/restarted.  So the above semi-common devel workflow will
be fine.  When docker.service is stopped, so is docker.socket,   docker
-d (without -F fd://) will create and delete /var/run/docker.sock.
Starting docker.service again will restart docker.socket, which will
create the file an all is happy in the word.

Signed-off-by: Eric Paris eparis@redhat.com
