### PR TITLE
builder: some small fixups + fix a bug where empty entrypoints would not override inheritance.

### DIFF
--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -195,7 +195,7 @@ func run(b *Builder, args []string, attributes map[string]bool, original string)
 
 	defer func(cmd []string) { b.Config.Cmd = cmd }(cmd)
 
-	log.Debugf("Command to be executed: %v", b.Config.Cmd)
+	log.Debugf("[BUILDER] Command to be executed: %v", b.Config.Cmd)
 
 	hit, err := b.probeCache()
 	if err != nil {
@@ -261,14 +261,14 @@ func entrypoint(b *Builder, args []string, attributes map[string]bool, original 
 	parsed := handleJsonArgs(args, attributes)
 
 	switch {
-	case len(parsed) == 0:
-		// ENTYRPOINT []
-		b.Config.Entrypoint = nil
 	case attributes["json"]:
 		// ENTRYPOINT ["echo", "hi"]
 		b.Config.Entrypoint = parsed
+	case len(parsed) == 0:
+		// ENTRYPOINT []
+		b.Config.Entrypoint = nil
 	default:
-		// ENTYRPOINT echo hi
+		// ENTRYPOINT echo hi
 		b.Config.Entrypoint = []string{"/bin/sh", "-c", parsed[0]}
 	}
 

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -149,7 +149,7 @@ func (b *Builder) Run(context io.Reader) (string, error) {
 	b.dockerfile = ast
 
 	// some initializations that would not have been supplied by the caller.
-	b.Config = &runconfig.Config{Entrypoint: []string{}, Cmd: nil}
+	b.Config = &runconfig.Config{}
 	b.TmpContainers = map[string]struct{}{}
 
 	for i, n := range b.dockerfile.Children {

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -87,9 +87,10 @@ func parseLine(line string) (string, *Node, error) {
 
 	if sexp.Value != "" || sexp.Next != nil || sexp.Children != nil {
 		node.Next = sexp
-		node.Attributes = attrs
-		node.Original = line
 	}
+
+	node.Attributes = attrs
+	node.Original = line
 
 	return "", node, nil
 }

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -1429,6 +1429,49 @@ func TestBuildExpose(t *testing.T) {
 	logDone("build - expose")
 }
 
+func TestBuildEmptyEntrypointInheritance(t *testing.T) {
+	name := "testbuildentrypointinheritance"
+	name2 := "testbuildentrypointinheritance2"
+	defer deleteImages(name, name2)
+
+	_, err := buildImage(name,
+		`FROM busybox
+        ENTRYPOINT ["/bin/echo"]`,
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := inspectField(name, "Config.Entrypoint")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "[/bin/echo]"
+	if res != expected {
+		t.Fatalf("Entrypoint %s, expected %s", res, expected)
+	}
+
+	_, err = buildImage(name2,
+		fmt.Sprintf(`FROM %s
+        ENTRYPOINT []`, name),
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err = inspectField(name2, "Config.Entrypoint")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected = "[]"
+
+	if res != expected {
+		t.Fatalf("Entrypoint %s, expected %s", res, expected)
+	}
+
+	logDone("build - empty entrypoint inheritance")
+}
+
 func TestBuildEmptyEntrypoint(t *testing.T) {
 	name := "testbuildentrypoint"
 	defer deleteImages(name)

--- a/runconfig/merge.go
+++ b/runconfig/merge.go
@@ -88,7 +88,10 @@ func Merge(userConf, imageConf *Config) error {
 		if len(userConf.Cmd) == 0 {
 			userConf.Cmd = imageConf.Cmd
 		}
-		userConf.Entrypoint = imageConf.Entrypoint
+
+		if userConf.Entrypoint == nil {
+			userConf.Entrypoint = imageConf.Entrypoint
+		}
 	}
 	if userConf.WorkingDir == "" {
 		userConf.WorkingDir = imageConf.WorkingDir


### PR DESCRIPTION
closes #8732. I also tacked on some spelling fixes and a formatting change to debug logging. There is a test as well.

The crux of the issue is multi-tiered:
- in the parser, in single word cases (remember, `[]` evaluates to no content), the attributes and "original" line did not propagate to the evaluator.
- in runconfig, merging the image settings into the new builder settings would not distinguish between `nil` and an empty array.
- in the `entrypoint` evaluator, the switch statement would eagerly treat nil and empty arrays as equal regardless of how they were defined.
