### PR TITLE
docs: compress search_content.json for release

### DIFF
--- a/docs/release.sh
+++ b/docs/release.sh
@@ -72,6 +72,8 @@ setup_s3() {
 
 build_current_documentation() {
 	mkdocs build
+	cd site/
+	gzip -9k search_content.json
 }
 
 upload_current_documentation() {


### PR DESCRIPTION
This should lower the size of the search_content.json from ~2.5 MB down to ~500 KB. The compressed file should be served automatically by S3.
