### PR TITLE
[WiP] Adds testing for bridge's IPv6 support

### DIFF
--- a/daemon/networkdriver/bridge/driver_test.go
+++ b/daemon/networkdriver/bridge/driver_test.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"testing"
@@ -102,6 +103,123 @@ func TestHostnameFormatChecking(t *testing.T) {
 	if res := AllocatePort(job); res == engine.StatusOK {
 		t.Fatal("Failed to check invalid HostIP")
 	}
+}
+
+func newInterfaceAllocation(t *testing.T, input engine.Env) (output engine.Env) {
+	eng := engine.New()
+	eng.Logging = false
+
+	done := make(chan bool)
+
+	// set IPv6 global if given
+	if input.Exists("globalIPv6Network") {
+		_, globalIPv6Network, _ = net.ParseCIDR(input.Get("globalIPv6Network"))
+	}
+
+	job := eng.Job("allocate_interface", "container_id")
+	job.Env().Init(&input)
+	reader, _ := job.Stdout.AddPipe()
+	go func() {
+		output.Decode(reader)
+		done <- true
+	}()
+
+	res := Allocate(job)
+	job.Stdout.Close()
+	<-done
+
+	if input.Exists("expectFail") && input.GetBool("expectFail") {
+		if res == engine.StatusOK {
+			t.Fatal("Doesn't fail to allocate network interface")
+		}
+	} else {
+		if res != engine.StatusOK {
+			t.Fatal("Failed to allocate network interface")
+		}
+	}
+
+	if input.Exists("globalIPv6Network") {
+		// check for bug #11427
+		_, subnet, _ := net.ParseCIDR(input.Get("globalIPv6Network"))
+		if globalIPv6Network.IP.String() != subnet.IP.String() {
+			t.Fatal("globalIPv6Network was modified during allocation")
+		}
+		// clean up IPv6 global
+		globalIPv6Network = nil
+	}
+
+	return
+}
+
+func TestIPv6InterfaceAllocationAutoNetmaskGt80(t *testing.T) {
+
+	input := engine.Env{}
+
+	_, subnet, _ := net.ParseCIDR("2001:db8:1234:1234:1234::/81")
+
+	// set global ipv6
+	input.Set("globalIPv6Network", subnet.String())
+
+	output := newInterfaceAllocation(t, input)
+
+	// ensure low manually assigend global ip
+	ip := net.ParseIP(output.Get("GlobalIPv6"))
+	_, subnet, _ = net.ParseCIDR(fmt.Sprintf("%s/%d", subnet.IP.String(), 120))
+	if !subnet.Contains(ip) {
+		t.Fatalf("Error ip %s not in subnet %s", ip.String(), subnet.String())
+	}
+}
+
+func TestIPv6InterfaceAllocationAutoNetmaskLe80(t *testing.T) {
+
+	input := engine.Env{}
+
+	_, subnet, _ := net.ParseCIDR("2001:db8:1234:1234:1234::/80")
+
+	// set global ipv6
+	input.Set("globalIPv6Network", subnet.String())
+	input.Set("RequestedMac", "ab:cd:ab:cd:ab:cd")
+
+	output := newInterfaceAllocation(t, input)
+
+	// ensure global ip with mac
+	ip := net.ParseIP(output.Get("GlobalIPv6"))
+	expected_ip := net.ParseIP("2001:db8:1234:1234:1234:abcd:abcd:abcd")
+	if ip.String() != expected_ip.String() {
+		t.Fatalf("Error ip %s should be %s", ip.String(), expected_ip.String())
+	}
+
+	// ensure link local format
+	ip = net.ParseIP(output.Get("LinkLocalIPv6"))
+	expected_ip = net.ParseIP("fe80::a9cd:abff:fecd:abcd")
+	if ip.String() != expected_ip.String() {
+		t.Fatalf("Error ip %s should be %s", ip.String(), expected_ip.String())
+	}
+
+}
+
+func TestIPv6InterfaceAllocationRequest(t *testing.T) {
+
+	input := engine.Env{}
+
+	_, subnet, _ := net.ParseCIDR("2001:db8:1234:1234:1234::/80")
+	expected_ip := net.ParseIP("2001:db8:1234:1234:1234::1328")
+
+	// set global ipv6
+	input.Set("globalIPv6Network", subnet.String())
+	input.Set("RequestedIPv6", expected_ip.String())
+
+	output := newInterfaceAllocation(t, input)
+
+	// ensure global ip with mac
+	ip := net.ParseIP(output.Get("GlobalIPv6"))
+	if ip.String() != expected_ip.String() {
+		t.Fatalf("Error ip %s should be %s", ip.String(), expected_ip.String())
+	}
+
+	// retry -> fails for duplicated address
+	input.SetBool("expectFail", true)
+	output = newInterfaceAllocation(t, input)
 }
 
 func TestMacAddrGeneration(t *testing.T) {


### PR DESCRIPTION
Here my first try to add some tests for the IPv6 bridge implementation (cf. #10001). Comments and help are warmly appreciated, since this is my first Docker / Golang contribution.

I implemented the following tests:
- test for global subnets <= 80
- test for global subnets > 80
- test link local generation
- test duplicated addresses
- tests regression from bug #11427

Cheers
