### PR TITLE
Use Syscall.Tcgetattr and Syscall.Tcsetattr of GCCGO when available

### DIFF
--- a/pkg/term/term.go
+++ b/pkg/term/term.go
@@ -45,7 +45,7 @@ func SetWinsize(fd uintptr, ws *Winsize) error {
 // IsTerminal returns true if the given file descriptor is a terminal.
 func IsTerminal(fd uintptr) bool {
 	var termios Termios
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(getTermios), uintptr(unsafe.Pointer(&termios)))
+	err := getTerminalState(fd, &termios)
 	return err == 0
 }
 
@@ -55,7 +55,7 @@ func RestoreTerminal(fd uintptr, state *State) error {
 	if state == nil {
 		return ErrInvalidState
 	}
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(setTermios), uintptr(unsafe.Pointer(&state.termios)))
+	err := setTerminalState(fd, &state.termios)
 	if err != 0 {
 		return err
 	}
@@ -64,7 +64,7 @@ func RestoreTerminal(fd uintptr, state *State) error {
 
 func SaveState(fd uintptr) (*State, error) {
 	var oldState State
-	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, getTermios, uintptr(unsafe.Pointer(&oldState.termios))); err != 0 {
+	if err := getTerminalState(fd, &oldState.termios); err != 0 {
 		return nil, err
 	}
 
@@ -75,7 +75,7 @@ func DisableEcho(fd uintptr, state *State) error {
 	newState := state.termios
 	newState.Lflag &^= syscall.ECHO
 
-	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, setTermios, uintptr(unsafe.Pointer(&newState))); err != 0 {
+	if err := setTerminalState(fd, &newState); err != 0 {
 		return err
 	}
 	handleInterrupt(fd, state)

--- a/pkg/term/termios_darwin.go
+++ b/pkg/term/termios_darwin.go
@@ -63,3 +63,13 @@ func MakeRaw(fd uintptr) (*State, error) {
 
 	return &oldState, nil
 }
+
+func getTerminalState(fd uintptr, p *Termios) syscall.Errno {
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(getTermios), uintptr(unsafe.Pointer(p)))
+	return err
+}
+
+func setTerminalState(fd uintptr, p *Termios) syscall.Errno {
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(setTermios), uintptr(unsafe.Pointer(p)))
+	return err
+}

--- a/pkg/term/termios_freebsd.go
+++ b/pkg/term/termios_freebsd.go
@@ -63,3 +63,13 @@ func MakeRaw(fd uintptr) (*State, error) {
 
 	return &oldState, nil
 }
+
+func getTerminalState(fd uintptr, p *Termios) syscall.Errno {
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(getTermios), uintptr(unsafe.Pointer(p)))
+	return err
+}
+
+func setTerminalState(fd uintptr, p *Termios) syscall.Errno {
+	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(setTermios), uintptr(unsafe.Pointer(p)))
+	return err
+}


### PR DESCRIPTION
This PR fixes Issue https://github.com/docker/docker/issues/8653 (This issue seems closed by mistake. My previous PR https://github.com/docker/libcontainer/pull/231 does not fix this issue.)

The direct calls of ioctl for TCGETS and TCSETS do not work correctly on Power architectures as describe in Issue https://github.com/docker/docker/issues/8653.

We discuss this issue with the Go community, and the suggestion is using Syscall.Tcgetattr and Syscall.Tcsetattr available for GCCGO.
https://code.google.com/p/go/issues/detail?id=9010&thanks=9010&ts=1414521788

We use GCCGO to build Docker on Power, and keep using GC on x86_64, so I use build constraints to enable my code only when GCCGO is used on Linux.

Signed-off-by: Yohei Ueda yohei@jp.ibm.com
