### PR TITLE
Create api types package for structured responses

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -26,7 +26,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api"
-	"github.com/docker/docker/api/stats"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/autogen/dockerversion"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/graph"
@@ -2640,7 +2640,7 @@ func (s *containerStats) Collect(cli *DockerCli) {
 	)
 	go func() {
 		for {
-			var v *stats.Stats
+			var v *types.Stats
 			if err := dec.Decode(&v); err != nil {
 				u <- err
 				return
@@ -2757,7 +2757,7 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 	return nil
 }
 
-func calculateCpuPercent(previousCpu, previousSystem uint64, v *stats.Stats) float64 {
+func calculateCpuPercent(previousCpu, previousSystem uint64, v *types.Stats) float64 {
 	var (
 		cpuPercent = 0.0
 		// calculate the change for the cpu usage of the container in between readings

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -27,6 +27,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/daemon/networkdriver/portallocator"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/pkg/listenbuffer"
@@ -140,10 +141,20 @@ func httpError(w http.ResponseWriter, err error) {
 	}
 }
 
-func writeJSON(w http.ResponseWriter, code int, v engine.Env) error {
+// writeJSONEnv writes the engine.Env values to the http response stream as a
+// json encoded body.
+func writeJSONEnv(w http.ResponseWriter, code int, v engine.Env) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
 	return v.Encode(w)
+}
+
+// writeJSON writes the value v to the http response stream as json with standard
+// json encoding.
+func writeJSON(w http.ResponseWriter, code int, v interface{}) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	return json.NewEncoder(w).Encode(v)
 }
 
 func streamJSON(job *engine.Job, w http.ResponseWriter, flush bool) {
@@ -183,7 +194,7 @@ func postAuth(eng *engine.Engine, version version.Version, w http.ResponseWriter
 	if status := engine.Tail(stdoutBuffer, 1); status != "" {
 		var env engine.Env
 		env.Set("Status", status)
-		return writeJSON(w, http.StatusOK, env)
+		return writeJSONEnv(w, http.StatusOK, env)
 	}
 	w.WriteHeader(http.StatusNoContent)
 	return nil
@@ -525,7 +536,7 @@ func postCommit(eng *engine.Engine, version version.Version, w http.ResponseWrit
 		return err
 	}
 	env.Set("Id", engine.Tail(stdoutBuffer, 1))
-	return writeJSON(w, http.StatusCreated, env)
+	return writeJSONEnv(w, http.StatusCreated, env)
 }
 
 // Creates an image from Pull or from Import
@@ -703,17 +714,15 @@ func postContainersCreate(eng *engine.Engine, version version.Version, w http.Re
 	if err := parseForm(r); err != nil {
 		return nil
 	}
+	if err := checkForJson(r); err != nil {
+		return err
+	}
 	var (
-		out          engine.Env
 		job          = eng.Job("create", r.Form.Get("name"))
 		outWarnings  []string
 		stdoutBuffer = bytes.NewBuffer(nil)
 		warnings     = bytes.NewBuffer(nil)
 	)
-
-	if err := checkForJson(r); err != nil {
-		return err
-	}
 
 	if err := job.DecodeEnv(r.Body); err != nil {
 		return err
@@ -730,10 +739,10 @@ func postContainersCreate(eng *engine.Engine, version version.Version, w http.Re
 	for scanner.Scan() {
 		outWarnings = append(outWarnings, scanner.Text())
 	}
-	out.Set("Id", engine.Tail(stdoutBuffer, 1))
-	out.SetList("Warnings", outWarnings)
-
-	return writeJSON(w, http.StatusCreated, out)
+	return writeJSON(w, http.StatusCreated, &types.ContainerCreateResponse{
+		ID:       engine.Tail(stdoutBuffer, 1),
+		Warnings: outWarnings,
+	})
 }
 
 func postContainersRestart(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -876,7 +885,7 @@ func postContainersWait(eng *engine.Engine, version version.Version, w http.Resp
 	}
 
 	env.Set("StatusCode", engine.Tail(stdoutBuffer, 1))
-	return writeJSON(w, http.StatusOK, env)
+	return writeJSONEnv(w, http.StatusOK, env)
 }
 
 func postContainersResize(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -1147,7 +1156,7 @@ func postContainerExecCreate(eng *engine.Engine, version version.Version, w http
 	// Return the ID
 	out.Set("Id", engine.Tail(stdoutBuffer, 1))
 
-	return writeJSON(w, http.StatusCreated, out)
+	return writeJSONEnv(w, http.StatusCreated, out)
 }
 
 // TODO(vishh): Refactor the code to avoid having to specify stream config as part of both create and start.

--- a/api/types/stats.go
+++ b/api/types/stats.go
@@ -1,6 +1,6 @@
 // This package is used for API stability in the types and response to the
 // consumers of the API stats endpoint.
-package stats
+package types
 
 import "time"
 

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -1,0 +1,11 @@
+package types
+
+// ContainerCreateResponse contains the information returned to a client on the
+// creation of a new container.
+type ContainerCreateResponse struct {
+	// ID is the ID of the created container.
+	ID string `json:"Id"`
+
+	// Warnings are any warnings encountered during the creation of the container.
+	Warnings []string `json:"Warnings"`
+}

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -3,7 +3,7 @@ package daemon
 import (
 	"encoding/json"
 
-	"github.com/docker/docker/api/stats"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/engine"
 	"github.com/docker/libcontainer"
@@ -33,10 +33,10 @@ func (daemon *Daemon) ContainerStats(job *engine.Job) engine.Status {
 
 // convertToAPITypes converts the libcontainer.ContainerStats to the api specific
 // structs.  This is done to preserve API compatibility and versioning.
-func convertToAPITypes(ls *libcontainer.ContainerStats) *stats.Stats {
-	s := &stats.Stats{}
+func convertToAPITypes(ls *libcontainer.ContainerStats) *types.Stats {
+	s := &types.Stats{}
 	if ls.NetworkStats != nil {
-		s.Network = stats.Network{
+		s.Network = types.Network{
 			RxBytes:   ls.NetworkStats.RxBytes,
 			RxPackets: ls.NetworkStats.RxPackets,
 			RxErrors:  ls.NetworkStats.RxErrors,
@@ -49,7 +49,7 @@ func convertToAPITypes(ls *libcontainer.ContainerStats) *stats.Stats {
 	}
 	cs := ls.CgroupStats
 	if cs != nil {
-		s.BlkioStats = stats.BlkioStats{
+		s.BlkioStats = types.BlkioStats{
 			IoServiceBytesRecursive: copyBlkioEntry(cs.BlkioStats.IoServiceBytesRecursive),
 			IoServicedRecursive:     copyBlkioEntry(cs.BlkioStats.IoServicedRecursive),
 			IoQueuedRecursive:       copyBlkioEntry(cs.BlkioStats.IoQueuedRecursive),
@@ -60,21 +60,21 @@ func convertToAPITypes(ls *libcontainer.ContainerStats) *stats.Stats {
 			SectorsRecursive:        copyBlkioEntry(cs.BlkioStats.SectorsRecursive),
 		}
 		cpu := cs.CpuStats
-		s.CpuStats = stats.CpuStats{
-			CpuUsage: stats.CpuUsage{
+		s.CpuStats = types.CpuStats{
+			CpuUsage: types.CpuUsage{
 				TotalUsage:        cpu.CpuUsage.TotalUsage,
 				PercpuUsage:       cpu.CpuUsage.PercpuUsage,
 				UsageInKernelmode: cpu.CpuUsage.UsageInKernelmode,
 				UsageInUsermode:   cpu.CpuUsage.UsageInUsermode,
 			},
-			ThrottlingData: stats.ThrottlingData{
+			ThrottlingData: types.ThrottlingData{
 				Periods:          cpu.ThrottlingData.Periods,
 				ThrottledPeriods: cpu.ThrottlingData.ThrottledPeriods,
 				ThrottledTime:    cpu.ThrottlingData.ThrottledTime,
 			},
 		}
 		mem := cs.MemoryStats
-		s.MemoryStats = stats.MemoryStats{
+		s.MemoryStats = types.MemoryStats{
 			Usage:    mem.Usage,
 			MaxUsage: mem.MaxUsage,
 			Stats:    mem.Stats,
@@ -84,10 +84,10 @@ func convertToAPITypes(ls *libcontainer.ContainerStats) *stats.Stats {
 	return s
 }
 
-func copyBlkioEntry(entries []cgroups.BlkioStatEntry) []stats.BlkioStatEntry {
-	out := make([]stats.BlkioStatEntry, len(entries))
+func copyBlkioEntry(entries []cgroups.BlkioStatEntry) []types.BlkioStatEntry {
+	out := make([]types.BlkioStatEntry, len(entries))
 	for i, re := range entries {
-		out[i] = stats.BlkioStatEntry{
+		out[i] = types.BlkioStatEntry{
 			Major: re.Major,
 			Minor: re.Minor,
 			Op:    re.Op,

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/docker/api/stats"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
 )
 
@@ -311,7 +311,7 @@ func TestGetContainerStats(t *testing.T) {
 		}
 
 		dec := json.NewDecoder(bytes.NewBuffer(sr.body))
-		var s *stats.Stats
+		var s *types.Stats
 		// decode only one object from the stream
 		if err := dec.Decode(&s); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This creates a new package `api/types` and also implements a new type for the `/containers/create` endpoint which is also consumed via the client. 
