### PR TITLE
Refactor some registry client and auth code

### DIFF
--- a/pkg/httputils/resumablerequestreader.go
+++ b/pkg/httputils/resumablerequestreader.go
@@ -10,7 +10,7 @@ import (
 )
 
 type resumableRequestReader struct {
-	client          *http.Client
+	client          Client
 	request         *http.Request
 	lastRange       int64
 	totalSize       int64
@@ -19,14 +19,21 @@ type resumableRequestReader struct {
 	maxFailures     uint32
 }
 
+// Client describes an HTTP client or wrapper
+// of an HTTP client with a Do() method for performing
+// requests.
+type Client interface {
+	Do(req *http.Request) (resp *http.Response, err error)
+}
+
 // ResumableRequestReader makes it possible to resume reading a request's body transparently
 // maxfail is the number of times we retry to make requests again (not resumes)
 // totalsize is the total length of the body; auto detect if not provided
-func ResumableRequestReader(c *http.Client, r *http.Request, maxfail uint32, totalsize int64) io.ReadCloser {
+func ResumableRequestReader(c Client, r *http.Request, maxfail uint32, totalsize int64) io.ReadCloser {
 	return &resumableRequestReader{client: c, request: r, maxFailures: maxfail, totalSize: totalsize}
 }
 
-func ResumableRequestReaderWithInitialResponse(c *http.Client, r *http.Request, maxfail uint32, totalsize int64, initialResponse *http.Response) io.ReadCloser {
+func ResumableRequestReaderWithInitialResponse(c Client, r *http.Request, maxfail uint32, totalsize int64, initialResponse *http.Response) io.ReadCloser {
 	return &resumableRequestReader{client: c, request: r, maxFailures: maxfail, totalSize: totalsize, currentResponse: initialResponse}
 }
 

--- a/registry/client.go
+++ b/registry/client.go
@@ -1,0 +1,278 @@
+package registry
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/utils"
+	"github.com/go-fsnotify/fsnotify"
+)
+
+var (
+	caPool       *x509.CertPool
+	clientCerts  []tls.Certificate
+	certLock     sync.RWMutex
+	certWatcher  *fsnotify.Watcher
+	certsDirname = "/etc/docker/certs.d"
+)
+
+func init() {
+	// Setup initial certificate pool and client certificates.
+	loadCerts(watchCertDirs())
+}
+
+type TimeoutType uint32
+
+const (
+	NoTimeout TimeoutType = iota
+	ReceiveTimeout
+	ConnectTimeout
+)
+
+// Client should handle http requests for all registry sessions.
+type Client struct {
+	httpClient *http.Client
+	isSecure   bool
+}
+
+// Do handles making an http request and ensures that
+// Auth headers are never sent over an insecure channel.
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	authHeader := req.Header.Get("Authorization")
+	if authHeader != "" && !(c.isSecure && req.URL.Scheme == "https") {
+		return nil, fmt.Errorf("cannot send auth credentials over insecure channel %q: %s", authHeader, req.URL)
+	}
+
+	return c.httpClient.Do(req)
+}
+
+// NewClient prepares and returns an HTTP Client to use with this endpoint.
+func (e *Endpoint) NewClient(jar http.CookieJar, timeout TimeoutType) *Client {
+	return newClient(jar, timeout, e.IsSecure)
+}
+
+func newClient(jar http.CookieJar, timeout TimeoutType, secure bool) *Client {
+	certLock.RLock()
+	tlsConfig := tls.Config{
+		RootCAs: caPool,
+		// Avoid fallback to SSL protocols < TLS1.0
+		MinVersion:   tls.VersionTLS10,
+		Certificates: clientCerts,
+	}
+	certLock.RUnlock()
+
+	if !secure {
+		tlsConfig.InsecureSkipVerify = true
+	}
+
+	httpTransport := &http.Transport{
+		DisableKeepAlives: true,
+		Proxy:             http.ProxyFromEnvironment,
+		TLSClientConfig:   &tlsConfig,
+	}
+
+	switch timeout {
+	case ConnectTimeout:
+		httpTransport.Dial = func(proto string, addr string) (net.Conn, error) {
+			// Set the connect timeout to 5 seconds
+			d := net.Dialer{Timeout: 5 * time.Second, DualStack: true}
+
+			conn, err := d.Dial(proto, addr)
+			if err != nil {
+				return nil, err
+			}
+			// Set the recv timeout to 10 seconds
+			conn.SetDeadline(time.Now().Add(10 * time.Second))
+			return conn, nil
+		}
+	case ReceiveTimeout:
+		httpTransport.Dial = func(proto string, addr string) (net.Conn, error) {
+			d := net.Dialer{DualStack: true}
+
+			conn, err := d.Dial(proto, addr)
+			if err != nil {
+				return nil, err
+			}
+			conn = utils.NewTimeoutConn(conn, 1*time.Minute)
+			return conn, nil
+		}
+	}
+
+	return &Client{
+		httpClient: &http.Client{
+			Transport:     httpTransport,
+			CheckRedirect: AddRequiredHeadersToRedirectedRequests,
+			Jar:           jar,
+		},
+		isSecure: secure,
+	}
+}
+
+func getCertDirs() (certDirs []string) {
+	if err := os.MkdirAll(certsDirname, os.FileMode(0755)); err != nil {
+		log.Fatalf("unable to make docker registry certs directory %s: %s", certsDirname, err)
+	}
+
+	certDirs = []string{certsDirname}
+
+	// List directory entries to find all immediate subdirectories.
+	dirEntries, err := ioutil.ReadDir(certsDirname)
+	if err != nil {
+		log.Fatalf("unable to read certificate directory %s: %s", certsDirname, err)
+	}
+
+	for _, entry := range dirEntries {
+		if entry.IsDir() {
+			certDirs = append(certDirs, path.Join(certsDirname, entry.Name()))
+		}
+	}
+
+	return
+}
+
+func watchCertDirs() (certDirs []string) {
+	if certWatcher != nil {
+		certWatcher.Close()
+	}
+
+	certDirs = getCertDirs()
+
+	certWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatalf("unable to create certificate directory notifier: %s", err)
+	}
+
+	for _, certDir := range certDirs {
+		if err = certWatcher.Add(certDir); err != nil {
+			log.Errorf("unable to watch cert directory %s: %s", certDir, err)
+		}
+	}
+
+	go handleCertDirEvent(certWatcher)
+
+	return
+}
+
+func handleCertDirEvent(watcher *fsnotify.Watcher) {
+	var err error
+
+	select {
+	case _ = <-watcher.Events:
+	case err = <-watcher.Errors:
+	}
+
+	if err != nil {
+		log.Errorf("error watching for certificate dir events: %s", err)
+	}
+
+	// There was some filesystem event in one of the watched
+	// certificate directories. We should reload all certificates
+	// and reset the watcher.
+	loadCerts(watchCertDirs())
+}
+
+func loadCerts(certDirs []string) {
+	newCAPool, newClientCerts := prepareCerts(certDirs)
+
+	certLock.Lock()
+	caPool, clientCerts = newCAPool, newClientCerts
+	certLock.Unlock()
+}
+
+func addCACertToPool(pemFilename string, pool *x509.CertPool) (err error) {
+	log.Debugf("loading CA certificate file: %s", pemFilename)
+
+	var certPEM []byte
+	if certPEM, err = ioutil.ReadFile(pemFilename); err != nil {
+		return err
+	}
+
+	pool.AppendCertsFromPEM(certPEM)
+
+	return nil
+}
+
+func addClientCert(certFilename string, dirFileSet map[string]struct{}, certs *[]tls.Certificate) (err error) {
+	log.Debugf("loading client certificate file: %s", certFilename)
+
+	certName := path.Base(certFilename)
+	keyName := strings.TrimSuffix(certName, ".cert") + ".key"
+	keyFilename := path.Join(path.Dir(certFilename), keyName)
+
+	if _, exists := dirFileSet[keyName]; !exists {
+		return fmt.Errorf("missing key %s for certificate %s", keyName, certName)
+	}
+
+	cert, err := tls.LoadX509KeyPair(certFilename, keyFilename)
+	if err != nil {
+		return err
+	}
+
+	*certs = append(*certs, cert)
+
+	return nil
+}
+
+func prepareCerts(certificateDirnames []string) (pool *x509.CertPool, certs []tls.Certificate) {
+	var (
+		dirEntries []os.FileInfo
+		err        error
+	)
+
+	for _, certificateDirname := range certificateDirnames {
+		log.Debugf("loading certificates from directory: %s", certificateDirname)
+
+		if dirEntries, err = ioutil.ReadDir(certificateDirname); err != nil {
+			log.Errorf("unable to read certificate dir %s: %s", certificateDirname, err)
+			continue
+		}
+
+		// Make a set of all filenames in the certificate directory.
+		dirFileSet := make(map[string]struct{}, len(dirEntries))
+		for _, entry := range dirEntries {
+			if !entry.IsDir() {
+				dirFileSet[entry.Name()] = struct{}{}
+			}
+		}
+
+		for _, entry := range dirEntries {
+			if entry.IsDir() {
+				// Only interested in certificate files.
+				continue
+			}
+
+			pemFilename := path.Join(certificateDirname, entry.Name())
+
+			// CA certs should have a ".crt" suffix while client certs should have
+			// a ".cert" suffix. Client keys should have ".key" suffix as well.
+			switch {
+			case strings.HasSuffix(entry.Name(), ".crt"):
+				if pool == nil {
+					// It's important to leave the pool *nil* if there are no
+					// custom CA certs as a *nil* pool signals the TLS library
+					// to load the system certs instead.
+					pool = x509.NewCertPool()
+				}
+				err = addCACertToPool(pemFilename, pool)
+			case strings.HasSuffix(entry.Name(), ".cert"):
+				err = addClientCert(pemFilename, dirFileSet, &certs)
+			}
+
+			if err != nil {
+				log.Error(err)
+			}
+		}
+	}
+
+	return
+}

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -1,0 +1,118 @@
+package registry
+
+import (
+	"encoding/pem"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/docker/libtrust"
+)
+
+func TestClientCertLoading(t *testing.T) {
+	// There should already exist one custom certificate from our mock HTTPS
+	// server. Ensure there it at least one subject in the CA Pool. There
+	// should also be no client certs so far.
+	certLock.RLock()
+	if len(caPool.Subjects()) != 1 {
+		defer certLock.RUnlock()
+		t.Fatalf("expected 1 cert in the CA pool, got %d", len(caPool.Subjects()))
+	}
+	if len(clientCerts) != 0 {
+		defer certLock.RUnlock()
+		t.Fatalf("expected 0 certs in the client certs list, got %d", len(clientCerts))
+	}
+	certLock.RUnlock()
+
+	// Now create a new ca cert and client key/cert for a bogus host.
+	bogusCertsDirname := path.Join(certsDirname, "example.com")
+	if err := os.MkdirAll(bogusCertsDirname, os.FileMode(0755)); err != nil {
+		t.Fatalf("unable to create certs.d directory: %s", err)
+	}
+
+	key, err := libtrust.GenerateECP256PrivateKey()
+	if err != nil {
+		t.Fatalf("unable to generate key: %s", err)
+	}
+
+	// Generate CA certificate.
+	caCert, err := libtrust.GenerateCACert(key, key.PublicKey())
+	if err != nil {
+		t.Fatalf("unable to generate self-signed CA cert: %s", err)
+	}
+
+	// Generate Client certificate.
+	clientCert, err := libtrust.GenerateSelfSignedClientCert(key)
+	if err != nil {
+		t.Fatalf("unabel to generate self-signed client cert: %s", err)
+	}
+
+	// Write CA certificate file.
+	caCertPEM := pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caCert.Raw,
+	}
+
+	if err = ioutil.WriteFile(path.Join(bogusCertsDirname, "ca.crt"), pem.EncodeToMemory(&caCertPEM), os.FileMode(644)); err != nil {
+		t.Fatalf("unable to write test ca cert file: %s", err)
+	}
+
+	// Write client certificate file.
+	clientCertPEM := pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: clientCert.Raw,
+	}
+
+	if err = ioutil.WriteFile(path.Join(bogusCertsDirname, "client.cert"), pem.EncodeToMemory(&clientCertPEM), os.FileMode(644)); err != nil {
+		t.Fatalf("unable to write test client cert file: %s", err)
+	}
+
+	// Write client key certificate file.
+	clientKeyPEM, err := key.PEMBlock()
+	if err != nil {
+		t.Fatalf("unable to get clinet key PEM block: %s", err)
+	}
+
+	if err = ioutil.WriteFile(path.Join(bogusCertsDirname, "client.key"), pem.EncodeToMemory(clientKeyPEM), os.FileMode(644)); err != nil {
+		t.Fatalf("unable to write test client cert file: %s", err)
+	}
+
+	// Now that we've written some new certs/keys, they should automatically
+	// be reloaded into the global caPool and clientCerts objects. There is a
+	// race condition here, so we wait for 100 milliseconds in case the watcher
+	// needs the time to catch up and update the certs.
+	time.Sleep(100 * time.Millisecond)
+
+	// Now there should be 2 certs in the ca pool, and 1 client certificate.
+	certLock.RLock()
+	if len(caPool.Subjects()) != 2 {
+		defer certLock.RUnlock()
+		t.Fatalf("expected 2 certs in the CA pool, got %d", len(caPool.Subjects()))
+	}
+	if len(clientCerts) != 1 {
+		defer certLock.RUnlock()
+		t.Fatalf("expected 1 cert in the client certs list, got %d", len(clientCerts))
+	}
+	certLock.RUnlock()
+
+	// Now remove the bogus server cert directory and wait for another update.
+	if err = os.RemoveAll(bogusCertsDirname); err != nil {
+		t.Fatalf("unable to remove test certs directory: %s", err)
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Now there should be 1 certs in the ca pool again, and 0 client certificates.
+	certLock.RLock()
+	if len(caPool.Subjects()) != 1 {
+		defer certLock.RUnlock()
+		t.Fatalf("expected 1 cert in the CA pool, got %d", len(caPool.Subjects()))
+	}
+	if len(clientCerts) != 0 {
+		defer certLock.RUnlock()
+		t.Fatalf("expected 0 certs in the client certs list, got %d", len(clientCerts))
+	}
+	certLock.RUnlock()
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,20 +1,9 @@
 package registry
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"errors"
-	"fmt"
-	"io/ioutil"
-	"net"
 	"net/http"
-	"os"
-	"path"
 	"strings"
-	"time"
-
-	log "github.com/Sirupsen/logrus"
-	"github.com/docker/docker/utils"
 )
 
 var (
@@ -22,139 +11,6 @@ var (
 	ErrDoesNotExist  = errors.New("Image does not exist")
 	errLoginRequired = errors.New("Authentication is required.")
 )
-
-type TimeoutType uint32
-
-const (
-	NoTimeout TimeoutType = iota
-	ReceiveTimeout
-	ConnectTimeout
-)
-
-func newClient(jar http.CookieJar, roots *x509.CertPool, certs []tls.Certificate, timeout TimeoutType, secure bool) *http.Client {
-	tlsConfig := tls.Config{
-		RootCAs: roots,
-		// Avoid fallback to SSL protocols < TLS1.0
-		MinVersion:   tls.VersionTLS10,
-		Certificates: certs,
-	}
-
-	if !secure {
-		tlsConfig.InsecureSkipVerify = true
-	}
-
-	httpTransport := &http.Transport{
-		DisableKeepAlives: true,
-		Proxy:             http.ProxyFromEnvironment,
-		TLSClientConfig:   &tlsConfig,
-	}
-
-	switch timeout {
-	case ConnectTimeout:
-		httpTransport.Dial = func(proto string, addr string) (net.Conn, error) {
-			// Set the connect timeout to 5 seconds
-			d := net.Dialer{Timeout: 5 * time.Second, DualStack: true}
-
-			conn, err := d.Dial(proto, addr)
-			if err != nil {
-				return nil, err
-			}
-			// Set the recv timeout to 10 seconds
-			conn.SetDeadline(time.Now().Add(10 * time.Second))
-			return conn, nil
-		}
-	case ReceiveTimeout:
-		httpTransport.Dial = func(proto string, addr string) (net.Conn, error) {
-			d := net.Dialer{DualStack: true}
-
-			conn, err := d.Dial(proto, addr)
-			if err != nil {
-				return nil, err
-			}
-			conn = utils.NewTimeoutConn(conn, 1*time.Minute)
-			return conn, nil
-		}
-	}
-
-	return &http.Client{
-		Transport:     httpTransport,
-		CheckRedirect: AddRequiredHeadersToRedirectedRequests,
-		Jar:           jar,
-	}
-}
-
-func doRequest(req *http.Request, jar http.CookieJar, timeout TimeoutType, secure bool) (*http.Response, *http.Client, error) {
-	var (
-		pool  *x509.CertPool
-		certs []tls.Certificate
-	)
-
-	if secure && req.URL.Scheme == "https" {
-		hasFile := func(files []os.FileInfo, name string) bool {
-			for _, f := range files {
-				if f.Name() == name {
-					return true
-				}
-			}
-			return false
-		}
-
-		hostDir := path.Join("/etc/docker/certs.d", req.URL.Host)
-		log.Debugf("hostDir: %s", hostDir)
-		fs, err := ioutil.ReadDir(hostDir)
-		if err != nil && !os.IsNotExist(err) {
-			return nil, nil, err
-		}
-
-		for _, f := range fs {
-			if strings.HasSuffix(f.Name(), ".crt") {
-				if pool == nil {
-					pool = x509.NewCertPool()
-				}
-				log.Debugf("crt: %s", hostDir+"/"+f.Name())
-				data, err := ioutil.ReadFile(path.Join(hostDir, f.Name()))
-				if err != nil {
-					return nil, nil, err
-				}
-				pool.AppendCertsFromPEM(data)
-			}
-			if strings.HasSuffix(f.Name(), ".cert") {
-				certName := f.Name()
-				keyName := certName[:len(certName)-5] + ".key"
-				log.Debugf("cert: %s", hostDir+"/"+f.Name())
-				if !hasFile(fs, keyName) {
-					return nil, nil, fmt.Errorf("Missing key %s for certificate %s", keyName, certName)
-				}
-				cert, err := tls.LoadX509KeyPair(path.Join(hostDir, certName), path.Join(hostDir, keyName))
-				if err != nil {
-					return nil, nil, err
-				}
-				certs = append(certs, cert)
-			}
-			if strings.HasSuffix(f.Name(), ".key") {
-				keyName := f.Name()
-				certName := keyName[:len(keyName)-4] + ".cert"
-				log.Debugf("key: %s", hostDir+"/"+f.Name())
-				if !hasFile(fs, certName) {
-					return nil, nil, fmt.Errorf("Missing certificate %s for key %s", certName, keyName)
-				}
-			}
-		}
-	}
-
-	if len(certs) == 0 {
-		client := newClient(jar, pool, nil, timeout, secure)
-		res, err := client.Do(req)
-		if err != nil {
-			return nil, nil, err
-		}
-		return res, client, nil
-	}
-
-	client := newClient(jar, pool, certs, timeout, secure)
-	res, err := client.Do(req)
-	return res, client, err
-}
 
 func trustedLocation(req *http.Request) bool {
 	var (

--- a/registry/session_v2.go
+++ b/registry/session_v2.go
@@ -79,7 +79,7 @@ func (r *Session) GetV2ImageManifest(ep *Endpoint, imageName, tagName string, au
 	if err := auth.Authorize(req); err != nil {
 		return nil, err
 	}
-	res, _, err := r.doRequest(req)
+	res, err := r.doRequest(req)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (r *Session) HeadV2ImageBlob(ep *Endpoint, imageName, sumType, sum string, 
 	if err := auth.Authorize(req); err != nil {
 		return false, err
 	}
-	res, _, err := r.doRequest(req)
+	res, err := r.doRequest(req)
 	if err != nil {
 		return false, err
 	}
@@ -150,7 +150,7 @@ func (r *Session) GetV2ImageBlob(ep *Endpoint, imageName, sumType, sum string, b
 	if err := auth.Authorize(req); err != nil {
 		return err
 	}
-	res, _, err := r.doRequest(req)
+	res, err := r.doRequest(req)
 	if err != nil {
 		return err
 	}
@@ -181,7 +181,7 @@ func (r *Session) GetV2ImageBlobReader(ep *Endpoint, imageName, sumType, sum str
 	if err := auth.Authorize(req); err != nil {
 		return nil, 0, err
 	}
-	res, _, err := r.doRequest(req)
+	res, err := r.doRequest(req)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -218,7 +218,7 @@ func (r *Session) PutV2ImageBlob(ep *Endpoint, imageName, sumType, sumStr string
 	if err := auth.Authorize(req); err != nil {
 		return err
 	}
-	res, _, err := r.doRequest(req)
+	res, err := r.doRequest(req)
 	if err != nil {
 		return err
 	}
@@ -236,7 +236,7 @@ func (r *Session) PutV2ImageBlob(ep *Endpoint, imageName, sumType, sumStr string
 	if err := auth.Authorize(req); err != nil {
 		return err
 	}
-	res, _, err = r.doRequest(req)
+	res, err = r.doRequest(req)
 	if err != nil {
 		return err
 	}
@@ -268,7 +268,7 @@ func (r *Session) PutV2ImageManifest(ep *Endpoint, imageName, tagName string, ma
 	if err := auth.Authorize(req); err != nil {
 		return err
 	}
-	res, _, err := r.doRequest(req)
+	res, err := r.doRequest(req)
 	if err != nil {
 		return err
 	}
@@ -307,7 +307,7 @@ func (r *Session) GetV2RemoteTags(ep *Endpoint, imageName string, auth *RequestA
 	if err := auth.Authorize(req); err != nil {
 		return nil, err
 	}
-	res, _, err := r.doRequest(req)
+	res, err := r.doRequest(req)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/token.go
+++ b/registry/token.go
@@ -15,7 +15,7 @@ type tokenResponse struct {
 	Token string `json:"token"`
 }
 
-func getToken(username, password string, params map[string]string, registryEndpoint *Endpoint, client *http.Client, factory *utils.HTTPRequestFactory) (token string, err error) {
+func getToken(username, password string, params map[string]string, registryEndpoint *Endpoint, factory *utils.HTTPRequestFactory) (token string, err error) {
 	realm, ok := params["realm"]
 	if !ok {
 		return "", errors.New("no realm specified for token auth challenge")
@@ -27,11 +27,11 @@ func getToken(username, password string, params map[string]string, registryEndpo
 	}
 
 	if realmURL.Scheme == "" {
-		if registryEndpoint.IsSecure {
-			realmURL.Scheme = "https"
-		} else {
-			realmURL.Scheme = "http"
-		}
+		realmURL.Scheme = registryEndpoint.URL.Scheme
+	}
+
+	if realmURL.Scheme != "https" {
+		return "", fmt.Errorf("cannot send token credentials over insecure channel: %s", realmURL)
 	}
 
 	req, err := factory.NewRequest("GET", realmURL.String(), nil)
@@ -55,6 +55,8 @@ func getToken(username, password string, params map[string]string, registryEndpo
 
 	req.URL.RawQuery = reqParams.Encode()
 	req.SetBasicAuth(username, password)
+
+	client := newClient(nil, ConnectTimeout, true)
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Adds NewClient() method to registry.Endpoint objects to make it much
simpler to create and use a http client for the registry package.

Switched registry.Session to use a single http client for reuse and
connection pooling.

Refactored the newClient() logic which configured custom server and
client certs for registry endpoints.

Updated registry package unit tests to use two different HTTP test servers,
one with a valid certificate configured by the test and another without.

Added checks to ensure that the registry session DOES NOT send auth
credentials over an insecure connection.

Docker-DCO-1.1-Signed-off-by: Josh Hawn josh.hawn@docker.com (github: jlhawn)
