### PR TITLE
Add support for an optional ".bashrc" file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ docs/VERSION
 docs/GITCOMMIT
 docs/changed-files
 autogen/
+.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -142,6 +142,9 @@ VOLUME /var/lib/docker
 WORKDIR /go/src/github.com/docker/docker
 ENV DOCKER_BUILDTAGS apparmor selinux btrfs_noversion
 
+# Let us use a .bashrc file
+RUN ln -sfv $PWD/.bashrc ~/.bashrc
+
 # Install man page generator
 COPY vendor /go/src/github.com/docker/docker/vendor
 # (copy vendor/ because go-md2man needs golang.org/x/net)


### PR DESCRIPTION
If `.bashrc` exists at the root of the source tree, it will be used as the `~/.bashrc` inside the container.
