### PR TITLE
Update docker_remote_api.md

### DIFF
--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -8,8 +8,10 @@ page_keywords: API, Docker, rcli, REST, documentation
    and the client must have `root` access to interact with the daemon.
  - If the Docker daemon is set to use an encrypted TCP socket (`--tls`,
    or `--tlsverify`) as with Boot2Docker 1.3.0, then you need to add extra
-   parameters to `curl` when making test API requests:
+   parameters to `curl` or `wget` when making test API requests:
    `curl --insecure --cert ~/.docker/cert.pem --key ~/.docker/key.pem https://boot2docker:2376/images/json`
+   or 
+   `wget --no-check-certificate --certificate=$DOCKER_CERT_PATH/cert.pem --private-key=$DOCKER_CERT_PATH/key.pem https://boot2docker:2376/images/json -O - -q`
  - If a group named `docker` exists on your system, docker will apply
    ownership of the socket to the group.
  - The API tends to be REST, but for some complex commands, like attach


### PR DESCRIPTION
alternate command using wget (curl seems broken on OSX Mavericks, see https://gist.github.com/ndeloof/a8d61f387a2a048e03be
