### PR TITLE
Add hostname path when container is set in 'container' network mode

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1055,6 +1055,7 @@ func (container *Container) initializeNetworking() error {
 		}
 		container.HostsPath = nc.HostsPath
 		container.ResolvConfPath = nc.ResolvConfPath
+		container.HostnamePath = nc.HostnamePath
 		container.Config.Hostname = nc.Config.Hostname
 		container.Config.Domainname = nc.Config.Domainname
 		return nil


### PR DESCRIPTION
When a container is running in 'container' network mode, its `HostnamePath` is not set in `initializeNetworking`. So the `/etc/hostname` in the container will be empty. This PR adds the configuration to have correct hostname file.
