### PR TITLE
Up test timeout to 10s based on recent drone.io timeout failures

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2266,7 +2266,7 @@ func TestRunRedirectStdout(t *testing.T) {
 		}()
 
 		select {
-		case <-time.After(2 * time.Second):
+		case <-time.After(10 * time.Second):
 			t.Fatal("command timeout")
 		case <-ch:
 		}


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
