### PR TITLE
Fixed --read-only description indentation

### DIFF
--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -302,14 +302,14 @@ allow the container nearly all the same access to the host as processes running
 outside of a container on the host.
 
 **--read-only**=*true*|*false*
-    Mount the container's root filesystem as read only.
+   Mount the container's root filesystem as read only.
 
-    By default a container will have its root filesystem writable allowing processes
+   By default a container will have its root filesystem writable allowing processes
 to write files anywhere.  By specifying the `--read-only` flag the container will have
 its root filesystem mounted as read only prohibiting any writes.
 
 **--restart**="no"
-      Restart policy to apply when a container exits (no, on-failure[:max-retry], always)
+   Restart policy to apply when a container exits (no, on-failure[:max-retry], always)
       
 **--rm**=*true*|*false*
    Automatically remove the container when it exits (incompatible with -d). The default is *false*.


### PR DESCRIPTION
The wrong indentation was breaking documentation layout with code blocks.
