### PR TITLE
Fix relative path execution of docker daemon in reexec.Self()

### DIFF
--- a/pkg/reexec/reexec.go
+++ b/pkg/reexec/reexec.go
@@ -35,8 +35,14 @@ func Self() string {
 	name := os.Args[0]
 	if filepath.Base(name) == name {
 		if lp, err := exec.LookPath(name); err == nil {
-			name = lp
+			return lp
 		}
 	}
+	// handle conversion of relative paths to absolute
+	if absName, err := filepath.Abs(name); err == nil {
+		return absName
+	}
+	// if we coudn't get absolute name, return original
+	// (NOTE: Go only errors on Abs() if os.Getwd fails)
 	return name
 }


### PR DESCRIPTION
After the merge of the new libcontainer API, `reexec.Self()` on the daemon
binary is used as the libcontainer factory `InitPath`.  If this path is relative,
it can't be found at container start time.  This patch solves the
problem by making sure that we return a rooted/absolute path if a
relative path is used.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
