### PR TITLE
unify `–`(en dash) to `-` when specifying options

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.2.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.2.md
@@ -979,4 +979,4 @@ To enable cross origin requests to the remote api add the flag
 "--api-enable-cors" when running docker in daemon mode.
 
 > docker -d -H="[tcp://192.168.1.9:2375](tcp://192.168.1.9:2375)"
-> –api-enable-cors
+> -api-enable-cors

--- a/docs/sources/reference/api/docker_remote_api_v1.3.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.3.md
@@ -1064,4 +1064,4 @@ stdout and stderr on the same socket. This might change in the future.
 To enable cross origin requests to the remote api add the flag
 "--api-enable-cors" when running docker in daemon mode.
 
-> docker -d -H="192.168.1.9:2375" –api-enable-cors
+> docker -d -H="192.168.1.9:2375" -api-enable-cors

--- a/docs/sources/reference/api/hub_registry_spec.md
+++ b/docs/sources/reference/api/hub_registry_spec.md
@@ -458,7 +458,7 @@ on a private network without having to rely on an external entity
 controlled by Docker Inc.
 
 In this case, the registry will be launched in a special mode
-(–standalone? ne? –no-index?). In this mode, the only thing which changes is
+(-standalone? ne? -no-index?). In this mode, the only thing which changes is
 that Registry will never contact the Docker Hub to verify a token. It will be
 the Registry owner responsibility to authenticate the user who pushes
 (or even pulls) an image using any mechanism (HTTP auth, IP based,

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -99,7 +99,7 @@ together in most interactive cases.
 
 ## Container identification
 
-### Name (–-name)
+### Name (--name)
 
 The operator can identify a container in three ways:
 
@@ -218,7 +218,7 @@ container itself as well as `localhost` and a few other common things.  The
     ::1	            localhost ip6-localhost ip6-loopback
     86.75.30.9      db-static
 
-## Clean up (–-rm)
+## Clean up (--rm)
 
 By default a container's file system persists even after the container
 exits. This makes debugging a lot easier (since you can inspect the

--- a/docs/sources/release-notes.md
+++ b/docs/sources/release-notes.md
@@ -114,7 +114,7 @@ accept an optional maximum restart count (e.g. `on-failure:5`). * `always` –
 Always restart the container no matter what exit code is returned. This
 deprecates the `--restart` flag on the Docker daemon.
 
-*New flags for `docker run`: `--cap-add` and `–-cap-drop`*
+*New flags for `docker run`: `--cap-add` and `--cap-drop`*
 
 In previous releases, Docker containers could either be given complete
 capabilities or they could all follow a whitelist of allowed capabilities while
@@ -127,7 +127,7 @@ This release introduces two new flags for `docker run`, `--cap-add` and
 `--cap-drop`, that give you fine-grain control over the specific capabilities
 you want grant to a particular container.
 
-*New `-–device` flag for `docker run`*
+*New `--device` flag for `docker run`*
 
 Previously, you could only use devices inside your containers by bind mounting
 them (with `-v`) in a `--privileged` container. With this release, we introduce


### PR DESCRIPTION
Signed-off-by: Xie Shi georgexsh@gmail.com
