### PR TITLE
avoid extra loop layer if data or metadata is already a blk device (or symlink to)

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -189,6 +189,17 @@ func (devices *DeviceSet) hasImage(name string) bool {
 	return err == nil
 }
 
+func (devices *DeviceSet) checkImage(name string) (exists, isblk bool, filename string) {
+	dirname := devices.loopbackDir()
+	filename = path.Join(dirname, name)
+	fi, err := os.Stat(filename)
+	if err != nil {
+		return false, false, ""
+	}
+	isblk = fi.Sys().(*syscall.Stat_t).Mode&syscall.S_IFBLK == syscall.S_IFBLK
+	return
+}
+
 // ensureImage creates a sparse file of <size> bytes at the path
 // <root>/devicemapper/<name>.
 // If the file already exists, it does nothing.
@@ -1014,10 +1025,13 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 			metadataFile *os.File
 		)
 
+		hasData, isBlk, filename := devices.checkImage("data")
+		if devices.dataDevice == "" && isBlk {
+			devices.dataDevice = filename
+		}
+
 		if devices.dataDevice == "" {
 			// Make sure the sparse images exist in <root>/devicemapper/data
-
-			hasData := devices.hasImage("data")
 
 			if !doInit && !hasData {
 				return errors.New("Loopback data file not found")
@@ -1047,10 +1061,13 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 		}
 		defer dataFile.Close()
 
+		hasMetadata, isBlk, filename := devices.checkImage("metadata")
+		if devices.metadataDevice == "" && isBlk {
+			devices.metadataDevice = filename
+		}
+
 		if devices.metadataDevice == "" {
 			// Make sure the sparse images exist in <root>/devicemapper/metadata
-
-			hasMetadata := devices.hasImage("metadata")
 
 			if !doInit && !hasMetadata {
 				return errors.New("Loopback metadata file not found")


### PR DESCRIPTION
Request For Comments:

From Jerome's this blog entry, I have seen a lot of docker deployment
creating "data" as a symlink to the real block device, this is wrong,
devicemapper driver has provided "--storage-opt dm.datadev=..." for them
to use, but why not detect this and provide them convenience?
http://jpetazzo.github.io/2014/01/29/docker-device-mapper-resize/

In this patch the checkImage is trying to detect that and skip setting up
loop layer if it's already a block device;

Without this patch (or explicit dm.datadev option), with data as symlink
the extra loop for that block device is involved, it's superfluous and
sometimes cause a lot of problems, since loop is opening underlying block
device in raw blk device and as time goes on, the kernel put more and more
memory into Buffers instead of Cache, those Buffers are treated differently
from kernel VFS's point of view and not easily reclaimable, may trigger
oom-killer in some cases,

```
-bash-4.2$ sudo losetup -a
/dev/loop0: [0005]:16512 (/dev/dm-2)
/dev/loop1: [64768]:2492172 (/var/lib/docker/devicemapper/devicemapper/metadata)
-bash-4.2$ free -m
             total       used       free     shared    buffers     cached
Mem:         48094      46081       2012         40      40324       2085
-/+ buffers/cache:       3671      44422
Swap:         8191          5       8186
```

Cc: Jerome Petazzoni jerome@docker.com
Signed-off-by: Derek Che drc@yahoo-inc.com
