### PR TITLE
Fix incorrect https example in mac.md (carry of 11063)

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -186,7 +186,7 @@ Work through this section to try some practical container tasks using `boot2dock
 	This tells you that the `web` container's port `80` is mapped to port
 	`49157` on your Docker host.
 
-4. Enter the `https://localhost:49157` address (`localhost` is `0.0.0.0`) in your browser:
+4. Enter the `http://localhost:49157` address (`localhost` is `0.0.0.0`) in your browser:
 
 	   ![Bad Address](/installation/images/bad_host.png)
 
@@ -199,7 +199,7 @@ Work through this section to try some practical container tasks using `boot2dock
 		$ boot2docker ip
 		192.168.59.103
 		
-6. Enter the `https://192.168.59.103:49157` address in your browser:
+6. Enter the `http://192.168.59.103:49157` address in your browser:
 
 	![Correct Addressing](/installation/images/good_host.png)
 


### PR DESCRIPTION
Carry of 11063 (thanks, @sellerjd)

replaces #11063
closes #11063

The Mac OS X Installation Guide incorrectly used `https://` links in the examples, making them not work. 

<strike>This also removes references to `0.0.0.0` being the same as `localhost`, because localhost is `127.0.0.1`, not `0.0.0.0`.</strike>
