### PR TITLE
Two SELinux Changes.

### DIFF
--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -47,7 +47,7 @@ func (d *Driver) Create(id, parent string) error {
 	}
 	opts := []string{"level:s0"}
 	if _, mountLabel, err := label.InitLabels(opts); err == nil {
-		label.Relabel(dir, mountLabel, "")
+		label.SetFileLabel(dir, mountLabel)
 	}
 	if parent == "" {
 		return nil

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -15,7 +15,6 @@ import (
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/volumes"
-	"github.com/docker/libcontainer/label"
 )
 
 type Mount struct {
@@ -342,12 +341,6 @@ func (container *Container) setupMounts() error {
 
 	if container.HostsPath != "" {
 		mounts = append(mounts, execdriver.Mount{Source: container.HostsPath, Destination: "/etc/hosts", Writable: true, Private: true})
-	}
-
-	for _, m := range mounts {
-		if err := label.SetFileLabel(m.Source, container.MountLabel); err != nil {
-			return err
-		}
 	}
 
 	container.command.Mounts = mounts


### PR DESCRIPTION
daemon/volumes.go

  This SetFileCon call made no sense, it was changing the labels of any
directory mounted into the containers SELinux label.  If it came from me,
then I apologize since it is a huge bug.

The Volumes Mount code should optionally do this, but it should not always
happen, and should never happen on a --privileged container.

The change to

daemon/graphdriver/vfs/driver.go, is a simplification since this it not
a relabel, it is only a setting of the shared label for docker volumes.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
