### PR TITLE
Fix bind-mounts only partially removed

### DIFF
--- a/volumes/repository.go
+++ b/volumes/repository.go
@@ -169,13 +169,11 @@ func (r *Repository) Delete(path string) error {
 		return err
 	}
 
-	if volume.IsBindMount {
-		return nil
-	}
-
-	if err := r.driver.Remove(volume.ID); err != nil {
-		if !os.IsNotExist(err) {
-			return err
+	if !volume.IsBindMount {
+		if err := r.driver.Remove(volume.ID); err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
When calling delete on a bind-mount volume, the config file was bing
removed, but it was not actually being removed from the volume index.

Found this when working on #10308
