### PR TITLE
Expose the getResourcePath and getRootResourcePath wrappers.

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -32,7 +32,6 @@ import (
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/progressreader"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/pkg/tarsum"
 	"github.com/docker/docker/pkg/urlutil"
@@ -646,14 +645,12 @@ func (b *Builder) addContext(container *daemon.Container, orig, dest string, dec
 		err        error
 		destExists = true
 		origPath   = path.Join(b.contextPath, orig)
-		destPath   = path.Join(container.RootfsPath(), dest)
+		destPath   string
 	)
 
-	if destPath != container.RootfsPath() {
-		destPath, err = symlink.FollowSymlinkInScope(destPath, container.RootfsPath())
-		if err != nil {
-			return err
-		}
+	destPath, err = container.GetResourcePath(dest)
+	if err != nil {
+		return err
 	}
 
 	// Preserve the trailing '/'

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -47,7 +47,7 @@ func (container *Container) createVolumes() error {
 			continue
 		}
 
-		realPath, err := container.getResourcePath(path)
+		realPath, err := container.GetResourcePath(path)
 		if err != nil {
 			return err
 		}
@@ -336,7 +336,7 @@ func (container *Container) mountVolumes() error {
 			return fmt.Errorf("could not find volume for %s:%s, impossible to mount", source, dest)
 		}
 
-		destPath, err := container.getResourcePath(dest)
+		destPath, err := container.GetResourcePath(dest)
 		if err != nil {
 			return err
 		}
@@ -347,7 +347,7 @@ func (container *Container) mountVolumes() error {
 	}
 
 	for _, mnt := range container.specialMounts() {
-		destPath, err := container.getResourcePath(mnt.Destination)
+		destPath, err := container.GetResourcePath(mnt.Destination)
 		if err != nil {
 			return err
 		}
@@ -360,7 +360,7 @@ func (container *Container) mountVolumes() error {
 
 func (container *Container) unmountVolumes() {
 	for dest := range container.Volumes {
-		destPath, err := container.getResourcePath(dest)
+		destPath, err := container.GetResourcePath(dest)
 		if err != nil {
 			logrus.Errorf("error while unmounting volumes %s: %v", destPath, err)
 			continue
@@ -372,7 +372,7 @@ func (container *Container) unmountVolumes() {
 	}
 
 	for _, mnt := range container.specialMounts() {
-		destPath, err := container.getResourcePath(mnt.Destination)
+		destPath, err := container.GetResourcePath(mnt.Destination)
 		if err != nil {
 			logrus.Errorf("error while unmounting volumes %s: %v", destPath, err)
 			continue

--- a/volumes/volume.go
+++ b/volumes/volume.go
@@ -114,14 +114,38 @@ func (v *Volume) FromDisk() error {
 }
 
 func (v *Volume) jsonPath() (string, error) {
-	return v.getRootResourcePath("config.json")
-}
-func (v *Volume) getRootResourcePath(path string) (string, error) {
-	cleanPath := filepath.Join("/", path)
-	return symlink.FollowSymlinkInScope(filepath.Join(v.configPath, cleanPath), v.configPath)
+	return v.GetRootResourcePath("config.json")
 }
 
-func (v *Volume) getResourcePath(path string) (string, error) {
+// Evalutes `path` in the scope of the volume's root path, with proper path
+// sanitisation. Symlinks are all scoped to the root of the volume, as
+// though the volume's root was `/`.
+//
+// The volume's root path is the host-facing path of the root of the volume's
+// mountpoint inside a container.
+//
+// NOTE: The returned path is *only* safely scoped inside the volume's root
+//       if no component of the returned path changes (such as a component
+//       symlinking to a different path) between using this method and using the
+//       path. See symlink.FollowSymlinkInScope for more details.
+func (v *Volume) GetResourcePath(path string) (string, error) {
 	cleanPath := filepath.Join("/", path)
 	return symlink.FollowSymlinkInScope(filepath.Join(v.Path, cleanPath), v.Path)
+}
+
+// Evalutes `path` in the scope of the volume's config path, with proper path
+// sanitisation. Symlinks are all scoped to the root of the config path, as
+// though the config path was `/`.
+//
+// The config path of a volume is not exposed to the container and is just used
+// to store volume configuration options and other internal information. If in
+// doubt, you probably want to just use v.GetResourcePath.
+//
+// NOTE: The returned path is *only* safely scoped inside the volume's config
+//       path if no component of the returned path changes (such as a component
+//       symlinking to a different path) between using this method and using the
+//       path. See symlink.FollowSymlinkInScope for more details.
+func (v *Volume) GetRootResourcePath(path string) (string, error) {
+	cleanPath := filepath.Join("/", path)
+	return symlink.FollowSymlinkInScope(filepath.Join(v.configPath, cleanPath), v.configPath)
 }


### PR DESCRIPTION
Due to the importance of path safety, the internal sanitisation wrappers
for volumes and containers should be exposed so other parts of Docker
can benefit from proper path sanitisation.

Signed-off-by: Aleksa Sarai cyphar@cyphar.com (github: cyphar)
