### PR TITLE
Fix erroneously wrapped URLs in links

### DIFF
--- a/docs/sources/faq.md
+++ b/docs/sources/faq.md
@@ -109,8 +109,7 @@ with several powerful functionalities:
 ### What is different between a Docker container and a VM?
 
 There's a great StackOverflow answer [showing the differences](
-http://stackoverflow.com/questions/16047306/how-is-docker-io-different-from-a-
-normal-virtual-machine).
+http://stackoverflow.com/questions/16047306/how-is-docker-io-different-from-a-normal-virtual-machine).
 
 ### Do I lose my data when the container exits?
 
@@ -170,8 +169,7 @@ You can learn about the project's security policy
 ### Why do I need to sign my commits to Docker with the DCO?
 
 Please read [our blog post](
-http://blog.docker.com/2014/01/docker-code-contributions-require-developer-
-certificate-of-origin/) on the introduction of the DCO.
+http://blog.docker.com/2014/01/docker-code-contributions-require-developer-certificate-of-origin/) on the introduction of the DCO.
 
 ### When building an image, should I prefer system libraries or bundled ones?
 


### PR DESCRIPTION
Some of the links in this document contained hard-wrapped URL portions, which causes Markdown to insert a literal URL encoded `\n` inside the link, thus breaking them.
