### PR TITLE
integration-cli: remove bash dependency of TestRunSlowStdoutConsumer

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2617,7 +2617,7 @@ func TestRunVolumesCleanPaths(t *testing.T) {
 func TestRunSlowStdoutConsumer(t *testing.T) {
 	defer deleteAllContainers()
 
-	c := exec.Command("/bin/bash", "-c", dockerBinary+` run --rm -i busybox /bin/sh -c "dd if=/dev/zero of=/foo bs=1024 count=2000 &>/dev/null; catv /foo"`)
+	c := exec.Command(dockerBinary, "run", "--rm", "busybox", "/bin/sh", "-c", "dd if=/dev/zero of=/dev/stdout bs=1024 count=2000 | catv")
 
 	stdout, err := c.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
This makes this test case run on msys bash on windows or
cmd.exe. On windows, os.Exec("/bin/bash") simply fails because
that's not the correct abspath.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
Label: `#windows`
cc: @unclejack @cpuguy83 @tianon @tiborvass 
