### PR TITLE
Fix hanging up problem when start and attach multiple containers at once

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -723,18 +723,6 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 	cmd.Require(flag.Min, 1)
 	utils.ParseFlags(cmd, args, true)
 
-	hijacked := make(chan io.Closer)
-	// Block the return until the chan gets closed
-	defer func() {
-		log.Debugf("CmdStart() returned, defer waiting for hijack to finish.")
-		if _, ok := <-hijacked; ok {
-			log.Errorf("Hijack did not finish (chan still open)")
-		}
-		if *openStdin || *attach {
-			cli.in.Close()
-		}
-	}()
-
 	if *attach || *openStdin {
 		if cmd.NArg() > 1 {
 			return fmt.Errorf("You cannot start and attach multiple containers at once.")
@@ -770,26 +758,34 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 		v.Set("stdout", "1")
 		v.Set("stderr", "1")
 
+		hijacked := make(chan io.Closer)
+		// Block the return until the chan gets closed
+		defer func() {
+			log.Debugf("CmdStart() returned, defer waiting for hijack to finish.")
+			if _, ok := <-hijacked; ok {
+				log.Errorf("Hijack did not finish (chan still open)")
+			}
+			cli.in.Close()
+		}()
 		cErr = promise.Go(func() error {
 			return cli.hijack("POST", "/containers/"+cmd.Arg(0)+"/attach?"+v.Encode(), tty, in, cli.out, cli.err, hijacked, nil)
 		})
-	} else {
-		close(hijacked)
+
+		// Acknowledge the hijack before starting
+		select {
+		case closer := <-hijacked:
+			// Make sure that the hijack gets closed when returning (results
+			// in closing the hijack chan and freeing server's goroutines)
+			if closer != nil {
+				defer closer.Close()
+			}
+		case err := <-cErr:
+			if err != nil {
+				return err
+			}
+		}
 	}
 
-	// Acknowledge the hijack before starting
-	select {
-	case closer := <-hijacked:
-		// Make sure that the hijack gets closed when returning (results
-		// in closing the hijack chan and freeing server's goroutines)
-		if closer != nil {
-			defer closer.Close()
-		}
-	case err := <-cErr:
-		if err != nil {
-			return err
-		}
-	}
 	var encounteredError error
 	for _, name := range cmd.Args() {
 		_, _, err := readBody(cli.call("POST", "/containers/"+name+"/start", nil, false))


### PR DESCRIPTION
Operation:
1.start up docker daemon
mabin@mabin-PC:~/work/osc$ sudo docker -d -s  btrfs --icc=true -D --exec-driver=native
....

2.ps current containers in local repository
mabin@mabin-PC:~/work/osc/pr/docker$ sudo docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                         PORTS               NAMES
849de9267117        ubuntu:14.04        "/bin/bash"         3 days ago          Exited (0) 25 seconds ago                          kickass_swartz  
980b483f7ec2        ubuntu:14.04        "/bin/bash"         3 days ago          Exited (0) About an hour ago                       serene_franklin  
b52cf150c376        ubuntu:14.10        "/bin/bash"         4 days ago          Exited (0) About an hour ago                       sick_stallman  
af8c79a5d861        ubuntu:14.10        "/bin/bash"         4 days ago          Exited (0) 8 hours ago                             mad_engelbart       

3.start up multiple containers with -ai,  then the SHELL hangings up, and there is nothing log output.
mabin@mabin-PC:~/work/osc/pr/docker$ sudo docker start -ai 849de9267117 980b483f7ec2

^Cmabin@mabin-PC:~/work/osc/pr/docker$ 

Maybe it can make the SHELL be released automaticly and output logs when somebody starts and attachs multiple containers at once.
