### PR TITLE
Cleanup daemon/volumes

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4504,7 +4504,7 @@ func (s *DockerSuite) TestBuildExoticShellInterpolation(c *check.C) {
 
 	_, err := buildImage(name, `
 		FROM busybox
-		
+
 		ENV SOME_VAR a.b.c
 
 		RUN [ "$SOME_VAR"       = 'a.b.c' ]


### PR DESCRIPTION
- Mount struct now called volumeMount
- Merged volume creation for each volume type (volumes-from, binds, normal
  volumes) so this only happens in once place
- Simplified container copy of volumes (for when `docker cp` is a
  volume)
