### PR TITLE
Docs: add some docs for docker start option Fix #10514

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -679,7 +679,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 
 		cmd       = cli.Subcmd("start", "CONTAINER [CONTAINER...]", "Restart a stopped container", true)
 		attach    = cmd.Bool([]string{"a", "-attach"}, false, "Attach container's STDOUT and STDERR and forward all signals to the process")
-		openStdin = cmd.Bool([]string{"i", "-interactive"}, false, "Attach container's STDIN")
+		openStdin = cmd.Bool([]string{"i", "-interactive"}, false, "Attach container's STDIN if container's STDIN is open")
 	)
 
 	cmd.Require(flag.Min, 1)

--- a/docs/man/docker-start.1.md
+++ b/docs/man/docker-start.1.md
@@ -23,7 +23,11 @@ Start a stopped container.
   Print usage statement
 
 **-i**, **--interactive**=*true*|*false*
-   Attach container's STDIN. The default is *false*.
+   Attach container's STDIN if the container's STDIN is open. The default is *false*.
+ 
+   **-i** option only work when the container's STDIN is open. The container's STDIN is 
+   opened by setting the **-i** option when the container is created use **docker create** 
+   or **docker run**.
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -2002,7 +2002,7 @@ more details on finding shared images from the command line.
     Restart a stopped container
 
       -a, --attach=false         Attach container's STDOUT and STDERR and forward all signals to the process
-      -i, --interactive=false    Attach container's STDIN
+      -i, --interactive=false    Attach container's STDIN if container's STDIN is open
 
 ## stats
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Add some docs for docker start option `-i`,the `-i` option is only worked when the container
is created by set the `-i`.This patch make it more clear of the usage of  `-i` option in `docker start`

see https://github.com/docker/docker/blob/master/api/client/commands.go#L717

Fixes #10514 
