### PR TITLE
Revert push to v2 official registry

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -72,7 +72,7 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 		logName += ":" + tag
 	}
 
-	if len(repoInfo.Index.Mirrors) == 0 && (repoInfo.Index.Official || endpoint.Version == registry.APIVersion2) {
+	if len(repoInfo.Index.Mirrors) == 0 && ((repoInfo.Official && repoInfo.Index.Official) || endpoint.Version == registry.APIVersion2) {
 		j := job.Eng.Job("trust_update_base")
 		if err = j.Run(); err != nil {
 			log.Errorf("error updating trust base graph: %s", err)

--- a/graph/push.go
+++ b/graph/push.go
@@ -455,7 +455,7 @@ func (s *TagStore) CmdPush(job *engine.Job) engine.Status {
 		return job.Error(err2)
 	}
 
-	if repoInfo.Index.Official || endpoint.Version == registry.APIVersion2 {
+	if endpoint.Version == registry.APIVersion2 {
 		err := s.pushV2Repository(r, job.Eng, job.Stdout, repoInfo, tag, sf)
 		if err == nil {
 			return engine.StatusOK


### PR DESCRIPTION
No longer push to the official v2 registry when it is available. This allows pulling images from the v2 registry without defaulting push.

Fixes #10557
