### PR TITLE
integ-cli: Skip some unix-specific cli tests

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -1673,6 +1673,8 @@ func TestBuildAddBadLinksVolume(t *testing.T) {
 // Issue #5270 - ensure we throw a better error than "unexpected EOF"
 // when we can't access files in the context.
 func TestBuildWithInaccessibleFilesInContext(t *testing.T) {
+	testRequires(t, UnixCli) // test uses chown/chmod: not available on windows
+
 	{
 		name := "testbuildinaccessiblefiles"
 		defer deleteImages(name)
@@ -4387,6 +4389,8 @@ func TestBuildStderr(t *testing.T) {
 }
 
 func TestBuildChownSingleFile(t *testing.T) {
+	testRequires(t, UnixCli) // test uses chown: not available on windows
+
 	name := "testbuildchownsinglefile"
 	defer deleteImages(name)
 
@@ -4658,6 +4662,8 @@ func TestBuildFromOfficialNames(t *testing.T) {
 }
 
 func TestBuildDockerfileOutsideContext(t *testing.T) {
+	testRequires(t, UnixCli) // uses os.Symlink: not implemented in windows at the time of writing (go-1.4.2)
+
 	name := "testbuilddockerfileoutsidecontext"
 	tmpdir, err := ioutil.TempDir("", name)
 	if err != nil {

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -347,6 +347,8 @@ func TestCpSymlinkComponent(t *testing.T) {
 
 // Check that cp with unprivileged user doesn't return any error
 func TestCpUnprivilegedUser(t *testing.T) {
+	testRequires(t, UnixCli) // uses chmod/su: not available on windows
+
 	out, exitCode, err := dockerCmd(t, "run", "-d", "busybox", "/bin/sh", "-c", "touch "+cpTestName)
 	if err != nil || exitCode != 0 {
 		t.Fatal("failed to create a container", out, err)

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -17,6 +17,10 @@ var (
 		func() bool { return isLocalDaemon },
 		"Test requires docker daemon to runs on the same machine as CLI",
 	}
+	UnixCli = TestRequirement{
+		func() bool { return isUnixCli },
+		"Test requires posix utilities or functionality to run.",
+	}
 )
 
 // testRequires checks if the environment satisfies the requirements

--- a/integration-cli/test_vars_unix.go
+++ b/integration-cli/test_vars_unix.go
@@ -3,6 +3,6 @@
 package main
 
 const (
-	// idetifies if test suite is running on a unix platform
+	// identifies if test suite is running on a unix platform
 	isUnixCli = true
 )

--- a/integration-cli/test_vars_unix.go
+++ b/integration-cli/test_vars_unix.go
@@ -1,0 +1,8 @@
+// +build !windows
+
+package main
+
+const (
+	// idetifies if test suite is running on a unix platform
+	isUnixCli = true
+)

--- a/integration-cli/test_vars_windows.go
+++ b/integration-cli/test_vars_windows.go
@@ -1,0 +1,8 @@
+// +build windows
+
+package main
+
+const (
+	// idetifies if test suite is running on a unix platform
+	isUnixCli = false
+)

--- a/integration-cli/test_vars_windows.go
+++ b/integration-cli/test_vars_windows.go
@@ -3,6 +3,6 @@
 package main
 
 const (
-	// idetifies if test suite is running on a unix platform
+	// identifies if test suite is running on a unix platform
 	isUnixCli = false
 )


### PR DESCRIPTION
Skipping some of the tests closely tied to running in a
unix environment. Windows does not support chmod/chown
and this causes some tests to fail creating desired
behavior.
- `TestBuildWithInaccessibleFilesInContext`: uses chown/chmod
- `TestBuildDockerfileOutsideContext`: uses os.Symlink, not implemented on
  windows
- `TestCpUnprivilegedUser`: uses chmod, and requires 'unprivilegeduser'
  created by Dockerfile (and thus requires to run inside container)
- `TestBuildChownSingleFile`: uses chown

I wonder if I can write windows equivalents of those using golang
pkg/os calls for windows. Most of them are not implemented, especially
windows-specific security ACLs etc. 

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @unclejack @tianon @jfrazelle @icecrime @tiborvass 
