### PR TITLE
Cleanup some integration-cli output

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -169,7 +169,7 @@ func TestDaemonIptablesClean(t *testing.T) {
 
 	deleteAllContainers()
 
-	logDone("run,iptables - iptables rules cleaned after daemon restart")
+	logDone("daemon - run,iptables - iptables rules cleaned after daemon restart")
 }
 
 func TestDaemonIptablesCreate(t *testing.T) {
@@ -221,5 +221,5 @@ func TestDaemonIptablesCreate(t *testing.T) {
 
 	deleteAllContainers()
 
-	logDone("run,iptables - iptables rules for always restarted container created after daemon restart")
+	logDone("daemon - run,iptables - iptables rules for always restarted container created after daemon restart")
 }

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -40,7 +40,6 @@ func TestExecInteractiveStdinClose(t *testing.T) {
 	}
 
 	contId := strings.TrimSpace(out)
-	println(contId)
 
 	returnchan := make(chan struct{})
 

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -74,7 +74,7 @@ func TestRmiTag(t *testing.T) {
 		}
 
 	}
-	logDone("tag,rmi- tagging the same images multiple times then removing tags")
+	logDone("rmi - tag,rmi- tagging the same images multiple times then removing tags")
 }
 
 func TestRmiTagWithExistingContainers(t *testing.T) {

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -71,8 +71,7 @@ func TestSaveAndLoadRepoStdout(t *testing.T) {
 
 	os.Remove("/tmp/foobar-save-load-test.tar")
 
-	logDone("save - save a repo using stdout")
-	logDone("load - load a repo using stdout")
+	logDone("save - save/load a repo using stdout")
 
 	pty, tty, err := pty.Open()
 	if err != nil {
@@ -228,8 +227,7 @@ func TestSaveAndLoadRepoFlags(t *testing.T) {
 
 	os.Remove("/tmp/foobar-save-load-test.tar")
 
-	logDone("save - save a repo using -o")
-	logDone("load - load a repo using -i")
+	logDone("save - save a repo using -o && load a repo using -i")
 }
 
 func TestSaveMultipleNames(t *testing.T) {


### PR DESCRIPTION
I noticed a few things that were bugging me in the output
of the integration-cli tests.
- one of the tests used println to stdout so we had garage sent to the screen
- some of the test, in their final log message, didn't include the name of
  the group/file e.g.  daemon - run,iptables   was just   run,iptables

And yes, I noticed this because I'm anal :-)  but also because we should keep
the output of the tests as clean as possible so its easy to spot it when
things go bad.

Signed-off-by: Doug Davis dug@us.ibm.com
