### PR TITLE
Fix create volume /etc cover /etc/{hosts,resolv.conf,hostname} Fixes # 10604

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2476,6 +2476,41 @@ func TestRunReuseBindVolumeThatIsSymlink(t *testing.T) {
 	logDone("run - can remount old bindmount volume")
 }
 
+//test create /etc volume
+func TestRunCreateVolumeEtc(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "run", "--dns=127.0.0.1", "-v", "/etc", "busybox", "cat", "/etc/resolv.conf")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal("failed to run container: %v, output: %q", err, out)
+	}
+	if !strings.Contains(out, "nameserver 127.0.0.1") {
+		t.Fatal("failed: create /etc volume cover /etc/resolv.conf")
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "-h=test123", "-v", "/etc", "busybox", "cat", "/etc/hostname")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal("failed to run container: %v, output: %q", err, out)
+	}
+	if !strings.Contains(out, "test123") {
+		t.Fatal("failed: create /etc volume cover /etc/hostname")
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--add-host=test:192.168.0.1", "-v", "/etc", "busybox", "cat", "/etc/hosts")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal("failed to run container: %v, output: %q", err, out)
+	}
+	out = strings.Replace(out, "\n", " ", -1)
+	if !strings.Contains(out, "192.168.0.1"+"\t"+"test") || !strings.Contains(out, "127.0.0.1"+"\t"+"localhost") {
+		t.Fatal("failed: create /etc volume cover /etc/hosts", out)
+	}
+
+	deleteAllContainers()
+
+	logDone("run - create /etc volume success")
+}
+
 func TestVolumesNoCopyData(t *testing.T) {
 	defer deleteImages("dataimage")
 	defer deleteAllContainers()


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Fixes #10604 

When start container, docker mount `/etc/{hosts,resolv.conf,hostname}` first and then
mount user specified volumes. But there is a problem when someone want to create volume
`/etc`, `/etc` is user specified volume, it will cover `/etc/{hosts,resolv.conf,hostname}` and the context in 
`hosts, resolv.conf , hostname` will all gone. 
I think the use case in #10604 is reasonable, user want to create `/etc` volume to check/change realtime configuration files in `/etc`  
So I think  `/etc/{hosts,resolv.conf,hostname}` should be mounted at last.

I'm not sure this patch is necessary or not, if not ,I think a docs PR is need to tell user not to 
create `/etc` volume.
