### PR TITLE
Port number 49153(BeginPortRange) would be returned twice, causing dupli...

### DIFF
--- a/daemon/networkdriver/portallocator/portallocator.go
+++ b/daemon/networkdriver/portallocator/portallocator.go
@@ -14,7 +14,7 @@ type portMap struct {
 
 func newPortMap() *portMap {
 	return &portMap{
-		p: map[int]struct{}{},
+		p:    map[int]struct{}{},
 		last: EndPortRange,
 	}
 }

--- a/daemon/networkdriver/portallocator/portallocator.go
+++ b/daemon/networkdriver/portallocator/portallocator.go
@@ -15,6 +15,7 @@ type portMap struct {
 func newPortMap() *portMap {
 	return &portMap{
 		p: map[int]struct{}{},
+		last: EndPortRange,
 	}
 }
 
@@ -135,12 +136,6 @@ func ReleaseAll() error {
 }
 
 func (pm *portMap) findPort() (int, error) {
-	if pm.last == 0 {
-		pm.p[BeginPortRange] = struct{}{}
-		pm.last = BeginPortRange
-		return BeginPortRange, nil
-	}
-
 	for port := pm.last + 1; port != pm.last; port++ {
 		if port > EndPortRange {
 			port = BeginPortRange

--- a/daemon/networkdriver/portallocator/portallocator_test.go
+++ b/daemon/networkdriver/portallocator/portallocator_test.go
@@ -214,3 +214,19 @@ func TestPortAllocation(t *testing.T) {
 		t.Fatal("Requesting a dynamic port should never allocate a used port")
 	}
 }
+
+func TestNoDuplicateBPR(t *testing.T) {
+	defer reset()
+
+	if port, err := RequestPort(defaultIP, "tcp", BeginPortRange); err != nil {
+		t.Fatal(err)
+	} else if port != BeginPortRange {
+		t.Fatalf("Expected port %d got %d", BeginPortRange, port)
+	}
+
+	if port, err := RequestPort(defaultIP, "tcp", 0); err != nil {
+		t.Fatal(err)
+	} else if port == BeginPortRange {
+		t.Fatalf("Acquire(0) allocated the same port twice: %d", port)
+	}
+}


### PR DESCRIPTION
...cation and potential errors.

If we first request port 49153 (BeginPortRange) explicitly, and later some time request the next free port (of same ip/proto) by calling RequestPort() with port number 0, we will again get 49153 returned, even if it's currently in use. Because findPort() blindly retured BeginPortRange the first run, without checking if it has already been taken.
