### PR TITLE
Proposal - Network plugins

### DIFF
--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -2,7 +2,25 @@ page_title: Network Configuration
 page_description: Docker networking
 page_keywords: network, networking, bridge, docker, documentation
 
-# Network Configuration
+# Network concepts
+
+Networks are first class citizens in Docker. They can be managed independently
+from containers using the `docker net` command. Once a network is created with
+the `docker net create` command, you can have containers *join* it using the
+`docker net join` subcommand. Containers inside a given network can communicate
+with each other.
+
+A network is linked to a particular *network driver*, which takes care of
+translating user actions to specific operations, such as creating network
+interfaces or allocating range of IP.
+
+In order to provide working networking features out of the box, a default
+network `default`, managed by the default `simplebridge` driver, is creating at
+Docker start time. Newly created containers will automatically join this
+default network, either under the user provided name, or under a randomly
+generated name.
+
+# The simple bridge network driver
 
 ## TL;DR
 

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -1130,7 +1130,106 @@ Status Codes:
 -   **200** – no error
 -   **500** – server error
 
-## 2.3 Misc
+## 2.3 Networks
+
+All network related API endpoints go through the generic `/cmd` with a JSON
+payload identifying:
+
+-   The action in the `"Name"` field
+-   Optional arguments in the `"Args"` field
+-   Optional daemon job environment in the `"Env"` field
+
+### List networks
+
+**Example request**:
+
+    POST /cmd HTTP/1.1
+    Content-type: application/json
+
+    {
+       "Name": "net_ls"
+    }
+
+**Example response**:
+
+    HTTP/1.1 200
+    Content-Type: application/json
+
+    [
+        {
+            "Name": "default0"
+        },
+        {
+            "Name": "private_network"
+        }
+    ]
+
+### Create a network
+
+**Example request**:
+
+    POST /cmd HTTP/1.1
+    Content-type: application/json
+
+    {
+       "Name": "net_create",
+       "Args": ["public_network"]
+    }
+
+**Example response**:
+
+    HTTP/1.1 200
+    Content-Type: text/plain; charset=utf-8
+
+    public_network
+
+### Delete a network
+
+**Example request**:
+
+    POST /cmd HTTP/1.1
+    Content-type: application/json
+
+    {
+       "Name": "net_rm",
+       "Args": ["public_network"]
+    }
+
+**Example response**:
+
+    HTTP/1.1 200 OK
+
+### Join a network
+
+**Example request**:
+
+    POST /cmd HTTP/1.1
+    Content-type: application/json
+
+    {
+       "Name": "net_join",
+       "Args": ["private_network", "f37e582e3e1c", "secret_santa"]
+    }
+
+**Example response**:
+
+    HTTP/1.1 200 OK
+
+### Leave a network
+
+    POST /cmd HTTP/1.1
+    Content-type: application/json
+
+    {
+       "Name": "net_leave",
+       "Args": ["private_network", "f37e582e3e1c"]
+    }
+
+**Example response**:
+
+    HTTP/1.1 200 OK
+
+## 2.4 Misc
 
 ### Build an image from Dockerfile via stdin
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1236,6 +1236,56 @@ timestamp, for example `2014-09-16T06:17:46.000000000Z`, to each
 log entry. To ensure that the timestamps for are aligned the
 nano-second part of the timestamp will be padded with zero when necessary.
 
+## net
+
+    Usage: docker net [SUBCOMMAND]
+
+    Manage networks
+
+    Commands:
+        create         Create a network
+        join           Add a container to a network
+        leave          Remove a container from a network
+        ls             List networks
+        rm             Remove a network
+
+The `docker net` command is the entrypoint to manage networks. A network is a
+named entity managed by a *network driver*. A containers may dynamically join
+and leave any number of networks.
+
+Invoking `docker net` without subcommand has the same effect `docker net ls`.
+
+    Usage: docker net create NAME
+
+The `docker net create` subcommand creates a new network under the specified
+name. Once created, a network may be joined by containers. The concrete effects
+of network creation entirely depend on the driver in use.
+
+    Usage: docker net rm NETWORK
+
+The `docker net rm` subcommand deletes the specified network. The concrete
+effects of network removal entirely depend on the driver managing `NETWORK`.
+
+    Usage: docker net join NETWORK CONTAINER NAME
+
+The `docker net join` subcommand makes `CONTAINER` join the network `NETWORK`
+wunder the name `NAME`. When the command succeeds, the container becomes
+reachable in the specified network under the name `NAME`. The concrete effects
+of joining a network entirely depend on the driver responsible for managing
+`NETWORK`.
+
+    Usage: docker net leave NETWORK CONTAINER
+
+The `docker net leave` subcommand removes `CONTAINER` from the network
+`NETWORK`. When the command succeeds, the name under which the container
+previously joined the network is relinquished and available for reuse. The
+concrete effets of leaving a network entirely depend on the driver reponsible
+for managing `NETWORK`.
+
+    Usage: docker net ls
+
+The `docker net ls` subcommand lists all available networks.
+
 ## port
 
     Usage: docker port CONTAINER [PRIVATE_PORT[/PROTO]]


### PR DESCRIPTION
_This proposal documents a collective effort from @erikh (lead, network driver), @LK4D4 (sandbox), @aanand (UX, API), @tibor (state), @shykes (arch), and myself (daemon). It is only a draft: there is much more documentation to write (only basic UX is documented in `doc/` as part of this proposal), and some questions left answered. However, it should give a good overview on the ongoing work regarding network plugins._
## Issue statement

Networking aspects in Docker suffer from two major flaws:
- It is naive, and most notably not multi-host aware.
- The networking related code is entangled with the rest of the daemon, and cannot be easily substituted with an alternative implementation.

The goal of this proposal is to introduce a new ways to customize Docker internal behavior with a first focus on networking. Following our "batteries included but removable" motto we want to keep providing a functional networking support out of the box, but we also want to allow anyone to come up with an awesome implementation of a networking stack for Docker and make it easy for users to take advantage of it.

A proof of concept was developed on [shykes/docker](https://github.com/shykes/docker) [`extensions` branch](https://github.com/shykes/docker/tree/extensions). Network is managed by a `simplebridge` driver which implements the already existing bridge + veth approach.
## Subsystems

The goal is to provide new "hook points" to Docker internals with a focus on networking. You might recognize in this approach was has been achieved in the past with `execdriver` or `graphdriver`. However, whereas these refer to low-level concepts, what we try to identify here are higher level responsibilities, and design them to be extensible from day one. We call these **subsystems**.

In the end, we expect the existing `docker/daemon` package to shrink as responsibilities are moved to subsystems, and he becomes more of a subsystems orchestrator.
### State

The **state** subsystem is the first introduced subsystem and provides persistency for the Docker engine. It was introduced early to provide a unified way for all subsystems to manage their internal state. The Docker engine has the responsibility of managing the state and providing each subsystem with their own persistent subsection of the global state.

The state subsystem lives inside the `/state` directory at the project root. Relevant links:
- [`State` interface](https://github.com/shykes/docker/blob/666fae8ee598c4aefd9fc4b65250e8ce837f4320/state/state.go#L6)
- [`GitState` implementation](https://github.com/shykes/docker/blob/666fae8ee598c4aefd9fc4b65250e8ce837f4320/state/gitstate.go) based on [docker/libpack](https://github.com/docker/libpack)
### Sandbox

The **sandbox** is a second introduced subsystem. It provides the mechanism to manipulate a sandboxed execution environment, and relies on the existing `execdriver` mechanism as an implementation detail. The reason sandbox was introduced in the context of network plugins is to abstract namespace manipulation: network drivers will rely on `sandbox` abstraction as a mean of inserting network interfaces inside a network namespace.

The sandbox subsystem lives inside the `/sandbox` directory at the project root. Relevant links:
- [`Sandbox` interface](https://github.com/shykes/docker/blob/666fae8ee598c4aefd9fc4b65250e8ce837f4320/sandbox/controller.go#L54) (implemented by the existing [`execriver.Driver`](https://github.com/shykes/docker/blob/666fae8ee598c4aefd9fc4b65250e8ce837f4320/daemon/execdriver/driver.go#L65))
### Network

Finally, the **network** subsystem provides mechanisms to create networks and have sandboxes join them. The subsystem manages _n_ networks, themselves being managed by _m_ drivers. Networks can be created through new API endpoint and are assigned a user-provided name. Having a sandbox join a network creates an **endpoint** with a user-provided name. This is very important change: containers don't have names, endpoint do: a container in no network has no name, while a container in _n_ networks may have up to _n_ distinct names. To provide a proper "out-of-the-box" experience, newly created sandboxes will be [joining a default network](https://github.com/shykes/docker/blob/666fae8ee598c4aefd9fc4b65250e8ce837f4320/daemon/create.go#L70) under either a randomly generated or user-provided name.

The network subsystem lives inside the `/network` directory at the project root. Relevant links:
- [`Driver` interface](https://github.com/shykes/docker/blob/666fae8ee598c4aefd9fc4b65250e8ce837f4320/network/driver.go#L8)
- The default [`simplebridge` implementation](https://github.com/shykes/docker/tree/666fae8ee598c4aefd9fc4b65250e8ce837f4320/extensions/simplebridge)
- New API endpoints implementation: [`daemon/net.go`](https://github.com/shykes/docker/blob/666fae8ee598c4aefd9fc4b65250e8ce837f4320/daemon/net.go)
## Extensions

Subsystems are conceived with flexibility in mind, which is why we introduce the concept of **extensions**. An extension is a collection of drivers that can be registered upon extension load. The idea behind having a _collection_ of drivers rather than a single driver is to account for the possibility of a higher level extension which would required customizing different aspects of the Docker engine to provide their functionality. In a first step, extensions are compiled in with the Docker binary: this is not our end goal, as we intend to support out-of-process extensions.

The extension mechanism lives inside the `/extensions` directory at the project root. This is also where compiled-in extensions live for the moment.
## Remaining work

UX questions:
- How to pick which driver should manage a given network?
- How to specify a container should join a specific network in `docker run`?

Design questions:
- How to handle out-of-process plugins in the future?
