### PR TITLE
docs/man/docker.1.md: spelling mistake fix

### DIFF
--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -296,7 +296,7 @@ for data and metadata:
 For specific client examples please see the man page for the specific Docker
 command. For example:
 
-    man docker run
+    man docker-run
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com) based on docker.com source material and internal work.


### PR DESCRIPTION
Spelling mistake fix in the documentation
