### PR TITLE
Fix docker commit make a paused container to unpaused

### DIFF
--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -41,7 +41,7 @@ func (daemon *Daemon) ContainerCommit(job *engine.Job) engine.Status {
 // Commit creates a new filesystem image from the current state of a container.
 // The image can optionally be tagged into a repository
 func (daemon *Daemon) Commit(container *Container, repository, tag, comment, author string, pause bool, config *runconfig.Config) (*image.Image, error) {
-	if pause {
+	if pause && !container.IsPaused() {
 		container.Pause()
 		defer container.Unpause()
 	}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Fixes #10932 

By default, docker commit will pause the container and unpause it when commit is finished. 
but, if the container is already paused by user manually, docker commit will also unpause it after commit,
I don't think this is a desired behavior. This patch will fix this
