### PR TITLE
Turn on Security opts including labeling for docker build

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -91,7 +91,10 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 	if warnings, err = daemon.mergeAndVerifyConfig(config, img); err != nil {
 		return nil, nil, err
 	}
-	if hostConfig != nil && hostConfig.SecurityOpt == nil {
+	if hostConfig == nil {
+		hostConfig = &runconfig.HostConfig{}
+	}
+	if hostConfig.SecurityOpt == nil {
 		hostConfig.SecurityOpt, err = daemon.GenerateSecurityOpt(hostConfig.IpcMode, hostConfig.PidMode)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
Currently docker build is not passing HostConfig to daemon.Create.
this patch creates the default HostConfig and passes it to daemon.Create.
This will cause the SELinux labeling to turn on for docker build.  Basically
it causes a SecurtyOpt field to be created.  In the future this might also
allow us to use seccomp and UserNamespace with docker build.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
