### PR TITLE
Allow IPC namespace to be shared between containers or with the host

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -229,6 +229,23 @@ func populateCommand(c *Container, env []string) error {
 		return fmt.Errorf("invalid network mode: %s", c.hostConfig.NetworkMode)
 	}
 
+	ipc := &execdriver.Ipc{}
+
+	parts = strings.SplitN(string(c.hostConfig.IpcMode), ":", 2)
+	switch parts[0] {
+	case "":
+	case "host":
+		ipc.HostIpc = true
+	case "container":
+		ic, err := c.getIpcContainer()
+		if err != nil {
+			return err
+		}
+		ipc.ContainerID = ic.ID
+	default:
+		return fmt.Errorf("invalid IPC mode: %s", c.hostConfig.IpcMode)
+	}
+
 	// Build lists of devices allowed and created within the container.
 	userSpecifiedDevices := make([]*devices.Device, len(c.hostConfig.Devices))
 	for i, deviceMapping := range c.hostConfig.Devices {
@@ -270,6 +287,7 @@ func populateCommand(c *Container, env []string) error {
 		InitPath:           "/.dockerinit",
 		WorkingDir:         c.Config.WorkingDir,
 		Network:            en,
+		Ipc:                ipc,
 		Resources:          resources,
 		AllowedDevices:     allowedDevices,
 		AutoCreatedDevices: autoCreatedDevices,
@@ -1239,10 +1257,33 @@ func (container *Container) GetMountLabel() string {
 	return container.MountLabel
 }
 
+func (container *Container) getIpcContainer() (*Container, error) {
+	parts := strings.SplitN(string(container.hostConfig.IpcMode), ":", 2)
+	switch parts[0] {
+	case "container":
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("no container specified to join IPC")
+		}
+		c := container.daemon.Get(parts[1])
+		if c == nil {
+			return nil, fmt.Errorf("no such container to join IPC: %s", parts[1])
+		}
+		if !c.IsRunning() {
+			return nil, fmt.Errorf("cannot join IPC of a non running container: %s", parts[1])
+		}
+		return c, nil
+	default:
+		return nil, fmt.Errorf("IPC mode not set to container")
+	}
+}
+
 func (container *Container) getNetworkedContainer() (*Container, error) {
 	parts := strings.SplitN(string(container.hostConfig.NetworkMode), ":", 2)
 	switch parts[0] {
 	case "container":
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("no container specified to join network")
+		}
 		nc := container.daemon.Get(parts[1])
 		if nc == nil {
 			return nil, fmt.Errorf("no such container to join network: %s", parts[1])

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -62,6 +62,12 @@ type Network struct {
 	HostNetworking bool              `json:"host_networking"`
 }
 
+// Network settings of the container
+type Ipc struct {
+	ContainerID string `json:"container_id"` // id of the container to join ipc.
+	HostIpc     bool   `json:"host_ipc"`
+}
+
 type NetworkInterface struct {
 	Gateway     string `json:"gateway"`
 	IPAddress   string `json:"ip"`
@@ -106,6 +112,7 @@ type Command struct {
 	WorkingDir         string            `json:"working_dir"`
 	ConfigPath         string            `json:"config_path"` // this should be able to be removed when the lxc template is moved into the driver
 	Network            *Network          `json:"network"`
+	Ipc                *Ipc              `json:"ipc"`
 	Resources          *Resources        `json:"resources"`
 	Mounts             []Mount           `json:"mounts"`
 	AllowedDevices     []*devices.Device `json:"allowed_devices"`

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -36,6 +36,10 @@ func (d *driver) createContainer(c *execdriver.Command) (*libcontainer.Config, e
 	container.MountConfig.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""
 	container.RestrictSys = true
 
+	if err := d.createIpc(container, c); err != nil {
+		return nil, err
+	}
+
 	if err := d.createNetwork(container, c); err != nil {
 		return nil, err
 	}
@@ -119,6 +123,28 @@ func (d *driver) createNetwork(container *libcontainer.Config, c *execdriver.Com
 			Type:   "netns",
 			NsPath: nspath,
 		})
+	}
+
+	return nil
+}
+
+func (d *driver) createIpc(container *libcontainer.Config, c *execdriver.Command) error {
+	if c.Ipc.HostIpc {
+		container.Namespaces["NEWIPC"] = false
+		return nil
+	}
+
+	if c.Ipc.ContainerID != "" {
+		d.Lock()
+		active := d.activeContainers[c.Ipc.ContainerID]
+		d.Unlock()
+
+		if active == nil || active.cmd.Process == nil {
+			return fmt.Errorf("%s is not a valid running container to join", c.Ipc.ContainerID)
+		}
+		cmd := active.cmd
+
+		container.IpcNsPath = filepath.Join("/proc", fmt.Sprint(cmd.Process.Pid), "ns", "ipc")
 	}
 
 	return nil

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -23,6 +23,7 @@ docker-run - Run a command in a new container
 [**--expose**[=*[]*]]
 [**-h**|**--hostname**[=*HOSTNAME*]]
 [**-i**|**--interactive**[=*false*]]
+[**--ipc**[=*[]*]]
 [**--security-opt**[=*[]*]]
 [**--link**[=*[]*]]
 [**--lxc-conf**[=*[]*]]
@@ -145,6 +146,12 @@ container can be started with the **--link**.
 **-i**, **--interactive**=*true*|*false*
    When set to true, keep stdin open even if not attached. The default is false.
 
+**--ipc**=[]
+   Set the IPC mode for the container
+     **container**:<*name*|*id*>: reuses another container's IPC stack
+     **host**: use the host IPC stack inside the container.  
+     Note: the host mode gives the container full access to local IPC and is therefore considered insecure.
+
 **--security-opt**=*secdriver*:*name*:*value*
     "label:user:USER"   : Set the label user for the container
     "label:role:ROLE"   : Set the label role for the container
@@ -186,10 +193,11 @@ and foreground Docker containers.
 
 **--net**="bridge"
    Set the Network mode for the container
-                               'bridge': creates a new network stack for the container on the docker bridge
-                               'none': no networking for this container
-                               'container:<name|id>': reuses another container network stack
-                               'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+   **bridge**: creates a new network stack for the container on the docker bridge
+   **none**: no networking for this container
+   **container**:<*name*|*id*>: reuses another container's network stack
+   **host**: use the host network stack inside the container.  
+   Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
 
 **-P**, **--publish-all**=*true*|*false*
    When set to true publish all exposed ports to the host interfaces. The
@@ -304,6 +312,64 @@ If you do not specify -a then Docker will attach everything (stdin,stdout,stderr
 you’d like to connect instead, as in:
 
     # docker run -a stdin -a stdout -i -t fedora /bin/bash
+
+## Sharing IPC between containers
+
+Using shm_server.c available here: http://www.cs.cf.ac.uk/Dave/C/node27.html
+
+Testing --ipc=host mode:
+
+Host shows a shared memory segment with 7 pids attached, happens to be from httpd:
+
+ # ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+ 0x01128e25 0          root       600        1000       7                       
+
+
+Now run a regular container, and it correctly does NOT see the shared memory segment from the host:
+
+ # docker run -it shm ipcs -m
+
+ ------ Shared Memory Segments --------	
+ key        shmid      owner      perms      bytes      nattch     status      
+
+Run a container with the new --ipc=host option, and it now sees the shared memory segment from the host httpd:
+
+ # docker run -it --ipc=host shm ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+ 0x01128e25 0          root       600        1000       7                   
+
+Testing --ipc=container:CONTAINERID mode:
+
+Start a container with a program to create a shared memory segment:
+
+ # docker run -it shm bash
+ # shm/shm_server &
+ # ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+ 0x0000162e 0          root       666        27         1                       
+
+Create a 2nd container correctly shows no shared memory segment from 1st container:
+
+ # docker run shm ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+
+Create a 3rd container using the new --ipc=container:CONTAINERID option, now it shows the shared memory segment from the first:
+
+ # docker run -it --ipc=container:ed735b2264ac shm ipcs -m
+ # ipcs -m
+
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status      
+ 0x0000162e 0          root       666        27         1
 
 ## Linking Containers
 

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -50,6 +50,7 @@ following options.
  - [Container Identification](#container-identification)
      - [Name (--name)](#name-name)
      - [PID Equivalent](#pid-equivalent)
+ - [IPC Settings](#ipc-settings)
  - [Network Settings](#network-settings)
  - [Clean Up (--rm)](#clean-up-rm)
  - [Runtime Constraints on CPU and Memory](#runtime-constraints-on-cpu-and-memory)
@@ -131,13 +132,25 @@ While not strictly a means of identifying a container, you can specify a version
 image you'd like to run the container with by adding `image[:tag]` to the command. For
 example, `docker run ubuntu:14.04`.
 
-## Network settings
+## IPC Settings
+    --ipc=""  : Set the IPC mode for the container,
+                                 'container:<name|id>': reuses another container's IPC stack
+                                 'host': use the host IPC stack inside the container
+By default, all containers have IPC enabled 
+
+Shared memory segments are used to accelerate inter-process communication at memory speed, rather than through 
+pipes or through the network stack. Shared memory is commonly used by databases and custom-built (typically C/OpenMPI, 
+C++/using boost libraries) high performance applications for scientific computing and financial services industries.
+If these types of applications are broken into multiple containers, you might need to share the IPC mechansims of the 
+containers.
+
+## Network Settings
 
     --dns=[]        : Set custom dns servers for the container
     --net="bridge"  : Set the Network mode for the container
                                  'bridge': creates a new network stack for the container on the docker bridge
                                  'none': no networking for this container
-                                 'container:<name|id>': reuses another container network stack
+                                 'container:<name|id>': reuses another container's network stack
                                  'host': use the host network stack inside the container
     --add-host=""   : Add a line to /etc/hosts (host:IP)
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2446,3 +2446,73 @@ func TestRunVolumesCleanPaths(t *testing.T) {
 
 	logDone("run - volume paths are cleaned")
 }
+
+func TestRunModeIpcHost(t *testing.T) {
+	hostIpc, err := os.Readlink("/proc/1/ns/ipc")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(dockerBinary, "run", "--ipc=host", "busybox", "readlink", "/proc/self/ns/ipc")
+	out2, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out2)
+	}
+
+	out2 = strings.Trim(out2, "\n")
+	if hostIpc != out2 {
+		t.Fatalf("IPC different with --ipc=host %s != %s\n", hostIpc, out2)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "busybox", "readlink", "/proc/self/ns/ipc")
+	out2, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out2)
+	}
+
+	out2 = strings.Trim(out2, "\n")
+	if hostIpc == out2 {
+		t.Fatalf("IPC should be different without --ipc=host %s != %s\n", hostIpc, out2)
+	}
+	deleteAllContainers()
+
+	logDone("run - hostname and several network modes")
+}
+
+func TestRunModeIpcContainer(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+	id := strings.TrimSpace(out)
+	state, err := inspectField(id, "State.Running")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != "true" {
+		t.Fatal("Container state is 'not running'")
+	}
+	pid1, err := inspectField(id, "State.Pid")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parentContainerIpc, err := os.Readlink(fmt.Sprintf("/proc/%s/ns/ipc", pid1))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd = exec.Command(dockerBinary, "run", fmt.Sprintf("--ipc=container:%s", id), "busybox", "readlink", "/proc/self/ns/ipc")
+	out2, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out2)
+	}
+
+	out2 = strings.Trim(out2, "\n")
+	if parentContainerIpc != out2 {
+		t.Fatalf("IPC different with --ipc=container:%s %s != %s\n", id, parentContainerIpc, out2)
+	}
+	deleteAllContainers()
+
+	logDone("run - hostname and several network modes")
+}

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -59,6 +59,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.")
+		flIpcMode         = cmd.String([]string{"-ipc"}, "", "Default is to create a private IPC namespace for the container\n'container:<name|id>': reuses another container shared memory\n'host': use the host shared memory inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.")
 		flRestartPolicy   = cmd.String([]string{"-restart"}, "", "Restart policy to apply when a container exits (no, on-failure[:max-retry], always)")
 	)
 
@@ -225,6 +226,11 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 	// parse the '-e' and '--env' after, to allow override
 	envVariables = append(envVariables, flEnv.GetAll()...)
 
+	ipcMode, err := parseIpcMode(*flIpcMode)
+	if err != nil {
+		return nil, nil, cmd, fmt.Errorf("--ipc: invalid IPC mode: %v", err)
+	}
+
 	netMode, err := parseNetMode(*flNetMode)
 	if err != nil {
 		return nil, nil, cmd, fmt.Errorf("--net: invalid net mode: %v", err)
@@ -272,6 +278,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 		ExtraHosts:      flExtraHosts.GetAll(),
 		VolumesFrom:     flVolumesFrom.GetAll(),
 		NetworkMode:     netMode,
+		IpcMode:         ipcMode,
 		Devices:         deviceMappings,
 		CapAdd:          flCapAdd.GetAll(),
 		CapDrop:         flCapDrop.GetAll(),
@@ -359,6 +366,20 @@ func parseKeyValueOpts(opts opts.ListOpts) ([]utils.KeyValuePair, error) {
 		out[i] = utils.KeyValuePair{Key: k, Value: v}
 	}
 	return out, nil
+}
+
+func parseIpcMode(ipcMode string) (IpcMode, error) {
+	parts := strings.Split(ipcMode, ":")
+	switch mode := parts[0]; mode {
+	case "", "host":
+	case "container":
+		if len(parts) < 2 || parts[1] == "" {
+			return "", fmt.Errorf("invalid container format container:<name|id>")
+		}
+	default:
+		return "", fmt.Errorf("invalid --ipc: %s", ipcMode)
+	}
+	return IpcMode(ipcMode), nil
 }
 
 func parseNetMode(netMode string) (NetworkMode, error) {


### PR DESCRIPTION
Replaces #8211

Some workloads rely on IPC for communications with other processes.  We
would like to split workloads between two container but still allow them
to communicate though shared IPC.

This patch mimics the --net code to allow --ipc=host to not split off
the IPC Namespace.  ipc=container:CONTAINERID to share ipc between containers

If you share IPC between containers, then you need to make sure SELinux labels
match.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
Signed-off-by: Michael Crosby crosbymichael@gmail.com
