### PR TITLE
Remove leading spaces of username when login

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -344,6 +344,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	if username == "" {
 		promptDefault("Username", authconfig.Username)
 		username = readInput(cli.in, cli.out)
+		username = strings.Trim(username, " ")
 		if username == "" {
 			username = authconfig.Username
 		}


### PR DESCRIPTION
When we run `docker login` we will be asked to input our username.

Prior to this PR, "userA" and " userA" will be considered as two
diferrent user, which is not right.

Signed-off-by: Hu Keping hukeping@huawei.com
