### PR TITLE
Add a warning if /etc/docker/key.json permission isn't 0600 or 0400.

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -67,6 +67,11 @@ func main() {
 		flHosts = append(flHosts, defaultHost)
 	}
 
+	file := "/etc/docker/key.json"
+	info, _ := os.Stat(file)
+	if info.Mode().Perm()&0177 != 0 {
+		log.Warnf("%s file's permission isn't 400 or 600.", file)
+	}
 	setDefaultConfFlag(flTrustKey, defaultTrustKeyFile)
 
 	if *flDaemon {


### PR DESCRIPTION
The permission would lead to a risk. The warning would remind users of the risk.
For ssh, users have to input passwords manually if ssh key file's permission isn't 0400.

Signed-off-by: Yuan Sun sunyuan3@huawei.com
