### PR TITLE
one way of fix the issue 9056, can't remove the related image

### DIFF
--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -84,7 +84,7 @@ func (daemon *Daemon) DeleteImage(eng *engine.Engine, name string, imgs *engine.
 		return nil
 	}
 
-	if len(repos) <= 1 {
+	if len(repos) <= 1 && first {
 		if err := daemon.canDeleteImage(img.ID, force); err != nil {
 			return err
 		}


### PR DESCRIPTION
I get why this issue happened. assume that 
1. we have a image A which has 4 layer A, B, C, D. which A is the children. B is parent, C is grand-parent, D is ancestor
2. we start a container E with A. and container E 's image id must be A.
3. exit container E. and rmi -f A 
when we remove image A. we should first remove A, then remove B, then C....
every remove action will call "parent, err := daemon.Repositories().LookupImage(container.Image)" function. for removing image A is ok. but for removing image B. the container E's image id is still A, but A has been removed. so this issue happend.
So I set the bool flag just the first remove action will call "LookupImage".
Signed-off-by: Chen Chao cc272309126@gmail.com
