### PR TITLE
Revert doc changes from #9652

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -393,10 +393,8 @@ Get stdout and stderr logs from the container ``id``
 
 **Example response**:
 
-       HTTP/1.1 101 UPGRADED
+       HTTP/1.1 200 OK
        Content-Type: application/vnd.docker.raw-stream
-       Connection: Upgrade
-       Upgrade: tcp
 
        {{ STREAM }}
 
@@ -411,8 +409,7 @@ Query Parameters:
 
 Status Codes:
 
--   **101** – no error, hints proxy about hijacking
--   **200** – no error, no upgrade header found
+-   **200** – no error
 -   **404** – no such container
 -   **500** – server error
 
@@ -647,10 +644,8 @@ Attach to the container `id`
 
 **Example response**:
 
-        HTTP/1.1 101 UPGRADED
+        HTTP/1.1 200 OK
         Content-Type: application/vnd.docker.raw-stream
-        Connection: Upgrade
-        Upgrade: tcp
 
         {{ STREAM }}
 
@@ -668,8 +663,7 @@ Query Parameters:
 
 Status Codes:
 
--   **101** – no error, hints proxy about hijacking
--   **200** – no error, no upgrade header found
+-   **200** – no error
 -   **400** – bad parameter
 -   **404** – no such container
 -   **500** – server error
@@ -1752,18 +1746,7 @@ As an example, the `docker run` command line makes the following API calls:
 ## 3.2 Hijacking
 
 In this version of the API, /attach, uses hijacking to transport stdin,
-stdout and stderr on the same socket.
-
-To hint potential proxies about connection hijacking, Docker client sends
-connection upgrade headers similarly to websocket.
-
-    Upgrade: tcp
-    Connection: Upgrade
-
-When Docker daemon detects the `Upgrade` header, it will switch its status code
-from **200 OK** to **101 UPGRADED** and resend the same headers.
-
-This might change in the future.
+stdout and stderr on the same socket. This might change in the future.
 
 ## 3.3 CORS Requests
 


### PR DESCRIPTION
Because the patch is not in 1.4, [the v1.16 docs shouldn't have been updated](https://github.com/docker/docker/pull/9652#issuecomment-67604594). Docs were promoted to v1.17 by #9742.

Ping @SvenDowideit @fredlf
