### PR TITLE
Update the trust graph only when pulling an official image

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -73,9 +73,11 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 	}
 
 	if len(repoInfo.Index.Mirrors) == 0 && ((repoInfo.Official && repoInfo.Index.Official) || endpoint.Version == registry.APIVersion2) {
-		j := job.Eng.Job("trust_update_base")
-		if err = j.Run(); err != nil {
-			log.Errorf("error updating trust base graph: %s", err)
+		if repoInfo.Official {
+			j := job.Eng.Job("trust_update_base")
+			if err = j.Run(); err != nil {
+				log.Errorf("error updating trust base graph: %s", err)
+			}
 		}
 
 		log.Debugf("pulling v2 repository with local name %q", repoInfo.LocalName)


### PR DESCRIPTION
The trust graph currently pulls the keys needed to verify official images. For non-official images this graph check is useless. To avoid hitting the key statement url when pulling from private v2 registries, restrict the check to official image pulls.
