### PR TITLE
add centos to supported distros

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -81,7 +81,7 @@ fi
 
 lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
 case "$lsb_dist" in
-	amzn|fedora)
+	amzn|fedora|centos)
 		if [ "$lsb_dist" = 'amzn' ]; then
 			(
 				set -x


### PR DESCRIPTION
centos7 has a package alias to docker-io that installs the docker package, so we can just add it as-is

Signed-off-by: Aaron Welch welch@packet.net
