### PR TITLE
Always Call canDeleteImage When Deleting an Image By ID

### DIFF
--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -88,7 +88,7 @@ func (daemon *Daemon) DeleteImage(eng *engine.Engine, name string, imgs *engine.
 		return nil
 	}
 
-	if len(repos) <= 1 {
+	if len(repos) <= 1 || repoName == "" {
 		if err := daemon.canDeleteImage(img.ID, force); err != nil {
 			return err
 		}

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -88,7 +88,7 @@ func (daemon *Daemon) DeleteImage(eng *engine.Engine, name string, imgs *engine.
 		return nil
 	}
 
-	if len(repos) <= 1 || repoName == "" {
+	if len(repos) <= len(tags) {
 		if err := daemon.canDeleteImage(img.ID, force); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes #11414 

This change ensures that `canDeleteImage` is called whenever an image is deleted by it's ID instead of by a repo/tag. If this happens, and `canDeleteImage` returns false, then nothing happens (no tags are removed, and the image isn't deleted)
