### PR TITLE
Adds Fred, updates docs LGTMs

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -193,13 +193,18 @@ for each.
 			# They should ask for any editorial change that makes the documentation more
 			# consistent and easier to understand.
 			#
-			# Once documentation is approved, a maintainer should make sure to remove this
+			# Once documentation is approved (see below), a maintainer should make sure to remove this
 			# label and add the next one.
 
 			close = ""
 			2-code-review = "requires more code changes"
 			1-design-review = "raises design concerns"
 			4-merge = "general case"
+			
+		# Docs approval
+		[Rules.review.docs-approval]
+			# Changes and additions to docs must be reviewed and approved (LGTM'd) by a minimum of two docs sub-project maintainers.
+			# If the docs change originates with a docs maintainer, only one additional LGTM is required (since we assume a docs maintainer approves of their own PR). 	
 
 		# Merge
 		[Rules.review.states.4-merge]
@@ -534,6 +539,11 @@ made through a pull request.
 	Name = "Phil Estes"
 	Email = "estesp@linux.vnet.ibm.com"
 	GitHub = "estesp"
+
+	[people.fredlf]
+	Name = "Fred Lifton"
+	Email = "fred.lifton@docker.com"
+	GitHub = "fredlf"
 
 	[people.icecrime]
 	Name = "Arnaud Porterie"


### PR DESCRIPTION
Adds Fred to list of people and clarifies that docs approval requires only two LGTMS (not a "majority" as it was before Mary and Steve were added).

Docker-DCO-1.1-Signed-off-by: Fred Lifton fred.lifton@docker.com (github: fredlf)
