### PR TITLE
Support forwarding container logs to syslog

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1332,6 +1332,22 @@ func (container *Container) startLoggingToDisk() error {
 	return nil
 }
 
+func (container *Container) startLoggingToSyslog() error {
+	syslogConfig := container.hostConfig.SyslogConfig
+	if syslogConfig != nil {
+		// Setup logging of stdout and stderr to syslog
+		if err := container.daemon.LogToSyslog(container.stdout, *syslogConfig); err != nil {
+			return err
+		}
+
+		if err := container.daemon.LogToSyslog(container.stderr, *syslogConfig); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (container *Container) waitForStart() error {
 	container.monitor = newContainerMonitor(container, container.hostConfig.RestartPolicy)
 

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -129,6 +129,12 @@ func (m *containerMonitor) Start() error {
 			return err
 		}
 
+		if err := m.container.startLoggingToSyslog(); err != nil {
+			m.resetContainer(false)
+
+			return err
+		}
+
 		pipes := execdriver.NewPipes(m.container.stdin, m.container.stdout, m.container.stderr, m.container.Config.OpenStdin)
 
 		m.container.LogEvent("start")

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -41,6 +41,11 @@ docker-run - Run a command in a new container
 [**--rm**[=*false*]]
 [**--security-opt**[=*[]*]]
 [**--sig-proxy**[=*true*]]
+[**--syslog**[=false]]
+[**--syslog-url**[=*SYSLOGURL*]]
+[**--syslog-facility**[=*FACILITY*]]
+[**--syslog-severity**[=*SEVERITY*]]
+[**--syslog-tag**[=*TAG*]]
 [**-t**|**--tty**[=*false*]]
 [**-u**|**--user**[=*USER*]]
 [**-v**|**--volume**[=*[]*]]
@@ -284,6 +289,21 @@ its root filesystem mounted as read only prohibiting any writes.
 
 **--sig-proxy**=*true*|*false*
    Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true*.
+
+**--syslog**=*true*|*false*
+   When set to true Docker will send all STDOUT and STDERR output to the syslog server in addition to sending it to Docker's internal log store. The default is *false*.
+
+**--syslog-url**=""
+   URL of syslog server (e.g. "tcp://log-server:514" or "udp://log-server:1234"). If empty, use host system's syslog server. The default is "".
+
+**--syslog-facility**="user"
+   Facility to use when sending log messages to syslog. See syslog(3) for list of available values. The default is "user".
+
+**--syslog-severity**="info"
+   Severity to use when sending log messages to the syslog. See syslog(3) for list of available values. The default is "info".
+
+**--syslog-tag**=""
+   Tag to attach to log messages forwarded to the syslog. The default is the Docker process name (E.g., "/usr/bin/docker").
 
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1350,6 +1350,9 @@ timestamp, for example `2014-09-16T06:17:46.000000000Z`, to each
 log entry. To ensure that the timestamps for are aligned the
 nano-second part of the timestamp will be padded with zero when necessary.
 
+This command is useful when you need to peek into a running container.
+See `--syslog` option of `docker run` command for an advanced log collection.
+
 ## pause
 
     Usage: docker pause CONTAINER
@@ -1634,6 +1637,11 @@ removed before the image is removed.
       --rm=false                 Automatically remove the container when it exits (incompatible with -d)
       --security-opt=[]          Security Options
       --sig-proxy=true           Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied.
+      --syslog=false             Send logs to the syslog server
+      --syslog-url=""            URL of syslog server (e.g., "tcp://log-server:514" or "udp://log-server:1234")
+      --syslog-facility="user"   Facility to use when sending log messages to the syslog
+      --syslog-severity="info"   Severity to use when sending log messages to the syslog
+      --syslog-tag=""            Tag to attach to log messages forwarded to the syslog
       -t, --tty=false            Allocate a pseudo-TTY
       -u, --user=""              Username or UID
       -v, --volume=[]            Bind mount a volume (e.g., from the host: -v /host:/container, from Docker: -v /container)
@@ -1780,6 +1788,20 @@ An example of a file passed with `--env-file`
 
 This will create and run a new container with the container name being
 `console`.
+
+    $ sudo docker run --syslog --syslog-tag MONGODB mongo:latest
+
+The `--syslog` flag will make Docker forward logs to the system's log server
+in addition to sending it to Docker's internal log store.
+The `--syslog-tag MONGO` flag will add a tag, `MONGO`, to the selected log messages.
+You can customize syslog facility and severity for messages with `--syslog-facility`
+and `--syslog-severity` arguments.
+
+    $ sudo docker run --syslog --syslog-url udp://log-server:514 mongo:latest
+
+The `--syslog-url` allows sending log messages to a remote syslog server.
+
+Enabling syslog support does not change functionality of `docker logs` command in any way.
 
     $ sudo docker run --link /redis:redis --name console ubuntu bash
 

--- a/pkg/syslog/syslog.go
+++ b/pkg/syslog/syslog.go
@@ -1,0 +1,46 @@
+package syslog
+
+import "io"
+
+type Priority int
+
+const (
+	LOG_EMERG Priority = iota
+	LOG_ALERT
+	LOG_CRIT
+	LOG_ERR
+	LOG_WARNING
+	LOG_NOTICE
+	LOG_INFO
+	LOG_DEBUG
+)
+
+const (
+	// These are the same up to LOG_FTP on Linux, BSD, and OS X.
+	LOG_KERN Priority = iota << 3
+	LOG_USER
+	LOG_MAIL
+	LOG_DAEMON
+	LOG_AUTH
+	LOG_SYSLOG
+	LOG_LPR
+	LOG_NEWS
+	LOG_UUCP
+	LOG_CRON
+	LOG_AUTHPRIV
+	LOG_FTP
+
+	LOG_LOCAL0
+	LOG_LOCAL1
+	LOG_LOCAL2
+	LOG_LOCAL3
+	LOG_LOCAL4
+	LOG_LOCAL5
+	LOG_LOCAL6
+	LOG_LOCAL7
+)
+
+type Writer interface {
+	io.Writer
+	io.Closer
+}

--- a/pkg/syslog/unix.go
+++ b/pkg/syslog/unix.go
@@ -1,0 +1,30 @@
+// +build unix linux freebsd
+
+package syslog
+
+import realSyslog "log/syslog"
+
+type syslogWriter struct {
+	w *realSyslog.Writer
+}
+
+func New(priority Priority, tag string) (Writer, error) {
+	return Dial("", "", priority, tag)
+}
+
+func Dial(network, raddr string, priority Priority, tag string) (Writer, error) {
+	w, err := realSyslog.Dial(network, raddr, realSyslog.Priority(priority), tag)
+	if err != nil {
+		return nil, err
+	}
+
+	return &syslogWriter{w}, nil
+}
+
+func (sw *syslogWriter) Write(b []byte) (int, error) {
+	return sw.w.Write(b)
+}
+
+func (sw *syslogWriter) Close() error {
+	return sw.w.Close()
+}

--- a/pkg/syslog/windows.go
+++ b/pkg/syslog/windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package syslog
+
+import "fmt"
+
+func New(priority Priority, tag string) (*Writer, error) {
+	return Dial("", "", priority, tag)
+}
+
+func Dial(network, raddr string, priority Priority, tag string) (*Writer, error) {
+	return nil, fmt.Errorf("Syslog is not supported on this platform")
+}

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/nat"
+	"github.com/docker/docker/pkg/syslog"
 	"github.com/docker/docker/utils"
 )
 
@@ -98,6 +99,12 @@ type RestartPolicy struct {
 	MaximumRetryCount int
 }
 
+type SyslogConfig struct {
+	Url      string
+	Priority syslog.Priority
+	Tag      string
+}
+
 type HostConfig struct {
 	Binds           []string
 	ContainerIDFile string
@@ -119,6 +126,7 @@ type HostConfig struct {
 	RestartPolicy   RestartPolicy
 	SecurityOpt     []string
 	ReadonlyRootfs  bool
+	SyslogConfig    *SyslogConfig
 }
 
 // This is used by the create command when you want to set both the
@@ -181,6 +189,7 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 	if CapDrop := job.GetenvList("CapDrop"); CapDrop != nil {
 		hostConfig.CapDrop = CapDrop
 	}
+	job.GetenvJson("SyslogConfig", &hostConfig.SyslogConfig)
 
 	return hostConfig
 }


### PR DESCRIPTION
Docker has feature to view container logs (output to stdout and stderr),
but it is not very convenient. This patch adds an option to enable
forwarding of log messages to syslog server.

To enable syslog forwarding, add "--syslog" to docker's "run" command's
arguments. It will forward messages to local (host's) syslog server. To
forward to remote syslog, use "--syslog-url=udp://server:port"
parameter.

Other options allow configuring syslog parameters:
- --syslog-facility
- --syslog-severity
- --syslog-tag
