### PR TITLE
Fix test pull verified

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,7 +146,7 @@ RUN ln -sfv $PWD/.bashrc ~/.bashrc
 COPY contrib/download-frozen-image.sh /go/src/github.com/docker/docker/contrib/
 RUN ./contrib/download-frozen-image.sh /docker-frozen-images \
 	busybox:latest@4986bf8c15363d1c5d15512d5266f8777bfba4974ac56e3270e7760f6f0a8125 \
-	hello-world:latest@e45a5af57b00862e5ef5782a9925979a02ba2b12dff832fd0991335f4a11e5c5
+	hello-world:frozen@e45a5af57b00862e5ef5782a9925979a02ba2b12dff832fd0991335f4a11e5c5
 # see also "hack/make/.ensure-frozen-images" (which needs to be updated any time this list is)
 
 # Install man page generator

--- a/hack/make/.ensure-frozen-images
+++ b/hack/make/.ensure-frozen-images
@@ -4,7 +4,7 @@ set -e
 # this list should match roughly what's in the Dockerfile (minus the explicit image IDs, of course)
 images=(
 	busybox:latest
-	hello-world:latest
+	hello-world:frozen
 )
 
 if ! docker inspect "${images[@]}" &> /dev/null; then

--- a/hack/make/.ensure-frozen-images
+++ b/hack/make/.ensure-frozen-images
@@ -11,10 +11,10 @@ if ! docker inspect "${images[@]}" &> /dev/null; then
 	hardCodedDir='/docker-frozen-images'
 	if [ -d "$hardCodedDir" ]; then
 		( set -x; tar -cC "$hardCodedDir" . | docker load )
-	elif [ -e Dockerfile ] && command -v curl > /dev/null; then
-		# testing for "curl" because "download-frozen-image.sh" is built around curl
+	else
 		dir="$DEST/frozen-images"
 		# extract the exact "RUN download-frozen-image.sh" line from the Dockerfile itself for consistency
+		# NOTE: this will fail if either "curl" is not installed or if the Dockerfile is not available/readable
 		awk '
 			$1 == "RUN" && $2 == "./contrib/download-frozen-image.sh" {
 				for (i = 2; i < NF; i++)
@@ -33,11 +33,5 @@ if ! docker inspect "${images[@]}" &> /dev/null; then
 			}
 		' Dockerfile | sh -x
 		( set -x; tar -cC "$dir" . | docker load )
-	else
-		for image in "${images[@]}"; do
-			if ! docker inspect "$image" &> /dev/null; then
-				( set -x; docker pull "$image" )
-			fi
-		done
 	fi
 fi

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5234,7 +5234,7 @@ func TestBuildRUNoneJSON(t *testing.T) {
 	defer deleteAllContainers()
 	defer deleteImages(name)
 
-	ctx, err := fakeContext(`FROM hello-world:latest
+	ctx, err := fakeContext(`FROM hello-world:frozen
 RUN [ "/hello" ]`, map[string]string{})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Update pull code to consider any layer download or new tag as an update.
Update hello-world frozen image to be explicitly tagged as frozen, to not interfere with pull tests.  The hello-world is used by pull tests because of its small size and there is no other official image with such a size.

fixes #11383 
