### PR TITLE
Docs: remove registry port-number from CA certificate path

### DIFF
--- a/docs/sources/reference/api/registry_api.md
+++ b/docs/sources/reference/api/registry_api.md
@@ -70,7 +70,7 @@ are then delegated to SSH (e.g., with public keys).
 > **Note**:
 > Private registry servers that expose an HTTP endpoint need to be secured with
 > TLS (preferably TLSv1.2, but at least TLSv1.0). Make sure to put the CA
-> certificate at /etc/docker/certs.d/my.registry.com:5000/ca.crt on the Docker
+> certificate at /etc/docker/certs.d/my.registry.com/ca.crt on the Docker
 > host, so that the daemon can securely access the private registry.
 > Support for SSLv3 and lower is not available due to security issues.
 


### PR DESCRIPTION
The path name should not contain the port number of the private registry 
because a colon (`:`) is used as a path delimiter on the file system.

Signed-off-by: Sebastiaan van Stijn thaJeztah@users.noreply.github.com
