### PR TITLE
root:root owns docker.sock by default

### DIFF
--- a/contrib/init/systemd/docker.socket
+++ b/contrib/init/systemd/docker.socket
@@ -5,8 +5,6 @@ PartOf=docker.service
 [Socket]
 ListenStream=/var/run/docker.sock
 SocketMode=0660
-SocketUser=root
-SocketGroup=docker
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
See: https://docs.docker.com/installation/binaries/#giving-non-root-access

Signed-off-by: Lokesh Mandvekar lsm5@fedoraproject.org
