### PR TITLE
Disable stable IPs.

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -564,6 +564,8 @@ func (container *Container) RestoreNetwork() error {
 // cleanup releases any network resources allocated to the container along with any rules
 // around how containers are linked together.  It also unmounts the container's root filesystem.
 func (container *Container) cleanup() {
+	container.ReleaseNetwork()
+
 	// Disable all active links
 	if container.activeLinks != nil {
 		for _, link := range container.activeLinks {
@@ -1019,14 +1021,8 @@ func (container *Container) initializeNetworking() error {
 		container.Config.NetworkDisabled = true
 		return container.buildHostnameAndHostsFiles("127.0.1.1")
 	}
-	// Backward compatibility:
-	// Network allocation used to be done when containers started, not when they
-	// were created, therefore we might be starting a legacy container that
-	// doesn't have networking.
-	if !container.isNetworkAllocated() {
-		if err := container.AllocateNetwork(); err != nil {
-			return err
-		}
+	if err := container.AllocateNetwork(); err != nil {
+		return err
 	}
 	return container.buildHostnameAndHostsFiles(container.NetworkSettings.IPAddress)
 }

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -93,10 +93,6 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 		if err := daemon.setHostConfig(container, hostConfig); err != nil {
 			return nil, nil, err
 		}
-		// We may only allocate the network if a host config was passed, otherwise we'll miss port mappings.
-		if err := container.AllocateNetwork(); err != nil {
-			return nil, nil, err
-		}
 	}
 	if err := container.ToDisk(); err != nil {
 		return nil, nil, err

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -370,16 +370,6 @@ func (daemon *Daemon) restore() error {
 		registeredContainers = append(registeredContainers, container)
 	}
 
-	// Restore networking of registered containers.
-	// This must be performed prior to any IP allocation, otherwise we might
-	// end up giving away an already allocated address.
-	for _, container := range registeredContainers {
-		if err := container.RestoreNetwork(); err != nil {
-			log.Errorf("Failed to restore network for %v: %v", container.Name, err)
-			continue
-		}
-	}
-
 	// check the restart policy on the containers and restart any container with
 	// the restart policy of "always"
 	if daemon.config.AutoRestart {

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -94,8 +94,6 @@ func (daemon *Daemon) Destroy(container *Container) error {
 		return err
 	}
 
-	container.ReleaseNetwork()
-
 	// Deregister the container before removing its directory, to avoid race conditions
 	daemon.idIndex.Delete(container.ID)
 	daemon.containers.Delete(container.ID)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1937,100 +1937,6 @@ func TestRunMutableNetworkFiles(t *testing.T) {
 	}
 }
 
-func TestRunStableIPAndPort(t *testing.T) {
-	const nContainers = 2
-	var ids, ips, macs, ports [nContainers]string
-
-	// Setup: Create a couple of containers and collect their IPs and public ports.
-	for i := 0; i < nContainers; i++ {
-		runCmd := exec.Command(dockerBinary, "run", "-d", "-p", "1234", "busybox", "top")
-		out, _, err := runCommandWithOutput(runCmd)
-		if err != nil {
-			t.Fatal(err)
-		}
-		ids[i] = strings.TrimSpace(out)
-
-		ips[i], err = inspectField(ids[i], "NetworkSettings.IPAddress")
-		errorOut(err, t, out)
-		if ips[i] == "" {
-			t.Fatal("IP allocation failed")
-		}
-
-		macs[i], err = inspectField(ids[i], "NetworkSettings.MacAddress")
-		errorOut(err, t, out)
-
-		portCmd := exec.Command(dockerBinary, "port", ids[i], "1234")
-		ports[i], _, err = runCommandWithOutput(portCmd)
-		errorOut(err, t, out)
-		if ports[i] == "" {
-			t.Fatal("Port allocation failed")
-		}
-	}
-
-	// Stop them all.
-	for _, id := range ids {
-		cmd := exec.Command(dockerBinary, "stop", id)
-		out, _, err := runCommandWithOutput(cmd)
-		if err != nil {
-			t.Fatal(err, out)
-		}
-	}
-
-	// Create a new container and ensure it's not getting the IP or port of some stopped container.
-	{
-		runCmd := exec.Command(dockerBinary, "run", "-d", "-p", "1234", "busybox", "top")
-		out, _, err := runCommandWithOutput(runCmd)
-		errorOut(err, t, out)
-
-		id := strings.TrimSpace(out)
-		ip, err := inspectField(id, "NetworkSettings.IPAddress")
-		errorOut(err, t, out)
-
-		portCmd := exec.Command(dockerBinary, "port", id, "1234")
-		port, _, err := runCommandWithOutput(portCmd)
-		errorOut(err, t, out)
-
-		for i := range ids {
-			if ip == ips[i] {
-				t.Fatalf("Conflicting IP: %s", ip)
-			}
-			if port == ports[i] {
-				t.Fatalf("Conflicting port: %s", port)
-			}
-		}
-	}
-
-	// Start the containers back, and ensure they are getting the same IPs, MACs and ports.
-	for i, id := range ids {
-		runCmd := exec.Command(dockerBinary, "start", id)
-		out, _, err := runCommandWithOutput(runCmd)
-		errorOut(err, t, out)
-
-		ip, err := inspectField(id, "NetworkSettings.IPAddress")
-		errorOut(err, t, out)
-
-		mac, err := inspectField(id, "NetworkSettings.MacAddress")
-		errorOut(err, t, out)
-
-		portCmd := exec.Command(dockerBinary, "port", ids[i], "1234")
-		port, _, err := runCommandWithOutput(portCmd)
-		errorOut(err, t, out)
-
-		if ips[i] != ip {
-			t.Fatalf("Container started with a different IP: %s != %s", ip, ips[i])
-		}
-		if macs[i] != mac {
-			t.Fatalf("Container started with a different MAC: %s != %s", mac, macs[i])
-		}
-		if ports[i] != port {
-			t.Fatalf("Container started with a different port: %s != %s", port, ports[i])
-		}
-	}
-
-	deleteAllContainers()
-	logDone("run - ips and ports must not change")
-}
-
 // Ensure that CIDFile gets deleted if it's empty
 // Perform this test by making `docker run` fail
 func TestRunCidFileCleanupIfEmpty(t *testing.T) {
@@ -2139,7 +2045,7 @@ func TestRunPortInUse(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer l.Close()
-	cmd := exec.Command(dockerBinary, "run", "-p", port+":80", "busybox", "true")
+	cmd := exec.Command(dockerBinary, "run", "-d", "-p", port+":80", "busybox", "top")
 	out, _, err := runCommandWithOutput(cmd)
 	if err == nil {
 		t.Fatalf("Binding on used port must fail")
@@ -2157,7 +2063,7 @@ func TestRunPortProxy(t *testing.T) {
 	defer deleteAllContainers()
 
 	port := "12345"
-	cmd := exec.Command(dockerBinary, "run", "-p", port+":80", "busybox", "true")
+	cmd := exec.Command(dockerBinary, "run", "-d", "-p", port+":80", "busybox", "top")
 
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {


### PR DESCRIPTION
Stable IPs causes some regressions in the way people use Docker, fix #8493.

Reverting it for 1.3, we'll enable it back for the next release.

Signed-off-by: Andrea Luzzardi aluzzardi@gmail.com
