### PR TITLE
daemon mount namespaces

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -6,6 +6,7 @@ Requires=docker.socket
 
 [Service]
 ExecStart=/usr/bin/docker -d -H fd://
+MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
 

--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -23,6 +23,7 @@
 . /etc/rc.d/init.d/functions
 
 prog="docker"
+unshare=/usr/bin/unshare
 exec="/usr/bin/$prog"
 pidfile="/var/run/$prog.pid"
 lockfile="/var/lock/subsys/$prog"
@@ -46,7 +47,7 @@ start() {
         prestart
         printf "Starting $prog:\t"
         echo "\n$(date)\n" >> $logfile
-        $exec -d $other_args &>> $logfile &
+        "$unshare" -m -- $exec -d $other_args &>> $logfile &
         pid=$!
         touch $lockfile
         # wait up to 10 seconds for the pidfile to exist.  see


### PR DESCRIPTION
This change covers two of the contrib init's. The daemon ought to be invoked in its own mount namespace, unshared from the root mount namespace.

Some of the error most often seen affect the devicemapper graph driver, seen as EBUSY or "device or resource busy".
Though others are likely to run in to this as folks will have containers that will have mounts or even devices being mounted. 

If any other pid outside of the docker daemon unshares their mount namespace, and that  pid's mountinfo includes a mount reference of a container, then even when the container exits, and attempts to remove, there kernel will return that the path is busy, due to the mount reference by the outside pid.

I've written about this here: http://blog.hashbangbash.com/2014/11/docker-devicemapper-fix-for-device-or-resource-busy-ebusy/

I did not include a commit for the init scripts with `start-stop-daemon`, as I would like them to get more testing first. See: 
- openrc - http://pastebin.com/tT1jUhzR
- sysvinit-debian - http://pastebin.com/7hbkSTna

(and for completeness, here is the change for ubuntu's upstart http://pastebin.com/D5MsVCUK)
