### PR TITLE
Fix token basic auth header issue

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -387,6 +387,9 @@ func (s *TagStore) pullV2Repository(eng *engine.Engine, r *registry.Session, out
 		if err != nil {
 			return err
 		}
+		if len(tags) == 0 {
+			return registry.ErrDoesNotExist
+		}
 		for _, t := range tags {
 			if downloaded, err := s.pullV2Tag(eng, r, out, endpoint, repoInfo, t, sf, parallel, auth); err != nil {
 				return err

--- a/registry/session_v2.go
+++ b/registry/session_v2.go
@@ -128,6 +128,8 @@ func (r *Session) HeadV2ImageBlob(ep *Endpoint, imageName, sumType, sum string, 
 	case res.StatusCode >= 200 && res.StatusCode < 400:
 		// return something indicating no push needed
 		return true, nil
+	case res.StatusCode == 401:
+		return false, errLoginRequired
 	case res.StatusCode == 404:
 		// return something indicating blob push needed
 		return false, nil

--- a/registry/token.go
+++ b/registry/token.go
@@ -51,10 +51,12 @@ func getToken(username, password string, params map[string]string, registryEndpo
 		reqParams.Add("scope", scopeField)
 	}
 
-	reqParams.Add("account", username)
+	if username != "" {
+		reqParams.Add("account", username)
+		req.SetBasicAuth(username, password)
+	}
 
 	req.URL.RawQuery = reqParams.Encode()
-	req.SetBasicAuth(username, password)
 
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
When requesting a token, the basic auth header is always being set even
if there is no username value. This patch corrects this and does not set
the basic auth header if the username is empty.

Docker-DCO-1.1-Signed-off-by: Josh Hawn josh.hawn@docker.com (github: jlhawn)
