### PR TITLE
Fix for running unit tests on a 3.18 kernel with btrfs.

### DIFF
--- a/daemon/graphdriver/graphtest/graphtest.go
+++ b/daemon/graphdriver/graphtest/graphtest.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"strings"
 	"syscall"
 	"testing"
 
@@ -74,7 +73,8 @@ func newDriver(t *testing.T, name string) *Driver {
 
 	d, err := graphdriver.GetDriver(name, root, nil)
 	if err != nil {
-		if err == graphdriver.ErrNotSupported || err == graphdriver.ErrPrerequisites || strings.Contains(err.Error(), "'overlay' is not supported over") {
+		t.Logf("graphdriver: %s\n", err.Error())
+		if err == graphdriver.ErrNotSupported || err == graphdriver.ErrPrerequisites || err == graphdriver.ErrIncompatibleFS {
 			t.Skipf("Driver %s not supported", name)
 		}
 		t.Fatal(err)


### PR DESCRIPTION
Was failing on overlay before and comparing the wrong error.

@LK4D4 sorry this is the correct fix, I updated my kernel and see it now :(
