### PR TITLE
Fix create container output messages when the image is not existed locally

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2026,16 +2026,15 @@ func (cli *DockerCli) CmdTag(args ...string) error {
 }
 
 func (cli *DockerCli) pullImage(image string) error {
-	return cli.pullImageCustomOut(image, cli.out)
+	repos, tag := parsers.ParseRepositoryTag(image)
+	if tag == "" {
+		tag = graph.DEFAULTTAG
+	}
+	return cli.pullImageCustomOut(repos, tag, cli.out)
 }
 
-func (cli *DockerCli) pullImageCustomOut(image string, out io.Writer) error {
+func (cli *DockerCli) pullImageCustomOut(repos string, tag string, out io.Writer) error {
 	v := url.Values{}
-	repos, tag := parsers.ParseRepositoryTag(image)
-	// pull only the image tagged 'latest' if no tag was specified
-	if tag == "" {
-		tag = "latest"
-	}
 	v.Set("fromImage", repos)
 	v.Set("tag", tag)
 
@@ -2123,10 +2122,14 @@ func (cli *DockerCli) createContainer(config *runconfig.Config, hostConfig *runc
 	stream, statusCode, err := cli.call("POST", "/containers/create?"+containerValues.Encode(), mergedConfig, false)
 	//if image not found try to pull it
 	if statusCode == 404 {
-		fmt.Fprintf(cli.err, "Unable to find image '%s' locally\n", config.Image)
+		repos, tag := parsers.ParseRepositoryTag(config.Image)
+		if tag == "" {
+			tag = graph.DEFAULTTAG
+		}
+		fmt.Fprintf(cli.err, "Unable to find image '%s:%s' locally\n", repos, tag)
 
 		// we don't want to write to stdout anything apart from container.ID
-		if err = cli.pullImageCustomOut(config.Image, cli.err); err != nil {
+		if err = cli.pullImageCustomOut(repos, tag, cli.err); err != nil {
 			return nil, err
 		}
 		// Retry


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

when create a container with an image which is not existed locally and without tag,the output messages would confuse the user.For example:

$ sudo docker run -ti ubuntu /bin/bash
Unable to find image 'ubuntu' locally

I think the output messages "Unable to find image 'ubuntu' locally" should be "Unable to find image 'ubuntu:latest' locally" ,which is more exactly and in fact 'ubuntu' is not an image. Sometimes I has an image 
'ubuntu:14.04' locally,but forget the tag when create a container,the output "Unable to find image 'ubuntu' locally" is confused because I has repository "ubuntu" locally,and "Unable to find image 'ubuntu:latest' locally" 
can remind me that I may forget the tag.
relate #8868  
