### PR TITLE
pkg/mount: include optional field

### DIFF
--- a/pkg/mount/mountinfo.go
+++ b/pkg/mount/mountinfo.go
@@ -1,7 +1,7 @@
 package mount
 
 type MountInfo struct {
-	Id, Parent, Major, Minor int
-	Root, Mountpoint, Opts   string
-	Fstype, Source, VfsOpts  string
+	Id, Parent, Major, Minor         int
+	Root, Mountpoint, Opts, Optional string
+	Fstype, Source, VfsOpts          string
 }

--- a/pkg/mount/mountinfo_linux.go
+++ b/pkg/mount/mountinfo_linux.go
@@ -23,7 +23,7 @@ const (
 	   (9) filesystem type:  name of filesystem of the form "type[.subtype]"
 	   (10) mount source:  filesystem specific information or "none"
 	   (11) super options:  per super block options*/
-	mountinfoFormat = "%d %d %d:%d %s %s %s "
+	mountinfoFormat = "%d %d %d:%d %s %s %s %s"
 )
 
 // Parse /proc/self/mountinfo because comparing Dev and ino does not work from bind mounts
@@ -49,13 +49,14 @@ func parseInfoFile(r io.Reader) ([]*MountInfo, error) {
 		}
 
 		var (
-			p    = &MountInfo{}
-			text = s.Text()
+			p              = &MountInfo{}
+			text           = s.Text()
+			optionalFields string
 		)
 
 		if _, err := fmt.Sscanf(text, mountinfoFormat,
 			&p.Id, &p.Parent, &p.Major, &p.Minor,
-			&p.Root, &p.Mountpoint, &p.Opts); err != nil {
+			&p.Root, &p.Mountpoint, &p.Opts, &optionalFields); err != nil {
 			return nil, fmt.Errorf("Scanning '%s' failed: %s", text, err)
 		}
 		// Safe as mountinfo encodes mountpoints with spaces as \040.
@@ -63,6 +64,10 @@ func parseInfoFile(r io.Reader) ([]*MountInfo, error) {
 		postSeparatorFields := strings.Fields(text[index+3:])
 		if len(postSeparatorFields) < 3 {
 			return nil, fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
+		}
+
+		if optionalFields != "-" {
+			p.Optional = optionalFields
 		}
 
 		p.Fstype = postSeparatorFields[0]

--- a/pkg/mount/mountinfo_linux_test.go
+++ b/pkg/mount/mountinfo_linux_test.go
@@ -446,3 +446,32 @@ func TestParseGentooMountinfo(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestParseFedoraMountinfoFields(t *testing.T) {
+	r := bytes.NewBuffer([]byte(fedoraMountinfo))
+	infos, err := parseInfoFile(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedLength := 58
+	if len(infos) != expectedLength {
+		t.Fatalf("Expected %d entries, got %d", expectedLength, len(infos))
+	}
+	mi := MountInfo{
+		Id:         15,
+		Parent:     35,
+		Major:      0,
+		Minor:      3,
+		Root:       "/",
+		Mountpoint: "/proc",
+		Opts:       "rw,nosuid,nodev,noexec,relatime",
+		Optional:   "shared:5",
+		Fstype:     "proc",
+		Source:     "proc",
+		VfsOpts:    "rw",
+	}
+
+	if *infos[0] != mi {
+		t.Fatalf("expected %#v, got %#v", mi, infos[0])
+	}
+}


### PR DESCRIPTION
one linux, the optional field designates the sharedsubtree information,
if any.

ping @crosbymichael 

Signed-off-by: Vincent Batts vbatts@redhat.com
