### PR TITLE
Add mirroring support for v2

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -72,7 +72,7 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 		logName += ":" + tag
 	}
 
-	if len(repoInfo.Index.Mirrors) == 0 && (repoInfo.Index.Official || endpoint.Version == registry.APIVersion2) {
+	if repoInfo.Index.Official || endpoint.Version == registry.APIVersion2 {
 		j := job.Eng.Job("trust_update_base")
 		if err = j.Run(); err != nil {
 			log.Errorf("error updating trust base graph: %s", err)
@@ -373,7 +373,7 @@ type downloadInfo struct {
 }
 
 func (s *TagStore) pullV2Repository(eng *engine.Engine, r *registry.Session, out io.Writer, repoInfo *registry.RepositoryInfo, tag string, sf *utils.StreamFormatter, parallel bool) error {
-	endpoint, err := r.V2RegistryEndpoint(repoInfo.Index)
+	endpoint, err := r.V2RegistryEndpoint(repoInfo.Index, true)
 	if err != nil {
 		return fmt.Errorf("error getting registry endpoint: %s", err)
 	}

--- a/graph/push.go
+++ b/graph/push.go
@@ -260,7 +260,7 @@ func (s *TagStore) pushV2Repository(r *registry.Session, eng *engine.Engine, out
 		}
 	}
 
-	endpoint, err := r.V2RegistryEndpoint(repoInfo.Index)
+	endpoint, err := r.V2RegistryEndpoint(repoInfo.Index, false)
 	if err != nil {
 		return fmt.Errorf("error getting registry endpoint: %s", err)
 	}

--- a/registry/session_v2.go
+++ b/registry/session_v2.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -19,10 +20,31 @@ func getV2Builder(e *Endpoint) *v2.URLBuilder {
 	return e.URLBuilder
 }
 
-func (r *Session) V2RegistryEndpoint(index *IndexInfo) (ep *Endpoint, err error) {
-	// TODO check if should use Mirror
-	if index.Official {
-		ep, err = newEndpoint(REGISTRYSERVER, true)
+func (r *Session) V2RegistryEndpoint(index *IndexInfo, useMirror bool) (ep *Endpoint, err error) {
+	if useMirror && len(index.Mirrors) > 1 {
+		for i := 0; i < len(index.Mirrors); i++ {
+			ep, err = newEndpoint(index.Mirrors[i], index.Secure)
+			if err != nil {
+				return
+			}
+			err = validateEndpoint(ep)
+			if err != nil {
+				return
+			}
+			if ep.Version == APIVersion2 {
+				// V2 endpoint found
+				break
+			} else {
+				// Unsupported endpoint, try next
+				ep = nil
+			}
+		}
+		if ep == nil {
+			err = errors.New("no V2 supported mirrors")
+			return
+		}
+	} else if index.Official {
+		ep, err = newEndpoint(REGISTRYSERVER, index.Secure)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
Adds support for using the mirror flag for a v2 registry.  Unlike in v1, the flag is interpreted as an endpoint to use to send all v2 requests, acting more as a proxy-cache than a pure content mirror.  The plan for v2 mirroring of the content-addressable blobs is outside the scope of the current flag.

See https://github.com/docker/distribution/issues/80 for the proposal to configure content mirrors
