### PR TITLE
Label content created for containers with the private label

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/volumes"
+	"github.com/docker/libcontainer/label"
 )
 
 type Mount struct {
@@ -235,15 +236,24 @@ func validMountMode(mode string) bool {
 }
 
 func (container *Container) setupMounts() error {
+	if err := label.SetFileLabel(container.ResolvConfPath, container.MountLabel); err != nil {
+		return err
+	}
 	mounts := []execdriver.Mount{
 		{Source: container.ResolvConfPath, Destination: "/etc/resolv.conf", Writable: true, Private: true},
 	}
 
 	if container.HostnamePath != "" {
+		if err := label.SetFileLabel(container.HostnamePath, container.MountLabel); err != nil {
+			return err
+		}
 		mounts = append(mounts, execdriver.Mount{Source: container.HostnamePath, Destination: "/etc/hostname", Writable: true, Private: true})
 	}
 
 	if container.HostsPath != "" {
+		if err := label.SetFileLabel(container.HostsPath, container.MountLabel); err != nil {
+			return err
+		}
 		mounts = append(mounts, execdriver.Mount{Source: container.HostsPath, Destination: "/etc/hosts", Writable: true, Private: true})
 	}
 


### PR DESCRIPTION
Currently this content gets a system label and is not writable based on
SELinux controls.  This patch will set the labels to the correct label.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
