### PR TITLE
fix cleanup of /tmp in tests

### DIFF
--- a/daemon/graphdriver/aufs/aufs_test.go
+++ b/daemon/graphdriver/aufs/aufs_test.go
@@ -4,16 +4,18 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"github.com/docker/docker/daemon/graphdriver"
-	"github.com/docker/docker/pkg/archive"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/pkg/archive"
 )
 
 var (
-	tmp = path.Join(os.TempDir(), "aufs-tests", "aufs")
+	tmpOuter = path.Join(os.TempDir(), "aufs-tests")
+	tmp      = path.Join(tmpOuter, "aufs")
 )
 
 func testInit(dir string, t *testing.T) graphdriver.Driver {
@@ -640,8 +642,8 @@ func testMountMoreThan42Layers(t *testing.T, mountPath string) {
 		t.Fatal(err)
 	}
 
-	d := testInit(mountPath, t).(*Driver)
 	defer os.RemoveAll(mountPath)
+	d := testInit(mountPath, t).(*Driver)
 	defer d.Cleanup()
 	var last string
 	var expected int
@@ -662,24 +664,24 @@ func testMountMoreThan42Layers(t *testing.T, mountPath string) {
 
 		if err := d.Create(current, parent); err != nil {
 			t.Logf("Current layer %d", i)
-			t.Fatal(err)
+			t.Error(err)
 		}
 		point, err := d.Get(current, "")
 		if err != nil {
 			t.Logf("Current layer %d", i)
-			t.Fatal(err)
+			t.Error(err)
 		}
 		f, err := os.Create(path.Join(point, current))
 		if err != nil {
 			t.Logf("Current layer %d", i)
-			t.Fatal(err)
+			t.Error(err)
 		}
 		f.Close()
 
 		if i%10 == 0 {
 			if err := os.Remove(path.Join(point, parent)); err != nil {
 				t.Logf("Current layer %d", i)
-				t.Fatal(err)
+				t.Error(err)
 			}
 			expected--
 		}
@@ -689,28 +691,30 @@ func testMountMoreThan42Layers(t *testing.T, mountPath string) {
 	// Perform the actual mount for the top most image
 	point, err := d.Get(last, "")
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	files, err := ioutil.ReadDir(point)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	if len(files) != expected {
-		t.Fatalf("Expected %d got %d", expected, len(files))
+		t.Errorf("Expected %d got %d", expected, len(files))
 	}
 }
 
 func TestMountMoreThan42Layers(t *testing.T) {
+	os.RemoveAll(tmpOuter)
 	testMountMoreThan42Layers(t, tmp)
 }
 
 func TestMountMoreThan42LayersMatchingPathLength(t *testing.T) {
-	tmp := "aufs-tests"
+	defer os.RemoveAll(tmpOuter)
+	zeroes := "0"
 	for {
 		// This finds a mount path so that when combined into aufs mount options
 		// 4096 byte boundary would be in between the paths or in permission
-		// section. For '/tmp' it will use '/tmp/aufs-tests00000000/aufs'
-		mountPath := path.Join(os.TempDir(), tmp, "aufs")
+		// section. For '/tmp' it will use '/tmp/aufs-tests/00000000/aufs'
+		mountPath := path.Join(tmpOuter, zeroes, "aufs")
 		pathLength := 77 + len(mountPath)
 
 		if mod := 4095 % pathLength; mod == 0 || mod > pathLength-2 {
@@ -718,6 +722,6 @@ func TestMountMoreThan42LayersMatchingPathLength(t *testing.T) {
 			testMountMoreThan42Layers(t, mountPath)
 			return
 		}
-		tmp += "0"
+		zeroes += "0"
 	}
 }

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -179,6 +179,7 @@ func TestBuildEnvironmentReplacementAddCopy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
 
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
@@ -632,6 +633,8 @@ func TestBuildSixtySteps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -656,6 +659,8 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -674,6 +679,8 @@ ADD test_file .`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	done := make(chan struct{})
 	go func() {
 		if _, err := buildImageFromContext(name, ctx, true); err != nil {
@@ -708,6 +715,8 @@ RUN [ $(ls -l /exists/exists_file | awk '{print $3":"$4}') = 'dockerio:dockerio'
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -947,6 +956,8 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -971,6 +982,8 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -996,6 +1009,8 @@ RUN [ $(ls -l /exists/test_file | awk '{print $3":"$4}') = 'root:root' ]`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -1022,6 +1037,8 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -1040,6 +1057,8 @@ ADD . /`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -1064,6 +1083,8 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -1082,6 +1103,8 @@ COPY test_file .`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	done := make(chan struct{})
 	go func() {
 		if _, err := buildImageFromContext(name, ctx, true); err != nil {
@@ -1116,6 +1139,8 @@ RUN [ $(ls -l /exists/exists_file | awk '{print $3":"$4}') = 'dockerio:dockerio'
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -1140,6 +1165,8 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -1163,6 +1190,8 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -1188,6 +1217,8 @@ RUN [ $(ls -l /exists/test_file | awk '{print $3":"$4}') = 'root:root' ]`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -1214,6 +1245,8 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -1231,6 +1264,8 @@ COPY . /`,
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatal(err)
 	}
@@ -1858,6 +1893,7 @@ func TestBuildOnBuildLimitedInheritence(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer ctx.Close()
 
 		out1, _, err := dockerCmdInDir(t, ctx.Dir, "build", "-t", name1, ".")
 		if err != nil {
@@ -1874,6 +1910,7 @@ func TestBuildOnBuildLimitedInheritence(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer ctx.Close()
 
 		out2, _, err = dockerCmdInDir(t, ctx.Dir, "build", "-t", name2, ".")
 		if err != nil {
@@ -1890,6 +1927,7 @@ func TestBuildOnBuildLimitedInheritence(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		defer ctx.Close()
 
 		out3, _, err = dockerCmdInDir(t, ctx.Dir, "build", "-t", name3, ".")
 		if err != nil {
@@ -2984,6 +3022,8 @@ RUN    [ "$(cat $TO)" = "hello" ]
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	_, err = buildImageFromContext(name, ctx, true)
 	if err != nil {
 		t.Fatal(err)
@@ -3006,6 +3046,8 @@ RUN [ "$(cat /testfile)" = 'test!' ]`
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ctx.Close()
+
 	_, err = buildImageFromContext(name, ctx, true)
 	if err != nil {
 		t.Fatal(err)
@@ -3060,6 +3102,7 @@ RUN cat /existing-directory-trailing-slash/test/foo | grep Hi`
 		}
 		return &FakeContext{Dir: tmpDir}
 	}()
+	defer ctx.Close()
 
 	if _, err := buildImageFromContext(name, ctx, true); err != nil {
 		t.Fatalf("build failed to complete for TestBuildAddTar: %v", err)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1257,6 +1257,7 @@ func TestRunWithVolumesIsRecursive(t *testing.T) {
 	if err := mount.Mount("tmpfs", tmpfsDir, "tmpfs", ""); err != nil {
 		t.Fatalf("failed to create a tmpfs mount at %s - %s", tmpfsDir, err)
 	}
+	defer mount.Unmount(tmpfsDir)
 
 	f, err := ioutil.TempFile(tmpfsDir, "touch-me")
 	if err != nil {

--- a/pkg/symlink/fs_test.go
+++ b/pkg/symlink/fs_test.go
@@ -46,6 +46,7 @@ func TestFollowSymLinkUnderLinkedDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.RemoveAll(dir)
 
 	os.Mkdir(filepath.Join(dir, "realdir"), 0700)
 	os.Symlink("realdir", filepath.Join(dir, "linkdir"))

--- a/pkg/system/lstat_test.go
+++ b/pkg/system/lstat_test.go
@@ -1,11 +1,13 @@
 package system
 
 import (
+	"os"
 	"testing"
 )
 
 func TestLstat(t *testing.T) {
-	file, invalid, _ := prepareFiles(t)
+	file, invalid, _, dir := prepareFiles(t)
+	defer os.RemoveAll(dir)
 
 	statFile, err := Lstat(file)
 	if err != nil {

--- a/pkg/system/stat_test.go
+++ b/pkg/system/stat_test.go
@@ -1,12 +1,14 @@
 package system
 
 import (
+	"os"
 	"syscall"
 	"testing"
 )
 
 func TestFromStatT(t *testing.T) {
-	file, _, _ := prepareFiles(t)
+	file, _, _, dir := prepareFiles(t)
+	defer os.RemoveAll(dir)
 
 	stat := &syscall.Stat_t{}
 	err := syscall.Lstat(file, stat)

--- a/pkg/system/utimes_test.go
+++ b/pkg/system/utimes_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func prepareFiles(t *testing.T) (string, string, string) {
+func prepareFiles(t *testing.T) (string, string, string, string) {
 	dir, err := ioutil.TempDir("", "docker-system-test")
 	if err != nil {
 		t.Fatal(err)
@@ -26,11 +26,12 @@ func prepareFiles(t *testing.T) (string, string, string) {
 		t.Fatal(err)
 	}
 
-	return file, invalid, symlink
+	return file, invalid, symlink, dir
 }
 
 func TestLUtimesNano(t *testing.T) {
-	file, invalid, symlink := prepareFiles(t)
+	file, invalid, symlink, dir := prepareFiles(t)
+	defer os.RemoveAll(dir)
 
 	before, err := os.Stat(file)
 	if err != nil {


### PR DESCRIPTION
This PR fixes the cleanup of the items created in /tmp during the execution of the tests.
