### PR TITLE
Fix docker run/create not printing error messages

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2164,7 +2164,7 @@ func (cli *DockerCli) CmdCreate(args ...string) error {
 
 	config, hostConfig, cmd, err := runconfig.Parse(cmd, args)
 	if err != nil {
-		return &utils.StatusError{StatusCode: 1}
+		utils.ReportError(cmd, err.Error(), true)
 	}
 	if config.Image == "" {
 		cmd.Usage()
@@ -2201,7 +2201,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 	config, hostConfig, cmd, err := runconfig.Parse(cmd, args)
 	// just in case the Parse does not exit
 	if err != nil {
-		return &utils.StatusError{StatusCode: 1}
+		utils.ReportError(cmd, err.Error(), true)
 	}
 	if config.Image == "" {
 		cmd.Usage()

--- a/utils/flags.go
+++ b/utils/flags.go
@@ -27,15 +27,19 @@ func ParseFlags(cmd *flag.FlagSet, args []string, withHelp bool) error {
 		os.Exit(0)
 	}
 	if str := cmd.CheckArgs(); str != "" {
-		if withHelp {
-			if os.Args[0] == cmd.Name() {
-				str += ". See '" + os.Args[0] + " --help'"
-			} else {
-				str += ". See '" + os.Args[0] + " " + cmd.Name() + " --help'"
-			}
-		}
-		fmt.Fprintf(cmd.Out(), "docker: %s.\n", str)
-		os.Exit(1)
+		ReportError(cmd, str, withHelp)
 	}
 	return nil
+}
+
+func ReportError(cmd *flag.FlagSet, str string, withHelp bool) {
+	if withHelp {
+		if os.Args[0] == cmd.Name() {
+			str += ". See '" + os.Args[0] + " --help'"
+		} else {
+			str += ". See '" + os.Args[0] + " " + cmd.Name() + " --help'"
+		}
+	}
+	fmt.Fprintf(cmd.Out(), "docker: %s.\n", str)
+	os.Exit(1)
 }


### PR DESCRIPTION
If an error happens while parsing docker run or docker create, the error message is not being printed out.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
