### PR TITLE
cleaner handling of client socket access

### DIFF
--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -40,6 +40,14 @@ func (cli *DockerCli) HTTPClient() *http.Client {
 			return net.DialTimeout(cli.proto, cli.addr, 32*time.Second)
 		},
 	}
+	if cli.proto == "unix" {
+		// XXX workaround for net/http Transport which caches connections, but is
+		// intended for tcp connections, not unix sockets.
+		tr.DisableKeepAlives = true
+
+		// no need in compressing for local communications
+		tr.DisableCompression = true
+	}
 	return &http.Client{Transport: tr}
 }
 


### PR DESCRIPTION
In the go stdlib net/http Transport, the used connections are cached
when idled. This behaviour is intended for TCP connections and does not
behave correctly for unix sockets. Despite the
DefaultMaxIdleConnsPerHost being 2, the idled connections are held open
during a session. For large sessions like `docker rm $(docker ps -a -q)`
of thousands of containers, it will cause the client _and_ the server to
open too many fails and have failures.

Having keep alives not used for only unix sockets is a work around for
this stdlib issue.

Also this includes disabling compression when communicating over the
local unix socket too.

ping @unclejack @vieux 

Fixes #5970

Signed-off-by: Vincent Batts vbatts@redhat.com
