### PR TITLE
Specifying -a and -d to docker run should throw an error

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2227,7 +2227,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 			return err
 		}
 	} else {
-		if fl := cmd.Lookup("attach"); fl != nil {
+		if fl := cmd.Lookup("-attach"); fl != nil {
 			flAttach = fl.Value.(*opts.ListOpts)
 			if flAttach.Len() != 0 {
 				return ErrConflictAttachDetach

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1753,6 +1753,23 @@ func TestRunAttachStdOutAndErrTTYMode(t *testing.T) {
 	logDone("run - Attach stderr and stdout with -t")
 }
 
+// Test for #10388 - this will run the same test as TestRunAttachStdOutAndErrTTYMode
+// but using --attach instead of -a to make sure we read the flag correctly
+func TestRunAttachWithDettach(t *testing.T) {
+	defer deleteAllContainers()
+
+	cmd := exec.Command(dockerBinary, "run", "-d", "--attach", "stdout", "busybox", "true")
+
+	_, stderr, _, err := runCommandWithStdoutStderr(cmd)
+	if err == nil {
+		t.Fatalf("Container should have exited with error code different than 0", err)
+	} else if !strings.Contains(stderr, "Conflicting options: -a and -d") {
+		t.Fatalf("Should have been returned an error with conflicting options -a and -d")
+	}
+
+	logDone("run - Attach stdout with -d")
+}
+
 func TestRunState(t *testing.T) {
 	defer deleteAllContainers()
 	cmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")


### PR DESCRIPTION
The cmd.Lookup should be "-attach" and not "attach", as seen in
docker/docker/runconfig/parse.go

Fixes #10388 

Signed-off-by: André Martins martins@noironetworks.com
