### PR TITLE
devicemapper: set flags based on udev sync support

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1099,7 +1099,7 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 
 func (devices *DeviceSet) AddDevice(hash, baseHash string) error {
 	log.Debugf("[deviceset] AddDevice() hash=%s basehash=%s", hash, baseHash)
-	defer log.Debugf("[deviceset] AddDevice END")
+	defer log.Debugf("[deviceset] AddDevice(hash=%s basehash=%s) END", hash, baseHash)
 
 	baseInfo, err := devices.lookupDevice(baseHash)
 	if err != nil {
@@ -1203,7 +1203,7 @@ func (devices *DeviceSet) deactivatePool() error {
 
 func (devices *DeviceSet) deactivateDevice(info *DevInfo) error {
 	log.Debugf("[devmapper] deactivateDevice(%s)", info.Hash)
-	defer log.Debugf("[devmapper] deactivateDevice END")
+	defer log.Debugf("[devmapper] deactivateDevice END(%s)", info.Hash)
 
 	// Wait for the unmount to be effective,
 	// by watching the value of Info.OpenCount for the device
@@ -1425,7 +1425,7 @@ func (devices *DeviceSet) MountDevice(hash, path, mountLabel string) error {
 
 func (devices *DeviceSet) UnmountDevice(hash string) error {
 	log.Debugf("[devmapper] UnmountDevice(hash=%s)", hash)
-	defer log.Debugf("[devmapper] UnmountDevice END")
+	defer log.Debugf("[devmapper] UnmountDevice(hash=%s) END", hash)
 
 	info, err := devices.lookupDevice(hash)
 	if err != nil {

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -341,8 +341,8 @@ func UdevSetSyncSupport(enable bool) bool {
 
 // Useful helper for cleanup
 func RemoveDevice(name string) error {
-	log.Debugf("[devmapper] RemoveDevice START")
-	defer log.Debugf("[devmapper] RemoveDevice END")
+	log.Debugf("[devmapper] RemoveDevice START(%s)", name)
+	defer log.Debugf("[devmapper] RemoveDevice END(%s)", name)
 	task, err := TaskCreateNamed(DeviceRemove, name)
 	if task == nil {
 		return err

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -291,6 +291,14 @@ func UdevWait(cookie uint) error {
 	return nil
 }
 
+func basicTaskFlags() uint16 {
+	var flags uint16
+	if UdevSyncSupported() {
+		flags |= DmUdevDisableLibraryFallback
+	}
+	return flags
+}
+
 func LogInitVerbose(level int) {
 	DmLogInitVerbose(level)
 }
@@ -348,8 +356,11 @@ func RemoveDevice(name string) error {
 		return err
 	}
 
-	var cookie uint = 0
-	if err := task.SetCookie(&cookie, 0); err != nil {
+	var (
+		cookie uint = 0
+		flags       = basicTaskFlags()
+	)
+	if err := task.SetCookie(&cookie, flags); err != nil {
 		return fmt.Errorf("Can not set cookie: %s", err)
 	}
 	defer UdevWait(cookie)
@@ -414,8 +425,10 @@ func CreatePool(poolName string, dataFile, metadataFile *os.File, poolBlockSize 
 		return fmt.Errorf("Can't add target %s", err)
 	}
 
-	var cookie uint = 0
-	var flags uint16 = DmUdevDisableSubsystemRulesFlag | DmUdevDisableDiskRulesFlag | DmUdevDisableOtherRulesFlag
+	var (
+		cookie uint = 0
+		flags       = basicTaskFlags() | DmUdevDisableSubsystemRulesFlag | DmUdevDisableDiskRulesFlag | DmUdevDisableOtherRulesFlag
+	)
 	if err := task.SetCookie(&cookie, flags); err != nil {
 		return fmt.Errorf("Can't set cookie %s", err)
 	}
@@ -546,8 +559,11 @@ func ResumeDevice(name string) error {
 		return err
 	}
 
-	var cookie uint = 0
-	if err := task.SetCookie(&cookie, 0); err != nil {
+	var (
+		cookie uint = 0
+		flags       = basicTaskFlags()
+	)
+	if err := task.SetCookie(&cookie, flags); err != nil {
 		return fmt.Errorf("Can't set cookie %s", err)
 	}
 	defer UdevWait(cookie)
@@ -620,8 +636,11 @@ func ActivateDevice(poolName string, name string, deviceId int, size uint64) err
 		return fmt.Errorf("Can't add node %s", err)
 	}
 
-	var cookie uint = 0
-	if err := task.SetCookie(&cookie, 0); err != nil {
+	var (
+		cookie uint = 0
+		flags       = basicTaskFlags()
+	)
+	if err := task.SetCookie(&cookie, flags); err != nil {
 		return fmt.Errorf("Can't set cookie %s", err)
 	}
 

--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -86,6 +86,7 @@ const (
 	DmUdevDisableSubsystemRulesFlag = C.DM_UDEV_DISABLE_SUBSYSTEM_RULES_FLAG
 	DmUdevDisableDiskRulesFlag      = C.DM_UDEV_DISABLE_DISK_RULES_FLAG
 	DmUdevDisableOtherRulesFlag     = C.DM_UDEV_DISABLE_OTHER_RULES_FLAG
+	DmUdevDisableLibraryFallback    = C.DM_UDEV_DISABLE_LIBRARY_FALLBACK
 )
 
 var (


### PR DESCRIPTION
per #10195 this will disable fallback on devicemapper for device node creation when udev sync is supported. This eliminates the risk of udev vs. devicemapper race _only_ when sync is supported.

If sync is _not_ supported, then the race will likely be hit.

relates to #4036 

Ping @unclejack 
