### PR TITLE
Proposal: Container and Engine telemetry

### DIFF
--- a/docs/man/docker-metrics-1.md
+++ b/docs/man/docker-metrics-1.md
@@ -1,0 +1,39 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JANUARY 2015
+# NAME
+docker-metrics - Show Docker metrics
+
+# SYNOPSIS
+**docker metrics**
+[**-f**|**--follow**[=*SECONDS*]]
+
+
+# DESCRIPTION
+
+List the containers in the local repository. By default this show only
+the running containers.
+
+# OPTIONS
+**-f**, **--follow**="0"
+   Update metrics every specified seconds. 0 = disabled.
+
+# EXAMPLES
+# Show global Docker metrics.
+
+    # docker metrics
+    METRIC                                             VALUE
+    http_requests_total                             63251.00
+    http_request_duration_seconds/ping                  0.02
+    http_request_duration_seconds/getEvents             0.53
+    http_request_duration_seconds/getVersion            0.03
+    http_request_duration_seconds/getImagesJSON         0.23
+    http_request_duration_seconds/getImagesViz          0.25
+    http_request_duration_seconds/getImagesSearch       3.56
+    ...
+    http_request_duration_seconds/postContainersCreate  2.21
+    ...
+    http_request_duration_seconds/postContainersPause   0.58
+    http_request_duration_seconds/postContainersUnpause 0.69
+    ...
+

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -112,6 +112,7 @@ pages:
 - ['reference/api/registry_api_client_libraries.md', 'Reference', 'Docker Registry API Client Libraries']
 - ['reference/api/hub_registry_spec.md', 'Reference', 'Docker Hub and Registry Spec']
 - ['reference/api/docker_remote_api.md', 'Reference', 'Docker Remote API']
+- ['reference/api/docker_remote_api_v1.17.md', 'Reference', 'Docker Remote API v1.17']
 - ['reference/api/docker_remote_api_v1.16.md', 'Reference', 'Docker Remote API v1.16']
 - ['reference/api/docker_remote_api_v1.15.md', 'Reference', 'Docker Remote API v1.15']
 - ['reference/api/docker_remote_api_v1.14.md', 'Reference', 'Docker Remote API v1.14']

--- a/docs/sources/articles/runmetrics.md
+++ b/docs/sources/articles/runmetrics.md
@@ -1,438 +1,85 @@
-page_title: Runtime Metrics
+page_title: Docker Metrics
 page_description: Measure the behavior of running containers
 page_keywords: docker, metrics, CPU, memory, disk, IO, run, runtime
 
-# Runtime Metrics
-
-Linux Containers rely on [control groups](
-https://www.kernel.org/doc/Documentation/cgroups/cgroups.txt)
-which not only track groups of processes, but also expose metrics about
-CPU, memory, and block I/O usage. You can access those metrics and
-obtain network usage metrics as well. This is relevant for "pure" LXC
-containers, as well as for Docker containers.
-
-## Control Groups
-
-Control groups are exposed through a pseudo-filesystem. In recent
-distros, you should find this filesystem under `/sys/fs/cgroup`. Under
-that directory, you will see multiple sub-directories, called devices,
-freezer, blkio, etc.; each sub-directory actually corresponds to a different
-cgroup hierarchy.
-
-On older systems, the control groups might be mounted on `/cgroup`, without
-distinct hierarchies. In that case, instead of seeing the sub-directories,
-you will see a bunch of files in that directory, and possibly some directories
-corresponding to existing containers.
-
-To figure out where your control groups are mounted, you can run:
-
-    $ grep cgroup /proc/mounts
-
-## Enumerating Cgroups
-
-You can look into `/proc/cgroups` to see the different control group subsystems
-known to the system, the hierarchy they belong to, and how many groups they contain.
-
-You can also look at `/proc/<pid>/cgroup` to see which control groups a process
-belongs to. The control group will be shown as a path relative to the root of
-the hierarchy mountpoint; e.g., `/` means “this process has not been assigned into
-a particular group”, while `/lxc/pumpkin` means that the process is likely to be
-a member of a container named `pumpkin`.
-
-## Finding the Cgroup for a Given Container
-
-For each container, one cgroup will be created in each hierarchy. On
-older systems with older versions of the LXC userland tools, the name of
-the cgroup will be the name of the container. With more recent versions
-of the LXC tools, the cgroup will be `lxc/<container_name>.`
-
-For Docker containers using cgroups, the container name will be the full
-ID or long ID of the container. If a container shows up as ae836c95b4c3
-in `docker ps`, its long ID might be something like
-`ae836c95b4c3c9e9179e0e91015512da89fdec91612f63cebae57df9a5444c79`. You can
-look it up with `docker inspect` or `docker ps --no-trunc`.
-
-Putting everything together to look at the memory metrics for a Docker
-container, take a look at `/sys/fs/cgroup/memory/lxc/<longid>/`.
-
-## Metrics from Cgroups: Memory, CPU, Block IO
-
-For each subsystem (memory, CPU, and block I/O), you will find one or
-more pseudo-files containing statistics.
-
-### Memory Metrics: `memory.stat`
-
-Memory metrics are found in the "memory" cgroup. Note that the memory
-control group adds a little overhead, because it does very fine-grained
-accounting of the memory usage on your host. Therefore, many distros
-chose to not enable it by default. Generally, to enable it, all you have
-to do is to add some kernel command-line parameters:
-`cgroup_enable=memory swapaccount=1`.
-
-The metrics are in the pseudo-file `memory.stat`.
-Here is what it will look like:
-
-    cache 11492564992
-    rss 1930993664
-    mapped_file 306728960
-    pgpgin 406632648
-    pgpgout 403355412
-    swap 0
-    pgfault 728281223
-    pgmajfault 1724
-    inactive_anon 46608384
-    active_anon 1884520448
-    inactive_file 7003344896
-    active_file 4489052160
-    unevictable 32768
-    hierarchical_memory_limit 9223372036854775807
-    hierarchical_memsw_limit 9223372036854775807
-    total_cache 11492564992
-    total_rss 1930993664
-    total_mapped_file 306728960
-    total_pgpgin 406632648
-    total_pgpgout 403355412
-    total_swap 0
-    total_pgfault 728281223
-    total_pgmajfault 1724
-    total_inactive_anon 46608384
-    total_active_anon 1884520448
-    total_inactive_file 7003344896
-    total_active_file 4489052160
-    total_unevictable 32768
-
-The first half (without the `total_` prefix) contains statistics relevant
-to the processes within the cgroup, excluding sub-cgroups. The second half
-(with the `total_` prefix) includes sub-cgroups as well.
-
-Some metrics are "gauges", i.e. values that can increase or decrease
-(e.g., swap, the amount of swap space used by the members of the cgroup).
-Some others are "counters", i.e. values that can only go up, because
-they represent occurrences of a specific event (e.g., pgfault, which
-indicates the number of page faults which happened since the creation of
-the cgroup; this number can never decrease).
-
-
- - **cache:**  
-   the amount of memory used by the processes of this control group
-   that can be associated precisely with a block on a block device.
-   When you read from and write to files on disk, this amount will
-   increase. This will be the case if you use "conventional" I/O
-   (`open`, `read`,
-   `write` syscalls) as well as mapped files (with
-   `mmap`). It also accounts for the memory used by
-   `tmpfs` mounts, though the reasons are unclear.
-
- - **rss:**  
-   the amount of memory that *doesn't* correspond to anything on disk:
-   stacks, heaps, and anonymous memory maps.
-
- - **mapped_file:**  
-   indicates the amount of memory mapped by the processes in the
-   control group. It doesn't give you information about *how much*
-   memory is used; it rather tells you *how* it is used.
-
- - **pgfault and pgmajfault:**  
-   indicate the number of times that a process of the cgroup triggered
-   a "page fault" and a "major fault", respectively. A page fault
-   happens when a process accesses a part of its virtual memory space
-   which is nonexistent or protected. The former can happen if the
-   process is buggy and tries to access an invalid address (it will
-   then be sent a `SIGSEGV` signal, typically
-   killing it with the famous `Segmentation fault`
-   message). The latter can happen when the process reads from a memory
-   zone which has been swapped out, or which corresponds to a mapped
-   file: in that case, the kernel will load the page from disk, and let
-   the CPU complete the memory access. It can also happen when the
-   process writes to a copy-on-write memory zone: likewise, the kernel
-   will preempt the process, duplicate the memory page, and resume the
-   write operation on the process` own copy of the page. "Major" faults
-   happen when the kernel actually has to read the data from disk. When
-   it just has to duplicate an existing page, or allocate an empty
-   page, it's a regular (or "minor") fault.
-
- - **swap:**  
-   the amount of swap currently used by the processes in this cgroup.
-
- - **active_anon and inactive_anon:**  
-   the amount of *anonymous* memory that has been identified has
-   respectively *active* and *inactive* by the kernel. "Anonymous"
-   memory is the memory that is *not* linked to disk pages. In other
-   words, that's the equivalent of the rss counter described above. In
-   fact, the very definition of the rss counter is **active_anon** +
-   **inactive_anon** - **tmpfs** (where tmpfs is the amount of memory
-   used up by `tmpfs` filesystems mounted by this
-   control group). Now, what's the difference between "active" and
-   "inactive"? Pages are initially "active"; and at regular intervals,
-   the kernel sweeps over the memory, and tags some pages as
-   "inactive". Whenever they are accessed again, they are immediately
-   retagged "active". When the kernel is almost out of memory, and time
-   comes to swap out to disk, the kernel will swap "inactive" pages.
-
- - **active_file and inactive_file:**  
-   cache memory, with *active* and *inactive* similar to the *anon*
-   memory above. The exact formula is cache = **active_file** +
-   **inactive_file** + **tmpfs**. The exact rules used by the kernel
-   to move memory pages between active and inactive sets are different
-   from the ones used for anonymous memory, but the general principle
-   is the same. Note that when the kernel needs to reclaim memory, it
-   is cheaper to reclaim a clean (=non modified) page from this pool,
-   since it can be reclaimed immediately (while anonymous pages and
-   dirty/modified pages have to be written to disk first).
-
- - **unevictable:**  
-   the amount of memory that cannot be reclaimed; generally, it will
-   account for memory that has been "locked" with `mlock`.
-   It is often used by crypto frameworks to make sure that
-   secret keys and other sensitive material never gets swapped out to
-   disk.
-
- - **memory and memsw limits:**  
-   These are not really metrics, but a reminder of the limits applied
-   to this cgroup. The first one indicates the maximum amount of
-   physical memory that can be used by the processes of this control
-   group; the second one indicates the maximum amount of RAM+swap.
-
-Accounting for memory in the page cache is very complex. If two
-processes in different control groups both read the same file
-(ultimately relying on the same blocks on disk), the corresponding
-memory charge will be split between the control groups. It's nice, but
-it also means that when a cgroup is terminated, it could increase the
-memory usage of another cgroup, because they are not splitting the cost
-anymore for those memory pages.
-
-### CPU metrics: `cpuacct.stat`
-
-Now that we've covered memory metrics, everything else will look very
-simple in comparison. CPU metrics will be found in the
-`cpuacct` controller.
-
-For each container, you will find a pseudo-file `cpuacct.stat`,
-containing the CPU usage accumulated by the processes of the container,
-broken down between `user` and `system` time. If you're not familiar
-with the distinction, `user` is the time during which the processes were
-in direct control of the CPU (i.e. executing process code), and `system`
-is the time during which the CPU was executing system calls on behalf of
-those processes.
-
-Those times are expressed in ticks of 1/100th of a second. Actually,
-they are expressed in "user jiffies". There are `USER_HZ`
-*"jiffies"* per second, and on x86 systems,
-`USER_HZ` is 100. This used to map exactly to the
-number of scheduler "ticks" per second; but with the advent of higher
-frequency scheduling, as well as [tickless kernels](
-http://lwn.net/Articles/549580/), the number of kernel ticks
-wasn't relevant anymore. It stuck around anyway, mainly for legacy and
-compatibility reasons.
-
-### Block I/O metrics
-
-Block I/O is accounted in the `blkio` controller.
-Different metrics are scattered across different files. While you can
-find in-depth details in the [blkio-controller](
-https://www.kernel.org/doc/Documentation/cgroups/blkio-controller.txt)
-file in the kernel documentation, here is a short list of the most
-relevant ones:
-
-
- - **blkio.sectors:**  
-   contain the number of 512-bytes sectors read and written by the
-   processes member of the cgroup, device by device. Reads and writes
-   are merged in a single counter.
-
- - **blkio.io_service_bytes:**  
-   indicates the number of bytes read and written by the cgroup. It has
-   4 counters per device, because for each device, it differentiates
-   between synchronous vs. asynchronous I/O, and reads vs. writes.
-
- - **blkio.io_serviced:**  
-   the number of I/O operations performed, regardless of their size. It
-   also has 4 counters per device.
-
- - **blkio.io_queued:**  
-   indicates the number of I/O operations currently queued for this
-   cgroup. In other words, if the cgroup isn't doing any I/O, this will
-   be zero. Note that the opposite is not true. In other words, if
-   there is no I/O queued, it does not mean that the cgroup is idle
-   (I/O-wise). It could be doing purely synchronous reads on an
-   otherwise quiescent device, which is therefore able to handle them
-   immediately, without queuing. Also, while it is helpful to figure
-   out which cgroup is putting stress on the I/O subsystem, keep in
-   mind that is is a relative quantity. Even if a process group does
-   not perform more I/O, its queue size can increase just because the
-   device load increases because of other devices.
-
-## Network Metrics
-
-Network metrics are not exposed directly by control groups. There is a
-good explanation for that: network interfaces exist within the context
-of *network namespaces*. The kernel could probably accumulate metrics
-about packets and bytes sent and received by a group of processes, but
-those metrics wouldn't be very useful. You want per-interface metrics
-(because traffic happening on the local `lo`
-interface doesn't really count). But since processes in a single cgroup
-can belong to multiple network namespaces, those metrics would be harder
-to interpret: multiple network namespaces means multiple `lo`
-interfaces, potentially multiple `eth0`
-interfaces, etc.; so this is why there is no easy way to gather network
-metrics with control groups.
-
-Instead we can gather network metrics from other sources:
-
-### IPtables
-
-IPtables (or rather, the netfilter framework for which iptables is just
-an interface) can do some serious accounting.
-
-For instance, you can setup a rule to account for the outbound HTTP
-traffic on a web server:
-
-    $ iptables -I OUTPUT -p tcp --sport 80
-
-There is no `-j` or `-g` flag,
-so the rule will just count matched packets and go to the following
-rule.
-
-Later, you can check the values of the counters, with:
-
-    $ iptables -nxvL OUTPUT
-
-Technically, `-n` is not required, but it will
-prevent iptables from doing DNS reverse lookups, which are probably
-useless in this scenario.
-
-Counters include packets and bytes. If you want to setup metrics for
-container traffic like this, you could execute a `for`
-loop to add two `iptables` rules per
-container IP address (one in each direction), in the `FORWARD`
-chain. This will only meter traffic going through the NAT
-layer; you will also have to add traffic going through the userland
-proxy.
-
-Then, you will need to check those counters on a regular basis. If you
-happen to use `collectd`, there is a [nice plugin](https://collectd.org/wiki/index.php/Plugin:IPTables)
-to automate iptables counters collection.
-
-### Interface-level counters
-
-Since each container has a virtual Ethernet interface, you might want to
-check directly the TX and RX counters of this interface. You will notice
-that each container is associated to a virtual Ethernet interface in
-your host, with a name like `vethKk8Zqi`. Figuring
-out which interface corresponds to which container is, unfortunately,
-difficult.
-
-But for now, the best way is to check the metrics *from within the
-containers*. To accomplish this, you can run an executable from the host
-environment within the network namespace of a container using **ip-netns
-magic**.
-
-The `ip-netns exec` command will let you execute any
-program (present in the host system) within any network namespace
-visible to the current process. This means that your host will be able
-to enter the network namespace of your containers, but your containers
-won't be able to access the host, nor their sibling containers.
-Containers will be able to “see” and affect their sub-containers,
-though.
-
-The exact format of the command is:
-
-    $ ip netns exec <nsname> <command...>
-
-For example:
-
-    $ ip netns exec mycontainer netstat -i
-
-`ip netns` finds the "mycontainer" container by
-using namespaces pseudo-files. Each process belongs to one network
-namespace, one PID namespace, one `mnt` namespace,
-etc., and those namespaces are materialized under
-`/proc/<pid>/ns/`. For example, the network
-namespace of PID 42 is materialized by the pseudo-file
-`/proc/42/ns/net`.
-
-When you run `ip netns exec mycontainer ...`, it
-expects `/var/run/netns/mycontainer` to be one of
-those pseudo-files. (Symlinks are accepted.)
-
-In other words, to execute a command within the network namespace of a
-container, we need to:
-
-- Find out the PID of any process within the container that we want to investigate;
-- Create a symlink from `/var/run/netns/<somename>` to `/proc/<thepid>/ns/net`
-- Execute `ip netns exec <somename> ....`
-
-Please review [*Enumerating Cgroups*](#enumerating-cgroups) to learn how to find
-the cgroup of a process running in the container of which you want to
-measure network usage. From there, you can examine the pseudo-file named
-`tasks`, which contains the PIDs that are in the
-control group (i.e. in the container). Pick any one of them.
-
-Putting everything together, if the "short ID" of a container is held in
-the environment variable `$CID`, then you can do this:
-
-    $ TASKS=/sys/fs/cgroup/devices/$CID*/tasks
-    $ PID=$(head -n 1 $TASKS)
-    $ mkdir -p /var/run/netns
-    $ ln -sf /proc/$PID/ns/net /var/run/netns/$CID
-    $ ip netns exec $CID netstat -i
-
-## Tips for high-performance metric collection
-
-Note that running a new process each time you want to update metrics is
-(relatively) expensive. If you want to collect metrics at high
-resolutions, and/or over a large number of containers (think 1000
-containers on a single host), you do not want to fork a new process each
-time.
-
-Here is how to collect metrics from a single process. You will have to
-write your metric collector in C (or any language that lets you do
-low-level system calls). You need to use a special system call,
-`setns()`, which lets the current process enter any
-arbitrary namespace. It requires, however, an open file descriptor to
-the namespace pseudo-file (remember: that's the pseudo-file in
-`/proc/<pid>/ns/net`).
-
-However, there is a catch: you must not keep this file descriptor open.
-If you do, when the last process of the control group exits, the
-namespace will not be destroyed, and its network resources (like the
-virtual interface of the container) will stay around for ever (or until
-you close that file descriptor).
-
-The right approach would be to keep track of the first PID of each
-container, and re-open the namespace pseudo-file each time.
-
-## Collecting metrics when a container exits
-
-Sometimes, you do not care about real time metric collection, but when a
-container exits, you want to know how much CPU, memory, etc. it has
-used.
-
-Docker makes this difficult because it relies on `lxc-start`, which
-carefully cleans up after itself, but it is still possible. It is
-usually easier to collect metrics at regular intervals (e.g., every
-minute, with the collectd LXC plugin) and rely on that instead.
-
-But, if you'd still like to gather the stats when a container stops,
-here is how:
-
-For each container, start a collection process, and move it to the
-control groups that you want to monitor by writing its PID to the tasks
-file of the cgroup. The collection process should periodically re-read
-the tasks file to check if it's the last process of the control group.
-(If you also want to collect network statistics as explained in the
-previous section, you should also move the process to the appropriate
-network namespace.)
-
-When the container exits, `lxc-start` will try to
-delete the control groups. It will fail, since the control group is
-still in use; but that's fine. You process should now detect that it is
-the only one remaining in the group. Now is the right time to collect
-all the metrics you need!
-
-Finally, your process should move itself back to the root control group,
-and remove the container control group. To remove a control group, just
-`rmdir` its directory. It's counter-intuitive to
-`rmdir` a directory as it still contains files; but
-remember that this is a pseudo-filesystem, so usual rules don't apply.
-After the cleanup is done, the collection process can exit safely.
+# Metrics
+
+Docker provides various metrics both about the containers it manages
+as well as about its internal state and health.
+
+You can access the most imporant metrics via the `docker metrics`
+command.
+
+To integrate all metrics into your existing monitoring system, you can
+use the Docker API. The `/metrics` endpoint exposes all available
+metrics for bulk import into existing monitoring infrastructure.
+
+All metric endpoints return a list of metrics in the following format:
+
+    {
+      "type": "COUNTER",
+      "help": "Total seconds of cpu time consumed.",
+      "name": "cpu_usage_seconds_total",
+      "metrics": [
+        {
+          "value": 53.21,
+          "labels": {
+            "space": "kernel"
+          }
+        },
+        {
+          "value": 2778.09,
+          "labels": {
+            "space": "user"
+          }
+        }
+      ]
+    }
+
+As you see, this metric has a set of labels as keys. Those labels may
+refer to things like sub system, in this case whether the cpu time is
+spent in user- or kernel space.
+
+In the global `/metrics` endpoint, the labels are used to specify the
+container a metric is about.
+
+## CGroup Metrics
+
+The following metrics are available for each container, running or not,
+and for the host system itself.
+
+- cpu_usage_seconds_total: Total seconds of cpu time. Labels: space =
+  kernel|user. *Counter*
+- cpu_throttling_periods_total: Total number of periods, as defined by
+  cpu.cfs_period_us, with throttling enabled. *Counter*
+- cpu_throttling_throttled_periods_total: Total number of periods with
+  throttling enabled. *Counter*
+- cpu_throttled_time_seconds_total: Total time the container was
+  throttled for in seconds. *Counter*
+- memory_usage_bytes: Current memory usage in bytes. *Gauge*
+- memory_max_usage_bytes: Maximum memory usage ever recorded for
+  container in bytes. *Gauge*
+- memory_failures_total: Total number of times the container hit its
+  memory limit. *Counter*
+- memory_stats_*: Various metrics from group/memory/memory.stat. See 
+  [cgroup documentation](https://www.kernel.org/doc/Documentation/cgroups/memory.txt),
+  section 5.2 for more details. *Counter*s and *Gauge*s
+- blkio_io_service_bytes_total: Number
+  of bytes transferred by `operation` from/to `device`. Labels: device,
+  operation. *Counter*
+- blkio_io_serviced_total: Number of `operation`s from/to `device`.
+  Labels: device, operation. *Counter*
+- blkio_io_queued: Number of`operation`s currently queued up. Labels:
+  device, operation. *Gauge*
+- blkio_sectors_total: Number of sectors transferred by `operation`
+  to/from `device. Labels: device, operation. *Counter*
+
+
+## Global Docker Metrics
+
+- http_requests_total: Total number of HTTP requests to the API. Labels: method, path. *Counter*
+- http_request_duration_seconds: HTTP request latencies for API handlers in seconds. Labels: method, path. *Gauge*
+- jobs_created_total: Total number of Docker internal jobs created. Labels: name. *Counter*
+- jobs_ran_total: Total number of Docker internal jobs ran. Labels: name. *Counter*
+- jobs_run_failed_total: Total number of Docker internal jobs failed during run. Labels: name. *Counter*
+- jobs_run_duration_ms: Job run latency. Labels: name. *Counter*

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -30,13 +30,36 @@ page_keywords: API, Docker, rcli, REST, documentation
    Client applications need to take this into account to ensure
    they will not break when talking to newer Docker daemons.
 
-The current version of the API is v1.16
+The current version of the API is v1.17
 
 Calling `/info` is the same as calling
-`/v1.16/info`.
+`/v1.17/info`.
 
 You can still call an old version of the API using
-`/v1.15/info`.
+`/v1.16/info`.
+
+## v1.17
+
+### Full Documentation
+
+[*Docker Remote API v1.17*](/reference/api/docker_remote_api_v1.17/)
+
+### What's new
+
+`GET /containers/(id)/metrics`
+
+**New!***
+This endpoint returns metrics about the given container.
+
+`GET /info/metrics`
+
+**New!***
+This endpoint returns side-wide metrics including white box telemetry about docker.
+
+`GET /metrics`
+
+**New!***
+This endpoint combines all other metric endpoints and returns all available metrics.
 
 ## v1.16
 

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -1,0 +1,1859 @@
+page_title: Remote API v1.17
+page_description: API Documentation for Docker
+page_keywords: API, Docker, rcli, REST, documentation
+
+# Docker Remote API v1.17
+
+## 1. Brief introduction
+
+ - The Remote API has replaced `rcli`.
+ - The daemon listens on `unix:///var/run/docker.sock` but you can
+   [Bind Docker to another host/port or a Unix socket](
+   /articles/basics/#bind-docker-to-another-hostport-or-a-unix-socket).
+ - The API tends to be REST, but for some complex commands, like `attach`
+   or `pull`, the HTTP connection is hijacked to transport `STDOUT`,
+   `STDIN` and `STDERR`.
+
+# 2. Endpoints
+
+## 2.1 Containers
+
+### List containers
+
+`GET /containers/json`
+
+List containers
+
+**Example request**:
+
+        GET /containers/json?all=1&before=8dfafdbc3a40&size=1 HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+             {
+                     "Id": "8dfafdbc3a40",
+                     "Image": "base:latest",
+                     "Command": "echo 1",
+                     "Created": 1367854155,
+                     "Status": "Exit 0",
+                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw":12288,
+                     "SizeRootFs":0
+             },
+             {
+                     "Id": "9cd87474be90",
+                     "Image": "base:latest",
+                     "Command": "echo 222222",
+                     "Created": 1367854155,
+                     "Status": "Exit 0",
+                     "Ports":[],
+                     "SizeRw":12288,
+                     "SizeRootFs":0
+             },
+             {
+                     "Id": "3176a2479c92",
+                     "Image": "base:latest",
+                     "Command": "echo 3333333333333333",
+                     "Created": 1367854154,
+                     "Status": "Exit 0",
+                     "Ports":[],
+                     "SizeRw":12288,
+                     "SizeRootFs":0
+             },
+             {
+                     "Id": "4cb07b47f9fb",
+                     "Image": "base:latest",
+                     "Command": "echo 444444444444444444444444444444444",
+                     "Created": 1367854152,
+                     "Status": "Exit 0",
+                     "Ports":[],
+                     "SizeRw":12288,
+                     "SizeRootFs":0
+             }
+        ]
+
+Query Parameters:
+
+-   **all** – 1/True/true or 0/False/false, Show all containers.
+        Only running containers are shown by default (i.e., this defaults to false)
+-   **limit** – Show `limit` last created
+        containers, include non-running ones.
+-   **since** – Show only containers created since Id, include
+        non-running ones.
+-   **before** – Show only containers created before Id, include
+        non-running ones.
+-   **size** – 1/True/true or 0/False/false, Show the containers
+        sizes
+
+Status Codes:
+
+-   **200** – no error
+-   **400** – bad parameter
+-   **500** – server error
+
+### Create a container
+
+`POST /containers/create`
+
+Create a container
+
+**Example request**:
+
+        POST /containers/create HTTP/1.1
+        Content-Type: application/json
+
+        {
+             "Hostname":"",
+             "Domainname": "",
+             "User":"",
+             "Memory":0,
+             "MemorySwap":0,
+             "CpuShares": 512,
+             "Cpuset": "0,1",
+             "AttachStdin":false,
+             "AttachStdout":true,
+             "AttachStderr":true,
+             "Tty":false,
+             "OpenStdin":false,
+             "StdinOnce":false,
+             "Env":null,
+             "Cmd":[
+                     "date"
+             ],
+             "Entrypoint": "",
+             "Image":"base",
+             "Volumes":{
+                     "/tmp": {}
+             },
+             "WorkingDir":"",
+             "NetworkDisabled": false,
+             "MacAddress":"12:34:56:78:9a:bc",
+             "ExposedPorts":{
+                     "22/tcp": {}
+             },
+             "SecurityOpts": [""],
+             "HostConfig": {
+               "Binds":["/tmp:/tmp"],
+               "Links":["redis3:redis"],
+               "LxcConf":{"lxc.utsname":"docker"},
+               "PortBindings":{ "22/tcp": [{ "HostPort": "11022" }] },
+               "PublishAllPorts":false,
+               "Privileged":false,
+               "Dns": ["8.8.8.8"],
+               "DnsSearch": [""],
+               "VolumesFrom": ["parent", "other:ro"],
+               "CapAdd": ["NET_ADMIN"],
+               "CapDrop": ["MKNOD"],
+               "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
+               "NetworkMode": "bridge",
+               "Devices": []
+            }
+        }
+
+**Example response**:
+
+        HTTP/1.1 201 Created
+        Content-Type: application/json
+
+        {
+             "Id":"e90e34656806"
+             "Warnings":[]
+        }
+
+Json Parameters:
+
+-   **Hostname** - A string value containing the desired hostname to use for the
+      container.
+-   **Domainname** - A string value containing the desired domain name to use
+      for the container.
+-   **User** - A string value containg the user to use inside the container.
+-   **Memory** - Memory limit in bytes.
+-   **MemorySwap**- Total memory usage (memory + swap); set `-1` to disable swap.
+-   **CpuShares** - An integer value containing the CPU Shares for container
+      (ie. the relative weight vs othercontainers).
+    **CpuSet** - String value containg the cgroups Cpuset to use.
+-   **AttachStdin** - Boolean value, attaches to stdin.
+-   **AttachStdout** - Boolean value, attaches to stdout.
+-   **AttachStderr** - Boolean value, attaches to stderr.
+-   **Tty** - Boolean value, Attach standard streams to a tty, including stdin if it is not closed.
+-   **OpenStdin** - Boolean value, opens stdin,
+-   **StdinOnce** - Boolean value, close stdin after the 1 attached client disconnects.
+-   **Env** - A list of environment variables in the form of `VAR=value`
+-   **Cmd** - Command to run specified as a string or an array of strings.
+-   **Entrypoint** - Set the entrypoint for the container a a string or an array
+      of strings
+-   **Image** - String value containing the image name to use for the container
+-   **Volumes** – An object mapping mountpoint paths (strings) inside the
+        container to empty objects.
+-   **WorkingDir** - A string value containing the working dir for commands to
+      run in.
+-   **NetworkDisabled** - Boolean value, when true disables neworking for the
+      container
+-   **ExposedPorts** - An object mapping ports to an empty object in the form of:
+      `"ExposedPorts": { "<port>/<tcp|udp>: {}" }`
+-   **SecurityOpts**: A list of string values to customize labels for MLS
+      systems, such as SELinux.
+-   **HostConfig**
+  -   **Binds** – A list of volume bindings for this container.  Each volume
+          binding is a string of the form `container_path` (to create a new
+          volume for the container), `host_path:container_path` (to bind-mount
+          a host path into the container), or `host_path:container_path:ro`
+          (to make the bind-mount read-only inside the container).
+  -   **Links** - A list of links for the container.  Each link entry should be of
+        of the form "container_name:alias".
+  -   **LxcConf** - LXC specific configurations.  These configurations will only
+        work when using the `lxc` execution driver.
+  -   **PortBindings** - A map of exposed container ports and the host port they
+        should map to. It should be specified in the form
+        `{ <port>/<protocol>: [{ "HostPort": "<port>" }] }`
+        Take note that `port` is specified as a string and not an integer value.
+  -   **PublishAllPorts** - Allocates a random host port for all of a container's
+        exposed ports. Specified as a boolean value.
+  -   **Privileged** - Gives the container full access to the host.  Specified as
+        a boolean value.
+  -   **Dns** - A list of dns servers for the container to use.
+  -   **DnsSearch** - A list of DNS search domains
+  -   **VolumesFrom** - A list of volumes to inherit from another container.
+        Specified in the form `<container name>[:<ro|rw>]`
+  -   **CapAdd** - A list of kernel capabilties to add to the container.
+  -   **Capdrop** - A list of kernel capabilties to drop from the container.
+  -   **RestartPolicy** – The behavior to apply when the container exits.  The
+          value is an object with a `Name` property of either `"always"` to
+          always restart or `"on-failure"` to restart only when the container
+          exit code is non-zero.  If `on-failure` is used, `MaximumRetryCount`
+          controls the number of times to retry before giving up.
+          The default is not to restart. (optional)
+  -   **NetworkMode** - Sets the networking mode for the container. Supported
+        values are: `bridge`, `host`, and `container:<name|id>`
+  -   **Devices** - A list of devices to add to the container specified in the
+        form
+        `{ "PathOnHost": "/dev/deviceName", "PathInContainer": "/dev/deviceName", "CgroupPermissions": "mrw"}`
+
+Query Parameters:
+
+-   **name** – Assign the specified name to the container. Must
+    match `/?[a-zA-Z0-9_-]+`.
+
+Status Codes:
+
+-   **201** – no error
+-   **404** – no such container
+-   **406** – impossible to attach (container not running)
+-   **500** – server error
+
+### Inspect a container
+
+`GET /containers/(id)/json`
+
+Return low-level information on the container `id`
+
+
+**Example request**:
+
+        GET /containers/4fa6e0f0c678/json HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+                     "Id": "4fa6e0f0c6786287e131c3852c58a2e01cc697a68231826813597e4994f1d6e2",
+                     "Created": "2013-05-07T14:51:42.041847+02:00",
+                     "Path": "date",
+                     "Args": [],
+                     "Config": {
+                             "Hostname": "4fa6e0f0c678",
+                             "User": "",
+                             "Memory": 0,
+                             "MemorySwap": 0,
+                             "AttachStdin": false,
+                             "AttachStdout": true,
+                             "AttachStderr": true,
+                             "PortSpecs": null,
+                             "Tty": false,
+                             "OpenStdin": false,
+                             "StdinOnce": false,
+                             "Env": null,
+                             "Cmd": [
+                                     "date"
+                             ],
+                             "Dns": null,
+                             "Image": "base",
+                             "Volumes": {},
+                             "VolumesFrom": "",
+                             "WorkingDir":""
+
+                     },
+                     "State": {
+                             "Running": false,
+                             "Pid": 0,
+                             "ExitCode": 0,
+                             "StartedAt": "2013-05-07T14:51:42.087658+02:01360",
+                             "Ghost": false
+                     },
+                     "Image": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+                     "NetworkSettings": {
+                             "IpAddress": "",
+                             "IpPrefixLen": 0,
+                             "Gateway": "",
+                             "Bridge": "",
+                             "PortMapping": null
+                     },
+                     "SysInitPath": "/home/kitty/go/src/github.com/docker/docker/bin/docker",
+                     "ResolvConfPath": "/etc/resolv.conf",
+                     "Volumes": {},
+                     "HostConfig": {
+                         "Binds": null,
+                         "ContainerIDFile": "",
+                         "LxcConf": [],
+                         "Privileged": false,
+                         "PortBindings": {
+                            "80/tcp": [
+                                {
+                                    "HostIp": "0.0.0.0",
+                                    "HostPort": "49153"
+                                }
+                            ]
+                         },
+                         "Links": ["/name:alias"],
+                         "PublishAllPorts": false,
+                         "CapAdd: ["NET_ADMIN"],
+                         "CapDrop: ["MKNOD"]
+                     }
+        }
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### List processes running inside a container
+
+`GET /containers/(id)/top`
+
+List processes running inside the container `id`
+
+**Example request**:
+
+        GET /containers/4fa6e0f0c678/top HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+             "Titles":[
+                     "USER",
+                     "PID",
+                     "%CPU",
+                     "%MEM",
+                     "VSZ",
+                     "RSS",
+                     "TTY",
+                     "STAT",
+                     "START",
+                     "TIME",
+                     "COMMAND"
+                     ],
+             "Processes":[
+                     ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
+                     ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
+             ]
+        }
+
+Query Parameters:
+
+-   **ps_args** – ps arguments to use (e.g., aux)
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### Get container logs
+
+`GET /containers/(id)/logs`
+
+Get stdout and stderr logs from the container ``id``
+
+**Example request**:
+
+       GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10 HTTP/1.1
+
+**Example response**:
+
+       HTTP/1.1 200 OK
+       Content-Type: application/vnd.docker.raw-stream
+
+       {{ STREAM }}
+
+Query Parameters:
+
+-   **follow** – 1/True/true or 0/False/false, return stream. Default false
+-   **stdout** – 1/True/true or 0/False/false, show stdout log. Default false
+-   **stderr** – 1/True/true or 0/False/false, show stderr log. Default false
+-   **timestamps** – 1/True/true or 0/False/false, print timestamps for
+        every log line. Default false
+-   **tail** – Output specified number of lines at the end of logs: `all` or `<number>`. Default all
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### Inspect changes on a container's filesystem
+
+`GET /containers/(id)/changes`
+
+Inspect changes on container `id`'s filesystem
+
+**Example request**:
+
+        GET /containers/4fa6e0f0c678/changes HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+             {
+                     "Path":"/dev",
+                     "Kind":0
+             },
+             {
+                     "Path":"/dev/kmsg",
+                     "Kind":1
+             },
+             {
+                     "Path":"/test",
+                     "Kind":1
+             }
+        ]
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### Export a container
+
+`GET /containers/(id)/export`
+
+Export the contents of container `id`
+
+**Example request**:
+
+        GET /containers/4fa6e0f0c678/export HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/octet-stream
+
+        {{ TAR STREAM }}
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### Return metrics about container
+
+`GET /containers/(id)/metrics`
+
+Return metrics about container `id`. Since those metrics are specific
+to the given container, each metric has a single value.
+
+**Example request**:
+
+        GET /containers/4fa6e0f0c678/metrics HTTP/1.1
+        Content-Type: application/json
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+          {
+            "type": "COUNTER",
+            "help": "Total seconds of cpu time consumed.",
+            "name": "cpu_usage_seconds_total",
+            "metrics": [
+              {
+                "value": 53.21,
+                "labels": {
+                  "space": "kernel"
+                }
+              },
+              {
+                "value": 2778.09,
+                "labels": {
+                  "space": "user"
+                }
+              }
+            ]
+          }
+        ]
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### Resize a container TTY
+
+`GET /containers/(id)/resize?h=<height>&w=<width>`
+
+Resize the TTY of container `id`
+
+**Example request**:
+
+        GET /containers/4fa6e0f0c678/resize?h=40&w=80 HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Length: 0
+        Content-Type: text/plain; charset=utf-8
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – No such container
+-   **500** – bad file descriptor
+
+### Start a container
+
+`POST /containers/(id)/start`
+
+Start the container `id`
+
+**Example request**:
+
+        POST /containers/(id)/start HTTP/1.1
+        Content-Type: application/json
+
+**Example response**:
+
+        HTTP/1.1 204 No Content
+
+Json Parameters:
+
+Status Codes:
+
+-   **204** – no error
+-   **304** – container already started
+-   **404** – no such container
+-   **500** – server error
+
+### Stop a container
+
+`POST /containers/(id)/stop`
+
+Stop the container `id`
+
+**Example request**:
+
+        POST /containers/e90e34656806/stop?t=5 HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 204 No Content
+
+Query Parameters:
+
+-   **t** – number of seconds to wait before killing the container
+
+Status Codes:
+
+-   **204** – no error
+-   **304** – container already stopped
+-   **404** – no such container
+-   **500** – server error
+
+### Restart a container
+
+`POST /containers/(id)/restart`
+
+Restart the container `id`
+
+**Example request**:
+
+        POST /containers/e90e34656806/restart?t=5 HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 204 No Content
+
+Query Parameters:
+
+-   **t** – number of seconds to wait before killing the container
+
+Status Codes:
+
+-   **204** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### Kill a container
+
+`POST /containers/(id)/kill`
+
+Kill the container `id`
+
+**Example request**:
+
+        POST /containers/e90e34656806/kill HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 204 No Content
+
+Query Parameters
+
+-   **signal** - Signal to send to the container: integer or string like "SIGINT".
+        When not set, SIGKILL is assumed and the call will waits for the container to exit.
+
+Status Codes:
+
+-   **204** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### Pause a container
+
+`POST /containers/(id)/pause`
+
+Pause the container `id`
+
+**Example request**:
+
+        POST /containers/e90e34656806/pause HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 204 No Content
+
+Status Codes:
+
+-   **204** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### Unpause a container
+
+`POST /containers/(id)/unpause`
+
+Unpause the container `id`
+
+**Example request**:
+
+        POST /containers/e90e34656806/unpause HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 204 No Content
+
+Status Codes:
+
+-   **204** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### Attach to a container
+
+`POST /containers/(id)/attach`
+
+Attach to the container `id`
+
+**Example request**:
+
+        POST /containers/16253994b7c4/attach?logs=1&stream=0&stdout=1 HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/vnd.docker.raw-stream
+
+        {{ STREAM }}
+
+Query Parameters:
+
+-   **logs** – 1/True/true or 0/False/false, return logs. Default false
+-   **stream** – 1/True/true or 0/False/false, return stream.
+        Default false
+-   **stdin** – 1/True/true or 0/False/false, if stream=true, attach
+        to stdin. Default false
+-   **stdout** – 1/True/true or 0/False/false, if logs=true, return
+        stdout log, if stream=true, attach to stdout. Default false
+-   **stderr** – 1/True/true or 0/False/false, if logs=true, return
+        stderr log, if stream=true, attach to stderr. Default false
+
+Status Codes:
+
+-   **200** – no error
+-   **400** – bad parameter
+-   **404** – no such container
+-   **500** – server error
+
+    **Stream details**:
+
+    When using the TTY setting is enabled in
+    [`POST /containers/create`
+    ](../docker_remote_api_v1.9/#post--containers-create "POST /containers/create"),
+    the stream is the raw data from the process PTY and client's stdin.
+    When the TTY is disabled, then the stream is multiplexed to separate
+    stdout and stderr.
+
+    The format is a **Header** and a **Payload** (frame).
+
+    **HEADER**
+
+    The header will contain the information on which stream write the
+    stream (stdout or stderr). It also contain the size of the
+    associated frame encoded on the last 4 bytes (uint32).
+
+    It is encoded on the first 8 bytes like this:
+
+        header := [8]byte{STREAM_TYPE, 0, 0, 0, SIZE1, SIZE2, SIZE3, SIZE4}
+
+    `STREAM_TYPE` can be:
+
+-   0: stdin (will be written on stdout)
+-   1: stdout
+-   2: stderr
+
+    `SIZE1, SIZE2, SIZE3, SIZE4` are the 4 bytes of
+    the uint32 size encoded as big endian.
+
+    **PAYLOAD**
+
+    The payload is the raw stream.
+
+    **IMPLEMENTATION**
+
+    The simplest way to implement the Attach protocol is the following:
+
+    1.  Read 8 bytes
+    2.  chose stdout or stderr depending on the first byte
+    3.  Extract the frame size from the last 4 byets
+    4.  Read the extracted size and output it on the correct output
+    5.  Goto 1
+
+### Wait a container
+
+`POST /containers/(id)/wait`
+
+Block until container `id` stops, then returns the exit code
+
+**Example request**:
+
+        POST /containers/16253994b7c4/wait HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {"StatusCode":0}
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### Remove a container
+
+`DELETE /containers/(id)`
+
+Remove the container `id` from the filesystem
+
+**Example request**:
+
+        DELETE /containers/16253994b7c4?v=1 HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 204 No Content
+
+Query Parameters:
+
+-   **v** – 1/True/true or 0/False/false, Remove the volumes
+        associated to the container. Default false
+-   **force** - 1/True/true or 0/False/false, Kill then remove the container.
+        Default false
+
+Status Codes:
+
+-   **204** – no error
+-   **400** – bad parameter
+-   **404** – no such container
+-   **500** – server error
+
+### Copy files or folders from a container
+
+`POST /containers/(id)/copy`
+
+Copy files or folders of container `id`
+
+**Example request**:
+
+        POST /containers/4fa6e0f0c678/copy HTTP/1.1
+        Content-Type: application/json
+
+        {
+             "Resource":"test.txt"
+        }
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/x-tar
+
+        {{ TAR STREAM }}
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such container
+-   **500** – server error
+
+## 2.2 Images
+
+### List Images
+
+`GET /images/json`
+
+**Example request**:
+
+        GET /images/json?all=0 HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+          {
+             "RepoTags": [
+               "ubuntu:12.04",
+               "ubuntu:precise",
+               "ubuntu:latest"
+             ],
+             "Id": "8dbd9e392a964056420e5d58ca5cc376ef18e2de93b5cc90e868a1bbc8318c1c",
+             "Created": 1365714795,
+             "Size": 131506275,
+             "VirtualSize": 131506275
+          },
+          {
+             "RepoTags": [
+               "ubuntu:12.10",
+               "ubuntu:quantal"
+             ],
+             "ParentId": "27cf784147099545",
+             "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+             "Created": 1364102658,
+             "Size": 24653,
+             "VirtualSize": 180116135
+          }
+        ]
+
+
+Query Parameters:
+
+-   **all** – 1/True/true or 0/False/false, default false
+-   **filters** – a json encoded value of the filters (a map[string][]string) to process on the images list.
+
+### Create an image
+
+`POST /images/create`
+
+Create an image, either by pulling it from the registry or by importing it
+
+**Example request**:
+
+        POST /images/create?fromImage=base HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {"status":"Pulling..."}
+        {"status":"Pulling", "progress":"1 B/ 100 B", "progressDetail":{"current":1, "total":100}}
+        {"error":"Invalid..."}
+        ...
+
+    When using this endpoint to pull an image from the registry, the
+    `X-Registry-Auth` header can be used to include
+    a base64-encoded AuthConfig object.
+
+Query Parameters:
+
+-   **fromImage** – name of the image to pull
+-   **fromSrc** – source to import, - means stdin
+-   **repo** – repository
+-   **tag** – tag
+-   **registry** – the registry to pull from
+
+    Request Headers:
+
+-   **X-Registry-Auth** – base64-encoded AuthConfig object
+
+Status Codes:
+
+-   **200** – no error
+-   **500** – server error
+
+
+
+### Inspect an image
+
+`GET /images/(name)/json`
+
+Return low-level information on the image `name`
+
+**Example request**:
+
+        GET /images/base/json HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+             "Created":"2013-03-23T22:24:18.818426-07:00",
+             "Container":"3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
+             "ContainerConfig":
+                     {
+                             "Hostname":"",
+                             "User":"",
+                             "Memory":0,
+                             "MemorySwap":0,
+                             "AttachStdin":false,
+                             "AttachStdout":false,
+                             "AttachStderr":false,
+                             "PortSpecs":null,
+                             "Tty":true,
+                             "OpenStdin":true,
+                             "StdinOnce":false,
+                             "Env":null,
+                             "Cmd": ["/bin/bash"],
+                             "Dns":null,
+                             "Image":"base",
+                             "Volumes":null,
+                             "VolumesFrom":"",
+                             "WorkingDir":""
+                     },
+             "Id":"b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+             "Parent":"27cf784147099545",
+             "Size": 6824592
+        }
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such image
+-   **500** – server error
+
+### Get the history of an image
+
+`GET /images/(name)/history`
+
+Return the history of the image `name`
+
+**Example request**:
+
+        GET /images/base/history HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+             {
+                     "Id":"b750fe79269d",
+                     "Created":1364102658,
+                     "CreatedBy":"/bin/bash"
+             },
+             {
+                     "Id":"27cf78414709",
+                     "Created":1364068391,
+                     "CreatedBy":""
+             }
+        ]
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such image
+-   **500** – server error
+
+### Push an image on the registry
+
+`POST /images/(name)/push`
+
+Push the image `name` on the registry
+
+**Example request**:
+
+        POST /images/test/push HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {"status":"Pushing..."}
+        {"status":"Pushing", "progress":"1/? (n/a)", "progressDetail":{"current":1}}}
+        {"error":"Invalid..."}
+        ...
+
+    If you wish to push an image on to a private registry, that image must already have been tagged
+    into a repository which references that registry host name and port.  This repository name should
+    then be used in the URL. This mirrors the flow of the CLI.
+
+**Example request**:
+
+        POST /images/registry.acme.com:5000/test/push HTTP/1.1
+
+
+Query Parameters:
+
+-   **tag** – the tag to associate with the image on the registry, optional
+
+Request Headers:
+
+-   **X-Registry-Auth** – include a base64-encoded AuthConfig
+        object.
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such image
+-   **500** – server error
+
+### Tag an image into a repository
+
+`POST /images/(name)/tag`
+
+Tag the image `name` into a repository
+
+**Example request**:
+
+        POST /images/test/tag?repo=myrepo&force=0&tag=v42 HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 201 OK
+
+Query Parameters:
+
+-   **repo** – The repository to tag in
+-   **force** – 1/True/true or 0/False/false, default false
+-   **tag** - The new tag name
+
+Status Codes:
+
+-   **201** – no error
+-   **400** – bad parameter
+-   **404** – no such image
+-   **409** – conflict
+-   **500** – server error
+
+### Remove an image
+
+`DELETE /images/(name)`
+
+Remove the image `name` from the filesystem
+
+**Example request**:
+
+        DELETE /images/test HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-type: application/json
+
+        [
+         {"Untagged":"3e2f21a89f"},
+         {"Deleted":"3e2f21a89f"},
+         {"Deleted":"53b4f83ac9"}
+        ]
+
+Query Parameters:
+
+-   **force** – 1/True/true or 0/False/false, default false
+-   **noprune** – 1/True/true or 0/False/false, default false
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such image
+-   **409** – conflict
+-   **500** – server error
+
+### Search images
+
+`GET /images/search`
+
+Search for an image on [Docker Hub](https://hub.docker.com).
+
+> **Note**:
+> The response keys have changed from API v1.6 to reflect the JSON
+> sent by the registry server to the docker daemon's request.
+
+**Example request**:
+
+        GET /images/search?term=sshd HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+                {
+                    "description": "",
+                    "is_official": false,
+                    "is_automated": false,
+                    "name": "wma55/u1210sshd",
+                    "star_count": 0
+                },
+                {
+                    "description": "",
+                    "is_official": false,
+                    "is_automated": false,
+                    "name": "jdswinbank/sshd",
+                    "star_count": 0
+                },
+                {
+                    "description": "",
+                    "is_official": false,
+                    "is_automated": false,
+                    "name": "vgauthier/sshd",
+                    "star_count": 0
+                }
+        ...
+        ]
+
+Query Parameters:
+
+-   **term** – term to search
+
+Status Codes:
+
+-   **200** – no error
+-   **500** – server error
+
+## 2.3 Misc
+
+### Build an image from Dockerfile via stdin
+
+`POST /build`
+
+Build an image from Dockerfile via stdin
+
+**Example request**:
+
+        POST /build HTTP/1.1
+
+        {{ TAR STREAM }}
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {"stream":"Step 1..."}
+        {"stream":"..."}
+        {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
+
+    The stream must be a tar archive compressed with one of the
+    following algorithms: identity (no compression), gzip, bzip2, xz.
+
+    The archive must include a file called `Dockerfile`
+    at its root. It may include any number of other files,
+    which will be accessible in the build context (See the [*ADD build
+    command*](/reference/builder/#dockerbuilder)).
+
+Query Parameters:
+
+-   **t** – repository name (and optionally a tag) to be applied to
+        the resulting image in case of success
+-   **q** – suppress verbose build output
+-   **nocache** – do not use the cache when building the image
+-   **rm** - remove intermediate containers after a successful build (default behavior)
+-   **forcerm - always remove intermediate containers (includes rm)
+
+    Request Headers:
+
+-   **Content-type** – should be set to `"application/tar"`.
+-   **X-Registry-Config** – base64-encoded ConfigFile objec
+
+Status Codes:
+
+-   **200** – no error
+-   **500** – server error
+
+### Check auth configuration
+
+`POST /auth`
+
+Get the default username and email
+
+**Example request**:
+
+        POST /auth HTTP/1.1
+        Content-Type: application/json
+
+        {
+             "username":"hannibal",
+             "password:"xxxx",
+             "email":"hannibal@a-team.com",
+             "serveraddress":"https://index.docker.io/v1/"
+        }
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+
+Status Codes:
+
+-   **200** – no error
+-   **204** – no error
+-   **500** – server error
+
+### Display system-wide information
+
+`GET /info`
+
+Display system-wide information
+
+**Example request**:
+
+        GET /info HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+             "Containers":11,
+             "Images":16,
+             "Driver":"btrfs",
+             "ExecutionDriver":"native-0.1",
+             "KernelVersion":"3.12.0-1-amd64"
+             "NCPU":1,
+             "MemTotal":2099236864,
+             "Debug":false,
+             "NFd": 11,
+             "NGoroutines":21,
+             "NEventsListener":0,
+             "InitPath":"/usr/bin/docker",
+             "IndexServerAddress":["https://index.docker.io/v1/"],
+             "MemoryLimit":true,
+             "SwapLimit":false,
+             "IPv4Forwarding":true
+        }
+
+Status Codes:
+
+-   **200** – no error
+-   **500** – server error
+
+### Return side-wide metrics
+
+`GET /info/metrics`
+
+Return root cgroup, system-wide metrics and internal Docker white box
+telemetry exposing details about internals like the job system.
+The internal telemetry metrics are split by sub systems like job- or
+handler name.
+
+**Example request**:
+
+        GET /info/metrics HTTP/1.1
+        Content-Type: application/json
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+          {
+            "type": "COUNTER",
+            "help": "Number of jobs created.",
+            "name": "jobs_created_total",
+            "metrics": [
+              {
+                "value": 12,
+                "labels": {
+                  "name": "acceptconnections",
+                }
+              },
+              {
+                "value": 28,
+                "labels": {
+                  "name": "allocate_interface",
+                }
+              },
+              {
+                "value": 3,
+                "labels": {
+                  "name: "build"
+                }
+              }
+            ]
+          },
+          ...
+          {
+            "type": "COUNTER",
+            "help": "Total seconds of cpu time consumed.",
+            "name": "cpu_usage_seconds_total",
+            "metrics": [
+              {
+                "value": 53.21,
+                "labels": {
+                  "space": "kernel"
+                }
+              },
+              {
+                "value": 2778.09,
+                "labels": {
+                  "space": "user"
+                }
+              }
+            ]
+          }
+        ]
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such container
+-   **500** – server error
+
+
+### Show the docker version information
+
+`GET /version`
+
+Show the docker version information
+
+**Example request**:
+
+        GET /version HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {
+             "ApiVersion":"1.12",
+             "Version":"0.2.2",
+             "GitCommit":"5a2a5cc+CHANGES",
+             "GoVersion":"go1.0.3"
+        }
+
+Status Codes:
+
+-   **200** – no error
+-   **500** – server error
+
+### Return all available metrics
+
+`GET /metrics`
+
+This endpoint combines the `/info/metrics` and `/containers/(id)/metrics`
+endpoints to provide a single endpoint to easily feed the metrics into
+monitoring systems.
+
+**Example request**:
+
+        GET /metrics HTTP/1.1
+        Content-Type: application/json
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+          {
+            "type": "COUNTER",
+            "help": "Number of jobs created.",
+            "name": "jobs_created_total",
+            "metrics": [
+              {
+                "value": 12,
+                "labels": {
+                  "name": "acceptconnections",
+                }
+              },
+              {
+                "value": 28,
+                "labels": {
+                  "name": "allocate_interface",
+                }
+              },
+              {
+                "value": 3,
+                "labels": {
+                  "name: "build"
+                }
+              }
+            ]
+          },
+          ...
+          {
+            "type": "COUNTER",
+            "help": "HTTP request latencies for API handles in seconds.",
+            "name": "http_request_duration_seconds",
+            "metrics": [
+              {
+                "value": 52.42,
+                "labels": {
+                  "method": "GET",
+                  "path": "/container/json",
+                }
+              },
+              {
+                "value": 2.42,
+                "labels": {
+                  "method": "GET"
+                  "handler": "/info",
+                }
+              },
+            ]
+          },
+          ...
+          {
+            "type": "COUNTER",
+            "help": "Total seconds of cpu time consumed.",
+            "name": "cpu_usage_seconds_total",
+            "metrics": [
+              {
+                "value": 53.21,
+                "labels": {
+                  "container_id": "4fa6e0f0c678",
+                  "space": "kernel"
+                }
+              },
+              {
+                "value": 2778.09,
+                "labels": {
+                  "container_id": "4fa6e0f0c678",
+                  "space": "user"
+                }
+              },
+              {
+                "value": 53.21,
+                "labels": {
+                  "container_id": "2e4cd665e124",
+                  "space": "kernel"
+                }
+              },
+              {
+                "value": 2778.09,
+                "labels": {
+                  "container_id": "2e4cd665e124",
+                  "space": "user"
+                }
+              }
+            ]
+          }
+          ...
+        ]
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### Ping the docker server
+
+`GET /_ping`
+
+Ping the docker server
+
+**Example request**:
+
+        GET /_ping HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: text/plain
+
+        OK
+
+Status Codes:
+
+-   **200** - no error
+-   **500** - server error
+
+### Create a new image from a container's changes
+
+`POST /commit`
+
+Create a new image from a container's changes
+
+**Example request**:
+
+        POST /commit?container=44c004db4b17&comment=message&repo=myrepo HTTP/1.1
+        Content-Type: application/json
+
+        {
+             "Hostname":"",
+             "Domainname": "",
+             "User":"",
+             "Memory":0,
+             "MemorySwap":0,
+             "CpuShares": 512,
+             "Cpuset": "0,1",
+             "AttachStdin":false,
+             "AttachStdout":true,
+             "AttachStderr":true,
+             "PortSpecs":null,
+             "Tty":false,
+             "OpenStdin":false,
+             "StdinOnce":false,
+             "Env":null,
+             "Cmd":[
+                     "date"
+             ],
+             "Volumes":{
+                     "/tmp": {}
+             },
+             "WorkingDir":"",
+             "NetworkDisabled": false,
+             "ExposedPorts":{
+                     "22/tcp": {}
+             }
+        }
+
+**Example response**:
+
+        HTTP/1.1 201 Created
+        Content-Type: application/vnd.docker.raw-stream
+
+        {"Id":"596069db4bf5"}
+
+Json Parameters:
+
+-  **config** - the container's configuration
+
+Query Parameters:
+
+-   **container** – source container
+-   **repo** – repository
+-   **tag** – tag
+-   **comment** – commit message
+-   **author** – author (e.g., "John Hannibal Smith
+    <[hannibal@a-team.com](mailto:hannibal%40a-team.com)>")
+
+Status Codes:
+
+-   **201** – no error
+-   **404** – no such container
+-   **500** – server error
+
+### Monitor Docker's events
+
+`GET /events`
+
+Get container events from docker, either in real time via streaming, or via
+polling (using since).
+
+Docker containers will report the following events:
+
+    create, destroy, die, export, kill, pause, restart, start, stop, unpause
+
+and Docker images will report:
+
+    untag, delete
+
+**Example request**:
+
+        GET /events?since=1374067924
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
+        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
+        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
+        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+
+Query Parameters:
+
+-   **since** – timestamp used for polling
+-   **until** – timestamp used for polling
+
+Status Codes:
+
+-   **200** – no error
+-   **500** – server error
+
+### Get a tarball containing all images in a repository
+
+`GET /images/(name)/get`
+
+Get a tarball containing all images and metadata for the repository specified
+by `name`.
+
+If `name` is a specific name and tag (e.g. ubuntu:latest), then only that image
+(and its parents) are returned. If `name` is an image ID, similarly only tha
+image (and its parents) are returned, but with the exclusion of the
+'repositories' file in the tarball, as there were no image names referenced.
+
+See the [image tarball format](#image-tarball-format) for more details.
+
+**Example request**
+
+        GET /images/ubuntu/get
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/x-tar
+
+        Binary data stream
+
+Status Codes:
+
+-   **200** – no error
+-   **500** – server error
+
+### Get a tarball containing all images.
+
+`GET /images/get`
+
+Get a tarball containing all images and metadata for one or more repositories.
+
+For each value of the `names` parameter: if it is a specific name and tag (e.g.
+ubuntu:latest), then only that image (and its parents) are returned; if it is
+an image ID, similarly only that image (and its parents) are returned and there
+would be no names referenced in the 'repositories' file for this image ID.
+
+See the [image tarball format](#image-tarball-format) for more details.
+
+**Example request**
+
+        GET /images/get?names=myname%2Fmyapp%3Alatest&names=busybox
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/x-tar
+
+        Binary data stream
+
+Status Codes:
+
+-   **200** – no error
+-   **500** – server error
+
+### Load a tarball with a set of images and tags into docker
+
+`POST /images/load`
+
+Load a set of images and tags into the docker repository.
+See the [image tarball format](#image-tarball-format) for more details.
+
+**Example request**
+
+        POST /images/load
+
+        Tarball in body
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+
+Status Codes:
+
+-   **200** – no error
+-   **500** – server error
+
+### Image tarball format
+
+An image tarball contains one directory per image layer (named using its long ID),
+each containing three files:
+
+1. `VERSION`: currently `1.0` - the file format version
+2. `json`: detailed layer information, similar to `docker inspect layer_id`
+3. `layer.tar`: A tarfile containing the filesystem changes in this layer
+
+The `layer.tar` file will contain `aufs` style `.wh..wh.aufs` files and directories
+for storing attribute changes and deletions.
+
+If the tarball defines a repository, there will also be a `repositories` file at
+the root that contains a list of repository and tag names mapped to layer IDs.
+
+```
+{"hello-world":
+    {"latest":"565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
+}
+```
+
+### Exec Create
+
+`POST /containers/(id)/exec`
+
+Sets up an exec instance in a running container `id`
+
+**Example request**:
+
+        POST /containers/e90e34656806/exec HTTP/1.1
+        Content-Type: application/json
+
+        {
+	     "AttachStdin":false,
+	     "AttachStdout":true,
+	     "AttachStderr":true,
+	     "Tty":false,
+	     "Cmd":[
+                     "date"
+             ],
+	     "Container":"e90e34656806",
+        }
+
+**Example response**:
+
+        HTTP/1.1 201 OK
+        Content-Type: application/json
+
+        {
+             "Id":"f90e34656806"
+        }
+
+Json Parameters:
+
+-   **execConfig** ? exec configuration.
+
+Status Codes:
+
+-   **201** – no error
+-   **404** – no such container
+
+### Exec Start
+
+`POST /exec/(id)/start`
+
+Starts a previously set up exec instance `id`. If `detach` is true, this API returns after
+starting the `exec` command. Otherwise, this API sets up an interactive session with the `exec` command.
+
+**Example request**:
+
+        POST /exec/e90e34656806/start HTTP/1.1
+        Content-Type: application/json
+
+        {
+	     "Detach":false,
+	     "Tty":false,
+        }
+
+**Example response**:
+
+        HTTP/1.1 201 OK
+        Content-Type: application/json
+
+        {{ STREAM }}
+
+Json Parameters:
+
+-   **execConfig** ? exec configuration.
+
+Status Codes:
+
+-   **201** – no error
+-   **404** – no such exec instance
+
+    **Stream details**:
+    Similar to the stream behavior of `POST /container/(id)/attach` API
+
+### Exec Resize
+
+`POST /exec/(id)/resize`
+
+Resizes the tty session used by the exec command `id`.
+This API is valid only if `tty` was specified as part of creating and starting the exec command.
+
+**Example request**:
+
+        POST /exec/e90e34656806/resize HTTP/1.1
+        Content-Type: plain/text
+
+**Example response**:
+
+        HTTP/1.1 201 OK
+        Content-Type: plain/text
+
+Query Parameters:
+
+-   **h** – height of tty session
+-   **w** – width
+
+Status Codes:
+
+-   **201** – no error
+-   **404** – no such exec instance
+
+# 3. Going further
+
+## 3.1 Inside `docker run`
+
+As an example, the `docker run` command line makes the following API calls:
+
+- Create the container
+
+- If the status code is 404, it means the image doesn't exist:
+    - Try to pull it
+    - Then retry to create the container
+
+- Start the container
+
+- If you are not in detached mode:
+- Attach to the container, using logs=1 (to have stdout and
+      stderr from the container's start) and stream=1
+
+- If in detached mode or only stdin is attached:
+- Display the container's id
+
+## 3.2 Hijacking
+
+In this version of the API, /attach, uses hijacking to transport stdin,
+stdout and stderr on the same socket. This might change in the future.
+
+## 3.3 CORS Requests
+
+To enable cross origin requests to the remote api add the flag
+"--api-enable-cors" when running docker in daemon mode.
+
+    $ docker -d -H="192.168.1.9:2375" --api-enable-cors

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1627,3 +1627,21 @@ both Docker client and daemon.
 
     Block until a container stops, then print its exit code.
 
+
+## metrics
+
+    Usage: docker metrics [OPTIONS] [CONTAINER]
+
+    Show various metrics about docker itself or specified container.
+
+    -f,--follow=0    Poll every specified seconds. 0=disabled
+
+Without specifying a container, this command shows various metrics
+about the daemons internals, like number of processed engine jobs
+and various error counters.
+
+If a container is specified, this command shows metrics about the
+container like memory and cpu usage.
+
+When `-f` is specified, the command will poll the Docker daemon every
+given second. Counter values will returned as rates.


### PR DESCRIPTION
This is proposing to add per container metrics, based on cgroups, as well as docker engine metrics about Docker's internal health and job management.

This will either solve or at least provide a basis to address #8875, #1091, #4530, #5473, #8842
# Why?

Tools like cAdvisor talk to the docker daemon as well as access the cgroup kernel features to read metrics from. Even though both use libcontainer, it's error prone and racy. Metrics are coupled to the container and since this container is managed by Docker, it should also provide the metrics for it.

Beside that, metrics are key for every production deployment of Docker. So this is a problem that everyone needs to solve. This is also reflected in the high number of issues asking for native docker metrics.

This also proposes white box telemetry. The idea is to expose various metrics about the Docker internals. For now, some failure/success counters and latencies for the internal job management as well as latencies for the API endpoints.

With the proposed change, it's easy to pull the metrics from Docker into any monitoring system. For smaller setups and on the fly debugging, there will be a metrics endpoint.
# How?

The exposed metrics are pretty raw: We won't do rate conversions or advanced features like histograms and leave this to the monitoring tool. This has the limitation that `docker metrics [container]` will only show the current raw, values. If `-f` is used, it will convert the values into a rate where appropriate. To make it explicit whether a metric is a gauge or a counter, the type is included in the API.
The API is self-explanatory by including a description for each metric.

/cc @aluzzardi @crosbymichael @johncosta @kencochrane 
# Additions
- expvar/ to get various stats (memstats, http handler) and maybe use it for implementation
- container uptime and restart counters
- correlate jobs to containers where possible; have a container dimension for the jobs
