### PR TITLE
DOCKER_VERSION and docker-version havn't been implemented.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-docker-version	0.6.1
 FROM	ubuntu:14.04
 MAINTAINER	Tianon Gravi <admwiggin@gmail.com> (@tianon)
 

--- a/builder/parser/testfiles/docker/Dockerfile
+++ b/builder/parser/testfiles/docker/Dockerfile
@@ -23,7 +23,6 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-docker-version	0.6.1
 FROM	ubuntu:14.04
 MAINTAINER	Tianon Gravi <admwiggin@gmail.com> (@tianon)
 

--- a/builder/parser/testfiles/docker/result
+++ b/builder/parser/testfiles/docker/result
@@ -1,4 +1,3 @@
-(docker-version)
 (from "ubuntu:14.04")
 (maintainer "Tianon Gravi <admwiggin@gmail.com> (@tianon)")
 (run "apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -yq 	apt-utils 	aufs-tools 	automake 	btrfs-tools 	build-essential 	curl 	dpkg-sig 	git 	iptables 	libapparmor-dev 	libcap-dev 	libsqlite3-dev 	lxc=1.0* 	mercurial 	pandoc 	parallel 	reprepro 	ruby1.9.1 	ruby1.9.1-dev 	s3cmd=1.1.0* 	--no-install-recommends")

--- a/contrib/desktop-integration/chromium/Dockerfile
+++ b/contrib/desktop-integration/chromium/Dockerfile
@@ -20,8 +20,6 @@
 #   docker run --volumes-from chromium-data -v /tmp/.X11-unix:/tmp/.X11-unix \
 #   -e DISPLAY=unix$DISPLAY chromium
 
-DOCKER_VERSION 1.3
-
 # Base docker image
 FROM debian:jessie
 MAINTAINER Jessica Frazelle <jess@docker.com>

--- a/contrib/desktop-integration/gparted/Dockerfile
+++ b/contrib/desktop-integration/gparted/Dockerfile
@@ -17,8 +17,6 @@
 #     -e DISPLAY=unix$DISPLAY gparted
 #
 
-DOCKER-VERSION 1.3
-
 # Base docker image
 FROM debian:jessie
 MAINTAINER Jessica Frazelle <jess@docker.com>

--- a/contrib/host-integration/Dockerfile.dev
+++ b/contrib/host-integration/Dockerfile.dev
@@ -2,8 +2,6 @@
 # This Dockerfile will create an image that allows to generate upstart and
 # systemd scripts (more to come)
 #
-# docker-version 0.6.2
-#
 
 FROM		ubuntu:12.10
 MAINTAINER	Guillaume J. Charmes <guillaume@docker.com>

--- a/docs/sources/examples/nodejs_web_app.md
+++ b/docs/sources/examples/nodejs_web_app.md
@@ -59,12 +59,8 @@ Create an empty file called `Dockerfile`:
     touch Dockerfile
 
 Open the `Dockerfile` in your favorite text editor
-and add the following line that defines the version of Docker the image
-requires to build (this example uses Docker 0.3.4):
 
-    # DOCKER-VERSION 0.3.4
-
-Next, define the parent image you want to use to build your own image on
+Define the parent image you want to use to build your own image on
 top of. Here, we'll use
 [CentOS](https://registry.hub.docker.com/_/centos/) (tag: `centos6`)
 available on the [Docker Hub](https://hub.docker.com/):
@@ -108,7 +104,6 @@ defines your runtime, i.e. `node`, and the path to our app, i.e. `src/index.js`
 
 Your `Dockerfile` should now look like this:
 
-    # DOCKER-VERSION 0.3.4
     FROM    centos:centos6
 
     # Enable EPEL for Node.js


### PR DESCRIPTION
So far, it looks like the declarations are not used, and so its safer not to
confuse people into thinking they do something.

Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@docker.com (github: SvenDowideit)

@tianon when was the last time someone made sure that our main `Dockerfile` worked on Docker 0.6.1, and are we really intending to send that message?

@jfrazelle are you suggesting that your Dockerfiles cannot be used with older Docker daemons? - and which is it :) (I know where these came from)

@me - seriously, do you really thing Docker 0.3 is something we want to bring up in the docs?

On a serious note - is this INSTRUCTION being worked on, in which case I'll reduce the scope to the documentation examples, where its distracting, or can we move on?

@crosbymichael feel free to yell at me about busting the cache - maybe we can use the golang:1.3-onbuild image - its only 1.5GB big >:+
