### PR TITLE
Revert "contrib/systemd: mount namespace and subtree flags"

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -6,7 +6,6 @@ Requires=docker.socket
 
 [Service]
 ExecStart=/usr/bin/docker -d -H fd://
-MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576
 


### PR DESCRIPTION
This reverts commit eb76cb2301fc883941bc4ca2d9ebc3a486ab8e0a.

ping @vbatts @crosbymichael I figured we only needed to revert the systemd one because the other is redhat specific. You think that is ok?
