### PR TITLE
Make use of %USERPROFILE% in cli help message

### DIFF
--- a/pkg/mflag/flag.go
+++ b/pkg/mflag/flag.go
@@ -506,15 +506,11 @@ func Set(name, value string) error {
 // otherwise, the default values of all defined flags in the set.
 func (f *FlagSet) PrintDefaults() {
 	writer := tabwriter.NewWriter(f.Out(), 20, 1, 3, ' ', 0)
-	var home string
-	if runtime.GOOS != "windows" {
-		// Only do this on non-windows systems
-		home = homedir.Get()
+	home := homedir.Get()
 
-		// Don't substitute when HOME is /
-		if home == "/" {
-			home = ""
-		}
+	// Don't substitute when HOME is /
+	if runtime.GOOS != "windows" && home == "/" {
+		home = ""
 	}
 	f.VisitAll(func(flag *Flag) {
 		format := "  -%s=%s"


### PR DESCRIPTION
An earlier commit was causing docker windows CLI build to not to pick up
the shorthand form for home directory (`%USERPROFILE%`) shown in when
`docker --help` is executed. 

Example:

```
c:\gopath\src\github.com\docker\docker>docker --help
Usage: docker [OPTIONS] COMMAND [arg...]

A self-sufficient runtime for linux containers.

Options:
[...]
  --tlscacert=%USERPROFILE%\.docker\ca.pem    Trust certs signed only by this CA
  --tlscert=%USERPROFILE%\.docker\cert.pem    Path to TLS certificate file
  --tlskey=%USERPROFILE%\.docker\key.pem      Path to TLS key file
  --tlsverify=false                           Use TLS and verify the remote
  -v, --version=false                         Print version information and quit
```

Fixing this bug and making the if statement concise and clear. This also fixes
the test failure `TestHelpTextVerify` (line >80 char) on windows CI.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @duglin @tiborvass 
