### PR TITLE
Make sure integration-cli tests clean up

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -39,6 +39,7 @@ func TestBuildShCmdJSONEntrypoint(t *testing.T) {
 		exec.Command(
 			dockerBinary,
 			"run",
+			"--rm",
 			name))
 
 	if err != nil {
@@ -263,6 +264,8 @@ func TestBuildHandleEscapes(t *testing.T) {
 		t.Fatal("Could not find volume bar set from env foo in volumes table")
 	}
 
+	deleteImages(name)
+
 	_, err = buildImage(name,
 		`
   FROM scratch
@@ -286,6 +289,8 @@ func TestBuildHandleEscapes(t *testing.T) {
 	if _, ok := result["${FOO}"]; !ok {
 		t.Fatal("Could not find volume ${FOO} set from env foo in volumes table")
 	}
+
+	deleteImages(name)
 
 	// this test in particular provides *7* backslashes and expects 6 to come back.
 	// Like above, the first escape is swallowed and the rest are treated as
@@ -355,8 +360,8 @@ func TestBuildOnBuildLowercase(t *testing.T) {
 
 func TestBuildEnvEscapes(t *testing.T) {
 	name := "testbuildenvescapes"
-	defer deleteAllContainers()
 	defer deleteImages(name)
+	defer deleteAllContainers()
 	_, err := buildImage(name,
 		`
     FROM busybox
@@ -380,8 +385,8 @@ func TestBuildEnvEscapes(t *testing.T) {
 
 func TestBuildEnvOverwrite(t *testing.T) {
 	name := "testbuildenvoverwrite"
-	defer deleteAllContainers()
 	defer deleteImages(name)
+	defer deleteAllContainers()
 
 	_, err := buildImage(name,
 		`
@@ -410,7 +415,10 @@ func TestBuildEnvOverwrite(t *testing.T) {
 
 func TestBuildOnBuildForbiddenMaintainerInSourceImage(t *testing.T) {
 	name := "testbuildonbuildforbiddenmaintainerinsourceimage"
+	defer deleteImages("onbuild")
 	defer deleteImages(name)
+	defer deleteAllContainers()
+
 	createCmd := exec.Command(dockerBinary, "create", "busybox", "true")
 	out, _, _, err := runCommandWithStdoutStderr(createCmd)
 	if err != nil {
@@ -441,7 +449,10 @@ func TestBuildOnBuildForbiddenMaintainerInSourceImage(t *testing.T) {
 
 func TestBuildOnBuildForbiddenFromInSourceImage(t *testing.T) {
 	name := "testbuildonbuildforbiddenfrominsourceimage"
+	defer deleteImages("onbuild")
 	defer deleteImages(name)
+	defer deleteAllContainers()
+
 	createCmd := exec.Command(dockerBinary, "create", "busybox", "true")
 	out, _, _, err := runCommandWithStdoutStderr(createCmd)
 	if err != nil {
@@ -472,7 +483,10 @@ func TestBuildOnBuildForbiddenFromInSourceImage(t *testing.T) {
 
 func TestBuildOnBuildForbiddenChainedInSourceImage(t *testing.T) {
 	name := "testbuildonbuildforbiddenchainedinsourceimage"
+	defer deleteImages("onbuild")
 	defer deleteImages(name)
+	defer deleteAllContainers()
+
 	createCmd := exec.Command(dockerBinary, "create", "busybox", "true")
 	out, _, _, err := runCommandWithStdoutStderr(createCmd)
 	if err != nil {
@@ -505,9 +519,9 @@ func TestBuildOnBuildCmdEntrypointJSON(t *testing.T) {
 	name1 := "onbuildcmd"
 	name2 := "onbuildgenerated"
 
-	defer deleteAllContainers()
 	defer deleteImages(name2)
 	defer deleteImages(name1)
+	defer deleteAllContainers()
 
 	_, err := buildImage(name1, `
 FROM busybox
@@ -542,9 +556,9 @@ func TestBuildOnBuildEntrypointJSON(t *testing.T) {
 	name1 := "onbuildcmd"
 	name2 := "onbuildgenerated"
 
-	defer deleteAllContainers()
 	defer deleteImages(name2)
 	defer deleteImages(name1)
+	defer deleteAllContainers()
 
 	_, err := buildImage(name1, `
 FROM busybox
@@ -590,6 +604,10 @@ func TestBuildCacheADD(t *testing.T) {
 		true); err != nil {
 		t.Fatal(err)
 	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	deleteImages(name)
 	_, out, err := buildImageWithOut(name,
 		fmt.Sprintf(`FROM scratch
 		ADD %s/index.html /`, server.URL),
@@ -1314,9 +1332,12 @@ func TestBuildWithInaccessibleFilesInContext(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer ctx.Close()
-		if err := os.Symlink(filepath.Join(ctx.Dir, "g"), "../../../../../../../../../../../../../../../../../../../azA"); err != nil {
+
+		target := "../../../../../../../../../../../../../../../../../../../azA"
+		if err := os.Symlink(filepath.Join(ctx.Dir, "g"), target); err != nil {
 			t.Fatal(err)
 		}
+		defer os.Remove(target)
 		// This is used to ensure we don't follow links when checking if everything in the context is accessible
 		// This test doesn't require that we run commands as an unprivileged user
 		if _, err := buildImageFromContext(name, ctx, true); err != nil {
@@ -1668,6 +1689,7 @@ func TestBuildContextCleanup(t *testing.T) {
 func TestBuildContextCleanupFailedBuild(t *testing.T) {
 	name := "testbuildcontextcleanup"
 	defer deleteImages(name)
+	defer deleteAllContainers()
 	entries, err := ioutil.ReadDir("/var/lib/docker/tmp")
 	if err != nil {
 		t.Fatalf("failed to list contents of tmp dir: %s", err)
@@ -1919,7 +1941,8 @@ func TestBuildWithCache(t *testing.T) {
 
 func TestBuildWithoutCache(t *testing.T) {
 	name := "testbuildwithoutcache"
-	defer deleteImages(name)
+	name2 := "testbuildwithoutcache2"
+	defer deleteImages(name, name2)
 	id1, err := buildImage(name,
 		`FROM scratch
 		MAINTAINER dockerio
@@ -1929,7 +1952,8 @@ func TestBuildWithoutCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	id2, err := buildImage(name,
+
+	id2, err := buildImage(name2,
 		`FROM scratch
 		MAINTAINER dockerio
 		EXPOSE 5432
@@ -1946,7 +1970,8 @@ func TestBuildWithoutCache(t *testing.T) {
 
 func TestBuildADDLocalFileWithCache(t *testing.T) {
 	name := "testbuildaddlocalfilewithcache"
-	defer deleteImages(name)
+	name2 := "testbuildaddlocalfilewithcache2"
+	defer deleteImages(name, name2)
 	dockerfile := `
 		FROM busybox
         MAINTAINER dockerio
@@ -1963,7 +1988,7 @@ func TestBuildADDLocalFileWithCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name, ctx, true)
+	id2, err := buildImageFromContext(name2, ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1975,7 +2000,8 @@ func TestBuildADDLocalFileWithCache(t *testing.T) {
 
 func TestBuildADDMultipleLocalFileWithCache(t *testing.T) {
 	name := "testbuildaddmultiplelocalfilewithcache"
-	defer deleteImages(name)
+	name2 := "testbuildaddmultiplelocalfilewithcache2"
+	defer deleteImages(name, name2)
 	dockerfile := `
 		FROM busybox
         MAINTAINER dockerio
@@ -1992,7 +2018,7 @@ func TestBuildADDMultipleLocalFileWithCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name, ctx, true)
+	id2, err := buildImageFromContext(name2, ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2004,7 +2030,8 @@ func TestBuildADDMultipleLocalFileWithCache(t *testing.T) {
 
 func TestBuildADDLocalFileWithoutCache(t *testing.T) {
 	name := "testbuildaddlocalfilewithoutcache"
-	defer deleteImages(name)
+	name2 := "testbuildaddlocalfilewithoutcache2"
+	defer deleteImages(name, name2)
 	dockerfile := `
 		FROM busybox
         MAINTAINER dockerio
@@ -2021,7 +2048,7 @@ func TestBuildADDLocalFileWithoutCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name, ctx, false)
+	id2, err := buildImageFromContext(name2, ctx, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2033,7 +2060,8 @@ func TestBuildADDLocalFileWithoutCache(t *testing.T) {
 
 func TestBuildCopyDirButNotFile(t *testing.T) {
 	name := "testbuildcopydirbutnotfile"
-	defer deleteImages(name)
+	name2 := "testbuildcopydirbutnotfile2"
+	defer deleteImages(name, name2)
 	dockerfile := `
         FROM scratch
         COPY dir /tmp/`
@@ -2052,7 +2080,7 @@ func TestBuildCopyDirButNotFile(t *testing.T) {
 	if err := ctx.Add("dir_file", "hello2"); err != nil {
 		t.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name, ctx, true)
+	id2, err := buildImageFromContext(name2, ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2064,7 +2092,11 @@ func TestBuildCopyDirButNotFile(t *testing.T) {
 
 func TestBuildADDCurrentDirWithCache(t *testing.T) {
 	name := "testbuildaddcurrentdirwithcache"
-	defer deleteImages(name)
+	name2 := name + "2"
+	name3 := name + "3"
+	name4 := name + "4"
+	name5 := name + "5"
+	defer deleteImages(name, name2, name3, name4, name5)
 	dockerfile := `
         FROM scratch
         MAINTAINER dockerio
@@ -2084,7 +2116,7 @@ func TestBuildADDCurrentDirWithCache(t *testing.T) {
 	if err := ctx.Add("bar", "hello2"); err != nil {
 		t.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name, ctx, true)
+	id2, err := buildImageFromContext(name2, ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2095,7 +2127,7 @@ func TestBuildADDCurrentDirWithCache(t *testing.T) {
 	if err := ctx.Add("foo", "hello1"); err != nil {
 		t.Fatal(err)
 	}
-	id3, err := buildImageFromContext(name, ctx, true)
+	id3, err := buildImageFromContext(name3, ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2107,14 +2139,14 @@ func TestBuildADDCurrentDirWithCache(t *testing.T) {
 	if err := ctx.Add("foo", "hello1"); err != nil {
 		t.Fatal(err)
 	}
-	id4, err := buildImageFromContext(name, ctx, true)
+	id4, err := buildImageFromContext(name4, ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if id3 == id4 {
 		t.Fatal("The cache should have been invalided but hasn't.")
 	}
-	id5, err := buildImageFromContext(name, ctx, true)
+	id5, err := buildImageFromContext(name5, ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2126,7 +2158,8 @@ func TestBuildADDCurrentDirWithCache(t *testing.T) {
 
 func TestBuildADDCurrentDirWithoutCache(t *testing.T) {
 	name := "testbuildaddcurrentdirwithoutcache"
-	defer deleteImages(name)
+	name2 := "testbuildaddcurrentdirwithoutcache2"
+	defer deleteImages(name, name2)
 	dockerfile := `
         FROM scratch
         MAINTAINER dockerio
@@ -2142,7 +2175,7 @@ func TestBuildADDCurrentDirWithoutCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name, ctx, false)
+	id2, err := buildImageFromContext(name2, ctx, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2186,7 +2219,8 @@ func TestBuildADDRemoteFileWithCache(t *testing.T) {
 
 func TestBuildADDRemoteFileWithoutCache(t *testing.T) {
 	name := "testbuildaddremotefilewithoutcache"
-	defer deleteImages(name)
+	name2 := "testbuildaddremotefilewithoutcache2"
+	defer deleteImages(name, name2)
 	server, err := fakeStorage(map[string]string{
 		"baz": "hello",
 	})
@@ -2202,7 +2236,7 @@ func TestBuildADDRemoteFileWithoutCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	id2, err := buildImage(name,
+	id2, err := buildImage(name2,
 		fmt.Sprintf(`FROM scratch
         MAINTAINER dockerio
         ADD %s/baz /usr/lib/baz/quux`, server.URL),
@@ -2218,7 +2252,11 @@ func TestBuildADDRemoteFileWithoutCache(t *testing.T) {
 
 func TestBuildADDRemoteFileMTime(t *testing.T) {
 	name := "testbuildaddremotefilemtime"
-	defer deleteImages(name)
+	name2 := name + "2"
+	name3 := name + "3"
+	name4 := name + "4"
+
+	defer deleteImages(name, name2, name3, name4)
 
 	server, err := fakeStorage(map[string]string{"baz": "hello"})
 	if err != nil {
@@ -2239,7 +2277,7 @@ func TestBuildADDRemoteFileMTime(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	id2, err := buildImageFromContext(name, ctx, true)
+	id2, err := buildImageFromContext(name2, ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2255,7 +2293,7 @@ func TestBuildADDRemoteFileMTime(t *testing.T) {
 		t.Fatalf("Error setting mtime on %q: %v", bazPath, err)
 	}
 
-	id3, err := buildImageFromContext(name, ctx, true)
+	id3, err := buildImageFromContext(name3, ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2264,7 +2302,7 @@ func TestBuildADDRemoteFileMTime(t *testing.T) {
 	}
 
 	// And for good measure do it again and make sure cache is used this time
-	id4, err := buildImageFromContext(name, ctx, true)
+	id4, err := buildImageFromContext(name4, ctx, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2353,7 +2391,7 @@ func TestBuildNoContext(t *testing.T) {
 		t.Fatalf("build failed to complete: %v %v", out, err)
 	}
 
-	if out, _, err := cmd(t, "run", "nocontext"); out != "ok\n" || err != nil {
+	if out, _, err := cmd(t, "run", "--rm", "nocontext"); out != "ok\n" || err != nil {
 		t.Fatalf("run produced invalid output: %q, expected %q", out, "ok")
 	}
 
@@ -2364,7 +2402,8 @@ func TestBuildNoContext(t *testing.T) {
 // TODO: TestCaching
 func TestBuildADDLocalAndRemoteFilesWithoutCache(t *testing.T) {
 	name := "testbuildaddlocalandremotefilewithoutcache"
-	defer deleteImages(name)
+	name2 := "testbuildaddlocalandremotefilewithoutcache2"
+	defer deleteImages(name, name2)
 	server, err := fakeStorage(map[string]string{
 		"baz": "hello",
 	})
@@ -2387,7 +2426,7 @@ func TestBuildADDLocalAndRemoteFilesWithoutCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	id2, err := buildImageFromContext(name, ctx, false)
+	id2, err := buildImageFromContext(name2, ctx, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2552,6 +2591,7 @@ func TestBuildInheritance(t *testing.T) {
 func TestBuildFails(t *testing.T) {
 	name := "testbuildfails"
 	defer deleteImages(name)
+	defer deleteAllContainers()
 	_, err := buildImage(name,
 		`FROM busybox
 		RUN sh -c "exit 23"`,
@@ -3217,6 +3257,7 @@ func TestBuildIgnoreInvalidInstruction(t *testing.T) {
 
 func TestBuildEntrypointInheritance(t *testing.T) {
 	defer deleteImages("parent", "child")
+	defer deleteAllContainers()
 
 	if _, err := buildImage("parent", `
     FROM busybox
@@ -3255,6 +3296,7 @@ func TestBuildEntrypointInheritanceInspect(t *testing.T) {
 	)
 
 	defer deleteImages(name, name2)
+	defer deleteAllContainers()
 
 	if _, err := buildImage(name, "FROM busybox\nENTRYPOINT /foo/bar", true); err != nil {
 		t.Fatal(err)
@@ -3298,7 +3340,7 @@ func TestBuildRunShEntrypoint(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", name))
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "--rm", name))
 
 	if err != nil {
 		t.Fatal(err, out)
@@ -3345,12 +3387,13 @@ func TestBuildVerifySingleQuoteFails(t *testing.T) {
 	// it should barf on it.
 	name := "testbuildsinglequotefails"
 	defer deleteImages(name)
+	defer deleteAllContainers()
 
 	_, err := buildImage(name,
 		`FROM busybox
 		CMD [ '/bin/sh', '-c', 'echo hi' ]`,
 		true)
-	_, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", name))
+	_, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", "--rm", name))
 
 	if err == nil {
 		t.Fatal("The image was not supposed to be able to run")

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -154,6 +154,9 @@ func TestCommitHardlink(t *testing.T) {
 }
 
 func TestCommitTTY(t *testing.T) {
+	defer deleteImages("ttytest")
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-t", "--name", "tty", "busybox", "/bin/ls")
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)

--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -16,7 +16,7 @@ func TestImportDisplay(t *testing.T) {
 	}
 	defer server.Close()
 	fileURL := fmt.Sprintf("%s/cirros.tar.gz", server.URL)
-	importCmd := exec.Command(dockerBinary, "import", fileURL)
+	importCmd := exec.Command(dockerBinary, "import", fileURL, "cirros")
 	out, _, err := runCommandWithOutput(importCmd)
 	if err != nil {
 		t.Errorf("import failed with errors: %v, output: %q", err, out)
@@ -25,6 +25,8 @@ func TestImportDisplay(t *testing.T) {
 	if n := strings.Count(out, "\n"); n != 2 {
 		t.Fatalf("display is messed up: %d '\\n' instead of 2", n)
 	}
+
+	deleteImages("cirros")
 
 	logDone("import - cirros was imported and display is fine")
 }

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -106,6 +106,7 @@ func TestRmContainerOrphaning(t *testing.T) {
 	}
 
 	deleteAllContainers()
+	deleteImages(img1)
 
 	logDone("rm - container orphaning")
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -563,7 +563,8 @@ func TestRunCreateVolumeWithSymlink(t *testing.T) {
 
 // Tests that a volume path that has a symlink exists in a container mounting it with `--volumes-from`.
 func TestRunVolumesFromSymlinkPath(t *testing.T) {
-	buildCmd := exec.Command(dockerBinary, "build", "-t", "docker-test-volumesfromsymlinkpath", "-")
+	name := "docker-test-volumesfromsymlinkpath"
+	buildCmd := exec.Command(dockerBinary, "build", "-t", name, "-")
 	buildCmd.Stdin = strings.NewReader(`FROM busybox
 		RUN mkdir /baz && ln -s /baz /foo
 		VOLUME ["/foo/bar"]`)
@@ -573,7 +574,7 @@ func TestRunVolumesFromSymlinkPath(t *testing.T) {
 		t.Fatalf("could not build 'docker-test-volumesfromsymlinkpath': %v", err)
 	}
 
-	cmd := exec.Command(dockerBinary, "run", "--name", "test-volumesfromsymlinkpath", "docker-test-volumesfromsymlinkpath")
+	cmd := exec.Command(dockerBinary, "run", "--name", "test-volumesfromsymlinkpath", name)
 	exitCode, err := runCommand(cmd)
 	if err != nil || exitCode != 0 {
 		t.Fatalf("[run] (volume) err: %v, exitcode: %d", err, exitCode)
@@ -585,8 +586,8 @@ func TestRunVolumesFromSymlinkPath(t *testing.T) {
 		t.Fatalf("[run] err: %v, exitcode: %d", err, exitCode)
 	}
 
-	deleteImages("docker-test-volumesfromsymlinkpath")
 	deleteAllContainers()
+	deleteImages(name)
 
 	logDone("run - volumes-from symlink path")
 }
@@ -892,6 +893,7 @@ func TestRunUnPrivilegedCanMknod(t *testing.T) {
 }
 
 func TestRunCapDropInvalid(t *testing.T) {
+	defer deleteAllContainers()
 	cmd := exec.Command(dockerBinary, "run", "--cap-drop=CHPASS", "busybox", "ls")
 	out, _, err := runCommandWithOutput(cmd)
 	if err == nil {
@@ -962,6 +964,8 @@ func TestRunCapDropALLAddMknodCannotMknod(t *testing.T) {
 }
 
 func TestRunCapAddInvalid(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--cap-add=CHPASS", "busybox", "ls")
 	out, _, err := runCommandWithOutput(cmd)
 	if err == nil {
@@ -1718,6 +1722,8 @@ func TestRunExitOnStdinClose(t *testing.T) {
 
 // Test for #2267
 func TestRunWriteHostsFileAndNotCommit(t *testing.T) {
+	defer deleteAllContainers()
+
 	name := "writehosts"
 	cmd := exec.Command(dockerBinary, "run", "--name", name, "busybox", "sh", "-c", "echo test2267 >> /etc/hosts && cat /etc/hosts")
 	out, _, err := runCommandWithOutput(cmd)
@@ -1745,6 +1751,8 @@ func TestRunWriteHostsFileAndNotCommit(t *testing.T) {
 
 // Test for #2267
 func TestRunWriteHostnameFileAndNotCommit(t *testing.T) {
+	defer deleteAllContainers()
+
 	name := "writehostname"
 	cmd := exec.Command(dockerBinary, "run", "--name", name, "busybox", "sh", "-c", "echo test2267 >> /etc/hostname && cat /etc/hostname")
 	out, _, err := runCommandWithOutput(cmd)
@@ -1772,6 +1780,8 @@ func TestRunWriteHostnameFileAndNotCommit(t *testing.T) {
 
 // Test for #2267
 func TestRunWriteResolvFileAndNotCommit(t *testing.T) {
+	defer deleteAllContainers()
+
 	name := "writeresolv"
 	cmd := exec.Command(dockerBinary, "run", "--name", name, "busybox", "sh", "-c", "echo test2267 >> /etc/resolv.conf && cat /etc/resolv.conf")
 	out, _, err := runCommandWithOutput(cmd)
@@ -1798,6 +1808,8 @@ func TestRunWriteResolvFileAndNotCommit(t *testing.T) {
 }
 
 func TestRunWithBadDevice(t *testing.T) {
+	defer deleteAllContainers()
+
 	name := "baddevice"
 	cmd := exec.Command(dockerBinary, "run", "--name", name, "--device", "/etc", "busybox", "true")
 	out, _, err := runCommandWithOutput(cmd)
@@ -1812,6 +1824,8 @@ func TestRunWithBadDevice(t *testing.T) {
 }
 
 func TestRunEntrypoint(t *testing.T) {
+	defer deleteAllContainers()
+
 	name := "entrypoint"
 	cmd := exec.Command(dockerBinary, "run", "--name", name, "--entrypoint", "/bin/echo", "busybox", "-n", "foobar")
 	out, _, err := runCommandWithOutput(cmd)
@@ -1826,6 +1840,8 @@ func TestRunEntrypoint(t *testing.T) {
 }
 
 func TestRunBindMounts(t *testing.T) {
+	defer deleteAllContainers()
+
 	tmpDir, err := ioutil.TempDir("", "docker-test-container")
 	if err != nil {
 		t.Fatal(err)
@@ -2435,8 +2451,6 @@ func TestRunNoOutputFromPullInStdout(t *testing.T) {
 }
 
 func TestRunVolumesCleanPaths(t *testing.T) {
-	defer deleteAllContainers()
-
 	if _, err := buildImage("run_volumes_clean_paths",
 		`FROM busybox
 		 VOLUME /foo/`,
@@ -2444,6 +2458,7 @@ func TestRunVolumesCleanPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer deleteImages("run_volumes_clean_paths")
+	defer deleteAllContainers()
 
 	cmd := exec.Command(dockerBinary, "run", "-v", "/foo", "-v", "/bar/", "--name", "dark_helmet", "run_volumes_clean_paths")
 	if out, _, err := runCommandWithOutput(cmd); err != nil {

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -239,12 +239,15 @@ func TestSaveMultipleNames(t *testing.T) {
 	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
 		t.Fatalf("failed to tag repo: %s, %v", out, err)
 	}
+	defer deleteImages(repoName + "-one")
+
 	// Make two images
 	tagCmdFinal = fmt.Sprintf("%v tag scratch:latest %v-two:latest", dockerBinary, repoName)
 	tagCmd = exec.Command("bash", "-c", tagCmdFinal)
 	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
 		t.Fatalf("failed to tag repo: %s, %v", out, err)
 	}
+	defer deleteImages(repoName + "-two")
 
 	saveCmdFinal := fmt.Sprintf("%v save %v-one %v-two:latest | tar xO repositories | grep -q -E '(-one|-two)'", dockerBinary, repoName, repoName)
 	saveCmd := exec.Command("bash", "-c", saveCmdFinal)

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -322,7 +322,10 @@ func deleteAllContainers() error {
 }
 
 func deleteImages(images ...string) error {
-	rmiCmd := exec.Command(dockerBinary, "rmi", strings.Join(images, " "))
+	args := make([]string, 1, 2)
+	args[0] = "rmi"
+	args = append(args, images...)
+	rmiCmd := exec.Command(dockerBinary, args...)
 	exitCode, err := runCommand(rmiCmd)
 	// set error manually if not set
 	if exitCode != 0 && err == nil {


### PR DESCRIPTION
Common patterns:
- Multiple images were built with same name but only one cleanup.
- Containers were deleted after images.
- Images not removed after retagging.
- deleteImages() did not work for deleting many images together.

Signed-off-by: Tõnis Tiigi tonistiigi@gmail.com (github: tonistiigi)

This will become more important when there is progress with #9217 . Even at the moment when `integration-cli` is ran inside temporary container this can easily result false positives when one test leaks information to another. Currently there are many tests that do not pass if ran for a second time in same environment.

edit: pushed again [diff](https://gist.github.com/tonistiigi/ca99deea7b679c398cc7)
