### PR TITLE
Replace "base" with "debian" in API documentation

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.10.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.10.md
@@ -35,7 +35,7 @@ List containers
         [
              {
                      "Id": "8dfafdbc3a40",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -45,7 +45,7 @@ List containers
              },
              {
                      "Id": "9cd87474be90",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -55,7 +55,7 @@ List containers
              },
              {
                      "Id": "3176a2479c92",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 3333333333333333",
                      "Created": 1367854154,
                      "Status": "Exit 0",
@@ -65,7 +65,7 @@ List containers
              },
              {
                      "Id": "4cb07b47f9fb",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
@@ -119,7 +119,7 @@ Create a container
              "Cmd":[
                      "date"
              ],
-             "Image":"base",
+             "Image":"ubuntu",
              "Volumes":{
                      "/tmp": {}
              },
@@ -194,7 +194,7 @@ Return low-level information on the container `id`
                              "Cmd": [
                                      "date"
                              ],
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": {},
                              "WorkingDir":""
 
@@ -702,7 +702,7 @@ Create an image, either by pull it from the registry or by importing
 
 **Example request**:
 
-        POST /images/create?fromImage=base HTTP/1.1
+        POST /images/create?fromImage=ubuntu HTTP/1.1
 
 **Example response**:
 
@@ -774,7 +774,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-        GET /images/base/json HTTP/1.1
+        GET /images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -801,7 +801,7 @@ Return low-level information on the image `name`
                              "StdinOnce":false,
                              "Env":null,
                              "Cmd": ["/bin/bash"]
-                             "Image":"base",
+                             "Image":"ubuntu",
                              "Volumes":null,
                              "WorkingDir":""
                      },
@@ -822,7 +822,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-        GET /images/base/history HTTP/1.1
+        GET /images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1229,10 +1229,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
-        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067970}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.11.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.11.md
@@ -35,7 +35,7 @@ List containers
         [
              {
                      "Id": "8dfafdbc3a40",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -45,7 +45,7 @@ List containers
              },
              {
                      "Id": "9cd87474be90",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -55,7 +55,7 @@ List containers
              },
              {
                      "Id": "3176a2479c92",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 3333333333333333",
                      "Created": 1367854154,
                      "Status": "Exit 0",
@@ -65,7 +65,7 @@ List containers
              },
              {
                      "Id": "4cb07b47f9fb",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
@@ -119,7 +119,7 @@ Create a container
              "Cmd":[
                      "date"
              ],
-             "Image":"base",
+             "Image":"ubuntu",
              "Volumes":{
                      "/tmp": {}
              },
@@ -195,7 +195,7 @@ Return low-level information on the container `id`
                                      "date"
                              ],
                              "Dns": null,
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": {},
                              "VolumesFrom": "",
                              "WorkingDir": ""
@@ -736,7 +736,7 @@ Create an image, either by pull it from the registry or by importing i
 
 **Example request**:
 
-        POST /images/create?fromImage=base HTTP/1.1
+        POST /images/create?fromImage=ubuntu HTTP/1.1
 
 **Example response**:
 
@@ -777,7 +777,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-        GET /images/base/json HTTP/1.1
+        GET /images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -805,7 +805,7 @@ Return low-level information on the image `name`
                              "Env":null,
                              "Cmd": ["/bin/bash"],
                              "Dns":null,
-                             "Image":"base",
+                             "Image":"ubuntu",
                              "Volumes":null,
                              "VolumesFrom":"",
                              "WorkingDir":""
@@ -827,7 +827,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-        GET /images/base/history HTTP/1.1
+        GET /images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1259,10 +1259,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
-        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067970}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.12.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.12.md
@@ -36,7 +36,7 @@ List containers
         [
              {
                      "Id": "8dfafdbc3a40",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -46,7 +46,7 @@ List containers
              },
              {
                      "Id": "9cd87474be90",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -56,7 +56,7 @@ List containers
              },
              {
                      "Id": "3176a2479c92",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 3333333333333333",
                      "Created": 1367854154,
                      "Status": "Exit 0",
@@ -66,7 +66,7 @@ List containers
              },
              {
                      "Id": "4cb07b47f9fb",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
@@ -127,7 +127,7 @@ Create a container
              "Cmd":[
                      "date"
              ],
-             "Image":"base",
+             "Image":"ubuntu",
              "Volumes":{
                      "/tmp": {}
              },
@@ -204,7 +204,7 @@ Return low-level information on the container `id`
                                      "date"
                              ],
                              "Dns": null,
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": {},
                              "VolumesFrom": "",
                              "WorkingDir": ""
@@ -795,7 +795,7 @@ Create an image, either by pull it from the registry or by importing i
 
 **Example request**:
 
-        POST /images/create?fromImage=base HTTP/1.1
+        POST /images/create?fromImage=ubuntu HTTP/1.1
 
 **Example response**:
 
@@ -838,7 +838,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-        GET /images/base/json HTTP/1.1
+        GET /images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -864,7 +864,7 @@ Return low-level information on the image `name`
                              "Env": null,
                              "Cmd": ["/bin/bash"],
                              "Dns": null,
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": null,
                              "VolumesFrom": "",
                              "WorkingDir": ""
@@ -888,7 +888,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-        GET /images/base/history HTTP/1.1
+        GET /images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1325,10 +1325,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
-        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067970}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.13.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.13.md
@@ -36,7 +36,7 @@ List containers
         [
              {
                      "Id": "8dfafdbc3a40",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -46,7 +46,7 @@ List containers
              },
              {
                      "Id": "9cd87474be90",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -56,7 +56,7 @@ List containers
              },
              {
                      "Id": "3176a2479c92",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 3333333333333333",
                      "Created": 1367854154,
                      "Status": "Exit 0",
@@ -66,7 +66,7 @@ List containers
              },
              {
                      "Id": "4cb07b47f9fb",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
@@ -121,7 +121,7 @@ Create a container
              "Cmd":[
                      "date"
              ],
-             "Image":"base",
+             "Image":"ubuntu",
              "Volumes":{
                      "/tmp": {}
              },
@@ -198,7 +198,7 @@ Return low-level information on the container `id`
                                      "date"
                              ],
                              "Dns": null,
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": {},
                              "VolumesFrom": "",
                              "WorkingDir": ""
@@ -784,7 +784,7 @@ Create an image, either by pulling it from the registry or by importing it
 
 **Example request**:
 
-        POST /images/create?fromImage=base HTTP/1.1
+        POST /images/create?fromImage=ubuntu HTTP/1.1
 
 **Example response**:
 
@@ -827,7 +827,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-        GET /images/base/json HTTP/1.1
+        GET /images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -853,7 +853,7 @@ Return low-level information on the image `name`
                              "Env": null,
                              "Cmd": ["/bin/bash"],
                              "Dns": null,
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": null,
                              "VolumesFrom": "",
                              "WorkingDir": ""
@@ -877,7 +877,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-        GET /images/base/history HTTP/1.1
+        GET /images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1314,10 +1314,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
-        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067970}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.14.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.14.md
@@ -36,7 +36,7 @@ List containers
         [
              {
                      "Id": "8dfafdbc3a40",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -46,7 +46,7 @@ List containers
              },
              {
                      "Id": "9cd87474be90",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -56,7 +56,7 @@ List containers
              },
              {
                      "Id": "3176a2479c92",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 3333333333333333",
                      "Created": 1367854154,
                      "Status": "Exit 0",
@@ -66,7 +66,7 @@ List containers
              },
              {
                      "Id": "4cb07b47f9fb",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
@@ -124,7 +124,7 @@ Create a container
              "Cmd":[
                      "date"
              ],
-             "Image":"base",
+             "Image":"ubuntu",
              "Volumes":{
                      "/tmp": {}
              },
@@ -207,7 +207,7 @@ Return low-level information on the container `id`
                                      "date"
                              ],
                              "Dns": null,
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": {},
                              "VolumesFrom": "",
                              "WorkingDir": ""
@@ -794,7 +794,7 @@ Create an image, either by pulling it from the registry or by importing it
 
 **Example request**:
 
-        POST /images/create?fromImage=base HTTP/1.1
+        POST /images/create?fromImage=ubuntu HTTP/1.1
 
 **Example response**:
 
@@ -837,7 +837,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-        GET /images/base/json HTTP/1.1
+        GET /images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -863,7 +863,7 @@ Return low-level information on the image `name`
                              "Env": null,
                              "Cmd": ["/bin/bash"],
                              "Dns": null,
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": null,
                              "VolumesFrom": "",
                              "WorkingDir": ""
@@ -887,7 +887,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-        GET /images/base/history HTTP/1.1
+        GET /images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1324,10 +1324,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
-        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067970}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -36,7 +36,7 @@ List containers
         [
              {
                      "Id": "8dfafdbc3a40",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -46,7 +46,7 @@ List containers
              },
              {
                      "Id": "9cd87474be90",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -56,7 +56,7 @@ List containers
              },
              {
                      "Id": "3176a2479c92",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 3333333333333333",
                      "Created": 1367854154,
                      "Status": "Exit 0",
@@ -66,7 +66,7 @@ List containers
              },
              {
                      "Id": "4cb07b47f9fb",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
@@ -128,7 +128,7 @@ Create a container
                      "date"
              ],
              "Entrypoint": "",
-             "Image": "base",
+             "Image": "ubuntu",
              "Volumes": {
                      "/tmp": {}
              },
@@ -291,7 +291,7 @@ Return low-level information on the container `id`
                                      "date"
                              ],
                              "Dns": null,
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": {},
                              "VolumesFrom": "",
                              "WorkingDir": ""
@@ -939,7 +939,7 @@ Create an image, either by pulling it from the registry or by importing it
 
 **Example request**:
 
-        POST /images/create?fromImage=base HTTP/1.1
+        POST /images/create?fromImage=ubuntu HTTP/1.1
 
 **Example response**:
 
@@ -983,7 +983,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-        GET /images/base/json HTTP/1.1
+        GET /images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -1009,7 +1009,7 @@ Return low-level information on the image `name`
                              "Env": null,
                              "Cmd": ["/bin/bash"],
                              "Dns": null,
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": null,
                              "VolumesFrom": "",
                              "WorkingDir": ""
@@ -1033,7 +1033,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-        GET /images/base/history HTTP/1.1
+        GET /images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1471,10 +1471,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
-        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067970}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -36,7 +36,7 @@ List containers
         [
              {
                      "Id": "8dfafdbc3a40",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -46,7 +46,7 @@ List containers
              },
              {
                      "Id": "9cd87474be90",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -56,7 +56,7 @@ List containers
              },
              {
                      "Id": "3176a2479c92",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 3333333333333333",
                      "Created": 1367854154,
                      "Status": "Exit 0",
@@ -66,7 +66,7 @@ List containers
              },
              {
                      "Id": "4cb07b47f9fb",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
@@ -128,7 +128,7 @@ Create a container
                      "date"
              ],
              "Entrypoint": "",
-             "Image": "base",
+             "Image": "ubuntu",
              "Volumes": {
                      "/tmp": {}
              },
@@ -291,7 +291,7 @@ Return low-level information on the container `id`
                                      "date"
                              ],
                              "Dns": null,
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": {},
                              "VolumesFrom": "",
                              "WorkingDir": ""
@@ -885,7 +885,7 @@ Create an image, either by pulling it from the registry or by importing it
 
 **Example request**:
 
-        POST /images/create?fromImage=base HTTP/1.1
+        POST /images/create?fromImage=ubuntu HTTP/1.1
 
 **Example response**:
 
@@ -929,7 +929,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-        GET /images/base/json HTTP/1.1
+        GET /images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -955,7 +955,7 @@ Return low-level information on the image `name`
                              "Env": null,
                              "Cmd": ["/bin/bash"],
                              "Dns": null,
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": null,
                              "VolumesFrom": "",
                              "WorkingDir": ""
@@ -979,7 +979,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-        GET /images/base/history HTTP/1.1
+        GET /images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1427,10 +1427,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
-        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067970}
 
 Query Parameters:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -36,7 +36,7 @@ List containers
         [
              {
                      "Id": "8dfafdbc3a40",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 1",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -46,7 +46,7 @@ List containers
              },
              {
                      "Id": "9cd87474be90",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 222222",
                      "Created": 1367854155,
                      "Status": "Exit 0",
@@ -56,7 +56,7 @@ List containers
              },
              {
                      "Id": "3176a2479c92",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 3333333333333333",
                      "Created": 1367854154,
                      "Status": "Exit 0",
@@ -66,7 +66,7 @@ List containers
              },
              {
                      "Id": "4cb07b47f9fb",
-                     "Image": "base:latest",
+                     "Image": "ubuntu:latest",
                      "Command": "echo 444444444444444444444444444444444",
                      "Created": 1367854152,
                      "Status": "Exit 0",
@@ -128,7 +128,7 @@ Create a container
                      "date"
              ],
              "Entrypoint": "",
-             "Image": "base",
+             "Image": "ubuntu",
              "Volumes": {
                      "/tmp": {}
              },
@@ -1096,7 +1096,7 @@ Create an image, either by pulling it from the registry or by importing it
 
 **Example request**:
 
-        POST /images/create?fromImage=base HTTP/1.1
+        POST /images/create?fromImage=ubuntu HTTP/1.1
 
 **Example response**:
 
@@ -1140,7 +1140,7 @@ Return low-level information on the image `name`
 
 **Example request**:
 
-        GET /images/base/json HTTP/1.1
+        GET /images/ubuntu/json HTTP/1.1
 
 **Example response**:
 
@@ -1166,7 +1166,7 @@ Return low-level information on the image `name`
                              "Env": null,
                              "Cmd": ["/bin/bash"],
                              "Dns": null,
-                             "Image": "base",
+                             "Image": "ubuntu",
                              "Volumes": null,
                              "VolumesFrom": "",
                              "WorkingDir": ""
@@ -1190,7 +1190,7 @@ Return the history of the image `name`
 
 **Example request**:
 
-        GET /images/base/history HTTP/1.1
+        GET /images/ubuntu/history HTTP/1.1
 
 **Example response**:
 
@@ -1589,10 +1589,10 @@ and Docker images will report:
         HTTP/1.1 200 OK
         Content-Type: application/json
 
-        {"status": "create", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "start", "id": "dfdf82bd3881","from": "base:latest", "time":1374067924}
-        {"status": "stop", "id": "dfdf82bd3881","from": "base:latest", "time":1374067966}
-        {"status": "destroy", "id": "dfdf82bd3881","from": "base:latest", "time":1374067970}
+        {"status": "create", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "start", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067924}
+        {"status": "stop", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067966}
+        {"status": "destroy", "id": "dfdf82bd3881","from": "ubuntu:latest", "time":1374067970}
 
 Query Parameters:
 


### PR DESCRIPTION
### Update:

Following the discussion below, I changed the PR and removed the "proposal" (for now), I only updated the documentation and replaced "base" with "ubuntu" in the examples.

<strike>
The current documentation uses the "base" image in various places. The "base" image is deprecated and it is no longer possible to "pull" this image. (see https://github.com/docker/docker/issues/9775)
</strike>
<strike>
To prevent such cases in the future and to differentiate between "actual" and "illustrational" examples in the documentation, an "example" repository/image should be created on the registry that is meant for this purpose.
</strike>
<strike>
The "example" repository/image should have a number of frequently-used "tags" (e.g. `example:foo`, `example:bar`) and contain some "dummy" commands, to allow, for example, `docker run example baz --bar` to _illustrate_ an example and still be "functional" (it doesn't produce errors). The dummy commands could even output something, for example:
</strike>

```
"This output is produced by the 'baz' command running in the container."
```

<strike>
This proposal contains the initial change to the documentation style guide, and updates the API documentation to use the `example` image (actual response, image-IDs are not yet updated).
</strike>

<strike>
This is (obviously) NOT ready to be merged, because the example image does not yet exist and should be decided on.
</strike>
