### PR TITLE
Proposal: use a bot to check PRs & help maintainer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ feels wrong or incomplete.
 * [Build Environment](#build-environment)
 * [Contribution Guidelines](#contribution-guidelines)
 * [Community Guidelines](#docker-community-guidelines)
+* [Docker Dev Bot](#docker-dev-bot)
 
 ## Reporting Security Issues
 
@@ -354,3 +355,22 @@ do need a fair way to deal with people who are making our community suck.
   appeals, we know that mistakes happen, and we'll work with you to come up with
   a fair solution if there has been a misunderstanding.
 
+
+## Docker Dev Bot
+
+`docker-dev-bot` is responsible to check PR for adherence to the Contributing Guidelines, and help maintainers communicate about the acceptance of an specific PR.
+
+### `docker-dev-bot` auto-cheks
+
+Docker will be listening to all the PR created and make a series of checks and provide feedback inside the PR's comments about what's needed to improve the PR.
+
+* Branching name convention for bug/feature branches;
+* PR's title length and prefix;
+* Check commit's changed files, and ping maintainers based on subsystem X maintainers;
+* Asks/suggest tagging for better issue triage;
+* Check if commits are signed.
+
+### `docker-dev-bot` commands
+
+* Listens to LGTM from subsystem maintainers and check if it has the majority, and auto-merge if it applies;
+* Accept release commands from release maintainers.


### PR DESCRIPTION
## Problem

Docker is getting bigger, and the number os PRs just grows and a lot of PRs are not following the contributing guidelines. The talk inside a PR can help solve the problems of the PR itself, but a lot of energy is lost talking about the PR adherence problems, when maintainers should be talking about the problem that PRs is trying to solve.
## Types of checks

Bellow is a list of types of checks a bot could make on every new PR or changes to the PR commits.
- Branching name convention for bug/feature branches;
- PR's title length and prefix;
- Check commit's changed files, and ping maintainers based on subsystem X maintainers;
- Asks/suggest tagging for better issue triage;
- Check if commits are signed;
## Talking to the bot

Bellow is a list of commands the bot could get from maintainers.
- Listens to LGTM from subsystem maintainers and check if it has the majority, and auto-merge if it applies;
- Accept release commands from release maintainers;

---

I'd like to focus on defining what more (or fewer) command and checks this bot cold have, before detailing the behavior of each command and check on the docs.

I'm in doubt if /CONTRIBUTING.md is the best place for it, or if it should be /MAINTAINERS or even another file.

When you (project maitainers ?) think we have enough commands and checks, alert here, so I can think in working on the bot implementation.

Suggestions about implementation are welcome!

Signed-off-by: Enderson Maia endersonmaia@gmail.com
