### PR TITLE
Enable v2 default push

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -74,7 +74,7 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 		logName = utils.ImageReference(logName, tag)
 	}
 
-	if len(repoInfo.Index.Mirrors) == 0 && ((repoInfo.Official && repoInfo.Index.Official) || endpoint.Version == registry.APIVersion2) {
+	if len(repoInfo.Index.Mirrors) == 0 && (repoInfo.Index.Official || endpoint.Version == registry.APIVersion2) {
 		if repoInfo.Official {
 			j := job.Eng.Job("trust_update_base")
 			if err = j.Run(); err != nil {

--- a/graph/push.go
+++ b/graph/push.go
@@ -539,7 +539,7 @@ func (s *TagStore) CmdPush(job *engine.Job) engine.Status {
 		return job.Errorf("Repository does not exist: %s", repoInfo.LocalName)
 	}
 
-	if endpoint.Version == registry.APIVersion2 {
+	if repoInfo.Index.Official || endpoint.Version == registry.APIVersion2 {
 		err := s.pushV2Repository(r, localRepo, job.Stdout, repoInfo, tag, sf)
 		if err == nil {
 			return engine.StatusOK


### PR DESCRIPTION
When pushing to the official registry, v2 push will be attempted first. If the v2 endpoint is unavailable, a push to v1 will occur. If a v2 push is started and failed, the push operation will fail. Pulling non-official images the official v2 registry is also enabled to pull the newly push images. When a pull of a v2 image fails, v1 will always be attempted.
