### PR TITLE
Updated installation docs for CRUX as a Docker Host.

### DIFF
--- a/docs/sources/installation/cruxlinux.md
+++ b/docs/sources/installation/cruxlinux.md
@@ -4,16 +4,14 @@ page_keywords: crux linux, virtualization, Docker, documentation, installation
 
 # CRUX Linux
 
-Installing on CRUX Linux can be handled via the ports from [James
-Mills](http://prologic.shortcircuit.net.au/) and are included in the
+Installing on CRUX Linux can be handled via the contrib ports from
+[James Mills](http://prologic.shortcircuit.net.au/) and are included in the
 official [contrib](http://crux.nu/portdb/?a=repo&q=contrib) ports:
 
 - docker
-- docker-bin
 
-The `docker` port will install the latest tagged
-version of Docker. The `docker-bin` port will
-install the latest tagged version of Docker from upstream built binaries.
+The `docker` port will build and install the latest tagged version of Docker.
+
 
 ## Installation
 
@@ -21,22 +19,21 @@ Assuming you have contrib enabled, update your ports tree and install docker (*a
 
     # prt-get depinst docker
 
-You can install `docker-bin` instead if you wish to avoid compilation time.
-
 
 ## Kernel Requirements
 
 To have a working **CRUX+Docker** Host you must ensure your Kernel has
-the necessary modules enabled for LXC containers to function correctly
-and Docker Daemon to work properly.
+the necessary modules enabled for the Docker Daemon to function correctly.
 
 Please read the `README`:
 
     $ prt-get readme docker
 
-The `docker` and `docker-bin` ports install the `contrib/check-config.sh`
-script provided by the Docker contributors for checking your kernel
-configuration as a suitable Docker Host.
+The `docker` port installs the `contrib/check-config.sh` script
+provided by the Docker contributors for checking your kernel
+configuration as a suitable Docker host.
+
+To check your Kernel configuration run:
 
     $ /usr/share/docker/check-config.sh
 
@@ -50,6 +47,18 @@ To start on system boot:
 
  - Edit `/etc/rc.conf`
  - Put `docker` into the `SERVICES=(...)` array after `net`.
+
+## Images
+
+There is a CRUX image maintained by [James Mills](http://prologic.shortcircuit.net.au/)
+as part of the Docker "Official Library" of images. To use this image simply pull it
+or use it as part of your `FROM` line in your `Dockerfile(s)`.
+
+    $ docker pull crux
+    $ docker run -i -t crux
+
+There are also user contributed [CRUX based image(s)](https://registry.hub.docker.com/repos/crux/) on the Docker Hub.
+
 
 ## Issues
 


### PR DESCRIPTION
- Document availability of Images on the Hub
- We no longer provide a `docker-bin` port. (_It's trivial to use the upstream binary_).
