### PR TITLE
Check /etc/resolv.conf on every docker run for 127.* content

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -32,7 +31,6 @@ import (
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/log"
 	"github.com/docker/docker/pkg/namesgenerator"
-	"github.com/docker/docker/pkg/networkfs/resolvconf"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/sysinfo"
@@ -925,9 +923,6 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		eng:            eng,
 		trustStore:     t,
 	}
-	if err := daemon.checkLocaldns(); err != nil {
-		return nil, err
-	}
 	if err := daemon.restore(); err != nil {
 		return nil, err
 	}
@@ -1085,20 +1080,6 @@ func (daemon *Daemon) ExecutionDriver() execdriver.Driver {
 
 func (daemon *Daemon) ContainerGraph() *graphdb.Database {
 	return daemon.containerGraph
-}
-
-func (daemon *Daemon) checkLocaldns() error {
-	resolvConf, err := resolvconf.Get()
-	if err != nil {
-		return err
-	}
-	resolvConf = utils.RemoveLocalDns(resolvConf)
-
-	if len(daemon.config.Dns) == 0 && !bytes.Contains(resolvConf, []byte("nameserver")) {
-		log.Infof("No non localhost DNS resolver found in resolv.conf and containers can't use it. Using default external servers : %v", DefaultDns)
-		daemon.config.Dns = DefaultDns
-	}
-	return nil
 }
 
 func (daemon *Daemon) ImageGetCached(imgID string, config *runconfig.Config) (*image.Image, error) {


### PR DESCRIPTION
Currently if you start the docker -d on a system with 127.0.0.1 in /etc/resolv.conf
It will set the default dns to 8.8.8.8 8.8.4.4 permanently.

This causes a problem at boot on Fedora machines where NetworkManager has not
populated /etc/resolv.conf before docker gets started.

This fix checks /etc/resolv.conf on every docker run. And only populates
daemon.config.Dns  if the user specified it on the command line.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
