### PR TITLE
Add "docker stats -d <count>" option to "Show only count displays, then ...

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2702,6 +2702,7 @@ func (s *containerStats) Display(w io.Writer) error {
 
 func (cli *DockerCli) CmdStats(args ...string) error {
 	cmd := cli.Subcmd("stats", "CONTAINER", "Display a live stream of one or more containers' resource usage statistics", true)
+	display := cmd.Int([]string{"d", "-display"}, -1, "Show only count displays, then exit")
 	cmd.Require(flag.Min, 1)
 	utils.ParseFlags(cmd, args, true)
 
@@ -2735,7 +2736,12 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, ", "))
 	}
+	k := 0
 	for _ = range time.Tick(500 * time.Millisecond) {
+		if *display >= 0 && k >= *display {
+			break
+		}
+		k += 1
 		printHeader()
 		toRemove := []int{}
 		for i, s := range cStats {

--- a/docs/man/docker-stats.1.md
+++ b/docs/man/docker-stats.1.md
@@ -6,6 +6,7 @@ docker-stats - Display a live stream of one or more containers' resource usage s
 
 # SYNOPSIS
 **docker stats**
+[**-d**|**--display**[=*-1*]]
 [**--help**]
 [CONTAINERS]
 
@@ -16,6 +17,9 @@ Display a live stream of one or more containers' resource usage statistics
 Note: this functionality currently only works when using the *libcontainer* exec-driver.
 
 # OPTIONS
+**-d**, **--display**=-1
+  Show only count displays, then exit
+
 **--help**
   Print usage statement
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -2027,6 +2027,7 @@ more details on finding shared images from the command line.
 
     Display a live stream of one or more containers' resource usage statistics
 
+      -d, --display=-1   Show only count displays, then exit
       --help=false       Print usage
 
 > **Note**: this functionality currently only works when using the *libcontainer* exec-driver.


### PR DESCRIPTION
...exit", just like in OpenBSD's top(1)

http://www.openbsd.org/cgi-bin/man.cgi/OpenBSD-current/man1/top.1

Use case

docker stats -d 1 `docker ps -q` > stats.out
