### PR TITLE
Need to support new linux capability AUDIT_READ

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -131,6 +131,7 @@ __docker_capabilities() {
 		ALL
 		AUDIT_CONTROL
 		AUDIT_WRITE
+		AUDIT_READ
 		BLOCK_SUSPEND
 		CHOWN
 		DAC_OVERRIDE


### PR DESCRIPTION
Currently our containers are still allowed access to AUDIT_READ even if you tell the system to disable all
CAPS.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
