### PR TITLE
Shorten printed Windows paths on docker help command

### DIFF
--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -72,7 +72,7 @@ complete -c docker -f -n '__fish_docker_no_subcommand' -l registry-mirror -d 'Sp
 complete -c docker -f -n '__fish_docker_no_subcommand' -s s -l storage-driver -d 'Force the Docker runtime to use a specific storage driver'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l selinux-enabled -d 'Enable selinux support. SELinux does not presently support the BTRFS storage driver'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l storage-opt -d 'Set storage driver options'
-complete -c docker -f -n '__fish_docker_no_subcommand' -l tls -d 'Use TLS; implied by --tlsverify flag'
+complete -c docker -f -n '__fish_docker_no_subcommand' -l tls -d 'Use TLS; implied by --tlsverify'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l tlscacert -d 'Trust only remotes providing a certificate signed by the CA given here'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l tlscert -d 'Path to TLS certificate file'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l tlskey -d 'Path to TLS key file'

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -35,7 +35,7 @@ var (
 	flDaemon    = flag.Bool([]string{"d", "-daemon"}, false, "Enable daemon mode")
 	flDebug     = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
 	flLogLevel  = flag.String([]string{"l", "-log-level"}, "info", "Set the logging level")
-	flTls       = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by --tlsverify flag")
+	flTls       = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by --tlsverify")
 	flHelp      = flag.Bool([]string{"h", "-help"}, false, "Print usage")
 	flTlsVerify = flag.Bool([]string{"-tlsverify"}, dockerTlsVerify, "Use TLS and verify the remote")
 
@@ -65,7 +65,7 @@ func init() {
 	flCa = flag.String([]string{"-tlscacert"}, filepath.Join(dockerCertPath, defaultCaFile), "Trust certs signed only by this CA")
 	flCert = flag.String([]string{"-tlscert"}, filepath.Join(dockerCertPath, defaultCertFile), "Path to TLS certificate file")
 	flKey = flag.String([]string{"-tlskey"}, filepath.Join(dockerCertPath, defaultKeyFile), "Path to TLS key file")
-	opts.HostListVar(&flHosts, []string{"H", "-host"}, "Daemon socket(s) to use or connect to")
+	opts.HostListVar(&flHosts, []string{"H", "-host"}, "Daemon socket(s) to connect to")
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stdout, "Usage: docker [OPTIONS] COMMAND [arg...]\n\nA self-sufficient runtime for linux containers.\n\nOptions:\n")

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -86,7 +86,7 @@ expect an integer, and they can only be specified once.
       --fixed-cidr-v6=""                     IPv6 subnet for fixed IPs
       -G, --group="docker"                   Group for the unix socket
       -g, --graph="/var/lib/docker"          Root of the Docker runtime
-      -H, --host=[]                          Daemon socket(s) to use or connect to
+      -H, --host=[]                          Daemon socket(s) to connect to
       -h, --help=false                       Print usage
       --icc=true                             Enable inter-container communication
       --insecure-registry=[]                 Enable insecure registry communication
@@ -103,7 +103,7 @@ expect an integer, and they can only be specified once.
       -s, --storage-driver=""                Storage driver to use
       --selinux-enabled=false                Enable selinux support
       --storage-opt=[]                       Set storage driver options
-      --tls=false                            Use TLS; implied by --tlsverify flag
+      --tls=false                            Use TLS; implied by --tlsverify
       --tlscacert="~/.docker/ca.pem"         Trust certs signed only by this CA
       --tlscert="~/.docker/cert.pem"         Path to TLS certificate file
       --tlskey="~/.docker/key.pem"           Path to TLS key file

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -1,23 +1,19 @@
 package main
 
 import (
-	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 	"testing"
 	"unicode"
+
+	"github.com/docker/docker/pkg/homedir"
 )
 
 func TestMainHelpWidth(t *testing.T) {
 	// Make sure main help text fits within 80 chars and that
 	// on non-windows system we use ~ when possible (to shorten things)
 
-	var home string
-	if runtime.GOOS != "windows" {
-		home = os.Getenv("HOME")
-	}
-
+	home := homedir.Get()
 	helpCmd := exec.Command(dockerBinary, "help")
 	out, ec, err := runCommandWithOutput(helpCmd)
 	if err != nil || ec != 0 {
@@ -27,9 +23,10 @@ func TestMainHelpWidth(t *testing.T) {
 	for _, line := range lines {
 		if len(line) > 80 {
 			t.Fatalf("Line is too long(%d chars):\n%s", len(line), line)
+
 		}
 		if home != "" && strings.Contains(line, home) {
-			t.Fatalf("Line should use ~ instead of %q:\n%s", home, line)
+			t.Fatalf("Line should use '%q' instead of %q:\n%s", homedir.GetShortcutString(), home, line)
 		}
 	}
 	logDone("help - verify main width")
@@ -39,11 +36,7 @@ func TestCmdHelpWidth(t *testing.T) {
 	// Make sure main help text fits within 80 chars and that
 	// on non-windows system we use ~ when possible (to shorten things)
 
-	var home string
-	if runtime.GOOS != "windows" {
-		home = os.Getenv("HOME")
-	}
-
+	home := homedir.Get()
 	// Pull the list of commands from the "Commands:" section of docker help
 	helpCmd := exec.Command(dockerBinary, "help")
 	out, ec, err := runCommandWithOutput(helpCmd)
@@ -82,7 +75,7 @@ func TestCmdHelpWidth(t *testing.T) {
 				t.Fatalf("Help for %q is too long(%d chars):\n%s", command, len(line), line)
 			}
 			if home != "" && strings.Contains(line, home) {
-				t.Fatalf("Help for %q should use ~ instead of %q on:\n%s", command, home, line)
+				t.Fatalf("Help for %q should use home shortcut instead of %q on:\n%s", command, home, line)
 			}
 		}
 	}

--- a/pkg/homedir/homedir.go
+++ b/pkg/homedir/homedir.go
@@ -14,3 +14,12 @@ func Get() string {
 	}
 	return os.Getenv("HOME")
 }
+
+// GetShortcutString returns the string that is shortcut to user's home directory
+// in the native shell of the platform running on.
+func GetShortcutString() string {
+	if runtime.GOOS == "windows" {
+		return "%USERPROFILE%" // be careful while using in format functions
+	}
+	return "~"
+}

--- a/pkg/homedir/homedir_test.go
+++ b/pkg/homedir/homedir_test.go
@@ -15,3 +15,10 @@ func TestGet(t *testing.T) {
 		t.Fatalf("returned path is not absolute: %s", home)
 	}
 }
+
+func TestGetShortcutString(t *testing.T) {
+	shortcut := GetShortcutString()
+	if shortcut == "" {
+		t.Fatal("returned shortcut string is empty")
+	}
+}

--- a/pkg/mflag/flag.go
+++ b/pkg/mflag/flag.go
@@ -86,12 +86,13 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
+
+	"github.com/docker/docker/pkg/homedir"
 )
 
 // ErrHelp is the error returned if the flag -help is invoked but no such flag is defined.
@@ -504,16 +505,9 @@ func Set(name, value string) error {
 // otherwise, the default values of all defined flags in the set.
 func (f *FlagSet) PrintDefaults() {
 	writer := tabwriter.NewWriter(f.Out(), 20, 1, 3, ' ', 0)
-	var home string
-	if runtime.GOOS != "windows" {
-		home = os.Getenv("HOME")
-	}
+	home := homedir.Get()
 	f.VisitAll(func(flag *Flag) {
 		format := "  -%s=%s"
-		if _, ok := flag.Value.(*stringValue); ok {
-			// put quotes on the value
-			format = "  -%s=%q"
-		}
 		names := []string{}
 		for _, name := range flag.Names {
 			if name[0] != '#' {
@@ -524,7 +518,7 @@ func (f *FlagSet) PrintDefaults() {
 			val := flag.DefValue
 
 			if home != "" && strings.HasPrefix(val, home) {
-				val = "~" + val[len(home):]
+				val = homedir.GetShortcutString() + val[len(home):]
 			}
 
 			fmt.Fprintf(writer, format, strings.Join(names, ", -"), val)


### PR DESCRIPTION
This makes use of **`%USERPROFILE%`** as a substitute for
`~` on Windows and prints shorter strings for default
cert paths etc.

Removes string escaping/quotes around default
path values printed in `docker help` command as they
are not really necessary and adds double backslashes
(\) on windows to gain some chars and reworded
messages with shorter ones for `--tls` and `-H` flags.

Fixes test `TestMainHelpWidth` on Windows (width
is exactly at 80 char limit).

![](http://cl.ly/image/0I0v3m033a1I/Image%202015-02-18%20at%202.09.11%20PM.png)

 On Unix it becomes:
![](http://cl.ly/image/2q3x021X1p0m/Image%202015-02-18%20at%202.37.01%20PM.png)

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @duglin @SvenDowideit @unclejack @jfrazelle 
