### PR TITLE
Throw error when container links to --net host container

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -696,6 +696,9 @@ func (daemon *Daemon) RegisterLinks(container *Container, hostConfig *runconfig.
 			if child == nil {
 				return fmt.Errorf("Could not get container for %s", parts["name"])
 			}
+			if child.hostConfig.NetworkMode.IsHost() {
+				return runconfig.ErrConflictHostNetworkAndLinks
+			}
 			if err := daemon.RegisterLink(container, child, parts["alias"]); err != nil {
 				return err
 			}

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -215,3 +215,19 @@ func TestLinksHostsFilesInject(t *testing.T) {
 
 	logDone("link - ensure containers hosts files are updated with the link alias.")
 }
+
+func TestLinksNetworkHostContainer(t *testing.T) {
+	defer deleteAllContainers()
+
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "--net", "host", "--name", "host_container", "busybox", "top"))
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", "--name", "should_fail", "--link", "host_container:tester", "busybox", "true"))
+	if err == nil || !strings.Contains(out, "--net=host can't be used with links. This would result in undefined behavior.") {
+		t.Fatalf("Running container linking to a container with --net host should have failed: %s", out)
+	}
+
+	logDone("link - error thrown when linking to container with --net host")
+}


### PR DESCRIPTION
Running a container that links to a container with --net host
should throw an error.

Closes #8333 

Docker-DCO-1.1-Signed-off-by: Jessica Frazelle jess@docker.com (github: jfrazelle)
