### PR TITLE
Update ubuntulinux.md

### DIFF
--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -27,6 +27,7 @@ installs Docker 0.9.1 and all its prerequisites from Ubuntu's repository.
 
 To install the latest Ubuntu package (may not be the latest Docker release):
 
+    $ /bin/bash      # the following assumes we are in the bash shell
     $ sudo apt-get update
     $ sudo apt-get install docker.io
     $ sudo ln -sf /usr/bin/docker.io /usr/local/bin/docker


### PR DESCRIPTION
Hi - Installing Docker on my Ubuntu 14.04 LTS failed on the line 

   source /etc/bash_completion.d/docker.io

since this implicitely assumes one is running the BASH shell.  Since I was running ZSH I got the error 

   ~ > source /etc/bash_completion.d/docker.io
   /etc/bash_completion.d/docker.io:679: command not found: complete
   /etc/bash_completion.d/docker.io:680: command not found: complete

I thought we should either update the instructions or modify them to avoid BASH assumptions.  :)

Alan Thompson
