### PR TITLE
Update libcontainer to 84c1636580a356db88b079d118b94abe6a1a0acd

### DIFF
--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -73,6 +73,7 @@ func (c *Chain) Forward(action Action, ip net.IP, port int, proto, dest_addr str
 		"-p", proto,
 		"-d", daddr,
 		"--dport", strconv.Itoa(port),
+		"!", "-i", c.Bridge,
 		"-j", "DNAT",
 		"--to-destination", net.JoinHostPort(dest_addr, strconv.Itoa(dest_port))); err != nil {
 		return err
@@ -91,17 +92,6 @@ func (c *Chain) Forward(action Action, ip net.IP, port int, proto, dest_addr str
 		"-d", dest_addr,
 		"--dport", strconv.Itoa(dest_port),
 		"-j", "ACCEPT"); err != nil {
-		return err
-	} else if len(output) != 0 {
-		return fmt.Errorf("Error iptables forward: %s", output)
-	}
-
-	if output, err := Raw("-t", "nat", string(fAction), "POSTROUTING",
-		"-p", proto,
-		"-s", dest_addr,
-		"-d", dest_addr,
-		"--dport", strconv.Itoa(dest_port),
-		"-j", "MASQUERADE"); err != nil {
 		return err
 	} else if len(output) != 0 {
 		return fmt.Errorf("Error iptables forward: %s", output)

--- a/project/vendor.sh
+++ b/project/vendor.sh
@@ -66,7 +66,7 @@ if [ "$1" = '--go' ]; then
 	mv tmp-tar src/code.google.com/p/go/src/pkg/archive/tar
 fi
 
-clone git github.com/docker/libcontainer 28cb5f9dfd6f3352c610a4f1502b5df4f69389ea
+clone git github.com/docker/libcontainer 84c1636580a356db88b079d118b94abe6a1a0acd
 # see src/github.com/docker/libcontainer/update-vendor.sh which is the "source of truth" for libcontainer deps (just like this file)
 rm -rf src/github.com/docker/libcontainer/vendor
 eval "$(grep '^clone ' src/github.com/docker/libcontainer/update-vendor.sh | grep -v 'github.com/codegangsta/cli')"

--- a/vendor/src/github.com/docker/libcontainer/cgroups/fs/cpuset.go
+++ b/vendor/src/github.com/docker/libcontainer/cgroups/fs/cpuset.go
@@ -14,17 +14,11 @@ type CpusetGroup struct {
 }
 
 func (s *CpusetGroup) Set(d *data) error {
-	// we don't want to join this cgroup unless it is specified
-	if d.c.CpusetCpus != "" {
-		dir, err := d.path("cpuset")
-		if err != nil {
-			return err
-		}
-
-		return s.SetDir(dir, d.c.CpusetCpus, d.pid)
+	dir, err := d.path("cpuset")
+	if err != nil {
+		return err
 	}
-
-	return nil
+	return s.SetDir(dir, d.c.CpusetCpus, d.pid)
 }
 
 func (s *CpusetGroup) Remove(d *data) error {
@@ -46,8 +40,12 @@ func (s *CpusetGroup) SetDir(dir, value string, pid int) error {
 		return err
 	}
 
-	if err := writeFile(dir, "cpuset.cpus", value); err != nil {
-		return err
+	// If we don't use --cpuset, the default cpuset.cpus is set in
+	// s.ensureParent, otherwise, use the value we set
+	if value != "" {
+		if err := writeFile(dir, "cpuset.cpus", value); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/vendor/src/github.com/docker/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/vendor/src/github.com/docker/libcontainer/cgroups/systemd/apply_systemd.go
@@ -137,16 +137,14 @@ func Apply(c *cgroups.Cgroup, pid int) (map[string]string, error) {
 
 	}
 
-	// we need to manually join the freezer cgroup in systemd because it does not currently support it
-	// via the dbus api
+	// we need to manually join the freezer and cpuset cgroup in systemd
+	// because it does not currently support it via the dbus api.
 	if err := joinFreezer(c, pid); err != nil {
 		return nil, err
 	}
 
-	if c.CpusetCpus != "" {
-		if err := joinCpuset(c, pid); err != nil {
-			return nil, err
-		}
+	if err := joinCpuset(c, pid); err != nil {
+		return nil, err
 	}
 
 	paths := make(map[string]string)

--- a/vendor/src/github.com/docker/libcontainer/network/veth.go
+++ b/vendor/src/github.com/docker/libcontainer/network/veth.go
@@ -39,9 +39,6 @@ func (v *Veth) Create(n *Network, nspid int, networkState *NetworkState) error {
 	if err := SetMtu(name1, n.Mtu); err != nil {
 		return err
 	}
-	if err := SetHairpinMode(name1, true); err != nil {
-		return err
-	}
 	if err := InterfaceUp(name1); err != nil {
 		return err
 	}


### PR DESCRIPTION
This reverts #6810 and the hairpin nat code.  There are issues causing container runs to fail on 2.6.x kernels, specifically RHEL 6.5 and CentOS 6.5.

Fixes #9134
