### PR TITLE
Fix an endian bug for the ioctl argument

### DIFF
--- a/vendor/src/github.com/docker/libcontainer/console/console.go
+++ b/vendor/src/github.com/docker/libcontainer/console/console.go
@@ -67,14 +67,14 @@ func OpenAndDup(consolePath string) error {
 // Unlockpt unlocks the slave pseudoterminal device corresponding to the master pseudoterminal referred to by f.
 // Unlockpt should be called before opening the slave side of a pseudoterminal.
 func Unlockpt(f *os.File) error {
-	var u int
+	var u int32
 
 	return Ioctl(f.Fd(), syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
 }
 
 // Ptsname retrieves the name of the first available pts for the given master.
 func Ptsname(f *os.File) (string, error) {
-	var n int
+	var n int32
 
 	if err := Ioctl(f.Fd(), syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n))); err != nil {
 		return "", err


### PR DESCRIPTION
The third argument of these ioctl calls must be an 32-bit integer, but 64-bit integers are used instead. This code works only on little-endian architectures, but not on big-endian architectures.

This patch fixes the size of the integer variables, and works with both endians.

Signed-off-by: Yohei Ueda yohei@jp.ibm.com
