### PR TITLE
Fix bash completion for docker run -d

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -663,7 +663,7 @@ _docker_run() {
 			_filedir
 			return
 			;;
-		--device|-d|--volume)
+		--device|--volume|-v)
 			case "$cur" in
 				*:*)
 					# TODO somehow do _filedir for stuff inside the image, if it's already specified (which is also somewhat difficult to determine)


### PR DESCRIPTION
#9863 introduced a regression in bash completion, see [diff](https://github.com/docker/docker/commit/70161b4d45ec990a4e597e133092e389e168ad79#diff-754420541b12dbcbbea00825942a4635L572).

Bash completion for `docker run -d` presently completes to "/", which is very confusing for a boolean argument. This effectively terminates completion at this stage.
As this particular completion is _very_ frequently used, I suggest this PR should be labelled **bug** and scheduled for Docker 1.5.1.

@jfrazelle @tianon please review.
