### PR TITLE
Falling back to v1 if --registry-mirror is set

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -137,7 +137,7 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 		mirrors = s.mirrors
 	}
 
-	if isOfficial || endpoint.Version == registry.APIVersion2 {
+	if mirrors != nil && (isOfficial || endpoint.Version == registry.APIVersion2) {
 		j := job.Eng.Job("trust_update_base")
 		if err = j.Run(); err != nil {
 			return job.Errorf("error updating trust base graph: %s", err)


### PR DESCRIPTION
Falling back to v1 if --registry-mirror is set.
--registry-mirror is ignored in new V2 pull codepath, official mirror is important.

Ref [#8688](https://github.com/docker/docker/issues/8688)

Signed-off-by: Kay Yan yankaycom@gmail.com
