### PR TITLE
docs: man docker-images: inconsistent naming

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1328,7 +1328,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 }
 
 func (cli *DockerCli) CmdImages(args ...string) error {
-	cmd := cli.Subcmd("images", "[NAME]", "List images")
+	cmd := cli.Subcmd("images", "[REPOSITORY]", "List images")
 	quiet := cmd.Bool([]string{"q", "-quiet"}, false, "Only show numeric IDs")
 	all := cmd.Bool([]string{"a", "-all"}, false, "Show all images (by default filter out the intermediate image layers)")
 	noTrunc := cmd.Bool([]string{"#notrunc", "-no-trunc"}, false, "Don't truncate output")

--- a/docs/man/docker-images.1.md
+++ b/docs/man/docker-images.1.md
@@ -10,7 +10,7 @@ docker-images - List images
 [**-f**|**--filter**[=*[]*]]
 [**--no-trunc**[=*false*]]
 [**-q**|**--quiet**[=*false*]]
- [NAME]
+ [REPOSITORY]
 
 # DESCRIPTION
 This command lists the images stored in the local Docker repository.

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -725,7 +725,7 @@ To see how the `docker:latest` image was built:
 
 ## images
 
-    Usage: docker images [OPTIONS] [NAME]
+    Usage: docker images [OPTIONS] [REPOSITORY]
 
     List images
 


### PR DESCRIPTION
Synopsis is mentioning `NAME` while description is describing
`REPOSITORY`.
