### PR TITLE
Add link to user guide to end of 14.04 section

### DIFF
--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -80,6 +80,11 @@ To verify that everything has worked as expected:
 
 Which should download the `ubuntu` image, and then start `bash` in a container.
 
+Type `exit` to exit
+
+**Done!**, continue with the [User Guide](/userguide/).
+
+
 ## Ubuntu Precise 12.04 (LTS) (64-bit)
 
 This installation path should work at all times.


### PR DESCRIPTION
Adding instructions to exit the test shell and a link to the user guide (as is done in the following sections for 12.04 and 13.04/10.

PS: I'm pretty sure the docker contributions encouraged pull requests like these for small changes to documentation. I hope it's not annoying!
