### PR TITLE
Docs: Add note that export doesn't include volume data.

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -998,6 +998,15 @@ For example:
 
     $ sudo docker export red_panda > latest.tar
 
+> **Note:**
+> `docker export` does not export the contents of volumes associated with the
+> container. If a volume is mounted on top of an existing directory in the 
+> container, `docker export` will export the contents of the *underlying* 
+> directory, not the contents of the volume.
+>
+> Refer to [Backup, restore, or migrate data volumes](/userguide/dockervolumes/#backup-restore-or-migrate-data-volumes)
+> in the user guide for examples on exporting data in a volume.
+
 ## history
 
     Usage: docker history [OPTIONS] IMAGE


### PR DESCRIPTION
The documentation on `docker export` doesn't mention that data in volumes is not included in the export.

This adds a note that volumes are not part of the export and refers to the "Backup, restore, or migrate data volumes" to give the user some pointers.

Relates to https://github.com/docker/docker/issues/10095

Signed-off-by: Sebastiaan van Stijn github@gone.nl
