### PR TITLE
Additional info for docker binary

### DIFF
--- a/docs/sources/contributing/devenvironment.md
+++ b/docs/sources/contributing/devenvironment.md
@@ -63,7 +63,8 @@ To create the Docker binary, run this command:
 
     $ sudo make binary
 
-This will create the Docker binary in `./bundles/<version>-dev/binary/`. If you do not see files in the `./bundles` directory in your host, your BINDDIR setting is not set quite right. You want to run the following command: 
+This will create the Docker binary in `./bundles/<version>-dev/binary/`. If you do not see files in the `./bundles` directory in your host, 
+your `BINDDIR` setting is not set quite right. You want to run the following command: 
     
     $ sudo make BINDDIR=. binary 
 

--- a/docs/sources/contributing/devenvironment.md
+++ b/docs/sources/contributing/devenvironment.md
@@ -63,12 +63,14 @@ To create the Docker binary, run this command:
 
     $ sudo make binary
 
-This will create the Docker binary in `./bundles/<version>-dev/binary/`. If you do not see files in the `./bundles` directory in your host, 
-your `BINDDIR` setting is not set quite right. You want to run the following command: 
+This will create the Docker binary in `./bundles/<version>-dev/binary/`. If you
+do not see files in the `./bundles` directory in your host, your `BINDDIR`
+setting is not set quite right. You want to run the following command: 
     
     $ sudo make BINDDIR=. binary 
 
-If you are on a non-Linux platform, e.g., OSX, you'll want to run `make cross` or `make BINDDIR=. cross`.
+If you are on a non-Linux platform, e.g., OSX, you'll want to run `make cross`
+or `make BINDDIR=. cross`.
 
 ### Using your built Docker binary
 

--- a/docs/sources/contributing/devenvironment.md
+++ b/docs/sources/contributing/devenvironment.md
@@ -63,7 +63,11 @@ To create the Docker binary, run this command:
 
     $ sudo make binary
 
-This will create the Docker binary in `./bundles/<version>-dev/binary/`
+This will create the Docker binary in `./bundles/<version>-dev/binary/`. If you do not see files in the `./bundles` directory in your host, your BINDDIR setting is not set quite right. You want to run the following command: 
+    
+    $ sudo make BINDDIR=. binary 
+
+If you are not in Linux - for example: OSX, you want to run `make cross` or `make BINDDIR=. cross`.
 
 ### Using your built Docker binary
 

--- a/docs/sources/contributing/devenvironment.md
+++ b/docs/sources/contributing/devenvironment.md
@@ -68,7 +68,7 @@ your `BINDDIR` setting is not set quite right. You want to run the following com
     
     $ sudo make BINDDIR=. binary 
 
-If you are not in Linux - for example: OSX, you want to run `make cross` or `make BINDDIR=. cross`.
+If you are on a non-Linux platform, e.g., OSX, you'll want to run `make cross` or `make BINDDIR=. cross`.
 
 ### Using your built Docker binary
 


### PR DESCRIPTION
I found that certain docker installations do not handle binding to the source directory quite right. In my case it was `boot2docker` but I don't think it is specific to it. Updating the docs based on help from `backjlack` and `tibor` in IRC.
