### PR TITLE
Enabled aufs-over-btrfs support back

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -42,7 +42,6 @@ import (
 var (
 	ErrAufsNotSupported = fmt.Errorf("AUFS was not found in /proc/filesystems")
 	incompatibleFsMagic = []graphdriver.FsMagic{
-		graphdriver.FsMagicBtrfs,
 		graphdriver.FsMagicAufs,
 	}
 	backingFs = "<unknown>"


### PR DESCRIPTION
AUFS author supports this configuration (there are still bugs found from time to time like fixed http://sourceforge.net/p/aufs/aufs3-standalone/ci/af8aee7bb0ee38a8f4e565956470555d434f728d/, but in general it's usable with latest aufs version).
Usage of this configuration may be reasonable for user, if he/she wants to get advantages of inode vfs cache sharing, because btrfs subvols don't support such option and unlikely to do this in future due to linux pagecache architecture.
