### PR TITLE
Proposal: Add real-time priorities for processes

### DIFF
--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -97,6 +97,9 @@ run**.
 **--cidfile**=""
    Write the container ID to the file
 
+**--cpu-rt**=*true*|*false*
+   Allow processes within the container to run with real-time priority. The default is *false*.
+
 **--cpuset**=""
    CPUs in which to allow execution (0-3, 0,1)
 


### PR DESCRIPTION
This is a proposal to add a hook into docker to allow processes to run with realtime priorities within containers. This is my first post, and I don't know too much about the docker source code, but doing a cursory glance through the source code, I was thinking that this could be implemented by altering the cpu.rt_runtime_us parameter within the cgroup hierarchy. This idea is based on the following blog post:
http://www.breakage.org/2014/08/22/using-sched_fifo-in-docker-containers-on-rhel/

Based on the blog post, it seems feasible to programmatically alter cpu.rt_runtime_us within docker-[id].scope (/sys/fs/cgroup/cpu/system.slice/docker-[long_id].scope/cpu.rt_runtime_us). There is already code within libcontainer to modify other parameters such as CPU shares. My thought was that if the proposed parameter was set to true, it would set rt_runtime_us to 950000 (the default within /proc/sched/kernel/sched_rt_runtime_us). If the proposed parameter was set to false, it would set rt_runtime_us to 0. 

The piece that is less obvious to me is whether Docker should be responsible for altering the parameter within the parent cgroup: (/sys/fs/cgroup/cpu/system.slice/cpu.rt_runtime_us), since this may have an effect on other processes within that slice. 

One thing that's not completely clean about my approach is that the sys_nice capability needs to be added in conjunction with my proposed parameter being set to true. This could be added to the documentation of that parameter, or the setting of that parameter to true could do something like automatically add the sys_nice capability. This doesn't seem too bad since other Docker command line arguments are dependent on each other -> for example, you cannot invoke the -d and the --rm option at the same time.

Note that I've seen PR #9437 and this did not solve the issue; it seems necessary to tell the cgroup that it has RT runtime on the CPU, in addition to setting the ulimits properly.

It is worth mentioning that this is simply one idea for this implementation -> if folks know how to accomplish this using a different method, please feel free to bring it up.

In testing this feature, one can use the chrt utility as described in the blog post. Or, one can invoke the condition that failed for me in the first place that prompted this feature: the function sched_setscheduler() in C. The following C program demonstrates the test condition:

```
#include <stdio.h>
#include <sched.h>

int main()
{
    struct sched_param param;
    param.sched_priority = 50;
    const int myself  =  0; // 0 is the PID of ourself
    if (0 != sched_setscheduler(myself, SCHED_FIFO, &param))
    {
        printf("Failure\n");
        return -1;
    }

    printf("Success\n");
    return 0;
}
```

Information about my environment:

[root@localhost cpu]# cat /etc/*-release
CentOS Linux release 7.0.1406 (Core)
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CentOS Linux release 7.0.1406 (Core)
CentOS Linux release 7.0.1406 (Core)

[root@localhost cpu]# docker version
Client version: 1.3.2
Client API version: 1.15
Go version (client): go1.3.3
Git commit (client): 39fa2fa/1.3.2
OS/Arch (client): linux/amd64
Server version: 1.3.2
Server API version: 1.15
Go version (server): go1.3.3
Git commit (server): 39fa2fa/1.3.2

Signed-off-by: Glenn Duffy glennduffy@gmail.com
