### PR TITLE
Use graphdb.Walk with depth=1 in /containers

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -54,12 +54,11 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 			}
 		}
 	}
-
 	names := map[string][]string{}
 	daemon.ContainerGraph().Walk("/", func(p string, e *graphdb.Entity) error {
 		names[e.ID()] = append(names[e.ID()], p)
 		return nil
-	}, -1)
+	}, 1)
 
 	var beforeCont, sinceCont *Container
 	if before != "" {

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1433,12 +1433,12 @@ The `docker rename` command allows the container to be renamed to a different na
       -s, --size=false      Display total file sizes
       --since=""            Show created since Id or Name, include non-running.
 
-Running `docker ps` showing 2 linked containers.
+Running `docker ps --no-trunc` showing 2 linked containers.
 
     $ sudo docker ps
-    CONTAINER ID        IMAGE                        COMMAND                CREATED              STATUS              PORTS               NAMES
-    4c01db0b339c        ubuntu:12.04                 bash                   17 seconds ago       Up 16 seconds                           webapp
-    d7886598dbe2        crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db
+    CONTAINER ID                                                            IMAGE                        COMMAND                CREATED              STATUS              PORTS               NAMES
+    f7ee772232194fcc088c6bdec6ea09f7b3f6c54d53934658164b8602d7cd4744        ubuntu:12.04                 bash                   17 seconds ago       Up 16 seconds                           webapp
+    d0963715a061c7c7b7cc80b2646da913a959fbf13e80a971d4a60f6997a2f595        crosbymichael/redis:latest   /redis-server --dir    33 minutes ago       Up 33 minutes       6379/tcp            redis,webapp/db
 
 `docker ps` will show only running containers by default. To see all containers:
 `docker ps -a`


### PR DESCRIPTION
I don't think that it was very useful feature in current implementation,
but when you have a lot of links - your daemon became unusable because
on first call of /containers global graphdb lock will be acquired and it
can take a lot of time: 30m for 15 containers linked to each other.

Fixes #9967

Also note that this was undocumented feature.

ping @aanand @vieux @tbatchelli
