### PR TITLE
Update License year to range 2013-2015

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2014 Docker, Inc.
+   Copyright 2013-2015 Docker, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Copyright notices must reflect the current year. This commit updates the listed year to 2015 with a starting year of 2013 from
https://github.com/docker/docker/commit/a27b4b8cb8e838d03a99b6d2b30f76bdaf2f9e5d

Docker-DCO-1.1-Signed-off-by: Patrick Stapleton github@gdi2290.com (github: gdi2290)
