### PR TITLE
TestRunRedirectStdout kept failing with timed out.

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2266,7 +2266,7 @@ func TestRunRedirectStdout(t *testing.T) {
 		}()
 
 		select {
-		case <-time.After(time.Second):
+		case <-time.After(2 * time.Second):
 			t.Fatal("command timeout")
 		case <-ch:
 		}


### PR DESCRIPTION
So I really don't like this fix, but I could not get this test to pass consistently and with this change I ran it on a loop 100 times with success. Open to any other ideas to fix.

Docker-DCO-1.1-Signed-off-by: Jessica Frazelle jess@docker.com (github: jfrazelle)
