### PR TITLE
[css] mobile formatting of docs

### DIFF
--- a/docs/theme/mkdocs/css/docs.css
+++ b/docs/theme/mkdocs/css/docs.css
@@ -59,7 +59,7 @@ pre {
 
 /* Main Navigation */
 #nav_menu > #docsnav {
-  max-width: 940px;
+  width: 940px;
   margin: 0 auto;
 }
 #nav_menu > #docsnav > #nav_search {
@@ -103,6 +103,7 @@ pre {
   background: #E8E8E8;
   position: relative;
   width: 100%;
+  min-width: 960px;
   height: 54px;
   z-index: 1000;
   top: auto;
@@ -319,6 +320,35 @@ pre {
 
 .content-body strong {
   font-weight: bold;
+}
+
+@media (max-width: 767px) {
+  #leftnav {
+    display: none !important;
+  }
+
+  .content-body {
+    padding: 0;
+  }
+
+  #content {
+    width: 100%;
+  }
+
+  #content .row {
+    margin: 0;
+    padding: 0 15px;
+  }
+
+  #content [class*="span"] {
+    display: block;
+    float: none;
+    width: 100%;
+    margin-left: 0;
+    -webkit-box-sizing: border-box;
+       -moz-box-sizing: border-box;
+            box-sizing: border-box;
+  }
 }
 
 #leftnav .nav.nav-tabs li a {


### PR DESCRIPTION
Enables a mobile device to read the documentation without scrolling back
and forth for each line.

Fix: < 767px, display content as 100% of the viewport with stacked
span elements. Previously, they were fixed-width elements that must be
clipped.
- Borrowed CSS from bootstrap-responsive, but restricted it to the
  #content div. Dropping it in raw made a mess of the footer.
##### Before

![screenshot from 2014-12-18 07 28 57](https://cloud.githubusercontent.com/assets/1069495/5488914/e96d300c-8691-11e4-95e3-f250241c29e1.png)
##### After

![screenshot from 2014-12-18 08 45 05](https://cloud.githubusercontent.com/assets/1069495/5488943/4f1d2db2-8692-11e4-80d2-75558e38576f.png)

Signed-off-by: Will O'Brien will.obrien@dibit.co
