### PR TITLE
Fixed relative filepath check

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4879,3 +4879,20 @@ func TestBuildEmptyScratch(t *testing.T) {
 	}
 	logDone("build - empty scratch Dockerfile")
 }
+
+func TestBuildDotDotFile(t *testing.T) {
+	defer deleteImages("sc")
+	ctx, err := fakeContext("FROM busybox\n",
+		map[string]string{
+			"..gitme": "",
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctx.Close()
+
+	if _, err = buildImageFromContext("sc", ctx, false); err != nil {
+		t.Fatalf("Build was supposed to work: %s", err)
+	}
+	logDone("build - ..file")
+}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -525,7 +525,7 @@ loop:
 		if err != nil {
 			return err
 		}
-		if strings.HasPrefix(rel, "..") {
+		if strings.HasPrefix(rel, "../") {
 			return breakoutError(fmt.Errorf("%q is outside of %q", hdr.Name, dest))
 		}
 

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -81,7 +81,7 @@ func UnpackLayer(dest string, layer ArchiveReader) (size int64, err error) {
 		if err != nil {
 			return 0, err
 		}
-		if strings.HasPrefix(rel, "..") {
+		if strings.HasPrefix(rel, "../") {
 			return 0, breakoutError(fmt.Errorf("%q is outside of %q", hdr.Name, dest))
 		}
 		base := filepath.Base(path)

--- a/pkg/chrootarchive/archive_test.go
+++ b/pkg/chrootarchive/archive_test.go
@@ -99,3 +99,29 @@ func TestChrootApplyEmptyArchiveFromSlowReader(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestChrootApplyDotDotFile(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "docker-TestChrootApplyDotDotFile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+	src := filepath.Join(tmpdir, "src")
+	if err := os.MkdirAll(src, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(src, "..gitme"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+	stream, err := archive.Tar(src, archive.Uncompressed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(tmpdir, "dest")
+	if err := os.MkdirAll(dest, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ApplyLayer(dest, stream); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This fixes the false error for certain filenames described in #10815

Closes #10815
