### PR TITLE
Fix README punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Contributing to Docker
 Want to hack on Docker? Awesome! There are instructions to get you
 started [here](CONTRIBUTING.md).
 
-They are probably not perfect, please let us know if anything feels
+They are probably not perfect - please let us know if anything feels
 wrong or incomplete.
 
 ### Legal


### PR DESCRIPTION
This is a minor fix and should satisfy [small patch exception](https://github.com/docker/docker/blob/master/CONTRIBUTING.md#small-patch-exception)

[Guide to semicolon vs dash](http://english.stackexchange.com/a/4015) The README seems to currently favor dashes. Regardless of fix to either dash or semicolon, I think it's clear the status quo should be changed.
