### PR TITLE
Properly handle containers which pre-date the resolv.conf update feature

### DIFF
--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -201,6 +201,13 @@ If the options (`--dns` or `--dns-search`) have been used to modify the
 default host configuration, then the replacement with an updated host's
 `/etc/resolv.conf` will not happen as well.
 
+> **Note**:
+> For containers which were created prior to the implementation of
+> the `/etc/resolv.conf` update feature in Docker 1.5.0: those
+> containers will **not** receive updates when the host `resolv.conf`
+> file changes. Only containers created with Docker 1.5.0 and above
+> will utilize this auto-update feature.
+
 ## Communication between containers and the wider world
 
 <a name="the-world"></a>


### PR DESCRIPTION
This fixes the container start issue for containers which were started
on a daemon prior to the resolv.conf updater PR. The update code will
now safely ignore these containers (given they don't have a sha256 hash
to compare against) and will not attempt to update the resolv.conf
through their lifetime.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
