### PR TITLE
Fix for rmi throws error "no such id".

### DIFF
--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -133,6 +133,9 @@ func (daemon *Daemon) canDeleteImage(imgID string, force bool) error {
 	for _, container := range daemon.List() {
 		parent, err := daemon.Repositories().LookupImage(container.Image)
 		if err != nil {
+			if daemon.Graph().IsNotExist(err) {
+				return nil
+			}
 			return err
 		}
 

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -99,3 +99,23 @@ func TestRmiTagWithExistingContainers(t *testing.T) {
 
 	logDone("rmi - delete tag with existing containers")
 }
+
+func TestRmiForceWithExistingContainers(t *testing.T) {
+	image := "busybox-clone"
+	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "build", "--no-cache", "-t", image, "/docker-busybox")); err != nil {
+		t.Fatalf("Could not build %s: %s, %v", image, out, err)
+	}
+
+	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "--name", "test-force-rmi", image, "/bin/true")); err != nil {
+		t.Fatalf("Could not run container: %s, %v", out, err)
+	}
+
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "rmi", "-f", image))
+	if err != nil {
+		t.Fatalf("Could not remove image %s:  %s, %v", image, out, err)
+	}
+
+	deleteAllContainers()
+
+	logDone("rmi - force delete with existing containers")
+}


### PR DESCRIPTION
Closes #9056. Also closes #9170. Thanks @coolljt0725 for the start!
Includes integration-cli test, I am not necessarily in love with, but it is necessary evil. :smiling_imp: 
