### PR TITLE
nat: enable upper case proto

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2293,6 +2293,27 @@ func TestBuildExposeOrder(t *testing.T) {
 	logDone("build - expose order")
 }
 
+func TestBuildExposeUpperCaseProto(t *testing.T) {
+	name := "testbuildexposeuppercaseproto"
+	expected := "map[5678/udp:map[]]"
+	defer deleteImages(name)
+	_, err := buildImage(name,
+		`FROM scratch
+        EXPOSE 5678/UDP`,
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := inspectField(name, "Config.ExposedPorts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != expected {
+		t.Fatalf("Exposed ports %s, expected %s", res, expected)
+	}
+	logDone("build - expose port with upper case proto")
+}
+
 func TestBuildEmptyEntrypointInheritance(t *testing.T) {
 	name := "testbuildentrypointinheritance"
 	name2 := "testbuildentrypointinheritance2"

--- a/nat/nat.go
+++ b/nat/nat.go
@@ -140,7 +140,7 @@ func ParsePortSpecs(ports []string) (map[Port]struct{}, map[Port][]PortBinding, 
 			return nil, nil, fmt.Errorf("Invalid ranges specified for container and host Ports: %s and %s", containerPort, hostPort)
 		}
 
-		if !validateProto(proto) {
+		if !validateProto(strings.ToLower(proto)) {
 			return nil, nil, fmt.Errorf("Invalid proto: %s", proto)
 		}
 
@@ -149,7 +149,7 @@ func ParsePortSpecs(ports []string) (map[Port]struct{}, map[Port][]PortBinding, 
 			if len(hostPort) > 0 {
 				hostPort = strconv.FormatUint(startHostPort+i, 10)
 			}
-			port := NewPort(proto, containerPort)
+			port := NewPort(strings.ToLower(proto), containerPort)
 			if _, exists := exposedPorts[port]; !exists {
 				exposedPorts[port] = struct{}{}
 			}


### PR DESCRIPTION
We only accepted lower case proto:
tcp, udp.
This patch will enable us to use upper case
of proto such as: EXPOSE 1234/TCP

Signed-off-by: Chen Hanxiao chenhanxiao@cn.fujitsu.com
