### PR TITLE
Giving more options for user input on `docker events` timestamps

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -45,7 +45,7 @@ import (
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/pkg/term"
-	"github.com/docker/docker/pkg/timeutils"
+	timeutils "github.com/docker/docker/pkg/timeutils"
 	"github.com/docker/docker/pkg/units"
 	"github.com/docker/docker/pkg/urlutil"
 	"github.com/docker/docker/registry"
@@ -1893,7 +1893,6 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 
 	var (
 		v               = url.Values{}
-		loc             = time.FixedZone(time.Now().Zone())
 		eventFilterArgs = filters.Args{}
 	)
 
@@ -1906,22 +1905,20 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 			return err
 		}
 	}
-	var setTime = func(key, value string) {
-		format := timeutils.RFC3339NanoFixed
-		if len(value) < len(format) {
-			format = format[:len(value)]
-		}
-		if t, err := time.ParseInLocation(format, value, loc); err == nil {
-			v.Set(key, strconv.FormatInt(t.Unix(), 10))
-		} else {
-			v.Set(key, value)
-		}
-	}
+
 	if *since != "" {
-		setTime("since", *since)
+		if err, newTime := timeutils.ConvertFrom(*since); err != nil {
+			return err
+		} else {
+			v.Set("since", newTime)
+		}
 	}
 	if *until != "" {
-		setTime("until", *until)
+		if err, newTime := timeutils.ConvertFrom(*until); err != nil {
+			return err
+		} else {
+			v.Set("until", newTime)
+		}
 	}
 	if len(eventFilterArgs) > 0 {
 		filterJson, err := filters.ToParam(eventFilterArgs)

--- a/docs/man/docker-events.1.md
+++ b/docs/man/docker-events.1.md
@@ -1,6 +1,6 @@
 % DOCKER(1) Docker User Manuals
 % Docker Community
-% JUNE 2014
+% MARCH 2015
 # NAME
 docker-events - Get real time events from the server
 
@@ -57,13 +57,13 @@ Again the output container IDs have been shortened for the purposes of this docu
     2015-01-28T20:25:38.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
     2015-01-28T20:25:39.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) create
     2015-01-28T20:25:39.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
-    2015-01-28T20:25:40.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) die
-    2015-01-28T20:25:42.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) stop
-    2015-01-28T20:25:45.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
-    2015-01-28T20:25:45.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) die
-    2015-01-28T20:25:46.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) stop
+
+    # docker events --until '2015-01-28 20:25:39'
+    2015-01-28T20:25:38.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) create
+    2015-01-28T20:25:38.000000000-08:00 c21f6c22ba27: (from whenry/testimage:latest) start
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+March 2015, updated by André Martins <martins@noironetworks.com>

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -992,6 +992,12 @@ You'll need two shells for this example.
     2014-05-10T17:42:14.999999999Z07:00 7805c1d35632: (from redis:2.8) die
     2014-09-03T17:42:14.999999999Z07:00 7805c1d35632: (from redis:2.8) stop
 
+    $ sudo docker events --since '2013-09-03 15:49:29'
+    2014-09-03T15:49:29.999999999Z07:00 4386fb97867d: (from ubuntu-1:14.04) die
+    2014-05-10T17:42:14.999999999Z07:00 4386fb97867d: (from ubuntu-1:14.04) stop
+    2014-05-10T17:42:14.999999999Z07:00 7805c1d35632: (from redis:2.8) die
+    2014-09-03T15:49:29.999999999Z07:00 7805c1d35632: (from redis:2.8) stop
+
     $ sudo docker events --since '2013-09-03T15:49:29'
     2014-09-03T15:49:29.999999999Z07:00 4386fb97867d: (from ubuntu-1:14.04) die
     2014-05-10T17:42:14.999999999Z07:00 4386fb97867d: (from ubuntu-1:14.04) stop

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -112,6 +112,44 @@ func TestEventsContainerEvents(t *testing.T) {
 	logDone("events - container create, start, die, destroy is logged")
 }
 
+func TestEventsContainerEventsUntil(t *testing.T) {
+	dockerCmd(t, "run", "--rm", "busybox", "true")
+	timeNow := time.Now()
+	timeBeginning := time.Unix(0, 0).Format(time.RFC3339Nano)
+	timeBeginning = strings.Replace(timeBeginning, "Z", ".000000000Z", -1)
+	timeNowStr := fmt.Sprintf("%04d-%02d-%02d %02d:%02d:%02d", timeNow.Year(), timeNow.Month(),
+		timeNow.Day(), timeNow.Hour(), timeNow.Minute(), timeNow.Second())
+	eventsCmd := exec.Command(dockerBinary, "events", fmt.Sprintf("--since='%s'", timeBeginning),
+		fmt.Sprintf("--until='%s'", timeNowStr))
+	out, exitCode, err := runCommandWithOutput(eventsCmd)
+	if exitCode != 0 || err != nil {
+		t.Fatalf("Failed to get events with exit code %d: %s", exitCode, err)
+	}
+	events := strings.Split(out, "\n")
+	events = events[:len(events)-1]
+	if len(events) < 4 {
+		t.Fatalf("Missing expected event")
+	}
+	createEvent := strings.Fields(events[len(events)-4])
+	startEvent := strings.Fields(events[len(events)-3])
+	dieEvent := strings.Fields(events[len(events)-2])
+	destroyEvent := strings.Fields(events[len(events)-1])
+	if createEvent[len(createEvent)-1] != "create" {
+		t.Fatalf("event should be create, not %#v", createEvent)
+	}
+	if startEvent[len(startEvent)-1] != "start" {
+		t.Fatalf("event should be start, not %#v", startEvent)
+	}
+	if dieEvent[len(dieEvent)-1] != "die" {
+		t.Fatalf("event should be die, not %#v", dieEvent)
+	}
+	if destroyEvent[len(destroyEvent)-1] != "destroy" {
+		t.Fatalf("event should be destroy, not %#v", destroyEvent)
+	}
+
+	logDone("events - container create, start, die, destroy with different until option is logged")
+}
+
 func TestEventsImageUntagDelete(t *testing.T) {
 	name := "testimageevents"
 	defer deleteImages(name)

--- a/pkg/timeutils/json.go
+++ b/pkg/timeutils/json.go
@@ -3,13 +3,16 @@ package timeutils
 import (
 	"errors"
 	"time"
+	"fmt"
+	"strconv"
 )
 
 const (
 	// RFC3339NanoFixed is our own version of RFC339Nano because we want one
 	// that pads the nano seconds part with zeros to ensure
 	// the timestamps are aligned in the logs.
-	RFC3339NanoFixed = "2006-01-02T15:04:05.000000000Z07:00"
+	RFC3339NanoFixed           = "2006-01-02T15:04:05.000000000Z07:00"
+	RFC3339NanoFixedWithSpaces = "2006-01-02 15:04:05.000000000 07:00"
 	// JSONFormat is the format used by FastMarshalJSON
 	JSONFormat = `"` + time.RFC3339Nano + `"`
 )
@@ -23,4 +26,34 @@ func FastMarshalJSON(t time.Time) (string, error) {
 		return "", errors.New("time.MarshalJSON: year outside of range [0,9999]")
 	}
 	return t.Format(JSONFormat), nil
+}
+
+func AcceptedFormats() []string {
+	return []string{
+		RFC3339NanoFixed,
+		RFC3339NanoFixedWithSpaces,
+		JSONFormat,
+	}
+}
+
+func ConvertFrom(value string) (error error, convertValue string){
+	loc := time.FixedZone(time.Now().Zone())
+	for _, format := range AcceptedFormats() {
+		if len(value) < len(format) {
+			format = format[:len(value)]
+		}
+		if t, err := time.ParseInLocation(format, value, loc); err == nil {
+			convertValue = strconv.FormatInt(t.Unix(), 10)
+			break
+		}
+	}
+	if convertValue == "" {
+		//last try is UintTime64
+		if _, err := strconv.ParseUint(value, 10, 64); err != nil {
+			return fmt.Errorf("Invalid timestamp format on `%s` field", value), ""
+		} else {
+			convertValue = value
+		}
+	}
+	return nil, convertValue
 }


### PR DESCRIPTION
Fixes #10501

Changed documentation for docker events.
Added one timestamp accepted format.

Signed-off-by: André Martins martins@noironetworks.com
