### PR TITLE
Fix cli echoing container ID on start -a|-i

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -707,12 +707,12 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 	for _, name := range cmd.Args() {
 		_, _, err := readBody(cli.call("POST", "/containers/"+name+"/start", nil, false))
 		if err != nil {
-			if !*attach || !*openStdin {
+			if !*attach && !*openStdin {
 				fmt.Fprintf(cli.err, "%s\n", err)
 			}
 			encounteredError = fmt.Errorf("Error: failed to start one or more containers")
 		} else {
-			if !*attach || !*openStdin {
+			if !*attach && !*openStdin {
 				fmt.Fprintf(cli.out, "%s\n", name)
 			}
 		}


### PR DESCRIPTION
The cli now doesn't echo the container ID when started using either `-a` or `-i`.

Also fixes `TestStartAttachCorrectExitCode` which incorrectly called start with the output of wait (i.e.: the container exit code) rather than the container ID.
