### PR TITLE
If $HOME is not set, return homedir from /etc/passwd

### DIFF
--- a/pkg/homedir/homedir.go
+++ b/pkg/homedir/homedir.go
@@ -3,6 +3,8 @@ package homedir
 import (
 	"os"
 	"runtime"
+
+	"github.com/docker/libcontainer/user"
 )
 
 // Key returns the env var name for the user's home dir based on
@@ -18,7 +20,13 @@ func Key() string {
 // environment variables depending on the target operating system.
 // Returned path should be used with "path/filepath" to form new paths.
 func Get() string {
-	return os.Getenv(Key())
+	home := os.Getenv(Key())
+	if home == "" && runtime.GOOS != "windows" {
+		if u, err := user.CurrentUser(); err == nil {
+			return u.Home
+		}
+	}
+	return home
 }
 
 // GetShortcutString returns the string that is shortcut to user's home directory


### PR DESCRIPTION
Running docker within a systemd unit file, the $HOME environment variable is not set.  This causes docker to attempt to write the .docker directory to /.  In a Atomic platform the / is immutable, so docker fails.

This patch will look up the users homedir if the $HOME environment variable is not set.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
