### PR TITLE
Update "official repos" doc to mention 100 char short desc limit

### DIFF
--- a/docs/sources/docker-hub/official_repos.md
+++ b/docs/sources/docker-hub/official_repos.md
@@ -60,7 +60,7 @@ should also:
 
 * Be named `README-short.txt`
 * Reside in the repo for the “latest” tag
-* Not exceed 200 characters
+* Not exceed 100 characters
 
 ### A logo
 


### PR DESCRIPTION
The Hub no longer accepts short descriptions over 100 characters.
