### PR TITLE
Ensure clean engine shutdown on startup errors

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1002,14 +1002,6 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		trustStore:     t,
 		statsCollector: newStatsCollector(1 * time.Second),
 	}
-	if err := daemon.restore(); err != nil {
-		return nil, err
-	}
-
-	// set up filesystem watch on resolv.conf for network changes
-	if err := daemon.setupResolvconfWatcher(); err != nil {
-		return nil, err
-	}
 
 	// Setup shutdown handlers
 	// FIXME: can these shutdown handlers be registered closer to their source?
@@ -1029,6 +1021,15 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 			log.Errorf("daemon.containerGraph.Close(): %s", err.Error())
 		}
 	})
+
+	if err := daemon.restore(); err != nil {
+		return nil, err
+	}
+
+	// set up filesystem watch on resolv.conf for network changes
+	if err := daemon.setupResolvconfWatcher(); err != nil {
+		return nil, err
+	}
 
 	return daemon, nil
 }


### PR DESCRIPTION
Previously on error either from the daemon or from the api it is just
exiting with exit status 1 but not performing a shutdown.
This can produce insconsistent state depending on where the error came
from.

This makes sure that before we exit on error that the engine gets fully
shutdown.

I'm hoping this fixes #7585
For sure I can reliably reproduce dangling mounts with something as simple as having invalid tls keys specified (or anything that causes the `serveapi` job to error out)
