### PR TITLE
Enable docker daemon cross-building for ARM and i386

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,23 +80,6 @@ ENV PATH /go/bin:/usr/local/go/bin:$PATH
 ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
 RUN cd /usr/local/go/src && ./make.bash --no-clean 2>&1
 
-# Compile Go for cross compilation
-ENV DOCKER_CROSSPLATFORMS \
-	linux/386 linux/arm \
-	darwin/amd64 darwin/386 \
-	freebsd/amd64 freebsd/386 freebsd/arm \
-	windows/amd64 windows/386
-
-# (set an explicit GOARM of 5 for maximum compatibility)
-ENV GOARM 5
-RUN cd /usr/local/go/src \
-	&& set -x \
-	&& for platform in $DOCKER_CROSSPLATFORMS; do \
-		GOOS=${platform%/*} \
-		GOARCH=${platform##*/} \
-			./make.bash --no-clean 2>&1; \
-	done
-
 # We still support compiling with older Go, so need to grab older "gofmt"
 ENV GOFMT_VERSION 1.3.3
 RUN curl -sSL https://storage.googleapis.com/golang/go${GOFMT_VERSION}.$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C /go/bin -xz --strip-components=2 go/bin/gofmt

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,0 +1,83 @@
+# This file describes the standard way to cross building Docker, using docker
+#
+# Usage:
+#
+# # Assemble the full dev environment. This is slow the first time.
+# head -n -2 Dockerfile > .DockerfileCross.swp
+# cat Dockerfile.cross >> .DockerfileCross.swp
+# tail -n 2 Dockerfile >> .DockerfileCross.swp
+# docker build -t dockercross -f DockerfileCross.swp
+#
+# # Mount your source in an interactive container for quick testing:
+# docker run -v `pwd`:/go/src/github.com/docker/docker --privileged -i -t dockercross bash
+#
+
+MAINTAINER Praneeth Bodduluri <lifeeth@resin.io>
+
+# Packaged dependencies
+RUN apt-get install -y \
+	bison \
+	flex \
+	libc6-dev-armel-armhf-cross \
+	gcc-arm-linux-gnueabi \
+	gcc-multilib \
+	--no-install-recommends
+
+# Compile and install lvm for linux/arm and linux/i386
+RUN cd /usr/local/lvm2 \
+	&& make clean && export ac_cv_func_malloc_0_nonnull=yes \
+	&& ./configure --enable-static_link --host=arm-linux-gnueabi --prefix=/usr/arm-linux-gnueabi/ \
+	&& make device-mapper \
+	&& make install_device-mapper
+RUN cd /usr/local/lvm2 \
+	&& make clean && export ac_cv_func_malloc_0_nonnull=yes \
+	&& ./configure --build=i686-pc-linux-gnu "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32" --prefix=/usr/lib32/ --enable-static_link \
+	&& make device-mapper \
+	&& make install_device-mapper
+
+# Compile and install sqlite3 for linux/arm and linux/i386
+ENV SQLITE3_VERSION 3080803
+RUN mkdir -p /usr/src/sqlite3 \
+	&& curl -sSL http://www.sqlite.org/2015/sqlite-autoconf-${SQLITE3_VERSION}.tar.gz | tar -v -C /usr/src/sqlite3 -xz --strip-components=1
+RUN cd /usr/src/sqlite3 \
+	&& ./configure --host=arm-linux-gnueabi --prefix=/usr/arm-linux-gnueabi/ \
+	&& make \
+	&& make install
+RUN cd /usr/src/sqlite3 \
+	&& make clean && ./configure --build=i686-pc-linux-gnu "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32" --prefix=/usr/lib32/ \
+	&& make \
+	&& make install
+
+# Compile and install libapparmor for linux/arm and linux/i386
+ENV LIBAPPARMOR_VERSION 2.9
+ENV LIBAPPARMOR_PATCH 1
+RUN mkdir -p /usr/src/apparmor \
+	&& curl -sSL https://launchpad.net/apparmor/${LIBAPPARMOR_VERSION}/${LIBAPPARMOR_VERSION}.${LIBAPPARMOR_PATCH}/+download/apparmor-${LIBAPPARMOR_VERSION}.${LIBAPPARMOR_PATCH}.tar.gz | tar -v -C /usr/src/apparmor -xz --strip-components=1
+RUN cd /usr/src/apparmor/libraries/libapparmor \
+	&& ./configure --host=arm-linux-gnueabi --prefix=/usr/arm-linux-gnueabi/ \
+	&& make \
+	&& make install
+RUN cd /usr/src/apparmor/libraries/libapparmor \
+	&& make clean && ./configure --build=i686-pc-linux-gnu "CFLAGS=-m32" "CXXFLAGS=-m32" "LDFLAGS=-m32" --prefix=/usr/lib32/ \
+	&& make \
+	&& make install
+
+# Compile Go for cross compilation
+ENV DOCKER_CROSSPLATFORMS \
+	linux/386 linux/arm \
+	darwin/amd64 darwin/386 \
+	freebsd/amd64 freebsd/386 freebsd/arm \
+	windows/amd64 windows/386
+
+# (set an explicit GOARM of 5 for maximum compatibility)
+ENV GOARM 5
+RUN cd /usr/local/go/src \
+	&& set -x \
+	&& for platform in $DOCKER_CROSSPLATFORMS; do \
+		GOOS=${platform%/*} \
+		GOARCH=${platform##*/} \
+			./make.bash --no-clean 2>&1; \
+	done
+
+# Set an explicit BUILD_CROSS variable so that the hack/make.sh cross uses this specific paths set in this Dockerfile for C libraries
+ENV BUILD_CROSS 1

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -9,6 +9,13 @@ daemonSupporting=(
 	[linux/amd64]=1
 )
 
+if [ -n "$BUILD_CROSS" ]; then
+
+	daemonSupporting[linux/arm]=1
+	daemonSupporting[linux/386]=1
+
+fi
+
 # if we have our linux/amd64 version compiled, let's symlink it in
 if [ -x "$DEST/../binary/docker-$VERSION" ]; then
 	mkdir -p "$DEST/linux/amd64"
@@ -27,6 +34,23 @@ for platform in $DOCKER_CROSSPLATFORMS; do
 		if [ -z "${daemonSupporting[$platform]}" ]; then
 			export LDFLAGS_STATIC_DOCKER="" # we just need a simple client for these platforms
 			export BUILDFLAGS=( "${ORIG_BUILDFLAGS[@]/ daemon/}" ) # remove the "daemon" build tag from platforms that aren't supported
+		fi
+		if [ -n "$BUILD_CROSS" ]; then
+			if [ $GOARCH = "arm" ] && [ $GOOS = "linux" ]
+			then
+				export CC=arm-linux-gnueabi-gcc
+				export LD_FLAGS="-extld=arm-linux-gnueabi-gcc"
+				export CGO_ENABLED=1
+				export LIBRARY_PATH=$LIBRARY_PATH:/usr/arm-linux-gnueabi/lib
+			fi
+			if [ $GOARCH = "386" ] && [ $GOOS = "linux" ]
+			then
+				export CFLAGS="-m32"
+				export CXXFLAGS="-m32"
+				export LD_FLAGS="-m32"
+				export CGO_ENABLED=1
+				export LIBRARY_PATH=$LIBRARY_PATH:/usr/lib32/lib
+			fi
 		fi
 		source "$(dirname "$BASH_SOURCE")/binary" "$DEST/$platform"
 	)


### PR DESCRIPTION
This commit does the following:
1. Separates out the cross-building parts of env Dockerfile into Dockerfile.cross
2. Enables daemon building for ARM and i386 on Linux.

Signed-off-by: Praneeth Bodduluri lifeeth@gmail.com
