### PR TITLE
builder filter volumes on run

### DIFF
--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -253,10 +253,19 @@ func run(b *Builder, args []string, attributes map[string]bool, original string)
 	c.Mount()
 	defer c.Unmount()
 
+	// Unset the volumes
+	volumeConfig := c.Config.Volumes
+	c.Config.Volumes = nil
+	volumes := c.Volumes
+	c.Volumes = nil
+
 	err = b.run(c)
 	if err != nil {
 		return err
 	}
+	c.Volumes = volumes
+	c.Config.Volumes = volumeConfig
+
 	if err := b.commit(c.ID, cmd, "run"); err != nil {
 		return err
 	}

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -90,6 +90,16 @@ func (b *Builder) commit(id string, autoCmd []string, comment string) error {
 			return err
 		}
 		defer container.Unmount()
+
+		// Make sure all resources are setup, but we can ignore errors
+		// Supress output from this
+		errStream := b.ErrStream
+		outStream := b.OutStream
+		b.ErrStream = nil
+		b.OutStream = nil
+		b.run(container)
+		b.ErrStream = errStream
+		b.OutStream = outStream
 	}
 	container, err := b.Daemon.Get(id)
 	if err != nil {


### PR DESCRIPTION
Fixes #3639

This makes the builder, on `RUN` commands disable volumes, this way
anything written to dirs that have a volume will persist in the image,
as is the expected behavior in builds.

This is an alternative to #7133
This one is a little hacky but seems to work without modifying how
containers actually work in Docker (as #7133 does)
This is a last ditch effort to fix this within just the builder
itself.
