### PR TITLE
Removed race condition

### DIFF
--- a/pkg/signal/trap.go
+++ b/pkg/signal/trap.go
@@ -34,9 +34,8 @@ func Trap(cleanup func()) {
 				case os.Interrupt, syscall.SIGTERM:
 					// If the user really wants to interrupt, let him do so.
 					if atomic.LoadUint32(&interruptCount) < 3 {
-						atomic.AddUint32(&interruptCount, 1)
 						// Initiate the cleanup only once
-						if atomic.LoadUint32(&interruptCount) == 1 {
+						if atomic.AddUint32(&interruptCount, 1) == 1 {
 							// Call cleanup handler
 							cleanup()
 							os.Exit(0)


### PR DESCRIPTION
If two interrupts were fired really quickly interruptCount could have been incremented twice before the LoadUint32 making cleanup not being called at all.
