### PR TITLE
Another way to fix docker rmi

### DIFF
--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -130,9 +130,11 @@ func (daemon *Daemon) DeleteImage(eng *engine.Engine, name string, imgs *engine.
 }
 
 func (daemon *Daemon) canDeleteImage(imgID string, force bool) error {
+	var ErrMsg string
 	for _, container := range daemon.List() {
 		parent, err := daemon.Repositories().LookupImage(container.Image)
-		if err != nil {
+		ErrMsg = fmt.Sprintf("%s", err)
+		if err != nil && !strings.Contains(ErrMsg,"no such id: " + container.Image) {
 			return err
 		}
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

relate #9063 
fix #9056 
When remove an image which is used by a container use the command line docker `rmi -f xxxx`,
the image will be removed,but the container not and so the problem happened,
if you remove any unrelated image,it will fail with a message `No such id: xxxx`.
This is because when remove any image,it will check all existing container to find if the image is 
used by a container and the container whose image is already removed will also be checked,
and the check will return an error because the image of the container is not existed any more.

When the function `daemon.Repositories().LookupImage(container.Image)` return an `err` which is  `no such id: XXXX`, it means this image is not existed and there is no need to check it,so we can skip this.I think this can fix the `docker rmi issue`.

I don't konw if this is a good idea or not,if it is not good ,just feel free to close it.
