### PR TITLE
need to call syscall.Unmount with MNT_DETACH

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1433,7 +1433,7 @@ func (devices *DeviceSet) UnmountDevice(hash string) error {
 	}
 
 	log.Debugf("[devmapper] Unmount(%s)", info.mountPath)
-	if err := syscall.Unmount(info.mountPath, 0); err != nil {
+	if err := syscall.Unmount(info.mountPath, syscall.MNT_DETACH); err != nil {
 		return err
 	}
 	log.Debugf("[devmapper] Unmount done")


### PR DESCRIPTION
syscall.Unmount failed sometimes when user interrupted exporting, for example a Ctrl-C, or commands closed the pipe before reading finish, like "docker export <container_name> | file -z -"; the following export command would fail because of previous syscall.Unmount failed of EBUSY, change it Unmount with MNT_DETACH can fix the problem, it's the same behavior as in Shutdown;

``` text
time="2015-01-03T21:27:26Z" level=error msg="Warning: error unmounting device 34a3e77cdbca17ceffd0636aee0415bb412996adb12360bfe2585ce30467fa8e: device or resource busy"
```

```
$ docker export thirsty_ardinghelli | file -z -
/dev/stdin: POSIX tar archive
time="2015-01-03T21:58:17Z" level=fatal msg="write /dev/stdout: broken pipe"
$ docker export thirsty_ardinghelli
time="2015-01-03T21:54:33Z" level=fatal msg="Error: thirsty_ardinghelli: Error getting container 34a3e77cdbca17ceffd0636aee0415bb412996adb12360bfe2585ce30467fa8e from driver devicemapper: Error mounting '/dev/mapper/docker-253:0-3148372-34a3e77cdbca17ceffd0636aee0415bb412996adb12360bfe2585ce30467fa8e' on '/var/lib/docker/devicemapper/mnt/34a3e77cdbca17ceffd0636aee0415bb412996adb12360bfe2585ce30467fa8e': device or resource busy"
```

Signed-off-by: Derek Che drc@yahoo-inc.com
