### PR TITLE
devmapper fix usage of pool transaction id 

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -205,12 +205,10 @@ func (devices *DeviceSet) allocateTransactionId() uint64 {
 }
 
 func (devices *DeviceSet) updatePoolTransactionId() error {
-	if devices.NewTransactionId != devices.TransactionId {
-		if err := devicemapper.SetTransactionId(devices.getPoolDevName(), devices.TransactionId, devices.NewTransactionId); err != nil {
-			return fmt.Errorf("Error setting devmapper transaction ID: %s", err)
-		}
-		devices.TransactionId = devices.NewTransactionId
+	if err := devicemapper.SetTransactionId(devices.getPoolDevName(), devices.TransactionId, devices.NewTransactionId); err != nil {
+		return fmt.Errorf("Error setting devmapper transaction ID: %s", err)
 	}
+	devices.TransactionId = devices.NewTransactionId
 	return nil
 }
 

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -793,7 +793,6 @@ func (devices *DeviceSet) deleteDevice(info *DevInfo) error {
 		return err
 	}
 
-	devices.allocateTransactionId()
 	devices.devicesLock.Lock()
 	delete(devices.Devices, info.Hash)
 	devices.devicesLock.Unlock()

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -367,11 +367,7 @@ func (devices *DeviceSet) initMetaData() error {
 
 		for hash, info := range m.Devices {
 			info.Hash = hash
-
-			// If the transaction id is larger than the actual one we lost the device due to some crash
-			if info.TransactionId <= devices.TransactionId {
-				devices.saveMetadata(info)
-			}
+			devices.saveMetadata(info)
 		}
 		if err := os.Rename(devices.oldMetadataFile(), devices.oldMetadataFile()+".migrated"); err != nil {
 			return err

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -200,7 +200,7 @@ func (devices *DeviceSet) ensureImage(name string, size int64) (string, error) {
 }
 
 func (devices *DeviceSet) allocateTransactionId() uint64 {
-	devices.NewTransactionId = devices.NewTransactionId + 1
+	devices.NewTransactionId = devices.TransactionId + 1
 	return devices.NewTransactionId
 }
 
@@ -398,7 +398,6 @@ func (devices *DeviceSet) initMetaData() error {
 	}
 
 	devices.TransactionId = transactionId
-	devices.NewTransactionId = devices.TransactionId
 	return nil
 }
 

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -814,9 +814,6 @@ func (devices *DeviceSet) deleteDevice(info *DevInfo) error {
 	devices.devicesLock.Unlock()
 
 	if err := devices.removeMetadata(info); err != nil {
-		devices.devicesLock.Lock()
-		devices.Devices[info.Hash] = info
-		devices.devicesLock.Unlock()
 		log.Debugf("Error removing meta data: %s", err)
 		return err
 	}

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -390,11 +390,6 @@ func (devices *DeviceSet) loadMetadata(hash string) *DevInfo {
 		return nil
 	}
 
-	// If the transaction id is larger than the actual one we lost the device due to some crash
-	if info.TransactionId > devices.TransactionId {
-		return nil
-	}
-
 	return info
 }
 

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -516,7 +516,7 @@ func (devices *DeviceSet) setupBaseImage() error {
 
 	if oldInfo != nil && !oldInfo.Initialized {
 		log.Debugf("Removing uninitialized base image")
-		if err := devices.deleteDevice(oldInfo); err != nil {
+		if err := devices.DeleteDevice(""); err != nil {
 			return err
 		}
 	}

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1128,12 +1128,21 @@ func (devices *DeviceSet) deleteDevice(info *DevInfo) error {
 		}
 	}
 
+	if err := devices.openTransaction(info.Hash, info.DeviceId); err != nil {
+		log.Debugf("Error opening transaction hash = %s deviceId = %d", "", info.DeviceId)
+		return err
+	}
+
 	if err := devicemapper.DeleteDevice(devices.getPoolDevName(), info.DeviceId); err != nil {
 		log.Debugf("Error deleting device: %s", err)
 		return err
 	}
 
 	if err := devices.unregisterDevice(info.DeviceId, info.Hash); err != nil {
+		return err
+	}
+
+	if err := devices.closeTransaction(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixes Issue: #9257

There are multiple issues with current devmapper usage of pool transaction Id. This patch series tries to fix these.

Details of problem and proposed fix are available in Issue: #9257

Thanks
Vivek
