### PR TITLE
pkg/archive: fix Size of layer//changes when hardlinks are involved

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -168,34 +168,6 @@ type tarAppender struct {
 	SeenFiles SeenFiles
 }
 
-// for hardlink mapping
-type SeenFiles map[uint64]string
-
-func (sf SeenFiles) Add(fi os.FileInfo) {
-	switch sys := fi.Sys().(type) {
-	case *syscall.Stat_t:
-		sf[uint64(sys.Ino)] = fi.Name()
-	default:
-		// length plus one. Not an inode, but still usable by systems that don't have inodes
-		sf[uint64(len(sf))] = fi.Name()
-	}
-}
-
-func (sf SeenFiles) Include(fi os.FileInfo) string {
-	switch sys := fi.Sys().(type) {
-	case *syscall.Stat_t:
-		return sf[uint64(sys.Ino)]
-	default:
-		n := fi.Name()
-		for _, path := range sf {
-			if n == path {
-				return path
-			}
-		}
-	}
-	return ""
-}
-
 func (ta *tarAppender) addTarFile(path, name string) error {
 	fi, err := os.Lstat(path)
 	if err != nil {

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -227,6 +227,7 @@ func TestUntarUstarGnuConflict(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer f.Close()
 	found := false
 	tr := tar.NewReader(f)
 	// Iterate through the files in the archive.

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -9,16 +9,13 @@ import (
 	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 )
 
-func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {
+func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (err error) {
 	s, ok := stat.(*syscall.Stat_t)
 
 	if !ok {
 		err = errors.New("cannot convert stat value to syscall.Stat_t")
 		return
 	}
-
-	nlink = uint32(s.Nlink)
-	inode = uint64(s.Ino)
 
 	// Currently go does not fil in the major/minors
 	if s.Mode&syscall.S_IFBLK == syscall.S_IFBLK ||

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -6,7 +6,7 @@ import (
 	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 )
 
-func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {
+func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (err error) {
 	// do nothing. no notion of Rdev, Inode, Nlink in stat on Windows
 	return
 }

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -355,7 +355,11 @@ func ChangesSize(newDir string, changes []Change) int64 {
 	for _, change := range changes {
 		if change.Kind == ChangeModify || change.Kind == ChangeAdd {
 			file := filepath.Join(newDir, change.Path)
-			fileInfo, _ := os.Lstat(file)
+			fileInfo, err := os.Lstat(file)
+			if err != nil {
+				log.Debugf("Can not stat %q: %s", file, err)
+				continue
+			}
 			if fileInfo != nil && !fileInfo.IsDir() {
 				if IsHardlink(fileInfo) {
 					// if the file has not been seen, then perhaps this link maybe elsewhere,

--- a/pkg/archive/changes_test.go
+++ b/pkg/archive/changes_test.go
@@ -276,6 +276,11 @@ func TestApplyLayer(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	expectedSize := int64(55)
+	if size := ChangesSize(dst, changes); size != expectedSize {
+		t.Errorf("expected size of %d bytes, got %d", expectedSize, size)
+	}
+
 	layer, err := ExportChanges(dst, changes)
 	if err != nil {
 		t.Fatal(err)
@@ -297,5 +302,36 @@ func TestApplyLayer(t *testing.T) {
 
 	if len(changes2) != 0 {
 		t.Fatalf("Unexpected differences after reapplying mutation: %v", changes2)
+	}
+}
+
+func TestChangesSizeWithHardlinks(t *testing.T) {
+	srcDir, err := ioutil.TempDir("", "docker-test-srcDir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(srcDir)
+
+	destDir, err := ioutil.TempDir("", "docker-test-destDir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(destDir)
+
+	creationSize, err := prepareUntarSourceDirectory(100, destDir, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changes, err := ChangesDirs(destDir, srcDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("The changes were -- %#v", changes)
+
+	got := ChangesSize(destDir, changes)
+	if got != int64(creationSize) {
+		t.Errorf("expected %d bytes of changes, got %d", creationSize, got)
 	}
 }

--- a/pkg/archive/changes_unix.go
+++ b/pkg/archive/changes_unix.go
@@ -1,0 +1,18 @@
+// +build linux osx freebsd openbsd
+
+package archive
+
+import (
+	"os"
+	"syscall"
+)
+
+func IsHardlink(fi os.FileInfo) bool {
+	switch sys := fi.Sys().(type) {
+	case *syscall.Stat_t:
+		if fi.Mode().IsRegular() && sys.Nlink > 1 {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/archive/changes_unsupported.go
+++ b/pkg/archive/changes_unsupported.go
@@ -1,0 +1,9 @@
+// +build !linux,!osx,!freebsd,!openbsd
+
+package archive
+
+import "os"
+
+func IsHardlink(fi os.FileInfo) bool {
+	return false
+}

--- a/pkg/archive/seenfiles.go
+++ b/pkg/archive/seenfiles.go
@@ -1,0 +1,4 @@
+package archive
+
+// for hardlink mapping
+type SeenFiles map[uint64]string

--- a/pkg/archive/seenfiles_unix.go
+++ b/pkg/archive/seenfiles_unix.go
@@ -1,0 +1,23 @@
+// +build !windows
+
+package archive
+
+import (
+	"os"
+	"syscall"
+)
+
+func (sf SeenFiles) Add(fi os.FileInfo) {
+	switch sys := fi.Sys().(type) {
+	case *syscall.Stat_t:
+		sf[uint64(sys.Ino)] = fi.Name()
+	}
+}
+
+func (sf SeenFiles) Include(fi os.FileInfo) string {
+	switch sys := fi.Sys().(type) {
+	case *syscall.Stat_t:
+		return sf[uint64(sys.Ino)]
+	}
+	return ""
+}

--- a/pkg/archive/seenfiles_windows.go
+++ b/pkg/archive/seenfiles_windows.go
@@ -1,0 +1,20 @@
+// +build windows
+
+package archive
+
+import "os"
+
+func (sf SeenFiles) Add(fi os.FileInfo) {
+	// length plus one. Not an inode, but still usable by systems that don't have inodes
+	sf[uint64(len(sf))] = fi.Name()
+}
+
+func (sf SeenFiles) Include(fi os.FileInfo) string {
+	n := fi.Name()
+	for _, path := range sf {
+		if n == path {
+			return path
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Now that hardlinks are supported, it's come to my attention that the VirtualSize of an image does not account for this.

This PR fixes that.

ping @unclejack @tiborvass 
// cc @ncdc 
