### PR TITLE
docs: use systemd drop-ins instead of copying

### DIFF
--- a/docs/sources/articles/systemd.md
+++ b/docs/sources/articles/systemd.md
@@ -45,14 +45,14 @@ In this example, we'll assume that your `docker.services` file looks something l
     Documentation=http://docs.docker.com
     After=network.target docker.socket
     Requires=docker.socket
-    
+
     [Service]
     Type=notify
     EnvironmentFile=-/etc/sysconfig/docker
     ExecStart=/usr/bin/docker -d -H fd:// $OPTIONS
     LimitNOFILE=1048576
     LimitNPROC=1048576
-    
+
     [Install]
     Also=docker.socket
 
@@ -68,7 +68,7 @@ You can also set other environment variables in this file, for example, the
 
 This example overrides the default `docker.service` file.
 
-If you are behind a HTTP proxy server, for example in corporate settings, 
+If you are behind a HTTP proxy server, for example in corporate settings,
 you will need to add this configuration in the Docker systemd service file.
 
 Copy file `/usr/lib/systemd/system/docker.service` to `/etc/systemd/system/docker/service`.
@@ -85,7 +85,7 @@ proxying you can specify them via the `NO_PROXY` environment variable:
 Flush changes:
 
     $ sudo systemctl daemon-reload
-    
+
 Restart Docker:
 
     $ sudo systemctl restart docker

--- a/docs/sources/articles/systemd.md
+++ b/docs/sources/articles/systemd.md
@@ -71,10 +71,14 @@ This example overrides the default `docker.service` file.
 If you are behind a HTTP proxy server, for example in corporate settings,
 you will need to add this configuration in the Docker systemd service file.
 
-Copy file `/usr/lib/systemd/system/docker.service` to `/etc/systemd/system/docker/service`.
+First, create a systemd drop-in directory for the docker service:
 
-Add the following to the `[Service]` section in the new file:
+    mkdir /etc/systemd/system/docker.service.d
 
+Now create a file called `/etc/systemd/system/docker.service.d/http-proxy.conf`
+that adds the `HTTP_PROXY` environment variable:
+
+    [Service]
     Environment="HTTP_PROXY=http://proxy.example.com:80/"
 
 If you have internal Docker registries that you need to contact without


### PR DESCRIPTION
Copying the entire docker service file isn't necessary to add an
environment variable, instead use a drop-in configuration file. The nice
side-effect is that the user gets any vendor updates to the docker.service
file.
