### PR TITLE
Secure localhost registry (carry of #8898)

### DIFF
--- a/registry/endpoint.go
+++ b/registry/endpoint.go
@@ -152,19 +152,25 @@ func (e Endpoint) Ping() (RegistryInfo, error) {
 // IsSecure returns false if the provided hostname is part of the list of insecure registries.
 // Insecure registries accept HTTP and/or accept HTTPS with certificates from unknown CAs.
 func IsSecure(hostname string, insecureRegistries []string) bool {
+
 	if hostname == IndexServerAddress() {
 		return true
 	}
+
+	host, _, err := net.SplitHostPort(hostname)
+
+	if err != nil {
+		host = hostname
+	}
+
+	if host == "127.0.0.1" || host == "localhost" {
+		return false
+	}
+
 	if len(insecureRegistries) == 0 {
-		host, _, err := net.SplitHostPort(hostname)
-		if err != nil {
-			host = hostname
-		}
-		if host == "127.0.0.1" || host == "localhost" {
-			return false
-		}
 		return true
 	}
+
 	for _, h := range insecureRegistries {
 		if hostname == h {
 			return false

--- a/registry/endpoint.go
+++ b/registry/endpoint.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -154,7 +155,16 @@ func IsSecure(hostname string, insecureRegistries []string) bool {
 	if hostname == IndexServerAddress() {
 		return true
 	}
-
+	if len(insecureRegistries) == 0 {
+		host, _, err := net.SplitHostPort(hostname)
+		if err != nil {
+			host = hostname
+		}
+		if host == "127.0.0.1" || host == "localhost" {
+			return false
+		}
+		return true
+	}
 	for _, h := range insecureRegistries {
 		if hostname == h {
 			return false

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -328,31 +328,19 @@ func TestIsSecure(t *testing.T) {
 	}{
 		{"example.com", []string{}, true},
 		{"example.com", []string{"example.com"}, false},
-		{"localhost", []string{"localhost:5000"}, true},
+		{"localhost", []string{"localhost:5000"}, false},
 		{"localhost:5000", []string{"localhost:5000"}, false},
-		{"localhost", []string{"example.com"}, true},
+		{"localhost", []string{"example.com"}, false},
 		{"127.0.0.1:5000", []string{"127.0.0.1:5000"}, false},
-	}
-	for _, tt := range tests {
-		if sec := IsSecure(tt.addr, tt.insecureRegistries); sec != tt.expected {
-			t.Errorf("IsSecure failed for %q %v, expected %v got %v", tt.addr, tt.insecureRegistries, tt.expected, sec)
-		}
-	}
-}
-
-func TestIsSecure(t *testing.T) {
-	tests := []struct {
-		addr               string
-		insecureRegistries []string
-		expected           bool
-	}{
 		{"localhost", []string{}, false},
 		{"localhost:5000", []string{}, false},
 		{"127.0.0.1", []string{}, false},
-		{"localhost", []string{"example.com"}, true},
-		{"127.0.0.1", []string{"example.com"}, true},
+		{"localhost", []string{"example.com"}, false},
+		{"127.0.0.1", []string{"example.com"}, false},
 		{"example.com", []string{}, true},
 		{"example.com", []string{"example.com"}, false},
+		{"127.0.0.1", []string{"example.com"}, false},
+		{"127.0.0.1:5000", []string{"example.com"}, false},
 	}
 	for _, tt := range tests {
 		if sec := IsSecure(tt.addr, tt.insecureRegistries); sec != tt.expected {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -339,3 +339,24 @@ func TestIsSecure(t *testing.T) {
 		}
 	}
 }
+
+func TestIsSecure(t *testing.T) {
+	tests := []struct {
+		addr               string
+		insecureRegistries []string
+		expected           bool
+	}{
+		{"localhost", []string{}, false},
+		{"localhost:5000", []string{}, false},
+		{"127.0.0.1", []string{}, false},
+		{"localhost", []string{"example.com"}, true},
+		{"127.0.0.1", []string{"example.com"}, true},
+		{"example.com", []string{}, true},
+		{"example.com", []string{"example.com"}, false},
+	}
+	for _, tt := range tests {
+		if sec := IsSecure(tt.addr, tt.insecureRegistries); sec != tt.expected {
+			t.Errorf("IsSecure failed for %q %v, expected %v got %v", tt.addr, tt.insecureRegistries, tt.expected, sec)
+		}
+	}
+}


### PR DESCRIPTION
This carries @proppy's localhost registry patch but makes one big modification: all 127.0.0.1 registries are always treated as insecure.

/cc @tiborvass 
