### PR TITLE
Update format of notes in docs style guide

### DIFF
--- a/docs/sources/contributing/docs_style-guide.md
+++ b/docs/sources/contributing/docs_style-guide.md
@@ -169,7 +169,7 @@ Use notes sparingly and only to bring things to the reader's attention that are
 critical or otherwise deserving of being called out from the body text. Please
 format all notes as follows:
 
-    **Note:**
+    > **Note:**
     > One line of note text
     > another line of note text
 


### PR DESCRIPTION
It seems like all of the notes in the docs are this format, judging by `ack -Q "Note:" docs`.
