### PR TITLE
Update CONTRIBUTING to reflect new PR-docs process.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,10 +23,11 @@ reports to [security@docker.com](mailto:security@docker.com) instead.
 When considering a design proposal, we are looking for:
 
 * A description of the problem this design proposal solves
-* An issue -- not a pull request -- that describes what you will take action on
+* A pull request, not an issue, that modifies the documentation describing
+  the feature you are proposing, adding new documentation if necessary.
   * Please prefix your issue with `Proposal:` in the title
-* Please review [the existing Proposals](https://github.com/docker/docker/issues?direction=asc&labels=Proposal&page=1&sort=created&state=open)
-  before reporting a new issue. You can always pair with someone if you both
+* Please review [the existing Proposals](https://github.com/docker/docker/pulls?q=is%3Aopen+is%3Apr+label%3AProposal)
+  before reporting a new one. You can always pair with someone if you both
   have the same idea.
 
 When considering a cleanup task, we are looking for:


### PR DESCRIPTION
This updates the contributing process/docs to adjust it to reflect the new "docs first" PR process. No new proposals are being made here.

ping @shykes 
