### PR TITLE
Allow IPv6 addresses in ExtraHosts option settings

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -461,7 +461,8 @@ func (container *Container) buildHostsFiles(IP string) error {
 	}
 
 	for _, extraHost := range container.hostConfig.ExtraHosts {
-		parts := strings.Split(extraHost, ":")
+		// allow IPv6 addresses in extra hosts; only split on first ":"
+		parts := strings.SplitN(extraHost, ":", 2)
 		extraContent = append(extraContent, etchosts.Record{Hosts: parts[0], IP: parts[1]})
 	}
 

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -204,7 +204,8 @@ func validateDomain(val string) (string, error) {
 }
 
 func ValidateExtraHost(val string) (string, error) {
-	arr := strings.Split(val, ":")
+	// allow for IPv6 addresses in extra hosts by only splitting on first ":"
+	arr := strings.SplitN(val, ":", 2)
 	if len(arr) != 2 || len(arr[0]) == 0 {
 		return "", fmt.Errorf("bad format for add-host: %s", val)
 	}

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -104,3 +104,31 @@ func TestValidateDnsSearch(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateExtraHosts(t *testing.T) {
+	valid := []string{
+		`myhost:192.168.0.1`,
+		`thathost:10.0.2.1`,
+		`anipv6host:2003:ab34:e::1`,
+		`ipv6local:::1`,
+	}
+
+	invalid := []string{
+		`myhost:192.notanipaddress.1`,
+		`thathost-nosemicolon10.0.0.1`,
+		`anipv6host:::::1`,
+		`ipv6local:::0::`,
+	}
+
+	for _, extrahost := range valid {
+		if _, err := ValidateExtraHost(extrahost); err != nil {
+			t.Fatalf("ValidateExtraHost(`"+extrahost+"`) should succeed: error %v", err)
+		}
+	}
+
+	for _, extrahost := range invalid {
+		if _, err := ValidateExtraHost(extrahost); err == nil {
+			t.Fatalf("ValidateExtraHost(`" + extrahost + "`) should have failed validation")
+		}
+	}
+}


### PR DESCRIPTION
Since the separator for extra host settings (for /etc/hosts in a
container) is a ":", the code that handles extra hosts needs to only
split on the first ":" to preserve IPv6 addresses which are passed via
the command line settings as well as stored in the JSON container
config.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
