### PR TITLE
Modify misleading daemon debug line

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -133,7 +133,7 @@ func mainDaemon() {
 			return
 		}
 
-		log.Debugf("daemon finished")
+		log.Debugf("daemon completed loading")
 	}()
 
 	// Serve api


### PR DESCRIPTION
Upon loading it says:
   DEBU[0000] daemon finished
which is kind of odd looking during a start-up phase.
Changing it to
   DEBU[0000] daemon completed loading

Noticed by @LK4D4

Signed-off-by: Doug Davis dug@us.ibm.com
