### PR TITLE
Added -allow-insecure flag for docker push/pull

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1191,6 +1191,7 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 
 func (cli *DockerCli) CmdPush(args ...string) error {
 	cmd := cli.Subcmd("push", "NAME[:TAG]", "Push an image or a repository to the registry", true)
+	allowInsecure := cmd.Bool([]string{"i", "-insecure-registry"}, false, "Allow communication with insecure registries")
 	cmd.Require(flag.Exact, 1)
 
 	utils.ParseFlags(cmd, args, true)
@@ -1223,6 +1224,10 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 	v := url.Values{}
 	v.Set("tag", tag)
 
+	if *allowInsecure {
+		v.Set("allowInsecure", "1")
+	}
+
 	push := func(authConfig registry.AuthConfig) error {
 		buf, err := json.Marshal(authConfig)
 		if err != nil {
@@ -1254,6 +1259,7 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 func (cli *DockerCli) CmdPull(args ...string) error {
 	cmd := cli.Subcmd("pull", "NAME[:TAG]", "Pull an image or a repository from the registry", true)
 	allTags := cmd.Bool([]string{"a", "-all-tags"}, false, "Download all tagged images in the repository")
+	allowInsecure := cmd.Bool([]string{"i", "-insecure-registry"}, false, "Allow communication with insecure registries")
 	cmd.Require(flag.Exact, 1)
 
 	utils.ParseFlags(cmd, args, true)
@@ -1272,6 +1278,10 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 	}
 
 	v.Set("fromImage", newRemote)
+
+	if *allowInsecure {
+		v.Set("allowInsecure", "1")
+	}
 
 	// Resolve the Repository name from fqn to RepositoryInfo
 	repoInfo, err := registry.ParseRepositoryInfo(taglessRemote)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -564,6 +564,7 @@ func postImagesCreate(eng *engine.Engine, version version.Version, w http.Respon
 		job.SetenvBool("parallel", version.GreaterThan("1.3"))
 		job.SetenvJson("metaHeaders", metaHeaders)
 		job.SetenvJson("authConfig", authConfig)
+		job.SetenvBool("allowInsecure", r.FormValue("allowInsecure") == "1")
 	} else { //import
 		if tag == "" {
 			repo, tag = parsers.ParseRepositoryTag(repo)
@@ -655,6 +656,7 @@ func postImagesPush(eng *engine.Engine, version version.Version, w http.Response
 	job := eng.Job("push", vars["name"])
 	job.SetenvJson("metaHeaders", metaHeaders)
 	job.SetenvJson("authConfig", authConfig)
+	job.SetenvBool("allowInsecure", r.FormValue("allowInsecure") == "1")
 	job.Setenv("tag", r.Form.Get("tag"))
 	if version.GreaterThan("1.0") {
 		job.SetenvBool("json", true)

--- a/docs/man/docker-pull.1.md
+++ b/docs/man/docker-pull.1.md
@@ -7,7 +7,7 @@ docker-pull - Pull an image or a repository from the registry
 # SYNOPSIS
 **docker pull**
 [**-a**|**--all-tags**[=*false*]]
-[**--help**] 
+[**--help**]
 NAME[:TAG]
 
 # DESCRIPTION
@@ -19,7 +19,9 @@ It is also possible to specify a non-default registry to pull from.
 
 # OPTIONS
 **-a**, **--all-tags**=*true*|*false*
-   Download all tagged images in the repository. The default is *false*.
+  Download all tagged images in the repository. The default is *false*.
+**-i**, **--insecure-registry**=*true*|*false*
+  Allow communication with insecure registries. The default is *false*.
 **--help**
   Print usage statement
 
@@ -51,9 +53,9 @@ It is also possible to specify a non-default registry to pull from.
 
     $ sudo docker pull registry.hub.docker.com/fedora:20
     Pulling repository fedora
-    3f2fed40e4b0: Download complete 
-    511136ea3c5a: Download complete 
-    fd241224e9cf: Download complete 
+    3f2fed40e4b0: Download complete
+    511136ea3c5a: Download complete
+    fd241224e9cf: Download complete
 
     Status: Downloaded newer image for registry.hub.docker.com/fedora:20
 

--- a/docs/man/docker-push.1.md
+++ b/docs/man/docker-push.1.md
@@ -10,12 +10,14 @@ docker-push - Push an image or a repository to the registry
 NAME[:TAG]
 
 # DESCRIPTION
-Push an image or a repository to a registry. The default registry is the Docker 
-Hub located at [hub.docker.com](https://hub.docker.com/). However the 
-image can be pushed to another, perhaps private, registry as demonstrated in 
+Push an image or a repository to a registry. The default registry is the Docker
+Hub located at [hub.docker.com](https://hub.docker.com/). However the
+image can be pushed to another, perhaps private, registry as demonstrated in
 the example below.
 
 # OPTIONS
+**-i**, **--insecure-registry**=*true*|*false*
+  Allow communication with insecure registries. The default is *false*.
 **--help**
   Print usage statement
 

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -1124,6 +1124,7 @@ Query Parameters:
 -   **repo** – repository
 -   **tag** – tag
 -   **registry** – the registry to pull from
+-   **allowInsecure** – 1/True/true or 0/False/false, default false
 
     Request Headers:
 
@@ -1252,6 +1253,7 @@ Push the image `name` on the registry
 Query Parameters:
 
 -   **tag** – the tag to associate with the image on the registry, optional
+-   **allowInsecure** – 1/True/true or 0/False/false, default false
 
 Request Headers:
 

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -24,11 +24,12 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 	}
 
 	var (
-		localName   = job.Args[0]
-		tag         string
-		sf          = utils.NewStreamFormatter(job.GetenvBool("json"))
-		authConfig  = &registry.AuthConfig{}
-		metaHeaders map[string][]string
+		localName     = job.Args[0]
+		allowInsecure = job.GetenvBool("allowInsecure")
+		tag           string
+		sf            = utils.NewStreamFormatter(job.GetenvBool("json"))
+		authConfig    = &registry.AuthConfig{}
+		metaHeaders   map[string][]string
 	)
 
 	// Resolve the Repository name from fqn to RepositoryInfo
@@ -55,6 +56,10 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 		return job.Error(err)
 	}
 	defer s.poolRemove("pull", repoInfo.LocalName+":"+tag)
+
+	if allowInsecure {
+		repoInfo.Index.Secure = false
+	}
 
 	log.Debugf("pulling image from host %q with remote name %q", repoInfo.Index.Name, repoInfo.RemoteName)
 	endpoint, err := repoInfo.GetEndpoint()

--- a/graph/push.go
+++ b/graph/push.go
@@ -425,10 +425,11 @@ func (s *TagStore) CmdPush(job *engine.Job) engine.Status {
 		return job.Errorf("Usage: %s IMAGE", job.Name)
 	}
 	var (
-		localName   = job.Args[0]
-		sf          = utils.NewStreamFormatter(job.GetenvBool("json"))
-		authConfig  = &registry.AuthConfig{}
-		metaHeaders map[string][]string
+		localName     = job.Args[0]
+		allowInsecure = job.GetenvBool("allowInsecure")
+		sf            = utils.NewStreamFormatter(job.GetenvBool("json"))
+		authConfig    = &registry.AuthConfig{}
+		metaHeaders   map[string][]string
 	)
 
 	// Resolve the Repository name from fqn to RepositoryInfo
@@ -445,6 +446,10 @@ func (s *TagStore) CmdPush(job *engine.Job) engine.Status {
 		return job.Error(err)
 	}
 	defer s.poolRemove("push", repoInfo.LocalName)
+
+	if allowInsecure {
+		repoInfo.Index.Secure = false
+	}
 
 	endpoint, err := repoInfo.GetEndpoint()
 	if err != nil {


### PR DESCRIPTION
This PR addresses the commonly requested feature of allowing communication with insecure registries at runtime discussed at #8887 and #10027. The flag `-allow-insecure` is added to `docker {pull,push}`. Documentation and unit tests will be done shortly.
