### PR TITLE
mkimage-alpine.sh: Allow to change ARCH from the environment

### DIFF
--- a/contrib/mkimage-alpine.sh
+++ b/contrib/mkimage-alpine.sh
@@ -72,7 +72,7 @@ REL=${REL:-edge}
 MIRROR=${MIRROR:-http://nl.alpinelinux.org/alpine}
 SAVE=${SAVE:-0}
 REPO=$MIRROR/$REL/main
-ARCH=$(uname -m)
+ARCH=${ARCH:-$(uname -m)}
 
 tmp
 getapk


### PR DESCRIPTION
It is more convenient to be able to change the automatically resolved ARCH variable

On Armada XP processors, `uname -m` returns `armv7l` and the corresponding alpine ARCH on their repository is `armhf`.

You can also want to build a `x86` alpine image on a `x86_64` server.
