### PR TITLE
Proposal: Add --no-parents option to `docker save` to support peer to peer image transfers

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -691,6 +691,7 @@ func getImagesGet(eng *engine.Engine, version version.Version, w http.ResponseWr
 	} else {
 		job = eng.Job("image_export", r.Form["names"]...)
 	}
+	job.Setenv("noparents", r.Form.Get("noparents"))
 	job.Stdout.Add(w)
 	return job.Run()
 }


### PR DESCRIPTION
There are several tickets relating to partial exports of docker images, mostly related to efficiently transferring images between docker daemons without the use of a registry:
- #247 proposes peer to peer transfers of docker images between docker daemons
- #3870 proposes modifying `docker save` to export a range of layers when exporting an image
- #9304 proposes an --exclude flag for `docker save` to exclude large common layers
- #8039 suggests an --include flag for `docker save`

I would like to make yet another suggestion, a --no-parents flag for the `docker save` command and corresponding api. This flag would prevent `docker save` from exporting parent layers so it only exports the specified layer.

With this small change an external program can use the Docker Remote API  to efficiently transfer images between docker daemons. The external program would:
1. Repeatedly call the `/images/<image>/json` api on the source daemon to find all parent images of the specific image
2. Call `/images/<image>/json` on the destination daemon to check which layers have already been loaded into the destination
3. Call `/images/<image>/get` and `/images/load` on the respective daemons to transfer the layers not yet present at the destination

I have developed a proof of concept implementation of this external program called [docker2docker](https://github.com/richardcrichardc/docker2docker). (In hindsight I will probably need to rename it)

Different external programs could use different transports. I like the use of SSH and intent to extent docker2docker to create SSH tunnels between hosts for transferring images. Some people may prefer other methods, like connecting to the daemons over TCP+SSL. Another hybrid approach would be to pull layers from the Docker registry when available and fall back to peer to peer for other layers.

This functionality could also be included directly in Docker. When I started working on this, I intended to extend the Docker daemon to transfer images directly to another Docker daemon. I stopped when I came across the complication of where to store client certificates and keys for securely communicating to the remote daemon. Neither option of storing credentials on the docker server or transferring them from the client to the daemon seemed entirely appropriate for a peer to peer implementation. For this reason I'd suggest implementing this functionality in the client rather than the daemon and keeping the client certificates and keys local to the client.

The demonstration program does not currently transfer tags to the destination docker daemon. I expect this can be rectified by making additional calls to tag the images on the destination Docker daemon. I will add a comment in a day or two once I have investigated furthur.

This pull request is not ready to merge. If feedback indicates it is likely to be merged I will update documentation and make other changes as required.
