### PR TITLE
Clean up localhost resolv logic and add IPv6 support to regexp

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -434,7 +434,7 @@ func (daemon *Daemon) setupResolvconfWatcher() error {
 						log.Debugf("Error retrieving updated host resolv.conf: %v", err)
 					} else if updatedResolvConf != nil {
 						// because the new host resolv.conf might have localhost nameservers..
-						updatedResolvConf, modified := resolvconf.RemoveReplaceLocalDns(updatedResolvConf)
+						updatedResolvConf, modified := resolvconf.FilterResolvDns(updatedResolvConf, daemon.config.EnableIPv6)
 						if modified {
 							// changes have occurred during localhost cleanup: generate an updated hash
 							newHash, err := utils.HashData(bytes.NewReader(updatedResolvConf))

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1238,40 +1238,42 @@ func TestRunDisallowBindMountingRootToRoot(t *testing.T) {
 	logDone("run - bind mount /:/ as volume should fail")
 }
 
+// Verify that a container gets default DNS when only localhost resolvers exist
 func TestRunDnsDefaultOptions(t *testing.T) {
-	// ci server has default resolv.conf
-	// so rewrite it for the test
+
+	// preserve original resolv.conf for restoring after test
 	origResolvConf, err := ioutil.ReadFile("/etc/resolv.conf")
 	if os.IsNotExist(err) {
 		t.Fatalf("/etc/resolv.conf does not exist")
 	}
-
-	// test with file
-	tmpResolvConf := []byte("nameserver 127.0.0.1")
-	if err := ioutil.WriteFile("/etc/resolv.conf", tmpResolvConf, 0644); err != nil {
-		t.Fatal(err)
-	}
-	// put the old resolvconf back
+	// defer restored original conf
 	defer func() {
 		if err := ioutil.WriteFile("/etc/resolv.conf", origResolvConf, 0644); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
+	// test 3 cases: standard IPv4 localhost, commented out localhost, and IPv6 localhost
+	// 2 are removed from the file at container start, and the 3rd (commented out) one is ignored by
+	// GetNameservers(), leading to a replacement of nameservers with the default set
+	tmpResolvConf := []byte("nameserver 127.0.0.1\n#nameserver 127.0.2.1\nnameserver ::1")
+	if err := ioutil.WriteFile("/etc/resolv.conf", tmpResolvConf, 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	cmd := exec.Command(dockerBinary, "run", "busybox", "cat", "/etc/resolv.conf")
 
 	actual, _, err := runCommandWithOutput(cmd)
 	if err != nil {
-		t.Error(err, actual)
-		return
+		t.Fatal(err, actual)
 	}
 
-	// check that the actual defaults are there
-	// if we ever change the defaults from google dns, this will break
-	expected := "\nnameserver 8.8.8.8\nnameserver 8.8.4.4"
+	// check that the actual defaults are appended to the commented out
+	// localhost resolver (which should be preserved)
+	// NOTE: if we ever change the defaults from google dns, this will break
+	expected := "#nameserver 127.0.2.1\n\nnameserver 8.8.8.8\nnameserver 8.8.4.4"
 	if actual != expected {
-		t.Errorf("expected resolv.conf be: %q, but was: %q", expected, actual)
-		return
+		t.Fatalf("expected resolv.conf be: %q, but was: %q", expected, actual)
 	}
 
 	deleteAllContainers()

--- a/pkg/networkfs/resolvconf/resolvconf_test.go
+++ b/pkg/networkfs/resolvconf/resolvconf_test.go
@@ -157,33 +157,82 @@ func TestBuildWithZeroLengthDomainSearch(t *testing.T) {
 	}
 }
 
-func TestRemoveReplaceLocalDns(t *testing.T) {
+func TestFilterResolvDns(t *testing.T) {
 	ns0 := "nameserver 10.16.60.14\nnameserver 10.16.60.21\n"
 
-	if result, _ := RemoveReplaceLocalDns([]byte(ns0)); result != nil {
+	if result, _ := FilterResolvDns([]byte(ns0), false); result != nil {
 		if ns0 != string(result) {
 			t.Fatalf("Failed No Localhost: expected \n<%s> got \n<%s>", ns0, string(result))
 		}
 	}
 
 	ns1 := "nameserver 10.16.60.14\nnameserver 10.16.60.21\nnameserver 127.0.0.1\n"
-	if result, _ := RemoveReplaceLocalDns([]byte(ns1)); result != nil {
+	if result, _ := FilterResolvDns([]byte(ns1), false); result != nil {
 		if ns0 != string(result) {
 			t.Fatalf("Failed Localhost: expected \n<%s> got \n<%s>", ns0, string(result))
 		}
 	}
 
 	ns1 = "nameserver 10.16.60.14\nnameserver 127.0.0.1\nnameserver 10.16.60.21\n"
-	if result, _ := RemoveReplaceLocalDns([]byte(ns1)); result != nil {
+	if result, _ := FilterResolvDns([]byte(ns1), false); result != nil {
 		if ns0 != string(result) {
 			t.Fatalf("Failed Localhost: expected \n<%s> got \n<%s>", ns0, string(result))
 		}
 	}
 
 	ns1 = "nameserver 127.0.1.1\nnameserver 10.16.60.14\nnameserver 10.16.60.21\n"
-	if result, _ := RemoveReplaceLocalDns([]byte(ns1)); result != nil {
+	if result, _ := FilterResolvDns([]byte(ns1), false); result != nil {
 		if ns0 != string(result) {
 			t.Fatalf("Failed Localhost: expected \n<%s> got \n<%s>", ns0, string(result))
+		}
+	}
+
+	ns1 = "nameserver ::1\nnameserver 10.16.60.14\nnameserver 127.0.2.1\nnameserver 10.16.60.21\n"
+	if result, _ := FilterResolvDns([]byte(ns1), false); result != nil {
+		if ns0 != string(result) {
+			t.Fatalf("Failed Localhost: expected \n<%s> got \n<%s>", ns0, string(result))
+		}
+	}
+
+	ns1 = "nameserver 10.16.60.14\nnameserver ::1\nnameserver 10.16.60.21\nnameserver ::1"
+	if result, _ := FilterResolvDns([]byte(ns1), false); result != nil {
+		if ns0 != string(result) {
+			t.Fatalf("Failed Localhost: expected \n<%s> got \n<%s>", ns0, string(result))
+		}
+	}
+
+	// with IPv6 disabled (false param), the IPv6 nameserver should be removed
+	ns1 = "nameserver 10.16.60.14\nnameserver 2002:dead:beef::1\nnameserver 10.16.60.21\nnameserver ::1"
+	if result, _ := FilterResolvDns([]byte(ns1), false); result != nil {
+		if ns0 != string(result) {
+			t.Fatalf("Failed Localhost+IPv6 off: expected \n<%s> got \n<%s>", ns0, string(result))
+		}
+	}
+
+	// with IPv6 enabled, the IPv6 nameserver should be preserved
+	ns0 = "nameserver 10.16.60.14\nnameserver 2002:dead:beef::1\nnameserver 10.16.60.21\n"
+	ns1 = "nameserver 10.16.60.14\nnameserver 2002:dead:beef::1\nnameserver 10.16.60.21\nnameserver ::1"
+	if result, _ := FilterResolvDns([]byte(ns1), true); result != nil {
+		if ns0 != string(result) {
+			t.Fatalf("Failed Localhost+IPv6 on: expected \n<%s> got \n<%s>", ns0, string(result))
+		}
+	}
+
+	// with IPv6 enabled, and no non-localhost servers, Google defaults (both IPv4+IPv6) should be added
+	ns0 = "\nnameserver 8.8.8.8\nnameserver 8.8.4.4\nnameserver 2001:4860:4860::8888\nnameserver 2001:4860:4860::8844"
+	ns1 = "nameserver 127.0.0.1\nnameserver ::1\nnameserver 127.0.2.1"
+	if result, _ := FilterResolvDns([]byte(ns1), true); result != nil {
+		if ns0 != string(result) {
+			t.Fatalf("Failed no Localhost+IPv6 enabled: expected \n<%s> got \n<%s>", ns0, string(result))
+		}
+	}
+
+	// with IPv6 disabled, and no non-localhost servers, Google defaults (only IPv4) should be added
+	ns0 = "\nnameserver 8.8.8.8\nnameserver 8.8.4.4"
+	ns1 = "nameserver 127.0.0.1\nnameserver ::1\nnameserver 127.0.2.1"
+	if result, _ := FilterResolvDns([]byte(ns1), false); result != nil {
+		if ns0 != string(result) {
+			t.Fatalf("Failed no Localhost+IPv6 enabled: expected \n<%s> got \n<%s>", ns0, string(result))
 		}
 	}
 }


### PR DESCRIPTION
Addresses #5811

This cleans up an error in the logic which removes localhost resolvers
from the host resolv.conf at container creation start time. Specifically
when the determination is made if any nameservers are left after
removing localhost resolvers, it was using a string match on the word
"nameserver", which could have been anywhere (including commented out)
leading to incorrect situations where no nameservers were left but the
default ones were not added.

This also adds some complexity to the regular expressions for finding
nameservers in general, as well as matching on localhost resolvers due
to the recent addition of IPv6 support.  Because of IPv6 support now
available in the Docker daemon, the resolvconf code is now aware of
IPv6 enable/disable state and uses that for both filter/cleaning of
nameservers as well as adding default Google DNS (IPv4 only vs. IPv4
and IPv6 if IPv6 enabled).  For all these changes, tests have been
added/strengthened to test these additional capabilities.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
