### PR TITLE
Add --link accept container ID

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -752,10 +752,7 @@ func (daemon *Daemon) RegisterLinks(container *Container, hostConfig *runconfig.
 			if err != nil {
 				return err
 			}
-			child, err := daemon.GetByName(parts["name"])
-			if err != nil {
-				return err
-			}
+			child := daemon.Get(parts["name"])
 			if child == nil {
 				return fmt.Errorf("Could not get container for %s", parts["name"])
 			}

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -66,7 +66,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 
 	cmd.Var(&flAttach, []string{"a", "-attach"}, "Attach to STDIN, STDOUT or STDERR.")
 	cmd.Var(&flVolumes, []string{"v", "-volume"}, "Bind mount a volume (e.g., from the host: -v /host:/container, from Docker: -v /container)")
-	cmd.Var(&flLinks, []string{"#link", "-link"}, "Add link to another container in the form of name:alias")
+	cmd.Var(&flLinks, []string{"#link", "-link"}, "Add link to another container in the form of <name|id>:alias")
 	cmd.Var(&flDevices, []string{"-device"}, "Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc:rwm)")
 
 	cmd.Var(&flEnv, []string{"e", "-env"}, "Set environment variables")


### PR DESCRIPTION
The --link only accept container names right now,but we can't find a 
reason to prevent us from using a container id to link target.We don't always to assign 
a name to a container and use its id to identify it.Some other option such as `--volumes-from`
can accept both container names and id,so it's weird `--link` only accept container name. This 
patch add `--link` accept container ID.
Signed-off-by: Lei Jitang leijitang@huawei.com

Fixes #5186
