### PR TITLE
On Red Hat Registry Servers we return 404 on certification errors.

### DIFF
--- a/docs/sources/articles/certificates.md
+++ b/docs/sources/articles/certificates.md
@@ -31,7 +31,7 @@ repository.
 
 > **Note:**
 > If there are multiple certificates, each will be tried in alphabetical
-> order. If there is an authentication error (e.g., 403, 5xx, etc.), Docker
+> order. If there is an authentication error (e.g., 403, 404, 5xx, etc.), Docker
 > will continue to try with the next certificate.
 
 Our example is set up like this:

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -147,7 +147,10 @@ func doRequest(req *http.Request, jar http.CookieJar, timeout TimeoutType) (*htt
 		client := newClient(jar, pool, cert, timeout)
 		res, err := client.Do(req)
 		// If this is the last cert, otherwise, continue to next cert if 403 or 5xx
-		if i == len(certs)-1 || err == nil && res.StatusCode != 403 && res.StatusCode < 500 {
+		if i == len(certs)-1 || err == nil &&
+			res.StatusCode != 403 &&
+			res.StatusCode != 404 &&
+			res.StatusCode < 500 {
 			return res, client, err
 		}
 	}


### PR DESCRIPTION
We do this to prevent leakage of information, we don't want people
to be able to probe for existing content.

According to RFC 2616, "This status code (404) is commonly used when the server does not
wish to reveal exactly why the request has been refused, or when no other response i
is applicable."

https://www.ietf.org/rfc/rfc2616.txt

10.4.4 403 Forbidden

   The server understood the request, but is refusing to fulfill it.
   Authorization will not help and the request SHOULD NOT be repeated.
   If the request method was not HEAD and the server wishes to make
   public why the request has not been fulfilled, it SHOULD describe the
   reason for the refusal in the entity.  If the server does not wish to
   make this information available to the client, the status code 404
   (Not Found) can be used instead.

10.4.5 404 Not Found

   The server has not found anything matching the Request-URI. No
   indication is given of whether the condition is temporary or
   permanent. The 410 (Gone) status code SHOULD be used if the server
   knows, through some internally configurable mechanism, that an old
   resource is permanently unavailable and has no forwarding address.
   This status code is commonly used when the server does not wish to
   reveal exactly why the request has been refused, or when no other
   response is applicable.

When docker is running through its certificates, it should continue
trying with a new certificate even if it gets back a 404 error code.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
