### PR TITLE
Update TestBuildWithTabs to allow for the "\t"-equivalent "\u0009" (for Go 1.3 support)

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4302,9 +4302,10 @@ func TestBuildWithTabs(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expected := `["/bin/sh","-c","echo\tone\t\ttwo"]`
-	if res != expected {
-		t.Fatalf("Missing tabs.\nGot:%s\nExp:%s", res, expected)
+	expected1 := `["/bin/sh","-c","echo\tone\t\ttwo"]`
+	expected2 := `["/bin/sh","-c","echo\u0009one\u0009\u0009two"]` // syntactically equivalent, and what Go 1.3 generates
+	if res != expected1 && res != expected2 {
+		t.Fatalf("Missing tabs.\nGot: %s\nExp: %s or %s", res, expected1, expected2)
 	}
 	logDone("build - with tabs")
 }


### PR DESCRIPTION
This is literally the only failing test on Go 1.3.3: :tada:

```
--- FAIL: TestBuildWithTabs (0.43 seconds)
    docker_cli_build_test.go:4307: Missing tabs.
        Got:["/bin/sh","-c","echo\u0009one\u0009\u0009two"]
        Exp:["/bin/sh","-c","echo\tone\t\ttwo"]
```

See also https://jenkins.dockerproject.com/job/Docker%20Go%201.3.3/label=ubuntu-btrfs/1/console

cc @jfrazelle
