### PR TITLE
Use Set for stderr "logs" job in builder

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -539,7 +539,7 @@ func (b *Builder) run(c *daemon.Container) error {
 		logsJob.Setenv("stdout", "1")
 		logsJob.Setenv("stderr", "1")
 		logsJob.Stdout.Add(b.OutStream)
-		logsJob.Stderr.Add(b.ErrStream)
+		logsJob.Stderr.Set(b.ErrStream)
 		if err := logsJob.Run(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Because engine implicitly adds his stder to job stderr

ping @erikh @jfrazelle 
