### PR TITLE
Closes #9860: docker cli attach exit and restore terminal state immediately after container dies

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -168,7 +168,7 @@ func (d *Daemon) ContainerExecStart(job *engine.Job) engine.Status {
 
 	var (
 		cStdin           io.ReadCloser
-		cStdout, cStderr io.Writer
+		cStdout, cStderr io.WriteCloser
 		execName         = job.Args[0]
 	)
 


### PR DESCRIPTION
The `attach` job's stdout handle referencing the http server hijacked connection's `outstream` was never closed properly if the container died while cli was attached. We were only closing the pipe between the container's stdout handle and the `attach` job's stdout handle.

Signed-off-by: Andrew C. Bodine acbodine@us.ibm.com
