### PR TITLE
Fix specific return value about ForceUnmount

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -66,5 +66,5 @@ func ForceUnmount(target string) (err error) {
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	return
+	return err
 }


### PR DESCRIPTION
In functon ForceUnmount,there is no specific return value when unmount failure, and then the function maybe returns a undefined error,so we should define it explicitly.
