### PR TITLE
Fix race condition between parseSecurityOpt and container.Mount

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -44,6 +44,8 @@ func (daemon *Daemon) ContainerStart(job *engine.Job) engine.Status {
 }
 
 func (daemon *Daemon) setHostConfig(container *Container, hostConfig *runconfig.HostConfig) error {
+	container.Lock()
+	defer container.Unlock()
 	if err := parseSecurityOpt(container, hostConfig); err != nil {
 		return err
 	}
@@ -66,8 +68,8 @@ func (daemon *Daemon) setHostConfig(container *Container, hostConfig *runconfig.
 	if err := daemon.RegisterLinks(container, hostConfig); err != nil {
 		return err
 	}
-	container.SetHostConfig(hostConfig)
-	container.ToDisk()
+	container.hostConfig = hostConfig
+	container.toDisk()
 
 	return nil
 }


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Write by goroutine 2164:
  github.com/docker/docker/daemon.parseSecurityOpt()
      /go/src/github.com/docker/docker/daemon/daemon.go:557 +0x47d
  github.com/docker/docker/daemon.(*Daemon).setHostConfig()
      /go/src/github.com/docker/docker/daemon/start.go:47 +0x6a
  github.com/docker/docker/daemon.(*Daemon).Create()
      /go/src/github.com/docker/docker/daemon/create.go:99 +0x5ed
  github.com/docker/docker/daemon.(*Daemon).ContainerCreate()
      /go/src/github.com/docker/docker/daemon/create.go:41 +0x3e0
  github.com/docker/docker/daemon.*Daemon.ContainerCreate·fm()
      /go/src/github.com/docker/docker/daemon/daemon.go:115 +0x3d
  github.com/docker/docker/engine.(*Job).Run()
      /go/src/github.com/docker/docker/engine/job.go:83 +0xa27
  github.com/docker/docker/api/server.postContainersCreate()
      /go/src/github.com/docker/docker/api/server/server.go:711 +0x561
  github.com/docker/docker/api/server.func·002()
      /go/src/github.com/docker/docker/api/server/server.go:1219 +0x9a6
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/pkg/net/http/server.go:1235 +0x4d
  github.com/gorilla/mux.(*Router).ServeHTTP()
      /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x39f
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/pkg/net/http/server.go:1673 +0x1fc
  net/http.(*conn).serve()
      /usr/local/go/src/pkg/net/http/server.go:1174 +0xf9e

Previous read by goroutine 2166:
  github.com/docker/docker/daemon.(*Daemon).Mount()
      /go/src/github.com/docker/docker/daemon/daemon.go:974 +0x758
  github.com/docker/docker/daemon.(*Container).Mount()
      /go/src/github.com/docker/docker/daemon/container.go:772 +0x68
  github.com/docker/docker/daemon.(*Container).GetSize()
      /go/src/github.com/docker/docker/daemon/container.go:837 +0xe9
  github.com/docker/docker/daemon.func·027()
      /go/src/github.com/docker/docker/daemon/list.go:143 +0x1c9f
  github.com/docker/docker/daemon.(*Daemon).Containers()
      /go/src/github.com/docker/docker/daemon/list.go:152 +0xd73
  github.com/docker/docker/daemon.*Daemon.Containers·fm()
      /go/src/github.com/docker/docker/daemon/daemon.go:114 +0x3d
  github.com/docker/docker/engine.(*Job).Run()
      /go/src/github.com/docker/docker/engine/job.go:83 +0xa27
  github.com/docker/docker/api/server.getContainersJSON()
      /go/src/github.com/docker/docker/api/server/server.go:396 +0x5d7
  github.com/docker/docker/api/server.func·002()
      /go/src/github.com/docker/docker/api/server/server.go:1219 +0x9a6
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/go/src/pkg/net/http/server.go:1235 +0x4d
  github.com/gorilla/mux.(*Router).ServeHTTP()
      /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x39f
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/pkg/net/http/server.go:1673 +0x1fc
  net/http.(*conn).serve()
      /usr/local/go/src/pkg/net/http/server.go:1174 +0xf9e
```
