### PR TITLE
Change emptyfs path in integration-cli tests

### DIFF
--- a/project/make/.ensure-emptyfs
+++ b/project/make/.ensure-emptyfs
@@ -5,7 +5,8 @@ if ! docker inspect emptyfs &> /dev/null; then
 	# let's build a "docker save" tarball for "emptyfs"
 	# see https://github.com/docker/docker/pull/5262
 	# and also https://github.com/docker/docker/issues/4242
-	dir="$(mktemp -d)"
+	dir="$DEST/emptyfs"
+	mkdir -p "$dir"
 	(
 		cd "$dir"
 		echo '{"emptyfs":{"latest":"511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158"}}' > repositories


### PR DESCRIPTION
This fixes the build break in Jenkins Windows CI tests and
fixes TestInspectImage for Windows CLI.

Since `mktemp -d` doesn't come with MSYSGIT, this was breaking
the Jenkins build for a while now.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
Label: `#windows`
cc: @tianon @jfrazelle @unclejack @tiborvass @sachin-jayant-joshi
