### PR TITLE
Rename Daemon.Destroy to Daemon.Rm to be consistent with CLI command.

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -712,7 +712,7 @@ func (b *Builder) clearTmp() {
 			fmt.Fprint(b.OutStream, err.Error())
 		}
 
-		if err := b.Daemon.Destroy(tmp); err != nil {
+		if err := b.Daemon.Rm(tmp); err != nil {
 			fmt.Fprintf(b.OutStream, "Error removing intermediate container %s: %s\n", utils.TruncateID(c), err.Error())
 			return
 		}

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -61,7 +61,7 @@ func (daemon *Daemon) ContainerRm(job *engine.Job) engine.Status {
 				return job.Errorf("Conflict, You cannot remove a running container. Stop the container before attempting removal or use -f")
 			}
 		}
-		if err := daemon.Destroy(container); err != nil {
+		if err := daemon.Rm(container); err != nil {
 			return job.Errorf("Cannot destroy container %s: %s", name, err)
 		}
 		container.LogEvent("destroy")
@@ -82,8 +82,7 @@ func (daemon *Daemon) DeleteVolumes(volumeIDs map[string]struct{}) {
 }
 
 // Destroy unregisters a container from the daemon and cleanly removes its contents from the filesystem.
-// FIXME: rename to Rm for consistency with the CLI command
-func (daemon *Daemon) Destroy(container *Container) error {
+func (daemon *Daemon) Rm(container *Container) error {
 	if container == nil {
 		return fmt.Errorf("The given container is <nil>")
 	}

--- a/integration/container_test.go
+++ b/integration/container_test.go
@@ -24,7 +24,7 @@ func TestRestartStdin(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer daemon.Destroy(container)
+	defer daemon.Rm(container)
 
 	stdin := container.StdinPipe()
 	stdout := container.StdoutPipe()
@@ -89,7 +89,7 @@ func TestStdin(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer daemon.Destroy(container)
+	defer daemon.Rm(container)
 
 	stdin := container.StdinPipe()
 	stdout := container.StdoutPipe()
@@ -129,7 +129,7 @@ func TestTty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer daemon.Destroy(container)
+	defer daemon.Rm(container)
 
 	stdin := container.StdinPipe()
 	stdout := container.StdoutPipe()
@@ -168,7 +168,7 @@ func BenchmarkRunSequential(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		defer daemon.Destroy(container)
+		defer daemon.Rm(container)
 		output, err := container.Output()
 		if err != nil {
 			b.Fatal(err)
@@ -176,7 +176,7 @@ func BenchmarkRunSequential(b *testing.B) {
 		if string(output) != "foo" {
 			b.Fatalf("Unexpected output: %s", output)
 		}
-		if err := daemon.Destroy(container); err != nil {
+		if err := daemon.Rm(container); err != nil {
 			b.Fatal(err)
 		}
 	}
@@ -203,7 +203,7 @@ func BenchmarkRunParallel(b *testing.B) {
 				complete <- err
 				return
 			}
-			defer daemon.Destroy(container)
+			defer daemon.Rm(container)
 			if err := container.Start(); err != nil {
 				complete <- err
 				return
@@ -215,7 +215,7 @@ func BenchmarkRunParallel(b *testing.B) {
 			// if string(output) != "foo" {
 			// 	complete <- fmt.Errorf("Unexecpted output: %v", string(output))
 			// }
-			if err := daemon.Destroy(container); err != nil {
+			if err := daemon.Rm(container); err != nil {
 				complete <- err
 				return
 			}

--- a/integration/runtime_test.go
+++ b/integration/runtime_test.go
@@ -62,7 +62,7 @@ func cleanup(eng *engine.Engine, t *testing.T) error {
 	daemon := mkDaemonFromEngine(eng, t)
 	for _, container := range daemon.List() {
 		container.Kill()
-		daemon.Destroy(container)
+		daemon.Rm(container)
 	}
 	job := eng.Job("images")
 	images, err := job.Stdout.AddTable()
@@ -266,7 +266,7 @@ func TestDaemonCreate(t *testing.T) {
 	}
 
 	defer func() {
-		if err := daemon.Destroy(container); err != nil {
+		if err := daemon.Rm(container); err != nil {
 			t.Error(err)
 		}
 	}()
@@ -368,7 +368,7 @@ func TestDestroy(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Destroy
-	if err := daemon.Destroy(container); err != nil {
+	if err := daemon.Rm(container); err != nil {
 		t.Error(err)
 	}
 
@@ -388,7 +388,7 @@ func TestDestroy(t *testing.T) {
 	}
 
 	// Test double destroy
-	if err := daemon.Destroy(container); err == nil {
+	if err := daemon.Rm(container); err == nil {
 		// It should have failed
 		t.Errorf("Double destroy did not fail")
 	}
@@ -399,13 +399,13 @@ func TestGet(t *testing.T) {
 	defer nuke(daemon)
 
 	container1, _, _ := mkContainer(daemon, []string{"_", "ls", "-al"}, t)
-	defer daemon.Destroy(container1)
+	defer daemon.Rm(container1)
 
 	container2, _, _ := mkContainer(daemon, []string{"_", "ls", "-al"}, t)
-	defer daemon.Destroy(container2)
+	defer daemon.Rm(container2)
 
 	container3, _, _ := mkContainer(daemon, []string{"_", "ls", "-al"}, t)
-	defer daemon.Destroy(container3)
+	defer daemon.Rm(container3)
 
 	if c, _ := daemon.Get(container1.ID); c != container1 {
 		t.Errorf("Get(test1) returned %v while expecting %v", c, container1)
@@ -594,11 +594,11 @@ func TestRestore(t *testing.T) {
 	defer daemon1.Nuke()
 	// Create a container with one instance of docker
 	container1, _, _ := mkContainer(daemon1, []string{"_", "ls", "-al"}, t)
-	defer daemon1.Destroy(container1)
+	defer daemon1.Rm(container1)
 
 	// Create a second container meant to be killed
 	container2, _, _ := mkContainer(daemon1, []string{"-i", "_", "/bin/cat"}, t)
-	defer daemon1.Destroy(container2)
+	defer daemon1.Rm(container2)
 
 	// Start the container non blocking
 	if err := container2.Start(); err != nil {
@@ -886,7 +886,7 @@ func TestDestroyWithInitLayer(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Destroy
-	if err := daemon.Destroy(container); err != nil {
+	if err := daemon.Rm(container); err != nil {
 		t.Fatal(err)
 	}
 

--- a/integration/server_test.go
+++ b/integration/server_test.go
@@ -46,7 +46,7 @@ func TestMergeConfigOnCommit(t *testing.T) {
 	defer runtime.Nuke()
 
 	container1, _, _ := mkContainer(runtime, []string{"-e", "FOO=bar", unitTestImageID, "echo test > /tmp/foo"}, t)
-	defer runtime.Destroy(container1)
+	defer runtime.Rm(container1)
 
 	config, _, _, err := parseRun([]string{container1.ID, "cat /tmp/foo"})
 	if err != nil {
@@ -64,7 +64,7 @@ func TestMergeConfigOnCommit(t *testing.T) {
 	}
 
 	container2, _, _ := mkContainer(runtime, []string{engine.Tail(outputBuffer, 1)}, t)
-	defer runtime.Destroy(container2)
+	defer runtime.Rm(container2)
 
 	job = eng.Job("container_inspect", container1.Name)
 	baseContainer, _ := job.Stdout.AddEnv()

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -293,7 +293,7 @@ func runContainer(eng *engine.Engine, r *daemon.Daemon, args []string, t *testin
 	if err != nil {
 		return "", err
 	}
-	defer r.Destroy(container)
+	defer r.Rm(container)
 	stdout := container.StdoutPipe()
 	defer stdout.Close()
 


### PR DESCRIPTION
Signed-off-by: Rik Nijessen riknijessen@gmail.com

Hi,

@MartijnDwars, @RickWieman, @wrvangeest and I are students from the Delft University of Technology in the Netherlands and are currently working on a project for our Software Architecture course (http://avandeursen.com/2013/12/30/teaching-software-architecture-with-github/).

During this course we will analyze the architecture an open-source project (in our case Docker, because we think Docker is awesome!). Our findings will be published in a chapter of a collaborative book, which will be published online. Last year's book can be found here http://delftswa2014.github.io/.

We'd love to contribute to Docker, so to get a little bit more familiar with the system we have fixed a simple FIXME.

We have renamed the Daemon.Destroy method to Daemon.Rm to be consistent with the corresponding CLI command. 
