### PR TITLE
Zenlin handlerkey format

### DIFF
--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -53,7 +53,7 @@ func remote(eng *engine.Engine) error {
 // These components should be broken off into plugins of their own.
 //
 func daemon(eng *engine.Engine) error {
-	return eng.Register("init_networkdriver", bridge.InitDriver)
+	return eng.Register("initNetworkdriver", bridge.InitDriver)
 }
 
 // builtins jobs independent of any subsystem

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -931,7 +931,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 	}
 
 	if !config.DisableNetwork {
-		job := eng.Job("init_networkdriver")
+		job := eng.Job("initNetworkdriver")
 
 		job.SetenvBool("EnableIptables", config.EnableIptables)
 		job.SetenvBool("InterContainerCommunication", config.InterContainerCommunication)

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -469,7 +469,7 @@ func (devices *DeviceSet) createFilesystem(info *DevInfo) error {
 }
 
 func (devices *DeviceSet) migrateOldMetaData() error {
-	// Migrate old metadatafile
+	// Migrate old metadata file
 	jsonData, err := ioutil.ReadFile(devices.oldMetadataFile())
 	if err != nil && !os.IsNotExist(err) {
 		return err
@@ -1093,7 +1093,7 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 		}
 	}
 
-	// Right now this loads only NextDeviceId. If there is more metatadata
+	// Right now this loads only NextDeviceId. If there is more metadata
 	// down the line, we might have to move it earlier.
 	if err = devices.loadDeviceSetMetaData(); err != nil {
 		return err
@@ -1568,7 +1568,7 @@ func (devices *DeviceSet) poolStatus() (totalSizeInSectors, transactionId, dataU
 	return
 }
 
-// MetadataDevicePath returns the path to the metadata storage for this deviceset,
+// DataDevicePath returns the path to the data storage for this deviceset,
 // regardless of loopback or block device
 func (devices *DeviceSet) DataDevicePath() string {
 	return devices.dataDevice


### PR DESCRIPTION
Format the key of the bridge.Handler,change "init_networkdriver" to "initNetworkdriver".

The format should be "initNetworkdriver" or "networkdriver_init", just in the purpose to keep accordant format.
