### PR TITLE
Improve deprecation messages and message for "commit --run"

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1735,7 +1735,7 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	flChanges := opts.NewListOpts(nil)
 	cmd.Var(&flChanges, []string{"c", "-change"}, "Apply Dockerfile instruction to the created image")
 	// FIXME: --run is deprecated, it will be replaced with inline Dockerfile commands.
-	flConfig := cmd.String([]string{"#run", "#-run"}, "", "This option is deprecated and will be removed in a future version in favor of inline Dockerfile-compatible commands")
+	flConfig := cmd.String([]string{"#run", "#-run", "@-change"}, "", "This option is deprecated and will be removed in a future version in favor of inline Dockerfile-compatible commands")
 	cmd.Require(flag.Max, 2)
 	cmd.Require(flag.Min, 1)
 	utils.ParseFlags(cmd, args, true)

--- a/pkg/mflag/flag.go
+++ b/pkg/mflag/flag.go
@@ -33,6 +33,12 @@
 		var ip = flag.Int([]string{"f", "#flagname"}, 1234, "help message for flagname")
 	will display: `Warning: '-flagname' is deprecated, it will be removed soon. See usage.`
 	so you can only use `-f`.
+	If the replacement flag is a flag that has already been defined elsewhere, the
+	replacement flag can be prefixed with a `@` (see other):
+		var ip = flag.Int([]string{"#-old-flag", "@-other-flag"}, 1234, "help message for flagname")
+	this will display: `Warning: '--old-flag' is deprecated, it will be replaced by '--other-flag' soon. See usage.`
+	'see other' flags are only used for displaying the deprecation message and will not
+	be displayed in the help output.
 
 	You can also group one letter flags, bif you declare
 		var v = flag.Bool([]string{"v", "-verbose"}, false, "help message for verbose")
@@ -330,6 +336,11 @@ func sortFlags(flags map[string]*Flag) []*Flag {
 	nameMap := make(map[string]string)
 
 	for n, f := range flags {
+		if strings.HasPrefix(f.Names[0], "@") {
+			// Ignore 'see other' flags.
+			continue
+		}
+
 		fName := strings.TrimPrefix(f.Names[0], "#")
 		nameMap[fName] = n
 		if len(f.Names) == 1 {
@@ -520,7 +531,7 @@ func (f *FlagSet) PrintDefaults() {
 		format := "  -%s=%s"
 		names := []string{}
 		for _, name := range flag.Names {
-			if name[0] != '#' {
+			if strings.IndexAny(name, "#@") != 0 {
 				names = append(names, name)
 			}
 		}
@@ -577,7 +588,7 @@ func (f *FlagSet) FlagCountUndeprecated() int {
 	count := 0
 	for _, flag := range sortFlags(f.formal) {
 		for _, name := range flag.Names {
-			if name[0] != '#' {
+			if strings.IndexAny(name, "#@") != 0 {
 				count++
 				break
 			}
@@ -837,6 +848,10 @@ func (f *FlagSet) Var(value Value, names []string, usage string) {
 	// Remember the default value as a string; it won't change.
 	flag := &Flag{names, usage, value, value.String()}
 	for _, name := range names {
+		if strings.HasPrefix(name, "@") {
+			// Ignore 'see other' flags.
+			continue
+		}
 		name = strings.TrimPrefix(name, "#")
 		_, alreadythere := f.formal[name]
 		if alreadythere {
@@ -1001,7 +1016,7 @@ func (f *FlagSet) parseOne() (bool, string, error) {
 				}
 			}
 			if replacement != "" {
-				fmt.Fprintf(f.Out(), "Warning: '-%s' is deprecated, it will be replaced by '-%s' soon. See usage.\n", name, replacement)
+				fmt.Fprintf(f.Out(), "Warning: '-%s' is deprecated, it will be replaced by '-%s' soon. See usage.\n", name, strings.TrimPrefix(replacement, "@"))
 			} else {
 				fmt.Fprintf(f.Out(), "Warning: '-%s' is deprecated, it will be removed soon. See usage.\n", name)
 			}

--- a/pkg/mflag/flag_test.go
+++ b/pkg/mflag/flag_test.go
@@ -363,6 +363,20 @@ func TestUserDefinedBool(t *testing.T) {
 	}
 }
 
+// This tests that "see other" flags are ignored as "formal"
+func TestIgnoreSeeOther(t *testing.T) {
+	var flags FlagSet
+	flags.Init("test", ContinueOnError)
+	var b boolFlagVar
+	flags.Var(&b, []string{"#b", "#-boo", "@-something"}, "usage")
+
+	c := len(flags.formal)
+
+	if c != 2 {
+		t.Errorf("want: %d; got: %d", 2, c)
+	}
+}
+
 func TestSetOutput(t *testing.T) {
 	var flags FlagSet
 	var buf bytes.Buffer
@@ -449,8 +463,9 @@ func TestFlagCounts(t *testing.T) {
 	fs.BoolVar(&flag, []string{"#d", "#deprecated2"}, false, "regular flag")
 	fs.BoolVar(&flag, []string{"flag3"}, false, "regular flag")
 	fs.BoolVar(&flag, []string{"g", "#flag4", "-flag4"}, false, "regular flag")
+	fs.BoolVar(&flag, []string{"#o", "#-old-flag", "@flag3"}, false, "replaced flag")
 
-	if fs.FlagCount() != 6 {
+	if fs.FlagCount() != 7 {
 		t.Fatal("FlagCount wrong. ", fs.FlagCount())
 	}
 	if fs.FlagCountUndeprecated() != 4 {


### PR DESCRIPTION
This implements "see other" flags for deprecation messages, which allows a "replacement" flag to refer to another flag that is defined separately.

Before this change, the "replacement" flag could only be part of the same flag definitions, which made it impossible to output a deprecation message for flags that were replaced with another flag.

The "see other" replacement flags can be set by prefixing the flag-name with '@' and are ignored as an actual
flag.

In addition the deprecation warning for `docker commit --run` was improved (using the feature above) to give a hint for the new `--change` flag.

Before this change;

```
Warning: '--run' is deprecated, it will be removed soon. See usage.
```

After:

```
Warning: '--run' is deprecated, it will be replaced by '--change' soon. See usage.
```

relates to: https://github.com/docker/docker/issues/9525#issuecomment-77700372

**notes**
- I wasn't sure if these changes should be created as two separate pull-requests, I kept them as two commits, but let me know if you want them to be split to two pull-requests.
- It's my first "playing around" with the code. Probably lots of improvements to be made; hit me!
- Attempted to add some tests, but open to suggestions :)
