### PR TITLE
Remove redundant stripComment

### DIFF
--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -103,10 +103,6 @@ func Parse(rwc io.Reader) (*Node, error) {
 
 	for scanner.Scan() {
 		scannedLine := strings.TrimLeftFunc(scanner.Text(), unicode.IsSpace)
-		if stripComments(scannedLine) == "" {
-			continue
-		}
-
 		line, child, err := parseLine(scannedLine)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This `stripComments` seems to be redundant, cause another same strip is done by the `parseLine` below it.

Docker-DCO-1.1-Signed-off-by: xuzhaokui cynicholas@gmail.com (github: coaku)
