### PR TITLE
Add file path to errors loading the key file

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -69,7 +69,7 @@ func LoadOrCreateTrustKey(trustKeyPath string) (libtrust.PrivateKey, error) {
 			return nil, fmt.Errorf("Error saving key file: %s", err)
 		}
 	} else if err != nil {
-		return nil, fmt.Errorf("Error loading key file: %s", err)
+		return nil, fmt.Errorf("Error loading key file %s: %s", trustKeyPath, err)
 	}
 	return trustKey, nil
 }


### PR DESCRIPTION
Adds the key file to the load error message to make it clear what the path to the problematic key file is.  This will help users diagnose problems related to the key file.
