### PR TITLE
9785 add comment column in docker history command

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1061,7 +1061,7 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 
 	w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
 	if !*quiet {
-		fmt.Fprintln(w, "IMAGE\tCREATED\tCREATED BY\tSIZE")
+		fmt.Fprintln(w, "IMAGE\tCREATED\tCREATED BY\tSIZE\tCOMMENT")
 	}
 
 	for _, out := range outs.Data {
@@ -1080,7 +1080,8 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 			} else {
 				fmt.Fprintf(w, "%s\t", utils.Trunc(out.Get("CreatedBy"), 45))
 			}
-			fmt.Fprintf(w, "%s\n", units.HumanSize(float64(out.GetInt64("Size"))))
+			fmt.Fprintf(w, "%s\t", units.HumanSize(float64(out.GetInt64("Size"))))
+			fmt.Fprintf(w, "%s\n", out.Get("Comment"))
 		} else {
 			if *noTrunc {
 				fmt.Fprintln(w, outID)

--- a/docs/man/docker-history.1.md
+++ b/docs/man/docker-history.1.md
@@ -32,7 +32,7 @@ Show the history of when and how an image was created.
     511136ea3c5a   10 months ago                                                    0 B                 Imported from -
 
 ## Show the history of images created through docker commit command
-`docker commit` command accepts a **-m** parameter to provide comment messages to the image. You can see these messages in image history.
+The `docker commit` command has a **-m** flag for adding comments to the image. These comments will be displayed in the image history.
 
     $ sudo docker history docker:scm
     IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT

--- a/docs/man/docker-history.1.md
+++ b/docs/man/docker-history.1.md
@@ -22,11 +22,24 @@ Show the history of when and how an image was created.
    Only show numeric IDs. The default is *false*.
 
 # EXAMPLES
+
+## Show the history of images created through docker build command
+
     $ sudo docker history fedora
-    IMAGE          CREATED          CREATED BY                                      SIZE
+    IMAGE          CREATED          CREATED BY                                      SIZE                COMMENT
     105182bb5e8b   5 days ago       /bin/sh -c #(nop) ADD file:71356d2ad59aa3119d   372.7 MB
     73bd853d2ea5   13 days ago      /bin/sh -c #(nop) MAINTAINER Lokesh Mandvekar   0 B
-    511136ea3c5a   10 months ago                                                    0 B
+    511136ea3c5a   10 months ago                                                    0 B                 Imported from -
+
+## Show the history of images created through docker commit command
+`docker commit` command accepts a **-m** parameter to provide comment messages to the image. You can see these messages in image history.
+
+    $ sudo docker history docker:scm
+    IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+    2ac9d1098bf1        3 months ago        /bin/bash                                       241.4 MB            Added Apache to Fedora base image
+    88b42ffd1f7c        5 months ago        /bin/sh -c #(nop) ADD file:1fd8d7f9f6557cafc7   373.7 MB            
+    c69cab00d6ef        5 months ago        /bin/sh -c #(nop) MAINTAINER Lokesh Mandvekar   0 B                 
+    511136ea3c5a        19 months ago                                                       0 B                 Imported from -
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -953,7 +953,7 @@ To see how the `docker:latest` image was built:
     750d58736b4b        6 weeks ago         /bin/sh -c #(nop) MAINTAINER Tianon Gravi <ad   0 B
     511136ea3c5a        9 months ago                                                        0 B                 Imported from -
 
-To see how the `docker:apache` image which was commited from a container:
+To see how the `docker:apache` image was added to a container's base image:
 
     $ sudo docker history docker:scm
     IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -945,13 +945,23 @@ For example:
 To see how the `docker:latest` image was built:
 
     $ sudo docker history docker
-    IMAGE                                                              CREATED             CREATED BY                                                                                                                                                 SIZE
-    3e23a5875458790b7a806f95f7ec0d0b2a5c1659bfc899c89f939f6d5b8f7094   8 days ago          /bin/sh -c #(nop) ENV LC_ALL=C.UTF-8                                                                                                                       0 B
-    8578938dd17054dce7993d21de79e96a037400e8d28e15e7290fea4f65128a36   8 days ago          /bin/sh -c dpkg-reconfigure locales &&    locale-gen C.UTF-8 &&    /usr/sbin/update-locale LANG=C.UTF-8                                                    1.245 MB
-    be51b77efb42f67a5e96437b3e102f81e0a1399038f77bf28cea0ed23a65cf60   8 days ago          /bin/sh -c apt-get update && apt-get install -y    git    libxml2-dev    python    build-essential    make    gcc    python-dev    locales    python-pip   338.3 MB
-    4b137612be55ca69776c7f30c2d2dd0aa2e7d72059820abf3e25b629f887a084   6 weeks ago         /bin/sh -c #(nop) ADD jessie.tar.xz in /                                                                                                                   121 MB
-    750d58736b4b6cc0f9a9abe8f258cef269e3e9dceced1146503522be9f985ada   6 weeks ago         /bin/sh -c #(nop) MAINTAINER Tianon Gravi <admwiggin@gmail.com> - mkimage-debootstrap.sh -t jessie.tar.xz jessie http://http.debian.net/debian             0 B
-    511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158   9 months ago                                                                                                                                                                   0 B
+    IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+    3e23a5875458        8 days ago          /bin/sh -c #(nop) ENV LC_ALL=C.UTF-8            0 B
+    8578938dd170        8 days ago          /bin/sh -c dpkg-reconfigure locales &&    loc   1.245 MB
+    be51b77efb42        8 days ago          /bin/sh -c apt-get update && apt-get install    338.3 MB
+    4b137612be55        6 weeks ago         /bin/sh -c #(nop) ADD jessie.tar.xz in /        121 MB
+    750d58736b4b        6 weeks ago         /bin/sh -c #(nop) MAINTAINER Tianon Gravi <ad   0 B
+    511136ea3c5a        9 months ago                                                        0 B                 Imported from -
+
+To see how the `docker:apache` image which was commited from a container:
+
+    $ sudo docker history docker:scm
+    IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+    2ac9d1098bf1        3 months ago        /bin/bash                                       241.4 MB            Added Apache to Fedora base image
+    88b42ffd1f7c        5 months ago        /bin/sh -c #(nop) ADD file:1fd8d7f9f6557cafc7   373.7 MB            
+    c69cab00d6ef        5 months ago        /bin/sh -c #(nop) MAINTAINER Lokesh Mandvekar   0 B                 
+    511136ea3c5a        19 months ago                                                       0 B                 Imported from -
+
 
 ## images
 

--- a/graph/history.go
+++ b/graph/history.go
@@ -36,6 +36,7 @@ func (s *TagStore) CmdHistory(job *engine.Job) engine.Status {
 		out.Set("CreatedBy", strings.Join(img.ContainerConfig.Cmd, " "))
 		out.SetList("Tags", lookupMap[img.ID])
 		out.SetInt64("Size", img.Size)
+		out.Set("Comment", img.Comment)
 		outs.Add(out)
 		return nil
 	})

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -81,4 +82,50 @@ func TestHistoryNonExistentImage(t *testing.T) {
 		t.Fatal("history on a non-existent image didn't result in a non-zero exit status")
 	}
 	logDone("history - history on non-existent image must fail")
+}
+
+func TestHistoryImageWithComment(t *testing.T) {
+
+	// make a image through docker commit <container id> [ -m messages ]
+	runCmd := exec.Command(dockerBinary, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
+	out, _, _, err := runCommandWithStdoutStderr(runCmd)
+	if err != nil {
+		t.Fatalf("failed to run container: %s, %v", out, err)
+	}
+
+	cleanedContainerID := stripTrailingCharacters(out)
+
+	waitCmd := exec.Command(dockerBinary, "wait", cleanedContainerID)
+	if _, _, err = runCommandWithOutput(waitCmd); err != nil {
+		t.Fatalf("error thrown while waiting for container: %s, %v", out, err)
+	}
+
+	commitCmd := exec.Command(dockerBinary, "commit", "-m=This is a comment", cleanedContainerID)
+	out, _, err = runCommandWithOutput(commitCmd)
+	if err != nil {
+		t.Fatalf("failed to commit container to image: %s, %v", out, err)
+	}
+
+	cleanedImageID := stripTrailingCharacters(out)
+	deleteContainer(cleanedContainerID)
+	defer deleteImages(cleanedImageID)
+
+	// test docker history <image id> to check comment messages
+	historyCmd := exec.Command(dockerBinary, "history", cleanedImageID)
+	out, exitCode, err := runCommandWithOutput(historyCmd)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("failed to get image history: %s, %v", out, err)
+	}
+
+	expectedValue := "This is a comment"
+
+	outputLine := strings.Split(out, "\n")[1]
+	outputTabs := regexp.MustCompile("  +").Split(outputLine, -1)
+	actualValue := outputTabs[len(outputTabs)-1]
+
+	if !strings.Contains(actualValue, expectedValue) {
+		t.Fatalf("Expected comments \"%s\", but found \"%s\"", expectedValue, actualValue)
+	}
+
+	logDone("history - history on image with comment")
 }


### PR DESCRIPTION
I added a new column COMMENT in output of <code>docker history</code> command to display messages would be submitted using <code>docker commit </code> command with <code>-m</code> parameter. This change will give an output like this:

```
./docker history 2ac9d1098bf1
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
2ac9d1098bf1        3 months ago        /bin/bash                                       241.4 MB            Add Git and SVN
88d178232033        3 months ago        /bin/bash                                       186 MB              Add JDK1.7
```

Messages submitted in  <code>docker commit </code> command are very important to me, and to other users I think, to trace image changes in Docker just like code changes in Git. So it is a very good feature, but I am also surprised of those messages are not displayed in <code>docker history</code> command output. This problem makes these messages make no sense. 

This PR is used to fetch these messages and display them into <code>docker history</code> command. Thanks for your appreciate.

Closes #9785
