### PR TITLE
Add cli build warning about chmod bits on windows

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -227,6 +227,13 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 			return err
 		}
 	}
+
+	// windows: show error message about modified file permissions
+	// FIXME: this is not a valid warning when the daemon is running windows. should be removed once docker engine for windows can build.
+	if runtime.GOOS == "windows" {
+		log.Warn(`SECURITY WARNING: You are building a Docker image from Windows against a Linux Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.`)
+	}
+
 	var body io.Reader
 	// Setup an upload progress bar
 	// FIXME: ProgressReader shouldn't be this annoying to use

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4551,8 +4551,19 @@ func TestBuildStderr(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stderr != "" {
-		t.Fatalf("Stderr should have been empty, instead its: %q", stderr)
+
+	if runtime.GOOS == "windows" {
+		// stderr might contain a security warning on windows
+		lines := strings.Split(stderr, "\n")
+		for _, v := range lines {
+			if v != "" && !strings.Contains(v, "SECURITY WARNING:") {
+				t.Fatalf("Stderr contains unexpected output line: %q", v)
+			}
+		}
+	} else {
+		if stderr != "" {
+			t.Fatalf("Stderr should have been empty, instead its: %q", stderr)
+		}
 	}
 	logDone("build - testing stderr")
 }


### PR DESCRIPTION
This shows a warning message about adjusted file/directory permission bits
when the `docker build` cli command is executed on windows. This will help
Windows users understand the potential security problems.

We should be revisiting this warning when building against a Windows
docker engine. @jhowardmsft

Example:
![](http://cl.ly/image/402c0B3Q1L0S/Image%202015-03-16%20at%2012.04.30%20AM.png)

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @tianon @tiborvass @ewindisch
