### PR TITLE
Fix hostname missing when a container's net mode is contaienr mode

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1222,6 +1222,7 @@ func (container *Container) initializeNetworking() error {
 		if err != nil {
 			return err
 		}
+		container.HostnamePath = nc.HostnamePath
 		container.HostsPath = nc.HostsPath
 		container.ResolvConfPath = nc.ResolvConfPath
 		container.Config.Hostname = nc.Config.Hostname

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -412,6 +412,31 @@ func TestRunLinkToContainerNetMode(t *testing.T) {
 	logDone("run - link to a container which net mode is container success")
 }
 
+func TestRunModeNetContainerHostname(t *testing.T) {
+	defer deleteAllContainers()
+	cmd := exec.Command(dockerBinary, "run", "-i", "-d", "--name", "parent", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+	cmd = exec.Command(dockerBinary, "exec", "parent", "cat", "/etc/hostname")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("failed to exec command: %v, output: %q", err, out)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--net=container:parent", "busybox", "cat", "/etc/hostname")
+	out1, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatalf("failed to run container: %v, output: %q", err, out1)
+	}
+	if out1 != out {
+		t.Fatal("containers with shared net namespace should have same hostname")
+	}
+
+	logDone("run - containers with shared net namespace have same hostname")
+}
+
 // Regression test for #4741
 func TestRunWithVolumesAsFiles(t *testing.T) {
 	defer deleteAllContainers()


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

When a container's net mode is container mode, it share the net namespace with another
container and the `resolv.conf` `hosts` `hostname` should be the same.
But now, the `resolv.conf` `hosts` are the same, but the `hostname` is missing.
