### PR TITLE
integration-cli: Seed rand in makeRandomString

### DIFF
--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -235,8 +235,9 @@ func makeRandomString(n int) string {
 	// make a really long string
 	letters := []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 	b := make([]byte, n)
+	r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		b[i] = letters[r.Intn(len(letters))]
 	}
 	return string(b)
 }


### PR DESCRIPTION
Current use of `makeRandomString` is to create really
long strings. In #10794, I used them to create nearly-unique
unix paths for the daemon. Although collions are harmless and don't
fail the tests, this prevents the same strings from being created
consistently in every run by seeding a rand.Random instance.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @unclejack @jfrazelle 
