### PR TITLE
integ-cli: skip TestRunBindMounts (same-host daemon requirement)

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2190,6 +2190,7 @@ func TestRunEntrypoint(t *testing.T) {
 }
 
 func TestRunBindMounts(t *testing.T) {
+	testRequires(t, SameHostDaemon)
 	defer deleteAllContainers()
 
 	tmpDir, err := ioutil.TempDir("", "docker-test-container")


### PR DESCRIPTION
`TestRunBindMounts` requires daemon to be on the same host
as it examines side effects of `run -v...` by running commands
on the filesystem of docker host.

Running this cli test on Linux is fair enough coverage for
this functionality and we can skip this for platforms where
daemon cannot run side-by-side with the cli for now.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @cpuguy83 @duglin @jfrazelle @LK4D4 
