### PR TITLE
Fix incorrect error type

### DIFF
--- a/integration/https_test.go
+++ b/integration/https_test.go
@@ -90,7 +90,7 @@ func TestHttpsInfoRogueServerCert(t *testing.T) {
 		}
 
 		if !strings.Contains(err.Error(), errCaUnknown) {
-			t.Fatalf("Expected error: %s, got instead: %s", errBadCertificate, err)
+			t.Fatalf("Expected error: %s, got instead: %s", errCaUnknown, err)
 		}
 
 	})


### PR DESCRIPTION
I think that it should be `errCaUnknown` instead of `errBadCertificate`.
