### PR TITLE
graphdb: initialize the database semi-idempotently on every connection, not just new installs.

### DIFF
--- a/pkg/graphdb/conn_sqlite3.go
+++ b/pkg/graphdb/conn_sqlite3.go
@@ -4,31 +4,15 @@ package graphdb
 
 import (
 	"database/sql"
-	"os"
 
 	_ "code.google.com/p/gosqlite/sqlite3" // registers sqlite
 )
 
 func NewSqliteConn(root string) (*Database, error) {
-	initDatabase := false
-
-	stat, err := os.Stat(root)
-	if err != nil {
-		if os.IsNotExist(err) {
-			initDatabase = true
-		} else {
-			return nil, err
-		}
-	}
-
-	if stat != nil && stat.Size() == 0 {
-		initDatabase = true
-	}
-
 	conn, err := sql.Open("sqlite3", root)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewDatabase(conn, initDatabase)
+	return NewDatabase(conn)
 }

--- a/pkg/graphdb/graphdb_test.go
+++ b/pkg/graphdb/graphdb_test.go
@@ -14,7 +14,7 @@ import (
 func newTestDb(t *testing.T) (*Database, string) {
 	p := path.Join(os.TempDir(), "sqlite.db")
 	conn, err := sql.Open("sqlite3", p)
-	db, err := NewDatabase(conn, true)
+	db, err := NewDatabase(conn)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
I think this will resolve #9428, and it simplifies our code. @rhatdan can you verify?
