### PR TITLE
Fix for #8777 (continuing PR #9061)

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -47,6 +47,10 @@ const (
 	tarHeaderSize = 512
 )
 
+var (
+	acceptedImageFilterTags = map[string]struct{}{"dangling": {}}
+)
+
 func (cli *DockerCli) CmdHelp(args ...string) error {
 	if len(args) > 1 {
 		method, exists := cli.getMethod(args[:2]...)
@@ -1333,6 +1337,12 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 		imageFilterArgs, err = filters.ParseFlag(f, imageFilterArgs)
 		if err != nil {
 			return err
+		}
+	}
+
+	for name := range imageFilterArgs {
+		if _, ok := acceptedImageFilterTags[name]; !ok {
+			return fmt.Errorf("Invalid filter '%s'", name)
 		}
 	}
 

--- a/pkg/parsers/filters/parse.go
+++ b/pkg/parsers/filters/parse.go
@@ -29,7 +29,9 @@ func ParseFlag(arg string, prev Args) (Args, error) {
 	}
 
 	f := strings.SplitN(arg, "=", 2)
-	filters[f[0]] = append(filters[f[0]], f[1])
+	name := strings.ToLower(strings.TrimSpace(f[0]))
+	value := strings.TrimSpace(f[1])
+	filters[name] = append(filters[name], value)
 
 	return filters, nil
 }


### PR DESCRIPTION
Now filter name is trimmed and lowercased before evaluation for case
insensitive and whitespace trimemd check.

Fixes #8777

Signed-off-by: Oh Jinkyun tintypemolly@gmail.com
