### PR TITLE
integ-cli: use httpserver container for fakeGIT

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -382,7 +382,7 @@ func TestBuildApiLowerDockerfile(t *testing.T) {
 	git, err := fakeGIT("repo", map[string]string{
 		"dockerfile": `FROM busybox
 RUN echo from dockerfile`,
-	})
+	}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -407,7 +407,7 @@ func TestBuildApiBuildGitWithF(t *testing.T) {
 RUN echo from baz`,
 		"Dockerfile": `FROM busybox
 RUN echo from Dockerfile`,
-	})
+	}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -428,12 +428,13 @@ RUN echo from Dockerfile`,
 }
 
 func TestBuildApiDoubleDockerfile(t *testing.T) {
+	testRequires(t, UnixCli) // dockerfile overwrites Dockerfile on Windows
 	git, err := fakeGIT("repo", map[string]string{
 		"Dockerfile": `FROM busybox
 RUN echo from Dockerfile`,
 		"dockerfile": `FROM busybox
 RUN echo from dockerfile`,
-	})
+	}, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -3940,7 +3940,7 @@ RUN cat /existing-directory-trailing-slash/test/foo | grep Hi`
 		if err := ioutil.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte(dockerfile), 0644); err != nil {
 			t.Fatalf("failed to open destination dockerfile: %v", err)
 		}
-		return &FakeContext{Dir: tmpDir}
+		return fakeContextFromDir(tmpDir)
 	}()
 	defer ctx.Close()
 
@@ -3991,7 +3991,7 @@ func TestBuildAddTarXz(t *testing.T) {
 		if err := ioutil.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte(dockerfile), 0644); err != nil {
 			t.Fatalf("failed to open destination dockerfile: %v", err)
 		}
-		return &FakeContext{Dir: tmpDir}
+		return fakeContextFromDir(tmpDir)
 	}()
 
 	defer ctx.Close()
@@ -4051,7 +4051,7 @@ func TestBuildAddTarXzGz(t *testing.T) {
 		if err := ioutil.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte(dockerfile), 0644); err != nil {
 			t.Fatalf("failed to open destination dockerfile: %v", err)
 		}
-		return &FakeContext{Dir: tmpDir}
+		return fakeContextFromDir(tmpDir)
 	}()
 
 	defer ctx.Close()
@@ -4072,7 +4072,7 @@ func TestBuildFromGIT(t *testing.T) {
 					RUN [ -f /first ]
 					MAINTAINER docker`,
 		"first": "test git data",
-	})
+	}, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4563,7 +4563,7 @@ func TestBuildSymlinkBreakout(t *testing.T) {
 	})
 	w.Close()
 	f.Close()
-	if _, err := buildImageFromContext(name, &FakeContext{Dir: ctx}, false); err != nil {
+	if _, err := buildImageFromContext(name, fakeContextFromDir(ctx), false); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Lstat(filepath.Join(tmpdir, "inject")); err == nil {


### PR DESCRIPTION
This change enables `fakeGIT()` to use the new `fakeStorage()` server (#10893)
which is automatically starting a container on the remote test daemon machine
using the git repo directory.

Fixes the following tests:
- `TestBuildApiLowerDockerfile`
- `TestBuildApiBuildGitWithF`
- `TestBuildApiDoubleDockerfile` (skipped on windows: NTFS case-insensitive)
- `TestBuildWithGIT` (requires local http server)

These tests are currently failing because we're starting the fakeGIT server on
the same host with the CLI; not the test daemon.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
