### PR TITLE
Use gpg from our server if keyserver is down

### DIFF
--- a/docs/sources/articles/dsc.md
+++ b/docs/sources/articles/dsc.md
@@ -43,7 +43,7 @@ More detailed usage information can be found at
 The Docker installation configuration is equivalent to running:
 
 ```
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys\
+apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys\
 36A1D7869245C8950F966E92D8576A8BA88D21E9
 sh -c "echo deb https://get.docker.com/ubuntu docker main\
 > /etc/apt/sources.list.d/docker.list"

--- a/docs/sources/examples/mongodb.md
+++ b/docs/sources/examples/mongodb.md
@@ -59,7 +59,7 @@ a MongoDB repository file for the package manager.
 
     # Installation:
     # Import MongoDB public GPG key AND create a MongoDB list file
-    RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+    RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv 7F0CEB10
     RUN echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/10gen.list
 
 After this initial preparation we can update our packages and install MongoDB.

--- a/docs/sources/examples/mongodb/Dockerfile
+++ b/docs/sources/examples/mongodb/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER Docker
 
 # Installation:
 # Import MongoDB public GPG key AND create a MongoDB list file
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv 7F0CEB10
 RUN echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/10gen.list
 
 # Update apt-get sources AND install MongoDB

--- a/docs/sources/examples/postgresql_service.Dockerfile
+++ b/docs/sources/examples/postgresql_service.Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER SvenDowideit@docker.com
 
 # Add the PostgreSQL PGP key to verify their Debian packages.
 # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc 
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
 # Add PostgreSQL's repository. It contains the most recent stable release
 #     of PostgreSQL, ``9.3``.

--- a/docs/sources/examples/postgresql_service.md
+++ b/docs/sources/examples/postgresql_service.md
@@ -29,7 +29,7 @@ Start by creating a new `Dockerfile`:
 
     # Add the PostgreSQL PGP key to verify their Debian packages.
     # It should be the same key as https://www.postgresql.org/media/keys/ACCC4CF8.asc
-    RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
+    RUN apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
     # Add PostgreSQL's repository. It contains the most recent stable release
     #     of PostgreSQL, ``9.3``.

--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -55,7 +55,7 @@ should exist. If it doesn't, you need to install the package
 
 Then, add the Docker repository key to your local keychain.
 
-    $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+    $ sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
 Add the Docker repository to your apt sources list, update and install
 the `lxc-docker` package.
@@ -147,7 +147,7 @@ should exist. If it doesn't, you need to install the package
 
 Then, add the Docker repository key to your local keychain.
 
-    $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+    $ sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
 Add the Docker repository to your apt sources list, update and install
 the `lxc-docker` package.
@@ -203,7 +203,7 @@ Docker is available as a Debian package, which makes installation easy.
 
 First add the Docker repository key to your local keychain.
 
-    $ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+    $ sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
 
 Add the Docker repository to your apt sources list, update and install
 the `lxc-docker` package.

--- a/project/install.sh
+++ b/project/install.sh
@@ -161,9 +161,9 @@ case "$lsb_dist" in
 		(
 			set -x
 			if [ "https://get.docker.com/" = "$url" ]; then
-				$sh_c "apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
+				$sh_c "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
 			elif [ "https://test.docker.com/" = "$url" ]; then
-				$sh_c "apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 740B314AE3941731B942C66ADF4FD13717AAD7D6"
+				$sh_c "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 740B314AE3941731B942C66ADF4FD13717AAD7D6"
 			else
 				$sh_c "$curl ${url}gpg | apt-key add -"
 			fi

--- a/project/release.sh
+++ b/project/release.sh
@@ -292,7 +292,7 @@ fi
 echo deb $(s3_url)/ubuntu docker main > /etc/apt/sources.list.d/docker.list
 
 # Then import the repository key
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $gpgFingerprint
+apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys $gpgFingerprint
 
 # Install docker
 apt-get update


### PR DESCRIPTION
Make the install script independent from the ubuntu keyserver by allowing fallback to `${url}/gpg` on failure.

As usual, I did my best with my little knowledge of Bash scripting (which I definitely intend to improve):
- It seems `|| key_installed=$?` is the idiomatic way to get a command exit code in the context of `set -e`.
- I don't understand the use of `$sh_c "apt-key ...` over the more simple `apt-key ...`, so I kept it as was.

Ping @tianon!
