### PR TITLE
Split API Version header when checking for v2

### DIFF
--- a/registry/endpoint.go
+++ b/registry/endpoint.go
@@ -231,10 +231,13 @@ func (e *Endpoint) pingV2() (RegistryInfo, error) {
 	// Ensure it supports the v2 Registry API.
 	var supportsV2 bool
 
-	for _, versionName := range resp.Header[http.CanonicalHeaderKey("Docker-Distribution-API-Version")] {
-		if versionName == "registry/2.0" {
-			supportsV2 = true
-			break
+HeaderLoop:
+	for _, supportedVersions := range resp.Header[http.CanonicalHeaderKey("Docker-Distribution-API-Version")] {
+		for _, versionName := range strings.Fields(supportedVersions) {
+			if versionName == "registry/2.0" {
+				supportsV2 = true
+				break HeaderLoop
+			}
 		}
 	}
 

--- a/registry/endpoint_test.go
+++ b/registry/endpoint_test.go
@@ -42,7 +42,9 @@ func TestValidateEndpointAmbiguousAPIVersion(t *testing.T) {
 	})
 
 	requireBasicAuthHandlerV2 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add("Docker-Distribution-API-Version", "registry/2.0")
+		// This mock server supports v2.0, v2.1, v42.0, and v100.0
+		w.Header().Add("Docker-Distribution-API-Version", "registry/100.0 registry/42.0")
+		w.Header().Add("Docker-Distribution-API-Version", "registry/2.0 registry/2.1")
 		requireBasicAuthHandler.ServeHTTP(w, r)
 	})
 


### PR DESCRIPTION
Since the Docker-Distribution-API-Version header value may contain multiple
space delimited versions as well as many instances of the header key, the
header value is now split on whitespace characters to iterate over all versions
that may be listed in one instance of the header.

fixes #10247
