### PR TITLE
manifest: Close archive once done to umount the device backing the layer

### DIFF
--- a/graph/manifest.go
+++ b/graph/manifest.go
@@ -73,6 +73,8 @@ func (s *TagStore) newManifest(localName, remoteName, tag string) ([]byte, error
 				return nil, err
 			}
 
+			defer archive.Close()
+
 			tarSum, err := tarsum.NewTarSum(archive, true, tarsum.Version1)
 			if err != nil {
 				return nil, err

--- a/graph/push.go
+++ b/graph/push.go
@@ -392,6 +392,8 @@ func (s *TagStore) pushV2Image(r *registry.Session, img *image.Image, endpoint *
 	if err != nil {
 		return err
 	}
+	defer arch.Close()
+
 	tf, err := s.graph.newTempFile()
 	if err != nil {
 		return err


### PR DESCRIPTION
This fixes issue #10593 

Currently newManifest() code can call TarLayer() which returns the archive.
This archive can have some devices mounted (which are backing the layer)
so one needs to call Close() on archive to release those resources once
caller is done with archive.

Looks like newManifest() is not calling Close() on archive and that leads
to some devices not being unmounted when using devicemapper graph drvier.
That also means that if one deletes the image/device later, that deletion
fails as device is still in use (due to previous mount).

So call archive.Close() once archive is not needed anymore to release the
resources backing the archive.

Signed-off-by: Vivek Goyal vgoyal@redhat.com
