### PR TITLE
Adapt project/make.sh for Windows builds

### DIFF
--- a/project/make.sh
+++ b/project/make.sh
@@ -101,6 +101,10 @@ LDFLAGS='
 	-X '$DOCKER_PKG'/dockerversion.VERSION "'$VERSION'"
 '
 LDFLAGS_STATIC='-linkmode external'
+# Cgo -H windows is incompatible with -linkmode external.
+if [ "$(go env GOOS)" == 'windows' ]; then
+	LDFLAGS_STATIC=''
+fi
 EXTLDFLAGS_STATIC='-static'
 # ORIG_BUILDFLAGS is necessary for the cross target which cannot always build
 # with options like -race.
@@ -215,7 +219,7 @@ bundle() {
 	bundle=$(basename $bundlescript)
 	echo "---> Making bundle: $bundle (in bundles/$VERSION/$bundle)"
 	mkdir -p bundles/$VERSION/$bundle
-	source $bundlescript $(pwd)/bundles/$VERSION/$bundle
+	source "$bundlescript" "$(pwd)/bundles/$VERSION/$bundle"
 }
 
 main() {

--- a/project/make/binary
+++ b/project/make/binary
@@ -3,19 +3,26 @@ set -e
 
 DEST=$1
 BINARY_NAME="docker-$VERSION"
+BINARY_EXTENSION=
 if [ "$(go env GOOS)" = 'windows' ]; then
-	BINARY_NAME+='.exe'
+	BINARY_EXTENSION='.exe'
+fi
+BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
+
+# Cygdrive paths don't play well with go build -o.
+if [[ "$(uname -s)" == CYGWIN* ]]; then
+	DEST=$(cygpath -mw $DEST)
 fi
 
 go build \
-	-o "$DEST/$BINARY_NAME" \
+	-o "$DEST/$BINARY_FULLNAME" \
 	"${BUILDFLAGS[@]}" \
 	-ldflags "
 		$LDFLAGS
 		$LDFLAGS_STATIC_DOCKER
 	" \
 	./docker
-echo "Created binary: $DEST/$BINARY_NAME"
-ln -sf "$BINARY_NAME" "$DEST/docker"
+echo "Created binary: $DEST/$BINARY_FULLNAME"
+ln -sf "$BINARY_FULLNAME" "$DEST/docker$BINARY_EXTENSION"
 
-hash_files "$DEST/$BINARY_NAME"
+hash_files "$DEST/$BINARY_FULLNAME"


### PR DESCRIPTION
Fixes:
- link `-H windows` is not compatible with `-linkmode external`
- under Cygwin go does not play well with cygdrive type paths (i.e.: `/cygdrive/e/src/...`)

These issues were encountered while examining the required work for proper integration tests on client only platforms (#9217).
