### PR TITLE
restrict bash completion for hostdir arg to directories

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -325,7 +325,7 @@ _docker_cp() {
 			(( counter++ ))
 
 			if [ $cword -eq $counter ]; then
-				_filedir
+				_filedir -d
 				return
 			fi
 			;;


### PR DESCRIPTION
The previous state assumed that the `HOSTPATH` argument referred to a file.
As clarified by @moxiegirl in PR #11305, it is a directory.
Adjusted completion to reflect this.

ping @jfrazelle @tianon 
