### PR TITLE
Ambiguous example in registry_mirror.md

### DIFF
--- a/docs/sources/articles/registry_mirror.md
+++ b/docs/sources/articles/registry_mirror.md
@@ -50,7 +50,8 @@ port `5000` and mirrors the content at `registry-1.docker.io`:
     sudo docker run -p 5000:5000 \
         -e STANDALONE=false \
         -e MIRROR_SOURCE=https://registry-1.docker.io \
-        -e MIRROR_SOURCE_INDEX=https://index.docker.io registry
+        -e MIRROR_SOURCE_INDEX=https://index.docker.io \
+        registry
 
 ## Test it out
 


### PR DESCRIPTION
![screen shot 2015-03-15 at 12 17 10 pm](https://cloud.githubusercontent.com/assets/701648/6655796/c855e286-cb0d-11e4-9abc-91a4268338ed.png)

The syntactic coloration is a little bit ambiguous, I suggest this as a fix: new line for `registry` parameter.
