### PR TITLE
Fix race in test registry setup

### DIFF
--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -870,5 +870,18 @@ func setupRegistry(t *testing.T) func() {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// Wait for registry to be ready to serve requests.
+	for i := 0; i != 5; i++ {
+		if err = reg.Ping(); err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if err != nil {
+		t.Fatal("Timeout waiting for test registry to become available")
+	}
+
 	return func() { reg.Close() }
 }

--- a/integration-cli/registry.go
+++ b/integration-cli/registry.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -50,6 +51,18 @@ http:
 		cmd: cmd,
 		dir: tmp,
 	}, nil
+}
+
+func (t *testRegistryV2) Ping() error {
+	// We always ping through HTTP for our test registry.
+	resp, err := http.Get(fmt.Sprintf("http://%s/v2/", privateRegistryURL))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("registry ping replied with an unexpected status code %s", resp.StatusCode)
+	}
+	return nil
 }
 
 func (r *testRegistryV2) Close() {


### PR DESCRIPTION
Wait for the local registry-v2 test instance to become available to avoid random tests failures (as made obvious in #10471).
