### PR TITLE
Revise Docs Maintainers list

### DIFF
--- a/docs/MAINTAINERS
+++ b/docs/MAINTAINERS
@@ -1,4 +1,3 @@
 Fred Lifton <fred.lifton@docker.com> (@fredlf)
 James Turnbull <james@lovedthanlost.net> (@jamtur01)
 Sven Dowideit <SvenDowideit@fosiki.com> (@SvenDowideit)
-O.S. Tezer <ostezer@gmail.com> (@OSTezer)


### PR DESCRIPTION
Removing Sonat from docs maintainers because he no longer has time to complete all the responsibilities. Many thanks to Sonat for all of his help.

Pinging @shykes @SvenDowideit @jamtur01 

Docker-DCO-1.1-Signed-off-by: Fred Lifton fred.lifton@docker.com (github: fredlf)
