### PR TITLE
Fix "-X" 6l usage ("define string data")

### DIFF
--- a/dockerversion/dockerversion.go
+++ b/dockerversion/dockerversion.go
@@ -9,7 +9,7 @@ var (
 	GITCOMMIT string
 	VERSION   string
 
-	IAMSTATIC bool   // whether or not Docker itself was compiled statically via ./hack/make.sh binary
+	IAMSTATIC string // whether or not Docker itself was compiled statically via ./hack/make.sh binary ("true" or not "true")
 	INITSHA1  string // sha1sum of separate static dockerinit, if Docker itself was compiled dynamically via ./hack/make.sh dynbinary
 	INITPATH  string // custom location to search for a valid dockerinit binary (available for packagers as a last resort escape hatch)
 )

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -94,7 +94,7 @@ func isValidDockerInitPath(target string, selfPath string) bool { // target and 
 	if target == "" {
 		return false
 	}
-	if dockerversion.IAMSTATIC {
+	if dockerversion.IAMSTATIC == "true" {
 		if selfPath == "" {
 			return false
 		}


### PR DESCRIPTION
It turns out "-X" is only for strings! :)

See https://github.com/golang/go/issues/9621#issuecomment-70354289 for more context.
