### PR TITLE
Better error message for `docker rmi ''`

### DIFF
--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -41,6 +41,10 @@ func (daemon *Daemon) DeleteImage(eng *engine.Engine, name string, imgs *engine.
 		tag = graph.DEFAULTTAG
 	}
 
+	if name == "" {
+		return fmt.Errorf("Image name can not be blank")
+	}
+
 	img, err := daemon.Repositories().LookupImage(name)
 	if err != nil {
 		if r, _ := daemon.Repositories().Get(repoName); r != nil {

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -155,5 +155,19 @@ func TestRmiWithMultipleRepositories(t *testing.T) {
 	}
 
 	logDone("rmi - delete a image which its dependency tagged to multiple repositories success")
+}
 
+func TestRmiBlank(t *testing.T) {
+	// try to delete a blank image name
+	runCmd := exec.Command(dockerBinary, "rmi", "")
+	out, _, err := runCommandWithOutput(runCmd)
+
+	if err == nil {
+		t.Fatal("Should have failed to delete '' image")
+	}
+
+	if strings.Contains(out, "No such image") {
+		t.Fatalf("Wrong error message generated: %s", out)
+	}
+	logDone("rmi- blank image name")
 }


### PR DESCRIPTION
See: https://github.com/docker/docker/issues/10867

While looking at #10867 I noticed that the error message generated for
a blank image ID wasn't very helpful so this fixes that.

Signed-off-by: Doug Davis dug@us.ibm.com
