### PR TITLE
Remove `jsonData` argument from `image.StoreImage`

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -132,14 +132,14 @@ func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, contain
 		img.ContainerConfig = *containerConfig
 	}
 
-	if err := graph.Register(img, nil, layerData); err != nil {
+	if err := graph.Register(img, layerData); err != nil {
 		return nil, err
 	}
 	return img, nil
 }
 
 // Register imports a pre-existing image into the graph.
-func (graph *Graph) Register(img *image.Image, jsonData []byte, layerData archive.ArchiveReader) (err error) {
+func (graph *Graph) Register(img *image.Image, layerData archive.ArchiveReader) (err error) {
 	defer func() {
 		// If any error occurs, remove the new dir from the driver.
 		// Don't check for errors since the dir might not have been created.
@@ -181,7 +181,7 @@ func (graph *Graph) Register(img *image.Image, jsonData []byte, layerData archiv
 	}
 	// Apply the diff/layer
 	img.SetGraph(graph)
-	if err := image.StoreImage(img, jsonData, layerData, tmp); err != nil {
+	if err := image.StoreImage(img, layerData, tmp); err != nil {
 		return err
 	}
 	// Commit

--- a/graph/load.go
+++ b/graph/load.go
@@ -118,7 +118,7 @@ func (s *TagStore) recursiveLoad(eng *engine.Engine, address, tmpImageDir string
 				}
 			}
 		}
-		if err := s.graph.Register(img, imageJson, layer); err != nil {
+		if err := s.graph.Register(img, layer); err != nil {
 			return err
 		}
 	}

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -392,7 +392,7 @@ func (s *TagStore) pullImage(r *registry.Session, out io.Writer, imgID, endpoint
 				layers_downloaded = true
 				defer layer.Close()
 
-				err = s.graph.Register(img, imgJSON,
+				err = s.graph.Register(img,
 					utils.ProgressReader(layer, imgSize, out, sf, false, utils.TruncateID(id), "Downloading"))
 				if terr, ok := err.(net.Error); ok && terr.Timeout() && j < retries {
 					time.Sleep(time.Duration(j) * 500 * time.Millisecond)
@@ -577,7 +577,7 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 			defer d.tmpFile.Close()
 			d.tmpFile.Seek(0, 0)
 			if d.tmpFile != nil {
-				err = s.graph.Register(d.img, d.imgJSON,
+				err = s.graph.Register(d.img,
 					utils.ProgressReader(d.tmpFile, int(d.length), out, sf, false, utils.TruncateID(d.img.ID), "Extracting"))
 				if err != nil {
 					return false, err

--- a/graph/service.go
+++ b/graph/service.go
@@ -74,7 +74,7 @@ func (s *TagStore) CmdSet(job *engine.Job) engine.Status {
 	if err != nil {
 		return job.Error(err)
 	}
-	if err := s.graph.Register(img, imgJSON, layer); err != nil {
+	if err := s.graph.Register(img, layer); err != nil {
 		return job.Error(err)
 	}
 	return engine.StatusOK

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -62,7 +62,7 @@ func mkTestTagStore(root string, t *testing.T) *TagStore {
 		t.Fatal(err)
 	}
 	img := &image.Image{ID: testImageID}
-	if err := graph.Register(img, nil, archive); err != nil {
+	if err := graph.Register(img, archive); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.Set(testImageName, "", testImageID, false); err != nil {

--- a/image/image.go
+++ b/image/image.go
@@ -70,7 +70,7 @@ func LoadImage(root string) (*Image, error) {
 	return img, nil
 }
 
-func StoreImage(img *Image, jsonData []byte, layerData archive.ArchiveReader, root string) error {
+func StoreImage(img *Image, layerData archive.ArchiveReader, root string) error {
 	// Store the layer
 	var (
 		size   int64
@@ -90,20 +90,14 @@ func StoreImage(img *Image, jsonData []byte, layerData archive.ArchiveReader, ro
 		return err
 	}
 
-	// If raw json is provided, then use it
-	if jsonData != nil {
-		if err := ioutil.WriteFile(jsonPath(root), jsonData, 0600); err != nil {
-			return err
-		}
-	} else {
-		if jsonData, err = json.Marshal(img); err != nil {
-			return err
-		}
-		if err := ioutil.WriteFile(jsonPath(root), jsonData, 0600); err != nil {
-			return err
-		}
+	f, err := os.OpenFile(jsonPath(root), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(0600))
+	if err != nil {
+		return err
 	}
-	return nil
+
+	defer f.Close()
+
+	return json.NewEncoder(f).Encode(img)
 }
 
 func (img *Image) SetGraph(graph Graph) {

--- a/integration/graph_test.go
+++ b/integration/graph_test.go
@@ -74,7 +74,7 @@ func TestInterruptedRegister(t *testing.T) {
 		Created: time.Now(),
 	}
 	w.CloseWithError(errors.New("But I'm not a tarball!")) // (Nobody's perfect, darling)
-	graph.Register(image, nil, badArchive)
+	graph.Register(image, badArchive)
 	if _, err := graph.Get(image.ID); err == nil {
 		t.Fatal("Image should not exist after Register is interrupted")
 	}
@@ -83,7 +83,7 @@ func TestInterruptedRegister(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := graph.Register(image, nil, goodArchive); err != nil {
+	if err := graph.Register(image, goodArchive); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -133,7 +133,7 @@ func TestRegister(t *testing.T) {
 		Comment: "testing",
 		Created: time.Now(),
 	}
-	err = graph.Register(image, nil, archive)
+	err = graph.Register(image, archive)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -228,7 +228,7 @@ func TestDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Test delete twice (pull -> rm -> pull -> rm)
-	if err := graph.Register(img1, nil, archive); err != nil {
+	if err := graph.Register(img1, archive); err != nil {
 		t.Fatal(err)
 	}
 	if err := graph.Delete(img1.ID); err != nil {
@@ -262,9 +262,9 @@ func TestByParent(t *testing.T) {
 		Created: time.Now(),
 		Parent:  parentImage.ID,
 	}
-	_ = graph.Register(parentImage, nil, archive1)
-	_ = graph.Register(childImage1, nil, archive2)
-	_ = graph.Register(childImage2, nil, archive3)
+	_ = graph.Register(parentImage, archive1)
+	_ = graph.Register(childImage1, archive2)
+	_ = graph.Register(childImage2, archive3)
 
 	byParent, err := graph.ByParent()
 	if err != nil {


### PR DESCRIPTION
The argument specified the json data to save to disk when registering
a new image into the image graph. If it is nil, then the given image
is serialized to json and that is written by default. This default
behavior is sufficient if the given image was originally deserialzed
from this jsonData to begin with which has always been the case.

Signed-off-by: Josh Hawn josh.hawn@docker.com (github: jlhawn)
