### PR TITLE
docker-run man page has screwed up indenting on --net option

### DIFF
--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -196,7 +196,6 @@ according to RFC4862.
    Assign a name to the container
 
    The operator can identify a container in three ways:
-
     UUID long identifier (“f78375b1c487e03c9438c729345e54db9d20cfa2ac1fc3494b6eb60872e74778”)
     UUID short identifier (“f78375b1c487”)
     Name (“jonah”)


### PR DESCRIPTION
This patch fixes the indenting.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
