### PR TITLE
Cleanup Removed unused function GetMap in opts/opts.go

### DIFF
--- a/opts/opts.go
+++ b/opts/opts.go
@@ -89,19 +89,8 @@ func (opts *ListOpts) Delete(key string) {
 	}
 }
 
-// GetMap returns the content of values in a map in order to avoid
-// duplicates.
-// FIXME: can we remove this?
-func (opts *ListOpts) GetMap() map[string]struct{} {
-	ret := make(map[string]struct{})
-	for _, k := range *opts.values {
-		ret[k] = struct{}{}
-	}
-	return ret
-}
 
 // GetAll returns the values' slice.
-// FIXME: Can we remove this?
 func (opts *ListOpts) GetAll() []string {
 	return (*opts.values)
 }

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -89,7 +89,6 @@ func (opts *ListOpts) Delete(key string) {
 	}
 }
 
-
 // GetAll returns the values' slice.
 func (opts *ListOpts) GetAll() []string {
 	return (*opts.values)


### PR DESCRIPTION
opts/opts.go:

GetMap() removed

in refactor 1ba11384bf82f824b0efbab31aaca439cfba1b4f:
- GetMap() was moved into opts.go
- A fixme tag was added questioning whether GetMap() could be removed
- All other references to GetMap() in files modifed refer to flVolumes.GetMap()

Currently: 
- Only references to anything called GetMap in the entire project are to flVolumes.GetMap() in runconfig.go, 
  which points to opts.ValidatePath() 
- Conclusion: opts.GetMap() no longer needed 

GetAll "FIXME: Can we remove this?" removed:
- Fixme tag added in same commit as above.
- opts.GetAll called several times in parse.go, (196, 335, 354....)

opts.GetAll() appears to still be needed

Signed-off-by: Blake Geno blakegeno@gmail.com
