### PR TITLE
Ignore terminating processes within a specific Linux Control Group

### DIFF
--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -22,6 +22,7 @@ docker-create - Create a new container
 [**--expose**[=*[]*]]
 [**-h**|**--hostname**[=*HOSTNAME*]]
 [**-i**|**--interactive**[=*false*]]
+[**--ignore-cgroups**[=*[]*]]
 [**--ipc**[=*IPC*]]
 [**--link**[=*[]*]]
 [**--lxc-conf**[=*[]*]]
@@ -89,6 +90,10 @@ IMAGE [COMMAND] [ARG...]
 
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.
+
+**--ignore-cgroups**=""
+   Ignore processes in the named Linux control groups when killing processes
+   related to a container.
 
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -23,6 +23,7 @@ docker-run - Run a command in a new container
 [**--expose**[=*[]*]]
 [**-h**|**--hostname**[=*HOSTNAME*]]
 [**-i**|**--interactive**[=*false*]]
+[**--ignore-cgroups**[=*[]*]]
 [**--ipc**[=*IPC*]]
 [**--link**[=*[]*]]
 [**--lxc-conf**[=*[]*]]
@@ -158,6 +159,11 @@ ENTRYPOINT.
 
    When set to true, keep stdin open even if not attached. The default is false.
 
+[**--ignore-cgroups**[=*[]*]]
++   Ignore processes in the named Linux control groups when killing processes
++   related to a container.
+
+   
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
                                'container:<name|id>': reuses another container shared memory, semaphores and message queues

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -672,6 +672,7 @@ Creates a new container.
       --expose=[]                Expose a port or a range of ports (e.g. --expose=3300-3310) from the container without publishing it to your host
       -h, --hostname=""          Container host name
       -i, --interactive=false    Keep STDIN open even if not attached
+      --ignore-cgroups=[]        A CDL of control groups, whereby the processes are ignored when the container is killed
       --ipc=""                   Default is to create a private IPC namespace (POSIX SysV IPC) for the container
                                    'container:<name|id>': reuses another container shared memory, semaphores and message queues
                                    'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.


### PR DESCRIPTION
The purpose of this change is to allow certain special processes that
understand how to reconnect to existing processes to reconnect during
an upgrade using Docker container technology to execute the upgrade
process.

One such use case is a container with libvirt within it.  If the libvirt
container is killed, it can be restarted.  Clearly we don't want to kill
all the processes related to libvirt, especially those running virtual
machines, so instead, we can trigger this ignore cgroup operation when
creating the container.  In conjunction, libvirt can store qemu processes
in a specific control group which will be specified when the libvirt
container is created.

Since the feature is optional and only expected to be used in rare cases,
it is unlikely a user will randomly create problems for their own environment.

DOCKER-DCO-1.1-Signed-off-by: Steven Dake sdake@redhat.com (github: sdake)
