### PR TITLE
Fix builder when num of RUN args is 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,8 @@ RUN ln -sfv $PWD/.bashrc ~/.bashrc
 # Get useful and necessary Hub images so we can "docker load" locally instead of pulling
 COPY contrib/download-frozen-image.sh /go/src/github.com/docker/docker/contrib/
 RUN ./contrib/download-frozen-image.sh /docker-frozen-images \
-	busybox:latest@4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125
+	busybox:latest@4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125 \
+	hello-world:latest@e45a5af57b00862e5ef5782a9925979a02ba2b12dff832fd0991335f4a11e5c5
 # see also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
 # Install man page generator

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -213,8 +213,8 @@ func run(b *Builder, args []string, attributes map[string]bool, original string)
 
 	args = handleJsonArgs(args, attributes)
 
-	if len(args) == 1 {
-		args = append([]string{"/bin/sh", "-c"}, args[0])
+	if !attributes["json"] {
+		args = append([]string{"/bin/sh", "-c"}, args...)
 	}
 
 	runCmd := flag.NewFlagSet("run", flag.ContinueOnError)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5227,3 +5227,30 @@ func TestBuildNotVerbose(t *testing.T) {
 
 	logDone("build - not verbose")
 }
+
+func TestBuildRUNoneJSON(t *testing.T) {
+	name := "testbuildrunonejson"
+
+	defer deleteAllContainers()
+	defer deleteImages(name)
+
+	ctx, err := fakeContext(`FROM hello-world:latest
+RUN [ "/hello" ]`, map[string]string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ctx.Close()
+
+	buildCmd := exec.Command(dockerBinary, "build", "--no-cache", "-t", name, ".")
+	buildCmd.Dir = ctx.Dir
+	out, _, err := runCommandWithOutput(buildCmd)
+	if err != nil {
+		t.Fatalf("failed to build the image: %s, %v", out, err)
+	}
+
+	if !strings.Contains(out, "Hello from Docker") {
+		t.Fatalf("bad output: %s", out)
+	}
+
+	logDone("build - RUN with one JSON arg")
+}

--- a/project/make/.ensure-frozen-images
+++ b/project/make/.ensure-frozen-images
@@ -4,6 +4,7 @@ set -e
 # this list should match roughly what's in the Dockerfile (minus the explicit image IDs, of course)
 images=(
 	busybox:latest
+	hello-world:latest
 )
 
 if ! docker inspect "${images[@]}" &> /dev/null; then


### PR DESCRIPTION
FROM scratch
ADD echo /
RUN [ "echo" ]

will die with
  exec: "/bin/sh": stat /bin/sh: no such file or directory

Signed-off-by: Doug Davis dug@us.ibm.com
