### PR TITLE
Adds ipc namespace capability to lxc, and fixes tests.

### DIFF
--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -92,6 +92,17 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 			"--share-net", c.Network.ContainerID,
 		)
 	}
+	if c.Ipc != nil {
+		if c.Ipc.ContainerID != "" {
+			params = append(params,
+				"--share-ipc", c.Ipc.ContainerID,
+			)
+		} else if c.Ipc.HostIpc {
+			params = append(params,
+				"--share-ipc", "1",
+			)
+		}
+	}
 
 	params = append(params,
 		"--",
@@ -141,7 +152,7 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 			"unshare", "-m", "--", "/bin/sh", "-c", shellString,
 		}
 	}
-
+	log.Debugf("lxc params %s", params)
 	var (
 		name = params[0]
 		arg  = params[1:]

--- a/daemon/execdriver/lxc/lxc_template.go
+++ b/daemon/execdriver/lxc/lxc_template.go
@@ -126,7 +126,9 @@ lxc.network.ipv4 = {{.Network.Interface.IPAddress}}/{{.Network.Interface.IPPrefi
 {{if .Network.Interface.Gateway}}
 lxc.network.ipv4.gateway = {{.Network.Interface.Gateway}}
 {{end}}
-
+{{if .Network.Interface.MacAddress}}
+lxc.network.hwaddr = {{.Network.Interface.MacAddress}}
+{{end}}
 {{if .ProcessConfig.Env}}
 lxc.utsname = {{getHostname .ProcessConfig.Env}}
 {{end}}
@@ -194,6 +196,7 @@ func dropList(drops []string) ([]string, error) {
 
 func isDirectory(source string) string {
 	f, err := os.Stat(source)
+	log.Debugf("dir: %s\n", source)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "dir"

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -288,7 +288,7 @@ func TestPsListContainersSize(t *testing.T) {
 func TestPsListContainersFilterStatus(t *testing.T) {
 	// FIXME: this should test paused, but it makes things hang and its wonky
 	// this is because paused containers can't be controlled by signals
-
+	deleteAllContainers()
 	// start exited container
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox")
 	out, _, err := runCommandWithOutput(runCmd)
@@ -304,7 +304,7 @@ func TestPsListContainersFilterStatus(t *testing.T) {
 	}
 
 	// start running container
-	runCmd = exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", "sleep 360")
+	runCmd = exec.Command(dockerBinary, "run", "-itd", "busybox")
 	out, _, err = runCommandWithOutput(runCmd)
 	if err != nil {
 		t.Fatal(out, err)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -792,7 +792,13 @@ func TestRunEnvironment(t *testing.T) {
 		t.Fatal(err, out)
 	}
 
-	actualEnv := strings.Split(strings.TrimSpace(out), "\n")
+	actualEnvLxc := strings.Split(strings.TrimSpace(out), "\n")
+	actualEnv := []string{}
+	for i := range actualEnvLxc {
+		if actualEnvLxc[i] != "container=lxc" {
+			actualEnv = append(actualEnv, actualEnvLxc[i])
+		}
+	}
 	sort.Strings(actualEnv)
 
 	goodEnv := []string{
@@ -831,7 +837,13 @@ func TestRunEnvironmentErase(t *testing.T) {
 		t.Fatal(err, out)
 	}
 
-	actualEnv := strings.Split(strings.TrimSpace(out), "\n")
+	actualEnvLxc := strings.Split(strings.TrimSpace(out), "\n")
+	actualEnv := []string{}
+	for i := range actualEnvLxc {
+		if actualEnvLxc[i] != "container=lxc" {
+			actualEnv = append(actualEnv, actualEnvLxc[i])
+		}
+	}
 	sort.Strings(actualEnv)
 
 	goodEnv := []string{
@@ -863,7 +875,13 @@ func TestRunEnvironmentOverride(t *testing.T) {
 		t.Fatal(err, out)
 	}
 
-	actualEnv := strings.Split(strings.TrimSpace(out), "\n")
+	actualEnvLxc := strings.Split(strings.TrimSpace(out), "\n")
+	actualEnv := []string{}
+	for i := range actualEnvLxc {
+		if actualEnvLxc[i] != "container=lxc" {
+			actualEnv = append(actualEnv, actualEnvLxc[i])
+		}
+	}
 	sort.Strings(actualEnv)
 
 	goodEnv := []string{
@@ -1969,11 +1987,42 @@ func TestRunWriteHostsFileAndNotCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err, out)
 	}
-	if len(strings.Trim(out, "\r\n")) != 0 {
+
+	if len(strings.Trim(out, "\r\n")) != 0 && !eqToBaseDiff(out, t) {
 		t.Fatal("diff should be empty")
 	}
 
 	logDone("run - write to /etc/hosts and not commited")
+}
+
+func eqToBaseDiff(out string, t *testing.T) bool {
+	cmd := exec.Command(dockerBinary, "run", "-d", "busybox", "echo", "hello")
+	out1, _, err := runCommandWithOutput(cmd)
+	cID := stripTrailingCharacters(out1)
+	cmd = exec.Command(dockerBinary, "diff", cID)
+	base_diff, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, base_diff)
+	}
+	base_arr := strings.Split(base_diff, "\n")
+	sort.Strings(base_arr)
+	out_arr := strings.Split(out, "\n")
+	sort.Strings(out_arr)
+	return sliceEq(base_arr, out_arr)
+}
+
+func sliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
 }
 
 // Test for #2267
@@ -1998,7 +2047,7 @@ func TestRunWriteHostnameFileAndNotCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err, out)
 	}
-	if len(strings.Trim(out, "\r\n")) != 0 {
+	if len(strings.Trim(out, "\r\n")) != 0 && !eqToBaseDiff(out, t) {
 		t.Fatal("diff should be empty")
 	}
 
@@ -2027,7 +2076,7 @@ func TestRunWriteResolvFileAndNotCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err, out)
 	}
-	if len(strings.Trim(out, "\r\n")) != 0 {
+	if len(strings.Trim(out, "\r\n")) != 0 && !eqToBaseDiff(out, t) {
 		t.Fatal("diff should be empty")
 	}
 
@@ -2737,10 +2786,7 @@ func TestRunUnknownCommand(t *testing.T) {
 	cID = strings.TrimSpace(cID)
 
 	runCmd = exec.Command(dockerBinary, "start", cID)
-	_, _, _, err = runCommandWithStdoutStderr(runCmd)
-	if err == nil {
-		t.Fatalf("Container should not have been able to start!")
-	}
+	_, _, _, _ = runCommandWithStdoutStderr(runCmd)
 
 	runCmd = exec.Command(dockerBinary, "inspect", "--format={{.State.ExitCode}}", cID)
 	rc, _, _, err2 := runCommandWithStdoutStderr(runCmd)
@@ -2750,8 +2796,8 @@ func TestRunUnknownCommand(t *testing.T) {
 		t.Fatalf("Error getting status of container: %v", err2)
 	}
 
-	if rc != "-1" {
-		t.Fatalf("ExitCode(%v) was supposed to be -1", rc)
+	if rc == "0" {
+		t.Fatalf("ExitCode(%v) cannot be 0", rc)
 	}
 
 	logDone("run - Unknown Command")


### PR DESCRIPTION
This fixes various tests by checking for non zero exit code, accounting for lxc-specific base-diffs, and by removing lxc specific environment vars.
It also adds the --share-ipc option to lxc-start for shared ipc namespaces.
Signed-off-by: Abin Shahab ashahab@altiscale.com (github: ashahab-altiscale)
