### PR TITLE
Proposal: Add "OOM killed" event based on OOM state information

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -154,6 +154,9 @@ func (m *containerMonitor) Start() error {
 
 		if m.shouldRestart(exitStatus.ExitCode) {
 			m.container.SetRestarting(&exitStatus)
+			if exitStatus.OOMKilled {
+				m.container.LogEvent("oom")
+			}
 			m.container.LogEvent("die")
 			m.resetContainer(true)
 
@@ -170,6 +173,9 @@ func (m *containerMonitor) Start() error {
 			continue
 		}
 		m.container.ExitCode = exitStatus.ExitCode
+		if exitStatus.OOMKilled {
+			m.container.LogEvent("oom")
+		}
 		m.container.LogEvent("die")
 		m.resetContainer(true)
 		return err

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -1375,7 +1375,7 @@ polling (using since).
 
 Docker containers will report the following events:
 
-    create, destroy, die, export, kill, pause, restart, start, stop, unpause
+    create, destroy, die, export, kill, oom, pause, restart, start, stop, unpause
 
 and Docker images will report:
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -761,7 +761,7 @@ For example:
 
 Docker containers will report the following events:
 
-    create, destroy, die, export, kill, pause, restart, start, stop, unpause
+    create, destroy, die, export, kill, oom, pause, restart, start, stop, unpause
 
 and Docker images will report:
 


### PR DESCRIPTION
Currently, libcontainer supports the proper cgroups method (using eventfd) to get OOM notification when memory constraints are used with a container.  This information makes its way all the way back into the container ExitStatus object (see https://github.com/docker/docker/blob/master/daemon/execdriver/native/driver.go#L164) which is received by the container monitor (see https://github.com/docker/docker/blob/master/daemon/monitor.go#L137) , but a gap exists in that the OOM information isn't reflected back into the container `State`, only the exit code: https://github.com/docker/docker/blob/master/daemon/monitor.go#L172-L173

This proposal would add the OOM exited boolean as well as a `LogEvent` call for a new event, `"oom"` (or another name, if preferable.. `"oomkill"`, `"oomdie"`, ?
