### PR TITLE
Install lxc from source.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update && apt-get install -y \
 	libapparmor-dev \
 	libcap-dev \
 	libsqlite3-dev \
-	lxc=1.0* \
 	mercurial \
 	parallel \
 	python-mock \
@@ -61,6 +60,15 @@ RUN cd /usr/local/lvm2 \
 	&& make device-mapper \
 	&& make install_device-mapper
 # see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
+
+# Install lxc
+RUN mkdir -p /usr/src/lxc \
+	&& curl -sSL https://linuxcontainers.org/downloads/lxc/lxc-1.0.7.tar.gz | tar -v -C /usr/src/lxc/ -xz --strip-components=1
+RUN cd /usr/src/lxc \
+	&& ./configure \
+	&& make \
+	&& make install \
+	&& ldconfig
 
 # Install Go
 RUN curl -sSL https://golang.org/dl/go1.4.src.tar.gz | tar -v -C /usr/local -xz

--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -306,7 +306,7 @@ the client will even run on alternative platforms such as Mac OS X / Darwin.
 Some of Docker's features are activated by using optional command-line flags or
 by having support for them in the kernel or userspace. A few examples include:
 
-* LXC execution driver (requires version 1.0 or later of the LXC utility scripts)
+* LXC execution driver (requires version 1.0.7 or later of lxc and the lxc-libs)
 * AUFS graph driver (requires AUFS patches/support enabled in the kernel, and at
   least the "auplink" utility from aufs-tools)
 * BTRFS graph driver (requires BTRFS support enabled in the kernel)


### PR DESCRIPTION
Haters gunna hate, cache bust. But this fixes a bunch of tests.

Specifically the volumes tests of #9875:

```
- TestRunVolumesMountedAsReadonly (0.95s)
- TestRunVolumesFromInReadonlyMode (2.08s)
- TestRunVolumesFromInReadWriteMode (0.03s)
- TestVolumesFromGetsProperMode (0.02s)
- TestRunApplyVolumesFromBeforeVolumes (0.02s)
```

Improvement! Yayyyy!
After we get the CI, running in success we will know when we break things!

Also this way we can stay up with the latest lxc and hopefully there will be fixes for the other tests :)

ping @ashahab-altiscale
