### PR TITLE
Fix a minor typo

### DIFF
--- a/docker/flags.go
+++ b/docker/flags.go
@@ -97,7 +97,7 @@ func init() {
 			{"images", "List images"},
 			{"import", "Create a new filesystem image from the contents of a tarball"},
 			{"info", "Display system-wide information"},
-			{"inspect", "Return low-level information on a container"},
+			{"inspect", "Return low-level information on a container or image"},
 			{"kill", "Kill a running container"},
 			{"load", "Load an image from a tar archive"},
 			{"login", "Register or log in to a Docker registry server"},

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -144,7 +144,7 @@ unix://[/path/to/socket] to use.
   Display system-wide information
 
 **docker-inspect(1)**
-  Return low-level information on a container
+  Return low-level information on a container or image
 
 **docker-kill(1)**
   Kill a running container (which includes the wrapper process and everything


### PR DESCRIPTION
The description of `docker inspect` is lack of the "image" part.

Prior to this patch, the output of `docker help` is like:

```
   ...
    info      Display system-wide information
    inspect   Return low-level information on a container
    kill      Kill a running container
   ...
```
