### PR TITLE
Setting iptables=false should propagate to ip-masq=false

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -731,7 +731,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		return nil, fmt.Errorf("You specified --iptables=false with --icc=false. ICC uses iptables to function. Please set --icc or --iptables to true.")
 	}
 	if !config.EnableIptables && config.EnableIpMasq {
-		return nil, fmt.Errorf("You specified --iptables=false with --ipmasq=true. IP masquerading uses iptables to function. Please set --ipmasq to false or --iptables to true.")
+		config.EnableIpMasq = false
 	}
 	config.DisableNetwork = config.BridgeIface == disableNetworkBridge
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -82,3 +82,13 @@ func TestDaemonRestartWithVolumesRefs(t *testing.T) {
 
 	logDone("daemon - volume refs are restored")
 }
+
+func TestDaemonStartIptablesFalse(t *testing.T) {
+	d := NewDaemon(t)
+	if err := d.Start("--iptables=false"); err != nil {
+		t.Fatalf("we should have been able to start the daemon with passing iptables=false: %v", err)
+	}
+	d.Stop()
+
+	logDone("daemon - started daemon with iptables=false")
+}


### PR DESCRIPTION
Setting iptables=false should propagate to ip-masq=false

Closes #8611 

Signed-off-by: Jessica Frazelle jess@docker.com
