### PR TITLE
Use server.URL() instead of server.URL

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -686,7 +686,7 @@ func TestBuildLastModified(t *testing.T) {
 ADD %s/file /
 RUN ls -le /file`
 
-	dockerfile := fmt.Sprintf(dFmt, server.URL)
+	dockerfile := fmt.Sprintf(dFmt, server.URL())
 
 	if _, out, err = buildImageWithOut(name, dockerfile, false); err != nil {
 		t.Fatal(err)
@@ -721,7 +721,7 @@ RUN ls -le /file`
 	}
 	defer server.Close()
 
-	dockerfile = fmt.Sprintf(dFmt, server.URL)
+	dockerfile = fmt.Sprintf(dFmt, server.URL())
 
 	if _, out2, err = buildImageWithOut(name, dockerfile, false); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Old way now returns the go type instead of the value
