### PR TITLE
Add the possibility with docker to choose the parent slice of containers’ cgroup.

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -267,6 +267,7 @@ func populateCommand(c *Container, env []string) error {
 		MemorySwap: c.Config.MemorySwap,
 		CpuShares:  c.Config.CpuShares,
 		Cpuset:     c.Config.Cpuset,
+		Slice:      c.Config.Slice,
 	}
 
 	processConfig := execdriver.ProcessConfig{

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -90,6 +90,7 @@ type Resources struct {
 	MemorySwap int64  `json:"memory_swap"`
 	CpuShares  int64  `json:"cpu_shares"`
 	Cpuset     string `json:"cpuset"`
+	Slice      string `json:"slice"`
 }
 
 type Mount struct {

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -181,6 +181,7 @@ func (d *driver) setupCgroups(container *libcontainer.Config, c *execdriver.Comm
 		container.Cgroups.MemoryReservation = c.Resources.Memory
 		container.Cgroups.MemorySwap = c.Resources.MemorySwap
 		container.Cgroups.CpusetCpus = c.Resources.Cpuset
+		container.Cgroups.Slice = c.Resources.Slice
 	}
 
 	return nil

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -114,6 +114,7 @@ Create a container
              "MemorySwap":0,
              "CpuShares": 512,
              "Cpuset": "0,1",
+             "Slice": "system-kubernetes.slice",
              "AttachStdin":false,
              "AttachStdout":true,
              "AttachStderr":true,
@@ -175,7 +176,8 @@ Json Parameters:
 -   **MemorySwap**- Total memory usage (memory + swap); set `-1` to disable swap.
 -   **CpuShares** - An integer value containing the CPU Shares for container
       (ie. the relative weight vs othercontainers).
-    **CpuSet** - String value containg the cgroups Cpuset to use.
+-   **CpuSet** - String value containg the cgroups Cpuset to use.
+-   **Slice** - Parent slice
 -   **AttachStdin** - Boolean value, attaches to stdin.
 -   **AttachStdout** - Boolean value, attaches to stdout.
 -   **AttachStderr** - Boolean value, attaches to stderr.
@@ -1308,6 +1310,7 @@ Create a new image from a container's changes
              "MemorySwap":0,
              "CpuShares": 512,
              "Cpuset": "0,1",
+             "Slice": "system-kubernetes.slice",
              "AttachStdin":false,
              "AttachStdout":true,
              "AttachStderr":true,
@@ -1662,6 +1665,7 @@ Return low-level information about the exec command `id`.
               "MemorySwap" : 0,
               "CpuShares" : 0,
               "Cpuset" : "",
+              "Slice": "system-kubernetes.slice",
               "AttachStdin" : false,
               "AttachStdout" : false,
               "AttachStderr" : false,

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	MemorySwap      int64  // Total memory usage (memory + swap); set `-1' to disable swap
 	CpuShares       int64  // CPU shares (relative weight vs. other containers)
 	Cpuset          string // Cpuset 0-2, 0,1
+	Slice           string
 	AttachStdin     bool
 	AttachStdout    bool
 	AttachStderr    bool
@@ -44,6 +45,7 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 		MemorySwap:      job.GetenvInt64("MemorySwap"),
 		CpuShares:       job.GetenvInt64("CpuShares"),
 		Cpuset:          job.Getenv("Cpuset"),
+		Slice:           job.Getenv("Slice"),
 		AttachStdin:     job.GetenvBool("AttachStdin"),
 		AttachStdout:    job.GetenvBool("AttachStdout"),
 		AttachStderr:    job.GetenvBool("AttachStderr"),

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -57,6 +57,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flWorkingDir      = cmd.String([]string{"w", "-workdir"}, "", "Working directory inside the container")
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpuset          = cmd.String([]string{"-cpuset"}, "", "CPUs in which to allow execution (0-3, 0,1)")
+		flSlice           = cmd.String([]string{"s", "-slice"}, "", "Parent slice")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container\n'bridge': creates a new network stack for the container on the docker bridge\n'none': no networking for this container\n'container:<name|id>': reuses another container network stack\n'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.")
 		flMacAddress      = cmd.String([]string{"-mac-address"}, "", "Container MAC address (e.g. 92:d0:c6:0a:29:33)")
 		flIpcMode         = cmd.String([]string{"-ipc"}, "", "Default is to create a private IPC namespace (POSIX SysV IPC) for the container\n'container:<name|id>': reuses another container shared memory, semaphores and message queues\n'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.")
@@ -263,6 +264,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		Memory:          flMemory,
 		CpuShares:       *flCpuShares,
 		Cpuset:          *flCpuset,
+		Slice:           *flSlice,
 		AttachStdin:     attachStdin,
 		AttachStdout:    attachStdout,
 		AttachStderr:    attachStderr,


### PR DESCRIPTION
docker spawns the containers in their dedicated cgroup.
However, all the docker’s cgroups are created under `/system.slice`.
It may be interesting to have a more complex hierarchy.

For example, some tools implement the concept of “group of containers” aka POD, like fig or kubernetes. We can imagine to have a slice per POD and the containers cgroup be inside the slice of their POD.

This patch adds the `--slice` option to “`docker run`” that allows to specify in which parent slice a docker container must be spawned.

Ex:

```
# docker run -d -s system-kubernetes-podX.slice busybox sleep 1800

# systemd-cgls
|-1 /usr/lib/systemd/systemd
|-system.slice
| |-system-kubernetes.slice
| | `-system-kubernetes-podX.slice
| |   `-docker-d8fc58071d684677b71dd733e3eea8dac17989bd39773705bbfb96649a00e4c1.scope
| |     `-272 sleep 1800
```

libcontainer already contained what is needed for that in `vendor/src/github.com/docker/libcontainer/cgroups/systemd/apply_systemd.go`. Only docker had to be touched.

I tested that change on my PC and it worked as expected and as in the example above.
I tried to write a test in `docker_cli_run_test.go` but in the context created by `make test-integration-cli`, it didn’t work.
I suspect that it is because `make test-integration-cli` runs `docker_cli_run_test` inside a docker where there is no systemd running.
