### PR TITLE
Fix docker start help message

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -703,7 +703,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 		cErr chan error
 		tty  bool
 
-		cmd       = cli.Subcmd("start", "CONTAINER [CONTAINER...]", "Restart a stopped container", true)
+		cmd       = cli.Subcmd("start", "CONTAINER [CONTAINER...]", "Start one or more stopped containers", true)
 		attach    = cmd.Bool([]string{"a", "-attach"}, false, "Attach STDOUT/STDERR and forward signals")
 		openStdin = cmd.Bool([]string{"i", "-interactive"}, false, "Attach container's STDIN")
 	)

--- a/docs/man/docker-start.1.md
+++ b/docs/man/docker-start.1.md
@@ -2,7 +2,7 @@
 % Docker Community
 % JUNE 2014
 # NAME
-docker-start - Restart a stopped container
+docker-start - Start one or more stopped containers
 
 # SYNOPSIS
 **docker start**
@@ -13,7 +13,7 @@ CONTAINER [CONTAINER...]
 
 # DESCRIPTION
 
-Start a stopped container.
+Start one or more stopped containers.
 
 # OPTIONS
 **-a**, **--attach**=*true*|*false*

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -2081,7 +2081,7 @@ more details on finding shared images from the command line.
 
     Usage: docker start [OPTIONS] CONTAINER [CONTAINER...]
 
-    Restart a stopped container
+    Start one or more stopped containers
 
       -a, --attach=false         Attach STDOUT/STDERR and forward signals
       -i, --interactive=false    Attach container's STDIN


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Docker start can start multiple containers, but the help messages show 
`Restart a stopped container` which is not correct.
