### PR TITLE
Fix dynbinary with new autogen code

### DIFF
--- a/project/make/dynbinary
+++ b/project/make/dynbinary
@@ -15,6 +15,7 @@ fi
 
 (
 	export IAMSTATIC="false"
+	export LDFLAGS_STATIC_DOCKER=''
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/static_build /}" ) # we're not building a "static" binary here
 	source "$(dirname "$BASH_SOURCE")/binary"


### PR DESCRIPTION
This was a subtle consequence of #10665 -- we stopped overwriting `LDFLAGS_STATIC_DOCKER`, which was as important as the bits we put into it (because that's exactly what made the binary not static anymore).
