### PR TITLE
integ-cli: skip tests launching registry-v2

### DIFF
--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -901,6 +901,7 @@ func readContainerFileWithExec(containerId, filename string) ([]byte, error) {
 }
 
 func setupRegistry(t *testing.T) func() {
+	testRequires(t, RegistryHosting)
 	reg, err := newTestRegistryV2(t)
 	if err != nil {
 		t.Fatal(err)

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+	"os/exec"
 	"testing"
 )
 
@@ -24,6 +26,16 @@ var (
 	ExecSupport = TestRequirement{
 		func() bool { return supportsExec },
 		"Test requires 'docker exec' capabilities on the tested daemon.",
+	}
+	RegistryHosting = TestRequirement{
+		func() bool {
+			// for now registry binary is built only if we're running inside
+			// container through `make test`. Figure that out by testing if
+			// registry binary is in PATH.
+			_, err := exec.LookPath(v2binary)
+			return err == nil
+		},
+		fmt.Sprintf("Test requires an environment that can host %s in the same host", v2binary),
 	}
 )
 


### PR DESCRIPTION
Some pull/push tests are launching a local `registry-v2`
binary which is compiled and installed if the tests
are running in-container through `make test-integration-cli`.

However, registry is not supported to run on non-linux
platforms and we can't really spin up any registry-v2
containers in the remote DOCKER_TEST_HOST at this point.

Just skipping those with the new TestRequirement called
`RegistryHosting`. If the registry-v2 image becomes available
we can take a path like #10893 and spin up registry containers
at the remote daemon hosts and re-enable tests.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @tianon @unclejack @jfrazelle @icecrime @LK4D4 
