### PR TITLE
Fix for kill pid error

### DIFF
--- a/project/make/test-integration-cli
+++ b/project/make/test-integration-cli
@@ -40,7 +40,9 @@ exec > >(tee -a $DEST/test.log) 2>&1
 
 	for pid in $(find "$DEST" -name docker.pid); do
 		DOCKER_PID=$(set -x; cat "$pid")
-		( set -x; kill $DOCKER_PID )
-		wait $DOCKERD_PID || true
+		if ps -p $DOCKER_PID > /dev/null ; then
+			( set -x; kill $DOCKER_PID )
+			wait $DOCKERD_PID || true
+		fi
 	done
 )


### PR DESCRIPTION
So my first thoughts when seeing the error on kill were that is was the wrong pid,
but that is incorrect because it works locally, but jenkins seems to take issue
when docker is run without `-t`, maybe... I'm really not sure.
But this checks first to see if the PID exists...
Still really weirded out as to why this fails, consistently on jenkins without this.

ping @unclejack I think you saw this same issue at some point.
