### PR TITLE
Fix bridge initialization for IPv6 if IPv4-only docker0 exists

### DIFF
--- a/daemon/networkdriver/utils.go
+++ b/daemon/networkdriver/utils.go
@@ -74,7 +74,7 @@ func NetworkRange(network *net.IPNet) (net.IP, net.IP) {
 	return netIP.Mask(network.Mask), net.IP(lastIP)
 }
 
-// Return the IPv4 address of a network interface
+// Return the first IPv4 address and slice of IPv6 addresses for the specified network interface
 func GetIfaceAddr(name string) (net.Addr, []net.Addr, error) {
 	iface, err := net.InterfaceByName(name)
 	if err != nil {


### PR DESCRIPTION
This fixes the daemon's failure to start when setting `--ipv6=true` for
the first time without deleting `docker0` bridge from a prior use with
only IPv4 addressing.

The addition of the IPv6 bridge address is factored out into a separate
initialization routine which is called even if the bridge exists, but no
IPv6 addresses are found.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
