### PR TITLE
Close stdin after execution with `docker exec -i`

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -203,7 +203,7 @@ func (d *Daemon) ContainerExecStart(job *engine.Job) engine.Status {
 		execConfig.StreamConfig.stdinPipe = ioutils.NopWriteCloser(ioutil.Discard) // Silently drop stdin
 	}
 
-	attachErr := d.attach(&execConfig.StreamConfig, execConfig.OpenStdin, false, execConfig.ProcessConfig.Tty, cStdin, cStdout, cStderr)
+	attachErr := d.attach(&execConfig.StreamConfig, execConfig.OpenStdin, true, execConfig.ProcessConfig.Tty, cStdin, cStdout, cStderr)
 
 	execErr := make(chan error)
 


### PR DESCRIPTION
If you wish to test manually:

Dockerfile:
https://gist.github.com/erikh/765ecedf6bc82ae91ae0 (I just needed something that would reliably hang)

```
docker build -t test .
docker exec -i `docker run -itd test` ls /
```

Second command on master _should_ hang after the command runs. This is because the attach logic was expecting another attach later.

The test is not as good as I'd like and I'm open to suggestions on how to make it better.
