### PR TITLE
Cleanup:change "latest" to graph.DEFAULTTAG

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1235,7 +1235,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 	)
 	taglessRemote, tag := parsers.ParseRepositoryTag(remote)
 	if tag == "" && !*allTags {
-		newRemote = taglessRemote + ":latest"
+		newRemote = taglessRemote + ":" + graph.DEFAULTTAG
 	}
 	if tag != "" && *allTags {
 		return fmt.Errorf("tag can't be used with --all-tags/-a")
@@ -2034,7 +2034,7 @@ func (cli *DockerCli) pullImageCustomOut(image string, out io.Writer) error {
 	repos, tag := parsers.ParseRepositoryTag(image)
 	// pull only the image tagged 'latest' if no tag was specified
 	if tag == "" {
-		tag = "latest"
+		tag = graph.DEFAULTTAG
 	}
 	v.Set("fromImage", repos)
 	v.Set("tag", tag)


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

I don't know if this is necessary or not,if not, feel free to close this.
But for a good coding style, it's better to use a global constant.
And some place also use `grath.DEFAULTTAG` instead of `latest`
https://github.com/docker/docker/blob/master/daemon/create.go#L43
