### PR TITLE
Windows should not be in "official release" yet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,10 @@ RUN	cd /usr/local/go/src && ./make.bash --no-clean 2>&1
 ENV	DOCKER_CROSSPLATFORMS	\
 	linux/386 linux/arm \
 	darwin/amd64 darwin/386 \
-	freebsd/amd64 freebsd/386 freebsd/arm \
-	windows/amd64 windows/386
+	freebsd/amd64 freebsd/386 freebsd/arm 
+#	windows is experimental for now
+#	windows/amd64 windows/386
+
 # (set an explicit GOARM of 5 for maximum compatibility)
 ENV	GOARM	5
 RUN	cd /usr/local/go/src && bash -xc 'for platform in $DOCKER_CROSSPLATFORMS; do GOOS=${platform%/*} GOARCH=${platform##*/} ./make.bash --no-clean 2>&1; done'


### PR DESCRIPTION
Realized this when trying to push to test.docker.com

Docker-DCO-1.1-Signed-off-by: Jessica Frazelle jess@docker.com (github: jfrazelle)
