### PR TITLE
Add validate the input mac address on docker run command

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2355,6 +2355,20 @@ func TestRunInspectMacAddress(t *testing.T) {
 	logDone("run - inspecting MAC address")
 }
 
+// test docker run use a invalid mac address
+func TestRunWithInvalidMacAddress(t *testing.T) {
+	defer deleteAllContainers()
+
+	runCmd := exec.Command(dockerBinary, "run", "--mac-address", "92:d0:c6:0a:29", "busybox")
+	out, _, err := runCommandWithOutput(runCmd)
+	//use a invalid mac address should with a error out
+	if err == nil || !strings.Contains(out, "is not a valid mac address") {
+		t.Fatalf("run with an invalid --mac-address should with error out")
+	}
+
+	logDone("run - can't use an invalid mac address")
+}
+
 func TestRunDeallocatePortOnMissingIptablesRule(t *testing.T) {
 	defer deleteAllContainers()
 	testRequires(t, SameHostDaemon)

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -183,6 +183,15 @@ func ValidateIPAddress(val string) (string, error) {
 	return "", fmt.Errorf("%s is not an ip address", val)
 }
 
+func ValidateMACAddress(val string) (string, error) {
+	_, err := net.ParseMAC(strings.TrimSpace(val))
+	if err != nil {
+		return "", err
+	} else {
+		return val, nil
+	}
+}
+
 // Validates domain for resolvconf search configuration.
 // A zero length domain is represented by .
 func ValidateDnsSearch(val string) (string, error) {

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -28,6 +28,20 @@ func TestValidateIPAddress(t *testing.T) {
 
 }
 
+func TestValidateMACAddress(t *testing.T) {
+	if _, err := ValidateMACAddress(`92:d0:c6:0a:29:33`); err != nil {
+		t.Fatalf("ValidateMACAddress(`92:d0:c6:0a:29:33`) got %s", err)
+	}
+
+	if _, err := ValidateMACAddress(`92:d0:c6:0a:33`); err == nil {
+		t.Fatalf("ValidateMACAddress(`92:d0:c6:0a:33`) succeeded; expected failure on invalid MAC")
+	}
+
+	if _, err := ValidateMACAddress(`random invalid string`); err == nil {
+		t.Fatalf("ValidateMACAddress(`random invalid string`) succeeded; expected failure on invalid MAC")
+	}
+}
+
 func TestListOpts(t *testing.T) {
 	o := NewListOpts(nil)
 	o.Set("foo")

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -94,6 +94,12 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		return nil, nil, cmd, ErrInvalidWorkingDirectory
 	}
 
+	// Validate the input mac address
+	if *flMacAddress != "" {
+		if _, err := opts.ValidateMACAddress(*flMacAddress); err != nil {
+			return nil, nil, cmd, fmt.Errorf("%s is not a valid mac address", *flMacAddress)
+		}
+	}
 	var (
 		attachStdin  = flAttach.Get("stdin")
 		attachStdout = flAttach.Get("stdout")


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

when docker run with a invalid mac address, the container will still start and  assigned a
random mac address.
Is this a desired behavior?
I think it should show a message to info the user that the input mac address is invalid.

Fixes #11027 
