### PR TITLE
print detailed error info for docker pull

### DIFF
--- a/registry/session.go
+++ b/registry/session.go
@@ -281,7 +281,11 @@ func (r *Session) GetRepositoryData(remote string) (*RepositoryData, error) {
 	// TODO: Right now we're ignoring checksums in the response body.
 	// In the future, we need to use them to check image validity.
 	if res.StatusCode != 200 {
-		return nil, utils.NewHTTPRequestError(fmt.Sprintf("HTTP code: %d", res.StatusCode), res)
+		errBody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			log.Debugf("Error reading response body: %s", err)
+		}
+		return nil, utils.NewHTTPRequestError(fmt.Sprintf("Error: Status %d trying to pull repository %s: %q", res.StatusCode, remote, errBody), res)
 	}
 
 	var tokens []string
@@ -510,7 +514,7 @@ func (r *Session) PushImageJSONIndex(remote string, imgList []*ImgData, validate
 		if res.StatusCode != 200 && res.StatusCode != 201 {
 			errBody, err := ioutil.ReadAll(res.Body)
 			if err != nil {
-				return nil, err
+				log.Debugf("Error reading response body: %s", err)
 			}
 			return nil, utils.NewHTTPRequestError(fmt.Sprintf("Error: Status %d trying to push repository %s: %q", res.StatusCode, remote, errBody), res)
 		}
@@ -534,7 +538,7 @@ func (r *Session) PushImageJSONIndex(remote string, imgList []*ImgData, validate
 		if res.StatusCode != 204 {
 			errBody, err := ioutil.ReadAll(res.Body)
 			if err != nil {
-				return nil, err
+				log.Debugf("Error reading response body: %s", err)
 			}
 			return nil, utils.NewHTTPRequestError(fmt.Sprintf("Error: Status %d trying to push checksums %s: %q", res.StatusCode, remote, errBody), res)
 		}


### PR DESCRIPTION
When docker push get response with unknown HTTP status, docker daemon print:
"Error: Status XXX trying to push repository XXX: XXX"
But when docker pull meets response with unknown status code, it gives:
"HTTP code: XXX"

This commit helps docker pull print more detailed error info like push
does, so push and pull can behave consistently when error happens.

We are developing our own private hub, this print is especially helpful because we can
define our own status codes for different error and give users more infos of what's wrong
with their operation. Hope that you can understand and add this in

BTW, I'm not sure how to write the test case, does this also need a test case? 

Signed-off-by: Zhang Wei zhangwei555@huawei.com
