### PR TITLE
Remove word "fail" from tests

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -1796,7 +1796,7 @@ func TestBuildWithInaccessibleFilesInContext(t *testing.T) {
 		}
 
 	}
-	logDone("build - ADD from context with inaccessible files must fail")
+	logDone("build - ADD from context with inaccessible files must not pass")
 	logDone("build - ADD from context with accessible links must work")
 	logDone("build - ADD from context with ignored inaccessible files must work")
 }
@@ -2169,7 +2169,7 @@ func TestBuildContextCleanupFailedBuild(t *testing.T) {
 		t.Fatalf("context should have been deleted, but wasn't")
 	}
 
-	logDone("build - verify context cleanup works properly after a failed build")
+	logDone("build - verify context cleanup works properly after an unsuccessful build")
 }
 
 func TestBuildCmd(t *testing.T) {
@@ -3206,7 +3206,7 @@ func TestBuildFails(t *testing.T) {
 	} else {
 		t.Fatal("Error must not be nil")
 	}
-	logDone("build - fails")
+	logDone("build - unsuccessful")
 }
 
 func TestBuildFailsDockerfileEmpty(t *testing.T) {
@@ -3220,7 +3220,7 @@ func TestBuildFailsDockerfileEmpty(t *testing.T) {
 	} else {
 		t.Fatal("Error must not be nil")
 	}
-	logDone("build - fails with empty dockerfile")
+	logDone("build - unsuccessful with empty dockerfile")
 }
 
 func TestBuildOnBuild(t *testing.T) {
@@ -4327,7 +4327,7 @@ func TestBuildVerifySingleQuoteFails(t *testing.T) {
 		t.Fatal("The image was not supposed to be able to run")
 	}
 
-	logDone("build - verify single quotes fail")
+	logDone("build - verify single quotes break the build")
 }
 
 func TestBuildVerboseOut(t *testing.T) {

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -93,7 +93,7 @@ func TestEventsContainerFailStartDie(t *testing.T) {
 		t.Fatalf("event should be die, not %#v", dieEvent)
 	}
 
-	logDone("events - container failed to start logs die")
+	logDone("events - container unwilling to start logs die")
 }
 
 func TestEventsLimit(t *testing.T) {

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -71,7 +71,7 @@ func TestHistoryExistentImage(t *testing.T) {
 	if err != nil || exitCode != 0 {
 		t.Fatal("failed to get image history")
 	}
-	logDone("history - history on existent image must not fail")
+	logDone("history - history on existent image must pass")
 }
 
 func TestHistoryNonExistentImage(t *testing.T) {
@@ -80,5 +80,5 @@ func TestHistoryNonExistentImage(t *testing.T) {
 	if err == nil || exitCode == 0 {
 		t.Fatal("history on a non-existent image didn't result in a non-zero exit status")
 	}
-	logDone("history - history on non-existent image must fail")
+	logDone("history - history on non-existent image must pass")
 }

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -193,7 +193,7 @@ func TestLinksNotStartedParentNotFail(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	logDone("link - container start not failing on updating stopped parent links")
+	logDone("link - container start successfully updating stopped parent links")
 }
 
 func TestLinksHostsFilesInject(t *testing.T) {

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -37,7 +37,7 @@ func TestPushUnprefixedRepo(t *testing.T) {
 	if out, _, err := runCommandWithOutput(pushCmd); err == nil {
 		t.Fatalf("pushing an unprefixed repo didn't result in a non-zero exit status: %s", out)
 	}
-	logDone("push - unprefixed busybox repo must fail")
+	logDone("push - unprefixed busybox repo must not pass")
 }
 
 func TestPushUntagged(t *testing.T) {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1398,7 +1398,7 @@ func TestRunDisallowBindMountingRootToRoot(t *testing.T) {
 
 	deleteAllContainers()
 
-	logDone("run - bind mount /:/ as volume should fail")
+	logDone("run - bind mount /:/ as volume should not work")
 }
 
 // Verify that a container gets default DNS when only localhost resolvers exist
@@ -2234,7 +2234,7 @@ func TestRunCidFileCleanupIfEmpty(t *testing.T) {
 		t.Fatalf("empty CIDFile %q should've been deleted", tmpCidFile)
 	}
 	deleteAllContainers()
-	logDone("run - cleanup empty cidfile on fail")
+	logDone("run - cleanup empty cidfile on error")
 }
 
 // #2098 - Docker cidFiles only contain short version of the containerId
@@ -2367,7 +2367,7 @@ func TestRunPortInUse(t *testing.T) {
 	}
 
 	deleteAllContainers()
-	logDone("run - fail if port already in use")
+	logDone("run - error out if port already in use")
 }
 
 // https://github.com/docker/docker/issues/8428

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -135,7 +135,7 @@ func TestStartRecordError(t *testing.T) {
 		t.Fatalf("Expected to not have state error but got state.Error(%q)", stateErr)
 	}
 
-	logDone("start - set state error when start fails")
+	logDone("start - set state error when start is unsuccessful")
 }
 
 // gh#8726: a failed Start() breaks --volumes-from on subsequent Start()'s

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -54,7 +54,7 @@ func TestTagInvalidUnprefixedRepo(t *testing.T) {
 			t.Fatalf("tag busybox %v should have failed", repo)
 		}
 	}
-	logDone("tag - busybox invalid repo names --> must fail")
+	logDone("tag - busybox invalid repo names --> must not work")
 }
 
 // ensure we don't allow the use of invalid tags; these tag operations should fail
@@ -70,7 +70,7 @@ func TestTagInvalidPrefixedRepo(t *testing.T) {
 			t.Fatalf("tag busybox %v should have failed", repotag)
 		}
 	}
-	logDone("tag - busybox with invalid repo:tagnames --> must fail")
+	logDone("tag - busybox with invalid repo:tagnames --> must not work")
 }
 
 // ensure we allow the use of valid tags
@@ -111,7 +111,7 @@ func TestTagExistedNameWithoutForce(t *testing.T) {
 	}
 	deleteImages("busybox:test")
 
-	logDone("tag - busybox with an existed tag name without -f option --> must fail")
+	logDone("tag - busybox with an existed tag name without -f option --> must not work")
 }
 
 // tag an image with an existed tag name with -f option should work


### PR DESCRIPTION
Signed-off-by: Tibor Vass tibor@docker.com

Ping @unclejack 

@tianon's gonna be happy? One catch though: I couldn't remove `logDone("restart - recording restart policy name for --restart=on-failure")`.
