### PR TITLE
devmapper: remove newline string

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1424,7 +1424,7 @@ func (devices *DeviceSet) UnmountDevice(hash string) error {
 	defer devices.Unlock()
 
 	if info.mountCount == 0 {
-		return fmt.Errorf("UnmountDevice: device not-mounted id %s\n", hash)
+		return fmt.Errorf("UnmountDevice: device not-mounted id %s", hash)
 	}
 
 	info.mountCount--


### PR DESCRIPTION
Simple nit, of an unneeded `\n` string.

Ping @tiborvass @unclejack @LK4D4 

Signed-off-by: Vincent Batts vbatts@redhat.com
