### PR TITLE
LXC needs stdin for container to remain up

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -316,7 +316,7 @@ func TestRunWithoutNetworking(t *testing.T) {
 
 //test --link use container name to link target
 func TestRunLinksContainerWithContainerName(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-t", "-d", "--name", "parent", "busybox")
+	cmd := exec.Command(dockerBinary, "run", "-i", "-t", "-d", "--name", "parent", "busybox")
 	out, _, _, err := runCommandWithStdoutStderr(cmd)
 	if err != nil {
 		t.Fatalf("failed to run container: %v, output: %q", err, out)
@@ -342,7 +342,7 @@ func TestRunLinksContainerWithContainerName(t *testing.T) {
 
 //test --link use container id to link target
 func TestRunLinksContainerWithContainerId(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-t", "-d", "busybox")
+	cmd := exec.Command(dockerBinary, "run", "-i", "-t", "-d", "busybox")
 	cID, _, _, err := runCommandWithStdoutStderr(cmd)
 	if err != nil {
 		t.Fatalf("failed to run container: %v, output: %q", err, cID)


### PR DESCRIPTION
To run shell(and not exit), lxc needs STDIN. Without STDIN open, it will exit 0.

Docker-DCO-1.1-Signed-off-by: Abin Shahab ashahab@altiscale.com (github: ashahab-altiscale)
