### PR TITLE
Proposal: Add a NOCACHE instruction to Dockerfiles

### DIFF
--- a/builder/command/command.go
+++ b/builder/command/command.go
@@ -17,6 +17,7 @@ const (
 	Volume     = "volume"
 	User       = "user"
 	Insert     = "insert"
+	Nocache    = "nocache"
 )
 
 // Commands is list of all Dockerfile commands
@@ -36,4 +37,5 @@ var Commands = map[string]struct{}{
 	Volume:     {},
 	User:       {},
 	Insert:     {},
+	Nocache:    {},
 }

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -439,6 +439,27 @@ func volume(b *Builder, args []string, attributes map[string]bool, original stri
 	return nil
 }
 
+// NOCACHE
+//
+// Turns off caching from this point on in the Dockerfile
+//
+func nocache(b *Builder, args []string, attributes map[string]bool, original string) error {
+	if len(args) != 0 {
+		return fmt.Errorf("NOCACHE does not accept any arguments: %d %q", len(args), args)
+	}
+
+	if b.UtilizeCache {
+		fmt.Fprintf(b.OutStream, " ---> Turning caching off\n")
+		log.Debugf("[BUILDER] Turning caching off")
+		b.UtilizeCache = false
+	} else {
+		fmt.Fprintf(b.OutStream, " ---> Caching is already off, no effect\n")
+		log.Debugf("[BUILDER] Caching is already off, no effect")
+	}
+
+	return nil
+}
+
 // INSERT is no longer accepted, but we still parse it.
 func insert(b *Builder, args []string, attributes map[string]bool, original string) error {
 	return fmt.Errorf("INSERT has been deprecated. Please use ADD instead")

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -72,6 +72,7 @@ func init() {
 		command.Volume:     volume,
 		command.User:       user,
 		command.Insert:     insert,
+		command.Nocache:    nocache,
 	}
 }
 

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -61,6 +61,7 @@ func init() {
 		command.Expose:     parseStringsWhitespaceDelimited,
 		command.Volume:     parseMaybeJSONToList,
 		command.Insert:     parseIgnore,
+		command.Nocache:    parseString,
 	}
 }
 

--- a/docs/man/Dockerfile.5.md
+++ b/docs/man/Dockerfile.5.md
@@ -26,7 +26,7 @@ For example:
 
 # DESCRIPTION
 
-A Dockerfile is a file that automates the steps of creating a Docker image. 
+A Dockerfile is a file that automates the steps of creating a Docker image.
 A Dockerfile is similar to a Makefile.
 
 # USAGE
@@ -142,7 +142,7 @@ A Dockerfile is similar to a Makefile.
   ```
 
   -- To make the container run the same executable every time, use **ENTRYPOINT** in
-  combination with **CMD**. 
+  combination with **CMD**.
   If the user specifies arguments to `docker run`, the specified commands
   override the default in **CMD**.
   Do not confuse **RUN** with **CMD**. **RUN** runs a command and commits the result.
@@ -160,8 +160,8 @@ A Dockerfile is similar to a Makefile.
   ```
 
   An image can have more than one label. To specify multiple labels, separate
-  each key-value pair by a space. 
-  
+  each key-value pair by a space.
+
   Labels are additive including `LABEL`s in `FROM` images. As the system
   encounters and then applies a new label, new `key`s override any previous
   labels with identical keys.
@@ -178,7 +178,7 @@ A Dockerfile is similar to a Makefile.
 **ENV**
   -- `ENV <key> <value>`
   The **ENV** instruction sets the environment variable <key> to
-  the value `<value>`. This value is passed to all future 
+  the value `<value>`. This value is passed to all future
   RUN, **ENTRYPOINT**, and **CMD** instructions. This is
   functionally equivalent to prefixing the command with `<key>=<value>`.  The
   environment variables that are set with **ENV** persist when a container is run
@@ -205,7 +205,7 @@ A Dockerfile is similar to a Makefile.
   then they must be relative to the source directory that is being built
   (the context of the build). The `<dest>` is the absolute path, or path relative
   to **WORKDIR**, into which the source is copied inside the target container.
-  All new files and directories are created with mode 0755 and with the uid 
+  All new files and directories are created with mode 0755 and with the uid
   and gid of **0**.
 
 **COPY**
@@ -310,8 +310,8 @@ A Dockerfile is similar to a Makefile.
   You can register any build instruction as a trigger. A trigger is useful if
   you are defining an image to use as a base for building other images. For
   example, if you are defining an application build environment or a daemon that
-  is customized with a user-specific configuration.  
-  
+  is customized with a user-specific configuration.
+
   Consider an image intended as a reusable python application builder. It must
   add application source code to a particular directory, and might need a build
   script called after that. You can't just call **ADD** and **RUN** now, because
@@ -323,6 +323,16 @@ A Dockerfile is similar to a Makefile.
   difficult to update because it mixes with application-specific code.
   The solution is to use **ONBUILD** to register instructions in advance, to
   run later, during the next build stage.
+
+**NOCACHE**
+ -- **NOCACHE**
+ The `NOCACHE` instruction will turn off caching from that point forward
+ in the Dockerfile processing. If caching is already turned off, e.g. via
+ the `--no-cache` flag on the `docker build` command, then this instruction
+ will have no effect. While the builder will no longer look in the cache
+ as it processing the instructions, the cache will still be populated
+ so that future builds (that have caching turned on) can still leverage
+ this optimization.
 
 # HISTORY
 *May 2014, Compiled by Zac Dover (zdover at redhat dot com) based on docker.com Dockerfile documentation.

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -34,7 +34,7 @@ whole context must be transferred to the daemon. The Docker CLI reports
 "Sending build context to Docker daemon" when the context is sent to the daemon.
 
 > **Warning**
-> Avoid using your root directory, `/`, as the root of the source repository. The 
+> Avoid using your root directory, `/`, as the root of the source repository. The
 > `docker build` command will use whatever directory contains the Dockerfile as the build
 > context (including all of its subdirectories). The build context will be sent to the
 > Docker daemon before building the image, which means if you use `/` as the source
@@ -124,7 +124,7 @@ whitespace, like `${foo}_bar`.
 
 Escaping is possible by adding a `\` before the variable: `\$foo` or `\${foo}`,
 for example, will translate to `$foo` and `${foo}` literals respectively.
- 
+
 Example (parsed representation is displayed after the `#`):
 
     FROM busybox
@@ -153,7 +153,7 @@ throughout the entire command.  In other words, in this example:
     ENV abc=bye def=$abc
     ENV ghi=$abc
 
-will result in `def` having a value of `hello`, not `bye`.  However, 
+will result in `def` having a value of `hello`, not `bye`.  However,
 `ghi` will have a value of `bye` because it is not part of the same command
 that set `abc` to `bye`.
 
@@ -168,7 +168,7 @@ that will be excluded from the context. Globbing is done using Go's
 > **Note**:
 > The `.dockerignore` file can even be used to ignore the `Dockerfile` and
 > `.dockerignore` files. This might be useful if you are copying files from
-> the root of the build context into your new containter but do not want to 
+> the root of the build context into your new containter but do not want to
 > include the `Dockerfile` or `.dockerignore` files (e.g. `ADD . /someDir/`).
 
 The following example shows the use of the `.dockerignore` file to exclude the
@@ -261,13 +261,13 @@ commands using a base image that does not contain `/bin/sh`.
 > Unlike the *shell* form, the *exec* form does not invoke a command shell.
 > This means that normal shell processing does not happen. For example,
 > `RUN [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
-> If you want shell processing then either use the *shell* form or execute 
+> If you want shell processing then either use the *shell* form or execute
 > a shell directly, for example: `RUN [ "sh", "-c", "echo", "$HOME" ]`.
 
 The cache for `RUN` instructions isn't invalidated automatically during
-the next build. The cache for an instruction like 
-`RUN apt-get dist-upgrade -y` will be reused during the next build.  The 
-cache for `RUN` instructions can be invalidated by using the `--no-cache` 
+the next build. The cache for an instruction like
+`RUN apt-get dist-upgrade -y` will be reused during the next build.  The
+cache for `RUN` instructions can be invalidated by using the `--no-cache`
 flag, for example `docker build --no-cache`.
 
 See the [`Dockerfile` Best Practices
@@ -300,8 +300,8 @@ the executable, in which case you must specify an `ENTRYPOINT`
 instruction as well.
 
 > **Note**:
-> If `CMD` is used to provide default arguments for the `ENTRYPOINT` 
-> instruction, both the `CMD` and `ENTRYPOINT` instructions should be specified 
+> If `CMD` is used to provide default arguments for the `ENTRYPOINT`
+> instruction, both the `CMD` and `ENTRYPOINT` instructions should be specified
 > with the JSON array format.
 
 > **Note**:
@@ -312,7 +312,7 @@ instruction as well.
 > Unlike the *shell* form, the *exec* form does not invoke a command shell.
 > This means that normal shell processing does not happen. For example,
 > `CMD [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
-> If you want shell processing then either use the *shell* form or execute 
+> If you want shell processing then either use the *shell* form or execute
 > a shell directly, for example: `CMD [ "sh", "-c", "echo", "$HOME" ]`.
 
 When used in the shell or exec formats, the `CMD` instruction sets the command
@@ -366,11 +366,11 @@ key-value pair by an EOL.
 Docker recommends combining labels in a single `LABEL` instruction where
 possible. Each `LABEL` instruction produces a new layer which can result in an
 inefficient image if you use many labels. This example results in four image
-layers. 
-    
+layers.
+
 Labels are additive including `LABEL`s in `FROM` images. As the system
 encounters and then applies a new label, new `key`s override any previous labels
-with identical keys.    
+with identical keys.
 
 To view an image's labels, use the `docker inspect` command.
 
@@ -401,12 +401,12 @@ commands and can be [replaced inline](#environment-replacement) in many as well.
 
 The `ENV` instruction has two forms. The first form, `ENV <key> <value>`,
 will set a single variable to a value. The entire string after the first
-space will be treated as the `<value>` - including characters such as 
+space will be treated as the `<value>` - including characters such as
 spaces and quotes.
 
-The second form, `ENV <key>=<value> ...`, allows for multiple variables to 
-be set at one time. Notice that the second form uses the equals sign (=) 
-in the syntax, while the first form does not. Like command line parsing, 
+The second form, `ENV <key>=<value> ...`, allows for multiple variables to
+be set at one time. Notice that the second form uses the equals sign (=)
+in the syntax, while the first form does not. Like command line parsing,
 quotes and backslashes can be used to include spaces within values.
 
 For example:
@@ -420,7 +420,7 @@ and
     ENV myDog Rex The Dog
     ENV myCat fluffy
 
-will yield the same net results in the final container, but the first form 
+will yield the same net results in the final container, but the first form
 does it all in one layer.
 
 The environment variables set using `ENV` will persist when a container is run
@@ -442,10 +442,10 @@ ADD has two forms:
 whitespace)
 
 The `ADD` instruction copies new files, directories or remote file URLs from `<src>`
-and adds them to the filesystem of the container at the path `<dest>`.  
+and adds them to the filesystem of the container at the path `<dest>`.
 
-Multiple `<src>` resource may be specified but if they are files or 
-directories then they must be relative to the source directory that is 
+Multiple `<src>` resource may be specified but if they are files or
+directories then they must be relative to the source directory that is
 being built (the context of the build).
 
 Each `<src>` may contain wildcards and matching will be done using Go's
@@ -508,8 +508,8 @@ The copy obeys the following rules:
   appropriate filename can be discovered in this case (`http://example.com`
   will not work).
 
-- If `<src>` is a directory, the entire contents of the directory are copied, 
-  including filesystem metadata. 
+- If `<src>` is a directory, the entire contents of the directory are copied,
+  including filesystem metadata.
 > **Note**:
 > The directory itself is not copied, just its contents.
 
@@ -528,7 +528,7 @@ The copy obeys the following rules:
   at `<dest>/base(<src>)`.
 
 - If multiple `<src>` resources are specified, either directly or due to the
-  use of a wildcard, then `<dest>` must be a directory, and it must end with 
+  use of a wildcard, then `<dest>` must be a directory, and it must end with
   a slash `/`.
 
 - If `<dest>` does not end with a trailing slash, it will be considered a
@@ -576,8 +576,8 @@ The copy obeys the following rules:
   `docker build` is to send the context directory (and subdirectories) to the
   docker daemon.
 
-- If `<src>` is a directory, the entire contents of the directory are copied, 
-  including filesystem metadata. 
+- If `<src>` is a directory, the entire contents of the directory are copied,
+  including filesystem metadata.
 > **Note**:
 > The directory itself is not copied, just its contents.
 
@@ -587,7 +587,7 @@ The copy obeys the following rules:
   at `<dest>/base(<src>)`.
 
 - If multiple `<src>` resources are specified, either directly or due to the
-  use of a wildcard, then `<dest>` must be a directory, and it must end with 
+  use of a wildcard, then `<dest>` must be a directory, and it must end with
   a slash `/`.
 
 - If `<dest>` does not end with a trailing slash, it will be considered a
@@ -616,7 +616,7 @@ Command line arguments to `docker run <image>` will be appended after all
 elements in an *exec* form `ENTRYPOINT`, and will override all elements specified
 using `CMD`.
 This allows arguments to be passed to the entry point, i.e., `docker run <image> -d`
-will pass the `-d` argument to the entry point. 
+will pass the `-d` argument to the entry point.
 You can override the `ENTRYPOINT` instruction using the `docker run --entrypoint`
 flag.
 
@@ -647,10 +647,10 @@ When you run the container, you can see that `top` is the only process:
     %Cpu(s):  0.1 us,  0.1 sy,  0.0 ni, 99.7 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
     KiB Mem:   2056668 total,  1616832 used,   439836 free,    99352 buffers
     KiB Swap:  1441840 total,        0 used,  1441840 free.  1324440 cached Mem
-    
+
       PID USER      PR  NI    VIRT    RES    SHR S %CPU %MEM     TIME+ COMMAND
         1 root      20   0   19744   2336   2080 R  0.0  0.1   0:00.04 top
-    
+
 To examine the result further, you can use `docker exec`:
 
     $ docker exec -it test ps aux
@@ -754,7 +754,7 @@ sys	0m 0.03s
 > Unlike the *shell* form, the *exec* form does not invoke a command shell.
 > This means that normal shell processing does not happen. For example,
 > `ENTRYPOINT [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
-> If you want shell processing then either use the *shell* form or execute 
+> If you want shell processing then either use the *shell* form or execute
 > a shell directly, for example: `ENTRYPOINT [ "sh", "-c", "echo", "$HOME" ]`.
 > Variables that are defined in the `Dockerfile`using `ENV`, will be substituted by
 > the `Dockerfile` parser.
@@ -828,12 +828,12 @@ and marks it as holding externally mounted volumes from native host or other
 containers. The value can be a JSON array, `VOLUME ["/var/log/"]`, or a plain
 string with multiple arguments, such as `VOLUME /var/log` or `VOLUME /var/log
 /var/db`.  For more information/examples and mounting instructions via the
-Docker client, refer to 
+Docker client, refer to
 [*Share Directories via Volumes*](/userguide/dockervolumes/#volume)
 documentation.
 
-The `docker run` command initializes the newly created volume with any data 
-that exists at the specified location within the base image. For example, 
+The `docker run` command initializes the newly created volume with any data
+that exists at the specified location within the base image. For example,
 consider the following Dockerfile snippet:
 
     FROM ubuntu
@@ -842,7 +842,7 @@ consider the following Dockerfile snippet:
     VOLUME /myvol
 
 This Dockerfile results in an image that causes `docker run`, to
-create a new mount point at `/myvol` and copy the  `greating` file 
+create a new mount point at `/myvol` and copy the  `greating` file
 into the newly created volume.
 
 > **Note**:
@@ -943,6 +943,27 @@ For example you might add something like this:
 > **Warning**: Chaining `ONBUILD` instructions using `ONBUILD ONBUILD` isn't allowed.
 
 > **Warning**: The `ONBUILD` instruction may not trigger `FROM` or `MAINTAINER` instructions.
+
+## NOCACHE
+
+    NOCACHE
+
+The `NOCACHE` instruction will turn off caching from that point forward
+in the Dockerfile processing. This is useful when a certain command needs
+to be executed every time even if the `docker build` command turns on
+caching.  For example, if you need to `git clone` the very latest version
+of a repository every time then that portion of your Dockerfile might look
+like:
+
+    NOCACHE
+    RUN git clone http://example.com/myrepo.git
+
+If caching is already turned off, e.g. via
+the `--no-cache` flag on the `docker build` command, then this instruction
+will have no effect. While the builder will no longer look in the cache
+as it processing the instructions, the cache will still be populated
+so that future builds (that have caching turned on) can still leverage
+this optimization.
 
 ## Dockerfile Examples
 

--- a/docs/sources/release-notes.md
+++ b/docs/sources/release-notes.md
@@ -18,6 +18,8 @@ For a complete list of patches, fixes, and other improvements, see the
 * [1.6] The Docker daemon will no longer ignore unknown commands
   while processing a `Dockerfile`. Instead it will generate an error and halt
   processing.
+* There is a new Dockerfile command called `NOCACHE` which will disable
+  caching from that point forward in the processing of the Dockerfile.
 * The Docker daemon has now supports for IPv6 networking between containers
   and on the `docker0` bridge. For more information see the
   [IPv6 networking reference](/articles/networking/#ipv6).


### PR DESCRIPTION
This adds a NOCACHE instruction to Dockerfiles which will disable all
caching from that point forward.  The cache is still populated, but the
look-up processing is disbled.

Closes #1996

Signed-off-by: Doug Davis dug@us.ibm.com
