### PR TITLE
devicemapper: Skip the files with prefix "." during device map construct...

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -323,6 +323,11 @@ func (devices *DeviceSet) deviceFileWalkFunction(path string, finfo os.FileInfo)
 		return nil
 	}
 
+	if strings.HasPrefix(finfo.Name(), ".") {
+		log.Debugf("Skipping file %s", path)
+		return nil
+	}
+
 	if finfo.Name() == deviceSetMetaFile {
 		log.Debugf("Skipping file %s", path)
 		return nil


### PR DESCRIPTION
...ion

Any file which starts with "." is not a valid metadata file. Skip it
during device map construction.

This closes Issue #9644

Signed-off-by: Vivek Goyal vgoyal@redhat.com
