### PR TITLE
Fix Docker Hub tags list specification

### DIFF
--- a/docs/sources/reference/api/hub_registry_spec.md
+++ b/docs/sources/reference/api/hub_registry_spec.md
@@ -579,13 +579,19 @@ The following naming restrictions apply:
 
 ### Get all tags:
 
-GET /v1/repositories/<namespace>/<repository_name>/tags
+    GET /v1/repositories/<namespace>/<repository_name>/tags
 
     **Return**: HTTP 200
-    { "latest":
-    "9e89cc6f0bc3c38722009fe6857087b486531f9a779a0c17e3ed29dae8f12c4f",
-    “0.1.1”:
-    “b486531f9a779a0c17e3ed29dae8f12c4f9e89cc6f0bc3c38722009fe6857087” }
+    [
+        {
+            "layer": "9e89cc6f",
+            "name": "latest"
+        },
+        {
+            "layer": "b486531f",
+            "name": "0.1.1",
+        }
+    ]
 
 **4.3.2 Read the content of a tag (resolve the image id):**
 


### PR DESCRIPTION
The current implementation of the Docker Hub returns a list of objects containing the tag name and the layer id.

``` json
$ curl https://registry.hub.docker.com/v1/repositories/redis/tags
[{"layer": "ef16032a", "name": "latest"}, {"layer": "51345c84", "name": "2.6"}, {"layer": "51345c84", "name": "2.6.17"}, {"layer": "ef16032a", "name": "2.8"}, {"layer": "9554c310", "name": "2.8.10"}, {"layer": "fb968d8e", "name": "2.8.11"}, {"layer": "a2f8e595", "name": "2.8.12"}, {"layer": "1e665a02", "name": "2.8.13"}, {"layer": "9a809f46", "name": "2.8.14"}, {"layer": "b1985912", "name": "2.8.15"}, {"layer": "7c66279c", "name": "2.8.16"}, {"layer": "ef16032a", "name": "2.8.17"}, {"layer": "6064dc06", "name": "2.8.6"}, {"layer": "818c4318", "name": "2.8.7"}, {"layer": "acf48e3e", "name": "2.8.8"}, {"layer": "e938c5d0", "name": "2.8.9"}]
```
