### PR TITLE
device-mapper udev sync

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -947,6 +947,12 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 		return graphdriver.ErrNotSupported
 	}
 
+	// https://github.com/docker/docker/issues/4036
+	if supported := devicemapper.UdevSetSyncSupport(true); !supported {
+		log.Warnf("WARNING: Udev sync is not supported. This will lead to unexpected behavior, data loss and errors")
+	}
+	log.Debugf("devicemapper: udev sync support: %v", devicemapper.UdevSyncSupported())
+
 	if err := os.MkdirAll(devices.metadataDir(), 0700); err != nil && !os.IsExist(err) {
 		return err
 	}

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -105,14 +105,15 @@ type DiskUsage struct {
 }
 
 type Status struct {
-	PoolName         string
-	DataFile         string // actual block device for data
-	DataLoopback     string // loopback file, if used
-	MetadataFile     string // actual block device for metadata
-	MetadataLoopback string // loopback file, if used
-	Data             DiskUsage
-	Metadata         DiskUsage
-	SectorSize       uint64
+	PoolName          string
+	DataFile          string // actual block device for data
+	DataLoopback      string // loopback file, if used
+	MetadataFile      string // actual block device for metadata
+	MetadataLoopback  string // loopback file, if used
+	Data              DiskUsage
+	Metadata          DiskUsage
+	SectorSize        uint64
+	UdevSyncSupported bool
 }
 
 type DevStatus struct {
@@ -1578,6 +1579,7 @@ func (devices *DeviceSet) Status() *Status {
 	status.DataLoopback = devices.dataLoopFile
 	status.MetadataFile = devices.MetadataDevicePath()
 	status.MetadataLoopback = devices.metadataLoopFile
+	status.UdevSyncSupported = devicemapper.UdevSyncSupported()
 
 	totalSizeInSectors, _, dataUsed, dataTotal, metadataUsed, metadataTotal, err := devices.poolStatus()
 	if err == nil {

--- a/daemon/graphdriver/devmapper/driver.go
+++ b/daemon/graphdriver/devmapper/driver.go
@@ -74,6 +74,7 @@ func (d *Driver) Status() [][2]string {
 		{"Data Space Total", fmt.Sprintf("%s", units.HumanSize(float64(s.Data.Total)))},
 		{"Metadata Space Used", fmt.Sprintf("%s", units.HumanSize(float64(s.Metadata.Used)))},
 		{"Metadata Space Total", fmt.Sprintf("%s", units.HumanSize(float64(s.Metadata.Total)))},
+		{"Udev Sync Supported", fmt.Sprintf("%v", s.UdevSyncSupported)},
 	}
 	if len(s.DataLoopback) > 0 {
 		status = append(status, [2]string{"Data loop file", s.DataLoopback})

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -319,6 +319,26 @@ func GetLibraryVersion() (string, error) {
 	return version, nil
 }
 
+// UdevSyncSupported returns whether device-mapper is able to sync with udev
+//
+// This is essential otherwise race conditions can arise where both udev and
+// device-mapper attempt to create and destroy devices.
+func UdevSyncSupported() bool {
+	return DmUdevGetSyncSupport() != 0
+}
+
+// UdevSetSyncSupport allows setting whether the udev sync should be enabled.
+// The return bool indicates the state of whether the sync is enabled.
+func UdevSetSyncSupport(enable bool) bool {
+	if enable {
+		DmUdevSetSyncSupport(1)
+	} else {
+		DmUdevSetSyncSupport(0)
+	}
+
+	return UdevSyncSupported()
+}
+
 // Useful helper for cleanup
 func RemoveDevice(name string) error {
 	log.Debugf("[devmapper] RemoveDevice START")

--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -107,6 +107,8 @@ var (
 	DmTaskSetRo            = dmTaskSetRoFct
 	DmTaskSetSector        = dmTaskSetSectorFct
 	DmUdevWait             = dmUdevWaitFct
+	DmUdevSetSyncSupport   = dmUdevSetSyncSupportFct
+	DmUdevGetSyncSupport   = dmUdevGetSyncSupportFct
 	LogWithErrnoInit       = logWithErrnoInitFct
 )
 
@@ -229,6 +231,14 @@ func dmGetNextTargetFct(task *CDmTask, next uintptr, start, length *uint64, targ
 
 	nextp := C.dm_get_next_target((*C.struct_dm_task)(task), unsafe.Pointer(next), &Cstart, &Clength, &CtargetType, &Cparams)
 	return uintptr(nextp)
+}
+
+func dmUdevSetSyncSupportFct(syncWithUdev int) {
+	(C.dm_udev_set_sync_support(C.int(syncWithUdev)))
+}
+
+func dmUdevGetSyncSupportFct() int {
+	return int(C.dm_udev_get_sync_support())
 }
 
 func dmUdevWaitFct(cookie uint) int {


### PR DESCRIPTION
sync devicemapper and udev.
If sync is not supported, print a warning that unexpected behavior may occur.
relates to #4036 
ping @unclejack 
