### PR TITLE
integration-cli: add const to skip daemon-requiring cli tests

### DIFF
--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -31,6 +31,8 @@ func TestLinksEtcHostsRegularFile(t *testing.T) {
 }
 
 func TestLinksEtcHostsContentMatch(t *testing.T) {
+	testRequires(t, SameHostDaemon)
+
 	runCmd := exec.Command(dockerBinary, "run", "--net=host", "busybox", "cat", "/etc/hosts")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -93,6 +95,8 @@ func TestLinksPingLinkedContainersAfterRename(t *testing.T) {
 }
 
 func TestLinksIpTablesRulesWhenLinkAndUnlink(t *testing.T) {
+	testRequires(t, SameHostDaemon)
+
 	dockerCmd(t, "run", "-d", "--name", "child", "--publish", "8080:80", "busybox", "sleep", "10")
 	dockerCmd(t, "run", "-d", "--name", "parent", "--link", "child:http", "busybox", "sleep", "10")
 
@@ -197,6 +201,8 @@ func TestLinksNotStartedParentNotFail(t *testing.T) {
 }
 
 func TestLinksHostsFilesInject(t *testing.T) {
+	testRequires(t, SameHostDaemon)
+
 	defer deleteAllContainers()
 
 	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-itd", "--name", "one", "busybox", "top"))
@@ -249,6 +255,8 @@ func TestLinksNetworkHostContainer(t *testing.T) {
 }
 
 func TestLinksUpdateOnRestart(t *testing.T) {
+	testRequires(t, SameHostDaemon)
+
 	defer deleteAllContainers()
 
 	if out, err := exec.Command(dockerBinary, "run", "-d", "--name", "one", "busybox", "top").CombinedOutput(); err != nil {

--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestNetworkNat(t *testing.T) {
+	testRequires(t, SameHostDaemon)
+
 	iface, err := net.InterfaceByName("eth0")
 	if err != nil {
 		t.Skipf("Test not running with `make test`. Interface eth0 not found: %s", err)

--- a/integration-cli/docker_test_vars_cli.go
+++ b/integration-cli/docker_test_vars_cli.go
@@ -1,0 +1,8 @@
+// +build !daemon
+
+package main
+
+const (
+	// tests should not assume daemon runs on the same machine as CLI
+	isLocalDaemon = false
+)

--- a/integration-cli/docker_test_vars_daemon.go
+++ b/integration-cli/docker_test_vars_daemon.go
@@ -1,0 +1,8 @@
+// +build daemon
+
+package main
+
+const (
+	// tests can assume daemon runs on the same machine as CLI
+	isLocalDaemon = true
+)

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+)
+
+type TestCondition func() bool
+
+type TestRequirement struct {
+	Condition   TestCondition
+	SkipMessage string
+}
+
+// List test requirements
+var (
+	SameHostDaemon = TestRequirement{
+		func() bool { return isLocalDaemon },
+		"Test requires docker daemon to runs on the same machine as CLI",
+	}
+)
+
+// testRequires checks if the environment satisfies the requirements
+// for the test to run or skips the tests.
+func testRequires(t *testing.T, requirements ...TestRequirement) {
+	for _, r := range requirements {
+		if !r.Condition() {
+			t.Skip(r.SkipMessage)
+		}
+	}
+}


### PR DESCRIPTION
If `DOCKER_CLIENTONLY` is set for `test-integration-cli`, we don't set the `daemon` build tag. `const isRemoteDaemon` will help us skip tests _which require daemon and cli to be running on the same machine_ without moving them to a separate file and accidentally lose track of them.

As a start I skipped some `TestLinks*` and `TestNetworkNat` tests. These are the ones verifying the functionality of the cli commands by examining its daemon-side side effects, and thus assume daemon is on the same machine with cli.

Doing such will disable them from being executed for windows/darwin CLIs but it will still run as a part of Linux tests. When Windows daemon starts to light up and can start to compile without `DOCKER_CLIENTONLY`, these tests will need to be fixed to verify things "the windows way".

I will be sending more test skips in this integration-cli suite as I go, this is just a beginning. :+1: 

Signed-off-by: Ahmet Alp Balkan ahmetb@microsoft.com
Label: `#windows`
Cc: @tianon @unclejack @jfrazelle @jhowardmsft @icecrime @swernli
