### PR TITLE
Attempt to implement #332 - flattening layers

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1112,6 +1112,39 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 	return cli.stream("POST", "/images/create?"+v.Encode(), in, cli.out, nil)
 }
 
+func (cli *DockerCli) CmdFlatten(args ...string) error {
+	cmd := cli.Subcmd("flatten", "PARENT_IMAGE IMAGE [REPOSITORY[:TAG]]", "Flatten all layers between parent and image, create a new image from it")
+
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+	if cmd.NArg() < 2 {
+		cmd.Usage()
+		return nil
+	}
+
+	var (
+		v          = url.Values{}
+		parent     = cmd.Arg(0)
+		name       = cmd.Arg(1)
+		repository = cmd.Arg(2)
+	)
+
+	v.Set("parent", parent)
+	v.Set("name", name)
+	v.Set("repo", repository)
+
+	if repository != "" {
+		//Check if the given image name can be resolved
+		repo, _ := parsers.ParseRepositoryTag(repository)
+		if _, _, err := registry.ResolveRepositoryName(repo); err != nil {
+			return err
+		}
+	}
+
+	return cli.stream("GET", "/images/flatten?"+v.Encode(), nil, cli.out, nil)
+}
+
 func (cli *DockerCli) CmdPush(args ...string) error {
 	cmd := cli.Subcmd("push", "NAME[:TAG]", "Push an image or a repository to the registry")
 	if err := cmd.Parse(args); err != nil {

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -64,6 +64,7 @@ func init() {
 			{"events", "Get real time events from the server"},
 			{"exec", "Run a command in an existing container"},
 			{"export", "Stream the contents of a container as a tar archive"},
+			{"flatten", "Flatten images and create a new image from them"},
 			{"history", "Show the history of an image"},
 			{"images", "List images"},
 			{"import", "Create a new filesystem image from the contents of a tarball"},

--- a/graph/flatten.go
+++ b/graph/flatten.go
@@ -1,0 +1,50 @@
+package graph
+
+import (
+	"github.com/docker/docker/engine"
+	"github.com/docker/docker/utils"
+)
+
+func (s *TagStore) CmdFlatten(job *engine.Job) engine.Status {
+	if n := len(job.Args); n != 3 && n != 4 {
+		return job.Errorf("Usage: %s PARENT NAME [TAG]", job.Name)
+	}
+	var (
+		parent = job.Args[0]
+		name   = job.Args[1]
+		repo   = job.Args[2]
+		tag    string
+		sf     = utils.NewStreamFormatter(job.GetenvBool("json"))
+	)
+	if len(job.Args) > 3 {
+		tag = job.Args[3]
+	}
+
+	if par, err := s.LookupImage(parent); err == nil && par != nil {
+		if img, err := s.LookupImage(name); err == nil && img != nil {
+
+			driver := s.graph.Driver()
+
+			fs, err := driver.Diff(img.ID, par.ID)
+			if err != nil {
+				return job.Error(err)
+			}
+			defer fs.Close()
+
+			img, err := s.graph.Create(fs, img.Container, par.ID, "Flattened from parent "+par.ID+" to "+img.ID, img.Author, &img.ContainerConfig, img.Config)
+			if err != nil {
+				return job.Error(err)
+			}
+			// Optionally register the image at REPO/TAG
+			if repo != "" {
+				if err := s.Set(repo, tag, img.ID, true); err != nil {
+					return job.Error(err)
+				}
+			}
+			job.Stdout.Write(sf.FormatStatus("", img.ID))
+
+			return engine.StatusOK
+		}
+	}
+	return job.Errorf("No such image: %s", name)
+}

--- a/graph/service.go
+++ b/graph/service.go
@@ -23,6 +23,7 @@ func (s *TagStore) Install(eng *engine.Engine) error {
 		"viz":            s.CmdViz,
 		"load":           s.CmdLoad,
 		"import":         s.CmdImport,
+		"flatten":        s.CmdFlatten,
 		"pull":           s.CmdPull,
 		"push":           s.CmdPush,
 	} {


### PR DESCRIPTION
Please review, it implements basic flattening of layers, suitable for improvements of build process.

Example of flattening, It builds a new temporary image with many layers using Dockerfile and then it creates a single-layer new image that is diff from parent to the temporary image and uses settings from it:

cat Dockerfile | \
docker build --rm -t temporary:tag - && \
docker flatten parent:tag temporary:tag parent:newtag && \
docker rmi -f temporary:tag
