### PR TITLE
Allow empty layer configs in manifests

### DIFF
--- a/graph/manifest.go
+++ b/graph/manifest.go
@@ -3,7 +3,6 @@ package graph
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -71,14 +70,13 @@ func (s *TagStore) newManifest(localName, remoteName, tag string) ([]byte, error
 	if err != nil {
 		return nil, err
 	}
-	if layer.Config == nil {
-		return nil, errors.New("Missing layer configuration")
-	}
 	manifest.Architecture = layer.Architecture
 	manifest.FSLayers = make([]*registry.FSLayer, 0, 4)
 	manifest.History = make([]*registry.ManifestHistory, 0, 4)
 	var metadata runconfig.Config
-	metadata = *layer.Config
+	if layer.Config != nil {
+		metadata = *layer.Config
+	}
 
 	for ; layer != nil; layer, err = layer.GetParent() {
 		if err != nil {


### PR DESCRIPTION
This bug was introduced in commit 188b56c836e49e3c888e1e27e4e26b5cc0f1caaa (V2 registry).

Previous to that commit, the following command would work without error:
`tar c --files-from /dev/null | docker import - "$USER/test"; docker push "$USER/test"`

After that commit, running the above results in the error:
`FATA[0000] Error: Missing layer configuration`

The imported image doesn't have to be empty to trigger this bug; it can be a rootfs with runnable static binaries and so on. It'll run fine with `docker run`, just not be able to be used in `docker push`.

This fix causes a nonexistent layer config to be treated as a "zero value" one instead of erroring out.
I verified that the added integ test did fail before making the graph manifest code change.
