### PR TITLE
docs/articles/systemd: correct --storage-driver

### DIFF
--- a/docs/sources/articles/systemd.md
+++ b/docs/sources/articles/systemd.md
@@ -59,7 +59,7 @@ In this example, we'll assume that your `docker.service` file looks something li
 This will allow us to add extra flags to the `/etc/sysconfig/docker` file by
 setting `OPTIONS`:
 
-    OPTIONS="--graph /mnt/docker-data --storage btrfs"
+    OPTIONS="--graph /mnt/docker-data --storage-driver btrfs"
 
 You can also set other environment variables in this file, for example, the
 `HTTP_PROXY` environment variables described below.


### PR DESCRIPTION
Fixes #10587

```
First off, thanks to all for their contributions. The issue was with the command line options. In the docs for version 1.4 (the one I have) the argument for storage is given as:
--storage btrfs
In actuality, the correct syntax is:
--storage-driver btrfs
Now, I do not know why there is this discrepancy between the online docs and 'docker --help' (this is where the correct form is referenced).
Again thanks to all, and I really hope the docs for this wonderful piece of S/W get fixed.
```
