### PR TITLE
Document regression in pulling aliases

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1084,6 +1084,10 @@ use `docker pull`:
     # manually specifies the path to the default Docker registry. This could
     # be replaced with the path to a local registry to pull from another source.
 
+> **Note:** Due to changes in the registry, `docker pull` will not 
+> automatically pull all aliases of an image. For more information, 
+> see issue [#8689](https://github.com/docker/docker/issues/8689)
+
 ## push
 
     Usage: docker push NAME[:TAG]


### PR DESCRIPTION
Docker pull currently doesn’t pull all aliases of an image. This is a (temporary?) regression caused by changes in the V2 registry, as described in https://github.com/docker/docker/issues/8689

This change adds a note to the documentation about this regression.

Relates to #8689
