### PR TITLE
fix /etc/host typo in remote API docs

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -222,7 +222,7 @@ Json Parameters:
   -   **Dns** - A list of dns servers for the container to use.
   -   **DnsSearch** - A list of DNS search domains
   -   **ExtraHosts** - A list of hostnames/IP mappings to be added to the
-      container's `/etc/host` file. Specified in the form `["hostname:IP"]`.
+      container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
   -   **VolumesFrom** - A list of volumes to inherit from another container.
         Specified in the form `<container name>[:<ro|rw>]`
   -   **CapAdd** - A list of kernel capabilties to add to the container.

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -222,7 +222,7 @@ Json Parameters:
   -   **Dns** - A list of dns servers for the container to use.
   -   **DnsSearch** - A list of DNS search domains
   -   **ExtraHosts** - A list of hostnames/IP mappings to be added to the
-      container's `/etc/host` file. Specified in the form `["hostname:IP"]`.
+      container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
   -   **VolumesFrom** - A list of volumes to inherit from another container.
         Specified in the form `<container name>[:<ro|rw>]`
   -   **CapAdd** - A list of kernel capabilties to add to the container.

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -225,7 +225,7 @@ Json Parameters:
   -   **Dns** - A list of dns servers for the container to use.
   -   **DnsSearch** - A list of DNS search domains
   -   **ExtraHosts** - A list of hostnames/IP mappings to be added to the
-      container's `/etc/host` file. Specified in the form `["hostname:IP"]`.
+      container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
   -   **VolumesFrom** - A list of volumes to inherit from another container.
         Specified in the form `<container name>[:<ro|rw>]`
   -   **CapAdd** - A list of kernel capabilties to add to the container.


### PR DESCRIPTION
Just fixing a typo from my last pull request that was already merged.
