### PR TITLE
integ-cli: skip test assuming -H is unix://...

### DIFF
--- a/integration-cli/docker_cli_proxy_test.go
+++ b/integration-cli/docker_cli_proxy_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestCliProxyDisableProxyUnixSock(t *testing.T) {
+	testRequires(t, SameHostDaemon) // test is valid when DOCKER_HOST=unix://..
+
 	cmd := exec.Command(dockerBinary, "info")
 	cmd.Env = appendDockerHostEnv([]string{"HTTP_PROXY=http://127.0.0.1:9999"})
 


### PR DESCRIPTION
`TestCliProxyDisableProxyUnixSock` verifies that HTTP_PROXY env var is
used when DOCKER_HOST is not set and cli connects to `unix://...` by
default.

In the windows/darwin CLI CIs, daemon is on remote host and we always
connect via `tcp://`, therefore this test fails very straight. Skipping
this test to run only on "same host daemon" case.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @cpuguy83 (test author) @duglin  
