### PR TITLE
Help suffix space

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -93,10 +93,13 @@ func (cli *DockerCli) Subcmd(name, signature, description string, exitOnError bo
 	flags := flag.NewFlagSet(name, errorHandling)
 	flags.Usage = func() {
 		options := ""
-		if flags.FlagCountUndeprecated() > 0 {
-			options = "[OPTIONS] "
+		if signature != "" {
+			signature = " " + signature
 		}
-		fmt.Fprintf(cli.out, "\nUsage: docker %s %s%s\n\n%s\n\n", name, options, signature, description)
+		if flags.FlagCountUndeprecated() > 0 {
+			options = " [OPTIONS]"
+		}
+		fmt.Fprintf(cli.out, "\nUsage: docker %s%s%s\n\n%s\n\n", name, options, signature, description)
 		flags.SetOutput(cli.out)
 		flags.PrintDefaults()
 		os.Exit(0)

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -130,6 +130,11 @@ func TestHelpTextVerify(t *testing.T) {
 				if strings.HasPrefix(line, "  -") && strings.HasSuffix(line, ".") {
 					t.Fatalf("Help for %q should not end with a period: %s", cmd, line)
 				}
+				
+				// Options should not end with a space
+				if strings.HasSuffix(line, " ") {
+					t.Fatalf("Help for %q should not end with a space: %s", cmd, line)
+				}
 			}
 		}
 

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -59,6 +59,11 @@ func TestHelpTextVerify(t *testing.T) {
 				t.Fatalf("Line is too long(%d chars):\n%s", len(line), line)
 			}
 
+			// All lines should not end with a space
+			if strings.HasSuffix(line, " ") {
+				t.Fatalf("Line should not end with a space: %s", line)
+			}
+
 			if scanForHome && strings.Contains(line, `=`+home) {
 				t.Fatalf("Line should use '%q' instead of %q:\n%s", homedir.GetShortcutString(), home, line)
 			}
@@ -131,10 +136,11 @@ func TestHelpTextVerify(t *testing.T) {
 					t.Fatalf("Help for %q should not end with a period: %s", cmd, line)
 				}
 
-				// Options should not end with a space
+				// Options should NOT end with a space
 				if strings.HasSuffix(line, " ") {
 					t.Fatalf("Help for %q should not end with a space: %s", cmd, line)
 				}
+
 			}
 		}
 

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -130,7 +130,7 @@ func TestHelpTextVerify(t *testing.T) {
 				if strings.HasPrefix(line, "  -") && strings.HasSuffix(line, ".") {
 					t.Fatalf("Help for %q should not end with a period: %s", cmd, line)
 				}
-				
+
 				// Options should not end with a space
 				if strings.HasSuffix(line, " ") {
 					t.Fatalf("Help for %q should not end with a space: %s", cmd, line)


### PR DESCRIPTION
 Normalize the log for docker subcommand usage, delete the trailing space at the end of option.
Add checking for for suffix of option in each line of help, to make sure no extra space in it.
