### PR TITLE
Fix test-integration so it runs dynbinary and dyntest-integration.

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -238,8 +238,12 @@ main() {
 		bundles=(${DEFAULT_BUNDLES[@]})
 	else
 		bundles=($@)
-	fi
+    fi
 	for bundle in ${bundles[@]}; do
+        if [ $bundle == "test-integration" ] && [ ! -x "bundles/$VERSION/dynbinary/dockerinit-$VERSION" ]; then
+            bundle $SCRIPTDIR/make/dynbinary
+            bundle $SCRIPTDIR/make/dyntest-integration
+        fi
 		bundle $SCRIPTDIR/make/$bundle
 		echo
 	done


### PR DESCRIPTION
Running `docker run ... hack/make.sh test-integration` was never creating the dynbinary/dockerinit-$VERSION, which caused failures.

Docker-DCO-1.1-Signed-off-by: Jessica Frazelle jess@docker.com (github: jfrazelle)
