### PR TITLE
Try to cleanly unmount docker block devices

### DIFF
--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -25,6 +25,7 @@
 prog="docker"
 exec="/usr/bin/$prog"
 pidfile="/var/run/$prog.pid"
+lib="/var/lib/$prog"
 lockfile="/var/lock/subsys/$prog"
 logfile="/var/log/$prog"
 
@@ -72,6 +73,9 @@ stop() {
     retval=$?
     echo
     [ $retval -eq 0 ] && rm -f $lockfile
+    if [ $(df | grep $lib | awk '{print $1}' | wc -l) -gt 0 ]; then
+        umount $(df | grep $lib | awk '{print $1}')
+    fi
     return $retval
 }
 


### PR DESCRIPTION
In an attempt to _improve_ the situation with #5684 this change tries to clean up those block devices. Docker _very_ frequently leaves block devices behind if the running containers are not stopped prior to stopping the daemon resulting in the service not starting correctly.

Containers with restart policies set to "always" are not able to start as a result of this. This change tries to unmount devices left by the service after the service is stopped. If the community doesn't like this solution, another possible solution would be to stop all containers using `docker stop $(docker ps -aq)` _before_ the daemon is stopped which should work pretty well as well.
