### PR TITLE
dispatchers: warn user if try to use EXPOSE ip:hostPort:containerPort

### DIFF
--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -339,9 +339,17 @@ func expose(b *Builder, args []string, attributes map[string]bool, original stri
 		b.Config.ExposedPorts = make(nat.PortSet)
 	}
 
-	ports, _, err := nat.ParsePortSpecs(append(portsTab, b.Config.PortSpecs...))
+	ports, bindingMap, err := nat.ParsePortSpecs(append(portsTab, b.Config.PortSpecs...))
 	if err != nil {
 		return err
+	}
+
+	for _, bindings := range bindingMap {
+		if bindings[0].HostIp != "" || bindings[0].HostPort != "" {
+			fmt.Fprintf(b.ErrStream, " ---> Using Dockerfile's EXPOSE instruction"+
+				"      to map host ports to container ports (ip:hostPort:containerPort) is deprecated.\n"+
+				"      Please use -p to publish the ports.\n")
+		}
 	}
 
 	// instead of using ports directly, we build a list of ports and sort it so

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2343,6 +2343,33 @@ func TestBuildExposeUpperCaseProto(t *testing.T) {
 	logDone("build - expose port with upper case proto")
 }
 
+func TestBuildExposeHostPort(t *testing.T) {
+	// start building docker file with ip:hostPort:containerPort
+	name := "testbuildexpose"
+	expected := "map[5678/tcp:map[]]"
+	defer deleteImages(name)
+	_, out, err := buildImageWithOut(name,
+		`FROM scratch
+        EXPOSE 192.168.1.2:2375:5678`,
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(out, "to map host ports to container ports (ip:hostPort:containerPort) is deprecated.") {
+		t.Fatal("Missing warning message")
+	}
+
+	res, err := inspectField(name, "Config.ExposedPorts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res != expected {
+		t.Fatalf("Exposed ports %s, expected %s", res, expected)
+	}
+	logDone("build - ignore exposing host's port")
+}
+
 func TestBuildEmptyEntrypointInheritance(t *testing.T) {
 	name := "testbuildentrypointinheritance"
 	name2 := "testbuildentrypointinheritance2"


### PR DESCRIPTION
We could use EXPOSE ip:hostPort:containerPort,
but actually it did as EXPOSE ::containerPort

commit 2275c833 already warned user on daemon side.
This patch will print warning message on client side.

Signed-off-by: Chen Hanxiao chenhanxiao@cn.fujitsu.com
