### PR TITLE
/var/run is deprecated. Support using /run

### DIFF
--- a/contrib/init/openrc/docker.confd
+++ b/contrib/init/openrc/docker.confd
@@ -11,3 +11,7 @@
 
 # any other random options you want to pass to docker
 DOCKER_OPTS=""
+
+# how to contact the docker daemon
+DOCKER_HOST="unix:///run/docker.unix"
+

--- a/contrib/init/openrc/docker.initd
+++ b/contrib/init/openrc/docker.initd
@@ -7,6 +7,7 @@ DOCKER_LOGFILE=${DOCKER_LOGFILE:-/var/log/${SVCNAME}.log}
 DOCKER_PIDFILE=${DOCKER_PIDFILE:-/run/${SVCNAME}.pid}
 DOCKER_BINARY=${DOCKER_BINARY:-/usr/bin/docker}
 DOCKER_OPTS=${DOCKER_OPTS:-}
+DOCKER_HOST=${DOCKER_HOST:-unix:///run/docker.unix}
 
 start() {
 	checkpath -f -m 0644 -o root:docker "$DOCKER_LOGFILE"
@@ -21,6 +22,7 @@ start() {
 		--stdout "$DOCKER_LOGFILE" \
 		--stderr "$DOCKER_LOGFILE" \
 		-- -d -p "$DOCKER_PIDFILE" \
+		-H "$DOCKER_HOST" \
 		$DOCKER_OPTS
 	eend $?
 }


### PR DESCRIPTION
- Allow user to configure listen location for daemon
- Install env.d file for location
