### PR TITLE
Support windows style dockerfile paths for build cmd

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -155,11 +155,10 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		if *dockerfileName == "" {
 			// No -f/--file was specified so use the default
 			*dockerfileName = api.DefaultDockerfileName
-			filename = path.Join(absRoot, *dockerfileName)
+			filename = filepath.Join(absRoot, *dockerfileName)
 		}
 
 		origDockerfile := *dockerfileName // used for error msg
-
 		if filename, err = filepath.Abs(filename); err != nil {
 			return err
 		}
@@ -174,6 +173,11 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		*dockerfileName, err = filepath.Rel(absRoot, filename)
 		if err != nil {
 			return err
+		}
+		// And canonicalize dockerfile name to a platform-independent one
+		*dockerfileName, err = archive.CanonicalTarNameForPath(*dockerfileName)
+		if err != nil {
+			return fmt.Errorf("Cannot canonicalize dockerfile path %s: %v", dockerfileName, err)
 		}
 
 		if _, err = os.Lstat(filename); os.IsNotExist(err) {

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -175,7 +175,7 @@ type tarAppender struct {
 // canonicalTarName provides a platform-independent and consistent posix-style
 //path for files and directories to be archived regardless of the platform.
 func canonicalTarName(name string, isDir bool) (string, error) {
-	name, err := canonicalTarNameForPath(name)
+	name, err := CanonicalTarNameForPath(name)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -12,7 +12,7 @@ import (
 // canonicalTarNameForPath returns platform-specific filepath
 // to canonical posix-style path for tar archival. p is relative
 // path.
-func canonicalTarNameForPath(p string) (string, error) {
+func CanonicalTarNameForPath(p string) (string, error) {
 	return p, nil // already unix-style
 }
 

--- a/pkg/archive/archive_unix_test.go
+++ b/pkg/archive/archive_unix_test.go
@@ -13,7 +13,7 @@ func TestCanonicalTarNameForPath(t *testing.T) {
 		{"foo/dir/", "foo/dir/"},
 	}
 	for _, v := range cases {
-		if out, err := canonicalTarNameForPath(v.in); err != nil {
+		if out, err := CanonicalTarNameForPath(v.in); err != nil {
 			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
 		} else if out != v.expected {
 			t.Fatalf("wrong canonical tar name. expected:%s got:%s", v.expected, out)

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -12,7 +12,7 @@ import (
 // canonicalTarNameForPath returns platform-specific filepath
 // to canonical posix-style path for tar archival. p is relative
 // path.
-func canonicalTarNameForPath(p string) (string, error) {
+func CanonicalTarNameForPath(p string) (string, error) {
 	// windows: convert windows style relative path with backslashes
 	// into forward slashes. since windows does not allow '/' or '\'
 	// in file names, it is mostly safe to replace however we must

--- a/pkg/archive/archive_windows_test.go
+++ b/pkg/archive/archive_windows_test.go
@@ -17,7 +17,7 @@ func TestCanonicalTarNameForPath(t *testing.T) {
 		{`foo\bar`, "foo/bar/", false},
 	}
 	for _, v := range cases {
-		if out, err := canonicalTarNameForPath(v.in); err != nil && !v.shouldFail {
+		if out, err := CanonicalTarNameForPath(v.in); err != nil && !v.shouldFail {
 			t.Fatalf("cannot get canonical name for path: %s: %v", v.in, err)
 		} else if v.shouldFail && err == nil {
 			t.Fatalf("canonical path call should have pailed with error. in=%s out=%s", v.in, out)


### PR DESCRIPTION
Currently `TestBuildRenamedDockerfile` fails since passing
custom dockerfile paths like:

```
docker build -f dir/file .
```

fails on windows because those are unix paths. Instead, on
windows, accept windows-style paths like:

```
docker build -f dir\file .
```

and convert them to unix style paths using the helper we
have in `pkg/archive` so that daemon can correctly locate
the path in the context. This can fix the test without touching it.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @unclejack @tiborvass @jfrazelle 
