### PR TITLE
Extract $HOME usages into utils.GetHomeDir() for windows

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -17,6 +17,7 @@ import (
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/docker/registry"
+	"github.com/docker/docker/utils"
 	"github.com/docker/libtrust"
 )
 
@@ -105,7 +106,7 @@ func (cli *DockerCli) Subcmd(name, signature, description string, exitOnError bo
 }
 
 func (cli *DockerCli) LoadConfigFile() (err error) {
-	cli.configFile, err = registry.LoadConfig(os.Getenv("HOME"))
+	cli.configFile, err = registry.LoadConfig(utils.GetHomeDir())
 	if err != nil {
 		fmt.Fprintf(cli.err, "WARNING: %s\n", err)
 	}

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -388,7 +388,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	var out2 engine.Env
 	err = out2.Decode(stream)
 	if err != nil {
-		cli.configFile, _ = registry.LoadConfig(os.Getenv("HOME"))
+		cli.configFile, _ = registry.LoadConfig(utils.GetHomeDir())
 		return err
 	}
 	registry.SaveConfig(cli.configFile)

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -36,7 +36,7 @@ func init() {
 
 func migrateKey() (err error) {
 	// Migrate trust key if exists at ~/.docker/key.json and owned by current user
-	oldPath := filepath.Join(getHomeDir(), ".docker", defaultTrustKeyFile)
+	oldPath := filepath.Join(utils.GetHomeDir(), ".docker", defaultTrustKeyFile)
 	newPath := filepath.Join(getDaemonConfDir(), defaultTrustKeyFile)
 	if _, statErr := os.Stat(newPath); os.IsNotExist(statErr) && utils.IsFileOwner(oldPath) {
 		defer func() {

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/utils"
 )
 
 var (
@@ -17,21 +18,14 @@ var (
 
 func init() {
 	if dockerCertPath == "" {
-		dockerCertPath = filepath.Join(getHomeDir(), ".docker")
+		dockerCertPath = filepath.Join(utils.GetHomeDir(), ".docker")
 	}
-}
-
-func getHomeDir() string {
-	if runtime.GOOS == "windows" {
-		return os.Getenv("USERPROFILE")
-	}
-	return os.Getenv("HOME")
 }
 
 func getDaemonConfDir() string {
 	// TODO: update for Windows daemon
 	if runtime.GOOS == "windows" {
-		return filepath.Join(os.Getenv("USERPROFILE"), ".docker")
+		return filepath.Join(utils.GetHomeDir(), ".docker")
 	}
 	return "/etc/docker"
 }
@@ -60,7 +54,7 @@ func setDefaultConfFlag(flag *string, def string) {
 		if *flDaemon {
 			*flag = filepath.Join(getDaemonConfDir(), def)
 		} else {
-			*flag = filepath.Join(getHomeDir(), ".docker", def)
+			*flag = filepath.Join(utils.GetHomeDir(), ".docker", def)
 		}
 	}
 }

--- a/utils/homedir.go
+++ b/utils/homedir.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"os"
+	"runtime"
+)
+
+func GetHomeDir() string {
+	if runtime.GOOS == "windows" {
+		return os.Getenv("USERPROFILE")
+	}
+	return os.Getenv("HOME")
+}


### PR DESCRIPTION
Refactored getHomeDir in docker/docker to GetHomeDir in utils. Currently covers all use cases on the client-side.

@icecrime can we please tag with `windows`?
cc: maintainers @vieux @jfrazelle
