### PR TITLE
integ-cli: fix test requiring scratch

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2289,11 +2289,12 @@ func TestRunCidFileCleanupIfEmpty(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	tmpCidFile := path.Join(tmpDir, "cid")
-	cmd := exec.Command(dockerBinary, "run", "--cidfile", tmpCidFile, "scratch")
+	cmd := exec.Command(dockerBinary, "run", "--cidfile", tmpCidFile, "emptyfs")
 	out, _, err := runCommandWithOutput(cmd)
-	t.Log(out)
 	if err == nil {
-		t.Fatal("Run without command must fail")
+		t.Fatalf("Run without command must fail. out=%s", out)
+	} else if !strings.Contains(out, "No command specified") {
+		t.Fatalf("Run without command failed with wrong output. out=%s\nerr=%v", out, err)
 	}
 
 	if _, err := os.Stat(tmpCidFile); err == nil {


### PR DESCRIPTION
TestRunCidFileCleanupIfEmpty fails on windows/mac because the test runs
the command `docker run scratch` and it gives the following error:

```
Unable to find image 'scratch:latest' locally
Pulling repository scratch
511136ea3c5a: Download complete
FATA[0004] 'scratch' is a reserved name
```

I am not entirely sure if this is a test issue or not but I had a quick
workaround by creating another image using `FROM scratch` and using that.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @LK4D4 @duglin @cpuguy83 
