### PR TITLE
registry: Introduce --insecure-ssl-registry daemon flag to control secur...

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -70,6 +70,7 @@ expect an integer, and they can only be specified once.
       -g, --graph="/var/lib/docker"              Path to use as the root of the Docker runtime
       -H, --host=[]                              The socket(s) to bind to in daemon mode or connect to in client mode, specified using one or more tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.
       --icc=true                                 Enable inter-container communication
+      --insecure-ssl-registry=false              Skip TLS verify between daemon with registry
       --ip=0.0.0.0                               Default IP address to use when binding container ports
       --ip-forward=true                          Enable net.ipv4.ip_forward
       --ip-masq=true                             Enable IP masquerading for bridge's IP range

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/utils"
 )
 
@@ -25,6 +26,8 @@ var (
 	validHex                 = regexp.MustCompile(`^([a-f0-9]{64})$`)
 	validNamespace           = regexp.MustCompile(`^([a-z0-9_]{4,30})$`)
 	validRepo                = regexp.MustCompile(`^([a-z0-9-_.]+)$`)
+
+	flInsecureSslRegistry = flag.Bool([]string{"-insecure-ssl-registry"}, false, "Skip TLS verify between daemon with registry")
 )
 
 type TimeoutType uint32
@@ -36,7 +39,7 @@ const (
 )
 
 func newClient(jar http.CookieJar, roots *x509.CertPool, cert *tls.Certificate, timeout TimeoutType) *http.Client {
-	tlsConfig := tls.Config{RootCAs: roots}
+	tlsConfig := tls.Config{RootCAs: roots, InsecureSkipVerify: *flInsecureSslRegistry}
 
 	if cert != nil {
 		tlsConfig.Certificates = append(tlsConfig.Certificates, *cert)


### PR DESCRIPTION
...e certificate verify with registry

Currently many users cannot pull registry image behind corporate firewall,
because of the certificate issue.

[root@localhost docker]# docker pull ubuntu
Pulling repository ubuntu
2014/05/15 15:51:24 Get https://index.docker.io/v1/repositories/ubuntu/images: x509: certificate signed by unknown authority

This patch introduce a new daemon flag "--insecure-ssl-registry" to control
secure certificate verify. The default value is false.

Note that this global daemon flag will affects _all_ hosts, it's also possible
make sense allow per-host configuration in future.

Docker-DCO-1.1-Signed-off-by: Jovi Zhangwei jovi.zhangwei@gmail.com (github: ktap)
