### PR TITLE
Add "deb-devscripts" Dockerfiles for building packages

### DIFF
--- a/contrib/deb-builder/README.md
+++ b/contrib/deb-builder/README.md
@@ -1,0 +1,5 @@
+# `dockercore/deb-builder`
+
+This image's tags contain the dependencies for building Docker `.deb`s for each of the Debian-based platforms Docker targets.
+
+To add new tags, see [`contrib/deb-builder` in https://github.com/docker/docker](https://github.com/docker/docker/tree/master/contrib/deb-builder), specifically the `generate.sh` script, whose usage is described in a comment at the top of the file.

--- a/contrib/deb-builder/debian-jessie/Dockerfile
+++ b/contrib/deb-builder/debian-jessie/Dockerfile
@@ -1,0 +1,2 @@
+FROM debian:jessie
+RUN apt-get update && apt-get install -y devscripts && rm -rf /var/lib/apt/lists/*

--- a/contrib/deb-builder/debian-wheezy/Dockerfile
+++ b/contrib/deb-builder/debian-wheezy/Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:wheezy
+RUN echo deb http://http.debian.net/debian wheezy-backports main > /etc/apt/sources.list.d/wheezy-backports.list
+RUN apt-get update && apt-get install -y devscripts && rm -rf /var/lib/apt/lists/*

--- a/contrib/deb-builder/generate.sh
+++ b/contrib/deb-builder/generate.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# usage: ./generate.sh [versions]
+#    ie: ./generate.sh
+#        to update all Dockerfiles in this directory
+#    or: ./generate.sh debian-jessie
+#        to only update debian-jessie/Dockerfile
+#    or: ./generate.sh debian-newversion
+#        to create a new folder and a Dockerfile within it
+
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+versions=( "$@" )
+if [ ${#versions[@]} -eq 0 ]; then
+	versions=( */ )
+fi
+versions=( "${versions[@]%/}" )
+
+for version in "${versions[@]}"; do
+	mkdir -p "$version"
+	distro="${version%-*}"
+	suite="${version##*-}"
+	from="${distro}:${suite}"
+	echo "$version -> FROM $from"
+	echo "FROM $from" > "$version/Dockerfile"
+	case "$from" in
+		debian:wheezy)
+			# let's add -backports for wheezy, like our users have to
+			echo "RUN echo deb http://http.debian.net/debian $suite-backports main > /etc/apt/sources.list.d/$suite-backports.list" >> "$version/Dockerfile"
+			;;
+	esac
+	echo 'RUN apt-get update && apt-get install -y devscripts && rm -rf /var/lib/apt/lists/*' >> "$version/Dockerfile"
+done

--- a/contrib/deb-builder/ubuntu-debootstrap-precise/Dockerfile
+++ b/contrib/deb-builder/ubuntu-debootstrap-precise/Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu-debootstrap:precise
+RUN apt-get update && apt-get install -y devscripts && rm -rf /var/lib/apt/lists/*

--- a/contrib/deb-builder/ubuntu-debootstrap-trusty/Dockerfile
+++ b/contrib/deb-builder/ubuntu-debootstrap-trusty/Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu-debootstrap:trusty
+RUN apt-get update && apt-get install -y devscripts && rm -rf /var/lib/apt/lists/*

--- a/contrib/deb-builder/ubuntu-debootstrap-utopic/Dockerfile
+++ b/contrib/deb-builder/ubuntu-debootstrap-utopic/Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu-debootstrap:utopic
+RUN apt-get update && apt-get install -y devscripts && rm -rf /var/lib/apt/lists/*

--- a/contrib/deb-builder/ubuntu-debootstrap-vivid/Dockerfile
+++ b/contrib/deb-builder/ubuntu-debootstrap-vivid/Dockerfile
@@ -1,0 +1,2 @@
+FROM ubuntu-debootstrap:vivid
+RUN apt-get update && apt-get install -y devscripts && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The intent here is that we can create from this a new `dockercore/deb-devscripts` image with a tag for each directory listed here.

The goal is to be able to consume this in our own build process in order to build proper, separate `.deb` packages for each distribution we officially target/support.

This will, for example, let us build our distro packages dynamically and thus properly support `dynbinary` in them and fix `devicemapper` issues with being statically compiled. :+1:
