### PR TITLE
Check kernel params for bridge traffic filtering

### DIFF
--- a/daemon/networkdriver/bridge/driver_test.go
+++ b/daemon/networkdriver/bridge/driver_test.go
@@ -31,6 +31,15 @@ func findFreePort(t *testing.T) string {
 	return strconv.Itoa(result.Port)
 }
 
+func TestIPConstantValues(t *testing.T) {
+	if ipv4|ipv6 != ipvboth {
+		t.Fatalf("bitwise or of ipv4(%04b) and ipv6(%04b) must yield ipvboth(%04b)", ipv4, ipv6, ipvboth)
+	}
+	if ipvboth&(^(ipv4 | ipv6)) != ipvnone {
+		t.Fatalf("ipvboth(%04b) with unset ipv4(%04b) and ipv6(%04b) bits shall equal to ipvnone", ipvboth, ipv4, ipv6)
+	}
+}
+
 func TestAllocatePortDetection(t *testing.T) {
 	freePort := findFreePort(t)
 

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -217,7 +217,7 @@ the daemon filters out all localhost IP address `nameserver` entries from
 the host's original file.
 
 Filtering is necessary because all localhost addresses on the host are
-unreachable from the container's network.  After this filtering, if there 
+unreachable from the container's network.  After this filtering, if there
 are no more `nameserver` entries left in the container's `/etc/resolv.conf`
 file, the daemon adds public Google DNS nameservers
 (8.8.8.8 and 8.8.4.4) to the container's DNS configuration.  If IPv6 is
@@ -235,7 +235,7 @@ notifier active which will watch for changes to the host DNS configuration.
 
 > **Note**:
 > The file change notifier relies on the Linux kernel's inotify feature.
-> Because this feature is currently incompatible with the overlay filesystem 
+> Because this feature is currently incompatible with the overlay filesystem
 > driver, a Docker daemon using "overlay" will not be able to take advantage
 > of the `/etc/resolv.conf` auto-update feature.
 
@@ -247,7 +247,7 @@ of a facility to ensure atomic writes of the `resolv.conf` file while the
 container is running. If the container's `resolv.conf` has been edited since
 it was started with the default configuration, no replacement will be
 attempted as it would overwrite the changes performed by the container.
-If the options (`--dns` or `--dns-search`) have been used to modify the 
+If the options (`--dns` or `--dns-search`) have been used to modify the
 default host configuration, then the replacement with an updated host's
 `/etc/resolv.conf` will not happen as well.
 
@@ -348,6 +348,15 @@ page for further details.
 > assigned with `--name=` when you ran `docker run`.  It cannot be a
 > hostname, which Docker will not recognize in the context of the
 > `--link=` option.
+
+> **Note**:
+> For the `--icc=false` option to work, the bridge's traffic must be passed to
+> iptables' chains. This is controled by the kernel parameters
+> `net.bridge.bridge-nf-call-iptables` and
+> `net.bridge.bridge-nf-call-ip6tables`. They are provided by kernel module
+> `br_netfilter` which must be loaded or compiled in running kernel. If they
+> are set to 1, traffic will be processed with `iptables` rules. Docker will
+> attempt to set them upon its initialization if the `--icc=false` is set.
 
 You can run the `iptables` command on your Docker host to see whether
 the `FORWARD` chain has a default policy of `ACCEPT` or `DROP`:
@@ -680,7 +689,7 @@ on every host.
 
 In this scenario containers of the same host can communicate directly with each
 other. The traffic between containers on different hosts will be routed via
-their hosts and the router. For example packet from `Container1-1` to 
+their hosts and the router. For example packet from `Container1-1` to
 `Container2-1` will be routed through `Host1`, `Router` and `Host2` until it
 arrives at `Container2-1`.
 

--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -304,6 +304,8 @@ by having support for them in the kernel or userspace. A few examples include:
   least the "auplink" utility from aufs-tools)
 * BTRFS graph driver (requires BTRFS support enabled in the kernel)
 * ZFS graph driver (requires userspace zfs-utils and a corresponding kernel module)
+* Restriction of inter-container communication (requires `br_netfilter` module
+  loaded or compiled in).
 
 ## Daemon Init Script
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -286,3 +286,8 @@ func ImageReference(repo, ref string) string {
 func DigestReference(ref string) bool {
 	return strings.Contains(ref, ":")
 }
+
+func RunningInsideDockerContainer() bool {
+	_, err := os.Stat("/.dockerinit")
+	return !os.IsNotExist(err)
+}


### PR DESCRIPTION
Check whether bridge traffic is passed to iptables' chains if started
with `--icc=false`. Inter-container communication can be restricted only
if following parameters are set.
- `/proc/sys/net/bridge/bridge-nf-call-iptables`
- `/proc/sys/net/bridge/bridge-nf-call-ip6tables`

Resolves issue #11404
