### PR TITLE
Clear the internal state before raising error.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -970,6 +970,7 @@ func (daemon *Daemon) Mount(container *Container) error {
 	if container.basefs == "" {
 		container.basefs = dir
 	} else if container.basefs != dir {
+		daemon.driver.Put(container.ID)
 		return fmt.Errorf("Error: driver %s is returning inconsistent paths for container %s ('%s' then '%s')",
 			daemon.driver, container.ID, container.basefs, dir)
 	}


### PR DESCRIPTION
If we need to raise an error, make sure the internal state is clean, because
a successful driver.Get() may have its internal state changed (eg. counting,
or mounts), while callers will only do that after a succussful Mount().

Signed-off-by: shuai-z zs.broccoli@gmail.com
