### PR TITLE
registry: fix ServerAddress setting

### DIFF
--- a/registry/auth.go
+++ b/registry/auth.go
@@ -126,8 +126,8 @@ func LoadConfig(rootPath string) (*ConfigFile, error) {
 				return &configFile, err
 			}
 			authConfig.Auth = ""
-			configFile.Configs[k] = authConfig
 			authConfig.ServerAddress = k
+			configFile.Configs[k] = authConfig
 		}
 	}
 	return &configFile, nil


### PR DESCRIPTION
This ensures that ServerAddress is set, while previously it was getting
set after configFile.Configs.
