### PR TITLE
Allow undead containers to remain in index with state "deleted"

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -322,6 +322,12 @@ func (container *Container) Start() (err error) {
 		return nil
 	}
 
+	// if the container was deleted, but removal failed, we do not want to attempt
+	// to start it again
+	if container.Deleted {
+		return errors.New("Cannot start a container which is in deleted state.")
+	}
+
 	// if we encounter and error during start we need to ensure that any other
 	// setup has been cleaned up properly
 	defer func() {

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -81,6 +81,8 @@ func (daemon *Daemon) DeleteVolumes(volumeIDs map[string]struct{}) {
 // Destroy unregisters a container from the daemon and cleanly removes its contents from the filesystem.
 // FIXME: rename to Rm for consistency with the CLI command
 func (daemon *Daemon) Destroy(container *Container) error {
+	var failureErr error
+
 	if container == nil {
 		return fmt.Errorf("The given container is <nil>")
 	}
@@ -94,6 +96,18 @@ func (daemon *Daemon) Destroy(container *Container) error {
 		return err
 	}
 
+	defer func() {
+		// if any of the final cleanup steps fail, restore the container ID into the index
+		// so that the end user has the opportunity to potentially correct external-to-Docker
+		// issues that led to the removal failure.  With the container remaining in the
+		// index it can be listed/seen and then removal can be performed again (successfully)
+		if failureErr != nil {
+			container.State.SetDeleted()
+			container.State.setError(failureErr)
+			daemon.idIndex.Add(container.ID)
+			daemon.containers.Add(container.ID, container)
+		}
+	}()
 	// Deregister the container before removing its directory, to avoid race conditions
 	daemon.idIndex.Delete(container.ID)
 	daemon.containers.Delete(container.ID)
@@ -103,20 +117,24 @@ func (daemon *Daemon) Destroy(container *Container) error {
 	}
 
 	if err := daemon.driver.Remove(container.ID); err != nil {
-		return fmt.Errorf("Driver %s failed to remove root filesystem %s: %s", daemon.driver, container.ID, err)
+		failureErr = fmt.Errorf("Driver %s failed to remove root filesystem %s: %s", daemon.driver, container.ID, err)
+		return failureErr
 	}
 
 	initID := fmt.Sprintf("%s-init", container.ID)
 	if err := daemon.driver.Remove(initID); err != nil {
-		return fmt.Errorf("Driver %s failed to remove init filesystem %s: %s", daemon.driver, initID, err)
+		failureErr = fmt.Errorf("Driver %s failed to remove init filesystem %s: %s", daemon.driver, initID, err)
+		return failureErr
 	}
 
 	if err := os.RemoveAll(container.root); err != nil {
-		return fmt.Errorf("Unable to remove filesystem for %v: %v", container.ID, err)
+		failureErr = fmt.Errorf("Unable to remove filesystem for %v: %v", container.ID, err)
+		return failureErr
 	}
 
 	if err := daemon.execDriver.Clean(container.ID); err != nil {
-		return fmt.Errorf("Unable to remove execdriver data for %s: %s", container.ID, err)
+		failureErr = fmt.Errorf("Unable to remove execdriver data for %s: %s", container.ID, err)
+		return failureErr
 	}
 
 	selinuxFreeLxcContexts(container.ProcessLabel)

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -15,6 +15,7 @@ type State struct {
 	Paused     bool
 	Restarting bool
 	OOMKilled  bool
+	Deleted    bool
 	Pid        int
 	ExitCode   int
 	Error      string // contains last known error when starting the container
@@ -46,6 +47,10 @@ func (s *State) String() string {
 		return ""
 	}
 
+	if s.Deleted {
+		return fmt.Sprintf("Delete attempted (Error: %q)", s.Error)
+	}
+
 	return fmt.Sprintf("Exited (%d) %s ago", s.ExitCode, units.HumanDuration(time.Now().UTC().Sub(s.FinishedAt)))
 }
 
@@ -59,6 +64,9 @@ func (s *State) StateString() string {
 			return "restarting"
 		}
 		return "running"
+	}
+	if s.Deleted {
+		return "deleted"
 	}
 	return "exited"
 }
@@ -216,4 +224,10 @@ func (s *State) IsPaused() bool {
 	res := s.Paused
 	s.Unlock()
 	return res
+}
+
+func (s *State) SetDeleted() {
+	s.Lock()
+	s.Deleted = true
+	s.Unlock()
 }


### PR DESCRIPTION
Addresses #10043

This change will save the error string of any errors which occur after
removing the container from the indexes (to keep from races with the
directory removal), and instead of leaving the container removed from
access, restore it to the index with state deleted and the error
message.  This allows the end user to access it from `docker ps` and to
see the error, which may be solveable by the user and then removal can
be attempted again. Starting a container in 'deleted' state will be
disallowed as the container's root fs or execdriver directory may be in
a very unstable state depending on where the error occurs.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com
