### PR TITLE
Remove BridgeIP from ipallocation pool

### DIFF
--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -171,6 +171,9 @@ func InitDriver(job *engine.Job) engine.Status {
 		}
 	}
 
+	// Block BridgeIP in IP allocator
+	ipallocator.RequestIP(bridgeNetwork, bridgeNetwork.IP)
+
 	// https://github.com/docker/docker/issues/2768
 	job.Eng.Hack_SetGlobalVar("httpapi.bridgeIP", bridgeNetwork.IP)
 

--- a/daemon/networkdriver/ipallocator/allocator.go
+++ b/daemon/networkdriver/ipallocator/allocator.go
@@ -121,7 +121,6 @@ func (allocated *allocatedMap) checkIP(ip net.IP) (net.IP, error) {
 
 	// Register the IP.
 	allocated.p[ip.String()] = struct{}{}
-	allocated.last.Set(pos)
 
 	return ip, nil
 }


### PR DESCRIPTION
Fixes #9938

The Bridge IP will be allocated during Docker network driver initialization.

Apart from that I have removed to update the next/last pointer in the ipallocation logic when a specific IP address is requested.
Currently when you request a specific IP address manually for container A, a container B that will be created afterwards will get the IP address of container A + 1.
With my changes in `daemon/networkdriver/ipallocator/allocator.go` container B will get the last automatically assigned IP address + 1.
