### PR TITLE
Fix for help when $HOME is /

### DIFF
--- a/pkg/homedir/homedir.go
+++ b/pkg/homedir/homedir.go
@@ -5,14 +5,20 @@ import (
 	"runtime"
 )
 
+// Key returns the env var name for the user's home dir based on
+// the platform being run on
+func Key() string {
+	if runtime.GOOS == "windows" {
+		return "USERPROFILE"
+	}
+	return "HOME"
+}
+
 // Get returns the home directory of the current user with the help of
 // environment variables depending on the target operating system.
 // Returned path should be used with "path/filepath" to form new paths.
 func Get() string {
-	if runtime.GOOS == "windows" {
-		return os.Getenv("USERPROFILE")
-	}
-	return os.Getenv("HOME")
+	return os.Getenv(Key())
 }
 
 // GetShortcutString returns the string that is shortcut to user's home directory

--- a/pkg/mflag/flag.go
+++ b/pkg/mflag/flag.go
@@ -86,6 +86,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -505,7 +506,16 @@ func Set(name, value string) error {
 // otherwise, the default values of all defined flags in the set.
 func (f *FlagSet) PrintDefaults() {
 	writer := tabwriter.NewWriter(f.Out(), 20, 1, 3, ' ', 0)
-	home := homedir.Get()
+	var home string
+	if runtime.GOOS != "windows" {
+		// Only do this on non-windows systems
+		home = homedir.Get()
+
+		// Don't substitute when HOME is /
+		if home == "/" {
+			home = ""
+		}
+	}
 	f.VisitAll(func(flag *Flag) {
 		format := "  -%s=%s"
 		names := []string{}


### PR DESCRIPTION
@estesp noticed that when $HOME is / the ~ substitutions messes up
because it tries to replace all paths that start with "/" with "~".
This fixes it so that it will only replace it when $HOME isn't "/".

This is a follow-on/fix to: https://github.com/docker/docker/pull/10547

Signed-off-by: Doug Davis dug@us.ibm.com
