### PR TITLE
pkg/tarsum: add maintainers & add missing s

### DIFF
--- a/pkg/tarsum/MAINTAINER
+++ b/pkg/tarsum/MAINTAINER
@@ -1,1 +1,0 @@
-Eric Windisch <ewindisch@docker.com> (@ewindisch)

--- a/pkg/tarsum/MAINTAINERS
+++ b/pkg/tarsum/MAINTAINERS
@@ -1,0 +1,4 @@
+Derek McGowan <derek@mcgstyle.net> (github: dmcgowan)
+Eric Windisch <ewindisch@docker.com> (github: ewindisch)
+Josh Hawn <josh.hawn@docker.com> (github: jlhawn)
+Vincent Batts <vbatts@redhat.com> (github: vbatts)


### PR DESCRIPTION
This adds Derek McGowan, Josh Hawn and Vincent Batts to the pkg/tarsum MAINTAINERS.

MAINTAINER was renamed to MAINTAINERS as that's the correct name.
