### PR TITLE
Mknod more loopbacks for devmapper

### DIFF
--- a/daemon/graphdriver/devmapper/devmapper_test.go
+++ b/daemon/graphdriver/devmapper/devmapper_test.go
@@ -13,6 +13,9 @@ func init() {
 	DefaultDataLoopbackSize = 300 * 1024 * 1024
 	DefaultMetaDataLoopbackSize = 200 * 1024 * 1024
 	DefaultBaseFsSize = 300 * 1024 * 1024
+	if err := graphtest.InitLoopbacks(); err != nil {
+		panic(err)
+	}
 }
 
 // This avoids creating a new driver for each test if all tests are run

--- a/daemon/graphdriver/graphtest/graphtest.go
+++ b/daemon/graphdriver/graphtest/graphtest.go
@@ -1,6 +1,7 @@
 package graphtest
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -18,6 +19,46 @@ type Driver struct {
 	graphdriver.Driver
 	root     string
 	refCount int
+}
+
+// InitLoopbacks ensures that the loopback devices are properly created within
+// the system running the device mapper tests.
+func InitLoopbacks() error {
+	stat_t, err := getBaseLoopStats()
+	if err != nil {
+		return err
+	}
+	// create atleast 8 loopback files, ya, that is a good number
+	for i := 0; i < 8; i++ {
+		loopPath := fmt.Sprintf("/dev/loop%d", i)
+		// only create new loopback files if they don't exist
+		if _, err := os.Stat(loopPath); err != nil {
+			if mkerr := syscall.Mknod(loopPath,
+				uint32(stat_t.Mode|syscall.S_IFBLK), int((7<<8)|(i&0xff)|((i&0xfff00)<<12))); mkerr != nil {
+				return mkerr
+			}
+			os.Chown(loopPath, int(stat_t.Uid), int(stat_t.Gid))
+		}
+	}
+	return nil
+}
+
+// getBaseLoopStats inspects /dev/loop0 to collect uid,gid, and mode for the
+// loop0 device on the system.  If it does not exist we assume 0,0,0660 for the
+// stat data
+func getBaseLoopStats() (*syscall.Stat_t, error) {
+	loop0, err := os.Stat("/dev/loop0")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &syscall.Stat_t{
+				Uid:  0,
+				Gid:  0,
+				Mode: 0660,
+			}, nil
+		}
+		return nil, err
+	}
+	return loop0.Sys().(*syscall.Stat_t), nil
 }
 
 func newDriver(t *testing.T, name string) *Driver {


### PR DESCRIPTION
Fixes #7058

The change creates additional loopback files for the devicemapper unit tests.  Some systems do not initially create very many so this ensures that we have alteast 7 loop devices available. 

Signed-off-by: Michael Crosby crosbymichael@gmail.com
