### PR TITLE
Exclude `.wh..wh.*` AUFS metadata on layer export

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -300,6 +300,7 @@ func (a *Driver) Diff(id, parent string) (archive.Archive, error) {
 	// AUFS doesn't need the parent layer to produce a diff.
 	return archive.TarWithOptions(path.Join(a.rootPath(), "diff", id), &archive.TarOptions{
 		Compression: archive.Uncompressed,
+		Excludes:    []string{".wh..wh.*"},
 	})
 }
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -369,7 +369,9 @@ func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) 
 				}
 
 				relFilePath, err := filepath.Rel(srcPath, filePath)
-				if err != nil {
+				if err != nil || (relFilePath == "." && f.IsDir()) {
+					// Error getting relative path OR we are looking
+					// at the root path. Skip in both situations.
 					return nil
 				}
 


### PR DESCRIPTION
In an effort to make layer content 'stable' between import
and export from two different graph drivers, we must resolve
an issue where AUFS produces metadata files in its layers
which other drivers explicitly ignore when importing.

The issue presents itself like this:

```
- Generate a layer using AUFS
- On commit of that container, the new stored layer contains
  AUFS metadata files/dirs. The stored layer content has some
  tarsum value: '1234567'
- `docker save` that image to a USB drive and `docker load`
  into another docker engine instance which uses another
  graph driver, say 'btrfs'
- On load, this graph driver explicitly ignores any AUFS metadata
  that it encounters. The stored layer content now has some
  different tarsum value: 'abcdefg'.
```

The only (apparent) useful aufs metadata to keep are the psuedo link
files located at `/.wh..wh.plink/`. Thes files hold information at the
RW layer about hard linked files between this layer and another layer.
The other graph drivers make sure to copy up these psuedo linked files
but I've tested out a few different situations and it seems that this
is unnecessary (In my test, AUFS already copies up the other hard linked
files to the RW layer).

This changeset adds explicit exclusion of the AUFS metadata files and
directories (NOTE: not the whiteout files!) on commit of a container
using the AUFS storage driver.

Also included is a change to the archive package. It now explicitly
ignores the root directory from being included in the resulting tar archive
for 2 reasons: 1) it's unnecessary. 2) It's another difference between
what other graph drivers produce when exporting a layer to a tar archive.

Signed-off-by: Josh Hawn josh.hawn@docker.com (github: jlhawn)
