### PR TITLE
Fixed typo in documentation.

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -155,7 +155,7 @@ string is equivalent to setting the `--tlsverify` flag. The following are equiva
 
 ### Daemon storage-driver option
 
-The Docker daemon has support for four different image layer storage drivers: `aufs`,
+The Docker daemon has support for several different image layer storage drivers: `aufs`,
 `devicemapper`, `btrfs` and `overlayfs`.
 
 The `aufs` driver is the oldest, but is based on a Linux kernel patch-set that

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -155,7 +155,7 @@ string is equivalent to setting the `--tlsverify` flag. The following are equiva
 
 ### Daemon storage-driver option
 
-The Docker daemon has support for three different image layer storage drivers: `aufs`,
+The Docker daemon has support for four different image layer storage drivers: `aufs`,
 `devicemapper`, `btrfs` and `overlayfs`.
 
 The `aufs` driver is the oldest, but is based on a Linux kernel patch-set that


### PR DESCRIPTION
Just a trivial fix is cli.md.
