### PR TITLE
Adds build option to squash newly built layers

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -83,6 +83,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	rm := cmd.Bool([]string{"#rm", "-rm"}, true, "Remove intermediate containers after a successful build")
 	forceRm := cmd.Bool([]string{"-force-rm"}, false, "Always remove intermediate containers, even after unsuccessful builds")
 	pull := cmd.Bool([]string{"-pull"}, false, "Always attempt to pull a newer version of the image")
+	squash := cmd.Bool([]string{"-squash"}, false, "Squash all newly built layers into a single layer")
 	if err := cmd.Parse(args); err != nil {
 		return nil
 	}
@@ -221,6 +222,9 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 
 	if *pull {
 		v.Set("pull", "1")
+	}
+	if *squash {
+		v.Set("squash", "1")
 	}
 	cli.LoadConfigFile()
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1029,6 +1029,9 @@ func postBuild(eng *engine.Engine, version version.Version, w http.ResponseWrite
 	if r.FormValue("pull") == "1" && version.GreaterThanOrEqualTo("1.16") {
 		job.Setenv("pull", "1")
 	}
+	if r.FormValue("squash") == "1" && version.GreaterThanOrEqualTo("1.16") {
+		job.SetenvBool("squash", true)
+	}
 	job.Stdin.Add(r.Body)
 	job.Setenv("remote", r.FormValue("remote"))
 	job.Setenv("t", r.FormValue("t"))

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -435,6 +435,7 @@ func (b *Builder) pullImage(name string) (*imagepkg.Image, error) {
 
 func (b *Builder) processImageFrom(img *imagepkg.Image) error {
 	b.image = img.ID
+	b.baseImageID = img.ID
 
 	if img.Config != nil {
 		b.Config = img.Config

--- a/builder/job.go
+++ b/builder/job.go
@@ -37,6 +37,7 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 		rm             = job.GetenvBool("rm")
 		forceRm        = job.GetenvBool("forcerm")
 		pull           = job.GetenvBool("pull")
+		squash         = job.GetenvBool("squash")
 		authConfig     = &registry.AuthConfig{}
 		configFile     = &registry.ConfigFile{}
 		tag            string
@@ -118,6 +119,7 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 		StreamFormatter: sf,
 		AuthConfig:      authConfig,
 		AuthConfigFile:  configFile,
+		Squash:          squash,
 	}
 
 	id, err := builder.Run(context)

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -305,6 +305,15 @@ func (a *Driver) Diff(id, parent string) (archive.Archive, error) {
 	})
 }
 
+// DiffAncestor produces an archive of the changes between the
+// specified layer and one of its ancestor layers which may be "".
+func (a *Driver) DiffAncestor(id, ancestor string) (archive.Archive, error) {
+	// AUFS doesn't have any clever structure which makes this
+	// task trivial in the way that it can with `Diff', so it can
+	// just be wrapped in a `naiveDiffDriver` for this task.
+	return graphdriver.NaiveDiffDriver(a).DiffAncestor(id, ancestor)
+}
+
 func (a *Driver) applyDiff(id string, diff archive.ArchiveReader) error {
 	return chrootarchive.Untar(diff, path.Join(a.rootPath(), "diff", id), nil)
 }

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -57,6 +57,9 @@ type Driver interface {
 	// Diff produces an archive of the changes between the specified
 	// layer and its parent layer which may be "".
 	Diff(id, parent string) (archive.Archive, error)
+	// DiffAncestor produces an archive of the changes between the
+	// specified layer and one of its ancestor layers which may be "".
+	DiffAncestor(id, ancestor string) (archive.Archive, error)
 	// Changes produces a list of changes between the specified layer
 	// and its parent layer. If parent is "", then all changes will be ADD changes.
 	Changes(id, parent string) ([]archive.Change, error)

--- a/daemon/graphdriver/fsdiff.go
+++ b/daemon/graphdriver/fsdiff.go
@@ -26,6 +26,7 @@ type naiveDiffDriver struct {
 // given ProtoDriver and adds the capability of the following methods which
 // it may or may not support on its own:
 //     Diff(id, parent string) (archive.Archive, error)
+//     DiffAncestor(id, ancestor string) (archive.Archive, error)
 //     Changes(id, parent string) ([]archive.Change, error)
 //     ApplyDiff(id, parent string, diff archive.ArchiveReader) (bytes int64, err error)
 //     DiffSize(id, parent string) (bytes int64, err error)
@@ -36,6 +37,14 @@ func NaiveDiffDriver(driver ProtoDriver) Driver {
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
 func (gdw *naiveDiffDriver) Diff(id, parent string) (arch archive.Archive, err error) {
+	// For a naiveDiffDriver, diffing from the direct
+	// parent is the same logic as diffing from any ancestor.
+	return gdw.DiffAncestor(id, parent)
+}
+
+// DiffAncestor produces an archive of the changes between the
+// specified layer and one of its ancestor layers which may be "".
+func (gdw *naiveDiffDriver) DiffAncestor(id, ancestor string) (arch archive.Archive, err error) {
 	driver := gdw.ProtoDriver
 
 	layerFs, err := driver.Get(id, "")
@@ -49,7 +58,7 @@ func (gdw *naiveDiffDriver) Diff(id, parent string) (arch archive.Archive, err e
 		}
 	}()
 
-	if parent == "" {
+	if ancestor == "" {
 		archive, err := archive.Tar(layerFs, archive.Uncompressed)
 		if err != nil {
 			return nil, err
@@ -61,13 +70,13 @@ func (gdw *naiveDiffDriver) Diff(id, parent string) (arch archive.Archive, err e
 		}), nil
 	}
 
-	parentFs, err := driver.Get(parent, "")
+	ancestorFs, err := driver.Get(ancestor, "")
 	if err != nil {
 		return nil, err
 	}
-	defer driver.Put(parent)
+	defer driver.Put(ancestor)
 
-	changes, err := archive.ChangesDirs(layerFs, parentFs)
+	changes, err := archive.ChangesDirs(layerFs, ancestorFs)
 	if err != nil {
 		return nil, err
 	}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -114,9 +114,10 @@ func (graph *Graph) Get(name string) (*image.Image, error) {
 }
 
 // Create creates a new image and registers it in the graph.
-func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, containerImage, comment, author string, containerConfig, config *runconfig.Config) (*image.Image, error) {
+func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, parentImgID, comment, author string, containerConfig, config *runconfig.Config) (*image.Image, error) {
 	img := &image.Image{
 		ID:            utils.GenerateRandomID(),
+		Parent:        parentImgID,
 		Comment:       comment,
 		Created:       time.Now().UTC(),
 		DockerVersion: dockerversion.VERSION,
@@ -127,8 +128,9 @@ func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, contain
 	}
 
 	if containerID != "" {
-		img.Parent = containerImage
 		img.Container = containerID
+	}
+	if containerConfig != nil {
 		img.ContainerConfig = *containerConfig
 	}
 

--- a/graph/squash.go
+++ b/graph/squash.go
@@ -1,0 +1,67 @@
+package graph
+
+import (
+	"errors"
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/pkg/archive"
+)
+
+// SquashLayers consolidates all layers in between the given imageID and
+// ancestorID into a single layer. Returns the ID of the newly created image.
+func (graph *Graph) SquashLayers(imageID, ancestorID string) (squashedID string, err error) {
+	log.Debugf("squashing image ID %q up to %q", imageID, ancestorID)
+
+	if imageID == ancestorID {
+		// No need to squash! They are the same image already!
+		return imageID, nil
+	}
+
+	var (
+		img           *image.Image
+		squashedImage *image.Image
+		squashDiff    archive.Archive
+	)
+
+	if img, err = graph.Get(imageID); err != nil {
+		return "", err
+	}
+
+	if img.Parent == ancestorID {
+		// No need to squash! It's already only a single layer difference!
+		return imageID, nil
+	}
+
+	if ancestorID != "" {
+		// Ensure that the ancestorID is an actual ancestor
+		// by walking the image history to find it.
+		foundAncestor := errors.New("")
+		err = img.WalkHistory(func(ancestorImg *image.Image) error {
+			if ancestorImg.ID == ancestorID {
+				return foundAncestor // Exit walk early.
+			}
+			return nil
+		})
+		if err == nil {
+			return "", fmt.Errorf("unable to squash: %q is not an ancestor of %q", ancestorID, imageID)
+		}
+		if err != foundAncestor {
+			return "", err
+		}
+	}
+
+	// The special sauce! Actually getting an diff from the ancestor Image rootfs.
+	if squashDiff, err = graph.Driver().DiffAncestor(imageID, ancestorID); err != nil {
+		return "", err
+	}
+	defer squashDiff.Close()
+
+	// Create it like any other image is created!
+	if squashedImage, err = graph.Create(squashDiff, "", ancestorID, img.Comment, img.Author, nil, img.Config); err != nil {
+		return "", err
+	}
+
+	return squashedImage.ID, nil
+}


### PR DESCRIPTION
This patch brings support for a `--squash` option to `docker build`.
If used, before a build completes like it normally would, it consolidates all
newly built layers, making all build steps result in only a single new image.

THIS DOES NOT AFFECT BUILD CACHE IN ANY WAY!

That's right, you still get all the advantages of the build cache (assuming
you don't specify `--no-cache` that is). An image built with the `--squash`
option still produces a layer for each built step, but also a second image
which has all of the changes consolidated into one layer.

If you use the `--tag` option along with `--squash`, it is the squashed layer
which gets tagged.

Docker-DCO-1.1-Signed-off-by: Josh Hawn josh.hawn@docker.com (github: jlhawn)
