### PR TITLE
Revisiting mkimage-arch.sh

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -18,7 +18,32 @@ ROOTFS=$(mktemp -d ${TMPDIR:-/var/tmp}/rootfs-archlinux-XXXXXXXXXX)
 chmod 755 $ROOTFS
 
 # packages to ignore for space savings
-PKGIGNORE=linux,jfsutils,lvm2,cryptsetup,groff,man-db,man-pages,mdadm,pciutils,pcmciautils,reiserfsprogs,s-nail,xfsprogs
+PKGIGNORE=(
+    cryptsetup
+    device-mapper
+    dhcpcd
+    iproute2
+    jfsutils
+    linux
+    lvm2
+    man-db
+    man-pages
+    mdadm
+    nano
+    netctl
+    openresolv
+    pciutils
+    pcmciautils
+    reiserfsprogs
+    s-nail
+    systemd-sysvcompat
+    usbutils
+    vi
+    xfsprogs
+)
+IFS=','
+PKGIGNORE="${PKGIGNORE[*]}"
+unset IFS
 
 expect <<EOF
 	set send_slow {1 .1}

--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -61,6 +61,7 @@ expect <<EOF
 	}
 EOF
 
+arch-chroot $ROOTFS /bin/sh -c 'rm -r /usr/share/man/*'
 arch-chroot $ROOTFS /bin/sh -c "haveged -w 1024; pacman-key --init; pkill haveged; pacman -Rs --noconfirm haveged; pacman-key --populate archlinux; pkill gpg-agent"
 arch-chroot $ROOTFS /bin/sh -c "ln -s /usr/share/zoneinfo/UTC /etc/localtime"
 echo 'en_US.UTF-8 UTF-8' > $ROOTFS/etc/locale.gen


### PR DESCRIPTION
# Overview

This pull request aims to clean up and slightly reduce the size of Arch Linux base images generated with `mkimage-arch.sh`. So far it does the following two things:
- prevent installing more unnecessary packages
- delete man pages of installed packages

These changes reduce the image size by 17.7 MB or ~5% (from 310.4 MB to 292.7 MB).

**_Note:**_ _Image size is the VIRTUAL SIZE as reported by `docker inspect` on a btrfs file system. The test images were built around 2015-01-08 18:45:48 UTC._
# Details
## Deleting man pages

The script already skips installing [`man-db`](https://www.archlinux.org/packages/core/x86_64/man-db/) and [`man-pages`](https://www.archlinux.org/packages/core/x86_64/man-pages/) to save on disk space, however it fails to delete man pages that belong to the installed packages. `rm -r /usr/share/man/*` accomplishes just that, and reduces the image size by about 11.9 MB.
## Revising list of installed packages

This is more for cleaning up than to save a few megabytes, but it also further reduces the image size by 5.8 MB.

The following is a revised list of packages that should not be installed and a short explanation on why they should be left out, along with a few notes on packages that cannot be left out. Packages denoted with an _*_ are already ignored in the current version of `mkimage-arch.sh`, the rest are new additions.
- [`linux*`](https://www.archlinux.org/packages/core/x86_64/linux/), [`systemd-sysvcompat`](https://www.archlinux.org/packages/core/x86_64/systemd-sysvcompat/) - Containers do not boot.
  
  > [`systemd`](https://www.archlinux.org/packages/core/x86_64/systemd/) - [`procps-ng`](https://www.archlinux.org/packages/core/x86_64/procps-ng/) (`pkill`, `pgrep`, etc.) depends on it.
- [`openresolv`](https://www.archlinux.org/packages/core/x86_64/openresolv/) - `resolv.conf` is managed by the docker daemon.
- [`netctl`](https://www.archlinux.org/packages/core/x86_64/netctl/),[`dhcpcd`](https://www.archlinux.org/packages/core/x86_64/dhcpcd/),[`iproute2`](https://www.archlinux.org/packages/core/x86_64/iproute2/) - Network interface is managed by the docker daemon.
  
  > [`inetutils`](https://www.archlinux.org/packages/core/x86_64/inetutils/) - Contains `telnet` and `ftp`.
  > [`iputils`](https://www.archlinux.org/packages/core/x86_64/iputils/) - Contains `ping`.
- [`pciutils*`](https://www.archlinux.org/packages/core/x86_64/pciutils/), [`pcmciautils*`](https://www.archlinux.org/packages/core/x86_64/pcmciautils/), [`usbutils`](https://www.archlinux.org/packages/core/x86_64/usbutils/) - Hardware management is done by the host.
- [`jfsutils*`](https://www.archlinux.org/packages/core/x86_64/jfsutils/), [`xfsprogs*`](https://www.archlinux.org/packages/core/x86_64/xfsprogs/), [`reiserfsprogs*`](https://www.archlinux.org/packages/core/x86_64/reiserfsprogs/) - File systems are managed by the host.
  
  > [`e2fsprogs`](https://www.archlinux.org/packages/core/x86_64/e2fspriogs/) - [`pam`](https://www.archlinux.org/packages/core/x86_64/pam/), a `base` package indirectly depends on it.
- [`lvm2*`](https://www.archlinux.org/packages/core/x86_64/lvm2/), [`mdadm*`](https://www.archlinux.org/packages/core/x86_64/mdadm/), [`cryptsetup*`](https://www.archlinux.org/packages/core/x86_64/cryptsetup/), [`device-mapper`](https://www.archlinux.org/packages/core/x86_64/device-mapper/) - Storage devices are managed by the host.
- [`man-db*`](https://www.archlinux.org/packages/core/x86_64/man-db/), [`man-pages*`](https://www.archlinux.org/packages/core/x86_64/man-pages/) - Documentation not useful inside a container.
  
  > [`texinfo`](https://www.archlinux.org/packages/core/x86_64/texinfo/) - `pacman` indirectly depends on it.
  > [`licenses`](https://www.archlinux.org/packages/core/x86_64/licenses/) - Should not be left out, see [here](https://wiki.archlinux.org/index.php/PKGBUILD#license)
- [`s-nail*`](https://www.archlinux.org/packages/core/x86_64/s-nail/), [`nano`](https://www.archlinux.org/packages/core/x86_64/nano/), [`vi`](https://www.archlinux.org/packages/core/x86_64/vi/) - Unlikely to be widely used.

For completeness, here are the members of the `base` group that are installed.
[`bash`](https://www.archlinux.org/packages/core/x86_64/bash/), [`bzip2`](https://www.archlinux.org/packages/core/x86_64/bzip2/), [`coreutils`](https://www.archlinux.org/packages/core/x86_64/coreutils/), [`diffutils`](https://www.archlinux.org/packages/core/x86_64/diffutils/), [`e2fsprogs`](https://www.archlinux.org/packages/core/x86_64/e2fspriogs/), [`file`](https://www.archlinux.org/packages/core/x86_64/file/), [`filesystem`](https://www.archlinux.org/packages/core/x86_64/filesystem/), [`findutils`](https://www.archlinux.org/packages/core/x86_64/findutils/), [`gawk`](https://www.archlinux.org/packages/core/x86_64/gawk/), [`gcc-libs`](https://www.archlinux.org/packages/core/x86_64/gcc-libs/), [`gettext`](https://www.archlinux.org/packages/core/x86_64/gettext/), [`glibc`](https://www.archlinux.org/packages/core/x86_64/glibc/), [`grep`](https://www.archlinux.org/packages/core/x86_64/grep/), [`gzip`](https://www.archlinux.org/packages/core/x86_64/gzip/), [`inetutils`](https://www.archlinux.org/packages/core/x86_64/inetutils/), [`iputils`](https://www.archlinux.org/packages/core/x86_64/iputils/), [`less`](https://www.archlinux.org/packages/core/x86_64/less/), [`licenses`](https://www.archlinux.org/packages/core/x86_64/licenses/), [`logrotate`](https://www.archlinux.org/packages/core/x86_64/logrotate/), [`pacman`](https://www.archlinux.org/packages/core/x86_64/pacman/), [`perl`](https://www.archlinux.org/packages/core/x86_64/perl/), [`procps-ng`](https://www.archlinux.org/packages/core/x86_64/procps-ng/), [`psmisc`](https://www.archlinux.org/packages/core/x86_64/psmisc/), [`sed`](https://www.archlinux.org/packages/core/x86_64/sed/), [`shadow`](https://www.archlinux.org/packages/core/x86_64/shadow/), [`sysfsutils`](https://www.archlinux.org/packages/core/x86_64/sysfsutils/), [`tar`](https://www.archlinux.org/packages/core/x86_64/tar/), [`texinfo`](https://www.archlinux.org/packages/core/x86_64/texinfo/), [`util-linux`](https://www.archlinux.org/packages/core/x86_64/util-linux/), [`which`](https://www.archlinux.org/packages/core/x86_64/which/).

**_Note:**_ _`groff` has been removed from the ignore list because it is actually not installed by `base` (it's in `base-devel`)._
## Images sizes

The following table summarises the space saving introduced in this pull request. Images are _cumulative_ in that an image also contains the changes made by the one above it, e.g. _minimal packages_ also deletes the man pages. Differences in size are calculated against the image immediately above.

| image | size (MB) | diff (MB) |
| :-- | --: | --: |
| original | 310.4 |  |
| deleting man | 298.5 | -11.9 |
| minimal packages | 294.3 | -4.2 |
| removed editors | 292.7 | -1.6 |
# Feedback wanted

The patched script builds a working image, however it's possible that I overlooked an unnecessary package or removed an important one. I linked all package names to the respective pages on the Arch Linux web site to make it easier to review the changes. Let me know what you think.

<!-- References -->

<!-- IGNORED -->

<!-- INSTALLED -->
