### PR TITLE
Add Apache license and link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,5 +202,7 @@ For more information, please see http://www.bis.doc.gov
 
 Licensing
 =========
-Docker is licensed under the Apache License, Version 2.0. See LICENSE for full license text.
+Docker is licensed under the Apache License, Version 2.0. See
+[LICENSE](https://github.com/docker/docker/blob/master/LICENSE) for the full
+license text.
 

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -88,4 +88,12 @@ implementation, check out the [Docker User Guide](/userguide/).
 
 ## Release Notes
 
-A summary of the changes in each release in the current series can now be found on the separate [Release Notes page](/release-notes/)
+A summary of the changes in each release in the current series can now be found
+on the separate [Release Notes page](/release-notes/)
+
+## Licensing
+
+Docker is licensed under the Apache License, Version 2.0. See
+[LICENSE](https://github.com/docker/docker/blob/master/LICENSE) for the full
+license text.
+


### PR DESCRIPTION
I was talking to someone whom i listen to, and she noted that our docs don't mention the license
