### PR TITLE
Add basic build cancellation

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -581,6 +581,17 @@ func (b *Builder) run(c *daemon.Container) error {
 		return err
 	}
 
+	finished := make(chan struct{})
+	defer close(finished)
+	go func() {
+		select {
+		case <-b.cancelled:
+			log.Debugln("Build cancelled, killing container:", c.ID)
+			c.Kill()
+		case <-finished:
+		}
+	}()
+
 	if b.Verbose {
 		// Block on reading output from container, stop on err or chan closed
 		if err := <-errCh; err != nil {

--- a/builder/job.go
+++ b/builder/job.go
@@ -153,6 +153,7 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) engine.Status {
 		cpuSetCpus:      cpuSetCpus,
 		memory:          memory,
 		memorySwap:      memorySwap,
+		cancelled:       job.WaitCancelled(),
 	}
 
 	id, err := builder.Run(context)

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -76,6 +76,11 @@ Builds can now set resource constraints for all containers created for the build
 (`CgroupParent`) can be passed in the host config to setup container cgroups under a specific cgroup.
 
 
+`POST /build`
+
+**New!**
+Closing the HTTP request will now cause the build to be canceled.
+
 ## v1.17
 
 ### Full Documentation

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -1144,6 +1144,9 @@ The archive may include any number of other files,
 which will be accessible in the build context (See the [*ADD build
 command*](/reference/builder/#dockerbuilder)).
 
+The build will also be canceled if the client drops the connection by quitting
+or being killed.
+
 Query Parameters:
 
 -   **dockerfile** - path within the build context to the Dockerfile. This is 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -599,6 +599,12 @@ in cases where the same set of files are used for multiple builds. The path
 must be to a file within the build context. If a relative path is specified
 then it must to be relative to the current directory.
 
+If the Docker client loses connection to the daemon, the build is canceled.
+This happens if you interrupt the Docker client with `ctrl-c` or if the Docker
+client is killed for any reason.
+
+> **Note:** Currently only the "run" phase of the build can be canceled until
+> pull cancelation is implemented).
 
 See also:
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -123,6 +123,8 @@ func (eng *Engine) Job(name string, args ...string) *Job {
 		Stderr:  NewOutput(),
 		env:     &Env{},
 		closeIO: true,
+
+		cancelled: make(chan struct{}),
 	}
 	if eng.Logging {
 		job.Stderr.Add(ioutils.NopWriteCloser(eng.Stderr))

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -42,6 +42,18 @@ func processExitCode(err error) (exitCode int) {
 	return
 }
 
+func IsKilled(err error) bool {
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		sys := exitErr.ProcessState.Sys()
+		status, ok := sys.(syscall.WaitStatus)
+		if !ok {
+			return false
+		}
+		return status.Signaled() && status.Signal() == os.Kill
+	}
+	return false
+}
+
 func runCommandWithOutput(cmd *exec.Cmd) (output string, exitCode int, err error) {
 	exitCode = 0
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
Cancelling the build is a desirable function. For example, let's say one wanted
to hook up inotify to trigger a build/run cycle when code was edited. At the
moment if there were multiple changes in quick succession, you would end up
with many in-flight builds contending with each other, and no way to cancel
them other than restarting the docker daemon.

This PR has been optimised for being the smallest useful change. It does not
represent the full changes needed to cancel in all circumstances yet. That
will come later, first I hope to disseminate some understanding of how to
achieve this.

Currently it only allows cancellation during the command running phase. If the
command is a `RUN` statement, the container is killed. Other statements are
not currently interrupted but instead the build is cancelled just before
the next statement.

Cancellation can be used by non-docker clients by cancelling the http request.
There is an example of how to do that here:

https://github.com/fsouza/go-dockerclient/pull/183

---

Add the capability to cancel the build by disconnecting the client.

This adds a `cancelled` channel which is used to signal that a build
should halt. The build is halted by sending a Kill signal and noticing
that the cancellation channel is closed.

This first pass implementation does not allow cancellation during a
pull, but that will come in a subsequent PR.

See also:
https://github.com/docker/docker/issues/3654
https://github.com/docker/docker/issues/6928

Next on my TODO list will be to implement the same thing in a similar style
for `docker pull`, if this PR is accepted. That change will automatically
make the pull phase of builds cancellable, too.

Docker-DCO-1.1-Signed-off-by: Peter Waller p@pwaller.net (github: pwaller)
