### PR TITLE
Introduce python-behave based tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ docs/GIT_BRANCH
 docs/VERSION
 docs/GITCOMMIT
 docs/changed-files
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,6 +129,9 @@ RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT
 
+# Install the python-behave library
+RUN pip install behave==1.2.5
+
 # Setup s3cmd config
 RUN { \
 		echo '[default]'; \

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,9 @@ test-unit: build
 test-integration: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh test-integration
 
+test-integration-behave: build
+	$(DOCKER_RUN_DOCKER) hack/make.sh binary test-integration-behave
+
 test-integration-cli: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary test-integration-cli
 

--- a/integration-behave/environment.py
+++ b/integration-behave/environment.py
@@ -1,0 +1,45 @@
+from behave.log_capture import capture
+import distutils.spawn
+import logging
+import os
+
+import steps.docker
+
+
+def before_all(context):
+    context.docker_binary = "test"
+    docker_binary = "docker"
+    env_binary = os.getenv(docker_binary)
+    docker_binary = env_binary or distutils.spawn.find_executable(docker_binary)
+    if docker_binary is None:
+        raise "Failed to get path to the docker binary"
+    context.docker_binary = docker_binary
+
+
+def before_scenario(context, scenario):
+    context.containers = {}
+
+
+@capture
+def after_scenario(context, scenario):
+    # Retrieve the list of containers
+    cmd_ps = steps.docker.invoke(context, "ps", "-aq", trace=False)
+    stdout, stderr = cmd_ps.communicate()
+    if cmd_ps.returncode != 0:
+        logging.error("Failed to retrieve container list to cleanup ({})".format(stderr))
+
+    # Make a list of space-separated containers ids
+    containers = stdout.replace('\n', ' ').strip()
+    if not containers:
+        return
+
+    # Kill all containers
+    cmd = steps.docker.invoke(context, "kill", containers, trace=False)
+    if cmd.wait() != 0:
+        logging.error("Error when killing containers ({})".format(cmd.stderr.read()))
+
+    # Remove all containers and their volumes
+    cmd = steps.docker.invoke(context, "rm", "-v " + containers, trace=False)
+    if cmd.wait() != 0:
+        logging.error("Error when removing containers ({})".format(cmd.stderr.read()))
+

--- a/integration-behave/sample.feature
+++ b/integration-behave/sample.feature
@@ -1,0 +1,31 @@
+Feature: showing what we can do with behave
+
+
+Scenario: example testing inspect output
+    Given an empty environment
+     When I start container "test" with "busybox top"
+      And I wait for the container "test" to be running
+     Then the "State.Running" attribute of container "test" should be "true"
+      And the "Path" attribute of container "test" should be "top"
+      And the "Config.Image" attribute of container "test" should be "busybox"
+
+
+Scenario: example testing ps output
+    Given an empty environment
+     When I start container "test" with "busybox top"
+      And I wait for the container "test" to be running
+     Then the IMAGE column of ps output for container "test" is "busybox:latest"
+      And the COMMAND column of ps output for container "test" is ""top""
+
+
+Scenario: example sending input to a container
+    Given a container "test" started with "busybox"
+     When I send "exit" to container "test"
+     Then the container "test" stops
+
+
+Scenario: example reading container's output
+    Given an empty environment
+     When I start container "test" with "busybox echo -n pouet"
+     Then the container "test" outputs "pouet"
+

--- a/integration-behave/steps/base.py
+++ b/integration-behave/steps/base.py
@@ -1,0 +1,62 @@
+from behave import *
+import shlex
+import time
+
+import docker
+
+
+@given('an empty environment')
+def step_impl(context):
+    pass
+
+
+@given('a container "{name}" started with "{args}"')
+def step_impl(context, name, args):
+    cmd, cid = docker.run(context, name, args)
+    assert not cmd.poll(), "Error launching container (exit code: {})".format(cmd.returncode)
+    context.containers[name] = cmd
+    context.containers[name].cid = cid
+
+
+@when('I start container "{name}" with "{args}"')
+def step_impl(context, name, args):
+    cmd, cid = docker.run(context, name, args)
+    assert not cmd.poll(), "Error launching container (exit code: {})".format(cmd.returncode)
+    context.containers[name] = cmd
+    context.containers[name].cid = cid
+
+
+@when('I send "{data}" to container "{name}"')
+def step_impl(context, data, name):
+    assert name in context.containers, 'Unknown container "{}"'.format(name)
+    context.containers[name].stdin.write(data)
+
+
+@when('I wait for the container "{name}" to be running')
+def step_impl(context, name):
+    assert name in context.containers, 'Unknown container "{}"'.format(name)
+    for _ in range(10):
+        if docker.inspect_field(context, name, "State.Running", trace=False) == "true":
+            return
+        time.sleep(0.1)
+    assert False, "Container didn't start in time"
+
+
+@then('the container "{name}" stops')
+def step_impl(context, name):
+    assert name in context.containers, 'Unknown container "{}"'.format(name)
+    for _ in range(10):
+        if docker.inspect_field(context, name, "State.Running", trace=False) == "false":
+            return
+        time.sleep(0.1)
+    assert False, "Container didn't stop in time"
+
+
+@then('the container "{name}" outputs "{expected}"')
+def step_impl(context, name, expected):
+    assert name in context.containers, 'Unknown container "{}"'.format(name)
+    import time
+    time.sleep(1)
+    stdout = context.containers[name].stdout.readline()
+    assert stdout == expected, 'Unexpected output: expected "{}", got "{}"'.format(expected, stdout)
+

--- a/integration-behave/steps/docker.py
+++ b/integration-behave/steps/docker.py
@@ -1,0 +1,44 @@
+import logging
+import subprocess
+import shlex
+
+
+def invoke(context, command, args='', trace=True):
+    args = [context.docker_binary, command] + shlex.split(args)
+    if trace:
+        logging.info("Invoking command: {}".format(args))
+
+    return subprocess.Popen(
+            args,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True
+        )
+
+def inspect_field(context, container, field, **kwargs):
+    args = "-f '{{{{ .{} }}}}' {}".format(field, container)
+    cmd = invoke(context, "inspect", args, **kwargs)
+    stdout, stderr = cmd.communicate()
+    return stdout and stdout.rstrip()
+
+
+def run(context, name, args):
+    # That's a bit of a hack, but we need to know whether the container was
+    # launched detached or not: when it is we read the id from stdout, when it
+    # is not we inject a --name flag if necessary.
+    sh_args = shlex.split(args)
+    detached = "-d" in sh_args
+    if not detached and "--name" not in sh_args:
+        args = "--name {} {}".format(name, args)
+        sh_args = shlex.split(args)
+
+    # Execute the command and retrieve the container id
+    cmd = invoke(context, "run", args)
+    if not detached:
+        cid = sh_args[sh_args.index("--name") + 1]
+    else:
+        cid, _ = cmd.communicate()
+
+    # Return the process and container id
+    return cmd, cid.strip()

--- a/integration-behave/steps/inspect.py
+++ b/integration-behave/steps/inspect.py
@@ -1,0 +1,11 @@
+from behave import *
+
+import docker
+
+
+@then('the "{attribute}" attribute of container "{name}" should be "{expected}"')
+def step_impl(context, attribute, name, expected):
+    conid = context.containers[name].cid
+    value = docker.inspect_field(context, conid, attribute)
+    assert value == expected, "Bad value for inspect field: expected {}, got {}".format(expected, value)
+

--- a/integration-behave/steps/ps.py
+++ b/integration-behave/steps/ps.py
@@ -1,0 +1,24 @@
+from behave import *
+import itertools
+
+import docker
+import table
+
+
+@then('the {column} column of ps output for container "{id_or_name}" is "{value}"')
+def step_impl(context, column, id_or_name, value):
+    # Run `docker ps -a`.
+    cmd = docker.invoke(context, "ps", "-a")
+    stdout, stderr = cmd.communicate()
+    assert cmd.returncode == 0, \
+        "Failed to invoke docker ps (code: {}, output: {}".format(cmd.returncode, stdout)
+
+    # Parse command output and find the matching container.
+    structd_output = table.parse(stdout)
+    cont_predicate = lambda c: c["CONTAINER ID"] == id_or_name[:8] or c["NAMES"] == id_or_name
+    find_container = next(itertools.ifilter(cont_predicate, structd_output), None)
+    assert find_container is not None, \
+         'No container with ID or name {} in ps output'.format(id_or_name)
+    assert find_container[column] == value, \
+        'Wrong value in column "{}" for container {}: expected {}, got {}'.format(column, id_or_name, value, find_container[column])
+

--- a/integration-behave/steps/table.py
+++ b/integration-behave/steps/table.py
@@ -1,0 +1,32 @@
+def _column_indices(header):
+    # A column is delimited by 2 or more consecutive spaces: this is how we
+    # determine their respective width.
+    result = [0]
+    for i in range(len(header) - 2):
+        triplet = header[i:i+3]
+        if map(str.isspace, triplet) == [True, True, False]:
+            result.append(i+2)
+    result.append(len(header))
+    return result
+
+
+def _fixed_width_split(cols, line):
+    return [line[cols[i]:cols[i+1]].strip() for i in range(len(cols) - 1)]
+
+
+def parse(output):
+    reader = (line for line in output.splitlines())
+
+    # We need to account for the fact that headers and content values may have
+    # whitespace, so splitting is not an option here: we detect the column
+    # width, and use this for splitting.
+    headers = next(reader)
+    columns = _column_indices(headers)
+    headers = _fixed_width_split(columns, headers)
+
+    # Build a list of objects from the rest of the output.
+    result = []
+    for line in reader:
+        result.append(dict(zip(headers, _fixed_width_split(columns, line))))
+    return result
+

--- a/project/make/test-integration-behave
+++ b/project/make/test-integration-behave
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+DEST=$1
+
+# subshell so that we can export PATH without breaking other things
+(
+	source "$(dirname "$BASH_SOURCE")/.integration-daemon-start"
+
+	# we need to wrap up everything in between integration-daemon-start and
+	# integration-daemon-stop to make sure we kill the daemon and don't hang,
+	# even and especially on test failures
+	didFail=
+	if ! {
+		# pull the busybox image before running the tests
+		sleep 2
+
+		source "$(dirname "$BASH_SOURCE")/.ensure-busybox"
+		source "$(dirname "$BASH_SOURCE")/.ensure-emptyfs"
+
+		behave integration-behave
+	}; then
+		didFail=1
+	fi
+
+	source "$(dirname "$BASH_SOURCE")/.integration-daemon-stop"
+
+	[ -z "$didFail" ] # "set -e" ftw
+) 2>&1 | tee -a $DEST/test.log


### PR DESCRIPTION
I'd like to collect feedback on a thing I started playing with in my free time: although it can probably be merged in its current state and further built upon, it's mostly just a proof of concept.
## Motivation

The idea comes from the following observations:
1. Writing test for Docker is hard: we suffer from code duplication, and incorrect tests implementations (race conditions, ...)
2. We have few participation possibilities to offer to non-coding contributors (technical writers, users without programming knowledge, ...)
## Proposed solution

The PR introduces yet another family of tests: `test-integration-behave`. These tests are written in what's commonly known as "Gherkin language", which is essentially plain english with a well-defined structure.

This is an example of a basic test:

```
Scenario: example testing ps output
     Given an empty environment
      When I start container "test" with "busybox top"
       And I wait for the container "test" to be running
      Then the IMAGE column of ps output for container "test" is "busybox:latest"
```

Running the test suite transforms this plain english test in a sequence of command line invocations (such as `docker run` and `docker inspect`) and assertions. For this test, the output is:

```
Feature: showing what we can do with behave # integration-behave/sample.feature:1

  Scenario: example testing ps output                                           # integration-behave/sample.feature:4
    Given an empty environment                                                  # integration-behave/steps/base.py:8
    When I start container "test" with "busybox top"                            # integration-behave/steps/base.py:21
    And I wait for the container "test" to be running                           # integration-behave/steps/base.py:35
    Then the IMAGE column of ps output for container "test" is "busybox:latest" # integration-behave/steps/ps.py:8

1 feature passed, 0 failed, 0 skipped
1 scenario passed, 0 failed, 0 skipped
4 steps passed, 0 failed, 0 skipped, 0 undefined
Took 0m1.454s
```

I think it nicely improves on the two previously mentioned observations:
1. Boilerplate code is written once (and hopefully right) for everyone to reuse
2. Anyone can write a test, provided the grammar elements to express his idea are implemented. I want to emphasize here that no code change nor recompilation is involved in writing a test: it's a text file that gets interpreted (see [`integration-behave/sample.feature`](https://github.com/icecrime/docker/blob/af754592a86bab570c1a1df3dae463b82b5d7e25/integration-behave/sample.feature)).
## Usage
#### Modifying or writing tests

Test files are located in the `integration-behave/` subdirectory and must be have a `.feature` extension: a sample is provided in [`integration-behave/sample.feature`](https://github.com/icecrime/docker/blob/af754592a86bab570c1a1df3dae463b82b5d7e25/integration-behave/sample.feature).
#### Running the tests

You can use the following command at the root of a cloned repository to run the tests:

```
make test-integration-behave
```
## Implemented grammar
### `Given`

| Grammar | Interpretation |
| --- | --- |
| `an empty environment` |  |
| `a container "<name>" started with "<run_arguments>"` | `docker run --name <name> <run_arguments>` |
### `When`

| Grammar | Interpretation |
| --- | --- |
| `I start container "<name>" with "<run_arguments>"` | `docker run --name <name> <run_arguments>` |
| `I wait for container "<name>" to be running` | `docker inspect -f {{ .State.Running }} name == true` (10 attempts, 1 second) |
| `I send "<data>" to "<name>"` | sends `<data>` on container `<name>` standard input |
### `Then`

| Grammar | Interpretation |
| --- | --- |
| `the container "<name>" stops"` | `docker inspect -f {{ .State.Running }} == false` (10 attempts, 1 second) |
| `the attribute "<attribute>" of container "<name>" should be "<expected>"` | `assert docker inspect -f {{ <attribute> }} <name> == <expected>` |
| `the container "<name>" outputs "<expected>"` | compares the container's standard output with `<expected>` |
| `the column "<column>" of ps output for container "<id_or_name>" is "<expected>"` | compares `docker ps` `<column>` of container `<id_or_name>` with `<expected>` |
## Questions

**Q: Is it meant to replace the existing `test-integration-cli` suite?**

No! I don't believe **all** tests are better expressed with this syntax.

**Q: Why Python?**
- Because [Python is awesome](http://xkcd.com/353/)
- Python is already baked in our image, so I figured I'm not introducing a massive overhead
- The [`python-behave`](https://pythonhosted.org/behave/index.html) is a nice implementation of the test framework
- Golang lacks the dynamic aspects allowing for a 0-effort integration
- Did I mention how much I love Python?
