### PR TITLE
Proposal: Add identity information to container environment

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1162,6 +1162,20 @@ func (container *Container) createDaemonEnvironment(linkedEnv []string) []string
 	// else.
 	env = utils.ReplaceOrAppendEnvValues(env, container.Config.Env)
 
+	// These variables can't be overridden; if they're specified, then they
+	// should reflect the actual values they represent.  This is a judgement
+	// call, but maybe a good one...
+	if container.Config.StdEnv {
+		stdenv := []string{
+			"DOCKER_CONTAINER=" + container.ID,
+			"DOCKER_IMAGE=" + container.Image,
+		}
+		if hostname, err := os.Hostname(); err == nil {
+			stdenv = append(stdenv, "DOCKER_HOST="+hostname)
+		}
+		env = utils.ReplaceOrAppendEnvValues(env, stdenv)
+	}
+
 	return env
 }
 

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1167,11 +1167,11 @@ func (container *Container) createDaemonEnvironment(linkedEnv []string) []string
 	// call, but maybe a good one...
 	if container.Config.StdEnv {
 		stdenv := []string{
-			"DOCKER_CONTAINER=" + container.ID,
-			"DOCKER_IMAGE=" + container.Image,
+			"CONTAINER_ID=" + container.ID,
+			"CONTAINER_IMAGE=" + container.Image,
 		}
 		if hostname, err := os.Hostname(); err == nil {
-			stdenv = append(stdenv, "DOCKER_HOST="+hostname)
+			stdenv = append(stdenv, "CONTAINER_HOST="+hostname)
 		}
 		env = utils.ReplaceOrAppendEnvValues(env, stdenv)
 	}

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -34,6 +34,7 @@ docker-create - Create a new container
 [**--privileged**[=*false*]]
 [**--restart**[=*RESTART*]]
 [**--security-opt**[=*[]*]]
+[**--stdenv**[=*true*]]
 [**-t**|**--tty**[=*false*]]
 [**-u**|**--user**[=*USER*]]
 [**-v**|**--volume**[=*[]*]]
@@ -133,6 +134,9 @@ IMAGE [COMMAND] [ARG...]
 
 **--security-opt**=[]
    Security Options
+
+**--stdenv**=*true*|*false*
+   Supply identifying information about the container and the image it was created from through DOCKER_* environment variables.  The default is *true*.
 
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -37,6 +37,7 @@ docker-run - Run a command in a new container
 [**--rm**[=*false*]]
 [**--security-opt**[=*[]*]]
 [**--sig-proxy**[=*true*]]
+[**--stdenv**[=*true*]]
 [**-t**|**--tty**[=*false*]]
 [**-u**|**--user**[=*USER*]]
 [**-v**|**--volume**[=*[]*]]
@@ -259,6 +260,25 @@ outside of a container on the host.
 
 **--sig-proxy**=*true*|*false*
    Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true*.
+
+**--stdenv**=*true*|*false*
+   Provide information about the running container to that container via 
+environment variables.  By default (=*true*), the following environment
+variables will be set:
+
+   **DOCKER_CONTAINER**: The long UUID identifier of the running container.
+   **DOCKER_IMAGE**: The long UUID identifier of the image used for this container.
+   **DOCKER_HOST**: The FQDN of the host on which this container is running.
+
+   This information may be used for any purpose within the container.  Note,
+however, that some public registries do not properly secure the images
+themselves; therefore, you should not expose the value of DOCKER_IMAGE
+externally if you are using a public repository if you don't want people
+to download your image.  
+
+   If you run a large cluster and aggregate your application error logs,
+reporting these values may make it easier to isolate faults to a particular
+container, image, and/or host.
 
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -266,14 +266,14 @@ outside of a container on the host.
 environment variables.  By default (=*true*), the following environment
 variables will be set:
 
-   **DOCKER_CONTAINER**: The long UUID identifier of the running container.
-   **DOCKER_IMAGE**: The long UUID identifier of the image used for this container.
-   **DOCKER_HOST**: The FQDN of the host on which this container is running.
+   **CONTAINER_ID**: The long UUID identifier of the running container.
+   **CONTAINER_IMAGE**: The long UUID identifier of the image used for this container.
+   **CONTAINER_HOST**: The FQDN of the host on which this container is running.
 
    This information may be used for any purpose within the container.  Note,
 however, that some public registries do not properly secure the images
-themselves; therefore, you should not expose the value of DOCKER_IMAGE
-externally if you are using a public repository if you don't want people
+themselves; therefore, you should not expose the value of CONTAINER_IMAGE
+externally if you are using a public repository and you don't want people
 to download your image.  
 
    If you run a large cluster and aggregate your application error logs,

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1479,6 +1479,7 @@ removed before the image is removed.
       --rm=false                 Automatically remove the container when it exits (incompatible with -d)
       --security-opt=[]          Security Options
       --sig-proxy=true           Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied.
+      --stdenv=true              Publish container/image information into container's environment
       -t, --tty=false            Allocate a pseudo-TTY
       -u, --user=""              Username or UID
       -v, --volume=[]            Bind mount a volume (e.g., from the host: -v /host:/container, from Docker: -v /container)
@@ -1615,6 +1616,25 @@ An example of a file passed with `--env-file`
 
 This will create and run a new container with the container name being
 `console`.
+
+Several evironment variables are set by default, and cannot be overridden
+through the use of `-e`, `--env`, or `--env-file`.  These variables provide
+identifying information about the running container.
+
+     $ sudo docker run -e DOCKER_HOST=myhost busybox env | grep DOCKER
+     DOCKER_CONTAINER=5d3dec76d735d96fef790414a6f8cc62288cf64a0e5fff146b3ee94cd09fd40f
+     DOCKER_IMAGE=e72ac664f4f0c6a061ac4ef332557a70d69b0c624b6add35f1c181ff7fff2287
+     DOCKER_HOST=docker-01.some.domain.com
+
+Note how the variable specified by the command line was overridden by the 
+standard variables.  If you want to disable these for some reason, you can
+pass `--stdenv=false`.
+
+     $ sudo docker run --stdenv=false -e DOCKER_HOST=hello busybox env | grep DOCKER
+     DOCKER_HOST=hello
+
+This will prevent docker from setting or overriding the value of DOCKER_
+environment variables.
 
     $ sudo docker run --link /redis:redis --name console ubuntu bash
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1621,19 +1621,19 @@ Several evironment variables are set by default, and cannot be overridden
 through the use of `-e`, `--env`, or `--env-file`.  These variables provide
 identifying information about the running container.
 
-     $ sudo docker run -e DOCKER_HOST=myhost busybox env | grep DOCKER
-     DOCKER_CONTAINER=5d3dec76d735d96fef790414a6f8cc62288cf64a0e5fff146b3ee94cd09fd40f
-     DOCKER_IMAGE=e72ac664f4f0c6a061ac4ef332557a70d69b0c624b6add35f1c181ff7fff2287
-     DOCKER_HOST=docker-01.some.domain.com
+     $ sudo docker run -e CONTAINER_HOST=myhost busybox env | grep CONTAINER
+     CONTAINER_ID=5d3dec76d735d96fef790414a6f8cc62288cf64a0e5fff146b3ee94cd09fd40f
+     CONTAINER_IMAGE=e72ac664f4f0c6a061ac4ef332557a70d69b0c624b6add35f1c181ff7fff2287
+     CONTAINER_HOST=docker-01.some.domain.com
 
 Note how the variable specified by the command line was overridden by the 
 standard variables.  If you want to disable these for some reason, you can
 pass `--stdenv=false`.
 
-     $ sudo docker run --stdenv=false -e DOCKER_HOST=hello busybox env | grep DOCKER
-     DOCKER_HOST=hello
+     $ sudo docker run --stdenv=false -e CONTAINER_HOST=hello busybox env | grep CONTAINER
+     CONTAINER_HOST=hello
 
-This will prevent docker from setting or overriding the value of DOCKER_
+This will prevent docker from setting or overriding the value of CONTAINER_
 environment variables.
 
     $ sudo docker run --link /redis:redis --name console ubuntu bash

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -780,7 +780,7 @@ func TestRunStdEnvironment(t *testing.T) {
 		iid      string
 	)
 
-	cmd := exec.Command(dockerBinary, "run", "--name", "TestRunStdEnvironment", "busybox", "/bin/sh", "-c", "echo $DOCKER_IMAGE;echo $DOCKER_CONTAINER;echo $DOCKER_HOST")
+	cmd := exec.Command(dockerBinary, "run", "--name", "TestRunStdEnvironment", "busybox", "/bin/sh", "-c", "echo $CONTAINER_IMAGE;echo $CONTAINER_ID;echo $CONTAINER_HOST")
 
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	OpenStdin       bool // Open stdin
 	StdinOnce       bool // If true, close stdin after the 1 attached client disconnects.
 	Env             []string
+	StdEnv          bool // If true, add image/container info as DOCKER_* environment variables
 	Cmd             []string
 	Image           string // Name of the image as it was passed by the operator (eg. could be symbolic)
 	Volumes         map[string]struct{}
@@ -50,6 +51,7 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 		Tty:             job.GetenvBool("Tty"),
 		OpenStdin:       job.GetenvBool("OpenStdin"),
 		StdinOnce:       job.GetenvBool("StdinOnce"),
+		StdEnv:          job.GetenvBool("StdEnv"),
 		Image:           job.Getenv("Image"),
 		WorkingDir:      job.Getenv("WorkingDir"),
 		NetworkDisabled: job.GetenvBool("NetworkDisabled"),

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -47,6 +47,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flNetwork         = cmd.Bool([]string{"#n", "#-networking"}, true, "Enable networking for this container")
 		flPrivileged      = cmd.Bool([]string{"#privileged", "-privileged"}, false, "Give extended privileges to this container")
 		flPublishAll      = cmd.Bool([]string{"P", "-publish-all"}, false, "Publish all exposed ports to the host interfaces")
+		flStdEnv          = cmd.Bool([]string{"-stdenv"}, true, "Publish container/image information into container's environment")
 		flStdin           = cmd.Bool([]string{"i", "-interactive"}, false, "Keep STDIN open even if not attached")
 		flTty             = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
 		flContainerIDFile = cmd.String([]string{"#cidfile", "-cidfile"}, "", "Write the container ID to the file")
@@ -267,6 +268,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		AttachStdout:    attachStdout,
 		AttachStderr:    attachStderr,
 		Env:             envVariables,
+		StdEnv:          *flStdEnv,
 		Cmd:             runCmd,
 		Image:           image,
 		Volumes:         flVolumes.GetMap(),


### PR DESCRIPTION
Add a set of standard environment variables to docker containers to provide identity information.
# What?

As far as I can tell, the only way a container can (easily) get its own identity at present is to look at the HOSTNAME environment variable or /etc/hostname.  This will provide the short ID of the container.  Furthermore, this the short ID, which is not guaranteed to be unique, and says nothing about the running image.

The attached implementation, by default, adds a few environment variables to the default container environment.  These variables provide the full container ID, the full ID of the image the container was created from, and the hostname of the docker host on which the container is running DOCKER_CONTAINER, DOCKER_IMAGE, and DOCKER_HOST respectively).

This behavior can be disabled by adding `--stdenv=false` to the run or create commands.
# Use Cases
## Debug Isolation

In large environments, you might (for example) have a few dozen docker hosts running the same web application behind a single load balancer.  If a single container instance is failing in some subtle way, it can be difficult to isolate.  To combat this, the container ID and hostname can be stored in a log somewhere with the associated request identifier, or even passed through as a comment in a web page, allowing admins to easily determine exactly which container generated that page.

This is, perhaps, more important in compute-centric applications where there are hundreds of nodes with logs aggregated centrally.  By logging this information at the application level, the location of a failure can again be isolated.
## Automatic Cache Busting (or, why I actually did this!)

Anyone who works with web apps (especially with CDNs involved) knows that browser-level and other content caches can be a pain to deal with.  If you deploy a new version of an application, you have to make sure that you don't request and/or use a previous version of your javascript and other assets.  This is a common problem.

A typical solution is to add a query argument to the end of a request specifying the desired version of the asset.  The problem is that maintaining this is often error-prone; developers with insufficiently-automated workflows occasionally forget to update values.

With the addition of this patch, this version information can now be automatically generated based on the ID of the particular image the container is running.  This ensures that all assets are correctly versioned -- and tied not to the application, but to a particular build, represented by a docker image.

For Example:

``` php
<?php
function js_version() {
  // Tie the version to the image ID, but keep the actual value private.
  return md5("salt" . $_ENV["DOCKER_IMAGE"]);
}
// ...
?>
<script src="/some/js/file.js?v=<?= js_version() ?>"></script>
```
# Notes
- I have a running argument in my head as to whether or not a "NOSTDENV" type command should exist so this can be disabled in a Dockerfile.  My guess is that nobody would use it, but who knows?
- I did consider adding the short ID's as additional variables, but ultimately decided against it.  They can easily be derived from the full ID's, so it's mostly pointless IMO.
- There may be other information that could be presented this way, but I couldn't think of any offhand.
- This is my first exposure to Go.  The feature itself is simple and straightforward, so I don't expect trouble.  Someone should probably review the unit test code, though!  It struck me as way too complex for such a simple test.
