### PR TITLE
integration-cli: wait for container before sending ^D

### DIFF
--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -81,6 +81,9 @@ func TestAttachAfterDetach(t *testing.T) {
 	}()
 
 	time.Sleep(500 * time.Millisecond)
+	if err := waitRun(name); err != nil {
+		t.Fatal(err)
+	}
 	cpty.Write([]byte{16})
 	time.Sleep(100 * time.Millisecond)
 	cpty.Write([]byte{17})


### PR DESCRIPTION
Signed-off-by: Tibor Vass teabee89@gmail.com

Ping @icecrime @jfrazelle @LK4D4 
