### PR TITLE
overlayfs: search for upstream filesystem name

### DIFF
--- a/daemon/graphdriver/overlayfs/overlayfs.go
+++ b/daemon/graphdriver/overlayfs/overlayfs.go
@@ -125,7 +125,7 @@ func supportsOverlayfs() error {
 
 	s := bufio.NewScanner(f)
 	for s.Scan() {
-		if strings.Contains(s.Text(), "overlayfs") {
+		if strings.Contains(s.Text(), "overlay") {
 			return nil
 		}
 	}


### PR DESCRIPTION
upstream switched the word from "overlayfs" to "overlay".
https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=ef94b1864d1ed5be54376404bb23d22ed0481feb

Ping @jfrazelle @tiborvass @unclejack 
Might should be cherry-picked, since 3.18 will release during the docker-1.4.0 cycle

Signed-off-by: Vincent Batts vbatts@redhat.com
