### PR TITLE
Allow a few more DOCKER_* env vars to pass thru Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ DOCKER_IMAGE := docker$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 DOCKER_DOCS_IMAGE := docker-docs$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 DOCKER_MOUNT := $(if $(BINDDIR),-v "$(CURDIR)/$(BINDDIR):/go/src/github.com/docker/docker/$(BINDDIR)")
 
-DOCKER_RUN_DOCKER := docker run --rm -it --privileged -e TIMEOUT -e BUILDFLAGS -e TESTFLAGS -e TESTDIRS -e DOCKER_GRAPHDRIVER -e DOCKER_EXECDRIVER $(DOCKER_MOUNT) "$(DOCKER_IMAGE)"
+DOCKER_ENVS := -e TIMEOUT -e BUILDFLAGS -e TESTFLAGS \
+  -e TESTDIRS -e DOCKER_GRAPHDRIVER -e DOCKER_EXECDRIVER \
+  -e DOCKER_CLIENTONLY
+DOCKER_RUN_DOCKER := docker run --rm -it --privileged $(DOCKER_ENVS) $(DOCKER_MOUNT) "$(DOCKER_IMAGE)"
 # to allow `make DOCSDIR=docs docs-shell`
 DOCKER_RUN_DOCS := docker run --rm -it $(if $(DOCSDIR),-v $(CURDIR)/$(DOCSDIR):/$(DOCSDIR)) -e AWS_S3_BUCKET
 


### PR DESCRIPTION
I was trying to just build the Docker client but DOCKER_CLIENTONLY wasn't
getting passed thru from the shell to the container building docker.
I checked for other DOCKER_\* env vars in hack/make.sh to see what other
ones might be candidates to be passed along and just DOCKER_GITCOMMIT
jumped out at me.

So, this PR passes those vars (via the -e option) on the docker run command
so we pick them up from the devs shell when running "make ...".

While in there I pulled all of the "-e" options into a new Makefile variable
so its easy to see just the list of env vars we pass along.

Signed-off-by: Doug Davis dug@us.ibm.com
