### PR TITLE
Use the official mime type that exists instead of an imaginary one that does not.

### DIFF
--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -134,7 +134,7 @@ func (cli *DockerCli) hijack(method, path string, setRawTerminal bool, in io.Rea
 		return err
 	}
 	req.Header.Set("User-Agent", "Docker-Client/"+dockerversion.VERSION)
-	req.Header.Set("Content-Type", "plain/text")
+	req.Header.Set("Content-Type", "text/plain")
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", "tcp")
 	req.Host = cli.addr

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -89,7 +89,7 @@ func (cli *DockerCli) call(method, path string, data interface{}, passAuthInfo b
 	if data != nil {
 		req.Header.Set("Content-Type", "application/json")
 	} else if method == "POST" {
-		req.Header.Set("Content-Type", "plain/text")
+		req.Header.Set("Content-Type", "text/plain")
 	}
 	resp, err := cli.HTTPClient().Do(req)
 	if err != nil {
@@ -135,7 +135,7 @@ func (cli *DockerCli) streamHelper(method, path string, setRawTerminal bool, in 
 	req.URL.Host = cli.addr
 	req.URL.Scheme = cli.scheme
 	if method == "POST" {
-		req.Header.Set("Content-Type", "plain/text")
+		req.Header.Set("Content-Type", "text/plain")
 	}
 
 	if headers != nil {

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -1616,12 +1616,12 @@ This API is valid only if `tty` was specified as part of creating and starting t
 **Example request**:
 
         POST /exec/e90e34656806/resize HTTP/1.1
-        Content-Type: plain/text
+        Content-Type: text/plain
 
 **Example response**:
 
         HTTP/1.1 201 OK
-        Content-Type: plain/text
+        Content-Type: text/plain
 
 Query Parameters:
 


### PR DESCRIPTION
Fixes #9954 

I didn't add any unit tests for this change because I couldn't find any existing unit tests for either of the modified files and my understanding of the code being modified is not sufficiently great that I feel comfortable starting these test suites from scratch.

I did modify part of the API docs to apply this fix - but only in the two cases where it seemed likely relevant.  I left one other occurrence alone where the correct fix would **seem** to be a change to application/json or something similar.
