### PR TITLE
Remove escaping from TESTFLAGS; it is no longer required

### DIFF
--- a/docs/sources/project/test-and-docs.md
+++ b/docs/sources/project/test-and-docs.md
@@ -170,7 +170,7 @@ You can use the `TESTFLAGS` environment variable to run a single test. The
 flag's value is passed as arguments to the `go test` command. For example, from
 your local host you can run the `TestBuild` test with this command:
 
-        $ TESTFLAGS='-test.run \^TestBuild\$' make test
+        $ TESTFLAGS='-test.run ^TestBuild$' make test
 
 To run the same test inside your Docker development container, you do this:
 


### PR DESCRIPTION
In fact, it doesn't work as the bare `\` backslashes are now preserved
and therefore are not valid regex matches on any test, making it not run
any tests at all.  I assume at some point there was a process in the
pipeline that needed escaping, but on master (for quite a while) this
has not worked.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
