### PR TITLE
Switch docker-py clone to use an explicit commit for natural cache-busting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,10 @@ RUN git clone -b buildroot-2014.02 https://github.com/jpetazzo/docker-busybox.gi
 RUN curl -sSL -o /cirros.tar.gz https://github.com/ewindisch/docker-cirros/raw/1cded459668e8b9dbf4ef976c94c05add9bbd8e9/cirros-0.3.0-x86_64-lxc.tar.gz
 
 # Get the "docker-py" source so we can run their integration tests
-RUN git clone -b 0.7.1 https://github.com/docker/docker-py.git /docker-py
+ENV DOCKER_PY_COMMIT aa19d7b6609c6676e8258f6b900dea2eda1dbe95
+RUN git clone https://github.com/docker/docker-py.git /docker-py \
+	&& cd /docker-py \
+	&& git checkout -q $DOCKER_PY_COMMIT
 
 # Setup s3cmd config
 RUN { \


### PR DESCRIPTION
cc @jfrazelle

ref https://github.com/docker/docker/pull/10058#issuecomment-69797986
