### PR TITLE
Decode JSON to avoid ReadFile

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -102,13 +102,17 @@ func (container *Container) FromDisk() error {
 		return err
 	}
 
-	data, err := ioutil.ReadFile(pth)
+	jsonSource, err := os.Open(pth)
 	if err != nil {
 		return err
 	}
+	defer jsonSource.Close()
+
+	dec := json.NewDecoder(jsonSource)
+
 	// Load container settings
 	// udp broke compat of docker.PortMapping, but it's not used when loading a container, we can skip it
-	if err := json.Unmarshal(data, container); err != nil && !strings.Contains(err.Error(), "docker.PortMapping") {
+	if err := dec.Decode(container); err != nil && !strings.Contains(err.Error(), "docker.PortMapping") {
 		return err
 	}
 

--- a/image/image.go
+++ b/image/image.go
@@ -38,14 +38,18 @@ type Image struct {
 }
 
 func LoadImage(root string) (*Image, error) {
-	// Load the json data
-	jsonData, err := ioutil.ReadFile(jsonPath(root))
+	// Open the JSON file to decode by streaming
+	jsonSource, err := os.Open(jsonPath(root))
 	if err != nil {
 		return nil, err
 	}
-	img := &Image{}
+	defer jsonSource.Close()
 
-	if err := json.Unmarshal(jsonData, img); err != nil {
+	img := &Image{}
+	dec := json.NewDecoder(jsonSource)
+
+	// Decode the JSON data
+	if err := dec.Decode(img); err != nil {
 		return nil, err
 	}
 	if err := utils.ValidateID(img.ID); err != nil {

--- a/volumes/volume.go
+++ b/volumes/volume.go
@@ -154,12 +154,15 @@ func (v *Volume) FromDisk() error {
 		return err
 	}
 
-	data, err := ioutil.ReadFile(pth)
+	jsonSource, err := os.Open(pth)
 	if err != nil {
 		return err
 	}
+	defer jsonSource.Close()
 
-	return json.Unmarshal(data, v)
+	dec := json.NewDecoder(jsonSource)
+
+	return dec.Decode(v)
 }
 
 func (v *Volume) jsonPath() (string, error) {


### PR DESCRIPTION
`docker ps -a` and `docker images` were allocating a lot of memory because of `ioutil.ReadFile`. Running those two commands 10000 times would cause the allocation of around 30-50 gigabytes because of ReadFile.

This PR fixes some code paths for images, containers and volumes to use JSON decoding instead.
