### PR TITLE
Add a note that remote and Boot2Docker users should not type sudo

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -56,4 +56,6 @@ RUN VERSION=$(cat VERSION) \
 
 EXPOSE 8000
 
+RUN cd sources && rgrep --files-with-matches '{{ include ".*" }}' | xargs sed -i~ 's/{{ include "\(.*\)" }}/cat include\/\1/ge'
+
 CMD ["mkdocs", "serve"]

--- a/docs/sources/articles/basics.md
+++ b/docs/sources/articles/basics.md
@@ -37,7 +37,7 @@ image cache.
 > characters of the full image ID - which can be found using
 > `docker inspect` or `docker images --no-trunc=true`
 
-**If you're using OS X** then you shouldn't use `sudo`.
+{{ include "no-remote-sudo.md" }}
 
 ## Running an interactive shell
 

--- a/docs/sources/faq.md
+++ b/docs/sources/faq.md
@@ -26,6 +26,8 @@ Windows*](../installation/windows/#windows) installation guides. The small
 Linux distribution boot2docker can be run inside virtual machines on these
 two operating systems.
 
+{{ include "no-remote-sudo.md" }}
+
 ### How do containers compare to virtual machines?
 
 They are complementary. VMs are best used to allocate chunks of

--- a/docs/sources/include/no-remote-sudo.md
+++ b/docs/sources/include/no-remote-sudo.md
@@ -1,0 +1,3 @@
+> **Note:** if you are using a remote Docker daemon, such as Boot2Docker, 
+> then _do not_ type the `sudo` before the `docker` commands shown in the
+> documentation's examples.

--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -72,6 +72,8 @@ complete. You can test it by following the directions below.
 
 ## Running Docker
 
+{{ include "no-remote-sudo.md" }}
+
 From your terminal, you can test that Docker is running with our small `hello-world`
 example image:
 Start the vm (`boot2docker start`) and then run:

--- a/docs/sources/installation/windows.md
+++ b/docs/sources/installation/windows.md
@@ -49,6 +49,8 @@ and the Boot2Docker management tool.
 
 ## Running Docker
 
+{{ include "no-remote-sudo.md" }}
+
 Boot2Docker will log you in automatically so you can start using Docker right away.
 
 Let's try the `hello-world` example image. Run

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -4,6 +4,8 @@ page_keywords: Docker, Docker documentation, CLI, command line
 
 # Command Line
 
+{{ include "no-remote-sudo.md" }}
+
 To list available commands, either run `docker` with no parameters
 or execute `docker help`:
 

--- a/docs/sources/userguide/dockerizing.md
+++ b/docs/sources/userguide/dockerizing.md
@@ -9,6 +9,8 @@ page_keywords: docker guide, docker, docker platform, virtualization framework, 
 Docker allows you to run applications inside containers. Running an
 application inside a container takes a single command: `docker run`.
 
+{{ include "no-remote-sudo.md" }}
+
 ## Hello world
 
 Let's try it now.


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@docker.com (github: SvenDowideit)

Closes #9808

and I've implemented a quick transclusion so `{{ include "filename" }}` will be replaced by that content.
