### PR TITLE
registry: default --insecure-registry to localhost and 127.0.0.1

### DIFF
--- a/registry/endpoint.go
+++ b/registry/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -154,7 +155,16 @@ func IsSecure(hostname string, insecureRegistries []string) bool {
 	if hostname == IndexServerAddress() {
 		return true
 	}
-
+	if len(insecureRegistries) == 0 {
+		host, _, err := net.SplitHostPort(hostname)
+		if err != nil {
+			host = hostname
+		}
+		if host == "127.0.0.1" || host == "localhost" {
+			return false
+		}
+		return true
+	}
 	for _, h := range insecureRegistries {
 		if hostname == h {
 			return false

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -326,12 +326,14 @@ func TestIsSecure(t *testing.T) {
 		insecureRegistries []string
 		expected           bool
 	}{
+		{"localhost", []string{}, false},
+		{"localhost:5000", []string{}, false},
+		{"127.0.0.1", []string{}, false},
+		{"127.0.0.1:5000", []string{}, false},
+		{"localhost", []string{"example.com"}, true},
+		{"127.0.0.1", []string{"example.com"}, true},
 		{"example.com", []string{}, true},
 		{"example.com", []string{"example.com"}, false},
-		{"localhost", []string{"localhost:5000"}, true},
-		{"localhost:5000", []string{"localhost:5000"}, false},
-		{"localhost", []string{"example.com"}, true},
-		{"127.0.0.1:5000", []string{"127.0.0.1:5000"}, false},
 	}
 	for _, tt := range tests {
 		if sec := IsSecure(tt.addr, tt.insecureRegistries); sec != tt.expected {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -334,6 +334,7 @@ func TestIsSecure(t *testing.T) {
 		{"127.0.0.1", []string{"example.com"}, true},
 		{"example.com", []string{}, true},
 		{"example.com", []string{"example.com"}, false},
+		{"localhost", []string{""}, true},
 	}
 	for _, tt := range tests {
 		if sec := IsSecure(tt.addr, tt.insecureRegistries); sec != tt.expected {


### PR DESCRIPTION
Note sure it's the best way to do this, since `opt.ListVar` have no defaults.

Fixes #8889 #8887

Also added some tests for `registry.IsSecure`

This PR makes the daemon treat `localhost` and `127.0.0.1` as part of the `insecureRegistries` whitelist, if the said list is empty.
