### PR TITLE
Allow single name component repository names

### DIFF
--- a/registry/v2/regexp.go
+++ b/registry/v2/regexp.go
@@ -11,9 +11,9 @@ import "regexp"
 // separated by one period, dash or underscore.
 var RepositoryNameComponentRegexp = regexp.MustCompile(`[a-z0-9]+(?:[._-][a-z0-9]+)*`)
 
-// RepositoryNameRegexp builds on RepositoryNameComponentRegexp to allow 2 to
+// RepositoryNameRegexp builds on RepositoryNameComponentRegexp to allow 1 to
 // 5 path components, separated by a forward slash.
-var RepositoryNameRegexp = regexp.MustCompile(`(?:` + RepositoryNameComponentRegexp.String() + `/){1,4}` + RepositoryNameComponentRegexp.String())
+var RepositoryNameRegexp = regexp.MustCompile(`(?:` + RepositoryNameComponentRegexp.String() + `/){0,4}` + RepositoryNameComponentRegexp.String())
 
 // TagNameRegexp matches valid tag names. From docker/docker:graph/tags.go.
 var TagNameRegexp = regexp.MustCompile(`[\w][\w.-]{0,127}`)

--- a/registry/v2/routes_test.go
+++ b/registry/v2/routes_test.go
@@ -53,6 +53,14 @@ func TestRouter(t *testing.T) {
 		},
 		{
 			RouteName:  RouteNameManifest,
+			RequestURI: "/v2/foo/manifests/bar",
+			Vars: map[string]string{
+				"name": "foo",
+				"tag":  "bar",
+			},
+		},
+		{
+			RouteName:  RouteNameManifest,
 			RequestURI: "/v2/foo/bar/manifests/tag",
 			Vars: map[string]string{
 				"name": "foo/bar",


### PR DESCRIPTION
Private registries should support having images pushed with only a single name component (e.g. localhost:5000/myapp). The public registry currently requires two name components, but this is already enforced in the registry code.

@tibor this covers the regression case you found testing against a private v2 registry
