### PR TITLE
Restore volume refs after daemon restart

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -400,9 +400,7 @@ func (daemon *Daemon) restore() error {
 	}
 
 	for _, c := range registeredContainers {
-		for _, mnt := range c.VolumeMounts() {
-			daemon.volumes.Add(mnt.volume)
-		}
+		c.registerVolumes()
 	}
 
 	if !debug {

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -92,6 +92,12 @@ func (container *Container) VolumePaths() map[string]struct{} {
 	return paths
 }
 
+func (container *Container) registerVolumes() {
+	for _, mnt := range container.VolumeMounts() {
+		mnt.volume.AddContainer(container.ID)
+	}
+}
+
 func (container *Container) derefVolumes() {
 	for path := range container.VolumePaths() {
 		vol := container.daemon.volumes.Get(path)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 )
@@ -47,4 +49,36 @@ func TestDaemonRestartWithRunningContainersPorts(t *testing.T) {
 	testRun(map[string]bool{"top1": true, "top2": false}, "After daemon restart: ")
 
 	logDone("daemon - running containers on daemon restart")
+}
+
+func TestDaemonRestartWithVolumesRefs(t *testing.T) {
+	d := NewDaemon(t)
+	if err := d.StartWithBusybox(); err != nil {
+		t.Fatal(err)
+	}
+	defer d.Stop()
+
+	if out, err := d.Cmd("run", "-d", "--name", "volrestarttest1", "-v", "/foo", "busybox"); err != nil {
+		t.Fatal(err, out)
+	}
+	if err := d.Restart(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := d.Cmd("run", "-d", "--volumes-from", "volrestarttest1", "--name", "volrestarttest2", "busybox"); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := d.Cmd("rm", "-fv", "volrestarttest2"); err != nil {
+		t.Fatal(err, out)
+	}
+	v, err := d.Cmd("inspect", "--format", "{{ json .Volumes }}", "volrestarttest1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	volumes := make(map[string]string)
+	json.Unmarshal([]byte(v), &volumes)
+	if _, err := os.Stat(volumes["/foo"]); err != nil {
+		t.Fatalf("Expected volume to exist: %s - %s", volumes["/foo"], err)
+	}
+
+	logDone("daemon - volume refs are restored")
 }


### PR DESCRIPTION
Volume refs were not being restored on daemon restart.
This made it possible to remove a volume being used by other containers
after a daemon restart.
