### PR TITLE
Show the right image name/ID in job log

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -188,7 +188,7 @@ func (container *Container) WriteHostConfig() error {
 
 func (container *Container) LogEvent(action string) {
 	d := container.daemon
-	if err := d.eng.Job("log", action, container.ID, d.Repositories().ImageName(container.ImageID)).Run(); err != nil {
+	if err := d.eng.Job("log", action, container.ID, container.Config.Image).Run(); err != nil {
 		log.Errorf("Error logging event %s for %s: %s", action, container.ID, err)
 	}
 }


### PR DESCRIPTION
When we tag an Image with several names and we run one of them,
The "create" job will log this event with
 +job log(create, containerID, Imagename).

And the "Imagename" is always the first one (sorted). It is the
same to "start/stop/rm" jobs. So use the correct name instand.

Signed-off-by: Liu Hua sdu.liu@huawei.com
