### PR TITLE
removed redis-server and replaced with redis-tools

### DIFF
--- a/docs/sources/examples/running_redis_service.md
+++ b/docs/sources/examples/running_redis_service.md
@@ -49,8 +49,7 @@ Once inside our freshly created container we need to install Redis to
 get the `redis-cli` binary to test our connection.
 
     $ sudo apt-get update
-    $ sudo apt-get install redis-server
-    $ sudo service redis-server stop
+    $ sudo apt-get install redis-tools
 
 As we've used the `--link redis:db` option, Docker
 has created some environment variables in our web application container.


### PR DESCRIPTION
On the web application container we should install only redis-tools as is faster and no hassle with stopping the server.
