### PR TITLE
Ipv6 support for iptables

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	FixedCIDR                   string
 	InsecureRegistries          []string
 	InterContainerCommunication bool
+	UseIpv6                     bool
 	GraphDriver                 string
 	GraphOptions                []string
 	ExecDriver                  string
@@ -58,6 +59,7 @@ func (config *Config) InstallFlags() {
 	flag.StringVar(&config.FixedCIDR, []string{"-fixed-cidr"}, "", "IPv4 subnet for fixed IPs (ex: 10.20.0.0/16)\nthis subnet must be nested in the bridge subnet (which is defined by -b or --bip)")
 	opts.ListVar(&config.InsecureRegistries, []string{"-insecure-registry"}, "Enable insecure communication with specified registries (no certificate verification for HTTPS and enable HTTP fallback)")
 	flag.BoolVar(&config.InterContainerCommunication, []string{"#icc", "-icc"}, true, "Enable inter-container communication")
+	flag.BoolVar(&config.UseIpv6, []string{"#ipv6", "-ipv6"}, false, "Use ipv6")
 	flag.StringVar(&config.GraphDriver, []string{"s", "-storage-driver"}, "", "Force the Docker runtime to use a specific storage driver")
 	flag.StringVar(&config.ExecDriver, []string{"e", "-exec-driver"}, "native", "Force the Docker runtime to use a specific exec driver")
 	flag.BoolVar(&config.EnableSelinuxSupport, []string{"-selinux-enabled"}, false, "Enable selinux support. SELinux does not presently support the BTRFS storage driver")

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -851,6 +851,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 
 		job.SetenvBool("EnableIptables", config.EnableIptables)
 		job.SetenvBool("InterContainerCommunication", config.InterContainerCommunication)
+		job.SetenvBool("UseIpv6", config.UseIpv6)
 		job.SetenvBool("EnableIpForward", config.EnableIpForward)
 		job.SetenvBool("EnableIpMasq", config.EnableIpMasq)
 		job.Setenv("BridgeIface", config.BridgeIface)


### PR DESCRIPTION
This extends iptables.go to support IPv6 addresses, and adds a config option to use IPv6 addresses and not IPv4 addresses.

Another step towards IPv6!
