### PR TITLE
Add missing code example to RM command

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1133,6 +1133,8 @@ containers removing all network communication.
 The main process inside the container referenced under the link `/redis` will receive
 `SIGKILL`, then the container will be removed.
 
+    $ sudo docker rm $(docker ps -a -q)
+
 This command will delete all stopped containers. The command `docker ps
 -a -q` will return all existing container IDs and pass them to the `rm`
 command which will delete them. Any running containers will not be


### PR DESCRIPTION
The command to delete all stopped containers is described, but not shown. Signed-off-by: John Dowd dowdjj@gmail.com
