### PR TITLE
Allow specification of DOCKER_HOST, DOCKER_TLS_VERIFY, and DOCKER_CERT_PATH in a file

### DIFF
--- a/docker/defaults.go
+++ b/docker/defaults.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+
+	"github.com/docker/docker/api"
+)
+
+var (
+	configFileValues  map[string]interface{}
+	defaultStorageDir string
+	defaultGetter     = DefaultGetter{}
+	dockerConfigPath  string
+	dockerCertPath    string
+	dockerTlsVerify   bool
+	configFileHost    string
+)
+
+type DefaultGetter struct {
+	configFileValues map[string]interface{}
+}
+
+type ConfigHierarchy struct {
+	EnvVar  string
+	JsonKey string
+	Default interface{}
+}
+
+// The hierarchy of configuration options flows like
+// this, in order of most preferred to least preferred:
+//
+// Command Line Flags => Environment Variables => defaults.json => Hardcoded Defaults
+func getHomeDir() string {
+	if runtime.GOOS == "windows" {
+		return os.Getenv("USERPROFILE")
+	}
+	return os.Getenv("HOME")
+}
+
+func getConfigPath() string {
+	// This is a "special case" since we
+	// need to know about it to check the other
+	// defaut values.
+	envVal := os.Getenv("DOCKER_CONFIG_PATH")
+	if envVal == "" {
+		return defaultStorageDir
+	} else {
+		return envVal
+	}
+}
+
+func (d *DefaultGetter) GetCertPath() string {
+	return d.getConfigValue(configFileValues, ConfigHierarchy{
+		EnvVar:  "DOCKER_CERT_PATH",
+		JsonKey: "CertPath",
+		Default: defaultStorageDir,
+	}).(string)
+}
+
+func (d *DefaultGetter) GetTlsVerify() bool {
+	configVal := d.getConfigValue(configFileValues, ConfigHierarchy{
+		EnvVar:  "DOCKER_TLS_VERIFY",
+		JsonKey: "TlsVerify",
+		Default: "false",
+	})
+	if boolVal, ok := configVal.(bool); ok {
+		return boolVal
+	}
+	if stringVal, ok := configVal.(string); ok {
+		val, err := strconv.ParseBool(stringVal)
+		if err != nil {
+			log.Fatal("Error parsing TlsVerify / DOCKER_TLS_VERIFY value: %s", err)
+		}
+		return val
+	}
+	log.Fatal("Unrecognized type for TlsVerify value in config file")
+	return false
+}
+
+func (d *DefaultGetter) GetHost() string {
+	return d.getConfigValue(configFileValues, ConfigHierarchy{
+		EnvVar:  "DOCKER_HOST",
+		JsonKey: "Host",
+		Default: fmt.Sprintf("unix://%s", api.DEFAULTUNIXSOCKET),
+	}).(string)
+}
+
+func (d *DefaultGetter) readConfigFile(dockerConfigPath string) {
+	var (
+		cfv map[string]interface{}
+	)
+	configFilePath := filepath.Join(dockerConfigPath, "defaults.json")
+	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
+		d.configFileValues = nil
+		return
+	}
+	data, err := ioutil.ReadFile(configFilePath)
+	if err != nil {
+		switch err {
+		case os.ErrPermission:
+			log.Fatalf("Error reading %s: Insufficient permissions", configFilePath)
+		default:
+			log.Fatalf("Unrecognized error reading %s: %s", configFilePath, err)
+		}
+	}
+	if json.Unmarshal(data, &cfv); err != nil {
+		log.Fatalf("Error unmarshalling %s: %s", configFilePath, err)
+	}
+	d.configFileValues = cfv
+}
+
+func (d *DefaultGetter) getConfigValue(configFileValues map[string]interface{}, c ConfigHierarchy) interface{} {
+	envVal := os.Getenv(c.EnvVar)
+	if envVal == "" {
+		if d.configFileValues != nil {
+			if d.configFileValues[c.JsonKey] != nil {
+				return d.configFileValues[c.JsonKey]
+			}
+		}
+	} else {
+		return envVal
+	}
+	return c.Default
+}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -55,12 +55,7 @@ func main() {
 	}
 
 	if len(flHosts) == 0 {
-		defaultHost := os.Getenv("DOCKER_HOST")
-		if defaultHost == "" || *flDaemon {
-			// If we do not have a host, default to unix socket
-			defaultHost = fmt.Sprintf("unix://%s", api.DEFAULTUNIXSOCKET)
-		}
-		defaultHost, err := api.ValidateHost(defaultHost)
+		defaultHost, err := api.ValidateHost(configFileHost)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
## Abstract

This PR introduces a file, `defaults.json`, which can be used to specify values for which `DOCKER_HOST`, `DOCKER_TLS_VERIFY`, and `DOCKER_CERT_PATH` are used now.  This is similar to how you can save a `.aws/credentials` file with your keys in it in addition to putting them in environment variables.  

To be clear, this is in _addition_ to the current environment variables and flags, not in lieu of.
## Motivation

Currently in [docker machine](https://github.com/docker/machine), when you create a shiny new Docker host `machine` will switch its state to point to that host as the "active host" (the host commands are meant to be run against).  However, processes cannot modify the environment variables of their parent processes, so `machine` has no way of automatically switching the host to run commands against from Docker's point of view.  The user must either run `export DOCKER_HOST=$(machine url) DOCKER_AUTH=identity` themselves (in the case of using `machine` with identity auth) or (in the case of TLS auth) execute commands in a fashion such as:

``` console
$ docker $(machine config machine_name) ps 
```

This violates what I consider to be a principal of things which are well designed: ideally, users shouldn't have to notice or care about their presence at all (oft expressed in the cliche "It Just Works").  Either of these will be cumbersome to someone accustomed to what a typical Docker workflow looks like today, and it causes the state reported by `machine` and the actual state of the system to drift.

Also, if I'm not mistaken we could possibly use this to deprecate `$(boot2docker shellinit)` in the immediate future and lower the barrier to entry for users getting started with b2d further than it is now.  Not everyone is comfortable hacking their `.bashrc` and/or moving it around to all the computers they use and I'm not sure if an analogue to `.bashrc` exists on Windows so this would be helpful there). 

Finally, it could be used by 3rd party clients (perhaps with some sort of permissions model?) to do similar things to what `machine` and `boot2docker` would use it for.
## Possible Issues
- Lots of naming (e.g. `DefaultGetter`, `defaults.json`) and the general architecture / approach of the implementation could probably be improved to be more clear so I welcome feedback there.
- I've tried my best to make sure pathing and e.g. assumptions about `~/.docker`'s location have been handled well but that kind of thing always gets tricky, so it's certainly an area to scrutinize.
- Having so many places where these values could be changed could get confusing for users, which is why I've documented so thoroughly and included a warning to not edit `defaults.json` by hand if they don't know what they're dong.  In most cases the things that users will interact directly with will be flags, environment variables, or wrapper programs that edit `defaults.json`.
- This touches a _very_ common code path and shouldn't be taken lightly, or accepted without thorough testing and review.
- Calculating the value of `DOCKER_TLS_VERIFY` has changed slightly in this implementation from "Empty string is false, anything else is true" to "truthy strings (1, true, T) are true, falsy strings (0, false, F, "") are false".  Is this change acceptable?  I posit that it makes setting the value in `defaults.json` less error-prone for users, since `"true"` and "true" both work and are both valid JSON.

cc @bfirsh @ehazlett PTAL with `machine` in mind, help on the code itself is welcome too of course.
cc @SvenDowideit @fredlf @jamtur01 For docs review.  Do they look thorough and convey the intent well?

Slightly influenced by #7232, but with pretty reduced scope.  I mostly care about setting default hosts and TLS settings.

I will happily add tests if the ideas, design, and abstraction look good to the maintainers.  But first I wanted to get a rough draft together for everyone to look over and for people to play with if they wish.
