### PR TITLE
API: Allow for container IDs to be forced through the remote API.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -431,11 +431,21 @@ func (daemon *Daemon) mergeAndVerifyConfig(config *runconfig.Config, img *image.
 	return warnings, nil
 }
 
-func (daemon *Daemon) generateIdAndName(name string) (string, string, error) {
+func (daemon *Daemon) generateIdAndName(id, name string) (string, string, error) {
 	var (
 		err error
-		id  = utils.GenerateRandomID()
 	)
+
+	if id == "" {
+		id = utils.GenerateRandomID()
+	}
+	if err := utils.ValidateID(id); err != nil {
+		return "", "", err
+	}
+
+	if daemon.Exists(id) {
+		return "", "", fmt.Errorf("Container ID %s is already in use", id)
+	}
 
 	if name == "" {
 		if name, err = daemon.generateNewName(id); err != nil {
@@ -562,7 +572,7 @@ func (daemon *Daemon) newContainer(name string, config *runconfig.Config, imgID 
 		id  string
 		err error
 	)
-	id, name, err = daemon.generateIdAndName(name)
+	id, name, err = daemon.generateIdAndName(config.ID, name)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -79,6 +79,9 @@ You can set the new container's MAC address explicitly.
 **New!**
 Volumes are now initialized when the container is created.
 
+**New!**
+You can set the new container's ID explicitly.
+
 `POST /containers/(id)/copy`
 
 **New!**

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -169,6 +169,7 @@ Create a container
 
 Json Parameters:
 
+-   **ID** - A string value containing the ID to use for the container.
 -   **Hostname** - A string value containing the desired hostname to use for the
       container.
 -   **Domainname** - A string value containing the desired domain name to use

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -9,6 +9,7 @@ import (
 // Here, "portable" means "independent from the host we are running on".
 // Non-portable information *should* appear in HostConfig.
 type Config struct {
+	ID              string // Force a specific ID for the container (optional)
 	Hostname        string
 	Domainname      string
 	User            string
@@ -37,6 +38,7 @@ type Config struct {
 
 func ContainerConfigFromJob(job *engine.Job) *Config {
 	config := &Config{
+		ID:              job.Getenv("ID"),
 		Hostname:        job.Getenv("Hostname"),
 		Domainname:      job.Getenv("Domainname"),
 		User:            job.Getenv("User"),

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -195,7 +195,7 @@ func GenerateRandomID() string {
 
 func ValidateID(id string) error {
 	if ok := validHex.MatchString(id); !ok {
-		err := fmt.Errorf("image ID '%s' is invalid", id)
+		err := fmt.Errorf("ID '%s' is invalid", id)
 		return err
 	}
 	return nil


### PR DESCRIPTION
Forced IDs must be in the exact same format as the ones generated
automatically and be unique (as in, not already in use).

Signed-off-by: Andrea Luzzardi aluzzardi@gmail.com
