### PR TITLE
integration-cli: pass platform-compatible paths to os.Symlink

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4688,14 +4688,15 @@ func TestBuildDockerfileOutsideContext(t *testing.T) {
 	if err := ioutil.WriteFile(filepath.Join(tmpdir, "outsideDockerfile"), []byte("FROM scratch\nENV x y"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Symlink("../outsideDockerfile", filepath.Join(ctx, "dockerfile1")); err != nil {
+	if err := os.Symlink(filepath.Join("..", "outsideDockerfile"), filepath.Join(ctx, "dockerfile1")); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Symlink(filepath.Join(tmpdir, "outsideDockerfile"), filepath.Join(ctx, "dockerfile2")); err != nil {
 		t.Fatal(err)
 	}
+
 	for _, dockerfilePath := range []string{
-		"../outsideDockerfile",
+		filepath.Join("..", "outsideDockerfile"),
 		filepath.Join(ctx, "dockerfile1"),
 		filepath.Join(ctx, "dockerfile2"),
 	} {


### PR DESCRIPTION
Although this doesn't fix the test (`os.Symlink` is not yet implemented for Windows), this prevents unix-style paths from being passed to os.Symlink. Also makes code cleaner for linux.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @tianon @unclejack @jfrazelle @icecrime 
