### PR TITLE
Patch to origin/commit-change patch to add docker import support

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1112,6 +1112,8 @@ func (cli *DockerCli) CmdKill(args ...string) error {
 
 func (cli *DockerCli) CmdImport(args ...string) error {
 	cmd := cli.Subcmd("import", "URL|- [REPOSITORY[:TAG]]", "Create an empty filesystem image and import the contents of the tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then optionally tag it.")
+	flChanges := opts.NewListOpts(nil)
+	cmd.Var(&flChanges, []string{"c", "-change"}, "Apply a modification before importing the image")
 
 	if err := cmd.Parse(args); err != nil {
 		return nil
@@ -1129,6 +1131,7 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 
 	v.Set("fromSrc", src)
 	v.Set("repo", repository)
+	v.Set("changes", strings.Join(flChanges.GetAll(), "\n"))
 
 	if cmd.NArg() == 3 {
 		fmt.Fprintf(cli.err, "[DEPRECATED] The format 'URL|- [REPOSITORY [TAG]]' as been deprecated. Please use URL|- [REPOSITORY[:TAG]]\n")

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1672,6 +1672,8 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	flPause := cmd.Bool([]string{"p", "-pause"}, true, "Pause container during commit")
 	flComment := cmd.String([]string{"m", "-message"}, "", "Commit message")
 	flAuthor := cmd.String([]string{"a", "#author", "-author"}, "", "Author (e.g., \"John Hannibal Smith <hannibal@a-team.com>\")")
+	flChanges := opts.NewListOpts(nil)
+	cmd.Var(&flChanges, []string{"c", "-change"}, "Apply a modification before committing the image")
 	// FIXME: --run is deprecated, it will be replaced with inline Dockerfile commands.
 	flConfig := cmd.String([]string{"#run", "#-run"}, "", "This option is deprecated and will be removed in a future version in favor of inline Dockerfile-compatible commands")
 	if err := cmd.Parse(args); err != nil {
@@ -1701,6 +1703,7 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	v.Set("tag", tag)
 	v.Set("comment", *flComment)
 	v.Set("author", *flAuthor)
+	v.Set("changes", strings.Join(flChanges.GetAll(), "\n"))
 
 	if *flPause != true {
 		v.Set("pause", "0")

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -477,6 +477,7 @@ func postCommit(eng *engine.Engine, version version.Version, w http.ResponseWrit
 	job.Setenv("tag", r.Form.Get("tag"))
 	job.Setenv("author", r.Form.Get("author"))
 	job.Setenv("comment", r.Form.Get("comment"))
+	job.Setenv("changes", r.Form.Get("changes"))
 	job.SetenvSubEnv("config", &config)
 
 	job.Stdout.Add(stdoutBuffer)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -530,6 +530,7 @@ func postImagesCreate(eng *engine.Engine, version version.Version, w http.Respon
 		}
 		job = eng.Job("import", r.Form.Get("fromSrc"), repo, tag)
 		job.Stdin.Add(r.Body)
+		job.Setenv("changes", r.Form.Get("changes"))
 	}
 
 	if version.GreaterThan("1.0") {

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -91,6 +91,11 @@ type Builder struct {
 	Remove      bool
 	ForceRemove bool
 
+	// set this to true if we want the builder to not commit between steps.
+	// This is useful when we only want to use the evaluator table to generate
+	// the final configs of the Dockerfile but dont want the layers
+	disableCommit bool
+
 	AuthConfig     *registry.AuthConfig
 	AuthConfigFile *registry.ConfigFile
 

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -55,6 +55,9 @@ func (b *Builder) readContext(context io.Reader) error {
 }
 
 func (b *Builder) commit(id string, autoCmd []string, comment string) error {
+	if b.disableCommit {
+		return nil
+	}
 	if b.image == "" {
 		return fmt.Errorf("Please provide a source image with `from` prior to commit")
 	}

--- a/builder/job.go
+++ b/builder/job.go
@@ -1,17 +1,22 @@
 package builder
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 
+	"github.com/docker/docker/builder/parser"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/graph"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/registry"
+	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
 )
 
@@ -22,6 +27,7 @@ type BuilderJob struct {
 
 func (b *BuilderJob) Install() {
 	b.Engine.Register("build", b.CmdBuild)
+	b.Engine.Register("build_config", b.CmdBuildConfig)
 }
 
 func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
@@ -124,6 +130,61 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 
 	if repoName != "" {
 		b.Daemon.Repositories().Set(repoName, tag, id, true)
+	}
+	return engine.StatusOK
+}
+
+func (b *BuilderJob) CmdBuildConfig(job *engine.Job) engine.Status {
+	if len(job.Args) != 0 {
+		return job.Errorf("Usage: %s\n", job.Name)
+	}
+	var (
+		validCmd = map[string]struct{}{
+			"entrypoint": {},
+			"cmd":        {},
+			"user":       {},
+			"workdir":    {},
+			"env":        {},
+			"volume":     {},
+			"expose":     {},
+			"onbuild":    {},
+		}
+
+		changes   = job.Getenv("changes")
+		newConfig runconfig.Config
+	)
+
+	if err := job.GetenvJson("config", &newConfig); err != nil {
+		return job.Error(err)
+	}
+
+	ast, err := parser.Parse(bytes.NewBufferString(changes))
+	if err != nil {
+		return job.Error(err)
+	}
+
+	builder := &Builder{
+		Daemon:        b.Daemon,
+		Engine:        b.Engine,
+		Config:        &newConfig,
+		OutStream:     ioutil.Discard,
+		ErrStream:     ioutil.Discard,
+		disableCommit: true,
+	}
+
+	for i, n := range ast.Children {
+		cmd := n.Value
+		if _, ok := validCmd[cmd]; ok {
+			if err := builder.dispatch(i, n); err != nil {
+				return job.Error(err)
+			}
+		} else {
+			fmt.Fprintf(builder.ErrStream, "# Skipping serialization of instruction %s\n", strings.ToUpper(cmd))
+		}
+	}
+
+	if err := json.NewEncoder(job.Stdout).Encode(builder.Config); err != nil {
+		return job.Error(err)
 	}
 	return engine.StatusOK
 }

--- a/builder/job.go
+++ b/builder/job.go
@@ -3,7 +3,6 @@ package builder
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -19,6 +18,18 @@ import (
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
 )
+
+// whitelist of commands allowed for a commit
+var validCommitCommands = map[string]bool{
+	"entrypoint": true,
+	"cmd":        true,
+	"user":       true,
+	"workdir":    true,
+	"env":        true,
+	"volume":     true,
+	"expose":     true,
+	"onbuild":    true,
+}
 
 type BuilderJob struct {
 	Engine *engine.Engine
@@ -138,18 +149,8 @@ func (b *BuilderJob) CmdBuildConfig(job *engine.Job) engine.Status {
 	if len(job.Args) != 0 {
 		return job.Errorf("Usage: %s\n", job.Name)
 	}
-	var (
-		validCmd = map[string]struct{}{
-			"entrypoint": {},
-			"cmd":        {},
-			"user":       {},
-			"workdir":    {},
-			"env":        {},
-			"volume":     {},
-			"expose":     {},
-			"onbuild":    {},
-		}
 
+	var (
 		changes   = job.Getenv("changes")
 		newConfig runconfig.Config
 	)
@@ -163,6 +164,13 @@ func (b *BuilderJob) CmdBuildConfig(job *engine.Job) engine.Status {
 		return job.Error(err)
 	}
 
+	// ensure that the commands are valid
+	for _, n := range ast.Children {
+		if !validCommitCommands[n.Value] {
+			return job.Errorf("%s is not a valid change command", n.Value)
+		}
+	}
+
 	builder := &Builder{
 		Daemon:        b.Daemon,
 		Engine:        b.Engine,
@@ -173,13 +181,8 @@ func (b *BuilderJob) CmdBuildConfig(job *engine.Job) engine.Status {
 	}
 
 	for i, n := range ast.Children {
-		cmd := n.Value
-		if _, ok := validCmd[cmd]; ok {
-			if err := builder.dispatch(i, n); err != nil {
-				return job.Error(err)
-			}
-		} else {
-			fmt.Fprintf(builder.ErrStream, "# Skipping serialization of instruction %s\n", strings.ToUpper(cmd))
+		if err := builder.dispatch(i, n); err != nil {
+			return job.Error(err)
 		}
 	}
 

--- a/builder/job.go
+++ b/builder/job.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/docker/utils"
 )
 
-// whitelist of commands allowed for a commit
+// whitelist of commands allowed for a commit/import
 var validCommitCommands = map[string]bool{
 	"entrypoint": true,
 	"cmd":        true,

--- a/docs/man/docker-commit.1.md
+++ b/docs/man/docker-commit.1.md
@@ -7,6 +7,7 @@ docker-commit - Create a new image from a container's changes
 # SYNOPSIS
 **docker commit**
 [**-a**|**--author**[=*AUTHOR*]]
+[**-c**|**--change**[= []**]]
 [**-m**|**--message**[=*MESSAGE*]]
 [**-p**|**--pause**[=*true*]]
  CONTAINER [REPOSITORY[:TAG]]
@@ -17,6 +18,9 @@ Using an existing container's name or ID you can create a new image.
 # OPTIONS
 **-a**, **--author**=""
    Author (e.g., "John Hannibal Smith <hannibal@a-team.com>")
+
+ -c ,  --change =[]
+   Apply a modification in Dockerfile format before committing the image.
 
 **-m**, **--message**=""
    Commit message
@@ -34,8 +38,17 @@ create a new image run docker ps to find the container's ID and then run:
     # docker commit -m="Added Apache to Fedora base image" \
       -a="A D Ministrator" 98bd7fc99854 fedora/fedora_httpd:20
 
+## Modify configuration settings before committing the image
+An existing container was created without the necessary environment variable
+DEBUG set to "true". To create a new image based on the container with a
+correct DEBUG environment variable, run docker ps to find the container's ID
+and then run
+
+    # docker commit -c="ENV DEBUG true" 98bd7fc99854 debug-image
+
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and in
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 July 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+Oct 2014, updated by Daniel, Dao Quang Minh <daniel at nitrous dot io>

--- a/docs/man/docker-import.1.md
+++ b/docs/man/docker-import.1.md
@@ -6,7 +6,12 @@ docker-import - Create an empty filesystem image and import the contents of the 
 
 # SYNOPSIS
 **docker import**
+[**-c**|**--change**[= []**]]
 URL|- [REPOSITORY[:TAG]]
+
+# OPTIONS
+ -c ,  --change =[]
+   Apply a modification in Dockerfile format before importing the image.
 
 # DESCRIPTION
 Create a new filesystem image from the contents of a tarball (`.tar`,
@@ -36,6 +41,11 @@ Import to docker via pipe and stdin:
 ## Import from a local directory
 
     # tar -c . | docker import - exampleimagedir
+
+## Modify configuration settings before importing the image
+This example sets the docker image ENV variable DEBUG to true by default.
+
+    # tar -c . | docker import -c="ENV DEBUG true" - exampleimagedir
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -453,6 +453,7 @@ schema.
     Create a new image from a container's changes
 
       -a, --author=""     Author (e.g., "John Hannibal Smith <hannibal@a-team.com>")
+      -c, --change=[]     Apply a modification in Dockerfile format before committing the image
       -m, --message=""    Commit message
       -p, --pause=true    Pause container during commit
 
@@ -478,6 +479,19 @@ If this behavior is undesired, set the 'p' option to false.
     $ sudo docker images | head
     REPOSITORY                        TAG                 ID                  CREATED             VIRTUAL SIZE
     SvenDowideit/testimage            version3            f5283438590d        16 seconds ago      335.7 MB
+
+#### Commit an existing container with new configurations
+
+    $ sudo docker ps
+    ID                  IMAGE               COMMAND             CREATED             STATUS              PORTS
+    c3f279d17e0a        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours
+    197387f1b436        ubuntu:12.04        /bin/bash           7 days ago          Up 25 hours
+    $ sudo docker inspect -f "{{ .Config.Env }}" c3f279d17e0a
+    [HOME=/ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin]
+    $ sudo docker commit --change "ENV DEBUG true" c3f279d17e0a  SvenDowideit/testimage:version3
+    f5283438590d
+    $ sudo docker inspect -f "{{ .Config.Env }}" f5283438590d
+    [HOME=/ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin DEBUG=true]
 
 ## cp
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -803,6 +803,8 @@ NOTE: Docker will warn you if any containers exist that are using these untagged
 
     Create an empty filesystem image and import the contents of the tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then optionally tag it.
 
+      -c, --change=[]     Apply a modification in Dockerfile format before importing the image
+
 URLs must start with `http` and point to a single file archive (.tar,
 .tar.gz, .tgz, .bzip, .tar.xz, or .txz) containing a root filesystem. If
 you would like to import from a local directory or archive, you can use
@@ -825,6 +827,10 @@ Import to docker via pipe and `STDIN`.
 **Import from a local directory:**
 
     $ sudo tar -c . | sudo docker import - exampleimagedir
+
+**Import from a local directory with new configurations:**
+
+    $ sudo tar -c . | sudo docker import --change "ENV DEBUG true" - exampleimagedir
 
 Note the `sudo` in this example – you must preserve
 the ownership of the files (especially root ownership) during the

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -199,3 +199,36 @@ func TestCommitWithHostBindMount(t *testing.T) {
 
 	logDone("commit - commit bind mounted file")
 }
+
+func TestCommitChange(t *testing.T) {
+	defer deleteAllContainers()
+	cmd(t, "run", "--name", "test", "busybox", "true")
+
+	cmd := exec.Command(dockerBinary, "commit",
+		"--change", "EXPOSE 8080",
+		"--change", "ENV DEBUG true",
+		"test", "test-commit")
+	imageId, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(imageId, err)
+	}
+	imageId = strings.Trim(imageId, "\r\n")
+	defer deleteImages(imageId)
+
+	expected := map[string]string{
+		"Config.ExposedPorts": "map[8080/tcp:map[]]",
+		"Config.Env":          "[DEBUG=true PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin]",
+	}
+
+	for conf, value := range expected {
+		res, err := inspectField(imageId, conf)
+		if err != nil {
+			t.Errorf("failed to get value %s, error: %s", conf, err)
+		}
+		if res != value {
+			t.Errorf("%s('%s'), expected %s", conf, res, value)
+		}
+	}
+
+	logDone("commit - commit --change")
+}

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/server"
+	"github.com/docker/docker/builder"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
@@ -170,6 +171,8 @@ func TestGetContainersTop(t *testing.T) {
 
 func TestPostCommit(t *testing.T) {
 	eng := NewTestEngine(t)
+	b := &builder.BuilderJob{Engine: eng}
+	b.Install()
 	defer mkDaemonFromEngine(eng, t).Nuke()
 
 	// Create a container and remove a file

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/builder"
 	"github.com/docker/docker/engine"
 )
 
@@ -22,6 +23,8 @@ func TestCreateNumberHostname(t *testing.T) {
 
 func TestCommit(t *testing.T) {
 	eng := NewTestEngine(t)
+	b := &builder.BuilderJob{Engine: eng}
+	b.Install()
 	defer mkDaemonFromEngine(eng, t).Nuke()
 
 	config, _, _, err := parseRun([]string{unitTestImageID, "/bin/cat"}, nil)
@@ -42,6 +45,8 @@ func TestCommit(t *testing.T) {
 
 func TestMergeConfigOnCommit(t *testing.T) {
 	eng := NewTestEngine(t)
+	b := &builder.BuilderJob{Engine: eng}
+	b.Install()
 	runtime := mkDaemonFromEngine(eng, t)
 	defer runtime.Nuke()
 


### PR DESCRIPTION
```
pass --change changes to the import job

Docker-DCO-1.1-Signed-off-by: Dan Walsh <dwalsh@redhat.com> (github: rhatdan)
```

I have added a patch to  https://github.com/docker/docker/pull/8765

Which implements docker import --change.
