### PR TITLE
Change windows default permissions to 755 not 711, read access for all p...

### DIFF
--- a/integration-cli/test_vars_windows.go
+++ b/integration-cli/test_vars_windows.go
@@ -6,6 +6,6 @@ const (
 	// identifies if test suite is running on a unix platform
 	isUnixCli = false
 
-	// this is the expected file permission set on windows: gh#11047
-	expectedFileChmod = "-rwx------"
+	// this is the expected file permission set on windows: gh#11395
+	expectedFileChmod = "-rwxr-xr-x"
 )

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -28,10 +28,9 @@ func CanonicalTarNameForPath(p string) (string, error) {
 // chmodTarEntry is used to adjust the file permissions used in tar header based
 // on the platform the archival is done.
 func chmodTarEntry(perm os.FileMode) os.FileMode {
-	// Clear r/w on grp/others: no precise equivalen of group/others on NTFS.
-	perm &= 0711
+	perm &= 0755
 	// Add the x bit: make everything +x from windows
-	perm |= 0100
+	perm |= 0111
 
 	return perm
 }

--- a/pkg/archive/archive_windows_test.go
+++ b/pkg/archive/archive_windows_test.go
@@ -51,11 +51,11 @@ func TestChmodTarEntry(t *testing.T) {
 	cases := []struct {
 		in, expected os.FileMode
 	}{
-		{0000, 0100},
-		{0777, 0711},
-		{0644, 0700},
-		{0755, 0711},
-		{0444, 0500},
+		{0000, 0111},
+		{0777, 0755},
+		{0644, 0755},
+		{0755, 0755},
+		{0444, 0555},
 	}
 	for _, v := range cases {
 		if out := chmodTarEntry(v.in); out != v.expected {


### PR DESCRIPTION
...oses little security risk and prevents breaking existing Dockerfiles

See issue #11246 for more details. #11246 goes to more than just windows, but windows was recently rolled in so what would be good to rollback sooner rather than later.
