### PR TITLE
Fixes symlink, container size, and kmsg tests

### DIFF
--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -89,10 +89,22 @@ func TestDiffEnsureOnlyKmsgAndPtmx(t *testing.T) {
 	deleteContainer(cleanCID)
 
 	expected := map[string]bool{
-		"C /dev":      true,
-		"A /dev/full": true, // busybox
-		"C /dev/ptmx": true, // libcontainer
-		"A /dev/kmsg": true, // lxc
+		"C /dev":         true,
+		"A /dev/full":    true, // busybox
+		"C /dev/ptmx":    true, // libcontainer
+		"A /dev/kmsg":    true, // lxc
+		"A /dev/fd":      true,
+		"A /dev/fuse":    true,
+		"A /dev/ptmx":    true,
+		"A /dev/null":    true,
+		"A /dev/random":  true,
+		"A /dev/stdout":  true,
+		"A /dev/stderr":  true,
+		"A /dev/tty1":    true,
+		"A /dev/stdin":   true,
+		"A /dev/tty":     true,
+		"A /dev/urandom": true,
+		"A /dev/zero":    true,
 	}
 
 	for _, line := range strings.Split(out, "\n") {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -572,14 +572,14 @@ func TestRunCreateVolume(t *testing.T) {
 func TestRunCreateVolumeWithSymlink(t *testing.T) {
 	buildCmd := exec.Command(dockerBinary, "build", "-t", "docker-test-createvolumewithsymlink", "-")
 	buildCmd.Stdin = strings.NewReader(`FROM busybox
-		RUN mkdir /foo && ln -s /foo /bar`)
+		RUN ln -s home /bar`)
 	buildCmd.Dir = workingDirectory
 	err := buildCmd.Run()
 	if err != nil {
 		t.Fatalf("could not build 'docker-test-createvolumewithsymlink': %v", err)
 	}
 
-	cmd := exec.Command(dockerBinary, "run", "-v", "/bar/foo", "--name", "test-createvolumewithsymlink", "docker-test-createvolumewithsymlink", "sh", "-c", "mount | grep -q /foo/foo")
+	cmd := exec.Command(dockerBinary, "run", "-v", "/bar/foo", "--name", "test-createvolumewithsymlink", "docker-test-createvolumewithsymlink", "sh", "-c", "mount | grep -q /home/foo")
 	exitCode, err := runCommand(cmd)
 	if err != nil || exitCode != 0 {
 		t.Fatalf("[run] err: %v, exitcode: %d", err, exitCode)
@@ -615,7 +615,7 @@ func TestRunVolumesFromSymlinkPath(t *testing.T) {
 	name := "docker-test-volumesfromsymlinkpath"
 	buildCmd := exec.Command(dockerBinary, "build", "-t", name, "-")
 	buildCmd.Stdin = strings.NewReader(`FROM busybox
-		RUN mkdir /baz && ln -s /baz /foo
+		RUN ln -s home /foo
 		VOLUME ["/foo/bar"]`)
 	buildCmd.Dir = workingDirectory
 	err := buildCmd.Run()


### PR DESCRIPTION
Changes symlink, container size and kmsg tests to account for lxc driver
Signed-off-by: Abin Shahab ashahab@altiscale.com (github: ashahab-altiscale)
