### PR TITLE
docs: --api-enable-cors is deprecated,updated docs description

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -188,7 +188,6 @@ __docker_signals() {
 
 _docker_docker() {
 	local boolean_options="
-		--api-enable-cors
 		--daemon -d
 		--debug -D
 		--help -h
@@ -972,6 +971,7 @@ _docker() {
 	)
 
 	local main_options_with_args="
+		--api-cors-header
 		--bip
 		--bridge -b
 		--default-ulimit

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -43,7 +43,7 @@ function __fish_print_docker_repositories --description 'Print a list of docker 
 end
 
 # common options
-complete -c docker -f -n '__fish_docker_no_subcommand' -l api-enable-cors -d 'Enable CORS headers in the remote API'
+complete -c docker -f -n '__fish_docker_no_subcommand' -l api-cors-header -d "Set CORS headers in the remote API. Default is cors disabled"
 complete -c docker -f -n '__fish_docker_no_subcommand' -s b -l bridge -d 'Attach containers to a pre-existing network bridge'
 complete -c docker -f -n '__fish_docker_no_subcommand' -l bip -d "Use this CIDR notation address for the network bridge's IP, not compatible with -b"
 complete -c docker -f -n '__fish_docker_no_subcommand' -s D -l debug -d 'Enable debug mode'

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -34,9 +34,6 @@ unix://[/path/to/socket] to use.
    The socket(s) to bind to in daemon mode specified using one or more
    tcp://host:port, unix:///path/to/socket, fd://* or fd://socketfd.
 
-**--api-enable-cors**=*true*|*false*
-  Enable CORS headers in the remote API. Default is false.
-
 **--api-cors-header**=""
   Set CORS headers in the remote API. Default is cors disabled. Give urls like "http://foo, http://bar, ...". Give "*" to allow all.
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -74,7 +74,6 @@ expect an integer, and they can only be specified once.
     A self-sufficient runtime for linux containers.
 
     Options:
-      --api-enable-cors=false                Enable CORS headers in the remote API
       --api-cors-header=""                   Set CORS headers in the remote API
       -b, --bridge=""                        Attach containers to a network bridge
       --bip=""                               Specify network bridge IP


### PR DESCRIPTION
--api-enable-cors is deprecated, so we updated docs description.

1.start daemon:
mabin@mabin-PC:~/work/osc$ sudo docker -d -s btrfs --api-enable-cors=true
Warning: '--api-enable-cors' is deprecated, it will be removed soon. See usage.
.....

2.show docker usage, no '--api-enable-cors' usage info:
mabin@mabin-PC:~/work/osc$ sudo docker --help
Usage: docker [OPTIONS] COMMAND [arg...]

A self-sufficient runtime for linux containers.

Options:
  --api-cors-header=                   Set CORS headers in the remote API
  -b, --bridge=                        Attach containers to a network bridge
  --bip=                               Specify network bridge IP
  -D, --debug=false                    Enable debug mode
  -d, --daemon=false                   Enable daemon mode
  --default-ulimit=[]                  Set default ulimits for containers
  --dns=[]                             DNS server to use
  --dns-search=[]                      DNS search domains to use
  -e, --exec-driver=native             Exec driver to use
  --fixed-cidr=                        IPv4 subnet for fixed IPs
  --fixed-cidr-v6=                     IPv6 subnet for fixed IPs
  -G, --group=docker                   Group for the unix socket
  -g, --graph=/var/lib/docker          Root of the Docker runtime
  -H, --host=[]                        Daemon socket(s) to connect to
  -h, --help=false                     Print usage
  --icc=true                           Enable inter-container communication
  --insecure-registry=[]               Enable insecure registry communication
  --ip=0.0.0.0                         Default IP when binding container ports
  --ip-forward=true                    Enable net.ipv4.ip_forward
  --ip-masq=true                       Enable IP masquerading
  --iptables=true                      Enable addition of iptables rules
  --ipv6=false                         Enable IPv6 networking
  -l, --log-level=info                 Set the logging level
  --label=[]                           Set key=value labels to the daemon
  --mtu=0                              Set the containers network MTU
  -p, --pidfile=/var/run/docker.pid    Path to use for daemon PID file
  --registry-mirror=[]                 Preferred Docker registry mirror
  -s, --storage-driver=                Storage driver to use
  --selinux-enabled=false              Enable selinux support
  --storage-opt=[]                     Set storage driver options
  --tls=false                          Use TLS; implied by --tlsverify
  --tlscacert=~/.docker/ca.pem         Trust certs signed only by this CA
  --tlscert=~/.docker/cert.pem         Path to TLS certificate file
  --tlskey=~/.docker/key.pem           Path to TLS key file
  --tlsverify=false                    Use TLS and verify the remote
  -v, --version=false                  Print version information and quit
.....

3.my docker info:
mabin@mabin-PC:~/work/osc/pr/docker$ sudo docker -v
Docker version 1.5.0-dev, build c5af44e-dirty

mabin@mabin-PC:~/work/osc/pr/docker$ sudo docker info
Containers: 2
Images: 107
Storage Driver: btrfs
Execution Driver: native-0.2
Kernel Version: 3.13.0-46-generic
Operating System: Ubuntu 14.04 LTS
CPUs: 4
Total Memory: 3.666 GiB
Name: mabin-PC
ID: JRLZ:LAQV:CT2Z:WLEF:CCEB:J24M:HY75:GBOK:Y3A5:6Y2B:OLM3:CKXZ
