### PR TITLE
delete duplicated word in registry/session.go

### DIFF
--- a/registry/session.go
+++ b/registry/session.go
@@ -54,7 +54,7 @@ func NewSession(authConfig *AuthConfig, factory *utils.HTTPRequestFactory, endpo
 			return nil, err
 		}
 		if info.Standalone {
-			log.Debugf("Endpoint %s is eligible for private registry registry. Enabling decorator.", r.indexEndpoint.String())
+			log.Debugf("Endpoint %s is eligible for private registry. Enabling decorator.", r.indexEndpoint.String())
 			dec := utils.NewHTTPAuthDecorator(authConfig.Username, authConfig.Password)
 			factory.AddDecorator(dec)
 		}


### PR DESCRIPTION
fix a minor typo in registry/session.go
Signed-off-by: Liu Hua sdu.liu@huawei.com
