### PR TITLE
Fix pkg/units compilation of size_test

### DIFF
--- a/pkg/units/size_test.go
+++ b/pkg/units/size_test.go
@@ -23,9 +23,9 @@ func TestHumanSize(t *testing.T) {
 	assertEquals(t, "1 MB", HumanSize(1000000))
 	assertEquals(t, "1.049 MB", HumanSize(1048576))
 	assertEquals(t, "2 MB", HumanSize(2*MB))
-	assertEquals(t, "3.42 GB", HumanSize(int64(float64(3.42*GB))))
-	assertEquals(t, "5.372 TB", HumanSize(int64(float64(5.372*TB))))
-	assertEquals(t, "2.22 PB", HumanSize(int64(float64(2.22*PB))))
+	assertEquals(t, "3.42 GB", HumanSize(float64(3.42*GB)))
+	assertEquals(t, "5.372 TB", HumanSize(float64(5.372*TB)))
+	assertEquals(t, "2.22 PB", HumanSize(float64(2.22*PB)))
 }
 
 func TestFromHumanSize(t *testing.T) {


### PR DESCRIPTION
This fixes an issue introduced by #9233 

```
    /size_test.go:26: cannot use int64(float64(3.42 * GB)) (type int64) as type float64 in argument to HumanSize
    ./size_test.go:27: cannot use int64(float64(5.372 * TB)) (type int64) as type float64 in argument to HumanSize
    ./size_test.go:28: cannot use int64(float64(2.22 * PB)) (type int64) as type float64 in argument to HumanSize
```

The CI missed this issue.
