### PR TITLE
Improve MemorySwap validation

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1198,7 +1198,7 @@ func (container *Container) verifyDaemonSettings() {
 		log.Infof("WARNING: Your kernel does not support memory limit capabilities. Limitation discarded.")
 		container.Config.Memory = 0
 	}
-	if container.Config.Memory > 0 && !container.daemon.sysInfo.SwapLimit {
+	if container.Config.MemorySwap != -1 && (container.Config.Memory > 0 || container.Config.MemorySwap > 0) && !container.daemon.sysInfo.SwapLimit {
 		log.Infof("WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.")
 		container.Config.MemorySwap = -1
 	}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -26,7 +26,7 @@ func (daemon *Daemon) ContainerCreate(job *engine.Job) engine.Status {
 		job.Errorf("Your kernel does not support memory limit capabilities. Limitation discarded.\n")
 		config.Memory = 0
 	}
-	if config.Memory > 0 && !daemon.SystemConfig().SwapLimit {
+	if config.MemorySwap != -1 && (config.Memory > 0 || config.MemorySwap > 0) && !daemon.SystemConfig().SwapLimit {
 		job.Errorf("Your kernel does not support swap limit capabilities. Limitation discarded.\n")
 		config.MemorySwap = -1
 	}


### PR DESCRIPTION
I ran into the lack of error handling when trying out `--memory-swap` on a vanilla Ubuntu host.

The (not-so-obvious) logic about whether swap limiting support will be needed or not was inferred from https://github.com/docker/libcontainer/commit/e8f5b543010eb0db146fd2593284ed19af93eccd
