### PR TITLE
Adds /exec/(id)/start/ws endpoint similar to functionality of /containers/(id)/attach/ws

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1220,6 +1220,34 @@ func postContainerExecStart(eng *engine.Engine, version version.Version, w http.
 	return nil
 }
 
+func wsContainersExecStart(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if vars == nil {
+		return fmt.Errorf("Missing parameter")
+	}
+
+	if err := parseForm(r); err != nil {
+		return err
+	}
+
+	h := websocket.Handler(func(ws *websocket.Conn) {
+		defer ws.Close()
+
+		job := eng.Job("execStart", vars["name"])
+		job.SetenvBool("Detach", false)
+		job.Setenv("Tty", r.Form.Get("tty"))
+		job.Stdin.Add(ws)
+		job.Stdout.Add(ws)
+		job.Stderr.Set(ws)
+
+		if err := job.Run(); err != nil {
+			log.Errorf("Error starting exec command in container %s: %s\n", vars["name"], err)
+		}
+	})
+	h.ServeHTTP(w, r)
+
+	return nil
+}
+
 func postContainerExecResize(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -1339,6 +1367,7 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 			"/containers/{name:.*}/stats":     getContainersStats,
 			"/containers/{name:.*}/attach/ws": wsContainersAttach,
 			"/exec/{id:.*}/json":              getExecByID,
+			"/exec/{name:.*}/start/ws":        wsContainersExecStart,
 		},
 		"POST": {
 			"/auth":                         postAuth,

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -1754,6 +1754,32 @@ Status Codes:
     **Stream details**:
     Similar to the stream behavior of `POST /container/(id)/attach` API
 
+### Exec Start (websocket)
+
+`GET /exec/(id)/start/ws`
+
+Starts a previously set up exec instance `id`. This API sets up and interactive
+session with the `exec` command via websocket according to the io configuration
+when the exec instance `id` was created.
+
+Implements websocket protocol handshake according to [RFC 6455](http://tools.ietf.org/html/rfc6455)
+
+**Example request**
+
+        GET /exec/e90e34656806/start/ws?tty=0 HTTP/1.1
+
+**Example response**
+
+        {{ STREAM }}
+
+Query Parameters:
+
+-   **tty** – Boolean value, attach standard streams to a tty
+
+Status Codes:
+
+    **404** - no such exec instance
+
 ### Exec Resize
 
 `POST /exec/(id)/resize`

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -2,9 +2,14 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net"
 	"os/exec"
 	"testing"
+
+	"code.google.com/p/go.net/websocket"
 )
 
 // Regression test for #9414
@@ -22,4 +27,177 @@ func TestExecApiCreateNoCmd(t *testing.T) {
 	}
 
 	logDone("exec create API - returns error when missing Cmd")
+}
+
+func TestGetContainersExecStartWebsocketInvalidExecId(t *testing.T) {
+	config, err := websocket.NewConfig(
+		"/exec//start/ws",
+		"http://localhost",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rwc, err := net.Dial("unix", "/var/run/docker.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = websocket.NewClient(config, rwc)
+	if err == nil {
+		t.Fatal("Expected an error for an invalid exec id")
+	}
+
+	logDone("exec start API - returns error with invalid exec id")
+}
+
+func TestGetContainersExecStartWebsocket(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "-dit", "busybox", "sh")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatalf(out, err)
+	}
+	cleanedContainerID := stripTrailingCharacters(out)
+	defer deleteAllContainers()
+
+	// create the exec instance
+	body, err := sockRequest(
+		"POST",
+		"/containers/"+cleanedContainerID+"/exec",
+		map[string]interface{}{
+			"AttachStdin":  true,
+			"AttachStdout": true,
+			"AttachStderr": true,
+			"Tty":          false,
+			"Cmd":          []string{"cat"},
+		},
+	)
+	if body == nil && err != nil {
+		t.Fatal(err)
+	}
+	setupExec := struct {
+		Id string
+	}{}
+	if err = json.Unmarshal(body, &setupExec); err != nil {
+		t.Fatal(err)
+	}
+
+	// connect to websocket endpoint
+	config, err := websocket.NewConfig(
+		"/exec/"+setupExec.Id+"/start/ws",
+		"http://localhost",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rwc, err := net.Dial("unix", "/var/run/docker.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ws, err := websocket.NewClient(config, rwc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ws.Close()
+
+	// test cat echo
+	expected := []byte("hello")
+	actual := make([]byte, len(expected))
+	readChan := make(chan string)
+	go func() {
+		if _, err := ws.Read(actual); err != nil {
+			t.Fatal(err)
+		}
+		readChan <- "done"
+	}()
+
+	writeChan := make(chan string)
+	go func() {
+		if _, err := ws.Write(expected); err != nil {
+			t.Fatal(err)
+		}
+		writeChan <- "done"
+	}()
+
+	<-writeChan
+	<-readChan
+
+	if !bytes.Equal(expected, actual) {
+		t.Fatalf("Output should be '%s', got '%s'", expected, actual)
+	}
+
+	logDone("exec start API - cat echo via websocket")
+}
+
+func TestGetContainersExecStartWebsocketTty(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "-dit", "busybox", "sh")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatalf(out, err)
+	}
+	cleanedContainerID := stripTrailingCharacters(out)
+	defer deleteAllContainers()
+
+	// create the exec instance
+	body, err := sockRequest(
+		"POST",
+		"/containers/"+cleanedContainerID+"/exec",
+		map[string]interface{}{
+			"AttachStdin":  true,
+			"AttachStdout": true,
+			"AttachStderr": true,
+			"Tty":          true,
+			"Cmd":          []string{"cat"},
+		},
+	)
+	if body == nil && err != nil {
+		t.Fatal(err)
+	}
+	setupExec := struct {
+		Id string
+	}{}
+	if err = json.Unmarshal(body, &setupExec); err != nil {
+		t.Fatal(err)
+	}
+
+	// connect to websocket endpoint
+	config, err := websocket.NewConfig(
+		"/exec/"+setupExec.Id+"/start/ws?tty=1",
+		"http://localhost",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rwc, err := net.Dial("unix", "/var/run/docker.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ws, err := websocket.NewClient(config, rwc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ws.Close()
+
+	// test ctrl-p-q detach
+	writeChan := make(chan string)
+	go func() {
+		if _, err := ws.Write([]byte{16}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ws.Write([]byte{17}); err != nil {
+			t.Fatal(err)
+		}
+		writeChan <- "done"
+	}()
+	<-writeChan
+
+	// expect a read to fail
+	readChan := make(chan string)
+	go func() {
+		if _, err := ws.Read(make([]byte, 1)); err != io.EOF {
+			t.Fatal("Should have received io.EOF when trying to read from websocket after ctrl-p-q")
+		}
+		readChan <- "done"
+	}()
+	<-readChan
+
+	logDone("exec start API - ctrl-p-q detach via websocket")
 }


### PR DESCRIPTION
Closes #9372

Provided a valid `exec` instance id, `/exec/(id)/start/ws` establishes a websocket connection to the owning container's standard pipes. This is similar to the `/containers/(id)/attach/ws` endpoint and functionality.

I have defaulted the `Detach: false` flag for the `execStart` job to the daemon as a result of a request to `/exec/(id)/start/ws` because I assumed the client would not desire `Detach: true` to be set as they are attempting to establish a websocket connection. However the `Tty` flag is still available for the client to specify via query string.

Signed-off-by: Andrew C. Bodine acbodine@us.ibm.com
