### PR TITLE
fix Bind-mounts not properly registering after daemon restart

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -237,6 +238,8 @@ func (daemon *Daemon) register(container *Container, updateSuffixarray bool) err
 	// we'll waste time if we update it for every container
 	daemon.idIndex.Add(container.ID)
 
+	container.registerVolumes()
+
 	// FIXME: if the container is supposed to be running but is not, auto restart it?
 	//        if so, then we need to restart monitor and init a new lock
 	// If the container is supposed to be running, make sure of it
@@ -398,10 +401,6 @@ func (daemon *Daemon) restore() error {
 				}
 			}
 		}
-	}
-
-	for _, c := range registeredContainers {
-		c.registerVolumes()
 	}
 
 	if !debug {
@@ -890,7 +889,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		return nil, err
 	}
 
-	volumes, err := volumes.NewRepository(path.Join(config.Root, "volumes"), volumesDriver)
+	volumes, err := volumes.NewRepository(filepath.Join(config.Root, "volumes"), volumesDriver)
 	if err != nil {
 		return nil, err
 	}

--- a/volumes/repository.go
+++ b/volumes/repository.go
@@ -87,16 +87,10 @@ func (r *Repository) restore() error {
 
 	for _, v := range dir {
 		id := v.Name()
-		path, err := r.driver.Get(id, "")
-		if err != nil {
-			log.Debugf("Could not find volume for %s: %v", id, err)
-			continue
-		}
 		vol := &Volume{
 			ID:         id,
 			configPath: r.configPath + "/" + id,
 			containers: make(map[string]struct{}),
-			Path:       path,
 		}
 		if err := vol.FromDisk(); err != nil {
 			if !os.IsNotExist(err) {


### PR DESCRIPTION
Fixes #9629 #9768

1) Volume config is not restored if we couldn't find it with the graph
driver, but bind-mounts would never be found by the graph driver since
they aren't in that dir

2) container volumes were only being restored if they were found in the
volumes repo, but volumes created by old daemons wouldn't be in the
repo until the container is at least started.
