### PR TITLE
Add Phil Estes as a core maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -343,7 +343,8 @@ made through a pull request.
 			"tibor",
 			"vbatts",
 			"vieux",
-			"vishh"
+			"vishh",
+			"estesp"
 		]
 
 
@@ -595,3 +596,8 @@ made through a pull request.
 	Name = "Vishnu Kannan"
 	Email = "vishnuk@google.com"
 	GitHub = "vishh"
+
+	[people.estesp]
+	Name = "Phil Estes"
+	Email = "estesp@linux.vnet.ibm.com"
+	GitHub = "estesp"


### PR DESCRIPTION
Phil has been very active across the repository for a few months now.
He has not only triaged issues but also contributed to features and bug
fixes and is a very active participant on the project.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
