### PR TITLE
[WIP] push/pull attach stdout/stderr of other pull/push

### DIFF
--- a/graph/pools_test.go
+++ b/graph/pools_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"io"
 	"testing"
 
 	"github.com/docker/docker/pkg/reexec"
@@ -10,25 +11,33 @@ func init() {
 	reexec.Init()
 }
 
+type testAttacher struct{}
+
+func (a *testAttacher) Attach(out, err io.Writer) {
+	return
+}
+
 func TestPools(t *testing.T) {
 	s := &TagStore{
-		pullingPool: make(map[string]chan struct{}),
-		pushingPool: make(map[string]chan struct{}),
+		pullingPool: make(map[string]Attacher),
+		pushingPool: make(map[string]Attacher),
 	}
 
-	if _, err := s.poolAdd("pull", "test1"); err != nil {
+	attacher := &testAttacher{}
+
+	if _, err := s.poolAdd("pull", "test1", attacher); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.poolAdd("pull", "test2"); err != nil {
+	if _, err := s.poolAdd("pull", "test2", attacher); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.poolAdd("push", "test1"); err == nil || err.Error() != "pull test1 is already in progress" {
+	if _, err := s.poolAdd("push", "test1", attacher); err == nil || err.Error() != "pull test1 is already in progress" {
 		t.Fatalf("Expected `pull test1 is already in progress`")
 	}
-	if _, err := s.poolAdd("pull", "test1"); err == nil || err.Error() != "pull test1 is already in progress" {
+	if _, err := s.poolAdd("pull", "test1", attacher); err == nil || err.Error() != "pull test1 is already in progress" {
 		t.Fatalf("Expected `pull test1 is already in progress`")
 	}
-	if _, err := s.poolAdd("wait", "test3"); err == nil || err.Error() != "Unknown pool type" {
+	if _, err := s.poolAdd("wait", "test3", attacher); err == nil || err.Error() != "Unknown pool type" {
 		t.Fatalf("Expected `Unknown pool type`")
 	}
 	if err := s.poolRemove("pull", "test2"); err != nil {

--- a/graph/push.go
+++ b/graph/push.go
@@ -489,7 +489,11 @@ func (s *TagStore) CmdPush(job *engine.Job) engine.Status {
 	job.GetenvJson("authConfig", authConfig)
 	job.GetenvJson("metaHeaders", &metaHeaders)
 
-	if _, err := s.poolAdd("push", repoInfo.LocalName); err != nil {
+	if j, err := s.poolAdd("push", repoInfo.LocalName, job); err != nil {
+		if j != nil {
+			j.Attach(job.Stdout, job.Stderr)
+			return engine.StatusOK
+		}
 		return job.Error(err)
 	}
 	defer s.poolRemove("push", repoInfo.LocalName)


### PR DESCRIPTION
Fixes #8385

When there is already a push/pull in progress for an image, instead of
just reporting "another client is already ...", attach to the
stdout/stderr of the other job so push/pull progress is reported to new
client.

For example:

``` bash
docker pull debian:jessie &
docker pull debian:jessie
```

Both clients will have the pull progress reported instead of just the
first.
The example is contrived, but illustrates when two clients are trying to
pull the same image.
