### PR TITLE
Always store images with tarsum.v1 checksum added

### DIFF
--- a/pkg/tarsum/tarsum.go
+++ b/pkg/tarsum/tarsum.go
@@ -122,6 +122,7 @@ type tHashConfig struct {
 }
 
 var (
+	// NOTE: DO NOT include MD5 or SHA1, which are considered insecure.
 	standardHashConfigs = map[string]tHashConfig{
 		"sha256": {name: "sha256", hash: crypto.SHA256},
 		"sha512": {name: "sha512", hash: crypto.SHA512},

--- a/pkg/tarsum/versioning.go
+++ b/pkg/tarsum/versioning.go
@@ -22,6 +22,18 @@ const (
 	VersionDev
 )
 
+// VersionLabelForChecksum returns the label for the given tarsum
+// checksum, i.e., everything before the first `+` character in
+// the string or an empty string if no label separator is found.
+func VersionLabelForChecksum(checksum string) string {
+	// Checksums are in the form: {versionLabel}+{hashID}:{hex}
+	sepIndex := strings.Index(checksum, "+")
+	if sepIndex < 0 {
+		return ""
+	}
+	return checksum[:sepIndex]
+}
+
 // Get a list of all known tarsum Version
 func GetVersions() []Version {
 	v := []Version{}


### PR DESCRIPTION
Updates `image.StoreImage()` to always ensure that images
that are installed in Docker have a tarsum.v1 checksum.

Docker-DCO-1.1-Signed-off-by: Josh Hawn josh.hawn@docker.com (github: jlhawn)
