### PR TITLE
Remove extra line feed typo

### DIFF
--- a/docs/sources/userguide/dockerizing.md
+++ b/docs/sources/userguide/dockerizing.md
@@ -126,8 +126,7 @@ identifies a container so we can work with it.
 > on we'll see a shorter ID and some ways to name our containers to make
 > working with them easier.
 
-We can use this container ID to see what's happening with our `hello
-world` daemon.
+We can use this container ID to see what's happening with our `hello world` daemon.
 
 Firstly let's make sure our container is running. We can
 do that with the `docker ps` command. The `docker ps` command queries


### PR DESCRIPTION
The removed extra line feed broke the paragraph at https://docs.docker.com/userguide/dockerizing/
