### PR TITLE
integration-cli: use remote daemon env var in TestCliProxyDisableProxyUnixSock 

### DIFF
--- a/integration-cli/docker_cli_proxy_test.go
+++ b/integration-cli/docker_cli_proxy_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestCliProxyDisableProxyUnixSock(t *testing.T) {
 	cmd := exec.Command(dockerBinary, "info")
-	cmd.Env = []string{"HTTP_PROXY=http://127.0.0.1:9999"}
+	cmd.Env = appendDockerHostEnv([]string{"HTTP_PROXY=http://127.0.0.1:9999"})
 
 	if out, _, err := runCommandWithOutput(cmd); err != nil {
 		t.Fatal(err, out)


### PR DESCRIPTION
TestCliProxyDisableProxyUnixSock execs `docker info` by
clearing env, however if the daemon is set up to run in a
different machine (e.g. Windows CI case) it does not make
use of `DOCKER_TEST_HOST` and tries to connect unix sock.

This fix injects `DOCKER_HOST` back to the test.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
Label: `#windows`
cc: @cpuguy83 @unclejack @tianon @jfrazelle 
