### PR TITLE
mkimage-arch.sh - don't run docker in interactive mode

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -87,5 +87,5 @@ mknod -m 666 $DEV/ptmx c 5 2
 ln -sf /proc/self/fd $DEV/fd
 
 tar --numeric-owner --xattrs --acls -C $ROOTFS -c . | docker import - archlinux
-docker run -i -t archlinux echo Success.
+docker run -t archlinux echo Success.
 rm -rf $ROOTFS


### PR DESCRIPTION
Don't run docker in interactive mode in the archlinux container build script. Recent versions of Docker error out with "cannot enable tty mode on non tty input" when being run non-interactively (such as in a cron job, Jenkins build, etc.)
