### PR TITLE
Updated image spec docs to clarify image JSON

### DIFF
--- a/image/spec/v1.md
+++ b/image/spec/v1.md
@@ -114,7 +114,7 @@ This specification uses the following terms:
     </dd>
 </dl>
 
-## Image JSON Schema
+## Image JSON Description
 
 Here is an example image JSON file:
 


### PR DESCRIPTION
The title `Image JSON Schema` was used as a header in the section
which describes the layout and fields of the image metadata JSON
file. It was pointed out that `JSON Schema` is its own term for
describing JSON in a machine-and-human-readable format, while the
word "Schema" in this context was used more generically to say that
the section is meant to be an example and outline of the Image JSON.

http://spacetelescope.github.io/understanding-json-schema/

This section now has the title `Image JSON Description` in order
to not cause this confusion.
