### PR TITLE
Clarify Mac OS X experience. Signed-off by: Mary Anthony (moxieandmore@g...

### DIFF
--- a/docs/sources/contributing/devenvironment.md
+++ b/docs/sources/contributing/devenvironment.md
@@ -41,7 +41,7 @@ with the name of branch or revision number.
 ## Build the Environment
 
 This following command builds a development environment using the
-Dockerfile in the current directory. Essentially, it installs all
+`Dockerfile` in the current directory. Essentially, it installs all
 the build and runtime dependencies necessary to build and test Docker.
 Your first build will take some time to complete. On Linux systems:
 

--- a/docs/sources/contributing/devenvironment.md
+++ b/docs/sources/contributing/devenvironment.md
@@ -40,22 +40,24 @@ with the name of branch or revision number.
 
 ## Build the Environment
 
-This following command will build a development environment using the
-Dockerfile in the current directory. Essentially, it will install all
+This following command builds a development environment using the
+Dockerfile in the current directory. Essentially, it installs all
 the build and runtime dependencies necessary to build and test Docker.
-This command will take some time to complete when you first execute it.
+Your first build will take some time to complete. On Linux systems:
 
     $ sudo make build
+    
+On Mac OS X, from within the `boot2docker` shell:
+
+    $ make build
+
+> **Note**:
+> On Mac OS X, **do not** build Docker make targets such as `build`, `binary`, and `test`
+> under root (sudo). 
 
 If the build is successful, congratulations! You have produced a clean
 build of docker, neatly encapsulated in a standard build environment.
 
-> **Note**:
-> On Mac OS X, make targets such as `build`, `binary`, and `test`
-> must **not** be built under root. So, for example, instead of the above
-> command, issue:
-> 
->     $ make build
 
 ## Build the Docker Binary
 

--- a/docs/sources/contributing/devenvironment.md
+++ b/docs/sources/contributing/devenvironment.md
@@ -53,7 +53,7 @@ On Mac OS X, from within the `boot2docker` shell:
 
 > **Note**:
 > On Mac OS X, **do not** build Docker make targets such as `build`, `binary`, and `test`
-> under root (sudo). 
+> under root using the `sudo` command. 
 
 If the build is successful, congratulations! You have produced a clean
 build of docker, neatly encapsulated in a standard build environment.

--- a/docs/sources/contributing/devenvironment.md
+++ b/docs/sources/contributing/devenvironment.md
@@ -52,8 +52,9 @@ On Mac OS X, from within the `boot2docker` shell:
     $ make build
 
 > **Note**:
-> On Mac OS X, **do not** build Docker make targets such as `build`, `binary`, and `test`
-> under root using the `sudo` command. 
+> On Mac OS X, the Docker make targets such as `build`, `binary`, and `test`
+> should **not** be built by the 'root' user. Therefore, you shouldn't use `sudo` when 
+> running these commands on OS X. 
 
 If the build is successful, congratulations! You have produced a clean
 build of docker, neatly encapsulated in a standard build environment.


### PR DESCRIPTION
...mail.com)

Newb here just running through the process for setting up dev environment and contributing.  In the process, I saw a chance to clarify some make instructions.
- Took out the unnecessary future tense. (Readers use technical documents to perform tasks or gather information. For readers, these activities take place in the present. Therefore, the present tense is appropriate in most cases. -- Read Me First, A Style Guide for the Computer Industry)
- Put the Mac OS X command line closer to the "Linux standard" example -- was a bit buried in the note
- Clarified the note -- I think this is Docker-specific not make targets in general
- Added the bit about running this in the boot2docker shell just cause I skimmed past the phrase at the top about the containerized make. When I ran the make from a standard terminal the error was not exactly "run this build in a container dummy" so it took me a moment to suss out.
