### PR TITLE
Make .dockercfg with json.MarshallIndent

### DIFF
--- a/integration-cli/docker_cli_login_test.go
+++ b/integration-cli/docker_cli_login_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"io"
 	"os/exec"
 	"testing"
 )
@@ -10,17 +9,8 @@ import (
 func TestLoginWithoutTTY(t *testing.T) {
 	cmd := exec.Command(dockerBinary, "login")
 
-	// create a buffer with text then a new line as a return
-	buf := bytes.NewBuffer([]byte("buffer test string \n"))
-
-	// use a pipe for stdin and manually copy the data so that
-	// the process does not get the TTY
-	in, err := cmd.StdinPipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// copy the bytes into the commands stdin along with a new line
-	go io.Copy(in, buf)
+	// Send to stdin so the process does not get the TTY
+	cmd.Stdin = bytes.NewBufferString("buffer test string \n")
 
 	// run the command and block until it's done
 	if err := cmd.Run(); err == nil {

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -133,7 +133,7 @@ func SaveConfig(configFile *ConfigFile) error {
 		configs[k] = authCopy
 	}
 
-	b, err := json.Marshal(configs)
+	b, err := json.MarshalIndent(configs, "", "\t")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #10129
Makes the .dockercfg more human parsable.

Also cleaned up the (technically) racey login test.
