### PR TITLE
Remove client key.json generation for trust

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -79,7 +79,6 @@ func mainDaemon() {
 	job.Setenv("TlsCa", *flCa)
 	job.Setenv("TlsCert", *flCert)
 	job.Setenv("TlsKey", *flKey)
-	job.Setenv("TrustKey", *flTrustKey)
 	job.SetenvBool("BufferRequests", true)
 	if err := job.Run(); err != nil {
 		log.Fatal(err)

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 	"strings"
 
 	"github.com/docker/docker/api"
@@ -16,7 +15,6 @@ import (
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/reexec"
 	"github.com/docker/docker/utils"
-	"github.com/docker/libtrust"
 )
 
 const (
@@ -64,20 +62,6 @@ func main() {
 	}
 	protoAddrParts := strings.SplitN(flHosts[0], "://", 2)
 
-	err := os.MkdirAll(path.Dir(*flTrustKey), 0700)
-	if err != nil {
-		log.Fatal(err)
-	}
-	trustKey, keyErr := libtrust.LoadKeyFile(*flTrustKey)
-	if keyErr == libtrust.ErrKeyFileDoesNotExist {
-		trustKey, keyErr = libtrust.GenerateECP256PrivateKey()
-		if keyErr == nil {
-			keyErr = libtrust.SaveKey(*flTrustKey, trustKey)
-		}
-	}
-	if keyErr != nil {
-		log.Fatal(keyErr)
-	}
 	var (
 		cli       *client.DockerCli
 		tlsConfig tls.Config
@@ -112,9 +96,9 @@ func main() {
 	}
 
 	if *flTls || *flTlsVerify {
-		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, trustKey, protoAddrParts[0], protoAddrParts[1], &tlsConfig)
+		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, nil, protoAddrParts[0], protoAddrParts[1], &tlsConfig)
 	} else {
-		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, trustKey, protoAddrParts[0], protoAddrParts[1], nil)
+		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, nil, protoAddrParts[0], protoAddrParts[1], nil)
 	}
 
 	if err := cli.Cmd(flag.Args()...); err != nil {


### PR DESCRIPTION
This removes the key generation for trust from main while it is not
being consumed.  The problem is that because this is being set in main
if a user runs as root initially the files will be owned by root.  Later
if the user sets up the docker group they are unable to read the keys.
This is half a user error and documentation problem and the other half
is management.

We decided to remove this code for now while it is not being used and
will revisit it later when the consuming features are added.  A few
options are to generate lazily and provide a clear error message on an
EPERM so that the user knows what is wrong and can correct the
permissions.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
