### PR TITLE
Fix a few code rendering errors in docs

### DIFF
--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -228,13 +228,11 @@ Whether a container can talk to the world is governed by two factors.
     Docker will go set `ip_forward` to `1` for you when the server
     starts up. To check the setting or turn it on manually:
 
-    ```
-    $ cat /proc/sys/net/ipv4/ip_forward
-    0
-    $ echo 1 > /proc/sys/net/ipv4/ip_forward
-    $ cat /proc/sys/net/ipv4/ip_forward
-    1
-    ```
+        $ cat /proc/sys/net/ipv4/ip_forward
+        0
+        $ echo 1 > /proc/sys/net/ipv4/ip_forward
+        $ cat /proc/sys/net/ipv4/ip_forward
+        1
 
     Many using Docker will want `ip_forward` to be on, to at
     least make communication *possible* between containers and
@@ -463,9 +461,7 @@ your host's interfaces you should set `accept_ra` to `2`. Otherwise IPv6
 enabled forwarding will result in rejecting Router Advertisements. E.g., if you
 want to configure `eth0` via Router Advertisements you should set:
 
-    ```
     $ sysctl net.ipv6.conf.eth0.accept_ra=2
-    ```
 
 ![](/article-img/ipv6_basic_host_config.svg)
 

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -228,11 +228,11 @@ Whether a container can talk to the world is governed by two factors.
     Docker will go set `ip_forward` to `1` for you when the server
     starts up. To check the setting or turn it on manually:
 
-        $ cat /proc/sys/net/ipv4/ip_forward
-        0
-        $ echo 1 > /proc/sys/net/ipv4/ip_forward
-        $ cat /proc/sys/net/ipv4/ip_forward
-        1
+        $ sysctl net.ipv4.conf.all.forwarding
+        net.ipv4.conf.all.forwarding = 0
+        $ sysctl net.ipv4.conf.all.forwarding=1
+        $ sysctl net.ipv4.conf.all.forwarding
+        net.ipv4.conf.all.forwarding = 1
 
     Many using Docker will want `ip_forward` to be on, to at
     least make communication *possible* between containers and

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -475,7 +475,6 @@ By default, the container will be able to `read`, `write`, and `mknod` these dev
 This can be overridden using a third `:rwm` set of options to each `--device` flag:
 
 
-```
 	$ sudo docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
 
 	Command (m for help): q
@@ -489,7 +488,6 @@ This can be overridden using a third `:rwm` set of options to each `--device` fl
 
 	$ sudo docker run --device=/dev/sda:/dev/xvdc:m --rm -it ubuntu fdisk  /dev/xvdc
 	fdisk: unable to open /dev/xvdc: Operation not permitted
-```
 
 In addition to `--privileged`, the operator can have fine grain control over the
 capabilities using `--cap-add` and `--cap-drop`. By default, Docker has a default


### PR DESCRIPTION
Fixes the following errors:
- https://docs.docker.com/articles/networking/
  ![screenshot 2015-03-08 16 10 30](https://cloud.githubusercontent.com/assets/551247/6548234/7a1a213a-c5af-11e4-93e6-e4b82e383fb3.png)
  ![screenshot 2015-03-08 16 06 39](https://cloud.githubusercontent.com/assets/551247/6548233/7a1965b0-c5af-11e4-87ff-87803e30dcfd.png)
- https://docs.docker.com/reference/run/

![screenshot 2015-03-08 16 23 48](https://cloud.githubusercontent.com/assets/551247/6548239/89d313ca-c5af-11e4-8f0d-64d77086de41.png)
Signed-off-by: ChristoperBiscardi chris@docker.com
