### PR TITLE
Save restore device Id: issue #8978

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -64,23 +64,23 @@ type MetaData struct {
 type DeviceSet struct {
 	MetaData         `json:"-"`
 	sync.Mutex       `json:"-"` // Protects Devices map and serializes calls into libdevmapper
-	root             string     `json:"-"`
-	devicePrefix     string     `json:"-"`
-	TransactionId    uint64     `json:"-"`
-	NewTransactionId uint64     `json:"-"`
-	NextDeviceId     int        `json:"next_device_id"`
+	root             string
+	devicePrefix     string
+	TransactionId    uint64 `json:"-"`
+	NewTransactionId uint64 `json:"-"`
+	NextDeviceId     int    `json:"next_device_id"`
 
 	// Options
-	dataLoopbackSize     int64    `json:"-"`
-	metaDataLoopbackSize int64    `json:"-"`
-	baseFsSize           uint64   `json:"-"`
-	filesystem           string   `json:"-"`
-	mountOptions         string   `json:"-"`
-	mkfsArgs             []string `json:"-"`
-	dataDevice           string   `json:"-"`
-	metadataDevice       string   `json:"-"`
-	doBlkDiscard         bool     `json:"-"`
-	thinpBlockSize       uint32   `json:"-"`
+	dataLoopbackSize     int64
+	metaDataLoopbackSize int64
+	baseFsSize           uint64
+	filesystem           string
+	mountOptions         string
+	mkfsArgs             []string
+	dataDevice           string
+	metadataDevice       string
+	doBlkDiscard         bool
+	thinpBlockSize       uint32
 }
 
 type DiskUsage struct {

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -62,25 +62,25 @@ type MetaData struct {
 }
 
 type DeviceSet struct {
-	MetaData		`json:"-"`
-	sync.Mutex       	`json:"-"` // Protects Devices map and serializes calls into libdevmapper
-	root             string	`json:"-"`
-	devicePrefix     string	`json:"-"`
-	TransactionId    uint64	`json:"-"`
-	NewTransactionId uint64 `json:"-"`
-	NextDeviceId     int	`json:"next_device_id"`
+	MetaData         `json:"-"`
+	sync.Mutex       `json:"-"` // Protects Devices map and serializes calls into libdevmapper
+	root             string     `json:"-"`
+	devicePrefix     string     `json:"-"`
+	TransactionId    uint64     `json:"-"`
+	NewTransactionId uint64     `json:"-"`
+	NextDeviceId     int        `json:"next_device_id"`
 
 	// Options
-	dataLoopbackSize     int64	`json:"-"`
-	metaDataLoopbackSize int64	`json:"-"`
-	baseFsSize           uint64	`json:"-"`
-	filesystem           string	`json:"-"`
-	mountOptions         string	`json:"-"`
-	mkfsArgs             []string	`json:"-"`
-	dataDevice           string	`json:"-"`
-	metadataDevice       string	`json:"-"`
-	doBlkDiscard         bool	`json:"-"`
-	thinpBlockSize       uint32	`json:"-"`
+	dataLoopbackSize     int64    `json:"-"`
+	metaDataLoopbackSize int64    `json:"-"`
+	baseFsSize           uint64   `json:"-"`
+	filesystem           string   `json:"-"`
+	mountOptions         string   `json:"-"`
+	mkfsArgs             []string `json:"-"`
+	dataDevice           string   `json:"-"`
+	metadataDevice       string   `json:"-"`
+	doBlkDiscard         bool     `json:"-"`
+	thinpBlockSize       uint32   `json:"-"`
 }
 
 type DiskUsage struct {

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -68,7 +68,7 @@ type DeviceSet struct {
 	devicePrefix     string
 	TransactionId    uint64
 	NewTransactionId uint64
-	nextDeviceId     int
+	NextDeviceId     int
 
 	// Options
 	dataLoopbackSize     int64
@@ -407,7 +407,7 @@ func (devices *DeviceSet) setupBaseImage() error {
 
 	log.Debugf("Initializing base device-manager snapshot")
 
-	id := devices.nextDeviceId
+	id := devices.NextDeviceId
 
 	// Create initial device
 	if err := createDevice(devices.getPoolDevName(), &id); err != nil {
@@ -415,7 +415,7 @@ func (devices *DeviceSet) setupBaseImage() error {
 	}
 
 	// Ids are 24bit, so wrap around
-	devices.nextDeviceId = (id + 1) & 0xffffff
+	devices.NextDeviceId = (id + 1) & 0xffffff
 
 	log.Debugf("Registering base device (id %v) with FS size %v", id, devices.baseFsSize)
 	info, err := devices.registerDevice(id, "", devices.baseFsSize)
@@ -703,7 +703,7 @@ func (devices *DeviceSet) AddDevice(hash, baseHash string) error {
 		return fmt.Errorf("device %s already exists", hash)
 	}
 
-	deviceId := devices.nextDeviceId
+	deviceId := devices.NextDeviceId
 
 	if err := createSnapDevice(devices.getPoolDevName(), &deviceId, baseInfo.Name(), baseInfo.DeviceId); err != nil {
 		log.Debugf("Error creating snap device: %s", err)
@@ -711,7 +711,7 @@ func (devices *DeviceSet) AddDevice(hash, baseHash string) error {
 	}
 
 	// Ids are 24bit, so wrap around
-	devices.nextDeviceId = (deviceId + 1) & 0xffffff
+	devices.NextDeviceId = (deviceId + 1) & 0xffffff
 
 	if _, err := devices.registerDevice(deviceId, hash, baseInfo.Size); err != nil {
 		deleteDevice(devices.getPoolDevName(), deviceId)


### PR DESCRIPTION
Fixes #8978

During testing of docker with device mapper backend, I often noticed bunch of warnings on console and often thought that if something is wrong with my docker setup. It turned out that docker does not keep track of already used device ids.  This patch series should make docker little bit smarter about it.

More details are in issue and patches. Please review and pull.

Thanks
Vivek
