### PR TITLE
Forbid client piping to tty enabled container

### DIFF
--- a/docs/man/docker-attach.1.md
+++ b/docs/man/docker-attach.1.md
@@ -20,6 +20,9 @@ container, or `CTRL-\` to get a stacktrace of the Docker client when it quits.
 When you detach from a container the exit code will be returned to
 the client.
 
+It is forbidden to redirect the standard input of a docker attach command while
+attaching to a tty-enabled container (i.e.: launched with -t`).
+
 # OPTIONS
 **--no-stdin**=*true*|*false*
    Do not attach STDIN. The default is *false*.

--- a/docs/man/docker-exec.1.md
+++ b/docs/man/docker-exec.1.md
@@ -31,5 +31,8 @@ container is unpaused, and then run
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.
 
+The **-t** option is incompatible with a redirection of the docker client
+standard input.
+
 # HISTORY
 November 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -267,6 +267,9 @@ outside of a container on the host.
 input of any container. This can be used, for example, to run a throwaway
 interactive shell. The default is value is false.
 
+The **-t** option is incompatible with a redirection of the docker client
+standard input.
+
 **-u**, **--user**=""
    Username or UID
 

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -94,9 +94,10 @@ specify to which of the three standard streams (`STDIN`, `STDOUT`,
 
     $ sudo docker run -a stdin -a stdout -i -t ubuntu /bin/bash
 
-For interactive processes (like a shell) you will typically want a tty
-as well as persistent standard input (`STDIN`), so you'll use `-i -t`
-together in most interactive cases.
+For interactive processes (like a shell), you must use `-i -t` together in
+order to allocate a tty for the container process. Specifying `-t` is however
+forbidden when the client standard output is redirected or pipe, such as in:
+`echo test | docker run -i busybox cat`.
 
 ## Container identification
 

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -263,3 +263,44 @@ func TestExecPausedContainer(t *testing.T) {
 
 	logDone("exec - exec should not exec a pause container")
 }
+
+// regression test for #9476
+func TestExecTtyCloseStdin(t *testing.T) {
+	defer deleteAllContainers()
+
+	cmd := exec.Command(dockerBinary, "run", "-d", "-it", "--name", "exec_tty_stdin", "busybox")
+	if out, _, err := runCommandWithOutput(cmd); err != nil {
+		t.Fatal(out, err)
+	}
+
+	cmd = exec.Command(dockerBinary, "exec", "-it", "exec_tty_stdin", "cat")
+	stdinRw, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stdinRw.Write([]byte("test"))
+	stdinRw.Close()
+
+	if out, _, err := runCommandWithOutput(cmd); err != nil {
+		t.Fatal(out, err)
+	}
+
+	cmd = exec.Command(dockerBinary, "top", "exec_tty_stdin")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(out, err)
+	}
+
+	outArr := strings.Split(out, "\n")
+	if len(outArr) > 3 || strings.Contains(out, "nsenter-exec") {
+		// This is the really bad part
+		if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "rm", "-f", "exec_tty_stdin")); err != nil {
+			t.Fatal(out, err)
+		}
+
+		t.Fatalf("exec process left running\n\t %s", out)
+	}
+
+	logDone("exec - stdin is closed properly with tty enabled")
+}


### PR DESCRIPTION
When a container is launched with `-t`, it is meaningless to connect its input to a client side pipe. This patch explicitly forbids:
- `docker run -t` with a redirected stdin (`echo test | docker run -ti busybox cat`)
- `docker exec -t` with a redirected stdin (`docker exec -ti container psql) < script.sql`)
- `docker attach` with a redirect stdin toward a tty enabled container

**Open question**: should this patch make it in a point release? As broken as it may be, I'm wondering if some people actual rely on this feature today.

Fixes #8015
Fixes #9476
Fixes #9545
Replaces #9492
