### PR TITLE
bugfix: adds a log redirect to the upstart script using $DOCKER_LOGFILE

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -37,7 +37,11 @@ script
 	if [ -f /etc/default/$UPSTART_JOB ]; then
 		. /etc/default/$UPSTART_JOB
 	fi
-	exec "$DOCKER" -d $DOCKER_OPTS
+	if [ -z $DOCKER_LOGFILE ]; then
+		exec "$DOCKER" -d $DOCKER_OPTS
+	else
+		exec "$DOCKER" -d $DOCKER_OPTS >> $DOCKER_LOGFILE 2>&1
+	fi
 end script
 
 # Don't emit "started" event until docker.sock is ready.


### PR DESCRIPTION
that Docker daemon output will be redirected to that file, if the
variable is defined (using the same variable name as is used by the SysV init scripts)
