### PR TITLE
docs: Remove `Detach` parameter from Exec Create example

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -1447,8 +1447,7 @@ Sets up an exec instance in a running container `id`
         POST /containers/e90e34656806/exec HTTP/1.1
         Content-Type: application/json
 
-        {             
-	     "Detach":false,
+        {
 	     "AttachStdin":false,
 	     "AttachStdout":true,
 	     "AttachStderr":true,


### PR DESCRIPTION
Based on some [initial testing](https://github.com/fsouza/go-dockerclient/pull/162/files#diff-cc79fe39318bd23b3e2242c0aaac24fdR21) it seems that the parameter is not required when creating exec instances, only when starting them.
