### PR TITLE
pkg/archive: remove tar autodetection log line

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -101,7 +101,6 @@ func DecompressStream(archive io.Reader) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Debugf("[tar autodetect] n: %v", bs)
 
 	compression := DetectCompression(bs)
 	switch compression {


### PR DESCRIPTION
This PR removes the `tar autodetect` log line from pkg/archive.
