### PR TITLE
Generate an error on unknown Dockerfile instruction

### DIFF
--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -309,7 +309,5 @@ func (b *Builder) dispatch(stepN int, ast *parser.Node) error {
 		return f(b, strList, attrs, original)
 	}
 
-	fmt.Fprintf(b.ErrStream, "# Skipping unknown instruction %s\n", strings.ToUpper(cmd))
-
-	return nil
+	return fmt.Errorf("Unknown instruction: %s", strings.ToUpper(cmd))
 }

--- a/docs/sources/release-notes.md
+++ b/docs/sources/release-notes.md
@@ -15,6 +15,9 @@ For a complete list of patches, fixes, and other improvements, see the
 
 *New Features*
 
+* [1.6] The Docker daemon will no longer ignore unknown commands
+  while processing a `Dockerfile`. Instead it will generate an error and halt
+  processing.
 * The Docker daemon has now supports for IPv6 networking between containers
   and on the `docker0` bridge. For more information see the
   [IPv6 networking reference](/articles/networking/#ipv6).
@@ -22,7 +25,7 @@ For a complete list of patches, fixes, and other improvements, see the
   container to writing to volumes [PR# 10093](https://github.com/docker/docker/pull/10093).
 * A new `docker stats CONTAINERID` command has been added to allow users to view a
   continuously updating stream of container resource usage statistics. See the
-  [`stats` command line reference](/reference/commandline/cli/#stats) and the 
+  [`stats` command line reference](/reference/commandline/cli/#stats) and the
   [container `stats` API reference](/reference/api/docker_remote_api_v1.17/#get-container-stats-based-on-resource-usage).
   **Note**: this feature is only enabled for the `libcontainer` exec-driver at this point.
 * Users can now specify the file to use as the `Dockerfile` by running

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4343,16 +4343,16 @@ func TestBuildCmdJSONNoShDashC(t *testing.T) {
 	logDone("build - cmd should not have /bin/sh -c for json")
 }
 
-func TestBuildIgnoreInvalidInstruction(t *testing.T) {
+func TestBuildErrorInvalidInstruction(t *testing.T) {
 	name := "testbuildignoreinvalidinstruction"
 	defer deleteImages(name)
 
 	out, _, err := buildImageWithOut(name, "FROM busybox\nfoo bar", true)
-	if err != nil {
-		t.Fatal(err, out)
+	if err == nil {
+		t.Fatalf("Should have failed: %s", out)
 	}
 
-	logDone("build - ignore invalid Dockerfile instruction")
+	logDone("build - error invalid Dockerfile instruction")
 }
 
 func TestBuildEntrypointInheritance(t *testing.T) {


### PR DESCRIPTION
Instead of just printing a warning and going on, this will generate
an error and stop processing.

This used to be part of #10561 but I decided it might need its own
independent discussion/PR as to not derail #10561.

Signed-off-by: Doug Davis dug@us.ibm.com
