### PR TITLE
`docker ps --filter status=exited should not require passing -a`

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -45,6 +45,14 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 		}
 	}
 
+	if i, ok := psFilters["status"]; ok {
+		for _, value := range i {
+			if value == "exited" {
+				all = true
+			}
+		}
+	}
+
 	names := map[string][]string{}
 	daemon.ContainerGraph().Walk("/", func(p string, e *graphdb.Entity) error {
 		names[e.ID()] = append(names[e.ID()], p)

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -312,7 +312,7 @@ func TestPsListContainersFilterStatus(t *testing.T) {
 	secondID := stripTrailingCharacters(out)
 
 	// filter containers by exited
-	runCmd = exec.Command(dockerBinary, "ps", "-a", "-q", "--filter=status=exited")
+	runCmd = exec.Command(dockerBinary, "ps", "-q", "--filter=status=exited")
 	out, _, err = runCommandWithOutput(runCmd)
 	if err != nil {
 		t.Fatal(out, err)


### PR DESCRIPTION
I can't use filters.Match because this line https://github.com/docker/docker/blame/master/pkg/parsers/filters/parse.go#L72

Docker-DCO-1.1-Signed-off-by: Jessica Frazelle jess@docker.com (github: jfrazelle)
