### PR TITLE
fix link to PACKAGERS.md

### DIFF
--- a/docs/sources/contributing/contributing.md
+++ b/docs/sources/contributing/contributing.md
@@ -21,4 +21,4 @@ https://github.com/docker/docker/blob/master/docs/Dockerfile)
 specifies the tools and versions used to build the Documentation.
 
 Further interesting details can be found in the [Packaging hints](
-https://github.com/docker/docker/blob/master/hack/PACKAGERS.md).
+https://github.com/docker/docker/blob/master/project/PACKAGERS.md).


### PR DESCRIPTION
fix link from /hack/PACKAGERS.md to /project/PACKAGERS.md

Signed-off-by: Daehyeok Mun daehyeok@gmail.com
