### PR TITLE
fix a minor typo in daemon/container.go

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -324,7 +324,7 @@ func (container *Container) Start() (err error) {
 		return nil
 	}
 
-	// if we encounter and error during start we need to ensure that any other
+	// if we encounter an error during start we need to ensure that any other
 	// setup has been cleaned up properly
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
fix minor typo "s/and/an"

Signed-off-by: Liu Hua sdu.liu@huawei.com
