### PR TITLE
Fix docker build -f bash completion and docker run bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -255,11 +255,15 @@ _docker_build() {
 			__docker_image_repos_and_tags
 			return
 			;;
+		--file|-f)
+			_filedir
+			return	
+			;;	
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--force-rm --no-cache --quiet -q --rm --tag -t" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--file -f --force-rm --no-cache --quiet -q --rm --tag -t" -- "$cur" ) )
 			;;
 		*)
 			local counter="$(__docker_pos_first_nonflag '--tag|-t')"
@@ -623,8 +627,10 @@ _docker_run() {
 		--lxc-conf
 		--mac-address
 		--memory -m
+		--memory-swap
 		--name
 		--net
+		--pid
 		--publish -p
 		--restart
 		--security-opt
@@ -635,9 +641,11 @@ _docker_run() {
 	"
 
 	local all_options="$options_with_args
+		--help
 		--interactive -i
 		--privileged
 		--publish-all -P
+		--read-only
 		--tty -t
 	"
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Docker build has `-f` flag, but when I use `Tab` to completion, it was missing `-f`

Docker run has missing `--help` `--pid` `--read-only` `--memory-swap` in bash completion
