### PR TITLE
Allow path from normal volume existing to overwrite in start Binds

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -25,6 +25,7 @@ type Mount struct {
 	Writable    bool
 	copyData    bool
 	from        *Container
+	isBind      bool
 }
 
 func (mnt *Mount) Export(resource string) (io.ReadCloser, error) {
@@ -80,7 +81,7 @@ func (m *Mount) initialize() error {
 	if hostPath, exists := m.container.Volumes[m.MountToPath]; exists {
 		// If this is a bind-mount/volumes-from, maybe it was passed in at start instead of create
 		// We need to make sure bind-mounts/volumes-from passed on start can override existing ones.
-		if !m.volume.IsBindMount && m.from == nil {
+		if (!m.volume.IsBindMount && !m.isBind) && m.from == nil {
 			return nil
 		}
 		if m.volume.Path == hostPath {
@@ -172,6 +173,7 @@ func (container *Container) parseVolumeMountConfig() (map[string]*Mount, error) 
 			volume:      vol,
 			MountToPath: mountToPath,
 			Writable:    writable,
+			isBind:      true, // in case the volume itself is a normal volume, but is being mounted in as a bindmount here
 		}
 	}
 


### PR DESCRIPTION
Fixes #9981
Allows a volume which was created by docker (ie, in
/var/lib/docker/vfs/dir) to be used as a Bind argument via the container
start API and overwrite an existing volume.

For example:

``` bash
docker create -v /foo --name one
docker create -v /foo --name two
```

This allows the volume from `one` to be passed into the container start
API as a bind to `two`, and it will overwrite it.

This was possible before 7107898d5cf0f86dc1c6dab29e9dbdad3edc9411
