### PR TITLE
To avoid the confusing in log, change '%s' to '%q', change the question ...

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -111,7 +111,7 @@ func main() {
 			*flTls = true
 			cert, err := tls.LoadX509KeyPair(*flCert, *flKey)
 			if err != nil {
-				log.Fatalf("Couldn't load X509 key pair: %s. Key encrypted?", err)
+				log.Fatalf("Couldn't load X509 key pair: %q. Make sure the key is encrypted", err)
 			}
 			tlsConfig.Certificates = []tls.Certificate{cert}
 		}


### PR DESCRIPTION
 To avoid the confusing in log, change '%s' to '%q', change the question sentence to a reminding sentence.

 '%q' for more infomation about the PEM encoded data.
 Reminding sentence here is more effctive than question sentenc, avoid confusing.

Signed-off-by: Zen Lin(Zhinan Lin) linzhinan@huawei.com
