### PR TITLE
restrict filters server side in docker images

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -49,10 +49,6 @@ const (
 	tarHeaderSize = 512
 )
 
-var (
-	acceptedImageFilterTags = map[string]struct{}{"dangling": {}}
-)
-
 func (cli *DockerCli) CmdHelp(args ...string) error {
 	if len(args) > 1 {
 		method, exists := cli.getMethod(args[:2]...)
@@ -1328,12 +1324,6 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 		imageFilterArgs, err = filters.ParseFlag(f, imageFilterArgs)
 		if err != nil {
 			return err
-		}
-	}
-
-	for name := range imageFilterArgs {
-		if _, ok := acceptedImageFilterTags[name]; !ok {
-			return fmt.Errorf("Invalid filter '%s'", name)
 		}
 	}
 

--- a/graph/list.go
+++ b/graph/list.go
@@ -11,6 +11,8 @@ import (
 	"github.com/docker/docker/pkg/parsers/filters"
 )
 
+var acceptedImageFilterTags = map[string]struct{}{"dangling": {}}
+
 func (s *TagStore) CmdImages(job *engine.Job) engine.Status {
 	var (
 		allImages   map[string]*image.Image
@@ -22,6 +24,12 @@ func (s *TagStore) CmdImages(job *engine.Job) engine.Status {
 	if err != nil {
 		return job.Error(err)
 	}
+	for name := range imageFilters {
+		if _, ok := acceptedImageFilterTags[name]; !ok {
+			return job.Errorf("Invalid filter '%s'", name)
+		}
+	}
+
 	if i, ok := imageFilters["dangling"]; ok {
 		for _, value := range i {
 			if strings.ToLower(value) == "true" {

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -67,16 +67,6 @@ func TestImagesOrderedByCreationDate(t *testing.T) {
 	logDone("images - ordering by creation date")
 }
 
-func TestImagesErrorWithInvalidFilterNameTest(t *testing.T) {
-	imagesCmd := exec.Command(dockerBinary, "images", "-f", "FOO=123")
-	out, _, err := runCommandWithOutput(imagesCmd)
-	if !strings.Contains(out, "Invalid filter") {
-		t.Fatalf("error should occur when listing images with invalid filter name FOO, %s, %v", out, err)
-	}
-
-	logDone("images - invalid filter name check working")
-}
-
 func TestImagesFilterWhiteSpaceTrimmingAndLowerCasingWorking(t *testing.T) {
 	imageName := "images_filter_test"
 	defer deleteAllContainers()

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -67,6 +67,16 @@ func TestImagesOrderedByCreationDate(t *testing.T) {
 	logDone("images - ordering by creation date")
 }
 
+func TestImagesErrorWithInvalidFilterNameTest(t *testing.T) {
+	imagesCmd := exec.Command(dockerBinary, "images", "-f", "FOO=123")
+	out, _, err := runCommandWithOutput(imagesCmd)
+	if !strings.Contains(out, "Invalid filter") {
+		t.Fatalf("error should occur when listing images with invalid filter name FOO, %s, %v", out, err)
+	}
+
+	logDone("images - invalid filter name check working")
+}
+
 func TestImagesFilterWhiteSpaceTrimmingAndLowerCasingWorking(t *testing.T) {
 	imageName := "images_filter_test"
 	defer deleteAllContainers()


### PR DESCRIPTION
Unlike `docker ps`, `docker images` filters are restricted.

Filters are a great way to extend the filtering of the cli.
This change would be extremely useful in Swarm.
