### PR TITLE
Create builder/command, cut libcontainer dependency on integration-cli

### DIFF
--- a/builder/command/command.go
+++ b/builder/command/command.go
@@ -1,0 +1,37 @@
+// This package contains the set of Dockerfile commands.
+package command
+
+const (
+	Env        = "env"
+	Maintainer = "maintainer"
+	Add        = "add"
+	Copy       = "copy"
+	From       = "from"
+	Onbuild    = "onbuild"
+	Workdir    = "workdir"
+	Run        = "run"
+	Cmd        = "cmd"
+	Entrypoint = "entrypoint"
+	Expose     = "expose"
+	Volume     = "volume"
+	User       = "user"
+	Insert     = "insert"
+)
+
+// Commands is list of all Dockerfile commands
+var Commands = []string{
+	Env,
+	Maintainer,
+	Add,
+	Copy,
+	From,
+	Onbuild,
+	Workdir,
+	Run,
+	Cmd,
+	Entrypoint,
+	Expose,
+	Volume,
+	User,
+	Insert,
+}

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+
+	"github.com/docker/docker/builder/command"
 )
 
 // Node is a structure used to represent a parse tree.
@@ -44,20 +46,20 @@ func init() {
 	// functions. Errors are propagated up by Parse() and the resulting AST can
 	// be incorporated directly into the existing AST as a next.
 	dispatch = map[string]func(string) (*Node, map[string]bool, error){
-		"user":       parseString,
-		"onbuild":    parseSubCommand,
-		"workdir":    parseString,
-		"env":        parseEnv,
-		"maintainer": parseString,
-		"from":       parseString,
-		"add":        parseMaybeJSONToList,
-		"copy":       parseMaybeJSONToList,
-		"run":        parseMaybeJSON,
-		"cmd":        parseMaybeJSON,
-		"entrypoint": parseMaybeJSON,
-		"expose":     parseStringsWhitespaceDelimited,
-		"volume":     parseMaybeJSONToList,
-		"insert":     parseIgnore,
+		command.User:       parseString,
+		command.Onbuild:    parseSubCommand,
+		command.Workdir:    parseString,
+		command.Env:        parseEnv,
+		command.Maintainer: parseString,
+		command.From:       parseString,
+		command.Add:        parseMaybeJSONToList,
+		command.Copy:       parseMaybeJSONToList,
+		command.Run:        parseMaybeJSON,
+		command.Cmd:        parseMaybeJSON,
+		command.Entrypoint: parseMaybeJSON,
+		command.Expose:     parseStringsWhitespaceDelimited,
+		command.Volume:     parseMaybeJSONToList,
+		command.Insert:     parseIgnore,
 	}
 }
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -19,7 +19,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/docker/docker/builder"
+	"github.com/docker/docker/builder/command"
 	"github.com/docker/docker/pkg/archive"
 )
 
@@ -4828,7 +4828,6 @@ func TestBuildMissingArgs(t *testing.T) {
 	// Test to make sure that all Dockerfile commands (except the ones listed
 	// in skipCmds) will generate an error if no args are provided.
 	// Note: INSERT is deprecated so we exclude it because of that.
-
 	skipCmds := map[string]struct{}{
 		"CMD":        {},
 		"RUN":        {},
@@ -4838,15 +4837,13 @@ func TestBuildMissingArgs(t *testing.T) {
 
 	defer deleteAllContainers()
 
-	for cmd := range builder.EvaluateTable {
-		var dockerfile string
-
+	for _, cmd := range command.Commands {
 		cmd = strings.ToUpper(cmd)
-
 		if _, ok := skipCmds[cmd]; ok {
 			continue
 		}
 
+		var dockerfile string
 		if cmd == "FROM" {
 			dockerfile = cmd
 		} else {


### PR DESCRIPTION
#10561 (d1e9d07c) introduces a dependency to libcontainer and other daemon related packages through builder package in integration-cli tests. The only thing test needs is set of the Dockerfile commands. Extracting them to a separate

package: `builder/commands`.

This was causing CI tests to not to compile on non-Linux platforms due to indirect dependency to libcontainer from CLI test code. (Example: https://jenkins.dockerproject.com/job/Windows-PRs/2/console)

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com

Label: `#windows`
Cc: @duglin @tiborvass @erikh @unclejack
