### PR TITLE
Initial gccgo build script, requires host to contain gccgo 5.0

### DIFF
--- a/hack/make/.dockerinit-gccgo
+++ b/hack/make/.dockerinit-gccgo
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+IAMSTATIC="true"
+source "$(dirname "$BASH_SOURCE")/.go-autogen"
+
+go build --compiler=gccgo \
+	-o "$DEST/dockerinit-$VERSION" \
+	"${BUILDFLAGS[@]}" \
+	--gccgoflags "
+		-g
+		-Wl,--no-export-dynamic
+		$EXTLDFLAGS_STATIC_DOCKER
+	" \
+	./dockerinit
+
+echo "Created binary: $DEST/dockerinit-$VERSION"
+ln -sf "dockerinit-$VERSION" "$DEST/dockerinit"
+
+sha1sum=
+if command -v sha1sum &> /dev/null; then
+	sha1sum=sha1sum
+else
+	echo >&2 'error: cannot find sha1sum command or equivalent'
+	exit 1
+fi
+
+# sha1 our new dockerinit to ensure separate docker and dockerinit always run in a perfect pair compiled for one another
+export DOCKER_INITSHA1="$($sha1sum $DEST/dockerinit-$VERSION | cut -d' ' -f1)"

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -2,7 +2,7 @@
 
 # see test-integration-cli for example usage of this script
 
-export PATH="$DEST/../binary:$DEST/../dynbinary:$PATH"
+export PATH="$DEST/../binary:$DEST/../dynbinary:$DEST/../gccgo:$PATH"
 
 if ! command -v docker &> /dev/null; then
 	echo >&2 'error: binary or dynbinary must be run before .integration-daemon-start'

--- a/hack/make/dyngccgo
+++ b/hack/make/dyngccgo
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e 
+
+DEST=$1
+
+if [ -z "$DOCKER_CLIENTONLY" ]; then
+	source "$(dirname "$BASH_SOURCE")/.dockerinit-gccgo"
+	
+	hash_files "$DEST/dockerinit-$VERSION"
+else
+	# DOCKER_CLIENTONLY must be truthy, so we don't need to bother with dockerinit :)
+	export DOCKER_INITSHA1=""
+fi
+# DOCKER_INITSHA1 is exported so that other bundlescripts can easily access it later without recalculating it
+
+(
+	export IAMSTATIC="false"
+	export EXTLDFLAGS_STATIC_DOCKER=''
+	export LDFLAGS_STATIC_DOCKER=''
+	export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
+	export BUILDFLAGS=( "${BUILDFLAGS[@]/static_build /}" ) # we're not building a "static" binary here
+	source "$(dirname "$BASH_SOURCE")/gccgo"
+)

--- a/hack/make/gccgo
+++ b/hack/make/gccgo
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+DEST=$1
+BINARY_NAME="docker-$VERSION"
+BINARY_EXTENSION="$(binary_extension)"
+BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
+
+source "$(dirname "$BASH_SOURCE")/.go-autogen"
+
+go build --compiler=gccgo \
+	-o "$DEST/$BINARY_FULLNAME" \
+	"${BUILDFLAGS[@]}" \
+	--gccgoflags "
+		-g
+		$EXTLDFLAGS_STATIC_DOCKER
+		-Wl,--no-export-dynamic
+		-ldl
+	" \
+	./docker
+
+
+echo "Created binary: $DEST/$BINARY_FULLNAME"
+ln -sf "$BINARY_FULLNAME" "$DEST/docker$BINARY_EXTENSION"
+
+hash_files "$DEST/$BINARY_FULLNAME"


### PR DESCRIPTION
Addresses #9207
Signed-off-by: Srini Brahmaroutu srbrahma@us.ibm.com

When testing gccgo, you must install or build gccgo 5.0 version that supports go1.4. The following steps can be used to build gccgo.
    Checkout gccgo : svn co -q --revision 219661 svn://gcc.gnu.org/svn/gcc/trunk src
    Run configure : ../src/configure --enable-threads=posix --enable-shared --enable-__cxa_atexit --enable-languages=c,c++,go --enable-secureplt --enable-checking=yes --with-long-double-128 --enable-decimal-float --disable-bootstrap --disable-alsa --disable-multilib --prefix=/usr/local/gccgo
    Build : make; make install 
    Setup : cp go packages into /usr/local/gccgo/src/pkg (cp -R ../src/libgo/go /usr/local/gccgo/src/pkg)
            set path to /usr/local/gccgo/bin
            add libgo into ldconf /usr/local/gccgo/lib64 > /etc/ld.so.conf.d/gccgo.conf ; ldconfig
Before you build the binary, make sure that we have set required environment
    export GOROOT=/usr/local/gccgo
    export PATH=$PATH:/usr/local/gccgo/bin
    export GOPATH=$GOPATH:/root/go/src/github.com/docker/docker/vendor
    export DOCKER_BUILDTAGS='btrfs_noversion'    //anything else your environment require
    export USE_GCCGO=1
    export CGO_ENABLED=1
Build docker binary  
    project/make.sh gccgo 
To run tests locally we may need additional setup like adding users, etc.
