### PR TITLE
Add DOCKER_TLS_VERIFY environment variable, equivalent to --tlsverify flag

### DIFF
--- a/docker/flags.go
+++ b/docker/flags.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	dockerCertPath = os.Getenv("DOCKER_CERT_PATH")
+	dockerCertPath  = os.Getenv("DOCKER_CERT_PATH")
+	dockerTlsVerify = os.Getenv("DOCKER_TLS_VERIFY") != ""
 )
 
 func init() {
@@ -26,7 +27,7 @@ var (
 	flSocketGroup = flag.String([]string{"G", "-group"}, "docker", "Group to assign the unix socket specified by -H when running in daemon mode\nuse '' (the empty string) to disable setting of a group")
 	flEnableCors  = flag.Bool([]string{"#api-enable-cors", "-api-enable-cors"}, false, "Enable CORS headers in the remote API")
 	flTls         = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by tls-verify flags")
-	flTlsVerify   = flag.Bool([]string{"-tlsverify"}, false, "Use TLS and verify the remote (daemon: verify client, client: verify daemon)")
+	flTlsVerify   = flag.Bool([]string{"-tlsverify"}, dockerTlsVerify, "Use TLS and verify the remote (daemon: verify client, client: verify daemon)")
 
 	// these are initialized in init() below since their default values depend on dockerCertPath which isn't fully initialized until init() runs
 	flTrustKey *string

--- a/docs/sources/articles/https.md
+++ b/docs/sources/articles/https.md
@@ -139,16 +139,18 @@ need to provide your client keys, certificates and trusted CA:
 
 If you want to secure your Docker client connections by default, you can move 
 the files to the `.docker` directory in your home directory - and set the
-`DOCKER_HOST` variable as well.
+`DOCKER_HOST` and `DOCKER_TLS_VERIFY` variables as well (instead of passing
+`-H=tcp://:2376` and `--tlsverify` on every call).
 
     $ cp ca.pem ~/.docker/ca.pem
     $ cp cert.pem ~/.docker/cert.pem
     $ cp key.pem ~/.docker/key.pem
     $ export DOCKER_HOST=tcp://:2376
+    $ export DOCKER_TLS_VERIFY=1
 
-Then you can run Docker with the `--tlsverify` option.
+Docker will now connect securely by default:
 
-    $ sudo docker --tlsverify ps
+    $ sudo docker ps
 
 ## Other modes
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -116,6 +116,14 @@ the `-H` flag for the client.
     $ sudo docker ps
     # both are equal
 
+Setting the `DOCKER_TLS_VERIFY` environment variable to any value other than the empty
+string is equivalent to setting the `--tlsverify` flag. The following are equivalent:
+
+    $ sudo docker --tlsverify ps
+    # or
+    $ export DOCKER_TLS_VERIFY=1
+    $ sudo docker ps
+
 IP masquerading uses address translation to allow containers without a public IP to talk
 to other machines on the Internet. This may interfere with some network topologies and
 can be disabled with --ip-masq=false.


### PR DESCRIPTION
This makes it possible to make the Docker client "secure by default" without wrapping the binary in a shell alias so that `--tlsverify` is always passed.
