### PR TITLE
devicemapper: autoloopfile distinction

### DIFF
--- a/daemon/graphdriver/devmapper/README.md
+++ b/daemon/graphdriver/devmapper/README.md
@@ -106,7 +106,7 @@ Here is the list of supported options:
  *  `dm.loopmetadatasize`
 
     Specifies the size to use when creating the loopback file for the
-    "metadadata" device which is used for the thin pool. The default size is
+    "metadata" device which is used for the thin pool. The default size is
     2G. Note that the file is sparse, so it will not initially take
     up this much space.
 
@@ -212,3 +212,16 @@ Here is the list of supported options:
     Example use:
 
     ``docker -d --storage-opt dm.blkdiscard=false``
+
+ *  `dm.autoloopfile`
+
+    Instructs the devicemapper driver to allow automatic creation of loopback
+    attached files datadev and metadatadev. This provides the behavior that has
+    been default in the devicemapper prior, but now is an explicit flag. If
+    this flag is not provided, then the `dm.datadev` and `dm.metadata` options
+    must be provided.
+
+    Example use:
+
+    ``docker -d --storage-opt dm.autoloopfile=true``
+

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -33,6 +33,7 @@ var (
 	DefaultThinpBlockSize       uint32 = 128      // 64K = 128 512b sectors
 	MaxDeviceId                 int    = 0xffffff // 24 bit, pool limit
 	DeviceIdMapSz               int    = (MaxDeviceId + 1) / 8
+	DefaultAutoLoopFile         bool   = false
 )
 
 const deviceSetMetaFile string = "deviceset-metadata"
@@ -1630,6 +1631,7 @@ func NewDeviceSet(root string, doInit bool, options []string) (*DeviceSet, error
 		doBlkDiscard:         true,
 		thinpBlockSize:       DefaultThinpBlockSize,
 		deviceIdMap:          make([]byte, DeviceIdMapSz),
+		autoLoopfile:         DefaultAutoLoopFile,
 	}
 
 	foundBlkDiscard := false

--- a/daemon/graphdriver/devmapper/devmapper_test.go
+++ b/daemon/graphdriver/devmapper/devmapper_test.go
@@ -13,6 +13,7 @@ func init() {
 	DefaultDataLoopbackSize = 300 * 1024 * 1024
 	DefaultMetaDataLoopbackSize = 200 * 1024 * 1024
 	DefaultBaseFsSize = 300 * 1024 * 1024
+	DefaultAutoLoopFile = true
 	if err := graphtest.InitLoopbacks(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This set introduces a change to default behavior of the devicemapper driver, and introduces a new flag that delivers the previous [transparent] expected behavior.

This needs a bit of discussion, even though I feel like is a nicely supportable use case.

Many complaints around the performance of the devicemapper driver (or just "performance" in general because folks are not even aware of storage driver differences), are due to the io traversal of the loopback file.

With this change, devicemapper driver will expect (and fail without) a block device being provided, _OR_ with daemon flag `--storage-opt dm.autoloopfile=true` it will automatically create files and attach them on loopback.
