### PR TITLE
change API verison check to NotEqual

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1222,7 +1222,7 @@ func makeHttpHandler(eng *engine.Engine, logging bool, localMethod string, local
 			writeCorsHeaders(w, r)
 		}
 
-		if version.GreaterThan(api.APIVERSION) {
+		if version.NotEqual(api.APIVERSION) {
 			http.Error(w, fmt.Errorf("client and server don't have same version (client : %s, server: %s)", version, api.APIVERSION).Error(), http.StatusNotFound)
 			return
 		}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -61,3 +61,8 @@ func (v Version) GreaterThanOrEqualTo(other Version) bool {
 func (v Version) Equal(other Version) bool {
 	return v.compareTo(other) == 0
 }
+
+// NotEqual checks if a version is not equal to another
+func (v Version) NotEqual(other Version) bool {
+	return v.compareTo(other) != 0
+}


### PR DESCRIPTION
Usually docker server should support backward compatibility,
but that is not guaranteed, we should let user always use
the same version of docker from server to client.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
