### PR TITLE
integ-cli: Fix clock skew against remote test daemon

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -45,7 +45,7 @@ func TestEventsContainerFailStartDie(t *testing.T) {
 		t.Fatalf("Container run with command blerg should have failed, but it did not")
 	}
 
-	eventsCmd = exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", time.Now().Unix()))
+	eventsCmd = exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(t).Unix()))
 	out, _, _ = runCommandWithOutput(eventsCmd)
 	events := strings.Split(out, "\n")
 	if len(events) <= 1 {
@@ -70,7 +70,7 @@ func TestEventsLimit(t *testing.T) {
 	for i := 0; i < 30; i++ {
 		dockerCmd(t, "run", "busybox", "echo", strconv.Itoa(i))
 	}
-	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", time.Now().Unix()))
+	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(t).Unix()))
 	out, _, _ := runCommandWithOutput(eventsCmd)
 	events := strings.Split(out, "\n")
 	nEvents := len(events) - 1
@@ -82,7 +82,7 @@ func TestEventsLimit(t *testing.T) {
 
 func TestEventsContainerEvents(t *testing.T) {
 	dockerCmd(t, "run", "--rm", "busybox", "true")
-	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", time.Now().Unix()))
+	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(t).Unix()))
 	out, exitCode, err := runCommandWithOutput(eventsCmd)
 	if exitCode != 0 || err != nil {
 		t.Fatalf("Failed to get events with exit code %d: %s", exitCode, err)
@@ -125,7 +125,7 @@ func TestEventsImageUntagDelete(t *testing.T) {
 	if err := deleteImages(name); err != nil {
 		t.Fatal(err)
 	}
-	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", time.Now().Unix()))
+	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(t).Unix()))
 	out, exitCode, err := runCommandWithOutput(eventsCmd)
 	if exitCode != 0 || err != nil {
 		t.Fatalf("Failed to get events with exit code %d: %s", exitCode, err)
@@ -148,7 +148,7 @@ func TestEventsImageUntagDelete(t *testing.T) {
 }
 
 func TestEventsImagePull(t *testing.T) {
-	since := time.Now().Unix()
+	since := daemonTime(t).Unix()
 
 	defer deleteImages("hello-world")
 
@@ -159,7 +159,7 @@ func TestEventsImagePull(t *testing.T) {
 
 	eventsCmd := exec.Command(dockerBinary, "events",
 		fmt.Sprintf("--since=%d", since),
-		fmt.Sprintf("--until=%d", time.Now().Unix()))
+		fmt.Sprintf("--until=%d", daemonTime(t).Unix()))
 	out, _, _ := runCommandWithOutput(eventsCmd)
 
 	events := strings.Split(strings.TrimSpace(out), "\n")
@@ -174,7 +174,7 @@ func TestEventsImagePull(t *testing.T) {
 
 func TestEventsImageImport(t *testing.T) {
 	defer deleteAllContainers()
-	since := time.Now().Unix()
+	since := daemonTime(t).Unix()
 
 	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
@@ -193,7 +193,7 @@ func TestEventsImageImport(t *testing.T) {
 
 	eventsCmd := exec.Command(dockerBinary, "events",
 		fmt.Sprintf("--since=%d", since),
-		fmt.Sprintf("--until=%d", time.Now().Unix()))
+		fmt.Sprintf("--until=%d", daemonTime(t).Unix()))
 	out, _, _ = runCommandWithOutput(eventsCmd)
 
 	events := strings.Split(strings.TrimSpace(out), "\n")
@@ -219,7 +219,7 @@ func TestEventsFilters(t *testing.T) {
 		}
 	}
 
-	since := time.Now().Unix()
+	since := daemonTime(t).Unix()
 	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "--rm", "busybox", "true"))
 	if err != nil {
 		t.Fatal(out, err)
@@ -228,13 +228,13 @@ func TestEventsFilters(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", time.Now().Unix()), "--filter", "event=die"))
+	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(t).Unix()), "--filter", "event=die"))
 	if err != nil {
 		t.Fatalf("Failed to get events: %s", err)
 	}
 	parseEvents(out, "die")
 
-	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", time.Now().Unix()), "--filter", "event=die", "--filter", "event=start"))
+	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(t).Unix()), "--filter", "event=die", "--filter", "event=start"))
 	if err != nil {
 		t.Fatalf("Failed to get events: %s", err)
 	}
@@ -250,7 +250,7 @@ func TestEventsFilters(t *testing.T) {
 }
 
 func TestEventsFilterImageName(t *testing.T) {
-	since := time.Now().Unix()
+	since := daemonTime(t).Unix()
 	defer deleteAllContainers()
 
 	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "--name", "container_1", "-d", "busybox", "true"))
@@ -266,7 +266,7 @@ func TestEventsFilterImageName(t *testing.T) {
 	container2 := stripTrailingCharacters(out)
 
 	for _, s := range []string{"busybox", "busybox:latest"} {
-		eventsCmd := exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", time.Now().Unix()), "--filter", fmt.Sprintf("image=%s", s))
+		eventsCmd := exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(t).Unix()), "--filter", fmt.Sprintf("image=%s", s))
 		out, _, err := runCommandWithOutput(eventsCmd)
 		if err != nil {
 			t.Fatalf("Failed to get events, error: %s(%s)", err, out)
@@ -294,7 +294,7 @@ func TestEventsFilterImageName(t *testing.T) {
 }
 
 func TestEventsFilterContainerID(t *testing.T) {
-	since := time.Now().Unix()
+	since := daemonTime(t).Unix()
 	defer deleteAllContainers()
 
 	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "busybox", "true"))
@@ -310,7 +310,7 @@ func TestEventsFilterContainerID(t *testing.T) {
 	container2 := stripTrailingCharacters(out)
 
 	for _, s := range []string{container1, container2, container1[:12], container2[:12]} {
-		eventsCmd := exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", time.Now().Unix()), "--filter", fmt.Sprintf("container=%s", s))
+		eventsCmd := exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(t).Unix()), "--filter", fmt.Sprintf("container=%s", s))
 		out, _, err := runCommandWithOutput(eventsCmd)
 		if err != nil {
 			t.Fatalf("Failed to get events, error: %s(%s)", err, out)
@@ -342,7 +342,7 @@ func TestEventsFilterContainerID(t *testing.T) {
 }
 
 func TestEventsFilterContainerName(t *testing.T) {
-	since := time.Now().Unix()
+	since := daemonTime(t).Unix()
 	defer deleteAllContainers()
 
 	_, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "--name", "container_1", "busybox", "true"))
@@ -356,7 +356,7 @@ func TestEventsFilterContainerName(t *testing.T) {
 	}
 
 	for _, s := range []string{"container_1", "container_2"} {
-		eventsCmd := exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", time.Now().Unix()), "--filter", fmt.Sprintf("container=%s", s))
+		eventsCmd := exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(t).Unix()), "--filter", fmt.Sprintf("container=%s", s))
 		out, _, err := runCommandWithOutput(eventsCmd)
 		if err != nil {
 			t.Fatalf("Failed to get events, error : %s(%s)", err, out)

--- a/integration-cli/docker_cli_events_unix_test.go
+++ b/integration-cli/docker_cli_events_unix_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"testing"
-	"time"
 	"unicode"
 
 	"github.com/kr/pty"
@@ -17,11 +16,8 @@ import (
 
 // #5979
 func TestEventsRedirectStdout(t *testing.T) {
-
-	since := time.Now().Unix()
-
+	since := daemonTime(t).Unix()
 	dockerCmd(t, "run", "busybox", "true")
-
 	defer deleteAllContainers()
 
 	file, err := ioutil.TempFile("", "")
@@ -30,7 +26,7 @@ func TestEventsRedirectStdout(t *testing.T) {
 	}
 	defer os.Remove(file.Name())
 
-	command := fmt.Sprintf("%s events --since=%d --until=%d > %s", dockerBinary, since, time.Now().Unix(), file.Name())
+	command := fmt.Sprintf("%s events --since=%d --until=%d > %s", dockerBinary, since, daemonTime(t).Unix(), file.Name())
 	_, tty, err := pty.Open()
 	if err != nil {
 		t.Fatalf("Could not open pty: %v", err)

--- a/integration-cli/docker_cli_pause_test.go
+++ b/integration-cli/docker_cli_pause_test.go
@@ -5,7 +5,6 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
-	"time"
 )
 
 func TestPause(t *testing.T) {
@@ -28,7 +27,7 @@ func TestPause(t *testing.T) {
 
 	dockerCmd(t, "unpause", name)
 
-	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", time.Now().Unix()))
+	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(t).Unix()))
 	out, _, _ = runCommandWithOutput(eventsCmd)
 	events := strings.Split(out, "\n")
 	if len(events) <= 1 {
@@ -77,7 +76,7 @@ func TestPauseMultipleContainers(t *testing.T) {
 
 	dockerCmd(t, append([]string{"unpause"}, containers...)...)
 
-	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", time.Now().Unix()))
+	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(t).Unix()))
 	out, _, _ = runCommandWithOutput(eventsCmd)
 	events := strings.Split(out, "\n")
 	if len(events) <= len(containers)*3-2 {


### PR DESCRIPTION
This fixes the `docker events`-related tests as they have been
failing due to clock skew between CI machine and test daemon on
some other machine (even 1-2 seconds of diff causes races as
we use local machine time in --since/--until args).

If we're running in same host, we keep using `time.Now()`, otherwise
we read the system time of the daemon from `/info` endpoint, which
is recently added there.

Fixes pretty much all events-related tests on windows CI.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @jfrazelle @duglin @LK4D4 @icecrime 
