### PR TITLE
integ-cli: skip more case-senstive dockerfile tests on Windows

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -379,6 +379,8 @@ RUN find /tmp/`,
 }
 
 func TestBuildApiLowerDockerfile(t *testing.T) {
+	testRequires(t, UnixCli) // Dockerfile overwrites dockerfile on windows
+
 	git, err := fakeGIT("repo", map[string]string{
 		"dockerfile": `FROM busybox
 RUN echo from dockerfile`,
@@ -428,6 +430,8 @@ RUN echo from Dockerfile`,
 }
 
 func TestBuildApiDoubleDockerfile(t *testing.T) {
+	testRequires(t, UnixCli) // Dockerfile overwrites dockerfile on windows
+
 	git, err := fakeGIT("repo", map[string]string{
 		"Dockerfile": `FROM busybox
 RUN echo from Dockerfile`,


### PR DESCRIPTION
> **DO NOT REVIEW/MERGE** until I remove this message. :exclamation: :exclamation: :exclamation: 

Followup to #11186. I was not able to catch those ones initially. These
tests overwrite `dockerfile` by creating another file named `Dockerfile`
and NTFS is case-sensitive. So skipping those tests for windows CLI.

Tests skipped:
- `TestBuildApiLowerDockerfile`
- `TestBuildapiDoubleDockerfile`

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @duglin @tiborvass 
