### PR TITLE
Have docker command use $HOME instead of '/Users/mary'

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -234,7 +234,7 @@ The next exercise demonstrates how to do this.
 	
 5. Start a new `nginx` container and replace the `html` folder with your `site` directory.
 
-		$ docker run -d -P -v /Users/mary/site:/usr/share/nginx/html --name mysite nginx
+		$ docker run -d -P -v $HOME/site:/usr/share/nginx/html --name mysite nginx
 	
 6. Get the `mysite` container's port.
 


### PR DESCRIPTION
I recognize people following the tutorial should not just be copy+pasting as they go, but this small change allows someone who is doing that to have the docker command work without replacing `mary` with their own home folder, and is consistent with prior instruction to `cd $HOME`. 
