### PR TITLE
1.4 release notes: Clarify change to `docker tag`

### DIFF
--- a/docs/sources/release-notes.md
+++ b/docs/sources/release-notes.md
@@ -33,7 +33,7 @@ container, or image. For more information, see  the
 * The `docker cp` command now supports copying files from the filesystem of a
 container's volumes. For more information, see  the 
 [remote API reference](http://docs.docker.com/reference/api/docker_remote_api/).
-* The `docker tag` command has been fixed so that it correctly honors `--force`
+* The `docker tag` command has been fixed so that it correctly requires `--force`
 when overriding a tag for existing image. For more information, see 
 the [command line reference](http://docs.docker.com/reference/commandline/cli/#tag).
 


### PR DESCRIPTION
Minor clarification to the 1.4 release notes. I'm not sure what your policy is on changing the release notes after the release, or if changing this file will propagate to https://docs.docker.com/release-notes/, but anyway this wording would have saved me some head-scratching.

Also the 1.3.2 release notes state "The `--insecure-registry` flag of the `docker run` command" -- but the flag belongs to the main `docker` daemon command, not `docker run`. However the 1.3.2 release notes are gone from docs/sources/release-notes.md so I didn't attempt to fix this.

@fredlf you were the last person to touch this file, so you might want to look at this. Or just close it if I'm too late. Cheers. :-)
