### PR TITLE
Fixed a minor docs issue in a Dockerfile Example

### DIFF
--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -642,7 +642,7 @@ For example you might add something like this:
 
     # Install vnc, xvfb in order to create a 'fake' display and firefox
     RUN apt-get update && apt-get install -y x11vnc xvfb firefox
-    RUN mkdir /.vnc
+    RUN mkdir ~/.vnc
     # Setup a password
     RUN x11vnc -storepasswd 1234 ~/.vnc/passwd
     # Autostart firefox (might not be the best way, but it does the trick)


### PR DESCRIPTION
The Dockerfile Instruction to create the .vnc directory results in a failure :
-storepasswd failed for file: /root/.vnc/passwd

Signed-off-by: Madhu Venugopal madhu@socketplane.io
