### PR TITLE
Don't hardcode default rlimit

### DIFF
--- a/daemon/execdriver/native/template/default_template.go
+++ b/daemon/execdriver/native/template/default_template.go
@@ -66,13 +66,6 @@ func New() *configs.Config {
 		ReadonlyPaths: []string{
 			"/proc/sys", "/proc/sysrq-trigger", "/proc/irq", "/proc/bus",
 		},
-		Rlimits: []configs.Rlimit{
-			{
-				Type: syscall.RLIMIT_NOFILE,
-				Hard: 1024,
-				Soft: 1024,
-			},
-		},
 	}
 
 	if apparmor.IsEnabled() {


### PR DESCRIPTION
The default for rlimit handling should be to inherit the rlimit of the
daemon unless explicitly set.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
