### PR TITLE
Better error messaging and logging for v2 registry requests

### DIFF
--- a/graph/push.go
+++ b/graph/push.go
@@ -411,7 +411,7 @@ func (s *TagStore) CmdPush(job *engine.Job) engine.Status {
 		}
 
 		// error out, no fallback to V1
-		return job.Error(err)
+		return job.Errorf("Error pushing to registry: %s", err)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Adds uniformity to the v2 error messages as well as ensuring the error body gets into the debug logs.
