### PR TITLE
do not warning when we disable memoryswap

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -33,7 +33,7 @@ func (daemon *Daemon) ContainerCreate(job *engine.Job) engine.Status {
 		job.Errorf("Your kernel does not support memory limit capabilities. Limitation discarded.\n")
 		hostConfig.Memory = 0
 	}
-	if hostConfig.Memory > 0 && !daemon.SystemConfig().SwapLimit {
+	if hostConfig.Memory > 0 && hostConfig.MemorySwap != -1 && !daemon.SystemConfig().SwapLimit {
 		job.Errorf("Your kernel does not support swap limit capabilities. Limitation discarded.\n")
 		hostConfig.MemorySwap = -1
 	}


### PR DESCRIPTION
$ docker run -ti --rm -m 300M --memory-swap=-1 ubuntu:14.04  /bin/bash
WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.
root@813aafc019d5:/#

When we disable memoryswap, it should not warning swap limit not support.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
