### PR TITLE
Loosen LGTM requirements for docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,10 +154,22 @@ regularly from the Git history.
 Docker maintainers use LGTM (Looks Good To Me) in comments on the code review
 to indicate acceptance.
 
-A change requires LGTMs from an absolute majority of the maintainers of each
-component affected. For example, if a change affects `docs/` and `registry/`, it
-needs an absolute majority from the maintainers of `docs/` AND, separately, an
-absolute majority of the maintainers of `registry/`.
+A code change requires LGTMs from an absolute majority of the maintainers of
+each component affected. For example, if a change affects `daemon/` and
+`registry/`, it needs an absolute majority from the maintainers of `daemon/`
+AND, separately, an absolute majority of the maintainers of `registry/`.
+
+Changes to `docs/` are slightly different. Changes to documentation require only
+two LGTMs from docs maintainers and one LGTM from a maintainer of the component
+being discussed or described in the proposed docs change. If more than one
+component is discussed in the docs, then an LGTM is required from a maintainer
+of each component being documented. For example, documents covering a change
+that affects both `daemon/` and `registry/` would require two LGTMs from docs
+maintainers and one LGTM from a maintainer of each component. 
+
+The exception to this is any docs change that could be described as a "copy
+edit:" fixing a typo, correcting a bad URL, fixing a formatting mistake,
+correcting grammar, etc. See the "Small patch exception" section below.
 
 For more details see [MAINTAINERS.md](hack/MAINTAINERS.md)
 


### PR DESCRIPTION
This PR, based on discussion with Solomon and the docs maintainers, loosens the LGTM requirements for docs PRs to require only two approvals from docs maintainers and one approval from the maintainers of the component(s) being documented.

Docker-DCO-1.1-Signed-off-by: Fred Lifton fred.lifton@docker.com (github: fredlf)
