### PR TITLE
integ-cli: fix volume test by passing unix path as volume

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2548,13 +2548,7 @@ func TestVolumesNoCopyData(t *testing.T) {
 		t.Fatalf("Data was copied on volumes-from but shouldn't be:\n%q", out)
 	}
 
-	tmpDir, err := ioutil.TempDir("", "docker_test_bind_mount_copy_data")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	defer os.RemoveAll(tmpDir)
-
+	tmpDir := randomUnixTmpDirPath("docker_test_bind_mount_copy_data")
 	cmd = exec.Command(dockerBinary, "run", "-v", tmpDir+":/foo", "dataimage", "ls", "-lh", "/foo/bar")
 	if out, _, err := runCommandWithOutput(cmd); err == nil || !strings.Contains(out, "No such file or directory") {
 		t.Fatalf("Data was copied on bind-mount but shouldn't be:\n%q", out)


### PR DESCRIPTION
This fixes `TestVolumesNoCopyData` for test execution on
windows by passing a unix-style path as volume even though
it's running on windows.

There's no point on creating that temp dir locally since we
could be running against a remote daemon that is not on this
test machine.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @jfrazelle @unclejack @duglin @icecrime (low-hanging fruit :cherries:)
