### PR TITLE
Do not create new volumes on build

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -58,6 +58,7 @@ func (b *Builder) commit(id string, autoCmd []string, comment string) error {
 		return fmt.Errorf("Please provide a source image with `from` prior to commit")
 	}
 	b.Config.Image = b.image
+	b.Config.BuildOnly = true
 	if id == "" {
 		cmd := b.Config.Cmd
 		b.Config.Cmd = []string{"/bin/sh", "-c", "#(nop) " + comment}

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -86,6 +86,13 @@ func (m *Mount) initialize() error {
 	if err != nil {
 		return err
 	}
+
+	// If this is a build, we don't actually want to create the volume.
+	// However, since the user is expecting the dir to be automatically created it needs to be created here.
+	if m.container.Config.BuildOnly {
+		return os.MkdirAll(containerMntPath, 0755)
+	}
+
 	m.container.VolumesRW[m.MountToPath] = m.Writable
 	m.container.Volumes[m.MountToPath] = m.volume.Path
 	m.volume.AddContainer(m.container.ID)

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -136,6 +136,7 @@ Create a container
                      "22/tcp": {}
              },
              "SecurityOpts": [""],
+             "BuildOnly": false
              "HostConfig": {
                "Binds":["/tmp:/tmp"],
                "Links":["redis3:redis"],

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -716,10 +716,12 @@ If you then run `docker stop test`, the container will not exit cleanly - the
 
 The `VOLUME` instruction will create a mount point with the specified name
 and mark it as holding externally mounted volumes from native host or other
-containers. The value can be a JSON array, `VOLUME ["/var/log/"]`, or a plain
-string with multiple arguments, such as `VOLUME /var/log` or `VOLUME /var/log
-/var/db`.  For more information/examples and mounting instructions via the
-Docker client, refer to [*Share Directories via Volumes*](/userguide/dockervolumes/#volume-def)
+containers. When a container is created from this image Docker will create a
+directory on the host filesystem and mount it to the specified location. The
+value can be a JSON array, `VOLUME ["/var/log/"]`, or a plain string with
+multiple arguments, such as `VOLUME /var/log` or `VOLUME /var/log/var/db`.  For
+more information/examples and mounting instructions via the Docker client, refer
+to [*Share Directories via Volumes*](/userguide/dockervolumes/#volume-def)
 documentation.
 
 > **Note**:

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3336,3 +3336,26 @@ func TestBuildWithTabs(t *testing.T) {
 	}
 	logDone("build - with tabs")
 }
+
+func TestBuildVolumesAreNotCreated(t *testing.T) {
+	name := "testbuildnovolumes"
+	defer deleteImages(name)
+	out, err := buildImage(name,
+		`FROM busybox
+		VOLUME /foo
+		RUN touch /foo/bar
+		RUN [ -f /foo/bar ] || exit 1`, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "inspect", "--format", `'{{ index .Config.Volumes "/foo" }}'`, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out == "<no value>" {
+		t.Fatal("Expect a volume config for /foo but got none")
+	}
+
+	logDone("build - do not create volumes on build")
+}

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	MacAddress      string
 	OnBuild         []string
 	SecurityOpt     []string
+	BuildOnly       bool
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {


### PR DESCRIPTION
Fixes #3639 
During builds when `VOLUME` is declared it is not treated any
differently than a normal volume.  As such, for each new container
created as part of the build there is a new volume created for that
container.

Because of the way volumes work, this essentially makes a delcared
volume an immutable directory within the image since changes to the
data in the volume are not commited back to disk. This in turn makes
VOLUME delcarations highly positional and they must be declared at the
end of the Dockerfile.

The current behavior can also create a lot of added overhead if there is
any signficant amount of data in the image at the declared volume
location since this data gets automatically copied out onto the host as
part of the volume initialization.

This change introduces for the first time a differentiation from a build
container and a normal container.
This means a new HostConfig field called `BuildOnly` has been added.
This field is a boolean that can be used to change behavior of the
container creation depending on if it is for a build or not. In the case
of this change it checks if `container.Config.BuildOnly` is true,
and if so, does not fully initialize the volume and instead just creates
the dir within the container's fs (if it doesn't exist).
