### PR TITLE
fix issue: if bridge Interface existing and the config is not the same with passing config bridge IP(using '--bip='). Docker daemon will failed to start.

### DIFF
--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/pkg/networkfs/resolvconf"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/libcontainer/netlink"
+	"github.com/docker/libcontainer/network"
 )
 
 const (
@@ -140,13 +141,37 @@ func InitDriver(job *engine.Job) engine.Status {
 		// Bridge exists already. Getting info...
 		// validate that the bridge ip matches the ip specified by BridgeIP
 		if bridgeIP != "" {
-			networkv4 = addrv4.(*net.IPNet)
 			bip, _, err := net.ParseCIDR(bridgeIP)
+			networkv4 = addrv4.(*net.IPNet)
 			if err != nil {
 				return job.Error(err)
 			}
 			if !networkv4.IP.Equal(bip) {
-				return job.Errorf("bridge ip (%s) does not match existing bridge configuration %s", networkv4.IP, bip)
+				// Configured bridge IP (by --bip="xxxx/x") is not the same with the real bridge IP.
+				// Add a new bridge IP here and remove the old one.
+				log.Infof("Overriding bridge(%s) IP address from %s to %s, as '--bip' is used.", bridgeIface, networkv4.String(), bridgeIP)
+				if err := network.DeleteInterfaceIp(bridgeIface, networkv4.String()); err != nil {
+					job.Error(err)
+				}
+				if err := network.SetInterfaceIp(bridgeIface, bridgeIP); err != nil {
+					job.Error(err)
+				}
+
+				addrv4_new, addrsv6_new, err := networkdriver.GetIfaceAddr(bridgeIface)
+				if err != nil {
+					return job.Error(err)
+				}
+				if fixedCIDRv6 != "" {
+					// Setting route to global IPv6 subnet
+					log.Infof("Adding route to IPv6 network %q via device %q", fixedCIDRv6, bridgeIface)
+					if err := netlink.AddRoute(fixedCIDRv6, "", "", bridgeIface); err != nil {
+						log.Fatalf("Could not add route to IPv6 network %q via device %q", fixedCIDRv6, bridgeIface)
+					}
+				}
+
+				addrsv6 = addrsv6_new
+				addrv4 = addrv4_new
+				networkv4 = addrv4.(*net.IPNet)
 			}
 		}
 

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -599,7 +599,8 @@ options are configurable at server startup:
 
  *  `--bip=CIDR` — supply a specific IP address and netmask for the
     `docker0` bridge, using standard CIDR notation like
-    `192.168.1.5/24`.
+    `192.168.1.5/24`. If the provided CIDR does not match the current,
+    docker will replace the current bridge IP with the provided CIDR.
 
  *  `--fixed-cidr=CIDR` — restrict the IP range from the `docker0` subnet,
     using the standard CIDR notation like `172.167.1.0/28`. This range must


### PR DESCRIPTION
Signed-off-by: zhangwentao zhangwentao234@huawei.com
