### PR TITLE
Show warning message when icc is false and bridge-nf-call-iptables is disabled

### DIFF
--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -302,6 +302,11 @@ func setupIPTables(addr net.Addr, icc, ipmasq bool) error {
 	)
 
 	if !icc {
+		output, err := ioutil.ReadFile("/proc/sys/net/bridge/bridge-nf-call-iptables")
+		if err != nil || string(output[:1]) == "0" {
+			log.Warnf("net.bridge.bridge-nf-call-iptables is not enabled. So --icc=false does not work.")
+		}
+
 		iptables.Raw(append([]string{"-D"}, acceptArgs...)...)
 
 		if !iptables.Exists(dropArgs...) {

--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -304,7 +304,7 @@ func setupIPTables(addr net.Addr, icc, ipmasq bool) error {
 	if !icc {
 		output, err := ioutil.ReadFile("/proc/sys/net/bridge/bridge-nf-call-iptables")
 		if err != nil || string(output[:1]) == "0" {
-			log.Warnf("net.bridge.bridge-nf-call-iptables is not enabled. So --icc=false does not work.")
+			log.Warnf("WARNING: disabling intercontainer communication is not supported: net.bridge.bridge-nf-call-iptables is not enabled.")
 		}
 
 		iptables.Raw(append([]string{"-D"}, acceptArgs...)...)


### PR DESCRIPTION
This pull request is for showing a warning message when --icc=false and net.bridge.bridge-nf-call-iptables is disabled.

If net.bridge.bridge-nf-call-iptables is disabled, iptables does not see bridge traffic. So contaniers can communicate with each other even though icc option is false.

I found this problem when I tested Docker on CoreOS. Since Linux kernel 3.18 rc-1, you have to modprobe br_netfilter explicitly to enable net.bridge.bridge-nf-call-iptables.

It took very long time to investigate this problem because there were no messages and Docker worked correctly other than --icc=false did not work.

So it is kind to show this warning message to find the problem easily.

Please check it.
