### PR TITLE
Add secondary "simple" Dockerfile

### DIFF
--- a/Dockerfile.simple
+++ b/Dockerfile.simple
@@ -1,0 +1,32 @@
+# docker build -t docker:simple -f Dockerfile.simple .
+# docker run --rm docker:simple hack/make.sh dynbinary
+# docker run --rm --privileged docker:simple hack/make.sh test-unit
+# docker run --rm --privileged docker:simple hack/dind hack/make.sh dynbinary test-integration-cli
+
+# This represents the bare minimum required to build and test Docker.
+
+FROM debian:jessie
+
+# compile and runtime deps
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#build-dependencies
+# https://github.com/docker/docker/blob/master/project/PACKAGERS.md#runtime-dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		btrfs-tools \
+		gcc \
+		git \
+		golang \
+		libdevmapper-dev \
+		libsqlite3-dev \
+		\
+		ca-certificates \
+		e2fsprogs \
+		iptables \
+		procps \
+		xz-utils \
+		\
+		lxc \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV AUTO_GOPATH 1
+WORKDIR /usr/src/docker
+COPY . /usr/src/docker


### PR DESCRIPTION
This is the absolute bare minimum necessary to compile and test Docker -- this is going to be especially useful for testing and verifying assumptions.

With this, we can setup a Jenkins job that tests to ensure that all the work we do to make sure our build scripts and tests don't contain assumptions is not effort spent in vain.

This is important because this is the kind of bare-bones stock environment our packagers build in.  Additionally, this verifies that our scripts will work reasonably on other platforms (such as Darwin and Windows) as well.

Assumptions existing tests make that currently fail:
- `registry-v2` exists as a binary in `$PATH` (FIXED IN #11005 :tada:)
- `unprivilegeduser` exists as a user in `/etc/passwd`
