### PR TITLE
Update mac.md

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -186,7 +186,7 @@ Work through this section to try some practical container tasks using `boot2dock
 	This tells you that the `web` container's port `80` is mapped to port
 	`49157` on your Docker host.
 
-4. Enter the `https://localhost:49157` address (`localhost` is `0.0.0.0`) in your browser:
+4. Enter the `http://localhost:49157` address (`localhost` is `0.0.0.0`) in your browser:
 
 	   ![Bad Address](/installation/images/bad_host.png)
 
@@ -199,7 +199,7 @@ Work through this section to try some practical container tasks using `boot2dock
 		$ boot2docker ip
 		192.168.59.103
 		
-6. Enter the `https://192.168.59.103:49157` address in your browser:
+6. Enter the `http://192.168.59.103:49157` address in your browser:
 
 	![Correct Addressing](/installation/images/good_host.png)
 


### PR DESCRIPTION
The document referenced https but was using the http port.  I changed the examples from https to http.

Also, fyi, when I tried accessing https using the correct 443 port, it did not work.  I have not investigated why.  Port 80 worked fine.

For me:
jay-mac:.ssh jay$ docker port web
80/tcp -> 0.0.0.0:49153
443/tcp -> 0.0.0.0:49154
jay-mac:.ssh jay$ boot2docker ip
192.168.59.103

works: http://192.168.59.103:49153/
fails: https://192.168.59.103:49154/
