### PR TITLE
integration-cli: use cmd.Stdin instead of cat/tee for TestExportContainerAndImportImage

### DIFF
--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	"fmt"
-	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -23,15 +22,13 @@ func TestExportContainerAndImportImage(t *testing.T) {
 		t.Fatalf("output should've been a container id: %s %s ", cleanedContainerID, err)
 	}
 
-	exportCmdTemplate := `%v export %v > /tmp/testexp.tar`
-	exportCmdFinal := fmt.Sprintf(exportCmdTemplate, dockerBinary, cleanedContainerID)
-	exportCmd := exec.Command("bash", "-c", exportCmdFinal)
+	exportCmd := exec.Command(dockerBinary, "export", cleanedContainerID)
 	if out, _, err = runCommandWithOutput(exportCmd); err != nil {
 		t.Fatalf("failed to export container: %s, %v", out, err)
 	}
 
-	importCmdFinal := `cat /tmp/testexp.tar | docker import - repo/testexp:v1`
-	importCmd := exec.Command("bash", "-c", importCmdFinal)
+	importCmd := exec.Command(dockerBinary, "import", "-", "repo/testexp:v1")
+	importCmd.Stdin = strings.NewReader(out)
 	out, _, err = runCommandWithOutput(importCmd)
 	if err != nil {
 		t.Fatalf("failed to import image: %s, %v", out, err)
@@ -46,8 +43,6 @@ func TestExportContainerAndImportImage(t *testing.T) {
 
 	deleteContainer(cleanedContainerID)
 	deleteImages("repo/testexp:v1")
-
-	os.Remove("/tmp/testexp.tar")
 
 	logDone("export - export a container")
 	logDone("import - import an image")


### PR DESCRIPTION
TestExportContainerAndImportImage:

`os.Exec("bash", "-c", dockerBinary)` ends up making a call like `bash -c "c:\...\docker.exe"` on windows which doesn't work because bash won't accept windows paths and there's no unix path available for `dockerBinary`. 

This test makes use of `exec.Command.Stdin` to pass the `docker export`ed image back to docker import using `strings.Reader`.
- Upside: fixes the test on windows
- Downside: cat/tee compatibility of the commands is no longer tested in this test case

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
Label: `#windows`
cc: @tianon @unclejack @jfrazelle @icecrime 
