### PR TITLE
Log when truncindex.Get returns >1 container

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -151,11 +151,21 @@ func (daemon *Daemon) Install(eng *engine.Engine) error {
 // Get looks for a container by the specified ID or name, and returns it.
 // If the container is not found, or if an error occurs, nil is returned.
 func (daemon *Daemon) Get(name string) *Container {
-	if id, err := daemon.idIndex.Get(name); err == nil {
+	var (
+		id  string
+		err error
+	)
+
+	if id, err = daemon.idIndex.Get(name); err == nil {
 		return daemon.containers.Get(id)
 	}
+
 	if c, _ := daemon.GetByName(name); c != nil {
 		return c
+	}
+
+	if err == truncindex.ErrDuplicateID {
+		log.Errorf("Short ID %s is ambiguous: please retry with more characters or use the full ID.\n", name)
 	}
 	return nil
 }

--- a/pkg/truncindex/truncindex.go
+++ b/pkg/truncindex/truncindex.go
@@ -11,8 +11,9 @@ import (
 
 var (
 	// ErrNoID is thrown when attempting to use empty prefixes
-	ErrNoID        = errors.New("prefix can't be empty")
-	errDuplicateID = errors.New("multiple IDs were found")
+	ErrNoID = errors.New("prefix can't be empty")
+	// ErrDuplicateID is thrown when a duplicated id was found
+	ErrDuplicateID = errors.New("multiple IDs were found")
 )
 
 func init() {
@@ -98,7 +99,7 @@ func (idx *TruncIndex) Get(s string) (string, error) {
 		if id != "" {
 			// we haven't found the ID if there are two or more IDs
 			id = ""
-			return errDuplicateID
+			return ErrDuplicateID
 		}
 		id = string(prefix)
 		return nil


### PR DESCRIPTION
When the user is not using the full hash to retrieve a container it's
possible that we find conflicts with the ids of other containers.

At the moment it's just failing saying that it can not find a container,
but it doesn't say why. Adding a small log saying that duplicates where
found is going to help the user.

Closes #8098
