### PR TITLE
Use the release branch for docs releases

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,18 +56,14 @@ work!](../CONTRIBUTING.md#sign-your-work)
 
 ## Branches
 
-**There are two branches related to editing docs**: `master` and `docs`. You
-should always edit the documentation on a local branch of the `master`
+You should always edit the documentation on a local branch of the `master`
 branch, and send a PR against `master`.
 
 That way your fixes will automatically get included in later releases, and docs
-maintainers can easily cherry-pick your changes into the `docs` release branch.
-In the rare case where your change is not forward-compatible, you may need to
-base your changes on the `docs` branch.
+maintainers can easily cherry-pick your changes into the `release` branch.
 
-Also, now that we have a `docs` branch, we can keep the
-[http://docs.docker.com](http://docs.docker.com) docs up to date with any bugs
-found between Docker code releases.
+The [http://docs.docker.com](http://docs.docker.com) documentation will be updated
+inbetween Docker releases by the Documentation team.
 
 > **Warning**: When *reading* the docs, the
 > [http://docs-stage.docker.com](http://docs-stage.docker.com) documentation may
@@ -84,8 +80,10 @@ you need to access the AWS bucket you'll be deploying to.
 
 The release script will create an s3 if needed, and will then push the files to it.
 
-    [profile dowideit-docs] aws_access_key_id = IHOIUAHSIDH234rwf....
-    aws_secret_access_key = OIUYSADJHLKUHQWIUHE......  region = ap-southeast-2
+    [profile dowideit-docs]
+    aws_access_key_id = IHOIUAHSIDH234rwf....
+    aws_secret_access_key = OIUYSADJHLKUHQWIUHE......
+    region = ap-southeast-2
 
 The `profile` name must be the same as the name of the bucket you are deploying
 to - which you call from the `docker` directory:
@@ -110,29 +108,28 @@ also update the root docs pages by running
 ## Cherry-picking documentation changes to update an existing release.
 
 Whenever the core team makes a release, they publish the documentation based
-on the `release` branch (which is copied into the `docs` branch). The
-documentation team can make updates in the meantime, by cherry-picking changes
-from `master` into any of the docs branches.
+on the `release` branch. The documentation team can make updates in the meantime,
+by cherry-picking changes from `master` into the `release` branche.
 
 For example, to update the current release's docs:
 
     git fetch upstream
-    git checkout -b post-1.2.0-docs-update-1 upstream/docs
-    # Then go through the Merge commit linked to PR's (making sure they apply
-    to that release)
-    # see https://github.com/docker/docker/commits/master
-    git cherry-pick -x fe845c4
+    git checkout -b post-1.2.0-docs-update-1 upstream/release
+    # use the gordon pulls tool to list all the candidate PR's
+    pulls --remote upstream compare upstream/master post-1.2.0-docs-update-1
+    # cherry-pick the ones you need into the branch
+    git cherry-pick -x -m 1 fe845c4
     # Repeat until you have cherry picked everything you will propose to be merged
     git push upstream post-1.2.0-docs-update-1
 
-Then make a pull request to merge into the `docs` branch, __NOT__ into master.
+Then make a pull request to merge into the `release` branch, __NOT__ into `master`.
 
 Once the PR has the needed `LGTM`s, merge it, then publish to our beta server
 to test:
 
     git fetch upstream
-    git checkout post-1.2.0-docs-update-1
-    git reset --hard upstream/post-1.2.0-docs-update-1
+    git checkout release
+    git reset --hard upstream/release
     make AWS_S3_BUCKET=beta-docs.docker.io BUILD_ROOT=yes docs-release
 
 Then go to http://beta-docs.docker.io.s3-website-us-west-2.amazonaws.com/
@@ -142,7 +139,9 @@ When you're happy with it, publish the docs to our live site:
 
     make AWS_S3_BUCKET=docs.docker.com BUILD_ROOT=yes docs-release
     
-Note that the new docs will not appear live on the site until the cache (a complex,
-distributed CDN system) is flushed. This requires someone with S3 keys. Contact Docker
-(Sven Dowideit or John Costa) for assistance. 
 
+> **Note:**
+> The docs will appear on http://docs.docker.com/ (though there may be cached
+> versions, so its worth checking http://docs.docker.com.s3-website-us-east-1.amazonaws.com/).
+> For more information about documentation releases, see `docs/README.md`.
+> Invalidate the cloudfront cache using the CND Planet chrome applet.

--- a/project/RELEASE-CHECKLIST.md
+++ b/project/RELEASE-CHECKLIST.md
@@ -1,5 +1,5 @@
 # Release Checklist
-## A maintainer's guide to releasing Docker
+##I A maintainer's guide to releasing Docker
 
 So you're in charge of a Docker release? Cool. Here's what to do.
 
@@ -247,26 +247,13 @@ git push origin $VERSION
 Don't forget to push that pretty blue button to delete the leftover
 branch afterwards!
 
-### 11. Update the docs branch
-
-If this is a MAJOR.MINOR.0 release, you need to make an branch for the previous release's
-documentation:
-
-```bash
-git checkout -b docs-$PREVIOUS_MAJOR_MINOR docs
-git fetch
-git reset --hard origin/docs
-git push -f origin docs-$PREVIOUS_MAJOR_MINOR
-```
+### 11. Publish documentation to docs.docker.com
 
 You will need the `awsconfig` file added to the `docs/` directory to contain the
 s3 credentials for the bucket you are deploying to.
 
 ```bash
-git checkout -b docs release || git checkout docs
-git fetch
-git reset --hard origin/release
-git push -f origin docs
+git checkout release
 make AWS_S3_BUCKET=docs.docker.com BUILD_ROOT=yes docs-release
 ```
 
@@ -274,7 +261,7 @@ The docs will appear on http://docs.docker.com/ (though there may be cached
 versions, so its worth checking http://docs.docker.com.s3-website-us-east-1.amazonaws.com/).
 For more information about documentation releases, see `docs/README.md`.
 
-Ask Sven, or JohnC to invalidate the cloudfront cache using the CND Planet chrome applet.
+Invalidate the cloudfront cache using the CND Planet chrome applet.
 
 ### 12. Create a new pull request to merge release back into master
 


### PR DESCRIPTION
- that way its always ready for the next patch release

**The biggest benefit to this, is that release tags will actually be up to date with the last documentation updates for that release.**

Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@docker.com (github: SvenDowideit)

Simplify the documentation and patch release process by getting the docs team to release their out of band updates to the docs site from the same release branch.

> **Warning:**
> This changes to the current `release` branch
> 1. It makes the `release` branch a living thing - ideally, simple docs PR's would be merged from master many times a day, and published from the `release` branch automatically
> 2. It cherry-picks the **merge** commit, and rolls the changes into that commit. This allows the `pulls compare` code to track the differences between the master and release branch, and simplifies the cherry-pick process.

I am using the merge-commit so that release branch commits have a simple way to trace back to the PR - with the existing process, its time consuming to go from a commit back to its PR, as they're rarely in the commit's message.
