### PR TITLE
docker metrics (read metrics from cgroups for specified container)

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -812,6 +812,46 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 	return nil
 }
 
+func (cli *DockerCli) CmdMetrics(args ...string) error {
+	cmd := cli.Subcmd("metrics", "CONTAINER", "Return runtime information on a container")
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+	if cmd.NArg() < 1 {
+		cmd.Usage()
+		return nil
+	}
+
+	indented := new(bytes.Buffer)
+	indented.WriteByte('[')
+	status := 0
+
+	for _, name := range cmd.Args() {
+		obj, _, err := readBody(cli.call("GET", "/containers/"+name+"/metrics", nil, false))
+		if err = json.Indent(indented, obj, "", "    "); err != nil {
+			fmt.Fprintf(cli.err, "%s\n", err)
+			status = 1
+			continue
+		}
+		indented.WriteString(",")
+	}
+
+	if indented.Len() > 1 {
+		// Remove trailing ','
+		indented.Truncate(indented.Len() - 1)
+	}
+	indented.WriteByte(']')
+
+	if _, err := io.Copy(cli.out, indented); err != nil {
+		return err
+	}
+
+	if status != 0 {
+		return &utils.StatusError{StatusCode: status}
+	}
+	return nil
+}
+
 func (cli *DockerCli) CmdTop(args ...string) error {
 	cmd := cli.Subcmd("top", "CONTAINER [ps OPTIONS]", "Display the running processes of a container")
 	if err := cmd.Parse(args); err != nil {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -343,6 +343,19 @@ func getContainersTop(eng *engine.Engine, version version.Version, w http.Respon
 	return job.Run()
 }
 
+func getContainersMetrics(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := parseForm(r); err != nil {
+		return err
+	}
+	if vars == nil {
+		return fmt.Errorf("Missing parameter")
+	}
+
+	job := eng.Job("container_metrics", vars["name"])
+	streamJSON(job, w, false)
+	return job.Run()
+}
+
 func getContainersJSON(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -1262,6 +1275,7 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 			"/containers/{name:.*}/top":       getContainersTop,
 			"/containers/{name:.*}/logs":      getContainersLogs,
 			"/containers/{name:.*}/attach/ws": wsContainersAttach,
+			"/containers/{name:.*}/metrics":   getContainersMetrics,
 		},
 		"POST": {
 			"/auth":                         postAuth,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -109,6 +109,7 @@ func (daemon *Daemon) Install(eng *engine.Engine) error {
 		"container_changes": daemon.ContainerChanges,
 		"container_copy":    daemon.ContainerCopy,
 		"container_inspect": daemon.ContainerInspect,
+		"container_metrics": daemon.ContainerMetrics,
 		"containers":        daemon.Containers,
 		"create":            daemon.ContainerCreate,
 		"rm":                daemon.ContainerRm,

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -1,0 +1,97 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/docker/docker/engine"
+	"github.com/docker/libcontainer/cgroups"
+)
+
+var metricInfoTable map[string][]string
+
+func init() {
+	metricInfoTable = map[string][]string{
+		"CpuUsage":       {"cpuacct", "usage"},
+		"MemoryUsage":    {"memory", "usage_in_bytes"},
+		"MemoryMaxUsage": {"memory", "max_usage_in_bytes"},
+		"MemoryLimit":    {"memory", "limit_in_bytes"},
+	}
+}
+
+func (daemon *Daemon) ContainerMetrics(job *engine.Job) engine.Status {
+	if len(job.Args) != 1 {
+		return job.Errorf("usage: %s NAME", job.Name)
+	}
+	name := job.Args[0]
+	if container := daemon.Get(name); container != nil {
+		container.Lock()
+		defer container.Unlock()
+
+		out := &engine.Env{}
+		out.Set("Id", container.ID)
+		out.Set("Image", container.Image)
+		out.Set("Name", container.Name)
+		out.SetJson("State", container.State)
+
+		metrics := map[string]string{}
+		for metricKey, cgroupInfo := range metricInfoTable {
+			cgroupSystem, cgroupKey := cgroupInfo[0], cgroupInfo[1]
+			value, err := cgSubsystemValue(container.ID, cgroupSystem, cgroupKey)
+			if err != nil {
+				metrics[metricKey] = err.Error()
+			} else {
+				metrics[metricKey] = value
+			}
+		}
+		out.SetJson("Metrics", metrics)
+
+		if _, err := out.WriteTo(job.Stdout); err != nil {
+			return job.Error(err)
+		}
+		return engine.StatusOK
+	}
+	return job.Errorf("No such container: %s", name)
+}
+
+func cgSubsystemValue(id, subsystem, key string) (string, error) {
+	cgDir, err := cgSubsystemDir(id, subsystem)
+	if err != nil {
+		return "", err
+	}
+	data, err := ioutil.ReadFile(filepath.Join(cgDir, fmt.Sprintf("%s.%s", subsystem, key)))
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(string(data), "\r\n"+string(0)), nil
+}
+
+func cgSubsystemDir(id, subsystem string) (string, error) {
+	cgroupRoot, err := cgroups.FindCgroupMountpoint(subsystem)
+	if err != nil {
+		return "", err
+	}
+
+	cgroupDir, err := cgroups.GetThisCgroupDir(subsystem)
+	if err != nil {
+		return "", err
+	}
+
+	// With more recent lxc versions use, cgroup will be in lxc/, we'll search in bot
+	dirnames := []string{
+		filepath.Join(cgroupRoot, cgroupDir, id),
+		filepath.Join(cgroupRoot, cgroupDir, "docker", id),
+		filepath.Join(cgroupRoot, cgroupDir, "lxc", id),
+	}
+	for i := range dirnames {
+		if _, err := os.Stat(dirnames[i]); err == nil {
+			return dirnames[i], nil
+		}
+	}
+
+	return "", fmt.Errorf("Error: cgroup subsystem '%s' directory not found for container '%s'", subsystem, id)
+}

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -74,6 +74,7 @@ func init() {
 			{"login", "Register or log in to a Docker registry server"},
 			{"logout", "Log out from a Docker registry server"},
 			{"logs", "Fetch the logs of a container"},
+			{"metrics", "Fetch metrics of a container"},
 			{"port", "Lookup the public-facing port that is NAT-ed to PRIVATE_PORT"},
 			{"pause", "Pause all processes within a container"},
 			{"ps", "List containers"},


### PR DESCRIPTION
Fixes #8842.

This is first and very simple implementation of docker metrics command. A lot of work needed to push it to production.

Roadmap:
- make find of cgroup paths more reliable (not just try to search predefined locations, but get exact value from procfs)
- specify set of metrics (from `cpuacct`, `memory`, `blkio`, ... controllers)
- store metrics in `struct` instead of `map[string]string` (typed data)
- `-f FORMAT` support
- documentation

PS. PR created for further discussion and this branch will be constantly updated.

/cc @shykes @tobegit3hub @thaJeztah
