### PR TITLE
Remove small patch exception checking in hack/make/validate-dco

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,18 +272,6 @@ Note that the old-style `Docker-DCO-1.1-Signed-off-by: ...` format is still
 accepted, so there is no need to update outstanding pull requests to the new
 format right away, but please do adjust your processes for future contributions.
 
-#### Small patch exception
-
-There are several exceptions to the signing requirement. Currently these are:
-
-* Your patch fixes spelling or grammar errors.
-* Your patch is a single line change to documentation contained in the
-  `docs` directory.
-* Your patch fixes Markdown formatting or syntax errors in the
-  documentation contained in the `docs` directory.
-
-If you have any questions, please refer to the FAQ in the [docs](http://docs.docker.com)
-
 ### How can I become a maintainer?
 
 * Step 1: Learn the component inside out

--- a/project/MAINTAINERS.md
+++ b/project/MAINTAINERS.md
@@ -121,6 +121,23 @@ request that comments out your `MAINTAINERS` file entry using a `#`.
 Yes. Nobody should ever push to master directly. All changes should be
 made through a pull request.
 
+### Helping contributors with the DCO
+
+The [DCO or `Sign your work`](
+https://github.com/docker/docker/blob/master/CONTRIBUTING.md#sign-your-work)
+requirement is not intended as a roadblock or speed bump.
+
+Some Docker contributors are not as familiar with `git`, or have used a web based
+editor, and thus asking them to `git commit --amend -s` is not the best way forward.
+
+In this case, maintainers can update the commits based on clause (c) of the DCO. The
+most trivial way for a contributor to allow the maintainer to do this, is to add
+a DCO signature in a Pull Requests's comment, or a maintainer can simply note that
+the change is sufficiently trivial that it does not substantivly change the existing
+contribution - i.e., a spelling change.
+
+When you add someone's DCO, please also add your own to keep a log.
+
 ### Who assigns maintainers?
 
 Solomon has final `LGTM` approval for all pull requests to `MAINTAINERS` files.

--- a/project/make/validate-dco
+++ b/project/make/validate-dco
@@ -4,7 +4,7 @@ source "$(dirname "$BASH_SOURCE")/.validate"
 
 adds=$(validate_diff --numstat | awk '{ s += $1 } END { print s }')
 dels=$(validate_diff --numstat | awk '{ s += $2 } END { print s }')
-notDocs="$(validate_diff --numstat | awk '$3 !~ /^docs\// { print $3 }')"
+#notDocs="$(validate_diff --numstat | awk '$3 !~ /^docs\// { print $3 }')"
 
 : ${adds:=0}
 : ${dels:=0}
@@ -22,8 +22,6 @@ check_dco() {
 
 if [ $adds -eq 0 -a $dels -eq 0 ]; then
 	echo '0 adds, 0 deletions; nothing to validate! :)'
-elif [ -z "$notDocs" -a $adds -le 1 -a $dels -le 1 ]; then
-	echo 'Congratulations!  DCO small-patch-exception material!'
 else
 	commits=( $(validate_log --format='format:%H%n') )
 	badCommits=()


### PR DESCRIPTION
I propose allowing maintainers to add a DCO when its missing from the git commit. 

Either by asking the commiter to add it to the Pull Request's comments, or by deciding its a trivial change, so can be signed by them.

replaces #9010 
#9079 is an example of this in action.
