### PR TITLE
Cleanup docs Dockerfile, so it matches best practices.

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,49 +1,59 @@
 #
 # See the top level Makefile in https://github.com/docker/docker for usage.
 #
-FROM 		debian:jessie
-MAINTAINER	Sven Dowideit <SvenDowideit@docker.com> (@SvenDowideit)
+FROM debian:jessie
+MAINTAINER Sven Dowideit <SvenDowideit@docker.com> (@SvenDowideit)
 
-RUN 	apt-get update && apt-get install -y make python-pip python-setuptools vim-tiny git gettext python-dev libssl-dev
+RUN apt-get update \
+	&& apt-get install -y \
+		gettext \
+		git \
+		libssl-dev \
+		make \
+		python-dev \
+		python-pip \
+		python-setuptools \
+		vim-tiny
 
-RUN	pip install mkdocs
+RUN pip install mkdocs
 
 # add MarkdownTools to get transclusion
 # (future development)
-#RUN	easy_install -U setuptools
-#RUN	pip install MarkdownTools2
+#RUN easy_install -U setuptools
+#RUN pip install MarkdownTools2
 
 # this version works, the current versions fail in different ways
-RUN	pip install awscli==1.4.4 pyopenssl==0.12
-
-# make sure the git clone is not an old cache - we've published old versions a few times now
-ENV	CACHE_BUST Jul2014
+RUN pip install awscli==1.4.4 pyopenssl==0.12
 
 # get my sitemap.xml branch of mkdocs and use that for now
-RUN	git clone https://github.com/SvenDowideit/mkdocs	&&\
-	cd mkdocs/						&&\
-	git checkout docker-markdown-merge			&&\
-	./setup.py install
+# commit hash of the newest commit of SvenDowideit/mkdocs on
+# docker-markdown-merge branch, it is used to break docker cache
+# see: https://github.com/SvenDowideit/mkdocs/tree/docker-markdown-merge
+RUN git clone -b docker-markdown-merge https://github.com/SvenDowideit/mkdocs \
+	&& cd mkdocs/ \
+	&& git checkout ad32549c452963b8854951d6783f4736c0f7c5d5 \
+	&& ./setup.py install
 
-ADD 	. /docs
-ADD	MAINTAINERS /docs/sources/humans.txt
-WORKDIR	/docs
+COPY . /docs
+COPY MAINTAINERS /docs/sources/humans.txt
+WORKDIR /docs
 
-RUN	VERSION=$(cat /docs/VERSION)								&&\
-        MAJOR_MINOR="${VERSION%.*}"								&&\
-	for i in $(seq $MAJOR_MINOR -0.1 1.0) ; do echo "<li><a class='version' href='/v$i'>Version v$i</a></li>" ; done > /docs/sources/versions.html_fragment &&\
-	GIT_BRANCH=$(cat /docs/GIT_BRANCH)							&&\
-	GITCOMMIT=$(cat /docs/GITCOMMIT)							&&\
-	AWS_S3_BUCKET=$(cat /docs/AWS_S3_BUCKET)						&&\
-	BUILD_DATE=$(date)									&&\
-	sed -i "s/\$VERSION/$VERSION/g" /docs/theme/mkdocs/base.html				&&\
-	sed -i "s/\$MAJOR_MINOR/v$MAJOR_MINOR/g" /docs/theme/mkdocs/base.html			&&\
-	sed -i "s/\$GITCOMMIT/$GITCOMMIT/g" /docs/theme/mkdocs/base.html			&&\
-	sed -i "s/\$GIT_BRANCH/$GIT_BRANCH/g" /docs/theme/mkdocs/base.html			&&\
-	sed -i "s/\$BUILD_DATE/$BUILD_DATE/g" /docs/theme/mkdocs/base.html				&&\
-	sed -i "s/\$AWS_S3_BUCKET/$AWS_S3_BUCKET/g" /docs/theme/mkdocs/base.html
+RUN VERSION=$(cat VERSION) \
+	&& MAJOR_MINOR="${VERSION%.*}" \
+	&& for i in $(seq $MAJOR_MINOR -0.1 1.0); do \
+		echo "<li><a class='version' href='/v$i'>Version v$i</a></li>"; \
+	done > sources/versions.html_fragment \
+	&& GIT_BRANCH=$(cat GIT_BRANCH) \
+	&& GITCOMMIT=$(cat GITCOMMIT) \
+	&& AWS_S3_BUCKET=$(cat AWS_S3_BUCKET) \
+	&& BUILD_DATE=$(date) \
+	&& sed -i "s/\$VERSION/$VERSION/g" theme/mkdocs/base.html \
+	&& sed -i "s/\$MAJOR_MINOR/v$MAJOR_MINOR/g" theme/mkdocs/base.html \
+	&& sed -i "s/\$GITCOMMIT/$GITCOMMIT/g" .heme/mkdocs/base.html \
+	&& sed -i "s/\$GIT_BRANCH/$GIT_BRANCH/g" theme/mkdocs/base.html \
+	&& sed -i "s/\$BUILD_DATE/$BUILD_DATE/g" theme/mkdocs/base.html \
+	&& sed -i "s/\$AWS_S3_BUCKET/$AWS_S3_BUCKET/g" theme/mkdocs/base.html
 
-# note, EXPOSE is only last because of https://github.com/docker/docker/issues/3525
-EXPOSE	8000
+EXPOSE 8000
 
-CMD 	["mkdocs", "serve"]
+CMD ["mkdocs", "serve"]


### PR DESCRIPTION
- Cleanup spacing throughout
- swap `&&` to beginning of lines to improve readability
- better cache busting for the SvenDowideit/mkdocs repo based on git commit id
- take advantage of the `WORKDIR`

Thanks to @tianon for the review so far :smile:.

I made this and realized I had included the same changes as @jfrazelle in #8715, but I think this adds a few more tweaks to make it more readable.
