### PR TITLE
Proposal: Add --filter flag to logs command with before and since filter.

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1800,15 +1800,6 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 		eventFilterArgs = filters.Args{}
 	)
 
-	// Consolidate all filter flags, and sanity check them early.
-	// They'll get process in the daemon/server.
-	for _, f := range flFilter.GetAll() {
-		var err error
-		eventFilterArgs, err = filters.ParseFlag(f, eventFilterArgs)
-		if err != nil {
-			return err
-		}
-	}
 	var setTime = func(key, value string) {
 		format := timeutils.RFC3339NanoFixed
 		if len(value) < len(format) {
@@ -1826,12 +1817,12 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 	if *until != "" {
 		setTime("until", *until)
 	}
-	if len(eventFilterArgs) > 0 {
-		filterJson, err := filters.ToParam(eventFilterArgs)
-		if err != nil {
-			return err
-		}
-		v.Set("filters", filterJson)
+	json, err := eventFilterArgs.GetAsJSON(flFilter)
+	if err != nil {
+		return err
+	}
+	if json != "" {
+		v.Set("filters", json)
 	}
 	if err := cli.stream("GET", "/events?"+v.Encode(), nil, cli.out, nil); err != nil {
 		return err
@@ -1893,11 +1884,15 @@ func (cli *DockerCli) CmdDiff(args ...string) error {
 
 func (cli *DockerCli) CmdLogs(args ...string) error {
 	var (
-		cmd    = cli.Subcmd("logs", "CONTAINER", "Fetch the logs of a container")
-		follow = cmd.Bool([]string{"f", "-follow"}, false, "Follow log output")
-		times  = cmd.Bool([]string{"t", "-timestamps"}, false, "Show timestamps")
-		tail   = cmd.String([]string{"-tail"}, "all", "Output the specified number of lines at the end of logs (defaults to all logs)")
+		cmd        = cli.Subcmd("logs", "CONTAINER", "Fetch the logs of a container")
+		follow     = cmd.Bool([]string{"f", "-follow"}, false, "Follow log output")
+		times      = cmd.Bool([]string{"t", "-timestamps"}, false, "Show timestamps")
+		tail       = cmd.String([]string{"-tail"}, "all", "Output the specified number of lines at the end of logs (defaults to all logs)")
+		logFilter  = opts.NewListOpts(nil)
+		filterArgs = filters.Args{}
 	)
+	// r is for refine
+	cmd.Var(&logFilter, []string{"r", "-filter"}, "Provide filter values (i.e. 'since=01:00')")
 
 	if err := cmd.Parse(args); err != nil {
 		return nil
@@ -1931,6 +1926,14 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 		v.Set("follow", "1")
 	}
 	v.Set("tail", *tail)
+
+	json, err := filterArgs.GetAsJSON(logFilter)
+	if err != nil {
+		return err
+	}
+	if json != "" {
+		v.Set("filters", json)
+	}
 
 	return cli.streamHelper("GET", "/containers/"+name+"/logs?"+v.Encode(), env.GetSubEnv("Config").GetBool("Tty"), nil, cli.out, cli.err, nil)
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -414,6 +414,7 @@ func getContainersLogs(eng *engine.Engine, version version.Version, w http.Respo
 	if err != nil {
 		return err
 	}
+	logsJob.Setenv("filters", r.Form.Get("filters"))
 	logsJob.Setenv("follow", r.Form.Get("follow"))
 	logsJob.Setenv("tail", r.Form.Get("tail"))
 	logsJob.Setenv("stdout", r.Form.Get("stdout"))

--- a/docs/man/docker-logs.1.md
+++ b/docs/man/docker-logs.1.md
@@ -6,6 +6,7 @@ docker-logs - Fetch the logs of a container
 
 # SYNOPSIS
 **docker logs**
+[**-r**|**--filter**]
 [**-f**|**--follow**[=*false*]]
 [**-t**|**--timestamps**[=*false*]]
 [**--tail**[=*"all"*]]
@@ -22,6 +23,11 @@ The **docker logs --follow** command combines commands **docker logs** and
 then continue streaming new output from the container’s stdout and stderr.
 
 # OPTIONS
+
+**-r**, **--filter=[]**    Provide filter values. Valid filters:
+                           since=*"yyyy-mm-dd hh:mm"*|*yyyy-mm-dd*|*hh:mm* - Show logs since
+                           before=*"yyyy-mm-dd hh:mm"*|*yyyy-mm-dd*|*hh:mm* - Show logs before
+
 **-f**, **--follow**=*true*|*false*
    Follow log output. The default is *false*.
 

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -397,6 +397,7 @@ Get stdout and stderr logs from the container ``id``
 
 Query Parameters:
 
+-   **filters** – a json encoded value of the filters (a map[string][]string)
 -   **follow** – 1/True/true or 0/False/false, return stream. Default false
 -   **stdout** – 1/True/true or 0/False/false, show stdout log. Default false
 -   **stderr** – 1/True/true or 0/False/false, show stderr log. Default false

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1071,6 +1071,7 @@ For example:
 
     Fetch the logs of a container
 
+      -r, --filter              Provide filter values (i.e. 'since=01:00')
       -f, --follow=false        Follow log output
       -t, --timestamps=false    Show timestamps
       --tail="all"              Output the specified number of lines at the end of logs (defaults to all logs)
@@ -1087,6 +1088,17 @@ The `docker logs --timestamp` commands will add an RFC3339Nano
 timestamp, for example `2014-09-16T06:17:46.000000000Z`, to each
 log entry. To ensure that the timestamps for are aligned the
 nano-second part of the timestamp will be padded with zero when necessary.
+
+The `docker logs --filter` command accepts the following filters:
+
+* since
+* before
+
+The value to these filters must be in one of the following formats:
+
+`yyyy-dd-mm hh:mm`: show logs from that day and time onwards.
+`yyyy-dd-mm`: show logs from 00:00 on that day and onwards.
+`hh:mm`: show logs from that time today and onwards.
 
 ## port
 

--- a/pkg/parsers/filters/parse.go
+++ b/pkg/parsers/filters/parse.go
@@ -3,6 +3,7 @@ package filters
 import (
 	"encoding/json"
 	"errors"
+	"github.com/docker/docker/opts"
 	"regexp"
 	"strings"
 )
@@ -82,4 +83,20 @@ func (filters Args) Match(field, source string) bool {
 		}
 	}
 	return false
+}
+
+// Consolidate all filter flags, and sanity check them early.
+// They'll get process in the daemon/server.
+func (args Args) GetAsJSON(opts opts.ListOpts) (string, error) {
+	for _, f := range opts.GetAll() {
+		var err error
+		args, err = ParseFlag(f, args)
+		if err != nil {
+			return "", err
+		}
+	}
+	if len(args) > 0 {
+		return ToParam(args)
+	}
+	return "", nil
 }

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // FIXME: Change this not to receive default value as parameter
@@ -103,4 +104,25 @@ func ParseKeyValueOpt(opt string) (string, string, error) {
 		return "", "", fmt.Errorf("Unable to parse key/value option: %s", opt)
 	}
 	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
+}
+
+func ParseFilterDate(filter string) (time.Time, error) {
+	var format = "2006-01-02 15:04:05"
+	parts := strings.FieldsFunc(filter, func(c rune) bool {
+		return c == '-' || c == ' ' || c == ':'
+	})
+
+	switch len(parts) {
+	case 5: // date & time
+		filter = fmt.Sprintf("%s:00", filter)
+	case 3: // date
+		filter = fmt.Sprintf("%s 00:00:00", filter)
+	case 2: // time
+		y, m, d := time.Now().Date()
+		filter = fmt.Sprintf("%d-%02d-%02d %s:00", y, m, d, filter)
+	default:
+		return time.Time{}, fmt.Errorf("Invalid filter date format %s", filter)
+	}
+
+	return time.ParseInLocation(format, filter, time.Local)
 }

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -107,6 +107,11 @@ func ParseKeyValueOpt(opt string) (string, string, error) {
 }
 
 func ParseFilterDate(filter string) (time.Time, error) {
+	// Probably got a timestamp
+	if ts, err := strconv.ParseInt(filter, 10, 64); err == nil {
+		return time.Unix(ts, 0), nil
+	}
+
 	var format = "2006-01-02 15:04:05"
 	parts := strings.FieldsFunc(filter, func(c rune) bool {
 		return c == '-' || c == ' ' || c == ':'
@@ -123,6 +128,5 @@ func ParseFilterDate(filter string) (time.Time, error) {
 	default:
 		return time.Time{}, fmt.Errorf("Invalid filter date format %s", filter)
 	}
-
 	return time.ParseInLocation(format, filter, time.Local)
 }

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -1,7 +1,10 @@
 package parsers
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseHost(t *testing.T) {
@@ -79,5 +82,46 @@ func TestParsePortMapping(t *testing.T) {
 	}
 	if data["private"] != "8080" {
 		t.Fail()
+	}
+}
+
+func TestParseFilterDate(t *testing.T) {
+	tz := strings.Split(time.Now().Local().String(), "+")[1]
+	testData := []struct {
+		t string
+		v string
+	}{
+		{"2012-03-12 05:04", "2012-03-12 05:04:00 +" + tz},
+		{"2012-03-12", "2012-03-12 00:00:00 +" + tz},
+		{"05:04", fmt.Sprintf("%d-%02d-%02d 05:04:00 +%s", time.Now().Year(), time.Now().Month(), time.Now().Day(), tz)},
+	}
+
+	for _, d := range testData {
+		date, err := ParseFilterDate(d.t)
+		if err != nil {
+			t.Errorf("%s: %s", d.t, err)
+		}
+		if d.v != date.String() {
+			t.Errorf("%s: Expecting %v, got %v", d.t, d.v, date)
+		}
+	}
+}
+
+func TestParseFilterDateError(t *testing.T) {
+	testData := []struct {
+		t string
+	}{
+		{"05:04 2012-03-12"},
+		{"2012-13-03"},
+		{"2012-2-3"},
+		{"25:66"},
+		{"05:60"},
+		{"5:6"},
+	}
+
+	for _, d := range testData {
+		if date, err := ParseFilterDate(d.t); err == nil {
+			t.Errorf("%s: Expecting error, got %s", d.t, date)
+		}
 	}
 }

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -94,6 +94,7 @@ func TestParseFilterDate(t *testing.T) {
 		{"2012-03-12 05:04", "2012-03-12 05:04:00 +" + tz},
 		{"2012-03-12", "2012-03-12 00:00:00 +" + tz},
 		{"05:04", fmt.Sprintf("%d-%02d-%02d 05:04:00 +%s", time.Now().Year(), time.Now().Month(), time.Now().Day(), tz)},
+		{"1257894000", "2009-11-10 23:00:00 +" + tz},
 	}
 
 	for _, d := range testData {


### PR DESCRIPTION
This is a follow on from #9338.

This patch adds a flag --filter to the logs command. It includes two filters, `before` and `since` which will show logs since a time point or before or both if combined.

`yyyy-dd-mm hh:mm`: logs from that day, and time onwards
`yyyy-dd-mm`: logs from midnight on that day and onwards
`hh:mm`: logs from that time today and onwards.
`$(date +"%s")`: a unix timestamp

Caveats:
- I moved the filter flag processing code into a method (Args.GetAsJSON) in filters/parse/parse.go.    There may be other instances of the orignal code that need updating to this.
- Shortcode flag for the filter is `r`.  `f` was taken by `follow`.
