### PR TITLE
Fix race in TestDaemonRestartWithVolumesRefs

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -66,7 +66,7 @@ func TestDaemonRestartWithVolumesRefs(t *testing.T) {
 	if err := d.Restart(); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := d.Cmd("run", "-d", "--volumes-from", "volrestarttest1", "--name", "volrestarttest2", "busybox"); err != nil {
+	if _, err := d.Cmd("run", "-d", "--volumes-from", "volrestarttest1", "--name", "volrestarttest2", "busybox", "top"); err != nil {
 		t.Fatal(err)
 	}
 	if out, err := d.Cmd("rm", "-fv", "volrestarttest2"); err != nil {


### PR DESCRIPTION
Sometimes rm begins before process death, but Kill called already after
it, so we get error - no such process.
Seems like my laptop slow enough to catch it.
