### PR TITLE
Update cli.go

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -76,7 +76,8 @@ func (cli *DockerCli) Cmd(args ...string) error {
 		method, exists := cli.getMethod(args[0])
 		if !exists {
 			fmt.Println("Error: Command not found:", args[0])
-			return cli.CmdHelp()
+			cli.CmdHelp()
+			os.Exit(2)
 		}
 		return method(args[1:]...)
 	}


### PR DESCRIPTION
Currently CLI command error doesn't return error code.  It is convenient for scripting.  Adding return code 1 the same way as flag error.
