### PR TITLE
Cleanup: integration-cli ('%s' with %q)

### DIFF
--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -107,7 +107,7 @@ func TestCreateEchoStdout(t *testing.T) {
 	errorOut(err, t, out)
 
 	if out != "test123\n" {
-		t.Errorf("container should've printed 'test123', got '%s'", out)
+		t.Errorf("container should've printed 'test123', got %q", out)
 	}
 
 	deleteAllContainers()

--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -85,7 +85,7 @@ func TestDiffEnsureOnlyKmsgAndPtmx(t *testing.T) {
 
 	for _, line := range strings.Split(out, "\n") {
 		if line != "" && !expected[line] {
-			t.Errorf("'%s' is shown in the diff but shouldn't", line)
+			t.Errorf("%q is shown in the diff but shouldn't", line)
 		}
 	}
 

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -102,7 +102,7 @@ func TestRmContainerOrphaning(t *testing.T) {
 		t.Fatalf("%v: %s", err, out)
 	}
 	if !strings.Contains(out, img1) {
-		t.Fatalf("Orphaned container (could not find '%s' in docker images): %s", img1, out)
+		t.Fatalf("Orphaned container (could not find %q in docker images): %s", img1, out)
 	}
 
 	deleteAllContainers()

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1182,7 +1182,7 @@ func TestRunModeHostname(t *testing.T) {
 		t.Fatal(err)
 	}
 	if actual := strings.Trim(out, "\r\n"); actual != hostname {
-		t.Fatalf("expected %q, but says: '%s'", hostname, actual)
+		t.Fatalf("expected %q, but says: %q", hostname, actual)
 	}
 
 	deleteAllContainers()
@@ -1357,11 +1357,11 @@ func TestRunDnsOptionsBasedOnHostResolvConf(t *testing.T) {
 
 	actualSearch := resolvconf.GetSearchDomains([]byte(out))
 	if len(actualSearch) != len(hostSearch) {
-		t.Fatalf("expected %q search domain(s), but it has: '%s'", len(hostSearch), len(actualSearch))
+		t.Fatalf("expected %q search domain(s), but it has: %q", len(hostSearch), len(actualSearch))
 	}
 	for i := range actualSearch {
 		if actualSearch[i] != hostSearch[i] {
-			t.Fatalf("expected %q domain, but says: '%s'", actualSearch[i], hostSearch[i])
+			t.Fatalf("expected %q domain, but says: %q", actualSearch[i], hostSearch[i])
 		}
 	}
 
@@ -1373,11 +1373,11 @@ func TestRunDnsOptionsBasedOnHostResolvConf(t *testing.T) {
 
 	actualNameservers := resolvconf.GetNameservers([]byte(out))
 	if len(actualNameservers) != len(hostNamservers) {
-		t.Fatalf("expected %q nameserver(s), but it has: '%s'", len(hostNamservers), len(actualNameservers))
+		t.Fatalf("expected %q nameserver(s), but it has: %q", len(hostNamservers), len(actualNameservers))
 	}
 	for i := range actualNameservers {
 		if actualNameservers[i] != hostNamservers[i] {
-			t.Fatalf("expected %q nameserver, but says: '%s'", actualNameservers[i], hostNamservers[i])
+			t.Fatalf("expected %q nameserver, but says: %q", actualNameservers[i], hostNamservers[i])
 		}
 	}
 
@@ -1421,7 +1421,7 @@ func TestRunDnsOptionsBasedOnHostResolvConf(t *testing.T) {
 	}
 	for i := range actualSearch {
 		if actualSearch[i] != hostSearch[i] {
-			t.Fatalf("expected %q domain, but says: '%s'", actualSearch[i], hostSearch[i])
+			t.Fatalf("expected %q domain, but says: %q", actualSearch[i], hostSearch[i])
 		}
 	}
 

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -44,7 +44,7 @@ func NewDaemon(t *testing.T) *Daemon {
 	dir := filepath.Join(dest, fmt.Sprintf("daemon%d", time.Now().Unix()))
 	daemonFolder, err := filepath.Abs(dir)
 	if err != nil {
-		t.Fatalf("Could not make '%s' an absolute path: %v", dir, err)
+		t.Fatalf("Could not make %q an absolute path: %v", dir, err)
 	}
 
 	if err := os.MkdirAll(filepath.Join(daemonFolder, "graph"), 0600); err != nil {
@@ -317,7 +317,7 @@ func imageExists(image string) error {
 	inspectCmd := exec.Command(dockerBinary, "inspect", image)
 	exitCode, err := runCommand(inspectCmd)
 	if exitCode != 0 && err == nil {
-		err = fmt.Errorf("couldn't find image '%s'", image)
+		err = fmt.Errorf("couldn't find image %q", image)
 	}
 	return err
 }
@@ -328,7 +328,7 @@ func pullImageIfNotExist(image string) (err error) {
 		_, exitCode, err := runCommandWithOutput(pullCmd)
 
 		if err != nil || exitCode != 0 {
-			err = fmt.Errorf("image '%s' wasn't found locally and it couldn't be pulled: %s", image, err)
+			err = fmt.Errorf("image %q wasn't found locally and it couldn't be pulled: %s", image, err)
 		}
 	}
 	return
@@ -341,7 +341,7 @@ func cmd(t *testing.T, args ...string) (string, int, error) {
 
 func dockerCmd(t *testing.T, args ...string) (string, int, error) {
 	out, status, err := runCommandWithOutput(exec.Command(dockerBinary, args...))
-	errorOut(err, t, fmt.Sprintf("'%s' failed with errors: %v (%v)", strings.Join(args, " "), err, out))
+	errorOut(err, t, fmt.Sprintf("%q failed with errors: %v (%v)", strings.Join(args, " "), err, out))
 	return out, status, err
 }
 
@@ -349,7 +349,7 @@ func dockerCmd(t *testing.T, args ...string) (string, int, error) {
 func dockerCmdWithTimeout(timeout time.Duration, args ...string) (string, int, error) {
 	out, status, err := runCommandWithOutputAndTimeout(exec.Command(dockerBinary, args...), timeout)
 	if err != nil {
-		return out, status, fmt.Errorf("'%s' failed with errors: %v : %q)", strings.Join(args, " "), err, out)
+		return out, status, fmt.Errorf("%q failed with errors: %v : %q)", strings.Join(args, " "), err, out)
 	}
 	return out, status, err
 }
@@ -360,7 +360,7 @@ func dockerCmdInDir(t *testing.T, path string, args ...string) (string, int, err
 	dockerCommand.Dir = path
 	out, status, err := runCommandWithOutput(dockerCommand)
 	if err != nil {
-		return out, status, fmt.Errorf("'%s' failed with errors: %v : %q)", strings.Join(args, " "), err, out)
+		return out, status, fmt.Errorf("%q failed with errors: %v : %q)", strings.Join(args, " "), err, out)
 	}
 	return out, status, err
 }
@@ -371,7 +371,7 @@ func dockerCmdInDirWithTimeout(timeout time.Duration, path string, args ...strin
 	dockerCommand.Dir = path
 	out, status, err := runCommandWithOutputAndTimeout(dockerCommand, timeout)
 	if err != nil {
-		return out, status, fmt.Errorf("'%s' failed with errors: %v : %q)", strings.Join(args, " "), err, out)
+		return out, status, fmt.Errorf("%q failed with errors: %v : %q)", strings.Join(args, " "), err, out)
 	}
 	return out, status, err
 }
@@ -521,7 +521,7 @@ func getContainerState(t *testing.T, id string) (int, bool, error) {
 	)
 	out, exitCode, err := dockerCmd(t, "inspect", "--format={{.State.Running}} {{.State.ExitCode}}", id)
 	if err != nil || exitCode != 0 {
-		return 0, false, fmt.Errorf("'%s' doesn't exist: %s", id, err)
+		return 0, false, fmt.Errorf("%q doesn't exist: %s", id, err)
 	}
 
 	out = strings.Trim(out, "\n")


### PR DESCRIPTION
Replaces `'%s'` with `%q`, purely aesthetic change, but looks a bit nicer and now there's some unity.
