### PR TITLE
client: even cleaner use of Transport

### DIFF
--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -16,7 +15,6 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/dockerversion"
@@ -33,22 +31,7 @@ var (
 )
 
 func (cli *DockerCli) HTTPClient() *http.Client {
-	tr := &http.Transport{
-		TLSClientConfig: cli.tlsConfig,
-		Dial: func(network, addr string) (net.Conn, error) {
-			// Why 32? See issue 8035
-			return net.DialTimeout(cli.proto, cli.addr, 32*time.Second)
-		},
-	}
-	if cli.proto == "unix" {
-		// XXX workaround for net/http Transport which caches connections, but is
-		// intended for tcp connections, not unix sockets.
-		tr.DisableKeepAlives = true
-
-		// no need in compressing for local communications
-		tr.DisableCompression = true
-	}
-	return &http.Client{Transport: tr}
+	return &http.Client{Transport: cli.transport}
 }
 
 func (cli *DockerCli) encodeData(data interface{}) (*bytes.Buffer, error) {


### PR DESCRIPTION
First off, sorry for the noise. This is a cleaner step of #8508

Found more of a root cause of the open file handles.
After more testing I found that the open file descriptors will still
occur for TCP:// connections to the daemon, causing client and/or daemon
to fail.

The issue was instantiating a new http.Transport on _ever_ client
request. So each instance held the prior connection alive, but was only
ever used once.

By moving it out to the initilization of DockerCli, we can now have
reuse of idled connections. Simplifies the garbage overhead of the
client too, though that's not usually a deal.

ping @unclejack @vieux 

Signed-off-by: Vincent Batts vbatts@redhat.com
