### PR TITLE
Proposal: structured logging and new --log-format daemon flag

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -180,6 +180,18 @@ func (container *Container) WriteHostConfig() error {
 	return ioutil.WriteFile(pth, data, 0666)
 }
 
+func (container *Container) Logger() *log.Entry {
+	return log.WithField("containerID", container.ID)
+}
+
+func (container *Container) LoggerWithField(key string, value interface{}) *log.Entry {
+	return container.Logger().WithField(key, value)
+}
+
+func (container *Container) LoggerWithFields(fields log.Fields) *log.Entry {
+	return container.Logger().WithFields(fields)
+}
+
 func (container *Container) LogEvent(action string) {
 	d := container.daemon
 	if err := d.eng.Job("log", action, container.ID, d.Repositories().ImageName(container.Image)).Run(); err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -228,7 +228,7 @@ func (daemon *Daemon) register(container *Container, updateSuffixarray bool) err
 	//        if so, then we need to restart monitor and init a new lock
 	// If the container is supposed to be running, make sure of it
 	if container.IsRunning() {
-		log.Debugf("killing old running container %s", container.ID)
+		container.Logger().Debug("Killing old running container")
 
 		existingPid := container.Pid
 		container.SetStopped(0)
@@ -245,24 +245,21 @@ func (daemon *Daemon) register(container *Container, updateSuffixarray bool) err
 			var err error
 			cmd.ProcessConfig.Process, err = os.FindProcess(existingPid)
 			if err != nil {
-				log.Debugf("cannot find existing process for %d", existingPid)
+				log.WithField("PID", existingPid).Debug("Cannot find existing process")
 			}
 			daemon.execDriver.Terminate(cmd)
 		}
 
 		if err := container.Unmount(); err != nil {
-			log.Debugf("unmount error %s", err)
+			container.LoggerWithField("error", err).Debug("Failed to unmount container")
 		}
 		if err := container.ToDisk(); err != nil {
-			log.Debugf("saving stopped state to disk %s", err)
+			container.LoggerWithField("error", err).Debug("Failed to save stopped state to disk")
 		}
 
 		info := daemon.execDriver.Info(container.ID)
 		if !info.IsRunning() {
-			log.Debugf("Container %s was supposed to be running but is not.", container.ID)
-
-			log.Debugf("Marking as stopped")
-
+			container.Logger().Debug("Container was expected to be running: marking as stopped")
 			container.SetStopped(-127)
 			if err := container.ToDisk(); err != nil {
 				return err
@@ -281,7 +278,7 @@ func (daemon *Daemon) ensureName(container *Container) error {
 		container.Name = name
 
 		if err := container.ToDisk(); err != nil {
-			log.Debugf("Error saving container name %s", err)
+			container.LoggerWithField("error", err).Debug("Failed to save container")
 		}
 	}
 	return nil
@@ -318,17 +315,17 @@ func (daemon *Daemon) restore() error {
 			fmt.Print(".")
 		}
 		if err != nil {
-			log.Errorf("Failed to load container %v: %v", id, err)
+			container.LoggerWithField("error", err).Error("Failed to load container")
 			continue
 		}
 
 		// Ignore the container if it does not support the current driver being used by the graph
 		if (container.Driver == "" && currentDriver == "aufs") || container.Driver == currentDriver {
-			log.Debugf("Loaded container %v", container.ID)
+			container.Logger().Debug("Loaded container")
 
 			containers[container.ID] = container
 		} else {
-			log.Debugf("Cannot load container %s because it was created with another graph driver.", container.ID)
+			container.Logger().Debug("Cannot load a container created with different graph driver")
 		}
 	}
 
@@ -344,7 +341,7 @@ func (daemon *Daemon) restore() error {
 
 			if container, ok := containers[e.ID()]; ok {
 				if err := daemon.register(container, false); err != nil {
-					log.Debugf("Failed to register container %s: %s", container.ID, err)
+					container.LoggerWithField("error", err).Debug("Failed to register container")
 				}
 
 				registeredContainers = append(registeredContainers, container)
@@ -360,11 +357,11 @@ func (daemon *Daemon) restore() error {
 		// Try to set the default name for a container if it exists prior to links
 		container.Name, err = daemon.generateNewName(container.ID)
 		if err != nil {
-			log.Debugf("Setting default id - %s", err)
+			container.LoggerWithField("error", err).Debug("Failed to set default name")
 		}
 
 		if err := daemon.register(container, false); err != nil {
-			log.Debugf("Failed to register container %s: %s", container.ID, err)
+			container.LoggerWithField("error", err).Debug("Failed to register container")
 		}
 
 		registeredContainers = append(registeredContainers, container)
@@ -378,10 +375,10 @@ func (daemon *Daemon) restore() error {
 		for _, container := range registeredContainers {
 			if container.hostConfig.RestartPolicy.Name == "always" ||
 				(container.hostConfig.RestartPolicy.Name == "on-failure" && container.ExitCode != 0) {
-				log.Debugf("Starting container %s", container.ID)
+				container.Logger().Debug("Starting container")
 
 				if err := container.Start(); err != nil {
-					log.Debugf("Failed to start container %s: %s", container.ID, err)
+					container.LoggerWithField("error", err).Debug("Failed to start container")
 				}
 			}
 		}
@@ -922,16 +919,16 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		// them as separate handlers to speed up total shutdown time
 		// FIXME: use engine logging instead of log.Errorf
 		if err := daemon.shutdown(); err != nil {
-			log.Errorf("daemon.shutdown(): %s", err)
+			log.WithField("error", err).Error("daemon.shutdown()")
 		}
 		if err := portallocator.ReleaseAll(); err != nil {
-			log.Errorf("portallocator.ReleaseAll(): %s", err)
+			log.WithField("error", err).Error("portallocator.ReleaseAll()")
 		}
 		if err := daemon.driver.Cleanup(); err != nil {
-			log.Errorf("daemon.driver.Cleanup(): %s", err.Error())
+			log.WithField("error", err).Error("daemon.driver.Cleanup()")
 		}
 		if err := daemon.containerGraph.Close(); err != nil {
-			log.Errorf("daemon.containerGraph.Close(): %s", err.Error())
+			log.WithField("error", err).Error("daemon.containerGraph.Close()")
 		}
 	})
 
@@ -940,20 +937,20 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 
 func (daemon *Daemon) shutdown() error {
 	group := sync.WaitGroup{}
-	log.Debugf("starting clean shutdown of all containers...")
+	log.Debugf("Starting clean shutdown of all containers...")
 	for _, container := range daemon.List() {
 		c := container
 		if c.IsRunning() {
-			log.Debugf("stopping %s", c.ID)
+			container.Logger().Debug("Stopping container")
 			group.Add(1)
 
 			go func() {
 				defer group.Done()
 				if err := c.KillSig(15); err != nil {
-					log.Debugf("kill 15 error for %s - %s", c.ID, err)
+					container.LoggerWithField("error", err).Debug("Failed to kill 15 container")
 				}
 				c.WaitStop(-1 * time.Second)
-				log.Debugf("container stopped %s", c.ID)
+				container.Logger().Debug("Container stopped")
 			}()
 		}
 	}
@@ -1117,11 +1114,11 @@ func checkKernelAndArch() error {
 	// the circumstances of pre-3.8 crashes are clearer.
 	// For details see http://github.com/docker/docker/issues/407
 	if k, err := kernel.GetKernelVersion(); err != nil {
-		log.Infof("WARNING: %s", err)
+		log.WithField("error", err).Warn("Failed to retrieve kernel version")
 	} else {
 		if kernel.CompareKernelVersion(k, &kernel.KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0}) < 0 {
 			if os.Getenv("DOCKER_NOWARN_KERNEL_VERSION") == "" {
-				log.Infof("WARNING: You are running linux kernel version %s, which might be unstable running docker. Please upgrade your kernel to 3.8.0.", k.String())
+				log.Warnf("WARNING: You are running linux kernel version %s, which might be unstable running docker. Please upgrade your kernel to 3.8.0.", k.String())
 			}
 		}
 	}

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -52,12 +52,13 @@ func mainDaemon() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		log.Infof("docker daemon: %s %s; execdriver: %s; graphdriver: %s",
-			dockerversion.VERSION,
-			dockerversion.GITCOMMIT,
-			d.ExecutionDriver().Name(),
-			d.GraphDriver().String(),
-		)
+
+		logFields := log.Fields{
+			"version":     dockerversion.VERSION,
+			"gitcommit":   dockerversion.GITCOMMIT,
+			"execdriver":  d.ExecutionDriver().Name(),
+			"graphdriver": d.GraphDriver().String()}
+		log.WithFields(logFields).Info("Docker daemon starting")
 
 		if err := d.Install(eng); err != nil {
 			log.Fatal(err)

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -40,7 +40,9 @@ func main() {
 		os.Setenv("DEBUG", "1")
 	}
 
-	initLogging(*flDebug)
+	if err := initLogging(*flDebug, *flLogFormat); err != nil {
+		log.Fatal(err)
+	}
 
 	if len(flHosts) == 0 {
 		defaultHost := os.Getenv("DOCKER_HOST")

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -28,6 +28,7 @@ var (
 	flEnableCors  = flag.Bool([]string{"#api-enable-cors", "-api-enable-cors"}, false, "Enable CORS headers in the remote API")
 	flTls         = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by tls-verify flags")
 	flTlsVerify   = flag.Bool([]string{"-tlsverify"}, dockerTlsVerify, "Use TLS and verify the remote (daemon: verify client, client: verify daemon)")
+	flLogFormat   = flag.String([]string{"-log-format"}, "std", "Log format (std or json)")
 
 	// these are initialized in init() below since their default values depend on dockerCertPath which isn't fully initialized until init() runs
 	flTrustKey *string

--- a/docker/log.go
+++ b/docker/log.go
@@ -1,16 +1,138 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"os"
+	"sort"
+	"strings"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 )
 
-func initLogging(debug bool) {
+const (
+	nocolor = 0
+	red     = 31
+	green   = 32
+	yellow  = 33
+	blue    = 34
+)
+
+var (
+	baseTimestamp time.Time
+	isTerminal    bool
+)
+
+func init() {
+	baseTimestamp = time.Now()
+	isTerminal = log.IsTerminal()
+}
+
+func miniTS() int {
+	return int(time.Since(baseTimestamp) / time.Second)
+}
+
+func prefixFieldClashes(entry *log.Entry) {
+	_, ok := entry.Data["time"]
+	if ok {
+		entry.Data["fields.time"] = entry.Data["time"]
+	}
+
+	_, ok = entry.Data["msg"]
+	if ok {
+		entry.Data["fields.msg"] = entry.Data["msg"]
+	}
+
+	_, ok = entry.Data["level"]
+	if ok {
+		entry.Data["fields.level"] = entry.Data["level"]
+	}
+}
+
+type TextFormatter struct {
+	// Set to true to bypass checking for a TTY before outputting colors.
+	ForceColors   bool
+	DisableColors bool
+}
+
+func (f *TextFormatter) Format(entry *log.Entry) ([]byte, error) {
+	var keys []string
+	for k := range entry.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	b := &bytes.Buffer{}
+
+	prefixFieldClashes(entry)
+
+	isColored := (f.ForceColors || isTerminal) && !f.DisableColors
+
+	if isColored {
+		printColored(b, entry, keys)
+	} else {
+		f.appendKeyValue(b, "time", entry.Time.Format(time.RFC3339))
+		f.appendKeyValue(b, "level", entry.Level.String())
+		f.appendKeyValue(b, "msg", entry.Message)
+		for _, key := range keys {
+			f.appendKeyValue(b, key, entry.Data[key])
+		}
+	}
+
+	b.WriteByte('\n')
+	return b.Bytes(), nil
+}
+
+func printColored(b *bytes.Buffer, entry *log.Entry, keys []string) {
+	var levelColor int
+	switch entry.Level {
+	case log.WarnLevel:
+		levelColor = yellow
+	case log.ErrorLevel, log.FatalLevel, log.PanicLevel:
+		levelColor = red
+	default:
+		levelColor = blue
+	}
+
+	levelText := strings.ToUpper(entry.Level.String())[0:4]
+
+	fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m[%04d] %s", levelColor, levelText, miniTS(), entry.Message)
+	if len(keys) > 0 {
+		fmt.Fprintf(b, " [")
+		for _, k := range keys {
+			v := entry.Data[k]
+			fmt.Fprintf(b, " \x1b[%dm%s\x1b[0m=%v", levelColor, k, v)
+		}
+		fmt.Fprintf(b, " ]")
+	}
+}
+
+func (f *TextFormatter) appendKeyValue(b *bytes.Buffer, key, value interface{}) {
+	switch value.(type) {
+	case string, error:
+		fmt.Fprintf(b, "%v=%q ", key, value)
+	default:
+		fmt.Fprintf(b, "%v=%v ", key, value)
+	}
+}
+
+func initLogging(debug bool, format string) error {
+	switch format {
+	case "json":
+		log.SetFormatter(new(log.JSONFormatter))
+	case "std":
+		log.SetFormatter(new(TextFormatter))
+	default:
+		return fmt.Errorf("invalid log format '%s'", format)
+	}
+
 	log.SetOutput(os.Stderr)
 	if debug {
 		log.SetLevel(log.DebugLevel)
 	} else {
 		log.SetLevel(log.InfoLevel)
 	}
+
+	return nil
 }

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -75,6 +75,7 @@ expect an integer, and they can only be specified once.
       --ip-forward=true                          Enable net.ipv4.ip_forward
       --ip-masq=true                             Enable IP masquerading for bridge's IP range
       --iptables=true                            Enable Docker's addition of iptables rules
+      --log-format=std                           Log output format (std or json)
       --mtu=0                                    Set the containers network MTU
                                                    if no value is provided: default to the default route MTU or 1500 if no default route is available
       -p, --pidfile="/var/run/docker.pid"        Path to use for daemon PID file

--- a/engine/job.go
+++ b/engine/job.go
@@ -69,9 +69,9 @@ func (job *Job) Run() error {
 	}
 	// Log beginning and end of the job
 	if job.Eng.Logging {
-		log.Infof("+job %s", job.CallString())
+		log.WithFields(job.CallLogFields()).Debug("+job")
 		defer func() {
-			log.Infof("-job %s%s", job.CallString(), job.StatusString())
+			log.WithFields(job.CallLogFields()).WithFields(job.StatusLogFields()).Debug("-job")
 		}()
 	}
 	var errorMessage = bytes.NewBuffer(nil)
@@ -102,14 +102,14 @@ func (job *Job) Run() error {
 	return nil
 }
 
-func (job *Job) CallString() string {
-	return fmt.Sprintf("%s(%s)", job.Name, strings.Join(job.Args, ", "))
+func (job *Job) CallLogFields() log.Fields {
+	return log.Fields{"job": job.Name, "jobArgs": job.Args}
 }
 
-func (job *Job) StatusString() string {
+func (job *Job) StatusLogFields() log.Fields {
 	// If the job hasn't completed, status string is empty
 	if job.end.IsZero() {
-		return ""
+		return log.Fields{}
 	}
 	var okerr string
 	if job.status == StatusOK {
@@ -117,13 +117,13 @@ func (job *Job) StatusString() string {
 	} else {
 		okerr = "ERR"
 	}
-	return fmt.Sprintf(" = %s (%d)", okerr, job.status)
+	return log.Fields{"status": okerr, "statusValue": job.status}
 }
 
 // String returns a human-readable description of `job`
-func (job *Job) String() string {
-	return fmt.Sprintf("%s.%s%s", job.Eng, job.CallString(), job.StatusString())
-}
+//func (job *Job) String() string {
+//	return fmt.Sprintf("%s.%s%s", job.Eng, job.CallString(), job.StatusString())
+//}
 
 func (job *Job) Env() *Env {
 	return job.env


### PR DESCRIPTION
The [`logrus`](https://github.com/Sirupsen/logrus) logging library was introduced by @LK4D4 in #8770 as a drop-in replacement for golang's log package (see also related issue #8921). This is a proposal to:
- Take advantage of `logrus` features, especially [structured logging](https://github.com/Sirupsen/logrus#fields)
- Seize the opportunity to review log levels and wording if necessary

This PR includes documentation changes and only starts implementing the changes on chosen source files to get an idea of what the output would end up looking like. Here's my first thoughts:
- Structure logging is appreciable, especially as it opens the door to JSON log output. However, it does make things a little weird from a human perspective as log messages become extremely short (e.g.: `API Call`) with many context fields following them (e.g.: `method=POST remoteAddr=@ uri=/v1.16/containers/8c227b1dadab2b3227bf3f60a7b5653ca7673a6d1bfd564bed13221d4c30a117/start`)
- The `logrus` default `TextFormatter` produces a lot of whitespace: I messily copied it in order to tweak the output format.

Let's discuss to see if it's worth applying this strategy to all Docker logs. (cc @crosbymichael, @dmp42 who expressed interest in our usage of `logrus`)

---

Exemple standard output:

![Standard output screenshot](http://iceenmousse.free.fr/_upload/logrus_example.png)

Example JSON output:

```
$> docker -dD --log-format=json
{"job":"serveapi","jobArgs":["unix:///var/run/docker.sock"],"level":"debug","msg":"+job","time":"2014-11-04T16:11:22Z"}
{"address":"/var/run/docker.sock","level":"info","msg":"Listening for HTTP","proto":"unix","time":"2014-11-04T16:11:22Z"}
{"level":"debug","method":"POST","msg":"Registering API endpoint","route":"/exec/{name:.*}/resize","time":"2014-11-04T16:11:22Z"}
{"level":"debug","method":"POST","msg":"Registering API endpoint","route":"/auth","time":"2014-11-04T16:11:22Z"}
{"level":"debug","method":"POST","msg":"Registering API endpoint","route":"/exec/{name:.*}/start","time":"2014-11-04T16:11:22Z"}
{"level":"debug","method":"POST","msg":"Registering API endpoint","route":"/images/{name:.*}/push","time":"2014-11-04T16:11:22Z"}
{"level":"debug","method":"POST","msg":"Registering API endpoint","route":"/containers/{name:.*}/start","time":"2014-11-04T16:11:22Z"}
{"level":"debug","method":"POST","msg":"Registering API endpoint","route":"/images/create","time":"2014-11-04T16:11:22Z"}
```
