### PR TITLE
allow + symbol in tag names

### DIFF
--- a/graph/tags.go
+++ b/graph/tags.go
@@ -20,7 +20,7 @@ import (
 const DEFAULTTAG = "latest"
 
 var (
-	validTagName = regexp.MustCompile(`^[\w][\w.-]{0,127}$`)
+	validTagName = regexp.MustCompile(`^[\w][\+\w.-]{0,127}$`)
 )
 
 type TagStore struct {

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -158,7 +158,7 @@ func TestLookupImage(t *testing.T) {
 }
 
 func TestValidTagName(t *testing.T) {
-	validTags := []string{"9", "foo", "foo-test", "bar.baz.boo"}
+	validTags := []string{"9", "foo", "foo-test", "bar.baz.boo", "foo-test-1.2+ad4455", "my_app-1.0+00f023"}
 	for _, tag := range validTags {
 		if err := ValidateTagName(tag); err != nil {
 			t.Errorf("'%s' should've been a valid tag", tag)


### PR DESCRIPTION
as I stated out before in https://github.com/docker/docker/issues/8944 it should be possible to follow the versioning guidelines of semantic versioning (http://semver.org/) 

Therefore the + sign in the tag name has to be allowed to create tags like

myapplication:1.1.0-beta+2c4f57c
