### PR TITLE
Fix --link to a container which net mode is container

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -774,6 +774,13 @@ func (daemon *Daemon) RegisterLinks(container *Container, hostConfig *runconfig.
 				//An error from daemon.Get() means this name could not be found
 				return fmt.Errorf("Could not get container for %s", parts["name"])
 			}
+			for child.hostConfig.NetworkMode.IsContainer() {
+				parts := strings.SplitN(string(child.hostConfig.NetworkMode), ":", 2)
+				child, err = daemon.Get(parts[1])
+				if err != nil {
+					return fmt.Errorf("Could not get container for %s", parts[1])
+				}
+			}
 			if child.hostConfig.NetworkMode.IsHost() {
 				return runconfig.ErrConflictHostNetworkAndLinks
 			}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -379,6 +379,39 @@ func TestRunLinksContainerWithContainerId(t *testing.T) {
 	logDone("run - use a container id to link target work")
 }
 
+func TestRunLinkToContainerNetMode(t *testing.T) {
+	defer deleteAllContainers()
+
+	cmd := exec.Command(dockerBinary, "run", "--name", "test", "-d", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+	cmd = exec.Command(dockerBinary, "run", "--name", "parent", "-d", "--net=container:test", "busybox", "top")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+	cmd = exec.Command(dockerBinary, "run", "-d", "--link=parent:parent", "busybox", "top")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--name", "child", "-d", "--net=container:parent", "busybox", "top")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+	cmd = exec.Command(dockerBinary, "run", "-d", "--link=child:child", "busybox", "top")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+
+	logDone("run - link to a container which net mode is container success")
+}
+
 // Regression test for #4741
 func TestRunWithVolumesAsFiles(t *testing.T) {
 	defer deleteAllContainers()


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

If  `docker run --link` link to a container which net mode is container mode,  it will failed with 
`FATA[0000] Error response from daemon: Cannot start container 95c255a241c05afeb489ce2abafb650968b786adbe6ad7ef9c0571a757b96636: Child IP '' is invalid`
because if the net mode of a container is container mode, it share with net namespace with other container and the network configuration is all nil.

there are two way to fix this, one is this PR,  another way is to prevent user from
linking to a container which net mode is container mode.
which way is the right way? keep me know and I will update this.

ping @LK4D4  @estesp  @crosbymichael  @jfrazelle 
