### PR TITLE
builder: ONBUILD triggers were not accurately being executed in JSON cases

### DIFF
--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -41,10 +41,10 @@ var (
 	ErrDockerfileEmpty = errors.New("Dockerfile cannot be empty")
 )
 
-var evaluateTable map[string]func(*Builder, []string, map[string]bool) error
+var evaluateTable map[string]func(*Builder, []string, map[string]bool, string) error
 
 func init() {
-	evaluateTable = map[string]func(*Builder, []string, map[string]bool) error{
+	evaluateTable = map[string]func(*Builder, []string, map[string]bool, string) error{
 		"env":        env,
 		"maintainer": maintainer,
 		"add":        add,
@@ -190,6 +190,7 @@ func (b *Builder) Run(context io.Reader) (string, error) {
 func (b *Builder) dispatch(stepN int, ast *parser.Node) error {
 	cmd := ast.Value
 	attrs := ast.Attributes
+	original := ast.Original
 	strs := []string{}
 	msg := fmt.Sprintf("Step %d : %s", stepN, strings.ToUpper(cmd))
 
@@ -210,7 +211,7 @@ func (b *Builder) dispatch(stepN int, ast *parser.Node) error {
 	// XXX yes, we skip any cmds that are not valid; the parser should have
 	// picked these out already.
 	if f, ok := evaluateTable[cmd]; ok {
-		return f(b, strs, attrs)
+		return f(b, strs, attrs, original)
 	}
 
 	fmt.Fprintf(b.ErrStream, "# Skipping unknown instruction %s\n", strings.ToUpper(cmd))

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -26,6 +26,7 @@ type Node struct {
 	Next       *Node           // the next item in the current sexp
 	Children   []*Node         // the children of this sexp
 	Attributes map[string]bool // special attributes for this node
+	Original   string          // original line used before parsing
 }
 
 var (
@@ -84,6 +85,7 @@ func parseLine(line string) (string, *Node, error) {
 	if sexp.Value != "" || sexp.Next != nil || sexp.Children != nil {
 		node.Next = sexp
 		node.Attributes = attrs
+		node.Original = line
 	}
 
 	return "", node, nil


### PR DESCRIPTION
closes #8520

This re-invokes the parser for onbuild instructions. The method signatures for the dispatchers needed to change, so sorry about the extra noise.

/cc @crosbymichael @tiborvass @tianon

Docker-DCO-1.1-Signed-off-by: Erik Hollensbe github@hollensbe.org (github: erikh)
