### PR TITLE
Cleanup: integration-cli (get rid of errorOut)

### DIFF
--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"os/exec"
 	"testing"
 )
@@ -10,7 +9,9 @@ import (
 func TestInspectApiContainerResponse(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, fmt.Sprintf("failed to create a container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to create a container: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -20,7 +20,9 @@ func TestBuildOnBuildForbiddenMaintainerInSourceImage(t *testing.T) {
 	defer deleteImages(name)
 	createCmd := exec.Command(dockerBinary, "create", "busybox", "true")
 	out, _, _, err := runCommandWithStdoutStderr(createCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
@@ -49,7 +51,9 @@ func TestBuildOnBuildForbiddenFromInSourceImage(t *testing.T) {
 	defer deleteImages(name)
 	createCmd := exec.Command(dockerBinary, "create", "busybox", "true")
 	out, _, _, err := runCommandWithStdoutStderr(createCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
@@ -78,7 +82,9 @@ func TestBuildOnBuildForbiddenChainedInSourceImage(t *testing.T) {
 	defer deleteImages(name)
 	createCmd := exec.Command(dockerBinary, "create", "busybox", "true")
 	out, _, _, err := runCommandWithStdoutStderr(createCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
@@ -299,11 +305,8 @@ RUN [ $(ls -l /exists/exists_file | awk '{print $3":"$4}') = 'dockerio:dockerio'
 
 func TestBuildCopyAddMultipleFiles(t *testing.T) {
 	buildDirectory := filepath.Join(workingDirectory, "build_tests", "TestCopy")
-	out, exitCode, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testaddimg", "MultipleFiles")
-	errorOut(err, t, fmt.Sprintf("build failed to complete: %v %v", out, err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("failed to build the image")
+	if out, _, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testaddimg", "MultipleFiles"); err != nil {
+		t.Fatalf("build failed to complete: %s, %v", out, err)
 	}
 
 	deleteImages("testaddimg")
@@ -620,11 +623,8 @@ func TestBuildCopySingleFileToRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	f.Close()
-	out, exitCode, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", ".")
-	errorOut(err, t, fmt.Sprintf("build failed to complete: %v %v", out, err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("failed to build the image")
+	if out, _, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", "."); err != nil {
+		t.Fatalf("build failed to complete: %s, %v", out, err)
 	}
 
 	deleteImages("testcopyimg")
@@ -650,9 +650,8 @@ func TestBuildCopySingleFileToWorkdir(t *testing.T) {
 		t.Fatal(err)
 	}
 	f.Close()
-	_, exitCode, err := dockerCmdInDirWithTimeout(5*time.Second, buildDirectory, "build", "-t", "testcopyimg", ".")
-	if err != nil || exitCode != 0 {
-		t.Fatalf("build failed: %s", err)
+	if out, _, err := dockerCmdInDirWithTimeout(5*time.Second, buildDirectory, "build", "-t", "testcopyimg", "."); err != nil {
+		t.Fatalf("build failed to complete: %s, %v", out, err)
 	}
 
 	deleteImages("testcopyimg")
@@ -662,11 +661,8 @@ func TestBuildCopySingleFileToWorkdir(t *testing.T) {
 
 func TestBuildCopySingleFileToExistDir(t *testing.T) {
 	buildDirectory := filepath.Join(workingDirectory, "build_tests", "TestCopy")
-	out, exitCode, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", "SingleFileToExistDir")
-	errorOut(err, t, fmt.Sprintf("build failed to complete: %v %v", out, err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("failed to build the image")
+	if out, _, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", "SingleFileToExistDir"); err != nil {
+		t.Fatalf("build failed to complete: %s, %v", out, err)
 	}
 
 	deleteImages("testcopyimg")
@@ -676,11 +672,8 @@ func TestBuildCopySingleFileToExistDir(t *testing.T) {
 
 func TestBuildCopySingleFileToNonExistDir(t *testing.T) {
 	buildDirectory := filepath.Join(workingDirectory, "build_tests", "TestCopy")
-	out, exitCode, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", "SingleFileToNonExistDir")
-	errorOut(err, t, fmt.Sprintf("build failed to complete: %v %v", out, err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("failed to build the image")
+	if out, _, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", "SingleFileToNonExistDir"); err != nil {
+		t.Fatalf("build failed to complete: %s, %v", out, err)
 	}
 
 	deleteImages("testcopyimg")
@@ -690,11 +683,8 @@ func TestBuildCopySingleFileToNonExistDir(t *testing.T) {
 
 func TestBuildCopyDirContentToRoot(t *testing.T) {
 	buildDirectory := filepath.Join(workingDirectory, "build_tests", "TestCopy")
-	out, exitCode, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", "DirContentToRoot")
-	errorOut(err, t, fmt.Sprintf("build failed to complete: %v %v", out, err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("failed to build the image")
+	if out, _, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", "DirContentToRoot"); err != nil {
+		t.Fatalf("build failed to complete: %s, %v", out, err)
 	}
 
 	deleteImages("testcopyimg")
@@ -704,11 +694,8 @@ func TestBuildCopyDirContentToRoot(t *testing.T) {
 
 func TestBuildCopyDirContentToExistDir(t *testing.T) {
 	buildDirectory := filepath.Join(workingDirectory, "build_tests", "TestCopy")
-	out, exitCode, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", "DirContentToExistDir")
-	errorOut(err, t, fmt.Sprintf("build failed to complete: %v %v", out, err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("failed to build the image")
+	if out, _, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", "DirContentToExistDir"); err != nil {
+		t.Fatalf("build failed to complete: %s, %v", out, err)
 	}
 
 	deleteImages("testcopyimg")
@@ -737,11 +724,8 @@ func TestBuildCopyWholeDirToRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	f.Close()
-	out, exitCode, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", ".")
-	errorOut(err, t, fmt.Sprintf("build failed to complete: %v %v", out, err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("failed to build the image")
+	if out, _, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", "."); err != nil {
+		t.Fatalf("build failed to complete: %s, %v", out, err)
 	}
 
 	deleteImages("testcopyimg")
@@ -751,11 +735,8 @@ func TestBuildCopyWholeDirToRoot(t *testing.T) {
 
 func TestBuildCopyEtcToRoot(t *testing.T) {
 	buildDirectory := filepath.Join(workingDirectory, "build_tests", "TestCopy")
-	out, exitCode, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", "EtcToRoot")
-	errorOut(err, t, fmt.Sprintf("build failed to complete: %v %v", out, err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("failed to build the image")
+	if out, _, err := dockerCmdInDir(t, buildDirectory, "build", "-t", "testcopyimg", "EtcToRoot"); err != nil {
+		t.Fatalf("build failed to complete: %s, %v", out, err)
 	}
 
 	deleteImages("testcopyimg")
@@ -766,9 +747,7 @@ func TestBuildCopyDisallowRemote(t *testing.T) {
 	buildDirectory := filepath.Join(workingDirectory, "build_tests", "TestCopy")
 	buildCmd := exec.Command(dockerBinary, "build", "-t", "testcopyimg", "DisallowRemote")
 	buildCmd.Dir = buildDirectory
-	out, exitCode, err := runCommandWithOutput(buildCmd)
-
-	if err == nil || exitCode == 0 {
+	if out, _, err := runCommandWithOutput(buildCmd); err == nil {
 		t.Fatalf("building the image should've failed; output: %s", out)
 	}
 
@@ -790,14 +769,16 @@ func TestBuildWithInaccessibleFilesInContext(t *testing.T) {
 		// This is used to ensure we detect inaccessible files early during build in the cli client
 		pathToFileWithoutReadAccess := filepath.Join(ctx.Dir, "fileWithoutReadAccess")
 
-		err = os.Chown(pathToFileWithoutReadAccess, 0, 0)
-		errorOut(err, t, fmt.Sprintf("failed to chown file to root: %s", err))
-		err = os.Chmod(pathToFileWithoutReadAccess, 0700)
-		errorOut(err, t, fmt.Sprintf("failed to chmod file to 700: %s", err))
+		if err = os.Chown(pathToFileWithoutReadAccess, 0, 0); err != nil {
+			t.Fatalf("failed to chown file to root: %s", err)
+		}
+		if err = os.Chmod(pathToFileWithoutReadAccess, 0700); err != nil {
+			t.Fatalf("failed to chmod file to 700: %s", err)
+		}
 		buildCmd := exec.Command("su", "unprivilegeduser", "-c", fmt.Sprintf("%s build -t %s .", dockerBinary, name))
 		buildCmd.Dir = ctx.Dir
-		out, exitCode, err := runCommandWithOutput(buildCmd)
-		if err == nil || exitCode == 0 {
+		out, _, err := runCommandWithOutput(buildCmd)
+		if err == nil {
 			t.Fatalf("build should have failed: %s %s", err, out)
 		}
 
@@ -822,17 +803,20 @@ func TestBuildWithInaccessibleFilesInContext(t *testing.T) {
 		pathToDirectoryWithoutReadAccess := filepath.Join(ctx.Dir, "directoryWeCantStat")
 		pathToFileInDirectoryWithoutReadAccess := filepath.Join(pathToDirectoryWithoutReadAccess, "bar")
 
-		err = os.Chown(pathToDirectoryWithoutReadAccess, 0, 0)
-		errorOut(err, t, fmt.Sprintf("failed to chown directory to root: %s", err))
-		err = os.Chmod(pathToDirectoryWithoutReadAccess, 0444)
-		errorOut(err, t, fmt.Sprintf("failed to chmod directory to 755: %s", err))
-		err = os.Chmod(pathToFileInDirectoryWithoutReadAccess, 0700)
-		errorOut(err, t, fmt.Sprintf("failed to chmod file to 444: %s", err))
+		if err = os.Chown(pathToDirectoryWithoutReadAccess, 0, 0); err != nil {
+			t.Fatalf("failed to chown directory to root: %s", err)
+		}
+		if err = os.Chmod(pathToDirectoryWithoutReadAccess, 0444); err != nil {
+			t.Fatalf("failed to chmod directory to 755: %s", err)
+		}
+		if err = os.Chmod(pathToFileInDirectoryWithoutReadAccess, 0700); err != nil {
+			t.Fatalf("failed to chmod file to 444: %s", err)
+		}
 
 		buildCmd := exec.Command("su", "unprivilegeduser", "-c", fmt.Sprintf("%s build -t %s .", dockerBinary, name))
 		buildCmd.Dir = ctx.Dir
-		out, exitCode, err := runCommandWithOutput(buildCmd)
-		if err == nil || exitCode == 0 {
+		out, _, err := runCommandWithOutput(buildCmd)
+		if err == nil {
 			t.Fatalf("build should have failed: %s %s", err, out)
 		}
 
@@ -878,17 +862,19 @@ func TestBuildWithInaccessibleFilesInContext(t *testing.T) {
 		// This is used to ensure we don't try to add inaccessible files when they are ignored by a .dockerignore pattern
 		pathToDirectoryWithoutReadAccess := filepath.Join(ctx.Dir, "directoryWeCantStat")
 		pathToFileInDirectoryWithoutReadAccess := filepath.Join(pathToDirectoryWithoutReadAccess, "bar")
-		err = os.Chown(pathToDirectoryWithoutReadAccess, 0, 0)
-		errorOut(err, t, fmt.Sprintf("failed to chown directory to root: %s", err))
-		err = os.Chmod(pathToDirectoryWithoutReadAccess, 0444)
-		errorOut(err, t, fmt.Sprintf("failed to chmod directory to 755: %s", err))
-		err = os.Chmod(pathToFileInDirectoryWithoutReadAccess, 0700)
-		errorOut(err, t, fmt.Sprintf("failed to chmod file to 444: %s", err))
+		if err = os.Chown(pathToDirectoryWithoutReadAccess, 0, 0); err != nil {
+			t.Fatalf("failed to chown directory to root: %s", err)
+		}
+		if err = os.Chmod(pathToDirectoryWithoutReadAccess, 0444); err != nil {
+			t.Fatalf("failed to chmod directory to 755: %s", err)
+		}
+		if err = os.Chmod(pathToFileInDirectoryWithoutReadAccess, 0700); err != nil {
+			t.Fatalf("failed to chmod file to 444: %s", err)
+		}
 
 		buildCmd := exec.Command("su", "unprivilegeduser", "-c", fmt.Sprintf("%s build -t %s .", dockerBinary, name))
 		buildCmd.Dir = ctx.Dir
-		out, exitCode, err := runCommandWithOutput(buildCmd)
-		if err != nil || exitCode != 0 {
+		if out, _, err := runCommandWithOutput(buildCmd); err != nil {
 			t.Fatalf("build should have worked: %s %s", err, out)
 		}
 
@@ -913,10 +899,8 @@ func TestBuildForceRm(t *testing.T) {
 
 	buildCmd := exec.Command(dockerBinary, "build", "-t", name, "--force-rm", ".")
 	buildCmd.Dir = ctx.Dir
-	_, exitCode, err := runCommandWithOutput(buildCmd)
-
-	if err == nil || exitCode == 0 {
-		t.Fatal("failed to build the image")
+	if out, _, err := runCommandWithOutput(buildCmd); err == nil {
+		t.Fatal("failed to build the image: %s, %v", out, err)
 	}
 
 	containerCountAfter, err := getContainerCount()
@@ -945,9 +929,9 @@ func TestBuildRm(t *testing.T) {
 			t.Fatalf("failed to get the container count: %s", err)
 		}
 
-		out, exitCode, err := dockerCmdInDir(t, ctx.Dir, "build", "--rm", "-t", name, ".")
+		out, _, err := dockerCmdInDir(t, ctx.Dir, "build", "--rm", "-t", name, ".")
 
-		if err != nil || exitCode != 0 {
+		if err != nil {
 			t.Fatal("failed to build the image", out)
 		}
 
@@ -968,9 +952,9 @@ func TestBuildRm(t *testing.T) {
 			t.Fatalf("failed to get the container count: %s", err)
 		}
 
-		out, exitCode, err := dockerCmdInDir(t, ctx.Dir, "build", "-t", name, ".")
+		out, _, err := dockerCmdInDir(t, ctx.Dir, "build", "-t", name, ".")
 
-		if err != nil || exitCode != 0 {
+		if err != nil {
 			t.Fatal("failed to build the image", out)
 		}
 
@@ -991,9 +975,9 @@ func TestBuildRm(t *testing.T) {
 			t.Fatalf("failed to get the container count: %s", err)
 		}
 
-		out, exitCode, err := dockerCmdInDir(t, ctx.Dir, "build", "--rm=false", "-t", name, ".")
+		out, _, err := dockerCmdInDir(t, ctx.Dir, "build", "--rm=false", "-t", name, ".")
 
-		if err != nil || exitCode != 0 {
+		if err != nil {
 			t.Fatal("failed to build the image", out)
 		}
 
@@ -1335,7 +1319,9 @@ func TestBuildOnBuildLimitedInheritence(t *testing.T) {
 		}
 
 		out1, _, err := dockerCmdInDir(t, ctx.Dir, "build", "-t", name1, ".")
-		errorOut(err, t, fmt.Sprintf("build failed to complete: %v %v", out1, err))
+		if err != nil {
+			t.Fatalf("build failed to complete: %s, %v", out1, err)
+		}
 		defer deleteImages(name1)
 	}
 	{
@@ -1349,7 +1335,9 @@ func TestBuildOnBuildLimitedInheritence(t *testing.T) {
 		}
 
 		out2, _, err = dockerCmdInDir(t, ctx.Dir, "build", "-t", name2, ".")
-		errorOut(err, t, fmt.Sprintf("build failed to complete: %v %v", out2, err))
+		if err != nil {
+			t.Fatalf("build failed to complete: %s, %v", out2, err)
+		}
 		defer deleteImages(name2)
 	}
 	{
@@ -1363,7 +1351,10 @@ func TestBuildOnBuildLimitedInheritence(t *testing.T) {
 		}
 
 		out3, _, err = dockerCmdInDir(t, ctx.Dir, "build", "-t", name3, ".")
-		errorOut(err, t, fmt.Sprintf("build failed to complete: %v %v", out3, err))
+		if err != nil {
+			t.Fatalf("build failed to complete: %s, %v", out3, err)
+		}
+
 		defer deleteImages(name3)
 	}
 
@@ -1763,8 +1754,7 @@ CMD ["cat", "/foo"]`,
 	defer deleteImages(name)
 	buildCmd.Stdin = context
 
-	out, exitCode, err := runCommandWithOutput(buildCmd)
-	if err != nil || exitCode != 0 {
+	if out, _, err := runCommandWithOutput(buildCmd); err != nil {
 		t.Fatalf("build failed to complete: %v %v", out, err)
 	}
 	logDone(fmt.Sprintf("build - build an image with a context tar, compression: %v", compression))
@@ -1782,13 +1772,11 @@ func TestBuildNoContext(t *testing.T) {
 	buildCmd := exec.Command(dockerBinary, "build", "-t", "nocontext", "-")
 	buildCmd.Stdin = strings.NewReader("FROM busybox\nCMD echo ok\n")
 
-	out, exitCode, err := runCommandWithOutput(buildCmd)
-	if err != nil || exitCode != 0 {
+	if out, _, err := runCommandWithOutput(buildCmd); err != nil {
 		t.Fatalf("build failed to complete: %v %v", out, err)
 	}
 
-	out, exitCode, err = cmd(t, "run", "nocontext")
-	if out != "ok\n" {
+	if out, _, err := cmd(t, "run", "nocontext"); out != "ok\n" || err != nil {
 		t.Fatalf("run produced invalid output: %q, expected %q", out, "ok")
 	}
 
@@ -2717,7 +2705,7 @@ func TestBuildExoticShellInterpolation(t *testing.T) {
 
 	_, err := buildImage(name, `
 		FROM busybox
-
+		
 		ENV SOME_VAR a.b.c
 
 		RUN [ "$SOME_VAR"       = 'a.b.c' ]

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -10,23 +9,29 @@ import (
 func TestCommitAfterContainerIsDone(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, fmt.Sprintf("failed to run container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to run container: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	waitCmd := exec.Command(dockerBinary, "wait", cleanedContainerID)
-	_, _, err = runCommandWithOutput(waitCmd)
-	errorOut(err, t, fmt.Sprintf("error thrown while waiting for container: %s", out))
+	if _, _, err = runCommandWithOutput(waitCmd); err != nil {
+		t.Fatalf("error thrown while waiting for container: %s, %v", out, err)
+	}
 
 	commitCmd := exec.Command(dockerBinary, "commit", cleanedContainerID)
 	out, _, err = runCommandWithOutput(commitCmd)
-	errorOut(err, t, fmt.Sprintf("failed to commit container to image: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to commit container to image: %s, %v", out, err)
+	}
 
 	cleanedImageID := stripTrailingCharacters(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedImageID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("failed to inspect image: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
+		t.Fatalf("failed to inspect image: %s, %v", out, err)
+	}
 
 	deleteContainer(cleanedContainerID)
 	deleteImages(cleanedImageID)
@@ -37,23 +42,29 @@ func TestCommitAfterContainerIsDone(t *testing.T) {
 func TestCommitWithoutPause(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, fmt.Sprintf("failed to run container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to run container: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	waitCmd := exec.Command(dockerBinary, "wait", cleanedContainerID)
-	_, _, err = runCommandWithOutput(waitCmd)
-	errorOut(err, t, fmt.Sprintf("error thrown while waiting for container: %s", out))
+	if _, _, err = runCommandWithOutput(waitCmd); err != nil {
+		t.Fatalf("error thrown while waiting for container: %s, %v", out, err)
+	}
 
 	commitCmd := exec.Command(dockerBinary, "commit", "-p=false", cleanedContainerID)
 	out, _, err = runCommandWithOutput(commitCmd)
-	errorOut(err, t, fmt.Sprintf("failed to commit container to image: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to commit container to image: %s, %v", out, err)
+	}
 
 	cleanedImageID := stripTrailingCharacters(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedImageID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("failed to inspect image: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
+		t.Fatalf("failed to inspect image: %s, %v", out, err)
+	}
 
 	deleteContainer(cleanedContainerID)
 	deleteImages(cleanedImageID)
@@ -81,7 +92,7 @@ func TestCommitNewFile(t *testing.T) {
 		t.Fatal(err, out)
 	}
 	if actual := strings.Trim(out, "\r\n"); actual != "koye" {
-		t.Fatalf("expected output koye received %s", actual)
+		t.Fatalf("expected output koye received %q", actual)
 	}
 
 	deleteAllContainers()
@@ -92,7 +103,6 @@ func TestCommitNewFile(t *testing.T) {
 
 func TestCommitTTY(t *testing.T) {
 	cmd := exec.Command(dockerBinary, "run", "-t", "--name", "tty", "busybox", "/bin/ls")
-
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
 	}
@@ -105,7 +115,6 @@ func TestCommitTTY(t *testing.T) {
 	imageID = strings.Trim(imageID, "\r\n")
 
 	cmd = exec.Command(dockerBinary, "run", "ttytest", "/bin/ls")
-
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
 	}
@@ -124,6 +133,7 @@ func TestCommitWithHostBindMount(t *testing.T) {
 	if err != nil {
 		t.Fatal(imageID, err)
 	}
+
 	imageID = strings.Trim(imageID, "\r\n")
 
 	cmd = exec.Command(dockerBinary, "run", "bindtest", "true")

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"os/exec"
 	"testing"
 	"time"
@@ -12,13 +11,17 @@ import (
 func TestCreateArgs(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "create", "busybox", "command", "arg1", "arg2", "arg with space")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	inspectOut, _, err := runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("out should've been a container id: %v %v", inspectOut, err))
+	out, _, err = runCommandWithOutput(inspectCmd)
+	if err != nil {
+		t.Fatalf("out should've been a container id: %s, %v", out, err)
+	}
 
 	containers := []struct {
 		ID      string
@@ -27,7 +30,7 @@ func TestCreateArgs(t *testing.T) {
 		Args    []string
 		Image   string
 	}{}
-	if err := json.Unmarshal([]byte(inspectOut), &containers); err != nil {
+	if err := json.Unmarshal([]byte(out), &containers); err != nil {
 		t.Fatalf("Error inspecting the container: %s", err)
 	}
 	if len(containers) != 1 {
@@ -60,20 +63,24 @@ func TestCreateArgs(t *testing.T) {
 func TestCreateHostConfig(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "create", "-P", "busybox", "echo")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	inspectOut, _, err := runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("out should've been a container id: %v %v", inspectOut, err))
+	out, _, err = runCommandWithOutput(inspectCmd)
+	if err != nil {
+		t.Fatalf("out should've been a container id: %s, %v", out, err)
+	}
 
 	containers := []struct {
 		HostConfig *struct {
 			PublishAllPorts bool
 		}
 	}{}
-	if err := json.Unmarshal([]byte(inspectOut), &containers); err != nil {
+	if err := json.Unmarshal([]byte(out), &containers); err != nil {
 		t.Fatalf("Error inspecting the container: %s", err)
 	}
 	if len(containers) != 1 {
@@ -98,13 +105,17 @@ func TestCreateHostConfig(t *testing.T) {
 func TestCreateEchoStdout(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "create", "busybox", "echo", "test123")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	runCmd = exec.Command(dockerBinary, "start", "-ai", cleanedContainerID)
 	out, _, _, err = runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if out != "test123\n" {
 		t.Errorf("container should've printed 'test123', got %q", out)

--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -11,14 +10,18 @@ import (
 func TestDiffFilenameShownInOutput(t *testing.T) {
 	containerCmd := `echo foo > /root/bar`
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", containerCmd)
-	cid, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, fmt.Sprintf("failed to start the container: %v", err))
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatalf("failed to start the container: %s, %v", out, err)
+	}
 
-	cleanCID := stripTrailingCharacters(cid)
+	cleanCID := stripTrailingCharacters(out)
 
 	diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
-	out, _, err := runCommandWithOutput(diffCmd)
-	errorOut(err, t, fmt.Sprintf("failed to run diff: %v %v", out, err))
+	out, _, err = runCommandWithOutput(diffCmd)
+	if err != nil {
+		t.Fatalf("failed to run diff: %s %v", out, err)
+	}
 
 	found := false
 	for _, line := range strings.Split(out, "\n") {
@@ -44,14 +47,18 @@ func TestDiffEnsureDockerinitFilesAreIgnored(t *testing.T) {
 	for i := 0; i < 20; i++ {
 		containerCmd := `echo foo > /root/bar`
 		runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", containerCmd)
-		cid, _, err := runCommandWithOutput(runCmd)
-		errorOut(err, t, fmt.Sprintf("%s", err))
+		out, _, err := runCommandWithOutput(runCmd)
+		if err != nil {
+			t.Fatal(out, err)
+		}
 
-		cleanCID := stripTrailingCharacters(cid)
+		cleanCID := stripTrailingCharacters(out)
 
 		diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
-		out, _, err := runCommandWithOutput(diffCmd)
-		errorOut(err, t, fmt.Sprintf("failed to run diff: %v %v", out, err))
+		out, _, err = runCommandWithOutput(diffCmd)
+		if err != nil {
+			t.Fatalf("failed to run diff: %s, %v", out, err)
+		}
 
 		deleteContainer(cleanCID)
 
@@ -67,13 +74,18 @@ func TestDiffEnsureDockerinitFilesAreIgnored(t *testing.T) {
 
 func TestDiffEnsureOnlyKmsgAndPtmx(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sleep", "0")
-	cid, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, fmt.Sprintf("%s", err))
-	cleanCID := stripTrailingCharacters(cid)
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatal(out, err)
+	}
+
+	cleanCID := stripTrailingCharacters(out)
 
 	diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
-	out, _, err := runCommandWithOutput(diffCmd)
-	errorOut(err, t, fmt.Sprintf("failed to run diff: %v %v", out, err))
+	out, _, err = runCommandWithOutput(diffCmd)
+	if err != nil {
+		t.Fatalf("failed to run diff: %s, %v", out, err)
+	}
 	deleteContainer(cleanCID)
 
 	expected := map[string]bool{

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -10,13 +10,15 @@ import (
 
 func TestExec(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "testing", "busybox", "sh", "-c", "echo test > /tmp/file && sleep 100")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, out)
+	if out, _, _, err := runCommandWithStdoutStderr(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	execCmd := exec.Command(dockerBinary, "exec", "testing", "cat", "/tmp/file")
-
-	out, _, err = runCommandWithOutput(execCmd)
-	errorOut(err, t, out)
+	out, _, err := runCommandWithOutput(execCmd)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	out = strings.Trim(out, "\r\n")
 
@@ -31,8 +33,9 @@ func TestExec(t *testing.T) {
 
 func TestExecInteractive(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "testing", "busybox", "sh", "-c", "echo test > /tmp/file && sleep 100")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, out)
+	if out, _, _, err := runCommandWithStdoutStderr(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	execCmd := exec.Command(dockerBinary, "exec", "-i", "testing", "sh")
 	stdin, err := execCmd.StdinPipe()
@@ -84,17 +87,22 @@ func TestExecInteractive(t *testing.T) {
 func TestExecAfterContainerRestart(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	runCmd = exec.Command(dockerBinary, "restart", cleanedContainerID)
-	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	runCmd = exec.Command(dockerBinary, "exec", cleanedContainerID, "echo", "hello")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	outStr := strings.TrimSpace(out)
 	if outStr != "hello" {

--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -26,19 +26,23 @@ func TestExportContainerAndImportImage(t *testing.T) {
 	exportCmdTemplate := `%v export %v > /tmp/testexp.tar`
 	exportCmdFinal := fmt.Sprintf(exportCmdTemplate, dockerBinary, cleanedContainerID)
 	exportCmd := exec.Command("bash", "-c", exportCmdFinal)
-	out, _, err = runCommandWithOutput(exportCmd)
-	errorOut(err, t, fmt.Sprintf("failed to export container: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(exportCmd); err != nil {
+		t.Fatalf("failed to export container: %s, %v", out, err)
+	}
 
 	importCmdFinal := `cat /tmp/testexp.tar | docker import - repo/testexp:v1`
 	importCmd := exec.Command("bash", "-c", importCmdFinal)
 	out, _, err = runCommandWithOutput(importCmd)
-	errorOut(err, t, fmt.Sprintf("failed to import image: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to import image: %s, %v", out, err)
+	}
 
 	cleanedImageID := stripTrailingCharacters(out)
 
 	inspectCmd = exec.Command(dockerBinary, "inspect", cleanedImageID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("output should've been an image id: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
+		t.Fatalf("output should've been an image id: %s, %v", out, err)
+	}
 
 	deleteContainer(cleanedContainerID)
 	deleteImages("repo/testexp:v1")

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -46,9 +46,8 @@ RUN echo "Z"`,
 	}
 
 	out, exitCode, err := runCommandWithOutput(exec.Command(dockerBinary, "history", "testbuildhistory"))
-	errorOut(err, t, fmt.Sprintf("image history failed: %v %v", out, err))
 	if err != nil || exitCode != 0 {
-		t.Fatal("failed to get image history")
+		t.Fatal("failed to get image history: %s, %v", out, err)
 	}
 
 	actualValues := strings.Split(out, "\n")[1:27]

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -11,7 +10,9 @@ import (
 func TestImagesEnsureImageIsListed(t *testing.T) {
 	imagesCmd := exec.Command(dockerBinary, "images")
 	out, _, err := runCommandWithOutput(imagesCmd)
-	errorOut(err, t, fmt.Sprintf("listing images failed with errors: %v", err))
+	if err != nil {
+		t.Fatalf("listing images failed with errors: %s, %v", out, err)
+	}
 
 	if !strings.Contains(out, "busybox") {
 		t.Fatal("images should've listed busybox")
@@ -46,7 +47,9 @@ func TestImagesOrderedByCreationDate(t *testing.T) {
 	}
 
 	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "images", "-q", "--no-trunc"))
-	errorOut(err, t, fmt.Sprintf("listing images failed with errors: %v", err))
+	if err != nil {
+		t.Fatalf("listing images failed with errors: %s, %v", out, err)
+	}
 	imgs := strings.Split(out, "\n")
 	if imgs[0] != id3 {
 		t.Fatalf("First image must be %s, got %s", id3, imgs[0])

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -11,10 +10,8 @@ import (
 func TestInfoEnsureSucceeds(t *testing.T) {
 	versionCmd := exec.Command(dockerBinary, "info")
 	out, exitCode, err := runCommandWithOutput(versionCmd)
-	errorOut(err, t, fmt.Sprintf("encountered error while running docker info: %v", err))
-
 	if err != nil || exitCode != 0 {
-		t.Fatal("failed to execute docker info")
+		t.Fatal("failed to execute docker info: %s, %v", out, err)
 	}
 
 	stringsToCheck := []string{"Containers:", "Execution Driver:", "Kernel Version:"}

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -10,13 +10,14 @@ func TestInspectImage(t *testing.T) {
 	imageTest := "scratch"
 	imageTestID := "511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158"
 	imagesCmd := exec.Command(dockerBinary, "inspect", "--format='{{.Id}}'", imageTest)
-
 	out, exitCode, err := runCommandWithOutput(imagesCmd)
 	if exitCode != 0 || err != nil {
-		t.Fatalf("failed to inspect image")
+		t.Fatalf("failed to inspect image: %s, %v", out, err)
 	}
+
 	if id := strings.TrimSuffix(out, "\n"); id != imageTestID {
 		t.Fatalf("Expected id: %s for image: %s but received id: %s", imageTestID, imageTest, id)
 	}
+
 	logDone("inspect - inspect an image")
 }

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -10,21 +9,27 @@ import (
 func TestKillContainer(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", "sleep 10")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, fmt.Sprintf("run failed with errors: %v", err))
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	inspectOut, _, err := runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("out should've been a container id: %v %v", inspectOut, err))
+	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
+		t.Fatalf("out should've been a container id: %s, %v", out, err)
+	}
 
 	killCmd := exec.Command(dockerBinary, "kill", cleanedContainerID)
-	out, _, err = runCommandWithOutput(killCmd)
-	errorOut(err, t, fmt.Sprintf("failed to kill container: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(killCmd); err != nil {
+		t.Fatalf("failed to kill container: %s, %v", out, err)
+	}
 
 	listRunningContainersCmd := exec.Command(dockerBinary, "ps", "-q")
 	out, _, err = runCommandWithOutput(listRunningContainersCmd)
-	errorOut(err, t, fmt.Sprintf("failed to list running containers: %v", err))
+	if err != nil {
+		t.Fatalf("failed to list running containers: %s, %v", out, err)
+	}
 
 	if strings.Contains(out, cleanedContainerID) {
 		t.Fatal("killed container is still running")
@@ -38,21 +43,27 @@ func TestKillContainer(t *testing.T) {
 func TestKillDifferentUserContainer(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-u", "daemon", "-d", "busybox", "sh", "-c", "sleep 10")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, fmt.Sprintf("run failed with errors: %v", err))
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	inspectOut, _, err := runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("out should've been a container id: %v %v", inspectOut, err))
+	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
+		t.Fatalf("out should've been a container id: %s, %v", out, err)
+	}
 
 	killCmd := exec.Command(dockerBinary, "kill", cleanedContainerID)
-	out, _, err = runCommandWithOutput(killCmd)
-	errorOut(err, t, fmt.Sprintf("failed to kill container: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(killCmd); err != nil {
+		t.Fatalf("failed to kill container: %s, %v", out, err)
+	}
 
 	listRunningContainersCmd := exec.Command(dockerBinary, "ps", "-q")
 	out, _, err = runCommandWithOutput(listRunningContainersCmd)
-	errorOut(err, t, fmt.Sprintf("failed to list running containers: %v", err))
+	if err != nil {
+		t.Fatalf("failed to list running containers: %s, %v", out, err)
+	}
 
 	if strings.Contains(out, cleanedContainerID) {
 		t.Fatal("killed container is still running")

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -14,7 +13,9 @@ import (
 func TestLinksEtcHostsRegularFile(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "--net=host", "busybox", "ls", "-la", "/etc/hosts")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !strings.HasPrefix(out, "-") {
 		t.Errorf("/etc/hosts should be a regular file")
@@ -28,7 +29,9 @@ func TestLinksEtcHostsRegularFile(t *testing.T) {
 func TestLinksEtcHostsContentMatch(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "--net=host", "busybox", "cat", "/etc/hosts")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	hosts, err := ioutil.ReadFile("/etc/hosts")
 	if os.IsNotExist(err) {
@@ -51,7 +54,7 @@ func TestLinksPingUnlinkedContainers(t *testing.T) {
 	if exitCode == 0 {
 		t.Fatal("run ping did not fail")
 	} else if exitCode != 1 {
-		errorOut(err, t, fmt.Sprintf("run ping failed with errors: %v", err))
+		t.Fatalf("run ping failed with errors: %v", err)
 	}
 
 	logDone("links - ping unlinked container")

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -16,14 +16,18 @@ func TestLogsContainerSmallerThanPage(t *testing.T) {
 	testLen := 32767
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, fmt.Sprintf("run failed with errors: %v", err))
+	if err != nil {
+		t.Fatalf("run failed with errors: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
 	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	errorOut(err, t, fmt.Sprintf("failed to log container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to log container: %s, %v", out, err)
+	}
 
 	if len(out) != testLen+1 {
 		t.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
@@ -39,14 +43,18 @@ func TestLogsContainerBiggerThanPage(t *testing.T) {
 	testLen := 32768
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, fmt.Sprintf("run failed with errors: %v", err))
+	if err != nil {
+		t.Fatalf("run failed with errors: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
 	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	errorOut(err, t, fmt.Sprintf("failed to log container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to log container: %s, %v", out, err)
+	}
 
 	if len(out) != testLen+1 {
 		t.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
@@ -62,14 +70,18 @@ func TestLogsContainerMuchBiggerThanPage(t *testing.T) {
 	testLen := 33000
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, fmt.Sprintf("run failed with errors: %v", err))
+	if err != nil {
+		t.Fatalf("run failed with errors: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
 	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	errorOut(err, t, fmt.Sprintf("failed to log container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to log container: %s, %v", out, err)
+	}
 
 	if len(out) != testLen+1 {
 		t.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
@@ -85,14 +97,18 @@ func TestLogsTimestamps(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
 
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, fmt.Sprintf("run failed with errors: %v", err))
+	if err != nil {
+		t.Fatalf("run failed with errors: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", "-t", cleanedContainerID)
 	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	errorOut(err, t, fmt.Sprintf("failed to log container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to log container: %s, %v", out, err)
+	}
 
 	lines := strings.Split(out, "\n")
 
@@ -124,14 +140,18 @@ func TestLogsSeparateStderr(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
 
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, fmt.Sprintf("run failed with errors: %v", err))
+	if err != nil {
+		t.Fatalf("run failed with errors: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
 	stdout, stderr, _, err := runCommandWithStdoutStderr(logsCmd)
-	errorOut(err, t, fmt.Sprintf("failed to log container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to log container: %s, %v", out, err)
+	}
 
 	if stdout != "" {
 		t.Fatalf("Expected empty stdout stream, got %v", stdout)
@@ -152,14 +172,18 @@ func TestLogsStderrInStdout(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "-t", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
 
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, fmt.Sprintf("run failed with errors: %v", err))
+	if err != nil {
+		t.Fatalf("run failed with errors: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
 	stdout, stderr, _, err := runCommandWithStdoutStderr(logsCmd)
-	errorOut(err, t, fmt.Sprintf("failed to log container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to log container: %s, %v", out, err)
+	}
 
 	if stderr != "" {
 		t.Fatalf("Expected empty stderr stream, got %v", stdout)
@@ -180,14 +204,18 @@ func TestLogsTail(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
 
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, fmt.Sprintf("run failed with errors: %v", err))
+	if err != nil {
+		t.Fatalf("run failed with errors: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", "--tail", "5", cleanedContainerID)
 	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	errorOut(err, t, fmt.Sprintf("failed to log container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to log container: %s, %v", out, err)
+	}
 
 	lines := strings.Split(out, "\n")
 
@@ -197,7 +225,9 @@ func TestLogsTail(t *testing.T) {
 
 	logsCmd = exec.Command(dockerBinary, "logs", "--tail", "all", cleanedContainerID)
 	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	errorOut(err, t, fmt.Sprintf("failed to log container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to log container: %s, %v", out, err)
+	}
 
 	lines = strings.Split(out, "\n")
 
@@ -207,7 +237,9 @@ func TestLogsTail(t *testing.T) {
 
 	logsCmd = exec.Command(dockerBinary, "logs", "--tail", "random", cleanedContainerID)
 	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	errorOut(err, t, fmt.Sprintf("failed to log container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to log container: %s, %v", out, err)
+	}
 
 	lines = strings.Split(out, "\n")
 
@@ -223,7 +255,9 @@ func TestLogsFollowStopped(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "echo", "hello")
 
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	errorOut(err, t, fmt.Sprintf("run failed with errors: %v", err))
+	if err != nil {
+		t.Fatalf("run failed with errors: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()

--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -26,17 +26,24 @@ func TestNetworkNat(t *testing.T) {
 
 	runCmd := exec.Command(dockerBinary, "run", "-dt", "-p", "8080:8080", "busybox", "nc", "-lp", "8080")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, fmt.Sprintf("run1 failed with errors: %v (%s)", err, out))
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	runCmd = exec.Command(dockerBinary, "run", "busybox", "sh", "-c", fmt.Sprintf("echo hello world | nc -w 30 %s 8080", ifaceIP))
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, fmt.Sprintf("run2 failed with errors: %v (%s)", err, out))
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	runCmd = exec.Command(dockerBinary, "logs", cleanedContainerID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, fmt.Sprintf("failed to retrieve logs for container: %v %v", cleanedContainerID, err))
+	if err != nil {
+		t.Fatalf("failed to retrieve logs for container: %s, %v", out, err)
+	}
+
 	out = strings.Trim(out, "\r\n")
 
 	if expected := "hello world"; out != expected {
@@ -44,8 +51,9 @@ func TestNetworkNat(t *testing.T) {
 	}
 
 	killCmd := exec.Command(dockerBinary, "kill", cleanedContainerID)
-	out, _, err = runCommandWithOutput(killCmd)
-	errorOut(err, t, fmt.Sprintf("failed to kill container: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(killCmd); err != nil {
+		t.Fatalf("failed to kill container: %s, %v", out, err)
+	}
 	deleteAllContainers()
 
 	logDone("network - make sure nat works through the host")

--- a/integration-cli/docker_cli_port_test.go
+++ b/integration-cli/docker_cli_port_test.go
@@ -11,12 +11,16 @@ func TestPortList(t *testing.T) {
 	// one port
 	runCmd := exec.Command(dockerBinary, "run", "-d", "-p", "9876:80", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	firstID := stripTrailingCharacters(out)
 
 	runCmd = exec.Command(dockerBinary, "port", firstID, "80")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertPortList(t, out, []string{"0.0.0.0:9876"}) {
 		t.Error("Port list is not correct")
@@ -24,14 +28,17 @@ func TestPortList(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "port", firstID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertPortList(t, out, []string{"80/tcp -> 0.0.0.0:9876"}) {
 		t.Error("Port list is not correct")
 	}
 	runCmd = exec.Command(dockerBinary, "rm", "-f", firstID)
-	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	// three port
 	runCmd = exec.Command(dockerBinary, "run", "-d",
@@ -40,12 +47,16 @@ func TestPortList(t *testing.T) {
 		"-p", "9878:82",
 		"busybox", "top")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	ID := stripTrailingCharacters(out)
 
 	runCmd = exec.Command(dockerBinary, "port", ID, "80")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertPortList(t, out, []string{"0.0.0.0:9876"}) {
 		t.Error("Port list is not correct")
@@ -53,7 +64,9 @@ func TestPortList(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "port", ID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertPortList(t, out, []string{
 		"80/tcp -> 0.0.0.0:9876",
@@ -63,7 +76,9 @@ func TestPortList(t *testing.T) {
 	}
 	runCmd = exec.Command(dockerBinary, "rm", "-f", ID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	// more and one port mapped to the same container port
 	runCmd = exec.Command(dockerBinary, "run", "-d",
@@ -73,12 +88,16 @@ func TestPortList(t *testing.T) {
 		"-p", "9878:82",
 		"busybox", "top")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	ID = stripTrailingCharacters(out)
 
 	runCmd = exec.Command(dockerBinary, "port", ID, "80")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertPortList(t, out, []string{"0.0.0.0:9876", "0.0.0.0:9999"}) {
 		t.Error("Port list is not correct")
@@ -86,7 +105,9 @@ func TestPortList(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "port", ID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertPortList(t, out, []string{
 		"80/tcp -> 0.0.0.0:9876",
@@ -96,8 +117,9 @@ func TestPortList(t *testing.T) {
 		t.Error("Port list is not correct\n", out)
 	}
 	runCmd = exec.Command(dockerBinary, "rm", "-f", ID)
-	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	deleteAllContainers()
 

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -10,34 +10,45 @@ import (
 func TestPsListContainers(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	firstID := stripTrailingCharacters(out)
 
 	runCmd = exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	secondID := stripTrailingCharacters(out)
 
 	// not long running
 	runCmd = exec.Command(dockerBinary, "run", "-d", "busybox", "true")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	thirdID := stripTrailingCharacters(out)
 
 	runCmd = exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	fourthID := stripTrailingCharacters(out)
 
 	// make sure third one is not running
 	runCmd = exec.Command(dockerBinary, "wait", thirdID)
-	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	// all
 	runCmd = exec.Command(dockerBinary, "ps", "-a")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertContainerList(out, []string{fourthID, thirdID, secondID, firstID}) {
 		t.Error("Container list is not in the correct order")
@@ -46,7 +57,9 @@ func TestPsListContainers(t *testing.T) {
 	// running
 	runCmd = exec.Command(dockerBinary, "ps")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertContainerList(out, []string{fourthID, secondID, firstID}) {
 		t.Error("Container list is not in the correct order")
@@ -57,7 +70,9 @@ func TestPsListContainers(t *testing.T) {
 	// limit
 	runCmd = exec.Command(dockerBinary, "ps", "-n=2", "-a")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	expected := []string{fourthID, thirdID}
 
 	if !assertContainerList(out, expected) {
@@ -66,7 +81,9 @@ func TestPsListContainers(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "ps", "-n=2")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertContainerList(out, expected) {
 		t.Error("Container list is not in the correct order")
@@ -75,7 +92,9 @@ func TestPsListContainers(t *testing.T) {
 	// since
 	runCmd = exec.Command(dockerBinary, "ps", "--since", firstID, "-a")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	expected = []string{fourthID, thirdID, secondID}
 
 	if !assertContainerList(out, expected) {
@@ -84,7 +103,9 @@ func TestPsListContainers(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "ps", "--since", firstID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertContainerList(out, expected) {
 		t.Error("Container list is not in the correct order")
@@ -93,7 +114,9 @@ func TestPsListContainers(t *testing.T) {
 	// before
 	runCmd = exec.Command(dockerBinary, "ps", "--before", thirdID, "-a")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	expected = []string{secondID, firstID}
 
 	if !assertContainerList(out, expected) {
@@ -102,7 +125,9 @@ func TestPsListContainers(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "ps", "--before", thirdID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertContainerList(out, expected) {
 		t.Error("Container list is not in the correct order")
@@ -111,7 +136,9 @@ func TestPsListContainers(t *testing.T) {
 	// since & before
 	runCmd = exec.Command(dockerBinary, "ps", "--since", firstID, "--before", fourthID, "-a")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	expected = []string{thirdID, secondID}
 
 	if !assertContainerList(out, expected) {
@@ -120,7 +147,9 @@ func TestPsListContainers(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "ps", "--since", firstID, "--before", fourthID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	if !assertContainerList(out, expected) {
 		t.Error("Container list is not in the correct order")
 	}
@@ -128,7 +157,9 @@ func TestPsListContainers(t *testing.T) {
 	// since & limit
 	runCmd = exec.Command(dockerBinary, "ps", "--since", firstID, "-n=2", "-a")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	expected = []string{fourthID, thirdID}
 
 	if !assertContainerList(out, expected) {
@@ -137,7 +168,9 @@ func TestPsListContainers(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "ps", "--since", firstID, "-n=2")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertContainerList(out, expected) {
 		t.Error("Container list is not in the correct order")
@@ -146,7 +179,9 @@ func TestPsListContainers(t *testing.T) {
 	// before & limit
 	runCmd = exec.Command(dockerBinary, "ps", "--before", fourthID, "-n=1", "-a")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	expected = []string{thirdID}
 
 	if !assertContainerList(out, expected) {
@@ -155,7 +190,9 @@ func TestPsListContainers(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "ps", "--before", fourthID, "-n=1")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertContainerList(out, expected) {
 		t.Error("Container list is not in the correct order")
@@ -164,7 +201,9 @@ func TestPsListContainers(t *testing.T) {
 	// since & before & limit
 	runCmd = exec.Command(dockerBinary, "ps", "--since", firstID, "--before", fourthID, "-n=1", "-a")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	expected = []string{thirdID}
 
 	if !assertContainerList(out, expected) {
@@ -173,7 +212,9 @@ func TestPsListContainers(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "ps", "--since", firstID, "--before", fourthID, "-n=1")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if !assertContainerList(out, expected) {
 		t.Error("Container list is not in the correct order")
@@ -205,7 +246,9 @@ func TestPsListContainersSize(t *testing.T) {
 	name := "test_size"
 	runCmd := exec.Command(dockerBinary, "run", "--name", name, "busybox", "sh", "-c", "echo 1 > test")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	id, err := getIDByName(name)
 	if err != nil {
 		t.Fatal(err)
@@ -222,7 +265,9 @@ func TestPsListContainersSize(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatalf("Calling \"docker ps -s\" timed out!")
 	}
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	lines := strings.Split(strings.Trim(out, "\n "), "\n")
 	sizeIndex := strings.Index(lines[0], "SIZE")
 	idIndex := strings.Index(lines[0], "CONTAINER ID")
@@ -247,24 +292,31 @@ func TestPsListContainersFilterStatus(t *testing.T) {
 	// start exited container
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	firstID := stripTrailingCharacters(out)
 
 	// make sure the exited cintainer is not running
 	runCmd = exec.Command(dockerBinary, "wait", firstID)
-	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	// start running container
 	runCmd = exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", "sleep 360")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	secondID := stripTrailingCharacters(out)
 
 	// filter containers by exited
 	runCmd = exec.Command(dockerBinary, "ps", "-a", "-q", "--filter=status=exited")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	containerOut := strings.TrimSpace(out)
 	if containerOut != firstID[:12] {
 		t.Fatalf("Expected id %s, got %s for exited filter, output: %q", firstID[:12], containerOut, out)
@@ -272,7 +324,9 @@ func TestPsListContainersFilterStatus(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "ps", "-a", "-q", "--filter=status=running")
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 	containerOut = strings.TrimSpace(out)
 	if containerOut != secondID[:12] {
 		t.Fatalf("Expected id %s, got %s for running filter, output: %q", secondID[:12], containerOut, out)

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os/exec"
 	"testing"
 )
@@ -11,11 +10,8 @@ import (
 // pulling an image from the central registry should work
 func TestPullImageFromCentralRegistry(t *testing.T) {
 	pullCmd := exec.Command(dockerBinary, "pull", "scratch")
-	out, exitCode, err := runCommandWithOutput(pullCmd)
-	errorOut(err, t, fmt.Sprintf("%s %s", out, err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("pulling the scratch image from the registry has failed")
+	if out, _, err := runCommandWithOutput(pullCmd); err != nil {
+		t.Fatal("pulling the scratch image from the registry has failed: %s, %v", out, err)
 	}
 	logDone("pull - pull scratch")
 }
@@ -23,10 +19,8 @@ func TestPullImageFromCentralRegistry(t *testing.T) {
 // pulling a non-existing image from the central registry should return a non-zero exit code
 func TestPullNonExistingImage(t *testing.T) {
 	pullCmd := exec.Command(dockerBinary, "pull", "fooblahblah1234")
-	_, exitCode, err := runCommandWithOutput(pullCmd)
-
-	if err == nil || exitCode == 0 {
-		t.Fatal("expected non-zero exit status when pulling non-existing image")
+	if out, _, err := runCommandWithOutput(pullCmd); err == nil {
+		t.Fatal("expected non-zero exit status when pulling non-existing image: %s", out)
 	}
 	logDone("pull - pull fooblahblah1234 (non-existing image)")
 }

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -15,22 +15,17 @@ func TestPushBusyboxImage(t *testing.T) {
 	// tag the image to upload it tot he private registry
 	repoName := fmt.Sprintf("%v/busybox", privateRegistryURL)
 	tagCmd := exec.Command(dockerBinary, "tag", "busybox", repoName)
-	out, exitCode, err := runCommandWithOutput(tagCmd)
-	errorOut(err, t, fmt.Sprintf("%v %v", out, err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("image tagging failed")
+	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
+		t.Fatal("image tagging failed: %s, %v", out, err)
 	}
 
 	pushCmd := exec.Command(dockerBinary, "push", repoName)
-	out, exitCode, err = runCommandWithOutput(pushCmd)
-	errorOut(err, t, fmt.Sprintf("%v %v", out, err))
+	if out, _, err := runCommandWithOutput(pushCmd); err != nil {
+		t.Fatal("pushing the image to the private registry has failed: %s, %v", out, err)
+	}
 
 	deleteImages(repoName)
 
-	if err != nil || exitCode != 0 {
-		t.Fatal("pushing the image to the private registry has failed")
-	}
 	logDone("push - push busybox to private registry")
 }
 
@@ -39,10 +34,8 @@ func TestPushUnprefixedRepo(t *testing.T) {
 	// skip this test until we're able to use a registry
 	t.Skip()
 	pushCmd := exec.Command(dockerBinary, "push", "busybox")
-	_, exitCode, err := runCommandWithOutput(pushCmd)
-
-	if err == nil || exitCode == 0 {
-		t.Fatal("pushing an unprefixed repo didn't result in a non-zero exit status")
+	if out, _, err := runCommandWithOutput(pushCmd); err == nil {
+		t.Fatal("pushing an unprefixed repo didn't result in a non-zero exit status: %s", out)
 	}
 	logDone("push - push unprefixed busybox repo --> must fail")
 }

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -10,29 +10,37 @@ import (
 func TestRestartStoppedContainer(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "echo", "foobar")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	runCmd = exec.Command(dockerBinary, "wait", cleanedContainerID)
-	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	runCmd = exec.Command(dockerBinary, "logs", cleanedContainerID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if out != "foobar\n" {
 		t.Errorf("container should've printed 'foobar'")
 	}
 
 	runCmd = exec.Command(dockerBinary, "restart", cleanedContainerID)
-	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	runCmd = exec.Command(dockerBinary, "logs", cleanedContainerID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if out != "foobar\nfoobar\n" {
 		t.Errorf("container should've printed 'foobar' twice")
@@ -46,7 +54,9 @@ func TestRestartStoppedContainer(t *testing.T) {
 func TestRestartRunningContainer(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", "echo foobar && sleep 30 && echo 'should not print this'")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
@@ -54,19 +64,24 @@ func TestRestartRunningContainer(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "logs", cleanedContainerID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if out != "foobar\n" {
 		t.Errorf("container should've printed 'foobar'")
 	}
 
 	runCmd = exec.Command(dockerBinary, "restart", "-t", "1", cleanedContainerID)
-	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	runCmd = exec.Command(dockerBinary, "logs", cleanedContainerID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	time.Sleep(1 * time.Second)
 
@@ -83,13 +98,17 @@ func TestRestartRunningContainer(t *testing.T) {
 func TestRestartWithVolumes(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "-v", "/test", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	runCmd = exec.Command(dockerBinary, "inspect", "--format", "{{ len .Volumes }}", cleanedContainerID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if out = strings.Trim(out, " \n\r"); out != "1" {
 		t.Errorf("expect 1 volume received %s", out)
@@ -97,15 +116,20 @@ func TestRestartWithVolumes(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "inspect", "--format", "{{ .Volumes }}", cleanedContainerID)
 	volumes, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, volumes)
+	if err != nil {
+		t.Fatal(volumes, err)
+	}
 
 	runCmd = exec.Command(dockerBinary, "restart", cleanedContainerID)
-	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	runCmd = exec.Command(dockerBinary, "inspect", "--format", "{{ len .Volumes }}", cleanedContainerID)
 	out, _, err = runCommandWithOutput(runCmd)
-	errorOut(err, t, out)
+	if err != nil {
+		t.Fatal(out, err)
+	}
 
 	if out = strings.Trim(out, " \n\r"); out != "1" {
 		t.Errorf("expect 1 volume after restart received %s", out)
@@ -113,7 +137,9 @@ func TestRestartWithVolumes(t *testing.T) {
 
 	runCmd = exec.Command(dockerBinary, "inspect", "--format", "{{ .Volumes }}", cleanedContainerID)
 	volumesAfterRestart, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, volumesAfterRestart)
+	if err != nil {
+		t.Fatal(volumesAfterRestart, err)
+	}
 
 	if volumes != volumesAfterRestart {
 		volumes = strings.Trim(volumes, " \n\r")

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -13,7 +12,9 @@ func TestRmiWithContainerFails(t *testing.T) {
 	// create a container
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, fmt.Sprintf("failed to create a container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to create a container: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -14,40 +14,50 @@ import (
 func TestSaveAndLoadRepoStdout(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, fmt.Sprintf("failed to create a container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to create a container: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	repoName := "foobar-save-load-test"
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("output should've been a container id: %v %v", cleanedContainerID, err))
+	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
+		t.Fatalf("output should've been a container id: %s, %v", out, err)
+	}
 
 	commitCmd := exec.Command(dockerBinary, "commit", cleanedContainerID, repoName)
-	out, _, err = runCommandWithOutput(commitCmd)
-	errorOut(err, t, fmt.Sprintf("failed to commit container: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(commitCmd); err != nil {
+		t.Fatalf("failed to commit container: %s, %v", out, err)
+	}
 
 	inspectCmd = exec.Command(dockerBinary, "inspect", repoName)
 	before, _, err := runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("the repo should exist before saving it: %v %v", before, err))
+	if err != nil {
+		t.Fatalf("the repo should exist before saving it: %s, %v", before, err)
+	}
 
 	saveCmdTemplate := `%v save %v > /tmp/foobar-save-load-test.tar`
 	saveCmdFinal := fmt.Sprintf(saveCmdTemplate, dockerBinary, repoName)
 	saveCmd := exec.Command("bash", "-c", saveCmdFinal)
-	out, _, err = runCommandWithOutput(saveCmd)
-	errorOut(err, t, fmt.Sprintf("failed to save repo: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(saveCmd); err != nil {
+		t.Fatalf("failed to save repo: %s, %v", out, err)
+	}
 
 	deleteImages(repoName)
 
 	loadCmdFinal := `cat /tmp/foobar-save-load-test.tar | docker load`
 	loadCmd := exec.Command("bash", "-c", loadCmdFinal)
-	out, _, err = runCommandWithOutput(loadCmd)
-	errorOut(err, t, fmt.Sprintf("failed to load repo: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(loadCmd); err != nil {
+		t.Fatalf("failed to load repo: %s, %v", out, err)
+	}
 
 	inspectCmd = exec.Command(dockerBinary, "inspect", repoName)
 	after, _, err := runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("the repo should exist after loading it: %v %v", after, err))
+	if err != nil {
+		t.Fatalf("the repo should exist after loading it: %s %v", after, err)
+	}
 
 	if before != after {
 		t.Fatalf("inspect is not the same after a save / load")
@@ -67,20 +77,24 @@ func TestSaveSingleTag(t *testing.T) {
 
 	tagCmdFinal := fmt.Sprintf("%v tag busybox:latest %v:latest", dockerBinary, repoName)
 	tagCmd := exec.Command("bash", "-c", tagCmdFinal)
-	out, _, err := runCommandWithOutput(tagCmd)
-	errorOut(err, t, fmt.Sprintf("failed to tag repo: %v %v", out, err))
+	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
+		t.Fatalf("failed to tag repo: %s, %v", out, err)
+	}
 
 	idCmdFinal := fmt.Sprintf("%v images -q --no-trunc %v", dockerBinary, repoName)
 	idCmd := exec.Command("bash", "-c", idCmdFinal)
-	out, _, err = runCommandWithOutput(idCmd)
-	errorOut(err, t, fmt.Sprintf("failed to get repo ID: %v %v", out, err))
+	out, _, err := runCommandWithOutput(idCmd)
+	if err != nil {
+		t.Fatalf("failed to get repo ID: %s, %v", out, err)
+	}
 
 	cleanedImageID := stripTrailingCharacters(out)
 
 	saveCmdFinal := fmt.Sprintf("%v save %v:latest | tar t | grep -E '(^repositories$|%v)'", dockerBinary, repoName, cleanedImageID)
 	saveCmd := exec.Command("bash", "-c", saveCmdFinal)
-	out, _, err = runCommandWithOutput(saveCmd)
-	errorOut(err, t, fmt.Sprintf("failed to save repo with image ID and 'repositories' file: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(saveCmd); err != nil {
+		t.Fatalf("failed to save repo with image ID and 'repositories' file: %s, %v", out, err)
+	}
 
 	deleteImages(repoName)
 
@@ -92,27 +106,33 @@ func TestSaveImageId(t *testing.T) {
 
 	tagCmdFinal := fmt.Sprintf("%v tag scratch:latest %v:latest", dockerBinary, repoName)
 	tagCmd := exec.Command("bash", "-c", tagCmdFinal)
-	out, _, err := runCommandWithOutput(tagCmd)
-	errorOut(err, t, fmt.Sprintf("failed to tag repo: %v %v", out, err))
+	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
+		t.Fatalf("failed to tag repo: %s, %v", out, err)
+	}
 
 	idLongCmdFinal := fmt.Sprintf("%v images -q --no-trunc %v", dockerBinary, repoName)
 	idLongCmd := exec.Command("bash", "-c", idLongCmdFinal)
-	out, _, err = runCommandWithOutput(idLongCmd)
-	errorOut(err, t, fmt.Sprintf("failed to get repo ID: %v %v", out, err))
+	out, _, err := runCommandWithOutput(idLongCmd)
+	if err != nil {
+		t.Fatalf("failed to get repo ID: %s, %v", out, err)
+	}
 
 	cleanedLongImageID := stripTrailingCharacters(out)
 
 	idShortCmdFinal := fmt.Sprintf("%v images -q %v", dockerBinary, repoName)
 	idShortCmd := exec.Command("bash", "-c", idShortCmdFinal)
 	out, _, err = runCommandWithOutput(idShortCmd)
-	errorOut(err, t, fmt.Sprintf("failed to get repo short ID: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to get repo short ID: %s, %v", out, err)
+	}
 
 	cleanedShortImageID := stripTrailingCharacters(out)
 
 	saveCmdFinal := fmt.Sprintf("%v save %v | tar t | grep %v", dockerBinary, cleanedShortImageID, cleanedLongImageID)
 	saveCmd := exec.Command("bash", "-c", saveCmdFinal)
-	out, _, err = runCommandWithOutput(saveCmd)
-	errorOut(err, t, fmt.Sprintf("failed to save repo with image ID: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(saveCmd); err != nil {
+		t.Fatalf("failed to save repo with image ID: %s, %v", out, err)
+	}
 
 	deleteImages(repoName)
 
@@ -123,40 +143,50 @@ func TestSaveImageId(t *testing.T) {
 func TestSaveAndLoadRepoFlags(t *testing.T) {
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
-	errorOut(err, t, fmt.Sprintf("failed to create a container: %v %v", out, err))
+	if err != nil {
+		t.Fatalf("failed to create a container: %s, %v", out, err)
+	}
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
 	repoName := "foobar-save-load-test"
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("output should've been a container id: %v %v", cleanedContainerID, err))
+	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
+		t.Fatalf("output should've been a container id: %s, %v", out, err)
+	}
 
 	commitCmd := exec.Command(dockerBinary, "commit", cleanedContainerID, repoName)
-	out, _, err = runCommandWithOutput(commitCmd)
-	errorOut(err, t, fmt.Sprintf("failed to commit container: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(commitCmd); err != nil {
+		t.Fatalf("failed to commit container: %s, %v", out, err)
+	}
 
 	inspectCmd = exec.Command(dockerBinary, "inspect", repoName)
 	before, _, err := runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("the repo should exist before saving it: %v %v", before, err))
+	if err != nil {
+		t.Fatalf("the repo should exist before saving it: %s, %v", before, err)
+	}
 
 	saveCmdTemplate := `%v save -o /tmp/foobar-save-load-test.tar %v`
 	saveCmdFinal := fmt.Sprintf(saveCmdTemplate, dockerBinary, repoName)
 	saveCmd := exec.Command("bash", "-c", saveCmdFinal)
-	out, _, err = runCommandWithOutput(saveCmd)
-	errorOut(err, t, fmt.Sprintf("failed to save repo: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(saveCmd); err != nil {
+		t.Fatalf("failed to save repo: %s, %v", out, err)
+	}
 
 	deleteImages(repoName)
 
 	loadCmdFinal := `docker load -i /tmp/foobar-save-load-test.tar`
 	loadCmd := exec.Command("bash", "-c", loadCmdFinal)
-	out, _, err = runCommandWithOutput(loadCmd)
-	errorOut(err, t, fmt.Sprintf("failed to load repo: %v %v", out, err))
+	if out, _, err = runCommandWithOutput(loadCmd); err != nil {
+		t.Fatalf("failed to load repo: %s, %v", out, err)
+	}
 
 	inspectCmd = exec.Command(dockerBinary, "inspect", repoName)
 	after, _, err := runCommandWithOutput(inspectCmd)
-	errorOut(err, t, fmt.Sprintf("the repo should exist after loading it: %v %v", after, err))
+	if err != nil {
+		t.Fatalf("the repo should exist after loading it: %s, %v", after, err)
+	}
 
 	if before != after {
 		t.Fatalf("inspect is not the same after a save / load")
@@ -177,18 +207,21 @@ func TestSaveMultipleNames(t *testing.T) {
 	// Make one image
 	tagCmdFinal := fmt.Sprintf("%v tag scratch:latest %v-one:latest", dockerBinary, repoName)
 	tagCmd := exec.Command("bash", "-c", tagCmdFinal)
-	out, _, err := runCommandWithOutput(tagCmd)
-	errorOut(err, t, fmt.Sprintf("failed to tag repo: %v %v", out, err))
+	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
+		t.Fatalf("failed to tag repo: %s, %v", out, err)
+	}
 	// Make two images
 	tagCmdFinal = fmt.Sprintf("%v tag scratch:latest %v-two:latest", dockerBinary, repoName)
 	tagCmd = exec.Command("bash", "-c", tagCmdFinal)
-	out, _, err = runCommandWithOutput(tagCmd)
-	errorOut(err, t, fmt.Sprintf("failed to tag repo: %v %v", out, err))
+	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
+		t.Fatalf("failed to tag repo: %s, %v", out, err)
+	}
 
 	saveCmdFinal := fmt.Sprintf("%v save %v-one %v-two:latest | tar xO repositories | grep -q -E '(-one|-two)'", dockerBinary, repoName, repoName)
 	saveCmd := exec.Command("bash", "-c", saveCmdFinal)
-	out, _, err = runCommandWithOutput(saveCmd)
-	errorOut(err, t, fmt.Sprintf("failed to save multiple repos: %v %v", out, err))
+	if out, _, err := runCommandWithOutput(saveCmd); err != nil {
+		t.Fatalf("failed to save multiple repos: %s, %v", out, err)
+	}
 
 	deleteImages(repoName)
 
@@ -202,12 +235,12 @@ func TestSaveDirectoryPermissions(t *testing.T) {
 
 	name := "save-directory-permissions"
 	tmpDir, err := ioutil.TempDir("", "save-layers-with-directories")
-	extractionDirectory := filepath.Join(tmpDir, "image-extraction-dir")
-	os.Mkdir(extractionDirectory, 0777)
-
 	if err != nil {
 		t.Errorf("failed to create temporary directory: %s", err)
 	}
+	extractionDirectory := filepath.Join(tmpDir, "image-extraction-dir")
+	os.Mkdir(extractionDirectory, 0777)
+
 	defer os.RemoveAll(tmpDir)
 	defer deleteImages(name)
 	_, err = buildImage(name,
@@ -221,8 +254,7 @@ func TestSaveDirectoryPermissions(t *testing.T) {
 
 	saveCmdFinal := fmt.Sprintf("%s save %s | tar -xf - -C %s", dockerBinary, name, extractionDirectory)
 	saveCmd := exec.Command("bash", "-c", saveCmdFinal)
-	out, _, err := runCommandWithOutput(saveCmd)
-	if err != nil {
+	if out, _, err := runCommandWithOutput(saveCmd); err != nil {
 		t.Errorf("failed to save and extract image: %s", out)
 	}
 

--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -11,10 +10,8 @@ import (
 func TestSearchOnCentralRegistry(t *testing.T) {
 	searchCmd := exec.Command(dockerBinary, "search", "busybox")
 	out, exitCode, err := runCommandWithOutput(searchCmd)
-	errorOut(err, t, fmt.Sprintf("encountered error while searching: %v", err))
-
 	if err != nil || exitCode != 0 {
-		t.Fatal("failed to search on the central registry")
+		t.Fatal("failed to search on the central registry: %s, %v", out, err)
 	}
 
 	if !strings.Contains(out, "Busybox base image.") {

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -13,8 +13,9 @@ func TestTagUnprefixedRepoByName(t *testing.T) {
 	}
 
 	tagCmd := exec.Command(dockerBinary, "tag", "busybox:latest", "testfoobarbaz")
-	out, _, err := runCommandWithOutput(tagCmd)
-	errorOut(err, t, fmt.Sprintf("%v %v", out, err))
+	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	deleteImages("testfoobarbaz")
 
@@ -25,12 +26,15 @@ func TestTagUnprefixedRepoByName(t *testing.T) {
 func TestTagUnprefixedRepoByID(t *testing.T) {
 	getIDCmd := exec.Command(dockerBinary, "inspect", "-f", "{{.Id}}", "busybox")
 	out, _, err := runCommandWithOutput(getIDCmd)
-	errorOut(err, t, fmt.Sprintf("failed to get the image ID of busybox: %v", err))
+	if err != nil {
+		t.Fatalf("failed to get the image ID of busybox: %s, %v", out, err)
+	}
 
 	cleanedImageID := stripTrailingCharacters(out)
 	tagCmd := exec.Command(dockerBinary, "tag", cleanedImageID, "testfoobarbaz")
-	out, _, err = runCommandWithOutput(tagCmd)
-	errorOut(err, t, fmt.Sprintf("%s %s", out, err))
+	if out, _, err = runCommandWithOutput(tagCmd); err != nil {
+		t.Fatal(out, err)
+	}
 
 	deleteImages("testfoobarbaz")
 

--- a/integration-cli/docker_cli_version_test.go
+++ b/integration-cli/docker_cli_version_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os/exec"
 	"strings"
 	"testing"
@@ -10,11 +9,9 @@ import (
 // ensure docker version works
 func TestVersionEnsureSucceeds(t *testing.T) {
 	versionCmd := exec.Command(dockerBinary, "version")
-	out, exitCode, err := runCommandWithOutput(versionCmd)
-	errorOut(err, t, fmt.Sprintf("encountered error while running docker version: %v", err))
-
-	if err != nil || exitCode != 0 {
-		t.Fatal("failed to execute docker version")
+	out, _, err := runCommandWithOutput(versionCmd)
+	if err != nil {
+		t.Fatal("failed to execute docker version: %s, %v", out, err)
 	}
 
 	stringsToCheck := []string{

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -341,7 +341,9 @@ func cmd(t *testing.T, args ...string) (string, int, error) {
 
 func dockerCmd(t *testing.T, args ...string) (string, int, error) {
 	out, status, err := runCommandWithOutput(exec.Command(dockerBinary, args...))
-	errorOut(err, t, fmt.Sprintf("%q failed with errors: %v (%v)", strings.Join(args, " "), err, out))
+	if err != nil {
+		t.Fatalf("%q failed with errors: %s, %v", strings.Join(args, " "), out, err)
+	}
 	return out, status, err
 }
 

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -13,7 +13,6 @@ import (
 	"reflect"
 	"strings"
 	"syscall"
-	"testing"
 	"time"
 
 	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
@@ -111,18 +110,6 @@ func stripTrailingCharacters(target string) string {
 	target = strings.Trim(target, "\n")
 	target = strings.Trim(target, " ")
 	return target
-}
-
-func errorOut(err error, t *testing.T, message string) {
-	if err != nil {
-		t.Fatal(message)
-	}
-}
-
-func errorOutOnNonNilError(err error, t *testing.T, message string) {
-	if err == nil {
-		t.Fatalf(message)
-	}
 }
 
 func nLines(s string) int {


### PR DESCRIPTION
Nuke the `errorOut` function in integration-cli
