### PR TITLE
Cleanup: remove obsolete workaround

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -53,12 +53,9 @@ func (daemon *Daemon) ContainerCreate(job *engine.Job) engine.Status {
 		job.Errorf("IPv4 forwarding is disabled.\n")
 	}
 	container.LogEvent("create")
-	// FIXME: this is necessary because daemon.Create might return a nil container
-	// with a non-nil error. This should not happen! Once it's fixed we
-	// can remove this workaround.
-	if container != nil {
-		job.Printf("%s\n", container.ID)
-	}
+
+	job.Printf("%s\n", container.ID)
+
 	for _, warning := range buildWarnings {
 		job.Errorf("%s\n", warning)
 	}
@@ -108,6 +105,7 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 	}
 	return container, warnings, nil
 }
+
 func (daemon *Daemon) GenerateSecurityOpt(ipcMode runconfig.IpcMode) ([]string, error) {
 	if ipcMode.IsHost() {
 		return label.DisableSecOpt(), nil


### PR DESCRIPTION
Daemon.Create() no longer returns a nil container with a non-nil error code, so the extra check is no longer necessary. 

Signed-off-by: Blake Geno blakegeno@gmail.com
