### PR TITLE
integration-cli: readContainerFileWithExec for links tests

### DIFF
--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -231,7 +231,7 @@ func TestLinksNotStartedParentNotFail(t *testing.T) {
 }
 
 func TestLinksHostsFilesInject(t *testing.T) {
-	testRequires(t, SameHostDaemon)
+	testRequires(t, SameHostDaemon, ExecSupport)
 
 	defer deleteAllContainers()
 
@@ -285,7 +285,7 @@ func TestLinksNetworkHostContainer(t *testing.T) {
 }
 
 func TestLinksUpdateOnRestart(t *testing.T) {
-	testRequires(t, SameHostDaemon)
+	testRequires(t, SameHostDaemon, ExecSupport)
 
 	defer deleteAllContainers()
 

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -251,12 +251,12 @@ func TestLinksHostsFilesInject(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
-	contentOne, err := readContainerFile(idOne, "hosts")
+	contentOne, err := readContainerFileWithExec(idOne, "/etc/hosts")
 	if err != nil {
 		t.Fatal(err, string(contentOne))
 	}
 
-	contentTwo, err := readContainerFile(idTwo, "hosts")
+	contentTwo, err := readContainerFileWithExec(idTwo, "/etc/hosts")
 	if err != nil {
 		t.Fatal(err, string(contentTwo))
 	}
@@ -302,7 +302,7 @@ func TestLinksUpdateOnRestart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	content, err := readContainerFile(id, "hosts")
+	content, err := readContainerFileWithExec(id, "/etc/hosts")
 	if err != nil {
 		t.Fatal(err, string(content))
 	}
@@ -327,7 +327,7 @@ func TestLinksUpdateOnRestart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	content, err = readContainerFile(id, "hosts")
+	content, err = readContainerFileWithExec(id, "/etc/hosts")
 	if err != nil {
 		t.Fatal(err, string(content))
 	}

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -895,6 +895,11 @@ func readContainerFile(containerId, filename string) ([]byte, error) {
 	return content, nil
 }
 
+func readContainerFileWithExec(containerId, filename string) ([]byte, error) {
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "exec", containerId, "cat", filename))
+	return []byte(out), err
+}
+
 func setupRegistry(t *testing.T) func() {
 	reg, err := newTestRegistryV2(t)
 	if err != nil {

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -21,6 +21,10 @@ var (
 		func() bool { return isUnixCli },
 		"Test requires posix utilities or functionality to run.",
 	}
+	ExecSupport = TestRequirement{
+		func() bool { return supportsExec },
+		"Test requires 'docker exec' capabilities on the tested daemon.",
+	}
 )
 
 // testRequires checks if the environment satisfies the requirements

--- a/integration-cli/test_vars_exec.go
+++ b/integration-cli/test_vars_exec.go
@@ -1,0 +1,8 @@
+// +build !test_no_exec
+
+package main
+
+const (
+	// indicates docker daemon tested supports 'docker exec'
+	supportsExec = true
+)

--- a/integration-cli/test_vars_noexec.go
+++ b/integration-cli/test_vars_noexec.go
@@ -1,0 +1,8 @@
+// +build test_no_exec
+
+package main
+
+const (
+	// indicates docker daemon tested supports 'docker exec'
+	supportsExec = false
+)


### PR DESCRIPTION
Shout out to @estesp for the idea. Some use cases of
`readContainerFile` can be replaced with `docker exec $id cat $file`.
This helper method can eliminate the assumption that
host/cli should be on the same machine, partially.

TestRunMutableNetworkFiles and TestRunResolvconfUpdater still
need to access the docker host filesystem as they modify
the file directly from there assuming cli and daemon are
on the same machine. They may keep using`readContainerFile`.

This fixes `TestLinksUpdateOnRestart` and `TestLinksHostsFilesInject`
for Windows CI.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
Label: `#windows`
Cc: @estesp @duglin @unclejack @jfrazelle @tianon 
