### PR TITLE
Remove 5-component limit from repository name

### DIFF
--- a/registry/v2/regexp.go
+++ b/registry/v2/regexp.go
@@ -11,9 +11,9 @@ import "regexp"
 // separated by one period, dash or underscore.
 var RepositoryNameComponentRegexp = regexp.MustCompile(`[a-z0-9]+(?:[._-][a-z0-9]+)*`)
 
-// RepositoryNameRegexp builds on RepositoryNameComponentRegexp to allow 1 to
-// 5 path components, separated by a forward slash.
-var RepositoryNameRegexp = regexp.MustCompile(`(?:` + RepositoryNameComponentRegexp.String() + `/){0,4}` + RepositoryNameComponentRegexp.String())
+// RepositoryNameRegexp builds on RepositoryNameComponentRegexp to allow
+// multiple path components, separated by a forward slash.
+var RepositoryNameRegexp = regexp.MustCompile(`(?:` + RepositoryNameComponentRegexp.String() + `/)*` + RepositoryNameComponentRegexp.String())
 
 // TagNameRegexp matches valid tag names. From docker/docker:graph/tags.go.
 var TagNameRegexp = regexp.MustCompile(`[\w][\w.-]{0,127}`)


### PR DESCRIPTION
Remove 5-component limit from repository name. Matches
code in docker/distribution.

Signed-off-by: Andy Goldstein agoldste@redhat.com
