### PR TITLE
partial image export

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2472,6 +2472,8 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 func (cli *DockerCli) CmdSave(args ...string) error {
 	cmd := cli.Subcmd("save", "IMAGE [IMAGE...]", "Save an image(s) to a tar archive (streamed to STDOUT by default)")
 	outfile := cmd.String([]string{"o", "-output"}, "", "Write to a file, instead of STDOUT")
+	exclude := opts.NewListOpts(nil)
+	cmd.Var(&exclude, []string{"e", "-exclude"}, "Images not to be included in the archive")
 
 	if err := cmd.Parse(args); err != nil {
 		return err
@@ -2495,13 +2497,16 @@ func (cli *DockerCli) CmdSave(args ...string) error {
 		return errors.New("Cowardly refusing to save to a terminal. Use the -o flag or redirect.")
 	}
 
+	v := url.Values{}
+	for _, img := range exclude.GetAll() {
+		v.Add("exclude", img)
+	}
 	if len(cmd.Args()) == 1 {
 		image := cmd.Arg(0)
-		if err := cli.stream("GET", "/images/"+image+"/get", nil, output, nil); err != nil {
+		if err := cli.stream("GET", "/images/"+image+"/get?"+v.Encode(), nil, output, nil); err != nil {
 			return err
 		}
 	} else {
-		v := url.Values{}
 		for _, arg := range cmd.Args() {
 			v.Add("names", arg)
 		}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -662,6 +662,7 @@ func getImagesGet(eng *engine.Engine, version version.Version, w http.ResponseWr
 	} else {
 		job = eng.Job("image_export", r.Form["names"]...)
 	}
+	job.SetenvJson("exclude", r.Form["exclude"])
 	job.Stdout.Add(w)
 	return job.Run()
 }

--- a/contrib/docker-ssh.py
+++ b/contrib/docker-ssh.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python3
+#
+# docker-ssh: push and pull docker images over ssh
+#
+# usage:
+#   docker-ssh pull [-h] [USER@]HOST[:PORT] IMAGE [IMAGE ...]
+#   docker-ssh push [-h] [USER@]HOST[:PORT] IMAGE [IMAGE ...]
+#
+# This script uses `docker save` `docker load` and a ssh session to transfer
+# images from/to a docker daemon running on a remote host.
+#
+# If possible it calls the `docker save` command with the --exclude option so
+# as not to transfer images that are already present in the destination daemon.
+#
+
+import argparse, os, re, subprocess, sys, tempfile, time
+
+PROG = "docker-ssh"
+
+class SshSession:
+    def __init__(self, user, host, port):
+        self.user = user
+        self.host = host
+        self.port = port
+        self.proc = None
+
+    def cmd(self, args=[], opt=()):
+        cmd = list(self.basecmd)
+        cmd.extend(opt)
+        cmd.append(self.host)
+        assert isinstance(args, list)
+        cmd.extend(args)
+        return cmd
+
+    def __enter__(self):
+        assert self.proc is None
+        self.tmpdir  = tempfile.TemporaryDirectory()
+        self.tmpsock = os.path.join(self.tmpdir.__enter__(), "sock")
+
+        self.basecmd = ["ssh", "-o", "ControlPath %s" % self.tmpsock, "-e", "none"]
+        if self.user:
+            self.basecmd.extend(["-l", self.user])
+        if self.port:
+            self.basecmd.extend(["-p", self.port])
+
+        self.proc = subprocess.Popen(self.cmd(opt=["-MN"]))
+        while not os.path.exists(self.tmpsock):
+            time.sleep(0.1)
+            if self.proc.poll() is not None:
+                die("ssh connection error")
+
+        return self
+
+    def __exit__(self, a, b, c):
+        try:
+            self.proc.terminate()
+            self.proc.wait()
+        finally:
+            self.tmpdir.cleanup()
+            self.tmpdir.__exit__(a, b, c)
+
+def run(cmd, *, input="", **kw):
+    print (cmd)
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, **kw)
+    out, err = proc.communicate(input)
+
+    if proc.returncode:
+        die("subprocess returned error code %d" % proc.returncode)
+    return out
+
+def run_err(cmd, *, input="", **kw):
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=subprocess.PIPE, **kw)
+    out, err = proc.communicate(input)
+    return err, proc.returncode
+
+def die(msg):
+    sys.stderr.write("%s: %s\n" % (PROG, msg))
+    sys.exit(1)
+
+def list_images(docker_cmd):
+    return run(docker_cmd + ["images", "-q", "--no-trunc", "-a"]).decode().splitlines()
+
+def push(session, images):
+    err, code = run_err(["docker", "save"])
+    excludes = list_images(session.cmd(["docker"])) if b"--exclude" in err else ()
+
+    
+    cmd = "docker save {exclude} {images} | {ssh} docker load".format(
+            ssh     = " ".join(map(repr, session.cmd())),
+            exclude = " ".join("-e %s" % x for x in excludes),
+            images  = " ".join(map(repr, images))
+            )
+    run(cmd, shell=True)
+
+    
+
+def pull(session, images):
+    err, code = run_err(session.cmd(["docker", "save"]))
+    excludes = list_images(["docker"]) if b"--exclude" in err else ()
+
+    cmd = "{ssh} docker save {exclude} {images} | tar tv".format(
+            ssh     = " ".join(map(repr, session.cmd())),
+            exclude = " ".join("-e %s" % x for x in excludes),
+            images  = " ".join(map(repr, images))
+            )
+    run(cmd, shell=True)
+
+def main():
+
+    parser = argparse.ArgumentParser(prog=PROG,
+        	    description="pull and push docker images over ssh")
+
+    sub = parser.add_subparsers(dest="command", help="sub-command help")
+
+    
+    p = sub.add_parser("push", help="push images to the remote host")
+    p.add_argument("remote", metavar="[USER@]HOST[:PORT]",
+            help="paramenters to connect to the remote docker daemon")
+    p.add_argument("images", metavar="IMAGE", nargs="+",
+            help="docker images to be pushed")
+
+    p = sub.add_parser("pull", help="pull images from the remote host")
+    p.add_argument("remote", metavar="[USER@]HOST[:PORT]",
+            help="paramenters to connect to the remote docker daemon")
+    p.add_argument("images", metavar="IMAGE", nargs="+",
+            help="docker images to be pulled")
+
+
+    args = parser.parse_args()
+
+    mo = re.match(r"(?:([^:@/\s]+)@)?([^:@/\s]+)(?::([^:@/\s]+))?$", args.remote, re.I)
+    if not mo:
+        die("remote host must match: [USER@]HOST[:PORT]")
+
+    args.user, args.host, args.port = mo.groups()
+
+    with SshSession(args.user, args.host, args.port) as session:
+        if args.command == "push":
+            push(session, args.images)
+        elif args.command == "pull":
+            pull(session, args.images)
+
+main()
+
+# vim:sw=4:et:sts=4:nosta:

--- a/docs/man/docker-save.1.md
+++ b/docs/man/docker-save.1.md
@@ -6,6 +6,7 @@ docker-save - Save an image to a tar archive (streamed to STDOUT by default)
 
 # SYNOPSIS
 **docker save**
+[**-e**|**--exclude**[=*[]*]]
 [**-o**|**--output**[=*OUTPUT*]]
 IMAGE
 
@@ -16,6 +17,9 @@ parent layers, and all tags + versions, or specified repo:tag.
 Stream to a file instead of STDOUT by using **-o**.
 
 # OPTIONS
+**-e**, **--exclude**=[]
+   Images not to be included in the archive
+
 **-o**, **--output**=""
    Write to a file, instead of STDOUT
 

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -1418,6 +1418,10 @@ See the [image tarball format](#image-tarball-format) for more details.
 
         Binary data stream
 
+Query Parameters:
+
+-   **exclude** – image to be excluded from the tarball (may be used multiple times)
+
 Status Codes:
 
 -   **200** – no error
@@ -1446,6 +1450,10 @@ See the [image tarball format](#image-tarball-format) for more details.
         Content-Type: application/x-tar
 
         Binary data stream
+
+Query Parameters:
+
+-   **exclude** – image to be excluded from the tarball (may be used multiple times)
 
 Status Codes:
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1557,6 +1557,7 @@ restart limit is only valid for the ** on-failure ** policy.
 
     Save an image(s) to a tar archive (streamed to STDOUT by default)
 
+      -e, --exclude=[]   Images not to be included in the archive
       -o, --output=""    Write to a file, instead of STDOUT
 
 Produces a tarred repository to the standard output stream.
@@ -1577,6 +1578,10 @@ It is used to create a backup that can then be used with `docker load`
 It is even useful to cherry-pick particular tags of an image repository
 
    $ sudo docker save -o ubuntu.tar ubuntu:lucid ubuntu:saucy
+
+The purpose of the `--exclude` option is to reduce the size of the archive by
+excluding specific layers (and their parents). This is useful for transferring
+an image to another host where parent layers are already present.
 
 ## search
 


### PR DESCRIPTION
close #3870

This PR introduces the `--exclude` option in  `docker save` (and in the underlying API) to exclude the given layers from the created archive.

 Note : I used --exclude instead of --have (as I suggested in #3870) because it is clearer in the documentation and consistent with the meaning of --exclude in archiving utilities like `tar`
