### PR TITLE
We want to allow the sharing of /dev from the host into the container.

### DIFF
--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -220,8 +220,12 @@ func (d *driver) setupMounts(container *configs.Config, c *execdriver.Command) e
 
 	// Filter out mounts that are overriden by user supplied mounts
 	var defaultMounts []*configs.Mount
+	_, mountDev := userMounts["/dev"]
 	for _, m := range container.Mounts {
 		if _, ok := userMounts[m.Destination]; !ok {
+			if mountDev && strings.HasPrefix(m.Destination, "/dev/") {
+				continue
+			}
 			defaultMounts = append(defaultMounts, m)
 		}
 	}


### PR DESCRIPTION
docker run -v /dev:/dev into the container is not acceptable solution,
since directories and devices like /dev/ptx get mishandled.

We want to be able to run libvirtd for launching vms and it needs
access to the hosts /dev.  This is a key componant of OpenStack.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
