### PR TITLE
integration-cli: check that docker port command output is not empty

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2921,6 +2921,10 @@ func TestRunPortFromDockerRangeInUse(t *testing.T) {
 		t.Fatal(out, err)
 	}
 	out = strings.TrimSpace(out)
+
+	if out == "" {
+		t.Fatal("docker port command output is empty")
+	}
 	out = strings.Split(out, ":")[1]
 	lastPort, err := strconv.Atoi(out)
 	if err != nil {


### PR DESCRIPTION
Or else we can violate array range boundaries in:
    out = strings.Split(out, ":")[1]
and get runtime error.

We got this runtime error when run TestRunPortFromDockerRangeInUse
Somehow docker goes silently if it cannot publish port because
of no bridge.

Signed-off-by: Pavel Tikhomirov ptikhomirov@parallels.com
