### PR TITLE
Fix 'docker stats' help message

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2701,7 +2701,7 @@ func (s *containerStats) Display(w io.Writer) error {
 }
 
 func (cli *DockerCli) CmdStats(args ...string) error {
-	cmd := cli.Subcmd("stats", "CONTAINER", "Display a live stream of one or more containers' resource usage statistics", true)
+	cmd := cli.Subcmd("stats", "CONTAINER [CONTAINER...]", "Display a live stream of one or more containers' resource usage statistics", true)
 	cmd.Require(flag.Min, 1)
 	utils.ParseFlags(cmd, args, true)
 

--- a/docs/man/docker-stats.1.md
+++ b/docs/man/docker-stats.1.md
@@ -7,7 +7,7 @@ docker-stats - Display a live stream of one or more containers' resource usage s
 # SYNOPSIS
 **docker stats**
 [**--help**]
-[CONTAINERS]
+CONTAINER [CONTAINER...]
 
 # DESCRIPTION
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -2023,7 +2023,7 @@ more details on finding shared images from the command line.
 
 ## stats
 
-    Usage: docker stats [CONTAINERS]
+    Usage: docker stats CONTAINER [CONTAINER...]
 
     Display a live stream of one or more containers' resource usage statistics
 


### PR DESCRIPTION
It was missing the fact that you can pass in more than one container

Closes #10771

Signed-off-by: Doug Davis dug@us.ibm.com
