### PR TITLE
Update verification message logic

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -180,6 +180,9 @@ func TestEventsImageUntagDelete(t *testing.T) {
 
 func TestEventsImagePull(t *testing.T) {
 	since := time.Now().Unix()
+
+	defer deleteImages("hello-world")
+
 	pullCmd := exec.Command(dockerBinary, "pull", "hello-world")
 	if out, _, err := runCommandWithOutput(pullCmd); err != nil {
 		t.Fatalf("pulling the hello-world image from has failed: %s, %v", out, err)


### PR DESCRIPTION
Only show the verification message if all the tarsum checks pass and the image manifest is verified. No longer return an error when a tarsum verification fails, just reset the verification flag. Tarsum verification is less meaningful without a verified manifest and therefore it should not cause an error.

This will make the last verification more meaningful since it will only be shown if both the manifest and layer checksums are verified. 
