### PR TITLE
Proposal: Add volume ls/inspect/rm/create commands

### DIFF
--- a/api/client/volume_commands.go
+++ b/api/client/volume_commands.go
@@ -1,0 +1,262 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+	"time"
+
+	"github.com/docker/docker/engine"
+	"github.com/docker/docker/opts"
+	"github.com/docker/docker/pkg/parsers/filters"
+	"github.com/docker/docker/pkg/units"
+	"github.com/docker/docker/utils"
+)
+
+func (cli *DockerCli) CmdVolume(args ...string) error {
+	description := "Manage Docker Volumes\n\nCommands:\n"
+	commands := [][]string{
+		{"ls", "List volumes"},
+		{"inspect", "Inspect a volume"},
+		{"create", "Create a volume"},
+		{"rm", "Remove a volume"},
+	}
+
+	for _, cmd := range commands {
+		description += fmt.Sprintf("    %-10.10s%s\n", cmd[0], cmd[1])
+	}
+
+	description += "\nRun 'docker volume COMMNAD --help' for more information on a command."
+
+	cmd := cli.Subcmd("volume", "[COMMAND]", description, true)
+	if len(args) > 0 && (args[0] == "--help" || args[0] == "-h") {
+		cmd.Usage()
+		return nil
+	}
+
+	return cli.CmdVolumeLs(args...)
+}
+
+func (cli *DockerCli) CmdVolumeLs(args ...string) error {
+	cmd := cli.Subcmd("volume ls", "", "List volumes", true)
+
+	quiet := cmd.Bool([]string{"q", "-quiet"}, false, "Only display volume names")
+	size := cmd.Bool([]string{"s", "-size"}, false, "Display total size of volumes")
+	flFilter := opts.NewListOpts(nil)
+	cmd.Var(&flFilter, []string{"f", "-filter"}, "Provide filter values (i.e. 'dangling=true')")
+	cmd.Parse(args)
+
+	volFilterArgs := filters.Args{}
+	for _, f := range flFilter.GetAll() {
+		var err error
+		volFilterArgs, err = filters.ParseFlag(f, volFilterArgs)
+		if err != nil {
+			return err
+		}
+	}
+
+	v := url.Values{}
+	if *quiet {
+		v.Set("quiet", "1")
+	}
+
+	if *size {
+		v.Set("size", "1")
+	}
+
+	if len(volFilterArgs) > 0 {
+		filterJson, err := filters.ToParam(volFilterArgs)
+		if err != nil {
+			return err
+		}
+		v.Set("filters", filterJson)
+	}
+
+	body, _, err := readBody(cli.call("GET", "/volumes?"+v.Encode(), nil, false))
+	if err != nil {
+		return err
+	}
+
+	outs := engine.NewTable("Created", 0)
+	if _, err := outs.ReadListFrom(body); err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
+	if !*quiet {
+		fmt.Fprint(w, "NAME\tCREATED\tUSED COUNT\t")
+		if *size {
+			fmt.Fprintf(w, "SIZE")
+		}
+	}
+	fmt.Fprint(w, "\n")
+
+	for _, out := range outs.Data {
+		var (
+			name      = out.Get("Name")
+			usedCount = out.Get("Count")
+			created   = units.HumanDuration(time.Now().UTC().Sub(time.Unix(out.GetInt64("Created"), 0)))
+		)
+
+		if *quiet {
+			fmt.Fprintln(w, name)
+			continue
+		}
+		fmt.Fprintf(w, name+"\t")
+		fmt.Fprintf(w, fmt.Sprintf("%s ago\t", created))
+		fmt.Fprintf(w, usedCount+"\t")
+
+		if *size {
+			fmt.Fprintf(w, fmt.Sprintf("%s\t", units.HumanSize(float64(out.GetInt64("Size")))))
+		}
+		fmt.Fprintf(w, "\n")
+	}
+
+	if !*quiet {
+		w.Flush()
+	}
+	return nil
+}
+
+func (cli *DockerCli) CmdVolumeInspect(args ...string) error {
+	cmd := cli.Subcmd("volume inspect", "", "Inspect a volume", true)
+	tmplStr := cmd.String([]string{"f", "#format", "-format"}, "", "Format the output using the given go template.")
+	size := cmd.Bool([]string{"s", "-size"}, false, "Show the size of the volume in output")
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+	if cmd.NArg() < 1 {
+		cmd.Usage()
+		return nil
+	}
+
+	var tmpl *template.Template
+	if *tmplStr != "" {
+		var err error
+		if tmpl, err = template.New("").Funcs(funcMap).Parse(*tmplStr); err != nil {
+			fmt.Fprintf(cli.err, "Template parsing error: %v\n", err)
+			return &utils.StatusError{StatusCode: 64,
+				Status: "Template parsing error: " + err.Error()}
+		}
+	}
+
+	indented := new(bytes.Buffer)
+	indented.WriteByte('[')
+	status := 0
+
+	for _, name := range cmd.Args() {
+		v := url.Values{}
+		if *size {
+			v.Set("size", "1")
+		}
+		obj, _, err := readBody(cli.call("GET", "/volumes/"+name+"?"+v.Encode(), nil, false))
+		if err != nil {
+			if strings.Contains(err.Error(), "No such") {
+				fmt.Fprintf(cli.err, "Error: No such volume: %s\n", name)
+			} else {
+				fmt.Fprintf(cli.err, "%s", err)
+			}
+			status = 1
+			continue
+		}
+
+		if tmpl == nil {
+			if err = json.Indent(indented, obj, "", "    "); err != nil {
+				fmt.Fprintf(cli.err, "%s\n", err)
+				status = 1
+				continue
+			}
+		} else {
+			// Has template, will render
+			var value interface{}
+			if err := json.Unmarshal(obj, &value); err != nil {
+				fmt.Fprintf(cli.err, "%s\n", err)
+				status = 1
+				continue
+			}
+			if err := tmpl.Execute(cli.out, value); err != nil {
+				return err
+			}
+			cli.out.Write([]byte{'\n'})
+		}
+		indented.WriteString(",")
+	}
+
+	if indented.Len() > 1 {
+		// Remove trailing ','
+		indented.Truncate(indented.Len() - 1)
+	}
+	indented.WriteByte(']')
+
+	if tmpl == nil {
+		if _, err := io.Copy(cli.out, indented); err != nil {
+			return err
+		}
+	}
+
+	if status != 0 {
+		return &utils.StatusError{StatusCode: status}
+	}
+	return nil
+
+}
+
+func (cli *DockerCli) CmdVolumeRm(args ...string) error {
+	cmd := cli.Subcmd("volume rm", "", "remove a volume", true)
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+	if cmd.NArg() < 1 {
+		cmd.Usage()
+		return nil
+	}
+
+	var encounteredError error
+	for _, name := range cmd.Args() {
+		_, _, err := readBody(cli.call("DELETE", "/volumes/"+name, nil, false))
+		if err != nil {
+			fmt.Fprintf(cli.err, "%s\n", err)
+			encounteredError = fmt.Errorf("Error: failed to remove one or more volumes")
+			continue
+		}
+		fmt.Fprintf(cli.out, "%s\n", name)
+	}
+	return encounteredError
+}
+
+func (cli *DockerCli) CmdVolumeCreate(args ...string) error {
+	var (
+		cmd  = cli.Subcmd("volume create", "", "create a volume", true)
+		path = cmd.String([]string{"p", "-path"}, "", "Specify path of new volume")
+		mode = cmd.String([]string{"m", "-mode"}, "rw", "Sepcify write-mode of volume")
+		name = cmd.String([]string{"n", "-name"}, "", "Specify name of volume")
+	)
+
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+
+	v := map[string]string{
+		"mode": *mode,
+		"path": *path,
+		"name": *name,
+	}
+
+	stream, _, err := cli.call("POST", "/volumes", v, false)
+	if err != nil {
+		return err
+	}
+
+	var result engine.Env
+	if err := result.Decode(stream); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(cli.out, "%s\n", result.Get("Name"))
+	return nil
+}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -141,3 +141,24 @@ func (daemon *Daemon) GenerateSecurityOpt(ipcMode runconfig.IpcMode) ([]string, 
 	}
 	return nil, nil
 }
+
+func (daemon *Daemon) VolumeCreate(job *engine.Job) engine.Status {
+	var (
+		name = job.Getenv("name")
+		path = job.Getenv("path")
+		mode = job.Getenv("mode")
+	)
+
+	if !validMountMode(mode) {
+		return job.Errorf("Invalid mount mode: %s", mode)
+	}
+
+	writable := determineMountWritable(mode, true)
+	v, err := daemon.volumes.NewVolume(path, name, writable)
+	if err != nil {
+		return job.Errorf("Error creating volume: %q", err)
+	}
+
+	job.Printf("%s\n", v.Name)
+	return engine.StatusOK
+}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -134,6 +134,10 @@ func (daemon *Daemon) Install(eng *engine.Engine) error {
 		"execStart":         daemon.ContainerExecStart,
 		"execResize":        daemon.ContainerExecResize,
 		"execInspect":       daemon.ContainerExecInspect,
+		"volumesList":       daemon.VolumesList,
+		"volumeInspect":     daemon.VolumeInspect,
+		"volumeDelete":      daemon.VolumeDelete,
+		"volumeCreate":      daemon.VolumeCreate,
 	} {
 		if err := eng.Register(name, method); err != nil {
 			return err

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -123,3 +123,15 @@ func (daemon *Daemon) Destroy(container *Container) error {
 
 	return nil
 }
+
+func (daemon *Daemon) VolumeDelete(job *engine.Job) engine.Status {
+	if len(job.Args) != 1 {
+		return job.Errorf("Not enough arguments. Usage: %s CONTAINER\n", job.Name)
+	}
+
+	if err := daemon.volumes.Delete(job.Args[0]); err != nil {
+		return job.Error(err)
+	}
+
+	return engine.StatusOK
+}

--- a/docs/man/docker-volumes-create.1.md
+++ b/docs/man/docker-volumes-create.1.md
@@ -1,0 +1,24 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2014
+# NAME
+docker-volumes-create - Create a new volume
+
+# SYNOPSIS
+**docker volumes create**
+[**-n**|**--name**]
+[**-p**|**--path**]
+[**-m**|**--mode**]
+
+# OPTIONS
+**-n**, **--name**=""
+   Set volume's name.
+
+**-p**, **--path**=""
+   Set volume's path.
+
+**-m**, **--mode**=""
+   Set volume's read/write mode.
+
+# HISTORY
+November 2014, updated by Brian Goff <cpuguy83@mail.com>

--- a/docs/man/docker-volumes-inspect.1.md
+++ b/docs/man/docker-volumes-inspect.1.md
@@ -1,0 +1,54 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% November 2014
+# NAME
+docker-volumes-inspect - Return low-level information on a volume
+
+# SYNOPSIS
+**docker volumes inspect**
+[**-f**|**--format**[=*FORMAT*]]
+VOLUME [VOLUME...]
+
+# DESCRIPTION
+
+This displays all the information available in Docker for a given
+volume. By default, this will render all results in a JSON array. If a format is
+specified, the given template will be executed for each result.
+
+# OPTIONS
+**-f**, **--format**=""
+   Format the output using the given Go template.
+
+# EXAMPLES
+
+## Getting information on a volume
+
+To get information on a volume's name:
+
+    #docker volumes inspect morose_torvalds
+{
+        "ID": "124670d406cb783e37ad10d339e7f980db75460bcf4fedf1baa00566ebbcad63",
+        "Name": "morose_torvalds",
+        "Created": "2014-10-01T16:17:01.417634973Z",
+        "Path": "/var/lib/docker/vfs/dir/124670d406cb783e37ad10d339e7f980db75460bcf4fedf1baa00566ebbcad63",
+        "IsBindMount": false,
+        "Writable": true,
+        "Containers": [
+             "04b22da1ac4c47f758a3553d5c1c36e7510d1e99c80da19504f5f9112bc5491e",
+             "835f0b9b62d09145d14339ee2f651df5d8dec1239c3c94b2cdc8a614649ecc1e"
+         ],
+        "Aliases": [
+             "determined_brown:/foo",
+             "angry_bell:/bar"
+        ]
+}
+
+## Getting the host path of a volume
+
+To get the host path of a volume:
+
+    # docker volumes inspect --format='{{.Path}}' morose_torvalds
+    /var/lib/docker/vfs/dir/124670d406cb783e37ad10d339e7f980db75460bcf4fedf1baa00566ebbcad63
+
+# HISTORY
+November 2014, updated by Brian Goff <cpuguy83@mail.com>

--- a/docs/man/docker-volumes-ls.1.md
+++ b/docs/man/docker-volumes-ls.1.md
@@ -1,0 +1,52 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% November 2014
+# NAME
+docker-volumes-ls - List volumes
+
+# SYNOPSIS
+**docker volumes ls**
+[**-f**|**--filter**[=*[]*]]
+[**-q**|**--quiet**[=*false*]]
+[**-s**|**--size**[=*false*]]
+ [NAME]
+
+# DESCRIPTION
+This command lists the volumes registered with the local Docker instance.
+
+# OPTIONS
+**-f**, **--filter**=[]
+   Provide filter values (i.e. 'dangling=true')
+
+**-q**, **--quiet**=*true*|*false*
+   Only show numeric names. The default is *false*.
+
+**-s**, **--size**=*true*|*false*
+   Show the size of the volume on disk.
+
+# EXAMPLES
+
+## Listing the volumes
+
+To list the registered volumes:
+
+    docker volumes ls
+
+The list will contain the volume name, creation date, and the number of
+containers using the volume. Columns: NAME CREATED USED COUNT. The **ls**
+subcommand is optional and instead be run as just **docker volumes**, without
+the **ls**.
+
+To get a list of volumes with the size of the volume on disk, use **-s**:
+
+    docker volumes ls -s
+
+## Listing only the volume names
+
+Listing just the volume names. This can be useful for some automated
+tools.
+
+    docker volumes ls -q
+
+# HISTORY
+November 2014, updated by Brian Goff <cpuguy83@mail.com>

--- a/docs/man/docker-volumes-rm.1.md
+++ b/docs/man/docker-volumes-rm.1.md
@@ -1,0 +1,27 @@
+
+% Docker Community
+% JUNE 2014
+# NAME
+docker-volumes-rm - Remove one or more volumes
+
+# SYNOPSIS
+**docker volumes rm**
+
+# DESCRIPTION
+
+**docker rm** will remove one or more volumes from the host node. You cannot
+remove a volume which is being used by one or more volumes. Docker can also
+only remove volumes which it created within the Docker root path.
+
+# OPTIONS
+
+# EXAMPLES
+
+##Removing a volume##
+
+To remove a volume, use the **docker volumes rm cmmand**:
+
+    docker volumes rm morose_torvalds
+
+# HISTORY
+November 2014, updated by Brian Goff <cpuguy83@mail.com>

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -167,7 +167,7 @@ Create a container
              "Warnings":[]
         }
 
-Json Parameters:
+JSON Parameters:
 
 -   **Hostname** - A string value containing the desired hostname to use for the
       container.
@@ -510,7 +510,7 @@ Start the container `id`
 
         HTTP/1.1 204 No Content
 
-Json Parameters:
+JSON Parameters:
 
 Status Codes:
 
@@ -1346,7 +1346,7 @@ Create a new image from a container's changes
 
         {"Id": "596069db4bf5"}
 
-Json Parameters:
+JSON Parameters:
 
 -  **config** - the container's configuration
 
@@ -1540,7 +1540,7 @@ Sets up an exec instance in a running container `id`
              "Id": "f90e34656806"
         }
 
-Json Parameters:
+JSON Parameters:
 
 -   **AttachStdin** - Boolean value, attaches to stdin of the exec command.
 -   **AttachStdout** - Boolean value, attaches to stdout of the exec command.
@@ -1579,7 +1579,7 @@ interactive session with the `exec` command.
 
         {{ STREAM }}
 
-Json Parameters:
+JSON Parameters:
 
 -   **Detach** - Detach from the exec command
 -   **Tty** - Boolean value to allocate a pseudo-TTY
@@ -1726,6 +1726,138 @@ Status Codes:
 -   **200** – no error
 -   **404** – no such exec instance
 -   **500** - server error
+
+### Create a volume
+
+`POST /volumes`
+
+Create a new volume
+
+**Example request**:
+
+        POST /volumes HTTP/1.1
+        Content-Type: application/json
+
+        {
+         "path":"",
+         "name":"",
+         "mode":"rw",
+        }
+
+**Example response**:
+
+        HTTP/1.1 201 Created
+        Content-Type: application/json
+
+        {
+             "Name":"morose_torvalds"
+        }
+
+JSON Parameters:
+
+-   **path** Specify the host path of the volume, as a string. Leave empty to
+      have Docker automatically create this path.
+-   **name** Specify a name for the new volume, as a string.  Leave empty to
+      have Docker automatically generate a name.
+-   **mode** Set the write mode of the volume, supports "ro", and "rw".
+
+Status Codes:
+
+-   **201** – Created
+
+###  Delete a volume
+
+`DELETE /volumes/(id)`
+
+Delete a volume
+
+**Example request**:
+
+        DELETE /volumes/(id) HTTP/1.1
+        Content-Type: application/json
+
+**Example response**:
+
+        HTTP/1.1 204 NO CONTENT
+        Content-Type: application/json
+
+
+JSON Parameters:
+
+Status Codes:
+
+-   **204** – no content
+
+### List volumes
+
+`GET /volumes`
+
+List Volumes
+
+**Example request**:
+
+        GET /volumes HTTP/1.1
+        Content-Type: application/json
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+          {
+            "Name": "morose_torvalds",
+            "Path": "/var/lib/docker/vfs/dir/124670d406cb783e37ad10d339e7f980db75460bcf4fedf1baa00566ebbcad63",
+            "Count": 2
+          }
+        ]
+
+JSON Parameters:
+
+-   **size** Boolean flag to include volume size (on disk) in output
+-   **filters** – a json encoded value of the filters (a map[string][]string) to process on the images list.
+-   **quiet** - Boolean flag to list only list volume names
+
+Status Codes:
+
+-   **200** – OK
+
+### Inspect a volume
+
+`GET /volumes/(id)`
+
+Inspect a volume
+
+**Example request**:
+
+        GET /volume/(id) HTTP/1.1
+        Content-Type: application/json
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+                "ID": "124670d406cb783e37ad10d339e7f980db75460bcf4fedf1baa00566ebbcad63",
+                "Name": "jolly_torvalds",
+                "Created": "2014-10-01T16:17:01.417634973Z",
+                "Path": "/var/lib/docker/vfs/dir/124670d406cb783e37ad10d339e7f980db75460bcf4fedf1baa00566ebbcad63",
+                "IsBindMount": false,
+                "Writable": true,
+                "Aliases": [
+                     "determined_brown:/foo",
+                     "angry_bell:/bar"
+                ]
+        }
+
+JSON Parameters:
+
+-   **size** Boolean flag to include volume size (on disk) in output
+
+Status Codes:
+
+-   **200** – OK
 
 # 3. Going further
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1188,10 +1188,10 @@ ensure we know how your setup is configured.
 
     Return low-level information on a container or image
 
-      -f, --format=""    Format the output using the given go template.
+      -f, --format=""    Format the output using the given Go template.
 
 By default, this will render all results in a JSON array. If a format is
-specified, the given template will be executed for each result.
+specified, the given template will be applied for each result.
 
 Go's [text/template](http://golang.org/pkg/text/template/) package
 describes all the details of the format.
@@ -2000,3 +2000,48 @@ both Docker client and daemon.
 
     Block until a container stops, then print its exit code.
 
+
+## volumes ls
+
+    Usage: docker volumes ls
+
+      -f, --filter=[]   Provide filter values (i.e. 'dangling=true')
+      -q, --quiet=false Only display volume names
+      -s, --size=false  Display total size (on disk) of volumes
+
+    Lists registered volumes. `ls` is optional. Running `docker volumes` alone,
+    without `ls`, will yield the same result.
+
+## volumes rm
+
+    Usage: docker volumes rm VOLUME [VOLUME...]
+
+    Remove a volume
+
+## volumes inspect
+
+    Usage: docker volumes inspect VOLUME [VOLUME...]
+
+      -f, --format=""    Format the output using the given Go template.
+
+    Return low-level information on a volume
+
+By default, this will render all results in a JSON array. If a format is
+specified, the given template will be applied for each result.
+
+Go's [text/template](http://golang.org/pkg/text/template/) package
+describes all the details of the format.
+
+## volumes create
+
+    Usage: docker volumes create [OPTIONS]
+
+      -p, --path=""   Specify path of new volume
+      -n, --name=""   Specify name of volume
+      -m, --mode="rw" Sepcify write-mode of volume
+
+The `docker volumes create` command creates a volume, which is a directory or
+file on the host that can be mounted into containers.
+
+If no path is specified, one is automatically created.
+If there is no name specified, one will be generated.

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -629,9 +629,10 @@ container's `/etc/hosts` entry will be automatically updated.
 
 ## VOLUME (shared filesystems)
 
-    -v=[]: Create a bind mount with: [host-dir]:[container-dir]:[rw|ro].
+    -v=[]: Create a bind mount with: [host-dir|volume-name]:[container-dir]:[rw|ro].
            If "container-dir" is missing, then docker creates a new volume.
-    --volumes-from="": Mount all volumes from the given container(s)
+    --volumes-from="": Mount all volumes from the given container(s) with:
+                        [container]:[rw|ro|volume-dir][:container-dir|rw|ro][:rw|ro]
 
 The volumes commands are complex enough to have their own documentation
 in section [*Managing data in 

--- a/integration-cli/docker_cli_volumes_create_test.go
+++ b/integration-cli/docker_cli_volumes_create_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestVolumeCreate(t *testing.T) {
+	defer deleteAllVolumes()
+	cmd := exec.Command(dockerBinary, "volume", "create", "--name", "dark_helmet")
+	if out, _, err := runCommandWithOutput(cmd); err != nil {
+		t.Fatal(err, out)
+	}
+	cmd = exec.Command(dockerBinary, "volume", "inspect", "--format", "{{ .Path }}", "dark_helmet")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+	path := strings.TrimSpace(out)
+	if os.Stat(path); err != nil && os.IsNotExist(err) {
+		t.Fatalf("expected %s to exist", path)
+	}
+
+	logDone("volumes create - volume created")
+}
+
+func TestVolumeCreateBindMount(t *testing.T) {
+	defer deleteAllVolumes()
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "volumescreate-testbindmount")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	cmd := exec.Command(dockerBinary, "volume", "create", "--name", "princess_vespa", "--path", tmpDir)
+	if out, _, err := runCommandWithOutput(cmd); err != nil {
+		t.Fatal(err, out)
+	}
+	cmd = exec.Command(dockerBinary, "volume", "inspect", "--format", "{{ .IsBindMount }}", "princess_vespa")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "true") {
+		t.Fatal("Exepected IsBindMount to be true, got: %s", out)
+	}
+
+	logDone("volumes create - bind mount")
+}
+
+func TestVolumeCreateMode(t *testing.T) {
+	defer deleteAllVolumes()
+	// mode with normal volume
+	cmd := exec.Command(dockerBinary, "volume", "create", "--name", "dot_matrix", "--mode", "ro")
+	if out, _, err := runCommandWithOutput(cmd); err != nil {
+		t.Fatal(err, out)
+	}
+	cmd = exec.Command(dockerBinary, "volume", "inspect", "--format", "{{ .Writable }}", "dot_matrix")
+	if out, _, err := runCommandWithOutput(cmd); err != nil || !strings.Contains(out, "false") {
+		t.Fatal(err, "Failed to set mode:", out)
+	}
+
+	// mode with bind-mount
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "volumescreate-modetest2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+	cmd = exec.Command(dockerBinary, "volume", "create", "--name", "king_roland", "--path", tmpDir, "--mode", "ro")
+	if out, _, err := runCommandWithOutput(cmd); err != nil {
+		t.Fatal(err, out)
+	}
+	cmd = exec.Command(dockerBinary, "volume", "inspect", "--format", "{{ .Writable }}:{{ .IsBindMount }}", "king_roland")
+	if out, _, err := runCommandWithOutput(cmd); err != nil || !strings.Contains(out, "false:true") {
+		t.Fatal(err, "Failed to set mode:", out)
+	}
+
+	logDone("volumes create - mode is set")
+}
+
+func TestVolumeCreateUniquePaths(t *testing.T) {
+	defer deleteAllVolumes()
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "volumescreate-onevolume")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command(dockerBinary, "volume", "create", "--path", tmpDir)
+	if out, _, err := runCommandWithOutput(cmd); err != nil {
+		t.Fatal(err, out)
+	}
+
+	cmd = exec.Command(dockerBinary, "volume", "create", "--path", tmpDir)
+	if out, _, err := runCommandWithOutput(cmd); err == nil || !strings.Contains(out, "Volume exists") {
+		t.Fatalf("Expected creating 2nd volume with same path to fail\n%q", out)
+	}
+
+	logDone("volumes create - paths are unique")
+}
+
+func TestVolumeCreateUniqueNames(t *testing.T) {
+	defer deleteAllVolumes()
+
+	cmd := exec.Command(dockerBinary, "volume", "create", "--name", "lone_starr")
+	if out, _, err := runCommandWithOutput(cmd); err != nil {
+		t.Fatal(err, out)
+	}
+
+	cmd = exec.Command(dockerBinary, "volume", "create", "--name", "lone_starr")
+	if out, _, err := runCommandWithOutput(cmd); err == nil || !strings.Contains(out, "Volume exists") {
+		t.Fatalf("Expected creating 2nd volume with same name to fail\n%q", out)
+	}
+
+	logDone("volumes create - names are unique")
+}

--- a/integration-cli/docker_cli_volumes_ls_test.go
+++ b/integration-cli/docker_cli_volumes_ls_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestVolumesLs(t *testing.T) {
+	deleteAllVolumes()
+
+	defer deleteAllVolumes()
+
+	numberOfVolumes := 3
+
+	for i := 0; i < numberOfVolumes; i++ {
+		cmd := exec.Command(dockerBinary, "volume", "create")
+		if _, err := runCommand(cmd); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd := exec.Command(dockerBinary, "volume", "ls")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+	lines := strings.Split(strings.Trim(out, "\n "), "\n")
+	if len(lines)-1 < numberOfVolumes {
+		t.Fatalf("Volumes are not showing up in list:\n%q", out)
+	}
+
+	logDone("volumes ls - volumes are being listed")
+}

--- a/integration-cli/docker_cli_volumes_rm_test.go
+++ b/integration-cli/docker_cli_volumes_rm_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestVolumesRm(t *testing.T) {
+	defer deleteAllContainers()
+	deleteAllVolumes()
+
+	cmd := exec.Command(dockerBinary, "volume", "create", "--name", "kevin_flynn")
+	if _, err := runCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--name", "sam_flynn", "-v", "kevin_flynn:/foo", "busybox")
+	if _, err := runCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	// This should fail since a container is using it
+	cmd = exec.Command(dockerBinary, "volume", "rm", "kevin_flynn")
+	out, _, err := runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "is being used") {
+		t.Fatal(err, out)
+	}
+
+	cmd = exec.Command(dockerBinary, "rm", "sam_flynn")
+	if _, err := runCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd = exec.Command(dockerBinary, "volume", "rm", "kevin_flynn")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	lines := strings.Split(strings.Trim(out, "\n "), "\n")
+	if len(lines)-1 != 0 {
+		t.Fatalf("Volumes not removed properly\n%q", out)
+	}
+
+	logDone("volume rm - volumes are removed")
+}

--- a/volumes/volume.go
+++ b/volumes/volume.go
@@ -8,17 +8,21 @@ import (
 	"path"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/symlink"
+	"github.com/docker/docker/utils"
 )
 
 type Volume struct {
 	ID          string
+	Created     time.Time
 	Path        string
 	IsBindMount bool
 	Writable    bool
 	containers  map[string]struct{}
+	Name        string
 	configPath  string
 	repository  *Repository
 	lock        sync.Mutex
@@ -126,6 +130,15 @@ func (v *Volume) initialize() error {
 	defer f.Close()
 
 	return v.toDisk()
+}
+
+func (v *Volume) Size() int64 {
+	size, err := utils.TreeSize(v.Path)
+	if err != nil {
+		return -1
+	}
+
+	return size
 }
 
 func (v *Volume) ToDisk() error {


### PR DESCRIPTION
`docker volumes ls` - list all volumes
Can be used with --filter dangling=true to list volumes not in use

`docker volumes create` - create volumes
Can set, `--name`, `--path`, `--mode`.  Can also be used with no
arguments to have everything auto generated

`docker volumes rm <volume name>` - Remove a volume
Volumes in use by containers cannot be removed.
Bind-mounts cannot be removed. (May want to have a way to remove just
the bind-mount config. Else this does seem to cause issues with tests)

`docker volumes inspect <volume name>` - Inspect a volume/get its config
Supports `--format` just like container inspect.

`docker run` can be used to either call a volume by name as `docker run
-v <volume name>:<mount point>` or with `docker run --volumes-from
<volume alias>:<mount point>[:<mode>]`
`docker run -v <path>` will create a volume with a generated name, just
as `docker volumes create` with no args.

All existing APIs/UI will work as normal.
There is no breakage in these changes.

Implements Proposal https://github.com/docker/docker/issues/8363
