### PR TITLE
bump Go to 1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,9 @@ ENV	DOCKER_CROSSPLATFORMS	\
 ENV	GOARM	5
 RUN	cd /usr/local/go/src && bash -xc 'for platform in $DOCKER_CROSSPLATFORMS; do GOOS=${platform%/*} GOARCH=${platform##*/} ./make.bash --no-clean 2>&1; done'
 
+# reinstall standard library with netgo
+RUN go clean -i net && go install -tags netgo std
+
 # Grab Go's cover tool for dead-simple code coverage testing
 RUN	go get golang.org/x/tools/cmd/cover
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN	cd /usr/local/lvm2 && ./configure --enable-static_link && make device-mapper
 # see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
 # Install Go
-RUN	curl -sSL https://golang.org/dl/go1.3.3.src.tar.gz | tar -v -C /usr/local -xz
+RUN	curl -sSL https://golang.org/dl/go1.4.src.tar.gz | tar -v -C /usr/local -xz
 ENV	PATH	/usr/local/go/bin:$PATH
 ENV	GOPATH	/go:/go/src/github.com/docker/docker/vendor
 ENV PATH /go/bin:$PATH

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3925,7 +3925,7 @@ func TestBuildWithTabs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := "[\"/bin/sh\",\"-c\",\"echo\\u0009one\\u0009\\u0009two\"]"
+	expected := `["/bin/sh","-c","echo\tone\t\ttwo"]`
 	if res != expected {
 		t.Fatalf("Missing tabs.\nGot:%s\nExp:%s", res, expected)
 	}


### PR DESCRIPTION
This bumps the Go version to 1.4.

Please note that this version of Go breaks gosqlite and it also breaks mattn/go-sqlite3 when used with Docker.

This PR is also meant to be the place where we discuss everything related to this bump.
