### PR TITLE
daemon: fix /dev/console getting mknod'd

### DIFF
--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -132,6 +132,19 @@ func (d *driver) setPrivileged(container *libcontainer.Config) (err error) {
 	if err != nil {
 		return err
 	}
+
+	// remove /dev/console from the mknod list
+	// since /dev/console might be a pts and items from
+	// the devpts fs are unusable if mknod'd
+	i := 0
+	for i < len(hostDeviceNodes) {
+		if hostDeviceNodes[i].Path == "/dev/console" {
+			hostDeviceNodes = append(hostDeviceNodes[:i], hostDeviceNodes[i+1:]...)
+		} else {
+			i = i + 1
+		}
+	}
+
 	container.MountConfig.DeviceNodes = hostDeviceNodes
 
 	container.RestrictSys = false


### PR DESCRIPTION
Fixed setPrivileged() so it won't add /dev/console to the device node
list.

This fixes an issue where containers wouldn't start if
/dev/console is a pts (which is the case when running docker inside
docker), because devpts inodes are special and cannot be created with
mknod: attempting to open the result of doing so will return EIO.

Since later libcontainer would attempt to open the file to mount --bind
over it and fail because of the EIO error, the container wouldn't start
if the /dev/console was a pts, which is the case inside a docker
that was started from a pts.

Signed-off-by: Alejandro Ojeda alex@x3y.org
## 

This patch fixes the following issue in dind: https://github.com/jpetazzo/dind/issues/25
This is my first commit here, hopefully I didn't miss anything important.
