### PR TITLE
Some fixes for new LABEL stuff

### DIFF
--- a/builder/command/command.go
+++ b/builder/command/command.go
@@ -22,6 +22,7 @@ const (
 // Commands is list of all Dockerfile commands
 var Commands = map[string]struct{}{
 	Env:        {},
+	Label:      {},
 	Maintainer: {},
 	Add:        {},
 	Copy:       {},

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -91,7 +91,7 @@ func maintainer(b *Builder, args []string, attributes map[string]bool, original 
 //
 func label(b *Builder, args []string, attributes map[string]bool, original string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("LABEL is missing arguments")
+		return fmt.Errorf("LABEL requires at least one argument")
 	}
 	if len(args)%2 != 0 {
 		// should never get here, but just in case

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -49,6 +49,7 @@ var (
 // Environment variable interpolation will happen on these statements only.
 var replaceEnvAllowed = map[string]struct{}{
 	command.Env:     {},
+	command.Label:   {},
 	command.Add:     {},
 	command.Copy:    {},
 	command.Workdir: {},

--- a/builder/parser/line_parsers.go
+++ b/builder/parser/line_parsers.go
@@ -137,7 +137,7 @@ func parseNameVal(rest string, key string) (*Node, map[string]bool, error) {
 	}
 
 	if len(words) == 0 {
-		return nil, nil, fmt.Errorf(key + " requires at least one argument")
+		return nil, nil, nil
 	}
 
 	// Old format (KEY name value)


### PR DESCRIPTION
- command.Commands was missing "Label"
- used the correct error string in dispatcher when LABEL has no args, otherwise
  the test TestBuildMissingArgs will not work
- removed the premature error msg in line_parser that was blocking the
  label() func in dispatcher from showing the err msg in previous bullet
- since LABEL uses the env parser it needs to be added to the replaceEnvAllowed
  list so that proper quote processing will be done.  Especially once
  PR #10431 is merged.

Signed-off-by: Doug Davis dug@us.ibm.com
