### PR TITLE
pkg/archive: rm invalid test case from achive_windows_test.go

### DIFF
--- a/pkg/archive/archive_windows_test.go
+++ b/pkg/archive/archive_windows_test.go
@@ -14,7 +14,6 @@ func TestCanonicalTarNameForPath(t *testing.T) {
 		{"foo", "foo", false},
 		{"foo/bar", "___", true}, // unix-styled windows path must fail
 		{`foo\bar`, "foo/bar", false},
-		{`foo\bar`, "foo/bar/", false},
 	}
 	for _, v := range cases {
 		if out, err := CanonicalTarNameForPath(v.in); err != nil && !v.shouldFail {


### PR DESCRIPTION
This is a leftover I accidentally forgot to delete in a previous PR, an invalid test case which is actually validated in the next test case.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
