### PR TITLE
Update emptyfs support to work properly if scratch is already an image

### DIFF
--- a/project/make/.ensure-busybox
+++ b/project/make/.ensure-busybox
@@ -1,8 +1,8 @@
 #!/bin/bash
+set -e
 
 if ! docker inspect busybox &> /dev/null; then
 	if [ -d /docker-busybox ]; then
-		source "$(dirname "$BASH_SOURCE")/.ensure-scratch"
 		( set -x; docker build -t busybox /docker-busybox )
 	else
 		( set -x; docker pull busybox )

--- a/project/make/.ensure-emptyfs
+++ b/project/make/.ensure-emptyfs
@@ -1,12 +1,13 @@
 #!/bin/bash
+set -e
 
-if ! docker inspect scratch &> /dev/null; then
+if ! docker inspect emptyfs &> /dev/null; then
 	# let's build a "docker save" tarball for "emptyfs"
 	# see https://github.com/docker/docker/pull/5262
 	# and also https://github.com/docker/docker/issues/4242
-	mkdir -p /docker-scratch
+	dir="$(mktemp -d)"
 	(
-		cd /docker-scratch
+		cd "$dir"
 		echo '{"emptyfs":{"latest":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158"}}' > repositories
 		mkdir -p 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158
 		(
@@ -16,6 +17,6 @@ if ! docker inspect scratch &> /dev/null; then
 			tar -cf layer.tar --files-from /dev/null
 		)
 	)
-	( set -x; tar -cf /docker-scratch.tar -C /docker-scratch . )
-	( set -x; docker load --input /docker-scratch.tar )
+	( set -x; tar -cC "$dir" . | docker load )
+	rm -rf "$dir"
 fi

--- a/project/make/test-integration-cli
+++ b/project/make/test-integration-cli
@@ -20,6 +20,7 @@ bundle_test_integration_cli() {
 		sleep 2
 
 		source "$(dirname "$BASH_SOURCE")/.ensure-busybox"
+		source "$(dirname "$BASH_SOURCE")/.ensure-emptyfs"
 
 		bundle_test_integration_cli
 	}; then


### PR DESCRIPTION
Also, this decouples the emptyfs script from the busybox one -- they're now functionally separate thanks to the scratch no-op change. :+1:
