### PR TITLE
Update go-md2man

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,7 @@ ENV DOCKER_BUILDTAGS apparmor selinux btrfs_noversion
 COPY vendor /go/src/github.com/docker/docker/vendor
 # (copy vendor/ because go-md2man needs golang.org/x/net)
 RUN set -x \
-	&& git clone -b v1 https://github.com/cpuguy83/go-md2man.git /go/src/github.com/cpuguy83/go-md2man \
+	&& git clone -b v1.0.1 https://github.com/cpuguy83/go-md2man.git /go/src/github.com/cpuguy83/go-md2man \
 	&& git clone -b v1.2 https://github.com/russross/blackfriday.git /go/src/github.com/russross/blackfriday \
 	&& go install -v github.com/cpuguy83/go-md2man
 


### PR DESCRIPTION
Update fixes some rendering issues, including improperly escaping '$' in
blocks, and actual parsing of blockcode.
#### Example from: docs/man/docker-attach.1.md

`ID=$(sudo docker run -d fedora /usr/bin/top -b)` was being converted to
`ID=do docker run -d fedora/usr/bin/top -b)`
