### PR TITLE
fixed the -it example

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -640,7 +640,7 @@ This will create a container named `ubuntu_bash` and start a Bash session.
 This will create a new file `/tmp/execWorks` inside the running container
 `ubuntu_bash`, in the background.
 
-    $ sudo docker exec ubuntu_bash -it bash
+    $ sudo docker exec -it ubuntu_bash bash
 
 This will create a new Bash session in the container `ubuntu_bash`.
 


### PR DESCRIPTION
```
jijo@jijo:~$ sudo docker exec ubuntu_bash -it bash
2014/10/16 20:31:02 docker-exec: failed to exec: exec: "-it": executable file not found in $PATH

jijo@jijo:~$ sudo docker exec -it ubuntu_bash bash
root@ff5017acc959:/#
```
