### PR TITLE
integ-cli: also preserve SystemRoot env var

### DIFF
--- a/integration-cli/docker_cli_proxy_test.go
+++ b/integration-cli/docker_cli_proxy_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestCliProxyDisableProxyUnixSock(t *testing.T) {
 	cmd := exec.Command(dockerBinary, "info")
-	cmd.Env = appendDockerHostEnv([]string{"HTTP_PROXY=http://127.0.0.1:9999"})
+	cmd.Env = appendBaseEnv([]string{"HTTP_PROXY=http://127.0.0.1:9999"})
 
 	if out, _, err := runCommandWithOutput(cmd); err != nil {
 		t.Fatal(err, out)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -869,7 +869,7 @@ func TestRunEnvironmentErase(t *testing.T) {
 	defer deleteAllContainers()
 
 	cmd := exec.Command(dockerBinary, "run", "-e", "FOO", "-e", "HOSTNAME", "busybox", "env")
-	cmd.Env = appendDockerHostEnv([]string{})
+	cmd.Env = appendBaseEnv([]string{})
 
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -908,7 +908,7 @@ func TestRunEnvironmentOverride(t *testing.T) {
 	defer deleteAllContainers()
 
 	cmd := exec.Command(dockerBinary, "run", "-e", "HOSTNAME", "-e", "HOME=/root2", "busybox", "env")
-	cmd.Env = appendDockerHostEnv([]string{"HOSTNAME=bar"})
+	cmd.Env = appendBaseEnv([]string{"HOSTNAME=bar"})
 
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {


### PR DESCRIPTION
Windows CI fails to dial remote test host over tcp in the test cases where
we clear environment variables during `exec(dockerBinary, ...)` in the
absence of `SystemRoot` environment variable (typically points to `c:\windows`).

This fixes tests:
- `TestRunEnvironmentErase`
- `TestRunEnvironmentOverride`
- `TestCliProxyDisableProxyUnixSock` (#11216 should also be merged for this one to get fully fixed)

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @tianon @duglin 
