### PR TITLE
Make sure that if a container can't start we set the exitcode to non-zero value

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -298,6 +298,10 @@ func (container *Container) Start() (err error) {
 	defer func() {
 		if err != nil {
 			container.setError(err)
+			// if no one else has set it, make sure we don't leave it at zero
+			if container.ExitCode == 0 {
+				container.ExitCode = 128
+			}
 			container.toDisk()
 			container.cleanup()
 		}

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -138,6 +138,7 @@ func (m *containerMonitor) Start() error {
 			// if we receive an internal error from the initial start of a container then lets
 			// return it instead of entering the restart loop
 			if m.container.RestartCount == 0 {
+				m.container.ExitCode = exitStatus
 				m.resetContainer(false)
 
 				return err
@@ -163,10 +164,12 @@ func (m *containerMonitor) Start() error {
 			// we need to check this before reentering the loop because the waitForNextRestart could have
 			// been terminated by a request from a user
 			if m.shouldStop {
+				m.container.ExitCode = exitStatus
 				return err
 			}
 			continue
 		}
+		m.container.ExitCode = exitStatus
 		m.container.LogEvent("die")
 		m.resetContainer(true)
 		return err

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2503,3 +2503,33 @@ func TestRunAllowPortRangeThroughExpose(t *testing.T) {
 	}
 	logDone("run - allow port range through --expose flag")
 }
+
+func TestRunUnknownCommand(t *testing.T) {
+	defer deleteAllContainers()
+	runCmd := exec.Command(dockerBinary, "create", "busybox", "/bin/nada")
+	cID, _, _, err := runCommandWithStdoutStderr(runCmd)
+	if err != nil {
+		t.Fatalf("Failed to create container: %v, output: %q", err, cID)
+	}
+	cID = strings.TrimSpace(cID)
+
+	runCmd = exec.Command(dockerBinary, "start", cID)
+	_, _, _, err = runCommandWithStdoutStderr(runCmd)
+	if err == nil {
+		t.Fatalf("Container should not have been able to start!")
+	}
+
+	runCmd = exec.Command(dockerBinary, "inspect", "--format={{.State.ExitCode}}", cID)
+	rc, _, _, err2 := runCommandWithStdoutStderr(runCmd)
+	rc = strings.TrimSpace(rc)
+
+	if err2 != nil {
+		t.Fatalf("Error getting status of container: %v", err2)
+	}
+
+	if rc != "-1" {
+		t.Fatalf("ExitCode(%v) was supposed to be -1", rc)
+	}
+
+	logDone("run - Unknown Command")
+}


### PR DESCRIPTION
See #8379 - if the container doesn't start I added code to make sure that if no other processing sets the
container.exitCode to a non-zero value when we make sure its done before we return.  I also made sure that while trying to start the CMD/ENTRYPOINT, if it fails, then we set the container.exitCode to the exitStatus from the exec().

Closes #8379

Signed-off-by: Doug Davis dug@us.ibm.com
