### PR TITLE
update graphtest

### DIFF
--- a/daemon/graphdriver/graphtest/graphtest.go
+++ b/daemon/graphdriver/graphtest/graphtest.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -73,7 +74,7 @@ func newDriver(t *testing.T, name string) *Driver {
 
 	d, err := graphdriver.GetDriver(name, root, nil)
 	if err != nil {
-		if err == graphdriver.ErrNotSupported || err == graphdriver.ErrPrerequisites {
+		if err == graphdriver.ErrNotSupported || err == graphdriver.ErrPrerequisites || strings.Contains(err.Error(), "'overlay' is not supported over") {
 			t.Skipf("Driver %s not supported", name)
 		}
 		t.Fatal(err)


### PR DESCRIPTION
Update graphtest so when overlay is tried over a non-supported backing
filesystem it will skip.
