### PR TITLE
Document container list filtering in API docs

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.12.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.12.md
@@ -748,7 +748,8 @@ Query Parameters:
      
 
 -   **all** – 1/True/true or 0/False/false, default false
--   **filters** – a JSON encoded value of the filters (a map[string][]string) to process on the images list.
+-   **filters** – a json encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
+  -   dangling=true
 
 
 

--- a/docs/sources/reference/api/docker_remote_api_v1.13.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.13.md
@@ -739,7 +739,8 @@ Status Codes:
 Query Parameters:
 
 -   **all** – 1/True/true or 0/False/false, default false
--   **filters** – a json encoded value of the filters (a map[string][string]) to process on the images list.
+-   **filters** – a json encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
+  -   dangling=true
 
 ### Create an image
 

--- a/docs/sources/reference/api/docker_remote_api_v1.14.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.14.md
@@ -84,7 +84,9 @@ Query Parameters:
 -   **since** – Show only containers created since Id, include non-running ones.
 -   **before** – Show only containers created before Id, include non-running ones.
 -   **size** – 1/True/true or 0/False/false, Show the containers sizes
--   **filters** - a json encoded value of the filters (a map[string][]string) to process on the containers list.
+-   **filters** - a json encoded value of the filters (a map[string][]string) to process on the containers list. Available filters:
+  -   exited=&lt;int&gt; -- containers with exit code of &lt;int&gt;
+  -   status=(restarting|running|paused|exited)
 
 Status Codes:
 
@@ -745,7 +747,8 @@ Status Codes:
 Query Parameters:
 
 -   **all** – 1/True/true or 0/False/false, default false
--   **filters** – a json encoded value of the filters (a map[string][string]) to process on the images list.
+-   **filters** – a json encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
+  -   dangling=true
 
 ### Create an image
 

--- a/docs/sources/reference/api/docker_remote_api_v1.14.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.14.md
@@ -84,6 +84,7 @@ Query Parameters:
 -   **since** – Show only containers created since Id, include non-running ones.
 -   **before** – Show only containers created before Id, include non-running ones.
 -   **size** – 1/True/true or 0/False/false, Show the containers sizes
+-   **filters** - a json encoded value of the filters (a map[string][]string) to process on the containers list.
 
 Status Codes:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -88,7 +88,9 @@ Query Parameters:
         non-running ones.
 -   **size** – 1/True/true or 0/False/false, Show the containers
         sizes
--   **filters** - a json encoded value of the filters (a map[string][]string) to process on the containers list.
+-   **filters** - a json encoded value of the filters (a map[string][]string) to process on the containers list. Available filters:
+  -   exited=&lt;int&gt; -- containers with exit code of &lt;int&gt;
+  -   status=(restarting|running|paused|exited)
 
 Status Codes:
 
@@ -885,7 +887,8 @@ Status Codes:
 Query Parameters:
 
 -   **all** – 1/True/true or 0/False/false, default false
--   **filters** – a json encoded value of the filters (a map[string][]string) to process on the images list.
+-   **filters** – a json encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
+  -   dangling=true
 
 ### Create an image
 

--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -88,6 +88,7 @@ Query Parameters:
         non-running ones.
 -   **size** – 1/True/true or 0/False/false, Show the containers
         sizes
+-   **filters** - a json encoded value of the filters (a map[string][]string) to process on the containers list.
 
 Status Codes:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -88,6 +88,7 @@ Query Parameters:
         non-running ones.
 -   **size** – 1/True/true or 0/False/false, Show the containers
         sizes
+-   **filters** - a json encoded value of the filters (a map[string][]string) to process on the containers list.
 
 Status Codes:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -88,7 +88,9 @@ Query Parameters:
         non-running ones.
 -   **size** – 1/True/true or 0/False/false, Show the containers
         sizes
--   **filters** - a json encoded value of the filters (a map[string][]string) to process on the containers list.
+-   **filters** - a json encoded value of the filters (a map[string][]string) to process on the containers list. Available filters:
+  -   exited=&lt;int&gt; -- containers with exit code of &lt;int&gt;
+  -   status=(restarting|running|paused|exited)
 
 Status Codes:
 
@@ -833,7 +835,8 @@ Status Codes:
 Query Parameters:
 
 -   **all** – 1/True/true or 0/False/false, default false
--   **filters** – a json encoded value of the filters (a map[string][]string) to process on the images list.
+-   **filters** – a json encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
+  -   dangling=true
 
 ### Create an image
 
@@ -1390,7 +1393,10 @@ Query Parameters:
 
 -   **since** – timestamp used for polling
 -   **until** – timestamp used for polling
--   **filters** – a json encoded value of the filters (a map[string][]string) to process on the event list.
+-   **filters** – a json encoded value of the filters (a map[string][]string) to process on the event list. Available filters:
+  -   event=&lt;string&gt; -- event to filter
+  -   image=&lt;string&gt; -- image to filter
+  -   container=&lt;string&gt; -- container to filter
 
 Status Codes:
 


### PR DESCRIPTION
The feature was added in 84146719, but not documented. It made it to API v1.14, so I assumed it would be proper to update all docs starting from that version.

ping @vbatts 
