### PR TITLE
docker-tests: mount hierarchies and make symlinks for subsystems

### DIFF
--- a/hack/dind
+++ b/hack/dind
@@ -33,28 +33,35 @@ if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
 fi
 
 # Mount the cgroup hierarchies exactly as they are in the parent system.
-for SUBSYS in $(cut -d: -f2 /proc/1/cgroup); do
-	mkdir -p "$CGROUP/$SUBSYS"
-	if ! mountpoint -q $CGROUP/$SUBSYS; then
-		mount -n -t cgroup -o "$SUBSYS" cgroup "$CGROUP/$SUBSYS"
-	fi
+for HIER in $(cut -d: -f2 /proc/1/cgroup); do
 
-	# The two following sections address a bug which manifests itself
+	# The following sections address a bug which manifests itself
 	# by a cryptic "lxc-start: no ns_cgroup option specified" when
-	# trying to start containers withina container.
+	# trying to start containers within a container.
 	# The bug seems to appear when the cgroup hierarchies are not
 	# mounted on the exact same directories in the host, and in the
 	# container.
+
+	SUBSYSTEMS="${HIER%name=*}"
+
+	# If cgroup hierarchy is named(mounted with "-o name=foo") we
+	# need to mount it in $CGROUP/foo to create exect same
+	# directoryes as on host. Else we need to mount it as is e.g.
+	# "subsys1,subsys2" if it has two subsystems
 
 	# Named, control-less cgroups are mounted with "-o name=foo"
 	# (and appear as such under /proc/<pid>/cgroup) but are usually
 	# mounted on a directory named "foo" (without the "name=" prefix).
 	# Systemd and OpenRC (and possibly others) both create such a
-	# cgroup. To avoid the aforementioned bug, we symlink "foo" to
-	# "name=foo". This shouldn't have any adverse effect.
-	name="${SUBSYS#name=}"
-	if [ "$name" != "$SUBSYS" ]; then
-		ln -s "$SUBSYS" "$CGROUP/$name"
+	# cgroup. So just mount them on directory $CGROUP/foo.
+
+	OHIER=$HIER
+	HIER="${HIER#*name=}"
+
+	mkdir -p "$CGROUP/$HIER"
+
+	if ! mountpoint -q $CGROUP/$HIER; then
+		mount -n -t cgroup -o "$OHIER" cgroup "$CGROUP/$HIER"
 	fi
 
 	# Likewise, on at least one system, it has been reported that
@@ -62,8 +69,25 @@ for SUBSYS in $(cut -d: -f2 /proc/1/cgroup); do
 	# (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
 	# but on a directory called "cpu,cpuacct" (note the inversion
 	# in the order of the groups). This tries to work around it.
-	if [ "$SUBSYS" = 'cpuacct,cpu' ]; then
-		ln -s "$SUBSYS" "$CGROUP/cpu,cpuacct"
+
+	if [ "$HIER" = 'cpuacct,cpu' ]; then
+		ln -s "$HIER" "$CGROUP/cpu,cpuacct"
+	fi
+
+	# If hierarchy has multiple subsystems, in /proc/<pid>/cgroup
+	# we will see ":subsys1,subsys2,subsys3,name=foo:" substring,
+	# we need to mount it to "$CGROUP/foo" and if there were no
+	# name to "$CGROUP/subsys1,subsys2,subsys3", so we must create
+	# symlinks for docker daemon to find these subsystems:
+	# ln -s $CGROUP/foo $CGROUP/subsys1
+	# ln -s $CGROUP/subsys1,subsys2,subsys3 $CGROUP/subsys1
+
+	if [ "$SUBSYSTEMS" != "${SUBSYSTEMS//,/ }" ]; then
+		SUBSYSTEMS="${SUBSYSTEMS//,/ }"
+		for SUBSYS in $SUBSYSTEMS
+		do
+			ln -s "$CGROUP/$HIER" "$CGROUP/$SUBSYS"
+		done
 	fi
 done
 


### PR DESCRIPTION
Docker does not know about our named cpuacct,cpu,cpuset cgroup
hierarchy with multiple subsystems in it so to use them by docker
in integration-cli test TestRunWithCpuset inside docker container
we need to add symlinks to them in hack/dind script.

Example:
old version of parser will do:
    cat /proc/1/cgroup
    11:cpu,cpuacct,name=my_cpu_cpuacct:/
    ...
and create and mount this hierarchy to directory
    /cgroup/cpu,cpuacct,name=my_cpu_cpuacct/
so docker cannot find it because it has strange name

in new parser directory will be same as on host
    /cgroup/my_cpu_cpuacct
and have symlinks for docker to find it
    /cgroup/cpu -> /cgroup/my_cpu_cpuacct
    /cgroup/cpuacct -> /cgroup/my_cpu_cpuacct

in other case if where is no name
    cat /proc/1/cgroup
    11:cpu,cpuacct:/
    ...
mount will be same for both parsers
    /cgroup/cpu,cpuacct
and new one will create symlinks
    /cgroup/cpu -> /cgroup/cpu,cpuacct
    /cgroup/cpuacct -> /cgroup/cpu,cpuacct

Signed-off-by: Pavel Tikhomirov ptikhomirov@parallels.com
