### PR TITLE
Fixes race condition in test. Closes #9389.

### DIFF
--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -13,7 +13,7 @@ func TestStartAttachReturnsOnError(t *testing.T) {
 	defer deleteAllContainers()
 
 	dockerCmd(t, "run", "-d", "--name", "test", "busybox")
-	dockerCmd(t, "stop", "test")
+	dockerCmd(t, "wait", "test")
 
 	// Expect this to fail because the above container is stopped, this is what we want
 	if _, err := runCommand(exec.Command(dockerBinary, "run", "-d", "--name", "test2", "--link", "test:test", "busybox")); err == nil {


### PR DESCRIPTION
The busybox container, when started as a background process, quickly stops itself. Changing stop to wait is equivalent but doesn't have the race condition mentioned in #9389 
