### PR TITLE
Add backing filesystem info to `docker info` command where applicable

### DIFF
--- a/daemon/graphdriver/aufs/aufs_test.go
+++ b/daemon/graphdriver/aufs/aufs_test.go
@@ -568,7 +568,7 @@ func TestStatus(t *testing.T) {
 		t.Fatal("Status should not be nil or empty")
 	}
 	rootDir := status[0]
-	dirs := status[1]
+	dirs := status[2]
 	if rootDir[0] != "Root Dir" {
 		t.Fatalf("Expected Root Dir got %s", rootDir[0])
 	}

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -29,7 +29,17 @@ type Driver struct {
 	home string
 }
 
+var backingFs = "<unknown>"
+
 func Init(home string, options []string) (graphdriver.Driver, error) {
+	fsMagic, err := graphdriver.GetFSMagic(home)
+	if err != nil {
+		return nil, err
+	}
+	if fsName, ok := graphdriver.FsNames[fsMagic]; ok {
+		backingFs = fsName
+	}
+
 	deviceSet, err := NewDeviceSet(home, true, options)
 	if err != nil {
 		return nil, err
@@ -57,6 +67,7 @@ func (d *Driver) Status() [][2]string {
 	status := [][2]string{
 		{"Pool Name", s.PoolName},
 		{"Pool Blocksize", fmt.Sprintf("%s", units.HumanSize(float64(s.SectorSize)))},
+		{"Backing Filesystem", backingFs},
 		{"Data file", s.DataFile},
 		{"Metadata file", s.MetadataFile},
 		{"Data Space Used", fmt.Sprintf("%s", units.HumanSize(float64(s.Data.Used)))},

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -14,8 +14,52 @@ import (
 type FsMagic uint32
 
 const (
-	FsMagicBtrfs = FsMagic(0x9123683E)
-	FsMagicAufs  = FsMagic(0x61756673)
+	FsMagicBtrfs       = FsMagic(0x9123683E)
+	FsMagicAufs        = FsMagic(0x61756673)
+	FsMagicExtfs       = FsMagic(0x0000EF53)
+	FsMagicCramfs      = FsMagic(0x28cd3d45)
+	FsMagicRamFs       = FsMagic(0x858458f6)
+	FsMagicTmpFs       = FsMagic(0x01021994)
+	FsMagicSquashFs    = FsMagic(0x73717368)
+	FsMagicNfsFs       = FsMagic(0x00006969)
+	FsMagicReiserFs    = FsMagic(0x52654973)
+	FsMagicSmbFs       = FsMagic(0x0000517B)
+	FsMagicJffs2Fs     = FsMagic(0x000072b6)
+	FsMagicUnsupported = FsMagic(0x00000000)
+)
+
+var (
+	DefaultDriver string
+	// All registred drivers
+	drivers map[string]InitFunc
+	// Slice of drivers that should be used in an order
+	priority = []string{
+		"aufs",
+		"btrfs",
+		"devicemapper",
+		"vfs",
+		// experimental, has to be enabled manually for now
+		"overlay",
+	}
+
+	ErrNotSupported   = errors.New("driver not supported")
+	ErrPrerequisites  = errors.New("prerequisites for driver not satisfied (wrong filesystem?)")
+	ErrIncompatibleFS = fmt.Errorf("backing file system is unsupported for this graph driver")
+
+	FsNames = map[FsMagic]string{
+		FsMagicAufs:        "aufs",
+		FsMagicBtrfs:       "btrfs",
+		FsMagicExtfs:       "extfs",
+		FsMagicCramfs:      "cramfs",
+		FsMagicRamFs:       "ramfs",
+		FsMagicTmpFs:       "tmpfs",
+		FsMagicSquashFs:    "squashfs",
+		FsMagicNfsFs:       "nfs",
+		FsMagicReiserFs:    "reiserfs",
+		FsMagicSmbFs:       "smb",
+		FsMagicJffs2Fs:     "jffs2",
+		FsMagicUnsupported: "unsupported",
+	}
 )
 
 type InitFunc func(root string, options []string) (Driver, error)
@@ -71,25 +115,6 @@ type Driver interface {
 	// relative to its base filesystem directory.
 	DiffSize(id, parent string) (size int64, err error)
 }
-
-var (
-	DefaultDriver string
-	// All registred drivers
-	drivers map[string]InitFunc
-	// Slice of drivers that should be used in an order
-	priority = []string{
-		"aufs",
-		"btrfs",
-		"devicemapper",
-		"vfs",
-		// experimental, has to be enabled manually for now
-		"overlay",
-	}
-
-	ErrNotSupported   = errors.New("driver not supported")
-	ErrPrerequisites  = errors.New("prerequisites for driver not satisfied (wrong filesystem?)")
-	ErrIncompatibleFS = fmt.Errorf("backing file system is unsupported for this graph driver")
-)
 
 func init() {
 	drivers = make(map[string]InitFunc)

--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -1,0 +1,14 @@
+package graphdriver
+
+import (
+	"path"
+	"syscall"
+)
+
+func GetFSMagic(rootpath string) (FsMagic, error) {
+	var buf syscall.Statfs_t
+	if err := syscall.Statfs(path.Dir(rootpath), &buf); err != nil {
+		return 0, err
+	}
+	return FsMagic(buf.Type), nil
+}

--- a/daemon/graphdriver/driver_unsupported.go
+++ b/daemon/graphdriver/driver_unsupported.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package graphdriver
+
+func GetFSMagic(rootpath string) (FsMagic, error) {
+	return FsMagicUnsupported, nil
+}

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1162,6 +1162,7 @@ For example:
     Images: 52
     Storage Driver: aufs
      Root Dir: /var/lib/docker/aufs
+     Backing Filesystem: extfs
      Dirs: 545
     Execution Driver: native-0.2
     Kernel Version: 3.13.0-24-generic


### PR DESCRIPTION
Fixes #9960

This adds the output of a `"Backing Filesystem:"` entry to `docker info`
to **overlay**, **aufs**, and **devicemapper** graphdrivers. The default list
includes a fairly complete list of common filesystem names from
linux/include/uapi/linux/magic.h, but if the backing filesystem is not
recognized, the code will simply show `"<unknown>"`

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com
