### PR TITLE
Make 'docker push' faster at the small expense of extra registry disk space

### DIFF
--- a/pkg/tarsum/tarsum.go
+++ b/pkg/tarsum/tarsum.go
@@ -155,7 +155,11 @@ func (ts *tarSum) initTarSum() error {
 	ts.tarR = tar.NewReader(ts.Reader)
 	ts.tarW = tar.NewWriter(ts.bufTar)
 	if !ts.DisableCompression {
-		ts.writer = gzip.NewWriter(ts.bufWriter)
+		var err error
+		ts.writer, err = gzip.NewWriterLevel(ts.bufWriter, gzip.BestSpeed)
+		if err != nil {
+			panic(err) // impossible
+		}
 	} else {
 		ts.writer = &nopCloseFlusher{Writer: ts.bufWriter}
 	}

--- a/pkg/tarsum/tarsum_test.go
+++ b/pkg/tarsum/tarsum_test.go
@@ -216,7 +216,10 @@ func TestEmptyTar(t *testing.T) {
 	}
 
 	bufgz := new(bytes.Buffer)
-	gz := gzip.NewWriter(bufgz)
+	gz, err := gzip.NewWriterLevel(bufgz, gzip.BestSpeed)
+	if err != nil {
+		t.Fatal(err)
+	}
 	n, err = io.Copy(gz, bytes.NewBuffer(zeroBlock))
 	gz.Close()
 	gzBytes := bufgz.Bytes()


### PR DESCRIPTION
Docker push currently uses default gzip settings to ship layers to the registry server.  This is somewhat cpu intensive and annoying when doing frequent pushes (as you would when inserting Docker into your CI pipeline).

Instead of using the default gzip settings use `gzip.BestSpeed` which is faster but compresses less completely than the defaults.  This pushes gzip closer to Google's Snappy compression library in spirit (["high speeds and reasonable compression"](https://code.google.com/p/snappy/)).

Timing comparision using the `google/golang` image over localhost into a sandbox registry:

```
# stock docker 1.3.1
$ time sudo docker push localhost:5050/google/golang
...
real    1m22.158s
user    0m0.217s
sys 0m0.138s

# docker 1.3.1 with the BestSpeed change
...
real    0m46.427s
user    0m0.224s
sys 0m0.133s
```

This is somewhat related to https://github.com/docker/docker/issues/7291 but that issue is locked from non-contributor comments.
