### PR TITLE
An initial quick import of documentation from Compose, Machine and Swarm

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -59,3 +59,28 @@ EXPOSE 8000
 RUN cd sources && rgrep --files-with-matches '{{ include ".*" }}' | xargs sed -i~ 's/{{ include "\(.*\)" }}/cat include\/\1/ge'
 
 CMD ["mkdocs", "serve"]
+
+# Initial Dockerfile driven documenation aggregation
+# Sven plans to move each Dockerfile into the respective repository
+
+# Docker Swarm
+ADD https://raw.githubusercontent.com/docker/swarm/master/logo.png /docs/sources/swarm/logo.png
+ADD https://raw.githubusercontent.com/docker/swarm/master/README.md /docs/sources/swarm/README.md
+ADD https://raw.githubusercontent.com/docker/swarm/master/discovery/README.md /docs/sources/swarm/discovery.md
+ADD https://raw.githubusercontent.com/docker/swarm/master/api/README.md /docs/sources/swarm/API.md
+ADD https://raw.githubusercontent.com/docker/swarm/master/scheduler/filter/README.md /docs/sources/swarm/filters.md
+
+# Docker Machine
+ADD https://raw.githubusercontent.com/docker/machine/master/docs/dockermachine.md /docs/sources/machine/userguide.md
+
+# Docker Compose
+ADD https://raw.githubusercontent.com/docker/fig/master/docs/index.md /docs/sources/compose/userguide.md
+ADD https://raw.githubusercontent.com/docker/fig/master/docs/install.md /docs/sources/compose/install.md
+ADD https://raw.githubusercontent.com/docker/fig/master/docs/cli.md /docs/sources/compose/cli.md
+ADD https://raw.githubusercontent.com/docker/fig/master/docs/yml.md /docs/sources/compose/yml.md
+
+# add the project docs from the `mkdocs-<project>.yml` files
+RUN cd /docs && ./build.sh
+
+# remove `^---*` lines from md's
+RUN cd /docs/sources && find . -name "*.md" | xargs sed -i~ -n '/^---*/!p'

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ In the root of the `docker` source directory:
 
     $ make docs
     .... (lots of output) ....
-    $ docker run --rm -it  -e AWS_S3_BUCKET -p 8000:8000 "docker-docs:master" mkdocs serve
+    docker run --rm -it  -e AWS_S3_BUCKET -p 8000:8000 "docker-docs:master" mkdocs serve
     Running at: http://0.0.0.0:8000/
     Live reload enabled.
     Hold ctrl+c to quit.

--- a/docs/build.sh
+++ b/docs/build.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -e
+
+set -o pipefail
+
+usage() {
+	exit 1
+}
+
+
+extrafiles=($(find . -name "mkdocs-*.yml"))
+extralines=()
+
+for file in "${extrafiles[@]}"
+do
+	#echo "LOADING $file"
+	while read line
+	do
+		if [[ "$line" != "" ]]
+		then
+			extralines+=("$line")
+
+			#echo "LINE (${#extralines[@]}):  $line"
+		fi
+	done < <(cat "$file")
+done
+
+#echo "extra count (${#extralines[@]})"
+mv mkdocs.yml mkdocs.yml.bak
+echo "# Generated mkdocs.yml from ${extrafiles[@]}"
+echo "# Generated mkdocs.yml from ${extrafiles[@]}" > mkdocs.yml
+
+while read line
+do
+	menu=$(echo $line | sed "s/^- \['\([^']*\)', '\([^']*\)'.*/\2/")
+	if [[ "$menu" != "**HIDDEN**" ]]
+		# or starts with a '#'?
+	then
+		if [[ "$lastmenu" != "" && "$lastmenu" != "$menu" ]]
+		then
+			# insert extra elements here
+			for extra in "${extralines[@]}"
+			do
+				#echo "EXTRA $extra"
+				extramenu=$(echo $extra | sed "s/^- \['\([^']*\)', '\([^']*\)'.*/\2/")
+				if [[ "$extramenu" == "$lastmenu" ]]
+				then
+					echo "$extra" >> mkdocs.yml
+				fi
+			done
+			#echo "# JUST FINISHED $lastmenu"
+		fi
+		lastmenu="$menu"
+	fi
+	echo "$line" >> mkdocs.yml
+
+done < <(cat "mkdocs.yml.bak")

--- a/docs/mkdocs-compose.yml
+++ b/docs/mkdocs-compose.yml
@@ -1,0 +1,5 @@
+
+- ['compose/userguide.md', 'User Guide', 'Docker Compose' ]
+- ['compose/install.md', 'Installation', 'Docker Compose']
+- ['compose/cli.md', 'Reference', 'Compose command line']
+- ['compose/yml.md', 'Reference', 'Compose yml']

--- a/docs/mkdocs-machine.yml
+++ b/docs/mkdocs-machine.yml
@@ -1,0 +1,2 @@
+
+- ['machine/userguide.md', 'User Guide', 'Docker Machine' ]

--- a/docs/mkdocs-swarm.yml
+++ b/docs/mkdocs-swarm.yml
@@ -1,0 +1,5 @@
+
+- ['swarm/README.md', 'User Guide', 'Docker Swarm' ]
+- ['swarm/discovery.md', 'Reference', 'Swarm discovery']
+- ['swarm/API.md', 'Reference', 'Swarm API']
+- ['swarm/filters.md', 'Reference', 'Swarm filters']


### PR DESCRIPTION
You can preview this at http://dowideit-docs.s3-website-ap-southeast-2.amazonaws.com/

There will be more work happening on this, and it will _later_ be extracted into a separate repository, with each Docker project having its own `mkdocs-project.yml` file and its own documentation.

it pulls from those project's `master` branch atm.

Docker-DCO-1.1-Signed-off-by: Sven Dowideit SvenDowideit@docker.com (github: SvenDowideit)
