### PR TITLE
Flush stdin from within chroot archive

### DIFF
--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -35,9 +34,7 @@ func untar() {
 		fatal(err)
 	}
 	// fully consume stdin in case it is zero padded
-	if _, err := ioutil.ReadAll(os.Stdin); err != nil {
-		fatal(err)
-	}
+	flush(os.Stdin)
 	os.Exit(0)
 }
 

--- a/pkg/chrootarchive/archive_test.go
+++ b/pkg/chrootarchive/archive_test.go
@@ -83,3 +83,19 @@ func TestChrootUntarEmptyArchiveFromSlowReader(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestChrootApplyEmptyArchiveFromSlowReader(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "docker-TestChrootApplyEmptyArchiveFromSlowReader")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+	dest := filepath.Join(tmpdir, "dest")
+	if err := os.MkdirAll(dest, 0700); err != nil {
+		t.Fatal(err)
+	}
+	stream := &slowEmptyTarReader{size: 10240, chunkSize: 1024}
+	if err := ApplyLayer(dest, stream); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/chrootarchive/diff.go
+++ b/pkg/chrootarchive/diff.go
@@ -32,6 +32,7 @@ func applyLayer() {
 		fatal(err)
 	}
 	os.RemoveAll(tmpDir)
+	flush(os.Stdin)
 	os.Exit(0)
 }
 

--- a/pkg/chrootarchive/init.go
+++ b/pkg/chrootarchive/init.go
@@ -2,6 +2,8 @@ package chrootarchive
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 
 	"github.com/docker/docker/pkg/reexec"
@@ -15,4 +17,10 @@ func init() {
 func fatal(err error) {
 	fmt.Fprint(os.Stderr, err)
 	os.Exit(1)
+}
+
+// flush consumes all the bytes from the reader discarding
+// any errors
+func flush(r io.Reader) {
+	io.Copy(ioutil.Discard, r)
 }


### PR DESCRIPTION
This makes sure that we don't buffer in memory and that we also flush
stdin from diff as well as untar.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
