### PR TITLE
Add ExecIDs to docker inspect

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -64,7 +64,7 @@ func (e *execStore) Delete(id string) {
 func (e *execStore) List() []string {
 	var IDs []string
 	e.RLock()
-	for id, _ := range e.s {
+	for id := range e.s {
 		IDs = append(IDs, id)
 	}
 	e.RUnlock()

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -50,6 +50,8 @@ func (daemon *Daemon) ContainerInspect(job *engine.Job) engine.Status {
 		out.SetJson("VolumesRW", container.VolumesRW)
 		out.SetJson("AppArmorProfile", container.AppArmorProfile)
 
+		out.SetList("ExecIDs", container.GetExecIDs())
+
 		if children, err := daemon.Children(container.Name); err == nil {
 			for linkAlias, child := range children {
 				container.hostConfig.Links = append(container.hostConfig.Links, fmt.Sprintf("%s:%s", child.Name, linkAlias))

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -51,6 +51,11 @@ You can still call an old version of the API using
 **New!**
 Docker client now hints potential proxies about connection hijacking using HTTP Upgrade headers.
 
+`GET /containers/(id)/json`
+
+**New!**
+This endpoint now returns the list current execs associated with the container (`ExecIDs`).
+
 ## v1.16
 
 ### Full Documentation

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -310,6 +310,9 @@ Return low-level information on the container `id`
                      "SysInitPath": "/home/kitty/go/src/github.com/docker/docker/bin/docker",
                      "ResolvConfPath": "/etc/resolv.conf",
                      "Volumes": {},
+                     "ExecIDs": [
+                         "15f211491dced6a353a2e0f37fe3f3692ee2370a4782418e9bf7052865c10fde"
+                     ],
                      "HostConfig": {
                          "Binds": null,
                          "ContainerIDFile": "",


### PR DESCRIPTION
I need this for docker swarm because right now there is no way from the API to tell an execID is lined to a container.

Swarm has a mapping container <---> node so when Swarm receives a `/container/<container_id>/kill` request, we can use the `<container_id>` to find the right host to proxy the request to.

When Swarm receives a `/exec/<exec_id>/start` there is no way to find the right host right now.
