### PR TITLE
Add a containerised test for the https cert doc

### DIFF
--- a/docs/sources/articles/https/Dockerfile
+++ b/docs/sources/articles/https/Dockerfile
@@ -1,0 +1,10 @@
+FROM debian
+
+RUN apt-get update && apt-get install -yq openssl
+
+ADD make_certs.sh /
+
+
+WORKDIR /data
+VOLUMES ["/data"]
+CMD /make_certs.sh

--- a/docs/sources/articles/https/Makefile
+++ b/docs/sources/articles/https/Makefile
@@ -1,0 +1,23 @@
+
+HOST:=boot2docker
+
+makescript:
+	./parsedocs.sh > make_certs.sh
+
+build: makescript
+	docker build -t makecerts .
+
+cert: build
+	docker run --rm -it -v $(CURDIR):/data -e HOST=$(HOST) makecerts
+
+certs: cert
+
+run:
+	docker -d -D --tlsverify --tlscacert=ca.pem --tlscert=server-cert.pem --tlskey=server-key.pem -H=0.0.0.0:6666 --pidfile=$(pwd)/docker.pid --graph=$(pwd)/graph
+
+client:
+	docker --tls --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem   -H=$(HOST):6666 version
+	docker --tlsverify --tlscacert=ca.pem --tlscert=cert.pem --tlskey=key.pem   -H=$(HOST):6666 info
+
+clean:
+	rm ca-key.pem ca.pem ca.srl cert.pem client.csr extfile.cnf key.pem server-cert.pem server-key.pem server.csr

--- a/docs/sources/articles/https/README.md
+++ b/docs/sources/articles/https/README.md
@@ -1,0 +1,26 @@
+
+
+This is an initial attempt to make it easier to test the examples in the https.md
+doc
+
+at this point, it has to be a manual thing, and I've been running it in boot2docker
+
+so my process is
+
+$ boot2docker ssh
+$$ git clone https://github.com/docker/docker
+$$ cd docker/docs/sources/articles/https
+$$ make cert
+lots of things to see and manually answer, as openssl wants to be interactive
+**NOTE:** make sure you enter the hostname (`boot2docker` in my case) when prompted for `Computer Name`)
+$$ sudo make run
+
+start another terminal
+
+$ boot2docker ssh
+$$ cd docker/docs/sources/articles/https
+$$ make client
+
+the last will connect first with `--tls` and then with `--tlsverify`
+
+both should succeed

--- a/docs/sources/articles/https/make_certs.sh
+++ b/docs/sources/articles/https/make_certs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+openssl genrsa -aes256 -out ca-key.pem 2048
+
+echo "enter your Docker daemon's hostname as the 'Common Name'= ($HOST)"
+
+#TODO add this as an ENV to docker run?
+openssl req -new -x509 -days 365 -key ca-key.pem -sha256 -out ca.pem
+
+
+# server cert
+openssl genrsa -out server-key.pem 2048
+openssl req -subj "/CN=$HOST" -new -key server-key.pem -out server.csr
+openssl x509 -req -days 365 -in server.csr -CA ca.pem -CAkey ca-key.pem \
+  -CAcreateserial -out server-cert.pem
+
+#client cert
+openssl genrsa -out key.pem 2048
+openssl req -subj '/CN=client' -new -key key.pem -out client.csr
+
+echo extendedKeyUsage = clientAuth > extfile.cnf
+openssl x509 -req -days 365 -in client.csr -CA ca.pem -CAkey ca-key.pem \
+  -CAcreateserial -out cert.pem -extfile extfile.cnf

--- a/docs/sources/articles/https/parsedocs.sh
+++ b/docs/sources/articles/https/parsedocs.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "#!/bin/sh"
+cat ../https.md | awk '{if (sub(/\\$/,"")) printf "%s", $0; else print $0}' | grep '   $ ' | sed 's/    $ //g' | sed 's/2375/7777/g' | sed 's/2376/7778/g'


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@docker.com (github: SvenDowideit)

some really really basic test harness for the https doc examples.

`make cert` fails when it gets to the `docker` lines, and then you use `make run` and make client` to test tls comms.

Ideally, we should have more than one Dockerfile - for different distros.
