### PR TITLE
Fix check-config.sh usage

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -14,7 +14,7 @@ possibleConfigs=(
 if [ $# -gt 0 ]; then
 	CONFIG="$1"
 else
-	CONFIG="${possibleConfigs[0]}"
+	: ${CONFIG:="${possibleConfigs[0]}"}
 fi
 
 if ! command -v zgrep &> /dev/null; then
@@ -94,7 +94,7 @@ if [ ! -e "$CONFIG" ]; then
 	if [ ! -e "$CONFIG" ]; then
 		wrap_warning "error: cannot find kernel config"
 		wrap_warning "  try running this script again, specifying the kernel config:"
-		wrap_warning "    CONFIG=/path/to/kernel/.config $0"
+		wrap_warning "    CONFIG=/path/to/kernel/.config $0 or $0 /path/to/kernel/.config"
 		exit 1
 	fi
 fi


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Before PR https://github.com/docker/docker/pull/10300 mergerd
The way to specify a path of CONFIG is 
`CONFIG=/path/to/kernel/.config ./check-config.sh`
see https://github.com/docker/docker/blob/master/contrib/check-config.sh#L97

PR https://github.com/docker/docker/pull/1030 add args support which is good to use,
but the previous usage can't work anymore and the help message still show the 
previous usage when possible config file is not found which will misleading the user.

 The this patch support the both two way of specifying  a CONFIG file and fix the usage message.

If we want to only support the usage of  `./check-config.sh /path/to/kernel/.config`, I'll
update the PR to just fix the usage message.
