### PR TITLE
Update project/make/dynbinary to unset the static_build tag

### DIFF
--- a/project/make/dynbinary
+++ b/project/make/dynbinary
@@ -16,5 +16,6 @@ fi
 (
 	export LDFLAGS_STATIC_DOCKER="-X $DOCKER_PKG/dockerversion.INITSHA1 \"$DOCKER_INITSHA1\" -X $DOCKER_PKG/dockerversion.INITPATH \"$DOCKER_INITPATH\""
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
+	export BUILDFLAGS=( "${BUILDFLAGS[@]/static_build /}" ) # we're not building a "static" binary here
 	source "$(dirname "$BASH_SOURCE")/binary"
 )


### PR DESCRIPTION
This allows us to use build tags in the code directly to include/exclude code based on our binary's "staticness".
