### PR TITLE
integ-cli: Skip some exec tests requiring same-host daemon

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -529,6 +529,7 @@ func TestLinksPingLinkedContainersOnRename(t *testing.T) {
 }
 
 func TestRunExecDir(t *testing.T) {
+	testRequires(t, SameHostDaemon)
 	cmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -629,6 +630,7 @@ func TestRunExecDir(t *testing.T) {
 }
 
 func TestRunMutableNetworkFiles(t *testing.T) {
+	testRequires(t, SameHostDaemon)
 	defer deleteAllContainers()
 
 	for _, fn := range []string{"resolv.conf", "hosts"} {


### PR DESCRIPTION
This skips the following exec tests:
- `TestRunExecDir`
- `TestRunMutableNetworkFiles`

Sorry they couldn't made #10995, you folks are fast at merging!

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
