### PR TITLE
log: Add restart policy name to the inspect information of container

### DIFF
--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -151,3 +151,72 @@ func TestRestartWithVolumes(t *testing.T) {
 
 	logDone("restart - does not create a new volume on restart")
 }
+
+func TestRecordRestartPolicyNO(t *testing.T) {
+	defer deleteAllContainers()
+
+	cmd := exec.Command(dockerBinary, "run", "-d", "--restart=no", "busybox", "false")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	id := strings.TrimSpace(string(out))
+	name, err := inspectField(id, "HostConfig.RestartPolicy.Name")
+	if err != nil {
+		t.Fatal(err, out)
+	}
+	if name != "no" {
+		t.Fatalf("Container restart policy name is %s, expected %s", name, "no")
+	}
+
+	logDone("restart - recording restart policy name for --restart=no")
+}
+
+func TestRecordRestartPolicyAlways(t *testing.T) {
+	defer deleteAllContainers()
+
+	cmd := exec.Command(dockerBinary, "run", "-d", "--restart=always", "busybox", "false")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	id := strings.TrimSpace(string(out))
+	name, err := inspectField(id, "HostConfig.RestartPolicy.Name")
+	if err != nil {
+		t.Fatal(err, out)
+	}
+	if name != "always" {
+		t.Fatalf("Container restart policy name is %s, expected %s", name, "always")
+	}
+
+	cmd = exec.Command(dockerBinary, "stop", id)
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	logDone("restart - recording restart policy name for --restart=always")
+}
+
+func TestRecordRestartPolicyOnFailure(t *testing.T) {
+	defer deleteAllContainers()
+
+	cmd := exec.Command(dockerBinary, "run", "-d", "--restart=on-failure:1", "busybox", "false")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	id := strings.TrimSpace(string(out))
+	name, err := inspectField(id, "HostConfig.RestartPolicy.Name")
+	if err != nil {
+		t.Fatal(err, out)
+	}
+	if name != "on-failure" {
+		t.Fatalf("Container restart policy name is %s, expected %s", name, "on-failure")
+	}
+
+	logDone("restart - recording restart policy name for --restart=on-failure")
+}

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -336,18 +336,15 @@ func parseRestartPolicy(policy string) (RestartPolicy, error) {
 		name  = parts[0]
 	)
 
+	p.Name = name
 	switch name {
 	case "always":
-		p.Name = name
-
 		if len(parts) == 2 {
 			return p, fmt.Errorf("maximum restart count not valid with restart policy of \"always\"")
 		}
 	case "no":
 		// do nothing
 	case "on-failure":
-		p.Name = name
-
 		if len(parts) == 2 {
 			count, err := strconv.Atoi(parts[1])
 			if err != nil {


### PR DESCRIPTION
Under the restart policy "--restart=no", there is no record about it
in the information from docker inspect.

To keep it consistent around the three(maybe more in the future) restart
policies and distinguish with no restart policy specified cases, it's
worth to record it even though it is the default restart policy which
will not restart the container.
## Example

case 1: no restart policy
"RestartPolicy": {
            "MaximumRetryCount": 0,
            "Name": ""
        },

case 2:--restart=on-failure:2
"RestartPolicy": {
            "MaximumRetryCount": 2,
            "Name": "on-failure"
        }

case3:--restart=always
"RestartPolicy": {
            "MaximumRetryCount": 0,
            "Name": "always"
        },

case4:--restart=no
"RestartPolicy": {
            "MaximumRetryCount": 0,
            "Name": ""
        },
