### PR TITLE
TestBuildAddTarXz(Gz): call xz with '-k' due to bug

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3877,7 +3877,7 @@ func TestBuildAddTarXz(t *testing.T) {
 		if err := tw.Close(); err != nil {
 			t.Fatalf("failed to close tar archive: %v", err)
 		}
-		xzCompressCmd := exec.Command("xz", "test.tar")
+		xzCompressCmd := exec.Command("xz", "-k", "test.tar")
 		xzCompressCmd.Dir = tmpDir
 		out, _, err := runCommandWithOutput(xzCompressCmd)
 		if err != nil {
@@ -3930,7 +3930,7 @@ func TestBuildAddTarXzGz(t *testing.T) {
 			t.Fatalf("failed to close tar archive: %v", err)
 		}
 
-		xzCompressCmd := exec.Command("xz", "test.tar")
+		xzCompressCmd := exec.Command("xz", "-k", "test.tar")
 		xzCompressCmd.Dir = tmpDir
 		out, _, err := runCommandWithOutput(xzCompressCmd)
 		if err != nil {


### PR DESCRIPTION
TestBuildAddTarXz/TestBuildAddTarXzGz make exec calls like
'cd %SOME_TEMP_DIR%; xz test.gz' but this fails when called
from integration-cli tests (doesn't fail from msys or cmd shell)
when executed on Windows.

It fails with error: "xz: test.tar: Cannot remove: Permission denied."
Proposing workaround of using the `xz --keep` argument since keeping
test.tar is harmless and it's already in os.TempDir().

If anybody volunteers to see what's going on, console log is here: 
https://jenkins.dockerproject.com/job/Windows-PRs/31/console
I can repro this as well but can't exactly figure out why it happens
only when it's called via `go test`.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
Label: `#windows`
Cc: @jfrazelle @unclejack @tiborvass 
