### PR TITLE
Remove the redundant include_search in mkdocs.yml

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -17,7 +17,6 @@ use_absolute_urls: true
 # theme: docker
 theme_dir: ./theme/mkdocs/
 theme_center_lead: false
-include_search: true
 
 copyright: Copyright &copy; 2014, Docker, Inc.
 google_analytics: ['UA-6096819-11', 'docker.io']


### PR DESCRIPTION
There're two `include_search: true` in mkdocs.yml. Just remove the redundant one.
