### PR TITLE
fix source command for tab-completion

### DIFF
--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -32,7 +32,7 @@ To install the latest Ubuntu package (this is **not** the most recent Docker rel
 
 Then, to enable tab-completion of Docker commands in BASH, either restart BASH or:
 
-    $ source /etc/bash_completion.d/docker.io
+    $ source /etc/bash_completion.d/docker*
 
 > **Note**:
 > Since the Ubuntu package is quite dated at this point, you may want to use


### PR DESCRIPTION
Ubuntu 14.10 - Server

I've installed docker.io with apt-get, then

```
source /etc/bash_completion.d/docker.io 
```

was not working for me, since the file is called docker, not docker.io.

My proposal is to change the wiki to:

```
source /etc/bash_completion.d/docker*
```

There might be versions with 'io' ending; asterisk is general enough.
