### PR TITLE
Ignore more packages for arch-based images

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -18,7 +18,7 @@ ROOTFS=$(mktemp -d ${TMPDIR:-/var/tmp}/rootfs-archlinux-XXXXXXXXXX)
 chmod 755 $ROOTFS
 
 # packages to ignore for space savings
-PKGIGNORE=linux,jfsutils,lvm2,cryptsetup,groff,man-db,man-pages,mdadm,pciutils,pcmciautils,reiserfsprogs,s-nail,xfsprogs
+PKGIGNORE=linux,jfsutils,licenses,lvm2,cryptsetup,device-mapper,groff,man-db,man-pages,mdadm,nano,netctl,pciutils,pcmciautils,reiserfsprogs,systemd-sysvcompat,s-nail,tar,usbutils,vi,xfsprogs
 
 expect <<EOF
 	set send_slow {1 .1}

--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -61,5 +61,6 @@ mknod -m 666 $DEV/ptmx c 5 2
 ln -sf /proc/self/fd $DEV/fd
 
 tar --numeric-owner --xattrs --acls -C $ROOTFS -c . | docker import - archlinux
-docker run -i -t archlinux echo Success.
+docker run -i --name archlinux -t archlinux echo Success.
+docker rm archlinux
 rm -rf $ROOTFS


### PR DESCRIPTION
contrib/mkimage-arch.sh now also ignores the packages nano,vi,tar, and
licenses.
These don't belong in a container that is minimal (as arch is).
