### PR TITLE
Revert some modification of PR #9435 to make show the usage of docker exec

### DIFF
--- a/runconfig/exec.go
+++ b/runconfig/exec.go
@@ -52,11 +52,10 @@ func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 		return nil, err
 	}
 	parsedArgs := cmd.Args()
-	if len(parsedArgs) < 2 {
-		return nil, fmt.Errorf("not enough arguments to create exec command")
+	if len(parsedArgs) > 1 {
+		container = cmd.Arg(0)
+		execCmd = parsedArgs[1:]
 	}
-	container = cmd.Arg(0)
-	execCmd = parsedArgs[1:]
 
 	execConfig := &ExecConfig{
 		// TODO(vishh): Expose '-u' flag once it is supported.


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
PR #9435 modify the function `ParseExec` in `runconfig/exec.go` to check if there is 
enough arguments to create exec command,but this cause a problem that the usage of 
of docker exec would never show if the user enter the wrong format of command or just want to 
see the usage with `docker exec`,so this is weird. Actually,I don't think there is need to check if 
there is enough arguments in `ParseExec`,because the client API  `CmdExec` will do  that and show the usage if the arguments is wrong.
This patch is just a revert of the modification of function `ParseExec` made by PR#9435  
