### PR TITLE
Normalize the log for docker subcommand usage

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -93,10 +93,13 @@ func (cli *DockerCli) Subcmd(name, signature, description string, exitOnError bo
 	flags := flag.NewFlagSet(name, errorHandling)
 	flags.Usage = func() {
 		options := ""
-		if flags.FlagCountUndeprecated() > 0 {
-			options = "[OPTIONS] "
+		if signature != "" {
+			signature = " " + signature
 		}
-		fmt.Fprintf(cli.out, "\nUsage: docker %s %s%s\n\n%s\n\n", name, options, signature, description)
+		if flags.FlagCountUndeprecated() > 0 {
+			options = " [OPTIONS]"
+		}
+		fmt.Fprintf(cli.out, "\nUsage: docker %s%s%s\n\n%s\n\n", name, options, signature, description)
 		flags.SetOutput(cli.out)
 		flags.PrintDefaults()
 		os.Exit(0)


### PR DESCRIPTION
Normalize the log for docker subcommand usage,
Change the trailing space of options to the begining.
Then make the output of the usage to be correct.

To the orignal code, someone should mistake the trailing space to as the content for signature.

Signed-off-by: Zen Lin(Zhinan Lin) linzhinan@huawei.com
