### PR TITLE
Add missing subcommand in set-up-prereqs doc.

### DIFF
--- a/docs/sources/project/set-up-prereqs.md
+++ b/docs/sources/project/set-up-prereqs.md
@@ -277,7 +277,7 @@ the branch to your fork on GitHub:
 
 9. Sign and commit your change.
 
-        $ git -s -m "Making a dry run test."
+        $ git commit -s -m "Making a dry run test."
         [dry-run-test 6e728fb] Making a dry run test
          1 file changed, 1 insertion(+)
          create mode 100644 TEST.md


### PR DESCRIPTION
Hi

I've found that `commit` subcommand is missing in `9. Sign and commit your change.` section of set-up-prereqs doc.

Please check it.
