### PR TITLE
Do some cleanup on .dockerignore paths

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -143,6 +143,11 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 			return fmt.Errorf("Error reading .dockerignore: '%s'", err)
 		}
 		for _, pattern := range strings.Split(string(ignore), "\n") {
+			pattern = strings.TrimSpace(pattern)
+			if pattern == "" {
+				continue
+			}
+			pattern = filepath.Clean(pattern)
 			ok, err := filepath.Match(pattern, "Dockerfile")
 			if err != nil {
 				return fmt.Errorf("Bad .dockerignore pattern: '%s', error: %s", pattern, err)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2325,6 +2325,29 @@ func TestBuildDockerignore(t *testing.T) {
 	logDone("build - test .dockerignore")
 }
 
+func TestBuildDockerignoreCleanPaths(t *testing.T) {
+	name := "testbuilddockerignorecleanpaths"
+	defer deleteImages(name)
+	dockerfile := `
+        FROM busybox
+        ADD . /tmp/
+        RUN (! ls /tmp/foo) && (! ls /tmp/foo2) && (! ls /tmp/dir1/foo)`
+	ctx, err := fakeContext(dockerfile, map[string]string{
+		"foo":           "foo",
+		"foo2":          "foo2",
+		"dir1/foo":      "foo in dir1",
+		".dockerignore": "./foo\ndir1//foo\n./dir1/../foo2",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctx.Close()
+	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+		t.Fatal(err)
+	}
+	logDone("build - test .dockerignore with clean paths")
+}
+
 func TestBuildDockerignoringDockerfile(t *testing.T) {
 	name := "testbuilddockerignoredockerfile"
 	defer deleteImages(name)
@@ -2334,13 +2357,20 @@ func TestBuildDockerignoringDockerfile(t *testing.T) {
 		"Dockerfile":    "FROM scratch",
 		".dockerignore": "Dockerfile\n",
 	})
-	defer ctx.Close()
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
 	if _, err = buildImageFromContext(name, ctx, true); err == nil {
 		t.Fatalf("Didn't get expected error from ignoring Dockerfile")
 	}
+
+	// now try it with ./Dockerfile
+	ctx.Add(".dockerignore", "./Dockerfile\n")
+	if _, err = buildImageFromContext(name, ctx, true); err == nil {
+		t.Fatalf("Didn't get expected error from ignoring ./Dockerfile")
+	}
+
 	logDone("build - test .dockerignore of Dockerfile")
 }
 


### PR DESCRIPTION
While working on the fix for #8330 I noticed a few things:
1 - the split() call for the .dockerignore process will generate a blank
    "exclude".  While this isn't causing an issue right now, I got worried
    that in the future some code later on might interpret "" as something bad,
    like "everything" or ".".  So I added a check for an empty "exclude"
    and skipped it
2 - if someone puts "foo" in their .dockerignore then we'll skip "foo".
    However, if they put "./foo" then we won't due to the painfully
    simplistic logic of go's filepath.Match algorithm.  To help things
    a little (and to treat ./Dockerfile just like Dockerfile) I added
    code to filepath.Clean() each entry in .dockerignore.  It should
    result in the same semantic path but ensure that no matter how the
    user expresses the path, we'll match it.

Signed-off-by: Doug Davis dug@us.ibm.com
