### PR TITLE
Add docker-py integration tests aginst the docker daemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ RUN	apt-get update && apt-get install -y \
 	lxc=1.0* \
 	mercurial \
 	parallel \
+	python-mock \
+	python-pip \
 	reprepro \
 	ruby1.9.1 \
 	ruby1.9.1-dev \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ docs-release: docs-build
 	$(DOCKER_RUN_DOCS) -e OPTIONS -e BUILD_ROOT "$(DOCKER_DOCS_IMAGE)" ./release.sh
 
 test: build
-	$(DOCKER_RUN_DOCKER) hack/make.sh binary cross test-unit test-integration test-integration-cli
+	$(DOCKER_RUN_DOCKER) hack/make.sh binary cross test-unit test-integration test-integration-cli test-docker-py
 
 test-unit: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh test-unit

--- a/project/make/test-docker-py
+++ b/project/make/test-docker-py
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+DEST=$1
+
+DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
+DOCKER_EXECDRIVER=${DOCKER_EXECDRIVER:-native}
+
+# subshell so that we can export PATH without breaking other things
+exec > >(tee -a $DEST/test.log) 2>&1
+(
+	export PATH="$DEST/../binary:$DEST/../dynbinary:$PATH"
+
+	if ! command -v docker &> /dev/null; then
+		echo >&2 'error: binary or dynbinary must be run before test-docker-py'
+		false
+	fi
+
+	# intentionally open a couple bogus file descriptors to help test that they get scrubbed in containers
+	exec 41>&1 42>&2
+
+	( set -x; exec \
+		docker --daemon --debug \
+		--storage-driver "$DOCKER_GRAPHDRIVER" \
+		--exec-driver "$DOCKER_EXECDRIVER" \
+		--pidfile "$DEST/docker.pid" \
+			&> "$DEST/docker.log"
+	) &
+
+	mkdir -p /tmp/dockerpy-tests && cd /tmp/dockerpy-tests
+	git clone https://github.com/docker/docker-py.git
+	cd docker-py
+	git checkout 0.6.0-integration
+	python setup.py install
+	python tests/integration_test.py
+
+	for pid in $(find "$DEST" -name docker.pid); do
+		DOCKER_PID=$(set -x; cat "$pid")
+		( set -x; kill $DOCKER_PID )
+		wait $DOCKERD_PID || true
+	done
+)
+


### PR DESCRIPTION
This clones and run the integration tests for docker-py master as part
of the integration tests created on master.  docker-py hits the api
directly and should be a good way to identify regressions in the api.

The tests will be pinning to a specific tag and updated when a new version of docker-py is released so that we track releases and not master to ensure API compatibility.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
