### PR TITLE
Allow a non-existent groupid to own the docker socket

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1457,6 +1457,11 @@ func lookupGidByName(nameOrGid string) (int, error) {
 	if groups != nil && len(groups) > 0 {
 		return groups[0].Gid, nil
 	}
+	gid, err := strconv.Atoi(nameOrGid)
+	if err != nil {
+		log.Warnf("Could not find GID %d", gid)
+		return gid, nil
+	}
 	return -1, fmt.Errorf("Group %s not found", nameOrGid)
 }
 


### PR DESCRIPTION
Workaround for #1715 - I've got an LDAP system which contains the group I want to use. It has a consistent gid so I'd like to be able to forcibly set the group id of the socket.

A group name can't be a valid parseable uint, so this check will only take effect when someone's trying to set a group id explicitly. I think it's a safe assumption that someone trying to set a group id explicitly knows what they're doing.
