### PR TITLE
doc: Standardise JSON examples

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.0.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.0.md
@@ -218,16 +218,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -400,7 +400,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -625,14 +625,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -906,7 +906,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 OK
         Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.1.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.1.md
@@ -218,16 +218,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -400,7 +400,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -632,14 +632,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -919,7 +919,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 OK
         Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.10.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.10.md
@@ -39,9 +39,9 @@ List containers
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "9cd87474be90",
@@ -49,9 +49,9 @@ List containers
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "3176a2479c92",
@@ -69,9 +69,9 @@ List containers
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              }
         ]
 
@@ -257,7 +257,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -270,7 +270,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -305,16 +305,16 @@ Inspect changes on container `id` 's filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -555,7 +555,7 @@ Block until container `id` stops, then returns
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -602,7 +602,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -674,9 +674,9 @@ Create an image, either by pull it from the registry or by importing
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pulling..."}
-        {"status":"Pulling", "progress":"1 B/ 100 B", "progressDetail":{"current":1, "total":100}}
-        {"error":"Invalid..."}
+        {"status": "Pulling..."}
+        {"status": "Pulling", "progress": "1 B/ 100 B", "progressDetail": {"current": 1, "total": 100}}
+        {"error": "Invalid..."}
         ...
 
     When using this endpoint to pull an image from the registry, the
@@ -796,14 +796,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -828,9 +828,9 @@ Push the image `name` on the registry
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pushing..."}
-        {"status":"Pushing", "progress":"1/? (n/a)", "progressDetail":{"current":1}}}
-        {"error":"Invalid..."}
+        {"status": "Pushing..."}
+        {"status": "Pushing", "progress": "1/? (n/a)", "progressDetail": {"current": 1}}}
+        {"error": "Invalid..."}
         ...
 
     If you wish to push an image on to a private registry, that image must already have been tagged
@@ -899,9 +899,9 @@ Status Codes:
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Query Parameters:
@@ -988,9 +988,9 @@ Build an image from Dockerfile via stdin
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"stream":"Step 1..."}
-        {"stream":"..."}
-        {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
+        {"stream": "Step 1..."}
+        {"stream": "..."}
+        {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 
     The stream must be a tar archive compressed with one of the
     following algorithms: identity (no compression), gzip, bzip2, xz.
@@ -1030,10 +1030,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1146,7 +1146,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 OK
             Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 
 Json Parameters:
@@ -1194,10 +1194,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
 
 Query Parameters:
 
@@ -1273,7 +1273,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 
 ```
 {"hello-world":
-    {"latest":"565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
+    {"latest": "565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
 }
 ```
 

--- a/docs/sources/reference/api/docker_remote_api_v1.11.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.11.md
@@ -39,9 +39,9 @@ List containers
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "9cd87474be90",
@@ -49,9 +49,9 @@ List containers
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "3176a2479c92",
@@ -69,9 +69,9 @@ List containers
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              }
         ]
 
@@ -198,8 +198,7 @@ Return low-level information on the container `id`
                              "Image": "base",
                              "Volumes": {},
                              "VolumesFrom": "",
-                             "WorkingDir":""
-
+                             "WorkingDir": ""
                      },
                      "State": {
                              "Running": false,
@@ -259,7 +258,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -272,7 +271,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -341,16 +340,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -590,7 +589,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -638,7 +637,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -709,9 +708,9 @@ Create an image, either by pull it from the registry or by importing i
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pulling..."}
-        {"status":"Pulling", "progress":"1 B/ 100 B", "progressDetail":{"current":1, "total":100}}
-        {"error":"Invalid..."}
+        {"status": "Pulling..."}
+        {"status": "Pulling", "progress": "1 B/ 100 B", "progressDetail": {"current": 1, "total": 100}}
+        {"error": "Invalid..."}
         ...
 
     When using this endpoint to pull an image from the registry, the
@@ -802,14 +801,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -834,9 +833,9 @@ Push the image `name` on the registry
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pushing..."}
-        {"status":"Pushing", "progress":"1/? (n/a)", "progressDetail":{"current":1}}}
-        {"error":"Invalid..."}
+        {"status": "Pushing..."}
+        {"status": "Pushing", "progress": "1/? (n/a)", "progressDetail": {"current": 1}}}
+        {"error": "Invalid..."}
         ...
 
     If you wish to push an image on to a private registry, that image must already have been tagged
@@ -906,9 +905,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Query Parameters:
@@ -995,9 +994,9 @@ Build an image from Dockerfile via stdin
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"stream":"Step 1..."}
-        {"stream":"..."}
-        {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
+        {"stream": "Step 1..."}
+        {"stream": "..."}
+        {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 
     The stream must be a tar archive compressed with one of the
     following algorithms: identity (no compression), gzip, bzip2, xz.
@@ -1037,10 +1036,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1069,20 +1068,20 @@ Display system-wide information
         Content-Type: application/json
 
         {
-             "Containers":11,
-             "Images":16,
-             "Driver":"btrfs",
-             "ExecutionDriver":"native-0.1",
-             "KernelVersion":"3.12.0-1-amd64"
-             "Debug":false,
+             "Containers": 11,
+             "Images": 16,
+             "Driver": "btrfs",
+             "ExecutionDriver": "native-0.1",
+             "KernelVersion": "3.12.0-1-amd64"
+             "Debug": false,
              "NFd": 11,
-             "NGoroutines":21,
-             "NEventsListener":0,
-             "InitPath":"/usr/bin/docker",
-             "IndexServerAddress":["https://index.docker.io/v1/"],
-             "MemoryLimit":true,
-             "SwapLimit":false,
-             "IPv4Forwarding":true
+             "NGoroutines": 21,
+             "NEventsListener": 0,
+             "InitPath": "/usr/bin/docker",
+             "IndexServerAddress": ["https://index.docker.io/v1/"],
+             "MemoryLimit": true,
+             "SwapLimit": false,
+             "IPv4Forwarding": true
         }
 
 Status Codes:
@@ -1180,7 +1179,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 Created
         Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Json Parameters:
 
@@ -1225,10 +1224,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
 
 Query Parameters:
 
@@ -1305,7 +1304,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 
 ```
 {"hello-world":
-    {"latest":"565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
+    {"latest": "565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
 }
 ```
 

--- a/docs/sources/reference/api/docker_remote_api_v1.12.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.12.md
@@ -40,9 +40,9 @@ List containers
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "9cd87474be90",
@@ -50,9 +50,9 @@ List containers
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "3176a2479c92",
@@ -70,9 +70,9 @@ List containers
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              }
         ]
 
@@ -207,8 +207,7 @@ Return low-level information on the container `id`
                              "Image": "base",
                              "Volumes": {},
                              "VolumesFrom": "",
-                             "WorkingDir":""
-
+                             "WorkingDir": ""
                      },
                      "State": {
                              "Running": false,
@@ -268,7 +267,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -281,7 +280,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -350,16 +349,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -638,7 +637,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -686,7 +685,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -768,9 +767,9 @@ Create an image, either by pull it from the registry or by importing i
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pulling..."}
-        {"status":"Pulling", "progress":"1 B/ 100 B", "progressDetail":{"current":1, "total":100}}
-        {"error":"Invalid..."}
+        {"status": "Pulling..."}
+        {"status": "Pulling", "progress": "1 B/ 100 B", "progressDetail": {"current": 1, "total": 100}}
+        {"error": "Invalid..."}
         ...
 
     When using this endpoint to pull an image from the registry, the
@@ -812,31 +811,31 @@ Return low-level information on the image `name`
         Content-Type: application/json
 
         {
-             "Created":"2013-03-23T22:24:18.818426-07:00",
-             "Container":"3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
+             "Created": "2013-03-23T22:24:18.818426-07:00",
+             "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
              "ContainerConfig":
                      {
-                             "Hostname":"",
-                             "User":"",
-                             "Memory":0,
-                             "MemorySwap":0,
-                             "AttachStdin":false,
-                             "AttachStdout":false,
-                             "AttachStderr":false,
-                             "PortSpecs":null,
-                             "Tty":true,
-                             "OpenStdin":true,
-                             "StdinOnce":false,
-                             "Env":null,
+                             "Hostname": "",
+                             "User": "",
+                             "Memory": 0,
+                             "MemorySwap": 0,
+                             "AttachStdin": false,
+                             "AttachStdout": false,
+                             "AttachStderr": false,
+                             "PortSpecs": null,
+                             "Tty": true,
+                             "OpenStdin": true,
+                             "StdinOnce": false,
+                             "Env": null,
                              "Cmd": ["/bin/bash"],
-                             "Dns":null,
-                             "Image":"base",
-                             "Volumes":null,
-                             "VolumesFrom":"",
-                             "WorkingDir":""
+                             "Dns": null,
+                             "Image": "base",
+                             "Volumes": null,
+                             "VolumesFrom": "",
+                             "WorkingDir": ""
                      },
-             "Id":"b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
-             "Parent":"27cf784147099545",
+             "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+             "Parent": "27cf784147099545",
              "Size": 6824592
         }
 
@@ -863,14 +862,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -895,9 +894,9 @@ Push the image `name` on the registry
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pushing..."}
-        {"status":"Pushing", "progress":"1/? (n/a)", "progressDetail":{"current":1}}}
-        {"error":"Invalid..."}
+        {"status": "Pushing..."}
+        {"status": "Pushing", "progress": "1/? (n/a)", "progressDetail": {"current": 1}}}
+        {"error": "Invalid..."}
         ...
 
     If you wish to push an image on to a private registry, that image must already have been tagged
@@ -967,9 +966,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Query Parameters:
@@ -1056,9 +1055,9 @@ Build an image from Dockerfile via stdin
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"stream":"Step 1..."}
-        {"stream":"..."}
-        {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
+        {"stream": "Step 1..."}
+        {"stream": "..."}
+        {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 
     The stream must be a tar archive compressed with one of the
     following algorithms: identity (no compression), gzip, bzip2, xz.
@@ -1099,10 +1098,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1131,20 +1130,20 @@ Display system-wide information
         Content-Type: application/json
 
         {
-             "Containers":11,
-             "Images":16,
-             "Driver":"btrfs",
-             "ExecutionDriver":"native-0.1",
-             "KernelVersion":"3.12.0-1-amd64"
-             "Debug":false,
+             "Containers": 11,
+             "Images": 16,
+             "Driver": "btrfs",
+             "ExecutionDriver": "native-0.1",
+             "KernelVersion": "3.12.0-1-amd64"
+             "Debug": false,
              "NFd": 11,
-             "NGoroutines":21,
-             "NEventsListener":0,
-             "InitPath":"/usr/bin/docker",
-             "IndexServerAddress":["https://index.docker.io/v1/"],
-             "MemoryLimit":true,
-             "SwapLimit":false,
-             "IPv4Forwarding":true
+             "NGoroutines": 21,
+             "NEventsListener": 0,
+             "InitPath": "/usr/bin/docker",
+             "IndexServerAddress": ["https://index.docker.io/v1/"],
+             "MemoryLimit": true,
+             "SwapLimit": false,
+             "IPv4Forwarding": true
         }
 
 Status Codes:
@@ -1168,10 +1167,10 @@ Show the docker version information
         Content-Type: application/json
 
         {
-             "ApiVersion":"1.12",
-             "Version":"0.2.2",
-             "GitCommit":"5a2a5cc+CHANGES",
-             "GoVersion":"go1.0.3"
+             "ApiVersion": "1.12",
+             "Version": "0.2.2",
+             "GitCommit": "5a2a5cc+CHANGES",
+             "GoVersion": "go1.0.3"
         }
 
 Status Codes:
@@ -1213,30 +1212,30 @@ Create a new image from a container's changes
         Content-Type: application/json
 
         {
-             "Hostname":"",
+             "Hostname": "",
              "Domainname": "",
-             "User":"",
-             "Memory":0,
-             "MemorySwap":0,
+             "User": "",
+             "Memory": 0,
+             "MemorySwap": 0,
              "CpuShares": 512,
              "Cpuset": "0,1",
-             "AttachStdin":false,
-             "AttachStdout":true,
-             "AttachStderr":true,
-             "PortSpecs":null,
-             "Tty":false,
-             "OpenStdin":false,
-             "StdinOnce":false,
-             "Env":null,
-             "Cmd":[
+             "AttachStdin": false,
+             "AttachStdout": true,
+             "AttachStderr": true,
+             "PortSpecs": null,
+             "Tty": false,
+             "OpenStdin": false,
+             "StdinOnce": false,
+             "Env": null,
+             "Cmd": [
                      "date"
              ],
-             "Volumes":{
+             "Volumes": {
                      "/tmp": {}
              },
-             "WorkingDir":"",
+             "WorkingDir": "",
              "NetworkDisabled": false,
-             "ExposedPorts":{
+             "ExposedPorts": {
                      "22/tcp": {}
              }
         }
@@ -1246,7 +1245,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 Created
         Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Json Parameters:
 
@@ -1291,10 +1290,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
 
 Query Parameters:
 
@@ -1370,7 +1369,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 
 ```
 {"hello-world":
-    {"latest":"565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
+    {"latest": "565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
 }
 ```
 

--- a/docs/sources/reference/api/docker_remote_api_v1.13.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.13.md
@@ -40,9 +40,9 @@ List containers
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "9cd87474be90",
@@ -50,9 +50,9 @@ List containers
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "3176a2479c92",
@@ -70,9 +70,9 @@ List containers
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              }
         ]
 
@@ -201,8 +201,7 @@ Return low-level information on the container `id`
                              "Image": "base",
                              "Volumes": {},
                              "VolumesFrom": "",
-                             "WorkingDir":""
-
+                             "WorkingDir": ""
                      },
                      "State": {
                              "Running": false,
@@ -262,7 +261,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -275,7 +274,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -341,16 +340,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -631,7 +630,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -679,7 +678,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -757,9 +756,9 @@ Create an image, either by pulling it from the registry or by importing it
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pulling..."}
-        {"status":"Pulling", "progress":"1 B/ 100 B", "progressDetail":{"current":1, "total":100}}
-        {"error":"Invalid..."}
+        {"status": "Pulling..."}
+        {"status": "Pulling", "progress": "1 B/ 100 B", "progressDetail": {"current": 1, "total": 100}}
+        {"error": "Invalid..."}
         ...
 
     When using this endpoint to pull an image from the registry, the
@@ -801,31 +800,31 @@ Return low-level information on the image `name`
         Content-Type: application/json
 
         {
-             "Created":"2013-03-23T22:24:18.818426-07:00",
-             "Container":"3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
+             "Created": "2013-03-23T22:24:18.818426-07:00",
+             "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
              "ContainerConfig":
                      {
-                             "Hostname":"",
-                             "User":"",
-                             "Memory":0,
-                             "MemorySwap":0,
-                             "AttachStdin":false,
-                             "AttachStdout":false,
-                             "AttachStderr":false,
-                             "PortSpecs":null,
-                             "Tty":true,
-                             "OpenStdin":true,
-                             "StdinOnce":false,
-                             "Env":null,
+                             "Hostname": "",
+                             "User": "",
+                             "Memory": 0,
+                             "MemorySwap": 0,
+                             "AttachStdin": false,
+                             "AttachStdout": false,
+                             "AttachStderr": false,
+                             "PortSpecs": null,
+                             "Tty": true,
+                             "OpenStdin": true,
+                             "StdinOnce": false,
+                             "Env": null,
                              "Cmd": ["/bin/bash"],
-                             "Dns":null,
-                             "Image":"base",
-                             "Volumes":null,
-                             "VolumesFrom":"",
-                             "WorkingDir":""
+                             "Dns": null,
+                             "Image": "base",
+                             "Volumes": null,
+                             "VolumesFrom": "",
+                             "WorkingDir": ""
                      },
-             "Id":"b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
-             "Parent":"27cf784147099545",
+             "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+             "Parent": "27cf784147099545",
              "Size": 6824592
         }
 
@@ -852,14 +851,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -884,9 +883,9 @@ Push the image `name` on the registry
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pushing..."}
-        {"status":"Pushing", "progress":"1/? (n/a)", "progressDetail":{"current":1}}}
-        {"error":"Invalid..."}
+        {"status": "Pushing..."}
+        {"status": "Pushing", "progress": "1/? (n/a)", "progressDetail": {"current": 1}}}
+        {"error": "Invalid..."}
         ...
 
     If you wish to push an image on to a private registry, that image must already have been tagged
@@ -956,9 +955,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Query Parameters:
@@ -1045,9 +1044,9 @@ Build an image from Dockerfile via stdin
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"stream":"Step 1..."}
-        {"stream":"..."}
-        {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
+        {"stream": "Step 1..."}
+        {"stream": "..."}
+        {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 
     The stream must be a tar archive compressed with one of the
     following algorithms: identity (no compression), gzip, bzip2, xz.
@@ -1088,10 +1087,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1120,20 +1119,20 @@ Display system-wide information
         Content-Type: application/json
 
         {
-             "Containers":11,
-             "Images":16,
-             "Driver":"btrfs",
-             "ExecutionDriver":"native-0.1",
-             "KernelVersion":"3.12.0-1-amd64"
-             "Debug":false,
+             "Containers": 11,
+             "Images": 16,
+             "Driver": "btrfs",
+             "ExecutionDriver": "native-0.1",
+             "KernelVersion": "3.12.0-1-amd64"
+             "Debug": false,
              "NFd": 11,
-             "NGoroutines":21,
-             "NEventsListener":0,
-             "InitPath":"/usr/bin/docker",
-             "IndexServerAddress":["https://index.docker.io/v1/"],
-             "MemoryLimit":true,
-             "SwapLimit":false,
-             "IPv4Forwarding":true
+             "NGoroutines": 21,
+             "NEventsListener": 0,
+             "InitPath": "/usr/bin/docker",
+             "IndexServerAddress": ["https://index.docker.io/v1/"],
+             "MemoryLimit": true,
+             "SwapLimit": false,
+             "IPv4Forwarding": true
         }
 
 Status Codes:
@@ -1157,10 +1156,10 @@ Show the docker version information
         Content-Type: application/json
 
         {
-             "ApiVersion":"1.12",
-             "Version":"0.2.2",
-             "GitCommit":"5a2a5cc+CHANGES",
-             "GoVersion":"go1.0.3"
+             "ApiVersion": "1.12",
+             "Version": "0.2.2",
+             "GitCommit": "5a2a5cc+CHANGES",
+             "GoVersion": "go1.0.3"
         }
 
 Status Codes:
@@ -1202,30 +1201,30 @@ Create a new image from a container's changes
         Content-Type: application/json
 
         {
-             "Hostname":"",
+             "Hostname": "",
              "Domainname": "",
-             "User":"",
-             "Memory":0,
-             "MemorySwap":0,
+             "User": "",
+             "Memory": 0,
+             "MemorySwap": 0,
              "CpuShares": 512,
              "Cpuset": "0,1",
-             "AttachStdin":false,
-             "AttachStdout":true,
-             "AttachStderr":true,
-             "PortSpecs":null,
-             "Tty":false,
-             "OpenStdin":false,
-             "StdinOnce":false,
-             "Env":null,
-             "Cmd":[
+             "AttachStdin": false,
+             "AttachStdout": true,
+             "AttachStderr": true,
+             "PortSpecs": null,
+             "Tty": false,
+             "OpenStdin": false,
+             "StdinOnce": false,
+             "Env": null,
+             "Cmd": [
                      "date"
              ],
-             "Volumes":{
+             "Volumes": {
                      "/tmp": {}
              },
-             "WorkingDir":"",
+             "WorkingDir": "",
              "NetworkDisabled": false,
-             "ExposedPorts":{
+             "ExposedPorts": {
                      "22/tcp": {}
              }
         }
@@ -1235,7 +1234,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 Created
         Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Json Parameters:
 
@@ -1280,10 +1279,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
 
 Query Parameters:
 
@@ -1360,7 +1359,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 
 ```
 {"hello-world":
-    {"latest":"565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
+    {"latest": "565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
 }
 ```
 

--- a/docs/sources/reference/api/docker_remote_api_v1.14.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.14.md
@@ -40,9 +40,9 @@ List containers
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "9cd87474be90",
@@ -50,9 +50,9 @@ List containers
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "3176a2479c92",
@@ -70,9 +70,9 @@ List containers
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              }
         ]
 
@@ -210,8 +210,7 @@ Return low-level information on the container `id`
                              "Image": "base",
                              "Volumes": {},
                              "VolumesFrom": "",
-                             "WorkingDir":""
-
+                             "WorkingDir": ""
                      },
                      "State": {
                              "Running": false,
@@ -246,8 +245,8 @@ Return low-level information on the container `id`
                          },
                          "Links": ["/name:alias"],
                          "PublishAllPorts": false,
-                         "CapAdd: ["NET_ADMIN"],
-                         "CapDrop: ["MKNOD"]
+                         "CapAdd": ["NET_ADMIN"],
+                         "CapDrop": ["MKNOD"]
                      }
         }
 
@@ -273,7 +272,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -286,7 +285,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -352,16 +351,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -641,7 +640,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -689,7 +688,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -767,9 +766,9 @@ Create an image, either by pulling it from the registry or by importing it
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pulling..."}
-        {"status":"Pulling", "progress":"1 B/ 100 B", "progressDetail":{"current":1, "total":100}}
-        {"error":"Invalid..."}
+        {"status": "Pulling..."}
+        {"status": "Pulling", "progress": "1 B/ 100 B", "progressDetail": {"current": 1, "total": 100}}
+        {"error": "Invalid..."}
         ...
 
     When using this endpoint to pull an image from the registry, the
@@ -811,31 +810,31 @@ Return low-level information on the image `name`
         Content-Type: application/json
 
         {
-             "Created":"2013-03-23T22:24:18.818426-07:00",
-             "Container":"3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
+             "Created": "2013-03-23T22:24:18.818426-07:00",
+             "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
              "ContainerConfig":
                      {
-                             "Hostname":"",
-                             "User":"",
-                             "Memory":0,
-                             "MemorySwap":0,
-                             "AttachStdin":false,
-                             "AttachStdout":false,
-                             "AttachStderr":false,
-                             "PortSpecs":null,
-                             "Tty":true,
-                             "OpenStdin":true,
-                             "StdinOnce":false,
-                             "Env":null,
+                             "Hostname": "",
+                             "User": "",
+                             "Memory": 0,
+                             "MemorySwap": 0,
+                             "AttachStdin": false,
+                             "AttachStdout": false,
+                             "AttachStderr": false,
+                             "PortSpecs": null,
+                             "Tty": true,
+                             "OpenStdin": true,
+                             "StdinOnce": false,
+                             "Env": null,
                              "Cmd": ["/bin/bash"],
-                             "Dns":null,
-                             "Image":"base",
-                             "Volumes":null,
-                             "VolumesFrom":"",
-                             "WorkingDir":""
+                             "Dns": null,
+                             "Image": "base",
+                             "Volumes": null,
+                             "VolumesFrom": "",
+                             "WorkingDir": ""
                      },
-             "Id":"b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
-             "Parent":"27cf784147099545",
+             "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+             "Parent": "27cf784147099545",
              "Size": 6824592
         }
 
@@ -862,14 +861,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -894,9 +893,9 @@ Push the image `name` on the registry
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pushing..."}
-        {"status":"Pushing", "progress":"1/? (n/a)", "progressDetail":{"current":1}}}
-        {"error":"Invalid..."}
+        {"status": "Pushing..."}
+        {"status": "Pushing", "progress": "1/? (n/a)", "progressDetail": {"current": 1}}}
+        {"error": "Invalid..."}
         ...
 
     If you wish to push an image on to a private registry, that image must already have been tagged
@@ -966,9 +965,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Query Parameters:
@@ -1055,9 +1054,9 @@ Build an image from Dockerfile via stdin
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"stream":"Step 1..."}
-        {"stream":"..."}
-        {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
+        {"stream": "Step 1..."}
+        {"stream": "..."}
+        {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 
     The stream must be a tar archive compressed with one of the
     following algorithms: identity (no compression), gzip, bzip2, xz.
@@ -1098,10 +1097,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1130,20 +1129,20 @@ Display system-wide information
         Content-Type: application/json
 
         {
-             "Containers":11,
-             "Images":16,
-             "Driver":"btrfs",
-             "ExecutionDriver":"native-0.1",
-             "KernelVersion":"3.12.0-1-amd64"
-             "Debug":false,
+             "Containers": 11,
+             "Images": 16,
+             "Driver": "btrfs",
+             "ExecutionDriver": "native-0.1",
+             "KernelVersion": "3.12.0-1-amd64"
+             "Debug": false,
              "NFd": 11,
-             "NGoroutines":21,
-             "NEventsListener":0,
-             "InitPath":"/usr/bin/docker",
-             "IndexServerAddress":["https://index.docker.io/v1/"],
-             "MemoryLimit":true,
-             "SwapLimit":false,
-             "IPv4Forwarding":true
+             "NGoroutines": 21,
+             "NEventsListener": 0,
+             "InitPath": "/usr/bin/docker",
+             "IndexServerAddress": ["https://index.docker.io/v1/"],
+             "MemoryLimit": true,
+             "SwapLimit": false,
+             "IPv4Forwarding": true
         }
 
 Status Codes:
@@ -1167,10 +1166,10 @@ Show the docker version information
         Content-Type: application/json
 
         {
-             "ApiVersion":"1.12",
-             "Version":"0.2.2",
-             "GitCommit":"5a2a5cc+CHANGES",
-             "GoVersion":"go1.0.3"
+             "ApiVersion": "1.12",
+             "Version": "0.2.2",
+             "GitCommit": "5a2a5cc+CHANGES",
+             "GoVersion": "go1.0.3"
         }
 
 Status Codes:
@@ -1212,30 +1211,30 @@ Create a new image from a container's changes
         Content-Type: application/json
 
         {
-             "Hostname":"",
+             "Hostname": "",
              "Domainname": "",
-             "User":"",
-             "Memory":0,
-             "MemorySwap":0,
+             "User": "",
+             "Memory": 0,
+             "MemorySwap": 0,
              "CpuShares": 512,
              "Cpuset": "0,1",
-             "AttachStdin":false,
-             "AttachStdout":true,
-             "AttachStderr":true,
-             "PortSpecs":null,
-             "Tty":false,
-             "OpenStdin":false,
-             "StdinOnce":false,
-             "Env":null,
-             "Cmd":[
+             "AttachStdin": false,
+             "AttachStdout": true,
+             "AttachStderr": true,
+             "PortSpecs": null,
+             "Tty": false,
+             "OpenStdin": false,
+             "StdinOnce": false,
+             "Env": null,
+             "Cmd": [
                      "date"
              ],
-             "Volumes":{
+             "Volumes": {
                      "/tmp": {}
              },
-             "WorkingDir":"",
+             "WorkingDir": "",
              "NetworkDisabled": false,
-             "ExposedPorts":{
+             "ExposedPorts": {
                      "22/tcp": {}
              }
         }
@@ -1245,7 +1244,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 Created
         Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Json Parameters:
 
@@ -1290,10 +1289,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
 
 Query Parameters:
 
@@ -1369,7 +1368,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 
 ```
 {"hello-world":
-    {"latest":"565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
+    {"latest": "565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
 }
 ```
 

--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -40,9 +40,9 @@ List containers
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "9cd87474be90",
@@ -50,9 +50,9 @@ List containers
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "3176a2479c92",
@@ -70,9 +70,9 @@ List containers
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              }
         ]
 
@@ -110,42 +110,42 @@ Create a container
         Content-Type: application/json
 
         {
-             "Hostname":"",
+             "Hostname": "",
              "Domainname": "",
-             "User":"",
-             "Memory":0,
-             "MemorySwap":0,
+             "User": "",
+             "Memory": 0,
+             "MemorySwap": 0,
              "CpuShares": 512,
              "Cpuset": "0,1",
-             "AttachStdin":false,
-             "AttachStdout":true,
-             "AttachStderr":true,
-             "Tty":false,
-             "OpenStdin":false,
-             "StdinOnce":false,
-             "Env":null,
-             "Cmd":[
+             "AttachStdin": false,
+             "AttachStdout": true,
+             "AttachStderr": true,
+             "Tty": false,
+             "OpenStdin": false,
+             "StdinOnce": false,
+             "Env": null,
+             "Cmd": [
                      "date"
              ],
              "Entrypoint": "",
-             "Image":"base",
-             "Volumes":{
+             "Image": "base",
+             "Volumes": {
                      "/tmp": {}
              },
-             "WorkingDir":"",
+             "WorkingDir": "",
              "NetworkDisabled": false,
-             "MacAddress":"12:34:56:78:9a:bc",
-             "ExposedPorts":{
+             "MacAddress": "12:34:56:78:9a:bc",
+             "ExposedPorts": {
                      "22/tcp": {}
              },
              "SecurityOpts": [""],
              "HostConfig": {
-               "Binds":["/tmp:/tmp"],
-               "Links":["redis3:redis"],
-               "LxcConf":{"lxc.utsname":"docker"},
-               "PortBindings":{ "22/tcp": [{ "HostPort": "11022" }] },
-               "PublishAllPorts":false,
-               "Privileged":false,
+               "Binds": ["/tmp:/tmp"],
+               "Links": ["redis3:redis"],
+               "LxcConf": {"lxc.utsname":"docker"},
+               "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
+               "PublishAllPorts": false,
+               "Privileged": false,
                "Dns": ["8.8.8.8"],
                "DnsSearch": [""],
                "VolumesFrom": ["parent", "other:ro"],
@@ -163,8 +163,8 @@ Create a container
         Content-Type: application/json
 
         {
-             "Id":"f91ddc4b01e079c4481a8340bbbeca4dbd33d6e4a10662e499f8eacbb5bf252b"
-             "Warnings":[]
+             "Id": "f91ddc4b01e079c4481a8340bbbeca4dbd33d6e4a10662e499f8eacbb5bf252b"
+             "Warnings": []
         }
 
 Json Parameters:
@@ -291,8 +291,7 @@ Return low-level information on the container `id`
                              "Image": "base",
                              "Volumes": {},
                              "VolumesFrom": "",
-                             "WorkingDir":""
-
+                             "WorkingDir": ""
                      },
                      "State": {
                              "Running": false,
@@ -327,8 +326,8 @@ Return low-level information on the container `id`
                          },
                          "Links": ["/name:alias"],
                          "PublishAllPorts": false,
-                         "CapAdd: ["NET_ADMIN"],
-                         "CapDrop: ["MKNOD"]
+                         "CapAdd": ["NET_ADMIN"],
+                         "CapDrop": ["MKNOD"]
                      }
         }
 
@@ -354,7 +353,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -367,7 +366,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -432,16 +431,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -508,12 +507,12 @@ Start the container `id`
         Content-Type: application/json
 
         {
-             "Binds":["/tmp:/tmp"],
-             "Links":["redis3:redis"],
-             "LxcConf":{"lxc.utsname":"docker"},
-             "PortBindings":{ "22/tcp": [{ "HostPort": "11022" }] },
-             "PublishAllPorts":false,
-             "Privileged":false,
+             "Binds": ["/tmp:/tmp"],
+             "Links": ["redis3:redis"],
+             "LxcConf": {"lxc.utsname":"docker"},
+             "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
+             "PublishAllPorts": false,
+             "Privileged": false,
              "Dns": ["8.8.8.8"],
              "DnsSearch": [""],
              "VolumesFrom": ["parent", "other:ro"],
@@ -783,7 +782,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -831,7 +830,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -909,9 +908,9 @@ Create an image, either by pulling it from the registry or by importing it
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pulling..."}
-        {"status":"Pulling", "progress":"1 B/ 100 B", "progressDetail":{"current":1, "total":100}}
-        {"error":"Invalid..."}
+        {"status": "Pulling..."}
+        {"status": "Pulling", "progress": "1 B/ 100 B", "progressDetail": {"current": 1, "total": 100}}
+        {"error": "Invalid..."}
         ...
 
     When using this endpoint to pull an image from the registry, the
@@ -954,31 +953,31 @@ Return low-level information on the image `name`
         Content-Type: application/json
 
         {
-             "Created":"2013-03-23T22:24:18.818426-07:00",
-             "Container":"3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
+             "Created": "2013-03-23T22:24:18.818426-07:00",
+             "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
              "ContainerConfig":
                      {
-                             "Hostname":"",
-                             "User":"",
-                             "Memory":0,
-                             "MemorySwap":0,
-                             "AttachStdin":false,
-                             "AttachStdout":false,
-                             "AttachStderr":false,
-                             "PortSpecs":null,
-                             "Tty":true,
-                             "OpenStdin":true,
-                             "StdinOnce":false,
-                             "Env":null,
+                             "Hostname": "",
+                             "User": "",
+                             "Memory": 0,
+                             "MemorySwap": 0,
+                             "AttachStdin": false,
+                             "AttachStdout": false,
+                             "AttachStderr": false,
+                             "PortSpecs": null,
+                             "Tty": true,
+                             "OpenStdin": true,
+                             "StdinOnce": false,
+                             "Env": null,
                              "Cmd": ["/bin/bash"],
-                             "Dns":null,
-                             "Image":"base",
-                             "Volumes":null,
-                             "VolumesFrom":"",
-                             "WorkingDir":""
+                             "Dns": null,
+                             "Image": "base",
+                             "Volumes": null,
+                             "VolumesFrom": "",
+                             "WorkingDir": ""
                      },
-             "Id":"b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
-             "Parent":"27cf784147099545",
+             "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+             "Parent": "27cf784147099545",
              "Size": 6824592
         }
 
@@ -1005,14 +1004,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -1037,9 +1036,9 @@ Push the image `name` on the registry
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pushing..."}
-        {"status":"Pushing", "progress":"1/? (n/a)", "progressDetail":{"current":1}}}
-        {"error":"Invalid..."}
+        {"status": "Pushing..."}
+        {"status": "Pushing", "progress": "1/? (n/a)", "progressDetail": {"current": 1}}}
+        {"error": "Invalid..."}
         ...
 
     If you wish to push an image on to a private registry, that image must already have been tagged
@@ -1110,9 +1109,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Query Parameters:
@@ -1199,9 +1198,9 @@ Build an image from Dockerfile via stdin
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"stream":"Step 1..."}
-        {"stream":"..."}
-        {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
+        {"stream": "Step 1..."}
+        {"stream": "..."}
+        {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 
     The stream must be a tar archive compressed with one of the
     following algorithms: identity (no compression), gzip, bzip2, xz.
@@ -1242,10 +1241,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1274,20 +1273,20 @@ Display system-wide information
         Content-Type: application/json
 
         {
-             "Containers":11,
-             "Images":16,
-             "Driver":"btrfs",
-             "ExecutionDriver":"native-0.1",
-             "KernelVersion":"3.12.0-1-amd64"
-             "Debug":false,
+             "Containers": 11,
+             "Images": 16,
+             "Driver": "btrfs",
+             "ExecutionDriver": "native-0.1",
+             "KernelVersion": "3.12.0-1-amd64"
+             "Debug": false,
              "NFd": 11,
-             "NGoroutines":21,
-             "NEventsListener":0,
-             "InitPath":"/usr/bin/docker",
-             "IndexServerAddress":["https://index.docker.io/v1/"],
-             "MemoryLimit":true,
-             "SwapLimit":false,
-             "IPv4Forwarding":true
+             "NGoroutines": 21,
+             "NEventsListener": 0,
+             "InitPath": "/usr/bin/docker",
+             "IndexServerAddress": ["https://index.docker.io/v1/"],
+             "MemoryLimit": true,
+             "SwapLimit": false,
+             "IPv4Forwarding": true
         }
 
 Status Codes:
@@ -1311,10 +1310,10 @@ Show the docker version information
         Content-Type: application/json
 
         {
-             "ApiVersion":"1.12",
-             "Version":"0.2.2",
-             "GitCommit":"5a2a5cc+CHANGES",
-             "GoVersion":"go1.0.3"
+             "ApiVersion": "1.12",
+             "Version": "0.2.2",
+             "GitCommit": "5a2a5cc+CHANGES",
+             "GoVersion": "go1.0.3"
         }
 
 Status Codes:
@@ -1356,30 +1355,30 @@ Create a new image from a container's changes
         Content-Type: application/json
 
         {
-             "Hostname":"",
+             "Hostname": "",
              "Domainname": "",
-             "User":"",
-             "Memory":0,
-             "MemorySwap":0,
+             "User": "",
+             "Memory": 0,
+             "MemorySwap": 0,
              "CpuShares": 512,
              "Cpuset": "0,1",
-             "AttachStdin":false,
-             "AttachStdout":true,
-             "AttachStderr":true,
-             "PortSpecs":null,
-             "Tty":false,
-             "OpenStdin":false,
-             "StdinOnce":false,
-             "Env":null,
-             "Cmd":[
+             "AttachStdin": false,
+             "AttachStdout": true,
+             "AttachStderr": true,
+             "PortSpecs": null,
+             "Tty": false,
+             "OpenStdin": false,
+             "StdinOnce": false,
+             "Env": null,
+             "Cmd": [
                      "date"
              ],
-             "Volumes":{
+             "Volumes": {
                      "/tmp": {}
              },
-             "WorkingDir":"",
+             "WorkingDir": "",
              "NetworkDisabled": false,
-             "ExposedPorts":{
+             "ExposedPorts": {
                      "22/tcp": {}
              }
         }
@@ -1389,7 +1388,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 Created
         Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Json Parameters:
 
@@ -1434,10 +1433,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
 
 Query Parameters:
 
@@ -1547,7 +1546,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 
 ```
 {"hello-world":
-    {"latest":"565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
+    {"latest": "565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
 }
 ```
 
@@ -1563,11 +1562,11 @@ Sets up an exec instance in a running container `id`
         Content-Type: application/json
 
         {
-	     "AttachStdin":false,
-	     "AttachStdout":true,
-	     "AttachStderr":true,
-	     "Tty":false,
-	     "Cmd":[
+	     "AttachStdin": false,
+	     "AttachStdout": true,
+	     "AttachStderr": true,
+	     "Tty": false,
+	     "Cmd": [
                      "date"
              ],
         }
@@ -1578,7 +1577,7 @@ Sets up an exec instance in a running container `id`
         Content-Type: application/json
 
         {
-             "Id":"f90e34656806"
+             "Id": "f90e34656806"
         }
 
 Json Parameters:
@@ -1609,8 +1608,8 @@ interactive session with the `exec` command.
         Content-Type: application/json
 
         {
-	     "Detach":false,
-	     "Tty":false,
+	     "Detach": false,
+	     "Tty": false,
         }
 
 **Example response**:

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -40,9 +40,9 @@ List containers
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "9cd87474be90",
@@ -50,9 +50,9 @@ List containers
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "3176a2479c92",
@@ -70,9 +70,9 @@ List containers
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              }
         ]
 
@@ -110,42 +110,42 @@ Create a container
         Content-Type: application/json
 
         {
-             "Hostname":"",
+             "Hostname": "",
              "Domainname": "",
-             "User":"",
-             "Memory":0,
-             "MemorySwap":0,
+             "User": "",
+             "Memory": 0,
+             "MemorySwap": 0,
              "CpuShares": 512,
              "Cpuset": "0,1",
-             "AttachStdin":false,
-             "AttachStdout":true,
-             "AttachStderr":true,
-             "Tty":false,
-             "OpenStdin":false,
-             "StdinOnce":false,
-             "Env":null,
-             "Cmd":[
+             "AttachStdin": false,
+             "AttachStdout": true,
+             "AttachStderr": true,
+             "Tty": false,
+             "OpenStdin": false,
+             "StdinOnce": false,
+             "Env": null,
+             "Cmd": [
                      "date"
              ],
              "Entrypoint": "",
-             "Image":"base",
-             "Volumes":{
+             "Image": "base",
+             "Volumes": {
                      "/tmp": {}
              },
-             "WorkingDir":"",
+             "WorkingDir": "",
              "NetworkDisabled": false,
-             "MacAddress":"12:34:56:78:9a:bc",
-             "ExposedPorts":{
+             "MacAddress": "12:34:56:78:9a:bc",
+             "ExposedPorts": {
                      "22/tcp": {}
              },
              "SecurityOpts": [""],
              "HostConfig": {
-               "Binds":["/tmp:/tmp"],
-               "Links":["redis3:redis"],
-               "LxcConf":{"lxc.utsname":"docker"},
-               "PortBindings":{ "22/tcp": [{ "HostPort": "11022" }] },
-               "PublishAllPorts":false,
-               "Privileged":false,
+               "Binds": ["/tmp:/tmp"],
+               "Links": ["redis3:redis"],
+               "LxcConf": {"lxc.utsname":"docker"},
+               "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
+               "PublishAllPorts": false,
+               "Privileged": false,
                "Dns": ["8.8.8.8"],
                "DnsSearch": [""],
                "VolumesFrom": ["parent", "other:ro"],
@@ -291,8 +291,7 @@ Return low-level information on the container `id`
                              "Image": "base",
                              "Volumes": {},
                              "VolumesFrom": "",
-                             "WorkingDir":""
-
+                             "WorkingDir": ""
                      },
                      "State": {
                              "Running": false,
@@ -327,8 +326,8 @@ Return low-level information on the container `id`
                          },
                          "Links": ["/name:alias"],
                          "PublishAllPorts": false,
-                         "CapAdd: ["NET_ADMIN"],
-                         "CapDrop: ["MKNOD"]
+                         "CapAdd": ["NET_ADMIN"],
+                         "CapDrop": ["MKNOD"]
                      }
         }
 
@@ -354,7 +353,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -367,7 +366,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -432,16 +431,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -729,7 +728,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -777,7 +776,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -855,9 +854,9 @@ Create an image, either by pulling it from the registry or by importing it
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pulling..."}
-        {"status":"Pulling", "progress":"1 B/ 100 B", "progressDetail":{"current":1, "total":100}}
-        {"error":"Invalid..."}
+        {"status": "Pulling..."}
+        {"status": "Pulling", "progress": "1 B/ 100 B", "progressDetail": {"current": 1, "total": 100}}
+        {"error": "Invalid..."}
         ...
 
     When using this endpoint to pull an image from the registry, the
@@ -900,31 +899,31 @@ Return low-level information on the image `name`
         Content-Type: application/json
 
         {
-             "Created":"2013-03-23T22:24:18.818426-07:00",
-             "Container":"3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
+             "Created": "2013-03-23T22:24:18.818426-07:00",
+             "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
              "ContainerConfig":
                      {
-                             "Hostname":"",
-                             "User":"",
-                             "Memory":0,
-                             "MemorySwap":0,
-                             "AttachStdin":false,
-                             "AttachStdout":false,
-                             "AttachStderr":false,
-                             "PortSpecs":null,
-                             "Tty":true,
-                             "OpenStdin":true,
-                             "StdinOnce":false,
-                             "Env":null,
+                             "Hostname": "",
+                             "User": "",
+                             "Memory": 0,
+                             "MemorySwap": 0,
+                             "AttachStdin": false,
+                             "AttachStdout": false,
+                             "AttachStderr": false,
+                             "PortSpecs": null,
+                             "Tty": true,
+                             "OpenStdin": true,
+                             "StdinOnce": false,
+                             "Env": null,
                              "Cmd": ["/bin/bash"],
-                             "Dns":null,
-                             "Image":"base",
-                             "Volumes":null,
-                             "VolumesFrom":"",
-                             "WorkingDir":""
+                             "Dns": null,
+                             "Image": "base",
+                             "Volumes": null,
+                             "VolumesFrom": "",
+                             "WorkingDir": ""
                      },
-             "Id":"b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
-             "Parent":"27cf784147099545",
+             "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+             "Parent": "27cf784147099545",
              "Size": 6824592
         }
 
@@ -951,14 +950,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -983,9 +982,9 @@ Push the image `name` on the registry
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pushing..."}
-        {"status":"Pushing", "progress":"1/? (n/a)", "progressDetail":{"current":1}}}
-        {"error":"Invalid..."}
+        {"status": "Pushing..."}
+        {"status": "Pushing", "progress": "1/? (n/a)", "progressDetail": {"current": 1}}}
+        {"error": "Invalid..."}
         ...
 
     If you wish to push an image on to a private registry, that image must already have been tagged
@@ -1056,9 +1055,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Query Parameters:
@@ -1145,9 +1144,9 @@ Build an image from Dockerfile via stdin
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"stream":"Step 1..."}
-        {"stream":"..."}
-        {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
+        {"stream": "Step 1..."}
+        {"stream": "..."}
+        {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 
     The stream must be a tar archive compressed with one of the
     following algorithms: identity (no compression), gzip, bzip2, xz.
@@ -1189,10 +1188,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1263,10 +1262,10 @@ Show the docker version information
         Content-Type: application/json
 
         {
-             "ApiVersion":"1.12",
-             "Version":"0.2.2",
-             "GitCommit":"5a2a5cc+CHANGES",
-             "GoVersion":"go1.0.3"
+             "ApiVersion": "1.12",
+             "Version": "0.2.2",
+             "GitCommit": "5a2a5cc+CHANGES",
+             "GoVersion": "go1.0.3"
         }
 
 Status Codes:
@@ -1308,30 +1307,30 @@ Create a new image from a container's changes
         Content-Type: application/json
 
         {
-             "Hostname":"",
+             "Hostname": "",
              "Domainname": "",
-             "User":"",
-             "Memory":0,
-             "MemorySwap":0,
+             "User": "",
+             "Memory": 0,
+             "MemorySwap": 0,
              "CpuShares": 512,
              "Cpuset": "0,1",
-             "AttachStdin":false,
-             "AttachStdout":true,
-             "AttachStderr":true,
-             "PortSpecs":null,
-             "Tty":false,
-             "OpenStdin":false,
-             "StdinOnce":false,
-             "Env":null,
-             "Cmd":[
+             "AttachStdin": false,
+             "AttachStdout": true,
+             "AttachStderr": true,
+             "PortSpecs": null,
+             "Tty": false,
+             "OpenStdin": false,
+             "StdinOnce": false,
+             "Env": null,
+             "Cmd": [
                      "date"
              ],
-             "Volumes":{
+             "Volumes": {
                      "/tmp": {}
              },
-             "WorkingDir":"",
+             "WorkingDir": "",
              "NetworkDisabled": false,
-             "ExposedPorts":{
+             "ExposedPorts": {
                      "22/tcp": {}
              }
         }
@@ -1341,7 +1340,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 Created
         Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Json Parameters:
 
@@ -1386,10 +1385,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
 
 Query Parameters:
 
@@ -1503,7 +1502,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 
 ```
 {"hello-world":
-    {"latest":"565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
+    {"latest": "565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
 }
 ```
 
@@ -1519,11 +1518,11 @@ Sets up an exec instance in a running container `id`
         Content-Type: application/json
 
         {
-	     "AttachStdin":false,
-	     "AttachStdout":true,
-	     "AttachStderr":true,
-	     "Tty":false,
-	     "Cmd":[
+	     "AttachStdin": false,
+	     "AttachStdout": true,
+	     "AttachStderr": true,
+	     "Tty": false,
+	     "Cmd": [
                      "date"
              ],
         }
@@ -1534,7 +1533,7 @@ Sets up an exec instance in a running container `id`
         Content-Type: application/json
 
         {
-             "Id":"f90e34656806"
+             "Id": "f90e34656806"
         }
 
 Json Parameters:
@@ -1565,8 +1564,8 @@ interactive session with the `exec` command.
         Content-Type: application/json
 
         {
-	     "Detach":false,
-	     "Tty":false,
+	     "Detach": false,
+	     "Tty": false,
         }
 
 **Example response**:

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -40,9 +40,9 @@ List containers
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "9cd87474be90",
@@ -50,9 +50,9 @@ List containers
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "3176a2479c92",
@@ -70,9 +70,9 @@ List containers
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              }
         ]
 
@@ -110,42 +110,42 @@ Create a container
         Content-Type: application/json
 
         {
-             "Hostname":"",
+             "Hostname": "",
              "Domainname": "",
-             "User":"",
-             "Memory":0,
-             "MemorySwap":0,
+             "User": "",
+             "Memory": 0,
+             "MemorySwap": 0,
              "CpuShares": 512,
              "Cpuset": "0,1",
-             "AttachStdin":false,
-             "AttachStdout":true,
-             "AttachStderr":true,
-             "Tty":false,
-             "OpenStdin":false,
-             "StdinOnce":false,
-             "Env":null,
-             "Cmd":[
+             "AttachStdin": false,
+             "AttachStdout": true,
+             "AttachStderr": true,
+             "Tty": false,
+             "OpenStdin": false,
+             "StdinOnce": false,
+             "Env": null,
+             "Cmd": [
                      "date"
              ],
              "Entrypoint": "",
-             "Image":"base",
-             "Volumes":{
+             "Image": "base",
+             "Volumes": {
                      "/tmp": {}
              },
-             "WorkingDir":"",
+             "WorkingDir": "",
              "NetworkDisabled": false,
-             "MacAddress":"12:34:56:78:9a:bc",
-             "ExposedPorts":{
+             "MacAddress": "12:34:56:78:9a:bc",
+             "ExposedPorts": {
                      "22/tcp": {}
              },
              "SecurityOpts": [""],
              "HostConfig": {
-               "Binds":["/tmp:/tmp"],
-               "Links":["redis3:redis"],
-               "LxcConf":{"lxc.utsname":"docker"},
-               "PortBindings":{ "22/tcp": [{ "HostPort": "11022" }] },
-               "PublishAllPorts":false,
-               "Privileged":false,
+               "Binds": ["/tmp:/tmp"],
+               "Links": ["redis3:redis"],
+               "LxcConf": {"lxc.utsname":"docker"},
+               "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
+               "PublishAllPorts": false,
+               "Privileged": false,
                "Dns": ["8.8.8.8"],
                "DnsSearch": [""],
                "VolumesFrom": ["parent", "other:ro"],
@@ -291,8 +291,7 @@ Return low-level information on the container `id`
                              "Image": "base",
                              "Volumes": {},
                              "VolumesFrom": "",
-                             "WorkingDir":""
-
+                             "WorkingDir": ""
                      },
                      "State": {
                              "Running": false,
@@ -330,8 +329,8 @@ Return low-level information on the container `id`
                          },
                          "Links": ["/name:alias"],
                          "PublishAllPorts": false,
-                         "CapAdd: ["NET_ADMIN"],
-                         "CapDrop: ["MKNOD"]
+                         "CapAdd": ["NET_ADMIN"],
+                         "CapDrop": ["MKNOD"]
                      }
         }
 
@@ -357,7 +356,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -370,7 +369,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -438,16 +437,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -738,7 +737,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -786,7 +785,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -864,9 +863,9 @@ Create an image, either by pulling it from the registry or by importing it
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pulling..."}
-        {"status":"Pulling", "progress":"1 B/ 100 B", "progressDetail":{"current":1, "total":100}}
-        {"error":"Invalid..."}
+        {"status": "Pulling..."}
+        {"status": "Pulling", "progress": "1 B/ 100 B", "progressDetail": {"current": 1, "total": 100}}
+        {"error": "Invalid..."}
         ...
 
     When using this endpoint to pull an image from the registry, the
@@ -909,31 +908,31 @@ Return low-level information on the image `name`
         Content-Type: application/json
 
         {
-             "Created":"2013-03-23T22:24:18.818426-07:00",
-             "Container":"3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
+             "Created": "2013-03-23T22:24:18.818426-07:00",
+             "Container": "3d67245a8d72ecf13f33dffac9f79dcdf70f75acb84d308770391510e0c23ad0",
              "ContainerConfig":
                      {
-                             "Hostname":"",
-                             "User":"",
-                             "Memory":0,
-                             "MemorySwap":0,
-                             "AttachStdin":false,
-                             "AttachStdout":false,
-                             "AttachStderr":false,
-                             "PortSpecs":null,
-                             "Tty":true,
-                             "OpenStdin":true,
-                             "StdinOnce":false,
-                             "Env":null,
+                             "Hostname": "",
+                             "User": "",
+                             "Memory": 0,
+                             "MemorySwap": 0,
+                             "AttachStdin": false,
+                             "AttachStdout": false,
+                             "AttachStderr": false,
+                             "PortSpecs": null,
+                             "Tty": true,
+                             "OpenStdin": true,
+                             "StdinOnce": false,
+                             "Env": null,
                              "Cmd": ["/bin/bash"],
-                             "Dns":null,
-                             "Image":"base",
-                             "Volumes":null,
-                             "VolumesFrom":"",
-                             "WorkingDir":""
+                             "Dns": null,
+                             "Image": "base",
+                             "Volumes": null,
+                             "VolumesFrom": "",
+                             "WorkingDir": ""
                      },
-             "Id":"b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
-             "Parent":"27cf784147099545",
+             "Id": "b750fe79269d2ec9a3c593ef05b4332b1d1a02a62b4accb2c21d589ff2f5f2dc",
+             "Parent": "27cf784147099545",
              "Size": 6824592
         }
 
@@ -960,14 +959,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -992,9 +991,9 @@ Push the image `name` on the registry
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pushing..."}
-        {"status":"Pushing", "progress":"1/? (n/a)", "progressDetail":{"current":1}}}
-        {"error":"Invalid..."}
+        {"status": "Pushing..."}
+        {"status": "Pushing", "progress": "1/? (n/a)", "progressDetail": {"current": 1}}}
+        {"error": "Invalid..."}
         ...
 
     If you wish to push an image on to a private registry, that image must already have been tagged
@@ -1065,9 +1064,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Query Parameters:
@@ -1154,9 +1153,9 @@ Build an image from Dockerfile via stdin
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"stream":"Step 1..."}
-        {"stream":"..."}
-        {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
+        {"stream": "Step 1..."}
+        {"stream": "..."}
+        {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 
     The stream must be a tar archive compressed with one of the
     following algorithms: identity (no compression), gzip, bzip2, xz.
@@ -1198,10 +1197,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1272,10 +1271,10 @@ Show the docker version information
         Content-Type: application/json
 
         {
-             "ApiVersion":"1.12",
-             "Version":"0.2.2",
-             "GitCommit":"5a2a5cc+CHANGES",
-             "GoVersion":"go1.0.3"
+             "ApiVersion": "1.12",
+             "Version": "0.2.2",
+             "GitCommit": "5a2a5cc+CHANGES",
+             "GoVersion": "go1.0.3"
         }
 
 Status Codes:
@@ -1317,30 +1316,30 @@ Create a new image from a container's changes
         Content-Type: application/json
 
         {
-             "Hostname":"",
+             "Hostname": "",
              "Domainname": "",
-             "User":"",
-             "Memory":0,
-             "MemorySwap":0,
+             "User": "",
+             "Memory": 0,
+             "MemorySwap": 0,
              "CpuShares": 512,
              "Cpuset": "0,1",
-             "AttachStdin":false,
-             "AttachStdout":true,
-             "AttachStderr":true,
-             "PortSpecs":null,
-             "Tty":false,
-             "OpenStdin":false,
-             "StdinOnce":false,
-             "Env":null,
-             "Cmd":[
+             "AttachStdin": false,
+             "AttachStdout": true,
+             "AttachStderr": true,
+             "PortSpecs": null,
+             "Tty": false,
+             "OpenStdin": false,
+             "StdinOnce": false,
+             "Env": null,
+             "Cmd": [
                      "date"
              ],
-             "Volumes":{
+             "Volumes": {
                      "/tmp": {}
              },
-             "WorkingDir":"",
+             "WorkingDir": "",
              "NetworkDisabled": false,
-             "ExposedPorts":{
+             "ExposedPorts": {
                      "22/tcp": {}
              }
         }
@@ -1350,7 +1349,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 Created
         Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Json Parameters:
 
@@ -1395,10 +1394,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
 
 Query Parameters:
 
@@ -1512,7 +1511,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 
 ```
 {"hello-world":
-    {"latest":"565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
+    {"latest": "565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
 }
 ```
 
@@ -1528,11 +1527,11 @@ Sets up an exec instance in a running container `id`
         Content-Type: application/json
 
         {
-	     "AttachStdin":false,
-	     "AttachStdout":true,
-	     "AttachStderr":true,
-	     "Tty":false,
-	     "Cmd":[
+	     "AttachStdin": false,
+	     "AttachStdout": true,
+	     "AttachStderr": true,
+	     "Tty": false,
+	     "Cmd": [
                      "date"
              ],
         }
@@ -1543,7 +1542,7 @@ Sets up an exec instance in a running container `id`
         Content-Type: application/json
 
         {
-             "Id":"f90e34656806"
+             "Id": "f90e34656806"
         }
 
 Json Parameters:
@@ -1574,8 +1573,8 @@ interactive session with the `exec` command.
         Content-Type: application/json
 
         {
-	     "Detach":false,
-	     "Tty":false,
+	     "Detach": false,
+	     "Tty": false,
         }
 
 **Example response**:

--- a/docs/sources/reference/api/docker_remote_api_v1.2.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.2.md
@@ -230,16 +230,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -412,7 +412,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -738,9 +738,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Status Codes:
@@ -930,7 +930,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 OK
             Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.3.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.3.md
@@ -266,16 +266,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -460,7 +460,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -697,14 +697,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -785,9 +785,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Status Codes:
@@ -978,7 +978,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 OK
             Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.4.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.4.md
@@ -189,8 +189,7 @@ Return low-level information on the container `id`
                              "Image": "ubuntu",
                              "Volumes": {},
                              "VolumesFrom": "",
-                             "WorkingDir":""
-
+                             "WorkingDir": ""
                      },
                      "State": {
                              "Running": false,
@@ -235,7 +234,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -248,7 +247,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -281,16 +280,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -476,7 +475,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -522,7 +521,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -743,14 +742,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -828,9 +827,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Status Codes:
@@ -926,10 +925,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1022,7 +1021,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 OK
             Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.5.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.5.md
@@ -473,7 +473,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -1032,7 +1032,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 OK
             Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.6.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.6.md
@@ -39,9 +39,9 @@ List containers
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "9cd87474be90",
@@ -49,9 +49,9 @@ List containers
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "3176a2479c92",
@@ -69,9 +69,9 @@ List containers
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              }
         ]
 
@@ -237,8 +237,7 @@ Return low-level information on the container `id`
                              "Image": "base",
                              "Volumes": {},
                              "VolumesFrom": "",
-                             "WorkingDir":""
-
+                             "WorkingDir": ""
                      },
                      "State": {
                              "Running": false,
@@ -282,7 +281,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -295,7 +294,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -328,16 +327,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -580,7 +579,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -626,7 +625,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -850,14 +849,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -937,9 +936,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Status Codes:
@@ -1035,10 +1034,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1130,7 +1129,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 OK
             Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Query Parameters:
 
@@ -1171,10 +1170,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.7.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.7.md
@@ -39,9 +39,9 @@ List containers
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "9cd87474be90",
@@ -49,9 +49,9 @@ List containers
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "3176a2479c92",
@@ -69,9 +69,9 @@ List containers
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              }
         ]
 
@@ -191,8 +191,7 @@ Return low-level information on the container `id`
                              "Image": "base",
                              "Volumes": {},
                              "VolumesFrom": "",
-                             "WorkingDir":""
-
+                             "WorkingDir": ""
                      },
                      "State": {
                              "Running": false,
@@ -236,7 +235,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -249,7 +248,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -282,16 +281,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -525,7 +524,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -571,7 +570,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -765,14 +764,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -859,9 +858,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Status Codes:
@@ -984,10 +983,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1073,7 +1072,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 OK
             Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Query Parameters:
 
@@ -1116,10 +1115,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.8.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.8.md
@@ -39,9 +39,9 @@ List containers
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "9cd87474be90",
@@ -49,9 +49,9 @@ List containers
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "3176a2479c92",
@@ -69,9 +69,9 @@ List containers
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              }
         ]
 
@@ -215,8 +215,7 @@ Return low-level information on the container `id`
                              "Image": "base",
                              "Volumes": {},
                              "VolumesFrom": "",
-                             "WorkingDir":""
-
+                             "WorkingDir": ""
                      },
                      "State": {
                              "Running": false,
@@ -276,7 +275,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -289,7 +288,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -322,16 +321,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -573,7 +572,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -619,7 +618,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -690,9 +689,9 @@ Create an image, either by pull it from the registry or by importing i
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pulling..."}
-        {"status":"Pulling", "progress":"1 B/ 100 B", "progressDetail":{"current":1, "total":100}}
-        {"error":"Invalid..."}
+        {"status": "Pulling..."}
+        {"status": "Pulling", "progress": "1 B/ 100 B", "progressDetail": {"current": 1, "total": 100}}
+        {"error": "Invalid..."}
         ...
 
     When using this endpoint to pull an image from the registry, the
@@ -813,14 +812,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -845,9 +844,9 @@ Push the image `name` on the registry
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pushing..."}
-        {"status":"Pushing", "progress":"1/? (n/a)", "progressDetail":{"current":1}}}
-        {"error":"Invalid..."}
+        {"status": "Pushing..."}
+        {"status": "Pushing", "progress": "1/? (n/a)", "progressDetail": {"current": 1}}}
+        {"error": "Invalid..."}
         ...
 
     Request Headers:
@@ -907,9 +906,9 @@ Remove the image `name` from the filesystem
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Status Codes:
@@ -991,9 +990,9 @@ Build an image from Dockerfile via stdin
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"stream":"Step 1..."}
-        {"stream":"..."}
-        {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
+        {"stream": "Step 1..."}
+        {"stream": "..."}
+        {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 
     The stream must be a tar archive compressed with one of the
     following algorithms: identity (no compression), gzip, bzip2, xz.
@@ -1035,10 +1034,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1124,7 +1123,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 OK
             Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Query Parameters:
 
@@ -1167,10 +1166,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
 
 Query Parameters:
 
@@ -1245,7 +1244,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 
 ```
 {"hello-world":
-    {"latest":"565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
+    {"latest": "565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
 }
 ```
 

--- a/docs/sources/reference/api/docker_remote_api_v1.9.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.9.md
@@ -39,9 +39,9 @@ List containers.
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "9cd87474be90",
@@ -49,9 +49,9 @@ List containers.
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              },
              {
                      "Id": "3176a2479c92",
@@ -69,9 +69,9 @@ List containers.
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
-                     "Ports":[],
-                     "SizeRw":12288,
-                     "SizeRootFs":0
+                     "Ports": [],
+                     "SizeRw": 12288,
+                     "SizeRootFs": 0
              }
         ]
 
@@ -215,8 +215,7 @@ Return low-level information on the container `id`
                              "Image": "base",
                              "Volumes": {},
                              "VolumesFrom": "",
-                             "WorkingDir":""
-
+                             "WorkingDir": ""
                      },
                      "State": {
                              "Running": false,
@@ -276,7 +275,7 @@ List processes running inside the container `id`
         Content-Type: application/json
 
         {
-             "Titles":[
+             "Titles": [
                      "USER",
                      "PID",
                      "%CPU",
@@ -289,7 +288,7 @@ List processes running inside the container `id`
                      "TIME",
                      "COMMAND"
                      ],
-             "Processes":[
+             "Processes": [
                      ["root","20147","0.0","0.1","18060","1864","pts/4","S","10:06","0:00","bash"],
                      ["root","20271","0.0","0.0","4312","352","pts/4","S+","10:07","0:00","sleep","10"]
              ]
@@ -322,16 +321,16 @@ Inspect changes on container `id`'s filesystem
 
         [
              {
-                     "Path":"/dev",
-                     "Kind":0
+                     "Path": "/dev",
+                     "Kind": 0
              },
              {
-                     "Path":"/dev/kmsg",
-                     "Kind":1
+                     "Path": "/dev/kmsg",
+                     "Kind": 1
              },
              {
-                     "Path":"/test",
-                     "Kind":1
+                     "Path": "/test",
+                     "Kind": 1
              }
         ]
 
@@ -577,7 +576,7 @@ Block until container `id` stops, then returns the exit code
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"StatusCode":0}
+        {"StatusCode": 0}
 
 Status Codes:
 
@@ -623,7 +622,7 @@ Copy files or folders of container `id`
         Content-Type: application/json
 
         {
-             "Resource":"test.txt"
+             "Resource": "test.txt"
         }
 
 **Example response**:
@@ -694,9 +693,9 @@ Create an image, either by pull it from the registry or by importing i
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pulling..."}
-        {"status":"Pulling", "progress":"1 B/ 100 B", "progressDetail":{"current":1, "total":100}}
-        {"error":"Invalid..."}
+        {"status": "Pulling..."}
+        {"status": "Pulling", "progress": "1 B/ 100 B", "progressDetail": {"current": 1, "total": 100}}
+        {"error": "Invalid..."}
         ...
 
     When using this endpoint to pull an image from the registry, the
@@ -817,14 +816,14 @@ Return the history of the image `name`
 
         [
              {
-                     "Id":"b750fe79269d",
-                     "Created":1364102658,
-                     "CreatedBy":"/bin/bash"
+                     "Id": "b750fe79269d",
+                     "Created": 1364102658,
+                     "CreatedBy": "/bin/bash"
              },
              {
-                     "Id":"27cf78414709",
-                     "Created":1364068391,
-                     "CreatedBy":""
+                     "Id": "27cf78414709",
+                     "Created": 1364068391,
+                     "CreatedBy": ""
              }
         ]
 
@@ -849,9 +848,9 @@ Push the image `name` on the registry
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"Pushing..."}
-        {"status":"Pushing", "progress":"1/? (n/a)", "progressDetail":{"current":1}}}
-        {"error":"Invalid..."}
+        {"status": "Pushing..."}
+        {"status": "Pushing", "progress": "1/? (n/a)", "progressDetail": {"current": 1}}}
+        {"error": "Invalid..."}
         ...
 
     Request Headers:
@@ -910,9 +909,9 @@ Status Codes:
         Content-type: application/json
 
         [
-         {"Untagged":"3e2f21a89f"},
-         {"Deleted":"3e2f21a89f"},
-         {"Deleted":"53b4f83ac9"}
+         {"Untagged": "3e2f21a89f"},
+         {"Deleted": "3e2f21a89f"},
+         {"Deleted": "53b4f83ac9"}
         ]
 
 Status Codes:
@@ -994,9 +993,9 @@ Build an image from Dockerfile using a POST body.
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"stream":"Step 1..."}
-        {"stream":"..."}
-        {"error":"Error...", "errorDetail":{"code": 123, "message": "Error..."}}
+        {"stream": "Step 1..."}
+        {"stream": "..."}
+        {"error": "Error...", "errorDetail": {"code": 123, "message": "Error..."}}
 
     The stream must be a tar archive compressed with one of the
     following algorithms: identity (no compression), gzip, bzip2, xz.
@@ -1036,10 +1035,10 @@ Get the default username and email
         Content-Type: application/json
 
         {
-             "username":"hannibal",
-             "password:"xxxx",
-             "email":"hannibal@a-team.com",
-             "serveraddress":"https://index.docker.io/v1/"
+             "username":" hannibal",
+             "password: "xxxx",
+             "email": "hannibal@a-team.com",
+             "serveraddress": "https://index.docker.io/v1/"
         }
 
 **Example response**:
@@ -1152,7 +1151,7 @@ Create a new image from a container's changes
         HTTP/1.1 201 Created
         Content-Type: application/vnd.docker.raw-stream
 
-        {"Id":"596069db4bf5"}
+        {"Id": "596069db4bf5"}
 
 Json Parameters:
 
@@ -1197,10 +1196,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status":"create","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"start","id":"dfdf82bd3881","from":"base:latest","time":1374067924}
-        {"status":"stop","id":"dfdf82bd3881","from":"base:latest","time":1374067966}
-        {"status":"destroy","id":"dfdf82bd3881","from":"base:latest","time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
 
 Query Parameters:
 
@@ -1275,7 +1274,7 @@ the root that contains a list of repository and tag names mapped to layer IDs.
 
 ```
 {"hello-world":
-    {"latest":"565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
+    {"latest": "565a9d68a73f6706862bfe8409a7f659776d4d60a8d096eb4a3cbce6999cc2a1"}
 }
 ```
 


### PR DESCRIPTION
This is mostly whitespace. Fixed:
- [Invalid JSON](https://github.com/flowlo/docker/commit/e583cc1eb47c29d7473f1dac7d4f39ddeb8ae1e6#diff-0ce150101f644b5b72bf5433202ad617R329)
- Inconsistent spacing at colon

Expressions for binary data streams (line 468 vs. 1474) remain inconsistent. Could fix that too, if you like.

I can also look at v1.16 if requested.
