### PR TITLE
Proposal: Provide a list of files that relates to a defined subsystem on MAINTAINERS file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -320,6 +320,11 @@ made through a pull request.
 				"sven",
 			]
 
+      files = [
+        "/docs/*",
+        "*.md"
+      ]
+
 		[Org.Subsystems.libcontainer]
 
 			people = [
@@ -338,6 +343,10 @@ made through a pull request.
 				"joffrey",
 				"samalba"
 			]
+
+      files = [
+        "/registry/*"
+      ]
 
 		[Org.Subsystems."build tools"]
 


### PR DESCRIPTION
For each subsystem in Org.Subsystem section in the MAINTAINERS files, a list of file matches should me provided, so that a software could check who is responsible for those files looking for the people list inside that
section.

I just provided two changes, since I don't have the knowledge to identify all the subsystems and folders.

I need some feedback how to address subsystems like compose, swarm that are not inside the structure of the docker/docker repository.
