### PR TITLE
Allow git@ urls for more than just github

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -462,7 +462,7 @@ Supported formats are: bzip2, gzip and xz.
 This will clone the GitHub repository and use the cloned repository as
 context. The Dockerfile at the root of the
 repository is used as Dockerfile. Note that you
-can specify an arbitrary Git repository by using the `git://`
+can specify an arbitrary Git repository by using the `git://` or `git@`
 schema.
 
 > **Note:** `docker build` will return a `no such file or directory` error

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -293,7 +293,7 @@ func IsURL(str string) bool {
 }
 
 func IsGIT(str string) bool {
-	return strings.HasPrefix(str, "git://") || strings.HasPrefix(str, "github.com/") || strings.HasPrefix(str, "git@github.com:") || (strings.HasSuffix(str, ".git") && IsURL(str))
+	return strings.HasPrefix(str, "git://") || strings.HasPrefix(str, "github.com/") || strings.HasPrefix(str, "git@") || (strings.HasSuffix(str, ".git") && IsURL(str))
 }
 
 func ValidGitTransport(str string) bool {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -98,23 +98,42 @@ func TestReadSymlinkedDirectoryToFile(t *testing.T) {
 	}
 }
 
-func TestValidGitTransport(t *testing.T) {
-	for _, url := range []string{
+var (
+	gitUrls = []string{
 		"git://github.com/docker/docker",
 		"git@github.com:docker/docker.git",
+		"git@bitbucket.org:atlassianlabs/atlassian-docker.git",
 		"https://github.com/docker/docker.git",
 		"http://github.com/docker/docker.git",
-	} {
+	}
+	incompleteGitUrls = []string{
+		"github.com/docker/docker",
+	}
+)
+
+func TestValidGitTransport(t *testing.T) {
+	for _, url := range gitUrls {
 		if ValidGitTransport(url) == false {
 			t.Fatalf("%q should be detected as valid Git prefix", url)
 		}
 	}
 
-	for _, url := range []string{
-		"github.com/docker/docker",
-	} {
+	for _, url := range incompleteGitUrls {
 		if ValidGitTransport(url) == true {
 			t.Fatalf("%q should not be detected as valid Git prefix", url)
+		}
+	}
+}
+
+func TestIsGIT(t *testing.T) {
+	for _, url := range gitUrls {
+		if IsGIT(url) == false {
+			t.Fatalf("%q should be detected as valid Git url", url)
+		}
+	}
+	for _, url := range incompleteGitUrls {
+		if IsGIT(url) == false {
+			t.Fatalf("%q should be detected as valid Git url", url)
 		}
 	}
 }


### PR DESCRIPTION
Without this change it's impossible to use (say) git@bitbucket.org:aidanhs/blah.git as an argument to `docker build` - ValidGitTransport _would_ return true, but IsGIT is the gatekeeper and prevents the code actually getting there.
