### PR TITLE
Switch the Dockerfile to use golang:1.3.3-cross as the base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 # the case. Therefore, you don't have to disable it anymore.
 #
 
-FROM	ubuntu:14.04
+FROM	golang:1.3.3-cross
 MAINTAINER	Tianon Gravi <admwiggin@gmail.com> (@tianon)
 
 # Packaged dependencies
@@ -32,6 +32,7 @@ RUN	apt-get update && apt-get install -y \
 	automake \
 	btrfs-tools \
 	build-essential \
+	ca-certificates \
 	curl \
 	dpkg-sig \
 	git \
@@ -39,51 +40,32 @@ RUN	apt-get update && apt-get install -y \
 	libapparmor-dev \
 	libcap-dev \
 	libsqlite3-dev \
-	lxc=1.0* \
+	lxc=1:1.0* \
 	mercurial \
+	procps \
 	parallel \
 	reprepro \
-	ruby1.9.1 \
-	ruby1.9.1-dev \
-	s3cmd=1.1.0* \
+	ruby \
+	ruby-dev \
+	s3cmd=1.5.0* \
 	--no-install-recommends
-
-# Get lvm2 source for compiling statically
-RUN	git clone --no-checkout https://git.fedorahosted.org/git/lvm2.git /usr/local/lvm2 && cd /usr/local/lvm2 && git checkout -q v2_02_103
-# see https://git.fedorahosted.org/cgit/lvm2.git/refs/tags for release tags
-# note: we don't use "git clone -b" above because it then spews big nasty warnings about 'detached HEAD' state that we can't silence as easily as we can silence them using "git checkout" directly
-
-# Compile and install lvm2
-RUN	cd /usr/local/lvm2 && ./configure --enable-static_link && make device-mapper && make install_device-mapper
-# see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
-
-# Install Go
-RUN	curl -sSL https://golang.org/dl/go1.3.3.src.tar.gz | tar -v -C /usr/local -xz
-ENV	PATH	/usr/local/go/bin:$PATH
-ENV	GOPATH	/go:/go/src/github.com/docker/docker/vendor
-ENV PATH /go/bin:$PATH
-RUN	cd /usr/local/go/src && ./make.bash --no-clean 2>&1
-
-# Compile Go for cross compilation
-ENV	DOCKER_CROSSPLATFORMS	\
-	linux/386 linux/arm \
-	darwin/amd64 darwin/386 \
-	freebsd/amd64 freebsd/386 freebsd/arm
-# (set an explicit GOARM of 5 for maximum compatibility)
-ENV	GOARM	5
-RUN	cd /usr/local/go/src && bash -xc 'for platform in $DOCKER_CROSSPLATFORMS; do GOOS=${platform%/*} GOARCH=${platform##*/} ./make.bash --no-clean 2>&1; done'
 
 # Grab Go's cover tool for dead-simple code coverage testing
 RUN	go get golang.org/x/tools/cmd/cover
 
+# Get lvm2 source for compiling statically
+RUN	git clone -b v2_02_103 https://git.fedorahosted.org/git/lvm2.git /usr/local/lvm2
+# see https://git.fedorahosted.org/cgit/lvm2.git/refs/tags for release tags
+
+# Compile and install lvm2
+RUN	cd /usr/local/lvm2 \
+	&& ./configure --enable-static_link \
+	&& make device-mapper \
+	&& make install_device-mapper
+# see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
+
 # TODO replace FPM with some very minimal debhelper stuff
 RUN	gem install --no-rdoc --no-ri fpm --version 1.3.2
-
-# Install man page generator
-RUN mkdir -p /go/src/github.com/cpuguy83 \
-    && git clone -b v1 https://github.com/cpuguy83/go-md2man.git /go/src/github.com/cpuguy83/go-md2man \
-    && cd /go/src/github.com/cpuguy83/go-md2man \
-    && go get -v ./...
 
 # Get the "busybox" image source so we can build locally instead of pulling
 RUN	git clone -b buildroot-2014.02 https://github.com/jpetazzo/docker-busybox.git /docker-busybox
@@ -98,15 +80,32 @@ RUN	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_
 RUN	git config --global user.email 'docker-dummy@example.com'
 
 # Add an unprivileged user to be used for tests which need it
-RUN groupadd -r docker
-RUN useradd --create-home --gid docker unprivilegeduser
+RUN	groupadd -r docker
+RUN	useradd --create-home --gid docker unprivilegeduser
 
 VOLUME	/var/lib/docker
 WORKDIR	/go/src/github.com/docker/docker
-ENV	DOCKER_BUILDTAGS	apparmor selinux btrfs_noversion
+ENV	DOCKER_BUILDTAGS	apparmor selinux
+
+ENV	DOCKER_CROSSPLATFORMS	\
+	linux/386 linux/arm \
+	darwin/amd64 darwin/386 \
+	freebsd/amd64 freebsd/386 freebsd/arm
+
+# (set an explicit GOARM of 5 for maximum compatibility)
+ENV	GOARM	5
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT	["hack/dind"]
+
+# Install man page generator
+COPY	vendor	/go/src/github.com/docker/docker/vendor
+ENV	GOPATH	$GOPATH:/go/src/github.com/docker/docker/vendor
+# (copy vendor/ because go-md2man needs golang.org/x/net)
+RUN	mkdir -p /go/src/github.com/cpuguy83 /go/src/github.com/russross \
+	&& git clone -b v1 https://github.com/cpuguy83/go-md2man.git /go/src/github.com/cpuguy83/go-md2man \
+	&& git clone -b v1.2 https://github.com/russross/blackfriday.git /go/src/github.com/russross/blackfriday \
+	&& go install -v github.com/cpuguy83/go-md2man
 
 # Upload docker source
 COPY	.	/go/src/github.com/docker/docker

--- a/contrib/golang/Dockerfile
+++ b/contrib/golang/Dockerfile
@@ -1,0 +1,58 @@
+# This file exists to make creating new golang images for building/testing
+# ../../Dockerfile on different Go versions easier.
+
+# see also:
+#   https://github.com/docker-library/golang/blob/455b15a41135afc8c34487c0f142c7241bbf11ce/1.3/Dockerfile
+#   https://github.com/docker-library/golang/blob/455b15a41135afc8c34487c0f142c7241bbf11ce/1.3/cross/Dockerfile
+
+FROM debian:jessie
+
+# SCMs for "go get", gcc for cgo
+RUN apt-get update && apt-get install -y \
+		ca-certificates curl gcc libc6-dev make \
+		bzr git mercurial \
+		--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV GOLANG_VERSION 1.3.3
+
+RUN curl -sSL https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz \
+		| tar -v -C /usr/src -xz
+
+RUN cd /usr/src/go/src && ./make.bash --no-clean 2>&1
+
+ENV PATH /usr/src/go/bin:$PATH
+
+RUN mkdir -p /go/src
+ENV GOPATH /go
+ENV PATH /go/bin:$PATH
+WORKDIR /go
+
+# see https://golang.org/doc/install/source#environment
+# see also http://build.golang.org/
+# and canonically, see defs_OS_ARCH.h files in src/pkg/runtime
+#   https://code.google.com/p/go/source/browse?name=go1.3#hg%2Fsrc%2Fpkg%2Fruntime
+ENV GOLANG_CROSSPLATFORMS \
+	darwin/386 darwin/amd64 \
+	dragonfly/386 dragonfly/amd64 \
+	freebsd/386 freebsd/amd64 freebsd/arm \
+	linux/386 linux/amd64 linux/arm \
+	nacl/386 nacl/amd64p32 \
+	netbsd/386 netbsd/amd64 netbsd/arm \
+	openbsd/386 openbsd/amd64 \
+	plan9/386 plan9/amd64 \
+	solaris/amd64 \
+	windows/386 windows/amd64
+
+# ls src/pkg/runtime/defs_*_*.h | sed -r 's!^.*/defs_([^_]+)_([^_]+)[.]h$!\1/\2!'
+
+# (set an explicit GOARM of 5 for maximum ARM compatibility)
+ENV GOARM 5
+
+RUN cd /usr/src/go/src \
+	&& set -ex \
+	&& for platform in $GOLANG_CROSSPLATFORMS; do \
+		GOOS=${platform%/*} \
+		GOARCH=${platform##*/} \
+		./make.bash --no-clean 2>&1; \
+	done


### PR DESCRIPTION
This switches us to Debian Jessie, which as of Nov 5th is in [freeze](https://release.debian.org/jessie/freeze_policy.html), so any changes to "Jessie" as our turtle at the bottom of the stack from here out will be reasonably minor and easy to manage.

This also includes some moving around of bits of the Dockerfile to improve caching and consistency.

This is essentially #5214, take two.
