### PR TITLE
Remove unused Engine.Logf method

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -926,7 +926,6 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 	eng.OnShutdown(func() {
 		// FIXME: if these cleanup steps can be called concurrently, register
 		// them as separate handlers to speed up total shutdown time
-		// FIXME: use engine logging instead of log.Errorf
 		if err := daemon.shutdown(); err != nil {
 			log.Errorf("daemon.shutdown(): %s", err)
 		}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/docker/docker/pkg/timeutils"
 	"github.com/docker/docker/utils"
 )
 
@@ -250,12 +249,4 @@ func (eng *Engine) ParseJob(input string) (*Job, error) {
 	job := eng.Job(cmd[0], cmd[1:]...)
 	job.Env().Init(&env)
 	return job, nil
-}
-
-func (eng *Engine) Logf(format string, args ...interface{}) (n int, err error) {
-	if !eng.Logging {
-		return 0, nil
-	}
-	prefixedFormat := fmt.Sprintf("[%s] [%s] %s\n", time.Now().Format(timeutils.RFC3339NanoFixed), eng, strings.TrimRight(format, "\n"))
-	return fmt.Fprintf(eng.Stderr, prefixedFormat, args...)
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -99,16 +99,6 @@ func TestEngineString(t *testing.T) {
 	}
 }
 
-func TestEngineLogf(t *testing.T) {
-	eng := New()
-	input := "Test log line"
-	if n, err := eng.Logf("%s\n", input); err != nil {
-		t.Fatal(err)
-	} else if n < len(input) {
-		t.Fatalf("Test: Logf() should print at least as much as the input\ninput=%d\nprinted=%d", len(input), n)
-	}
-}
-
 func TestParseJob(t *testing.T) {
 	eng := New()
 	// Verify that the resulting job calls to the right place


### PR DESCRIPTION
The `Engine.Logf` method is unused and confusing.

Replaces #9440.
