### PR TITLE
Fix test-unit run without parallel

### DIFF
--- a/project/make/test-unit
+++ b/project/make/test-unit
@@ -27,16 +27,17 @@ bundle_test_unit() {
 			export TESTFLAGS
 			export HAVE_GO_TEST_COVER
 			export DEST
+
+			# some hack to export array variables
+			export BUILDFLAGS_FILE="buildflags_file"
+			( IFS=$'\n'; echo "${BUILDFLAGS[*]}" ) > "$BUILDFLAGS_FILE"
+
 			if command -v parallel &> /dev/null; then
 				# accomodate parallel to be able to access variables
 				export SHELL="$BASH"
 				export HOME="$(mktemp -d)"
 				mkdir -p "$HOME/.parallel"
 				touch "$HOME/.parallel/ignored_vars"
-
-				# some hack to export array variables
-				export BUILDFLAGS_FILE="$HOME/buildflags_file"
-				( IFS=$'\n'; echo "${BUILDFLAGS[*]}" ) > "$BUILDFLAGS_FILE"
 
 				echo "$TESTDIRS" | parallel --jobs "$PARALLEL_JOBS" --env _ "$(dirname "$BASH_SOURCE")/.go-compile-test-dir"
 				rm -rf "$HOME"
@@ -47,6 +48,7 @@ bundle_test_unit() {
 					# don't let one directory that fails to build tank _all_ our tests!
 				done
 			fi
+			rm -f "$BUILDFLAGS_FILE"
 		)
 		echo "$TESTDIRS" | go_run_test_dir
 	}


### PR DESCRIPTION
Test-unit fails when running without parallel because BUILDFLAGS_FILE is not created in this conditional branch. This PR moves the code outside of the conditional expression.

Signed-off-by: Fabiano Rosas farosas@br.ibm.com

Closes #10832
