### PR TITLE
Fix the issue that when docker exec a paused container, it will always

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -98,7 +98,9 @@ func (d *Daemon) getActiveContainer(name string) (*Container, error) {
 	if !container.IsRunning() {
 		return nil, fmt.Errorf("Container %s is not running", name)
 	}
-
+	if container.IsPaused() {
+		return nil, fmt.Errorf("Container %s is paused, unpause the container before exec", name)
+	}
 	return container, nil
 }
 

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -328,6 +328,46 @@ func deleteAllContainers() error {
 	return nil
 }
 
+func getPausedContainers() (string, error) {
+	getPausedContainersCmd := exec.Command(dockerBinary, "ps", "-f", "status=paused", "-q", "-a")
+	out, exitCode, err := runCommandWithOutput(getPausedContainersCmd)
+	if exitCode != 0 && err == nil {
+		err = fmt.Errorf("failed to get a list of paused containers: %v\n", out)
+	}
+
+	return out, err
+}
+
+func unpauseContainer(container string) error {
+	unpauseCmd := exec.Command(dockerBinary, "unpause", container)
+	exitCode, err := runCommand(unpauseCmd)
+	if exitCode != 0 && err == nil {
+		err = fmt.Errorf("failed to unpause container")
+	}
+
+	return nil
+}
+
+func unpauseAllContainers() error {
+	containers, err := getPausedContainers()
+	if err != nil {
+		fmt.Println(containers)
+		return err
+	}
+
+	containers = strings.Replace(containers, "\n", " ", -1)
+	containers = strings.Trim(containers, " ")
+	containerList := strings.Split(containers, " ")
+
+	for _, value := range containerList {
+		if err = unpauseContainer(value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func deleteImages(images ...string) error {
 	args := make([]string, 1, 2)
 	args[0] = "rmi"


### PR DESCRIPTION
I think we should check the container status whether is paused  before exec a container. and it should not exec a paused container.

Fixes #9352

Signed-off-by: Chen Chao cc272309126@gmail.com
