### PR TITLE
Use SYS_SETUID32 for system.Setuid() on Linux for ARM

### DIFF
--- a/vendor/src/github.com/docker/libcontainer/system/syscall_linux_arm.go
+++ b/vendor/src/github.com/docker/libcontainer/system/syscall_linux_arm.go
@@ -7,7 +7,7 @@ import (
 
 // Setuid sets the uid of the calling thread to the specified uid.
 func Setuid(uid int) (err error) {
-	_, _, e1 := syscall.RawSyscall(syscall.SYS_SETUID, uintptr(uid), 0, 0)
+	_, _, e1 := syscall.RawSyscall(syscall.SYS_SETUID32, uintptr(uid), 0, 0)
 	if e1 != 0 {
 		err = e1
 	}


### PR DESCRIPTION
Besides possible other problems 16bit UIDs might be disabled by the kernel
configuration on Linux for ARM.

Signed-off-by: Alexander Holler holler@ahsoftware.de
