### PR TITLE
Add "eval" to every invocation of "boot2docker shellinit"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -106,7 +106,7 @@ also update the root docs pages by running
 > if you are using Boot2Docker on OSX and the above command returns an error,
 > `Post http:///var/run/docker.sock/build?rm=1&t=docker-docs%3Apost-1.2.0-docs_update-2:
 > dial unix /var/run/docker.sock: no such file or directory', you need to set the Docker
-> host. Run `$(boot2docker shellinit)` to see the correct variable to set. The command
+> host. Run `eval "$(boot2docker shellinit)"` to see the correct variable to set. The command
 > will return the full `export` command, so you can just cut and paste.
 
 ## Cherry-picking documentation changes to update an existing release.

--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -139,7 +139,7 @@ Initialize and run `boot2docker` from the command line, do the following:
 
 4. To set the environment variables in your shell do the following:
 
-		$ $(boot2docker shellinit)
+		$ eval "$(boot2docker shellinit)"
 		
 	You can also set them manually by using the `export` commands `boot2docker`
 	returns.

--- a/docs/sources/project/set-up-dev-env.md
+++ b/docs/sources/project/set-up-dev-env.md
@@ -99,7 +99,7 @@ environment.
 1. Open a terminal.
 
     Mac users, use `boot2docker status` to make sure Boot2Docker is running. You
-    may need to run `$(boot2docker shellinit)` to initialize your shell
+    may need to run `eval "$(boot2docker shellinit)"` to initialize your shell
     environment.
 
 3. Change into the root of your forked repository.
@@ -202,7 +202,7 @@ build and run a `docker` binary in your container.
 
     ![Multiple terminals](/project/images/three_terms.png)
 
-    Mac OSX users, make sure you run `$(boot2docker shellinit)` in any new 
+    Mac OSX users, make sure you run `eval "$(boot2docker shellinit)"` in any new 
     terminals.
 
 2. In a terminal, create a new container from your `dry-run-test` image.


### PR DESCRIPTION
See http://unix.stackexchange.com/a/181581 for the rationale behind this change.

See also https://github.com/boot2docker/boot2docker/issues/716 and https://github.com/boot2docker/boot2docker/pull/786.
