### PR TITLE
filters: enable operators, instead of just "="

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -49,6 +49,7 @@ const (
 )
 
 var (
+	// TODO(vbatts) make this a filter registration process
 	acceptedImageFilterTags = map[string]struct{}{"dangling": {}}
 )
 
@@ -1358,9 +1359,9 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 		}
 	}
 
-	for name := range imageFilterArgs {
-		if _, ok := acceptedImageFilterTags[name]; !ok {
-			return fmt.Errorf("Invalid filter '%s'", name)
+	for _, arg := range imageFilterArgs {
+		if _, ok := acceptedImageFilterTags[arg.Key]; !ok {
+			return fmt.Errorf("Invalid filter '%s'", arg.Key)
 		}
 	}
 

--- a/events/events.go
+++ b/events/events.go
@@ -104,19 +104,19 @@ func (e *Events) SubscribersCount(job *engine.Job) engine.Status {
 }
 
 func writeEvent(job *engine.Job, event *utils.JSONMessage, eventFilters filters.Args) error {
-	isFiltered := func(field string, filter []string) bool {
-		if len(filter) == 0 {
+	isFiltered := func(field string, args filters.Args) bool {
+		if len(args) == 0 {
 			return false
 		}
-		for _, v := range filter {
-			if v == field {
+		for _, v := range args {
+			if v.Key == field {
 				return false
 			}
 		}
 		return true
 	}
 
-	if isFiltered(event.Status, eventFilters["event"]) || isFiltered(event.From, eventFilters["image"]) || isFiltered(event.ID, eventFilters["container"]) {
+	if isFiltered(event.Status, eventFilters.GetAll("event")) || isFiltered(event.From, eventFilters.GetAll("image")) || isFiltered(event.ID, eventFilters.GetAll("container")) {
 		return nil
 	}
 

--- a/graph/list.go
+++ b/graph/list.go
@@ -22,11 +22,9 @@ func (s *TagStore) CmdImages(job *engine.Job) engine.Status {
 	if err != nil {
 		return job.Error(err)
 	}
-	if i, ok := imageFilters["dangling"]; ok {
-		for _, value := range i {
-			if strings.ToLower(value) == "true" {
-				filt_tagged = false
-			}
+	for _, arg := range imageFilters.GetAll("dangling") {
+		if arg.Operator == "=" && strings.ToLower(arg.Value) == "true" {
+			filt_tagged = false
 		}
 	}
 

--- a/pkg/parsers/filters/args.go
+++ b/pkg/parsers/filters/args.go
@@ -1,0 +1,51 @@
+package filters
+
+import "regexp"
+
+type Args []Arg
+
+// Get returns the first Arg with a matching key
+func (args Args) Get(key string) Arg {
+	for _, arg := range args {
+		if arg.Key == key {
+			return arg
+		}
+	}
+	return Arg{}
+}
+
+// GetAll returns all the Arg with a matching key
+func (args Args) GetAll(key string) []Arg {
+	a := []Arg{}
+	for _, arg := range args {
+		if arg.Key == key {
+			a = append(a, arg)
+		}
+	}
+	return a
+}
+
+type Arg struct {
+	Key      string
+	Operator string
+	Value    string
+}
+
+func (args Args) Match(key, source string) bool {
+	keyArgs := args.GetAll(key)
+
+	//do not filter if there is no filter set or cannot determine filter
+	if len(keyArgs) == 0 {
+		return true
+	}
+	for _, arg := range keyArgs {
+		match, err := regexp.MatchString(arg.Key, source)
+		if err != nil {
+			continue
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/parsers/filters/parse_test.go
+++ b/pkg/parsers/filters/parse_test.go
@@ -1,9 +1,6 @@
 package filters
 
-import (
-	"sort"
-	"testing"
-)
+import "testing"
 
 func TestParseArgs(t *testing.T) {
 	// equivalent of `docker ps -f 'created=today' -f 'image.name=ubuntu*' -f 'image.name=*untu'`
@@ -22,18 +19,19 @@ func TestParseArgs(t *testing.T) {
 			t.Errorf("failed to parse %s: %s", flagArgs[i], err)
 		}
 	}
-	if len(args["created"]) != 1 {
+	if len(args.GetAll("created")) != 1 {
 		t.Errorf("failed to set this arg")
 	}
-	if len(args["image.name"]) != 2 {
+	if len(args.GetAll("image.name")) != 2 {
 		t.Errorf("the args should have collapsed")
 	}
 }
 
 func TestParam(t *testing.T) {
 	a := Args{
-		"created":    []string{"today"},
-		"image.name": []string{"ubuntu*", "*untu"},
+		Arg{Key: "created", Operator: "=", Value: "today"},
+		Arg{Key: "image.name", Operator: "=", Value: "*untu"},
+		Arg{Key: "image.name", Operator: "=", Value: "ubuntu*"},
 	}
 
 	v, err := ToParam(a)
@@ -44,21 +42,9 @@ func TestParam(t *testing.T) {
 	if err != nil {
 		t.Errorf("%s", err)
 	}
-	for key, vals := range v1 {
-		if _, ok := a[key]; !ok {
-			t.Errorf("could not find key %s in original set", key)
-		}
-		sort.Strings(vals)
-		sort.Strings(a[key])
-		if len(vals) != len(a[key]) {
-			t.Errorf("value lengths ought to match")
-			continue
-		}
-		for i := range vals {
-			if vals[i] != a[key][i] {
-				t.Errorf("expected %s, but got %s", a[key][i], vals[i])
-			}
-		}
+	// likely a fragle test
+	if v1[0] != a[0] {
+		t.Fatalf("%#v -- %#v", a, v1)
 	}
 }
 

--- a/pkg/parsers/filters/scanner.go
+++ b/pkg/parsers/filters/scanner.go
@@ -1,0 +1,68 @@
+package filters
+
+import (
+	"bufio"
+	"bytes"
+	"unicode/utf8"
+)
+
+func SplitByOperators(str string) ([]string, error) {
+	argReader := bytes.NewBufferString(str)
+	s := bufio.NewScanner(argReader)
+	s.Split(ScanOperators)
+
+	items := []string{}
+	for s.Scan() {
+		items = append(items, s.Text())
+	}
+	return items, nil
+}
+
+const Operators = "<>=!"
+
+// a scanner splitter to get words and operators
+func ScanOperators(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	i := bytes.IndexAny(data, Operators)
+	if i == -1 {
+		return bufio.ScanWords(data, atEOF)
+	}
+
+	// ensure the beginning is not a space or newline
+	start := 0
+	for width := 0; start < len(data); start += width {
+		var r rune
+		r, width = utf8.DecodeRune(data[start:])
+		if !isSpace(r) {
+			break
+		}
+	}
+
+	if i != 0 {
+		return i, data[start:i], nil
+	}
+	for width, j := 0, 0; j < len(data); j += width {
+		var r rune
+		r, width = utf8.DecodeRune(data[j:])
+		if !isOperator(r) {
+			return j, data[0:j], nil
+		}
+	}
+	// Request more data.
+	return 0, nil, nil
+
+}
+func isSpace(r rune) bool {
+	return r == '\n' || r == '\r' || r == ' '
+}
+func isOperator(r rune) bool {
+	for _, c := range Operators {
+		if r == c {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/parsers/filters/scanner_test.go
+++ b/pkg/parsers/filters/scanner_test.go
@@ -1,0 +1,34 @@
+package filters
+
+import "testing"
+
+func TestOperatorParse(t *testing.T) {
+	for _, filt := range []struct {
+		argStr string
+		arg    Arg
+	}{
+		{"created=today", Arg{"created", "=", "today"}},
+		{"exited!=0", Arg{"exited", "!=", "0"}},
+		{"created>1d", Arg{"created", ">", "1d"}},
+		{"baz>=bif", Arg{"baz", ">=", "bif"}},
+		{"foo<=harfblat", Arg{"foo", "<=", "harfblat"}},
+		{"foo<:=harfblat", Arg{"foo", "<", ":"}}, // the =harfblat is discarded
+	} {
+		arg, err := ParseArg(filt.argStr)
+		if err != nil {
+			t.Errorf("failed to parse [%s]: %s", filt.argStr, err)
+		}
+		if arg != filt.arg {
+			t.Errorf("expected %d arg, got %d", filt.arg, arg)
+		}
+		if arg.Key != filt.arg.Key {
+			t.Errorf("expected %s arg, got %s", filt.arg.Key, arg.Key)
+		}
+		if arg.Operator != filt.arg.Operator {
+			t.Errorf("expected %s arg, got %s", filt.arg.Operator, arg.Operator)
+		}
+		if arg.Value != filt.arg.Value {
+			t.Errorf("expected %s arg, got %s", filt.arg.Value, arg.Value)
+		}
+	}
+}


### PR DESCRIPTION
This reworks the filter arguments, and includes an initial new operator
of `docker ps -a --filter exited!=0`

Signed-off-by: Vincent Batts vbatts@redhat.com
