### PR TITLE
Fix to avoid a compile error due to float to int truncation with GCCGO

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1052,7 +1052,7 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 			} else {
 				fmt.Fprintf(w, "%s\t", utils.Trunc(out.Get("CreatedBy"), 45))
 			}
-			fmt.Fprintf(w, "%s\n", units.HumanSize(out.GetInt64("Size")))
+			fmt.Fprintf(w, "%s\n", units.HumanSize(float64(out.GetInt64("Size"))))
 		} else {
 			if *noTrunc {
 				fmt.Fprintln(w, outID)
@@ -1451,7 +1451,7 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 				}
 
 				if !*quiet {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\t%s\n", repo, tag, outID, units.HumanDuration(time.Now().UTC().Sub(time.Unix(out.GetInt64("Created"), 0))), units.HumanSize(out.GetInt64("VirtualSize")))
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\t%s\n", repo, tag, outID, units.HumanDuration(time.Now().UTC().Sub(time.Unix(out.GetInt64("Created"), 0))), units.HumanSize(float64(out.GetInt64("VirtualSize"))))
 				} else {
 					fmt.Fprintln(w, outID)
 				}
@@ -1525,7 +1525,7 @@ func (cli *DockerCli) printTreeNode(noTrunc bool, image *engine.Env, prefix stri
 		imageID = utils.TruncateID(image.Get("Id"))
 	}
 
-	fmt.Fprintf(cli.out, "%s%s Virtual Size: %s", prefix, imageID, units.HumanSize(image.GetInt64("VirtualSize")))
+	fmt.Fprintf(cli.out, "%s%s Virtual Size: %s", prefix, imageID, units.HumanSize(float64(image.GetInt64("VirtualSize"))))
 	if image.GetList("RepoTags")[0] != "<none>:<none>" {
 		fmt.Fprintf(cli.out, " Tags: %s\n", strings.Join(image.GetList("RepoTags"), ", "))
 	} else {
@@ -1668,9 +1668,9 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 
 		if *size {
 			if out.GetInt("SizeRootFs") > 0 {
-				fmt.Fprintf(w, "%s (virtual %s)\n", units.HumanSize(out.GetInt64("SizeRw")), units.HumanSize(out.GetInt64("SizeRootFs")))
+				fmt.Fprintf(w, "%s (virtual %s)\n", units.HumanSize(float64(out.GetInt64("SizeRw"))), units.HumanSize(float64(out.GetInt64("SizeRootFs"))))
 			} else {
-				fmt.Fprintf(w, "%s\n", units.HumanSize(out.GetInt64("SizeRw")))
+				fmt.Fprintf(w, "%s\n", units.HumanSize(float64(out.GetInt64("SizeRw"))))
 			}
 
 			continue

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -56,13 +56,13 @@ func (d *Driver) Status() [][2]string {
 
 	status := [][2]string{
 		{"Pool Name", s.PoolName},
-		{"Pool Blocksize", fmt.Sprintf("%s", units.HumanSize(int64(s.SectorSize)))},
+		{"Pool Blocksize", fmt.Sprintf("%s", units.HumanSize(float64(s.SectorSize)))},
 		{"Data file", s.DataLoopback},
 		{"Metadata file", s.MetadataLoopback},
-		{"Data Space Used", fmt.Sprintf("%s", units.HumanSize(int64(s.Data.Used)))},
-		{"Data Space Total", fmt.Sprintf("%s", units.HumanSize(int64(s.Data.Total)))},
-		{"Metadata Space Used", fmt.Sprintf("%s", units.HumanSize(int64(s.Metadata.Used)))},
-		{"Metadata Space Total", fmt.Sprintf("%s", units.HumanSize(int64(s.Metadata.Total)))},
+		{"Data Space Used", fmt.Sprintf("%s", units.HumanSize(float64(s.Data.Used)))},
+		{"Data Space Total", fmt.Sprintf("%s", units.HumanSize(float64(s.Data.Total)))},
+		{"Metadata Space Used", fmt.Sprintf("%s", units.HumanSize(float64(s.Metadata.Used)))},
+		{"Metadata Space Total", fmt.Sprintf("%s", units.HumanSize(float64(s.Metadata.Total)))},
 	}
 	if vStr, err := devicemapper.GetLibraryVersion(); err == nil {
 		status = append(status, [2]string{"Library Version", vStr})

--- a/pkg/units/size.go
+++ b/pkg/units/size.go
@@ -39,7 +39,7 @@ var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB",
 
 // HumanSize returns a human-readable approximation of a size
 // using SI standard (eg. "44kB", "17MB")
-func HumanSize(size int64) string {
+func HumanSize(size float64) string {
 	return intToString(float64(size), 1000.0, decimapAbbrs)
 }
 

--- a/pkg/units/size_test.go
+++ b/pkg/units/size_test.go
@@ -23,9 +23,9 @@ func TestHumanSize(t *testing.T) {
 	assertEquals(t, "1 MB", HumanSize(1000000))
 	assertEquals(t, "1.049 MB", HumanSize(1048576))
 	assertEquals(t, "2 MB", HumanSize(2*MB))
-	assertEquals(t, "3.42 GB", HumanSize(3.42*GB))
-	assertEquals(t, "5.372 TB", HumanSize(5.372*TB))
-	assertEquals(t, "2.22 PB", HumanSize(2.22*PB))
+	assertEquals(t, "3.42 GB", HumanSize(int64(float64(3.42*GB))))
+	assertEquals(t, "5.372 TB", HumanSize(int64(float64(5.372*TB))))
+	assertEquals(t, "2.22 PB", HumanSize(int64(float64(2.22*PB))))
 }
 
 func TestFromHumanSize(t *testing.T) {

--- a/pkg/units/size_test.go
+++ b/pkg/units/size_test.go
@@ -23,9 +23,9 @@ func TestHumanSize(t *testing.T) {
 	assertEquals(t, "1 MB", HumanSize(1000000))
 	assertEquals(t, "1.049 MB", HumanSize(1048576))
 	assertEquals(t, "2 MB", HumanSize(2*MB))
-	assertEquals(t, "3.42 GB", HumanSize(int64(float64(3.42*GB))))
-	assertEquals(t, "5.372 TB", HumanSize(int64(float64(5.372*TB))))
-	assertEquals(t, "2.22 PB", HumanSize(int64(float64(2.22*PB))))
+	assertEquals(t, "3.42 GB", HumanSize(3.42*GB))
+	assertEquals(t, "5.372 TB", HumanSize(5.372*TB))
+	assertEquals(t, "2.22 PB", HumanSize(2.22*PB))
 }
 
 func TestFromHumanSize(t *testing.T) {

--- a/utils/jsonmessage.go
+++ b/utils/jsonmessage.go
@@ -44,11 +44,11 @@ func (p *JSONProgress) String() string {
 	if p.Current <= 0 && p.Total <= 0 {
 		return ""
 	}
-	current := units.HumanSize(int64(p.Current))
+	current := units.HumanSize(float64(p.Current))
 	if p.Total <= 0 {
 		return fmt.Sprintf("%8v", current)
 	}
-	total := units.HumanSize(int64(p.Total))
+	total := units.HumanSize(float64(p.Total))
 	percentage := int(float64(p.Current)/float64(p.Total)*100) / 2
 	if width > 110 {
 		// this number can't be negetive gh#7136


### PR DESCRIPTION
The unit test `pkg/units/size_test.go` fails with GCCGO due to a compilation error:

```
inagaki@black3:~/upstream/src/github.com/docker/docker/pkg/units$ go version
go version gccgo (GCC) 5.0.0 20141029 (experimental) linux/amd64
inagaki@black3:~/upstream/src/github.com/docker/docker/pkg/units$ go test
# _/home/inagaki/upstream/src/github.com/docker/docker/pkg/units
./size_test.go:28:43: error: floating point constant truncated to integer
  assertEquals(t, "2.22 PB", HumanSize(2.22*PB))
                                           ^
FAIL    _/home/inagaki/upstream/src/github.com/docker/docker/pkg/units [build failed]
inagaki@black3:~/upstream/src/github.com/docker/docker/pkg/units$
```

According to [the discussion on GCC Bugzilla](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63812#c3), this is due to the difference between GCCGO and GC in the implementations of floating point constant expression. The [language](http://golang.org/ref/spec#Constant_expressions) specifies that a compiler raises an error when a floating point constant expression is truncated to integer, a precision of the internal representation is implementation-dependent. While my workaround is modifying `size_test.go` as:

```
assertEquals(t, "2.22 PB", HumanSize(int64(float64(2.22*PB))))
```

, is it better to modify the parameter of `HumanSize()` from `int64` to `float64` like `BytesSize()`?
Signed-off-by: Tatsushi Inagaki e29253@jp.ibm.com
