### PR TITLE
Return docker's root dir in docker -D info

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -544,6 +544,9 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		if initPath := remoteInfo.Get("InitPath"); initPath != "" {
 			fmt.Fprintf(cli.out, "Init Path: %s\n", initPath)
 		}
+		if root := remoteInfo.Get("DockerRootDir"); root != "" {
+			fmt.Fprintf(cli.out, "Docker Root Dir: %s\n", root)
+		}
 	}
 
 	if len(remoteInfo.GetList("IndexServerAddress")) != 0 {

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -76,6 +76,7 @@ func (daemon *Daemon) CmdInfo(job *engine.Job) engine.Status {
 	v.Set("InitPath", initPath)
 	v.SetInt("NCPU", runtime.NumCPU())
 	v.SetInt64("MemTotal", meminfo.MemTotal)
+	v.Set("DockerRootDir", daemon.Config().Root)
 	if hostname, err := os.Hostname(); err == nil {
 		v.Set("Name", hostname)
 	}

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -934,6 +934,7 @@ For example:
     Goroutines: 9
     EventsListeners: 0
     Init Path: /usr/bin/docker
+    Docker Root Dir: /var/lib/docker
     Username: svendowideit
     Registry: [https://index.docker.io/v1/]
     Labels:


### PR DESCRIPTION
This adds the docker daemon's root directory to docker info when running
in debug mode.  This allows the user to view the root directory where
docker is writing and storing state.

Fixes #9390

Signed-off-by: Michael Crosby crosbymichael@gmail.com
