### PR TITLE
Use archive.CopyWithTar in vfs.Create

### DIFF
--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/libcontainer/label"
 )
 
@@ -46,21 +47,6 @@ func isGNUcoreutils() bool {
 	return false
 }
 
-func copyDir(src, dst string) error {
-	argv := make([]string, 0, 4)
-
-	if isGNUcoreutils() {
-		argv = append(argv, "-aT", "--reflink=auto", src, dst)
-	} else {
-		argv = append(argv, "-a", src+"/.", dst+"/.")
-	}
-
-	if output, err := exec.Command("cp", argv...).CombinedOutput(); err != nil {
-		return fmt.Errorf("Error VFS copying directory: %s (%s)", err, output)
-	}
-	return nil
-}
-
 func (d *Driver) Create(id, parent string) error {
 	dir := d.dir(id)
 	if err := os.MkdirAll(path.Dir(dir), 0700); err != nil {
@@ -80,7 +66,7 @@ func (d *Driver) Create(id, parent string) error {
 	if err != nil {
 		return fmt.Errorf("%s: %s", parent, err)
 	}
-	if err := copyDir(parentDir, dir); err != nil {
+	if err := archive.CopyWithTar(parentDir, dir); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
The vfs storage driver currently shells out to the `cp` binary on the host
system to perform an 'archive' copy of the base image to a new directory.
The archive option preserves the modified time of the files which are created
but there was an issue where it was unable to preserve the modified time of
copied symbolic links on some host systems with an outdated version of `cp`.

This change no longer relies on the host system implementation and instead
utilizes the `CopyWithTar` function found in `pkg/archive` which is used
to copy from source to destination directory using a Tar archive, which
should correctly preserve file attributes.

Docker-DCO-1.1-Signed-off-by: Josh Hawn josh.hawn@docker.com (github: jlhawn)
