### PR TITLE
registry: remove accidentally added --insecure-registry feature

### DIFF
--- a/registry/endpoint.go
+++ b/registry/endpoint.go
@@ -190,7 +190,7 @@ func isSecure(hostname string, insecureRegistries []string) (bool, error) {
 	}
 
 	for _, r := range insecureRegistries {
-		if hostname == r || host == r {
+		if hostname == r {
 			// hostname matches insecure registry
 			return false, nil
 		}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -350,7 +350,8 @@ func TestIsSecure(t *testing.T) {
 		{"42.42.42.42:5000", []string{"42.1.1.1/8"}, false},
 		{"invalid.domain.com", []string{"42.42.0.0/16"}, true},
 		{"invalid.domain.com", []string{"invalid.domain.com"}, false},
-		{"invalid.domain.com:5000", []string{"invalid.domain.com"}, false},
+		{"invalid.domain.com:5000", []string{"invalid.domain.com"}, true},
+		{"invalid.domain.com:5000", []string{"invalid.domain.com:5000"}, false},
 	}
 	for _, tt := range tests {
 		// TODO: remove this once we remove localhost insecure by default


### PR DESCRIPTION
If `--insecure-registry mydomain.com` was specified, it would match a registry at mydomain.com on any port.
This was accidentally added in #9735 and is now being reverted.

Signed-off-by: Tibor Vass teabee89@gmail.com

Ping @dkjer @icecrime 
