### PR TITLE
Fix error from daemon no such image even when the image exist

### DIFF
--- a/api/client/create.go
+++ b/api/client/create.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/graph"
@@ -94,7 +95,7 @@ func (cli *DockerCli) createContainer(config *runconfig.Config, hostConfig *runc
 	//create the container
 	stream, statusCode, err := cli.call("POST", "/containers/create?"+containerValues.Encode(), mergedConfig, nil)
 	//if image not found try to pull it
-	if statusCode == 404 {
+	if statusCode == 404 && strings.Contains(err.Error(), config.Image) {
 		repo, tag := parsers.ParseRepositoryTag(config.Image)
 		if tag == "" {
 			tag = graph.DEFAULTTAG

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -166,7 +166,7 @@ func from(b *Builder, args []string, attributes map[string]bool, original string
 		}
 	}
 	if err != nil {
-		if b.Daemon.Graph().IsNotExist(err) {
+		if b.Daemon.Graph().IsNotExist(err, name) {
 			image, err = b.pullImage(name)
 		}
 

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -46,7 +46,7 @@ func (daemon *Daemon) ContainerCreate(job *engine.Job) error {
 
 	container, buildWarnings, err := daemon.Create(config, hostConfig, name)
 	if err != nil {
-		if daemon.Graph().IsNotExist(err) {
+		if daemon.Graph().IsNotExist(err, config.Image) {
 			_, tag := parsers.ParseRepositoryTag(config.Image)
 			if tag == "" {
 				tag = graph.DEFAULTTAG

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -138,7 +138,7 @@ func (daemon *Daemon) canDeleteImage(imgID string, force bool) error {
 	for _, container := range daemon.List() {
 		parent, err := daemon.Repositories().LookupImage(container.ImageID)
 		if err != nil {
-			if daemon.Graph().IsNotExist(err) {
+			if daemon.Graph().IsNotExist(err, container.ImageID) {
 				return nil
 			}
 			return err

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -74,8 +74,8 @@ func (graph *Graph) restore() error {
 
 // FIXME: Implement error subclass instead of looking at the error text
 // Note: This is the way golang implements os.IsNotExists on Plan9
-func (graph *Graph) IsNotExist(err error) bool {
-	return err != nil && (strings.Contains(strings.ToLower(err.Error()), "does not exist") || strings.Contains(strings.ToLower(err.Error()), "no such"))
+func (graph *Graph) IsNotExist(err error, id string) bool {
+	return err != nil && (strings.Contains(strings.ToLower(err.Error()), "does not exist") || strings.Contains(strings.ToLower(err.Error()), "no such")) && strings.Contains(err.Error(), id)
 }
 
 // Exists returns true if an image is registered at the given id.

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2990,6 +2990,17 @@ func TestRunModeIpcContainer(t *testing.T) {
 	logDone("run - ipc container mode")
 }
 
+func TestRunModeIpcContainerNotExists(t *testing.T) {
+	defer deleteAllContainers()
+	cmd := exec.Command(dockerBinary, "run", "-d", "--ipc", "container:abcd1234", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if !strings.Contains(out, "abcd1234") || err == nil {
+		t.Fatalf("run IPC from a non exists container should with correct error out")
+	}
+
+	logDone("run - ipc from a non exists container failed with correct error out")
+}
+
 func TestContainerNetworkMode(t *testing.T) {
 	defer deleteAllContainers()
 	testRequires(t, SameHostDaemon)


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
There is a bug when `docker run  --ipc` use a container is not exists.
Reproduce:
`docker run -ti --rm --ipc=container:test busybox`   the `test` is a not exist container
the output is

<pre><code>Unable to find image 'busybox:latest' locally
latest: Pulling from busybox
511136ea3c5a: Already exists
df7546f9f060: Already exists
ea13149945cb: Already exists
4986bf8c1536: Already exists
Status: Image is up to date for busybox:latest
FATA[0005] Error response from daemon: No such image: busybox (tag: latest)</code></pre>

This is completely wrong, image `busybox` is  absolutely exist locally

<pre><code>[l00284783@localhost docker]$ docker images busybox
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
busybox             latest              4986bf8c1536        9 weeks ago         2.433 MB
</code></pre>


The correct output should be `No such id: test`

The bug is because https://github.com/docker/docker/blob/master/daemon/create.go#L48  will call https://github.com/docker/docker/blob/master/daemon/create.go#L133  `GenerateSecurityOpt(ipcMode runconfig.IpcMode, pidMode runconfig.PidMode)` and this function will check if the ipc share container is exists or not, and if not exists, it will return a error `no such id: test` , with this error message https://github.com/docker/docker/blob/master/daemon/create.go#L50 will think it was a no such image error and then pull the image.

I think this PR will fix this

ping @crosbymichael  @jfrazelle  @estesp  @cpuguy83 
