### PR TITLE
Fix several very minor consistency issues

### DIFF
--- a/hack/make/.dockerinit
+++ b/hack/make/.dockerinit
@@ -14,6 +14,7 @@ go build \
 		-extldflags \"$EXTLDFLAGS_STATIC\"
 	" \
 	./dockerinit
+
 echo "Created binary: $DEST/dockerinit-$VERSION"
 ln -sf "dockerinit-$VERSION" "$DEST/dockerinit"
 

--- a/hack/make/.dockerinit-gccgo
+++ b/hack/make/.dockerinit-gccgo
@@ -4,6 +4,7 @@ set -e
 IAMSTATIC="true"
 source "$(dirname "$BASH_SOURCE")/.go-autogen"
 
+# dockerinit still needs to be a static binary, even if docker is dynamic
 go build --compiler=gccgo \
 	-o "$DEST/dockerinit-$VERSION" \
 	"${BUILDFLAGS[@]}" \

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -2,7 +2,7 @@
 
 # see test-integration-cli for example usage of this script
 
-export PATH="$DEST/../binary:$DEST/../dynbinary:$DEST/../gccgo:$PATH"
+export PATH="$DEST/../binary:$DEST/../dynbinary:$DEST/../gccgo:$DEST/../dyngccgo:$PATH"
 
 if ! command -v docker &> /dev/null; then
 	echo >&2 'error: binary or dynbinary must be run before .integration-daemon-start'

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -21,6 +21,7 @@ go build \
 		$LDFLAGS_STATIC_DOCKER
 	" \
 	./docker
+
 echo "Created binary: $DEST/$BINARY_FULLNAME"
 ln -sf "$BINARY_FULLNAME" "$DEST/docker$BINARY_EXTENSION"
 

--- a/hack/make/dyngccgo
+++ b/hack/make/dyngccgo
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e 
+set -e
 
 DEST=$1
 

--- a/hack/make/gccgo
+++ b/hack/make/gccgo
@@ -8,17 +8,16 @@ BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
 
 source "$(dirname "$BASH_SOURCE")/.go-autogen"
 
-go build --compiler=gccgo \
+go build -compiler=gccgo \
 	-o "$DEST/$BINARY_FULLNAME" \
 	"${BUILDFLAGS[@]}" \
-	--gccgoflags "
+	-gccgoflags "
 		-g
 		$EXTLDFLAGS_STATIC_DOCKER
 		-Wl,--no-export-dynamic
 		-ldl
 	" \
 	./docker
-
 
 echo "Created binary: $DEST/$BINARY_FULLNAME"
 ln -sf "$BINARY_FULLNAME" "$DEST/docker$BINARY_EXTENSION"


### PR DESCRIPTION
``` console
$ echo hack/make/{,dyn}{binary,gccgo} hack/make/.dockerinit{,-gccgo} | xargs -n2 git diff --no-index
```

``` diff
diff --git a/hack/make/binary b/hack/make/gccgo
index 0f57ea0..16aa8ef 100644
--- a/hack/make/binary
+++ b/hack/make/gccgo
@@ -6,19 +6,16 @@ BINARY_NAME="docker-$VERSION"
 BINARY_EXTENSION="$(binary_extension)"
 BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"

-# Cygdrive paths don't play well with go build -o.
-if [[ "$(uname -s)" == CYGWIN* ]]; then
-       DEST=$(cygpath -mw $DEST)
-fi
-
 source "$(dirname "$BASH_SOURCE")/.go-autogen"

-go build \
+go build --compiler=gccgo \
        -o "$DEST/$BINARY_FULLNAME" \
        "${BUILDFLAGS[@]}" \
-       -ldflags "
-               $LDFLAGS
-               $LDFLAGS_STATIC_DOCKER
+       --gccgoflags "
+               -g
+               $EXTLDFLAGS_STATIC_DOCKER
+               -Wl,--no-export-dynamic
+               -ldl
        " \
        ./docker

diff --git a/hack/make/dynbinary b/hack/make/dyngccgo
index 861a192..a76e9c5 100644
--- a/hack/make/dynbinary
+++ b/hack/make/dyngccgo
@@ -4,7 +4,7 @@ set -e
 DEST=$1

 if [ -z "$DOCKER_CLIENTONLY" ]; then
-       source "$(dirname "$BASH_SOURCE")/.dockerinit"
+       source "$(dirname "$BASH_SOURCE")/.dockerinit-gccgo"

        hash_files "$DEST/dockerinit-$VERSION"
 else
@@ -15,8 +15,9 @@ fi

 (
        export IAMSTATIC="false"
+       export EXTLDFLAGS_STATIC_DOCKER=''
        export LDFLAGS_STATIC_DOCKER=''
        export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
        export BUILDFLAGS=( "${BUILDFLAGS[@]/static_build /}" ) # we're not building a "static" binary here
-       source "$(dirname "$BASH_SOURCE")/binary"
+       source "$(dirname "$BASH_SOURCE")/gccgo"
 )
diff --git a/hack/make/.dockerinit b/hack/make/.dockerinit-gccgo
index fceba7d..592a415 100644
--- a/hack/make/.dockerinit
+++ b/hack/make/.dockerinit-gccgo
@@ -5,13 +5,13 @@ IAMSTATIC="true"
 source "$(dirname "$BASH_SOURCE")/.go-autogen"

 # dockerinit still needs to be a static binary, even if docker is dynamic
-go build \
+go build --compiler=gccgo \
        -o "$DEST/dockerinit-$VERSION" \
        "${BUILDFLAGS[@]}" \
-       -ldflags "
-               $LDFLAGS
-               $LDFLAGS_STATIC
-               -extldflags \"$EXTLDFLAGS_STATIC\"
+       --gccgoflags "
+               -g
+               -Wl,--no-export-dynamic
+               $EXTLDFLAGS_STATIC_DOCKER
        " \
        ./dockerinit

@@ -21,9 +21,6 @@ ln -sf "dockerinit-$VERSION" "$DEST/dockerinit"
 sha1sum=
 if command -v sha1sum &> /dev/null; then
        sha1sum=sha1sum
-elif command -v shasum &> /dev/null; then
-       # Mac OS X - why couldn't they just use the same command name and be happy?
-       sha1sum=shasum
 else
        echo >&2 'error: cannot find sha1sum command or equivalent'
        exit 1
```
