### PR TITLE
Fix docker rmi

### DIFF
--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -131,10 +131,7 @@ func (daemon *Daemon) DeleteImage(eng *engine.Engine, name string, imgs *engine.
 
 func (daemon *Daemon) canDeleteImage(imgID string, force bool) error {
 	for _, container := range daemon.List() {
-		parent, err := daemon.Repositories().LookupImage(container.Image)
-		if err != nil {
-			return err
-		}
+		parent, _ := daemon.Repositories().LookupImage(container.Image)
 
 		if err := parent.WalkHistory(func(p *image.Image) error {
 			if imgID == p.ID {


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Fix #9056 
When remove an image which is used by a container use the command line `docker rmi -f xxxx`,
the image will be removed,but the container not and so the problem happened,
if you remove any unrelated image,it will fail with a message `No such id: xxxx`.
This is because when remove any image,it will check all existing container to find if the image is 
used by a container and the container whose image is already removed will also be checked,
and the check will return an error because the image of the container is not existed any more.

This patch ignore the return value `err` of  `daemon.Repositories().LookupImage(container.Image)`
because if `err` is not nil, the return value `parent` is also nil and the next function parent.WalkHistory
will skip. And in fact, there is no need to check a removed image.
I think this PR would fix the docker rmi issue.
