### PR TITLE
Add support for referring to images by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,11 +108,9 @@ RUN go get golang.org/x/tools/cmd/cover
 RUN gem install --no-rdoc --no-ri fpm --version 1.3.2
 
 # Install registry
-# FIXME update registry commit when https://github.com/docker/distribution/pull/211 is merged
-ENV REGISTRY_COMMIT 40273b1d367c3d54997b00faf7ecb1f0a8a4e666
-# FIXME change clone url back to github.com/docker/distribution when https://github.com/docker/distribution/pull/211 is merged
+ENV REGISTRY_COMMIT b4cc5e3ecc2e9f4fa0e95d94c389e1d79e902486
 RUN set -x \
-	&& git clone https://github.com/stevvooe/distribution.git /go/src/github.com/docker/distribution \
+	&& git clone https://github.com/docker/distribution.git /go/src/github.com/docker/distribution \
 	&& (cd /go/src/github.com/docker/distribution && git checkout -q $REGISTRY_COMMIT) \
 	&& GOPATH=/go/src/github.com/docker/distribution/Godeps/_workspace:/go \
 		go build -o /go/bin/registry-v2 github.com/docker/distribution/cmd/registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -108,9 +108,11 @@ RUN go get golang.org/x/tools/cmd/cover
 RUN gem install --no-rdoc --no-ri fpm --version 1.3.2
 
 # Install registry
-ENV REGISTRY_COMMIT c448e0416925a9876d5576e412703c9b8b865e19
+# FIXME update registry commit when https://github.com/docker/distribution/pull/211 is merged
+ENV REGISTRY_COMMIT b4dd565774e076166dc5134976a7ec4682a8a253
+# FIXME change clone url back to github.com/docker/distribution when https://github.com/docker/distribution/pull/211 is merged
 RUN set -x \
-	&& git clone https://github.com/docker/distribution.git /go/src/github.com/docker/distribution \
+	&& git clone https://github.com/stevvooe/distribution.git /go/src/github.com/docker/distribution \
 	&& (cd /go/src/github.com/docker/distribution && git checkout -q $REGISTRY_COMMIT) \
 	&& GOPATH=/go/src/github.com/docker/distribution/Godeps/_workspace:/go \
 		go build -o /go/bin/registry-v2 github.com/docker/distribution/cmd/registry

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ RUN gem install --no-rdoc --no-ri fpm --version 1.3.2
 
 # Install registry
 # FIXME update registry commit when https://github.com/docker/distribution/pull/211 is merged
-ENV REGISTRY_COMMIT b4dd565774e076166dc5134976a7ec4682a8a253
+ENV REGISTRY_COMMIT 40273b1d367c3d54997b00faf7ecb1f0a8a4e666
 # FIXME change clone url back to github.com/docker/distribution when https://github.com/docker/distribution/pull/211 is merged
 RUN set -x \
 	&& git clone https://github.com/stevvooe/distribution.git /go/src/github.com/docker/distribution \

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1516,6 +1516,9 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 			for _, repotag := range out.GetList("RepoTags") {
 				digest := repoDigests[repotag]
 				delete(repoDigests, repotag)
+				if len(digest) == 0 {
+					digest = "<none>"
+				}
 
 				repo, tag := parsers.ParseRepositoryTag(repotag)
 

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1368,6 +1368,7 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 	quiet := cmd.Bool([]string{"q", "-quiet"}, false, "Only show numeric IDs")
 	all := cmd.Bool([]string{"a", "-all"}, false, "Show all images (default hides intermediate images)")
 	noTrunc := cmd.Bool([]string{"#notrunc", "-no-trunc"}, false, "Don't truncate output")
+	showDigests := cmd.Bool([]string{"d", "-digests"}, false, "Show digests")
 	// FIXME: --viz and --tree are deprecated. Remove them in a future version.
 	flViz := cmd.Bool([]string{"#v", "#viz", "#-viz"}, false, "Output graph in graphviz format")
 	flTree := cmd.Bool([]string{"#t", "#tree", "#-tree"}, false, "Output graph in tree format")
@@ -1479,6 +1480,9 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 		}
 		if *all {
 			v.Set("all", "1")
+		}
+		if *showDigests {
+			v.Set("digests", "1")
 		}
 
 		body, _, err := readBody(cli.call("GET", "/images/json?"+v.Encode(), nil, false))

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -1302,7 +1302,7 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 }
 
 func (cli *DockerCli) CmdPull(args ...string) error {
-	cmd := cli.Subcmd("pull", "NAME[:TAG]", "Pull an image or a repository from the registry", true)
+	cmd := cli.Subcmd("pull", "NAME[:TAG|@DIGEST]", "Pull an image or a repository from the registry", true)
 	allTags := cmd.Bool([]string{"a", "-all-tags"}, false, "Download all tagged images in the repository")
 	cmd.Require(flag.Exact, 1)
 

--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2228,7 +2228,7 @@ func (cli *DockerCli) createContainer(config *runconfig.Config, hostConfig *runc
 		if tag == "" {
 			tag = graph.DEFAULTTAG
 		}
-		fmt.Fprintf(cli.err, "Unable to find image '%s:%s' locally\n", repo, tag)
+		fmt.Fprintf(cli.err, "Unable to find image '%s' locally\n", utils.ImageReference(repo, tag))
 
 		// we don't want to write to stdout anything apart from container.ID
 		if err = cli.pullImageCustomOut(config.Image, cli.err); err != nil {

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -280,7 +280,6 @@ func getImagesJSON(eng *engine.Engine, version version.Version, w http.ResponseW
 	// FIXME this parameter could just be a match filter
 	job.Setenv("filter", r.Form.Get("filter"))
 	job.Setenv("all", r.Form.Get("all"))
-	job.Setenv("digests", r.Form.Get("digests"))
 
 	if version.GreaterThanOrEqualTo("1.7") {
 		streamJSON(job, w, false)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -280,6 +280,7 @@ func getImagesJSON(eng *engine.Engine, version version.Version, w http.ResponseW
 	// FIXME this parameter could just be a match filter
 	job.Setenv("filter", r.Form.Get("filter"))
 	job.Setenv("all", r.Form.Get("all"))
+	job.Setenv("digests", r.Form.Get("digests"))
 
 	if version.GreaterThanOrEqualTo("1.7") {
 		streamJSON(job, w, false)

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/common"
 	"github.com/docker/docker/pkg/parsers"
+	"github.com/docker/docker/utils"
 )
 
 func (daemon *Daemon) ImageDelete(job *engine.Job) engine.Status {
@@ -48,7 +49,7 @@ func (daemon *Daemon) DeleteImage(eng *engine.Engine, name string, imgs *engine.
 	img, err := daemon.Repositories().LookupImage(name)
 	if err != nil {
 		if r, _ := daemon.Repositories().Get(repoName); r != nil {
-			return fmt.Errorf("No such image: %s:%s", repoName, tag)
+			return fmt.Errorf("No such image: %s", utils.ImageReference(repoName, tag))
 		}
 		return fmt.Errorf("No such image: %s", name)
 	}
@@ -102,7 +103,7 @@ func (daemon *Daemon) DeleteImage(eng *engine.Engine, name string, imgs *engine.
 		}
 		if tagDeleted {
 			out := &engine.Env{}
-			out.Set("Untagged", repoName+":"+tag)
+			out.Set("Untagged", utils.ImageReference(repoName, tag))
 			imgs.Add(out)
 			eng.Job("log", "untag", img.ID, "").Run()
 		}

--- a/docs/man/docker-images.1.md
+++ b/docs/man/docker-images.1.md
@@ -8,7 +8,7 @@ docker-images - List images
 **docker images**
 [**--help**]
 [**-a**|**--all**[=*false*]]
-[**-d**|**--digests**[=*false*]]
+[**--digests**[=*false*]]
 [**-f**|**--filter**[=*[]*]]
 [**--no-trunc**[=*false*]]
 [**-q**|**--quiet**[=*false*]]
@@ -34,7 +34,7 @@ versions.
 **-a**, **--all**=*true*|*false*
    Show all images (by default filter out the intermediate image layers). The default is *false*.
 
-**-d**, **--digests**=*true*|*false*
+**--digests**=*true*|*false*
    Show image digests. The default is *false*.
 
 **-f**, **--filter**=[]

--- a/docs/man/docker-images.1.md
+++ b/docs/man/docker-images.1.md
@@ -8,6 +8,7 @@ docker-images - List images
 **docker images**
 [**--help**]
 [**-a**|**--all**[=*false*]]
+[**-d**|**--digests**[=*false*]]
 [**-f**|**--filter**[=*[]*]]
 [**--no-trunc**[=*false*]]
 [**-q**|**--quiet**[=*false*]]
@@ -32,6 +33,9 @@ versions.
 # OPTIONS
 **-a**, **--all**=*true*|*false*
    Show all images (by default filter out the intermediate image layers). The default is *false*.
+
+**-d**, **--digests**=*true*|*false*
+   Show image digests. The default is *false*.
 
 **-f**, **--filter**=[]
    Provide filter values (i.e., 'dangling=true')

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -65,7 +65,7 @@ This endpoint now returns `SystemTime`, `HttpProxy`,`HttpsProxy` and `NoProxy`.
 `GET /images/json`
 
 **New!**
-Added a `digests` parameter (default `false`) to include image digest information.
+Added a `RepoDigests` field to include image digest information.
 
 ## v1.17
 

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -62,6 +62,10 @@ You can set ulimit settings to be used within the container.
 **New!**
 This endpoint now returns `SystemTime`, `HttpProxy`,`HttpsProxy` and `NoProxy`. 
 
+`GET /images/json`
+
+**New!**
+Added a `digests` parameter (default `false`) to include image digest information.
 
 ## v1.17
 

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -1056,9 +1056,9 @@ Status Codes:
             "Created": 1420064636,
             "Id": "4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125",
             "ParentId": "ea13149945cb6b1e746bf28032f02e9b5a793523481a0a18645fc77ad53c4ea2",
-            "RepoDigests": {
-              "localhost:5000/test/busybox:latest": "sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf"
-            },
+            "RepoDigests": [
+              "localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf"
+            ],
             "RepoTags": [
               "localhost:5000/test/busybox:latest",
               "busybox:latest",
@@ -1068,15 +1068,16 @@ Status Codes:
           }
         ]
 
-In the example above, this image ID is associated with 1 digest for `localhost:5000/test/busybox:latest`, meaning that
-it can be referenced as `localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf`.
-The image ID is also associated with the tag `busybox:latest`, but the `busybox` repository is not associated with the
-digest, so the image cannot be referenced as `busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf`.
+In the example above, this image ID is associated with 1 digest for the
+repository `localhost:5000/test/busybox`, meaning that it can be referenced as
+`localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf`.
+The image ID is also associated with the tag `busybox:latest`, but the
+`busybox` repository is not associated with the digest, so the image cannot be
+referenced as `busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf`.
 
 Query Parameters:
 
 -   **all** – 1/True/true or 0/False/false, default false
--   **digests** - 1/True/true or or 0/False/false, default false. Show image digest information
 -   **filters** – a json encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
   -   dangling=true
 

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -1042,10 +1042,41 @@ Status Codes:
           }
         ]
 
+** Example request, with digest information**:
+
+        GET /images/json?digests=1 HTTP/1.1
+
+**Example response, with digest information**:
+
+        HTTP/1.1 200 OK
+        Content-Type: application/json
+
+        [
+          {
+            "Created": 1420064636,
+            "Id": "4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125",
+            "ParentId": "ea13149945cb6b1e746bf28032f02e9b5a793523481a0a18645fc77ad53c4ea2",
+            "RepoDigests": {
+              "localhost:5000/test/busybox:latest": "sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf"
+            },
+            "RepoTags": [
+              "localhost:5000/test/busybox:latest",
+              "busybox:latest",
+            ],
+            "Size": 0,
+            "VirtualSize": 2429728
+          }
+        ]
+
+In the example above, this image ID is associated with 1 digest for `localhost:5000/test/busybox:latest`, meaning that
+it can be referenced as `localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf`.
+The image ID is also associated with the tag `busybox:latest`, but the `busybox` repository is not associated with the
+digest, so the image cannot be referenced as `busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf`.
 
 Query Parameters:
 
 -   **all** – 1/True/true or 0/False/false, default false
+-   **digests** - 1/True/true or or 0/False/false, default false. Show image digest information
 -   **filters** – a json encoded value of the filters (a map[string][]string) to process on the images list. Available filters:
   -   dangling=true
 

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -192,6 +192,10 @@ Or
 
     FROM <image>:<tag>
 
+Or
+
+    FROM <image>@<digest>
+
 The `FROM` instruction sets the [*Base Image*](/terms/image/#base-image)
 for subsequent instructions. As such, a valid `Dockerfile` must have `FROM` as
 its first instruction. The image can be any valid image – it is especially easy
@@ -204,8 +208,8 @@ to start by **pulling an image** from the [*Public Repositories*](
 multiple images. Simply make a note of the last image ID output by the commit
 before each new `FROM` command.
 
-If no `tag` is given to the `FROM` instruction, `latest` is assumed. If the
-used tag does not exist, an error will be returned.
+If no `tag` or `digest` is given to the `FROM` instruction, the tag `latest` is
+assumed. If the used tag does not exist, an error will be returned.
 
 ## MAINTAINER
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1087,12 +1087,12 @@ To see how the `docker:latest` image was built:
 
     List images
 
-      -a, --all=false        Show all images (default hides intermediate images)
-      -d, --digests=false    Show digests
-      -f, --filter=[]        Filter output based on conditions provided
-      --help=false           Print usage
-      --no-trunc=false       Don't truncate output
-      -q, --quiet=false      Only show numeric IDs
+      -a, --all=false      Show all images (default hides intermediate images)
+      --digests=false      Show digests
+      -f, --filter=[]      Filter output based on conditions provided
+      --help=false         Print usage
+      --no-trunc=false     Don't truncate output
+      -q, --quiet=false    Only show numeric IDs
 
 The default `docker images` will show all top level
 images, their repository and tags, and their virtual size.
@@ -1145,9 +1145,9 @@ Images using the v2 or later image format have content-addressable identifiers,
 referred to as a digest. Digests are repeatedly and consistently deterministic
 as long as the input used to generate the image doesn't change. Images pushed
 to or pulled from a 2.0 registry have a digest, and that digest can be seen by
-passing `--digests=true` to the `docker images` command.
+passing `--digests` to the `docker images` command.
 
-    $ sudo docker images --digests=true | head
+    $ sudo docker images --digests | head
     REPOSITORY                         TAG                 DIGEST                                                                    IMAGE ID            CREATED             VIRTUAL SIZE
     localhost:5000/test/busybox        <none>              sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf   4986bf8c1536        9 weeks ago         2.43 MB
 
@@ -1552,9 +1552,9 @@ use `docker pull`:
     $ sudo docker pull debian:testing
     # will pull the image named debian:testing and any intermediate
     # layers it is based on.
-    $ sudo docker pull debian@cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
+    $ sudo docker pull debian@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
     # will pull the image from the debian repository with the digest
-    # cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
+    # sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
     # and any intermediate layers it is based on.
     # (Typically the empty `scratch` image, a MAINTAINER layer,
     # and the un-tarred base).
@@ -1628,8 +1628,8 @@ deleted.
 #### Removing tagged images
 
 An image can be removed by its short or long ID, its tag, or its digest. If an
-image has more than one tag, each of them needs to be removed before the image
-is removed.
+image has more than one tag or digest reference, each of them needs to be
+removed before the image is removed.
 
     $ sudo docker images
     REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
@@ -1653,16 +1653,17 @@ is removed.
     Untagged: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8
     Deleted: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8
 
-An image pulled by digest has no tag associated with it (unless it is later pulled by the tag that refers to the same digest).
+An image pulled by digest has no tag associated with it (unless it is later
+pulled by the tag that refers to the same digest).
 
-    $ sudo docker images -d
+    $ sudo docker images --digests
     REPOSITORY                     TAG       DIGEST                                                                    IMAGE ID        CREATED         VIRTUAL SIZE
     localhost:5000/test/busybox    <none>    sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf   4986bf8c1536    9 weeks ago     2.43 MB
 
 To remove an image using its digest:
 
     $ sudo docker rmi localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
-    Untagged: localhost:5000/test/busybox:sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
+    Untagged: localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
     Deleted: 4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125
     Deleted: ea13149945cb6b1e746bf28032f02e9b5a793523481a0a18645fc77ad53c4ea2
     Deleted: df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1087,10 +1087,12 @@ To see how the `docker:latest` image was built:
 
     List images
 
-      -a, --all=false      Show all images (default hides intermediate images)
-      -f, --filter=[]      Filter output based on conditions provided
-      --no-trunc=false     Don't truncate output
-      -q, --quiet=false    Only show numeric IDs
+      -a, --all=false        Show all images (default hides intermediate images)
+      -d, --digests=false    Show digests
+      -f, --filter=[]        Filter output based on conditions provided
+      --help=false           Print usage
+      --no-trunc=false       Don't truncate output
+      -q, --quiet=false      Only show numeric IDs
 
 The default `docker images` will show all top level
 images, their repository and tags, and their virtual size.
@@ -1136,6 +1138,18 @@ uses up the `VIRTUAL SIZE` listed only once.
     <none>                        <none>              f9f1e26352f0a3ba6a0ff68167559f64f3e21ff7ada60366e2d44a04befd1d3a   23 hours ago        1.089 GB
     tryout                        latest              2629d1fa0b81b222fca63371ca16cbf6a0772d07759ff80e8d1369b926940074   23 hours ago        131.5 MB
     <none>                        <none>              5ed6274db6ceb2397844896966ea239290555e74ef307030ebb01ff91b1914df   24 hours ago        1.089 GB
+
+#### Listing image digests
+
+Images using the v2 or later image format have content-addressable identifiers,
+referred to as a digest. Digests are repeatedly and consistently deterministic
+as long as the input used to generate the image doesn't change. Images pushed
+to or pulled from a 2.0 registry have a digest, and that digest can be seen by
+passing `--digests=true` to the `docker images` command.
+
+    $ sudo docker images --digests=true | head
+    REPOSITORY                         TAG                 DIGEST                                                                    IMAGE ID            CREATED             VIRTUAL SIZE
+    localhost:5000/test/busybox        <none>              sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf   4986bf8c1536        9 weeks ago         2.43 MB
 
 #### Filtering
 
@@ -1538,6 +1552,10 @@ use `docker pull`:
     $ sudo docker pull debian:testing
     # will pull the image named debian:testing and any intermediate
     # layers it is based on.
+    $ sudo docker pull debian@cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
+    # will pull the image from the debian repository with the digest
+    # cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
+    # and any intermediate layers it is based on.
     # (Typically the empty `scratch` image, a MAINTAINER layer,
     # and the un-tarred base).
     $ sudo docker pull --all-tags centos
@@ -1609,9 +1627,9 @@ deleted.
 
 #### Removing tagged images
 
-Images can be removed either by their short or long IDs, or their image
-names. If an image has more than one name, each of them needs to be
-removed before the image is removed.
+An image can be removed by its short or long ID, its tag, or its digest. If an
+image has more than one tag, each of them needs to be removed before the image
+is removed.
 
     $ sudo docker images
     REPOSITORY                TAG                 IMAGE ID            CREATED             SIZE
@@ -1634,6 +1652,20 @@ removed before the image is removed.
     $ sudo docker rmi test
     Untagged: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8
     Deleted: fd484f19954f4920da7ff372b5067f5b7ddb2fd3830cecd17b96ea9e286ba5b8
+
+An image pulled by digest has no tag associated with it (unless it is later pulled by the tag that refers to the same digest).
+
+    $ sudo docker images -d
+    REPOSITORY                     TAG       DIGEST                                                                    IMAGE ID        CREATED         VIRTUAL SIZE
+    localhost:5000/test/busybox    <none>    sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf   4986bf8c1536    9 weeks ago     2.43 MB
+
+To remove an image using its digest:
+
+    $ sudo docker rmi localhost:5000/test/busybox@sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
+    Untagged: localhost:5000/test/busybox:sha256:cbbf2f9a99b47fc460d422812b6a5adff7dfee951d8fa2e4a98caa0382cfbdbf
+    Deleted: 4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125
+    Deleted: ea13149945cb6b1e746bf28032f02e9b5a793523481a0a18645fc77ad53c4ea2
+    Deleted: df7546f9f060a2268024c8a230d8639878585defcc1bc6f79d2728a13957871b
 
 ## run
 

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -18,7 +18,7 @@ other `docker` command.
 
 The basic `docker run` command takes this form:
 
-    $ sudo docker run [OPTIONS] IMAGE[:TAG] [COMMAND] [ARG...]
+    $ sudo docker run [OPTIONS] IMAGE[:TAG|@DIGEST] [COMMAND] [ARG...]
 
 To learn how to interpret the types of `[OPTIONS]`,
 see [*Option types*](/reference/commandline/cli/#option-types).
@@ -133,6 +133,11 @@ PID files):
 While not strictly a means of identifying a container, you can specify a version of an
 image you'd like to run the container with by adding `image[:tag]` to the command. For
 example, `docker run ubuntu:14.04`.
+
+### Image[@digest]
+
+Images using the v2 or later image format may be referred to using their
+content-addressable digest. For example, `docker run myimage@sha256:bacb1c27adb6886f0d8d831af74d1ed77d50761dbebfabb71dc1bdb0897af619`
 
 ## PID Settings
     --pid=""  : Set the PID (Process) Namespace mode for the container,
@@ -586,7 +591,7 @@ Dockerfile instruction and how the operator can override that setting.
 Recall the optional `COMMAND` in the Docker
 commandline:
 
-    $ sudo docker run [OPTIONS] IMAGE[:TAG] [COMMAND] [ARG...]
+    $ sudo docker run [OPTIONS] IMAGE[:TAG|@DIGEST] [COMMAND] [ARG...]
 
 This command is optional because the person who created the `IMAGE` may
 have already provided a default `COMMAND` using the Dockerfile `CMD`

--- a/graph/list.go
+++ b/graph/list.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"fmt"
 	"log"
 	"path"
 	"strings"
@@ -9,6 +8,7 @@ import (
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/parsers/filters"
+	"github.com/docker/docker/utils"
 )
 
 var acceptedImageFilterTags = map[string]struct{}{"dangling": {}}
@@ -63,7 +63,7 @@ func (s *TagStore) CmdImages(job *engine.Job) engine.Status {
 
 			if out, exists := lookup[id]; exists {
 				if filt_tagged {
-					out.SetList("RepoTags", append(out.GetList("RepoTags"), fmt.Sprintf("%s:%s", name, tag)))
+					out.SetList("RepoTags", append(out.GetList("RepoTags"), utils.ImageReference(name, tag)))
 				}
 			} else {
 				// get the boolean list for if only the untagged images are requested
@@ -71,7 +71,7 @@ func (s *TagStore) CmdImages(job *engine.Job) engine.Status {
 				if filt_tagged {
 					out := &engine.Env{}
 					out.SetJson("ParentId", image.Parent)
-					out.SetList("RepoTags", []string{fmt.Sprintf("%s:%s", name, tag)})
+					out.SetList("RepoTags", []string{utils.ImageReference(name, tag)})
 					out.SetJson("Id", image.ID)
 					out.SetInt64("Created", image.Created.Unix())
 					out.SetInt64("Size", image.Size)
@@ -102,7 +102,7 @@ func (s *TagStore) CmdImages(job *engine.Job) engine.Status {
 			// remove from allImages so it doesn't show up as dangling
 			delete(allImages, id)
 
-			repoDigestsKey := fmt.Sprintf("%s:%s", name, mapping.Tag)
+			repoDigestsKey := utils.ImageReference(name, mapping.Tag)
 			if showDigests && filt_tagged {
 				if out, exists := lookup[id]; exists {
 					repoDigests := make(map[string]string)

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -45,7 +45,7 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 	job.GetenvJson("authConfig", authConfig)
 	job.GetenvJson("metaHeaders", &metaHeaders)
 
-	c, err := s.poolAdd("pull", repoInfo.LocalName+":"+tag)
+	c, err := s.poolAdd("pull", utils.ImageReference(repoInfo.LocalName, tag))
 	if err != nil {
 		if c != nil {
 			// Another pull of the same repository is already taking place; just wait for it to finish
@@ -55,7 +55,7 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 		}
 		return job.Error(err)
 	}
-	defer s.poolRemove("pull", repoInfo.LocalName+":"+tag)
+	defer s.poolRemove("pull", utils.ImageReference(repoInfo.LocalName, tag))
 
 	log.Debugf("pulling image from host %q with remote name %q", repoInfo.Index.Name, repoInfo.RemoteName)
 	endpoint, err := repoInfo.GetEndpoint()
@@ -112,7 +112,7 @@ func (s *TagStore) pullRepository(r *registry.Session, out io.Writer, repoInfo *
 	repoData, err := r.GetRepositoryData(repoInfo.RemoteName)
 	if err != nil {
 		if strings.Contains(err.Error(), "HTTP code: 404") {
-			return fmt.Errorf("Error: image %s:%s not found", repoInfo.RemoteName, askedTag)
+			return fmt.Errorf("Error: image %s not found", utils.ImageReference(repoInfo.RemoteName, askedTag))
 		}
 		// Unexpected HTTP error
 		return err
@@ -258,7 +258,7 @@ func (s *TagStore) pullRepository(r *registry.Session, out io.Writer, repoInfo *
 
 	requestedTag := repoInfo.CanonicalName
 	if len(askedTag) > 0 {
-		requestedTag = repoInfo.CanonicalName + ":" + askedTag
+		requestedTag = utils.ImageReference(repoInfo.CanonicalName, askedTag)
 	}
 	WriteStatus(requestedTag, out, sf, layers_downloaded)
 	return nil
@@ -412,7 +412,7 @@ func (s *TagStore) pullV2Repository(eng *engine.Engine, r *registry.Session, out
 
 	requestedTag := repoInfo.CanonicalName
 	if len(tag) > 0 {
-		requestedTag = repoInfo.CanonicalName + ":" + tag
+		requestedTag = utils.ImageReference(repoInfo.CanonicalName, tag)
 	}
 	WriteStatus(requestedTag, out, sf, layersDownloaded)
 	return nil
@@ -435,7 +435,7 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 	}
 
 	if verified {
-		log.Printf("Image manifest for %s:%s has been verified", repoInfo.CanonicalName, tag)
+		log.Printf("Image manifest for %s has been verified", utils.ImageReference(repoInfo.CanonicalName, tag))
 	}
 	out.Write(sf.FormatStatus(tag, "Pulling from %s", repoInfo.CanonicalName))
 
@@ -564,7 +564,7 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 	}
 
 	if verified && layersDownloaded {
-		out.Write(sf.FormatStatus(repoInfo.CanonicalName+":"+tag, "The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security."))
+		out.Write(sf.FormatStatus(utils.ImageReference(repoInfo.CanonicalName, tag), "The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security."))
 	}
 
 	if !strings.Contains(tag, ":") {

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -581,6 +581,7 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 		if err = s.SetDigest(repoInfo.LocalName, digest, downloads[0].img.ID); err != nil {
 			return false, err
 		}
+		out.Write(sf.FormatStatus("", "Digest: %s", digest))
 	}
 
 	return layersDownloaded, nil

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -21,7 +21,7 @@ import (
 
 func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 	if n := len(job.Args); n != 1 && n != 2 {
-		return job.Errorf("Usage: %s IMAGE [TAG]", job.Name)
+		return job.Errorf("Usage: %s IMAGE [TAG|DIGEST]", job.Name)
 	}
 
 	var (

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -567,7 +567,7 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 		out.Write(sf.FormatStatus(utils.ImageReference(repoInfo.CanonicalName, tag), "The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security."))
 	}
 
-	if !strings.Contains(tag, ":") {
+	if !utils.DigestReference(tag) {
 		// only set the repository/tag -> image ID mapping when pulling by tag (i.e. not by digest)
 		if err = s.Set(repoInfo.LocalName, tag, downloads[0].img.ID, true); err != nil {
 			return false, err

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -578,7 +578,7 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 	// other v2 registries won't initially include it, so only update the digest info if we
 	// actually have a digest
 	if len(digest) > 0 {
-		if err = s.SetDigest(repoInfo.LocalName, digest, downloads[0].img.ID); err != nil {
+		if err = s.SetDigest(repoInfo.LocalName, digest, manifest.Tag, downloads[0].img.ID); err != nil {
 			return false, err
 		}
 		out.Write(sf.FormatStatus("", "Digest: %s", digest))

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -567,21 +567,16 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 		out.Write(sf.FormatStatus(utils.ImageReference(repoInfo.CanonicalName, tag), "The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security."))
 	}
 
-	if !utils.DigestReference(tag) {
+	if utils.DigestReference(tag) {
+		if err = s.SetDigest(repoInfo.LocalName, tag, downloads[0].img.ID); err != nil {
+			return false, err
+		}
+		out.Write(sf.FormatStatus("", "Digest: %s", digest))
+	} else {
 		// only set the repository/tag -> image ID mapping when pulling by tag (i.e. not by digest)
 		if err = s.Set(repoInfo.LocalName, tag, downloads[0].img.ID, true); err != nil {
 			return false, err
 		}
-	}
-
-	// the Hub doesn't currently include the digest in its response headers, and it's possible
-	// other v2 registries won't initially include it, so only update the digest info if we
-	// actually have a digest
-	if len(digest) > 0 {
-		if err = s.SetDigest(repoInfo.LocalName, digest, manifest.Tag, downloads[0].img.ID); err != nil {
-			return false, err
-		}
-		out.Write(sf.FormatStatus("", "Digest: %s", digest))
 	}
 
 	return layersDownloaded, nil

--- a/graph/push.go
+++ b/graph/push.go
@@ -320,6 +320,8 @@ func (s *TagStore) pushV2Repository(r *registry.Session, localRepo Repository, o
 			metadata = *layer.Config
 		}
 
+		digestImageID := layer.ID
+
 		layersSeen := make(map[string]bool)
 		layers := []*image.Image{layer}
 		for ; layer != nil; layer, err = layer.GetParent() {
@@ -412,7 +414,12 @@ func (s *TagStore) pushV2Repository(r *registry.Session, localRepo Repository, o
 		log.Infof("Signed manifest for %s:%s using daemon's key: %s", repoInfo.LocalName, tag, s.trustKey.KeyID())
 
 		// push the manifest
-		if err := r.PutV2ImageManifest(endpoint, repoInfo.RemoteName, tag, bytes.NewReader(signedBody), auth); err != nil {
+		digest, err := r.PutV2ImageManifest(endpoint, repoInfo.RemoteName, tag, bytes.NewReader(signedBody), auth)
+		if err != nil {
+			return err
+		}
+
+		if err := s.SetDigest(repoInfo.LocalName, digest, digestImageID); err != nil {
 			return err
 		}
 	}

--- a/graph/push.go
+++ b/graph/push.go
@@ -419,8 +419,10 @@ func (s *TagStore) pushV2Repository(r *registry.Session, localRepo Repository, o
 			return err
 		}
 
-		if err := s.SetDigest(repoInfo.LocalName, digest, digestImageID); err != nil {
-			return err
+		if len(digest) > 0 {
+			if err := s.SetDigest(repoInfo.LocalName, digest, digestImageID); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/graph/push.go
+++ b/graph/push.go
@@ -420,7 +420,7 @@ func (s *TagStore) pushV2Repository(r *registry.Session, localRepo Repository, o
 		}
 
 		if len(digest) > 0 {
-			if err := s.SetDigest(repoInfo.LocalName, digest, digestImageID); err != nil {
+			if err := s.SetDigest(repoInfo.LocalName, digest, manifest.Tag, digestImageID); err != nil {
 				return err
 			}
 			out.Write(sf.FormatStatus("", "Digest: %s", digest))

--- a/graph/push.go
+++ b/graph/push.go
@@ -423,6 +423,7 @@ func (s *TagStore) pushV2Repository(r *registry.Session, localRepo Repository, o
 			if err := s.SetDigest(repoInfo.LocalName, digest, digestImageID); err != nil {
 				return err
 			}
+			out.Write(sf.FormatStatus("", "Digest: %s", digest))
 		}
 	}
 	return nil

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/pkg/common"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/registry"
+	"github.com/docker/docker/utils"
 	"github.com/docker/libtrust"
 )
 
@@ -210,7 +211,7 @@ func (store *TagStore) Delete(repoName, tag string) (bool, error) {
 				}
 				deleted = true
 			} else {
-				return false, fmt.Errorf("No such image: %s:%s", repoName, tag)
+				return false, fmt.Errorf("No such image: %s", utils.ImageReference(repoName, tag))
 			}
 		}
 	} else {
@@ -224,7 +225,7 @@ func (store *TagStore) Delete(repoName, tag string) (bool, error) {
 					}
 					deleted = true
 				} else {
-					return false, fmt.Errorf("No such tag: %s:%s", repoName, tag)
+					return false, fmt.Errorf("No such tag: %s", utils.ImageReference(repoName, tag))
 				}
 			} else {
 				delete(store.Repositories, repoName)
@@ -376,7 +377,7 @@ func (store *TagStore) GetRepoRefs() map[string][]string {
 	for name, repository := range store.Repositories {
 		for tag, id := range repository {
 			shortID := common.TruncateID(id)
-			reporefs[shortID] = append(reporefs[shortID], fmt.Sprintf("%s:%s", name, tag))
+			reporefs[shortID] = append(reporefs[shortID], utils.ImageReference(name, tag))
 		}
 	}
 	store.Unlock()

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -215,6 +215,7 @@ func (store *TagStore) Delete(repoName, tag string) (bool, error) {
 					delete(r, tag)
 					if len(r) == 0 {
 						delete(store.Repositories, repoName)
+						delete(store.Digests, repoName)
 					}
 					deleted = true
 				} else {
@@ -222,7 +223,7 @@ func (store *TagStore) Delete(repoName, tag string) (bool, error) {
 				}
 			} else {
 				delete(store.Repositories, repoName)
-				// TODO should this delete from store.Digests?
+				delete(store.Digests, repoName)
 				deleted = true
 			}
 		} else {

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -127,7 +127,7 @@ func (store *TagStore) LookupImage(name string) (*image.Image, error) {
 		err error
 		img *image.Image
 	)
-	if strings.Contains(tag, ":") {
+	if utils.DigestReference(tag) {
 		img, err = store.GetImageByDigest(repos, tag)
 	} else {
 		img, err = store.GetImage(repos, tag)
@@ -201,8 +201,7 @@ func (store *TagStore) Delete(repoName, tag string) (bool, error) {
 
 	repoName = registry.NormalizeLocalName(repoName)
 
-	if strings.Contains(tag, ":") {
-		// if the tag has : in it, it's a digest, e.g. sha256:<digest>
+	if utils.DigestReference(tag) {
 		if r, exists := store.Digests[repoName]; exists {
 			if _, digestExists := r[tag]; digestExists {
 				delete(r, tag)

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -192,3 +192,24 @@ func TestInvalidTagName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateDigest(t *testing.T) {
+	tests := []struct {
+		input       string
+		expectError bool
+	}{
+		{"", true},
+		{"latest", true},
+		{"a:b", false},
+		{"aZ0124-.+:bY852-_.+=", false},
+		{"#$%#$^:$%^#$%", true},
+	}
+
+	for i, test := range tests {
+		err := validateDigest(test.input)
+		gotError := err != nil
+		if e, a := test.expectError, gotError; e != a {
+			t.Errorf("%d: with input %s, expected error=%t, got %t: %s", i, test.input, test.expectError, gotError, err)
+		}
+	}
+}

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -85,7 +85,7 @@ func mkTestTagStore(root string, t *testing.T) *TagStore {
 	if err := store.Set(testPrivateImageName, "", testPrivateImageID, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.SetDigest(testPrivateImageName, testPrivateImageDigest, testPrivateImageTag, testPrivateImageID); err != nil {
+	if err := store.SetDigest(testPrivateImageName, testPrivateImageDigest, testPrivateImageID); err != nil {
 		t.Fatal(err)
 	}
 	return store

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -22,6 +22,7 @@ const (
 	testPrivateImageID       = "5bc255f8699e4ee89ac4469266c3d11515da88fdcbde45d7b069b636ff4efd81"
 	testPrivateImageIDShort  = "5bc255f8699e"
 	testPrivateImageDigest   = "sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb"
+	testPrivateImageTag      = "sometag"
 )
 
 func fakeTar() (io.Reader, error) {
@@ -84,7 +85,7 @@ func mkTestTagStore(root string, t *testing.T) *TagStore {
 	if err := store.Set(testPrivateImageName, "", testPrivateImageID, false); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.SetDigest(testPrivateImageName, testPrivateImageDigest, testPrivateImageID); err != nil {
+	if err := store.SetDigest(testPrivateImageName, testPrivateImageDigest, testPrivateImageTag, testPrivateImageID); err != nil {
 		t.Fatal(err)
 	}
 	return store

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -21,6 +21,7 @@ const (
 	testPrivateImageName     = "127.0.0.1:8000/privateapp"
 	testPrivateImageID       = "5bc255f8699e4ee89ac4469266c3d11515da88fdcbde45d7b069b636ff4efd81"
 	testPrivateImageIDShort  = "5bc255f8699e"
+	testPrivateImageDigest   = "sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb"
 )
 
 func fakeTar() (io.Reader, error) {
@@ -83,6 +84,9 @@ func mkTestTagStore(root string, t *testing.T) *TagStore {
 	if err := store.Set(testPrivateImageName, "", testPrivateImageID, false); err != nil {
 		t.Fatal(err)
 	}
+	if err := store.SetDigest(testPrivateImageName, testPrivateImageDigest, testPrivateImageID); err != nil {
+		t.Fatal(err)
+	}
 	return store
 }
 
@@ -128,6 +132,10 @@ func TestLookupImage(t *testing.T) {
 		"fail:fail",
 	}
 
+	digestLookups := []string{
+		testPrivateImageName + "@" + testPrivateImageDigest,
+	}
+
 	for _, name := range officialLookups {
 		if img, err := store.LookupImage(name); err != nil {
 			t.Errorf("Error looking up %s: %s", name, err)
@@ -153,6 +161,16 @@ func TestLookupImage(t *testing.T) {
 			t.Errorf("Expected error, none found: %s", name)
 		} else if img != nil {
 			t.Errorf("Expected 0 image, 1 found: %s", name)
+		}
+	}
+
+	for _, name := range digestLookups {
+		if img, err := store.LookupImage(name); err != nil {
+			t.Errorf("Error looking up %s: %s", name, err)
+		} else if img == nil {
+			t.Errorf("Expected 1 image, none found: %s", name)
+		} else if img.ID != testPrivateImageID {
+			t.Errorf("Expected ID '%s' found '%s'", testPrivateImageID, img.ID)
 		}
 	}
 }

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var (
+	repoName    = fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
+	digestRegex = regexp.MustCompile("Digest: ([^\n]+)")
+)
+
+func setupImage() (string, error) {
+	containerName := "busyboxbydigest"
+
+	c := exec.Command(dockerBinary, "run", "-d", "-e", "digest=1", "--name", containerName, "busybox")
+	if _, err := runCommand(c); err != nil {
+		return "", err
+	}
+
+	// tag the image to upload it to the private registry
+	c = exec.Command(dockerBinary, "commit", containerName, repoName)
+	if out, _, err := runCommandWithOutput(c); err != nil {
+		return "", fmt.Errorf("image tagging failed: %s, %v", out, err)
+	}
+	defer deleteImages(repoName)
+
+	// delete the container as we don't need it any more
+	if err := deleteContainer(containerName); err != nil {
+		return "", err
+	}
+
+	// push the image
+	c = exec.Command(dockerBinary, "push", repoName)
+	out, _, err := runCommandWithOutput(c)
+	if err != nil {
+		return "", fmt.Errorf("pushing the image to the private registry has failed: %s, %v", out, err)
+	}
+
+	// delete busybox and our local repo that we previously tagged
+	//if err := deleteImages(repoName, "busybox"); err != nil {
+	c = exec.Command(dockerBinary, "rmi", repoName, "busybox")
+	if out, _, err := runCommandWithOutput(c); err != nil {
+		return "", fmt.Errorf("error deleting images prior to real test: %s, %v", out, err)
+	}
+
+	// the push output includes "Digest: <digest>", so find that
+	matches := digestRegex.FindStringSubmatch(out)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("unable to parse digest from push output: %s", out)
+	}
+	pushDigest := matches[1]
+
+	return pushDigest, nil
+}
+
+func TestPullByDigest(t *testing.T) {
+	defer setupRegistry(t)()
+
+	pushDigest, err := setupImage()
+	if err != nil {
+		t.Fatalf("error setting up image: %v", err)
+	}
+
+	// pull from the registry using the <name>@<digest> reference
+	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
+	c := exec.Command(dockerBinary, "pull", imageReference)
+	out, _, err := runCommandWithOutput(c)
+	if err != nil {
+		t.Fatalf("error pulling by digest: %s, %v", out, err)
+	}
+	defer deleteImages(imageReference)
+
+	// the pull output includes "Digest: <digest>", so find that
+	matches := digestRegex.FindStringSubmatch(out)
+	if len(matches) != 2 {
+		t.Fatalf("unable to parse digest from pull output: %s", out)
+	}
+	pullDigest := matches[1]
+
+	// make sure the pushed and pull digests match
+	if pushDigest != pullDigest {
+		t.Fatalf("push digest %q didn't match pull digest %q", pushDigest, pullDigest)
+	}
+
+	logDone("by_digest - pull by digest")
+}
+
+func TestCreateByDigest(t *testing.T) {
+	defer setupRegistry(t)()
+
+	pushDigest, err := setupImage()
+	if err != nil {
+		t.Fatalf("error setting up image: %v", err)
+	}
+
+	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
+
+	containerName := "createByDigest"
+	c := exec.Command(dockerBinary, "create", "--name", containerName, imageReference)
+	out, _, err := runCommandWithOutput(c)
+	if err != nil {
+		t.Fatalf("error creating by digest: %s, %v", out, err)
+	}
+	defer deleteContainer(containerName)
+
+	res, err := inspectField(containerName, "Config.Image")
+	if err != nil {
+		t.Fatalf("failed to get Config.Image: %s, %v", out, err)
+	}
+	if res != imageReference {
+		t.Fatalf("unexpected Config.Image: %s (expected %s)", res, imageReference)
+	}
+
+	logDone("by_digest - create by digest")
+}
+
+func TestRunByDigest(t *testing.T) {
+	defer setupRegistry(t)()
+
+	pushDigest, err := setupImage()
+	if err != nil {
+		t.Fatalf("error setting up image: %v", err)
+	}
+
+	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
+
+	containerName := "runByDigest"
+	c := exec.Command(dockerBinary, "run", "--name", containerName, imageReference, "sh", "-c", "echo found=$digest")
+	out, _, err := runCommandWithOutput(c)
+	if err != nil {
+		t.Fatalf("error run by digest: %s, %v", out, err)
+	}
+	defer deleteContainer(containerName)
+
+	foundRegex := regexp.MustCompile("found=([^\n]+)")
+	matches := foundRegex.FindStringSubmatch(out)
+	if len(matches) != 2 {
+		t.Fatalf("error locating expected 'found=1' output: %s", out)
+	}
+	if matches[1] != "1" {
+		t.Fatalf("Expected %q, got %q", "1", matches[1])
+	}
+
+	res, err := inspectField(containerName, "Config.Image")
+	if err != nil {
+		t.Fatalf("failed to get Config.Image: %s, %v", out, err)
+	}
+	if res != imageReference {
+		t.Fatalf("unexpected Config.Image: %s (expected %s)", res, imageReference)
+	}
+
+	logDone("by_digest - run by digest")
+}
+
+func TestRemoveImageByDigest(t *testing.T) {
+	defer setupRegistry(t)()
+
+	digest, err := setupImage()
+	if err != nil {
+		t.Fatalf("error setting up image: %v", err)
+	}
+
+	imageReference := fmt.Sprintf("%s@%s", repoName, digest)
+
+	// pull from the registry using the <name>@<digest> reference
+	c := exec.Command(dockerBinary, "pull", imageReference)
+	out, _, err := runCommandWithOutput(c)
+	if err != nil {
+		t.Fatalf("error pulling by digest: %s, %v", out, err)
+	}
+
+	// make sure inspect runs ok
+	if _, err := inspectField(imageReference, "Id"); err != nil {
+		t.Fatalf("failed to inspect image: %v", err)
+	}
+
+	// do the delete
+	if err := deleteImages(imageReference); err != nil {
+		t.Fatalf("unexpected error deleting image: %v", err)
+	}
+
+	// try to inspect again - it should error this time
+	if _, err := inspectField(imageReference, "Id"); err == nil {
+		t.Fatalf("unexpected nil err trying to inspect what should be a non-existent image")
+	} else if !strings.Contains(err.Error(), "No such image") {
+		t.Fatalf("expected 'No such image' output, got %v", err)
+	}
+
+	logDone("by_digest - remove image by digest")
+}
+
+func TestBuildByDigest(t *testing.T) {
+	defer setupRegistry(t)()
+
+	digest, err := setupImage()
+	if err != nil {
+		t.Fatalf("error setting up image: %v", err)
+	}
+
+	imageReference := fmt.Sprintf("%s@%s", repoName, digest)
+
+	// pull from the registry using the <name>@<digest> reference
+	c := exec.Command(dockerBinary, "pull", imageReference)
+	out, _, err := runCommandWithOutput(c)
+	if err != nil {
+		t.Fatalf("error pulling by digest: %s, %v", out, err)
+	}
+
+	// get the image id
+	imageID, err := inspectField(imageReference, "Id")
+	if err != nil {
+		t.Fatalf("error getting image id: %v", err)
+	}
+
+	// do the build
+	name := "buildbydigest"
+	defer deleteImages(name)
+	_, err = buildImage(name, fmt.Sprintf(
+		`FROM %s
+     CMD ["/bin/echo", "Hello World"]`, imageReference),
+		true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// get the build's image id
+	res, err := inspectField(name, "Config.Image")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// make sure they match
+	if res != imageID {
+		t.Fatalf("Image %s, expected %s", res, imageID)
+	}
+
+	logDone("by_digest - build by digest")
+}
+
+func TestTagByDigest(t *testing.T) {
+	defer setupRegistry(t)()
+
+	digest, err := setupImage()
+	if err != nil {
+		t.Fatalf("error setting up image: %v", err)
+	}
+
+	imageReference := fmt.Sprintf("%s@%s", repoName, digest)
+
+	// pull from the registry using the <name>@<digest> reference
+	c := exec.Command(dockerBinary, "pull", imageReference)
+	out, _, err := runCommandWithOutput(c)
+	if err != nil {
+		t.Fatalf("error pulling by digest: %s, %v", out, err)
+	}
+
+	// tag it
+	tag := "tagbydigest"
+	c = exec.Command(dockerBinary, "tag", imageReference, tag)
+	if _, err := runCommand(c); err != nil {
+		t.Fatalf("unexpected error tagging: %v", err)
+	}
+
+	expectedID, err := inspectField(imageReference, "Id")
+	if err != nil {
+		t.Fatalf("error getting original image id: %v", err)
+	}
+
+	tagID, err := inspectField(tag, "Id")
+	if err != nil {
+		t.Fatalf("error getting tagged image id: %v", err)
+	}
+
+	if tagID != expectedID {
+		t.Fatalf("expected image id %q, got %q", expectedID, tagID)
+	}
+
+	logDone("by_digest - tag by digest")
+}

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -17,7 +17,7 @@ func TestPushBusyboxImage(t *testing.T) {
 	defer setupRegistry(t)()
 
 	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
-	// tag the image to upload it tot he private registry
+	// tag the image to upload it to the private registry
 	tagCmd := exec.Command(dockerBinary, "tag", "busybox", repoName)
 	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
 		t.Fatalf("image tagging failed: %s, %v", out, err)

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -62,10 +62,10 @@ func ParseTCPAddr(addr string, defaultAddr string) (string, error) {
 	return fmt.Sprintf("tcp://%s:%d", host, p), nil
 }
 
-// Get a repos name and returns the right reposName + tag
+// Get a repos name and returns the right reposName + tag|digest
 // The tag can be confusing because of a port in a repository name.
 //     Ex: localhost.localdomain:5000/samalba/hipache:latest
-// Digest ex: localhost:5000/foo/bar@sha256:abcd1234
+//     Digest ex: localhost:5000/foo/bar@sha256:bc8813ea7b3603864987522f02a76101c17ad122e1c46d790efc0fca78ca7bfb
 func ParseRepositoryTag(repos string) (string, string) {
 	n := strings.Index(repos, "@")
 	if n >= 0 {

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -65,8 +65,14 @@ func ParseTCPAddr(addr string, defaultAddr string) (string, error) {
 // Get a repos name and returns the right reposName + tag
 // The tag can be confusing because of a port in a repository name.
 //     Ex: localhost.localdomain:5000/samalba/hipache:latest
+// Digest ex: localhost:5000/foo/bar@sha256:abcd1234
 func ParseRepositoryTag(repos string) (string, string) {
-	n := strings.LastIndex(repos, ":")
+	n := strings.Index(repos, "@")
+	if n >= 0 {
+		parts := strings.Split(repos, "@")
+		return parts[0], parts[1]
+	}
+	n = strings.LastIndex(repos, ":")
 	if n < 0 {
 		return repos, ""
 	}

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -49,17 +49,26 @@ func TestParseRepositoryTag(t *testing.T) {
 	if repo, tag := ParseRepositoryTag("root:tag"); repo != "root" || tag != "tag" {
 		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "root", "tag", repo, tag)
 	}
+	if repo, digest := ParseRepositoryTag("root@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"); repo != "root" || digest != "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+		t.Errorf("Expected repo: '%s' and digest: '%s', got '%s' and '%s'", "root", "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", repo, digest)
+	}
 	if repo, tag := ParseRepositoryTag("user/repo"); repo != "user/repo" || tag != "" {
 		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "user/repo", "", repo, tag)
 	}
 	if repo, tag := ParseRepositoryTag("user/repo:tag"); repo != "user/repo" || tag != "tag" {
 		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "user/repo", "tag", repo, tag)
 	}
+	if repo, digest := ParseRepositoryTag("user/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"); repo != "user/repo" || digest != "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+		t.Errorf("Expected repo: '%s' and digest: '%s', got '%s' and '%s'", "user/repo", "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", repo, digest)
+	}
 	if repo, tag := ParseRepositoryTag("url:5000/repo"); repo != "url:5000/repo" || tag != "" {
 		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "url:5000/repo", "", repo, tag)
 	}
 	if repo, tag := ParseRepositoryTag("url:5000/repo:tag"); repo != "url:5000/repo" || tag != "tag" {
 		t.Errorf("Expected repo: '%s' and tag: '%s', got '%s' and '%s'", "url:5000/repo", "tag", repo, tag)
+	}
+	if repo, digest := ParseRepositoryTag("url:5000/repo@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"); repo != "url:5000/repo" || digest != "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
+		t.Errorf("Expected repo: '%s' and digest: '%s', got '%s' and '%s'", "url:5000/repo", "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", repo, digest)
 	}
 }
 

--- a/registry/session_v2.go
+++ b/registry/session_v2.go
@@ -12,6 +12,8 @@ import (
 	"github.com/docker/docker/utils"
 )
 
+const DockerDigestHeader = "Docker-Digest"
+
 func getV2Builder(e *Endpoint) *v2.URLBuilder {
 	if e.URLBuilder == nil {
 		e.URLBuilder = v2.NewURLBuilder(e.URL)
@@ -63,10 +65,10 @@ func (r *Session) GetV2Authorization(ep *Endpoint, imageName string, readOnly bo
 //  1.c) if anything else, err
 // 2) PUT the created/signed manifest
 //
-func (r *Session) GetV2ImageManifest(ep *Endpoint, imageName, tagName string, auth *RequestAuthorization) ([]byte, error) {
+func (r *Session) GetV2ImageManifest(ep *Endpoint, imageName, tagName string, auth *RequestAuthorization) ([]byte, string, error) {
 	routeURL, err := getV2Builder(ep).BuildManifestURL(imageName, tagName)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	method := "GET"
@@ -74,30 +76,30 @@ func (r *Session) GetV2ImageManifest(ep *Endpoint, imageName, tagName string, au
 
 	req, err := r.reqFactory.NewRequest(method, routeURL, nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if err := auth.Authorize(req); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	res, _, err := r.doRequest(req)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer res.Body.Close()
 	if res.StatusCode != 200 {
 		if res.StatusCode == 401 {
-			return nil, errLoginRequired
+			return nil, "", errLoginRequired
 		} else if res.StatusCode == 404 {
-			return nil, ErrDoesNotExist
+			return nil, "", ErrDoesNotExist
 		}
-		return nil, utils.NewHTTPRequestError(fmt.Sprintf("Server error: %d trying to fetch for %s:%s", res.StatusCode, imageName, tagName), res)
+		return nil, "", utils.NewHTTPRequestError(fmt.Sprintf("Server error: %d trying to fetch for %s:%s", res.StatusCode, imageName, tagName), res)
 	}
 
 	buf, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return nil, fmt.Errorf("Error while reading the http response: %s", err)
+		return nil, "", fmt.Errorf("Error while reading the http response: %s", err)
 	}
-	return buf, nil
+	return buf, res.Header.Get(DockerDigestHeader), nil
 }
 
 // - Succeeded to head image blob (already exists)
@@ -261,41 +263,41 @@ func (r *Session) PutV2ImageBlob(ep *Endpoint, imageName, sumType, sumStr string
 }
 
 // Finally Push the (signed) manifest of the blobs we've just pushed
-func (r *Session) PutV2ImageManifest(ep *Endpoint, imageName, tagName string, manifestRdr io.Reader, auth *RequestAuthorization) error {
+func (r *Session) PutV2ImageManifest(ep *Endpoint, imageName, tagName string, manifestRdr io.Reader, auth *RequestAuthorization) (string, error) {
 	routeURL, err := getV2Builder(ep).BuildManifestURL(imageName, tagName)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	method := "PUT"
 	log.Debugf("[registry] Calling %q %s", method, routeURL)
 	req, err := r.reqFactory.NewRequest(method, routeURL, manifestRdr)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if err := auth.Authorize(req); err != nil {
-		return err
+		return "", err
 	}
 	res, _, err := r.doRequest(req)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer res.Body.Close()
 
 	// All 2xx and 3xx responses can be accepted for a put.
 	if res.StatusCode >= 400 {
 		if res.StatusCode == 401 {
-			return errLoginRequired
+			return "", errLoginRequired
 		}
 		errBody, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			return err
+			return "", err
 		}
 		log.Debugf("Unexpected response from server: %q %#v", errBody, res.Header)
-		return utils.NewHTTPRequestError(fmt.Sprintf("Server error: %d trying to push %s:%s manifest", res.StatusCode, imageName, tagName), res)
+		return "", utils.NewHTTPRequestError(fmt.Sprintf("Server error: %d trying to push %s:%s manifest", res.StatusCode, imageName, tagName), res)
 	}
 
-	return nil
+	return res.Header.Get(DockerDigestHeader), nil
 }
 
 type remoteTags struct {

--- a/registry/session_v2.go
+++ b/registry/session_v2.go
@@ -12,7 +12,7 @@ import (
 	"github.com/docker/docker/utils"
 )
 
-const DockerDigestHeader = "Docker-Digest"
+const DockerDigestHeader = "Docker-Content-Digest"
 
 func getV2Builder(e *Endpoint) *v2.URLBuilder {
 	if e.URLBuilder == nil {

--- a/registry/v2/regexp.go
+++ b/registry/v2/regexp.go
@@ -17,3 +17,6 @@ var RepositoryNameRegexp = regexp.MustCompile(`(?:` + RepositoryNameComponentReg
 
 // TagNameRegexp matches valid tag names. From docker/docker:graph/tags.go.
 var TagNameRegexp = regexp.MustCompile(`[\w][\w.-]{0,127}`)
+
+// DigestRegexp matches valid digest types.
+var DigestRegexp = regexp.MustCompile(`[a-zA-Z0-9-_+.]+:[a-zA-Z0-9-_+.=]+`)

--- a/registry/v2/routes.go
+++ b/registry/v2/routes.go
@@ -33,11 +33,11 @@ func Router() *mux.Router {
 		Path("/v2/").
 		Name(RouteNameBase)
 
-	// GET      /v2/<name>/manifest/<tag>	Image Manifest	Fetch the image manifest identified by name and tag.
-	// PUT      /v2/<name>/manifest/<tag>	Image Manifest	Upload the image manifest identified by name and tag.
-	// DELETE   /v2/<name>/manifest/<tag>	Image Manifest	Delete the image identified by name and tag.
+	// GET      /v2/<name>/manifest/<reference>	Image Manifest	Fetch the image manifest identified by name and reference where reference can be a tag or digest.
+	// PUT      /v2/<name>/manifest/<reference>	Image Manifest	Upload the image manifest identified by name and reference where reference can be a tag or digest.
+	// DELETE   /v2/<name>/manifest/<reference>	Image Manifest	Delete the image identified by name and reference where reference can be a tag or digest.
 	router.
-		Path("/v2/{name:" + RepositoryNameRegexp.String() + "}/manifests/{tag:" + TagNameRegexp.String() + "}").
+		Path("/v2/{name:" + RepositoryNameRegexp.String() + "}/manifests/{reference:" + TagNameRegexp.String() + "|" + DigestRegexp.String() + "}").
 		Name(RouteNameManifest)
 
 	// GET	/v2/<name>/tags/list	Tags	Fetch the tags under the repository identified by name.

--- a/registry/v2/routes_test.go
+++ b/registry/v2/routes_test.go
@@ -55,8 +55,8 @@ func TestRouter(t *testing.T) {
 			RouteName:  RouteNameManifest,
 			RequestURI: "/v2/foo/manifests/bar",
 			Vars: map[string]string{
-				"name": "foo",
-				"tag":  "bar",
+				"name":      "foo",
+				"reference": "bar",
 			},
 		},
 		{

--- a/registry/v2/routes_test.go
+++ b/registry/v2/routes_test.go
@@ -63,8 +63,8 @@ func TestRouter(t *testing.T) {
 			RouteName:  RouteNameManifest,
 			RequestURI: "/v2/foo/bar/manifests/tag",
 			Vars: map[string]string{
-				"name": "foo/bar",
-				"tag":  "tag",
+				"name":      "foo/bar",
+				"reference": "tag",
 			},
 		},
 		{
@@ -128,8 +128,8 @@ func TestRouter(t *testing.T) {
 			RouteName:  RouteNameManifest,
 			RequestURI: "/v2/foo/bar/manifests/manifests/tags",
 			Vars: map[string]string{
-				"name": "foo/bar/manifests",
-				"tag":  "tags",
+				"name":      "foo/bar/manifests",
+				"reference": "tags",
 			},
 		},
 		{

--- a/registry/v2/urls.go
+++ b/registry/v2/urls.go
@@ -74,11 +74,11 @@ func (ub *URLBuilder) BuildTagsURL(name string) (string, error) {
 	return tagsURL.String(), nil
 }
 
-// BuildManifestURL constructs a url for the manifest identified by name and tag.
-func (ub *URLBuilder) BuildManifestURL(name, tag string) (string, error) {
+// BuildManifestURL constructs a url for the manifest identified by name and reference.
+func (ub *URLBuilder) BuildManifestURL(name, reference string) (string, error) {
 	route := ub.cloneRoute(RouteNameManifest)
 
-	manifestURL, err := route.URL("name", name, "tag", tag)
+	manifestURL, err := route.URL("name", name, "reference", reference)
 	if err != nil {
 		return "", err
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -535,3 +535,14 @@ func (wc *WriteCounter) Write(p []byte) (count int, err error) {
 	wc.Count += int64(count)
 	return
 }
+
+// ImageReference combines `repo` and `ref` and returns a string representing
+// the combination. If `ref` is a digest (meaning it's of the form
+// <algorithm>:<digest>, the returned string is <repo>@<ref>. Otherwise,
+// ref is assumed to be a tag, and the returned string is <repo>:<tag>.
+func ImageReference(repo, ref string) string {
+	if strings.Contains(ref, ":") {
+		return repo + "@" + ref
+	}
+	return repo + ":" + ref
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -541,8 +541,14 @@ func (wc *WriteCounter) Write(p []byte) (count int, err error) {
 // <algorithm>:<digest>, the returned string is <repo>@<ref>. Otherwise,
 // ref is assumed to be a tag, and the returned string is <repo>:<tag>.
 func ImageReference(repo, ref string) string {
-	if strings.Contains(ref, ":") {
+	if DigestReference(ref) {
 		return repo + "@" + ref
 	}
 	return repo + ":" + ref
+}
+
+// DigestReference returns true if ref is a digest reference; i.e. if it
+// is of the form <algorithm>:<digest>.
+func DigestReference(ref string) bool {
+	return strings.Contains(ref, ":")
 }

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -140,3 +140,15 @@ func TestImageReference(t *testing.T) {
 		}
 	}
 }
+
+func TestDigestReference(t *testing.T) {
+	input := "sha256:c100b11b25d0cacd52c14e0e7bf525e1a4c0e6aec8827ae007055545909d1a64"
+	if !DigestReference(input) {
+		t.Errorf("Expected DigestReference=true for input %q", input)
+	}
+
+	input = "latest"
+	if DigestReference(input) {
+		t.Errorf("Unexpected DigestReference=true for input %q", input)
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -122,3 +122,21 @@ func TestWriteCounter(t *testing.T) {
 		t.Error("Wrong message written")
 	}
 }
+
+func TestImageReference(t *testing.T) {
+	tests := []struct {
+		repo     string
+		ref      string
+		expected string
+	}{
+		{"repo", "tag", "repo:tag"},
+		{"repo", "sha256:c100b11b25d0cacd52c14e0e7bf525e1a4c0e6aec8827ae007055545909d1a64", "repo@sha256:c100b11b25d0cacd52c14e0e7bf525e1a4c0e6aec8827ae007055545909d1a64"},
+	}
+
+	for i, test := range tests {
+		actual := ImageReference(test.repo, test.ref)
+		if test.expected != actual {
+			t.Errorf("%d: expected %q, got %q", i, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Supersedes #11109 by @ncdc with implementation of https://github.com/docker/docker/pull/11109#issuecomment-78370899
# Overview

When I create a container, I may specify an image such as `mysql:latest`. When the image is pulled, `latest` is resolved to a particular image at that point in time. If I later want to add more containers (e.g. possible read slaves in the MySQL case), all the new containers must use the exact same image as my first container. Using a tag isn't sufficient as the tag can be updated to point at a different image. We need a way to refer to images using immutable identifiers.

With the v2 image format, image manifests have content-addressable, immutable digests. The v2 registry supports retrieving manifests by digest; this pull request adds the corresponding support to the Docker Core.
# Digest reference format

We'll need to provide a means to reference an image by its digest. I'd like to propose the following format:

```
namespace/repository@digest
```
# Supported commands

We'll need to make sure the following commands continue to work as they currently do, as well as with an optional digest:
- `docker build`
- `docker pull`
- `docker create`
- `docker run`
- `docker rmi`

This list should eventually be comprehensive; anywhere you can refer to an image, you should be able to do so by digest. For the time being, the commands listed above should be sufficient for the use case listed in the overview.
# `docker images`

If you pull an image from a v2 registry, the registry provides the image manifest's digest as a response header. If you pull by tag, you'll have both the tag and the digest. If you pull only by digest, you won't have the tag information. 1 question to resolve is how to display images, tags, digests, and v1 image IDs in the `docker images` command.

It is possible (likely?) that a variety of code exists to scrape the output of `docker images`. If we change the format, e.g. by adding a new column, or overloading an existing column to sometimes show a v1 image ID vs a digest, we will probably break whatever code is out there doing the scraping. We need to determine how critical it is to retain the existing column and data formats in the `docker images` command.

I have the following ideas regarding this output:
- if an image was pulled by tag, and the registry it's pulled from includes the image's digest, display `repository`, `tag`, `digest`, and `image id`
- if an image was pulled by digest, display `repository`, <none> for tag, `digest`, and `image id`
## `docker images` questions
- should we add a new `DIGEST` column?
- if yes, should we always display it, or only display it if you indicate that you want to see digests (e.g. via a filter)
  - there can be confusion if you pull an image by digest and then run `docker images` - you won't see the image you just pulled
- should we display the digest instead of the v1 image ID (or some other value)?
# Questions

_What about v1 registry support?_
The v1 registry won't support this feature.

_If I create an image locally via `docker tag` or `docker commit`, can I refer to it by `name@digest`?_
As proposed in https://github.com/docker/distribution/issues/46, the registry is responsible for determining an image's digest and assigning it to the image. For an image that has not yet been pushed to a v2 registry, it may not be possible to refer to it by `name@digest`. This is unlikely to be a significant issue, as the use case for `name@digest` is consistent deployments using images pulled from registries. Or, if the community thinks this should be supported, we can revisit what component(s) are responsible for calculating digests.
# Additional information

See #10740 for more backstory.

Todo:
- [x] Test cases
- [x] Update documentation
