### PR TITLE
Proposal: Copy data from container to empty volume in all cases

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -22,7 +22,6 @@ type Mount struct {
 	container   *Container
 	volume      *volumes.Volume
 	Writable    bool
-	copyData    bool
 }
 
 func (mnt *Mount) Export(resource string) (io.ReadCloser, error) {
@@ -89,7 +88,7 @@ func (m *Mount) initialize() error {
 	m.container.VolumesRW[m.MountToPath] = m.Writable
 	m.container.Volumes[m.MountToPath] = m.volume.Path
 	m.volume.AddContainer(m.container.ID)
-	if m.Writable && m.copyData {
+	if m.Writable {
 		// Copy whatever is in the container at the mntToPath to the volume
 		copyExistingContents(containerMntPath, m.volume.Path)
 	}
@@ -165,7 +164,6 @@ func (container *Container) parseVolumeMountConfig() (map[string]*Mount, error) 
 			MountToPath: path,
 			volume:      vol,
 			Writable:    true,
-			copyData:    true,
 		}
 	}
 

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -63,6 +63,13 @@ You can set the new container's MAC address explicitly.
 Passing the container's `HostConfig` on start is now deprecated.  You should
 set this when creating the container.
 
+**New!**
+Previously, when creating a volume link to a container from `VolumesFrom` or
+`Binds`, data from the container at the specified path would not be copied into
+the volume. Now, as long as the volume is empty, data from the container will
+always be copied when the volume is created. Note that `docker restart` will not
+re-initialize the linked volume.
+
 `POST /containers/(id)/copy`
 
 **New!**

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2346,42 +2346,6 @@ func TestRunReuseBindVolumeThatIsSymlink(t *testing.T) {
 	logDone("run - can remount old bindmount volume")
 }
 
-func TestVolumesNoCopyData(t *testing.T) {
-	defer deleteImages("dataimage")
-	defer deleteAllContainers()
-	if _, err := buildImage("dataimage",
-		`FROM busybox
-		 RUN mkdir -p /foo
-		 RUN touch /foo/bar`,
-		true); err != nil {
-		t.Fatal(err)
-	}
-
-	cmd := exec.Command(dockerBinary, "run", "--name", "test", "-v", "/foo", "busybox")
-	if _, err := runCommand(cmd); err != nil {
-		t.Fatal(err)
-	}
-
-	cmd = exec.Command(dockerBinary, "run", "--volumes-from", "test", "dataimage", "ls", "-lh", "/foo/bar")
-	if out, _, err := runCommandWithOutput(cmd); err == nil || !strings.Contains(out, "No such file or directory") {
-		t.Fatalf("Data was copied on volumes-from but shouldn't be:\n%q", out)
-	}
-
-	tmpDir, err := ioutil.TempDir("", "docker_test_bind_mount_copy_data")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmpDir)
-
-	cmd = exec.Command(dockerBinary, "run", "-v", tmpDir+":/foo", "dataimage", "ls", "-lh", "/foo/bar")
-	if out, _, err := runCommandWithOutput(cmd); err == nil || !strings.Contains(out, "No such file or directory") {
-		t.Fatalf("Data was copied on bind-mount but shouldn't be:\n%q", out)
-	}
-
-	logDone("run - volumes do not copy data for volumes-from and bindmounts")
-}
-
 func TestRunVolumesNotRecreatedOnStart(t *testing.T) {
 	// Clear out any remnants from other tests
 	deleteAllContainers()


### PR DESCRIPTION
Currently data is only copied into a volume if it is a _normal_ volume,
e.g. not for volumes-from or host-mounts.

At one point a host-mounted volume would not be automatically created if
the dir didn't exist already, today that is no longer true.  If we are
willing to create the dir, we might as well populate it too.

This makes it so data is always copied if the volume is empty.
