### PR TITLE
Improve networking documentation with default mac address range

### DIFF
--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -12,7 +12,9 @@ private range defined by [RFC 1918](http://tools.ietf.org/html/rfc1918)
 that are not in use on the host machine, and assigns it to `docker0`.
 Docker made the choice `172.17.42.1/16` when I started it a few minutes
 ago, for example — a 16-bit netmask providing 65,534 addresses for the
-host machine and its containers.
+host machine and its containers. Mac address is generated from ip to 
+avoid arp collisions and uses a range from 02:42:ac:11:00:00 to 
+02:42:ac:11:ff:ff.
 
 > **Note:**
 > This document discusses advanced networking configuration

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -12,9 +12,9 @@ private range defined by [RFC 1918](http://tools.ietf.org/html/rfc1918)
 that are not in use on the host machine, and assigns it to `docker0`.
 Docker made the choice `172.17.42.1/16` when I started it a few minutes
 ago, for example — a 16-bit netmask providing 65,534 addresses for the
-host machine and its containers. Mac address is generated from ip to 
-avoid arp collisions and uses a range from 02:42:ac:11:00:00 to 
-02:42:ac:11:ff:ff.
+host machine and its containers. The MAC address is generated using the
+IP address allocated to the container to avoid ARP collisions, using a
+range from `02:42:ac:11:00:00` to `02:42:ac:11:ff:ff`.
 
 > **Note:**
 > This document discusses advanced networking configuration


### PR DESCRIPTION
Since we can control mac address with --mac-address it can be usefull to indicate which mac address is allocated by default for containers. 
Function that generate mac address is here : https://github.com/docker/docker/blob/master/daemon/networkdriver/bridge/driver.go#L342

Signed-off-by: Tangi COLIN tangicolin@gmail.com
