### PR TITLE
devmapper: initialize log levels

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -717,8 +717,10 @@ func setCloseOnExec(name string) {
 }
 
 func (devices *DeviceSet) DMLog(level int, file string, line int, dmError int, message string) {
-	if level >= 7 {
-		return // Ignore _LOG_DEBUG
+	if level >= devicemapper.LogLevelDebug {
+		// (vbatts) libdm debug is very verbose. If you're debugging libdm, you can
+		// comment out this check yourself
+		level = devicemapper.LogLevelInfo
 	}
 
 	// FIXME(vbatts) push this back into ./pkg/devicemapper/
@@ -939,6 +941,11 @@ func (devices *DeviceSet) closeTransaction() error {
 }
 
 func (devices *DeviceSet) initDevmapper(doInit bool) error {
+	if os.Getenv("DEBUG") != "" {
+		devicemapper.LogInitVerbose(devicemapper.LogLevelDebug)
+	} else {
+		devicemapper.LogInitVerbose(devicemapper.LogLevelWarn)
+	}
 	// give ourselves to libdm as a log handler
 	devicemapper.LogInit(devices)
 

--- a/pkg/devicemapper/log.go
+++ b/pkg/devicemapper/log.go
@@ -1,0 +1,11 @@
+package devicemapper
+
+// definitions from lvm2 lib/log/log.h
+const (
+	LogLevelFatal  = 2 + iota // _LOG_FATAL
+	LogLevelErr               // _LOG_ERR
+	LogLevelWarn              // _LOG_WARN
+	LogLevelNotice            // _LOG_NOTICE
+	LogLevelInfo              // _LOG_INFO
+	LogLevelDebug             // _LOG_DEBUG
+)


### PR DESCRIPTION
I'll say, the importance of this change is that the skipping debug level log did the opposite of what we would want. In that when docker is run in debug mode, then _no_ logging would occur.

Additionally, there are tell-tale output from device-mapper on WARN level 4, so this makes that the default level.

Signed-off-by: Vincent Batts vbatts@redhat.com
