### PR TITLE
Proposal: One Meta Data to Rule Them All => Labels

### DIFF
--- a/builder/command/command.go
+++ b/builder/command/command.go
@@ -3,6 +3,7 @@ package command
 
 const (
 	Env        = "env"
+	Label      = "label"
 	Maintainer = "maintainer"
 	Add        = "add"
 	Copy       = "copy"

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -85,6 +85,37 @@ func maintainer(b *Builder, args []string, attributes map[string]bool, original 
 	return b.commit("", b.Config.Cmd, fmt.Sprintf("MAINTAINER %s", b.maintainer))
 }
 
+// LABEL some json data describing the image
+//
+// Sets the Label variable foo to bar,
+//
+func label(b *Builder, args []string, attributes map[string]bool, original string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("LABEL is missing arguments")
+	}
+	if len(args)%2 != 0 {
+		// should never get here, but just in case
+		return fmt.Errorf("Bad input to LABEL, too many args")
+	}
+
+	commitStr := "LABEL"
+
+	if b.Config.Labels == nil {
+		b.Config.Labels = map[string]string{}
+	}
+
+	for j := 0; j < len(args); j++ {
+		// name  ==> args[j]
+		// value ==> args[j+1]
+		newVar := args[j] + "=" + args[j+1] + ""
+		commitStr += " " + newVar
+
+		b.Config.Labels[args[j]] = args[j+1]
+		j++
+	}
+	return b.commit("", b.Config.Cmd, commitStr)
+}
+
 // ADD foo /path
 //
 // Add the file 'foo' to '/path'. Tarball and Remote URL (git, http) handling

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -62,6 +62,7 @@ var evaluateTable map[string]func(*Builder, []string, map[string]bool, string) e
 func init() {
 	evaluateTable = map[string]func(*Builder, []string, map[string]bool, string) error{
 		command.Env:        env,
+		command.Label:      label,
 		command.Maintainer: maintainer,
 		command.Add:        add,
 		command.Copy:       dispatchCopy, // copy() is a go builtin

--- a/builder/parser/line_parsers.go
+++ b/builder/parser/line_parsers.go
@@ -44,10 +44,10 @@ func parseSubCommand(rest string) (*Node, map[string]bool, error) {
 
 // parse environment like statements. Note that this does *not* handle
 // variable interpolation, which will be handled in the evaluator.
-func parseEnv(rest string) (*Node, map[string]bool, error) {
+func parseNameVal(rest string, key string) (*Node, map[string]bool, error) {
 	// This is kind of tricky because we need to support the old
-	// variant:   ENV name value
-	// as well as the new one:    ENV name=value ...
+	// variant:   KEY name value
+	// as well as the new one:    KEY name=value ...
 	// The trigger to know which one is being used will be whether we hit
 	// a space or = first.  space ==> old, "=" ==> new
 
@@ -137,10 +137,10 @@ func parseEnv(rest string) (*Node, map[string]bool, error) {
 	}
 
 	if len(words) == 0 {
-		return nil, nil, fmt.Errorf("ENV requires at least one argument")
+		return nil, nil, fmt.Errorf(key + " requires at least one argument")
 	}
 
-	// Old format (ENV name value)
+	// Old format (KEY name value)
 	var rootnode *Node
 
 	if !strings.Contains(words[0], "=") {
@@ -149,7 +149,7 @@ func parseEnv(rest string) (*Node, map[string]bool, error) {
 		strs := TOKEN_WHITESPACE.Split(rest, 2)
 
 		if len(strs) < 2 {
-			return nil, nil, fmt.Errorf("ENV must have two arguments")
+			return nil, nil, fmt.Errorf(key + " must have two arguments")
 		}
 
 		node.Value = strs[0]
@@ -180,6 +180,14 @@ func parseEnv(rest string) (*Node, map[string]bool, error) {
 	}
 
 	return rootnode, nil, nil
+}
+
+func parseEnv(rest string) (*Node, map[string]bool, error) {
+	return parseNameVal(rest, "ENV")
+}
+
+func parseLabel(rest string) (*Node, map[string]bool, error) {
+	return parseNameVal(rest, "LABEL")
 }
 
 // parses a whitespace-delimited set of arguments. The result is effectively a

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -50,6 +50,7 @@ func init() {
 		command.Onbuild:    parseSubCommand,
 		command.Workdir:    parseString,
 		command.Env:        parseEnv,
+		command.Label:      parseLabel,
 		command.Maintainer: parseString,
 		command.From:       parseString,
 		command.Add:        parseMaybeJSONToList,

--- a/contrib/syntax/kate/Dockerfile.xml
+++ b/contrib/syntax/kate/Dockerfile.xml
@@ -22,6 +22,7 @@
       <item> CMD </item>
       <item> WORKDIR </item>
       <item> USER </item>
+      <item> LABEL </item>
     </list>
 
     <contexts>

--- a/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
+++ b/contrib/syntax/textmate/Docker.tmbundle/Syntaxes/Dockerfile.tmLanguage
@@ -12,7 +12,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>^\s*(ONBUILD\s+)?(FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|USER|WORKDIR|COPY)\s</string>
+			<string>^\s*(ONBUILD\s+)?(FROM|MAINTAINER|RUN|EXPOSE|ENV|ADD|VOLUME|USER|LABEL|WORKDIR|COPY)\s</string>
 			<key>captures</key>
 			<dict>
 				<key>0</key>

--- a/contrib/syntax/vim/syntax/dockerfile.vim
+++ b/contrib/syntax/vim/syntax/dockerfile.vim
@@ -11,7 +11,7 @@ let b:current_syntax = "dockerfile"
 
 syntax case ignore
 
-syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|VOLUME|WORKDIR|COPY)\s/
+syntax match dockerfileKeyword /\v^\s*(ONBUILD\s+)?(ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|LABEL|VOLUME|WORKDIR|COPY)\s/
 highlight link dockerfileKeyword Keyword
 
 syntax region dockerfileString start=/\v"/ skip=/\v\\./ end=/\v"/

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -90,6 +90,10 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 			return nil
 		}
 
+		if !psFilters.MatchKVList("label", container.Config.Labels) {
+			return nil
+		}
+
 		if before != "" && !foundBefore {
 			if container.ID == beforeCont.ID {
 				foundBefore = true
@@ -157,6 +161,7 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 			out.SetInt64("SizeRw", sizeRw)
 			out.SetInt64("SizeRootFs", sizeRootFs)
 		}
+		out.SetJson("Labels", container.Config.Labels)
 		outs.Add(out)
 		return nil
 	}

--- a/docs/man/Dockerfile.5.md
+++ b/docs/man/Dockerfile.5.md
@@ -144,16 +144,19 @@ A Dockerfile is similar to a Makefile.
   the image.
 
 **LABEL**
- --**LABEL <key>[=<value>] [<key>[=<value>] ...]**
+  -- `LABEL <key>[=<value>] [<key>[=<value>] ...]`
+  The **LABEL** instruction adds metadata to an image. A **LABEL** is a
+  key-value pair. To include spaces within a **LABEL** value, use quotes and
+  blackslashes as you would in command-line parsing.
 
- The **LABEL** instruction allows you to add meta-data to the image your 
- Dockerfile is building. LABEL is specified as name value pairs. This data can
- be retrieved using the `docker inspect` command.
+  ```
+  LABEL "com.example.vendor"="ACME Incorporated"
+  ```
 
- The LABEL instruction allows for multiple labels to be set at one time. Like 
- command line parsing, quotes and backslashes can be used to include spaces 
- within values.
+  An image can have more than one label. To specify multiple labels, separate each
+  key-value pair by a space.
 
+  To display an image's labels, use the `docker inspect` command.
 
 **EXPOSE**
   -- `EXPOSE <port> [<port>...]`

--- a/docs/man/Dockerfile.5.md
+++ b/docs/man/Dockerfile.5.md
@@ -143,6 +143,18 @@ A Dockerfile is similar to a Makefile.
   **CMD** executes nothing at build time, but specifies the intended command for
   the image.
 
+**LABEL**
+ --**LABEL <key>[=<value>] [<key>[=<value>] ...]**
+
+ The **LABEL** instruction allows you to add meta-data to the image your 
+ Dockerfile is building. LABEL is specified as name value pairs. This data can
+ be retrieved using the `docker inspect` command.
+
+ The LABEL instruction allows for multiple labels to be set at one time. Like 
+ command line parsing, quotes and backslashes can be used to include spaces 
+ within values.
+
+
 **EXPOSE**
   -- `EXPOSE <port> [<port>...]`
   The **EXPOSE** instruction informs Docker that the container listens on the

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -24,6 +24,8 @@ docker-create - Create a new container
 [**--help**]
 [**-i**|**--interactive**[=*false*]]
 [**--ipc**[=*IPC*]]
+[**-l**|**--label**[=*[]*]]
+[**--label-file**[=*[]*]]
 [**--link**[=*[]*]]
 [**--lxc-conf**[=*[]*]]
 [**-m**|**--memory**[=*MEMORY*]]
@@ -101,6 +103,12 @@ IMAGE [COMMAND] [ARG...]
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
                                'container:<name|id>': reuses another container shared memory, semaphores and message queues
                                'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+
+**-l**, **--label**=[]
+   Set meta data on the container (e.g., --label=com.example.key=value)
+
+**--label-file**=[]
+   Read in a line delimited file of labels
 
 **--link**=[]
    Add link to another container in the form of <name or id>:alias

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -105,10 +105,10 @@ IMAGE [COMMAND] [ARG...]
                                'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
 
 **-l**, **--label**=[]
-   Set meta data on the container (e.g., --label=com.example.key=value)
+   Set metadata on the container (e.g., --label=com.example.key=value)
 
 **--label-file**=[]
-   Read in a line delimited file of labels
+   Read in a file of labels (EOL delimited)
 
 **--link**=[]
    Add link to another container in the form of <name or id>:alias

--- a/docs/man/docker-images.1.md
+++ b/docs/man/docker-images.1.md
@@ -34,9 +34,7 @@ versions.
    Show all images (by default filter out the intermediate image layers). The default is *false*.
 
 **-f**, **--filter**=[]
-   Provide filter values. Valid filters:
-                          dangling=true - unlabeled images with no children
-                          label=<key> or label=<key>=<value>
+   Filters the output. The dangling=true filter finds unused images. While label=com.foo=amd64 filters for images with a com.foo value of amd64. The label=com.foo filter finds images with the label com.foo of any value.
 
 **--help**
   Print usage statement

--- a/docs/man/docker-images.1.md
+++ b/docs/man/docker-images.1.md
@@ -34,7 +34,9 @@ versions.
    Show all images (by default filter out the intermediate image layers). The default is *false*.
 
 **-f**, **--filter**=[]
-   Provide filter values (i.e., 'dangling=true')
+   Provide filter values. Valid filters:
+                          dangling=true - unlabeled images with no children
+                          label=<key> or label=<key>=<value>
 
 **--help**
   Print usage statement

--- a/docs/man/docker-inspect.1.md
+++ b/docs/man/docker-inspect.1.md
@@ -83,6 +83,11 @@ To get information on a container use it's ID or instance name:
             "Ghost": false
         },
         "Image": "df53773a4390e25936f9fd3739e0c0e60a62d024ea7b669282b27e65ae8458e6",
+        "Labels": {
+            "com.example.vendor": "Acme",
+            "com.example.license": "GPL",
+            "com.example.version": "1.0"
+        },
         "NetworkSettings": {
             "IPAddress": "172.17.0.2",
             "IPPrefixLen": 16,

--- a/docs/man/docker-ps.1.md
+++ b/docs/man/docker-ps.1.md
@@ -36,6 +36,7 @@ the running containers.
 **-f**, **--filter**=[]
    Provide filter values. Valid filters:
                           exited=<int> - containers with exit code of <int>
+                          label=<key> or label=<key>=<value>
                           status=(restarting|running|paused|exited)
                           name=<string> - container's name
                           id=<ID> - container's ID

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -25,6 +25,8 @@ docker-run - Run a command in a new container
 [**--help**]
 [**-i**|**--interactive**[=*false*]]
 [**--ipc**[=*IPC*]]
+[**-l**|**--label**[=*[]*]]
+[**--label-file**[=*[]*]]
 [**--link**[=*[]*]]
 [**--lxc-conf**[=*[]*]]
 [**-m**|**--memory**[=*MEMORY*]]
@@ -196,6 +198,12 @@ ENTRYPOINT.
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
                                'container:<name|id>': reuses another container shared memory, semaphores and message queues
                                'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+
+**-l**, **--label**=[]
+   Set meta data on the container (e.g., --label=com.example.key=value)
+
+**--label-file**=[]
+   Read in a line delimited file of labels
 
 **--link**=[]
    Add link to another container in the form of <name or id>:alias

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -200,7 +200,7 @@ ENTRYPOINT.
                                'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
 
 **-l**, **--label**=[]
-   Set meta data on the container (e.g., --label=com.example.key=value)
+   Set metadata on the container (e.g., --label com.example.key=value)
 
 **--label-file**=[]
    Read in a line delimited file of labels

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -59,7 +59,7 @@ pages:
 - ['userguide/dockerimages.md', 'User Guide', 'Working with Docker Images' ]
 - ['userguide/dockerlinks.md', 'User Guide', 'Linking containers together' ]
 - ['userguide/dockervolumes.md', 'User Guide', 'Managing data in containers' ]
-- ['userguide/labels-custom-metadata.md', 'User Guide', 'Labels - custom meta-data in Docker' ]
+- ['userguide/labels-custom-metadata.md', 'User Guide', 'Labels - custom metadata in Docker' ]
 - ['userguide/dockerrepos.md', 'User Guide', 'Working with Docker Hub' ]
 - ['userguide/level1.md', '**HIDDEN**' ]
 - ['userguide/level2.md', '**HIDDEN**' ]

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -59,6 +59,7 @@ pages:
 - ['userguide/dockerimages.md', 'User Guide', 'Working with Docker Images' ]
 - ['userguide/dockerlinks.md', 'User Guide', 'Linking containers together' ]
 - ['userguide/dockervolumes.md', 'User Guide', 'Managing data in containers' ]
+- ['userguide/labels-custom-metadata.md', 'User Guide', 'Labels - custom meta-data in Docker' ]
 - ['userguide/dockerrepos.md', 'User Guide', 'Working with Docker Hub' ]
 - ['userguide/level1.md', '**HIDDEN**' ]
 - ['userguide/level2.md', '**HIDDEN**' ]

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -83,10 +83,21 @@ to an image.  For example you could add data describing the content of an image.
 **New!**
 Docker client now hints potential proxies about connection hijacking using HTTP Upgrade headers.
 
+`POST /containers/create`
+
+**New!**
+You can set labels on container create describing the container.
+
+`GET /containers/json`
+
+**New!**
+This endpoint now returns the labels associated with each container (`Labels`).
+
 `GET /containers/(id)/json`
 
 **New!**
 This endpoint now returns the list current execs associated with the container (`ExecIDs`).
+This endpoint now returns the container labels (`Config.Labels`).
 
 `POST /containers/(id)/rename`
 
@@ -104,6 +115,12 @@ root filesystem as read only.
 
 **New!**
 This endpoint returns a live stream of a container's resource usage statistics.
+
+`GET /images/json`
+
+**New!**
+This endpoint now returns the labels associated with each image (`Labels`).
+
 
 ## v1.16
 

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -71,9 +71,8 @@ This endpoint now returns `SystemTime`, `HttpProxy`,`HttpsProxy` and `NoProxy`.
 
 ### What's new
 
-**New!**
-Build now has support for `LABEL` command which can be used to add user data
-to an image.  For example you could add data describing the content of an image.
+The build supports `LABEL` command. Use this to add metadata
+to an image. For example you could add data describing the content of an image.
 
 `LABEL "com.example.vendor"="ACME Incorporated"`
 
@@ -91,7 +90,7 @@ You can set labels on container create describing the container.
 `GET /containers/json`
 
 **New!**
-This endpoint now returns the labels associated with each container (`Labels`).
+The endpoint returns the labels associated with the containers (`Labels`).
 
 `GET /containers/(id)/json`
 

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -71,6 +71,13 @@ This endpoint now returns `SystemTime`, `HttpProxy`,`HttpsProxy` and `NoProxy`.
 
 ### What's new
 
+**New!**
+Build now has support for `LABEL` command which can be used to add user data
+to an image.  For example you could add data describing the content of an image.
+
+`LABEL "Vendor"="ACME Incorporated"`
+
+**New!**
 `POST /containers/(id)/attach` and `POST /exec/(id)/start`
 
 **New!**

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -75,7 +75,7 @@ This endpoint now returns `SystemTime`, `HttpProxy`,`HttpsProxy` and `NoProxy`.
 Build now has support for `LABEL` command which can be used to add user data
 to an image.  For example you could add data describing the content of an image.
 
-`LABEL "Vendor"="ACME Incorporated"`
+`LABEL "com.example.vendor"="ACME Incorporated"`
 
 **New!**
 `POST /containers/(id)/attach` and `POST /exec/(id)/start`

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -194,6 +194,7 @@ Json Parameters:
 -   **OpenStdin** - Boolean value, opens stdin,
 -   **StdinOnce** - Boolean value, close stdin after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `VAR=value`
+-   **Labels** - A list of labels that will applied in the form of `VAR=value`
 -   **Cmd** - Command to run specified as a string or an array of strings.
 -   **Entrypoint** - Set the entrypoint for the container a a string or an array
       of strings
@@ -303,6 +304,11 @@ Return low-level information on the container `id`
 			"ExposedPorts": null,
 			"Hostname": "ba033ac44011",
 			"Image": "ubuntu",
+                        "Labels": {
+                                "Vendor": "Acme",
+                                "License": "GPL",
+                                "Version": "1.0"
+                        },
 			"MacAddress": "",
 			"Memory": 0,
 			"MemorySwap": 0,
@@ -1174,7 +1180,11 @@ Return low-level information on the image `name`
                              "Cmd": ["/bin/bash"],
                              "Dns": null,
                              "Image": "ubuntu",
-                             "Labels": null,
+                             "Labels": {
+                                    "Vendor": "Acme",
+                                    "License": "GPL",
+                                    "Version": "1.0"
+                             },
                              "Volumes": null,
                              "VolumesFrom": "",
                              "WorkingDir": ""

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -129,6 +129,11 @@ Create a container
              ],
              "Entrypoint": "",
              "Image": "ubuntu",
+             "Labels": {
+                     "Vendor": "Acme",
+                     "License": "GPL",
+                     "Version": "1.0"
+             },
              "Volumes": {
                      "/tmp": {}
              },
@@ -1169,6 +1174,7 @@ Return low-level information on the image `name`
                              "Cmd": ["/bin/bash"],
                              "Dns": null,
                              "Image": "ubuntu",
+                             "Labels": null,
                              "Volumes": null,
                              "VolumesFrom": "",
                              "WorkingDir": ""

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -129,11 +129,6 @@ Create a container
              ],
              "Entrypoint": "",
              "Image": "ubuntu",
-             "Labels": {
-                     "com.example.vendor": "Acme",
-                     "com.example.license": "GPL",
-                     "com.example.version": "1.0"
-             },
              "Volumes": {
                      "/tmp": {}
              },
@@ -194,8 +189,6 @@ Json Parameters:
 -   **OpenStdin** - Boolean value, opens stdin,
 -   **StdinOnce** - Boolean value, close stdin after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `VAR=value`
--   **Labels** - A map of labels and their values that will be added to the 
-        container. It should be specified in the form `{"name":"value"[,"name2":"value2"]}`
 -   **Cmd** - Command to run specified as a string or an array of strings.
 -   **Entrypoint** - Set the entrypoint for the container a a string or an array
       of strings
@@ -305,11 +298,6 @@ Return low-level information on the container `id`
 			"ExposedPorts": null,
 			"Hostname": "ba033ac44011",
 			"Image": "ubuntu",
-			"Labels": {
-				"com.example.vendor": "Acme",
-				"com.example.license": "GPL",
-				"com.example.version": "1.0"
-			},
 			"MacAddress": "",
 			"Memory": 0,
 			"MemorySwap": 0,
@@ -1181,11 +1169,6 @@ Return low-level information on the image `name`
                              "Cmd": ["/bin/bash"],
                              "Dns": null,
                              "Image": "ubuntu",
-                             "Labels": {
-                                 "com.example.vendor": "Acme",
-                                 "com.example.license": "GPL",
-                                 "com.example.version": "1.0"
-                             },
                              "Volumes": null,
                              "VolumesFrom": "",
                              "WorkingDir": ""

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -130,9 +130,9 @@ Create a container
              "Entrypoint": "",
              "Image": "ubuntu",
              "Labels": {
-                     "Vendor": "Acme",
-                     "License": "GPL",
-                     "Version": "1.0"
+                     "com.example.vendor": "Acme",
+                     "com.example.license": "GPL",
+                     "com.example.version": "1.0"
              },
              "Volumes": {
                      "/tmp": {}
@@ -194,7 +194,8 @@ Json Parameters:
 -   **OpenStdin** - Boolean value, opens stdin,
 -   **StdinOnce** - Boolean value, close stdin after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `VAR=value`
--   **Labels** - A list of labels that will applied in the form of `VAR=value`
+-   **Labels** - A map of labels and their values that will be added to the 
+        container. It should be specified in the form `{"name":"value"[,"name2":"value2"]}`
 -   **Cmd** - Command to run specified as a string or an array of strings.
 -   **Entrypoint** - Set the entrypoint for the container a a string or an array
       of strings
@@ -304,11 +305,11 @@ Return low-level information on the container `id`
 			"ExposedPorts": null,
 			"Hostname": "ba033ac44011",
 			"Image": "ubuntu",
-                        "Labels": {
-                                "Vendor": "Acme",
-                                "License": "GPL",
-                                "Version": "1.0"
-                        },
+			"Labels": {
+				"com.example.vendor": "Acme",
+				"com.example.license": "GPL",
+				"com.example.version": "1.0"
+			},
 			"MacAddress": "",
 			"Memory": 0,
 			"MemorySwap": 0,
@@ -1181,9 +1182,9 @@ Return low-level information on the image `name`
                              "Dns": null,
                              "Image": "ubuntu",
                              "Labels": {
-                                    "Vendor": "Acme",
-                                    "License": "GPL",
-                                    "Version": "1.0"
+                                 "com.example.vendor": "Acme",
+                                 "com.example.license": "GPL",
+                                 "com.example.version": "1.0"
                              },
                              "Volumes": null,
                              "VolumesFrom": "",

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -129,6 +129,11 @@ Create a container
              ],
              "Entrypoint": "",
              "Image": "ubuntu",
+             "Labels": {
+                     "com.example.vendor": "Acme",
+                     "com.example.license": "GPL",
+                     "com.example.version": "1.0"
+             },
              "Volumes": {
                      "/tmp": {}
              },
@@ -190,6 +195,8 @@ Json Parameters:
 -   **OpenStdin** - Boolean value, opens stdin,
 -   **StdinOnce** - Boolean value, close stdin after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `VAR=value`
+-   **Labels** - A map of labels and their values that will be added to the
+        container. It should be specified in the form `{"name":"value"[,"name2":"value2"]}`
 -   **Cmd** - Command to run specified as a string or an array of strings.
 -   **Entrypoint** - Set the entrypoint for the container a a string or an array
       of strings
@@ -302,6 +309,11 @@ Return low-level information on the container `id`
 			"ExposedPorts": null,
 			"Hostname": "ba033ac44011",
 			"Image": "ubuntu",
+			"Labels": {
+				"com.example.vendor": "Acme",
+				"com.example.license": "GPL",
+				"com.example.version": "1.0"
+			},
 			"MacAddress": "",
 			"Memory": 0,
 			"MemorySwap": 0,
@@ -1186,6 +1198,11 @@ Return low-level information on the image `name`
                              "Cmd": ["/bin/bash"],
                              "Dns": null,
                              "Image": "ubuntu",
+                             "Labels": {
+                                 "com.example.vendor": "Acme",
+                                 "com.example.license": "GPL",
+                                 "com.example.version": "1.0"
+                             },
                              "Volumes": null,
                              "VolumesFrom": "",
                              "WorkingDir": ""

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -195,8 +195,7 @@ Json Parameters:
 -   **OpenStdin** - Boolean value, opens stdin,
 -   **StdinOnce** - Boolean value, close stdin after the 1 attached client disconnects.
 -   **Env** - A list of environment variables in the form of `VAR=value`
--   **Labels** - A map of labels and their values that will be added to the
-        container. It should be specified in the form `{"name":"value"[,"name2":"value2"]}`
+-   **Labels** - Adds a map of labels that to a container. To specify a map: `{"key":"value"[,"key2":"value2"]}`
 -   **Cmd** - Command to run specified as a string or an array of strings.
 -   **Entrypoint** - Set the entrypoint for the container a a string or an array
       of strings

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -331,13 +331,23 @@ default specified in `CMD`.
 ## LABEL
    LABEL <key>=<value> <key>=<value> <key>=<value> ...
 
- --The `LABEL` instruction allows you to describe the image your `Dockerfile`
-is building. `LABEL` is specified as name value pairs. This data can
+The `LABEL` instruction allows you to add meta-data to the image your 
+`Dockerfile` is building. `LABEL` is specified as name value pairs. This data can
 be retrieved using the `docker inspect` command
 
+    LABEL com.example.label-without-value
+    LABEL com.example.label-with-value="foo"
+    LABEL version="1.0"
+    LABEL description="This my ACME image" vendor="ACME Products"
 
-    LABEL Description="This image is used to start the foobar executable" Vendor="ACME Products"
-    LABEL Version="1.0"
+As illustrated above, the `LABEL` instruction allows for multiple labels to be
+set at one time. Like command line parsing, quotes and backslashes can be used
+to include spaces within values.
+
+For example:
+
+    LABEL description="This text illustrates \
+    that label-values can span multiple lines."
 
 ## EXPOSE
 

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -328,6 +328,17 @@ default specified in `CMD`.
 > the result; `CMD` does not execute anything at build time, but specifies
 > the intended command for the image.
 
+## LABEL
+   LABEL <key>=<value> <key>=<value> <key>=<value> ...
+
+ --The `LABEL` instruction allows you to describe the image your `Dockerfile`
+is building. `LABEL` is specified as name value pairs. This data can
+be retrieved using the `docker inspect` command
+
+
+    LABEL Description="This image is used to start the foobar executable" Vendor="ACME Products"
+    LABEL Version="1.0"
+
 ## EXPOSE
 
     EXPOSE <port> [<port>...]
@@ -907,6 +918,7 @@ For example you might add something like this:
     FROM      ubuntu
     MAINTAINER Victor Vieux <victor@docker.com>
 
+    LABEL Description="This image is used to start the foobar executable" Vendor="ACME Products" Version="1.0"
     RUN apt-get update && apt-get install -y inotify-tools nginx apache2 openssh-server
 
     # Firefox over VNC

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -329,25 +329,25 @@ default specified in `CMD`.
 > the intended command for the image.
 
 ## LABEL
-   LABEL <key>=<value> <key>=<value> <key>=<value> ...
 
-The `LABEL` instruction allows you to add meta-data to the image your 
-`Dockerfile` is building. `LABEL` is specified as name value pairs. This data can
-be retrieved using the `docker inspect` command
+    LABEL <key>=<value> <key>=<value> <key>=<value> ...
+
+The `LABEL` instruction adds metadata to an image. A `LABEL` is a
+key-value pair. To include spaces within a `LABEL` value, use quotes and
+blackslashes as you would in command-line parsing.
+
+    LABEL "com.example.vendor"="ACME Incorporated"
+
+An image can have more than one label. To specify multiple labels, separate each
+key-value pair by an EOL.
 
     LABEL com.example.label-without-value
     LABEL com.example.label-with-value="foo"
     LABEL version="1.0"
-    LABEL description="This my ACME image" vendor="ACME Products"
-
-As illustrated above, the `LABEL` instruction allows for multiple labels to be
-set at one time. Like command line parsing, quotes and backslashes can be used
-to include spaces within values.
-
-For example:
-
     LABEL description="This text illustrates \
     that label-values can span multiple lines."
+
+To view an image's labels, use the `docker inspect` command.
 
 ## EXPOSE
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1840,21 +1840,21 @@ An example of a file passed with `--env-file`
 This will create and run a new container with the container name being
 `console`.
 
-    $ sudo docker run -l my-label --env com.example.foo=bar ubuntu bash
+    $ sudo docker run -l my-label --label com.example.foo=bar ubuntu bash
 
 This sets two labels on the container. Label "my-label" doesn't have a value
 specified and will default to "" (empty string) for its value. Both `-l` and 
-`--env` can be repeated to add more labels. Label names are unique; if the same 
+`--label` can be repeated to add more labels. Label names are unique; if the same
 label is specified multiple times, latter values overwrite the previous value.
 
 Labels can also be loaded from a line delimited file of labels using the 
 `--label-file` flag. The example below will load labels from a file named `labels`
 in the current directory;
 
-    $ sudo docker run --env-file ./labels ubuntu bash
+    $ sudo docker run --label-file ./labels ubuntu bash
 
 The format of the labels-file is similar to that used for loading environment
-variables (see `--env-file` above). An example of a file passed with `--env-file`;
+variables (see `--label-file` above). An example of a file passed with `--label-file`;
 
     $ cat ./labels
     com.example.label1="a label"

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -791,6 +791,8 @@ Creates a new container.
       -h, --hostname=""          Container host name
       -i, --interactive=false    Keep STDIN open even if not attached
       --ipc=""                   IPC namespace to use
+      -l, --label=[]             Set meta data on the container (e.g., --label=com.example.key=value)
+      --label-file=[]            Read in a line delimited file of labels
       --link=[]                  Add link to another container
       --lxc-conf=[]              Add custom lxc options
       -m, --memory=""            Memory limit
@@ -1143,6 +1145,7 @@ than one filter, then pass multiple flags (e.g., `--filter "foo=bar" --filter "b
 
 Current filters:
  * dangling (boolean - true or false)
+ * label (`label=<key>` or `label=<key>=<value>`)
 
 ##### Untagged images
 
@@ -1662,8 +1665,8 @@ removed before the image is removed.
       --link=[]                  Add link to another container
       --lxc-conf=[]              Add custom lxc options
       -m, --memory=""            Memory limit
-      -l, --label=[]             Set meta data on a container, for example com.example.key=value
-      -label-file=[]             Read in a line delimited file of labels
+      -l, --label=[]             Set meta data on the container (e.g., --label=com.example.key=value)
+      --label-file=[]            Read in a line delimited file of labels
       --mac-address=""           Container MAC address (e.g. 92:d0:c6:0a:29:33)
       --memory-swap=""           Total memory (memory + swap), '-1' to disable swap
       --name=""                  Assign a name to the container
@@ -1836,6 +1839,36 @@ An example of a file passed with `--env-file`
 
 This will create and run a new container with the container name being
 `console`.
+
+    $ sudo docker run -l my-label --env com.example.foo=bar ubuntu bash
+
+This sets two labels on the container. Label "my-label" doesn't have a value
+specified and will default to "" (empty string) for its value. Both `-l` and 
+`--env` can be repeated to add more labels. Label names are unique; if the same 
+label is specified multiple times, latter values overwrite the previous value.
+
+Labels can also be loaded from a line delimited file of labels using the 
+`--label-file` flag. The example below will load labels from a file named `labels`
+in the current directory;
+
+    $ sudo docker run --env-file ./labels ubuntu bash
+
+The format of the labels-file is similar to that used for loading environment
+variables (see `--env-file` above). An example of a file passed with `--env-file`;
+
+    $ cat ./labels
+    com.example.label1="a label"
+
+    # this is a comment
+    com.example.label2=another\ label
+    com.example.label3
+
+Multiple label-files can be loaded by providing the `--label-file` multiple 
+times.
+
+For additional information on working with labels, see 
+[*Labels - custom meta-data in Docker*](/userguide/labels-custom-metadata/) in
+the user guide.
 
     $ sudo docker run --link /redis:redis --name console ubuntu bash
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1662,6 +1662,8 @@ removed before the image is removed.
       --link=[]                  Add link to another container
       --lxc-conf=[]              Add custom lxc options
       -m, --memory=""            Memory limit
+      -l, --label=[]             Set meta data on a container, for example com.example.key=value
+      -label-file=[]             Read in a line delimited file of labels
       --mac-address=""           Container MAC address (e.g. 92:d0:c6:0a:29:33)
       --memory-swap=""           Total memory (memory + swap), '-1' to disable swap
       --name=""                  Assign a name to the container

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -791,7 +791,7 @@ Creates a new container.
       -h, --hostname=""          Container host name
       -i, --interactive=false    Keep STDIN open even if not attached
       --ipc=""                   IPC namespace to use
-      -l, --label=[]             Set meta data on the container (e.g., --label=com.example.key=value)
+      -l, --label=[]             Set metadata on the container (e.g., --label=com.example.key=value)
       --label-file=[]            Read in a line delimited file of labels
       --link=[]                  Add link to another container
       --lxc-conf=[]              Add custom lxc options
@@ -1665,8 +1665,8 @@ removed before the image is removed.
       --link=[]                  Add link to another container
       --lxc-conf=[]              Add custom lxc options
       -m, --memory=""            Memory limit
-      -l, --label=[]             Set meta data on the container (e.g., --label=com.example.key=value)
-      --label-file=[]            Read in a line delimited file of labels
+      -l, --label=[]             Set metadata on the container (e.g., --label=com.example.key=value)
+      --label-file=[]            Read in a file of labels (EOL delimited)
       --mac-address=""           Container MAC address (e.g. 92:d0:c6:0a:29:33)
       --memory-swap=""           Total memory (memory + swap), '-1' to disable swap
       --name=""                  Assign a name to the container
@@ -1837,38 +1837,39 @@ An example of a file passed with `--env-file`
 
     $ sudo docker run --name console -t -i ubuntu bash
 
-This will create and run a new container with the container name being
-`console`.
+A label is a a `key=value` pair that applies metadata to a container. To label a container with two labels:
 
     $ sudo docker run -l my-label --label com.example.foo=bar ubuntu bash
 
-This sets two labels on the container. Label "my-label" doesn't have a value
-specified and will default to "" (empty string) for its value. Both `-l` and 
-`--label` can be repeated to add more labels. Label names are unique; if the same
-label is specified multiple times, latter values overwrite the previous value.
+The `my-label` key doesn't specify so the label defaults to an empty
+string(`""`). To add multiple labels, repeat the label flag (`-l` or
+`--label`).
 
-Labels can also be loaded from a line delimited file of labels using the 
-`--label-file` flag. The example below will load labels from a file named `labels`
-in the current directory;
+The `key=value` must be unique. If you specify the same key multiple times
+with different values, each subsequent value overwrites the previous. Docker
+applies the last `key=value` you supply.
+
+Use the `--label-file` flag to load multiple labels from a file. Delimit each
+label in the file with an EOL mark. The example below loads labels from a
+labels file in the current directory;
 
     $ sudo docker run --label-file ./labels ubuntu bash
 
-The format of the labels-file is similar to that used for loading environment
-variables (see `--label-file` above). An example of a file passed with `--label-file`;
+The label-file format is similar to the format for loading environment variables
+(see `--env-file` above). The following example illustrates a label-file format;
 
-    $ cat ./labels
     com.example.label1="a label"
 
     # this is a comment
     com.example.label2=another\ label
     com.example.label3
 
-Multiple label-files can be loaded by providing the `--label-file` multiple 
+You can load multiple label-files by supplying the `--label-file` flag multiple
 times.
 
-For additional information on working with labels, see 
-[*Labels - custom meta-data in Docker*](/userguide/labels-custom-metadata/) in
-the user guide.
+For additional information on working with labels, see
+[*Labels - custom metadata in Docker*](/userguide/labels-custom-metadata/) in
+the Docker User Guide.
 
     $ sudo docker run --link /redis:redis --name console ubuntu bash
 

--- a/docs/sources/userguide/labels-custom-metadata.md
+++ b/docs/sources/userguide/labels-custom-metadata.md
@@ -1,0 +1,194 @@
+page_title: Labels - custom meta-data in Docker
+page_description: Learn how to work with custom meta-data in Docker, using labels.
+page_keywords: Usage, user guide, labels, meta-data, docker, documentation, examples, annotating
+
+## Labels - custom meta-data in Docker
+
+Docker enables you to add meta-data to your images, containers, and daemons via
+labels. Meta-data can serve a wide range of uses ranging from adding notes or 
+licensing information to an image to identifying a host.
+
+Labels in Docker are implemented as `<key>` / `<value>` pairs and values are
+stored as *strings*.
+
+>**note:** Support for daemon-labels was added in docker 1.4.1, labels on
+>containers and images in docker 1.6.0
+
+### Naming your labels - namespaces
+
+Docker puts no hard restrictions on the names you pick for your labels, however,
+it's easy for labels to "conflict".
+
+For example, you're building a tool that categorizes your images in 
+architectures, doing so by using an "architecture" label;
+
+    LABEL architecture="amd64"
+
+    LABEL architecture="ARMv7"
+
+But a user decided to label images by Architectural style
+
+    LABEL architecture="Art Nouveau"
+
+To prevent such conflicts, Docker uses the convention to namespace label-names,
+using a reverse domain notation;
+
+
+- All (third-party) tools should namespace (prefix) their labels with the 
+  reverse DNS notation of a domain controlled by the author of the tool. For 
+  example, "com.example.some-label".
+- Namespaced labels should only consist of lower-cased alphanumeric characters,
+  dots and dashes (in short, `[a-z0-9-.]`), should start *and* end with an alpha
+  numeric character, and may not contain consecutive dots or dashes.
+- The `com.docker.*`, `io.docker.*` and `com.dockerproject.*` namespaces are
+  reserved for Docker's internal use.
+- Labels *without* namespace (dots) are reserved for CLI use. This allows end-
+  users to add meta-data to their containers and images, without having to type 
+  cumbersome namespaces on the command-line.
+
+
+> **Note:** Even though Docker does not *enforce* you to use namespaces,
+> preventing to do so will likely result in conflicting usage of labels. 
+> If you're building a tool that uses labels, you *should* use namespaces
+> for your labels.
+
+
+### Storing structured data in labels
+
+Labels can store any type of data, as long as its stored as a string. 
+
+
+    {
+        "Description": "A containerized foobar",
+        "Usage": "docker run --rm example/foobar [args]",
+        "License": "GPL",
+        "Version": "0.0.1-beta",
+        "aBoolean": true,
+        "aNumber" : 0.01234,
+        "aNestedArray": ["a", "b", "c"]
+    }
+
+Which can be stored in a label by serializing it to a string first;
+
+    LABEL com.example.image-specs="{\"Description\":\"A containerized foobar\",\"Usage\":\"docker run --rm example\\/foobar [args]\",\"License\":\"GPL\",\"Version\":\"0.0.1-beta\",\"aBoolean\":true,\"aNumber\":0.01234,\"aNestedArray\":[\"a\",\"b\",\"c\"]}"
+
+
+> **Note:** Although the example above shows it's *possible* to store structured 
+> data in labels, Docker does not treat this data any other way than a 'regular'
+> string. This means that Docker doesn't offer ways to query (filter) based on 
+> nested properties. If your tool needs to filter on nested properties, the 
+> tool itself should implement this.
+
+
+### Adding labels to images; the `LABEL` instruction
+
+Adding labels to your 
+
+
+    LABEL [<namespace>.]<name>[=<value>] ...
+
+The `LABEL` instruction adds a label to your image, optionally setting its value.
+Quotes surrounding name and value are optional, but required if they contain
+white space characters. Alternatively, backslashes can be used.
+
+Label values only support strings
+
+
+    LABEL vendor=ACME\ Incorporated
+    LABEL com.example.version.is-beta
+    LABEL com.example.version="0.0.1-beta"
+    LABEL com.example.release-date="2015-02-12"
+
+The `LABEL` instruction supports setting multiple labels in a single instruction
+using this notation;
+
+    LABEL com.example.version="0.0.1-beta" com.example.release-date="2015-02-12"
+
+Wrapping is allowed by using a backslash (`\`) as continuation marker;
+
+    LABEL vendor=ACME\ Incorporated \
+          com.example.is-beta \
+          com.example.version="0.0.1-beta" \
+          com.example.release-date="2015-02-12"
+
+
+You can view the labels via `docker inspect`
+
+    $ docker inspect 4fa6e0f0c678
+
+    ...
+    "Labels": {
+        "vendor": "ACME Incorporated",
+        "com.example.is-beta": "",
+        "com.example.version": "0.0.1-beta",
+        "com.example.release-date": "2015-02-12"
+    }
+    ...
+
+    $ docker inspect -f "{{json .Labels }}" 4fa6e0f0c678
+
+    {"Vendor":"ACME Incorporated","com.example.is-beta":"","com.example.version":"0.0.1-beta","com.example.release-date":"2015-02-12"}
+
+> **note:** We recommend combining labels in a single `LABEl` instruction in
+> stead of using a `LABEL` instruction for each label. Each instruction in a
+> Dockerfile produces a new layer, which can result in an inefficient image if
+> many labels are used.
+
+### Querying labels
+
+Besides storing meta-data, labels can be used to filter your images and 
+containers.
+
+List all running containers that have a `com.example.is-beta` label;
+
+    # List all running containers that have a `com.example.is-beta` label
+    $ docker ps --filter "label=com.example.is-beta"
+
+
+List all running containers with a "color" label set to "blue";
+
+    $ docker ps --filter "label=color=blue"
+
+List all images with "vendor" "ACME"
+
+    $ docker images --filter "label=vendor=ACME"
+
+
+### Daemon labels
+
+
+
+    docker -d \
+      --dns 8.8.8.8 \
+      --dns 8.8.4.4 \
+      -H unix:///var/run/docker.sock \
+      --label com.example.environment="production" \
+      --label com.example.storage="ssd"
+
+And can be seen as part of the `docker info` output for the daemon;
+
+    docker -D info
+    Containers: 12
+    Images: 672
+    Storage Driver: aufs
+     Root Dir: /var/lib/docker/aufs
+     Backing Filesystem: extfs
+     Dirs: 697
+    Execution Driver: native-0.2
+    Kernel Version: 3.13.0-32-generic
+    Operating System: Ubuntu 14.04.1 LTS
+    CPUs: 1
+    Total Memory: 994.1 MiB
+    Name: docker.example.com
+    ID: RC3P:JTCT:32YS:XYSB:YUBG:VFED:AAJZ:W3YW:76XO:D7NN:TEVU:UCRW
+    Debug mode (server): false
+    Debug mode (client): true
+    Fds: 11
+    Goroutines: 14
+    EventsListeners: 0
+    Init Path: /usr/bin/docker
+    Docker Root Dir: /var/lib/docker
+    WARNING: No swap limit support
+    Labels:
+     com.example.environment=production
+     com.example.storage=ssd

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4541,6 +4541,28 @@ func TestBuildWithTabs(t *testing.T) {
 	logDone("build - with tabs")
 }
 
+func TestBuildLabels(t *testing.T) {
+	name := "testbuildlabel"
+	expected := `{"License":"GPL","Vendor":"Acme"}`
+	defer deleteImages(name)
+	_, err := buildImage(name,
+		`FROM busybox
+		LABEL Vendor=Acme
+                LABEL License GPL`,
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := inspectFieldJSON(name, "Config.Labels")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != expected {
+		t.Fatalf("Labels %s, expected %s", res, expected)
+	}
+	logDone("build - label")
+}
+
 func TestBuildStderr(t *testing.T) {
 	// This test just makes sure that no non-error output goes
 	// to stderr

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -414,7 +414,7 @@ func TestPsListContainersFilterName(t *testing.T) {
 
 func TestPsListContainersFilterLabel(t *testing.T) {
 	// start container
-	runCmd := exec.Command(dockerBinary, "run", "-d", "-l", "match=me", "busybox")
+	runCmd := exec.Command(dockerBinary, "run", "-d", "-l", "match=me", "-l", "second=tag", "busybox")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		t.Fatal(out, err)
@@ -443,6 +443,26 @@ func TestPsListContainersFilterLabel(t *testing.T) {
 	containerOut := strings.TrimSpace(out)
 	if containerOut != firstID {
 		t.Fatalf("Expected id %s, got %s for exited filter, output: %q", firstID, containerOut, out)
+	}
+
+	// filter containers by two labels
+	runCmd = exec.Command(dockerBinary, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me", "--filter=label=second=tag")
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
+	containerOut = strings.TrimSpace(out)
+	if containerOut != firstID {
+		t.Fatalf("Expected id %s, got %s for exited filter, output: %q", firstID, containerOut, out)
+	}
+
+	// filter containers by two labels, but expect not found because of AND behavior
+	runCmd = exec.Command(dockerBinary, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me", "--filter=label=second=tag-no")
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
+	containerOut = strings.TrimSpace(out)
+	if containerOut != "" {
+		t.Fatalf("Expected nothing, got %s for exited filter, output: %q", containerOut, out)
 	}
 
 	// filter containers by exact key

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -412,6 +412,54 @@ func TestPsListContainersFilterName(t *testing.T) {
 	logDone("ps - test ps filter name")
 }
 
+func TestPsListContainersFilterLabel(t *testing.T) {
+	// start container
+	runCmd := exec.Command(dockerBinary, "run", "-d", "-l", "match=me", "busybox")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatal(out, err)
+	}
+	firstID := stripTrailingCharacters(out)
+
+	// start another container
+	runCmd = exec.Command(dockerBinary, "run", "-d", "-l", "match=me too", "busybox")
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
+	secondID := stripTrailingCharacters(out)
+
+	// start third container
+	runCmd = exec.Command(dockerBinary, "run", "-d", "-l", "nomatch=me", "busybox")
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
+	thirdID := stripTrailingCharacters(out)
+
+	// filter containers by exact match
+	runCmd = exec.Command(dockerBinary, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me")
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
+	containerOut := strings.TrimSpace(out)
+	if containerOut != firstID {
+		t.Fatalf("Expected id %s, got %s for exited filter, output: %q", firstID, containerOut, out)
+	}
+
+	// filter containers by exact key
+	runCmd = exec.Command(dockerBinary, "ps", "-a", "-q", "--no-trunc", "--filter=label=match")
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
+	containerOut = strings.TrimSpace(out)
+	if (!strings.Contains(containerOut, firstID) || !strings.Contains(containerOut, secondID)) || strings.Contains(containerOut, thirdID) {
+		t.Fatalf("Expected ids %s,%s, got %s for exited filter, output: %q", firstID, secondID, containerOut, out)
+	}
+
+	deleteAllContainers()
+
+	logDone("ps - test ps filter label")
+}
+
 func TestPsListContainersFilterExited(t *testing.T) {
 	defer deleteAllContainers()
 

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -724,6 +724,15 @@ COPY . /static`); err != nil {
 		ctx:       ctx}, nil
 }
 
+func inspectFieldAndMarshall(name, field string, output interface{}) error {
+	str, err := inspectFieldJSON(name, field)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal([]byte(str), output)
+}
+
 func inspectFilter(name, filter string) (string, error) {
 	format := fmt.Sprintf("{{%s}}", filter)
 	inspectCmd := exec.Command(dockerBinary, "inspect", "-f", format, name)

--- a/pkg/parsers/filters/parse.go
+++ b/pkg/parsers/filters/parse.go
@@ -65,6 +65,38 @@ func FromParam(p string) (Args, error) {
 	return args, nil
 }
 
+func (filters Args) MatchKVList(field string, sources map[string]string) bool {
+	fieldValues := filters[field]
+
+	//do not filter if there is no filter set or cannot determine filter
+	if len(fieldValues) == 0 {
+		return true
+	}
+
+	if sources == nil || len(sources) == 0 {
+		return false
+	}
+
+outer:
+	for _, name2match := range fieldValues {
+		testKV := strings.SplitN(name2match, "=", 2)
+
+		for k, v := range sources {
+			if len(testKV) == 1 {
+				if k == testKV[0] {
+					continue outer
+				}
+			} else if k == testKV[0] && v == testKV[1] {
+				continue outer
+			}
+		}
+
+		return false
+	}
+
+	return true
+}
+
 func (filters Args) Match(field, source string) bool {
 	fieldValues := filters[field]
 

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -33,6 +33,8 @@ type Config struct {
 	NetworkDisabled bool
 	MacAddress      string
 	OnBuild         []string
+	SecurityOpt     []string
+	Labels          map[string]string
 }
 
 func ContainerConfigFromJob(job *engine.Job) *Config {
@@ -66,6 +68,9 @@ func ContainerConfigFromJob(job *engine.Job) *Config {
 	if Cmd := job.GetenvList("Cmd"); Cmd != nil {
 		config.Cmd = Cmd
 	}
+
+	job.GetenvJson("Labels", &config.Labels)
+
 	if Entrypoint := job.GetenvList("Entrypoint"); Entrypoint != nil {
 		config.Entrypoint = Entrypoint
 	}

--- a/runconfig/merge.go
+++ b/runconfig/merge.go
@@ -84,6 +84,16 @@ func Merge(userConf, imageConf *Config) error {
 		}
 	}
 
+	if userConf.Labels == nil {
+		userConf.Labels = map[string]string{}
+	}
+	if imageConf.Labels != nil {
+		for l := range userConf.Labels {
+			imageConf.Labels[l] = userConf.Labels[l]
+		}
+		userConf.Labels = imageConf.Labels
+	}
+
 	if len(userConf.Entrypoint) == 0 {
 		if len(userConf.Cmd) == 0 {
 			userConf.Cmd = imageConf.Cmd

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -31,6 +31,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flVolumes = opts.NewListOpts(opts.ValidatePath)
 		flLinks   = opts.NewListOpts(opts.ValidateLink)
 		flEnv     = opts.NewListOpts(opts.ValidateEnv)
+		flLabels  = opts.NewListOpts(opts.ValidateEnv)
 		flDevices = opts.NewListOpts(opts.ValidatePath)
 
 		ulimits   = make(map[string]*ulimit.Ulimit)
@@ -47,6 +48,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flCapAdd      = opts.NewListOpts(nil)
 		flCapDrop     = opts.NewListOpts(nil)
 		flSecurityOpt = opts.NewListOpts(nil)
+		flLabelsFile  = opts.NewListOpts(nil)
 
 		flNetwork         = cmd.Bool([]string{"#n", "#-networking"}, true, "Enable networking for this container")
 		flPrivileged      = cmd.Bool([]string{"#privileged", "-privileged"}, false, "Give extended privileges to this container")
@@ -74,6 +76,8 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 	cmd.Var(&flVolumes, []string{"v", "-volume"}, "Bind mount a volume")
 	cmd.Var(&flLinks, []string{"#link", "-link"}, "Add link to another container")
 	cmd.Var(&flDevices, []string{"-device"}, "Add a host device to the container")
+	cmd.Var(&flLabels, []string{"l", "-label"}, "Set meta data on a container, for example com.example.key=value")
+	cmd.Var(&flLabelsFile, []string{"-label-file"}, "Read in a line delimited file of labels")
 	cmd.Var(&flEnv, []string{"e", "-env"}, "Set environment variables")
 	cmd.Var(&flEnvFile, []string{"-env-file"}, "Read in a file of environment variables")
 	cmd.Var(&flPublish, []string{"p", "-publish"}, "Publish a container's port(s) to the host")
@@ -243,16 +247,16 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 	}
 
 	// collect all the environment variables for the container
-	envVariables := []string{}
-	for _, ef := range flEnvFile.GetAll() {
-		parsedVars, err := opts.ParseEnvFile(ef)
-		if err != nil {
-			return nil, nil, cmd, err
-		}
-		envVariables = append(envVariables, parsedVars...)
+	envVariables, err := readKVStrings(flEnvFile.GetAll(), flEnv.GetAll())
+	if err != nil {
+		return nil, nil, cmd, err
 	}
-	// parse the '-e' and '--env' after, to allow override
-	envVariables = append(envVariables, flEnv.GetAll()...)
+
+	// collect all the labels for the container
+	labels, err := readKVStrings(flLabelsFile.GetAll(), flLabels.GetAll())
+	if err != nil {
+		return nil, nil, cmd, err
+	}
 
 	ipcMode := IpcMode(*flIpcMode)
 	if !ipcMode.Valid() {
@@ -297,6 +301,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		MacAddress:      *flMacAddress,
 		Entrypoint:      entrypoint,
 		WorkingDir:      *flWorkingDir,
+		Labels:          convertKVStringsToMap(labels),
 	}
 
 	hostConfig := &HostConfig{
@@ -328,6 +333,37 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		config.StdinOnce = true
 	}
 	return config, hostConfig, cmd, nil
+}
+
+// reads a file of line terminated key=value pairs and override that with override parameter
+func readKVStrings(files []string, override []string) ([]string, error) {
+	envVariables := []string{}
+	for _, ef := range files {
+		parsedVars, err := opts.ParseEnvFile(ef)
+		if err != nil {
+			return nil, err
+		}
+		envVariables = append(envVariables, parsedVars...)
+	}
+	// parse the '-e' and '--env' after, to allow override
+	envVariables = append(envVariables, override...)
+
+	return envVariables, nil
+}
+
+// converts ["key=value"] to {"key":"value"}
+func convertKVStringsToMap(values []string) map[string]string {
+	result := make(map[string]string, len(values))
+	for _, value := range values {
+		kv := strings.SplitN(value, "=", 2)
+		if len(kv) == 1 {
+			result[kv[0]] = ""
+		} else {
+			result[kv[0]] = kv[1]
+		}
+	}
+
+	return result
 }
 
 // parseRestartPolicy returns the parsed policy or an error indicating what is incorrect

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -76,7 +76,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 	cmd.Var(&flVolumes, []string{"v", "-volume"}, "Bind mount a volume")
 	cmd.Var(&flLinks, []string{"#link", "-link"}, "Add link to another container")
 	cmd.Var(&flDevices, []string{"-device"}, "Add a host device to the container")
-	cmd.Var(&flLabels, []string{"l", "-label"}, "Set meta data on a container, for example com.example.key=value")
+	cmd.Var(&flLabels, []string{"l", "-label"}, "Set meta data on a container")
 	cmd.Var(&flLabelsFile, []string{"-label-file"}, "Read in a line delimited file of labels")
 	cmd.Var(&flEnv, []string{"e", "-env"}, "Set environment variables")
 	cmd.Var(&flEnvFile, []string{"-env-file"}, "Read in a file of environment variables")


### PR DESCRIPTION
This is yet another meta data PR in an attempt to [pull together](http://xkcd.com/927/) multiple PRs hopefully into something we can get into Docker 1.5 (seriously, let's move fast).
## Background

Some background... (from what I can gather).  There is currently https://github.com/docker/docker/pull/8955 for adding UserData to a Dockerfile.  Basically it adds the `USERDATA key=value key="long value"` syntax to the Docker.  Then there is https://github.com/docker/docker/pull/9013 which looks to add structured JSON data to a Dockerfile and a container in much the same fashion as Kubernete's annotations.  Finally there is https://github.com/docker/docker/pull/9854 which discusses the need for meta data on container to help with Swarm and similar clustering systems.  There are probably another 10 threads that @thaJeztah can find that also talk about the need to add meta data to containers.
## We need this...

We need meta data, it's clear user want it.
## Labels

We already have labels on Hosts (Docker daemon) today.  It seems that going forward we should be able to add labels to everything: Hosts, containers, volumes, images, etc.  Let's just continue with that approach.  Labels are simple key/value pairs in the style of `map[string]string`.  There have been comments to standarize the format of the keys such that we have namespaces or other means to prevent conflicts.  Honestly I don't think that is all that necesary at the Docker level to dictate this.  It's just good practice to namespace things.  Whether you do "foo_bar" or "foo/bar" or "com.foo/bar", who really cares.  If your going to use "id=3", well that's a bad name and somebody may clobber your value.  I'm assuming some will disagree with me on this one.  That's fine, I'll agree to a namespace standard just as long as it doesn't take three weeks and 132 comments to decide that DNS format is far superior to arbitrary strings split by "/".

Labels are not structured data, and as such this PR is different from https://github.com/docker/docker/pull/9013, so that discussion can happen differently.  Honestly, I'm not in favor of adding structured data to objects and having Docker maintain it.  But if others disagree, so be it, we can have structured data as something else.
## What about ENV vars

Yes, labels are very close to environment variables.  You can add ENV to a Dockerfile and you can add them at container create.  The basic difference here is that these key/values are not visible to the running processes in the container.
## Lookup by Label

Another key attribute of labels is that you should be able to find an object based on it's label.  This should initially be kept very simple.  You can either say "give me all images/containers that have key foo."  Or you can say "give me all images/containers that have foo=bar".
## How should we go about doing this?

I think https://github.com/docker/docker/pull/8955 is the right start.  `USERDATA` should be renamed to `LABEL`.  Now that we have `LABEL` on images we need to add `--label key=value` to `docker run/create`.  This is in the same fashion as `ENV` and `-e` today.

Now the only thing left do to is to figure out how to query based on labels.  We just need to add `--label foo` or `--label foo=bar` to `docker images/ps`.
## It's just that simple folks

Okay, good?  Alright, let's move forward...
