### PR TITLE
remove sslv3 from server's TLS supported versions

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1439,6 +1439,8 @@ func ListenAndServe(proto, addr string, job *engine.Job) error {
 		tlsConfig := &tls.Config{
 			NextProtos:   []string{"http/1.1"},
 			Certificates: []tls.Certificate{cert},
+			// Avoid fallback on insecure SSL protocols
+			MinVersion: tls.VersionTLS10,
 		}
 		if job.GetenvBool("TlsVerify") {
 			certPool := x509.NewCertPool()

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -93,6 +93,8 @@ func main() {
 			}
 			tlsConfig.Certificates = []tls.Certificate{cert}
 		}
+		// Avoid fallback to SSL protocols < TLS1.0
+		tlsConfig.MinVersion = tls.VersionTLS10
 	}
 
 	if *flTls || *flTlsVerify {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -36,7 +36,11 @@ const (
 )
 
 func newClient(jar http.CookieJar, roots *x509.CertPool, cert *tls.Certificate, timeout TimeoutType) *http.Client {
-	tlsConfig := tls.Config{RootCAs: roots}
+	tlsConfig := tls.Config{
+		RootCAs: roots,
+		// Avoid fallback to SSL protocols < TLS1.0
+		MinVersion: tls.VersionTLS10,
+	}
 
 	if cert != nil {
 		tlsConfig.Certificates = append(tlsConfig.Certificates, *cert)


### PR DESCRIPTION
This makes TLS1.0 the minimum fallback version for TLS and helps mitigate [poodle](http://googleonlinesecurity.blogspot.de/2014/10/this-poodle-bites-exploiting-ssl-30.html) issue

Docker-DCO-1.1-Signed-off-by: Daniel, Dao Quang Minh dqminh89@gmail.com (github: dqminh)
