### PR TITLE
Allow pulling stats once and disconnecting.

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -611,7 +611,7 @@ func (s *Server) getContainersStats(eng *engine.Engine, version version.Version,
 		return fmt.Errorf("Missing parameter")
 	}
 
-	return s.daemon.ContainerStats(vars["name"], utils.NewWriteFlusher(w))
+	return s.daemon.ContainerStats(vars["name"], boolValue(r, "stream"), utils.NewWriteFlusher(w))
 }
 
 func (s *Server) getContainersLogs(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1003,7 +1003,7 @@ _docker_start() {
 _docker_stats() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--no-stream --help" -- "$cur" ) )
 			;;
 		*)
 			__docker_containers_running

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -16,7 +16,7 @@
 
 function __fish_docker_no_subcommand --description 'Test if docker has yet to be given the subcommand'
     for i in (commandline -opc)
-        if contains -- $i attach build commit cp create diff events exec export history images import info inspect kill load login logout logs pause port ps pull push rename restart rm rmi run save search start stop tag top unpause version wait
+        if contains -- $i attach build commit cp create diff events exec export history images import info inspect kill load login logout logs pause port ps pull push rename restart rm rmi run save search start stop tag top unpause version wait stats
             return 1
         end
     end
@@ -361,6 +361,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from start' -a '(__fish_prin
 # stats
 complete -c docker -f -n '__fish_docker_no_subcommand' -a stats -d "Display a live stream of one or more containers' resource usage statistics"
 complete -c docker -A -f -n '__fish_seen_subcommand_from stats' -l help -d 'Print usage'
+complete -c docker -A -f -n '__fish_seen_subcommand_from stats' -l no-stream -d 'Disable streaming stats and only pull the first result'
 complete -c docker -A -f -n '__fish_seen_subcommand_from stats' -a '(__fish_print_docker_containers running)' -d "Container"
 
 # stop

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -326,6 +326,7 @@ __docker_subcommand () {
             ;;
         (stats)
             _arguments \
+                '--no-stream[Disable streaming stats and only pull the first result]' \
                 '*:containers:__docker_runningcontainers'
             ;;
         (rm)

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/libcontainer/cgroups"
 )
 
-func (daemon *Daemon) ContainerStats(name string, out io.Writer) error {
+func (daemon *Daemon) ContainerStats(name string, stream bool, out io.Writer) error {
 	updates, err := daemon.SubscribeToContainerStats(name)
 	if err != nil {
 		return err
@@ -26,6 +26,9 @@ func (daemon *Daemon) ContainerStats(name string, out io.Writer) error {
 			// TODO: handle the specific broken pipe
 			daemon.UnsubscribeToContainerStats(name, updates)
 			return err
+		}
+		if !stream {
+			break
 		}
 	}
 	return nil

--- a/docs/man/docker-stats.1.md
+++ b/docs/man/docker-stats.1.md
@@ -17,6 +17,9 @@ Display a live stream of one or more containers' resource usage statistics
 **--help**
   Print usage statement
 
+**--no-stream**="false"
+  Disable streaming stats and only pull the first result
+
 # EXAMPLES
 
 Run **docker stats** with multiple containers.

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -46,6 +46,11 @@ You can still call an old version of the API using
 
 ### What's new
 
+`GET /containers/(id)/stats`
+
+**New!**
+You can now supply a `stream` bool to get only one set of stats and
+disconnect
 
 ## v1.18
 

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -644,6 +644,10 @@ This endpoint returns a live stream of a container's resource usage statistics.
            }
         }
 
+Query Parameters:
+
+-   **stream** – 1/True/true or 0/False/false, pull stats once then disconnect. Default true
+
 Status Codes:
 
 -   **200** – no error

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -2377,6 +2377,7 @@ more details on finding shared images from the command line.
     Display a live stream of one or more containers' resource usage statistics
 
       --help=false       Print usage
+      --no-stream=false  Disable streaming stats and only pull the first result
 
 Running `docker stats` on multiple containers
 

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestCliStatsNoStream(c *check.C) {
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "busybox", "top"))
+	if err != nil {
+		c.Fatalf("Error on container creation: %v, output: %s", err, out)
+	}
+	id := strings.TrimSpace(out)
+	if err := waitRun(id); err != nil {
+		c.Fatalf("error waiting for container to start: %v", err)
+	}
+
+	statsCmd := exec.Command(dockerBinary, "stats", "--no-stream", id)
+	chErr := make(chan error)
+	go func() {
+		chErr <- statsCmd.Run()
+	}()
+
+	select {
+	case err := <-chErr:
+		if err != nil {
+			c.Fatalf("Error running stats: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		statsCmd.Process.Kill()
+		c.Fatalf("stats did not return immediately when not streaming")
+	}
+}


### PR DESCRIPTION
Adds a `once` query param to the stats API which allows API users to
only collect one stats entry and disconnect instead of keeping the
connection alive to stream more stats.

Open to changing the query param here... maybe have a "follow" param that defaults to true (since today we follow by default)?
I've seen several people wanting to just be able to grab and go instead of streaming... and then I saw: https://github.com/discourse/discourse_docker/commit/03b50438d73dbe6076a5a4179e336afaef2b28c2#commitcomment-9731330

Figure simple change on the Docker side so clients don't have to deal with it.
