### PR TITLE
Map Commands instead of using them as a slice

### DIFF
--- a/builder/command/command.go
+++ b/builder/command/command.go
@@ -19,19 +19,19 @@ const (
 )
 
 // Commands is list of all Dockerfile commands
-var Commands = []string{
-	Env,
-	Maintainer,
-	Add,
-	Copy,
-	From,
-	Onbuild,
-	Workdir,
-	Run,
-	Cmd,
-	Entrypoint,
-	Expose,
-	Volume,
-	User,
-	Insert,
+var Commands = map[string]struct{}{
+	Env:        {},
+	Maintainer: {},
+	Add:        {},
+	Copy:       {},
+	From:       {},
+	Onbuild:    {},
+	Workdir:    {},
+	Run:        {},
+	Cmd:        {},
+	Entrypoint: {},
+	Expose:     {},
+	Volume:     {},
+	User:       {},
+	Insert:     {},
 }

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4836,7 +4836,7 @@ func TestBuildMissingArgs(t *testing.T) {
 
 	defer deleteAllContainers()
 
-	for _, cmd := range command.Commands {
+	for cmd := range command.Commands {
 		cmd = strings.ToUpper(cmd)
 		if _, ok := skipCmds[cmd]; ok {
 			continue


### PR DESCRIPTION
The most obvious use case is when one wants to make sure as fast
as possible that a command is a valid Dockerfile command.
