### PR TITLE
Add --allow-insecure to docker pull

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1197,6 +1197,7 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 func (cli *DockerCli) CmdPull(args ...string) error {
 	cmd := cli.Subcmd("pull", "NAME[:TAG]", "Pull an image or a repository from the registry")
 	allTags := cmd.Bool([]string{"a", "-all-tags"}, false, "Download all tagged images in the repository")
+	allowInsecure := cmd.Bool([]string{"i", "-allow-insecure"}, false, "Allow insecure repository")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -1230,6 +1231,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 
 	// Resolve the Auth config relevant for this server
 	authConfig := cli.configFile.ResolveAuthConfig(hostname)
+	authConfig.AllowInsecure = *allowInsecure
 
 	pull := func(authConfig registry.AuthConfig) error {
 		buf, err := json.Marshal(authConfig)

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -115,6 +115,10 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 
 	secure := registry.IsSecure(hostname, s.insecureRegistries)
 
+	if secure && authConfig.AllowInsecure {
+		secure = false
+	}
+
 	endpoint, err := registry.NewEndpoint(hostname, secure)
 	if err != nil {
 		return job.Error(err)

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -35,6 +35,7 @@ type AuthConfig struct {
 	Auth          string `json:"auth"`
 	Email         string `json:"email"`
 	ServerAddress string `json:"serveraddress,omitempty"`
+	AllowInsecure bool   `json:"allowinsecure,omitempty"`
 }
 
 type ConfigFile struct {


### PR DESCRIPTION
This adds a parameter to the docker pull command to allow users to manually specify an insecure repository when performing "docker pull", i.e. 

docker pull --allow-insecure internal.company.domain:5000/image_name
