### PR TITLE
Suppress output of TestLoginWithoutTTY

### DIFF
--- a/integration-cli/docker_cli_login_test.go
+++ b/integration-cli/docker_cli_login_test.go
@@ -3,16 +3,12 @@ package main
 import (
 	"bytes"
 	"io"
-	"os"
 	"os/exec"
 	"testing"
 )
 
 func TestLoginWithoutTTY(t *testing.T) {
 	cmd := exec.Command(dockerBinary, "login")
-	// setup STDOUT and STDERR so that we see any output and errors in our console
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
 
 	// create a buffer with text then a new line as a return
 	buf := bytes.NewBuffer([]byte("buffer test string \n"))


### PR DESCRIPTION
Suppress the log line produced by `TestLoginWithoutTTY` in integration-cli suite:

```
+ go test -test.run TestLoginWithoutTTY -test.timeout=30m github.com/docker/docker/integration-cli
Username: time="2014-12-12T01:07:54Z" level="fatal" msg="inappropriate ioctl for device"
[PASSED]: login - login without TTY
```
