### PR TITLE
Add a testcase to make sure we don't squash tabs or convert them to spaces

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2907,3 +2907,22 @@ RUN echo 123`,
 
 	logDone("build - verbose output from commands")
 }
+
+func TestBuildWithTabs(t *testing.T) {
+	name := "testbuildwithtabs"
+	defer deleteImages(name)
+	_, err := buildImage(name,
+		"FROM busybox\nRUN echo\tone\t\ttwo", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := inspectFieldJSON(name, "ContainerConfig.Cmd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "[\"/bin/sh\",\"-c\",\"echo\\u0009one\\u0009\\u0009two\"]"
+	if res != expected {
+		t.Fatalf("Missing tabs.\nGot:%s\nExp:%s", res, expected)
+	}
+	logDone("build - with tabs")
+}


### PR DESCRIPTION
This is in response to @SvenDowideit asking if we had a "tab" testcase
in https://github.com/docker/docker/issues/2315#issuecomment-58133508
I couldn't find one so I'm adding one

Signed-off-by: Doug Davis dug@us.ibm.com
