### PR TITLE
fixed the way of iterating over the range of map.

### DIFF
--- a/daemon/networkdriver/ipallocator/allocator.go
+++ b/daemon/networkdriver/ipallocator/allocator.go
@@ -129,7 +129,10 @@ func (allocated *allocatedMap) checkIP(ip net.IP) (net.IP, error) {
 // return an available ip if one is currently available.  If not,
 // return the next available ip for the nextwork
 func (allocated *allocatedMap) getNextIP() (net.IP, error) {
-	for pos := big.NewInt(0).Add(allocated.last, big.NewInt(1)); pos.Cmp(allocated.last) != 0; pos.Add(pos, big.NewInt(1)) {
+	pos := big.NewInt(0).Set(allocated.last)
+	allRange := big.NewInt(0).Sub(allocated.end, allocated.begin)
+	for i := big.NewInt(0); i.Cmp(allRange) <= 0; i.Add(i, big.NewInt(1)) {
+		pos.Add(pos, big.NewInt(1))
 		if pos.Cmp(allocated.end) == 1 {
 			pos.Set(allocated.begin)
 		}

--- a/daemon/networkdriver/portallocator/portallocator.go
+++ b/daemon/networkdriver/portallocator/portallocator.go
@@ -136,7 +136,9 @@ func ReleaseAll() error {
 }
 
 func (pm *portMap) findPort() (int, error) {
-	for port := pm.last + 1; port != pm.last; port++ {
+	port := pm.last
+	for i := 0; i <= EndPortRange-BeginPortRange; i++ {
+		port++
 		if port > EndPortRange {
 			port = BeginPortRange
 		}

--- a/daemon/networkdriver/portallocator/portallocator_test.go
+++ b/daemon/networkdriver/portallocator/portallocator_test.go
@@ -134,6 +134,19 @@ func TestAllocateAllPorts(t *testing.T) {
 	if newPort != port {
 		t.Fatalf("Expected port %d got %d", port, newPort)
 	}
+
+	// now pm.last == newPort, release it so that it's the only free port of
+	// the range, and ensure we get it back
+	if err := ReleasePort(defaultIP, "tcp", newPort); err != nil {
+		t.Fatal(err)
+	}
+	port, err = RequestPort(defaultIP, "tcp", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newPort != port {
+		t.Fatalf("Expected port %d got %d", newPort, port)
+	}
 }
 
 func BenchmarkAllocatePorts(b *testing.B) {


### PR DESCRIPTION
Fixed the following errors:
1. Request(0) causes a dead loop when the map is full and map.last == BEGIN.
2. When map.last is the only available port (or ip), Request(0) returns ErrAllPortsAllocated (or ErrNoAvailableIPs). Exception is when map.last == BEGIN.

Signed-off-by: shuai-z zs.broccoli@gmail.com
