### PR TITLE
Make API docs v1.17 visible

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -113,6 +113,7 @@ pages:
 - ['reference/api/registry_api_client_libraries.md', 'Reference', 'Docker Registry API Client Libraries']
 - ['reference/api/hub_registry_spec.md', 'Reference', 'Docker Hub and Registry Spec']
 - ['reference/api/docker_remote_api.md', 'Reference', 'Docker Remote API']
+- ['reference/api/docker_remote_api_v1.17.md', 'Reference', 'Docker Remote API v1.17']
 - ['reference/api/docker_remote_api_v1.16.md', 'Reference', 'Docker Remote API v1.16']
 - ['reference/api/docker_remote_api_v1.15.md', 'Reference', 'Docker Remote API v1.15']
 - ['reference/api/docker_remote_api_v1.14.md', 'Reference', 'Docker Remote API v1.14']


### PR DESCRIPTION
w/o this one-liner the v1.17 docs didn't appear in the Reference dropdown
and I would get a 404 when I tried to access
.../reference/api/docker_remote_api_v1.17/

Not sure if there are other spots that need to be fixed but this seemed to
fix it for me.

Signed-off-by: Doug Davis dug@us.ibm.com
