### PR TITLE
Add support limit the net that container can access to

### DIFF
--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -31,6 +31,7 @@ docker-create - Create a new container
 [**--mac-address**[=*MAC-ADDRESS*]]
 [**--name**[=*NAME*]]
 [**--net**[=*"bridge"*]]
+[**--netout**[=*[]*]]
 [**-P**|**--publish-all**[=*false*]]
 [**-p**|**--publish**[=*[]*]]
 [**--pid**[=*[]*]]
@@ -135,6 +136,13 @@ This value should always larger than **-m**, so you should alway use this with *
                                'none': no networking for this container
                                'container:<name|id>': reuses another container network stack
                                'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+
+**--netout**=[]
+   Set a net that the container can access to, the net can be a subnet, a host, or with specific port, 
+   or with a specific protocol. By default, the container can access to all the outside available net,
+   set the **--netout** will limit the net that container can access to.This flag is only use for the 
+   `bridge` network mode.
+				Format: ip | ip:port | ip/netmask | ip:port/protocol | ip:port/netmask | ip:port/netmask/protocl
 
 **-P**, **--publish-all**=*true*|*false*
    Publish all exposed ports to random ports on the host interfaces. The default is *false*.

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -32,6 +32,7 @@ docker-run - Run a command in a new container
 [**--mac-address**[=*MAC-ADDRESS*]]
 [**--name**[=*NAME*]]
 [**--net**[=*"bridge"*]]
+[**--netout**[=*[]*]]
 [**-P**|**--publish-all**[=*false*]]
 [**-p**|**--publish**[=*[]*]]
 [**--pid**[=*[]*]]
@@ -237,6 +238,13 @@ and foreground Docker containers.
                                'none': no networking for this container
                                'container:<name|id>': reuses another container network stack
                                'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
+
+**--netout**=[]
+   Set a net that the container can access to, the net can be a subnet, a host, or with specific port,
+   or with a specific protocol. By default, the container can access to all the outside available net,
+   set the **--netout** will limit the net that container can access to.This flag is only use for the
+   `bridge` network mode.
+                                Format: ip | ip:port | ip/netmask | ip:port/protocol | ip:port/netmask | ip:port/netmask/protocl
 
 **-P**, **--publish-all**=*true*|*false*
    Publish all exposed ports to random ports on the host interfaces. The default is *false*.

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -779,6 +779,7 @@ Creates a new container.
       --mac-address=""           Container MAC address (e.g. 92:d0:c6:0a:29:33)
       --name=""                  Assign a name to the container
       --net="bridge"             Set the Network mode for the container
+      --netout=[]                Specify net that container can access to
       -P, --publish-all=false    Publish all exposed ports to random ports
       -p, --publish=[]           Publish a container's port(s) to the host
       --privileged=false         Give extended privileges to this container
@@ -1637,6 +1638,7 @@ removed before the image is removed.
       --memory-swap=""           Total memory (memory + swap), '-1' to disable swap
       --name=""                  Assign a name to the container
       --net="bridge"             Set the Network mode for the container
+      --netout=[]                Specify net that container can access to
       -P, --publish-all=false    Publish all exposed ports to random ports
       -p, --publish=[]           Publish a container's port(s) to the host
       --pid=""                   PID namespace to use

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -179,6 +179,7 @@ of the containers.
                                   'host': use the host network stack inside the container
     --add-host=""    : Add a line to /etc/hosts (host:IP)
     --mac-address="" : Sets the container's Ethernet device's MAC address
+    --netout         : Specify net that can access to
 
 By default, all containers have networking enabled and they can make any
 outgoing connections. The operator can completely disable networking
@@ -255,6 +256,19 @@ container itself as well as `localhost` and a few other common things.  The
     127.0.0.1       localhost
     ::1	            localhost ip6-localhost ip6-loopback
     86.75.30.9      db-static
+
+### netout
+
+By default, the container can access to all the outside available net, you can 
+set `--netout` to specific net the container can access to.
+  
+   $sudo docker run -ti --netout=192.168.1.3:5000/tcp ubuntu:14.04
+This will allow the container only can access the host 192.168.1.3:5000 through
+tcp protocol.
+   
+   $sudo docker run -ti --netour=192.168.1.3/16 ubuntu:14.04
+This will allow the container only can access to he subnet 192.168.1.3/16
+
 
 ## Clean up (--rm)
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -106,6 +106,32 @@ func TestRunEchoStdoutWithCPUAndMemoryLimit(t *testing.T) {
 }
 
 // "test" should be printed
+func TestRunEchoStdoutWithNetout(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "--netout", "192.168.1.3:5000/16/tcp", "--name", "test", "busybox", "echo", "test")
+	out, _, _, err := runCommandWithStdoutStderr(runCmd)
+	if err != nil {
+		t.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+
+	if out != "test\n" {
+		t.Errorf("container should've printed 'test'")
+	}
+
+	cmd := exec.Command(dockerBinary, "inspect", "-f", "{{.HostConfig.Netout}}", "test")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("failed to inspect container: %s, %v", out, err)
+	}
+	if out != "[192.168.1.3:5000/16/tcp]\n" {
+		t.Errorf("failed to set netout to a container")
+	}
+
+	deleteAllContainers()
+
+	logDone("run - echo with netout")
+}
+
+// "test" should be printed
 func TestRunEchoNamedContainer(t *testing.T) {
 	defer deleteAllContainers()
 

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -120,6 +120,24 @@ func TestValidateDnsSearch(t *testing.T) {
 	}
 }
 
+func TestValidatenetout(t *testing.T) {
+	if _, err := ValidateNetout("192.168.1.3:5000/16/udp"); err != nil {
+		t.Fatalf("ValidateNetout(192.168.1.3:5000/16/udp) failed, expect success")
+	}
+	if _, err := ValidateNetout("192.168.1"); err == nil {
+		t.Fatalf("ValidateNetout(192.168.1) with invalid ip successed, expect failure")
+	}
+	if _, err := ValidateNetout("192.168.1.2:80000"); err == nil {
+		t.Fatalf("ValidateNetout(192.168.1.2:80000) with invalid port successed, expect failure")
+	}
+	if _, err := ValidateNetout("192.168.1.2:5000/33"); err == nil {
+		t.Fatalf("ValidateNetout(192.168.1.2/33) with invalid netmask successed, expect failure")
+	}
+	if _, err := ValidateNetout("192.168.1.2:5000/16/abc"); err == nil {
+		t.Fatalf("ValidateNetout(192.168.1.2:5000/16/abc) with invalid protocol successed, expect failure")
+	}
+}
+
 func TestValidateExtraHosts(t *testing.T) {
 	valid := []string{
 		`myhost:192.168.0.1`,

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -266,6 +266,50 @@ func Exists(args ...string) bool {
 	)
 }
 
+// Setup iptables filter table
+func SetupFilter(cmd string, chain string, src string, dst string, proto string, sport string, dport string, action string) error {
+	var rule = []string{}
+	if cmd == "" {
+		return fmt.Errorf("cmd can't be nil")
+	}
+
+	if chain == "" {
+		return fmt.Errorf("chain can't be nil")
+	}
+	rule = append(rule, chain)
+
+	if src != "" {
+		rule = append(rule, "-s", src)
+	}
+
+	if dst != "" {
+		rule = append(rule, "-d", dst)
+	}
+
+	if proto != "" {
+		rule = append(rule, "-p", proto)
+	}
+
+	if sport != "" {
+		rule = append(rule, "--sport", sport)
+	}
+
+	if dport != "" {
+		rule = append(rule, "--dport", dport)
+	}
+
+	if action == "" {
+		return fmt.Errorf("action can't be nil")
+	}
+	rule = append(rule, "-j", action)
+	if (cmd != "-D" && !Exists(rule...)) || (cmd == "-D" && Exists(rule...)) {
+		if _, err := Raw(append([]string{cmd}, rule...)...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // Call 'iptables' system command, passing supplied arguments
 func Raw(args ...string) ([]byte, error) {
 

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -29,6 +29,41 @@ func ParseHost(defaultTCPAddr, defaultUnixAddr, addr string) (string, error) {
 	}
 }
 
+// Parser an IP address return an IP, a port and protocal
+// The input IP address could be: ip:port/mask/proto
+func ParseNet(val string) (string, string, string) {
+	var (
+		ip    = val
+		port  string
+		mask  string
+		proto string
+	)
+	if strings.Contains(val, "/") {
+		parts := strings.SplitN(val, "/", 2)
+		ip = parts[0]
+		mask = parts[1]
+		if strings.Contains(mask, "/") {
+			parts := strings.Split(mask, "/")
+			mask = parts[0]
+			proto = parts[1]
+		} else {
+			if mask == "tcp" || mask == "udp" || mask == "icmp" || mask == "all" {
+				proto = mask
+				mask = ""
+			}
+		}
+	}
+	if strings.Contains(ip, ":") {
+		parts := strings.Split(ip, ":")
+		ip = parts[0]
+		port = parts[1]
+	}
+	if mask != "" {
+		ip = ip + "/" + mask
+	}
+	return ip, port, proto
+}
+
 func ParseUnixAddr(addr string, defaultAddr string) (string, error) {
 	addr = strings.TrimPrefix(addr, "unix://")
 	if strings.Contains(addr, "://") {

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -83,6 +83,30 @@ func TestParsePortMapping(t *testing.T) {
 	}
 }
 
+func TestParseNet(t *testing.T) {
+	ip, port, proto := ParseNet("192.168.1.3:5000/16/tcp")
+	if ip != "192.168.1.3/16" || port != "5000" || proto != "tcp" {
+		t.Fatalf("PaseNet(192.168.1.3:5000/16/tcp) failed, expect success")
+	}
+	ip, port, proto = ParseNet("192.168.1.3")
+	if ip != "192.168.1.3" || port != "" || proto != "" {
+		t.Fatalf("PaseNet(192.168.1.3) failed, expect success")
+	}
+	ip, port, proto = ParseNet("192.168.1.3:5000")
+	if ip != "192.168.1.3" || port != "5000" || proto != "" {
+		t.Fatalf("PaseNet(192.168.1.3:5000) failed, expect success")
+	}
+	ip, port, proto = ParseNet("192.168.1.3/16")
+	if ip != "192.168.1.3/16" || port != "" || proto != "" {
+		t.Fatalf("PaseNet(192.168.1.3/16) failed, expect success")
+	}
+	ip, port, proto = ParseNet("192.168.1.3:5000/tcp")
+	if ip != "192.168.1.3" || port != "5000" || proto != "tcp" {
+		t.Fatalf("PaseNet(192.168.1.3:5000/tcp) failed, expect success")
+	}
+
+}
+
 func TestParsePortRange(t *testing.T) {
 	if start, end, err := ParsePortRange("8000-8080"); err != nil || start != 8000 || end != 8080 {
 		t.Fatalf("Error: %s or Expecting {start,end} values {8000,8080} but found {%d,%d}.", err, start, end)

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -107,6 +107,7 @@ type HostConfig struct {
 	Links           []string
 	PublishAllPorts bool
 	Dns             []string
+	Netout          []string
 	DnsSearch       []string
 	ExtraHosts      []string
 	VolumesFrom     []string
@@ -165,6 +166,9 @@ func ContainerHostConfigFromJob(job *engine.Job) *HostConfig {
 	}
 	if Dns := job.GetenvList("Dns"); Dns != nil {
 		hostConfig.Dns = Dns
+	}
+	if Netout := job.GetenvList("Netout"); Netout != nil {
+		hostConfig.Netout = Netout
 	}
 	if DnsSearch := job.GetenvList("DnsSearch"); DnsSearch != nil {
 		hostConfig.DnsSearch = DnsSearch

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -21,6 +21,7 @@ var (
 	ErrConflictNetworkHostname          = fmt.Errorf("Conflicting options: -h and the network mode (--net)")
 	ErrConflictHostNetworkAndDns        = fmt.Errorf("Conflicting options: --net=host can't be used with --dns. This configuration is invalid.")
 	ErrConflictHostNetworkAndLinks      = fmt.Errorf("Conflicting options: --net=host can't be used with links. This would result in undefined behavior.")
+	ErrConflictHostNetworkAndNetout     = fmt.Errorf("Conflicting options: only --net=bridge can be used with --netout.")
 )
 
 func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSet, error) {
@@ -35,6 +36,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flPublish     = opts.NewListOpts(nil)
 		flExpose      = opts.NewListOpts(nil)
 		flDns         = opts.NewListOpts(opts.ValidateIPAddress)
+		flNetout      = opts.NewListOpts(opts.ValidateNetout)
 		flDnsSearch   = opts.NewListOpts(opts.ValidateDnsSearch)
 		flExtraHosts  = opts.NewListOpts(opts.ValidateExtraHost)
 		flVolumesFrom = opts.NewListOpts(nil)
@@ -69,6 +71,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 	cmd.Var(&flAttach, []string{"a", "-attach"}, "Attach to STDIN, STDOUT or STDERR.")
 	cmd.Var(&flVolumes, []string{"v", "-volume"}, "Bind mount a volume")
 	cmd.Var(&flLinks, []string{"#link", "-link"}, "Add link to another container")
+	cmd.Var(&flNetout, []string{"#netout", "-netout"}, "Specify net that container can access to")
 	cmd.Var(&flDevices, []string{"-device"}, "Add a host device to the container")
 	cmd.Var(&flEnv, []string{"e", "-env"}, "Set environment variables")
 	cmd.Var(&flEnvFile, []string{"-env-file"}, "Read in a file of environment variables")
@@ -126,6 +129,9 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		return nil, nil, cmd, ErrConflictContainerNetworkAndDns
 	}
 
+	if *flNetMode != "bridge" && flNetout.Len() > 0 {
+		return nil, nil, cmd, ErrConflictHostNetworkAndNetout
+	}
 	// If neither -d or -a are set, attach to everything by default
 	if flAttach.Len() == 0 {
 		attachStdout = true
@@ -301,6 +307,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		Privileged:      *flPrivileged,
 		PortBindings:    portBindings,
 		Links:           flLinks.GetAll(),
+		Netout:          flNetout.GetAll(),
 		PublishAllPorts: *flPublishAll,
 		Dns:             flDns.GetAll(),
 		DnsSearch:       flDnsSearch.GetAll(),


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

This patch add support limit the net that container can access to, by default, container can access all 
the  outside available net and every container is the same. 
but at some scenario, we want to limit the net that the container can access to and different container has 
different net access right. I think this feature is useful especially for the security.

This patch  use the iptables to limit the container network access right. Introduce a `--netout` flag in `docker run`, when `--netout` is not set,  the container have all the network access right. when `--netout` is set, the container can't access to all the net but the net specified by `--netout` and the nameserver in `/etc/resolv.conf`, 
the net specified by `--netout` could be
a host, a subnet...  such as `--netout=192.168.1.2` `--netout=192.168.1.2:5000/tcp` 
`--netout=192.168.1.2/16`

ping @jfrazelle @estesp @cpuguy83  what do you think of this ?
