### PR TITLE
Proposal: 9785 add comment column in docker history command

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1061,7 +1061,7 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 
 	w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
 	if !*quiet {
-		fmt.Fprintln(w, "IMAGE\tCREATED\tCREATED BY\tSIZE")
+		fmt.Fprintln(w, "IMAGE\tCREATED\tCREATED BY\tSIZE\tCOMMENT")
 	}
 
 	for _, out := range outs.Data {
@@ -1080,7 +1080,8 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 			} else {
 				fmt.Fprintf(w, "%s\t", utils.Trunc(out.Get("CreatedBy"), 45))
 			}
-			fmt.Fprintf(w, "%s\n", units.HumanSize(float64(out.GetInt64("Size"))))
+			fmt.Fprintf(w, "%s\t", units.HumanSize(float64(out.GetInt64("Size"))))
+			fmt.Fprintf(w, "%s\n", out.Get("Comment"))
 		} else {
 			if *noTrunc {
 				fmt.Fprintln(w, outID)

--- a/graph/history.go
+++ b/graph/history.go
@@ -36,6 +36,7 @@ func (s *TagStore) CmdHistory(job *engine.Job) engine.Status {
 		out.Set("CreatedBy", strings.Join(img.ContainerConfig.Cmd, " "))
 		out.SetList("Tags", lookupMap[img.ID])
 		out.SetInt64("Size", img.Size)
+		out.Set("Comment", img.Comment)
 		outs.Add(out)
 		return nil
 	})

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"regexp"
 )
 
 // This is a heisen-test.  Because the created timestamp of images and the behavior of
@@ -81,4 +82,53 @@ func TestHistoryNonExistentImage(t *testing.T) {
 		t.Fatal("history on a non-existent image didn't result in a non-zero exit status")
 	}
 	logDone("history - history on non-existent image must fail")
+}
+
+
+func TestHistoryImageWithComment(t *testing.T) {
+
+	// make a image through docker commit <container id> [ -m messages ]
+	runCmd := exec.Command(dockerBinary, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
+	out, _, _, err := runCommandWithStdoutStderr(runCmd)
+	if err != nil {
+		t.Fatalf("failed to run container: %s, %v", out, err)
+	}
+
+	cleanedContainerID := stripTrailingCharacters(out)
+
+	waitCmd := exec.Command(dockerBinary, "wait", cleanedContainerID)
+	if _, _, err = runCommandWithOutput(waitCmd); err != nil {
+		t.Fatalf("error thrown while waiting for container: %s, %v", out, err)
+	}
+
+	commitCmd := exec.Command(dockerBinary, "commit", "-m=This is a comment", cleanedContainerID)
+	out, _, err = runCommandWithOutput(commitCmd)
+	if err != nil {
+		t.Fatalf("failed to commit container to image: %s, %v", out, err)
+	}
+
+	cleanedImageID := stripTrailingCharacters(out)
+	deleteContainer(cleanedContainerID)
+	defer deleteImages(cleanedImageID)
+	logDone("history - commit a container with comment")
+
+	// test docker history <image id> to check comment messages
+	historyCmd := exec.Command(dockerBinary, "history", cleanedImageID)
+	out, exitCode, err := runCommandWithOutput(historyCmd)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("failed to get image history: %s, %v", out, err)
+	}
+	
+	expectedValue := "This is a comment"
+
+	outputLine := strings.Split(out, "\n")[1]
+	outputTabs := regexp.MustCompile("  +").Split(outputLine, -1)
+	actualValue := outputTabs[len(outputTabs) - 1]
+	
+	if strings.Contains(actualValue, expectedValue) {
+		
+		logDone("history - history on image with comment")
+		return
+	}
+	t.Fatalf("Expected comments \"%s\", but found \"%s\"", expectedValue, actualValue)
 }

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 	"testing"
-	"regexp"
 )
 
 // This is a heisen-test.  Because the created timestamp of images and the behavior of
@@ -84,7 +84,6 @@ func TestHistoryNonExistentImage(t *testing.T) {
 	logDone("history - history on non-existent image must fail")
 }
 
-
 func TestHistoryImageWithComment(t *testing.T) {
 
 	// make a image through docker commit <container id> [ -m messages ]
@@ -118,15 +117,15 @@ func TestHistoryImageWithComment(t *testing.T) {
 	if err != nil || exitCode != 0 {
 		t.Fatalf("failed to get image history: %s, %v", out, err)
 	}
-	
+
 	expectedValue := "This is a comment"
 
 	outputLine := strings.Split(out, "\n")[1]
 	outputTabs := regexp.MustCompile("  +").Split(outputLine, -1)
-	actualValue := outputTabs[len(outputTabs) - 1]
-	
+	actualValue := outputTabs[len(outputTabs)-1]
+
 	if strings.Contains(actualValue, expectedValue) {
-		
+
 		logDone("history - history on image with comment")
 		return
 	}


### PR DESCRIPTION
I added a new column COMMENT in the output of <code>docker history</code> command to display messages would be submitted using <code>docker commit </code> command with <code>-m</code> parameter. 

Messages submitted in  <code>docker commit </code> command are very important to me, and to other users I think, to trace image changes in Docker just like code changes in Git. So it is a very good feature, but I am also surprised of those messages are not displayed in <code>docker history</code> command output. This problem makes these messages make no sense. 

This PR is used to fetch these messages and display them into <code>docker history</code> command. Thanks for your appreciate.

Closes #9785
