### PR TITLE
Implement journalctl to see journald data within a docker container

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -207,6 +207,7 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowDecomp
 	if err != nil {
 		return err
 	}
+	container.SetHostConfig(&runconfig.HostConfig{BuildFlag: true})
 	b.TmpContainers[container.ID] = struct{}{}
 
 	if err := container.Mount(); err != nil {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -731,6 +731,15 @@ func (container *Container) cleanup() {
 		}
 	}
 
+	// Ignore errors here as it may not be mounted anymore
+	if !container.hostConfig.BuildFlag {
+		path, err := container.runPath()
+		if err != nil {
+			logrus.Errorf("%v: Failed to umount /run filesystem: %v", container.ID, err)
+		}
+		syscall.Unmount(path, syscall.MNT_DETACH)
+	}
+
 	if err := container.Unmount(); err != nil {
 		logrus.Errorf("%v: Failed to umount filesystem: %v", container.ID, err)
 	}
@@ -955,6 +964,10 @@ func (container *Container) GetImage() (*image.Image, error) {
 
 func (container *Container) Unmount() error {
 	return container.daemon.Unmount(container)
+}
+
+func (container *Container) runPath() (string, error) {
+	return container.GetRootResourcePath("run")
 }
 
 func (container *Container) hostConfigPath() (string, error) {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1405,6 +1405,7 @@ func (container *Container) createDaemonEnvironment(linkedEnv []string) []string
 	// because the env on the container can override certain default values
 	// we need to replace the 'env' keys where they match and append anything
 	// else.
+	env = append(env, fmt.Sprintf("container_uuid=%s", convertUUID(container.ID)))
 	env = utils.ReplaceOrAppendEnvValues(env, container.Config.Env)
 
 	return env

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -147,6 +147,12 @@ func (daemon *Daemon) commonRm(container *Container, forceRemove bool) (err erro
 		return fmt.Errorf("Driver %s failed to remove init filesystem %s: %s", daemon.driver, initID, err)
 	}
 
+	if path := journalPath(container.ID); path != "" {
+		if err = os.RemoveAll(path); err != nil {
+			return fmt.Errorf("Unable to remove journal content %v: %v", container.ID, err)
+		}
+	}
+
 	if err = os.RemoveAll(container.root); err != nil {
 		return fmt.Errorf("Unable to remove filesystem for %v: %v", container.ID, err)
 	}

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -174,4 +174,5 @@ type Command struct {
 	LxcConfig          []string          `json:"lxc_config"`
 	AppArmorProfile    string            `json:"apparmor_profile"`
 	CgroupParent       string            `json:"cgroup_parent"` // The parent cgroup for this command.
+	TmpDir             string            `json:"tmpdir"`        // Directory used to store docker tmpdirs.
 }

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -118,6 +118,13 @@ type execOutput struct {
 
 func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (execdriver.ExitStatus, error) {
 	// take the Command and populate the libcontainer.Config from it
+	var err error
+	c.TmpDir, err = ioutil.TempDir("", c.ID)
+	if err != nil {
+		return execdriver.ExitStatus{ExitCode: -1}, err
+	}
+	defer os.RemoveAll(c.TmpDir)
+
 	container, err := d.createContainer(c)
 	if err != nil {
 		return execdriver.ExitStatus{ExitCode: -1}, err

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -5,6 +5,7 @@ package native
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"

--- a/daemon/utils.go
+++ b/daemon/utils.go
@@ -56,3 +56,7 @@ func mergeLxcConfIntoOptions(hostConfig *runconfig.HostConfig) ([]string, error)
 
 	return out, nil
 }
+
+func convertUUID(id string) string {
+	return fmt.Sprintf("%s-%s-%s-%s-%.12s", id[0:8], id[8:12], id[12:16], id[16:20], id[20:])
+}

--- a/daemon/utils.go
+++ b/daemon/utils.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/docker/docker/nat"
@@ -59,4 +60,13 @@ func mergeLxcConfIntoOptions(hostConfig *runconfig.HostConfig) ([]string, error)
 
 func convertUUID(id string) string {
 	return fmt.Sprintf("%s-%s-%s-%s-%.12s", id[0:8], id[8:12], id[12:16], id[16:20], id[20:])
+}
+
+func journalPath(id string) string {
+	finfo, err := os.Stat("/var/log/journal")
+	if err != nil || !finfo.IsDir() {
+		return ""
+	}
+
+	return fmt.Sprintf("/var/log/journal/%.32s", id)
 }

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/symlink"
+	"github.com/docker/libcontainer/label"
 )
 
 type volumeMount struct {
@@ -238,6 +239,16 @@ func validMountMode(mode string) bool {
 	return validModes[mode]
 }
 
+func (container *Container) setupJournal() (string, error) {
+	path := journalPath(container.ID)
+	if path != "" {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			return "", err
+		}
+	}
+	return path, nil
+}
+
 func (container *Container) specialMounts() []execdriver.Mount {
 	var mounts []execdriver.Mount
 	if container.ResolvConfPath != "" {
@@ -255,6 +266,10 @@ func (container *Container) specialMounts() []execdriver.Mount {
 func (container *Container) setupMounts() error {
 	mounts := []execdriver.Mount{}
 
+	if container.hostConfig.MountRun && container.Volumes["/run"] == "" {
+		mounts = append(mounts, execdriver.Mount{Source: "tmpfs", Destination: "/run", Writable: true, Private: true})
+	}
+
 	// Mount user specified volumes
 	// Note, these are not private because you may want propagation of (un)mounts from host
 	// volumes. For instance if you use -v /usr:/usr and the host later mounts /usr/share you
@@ -266,6 +281,19 @@ func (container *Container) setupMounts() error {
 			Destination: path,
 			Writable:    container.VolumesRW[path],
 		})
+	}
+
+	if container.Volumes["/var"] == "" &&
+		container.Volumes["/var/log"] == "" &&
+		container.Volumes["/var/log/journal"] == "" {
+		if journalPath, err := container.setupJournal(); err != nil {
+			return err
+		} else {
+			if journalPath != "" {
+				label.Relabel(journalPath, container.MountLabel, "Z")
+				mounts = append(mounts, execdriver.Mount{Source: journalPath, Destination: journalPath, Writable: true, Private: true})
+			}
+		}
 	}
 
 	mounts = append(mounts, container.specialMounts()...)

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -266,7 +266,7 @@ func (container *Container) specialMounts() []execdriver.Mount {
 func (container *Container) setupMounts() error {
 	mounts := []execdriver.Mount{}
 
-	if container.hostConfig.MountRun && container.Volumes["/run"] == "" {
+	if !container.hostConfig.BuildFlag && container.Volumes["/run"] == "" {
 		mounts = append(mounts, execdriver.Mount{Source: "tmpfs", Destination: "/run", Writable: true, Private: true})
 	}
 
@@ -283,7 +283,8 @@ func (container *Container) setupMounts() error {
 		})
 	}
 
-	if container.Volumes["/var"] == "" &&
+	if !container.hostConfig.BuildFlag &&
+		container.Volumes["/var"] == "" &&
 		container.Volumes["/var/log"] == "" &&
 		container.Volumes["/var/log/journal"] == "" {
 		if journalPath, err := container.setupJournal(); err != nil {

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -194,6 +194,9 @@ is the case the **--dns** flags is necessary for every run.
 environment variables that are available for the process that will be launched
 inside of the container.
 
+   The container_uuid is set automatically with a 32 character truncated
+Container ID in standard UUID format.
+
 **--entrypoint**=""
    Overwrite the default ENTRYPOINT of the image
 
@@ -534,6 +537,7 @@ Running the **env** command in the linker container shows environment variables
  with the LT (alias) context (**LT_**)
 
     # env
+    container_uuid=be84194d-87f9-08c2-b2e1-67311f4409f5
     HOSTNAME=668231cb0978
     TERM=xterm
     LT_PORT_80_TCP=tcp://172.17.0.3:80

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -1031,6 +1031,7 @@ container by using one or more `-e` flags, even overriding those mentioned
 above, or already defined by the developer with a Dockerfile `ENV`:
 
     $ docker run -e "deep=purple" --rm ubuntu /bin/bash -c export
+    declare -x container_uuid="be84194d-87f9-08c2-b2e1-67311f4409f5"
     declare -x HOME="/"
     declare -x HOSTNAME="85bc26a0e200"
     declare -x OLDPWD

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -275,6 +275,7 @@ func SetupInitLayer(initLayer string) error {
 		"/dev/pts":         "dir",
 		"/dev/shm":         "dir",
 		"/proc":            "dir",
+		"/run":             "dir",
 		"/sys":             "dir",
 		"/.dockerinit":     "file",
 		"/.dockerenv":      "file",

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -831,14 +831,17 @@ func (s *DockerSuite) TestRunEnvironment(c *check.C) {
 		"cky",
 		"",
 		"HOME=/root",
+		"container_uuid=ID",
 	}
 	sort.Strings(goodEnv)
 	if len(goodEnv) != len(actualEnv) {
-		c.Fatalf("Wrong environment: should be %d variables, not: %q\n", len(goodEnv), strings.Join(actualEnv, ", "))
+		c.Fatalf("Wrong environment: should be %d variables, not %d: %q\n", len(goodEnv), len(actualEnv), strings.Join(actualEnv, ", "))
 	}
 	for i := range goodEnv {
 		if actualEnv[i] != goodEnv[i] {
-			c.Fatalf("Wrong environment variable: should be %s, not %s", goodEnv[i], actualEnv[i])
+			if strings.Split(actualEnv[i], "=")[0] != "container_uuid" {
+				c.Fatalf("Wrong environment variable: should be %s, not %s", goodEnv[i], actualEnv[i])
+			}
 		}
 	}
 }
@@ -868,6 +871,7 @@ func (s *DockerSuite) TestRunEnvironmentErase(c *check.C) {
 	goodEnv := []string{
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"HOME=/root",
+		"container_uuid=ID",
 	}
 	sort.Strings(goodEnv)
 	if len(goodEnv) != len(actualEnv) {
@@ -875,7 +879,9 @@ func (s *DockerSuite) TestRunEnvironmentErase(c *check.C) {
 	}
 	for i := range goodEnv {
 		if actualEnv[i] != goodEnv[i] {
-			c.Fatalf("Wrong environment variable: should be %s, not %s", goodEnv[i], actualEnv[i])
+			if strings.Split(actualEnv[i], "=")[0] != "container_uuid" {
+				c.Fatalf("Wrong environment variable: should be %s, not %s", goodEnv[i], actualEnv[i])
+			}
 		}
 	}
 }
@@ -905,6 +911,7 @@ func (s *DockerSuite) TestRunEnvironmentOverride(c *check.C) {
 		"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
 		"HOME=/root2",
 		"HOSTNAME=bar",
+		"container_uuid=ID",
 	}
 	sort.Strings(goodEnv)
 	if len(goodEnv) != len(actualEnv) {
@@ -912,7 +919,9 @@ func (s *DockerSuite) TestRunEnvironmentOverride(c *check.C) {
 	}
 	for i := range goodEnv {
 		if actualEnv[i] != goodEnv[i] {
-			c.Fatalf("Wrong environment variable: should be %s, not %s", goodEnv[i], actualEnv[i])
+			if strings.Split(actualEnv[i], "=")[0] != "container_uuid" {
+				c.Fatalf("Wrong environment variable: should be %s, not %s", goodEnv[i], actualEnv[i])
+			}
 		}
 	}
 }

--- a/pkg/systemd/register.go
+++ b/pkg/systemd/register.go
@@ -1,0 +1,34 @@
+package systemd
+
+import (
+	"encoding/hex"
+	"github.com/godbus/dbus"
+)
+
+var conn *dbus.Conn
+
+// RegisterMachine with systemd on the host system
+func RegisterMachine(name string, id string, pid int, root_directory string) error {
+	var (
+		av  []byte
+		err error
+	)
+	if !SdBooted() {
+		return nil
+	}
+
+	if conn == nil {
+		conn, err = dbus.SystemBus()
+		if err != nil {
+			return (err)
+		}
+	}
+
+	av, err = hex.DecodeString(id[0:32])
+	if err != nil {
+		return err
+	}
+
+	obj := conn.Object("org.freedesktop.machine1", "/org/freedesktop/machine1")
+	return obj.Call("org.freedesktop.machine1.Manager.RegisterMachine", 0, name, av, "docker", "container", uint32(pid), root_directory).Err
+}

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -217,6 +217,7 @@ type HostConfig struct {
 	Ulimits         []*ulimit.Ulimit
 	LogConfig       LogConfig
 	CgroupParent    string // Parent cgroup.
+	BuildFlag       bool
 }
 
 func MergeConfigs(config *Config, hostConfig *HostConfig) *ContainerConfigWrapper {

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -349,6 +349,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		CapDrop:         flCapDrop.GetAll(),
 		RestartPolicy:   restartPolicy,
 		SecurityOpt:     flSecurityOpt.GetAll(),
+		BuildFlag:       false,
 		ReadonlyRootfs:  *flReadonlyRootfs,
 		Ulimits:         flUlimits.GetList(),
 		LogConfig:       LogConfig{Type: *flLoggingDriver, Config: loggingOpts},


### PR DESCRIPTION
The basic idea is to allow us to run systemd/journald within a container and have the journal data exposed to the host.

In order to do this, we had to implement three different things.  
1. Define a container_uuid environment variable in a systemd with a UUID.  We do this using the container ID.(Patch 1)
2. Create a directory on the host in /var/log/journald/CONTAINER.ID (Truncated to 32 chars), volume mount this directory into the container.
3. Register the container with systemd using machinectl over systemd dbus.

With this patch you can do a 
journalctl -M CONTAINER_NAME
And see the journal data within a systemd based container.

This has a secondary effect of allowing us to see and manipulate docker containers using machinectl.  This will list all running containers, even if they are docker containers or systemd-nspawn containers.  It will also list any VM's running on the machine.
