### PR TITLE
when the file that was opened has been read into buffer, the file should be closed

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -140,14 +140,12 @@ func (img *Image) RawJson() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get root for image %s: %s", img.ID, err)
 	}
-	fh, err := os.Open(jsonPath(root))
-	if err != nil {
-		return nil, fmt.Errorf("Failed to open json for image %s: %s", img.ID, err)
-	}
-	buf, err := ioutil.ReadAll(fh)
+
+	buf, err := ioutil.ReadFile(jsonPath(root))
 	if err != nil {
 		return nil, fmt.Errorf("Failed to read json for image %s: %s", img.ID, err)
 	}
+
 	return buf, nil
 }
 

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -851,14 +851,11 @@ func writeFile(dst, content string, t *testing.T) {
 // Return the contents of file at path `src`.
 // Call t.Fatal() at the first error (including if the file doesn't exist)
 func readFile(src string, t *testing.T) (content string) {
-	f, err := os.Open(src)
+	data, err := ioutil.ReadFile(src)
 	if err != nil {
 		t.Fatal(err)
 	}
-	data, err := ioutil.ReadAll(f)
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	return string(data)
 }
 


### PR DESCRIPTION
```
In some function, the content of file  was read into buffer space,and then we do not use those file handle in the future,so the file which was opened should be close.

Signed-off-by: Mabin <bin.ma@huawei.com>
```
