### PR TITLE
FsMagic should avoid sign extension on i686

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -11,7 +11,7 @@ import (
 	"github.com/docker/docker/pkg/archive"
 )
 
-type FsMagic uint64
+type FsMagic uint32
 
 const (
 	FsMagicBtrfs = FsMagic(0x9123683E)


### PR DESCRIPTION
`uint64(buf.Type)` is `ffffffff9123683e` on i686 due to sign extension, so it is not equal to `FsMagic(0x9123683E)` and detection of `btrfs` using magic numbers always fails with `prerequisites not met` message
