### PR TITLE
Dockerfile: bump Go to 1.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN cd /usr/src/lxc \
 	&& ldconfig
 
 # Install Go
-ENV GO_VERSION 1.4.1
+ENV GO_VERSION 1.4.2
 RUN curl -sSL https://golang.org/dl/go${GO_VERSION}.src.tar.gz | tar -v -C /usr/local -xz \
 	&& mkdir -p /go/bin
 ENV PATH /go/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
This bumps Go to 1.4.2. Since this is a minor release of Go, no new problems are expected.
