### PR TITLE
Allow child to overwrite entrypoint from parent

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2459,3 +2459,95 @@ func TestBuildIgnoreInvalidInstruction(t *testing.T) {
 
 	logDone("build - ignore invalid Dockerfile instruction")
 }
+
+func TestBuildEntrypointInheritance(t *testing.T) {
+	defer deleteImages("parent", "child")
+
+	if _, err := buildImage("parent", `
+    FROM busybox
+    ENTRYPOINT exit 130
+    `, true); err != nil {
+		t.Fatal(err)
+	}
+
+	status, _ := runCommand(exec.Command(dockerBinary, "run", "parent"))
+
+	if status != 130 {
+		t.Fatalf("expected exit code 130 but received %d", status)
+	}
+
+	if _, err := buildImage("child", `
+    FROM parent
+    ENTRYPOINT exit 5
+    `, true); err != nil {
+		t.Fatal(err)
+	}
+
+	status, _ = runCommand(exec.Command(dockerBinary, "run", "child"))
+
+	if status != 5 {
+		t.Fatal("expected exit code 5 but received %d", status)
+	}
+
+	logDone("build - clear entrypoint")
+}
+
+func TestBuildEntrypointInheritanceInspect(t *testing.T) {
+	var (
+		name     = "testbuildepinherit"
+		name2    = "testbuildepinherit2"
+		expected = `["/bin/sh","-c","echo quux"]`
+	)
+
+	defer deleteImages(name, name2)
+
+	if _, err := buildImage(name, "FROM busybox\nENTRYPOINT /foo/bar", true); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := buildImage(name2, fmt.Sprintf("FROM %s\nENTRYPOINT echo quux", name), true); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := inspectFieldJSON(name2, "Config.Entrypoint")
+	if err != nil {
+		t.Fatal(err, res)
+	}
+
+	if res != expected {
+		t.Fatalf("Expected value %s not in Config.Entrypoint: %s", expected, res)
+	}
+
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-t", name2))
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	expected = "quux"
+
+	if strings.TrimSpace(out) != expected {
+		t.Fatalf("Expected output is %s, got %s", expected, out)
+	}
+
+	logDone("build - entrypoint override inheritance properly")
+}
+
+func TestBuildRunShEntrypoint(t *testing.T) {
+	name := "testbuildentrypoint"
+	defer deleteImages(name)
+	_, err := buildImage(name,
+		`FROM busybox
+                                ENTRYPOINT /bin/echo`,
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", name))
+
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	logDone("build - entrypoint with /bin/echo running successfully")
+}

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -302,8 +302,8 @@ func deleteAllContainers() error {
 	return nil
 }
 
-func deleteImages(images string) error {
-	rmiCmd := exec.Command(dockerBinary, "rmi", images)
+func deleteImages(images ...string) error {
+	rmiCmd := exec.Command(dockerBinary, "rmi", strings.Join(images, " "))
 	exitCode, err := runCommand(rmiCmd)
 	// set error manually if not set
 	if exitCode != 0 && err == nil {


### PR DESCRIPTION
There is a current issue that the entrypoint is not being overridden in a child build if the parent has it set.  This fixes that issue and adds a few integration tests to make sure that this does not change.

Closes #8429

Signed-off-by: Michael Crosby crosbymichael@gmail.com
