### PR TITLE
Correct url from github.com/dotcloud/docker{,-py}

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ When considering a design proposal, we are looking for:
 * A description of the problem this design proposal solves
 * An issue -- not a pull request -- that describes what you will take action on
   * Please prefix your issue with `Proposal:` in the title
-* Please review [the existing Proposals](https://github.com/dotcloud/docker/issues?direction=asc&labels=Proposal&page=1&sort=created&state=open)
+* Please review [the existing Proposals](https://github.com/docker/docker/issues?direction=asc&labels=Proposal&page=1&sort=created&state=open)
   before reporting a new issue. You can always pair with someone if you both
   have the same idea.
 

--- a/docs/sources/reference/api/remote_api_client_libraries.md
+++ b/docs/sources/reference/api/remote_api_client_libraries.md
@@ -131,7 +131,7 @@ will add the libraries here.
     <tr class="row-odd">
       <td>Python</td>
       <td>docker-py</td>
-      <td><a class="reference external" href="https://github.com/dotcloud/docker-py">https://github.com/dotcloud/docker-py</a></td>
+      <td><a class="reference external" href="https://github.com/docker/docker-py">https://github.com/docker/docker-py</a></td>
       <td>Active</td>
     </tr>
     <tr class="row-even">


### PR DESCRIPTION
to github.com/docker/docker{,-py}

Signed-off-by: Torstein Husebø torstein@huseboe.net
