### PR TITLE
Remove 'name' filter from docker events documentation

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -949,7 +949,6 @@ Current filters:
 * container
 * event
 * image
-* name
 
 #### Examples
 


### PR DESCRIPTION
e0fa57737879681a8888de992eb6d2f0e624da74 added support for container names as an argument to the `docker events --filter container=xxx` filter.
It did **not** add a new filter name=xxx as assumed in #11311, see also the discussion there.
So this PR removes the filter from the docs again.

ping @moxiegirl 
cc @brahmaroutu
