### PR TITLE
builder: Restore /bin/sh handling in CMD when entrypoint is specified with JSON

### DIFF
--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -234,7 +234,7 @@ func run(b *Builder, args []string, attributes map[string]bool, original string)
 func cmd(b *Builder, args []string, attributes map[string]bool, original string) error {
 	b.Config.Cmd = handleJsonArgs(args, attributes)
 
-	if !attributes["json"] && len(b.Config.Entrypoint) == 0 {
+	if !attributes["json"] {
 		b.Config.Cmd = append([]string{"/bin/sh", "-c"}, b.Config.Cmd...)
 	}
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -16,6 +16,40 @@ import (
 	"github.com/docker/docker/pkg/archive"
 )
 
+func TestBuildShCmdJSONEntrypoint(t *testing.T) {
+	name := "testbuildshcmdjsonentrypoint"
+	defer deleteImages(name)
+
+	_, err := buildImage(
+		name,
+		`
+    FROM busybox
+    ENTRYPOINT ["/bin/echo"]
+    CMD echo test
+    `,
+		true)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := runCommandWithOutput(
+		exec.Command(
+			dockerBinary,
+			"run",
+			name))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.TrimSpace(out) != "/bin/sh -c echo test" {
+		t.Fatal("CMD did not contain /bin/sh -c")
+	}
+
+	logDone("build - CMD should always contain /bin/sh -c when specified without JSON")
+}
+
 func TestBuildEnvironmentReplacementUser(t *testing.T) {
 	name := "testbuildenvironmentreplacement"
 	defer deleteImages(name)


### PR DESCRIPTION
@tiborvass @crosbymichael @vieux 
