### PR TITLE
Proposal: Flag to persist dynamically allocated ports across restarts

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -632,6 +632,7 @@ _docker_run() {
 		--privileged
 		--publish-all -P
 		--tty -t
+		--persist-ports
 	"
 
 	[ "$command" = "run" ] && all_options="$all_options

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -394,6 +394,7 @@ __docker_subcommand () {
                 '--net=-[Network mode]:network mode:(bridge none container: host)' \
                 {-P,--publish-all}'[Publish all exposed ports]' \
                 '*'{-p,--publish=-}'[Expose a container'"'"'s port to the host]:port:_ports' \
+                '--persist-ports[Persist published ports so that they remain the same]' \
                 '--privileged[Give extended privileges to this container]' \
                 '--restart=-[Restart policy]:restart policy:(no on-failure always)' \
                 '--rm[Remove intermediate containers when it exits]' \

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -542,6 +542,9 @@ func (container *Container) AllocateNetwork() error {
 			return err
 		}
 	}
+	if container.hostConfig.PersistPorts {
+		container.hostConfig.PortBindings = bindings
+	}
 	container.WriteHostConfig()
 
 	container.NetworkSettings.Ports = bindings

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -478,7 +478,7 @@ func (container *Container) buildHostnameAndHostsFiles(IP string) error {
 
 func (container *Container) AllocateNetwork() error {
 	mode := container.hostConfig.NetworkMode
-	if container.Config.NetworkDisabled || !mode.IsPrivate() {
+	if container.isNetworkAllocated() || container.Config.NetworkDisabled || !mode.IsPrivate() {
 		return nil
 	}
 
@@ -1430,4 +1430,23 @@ func (container *Container) getNetworkedContainer() (*Container, error) {
 
 func (container *Container) Stats() (*execdriver.ResourceStats, error) {
 	return container.daemon.Stats(container)
+}
+
+func (container *Container) hasHostConfigHostPort() bool {
+	if container.hostConfig == nil || container.hostConfig.PortBindings == nil {
+		return false
+	}
+	for _, b := range container.hostConfig.PortBindings {
+		for _, bb := range b {
+			if bb.HostPort != "" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (container *Container) policyShouldRestart() bool {
+	return container.hostConfig.RestartPolicy.Name == "always" ||
+		(container.hostConfig.RestartPolicy.Name == "on-failure" && container.ExitCode != 0)
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -393,9 +393,23 @@ func (daemon *Daemon) restore() error {
 	if daemon.config.AutoRestart {
 		log.Debugf("Restarting containers...")
 
+		// Preinitalize network in containers with explicit host ports in
+		// hostConfig. This will prevent the allocator from using these ports
+		// when starting containers with dynamic allocated ports.
 		for _, container := range registeredContainers {
-			if container.hostConfig.RestartPolicy.Name == "always" ||
-				(container.hostConfig.RestartPolicy.Name == "on-failure" && container.ExitCode != 0) {
+			if !container.policyShouldRestart() {
+				continue
+			}
+			if !container.hasHostConfigHostPort() {
+				continue
+			}
+			if err := container.initializeNetworking(); err != nil {
+				log.Debugf("Failed to preinitialize container network %s: %s", container.ID, err)
+			}
+		}
+
+		for _, container := range registeredContainers {
+			if container.policyShouldRestart() {
 				log.Debugf("Starting container %s", container.ID)
 
 				if err := container.Start(); err != nil {

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -32,6 +32,7 @@ docker-create - Create a new container
 [**--net**[=*"bridge"*]]
 [**-P**|**--publish-all**[=*false*]]
 [**-p**|**--publish**[=*[]*]]
+[**--persist-ports**[=*false*]]
 [**--pid**[=*[]*]]
 [**--privileged**[=*false*]]
 [**--read-only**[=*false*]]
@@ -132,6 +133,9 @@ IMAGE [COMMAND] [ARG...]
                                Both hostPort and containerPort can be specified as a range of ports. 
                                When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range. (e.g., `-p 1234-1236:1234-1236/tcp`)
                                (use 'docker port' to see the actual mapping)
+
+**--persist-ports**=*true*|*false*
+   Persist published host ports that were dynamically allocated so that they remain the same even after restarting the container.
 
 **--pid**=host
    Set the PID mode for the container

--- a/docs/man/docker-inspect.1.md
+++ b/docs/man/docker-inspect.1.md
@@ -124,7 +124,8 @@ To get information on a container use it's ID or instance name:
             "DriverOptions": {
                 "lxc": null
             },
-            "CliAddress": ""
+            "CliAddress": "",
+            "PersistPorts": false
         }
 
 ## Getting the IP address of a container instance

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -34,6 +34,7 @@ docker-run - Run a command in a new container
 [**--net**[=*"bridge"*]]
 [**-P**|**--publish-all**[=*false*]]
 [**-p**|**--publish**[=*[]*]]
+[**--persist-ports**[=*false*]]
 [**--pid**[=*[]*]]
 [**--privileged**[=*false*]]
 [**--read-only**[=*false*]]
@@ -241,6 +242,9 @@ mapping between the host ports and the exposed ports, use **docker port**.
                                Both hostPort and containerPort can be specified as a range of ports. 
                                When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range. (e.g., `-p 1234-1236:1234-1236/tcp`)
                                (use 'docker port' to see the actual mapping)
+
+**--persist-ports**=*true*|*false*
+   Persist published host ports that were dynamically allocated so that they remain the same even after restarting the container.
 
 **--pid**=host
    Set the PID mode for the container

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -121,6 +121,9 @@ Finally, several networking options can only be provided when calling
  *  `-P` or `--publish-all=true|false` — see
     [Binding container ports](#binding-ports)
 
+ *  `--persist-ports=true|false` — see
+    [Binding container ports](#binding-ports)
+
 The following sections tackle all of the above topics in an order that
 moves roughly from simplest to most complex.
 
@@ -374,6 +377,11 @@ More convenient is the `-p SPEC` or `--publish=SPEC` option which lets
 you be explicit about exactly which external port on the Docker server —
 which can be any port at all, not just those in the 49153-65535 block —
 you want mapped to which port in the container.
+
+You can also provide the `--persist-ports=true|false` option. This will
+cause dynamically allocated ports in the 49153-65535 range to be
+preserved across container restarts. If this flag is not provided, each
+time the container starts a new port will be allocated.
 
 Either way, you should be able to peek at what Docker has accomplished
 in your network stack by examining your NAT tables.

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -155,7 +155,8 @@ Create a container
                "CapDrop": ["MKNOD"],
                "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
                "NetworkMode": "bridge",
-               "Devices": []
+               "Devices": [],
+               "PersistPorts": false
             }
         }
 
@@ -218,6 +219,8 @@ Json Parameters:
         Take note that `port` is specified as a string and not an integer value.
   -   **PublishAllPorts** - Allocates a random host port for all of a container's
         exposed ports. Specified as a boolean value.
+  -   **PersistPorts** - Persist published host ports that were dynamically
+        allocated so that they remain the same even after restarting the container.
   -   **Privileged** - Gives the container full access to the host.  Specified as
         a boolean value.
   -   **ReadonlyRootfs** - Mount the container's root filesystem as read only.
@@ -336,7 +339,8 @@ Return low-level information on the container `id`
 				"Name": "on-failure"
 			},
 			"SecurityOpt": null,
-			"VolumesFrom": null
+			"VolumesFrom": null,
+			"PersistPorts": false
 		},
 		"HostnamePath": "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hostname",
 		"HostsPath": "/var/lib/docker/containers/ba033ac4401106a3b513bc9d639eee123ad78ca3616b921167cd74b20e25ed39/hosts",

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -760,6 +760,7 @@ Creates a new container.
       --net="bridge"             Set the Network mode for the container
       -P, --publish-all=false    Publish all exposed ports to random ports
       -p, --publish=[]           Publish a container's port(s) to the host
+      --persist-ports=false      Persist published dynamically allocated host ports
       --privileged=false         Give extended privileges to this container
       --read-only=false          Mount the container's root filesystem as read only
       --restart=""               Restart policy to apply when a container exits
@@ -1630,6 +1631,7 @@ removed before the image is removed.
                                    Both hostPort and containerPort can be specified as a range of ports. 
                                    When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range. (e.g., `-p 1234-1236:1234-1236/tcp`)
                                    (use 'docker port' to see the actual mapping)
+      --persist-ports=false      Persist published host ports that were dynamically allocated so that they remain the same even after restarting the container.
       --pid=host		 'host': use the host PID namespace inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
       --privileged=false         Give extended privileges to this container
       --read-only=false           Mount the container's root filesystem as read only

--- a/runconfig/config_test.go
+++ b/runconfig/config_test.go
@@ -262,3 +262,12 @@ func TestMerge(t *testing.T) {
 	}
 
 }
+
+func TestParsePersistPorts(t *testing.T) {
+	if _, hostConfig := mustParse(t, ""); hostConfig.PersistPorts {
+		t.Fatalf("Error parsing PersistPorts. Expected default to be false, received: %t", hostConfig.PersistPorts)
+	}
+	if _, hostConfig := mustParse(t, "--persist-ports"); !hostConfig.PersistPorts {
+		t.Fatalf("Error parsing PersistPorts. Expected to be true, received: %t", hostConfig.PersistPorts)
+	}
+}

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -119,6 +119,7 @@ type HostConfig struct {
 	RestartPolicy   RestartPolicy
 	SecurityOpt     []string
 	ReadonlyRootfs  bool
+	PersistPorts    bool
 }
 
 // This is used by the create command when you want to set both the
@@ -146,6 +147,7 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 		ContainerIDFile: job.Getenv("ContainerIDFile"),
 		Privileged:      job.GetenvBool("Privileged"),
 		PublishAllPorts: job.GetenvBool("PublishAllPorts"),
+		PersistPorts:    job.GetenvBool("PersistPorts"),
 		NetworkMode:     NetworkMode(job.Getenv("NetworkMode")),
 		IpcMode:         IpcMode(job.Getenv("IpcMode")),
 		PidMode:         PidMode(job.Getenv("PidMode")),

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -50,6 +50,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flPublishAll      = cmd.Bool([]string{"P", "-publish-all"}, false, "Publish all exposed ports to random ports")
 		flStdin           = cmd.Bool([]string{"i", "-interactive"}, false, "Keep STDIN open even if not attached")
 		flTty             = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
+		flPersistPorts    = cmd.Bool([]string{"-persist-ports"}, false, "Persist dynamically allocated ports across restarts")
 		flContainerIDFile = cmd.String([]string{"#cidfile", "-cidfile"}, "", "Write the container ID to the file")
 		flEntrypoint      = cmd.String([]string{"#entrypoint", "-entrypoint"}, "", "Overwrite the default ENTRYPOINT of the image")
 		flHostname        = cmd.String([]string{"h", "-hostname"}, "", "Container host name")
@@ -311,6 +312,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		RestartPolicy:   restartPolicy,
 		SecurityOpt:     flSecurityOpt.GetAll(),
 		ReadonlyRootfs:  *flReadonlyRootfs,
+		PersistPorts:    *flPersistPorts,
 	}
 
 	// When allocating stdin in attached mode, close stdin at client disconnect


### PR DESCRIPTION
This PR adds the `PersistPorts` flag to HostConfig which allows Docker server to save dynamically allocated published ports inside HostConfig after the allocation takes place.

This way, if the container is restarted or goes through a stop/start, Docker will bind the same host port.

This is quite useful for services that start docker containers with dynamically allocated ports as they will only need to verify which port was allocated once, when the container started for the first time.

Currently this kind of service would either have to manually manage host ports (replicating some work that Docker already does) or have some kind of mechanism that is notified every time the container is restarted so that port mappings can be updated.

We take the latter approach in tsuru PaaS, and this PR hopes to eliminate our need to do that, as relying on an external agent to be notified and update port mappings creates yet another point of failure.

This flag is exposed to the CLI as the `--persist-ports` parameter available to `create` and `run`.
