### PR TITLE
fix not show error when using --lxc-conf without lxc driver

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/graph"
@@ -22,6 +23,9 @@ func (daemon *Daemon) ContainerCreate(job *engine.Job) engine.Status {
 	config := runconfig.ContainerConfigFromJob(job)
 	hostConfig := runconfig.ContainerHostConfigFromJob(job)
 
+	if len(hostConfig.LxcConf) > 0 && !strings.Contains(daemon.ExecutionDriver().Name(), "lxc") {
+		return job.Errorf("Cannot use --lxc-conf with execdriver: %s", daemon.ExecutionDriver().Name())
+	}
 	if hostConfig.Memory != 0 && hostConfig.Memory < 4194304 {
 		return job.Errorf("Minimum memory limit allowed is 4MB")
 	}


### PR DESCRIPTION
Signed-off-by: Ma Shimiao mashimiao.fnst@cn.fujitsu.com

When use --lx-conf without lxc driver, the result will looks like:
$ docker run -d --name pctest --lxc-conf="lxc.network.type=veth" --lxc-conf="lxc.network.link=docker0" --lxc-conf="lxc.network.flags=up" ubuntu:14.04
FATA[0000] Error response from daemon: Could not use --lxc-conf with execdriver: native-0.2
