### PR TITLE
Bash completion for the daemon flags

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -104,6 +104,22 @@ __docker_pos_first_nonflag() {
 	echo $counter
 }
 
+# Transforms a multiline list of strings into a single line string
+# with the words separated by "|".
+# This is used to prepare arguments to __docker_pos_first_nonflag().
+__docker_to_alternatives() {
+	local parts=( $1 )
+	local IFS='|'
+	echo "${parts[*]}"
+}
+
+# Transforms a multiline list of options into an extglob pattern
+# suitable for use in case statements.
+__docker_to_extglob() {
+	local extglob=$( __docker_to_alternatives "$1" )
+	echo "@($extglob)"
+}
+
 __docker_resolve_hostname() {
 	command -v host >/dev/null 2>&1 || return
 	COMPREPLY=( $(host 2>/dev/null "${cur%:}" | awk '/has address/ {print $4}') )
@@ -154,15 +170,47 @@ __docker_capabilities() {
 }
 
 _docker_docker() {
+	local boolean_options="
+		--api-enable-cors
+		--daemon -d
+		--debug -D
+		--help -h
+		--icc
+		--ip-forward
+		--ip-masq
+		--iptables
+		--ipv6
+		--selinux-enabled
+		--tls
+		--tlsverify
+		--version -v
+	"
+
 	case "$prev" in
-		-H)
+		--graph|-g)
+			_filedir -d
+			return
+			;;
+		--log-level|-l)
+			COMPREPLY=( $( compgen -W "debug info warn error fatal" -- "$cur" ) )
+			return
+			;;
+		--pidfile|-p|--tlscacert|--tlscert|--tlskey)
+			_filedir
+			return
+			;;
+		--storage-driver|-s)
+			COMPREPLY=( $( compgen -W "aufs devicemapper btrfs overlay" -- "$(echo $cur | tr '[:upper:]' '[:lower:]')" ) )
+			return
+			;;
+		$main_options_with_args_glob )
 			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "-H" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "$boolean_options $main_options_with_args" -- "$cur" ) )
 			;;
 		*)
 			COMPREPLY=( $( compgen -W "${commands[*]} help" -- "$cur" ) )
@@ -561,6 +609,8 @@ _docker_run() {
 		--sig-proxy
 	"
 
+	local options_with_args_glob=$(__docker_to_extglob "$options_with_args")
+
 	case "$prev" in
 		--add-host)
 			case "$cur" in
@@ -677,7 +727,7 @@ _docker_run() {
 			__docker_containers_all
 			return
 			;;
-		--cpuset|--cpu-shares|-c|--dns|--dns-search|--entrypoint|--expose|--hostname|-h|--lxc-conf|--mac-address|--memory|-m|--name|-n|--publish|-p|--user|-u|--workdir|-w)
+		$options_with_args_glob )
 			return
 			;;
 	esac
@@ -687,7 +737,7 @@ _docker_run() {
 			COMPREPLY=( $( compgen -W "$all_options" -- "$cur" ) )
 			;;
 		*)
-			local counter=$( __docker_pos_first_nonflag $( echo $options_with_args | tr -d "\n" | tr " " "|" ) )
+			local counter=$( __docker_pos_first_nonflag $( __docker_to_alternatives "$options_with_args" ) )
 
 			if [ $cword -eq $counter ]; then
 				__docker_image_repos_and_tags_and_ids
@@ -801,6 +851,9 @@ _docker_wait() {
 }
 
 _docker() {
+	local previous_extglob_setting=$(shopt -p extglob)
+	shopt -s extglob
+
 	local commands=(
 		attach
 		build
@@ -841,6 +894,33 @@ _docker() {
 		wait
 	)
 
+	local main_options_with_args="
+		--bip
+		--bridge -b
+		--dns
+		--dns-search
+		--exec-driver -e
+		--fixed-cidr
+		--fixed-cidr-v6
+		--graph -g
+		--group -G
+		--host -H
+		--insecure-registry
+		--ip
+		--label
+		--log-level -l
+		--mtu
+		--pidfile -p
+		--registry-mirror
+		--storage-driver -s
+		--storage-opt
+		--tlscacert
+		--tlscert
+		--tlskey
+	"
+
+	local main_options_with_args_glob=$(__docker_to_extglob "$main_options_with_args")
+
 	COMPREPLY=()
 	local cur prev words cword
 	_get_comp_words_by_ref -n : cur prev words cword
@@ -849,7 +929,7 @@ _docker() {
 	local counter=1
 	while [ $counter -lt $cword ]; do
 		case "${words[$counter]}" in
-			-H)
+			$main_options_with_args_glob )
 				(( counter++ ))
 				;;
 			-*)
@@ -867,6 +947,7 @@ _docker() {
 	local completions_func=_docker_${command}
 	declare -F $completions_func >/dev/null && $completions_func
 
+	eval "$previous_extglob_setting"
 	return 0
 }
 


### PR DESCRIPTION
The only daemon flag implemented so far was `-H`.
When adding the missing options using the existing coding style, the list of options with arguments had to be duplicated in `__docker`, making this completion even worse (in terms of redundancy) than the subcommand completions.

I switched to using extended shell globbing which allows to use variables in case statements.
This allows to remove a lot of redundancy when argument lists grow long.

Another goody: in `_docker_run` a repeated call to `tr` was replaced by variable substitutions.

This PR also amends #10124.

@tianon @jfrazelle Please review. Hope it's not too late for the code freeze.
