### PR TITLE
Add docker start show error message form daemon when start failed

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -778,19 +778,27 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 			return err
 		}
 	}
-
+	var encounteredError error
 	for _, name := range cmd.Args() {
 		_, _, err := readBody(cli.call("POST", "/containers/"+name+"/start", nil, false))
 		if err != nil {
 			if !*attach && !*openStdin {
+				// attach and openStdin is false means it could be starting multiple containers
+				// when a container start failed, show the error message and start next
 				fmt.Fprintf(cli.err, "%s\n", err)
+				encounteredError = fmt.Errorf("Error: failed to start one or more containers")
+			} else {
+				encounteredError = err
 			}
-			return fmt.Errorf("Error: failed to start one or more containers")
 		} else {
 			if !*attach && !*openStdin {
 				fmt.Fprintf(cli.out, "%s\n", name)
 			}
 		}
+	}
+
+	if encounteredError != nil {
+		return encounteredError
 	}
 
 	if *openStdin || *attach {


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
This PR will do two things.
First: correct a mistake I have made in PR #11202 , in PR #11202 I delete 
the `var encounteredError error` and make a wrong return  at https://github.com/docker/docker/blob/master/api/client/commands.go#L788 , 
since docker start could start multiple containers,  the wrong return will stop 
the start if there is a container start failed.  Really sorry for make this mistake in PR#11202. This patch going to fix this.

Second: just as title said, we should show error message from daemon to 
let the user know why the container is failed to start, not 
just `Error: failed to start one or more containers`, this message is useless for user.

ping @estesp @tiborvass 
