### PR TITLE
Implement cleanup unix sockets after serving.

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1575,6 +1575,9 @@ func ServeApi(job *engine.Job) engine.Status {
 				return
 			}
 			chErrors <- srv.Serve()
+			if err := srv.Close(); err != nil {
+				log.Errorf("%s", err.Error())
+			}
 		}()
 	}
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1574,10 +1574,12 @@ func ServeApi(job *engine.Job) engine.Status {
 				chErrors <- err
 				return
 			}
+			job.Eng.OnShutdown(func() {
+				if err := srv.Close(); err != nil {
+					log.Errorf("%s", err.Error())
+				}
+			})
 			chErrors <- srv.Serve()
-			if err := srv.Close(); err != nil {
-				log.Errorf("%s", err.Error())
-			}
 		}()
 	}
 


### PR DESCRIPTION
I have tried to fix #10969.
Since the Sockets variable was moved out of Daemon in commit https://github.com/docker/docker/commit/1d10c55aec891df609d36c90ee6c30adb24c16c4, I have implemented the removeUnixSocket function in server.go which runs after the go routine starting the Server is completed.

I am not sure whether this is the right place to call the removeUnixSocket function or not. Could someone assist me in this? 
