### PR TITLE
Fix for #8777

### DIFF
--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -21,6 +21,16 @@ func TestImagesEnsureImageIsListed(t *testing.T) {
 	logDone("images - busybox should be listed")
 }
 
+func TestImagesErrorWithInvalidFilterNameTest(t *testing.T) {
+	imagesCmd := exec.Command(dockerBinary, "images", "-f", "FOO=123")
+	out, _, err := runCommandWithOutput(imagesCmd)
+	if !strings.Contains(out, "invalid filter name") {
+		t.Fatalf("error should occur when listing images with invalid filter name FOO, %s, %v", out, err)
+	}
+
+	logDone("images - invalid filter name check working")
+}
+
 func TestImagesOrderedByCreationDate(t *testing.T) {
 	defer deleteImages("order:test_a")
 	defer deleteImages("order:test_c")

--- a/pkg/parsers/filters/parse.go
+++ b/pkg/parsers/filters/parse.go
@@ -29,7 +29,9 @@ func ParseFlag(arg string, prev Args) (Args, error) {
 	}
 
 	f := strings.SplitN(arg, "=", 2)
-	filters[f[0]] = append(filters[f[0]], f[1])
+	name := strings.Trim(f[0], " ")
+	value := strings.Trim(f[1], " ")
+	filters[name] = append(filters[name], value)
 
 	return filters, nil
 }


### PR DESCRIPTION
Now filter name is trimmed and lowercased before evaluation for case
insensitive and whitespace trimemd check.

Signed-off-by: Oh Jinkyun tintypemolly@gmail.com
