### PR TITLE
Remaining steps for IPv6 support

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	FixedCIDR                   string
 	InsecureRegistries          []string
 	InterContainerCommunication bool
+	UseIpv6                     bool
 	GraphDriver                 string
 	GraphOptions                []string
 	ExecDriver                  string
@@ -58,6 +59,7 @@ func (config *Config) InstallFlags() {
 	flag.StringVar(&config.FixedCIDR, []string{"-fixed-cidr"}, "", "IPv4 subnet for fixed IPs (ex: 10.20.0.0/16)\nthis subnet must be nested in the bridge subnet (which is defined by -b or --bip)")
 	opts.ListVar(&config.InsecureRegistries, []string{"-insecure-registry"}, "Enable insecure communication with specified registries (no certificate verification for HTTPS and enable HTTP fallback)")
 	flag.BoolVar(&config.InterContainerCommunication, []string{"#icc", "-icc"}, true, "Enable inter-container communication")
+	flag.BoolVar(&config.UseIpv6, []string{"#ipv6", "-ipv6"}, false, "Use ipv6")
 	flag.StringVar(&config.GraphDriver, []string{"s", "-storage-driver"}, "", "Force the Docker runtime to use a specific storage driver")
 	flag.StringVar(&config.ExecDriver, []string{"e", "-exec-driver"}, "native", "Force the Docker runtime to use a specific exec driver")
 	flag.BoolVar(&config.EnableSelinuxSupport, []string{"-selinux-enabled"}, false, "Enable selinux support. SELinux does not presently support the BTRFS storage driver")

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -851,6 +851,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 
 		job.SetenvBool("EnableIptables", config.EnableIptables)
 		job.SetenvBool("InterContainerCommunication", config.InterContainerCommunication)
+		job.SetenvBool("UseIpv6", config.UseIpv6)
 		job.SetenvBool("EnableIpForward", config.EnableIpForward)
 		job.SetenvBool("EnableIpMasq", config.EnableIpMasq)
 		job.Setenv("BridgeIface", config.BridgeIface)

--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -83,6 +83,7 @@ func InitDriver(job *engine.Job) engine.Status {
 		network        *net.IPNet
 		enableIPTables = job.GetenvBool("EnableIptables")
 		icc            = job.GetenvBool("InterContainerCommunication")
+		useIpv6        = job.GetenvBool("UseIpv6")
 		ipMasq         = job.GetenvBool("EnableIpMasq")
 		ipForward      = job.GetenvBool("EnableIpForward")
 		bridgeIP       = job.Getenv("BridgeIP")
@@ -100,7 +101,7 @@ func InitDriver(job *engine.Job) engine.Status {
 		bridgeIface = DefaultNetworkBridge
 	}
 
-	addr, err := networkdriver.GetIfaceAddr(bridgeIface)
+	addr, err := networkdriver.GetIfaceAddr(bridgeIface, !useIpv6, useIpv6)
 	if err != nil {
 		// If we're not using the default bridge, fail without trying to create it
 		if !usingDefaultBridge {
@@ -111,7 +112,7 @@ func InitDriver(job *engine.Job) engine.Status {
 			return job.Error(err)
 		}
 
-		addr, err = networkdriver.GetIfaceAddr(bridgeIface)
+		addr, err = networkdriver.GetIfaceAddr(bridgeIface, !useIpv6, useIpv6)
 		if err != nil {
 			return job.Error(err)
 		}
@@ -145,12 +146,12 @@ func InitDriver(job *engine.Job) engine.Status {
 	}
 
 	// We can always try removing the iptables
-	if err := iptables.RemoveExistingChain("DOCKER"); err != nil {
+	if err := iptables.RemoveExistingChain(useIpv6, "DOCKER"); err != nil {
 		return job.Error(err)
 	}
 
 	if enableIPTables {
-		chain, err := iptables.NewChain("DOCKER", bridgeIface)
+		chain, err := iptables.NewChain(useIpv6, "DOCKER", bridgeIface)
 		if err != nil {
 			return job.Error(err)
 		}
@@ -185,14 +186,21 @@ func InitDriver(job *engine.Job) engine.Status {
 	return engine.StatusOK
 }
 
+func IsIpv6(addr net.Addr) bool {
+	ip := (addr.(*net.IPNet)).IP
+	return ip.To16() != nil
+}
+
 func setupIPTables(addr net.Addr, icc, ipmasq bool) error {
 	// Enable NAT
+
+	useIpv6 := IsIpv6(addr)
 
 	if ipmasq {
 		natArgs := []string{"POSTROUTING", "-t", "nat", "-s", addr.String(), "!", "-o", bridgeIface, "-j", "MASQUERADE"}
 
-		if !iptables.Exists(natArgs...) {
-			if output, err := iptables.Raw(append([]string{"-I"}, natArgs...)...); err != nil {
+		if !iptables.Exists(useIpv6, natArgs...) {
+			if output, err := iptables.Raw(useIpv6, append([]string{"-I"}, natArgs...)...); err != nil {
 				return fmt.Errorf("Unable to enable network bridge NAT: %s", err)
 			} else if len(output) != 0 {
 				return fmt.Errorf("Error iptables postrouting: %s", output)
@@ -207,22 +215,22 @@ func setupIPTables(addr net.Addr, icc, ipmasq bool) error {
 	)
 
 	if !icc {
-		iptables.Raw(append([]string{"-D"}, acceptArgs...)...)
+		iptables.Raw(useIpv6, append([]string{"-D"}, acceptArgs...)...)
 
-		if !iptables.Exists(dropArgs...) {
+		if !iptables.Exists(useIpv6, dropArgs...) {
 			log.Debugf("Disable inter-container communication")
-			if output, err := iptables.Raw(append([]string{"-I"}, dropArgs...)...); err != nil {
+			if output, err := iptables.Raw(useIpv6, append([]string{"-I"}, dropArgs...)...); err != nil {
 				return fmt.Errorf("Unable to prevent intercontainer communication: %s", err)
 			} else if len(output) != 0 {
 				return fmt.Errorf("Error disabling intercontainer communication: %s", output)
 			}
 		}
 	} else {
-		iptables.Raw(append([]string{"-D"}, dropArgs...)...)
+		iptables.Raw(useIpv6, append([]string{"-D"}, dropArgs...)...)
 
-		if !iptables.Exists(acceptArgs...) {
+		if !iptables.Exists(useIpv6, acceptArgs...) {
 			log.Debugf("Enable inter-container communication")
-			if output, err := iptables.Raw(append([]string{"-I"}, acceptArgs...)...); err != nil {
+			if output, err := iptables.Raw(useIpv6, append([]string{"-I"}, acceptArgs...)...); err != nil {
 				return fmt.Errorf("Unable to allow intercontainer communication: %s", err)
 			} else if len(output) != 0 {
 				return fmt.Errorf("Error enabling intercontainer communication: %s", output)
@@ -232,8 +240,8 @@ func setupIPTables(addr net.Addr, icc, ipmasq bool) error {
 
 	// Accept all non-intercontainer outgoing packets
 	outgoingArgs := []string{"FORWARD", "-i", bridgeIface, "!", "-o", bridgeIface, "-j", "ACCEPT"}
-	if !iptables.Exists(outgoingArgs...) {
-		if output, err := iptables.Raw(append([]string{"-I"}, outgoingArgs...)...); err != nil {
+	if !iptables.Exists(useIpv6, outgoingArgs...) {
+		if output, err := iptables.Raw(useIpv6, append([]string{"-I"}, outgoingArgs...)...); err != nil {
 			return fmt.Errorf("Unable to allow outgoing packets: %s", err)
 		} else if len(output) != 0 {
 			return fmt.Errorf("Error iptables allow outgoing: %s", output)
@@ -243,8 +251,8 @@ func setupIPTables(addr net.Addr, icc, ipmasq bool) error {
 	// Accept incoming packets for existing connections
 	existingArgs := []string{"FORWARD", "-o", bridgeIface, "-m", "conntrack", "--ctstate", "RELATED,ESTABLISHED", "-j", "ACCEPT"}
 
-	if !iptables.Exists(existingArgs...) {
-		if output, err := iptables.Raw(append([]string{"-I"}, existingArgs...)...); err != nil {
+	if !iptables.Exists(useIpv6, existingArgs...) {
+		if output, err := iptables.Raw(useIpv6, append([]string{"-I"}, existingArgs...)...); err != nil {
 			return fmt.Errorf("Unable to allow incoming packets: %s", err)
 		} else if len(output) != 0 {
 			return fmt.Errorf("Error iptables allow incoming: %s", output)
@@ -515,10 +523,11 @@ func LinkContainers(job *engine.Job) engine.Status {
 		parentIP     = job.Getenv("ParentIP")
 		ignoreErrors = job.GetenvBool("IgnoreErrors")
 		ports        = job.GetenvList("Ports")
+		useIpv6      = job.GetenvBool("UseIpv6")
 	)
 	for _, value := range ports {
 		port := nat.Port(value)
-		if output, err := iptables.Raw(action, "FORWARD",
+		if output, err := iptables.Raw(useIpv6, action, "FORWARD",
 			"-i", bridgeIface, "-o", bridgeIface,
 			"-p", port.Proto(),
 			"-s", parentIP,
@@ -530,7 +539,7 @@ func LinkContainers(job *engine.Job) engine.Status {
 			return job.Errorf("Error toggle iptables forward: %s", output)
 		}
 
-		if output, err := iptables.Raw(action, "FORWARD",
+		if output, err := iptables.Raw(useIpv6, action, "FORWARD",
 			"-i", bridgeIface, "-o", bridgeIface,
 			"-p", port.Proto(),
 			"-s", childIP,

--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -533,7 +533,7 @@ func LinkContainers(job *engine.Job) engine.Status {
 
 	for _, value := range ports {
 		port := nat.Port(value)
-		if output, err := iptable.Raw(useIpv6, action, "FORWARD",
+		if output, err := iptable.Raw(action, "FORWARD",
 			"-i", bridgeIface, "-o", bridgeIface,
 			"-p", port.Proto(),
 			"-s", parentIP,

--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -323,6 +323,14 @@ func configureBridge(bridgeIP string) error {
 		return err
 	}
 
+	if ipAddr.To16() != nil {
+		// Enable IPv6 on the bridge
+		procFile := "/proc/sys/net/ipv6/conf/" + iface.Name + "/disable_ipv6"
+		if err := ioutil.WriteFile(procFile, []byte{'0', '\n'}, 0644); err != nil {
+			return fmt.Errorf("Unable to enable IPv6 addresses on bridge: %s\n", err)
+		}
+	}
+
 	if netlink.NetworkLinkAddIp(iface, ipAddr, ipNet); err != nil {
 		return fmt.Errorf("Unable to add private network: %s", err)
 	}

--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -529,7 +529,7 @@ func LinkContainers(job *engine.Job) engine.Status {
 		useIpv6      = job.GetenvBool("UseIpv6")
 	)
 
-        iptable := iptables.GetTable(useIpv6)
+	iptable := iptables.GetTable(useIpv6)
 
 	for _, value := range ports {
 		port := nat.Port(value)

--- a/daemon/networkdriver/ipallocator/allocator.go
+++ b/daemon/networkdriver/ipallocator/allocator.go
@@ -20,13 +20,9 @@ type allocatedMap struct {
 
 func newAllocatedMap(network *net.IPNet) *allocatedMap {
 	firstIP, lastIP := networkdriver.NetworkRange(network)
-	begin := big.NewInt(0).Add(ipToBigInt(firstIP), big.NewInt(1))
+	// Skip the first IP, reserving it for the bridge
+	begin := big.NewInt(0).Add(ipToBigInt(firstIP), big.NewInt(2))
 	end := big.NewInt(0).Sub(ipToBigInt(lastIP), big.NewInt(1))
-
-	// if IPv4 network, then allocation range starts at begin + 1 because begin is bridge IP
-	if len(firstIP) == 4 {
-		begin = begin.Add(begin, big.NewInt(1))
-	}
 
 	return &allocatedMap{
 		p:     make(map[string]struct{}),

--- a/daemon/networkdriver/ipallocator/allocator_test.go
+++ b/daemon/networkdriver/ipallocator/allocator_test.go
@@ -93,7 +93,7 @@ func TestRequestNewIpV6(t *testing.T) {
 
 	var ip net.IP
 	var err error
-	for i := 1; i < 10; i++ {
+	for i := 2; i < 10; i++ {
 		ip, err = RequestIP(network, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -457,11 +457,11 @@ func TestAllocateDifferentSubnets(t *testing.T) {
 		1: net.IPv4(192, 168, 0, 3),
 		2: net.IPv4(127, 0, 0, 2),
 		3: net.IPv4(127, 0, 0, 3),
-		4: net.ParseIP("2a00:1450::1"),
-		5: net.ParseIP("2a00:1450::2"),
-		6: net.ParseIP("2a00:1450::3"),
-		7: net.ParseIP("2a00:1632::1"),
-		8: net.ParseIP("2a00:1632::2"),
+		4: net.ParseIP("2a00:1450::2"),
+		5: net.ParseIP("2a00:1450::3"),
+		6: net.ParseIP("2a00:1450::4"),
+		7: net.ParseIP("2a00:1632::2"),
+		8: net.ParseIP("2a00:1632::3"),
 	}
 
 	ip11, err := RequestIP(network1, nil)

--- a/daemon/networkdriver/portmapper/mapper_test.go
+++ b/daemon/networkdriver/portmapper/mapper_test.go
@@ -21,7 +21,9 @@ func reset() {
 func TestSetIptablesChain(t *testing.T) {
 	defer reset()
 
+	table := iptables.GetTable(false)
 	c := &iptables.Chain{
+		Table:  table,
 		Name:   "TEST",
 		Bridge: "192.168.1.1",
 	}

--- a/daemon/networkdriver/utils.go
+++ b/daemon/networkdriver/utils.go
@@ -86,10 +86,10 @@ func GetIfaceAddr(name string, ipv4 bool, ipv6 bool) (net.Addr, error) {
 	var addrs6 []net.Addr
 	for _, addr := range addrs {
 		ip := (addr.(*net.IPNet)).IP
-		if ip4 := ip.To4(); ip4 != nil {
+		isIpv4 := ip.To4() != nil
+		if isIpv4 {
 			addrs4 = append(addrs4, addr)
-		}
-		if ip6 := ip.To16(); ip6 != nil {
+		} else {
 			addrs6 = append(addrs6, addr)
 		}
 	}

--- a/daemon/networkdriver/utils.go
+++ b/daemon/networkdriver/utils.go
@@ -73,7 +73,7 @@ func NetworkRange(network *net.IPNet) (net.IP, net.IP) {
 }
 
 // Return the IPv4 address of a network interface
-func GetIfaceAddr(name string, ipv4 bool, ipv6 bool) (net.Addr, error) {
+func GetIfaceAddr(name string, ipv6 bool) (net.Addr, error) {
 	iface, err := net.InterfaceByName(name)
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func GetIfaceAddr(name string, ipv4 bool, ipv6 bool) (net.Addr, error) {
 			addrs6 = append(addrs6, addr)
 		}
 	}
-	if ipv4 && len(addrs4) != 0 {
+	if !ipv6 && len(addrs4) != 0 {
 		if len(addrs4) > 1 {
 			fmt.Printf("Interface %v has more than 1 IPv4 address. Defaulting to using %v\n",
 				name, (addrs4[0].(*net.IPNet)).IP)


### PR DESCRIPTION
Most of the work for IPv6 has already been done; this adds support for using ip6tables, makes sure ipv6 support is enabled on the docker0 bridge, and skips the first IP even on IPv6 so we don't have to use a sub-range.
