### PR TITLE
restart: Fix the compare of restart policy

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -230,7 +230,7 @@ func (m *containerMonitor) shouldRestart(exitCode int) bool {
 		return true
 	case "on-failure":
 		// the default value of 0 for MaximumRetryCount means that we will not enforce a maximum count
-		if max := m.restartPolicy.MaximumRetryCount; max != 0 && m.failureCount >= max {
+		if max := m.restartPolicy.MaximumRetryCount; max != 0 && m.failureCount > max {
 			log.Debugf("stopping restart of container %s because maximum failure could of %d has been reached",
 				utils.TruncateID(m.container.ID), max)
 			return false


### PR DESCRIPTION
Fix #9923 

Since the failure count of container will increase by 1 every time it
exits successfully, the compare in function shouldRestart() will stop
container to restart by the last time.

Signed-off-by: Hu Keping hukeping@huawei.com
