### PR TITLE
Remove leftover debugging artifact in test

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -1583,7 +1583,6 @@ func TestBuildAddBadLinks(t *testing.T) {
 		symlinkTarget = fmt.Sprintf("/../../../../../../../../../../../..%s", tempDir)
 	}
 
-	t.Logf("***=== %s", symlinkTarget)
 	tarPath := filepath.Join(ctx.Dir, "links.tar")
 	nonExistingFile := filepath.Join(tempDir, targetFile)
 	fooPath := filepath.Join(ctx.Dir, targetFile)


### PR DESCRIPTION
Sorry I forgot it there. :flushed: 

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
