### PR TITLE
Change LookupRemoteImage to return error

### DIFF
--- a/graph/push.go
+++ b/graph/push.go
@@ -115,17 +115,16 @@ func (s *TagStore) pushRepository(r *registry.Session, out io.Writer, localName,
 	}
 	for _, ep := range repoData.Endpoints {
 		out.Write(sf.FormatStatus("", "Pushing repository %s (%d tags)", localName, nTag))
-
 		for _, imgId := range imgList {
-			if r.LookupRemoteImage(imgId, ep, repoData.Tokens) {
-				out.Write(sf.FormatStatus("", "Image %s already pushed, skipping", utils.TruncateID(imgId)))
-			} else {
+			if err := r.LookupRemoteImage(imgId, ep, repoData.Tokens); err != nil {
+				log.Errorf("Error in LookupRemoteImage: %s", err)
 				if _, err := s.pushImage(r, out, remoteName, imgId, ep, repoData.Tokens, sf); err != nil {
 					// FIXME: Continue on error?
 					return err
 				}
+			} else {
+				out.Write(sf.FormatStatus("", "Image %s already pushed, skipping", utils.TruncateID(imgId)))
 			}
-
 			for _, tag := range tagsByImage[imgId] {
 				out.Write(sf.FormatStatus("", "Pushing tag for rev [%s] on {%s}", utils.TruncateID(imgId), ep+"repositories/"+remoteName+"/tags/"+tag))
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -58,10 +58,11 @@ func TestGetRemoteHistory(t *testing.T) {
 
 func TestLookupRemoteImage(t *testing.T) {
 	r := spawnTestRegistrySession(t)
-	found := r.LookupRemoteImage(imageID, makeURL("/v1/"), token)
-	assertEqual(t, found, true, "Expected remote lookup to succeed")
-	found = r.LookupRemoteImage("abcdef", makeURL("/v1/"), token)
-	assertEqual(t, found, false, "Expected remote lookup to fail")
+	err := r.LookupRemoteImage(imageID, makeURL("/v1/"), token)
+	assertEqual(t, err, nil, "Expected error of remote lookup to nil")
+	if err := r.LookupRemoteImage("abcdef", makeURL("/v1/"), token); err == nil {
+		t.Fatal("Expected error of remote lookup to not nil")
+	}
 }
 
 func TestGetRemoteImageJSON(t *testing.T) {

--- a/registry/session.go
+++ b/registry/session.go
@@ -102,22 +102,21 @@ func (r *Session) GetRemoteHistory(imgID, registry string, token []string) ([]st
 }
 
 // Check if an image exists in the Registry
-// TODO: This method should return the errors instead of masking them and returning false
-func (r *Session) LookupRemoteImage(imgID, registry string, token []string) bool {
-
+func (r *Session) LookupRemoteImage(imgID, registry string, token []string) error {
 	req, err := r.reqFactory.NewRequest("GET", registry+"images/"+imgID+"/json", nil)
 	if err != nil {
-		log.Errorf("Error in LookupRemoteImage %s", err)
-		return false
+		return err
 	}
 	setTokenAuth(req, token)
 	res, _, err := r.doRequest(req)
 	if err != nil {
-		log.Errorf("Error in LookupRemoteImage %s", err)
-		return false
+		return err
 	}
 	res.Body.Close()
-	return res.StatusCode == 200
+	if res.StatusCode != 200 {
+		return utils.NewHTTPRequestError(fmt.Sprintf("HTTP code %d", res.StatusCode), res)
+	}
+	return nil
 }
 
 // Retrieve an image from the Registry.


### PR DESCRIPTION
This carries and replaces #9192

This commit is patch for following comment
// TODO: This method should return the errors instead of masking them and returning false

Signed-off-by: Daehyeok Mun daehyeok@gmail.com
Signed-off-by: Michael Crosby crosbymichael@gmail.com
