### PR TITLE
-c/--cpu-shares flag set as a percentage rather than an absolute value

### DIFF
--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -290,7 +290,7 @@ The operator can also adjust the performance parameters of the
 container:
 
     -m="": Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
-    -c=0 : CPU shares (relative weight)
+    -c=0 : CPU shares (relative weight) // PR for moving to a percentage model, where -c/--cpu-shares flag should have "100%" value rather than 0. 
 
 The operator can constrain the memory available to a container easily
 with `docker run -m`. If the host supports swap memory, then the `-m`


### PR DESCRIPTION
Want to move to a percentage model for -c/--cpu-shares flag. 0 is a misleading value to represent 100% CPU-shares.

WIth this change,

1) If the user starts without the flag: `sudo docker run -it rhel7 /bin/bash`. The JSON `CpuShares` field should have 100%.
For custom values, user should pass percentage rather than an absolute value e.g. 50%, 100%, 25% etc. The JSON would be updated accordingly.

Just added a comment in the doc to open PR. No code changes as of now.
