### PR TITLE
Add docker-py integration tests aginst the docker daemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN	apt-get update && apt-get install -y \
 	parallel \
 	python-mock \
 	python-pip \
+	python-websocket \
 	reprepro \
 	ruby1.9.1 \
 	ruby1.9.1-dev \
@@ -94,6 +95,9 @@ RUN	git clone -b buildroot-2014.02 https://github.com/jpetazzo/docker-busybox.gi
 
 # Get the "cirros" image source so we can import it instead of fetching it during tests
 RUN	curl -sSL -o /cirros.tar.gz https://github.com/ewindisch/docker-cirros/raw/1cded459668e8b9dbf4ef976c94c05add9bbd8e9/cirros-0.3.0-x86_64-lxc.tar.gz
+
+# Get the "docker-py" source so we can run their integration tests
+RUN	git clone -b 0.7.0 https://github.com/docker/docker-py.git /docker-py
 
 # Setup s3cmd config
 RUN	/bin/echo -e '[default]\naccess_key=$AWS_ACCESS_KEY\nsecret_key=$AWS_SECRET_KEY' > $HOME/.s3cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ RUN	apt-get update && apt-get install -y \
 	lxc=1.0* \
 	mercurial \
 	parallel \
+	python-mock \
+	python-pip \
 	reprepro \
 	ruby1.9.1 \
 	ruby1.9.1-dev \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all binary build cross default docs docs-build docs-shell shell test test-unit test-integration test-integration-cli validate
+.PHONY: all binary build cross default docs docs-build docs-shell shell test test-unit test-integration test-integration-cli test-docker-py validate
 
 # env vars passed through directly to Docker's build scripts
 # to allow things like `make DOCKER_CLIENTONLY=1 binary` easily
@@ -66,6 +66,9 @@ test-integration: build
 
 test-integration-cli: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary test-integration-cli
+
+test-docker-py: build
+	$(DOCKER_RUN_DOCKER) hack/make.sh binary test-docker-py
 
 validate: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh validate-gofmt validate-dco

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ docs-release: docs-build
 	$(DOCKER_RUN_DOCS) -e OPTIONS -e BUILD_ROOT "$(DOCKER_DOCS_IMAGE)" ./release.sh
 
 test: build
-	$(DOCKER_RUN_DOCKER) hack/make.sh binary cross test-unit test-integration test-integration-cli
+	$(DOCKER_RUN_DOCKER) hack/make.sh binary cross test-unit test-integration test-integration-cli test-docker-py
 
 test-unit: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh test-unit

--- a/project/make.sh
+++ b/project/make.sh
@@ -50,6 +50,7 @@ DEFAULT_BUNDLES=(
 	test-unit
 	test-integration
 	test-integration-cli
+	test-docker-py
 
 	dynbinary
 	dyntest-unit

--- a/project/make/.integration-daemon-start
+++ b/project/make/.integration-daemon-start
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# see test-integration-cli for example usage of this script
+
+export PATH="$DEST/../binary:$DEST/../dynbinary:$PATH"
+
+if ! command -v docker &> /dev/null; then
+	echo >&2 'error: binary or dynbinary must be run before .integration-daemon-start'
+	false
+fi
+
+# intentionally open a couple bogus file descriptors to help test that they get scrubbed in containers
+exec 41>&1 42>&2
+
+DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
+DOCKER_EXECDRIVER=${DOCKER_EXECDRIVER:-native}
+
+( set -x; exec \
+	docker --daemon --debug \
+	--storage-driver "$DOCKER_GRAPHDRIVER" \
+	--exec-driver "$DOCKER_EXECDRIVER" \
+	--pidfile "$DEST/docker.pid" \
+		&> "$DEST/docker.log"
+) &

--- a/project/make/.integration-daemon-stop
+++ b/project/make/.integration-daemon-stop
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+for pid in $(find "$DEST" -name docker.pid); do
+	DOCKER_PID=$(set -x; cat "$pid")
+	( set -x; kill $DOCKER_PID )
+	wait $DOCKERD_PID || true
+done

--- a/project/make/test-docker-py
+++ b/project/make/test-docker-py
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+DEST=$1
+
+DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
+DOCKER_EXECDRIVER=${DOCKER_EXECDRIVER:-native}
+
+# subshell so that we can export PATH without breaking other things
+exec > >(tee -a $DEST/test.log) 2>&1
+(
+	export PATH="$DEST/../binary:$DEST/../dynbinary:$PATH"
+
+	if ! command -v docker &> /dev/null; then
+		echo >&2 'error: binary or dynbinary must be run before test-docker-py'
+		false
+	fi
+
+	# intentionally open a couple bogus file descriptors to help test that they get scrubbed in containers
+	exec 41>&1 42>&2
+
+	( set -x; exec \
+		docker --daemon --debug \
+		--storage-driver "$DOCKER_GRAPHDRIVER" \
+		--exec-driver "$DOCKER_EXECDRIVER" \
+		--pidfile "$DEST/docker.pid" \
+			&> "$DEST/docker.log"
+	) &
+
+	mkdir -p /tmp/dockerpy-tests && cd /tmp/dockerpy-tests
+	git clone https://github.com/docker/docker-py.git
+	cd docker-py
+	git checkout 0.6.0-integration
+	python setup.py install
+	python tests/integration_test.py
+
+	for pid in $(find "$DEST" -name docker.pid); do
+		DOCKER_PID=$(set -x; cat "$pid")
+		( set -x; kill $DOCKER_PID )
+		wait $DOCKERD_PID || true
+	done
+)
+

--- a/project/make/test-docker-py
+++ b/project/make/test-docker-py
@@ -3,41 +3,20 @@ set -e
 
 DEST=$1
 
-DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
-DOCKER_EXECDRIVER=${DOCKER_EXECDRIVER:-native}
-
 # subshell so that we can export PATH without breaking other things
 exec > >(tee -a $DEST/test.log) 2>&1
 (
-	export PATH="$DEST/../binary:$DEST/../dynbinary:$PATH"
+	source "$(dirname "$BASH_SOURCE")/.integration-daemon-start"
 
-	if ! command -v docker &> /dev/null; then
-		echo >&2 'error: binary or dynbinary must be run before test-docker-py'
-		false
-	fi
+	dockerPy='/docker-py'
+	[ -d "$dockerPy" ] || {
+		dockerPy="$DEST/docker-py"
+		git clone https://github.com/docker/docker-py.git "$dockerPy"
+	}
 
-	# intentionally open a couple bogus file descriptors to help test that they get scrubbed in containers
-	exec 41>&1 42>&2
-
-	( set -x; exec \
-		docker --daemon --debug \
-		--storage-driver "$DOCKER_GRAPHDRIVER" \
-		--exec-driver "$DOCKER_EXECDRIVER" \
-		--pidfile "$DEST/docker.pid" \
-			&> "$DEST/docker.log"
-	) &
-
-	mkdir -p /tmp/dockerpy-tests && cd /tmp/dockerpy-tests
-	git clone https://github.com/docker/docker-py.git
-	cd docker-py
-	git checkout 0.6.0-integration
-	python setup.py install
+	cd "$dockerPy"
+	export PYTHONPATH=. # import "docker" from "."
 	python tests/integration_test.py
 
-	for pid in $(find "$DEST" -name docker.pid); do
-		DOCKER_PID=$(set -x; cat "$pid")
-		( set -x; kill $DOCKER_PID )
-		wait $DOCKERD_PID || true
-	done
+	source "$(dirname "$BASH_SOURCE")/.integration-daemon-stop"
 )
-

--- a/project/make/test-integration-cli
+++ b/project/make/test-integration-cli
@@ -3,9 +3,6 @@ set -e
 
 DEST=$1
 
-DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
-DOCKER_EXECDRIVER=${DOCKER_EXECDRIVER:-native}
-
 bundle_test_integration_cli() {
 	go_test_dir ./integration-cli
 }
@@ -13,23 +10,7 @@ bundle_test_integration_cli() {
 # subshell so that we can export PATH without breaking other things
 exec > >(tee -a $DEST/test.log) 2>&1
 (
-	export PATH="$DEST/../binary:$DEST/../dynbinary:$PATH"
-
-	if ! command -v docker &> /dev/null; then
-		echo >&2 'error: binary or dynbinary must be run before test-integration-cli'
-		false
-	fi
-
-	# intentionally open a couple bogus file descriptors to help test that they get scrubbed in containers
-	exec 41>&1 42>&2
-
-	( set -x; exec \
-		docker --daemon --debug \
-		--storage-driver "$DOCKER_GRAPHDRIVER" \
-		--exec-driver "$DOCKER_EXECDRIVER" \
-		--pidfile "$DEST/docker.pid" \
-			&> "$DEST/docker.log"
-	) &
+	source "$(dirname "$BASH_SOURCE")/.integration-daemon-start"
 
 	# pull the busybox image before running the tests
 	sleep 2
@@ -38,9 +19,5 @@ exec > >(tee -a $DEST/test.log) 2>&1
 
 	bundle_test_integration_cli
 
-	for pid in $(find "$DEST" -name docker.pid); do
-		DOCKER_PID=$(set -x; cat "$pid")
-		( set -x; kill $DOCKER_PID )
-		wait $DOCKERD_PID || true
-	done
+	source "$(dirname "$BASH_SOURCE")/.integration-daemon-stop"
 )


### PR DESCRIPTION
Closes #9676

Changes from @crosbymichael's code:
- move docker/docker-py clone to the Dockerfile
- put "integration test daemon startup" code in a separate file for both scripts to source
- add new test-docker-py Makefile target
- include "python-websocket" package in Dockerfile for running the tests

``` console
$ make test-docker-py
docker build -t "docker:add-docker-py-tests" .
Sending build context to Docker daemon 43.49 MB
Sending build context to Docker daemon 
Step 0 : FROM ubuntu:14.04
...
Successfully built c04cdc4c528a
docker run --rm -it --privileged -e BUILDFLAGS -e DOCKER_CLIENTONLY -e DOCKER_EXECDRIVER -e DOCKER_GRAPHDRIVER -e TESTDIRS -e TESTFLAGS -e TIMEOUT -v "/home/tianon/docker/docker/bundles:/go/src/github.com/docker/docker/bundles" "docker:test-docker-py" hack/make.sh binary test-docker-py

bundles/1.4.1-dev already exists. Removing.

---> Making bundle: binary (in bundles/1.4.1-dev/binary)
Created binary: /go/src/github.com/docker/docker/bundles/1.4.1-dev/binary/docker-1.4.1-dev

---> Making bundle: test-docker-py (in bundles/1.4.1-dev/test-docker-py)
+++ exec docker --daemon --debug --storage-driver vfs --exec-driver native --pidfile /go/src/github.com/docker/docker/bundles/1.4.1-dev/test-docker-py/docker.pid
...................................................
----------------------------------------------------------------------
Ran 51 tests in 77.919s

OK
++++ cat /go/src/github.com/docker/docker/bundles/1.4.1-dev/test-docker-py/docker.pid
+++ kill 685

```
