### PR TITLE
Improve message when pushing a non-existent image

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -88,7 +88,7 @@ func (graph *Graph) Exists(id string) bool {
 func (graph *Graph) Get(name string) (*image.Image, error) {
 	id, err := graph.idIndex.Get(name)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not find image: %v", err)
 	}
 	img, err := image.LoadImage(graph.ImageRoot(id))
 	if err != nil {


### PR DESCRIPTION
I was confused earlier when I did:

```
docker push localhost.localdomain:1234/foo
```

Because docker told me:

```
No such id: localhost.localdomain:1234/foo
```

I actually had buried in my mind the solution to this, but the error message
confused me because I had recently had some fun trying to get the registry
working and therefore thought it was telling me that I didn't have an account
on the registry.

This pull request makes it unambiguous that the error is that the specified
image is unknown.

/cc @cpuguy83
