### PR TITLE
Don't show [] on single err inspect

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -884,7 +884,8 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 	}
 	indented.WriteString("]\n")
 
-	if tmpl == nil {
+	// On err, and no output, indented will be []\n so don't show it
+	if tmpl == nil && indented.Len() > 3 {
 		if _, err := io.Copy(cli.out, indented); err != nil {
 			return err
 		}

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -56,4 +57,17 @@ func TestInspectApiContainerResponse(t *testing.T) {
 	deleteAllContainers()
 
 	logDone("container json - check keys in container json response")
+}
+
+func TestInspectApiContainerErr(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "inspect", "000111000111")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err == nil {
+		t.Fatalf("Inspect was supposed to fail, but didn't")
+	}
+
+	// Just make sure that we don't show an empty JSON array
+	if strings.Contains(out, "[]") {
+		t.Fatal("Should not have an empty array: %s", out)
+	}
 }


### PR DESCRIPTION
$ docker inspect foofoo
wil produce:

Error: No such image or container: foofoo
[]

Notice the trailing [].  In cases where there is a single ID/name provided
this extra [] is just noise and makes no sense, it looks weird  :-)

This PR removes the [] only if there is no JSON to be shown at all.

Note that if there are a list of IDs and at least one of them doesn't
result in an error then things work as they do today.

Signed-off-by: Doug Davis dug@us.ibm.com
