### PR TITLE
Fix docker exec help messages.

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2470,7 +2470,7 @@ func (cli *DockerCli) CmdLoad(args ...string) error {
 }
 
 func (cli *DockerCli) CmdExec(args ...string) error {
-	cmd := cli.Subcmd("exec", "CONTAINER COMMAND [ARG...]", "Run a command in an existing container")
+	cmd := cli.Subcmd("exec", "CONTAINER COMMAND [ARG...]", "Run a command in a running container")
 
 	execConfig, err := runconfig.ParseExec(cmd, args)
 	if err != nil {

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -42,7 +42,7 @@ type TtyTerminal interface {
 
 type Driver interface {
 	Run(c *Command, pipes *Pipes, startCallback StartCallback) (int, error) // Run executes the process and blocks until the process exits and returns the exit code
-	// Exec executes the process in an existing container, blocks until the process exits and returns the exit code
+	// Exec executes the process in a running container, blocks until the process exits and returns the exit code
 	Exec(c *Command, processConfig *ProcessConfig, pipes *Pipes, startCallback StartCallback) (int, error)
 	Kill(c *Command, sig int) error
 	Pause(c *Command) error

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -62,7 +62,7 @@ func init() {
 			{"create", "Create a new container"},
 			{"diff", "Inspect changes on a container's filesystem"},
 			{"events", "Get real time events from the server"},
-			{"exec", "Run a command in an existing container"},
+			{"exec", "Run a command in a running container"},
 			{"export", "Stream the contents of a container as a tar archive"},
 			{"history", "Show the history of an image"},
 			{"images", "List images"},

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -637,7 +637,7 @@ You'll need two shells for this example.
 
     Usage: docker exec [OPTIONS] CONTAINER COMMAND [ARG...]
 
-    Run a command in an existing container
+    Run a command in a running container
 
       -d, --detach=false         Detached mode: run command in the background
       -i, --interactive=false    Keep STDIN open even if not attached


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

The docker exec command help messages "Run a command in an existing container"
should be "Run a command in a running container".
"an existing container" would confuse the users since docker exec exactly run a command 
in a running container.
docker-exec.1.md also description the docker exec command as 
"Run a process in a running container."
