### PR TITLE
docker premount postmount implementation using channels

### DIFF
--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -185,6 +185,14 @@ func (d *driver) setupRlimits(container *libcontainer.Config, c *execdriver.Comm
 }
 
 func (d *driver) setupMounts(container *libcontainer.Config, c *execdriver.Command) error {
+
+	exec, done := mount.GetChannels()
+	go func(exec chan bool, done chan bool) {
+		<-exec
+		fmt.Println("HELLO WORLD: REACHED DOCKER")
+		done <- true
+	}(exec, done)
+
 	for _, m := range c.Mounts {
 		container.MountConfig.Mounts = append(container.MountConfig.Mounts, &mount.Mount{
 			Type:        "bind",

--- a/vendor/src/github.com/docker/libcontainer/mount/mount.go
+++ b/vendor/src/github.com/docker/libcontainer/mount/mount.go
@@ -20,7 +20,26 @@ type Mount struct {
 	Slave       bool   `json:"slave,omitempty"`
 }
 
+var (
+	exec chan bool
+	done chan bool
+)
+
+func init() {
+	exec = make(chan bool)
+	done = make(chan bool)
+}
+
+func GetChannels() (chan bool, chan bool) {
+	return exec, done
+}
+
 func (m *Mount) Mount(rootfs, mountLabel string) error {
+
+	exec <- true
+	fmt.Println("HELLO WORLD: REACHED LIBCONTAINER")
+	<-done
+
 	switch m.Type {
 	case "bind":
 		return m.bindMount(rootfs, mountLabel)


### PR DESCRIPTION
Hi @crosbymichael @jlhawn 

I am working on a change for backing up the contents of a mount point (e.g. /run) into a tar stream (Premount), and unpacking the tarstream back once the mounting is done (Postmount). This will help us examine the contents of the image,

@rhatdan was already working on this change, and I am continuing on his efforts.
https://github.com/docker/docker/pull/8478

We are stuck in a strange problem where we are not able to share channels between docker and libcontainer.
I did a small POC in golang, and it works fine if I need to share channels between 2 different packages to synchronize. Can you help us on why it is not working in this particular case {docker: libcontainer}

Below is a small POC to elaborate on what I am trying to do.

Shishir
