### PR TITLE
integration-cli: Generate unix-style volume paths for tests

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -138,11 +136,7 @@ func TestContainerApiStartVolumeBinds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	bindPath, err := ioutil.TempDir(os.TempDir(), "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	bindPath := randomUnixTmpDirPath("test")
 	config = map[string]interface{}{
 		"Binds": []string{bindPath + ":/tmp"},
 	}
@@ -175,16 +169,8 @@ func TestContainerApiStartDupVolumeBinds(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	bindPath1, err := ioutil.TempDir("", "test1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(bindPath1)
-	bindPath2, err := ioutil.TempDir("", "test2")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(bindPath2)
+	bindPath1 := randomUnixTmpDirPath("test1")
+	bindPath2 := randomUnixTmpDirPath("test2")
 
 	config = map[string]interface{}{
 		"Binds": []string{bindPath1 + ":/tmp", bindPath2 + ":/tmp"},
@@ -262,11 +248,7 @@ func TestVolumesFromHasPriority(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	bindPath, err := ioutil.TempDir(os.TempDir(), "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	bindPath := randomUnixTmpDirPath("test")
 	config = map[string]interface{}{
 		"VolumesFrom": []string{volName},
 		"Binds":       []string{bindPath + ":/tmp"},

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path"
 	"reflect"
 	"strings"
 	"syscall"
@@ -239,6 +240,12 @@ func makeRandomString(n int) string {
 		b[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(b)
+}
+
+// randomUnixTmpDirPath provides a temporary unix path with rand string appended.
+// does not create or checks if it exists.
+func randomUnixTmpDirPath(s string) string {
+	return path.Join("/tmp", fmt.Sprintf("%s.%s", s, makeRandomString(10)))
 }
 
 // Reads chunkSize bytes from reader after every interval.


### PR DESCRIPTION
Some tests in `docker_api_containers_test.go` assume the
docker daemon is running at the same machine as the cli
and uses `ioutil.TempDir` to create temp dirs and use them
in the test.

On windows ioutil.TempDir and os.TempDir would create win-style
paths and pass them to daemon. Instead, I hardcoded `/tmp/test.{{randString}}`
and test generates some random path manually and allow daemon to create
the directory on daemon-side.

Fixes tests:
- TestContainerApiStartVolumeBinds
- TestContainerApiStartDupVolumeBinds
- TestVolumesFromHasPriority

Downside:
- Does not clean the temp dirs generated on the remote daemon machine unless delete container deletes them.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @unclejack @cpuguy83 @estesp @jfrazelle
Label: `#windows`
