### PR TITLE
TestGetContainersAttachWebsocket: use DOCKER_TEST_HOST if specified

### DIFF
--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"bytes"
-	"net"
 	"os/exec"
 	"testing"
+	"time"
 
 	"code.google.com/p/go.net/websocket"
 )
@@ -17,7 +17,7 @@ func TestGetContainersAttachWebsocket(t *testing.T) {
 	}
 	defer deleteAllContainers()
 
-	rwc, err := net.Dial("unix", "/var/run/docker.sock")
+	rwc, err := sockConn(time.Duration(10 * time.Second))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
TestGetContainersAttachWebsocket is currently broken on Windows CI tests b/c it has hardcoded unix://var/run/docker.sock. (introduced in #10153.) This change makes use of @icecrime's code in docker_utils and generalizes it with sockConn() to provide a net.Conn by making use of DOCKER_TEST_HOST. 

Also fixes the test TestGetContainersAttachWebsocket on windows/darwin.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
Label: `#windows`
Cc: @acbodine @tiborvass @icecrime @unclejack @jfrazelle 
