### PR TITLE
[RFC] commands: enable lowercase 'dockerfile'

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -19,6 +19,7 @@ const (
 	DEFAULTHTTPHOST                       = "127.0.0.1"
 	DEFAULTUNIXSOCKET                     = "/var/run/docker.sock"
 	DefaultDockerfileName string          = "Dockerfile"
+	DefaultDockerfileNameLower string     = "dockerfile"
 )
 
 func ValidateHost(val string) (string, error) {

--- a/docs/man/docker-build.1.md
+++ b/docs/man/docker-build.1.md
@@ -34,7 +34,7 @@ as context.
 
 # OPTIONS
 **-f**, **--file**=*Dockerfile*
-   Path to the Dockerfile to use. If the path is a relative path then it must be relative to the current directory. The file must be within the build context. The default is *Dockerfile*.
+   Path to the Dockerfile to use. If the path is a relative path then it must be relative to the current directory. The file must be within the build context. The default is *Dockerfile|dockerfile*.
 
 **--force-rm**=*true*|*false*
    Always remove intermediate containers, even after unsuccessful builds. The default is *false*.

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -497,7 +497,7 @@ is returned by the `docker attach` command to its caller too:
 
     Build a new image from the source code at PATH
 
-      -f, --file=""            Name of the Dockerfile(Default is 'Dockerfile')
+      -f, --file=""            Name of the Dockerfile(Default is 'Dockerfile', or 'dockerfile')
       --force-rm=false         Always remove intermediate containers
       --no-cache=false         Do not use cache when building the image
       --pull=false             Always attempt to pull a newer version of the image


### PR DESCRIPTION
1. Search `Dockerfile`
2. If no `Dockerfile`, search `dockerfile`
3. else, fail out.

Signed-off-by: Chen Hanxiao chenhanxiao@cn.fujitsu.com
