### PR TITLE
integ-cli: fix TestCommitChange for pulled busybox

### DIFF
--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -253,6 +253,7 @@ func TestCommitChange(t *testing.T) {
 		"--change", "EXPOSE 8080",
 		"--change", "ENV DEBUG true",
 		"--change", "ENV test 1",
+		"--change", "ENV PATH /foo",
 		"test", "test-commit")
 	imageId, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -263,7 +264,7 @@ func TestCommitChange(t *testing.T) {
 
 	expected := map[string]string{
 		"Config.ExposedPorts": "map[8080/tcp:map[]]",
-		"Config.Env":          "[DEBUG=true test=1]",
+		"Config.Env":          "[DEBUG=true test=1 PATH=/foo]",
 	}
 
 	for conf, value := range expected {


### PR DESCRIPTION
If the tests are running outside a container (i.e.
executed without `make test`), we are using a `busybox`
pulled from Docker Hub (instead of jpetazzo's [docker-busybox](https://github.com/jpetazzo/docker-busybox)).

The one pulled from Docker Hub always adds an extra
`PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`
env var all and that messes up the test `TestCommitChange`.
That's currently breaking the windows CI. (The test is introduced in #9123.)

I'm keeping the same PATH here but making it explicit
so that it's always set and we verify what we set. It's actually the same
thing if I set `ENV PATH foo` here but I thought it may lead to some
problems hard to debug in the future.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @tiborvass @dqminh @tianon @cpuguy83 
