### PR TITLE
Fixing stale pidfile issue when docker dies abruptly

### DIFF
--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -43,6 +43,8 @@ prestart() {
 start() {
     [ -x $exec ] || exit 5
 
+    check_for_cleanup
+
     if ! [ -f $pidfile ]; then
         prestart
         printf "Starting $prog:\t"
@@ -95,6 +97,13 @@ rh_status() {
 
 rh_status_q() {
     rh_status >/dev/null 2>&1
+}
+
+
+check_for_cleanup() {
+    if [ -f ${pidfile} ]; then
+        /bin/ps -fp $(cat ${pidfile}) > /dev/null || rm ${pidfile}
+    fi
 }
 
 case "$1" in


### PR DESCRIPTION
This fixes an issue i've ran into where docker dies but the pidfile is left. Sometimes the machine sefaults till the point where it reboots and then the docker service will not start from init. 

Signed-off-by: Mike Leone mleone896@gmail.com
