### PR TITLE
Build w/o verbose hangs w/RUN

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -555,8 +555,11 @@ func (b *Builder) run(c *daemon.Container) error {
 		return err
 	}
 
-	if err := <-errCh; err != nil {
-		return err
+	if b.Verbose {
+		// Block on reading output from container, stop on err or chan closed
+		if err := <-errCh; err != nil {
+			return err
+		}
 	}
 
 	// Wait for it to finish


### PR DESCRIPTION
`docker build -q .` where Dockerfile contains a RUN cmd will hang on the
RUN. It waits for the output stream to close but because of -q we never
attached to the container and end up waiting forever.

The fact that no one noticed this tells me that people may not actually
use -q and if so I wonder if it would make sense to make -q work the may
it does for other commands (like `docker ps`) and make it so it only
shows the container ID at the end.  A -q/quiet option that only hides the
container RUN output apparently isn't really that useful since no one is
using it.  See: https://github.com/docker/docker/issues/4094

Signed-off-by: Doug Davis dug@us.ibm.com
