### PR TITLE
mkimage-arch: Kill gpg-agent started in the chroot env

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -36,7 +36,7 @@ expect <<EOF
 	}
 EOF
 
-arch-chroot $ROOTFS /bin/sh -c "haveged -w 1024; pacman-key --init; pkill haveged; pacman -Rs --noconfirm haveged; pacman-key --populate archlinux"
+arch-chroot $ROOTFS /bin/sh -c "haveged -w 1024; pacman-key --init; pkill haveged; pacman -Rs --noconfirm haveged; pacman-key --populate archlinux; pkill gpg-agent || true"
 arch-chroot $ROOTFS /bin/sh -c "ln -s /usr/share/zoneinfo/UTC /etc/localtime"
 echo 'en_US.UTF-8 UTF-8' > $ROOTFS/etc/locale.gen
 arch-chroot $ROOTFS locale-gen


### PR DESCRIPTION
Add `pkill gpg-agent || true` after pacman-key command in chroot env to kill gpg-agent if it's running.

Arch Linux's gnuepg package has just been updated to 2.1, which does auto-start gpg-agent as documented(*1). pacman-key command depends on gnupg and running it in the chroot environment causes gpg-agent to start. This will make chroot to fail to umount $ROOTFS/dev because gpg-agent seems to open it.

Tested with Arch Linux 2014-12 and Docker 1.4.0.

---

*1: https://gnupg.org/faq/whats-new-in-2.1.html#autostart
