### PR TITLE
Proposal: Container annotations (metadata)

### DIFF
--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -351,6 +351,18 @@ change them using `docker run --env <key>=<value>`.
 > `ENV DEBIAN_FRONTEND noninteractive`. Which will persist when the container
 > is run interactively; for example: `docker run -t -i image bash`
 
+## ATTR
+
+    ATTR <key> <value>
+
+The `ATTR` instruction sets an initial value for the attribute named
+`<key>`. The attribute value is not available to the container itself,
+but may be reported by `docker inspect` and overidden by `docker
+attr`.
+
+The value must be a JSON literal; so, for example, strings must be
+double-quoted.
+
 ## ADD
 
     ADD <src>... <dest>

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -351,17 +351,17 @@ change them using `docker run --env <key>=<value>`.
 > `ENV DEBIAN_FRONTEND noninteractive`. Which will persist when the container
 > is run interactively; for example: `docker run -t -i image bash`
 
-## ATTR
+## ANNOTATE
 
-    ATTR <key> <value>
+    ANNOTATE <key> <value>
 
-The `ATTR` instruction sets an initial value for the attribute named
-`<key>`. The attribute value is not available to the container itself,
-but may be reported by `docker inspect` and overidden by `docker
-attr`.
+The `ANNOTATE` instruction sets an initial value for the annotation
+named `<key>`. The annotation value is not available to the container
+itself, but may be reported by `docker inspect` and overidden by
+`docker annotate`.
 
-The value must be a JSON literal; so, for example, strings must be
-double-quoted.
+The value should be a JSON literal; if it cannot be parsed as such, it
+will be treated as a string.
 
 ## ADD
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -497,7 +497,7 @@ Creates a new container.
     Create a new container
 
       -a, --attach=[]            Attach to STDIN, STDOUT or STDERR.
-      -A, --attr=[]              Set container attributes
+      -A, --annotate=[]          Set container annotations
       --add-host=[]              Add a custom host-to-IP mapping (host:ip)
       -c, --cpu-shares=0         CPU shares (relative weight)
       --cap-add=[]               Add Linux capabilities
@@ -904,33 +904,35 @@ section contains complex JSON object, so to grab it as JSON, you use
 
     $ sudo docker inspect --format='{{json .config}}' $INSTANCE_ID
 
-**Get an attribute:**
+**Get an annotation:**
 
-Attributes are given under the key `"Attributes"`, and will often be a
+Annotations are given under the key `"Annotations"`, and will often be a
 JSON value.
 
-    $ sudo docker inspect --format='{{json .Attributes.foo }} $INSTANCE_ID
+    $ sudo docker inspect --format='{{ index .Annotations "docker.io" "foo" | json }}' $INSTANCE_ID
 
-## attr
+## annotate
 
-    Usage: docker attr KEY VALUE CONTAINER
+    Usage: docker annotate KEY VALUE CONTAINER
 
-Set a container attribute. Attributes are arbitrary JSON values
+Set a container annotation. Annotations are arbitrary JSON values
 attached to a container, visible via the API and command-line tools,
 but not in general visible to the container.
 
-The `KEY` supplied must be a valid go identifier. It is encouraged to
-use prefixes to scope related keys; e.g., `frobnicatorFoo` and
-`frobnicatorBar`.
+The `KEY` supplied must be in the form `domain/id`, where `domain` is
+defined as in the production `<domainname>` in the grammar given in
+[RFC952](https://tools.ietf.org/html/rfc952) (page 4) and `id` is
+defined as in the production `<name>` in RFC952.
 
 The `VALUE` supplied must be a JSON literal. In many cases this will
-require quoting or escaping. The literal `null` removes the value for
+require quoting or escaping. Anything not parseable as a JSON literal
+will be treated as a string. The literal `null` removes the value for
 a key.
 
-Container attributes are available for inspection under the field
-`.Attributes`.
+Container annotations are available for inspection under the field
+`.Annotations`.
 
-Changing an attribute results in an `update` event being emitted.
+Changing an annotation results in an `update` event being emitted.
 
 ## kill
 
@@ -1236,7 +1238,7 @@ removed before the image is removed.
     Run a command in a new container
 
       -a, --attach=[]            Attach to STDIN, STDOUT or STDERR.
-      -A, --attr=[]              Set container attributes
+      -A, --annotate=[]          Set container annotations
       --add-host=[]              Add a custom host-to-IP mapping (host:ip)
       -c, --cpu-shares=0         CPU shares (relative weight)
       --cap-add=[]               Add Linux capabilities

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -497,6 +497,7 @@ Creates a new container.
     Create a new container
 
       -a, --attach=[]            Attach to STDIN, STDOUT or STDERR.
+      -A, --attr=[]              Set container attributes
       --add-host=[]              Add a custom host-to-IP mapping (host:ip)
       -c, --cpu-shares=0         CPU shares (relative weight)
       --cap-add=[]               Add Linux capabilities
@@ -594,7 +595,7 @@ For example:
 
 Docker containers will report the following events:
 
-    create, destroy, die, export, kill, pause, restart, start, stop, unpause
+    create, destroy, die, export, kill, pause, restart, start, stop, unpause, update
 
 and Docker images will report:
 
@@ -903,6 +904,34 @@ section contains complex JSON object, so to grab it as JSON, you use
 
     $ sudo docker inspect --format='{{json .config}}' $INSTANCE_ID
 
+**Get an attribute:**
+
+Attributes are given under the key `"Attributes"`, and will often be a
+JSON value.
+
+    $ sudo docker inspect --format='{{json .Attributes.foo }} $INSTANCE_ID
+
+## attr
+
+    Usage: docker attr KEY VALUE CONTAINER
+
+Set a container attribute. Attributes are arbitrary JSON values
+attached to a container, visible via the API and command-line tools,
+but not in general visible to the container.
+
+The `KEY` supplied must be a valid go identifier. It is encouraged to
+use prefixes to scope related keys; e.g., `frobnicatorFoo` and
+`frobnicatorBar`.
+
+The `VALUE` supplied must be a JSON literal. In many cases this will
+require quoting or escaping. The literal `null` removes the value for
+a key.
+
+Container attributes are available for inspection under the field
+`.Attributes`.
+
+Changing an attribute results in an `update` event being emitted.
+
 ## kill
 
     Usage: docker kill [OPTIONS] CONTAINER [CONTAINER...]
@@ -1207,6 +1236,7 @@ removed before the image is removed.
     Run a command in a new container
 
       -a, --attach=[]            Attach to STDIN, STDOUT or STDERR.
+      -A, --attr=[]              Set container attributes
       --add-host=[]              Add a custom host-to-IP mapping (host:ip)
       -c, --cpu-shares=0         CPU shares (relative weight)
       --cap-add=[]               Add Linux capabilities

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -368,6 +368,7 @@ Dockerfile instruction and how the operator can override that setting.
     #entrypoint-default-command-to-execute-at-runtime)
  - [EXPOSE (Incoming Ports)](#expose-incoming-ports)
  - [ENV (Environment Variables)](#env-environment-variables)
+ - [ATTR (Container Metadata)](#attr-container-metadata)
  - [VOLUME (Shared Filesystems)](#volume-shared-filesystems)
  - [USER](#user)
  - [WORKDIR](#workdir)
@@ -559,6 +560,27 @@ mechanism to communicate with a linked container by its alias:
 
 If you restart the source container (`servicename` in this case), the recipient
 container's `/etc/hosts` entry will be automatically updated.
+
+## ATTR (container metadata)
+
+An operator or developer can set attribute values for a
+container. These are arbitrary metadata that can be reported by
+`docker inspect` (and unlike env entries, set at any time with `docker
+attr`).
+
+When running the container, an operator can use the flag `-A` to give
+a value to an attribute:
+
+    $ sudo docker run -A 'smellsLike="teenspirit"' ubuntu /bin/bash
+
+The value given is any JSON literal.
+
+In a Dockerfile, attributes can be set with the `ATTR` instruction:
+
+    ATTR smellsLike "teenspirit"
+
+Attribute values set in `docker run` will override those given in the
+Dockerfile.
 
 ## VOLUME (shared filesystems)
 

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -368,7 +368,7 @@ Dockerfile instruction and how the operator can override that setting.
     #entrypoint-default-command-to-execute-at-runtime)
  - [EXPOSE (Incoming Ports)](#expose-incoming-ports)
  - [ENV (Environment Variables)](#env-environment-variables)
- - [ATTR (Container Metadata)](#attr-container-metadata)
+ - [ANNOTATE (Container Metadata)](#annotate-container-metadata)
  - [VOLUME (Shared Filesystems)](#volume-shared-filesystems)
  - [USER](#user)
  - [WORKDIR](#workdir)
@@ -561,25 +561,27 @@ mechanism to communicate with a linked container by its alias:
 If you restart the source container (`servicename` in this case), the recipient
 container's `/etc/hosts` entry will be automatically updated.
 
-## ATTR (container metadata)
+## ANNOTATE (container metadata)
 
-An operator or developer can set attribute values for a
-container. These are arbitrary metadata that can be reported by
-`docker inspect` (and unlike env entries, set at any time with `docker
-attr`).
+An operator or developer can set annotation values for a
+container. These are arbitrary, namespaced metadata that can be
+reported by `docker inspect` (and unlike env entries, set at any time
+with `docker annotate`).
 
 When running the container, an operator can use the flag `-A` to give
-a value to an attribute:
+a value to an annotation:
 
-    $ sudo docker run -A 'smellsLike="teenspirit"' ubuntu /bin/bash
+    $ sudo docker run -A 'docker.io/smellslike=teenspirit' ubuntu /bin/bash
 
-The value given is any JSON literal.
+The value given is any JSON literal, or characters which are
+unparseable as JSON (which will be treated as a string).
 
-In a Dockerfile, attributes can be set with the `ATTR` instruction:
+In a Dockerfile, annotations can be set with the `ANNOTATE`
+instruction:
 
-    ATTR smellsLike "teenspirit"
+    ANNOTATE docker.io/smellslike teenspirit
 
-Attribute values set in `docker run` will override those given in the
+Annotation values set in `docker run` will override those given in the
 Dockerfile.
 
 ## VOLUME (shared filesystems)


### PR DESCRIPTION
This PR describes "Container annotations", that is, metadata for containers.
## Motivation

The motivation for annotations is to be able to "hang" values on a container so that clients -- e.g., plugins -- can examine them and react accordingly. For example, a weave plugin might attach a container to the weave network based on a `weaveIPs` attribute.

Attributes can be set while the container is running, and are visible to consumers of the remote API and to command-line tooling, but not in general from within the container.
## Synopsis

Command line:

``` bash
# Run a container with an annotation
INSTANCE=$(docker run -ti --annotate example.com/animal=Dog ubuntu)
# Annotate a container (whether it's running or not)
docker annotate example.com/animal Fox $INSTANCE
# Get an annotation
docker inspect --format='{{ index .Annotations "example.com" "animal" }}' $INSTANCE
```

NB that annotation get JSON literals, so some values will require quoting; I'll discuss that below.

`Dockerfile`:

```
ANNOTATE example.com/animal Goat
```
## Design choices
### Keys

Keys are namespaced labels `<domain>/<id>`, where the `<id>` has no structure (i.e., no dots). This is to line up with e.g., Kubernetes' idea of annotation and label keys.

Although there's no structure to keys when _setting_ annotations, the values may be maps and arrays, and you can reach down into them with the `format` argument.

``` bash
docker annotate example.com/animals '["deer", "otter", "seal"]' $INSTANCE
docker inspect --format='{{ index .Annotations "example.com" "animals" 0 }}' $INSTANCE
```
### JSON values

Values are JSON literals. This will often necessitate quoting, which can be awkward. The upside is that you can have structured values, like lists of labels or IP addresses or animals.

Anything that _can't_ be parsed as a JSON literal is interpreted as a string -- but care needs to be taken here, since null, numbers and booleans look like strings without the quotes. Anything that's not a hard-coded value, e.g., variables in scripts, should always be quoted if it's intended as a string.
### Update semantics

The given semantics eschew transactions and fine-grained operations; you can inspect an annotation then set it, or you can just stomp on whatever value it has already; but there's no operation for say, adding an entry to an array-valued annotation, atomically. This is to keep things simple to implement and script, mainly.
### null for delete

The literal `null` is used to remove an annotation. This is consistent with what you get if you ask `docker inspect` for a field that doesn't exist -- i.e., `null` means missing.
### Events

There's an event `"update"` that gets fired whenever container annotations are changed. This is so that clients can react to changes in whatever annotations they were interested in.

It doesn't carry any additional information: clients are expected to go and look for a new value and react accordingly. Possibly the key could be included in the event, so clients don't end up spamming docker inspect.
