### PR TITLE
Refactor Dockerfile version number usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,9 @@ RUN cd /usr/local/lvm2 \
 # see https://git.fedorahosted.org/cgit/lvm2.git/tree/INSTALL
 
 # Install lxc
+ENV LXC_VERSION 1.0.7
 RUN mkdir -p /usr/src/lxc \
-	&& curl -sSL https://linuxcontainers.org/downloads/lxc/lxc-1.0.7.tar.gz | tar -v -C /usr/src/lxc/ -xz --strip-components=1
+	&& curl -sSL https://linuxcontainers.org/downloads/lxc/lxc-${LXC_VERSION}.tar.gz | tar -v -C /usr/src/lxc/ -xz --strip-components=1
 RUN cd /usr/src/lxc \
 	&& ./configure \
 	&& make \
@@ -71,10 +72,11 @@ RUN cd /usr/src/lxc \
 	&& ldconfig
 
 # Install Go
-RUN curl -sSL https://golang.org/dl/go1.4.src.tar.gz | tar -v -C /usr/local -xz
-ENV PATH /usr/local/go/bin:$PATH
+ENV GO_VERSION 1.4
+RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/local -xz \
+	&& mkdir -p /go/bin
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
-ENV PATH /go/bin:$PATH
 RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
 
 # Compile Go for cross compilation
@@ -94,7 +96,7 @@ RUN cd /usr/local/go/src \
 			./make.bash --no-clean 2>&1; \
 	done
 
-# reinstall standard library with netgo
+# Reinstall standard library with netgo
 RUN go clean -i net && go install -tags netgo std
 
 # Grab Go's cover tool for dead-simple code coverage testing


### PR DESCRIPTION
This refactors version number usage for several of our "download/install this exact version" bits so we have an easier time replacing the version numbers in Jenkins.

See also #9993 (which this is based on / includes).
