### PR TITLE
devicemapper: exclude from static Docker builds

### DIFF
--- a/daemon/daemon_devicemapper.go
+++ b/daemon/daemon_devicemapper.go
@@ -1,4 +1,4 @@
-// +build !exclude_graphdriver_devicemapper
+// +build !exclude_graphdriver_devicemapper,!static_build
 
 package daemon
 


### PR DESCRIPTION
This PR disables the building of the devicemapper graph driver for static Docker binaries.

As @vbatts has pointed out in #10195 and other PRs which are meant to fix #4036, devicemapper needs to allow udev to create the block device. However, statically linking in devicemapper doesn't make it possible for devicemapper to still be linked to udev. Not being able to use udev leads to udev racing with devicemapper, thus causing problems.

Disabling the building of devicemapper for static binaries is required. This won't affect distributions such as CentOS, RHEL, Fedora and others where dynamically linked Docker binaries are provided. 

Having devicemapper built in for statically linked Docker binaries doesn't make sense - we know for a fact issues will arise due to the lack of communication between devicemapper and udev.

The next step is to provide distribution specific package repositories and recommend specific drivers for certain distributions as needed.
