### PR TITLE
daemon: resolve the graphdriver to show

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -45,6 +45,13 @@ func mainDaemon() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		log.Infof("docker daemon: %s %s; execdriver: %s; graphdriver: %s",
+			dockerversion.VERSION,
+			dockerversion.GITCOMMIT,
+			d.ExecutionDriver().Name(),
+			d.GraphDriver().String(),
+		)
+
 		if err := d.Install(eng); err != nil {
 			log.Fatal(err)
 		}
@@ -58,13 +65,6 @@ func mainDaemon() {
 			log.Fatal(err)
 		}
 	}()
-	// TODO actually have a resolved graphdriver to show?
-	log.Infof("docker daemon: %s %s; execdriver: %s; graphdriver: %s",
-		dockerversion.VERSION,
-		dockerversion.GITCOMMIT,
-		daemonCfg.ExecDriver,
-		daemonCfg.GraphDriver,
-	)
 
 	// Serve api
 	job := eng.Job("serveapi", flHosts...)


### PR DESCRIPTION
graphdriver is not always specified when the log printed, because
it's provided in another thread. This patch will fix this.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
