### PR TITLE
Document that ENV vars are not automatically updated

### DIFF
--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -647,6 +647,12 @@ mechanism to communicate with a linked container by its alias:
 If you restart the source container (`servicename` in this case), the recipient
 container's `/etc/hosts` entry will be automatically updated.
 
+> **Note**:
+> Unlike host entries in the `/ets/hosts` file, IP addresses stored in the
+> environment variables are not automatically updated if the source container is
+> restarted. We recommend using the host entries in `/etc/hosts` to resolve the
+> IP address of linked containers.
+
 ## VOLUME (shared filesystems)
 
     -v=[]: Create a bind mount with: [host-dir]:[container-dir]:[rw|ro].

--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -232,6 +232,12 @@ command to list the specified container's environment variables.
 > container. Similarly, some daemons (such as `sshd`)
 > will scrub them when spawning shells for connection.
 
+> **Note**:
+> Unlike host entries in the [`/ets/hosts` file](#updating-the-etchosts-file),
+> IP addresses stored in the environment variables are not automatically updated
+> if the source container is restarted. We recommend using the host entries in
+> `/etc/hosts` to resolve the IP address of linked containers.
+
 You can see that Docker has created a series of environment variables with
 useful information about the source `db` container. Each variable is prefixed with
 `DB_`, which is populated from the `alias` you specified above. If the `alias`


### PR DESCRIPTION
Unlike the entries in `/etc/hosts`, environment-variables for linked containers are not automatically updated if the linked container is restarted.

This adds a note to the documentation in; https://docs.docker.com/userguide/dockerlinks/#environment-variables and https://docs.docker.com/reference/run/#env-environment-variables to make users aware that this is the case and recommends them to use the `/etc/hosts` entries in stead.

I added this change because users were expecting environment variables to be updated automatically as well (https://github.com/docker/docker/issues/10164).

NOTE;
I decided not to add a note to the brand-new [know issues](https://github.com/docker/docker/blob/f6777c7a40efdae161f6ba99223f4d6a625d4762/docs/sources/release-notes.md#known-issues) section; let me know if that is desired.
