### PR TITLE
Proposal: Add hostname `docker info`

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -505,6 +505,12 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	if remoteInfo.Exists("MemTotal") {
 		fmt.Fprintf(cli.out, "Total Memory: %s\n", units.BytesSize(float64(remoteInfo.GetInt64("MemTotal"))))
 	}
+	if remoteInfo.Exists("Hostname") {
+		fmt.Fprintf(cli.out, "Hostname: %s\n", remoteInfo.Get("Hostname"))
+	}
+	if remoteInfo.Exists("ID") {
+		fmt.Fprintf(cli.out, "ID: %s\n", remoteInfo.Get("ID"))
+	}
 
 	if remoteInfo.GetBool("Debug") || os.Getenv("DEBUG") != "" {
 		if remoteInfo.Exists("Debug") {

--- a/api/common.go
+++ b/api/common.go
@@ -3,12 +3,15 @@ package api
 import (
 	"fmt"
 	"mime"
+	"os"
+	"path"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/version"
+	"github.com/docker/docker/vendor/src/github.com/docker/libtrust"
 )
 
 const (
@@ -46,4 +49,26 @@ func MatchesContentType(contentType, expectedType string) bool {
 		log.Errorf("Error parsing media type: %s error: %s", contentType, err.Error())
 	}
 	return err == nil && mimetype == expectedType
+}
+
+// LoadOrCreateTrustKey attempts to load the libtrust key at the given path,
+// otherwise generates a new one
+func LoadOrCreateTrustKey(trustKeyPath string) (libtrust.PrivateKey, error) {
+	err := os.MkdirAll(path.Dir(trustKeyPath), 0700)
+	if err != nil {
+		return nil, err
+	}
+	trustKey, err := libtrust.LoadKeyFile(trustKeyPath)
+	if err == libtrust.ErrKeyFileDoesNotExist {
+		trustKey, err = libtrust.GenerateECP256PrivateKey()
+		if err != nil {
+			return nil, fmt.Errorf("Error generating key: %s", err)
+		}
+		if err := libtrust.SaveKey(trustKeyPath, trustKey); err != nil {
+			return nil, fmt.Errorf("Error saving key file: %s", err)
+		}
+	} else if err != nil {
+		log.Fatalf("Error loading key file: %s", err)
+	}
+	return trustKey, nil
 }

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	DisableNetwork              bool
 	EnableSelinuxSupport        bool
 	Context                     map[string][]string
+	TrustKeyPath                string
 }
 
 // InstallFlags adds command-line options to the top-level flag parser for

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/libcontainer/label"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/daemon/execdriver/execdrivers"
 	"github.com/docker/docker/daemon/execdriver/lxc"
@@ -83,6 +84,7 @@ func (c *contStore) List() []*Container {
 }
 
 type Daemon struct {
+	ID             string
 	repository     string
 	sysInitPath    string
 	containers     *contStore
@@ -893,7 +895,13 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		return nil, err
 	}
 
+	trustKey, err := api.LoadOrCreateTrustKey(config.TrustKeyPath)
+	if err != nil {
+		return nil, err
+	}
+
 	daemon := &Daemon{
+		ID:             trustKey.PublicKey().KeyID(),
 		repository:     daemonRepo,
 		containers:     &contStore{s: make(map[string]*Container)},
 		execCommands:   newExecStore(),

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -56,6 +56,7 @@ func (daemon *Daemon) CmdInfo(job *engine.Job) engine.Status {
 		return job.Error(err)
 	}
 	v := &engine.Env{}
+	v.Set("ID", daemon.ID)
 	v.SetInt("Containers", len(daemon.List()))
 	v.SetInt("Images", imgcount)
 	v.Set("Driver", daemon.GraphDriver().String())
@@ -75,6 +76,9 @@ func (daemon *Daemon) CmdInfo(job *engine.Job) engine.Status {
 	v.Set("InitPath", initPath)
 	v.SetInt("NCPU", runtime.NumCPU())
 	v.SetInt64("MemTotal", meminfo.MemTotal)
+	if hostname, err := os.Hostname(); err == nil {
+		v.Set("Hostname", hostname)
+	}
 	if _, err := v.WriteTo(job.Stdout); err != nil {
 		return job.Error(err)
 	}

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -34,6 +34,8 @@ func mainDaemon() {
 	eng := engine.New()
 	signal.Trap(eng.Shutdown)
 
+	daemonCfg.TrustKeyPath = *flTrustKey
+
 	// Load builtins
 	if err := builtins.Register(eng); err != nil {
 		log.Fatal(err)

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -49,8 +49,9 @@ You can still call an old version of the API using
 `GET /info`
 
 **New!**
-`info` now returns the number of CPUs available on the machine (`NCPU`) and
-total memory available (`MemTotal`).
+`info` now returns the number of CPUs available on the machine (`NCPU`),
+total memory available (`MemTotal`), the short hostname (`Hostname`). and
+the ID (`ID`).
 
 `POST /containers/create`
 

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -1220,6 +1220,8 @@ Display system-wide information
              "KernelVersion":"3.12.0-1-amd64"
              "NCPU":1,
              "MemTotal":2099236864,
+             "Hostname":"prod-server-42",
+             "ID":"7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS"
              "Debug":false,
              "NFd": 11,
              "NGoroutines":21,

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -856,6 +856,8 @@ For example:
     Kernel Version: 3.13.0-24-generic
     Operating System: Ubuntu 14.04 LTS
     CPUs: 1
+    Hostname: prod-server-42
+    ID: 7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS
     Total Memory: 2 GiB
     Debug mode (server): false
     Debug mode (client): true


### PR DESCRIPTION
Small proposal :dancer: 

In the multi-machines setup, it could be nice to be able to identify each host.

We propose to add a `--hostname` flag to the daemon and `Hostname:` in `docker info`

By default we use the system's hostname
