### PR TITLE
feature: add option for changing docker daemon cpu shares

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	TrustKeyPath                string
 	Labels                      []string
 	Ulimits                     map[string]*ulimit.Ulimit
+	CpuShares                   int64
 }
 
 // InstallFlags adds command-line options to the top-level flag parser for
@@ -73,6 +74,7 @@ func (config *Config) InstallFlags() {
 	flag.StringVar(&config.SocketGroup, []string{"G", "-group"}, "docker", "Group for the unix socket")
 	flag.BoolVar(&config.EnableCors, []string{"#api-enable-cors", "#-api-enable-cors"}, false, "Enable CORS headers in the remote API, this is deprecated by --api-cors-header")
 	flag.StringVar(&config.CorsHeaders, []string{"-api-cors-header"}, "", "Set CORS headers in the remote API")
+	flag.Int64Var(&config.CpuShares, []string{"-daemon-cpu-shares"}, 1024, "Set cpu shares for docker daemon")
 	opts.IPVar(&config.DefaultIp, []string{"#ip", "-ip"}, "0.0.0.0", "Default IP when binding container ports")
 	opts.ListVar(&config.GraphOptions, []string{"-storage-opt"}, "Set storage driver options")
 	// FIXME: why the inconsistency between "hosts" and "sockets"?

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -44,6 +44,8 @@ import (
 	"github.com/docker/docker/trust"
 	"github.com/docker/docker/utils"
 	"github.com/docker/docker/volumes"
+	"github.com/docker/libcontainer/cgroups"
+	"github.com/docker/libcontainer/cgroups/fs"
 
 	"github.com/go-fsnotify/fsnotify"
 )
@@ -802,6 +804,15 @@ func NewDaemon(config *Config, eng *engine.Engine) (*Daemon, error) {
 }
 
 func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error) {
+	log.Infof("cpu shares for daemon and all containers are %d", config.CpuShares)
+	cg := &cgroups.Cgroup{
+		Name:            "docker",
+		Parent:          "/",
+		CpuShares:       config.CpuShares,
+		AllowAllDevices: true,
+	}
+	fs.Apply(cg, os.Getpid())
+
 	if config.Mtu == 0 {
 		config.Mtu = getDefaultNetworkMtu()
 	}


### PR DESCRIPTION
add Cgroup support for changing docker daemon cpu shares, this will
also restrict cpu usage of all the containers.

two reasons why this option is necessary:
1. docker daemon SHOULD belong to "docker" cgroup logically, not the
   root cgroup as the current version does, and we should supply the capability
   to restrict the docker daemon resources.
2. now we can restrict the cpu shares and cpuset for each container,
   but we can't restrict sum of all the containers. To restrict the total
   usage of all running containers is useful because we can enable docker
   containers can get enough but not too much resource, including cpu,
   memory etc.

this patch will start Cgroup support for docker daemon from cpu-shares.

If this is OK, I'll start to add test cases.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
