### PR TITLE
Add DOCKER_LINKS and *_PORTS env vars when linking containers

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -1064,6 +1065,7 @@ func (container *Container) setupLinkedContainers() ([]string, error) {
 			container.activeLinks = nil
 		}
 
+		aliases := []string{}
 		for linkAlias, child := range children {
 			if !child.IsRunning() {
 				return nil, fmt.Errorf("Cannot link to a non running container: %s AS %s", child.Name, linkAlias)
@@ -1088,9 +1090,16 @@ func (container *Container) setupLinkedContainers() ([]string, error) {
 				return nil, err
 			}
 
+			alias := strings.Replace(link.Alias(), "-", "_", -1)
+			aliases = append(aliases, alias)
+
 			for _, envVar := range link.ToEnv() {
 				env = append(env, envVar)
 			}
+		}
+		if len(aliases) > 0 {
+			sort.Strings(aliases) // just so it looks nice to the user
+			env = append(env, "DOCKER_LINKS="+strings.Join(aliases, " "))
 		}
 	}
 	return env, nil

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -324,16 +324,18 @@ Running the **env** command in the linker container shows environment variables
     # env
     HOSTNAME=668231cb0978
     TERM=xterm
+    DOCKER_LINKS=lt
+    LT_NAME=/linker/lt
+    LT_PORTS=80/tcp
     LT_PORT_80_TCP=tcp://172.17.0.3:80
+    LT_PORT_80_TCP_ADDR=172.17.0.3
     LT_PORT_80_TCP_PORT=80
     LT_PORT_80_TCP_PROTO=tcp
     LT_PORT=tcp://172.17.0.3:80
     PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     PWD=/
-    LT_NAME=/linker/lt
     SHLVL=1
     HOME=/
-    LT_PORT_80_TCP_ADDR=172.17.0.3
     _=/usr/bin/env
 
 When linking two containers Docker will use the exposed ports of the container

--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -185,11 +185,22 @@ When two containers are linked, Docker will set some environment variables
 in the target container to enable programmatic discovery of information
 related to the source container.
 
-First, Docker will set an `<alias>_NAME` environment variable specifying the
-alias of each target container that was given in a `--link` parameter. So,
+First, Docker will set an environment variable called `DOCKER_LINKS`
+whose value will be a space separated list of alias containers that this
+container is linked to.
+
+For each linked container (or alias), Docker will then set an
+`<alias>_NAME` environment variable specifying the
+full alias of each target container that was given in a `--link` parameter. So,
 for example, if a new container called `web` is being linked to a database
 container called `db` via `--link db:webdb` then in the `web` container
 would be `WEBDB_NAME=/web/webdb`.
+
+Additionally, Docker will set an `<alias>_PORTS` environment variable
+whose value will be a space separated list of ports that are exposed
+by the linked container. Each port will be of the form `<port>/<protoco>`.
+For example, if `webdb` container's port 80 is exposed via tcp/ip, then
+`WEBDB_PORTS=80/tcp` would be set.
 
 Docker will then also define a set of environment variables for each
 port that is exposed by the source container. The pattern followed is:

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -154,3 +154,63 @@ func TestLinksInspectLinksStopped(t *testing.T) {
 
 	logDone("link - links in stopped container inspect")
 }
+
+func TestLinksEnvVars(t *testing.T) {
+	defer deleteAllContainers()
+
+	// First setup some containers that we'll link to later
+	cmd(t, "run", "-d", "--name", "c0", "busybox", "sleep", "10")
+	cmd(t, "run", "-d", "--expose", "81", "--name", "c1", "busybox", "sleep", "10")
+	cmd(t, "run", "-d", "--expose", "92", "--expose", "93/udp", "--name", "c2", "busybox", "sleep", "10")
+
+	// We're not going to check the full list of env vars set, the unit
+	// testcases should already cover those.  Instead, we're just going to
+	// check to make sure the top-level env vars are there - meaning
+	// ones like DOCKER_LINKS, *_PORTS and *_NAME
+
+	// First make sure DOCKER_LINKS isn't set when we're not linked
+	out, _, _ := cmd(t, "exec", "c1", "env")
+	if strings.Contains(out, "DOCKER_LINKS") {
+		t.Fatal("DOCKER_LINKS was not supposed to be set: %s", out)
+	}
+
+	// Now do some linking and check the env list each time
+
+	// Linking to a container w/o any exposed ports
+	out, _, _ = cmd(t, "run", "--link", "c0:c0", "--name", "p1", "busybox", "env")
+	if !strings.Contains(out, "DOCKER_LINKS=c0") ||
+		!strings.Contains(out, "C0_NAME=/p1/c0") ||
+		strings.Contains(out, "C0_PORTS") {
+		t.Fatal("P1 - Unexpected output: %s", out)
+	}
+
+	// Link to container with one exposed port
+	out, _, _ = cmd(t, "run", "--link", "c1:c1", "--name", "p2", "busybox", "env")
+	if !strings.Contains(out, "DOCKER_LINKS=c1") ||
+		!strings.Contains(out, "C1_NAME=/p2/c1") ||
+		!strings.Contains(out, "C1_PORTS=81/tcp") {
+		t.Fatal("P2 - Unexpected output: %s", out)
+	}
+
+	// Link to container with two exposed ports
+	out, _, _ = cmd(t, "run", "--link", "c2:c2", "--name", "p3", "busybox", "env")
+	if !strings.Contains(out, "DOCKER_LINKS=c2") ||
+		!strings.Contains(out, "C2_NAME=/p3/c2") ||
+		!strings.Contains(out, "C2_PORTS=92/tcp 93/udp") {
+		t.Fatal("P3 - Unexpected output: %s", out)
+	}
+
+	// Link to all containers
+	out, _, _ = cmd(t, "run", "--link", "c0:c0", "--link", "c1:c1", "--link", "c2:c2", "--name", "p4", "busybox", "env")
+	if !strings.Contains(out, "DOCKER_LINKS=c0 c1 c2") ||
+		!strings.Contains(out, "C0_NAME=/p4/c0") ||
+		!strings.Contains(out, "C1_NAME=/p4/c1") ||
+		!strings.Contains(out, "C2_NAME=/p4/c2") ||
+		strings.Contains(out, "C0_PORTS") ||
+		!strings.Contains(out, "C1_PORTS=81/tcp") ||
+		!strings.Contains(out, "C2_PORTS=92/tcp 93/udp") {
+		t.Fatal("P4 - Unexpected output: %s", out)
+	}
+
+	logDone("link - verify env vars")
+}

--- a/links/links_test.go
+++ b/links/links_test.go
@@ -85,6 +85,9 @@ func TestLinkEnv(t *testing.T) {
 		}
 		env[parts[0]] = parts[1]
 	}
+	if env["DOCKER_PORTS"] != "6379/tcp" {
+		t.Fatalf("Expected 6379/tcp, got %s", env["DOCKER_PORTS"])
+	}
 	if env["DOCKER_PORT"] != "tcp://172.0.17.2:6379" {
 		t.Fatalf("Expected 172.0.17.2:6379, got %s", env["DOCKER_PORT"])
 	}


### PR DESCRIPTION
Add two new env vars:
DOCKER_LINKS - lists the container aliases that this container is linked to
*_PORTS - lists all of the port/proto's for a particular container alias

Net result is:
new: DOCKER_LINKS=<link1> <link2> ...
new: link1_PORTS=<port1>/<proto> <port2>/<proto> ...
old: link1_NAME=<this_name>/<link1>
old: link1_PORT_port1_proto=<proto>://<ip>:<port>
old: link1_PORT_port1_proto_ADDR=<ip>
old: link1_PORT_port1_proto_PORT=<port>
old: link1_PORT_port1_proto_PROTO=<proto>

With this it should make it a lot easier to discover all of the ports
that are linked from within a container. W/o these two env vars people had
to iterate thru the env vars to find the list. Now there's a very clear way
to determine exactly what's there w/o looping/scanning.

Additionally, getting the *_NAME is now easier because there was no way
to discover this w/o either _just knowing_ the name in advance or looking
for all env vars that ended with _NAME, which seems very risky.

Signed-off-by: Doug Davis dug@us.ibm.com
