### PR TITLE
Builder: Environment replacement fixes

### DIFF
--- a/builder/support.go
+++ b/builder/support.go
@@ -24,8 +24,9 @@ func (b *Builder) replaceEnv(str string) string {
 				continue
 			}
 
+			prefix := match[:idx]
 			stripped := match[idx+2:]
-			str = strings.Replace(str, match, "$"+stripped, -1)
+			str = strings.Replace(str, match, prefix+"$"+stripped, -1)
 			continue
 		}
 


### PR DESCRIPTION
/cc @tiborvass  -- also putting this in the 1.3.1 milestone for posterity.

This is unfinished (needs more tests) but the functionality is here and people could (ideally) help test before I finish this up. There are a lot of tests to write.

This fixes two issues:
- In situations where escaping was used for environment replacement `\${FOO}`, multiple slashes `\\\\\${FOO}` would swallow all of them. Tests are completed for this section, so feel free to pick those apart.
- Several commands, such as ones that call out to the shell, should not be susceptible to environment replacement. This adds a whitelist for several non-shell-commands and incorporates environment replacement on them, skipping if unmatched. This part needs more tests but please feel free to review what's there. I will be adding one commit per test.
