### PR TITLE
Correct error message with --ip-masq=true and --iptables=false

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -731,7 +731,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		return nil, fmt.Errorf("You specified --iptables=false with --icc=false. ICC uses iptables to function. Please set --icc or --iptables to true.")
 	}
 	if !config.EnableIptables && config.EnableIpMasq {
-		return nil, fmt.Errorf("You specified --iptables=false with --ipmasq=true. IP masquerading uses iptables to function. Please set --ipmasq to false or --iptables to true.")
+		return nil, fmt.Errorf("You specified --iptables=false with --ip-masq=true. IP masquerading uses iptables to function. Please set --ip-masq to false or --iptables to true.")
 	}
 	config.DisableNetwork = config.BridgeIface == disableNetworkBridge
 


### PR DESCRIPTION
The error message when --iptables=false but --ip-masq is true is wrong
because it tells the user to use --ipmasq instead of --ipmasq. This
commit fixes that.
