### PR TITLE
Make test-unit runnable without parallel

### DIFF
--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -22,29 +22,31 @@ bundle_test_unit() {
 		if [ -z "$TESTDIRS" ]; then
 			TESTDIRS=$(find_dirs '*_test.go')
 		fi
-
-		if command -v parallel &> /dev/null; then (
-			# accomodate parallel to be able to access variables
-			export SHELL="$BASH"
-			export HOME="$(mktemp -d)"
-			mkdir -p "$HOME/.parallel"
-			touch "$HOME/.parallel/ignored_vars"
+		(
 			export LDFLAGS="$LDFLAGS $LDFLAGS_STATIC_DOCKER"
 			export TESTFLAGS
 			export HAVE_GO_TEST_COVER
 			export DEST
-			# some hack to export array variables
-			export BUILDFLAGS_FILE="$HOME/buildflags_file"
-			( IFS=$'\n'; echo "${BUILDFLAGS[*]}" ) > "$BUILDFLAGS_FILE"
+			if command -v parallel &> /dev/null; then
+				# accomodate parallel to be able to access variables
+				export SHELL="$BASH"
+				export HOME="$(mktemp -d)"
+				mkdir -p "$HOME/.parallel"
+				touch "$HOME/.parallel/ignored_vars"
 
-			echo "$TESTDIRS" | parallel --jobs "$PARALLEL_JOBS" --halt 2 --env _ "$(dirname "$BASH_SOURCE")/.go-compile-test-dir"
-			rm -rf "$HOME"
-		) else
-			# aww, no "parallel" available - fall back to boring
-			for test_dir in $TESTDIRS; do
-				. "$(dirname "$BASH_SOURCE")/.go-compile-test-dir" "$test_dir"
-			done
-		fi
+				# some hack to export array variables
+				export BUILDFLAGS_FILE="$HOME/buildflags_file"
+				( IFS=$'\n'; echo "${BUILDFLAGS[*]}" ) > "$BUILDFLAGS_FILE"
+
+				echo "$TESTDIRS" | parallel --jobs "$PARALLEL_JOBS" --halt 2 --env _ "$(dirname "$BASH_SOURCE")/.go-compile-test-dir"
+				rm -rf "$HOME"
+			else
+				# aww, no "parallel" available - fall back to boring
+				for test_dir in $TESTDIRS; do
+					"$(dirname "$BASH_SOURCE")/.go-compile-test-dir" "$test_dir"
+				done
+			fi
+		)
 		echo "$TESTDIRS" | go_run_test_dir
 	}
 }

--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -42,7 +42,7 @@ bundle_test_unit() {
 		) else
 			# aww, no "parallel" available - fall back to boring
 			for test_dir in $TESTDIRS; do
-				"$(dirname "$BASH_SOURCE")/.go-compile-test-dir" "$test_dir"
+				. "$(dirname "$BASH_SOURCE")/.go-compile-test-dir" "$test_dir"
 			done
 		fi
 		echo "$TESTDIRS" | go_run_test_dir


### PR DESCRIPTION
test-unit does not run correctly without parallel, since the environment variables such as DEST are not exported. This PR fixes this problem by souring the script, not invoking it.

Signed-off-by: Yohei Ueda yohei@jp.ibm.com
