### PR TITLE
Update libcontainer to f60d7b9195f8dc0b5d343abbc3293d

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -66,7 +66,7 @@ if [ "$1" = '--go' ]; then
 	mv tmp-tar src/code.google.com/p/go/src/pkg/archive/tar
 fi
 
-clone git github.com/docker/libcontainer aab3f6d17f2f56606f07f3a6eb6b693303f75812
+clone git github.com/docker/libcontainer f60d7b9195f8dc0b5d343abbc3293da7c17bb11c
 # see src/github.com/docker/libcontainer/update-vendor.sh which is the "source of truth" for libcontainer deps (just like this file)
 rm -rf src/github.com/docker/libcontainer/vendor
 eval "$(grep '^clone ' src/github.com/docker/libcontainer/update-vendor.sh | grep -v 'github.com/codegangsta/cli')"

--- a/vendor/src/github.com/docker/libcontainer/Makefile
+++ b/vendor/src/github.com/docker/libcontainer/Makefile
@@ -12,10 +12,10 @@ sh:
 GO_PACKAGES = $(shell find . -not \( -wholename ./vendor -prune -o -wholename ./.git -prune \) -name '*.go' -print0 | xargs -0n1 dirname | sort -u)
 
 direct-test:
-	go test -cover -v $(GO_PACKAGES)
+	go test $(TEST_TAGS) -cover -v $(GO_PACKAGES)
 
 direct-test-short:
-	go test -cover -test.short -v $(GO_PACKAGES)
+	go test $(TEST_TAGS) -cover -test.short -v $(GO_PACKAGES)
 
 direct-build:
 	go build -v $(GO_PACKAGES)

--- a/vendor/src/github.com/docker/libcontainer/README.md
+++ b/vendor/src/github.com/docker/libcontainer/README.md
@@ -56,7 +56,7 @@ Docs released under Creative commons.
 
 First of all, please familiarise yourself with the [libcontainer Principles](PRINCIPLES.md).
 
-If you're a *contributor* or aspiring contributor, you should read the [Contributors' Guide](CONTRIBUTORS_GUIDE.md).
+If you're a *contributor* or aspiring contributor, you should read the [Contributors' Guide](CONTRIBUTING.md).
 
 If you're a *maintainer* or aspiring maintainer, you should read the [Maintainers' Guide](MAINTAINERS_GUIDE.md) and
 "How can I become a maintainer?" in the Contributors' Guide.

--- a/vendor/src/github.com/docker/libcontainer/cgroups/fs/blkio.go
+++ b/vendor/src/github.com/docker/libcontainer/cgroups/fs/blkio.go
@@ -146,6 +146,26 @@ func getCFQStats(path string, stats *cgroups.Stats) error {
 	}
 	stats.BlkioStats.IoQueuedRecursive = blkioStats
 
+	if blkioStats, err = getBlkioStat(filepath.Join(path, "blkio.io_service_time_recursive")); err != nil {
+		return err
+	}
+	stats.BlkioStats.IoServiceTimeRecursive = blkioStats
+
+	if blkioStats, err = getBlkioStat(filepath.Join(path, "blkio.io_wait_time_recursive")); err != nil {
+		return err
+	}
+	stats.BlkioStats.IoWaitTimeRecursive = blkioStats
+
+	if blkioStats, err = getBlkioStat(filepath.Join(path, "blkio.io_merged_recursive")); err != nil {
+		return err
+	}
+	stats.BlkioStats.IoMergedRecursive = blkioStats
+
+	if blkioStats, err = getBlkioStat(filepath.Join(path, "blkio.time_recursive")); err != nil {
+		return err
+	}
+	stats.BlkioStats.IoTimeRecursive = blkioStats
+
 	return nil
 }
 

--- a/vendor/src/github.com/docker/libcontainer/cgroups/fs/blkio_test.go
+++ b/vendor/src/github.com/docker/libcontainer/cgroups/fs/blkio_test.go
@@ -26,7 +26,25 @@ Total 50`
 8:0 Async 3
 8:0 Total 5
 Total 5`
-	throttleServiceBytes = `8:0 Read 11030528
+	serviceTimeRecursiveContents = `8:0 Read 173959
+8:0 Write 0
+8:0 Sync 0
+8:0 Async 173959
+8:0 Total 17395
+Total 17395`
+	waitTimeRecursiveContents = `8:0 Read 15571
+8:0 Write 0
+8:0 Sync 0
+8:0 Async 15571
+8:0 Total 15571`
+	mergedRecursiveContents = `8:0 Read 5
+8:0 Write 10
+8:0 Sync 0
+8:0 Async 0
+8:0 Total 15
+Total 15`
+	timeRecursiveContents = `8:0 8`
+	throttleServiceBytes  = `8:0 Read 11030528
 8:0 Write 23
 8:0 Sync 42
 8:0 Async 11030528
@@ -61,6 +79,10 @@ func TestBlkioStats(t *testing.T) {
 		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
 		"blkio.io_queued_recursive":        queuedRecursiveContents,
+		"blkio.io_service_time_recursive":  serviceTimeRecursiveContents,
+		"blkio.io_wait_time_recursive":     waitTimeRecursiveContents,
+		"blkio.io_merged_recursive":        mergedRecursiveContents,
+		"blkio.time_recursive":             timeRecursiveContents,
 		"blkio.sectors_recursive":          sectorsRecursiveContents,
 	})
 
@@ -93,6 +115,26 @@ func TestBlkioStats(t *testing.T) {
 	appendBlkioStatEntry(&expectedStats.IoQueuedRecursive, 8, 0, 3, "Async")
 	appendBlkioStatEntry(&expectedStats.IoQueuedRecursive, 8, 0, 5, "Total")
 
+	appendBlkioStatEntry(&expectedStats.IoServiceTimeRecursive, 8, 0, 173959, "Read")
+	appendBlkioStatEntry(&expectedStats.IoServiceTimeRecursive, 8, 0, 0, "Write")
+	appendBlkioStatEntry(&expectedStats.IoServiceTimeRecursive, 8, 0, 0, "Sync")
+	appendBlkioStatEntry(&expectedStats.IoServiceTimeRecursive, 8, 0, 173959, "Async")
+	appendBlkioStatEntry(&expectedStats.IoServiceTimeRecursive, 8, 0, 17395, "Total")
+
+	appendBlkioStatEntry(&expectedStats.IoWaitTimeRecursive, 8, 0, 15571, "Read")
+	appendBlkioStatEntry(&expectedStats.IoWaitTimeRecursive, 8, 0, 0, "Write")
+	appendBlkioStatEntry(&expectedStats.IoWaitTimeRecursive, 8, 0, 0, "Sync")
+	appendBlkioStatEntry(&expectedStats.IoWaitTimeRecursive, 8, 0, 15571, "Async")
+	appendBlkioStatEntry(&expectedStats.IoWaitTimeRecursive, 8, 0, 15571, "Total")
+
+	appendBlkioStatEntry(&expectedStats.IoMergedRecursive, 8, 0, 5, "Read")
+	appendBlkioStatEntry(&expectedStats.IoMergedRecursive, 8, 0, 10, "Write")
+	appendBlkioStatEntry(&expectedStats.IoMergedRecursive, 8, 0, 0, "Sync")
+	appendBlkioStatEntry(&expectedStats.IoMergedRecursive, 8, 0, 0, "Async")
+	appendBlkioStatEntry(&expectedStats.IoMergedRecursive, 8, 0, 15, "Total")
+
+	appendBlkioStatEntry(&expectedStats.IoTimeRecursive, 8, 0, 8, "")
+
 	expectBlkioStatsEquals(t, expectedStats, actualStats.BlkioStats)
 }
 
@@ -103,6 +145,10 @@ func TestBlkioStatsNoSectorsFile(t *testing.T) {
 		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
 		"blkio.io_queued_recursive":        queuedRecursiveContents,
+		"blkio.io_service_time_recursive":  serviceTimeRecursiveContents,
+		"blkio.io_wait_time_recursive":     waitTimeRecursiveContents,
+		"blkio.io_merged_recursive":        mergedRecursiveContents,
+		"blkio.time_recursive":             timeRecursiveContents,
 	})
 
 	blkio := &BlkioGroup{}
@@ -117,9 +163,13 @@ func TestBlkioStatsNoServiceBytesFile(t *testing.T) {
 	helper := NewCgroupTestUtil("blkio", t)
 	defer helper.cleanup()
 	helper.writeFileContents(map[string]string{
-		"blkio.io_serviced_recursive": servicedRecursiveContents,
-		"blkio.io_queued_recursive":   queuedRecursiveContents,
-		"blkio.sectors_recursive":     sectorsRecursiveContents,
+		"blkio.io_serviced_recursive":     servicedRecursiveContents,
+		"blkio.io_queued_recursive":       queuedRecursiveContents,
+		"blkio.sectors_recursive":         sectorsRecursiveContents,
+		"blkio.io_service_time_recursive": serviceTimeRecursiveContents,
+		"blkio.io_wait_time_recursive":    waitTimeRecursiveContents,
+		"blkio.io_merged_recursive":       mergedRecursiveContents,
+		"blkio.time_recursive":            timeRecursiveContents,
 	})
 
 	blkio := &BlkioGroup{}
@@ -137,6 +187,10 @@ func TestBlkioStatsNoServicedFile(t *testing.T) {
 		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
 		"blkio.io_queued_recursive":        queuedRecursiveContents,
 		"blkio.sectors_recursive":          sectorsRecursiveContents,
+		"blkio.io_service_time_recursive":  serviceTimeRecursiveContents,
+		"blkio.io_wait_time_recursive":     waitTimeRecursiveContents,
+		"blkio.io_merged_recursive":        mergedRecursiveContents,
+		"blkio.time_recursive":             timeRecursiveContents,
 	})
 
 	blkio := &BlkioGroup{}
@@ -153,6 +207,106 @@ func TestBlkioStatsNoQueuedFile(t *testing.T) {
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
+		"blkio.sectors_recursive":          sectorsRecursiveContents,
+		"blkio.io_service_time_recursive":  serviceTimeRecursiveContents,
+		"blkio.io_wait_time_recursive":     waitTimeRecursiveContents,
+		"blkio.io_merged_recursive":        mergedRecursiveContents,
+		"blkio.time_recursive":             timeRecursiveContents,
+	})
+
+	blkio := &BlkioGroup{}
+	actualStats := *cgroups.NewStats()
+	err := blkio.GetStats(helper.CgroupPath, &actualStats)
+	if err != nil {
+		t.Fatalf("Failed unexpectedly: %s", err)
+	}
+}
+
+func TestBlkioStatsNoServiceTimeFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	helper := NewCgroupTestUtil("blkio", t)
+	defer helper.cleanup()
+	helper.writeFileContents(map[string]string{
+		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
+		"blkio.io_serviced_recursive":      servicedRecursiveContents,
+		"blkio.io_queued_recursive":        queuedRecursiveContents,
+		"blkio.io_wait_time_recursive":     waitTimeRecursiveContents,
+		"blkio.io_merged_recursive":        mergedRecursiveContents,
+		"blkio.time_recursive":             timeRecursiveContents,
+		"blkio.sectors_recursive":          sectorsRecursiveContents,
+	})
+
+	blkio := &BlkioGroup{}
+	actualStats := *cgroups.NewStats()
+	err := blkio.GetStats(helper.CgroupPath, &actualStats)
+	if err != nil {
+		t.Fatalf("Failed unexpectedly: %s", err)
+	}
+}
+
+func TestBlkioStatsNoWaitTimeFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	helper := NewCgroupTestUtil("blkio", t)
+	defer helper.cleanup()
+	helper.writeFileContents(map[string]string{
+		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
+		"blkio.io_serviced_recursive":      servicedRecursiveContents,
+		"blkio.io_queued_recursive":        queuedRecursiveContents,
+		"blkio.io_service_time_recursive":  serviceTimeRecursiveContents,
+		"blkio.io_merged_recursive":        mergedRecursiveContents,
+		"blkio.time_recursive":             timeRecursiveContents,
+		"blkio.sectors_recursive":          sectorsRecursiveContents,
+	})
+
+	blkio := &BlkioGroup{}
+	actualStats := *cgroups.NewStats()
+	err := blkio.GetStats(helper.CgroupPath, &actualStats)
+	if err != nil {
+		t.Fatalf("Failed unexpectedly: %s", err)
+	}
+}
+
+func TestBlkioStatsNoMergedFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	helper := NewCgroupTestUtil("blkio", t)
+	defer helper.cleanup()
+	helper.writeFileContents(map[string]string{
+		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
+		"blkio.io_serviced_recursive":      servicedRecursiveContents,
+		"blkio.io_queued_recursive":        queuedRecursiveContents,
+		"blkio.io_service_time_recursive":  serviceTimeRecursiveContents,
+		"blkio.io_wait_time_recursive":     waitTimeRecursiveContents,
+		"blkio.time_recursive":             timeRecursiveContents,
+		"blkio.sectors_recursive":          sectorsRecursiveContents,
+	})
+
+	blkio := &BlkioGroup{}
+	actualStats := *cgroups.NewStats()
+	err := blkio.GetStats(helper.CgroupPath, &actualStats)
+	if err != nil {
+		t.Fatalf("Failed unexpectedly: %s", err)
+	}
+}
+
+func TestBlkioStatsNoTimeFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	helper := NewCgroupTestUtil("blkio", t)
+	defer helper.cleanup()
+	helper.writeFileContents(map[string]string{
+		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
+		"blkio.io_serviced_recursive":      servicedRecursiveContents,
+		"blkio.io_queued_recursive":        queuedRecursiveContents,
+		"blkio.io_service_time_recursive":  serviceTimeRecursiveContents,
+		"blkio.io_wait_time_recursive":     waitTimeRecursiveContents,
+		"blkio.io_merged_recursive":        mergedRecursiveContents,
 		"blkio.sectors_recursive":          sectorsRecursiveContents,
 	})
 
@@ -172,6 +326,10 @@ func TestBlkioStatsUnexpectedNumberOfFields(t *testing.T) {
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
 		"blkio.io_queued_recursive":        queuedRecursiveContents,
 		"blkio.sectors_recursive":          sectorsRecursiveContents,
+		"blkio.io_service_time_recursive":  serviceTimeRecursiveContents,
+		"blkio.io_wait_time_recursive":     waitTimeRecursiveContents,
+		"blkio.io_merged_recursive":        mergedRecursiveContents,
+		"blkio.time_recursive":             timeRecursiveContents,
 	})
 
 	blkio := &BlkioGroup{}
@@ -190,6 +348,10 @@ func TestBlkioStatsUnexpectedFieldType(t *testing.T) {
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
 		"blkio.io_queued_recursive":        queuedRecursiveContents,
 		"blkio.sectors_recursive":          sectorsRecursiveContents,
+		"blkio.io_service_time_recursive":  serviceTimeRecursiveContents,
+		"blkio.io_wait_time_recursive":     waitTimeRecursiveContents,
+		"blkio.io_merged_recursive":        mergedRecursiveContents,
+		"blkio.time_recursive":             timeRecursiveContents,
 	})
 
 	blkio := &BlkioGroup{}
@@ -208,6 +370,10 @@ func TestNonCFQBlkioStats(t *testing.T) {
 		"blkio.io_serviced_recursive":      "",
 		"blkio.io_queued_recursive":        "",
 		"blkio.sectors_recursive":          "",
+		"blkio.io_service_time_recursive":  "",
+		"blkio.io_wait_time_recursive":     "",
+		"blkio.io_merged_recursive":        "",
+		"blkio.time_recursive":             "",
 		"blkio.throttle.io_service_bytes":  throttleServiceBytes,
 		"blkio.throttle.io_serviced":       throttleServiced,
 	})

--- a/vendor/src/github.com/docker/libcontainer/cgroups/fs/stats_util_test.go
+++ b/vendor/src/github.com/docker/libcontainer/cgroups/fs/stats_util_test.go
@@ -41,6 +41,26 @@ func expectBlkioStatsEquals(t *testing.T, expected, actual cgroups.BlkioStats) {
 		log.Printf("blkio SectorsRecursive do not match - %s\n", err)
 		t.Fail()
 	}
+
+	if err := blkioStatEntryEquals(expected.IoServiceTimeRecursive, actual.IoServiceTimeRecursive); err != nil {
+		log.Printf("blkio IoServiceTimeRecursive do not match - %s\n", err)
+		t.Fail()
+	}
+
+	if err := blkioStatEntryEquals(expected.IoWaitTimeRecursive, actual.IoWaitTimeRecursive); err != nil {
+		log.Printf("blkio IoWaitTimeRecursive do not match - %s\n", err)
+		t.Fail()
+	}
+
+	if err := blkioStatEntryEquals(expected.IoMergedRecursive, actual.IoMergedRecursive); err != nil {
+		log.Printf("blkio IoMergedRecursive do not match - %s vs %s\n", expected.IoMergedRecursive, actual.IoMergedRecursive)
+		t.Fail()
+	}
+
+	if err := blkioStatEntryEquals(expected.IoTimeRecursive, actual.IoTimeRecursive); err != nil {
+		log.Printf("blkio IoTimeRecursive do not match - %s\n", err)
+		t.Fail()
+	}
 }
 
 func expectThrottlingDataEquals(t *testing.T, expected, actual cgroups.ThrottlingData) {

--- a/vendor/src/github.com/docker/libcontainer/cgroups/stats.go
+++ b/vendor/src/github.com/docker/libcontainer/cgroups/stats.go
@@ -52,8 +52,12 @@ type BlkioStatEntry struct {
 type BlkioStats struct {
 	// number of bytes tranferred to and from the block device
 	IoServiceBytesRecursive []BlkioStatEntry `json:"io_service_bytes_recursive,omitempty"`
-	IoServicedRecursive     []BlkioStatEntry `json:"io_serviced_recusrive,omitempty"`
+	IoServicedRecursive     []BlkioStatEntry `json:"io_serviced_recursive,omitempty"`
 	IoQueuedRecursive       []BlkioStatEntry `json:"io_queue_recursive,omitempty"`
+	IoServiceTimeRecursive  []BlkioStatEntry `json:"io_service_time_recursive,omitempty"`
+	IoWaitTimeRecursive     []BlkioStatEntry `json:"io_wait_time_recursive,omitempty"`
+	IoMergedRecursive       []BlkioStatEntry `json:"io_merged_recursive,omitempty"`
+	IoTimeRecursive         []BlkioStatEntry `json:"io_time_recursive,omitempty"`
 	SectorsRecursive        []BlkioStatEntry `json:"sectors_recursive,omitempty"`
 }
 

--- a/vendor/src/github.com/docker/libcontainer/config.go
+++ b/vendor/src/github.com/docker/libcontainer/config.go
@@ -47,6 +47,9 @@ type Config struct {
 	// Networks specifies the container's network setup to be created
 	Networks []*Network `json:"networks,omitempty"`
 
+	// Ipc specifies the container's ipc setup to be created
+	IpcNsPath string `json:"ipc,omitempty"`
+
 	// Routes can be specified to create entries in the route table as the container is started
 	Routes []*Route `json:"routes,omitempty"`
 

--- a/vendor/src/github.com/docker/libcontainer/devices/devices.go
+++ b/vendor/src/github.com/docker/libcontainer/devices/devices.go
@@ -100,7 +100,8 @@ func getDeviceNodes(path string) ([]*Device, error) {
 
 	out := []*Device{}
 	for _, f := range files {
-		if f.IsDir() {
+		switch {
+		case f.IsDir():
 			switch f.Name() {
 			case "pts", "shm", "fd":
 				continue
@@ -113,6 +114,8 @@ func getDeviceNodes(path string) ([]*Device, error) {
 				out = append(out, sub...)
 				continue
 			}
+		case f.Name() == "console":
+			continue
 		}
 
 		device, err := GetDevice(filepath.Join(path, f.Name()), "rwm")

--- a/vendor/src/github.com/docker/libcontainer/ipc/ipc.go
+++ b/vendor/src/github.com/docker/libcontainer/ipc/ipc.go
@@ -1,0 +1,29 @@
+package ipc
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/docker/libcontainer/system"
+)
+
+// Join the IPC Namespace of specified ipc path if it exists.
+// If the path does not exist then you are not joining a container.
+func Initialize(nsPath string) error {
+	if nsPath == "" {
+		return nil
+	}
+	f, err := os.OpenFile(nsPath, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed get IPC namespace fd: %v", err)
+	}
+
+	err = system.Setns(f.Fd(), syscall.CLONE_NEWIPC)
+	f.Close()
+
+	if err != nil {
+		return fmt.Errorf("failed to setns current IPC namespace: %v", err)
+	}
+	return nil
+}

--- a/vendor/src/github.com/docker/libcontainer/namespaces/init.go
+++ b/vendor/src/github.com/docker/libcontainer/namespaces/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/libcontainer"
 	"github.com/docker/libcontainer/apparmor"
 	"github.com/docker/libcontainer/console"
+	"github.com/docker/libcontainer/ipc"
 	"github.com/docker/libcontainer/label"
 	"github.com/docker/libcontainer/mount"
 	"github.com/docker/libcontainer/netlink"
@@ -65,6 +66,9 @@ func Init(container *libcontainer.Config, uncleanRootfs, consolePath string, syn
 		if err := system.Setctty(); err != nil {
 			return fmt.Errorf("setctty %s", err)
 		}
+	}
+	if err := ipc.Initialize(container.IpcNsPath); err != nil {
+		return fmt.Errorf("setup IPC %s", err)
 	}
 	if err := setupNetwork(container, networkState); err != nil {
 		return fmt.Errorf("setup networking %s", err)

--- a/vendor/src/github.com/docker/libcontainer/xattr/errors.go
+++ b/vendor/src/github.com/docker/libcontainer/xattr/errors.go
@@ -1,0 +1,8 @@
+package xattr
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var ErrNotSupportedPlatform = fmt.Errorf("platform and architecture is not supported %s %s", runtime.GOOS, runtime.GOARCH)


### PR DESCRIPTION
This adds support of joining IPC namespaces via a path.
Additional blkio stats
Fixes issue with `/dev/console` within privileged containers 

Signed-off-by: Michael Crosby crosbymichael@gmail.com
