### PR TITLE
Fixes re-creating volume on (re)start

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -131,6 +131,11 @@ func (container *Container) parseVolumeMountConfig() (map[string]*Mount, error) 
 			continue
 		}
 
+		// Check if this has already been created
+		if _, exists := container.Volumes[path]; exists {
+			continue
+		}
+
 		vol, err := container.daemon.volumes.FindOrCreateVolume("", true)
 		if err != nil {
 			return nil, err

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -6,18 +6,21 @@ import (
 	"os/exec"
 )
 
-// the docker binary to use
-var dockerBinary = "docker"
+var (
+	// the docker binary to use
+	dockerBinary = "docker"
 
-// the private registry image to use for tests involving the registry
-var registryImageName = "registry"
+	// the private registry image to use for tests involving the registry
+	registryImageName = "registry"
 
-// the private registry to use for tests
-var privateRegistryURL = "127.0.0.1:5000"
+	// the private registry to use for tests
+	privateRegistryURL = "127.0.0.1:5000"
 
-var execDriverPath = "/var/lib/docker/execdriver/native"
+	execDriverPath    = "/var/lib/docker/execdriver/native"
+	volumesConfigPath = "/var/lib/docker/volumes"
 
-var workingDirectory string
+	workingDirectory string
+)
 
 func init() {
 	if dockerBin := os.Getenv("DOCKER_BINARY"); dockerBin != "" {

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -267,7 +267,7 @@ func deleteContainer(container string) error {
 	killSplitArgs := strings.Split(killArgs, " ")
 	killCmd := exec.Command(dockerBinary, killSplitArgs...)
 	runCommand(killCmd)
-	rmArgs := fmt.Sprintf("rm %v", container)
+	rmArgs := fmt.Sprintf("rm -v %v", container)
 	rmSplitArgs := strings.Split(rmArgs, " ")
 	rmCmd := exec.Command(dockerBinary, rmSplitArgs...)
 	exitCode, err := runCommand(rmCmd)


### PR DESCRIPTION
When a container is restarted all the volume configs are parsed again.
Even if the volume was already handled in a previous start it was still
calling "FindOrCreateVolume" on the volume repo causing a new volume to
be created.

This wasn't being detected because as part of the mount initialization
it checks to see if the the _mount_ was already initialized, but this
happens after the parsing of the configs.
So a check is added during parsing to skip a volume which was already
created for that container.
