### PR TITLE
Fix docker start -i work even if without -i when container on creation

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -693,31 +693,20 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 			return fmt.Errorf("You cannot start and attach multiple containers at once.")
 		}
 
-		stream, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, false)
-		if err != nil {
-			return err
-		}
-
-		env := engine.Env{}
-		if err := env.Decode(stream); err != nil {
-			return err
-		}
-		config := env.GetSubEnv("Config")
-		tty = config.GetBool("Tty")
-
-		if !tty {
-			sigc := cli.forwardAllSignals(cmd.Arg(0))
-			defer signal.StopCatch(sigc)
-		}
-
 		var in io.ReadCloser
 
 		v := url.Values{}
 		v.Set("stream", "1")
 
-		if *openStdin && config.GetBool("OpenStdin") {
+		if *openStdin {
 			v.Set("stdin", "1")
+			tty = true
 			in = cli.in
+		}
+
+		if !tty {
+			sigc := cli.forwardAllSignals(cmd.Arg(0))
+			defer signal.StopCatch(sigc)
 		}
 
 		v.Set("stdout", "1")

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -93,6 +93,10 @@ func (daemon *Daemon) ContainerAttach(job *engine.Job) engine.Status {
 				io.Copy(w, job.Stdin)
 			}()
 			cStdin = r
+			if !container.Config.OpenStdin {
+				container.Config.OpenStdin = true
+				container.stdin, container.stdinPipe = io.Pipe()
+			}
 		}
 		if stdout {
 			cStdout = job.Stdout

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -211,7 +211,7 @@ func TestCreateEchoStdout(t *testing.T) {
 
 	cleanedContainerID := stripTrailingCharacters(out)
 
-	runCmd = exec.Command(dockerBinary, "start", "-ai", cleanedContainerID)
+	runCmd = exec.Command(dockerBinary, "start", "-a", cleanedContainerID)
 	out, _, _, err = runCommandWithStdoutStderr(runCmd)
 	if err != nil {
 		t.Fatal(out, err)


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
@estesp If your fix is better, I'll close this. I don't think mine is a good one.
relate #10549 
Fixes #10514 

This fixes will overwrite `Config.OpenStdin` to true if docker start with stdin  attached.
