### PR TITLE
Fixed bad handling of "container not found" error

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -279,7 +279,7 @@ func (container *Container) applyVolumesFrom() error {
 
 		c, err := container.daemon.Get(id)
 		if err != nil {
-			return err
+			return fmt.Errorf("Could not apply volumes of non-existent container %q.", id)
 		}
 
 		var (


### PR DESCRIPTION
This closes #10979

Create container job could fail because a container specified with
`--volumes-from` does not exist. This error is not propagated to client
though. Instead it's recognized by higher levels as "image not found".
Client then tries to pull the image and launch the container again.

This patch changes the lower level error message so that it's not
recognized as "image not found" and thus it's propagated to client.

With this patch the same command as in #10979

```
docker run -d --name somebody --volumes-from nobody registry.access.redhat.com/rhel7 false
```

outputs:

```
FATA[0000] Error response from daemon: Could not apply volumes of non-existent container "nobody".
```
