### PR TITLE
Increase memory limit in integration-cli test cases

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -44,7 +44,7 @@ func TestRunEchoStdout(t *testing.T) {
 
 // "test" should be printed
 func TestRunEchoStdoutWithMemoryLimit(t *testing.T) {
-	runCmd := exec.Command(dockerBinary, "run", "-m", "4m", "busybox", "echo", "test")
+	runCmd := exec.Command(dockerBinary, "run", "-m", "16m", "busybox", "echo", "test")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
 		t.Fatalf("failed to run container: %v, output: %q", err, out)
@@ -81,7 +81,7 @@ func TestRunEchoStdoutWitCPULimit(t *testing.T) {
 
 // "test" should be printed
 func TestRunEchoStdoutWithCPUAndMemoryLimit(t *testing.T) {
-	runCmd := exec.Command(dockerBinary, "run", "-c", "1000", "-m", "4m", "busybox", "echo", "test")
+	runCmd := exec.Command(dockerBinary, "run", "-c", "1000", "-m", "16m", "busybox", "echo", "test")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
 		t.Fatalf("failed to run container: %v, output: %q", err, out)


### PR DESCRIPTION
`TestRunEchoStdoutWithMemoryLimit` and `TestRunEchoStdoutWithCPUAndMemoryLimit` defined in `integration-cli/docker_cli_run_test.go` set 4-MB memory limit using cgroups, and a binary compiled using Go Compiler can run successfully within the limit.

A binary compiled using GCCGO consumes more memory, and fails at these test cases. Changing the limit to 16 MB makes the binary pass the tests.

If the current limit value dose not have some specific meanings, I want to increase the memory limit to 16 MB.

Signed-off-by: Yohei Ueda yohei@jp.ibm.com
