### PR TITLE
New pull request review workflow

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -131,11 +131,12 @@ for each.
 """
 
 		# Triage
-		[Rules.review.states.nolabel]
+		[Rules.review.states.0-triage]
 
-			# Maintainers are expected to triage new incoming pull requests by adding
-			# the correct labels (e.g. `1-design-review`) potentially skipping some steps
-			# depending on the kind of pull request. Use common sense for judging.
+			# Maintainers are expected to triage new incoming pull requests by removing
+			# the `0-triage` label and adding the correct labels (e.g. `1-design-review`)
+			# potentially skipping some steps depending on the kind of pull request.
+			# Use common sense for judging.
 			#
 			# Checking for DCO should be done at this stage.
 			#
@@ -157,8 +158,8 @@ for each.
 			# Ideally, documentation should reflect the expected behavior of the code.
 			# No code review should take place in this step.
 			#
-			# Once design is approved, this label should be removed and the next label
-			# added.
+			# Once design is approved, a maintainer should make sure to remove this label
+			# and add the next one.
 
 			close = "design rejected"
 			3-docs-review = "proposals with only documentation changes"
@@ -168,14 +169,14 @@ for each.
 		[Rules.review.states.2-code-review]
 
 			# Maintainers are expected to review the code and ensure that it is good
-			# quality and in accordance with the documentation.
+			# quality and in accordance with the documentation in the PR.
 			#
 			# If documentation is absent but expected, maintainers should ask for documentation.
 			#
 			# All tests should pass.
 			#
-			# Once code is approved according to the rules of the subsystem, this label
-			# should be removed and the next label added.
+			# Once code is approved according to the rules of the subsystem, a maintainer
+			# should make sure to remove this label and add the next one.
 
 			close = ""
 			1-design-review = "raises design concerns"
@@ -190,8 +191,8 @@ for each.
 			# for any editorial change that makes the documentation more consistent and
 			# easier to understand.
 			#
-			# Once documentation is approved, this label should be removed and the next
-			# label added.
+			# Once documentation is approved, a maintainer should make sure to remove this
+			# label and add the next one.
 
 			close = ""
 			2-code-review = "requires more code changes"

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -124,7 +124,89 @@ the relevant operators.
 
 * If the change affects the governance, philosophy, goals or principles of the project,
 it must be approved by BDFL.
+
+* A pull request can be in 1 of 5 distinct states, for each of which there is a corresponding label
+that needs to be applied. `Rules.review.states` contains the list of states with possible targets
+for each.
 """
+
+		# Triage
+		[Rules.review.states.nolabel]
+
+			# Maintainers are expected to triage new incoming pull requests by adding
+			# the correct labels (e.g. `1-design-review`) potentially skipping some steps
+			# depending on the kind of pull request. Use common sense for judging.
+			#
+			# Checking for DCO should be done at this stage.
+			#
+			# If an owner, responsible for closing or merging, can be assigned to the PR,
+			# the better.
+
+			close = "unresponsive contributor without DCO"
+			3-docs-review = "Non-proposal documentation-only change"
+			2-code-review = "trivial bugfix"
+			1-design-review = "general case"
+
+		# Design review
+		[Rules.review.states.1-design-review]
+
+			# Maintainers are expected to comment on the design of the pull request.
+			# Review of documentation is expected only in the context of design validation,
+			# not for stylistic changes.
+			#
+			# Ideally, documentation should reflect the expected behavior of the code.
+			# No code review should take place in this step.
+			#
+			# Once design is approved, this label should be removed and the next label
+			# added.
+
+			close = "design rejected"
+			3-docs-review = "proposals with only documentation changes"
+			2-code-review = "general case"
+
+		# Code review
+		[Rules.review.states.2-code-review]
+
+			# Maintainers are expected to review the code and ensure that it is good
+			# quality and in accordance with the documentation.
+			#
+			# If documentation is absent but expected, maintainers should ask for documentation.
+			#
+			# All tests should pass.
+			#
+			# Once code is approved according to the rules of the subsystem, this label
+			# should be removed and the next label added.
+
+			close = ""
+			1-design-review = "raises design concerns"
+			4-merge = "trivial change not impacting documentation"
+			3-docs-review = "general case"
+
+		# Docs review
+		[Rules.review.states.3-docs-review]
+
+			# Maintainers are expected to review the documentation in its bigger context,
+			# ensuring consistency throughout the entire documentation. They should ask
+			# for any editorial change that makes the documentation more consistent and
+			# easier to understand.
+			#
+			# Once documentation is approved, this label should be removed and the next
+			# label added.
+
+			close = ""
+			2-code-review = "requires more code changes"
+			1-design-review = "raises design concerns"
+			4-merge = "general case"
+
+		# Merge
+		[Rules.review.states.4-merge]
+
+			# Maintainers are expected to merge this pull request as soon as possible.
+			# They can ask for a rebase, or carry the pull request themselves.
+			# These should be the easy PRs to merge.
+
+			close = "carry PR"
+			merge = ""
 
 	[Rules.DCO]
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -143,9 +143,9 @@ for each.
 			# If an owner, responsible for closing or merging, can be assigned to the PR,
 			# the better.
 
-			close = "unresponsive contributor without DCO"
-			3-docs-review = "Non-proposal documentation-only change"
-			2-code-review = "trivial bugfix"
+			close = "e.g. unresponsive contributor without DCO"
+			3-docs-review = "non-proposal documentation-only change"
+			2-code-review = "e.g. trivial bugfix"
 			1-design-review = "general case"
 
 		# Design review

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -187,9 +187,11 @@ for each.
 		[Rules.review.states.3-docs-review]
 
 			# Maintainers are expected to review the documentation in its bigger context,
-			# ensuring consistency throughout the entire documentation. They should ask
-			# for any editorial change that makes the documentation more consistent and
-			# easier to understand.
+			# ensuring consistency, completeness, validity, and breadth of coverage across
+			# all extent and new documentation.
+			#
+			# They should ask for any editorial change that makes the documentation more
+			# consistent and easier to understand.
 			#
 			# Once documentation is approved, a maintainer should make sure to remove this
 			# label and add the next one.


### PR DESCRIPTION
Signed-off-by: Tibor Vass teabee89@gmail.com

This proposal tries to bring better visibility in the pipeline of PRs, not only for maintainers but also for contributors. It would allow us to know how well we're doing design reviews, code reviews, docs reviews and better focus on improving bottlenecks.

It should also help not waste contributors' and maintainers' time by doing things in order (e.g. no need to ask to fix a coding style issue when the design was not approved).

Also, please keep in mind this is an experiment, and if it doesn't work we either fix it or revert it :)
