### PR TITLE
Make checking of help text smarter

### DIFF
--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"unicode"
 )
 
 func TestMainHelpWidth(t *testing.T) {
@@ -43,47 +44,33 @@ func TestCmdHelpWidth(t *testing.T) {
 		home = os.Getenv("HOME")
 	}
 
-	for _, command := range []string{
-		"attach",
-		"build",
-		"commit",
-		"cp",
-		"create",
-		"diff",
-		"events",
-		"exec",
-		"export",
-		"history",
-		"images",
-		"import",
-		"info",
-		"inspect",
-		"kill",
-		"load",
-		"login",
-		"logout",
-		"logs",
-		"port",
-		"pause",
-		"ps",
-		"pull",
-		"push",
-		"rename",
-		"restart",
-		"rm",
-		"rmi",
-		"run",
-		"save",
-		"search",
-		"start",
-		"stats",
-		"stop",
-		"tag",
-		"top",
-		"unpause",
-		"version",
-		"wait",
-	} {
+	// Pull the list of commands from the "Commands:" section of docker help
+	helpCmd := exec.Command(dockerBinary, "help")
+	out, ec, err := runCommandWithOutput(helpCmd)
+	if err != nil || ec != 0 {
+		t.Fatalf("docker help should have worked\nout:%s\nec:%d", out, ec)
+	}
+	i := strings.Index(out, "Commands:")
+	if i < 0 {
+		t.Fatalf("Missing 'Commands:' in:\n%s", out)
+	}
+
+	// Grab all chars starting at "Commands:"
+	// Skip first line, its "Commands:"
+	count := 0
+	cmds := ""
+	for _, command := range strings.Split(out[i:], "\n")[1:] {
+		// Stop on blank line or non-idented line
+		if command == "" || !unicode.IsSpace(rune(command[0])) {
+			break
+		}
+
+		// Grab just the first word of each line
+		command = strings.Split(strings.TrimSpace(command), " ")[0]
+
+		count++
+		cmds = cmds + "\n" + command
+
 		helpCmd := exec.Command(dockerBinary, command, "--help")
 		out, ec, err := runCommandWithOutput(helpCmd)
 		if err != nil || ec != 0 {
@@ -98,6 +85,12 @@ func TestCmdHelpWidth(t *testing.T) {
 				t.Fatalf("Help for %q should use ~ instead of %q on:\n%s", command, home, line)
 			}
 		}
+	}
+
+	expected := 39
+	if count != expected {
+		t.Fatalf("Wrong # of commands (%d), it should be: %d\nThe list:\n%s",
+			len(cmds), expected, cmds)
 	}
 
 	logDone("help - cmd widths")


### PR DESCRIPTION
As I was reworking https://github.com/docker/docker/pull/9402 I realized
that the new testcase I just added that verified all help text is within
80 characters really should be smarter and ask "docker help" for the list
of commands to check instead of having a hard-coded list.  This way
it will catch "docker execwait" automagically once #9402 is merged.

Signed-off-by: Doug Davis dug@us.ibm.com
