### PR TITLE
Show err msg on empty 'scratch' Dockerfile

### DIFF
--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -163,7 +163,7 @@ func (b *Builder) Run(context io.Reader) (string, error) {
 	}
 
 	if b.image == "" {
-		return "", fmt.Errorf("No image was generated. Is your Dockerfile empty?\n")
+		return "", fmt.Errorf("No image was generated. Is your Dockerfile empty?")
 	}
 
 	fmt.Fprintf(b.OutStream, "Successfully built %s\n", utils.TruncateID(b.image))

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4870,3 +4870,15 @@ func TestBuildMissingArgs(t *testing.T) {
 
 	logDone("build - verify missing args")
 }
+
+func TestBuildEmptyScratch(t *testing.T) {
+	defer deleteImages("sc")
+	_, out, err := buildImageWithOut("sc", "FROM scratch", true)
+	if err == nil {
+		t.Fatalf("Build was supposed to fail")
+	}
+	if !strings.Contains(out, "No image was generated") {
+		t.Fatalf("Wrong error message: %v", out)
+	}
+	logDone("build - empty scratch Dockerfile")
+}


### PR DESCRIPTION
If you have a Dockefile with just:

```
   FROM scratch
```

An error is generated but its never shown to the CLI. This PR fixes that.

Signed-off-by: Doug Davis dug@us.ibm.com
