### PR TITLE
Speed up build when using cache

### DIFF
--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -111,6 +111,7 @@ type Builder struct {
 	context     tarsum.TarSum // the context is a tarball that is uploaded by the client
 	contextPath string        // the path of the temporary directory the local context is unpacked to (server side)
 	noBaseImage bool          // indicates that this build does not start from any base image, but is being built from an empty file system.
+	imageCache  *ImageCache   // speed up probeCache
 }
 
 // Run the builder with the context. This is the lynchpin of this package. This

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -111,7 +111,7 @@ type Builder struct {
 	context     tarsum.TarSum // the context is a tarball that is uploaded by the client
 	contextPath string        // the path of the temporary directory the local context is unpacked to (server side)
 	noBaseImage bool          // indicates that this build does not start from any base image, but is being built from an empty file system.
-	imageCache  *ImageCache   // speed up probeCache
+	imageCache  *imageCache   // speed up probeCache
 }
 
 // Run the builder with the context. This is the lynchpin of this package. This

--- a/builder/image_cache.go
+++ b/builder/image_cache.go
@@ -27,11 +27,6 @@ func newImageCache(images map[string]*image.Image) *imageCache {
 	}
 }
 
-func (cache *imageCache) Dispose() {
-	cache.images = nil
-	cache.children = nil
-}
-
 func (cache *imageCache) Get(parentID string, config *runconfig.Config) (*image.Image, error) {
 	// Loop on the children of the given image and check the config
 	var match *image.Image

--- a/builder/image_cache.go
+++ b/builder/image_cache.go
@@ -1,0 +1,50 @@
+package builder
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/runconfig"
+)
+
+type ImageCache struct {
+	images   map[string]*image.Image
+	children map[string]map[string]struct{} // map[parentID][childID]
+}
+
+func newImageCache(images map[string]*image.Image) *ImageCache {
+	children := make(map[string]map[string]struct{})
+	for _, img := range images {
+		if _, exists := children[img.Parent]; !exists {
+			children[img.Parent] = make(map[string]struct{})
+		}
+		children[img.Parent][img.ID] = struct{}{}
+	}
+
+	return &ImageCache{
+		images:   images,
+		children: children,
+	}
+}
+
+func (cache *ImageCache) Dispose() {
+	cache.images = nil
+	cache.children = nil
+}
+
+func (cache *ImageCache) Get(parentID string, config *runconfig.Config) (*image.Image, error) {
+	// Loop on the children of the given image and check the config
+	var match *image.Image
+	for childID := range cache.children[parentID] {
+		child, exists := cache.images[childID]
+		if !exists {
+			return nil, fmt.Errorf("no such id: %s", childID)
+		}
+		if runconfig.Compare(&child.ContainerConfig, config) {
+			if match == nil || match.Created.Before(child.Created) {
+				match = child
+			}
+		}
+	}
+	return match, nil
+}

--- a/builder/image_cache.go
+++ b/builder/image_cache.go
@@ -7,12 +7,12 @@ import (
 	"github.com/docker/docker/runconfig"
 )
 
-type ImageCache struct {
+type imageCache struct {
 	images   map[string]*image.Image
 	children map[string]map[string]struct{} // map[parentID][childID]
 }
 
-func newImageCache(images map[string]*image.Image) *ImageCache {
+func newImageCache(images map[string]*image.Image) *imageCache {
 	children := make(map[string]map[string]struct{})
 	for _, img := range images {
 		if _, exists := children[img.Parent]; !exists {
@@ -21,18 +21,18 @@ func newImageCache(images map[string]*image.Image) *ImageCache {
 		children[img.Parent][img.ID] = struct{}{}
 	}
 
-	return &ImageCache{
+	return &imageCache{
 		images:   images,
 		children: children,
 	}
 }
 
-func (cache *ImageCache) Dispose() {
+func (cache *imageCache) Dispose() {
 	cache.images = nil
 	cache.children = nil
 }
 
-func (cache *ImageCache) Get(parentID string, config *runconfig.Config) (*image.Image, error) {
+func (cache *imageCache) Get(parentID string, config *runconfig.Config) (*image.Image, error) {
 	// Loop on the children of the given image and check the config
 	var match *image.Image
 	for childID := range cache.children[parentID] {

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -498,7 +498,7 @@ func (b *Builder) processImageFrom(img *imagepkg.Image) error {
 // is any error, it returns `(false, err)`.
 func (b *Builder) probeCache() (bool, error) {
 	if b.UtilizeCache {
-		if cache, err := b.Daemon.ImageGetCached(b.image, b.Config); err != nil {
+		if cache, err := b.imageCache.Get(b.image, b.Config); err != nil {
 			return false, err
 		} else if cache != nil {
 			fmt.Fprintf(b.OutStream, " ---> Using cache\n")

--- a/builder/job.go
+++ b/builder/job.go
@@ -98,7 +98,7 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 
 	sf := utils.NewStreamFormatter(job.GetenvBool("json"))
 
-	var imageCache *ImageCache
+	var imageCache *imageCache
 	if !noCache {
 		images, err := b.Daemon.Graph().Map()
 		if err != nil {

--- a/builder/job.go
+++ b/builder/job.go
@@ -98,6 +98,16 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 
 	sf := utils.NewStreamFormatter(job.GetenvBool("json"))
 
+	var imageCache *ImageCache
+	if !noCache {
+		images, err := b.Daemon.Graph().Map()
+		if err != nil {
+			return job.Error(err)
+		}
+		imageCache = newImageCache(images)
+		defer imageCache.Dispose()
+	}
+
 	builder := &Builder{
 		Daemon: b.Daemon,
 		Engine: b.Engine,
@@ -118,6 +128,7 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 		StreamFormatter: sf,
 		AuthConfig:      authConfig,
 		AuthConfigFile:  configFile,
+		imageCache:      imageCache,
 	}
 
 	id, err := builder.Run(context)

--- a/builder/job.go
+++ b/builder/job.go
@@ -105,7 +105,6 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 			return job.Error(err)
 		}
 		imageCache = newImageCache(images)
-		defer imageCache.Dispose()
 	}
 
 	builder := &Builder{

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1080,38 +1080,6 @@ func (daemon *Daemon) ContainerGraph() *graphdb.Database {
 	return daemon.containerGraph
 }
 
-func (daemon *Daemon) ImageGetCached(imgID string, config *runconfig.Config) (*image.Image, error) {
-	// Retrieve all images
-	images, err := daemon.Graph().Map()
-	if err != nil {
-		return nil, err
-	}
-
-	// Store the tree in a map of map (map[parentId][childId])
-	imageMap := make(map[string]map[string]struct{})
-	for _, img := range images {
-		if _, exists := imageMap[img.Parent]; !exists {
-			imageMap[img.Parent] = make(map[string]struct{})
-		}
-		imageMap[img.Parent][img.ID] = struct{}{}
-	}
-
-	// Loop on the children of the given image and check the config
-	var match *image.Image
-	for elem := range imageMap[imgID] {
-		img, ok := images[elem]
-		if !ok {
-			return nil, fmt.Errorf("unable to find image %q", elem)
-		}
-		if runconfig.Compare(&img.ContainerConfig, config) {
-			if match == nil || match.Created.Before(img.Created) {
-				match = img
-			}
-		}
-	}
-	return match, nil
-}
-
 func checkKernelAndArch() error {
 	// Check for unsupported architectures
 	if runtime.GOARCH != "amd64" {


### PR DESCRIPTION
Builder now calls Daemon.Graph().Map() once, instead of once per step.
