### PR TITLE
Initial work to allow typed errors from Jobs

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -762,11 +762,7 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 		if err != nil {
 			obj, _, err = readBody(cli.call("GET", "/images/"+name+"/json", nil, false))
 			if err != nil {
-				if strings.Contains(err.Error(), "No such") {
-					fmt.Fprintf(cli.err, "Error: No such image or container: %s\n", name)
-				} else {
-					fmt.Fprintf(cli.err, "%s", err)
-				}
+				fmt.Fprintf(cli.err, "%s", err)
 				status = 1
 				continue
 			}

--- a/api/server/server_unit_test.go
+++ b/api/server/server_unit_test.go
@@ -43,18 +43,19 @@ func TestGetBoolParam(t *testing.T) {
 
 func TesthttpError(t *testing.T) {
 	r := httptest.NewRecorder()
+	req := http.Request{}
 
-	httpError(r, fmt.Errorf("No such method"))
+	httpError(r, &req, engine.NotFoundError{Type: "method", Id: "test_method"})
 	if r.Code != http.StatusNotFound {
 		t.Fatalf("Expected %d, got %d", http.StatusNotFound, r.Code)
 	}
 
-	httpError(r, fmt.Errorf("This accound hasn't been activated"))
+	httpError(r, &req, engine.AccountDisabledError("This accound hasn't been activated"))
 	if r.Code != http.StatusForbidden {
 		t.Fatalf("Expected %d, got %d", http.StatusForbidden, r.Code)
 	}
 
-	httpError(r, fmt.Errorf("Some error"))
+	httpError(r, &req, fmt.Errorf("Some error"))
 	if r.Code != http.StatusInternalServerError {
 		t.Fatalf("Expected %d, got %d", http.StatusInternalServerError, r.Code)
 	}

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -111,7 +111,7 @@ type copyInfo struct {
 
 func (b *Builder) runContextCommand(args []string, allowRemote bool, allowDecompression bool, cmdName string) error {
 	if b.context == nil {
-		return fmt.Errorf("No context given. Impossible to use %s", cmdName)
+		return engine.StatusNotAcceptable("No context given. Impossible to use " + cmdName)
 	}
 
 	if len(args) < 2 {

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -30,7 +30,7 @@ func (daemon *Daemon) ContainerAttach(job *engine.Job) engine.Status {
 
 	container := daemon.Get(name)
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return engine.NotFoundError{Type: "container", Id: name}
 	}
 
 	//logs

--- a/daemon/changes.go
+++ b/daemon/changes.go
@@ -26,7 +26,7 @@ func (daemon *Daemon) ContainerChanges(job *engine.Job) engine.Status {
 			return job.Error(err)
 		}
 	} else {
-		return job.Errorf("No such container: %s", name)
+		return engine.NotFoundError{Type: "container", Id: name}
 	}
 	return engine.StatusOK
 }

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -14,7 +14,7 @@ func (daemon *Daemon) ContainerCommit(job *engine.Job) engine.Status {
 
 	container := daemon.Get(name)
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return engine.NotFoundError{Type: "container", Id: name}
 	}
 
 	var (

--- a/daemon/copy.go
+++ b/daemon/copy.go
@@ -29,5 +29,5 @@ func (daemon *Daemon) ContainerCopy(job *engine.Job) engine.Status {
 		}
 		return engine.StatusOK
 	}
-	return job.Errorf("No such container: %s", name)
+	return engine.NotFoundError{Type: "container", Id: name}
 }

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -42,7 +42,7 @@ func (daemon *Daemon) ContainerCreate(job *engine.Job) engine.Status {
 			if tag == "" {
 				tag = graph.DEFAULTTAG
 			}
-			return job.Errorf("No such image: %s (tag: %s)", config.Image, tag)
+			return engine.NotFoundError{"image", config.Image, "tag: " + tag}
 		}
 		return job.Error(err)
 	}

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -20,7 +20,7 @@ func (daemon *Daemon) ContainerRm(job *engine.Job) engine.Status {
 	container := daemon.Get(name)
 
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return engine.NotFoundError{Type: "container", Id: name}
 	}
 
 	if removeLink {
@@ -87,7 +87,7 @@ func (daemon *Daemon) Destroy(container *Container) error {
 
 	element := daemon.containers.Get(container.ID)
 	if element == nil {
-		return fmt.Errorf("Container %v not found - maybe it was already destroyed?", container.ID)
+		return engine.NotFoundError{Type: "container", Id: container.ID, Detail: "maybe it was already destroyed?"}
 	}
 
 	if err := container.Stop(3); err != nil {

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -79,7 +79,7 @@ func (d *Daemon) getExecConfig(name string) (*execConfig, error) {
 		return execConfig, nil
 	}
 
-	return nil, fmt.Errorf("No such exec instance '%s' found in daemon", name)
+	return nil, engine.NotFoundError{Type: "exec instance", Id: name, Detail: "not found in daemon"}
 }
 
 func (d *Daemon) unregisterExecCommand(execConfig *execConfig) {
@@ -91,7 +91,7 @@ func (d *Daemon) getActiveContainer(name string) (*Container, error) {
 	container := d.Get(name)
 
 	if container == nil {
-		return nil, fmt.Errorf("No such container: %s", name)
+		return nil, engine.NotFoundError{Type: "container", Id: name}
 	}
 
 	if !container.IsRunning() {

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -26,5 +26,5 @@ func (daemon *Daemon) ContainerExport(job *engine.Job) engine.Status {
 		container.LogEvent("export")
 		return engine.StatusOK
 	}
-	return job.Errorf("No such container: %s", name)
+	return engine.NotFoundError{Type: "container", Id: name}
 }

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -62,5 +62,5 @@ func (daemon *Daemon) ContainerInspect(job *engine.Job) engine.Status {
 		}
 		return engine.StatusOK
 	}
-	return job.Errorf("No such container: %s", name)
+	return engine.NotFoundError{Type: "container", Id: name}
 }

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -53,7 +53,7 @@ func (daemon *Daemon) ContainerKill(job *engine.Job) engine.Status {
 			// FIXME: Add event for signals
 		}
 	} else {
-		return job.Errorf("No such container: %s", name)
+		return engine.NotFoundError{Type: "container", Id: name}
 	}
 	return engine.StatusOK
 }

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -41,7 +41,7 @@ func (daemon *Daemon) ContainerLogs(job *engine.Job) engine.Status {
 	}
 	container := daemon.Get(name)
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return engine.NotFoundError{Type: "container", Id: name}
 	}
 	cLog, err := container.ReadLog("json")
 	if err != nil && os.IsNotExist(err) {

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -11,7 +11,7 @@ func (daemon *Daemon) ContainerPause(job *engine.Job) engine.Status {
 	name := job.Args[0]
 	container := daemon.Get(name)
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return engine.NotFoundError{Type: "container", Id: name}
 	}
 	if err := container.Pause(); err != nil {
 		return job.Errorf("Cannot pause container %s: %s", name, err)
@@ -27,7 +27,7 @@ func (daemon *Daemon) ContainerUnpause(job *engine.Job) engine.Status {
 	name := job.Args[0]
 	container := daemon.Get(name)
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return engine.NotFoundError{Type: "container", Id: name}
 	}
 	if err := container.Unpause(); err != nil {
 		return job.Errorf("Cannot unpause container %s: %s", name, err)

--- a/daemon/resize.go
+++ b/daemon/resize.go
@@ -26,7 +26,7 @@ func (daemon *Daemon) ContainerResize(job *engine.Job) engine.Status {
 		}
 		return engine.StatusOK
 	}
-	return job.Errorf("No such container: %s", name)
+	return engine.NotFoundError{Type: "container", Id: name}
 }
 
 func (daemon *Daemon) ContainerExecResize(job *engine.Job) engine.Status {

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -21,7 +21,7 @@ func (daemon *Daemon) ContainerRestart(job *engine.Job) engine.Status {
 		}
 		container.LogEvent("restart")
 	} else {
-		return job.Errorf("No such container: %s\n", name)
+		return engine.NotFoundError{Type: "container", Id: name}
 	}
 	return engine.StatusOK
 }

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -19,11 +19,11 @@ func (daemon *Daemon) ContainerStart(job *engine.Job) engine.Status {
 	)
 
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return engine.NotFoundError{Type: "container", Id: name}
 	}
 
 	if container.IsRunning() {
-		return job.Errorf("Container already started")
+		return engine.NotModifiedError("Container already started")
 	}
 
 	// If no environment was set, then no hostconfig was passed.

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -17,14 +17,14 @@ func (daemon *Daemon) ContainerStop(job *engine.Job) engine.Status {
 	}
 	if container := daemon.Get(name); container != nil {
 		if !container.IsRunning() {
-			return job.Errorf("Container already stopped")
+			return engine.NotModifiedError("Container already stopped")
 		}
 		if err := container.Stop(int(t)); err != nil {
 			return job.Errorf("Cannot stop container %s: %s\n", name, err)
 		}
 		container.LogEvent("stop")
 	} else {
-		return job.Errorf("No such container: %s\n", name)
+		return engine.NotFoundError{Type: "container", Id: name}
 	}
 	return engine.StatusOK
 }

--- a/daemon/top.go
+++ b/daemon/top.go
@@ -75,5 +75,5 @@ func (daemon *Daemon) ContainerTop(job *engine.Job) engine.Status {
 		return engine.StatusOK
 
 	}
-	return job.Errorf("No such container: %s", name)
+	return engine.NotFoundError{Type: "container", Id: name}
 }

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -251,7 +251,7 @@ func parseVolumesFromSpec(daemon *Daemon, spec string) (map[string]*Mount, error
 
 	c := daemon.Get(specParts[0])
 	if c == nil {
-		return nil, fmt.Errorf("Container %s not found. Impossible to mount its volumes", specParts[0])
+		return nil, engine.StatusNotAcceptable("Container " + specParts[0] + " not found. Impossible to mount its volumes")
 	}
 
 	mounts := c.VolumeMounts()

--- a/daemon/wait.go
+++ b/daemon/wait.go
@@ -16,5 +16,5 @@ func (daemon *Daemon) ContainerWait(job *engine.Job) engine.Status {
 		job.Printf("%d\n", status)
 		return engine.StatusOK
 	}
-	return job.Errorf("%s: No such container: %s", job.Name, name)
+	return engine.NotFoundError{"container", name, "job: " + job.Name}
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -45,7 +46,7 @@ func TestJob(t *testing.T) {
 
 	h := func(j *Job) Status {
 		j.Printf("%s\n", j.Name)
-		return 42
+		return errors.New("42")
 	}
 
 	eng.Register("dummy2", h)
@@ -56,7 +57,7 @@ func TestJob(t *testing.T) {
 		t.Fatalf("job2.handler shouldn't be nil")
 	}
 
-	if job2.handler(job2) != 42 {
+	if job2.handler(job2).Error() != "42" {
 		t.Fatalf("handler dummy2 was not found in job2")
 	}
 }

--- a/graph/service.go
+++ b/graph/service.go
@@ -155,7 +155,7 @@ func (s *TagStore) CmdLookup(job *engine.Job) engine.Status {
 		}
 		return engine.StatusOK
 	}
-	return job.Errorf("No such image: %s", name)
+	return engine.NotFoundError{Type: "image", Id: name}
 }
 
 // CmdTarLayer return the tarLayer of the image
@@ -178,5 +178,5 @@ func (s *TagStore) CmdTarLayer(job *engine.Job) engine.Status {
 		log.Debugf("rendered layer for %s of [%d] size", image.ID, written)
 		return engine.StatusOK
 	}
-	return job.Errorf("No such image: %s", name)
+	return engine.NotFoundError{Type: "image", Id: name}
 }

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/docker/docker/engine"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/utils"
@@ -184,14 +185,14 @@ func (store *TagStore) Delete(repoName, tag string) (bool, error) {
 				}
 				deleted = true
 			} else {
-				return false, fmt.Errorf("No such tag: %s:%s", repoName, tag)
+				return false, engine.NotFoundError{Type: "tag", Id: repoName + ":" + tag}
 			}
 		} else {
 			delete(store.Repositories, repoName)
 			deleted = true
 		}
 	} else {
-		return false, fmt.Errorf("No such repository: %s", repoName)
+		return false, engine.NotFoundError{Type: "repository", Id: repoName}
 	}
 	return deleted, store.save()
 }

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -150,7 +150,7 @@ func getContainer(eng *engine.Engine, id string, t log.Fataler) *daemon.Containe
 	daemon := mkDaemonFromEngine(eng, t)
 	c := daemon.Get(id)
 	if c == nil {
-		t.Fatal(fmt.Errorf("No such container: %s", id))
+		t.Fatal(engine.NotFoundError{Type: "container", Id: id})
 	}
 	return c
 }


### PR DESCRIPTION
This change allows for typed error returns from engine Jobs.
There are types defined for the basic errors in httpError and some additional types mirroring http response codes.
Modification of the wider codebase to use those typed errors has been done to the extent necessary to pass the test suite. There is work to be done verifying the completeness of that coverage, converting remaining untyped errors and adding additional per error fields as needed.
