### PR TITLE
fix link to introducion on 'Working with Docker Images' page

### DIFF
--- a/docs/sources/userguide/dockerimages.md
+++ b/docs/sources/userguide/dockerimages.md
@@ -4,7 +4,7 @@ page_keywords: documentation, docs, the docker guide, docker guide, docker, dock
 
 # Working with Docker Images
 
-In the [introduction](/introduction/) we've discovered that Docker
+In the [introduction](/introduction/understanding-docker/) we've discovered that Docker
 images are the basis of containers. In the
 [previous](/userguide/dockerizing/) [sections](/userguide/usingdocker/)
 we've used Docker images that already exist, for example the `ubuntu`


### PR DESCRIPTION
Old link go to Table of content page, but by context it should go to 'understaning-docker' pag
