### PR TITLE
Fix chroot untar for zero padded archive from slow reader

### DIFF
--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -31,6 +32,10 @@ func untar() {
 		fatal(err)
 	}
 	if err := archive.Untar(os.Stdin, "/", options); err != nil {
+		fatal(err)
+	}
+	// fully consume stdin in case it is zero padded
+	if _, err := ioutil.ReadAll(os.Stdin); err != nil {
 		fatal(err)
 	}
 	os.Exit(0)

--- a/pkg/chrootarchive/archive_test.go
+++ b/pkg/chrootarchive/archive_test.go
@@ -1,10 +1,12 @@
 package chrootarchive
 
 import (
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/reexec"
@@ -39,6 +41,45 @@ func TestChrootTarUntar(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := Untar(stream, dest, &archive.TarOptions{Excludes: []string{"lolo"}}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type slowEmptyTarReader struct {
+	size      int
+	offset    int
+	chunkSize int
+}
+
+// Read is a slow reader of an empty tar (like the output of "tar c --files-from /dev/null")
+func (s *slowEmptyTarReader) Read(p []byte) (int, error) {
+	time.Sleep(100 * time.Millisecond)
+	count := s.chunkSize
+	if len(p) < s.chunkSize {
+		count = len(p)
+	}
+	for i := 0; i < count; i++ {
+		p[i] = 0
+	}
+	s.offset += count
+	if s.offset > s.size {
+		return count, io.EOF
+	}
+	return count, nil
+}
+
+func TestChrootUntarEmptyArchiveFromSlowReader(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "docker-TestChrootUntarEmptyArchiveFromSlowReader")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+	dest := filepath.Join(tmpdir, "dest")
+	if err := os.MkdirAll(dest, 0700); err != nil {
+		t.Fatal(err)
+	}
+	stream := &slowEmptyTarReader{size: 10240, chunkSize: 1024}
+	if err := Untar(stream, dest, nil); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Downloading and extracting the scratch image using the chrootarchive package was intermittently failing with `Untar write |1: broken pipe` (see https://github.com/flynn/flynn/issues/529).

The scratch image is a 10kb tar, largely filled with zeroes, and the chrootarchive package was only reading what it needed to determine the contents of the tar (rather than until EOF), so stdin was still being written to after the forked process had exited.

The change here fixes that by reading stdin until EOF before exiting.
