### PR TITLE
integration-cli: Preserve DOCKER_TEST_HOST in env-clearing tests

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -862,7 +862,8 @@ func TestRunEnvironmentErase(t *testing.T) {
 	// not set in our local env that they're removed (if present) in
 	// the container
 	cmd := exec.Command(dockerBinary, "run", "-e", "FOO", "-e", "HOSTNAME", "busybox", "env")
-	cmd.Env = []string{}
+	cmd.Env = appendDockerHostEnv([]string{})
+
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		t.Fatal(err, out)
@@ -900,7 +901,8 @@ func TestRunEnvironmentOverride(t *testing.T) {
 	// Test to make sure that when we use -e on env vars that are
 	// already in the env that we're overriding them
 	cmd := exec.Command(dockerBinary, "run", "-e", "HOSTNAME", "-e", "HOME=/root2", "busybox", "env")
-	cmd.Env = []string{"HOSTNAME=bar"}
+	cmd.Env = appendDockerHostEnv([]string{"HOSTNAME=bar"})
+
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		t.Fatal(err, out)

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -893,3 +893,13 @@ func setupRegistry(t *testing.T) func() {
 
 	return func() { reg.Close() }
 }
+
+// appendDockerHostEnv adds given env slice DOCKER_HOST value if set in the
+// environment. Useful when environment is cleared but we want to preserve DOCKER_HOST
+// to execute tests against a remote daemon.
+func appendDockerHostEnv(env []string) []string {
+	if dockerHost := os.Getenv("DOCKER_HOST"); dockerHost != "" {
+		env = append(env, fmt.Sprintf("DOCKER_HOST=%s", dockerHost))
+	}
+	return env
+}


### PR DESCRIPTION
For Windows, we run integration-cli with DOCKER_TEST_HOST env var b/c
daemon is on some remote machine. This keeps the DOCKER_HOST set by
bash scripts in the env.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
Label: `#windows`
Cc: @tianon @unclejack @duglin @jfrazelle @icecrime 
