### PR TITLE
Cleanup unnecessary abstractions in integration-cli

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/version"
-	"github.com/docker/docker/vendor/src/github.com/docker/libtrust"
+	"github.com/docker/libtrust"
 )
 
 const (

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -50,7 +50,7 @@ func TestAttachMultipleAndRestart(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if _, err := startCommand(c); err != nil {
+			if err := c.Start(); err != nil {
 				t.Fatal(err)
 			}
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strings"
 	"syscall"
@@ -1569,7 +1570,7 @@ func TestBuildWithVolumes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	equal := deepEqual(&expected, &result)
+	equal := reflect.DeepEqual(&result, &expected)
 
 	if !equal {
 		t.Fatalf("Volumes %s, expected %s", result, expected)

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -512,7 +512,7 @@ func TestCpToDot(t *testing.T) {
 	}
 	content, err := ioutil.ReadFile("./test")
 	if string(content) != "lololol\n" {
-		t.Fatal("Wrong content in copied file %q, should be %q", content, "lololol\n")
+		t.Fatalf("Wrong content in copied file %q, should be %q", content, "lololol\n")
 	}
 	logDone("cp - to dot path")
 }

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -121,7 +122,7 @@ func TestLinksInspectLinksStarted(t *testing.T) {
 
 	output := convertSliceOfStringsToMap(result)
 
-	equal := deepEqual(expected, output)
+	equal := reflect.DeepEqual(output, expected)
 
 	if !equal {
 		t.Fatalf("Links %s, expected %s", result, expected)
@@ -150,7 +151,7 @@ func TestLinksInspectLinksStopped(t *testing.T) {
 
 	output := convertSliceOfStringsToMap(result)
 
-	equal := deepEqual(expected, output)
+	equal := reflect.DeepEqual(output, expected)
 
 	if !equal {
 		t.Fatalf("Links %s, but expected %s", result, expected)

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -46,14 +46,14 @@ func TestRmiTag(t *testing.T) {
 	dockerCmd(t, "tag", "busybox", "utest:5000/docker:tag3")
 	{
 		imagesAfter, _, _ := dockerCmd(t, "images", "-a")
-		if nLines(imagesAfter) != nLines(imagesBefore)+3 {
+		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+3 {
 			t.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
 		}
 	}
 	dockerCmd(t, "rmi", "utest/docker:tag2")
 	{
 		imagesAfter, _, _ := dockerCmd(t, "images", "-a")
-		if nLines(imagesAfter) != nLines(imagesBefore)+2 {
+		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+2 {
 			t.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
 		}
 
@@ -61,7 +61,7 @@ func TestRmiTag(t *testing.T) {
 	dockerCmd(t, "rmi", "utest:5000/docker:tag3")
 	{
 		imagesAfter, _, _ := dockerCmd(t, "images", "-a")
-		if nLines(imagesAfter) != nLines(imagesBefore)+1 {
+		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+1 {
 			t.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
 		}
 
@@ -69,7 +69,7 @@ func TestRmiTag(t *testing.T) {
 	dockerCmd(t, "rmi", "utest:tag1")
 	{
 		imagesAfter, _, _ := dockerCmd(t, "images", "-a")
-		if nLines(imagesAfter) != nLines(imagesBefore)+0 {
+		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+0 {
 			t.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
 		}
 

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -114,10 +114,6 @@ func unmarshalJSON(data []byte, result interface{}) error {
 	return nil
 }
 
-func deepEqual(expected interface{}, result interface{}) bool {
-	return reflect.DeepEqual(result, expected)
-}
-
 func convertSliceOfStringsToMap(input []string) map[string]struct{} {
 	output := make(map[string]struct{})
 	for _, v := range input {

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -95,13 +95,6 @@ func runCommand(cmd *exec.Cmd) (exitCode int, err error) {
 	return
 }
 
-func startCommand(cmd *exec.Cmd) (exitCode int, err error) {
-	exitCode = 0
-	err = cmd.Start()
-	exitCode = processExitCode(err)
-	return
-}
-
 func logDone(message string) {
 	fmt.Printf("[PASSED]: %s\n", message)
 }

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -105,10 +105,6 @@ func stripTrailingCharacters(target string) string {
 	return target
 }
 
-func nLines(s string) int {
-	return strings.Count(s, "\n")
-}
-
 func unmarshalJSON(data []byte, result interface{}) error {
 	err := json.Unmarshal(data, result)
 	if err != nil {

--- a/pkg/mount/sharedsubtree_linux_test.go
+++ b/pkg/mount/sharedsubtree_linux_test.go
@@ -312,7 +312,7 @@ func TestSubtreeUnbindable(t *testing.T) {
 	if err := Mount(sourceDir, targetDir, "none", "bind,rw"); err != nil && err != syscall.EINVAL {
 		t.Fatal(err)
 	} else if err == nil {
-		t.Fatalf("%q should not have been bindable")
+		t.Fatalf("%q should not have been bindable", sourceDir)
 	}
 	defer func() {
 		if err := Unmount(targetDir); err != nil {


### PR DESCRIPTION
There were several unnecessary abstractions integration-cli:
- `startCommand`
- `nLines`
- `deepEqual`

We only used them in one or two tests and forget about them when adding new ones, so we may as well just get rid of them all together.

BONUS: found that the libtrust path was imported inconsistently and fixed that too. I can put that one in another PR but it seemed easier like this. LMK. (it was one line)

DOUBLE BONUS: a one liner in `pkg/mount` where the format variable was not specified, and a line in `integration-cli` that fixed `.Fatal` to `.Fatalf`
