### PR TITLE
Adds 'name' filter to the CLI reference.

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -921,9 +921,11 @@ Using multiple filters will be handled as a *AND*; for example
 container 588a23dac085 *AND* the event type is *start*
 
 Current filters:
- * event
- * image
- * container
+
+* container
+* event
+* image
+* name
 
 #### Examples
 


### PR DESCRIPTION
Also sorts the filter list and fixes the rendering of the bullet list.
Fixes #11309.
