### PR TITLE
Fix docker remove an image show misleading conflicts

### DIFF
--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -70,7 +70,7 @@ func (daemon *Daemon) DeleteImage(eng *engine.Engine, name string, imgs *engine.
 				if parsedTag != "" {
 					tags = append(tags, parsedTag)
 				}
-			} else if repoName != parsedRepo && !force {
+			} else if repoName != parsedRepo && !force && first {
 				// the id belongs to multiple repos, like base:latest and user:test,
 				// in that case return conflict
 				return fmt.Errorf("Conflict, cannot delete image %s because it is tagged in multiple repositories, use -f to force", name)

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -124,3 +124,36 @@ MAINTAINER foo`)
 
 	logDone("rmi - force delete with existing containers")
 }
+
+func TestRmiWithMultipleRepositories(t *testing.T) {
+	defer deleteAllContainers()
+	newRepo := "127.0.0.1:5000/busybox"
+	oldRepo := "busybox"
+	newTag := "busybox:test"
+	cmd := exec.Command(dockerBinary, "tag", oldRepo, newRepo)
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("Could not tag busybox: %v: %s", err, out)
+	}
+	cmd = exec.Command(dockerBinary, "run", "--name", "test", oldRepo, "touch", "/home/abcd")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("failed to run container: %v, output: %s", err, out)
+	}
+	cmd = exec.Command(dockerBinary, "commit", "test", newTag)
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("failed to commit container: %v, output: %s", err, out)
+	}
+	cmd = exec.Command(dockerBinary, "rmi", newTag)
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("failed to remove image: %v, output: %s", err, out)
+	}
+	if !strings.Contains(out, "Untagged: "+newTag) {
+		t.Fatalf("Could not remove image %s: %s, %v", newTag, out, err)
+	}
+
+	logDone("rmi - delete a image which its dependency tagged to multiple repositories success")
+
+}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
steps to reproduce:
`1) docker tag busybox 127.0.0.1:5000/busybox`
`2) docker run --name test123 busybox touch /home/test`
`3)docker commit test123 busybox:test`
`4)docker rmi busybox:test`  
The output message is 
`Error response from daemon: Conflict, cannot delete image 4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125 because it is tagged in multiple repositories, use -f to force
FATA[0000] Error: failed to remove one or more images` 
This message is misleading, actually `4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125` is  ID of `busybox:latest` and the layer of  `busybox:test` has been removed.

Just as the comment in the source code said(see https://github.com/docker/docker/blob/master/daemon/image_delete.go#L74)
this conflict message is to info the user when remove a image use a ID and the the ID is taged to multiple repositories. 
The image which ID is taged to multiple repositories  is only removed at first time(see https://github.com/docker/docker/blob/master/daemon/image_delete.go#L83)

So when remove an image which its dependency image ID taged to multiple repositories, 
there is no need to show this message, because https://github.com/docker/docker/blob/master/daemon/image_delete.go#L83 will prevent it from 
being remove.

If it is ok, I'll add a test
