### PR TITLE
Defer creation of trust key file until needed

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -17,7 +17,6 @@ import (
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/docker/registry"
-	"github.com/docker/libtrust"
 )
 
 type DockerCli struct {
@@ -27,7 +26,7 @@ type DockerCli struct {
 	in         io.ReadCloser
 	out        io.Writer
 	err        io.Writer
-	key        libtrust.PrivateKey
+	keyFile    string
 	tlsConfig  *tls.Config
 	scheme     string
 	// inFd holds file descriptor of the client's STDIN, if it's a valid file
@@ -122,7 +121,7 @@ func (cli *DockerCli) CheckTtyInput(attachStdin, ttyMode bool) error {
 	return nil
 }
 
-func NewDockerCli(in io.ReadCloser, out, err io.Writer, key libtrust.PrivateKey, proto, addr string, tlsConfig *tls.Config) *DockerCli {
+func NewDockerCli(in io.ReadCloser, out, err io.Writer, keyFile string, proto, addr string, tlsConfig *tls.Config) *DockerCli {
 	var (
 		inFd          uintptr
 		outFd         uintptr
@@ -177,7 +176,7 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, key libtrust.PrivateKey,
 		in:            in,
 		out:           out,
 		err:           err,
-		key:           key,
+		keyFile:       keyFile,
 		inFd:          inFd,
 		outFd:         outFd,
 		isTerminalIn:  isTerminalIn,

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1191,6 +1191,10 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 	name := cmd.Arg(0)
 
 	cli.LoadConfigFile()
+	trustKey, err := api.LoadOrCreateTrustKey(cli.keyFile)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	remote, tag := parsers.ParseRepositoryTag(name)
 
@@ -1225,7 +1229,7 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 	if err != nil {
 		return err
 	}
-	err = js.Sign(cli.key)
+	err = js.Sign(trustKey)
 	if err != nil {
 		return err
 	}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -79,11 +79,6 @@ func main() {
 	}
 	protoAddrParts := strings.SplitN(flHosts[0], "://", 2)
 
-	trustKey, err := api.LoadOrCreateTrustKey(*flTrustKey)
-	if err != nil {
-		log.Fatal(err)
-	}
-
 	var (
 		cli       *client.DockerCli
 		tlsConfig tls.Config
@@ -125,9 +120,9 @@ func main() {
 	}
 
 	if *flTls || *flTlsVerify {
-		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, trustKey, protoAddrParts[0], protoAddrParts[1], &tlsConfig)
+		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, *flTrustKey, protoAddrParts[0], protoAddrParts[1], &tlsConfig)
 	} else {
-		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, trustKey, protoAddrParts[0], protoAddrParts[1], nil)
+		cli = client.NewDockerCli(os.Stdin, os.Stdout, os.Stderr, *flTrustKey, protoAddrParts[0], protoAddrParts[1], nil)
 	}
 
 	if err := cli.Cmd(flag.Args()...); err != nil {

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -383,6 +383,9 @@ func TestDaemonKeyMigration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error generating private key: %s", err)
 	}
+	if err := os.MkdirAll(filepath.Join(os.Getenv("HOME"), ".docker"), 0755); err != nil {
+		t.Fatalf("Error creating .docker directory: %s", err)
+	}
 	if err := libtrust.SaveKey(filepath.Join(os.Getenv("HOME"), ".docker", "key.json"), k1); err != nil {
 		t.Fatalf("Error saving private key: %s", err)
 	}

--- a/integration/commands_test.go
+++ b/integration/commands_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/docker/utils"
-	"github.com/docker/libtrust"
 	"github.com/kr/pty"
 )
 
@@ -122,12 +121,7 @@ func TestRunDetach(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	key, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cli := client.NewDockerCli(tty, stdoutPipe, ioutil.Discard, key, testDaemonProto, testDaemonAddr, nil)
+	cli := client.NewDockerCli(tty, stdoutPipe, ioutil.Discard, "", testDaemonProto, testDaemonAddr, nil)
 	defer cleanup(globalEngine, t)
 
 	ch := make(chan struct{})
@@ -177,12 +171,7 @@ func TestAttachDetach(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	key, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cli := client.NewDockerCli(tty, stdoutPipe, ioutil.Discard, key, testDaemonProto, testDaemonAddr, nil)
+	cli := client.NewDockerCli(tty, stdoutPipe, ioutil.Discard, "", testDaemonProto, testDaemonAddr, nil)
 	defer cleanup(globalEngine, t)
 
 	ch := make(chan struct{})
@@ -219,7 +208,7 @@ func TestAttachDetach(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cli = client.NewDockerCli(tty, stdoutPipe, ioutil.Discard, key, testDaemonProto, testDaemonAddr, nil)
+	cli = client.NewDockerCli(tty, stdoutPipe, ioutil.Discard, "", testDaemonProto, testDaemonAddr, nil)
 
 	ch = make(chan struct{})
 	go func() {
@@ -270,12 +259,7 @@ func TestAttachDetachTruncatedID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	key, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cli := client.NewDockerCli(tty, stdoutPipe, ioutil.Discard, key, testDaemonProto, testDaemonAddr, nil)
+	cli := client.NewDockerCli(tty, stdoutPipe, ioutil.Discard, "", testDaemonProto, testDaemonAddr, nil)
 	defer cleanup(globalEngine, t)
 
 	// Discard the CmdRun output
@@ -297,7 +281,7 @@ func TestAttachDetachTruncatedID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cli = client.NewDockerCli(tty, stdoutPipe, ioutil.Discard, key, testDaemonProto, testDaemonAddr, nil)
+	cli = client.NewDockerCli(tty, stdoutPipe, ioutil.Discard, "", testDaemonProto, testDaemonAddr, nil)
 
 	ch := make(chan struct{})
 	go func() {
@@ -347,12 +331,7 @@ func TestAttachDisconnect(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	key, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	cli := client.NewDockerCli(tty, stdoutPipe, ioutil.Discard, key, testDaemonProto, testDaemonAddr, nil)
+	cli := client.NewDockerCli(tty, stdoutPipe, ioutil.Discard, "", testDaemonProto, testDaemonAddr, nil)
 	defer cleanup(globalEngine, t)
 
 	go func() {
@@ -421,11 +400,8 @@ func TestAttachDisconnect(t *testing.T) {
 func TestRunAutoRemove(t *testing.T) {
 	t.Skip("Fixme. Skipping test for now, race condition")
 	stdout, stdoutPipe := io.Pipe()
-	key, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	cli := client.NewDockerCli(nil, stdoutPipe, ioutil.Discard, key, testDaemonProto, testDaemonAddr, nil)
+
+	cli := client.NewDockerCli(nil, stdoutPipe, ioutil.Discard, "", testDaemonProto, testDaemonAddr, nil)
 	defer cleanup(globalEngine, t)
 
 	c := make(chan struct{})

--- a/integration/https_test.go
+++ b/integration/https_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/client"
-	"github.com/docker/libtrust"
 )
 
 const (
@@ -38,11 +37,7 @@ func getTlsConfig(certFile, keyFile string, t *testing.T) *tls.Config {
 
 // TestHttpsInfo connects via two-way authenticated HTTPS to the info endpoint
 func TestHttpsInfo(t *testing.T) {
-	key, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	cli := client.NewDockerCli(nil, ioutil.Discard, ioutil.Discard, key, testDaemonProto,
+	cli := client.NewDockerCli(nil, ioutil.Discard, ioutil.Discard, "", testDaemonProto,
 		testDaemonHttpsAddr, getTlsConfig("client-cert.pem", "client-key.pem", t))
 
 	setTimeout(t, "Reading command output time out", 10*time.Second, func() {
@@ -55,11 +50,7 @@ func TestHttpsInfo(t *testing.T) {
 // TestHttpsInfoRogueCert connects via two-way authenticated HTTPS to the info endpoint
 // by using a rogue client certificate and checks that it fails with the expected error.
 func TestHttpsInfoRogueCert(t *testing.T) {
-	key, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	cli := client.NewDockerCli(nil, ioutil.Discard, ioutil.Discard, key, testDaemonProto,
+	cli := client.NewDockerCli(nil, ioutil.Discard, ioutil.Discard, "", testDaemonProto,
 		testDaemonHttpsAddr, getTlsConfig("client-rogue-cert.pem", "client-rogue-key.pem", t))
 
 	setTimeout(t, "Reading command output time out", 10*time.Second, func() {
@@ -76,11 +67,7 @@ func TestHttpsInfoRogueCert(t *testing.T) {
 // TestHttpsInfoRogueServerCert connects via two-way authenticated HTTPS to the info endpoint
 // which provides a rogue server certificate and checks that it fails with the expected error
 func TestHttpsInfoRogueServerCert(t *testing.T) {
-	key, err := libtrust.GenerateECP256PrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
-	cli := client.NewDockerCli(nil, ioutil.Discard, ioutil.Discard, key, testDaemonProto,
+	cli := client.NewDockerCli(nil, ioutil.Discard, ioutil.Discard, "", testDaemonProto,
 		testDaemonRogueHttpsAddr, getTlsConfig("client-cert.pem", "client-key.pem", t))
 
 	setTimeout(t, "Reading command output time out", 10*time.Second, func() {


### PR DESCRIPTION
Currently push is the only operation making uses of the key, this change defers creation until the push operation is called.

Fixes #10442
