### PR TITLE
update kernel reqs doc; recommend updates on RHEL

### DIFF
--- a/docs/sources/installation/binaries.md
+++ b/docs/sources/installation/binaries.md
@@ -32,17 +32,53 @@ runtime:
 Docker in daemon mode has specific kernel requirements. For details,
 check your distribution in [*Installation*](../#installation-list).
 
-In general, a 3.8 Linux kernel is the minimum requirement for Docker, as
-some of the prior versions have known issues that are triggered by Docker.
-Linux kernel versions older than 3.8 are known to cause kernel panics and
-to break Docker.
+A 3.10 Linux kernel is the minimum requirement for Docker.
+Kernels older than 3.10 lack some of the features required to run Docker
+containers. These older versions are known to have bugs which cause data loss
+and frequently panic under certain conditions.
+We recommend kernel 3.10 or newer.
 
 The latest minor version (3.x.y) of the 3.10 (or a newer maintained version)
 Linux kernel is recommended. Keeping the kernel up to date with the latest
 minor version will ensure critical kernel bugs get fixed.
 
+> **Warning**:
+> Installing custom kernels and kernel packages is likely to not be
+> supported by your Linux distribution's vendor. Please make sure to
+> ask your vendor about Docker support first before attempting to
+> install custom kernels on your distribution.
+
+> **Warning**:
+> Installing a newer kernel might not be enough for some distributions
+> which provide packages which are too old or incompatible with
+> newer kernels.
+
 Note that Docker also has a client mode, which can run on virtually any
 Linux kernel (it even builds on OS X!).
+
+## Check if AppArmor and SELinux are enabled
+
+Some Linux distributions enable AppArmor or SELinux by default and
+they run a kernel which doesn't meet the minimum requirements (3.10
+or newer). Updating the kernel to 3.10 or newer on such a system
+might not be enough to start Docker and run containers.
+Incompatibilities between the version of AppArmor/SELinux user
+space utilities provided by the system and the kernel could prevent
+Docker from running, from starting containers or make containers
+exhibit unexpected behaviour.
+
+> **Warning**:
+> If any of the two security mechanisms is enabled, it should not be
+> disabled to make Docker or its containers run. This will reduce
+> security in that environment, lose support from the distribution's
+> vendor for the system and might break regulations, and security
+> policies in heavily regulated environments.
+
+> **Warning**:
+> Please use AppArmor or SELinux if your Linux distribution supports
+> either of the two. This helps improve security and blocks certain
+> types of exploits. Your distribution's documentation should provide
+> detailed steps on how to enable the recommended security mechanism.
 
 ## Get the docker binary:
 

--- a/docs/sources/installation/rhel.md
+++ b/docs/sources/installation/rhel.md
@@ -47,6 +47,14 @@ running on kernels shipped by the distribution. There are things like namespace
 changes which will cause issues if one decides to step outside that box and run
 non-distro kernel packages.
 
+> **Warning**:
+> Please make sure that your system is up to date by installing updates
+> using `yum update` and rebooting your system.
+> Keeping the system up to date is recommended to ensure your system
+> receives fixes for critical security vulnerabilities and severe bugs.
+> The fixes for severe bugs include fixes for potential kernel panics
+> specific to kernel 2.6.32.
+
 ## Installation
 
 Firstly, you need to install the EPEL repository. Please follow the

--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -86,15 +86,23 @@ This installation path should work at all times.
 
 ### Dependencies
 
-**Linux kernel 3.8**
+**Linux kernel 3.13**
 
-Due to a bug in LXC, Docker works best on the 3.8 kernel. Precise comes
-with a 3.2 kernel, so we need to upgrade it. The kernel you'll install
-when following these steps comes with AUFS built in. We also include the
-generic headers to enable packages that depend on them, like ZFS and the
-VirtualBox guest additions. If you didn't install the headers for your
-"precise" kernel, then you can skip these headers for the "raring"
-kernel. But it is safer to include them if you're not sure.
+Kernel 3.13 is currently the recommended kernel version for Ubuntu Precise.
+Some Ubuntu Precise installs have an older kernel installed, so it must
+be upgraded. The kernel you'll install when following these steps has AUFS
+built in.
+We also include the generic headers to enable packages that depend on them,
+like ZFS and the VirtualBox guest additions. If you didn't install the
+headers for your "precise" kernel, then you can skip these headers for the
+"trusty" kernel. It is safer to include the headers if you're not sure.
+
+> **Warning**:
+> Kernels 3.8 and 3.11 are no longer supported by Canonical. Systems
+> running these kernels need to be updated using the instructions below.
+> Running Docker on these unsupported systems isn't supported either.
+> These old kernels are no longer patched for security vulnerabilities
+> and severe bugs which lead to data loss.
 
 Please read the installation instructions for backported kernels at
 Ubuntu.org to understand why you also need to install the Xorg packages
@@ -104,10 +112,10 @@ each version.
 
     # install the backported kernel
     $ sudo apt-get update
-    $ sudo apt-get install linux-image-generic-lts-raring linux-headers-generic-lts-raring
+    $ sudo apt-get install linux-image-generic-lts-trusty linux-headers-generic-lts-trusty
     
     # install the backported kernel and xorg if using Unity/Xorg
-    $ sudo apt-get install --install-recommends linux-generic-lts-raring xserver-xorg-lts-raring libgl1-mesa-glx-lts-raring
+    $ sudo apt-get install --install-recommends linux-generic-lts-trusty xserver-xorg-lts-trusty libgl1-mesa-glx-lts-trusty
 
     # reboot
     $ sudo reboot


### PR DESCRIPTION
We've received numerous reports for issues which have been fixed in newer kernels. We've also received reports from users who were trying to get Docker to run on systems where a Docker compatible kernel isn't available by default.

Issues like #1300, #7211 and #9256 have pointed out the fact that there are users out there who are a) trying to get Docker to run on unsupported systems, b) running kernels which are no longer supported (like kernel 3.8 on Ubuntu 12.04) or c) running supported kernels, but they're not installing system updates.

We need to make sure users are aware that they need to keep systems updated.

This PR also changes the Ubuntu docs to make it clear that 12.04 should actually be used together with kernel 3.13 (lts-trusty).

Fixes #9370
