### PR TITLE
Fix docker run --expose with an invalid port does not error out

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2718,6 +2718,20 @@ func TestRunAllowPortRangeThroughExpose(t *testing.T) {
 	logDone("run - allow port range through --expose flag")
 }
 
+// test docker run expose a invalid port
+func TestRunExposePort(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "--expose", "80000", "busybox")
+	out, _, err := runCommandWithOutput(runCmd)
+	//expose a invalid port should with a error out
+	if err == nil || !strings.Contains(out, "Invalid range format for --expose") {
+		t.Fatalf("run --expose a invalid port should with error out")
+	}
+
+	deleteAllContainers()
+
+	logDone("run - can't expose a invalid port")
+}
+
 func TestRunUnknownCommand(t *testing.T) {
 	defer deleteAllContainers()
 	runCmd := exec.Command(dockerBinary, "create", "busybox", "/bin/nada")

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -206,21 +206,15 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 			return nil, nil, cmd, fmt.Errorf("Invalid port format for --expose: %s", e)
 		}
 		//support two formats for expose, original format <portnum>/[<proto>] or <startport-endport>/[<proto>]
-		if strings.Contains(e, "-") {
-			proto, port := nat.SplitProtoPort(e)
-			//parse the start and end port and create a sequence of ports to expose
-			start, end, err := parsers.ParsePortRange(port)
-			if err != nil {
-				return nil, nil, cmd, fmt.Errorf("Invalid range format for --expose: %s, error: %s", e, err)
-			}
-			for i := start; i <= end; i++ {
-				p := nat.NewPort(proto, strconv.FormatUint(i, 10))
-				if _, exists := ports[p]; !exists {
-					ports[p] = struct{}{}
-				}
-			}
-		} else {
-			p := nat.NewPort(nat.SplitProtoPort(e))
+		proto, port := nat.SplitProtoPort(e)
+		//parse the start and end port and create a sequence of ports to expose
+		//if expose a port, the start and end port are the same
+		start, end, err := parsers.ParsePortRange(port)
+		if err != nil {
+			return nil, nil, cmd, fmt.Errorf("Invalid range format for --expose: %s, error: %s", e, err)
+		}
+		for i := start; i <= end; i++ {
+			p := nat.NewPort(proto, strconv.FormatUint(i, 10))
 			if _, exists := ports[p]; !exists {
 				ports[p] = struct{}{}
 			}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Fixes #10836 

when `docker run --expose`  with an invalid port, there is no error out.
This patch fix this and have some refactor to previous code to make the code 
more simplified. Since function `parsers.ParsePortRange` will do 
`strings.Contains(e, "-")` and if the port is not a range but a specified one, the return
`start port` and  `end port` are the same. So there is no need to do `if strings.Contains(e, "-")`
in `parse.go`
