### PR TITLE
Return usage on parseExec error.

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2589,6 +2589,7 @@ func (cli *DockerCli) CmdExec(args ...string) error {
 
 	execConfig, err := runconfig.ParseExec(cmd, args)
 	if err != nil {
+		cmd.Usage()
 		return err
 	}
 	if execConfig.Container == "" {

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -351,3 +351,19 @@ func TestExecTtyWithoutStdin(t *testing.T) {
 
 	logDone("exec - forbid piped stdin to tty enabled container")
 }
+
+func TestExecParseError(t *testing.T) {
+	defer deleteAllContainers()
+
+	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "top", "busybox", "top")
+	if out, _, err := runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
+
+	// Test normal (non-detached) case first
+	cmd := exec.Command(dockerBinary, "exec", "top")
+	if out, _, err := runCommandWithOutput(cmd); err == nil || !strings.Contains(out, "Usage:") {
+		t.Fatalf("Should have thrown error & given usage: %s", out)
+	}
+	logDone("exec - error on parseExec should return usage")
+}


### PR DESCRIPTION
Closes https://github.com/docker/docker/pull/9770, different fix.

We should return usage on parseExec error because it would be that the user provided the wrong arguments.

Docker-DCO-1.1-Signed-off-by: Jessica Frazelle jess@docker.com (github: jfrazelle)
