### PR TITLE
inspect: format the output of docker inspect

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -882,7 +882,7 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 		// Remove trailing ','
 		indented.Truncate(indented.Len() - 1)
 	}
-	indented.WriteByte(']')
+	indented.WriteString("]\n")
 
 	if tmpl == nil {
 		if _, err := io.Copy(cli.out, indented); err != nil {


### PR DESCRIPTION
Prior to this patch, one would get the output of docker inspect xxx
as below:

user@server:/mnt$ docker inspect ubuntu
[{
    "Architecture": "amd64",

```
...

"VirtualSize": 199257566
```

}
]user@server:/mnt$

The last ']' was on the same line with the prompt, i wonder if it is
really what we want it be, it is a little weird, so i add a '\n' to it.

Signed-off-by: Hu Keping hukeping@huawei.com
