### PR TITLE
Clarify HOSTPATH in docker cp

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2417,7 +2417,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 }
 
 func (cli *DockerCli) CmdCp(args ...string) error {
-	cmd := cli.Subcmd("cp", "CONTAINER:PATH HOSTPATH", "Copy files/folders from the PATH to the HOSTPATH", true)
+	cmd := cli.Subcmd("cp", "CONTAINER:PATH HOSTPATH", "Copy files/folders from the PATH of the container to the HOSTPATH of the host\nrunning the command.", true)
 	cmd.Require(flag.Exact, 2)
 
 	utils.ParseFlags(cmd, args, true)

--- a/docs/man/docker-cp.1.md
+++ b/docs/man/docker-cp.1.md
@@ -2,7 +2,8 @@
 % Docker Community
 % JUNE 2014
 # NAME
-docker-cp - Copy files/folders from the PATH to the HOSTPATH
+docker-cp - Copy files/folders from the PATH of the container to the HOSTPATH
+of the host running the command.
 
 # SYNOPSIS
 **docker cp**
@@ -11,8 +12,9 @@ CONTAINER:PATH HOSTPATH
 
 # DESCRIPTION
 Copy files/folders from a container's filesystem to the host
-path. Paths are relative to the root of the filesystem. Files
-can be copied from a running or stopped container.
+path running the command. Paths are relative to the root of
+the filesystem. Files can be copied from a running or stopped
+container.
 
 # OPTIONS
 **--help**

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -742,11 +742,12 @@ Supported `Dockerfile` instructions: `CMD`, `ENTRYPOINT`, `ENV`, `EXPOSE`,
 ## cp
 
 Copy files/folders from a container's filesystem to the host
-path.  Paths are relative to the root of the filesystem.
+path. Paths are relative to the root of the filesystem.
 
     Usage: docker cp CONTAINER:PATH HOSTPATH
 
-    Copy files/folders from the PATH to the HOSTPATH
+    Copy files/folders from the PATH of the container to the HOSTPATH of the host
+    running the command.
 
 ## create
 


### PR DESCRIPTION
Fixes #11141. It wasn't really clear if HOSTPATH is referring the daemon host or cli host.

cc: @duglin @cpuguy83 
Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
