### PR TITLE
api/server: don't print warning if serving on localhost

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1554,8 +1554,8 @@ func allocateDaemonPort(addr string) error {
 }
 
 func setupTcpHttp(addr string, job *engine.Job) (*HttpServer, error) {
-	if !strings.HasPrefix(addr, "127.0.0.1") && !job.GetenvBool("TlsVerify") {
-		log.Infof("/!\\ DON'T BIND ON ANOTHER IP ADDRESS THAN 127.0.0.1 IF YOU DON'T KNOW WHAT YOU'RE DOING /!\\")
+	if !job.GetenvBool("TlsVerify") {
+		log.Infof("/!\\ DON'T BIND ON ANY IP ADDRESS WITHOUT setting -tlsverify IF YOU DON'T KNOW WHAT YOU'RE DOING /!\\")
 	}
 
 	r := createRouter(job.Eng, job.GetenvBool("Logging"), job.GetenvBool("EnableCors"), job.Getenv("Version"))


### PR DESCRIPTION
Fixes bug #10728

Docker-DCO-1.1-Signed-off-by: Matt Williams lp@mattyw.net (github: mattyw)
