### PR TITLE
Closes #9311 Handles container id/name collisions against daemon functionalities according to #8069

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -847,6 +847,12 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 	for _, name := range cmd.Args() {
 		obj, _, err := readBody(cli.call("GET", "/containers/"+name+"/json", nil, false))
 		if err != nil {
+			if strings.Contains(err.Error(), "Too many") {
+				fmt.Fprintf(cli.err, "Error: %s", err.Error())
+				status = 1
+				continue
+			}
+
 			obj, _, err = readBody(cli.call("GET", "/images/"+name+"/json", nil, false))
 			if err != nil {
 				if strings.Contains(err.Error(), "No such") {
@@ -858,6 +864,20 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 				continue
 			}
 		}
+
+		// obj, _, err := readBody(cli.call("GET", "/containers/"+name+"/json", nil, false))
+		// if err != nil {
+		// 	obj, _, err = readBody(cli.call("GET", "/images/"+name+"/json", nil, false))
+		// 	if err != nil {
+		// 		if strings.Contains(err.Error(), "No such") {
+		// 			fmt.Fprintf(cli.err, "Error: No such image or container: %s\n", name)
+		// 		} else {
+		// 			fmt.Fprintf(cli.err, "%s", err)
+		// 		}
+		// 		status = 1
+		// 		continue
+		// 	}
+		// }
 
 		if tmpl == nil {
 			if err = json.Indent(indented, obj, "", "    "); err != nil {

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -86,7 +86,7 @@ func (b *Builder) commit(id string, autoCmd []string, comment string) error {
 		}
 		defer container.Unmount()
 	}
-	container := b.Daemon.Get(id)
+	container, _ := b.Daemon.Get(id)
 	if container == nil {
 		return fmt.Errorf("An error occured while creating the container")
 	}
@@ -693,7 +693,7 @@ func fixPermissions(source, destination string, uid, gid int, destExisted bool) 
 
 func (b *Builder) clearTmp() {
 	for c := range b.TmpContainers {
-		tmp := b.Daemon.Get(c)
+		tmp, _ := b.Daemon.Get(c)
 		if err := b.Daemon.Destroy(tmp); err != nil {
 			fmt.Fprintf(b.OutStream, "Error removing intermediate container %s: %s\n", utils.TruncateID(c), err.Error())
 			return

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -28,9 +28,9 @@ func (daemon *Daemon) ContainerAttach(job *engine.Job) engine.Status {
 		stderr = job.GetenvBool("stderr")
 	)
 
-	container := daemon.Get(name)
+	container, err := daemon.Get(name)
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return job.Error(err)
 	}
 
 	//logs

--- a/daemon/changes.go
+++ b/daemon/changes.go
@@ -9,7 +9,7 @@ func (daemon *Daemon) ContainerChanges(job *engine.Job) engine.Status {
 		return job.Errorf("Usage: %s CONTAINER", job.Name)
 	}
 	name := job.Args[0]
-	if container := daemon.Get(name); container != nil {
+	if container, err := daemon.Get(name); container != nil {
 		outs := engine.NewTable("", 0)
 		changes, err := container.Changes()
 		if err != nil {
@@ -26,7 +26,7 @@ func (daemon *Daemon) ContainerChanges(job *engine.Job) engine.Status {
 			return job.Error(err)
 		}
 	} else {
-		return job.Errorf("No such container: %s", name)
+		return job.Error(err)
 	}
 	return engine.StatusOK
 }

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -12,9 +12,9 @@ func (daemon *Daemon) ContainerCommit(job *engine.Job) engine.Status {
 	}
 	name := job.Args[0]
 
-	container := daemon.Get(name)
+	container, err := daemon.Get(name)
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return job.Error(err)
 	}
 
 	var (

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1004,7 +1004,7 @@ func (container *Container) updateParentsHosts() error {
 			continue
 		}
 
-		c := container.daemon.Get(cid)
+		c, _ := container.daemon.Get(cid)
 		if c != nil && !container.daemon.config.DisableNetwork && container.hostConfig.NetworkMode.IsPrivate() {
 			if err := etchosts.Update(c.HostsPath, container.NetworkSettings.IPAddress, container.Name[1:]); err != nil {
 				log.Errorf("Failed to update /etc/hosts in parent container: %v", err)
@@ -1272,7 +1272,7 @@ func (container *Container) GetMountLabel() string {
 
 func (container *Container) getIpcContainer() (*Container, error) {
 	containerID := container.hostConfig.IpcMode.Container()
-	c := container.daemon.Get(containerID)
+	c, _ := container.daemon.Get(containerID)
 	if c == nil {
 		return nil, fmt.Errorf("no such container to join IPC: %s", containerID)
 	}
@@ -1289,7 +1289,7 @@ func (container *Container) getNetworkedContainer() (*Container, error) {
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("no container specified to join network")
 		}
-		nc := container.daemon.Get(parts[1])
+		nc, _ := container.daemon.Get(parts[1])
 		if nc == nil {
 			return nil, fmt.Errorf("no such container to join network: %s", parts[1])
 		}

--- a/daemon/copy.go
+++ b/daemon/copy.go
@@ -16,8 +16,7 @@ func (daemon *Daemon) ContainerCopy(job *engine.Job) engine.Status {
 		resource = job.Args[1]
 	)
 
-	if container := daemon.Get(name); container != nil {
-
+	if container, err := daemon.Get(name); container != nil {
 		data, err := container.Copy(resource)
 		if err != nil {
 			return job.Error(err)
@@ -28,6 +27,7 @@ func (daemon *Daemon) ContainerCopy(job *engine.Job) engine.Status {
 			return job.Error(err)
 		}
 		return engine.StatusOK
+	} else {
+		return job.Error(err)
 	}
-	return job.Errorf("No such container: %s", name)
 }

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -118,7 +118,7 @@ func (daemon *Daemon) GenerateSecurityOpt(ipcMode runconfig.IpcMode) ([]string, 
 		return label.DisableSecOpt(), nil
 	}
 	if ipcContainer := ipcMode.Container(); ipcContainer != "" {
-		c := daemon.Get(ipcContainer)
+		c, _ := daemon.Get(ipcContainer)
 		if c == nil {
 			return nil, fmt.Errorf("no such container to join IPC: %s", ipcContainer)
 		}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -156,17 +156,7 @@ func (daemon *Daemon) Install(eng *engine.Engine) error {
 
 // Get looks for a container by the specified ID or name, and returns it.
 // If the container is not found, or if an error occurs, nil is returned.
-func (daemon *Daemon) Get(name string) *Container {
-	if id, err := daemon.idIndex.Get(name); err == nil {
-		return daemon.containers.Get(id)
-	}
-	if c, _ := daemon.GetByName(name); c != nil {
-		return c
-	}
-	return nil
-}
-
-func (daemon *Daemon) GetWithError(prefix string) (*Container, error) {
+func (daemon *Daemon) Get(prefix string) (*Container, error) {
 	if containerByID := daemon.containers.Get(prefix); containerByID != nil {
 		return containerByID, nil
 	}
@@ -205,7 +195,8 @@ func (daemon *Daemon) GetWithError(prefix string) (*Container, error) {
 // Exists returns a true if a container of the specified ID or name exists,
 // false otherwise.
 func (daemon *Daemon) Exists(id string) bool {
-	return daemon.Get(id) != nil
+	c, _ := daemon.Get(id)
+	return c != nil
 }
 
 func (daemon *Daemon) containerRoot(id string) string {
@@ -692,7 +683,7 @@ func (daemon *Daemon) Children(name string) (map[string]*Container, error) {
 	children := make(map[string]*Container)
 
 	err = daemon.containerGraph.Walk(name, func(p string, e *graphdb.Entity) error {
-		c := daemon.Get(e.ID())
+		c, _ := daemon.Get(e.ID())
 		if c == nil {
 			return fmt.Errorf("Could not get container for name %s and id %s", e.ID(), p)
 		}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1,0 +1,102 @@
+package daemon
+
+import (
+	"fmt"
+	"github.com/docker/docker/pkg/graphdb"
+	"github.com/docker/docker/pkg/truncindex"
+	"os"
+	"path"
+	"testing"
+)
+
+//
+// https://github.com/docker/docker/issues/8069
+//
+
+func TestGet(t *testing.T) {
+	c1 := &Container{
+		ID:   "5a4ff6a163ad4533d22d69a2b8960bf7fafdcba06e72d2febdba229008b0bf57",
+		Name: "tender_bardeen",
+	}
+	c2 := &Container{
+		ID:   "3cdbd1aa394fd68559fd1441d6eff2ab7c1e6363582c82febfaa8045df3bd8de",
+		Name: "drunk_hawking",
+	}
+	c3 := &Container{
+		ID:   "3cdbd1aa394fd68559fd1441d6eff2abfafdcba06e72d2febdba229008b0bf57",
+		Name: "3cdbd1aa",
+	}
+	c4 := &Container{
+		ID:   "75fb0b800922abdbef2d27e60abcdfaf7fb0698b2a96d22d3354da361a6ff4a5",
+		Name: "5a4ff6a163ad4533d22d69a2b8960bf7fafdcba06e72d2febdba229008b0bf57",
+	}
+	c5 := &Container{
+		ID:   "d22d69a2b8960bf7fafdcba06e72d2febdba960bf7fafdcba06e72d2f9008b060b",
+		Name: "d22d69a2b896",
+	}
+
+	store := &contStore{
+		s: map[string]*Container{
+			c1.ID: c1,
+			c2.ID: c2,
+			c3.ID: c3,
+			c4.ID: c4,
+			c5.ID: c5,
+		},
+	}
+
+	index := truncindex.NewTruncIndex([]string{})
+	index.Add(c1.ID)
+	index.Add(c2.ID)
+	index.Add(c3.ID)
+	index.Add(c4.ID)
+	index.Add(c5.ID)
+
+	daemonTestDbPath := path.Join(os.TempDir(), "daemon_test.db")
+	graph, err := graphdb.NewSqliteConn(daemonTestDbPath)
+	if err != nil {
+		t.Fatalf("Failed to create daemon test sqlite database at %s", daemonTestDbPath)
+	}
+	graph.Set(c1.Name, c1.ID)
+	graph.Set(c2.Name, c2.ID)
+	graph.Set(c3.Name, c3.ID)
+	graph.Set(c4.Name, c4.ID)
+	graph.Set(c5.Name, c5.ID)
+
+	daemon := &Daemon{
+		containers:     store,
+		idIndex:        index,
+		containerGraph: graph,
+	}
+
+	if container, _ := daemon.GetWithError("3cdbd1aa394fd68559fd1441d6eff2ab7c1e6363582c82febfaa8045df3bd8de"); container != c2 {
+		t.Fatal("Should explicitly match full container IDs")
+	}
+
+	if container, _ := daemon.GetWithError("75fb0b8009"); container != c4 {
+		t.Fatal("Should match a partial ID")
+	}
+
+	if container, _ := daemon.GetWithError("drunk_hawking"); container != c2 {
+		t.Fatal("Should match a full name")
+	}
+
+	// c3.Name is a partial match for both c3.ID and c2.ID
+	if _, err := daemon.GetWithError("3cdbd1aa"); err != ErrAmbiguousPrefix {
+		t.Fatal("Should return ErrAmbiguousPrefix when provided a container name that collides with another container's ID")
+	}
+
+	if container, _ := daemon.GetWithError("d22d69a2b896"); container != c5 {
+		t.Fatal("Should match a container where the provided prefix is an exact match to the it's name, and is also a prefix for it's ID")
+	}
+
+	if _, err := daemon.GetWithError("3cdbd1"); err != ErrAmbiguousPrefix {
+		t.Fatal("Should return ErrAmbiguousPrefix when provided a prefix that partially matches multiple container ID's")
+	}
+
+	if _, err := daemon.GetWithError("nothing"); err.Error() != fmt.Sprintf(ErrNotFound.Error(), "nothing") {
+		t.Fatal("Should return ErrNotFound when provided a prefix that is neither a name or a partial match to an ID")
+	}
+
+	os.Remove(daemonTestDbPath)
+}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -69,32 +69,32 @@ func TestGet(t *testing.T) {
 		containerGraph: graph,
 	}
 
-	if container, _ := daemon.GetWithError("3cdbd1aa394fd68559fd1441d6eff2ab7c1e6363582c82febfaa8045df3bd8de"); container != c2 {
+	if container, _ := daemon.Get("3cdbd1aa394fd68559fd1441d6eff2ab7c1e6363582c82febfaa8045df3bd8de"); container != c2 {
 		t.Fatal("Should explicitly match full container IDs")
 	}
 
-	if container, _ := daemon.GetWithError("75fb0b8009"); container != c4 {
+	if container, _ := daemon.Get("75fb0b8009"); container != c4 {
 		t.Fatal("Should match a partial ID")
 	}
 
-	if container, _ := daemon.GetWithError("drunk_hawking"); container != c2 {
+	if container, _ := daemon.Get("drunk_hawking"); container != c2 {
 		t.Fatal("Should match a full name")
 	}
 
 	// c3.Name is a partial match for both c3.ID and c2.ID
-	if _, err := daemon.GetWithError("3cdbd1aa"); err != ErrAmbiguousPrefix {
+	if _, err := daemon.Get("3cdbd1aa"); err != ErrAmbiguousPrefix {
 		t.Fatal("Should return ErrAmbiguousPrefix when provided a container name that collides with another container's ID")
 	}
 
-	if container, _ := daemon.GetWithError("d22d69a2b896"); container != c5 {
+	if container, _ := daemon.Get("d22d69a2b896"); container != c5 {
 		t.Fatal("Should match a container where the provided prefix is an exact match to the it's name, and is also a prefix for it's ID")
 	}
 
-	if _, err := daemon.GetWithError("3cdbd1"); err != ErrAmbiguousPrefix {
+	if _, err := daemon.Get("3cdbd1"); err != ErrAmbiguousPrefix {
 		t.Fatal("Should return ErrAmbiguousPrefix when provided a prefix that partially matches multiple container ID's")
 	}
 
-	if _, err := daemon.GetWithError("nothing"); err.Error() != fmt.Sprintf(ErrNotFound.Error(), "nothing") {
+	if _, err := daemon.Get("nothing"); err.Error() != fmt.Sprintf(ErrNotFound.Error(), "nothing") {
 		t.Fatal("Should return ErrNotFound when provided a prefix that is neither a name or a partial match to an ID")
 	}
 

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -17,10 +17,10 @@ func (daemon *Daemon) ContainerRm(job *engine.Job) engine.Status {
 	removeVolume := job.GetenvBool("removeVolume")
 	removeLink := job.GetenvBool("removeLink")
 	forceRemove := job.GetenvBool("forceRemove")
-	container := daemon.Get(name)
 
+	container, err := daemon.Get(name)
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return job.Error(err)
 	}
 
 	if removeLink {
@@ -36,7 +36,7 @@ func (daemon *Daemon) ContainerRm(job *engine.Job) engine.Status {
 		if pe == nil {
 			return job.Errorf("Cannot get parent %s for name %s", parent, name)
 		}
-		parentContainer := daemon.Get(pe.ID())
+		parentContainer, _ := daemon.Get(pe.ID())
 
 		if parentContainer != nil {
 			parentContainer.DisableLink(n)

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -89,10 +89,9 @@ func (d *Daemon) unregisterExecCommand(execConfig *execConfig) {
 }
 
 func (d *Daemon) getActiveContainer(name string) (*Container, error) {
-	container := d.Get(name)
-
+	container, err := d.Get(name)
 	if container == nil {
-		return nil, fmt.Errorf("No such container: %s", name)
+		return nil, err
 	}
 
 	if !container.IsRunning() {

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -11,7 +11,7 @@ func (daemon *Daemon) ContainerExport(job *engine.Job) engine.Status {
 		return job.Errorf("Usage: %s container_id", job.Name)
 	}
 	name := job.Args[0]
-	if container := daemon.Get(name); container != nil {
+	if container, err := daemon.Get(name); container != nil {
 		data, err := container.Export()
 		if err != nil {
 			return job.Errorf("%s: %s", name, err)
@@ -25,6 +25,7 @@ func (daemon *Daemon) ContainerExport(job *engine.Job) engine.Status {
 		// FIXME: factor job-specific LogEvent to engine.Job.Run()
 		container.LogEvent("export")
 		return engine.StatusOK
+	} else {
+		return job.Error(err)
 	}
-	return job.Errorf("No such container: %s", name)
 }

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -13,7 +13,7 @@ func (daemon *Daemon) ContainerInspect(job *engine.Job) engine.Status {
 		return job.Errorf("usage: %s NAME", job.Name)
 	}
 	name := job.Args[0]
-	if container := daemon.Get(name); container != nil {
+	if container, err := daemon.Get(name); container != nil {
 		container.Lock()
 		defer container.Unlock()
 		if job.GetenvBool("raw") {
@@ -63,8 +63,9 @@ func (daemon *Daemon) ContainerInspect(job *engine.Job) engine.Status {
 			return job.Error(err)
 		}
 		return engine.StatusOK
+	} else {
+		return job.Error(err)
 	}
-	return job.Errorf("No such container: %s", name)
 }
 
 func (daemon *Daemon) ContainerExecInspect(job *engine.Job) engine.Status {

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -38,7 +38,7 @@ func (daemon *Daemon) ContainerKill(job *engine.Job) engine.Status {
 		}
 	}
 
-	if container := daemon.Get(name); container != nil {
+	if container, err := daemon.Get(name); container != nil {
 		// If no signal is passed, or SIGKILL, perform regular Kill (SIGKILL + wait())
 		if sig == 0 || syscall.Signal(sig) == syscall.SIGKILL {
 			if err := container.Kill(); err != nil {
@@ -53,7 +53,7 @@ func (daemon *Daemon) ContainerKill(job *engine.Job) engine.Status {
 			// FIXME: Add event for signals
 		}
 	} else {
-		return job.Errorf("No such container: %s", name)
+		return job.Error(err)
 	}
 	return engine.StatusOK
 }

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -53,14 +53,14 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 
 	var beforeCont, sinceCont *Container
 	if before != "" {
-		beforeCont = daemon.Get(before)
+		beforeCont, _ = daemon.Get(before)
 		if beforeCont == nil {
 			return job.Error(fmt.Errorf("Could not find container with name or id %s", before))
 		}
 	}
 
 	if since != "" {
-		sinceCont = daemon.Get(since)
+		sinceCont, _ = daemon.Get(since)
 		if sinceCont == nil {
 			return job.Error(fmt.Errorf("Could not find container with name or id %s", since))
 		}

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -40,9 +40,9 @@ func (daemon *Daemon) ContainerLogs(job *engine.Job) engine.Status {
 	if tail == "" {
 		tail = "all"
 	}
-	container := daemon.Get(name)
+	container, err := daemon.Get(name)
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return job.Error(err)
 	}
 	cLog, err := container.ReadLog("json")
 	if err != nil && os.IsNotExist(err) {

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -9,9 +9,9 @@ func (daemon *Daemon) ContainerPause(job *engine.Job) engine.Status {
 		return job.Errorf("Usage: %s CONTAINER", job.Name)
 	}
 	name := job.Args[0]
-	container := daemon.Get(name)
+	container, err := daemon.Get(name)
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return job.Error(err)
 	}
 	if err := container.Pause(); err != nil {
 		return job.Errorf("Cannot pause container %s: %s", name, err)
@@ -25,9 +25,9 @@ func (daemon *Daemon) ContainerUnpause(job *engine.Job) engine.Status {
 		return job.Errorf("Usage: %s CONTAINER", job.Name)
 	}
 	name := job.Args[0]
-	container := daemon.Get(name)
+	container, err := daemon.Get(name)
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return job.Error(err)
 	}
 	if err := container.Unpause(); err != nil {
 		return job.Errorf("Cannot unpause container %s: %s", name, err)

--- a/daemon/resize.go
+++ b/daemon/resize.go
@@ -20,13 +20,14 @@ func (daemon *Daemon) ContainerResize(job *engine.Job) engine.Status {
 		return job.Error(err)
 	}
 
-	if container := daemon.Get(name); container != nil {
+	if container, err := daemon.Get(name); container != nil {
 		if err := container.Resize(height, width); err != nil {
 			return job.Error(err)
 		}
 		return engine.StatusOK
+	} else {
+		return job.Error(err)
 	}
-	return job.Errorf("No such container: %s", name)
 }
 
 func (daemon *Daemon) ContainerExecResize(job *engine.Job) engine.Status {

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -15,13 +15,13 @@ func (daemon *Daemon) ContainerRestart(job *engine.Job) engine.Status {
 	if job.EnvExists("t") {
 		t = job.GetenvInt("t")
 	}
-	if container := daemon.Get(name); container != nil {
+	if container, err := daemon.Get(name); container != nil {
 		if err := container.Restart(int(t)); err != nil {
 			return job.Errorf("Cannot restart container %s: %s\n", name, err)
 		}
 		container.LogEvent("restart")
 	} else {
-		return job.Errorf("No such container: %s\n", name)
+		return job.Error(err)
 	}
 	return engine.StatusOK
 }

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -15,11 +15,11 @@ func (daemon *Daemon) ContainerStart(job *engine.Job) engine.Status {
 	}
 	var (
 		name      = job.Args[0]
-		container = daemon.Get(name)
+		container, err = daemon.Get(name)
 	)
 
 	if container == nil {
-		return job.Errorf("No such container: %s", name)
+		return job.Error(err)
 	}
 
 	if container.IsRunning() {

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -15,7 +15,7 @@ func (daemon *Daemon) ContainerStop(job *engine.Job) engine.Status {
 	if job.EnvExists("t") {
 		t = job.GetenvInt("t")
 	}
-	if container := daemon.Get(name); container != nil {
+	if container, err := daemon.Get(name); container != nil {
 		if !container.IsRunning() {
 			return job.Errorf("Container already stopped")
 		}
@@ -24,7 +24,7 @@ func (daemon *Daemon) ContainerStop(job *engine.Job) engine.Status {
 		}
 		container.LogEvent("stop")
 	} else {
-		return job.Errorf("No such container: %s\n", name)
+		return job.Error(err)
 	}
 	return engine.StatusOK
 }

--- a/daemon/top.go
+++ b/daemon/top.go
@@ -21,7 +21,7 @@ func (daemon *Daemon) ContainerTop(job *engine.Job) engine.Status {
 		psArgs = job.Args[1]
 	}
 
-	if container := daemon.Get(name); container != nil {
+	if container, err := daemon.Get(name); container != nil {
 		if !container.IsRunning() {
 			return job.Errorf("Container %s is not running", name)
 		}
@@ -74,6 +74,7 @@ func (daemon *Daemon) ContainerTop(job *engine.Job) engine.Status {
 		out.WriteTo(job.Stdout)
 		return engine.StatusOK
 
+	} else {
+		return job.Error(err)
 	}
-	return job.Errorf("No such container: %s", name)
 }

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -290,7 +290,7 @@ func parseVolumesFromSpec(daemon *Daemon, spec string) (map[string]*Mount, error
 		return nil, fmt.Errorf("Malformed volumes-from specification: %s", spec)
 	}
 
-	c := daemon.Get(specParts[0])
+	c, _ := daemon.Get(specParts[0])
 	if c == nil {
 		return nil, fmt.Errorf("Container %s not found. Impossible to mount its volumes", specParts[0])
 	}

--- a/daemon/wait.go
+++ b/daemon/wait.go
@@ -11,10 +11,11 @@ func (daemon *Daemon) ContainerWait(job *engine.Job) engine.Status {
 		return job.Errorf("Usage: %s", job.Name)
 	}
 	name := job.Args[0]
-	if container := daemon.Get(name); container != nil {
+	if container, err := daemon.Get(name); container != nil {
 		status, _ := container.WaitStop(-1 * time.Second)
 		job.Printf("%d\n", status)
 		return engine.StatusOK
+	} else {
+		return job.Errorf("%s: %s", job.Name, err.Error())
 	}
-	return job.Errorf("%s: No such container: %s", job.Name, name)
 }

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -347,7 +347,7 @@ func TestPostCreateNull(t *testing.T) {
 
 	containerAssertExists(eng, containerID, t)
 
-	c := daemon.Get(containerID)
+	c, _ := daemon.Get(containerID)
 	if c.Config.Cpuset != "" {
 		t.Fatalf("Cpuset should have been empty - instead its:" + c.Config.Cpuset)
 	}

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -282,12 +282,12 @@ func TestDaemonCreate(t *testing.T) {
 	}
 
 	// Make sure we can get the container with Get()
-	if daemon.Get(container.ID) == nil {
+	if c, _ := daemon.Get(container.ID); c == nil {
 		t.Errorf("Unable to get newly created container")
 	}
 
 	// Make sure it is the right container
-	if daemon.Get(container.ID) != container {
+	if c, _ := daemon.Get(container.ID); c != container {
 		t.Errorf("Get() returned the wrong container")
 	}
 
@@ -383,7 +383,7 @@ func TestDestroy(t *testing.T) {
 	}
 
 	// Make sure daemon.Get() refuses to return the unexisting container
-	if daemon.Get(container.ID) != nil {
+	if c, _ := daemon.Get(container.ID); c != nil {
 		t.Errorf("Unable to get newly created container")
 	}
 
@@ -407,16 +407,16 @@ func TestGet(t *testing.T) {
 	container3, _, _ := mkContainer(daemon, []string{"_", "ls", "-al"}, t)
 	defer daemon.Destroy(container3)
 
-	if daemon.Get(container1.ID) != container1 {
-		t.Errorf("Get(test1) returned %v while expecting %v", daemon.Get(container1.ID), container1)
+	if c, _ := daemon.Get(container1.ID); c != container1 {
+		t.Errorf("Get(test1) returned %v while expecting %v", c, container1)
 	}
 
-	if daemon.Get(container2.ID) != container2 {
-		t.Errorf("Get(test2) returned %v while expecting %v", daemon.Get(container2.ID), container2)
+	if c, _ := daemon.Get(container2.ID); c != container2 {
+		t.Errorf("Get(test2) returned %v while expecting %v", c, container2)
 	}
 
-	if daemon.Get(container3.ID) != container3 {
-		t.Errorf("Get(test3) returned %v while expecting %v", daemon.Get(container3.ID), container3)
+	if c, _ := daemon.Get(container3.ID); c != container3 {
+		t.Errorf("Get(test3) returned %v while expecting %v", c, container3)
 	}
 
 }
@@ -485,7 +485,7 @@ func startEchoServerContainer(t *testing.T, proto string) (*daemon.Daemon, *daem
 		t.Fatal(err)
 	}
 
-	container := daemon.Get(id)
+	container, _ := daemon.Get(id)
 	if container == nil {
 		t.Fatalf("Couldn't fetch test container %s", id)
 	}
@@ -646,7 +646,7 @@ func TestRestore(t *testing.T) {
 	if runningCount != 0 {
 		t.Fatalf("Expected 0 container alive, %d found", runningCount)
 	}
-	container3 := daemon2.Get(container1.ID)
+	container3, _ := daemon2.Get(container1.ID)
 	if container3 == nil {
 		t.Fatal("Unable to Get container")
 	}
@@ -666,14 +666,14 @@ func TestDefaultContainerName(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	container := daemon.Get(createNamedTestContainer(eng, config, t, "some_name"))
+	container, _ := daemon.Get(createNamedTestContainer(eng, config, t, "some_name"))
 	containerID := container.ID
 
 	if container.Name != "/some_name" {
 		t.Fatalf("Expect /some_name got %s", container.Name)
 	}
 
-	if c := daemon.Get("/some_name"); c == nil {
+	if c, _ := daemon.Get("/some_name"); c == nil {
 		t.Fatalf("Couldn't retrieve test container as /some_name")
 	} else if c.ID != containerID {
 		t.Fatalf("Container /some_name has ID %s instead of %s", c.ID, containerID)
@@ -690,14 +690,14 @@ func TestRandomContainerName(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	container := daemon.Get(createTestContainer(eng, config, t))
+	container, _ := daemon.Get(createTestContainer(eng, config, t))
 	containerID := container.ID
 
 	if container.Name == "" {
 		t.Fatalf("Expected not empty container name")
 	}
 
-	if c := daemon.Get(container.Name); c == nil {
+	if c, _ := daemon.Get(container.Name); c == nil {
 		log.Fatalf("Could not lookup container %s by its name", container.Name)
 	} else if c.ID != containerID {
 		log.Fatalf("Looking up container name %s returned id %s instead of %s", container.Name, c.ID, containerID)
@@ -737,13 +737,13 @@ func TestContainerNameValidation(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		container := daemon.Get(engine.Tail(outputBuffer, 1))
+		container, _ := daemon.Get(engine.Tail(outputBuffer, 1))
 
 		if container.Name != "/"+test.Name {
 			t.Fatalf("Expect /%s got %s", test.Name, container.Name)
 		}
 
-		if c := daemon.Get("/" + test.Name); c == nil {
+		if c, _ := daemon.Get("/" + test.Name); c == nil {
 			t.Fatalf("Couldn't retrieve test container as /%s", test.Name)
 		} else if c.ID != container.ID {
 			t.Fatalf("Container /%s has ID %s instead of %s", test.Name, c.ID, container.ID)
@@ -762,7 +762,7 @@ func TestLinkChildContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	container := daemon.Get(createNamedTestContainer(eng, config, t, "/webapp"))
+	container, _ := daemon.Get(createNamedTestContainer(eng, config, t, "/webapp"))
 
 	webapp, err := daemon.GetByName("/webapp")
 	if err != nil {
@@ -778,7 +778,7 @@ func TestLinkChildContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	childContainer := daemon.Get(createTestContainer(eng, config, t))
+	childContainer, _ := daemon.Get(createTestContainer(eng, config, t))
 
 	if err := daemon.RegisterLink(webapp, childContainer, "db"); err != nil {
 		t.Fatal(err)
@@ -804,7 +804,7 @@ func TestGetAllChildren(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	container := daemon.Get(createNamedTestContainer(eng, config, t, "/webapp"))
+	container, _ := daemon.Get(createNamedTestContainer(eng, config, t, "/webapp"))
 
 	webapp, err := daemon.GetByName("/webapp")
 	if err != nil {
@@ -820,7 +820,7 @@ func TestGetAllChildren(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	childContainer := daemon.Get(createTestContainer(eng, config, t))
+	childContainer, _ := daemon.Get(createTestContainer(eng, config, t))
 
 	if err := daemon.RegisterLink(webapp, childContainer, "db"); err != nil {
 		t.Fatal(err)

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -122,7 +122,7 @@ func containerAssertExists(eng *engine.Engine, id string, t Fataler) {
 
 func containerAssertNotExists(eng *engine.Engine, id string, t Fataler) {
 	daemon := mkDaemonFromEngine(eng, t)
-	if c := daemon.Get(id); c != nil {
+	if c, _ := daemon.Get(id); c != nil {
 		t.Fatal(fmt.Errorf("Container %s should not exist", id))
 	}
 }
@@ -147,9 +147,9 @@ func assertHttpError(r *httptest.ResponseRecorder, t Fataler) {
 
 func getContainer(eng *engine.Engine, id string, t Fataler) *daemon.Container {
 	daemon := mkDaemonFromEngine(eng, t)
-	c := daemon.Get(id)
+	c, err := daemon.Get(id)
 	if c == nil {
-		t.Fatal(fmt.Errorf("No such container: %s", id))
+		t.Fatal(err)
 	}
 	return c
 }

--- a/pkg/truncindex/truncindex.go
+++ b/pkg/truncindex/truncindex.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	// ErrNoID is thrown when attempting to use empty prefixes
-	ErrNoID        = errors.New("prefix can't be empty")
-	errDuplicateID = errors.New("multiple IDs were found")
+	ErrNotFound        = errors.New("no such ID")
+	ErrEmptyPrefix     = errors.New("prefix can't be empty")
+	ErrMultipleResults = errors.New("multiple results were found")
 )
 
 func init() {
@@ -46,7 +46,7 @@ func (idx *TruncIndex) addID(id string) error {
 		return fmt.Errorf("illegal character: ' '")
 	}
 	if id == "" {
-		return ErrNoID
+		return ErrEmptyPrefix
 	}
 	if _, exists := idx.ids[id]; exists {
 		return fmt.Errorf("id already exists: '%s'", id)
@@ -86,29 +86,29 @@ func (idx *TruncIndex) Delete(id string) error {
 // Get retrieves an ID from the TruncIndex. If there are multiple IDs
 // with the given prefix, an error is thrown.
 func (idx *TruncIndex) Get(s string) (string, error) {
-	idx.RLock()
-	defer idx.RUnlock()
+	if s == "" {
+		return "", ErrEmptyPrefix
+	}
 	var (
 		id string
 	)
-	if s == "" {
-		return "", ErrNoID
-	}
 	subTreeVisitFunc := func(prefix patricia.Prefix, item patricia.Item) error {
 		if id != "" {
 			// we haven't found the ID if there are two or more IDs
 			id = ""
-			return errDuplicateID
+			return ErrMultipleResults
 		}
 		id = string(prefix)
 		return nil
 	}
 
+	idx.RLock()
+	defer idx.RUnlock()
 	if err := idx.trie.VisitSubtree(patricia.Prefix(s), subTreeVisitFunc); err != nil {
-		return "", fmt.Errorf("no such id: %s", s)
+		return "", err
 	}
 	if id != "" {
 		return id, nil
 	}
-	return "", fmt.Errorf("no such id: %s", s)
+	return "", ErrNotFound
 }

--- a/pkg/truncindex/truncindex_test.go
+++ b/pkg/truncindex/truncindex_test.go
@@ -59,6 +59,11 @@ func TestTruncIndex(t *testing.T) {
 	assertIndexGet(t, index, id[:4], "", true)
 	assertIndexGet(t, index, id[:1], "", true)
 
+	// An ambiguous id prefix should return ErrMultipleResults
+	if _, err := index.Get(id[:4]); err == nil || err != ErrMultipleResults {
+		t.Fatalf("An ambiguous id prefix should return %s", ErrMultipleResults)
+	}
+
 	// 7 characters should NOT conflict
 	assertIndexGet(t, index, id[:7], id, false)
 	assertIndexGet(t, index, id2[:7], id2, false)


### PR DESCRIPTION
Changes truncindex package to properly report when multiple results were found with a given prefix

Modifies Daemon Get method according to the discussion in #8069

Fixes references to Daemon Get throughout. Mostly just ignoring the error message that is now returned, but replacing redundant logic where applicable. These clean-ups could have been more pervasive but I believe they will be easier to carry out once Docker has some notion of error lists defined to replace all of the hard-coded error messages.
