### PR TITLE
pkg/archive: Canonicalize stored paths

### DIFF
--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -9,6 +9,13 @@ import (
 	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 )
 
+// canonicalTarNameForPath returns platform-specific filepath
+// to canonical posix-style path for tar archival. p is relative
+// path.
+func canonicalTarNameForPath(p string) (string, error) {
+	return p, nil // already unix-style
+}
+
 func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {
 	s, ok := stat.(*syscall.Stat_t)
 

--- a/pkg/archive/archive_unix_test.go
+++ b/pkg/archive/archive_unix_test.go
@@ -1,0 +1,42 @@
+// +build !windows
+
+package archive
+
+import (
+	"testing"
+)
+
+func TestCanonicalTarNameForPath(t *testing.T) {
+	cases := []struct{ in, expected string }{
+		{"foo", "foo"},
+		{"foo/bar", "foo/bar"},
+		{"foo/dir/", "foo/dir/"},
+	}
+	for _, v := range cases {
+		if out, err := canonicalTarNameForPath(v.in); err != nil {
+			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
+		} else if out != v.expected {
+			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)
+		}
+	}
+}
+
+func TestCanonicalTarName(t *testing.T) {
+	cases := []struct {
+		in       string
+		isDir    bool
+		expected string
+	}{
+		{"foo", false, "foo"},
+		{"foo", true, "foo/"},
+		{"foo/bar", false, "foo/bar"},
+		{"foo/bar", true, "foo/bar/"},
+	}
+	for _, v := range cases {
+		if out, err := canonicalTarName(v.in, v.isDir); err != nil {
+			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
+		} else if out != v.expected {
+			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)
+		}
+	}
+}

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -3,8 +3,25 @@
 package archive
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 )
+
+// canonicalTarNameForPath returns platform-specific filepath
+// to canonical posix-style path for tar archival. p is relative
+// path.
+func canonicalTarNameForPath(p string) (string, error) {
+	// windows: convert windows style relative path with backslashes
+	// into forward slashes. since windows does not allow '/' or '\'
+	// in file names, it is mostly safe to replace however we must
+	// check just in case
+	if strings.Contains(p, "/") {
+		return "", fmt.Errorf("windows path contains forward slash: %s", p)
+	}
+	return strings.Replace(p, "\\", "/", -1), nil
+}
 
 func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {
 	// do nothing. no notion of Rdev, Inode, Nlink in stat on Windows

--- a/pkg/archive/archive_windows_test.go
+++ b/pkg/archive/archive_windows_test.go
@@ -1,0 +1,48 @@
+// +build windows
+
+package archive
+
+import (
+	"testing"
+)
+
+func TestCanonicalTarNameForPath(t *testing.T) {
+	cases := []struct {
+		in, expected string
+		shouldFail   bool
+	}{
+		{"foo", "foo", false},
+		{"foo/bar", "___", true}, // unix-styled windows path must fail
+		{`foo\bar`, "foo/bar", false},
+		{`foo\bar`, "foo/bar/", false},
+	}
+	for _, v := range cases {
+		if out, err := canonicalTarNameForPath(v.in); err != nil && !v.shouldFail {
+			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
+		} else if v.shouldFail && err == nil {
+			t.Fatalf("canonical path call should have pailed with error. in=%s out=%s", v.in, out)
+		} else if !v.shouldFail && out != v.expected {
+			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)
+		}
+	}
+}
+
+func TestCanonicalTarName(t *testing.T) {
+	cases := []struct {
+		in       string
+		isDir    bool
+		expected string
+	}{
+		{"foo", false, "foo"},
+		{"foo", true, "foo/"},
+		{`foo\bar`, false, "foo/bar"},
+		{`foo\bar`, true, "foo/bar/"},
+	}
+	for _, v := range cases {
+		if out, err := canonicalTarName(v.in, v.isDir); err != nil {
+			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
+		} else if out != v.expected {
+			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)
+		}
+	}
+}


### PR DESCRIPTION
Currently pkg/archive stores nested windows files with
backslashes (e.g. `dir\`, `dir\file.txt`) and this causes
tar not being correctly extracted on Linux daemon.

This change assures we canonicalize all paths to unix
paths and add them to tar with that name independent of platform.
For example windows paths like `dir\foo.txt` gets stored as `dir/foo.txt`
and `dir\` entry gets stored as `dir/` in the tar.

With this change we sustain unix-style paths in Dockerfiles
and .dockerignore files. The windows daemon probably needs to
modify the logic to untar unix paths correctly on windows filesystems.

Fixes the following test cases for Windows CI:
- TestBuildAddFileWithWhitespace
- TestBuildCopyFileWithWhitespace
- TestBuildAddDirContentToRoot
- TestBuildAddDirContentToExistingDir
- TestBuildCopyDirContentToRoot
- TestBuildCopyDirContentToExistDir
- TestBuildDockerignore
- TestBuildEnvUsage
- TestBuildEnvUsage2
- TestBuildCopyWildcard

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @unclejack @tiborvass @icecrime @jfrazelle @swernli @jhowardmsft @jeffmendoza
