### PR TITLE
Fix to avoid a compile error due to float to int truncation with GCCGO

### DIFF
--- a/pkg/units/size_test.go
+++ b/pkg/units/size_test.go
@@ -23,9 +23,9 @@ func TestHumanSize(t *testing.T) {
 	assertEquals(t, "1 MB", HumanSize(1000000))
 	assertEquals(t, "1.049 MB", HumanSize(1048576))
 	assertEquals(t, "2 MB", HumanSize(2*MB))
-	assertEquals(t, "3.42 GB", HumanSize(3.42*GB))
-	assertEquals(t, "5.372 TB", HumanSize(5.372*TB))
-	assertEquals(t, "2.22 PB", HumanSize(2.22*PB))
+	assertEquals(t, "3.42 GB", HumanSize(int64(float64(3.42*GB))))
+	assertEquals(t, "5.372 TB", HumanSize(int64(float64(5.372*TB))))
+	assertEquals(t, "2.22 PB", HumanSize(int64(float64(2.22*PB))))
 }
 
 func TestFromHumanSize(t *testing.T) {


### PR DESCRIPTION
As part of Power and Z system port, compiling docker with latest gccgo compiler.
