### PR TITLE
Enable docker to choose a different graphdriver for volume

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -529,6 +529,18 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 			fmt.Fprintf(cli.out, " %s: %s\n", pair[0], pair[1])
 		}
 	}
+	if remoteInfo.Exists("VolumeDriver") {
+		fmt.Fprintf(cli.out, "Volume Driver: %s\n", remoteInfo.Get("VolumeDriver"))
+	}
+	if remoteInfo.Exists("VolumeDriverStatus") {
+		var driverStatus [][2]string
+		if err := remoteInfo.GetJson("VolumeDriverStatus", &driverStatus); err != nil {
+			return err
+		}
+		for _, pair := range driverStatus {
+			fmt.Fprintf(cli.out, " %s: %s\n", pair[0], pair[1])
+		}
+	}
 	if remoteInfo.Exists("ExecutionDriver") {
 		fmt.Fprintf(cli.out, "Execution Driver: %s\n", remoteInfo.Get("ExecutionDriver"))
 	}

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -35,6 +35,8 @@ type Config struct {
 	InterContainerCommunication bool
 	GraphDriver                 string
 	GraphOptions                []string
+	VolumeGraphDriver           string
+	VolumeGraphOptions          []string
 	ExecDriver                  string
 	Mtu                         int
 	SocketGroup                 string
@@ -64,6 +66,7 @@ func (config *Config) InstallFlags() {
 	flag.StringVar(&config.FixedCIDRv6, []string{"-fixed-cidr-v6"}, "", "IPv6 subnet for fixed IPs")
 	flag.BoolVar(&config.InterContainerCommunication, []string{"#icc", "-icc"}, true, "Enable inter-container communication")
 	flag.StringVar(&config.GraphDriver, []string{"s", "-storage-driver"}, "", "Storage driver to use")
+	flag.StringVar(&config.VolumeGraphDriver, []string{"-volume-driver"}, "", "Volume driver to use")
 	flag.StringVar(&config.ExecDriver, []string{"e", "-exec-driver"}, "native", "Exec driver to use")
 	flag.BoolVar(&config.EnableSelinuxSupport, []string{"-selinux-enabled"}, false, "Enable selinux support")
 	flag.IntVar(&config.Mtu, []string{"#mtu", "-mtu"}, 0, "Set the containers network MTU")
@@ -71,6 +74,7 @@ func (config *Config) InstallFlags() {
 	flag.BoolVar(&config.EnableCors, []string{"#api-enable-cors", "-api-enable-cors"}, false, "Enable CORS headers in the remote API")
 	opts.IPVar(&config.DefaultIp, []string{"#ip", "-ip"}, "0.0.0.0", "Default IP when binding container ports")
 	opts.ListVar(&config.GraphOptions, []string{"-storage-opt"}, "Set storage driver options")
+	opts.ListVar(&config.VolumeGraphOptions, []string{"-volume-driver-opt"}, "Set volume driver options")
 	// FIXME: why the inconsistency between "hosts" and "sockets"?
 	opts.IPListVar(&config.Dns, []string{"#dns", "-dns"}, "DNS server to use")
 	opts.DnsSearchListVar(&config.DnsSearch, []string{"-dns-search"}, "DNS search domains to use")

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -70,6 +70,8 @@ func (daemon *Daemon) CmdInfo(job *engine.Job) engine.Status {
 	v.SetInt("Images", imgcount)
 	v.Set("Driver", daemon.GraphDriver().String())
 	v.SetJson("DriverStatus", daemon.GraphDriver().Status())
+	v.Set("VolumeDriver", daemon.VolumeDriver().String())
+	v.SetJson("VolumeDriverStatus", daemon.VolumeDriver().Status())
 	v.SetBool("MemoryLimit", daemon.SystemConfig().MemoryLimit)
 	v.SetBool("SwapLimit", daemon.SystemConfig().SwapLimit)
 	v.SetBool("IPv4Forwarding", !daemon.SystemConfig().IPv4ForwardingDisabled)


### PR DESCRIPTION
The volume driver other than VFS would create internal directory under /var/docker/volumes, rather than /var/docker, to avoid conflict with graphdriver for images

This patch has been tested briefly using device mapper graphdriver. There is no migration path from other volume drivers(vfs) yet.

I don't think one volume driver per docker daemon is prefect, but that's what we have currently in docker, so this patch would live with for now. I think it's good for each volume should able to have an separate driver in some way, which would provide us much bigger flexibility on deployment.

Some related discussion happened on https://github.com/docker/docker/pull/8484#issuecomment-78374504
