### PR TITLE
Proposal: user should be able to stop/kill an exec command

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -1595,6 +1595,58 @@ Status Codes:
 -   **201** – no error
 -   **404** – no such exec instance
 
+### Exec Stop
+
+`POST /exec/(id)/stop`
+
+Stop the exec command `id`
+
+**Example request**:
+
+        POST /exec/e90e34656806/stop HTTP/1.1
+        Content-Type: plain/text
+
+**Example response**:
+
+        HTTP/1.1 201 OK
+        Content-Type: plain/text
+
+Query Parameters:
+
+-   **t** – number of seconds to wait before killing the exec command
+
+Status Codes:
+
+-   **204** – no error
+-   **404** – no such exec instance
+-   **500** – server error
+
+### Exec Kill
+
+`POST /exec/(id)/kill`
+
+Kill the exec command `id`
+
+**Example request**:
+
+        POST /exec/e90e34656806/kill HTTP/1.1
+        Content-Type: plain/text
+
+**Example response**:
+
+        HTTP/1.1 204 No Content
+
+Query Parameters:
+
+-   **signal** - Signal to send to the exec command: integer or string like "SIGINT".
+        When not set, SIGKILL is assumed and the call will waits for the exec command to exit.
+
+Status Codes:
+
+-   **204** – no error
+-   **404** – no such exec instance
+-   **500** – server error
+
 # 3. Going further
 
 ## 3.1 Inside `docker run`


### PR DESCRIPTION
Fix #9098

This proposes additional extenstions to the remote API for managing exec commands.
- POST /exec/id/stop similar to POST /containers/id/stop
  this will stop or kill the exec command after timeout
- POST /exec/id/kill similar to POST /containers/id/kill
  this will kill the exec command (optionally with a custom signal)

cc @vishh
also @vieux @jfrazelle for the API change

Docker-DCO-1.1-Signed-off-by: Daniel, Dao Quang Minh dqminh89@gmail.com (github: dqminh)
