### PR TITLE
Report number of times that docker has auto-restarted a container

### DIFF
--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -41,6 +41,7 @@ func (daemon *Daemon) ContainerInspect(job *engine.Job) engine.Status {
 		out.Set("HostnamePath", container.HostnamePath)
 		out.Set("HostsPath", container.HostsPath)
 		out.Set("Name", container.Name)
+		out.SetInt("RestartCount", container.RestartCount)
 		out.Set("Driver", container.Driver)
 		out.Set("ExecDriver", container.ExecDriver)
 		out.Set("MountLabel", container.MountLabel)


### PR DESCRIPTION
Fixes #9469.

The docker inspect command now displays the number of times that a container was restarted.

To test it, run the following commands:

```
# ./docker-1.3.3-dev run --name nginx --restart always -d nginx
14f7f3a2f2a32bdb8356ac015d60a1d38f0d0785537ed6ee8cf6d7f47f7211f0
# ./docker-1.3.3-dev inspect -f "{{.RestartCount}}" nginx
0
# kill -9 $(./docker-1.3.3-dev inspect -f "{{.State.Pid}}" nginx)
# ./docker-1.3.3-dev inspect -f "{{.RestartCount}}" nginx
1
```

Signed-off-by: Rémy Greinhofer remy.greinhofer@livelovely.com
