### PR TITLE
Fixes #9409, Infinite redirect loop for docker.io registry

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -202,8 +202,8 @@ func ResolveRepositoryName(reposName string) (string, string, error) {
 	}
 	hostname := nameParts[0]
 	reposName = nameParts[1]
-	if strings.Contains(hostname, "index.docker.io") {
-		return "", "", fmt.Errorf("Invalid repository name, try \"%s\" instead", reposName)
+	if strings.HasSuffix(hostname, "docker.io") {
+		return "", "", fmt.Errorf("You cannot specify the central docker registry explicitly. Try \"%s\" instead if that's what you intended", reposName)
 	}
 	if err := validateRepositoryName(reposName); err != nil {
 		return "", "", err


### PR DESCRIPTION
Specifying a registry name of `docker.io` causes an infinite redirect loop in the docker server -- see #9409. And although the code currently rejects `index.docker.io`, the error message is unclear about what exactly was offensive about the name.

This patch causes docker to reject any name with "docker.io" in the registry portion, not just index.docker.io, and clarifies the error message.

Fixes #9409
