### PR TITLE
Option to configure cgroup manager (adds --exec-opt)

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1151,6 +1151,7 @@ _docker() {
 		--dns
 		--dns-search
 		--exec-driver -e
+		--exec-opt
 		--fixed-cidr
 		--fixed-cidr-v6
 		--graph -g

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -51,6 +51,7 @@ complete -c docker -f -n '__fish_docker_no_subcommand' -s d -l daemon -d 'Enable
 complete -c docker -f -n '__fish_docker_no_subcommand' -l dns -d 'Force Docker to use specific DNS servers'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l dns-search -d 'Force Docker to use specific DNS search domains'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s e -l exec-driver -d 'Force the Docker runtime to use a specific exec driver'
+complete -c docker -f -n '__fish_docker_no_subcommand' -l exec-opt -d 'Set exec driver options'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l fixed-cidr -d 'IPv4 subnet for fixed IPs (e.g. 10.20.0.0/16)'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l fixed-cidr-v6 -d 'IPv6 subnet for fixed IPs (e.g.: 2001:a02b/48)'
 complete -c docker -f -n '__fish_docker_no_subcommand' -s G -l group -d 'Group to assign the unix socket specified by -H when running in daemon mode'

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	GraphDriver          string
 	GraphOptions         []string
 	ExecDriver           string
+	ExecOptions          []string
 	Mtu                  int
 	SocketGroup          string
 	EnableCors           bool
@@ -70,6 +71,7 @@ func (config *Config) InstallFlags() {
 	flag.StringVar(&config.CorsHeaders, []string{"-api-cors-header"}, "", "Set CORS headers in the remote API")
 	opts.IPVar(&config.Bridge.DefaultIp, []string{"#ip", "-ip"}, "0.0.0.0", "Default IP when binding container ports")
 	opts.ListVar(&config.GraphOptions, []string{"-storage-opt"}, "Set storage driver options")
+	opts.ListVar(&config.ExecOptions, []string{"-exec-opt"}, "Set exec driver options")
 	// FIXME: why the inconsistency between "hosts" and "sockets"?
 	opts.IPListVar(&config.Dns, []string{"#dns", "-dns"}, "DNS server to use")
 	opts.DnsSearchListVar(&config.DnsSearch, []string{"-dns-search"}, "DNS search domains to use")

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -942,7 +942,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine, registryService 
 
 	sysInfo := sysinfo.New(false)
 	const runDir = "/var/run/docker"
-	ed, err := execdrivers.NewDriver(config.ExecDriver, runDir, config.Root, sysInitPath, sysInfo)
+	ed, err := execdrivers.NewDriver(config.ExecDriver, config.ExecOptions, runDir, config.Root, sysInitPath, sysInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/execdriver/execdrivers/execdrivers.go
+++ b/daemon/execdriver/execdrivers/execdrivers.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/pkg/sysinfo"
 )
 
-func NewDriver(name, root, libPath, initPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
+func NewDriver(name string, options []string, root, libPath, initPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
 	switch name {
 	case "lxc":
 		// we want to give the lxc driver the full docker root because it needs
@@ -18,7 +18,7 @@ func NewDriver(name, root, libPath, initPath string, sysInfo *sysinfo.SysInfo) (
 		// to be backwards compatible
 		return lxc.NewDriver(root, libPath, initPath, sysInfo.AppArmor)
 	case "native":
-		return native.NewDriver(path.Join(root, "execdriver", "native"), initPath)
+		return native.NewDriver(path.Join(root, "execdriver", "native"), initPath, options)
 	}
 	return nil, fmt.Errorf("unknown exec driver %s", name)
 }

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -324,15 +324,15 @@ for data and metadata:
 
 # EXEC DRIVER OPTIONS
 
-Options to the exec-driver can be specified with the **--exec-opt** flags. The
-only driver accepting options is the *native* (libcontainer) driver. Therefore
-use these flags with **-s=**native.
-
-The following is the only *native* option:
+Use the **--exec-opt** flags to specify options to the exec-driver. The only
+driver that accepts this flag is the *native* (libcontainer) driver. As a
+result, you must also specify **-s=**native for this option to have effect. The 
+following is the only *native* option:
 
 #### native.cgroupdriver
-Specifies the management of the container's cgroups. As of now the only viable
-options are `cgroupfs` and `systemd`. The option will always fallback to `cgroupfs`.
+Specifies the management of the container's `cgroups`. You can specify 
+`cgroupfs` or `systemd`. If you specify `systemd` and it is not available, the 
+system uses `cgroupfs`.
 
 #### Client
 For specific client examples please see the man page for the specific Docker

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -124,6 +124,9 @@ unix://[/path/to/socket] to use.
 **-v**, **--version**=*true*|*false*
   Print version information and quit. Default is false.
 
+**--exec-opt**=[]
+  Set exec driver options. See EXEC DRIVER OPTIONS.
+
 **--selinux-enabled**=*true*|*false*
   Enable selinux support. Default is false. SELinux does not presently support the BTRFS storage driver.
 
@@ -318,6 +321,18 @@ for data and metadata:
       --storage-opt dm.datadev=/dev/vdb \
       --storage-opt dm.metadatadev=/dev/vdc \
       --storage-opt dm.basesize=20G
+
+# EXEC DRIVER OPTIONS
+
+Options to the exec-driver can be specified with the **--exec-opt** flags. The
+only driver accepting options is the *native* (libcontainer) driver. Therefore
+use these flags with **-s=**native.
+
+The following is the only *native* option:
+
+#### native.cgroupdriver
+Specifies the management of the container's cgroups. As of now the only viable
+options are `cgroupfs` and `systemd`. The option will always fallback to `cgroupfs`.
 
 #### Client
 For specific client examples please see the man page for the specific Docker

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -442,7 +442,7 @@ Currently supported options are:
     > Otherwise, set this flag for migrating existing Docker daemons to a
     > daemon with a supported environment.
 
-### Docker exec-driver option
+### Docker execdriver option
 
 The Docker daemon uses a specifically built `libcontainer` execution driver as its
 interface to the Linux kernel `namespaces`, `cgroups`, and `SELinux`.
@@ -452,27 +452,21 @@ https://linuxcontainers.org/) via the `lxc` execution driver, however, this is
 not where the primary development of new functionality is taking place.
 Add `-e lxc` to the daemon flags to use the `lxc` execution driver.
 
-#### Exec driver options
+#### Options for the native execdriver
 
-Particular exec-driver can be configured with options specified with
-`--exec-opt` flags. The only driver accepting options is `native`
-(libcontainer) as of now. All its options are prefixed with `native`.
+You can configure the `native` (libcontainer) execdriver using options specified
+with the `--exec-opt` flag. All the flag's options have the `native` prefix. A
+single `native.cgroupdriver` option is available.
 
-Currently supported options are:
+The `native.cgroupdriver` option specifies the management of the container's 
+cgroups. You can specify `cgroupfs` or `systemd`. If you specify `systemd` and 
+it is not available, the system uses `cgroupfs`. By default, if no option is 
+specified, the execdriver first tries `systemd` and falls back to `cgroupfs`. 
+This example sets the execdriver to `cgroupfs`:
 
- *  `native.cgroupdriver`
-
-    Specifies the management of the container's cgroups. As of now the only
-    viable options are `cgroupfs` and `systemd`. The option will always
-    fallback to `cgroupfs`. By default, if no option is specified, the
-    execdriver will try `systemd` and fallback to `cgroupfs`. Same applies if
-    `systemd` is passed as the `cgroupdriver` but is not capable of being used.
-
-    Example use:
-
-        $ sudo docker -d --exec-opt native.cgroupdriver=cgroupfs
-
-
+    $ sudo docker -d --exec-opt native.cgroupdriver=cgroupfs
+     
+Setting this option applies to all containers the daemon launches.
 
 ### Daemon DNS options
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -452,6 +452,27 @@ https://linuxcontainers.org/) via the `lxc` execution driver, however, this is
 not where the primary development of new functionality is taking place.
 Add `-e lxc` to the daemon flags to use the `lxc` execution driver.
 
+#### Exec driver options
+
+Particular exec-driver can be configured with options specified with
+`--exec-opt` flags. The only driver accepting options is `native`
+(libcontainer) as of now. All its options are prefixed with `native`.
+
+Currently supported options are:
+
+ *  `native.cgroupdriver`
+
+    Specifies the management of the container's cgroups. As of now the only
+    viable options are `cgroupfs` and `systemd`. The option will always
+    fallback to `cgroupfs`. By default, if no option is specified, the
+    execdriver will try `systemd` and fallback to `cgroupfs`. Same applies if
+    `systemd` is passed as the `cgroupdriver` but is not capable of being used.
+
+    Example use:
+
+        $ sudo docker -d --exec-opt native.cgroupdriver=cgroupfs
+
+
 
 ### Daemon DNS options
 


### PR DESCRIPTION
This adds a flag `--exec-opt` on the daemon (much like the current `--storage-opt` flag.
With the addition of this flag we can configure `--exec-opt native.cgroupdriver`.

This specifies the management of a container's cgroups. Obviously since I have chosen to add it as a daemon flag it applies to all containers. As of now the only viable options are 
`cgroupfs` and `systemd`. The option will always fallback to `cgroupfs`. By default, if no option
is specified, the execdriver will try `systemd` and fallback to `cgroupfs`. 
Same applies if systemd is passed as the `cgroupdriver` but is not capable of being used.
