### PR TITLE
Proposal: Add the ability to restart a container every X seconds

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1737,10 +1737,15 @@ You can also specify the maximum amount of times Docker will try to
 restart the container when using the ** on-failure ** policy.  The
 default is that Docker will try forever to restart the container.
 
-    $ sudo docker run --restart=always redis
+    $ sudo docker run --restart=always:2s redis
 
 This will run the `redis` container with a restart policy of ** always ** so that if
-the container exits, Docker will restart it.
+the container exits, Docker will restart it waiting 2 seconds each time.  If you do
+not specify a time it will sleep two times the amount it slept the last time starting
+with 100 milliseconds.  If your container is restarted 4 times that means the first
+time it will sleep 100 milliseconds, then 200, 400, and finally 800 milliseconds.  If
+your container runs successfully for 10 seconds, the sleep time will go back to 100
+milliseconds.
 
     $ sudo docker run --restart=on-failure:10 redis
 


### PR DESCRIPTION
Currently Docker will sleep 100 \* 2^(N-1) milliseconds where N is the number of times it has done a restart.  So this means each restart will sleep twice as long as the last sleep.  So 100 milliseconds, then 200, 400, 800, etc.  The problem is that if you have a container that is failing to start for awhile this sleep time can become hours.  For many things (like a container depending on an external service) it is preferable to just always restart on a fixed interval.  For example, just sleep 2 seconds each time.

The syntax for this will be

`--restart always:2s`

I know more docs need to change so I just documented the syntax I'm proposing.  I'm sure there will be many opinions so as soon as there is an agreement on the syntax, then I'll update all the docs.
