### PR TITLE
Add ProxyFromEnvironment enables client via proxy.

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -155,6 +155,7 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, key libtrust.PrivateKey,
 
 	// The transport is created here for reuse during the client session
 	tr := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: tlsConfig,
 	}
 


### PR DESCRIPTION
Enables `http.ProxyFromEnvironment` as done in `http.DefaultTransport`.
It allows a client to connect to a server through a proxy with `http_proxy` environment variables set
as described in the source code: https://golang.org/src/net/http/transport.go, line 34

Fixes #8751

Signed-off-by: Anders Janmyr anders@janmyr.com
