### PR TITLE
Fix help text being incorrect with multiple args

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -75,11 +75,11 @@ func (cli *DockerCli) Cmd(args ...string) error {
 		method, exists := cli.getMethod(args[0])
 		if !exists {
 			fmt.Println("Error: Command not found:", args[0])
-			return cli.CmdHelp(args[1:]...)
+			return cli.CmdHelp()
 		}
 		return method(args[1:]...)
 	}
-	return cli.CmdHelp(args...)
+	return cli.CmdHelp()
 }
 
 func (cli *DockerCli) Subcmd(name, signature, description string) *flag.FlagSet {


### PR DESCRIPTION
I'm not quite sure what the reasoning behind passing the arguments to `CmdHelp` is. Line 82 is a noop because `args` is empty. Line 78 produced odd behaviour when multiple args were passed to a non-existent command. E.g. it would print the help text for the second arg instead of the root help message:

```
$ docker fdkjhds run
Error: Command not found: fdkjhds

Usage: docker run [OPTIONS] IMAGE [COMMAND] [ARG...]

...
```
