### PR TITLE
Show canonical name in `docker ps`

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1558,22 +1558,27 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 			outID = utils.TruncateID(outID)
 		}
 
-		// Remove the leading / from the names
-		for i := 0; i < len(outNames); i++ {
-			outNames[i] = outNames[i][1:]
-		}
-
 		if !*quiet {
 			var (
-				outCommand   = out.Get("Command")
-				ports        = engine.NewTable("", 0)
-				outNamesList = strings.Join(outNames, ",")
+				outCommand = out.Get("Command")
+				ports      = engine.NewTable("", 0)
 			)
 			outCommand = strconv.Quote(outCommand)
 			if !*noTrunc {
 				outCommand = utils.Trunc(outCommand, 20)
-				outNamesList = outNames[0]
+				// Keep only the canonical name
+				for i := 0; i < len(outNames); i++ {
+					if !strings.Contains(outNames[i][1:], "/") {
+						outNames = outNames[i : i+1]
+						break
+					}
+				}
 			}
+			// Remove the leading / from the names
+			for i := 0; i < len(outNames); i++ {
+				outNames[i] = outNames[i][1:]
+			}
+			outNamesList := strings.Join(outNames, ",")
 			ports.ReadListFrom([]byte(out.Get("Ports")))
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\t%s\t%s\t%s\t", outID, out.Get("Image"), outCommand, units.HumanDuration(time.Now().UTC().Sub(time.Unix(out.GetInt64("Created"), 0))), out.Get("Status"), api.DisplayablePorts(ports), outNamesList)
 			if *size {

--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -151,12 +151,13 @@ earlier. The `--link` flag takes the form:
 Where `name` is the name of the container we're linking to and `alias` is an
 alias for the link name. You'll see how that alias gets used shortly.
 
-Next, look at your linked containers using `docker ps`.
+Next, look at the names of your linked containers by filtering the full output of
+`docker ps` to the last column (NAMES) using `docker ps --no-trunc | awk '{print $NF}'`.
 
-    $ sudo docker ps
-    CONTAINER ID  IMAGE                     COMMAND               CREATED             STATUS             PORTS                    NAMES
-    349169744e49  training/postgres:latest  su postgres -c '/usr  About a minute ago  Up About a minute  5432/tcp                 db, web/db
-    aed84ee21bde  training/webapp:latest    python app.py         16 hours ago        Up 2 minutes       0.0.0.0:49154->5000/tcp  web
+    $ sudo docker ps --no-trunc | awk '{print $NF}'
+    NAMES
+    db, web/db
+    web
 
 You can see your named containers, `db` and `web`, and you can see that the `db`
 container also shows `web/db` in the `NAMES` column. This tells you that the

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -282,3 +282,50 @@ func TestPsListContainersFilterStatus(t *testing.T) {
 
 	logDone("ps - test ps filter status")
 }
+
+func TestPsListContainersNames(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "--name", "link_target", "-d", "busybox", "top")
+	out, _, err := runCommandWithOutput(runCmd)
+	errorOut(err, t, out)
+
+	runCmd = exec.Command(dockerBinary, "run", "--name", "link_source", "--link", "link_target:link_alias", "-d", "busybox", "top")
+	out, _, err = runCommandWithOutput(runCmd)
+	errorOut(err, t, out)
+
+	// non-truncated ps should return all names
+	runCmd = exec.Command(dockerBinary, "ps", "--no-trunc")
+	out, _, err = runCommandWithOutput(runCmd)
+	errorOut(err, t, out)
+	lines := strings.Split(strings.Trim(out, "\n "), "\n")
+	namesIndex := strings.Index(lines[0], "NAMES")
+	expectedNames := "link_source"
+	foundNames := strings.TrimSpace(lines[1][namesIndex:])
+	if foundNames != expectedNames {
+		t.Fatalf("Expected names %q, got %q", expectedNames, foundNames)
+	}
+	expectedNames = "link_source/link_alias,link_target"
+	foundNames = strings.TrimSpace(lines[2][namesIndex:])
+	if foundNames != expectedNames {
+		t.Fatalf("Expected names %q, got %q", expectedNames, foundNames)
+	}
+
+	// truncated ps should return canonical names only
+	runCmd = exec.Command(dockerBinary, "ps")
+	out, _, err = runCommandWithOutput(runCmd)
+	errorOut(err, t, out)
+	lines = strings.Split(strings.Trim(out, "\n "), "\n")
+	namesIndex = strings.Index(lines[0], "NAMES")
+	expectedNames = "link_source"
+	foundNames = strings.TrimSpace(lines[1][namesIndex:])
+	if foundNames != expectedNames {
+		t.Fatalf("Expected names %q, got %q", expectedNames, foundNames)
+	}
+	expectedNames = "link_target"
+	foundNames = strings.TrimSpace(lines[2][namesIndex:])
+	if foundNames != expectedNames {
+		t.Fatalf("Expected names %q, got %q", expectedNames, foundNames)
+	}
+
+	deleteAllContainers()
+	logDone("ps - test ps names")
+}


### PR DESCRIPTION
After trying out the upcoming 1.3.0, I was pleased to see that https://github.com/docker/docker/pull/7686 made the default output of `docker ps` more compact. However, keeping the very first name could be confusing, as it might be the name resulting from a `--link` (`foo/bar`). @guywithnose @crosbymichael was that on purpose?

This patches makes sure that the canonical name is shown (which also happens to be the shortest), and avoid unnecessary processing of the names.
