### PR TITLE
Use `-q` argument in test using `docker images -f`

### DIFF
--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -97,7 +97,7 @@ func TestImagesFilterWhiteSpaceTrimmingAndLowerCasingWorking(t *testing.T) {
 
 	imageListings := make([][]string, 5, 5)
 	for idx, filter := range filters {
-		cmd := exec.Command(dockerBinary, "images", "-f", filter)
+		cmd := exec.Command(dockerBinary, "images", "-q", "-f", filter)
 		out, _, err := runCommandWithOutput(cmd)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
The test case `TestImagesFilterWhiteSpaceTrimmingAndLowerCasingWorking`
fails based on time because it uses full `docker images` output and
value in the `CREATED` column turns from `A minute ago` to `2 minutes ago`
in the middle of execution and output comparison fails.

e.g.

```
REPOSITORY                                   TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
foo-1219                                     latest              2b7225e23d92        About a minute ago   2.433 MB
```

vs

```
REPOSITORY                                   TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
foo-1219                                     latest              2b7225e23d92        2 minutes ago       2.433 MB
```

This test doesn't really care about output cosmetics but rather image IDs returned
so `-q` makes sense here.

Signed-off-by: Ahmet Alp Balkan ahmetb@microsoft.com
cc: @jfrazelle @dkjer @unclejack @TintypeMolly @sachin-jayant-joshi
