### PR TITLE
Proposal: ENVFILE support in builder (#7688)

### DIFF
--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -70,6 +70,7 @@ func init() {
 		"volume":     volume,
 		"user":       user,
 		"insert":     insert,
+		"envfile":    envfile,
 	}
 }
 

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -692,3 +692,16 @@ func (b *Builder) clearTmp() {
 		fmt.Fprintf(b.OutStream, "Removing intermediate container %s\n", utils.TruncateID(c))
 	}
 }
+
+func (b *Builder) setEnvVar(name string, value string) {
+	fullEnv := fmt.Sprintf("%s=%s", name, value)
+
+	for i, envVar := range b.Config.Env {
+		envParts := strings.SplitN(envVar, "=", 2)
+		if name == envParts[0] {
+			b.Config.Env[i] = fullEnv
+			return
+		}
+	}
+	b.Config.Env = append(b.Config.Env, fullEnv)
+}

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -58,6 +58,7 @@ func init() {
 		"expose":     parseStringsWhitespaceDelimited,
 		"volume":     parseMaybeJSONToList,
 		"insert":     parseIgnore,
+		"envfile":    parseString,
 	}
 }
 


### PR DESCRIPTION
I implemented a feature discussed in #7688.

```
$ cat Dockerfile
FROM busybox
ENVFILE foo.txt
CMD echo $FOO $BAR
```

```
$ cat foo.txt
FOO=42
BAR=72
```

Small modification for `ParseEnvFile` function in `github.com/docker/docker/opts/envfile` was applied to support URL(remote file).
(So usage like `docker run --env-file="http://www.example.com/envfile"` is now possible)
I added some unit tests for ENVFILE as sample use cases.
