### PR TITLE
.dockerignore ignore support. Fixes #9171

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Matches returns true if relFilePath matches any of the patterns
-// and isn't excluded by any of the patterns.
+// and isn't excluded by any of the subsequent patterns.
 func Matches(relFilePath string, patterns []string) (bool, error) {
 
 	var matched = false

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -6,21 +6,43 @@ import (
 )
 
 // Matches returns true if relFilePath matches any of the patterns
+// and isn't excluded by any of the patterns.
 func Matches(relFilePath string, patterns []string) (bool, error) {
-	for _, exclude := range patterns {
-		matched, err := filepath.Match(exclude, relFilePath)
+
+	var matched = false
+
+	for _, pattern := range patterns {
+
+		var negative bool
+		if pattern != "" && pattern[0] == '!' {
+			negative = true
+			pattern = pattern[1:]
+		}
+
+		match, err := filepath.Match(pattern, relFilePath)
 		if err != nil {
-			log.Errorf("Error matching: %s (pattern: %s)", relFilePath, exclude)
+			log.Errorf("Error matching: %s (pattern: %s)", relFilePath, pattern)
 			return false, err
 		}
-		if matched {
-			if filepath.Clean(relFilePath) == "." {
-				log.Errorf("Can't exclude whole path, excluding pattern: %s", exclude)
+
+		if match {
+
+			if negative {
+				matched = false
 				continue
 			}
-			log.Debugf("Skipping excluded path: %s", relFilePath)
-			return true, nil
+
+			if filepath.Clean(relFilePath) == "." {
+				log.Errorf("Can't exclude whole path, excluding pattern: %s", pattern)
+				continue
+			}
+			matched = true
 		}
 	}
-	return false, nil
+
+	if matched {
+		log.Debugf("Skipping excluded path: %s", relFilePath)
+	}
+
+	return matched, nil
 }


### PR DESCRIPTION
Allow ignoring files from .dockerignore exclude lists like .gitingore by prefixing `!` to a rule.

Closes #9171 
