### PR TITLE
Buffer tar file on v2 push

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -223,6 +223,28 @@ func (graph *Graph) Mktemp(id string) (string, error) {
 	return dir, nil
 }
 
+func (graph *Graph) newTempFile() (*os.File, error) {
+	tmp, err := graph.Mktemp("")
+	if err != nil {
+		return nil, err
+	}
+	return ioutil.TempFile(tmp, "")
+}
+
+func bufferToFile(f *os.File, src io.Reader) (int64, error) {
+	n, err := io.Copy(f, src)
+	if err != nil {
+		return n, err
+	}
+	if err = f.Sync(); err != nil {
+		return n, err
+	}
+	if _, err := f.Seek(0, 0); err != nil {
+		return n, err
+	}
+	return n, nil
+}
+
 // setupInitLayer populates a directory with mountpoints suitable
 // for bind-mounting dockerinit into the container. The mountpoint is simply an
 // empty file at /.dockerinit


### PR DESCRIPTION
Use the same buffering mechanism as v1 to buffer the tar contents on push.  Unlike in v1, the tarsum will not be calculated on push, therefore the tarsum library behavior with size/close cannot be relied on.  Add fixes on read to fix the problematic behavior when reaching EOF.

fixes #10312
fixes #10306
