### PR TITLE
Publish Windows binaries in release script

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -190,6 +190,13 @@ release_build() {
 		linux)
 			s3Os=Linux
 			;;
+		windows)
+			s3Os=Windows
+			binary+='.exe'
+			if [ "$latestBase" ]; then
+				latestBase+='.exe'
+			fi
+			;;
 		*)
 			echo >&2 "error: can't convert $s3Os to an appropriate value for 'uname -s'"
 			exit 1


### PR DESCRIPTION
Take Windows into account when deploying release binaries to s3.

I tested this locally with the following hack:

```
s3cmd() {
    echo "s3cmd" $*
}
```

See [the output](https://gist.github.com/icecrime/892c227c69cc024ab807) of my test run.

Ping @ahmetalpbalkan @tianon
