### PR TITLE
Proposal: Custom Access-Control-Allow-Origin value

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1219,8 +1219,8 @@ func optionsHandler(eng *engine.Engine, version version.Version, w http.Response
 	w.WriteHeader(http.StatusOK)
 	return nil
 }
-func writeCorsHeaders(w http.ResponseWriter, r *http.Request) {
-	w.Header().Add("Access-Control-Allow-Origin", "*")
+func writeCorsHeaders(w http.ResponseWriter, r *http.Request, enableCors string) {
+	w.Header().Add("Access-Control-Allow-Origin", enableCors)
 	w.Header().Add("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, X-Registry-Auth")
 	w.Header().Add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, OPTIONS")
 }
@@ -1230,7 +1230,7 @@ func ping(eng *engine.Engine, version version.Version, w http.ResponseWriter, r 
 	return err
 }
 
-func makeHttpHandler(eng *engine.Engine, logging bool, localMethod string, localRoute string, handlerFunc HttpApiFunc, enableCors bool, dockerVersion version.Version) http.HandlerFunc {
+func makeHttpHandler(eng *engine.Engine, logging bool, localMethod string, localRoute string, handlerFunc HttpApiFunc, enableCors string, dockerVersion version.Version) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// log the request
 		log.Debugf("Calling %s %s", localMethod, localRoute)
@@ -1249,8 +1249,8 @@ func makeHttpHandler(eng *engine.Engine, logging bool, localMethod string, local
 		if version == "" {
 			version = api.APIVERSION
 		}
-		if enableCors {
-			writeCorsHeaders(w, r)
+		if enableCors != "" {
+			writeCorsHeaders(w, r, enableCors)
 		}
 
 		if version.GreaterThan(api.APIVERSION) {
@@ -1292,7 +1292,7 @@ func AttachProfiler(router *mux.Router) {
 	router.HandleFunc("/debug/pprof/threadcreate", pprof.Handler("threadcreate").ServeHTTP)
 }
 
-func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion string) *mux.Router {
+func createRouter(eng *engine.Engine, logging bool, enableCors string, dockerVersion string) *mux.Router {
 	r := mux.NewRouter()
 	if os.Getenv("DEBUG") != "" {
 		AttachProfiler(r)
@@ -1382,7 +1382,7 @@ func createRouter(eng *engine.Engine, logging, enableCors bool, dockerVersion st
 // FIXME: refactor this to be part of Server and not require re-creating a new
 // router each time. This requires first moving ListenAndServe into Server.
 func ServeRequest(eng *engine.Engine, apiversion version.Version, w http.ResponseWriter, req *http.Request) {
-	router := createRouter(eng, false, true, "")
+	router := createRouter(eng, false, "*", "")
 	// Insert APIVERSION into the request as a convenience
 	req.URL.Path = fmt.Sprintf("/v%s%s", apiversion, req.URL.Path)
 	router.ServeHTTP(w, req)
@@ -1391,7 +1391,7 @@ func ServeRequest(eng *engine.Engine, apiversion version.Version, w http.Respons
 // serveFd creates an http.Server and sets it up to serve given a socket activated
 // argument.
 func serveFd(addr string, job *engine.Job) error {
-	r := createRouter(job.Eng, job.GetenvBool("Logging"), job.GetenvBool("EnableCors"), job.Getenv("Version"))
+	r := createRouter(job.Eng, job.GetenvBool("Logging"), job.Getenv("EnableCors"), job.Getenv("Version"))
 
 	ls, e := systemd.ListenFD(addr)
 	if e != nil {
@@ -1503,7 +1503,7 @@ func setSocketGroup(addr, group string) error {
 }
 
 func setupUnixHttp(addr string, job *engine.Job) (*HttpServer, error) {
-	r := createRouter(job.Eng, job.GetenvBool("Logging"), job.GetenvBool("EnableCors"), job.Getenv("Version"))
+	r := createRouter(job.Eng, job.GetenvBool("Logging"), job.Getenv("EnableCors"), job.Getenv("Version"))
 
 	if err := syscall.Unlink(addr); err != nil && !os.IsNotExist(err) {
 		return nil, err
@@ -1558,9 +1558,10 @@ func setupTcpHttp(addr string, job *engine.Job) (*HttpServer, error) {
 		log.Infof("/!\\ DON'T BIND ON ANOTHER IP ADDRESS THAN 127.0.0.1 IF YOU DON'T KNOW WHAT YOU'RE DOING /!\\")
 	}
 
-	r := createRouter(job.Eng, job.GetenvBool("Logging"), job.GetenvBool("EnableCors"), job.Getenv("Version"))
+	r := createRouter(job.Eng, job.GetenvBool("Logging"), job.Getenv("EnableCors"), job.Getenv("Version"))
 
 	l, err := newListener("tcp", addr, job.GetenvBool("BufferRequests"))
+
 	if err != nil {
 		return nil, err
 	}

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -130,7 +130,7 @@ func mainDaemon() {
 	// Serve api
 	job := eng.Job("serveapi", flHosts...)
 	job.SetenvBool("Logging", true)
-	job.SetenvBool("EnableCors", *flEnableCors)
+	job.Setenv("EnableCors", *flEnableCors)
 	job.Setenv("Version", dockerversion.VERSION)
 	job.Setenv("SocketGroup", *flSocketGroup)
 

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -36,7 +36,7 @@ var (
 	flDebug       = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
 	flSocketGroup = flag.String([]string{"G", "-group"}, "docker", "Group for the unix socket")
 	flLogLevel    = flag.String([]string{"l", "-log-level"}, "info", "Set the logging level")
-	flEnableCors  = flag.Bool([]string{"#api-enable-cors", "-api-enable-cors"}, false, "Enable CORS headers in the remote API")
+	flEnableCors  = flag.String([]string{"R", "-api-enable-cors"}, "*", "Enable CORS headers in the remote API")
 	flTls         = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by --tlsverify flag")
 	flHelp        = flag.Bool([]string{"h", "-help"}, false, "Print usage")
 	flTlsVerify   = flag.Bool([]string{"-tlsverify"}, dockerTlsVerify, "Use TLS and verify the remote")

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -1971,6 +1971,6 @@ This might change in the future.
 ## 3.3 CORS Requests
 
 To enable cross origin requests to the remote api add the flag
-"--api-enable-cors" when running docker in daemon mode.
+"--api-enable-cors" when running docker in daemon mode. Default "*"
 
-    $ docker -d -H="192.168.1.9:2375" --api-enable-cors
+    $ docker -d -H="192.168.1.9:2375" --api-enable-cors="http://origin.site.com"


### PR DESCRIPTION
Universal Allow  as [implemented now](https://github.com/docker/docker/blob/master/api/server/server.go#L1223) could be consider a potential security issue, and some CORS implementations doesn't allow it, for example Google Chrome. 
As described in [html5rocks website](http://www.html5rocks.com/en/tutorials/cors/)

```
... using '*' is fine. But if you’d like finer control over who can access your data,
use an actual value in the header. ..
```

This proposal changes the flag --api-enable-cors from `bool` to `string`, in this way user can specify a value for Access-Control-Allow-Origin 

```
  docker -d  --api-enable-cors="http://api.bob.com" 
# Produces header Access-Control-Allow-Origin: "http://api.bob.com" 
```

Falling back to default "*" in no value is passed 

```
  docker -d  --api-enable-cors
# Produces header Access-Control-Allow-Origin: "*" 
```

Signed-off-by: Alfonso Fernandez fernandez.alfonso@gmail.com
