### PR TITLE
integ-cli: skip case-sensitive dockerfile tests on windows

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4700,6 +4700,7 @@ func TestBuildRenamedDockerfile(t *testing.T) {
 }
 
 func TestBuildFromMixedcaseDockerfile(t *testing.T) {
+	testRequires(t, UnixCli) // Dockerfile overwrites dockerfile on windows
 	defer deleteImages("test1")
 
 	ctx, err := fakeContext(`FROM busybox
@@ -4725,6 +4726,7 @@ func TestBuildFromMixedcaseDockerfile(t *testing.T) {
 }
 
 func TestBuildWithTwoDockerfiles(t *testing.T) {
+	testRequires(t, UnixCli) // Dockerfile overwrites dockerfile on windows
 	defer deleteImages("test1")
 
 	ctx, err := fakeContext(`FROM busybox


### PR DESCRIPTION
The tests end up overwriting the `dockerfile` with `Dockerfile` since
windows filesystems are case-insensitive. The following methods are
skipped:
- TestBuildRenamedDockerfile
- TestBuildFromMixedcaseDockerfile

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @duglin 
