### PR TITLE
dispatchers: warn user if try to use EXPOSE ip:hostPort:containerPort

### DIFF
--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -331,9 +331,17 @@ func expose(b *Builder, args []string, attributes map[string]bool, original stri
 		b.Config.ExposedPorts = make(nat.PortSet)
 	}
 
-	ports, _, err := nat.ParsePortSpecs(append(portsTab, b.Config.PortSpecs...))
+	ports, bindingMap, err := nat.ParsePortSpecs(append(portsTab, b.Config.PortSpecs...))
 	if err != nil {
 		return err
+	}
+
+	for _, bindings := range bindingMap {
+            if bindings[0].HostIp != "" || bindings[0].HostPort != "" {
+                fmt.Fprintf(b.OutStream, " ---> The mapping to public ports on your host via:\n" +
+                            "      Dockerfile EXPOSE (ip:hostPort:containerPort) has been deprecated.\n" +
+                            "      Use -p to publish the ports.\n")
+		}
 	}
 
 	// instead of using ports directly, we build a list of ports and sort it so


### PR DESCRIPTION
We could use EXPOSE ip:hostPort:containerPort,
but actually it did as EXPOSE ::containerPort

commit 2275c833 already warned user on daemon side.
This patch will print warning message on client side.

Signed-off-by: Chen Hanxiao chenhanxiao@cn.fujitsu.com
