### PR TITLE
Update normalization logic to allow local images named "library/*"

### DIFF
--- a/api/client/push.go
+++ b/api/client/push.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/parsers"
@@ -36,7 +37,7 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 	// applied to repository names and can warn the user in advance.
 	// Custom repositories can have different rules, and we must also
 	// allow pushing by image ID.
-	if repoInfo.Official {
+	if strings.Index(name, "/") == -1 {
 		username := authConfig.Username
 		if username == "" {
 			username = "<user>"

--- a/registry/config.go
+++ b/registry/config.go
@@ -331,10 +331,6 @@ func (config *ServiceConfig) NewRepositoryInfo(reposName string) (*RepositoryInf
 
 	if repoInfo.Index.Official {
 		normalizedName := repoInfo.RemoteName
-		if strings.HasPrefix(normalizedName, "library/") {
-			// If pull "library/foo", it's stored locally under "foo"
-			normalizedName = strings.SplitN(normalizedName, "/", 2)[1]
-		}
 
 		repoInfo.LocalName = normalizedName
 		repoInfo.RemoteName = normalizedName


### PR DESCRIPTION
Currently pushing official images is broken since images must be tagged and and pushed with the library prefix. This change roles back the normalization which strips the library prefix.

closes #11955
