### PR TITLE
cleanup: simplify parser_test

### DIFF
--- a/builder/parser/parser_test.go
+++ b/builder/parser/parser_test.go
@@ -11,7 +11,7 @@ import (
 const testDir = "testfiles"
 const negativeTestDir = "testfiles-negative"
 
-func getDirs(t *testing.T, dir string) []os.FileInfo {
+func getDirs(t *testing.T, dir string) []string {
 	f, err := os.Open(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -19,7 +19,7 @@ func getDirs(t *testing.T, dir string) []os.FileInfo {
 
 	defer f.Close()
 
-	dirs, err := f.Readdir(0)
+	dirs, err := f.Readdirnames(0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -29,16 +29,16 @@ func getDirs(t *testing.T, dir string) []os.FileInfo {
 
 func TestTestNegative(t *testing.T) {
 	for _, dir := range getDirs(t, negativeTestDir) {
-		dockerfile := filepath.Join(negativeTestDir, dir.Name(), "Dockerfile")
+		dockerfile := filepath.Join(negativeTestDir, dir, "Dockerfile")
 
 		df, err := os.Open(dockerfile)
 		if err != nil {
-			t.Fatalf("Dockerfile missing for %s: %s", dir.Name(), err.Error())
+			t.Fatalf("Dockerfile missing for %s: %s", dir, err.Error())
 		}
 
 		_, err = Parse(df)
 		if err == nil {
-			t.Fatalf("No error parsing broken dockerfile for %s", dir.Name())
+			t.Fatalf("No error parsing broken dockerfile for %s", dir)
 		}
 
 		df.Close()
@@ -47,29 +47,29 @@ func TestTestNegative(t *testing.T) {
 
 func TestTestData(t *testing.T) {
 	for _, dir := range getDirs(t, testDir) {
-		dockerfile := filepath.Join(testDir, dir.Name(), "Dockerfile")
-		resultfile := filepath.Join(testDir, dir.Name(), "result")
+		dockerfile := filepath.Join(testDir, dir, "Dockerfile")
+		resultfile := filepath.Join(testDir, dir, "result")
 
 		df, err := os.Open(dockerfile)
 		if err != nil {
-			t.Fatalf("Dockerfile missing for %s: %s", dir.Name(), err.Error())
+			t.Fatalf("Dockerfile missing for %s: %s", dir, err.Error())
 		}
 		defer df.Close()
 
 		ast, err := Parse(df)
 		if err != nil {
-			t.Fatalf("Error parsing %s's dockerfile: %s", dir.Name(), err.Error())
+			t.Fatalf("Error parsing %s's dockerfile: %s", dir, err.Error())
 		}
 
 		content, err := ioutil.ReadFile(resultfile)
 		if err != nil {
-			t.Fatalf("Error reading %s's result file: %s", dir.Name(), err.Error())
+			t.Fatalf("Error reading %s's result file: %s", dir, err.Error())
 		}
 
 		if ast.Dump()+"\n" != string(content) {
 			fmt.Fprintln(os.Stderr, "Result:\n"+ast.Dump())
 			fmt.Fprintln(os.Stderr, "Expected:\n"+string(content))
-			t.Fatalf("%s: AST dump of dockerfile does not match result", dir.Name())
+			t.Fatalf("%s: AST dump of dockerfile does not match result", dir)
 		}
 	}
 }


### PR DESCRIPTION
parser_test only needed the directory-names for the tests to run.

This replaces `f.Readdir()` with `f.Readdirnames()` to only return the names.
