### PR TITLE
Removes the feature to pull all image aliases.

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1474,8 +1474,7 @@ To download a particular image, or set of images (i.e., a repository),
 use `docker pull`:
 
     $ sudo docker pull debian
-    # will pull the debian:latest image, its intermediate layers
-    # and any aliases of the same id
+    # will pull the debian:latest image and its intermediate layers
     $ sudo docker pull debian:testing
     # will pull the image named debian:testing and any intermediate
     # layers it is based on.

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -132,7 +132,6 @@ func (s *TagStore) pullRepository(r *registry.Session, out io.Writer, repoInfo *
 
 	log.Debugf("Registering tags")
 	// If no tag has been specified, pull them all
-	var imageId string
 	if askedTag == "" {
 		for tag, id := range tagsList {
 			repoData.ImgList[id].Tag = tag
@@ -143,7 +142,6 @@ func (s *TagStore) pullRepository(r *registry.Session, out io.Writer, repoInfo *
 		if !exists {
 			return fmt.Errorf("Tag %s not found in repository %s", askedTag, repoInfo.CanonicalName)
 		}
-		imageId = id
 		repoData.ImgList[id].Tag = askedTag
 	}
 
@@ -247,7 +245,7 @@ func (s *TagStore) pullRepository(r *registry.Session, out io.Writer, repoInfo *
 
 	}
 	for tag, id := range tagsList {
-		if askedTag != "" && id != imageId {
+		if askedTag != "" && tag != askedTag {
 			continue
 		}
 		if err := s.Set(repoInfo.LocalName, tag, id, true); err != nil {


### PR DESCRIPTION
It didn't work on v2 anyways. And an image with a lot of aliases was slow to
fetch.

Closes #8689 
