### PR TITLE
overlayfs: more helpful output when not supported

### DIFF
--- a/daemon/graphdriver/overlayfs/overlayfs.go
+++ b/daemon/graphdriver/overlayfs/overlayfs.go
@@ -129,6 +129,7 @@ func supportsOverlayfs() error {
 			return nil
 		}
 	}
+	log.Error("'overlayfs' not found as a supported filesystem on this host. Please ensure kernel is new enough and has overlayfs support loaded.")
 	return graphdriver.ErrNotSupported
 }
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -156,7 +156,7 @@ string is equivalent to setting the `--tlsverify` flag. The following are equiva
 ### Daemon storage-driver option
 
 The Docker daemon has support for three different image layer storage drivers: `aufs`,
-`devicemapper`, and `btrfs`.
+`devicemapper`, `btrfs` and `overlayfs`.
 
 The `aufs` driver is the oldest, but is based on a Linux kernel patch-set that
 is unlikely to be merged into the main kernel. These are also known to cause some
@@ -175,6 +175,9 @@ To tell the Docker daemon to use `devicemapper`, use
 The `btrfs` driver is very fast for `docker build` - but like `devicemapper` does not
 share executable memory between devices. Use `docker -d -s btrfs -g /mnt/btrfs_partition`.
 
+The `overlayfs` is a very fast union filesystem. It is now merged in the main
+Linux kernel as of [3.18.0](https://lkml.org/lkml/2014/10/26/137).
+Call `docker -d -s overlayfs` to use it.
 
 ### Docker exec-driver option
 


### PR DESCRIPTION
based on https://github.com/docker/docker/pull/7619#discussion_r20385086

```
INFO[0000] +job serveapi(unix:///var/run/docker.sock)
INFO[0000] Listening for HTTP on unix (/var/run/docker.sock)
ERRO[0000] 'overlayfs' not found as a supported filesystem
FATA[0000] driver not supported
```

Signed-off-by: Vincent Batts vbatts@hashbangbash.com
