### PR TITLE
Clean up dup. volume test and add API test for the same

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -495,7 +495,23 @@ func TestVolumesFromGetsProperMode(t *testing.T) {
 
 // Test for GH#10618
 func TestRunNoDupVolumes(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-v", "/etc:/someplace", "-v", "/usr/lib:/someplace", "busybox", "echo", "hi")
+
+	bindPath1, err := ioutil.TempDir("", "test1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(bindPath1)
+
+	bindPath2, err := ioutil.TempDir("", "test2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(bindPath2)
+
+	mountstr1 := bindPath1 + ":/someplace"
+	mountstr2 := bindPath2 + ":/someplace"
+
+	cmd := exec.Command(dockerBinary, "run", "-v", mountstr1, "-v", mountstr2, "busybox", "true")
 	if out, _, err := runCommandWithOutput(cmd); err == nil {
 		t.Fatal("Expected error about duplicate volume definitions")
 	} else {


### PR DESCRIPTION
Handles missed comments in PR #10622 and adds an API test to validate
error returned properly for duplicate bind mounts for the same
container target path.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
