### PR TITLE
Don't test resolv.conf updater on overlay filesystem

### DIFF
--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -189,6 +189,13 @@ the `/etc/resolv.conf` of the host machine where the `docker` daemon is
 running.  You might wonder what happens when the host machine's
 `/etc/resolv.conf` file changes.  The `docker` daemon has a file change
 notifier active which will watch for changes to the host DNS configuration.
+
+> **Note**:
+> The file change notifier relies on the Linux kernel's inotify feature.
+> Because this feature is currently incompatible with the overlay filesystem 
+> driver, a Docker daemon using "overlay" will not be able to take advantage
+> of the `/etc/resolv.conf` auto-update feature.
+
 When the host file changes, all stopped containers which have a matching
 `resolv.conf` to the host will be updated immediately to this newest host
 configuration.  Containers which are running when the host configuration

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1589,7 +1589,9 @@ func TestRunDnsOptionsBasedOnHostResolvConf(t *testing.T) {
 // stopped and have an unmodified copy of resolv.conf, as well as
 // marking running containers as requiring an update on next restart
 func TestRunResolvconfUpdater(t *testing.T) {
-	testRequires(t, SameHostDaemon)
+	// Because overlay doesn't support inotify properly, we need to skip
+	// this test if the docker daemon has Storage Driver == overlay
+	testRequires(t, SameHostDaemon, NotOverlay)
 
 	tmpResolvConf := []byte("search pommesfrites.fr\nnameserver 12.34.56.78")
 	tmpLocalhostResolvConf := []byte("nameserver 127.0.0.1")

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -66,6 +66,17 @@ var (
 		},
 		"Test requires the native (libcontainer) exec driver.",
 	}
+
+	NotOverlay = TestRequirement{
+		func() bool {
+			cmd := exec.Command("grep", "^overlay / overlay", "/proc/mounts")
+			if err := cmd.Run(); err != nil {
+				return true
+			}
+			return false
+		},
+		"Test requires underlying root filesystem not be backed by overlay.",
+	}
 )
 
 // testRequires checks if the environment satisfies the requirements


### PR DESCRIPTION
The overlay filesystem does not support inotify at this time. The
resolv.conf updater test was passing on overlay-based Jenkins because of
a fluke--because it was DIND, /etc/resolv.conf on the "host" was really
a bind-mounted resolv.conf from the outer container, which means a watch
directly on that file worked as it was not overlay backed.  The new test
(from #10703) unmounts the bind-mounted copy to test create and modify
code-paths, which caused us to hit the issue.

This PR also adds a note to the docs about the lack of auto-update when
using the overlay storage driver.

See https://lkml.org/lkml/2012/2/28/223 for more info on inotify and
overlay.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
