### PR TITLE
Proposal: add flag since to logs command.

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1870,6 +1870,7 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 		follow = cmd.Bool([]string{"f", "-follow"}, false, "Follow log output")
 		times  = cmd.Bool([]string{"t", "-timestamps"}, false, "Show timestamps")
 		tail   = cmd.String([]string{"-tail"}, "all", "Output the specified number of lines at the end of logs (defaults to all logs)")
+		since  = cmd.String([]string{"-since"}, "", "Show logs since (yyyy-mm-dd hh:mm or hh:mm)")
 	)
 
 	if err := cmd.Parse(args); err != nil {
@@ -1904,6 +1905,7 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 		v.Set("follow", "1")
 	}
 	v.Set("tail", *tail)
+	v.Set("since", *since)
 
 	return cli.streamHelper("GET", "/containers/"+name+"/logs?"+v.Encode(), env.GetSubEnv("Config").GetBool("Tty"), nil, cli.out, cli.err, nil)
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -415,6 +415,7 @@ func getContainersLogs(eng *engine.Engine, version version.Version, w http.Respo
 	}
 	logsJob.Setenv("follow", r.Form.Get("follow"))
 	logsJob.Setenv("tail", r.Form.Get("tail"))
+	logsJob.Setenv("since", r.Form.Get("since"))
 	logsJob.Setenv("stdout", r.Form.Get("stdout"))
 	logsJob.Setenv("stderr", r.Form.Get("stderr"))
 	logsJob.Setenv("timestamps", r.Form.Get("timestamps"))

--- a/daemon/logs_test.go
+++ b/daemon/logs_test.go
@@ -1,0 +1,49 @@
+package daemon
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseSinceDate(t *testing.T) {
+	tz := strings.Split(time.Now().Local().String(), "+")[1]
+	testData := []struct {
+		t string
+		v string
+	}{
+		{"2012-03-12 05:04", "2012-03-12 05:04:00 +" + tz},
+		{"2012-03-12", "2012-03-12 00:00:00 +" + tz},
+		{"05:04", fmt.Sprintf("%d-%02d-%02d 05:04:00 +%s", time.Now().Year(), time.Now().Month(), time.Now().Day(), tz)},
+	}
+
+	for _, d := range testData {
+		date, err := parseSinceDate(d.t)
+		if err != nil {
+			t.Errorf("%s: %s", d.t, err)
+		}
+		if d.v != date.String() {
+			t.Errorf("%s: Expecting %v, got %v", d.t, d.v, date)
+		}
+	}
+}
+
+func TestParseSinceDateError(t *testing.T) {
+	testData := []struct {
+		t string
+	}{
+		{"05:04 2012-03-12"},
+		{"2012-13-03"},
+		{"2012-2-3"},
+		{"25:66"},
+		{"05:60"},
+		{"5:6"},
+	}
+
+	for _, d := range testData {
+		if date, err := parseSinceDate(d.t); err == nil {
+			t.Errorf("%s: Expecting error, got %s", d.t, date)
+		}
+	}
+}

--- a/docs/man/docker-logs.1.md
+++ b/docs/man/docker-logs.1.md
@@ -25,6 +25,9 @@ then continue streaming new output from the container’s stdout and stderr.
 **-f**, **--follow**=*true*|*false*
    Follow log output. The default is *false*.
 
+**--since**=*"yyyy-mm-dd hh:mm"*|*yyyy-mm-dd*|*hh:mm*
+   Show logs since.  The default is to show all logs.
+
 **-t**, **--timestamps**=*true*|*false*
    Show timestamps. The default is *false*.
 

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -386,7 +386,7 @@ Get stdout and stderr logs from the container ``id``
 
 **Example request**:
 
-       GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10 HTTP/1.1
+       GET /containers/4fa6e0f0c678/logs?stderr=1&stdout=1&timestamps=1&follow=1&tail=10&since=14%3A00 HTTP/1.1
 
 **Example response**:
 
@@ -398,6 +398,7 @@ Get stdout and stderr logs from the container ``id``
 Query Parameters:
 
 -   **follow** – 1/True/true or 0/False/false, return stream. Default false
+-   **since** – `"yyyy-mm-dd hh:mm"` or `yyyy-mm-dd` or `hh:mm`, show logs since time period.  Default all logs
 -   **stdout** – 1/True/true or 0/False/false, show stdout log. Default false
 -   **stderr** – 1/True/true or 0/False/false, show stderr log. Default false
 -   **timestamps** – 1/True/true or 0/False/false, print timestamps for

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1013,6 +1013,7 @@ For example:
     Fetch the logs of a container
 
       -f, --follow=false        Follow log output
+      --since=""                Show logs since (defaults to all logs)
       -t, --timestamps=false    Show timestamps
       --tail="all"              Output the specified number of lines at the end of logs (defaults to all logs)
 
@@ -1028,6 +1029,12 @@ The `docker logs --timestamp` commands will add an RFC3339Nano
 timestamp, for example `2014-09-16T06:17:46.000000000Z`, to each
 log entry. To ensure that the timestamps for are aligned the
 nano-second part of the timestamp will be padded with zero when necessary.
+
+The `docker logs --since` flag accepts the follow date/time formats:
+
+`yyyy-dd-mm hh:mm`: show logs from that day and time onwards.
+`yyyy-dd-mm`: show logs from 00:00 on that day and onwards.
+`hh:mm`: show logs from that time today and onwards.
 
 ## port
 


### PR DESCRIPTION
This patch adds a flag `--since` to the logs command.  When specified; `docker logs` will only show logs from that timepoint onwards.

`yyyy-dd-mm hh:mm` : logs from that day, and time onwards
`yyyy-dd-mm` : logs from midnight on that day and onwards
`hh:mm`: logs from that time today and onwards.
