### PR TITLE
Default BINDDIR regardless of DOCKER_HOST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 .PHONY: all binary build cross default docs docs-build docs-shell shell test test-unit test-integration test-integration-cli validate
 
 # to allow `make BINDDIR=. shell` or `make BINDDIR= test`
-# (default to no bind mount if DOCKER_HOST is set)
-BINDDIR := $(if $(DOCKER_HOST),,bundles)
+BINDDIR := bundles
 # to allow `make DOCSPORT=9000 docs`
 DOCSPORT := 8000
 


### PR DESCRIPTION
[Please be merciful as I am new to the Docker community]

I was [setting up the development environment](http://docs.docker.com/contributing/devenvironment/#using-your-built-docker-binary) when I noticed the binary was not available outside of the container - as I use boot2docker.

I am happy to use `BINDDIR=bundles make ...`, but I guess other new developers using boot2docker will be surprised so I wonder if the logic around `DOCKER_HOST` shall be there at all, or whether it shall be more complex (e.g. considering the presence of the `boot2docker` executable and the output of `boot2docker ip`). Hence this pull request.

I [signed off the commit](https://github.com/docker/docker/blob/5631ffbdfd252c369d393e41ee86008ab2d7eb7c/CONTRIBUTING.md#sign-your-work) even if this is a simple revert because otherwise CI fails.
