### PR TITLE
Fix logs, so now, old and followed logs has same format without []

### DIFF
--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -99,7 +99,8 @@ func (daemon *Daemon) ContainerLogs(job *engine.Job) engine.Status {
 				}
 				logLine := l.Log
 				if times {
-					logLine = fmt.Sprintf("%s %s", l.Created.Format(format), logLine)
+					// format can be "" or time format, so here can't be error
+					logLine, _ = l.Format(format)
 				}
 				if l.Stream == "stdout" && stdout {
 					io.WriteString(job.Stdout, logLine)

--- a/docs/man/docker-events.1.md
+++ b/docs/man/docker-events.1.md
@@ -45,23 +45,23 @@ After running docker events a container 786d698004576 is started and stopped
 (The container name has been shortened in the output below):
 
     # docker events
-    [2014-04-12 18:23:04 -0400 EDT] 786d69800457: (from whenry/testimage:latest) start
-    [2014-04-12 18:23:13 -0400 EDT] 786d69800457: (from whenry/testimage:latest) die
-    [2014-04-12 18:23:13 -0400 EDT] 786d69800457: (from whenry/testimage:latest) stop
+    2015-01-28T20:21:31.000000000-08:00 59211849bc10: (from whenry/testimage:latest) start
+    2015-01-28T20:21:31.000000000-08:00 59211849bc10: (from whenry/testimage:latest) die
+    2015-01-28T20:21:32.000000000-08:00 59211849bc10: (from whenry/testimage:latest) stop
 
 ## Listening for events since a given date
 Again the output container IDs have been shortened for the purposes of this document:
 
-    # docker events --since '2014-04-12'
-    [2014-04-12 18:11:28 -0400 EDT] c655dbf640dc: (from whenry/testimage:latest) create
-    [2014-04-12 18:11:28 -0400 EDT] c655dbf640dc: (from whenry/testimage:latest) start
-    [2014-04-12 18:14:13 -0400 EDT] 786d69800457: (from whenry/testimage:latest) create
-    [2014-04-12 18:14:13 -0400 EDT] 786d69800457: (from whenry/testimage:latest) start
-    [2014-04-12 18:22:44 -0400 EDT] 786d69800457: (from whenry/testimage:latest) die
-    [2014-04-12 18:22:44 -0400 EDT] 786d69800457: (from whenry/testimage:latest) stop
-    [2014-04-12 18:23:04 -0400 EDT] 786d69800457: (from whenry/testimage:latest) start
-    [2014-04-12 18:23:13 -0400 EDT] 786d69800457: (from whenry/testimage:latest) die
-    [2014-04-12 18:23:13 -0400 EDT] 786d69800457: (from whenry/testimage:latest) stop
+    # docker events --since '2015-01-28'
+    2015-01-28T20:25:38.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) create
+    2015-01-28T20:25:38.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
+    2015-01-28T20:25:39.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) create
+    2015-01-28T20:25:39.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
+    2015-01-28T20:25:40.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) die
+    2015-01-28T20:25:42.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) stop
+    2015-01-28T20:25:45.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
+    2015-01-28T20:25:45.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) die
+    2015-01-28T20:25:46.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) stop
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/pkg/jsonlog/jsonlog.go
+++ b/pkg/jsonlog/jsonlog.go
@@ -23,7 +23,7 @@ func (jl *JSONLog) Format(format string) (string, error) {
 		m, err := json.Marshal(jl)
 		return string(m), err
 	}
-	return fmt.Sprintf("[%s] %s", jl.Created.Format(format), jl.Log), nil
+	return fmt.Sprintf("%s %s", jl.Created.Format(format), jl.Log), nil
 }
 
 func (jl *JSONLog) Reset() {

--- a/pkg/jsonlog/jsonlog_test.go
+++ b/pkg/jsonlog/jsonlog_test.go
@@ -30,7 +30,8 @@ func TestWriteLog(t *testing.T) {
 	if len(lines) != 30 {
 		t.Fatalf("Must be 30 lines but got %d", len(lines))
 	}
-	logRe := regexp.MustCompile(`\[.*\] Line that thinks that it is log line from docker`)
+	// 30+ symbols, five more can come from system timezone
+	logRe := regexp.MustCompile(`.{30,} Line that thinks that it is log line from docker`)
 	for _, l := range lines {
 		if !logRe.MatchString(l) {
 			t.Fatalf("Log line not in expected format: %q", l)


### PR DESCRIPTION
Also, this shows us how often this feature used :)
