### PR TITLE
Add missing people and subsystems to MAINTAINERS

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -445,6 +445,7 @@ made through a pull request.
 		[Org.Subsystem."remote api"]
 
 			people = [
+				"jfrazelle",
 				"vieux"
 			]
 
@@ -476,6 +477,62 @@ made through a pull request.
 				"duglin"
 			]
 
+		[Org.Subsystem.daemon]
+
+			people = [
+				"cpuguy83",
+				"crosbymichael",
+				"shykes",
+				"tibor",
+				"unclejack",
+				"vieux",
+				"vishh",
+			]
+
+		[Org.Subsystem.engine]
+
+			people = [
+				"shykes"
+			]
+
+		[Org.Subsystem.graph]
+
+			people = [
+				"crosbymichael",
+				"shykes",
+				"tibor",
+				"unclejack",
+				"vieux",
+			]
+
+		[Org.Subsystem.integration]
+
+			people = [
+				"tibor",
+				"unclejack"
+			]
+
+		[Org.Subsystem.integration-cli]
+
+			people = [
+				"unclejack"
+			]
+
+		[Org.Subsystem.project]
+
+			people = [
+				# NOTE: jpetazzo is maintainer for "dind"
+				"jpetazzo",
+				"tianon",
+				"tibor",
+				"unclejack"
+			]
+
+		[Org.Subsystem.volumes]
+
+			people = [
+				"cpuguy83"
+			]
 
 [people]
 
@@ -499,6 +556,11 @@ made through a pull request.
 	Name = "Ben Firshman"
 	Email = "ben@firshman.co.uk"
 	GitHub = "bfirsh"
+
+	[people.cpuguy83]
+	Name = "Brian Goff"
+	Email = "cpuguy83@gmail.com"
+	GitHub = "cpuguy83"
 
 	[people.crosbymichael]
 	Name = "Michael Crosby"
@@ -550,6 +612,11 @@ made through a pull request.
 	Email = "arnaud@docker.com"
 	GitHub = "icecrime"
 
+	[people.james]
+	Name = "James Turnbull"
+	Email = "james@lovedthanlost.net"
+	GitHub = "jamtur01"
+
 	[people.jfrazelle]
 	Name = "Jessie Frazelle"
 	Email = "jess@docker.com"
@@ -564,6 +631,11 @@ made through a pull request.
 	Name = "Joffrey Fuhrer"
 	Email = "joffrey@docker.com"
 	Github = "shin-"
+
+	[people.jpetazzo]
+	Name = "Jerome Petazzoni"
+	Email = "jerome@docker.com"
+	GitHub = "jpetazzo"
 
 	[people.lk4d4]
 	Name = "Alexander Morozov"
@@ -584,7 +656,7 @@ made through a pull request.
 	Name = "Solomon Hykes"
 	Email = "solomon@docker.com"
 	GitHub = "shykes"
-    
+
 	[people.spf13]
 	Name = "Steve Francia"
 	Email = "steve.francia@gmail.com"


### PR DESCRIPTION
The new MAINTAINERS file seemed to be missing a lot of information. This change adds the missing information by adding subsystems, based on MAINTAINERS files in top-level subdirectories in the repository and copying that information in this document.

Sub-directories have not been checked for MAINTAINERS files, so it's possible that additional information should still be added.

Summary of the changes made:
- <strike>Added @kencochrane to the "registry" subsystem (given that
  he is still included in registry/MAINTAINERS).</strike>
- Added @jfrazelle to the "remote API" subsystem (given that
  she is still included in api/MAINTAINERS)
- Added entries and maintainers for the subsystems;
  - daemon
  - engine
  - graph
  - integration
  - integration-cli
  - project (formerly known as "hack")
  - volumes
- Added missing information for people;
  - cpuguy83
  - fredlf
  - jamtur01
  - jpetazzo
  - <strike>kencochrane</strike>
#### Notes;
- **please** check if these changes are correct. I tried to copy the information correctly, but I may have made a slip-up during the process.
- I noticed the subsystems weren't in alphabetical order; is that something we want?
- I haven't added @icecrime to the API and Daemon subsystems yet (basically, that was the reason I noticed the document was incomplete: https://github.com/docker/docker/pull/10395 was closed to be replaced with adding him to _this_ document, but that never happened)
- What will be done with the existing `MAINTAINERS` files? Should they be removed? I can imagine it becoming a problem to keep them in sync with this document. Also; what is leading? this document, or the separate `MAINTAINERS` files?

I just noticed there's another PR targeting parts of this: https://github.com/docker/docker/pull/10425/files so some things may overlap.
