### PR TITLE
Add bash completion for "docker rename"

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -552,6 +552,13 @@ _docker_push() {
 	fi
 }
 
+_docker_rename() {
+	local counter=$(__docker_pos_first_nonflag)
+	if [ $cword -eq $counter ]; then
+		__docker_containers_all
+	fi
+}
+
 _docker_restart() {
 	case "$prev" in
 		--time|-t)
@@ -914,6 +921,7 @@ _docker() {
 		ps
 		pull
 		push
+		rename
 		restart
 		rm
 		rmi


### PR DESCRIPTION
This commit adds Bash completion for `docker rename`, modelled after the completion for `docker diff`. There are still other 1.5.0 updates to be made it would seem, but I thought I'd submit this change since I had time to make it now.
