### PR TITLE
Remove "-v" from "tar" usage in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN cd /usr/local/lvm2 \
 
 # Install lxc
 RUN mkdir -p /usr/src/lxc \
-	&& curl -sSL https://linuxcontainers.org/downloads/lxc/lxc-1.0.7.tar.gz | tar -v -C /usr/src/lxc/ -xz --strip-components=1
+	&& curl -sSL https://linuxcontainers.org/downloads/lxc/lxc-1.0.7.tar.gz | tar -C /usr/src/lxc/ -xz --strip-components=1
 RUN cd /usr/src/lxc \
 	&& ./configure \
 	&& make \
@@ -71,7 +71,7 @@ RUN cd /usr/src/lxc \
 	&& ldconfig
 
 # Install Go
-RUN curl -sSL https://golang.org/dl/go1.4.src.tar.gz | tar -v -C /usr/local -xz
+RUN curl -sSL https://golang.org/dl/go1.4.src.tar.gz | tar -C /usr/local -xz
 ENV PATH /usr/local/go/bin:$PATH
 ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 ENV PATH /go/bin:$PATH


### PR DESCRIPTION
It doesn't provide us any extra useful data, so it's just noise for us to be explicitly requesting this extra output.

I'm also thinking we should add/use `ENV`s like:

``` Dockerfile
ENV LXC_VERSION 1.0.7
```

This would especially make @jfrazelle's life easier in making Jenkins test multiple versions (since that's much easier to look for and replace than changing URLs directly).  Any maintainers have a strong opinion towards _not_ doing that? :smile:
