### PR TITLE
Implement docker export --output, like docker save

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1877,7 +1877,7 @@ func (cli *DockerCli) CmdExport(args ...string) error {
 	if err := cli.stream("GET", "/containers/"+image+"/export", nil, output, nil); err != nil {
 		return err
 	}
-	
+
 	return nil
 }
 

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1849,7 +1849,7 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 
 func (cli *DockerCli) CmdExport(args ...string) error {
 	cmd := cli.Subcmd("export", "CONTAINER", "Export the contents of a filesystem to a tar archive (streamed to STDOUT by default)")
-	outfile := cmd.String([]string{"o", "-output"}, "", "Write to a file, instead of STDOUT")
+	outfile := cmd.String([]string{"-o", "--output"}, "", "Write to a file, instead of STDOUT")
 
 	if err := cmd.Parse(args); err != nil {
 		return err
@@ -1879,11 +1879,7 @@ func (cli *DockerCli) CmdExport(args ...string) error {
 		   return err
 		}
 	} else {
-	        v := url.Values{}
-		for _, arg := range cmd.Args() {
-			v.Add("names", arg)
-		}
-		if err := cli.stream("GET", "/containers/get?"+v.Encode(), nil, output, nil); err != nil {
+		if err := cli.stream("GET", "/containers/"+v.Encode()+"/export", nil, output, nil); err != nil {
 			return err
 		}
 	}

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1849,7 +1849,7 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 
 func (cli *DockerCli) CmdExport(args ...string) error {
 	cmd := cli.Subcmd("export", "CONTAINER", "Export the contents of a filesystem to a tar archive (streamed to STDOUT by default)")
-	outfile := cmd.String([]string{"-o", "-output"}, "", "Write to a file, instead of STDOUT")
+	outfile := cmd.String([]string{"o", "-output"}, "", "Write to a file, instead of STDOUT")
 
 	if err := cmd.Parse(args); err != nil {
 		return err

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1848,18 +1848,44 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 }
 
 func (cli *DockerCli) CmdExport(args ...string) error {
-	cmd := cli.Subcmd("export", "CONTAINER", "Export the contents of a filesystem as a tar archive to STDOUT")
+	cmd := cli.Subcmd("export", "CONTAINER", "Export the contents of a filesystem to a tar archive (streamed to STDOUT by default)")
+	outfile := cmd.String([]string{"o", "-output"}, "", "Write to a file, instead of STDOUT")
+
 	if err := cmd.Parse(args); err != nil {
-		return nil
+		return err
 	}
 
-	if cmd.NArg() != 1 {
+	if cmd.NArg() < 1 {
 		cmd.Usage()
 		return nil
 	}
 
-	if err := cli.stream("GET", "/containers/"+cmd.Arg(0)+"/export", nil, cli.out, nil); err != nil {
-		return err
+	var (
+		output io.Writer = cli.out
+		err    error
+	)
+	if *outfile != "" {
+		output, err = os.Create(*outfile)
+		if err != nil {
+			return err
+		}
+	} else if cli.isTerminalOut {
+		return errors.New("Cowardly refusing to save to a terminal. Use the -o flag or redirect.")
+	}
+
+	if len(cmd.Args()) == 1 {
+		image := cmd.Arg(0)
+		if err := cli.stream("GET", "/containers/"+image+"/export", nil, output, nil); err != nil {
+		   return err
+		}
+	} else {
+	        v := url.Values{}
+		for _, arg := range cmd.Args() {
+			v.Add("names", arg)
+		}
+		if err := cli.stream("GET", "/containers/get?"+v.Encode(), nil, output, nil); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1849,7 +1849,7 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 
 func (cli *DockerCli) CmdExport(args ...string) error {
 	cmd := cli.Subcmd("export", "CONTAINER", "Export the contents of a filesystem to a tar archive (streamed to STDOUT by default)")
-	outfile := cmd.String([]string{"-o", "--output"}, "", "Write to a file, instead of STDOUT")
+	outfile := cmd.String([]string{"-o", "-output"}, "", "Write to a file, instead of STDOUT")
 
 	if err := cmd.Parse(args); err != nil {
 		return err
@@ -1873,16 +1873,11 @@ func (cli *DockerCli) CmdExport(args ...string) error {
 		return errors.New("Cowardly refusing to save to a terminal. Use the -o flag or redirect.")
 	}
 
-	if len(cmd.Args()) == 1 {
-		image := cmd.Arg(0)
-		if err := cli.stream("GET", "/containers/"+image+"/export", nil, output, nil); err != nil {
-		   return err
-		}
-	} else {
-		if err := cli.stream("GET", "/containers/"+v.Encode()+"/export", nil, output, nil); err != nil {
-			return err
-		}
+	image := cmd.Arg(0)
+	if err := cli.stream("GET", "/containers/"+image+"/export", nil, output, nil); err != nil {
+		return err
 	}
+	
 	return nil
 }
 

--- a/docs/man/docker-export.1.md
+++ b/docs/man/docker-export.1.md
@@ -13,18 +13,25 @@ Export the contents of a container's filesystem using the full or shortened
 container ID or container name. The output is exported to STDOUT and can be
 redirected to a tar file.
 
+Stream to a file instead of STDOUT by using **-o**.
+
 # OPTIONS
-There are no available options.
+**-o**, **--output**=""
+   Write to a file, instead of STDOUT
 
 # EXAMPLES
 Export the contents of the container called angry_bell to a tar file
-called test.tar:
+called angry_bell.tar:
 
-    # docker export angry_bell > test.tar
-    # ls *.tar
-    test.tar
+    # docker export angry_bell > angry_bell.tar
+    # docker export --output=angry_bell-latest.tar angry_bell
+    # ls -sh angry_bell.tar
+    321M angry_bell.tar
+    # ls -sh angry_bell-latest.tar
+    321M angry_bell-latest.tar
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+Janurary 2015, updated by Joseph Kern (josephakern at gmail dot com)

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -896,13 +896,21 @@ This will create a new Bash session in the container `ubuntu_bash`.
 
 ## export
 
-    Usage: docker export CONTAINER
+    Usage: docker export [OPTIONS] CONTAINER
 
-    Export the contents of a filesystem as a tar archive to STDOUT
+    Export a container to a tar archive (streamed to STDOUT by default)
 
-For example:
+      -o, --output=""    Write to a file, instead of STDOUT
+
+      Produces a tarred repository to the standard output stream.
+
+   For example:
 
     $ sudo docker export red_panda > latest.tar
+   
+   Or
+   
+    $ sudo docker export --output="latest.tar" red_panda
 
 ## history
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -898,7 +898,7 @@ This will create a new Bash session in the container `ubuntu_bash`.
 
     Usage: docker export [OPTIONS] CONTAINER
 
-    Export a container to a tar archive (streamed to STDOUT by default)
+    Export the contents of a filesystem to a tar archive (streamed to STDOUT by default)
 
       -o, --output=""    Write to a file, instead of STDOUT
 
@@ -907,9 +907,9 @@ This will create a new Bash session in the container `ubuntu_bash`.
    For example:
 
     $ sudo docker export red_panda > latest.tar
-   
+
    Or
-   
+
     $ sudo docker export --output="latest.tar" red_panda
 
 ## history

--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -52,3 +52,49 @@ func TestExportContainerAndImportImage(t *testing.T) {
 	logDone("export - export a container")
 	logDone("import - import an image")
 }
+
+// Used to test output flag in the export command
+func TestExportContainerWithOutputAndImportImage(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatal("failed to create a container", out, err)
+	}
+
+	cleanedContainerID := stripTrailingCharacters(out)
+
+	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
+	out, _, err = runCommandWithOutput(inspectCmd)
+	if err != nil {
+		t.Fatalf("output should've been a container id: %s %s ", cleanedContainerID, err)
+	}
+
+	exportCmdTemplate := `%v export --output=/tmp/testexp.tar %v`
+	exportCmdFinal := fmt.Sprintf(exportCmdTemplate, dockerBinary, cleanedContainerID)
+	exportCmd := exec.Command("bash", "-c", exportCmdFinal)
+	if out, _, err = runCommandWithOutput(exportCmd); err != nil {
+		t.Fatalf("failed to export container: %s, %v", out, err)
+	}
+
+	importCmdFinal := `cat /tmp/testexp.tar | docker import - repo/testexp:v1`
+	importCmd := exec.Command("bash", "-c", importCmdFinal)
+	out, _, err = runCommandWithOutput(importCmd)
+	if err != nil {
+		t.Fatalf("failed to import image: %s, %v", out, err)
+	}
+
+	cleanedImageID := stripTrailingCharacters(out)
+
+	inspectCmd = exec.Command(dockerBinary, "inspect", cleanedImageID)
+	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
+		t.Fatalf("output should've been an image id: %s, %v", out, err)
+	}
+
+	deleteContainer(cleanedContainerID)
+	deleteImages("repo/testexp:v1")
+
+	os.Remove("/tmp/testexp.tar")
+
+	logDone("export - export a container with output flag")
+	logDone("import - import an image with output flag")
+}


### PR DESCRIPTION
This was originally submitted under pull request #9744 moved to a new pull request, signed, tested, and cleaned up. `docker export` now has `--output` option symmetry with `docker save`.
