### PR TITLE
Fix a few minor issues with building/running inside msysGit

### DIFF
--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"runtime"
 )
 
 var (
@@ -26,28 +25,15 @@ var (
 	workingDirectory string
 )
 
-func binarySearchCommand() *exec.Cmd {
-	if runtime.GOOS == "windows" {
-		// Windows where.exe is included since Windows Server 2003. It accepts
-		// wildcards, which we use here to match the development builds binary
-		// names (such as docker-$VERSION.exe).
-		return exec.Command("where.exe", "docker*.exe")
-	}
-	return exec.Command("which", "docker")
-}
-
 func init() {
 	if dockerBin := os.Getenv("DOCKER_BINARY"); dockerBin != "" {
 		dockerBinary = dockerBin
-	} else {
-		whichCmd := binarySearchCommand()
-		out, _, err := runCommandWithOutput(whichCmd)
-		if err == nil {
-			dockerBinary = stripTrailingCharacters(out)
-		} else {
-			fmt.Printf("ERROR: couldn't resolve full path to the Docker binary (%v)", err)
-			os.Exit(1)
-		}
+	}
+	var err error
+	dockerBinary, err = exec.LookPath(dockerBinary)
+	if err != nil {
+		fmt.Printf("ERROR: couldn't resolve full path to the Docker binary (%v)", err)
+		os.Exit(1)
 	}
 	if registryImage := os.Getenv("REGISTRY_IMAGE"); registryImage != "" {
 		registryImageName = registryImage

--- a/project/make.sh
+++ b/project/make.sh
@@ -178,21 +178,28 @@ go_test_dir() {
 	)
 }
 
+# a helper to provide ".exe" when it's appropriate
+binary_extension() {
+	if [ "$(go env GOOS)" = 'windows' ]; then
+		echo -n '.exe'
+	fi
+}
+
 # This helper function walks the current directory looking for directories
 # holding certain files ($1 parameter), and prints their paths on standard
 # output, one per line.
 find_dirs() {
 	find . -not \( \
 		\( \
-			-wholename './vendor' \
-			-o -wholename './integration' \
-			-o -wholename './integration-cli' \
-			-o -wholename './contrib' \
-			-o -wholename './pkg/mflag/example' \
-			-o -wholename './.git' \
-			-o -wholename './bundles' \
-			-o -wholename './docs' \
-			-o -wholename './pkg/libcontainer/nsinit' \
+			-path './vendor/*' \
+			-o -path './integration/*' \
+			-o -path './integration-cli/*' \
+			-o -path './contrib/*' \
+			-o -path './pkg/mflag/example/*' \
+			-o -path './.git/*' \
+			-o -path './bundles/*' \
+			-o -path './docs/*' \
+			-o -path './pkg/libcontainer/nsinit/*' \
 		\) \
 		-prune \
 	\) -name "$1" -print0 | xargs -0n1 dirname | sort -u

--- a/project/make/.go-compile-test-dir
+++ b/project/make/.go-compile-test-dir
@@ -4,7 +4,13 @@ set -e
 # Compile phase run by parallel in test-unit. No support for coverpkg
 
 dir=$1
+in_file="$dir/$(basename "$dir").test"
 out_file="$DEST/precompiled/$dir.test"
+# we want to use binary_extension() here, but we can't because it's in main.sh and this file gets re-execed
+if [ "$(go env GOOS)" = 'windows' ]; then
+	in_file+='.exe'
+	out_file+='.exe'
+fi
 testcover=()
 if [ "$HAVE_GO_TEST_COVER" ]; then
 	# if our current go install has -cover, we want to use it :)
@@ -16,11 +22,14 @@ fi
 if [ "$BUILDFLAGS_FILE" ]; then
 	readarray -t BUILDFLAGS < "$BUILDFLAGS_FILE"
 fi
-(
+
+if ! (
 	cd "$dir"
 	go test "${testcover[@]}" -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}" $TESTFLAGS -c
-)
-[ $? -ne 0 ] && return 1
+); then
+	exit 1
+fi
+
 mkdir -p "$(dirname "$out_file")"
-mv "$dir/$(basename "$dir").test" "$out_file"
+mv "$in_file" "$out_file"
 echo "Precompiled: ${DOCKER_PKG}${dir#.}"

--- a/project/make/.integration-daemon-stop
+++ b/project/make/.integration-daemon-stop
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-for pid in $(find "$DEST" -name docker.pid); do
-	DOCKER_PID=$(set -x; cat "$pid")
-	( set -x; kill $DOCKER_PID )
-	wait $DOCKERD_PID || true
+for pidFile in $(find "$DEST" -name docker.pid); do
+	pid=$(set -x; cat "$pidFile")
+	( set -x; kill $pid )
+	if ! wait $pid; then
+		echo >&2 "warning: PID $pid from $pidFile had a nonzero exit code"
+	fi
 done

--- a/project/make/binary
+++ b/project/make/binary
@@ -3,10 +3,7 @@ set -e
 
 DEST=$1
 BINARY_NAME="docker-$VERSION"
-BINARY_EXTENSION=
-if [ "$(go env GOOS)" = 'windows' ]; then
-	BINARY_EXTENSION='.exe'
-fi
+BINARY_EXTENSION="$(binary_extension)"
 BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
 
 # Cygdrive paths don't play well with go build -o.

--- a/project/make/test-docker-py
+++ b/project/make/test-docker-py
@@ -4,7 +4,6 @@ set -e
 DEST=$1
 
 # subshell so that we can export PATH without breaking other things
-exec > >(tee -a $DEST/test.log) 2>&1
 (
 	source "$(dirname "$BASH_SOURCE")/.integration-daemon-start"
 
@@ -19,4 +18,4 @@ exec > >(tee -a $DEST/test.log) 2>&1
 	python tests/integration_test.py
 
 	source "$(dirname "$BASH_SOURCE")/.integration-daemon-stop"
-)
+) 2>&1 | tee -a $DEST/test.log

--- a/project/make/test-integration
+++ b/project/make/test-integration
@@ -10,6 +10,6 @@ bundle_test_integration() {
 
 # this "grep" hides some really irritating warnings that "go test -coverpkg"
 # spews when it is given packages that aren't used
-exec > >(tee -a $DEST/test.log) 2>&1
 bundle_test_integration 2>&1 \
-	| grep --line-buffered -v '^warning: no packages being tested depend on '
+	| grep --line-buffered -v '^warning: no packages being tested depend on ' \
+	| tee -a $DEST/test.log

--- a/project/make/test-integration-cli
+++ b/project/make/test-integration-cli
@@ -8,7 +8,6 @@ bundle_test_integration_cli() {
 }
 
 # subshell so that we can export PATH without breaking other things
-exec > >(tee -a $DEST/test.log) 2>&1
 (
 	source "$(dirname "$BASH_SOURCE")/.integration-daemon-start"
 
@@ -20,4 +19,4 @@ exec > >(tee -a $DEST/test.log) 2>&1
 	bundle_test_integration_cli
 
 	source "$(dirname "$BASH_SOURCE")/.integration-daemon-stop"
-)
+) 2>&1 | tee -a $DEST/test.log

--- a/project/make/test-unit
+++ b/project/make/test-unit
@@ -2,7 +2,7 @@
 set -e
 
 DEST=$1
-: ${PARALLEL_JOBS:=$(nproc)}
+: ${PARALLEL_JOBS:=$(nproc 2>/dev/null || echo 1)} # if nproc fails (usually because we don't have it), let's not parallelize by default
 
 RED=$'\033[31m'
 GREEN=$'\033[32m'
@@ -38,12 +38,13 @@ bundle_test_unit() {
 				export BUILDFLAGS_FILE="$HOME/buildflags_file"
 				( IFS=$'\n'; echo "${BUILDFLAGS[*]}" ) > "$BUILDFLAGS_FILE"
 
-				echo "$TESTDIRS" | parallel --jobs "$PARALLEL_JOBS" --halt 2 --env _ "$(dirname "$BASH_SOURCE")/.go-compile-test-dir"
+				echo "$TESTDIRS" | parallel --jobs "$PARALLEL_JOBS" --env _ "$(dirname "$BASH_SOURCE")/.go-compile-test-dir"
 				rm -rf "$HOME"
 			else
 				# aww, no "parallel" available - fall back to boring
 				for test_dir in $TESTDIRS; do
-					"$(dirname "$BASH_SOURCE")/.go-compile-test-dir" "$test_dir"
+					"$(dirname "$BASH_SOURCE")/.go-compile-test-dir" "$test_dir" || true
+					# don't let one directory that fails to build tank _all_ our tests!
 				done
 			fi
 		)
@@ -56,7 +57,7 @@ go_run_test_dir() {
 	while read dir; do
 		echo
 		echo '+ go test' $TESTFLAGS "${DOCKER_PKG}${dir#.}"
-		precompiled="$DEST/precompiled/$dir.test"
+		precompiled="$DEST/precompiled/$dir.test$(binary_extension)"
 		if ! ( cd "$dir" && "$precompiled" $TESTFLAGS ); then
 			TESTS_FAILED+=("$dir")
 			echo
@@ -82,5 +83,4 @@ go_run_test_dir() {
 	fi
 }
 
-exec > >(tee -a $DEST/test.log) 2>&1
-bundle_test_unit
+bundle_test_unit 2>&1 | tee -a $DEST/test.log

--- a/project/make/tgz
+++ b/project/make/tgz
@@ -14,10 +14,7 @@ for d in "$CROSS/"*/*; do
 	GOARCH="$(basename "$d")"
 	GOOS="$(basename "$(dirname "$d")")"
 	BINARY_NAME="docker-$VERSION"
-	BINARY_EXTENSION=
-	if [ "$GOOS" = 'windows' ]; then
-		BINARY_EXTENSION='.exe'
-	fi
+	BINARY_EXTENSION="$(binary_extension)"
 	BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
 	mkdir -p "$DEST/$GOOS/$GOARCH"
 	TGZ="$DEST/$GOOS/$GOARCH/$BINARY_NAME.tgz"


### PR DESCRIPTION
``` console
$ project/make.sh binary test-integration-cli
# WARNING! I don't seem to be running in the Docker container.
# The result of this command might be an incorrect build, and will not be
#   officially supported.
#
# Try this instead: make all
#

---> Making bundle: binary (in bundles/1.4.1-dev/binary)
Created binary: /c/Jenkins/gopath/src/github.com/docker/docker/bundles/1.4.1-dev/binary/docker-1.4.1-dev.exe

---> Making bundle: test-integration-cli (in bundles/1.4.1-dev/test-integration-cli)
/c/Jenkins/gopath/src/github.com/docker/docker/project/make/test-integration-cli: cannot make pipe for process substitution: Function not implemented
/c/Jenkins/gopath/src/github.com/docker/docker/project/make/test-integration-cli: cannot make pipe for process substitution: Function not implemented
/c/Jenkins/gopath/src/github.com/docker/docker/project/make/test-integration-cli: line 11: >(tee -a $DEST/test.log): ambiguous redirect
```

![](https://i.ytimg.com/vi/tD6Ek33AfWA/hqdefault.jpg)
