### PR TITLE
integ-cli: Skip new tests requiring same-host daemon

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -163,6 +163,7 @@ func TestExecAfterContainerRestart(t *testing.T) {
 }
 
 func TestExecAfterDaemonRestart(t *testing.T) {
+	testRequires(t, SameHostDaemon)
 	defer deleteAllContainers()
 
 	d := NewDaemon(t)


### PR DESCRIPTION
This skips the following tests:
- ~~`TestEventsFilters`~~
- `TestExecAfterContainerRestart`
- `TestRunExecDir`
- `TestRunMutableNetworkFiles`

as the tests require starting a daemon on the same host.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @unclejack @jfrazelle @LK4D4 
