### PR TITLE
Libtrust key function

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -3,12 +3,15 @@ package api
 import (
 	"fmt"
 	"mime"
+	"os"
+	"path"
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/version"
+	"github.com/docker/libtrust"
 )
 
 const (
@@ -46,4 +49,26 @@ func MatchesContentType(contentType, expectedType string) bool {
 		log.Errorf("Error parsing media type: %s error: %s", contentType, err.Error())
 	}
 	return err == nil && mimetype == expectedType
+}
+
+// LoadOrCreateTrustKey attempts to load the libtrust key at the given path,
+// otherwise generates a new one
+func LoadOrCreateTrustKey(trustKeyPath string) (libtrust.PrivateKey, error) {
+	err := os.MkdirAll(path.Dir(trustKeyPath), 0700)
+	if err != nil {
+		return nil, err
+	}
+	trustKey, err := libtrust.LoadKeyFile(trustKeyPath)
+	if err == libtrust.ErrKeyFileDoesNotExist {
+		trustKey, err = libtrust.GenerateECP256PrivateKey()
+		if err != nil {
+			return nil, fmt.Errorf("Error generating key: %s", err)
+		}
+		if err := libtrust.SaveKey(trustKeyPath, trustKey); err != nil {
+			return nil, fmt.Errorf("Error saving key file: %s", err)
+		}
+	} else if err != nil {
+		return nil, fmt.Errorf("Error loading key file: %s", err)
+	}
+	return trustKey, nil
 }

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -85,6 +85,7 @@ func mainDaemon() {
 	job.Setenv("TlsCa", *flCa)
 	job.Setenv("TlsCert", *flCert)
 	job.Setenv("TlsKey", *flKey)
+	job.Setenv("TrustKey", *flTrustKey)
 	job.SetenvBool("BufferRequests", true)
 	if err := job.Run(); err != nil {
 		log.Fatal(err)

--- a/project/vendor.sh
+++ b/project/vendor.sh
@@ -51,7 +51,7 @@ clone hg code.google.com/p/go.net 84a4013f96e0
 
 clone hg code.google.com/p/gosqlite 74691fb6f837
 
-clone git github.com/docker/libtrust d273ef2565ca
+clone git github.com/docker/libtrust 230dfd18c232
 
 clone git github.com/Sirupsen/logrus v0.6.0
 

--- a/vendor/src/github.com/docker/libtrust/ec_key.go
+++ b/vendor/src/github.com/docker/libtrust/ec_key.go
@@ -55,16 +55,7 @@ func (k *ecPublicKey) CurveName() string {
 
 // KeyID returns a distinct identifier which is unique to this Public Key.
 func (k *ecPublicKey) KeyID() string {
-	// Generate and return a libtrust fingerprint of the EC public key.
-	// For an EC key this should be:
-	//   SHA256("EC"+curveName+bytes(X)+bytes(Y))
-	// Then truncated to 240 bits and encoded into 12 base32 groups like so:
-	//   ABCD:EFGH:IJKL:MNOP:QRST:UVWX:YZ23:4567:ABCD:EFGH:IJKL:MNOP
-	hasher := crypto.SHA256.New()
-	hasher.Write([]byte(k.KeyType() + k.CurveName()))
-	hasher.Write(k.X.Bytes())
-	hasher.Write(k.Y.Bytes())
-	return keyIDEncode(hasher.Sum(nil)[:30])
+	return keyIDFromCryptoKey(k)
 }
 
 func (k *ecPublicKey) String() string {

--- a/vendor/src/github.com/docker/libtrust/filter_test.go
+++ b/vendor/src/github.com/docker/libtrust/filter_test.go
@@ -27,6 +27,8 @@ func TestFilter(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// we use both []interface{} and []string here because jwt uses
+		// []interface{} format, while PEM uses []string
 		switch {
 		case i == 0:
 			// Don't add entries for this key, key 0.
@@ -36,10 +38,10 @@ func TestFilter(t *testing.T) {
 			key.AddExtendedField("hosts", []interface{}{"*.even.example.com"})
 		case i == 7:
 			// Should catch only the last key, and make it match any hostname.
-			key.AddExtendedField("hosts", []interface{}{"*"})
+			key.AddExtendedField("hosts", []string{"*"})
 		default:
 			// should catch keys 1, 3, 5.
-			key.AddExtendedField("hosts", []interface{}{"*.example.com"})
+			key.AddExtendedField("hosts", []string{"*.example.com"})
 		}
 
 		keys = append(keys, key)

--- a/vendor/src/github.com/docker/libtrust/key_files_test.go
+++ b/vendor/src/github.com/docker/libtrust/key_files_test.go
@@ -138,7 +138,7 @@ func testTrustedHostKeysFile(t *testing.T, trustedHostKeysFilename string) {
 	}
 
 	for addr, hostKey := range trustedHostKeysMapping {
-		t.Logf("Host Address: %s\n", addr)
+		t.Logf("Host Address: %d\n", addr)
 		t.Logf("Host Key: %s\n\n", hostKey)
 	}
 
@@ -160,7 +160,7 @@ func testTrustedHostKeysFile(t *testing.T, trustedHostKeysFilename string) {
 	}
 
 	for addr, hostKey := range trustedHostKeysMapping {
-		t.Logf("Host Address: %s\n", addr)
+		t.Logf("Host Address: %d\n", addr)
 		t.Logf("Host Key: %s\n\n", hostKey)
 	}
 

--- a/vendor/src/github.com/docker/libtrust/rsa_key.go
+++ b/vendor/src/github.com/docker/libtrust/rsa_key.go
@@ -34,16 +34,7 @@ func (k *rsaPublicKey) KeyType() string {
 
 // KeyID returns a distinct identifier which is unique to this Public Key.
 func (k *rsaPublicKey) KeyID() string {
-	// Generate and return a 'libtrust' fingerprint of the RSA public key.
-	// For an RSA key this should be:
-	//   SHA256("RSA"+bytes(N)+bytes(E))
-	// Then truncated to 240 bits and encoded into 12 base32 groups like so:
-	//   ABCD:EFGH:IJKL:MNOP:QRST:UVWX:YZ23:4567:ABCD:EFGH:IJKL:MNOP
-	hasher := crypto.SHA256.New()
-	hasher.Write([]byte(k.KeyType()))
-	hasher.Write(k.N.Bytes())
-	hasher.Write(serializeRSAPublicExponentParam(k.E))
-	return keyIDEncode(hasher.Sum(nil)[:30])
+	return keyIDFromCryptoKey(k)
 }
 
 func (k *rsaPublicKey) String() string {

--- a/vendor/src/github.com/docker/libtrust/trustgraph/statement_test.go
+++ b/vendor/src/github.com/docker/libtrust/trustgraph/statement_test.go
@@ -201,7 +201,7 @@ func TestCollapseGrants(t *testing.T) {
 
 	collapsedGrants, expiration, err := CollapseStatements(statements, false)
 	if len(collapsedGrants) != 12 {
-		t.Fatalf("Unexpected number of grants\n\tExpected: %d\n\tActual: %s", 12, len(collapsedGrants))
+		t.Fatalf("Unexpected number of grants\n\tExpected: %d\n\tActual: %d", 12, len(collapsedGrants))
 	}
 	if expiration.After(time.Now().Add(time.Hour*5)) || expiration.Before(time.Now()) {
 		t.Fatalf("Unexpected expiration time: %s", expiration.String())
@@ -261,7 +261,7 @@ func TestCollapseGrants(t *testing.T) {
 
 	collapsedGrants, expiration, err = CollapseStatements(statements, false)
 	if len(collapsedGrants) != 12 {
-		t.Fatalf("Unexpected number of grants\n\tExpected: %d\n\tActual: %s", 12, len(collapsedGrants))
+		t.Fatalf("Unexpected number of grants\n\tExpected: %d\n\tActual: %d", 12, len(collapsedGrants))
 	}
 	if expiration.After(time.Now().Add(time.Hour*5)) || expiration.Before(time.Now()) {
 		t.Fatalf("Unexpected expiration time: %s", expiration.String())

--- a/vendor/src/github.com/docker/libtrust/util_test.go
+++ b/vendor/src/github.com/docker/libtrust/util_test.go
@@ -1,0 +1,23 @@
+package libtrust
+
+import (
+	"encoding/pem"
+	"reflect"
+	"testing"
+)
+
+func TestAddPEMHeadersToKey(t *testing.T) {
+	pk := &rsaPublicKey{nil, map[string]interface{}{}}
+	blk := &pem.Block{Headers: map[string]string{"hosts": "localhost,127.0.0.1"}}
+	addPEMHeadersToKey(blk, pk)
+
+	val := pk.GetExtendedField("hosts")
+	hosts, ok := val.([]string)
+	if !ok {
+		t.Fatalf("hosts type(%v), expected []string", reflect.TypeOf(val))
+	}
+	expected := []string{"localhost", "127.0.0.1"}
+	if !reflect.DeepEqual(hosts, expected) {
+		t.Errorf("hosts(%v), expected %v", hosts, expected)
+	}
+}


### PR DESCRIPTION
This PR adds a function for loading or creating the libtrust key.  This key function will be needed for changes related to identity-based TLS, provenance, and clustering.  The libtrust update contains changes related to using a standard method for generating the fingerprint.  It is important that any libtrust fingerprints use a standard method for generation to ensure key IDs may be matched across versions.

Example server usage to print the key ID

```
trustKey, _ := api.LoadOrCreateTrustKey(job.Getenv("TrustKey"))
fmt.Println(trustKey.KeyID())
```

Related to #8265
