### PR TITLE
Add rollover log driver, and --log-driver-opts flag

### DIFF
--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -19,7 +19,7 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 	follow := cmd.Bool([]string{"f", "-follow"}, false, "Follow log output")
 	since := cmd.String([]string{"-since"}, "", "Show logs since timestamp")
 	times := cmd.Bool([]string{"t", "-timestamps"}, false, "Show timestamps")
-	tail := cmd.String([]string{"-tail"}, "all", "Number of lines to show from the end of the logs")
+	tail := cmd.String([]string{"-tail"}, "latest", "Number of lines to show from the end of the logs")
 	cmd.Require(flag.Exact, 1)
 
 	cmd.ParseFlags(args, true)

--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -3,7 +3,6 @@ package logger
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"io"
 	"testing"
 	"time"
@@ -19,10 +18,6 @@ func (l *TestLoggerJSON) Close() error { return nil }
 
 func (l *TestLoggerJSON) Name() string { return "json" }
 
-func (l *TestLoggerJSON) GetReader() (io.Reader, error) {
-	return nil, errors.New("not used in the test")
-}
-
 type TestLoggerText struct {
 	*bytes.Buffer
 }
@@ -35,10 +30,6 @@ func (l *TestLoggerText) Log(m *Message) error {
 func (l *TestLoggerText) Close() error { return nil }
 
 func (l *TestLoggerText) Name() string { return "text" }
-
-func (l *TestLoggerText) GetReader() (io.Reader, error) {
-	return nil, errors.New("not used in the test")
-}
 
 func TestCopier(t *testing.T) {
 	stdoutLine := "Line that thinks that it is log line from docker stdout"

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -2,7 +2,7 @@ package fluentd
 
 import (
 	"bytes"
-	"io"
+	"fmt"
 	"math"
 	"net"
 	"strconv"
@@ -36,6 +36,9 @@ const (
 
 func init() {
 	if err := logger.RegisterLogDriver(name, New); err != nil {
+		logrus.Fatal(err)
+	}
+	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
 		logrus.Fatal(err)
 	}
 }
@@ -116,14 +119,22 @@ func (f *Fluentd) Log(msg *logger.Message) error {
 	return f.writer.PostWithTime(f.tag, msg.Timestamp, data)
 }
 
+func ValidateLogOpt(cfg map[string]string) error {
+	for key := range cfg {
+		switch key {
+		case "fluentd-address":
+		case "fluentd-tag":
+		default:
+			return fmt.Errorf("unknown log opt '%s' for fluentd log driver", key)
+		}
+	}
+	return nil
+}
+
 func (f *Fluentd) Close() error {
 	return f.writer.Close()
 }
 
 func (f *Fluentd) Name() string {
 	return name
-}
-
-func (s *Fluentd) GetReader() (io.Reader, error) {
-	return nil, logger.ReadLogsNotSupported
 }

--- a/daemon/logger/gelf/gelf.go
+++ b/daemon/logger/gelf/gelf.go
@@ -5,7 +5,6 @@ package gelf
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"net"
 	"net/url"
 	"time"
@@ -37,6 +36,9 @@ type GelfFields struct {
 
 func init() {
 	if err := logger.RegisterLogDriver(name, New); err != nil {
+		logrus.Fatal(err)
+	}
+	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
 		logrus.Fatal(err)
 	}
 }
@@ -113,16 +115,24 @@ func (s *GelfLogger) Log(msg *logger.Message) error {
 	return nil
 }
 
-func (s *GelfLogger) GetReader() (io.Reader, error) {
-	return nil, logger.ReadLogsNotSupported
-}
-
 func (s *GelfLogger) Close() error {
 	return s.writer.Close()
 }
 
 func (s *GelfLogger) Name() string {
 	return name
+}
+
+func ValidateLogOpt(cfg map[string]string) error {
+	for key := range cfg {
+		switch key {
+		case "gelf-address":
+		case "gelf-tag":
+		default:
+			return fmt.Errorf("unknown log opt '%s' for gelf log driver", key)
+		}
+	}
+	return nil
 }
 
 func parseAddress(address string) (string, error) {

--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -4,7 +4,6 @@ package journald
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/coreos/go-systemd/journal"
@@ -53,8 +52,4 @@ func (s *Journald) Close() error {
 
 func (s *Journald) Name() string {
 	return name
-}
-
-func (s *Journald) GetReader() (io.Reader, error) {
-	return nil, logger.ReadLogsNotSupported
 }

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -2,14 +2,17 @@ package jsonfilelog
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"sync"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/pkg/jsonlog"
 	"github.com/docker/docker/pkg/timeutils"
+	"github.com/docker/docker/pkg/units"
 )
 
 const (
@@ -19,15 +22,19 @@ const (
 // JSONFileLogger is Logger implementation for default docker logging:
 // JSON objects to file
 type JSONFileLogger struct {
-	buf *bytes.Buffer
-	f   *os.File   // store for closing
-	mu  sync.Mutex // protects buffer
-
-	ctx logger.Context
+	buf      *bytes.Buffer
+	f        *os.File   // store for closing
+	mu       sync.Mutex // protects buffer
+	capacity int64      //maximum size of each file
+	n        int        //maximum number of files
+	ctx      logger.Context
 }
 
 func init() {
 	if err := logger.RegisterLogDriver(Name, New); err != nil {
+		logrus.Fatal(err)
+	}
+	if err := logger.RegisterLogOptValidator(Name, ValidateLogOpt); err != nil {
 		logrus.Fatal(err)
 	}
 }
@@ -38,10 +45,30 @@ func New(ctx logger.Context) (logger.Logger, error) {
 	if err != nil {
 		return nil, err
 	}
+	var capval int64 = -1
+	if capacity, ok := ctx.Config["max-size"]; ok {
+		var err error
+		capval, err = units.FromHumanSize(capacity)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var maxFiles int = 1
+	if maxFileString, ok := ctx.Config["max-file"]; ok {
+		maxFiles, err = strconv.Atoi(maxFileString)
+		if err != nil {
+			return nil, err
+		}
+		if maxFiles < 1 {
+			return nil, fmt.Errorf("max-files cannot be less than 1.")
+		}
+	}
 	return &JSONFileLogger{
-		f:   log,
-		buf: bytes.NewBuffer(nil),
-		ctx: ctx,
+		f:        log,
+		buf:      bytes.NewBuffer(nil),
+		ctx:      ctx,
+		capacity: capval,
+		n:        maxFiles,
 	}, nil
 }
 
@@ -59,17 +86,102 @@ func (l *JSONFileLogger) Log(msg *logger.Message) error {
 		return err
 	}
 	l.buf.WriteByte('\n')
-	_, err = l.buf.WriteTo(l.f)
+	_, err = writeLog(l)
+	return err
+}
+
+func writeLog(l *JSONFileLogger) (int64, error) {
+	if l.capacity == -1 {
+		return writeToBuf(l)
+	}
+	meta, err := l.f.Stat()
 	if err != nil {
-		// this buffer is screwed, replace it with another to avoid races
+		return -1, err
+	}
+	if meta.Size() >= l.capacity {
+		name := l.f.Name()
+		if err := l.f.Close(); err != nil {
+			return -1, err
+		}
+		if err := rotate(name, l.n); err != nil {
+			return -1, err
+		}
+		file, err := os.OpenFile(name, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0666)
+		if err != nil {
+			return -1, err
+		}
+		l.f = file
+	}
+	return writeToBuf(l)
+}
+
+func writeToBuf(l *JSONFileLogger) (int64, error) {
+	i, err := l.buf.WriteTo(l.f)
+	if err != nil {
 		l.buf = bytes.NewBuffer(nil)
+	}
+	return i, err
+}
+
+func rotate(name string, n int) error {
+	if n < 2 {
+		return nil
+	}
+	for i := n - 1; i > 1; i-- {
+		oldFile := name + "." + strconv.Itoa(i)
+		replacingFile := name + "." + strconv.Itoa(i-1)
+		if err := backup(oldFile, replacingFile); err != nil {
+			return err
+		}
+	}
+	if err := backup(name+".1", name); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (l *JSONFileLogger) GetReader() (io.Reader, error) {
-	return os.Open(l.ctx.LogPath)
+func backup(old, curr string) error {
+	if _, err := os.Stat(old); !os.IsNotExist(err) {
+		err := os.Remove(old)
+		if err != nil {
+			return err
+		}
+	}
+	if _, err := os.Stat(curr); os.IsNotExist(err) {
+		if f, err := os.Create(curr); err != nil {
+			return err
+		} else {
+			f.Close()
+		}
+	}
+	return os.Rename(curr, old)
+}
+
+func ValidateLogOpt(cfg map[string]string) error {
+	for key := range cfg {
+		switch key {
+		case "max-file":
+		case "max-size":
+		default:
+			return fmt.Errorf("unknown log opt '%s' for json-file log driver", key)
+		}
+	}
+	return nil
+}
+
+func (l *JSONFileLogger) ReadLog(args ...string) (io.Reader, error) {
+	pth := l.ctx.LogPath
+	if len(args) > 0 {
+		//check if args[0] is an integer index
+		index, err := strconv.ParseInt(args[0], 0, 0)
+		if err != nil {
+			return nil, err
+		}
+		if index > 0 {
+			pth = pth + "." + args[0]
+		}
+	}
+	return os.Open(pth)
 }
 
 func (l *JSONFileLogger) LogPath() string {

--- a/daemon/logger/jsonfilelog/jsonfilelog_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -83,4 +84,68 @@ func BenchmarkJSONFileLogger(b *testing.B) {
 			}
 		}
 	}
+}
+
+func TestJSONFileLoggerWithOpts(t *testing.T) {
+	cid := "a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"
+	tmp, err := ioutil.TempDir("", "docker-logger-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+	filename := filepath.Join(tmp, "container.log")
+	config := map[string]string{"max-file": "2", "max-size": "1k"}
+	l, err := New(logger.Context{
+		ContainerID: cid,
+		LogPath:     filename,
+		Config:      config,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	for i := 0; i < 20; i++ {
+		if err := l.Log(&logger.Message{ContainerID: cid, Line: []byte("line" + strconv.Itoa(i)), Source: "src1"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	res, err := ioutil.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	penUlt, err := ioutil.ReadFile(filename + ".1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedPenultimate := `{"log":"line0\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line1\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line2\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line3\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line4\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line5\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line6\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line7\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line8\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line9\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line10\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line11\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line12\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line13\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line14\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line15\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+`
+	expected := `{"log":"line16\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line17\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line18\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+{"log":"line19\n","stream":"src1","time":"0001-01-01T00:00:00Z"}
+`
+
+	if string(res) != expected {
+		t.Fatalf("Wrong log content: %q, expected %q", res, expected)
+	}
+	if string(penUlt) != expectedPenultimate {
+		t.Fatalf("Wrong log content: %q, expected %q", penUlt, expectedPenultimate)
+	}
+
 }

--- a/daemon/logger/logger.go
+++ b/daemon/logger/logger.go
@@ -21,5 +21,9 @@ type Logger interface {
 	Log(*Message) error
 	Name() string
 	Close() error
-	GetReader() (io.Reader, error)
+}
+
+//Reader is an interface for docker logging drivers that support reading
+type Reader interface {
+	ReadLog(args ...string) (io.Reader, error)
 }

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -4,7 +4,7 @@ package syslog
 
 import (
 	"errors"
-	"io"
+	"fmt"
 	"log/syslog"
 	"net"
 	"net/url"
@@ -49,6 +49,9 @@ type Syslog struct {
 
 func init() {
 	if err := logger.RegisterLogDriver(name, New); err != nil {
+		logrus.Fatal(err)
+	}
+	if err := logger.RegisterLogOptValidator(name, ValidateLogOpt); err != nil {
 		logrus.Fatal(err)
 	}
 }
@@ -99,10 +102,6 @@ func (s *Syslog) Name() string {
 	return name
 }
 
-func (s *Syslog) GetReader() (io.Reader, error) {
-	return nil, logger.ReadLogsNotSupported
-}
-
 func parseAddress(address string) (string, string, error) {
 	if urlutil.IsTransportURL(address) {
 		url, err := url.Parse(address)
@@ -131,6 +130,19 @@ func parseAddress(address string) (string, string, error) {
 	}
 
 	return "", "", nil
+}
+
+func ValidateLogOpt(cfg map[string]string) error {
+	for key := range cfg {
+		switch key {
+		case "syslog-address":
+		case "syslog-tag":
+		case "syslog-facility":
+		default:
+			return fmt.Errorf("unknown log opt '%s' for syslog log driver", key)
+		}
+	}
+	return nil
 }
 
 func parseFacility(facility string) (syslog.Priority, error) {

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -15,6 +15,7 @@ import (
 	"github.com/docker/docker/autogen/dockerversion"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/daemon"
+	"github.com/docker/docker/daemon/logger"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/pidfile"
 	"github.com/docker/docker/pkg/signal"
@@ -92,6 +93,12 @@ func mainDaemon() {
 
 	if err := setDefaultUmask(); err != nil {
 		logrus.Fatalf("Failed to set umask: %v", err)
+	}
+
+	if len(daemonCfg.LogConfig.Config) > 0 {
+		if err := logger.ValidateLogOpts(daemonCfg.LogConfig.Type, daemonCfg.LogConfig.Config); err != nil {
+			logrus.Fatalf("Failed to set log opts: %v", err)
+		}
 	}
 
 	var pfile *pidfile.PidFile

--- a/docs/reference/commandline/logs.md
+++ b/docs/reference/commandline/logs.md
@@ -29,7 +29,7 @@ The `docker logs --follow` command will continue streaming the new output from
 the container's `STDOUT` and `STDERR`.
 
 Passing a negative number or a non-integer to `--tail` is invalid and the
-value is set to `all` in that case. This behavior may change in the future.
+value is set to `latest` in that case.
 
 The `docker logs --timestamp` commands will add an RFC3339Nano
 timestamp, for example `2014-09-16T06:17:46.000000000Z`, to each

--- a/docs/reference/logging/index.md
+++ b/docs/reference/logging/index.md
@@ -17,13 +17,27 @@ container's logging driver. The following options are supported:
 
 | `none`      | Disables any logging for the container. `docker logs` won't be available with this driver.                                    |
 |-------------|-------------------------------------------------------------------------------------------------------------------------------|
-| `json-file` | Default logging driver for Docker. Writes JSON messages to file.  No logging options are supported for this driver.           |
+| `json-file` | Default logging driver for Docker. Writes JSON messages to file.                                                              |
 | `syslog`    | Syslog logging driver for Docker. Writes log messages to syslog.                                                              |
 | `journald`  | Journald logging driver for Docker. Writes log messages to `journald`.                                                        |
 | `gelf`      | Graylog Extended Log Format (GELF) logging driver for Docker. Writes log messages to a GELF endpoint likeGraylog or Logstash. |
 | `fluentd`   | Fluentd logging driver for Docker. Writes log messages to `fluentd` (forward input).                                          |
 
 The `docker logs`command is available only for the `json-file` logging driver.  
+
+### The json-file options
+
+The following logging options are supported for the `json-file` logging driver:
+
+    --log-opt max-size=[0-9+][k|m|g]
+    --log-opt max-file=[0-9+]
+
+Logs that reach `max-size` are rolled over. You can set the size in kilobytes(k), megabytes(m), or gigabytes(g). eg `--log-opt max-size=50m`. If `max-size` is not set, then logs are not rolled over.
+
+
+`max-file` specifies the maximum number of files that a log is rolled over before being discarded. eg `--log-opt max-file=100`. If `max-size` is not set, then `max-file` is not honored.
+
+If `max-size` and `max-file` are set, `docker logs` only returns the log lines from the newest log file. 
 
 ### The syslog options
 

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -422,7 +422,6 @@ func parseLoggingOpts(loggingDriver string, loggingOpts []string) (map[string]st
 	if loggingDriver == "none" && len(loggingOpts) > 0 {
 		return map[string]string{}, fmt.Errorf("Invalid logging opts for driver %s", loggingDriver)
 	}
-	//TODO - validation step
 	return loggingOptsMap, nil
 }
 


### PR DESCRIPTION
Closes #8911

This adds log rollover capability to docker. I have added a new driver called `rollover` for this.

There are two options that can be specified along with this option. In order to specify these options, I added a new flag called `--log-driver-opts`. That would allow one to specify options like this

`docker run --logging-driver rollover --log-driver-opts max_size=1k --log-driver-opts file_count=10`
