### PR TITLE
Convert BUILDFLAGS to array before array concat

### DIFF
--- a/project/make.sh
+++ b/project/make.sh
@@ -118,7 +118,8 @@ EXTLDFLAGS_STATIC='-static'
 # with options like -race.
 ORIG_BUILDFLAGS=( -a -tags "netgo static_build $DOCKER_BUILDTAGS" -installsuffix netgo )
 # see https://github.com/golang/go/issues/9369#issuecomment-69864440 for why -installsuffix is necessary here
-BUILDFLAGS=( $BUILDFLAGS "${ORIG_BUILDFLAGS[@]}" )
+eval BUILDFLAGS=( "$BUILDFLAGS" )
+BUILDFLAGS=( "${BUILDFLAGS[@]}" "${ORIG_BUILDFLAGS[@]}" )
 # Test timeout.
 : ${TIMEOUT:=30m}
 TESTFLAGS+=" -test.timeout=${TIMEOUT}"


### PR DESCRIPTION
I have tried to build a debug version of docker binary. When you specify $BUILDFLAGS environment variable which contains a compiler flag with multiple arguments, the items are separated at unexpected positions.

``` console:
# DEBUG=true BUILDFLAGS="-gcflags '-N -l'" hack/make.sh binary

bundles/1.4.1-dev already exists. Removing.

---> Making bundle: binary (in bundles/1.4.1-dev/binary)
invalid value "'-N" for flag -gcflags: unterminated ' string
usage: build [-o output] [-i] [build flags] [packages]

Build compiles the packages named by the import paths,

...
```

You would have to convert the string to an array with `eval` before array concatenation.
