### PR TITLE
New padding-right for the docs' left navigation

### DIFF
--- a/docs/theme/mkdocs/css/docs.css
+++ b/docs/theme/mkdocs/css/docs.css
@@ -52,6 +52,7 @@
   margin-top: 20px;
  // text-indent: -16px;
   padding-left: 10px;
+  padding-right: 10px;
 }
 #leftnav .nav-tabs.nav ul li {
   margin-top: 5px;


### PR DESCRIPTION
Browsing the docset, I noticed in the user guide that the left navigation links were too close
 to the right edge of the menu.

![schermata 2015-02-22 alle 22 55 33](https://cloud.githubusercontent.com/assets/20770/6320716/f266a426-bae5-11e4-90d9-8667f776e5c6.png)

I fixed this. I tested this a bit, I hope not to introduce graphic regressions.

![schermata 2015-02-22 alle 22 56 47](https://cloud.githubusercontent.com/assets/20770/6320728/257ea80e-bae6-11e4-9be2-0b459d84b928.png)
