### PR TITLE
Fix broken link to project/MAINTAINERS.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,7 +211,7 @@ component affected. For example, if a change affects `docs/` and `registry/`, it
 needs an absolute majority from the maintainers of `docs/` AND, separately, an
 absolute majority of the maintainers of `registry/`.
 
-For more details see [MAINTAINERS.md](project/MAINTAINERS.md)
+For more details see [MAINTAINERS](MAINTAINERS)
 
 ### Sign your work
 


### PR DESCRIPTION
The link to project/MAINTAINERS.md was broken (it's not a MarkDown file), in addition, /MAINTAINERS containers more relevant information on the LGTM process and contains info about maintainers of all subsystems.

Please check if the 'root' "MAINTAINERS" document is indeed the intended target of this link.
