### PR TITLE
Docker Tag command: Relax the restriction on namespace (username) length from 30 to 255 characters.

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -223,8 +223,8 @@ func validateRemoteName(remoteName string) error {
 	if !validNamespaceChars.MatchString(namespace) {
 		return fmt.Errorf("Invalid namespace name (%s). Only [a-z0-9-_] are allowed.", namespace)
 	}
-	if len(namespace) < 4 || len(namespace) > 30 {
-		return fmt.Errorf("Invalid namespace name (%s). Cannot be fewer than 4 or more than 30 characters.", namespace)
+	if len(namespace) < 2 || len(namespace) > 255 {
+		return fmt.Errorf("Invalid namespace name (%s). Cannot be fewer than 2 or more than 255 characters.", namespace)
 	}
 	if strings.HasPrefix(namespace, "-") || strings.HasSuffix(namespace, "-") {
 		return fmt.Errorf("Invalid namespace name (%s). Cannot begin or end with a hyphen.", namespace)

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -751,6 +751,9 @@ func TestValidRemoteName(t *testing.T) {
 
 		// Allow underscores everywhere (as opposed to hyphens).
 		"____/____",
+
+		//Username doc and image name docker being tested.
+		"doc/docker",
 	}
 	for _, repositoryName := range validRepositoryNames {
 		if err := validateRemoteName(repositoryName); err != nil {
@@ -776,11 +779,14 @@ func TestValidRemoteName(t *testing.T) {
 		// Disallow consecutive hyphens.
 		"dock--er/docker",
 
-		// Namespace too short.
-		"doc/docker",
-
 		// No repository.
 		"docker/",
+
+		//namespace too short
+		"d/docker",
+
+		//namespace too long
+		"this_is_not_a_valid_namespace_because_its_lenth_is_greater_than_255_this_is_not_a_valid_namespace_because_its_lenth_is_greater_than_255_this_is_not_a_valid_namespace_because_its_lenth_is_greater_than_255_this_is_not_a_valid_namespace_because_its_lenth_is_greater_than_255/docker",
 	}
 	for _, repositoryName := range invalidRepositoryNames {
 		if err := validateRemoteName(repositoryName); err == nil {


### PR DESCRIPTION
This change relaxes the restriction on namespace (username) from 30 to 255 characters.

Issue related to this: #10392

Shishir
