### PR TITLE
Add more helpful error message for --add-host

### DIFF
--- a/opts/opts.go
+++ b/opts/opts.go
@@ -207,10 +207,10 @@ func ValidateExtraHost(val string) (string, error) {
 	// allow for IPv6 addresses in extra hosts by only splitting on first ":"
 	arr := strings.SplitN(val, ":", 2)
 	if len(arr) != 2 || len(arr[0]) == 0 {
-		return "", fmt.Errorf("bad format for add-host: %s", val)
+		return "", fmt.Errorf("bad format for add-host: %q", val)
 	}
 	if _, err := ValidateIPAddress(arr[1]); err != nil {
-		return "", fmt.Errorf("bad format for add-host: %s", val)
+		return "", fmt.Errorf("invalid IP address in add-host: %q", arr[1])
 	}
 	return val, nil
 }

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -1,6 +1,7 @@
 package opts
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -113,11 +114,11 @@ func TestValidateExtraHosts(t *testing.T) {
 		`ipv6local:::1`,
 	}
 
-	invalid := []string{
-		`myhost:192.notanipaddress.1`,
-		`thathost-nosemicolon10.0.0.1`,
-		`anipv6host:::::1`,
-		`ipv6local:::0::`,
+	invalid := map[string]string{
+		`myhost:192.notanipaddress.1`:  `invalid IP`,
+		`thathost-nosemicolon10.0.0.1`: `bad format`,
+		`anipv6host:::::1`:             `invalid IP`,
+		`ipv6local:::0::`:              `invalid IP`,
 	}
 
 	for _, extrahost := range valid {
@@ -126,9 +127,13 @@ func TestValidateExtraHosts(t *testing.T) {
 		}
 	}
 
-	for _, extrahost := range invalid {
-		if _, err := ValidateExtraHost(extrahost); err == nil {
-			t.Fatalf("ValidateExtraHost(`" + extrahost + "`) should have failed validation")
+	for extraHost, expectedError := range invalid {
+		if _, err := ValidateExtraHost(extraHost); err == nil {
+			t.Fatalf("ValidateExtraHost(`%q`) should have failed validation", extraHost)
+		} else {
+			if !strings.Contains(err.Error(), expectedError) {
+				t.Fatalf("ValidateExtraHost(`%q`) error should contain %q", extraHost, expectedError)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes: #10655

As noted in the issue, bad format was being returned even if the format
was appropriate, but the IP was invalid.  This adds a better error
message for when the IP address fails validation.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
