### PR TITLE
Add syslog logging driver

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -83,7 +83,7 @@ func (config *Config) InstallFlags() {
 	opts.LabelListVar(&config.Labels, []string{"-label"}, "Set key=value labels to the daemon")
 	config.Ulimits = make(map[string]*ulimit.Ulimit)
 	opts.UlimitMapVar(config.Ulimits, []string{"-default-ulimit"}, "Set default ulimits for containers")
-	flag.StringVar(&config.LogConfig.Type, []string{"-log-driver"}, "json-file", "Containers logging driver(json-file/none)")
+	flag.StringVar(&config.LogConfig.Type, []string{"-log-driver"}, "json-file", "Containers logging driver")
 }
 
 func getDefaultNetworkMtu() int {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/logger/jsonfilelog"
+	"github.com/docker/docker/daemon/logger/syslog"
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/links"
@@ -1373,6 +1374,12 @@ func (container *Container) startLogging() error {
 		}
 
 		dl, err := jsonfilelog.New(pth)
+		if err != nil {
+			return err
+		}
+		l = dl
+	case "syslog":
+		dl, err := syslog.New(container.ID[:12])
 		if err != nil {
 			return err
 		}

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -1,0 +1,54 @@
+package syslog
+
+import (
+	"fmt"
+	"log/syslog"
+	"os"
+	"path"
+	"sync"
+
+	"github.com/docker/docker/daemon/logger"
+)
+
+type Syslog struct {
+	writer *syslog.Writer
+	tag    string
+	mu     sync.Mutex
+}
+
+func New(tag string) (logger.Logger, error) {
+	log, err := syslog.New(syslog.LOG_USER, path.Base(os.Args[0]))
+	if err != nil {
+		return nil, err
+	}
+	return &Syslog{
+		writer: log,
+		tag:    tag,
+	}, nil
+}
+
+func (s *Syslog) Log(msg *logger.Message) error {
+	logMessage := fmt.Sprintf("%s: %s", s.tag, string(msg.Line))
+	if msg.Source == "stderr" {
+		if err := s.writer.Err(logMessage); err != nil {
+			return err
+		}
+
+	} else {
+		if err := s.writer.Info(logMessage); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Syslog) Close() error {
+	if s.writer != nil {
+		return s.writer.Close()
+	}
+	return nil
+}
+
+func (s *Syslog) Name() string {
+	return "Syslog"
+}

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -117,7 +117,7 @@ IMAGE [COMMAND] [ARG...]
 **--lxc-conf**=[]
    (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
 
-**--log-driver**="|*json-file*|*none*"
+**--log-driver**="|*json-file*|*syslog*|*none*"
   Logging driver for container. Default is defined by daemon `--log-driver` flag.
   **Warning**: `docker logs` command works only for `json-file` logging driver.
 

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -218,7 +218,7 @@ which interface and port to use.
 **--lxc-conf**=[]
    (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
 
-**--log-driver**="|*json-file*|*none*"
+**--log-driver**="|*json-file*|*syslog*|*none*"
   Logging driver for container. Default is defined by daemon `--log-driver` flag.
   **Warning**: `docker logs` command works only for `json-file` logging driver.
 

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -89,7 +89,7 @@ unix://[/path/to/socket] to use.
 **--label**="[]"
   Set key=value labels to the daemon (displayed in `docker info`)
 
-**--log-driver**="*json-file*|*none*"
+**--log-driver**="*json-file*|*syslog*|*none*"
   Container's logging driver. Default is `default`.
   **Warning**: `docker logs` command works only for `json-file` logging driver.
 

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -258,7 +258,7 @@ Json Parameters:
         `Ulimits: { "Name": "nofile", "Soft": 1024, "Hard", 2048 }}`
   -   **LogConfig** - Logging configuration to container, format
         `{ "Type": "<driver_name>", "Config": {"key1": "val1"}}
-        Available types: `json-file`, `none`.
+        Available types: `json-file`, `syslog`, `none`.
         `json-file` logging driver.
 
 Query Parameters:

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -656,6 +656,11 @@ this driver.
 Default logging driver for Docker. Writes JSON messages to file. `docker logs`
 command is available only for this logging driver
 
+## Logging driver: syslog
+
+Syslog logging driver for Docker. Writes log messages to syslog. `docker logs`
+command is not available for this logging driver
+
 ## Overriding Dockerfile image defaults
 
 When a developer builds an image from a [*Dockerfile*](/reference/builder)


### PR DESCRIPTION
This PR adds support for logging to syslog from Docker by using the go built in syslog package.  This code uses the existing logging driver framework added to Docker 1.6.  An example output to syslog looks like

``````
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:                 _._                                                  
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:            _.-``__ ''-._                                             
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:       _.-``    `.  `_.  ''-._           Redis 2.8.19 (00000000/0) 64 bit
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:   .-`` .-```.  ```\/    _.,_ ''-._                                   
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:  (    '      ,       .-`  | `,    )     Running in stand alone mode
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:  |`-._`-...-` __...-.``-._|'` _.-'|     Port: 6379
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:  |    `-._   `._    /     _.-'    |     PID: 1
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:   `-._    `-._  `-./  _.-'    _.-'                                   
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:  |`-._`-._    `-.__.-'    _.-'_.-'|                                  
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:  |    `-._`-._        _.-'_.-'    |           http://redis.io        
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:   `-._    `-._`-.__.-'_.-'    _.-'                                   
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:  |`-._`-._    `-.__.-'    _.-'_.-'|                                  
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:  |    `-._`-._        _.-'_.-'    |                                  
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:   `-._    `-._`-.__.-'_.-'    _.-'                                   
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:       `-._    `-.__.-'    _.-'                                       
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:           `-._        _.-'                                           
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b:               `-.__.-'                                               
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b: 
Mar 18 00:36:04 inotmac docker[28485]: 94ce4ded774b: [1] 18 Mar 07:36:04.448 # Server started, Redis version 2.8.19
``````

NOTE: Credit goes to @wlan0 for the development of this, I'm just submitting the PR
