### PR TITLE
Image RootFS Diff Blob Storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,9 +111,9 @@ RUN gem install --no-rdoc --no-ri fpm --version 1.3.2
 RUN git clone -b buildroot-2014.02 https://github.com/jpetazzo/docker-busybox.git /docker-busybox
 
 # Install registry
-ENV REGISTRY_COMMIT c448e0416925a9876d5576e412703c9b8b865e19
+ENV REGISTRY_COMMIT aa5f61e81114f6b0fed129c3b289022796823daf
 RUN set -x \
-	&& git clone https://github.com/docker/distribution.git /go/src/github.com/docker/distribution \
+	&& git clone -b canonical_sha256 https://github.com/endophage/distribution.git /go/src/github.com/docker/distribution \
 	&& (cd /go/src/github.com/docker/distribution && git checkout -q $REGISTRY_COMMIT) \
 	&& GOPATH=/go/src/github.com/docker/distribution/Godeps/_workspace:/go \
 		go build -o /go/bin/registry-v2 github.com/docker/distribution/cmd/registry

--- a/graph/manifest_test.go
+++ b/graph/manifest_test.go
@@ -38,19 +38,8 @@ func TestManifestTarsumCache(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if cs, err := img.GetCheckSum(store.graph.ImageRoot(testManifestImageID)); err != nil {
-		t.Fatal(err)
-	} else if cs != "" {
-		t.Fatalf("Non-empty checksum file after register")
-	}
-
 	// Generate manifest
 	payload, err := store.newManifest(testManifestImageName, testManifestImageName, testManifestTag)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	manifestChecksum, err := img.GetCheckSum(store.graph.ImageRoot(testManifestImageID))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,8 +53,15 @@ func TestManifestTarsumCache(t *testing.T) {
 		t.Fatalf("Unexpected number of layers, expecting 1: %d", len(manifest.FSLayers))
 	}
 
-	if manifest.FSLayers[0].BlobSum != manifestChecksum {
-		t.Fatalf("Unexpected blob sum, expecting %q, got %q", manifestChecksum, manifest.FSLayers[0].BlobSum)
+	digest, err := img.DiffDigest()
+	if err != nil {
+		t.Fatal(err)
+	} else if digest == "" {
+		t.Fatalf("empty image rootfs diff digest")
+	}
+
+	if manifest.FSLayers[0].BlobSum != digest {
+		t.Fatalf("Unexpected blob sum, expecting %q, got %q", digest, manifest.FSLayers[0].BlobSum)
 	}
 
 	if len(manifest.History) != 1 {

--- a/image/graph.go
+++ b/image/graph.go
@@ -2,10 +2,14 @@ package image
 
 import (
 	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/jlhawn/blobstore"
 )
 
 type Graph interface {
 	Get(id string) (*Image, error)
 	ImageRoot(id string) string
 	Driver() graphdriver.Driver
+	BlobStore() blobstore.Store
+	SetDiffDigest(id, digest string)
+	DiffDigest(id string) (string, bool)
 }

--- a/image/image.go
+++ b/image/image.go
@@ -119,13 +119,6 @@ func (img *Image) SaveSize(root string) error {
 	return nil
 }
 
-func (img *Image) SaveCheckSum(root, checksum string) error {
-	if err := ioutil.WriteFile(path.Join(root, "checksum"), []byte(checksum), 0600); err != nil {
-		return fmt.Errorf("Error storing checksum in %s/checksum: %s", root, err)
-	}
-	return nil
-}
-
 // DiffDigest returns the digest of the diff between the rootfs of this image
 // and its parent's. If the image graph's blobstore does not yet have a diff
 // blob for this image, one will be created, compressed, and stored before the
@@ -175,17 +168,6 @@ func (img *Image) DiffDigest() (digest string, err error) {
 	img.graph.SetDiffDigest(img.ID, desc.Digest())
 
 	return desc.Digest(), nil
-}
-
-func (img *Image) GetCheckSum(root string) (string, error) {
-	cs, err := ioutil.ReadFile(path.Join(root, "checksum"))
-	if err != nil {
-		if os.IsNotExist(err) {
-			return "", nil
-		}
-		return "", err
-	}
-	return string(cs), err
 }
 
 func jsonPath(root string) string {

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -53,36 +53,6 @@ func TestPullImageWithAliases(t *testing.T) {
 	logDone("pull - image with aliases")
 }
 
-// pulling library/hello-world should show verified message
-func TestPullVerified(t *testing.T) {
-	// Image must be pulled from central repository to get verified message
-	// unless keychain is manually updated to contain the daemon's sign key.
-
-	verifiedName := "hello-world"
-	defer deleteImages(verifiedName)
-
-	// pull it
-	expected := "The image you are pulling has been verified"
-	pullCmd := exec.Command(dockerBinary, "pull", verifiedName)
-	if out, exitCode, err := runCommandWithOutput(pullCmd); err != nil || !strings.Contains(out, expected) {
-		if err != nil || exitCode != 0 {
-			t.Skipf("pulling the '%s' image from the registry has failed: %s", verifiedName, err)
-		}
-		t.Fatalf("pulling a verified image failed. expected: %s\ngot: %s, %v", expected, out, err)
-	}
-
-	// pull it again
-	pullCmd = exec.Command(dockerBinary, "pull", verifiedName)
-	if out, exitCode, err := runCommandWithOutput(pullCmd); err != nil || strings.Contains(out, expected) {
-		if err != nil || exitCode != 0 {
-			t.Skipf("pulling the '%s' image from the registry has failed: %s", verifiedName, err)
-		}
-		t.Fatalf("pulling a verified image failed. unexpected verify message\ngot: %s, %v", out, err)
-	}
-
-	logDone("pull - pull verified")
-}
-
 // pulling an image from the central registry should work
 func TestPullImageFromCentralRegistry(t *testing.T) {
 	defer deleteImages("hello-world")

--- a/project/vendor.sh
+++ b/project/vendor.sh
@@ -57,6 +57,8 @@ clone git github.com/Sirupsen/logrus v0.6.0
 
 clone git github.com/go-fsnotify/fsnotify v1.0.4
 
+clone git github.com/jlhawn/blobstore 4bba590bc1e7
+
 # get Go tip's archive/tar, for xattr support and improved performance
 # TODO after Go 1.4 drops, bump our minimum supported version and drop this vendored dep
 if [ "$1" = '--go' ]; then

--- a/vendor/src/github.com/jlhawn/blobstore/.gitignore
+++ b/vendor/src/github.com/jlhawn/blobstore/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/src/github.com/jlhawn/blobstore/LICENSE
+++ b/vendor/src/github.com/jlhawn/blobstore/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/src/github.com/jlhawn/blobstore/README.md
+++ b/vendor/src/github.com/jlhawn/blobstore/README.md
@@ -1,0 +1,3 @@
+# blobstore
+
+A local blob storage system to be used by Docker 1.x

--- a/vendor/src/github.com/jlhawn/blobstore/blob.go
+++ b/vendor/src/github.com/jlhawn/blobstore/blob.go
@@ -1,0 +1,22 @@
+package blobstore
+
+import (
+	"io"
+	"os"
+)
+
+type blob struct {
+	Descriptor
+	blobFilepath string
+}
+
+func newBlob(d Descriptor, blobFilepath string) Blob {
+	return &blob{Descriptor: d, blobFilepath: blobFilepath}
+}
+
+// Open should open the underlying blob for reading. It is the responsibility
+// of the caller to close the returned io.ReadCloser. Returns a nil error on
+// success.
+func (h *blob) Open() (io.ReadCloser, error) {
+	return os.Open(h.blobFilepath)
+}

--- a/vendor/src/github.com/jlhawn/blobstore/blobwriter.go
+++ b/vendor/src/github.com/jlhawn/blobstore/blobwriter.go
@@ -1,0 +1,162 @@
+package blobstore
+
+import (
+	"crypto"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"io"
+	"io/ioutil"
+	"os"
+
+	// Imported to support sha256, sha384, and sha512.
+	_ "crypto/sha256"
+	_ "crypto/sha512"
+)
+
+var hashLabels = map[crypto.Hash]string{
+	crypto.SHA256: "sha256",
+	crypto.SHA384: "sha384",
+	crypto.SHA512: "sha512",
+}
+
+// HashForLabel return a crypto.Hash for the given digest label, e.g.,
+// "sha256". If the hash is not supported, `crypto.Hash(0)` is returned.
+// Currently, only "sha256", "sha384", and "sha512" are supported.
+func HashForLabel(label string) (h crypto.Hash) {
+	switch label {
+	case "sha256":
+		h = crypto.SHA256
+	case "sha384":
+		h = crypto.SHA384
+	case "sha512":
+		h = crypto.SHA512
+	}
+
+	if _, ok := hashLabels[h]; !(ok && h.Available()) {
+		return crypto.Hash(0)
+	}
+
+	return h
+}
+
+// NewWriter begins the process of writing a new blob. If an error is returned,
+// it is of type *Error.
+func (ls *localStore) NewWriter(h crypto.Hash) (bw BlobWriter, err error) {
+	hashLabel, ok := hashLabels[h]
+	if !(ok && h.Available()) {
+		return nil, newError(errCodeHashNotSupported, fmt.Sprintf("crypto.Hash(%d)", h))
+	}
+
+	tempFile, err := ioutil.TempFile(ls.root, "temp-blob-")
+	if err != nil {
+		return nil, newError(errCodeCannotMakeTempBlobFile, err.Error())
+	}
+
+	hasher := h.New()
+
+	return &blobWriter{
+		Writer:    io.MultiWriter(tempFile, hasher),
+		hasher:    hasher,
+		hashLabel: hashLabel,
+		tempFile:  tempFile,
+		store:     ls,
+	}, nil
+}
+
+type blobWriter struct {
+	io.Writer
+
+	hasher    hash.Hash
+	hashLabel string
+	tempFile  *os.File
+	store     *localStore
+}
+
+func (bw *blobWriter) Digest() string {
+	return fmt.Sprintf("%s:%x", bw.hashLabel, bw.hasher.Sum(nil))
+}
+
+func (bw *blobWriter) Commit(mediaType, refID string) (d Descriptor, err error) {
+	defer bw.Cancel()
+
+	// Close the tempFile.
+	if err = bw.tempFile.Close(); err != nil {
+		return nil, newError(errCodeCannotCloseTempBlobFile, err.Error())
+	}
+
+	digest := bw.Digest()
+
+	bw.store.Lock()
+	defer bw.store.Unlock()
+
+	// Is there already a blob with this digest in the store?
+	d, blobErr := bw.store.ref(digest, refID)
+	if blobErr == nil {
+		return d, nil
+	}
+
+	if !blobErr.IsBlobNotExists() {
+		return nil, newError(errCodeUnexpected, blobErr.Error())
+	}
+
+	// Need to get the size of the blob.
+	stat, err := os.Stat(bw.tempFile.Name())
+	if err != nil {
+		return nil, newError(errCodeCannotStatTempBlobFile, err.Error())
+	}
+
+	info := blobInfo{
+		Digest:     digest,
+		MediaType:  mediaType,
+		Size:       uint64(stat.Size()),
+		References: []string{refID},
+	}
+
+	// Blow away this new blob directory if there's any error later.
+	defer func() {
+		if err != nil {
+			os.RemoveAll(bw.store.blobDirname(digest))
+		}
+	}()
+
+	if blobErr = bw.store.putBlobInfo(info); blobErr != nil {
+		return nil, blobErr
+	}
+
+	blobFilename := bw.store.blobFilename(info.Digest)
+	if err = os.Rename(bw.tempFile.Name(), blobFilename); err != nil {
+		return nil, newError(errCodeCannotRenameTempBlobFile, err.Error())
+	}
+
+	return newDescriptor(info), nil
+}
+
+func (bw *blobWriter) Cancel() error {
+	if err := os.Remove(bw.tempFile.Name()); err != nil {
+		return newError(errCodeCannotRemoveTempBlobFile, err.Error())
+	}
+
+	return nil
+}
+
+func (ls *localStore) putBlobInfo(info blobInfo) *storeError {
+	blobDirname := ls.blobDirname(info.Digest)
+	if err := os.MkdirAll(blobDirname, os.FileMode(0755)); err != nil {
+		return newError(errCodeCannotMakeBlobDir, err.Error())
+	}
+
+	blobInfoFilename := ls.blobInfoFilename(info.Digest)
+	blobInfoFile, err := os.OpenFile(blobInfoFilename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(0600))
+	if err != nil {
+		return newError(errCodeCannotOpenBlobInfo, err.Error())
+	}
+	defer blobInfoFile.Close()
+
+	encoder := json.NewEncoder(blobInfoFile)
+	if err := encoder.Encode(info); err != nil {
+		return newError(errCodeCannotEncodeBlobInfo, err.Error())
+	}
+
+	return nil
+}

--- a/vendor/src/github.com/jlhawn/blobstore/blobwriter_get_test.go
+++ b/vendor/src/github.com/jlhawn/blobstore/blobwriter_get_test.go
@@ -1,0 +1,43 @@
+package blobstore
+
+import (
+	"testing"
+)
+
+func TestGetNotExists(t *testing.T) {
+	withTestStore(t, testGetNotExists)
+}
+
+func testGetNotExists(t *testing.T, testStore *localStore) {
+	_, err := testStore.Get(randomDigest(t))
+	if err == nil || !err.(Error).IsBlobNotExists() {
+		t.Fatalf("expected %q error, got: %s", errDescriptions[errCodeBlobNotExists], err)
+	}
+}
+
+func TestWriteGetRoundtrip(t *testing.T) {
+	withTestStore(t, testWriteGetRoundtrip)
+}
+
+func testWriteGetRoundtrip(t *testing.T, testStore *localStore) {
+	refID := "testWriteGetRoundtripRef"
+
+	d := writeRandomBlob(t, testStore, 20480, refID)
+
+	b, err := testStore.Get(d.Digest())
+	if err != nil {
+		t.Fatalf("unable to get blob: %s", err)
+	}
+
+	if b.Size() != d.Size() {
+		t.Fatalf("expected blob size to be %d, got %d", d.Size(), b.Size())
+	}
+
+	if b.MediaType() != randomDataMediaType {
+		t.Fatalf("expected blob media type to be %d, got %d", randomDataMediaType, b.MediaType())
+	}
+
+	if b.Digest() != d.Digest() {
+		t.Fatalf("put/get digest conflict: put %q, god %q", d.Digest(), b.Digest())
+	}
+}

--- a/vendor/src/github.com/jlhawn/blobstore/descriptor.go
+++ b/vendor/src/github.com/jlhawn/blobstore/descriptor.go
@@ -1,0 +1,32 @@
+package blobstore
+
+type blobInfo struct {
+	Digest     string   `json:"digest"`
+	MediaType  string   `json:"mediaType"`
+	Size       uint64   `json:"size"`
+	References []string `json:"references"`
+}
+
+type descriptor struct {
+	blobInfo
+}
+
+func newDescriptor(info blobInfo) Descriptor {
+	return &descriptor{blobInfo: info}
+}
+
+func (d *descriptor) Digest() string {
+	return d.blobInfo.Digest
+}
+
+func (d *descriptor) MediaType() string {
+	return d.blobInfo.MediaType
+}
+
+func (d *descriptor) Size() uint64 {
+	return d.blobInfo.Size
+}
+
+func (d *descriptor) References() []string {
+	return d.blobInfo.References
+}

--- a/vendor/src/github.com/jlhawn/blobstore/errors.go
+++ b/vendor/src/github.com/jlhawn/blobstore/errors.go
@@ -1,0 +1,74 @@
+package blobstore
+
+import (
+	"fmt"
+)
+
+type errCode int
+
+const (
+	errCodeUnexpected errCode = iota
+	errCodeBlobNotExists
+	errCodeHashNotSupported
+	errCodeCannotListBlobsDir
+	errCodeCannotOpenBlobInfo
+	errCodeCannotDecodeBlobInfo
+	errCodeCannotEncodeBlobInfo
+	errCodeCannotMakeBlobDir
+	errCodeCannotRemoveBlob
+	errCodeCannotMakeTempBlobFile
+	errCodeCannotCloseTempBlobFile
+	errCodeCannotStatTempBlobFile
+	errCodeCannotRenameTempBlobFile
+	errCodeCannotRemoveTempBlobFile
+	errCodeCannotStoreContent
+	errCodeNotImplemented
+)
+
+var errDescriptions = map[errCode]string{
+	errCodeUnexpected:               "unexpected error",
+	errCodeBlobNotExists:            "blob does not exist",
+	errCodeHashNotSupported:         "hash not supported",
+	errCodeCannotListBlobsDir:       "cannot list blobs directory",
+	errCodeCannotOpenBlobInfo:       "cannot open blob info file",
+	errCodeCannotDecodeBlobInfo:     "cannot decode blob info",
+	errCodeCannotEncodeBlobInfo:     "cannot encode blob info",
+	errCodeCannotMakeBlobDir:        "cannot make blob directory",
+	errCodeCannotRemoveBlob:         "cannot remove blob",
+	errCodeCannotMakeTempBlobFile:   "cannot make temporary blob file",
+	errCodeCannotCloseTempBlobFile:  "cannot close temporary blob file",
+	errCodeCannotStatTempBlobFile:   "cannot stat temporary blob file",
+	errCodeCannotRenameTempBlobFile: "cannot rename temporary blob file",
+	errCodeCannotRemoveTempBlobFile: "cannot remove temporary blob file",
+	errCodeCannotStoreContent:       "cannot store content blob",
+	errCodeNotImplemented:           "not implemented",
+}
+
+// storeError is the error type which implements blob store Error.
+type storeError struct {
+	code    errCode
+	message string
+}
+
+func newError(code errCode, message string) *storeError {
+	return &storeError{
+		code:    code,
+		message: message,
+	}
+}
+
+// Error returns the string representation of this blob store error.
+func (e *storeError) Error() string {
+	description, ok := errDescriptions[e.code]
+	if !ok {
+		description = "blob store error"
+	}
+
+	return fmt.Sprintf("%s: %s", description, e.message)
+}
+
+// IsBlobNotExists returns whether this error indicates that a blob does not
+// exist.
+func (e *storeError) IsBlobNotExists() bool {
+	return e.code == errCodeBlobNotExists
+}

--- a/vendor/src/github.com/jlhawn/blobstore/get.go
+++ b/vendor/src/github.com/jlhawn/blobstore/get.go
@@ -1,0 +1,38 @@
+package blobstore
+
+import (
+	"encoding/json"
+	"os"
+)
+
+// Get the blob with the given digest from this store. Returns a nil Error
+// on success.
+func (ls *localStore) Get(digest string) (Blob, error) {
+	info, err := ls.getBlobInfo(digest)
+	if err != nil {
+		return nil, err
+	}
+
+	return newBlob(newDescriptor(info), ls.blobFilename(digest)), nil
+}
+
+// getBlobInfo decodes the blob info JSON file stored beside the blob with the
+// given digest.
+func (ls *localStore) getBlobInfo(digest string) (info blobInfo, err *storeError) {
+	blobInfoFilename := ls.blobInfoFilename(digest)
+	blobInfoFile, e := os.Open(blobInfoFilename)
+	if e != nil {
+		if os.IsNotExist(e) {
+			return info, newError(errCodeBlobNotExists, digest)
+		}
+		return info, newError(errCodeCannotOpenBlobInfo, e.Error())
+	}
+	defer blobInfoFile.Close()
+
+	decoder := json.NewDecoder(blobInfoFile)
+	if e := decoder.Decode(&info); err != nil {
+		return info, newError(errCodeCannotDecodeBlobInfo, e.Error())
+	}
+
+	return info, nil
+}

--- a/vendor/src/github.com/jlhawn/blobstore/interface.go
+++ b/vendor/src/github.com/jlhawn/blobstore/interface.go
@@ -1,0 +1,62 @@
+package blobstore
+
+import (
+	"crypto"
+	"io"
+)
+
+// Store is the interface for managing image manifest and rootfs diff blobs.
+// Any errors returned by this interface are of type Error.
+type Store interface {
+	// Get the blob with the given digest from this store.
+	Get(digest string) (Blob, error)
+	// List returns a slice of digest strings for each blob in this store.
+	List() ([]string, error)
+	// NewWriter begins the process of writing a new blob using the given hash
+	// to compute the digest.
+	NewWriter(crypto.Hash) (BlobWriter, error)
+	// Ref associates a reference ID with the blob with the given digest.
+	Ref(digest, refID string) (Descriptor, error)
+	// Deref dissociates a reference ID with the blob with the given digest.
+	// If no references to the blob remain, the blob will be removed from the
+	// store.
+	Deref(digest, refID string) error
+}
+
+// BlobWriter provides a handle for writing a new blob to the blob store.
+type BlobWriter interface {
+	io.Writer
+	// Digest returns the digest of the data which has been written so far.
+	Digest() string
+	// Commit completes the blob writing process. The new blob is stored with
+	// the given mediaType and starting RefID. If another blob already exists
+	// with the same computed digest then the reference is added to that blob.
+	// If there is an error, it is of type Error.
+	Commit(mediaType, refID string) (Descriptor, error)
+	// Cancel ends the writing process, cleaning up any temporary resources. If
+	// there is an error, it is of type *Error.
+	Cancel() error
+}
+
+// Descriptor describes a blob.
+type Descriptor interface {
+	Digest() string
+	MediaType() string
+	Size() uint64
+	References() []string
+}
+
+// Blob is the interface for accessing a blob.
+type Blob interface {
+	Descriptor
+	// Open should open the underlying blob for reading. It is the
+	// responsibility of the caller to close the returned io.ReadCloser.
+	// Returns a nil error on success.
+	Open() (io.ReadCloser, error)
+}
+
+// Error is the error type returned by the Store interface.
+type Error interface {
+	error
+	IsBlobNotExists() bool
+}

--- a/vendor/src/github.com/jlhawn/blobstore/list.go
+++ b/vendor/src/github.com/jlhawn/blobstore/list.go
@@ -1,0 +1,26 @@
+package blobstore
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func (ls *localStore) List() ([]string, error) {
+	dirInfos, err := ioutil.ReadDir(ls.blobDirname(""))
+	if err != nil {
+		return nil, newError(errCodeCannotListBlobsDir, err.Error())
+	}
+
+	blobDigests := make([]string, 0, len(dirInfos))
+
+	for _, dirInfo := range dirInfos {
+		if !(dirInfo.IsDir() && strings.HasPrefix(dirInfo.Name(), "sha256:")) {
+			// Blobs are stored in directories prefixed by "sha256:".
+			continue
+		}
+
+		blobDigests = append(blobDigests, dirInfo.Name())
+	}
+
+	return blobDigests, nil
+}

--- a/vendor/src/github.com/jlhawn/blobstore/list_test.go
+++ b/vendor/src/github.com/jlhawn/blobstore/list_test.go
@@ -1,0 +1,25 @@
+package blobstore
+
+import (
+	"testing"
+)
+
+func TestList(t *testing.T) {
+	withTestStore(t, testList)
+}
+
+func testList(t *testing.T, testStore *localStore) {
+	// Make 10 random content blobs.
+	expectedDigests := make([]string, 10)
+	for i := range expectedDigests {
+		d := writeRandomBlob(t, testStore, 10240, "someRef")
+		expectedDigests[i] = d.Digest()
+	}
+
+	blobDigests, err := testStore.List()
+	if err != nil {
+		t.Fatalf("could not list blob digests: %s", err)
+	}
+
+	ensureEqualReferences(t, expectedDigests, blobDigests)
+}

--- a/vendor/src/github.com/jlhawn/blobstore/ref.go
+++ b/vendor/src/github.com/jlhawn/blobstore/ref.go
@@ -1,0 +1,97 @@
+package blobstore
+
+import (
+	"os"
+)
+
+// Ref increments the reference count for the blob with the given digest.
+func (ls *localStore) Ref(digest, refID string) (d Descriptor, err error) {
+	ls.Lock()
+	defer ls.Unlock()
+
+	// Avoid the (type, nil) interface issue.
+	d, blobErr := ls.ref(digest, refID)
+	if blobErr != nil {
+		return nil, blobErr
+	}
+
+	return
+}
+
+// Deref decrements the reference count for the blob with the given digest.
+// If the reference count reaches 0, the blob will be removed from the
+// store.
+func (ls *localStore) Deref(digest, refID string) error {
+	ls.Lock()
+	defer ls.Unlock()
+
+	// Avoid the (type, nil) interface issue.
+	blobErr := ls.deref(digest, refID)
+	if blobErr != nil {
+		return blobErr
+	}
+
+	return nil
+}
+
+// ref is the unexported version of Ref which does not acquire the store lock
+// before incrementing a blob reference count.
+func (ls *localStore) ref(digest, refID string) (Descriptor, *storeError) {
+	info, err := ls.getBlobInfo(digest)
+	if err != nil {
+		return nil, err
+	}
+
+	refSet := make(map[string]struct{}, len(info.References)+1)
+	for _, refID := range info.References {
+		refSet[refID] = struct{}{}
+	}
+
+	refSet[refID] = struct{}{}
+
+	references := make([]string, 0, len(refSet))
+	for refID := range refSet {
+		references = append(references, refID)
+	}
+
+	info.References = references
+
+	if err = ls.putBlobInfo(info); err != nil {
+		return nil, err
+	}
+
+	return newDescriptor(info), nil
+}
+
+// deref is the unexported version of Deref which does not acquire the store
+// lock before decrementing the blob reference count.
+func (ls *localStore) deref(digest, refID string) *storeError {
+	info, err := ls.getBlobInfo(digest)
+	if err != nil {
+		return err
+	}
+
+	refSet := make(map[string]struct{}, len(info.References))
+	for _, refID := range info.References {
+		refSet[refID] = struct{}{}
+	}
+
+	delete(refSet, refID)
+
+	if len(refSet) > 0 {
+		references := make([]string, 0, len(refSet))
+		for refID := range refSet {
+			references = append(references, refID)
+		}
+
+		info.References = references
+		return ls.putBlobInfo(info)
+	}
+
+	blobDirname := ls.blobDirname(digest)
+	if e := os.RemoveAll(blobDirname); e != nil {
+		return newError(errCodeCannotRemoveBlob, e.Error())
+	}
+
+	return nil
+}

--- a/vendor/src/github.com/jlhawn/blobstore/ref_test.go
+++ b/vendor/src/github.com/jlhawn/blobstore/ref_test.go
@@ -1,0 +1,77 @@
+package blobstore
+
+import (
+	"testing"
+)
+
+func TestRefNotExists(t *testing.T) {
+	withTestStore(t, testRefNotExists)
+}
+
+func testRefNotExists(t *testing.T, testStore *localStore) {
+	_, err := testStore.Ref(randomDigest(t), "shouldNotWork")
+	if err == nil || !err.(Error).IsBlobNotExists() {
+		t.Fatalf("expected %q error, got: %s", errDescriptions[errCodeBlobNotExists], err)
+	}
+}
+
+func TestRef(t *testing.T) {
+	withTestStore(t, testRef)
+}
+
+func testRef(t *testing.T, testStore *localStore) {
+	refs := []string{"ref0", "ref1", "ref2", "ref3", "ref4"}
+
+	d1 := writeRandomBlob(t, testStore, 20480, refs[0])
+
+	ensureEqualReferences(t, d1.References(), refs[:1])
+
+	for i := 0; i < len(refs); i++ {
+		d2, err := testStore.Ref(d1.Digest(), refs[i])
+		if err != nil {
+			t.Fatalf("unable to add reference %q: %s", refs[i], err)
+		}
+
+		ensureEqualDescriptors(t, d1, d2, false)
+		ensureEqualReferences(t, d2.References(), refs[:i+1])
+	}
+}
+
+func TestDeref(t *testing.T) {
+	withTestStore(t, testDeref)
+}
+
+func testDeref(t *testing.T, testStore *localStore) {
+	refs := []string{"ref0", "ref1", "ref2", "ref3", "ref4"}
+	d1 := writeRandomBlob(t, testStore, 20480, refs[0])
+
+	for i := 1; i < len(refs); i++ {
+		_, err := testStore.Ref(d1.Digest(), refs[i])
+		if err != nil {
+			t.Fatalf("unable to add reference %q: %s", refs[i], err)
+		}
+	}
+
+	for i := len(refs) - 1; i >= 0; i-- {
+		if err := testStore.Deref(d1.Digest(), refs[i]); err != nil {
+			t.Fatalf("unable to deref %q: %s", refs[i], err)
+		}
+
+		if i > 0 {
+			d2, err := testStore.Get(d1.Digest())
+			if err != nil {
+				t.Fatalf("unable to get blob %q: %s", d1.Digest(), err)
+			}
+
+			ensureEqualDescriptors(t, d1, d2, false)
+			ensureEqualReferences(t, d2.References(), refs[:i])
+		}
+	}
+
+	// The blob's references have all been removed
+	// and the blob should no longer exist.
+	_, err := testStore.Get(d1.Digest())
+	if err == nil || !err.(Error).IsBlobNotExists() {
+		t.Fatalf("expected %q error, got: %s", errDescriptions[errCodeBlobNotExists], err)
+	}
+}

--- a/vendor/src/github.com/jlhawn/blobstore/store.go
+++ b/vendor/src/github.com/jlhawn/blobstore/store.go
@@ -1,0 +1,43 @@
+package blobstore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+type localStore struct {
+	sync.Mutex
+	root string
+}
+
+// NewLocalStore creates a new local blob store in the given root directory.
+func NewLocalStore(root string) (Store, error) {
+	return newLocalStore(root)
+}
+
+func (ls *localStore) blobDirname(digest string) string {
+	return filepath.Join(ls.root, "blobs", digest)
+}
+
+func (ls *localStore) blobFilename(digest string) string {
+	return filepath.Join(ls.blobDirname(digest), "blob")
+}
+
+func (ls *localStore) blobInfoFilename(digest string) string {
+	return filepath.Join(ls.blobDirname(digest), "info.json")
+}
+
+// newLocalStore is the unexported version of NewLocalStore which returns
+// the unexported type.
+func newLocalStore(root string) (*localStore, error) {
+	ls := &localStore{root: root}
+
+	blobsDirname := ls.blobDirname("")
+	if err := os.MkdirAll(blobsDirname, os.FileMode(0755)); err != nil {
+		return nil, fmt.Errorf("unable to create local blob store directory %q: %s", blobsDirname, err)
+	}
+
+	return ls, nil
+}

--- a/vendor/src/github.com/jlhawn/blobstore/utils_test.go
+++ b/vendor/src/github.com/jlhawn/blobstore/utils_test.go
@@ -1,0 +1,133 @@
+package blobstore
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+// withTestStore will create a new test store and call the given test function
+// and remove the test store ONLY if the test passes.
+func withTestStore(t *testing.T, testFunc func(*testing.T, *localStore)) {
+	testStore := newTestStore(t)
+
+	testFunc(t, testStore)
+
+	if !t.Failed() {
+		os.RemoveAll(testStore.root)
+	}
+}
+
+func newTestStore(t *testing.T) *localStore {
+	tempDirname, err := ioutil.TempDir(".", "temp-local-blob-store-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ls, err := newLocalStore(tempDirname)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return ls
+}
+
+func writeRandomBlob(t *testing.T, testStore *localStore, blobSize uint64, refID string) Descriptor {
+	bw, err := testStore.NewWriter(HashForLabel("sha256"))
+	if err != nil {
+		t.Fatalf("unable to make new blob writer: %s", err)
+	}
+
+	randData := limitedRandReader(blobSize)
+	hasher := sha256.New()
+
+	if _, err := io.Copy(bw, io.TeeReader(randData, hasher)); err != nil {
+		t.Fatalf("unable to write random data blob: %s", err)
+	}
+
+	digest := fmt.Sprintf("sha256:%x", hasher.Sum(nil))
+
+	d, err := bw.Commit(randomDataMediaType, refID)
+	if err != nil {
+		t.Fatalf("unable to commit put of random blob: %s", err)
+	}
+
+	info := blobInfo{
+		Digest:    digest,
+		MediaType: randomDataMediaType,
+		Size:      blobSize,
+	}
+
+	ensureEqualDescriptors(t, d, newDescriptor(info), false)
+
+	return d
+}
+
+func ensureEqualDescriptors(t *testing.T, d1, d2 Descriptor, checkRefs bool) {
+	if d1.Digest() != d2.Digest() {
+		t.Fatalf("digest mismatch: %q != %q", d1.Digest(), d2.Digest())
+	}
+
+	if d1.Size() != d2.Size() {
+		t.Fatalf("blob size mismatch: %d != %d", d1.Size(), d2.Size())
+	}
+
+	if d1.MediaType() != d2.MediaType() {
+		t.Fatalf("media type mismatch: %q != %q", d1.MediaType(), d2.MediaType())
+	}
+
+	if checkRefs {
+		ensureEqualReferences(t, d1.References(), d2.References())
+	}
+}
+
+func ensureEqualReferences(t *testing.T, refs1, refs2 []string) {
+	if len(refs1) != len(refs2) {
+		t.Fatalf("refs length mismatch: %d != %d", len(refs1), len(refs2))
+	}
+
+	refSet1 := make(map[string]struct{}, len(refs1))
+	for _, ref := range refs1 {
+		refSet1[ref] = struct{}{}
+	}
+
+	refSet2 := make(map[string]struct{}, len(refs2))
+	for _, ref := range refs2 {
+		refSet2[ref] = struct{}{}
+	}
+
+	if len(refSet1) != len(refSet2) {
+		t.Fatalf("ref set size mismatch: %d != %d", len(refSet1), len(refSet2))
+	}
+
+	for ref := range refSet1 {
+		if _, ok := refSet2[ref]; !ok {
+			t.Fatalf("ref set does not contain %q, has: %s", ref, refs2)
+		}
+	}
+}
+
+func limitedRandReader(length uint64) io.Reader {
+	return io.LimitReader(rand.Reader, int64(length))
+}
+
+var randomDataMediaType = "application/random.data+octet-stream"
+
+func randomDigest(t *testing.T) string {
+	return fmt.Sprintf("sha256:%s", randomHexString(t))
+}
+
+func randomHexString(t *testing.T) string {
+	// Get 32 random bytes to make something that looks like a sha256 digest.
+	var buf [32]byte
+
+	if _, err := io.ReadFull(rand.Reader, buf[:]); err != nil {
+		t.Fatal(err)
+	}
+
+	return fmt.Sprintf("%x", buf[:])
+}


### PR DESCRIPTION
We need to stop using Tarsum for content-addressing image rootfs diffs. This PR is a way to accomplish that end goal.

The Docker daemon's Image "graph" will now store a gzipped-archive of rootfs diffs on commit of new images. These "blobs" are addressed by a _real_ cryptographically secure hash (sha256) of their contents and will live on the daemon as long as there is an image which references them. A push to a v2 registry can then upload this immutable blob rather than generate an archive at push time as it does today.
### Why is this a good thing?
- regain credibility for using a sha256 for image content verification vs tarsum (though still a "tech-preview" feature)
- expected performance increase for image pushes
  - no more need to buffer image diff archives to disk or compress-on-the-fly.
- consistency in exporting image content
### What's the performance/ux impact?
- uses ~35% more disk space for new image content.
- slight `docker commit` slowdown (to allow for compressing and hashing of new image content).
