### PR TITLE
Add `--hairpin-nat` daemon flag as a userland proxy alternative

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -44,6 +44,7 @@ type Config struct {
 	Context                     map[string][]string
 	TrustKeyPath                string
 	Labels                      []string
+	EnableUserlandProxy         bool
 }
 
 // InstallFlags adds command-line options to the top-level flag parser for
@@ -75,6 +76,7 @@ func (config *Config) InstallFlags() {
 	opts.IPListVar(&config.Dns, []string{"#dns", "-dns"}, "DNS server to use")
 	opts.DnsSearchListVar(&config.DnsSearch, []string{"-dns-search"}, "DNS search domains to use")
 	opts.LabelListVar(&config.Labels, []string{"-label"}, "Set key=value labels to the daemon")
+	flag.BoolVar(&config.EnableUserlandProxy, []string{"-userland-proxy"}, false, "Use userland proxy for loopback traffic")
 }
 
 func getDefaultNetworkMtu() int {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -227,6 +227,7 @@ func populateCommand(c *Container, env []string) error {
 				GlobalIPv6Address:    network.GlobalIPv6Address,
 				GlobalIPv6PrefixLen:  network.GlobalIPv6PrefixLen,
 				IPv6Gateway:          network.IPv6Gateway,
+				HairpinMode:          network.HairpinMode,
 			}
 		}
 	case "container":
@@ -556,6 +557,7 @@ func (container *Container) AllocateNetwork() error {
 	container.NetworkSettings.GlobalIPv6Address = env.Get("GlobalIPv6")
 	container.NetworkSettings.GlobalIPv6PrefixLen = env.GetInt("GlobalIPv6PrefixLen")
 	container.NetworkSettings.IPv6Gateway = env.Get("IPv6Gateway")
+	container.NetworkSettings.HairpinMode = env.GetBool("HairpinMode")
 
 	return nil
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -943,6 +943,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		job.Setenv("FixedCIDR", config.FixedCIDR)
 		job.Setenv("FixedCIDRv6", config.FixedCIDRv6)
 		job.Setenv("DefaultBindingIP", config.DefaultIp.String())
+		job.SetenvBool("EnableHairpinMode", !config.EnableUserlandProxy)
 
 		if err := job.Run(); err != nil {
 			return nil, err

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -95,6 +95,7 @@ type NetworkInterface struct {
 	LinkLocalIPv6Address string `json:"link_local_ipv6"`
 	GlobalIPv6PrefixLen  int    `json:"global_ipv6_prefix_len"`
 	IPv6Gateway          string `json:"ipv6_gateway"`
+	HairpinMode          bool   `json:"hairpin_mode"`
 }
 
 type Resources struct {

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -102,13 +102,14 @@ func (d *driver) createNetwork(container *libcontainer.Config, c *execdriver.Com
 
 	if c.Network.Interface != nil {
 		vethNetwork := libcontainer.Network{
-			Mtu:        c.Network.Mtu,
-			Address:    fmt.Sprintf("%s/%d", c.Network.Interface.IPAddress, c.Network.Interface.IPPrefixLen),
-			MacAddress: c.Network.Interface.MacAddress,
-			Gateway:    c.Network.Interface.Gateway,
-			Type:       "veth",
-			Bridge:     c.Network.Interface.Bridge,
-			VethPrefix: "veth",
+			Mtu:         c.Network.Mtu,
+			Address:     fmt.Sprintf("%s/%d", c.Network.Interface.IPAddress, c.Network.Interface.IPPrefixLen),
+			MacAddress:  c.Network.Interface.MacAddress,
+			Gateway:     c.Network.Interface.Gateway,
+			Type:        "veth",
+			Bridge:      c.Network.Interface.Bridge,
+			VethPrefix:  "veth",
+			HairpinMode: c.Network.Interface.HairpinMode,
 		}
 		if c.Network.Interface.GlobalIPv6Address != "" {
 			vethNetwork.IPv6Address = fmt.Sprintf("%s/%d", c.Network.Interface.GlobalIPv6Address, c.Network.Interface.GlobalIPv6PrefixLen)

--- a/daemon/network_settings.go
+++ b/daemon/network_settings.go
@@ -21,6 +21,7 @@ type NetworkSettings struct {
 	Bridge                 string
 	PortMapping            map[string]PortMapping // Deprecated
 	Ports                  nat.PortMap
+	HairpinMode            bool
 }
 
 func (settings *NetworkSettings) PortMappingAPI() *engine.Table {

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -97,6 +97,10 @@ unix://[/path/to/socket] to use.
 **--storage-opt**=[]
   Set storage driver options. See STORAGE DRIVER OPTIONS.
 
+**--userland-proxy**=*true*|*false*
+    Rely on a userland proxy implementation for inter-container and outside-to-
+    container loopback communications. Default is true.
+
 **-v**=*true*|*false*
   Print version information and quit. Default is false.
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -107,6 +107,7 @@ expect an integer, and they can only be specified once.
       --tlscert="/home/sven/.docker/cert.pem"    Path to TLS certificate file
       --tlskey="/home/sven/.docker/key.pem"      Path to TLS key file
       --tlsverify=false                          Use TLS and verify the remote
+      --userland-proxy=true                      Use userland proxy for loopback traffic
       -v, --version=false                        Print version information and quit
 
 Options with [] may be specified multiple times.

--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -6,12 +6,28 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 )
 
-func TestNetworkNat(t *testing.T) {
+func startServerContainer(t *testing.T, proto string) string {
+	cmd := []string{"run", "-dt", "-p", "8080:8080", "busybox", "nc", "-lp", "8080"}
+	if proto == "udp" {
+		cmd = append(cmd, "-u")
+	}
+
+	runCmd := exec.Command(dockerBinary, cmd...)
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatal(out, err)
+	}
+
+	return stripTrailingCharacters(out)
+}
+
+func getExternalAddress(t *testing.T) net.IP {
 	iface, err := net.InterfaceByName("eth0")
 	if err != nil {
-		t.Skipf("Test not running with `make test`. Interface eth0 not found: %s", err)
+		t.Skip("Test not running with `make test`. Interface eth0 not found: %s", err)
 	}
 
 	ifaceAddrs, err := iface.Addrs()
@@ -24,37 +40,83 @@ func TestNetworkNat(t *testing.T) {
 		t.Fatalf("Error retrieving the up for eth0: %s", err)
 	}
 
-	runCmd := exec.Command(dockerBinary, "run", "-dt", "-p", "8080:8080", "busybox", "nc", "-lp", "8080")
+	return ifaceIP
+}
+
+func getContainerLogs(t *testing.T, containerID string) string {
+	runCmd := exec.Command(dockerBinary, "logs", containerID)
 	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		t.Fatal(out, err)
-	}
-
-	cleanedContainerID := stripTrailingCharacters(out)
-
-	runCmd = exec.Command(dockerBinary, "run", "busybox", "sh", "-c", fmt.Sprintf("echo hello world | nc -w 30 %s 8080", ifaceIP))
-	out, _, err = runCommandWithOutput(runCmd)
-	if err != nil {
-		t.Fatal(out, err)
-	}
-
-	runCmd = exec.Command(dockerBinary, "logs", cleanedContainerID)
-	out, _, err = runCommandWithOutput(runCmd)
 	if err != nil {
 		t.Fatalf("failed to retrieve logs for container: %s, %v", out, err)
 	}
+	return strings.Trim(out, "\r\n")
+}
 
-	out = strings.Trim(out, "\r\n")
-
-	if expected := "hello world"; out != expected {
-		t.Fatalf("Unexpected output. Expected: %q, received: %q for iface %s", expected, out, ifaceIP)
+func getContainerStatus(t *testing.T, containerID string) string {
+	runCmd := exec.Command(dockerBinary, "inspect", "-f", "{{.State.Running}}", containerID)
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatalf("failed to retrieve container status: %s, %v", out, err)
 	}
+	return strings.Trim(out, "\r\n")
+}
 
-	killCmd := exec.Command(dockerBinary, "kill", cleanedContainerID)
-	if out, _, err = runCommandWithOutput(killCmd); err != nil {
+func killContainer(t *testing.T, containerID string) {
+	killCmd := exec.Command(dockerBinary, "kill", containerID)
+	if out, _, err := runCommandWithOutput(killCmd); err != nil {
 		t.Fatalf("failed to kill container: %s, %v", out, err)
 	}
+}
+
+func TestNetworkTCPNat(t *testing.T) {
+	srv := startServerContainer(t, "tcp")
+
+	// Spawn a new container which connects to the server through the
+	// interface address.
+	endpoint := getExternalAddress(t)
+	runCmd := exec.Command(dockerBinary, "run", "busybox", "sh", "-c", fmt.Sprintf("echo hello world | nc -w 30 %s 8080", endpoint))
+	if _, _, err := runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(err)
+	}
+
+	result := getContainerLogs(t, srv)
+	if expected := "hello world"; result != expected {
+		t.Fatalf("Unexpected output. Expected: %q, received: %q", expected, result)
+	}
+
+	killContainer(t, srv)
 	deleteAllContainers()
 
-	logDone("network - make sure nat works through the host")
+	logDone("network - make sure nat works in TCP through the host")
+}
+
+func TestNetworkLocalhostTCPNat(t *testing.T) {
+	srv := startServerContainer(t, "tcp")
+	for i := 0; i != 5; i++ {
+		value := getContainerStatus(t, srv)
+		if value == "true" {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Attempt to connect from the host to the listening container.
+	conn, err := net.Dial("tcp", "localhost:8080")
+	if err != nil {
+		t.Fatalf("Failed to connect to container (%v)", err)
+	}
+	if _, err := conn.Write([]byte("hello world\n")); err != nil {
+		t.Fatal(err)
+	}
+	conn.Close()
+
+	result := getContainerLogs(t, srv)
+	if expected := "hello world"; result != expected {
+		t.Fatalf("Unexpected output. Expected: %q, received: %q", expected, result)
+	}
+
+	killContainer(t, srv)
+	deleteAllContainers()
+
+	logDone("network - make sure nat works in TCP through the host loopback")
 }

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -80,19 +80,20 @@ func NewChain(name, bridge string, table Table) (*Chain, error) {
 	switch table {
 	case Nat:
 		preroute := []string{
+			"PREROUTING",
 			"-m", "addrtype",
 			"--dst-type", "LOCAL"}
 		if !Exists(preroute...) {
-			if err := c.Prerouting(Append, preroute...); err != nil {
+			if err := c.Prerouting(Append, preroute[1:]...); err != nil {
 				return nil, fmt.Errorf("Failed to inject docker in PREROUTING chain: %s", err)
 			}
 		}
 		output := []string{
+			"OUTPUT",
 			"-m", "addrtype",
-			"--dst-type", "LOCAL",
-			"!", "--dst", "127.0.0.0/8"}
+			"--dst-type", "LOCAL"}
 		if !Exists(output...) {
-			if err := c.Output(Append, output...); err != nil {
+			if err := c.Output(Append, output[1:]...); err != nil {
 				return nil, fmt.Errorf("Failed to inject docker in OUTPUT chain: %s", err)
 			}
 		}
@@ -230,7 +231,7 @@ func (c *Chain) Remove() error {
 	// Ignore errors - This could mean the chains were never set up
 	if c.Table == Nat {
 		c.Prerouting(Delete, "-m", "addrtype", "--dst-type", "LOCAL")
-		c.Output(Delete, "-m", "addrtype", "--dst-type", "LOCAL", "!", "--dst", "127.0.0.0/8")
+		c.Output(Delete, "-m", "addrtype", "--dst-type", "LOCAL")
 		c.Output(Delete, "-m", "addrtype", "--dst-type", "LOCAL") // Created in versions <= 0.1.6
 
 		c.Prerouting(Delete)


### PR DESCRIPTION
**Disclaimer: this is not yet ready to merge, but needs a bit of discussion.**

The new daemon flag `--hairpin-nat` makes it possible to rely on hairpin NAT and additional iptables routes instead of userland proxy for port publishing and inter-container communication.

Our first attempt at entirely removing userland proxy (#9078) failed because hairpin NAT is not universally available (see [this comment](https://github.com/docker/docker/pull/9078#issuecomment-63890121) on the previous PR):

> We cannot move forward with this PR at this time because systems running on 2.6.x are totally broken and cannot start any containers with the changes.

There are two known flaws to this implementation:
1. One which was [already raised](https://github.com/docker/docker/pull/9078#issuecomment-62496976) on the initial PR that in the absence of the userland proxy, nothing is here to actually bind the published ports, so nothing is preventing conflicts with a service listening _out_ of Docker.
2. A change of behavior that we failed to explain at that time (but I'm hoping @MalteJ and @phemmer will send assistance thanks to this disguised ping): when running `docker run -p 80:80 -dti ubuntu nc -lp 80` with `--hairpin-nat` enabled on the daemon, an attempt to connect with `nc -v localhost 80` makes a first failure to connect over IPv6 appear, followed by a success to connect over IPv4. This behavior doesn't appear without `--hairpin-nat` as nc successfully connects over IPv6... I'm thinking this might be because of `/proc/sys/net/ipv4/conf/docker0/route_localnet` param which has no equivalence in IPv6.

Depends on docker/libcontainer#366.
