### PR TITLE
integration-cli: fix test to use busybox outside container

### DIFF
--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -102,7 +102,12 @@ func TestRmiTagWithExistingContainers(t *testing.T) {
 
 func TestRmiForceWithExistingContainers(t *testing.T) {
 	image := "busybox-clone"
-	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "build", "--no-cache", "-t", image, "/docker-busybox")); err != nil {
+
+	cmd := exec.Command(dockerBinary, "build", "--no-cache", "-t", image, "-")
+	cmd.Stdin = strings.NewReader(`FROM busybox
+MAINTAINER foo`)
+
+	if out, _, err := runCommandWithOutput(cmd); err != nil {
 		t.Fatalf("Could not build %s: %s, %v", image, out, err)
 	}
 


### PR DESCRIPTION
Fixes TestRmiForceWithExistingContainers test to make it use
`busybox` image rather than /docker-busybox hardcoded path
and rebuilding image.

~~`TestRmiForceWithExistingContainers` uses downloaded
`/docker-busybox` to build the image offline without networking.~~

~~For cases where test needs to run outside docker containers
(e.g. windows CI) it is okay for now to make network requests.
In that case, test now uses `busybox` image (or pull it first).~~

~~This fixes the test without changing in-container behavior.~~

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @jfrazelle @duglin @unclejack @tianon @icecrime 
