### PR TITLE
Skip V2 registry and immediately fallback to V1 when mirrors are provided

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -139,7 +139,7 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 		mirrors = s.mirrors
 	}
 
-	if isOfficial || endpoint.Version == registry.APIVersion2 {
+	if len(mirrors) == 0 && (isOfficial || endpoint.Version == registry.APIVersion2) {
 		j := job.Eng.Job("trust_update_base")
 		if err = j.Run(); err != nil {
 			return job.Errorf("error updating trust base graph: %s", err)


### PR DESCRIPTION
Since V2 registry does not yet implement mirrors, when mirrors are given automatically fallback to V1 without checking V2 first.

Closes #8688
