### PR TITLE
Add docs Cloudfront cache invalidation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ docs-shell: docs-build
 	$(DOCKER_RUN_DOCS) -p $(if $(DOCSPORT),$(DOCSPORT):)8000 "$(DOCKER_DOCS_IMAGE)" bash
 
 docs-release: docs-build
-	$(DOCKER_RUN_DOCS) -e OPTIONS -e BUILD_ROOT "$(DOCKER_DOCS_IMAGE)" ./release.sh
+	$(DOCKER_RUN_DOCS) -e OPTIONS -e BUILD_ROOT -e DISTRIBUTION_ID "$(DOCKER_DOCS_IMAGE)" ./release.sh
 
 docs-test: docs-build
 	$(DOCKER_RUN_DOCS) "$(DOCKER_DOCS_IMAGE)" ./test.sh
@@ -83,6 +83,7 @@ build: bundles
 	docker build -t "$(DOCKER_IMAGE)" .
 
 docs-build:
+	git diff --name-status upstream/release..upstream/docs docs/ > docs/changed-files
 	cp ./VERSION docs/VERSION
 	echo "$(GIT_BRANCH)" > docs/GIT_BRANCH
 	echo "$(AWS_S3_BUCKET)" > docs/AWS_S3_BUCKET

--- a/docs/README.md
+++ b/docs/README.md
@@ -145,11 +145,13 @@ to view your results and make sure what you published is what you wanted.
 
 When you're happy with it, publish the docs to our live site:
 
-    make AWS_S3_BUCKET=docs.docker.com BUILD_ROOT=yes docs-release
+    make AWS_S3_BUCKET=docs.docker.com BUILD_ROOT=yes DISTRIBUTION_ID=C2K6......FL2F docs-release
 
 Test the uncached version of the live docs at http://docs.docker.com.s3-website-us-east-1.amazonaws.com/
     
 Note that the new docs will not appear live on the site until the cache (a complex,
-distributed CDN system) is flushed. This requires someone with S3 keys. Contact Docker
-(Sven Dowideit or John Costa) for assistance. 
+distributed CDN system) is flushed. The `make docs-release` command will do this
+_if_ the `DISTRIBUTION_ID` is set to the Cloudfront distribution ID (ask the meta
+team) - this will take at least 15 minutes to run and you can check its progress
+with the CDN Cloudfront Chrome addin.
 

--- a/project/RELEASE-CHECKLIST.md
+++ b/project/RELEASE-CHECKLIST.md
@@ -267,14 +267,17 @@ git checkout -b docs release || git checkout docs
 git fetch
 git reset --hard origin/release
 git push -f origin docs
-make AWS_S3_BUCKET=docs.docker.com BUILD_ROOT=yes docs-release
+make AWS_S3_BUCKET=docs.docker.com BUILD_ROOT=yes DISTRIBUTION_ID=C2K6......FL2F docs-release
 ```
 
 The docs will appear on http://docs.docker.com/ (though there may be cached
 versions, so its worth checking http://docs.docker.com.s3-website-us-east-1.amazonaws.com/).
 For more information about documentation releases, see `docs/README.md`.
 
-Ask Sven, or JohnC to invalidate the cloudfront cache using the CND Planet chrome applet.
+Note that the new docs will not appear live on the site until the cache (a complex,
+distributed CDN system) is flushed. The `make docs-release` command will do this
+_if_ the `DISTRIBUTION_ID` is set correctly - this will take at least 15 minutes to run
+and you can check its progress with the CDN Cloudfront Chrome addin.
 
 ### 12. Create a new pull request to merge release back into master
 


### PR DESCRIPTION
Signed-off-by: Sven Dowideit SvenDowideit@home.org.au

@tiborvass @crosbymichael @tianon @fredlf @jamtur01 

right now, it assumes its going to be used only for docs updates, I'll continue to work on it in another PR for the full releases, and to try to get it to auto-detect the DISTRIBUTION_ID
