### PR TITLE
Fix panic on slow log consumer.

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2474,19 +2474,3 @@ func TestRunSlowStdoutConsumer(t *testing.T) {
 
 	logDone("run - slow consumer")
 }
-
-func consumeSlow(reader io.Reader, chunkSize int, interval time.Duration) (n int, err error) {
-	buffer := make([]byte, chunkSize)
-	for {
-		var readBytes int
-		readBytes, err = reader.Read(buffer)
-		n += readBytes
-		if err != nil {
-			if err == io.EOF {
-				err = nil
-			}
-			return
-		}
-		time.Sleep(interval)
-	}
-}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"os"
@@ -2462,7 +2461,7 @@ func TestRunSlowStdoutConsumer(t *testing.T) {
 	if err := c.Start(); err != nil {
 		t.Fatal(err)
 	}
-	n, err := consumeSlow(stdout, 10000, 5*time.Millisecond)
+	n, err := consumeWithSpeed(stdout, 10000, 5*time.Millisecond, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -254,18 +254,25 @@ func makeRandomString(n int) string {
 	return string(b)
 }
 
-func consumeSlow(reader io.Reader, chunkSize int, interval time.Duration) (n int, err error) {
+// Reads chunkSize bytes from reader after every interval.
+// Returns total read bytes.
+func consumeWithSpeed(reader io.Reader, chunkSize int, interval time.Duration, stop chan bool) (n int, err error) {
 	buffer := make([]byte, chunkSize)
 	for {
-		var readBytes int
-		readBytes, err = reader.Read(buffer)
-		n += readBytes
-		if err != nil {
-			if err == io.EOF {
-				err = nil
-			}
+		select {
+		case <-stop:
 			return
+		default:
+			var readBytes int
+			readBytes, err = reader.Read(buffer)
+			n += readBytes
+			if err != nil {
+				if err == io.EOF {
+					err = nil
+				}
+				return
+			}
+			time.Sleep(interval)
 		}
-		time.Sleep(interval)
 	}
 }

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -253,3 +253,19 @@ func makeRandomString(n int) string {
 	}
 	return string(b)
 }
+
+func consumeSlow(reader io.Reader, chunkSize int, interval time.Duration) (n int, err error) {
+	buffer := make([]byte, chunkSize)
+	for {
+		var readBytes int
+		readBytes, err = reader.Read(buffer)
+		n += readBytes
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+			}
+			return
+		}
+		time.Sleep(interval)
+	}
+}


### PR DESCRIPTION
Fixes #8832

All stdio streams need to finish writing before the
connection can be closed.

Signed-off-by: Tõnis Tiigi tonistiigi@gmail.com (github: tonistiigi)

ping @LK4D4 @jfrazelle 
