### PR TITLE
Cleanup: Removed unused function layerArchive

### DIFF
--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -79,15 +79,6 @@ func cleanup(eng *engine.Engine, t *testing.T) error {
 	return nil
 }
 
-func layerArchive(tarfile string) (io.Reader, error) {
-	// FIXME: need to close f somewhere
-	f, err := os.Open(tarfile)
-	if err != nil {
-		return nil, err
-	}
-	return f, nil
-}
-
 func init() {
 	// Always use the same driver (vfs) for all integration tests.
 	// To test other drivers, we need a dedicated driver validation suite.


### PR DESCRIPTION
layerArchive() was created in aaaf3f072601923594754e46c1f0152847d9c2d9 with two calls.

both calls removed in de753d5a90282bec8dbefac1e5922fe6368a39f7.

Never referenced anywhere else. 

Signed-off-by: Blake Geno blakegeno@gmail.com
