### PR TITLE
The DHE documentation will not be published with 1.5.0

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -70,9 +70,9 @@ pages:
 - ['docker-hub/official_repos.md', 'Docker Hub', 'Official Repo Guidelines']
 
 # Docker Hub Enterprise
-- ['docker-hub-enterprise/index.md', '**HIDDEN**' ]
-- ['docker-hub-enterprise/install-config.md', 'Docker Hub Enterprise', 'Installation and Configuration' ]
-- ['docker-hub-enterprise/usage.md', 'Docker Hub Enterprise', 'User Guide' ]
+#- ['docker-hub-enterprise/index.md', '**HIDDEN**' ]
+#- ['docker-hub-enterprise/install-config.md', 'Docker Hub Enterprise', 'Installation and Configuration' ]
+#- ['docker-hub-enterprise/usage.md', 'Docker Hub Enterprise', 'User Guide' ]
 
 # Examples:
 - ['examples/index.md', '**HIDDEN**']


### PR DESCRIPTION
more timeline based churn - these problems will be removed when we re-develop the non-docker-engine docs tooling.

@fredlf @jamtur01 

Signed-off-by: Sven Dowideit SvenDowideit@home.org.au
