### PR TITLE
Update Ubuntu image tag to 14.04

### DIFF
--- a/docs/sources/examples/running_redis_service.md
+++ b/docs/sources/examples/running_redis_service.md
@@ -12,7 +12,7 @@ using a link.
 Firstly, we create a `Dockerfile` for our new Redis
 image.
 
-    FROM        ubuntu:12.10
+    FROM        ubuntu:14.04
     RUN         apt-get update && apt-get install -y redis-server
     EXPOSE      6379
     ENTRYPOINT  ["/usr/bin/redis-server"]
@@ -43,7 +43,7 @@ created with an alias of `db`. This will create a secure tunnel to the
 `redis` container and expose the Redis instance running inside that
 container to only this container.
 
-    $ sudo docker run --link redis:db -i -t ubuntu:12.10 /bin/bash
+    $ sudo docker run --link redis:db -i -t ubuntu:14.04 /bin/bash
 
 Once inside our freshly created container we need to install Redis to
 get the `redis-cli` binary to test our connection.


### PR DESCRIPTION
`apt-get update` for non-supported 12.10 doesn't work.
Building failed with

```
INFO[0011] The command [/bin/sh -c apt-get update && apt-get install -y redis-server] returned a non-zero code: 100
```

Signed-off-by: Evgeny Vereshchagin evvers@ya.ru
