### PR TITLE
Remove DCO small patch exception

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,18 +220,6 @@ Note that the old-style `Docker-DCO-1.1-Signed-off-by: ...` format is still
 accepted, so there is no need to update outstanding pull requests to the new
 format right away, but please do adjust your processes for future contributions.
 
-#### Small patch exception
-
-There are several exceptions to the signing requirement. Currently these are:
-
-* Your patch fixes spelling or grammar errors.
-* Your patch is a single line change to documentation contained in the
-  `docs` directory.
-* Your patch fixes Markdown formatting or syntax errors in the
-  documentation contained in the `docs` directory.
-
-If you have any questions, please refer to the FAQ in the [docs](http://docs.docker.com)
-
 ### How can I become a maintainer?
 
 * Step 1: Learn the component inside out

--- a/hack/make/validate-dco
+++ b/hack/make/validate-dco
@@ -4,7 +4,7 @@ source "$(dirname "$BASH_SOURCE")/.validate"
 
 adds=$(validate_diff --numstat | awk '{ s += $1 } END { print s }')
 dels=$(validate_diff --numstat | awk '{ s += $2 } END { print s }')
-notDocs="$(validate_diff --numstat | awk '$3 !~ /^docs\// { print $3 }')"
+#notDocs="$(validate_diff --numstat | awk '$3 !~ /^docs\// { print $3 }')"
 
 : ${adds:=0}
 : ${dels:=0}
@@ -22,8 +22,6 @@ check_dco() {
 
 if [ $adds -eq 0 -a $dels -eq 0 ]; then
 	echo '0 adds, 0 deletions; nothing to validate! :)'
-elif [ -z "$notDocs" -a $adds -le 1 -a $dels -le 1 ]; then
-	echo 'Congratulations!  DCO small-patch-exception material!'
 else
 	commits=( $(validate_log --format='format:%H%n') )
 	badCommits=()


### PR DESCRIPTION
As we move forward on automating our pull request review process and
tooling these exceptions hurt more than they help.  For consistency we
should not allow small patch exceptions for anything.  The source of
truth going forward for DCO and builds are the official drone status on
each pull request.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
