### PR TITLE
Add docs for --dns-search=.

### DIFF
--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -64,7 +64,7 @@ docker-create - Create a new container
    Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc:rwm)
 
 **--dns-search**=[]
-   Set custom DNS search domains
+   Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)
 
 **--dns**=[]
    Set custom DNS servers

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -103,7 +103,7 @@ stopping the process by pressing the keys CTRL-P CTRL-Q.
    Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc:rwm)
 
 **--dns-search**=[]
-   Set custom DNS search domains
+   Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)
 
 **--dns**=*IP-address*
    Set custom DNS servers. This option can be used to override the DNS
@@ -195,8 +195,8 @@ and foreground Docker containers.
    When set to true publish all exposed ports to the host interfaces. The
 default is false. If the operator uses -P (or -p) then Docker will make the
 exposed port accessible on the host and the ports will be available to any
-client that can reach the host. When using -P, Docker will bind the exposed 
-ports to a random port on the host between 49153 and 65535. To find the 
+client that can reach the host. When using -P, Docker will bind the exposed
+ports to a random port on the host between 49153 and 65535. To find the
 mapping between the host ports and the exposed ports, use **docker port**.
 
 **-p**, **--publish**=[]
@@ -232,11 +232,11 @@ interactive shell. The default is value is false.
 
 
 **-v**, **--volume**=*volume*[:ro|:rw]
-   Bind mount a volume to the container. 
+   Bind mount a volume to the container.
 
 The **-v** option can be used one or
 more times to add one or more mounts to a container. These mounts can then be
-used in other containers using the **--volumes-from** option. 
+used in other containers using the **--volumes-from** option.
 
 The volume may be optionally suffixed with :ro or :rw to mount the volumes in
 read-only or read-write mode, respectively. By default, the volumes are mounted
@@ -247,11 +247,11 @@ read-write. See examples.
 Once a volume is mounted in a one container it can be shared with other
 containers using the **--volumes-from** option when running those other
 containers. The volumes can be shared even if the original container with the
-mount is not running. 
+mount is not running.
 
-The container ID may be optionally suffixed with :ro or 
-:rw to mount the volumes in read-only or read-write mode, respectively. By 
-default, the volumes are mounted in the same mode (read write or read only) as 
+The container ID may be optionally suffixed with :ro or
+:rw to mount the volumes in read-only or read-write mode, respectively. By
+default, the volumes are mounted in the same mode (read write or read only) as
 the reference container.
 
 

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -14,7 +14,7 @@ Docker made the choice `172.17.42.1/16` when I started it a few minutes
 ago, for example — a 16-bit netmask providing 65,534 addresses for the
 host machine and its containers.
 
-> **Note:** 
+> **Note:**
 > This document discusses advanced networking configuration
 > and options for Docker. In most cases you won't need this information.
 > If you're looking to get started with a simpler explanation of Docker
@@ -170,6 +170,7 @@ Four different options affect container domain name services.
     When a container process attempts to access `host` and the search
     domain `example.com` is set, for instance, the DNS logic will not
     only look up `host` but also `host.example.com`.
+    Use `--dns-search=.` if you don't wish to set the search domain.
 
 Note that Docker, in the absence of either of the last two options
 above, will make `/etc/resolv.conf` inside of each container look like

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -113,7 +113,7 @@ proxy in front of it. You can listen on port `2375` on all network interfaces
 with `-H tcp://0.0.0.0:2375`, or on a particular network interface using its IP
 address: `-H tcp://192.168.59.103:2375`.
 
-On Systemd based systems, you can communicate with the daemon via 
+On Systemd based systems, you can communicate with the daemon via
 [systemd socket activation](http://0pointer.de/blog/projects/socket-activation.html), use
 `docker -d -H fd://`. Using `fd://` will work perfectly for most setups but
 you can also specify individual sockets: `docker -d -H fd://3`. If the
@@ -999,7 +999,7 @@ used, which is observable by the process being suspended. With the cgroups freez
 the process is unaware, and unable to capture, that it is being suspended,
 and subsequently resumed.
 
-See the 
+See the
 [cgroups freezer documentation](https://www.kernel.org/doc/Documentation/cgroups/freezer-subsystem.txt)
 for further details.
 
@@ -1191,7 +1191,7 @@ removed before the image is removed.
       -d, --detach=false         Detached mode: run the container in the background and print the new container ID
       --device=[]                Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc:rwm)
       --dns=[]                   Set custom DNS servers
-      --dns-search=[]            Set custom DNS search domains
+      --dns-search=[]            Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)
       -e, --env=[]               Set environment variables
       --entrypoint=""            Overwrite the default ENTRYPOINT of the image
       --env-file=[]              Read in a line delimited file of environment variables
@@ -1579,7 +1579,7 @@ them to [*Share Images via Repositories*](
 The `docker unpause` command uses the cgroups freezer to un-suspend all
 processes in a container.
 
-See the 
+See the
 [cgroups freezer documentation](https://www.kernel.org/doc/Documentation/cgroups/freezer-subsystem.txt)
 for further details.
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -489,7 +489,7 @@ Creates a new container.
       --cpuset=""                CPUs in which to allow execution (0-3, 0,1)
       --device=[]                Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc:rwm)
       --dns=[]                   Set custom DNS servers
-      --dns-search=[]            Set custom DNS search domains
+      --dns-search=[]            Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)
       -e, --env=[]               Set environment variables
       --entrypoint=""            Overwrite the default ENTRYPOINT of the image
       --env-file=[]              Read in a line delimited file of environment variables

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -73,7 +73,7 @@ func Parse(cmd *flag.FlagSet, args []string, sysInfo *sysinfo.SysInfo) (*Config,
 	cmd.Var(&flPublish, []string{"p", "-publish"}, fmt.Sprintf("Publish a container's port to the host\nformat: %s\n(use 'docker port' to see the actual mapping)", nat.PortSpecTemplateFormat))
 	cmd.Var(&flExpose, []string{"#expose", "-expose"}, "Expose a port from the container without publishing it to your host")
 	cmd.Var(&flDns, []string{"#dns", "-dns"}, "Set custom DNS servers")
-	cmd.Var(&flDnsSearch, []string{"-dns-search"}, "Set custom DNS search domains")
+	cmd.Var(&flDnsSearch, []string{"-dns-search"}, "Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)")
 	cmd.Var(&flExtraHosts, []string{"-add-host"}, "Add a custom host-to-IP mapping (host:ip)")
 	cmd.Var(&flVolumesFrom, []string{"#volumes-from", "-volumes-from"}, "Mount volumes from the specified container(s)")
 	cmd.Var(&flLxcOpts, []string{"#lxc-conf", "-lxc-conf"}, "(lxc exec-driver only) Add custom lxc options --lxc-conf=\"lxc.cgroup.cpuset.cpus = 0,1\"")


### PR DESCRIPTION
PR #6720 introduce that use `--dns-search=.` will not set `search` in `/etc/resolv.conf`.
