### PR TITLE
Initialize volumes when container is created

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -94,6 +94,13 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 			return nil, nil, err
 		}
 	}
+	if err := container.Mount(); err != nil {
+		return nil, nil, err
+	}
+	defer container.Unmount()
+	if err := container.prepareVolumes(); err != nil {
+		return nil, nil, err
+	}
 	if err := container.ToDisk(); err != nil {
 		return nil, nil, err
 	}

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -57,6 +57,9 @@ total memory available (`MemTotal`).
 **New!**
 You can set the new container's MAC address explicitly.
 
+**New!**
+Volumes are now initialized when the container is created.
+
 `POST /containers/(id)/start`
 
 **New!**

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"os"
 	"os/exec"
 	"testing"
 	"time"
@@ -124,4 +125,22 @@ func TestCreateEchoStdout(t *testing.T) {
 	deleteAllContainers()
 
 	logDone("create - echo test123")
+}
+
+func TestCreateVolumesCreated(t *testing.T) {
+	name := "test_create_volume"
+	cmd(t, "create", "--name", name, "-v", "/foo", "busybox")
+	dir, err := inspectFieldMap(name, "Volumes", "/foo")
+	if err != nil {
+		t.Fatalf("Error getting volume host path: %q", err)
+	}
+
+	if _, err := os.Stat(dir); err != nil && os.IsNotExist(err) {
+		t.Fatalf("Volume was not created")
+	}
+	if err != nil {
+		t.Fatalf("Error statting volume host path: %q", err)
+	}
+
+	logDone("create - volumes are created")
 }


### PR DESCRIPTION
Fixes #8942
Current behavior is that volumes aren't initialized until start.
Volumes still need to be initialized on start since VolumesFrom and
Binds can be passed in as part of HostConfig on start, however anything
that's already been initialized will just be skipped as is the current
behavior.
