### PR TITLE
integration-cli: Better test cleanup with defer

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestContainerApiGetAll(t *testing.T) {
+	defer deleteAllContainers()
+
 	startCount, err := getContainerCount()
 	if err != nil {
 		t.Fatalf("Cannot query container count: %v", err)
@@ -46,12 +48,12 @@ func TestContainerApiGetAll(t *testing.T) {
 		t.Fatalf("Container Name mismatch. Expected: %q, received: %q\n", "/"+name, actual)
 	}
 
-	deleteAllContainers()
-
 	logDone("container REST API - check GET json/all=1")
 }
 
 func TestContainerApiGetExport(t *testing.T) {
+	defer deleteAllContainers()
+
 	name := "exportcontainer"
 	runCmd := exec.Command(dockerBinary, "run", "--name", name, "busybox", "touch", "/test")
 	out, _, err := runCommandWithOutput(runCmd)
@@ -82,12 +84,13 @@ func TestContainerApiGetExport(t *testing.T) {
 	if !found {
 		t.Fatalf("The created test file has not been found in the exported image")
 	}
-	deleteAllContainers()
 
 	logDone("container REST API - check GET containers/export")
 }
 
 func TestContainerApiGetChanges(t *testing.T) {
+	defer deleteAllContainers()
+
 	name := "changescontainer"
 	runCmd := exec.Command(dockerBinary, "run", "--name", name, "busybox", "rm", "/etc/passwd")
 	out, _, err := runCommandWithOutput(runCmd)
@@ -118,8 +121,6 @@ func TestContainerApiGetChanges(t *testing.T) {
 	if !success {
 		t.Fatalf("/etc/passwd has been removed but is not present in the diff")
 	}
-
-	deleteAllContainers()
 
 	logDone("container REST API - check GET containers/changes")
 }

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestInspectApiContainerResponse(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
@@ -52,8 +54,6 @@ func TestInspectApiContainerResponse(t *testing.T) {
 			t.Fatalf("Path of `true` should not be converted to boolean `true` via JSON marshalling")
 		}
 	}
-
-	deleteAllContainers()
 
 	logDone("container json - check keys in container json response")
 }

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -11,6 +11,8 @@ import (
 
 // Make sure we can create a simple container with some args
 func TestCreateArgs(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "create", "busybox", "command", "arg1", "arg2", "arg with space")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -56,13 +58,13 @@ func TestCreateArgs(t *testing.T) {
 		t.Fatalf("Unexpected args. Expected %v, received: %v", expected, c.Args)
 	}
 
-	deleteAllContainers()
-
 	logDone("create - args")
 }
 
 // Make sure we can set hostconfig options too
 func TestCreateHostConfig(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "create", "-P", "busybox", "echo")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -98,12 +100,12 @@ func TestCreateHostConfig(t *testing.T) {
 		t.Fatalf("Expected PublishAllPorts, got false")
 	}
 
-	deleteAllContainers()
-
 	logDone("create - hostconfig")
 }
 
 func TestCreateWithPortRange(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "create", "-p", "3300-3303:3300-3303/tcp", "busybox", "echo")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -147,12 +149,12 @@ func TestCreateWithPortRange(t *testing.T) {
 		}
 	}
 
-	deleteAllContainers()
-
 	logDone("create - port range")
 }
 
 func TestCreateWithiLargePortRange(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "create", "-p", "1-65535:1-65535/tcp", "busybox", "echo")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -196,13 +198,13 @@ func TestCreateWithiLargePortRange(t *testing.T) {
 		}
 	}
 
-	deleteAllContainers()
-
 	logDone("create - large port range")
 }
 
 // "test123" should be printed by docker create + start
 func TestCreateEchoStdout(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "create", "busybox", "echo", "test123")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -221,12 +223,12 @@ func TestCreateEchoStdout(t *testing.T) {
 		t.Errorf("container should've printed 'test123', got %q", out)
 	}
 
-	deleteAllContainers()
-
 	logDone("create - echo test123")
 }
 
 func TestCreateVolumesCreated(t *testing.T) {
+	defer deleteAllContainers()
+
 	name := "test_create_volume"
 	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "create", "--name", name, "-v", "/foo", "busybox")); err != nil {
 		t.Fatal(out, err)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -137,6 +137,8 @@ func TestDaemonStartBridgeWithoutIPAssociation(t *testing.T) {
 }
 
 func TestDaemonIptablesClean(t *testing.T) {
+	defer deleteAllContainers()
+
 	d := NewDaemon(t)
 	if err := d.StartWithBusybox(); err != nil {
 		t.Fatalf("Could not start daemon with busybox: %v", err)
@@ -174,12 +176,12 @@ func TestDaemonIptablesClean(t *testing.T) {
 		t.Fatalf("iptables output should not have contained %q, but was %q", ipTablesSearchString, out)
 	}
 
-	deleteAllContainers()
-
 	logDone("daemon - run,iptables - iptables rules cleaned after daemon restart")
 }
 
 func TestDaemonIptablesCreate(t *testing.T) {
+	defer deleteAllContainers()
+
 	d := NewDaemon(t)
 	if err := d.StartWithBusybox(); err != nil {
 		t.Fatalf("Could not start daemon with busybox: %v", err)
@@ -225,8 +227,6 @@ func TestDaemonIptablesCreate(t *testing.T) {
 	if !strings.Contains(out, ipTablesSearchString) {
 		t.Fatalf("iptables output after restart should have contained %q, but was %q", ipTablesSearchString, out)
 	}
-
-	deleteAllContainers()
 
 	logDone("daemon - run,iptables - iptables rules for always restarted container created after daemon restart")
 }

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestExec(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "testing", "busybox", "sh", "-c", "echo test > /tmp/file && sleep 100")
 	if out, _, _, err := runCommandWithStdoutStderr(runCmd); err != nil {
 		t.Fatal(out, err)
@@ -33,8 +35,6 @@ func TestExec(t *testing.T) {
 	if expected := "test"; out != expected {
 		t.Errorf("container exec should've printed %q but printed %q", expected, out)
 	}
-
-	deleteAllContainers()
 
 	logDone("exec - basic test")
 }
@@ -80,6 +80,8 @@ func TestExecInteractiveStdinClose(t *testing.T) {
 }
 
 func TestExecInteractive(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "testing", "busybox", "sh", "-c", "echo test > /tmp/file && sleep 100")
 	if out, _, _, err := runCommandWithStdoutStderr(runCmd); err != nil {
 		t.Fatal(out, err)
@@ -127,12 +129,12 @@ func TestExecInteractive(t *testing.T) {
 		t.Fatal("docker exec failed to exit on stdin close")
 	}
 
-	deleteAllContainers()
-
 	logDone("exec - Interactive test")
 }
 
 func TestExecAfterContainerRestart(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
@@ -157,12 +159,12 @@ func TestExecAfterContainerRestart(t *testing.T) {
 		t.Errorf("container should've printed hello, instead printed %q", outStr)
 	}
 
-	deleteAllContainers()
-
 	logDone("exec - exec running container after container restart")
 }
 
 func TestExecAfterDaemonRestart(t *testing.T) {
+	defer deleteAllContainers()
+
 	d := NewDaemon(t)
 	if err := d.StartWithBusybox(); err != nil {
 		t.Fatalf("Could not start daemon with busybox: %v", err)
@@ -222,6 +224,8 @@ func TestExecEnv(t *testing.T) {
 }
 
 func TestExecExitStatus(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "top", "busybox", "top")
 	if out, _, _, err := runCommandWithStdoutStderr(runCmd); err != nil {
 		t.Fatal(out, err)
@@ -239,7 +243,6 @@ func TestExecExitStatus(t *testing.T) {
 }
 
 func TestExecPausedContainer(t *testing.T) {
-
 	defer deleteAllContainers()
 	defer unpauseAllContainers()
 
@@ -493,6 +496,8 @@ func TestInspectExecID(t *testing.T) {
 }
 
 func TestLinksPingLinkedContainersOnRename(t *testing.T) {
+	defer deleteAllContainers()
+
 	var out string
 	out, _, _ = dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
 	idA := stripTrailingCharacters(out)
@@ -518,8 +523,6 @@ func TestLinksPingLinkedContainersOnRename(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-
-	deleteAllContainers()
 
 	logDone("links - ping linked container upon rename")
 }

--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestNetworkNat(t *testing.T) {
 	testRequires(t, SameHostDaemon)
+	defer deleteAllContainers()
 
 	iface, err := net.InterfaceByName("eth0")
 	if err != nil {
@@ -56,7 +57,6 @@ func TestNetworkNat(t *testing.T) {
 	if out, _, err = runCommandWithOutput(killCmd); err != nil {
 		t.Fatalf("failed to kill container: %s, %v", out, err)
 	}
-	deleteAllContainers()
 
 	logDone("network - make sure nat works through the host")
 }

--- a/integration-cli/docker_cli_port_test.go
+++ b/integration-cli/docker_cli_port_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestPortList(t *testing.T) {
+	defer deleteAllContainers()
+
 	// one port
 	runCmd := exec.Command(dockerBinary, "run", "-d", "-p", "9876:80", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
@@ -120,8 +122,6 @@ func TestPortList(t *testing.T) {
 	if out, _, err = runCommandWithOutput(runCmd); err != nil {
 		t.Fatal(out, err)
 	}
-
-	deleteAllContainers()
 
 	logDone("port - test port list")
 }

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestPsListContainers(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
@@ -223,8 +225,6 @@ func TestPsListContainers(t *testing.T) {
 		t.Error("Container list is not in the correct order")
 	}
 
-	deleteAllContainers()
-
 	logDone("ps - test ps options")
 }
 
@@ -246,6 +246,8 @@ func assertContainerList(out string, expected []string) bool {
 }
 
 func TestPsListContainersSize(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-d", "busybox", "echo", "hello")
 	runCommandWithOutput(cmd)
 	cmd = exec.Command(dockerBinary, "ps", "-s", "-n=1")
@@ -296,14 +298,14 @@ func TestPsListContainersSize(t *testing.T) {
 		t.Fatalf("Expected size %q, got %q", expectedSize, foundSize)
 	}
 
-	deleteAllContainers()
 	logDone("ps - test ps size")
 }
 
 func TestPsListContainersFilterStatus(t *testing.T) {
 	// FIXME: this should test paused, but it makes things hang and its wonky
 	// this is because paused containers can't be controlled by signals
-	deleteAllContainers()
+	defer deleteAllContainers()
+
 	// start exited container
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox")
 	out, _, err := runCommandWithOutput(runCmd)
@@ -347,12 +349,12 @@ func TestPsListContainersFilterStatus(t *testing.T) {
 		t.Fatalf("Expected id %s, got %s for running filter, output: %q", secondID[:12], containerOut, out)
 	}
 
-	deleteAllContainers()
-
 	logDone("ps - test ps filter status")
 }
 
 func TestPsListContainersFilterID(t *testing.T) {
+	defer deleteAllContainers()
+
 	// start container
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox")
 	out, _, err := runCommandWithOutput(runCmd)
@@ -377,12 +379,12 @@ func TestPsListContainersFilterID(t *testing.T) {
 		t.Fatalf("Expected id %s, got %s for exited filter, output: %q", firstID[:12], containerOut, out)
 	}
 
-	deleteAllContainers()
-
 	logDone("ps - test ps filter id")
 }
 
 func TestPsListContainersFilterName(t *testing.T) {
+	defer deleteAllContainers()
+
 	// start container
 	runCmd := exec.Command(dockerBinary, "run", "-d", "--name=a_name_to_match", "busybox")
 	out, _, err := runCommandWithOutput(runCmd)
@@ -406,8 +408,6 @@ func TestPsListContainersFilterName(t *testing.T) {
 	if containerOut != firstID[:12] {
 		t.Fatalf("Expected id %s, got %s for exited filter, output: %q", firstID[:12], containerOut, out)
 	}
-
-	deleteAllContainers()
 
 	logDone("ps - test ps filter name")
 }

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestRenameStoppedContainer(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "--name", "first_name", "-d", "busybox", "sh")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
@@ -36,12 +38,13 @@ func TestRenameStoppedContainer(t *testing.T) {
 	if name != "new_name" {
 		t.Fatal("Failed to rename container ", name)
 	}
-	deleteAllContainers()
 
 	logDone("rename - stopped container")
 }
 
 func TestRenameRunningContainer(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "--name", "first_name", "-d", "busybox", "sh")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
@@ -62,12 +65,13 @@ func TestRenameRunningContainer(t *testing.T) {
 	if name != "new_name" {
 		t.Fatal("Failed to rename container ")
 	}
-	deleteAllContainers()
 
 	logDone("rename - running container")
 }
 
 func TestRenameCheckNames(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "--name", "first_name", "-d", "busybox", "sh")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
@@ -92,8 +96,6 @@ func TestRenameCheckNames(t *testing.T) {
 	if err == nil && !strings.Contains(err.Error(), "No such image or container: first_name") {
 		t.Fatal(err)
 	}
-
-	deleteAllContainers()
 
 	logDone("rename - running container")
 }

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestRestartStoppedContainer(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "echo", "foobar")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
@@ -46,12 +48,12 @@ func TestRestartStoppedContainer(t *testing.T) {
 		t.Errorf("container should've printed 'foobar' twice")
 	}
 
-	deleteAllContainers()
-
 	logDone("restart - echo foobar for stopped container")
 }
 
 func TestRestartRunningContainer(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", "echo foobar && sleep 30 && echo 'should not print this'")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
@@ -89,13 +91,13 @@ func TestRestartRunningContainer(t *testing.T) {
 		t.Errorf("container should've printed 'foobar' twice")
 	}
 
-	deleteAllContainers()
-
 	logDone("restart - echo foobar for running container")
 }
 
 // Test that restarting a container with a volume does not create a new volume on restart. Regression test for #819.
 func TestRestartWithVolumes(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-d", "-v", "/test", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
@@ -146,8 +148,6 @@ func TestRestartWithVolumes(t *testing.T) {
 		volumesAfterRestart = strings.Trim(volumesAfterRestart, " \n\r")
 		t.Errorf("expected volume path: %s Actual path: %s", volumes, volumesAfterRestart)
 	}
-
-	deleteAllContainers()
 
 	logDone("restart - does not create a new volume on restart")
 }

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestRmContainerWithRemovedVolume(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--name", "losemyvolumes", "-v", "/tmp/testing:/test", "busybox", "true")
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
@@ -22,12 +24,12 @@ func TestRmContainerWithRemovedVolume(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	deleteAllContainers()
-
 	logDone("rm - removed volume")
 }
 
 func TestRmContainerWithVolume(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--name", "foo", "-v", "/srv", "busybox", "true")
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
@@ -38,12 +40,12 @@ func TestRmContainerWithVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deleteAllContainers()
-
 	logDone("rm - volume")
 }
 
 func TestRmRunningContainer(t *testing.T) {
+	defer deleteAllContainers()
+
 	createRunningContainer(t, "foo")
 
 	// Test cannot remove running container
@@ -52,12 +54,12 @@ func TestRmRunningContainer(t *testing.T) {
 		t.Fatalf("Expected error, can't rm a running container")
 	}
 
-	deleteAllContainers()
-
 	logDone("rm - running container")
 }
 
 func TestRmRunningContainerCheckError409(t *testing.T) {
+	defer deleteAllContainers()
+
 	createRunningContainer(t, "foo")
 
 	endpoint := "/containers/foo"
@@ -70,12 +72,12 @@ func TestRmRunningContainerCheckError409(t *testing.T) {
 		t.Fatalf("Expected error to contain '409 Conflict' but found %s", err)
 	}
 
-	deleteAllContainers()
-
 	logDone("rm - running container")
 }
 
 func TestRmForceRemoveRunningContainer(t *testing.T) {
+	defer deleteAllContainers()
+
 	createRunningContainer(t, "foo")
 
 	// Stop then remove with -s
@@ -84,12 +86,12 @@ func TestRmForceRemoveRunningContainer(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deleteAllContainers()
-
 	logDone("rm - running container with --force=true")
 }
 
 func TestRmContainerOrphaning(t *testing.T) {
+	defer deleteAllContainers()
+
 	dockerfile1 := `FROM busybox:latest
 	ENTRYPOINT ["/bin/true"]`
 	img := "test-container-orphaning"
@@ -99,6 +101,7 @@ func TestRmContainerOrphaning(t *testing.T) {
 
 	// build first dockerfile
 	img1, err := buildImage(img, dockerfile1, true)
+	defer deleteImages(img1)
 	if err != nil {
 		t.Fatalf("Could not build image %s: %v", img, err)
 	}
@@ -122,9 +125,6 @@ func TestRmContainerOrphaning(t *testing.T) {
 	if !strings.Contains(out, img1) {
 		t.Fatalf("Orphaned container (could not find %q in docker images): %s", img1, out)
 	}
-
-	deleteAllContainers()
-	deleteImages(img1)
 
 	logDone("rm - container orphaning")
 }

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -78,6 +78,8 @@ func TestRmiTag(t *testing.T) {
 }
 
 func TestRmiTagWithExistingContainers(t *testing.T) {
+	defer deleteAllContainers()
+
 	container := "test-delete-tag"
 	newtag := "busybox:newtag"
 	bb := "busybox:latest"
@@ -95,12 +97,12 @@ func TestRmiTagWithExistingContainers(t *testing.T) {
 		t.Fatalf("Expected 1 untagged entry got %d: %q", d, out)
 	}
 
-	deleteAllContainers()
-
 	logDone("rmi - delete tag with existing containers")
 }
 
 func TestRmiForceWithExistingContainers(t *testing.T) {
+	defer deleteAllContainers()
+
 	image := "busybox-clone"
 
 	cmd := exec.Command(dockerBinary, "build", "--no-cache", "-t", image, "-")
@@ -119,8 +121,6 @@ MAINTAINER foo`)
 	if err != nil {
 		t.Fatalf("Could not remove image %s:  %s, %v", image, out, err)
 	}
-
-	deleteAllContainers()
 
 	logDone("rmi - force delete with existing containers")
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -25,6 +25,7 @@ import (
 
 // "test123" should be printed by docker run
 func TestRunEchoStdout(t *testing.T) {
+	defer deleteAllContainers()
 	runCmd := exec.Command(dockerBinary, "run", "busybox", "echo", "test123")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -35,13 +36,12 @@ func TestRunEchoStdout(t *testing.T) {
 		t.Errorf("container should've printed 'test123'")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - echo test123")
 }
 
 // "test" should be printed
 func TestRunEchoStdoutWithMemoryLimit(t *testing.T) {
+	defer deleteAllContainers()
 	runCmd := exec.Command(dockerBinary, "run", "-m", "16m", "busybox", "echo", "test")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -55,26 +55,26 @@ func TestRunEchoStdoutWithMemoryLimit(t *testing.T) {
 
 	}
 
-	deleteAllContainers()
-
 	logDone("run - echo with memory limit")
 }
 
 // should run without memory swap
 func TestRunWithoutMemoryswapLimit(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-m", "16m", "--memory-swap", "-1", "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		t.Fatalf("failed to run container, output: %q", out)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - without memory swap limit")
 }
 
 // "test" should be printed
 func TestRunEchoStdoutWitCPULimit(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-c", "1000", "busybox", "echo", "test")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -85,13 +85,13 @@ func TestRunEchoStdoutWitCPULimit(t *testing.T) {
 		t.Errorf("container should've printed 'test'")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - echo with CPU limit")
 }
 
 // "test" should be printed
 func TestRunEchoStdoutWithCPUAndMemoryLimit(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-c", "1000", "-m", "16m", "busybox", "echo", "test")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -102,13 +102,13 @@ func TestRunEchoStdoutWithCPUAndMemoryLimit(t *testing.T) {
 		t.Errorf("container should've printed 'test', got %q instead", out)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - echo with CPU and memory limit")
 }
 
 // "test" should be printed
 func TestRunEchoNamedContainer(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "--name", "testfoonamedcontainer", "busybox", "echo", "test")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -123,13 +123,13 @@ func TestRunEchoNamedContainer(t *testing.T) {
 		t.Errorf("failed to remove the named container: %v", err)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - echo with named container")
 }
 
 // docker run should not leak file descriptors
 func TestRunLeakyFileDescriptors(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "busybox", "ls", "-C", "/proc/self/fd")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -141,21 +141,19 @@ func TestRunLeakyFileDescriptors(t *testing.T) {
 		t.Errorf("container should've printed '0  1  2  3', not: %s", out)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - check file descriptor leakage")
 }
 
 // it should be possible to ping Google DNS resolver
 // this will fail when Internet access is unavailable
 func TestRunPingGoogle(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "busybox", "ping", "-c", "1", "8.8.8.8")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
 		t.Fatalf("failed to run container: %v, output: %q", err, out)
 	}
-
-	deleteAllContainers()
 
 	logDone("run - ping 8.8.8.8")
 }
@@ -163,12 +161,12 @@ func TestRunPingGoogle(t *testing.T) {
 // the exit code should be 0
 // some versions of lxc might make this test fail
 func TestRunExitCodeZero(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "busybox", "true")
 	if out, _, err := runCommandWithOutput(runCmd); err != nil {
 		t.Errorf("container should've exited with exit code 0: %s, %v", out, err)
 	}
-
-	deleteAllContainers()
 
 	logDone("run - exit with 0")
 }
@@ -176,6 +174,8 @@ func TestRunExitCodeZero(t *testing.T) {
 // the exit code should be 1
 // some versions of lxc might make this test fail
 func TestRunExitCodeOne(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "busybox", "false")
 	exitCode, err := runCommand(runCmd)
 	if err != nil && !strings.Contains("exit status 1", fmt.Sprintf("%s", err)) {
@@ -185,14 +185,14 @@ func TestRunExitCodeOne(t *testing.T) {
 		t.Errorf("container should've exited with exit code 1")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - exit with 1")
 }
 
 // it should be possible to pipe in data via stdin to a process running in a container
 // some versions of lxc might make this test fail
 func TestRunStdinPipe(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command("bash", "-c", `echo "blahblah" | docker run -i -a stdin busybox cat`)
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -228,13 +228,13 @@ func TestRunStdinPipe(t *testing.T) {
 		t.Fatalf("rm failed to remove container: %s, %v", out, err)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - pipe in with -i -a stdin")
 }
 
 // the container's ID should be printed when starting a container in detached mode
 func TestRunDetachedContainerIDPrinting(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -264,13 +264,13 @@ func TestRunDetachedContainerIDPrinting(t *testing.T) {
 		t.Errorf("rm didn't print the container ID %s %s", out, rmOut)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - print container ID in detached mode")
 }
 
 // the working directory should be set correctly
 func TestRunWorkingDirectory(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-w", "/root", "busybox", "pwd")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -295,14 +295,14 @@ func TestRunWorkingDirectory(t *testing.T) {
 		t.Errorf("--workdir failed to set working directory")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - run with working directory set by -w")
 	logDone("run - run with working directory set by --workdir")
 }
 
 // pinging Google's DNS resolver should fail when we disable the networking
 func TestRunWithoutNetworking(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "--net=none", "busybox", "ping", "-c", "1", "8.8.8.8")
 	out, _, exitCode, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil && exitCode != 1 {
@@ -321,14 +321,14 @@ func TestRunWithoutNetworking(t *testing.T) {
 		t.Errorf("-n=false should've disabled the network; the container shouldn't have been able to ping 8.8.8.8")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - disable networking with --net=none")
 	logDone("run - disable networking with -n=false")
 }
 
 //test --link use container name to link target
 func TestRunLinksContainerWithContainerName(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-i", "-t", "-d", "--name", "parent", "busybox")
 	out, _, _, err := runCommandWithStdoutStderr(cmd)
 	if err != nil {
@@ -348,13 +348,14 @@ func TestRunLinksContainerWithContainerName(t *testing.T) {
 	if !strings.Contains(out, ip+"	test") {
 		t.Fatalf("use a container name to link target failed")
 	}
-	deleteAllContainers()
 
 	logDone("run - use a container name to link target work")
 }
 
 //test --link use container id to link target
 func TestRunLinksContainerWithContainerId(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-i", "-t", "-d", "busybox")
 	cID, _, _, err := runCommandWithStdoutStderr(cmd)
 	if err != nil {
@@ -376,13 +377,13 @@ func TestRunLinksContainerWithContainerId(t *testing.T) {
 		t.Fatalf("use a container id to link target failed")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - use a container id to link target work")
 }
 
 // Regression test for #4741
 func TestRunWithVolumesAsFiles(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "--name", "test-data", "--volume", "/etc/hosts:/target-file", "busybox", "true")
 	out, stderr, exitCode, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil && exitCode != 0 {
@@ -394,13 +395,14 @@ func TestRunWithVolumesAsFiles(t *testing.T) {
 	if err != nil && exitCode != 0 {
 		t.Fatal("2", out, stderr, err)
 	}
-	deleteAllContainers()
 
 	logDone("run - regression test for #4741 - volumes from as files")
 }
 
 // Regression test for #4979
 func TestRunWithVolumesFromExited(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "--name", "test-data", "--volume", "/some/dir", "busybox", "touch", "/some/dir/file")
 	out, stderr, exitCode, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil && exitCode != 0 {
@@ -412,30 +414,29 @@ func TestRunWithVolumesFromExited(t *testing.T) {
 	if err != nil && exitCode != 0 {
 		t.Fatal("2", out, stderr, err)
 	}
-	deleteAllContainers()
 
 	logDone("run - regression test for #4979 - volumes-from on exited container")
 }
 
 // Regression test for #4830
 func TestRunWithRelativePath(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "-v", "tmp:/other-tmp", "busybox", "true")
 	if _, _, _, err := runCommandWithStdoutStderr(runCmd); err == nil {
 		t.Fatalf("relative path should result in an error")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - volume with relative path")
 }
 
 func TestRunVolumesMountedAsReadonly(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-v", "/test:/test:ro", "busybox", "touch", "/test/somefile")
 	if code, err := runCommand(cmd); err == nil || code == 0 {
 		t.Fatalf("run should fail because volume is ro: exit code %d", code)
 	}
-
-	deleteAllContainers()
 
 	logDone("run - volumes as readonly mount")
 }
@@ -508,6 +509,7 @@ func TestVolumesFromGetsProperMode(t *testing.T) {
 
 // Test for GH#10618
 func TestRunNoDupVolumes(t *testing.T) {
+	defer deleteAllContainers()
 
 	bindPath1, err := ioutil.TempDir("", "test1")
 	if err != nil {
@@ -532,13 +534,14 @@ func TestRunNoDupVolumes(t *testing.T) {
 			t.Fatalf("Expected 'duplicate volume' error, got %v", err)
 		}
 	}
-	deleteAllContainers()
 
 	logDone("run - don't allow multiple (bind) volumes on the same container target")
 }
 
 // Test for #1351
 func TestRunApplyVolumesFromBeforeVolumes(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--name", "parent", "-v", "/test", "busybox", "touch", "/test/foo")
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
@@ -549,12 +552,12 @@ func TestRunApplyVolumesFromBeforeVolumes(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - volumes from mounted first")
 }
 
 func TestRunMultipleVolumesFrom(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--name", "parent1", "-v", "/test", "busybox", "touch", "/test/foo")
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
@@ -571,13 +574,13 @@ func TestRunMultipleVolumesFrom(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - multiple volumes from")
 }
 
 // this tests verifies the ID format for the container
 func TestRunVerifyContainerID(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
 	out, exit, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -594,19 +597,17 @@ func TestRunVerifyContainerID(t *testing.T) {
 		t.Fatalf("Invalid container ID: %s", out)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - verify container ID")
 }
 
 // Test that creating a container with a volume doesn't crash. Regression test for #995.
 func TestRunCreateVolume(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-v", "/var/lib/data", "busybox", "true")
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
 	}
-
-	deleteAllContainers()
 
 	logDone("run - create docker managed volume")
 }
@@ -614,16 +615,21 @@ func TestRunCreateVolume(t *testing.T) {
 // Test that creating a volume with a symlink in its path works correctly. Test for #5152.
 // Note that this bug happens only with symlinks with a target that starts with '/'.
 func TestRunCreateVolumeWithSymlink(t *testing.T) {
-	buildCmd := exec.Command(dockerBinary, "build", "-t", "docker-test-createvolumewithsymlink", "-")
+	defer deleteAllContainers()
+
+	image := "docker-test-createvolumewithsymlink"
+	defer deleteImages(image)
+
+	buildCmd := exec.Command(dockerBinary, "build", "-t", image, "-")
 	buildCmd.Stdin = strings.NewReader(`FROM busybox
 		RUN ln -s home /bar`)
 	buildCmd.Dir = workingDirectory
 	err := buildCmd.Run()
 	if err != nil {
-		t.Fatalf("could not build 'docker-test-createvolumewithsymlink': %v", err)
+		t.Fatalf("could not build '%s': %v", image, err)
 	}
 
-	cmd := exec.Command(dockerBinary, "run", "-v", "/bar/foo", "--name", "test-createvolumewithsymlink", "docker-test-createvolumewithsymlink", "sh", "-c", "mount | grep -q /home/foo")
+	cmd := exec.Command(dockerBinary, "run", "-v", "/bar/foo", "--name", "test-createvolumewithsymlink", image, "sh", "-c", "mount | grep -q /home/foo")
 	exitCode, err := runCommand(cmd)
 	if err != nil || exitCode != 0 {
 		t.Fatalf("[run] err: %v, exitcode: %d", err, exitCode)
@@ -648,15 +654,16 @@ func TestRunCreateVolumeWithSymlink(t *testing.T) {
 		t.Fatalf("[open] (expecting 'file does not exist' error) err: %v, volPath: %s", err, volPath)
 	}
 
-	deleteImages("docker-test-createvolumewithsymlink")
-	deleteAllContainers()
-
 	logDone("run - create volume with symlink")
 }
 
 // Tests that a volume path that has a symlink exists in a container mounting it with `--volumes-from`.
 func TestRunVolumesFromSymlinkPath(t *testing.T) {
+	defer deleteAllContainers()
+
 	name := "docker-test-volumesfromsymlinkpath"
+	defer deleteImages(name)
+
 	buildCmd := exec.Command(dockerBinary, "build", "-t", name, "-")
 	buildCmd.Stdin = strings.NewReader(`FROM busybox
 		RUN ln -s home /foo
@@ -679,13 +686,12 @@ func TestRunVolumesFromSymlinkPath(t *testing.T) {
 		t.Fatalf("[run] err: %v, exitcode: %d", err, exitCode)
 	}
 
-	deleteAllContainers()
-	deleteImages(name)
-
 	logDone("run - volumes-from symlink path")
 }
 
 func TestRunExitCode(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "busybox", "/bin/sh", "-c", "exit 72")
 
 	exit, err := runCommand(cmd)
@@ -696,14 +702,13 @@ func TestRunExitCode(t *testing.T) {
 		t.Fatalf("expected exit code 72 received %d", exit)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - correct exit code")
 }
 
 func TestRunUserDefaultsToRoot(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "busybox", "id")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "busybox", "id")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		t.Fatal(err, out)
@@ -711,14 +716,14 @@ func TestRunUserDefaultsToRoot(t *testing.T) {
 	if !strings.Contains(out, "uid=0(root) gid=0(root)") {
 		t.Fatalf("expected root user got %s", out)
 	}
-	deleteAllContainers()
 
 	logDone("run - default user")
 }
 
 func TestRunUserByName(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-u", "root", "busybox", "id")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "-u", "root", "busybox", "id")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		t.Fatal(err, out)
@@ -726,14 +731,14 @@ func TestRunUserByName(t *testing.T) {
 	if !strings.Contains(out, "uid=0(root) gid=0(root)") {
 		t.Fatalf("expected root user got %s", out)
 	}
-	deleteAllContainers()
 
 	logDone("run - user by name")
 }
 
 func TestRunUserByID(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-u", "1", "busybox", "id")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "-u", "1", "busybox", "id")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		t.Fatal(err, out)
@@ -741,14 +746,14 @@ func TestRunUserByID(t *testing.T) {
 	if !strings.Contains(out, "uid=1(daemon) gid=1(daemon)") {
 		t.Fatalf("expected daemon user got %s", out)
 	}
-	deleteAllContainers()
 
 	logDone("run - user by id")
 }
 
 func TestRunUserByIDBig(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-u", "2147483648", "busybox", "id")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "-u", "2147483648", "busybox", "id")
 	out, _, err := runCommandWithOutput(cmd)
 	if err == nil {
 		t.Fatal("No error, but must be.", out)
@@ -756,14 +761,14 @@ func TestRunUserByIDBig(t *testing.T) {
 	if !strings.Contains(out, "Uids and gids must be in range") {
 		t.Fatalf("expected error about uids range, got %s", out)
 	}
-	deleteAllContainers()
 
 	logDone("run - user by id, id too big")
 }
 
 func TestRunUserByIDNegative(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-u", "-1", "busybox", "id")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "-u", "-1", "busybox", "id")
 	out, _, err := runCommandWithOutput(cmd)
 	if err == nil {
 		t.Fatal("No error, but must be.", out)
@@ -771,14 +776,14 @@ func TestRunUserByIDNegative(t *testing.T) {
 	if !strings.Contains(out, "Uids and gids must be in range") {
 		t.Fatalf("expected error about uids range, got %s", out)
 	}
-	deleteAllContainers()
 
 	logDone("run - user by id, id negative")
 }
 
 func TestRunUserByIDZero(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-u", "0", "busybox", "id")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "-u", "0", "busybox", "id")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		t.Fatal(err, out)
@@ -786,24 +791,25 @@ func TestRunUserByIDZero(t *testing.T) {
 	if !strings.Contains(out, "uid=0(root) gid=0(root) groups=10(wheel)") {
 		t.Fatalf("expected daemon user got %s", out)
 	}
-	deleteAllContainers()
 
 	logDone("run - user by id, zero uid")
 }
 
 func TestRunUserNotFound(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-u", "notme", "busybox", "id")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "-u", "notme", "busybox", "id")
 	_, err := runCommand(cmd)
 	if err == nil {
 		t.Fatal("unknown user should cause container to fail")
 	}
-	deleteAllContainers()
 
 	logDone("run - user not found")
 }
 
 func TestRunTwoConcurrentContainers(t *testing.T) {
+	defer deleteAllContainers()
+
 	group := sync.WaitGroup{}
 	group.Add(2)
 
@@ -819,12 +825,12 @@ func TestRunTwoConcurrentContainers(t *testing.T) {
 
 	group.Wait()
 
-	deleteAllContainers()
-
 	logDone("run - two concurrent containers")
 }
 
 func TestRunEnvironment(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-h", "testing", "-e=FALSE=true", "-e=TRUE", "-e=TRICKY", "-e=HOME=", "busybox", "env")
 	cmd.Env = append(os.Environ(),
 		"TRUE=false",
@@ -865,8 +871,6 @@ func TestRunEnvironment(t *testing.T) {
 		}
 	}
 
-	deleteAllContainers()
-
 	logDone("run - verify environment")
 }
 
@@ -874,6 +878,8 @@ func TestRunEnvironmentErase(t *testing.T) {
 	// Test to make sure that when we use -e on env vars that are
 	// not set in our local env that they're removed (if present) in
 	// the container
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-e", "FOO", "-e", "HOSTNAME", "busybox", "env")
 	cmd.Env = appendDockerHostEnv([]string{})
 
@@ -905,14 +911,14 @@ func TestRunEnvironmentErase(t *testing.T) {
 		}
 	}
 
-	deleteAllContainers()
-
 	logDone("run - verify environment erase")
 }
 
 func TestRunEnvironmentOverride(t *testing.T) {
 	// Test to make sure that when we use -e on env vars that are
 	// already in the env that we're overriding them
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-e", "HOSTNAME", "-e", "HOME=/root2", "busybox", "env")
 	cmd.Env = appendDockerHostEnv([]string{"HOSTNAME=bar"})
 
@@ -945,49 +951,48 @@ func TestRunEnvironmentOverride(t *testing.T) {
 		}
 	}
 
-	deleteAllContainers()
-
 	logDone("run - verify environment override")
 }
 
 func TestRunContainerNetwork(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "busybox", "ping", "-c", "1", "127.0.0.1")
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
 	}
-
-	deleteAllContainers()
 
 	logDone("run - test container network via ping")
 }
 
 // Issue #4681
 func TestRunLoopbackWhenNetworkDisabled(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--net=none", "busybox", "ping", "-c", "1", "127.0.0.1")
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - test container loopback when networking disabled")
 }
 
 func TestRunNetHostNotAllowedWithLinks(t *testing.T) {
-	_, _, err := dockerCmd(t, "run", "--name", "linked", "busybox", "true")
+	defer deleteAllContainers()
 
+	_, _, err := dockerCmd(t, "run", "--name", "linked", "busybox", "true")
 	cmd := exec.Command(dockerBinary, "run", "--net=host", "--link", "linked:linked", "busybox", "true")
 	_, _, err = runCommandWithOutput(cmd)
 	if err == nil {
 		t.Fatal("Expected error")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - don't allow --net=host to be used with links")
 }
 
 func TestRunLoopbackOnlyExistsWhenNetworkingDisabled(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--net=none", "busybox", "ip", "-o", "-4", "a", "show", "up")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -1013,8 +1018,6 @@ func TestRunLoopbackOnlyExistsWhenNetworkingDisabled(t *testing.T) {
 		t.Fatalf("Wrong interface in test container: expected [1: lo], got %s", out)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - test loopback only exists when networking disabled")
 }
 
@@ -1024,6 +1027,8 @@ func TestRunLoopbackOnlyExistsWhenNetworkingDisabled(t *testing.T) {
 // codepath is executed with "docker run -h <hostname>".  Both were manually
 // tested, but this testcase takes the simpler path of using "run -h .."
 func TestRunFullHostnameSet(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-h", "foo.bar.baz", "busybox", "hostname")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -1033,12 +1038,13 @@ func TestRunFullHostnameSet(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual != "foo.bar.baz" {
 		t.Fatalf("expected hostname 'foo.bar.baz', received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test fully qualified hostname set with -h")
 }
 
 func TestRunPrivilegedCanMknod(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--privileged", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -1048,12 +1054,13 @@ func TestRunPrivilegedCanMknod(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		t.Fatalf("expected output ok received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test privileged can mknod")
 }
 
 func TestRunUnPrivilegedCanMknod(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -1063,7 +1070,6 @@ func TestRunUnPrivilegedCanMknod(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		t.Fatalf("expected output ok received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test un-privileged can mknod")
 }
@@ -1080,6 +1086,8 @@ func TestRunCapDropInvalid(t *testing.T) {
 }
 
 func TestRunCapDropCannotMknod(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--cap-drop=MKNOD", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 	out, _, err := runCommandWithOutput(cmd)
 	if err == nil {
@@ -1089,12 +1097,13 @@ func TestRunCapDropCannotMknod(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual == "ok" {
 		t.Fatalf("expected output not ok received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test --cap-drop=MKNOD cannot mknod")
 }
 
 func TestRunCapDropCannotMknodLowerCase(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--cap-drop=mknod", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 	out, _, err := runCommandWithOutput(cmd)
 	if err == nil {
@@ -1104,12 +1113,13 @@ func TestRunCapDropCannotMknodLowerCase(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual == "ok" {
 		t.Fatalf("expected output not ok received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test --cap-drop=mknod cannot mknod lowercase")
 }
 
 func TestRunCapDropALLCannotMknod(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--cap-drop=ALL", "--cap-add=SETGID", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 	out, _, err := runCommandWithOutput(cmd)
 	if err == nil {
@@ -1119,12 +1129,13 @@ func TestRunCapDropALLCannotMknod(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual == "ok" {
 		t.Fatalf("expected output not ok received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test --cap-drop=ALL cannot mknod")
 }
 
 func TestRunCapDropALLAddMknodCanMknod(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--cap-drop=ALL", "--cap-add=MKNOD", "--cap-add=SETGID", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -1134,7 +1145,6 @@ func TestRunCapDropALLAddMknodCanMknod(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		t.Fatalf("expected output ok received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test --cap-drop=ALL --cap-add=MKNOD can mknod")
 }
@@ -1152,6 +1162,8 @@ func TestRunCapAddInvalid(t *testing.T) {
 }
 
 func TestRunCapAddCanDownInterface(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--cap-add=NET_ADMIN", "busybox", "sh", "-c", "ip link set eth0 down && echo ok")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -1161,12 +1173,13 @@ func TestRunCapAddCanDownInterface(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		t.Fatalf("expected output ok received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test --cap-add=NET_ADMIN can set eth0 down")
 }
 
 func TestRunCapAddALLCanDownInterface(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--cap-add=ALL", "busybox", "sh", "-c", "ip link set eth0 down && echo ok")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -1176,12 +1189,13 @@ func TestRunCapAddALLCanDownInterface(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		t.Fatalf("expected output ok received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test --cap-add=ALL can set eth0 down")
 }
 
 func TestRunCapAddALLDropNetAdminCanDownInterface(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--cap-add=ALL", "--cap-drop=NET_ADMIN", "busybox", "sh", "-c", "ip link set eth0 down && echo ok")
 	out, _, err := runCommandWithOutput(cmd)
 	if err == nil {
@@ -1191,14 +1205,14 @@ func TestRunCapAddALLDropNetAdminCanDownInterface(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual == "ok" {
 		t.Fatalf("expected output not ok received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test --cap-add=ALL --cap-drop=NET_ADMIN cannot set eth0 down")
 }
 
 func TestRunPrivilegedCanMount(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "--privileged", "busybox", "sh", "-c", "mount -t tmpfs none /tmp && echo ok")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "--privileged", "busybox", "sh", "-c", "mount -t tmpfs none /tmp && echo ok")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		t.Fatal(err)
@@ -1207,14 +1221,14 @@ func TestRunPrivilegedCanMount(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		t.Fatalf("expected output ok received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test privileged can mount")
 }
 
 func TestRunUnPrivilegedCannotMount(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "busybox", "sh", "-c", "mount -t tmpfs none /tmp && echo ok")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "busybox", "sh", "-c", "mount -t tmpfs none /tmp && echo ok")
 	out, _, err := runCommandWithOutput(cmd)
 	if err == nil {
 		t.Fatal(err, out)
@@ -1223,69 +1237,68 @@ func TestRunUnPrivilegedCannotMount(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual == "ok" {
 		t.Fatalf("expected output not ok received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test un-privileged cannot mount")
 }
 
 func TestRunSysNotWritableInNonPrivilegedContainers(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "busybox", "touch", "/sys/kernel/profiling")
 	if code, err := runCommand(cmd); err == nil || code == 0 {
 		t.Fatal("sys should not be writable in a non privileged container")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - sys not writable in non privileged container")
 }
 
 func TestRunSysWritableInPrivilegedContainers(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--privileged", "busybox", "touch", "/sys/kernel/profiling")
 	if code, err := runCommand(cmd); err != nil || code != 0 {
 		t.Fatalf("sys should be writable in privileged container")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - sys writable in privileged container")
 }
 
 func TestRunProcNotWritableInNonPrivilegedContainers(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "busybox", "touch", "/proc/sysrq-trigger")
 	if code, err := runCommand(cmd); err == nil || code == 0 {
 		t.Fatal("proc should not be writable in a non privileged container")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - proc not writable in non privileged container")
 }
 
 func TestRunProcWritableInPrivilegedContainers(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--privileged", "busybox", "touch", "/proc/sysrq-trigger")
 	if code, err := runCommand(cmd); err != nil || code != 0 {
 		t.Fatalf("proc should be writable in privileged container")
 	}
-
-	deleteAllContainers()
-
 	logDone("run - proc writable in privileged container")
 }
 
 func TestRunWithCpuset(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--cpuset", "0", "busybox", "true")
 	if code, err := runCommand(cmd); err != nil || code != 0 {
 		t.Fatalf("container should run successfuly with cpuset of 0: %s", err)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - cpuset 0")
 }
 
 func TestRunDeviceNumbers(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "busybox", "sh", "-c", "ls -l /dev/null")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "busybox", "sh", "-c", "ls -l /dev/null")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		t.Fatal(err, out)
@@ -1299,14 +1312,14 @@ func TestRunDeviceNumbers(t *testing.T) {
 	if !(reflect.DeepEqual(deviceLineFields, expected)) {
 		t.Fatalf("expected output\ncrw-rw-rw- 1 root root 1, 3 May 24 13:29 /dev/null\n received\n %s\n", out)
 	}
-	deleteAllContainers()
 
 	logDone("run - test device numbers")
 }
 
 func TestRunThatCharacterDevicesActLikeCharacterDevices(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "busybox", "sh", "-c", "dd if=/dev/zero of=/zero bs=1k count=5 2> /dev/null ; du -h /zero")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "busybox", "sh", "-c", "dd if=/dev/zero of=/zero bs=1k count=5 2> /dev/null ; du -h /zero")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		t.Fatal(err, out)
@@ -1315,26 +1328,25 @@ func TestRunThatCharacterDevicesActLikeCharacterDevices(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual[0] == '0' {
 		t.Fatalf("expected a new file called /zero to be create that is greater than 0 bytes long, but du says: %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test that character devices work.")
 }
 
 func TestRunUnprivilegedWithChroot(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "busybox", "chroot", "/", "true")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "busybox", "chroot", "/", "true")
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
 	}
-
-	deleteAllContainers()
 
 	logDone("run - unprivileged with chroot")
 }
 
 func TestRunAddingOptionalDevices(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "--device", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "ls /dev/nulo")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "--device", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "ls /dev/nulo")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		t.Fatal(err, out)
@@ -1343,14 +1355,14 @@ func TestRunAddingOptionalDevices(t *testing.T) {
 	if actual := strings.Trim(out, "\r\n"); actual != "/dev/nulo" {
 		t.Fatalf("expected output /dev/nulo, received %s", actual)
 	}
-	deleteAllContainers()
 
 	logDone("run - test --device argument")
 }
 
 func TestRunModeHostname(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-h=testhostname", "busybox", "cat", "/etc/hostname")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "-h=testhostname", "busybox", "cat", "/etc/hostname")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		t.Fatal(err, out)
@@ -1374,12 +1386,12 @@ func TestRunModeHostname(t *testing.T) {
 		t.Fatalf("expected %q, but says: %q", hostname, actual)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - hostname and several network modes")
 }
 
 func TestRunRootWorkdir(t *testing.T) {
+	defer deleteAllContainers()
+
 	s, _, err := dockerCmd(t, "run", "--workdir", "/", "busybox", "pwd")
 	if err != nil {
 		t.Fatal(s, err)
@@ -1388,36 +1400,35 @@ func TestRunRootWorkdir(t *testing.T) {
 		t.Fatalf("pwd returned %q (expected /\\n)", s)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - workdir /")
 }
 
 func TestRunAllowBindMountingRoot(t *testing.T) {
+	defer deleteAllContainers()
+
 	s, _, err := dockerCmd(t, "run", "-v", "/:/host", "busybox", "ls", "/host")
 	if err != nil {
 		t.Fatal(s, err)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - bind mount / as volume")
 }
 
 func TestRunDisallowBindMountingRootToRoot(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-v", "/:/", "busybox", "ls", "/host")
 	out, _, err := runCommandWithOutput(cmd)
 	if err == nil {
 		t.Fatal(out, err)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - bind mount /:/ as volume should not work")
 }
 
 // Verify that a container gets default DNS when only localhost resolvers exist
 func TestRunDnsDefaultOptions(t *testing.T) {
+	defer deleteAllContainers()
 
 	// preserve original resolv.conf for restoring after test
 	origResolvConf, err := ioutil.ReadFile("/etc/resolv.conf")
@@ -1454,12 +1465,12 @@ func TestRunDnsDefaultOptions(t *testing.T) {
 		t.Fatalf("expected resolv.conf be: %q, but was: %q", expected, actual)
 	}
 
-	deleteAllContainers()
-
 	logDone("run - dns default options")
 }
 
 func TestRunDnsOptions(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--dns=127.0.0.1", "--dns-search=mydomain", "busybox", "cat", "/etc/resolv.conf")
 
 	out, _, err := runCommandWithOutput(cmd)
@@ -1488,6 +1499,8 @@ func TestRunDnsOptions(t *testing.T) {
 }
 
 func TestRunDnsOptionsBasedOnHostResolvConf(t *testing.T) {
+	defer deleteAllContainers()
+
 	var out string
 
 	origResolvConf, err := ioutil.ReadFile("/etc/resolv.conf")
@@ -1577,8 +1590,7 @@ func TestRunDnsOptionsBasedOnHostResolvConf(t *testing.T) {
 			t.Fatalf("expected %q domain, but says: %q", actualSearch[i], hostSearch[i])
 		}
 	}
-
-	deleteAllContainers()
+	defer deleteAllContainers()
 
 	logDone("run - dns options based on host resolv.conf")
 }
@@ -1753,8 +1765,9 @@ func TestRunAddHost(t *testing.T) {
 
 // Regression test for #6983
 func TestRunAttachStdErrOnlyTTYMode(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-t", "-a", "stderr", "busybox", "true")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "-t", "-a", "stderr", "busybox", "true")
 	exitCode, err := runCommand(cmd)
 	if err != nil {
 		t.Fatal(err)
@@ -1762,13 +1775,13 @@ func TestRunAttachStdErrOnlyTTYMode(t *testing.T) {
 		t.Fatalf("Container should have exited with error code 0")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - Attach stderr only with -t")
 }
 
 // Regression test for #6983
 func TestRunAttachStdOutOnlyTTYMode(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-t", "-a", "stdout", "busybox", "true")
 
 	exitCode, err := runCommand(cmd)
@@ -1778,23 +1791,20 @@ func TestRunAttachStdOutOnlyTTYMode(t *testing.T) {
 		t.Fatalf("Container should have exited with error code 0")
 	}
 
-	deleteAllContainers()
-
 	logDone("run - Attach stdout only with -t")
 }
 
 // Regression test for #6983
 func TestRunAttachStdOutAndErrTTYMode(t *testing.T) {
-	cmd := exec.Command(dockerBinary, "run", "-t", "-a", "stdout", "-a", "stderr", "busybox", "true")
+	defer deleteAllContainers()
 
+	cmd := exec.Command(dockerBinary, "run", "-t", "-a", "stdout", "-a", "stderr", "busybox", "true")
 	exitCode, err := runCommand(cmd)
 	if err != nil {
 		t.Fatal(err)
 	} else if exitCode != 0 {
 		t.Fatalf("Container should have exited with error code 0")
 	}
-
-	deleteAllContainers()
 
 	logDone("run - Attach stderr and stdout with -t")
 }
@@ -1805,7 +1815,6 @@ func TestRunAttachWithDettach(t *testing.T) {
 	defer deleteAllContainers()
 
 	cmd := exec.Command(dockerBinary, "run", "-d", "--attach", "stdout", "busybox", "true")
-
 	_, stderr, _, err := runCommandWithStdoutStderr(cmd)
 	if err == nil {
 		t.Fatalf("Container should have exited with error code different than 0", err)
@@ -2232,6 +2241,8 @@ func TestRunBindMounts(t *testing.T) {
 // Ensure that CIDFile gets deleted if it's empty
 // Perform this test by making `docker run` fail
 func TestRunCidFileCleanupIfEmpty(t *testing.T) {
+	defer deleteAllContainers()
+
 	tmpDir, err := ioutil.TempDir("", "TestRunCidFile")
 	if err != nil {
 		t.Fatal(err)
@@ -2248,7 +2259,6 @@ func TestRunCidFileCleanupIfEmpty(t *testing.T) {
 	if _, err := os.Stat(tmpCidFile); err == nil {
 		t.Fatalf("empty CIDFile %q should've been deleted", tmpCidFile)
 	}
-	deleteAllContainers()
 	logDone("run - cleanup empty cidfile on error")
 }
 
@@ -2256,6 +2266,8 @@ func TestRunCidFileCleanupIfEmpty(t *testing.T) {
 //sudo docker run --cidfile /tmp/docker_test.cid ubuntu echo "test"
 // TestRunCidFile tests that run --cidfile returns the longid
 func TestRunCidFileCheckIDLength(t *testing.T) {
+	defer deleteAllContainers()
+
 	tmpDir, err := ioutil.TempDir("", "TestRunCidFile")
 	if err != nil {
 		t.Fatal(err)
@@ -2279,11 +2291,13 @@ func TestRunCidFileCheckIDLength(t *testing.T) {
 	if cid != id {
 		t.Fatalf("cid must be equal to %s, got %s", id, cid)
 	}
-	deleteAllContainers()
+
 	logDone("run - cidfile contains long id")
 }
 
 func TestRunNetworkNotInitializedNoneMode(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-d", "--net=none", "busybox", "top")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -2297,7 +2311,7 @@ func TestRunNetworkNotInitializedNoneMode(t *testing.T) {
 	if res != "" {
 		t.Fatalf("For 'none' mode network must not be initialized, but container got IP: %s", res)
 	}
-	deleteAllContainers()
+
 	logDone("run - network must not be initialized in 'none' mode")
 }
 
@@ -2319,6 +2333,8 @@ func TestRunSetMacAddress(t *testing.T) {
 }
 
 func TestRunInspectMacAddress(t *testing.T) {
+	defer deleteAllContainers()
+
 	mac := "12:34:56:78:9a:bc"
 	cmd := exec.Command(dockerBinary, "run", "-d", "--mac-address="+mac, "busybox", "top")
 	out, _, err := runCommandWithOutput(cmd)
@@ -2333,11 +2349,13 @@ func TestRunInspectMacAddress(t *testing.T) {
 	if inspectedMac != mac {
 		t.Fatalf("docker inspect outputs wrong MAC address: %q, should be: %q", inspectedMac, mac)
 	}
-	deleteAllContainers()
+
 	logDone("run - inspecting MAC address")
 }
 
 func TestRunDeallocatePortOnMissingIptablesRule(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-d", "-p", "23:23", "busybox", "top")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -2362,11 +2380,13 @@ func TestRunDeallocatePortOnMissingIptablesRule(t *testing.T) {
 	if err != nil {
 		t.Fatal(err, out)
 	}
-	deleteAllContainers()
+
 	logDone("run - port should be deallocated even on iptables error")
 }
 
 func TestRunPortInUse(t *testing.T) {
+	defer deleteAllContainers()
+
 	port := "1234"
 	l, err := net.Listen("tcp", ":"+port)
 	if err != nil {
@@ -2382,7 +2402,6 @@ func TestRunPortInUse(t *testing.T) {
 		t.Fatalf("Out must be about \"address already in use\", got %s", out)
 	}
 
-	deleteAllContainers()
 	logDone("run - error out if port already in use")
 }
 
@@ -2421,6 +2440,8 @@ func TestRunPortProxy(t *testing.T) {
 
 // Regression test for #7792
 func TestRunMountOrdering(t *testing.T) {
+	defer deleteAllContainers()
+
 	tmpDir, err := ioutil.TempDir("", "docker_nested_mount_test")
 	if err != nil {
 		t.Fatal(err)
@@ -2457,12 +2478,13 @@ func TestRunMountOrdering(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	deleteAllContainers()
 	logDone("run - volumes are mounted in the correct order")
 }
 
 // Regression test for https://github.com/docker/docker/issues/8259
 func TestRunReuseBindVolumeThatIsSymlink(t *testing.T) {
+	defer deleteAllContainers()
+
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "testlink")
 	if err != nil {
 		t.Fatal(err)
@@ -2488,12 +2510,13 @@ func TestRunReuseBindVolumeThatIsSymlink(t *testing.T) {
 		t.Fatal(err, out)
 	}
 
-	deleteAllContainers()
 	logDone("run - can remount old bindmount volume")
 }
 
 //test create /etc volume
 func TestRunCreateVolumeEtc(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "--dns=127.0.0.1", "-v", "/etc", "busybox", "cat", "/etc/resolv.conf")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -2521,8 +2544,6 @@ func TestRunCreateVolumeEtc(t *testing.T) {
 	if !strings.Contains(out, "192.168.0.1"+"\t"+"test") || !strings.Contains(out, "127.0.0.1"+"\t"+"localhost") {
 		t.Fatal("failed: create /etc volume cover /etc/hosts", out)
 	}
-
-	deleteAllContainers()
 
 	logDone("run - create /etc volume success")
 }
@@ -2692,6 +2713,8 @@ func TestRunSlowStdoutConsumer(t *testing.T) {
 }
 
 func TestRunAllowPortRangeThroughExpose(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-d", "--expose", "3000-3003", "-P", "busybox", "top")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -2721,14 +2744,14 @@ func TestRunAllowPortRangeThroughExpose(t *testing.T) {
 
 // test docker run expose a invalid port
 func TestRunExposePort(t *testing.T) {
+	defer deleteAllContainers()
+
 	runCmd := exec.Command(dockerBinary, "run", "--expose", "80000", "busybox")
 	out, _, err := runCommandWithOutput(runCmd)
 	//expose a invalid port should with a error out
 	if err == nil || !strings.Contains(out, "Invalid range format for --expose") {
 		t.Fatalf("run --expose a invalid port should with error out")
 	}
-
-	deleteAllContainers()
 
 	logDone("run - can't expose a invalid port")
 }
@@ -2761,6 +2784,8 @@ func TestRunUnknownCommand(t *testing.T) {
 }
 
 func TestRunModeIpcHost(t *testing.T) {
+	defer deleteAllContainers()
+
 	hostIpc, err := os.Readlink("/proc/1/ns/ipc")
 	if err != nil {
 		t.Fatal(err)
@@ -2787,12 +2812,13 @@ func TestRunModeIpcHost(t *testing.T) {
 	if hostIpc == out2 {
 		t.Fatalf("IPC should be different without --ipc=host %s == %s\n", hostIpc, out2)
 	}
-	deleteAllContainers()
 
 	logDone("run - ipc host mode")
 }
 
 func TestRunModeIpcContainer(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -2825,12 +2851,13 @@ func TestRunModeIpcContainer(t *testing.T) {
 	if parentContainerIpc != out2 {
 		t.Fatalf("IPC different with --ipc=container:%s %s != %s\n", id, parentContainerIpc, out2)
 	}
-	deleteAllContainers()
 
 	logDone("run - ipc container mode")
 }
 
 func TestContainerNetworkMode(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -2859,12 +2886,13 @@ func TestContainerNetworkMode(t *testing.T) {
 	if parentContainerNet != out2 {
 		t.Fatalf("NET different with --net=container:%s %s != %s\n", id, parentContainerNet, out2)
 	}
-	deleteAllContainers()
 
 	logDone("run - container shared network namespace")
 }
 
 func TestRunModePidHost(t *testing.T) {
+	defer deleteAllContainers()
+
 	hostPid, err := os.Readlink("/proc/1/ns/pid")
 	if err != nil {
 		t.Fatal(err)
@@ -2891,7 +2919,6 @@ func TestRunModePidHost(t *testing.T) {
 	if hostPid == out2 {
 		t.Fatalf("PID should be different without --pid=host %s == %s\n", hostPid, out2)
 	}
-	deleteAllContainers()
 
 	logDone("run - pid host mode")
 }
@@ -3040,9 +3067,10 @@ func TestRunNetHost(t *testing.T) {
 }
 
 func TestRunAllowPortRangeThroughPublish(t *testing.T) {
+	defer deleteAllContainers()
+
 	cmd := exec.Command(dockerBinary, "run", "-d", "--expose", "3000-3003", "-p", "3000-3003", "busybox", "top")
 	out, _, err := runCommandWithOutput(cmd)
-	defer deleteAllContainers()
 
 	id := strings.TrimSpace(out)
 	portstr, err := inspectFieldJSON(id, "NetworkSettings.Ports")

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -56,6 +56,8 @@ func TestRunRedirectStdout(t *testing.T) {
 
 // Test recursive bind mount works by default
 func TestRunWithVolumesIsRecursive(t *testing.T) {
+	defer deleteAllContainers()
+
 	tmpDir, err := ioutil.TempDir("", "docker_recursive_mount_test")
 	if err != nil {
 		t.Fatal(err)
@@ -86,8 +88,6 @@ func TestRunWithVolumesIsRecursive(t *testing.T) {
 	if !strings.Contains(out, filepath.Base(f.Name())) {
 		t.Fatal("Recursive bind mount test failed. Expected file not found")
 	}
-
-	deleteAllContainers()
 
 	logDone("run - volumes are bind mounted recursively")
 }


### PR DESCRIPTION
   This fixes a few misuses of `deleteAllContainers()` cleanup
   method in integration-cli suite by moving call to the
   beginning of the method and guaranteeing their execution
   (including panics) with `defer`s. Most calls were not actually
happening in case of t.Fatal.

   Also added some forgotten cleanup calls while I'm at it.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @unclejack @duglin @tianon @jfrazelle 
