### PR TITLE
makes the -s --size option documentation clearer

### DIFF
--- a/docs/man/docker-ps.1.md
+++ b/docs/man/docker-ps.1.md
@@ -46,7 +46,7 @@ the running containers.
    Only display numeric IDs. The default is *false*.
 
 **-s**, **--size**=*true*|*false*
-   Display sizes. The default is *false*.
+   Display total file sizes. The default is *false*.
 
 **--since**=""
    Show only containers created since Id or Name, include non-running ones.


### PR DESCRIPTION
As a newbie to docker I was hoping the size method would mean "Memory size". 

Because of the documentation I wasn't sure what it was doing, and only after observing the behaviour I knew.
So I'm suggesting to make the documentation clear as to what the size is of.
