### PR TITLE
Correct TarSum benchmarks: 9kTar and 9kTarGzip

### DIFF
--- a/pkg/tarsum/tarsum_test.go
+++ b/pkg/tarsum/tarsum_test.go
@@ -132,6 +132,7 @@ func sizedTar(opts sizedOptions) io.Reader {
 		fh = bytes.NewBuffer([]byte{})
 	}
 	tarW := tar.NewWriter(fh)
+	defer tarW.Close()
 	for i := int64(0); i < opts.num; i++ {
 		err := tarW.WriteHeader(&tar.Header{
 			Name: fmt.Sprintf("/testdata%d", i),

--- a/pkg/tarsum/tarsum_test.go
+++ b/pkg/tarsum/tarsum_test.go
@@ -486,10 +486,13 @@ func Benchmark9kTar(b *testing.B) {
 	n, err := io.Copy(buf, fh)
 	fh.Close()
 
+	reader := bytes.NewReader(buf.Bytes())
+
 	b.SetBytes(n)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ts, err := NewTarSum(buf, true, Version0)
+		reader.Seek(0, 0)
+		ts, err := NewTarSum(reader, true, Version0)
 		if err != nil {
 			b.Error(err)
 			return
@@ -509,10 +512,13 @@ func Benchmark9kTarGzip(b *testing.B) {
 	n, err := io.Copy(buf, fh)
 	fh.Close()
 
+	reader := bytes.NewReader(buf.Bytes())
+
 	b.SetBytes(n)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ts, err := NewTarSum(buf, false, Version0)
+		reader.Seek(0, 0)
+		ts, err := NewTarSum(reader, false, Version0)
 		if err != nil {
 			b.Error(err)
 			return


### PR DESCRIPTION
These two cases did not actually read the same content with each iteration
of the benchmark. After the first read, the buffer was consumed. This patch
corrects this by using a bytes.Reader and seeking to the beginning of the
buffer at the beginning of each iteration.

Unfortunately, this benchmark was not actually as fast as we believed. But
the new results do bring its results closer to those of the other benchmarks.

Docker-DCO-1.1-Signed-off-by: Josh Hawn josh.hawn@docker.com (github: jlhawn)
