### PR TITLE
[WIP] Initial steps towards our own rpm.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update && apt-get install -y \
 	python-pip \
 	python-websocket \
 	reprepro \
+	rpm \
 	ruby1.9.1 \
 	ruby1.9.1-dev \
 	s3cmd=1.1.0* \

--- a/project/make.sh
+++ b/project/make.sh
@@ -58,6 +58,8 @@ DEFAULT_BUNDLES=(
 	cover
 	cross
 	tgz
+
+	package-rpm
 	ubuntu
 )
 

--- a/project/make/.packages
+++ b/project/make/.packages
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# helper scripts for creating package bundles
+PACKAGE_URL="http://www.docker.com/"
+PACKAGE_MAINTAINER="support@docker.com"
+PACKAGE_DESCRIPTION="Linux container runtime
+Docker complements LXC with a high-level API which operates at the process
+level. It runs unix processes with strong guarantees of isolation and
+repeatability across servers.
+Docker is a great building block for automating distributed systems:
+large-scale web deployments, database clusters, continuous deployment systems,
+private PaaS, service-oriented architectures, etc."
+PACKAGE_LICENSE="Apache-2.0"
+
+# Include our udev rules
+bundle_udev() {
+	mkdir -p $DIR/etc/udev/rules.d
+	cp contrib/udev/80-docker.rules $DIR/etc/udev/rules.d/
+}
+
+# Include our init scripts
+bundle_init() {
+	mkdir -p $DIR/etc/init
+	cp contrib/init/upstart/docker.conf $DIR/etc/init/
+	mkdir -p $DIR/etc/init.d
+	cp contrib/init/sysvinit-debian/docker $DIR/etc/init.d/
+	mkdir -p $DIR/etc/default
+	cp contrib/init/sysvinit-debian/docker.default $DIR/etc/default/docker
+	mkdir -p $DIR/lib/systemd/system
+	cp contrib/init/systemd/docker.{service,socket} $DIR/lib/systemd/system/
+}
+
+# Include contributed completions
+bundle_completions() {
+	mkdir -p $DIR/etc/bash_completion.d
+	cp contrib/completion/bash/docker $DIR/etc/bash_completion.d/
+	mkdir -p $DIR/usr/share/zsh/vendor-completions
+	cp contrib/completion/zsh/_docker $DIR/usr/share/zsh/vendor-completions/
+	mkdir -p $DIR/etc/fish/completions
+	cp contrib/completion/fish/docker.fish $DIR/etc/fish/completions/
+}
+
+# Include contributed man pages
+bundle_manpages() {
+	docs/man/md2man-all.sh -q
+	manRoot="$DIR/usr/share/man"
+	mkdir -p "$manRoot"
+	for manDir in docs/man/man?; do
+		manBase="$(basename "$manDir")" # "man1"
+		for manFile in "$manDir"/*; do
+			manName="$(basename "$manFile")" # "docker-build.1"
+			mkdir -p "$manRoot/$manBase"
+			gzip -c "$manFile" > "$manRoot/$manBase/$manName.gz"
+		done
+	done
+}

--- a/project/make/README.md
+++ b/project/make/README.md
@@ -5,7 +5,7 @@ They should not be called directly - instead, pass it as argument to make.sh, fo
 
 ```
 ./hack/make.sh test
-./hack/make.sh binary ubuntu
+./hack/make.sh binary package-rpm ubuntu
 
 # Or to run all bundles:
 ./hack/make.sh

--- a/project/make/package-rpm
+++ b/project/make/package-rpm
@@ -13,23 +13,15 @@ if [[ "$VERSION" == *-dev ]] || [ -n "$(git status --porcelain)" ]; then
 	PKGVERSION="$PKGVERSION~$GIT_VERSION"
 fi
 
-# $ dpkg --compare-versions 1.5.0 gt 1.5.0~rc1 && echo true || echo false
-# true
-# $ dpkg --compare-versions 1.5.0~rc1 gt 1.5.0~git20150128.112847.17e840a && echo true || echo false
-# true
-# $ dpkg --compare-versions 1.5.0~git20150128.112847.17e840a gt 1.5.0~dev~git20150128.112847.17e840a && echo true || echo false
-# true
-
-# ie, 1.5.0 > 1.5.0~rc1 > 1.5.0~git20150128.112847.17e840a > 1.5.0~dev~git20150128.112847.17e840a
-
+# probably shouldn't be using dpkg here...
 PACKAGE_ARCHITECTURE="$(dpkg-architecture -qDEB_HOST_ARCH)"
 
 # source the .packages file
 source "$(dirname "$BASH_SOURCE")/.packages"
 
-# Build docker as an ubuntu package using FPM and REPREPRO (sue me).
+# Build docker as a rpm package using FPM and REPREPRO (sue me).
 # bundle_binary must be called first.
-bundle_ubuntu() {
+bundle_rpm() {
 	DIR=$DEST/build
 
 	# include udev rules, contributed init, completions & man pages
@@ -65,8 +57,6 @@ else
 	_dh_action=start
 fi
 service docker $_dh_action 2>/dev/null || true
-
-#DEBHELPER#
 EOF
 	cat > $DEST/prerm <<'EOF'
 #!/bin/sh
@@ -74,8 +64,6 @@ set -e
 set -u
 
 service docker stop 2>/dev/null || true
-
-#DEBHELPER#
 EOF
 	cat > $DEST/postrm <<'EOF'
 #!/bin/sh
@@ -91,14 +79,12 @@ fi
 if [ -d /run/systemd/system ] ; then
 	systemctl --system daemon-reload > /dev/null || true
 fi
-
-#DEBHELPER#
 EOF
 	# TODO swaths of these were borrowed from debhelper's auto-inserted stuff, because we're still using fpm - we need to use debhelper instead, and somehow reconcile Ubuntu that way
 	chmod +x $DEST/postinst $DEST/prerm $DEST/postrm
 
 	(
-		# switch directories so we create *.deb in the right folder
+		# switch directories so we create *.rpm in the right folder
 		cd $DEST
 
 		# create lxc-docker-VERSION package
@@ -110,15 +96,10 @@ EOF
 			--architecture "$PACKAGE_ARCHITECTURE" \
 			--prefix / \
 			--depends iptables \
-			--deb-recommends aufs-tools \
-			--deb-recommends ca-certificates \
-			--deb-recommends git \
-			--deb-recommends xz-utils \
-			--deb-recommends 'cgroupfs-mount | cgroup-lite' \
 			--description "$PACKAGE_DESCRIPTION" \
 			--maintainer "$PACKAGE_MAINTAINER" \
 			--conflicts docker \
-			--conflicts docker.io \
+			--conflicts docker-io \
 			--conflicts lxc-docker-virtual-package \
 			--provides lxc-docker \
 			--provides lxc-docker-virtual-package \
@@ -127,12 +108,11 @@ EOF
 			--url "$PACKAGE_URL" \
 			--license "$PACKAGE_LICENSE" \
 			--config-files /etc/udev/rules.d/80-docker.rules \
-			--config-files /etc/init/docker.conf \
 			--config-files /etc/init.d/docker \
 			--config-files /etc/default/docker \
-			--deb-compression gz \
-			-t deb .
-		# TODO replace "Suggests: cgroup-lite" with "Recommends: cgroupfs-mount | cgroup-lite" once cgroupfs-mount is available
+			--rpm-compression gzip \
+			--epoch 0 \
+			-t rpm .
 
 		# create empty lxc-docker wrapper package
 		fpm -s empty \
@@ -143,8 +123,9 @@ EOF
 			--maintainer "$PACKAGE_MAINTAINER" \
 			--url "$PACKAGE_URL" \
 			--license "$PACKAGE_LICENSE" \
-			--deb-compression gz \
-			-t deb
+			--rpm-compression gzip \
+			--epoch 0 \
+			-t rpm
 	)
 
 	# clean up after ourselves so we have a clean output directory
@@ -152,4 +133,4 @@ EOF
 	rm -r $DIR
 }
 
-bundle_ubuntu
+bundle_rpm


### PR DESCRIPTION
This adds building an rpm to `make all`. It is the first steps towards our own
rpm package for docker.

Next steps would include, getting this in. Then adding the rpm to the release 
script to test.docker.com and get.docker.com. I didn't add this in this PR because
I thought having it first in `make all`, which jenkins runs on every PR, would be
a great first step. Then I can make the changes to the release script and install 
scripts.

@tianon feel free to rip this apart. I am sure the `$DEST/postinst $DEST/prerm $DEST/postrm`
scripts need some TLC, I am not as familiar with building rpms :D 

Common items I tried to move to a dotfile, much like how the others work.
