### PR TITLE
make.sh tgz should handle windows binary

### DIFF
--- a/project/make/tgz
+++ b/project/make/tgz
@@ -25,7 +25,7 @@ for d in "$CROSS/"*/*; do
 	mkdir -p "$DEST/build"
 	
 	mkdir -p "$DEST/build/usr/local/bin"
-	cp -L "$d/$BINARY_FULLNAME" "$DEST/build/usr/local/bin/docker"
+	cp -L "$d/$BINARY_FULLNAME" "$DEST/build/usr/local/bin/docker$BINARY_EXTENSION"
 	
 	tar --numeric-owner --owner 0 -C "$DEST/build" -czf "$TGZ" usr
 	

--- a/project/make/tgz
+++ b/project/make/tgz
@@ -13,13 +13,19 @@ fi
 for d in "$CROSS/"*/*; do
 	GOARCH="$(basename "$d")"
 	GOOS="$(basename "$(dirname "$d")")"
+	BINARY_NAME="docker-$VERSION"
+	BINARY_EXTENSION=
+	if [ "$GOOS" = 'windows' ]; then
+		BINARY_EXTENSION='.exe'
+	fi
+	BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
 	mkdir -p "$DEST/$GOOS/$GOARCH"
-	TGZ="$DEST/$GOOS/$GOARCH/docker-$VERSION.tgz"
+	TGZ="$DEST/$GOOS/$GOARCH/$BINARY_NAME.tgz"
 	
 	mkdir -p "$DEST/build"
 	
 	mkdir -p "$DEST/build/usr/local/bin"
-	cp -L "$d/docker-$VERSION" "$DEST/build/usr/local/bin/docker"
+	cp -L "$d/$BINARY_FULLNAME" "$DEST/build/usr/local/bin/docker"
 	
 	tar --numeric-owner --owner 0 -C "$DEST/build" -czf "$TGZ" usr
 	


### PR DESCRIPTION
This allows `make tgz` to compress windows binary and `make all` to successfully run. Currently it fails with this message:

```
---> Making bundle: tgz (in bundles/1.4.0-dev/tgz)
...
cp: cannot stat '/go/src/github.com/docker/docker/bundles/1.4.0-dev/tgz/../cross/windows/386/docker-1.4.0-dev': No such file or directory
```

The windows exec binary is still being compressed with destination is `/usr/local/bin/docker` which is not too great, but i'm not sure how to fix it.
