### PR TITLE
Update to libcontainer 8d1d0ba38a7348c5cfdc05aea3b

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -64,7 +64,7 @@ if [ "$1" = '--go' ]; then
 	mv tmp-tar src/code.google.com/p/go/src/pkg/archive/tar
 fi
 
-clone git github.com/docker/libcontainer 4f409628d80b9842004a3f17c9228e54e73da258
+clone git github.com/docker/libcontainer 8d1d0ba38a7348c5cfdc05aea3be34d75aadc8de
 # see src/github.com/docker/libcontainer/update-vendor.sh which is the "source of truth" for libcontainer deps (just like this file)
 rm -rf src/github.com/docker/libcontainer/vendor
 eval "$(grep '^clone ' src/github.com/docker/libcontainer/update-vendor.sh | grep -v 'github.com/codegangsta/cli')"

--- a/vendor/src/github.com/docker/libcontainer/namespaces/execin.go
+++ b/vendor/src/github.com/docker/libcontainer/namespaces/execin.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/docker/libcontainer"
+	"github.com/docker/libcontainer/apparmor"
 	"github.com/docker/libcontainer/cgroups"
 	"github.com/docker/libcontainer/label"
 	"github.com/docker/libcontainer/syncpipe"
@@ -94,6 +95,10 @@ func FinalizeSetns(container *libcontainer.Config, args []string) error {
 
 	if err := FinalizeNamespace(container); err != nil {
 		return err
+	}
+
+	if err := apparmor.ApplyProfile(container.AppArmorProfile); err != nil {
+		return fmt.Errorf("set apparmor profile %s: %s", container.AppArmorProfile, err)
 	}
 
 	if container.ProcessLabel != "" {


### PR DESCRIPTION
Fixes #8488

This fixes issues where the apparmor profile is not applied to processes
via docker exec.  As a side effect the parent processes were unable to
kill the additional child processes because of the profile mismatch.

Easy way to reproduce on an apparmor system:

``` bash
docker run -ti debian:jessie bash
ps auxZ
#look at the labels

#in another shell
docker exec <name> sleep 1000

#go back to the first container and
ps auxZ
#make sure all processes have the correct docker-default profile
```

Signed-off-by: Michael Crosby crosbymichael@gmail.com
