### PR TITLE
Make 'docker build' send non-err output to stdout

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -180,7 +180,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	// FIXME: ProgressReader shouldn't be this annoying to use
 	if context != nil {
 		sf := utils.NewStreamFormatter(false)
-		body = utils.ProgressReader(context, 0, cli.err, sf, true, "", "Sending build context to Docker daemon")
+		body = utils.ProgressReader(context, 0, cli.out, sf, true, "", "Sending build context to Docker daemon")
 	}
 	// Send the build context
 	v := &url.Values{}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3523,3 +3523,19 @@ func TestBuildWithTabs(t *testing.T) {
 	}
 	logDone("build - with tabs")
 }
+
+func TestBuildStderr(t *testing.T) {
+	// This test just makes sure that no non-error output goes
+	// to stderr
+	name := "testbuildstderr"
+	defer deleteImages(name)
+	_, _, stderr, err := buildImageWithStdoutStderr(name,
+		"FROM busybox\nRUN echo one", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stderr != "" {
+		t.Fatal("Stderr should have been empty, instead its: %q", stderr)
+	}
+	logDone("build - testing stderr")
+}

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -596,6 +596,25 @@ func buildImageWithOut(name, dockerfile string, useCache bool) (string, string, 
 	return id, out, nil
 }
 
+func buildImageWithStdoutStderr(name, dockerfile string, useCache bool) (string, string, string, error) {
+	args := []string{"build", "-t", name}
+	if !useCache {
+		args = append(args, "--no-cache")
+	}
+	args = append(args, "-")
+	buildCmd := exec.Command(dockerBinary, args...)
+	buildCmd.Stdin = strings.NewReader(dockerfile)
+	stdout, stderr, exitCode, err := runCommandWithStdoutStderr(buildCmd)
+	if err != nil || exitCode != 0 {
+		return "", stdout, stderr, fmt.Errorf("failed to build the image: %s", stdout)
+	}
+	id, err := getIDByName(name)
+	if err != nil {
+		return "", stdout, stderr, err
+	}
+	return id, stdout, stderr, nil
+}
+
 func buildImage(name, dockerfile string, useCache bool) (string, error) {
 	id, _, err := buildImageWithOut(name, dockerfile, useCache)
 	return id, err


### PR DESCRIPTION
Right now 'docker build' will send:
   Sending build context to Docker daemon
to stderr, instead of stdout.  This PR fixes that.

I looked in the rest of api/client/commands.go for other cases
that might do this and only one jumped out at me:
  https://github.com/docker/docker/blob/master/api/client/commands.go#L2202
but I think if I changed that to go to stdout then it'll mess people up
who are expecting just the container ID to be printed to the screen and
there is no --quiet type of flag we can check.

Closes #9404

Signed-off-by: Doug Davis dug@us.ibm.com
