### PR TITLE
fix 'rmi -f imgID' problem

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1794,6 +1794,21 @@ before the image is removed.
     Untagged: test:latest
     Deleted: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8
 
+If you use the `-f` flag and specify the image's short or long ID, then this
+command untags and removes all images that match the specified ID.
+
+    $ docker images
+    REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
+    test1                     latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+    test                      latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+    test2                     latest              fd484f19954f        23 seconds ago      7 B (virtual 4.964 MB)
+
+    $ docker rmi -f fd484f19954f
+    Untagged: test1:latest
+    Untagged: test:latest
+    Untagged: test2:latest
+    Deleted: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8
+
 An image pulled by digest has no tag associated with it:
 
     $ docker images --digests

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -77,6 +77,43 @@ func TestRmiTag(t *testing.T) {
 	logDone("rmi - tag,rmi - tagging the same images multiple times then removing tags")
 }
 
+func TestRmiImgIDForce(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir '/busybox-test'")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatalf("failed to create a container:%s, %v", out, err)
+	}
+	containerID := strings.TrimSpace(out)
+	runCmd = exec.Command(dockerBinary, "commit", containerID, "busybox-test")
+	out, _, err = runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatalf("failed to commit a new busybox-test:%s, %v", out, err)
+	}
+
+	imagesBefore, _, _ := dockerCmd(t, "images", "-a")
+	dockerCmd(t, "tag", "busybox-test", "utest:tag1")
+	dockerCmd(t, "tag", "busybox-test", "utest:tag2")
+	dockerCmd(t, "tag", "busybox-test", "utest/docker:tag3")
+	dockerCmd(t, "tag", "busybox-test", "utest:5000/docker:tag4")
+	{
+		imagesAfter, _, _ := dockerCmd(t, "images", "-a")
+		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+4 {
+			t.Fatalf("tag busybox to create 4 more images with same imageID; docker images shows: %q\n", imagesAfter)
+		}
+	}
+	out, _, _ = dockerCmd(t, "inspect", "-f", "{{.Id}}", "busybox-test")
+	imgID := strings.TrimSpace(out)
+	dockerCmd(t, "rmi", "-f", imgID)
+	{
+		imagesAfter, _, _ := dockerCmd(t, "images", "-a")
+		if strings.Contains(imagesAfter, imgID[:12]) {
+			t.Fatalf("rmi -f %s failed, image still exists: %q\n\n", imgID, imagesAfter)
+		}
+
+	}
+	logDone("rmi - imgID,rmi -f imgID  delete all tagged repos of specific imgID")
+}
+
 func TestRmiTagWithExistingContainers(t *testing.T) {
 	defer deleteAllContainers()
 


### PR DESCRIPTION
If an image has been tagged to multiple repos and tags, 'docker rmi -f imgID' will just untag one repo other than untagging all repos and deleting the image. This patch fix it.
before:
![before](https://cloud.githubusercontent.com/assets/2840248/6411690/e7e3792e-beb5-11e4-8c74-65842f6740ca.png)
after:
![after](https://cloud.githubusercontent.com/assets/2840248/6411710/2c819926-beb6-11e4-9150-ab0b1561f182.png)

I think 'rmi -f imgID' just untag a random repo:tag is wired. Deleting all repos and tags may be proper
