### PR TITLE
remove deprecated cmd function in integration-cli

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2429,7 +2429,7 @@ func TestBuildNoContext(t *testing.T) {
 		t.Fatalf("build failed to complete: %v %v", out, err)
 	}
 
-	if out, _, err := cmd(t, "run", "--rm", "nocontext"); out != "ok\n" || err != nil {
+	if out, _, err := dockerCmd(t, "run", "--rm", "nocontext"); out != "ok\n" || err != nil {
 		t.Fatalf("run produced invalid output: %q, expected %q", out, "ok")
 	}
 

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -23,7 +23,7 @@ const (
 // Test for #5656
 // Check that garbage paths don't escape the container's rootfs
 func TestCpGarbagePath(t *testing.T) {
-	out, exitCode, err := cmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
+	out, exitCode, err := dockerCmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
 	if err != nil || exitCode != 0 {
 		t.Fatal("failed to create a container", out, err)
 	}
@@ -31,7 +31,7 @@ func TestCpGarbagePath(t *testing.T) {
 	cleanedContainerID := stripTrailingCharacters(out)
 	defer deleteContainer(cleanedContainerID)
 
-	out, _, err = cmd(t, "wait", cleanedContainerID)
+	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
 	if err != nil || stripTrailingCharacters(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
@@ -59,7 +59,7 @@ func TestCpGarbagePath(t *testing.T) {
 
 	path := filepath.Join("../../../../../../../../../../../../", cpFullPath)
 
-	_, _, err = cmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
+	_, _, err = dockerCmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
 	if err != nil {
 		t.Fatalf("couldn't copy from garbage path: %s:%s %s", cleanedContainerID, path, err)
 	}
@@ -85,7 +85,7 @@ func TestCpGarbagePath(t *testing.T) {
 
 // Check that relative paths are relative to the container's rootfs
 func TestCpRelativePath(t *testing.T) {
-	out, exitCode, err := cmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
+	out, exitCode, err := dockerCmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
 	if err != nil || exitCode != 0 {
 		t.Fatal("failed to create a container", out, err)
 	}
@@ -93,7 +93,7 @@ func TestCpRelativePath(t *testing.T) {
 	cleanedContainerID := stripTrailingCharacters(out)
 	defer deleteContainer(cleanedContainerID)
 
-	out, _, err = cmd(t, "wait", cleanedContainerID)
+	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
 	if err != nil || stripTrailingCharacters(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
@@ -122,7 +122,7 @@ func TestCpRelativePath(t *testing.T) {
 
 	path, _ := filepath.Rel("/", cpFullPath)
 
-	_, _, err = cmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
+	_, _, err = dockerCmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
 	if err != nil {
 		t.Fatalf("couldn't copy from relative path: %s:%s %s", cleanedContainerID, path, err)
 	}
@@ -148,7 +148,7 @@ func TestCpRelativePath(t *testing.T) {
 
 // Check that absolute paths are relative to the container's rootfs
 func TestCpAbsolutePath(t *testing.T) {
-	out, exitCode, err := cmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
+	out, exitCode, err := dockerCmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
 	if err != nil || exitCode != 0 {
 		t.Fatal("failed to create a container", out, err)
 	}
@@ -156,7 +156,7 @@ func TestCpAbsolutePath(t *testing.T) {
 	cleanedContainerID := stripTrailingCharacters(out)
 	defer deleteContainer(cleanedContainerID)
 
-	out, _, err = cmd(t, "wait", cleanedContainerID)
+	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
 	if err != nil || stripTrailingCharacters(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
@@ -185,7 +185,7 @@ func TestCpAbsolutePath(t *testing.T) {
 
 	path := cpFullPath
 
-	_, _, err = cmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
+	_, _, err = dockerCmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
 	if err != nil {
 		t.Fatalf("couldn't copy from absolute path: %s:%s %s", cleanedContainerID, path, err)
 	}
@@ -212,7 +212,7 @@ func TestCpAbsolutePath(t *testing.T) {
 // Test for #5619
 // Check that absolute symlinks are still relative to the container's rootfs
 func TestCpAbsoluteSymlink(t *testing.T) {
-	out, exitCode, err := cmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpFullPath+" container_path")
+	out, exitCode, err := dockerCmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpFullPath+" container_path")
 	if err != nil || exitCode != 0 {
 		t.Fatal("failed to create a container", out, err)
 	}
@@ -220,7 +220,7 @@ func TestCpAbsoluteSymlink(t *testing.T) {
 	cleanedContainerID := stripTrailingCharacters(out)
 	defer deleteContainer(cleanedContainerID)
 
-	out, _, err = cmd(t, "wait", cleanedContainerID)
+	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
 	if err != nil || stripTrailingCharacters(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
@@ -249,7 +249,7 @@ func TestCpAbsoluteSymlink(t *testing.T) {
 
 	path := filepath.Join("/", "container_path")
 
-	_, _, err = cmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
+	_, _, err = dockerCmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
 	if err != nil {
 		t.Fatalf("couldn't copy from absolute path: %s:%s %s", cleanedContainerID, path, err)
 	}
@@ -276,7 +276,7 @@ func TestCpAbsoluteSymlink(t *testing.T) {
 // Test for #5619
 // Check that symlinks which are part of the resource path are still relative to the container's rootfs
 func TestCpSymlinkComponent(t *testing.T) {
-	out, exitCode, err := cmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpTestPath+" container_path")
+	out, exitCode, err := dockerCmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpTestPath+" container_path")
 	if err != nil || exitCode != 0 {
 		t.Fatal("failed to create a container", out, err)
 	}
@@ -284,7 +284,7 @@ func TestCpSymlinkComponent(t *testing.T) {
 	cleanedContainerID := stripTrailingCharacters(out)
 	defer deleteContainer(cleanedContainerID)
 
-	out, _, err = cmd(t, "wait", cleanedContainerID)
+	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
 	if err != nil || stripTrailingCharacters(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
@@ -313,7 +313,7 @@ func TestCpSymlinkComponent(t *testing.T) {
 
 	path := filepath.Join("/", "container_path", cpTestName)
 
-	_, _, err = cmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
+	_, _, err = dockerCmd(t, "cp", cleanedContainerID+":"+path, tmpdir)
 	if err != nil {
 		t.Fatalf("couldn't copy from symlink path component: %s:%s %s", cleanedContainerID, path, err)
 	}
@@ -339,7 +339,7 @@ func TestCpSymlinkComponent(t *testing.T) {
 
 // Check that cp with unprivileged user doesn't return any error
 func TestCpUnprivilegedUser(t *testing.T) {
-	out, exitCode, err := cmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "touch "+cpTestName)
+	out, exitCode, err := dockerCmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "touch "+cpTestName)
 	if err != nil || exitCode != 0 {
 		t.Fatal("failed to create a container", out, err)
 	}
@@ -347,7 +347,7 @@ func TestCpUnprivilegedUser(t *testing.T) {
 	cleanedContainerID := stripTrailingCharacters(out)
 	defer deleteContainer(cleanedContainerID)
 
-	out, _, err = cmd(t, "wait", cleanedContainerID)
+	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
 	if err != nil || stripTrailingCharacters(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
@@ -389,7 +389,7 @@ func TestCpVolumePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	out, exitCode, err := cmd(t, "run", "-d", "-v", "/foo", "-v", tmpDir+"/test:/test", "-v", tmpDir+":/baz", "busybox", "/bin/sh", "-c", "touch /foo/bar")
+	out, exitCode, err := dockerCmd(t, "run", "-d", "-v", "/foo", "-v", tmpDir+"/test:/test", "-v", tmpDir+":/baz", "busybox", "/bin/sh", "-c", "touch /foo/bar")
 	if err != nil || exitCode != 0 {
 		t.Fatal("failed to create a container", out, err)
 	}
@@ -397,13 +397,13 @@ func TestCpVolumePath(t *testing.T) {
 	cleanedContainerID := stripTrailingCharacters(out)
 	defer deleteContainer(cleanedContainerID)
 
-	out, _, err = cmd(t, "wait", cleanedContainerID)
+	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
 	if err != nil || stripTrailingCharacters(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
 	// Copy actual volume path
-	_, _, err = cmd(t, "cp", cleanedContainerID+":/foo", outDir)
+	_, _, err = dockerCmd(t, "cp", cleanedContainerID+":/foo", outDir)
 	if err != nil {
 		t.Fatalf("couldn't copy from volume path: %s:%s %v", cleanedContainerID, "/foo", err)
 	}
@@ -423,7 +423,7 @@ func TestCpVolumePath(t *testing.T) {
 	}
 
 	// Copy file nested in volume
-	_, _, err = cmd(t, "cp", cleanedContainerID+":/foo/bar", outDir)
+	_, _, err = dockerCmd(t, "cp", cleanedContainerID+":/foo/bar", outDir)
 	if err != nil {
 		t.Fatalf("couldn't copy from volume path: %s:%s %v", cleanedContainerID, "/foo", err)
 	}
@@ -436,7 +436,7 @@ func TestCpVolumePath(t *testing.T) {
 	}
 
 	// Copy Bind-mounted dir
-	_, _, err = cmd(t, "cp", cleanedContainerID+":/baz", outDir)
+	_, _, err = dockerCmd(t, "cp", cleanedContainerID+":/baz", outDir)
 	if err != nil {
 		t.Fatalf("couldn't copy from bind-mounted volume path: %s:%s %v", cleanedContainerID, "/baz", err)
 	}
@@ -449,7 +449,7 @@ func TestCpVolumePath(t *testing.T) {
 	}
 
 	// Copy file nested in bind-mounted dir
-	_, _, err = cmd(t, "cp", cleanedContainerID+":/baz/test", outDir)
+	_, _, err = dockerCmd(t, "cp", cleanedContainerID+":/baz/test", outDir)
 	fb, err := ioutil.ReadFile(outDir + "/baz/test")
 	if err != nil {
 		t.Fatal(err)
@@ -463,7 +463,7 @@ func TestCpVolumePath(t *testing.T) {
 	}
 
 	// Copy bind-mounted file
-	_, _, err = cmd(t, "cp", cleanedContainerID+":/test", outDir)
+	_, _, err = dockerCmd(t, "cp", cleanedContainerID+":/test", outDir)
 	fb, err = ioutil.ReadFile(outDir + "/test")
 	if err != nil {
 		t.Fatal(err)

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -16,12 +16,12 @@ import (
 )
 
 func TestEventsUntag(t *testing.T) {
-	out, _, _ := cmd(t, "images", "-q")
+	out, _, _ := dockerCmd(t, "images", "-q")
 	image := strings.Split(out, "\n")[0]
-	cmd(t, "tag", image, "utest:tag1")
-	cmd(t, "tag", image, "utest:tag2")
-	cmd(t, "rmi", "utest:tag1")
-	cmd(t, "rmi", "utest:tag2")
+	dockerCmd(t, "tag", image, "utest:tag1")
+	dockerCmd(t, "tag", image, "utest:tag2")
+	dockerCmd(t, "rmi", "utest:tag1")
+	dockerCmd(t, "rmi", "utest:tag2")
 	eventsCmd := exec.Command("timeout", "0.2", dockerBinary, "events", "--since=1")
 	out, _, _ = runCommandWithOutput(eventsCmd)
 	events := strings.Split(out, "\n")
@@ -39,11 +39,11 @@ func TestEventsUntag(t *testing.T) {
 
 func TestEventsPause(t *testing.T) {
 	name := "testeventpause"
-	out, _, _ := cmd(t, "images", "-q")
+	out, _, _ := dockerCmd(t, "images", "-q")
 	image := strings.Split(out, "\n")[0]
-	cmd(t, "run", "-d", "--name", name, image, "sleep", "2")
-	cmd(t, "pause", name)
-	cmd(t, "unpause", name)
+	dockerCmd(t, "run", "-d", "--name", name, image, "sleep", "2")
+	dockerCmd(t, "pause", name)
+	dockerCmd(t, "unpause", name)
 
 	defer deleteAllContainers()
 
@@ -75,7 +75,7 @@ func TestEventsPause(t *testing.T) {
 func TestEventsContainerFailStartDie(t *testing.T) {
 	defer deleteAllContainers()
 
-	out, _, _ := cmd(t, "images", "-q")
+	out, _, _ := dockerCmd(t, "images", "-q")
 	image := strings.Split(out, "\n")[0]
 	eventsCmd := exec.Command(dockerBinary, "run", "-d", "--name", "testeventdie", image, "blerg")
 	_, _, err := runCommandWithOutput(eventsCmd)
@@ -106,7 +106,7 @@ func TestEventsContainerFailStartDie(t *testing.T) {
 func TestEventsLimit(t *testing.T) {
 	defer deleteAllContainers()
 	for i := 0; i < 30; i++ {
-		cmd(t, "run", "busybox", "echo", strconv.Itoa(i))
+		dockerCmd(t, "run", "busybox", "echo", strconv.Itoa(i))
 	}
 	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", time.Now().Unix()))
 	out, _, _ := runCommandWithOutput(eventsCmd)
@@ -119,7 +119,7 @@ func TestEventsLimit(t *testing.T) {
 }
 
 func TestEventsContainerEvents(t *testing.T) {
-	cmd(t, "run", "--rm", "busybox", "true")
+	dockerCmd(t, "run", "--rm", "busybox", "true")
 	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", time.Now().Unix()))
 	out, exitCode, err := runCommandWithOutput(eventsCmd)
 	if exitCode != 0 || err != nil {
@@ -190,7 +190,7 @@ func TestEventsRedirectStdout(t *testing.T) {
 
 	since := time.Now().Unix()
 
-	cmd(t, "run", "busybox", "true")
+	dockerCmd(t, "run", "busybox", "true")
 
 	defer deleteAllContainers()
 

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -62,21 +62,21 @@ func TestLinksPingUnlinkedContainers(t *testing.T) {
 
 func TestLinksPingLinkedContainers(t *testing.T) {
 	var out string
-	out, _, _ = cmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
+	out, _, _ = dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
 	idA := stripTrailingCharacters(out)
-	out, _, _ = cmd(t, "run", "-d", "--name", "container2", "busybox", "sleep", "10")
+	out, _, _ = dockerCmd(t, "run", "-d", "--name", "container2", "busybox", "sleep", "10")
 	idB := stripTrailingCharacters(out)
-	cmd(t, "run", "--rm", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "sh", "-c", "ping -c 1 alias1 -W 1 && ping -c 1 alias2 -W 1")
-	cmd(t, "kill", idA)
-	cmd(t, "kill", idB)
+	dockerCmd(t, "run", "--rm", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "sh", "-c", "ping -c 1 alias1 -W 1 && ping -c 1 alias2 -W 1")
+	dockerCmd(t, "kill", idA)
+	dockerCmd(t, "kill", idB)
 	deleteAllContainers()
 
 	logDone("links - ping linked container")
 }
 
 func TestLinksIpTablesRulesWhenLinkAndUnlink(t *testing.T) {
-	cmd(t, "run", "-d", "--name", "child", "--publish", "8080:80", "busybox", "sleep", "10")
-	cmd(t, "run", "-d", "--name", "parent", "--link", "child:http", "busybox", "sleep", "10")
+	dockerCmd(t, "run", "-d", "--name", "child", "--publish", "8080:80", "busybox", "sleep", "10")
+	dockerCmd(t, "run", "-d", "--name", "parent", "--link", "child:http", "busybox", "sleep", "10")
 
 	childIP := findContainerIP(t, "child")
 	parentIP := findContainerIP(t, "parent")
@@ -87,13 +87,13 @@ func TestLinksIpTablesRulesWhenLinkAndUnlink(t *testing.T) {
 		t.Fatal("Iptables rules not found")
 	}
 
-	cmd(t, "rm", "--link", "parent/http")
+	dockerCmd(t, "rm", "--link", "parent/http")
 	if iptables.Exists(sourceRule...) || iptables.Exists(destinationRule...) {
 		t.Fatal("Iptables rules should be removed when unlink")
 	}
 
-	cmd(t, "kill", "child")
-	cmd(t, "kill", "parent")
+	dockerCmd(t, "kill", "child")
+	dockerCmd(t, "kill", "parent")
 	deleteAllContainers()
 
 	logDone("link - verify iptables when link and unlink")
@@ -105,9 +105,9 @@ func TestLinksInspectLinksStarted(t *testing.T) {
 		result   []string
 	)
 	defer deleteAllContainers()
-	cmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
-	cmd(t, "run", "-d", "--name", "container2", "busybox", "sleep", "10")
-	cmd(t, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "sleep", "10")
+	dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
+	dockerCmd(t, "run", "-d", "--name", "container2", "busybox", "sleep", "10")
+	dockerCmd(t, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "sleep", "10")
 	links, err := inspectFieldJSON("testinspectlink", "HostConfig.Links")
 	if err != nil {
 		t.Fatal(err)
@@ -134,9 +134,9 @@ func TestLinksInspectLinksStopped(t *testing.T) {
 		result   []string
 	)
 	defer deleteAllContainers()
-	cmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
-	cmd(t, "run", "-d", "--name", "container2", "busybox", "sleep", "10")
-	cmd(t, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "true")
+	dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
+	dockerCmd(t, "run", "-d", "--name", "container2", "busybox", "sleep", "10")
+	dockerCmd(t, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "true")
 	links, err := inspectFieldJSON("testinspectlink", "HostConfig.Links")
 	if err != nil {
 		t.Fatal(err)

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -29,7 +29,7 @@ func TestRmiWithContainerFails(t *testing.T) {
 	}
 
 	// make sure it didn't delete the busybox name
-	images, _, _ := cmd(t, "images")
+	images, _, _ := dockerCmd(t, "images")
 	if !strings.Contains(images, "busybox") {
 		t.Fatalf("The name 'busybox' should not have been removed from images: %q", images)
 	}
@@ -40,35 +40,35 @@ func TestRmiWithContainerFails(t *testing.T) {
 }
 
 func TestRmiTag(t *testing.T) {
-	imagesBefore, _, _ := cmd(t, "images", "-a")
-	cmd(t, "tag", "busybox", "utest:tag1")
-	cmd(t, "tag", "busybox", "utest/docker:tag2")
-	cmd(t, "tag", "busybox", "utest:5000/docker:tag3")
+	imagesBefore, _, _ := dockerCmd(t, "images", "-a")
+	dockerCmd(t, "tag", "busybox", "utest:tag1")
+	dockerCmd(t, "tag", "busybox", "utest/docker:tag2")
+	dockerCmd(t, "tag", "busybox", "utest:5000/docker:tag3")
 	{
-		imagesAfter, _, _ := cmd(t, "images", "-a")
+		imagesAfter, _, _ := dockerCmd(t, "images", "-a")
 		if nLines(imagesAfter) != nLines(imagesBefore)+3 {
 			t.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
 		}
 	}
-	cmd(t, "rmi", "utest/docker:tag2")
+	dockerCmd(t, "rmi", "utest/docker:tag2")
 	{
-		imagesAfter, _, _ := cmd(t, "images", "-a")
+		imagesAfter, _, _ := dockerCmd(t, "images", "-a")
 		if nLines(imagesAfter) != nLines(imagesBefore)+2 {
 			t.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
 		}
 
 	}
-	cmd(t, "rmi", "utest:5000/docker:tag3")
+	dockerCmd(t, "rmi", "utest:5000/docker:tag3")
 	{
-		imagesAfter, _, _ := cmd(t, "images", "-a")
+		imagesAfter, _, _ := dockerCmd(t, "images", "-a")
 		if nLines(imagesAfter) != nLines(imagesBefore)+1 {
 			t.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
 		}
 
 	}
-	cmd(t, "rmi", "utest:tag1")
+	dockerCmd(t, "rmi", "utest:tag1")
 	{
-		imagesAfter, _, _ := cmd(t, "images", "-a")
+		imagesAfter, _, _ := dockerCmd(t, "images", "-a")
 		if nLines(imagesAfter) != nLines(imagesBefore)+0 {
 			t.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
 		}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -798,7 +798,7 @@ func TestRunLoopbackWhenNetworkDisabled(t *testing.T) {
 }
 
 func TestRunNetHostNotAllowedWithLinks(t *testing.T) {
-	_, _, err := cmd(t, "run", "--name", "linked", "busybox", "true")
+	_, _, err := dockerCmd(t, "run", "--name", "linked", "busybox", "true")
 
 	cmd := exec.Command(dockerBinary, "run", "--net=host", "--link", "linked:linked", "busybox", "true")
 	_, _, err = runCommandWithOutput(cmd)
@@ -1204,7 +1204,7 @@ func TestRunModeHostname(t *testing.T) {
 }
 
 func TestRunRootWorkdir(t *testing.T) {
-	s, _, err := cmd(t, "run", "--workdir", "/", "busybox", "pwd")
+	s, _, err := dockerCmd(t, "run", "--workdir", "/", "busybox", "pwd")
 	if err != nil {
 		t.Fatal(s, err)
 	}
@@ -1218,7 +1218,7 @@ func TestRunRootWorkdir(t *testing.T) {
 }
 
 func TestRunAllowBindMountingRoot(t *testing.T) {
-	s, _, err := cmd(t, "run", "-v", "/:/host", "busybox", "ls", "/host")
+	s, _, err := dockerCmd(t, "run", "-v", "/:/host", "busybox", "ls", "/host")
 	if err != nil {
 		t.Fatal(s, err)
 	}

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -12,8 +12,8 @@ import (
 func TestStartAttachReturnsOnError(t *testing.T) {
 	defer deleteAllContainers()
 
-	cmd(t, "run", "-d", "--name", "test", "busybox")
-	cmd(t, "stop", "test")
+	dockerCmd(t, "run", "-d", "--name", "test", "busybox")
+	dockerCmd(t, "stop", "test")
 
 	// Expect this to fail because the above container is stopped, this is what we want
 	if _, err := runCommand(exec.Command(dockerBinary, "run", "-d", "--name", "test2", "--link", "test:test", "busybox")); err == nil {
@@ -73,7 +73,7 @@ func TestStartRecordError(t *testing.T) {
 	defer deleteAllContainers()
 
 	// when container runs successfully, we should not have state.Error
-	cmd(t, "run", "-d", "-p", "9999:9999", "--name", "test", "busybox", "top")
+	dockerCmd(t, "run", "-d", "-p", "9999:9999", "--name", "test", "busybox", "top")
 	stateErr, err := inspectField("test", "State.Error")
 	if err != nil {
 		t.Fatalf("Failed to inspect %q state's error, got error %q", "test", err)
@@ -97,8 +97,8 @@ func TestStartRecordError(t *testing.T) {
 	}
 
 	// Expect the conflict to be resolved when we stop the initial container
-	cmd(t, "stop", "test")
-	cmd(t, "start", "test2")
+	dockerCmd(t, "stop", "test")
+	dockerCmd(t, "start", "test2")
 	stateErr, err = inspectField("test2", "State.Error")
 	if err != nil {
 		t.Fatalf("Failed to inspect %q state's error, got error %q", "test", err)
@@ -115,7 +115,7 @@ func TestStartVolumesFromFailsCleanly(t *testing.T) {
 	defer deleteAllContainers()
 
 	// Create the first data volume
-	cmd(t, "run", "-d", "--name", "data_before", "-v", "/foo", "busybox")
+	dockerCmd(t, "run", "-d", "--name", "data_before", "-v", "/foo", "busybox")
 
 	// Expect this to fail because the data test after contaienr doesn't exist yet
 	if _, err := runCommand(exec.Command(dockerBinary, "run", "-d", "--name", "consumer", "--volumes-from", "data_before", "--volumes-from", "data_after", "busybox")); err == nil {
@@ -123,13 +123,13 @@ func TestStartVolumesFromFailsCleanly(t *testing.T) {
 	}
 
 	// Create the second data volume
-	cmd(t, "run", "-d", "--name", "data_after", "-v", "/bar", "busybox")
+	dockerCmd(t, "run", "-d", "--name", "data_after", "-v", "/bar", "busybox")
 
 	// Now, all the volumes should be there
-	cmd(t, "start", "consumer")
+	dockerCmd(t, "start", "consumer")
 
 	// Check that we have the volumes we want
-	out, _, _ := cmd(t, "inspect", "--format='{{ len .Volumes }}'", "consumer")
+	out, _, _ := dockerCmd(t, "inspect", "--format='{{ len .Volumes }}'", "consumer")
 	n_volumes := strings.Trim(out, " \r\n'")
 	if n_volumes != "2" {
 		t.Fatalf("Missing volumes: expected 2, got %s", n_volumes)

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -356,11 +356,6 @@ func pullImageIfNotExist(image string) (err error) {
 	return
 }
 
-// deprecated, use dockerCmd instead
-func cmd(t *testing.T, args ...string) (string, int, error) {
-	return dockerCmd(t, args...)
-}
-
 func dockerCmd(t *testing.T, args ...string) (string, int, error) {
 	out, status, err := runCommandWithOutput(exec.Command(dockerBinary, args...))
 	if err != nil {


### PR DESCRIPTION
Remove deprecated cmd function in integration-cli
and change cmd to dockerCmd in all test files

Signed-off-by: Daehyeok Mun daehyeok@gmail.com
