### PR TITLE
Add mention of e2fsprogs to runtime dependencies.

### DIFF
--- a/hack/PACKAGERS.md
+++ b/hack/PACKAGERS.md
@@ -267,6 +267,7 @@ installed and available at runtime:
 
 * iptables version 1.4 or later
 * procps (or similar provider of a "ps" executable)
+* e2fsprogs version 1.4.12 or later (in use: mkfs.ext4, mkfs.xfs, tune2fs)
 * XZ Utils version 4.9 or later
 * a [properly
   mounted](https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount)


### PR DESCRIPTION
Followup mentioned by @tianon in
  https://github.com/docker/docker/pull/7698#issuecomment-55348177

Signed-off-by: Marc Tamsky <tamsky@users.noreply.github.com> (github: tamsky)
