### PR TITLE
Use container name as its hostname

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -515,11 +515,14 @@ func (daemon *Daemon) generateNewName(id string) (string, error) {
 	return name, nil
 }
 
-func (daemon *Daemon) generateHostname(id string, config *runconfig.Config) {
+func (daemon *Daemon) generateHostname(name string, config *runconfig.Config) {
 	// Generate default hostname
 	// FIXME: the lxc template no longer needs to set a default hostname
+	if name[0] == '/' {
+		name = name[1:]
+	}
 	if config.Hostname == "" {
-		config.Hostname = id[:12]
+		config.Hostname = name
 	}
 }
 
@@ -573,7 +576,7 @@ func (daemon *Daemon) newContainer(name string, config *runconfig.Config, imgID 
 		return nil, err
 	}
 
-	daemon.generateHostname(id, config)
+	daemon.generateHostname(name, config)
 	entrypoint, args := daemon.getEntrypointAndArgs(config.Entrypoint, config.Cmd)
 
 	container := &Container{


### PR DESCRIPTION
The randomly generated id in hex string is boring,
as we can generate a random name for the container,
why not use it as the hostname?

This is also supporting user specified name.

It is especially meaningful for those tasks which are tagged with hostname, like building linux kernel, got strings in /proc/version like (root@`920801690eff`), is awful; but with this change, next time when I build kernel inside the container, I can get a better signature in /proc/version like (root@my-building-box) ...

``` text
[drc@lab11 docker]$ bin/docker-1.4.1-dev-dirty run -i -t --rm --name 'my-building-box' --entrypoint=/bin/bash dche/fedora
bash-4.3# uname -a
Linux my-building-box 3.19.0-0.rc2.git0.1.build.20141231.el7.x86_64 #1 SMP Wed Dec 31 17:45:19 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
bash-4.3# cat /proc/version
Linux version 3.19.0-0.rc2.git0.1.build.20141231.el7.x86_64 (root@920801690eff) (gcc version 4.8.2 20140120 (Red Hat 4.8.2-16) (GCC) ) #1 SMP Wed Dec 31 17:45:19 UTC 2014
```

Signed-off-by: Derek Che drc@yahoo-inc.com
