### PR TITLE
integ-cli: remove bash dependency from TestSaveDirectoryPermissions

### DIFF
--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -376,9 +376,10 @@ func TestSaveDirectoryPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	saveCmdFinal := fmt.Sprintf("%s save %s | tar -xf - -C %s", dockerBinary, name, extractionDirectory)
-	saveCmd := exec.Command("bash", "-c", saveCmdFinal)
-	if out, _, err := runCommandWithOutput(saveCmd); err != nil {
+	if out, _, err := runCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", name),
+		exec.Command("tar", "-xf", "-", "-C", extractionDirectory),
+	); err != nil {
 		t.Errorf("failed to save and extract image: %s", out)
 	}
 


### PR DESCRIPTION
Use the new `runCommandPipelineWithOutput` helper to
remove bash dependency required for piping in
`TestSaveDirectoryPermissions`.

It wasn't working first time I tried it (test was getting stuck
indefinitely) magically works now.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @jfrazelle @tianon @duglin @LK4D4 
