### PR TITLE
Add the file close operation before function return to advoid resource leaking

### DIFF
--- a/daemon/graphdriver/devmapper/mount.go
+++ b/daemon/graphdriver/devmapper/mount.go
@@ -55,13 +55,14 @@ func ProbeFsType(device string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer file.Close()
 
 	buffer := make([]byte, maxLen)
 	l, err := file.Read(buffer)
 	if err != nil {
 		return "", err
 	}
-	file.Close()
+
 	if uint64(l) != maxLen {
 		return "", fmt.Errorf("unable to detect filesystem type of %s, short read", device)
 	}


### PR DESCRIPTION
In some functions,they do the open file operations but do not be close before functions return,so close file operations  should be added to advoid resource leaking.
