### PR TITLE
Hide dots on daemon startup when loglevel != info

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -346,7 +346,7 @@ func (daemon *Daemon) restore() error {
 	for _, v := range dir {
 		id := v.Name()
 		container, err := daemon.load(id)
-		if !debug {
+		if !debug && log.GetLevel() == log.InfoLevel {
 			fmt.Print(".")
 		}
 		if err != nil {
@@ -368,7 +368,7 @@ func (daemon *Daemon) restore() error {
 
 	if entities := daemon.containerGraph.List("/", -1); entities != nil {
 		for _, p := range entities.Paths() {
-			if !debug {
+			if !debug && log.GetLevel() == log.InfoLevel {
 				fmt.Print(".")
 			}
 
@@ -420,7 +420,9 @@ func (daemon *Daemon) restore() error {
 	}
 
 	if !debug {
-		fmt.Println()
+		if log.GetLevel() == log.InfoLevel {
+			fmt.Println()
+		}
 		log.Infof("Loading containers: done.")
 	}
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -726,3 +726,50 @@ func TestDaemonLoggingDriverNoneLogsError(t *testing.T) {
 	}
 	logDone("daemon - logs not available for non-json-file drivers")
 }
+
+func TestDaemonDots(t *testing.T) {
+	defer deleteAllContainers()
+	d := NewDaemon(t)
+	if err := d.StartWithBusybox(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now create 4 containers
+	if _, err := d.Cmd("create", "busybox"); err != nil {
+		t.Fatalf("Error creating container: %q", err)
+	}
+	if _, err := d.Cmd("create", "busybox"); err != nil {
+		t.Fatalf("Error creating container: %q", err)
+	}
+	if _, err := d.Cmd("create", "busybox"); err != nil {
+		t.Fatalf("Error creating container: %q", err)
+	}
+	if _, err := d.Cmd("create", "busybox"); err != nil {
+		t.Fatalf("Error creating container: %q", err)
+	}
+
+	d.Stop()
+
+	d.Start("--log-level=debug")
+	d.Stop()
+	content, _ := ioutil.ReadFile(d.logFile.Name())
+	if strings.Contains(string(content), "....") {
+		t.Fatalf("Debug level should not have ....\n%s", string(content))
+	}
+
+	d.Start("--log-level=error")
+	d.Stop()
+	content, _ = ioutil.ReadFile(d.logFile.Name())
+	if strings.Contains(string(content), "....") {
+		t.Fatalf("Error level should not have ....\n%s", string(content))
+	}
+
+	d.Start("--log-level=info")
+	d.Stop()
+	content, _ = ioutil.ReadFile(d.logFile.Name())
+	if !strings.Contains(string(content), "....") {
+		t.Fatalf("Info level should have ....\n%s", string(content))
+	}
+
+	logDone("daemon - test dots on INFO")
+}


### PR DESCRIPTION
When the deamon starts up with log level set to INFO it will show something
like this:

```
INFO[0000] Loading containers: start.
................................................................
INFO[0000] Loading containers: done.
```

where the dots represent containers in the system.
When you run with log level set to "error" it will still show the dots
w/o the "Loading..." lines before and after which looks really odd.
This PR will fix it so that the dots are only shown IFF the "Loading..."
lines are also shown

Signed-off-by: Doug Davis dug@us.ibm.com
