### PR TITLE
Mention "or rename" again in error-message.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -542,7 +542,7 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 		} else {
 			nameAsKnownByUser := strings.TrimPrefix(name, "/")
 			return "", fmt.Errorf(
-				"Conflict. The name %q is already in use by container %s. You have to delete that container to be able to reuse that name.", nameAsKnownByUser,
+				"Conflict. The name %q is already in use by container %s. You have to delete (or rename) that container to be able to reuse that name.", nameAsKnownByUser,
 				utils.TruncateID(conflictingContainer.ID))
 		}
 	}


### PR DESCRIPTION
The "or rename" part was removed from the error-message,
because renaming wasn't possible at the time.

Now that https://github.com/docker/docker/pull/8570 is merged,
renaming existing containers is possible.

Signed-off-by: Sebastiaan van Stijn github@gone.nl
