### PR TITLE
Fix write after close on http response

### DIFF
--- a/engine/streams.go
+++ b/engine/streams.go
@@ -111,6 +111,7 @@ func (o *Output) Close() error {
 		}
 	}
 	o.tasks.Wait()
+	o.dests = nil
 	return firstErr
 }
 

--- a/registry/session_v2.go
+++ b/registry/session_v2.go
@@ -226,7 +226,7 @@ func (r *Session) PutV2ImageBlob(ep *Endpoint, imageName, sumType, sumStr string
 
 	method := "PUT"
 	log.Debugf("[registry] Calling %q %s", method, location)
-	req, err = r.reqFactory.NewRequest(method, location, blobRdr)
+	req, err = r.reqFactory.NewRequest(method, location, ioutil.NopCloser(blobRdr))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Address #10228 but is not a confirmed fix

Both solutions should be valid and fix a possible panic caused by writing to an http.Response after the response has been finalized.  The fix in streams could fix a wider range of panics.  The registry fix is targeting a specific panic caused by a close on the progressreader being called by the network connection.  The NopCloser will prevent the network connection from being able to close the progressreader, which in turns attempts a flush on a writer bound to the http.Response to the client.
