### PR TITLE
"docker run hello-world" instead of "docker hello-world"

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -83,7 +83,7 @@ application:
 Once the launch completes, you can run `docker` commands. A good way to verify
 your setup succeeded is to run the `hello-world` container.
 
-		$ docker hello-world
+		$ docker run hello-world
 		Unable to find image 'hello-world:latest' locally
 		511136ea3c5a: Pull complete 
 		31cbccb51277: Pull complete 
@@ -146,7 +146,7 @@ Initialize and run `boot2docker` from the command line, do the following:
 
 5. Run the `hello-world` container to verify your setup.
 
-		$ docker hello-world		
+		$ docker run hello-world		
 
 
 ## Basic Boot2Docker Exercises


### PR DESCRIPTION
I just tried this guide. I had to use "docker run hello-world" instead of "docker run"

Signed-off-by: Dario Galvis sdreyesg@gmail.com
