### PR TITLE
Fix #9462

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -36,7 +36,7 @@ expect <<EOF
 	}
 EOF
 
-arch-chroot $ROOTFS /bin/sh -c "haveged -w 1024; pacman-key --init; pkill haveged; pacman -Rs --noconfirm haveged; pacman-key --populate archlinux"
+arch-chroot $ROOTFS /bin/sh -c "haveged -w 1024; pacman-key --init; pkill haveged; pacman -Rs --noconfirm haveged; pacman-key --populate archlinux; pkill gpg-agent"
 arch-chroot $ROOTFS /bin/sh -c "ln -s /usr/share/zoneinfo/UTC /etc/localtime"
 echo 'en_US.UTF-8 UTF-8' > $ROOTFS/etc/locale.gen
 arch-chroot $ROOTFS locale-gen


### PR DESCRIPTION
**_Note:**_ _credit goes to @jprjr and @k2s who [tracked down and fixed this bug](https://github.com/jprjr/docker-archlinux/issues/1) and @nasicus who [first reported it](https://forums.docker.com/t/creating-base-image-from-archlinux-script-not-working/415). I verified that jprjr's fix works and since he didn't submit a patch to upstream for 10 days, I prepared this patch._
# Overview

`gpg-agent` prevents `arch-chroot` to unmount `/dev`, and ultimately to mount it again when run next.
# Details

`pacman-key --init` starts `gpg-agent` in the background that keeps `/dev/{null,random,urandom}` open. This prevents `arch-chroot` to unmount `/dev` from the chroot on exit (_"umount: target is busy"_ messages). The script actually fails on the second invocation of `arch-chroot` when it fails to mount `/dev` because it stayed mounted after the first `arch-chroot` exited. This causes the _"ERROR: failed to setup API filesystems in chroot"_ error and `mkimage-arch.sh` to exit.

The solution is to kill `gpg-agent` before exiting the chroot.

<!-- References -->
