### PR TITLE
Build CMD/ENTRYPOINT cache strings properly

### DIFF
--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -272,7 +272,7 @@ func cmd(b *Builder, args []string, attributes map[string]bool, original string)
 		b.Config.Cmd = append([]string{"/bin/sh", "-c"}, b.Config.Cmd...)
 	}
 
-	if err := b.commit("", b.Config.Cmd, fmt.Sprintf("CMD %v", b.Config.Cmd)); err != nil {
+	if err := b.commit("", b.Config.Cmd, fmt.Sprintf("CMD %q", b.Config.Cmd)); err != nil {
 		return err
 	}
 
@@ -312,7 +312,7 @@ func entrypoint(b *Builder, args []string, attributes map[string]bool, original 
 		b.Config.Cmd = nil
 	}
 
-	if err := b.commit("", b.Config.Cmd, fmt.Sprintf("ENTRYPOINT %v", b.Config.Entrypoint)); err != nil {
+	if err := b.commit("", b.Config.Cmd, fmt.Sprintf("ENTRYPOINT %q", b.Config.Entrypoint)); err != nil {
 		return err
 	}
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3902,6 +3902,44 @@ func TestBuildCmdShDashC(t *testing.T) {
 	logDone("build - cmd should have sh -c for non-json")
 }
 
+func TestBuildCmdSpaces(t *testing.T) {
+	// Test to make sure that when we strcat arrays we take into account
+	// the arg separator to make sure ["echo","hi"] and ["echo hi"] don't
+	// look the same
+	name := "testbuildcmdspaces"
+	defer deleteImages(name)
+	var id1 string
+	var id2 string
+	var err error
+
+	if id1, err = buildImage(name, "FROM busybox\nCMD [\"echo hi\"]\n", true); err != nil {
+		t.Fatal(err)
+	}
+
+	if id2, err = buildImage(name, "FROM busybox\nCMD [\"echo\", \"hi\"]\n", true); err != nil {
+		t.Fatal(err)
+	}
+
+	if id1 == id2 {
+		t.Fatal("Should not have resulted in the same CMD")
+	}
+
+	// Now do the same with ENTRYPOINT
+	if id1, err = buildImage(name, "FROM busybox\nENTRYPOINT [\"echo hi\"]\n", true); err != nil {
+		t.Fatal(err)
+	}
+
+	if id2, err = buildImage(name, "FROM busybox\nENTRYPOINT [\"echo\", \"hi\"]\n", true); err != nil {
+		t.Fatal(err)
+	}
+
+	if id1 == id2 {
+		t.Fatal("Should not have resulted in the same ENTRYPOINT")
+	}
+
+	logDone("build - cmd with spaces")
+}
+
 func TestBuildCmdJSONNoShDashC(t *testing.T) {
 	name := "testbuildcmdjson"
 	defer deleteImages(name)


### PR DESCRIPTION
Make sure that as we build the CMD/ENTRYPOINT cache strings that we don't
treat ["echo","hi"] and ["echo hi"] as the same thing due to the fact that
we're just doing a strcat on the array.

Closes #10097

Signed-off-by: Doug Davis dug@us.ibm.com
