### PR TITLE
Mount /etc/localtime by default in containers

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -238,13 +238,14 @@ func (container *Container) setupMounts() error {
 	mounts := []execdriver.Mount{
 		{Source: container.ResolvConfPath, Destination: "/etc/resolv.conf", Writable: true, Private: true},
 	}
-
 	if container.HostnamePath != "" {
 		mounts = append(mounts, execdriver.Mount{Source: container.HostnamePath, Destination: "/etc/hostname", Writable: true, Private: true})
 	}
-
 	if container.HostsPath != "" {
 		mounts = append(mounts, execdriver.Mount{Source: container.HostsPath, Destination: "/etc/hosts", Writable: true, Private: true})
+	}
+	if container.LocaltimePath != "" {
+		mounts = append(mounts, execdriver.Mount{Source: container.LocaltimePath, Destination: "/etc/localtime", Writable: true, Private: true})
 	}
 
 	// Mount user specified volumes

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -241,6 +241,7 @@ func SetupInitLayer(initLayer string) error {
 		"/etc/hosts":       "file",
 		"/etc/hostname":    "file",
 		"/dev/console":     "file",
+		"/etc/localtime":   "file",
 		"/etc/mtab":        "/proc/mounts",
 	} {
 		parts := strings.Split(pth, "/")

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2568,3 +2568,19 @@ func TestRunUnknownCommand(t *testing.T) {
 
 	logDone("run - Unknown Command")
 }
+
+func TestLocaltimeContents(t *testing.T) {
+	defer deleteAllContainers()
+	hostsLocaltime, err := ioutil.ReadFile("/etc/localtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "--rm", "busybox", "cat", "/etc/localtime"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal([]byte(out), hostsLocaltime) {
+		t.Fatalf("hosts localtime %q does not match container's localtime %q", string(hostsLocaltime), out)
+	}
+	logDone("run - verify localtime contents")
+}


### PR DESCRIPTION
Right now docker does not handle anything around timezones for
containers.  There are a few ways to set the timezone in your container.
You can either use the env var `TZ` or use /etc/localtime.  By not
setting one or another then you can have a mismatch between either the
container and the host system or between two containers.

``` bash
# before change
root@development:~# date
Tue Nov 11 20:39:01 PST 2014
root@development:~# docker run --rm busybox date
Wed Nov 12 04:39:05 UTC 2014
```

This can cause issues for applications that deal with dates and times.
By mounting /etc/localtime in the container this ensures that the
container's timezones are consistent with the host machine and one
another.  The container still has the option to set the `TZ` env var to
override the settings within the /etc/localtime file.

``` bash
# after change
root@development:~# date
Tue Nov 11 21:26:31 PST 2014
root@development:~# docker run --rm busybox date
Tue Nov 11 21:26:35 PST 2014
```

Signed-off-by: Michael Crosby crosbymichael@gmail.com
