### PR TITLE
Support --storage-opt for aufs graph driver

### DIFF
--- a/daemon/graphdriver/aufs/README.md
+++ b/daemon/graphdriver/aufs/README.md
@@ -1,0 +1,25 @@
+## aufs - a storage backend based on AUFS
+
+The aufs graph driver uses AUFS (advanced multi layered unification filesystem)
+to implement COW layers. For each graph location ( typically stored at
+/var/lib/docker/aufs ), three directories are created:
+
+- layers: contains the metadata files for each layers. Each metatada file
+  contains its layer's parent ids.
+
+- diff: contains content of the layers. A layer's content will be saved into a
+  directory with the layer's id as the directory name.
+
+- mnt: mount points of the rw layers.
+
+### options
+
+The aufs backend supports some options that you can specify when starting the
+docker daemon using the `--storage-opt` flags.
+This uses the `aufs` prefix and would be used something like `docker -d --storage-opt aufs.foo=bar`
+
+Here is the list of supported options:
+
+ *  `aufs.mountopt`
+
+    Specifies extra mount options used when mounting the aufs layers.

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -61,7 +61,7 @@ type Driver struct {
 	mountOptions string
 }
 
-// New returns a new AUFS driver.
+// Init returns a new AUFS driver.
 // An error is returned if AUFS is not supported.
 func Init(root string, options []string) (graphdriver.Driver, error) {
 	// Try to load the aufs kernel module

--- a/daemon/graphdriver/aufs/aufs_test.go
+++ b/daemon/graphdriver/aufs/aufs_test.go
@@ -54,6 +54,43 @@ func TestNewDriver(t *testing.T) {
 	if d == nil {
 		t.Fatalf("Driver should not be nil")
 	}
+	aufsDriver := d.(*Driver)
+	if aufsDriver.mountOptions != "" {
+		t.Fatalf("mount options (%s), expect empty", aufsDriver.mountOptions)
+	}
+}
+
+func TestNewDriverWithMountOpts(t *testing.T) {
+	if err := os.MkdirAll(tmp, 0755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	d, err := Init(tmp, []string{"aufs.mountopt=dirperm1"})
+	if err != nil {
+		if err == graphdriver.ErrNotSupported {
+			t.Skip(err)
+		} else {
+			t.Fatal(err)
+		}
+	}
+	aufsDriver := d.(*Driver)
+	if aufsDriver.mountOptions != "dirperm1" {
+		t.Fatalf("mount options (%s), expected %s", aufsDriver.mountOptions, "dirperm1")
+	}
+}
+
+func TestNewDriverWithInvalidOptions(t *testing.T) {
+	if err := os.MkdirAll(tmp, 0755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	// should return error with unknown option
+	_, err := Init(tmp, []string{"aufs.invalid=option"})
+	if err == nil {
+		t.Fatal(err)
+	}
 }
 
 func TestAufsString(t *testing.T) {

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -219,8 +219,8 @@ inside it)
 # STORAGE DRIVER OPTIONS
 
 Options to storage backend can be specified with **--storage-opt** flags. The
-only backend which currently takes options is *devicemapper*. Therefore use these
-flags with **-s=**devicemapper.
+backends which currently take options are *devicemapper* and *aufs*. Therefore
+use these flags with **-s=**devicemapper or **-s=**aufs
 
 Here is the list of *devicemapper* options:
 
@@ -283,6 +283,11 @@ Disabling this on loopback can lead to *much* faster container removal times,
 but will prevent the space used in `/var/lib/docker` directory from being returned to
 the system for other use when containers are removed.
 
+Here is the list of *aufs* options:
+
+#### aufs.mountopt
+Specifies extra mount options used when mounting the aufs layers.
+
 # EXAMPLES
 Launching docker daemon with *devicemapper* backend with particular block devices
 for data and metadata:
@@ -292,6 +297,12 @@ for data and metadata:
       --storage-opt dm.metadatadev=/dev/vdc \
       --storage-opt dm.basesize=20G
 
+Launching docker daemon with *aufs*backend that applies `dirperm1` mount option
+to all layers
+
+    docker -d -s=aufs \
+      --storage-opt aufs.mountopt=dirperm1
+
 #### Client
 For specific client examples please see the man page for the specific Docker
 command. For example:
@@ -300,3 +311,4 @@ command. For example:
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com) based on docker.com source material and internal work.
+Dec 2014, updated by Daniel, Dao Quang Minh (dqminh89 at gmail dot com)

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -179,14 +179,17 @@ The `aufs` driver is the oldest, but is based on a Linux kernel patch-set that
 is unlikely to be merged into the main kernel. These are also known to cause some
 serious kernel crashes. However, `aufs` is also the only storage driver that allows
 containers to share executable and shared library memory, so is a useful choice
-when running thousands of containers with the same program or libraries.
+when running thousands of containers with the same program or libraries. AUFS
+driver can be configured with `--storage-opt` flags. Refer to [AUFS
+storage driver options](#aufs-storage-driver-options) below for a way to
+customize this setup.
 
 The `devicemapper` driver uses thin provisioning and Copy on Write (CoW)
 snapshots. For each devicemapper graph location – typically
 `/var/lib/docker/devicemapper` – a thin pool is created based on two block
 devices, one for data and one for metadata.  By default, these block devices
 are created automatically by using loopback mounts of automatically created
-sparse files. Refer to [Storage driver options](#storage-driver-options) below
+sparse files. Refer to [Devicemapper storage driver options](#devicemapper-storage-driver-options) below
 for a way how to customize this setup.
 [~jpetazzo/Resizing Docker containers with the Device Mapper plugin](
 http://jpetazzo.github.io/2014/01/29/docker-device-mapper-resize/) article
@@ -205,10 +208,12 @@ Call `docker -d -s overlay` to use it.
 #### Storage driver options
 
 Particular storage-driver can be configured with options specified with
-`--storage-opt` flags. The only driver accepting options is `devicemapper` as
-of now. All its options are prefixed with `dm`.
+`--storage-opt` flags. The only drivers accepting options are `devicemapper`
+and `aufs` as of now.
 
-Currently supported options are:
+##### Devicemapper storage driver options
+
+The devicemapper options are prefixed with `dm`. Currently supported options are:
 
  *  `dm.basesize`
 
@@ -330,6 +335,24 @@ Currently supported options are:
     Example use:
 
         $ sudo docker -d --storage-opt dm.blkdiscard=false
+
+##### AUFS storage driver options
+
+The aufs options are prefixed with `aufs`. Current supported options are:
+
+ * `aufs.mountopt`
+
+    Specifies extra mount options used when mounting the aufs layers.
+
+    Example use:
+
+        # Tell aufs to check the permission bits of the directory on the
+        # topmost branch and ignore the permission bits on all lower branches.
+        # This option is only available for kernel with `dirperm1` patches and
+        # can be used to fix aufs' permission bug (i.e. upper layer having
+        # broader mask than the lower layer). More information about the
+        # bug can be found at https://github.com/docker/docker/issues/783
+        $ sudo docker -d --storage-opt aufs.mountopt=dirperm1
 
 ### Docker exec-driver option
 


### PR DESCRIPTION
This patch alllows user to pass extra mount options to aufs graph driver via the daemon's `--storage-opt` flag. 

Our use case is that we want to test `dirperm1` mount option ( http://aufs.sourceforge.net/aufs3/man.html ) which only available to kernel with newer aufs patches to see if it can mitigate the permission bug with aufs (https://github.com/docker/docker/issues/783)
