### PR TITLE
Add import command support for dockerfile syntax.

### DIFF
--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -58,6 +58,7 @@ func init() {
 		"expose":     parseStringsWhitespaceDelimited,
 		"volume":     parseMaybeJSONToList,
 		"insert":     parseIgnore,
+		"import":     parseStringsWhitespaceDelimited,
 	}
 }
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3914,3 +3914,26 @@ RUN [ ! -e /injected ]`,
 
 	logDone("build - xz host is being used")
 }
+
+func TestBuildImportSingleFile(t *testing.T) {
+	name := "testbuildimportsinglefile"
+	defer deleteImages(name)
+	dockerfile := `
+		FROM busybox
+        	MAINTAINER dockerio
+        	IMPORT dockerfile1
+		RUN [ "$(cat /root/test)" = "hello import" ]`
+	ctx, err := fakeContext(dockerfile, map[string]string{
+		"dockerfile1": "ADD test /root/",
+		"test":        "hello import",
+	})
+	defer ctx.Close()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+		t.Fatal(err)
+	}
+	logDone("build - import single dockerfile fragment")
+}


### PR DESCRIPTION
1.support multi and single dockerfile fragment.
2.dockfile fragment must be relative path like add command.
3.can not support remote dockerfile fragment.

Docker-DCO-1.1-Signed-off-by: Chen Chao cc272309126@gmail.com (github: cc272309126)
