### PR TITLE
Proposal: Prevent orphan volumes creation from missing rm -v

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -64,6 +64,18 @@ func (daemon *Daemon) ContainerRm(job *engine.Job) error {
 			}
 		}
 
+                // require volume removal if the container has the sole reference to a volume
+                if !removeVolume {
+                        for id := range container.VolumePaths() {
+                                if v := daemon.volumes.Get(id); v != nil && !v.IsBindMount {
+                                        containers := v.Containers()
+                                        if len(containers) == 1 {
+                                                return job.Errorf("Cannot remove a container with sole ownership of volumes. Volume %s must be removed ith -v.", v.Path)
+                                        }
+                                }
+                        }
+                }
+
 		if forceRemove {
 			if err := daemon.ForceRm(container); err != nil {
 				logrus.Errorf("Cannot destroy container %s: %v", name, err)

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -64,17 +64,17 @@ func (daemon *Daemon) ContainerRm(job *engine.Job) error {
 			}
 		}
 
-                // require volume removal if the container has the sole reference to a volume
-                if !removeVolume {
-                        for id := range container.VolumePaths() {
-                                if v := daemon.volumes.Get(id); v != nil && !v.IsBindMount {
-                                        containers := v.Containers()
-                                        if len(containers) == 1 {
-                                                return job.Errorf("Cannot remove a container with sole ownership of volumes. Volume %s must be removed ith -v.", v.Path)
-                                        }
-                                }
-                        }
-                }
+		// require volume removal if the container has the sole reference to a volume
+		if !removeVolume {
+			for id := range container.VolumePaths() {
+				if v := daemon.volumes.Get(id); v != nil && !v.IsBindMount {
+					containers := v.Containers()
+					if len(containers) == 1 {
+						return job.Errorf("Cannot remove a container with sole ownership of volumes. Volume %s must be removed with -v.", v.Path)
+					}
+				}
+			}
+		}
 
 		if forceRemove {
 			if err := daemon.ForceRm(container); err != nil {

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -70,7 +70,7 @@ func (daemon *Daemon) ContainerRm(job *engine.Job) error {
 				if v := daemon.volumes.Get(id); v != nil && !v.IsBindMount {
 					containers := v.Containers()
 					if len(containers) == 1 {
-						return job.Errorf("Cannot remove a container with sole ownership of volumes. Volume %s must be removed with -v.", v.Path)
+						return fmt.Errorf("Cannot remove a container with sole ownership of volumes. Volume %s must be removed with -v.", v.Path)
 					}
 				}
 			}


### PR DESCRIPTION
Added logic to delete.go preventing the removal of containers that would create orphan managed volumes.

If volumes are not being removed then check that none of the target container's volumes are only referenced by the target container. If such a volume exists return an appropriate error and stop the container removal.

Fixes #8363 - By fixing the orphan issue, not by creating list-volumes

Signed-off-by: Jeff Nickoloff jeff@allingeek.com
