### PR TITLE
do not send hostconfig at start, as we do on create now

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2289,7 +2289,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	}
 
 	//start the container
-	if _, _, err = readBody(cli.call("POST", "/containers/"+runResult.Get("Id")+"/start", hostConfig, false)); err != nil {
+	if _, _, err = readBody(cli.call("POST", "/containers/"+runResult.Get("Id")+"/start", nil, false)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Victor Vieux vieux@docker.com
