### PR TITLE
pkg/archive_windows: make use of os.PathSeparator

### DIFF
--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -4,6 +4,7 @@ package archive
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/docker/docker/vendor/src/code.google.com/p/go/src/pkg/archive/tar"
@@ -20,7 +21,8 @@ func CanonicalTarNameForPath(p string) (string, error) {
 	if strings.Contains(p, "/") {
 		return "", fmt.Errorf("windows path contains forward slash: %s", p)
 	}
-	return strings.Replace(p, "\\", "/", -1), nil
+	return strings.Replace(p, string(os.PathSeparator), "/", -1), nil
+
 }
 
 func setHeaderForSpecialDevice(hdr *tar.Header, ta *tarAppender, name string, stat interface{}) (nlink uint32, inode uint64, err error) {


### PR DESCRIPTION
Addressing a small comment here: https://github.com/docker/docker/pull/11148#discussion_r25911469

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @jhowardmsft
