### PR TITLE
Start new API v1.17 docs

### DIFF
--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -30,13 +30,26 @@ page_keywords: API, Docker, rcli, REST, documentation
    Client applications need to take this into account to ensure
    they will not break when talking to newer Docker daemons.
 
-The current version of the API is v1.16
+The current version of the API is v1.17
 
 Calling `/info` is the same as calling
-`/v1.16/info`.
+`/v1.17/info`.
 
 You can still call an old version of the API using
-`/v1.15/info`.
+`/v1.16/info`.
+
+## v1.17
+
+### Full Documentation
+
+[*Docker Remote API v1.17*](/reference/api/docker_remote_api_v1.17/)
+
+### What's new
+
+`POST /containers/(id)/attach` and `POST /exec/(id)/start`
+
+**New!**
+Docker client now hints potential proxies about connection hijacking using HTTP Upgrade headers.
 
 ## v1.16
 

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -1,8 +1,8 @@
-page_title: Remote API v1.16
+page_title: Remote API v1.17
 page_description: API Documentation for Docker
 page_keywords: API, Docker, rcli, REST, documentation
 
-# Docker Remote API v1.16
+# Docker Remote API v1.17
 
 ## 1. Brief introduction
 
@@ -393,8 +393,10 @@ Get stdout and stderr logs from the container ``id``
 
 **Example response**:
 
-       HTTP/1.1 200 OK
+       HTTP/1.1 101 UPGRADED
        Content-Type: application/vnd.docker.raw-stream
+       Connection: Upgrade
+       Upgrade: tcp
 
        {{ STREAM }}
 
@@ -409,7 +411,8 @@ Query Parameters:
 
 Status Codes:
 
--   **200** – no error
+-   **101** – no error, hints proxy about hijacking
+-   **200** – no error, no upgrade header found
 -   **404** – no such container
 -   **500** – server error
 
@@ -644,8 +647,10 @@ Attach to the container `id`
 
 **Example response**:
 
-        HTTP/1.1 200 OK
+        HTTP/1.1 101 UPGRADED
         Content-Type: application/vnd.docker.raw-stream
+        Connection: Upgrade
+        Upgrade: tcp
 
         {{ STREAM }}
 
@@ -663,7 +668,8 @@ Query Parameters:
 
 Status Codes:
 
--   **200** – no error
+-   **101** – no error, hints proxy about hijacking
+-   **200** – no error, no upgrade header found
 -   **400** – bad parameter
 -   **404** – no such container
 -   **500** – server error
@@ -1746,7 +1752,18 @@ As an example, the `docker run` command line makes the following API calls:
 ## 3.2 Hijacking
 
 In this version of the API, /attach, uses hijacking to transport stdin,
-stdout and stderr on the same socket. This might change in the future.
+stdout and stderr on the same socket.
+
+To hint potential proxies about connection hijacking, Docker client sends
+connection upgrade headers similarly to websocket.
+
+    Upgrade: tcp
+    Connection: Upgrade
+
+When Docker daemon detects the `Upgrade` header, it will switch its status code
+from **200 OK** to **101 UPGRADED** and resend the same headers.
+
+This might change in the future.
 
 ## 3.3 CORS Requests
 


### PR DESCRIPTION
#9652 added some new feature's documentation in v1.16 docs. Fixes this by forking new v1.17 docs.
