### PR TITLE
Adds: notify user of login credential persistence for registry

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -393,6 +393,8 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 		return err
 	}
 	registry.SaveConfig(cli.configFile)
+	fmt.Fprintf(cli.out, "WARNING: login credentials saved in %s.\n", path.Join(homedir.Get(), registry.CONFIGFILE))
+
 	if out2.Get("Status") != "" {
 		fmt.Fprintf(cli.out, "%s\n", out2.Get("Status"))
 	}


### PR DESCRIPTION
Closes #10338 

Warn users about login credential persistence and encourage them to `docker logout` in order to cleanup creds on a non-private machine

Signed-off-by: Andrew C. Bodine acbodine@us.ibm.com
