### PR TITLE
add email format check when docker login

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -373,6 +374,11 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 			email = readInput(cli.in, cli.out)
 			if email == "" {
 				email = authconfig.Email
+			} else {
+				reg := regexp.MustCompile(`^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$`)
+				if !reg.Match([]byte(email)) {
+					return fmt.Errorf("Error : Bad Email Format")
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
Although index server can check the email address, it's still
necessary to check email format on docker daemon side, it can
save the communication cost and report error to user earlier.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
