### PR TITLE
devmapper: Call UdevWait() even in failure path

### DIFF
--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -373,12 +373,11 @@ func CreatePool(poolName string, dataFile, metadataFile *os.File, poolBlockSize 
 	if err := task.SetCookie(&cookie, 0); err != nil {
 		return fmt.Errorf("Can't set cookie %s", err)
 	}
+	defer UdevWait(cookie)
 
 	if err := task.Run(); err != nil {
 		return fmt.Errorf("Error running DeviceCreate (CreatePool) %s", err)
 	}
-
-	UdevWait(cookie)
 
 	return nil
 }
@@ -516,12 +515,11 @@ func ResumeDevice(name string) error {
 	if err := task.SetCookie(&cookie, 0); err != nil {
 		return fmt.Errorf("Can't set cookie %s", err)
 	}
+	defer UdevWait(cookie)
 
 	if err := task.Run(); err != nil {
 		return fmt.Errorf("Error running DeviceResume %s", err)
 	}
-
-	UdevWait(cookie)
 
 	return nil
 }
@@ -596,11 +594,11 @@ func ActivateDevice(poolName string, name string, deviceId int, size uint64) err
 		return fmt.Errorf("Can't set cookie %s", err)
 	}
 
+	defer UdevWait(cookie)
+
 	if err := task.Run(); err != nil {
 		return fmt.Errorf("Error running DeviceCreate (ActivateDevice) %s", err)
 	}
-
-	UdevWait(cookie)
 
 	return nil
 }


### PR DESCRIPTION
Currently we set up a cookie and upon failure not call UdevWait(). This
does not cleanup the cookie and associated semaphore and system will
soon max out on total number of semaphores.

To avoid this, call UdevWait() even in failure path which in turn will
cleanup associated semaphore.

Signed-off-by: Vivek Goyal vgoyal@redhat.com
Signed-off-by: Vincent Batts vbatts@redhat.com
