### PR TITLE
Fix interactive exec over TLS

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1136,15 +1136,19 @@ func postContainerExecStart(eng *engine.Engine, version version.Version, w http.
 		}
 
 		defer func() {
-			if tcpc, ok := inStream.(*net.TCPConn); ok {
-				tcpc.CloseWrite()
+			if cw, ok := inStream.(interface {
+				CloseWrite() error
+			}); ok {
+				cw.CloseWrite()
 			} else {
 				inStream.Close()
 			}
 		}()
 		defer func() {
-			if tcpc, ok := outStream.(*net.TCPConn); ok {
-				tcpc.CloseWrite()
+			if cw, ok := outStream.(interface {
+				CloseWrite() error
+			}); ok {
+				cw.CloseWrite()
 			} else if closer, ok := outStream.(io.Closer); ok {
 				closer.Close()
 			}


### PR DESCRIPTION
The code used to expose the exact same problem as fixed in #9442 (i.e.: explicitly type-casting to a `net.TCPConn` when we only require a `CloseWrite() error` method).

Possibly fixes #8679.
