### PR TITLE
Clarify USER instruction documentation

### DIFF
--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -731,7 +731,8 @@ documentation.
     USER daemon
 
 The `USER` instruction sets the user name or UID to use when running the image
-and for any following `RUN` directives.
+and for any `RUN`, `CMD` and `ENTRYPOINT` instructions that follow it in the
+`Dockerfile`.
 
 ## WORKDIR
 


### PR DESCRIPTION
Reuse `WORKDIR` wording to specify that the `USER` instructions affect the following `RUN`, `CMD`, and `ENTRYPOINT` instructions (as noted in comments on #8903).

Signed-off-by: Arnaud Porterie <arnaud.porterie@docker.com>
