### PR TITLE
pkg/archive: add interface for Untar

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -36,10 +36,17 @@ type (
 		NoLchown    bool
 		Name        string
 	}
+
+	// Archiver allows the reuse of most utility functions of this package
+	// with a pluggable Untar function.
+	Archiver struct {
+		Untar func(io.Reader, string, *TarOptions) error
+	}
 )
 
 var (
 	ErrNotImplemented = errors.New("Function not implemented")
+	defaultArchiver   = &Archiver{Untar}
 )
 
 const (
@@ -549,45 +556,47 @@ loop:
 	return nil
 }
 
-// TarUntar is a convenience function which calls Tar and Untar, with
-// the output of one piped into the other. If either Tar or Untar fails,
-// TarUntar aborts and returns the error.
-func TarUntar(src string, dst string) error {
+func (archiver *Archiver) TarUntar(src, dst string) error {
 	log.Debugf("TarUntar(%s %s)", src, dst)
 	archive, err := TarWithOptions(src, &TarOptions{Compression: Uncompressed})
 	if err != nil {
 		return err
 	}
 	defer archive.Close()
-	return Untar(archive, dst, nil)
+	return archiver.Untar(archive, dst, nil)
 }
 
-// UntarPath is a convenience function which looks for an archive
-// at filesystem path `src`, and unpacks it at `dst`.
-func UntarPath(src, dst string) error {
+// TarUntar is a convenience function which calls Tar and Untar, with the output of one piped into the other.
+// If either Tar or Untar fails, TarUntar aborts and returns the error.
+func TarUntar(src, dst string) error {
+	return defaultArchiver.TarUntar(src, dst)
+}
+
+func (archiver *Archiver) UntarPath(src, dst string) error {
 	archive, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer archive.Close()
-	if err := Untar(archive, dst, nil); err != nil {
+	if err := archiver.Untar(archive, dst, nil); err != nil {
 		return err
 	}
 	return nil
 }
 
-// CopyWithTar creates a tar archive of filesystem path `src`, and
-// unpacks it at filesystem path `dst`.
-// The archive is streamed directly with fixed buffering and no
-// intermediary disk IO.
-//
-func CopyWithTar(src, dst string) error {
+// UntarPath is a convenience function which looks for an archive
+// at filesystem path `src`, and unpacks it at `dst`.
+func UntarPath(src, dst string) error {
+	return defaultArchiver.UntarPath(src, dst)
+}
+
+func (archiver *Archiver) CopyWithTar(src, dst string) error {
 	srcSt, err := os.Stat(src)
 	if err != nil {
 		return err
 	}
 	if !srcSt.IsDir() {
-		return CopyFileWithTar(src, dst)
+		return archiver.CopyFileWithTar(src, dst)
 	}
 	// Create dst, copy src's content into it
 	log.Debugf("Creating dest directory: %s", dst)
@@ -595,16 +604,18 @@ func CopyWithTar(src, dst string) error {
 		return err
 	}
 	log.Debugf("Calling TarUntar(%s, %s)", src, dst)
-	return TarUntar(src, dst)
+	return archiver.TarUntar(src, dst)
 }
 
-// CopyFileWithTar emulates the behavior of the 'cp' command-line
-// for a single file. It copies a regular file from path `src` to
-// path `dst`, and preserves all its metadata.
-//
-// If `dst` ends with a trailing slash '/', the final destination path
-// will be `dst/base(src)`.
-func CopyFileWithTar(src, dst string) (err error) {
+// CopyWithTar creates a tar archive of filesystem path `src`, and
+// unpacks it at filesystem path `dst`.
+// The archive is streamed directly with fixed buffering and no
+// intermediary disk IO.
+func CopyWithTar(src, dst string) error {
+	return defaultArchiver.CopyWithTar(src, dst)
+}
+
+func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 	log.Debugf("CopyFileWithTar(%s, %s)", src, dst)
 	srcSt, err := os.Stat(src)
 	if err != nil {
@@ -652,7 +663,17 @@ func CopyFileWithTar(src, dst string) (err error) {
 			err = er
 		}
 	}()
-	return Untar(r, filepath.Dir(dst), nil)
+	return archiver.Untar(r, filepath.Dir(dst), nil)
+}
+
+// CopyFileWithTar emulates the behavior of the 'cp' command-line
+// for a single file. It copies a regular file from path `src` to
+// path `dst`, and preserves all its metadata.
+//
+// If `dst` ends with a trailing slash '/', the final destination path
+// will be `dst/base(src)`.
+func CopyFileWithTar(src, dst string) (err error) {
+	return defaultArchiver.CopyFileWithTar(src, dst)
 }
 
 // CmdStream executes a command, and returns its stdout as a stream.


### PR DESCRIPTION
This PR modifies archive to make it possible to use alternative Untar implementations. This could be extended to other functions in the future.
