### PR TITLE
cli: Add server OS/Arch info to 'version' cmd

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -483,6 +483,7 @@ func (cli *DockerCli) CmdVersion(args ...string) error {
 	}
 	fmt.Fprintf(cli.out, "Go version (server): %s\n", remoteVersion.Get("GoVersion"))
 	fmt.Fprintf(cli.out, "Git commit (server): %s\n", remoteVersion.Get("GitCommit"))
+	fmt.Fprintf(cli.out, "OS/Arch (server): %s/%s\n", remoteVersion.Get("Os"), remoteVersion.Get("Arch"))
 	return nil
 }
 

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -46,6 +46,11 @@ You can still call an old version of the API using
 
 ### What's new
 
+`GET /version`
+
+**New!**
+This endpoint now returns `Os`, `Arch` and `KernelVersion`.
+
 ## v1.17
 
 ### Full Documentation

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -1471,10 +1471,13 @@ Show the docker version information
         Content-Type: application/json
 
         {
-             "ApiVersion": "1.12",
-             "Version": "0.2.2",
-             "GitCommit": "5a2a5cc+CHANGES",
-             "GoVersion": "go1.0.3"
+             "Version": "1.5.0",
+             "Os": "linux",
+             "KernelVersion": "3.18.5-tinycore64",
+             "GoVersion": "go1.4.1",
+             "GitCommit": "a8a31ef",
+             "Arch": "amd64",
+             "ApiVersion": "1.18"
         }
 
 Status Codes:

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -2075,8 +2075,21 @@ for further details.
 
     Show the Docker version information.
 
-Show the Docker version, API version, Git commit, and Go version of
-both Docker client and daemon.
+Show the Docker version, API version, Git commit, Go version and OS/architecture
+of both Docker client and daemon. Example use:
+
+    $ sudo docker version
+    Client version: 1.5.0
+    Client API version: 1.17
+    Go version (client): go1.4.1
+    Git commit (client): a8a31ef
+    OS/Arch (client): darwin/amd64
+    Server version: 1.5.0
+    Server API version: 1.17
+    Go version (server): go1.4.1
+    Git commit (server): a8a31ef
+    OS/Arch (server): linux/amd64
+
 
 ## wait
 

--- a/integration-cli/docker_cli_version_test.go
+++ b/integration-cli/docker_cli_version_test.go
@@ -19,10 +19,12 @@ func TestVersionEnsureSucceeds(t *testing.T) {
 		"Client API version:",
 		"Go version (client):",
 		"Git commit (client):",
+		"OS/Arch (client):",
 		"Server version:",
 		"Server API version:",
 		"Go version (server):",
 		"Git commit (server):",
+		"OS/Arch (server):",
 	}
 
 	for _, linePrefix := range stringsToCheck {


### PR DESCRIPTION
Added 'OS/Arch (server)' line to `docker version`.

This info already is in `/version` endpoint but was missing from `docker version` output, it may come handy when we have a Windows daemon.

> Client API version: 1.17
> Go version (client): go1.4.1
> OS/Arch (client): darwin/amd64
> Server version: 1.5.0
> Server API version: 1.17
> Go version (server): go1.4.1
> Git commit (server): a8a31ef
> OS/Arch (server): linux/amd64 :new::new::new::new::new::new::new::new::new::new: 

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @vieux @jfrazelle @unclejack @tiborvass @tianon 
