### PR TITLE
Do not use HTTP_PROXY for unix sock

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -155,7 +155,6 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, keyFile string, proto, a
 
 	// The transport is created here for reuse during the client session
 	tr := &http.Transport{
-		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: tlsConfig,
 	}
 
@@ -168,6 +167,7 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, keyFile string, proto, a
 			return net.DialTimeout(proto, addr, timeout)
 		}
 	} else {
+		tr.Proxy = http.ProxyFromEnvironment
 		tr.Dial = (&net.Dialer{Timeout: timeout}).Dial
 	}
 

--- a/integration-cli/docker_cli_proxy_test.go
+++ b/integration-cli/docker_cli_proxy_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"net"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCliProxyDisableProxyUnixSock(t *testing.T) {
+	cmd := exec.Command(dockerBinary, "info")
+	cmd.Env = []string{"HTTP_PROXY=http://127.0.0.1:9999"}
+
+	if out, _, err := runCommandWithOutput(cmd); err != nil {
+		t.Fatal(err, out)
+	}
+
+	logDone("cli proxy - HTTP_PROXY is not used when connecting to unix sock")
+}
+
+// Can't use localhost here since go has a special case to not use proxy if connecting to localhost
+// See http://golang.org/pkg/net/http/#ProxyFromEnvironment
+func TestCliProxyProxyTCPSock(t *testing.T) {
+	// get the IP to use to connect since we can't use localhost
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var ip string
+	for _, addr := range addrs {
+		sAddr := addr.String()
+		if !strings.Contains(sAddr, "127.0.0.1") {
+			addrArr := strings.Split(sAddr, "/")
+			ip = addrArr[0]
+			break
+		}
+	}
+
+	if ip == "" {
+		t.Fatal("could not find ip to connect to")
+	}
+
+	d := NewDaemon(t)
+	if err := d.Start("-H", "tcp://"+ip+":2375"); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(dockerBinary, "info")
+	cmd.Env = []string{"DOCKER_HOST=tcp://" + ip + ":2375", "HTTP_PROXY=127.0.0.1:9999"}
+	if out, _, err := runCommandWithOutput(cmd); err == nil {
+		t.Fatal(err, out)
+	}
+
+	// Test with no_proxy
+	cmd.Env = append(cmd.Env, "NO_PROXY="+ip)
+	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "info")); err != nil {
+		t.Fatal(err, out)
+	}
+
+	logDone("cli proxy - HTTP_PROXY is used for TCP sock")
+}


### PR DESCRIPTION
Makes sure the CLI does not use HTTP_PROXY when connecting to unix
socket.
Also adds some tests to make sure this functionality works as expected.

Found that the ProxyFromEnvironment already has a special case to not proxy when connecting to localhost. So I think it makes sense to also not proxy when connecting over a unix socket.
