### PR TITLE
zsh: correctly parse available subcommands (completion)

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -177,7 +177,9 @@ __docker_commands () {
     if ( [[ ${+_docker_subcommands} -eq 0 ]] || _cache_invalid docker_subcommands) \
         && ! _retrieve_cache docker_subcommands;
     then
-        _docker_subcommands=(${${${${(f)"$(_call_program commands docker 2>&1)"}[5,-1]}## #}/ ##/:})
+        local -a lines
+        lines=(${(f)"$(_call_program commands docker 2>&1)"})
+        _docker_subcommands=(${${${lines[$((${lines[(i)Commands:]} + 1)),${lines[(I)    *]}]}## #}/ ##/:})
         _docker_subcommands=($_docker_subcommands 'help:Show help for a command')
         _store_cache docker_subcommands _docker_subcommands
     fi


### PR DESCRIPTION
A lot of flags have been added on the output of `docker help`. Use a
more robust method to extract the list of available subcommands by
spotting the `Command:` line and the next blank line.

Signed-off-by: Vincent Bernat vincent@bernat.im
