### PR TITLE
Fix URL check in build from Git.

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -116,7 +116,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		root := cmd.Arg(0)
 		if utils.IsGIT(root) {
 			remoteURL := cmd.Arg(0)
-			if !strings.HasPrefix(remoteURL, "git://") && !strings.HasPrefix(remoteURL, "git@") && !utils.IsURL(remoteURL) {
+			if !utils.ValidGitTransport(remoteURL) {
 				remoteURL = "https://" + remoteURL
 			}
 

--- a/builder/job.go
+++ b/builder/job.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/engine"
@@ -59,7 +58,7 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 	if remoteURL == "" {
 		context = ioutil.NopCloser(job.Stdin)
 	} else if utils.IsGIT(remoteURL) {
-		if !strings.HasPrefix(remoteURL, "git://") {
+		if !utils.ValidGitTransport(remoteURL) {
 			remoteURL = "https://" + remoteURL
 		}
 		root, err := ioutil.TempDir("", "docker-build-git")

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -304,6 +304,10 @@ func IsGIT(str string) bool {
 	return strings.HasPrefix(str, "git://") || strings.HasPrefix(str, "github.com/") || strings.HasPrefix(str, "git@github.com:") || (strings.HasSuffix(str, ".git") && IsURL(str))
 }
 
+func ValidGitTransport(str string) bool {
+	return strings.HasPrefix(str, "git://") || strings.HasPrefix(str, "git@") || IsURL(str)
+}
+
 var (
 	localHostRx = regexp.MustCompile(`(?m)^nameserver 127[^\n]+\n*`)
 )

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -97,3 +97,24 @@ func TestReadSymlinkedDirectoryToFile(t *testing.T) {
 		t.Errorf("failed to remove symlink: %s", err)
 	}
 }
+
+func TestValidGitTransport(t *testing.T) {
+	for _, url := range []string{
+		"git://github.com/docker/docker",
+		"git@github.com:docker/docker.git",
+		"https://github.com/docker/docker.git",
+		"http://github.com/docker/docker.git",
+	} {
+		if ValidGitTransport(url) == false {
+			t.Fatalf("%q should be detected as valid Git prefix", url)
+		}
+	}
+
+	for _, url := range []string{
+		"github.com/docker/docker",
+	} {
+		if ValidGitTransport(url) == true {
+			t.Fatalf("%q should not be detected as valid Git prefix", url)
+		}
+	}
+}


### PR DESCRIPTION
Existing check ignores valid git URLs with prefix, "git@", "http://" or "https://". This leads to erroneously prepending "https://" to valid URLs.
