### PR TITLE
Add usage of port mapping for Boot2docker.

### DIFF
--- a/docs/sources/examples/nodejs_web_app.md
+++ b/docs/sources/examples/nodejs_web_app.md
@@ -181,6 +181,11 @@ Now you can call your app using `curl` (install if needed via:
 
     Hello world
 
+If you use Boot2docker on OS X, the port is actually mapped to the Docker host VM,
+and you should use the following command:
+
+    $ curl $(boot2docker ip):49160
+
 We hope this tutorial helped you get up and running with Node.js and
 CentOS on Docker. You can get the full source code at
 [https://github.com/enokd/docker-node-hello/](https://github.com/enokd/docker-node-hello/).


### PR DESCRIPTION
On OS X, the port is mapped to the VirtualBox VM. Add this caveat so that it is more friendlier for Mac users.
