### PR TITLE
Cleanup: Remove unused function from vfs storage driver

### DIFF
--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -1,10 +1,8 @@
 package vfs
 
 import (
-	"bytes"
 	"fmt"
 	"os"
-	"os/exec"
 	"path"
 
 	"github.com/docker/docker/daemon/graphdriver"
@@ -37,14 +35,6 @@ func (d *Driver) Status() [][2]string {
 
 func (d *Driver) Cleanup() error {
 	return nil
-}
-
-func isGNUcoreutils() bool {
-	if stdout, err := exec.Command("cp", "--version").Output(); err == nil {
-		return bytes.Contains(stdout, []byte("GNU coreutils"))
-	}
-
-	return false
 }
 
 func (d *Driver) Create(id, parent string) error {


### PR DESCRIPTION
The function isGNUcoreutils is no longer used since the use of archive.CopyWithTar has replaced the previous copy mechanism.

Signed-off-by: Pierre Wacrenier pierre.wacrenier@gmail.com
