### PR TITLE
Mounting a dir of devices like /dev/snd should mount all child devices

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -173,3 +173,30 @@ func TestRunContainerWithCgroupParentAbsPath(t *testing.T) {
 
 	logDone("run - cgroup parent with absolute cgroup path")
 }
+
+func TestRunDeviceDirectory(t *testing.T) {
+	defer deleteAllContainers()
+	cmd := exec.Command(dockerBinary, "run", "--device", "/dev/snd:/dev/snd", "busybox", "sh", "-c", "ls /dev/snd/")
+
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	if actual := strings.Trim(out, "\r\n"); !strings.Contains(out, "timer") {
+		t.Fatalf("expected output /dev/snd/timer, received %s", actual)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--device", "/dev/snd:/dev/othersnd", "busybox", "sh", "-c", "ls /dev/othersnd/")
+
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+
+	if actual := strings.Trim(out, "\r\n"); !strings.Contains(out, "seq") {
+		t.Fatalf("expected output /dev/othersnd/timer, received %s", actual)
+	}
+
+	logDone("run - test --device directory mounts all internal devices")
+}


### PR DESCRIPTION
Mounting a directory of devices like /dev/snd should mount all child devices.

I have seen a lot of people try to do this and reach out to me on how to mount
/dev/snd because it is returning "not a device node". The docs imply you can
_just_ mount /dev/snd and that is not the case. This fixes that. It also allows
for coolness if you want to mount say /dev/usb.
