### PR TITLE
Add "Docker" to Reference pull-down for Command Line

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -116,7 +116,7 @@ pages:
 # Reference
 - ['reference/index.md', '**HIDDEN**']
 - ['reference/commandline/index.md', '**HIDDEN**']
-- ['reference/commandline/cli.md', 'Reference', 'Command line']
+- ['reference/commandline/cli.md', 'Reference', 'Docker command line']
 - ['reference/builder.md', 'Reference', 'Dockerfile']
 - ['faq.md', 'Reference', 'FAQ']
 - ['reference/run.md', 'Reference', 'Run Reference']

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -2,7 +2,7 @@ page_title: Command Line Interface
 page_description: Docker's CLI command description and usage
 page_keywords: Docker, Docker documentation, CLI, command line
 
-# Command Line
+# Docker Command Line
 
 {{ include "no-remote-sudo.md" }}
 


### PR DESCRIPTION
A minor thing, but I noticed that the "Reference" drop-down menu just
says "Command line".  This was fine when we just had one command line,
but now there's also 'Compose command line' and I suspect we may add
others later.  We should qualify the Docker one with the word "Docker"
in front

Signed-off-by: Doug Davis dug@us.ibm.com
