### PR TITLE
Make test-unit work without parallel

### DIFF
--- a/project/make/test-unit
+++ b/project/make/test-unit
@@ -27,16 +27,15 @@ bundle_test_unit() {
 			export TESTFLAGS
 			export HAVE_GO_TEST_COVER
 			export DEST
+			# some hack to export array variables
+			export BUILDFLAGS_FILE="$HOME/buildflags_file"
+			( IFS=$'\n'; echo "${BUILDFLAGS[*]}" ) > "$BUILDFLAGS_FILE"
 			if command -v parallel &> /dev/null; then
 				# accomodate parallel to be able to access variables
 				export SHELL="$BASH"
 				export HOME="$(mktemp -d)"
 				mkdir -p "$HOME/.parallel"
 				touch "$HOME/.parallel/ignored_vars"
-
-				# some hack to export array variables
-				export BUILDFLAGS_FILE="$HOME/buildflags_file"
-				( IFS=$'\n'; echo "${BUILDFLAGS[*]}" ) > "$BUILDFLAGS_FILE"
 
 				echo "$TESTDIRS" | parallel --jobs "$PARALLEL_JOBS" --env _ "$(dirname "$BASH_SOURCE")/.go-compile-test-dir"
 				rm -rf "$HOME"


### PR DESCRIPTION
Closes #10832 

You can test by removing `parallel` from the Dockerfile and running `make test-unit`
