### PR TITLE
cleanup: docs: remove temporary inline styles

### DIFF
--- a/docs/sources/project/find-an-issue.md
+++ b/docs/sources/project/find-an-issue.md
@@ -2,15 +2,7 @@ page_title: Make a project contribution
 page_description: Basic workflow for Docker contributions
 page_keywords: contribute, pull request, review, workflow, white-belt, black-belt, squash, commit
 
-<!-- TODO (@thaJeztah) remove after docs/base is updated -->
 <style type="text/css">
-.tg    {border-collapse:collapse;border-spacing:0;margin-bottom:15px;}
-.tg td {background-color: #fff;padding:5px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;vertical-align:top;}
-.tg th {font-weight:bold;padding:5px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;text-align:left;}
-.tg .tg-e3zv{width:150px;}
-</style>
-
-<style>
 
 /* GitHub label styles */
 .gh-label {

--- a/docs/sources/project/get-help.md
+++ b/docs/sources/project/get-help.md
@@ -2,7 +2,7 @@ page_title: Where to chat or get help
 page_description: Describes Docker's communication channels
 page_keywords: IRC, Google group, Twitter, blog, Stackoverflow
 
-<style>
+<style type="text/css">
 /* @TODO add 'no-zebra' table-style to the docs-base stylesheet */
 /* Table without "zebra" striping */
 .content-body table.no-zebra tr {
@@ -15,13 +15,7 @@ page_keywords: IRC, Google group, Twitter, blog, Stackoverflow
 There are several communications channels you can use to chat with Docker
 community members and developers.
 
-<!-- TODO (@thaJeztah) remove after docs/base is updated -->
-<style type="text/css">
-.tg  {border-collapse:collapse;border-spacing:0;text-align: left;}
-.tg td{padding:10px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;vertical-align:top;}
-.tg th{font-weight:normal;padding:10px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;}
-</style>
-<table class="tg">
+<table>
   <col width="25%">
   <col width="75%">
   <tr>
@@ -79,13 +73,7 @@ the easiest way to connect to IRC.
 
 2. Fill out the form.
 
-    <!-- TODO (@thaJeztah) remove after docs/base is updated -->
-    <style type="text/css">
-    .tg   {border-collapse:collapse;border-spacing:0;}
-    .tg td{padding:10px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;}
-    .tg th{font-weight:normal;padding:10px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;}
-    </style>
-    <table class="tg no-zebra" style="width: auto">
+    <table class="no-zebra" style="width: auto">
       <tr>
         <td><b>Nickname</b></td>
         <td>The short name you want to be known as in IRC.</td>

--- a/docs/sources/project/make-a-contribution.md
+++ b/docs/sources/project/make-a-contribution.md
@@ -2,40 +2,12 @@ page_title: Understand how to contribute
 page_description: Explains basic workflow for Docker contributions
 page_keywords: contribute, maintainers, review, workflow, process
 
-<!-- TODO (@thaJeztah) remove after docs/base is updated -->
-<style type="text/css">
-.tg    {border-collapse:collapse;border-spacing:0;margin-bottom:15px;}
-.tg td {background-color: #fff;padding:5px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;vertical-align:top;}
-.tg th {font-weight:bold;padding:5px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;text-align:left;}
-.tg .tg-e3zv{width:150px;}
-</style>
-
-<style>
-
-/* GitHub label styles */
-.gh-label {
-    display: inline-block;
-    padding: 3px 4px;
-    font-size: 11px;
-    font-weight: bold;
-    line-height: 1;
-    color: #fff;
-    border-radius: 2px;
-    box-shadow: inset 0 -1px 0 rgba(0,0,0,0.12);
-}
-
-.gh-label.black-belt  { background-color: #000000; color: #ffffff; }
-.gh-label.bug         { background-color: #fc2929; color: #ffffff; }
-.gh-label.improvement { background-color: #bfe5bf; color: #2a332a; }
-.gh-label.project-doc { background-color: #207de5; color: #ffffff; }
-.gh-label.white-belt  { background-color: #ffffff; color: #333333; }
-
-</style>
-
 # Understand how to contribute
 
 Contributing is a process where you work with Docker maintainers and the
-community to improve Docker. The maintainers are experienced contributors who specialize in one or more Docker components. Maintainers play a big role in reviewing contributions.
+community to improve Docker. The maintainers are experienced contributors
+who specialize in one or more Docker components. Maintainers play a big role
+in reviewing contributions.
 
 There is a formal process for contributing. We try to keep our contribution
 process simple so you'll want to contribute frequently.
@@ -59,4 +31,5 @@ contributions. When you reach that point in the flow, we make sure to tell you.
 
 ## Where to go next
 
-Now that you know a little about the contribution process, go to the next section to [find an issue you want to work on](/project/find-an-issue/).
+Now that you know a little about the contribution process, go to the next section
+to [find an issue you want to work on](/project/find-an-issue/).

--- a/docs/sources/project/set-up-dev-env.md
+++ b/docs/sources/project/set-up-dev-env.md
@@ -2,14 +2,6 @@ page_title: Work with a development container
 page_description: How to use Docker's development environment
 page_keywords: development, inception, container, image Dockerfile, dependencies, Go, artifacts
 
-
-<!-- TODO (@thaJeztah) remove after docs/base is updated -->
-<style type="text/css">
-.tg   {border-collapse:collapse;border-spacing:0;}
-.tg td{font-family:monospace, serif;font-size:11px;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;}
-.tg th{font-family:monospace, sans-serif;font-size:11px;font-weight:normal;padding:10px 5px;border-style:solid;border-width:0px;overflow:hidden;word-break:normal;}
-</style>
-
 # Work with a development container
 
 In this section, you learn to develop like a member of Docker's core team.
@@ -44,7 +36,7 @@ To remove unnecessary artifacts.
 
     You should see something similar to the following:
 
-    <table class="tg code">
+    <table class="code">
       <tr>
         <th>CONTAINER ID</th>
         <th>IMAGE</th>
@@ -66,7 +58,7 @@ To remove unnecessary artifacts.
 
     You should see something similar to the following:
 
-    <table class="tg code">
+    <table class="code">
       <tr>
         <th>REPOSITORY</th>
         <th>TAG</th>
@@ -128,7 +120,7 @@ environment.
 
     You should see something similar to this:
 
-    <table class="tg code">
+    <table class="code">
       <tr>
         <th>REPOSTITORY</th>
         <th>TAG</th>
@@ -292,7 +284,7 @@ build and run a `docker` binary in your container.
 
         $ docker ps
 
-    <table class="tg code">
+    <table class="code">
       <tr>
         <th>CONTAINER ID</th>
         <th>IMAGE</th>

--- a/docs/sources/project/test-and-docs.md
+++ b/docs/sources/project/test-and-docs.md
@@ -2,13 +2,6 @@ page_title: Run tests and test documentation
 page_description: Describes Docker's testing infrastructure
 page_keywords: make test, make docs, Go tests, gofmt, contributing, running tests
 
-<!-- TODO (@thaJeztah) remove after docs/base is updated -->
-<style type="text/css">
-.tg  {border-collapse:collapse;border-spacing:0;margin-bottom:15px;}
-.tg td{padding:5px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;}
-.tg th{padding:5px 5px;border-style:solid;border-width:1px;overflow:hidden;word-break:normal;text-align:left;}
-</style>
-
 # Run tests and test documentation
 
 Contributing includes testing your changes. If you change the Docker code, you
@@ -59,35 +52,35 @@ The `Makefile` contains a target for the entire test suite. The target's name
 is simply `test`. The make file contains several targets for testing:
 
 <style type="text/css">
-.make-target {font-family:"Courier New", Courier, monospace !important;}
+.monospaced {font-family: Monaco, Consolas, "Lucida Console", monospace !important;}
 </style>
-<table class="tg">
+<table>
   <tr>
     <th>Target</th>
     <th>What this target does</th>
   </tr>
   <tr>
-    <td class="make-target">test</td>
+    <td class="monospaced">test</td>
     <td>Run all the tests.</td>
   </tr>
   <tr>
-    <td class="make-target">test-unit</td>
+    <td class="monospaced">test-unit</td>
     <td>Run just the unit tests.</td>
   </tr>
   <tr>
-    <td class="make-target">test-integration</td>
+    <td class="monospaced">test-integration</td>
     <td>Run just integration tests.</td>
   </tr>
   <tr>
-    <td class="make-target">test-integration-cli</td>
+    <td class="monospaced">test-integration-cli</td>
     <td>Run the test for the integration command line interface.</td>
   </tr>
   <tr>
-    <td class="make-target">test-docker-py</td>
+    <td class="monospaced">test-docker-py</td>
     <td>Run the tests for Docker API client.</td>
   </tr>
   <tr>
-    <td class="make-target">docs-test</td>
+    <td class="monospaced">docs-test</td>
     <td>Runs the documentation test build.</td>
   </tr>
 </table>
@@ -170,11 +163,11 @@ You can use the `TESTFLAGS` environment variable to run a single test. The
 flag's value is passed as arguments to the `go test` command. For example, from
 your local host you can run the `TestBuild` test with this command:
 
-        $ TESTFLAGS='-test.run ^TestBuild$' make test
+    $ TESTFLAGS='-test.run ^TestBuild$' make test
 
 To run the same test inside your Docker development container, you do this:
 
-        root@5f8630b873fe:/go/src/github.com/docker/docker# TESTFLAGS='-run ^TestBuild$' hack/make.sh
+    root@5f8630b873fe:/go/src/github.com/docker/docker# TESTFLAGS='-run ^TestBuild$' hack/make.sh
 
 ## If test under Boot2Docker fail do to space errors
 

--- a/docs/sources/project/work-issue.md
+++ b/docs/sources/project/work-issue.md
@@ -51,31 +51,31 @@ Follow this workflow as you work:
 	
 5. Format your source files correctly.
 
-    <table class="tg">
+    <table>
       <thead>
       <tr>
-        <th class="tg-e3zv">File type</th>
+        <th>File type</th>
         <th>How to format</th>
       </tr>
       </thead>
       <tbody>
       <tr>
-        <td class="tg-e3zv"><code>.go</code></td>
+        <td><code>.go</code></td>
         <td>
             <p>
             Format <code>.go</code> files using the <code>gofmt</code> command.
             For example, if you edited the `docker.go` file you would format the file
-        like this:
-        </p>
-        <p><code>$ gofmt -s -w file.go</code></p>
-        <p>
-        Most file editors have a plugin to format for you. Check your editor's
-        documentation.
-        </p>
+            like this:
+            </p>
+            <p><code>$ gofmt -s -w file.go</code></p>
+            <p>
+            Most file editors have a plugin to format for you. Check your editor's
+            documentation.
+            </p>
         </td>
       </tr>
       <tr>
-        <td  class="tg-e3zv" style="white-space: nowrap"><code>.md</code> and non-<code>.go</code> files</td>
+        <td style="white-space: nowrap"><code>.md</code> and non-<code>.go</code> files</td>
         <td>Wrap lines to 80 characters.</td>
       </tr>
       </tbody>


### PR DESCRIPTION
**_NOT ready for merge (see below)**_

Some inline `<style>` tags were temporarily added to the documentation because the documentation-stylesheets where not yet updated to the latest version (see https://github.com/docker/docker/pull/11231 and
https://github.com/docker/docker/pull/11229#issuecomment-77698868).

This removes those temporary `<style>` tags.

depends on #11230
