### PR TITLE
Add support for detach docker exec

### DIFF
--- a/api/client/exec.go
+++ b/api/client/exec.go
@@ -52,8 +52,7 @@ func (cli *DockerCli) CmdExec(args ...string) error {
 		if _, _, err := readBody(cli.call("POST", "/exec/"+execID+"/start", execConfig, nil)); err != nil {
 			return err
 		}
-		// For now don't print this - wait for when we support exec wait()
-		// fmt.Fprintf(cli.out, "%s\n", execID)
+		fmt.Fprintf(cli.out, "%s\n", execID)
 		return nil
 	}
 

--- a/api/client/execwait.go
+++ b/api/client/execwait.go
@@ -1,0 +1,30 @@
+package client
+
+import (
+	"fmt"
+)
+
+// 'docker execwait': block until an exec stops
+func (cli *DockerCli) CmdExecwait(args ...string) error {
+	cmd := cli.Subcmd("execwait", "execID [execID...]",
+		"Block until an exec stops, then print its exit code.", true)
+	if err := cmd.Parse(args); err != nil {
+		return nil
+	}
+	if cmd.NArg() < 1 {
+		cmd.Usage()
+		return nil
+	}
+	var encounteredError error
+	for _, name := range cmd.Args() {
+		status, err := waitForExecExit(cli, name)
+		if err != nil {
+			fmt.Fprintf(cli.err, "%s\n", err)
+			encounteredError = fmt.Errorf("Error: failed to wait " +
+				"one or more execs")
+		} else {
+			fmt.Fprintf(cli.out, "%d\n", status)
+		}
+	}
+	return encounteredError
+}

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -235,6 +235,19 @@ func waitForExit(cli *DockerCli, containerID string) (int, error) {
 	return out.GetInt("StatusCode"), nil
 }
 
+func waitForExecExit(cli *DockerCli, execId string) (int, error) {
+	stream, _, err := cli.call("POST", "/exec/"+execId+"/wait", nil, nil)
+	if err != nil {
+		return -1, err
+	}
+
+	var out engine.Env
+	if err := out.Decode(stream); err != nil {
+		return -1, err
+	}
+	return out.GetInt("ExitCode"), nil
+}
+
 // getExitCode perform an inspect on the container. It returns
 // the running state and the exit code.
 func getExitCode(cli *DockerCli, containerID string) (bool, int, error) {

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -171,6 +171,11 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from exec' -s i -l interacti
 complete -c docker -A -f -n '__fish_seen_subcommand_from exec' -s t -l tty -d 'Allocate a pseudo-TTY'
 complete -c docker -A -f -n '__fish_seen_subcommand_from exec' -a '(__fish_print_docker_containers running)' -d "Container"
 
+# execwait
+complete -c docker -f -n '__fish_docker_no_subcommand' -a execwait -d 'Block until an exec stops, then print its exit code'
+complete -c docker -A -f -n '__fish_seen_subcommand_from execwait' -l help -d 'Print usage'
+complete -c docker -A -f -n '__fish_seen_subcommand_from execwait' -a '(__fish_print_docker_containers running)' -d "Exec"
+
 # export
 complete -c docker -f -n '__fish_docker_no_subcommand' -a export -d 'Stream the contents of a container as a tar archive'
 complete -c docker -A -f -n '__fish_seen_subcommand_from export' -l help -d 'Print usage'

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -661,10 +661,6 @@ func (container *Container) cleanup() {
 	if err := container.Unmount(); err != nil {
 		log.Errorf("%v: Failed to umount filesystem: %v", container.ID, err)
 	}
-
-	for _, eConfig := range container.execCommands.s {
-		container.daemon.unregisterExecCommand(eConfig)
-	}
 }
 
 func (container *Container) KillSig(sig int) error {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -97,7 +97,7 @@ type Daemon struct {
 	execCommands     *execStore
 	graph            *graph.Graph
 	repositories     *graph.TagStore
-	idIndex          *truncindex.TruncIndex
+	idIndex          *truncindex.TruncIndex // for container IDs
 	sysInfo          *sysinfo.SysInfo
 	volumes          *volumes.Repository
 	eng              *engine.Engine
@@ -105,6 +105,7 @@ type Daemon struct {
 	containerGraph   *graphdb.Database
 	driver           graphdriver.Driver
 	execDriver       execdriver.Driver
+	execIDIndex      *truncindex.TruncIndex // for exec IDs
 	trustStore       *trust.TrustStore
 	statsCollector   *statsCollector
 	defaultLogConfig runconfig.LogConfig
@@ -139,6 +140,7 @@ func (daemon *Daemon) Install(eng *engine.Engine) error {
 		"image_delete":      daemon.ImageDelete, // FIXME: see above
 		"execCreate":        daemon.ContainerExecCreate,
 		"execStart":         daemon.ContainerExecStart,
+		"execWait":          daemon.ContainerExecWait,
 		"execResize":        daemon.ContainerExecResize,
 		"execInspect":       daemon.ContainerExecInspect,
 	} {
@@ -1035,6 +1037,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		sysInitPath:      sysInitPath,
 		execDriver:       ed,
 		eng:              eng,
+		execIDIndex:      truncindex.NewTruncIndex([]string{}),
 		trustStore:       t,
 		statsCollector:   newStatsCollector(1 * time.Second),
 		defaultLogConfig: config.LogConfig,

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -98,6 +98,14 @@ func (daemon *Daemon) Rm(container *Container) error {
 		return err
 	}
 
+	// DO NOT unregister until we delete the container so that
+	// we can ask for the exit status of exec commands after the
+	// container and exec cmds stop. They only go away when the
+	// container is deleted
+	for _, eConfig := range container.execCommands.s {
+		container.daemon.unregisterExecCommand(eConfig)
+	}
+
 	// Deregister the container before removing its directory, to avoid race conditions
 	daemon.idIndex.Delete(container.ID)
 	daemon.containers.Delete(container.ID)

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"strings"
 	"sync"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/execdriver"
@@ -29,6 +30,7 @@ type execConfig struct {
 	OpenStderr bool
 	OpenStdout bool
 	Container  *Container
+	waitChan   chan struct{}
 }
 
 type execStore struct {
@@ -78,13 +80,15 @@ func (d *Daemon) registerExecCommand(execConfig *execConfig) {
 	execConfig.Container.execCommands.Add(execConfig.ID, execConfig)
 	// Storing execs in daemon for easy access via remote API.
 	d.execCommands.Add(execConfig.ID, execConfig)
+	d.execIDIndex.Add(execConfig.ID)
 }
 
 func (d *Daemon) getExecConfig(name string) (*execConfig, error) {
+	id, _ := d.execIDIndex.Get(name) // get full ID if needed
+	if id != "" {
+		name = id
+	}
 	if execConfig := d.execCommands.Get(name); execConfig != nil {
-		if !execConfig.Container.IsRunning() {
-			return nil, fmt.Errorf("Container %s is not running", execConfig.Container.ID)
-		}
 		return execConfig, nil
 	}
 
@@ -149,6 +153,7 @@ func (d *Daemon) ContainerExecCreate(job *engine.Job) error {
 		ProcessConfig: processConfig,
 		Container:     container,
 		Running:       false,
+		waitChan:      make(chan struct{}),
 	}
 
 	container.LogEvent("exec_create: " + execConfig.ProcessConfig.Entrypoint + " " + strings.Join(execConfig.ProcessConfig.Arguments, " "))
@@ -246,6 +251,21 @@ func (d *Daemon) ContainerExecStart(job *engine.Job) error {
 	return nil
 }
 
+func (daemon *Daemon) ContainerExecWait(job *engine.Job) error {
+	if len(job.Args) != 1 {
+		return fmt.Errorf("Usage: %s", job.Name)
+	}
+	name := job.Args[0]
+	execConfig, err := daemon.getExecConfig(name)
+	if err != nil {
+		return err
+	}
+
+	exitCode, _ := execConfig.WaitStop(-1 * time.Second)
+	job.Printf("%d\n", exitCode)
+	return nil
+}
+
 func (d *Daemon) Exec(c *Container, execConfig *execConfig, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
 	exitStatus, err := d.execDriver.Exec(c.command, &execConfig.ProcessConfig, pipes, startCallback)
 
@@ -256,6 +276,7 @@ func (d *Daemon) Exec(c *Container, execConfig *execConfig, pipes *execdriver.Pi
 
 	execConfig.ExitCode = exitStatus
 	execConfig.Running = false
+	close(execConfig.waitChan)
 
 	return exitStatus, err
 }
@@ -327,4 +348,19 @@ func (container *Container) monitorExec(execConfig *execConfig, callback execdri
 	}
 
 	return err
+}
+
+func (eConfig *execConfig) WaitStop(timeout time.Duration) (int, error) {
+	eConfig.Lock()
+	if !eConfig.Running {
+		exitCode := eConfig.ExitCode
+		eConfig.Unlock()
+		return exitCode, nil
+	}
+	waitChan := eConfig.waitChan
+	eConfig.Unlock()
+	if err := wait(waitChan, timeout); err != nil {
+		return -1, err
+	}
+	return eConfig.ExitCode, nil
 }

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -84,6 +84,7 @@ func init() {
 			{"diff", "Inspect changes on a container's filesystem"},
 			{"events", "Get real time events from the server"},
 			{"exec", "Run a command in a running container"},
+			{"execwait", "Block until an exec stops, then print its exit code"},
 			{"export", "Stream the contents of a container as a tar archive"},
 			{"history", "Show the history of an image"},
 			{"images", "List images"},

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -146,6 +146,9 @@ unix://[/path/to/socket] to use.
 **docker-exec(1)**
   Run a command in a running container
 
+**docker-execwait(1)**
+  Block until an exec stops, then print its exit code
+
 **docker-export(1)**
   Stream the contents of a container as a tar archive
 

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -1971,4 +1971,4 @@ This might change in the future.
 To set cross origin requests to the remote api, please add flag "--api-enable-cors"
 when running docker in daemon mode.
 
-    $ docker -d -H="192.168.1.9:2375" --api-enable-cors 
+    $ docker -d -H="192.168.1.9:2375" --api-enable-cors

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -1149,12 +1149,12 @@ or being killed.
 
 Query Parameters:
 
--   **dockerfile** - path within the build context to the Dockerfile. This is 
+-   **dockerfile** - path within the build context to the Dockerfile. This is
         ignored if `remote` is specified and points to an individual filename.
 -   **t** – repository name (and optionally a tag) to be applied to
         the resulting image in case of success
--   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the 
-        URI specifies a filename, the file's contents are placed into a file 
+-   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
+        URI specifies a filename, the file's contents are placed into a file
 		called `Dockerfile`.
 -   **q** – suppress verbose build output
 -   **nocache** – do not use the cache when building the image
@@ -2018,6 +2018,29 @@ Status Codes:
 -   **404** – no such exec instance
 -   **500** - server error
 
+### Exec Wait
+
+`POST /exec/(id)/wait`
+
+Block until exec `id` stops, then returns the exit code
+
+**Example request**:
+
+        POST /exec/16253994b7c4/wait HTTP/1.1
+
+**Example response**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        {"ExitCode": 0}
+
+Status Codes:
+
+-   **200** – no error
+-   **404** – no such container
+-   **500** – server error
+
 # 3. Going further
 
 ## 3.1 Inside `docker run`
@@ -2057,7 +2080,7 @@ This might change in the future.
 
 ## 3.3 CORS Requests
 
-To set cross origin requests to the remote api please give values to 
+To set cross origin requests to the remote api please give values to
 "--api-cors-header" when running docker in daemon mode. Set * will allow all,
 default or blank means CORS disabled
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1099,13 +1099,23 @@ If the container is paused, then the `docker exec` command will fail with an err
 This will create a container named `ubuntu_bash` and start a Bash session.
 
     $ docker exec -d ubuntu_bash touch /tmp/execWorks
+    3d8861a4c3224c9923130e76d0b544cb553db49146eb605aeb94b98b025d5fe3
 
 This will create a new file `/tmp/execWorks` inside the running container
-`ubuntu_bash`, in the background.
+`ubuntu_bash`. The `touch` command itself will be run in detached mode,
+meaning it is run in the background, and a unique identifier for the
+background process is printed to the screen. This can be used with the
+`docker execwait` command.
 
     $ docker exec -it ubuntu_bash bash
 
 This will create a new Bash session in the container `ubuntu_bash`.
+
+## execwait
+
+    Usage: docker execwait EXEC [EXEC...]
+
+    Block until an exec stops, then print its exit code.
 
 ## export
 
@@ -2342,4 +2352,3 @@ of both Docker client and daemon. Example use:
     Usage: docker wait CONTAINER [CONTAINER...]
 
     Block until a container stops, then print its exit code.
-

--- a/docs/sources/userguide/usingdocker.md
+++ b/docs/sources/userguide/usingdocker.md
@@ -87,7 +87,7 @@ This will display the help text and all available flags:
       --no-stdin=false: Do not attach stdin
       --sig-proxy=true: Proxify all received signal to the process (non-TTY mode only)
 
-> **Note:** 
+> **Note:**
 > You can see a full list of Docker's commands
 > [here](/reference/commandline/cli/).
 
@@ -116,7 +116,7 @@ application.
 
 Lastly, we've specified a command for our container to run: `python app.py`. This launches our web application.
 
-> **Note:** 
+> **Note:**
 > You can see more detail on the `docker run` command in the [command
 > reference](/reference/commandline/cli/#run) and the [Docker Run
 > Reference](/reference/run/).
@@ -133,7 +133,7 @@ You can see we've specified a new flag, `-l`, for the `docker ps`
 command. This tells the `docker ps` command to return the details of the
 *last* container started.
 
-> **Note:** 
+> **Note:**
 > By default, the `docker ps` command only shows information about running
 > containers. If you want to see stopped containers too use the `-a` flag.
 
@@ -147,7 +147,7 @@ column.
 When we passed the `-P` flag to the `docker run` command Docker mapped any
 ports exposed in our image to our host.
 
-> **Note:** 
+> **Note:**
 > We'll learn more about how to expose ports in Docker images when
 > [we learn how to build images](/userguide/dockerimages).
 
@@ -183,10 +183,10 @@ Our Python application is live!
 > you'll need to get the IP of the virtual host instead of using localhost.
 > You can do this by running the following in
 > the boot2docker shell.
-> 
+>
 >     $ boot2docker ip
 >     The VM's Host only interface IP address is: 192.168.59.103
-> 
+>
 > In this case you'd browse to http://192.168.59.103:49155 for the above example.
 
 ## A Network Port Shortcut
@@ -231,7 +231,7 @@ the container.
 
 ## Inspecting our Web Application Container
 
-Lastly, we can take a low-level dive into our Docker container using the
+We can also take a low-level dive into our Docker container using the
 `docker inspect` command. It returns a JSON hash of useful configuration
 and status information about Docker containers.
 
@@ -257,6 +257,51 @@ specific element, for example to return the container's IP address we would:
 
     $ docker inspect -f '{{ .NetworkSettings.IPAddress }}' nostalgic_morse
     172.17.0.5
+
+## Entering the Web Application Container
+
+Sometimes it may be necessary to run additional commands within a Docker
+container. For example, to help debug a situation or to simply run additional
+processes alongside the main one that was started when the container was
+created, in these situations you can use the `docker exec` command.
+
+For our example, let's run the `bash` shell command so we can look around
+the container:
+
+    $ sudo docker exec -it nostalgic_morse bash
+
+That command should result in the `bash` shell being run as a new process
+in the container, and due to the `-it` options (which attaches `STDIN` and
+allocates a tty), you should be presented with a normal command line
+prompt.  From there you should be able to look at any log file or even
+the processes running:
+
+    $ ps -Aef
+    UID        PID  PPID  C STIME TTY          TIME CMD
+    root         1     0  0 19:35 ?        00:00:00 python app.py
+    root        18     0  0 19:36 ?        00:00:00 bash
+    root        27    18  0 19:45 ?        00:00:00 ps -Aef
+
+Notice that we not only see our `bash` and `ps -Aef` commands, but also
+the Web Application (`python app.py`) process too.
+
+To leave, and as a result stop this additional process, just use the standard
+`exit` command.
+
+The `docker exec` command, like the `docker run` command allows for the
+`-d` option to be included, which starts the specified command in
+detached mode. In this case the command will print an unique ID for the
+command which can be used later on.  For example, you can then use the
+ID in the `docker execwait` command to wait for the specified exec command
+to complete:
+
+    $ sudo docker exec -d nostalgic_morse sh -c "sleep 60 ; exit 2"
+    dd0d7f861b4ad50df8ae3bea61514f3f935a7d6c9a7b6747ff7a83f3272a06a9
+    $ sudo docker execwait dd0d7f861b4ad50df8a
+	2
+
+Notice that when the `docker execwait` command completes it will print
+the exit code from the `docker exec` command that was being watched.
 
 ## Stopping our Web Application Container
 
@@ -285,7 +330,7 @@ Now quickly run `docker ps -l` again to see the running container is
 back up or browse to the container's URL to see if the application
 responds.
 
-> **Note:** 
+> **Note:**
 > Also available is the `docker restart` command that runs a stop and
 > then start on the container.
 

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -57,3 +57,67 @@ func TestInspectApiContainerResponse(t *testing.T) {
 
 	logDone("container json - check keys in container json response")
 }
+
+func TestInspectApiExecResponse(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sleep", "60")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatalf("failed to create a container: %s, %v", out, err)
+	}
+
+	defer deleteAllContainers()
+
+	cID := stripTrailingCharacters(out)
+
+	// Start an exec cmd
+	execCmd := exec.Command(dockerBinary, "exec", "-d", cID, "ssh", "-c", "whoami")
+	out, _, err = runCommandWithOutput(execCmd)
+	if err != nil {
+		t.Fatalf("failed to create exec: %s, %v", out, err)
+	}
+
+	// Get exec cmd's config (inspect) info
+	execID := stripTrailingCharacters(out)
+	body, err := sockRequest("GET", "/exec/"+execID+"/json", nil)
+	if err != nil {
+		t.Fatalf("sockRequest failed for: %v", err)
+	}
+
+	var inspectJSON map[string]interface{}
+	if err = json.Unmarshal(body, &inspectJSON); err != nil {
+		t.Fatalf("unable to unmarshal body: %v", err)
+	}
+
+	keys := []string{"ID", "Running", "ExitCode", "ProcessConfig", "OpenStdin", "OpenStderr", "OpenStdout", "Container"}
+
+	// Just verify the fields are there, irrespective of their values
+	for _, key := range keys {
+		if _, ok := inspectJSON[key]; !ok {
+			t.Fatalf("%s does not exist in reponse", key)
+		}
+	}
+
+	// Now make sure we can get the same data using a short version of the ID
+	shortID := execID[:10]
+	body, err = sockRequest("GET", "/exec/"+shortID+"/json", nil)
+	if err != nil {
+		t.Fatalf("sockRequest failed using shortID: %v", err)
+	}
+
+	// Now kill the container and make sure the exec inspect fails
+	runCmd = exec.Command(dockerBinary, "rm", "-f", cID)
+	runCommand(runCmd)
+
+	body, err = sockRequest("GET", "/exec/"+execID+"/json", nil)
+	if err == nil {
+		t.Fatalf("sockRequest was supposed to fail but didn't")
+	}
+
+	// And for fun make sure the shortID fails too
+	body, err = sockRequest("GET", "/exec/"+shortID+"/json", nil)
+	if err == nil {
+		t.Fatalf("sockRequest was supposed to fail on shortID but didn't")
+	}
+
+	logDone("exec json - check keys in exec json response")
+}

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -144,7 +144,7 @@ func TestHelpTextVerify(t *testing.T) {
 			}
 		}
 
-		expected := 39
+		expected := 40
 		if len(cmds) != expected {
 			t.Fatalf("Wrong # of cmds(%d), it should be: %d\nThe list:\n%q",
 				len(cmds), expected, cmds)


### PR DESCRIPTION
```
This is a follow-on to #9208.  In this one we add:
- support for (-d) detach mode of docker exec, where we show the execID to
  the cli
- add support for "docker execwait", which waits for an exec cmd to finish
- add support for shortIDs when specifying execIDs - meaning a prefix of the

While we could do "execwait" under "wait" I decided to create a new top-leve
command so that we didn't run into conflicts if (when?) we allow for
exec commands to be named.

Signed-off-by: Doug Davis <dug@us.ibm.com>
```
