### PR TITLE
Complete signals in bash completion for docker kill

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -169,6 +169,23 @@ __docker_capabilities() {
 	" -- "$cur" ) )
 }
 
+# a selection of the available signals that is most likely of interest in the
+# context of docker containers.
+__docker_signals() {
+	local signals=(
+		SIGCONT
+		SIGHUP
+		SIGINT
+		SIGKILL
+		SIGQUIT
+		SIGSTOP
+		SIGTERM
+		SIGUSR1
+		SIGUSR2
+	)
+	COMPREPLY=( $( compgen -W "${signals[*]} ${signals[*]#SIG}" -- "$( echo $cur | tr '[:lower:]' '[:upper:]')" ) )
+}
+
 _docker_docker() {
 	local boolean_options="
 		--api-enable-cors
@@ -417,7 +434,21 @@ _docker_inspect() {
 }
 
 _docker_kill() {
-	__docker_containers_running
+	case "$prev" in
+		--signal|-s)
+			__docker_signals
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--signal -s" -- "$cur" ) )
+			;;
+		*)
+			__docker_containers_running
+			;;
+	esac
 }
 
 _docker_load() {


### PR DESCRIPTION
This adds completion for signals to `docker kill -s`.
Theoretically a lot of signals are supported here, see [signal_linux.go](https://github.com/docker/docker/blob/master/pkg/signal/signal_linux.go).

I drastically reduced this list to what seemed to me the most common use cases. This list is a bit more comprehensive than the corresponding [completion for `docker-compose kill`](https://github.com/docker/fig/blob/master/contrib/completion/bash/docker-compose#L124) (which is SIGHUP SIGINT SIGKILL SIGUSR1 SIGUSR2).

Please let me know if you miss signals or if you think a signal should be dropped from the list.
