### PR TITLE
Fix possible panic on killing container

### DIFF
--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -4,6 +4,7 @@ package native
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -173,6 +174,9 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 }
 
 func (d *driver) Kill(p *execdriver.Command, sig int) error {
+	if p.ProcessConfig.Process == nil {
+		return errors.New("exec: not started")
+	}
 	return syscall.Kill(p.ProcessConfig.Process.Pid, syscall.Signal(sig))
 }
 


### PR DESCRIPTION
Caught that on jenkins.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x5a3982]

goroutine 1242 [running]:
github.com/docker/docker/daemon/execdriver/native.(*driver).Kill(0xc208420580, 0xc209943500, 0x9, 0x0, 0x0)
    github.com/docker/docker/daemon/execdriver/native/_obj/driver.go:209 +0x42
github.com/docker/docker/daemon.(*Daemon).Kill(0xc208d0b810, 0xc209910a80, 0x9, 0x0, 0x0)
    github.com/docker/docker/daemon/_obj/daemon.go:1399 +0x7e
github.com/docker/docker/daemon.(*Container).KillSig(0xc209910a80, 0x9, 0x0, 0x0)
    github.com/docker/docker/daemon/_obj/container.go:771 +0x3cd
github.com/docker/docker/daemon.(*Container).killPossiblyDeadProcess(0xc209910a80, 0x9, 0x0, 0x0)
    github.com/docker/docker/daemon/_obj/container.go:776 +0x62
github.com/docker/docker/daemon.(*Container).Kill(0xc209910a80, 0x0, 0x0)
    github.com/docker/docker/daemon/_obj/container.go:824 +0xb0
github.com/docker/docker/daemon.func·017(0xc209910a80)
    github.com/docker/docker/daemon/_obj/daemon.go:1439 +0x3b
created by github.com/docker/docker/daemon.(*Daemon).Nuke
    github.com/docker/docker/daemon/_obj/daemon.go:1441 +0x13f
```
