### PR TITLE
Fix lxc driver build issue on Mac OS X

### DIFF
--- a/daemon/execdriver/lxc/lxc_init_unsupported.go
+++ b/daemon/execdriver/lxc/lxc_init_unsupported.go
@@ -2,12 +2,10 @@
 
 package lxc
 
-import "github.com/docker/docker/daemon/execdriver"
-
 func setHostname(hostname string) error {
 	panic("Not supported on darwin")
 }
 
-func finalizeNamespace(args *execdriver.InitArgs) error {
+func finalizeNamespace(args *InitArgs) error {
 	panic("Not supported on darwin")
 }


### PR DESCRIPTION
Make the finalizeNamespace() in lxc_init_unsupported.go use the correct argument as lxc_init_linux.go, fix following build error on Mac OS X
./lxc_init_unsupported.go:11: undefined: execdriver.InitArgs
