### PR TITLE
Checking EXT4_FS_SECURITY for overlay

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -169,7 +169,7 @@ echo '- Storage Drivers:'
 	check_flags BLK_DEV_DM DM_THIN_PROVISIONING EXT4_FS EXT4_FS_POSIX_ACL EXT4_FS_SECURITY | sed 's/^/  /'
 
 	echo '- "'$(wrap_color 'overlay' blue)'":'
-	check_flags OVERLAY_FS | sed 's/^/  /'
+	check_flags OVERLAY_FS EXT4_FS_SECURITY EXT4_FS_POSIX_ACL | sed 's/^/  /'
 } | sed 's/^/  /'
 echo
 


### PR DESCRIPTION
`strace`:

```
[pid  8769] lgetxattr("/var/lib/docker/overlay/511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158/root", "security.capability" <unfinished ...>
[pid  8769] <... lgetxattr resumed> , 0xc2086c5b80, 128) = -1 EOPNOTSUPP (Operation not supported)
```

docker logs:

```
Error pulling image (latest) from busybox, operation not supported
```

I was running overlayfs on top of ext4.

cc @jfrazelle.
