### PR TITLE
Revert new netgo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,9 @@ RUN cd /usr/local/go/src \
 			./make.bash --no-clean 2>&1; \
 	done
 
+# Reinstall standard library with netgo
+RUN go clean -i net && go install -tags netgo std
+
 # We still support compiling with older Go, so need to grab older "gofmt"
 ENV GOFMT_VERSION 1.3.3
 RUN curl -sSL https://storage.googleapis.com/golang/go${GOFMT_VERSION}.$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C /go/bin -xz --strip-components=2 go/bin/gofmt

--- a/project/make.sh
+++ b/project/make.sh
@@ -113,8 +113,7 @@ fi
 EXTLDFLAGS_STATIC='-static'
 # ORIG_BUILDFLAGS is necessary for the cross target which cannot always build
 # with options like -race.
-ORIG_BUILDFLAGS=( -a -tags "netgo static_build $DOCKER_BUILDTAGS" -installsuffix netgo )
-# see https://github.com/golang/go/issues/9369#issuecomment-69864440 for why -installsuffix is necessary here
+ORIG_BUILDFLAGS=( -a -tags "netgo static_build $DOCKER_BUILDTAGS" )
 BUILDFLAGS=( $BUILDFLAGS "${ORIG_BUILDFLAGS[@]}" )
 # Test timeout.
 : ${TIMEOUT:=30m}


### PR DESCRIPTION
Reverts docker/docker#10087

It doesn't work for test-integration so either we finally get rid of test-integration of we revert this. :( ping @tianon 
