### PR TITLE
Add DEFAULTUNIXSOCKET to no_proxy

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -14,6 +14,7 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/docker/docker/api"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/docker/registry"
@@ -153,6 +154,11 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, key libtrust.PrivateKey,
 		err = out
 	}
 
+	no_proxy := os.Getenv("no_proxy")
+	if !strings.Contains(no_proxy, api.DEFAULTUNIXSOCKET) {
+		no_proxy = no_proxy + "," + api.DEFAULTUNIXSOCKET
+		os.Setenv("no_proxy", no_proxy)
+	}
 	// The transport is created here for reuse during the client session
 	tr := &http.Transport{
 		Proxy:           http.ProxyFromEnvironment,


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

PR #9951 enable client via proxy,and this cause a problem.
When I set the `http_proxy` and `https_proxy`,docker client can't work
and return `FATA[0000] Error response from daemon: 404 page not found` and add `/var/run/docker.sock`
to no_proxy, it work.
I don't konw if the fix is right or I understand the proxy correctly,please correct me if not.
Thanks.
