### PR TITLE
chnage LookupRemoteImage to return error

### DIFF
--- a/graph/push.go
+++ b/graph/push.go
@@ -117,7 +117,7 @@ func (s *TagStore) pushRepository(r *registry.Session, out io.Writer, localName,
 		out.Write(sf.FormatStatus("", "Pushing repository %s (%d tags)", localName, nTag))
 
 		for _, imgId := range imgList {
-			if r.LookupRemoteImage(imgId, ep, repoData.Tokens) {
+			if _, err := r.LookupRemoteImage(imgId, ep, repoData.Tokens); err != nil {
 				out.Write(sf.FormatStatus("", "Image %s already pushed, skipping", utils.TruncateID(imgId)))
 			} else {
 				if _, err := s.pushImage(r, out, remoteName, imgId, ep, repoData.Tokens, sf); err != nil {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -58,10 +58,14 @@ func TestGetRemoteHistory(t *testing.T) {
 
 func TestLookupRemoteImage(t *testing.T) {
 	r := spawnTestRegistrySession(t)
-	found := r.LookupRemoteImage(imageID, makeURL("/v1/"), token)
+	found, err := r.LookupRemoteImage(imageID, makeURL("/v1/"), token)
 	assertEqual(t, found, true, "Expected remote lookup to succeed")
-	found = r.LookupRemoteImage("abcdef", makeURL("/v1/"), token)
+	assertEqual(t, err, nil, "Expected error of remote lookup to nil")
+	found, err = r.LookupRemoteImage("abcdef", makeURL("/v1/"), token)
 	assertEqual(t, found, false, "Expected remote lookup to fail")
+	if err == nil {
+		t.Fatal("Expected error of remote lookup to not nil")
+	}
 }
 
 func TestGetRemoteImageJSON(t *testing.T) {

--- a/registry/session.go
+++ b/registry/session.go
@@ -102,22 +102,26 @@ func (r *Session) GetRemoteHistory(imgID, registry string, token []string) ([]st
 }
 
 // Check if an image exists in the Registry
-// TODO: This method should return the errors instead of masking them and returning false
-func (r *Session) LookupRemoteImage(imgID, registry string, token []string) bool {
+func (r *Session) LookupRemoteImage(imgID, registry string, token []string) (bool, error) {
 
 	req, err := r.reqFactory.NewRequest("GET", registry+"images/"+imgID+"/json", nil)
 	if err != nil {
 		log.Errorf("Error in LookupRemoteImage %s", err)
-		return false
+		return false, err
 	}
 	setTokenAuth(req, token)
 	res, _, err := r.doRequest(req)
 	if err != nil {
 		log.Errorf("Error in LookupRemoteImage %s", err)
-		return false
+		return false, err
 	}
 	res.Body.Close()
-	return res.StatusCode == 200
+
+	if res.StatusCode != 200 {
+		return false, utils.NewHTTPRequestError(fmt.Sprintf("HTTP code %d", res.StatusCode), res)
+	}
+
+	return true, nil
 }
 
 // Retrieve an image from the Registry.


### PR DESCRIPTION
This commit is patch for following comment
// TODO: This method should return the errors instead of masking them and returning false

Signed-off-by: Daehyeok Mun daehyeok@gmail.com
