### PR TITLE
Consistent hosts

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -420,7 +420,7 @@ func (container *Container) buildHostsFiles(IP string) error {
 	}
 	container.HostsPath = hostsPath
 
-	extraContent := make(map[string]string)
+	var extraContent []etchosts.Record
 
 	children, err := container.daemon.Children(container.Name)
 	if err != nil {
@@ -429,15 +429,15 @@ func (container *Container) buildHostsFiles(IP string) error {
 
 	for linkAlias, child := range children {
 		_, alias := path.Split(linkAlias)
-		extraContent[alias] = child.NetworkSettings.IPAddress
+		extraContent = append(extraContent, etchosts.Record{Hosts: alias, IP: child.NetworkSettings.IPAddress})
 	}
 
 	for _, extraHost := range container.hostConfig.ExtraHosts {
 		parts := strings.Split(extraHost, ":")
-		extraContent[parts[0]] = parts[1]
+		extraContent = append(extraContent, etchosts.Record{Hosts: parts[0], IP: parts[1]})
 	}
 
-	return etchosts.Build(container.HostsPath, IP, container.Config.Hostname, container.Config.Domainname, &extraContent)
+	return etchosts.Build(container.HostsPath, IP, container.Config.Hostname, container.Config.Domainname, extraContent)
 }
 
 func (container *Container) buildHostnameAndHostsFiles(IP string) error {

--- a/pkg/networkfs/etchosts/etchosts.go
+++ b/pkg/networkfs/etchosts/etchosts.go
@@ -3,40 +3,54 @@ package etchosts
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"regexp"
 )
 
-var defaultContent = map[string]string{
-	"localhost":                            "127.0.0.1",
-	"localhost ip6-localhost ip6-loopback": "::1",
-	"ip6-localnet":                         "fe00::0",
-	"ip6-mcastprefix":                      "ff00::0",
-	"ip6-allnodes":                         "ff02::1",
-	"ip6-allrouters":                       "ff02::2",
+type Record struct {
+	Hosts string
+	IP    string
 }
 
-func Build(path, IP, hostname, domainname string, extraContent *map[string]string) error {
+func (r Record) WriteTo(w io.Writer) (int64, error) {
+	n, err := fmt.Fprintf(w, "%s\t%s\n", r.IP, r.Hosts)
+	return int64(n), err
+}
+
+var defaultContent = []Record{
+	{Hosts: "localhost", IP: "127.0.0.1"},
+	{Hosts: "localhost ip6-localhost ip6-loopback", IP: "::1"},
+	{Hosts: "ip6-localnet", IP: "fe00::0"},
+	{Hosts: "ip6-mcastprefix", IP: "ff00::0"},
+	{Hosts: "ip6-allnodes", IP: "ff02::1"},
+	{Hosts: "ip6-allrouters", IP: "ff02::2"},
+}
+
+func Build(path, IP, hostname, domainname string, extraContent []Record) error {
 	content := bytes.NewBuffer(nil)
 	if IP != "" {
+		var mainRec Record
+		mainRec.IP = IP
 		if domainname != "" {
-			content.WriteString(fmt.Sprintf("%s\t%s.%s %s\n", IP, hostname, domainname, hostname))
+			mainRec.Hosts = fmt.Sprintf("%s.%s %s", hostname, domainname, hostname)
 		} else {
-			content.WriteString(fmt.Sprintf("%s\t%s\n", IP, hostname))
+			mainRec.Hosts = hostname
 		}
-	}
-
-	for hosts, ip := range defaultContent {
-		if _, err := content.WriteString(fmt.Sprintf("%s\t%s\n", ip, hosts)); err != nil {
+		if _, err := mainRec.WriteTo(content); err != nil {
 			return err
 		}
 	}
 
-	if extraContent != nil {
-		for hosts, ip := range *extraContent {
-			if _, err := content.WriteString(fmt.Sprintf("%s\t%s\n", ip, hosts)); err != nil {
-				return err
-			}
+	for _, r := range defaultContent {
+		if _, err := r.WriteTo(content); err != nil {
+			return err
+		}
+	}
+
+	for _, r := range extraContent {
+		if _, err := r.WriteTo(content); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/networkfs/etchosts/etchosts_test.go
+++ b/pkg/networkfs/etchosts/etchosts_test.go
@@ -7,6 +7,32 @@ import (
 	"testing"
 )
 
+func TestBuildDefault(t *testing.T) {
+	file, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	// check that /etc/hosts has consistent ordering
+	for i := 0; i <= 5; i++ {
+		err = Build(file.Name(), "", "", "", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		content, err := ioutil.ReadFile(file.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := "127.0.0.1\tlocalhost\n::1\tlocalhost ip6-localhost ip6-loopback\nfe00::0\tip6-localnet\nff00::0\tip6-mcastprefix\nff02::1\tip6-allnodes\nff02::2\tip6-allrouters\n"
+
+		if expected != string(content) {
+			t.Fatalf("Expected to find '%s' got '%s'", expected, content)
+		}
+	}
+}
+
 func TestBuildHostnameDomainname(t *testing.T) {
 	file, err := ioutil.TempFile("", "")
 	if err != nil {


### PR DESCRIPTION
This patch makes `/etc/hosts` file records consistent between container restarts.
Fixes #8972 
