### PR TITLE
Improve explanation of port mapping from containers

### DIFF
--- a/docs/sources/userguide/usingdocker.md
+++ b/docs/sources/userguide/usingdocker.md
@@ -167,8 +167,9 @@ host. You might be asking about now: why wouldn't we just want to always
 use 1:1 port mappings in Docker containers rather than mapping to high
 ports? Well 1:1 mappings have the constraint of only being able to map
 one of each port on your local host. Let's say you want to test two
-Python applications: both bound to port 5000 inside your container.
-Without Docker's port mapping you could only access one at a time.
+Python applications: both bound to port 5000 inside their own containers.
+Without Docker's port mapping you could only access one at a time on the
+Docker host.
 
 So let's now browse to port 49155 in a web browser to
 see the application.


### PR DESCRIPTION
I was a little confused by the wording in this paragraph. It made it seem like the purpose of non 1:1 port mapping had to do with running two python apps inside the same container on the same port. As far as I understand (general dev/unix newb here), this isn't possible. Only one thing can listen on a port at a time. So the example didn't make sense. 

I've updated the wording in a way that makes sense to me. 

PS, I could also be wrong in my interpretation and the original docs could be more accurate. In that case, I'll have learned something new!
