### PR TITLE
Add Image/Libcontainer spec refs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,8 @@ Under the hood, Docker is built on the following components:
   [namespacing](http://blog.dotcloud.com/under-the-hood-linux-kernels-on-dotcloud-part)
   capabilities of the Linux kernel;
 * The [Go](http://golang.org) programming language.
+* The [Docker Image Specification] (https://github.com/docker/docker/blob/master/image/spec/v1.md)
+* The [Libcontainer Specification] (https://github.com/docker/libcontainer/blob/master/SPEC.md)
 
 Contributing to Docker
 ======================


### PR DESCRIPTION
Right now its really hard for a newbie to find our Image specification
so I'm adding a link to it (and libcontainer's) to the main README.
I'm also trying to figure out how to add a link to it from the main docs
too but that's proving harder than I expected. I'll be working with Sven on
a subsequent PR to make that happen, but it might not happen until after 1.5
is out.

Signed-off-by: Doug Davis dug@us.ibm.com
