### PR TITLE
Remove windows from the list of supported platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,10 @@ RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
 ENV DOCKER_CROSSPLATFORMS \
 	linux/386 linux/arm \
 	darwin/amd64 darwin/386 \
-	freebsd/amd64 freebsd/386 freebsd/arm \
-	windows/amd64 windows/386
+	freebsd/amd64 freebsd/386 freebsd/arm
+
+# TODO when https://jenkins.dockerproject.com/job/Windows/ is green, add windows back to the list above
+#	windows/amd64 windows/386
 
 # (set an explicit GOARM of 5 for maximum compatibility)
 ENV GOARM 5


### PR DESCRIPTION
Since it can still be tested natively without this, this won't cause any harm while we fix the tests to actually work on Windows.
