### PR TITLE
Proposal: Dockerfile transactions

### DIFF
--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -44,20 +44,22 @@ func init() {
 	// functions. Errors are propogated up by Parse() and the resulting AST can
 	// be incorporated directly into the existing AST as a next.
 	dispatch = map[string]func(string) (*Node, map[string]bool, error){
-		"user":       parseString,
-		"onbuild":    parseSubCommand,
-		"workdir":    parseString,
-		"env":        parseEnv,
-		"maintainer": parseString,
-		"from":       parseString,
-		"add":        parseStringsWhitespaceDelimited,
-		"copy":       parseStringsWhitespaceDelimited,
-		"run":        parseMaybeJSON,
-		"cmd":        parseMaybeJSON,
-		"entrypoint": parseMaybeJSON,
-		"expose":     parseStringsWhitespaceDelimited,
-		"volume":     parseMaybeJSONToList,
-		"insert":     parseIgnore,
+		"user":        parseString,
+		"onbuild":     parseSubCommand,
+		"workdir":     parseString,
+		"env":         parseEnv,
+		"maintainer":  parseString,
+		"from":        parseString,
+		"add":         parseStringsWhitespaceDelimited,
+		"copy":        parseStringsWhitespaceDelimited,
+		"run":         parseMaybeJSON,
+		"cmd":         parseMaybeJSON,
+		"entrypoint":  parseMaybeJSON,
+		"expose":      parseStringsWhitespaceDelimited,
+		"volume":      parseMaybeJSONToList,
+		"insert":      parseIgnore,
+		"transaction": parseString,
+		"commit":      parseIgnore,
 	}
 }
 

--- a/builder/parser/utils.go
+++ b/builder/parser/utils.go
@@ -72,11 +72,14 @@ func fullDispatch(cmd, args string) (*Node, map[string]bool, error) {
 func splitCommand(line string) (string, string, error) {
 	cmdline := TOKEN_WHITESPACE.Split(line, 2)
 
-	if len(cmdline) != 2 {
+	if len(cmdline) != 2 && strings.ToLower(cmdline[0]) != "commit" {
 		return "", "", fmt.Errorf("We do not understand this file. Please ensure it is a valid Dockerfile. Parser error at %q", line)
 	}
 
 	cmd := strings.ToLower(cmdline[0])
+	if len(cmdline) == 1 {
+		return cmd, "", nil
+	}
 	// the cmd should never have whitespace, but it's possible for the args to
 	// have trailing whitespace.
 	return cmd, strings.TrimSpace(cmdline[1]), nil

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -56,9 +56,10 @@ to a new image if necessary, before finally outputting the ID of your
 new image. The Docker daemon will automatically clean up the context you
 sent.
 
-Note that each instruction is run independently, and causes a new image
-to be created - so `RUN cd /tmp` will not have any effect on the next
-instructions.
+Note that each instruction is run independently in a separate container
+execution - so `RUN cd /tmp` will not have any effect on the next instructions.
+Except for instructions within transactions, each instruction will cause a new
+image to be created.
 
 Whenever possible, Docker will re-use the intermediate images,
 accelerating `docker build` significantly (indicated by `Using cache` -
@@ -864,6 +865,19 @@ For example you might add something like this:
 > **Warning**: Chaining `ONBUILD` instructions using `ONBUILD ONBUILD` isn't allowed.
 
 > **Warning**: The `ONBUILD` instruction may not trigger `FROM` or `MAINTAINER` instructions.
+
+## TRANSACTION/COMMIT
+
+    TRANSACTION name
+    <instructions>
+    COMMIT
+
+The TRANSACTION instruction overrides the default behavior of committing each
+instruction to its own image. Within a transaction, a single container is
+successively executed with the instructions between TRANSACTION and COMMIT. When
+COMMIT is run, the results are committed to a single image and the image is
+given the history of `/bin/sh -c #(transaction) <name>`. Only RUN instructions
+are permitted inside of a transaction.
 
 ## Dockerfile Examples
 

--- a/runconfig/compare.go
+++ b/runconfig/compare.go
@@ -14,7 +14,8 @@ func Compare(a, b *Config) bool {
 		a.MemorySwap != b.MemorySwap ||
 		a.CpuShares != b.CpuShares ||
 		a.OpenStdin != b.OpenStdin ||
-		a.Tty != b.Tty {
+		a.Tty != b.Tty ||
+		a.Transactional != b.Transactional {
 		return false
 	}
 	if len(a.Cmd) != len(b.Cmd) ||
@@ -22,7 +23,8 @@ func Compare(a, b *Config) bool {
 		len(a.PortSpecs) != len(b.PortSpecs) ||
 		len(a.ExposedPorts) != len(b.ExposedPorts) ||
 		len(a.Entrypoint) != len(b.Entrypoint) ||
-		len(a.Volumes) != len(b.Volumes) {
+		len(a.Volumes) != len(b.Volumes) ||
+		len(a.TransactionCmds) != len(b.TransactionCmds) {
 		return false
 	}
 
@@ -54,6 +56,30 @@ func Compare(a, b *Config) bool {
 	for key := range a.Volumes {
 		if _, exists := b.Volumes[key]; !exists {
 			return false
+		}
+	}
+	for i := 0; i < len(a.TransactionCmds); i++ {
+		if a.TransactionCmds[i].Cmd != b.TransactionCmds[i].Cmd {
+			return false
+		}
+		if a.TransactionCmds[i].Original != b.TransactionCmds[i].Original {
+			return false
+		}
+		if len(a.TransactionCmds[i].Args) != len(b.TransactionCmds[i].Args) {
+			return false
+		}
+		for j := 0; j < len(a.TransactionCmds[i].Args); j++ {
+			if a.TransactionCmds[i].Args[j] !=
+				b.TransactionCmds[i].Args[j] {
+				return false
+			}
+		}
+		for key := range a.TransactionCmds[i].Attributes {
+			if val, exists := b.TransactionCmds[i].Attributes[key]; !exists {
+				return false
+			} else if a.TransactionCmds[i].Attributes[key] != val {
+				return false
+			}
 		}
 	}
 	return true

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -33,6 +33,15 @@ type Config struct {
 	NetworkDisabled bool
 	MacAddress      string
 	OnBuild         []string
+	Transactional   bool
+	TransactionCmds []ParsedCmd
+}
+
+type ParsedCmd struct {
+	Cmd        string
+	Args       []string
+	Attributes map[string]bool
+	Original   string
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {


### PR DESCRIPTION
I've implemented "transactions" in Dockerfiles, where instructions inside a transaction are all executed inside the same intermediate container. This makes all the instructions part of a single layer inside the final image. It closes #332 and #2439 

In the image history, a transaction is given the fictional command of /bin/sh -c #(transaction) <name>, similar to the #(nop) used for other instructions.

Currently only RUN instructions are supported inside a transaction, because allowing other instructions make caching far more difficult to implement for transactions.
