### PR TITLE
Set "Apt::AutoRemove::SuggestsImportant" to "false" in debootstrap

### DIFF
--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -28,13 +28,13 @@ shift
 # prevent init scripts from running during install/update
 echo >&2 "+ echo exit 101 > '$rootfsDir/usr/sbin/policy-rc.d'"
 cat > "$rootfsDir/usr/sbin/policy-rc.d" <<'EOF'
-#!/bin/sh
+	#!/bin/sh
 
-# For most Docker users, "apt-get install" only happens during "docker build",
-# where starting services doesn't work and often fails in humorous ways. This
-# prevents those failures by stopping the services from attempting to start.
+	# For most Docker users, "apt-get install" only happens during "docker build",
+	# where starting services doesn't work and often fails in humorous ways. This
+	# prevents those failures by stopping the services from attempting to start.
 
-exit 101
+	exit 101
 EOF
 chmod +x "$rootfsDir/usr/sbin/policy-rc.d"
 
@@ -59,12 +59,12 @@ if strings "$rootfsDir/usr/bin/dpkg" | grep -q unsafe-io; then
 	# force dpkg not to call sync() after package extraction (speeding up installs)
 	echo >&2 "+ echo force-unsafe-io > '$rootfsDir/etc/dpkg/dpkg.cfg.d/docker-apt-speedup'"
 	cat > "$rootfsDir/etc/dpkg/dpkg.cfg.d/docker-apt-speedup" <<-'EOF'
-	# For most Docker users, package installs happen during "docker build", which
-	# doesn't survive power loss and gets restarted clean afterwards anyhow, so
-	# this minor tweak gives us a nice speedup (much nicer on spinning disks,
-	# obviously).
+		# For most Docker users, package installs happen during "docker build", which
+		# doesn't survive power loss and gets restarted clean afterwards anyhow, so
+		# this minor tweak gives us a nice speedup (much nicer on spinning disks,
+		# obviously).
 
-	force-unsafe-io
+		force-unsafe-io
 	EOF
 fi
 
@@ -97,26 +97,26 @@ if [ -d "$rootfsDir/etc/apt/apt.conf.d" ]; then
 	# remove apt-cache translations for fast "apt-get update"
 	echo >&2 "+ echo Acquire::Languages 'none' > '$rootfsDir/etc/apt/apt.conf.d/docker-no-languages'"
 	cat > "$rootfsDir/etc/apt/apt.conf.d/docker-no-languages" <<-'EOF'
-	# In Docker, we don't often need the "Translations" files, so we're just wasting
-	# time and space by downloading them, and this inhibits that.  For users that do
-	# need them, it's a simple matter to delete this file and "apt-get update". :)
+		# In Docker, we don't often need the "Translations" files, so we're just wasting
+		# time and space by downloading them, and this inhibits that.  For users that do
+		# need them, it's a simple matter to delete this file and "apt-get update". :)
 
-	Acquire::Languages "none";
+		Acquire::Languages "none";
 	EOF
 
 	echo >&2 "+ echo Acquire::GzipIndexes 'true' > '$rootfsDir/etc/apt/apt.conf.d/docker-gzip-indexes'"
 	cat > "$rootfsDir/etc/apt/apt.conf.d/docker-gzip-indexes" <<-'EOF'
-	# Since Docker users using "RUN apt-get update && apt-get install -y ..." in
-	# their Dockerfiles don't go delete the lists files afterwards, we want them to
-	# be as small as possible on-disk, so we explicitly request "gz" versions and
-	# tell Apt to keep them gzipped on-disk.
+		# Since Docker users using "RUN apt-get update && apt-get install -y ..." in
+		# their Dockerfiles don't go delete the lists files afterwards, we want them to
+		# be as small as possible on-disk, so we explicitly request "gz" versions and
+		# tell Apt to keep them gzipped on-disk.
 
-	# For comparison, an "apt-get update" layer without this on a pristine
-	# "debian:wheezy" base image was "29.88 MB", where with this it was only
-	# "8.273 MB".
+		# For comparison, an "apt-get update" layer without this on a pristine
+		# "debian:wheezy" base image was "29.88 MB", where with this it was only
+		# "8.273 MB".
 
-	Acquire::GzipIndexes "true";
-	Acquire::CompressionTypes::Order:: "gz";
+		Acquire::GzipIndexes "true";
+		Acquire::CompressionTypes::Order:: "gz";
 	EOF
 fi
 

--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -118,6 +118,27 @@ if [ -d "$rootfsDir/etc/apt/apt.conf.d" ]; then
 		Acquire::GzipIndexes "true";
 		Acquire::CompressionTypes::Order:: "gz";
 	EOF
+
+	# update "autoremove" configuration to be aggressive about removing suggests deps that weren't manually installed
+	echo >&2 "+ echo Apt::AutoRemove::SuggestsImportant 'false' > '$rootfsDir/etc/apt/apt.conf.d/docker-autoremove-suggests'"
+	cat > "$rootfsDir/etc/apt/apt.conf.d/docker-autoremove-suggests" <<-'EOF'
+		# Since Docker users are looking for the smallest possible final images, the
+		# following emerges as a very common pattern:
+
+		#   RUN apt-get update \
+		#       && apt-get install -y <packages> \
+		#       && <do some compilation work> \
+		#       && apt-get purge -y --auto-remove <packages>
+
+		# By default, APT will actually _keep_ packages installed via Recommends or
+		# Depends if another package Suggests them, even and including if the package
+		# that originally caused them to be installed is removed.  Setting this to
+		# "false" ensures that APT is appropriately aggressive about removing the
+		# packages it added.
+
+		# https://aptitude.alioth.debian.org/doc/en/ch02s05s05.html#configApt-AutoRemove-SuggestsImportant
+		Apt::AutoRemove::SuggestsImportant "false";
+	EOF
 fi
 
 if [ -z "$DONT_TOUCH_SOURCES_LIST" ]; then


### PR DESCRIPTION
This makes APT be appropriately aggressive about removing packages it added due to `Recommends` dependencies if the packages they were added for are removed (even if other packages only have the softer `Suggests` relationship).

I tested this by doing `apt-get update` and then `apt-get install -y bzip2 file libcurl4-openssl-dev libreadline6-dev libssl-dev libxml2-dev`, which installed 84 packages.  Then I did `apt-get purge -y --auto-remove bzip2 file libcurl4-openssl-dev libreadline6-dev libssl-dev libxml2-dev`, which appropriately removed all 84 packages.

See also https://github.com/docker-library/php/pull/71 for more discussion (which prompted this).
