### PR TITLE
Improve error message for conflicting container name.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -478,8 +478,8 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 		} else {
 			nameAsKnownByUser := strings.TrimPrefix(name, "/")
 			return "", fmt.Errorf(
-				"Conflict, The name %s is already assigned to %s. You have to delete (or rename) that container to be able to assign %s to a container again.", nameAsKnownByUser,
-				utils.TruncateID(conflictingContainer.ID), nameAsKnownByUser)
+				"Conflict. The name %q is already in use by container %s. You have to delete that container to be able to reuse that name.", nameAsKnownByUser,
+				utils.TruncateID(conflictingContainer.ID))
 		}
 	}
 	return name, nil


### PR DESCRIPTION
This changes the error message that is returned by the daemon when
a container-name already exists.

The old message suggests that containers can be renamed, which is
currently not possible.

To prevent confusion, the part "(or rename)" is removed from
the error-message.

Message before this change;

```
FATA[0000] Error response from daemon: Conflict, The name foobar is already assigned to 728ac36fb0ab. You have to delete (or rename) that container to be able to assign foobar to a container again.
```

Message after this change;

```
FATA[0000] Error response from daemon: Conflict, The name foobar is already assigned to 728ac36fb0ab. You have to delete that container to be able to assign foobar to a container again.
```

Relates to: https://github.com/docker/docker/issues/3036

Signed-off-by: Sebastiaan van Stijn github@gone.nl
