### PR TITLE
Extract allocation logic from ipallocator and portallocator

### DIFF
--- a/daemon/networkdriver/allocator/allocator.go
+++ b/daemon/networkdriver/allocator/allocator.go
@@ -1,0 +1,170 @@
+package allocator
+
+import (
+	"errors"
+	"math/big"
+)
+
+type slotStatus uint
+
+var (
+	bigOne = big.NewInt(1)
+
+	slotAvailable slotStatus = 0
+	slotAllocated slotStatus = 1
+
+	ErrAlreadyAllocated = errors.New("requested slot is already allocated")
+	ErrRangeFull        = errors.New("no more available slots in range")
+)
+
+type pool interface {
+	GetSlotStatus(*big.Int) slotStatus
+	SetSlotStatus(*big.Int, slotStatus)
+}
+
+// Indices in the automaticPool are rebased to 0 to keep the `big.Int` compact.
+type automaticPool struct {
+	bitfield   *big.Int
+	last       *big.Int
+	rangeBegin *big.Int
+	rangeEnd   *big.Int
+	rangeSize  *big.Int
+}
+
+func newAutomaticPool(rangeBegin, rangeEnd *big.Int) *automaticPool {
+	rangeSize := big.NewInt(0).Sub(rangeEnd, rangeBegin)
+	return &automaticPool{
+		bitfield:   big.NewInt(0),
+		last:       big.NewInt(0).Sub(rangeBegin, bigOne),
+		rangeBegin: big.NewInt(0).Set(rangeBegin),
+		rangeEnd:   big.NewInt(0).Set(rangeEnd),
+		rangeSize:  rangeSize.Add(rangeSize, bigOne), // range is inclusive
+	}
+}
+
+func (pool *automaticPool) GetSlotStatus(idx *big.Int) slotStatus {
+	rebasedIdx := big.NewInt(0).Sub(idx, pool.rangeBegin)
+	return slotStatus(pool.bitfield.Bit(int(rebasedIdx.Int64())))
+}
+
+func (pool *automaticPool) SetSlotStatus(idx *big.Int, status slotStatus) {
+	if pool.IsInRange(idx) {
+		rebasedIdx := big.NewInt(0).Sub(idx, pool.rangeBegin).Int64()
+		pool.bitfield.SetBit(pool.bitfield, int(rebasedIdx), uint(status))
+	}
+}
+
+func (pool *automaticPool) Allocate() (*big.Int, error) {
+	candidate := big.NewInt(0).Add(pool.last, bigOne)
+	for i := big.NewInt(0); i.Cmp(pool.rangeSize) < 0; i.Add(i, bigOne) {
+		// If we go past the end of the range, loop back to the beginning to
+		// check if previously allocated slots have been released in the
+		// [begin, last[ range.
+		if candidate.Cmp(pool.rangeEnd) > 0 {
+			candidate.Set(pool.rangeBegin)
+		}
+
+		if pool.GetSlotStatus(candidate) == slotAvailable {
+			pool.SetSlotStatus(candidate, slotAllocated)
+			pool.last.Set(candidate)
+			return candidate, nil
+		}
+
+		candidate.Add(candidate, bigOne)
+	}
+	return nil, ErrRangeFull
+}
+
+func (pool *automaticPool) IsInRange(idx *big.Int) bool {
+	return idx.Cmp(pool.rangeBegin) >= 0 && idx.Cmp(pool.rangeEnd) <= 0
+}
+
+func (pool *automaticPool) ReleaseAll() {
+	pool.bitfield.Set(big.NewInt(0))
+}
+
+func (pool *automaticPool) Size() *big.Int {
+	return pool.rangeSize
+}
+
+// The custom pool simply holds a string representation of each allocated slot.
+type customPool map[string]struct{}
+
+func newCustomPool() customPool {
+	return make(map[string]struct{})
+}
+
+func (pool customPool) GetSlotStatus(idx *big.Int) slotStatus {
+	if _, ok := pool[idx.String()]; ok {
+		return slotAllocated
+	}
+	return slotAvailable
+}
+
+func (pool customPool) SetSlotStatus(idx *big.Int, status slotStatus) {
+	if status == slotAvailable {
+		delete(pool, idx.String())
+	} else {
+		pool[idx.String()] = struct{}{}
+	}
+}
+
+func (pool customPool) ReleaseAll() {
+	pool = make(map[string]struct{})
+}
+
+// Allocator is a thread-unsafe implementation of an allocation strategy which
+// offers both:
+//	- automatic sequential allocation inside a specified range
+//	- custom allocation of discrete slots.
+// It is left untyped in order to be reused for ports, IP address, or any need
+// other dynamic allocation inside a finite set.
+type Allocator struct {
+	customPool customPool
+	autoPool   *automaticPool
+}
+
+// Create a new allocator providing the inclusive boundaries of the automatic
+// allocation pool.
+func NewAllocator(automaticRangeBegin, automaticRangeEnd *big.Int) *Allocator {
+	return &Allocator{
+		autoPool:   newAutomaticPool(automaticRangeBegin, automaticRangeEnd),
+		customPool: newCustomPool(),
+	}
+}
+
+// Attempt to allocate the specified index in the range.
+func (allocator *Allocator) Allocate(candidate *big.Int) (err error) {
+	var targetPool pool = allocator.selectPool(candidate)
+	if targetPool.GetSlotStatus(candidate) == slotAllocated {
+		err = ErrAlreadyAllocated
+	}
+	targetPool.SetSlotStatus(candidate, slotAllocated)
+	return
+}
+
+// Attempt to find an available slot in the automatic pool.
+func (allocator *Allocator) AllocateFirstAvailable() (*big.Int, error) {
+	return allocator.autoPool.Allocate()
+}
+
+func (allocator *Allocator) AutomaticPoolSize() *big.Int {
+	return allocator.autoPool.Size()
+}
+
+func (allocator *Allocator) Release(idx *big.Int) {
+	allocator.selectPool(idx).SetSlotStatus(idx, slotAvailable)
+}
+
+func (allocator *Allocator) ReleaseAll() {
+	allocator.autoPool.ReleaseAll()
+	allocator.customPool.ReleaseAll()
+}
+
+func (allocator *Allocator) selectPool(idx *big.Int) pool {
+	if allocator.autoPool.IsInRange(idx) {
+		return allocator.autoPool
+	} else {
+		return allocator.customPool
+	}
+}

--- a/daemon/networkdriver/allocator/allocator_test.go
+++ b/daemon/networkdriver/allocator/allocator_test.go
@@ -1,0 +1,111 @@
+package allocator
+
+import (
+	"math/big"
+	"testing"
+)
+
+func allocateRange(alloc *Allocator, start, end *big.Int, t *testing.T) {
+	for i := big.NewInt(0).Set(start); i.Cmp(end) < 0; i.Add(i, big.NewInt(1)) {
+		idx, err := alloc.AllocateFirstAvailable()
+		if err != nil {
+			t.Fatalf("Expected index %d, got error %v", i, err)
+		} else if i.Cmp(idx) != 0 {
+			t.Fatalf("Expected index %d, got %d", i, idx)
+		}
+	}
+}
+
+func TestAllocateAuto(t *testing.T) {
+	alloc := NewAllocator(big.NewInt(0), big.NewInt(100))
+	allocateRange(alloc, big.NewInt(0), big.NewInt(0).Div(alloc.AutomaticPoolSize(), big.NewInt(2)), t)
+}
+
+func TestReallocateAuto(t *testing.T) {
+	alloc := NewAllocator(big.NewInt(100), big.NewInt(200))
+	idx, err := alloc.AllocateFirstAvailable()
+	if err != nil {
+		t.Fatalf("Failed to allocate automatic slot: %v", err)
+	}
+	if err := alloc.Allocate(idx); err == nil {
+		t.Fatalf("Slot was allocated twice")
+	}
+}
+
+func TestAllocatorRangeSize(t *testing.T) {
+	var low, high int64
+
+	low, high = 0, 10
+	alloc := NewAllocator(big.NewInt(low), big.NewInt(high))
+	if expected := big.NewInt(high - low + 1); alloc.AutomaticPoolSize().Cmp(expected) != 0 {
+		t.Fatalf("Wrong allocator range size: expected %d, got %d", expected, alloc.AutomaticPoolSize())
+	}
+
+	low, high = 100, 200
+	alloc = NewAllocator(big.NewInt(low), big.NewInt(high))
+	if expected := big.NewInt(high - low + 1); alloc.AutomaticPoolSize().Cmp(expected) != 0 {
+		t.Fatalf("Wrong allocator range size: expected %d, got %d", expected, alloc.AutomaticPoolSize())
+	}
+
+	low, high = 100, 100
+	alloc = NewAllocator(big.NewInt(low), big.NewInt(high))
+	if expected := big.NewInt(1); alloc.AutomaticPoolSize().Cmp(expected) != 0 {
+		t.Fatalf("Wrong allocator range size: expected %d, got %d", expected, alloc.AutomaticPoolSize())
+	}
+}
+
+func TestAllocateExplicit(t *testing.T) {
+	alloc := NewAllocator(big.NewInt(100), big.NewInt(200))
+	if err := alloc.Allocate(big.NewInt(10)); err != nil {
+		t.Fatalf("Failed to allocate explicit slot: %v", err)
+	}
+	if err := alloc.Allocate(big.NewInt(10)); err == nil {
+		t.Fatalf("Slot was allocated twice")
+	}
+
+	if err := alloc.Allocate(big.NewInt(100)); err != nil {
+		t.Fatalf("Failed to allocate explicit slot: %v", err)
+	}
+	if err := alloc.Allocate(big.NewInt(100)); err == nil {
+		t.Fatalf("Slot was allocated twice")
+	}
+
+	expected := big.NewInt(101)
+	idx, err := alloc.AllocateFirstAvailable()
+	if err != nil {
+		t.Fatalf("Expected index %d, got error %v", expected, err)
+	} else if idx.Cmp(expected) != 0 {
+		t.Fatalf("Expected index %d, got %d", expected, idx)
+	}
+}
+
+func TestAllocateWholeRange(t *testing.T) {
+	alloc := NewAllocator(big.NewInt(0), big.NewInt(10))
+	allocateRange(alloc, big.NewInt(0), alloc.AutomaticPoolSize(), t)
+	if idx, err := alloc.AllocateFirstAvailable(); err == nil {
+		t.Fatalf("Expected error %v, got index %d", err, idx)
+	}
+}
+
+func TestReuseReleased(t *testing.T) {
+	alloc := NewAllocator(big.NewInt(0), big.NewInt(10))
+	allocateRange(alloc, big.NewInt(0), alloc.AutomaticPoolSize(), t)
+
+	var slot int64 = 5
+	alloc.Release(big.NewInt(slot))
+	idx, err := alloc.AllocateFirstAvailable()
+	if err != nil {
+		t.Fatalf("Expected index %d, got error %v", slot, err)
+	} else if idx.Cmp(big.NewInt(slot)) != 0 {
+		t.Fatalf("Expected index %d, got %d", slot, idx)
+	}
+
+	slot = 8
+	alloc.Release(big.NewInt(slot))
+	idx, err = alloc.AllocateFirstAvailable()
+	if err != nil {
+		t.Fatalf("Expected index %d, got error %v", slot, err)
+	} else if idx.Cmp(big.NewInt(slot)) != 0 {
+		t.Fatalf("Expected index %d, got %d", slot, idx)
+	}
+}


### PR DESCRIPTION
IP and ports allocation shared a same strategy for automatically assigning slots inside a given range: this strategy is extracted and refactored (this idea was raised while reviewing #8699). The `ipallocator` and `portallocator` logics remain unchanged (it's just adaptations). Benchmarks results with this patch are very similar.
