### PR TITLE
Cleanup exec API docs and available params

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -122,8 +122,6 @@ func (d *Daemon) ContainerExecCreate(job *engine.Job) engine.Status {
 	entrypoint, args := d.getEntrypointAndArgs(nil, config.Cmd)
 
 	processConfig := execdriver.ProcessConfig{
-		Privileged: config.Privileged,
-		User:       config.User,
 		Tty:        config.Tty,
 		Entrypoint: entrypoint,
 		Arguments:  args,

--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -1560,7 +1560,6 @@ Sets up an exec instance in a running container `id`
 	     "Cmd":[
                      "date"
              ],
-	     "Container":"e90e34656806",
         }
 
 **Example response**:
@@ -1574,7 +1573,12 @@ Sets up an exec instance in a running container `id`
 
 Json Parameters:
 
--   **execConfig** ? exec configuration.
+-   **AttachStdin** - Boolean value, attaches to stdin of the exec command.
+-   **AttachStdout** - Boolean value, attaches to stdout of the exec command.
+-   **AttachStderr** - Boolean value, attaches to stderr of the exec command.
+-   **Tty** - Boolean value to allocate a pseudo-TTY
+-   **Cmd** - Command to run specified as a string or an array of strings.
+
 
 Status Codes:
 
@@ -1585,8 +1589,9 @@ Status Codes:
 
 `POST /exec/(id)/start`
 
-Starts a previously set up exec instance `id`. If `detach` is true, this API returns after
-starting the `exec` command. Otherwise, this API sets up an interactive session with the `exec` command.
+Starts a previously set up exec instance `id`. If `detach` is true, this API
+returns after starting the `exec` command. Otherwise, this API sets up an
+interactive session with the `exec` command.
 
 **Example request**:
 
@@ -1607,7 +1612,8 @@ starting the `exec` command. Otherwise, this API sets up an interactive session 
 
 Json Parameters:
 
--   **execConfig** ? exec configuration.
+-   **Detach** - Detach from the exec command
+-   **Tty** - Boolean value to allocate a pseudo-TTY
 
 Status Codes:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -1511,7 +1511,6 @@ Sets up an exec instance in a running container `id`
 	     "Cmd":[
                      "date"
              ],
-	     "Container":"e90e34656806",
         }
 
 **Example response**:
@@ -1525,7 +1524,12 @@ Sets up an exec instance in a running container `id`
 
 Json Parameters:
 
--   **execConfig** ? exec configuration.
+-   **AttachStdin** - Boolean value, attaches to stdin of the exec command.
+-   **AttachStdout** - Boolean value, attaches to stdout of the exec command.
+-   **AttachStderr** - Boolean value, attaches to stderr of the exec command.
+-   **Tty** - Boolean value to allocate a pseudo-TTY
+-   **Cmd** - Command to run specified as a string or an array of strings.
+
 
 Status Codes:
 
@@ -1536,8 +1540,9 @@ Status Codes:
 
 `POST /exec/(id)/start`
 
-Starts a previously set up exec instance `id`. If `detach` is true, this API returns after
-starting the `exec` command. Otherwise, this API sets up an interactive session with the `exec` command.
+Starts a previously set up exec instance `id`. If `detach` is true, this API
+returns after starting the `exec` command. Otherwise, this API sets up an
+interactive session with the `exec` command.
 
 **Example request**:
 
@@ -1558,7 +1563,8 @@ starting the `exec` command. Otherwise, this API sets up an interactive session 
 
 Json Parameters:
 
--   **execConfig** ? exec configuration.
+-   **Detach** - Detach from the exec command
+-   **Tty** - Boolean value to allocate a pseudo-TTY
 
 Status Codes:
 

--- a/runconfig/exec.go
+++ b/runconfig/exec.go
@@ -19,10 +19,11 @@ type ExecConfig struct {
 
 func ExecConfigFromJob(job *engine.Job) *ExecConfig {
 	execConfig := &ExecConfig{
-		User:         job.Getenv("User"),
-		Privileged:   job.GetenvBool("Privileged"),
+		// TODO(vishh): Expose 'User' once it is supported.
+		//User:         job.Getenv("User"),
+		// TODO(vishh): Expose 'Privileged' once it is supported.
+		//Privileged:   job.GetenvBool("Privileged"),
 		Tty:          job.GetenvBool("Tty"),
-		Container:    job.Getenv("Container"),
 		AttachStdin:  job.GetenvBool("AttachStdin"),
 		AttachStderr: job.GetenvBool("AttachStderr"),
 		AttachStdout: job.GetenvBool("AttachStdout"),


### PR DESCRIPTION
Adds pertinent information about what is expected in the json payload
and comments out unsupported (exec) features in runConfig.
