### PR TITLE
Update AUTHORS file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,8 +1,10 @@
-# Generate AUTHORS: hack/generate-authors.sh
+# Generate AUTHORS: project/generate-authors.sh
 
 # Tip for finding duplicates (besides scanning the output of AUTHORS for name
 # duplicates that aren't also email duplicates): scan the output of:
 #   git log --format='%aE - %aN' | sort -uf
+#
+# For explanation on this file format: man git-shortlog
 
 <charles.hooper@dotcloud.com> <chooper@plumata.com>
 <daniel.mizyrycki@dotcloud.com> <daniel@dotcloud.com>
@@ -29,6 +31,7 @@ Andy Smith <github@anarkystic.com>
 <victor.vieux@docker.com> <dev@vvieux.com>
 <victor.vieux@docker.com> <victor@docker.com>
 <victor.vieux@docker.com> <vieux@docker.com>
+<victor.vieux@docker.com> <victorvieux@gmail.com>
 <dominik@honnef.co> <dominikh@fork-bomb.org>
 <ehanchrow@ine.com> <eric.hanchrow@gmail.com>
 Walter Stanish <walter@pratyeka.org>
@@ -54,6 +57,7 @@ Jean-Baptiste Dalido <jeanbaptiste@appgratis.com>
 <proppy@google.com> <proppy@aminche.com>
 <michael@docker.com> <michael@crosbymichael.com>
 <michael@docker.com> <crosby.michael@gmail.com>
+<michael@docker.com> <crosbymichael@gmail.com>
 <github@developersupport.net> <github@metaliveblog.com> 
 <brandon@ifup.org> <brandon@ifup.co>
 <dano@spotify.com> <daniel.norberg@gmail.com>
@@ -63,10 +67,13 @@ Jean-Baptiste Dalido <jeanbaptiste@appgratis.com>
 <sjoerd-github@linuxonly.nl> <sjoerd@byte.nl>
 <solomon@docker.com> <solomon.hykes@dotcloud.com>
 <solomon@docker.com> <solomon@dotcloud.com>
+<solomon@docker.com> <s@docker.com>
 Sven Dowideit <SvenDowideit@home.org.au>
 Sven Dowideit <SvenDowideit@home.org.au> <SvenDowideit@fosiki.com>
 Sven Dowideit <SvenDowideit@home.org.au> <SvenDowideit@docker.com>
 Sven Dowideit <SvenDowideit@home.org.au> <¨SvenDowideit@home.org.au¨>
+Sven Dowideit <SvenDowideit@home.org.au> <SvenDowideit@users.noreply.github.com>
+Sven Dowideit <SvenDowideit@home.org.au> <sven@t440s.home.gateway>
 unclejack <unclejacksons@gmail.com> <unclejack@users.noreply.github.com>
 <alexl@redhat.com> <alexander.larsson@gmail.com>
 Alexandr Morozov <lk4d4math@gmail.com>
@@ -97,3 +104,24 @@ Matthew Heon <mheon@redhat.com> <mheon@mheonlaptop.redhat.com>
 <andrew.weiss@outlook.com> <andrew.weiss@microsoft.com>
 Francisco Carriedo <fcarriedo@gmail.com>
 <julienbordellier@gmail.com> <git@julienbordellier.com>
+<ahmetb@microsoft.com> <ahmetalpbalkan@gmail.com>
+<lk4d4@docker.com> <lk4d4math@gmail.com>
+<arnaud.porterie@docker.com> <icecrime@gmail.com>
+<baloo@gandi.net> <superbaloo+registrations.github@superbaloo.net>
+Brian Goff <cpuguy83@gmail.com>
+<cpuguy83@gmail.com> <bgoff@cpuguy83-mbp.home>
+<ewindisch@docker.com> <eric@windisch.us>
+<frank.rosquin+github@gmail.com> <frank.rosquin@gmail.com>
+Hollie Teal <hollie@docker.com>
+<hollie@docker.com> <hollie.teal@docker.com>
+<hollie@docker.com> <hollietealok@users.noreply.github.com>
+<huu@prismskylabs.com> <whoshuu@gmail.com>
+Jessica Frazelle <jess@docker.com> Jessie Frazelle <jfrazelle@users.noreply.github.com>
+<jess@docker.com> <jfrazelle@users.noreply.github.com>
+<konrad.wilhelm.kleine@gmail.com> <kwk@users.noreply.github.com>
+<tintypemolly@gmail.com> <tintypemolly@Ohui-MacBook-Pro.local>
+<estesp@linux.vnet.ibm.com> <estesp@gmail.com>
+<github@gone.nl> <thaJeztah@users.noreply.github.com>
+Thomas LEVEIL <thomasleveil@gmail.com> Thomas LÉVEIL <thomasleveil@users.noreply.github.com>
+<oi@truffles.me.uk> <timruffles@googlemail.com>
+<Vincent.Bernat@exoscale.ch> <bernat@luffy.cx>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,69 +1,87 @@
 # This file lists all individuals having contributed content to the repository.
-# For how it is generated, see `hack/generate-authors.sh`.
+# For how it is generated, see `project/generate-authors.sh`.
 
 Aanand Prasad <aanand.prasad@gmail.com>
 Aaron Feng <aaron.feng@gmail.com>
 Aaron Huslage <huslage@gmail.com>
 Abel Muiño <amuino@gmail.com>
+Abhinav Ajgaonkar <abhinav316@gmail.com>
+Abin Shahab <ashahab@altiscale.com>
 Adam Miller <admiller@redhat.com>
 Adam Singer <financeCoding@gmail.com>
 Aditya <aditya@netroy.in>
 Adrian Mouat <adrian.mouat@gmail.com>
 Adrien Folie <folie.adrien@gmail.com>
+Ahmet Alp Balkan <ahmetb@microsoft.com>
 AJ Bowen <aj@gandi.net>
-Al Tobey <al@ooyala.com>
 alambike <alambike@gmail.com>
+Alan Thompson <cloojure@gmail.com>
+Albert Callarisa <shark234@gmail.com>
 Albert Zhang <zhgwenming@gmail.com>
 Aleksa Sarai <cyphar@cyphar.com>
-Alex Gaynor <alex.gaynor@gmail.com>
-Alex Warhawk <ax.warhawk@gmail.com>
 Alexander Larsson <alexl@redhat.com>
 Alexander Shopov <ash@kambanaria.org>
-Alexandr Morozov <lk4d4math@gmail.com>
+Alexandr Morozov <lk4d4@docker.com>
 Alexey Kotlyarov <alexey@infoxchange.net.au>
 Alexey Shamrin <shamrin@gmail.com>
+Alex Gaynor <alex.gaynor@gmail.com>
 Alexis THOMAS <fr.alexisthomas@gmail.com>
+Alex Warhawk <ax.warhawk@gmail.com>
 almoehi <almoehi@users.noreply.github.com>
+Al Tobey <al@ooyala.com>
+Álvaro Lázaro <alvaro.lazaro.g@gmail.com>
 amangoel <amangoel@gmail.com>
+Amit Bakshi <ambakshi@gmail.com>
 AnandkumarPatel <anandkumarpatel@gmail.com>
-Andre Dublin <81dublin@gmail.com>
+Anand Patil <anand.prabhakar.patil@gmail.com>
 Andrea Luzzardi <aluzzardi@gmail.com>
-Andrea Turli <andrea.turli@gmail.com>
+Andreas Köhler <andi5.py@gmx.net>
 Andreas Savvides <andreas@editd.com>
 Andreas Tiefenthaler <at@an-ti.eu>
+Andrea Turli <andrea.turli@gmail.com>
+Andre Dublin <81dublin@gmail.com>
 Andrew Duckworth <grillopress@gmail.com>
 Andrew France <andrew@avito.co.uk>
 Andrew Macgregor <andrew.macgregor@agworld.com.au>
 Andrew Munsell <andrew@wizardapps.net>
+Andrews Medina <andrewsmedina@gmail.com>
 Andrew Weiss <andrew.weiss@outlook.com>
 Andrew Williams <williams.andrew@gmail.com>
-Andrews Medina <andrewsmedina@gmail.com>
+Andrey Petrov <andrey.petrov@shazow.net>
+Andrey Stolbovsky <andrey.stolbovsky@gmail.com>
 Andy Chambers <anchambers@paypal.com>
 andy diller <dillera@gmail.com>
 Andy Goldstein <agoldste@redhat.com>
 Andy Kipp <andy@rstudio.com>
 Andy Rothfusz <github@developersupport.net>
 Andy Smith <github@anarkystic.com>
+Andy Wilson <wilson.andrew.j+github@gmail.com>
 Anthony Bishopric <git@anthonybishopric.com>
 Anton Löfgren <anton.lofgren@gmail.com>
 Anton Nikitin <anton.k.nikitin@gmail.com>
 Antony Messerli <amesserl@rackspace.com>
 apocas <petermdias@gmail.com>
-Arnaud Porterie <icecrime@gmail.com>
+ArikaChen <eaglesora@gmail.com>
+Arnaud Porterie <arnaud.porterie@docker.com>
+Arthur Gautier <baloo@gandi.net>
 Asbjørn Enge <asbjorn@hanafjedle.net>
+averagehuman <averagehuman@users.noreply.github.com>
+Avi Miller <avi.miller@oracle.com>
 Barnaby Gray <barnaby@pickle.me.uk>
 Barry Allard <barry.allard@gmail.com>
 Bartłomiej Piotrowski <b@bpiotrowski.pl>
 bdevloed <boris.de.vloed@gmail.com>
 Ben Firshman <ben@firshman.co.uk>
+Benjamin Atkin <ben@benatkin.com>
+Benoit Chesneau <bchesneau@gmail.com>
 Ben Sargent <ben@brokendigits.com>
 Ben Toews <mastahyeti@gmail.com>
 Ben Wiklund <ben@daisyowl.com>
-Benjamin Atkin <ben@benatkin.com>
-Benoit Chesneau <bchesneau@gmail.com>
 Bernerd Schaefer <bj.schaefer@gmail.com>
+Bert Goethals <bert@bertg.be>
 Bhiraj Butala <abhiraj.butala@gmail.com>
 bin liu <liubin0329@users.noreply.github.com>
+Blake Geno <blakegeno@gmail.com>
 Bouke Haarsma <bouke@webatoom.nl>
 Boyd Hemphill <boyd@feedmagnet.com>
 Brandon Liu <bdon@bdon.org>
@@ -80,10 +98,13 @@ Brian Shumate <brian@couchbase.com>
 Brice Jaglin <bjaglin@teads.tv>
 Briehan Lombaard <briehan.lombaard@gmail.com>
 Bruno Bigras <bigras.bruno@gmail.com>
+Bruno Binet <bruno.binet@gmail.com>
 Bruno Renié <brutasse@gmail.com>
 Bryan Bess <squarejaw@bsbess.com>
 Bryan Matsuo <bryan.matsuo@gmail.com>
 Bryan Murphy <bmurphy1976@gmail.com>
+Burke Libbey <burke@libbey.me>
+Byung Kang <byung.kang.ctr@amrdec.army.mil>
 Caleb Spare <cespare@gmail.com>
 Calen Pennington <cale@edx.org>
 Cameron Boehmer <cameron.boehmer@gmail.com>
@@ -95,56 +116,68 @@ Charlie Lewis <charliel@lab41.org>
 Chewey <prosto-chewey@users.noreply.github.com>
 Chia-liang Kao <clkao@clkao.org>
 Chris Alfonso <calfonso@redhat.com>
+Chris Armstrong <chris@opdemand.com>
+chrismckinnel <chris.mckinnel@tangentlabs.co.uk>
 Chris Snow <chsnow123@gmail.com>
 Chris St. Pierre <chris.a.st.pierre@gmail.com>
-chrismckinnel <chris.mckinnel@tangentlabs.co.uk>
 Christian Berendt <berendt@b1-systems.de>
 ChristoperBiscardi <biscarch@sketcht.com>
-Christophe Troestler <christophe.Troestler@umons.ac.be>
 Christopher Currie <codemonkey+github@gmail.com>
 Christopher Rigor <crigor@gmail.com>
+Christophe Troestler <christophe.Troestler@umons.ac.be>
 Ciro S. Costa <ciro.costa@usp.br>
 Clayton Coleman <ccoleman@redhat.com>
 Colin Dunklau <colin.dunklau@gmail.com>
 Colin Rice <colin@daedrum.net>
 Colin Walters <walters@verbum.org>
 Cory Forsyth <cory.forsyth@gmail.com>
-cpuguy83 <cpuguy83@gmail.com>
 cressie176 <github@stephen-cresswell.net>
 Cruceru Calin-Cristian <crucerucalincristian@gmail.com>
 Daan van Berkel <daan.v.berkel.1980@gmail.com>
+Daehyeok.Mun <daehyeok@gmail.com>
 Dafydd Crosby <dtcrsby@gmail.com>
 Dan Buch <d.buch@modcloth.com>
+Dan Cotora <dan@bluevision.ro>
+Dan Griffin <dgriffin@peer1.com>
 Dan Hirsch <thequux@upstandinghackers.com>
-Dan Keder <dan.keder@gmail.com>
-Dan McPherson <dmcphers@redhat.com>
-Dan Stine <sw@stinemail.com>
-Dan Walsh <dwalsh@redhat.com>
-Dan Williams <me@deedubs.com>
+Daniel, Dao Quang Minh <dqminh89@gmail.com>
 Daniel Exner <dex@dragonslave.de>
+Daniel Farrell <dfarrell@redhat.com>
 Daniel Garcia <daniel@danielgarcia.info>
 Daniel Gasienica <daniel@gasienica.ch>
+Daniel Menet <membership@sontags.ch>
 Daniel Mizyrycki <daniel.mizyrycki@dotcloud.com>
 Daniel Norberg <dano@spotify.com>
 Daniel Nordberg <dnordberg@gmail.com>
 Daniel Robinson <gottagetmac@gmail.com>
 Daniel Von Fange <daniel@leancoder.com>
 Daniel YC Lin <dlin.tw@gmail.com>
-Daniel, Dao Quang Minh <dqminh89@gmail.com>
+Dan Keder <dan.keder@gmail.com>
+Dan McPherson <dmcphers@redhat.com>
 Danny Berger <dpb587@gmail.com>
 Danny Yates <danny@codeaholics.org>
+Dan Stine <sw@stinemail.com>
+Dan Walsh <dwalsh@redhat.com>
+Dan Williams <me@deedubs.com>
 Darren Coxall <darren@darrencoxall.com>
 Darren Shepherd <darren.s.shepherd@gmail.com>
 David Anderson <dave@natulte.net>
 David Calavera <david.calavera@gmail.com>
 David Corking <dmc-source@dcorking.com>
+Davide Ceretti <davide.ceretti@hogarthww.com>
 David Gageot <david@gageot.net>
+David Gebler <davidgebler@gmail.com>
 David Mcanulty <github@hellspark.com>
+David Pelaez <pelaez89@gmail.com>
 David Röthlisberger <david@rothlis.net>
 David Sissitka <me@dsissitka.com>
+Dawn Chen <dawnchen@google.com>
+decadent <decadent@users.noreply.github.com>
 Deni Bertovic <deni@kset.org>
 Derek <crq@kernel.org>
+Derek McGowan <derek@mcgstyle.net>
 Deric Crago <deric.crago@gmail.com>
+Deshi Xiao <dxiao@redhat.com>
 Dinesh Subhraveti <dineshs@altiscale.com>
 Djibril Koné <kone.djibril@gmail.com>
 dkumor <daniel@dkumor.com>
@@ -154,11 +187,13 @@ Dominik Honnef <dominik@honnef.co>
 Don Spaulding <donspauldingii@gmail.com>
 Doug Davis <dug@us.ibm.com>
 doug tangren <d.tangren@gmail.com>
-Dr Nic Williams <drnicwilliams@gmail.com>
+dragon788 <dragon788@users.noreply.github.com>
 Dražen Lučanin <kermit666@gmail.com>
+Dr Nic Williams <drnicwilliams@gmail.com>
 Dustin Sallings <dustin@spy.net>
 Edmund Wagner <edmund-wagner@web.de>
 Eiichi Tsukata <devel@etsukata.com>
+Eike Herzbach <eike@herzbach.net>
 Eivind Uggedal <eivind@uggedal.com>
 Elias Probst <mail@eliasprobst.eu>
 Emil Hernvall <emil@quench.at>
@@ -166,17 +201,19 @@ Emily Rose <emily@contactvibe.com>
 Eric Hanchrow <ehanchrow@ine.com>
 Eric Lee <thenorthsecedes@gmail.com>
 Eric Myhre <hash@exultant.us>
-Eric Windisch <eric@windisch.us>
+Eric Paris <eparis@redhat.com>
 Eric Windisch <ewindisch@docker.com>
 Erik Hollensbe <github@hollensbe.org>
 Erik Inge Bolsø <knan@redpill-linpro.com>
+Erik Kristensen <erik@erikkristensen.com>
 Erno Hopearuoho <erno.hopearuoho@gmail.com>
+Eugene Yakubovich <eugene.yakubovich@coreos.com>
 eugenkrizo <eugen.krizo@gmail.com>
+evanderkoogh <info@erronis.nl>
 Evan Hazlett <ejhazlett@gmail.com>
 Evan Krall <krall@yelp.com>
 Evan Phoenix <evan@fallingsnow.net>
 Evan Wies <evan@neomantra.net>
-evanderkoogh <info@erronis.nl>
 Eystein Måløy Stenberg <eystein.maloy.stenberg@cfengine.com>
 ezbercih <cem.ezberci@gmail.com>
 Fabio Falci <fabiofalci@gmail.com>
@@ -186,49 +223,60 @@ Faiz Khan <faizkhan00@gmail.com>
 Fareed Dudhia <fareeddudhia@googlemail.com>
 Felix Rabe <felix@rabe.io>
 Fernando <fermayo@gmail.com>
+Filipe Brandenburger <filbranden@google.com>
 Flavio Castelli <fcastelli@suse.com>
 FLGMwt <ryan.stelly@live.com>
 Francisco Carriedo <fcarriedo@gmail.com>
 Francisco Souza <f@souza.cc>
 Frank Macreery <frank@macreery.com>
-Fred Lifton <fred.lifton@docker.com>
+Frank Rosquin <frank.rosquin+github@gmail.com>
 Frederick F. Kautz IV <fkautz@alumni.cmu.edu>
 Frederik Loeffert <frederik@zitrusmedia.de>
+Fred Lifton <fred.lifton@docker.com>
 Freek Kalter <freek@kalteronline.org>
 Gabe Rosenhouse <gabe@missionst.com>
 Gabor Nagy <mail@aigeruth.hu>
 Gabriel Monroy <gabriel@opdemand.com>
 Galen Sampson <galen.sampson@gmail.com>
 Gareth Rushgrove <gareth@morethanseven.net>
+gautam, prasanna <prasannagautam@gmail.com>
 Geoffrey Bachelet <grosfrais@gmail.com>
+George Xie <georgexsh@gmail.com>
 Gereon Frey <gereon.frey@dynport.de>
 German DZ <germ@ndz.com.ar>
 Gert van Valkenhoef <g.h.m.van.valkenhoef@rug.nl>
 Giuseppe Mazzotta <gdm85@users.noreply.github.com>
 Gleb Fotengauer-Malinovskiy <glebfm@altlinux.org>
+Gleb M Borisov <borisov.gleb@gmail.com>
 Glyn Normington <gnormington@gopivotal.com>
 Goffert van Gool <goffert@phusion.nl>
+golubbe <ben.golub@dotcloud.com>
 Graydon Hoare <graydon@pobox.com>
 Greg Thornton <xdissent@me.com>
 grunny <mwgrunny@gmail.com>
 Guilherme Salgado <gsalgado@gmail.com>
+Guillaume Dufour <gdufour.prestataire@voyages-sncf.com>
 Guillaume J. Charmes <guillaume.charmes@docker.com>
 Gurjeet Singh <gurjeet@singh.im>
 Guruprasad <lgp171188@gmail.com>
+Hans Rødtang <hansrodtang@gmail.com>
 Harald Albers <github@albersweb.de>
 Harley Laue <losinggeneration@gmail.com>
 Hector Castro <hectcastro@gmail.com>
 Henning Sprang <henning.sprang@gmail.com>
 Hobofan <goisser94@gmail.com>
-Hollie Teal <hollie.teal@docker.com>
-Hollie Teal <hollietealok@users.noreply.github.com>
-hollietealok <hollie@docker.com>
+Hollie Teal <hollie@docker.com>
+Huayi Zhang <irachex@gmail.com>
+Hugo Duncan <hugo@hugoduncan.org>
 Hunter Blanks <hunter@twilio.com>
+Hu Tao <hutao@cn.fujitsu.com>
+Huu Nguyen <huu@prismskylabs.com>
 hyeongkyu.lee <hyeongkyu.lee@navercorp.com>
 Ian Babrou <ibobrik@gmail.com>
 Ian Bull <irbull@gmail.com>
 Ian Main <imain@redhat.com>
 Ian Truslove <ian.truslove@gmail.com>
+Igor Dolzhikov <bluesriverz@gmail.com>
 ILYA Khlopotov <ilya.khlopotov@gmail.com>
 inglesp <peter.inglesby@gmail.com>
 Isaac Dupree <antispam@idupree.com>
@@ -236,8 +284,8 @@ Isabel Jimenez <contact.isabeljimenez@gmail.com>
 Isao Jonas <isao.jonas@gmail.com>
 Ivan Fraixedes <ifcdev@gmail.com>
 Jack Danger Canty <jackdanger@squareup.com>
-Jake Moshenko <jake@devtable.com>
 jakedt <jake@devtable.com>
+Jake Moshenko <jake@devtable.com>
 James Allen <jamesallen0108@gmail.com>
 James Carr <james.r.carr@gmail.com>
 James DeFelice <james.defelice@ishisystems.com>
@@ -245,6 +293,7 @@ James Harrison Fisher <jameshfisher@gmail.com>
 James Kyle <james@jameskyle.org>
 James Mills <prologic@shortcircuit.net.au>
 James Turnbull <james@lovedthanlost.net>
+Jan Keromnes <janx@linux.com>
 Jan Pazdziora <jpazdziora@redhat.com>
 Jan Toebes <jan@toebes.info>
 Jaroslaw Zabiello <hipertracker@gmail.com>
@@ -256,31 +305,35 @@ Jason McVetta <jason.mcvetta@gmail.com>
 Jason Plum <jplum@devonit.com>
 Jean-Baptiste Barth <jeanbaptiste.barth@gmail.com>
 Jean-Baptiste Dalido <jeanbaptiste@appgratis.com>
+Jean-Paul Calderone <exarkun@twistedmatrix.com>
 Jeff Lindsay <progrium@gmail.com>
-Jeff Welch <whatthejeff@gmail.com>
 Jeffrey Bolle <jeffreybolle@gmail.com>
+Jeff Welch <whatthejeff@gmail.com>
 Jeremy Grosser <jeremy@synack.me>
+Jérôme Petazzoni <jerome.petazzoni@dotcloud.com>
 Jesse Dubay <jesse@thefortytwo.net>
+Jessica Frazelle <jess@docker.com>
 Jezeniel Zapanta <jpzapanta22@gmail.com>
 Jilles Oldenbeuving <ojilles@gmail.com>
 Jim Alateras <jima@comware.com.au>
-Jim Perrin <jperrin@centos.org>
 Jimmy Cuadra <jimmy@jimmycuadra.com>
+Jim Perrin <jperrin@centos.org>
 Jiří Župka <jzupka@redhat.com>
 Joe Beda <joe.github@bedafamily.com>
+Joe Ferguson <joe@infosiftr.com>
+Joel Handwell <joelhandwell@gmail.com>
 Joe Shaw <joe@joeshaw.org>
 Joe Van Dyk <joe@tanga.com>
-Joel Handwell <joelhandwell@gmail.com>
 Joffrey F <joffrey@docker.com>
 Johan Euphrosine <proppy@google.com>
-Johan Rydberg <johan.rydberg@gmail.com>
 Johannes 'fish' Ziemke <github@freigeist.org>
+Johan Rydberg <johan.rydberg@gmail.com>
 John Costa <john.costa@gmail.com>
 John Feminella <jxf@jxf.me>
 John Gardiner Myers <jgmyers@proofpoint.com>
+John Gossman <johngos@microsoft.com>
 John OBrien III <jobrieniii@yahoo.com>
 John Warwick <jwarwick@gmail.com>
-Jon Wedaman <jweede@gmail.com>
 Jonas Pfenniger <jonas@pfenniger.name>
 Jonathan Boulle <jonathanboulle@gmail.com>
 Jonathan Camp <jonathan@irondojo.com>
@@ -288,22 +341,25 @@ Jonathan McCrohan <jmccrohan@gmail.com>
 Jonathan Mueller <j.mueller@apoveda.ch>
 Jonathan Pares <jonathanpa@users.noreply.github.com>
 Jonathan Rudenberg <jonathan@titanous.com>
+Jon Wedaman <jweede@gmail.com>
 Joost Cassee <joost@cassee.net>
 Jordan Arentsen <blissdev@gmail.com>
 Jordan Sissel <jls@semicomplete.com>
 Joseph Anthony Pasquale Holsten <joseph@josephholsten.com>
 Joseph Hager <ajhager@gmail.com>
-Josh <jokajak@gmail.com>
 Josh Hawn <josh.hawn@docker.com>
+Josh <jokajak@gmail.com>
 Josh Poimboeuf <jpoimboe@redhat.com>
+Josiah Kiehl <jkiehl@riotgames.com>
 JP <jpellerin@leapfrogonline.com>
+Julian Taylor <jtaylor.debian@googlemail.com>
 Julien Barbier <write0@gmail.com>
 Julien Bordellier <julienbordellier@gmail.com>
 Julien Dubois <julien.dubois@gmail.com>
 Justin Force <justin.force@gmail.com>
 Justin Plock <jplock@users.noreply.github.com>
 Justin Simonelis <justin.p.simonelis@gmail.com>
-Jérôme Petazzoni <jerome.petazzoni@dotcloud.com>
+Jyrki Puttonen <jyrkiput@gmail.com>
 Karan Lyons <karan@karanlyons.com>
 Karl Grzeszczak <karlgrz@gmail.com>
 Kato Kazuyoshi <kato.kazuyoshi@gmail.com>
@@ -311,57 +367,68 @@ Kawsar Saiyeed <kawsar.saiyeed@projiris.com>
 Keli Hu <dev@keli.hu>
 Ken Cochrane <kencochrane@gmail.com>
 Ken ICHIKAWA <ichikawa.ken@jp.fujitsu.com>
-Kevin "qwazerty" Houdebert <kevin.houdebert@gmail.com>
 Kevin Clark <kevin.clark@gmail.com>
 Kevin J. Lynagh <kevin@keminglabs.com>
 Kevin Menard <kevin@nirvdrum.com>
+Kevin "qwazerty" Houdebert <kevin.houdebert@gmail.com>
 Kevin Wallace <kevin@pentabarf.net>
 Keyvan Fatehi <keyvanfatehi@gmail.com>
 kies <lleelm@gmail.com>
-Kim BKC Carlbacker <kim.carlbacker@gmail.com>
 kim0 <email.ahmedkamal@googlemail.com>
+Kim BKC Carlbacker <kim.carlbacker@gmail.com>
 Kimbro Staken <kstaken@kstaken.com>
 Kiran Gangadharan <kiran.daredevil@gmail.com>
 knappe <tyler.knappe@gmail.com>
 Kohei Tsuruta <coheyxyz@gmail.com>
+Konrad Kleine <konrad.wilhelm.kleine@gmail.com>
 Konstantin Pelykh <kpelykh@zettaset.com>
+krrg <krrgithub@gmail.com>
 Kyle Conroy <kyle.j.conroy@gmail.com>
 kyu <leehk1227@gmail.com>
 Lachlan Coote <lcoote@vmware.com>
+Lajos Papp <lajos.papp@sequenceiq.com>
+Lakshan Perera <lakshan@laktek.com>
 lalyos <lalyos@yahoo.com>
 Lance Chen <cyen0312@gmail.com>
 Lars R. Damerow <lars@pixar.com>
 Laurie Voss <github@seldo.com>
 leeplay <hyeongkyu.lee@navercorp.com>
+Lei Jitang <leijitang@huawei.com>
 Len Weincier <len@cloudafrica.net>
+Leszek Kowalski <github@leszekkowalski.pl>
 Levi Gross <levi@levigross.com>
 Lewis Peckover <lew+github@lew.io>
 Liang-Chi Hsieh <viirya@gmail.com>
+limsy <seongyeol37@gmail.com>
 Lokesh Mandvekar <lsm5@fedoraproject.org>
 Louis Opter <kalessin@kalessin.fr>
 lukaspustina <lukas.pustina@centerdevice.com>
 lukemarsden <luke@digital-crocus.com>
+Madhu Venugopal <madhu@socketplane.io>
 Mahesh Tiyyagura <tmahesh@gmail.com>
+Malte Janduda <mail@janduda.net>
 Manfred Zabarauskas <manfredas@zabarauskas.com>
 Manuel Meurer <manuel@krautcomputing.com>
 Manuel Woelker <github@manuel.woelker.org>
 Marc Abramowitz <marc@marc-abramowitz.com>
 Marc Kuo <kuomarc2@gmail.com>
-Marc Tamsky <mtamsky@gmail.com>
 Marco Hennings <marco.hennings@freiheit.com>
+Marc Tamsky <mtamsky@gmail.com>
 Marcus Farkas <toothlessgear@finitebox.com>
-Marcus Ramberg <marcus@nordaaker.com>
 marcuslinke <marcus.linke@gmx.de>
+Marcus Ramberg <marcus@nordaaker.com>
 Marek Goldmann <marek.goldmann@gmail.com>
 Marius Voila <marius.voila@gmail.com>
 Mark Allen <mrallen1@yahoo.com>
 Mark McGranaghan <mmcgrana@gmail.com>
 Marko Mikulicic <mmikulicic@gmail.com>
+Marko Tibold <marko@tibold.nl>
 Markus Fix <lispmeister@gmail.com>
 Martijn van Oosterhout <kleptog@svana.org>
 Martin Redmond <martin@tinychat.com>
 Mason Malone <mason.malone@gmail.com>
 Mateusz Sulima <sulima.mateusz@gmail.com>
+Mathias Monnerville <mathias@monnerville.com>
 Mathieu Le Marec - Pasquet <kiorky@cryptelium.net>
 Matt Apperson <me@mattapperson.com>
 Matt Bachmann <bachmann.matt@gmail.com>
@@ -372,17 +439,24 @@ Matthias Klumpp <matthias@tenstral.net>
 Matthias Kühnle <git.nivoc@neverbox.com>
 mattymo <raytrac3r@gmail.com>
 mattyw <mattyw@me.com>
-Max Shytikov <mshytikov@gmail.com>
-Maxim Treskin <zerthurd@gmail.com>
 Maxime Petazzoni <max@signalfuse.com>
+Maxim Treskin <zerthurd@gmail.com>
+Max Shytikov <mshytikov@gmail.com>
+Médi-Rémi Hashim <medimatrix@users.noreply.github.com>
 meejah <meejah@meejah.ca>
+Mengdi Gao <usrgdd@gmail.com>
+Mert Yazıcıoğlu <merty@users.noreply.github.com>
 Michael Brown <michael@netdirect.ca>
 Michael Crosby <michael@docker.com>
 Michael Gorsuch <gorsuch@github.com>
+Michael Hudson-Doyle <michael.hudson@linaro.org>
 Michael Neale <michael.neale@gmail.com>
-Michael Prokop <github@michael-prokop.at>
-Michael Stapelberg <michael+gh@stapelberg.de>
 Michaël Pailloncy <mpapo.dev@gmail.com>
+Michael Prokop <github@michael-prokop.at>
+Michael Scharf <github@scharf.gr>
+Michael Stapelberg <michael+gh@stapelberg.de>
+Michael Thies <michaelthies78@gmail.com>
+Michal Jemala <michal.jemala@gmail.com>
 Michiel@unhosted <michiel@unhosted.org>
 Miguel Angel Fernández <elmendalerenda@gmail.com>
 Mike Chelen <michael.chelen@gmail.com>
@@ -395,32 +469,40 @@ Mohit Soni <mosoni@ebay.com>
 Morgante Pell <morgante.pell@morgante.net>
 Morten Siebuhr <sbhr@sbhr.dk>
 Mrunal Patel <mrunalp@gmail.com>
+mschurenko <matt.schurenko@gmail.com>
+Mustafa Akın <mustafa91@gmail.com>
 Nan Monnand Deng <monnand@gmail.com>
 Naoki Orii <norii@cs.cmu.edu>
 Nate Jones <nate@endot.org>
+Nathan Hsieh <hsieh.nathan@gmail.com>
 Nathan Kleyn <nathan@nathankleyn.com>
 Nathan LeClaire <nathan.leclaire@docker.com>
 Nelson Chen <crazysim@gmail.com>
 Niall O'Higgins <niallo@unworkable.org>
+Nicholas E. Rabenau <nerab@gmx.at>
 Nick Payne <nick@kurai.co.uk>
 Nick Stenning <nick.stenning@digital.cabinet-office.gov.uk>
 Nick Stinemates <nick@stinemates.org>
+Nicolas De loof <nicolas.deloof@gmail.com>
 Nicolas Dudebout <nicolas.dudebout@gatech.edu>
+Nicolas Goy <kuon@goyman.com>
 Nicolas Kaiser <nikai@nikai.net>
 NikolaMandic <mn080202@gmail.com>
 noducks <onemannoducks@gmail.com>
 Nolan Darilek <nolan@thewordnerd.info>
-O.S. Tezer <ostezer@gmail.com>
+nzwsch <hi@nzwsch.com>
 OddBloke <daniel@daniel-watkins.co.uk>
 odk- <github@odkurzacz.org>
 Oguz Bilgic <fisyonet@gmail.com>
+Oh Jinkyun <tintypemolly@gmail.com>
 Ole Reifschneider <mail@ole-reifschneider.de>
 Olivier Gambier <dmp42@users.noreply.github.com>
+O.S. Tezer <ostezer@gmail.com>
 pandrew <letters@paulnotcom.se>
 Pascal Borreli <pascal@borreli.com>
+Pascal Hartig <phartig@rdrei.net>
 Patrick Hemmer <patrick.hemmer@gmail.com>
 pattichen <craftsbear@gmail.com>
-Paul <paul9869@gmail.com>
 Paul Annesley <paul@annesley.cc>
 Paul Bowsher <pbowsher@globalpersonals.co.uk>
 Paul Hammond <paul@paulhammond.org>
@@ -428,25 +510,39 @@ Paul Jimenez <pj@place.org>
 Paul Lietar <paul@lietar.net>
 Paul Morie <pmorie@gmail.com>
 Paul Nasrat <pnasrat@gmail.com>
+Paul <paul9869@gmail.com>
 Paul Weaver <pauweave@cisco.com>
+Pavlos Ratis <dastergon@gentoo.org>
 Peter Bourgon <peter@bourgon.org>
 Peter Braden <peterbraden@peterbraden.co.uk>
+Peter Ericson <pdericson@gmail.com>
+Peter Salvatore <peter@psftw.com>
 Peter Waller <p@pwaller.net>
-Phil <underscorephil@gmail.com>
-Phil Spitler <pspitler@gmail.com>
+Phil Estes <estesp@linux.vnet.ibm.com>
+Philipp Weissensteiner <mail@philippweissensteiner.com>
 Phillip Alexander <git@phillipalexander.io>
+Phil Spitler <pspitler@gmail.com>
+Phil <underscorephil@gmail.com>
 Piergiuliano Bossi <pgbossi@gmail.com>
 Pierre-Alain RIVIERE <pariviere@ippon.fr>
+Pierre <py@poujade.org>
 Piotr Bogdan <ppbogdan@gmail.com>
+pixelistik <pixelistik@users.noreply.github.com>
+Prasanna Gautam <prasannagautam@gmail.com>
+Przemek Hejman <przemyslaw.hejman@gmail.com>
 pysqz <randomq@126.com>
+Qiang Huang <h.huangqiang@huawei.com>
 Quentin Brossard <qbrossard@gmail.com>
 r0n22 <cameron.regan@gmail.com>
 Rafal Jeczalik <rjeczalik@gmail.com>
+Rafe Colton <rafael.colton@gmail.com>
 Rajat Pandit <rp@rajatpandit.com>
 Rajdeep Dua <dua_rajdeep@yahoo.com>
 Ralph Bean <rbean@redhat.com>
 Ramkumar Ramachandra <artagnon@gmail.com>
 Ramon van Alteren <ramon@vanalteren.nl>
+Recursive Madman <recursive.madman@gmx.de>
+Remi Rampin <remirampin@gmail.com>
 Renato Riccieri Santos Zannon <renato.riccieri@gmail.com>
 rgstephens <greg@udon.org>
 Rhys Hiltner <rhys@twitch.tv>
@@ -455,6 +551,7 @@ Richo Healey <richo@psych0tik.net>
 Rick Bradley <rick@users.noreply.github.com>
 Rick van de Loo <rickvandeloo@gmail.com>
 Robert Bachmann <rb@robertbachmann.at>
+Robert Bittle <guywithnose@gmail.com>
 Robert Obryk <robryk@gmail.com>
 Roberto G. Hashioka <roberto.hashioka@docker.com>
 Robin Speekenbrink <robin@kingsquare.nl>
@@ -470,25 +567,30 @@ Rovanion Luckey <rovanion.luckey@gmail.com>
 Rudolph Gottesheim <r.gottesheim@loot.at>
 Ryan Anderson <anderson.ryanc@gmail.com>
 Ryan Aslett <github@mixologic.com>
+Ryan Detzel <ryan.detzel@gmail.com>
 Ryan Fowler <rwfowler@gmail.com>
 Ryan O'Donnell <odonnellryanc@gmail.com>
 Ryan Seto <ryanseto@yak.net>
 Ryan Thomas <rthomas@atlassian.com>
-s-ko <aleks@s-ko.net>
 Sam Alba <sam.alba@gmail.com>
 Sam Bailey <cyprix@cyprix.com.au>
 Sam J Sharpe <sam.sharpe@digital.cabinet-office.gov.uk>
 Sam Reis <sreis@atlassian.com>
 Sam Rijs <srijs@airpost.net>
 Samuel Andaya <samuel@andaya.net>
+Samuel PHAN <samuel-phan@users.noreply.github.com>
 satoru <satorulogic@gmail.com>
 Satoshi Amemiya <satoshi_amemiya@voyagegroup.com>
 Scott Bessler <scottbessler@gmail.com>
 Scott Collier <emailscottcollier@gmail.com>
+Scott Johnston <scott@docker.com>
+Scott Walls <sawalls@umich.edu>
 Sean Cronin <seancron@gmail.com>
 Sean P. Kane <skane@newrelic.com>
 Sebastiaan van Stijn <github@gone.nl>
-Sebastiaan van Stijn <thaJeztah@users.noreply.github.com>
+Sébastien Luttringer <seblu@seblu.net>
+Sébastien <sebastien@yoozio.com>
+Sébastien Stormacq <sebsto@users.noreply.github.com>
 Senthil Kumar Selvaraj <senthil.thecoder@gmail.com>
 SeongJae Park <sj38.park@gmail.com>
 Shane Canon <scanon@lbl.gov>
@@ -496,28 +598,30 @@ shaunol <shaunol@gmail.com>
 Shawn Landden <shawn@churchofgit.com>
 Shawn Siefkas <shawn.siefkas@meredith.com>
 Shih-Yuan Lee <fourdollars@gmail.com>
+shuai-z <zs.broccoli@gmail.com>
 Silas Sewell <silas@sewell.org>
 Simon Taranto <simon.taranto@gmail.com>
 Sindhu S <sindhus@live.in>
 Sjoerd Langkemper <sjoerd-github@linuxonly.nl>
+s-ko <aleks@s-ko.net>
 Solomon Hykes <solomon@docker.com>
 Song Gao <song@gao.io>
 Soulou <leo@unbekandt.eu>
 soulshake <amy@gandi.net>
 Sridatta Thatipamala <sthatipamala@gmail.com>
 Sridhar Ratnakumar <sridharr@activestate.com>
+Srini Brahmaroutu <sbrahma@us.ibm.com>
 Steeve Morin <steeve.morin@gmail.com>
 Stefan Praszalowicz <stefan@greplin.com>
 Stephen Crosby <stevecrozz@gmail.com>
 Steven Burgess <steven.a.burgess@hotmail.com>
+Steven Merrill <steven.merrill@gmail.com>
 sudosurootdev <sudosurootdev@gmail.com>
-Sven Dowideit <svendowideit@home.org.au>
+Sven Dowideit <SvenDowideit@home.org.au>
 Sylvain Bellemare <sylvain.bellemare@ezeep.com>
-Sébastien <sebastien@yoozio.com>
-Sébastien Luttringer <seblu@seblu.net>
-Sébastien Stormacq <sebsto@users.noreply.github.com>
 tang0th <tang0th@gmx.com>
 Tatsuki Sugiura <sugi@nemui.org>
+Ted M. Young <tedyoung@gmail.com>
 Tehmasp Chaudhri <tehmasp@gmail.com>
 Thatcher Peskens <thatcher@docker.com>
 Thermionix <bond711@gmail.com>
@@ -526,25 +630,32 @@ Thomas Bikeev <thomas.bikeev@mac.com>
 Thomas Frössman <thomasf@jossystem.se>
 Thomas Hansen <thomas.hansen@gmail.com>
 Thomas LEVEIL <thomasleveil@gmail.com>
+Thomas Orozco <thomas@orozco.fr>
 Thomas Schroeter <thomas@cliqz.com>
 Tianon Gravi <admwiggin@gmail.com>
 Tibor Vass <teabee89@gmail.com>
 Tim Bosse <taim@bosboot.org>
-Tim Ruffles <oi@truffles.me.uk>
-Tim Ruffles <timruffles@googlemail.com>
-Tim Terhorst <mynamewastaken+git@gmail.com>
+Tim Hockin <thockin@google.com>
 Timothy Hobbs <timothyhobbs@seznam.cz>
+Tim Ruffles <oi@truffles.me.uk>
+Tim Smith <timbot@google.com>
+Tim Terhorst <mynamewastaken+git@gmail.com>
 tjmehta <tj@init.me>
+tjwebb123 <tjwebb123@users.noreply.github.com>
+tobe <tobegit3hub@gmail.com>
 Tobias Bieniek <Tobias.Bieniek@gmx.de>
 Tobias Gesellchen <tobias@gesellix.de>
 Tobias Schmidt <ts@soundcloud.com>
 Tobias Schwab <tobias.schwab@dynport.de>
 Todd Lunter <tlunter@gmail.com>
+Tomasz Lipinski <tlipinski@users.noreply.github.com>
 Tom Fotherby <tom+github@peopleperhour.com>
 Tom Hulihan <hulihan.tom159@gmail.com>
 Tom Maaswinkel <tom.maaswinkel@12wiki.eu>
 Tommaso Visconti <tommaso.visconti@gmail.com>
+Tonis Tiigi <tonistiigi@gmail.com>
 Tony Daws <tony@daws.ca>
+Torstein Husebø <torstein@huseboe.net>
 tpng <benny.tpng@gmail.com>
 Travis Cline <travis.cline@gmail.com>
 Trent Ogren <tedwardo2@gmail.com>
@@ -560,33 +671,43 @@ Victor Vieux <victor.vieux@docker.com>
 Viktor Vojnovski <viktor.vojnovski@amadeus.com>
 Vincent Batts <vbatts@redhat.com>
 Vincent Bernat <bernat@luffy.cx>
+Vincent Bernat <Vincent.Bernat@exoscale.ch>
+Vincent Giersch <vincent.giersch@ovh.net>
 Vincent Mayers <vincent.mayers@inbloom.org>
 Vincent Woo <me@vincentwoo.com>
 Vinod Kulkarni <vinod.kulkarni@gmail.com>
+Vishal Doshi <vishal.doshi@gmail.com>
 Vishnu Kannan <vishnuk@google.com>
 Vitor Monteiro <vmrmonteiro@gmail.com>
 Vivek Agarwal <me@vivek.im>
+Vivek Dasgupta <vdasgupt@redhat.com>
+Vivek Goyal <vgoyal@redhat.com>
 Vladimir Bulyga <xx@ccxx.cc>
 Vladimir Kirillov <proger@wilab.org.ua>
 Vladimir Rutsky <altsysrq@gmail.com>
+Vojtech Vitek (V-Teq) <vvitek@redhat.com>
 waitingkuo <waitingkuo0527@gmail.com>
 Walter Leibbrandt <github@wrl.co.za>
 Walter Stanish <walter@pratyeka.org>
+Ward Vandewege <ward@jhvc.com>
 WarheadsSE <max@warheads.net>
 Wes Morgan <cap10morgan@gmail.com>
 Will Dietz <w@wdtz.org>
-Will Rouesnel <w.rouesnel@gmail.com>
-Will Weaver <monkey@buildingbananas.com>
 William Delanoue <william.delanoue@gmail.com>
 William Henry <whenry@redhat.com>
 William Riancho <wr.wllm@gmail.com>
 William Thurston <thurstw@amazon.com>
+Will Rouesnel <w.rouesnel@gmail.com>
+Will Weaver <monkey@buildingbananas.com>
 wyc <wayne@neverfear.org>
 Xiuming Chen <cc@cxm.cc>
+xuzhaokui <cynicholas@gmail.com>
 Yang Bai <hamo.by@gmail.com>
 Yasunori Mahata <nori@mahata.net>
+Yohei Ueda <yohei@jp.ibm.com>
 Yurii Rashkovskii <yrashk@gmail.com>
 Zac Dover <zdover@redhat.com>
+Zach Borboa <zachborboa@gmail.com>
 Zain Memon <zain@inzain.net>
 Zaiste! <oh@zaiste.net>
 Zane DeGraffenried <zane.deg@gmail.com>
@@ -594,4 +715,4 @@ Zilin Du <zilin.du@gmail.com>
 zimbatm <zimbatm@zimbatm.com>
 Zoltan Tombol <zoltan.tombol@gmail.com>
 zqh <zqhxuyuan@gmail.com>
-Álvaro Lázaro <alvaro.lazaro.g@gmail.com>
+尹吉峰 <jifeng.yin@gmail.com>

--- a/project/generate-authors.sh
+++ b/project/generate-authors.sh
@@ -8,7 +8,7 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")/.."
 {
 	cat <<-'EOH'
 	# This file lists all individuals having contributed content to the repository.
-	# For how it is generated, see `hack/generate-authors.sh`.
+	# For how it is generated, see `project/generate-authors.sh`.
 	EOH
 	echo
 	git log --format='%aN <%aE>' | sort -uf


### PR DESCRIPTION
Raised by #9186: `AUTHORS` file was outdated, and generation script referred to the `hack` subdirectory which has now been renamed to `project`. Notice that a few people are listed more than once because of multiple email addresses used: I didn't clean them out, tell me if this is an issue.
