### PR TITLE
contrib/install.sh: remove pull of hello-world

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -85,7 +85,7 @@ case "$lsb_dist" in
 		if command_exists docker && [ -e /var/run/docker.sock ]; then
 			(
 				set -x
-				$sh_c 'docker run --rm hello-world'
+				$sh_c 'docker version'
 			) || true
 		fi
 		your_user=your-user
@@ -162,7 +162,7 @@ case "$lsb_dist" in
 		if command_exists docker && [ -e /var/run/docker.sock ]; then
 			(
 				set -x
-				$sh_c 'docker run --rm hello-world'
+				$sh_c 'docker version'
 			) || true
 		fi
 		your_user=your-user


### PR DESCRIPTION
This removes the pull of the hello-world image from install.sh to address privacy concerns.

Fixes #8512
