### PR TITLE
Update libcontainer to 4a72e540feb67091156b907c4700e580a99f5a9d

### DIFF
--- a/daemon/execdriver/native/template/default_template.go
+++ b/daemon/execdriver/native/template/default_template.go
@@ -41,6 +41,26 @@ func New() *configs.Config {
 		},
 		Mounts: []*configs.Mount{
 			{
+				Source:      "proc",
+				Destination: "/proc",
+				Device:      "proc",
+				Flags:       defaultMountFlags,
+			},
+			{
+				Source:      "tmpfs",
+				Destination: "/dev",
+				Device:      "tmpfs",
+				Flags:       syscall.MS_NOSUID | syscall.MS_STRICTATIME,
+				Data:        "mode=755",
+			},
+			{
+				Source:      "devpts",
+				Destination: "/dev/pts",
+				Device:      "devpts",
+				Flags:       syscall.MS_NOSUID | syscall.MS_NOEXEC,
+				Data:        "newinstance,ptmxmode=0666,mode=0620,gid=5",
+			},
+			{
 				Device:      "tmpfs",
 				Source:      "shm",
 				Destination: "/dev/shm",

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -75,7 +75,7 @@ rm -rf src/github.com/docker/distribution
 mkdir -p src/github.com/docker/distribution
 mv tmp-digest src/github.com/docker/distribution/digest
 
-clone git github.com/docker/libcontainer 52a8c004ca94cf98f6866536de828c71eb42d1ec
+clone git github.com/docker/libcontainer 4a72e540feb67091156b907c4700e580a99f5a9d
 # see src/github.com/docker/libcontainer/update-vendor.sh which is the "source of truth" for libcontainer deps (just like this file)
 rm -rf src/github.com/docker/libcontainer/vendor
 eval "$(grep '^clone ' src/github.com/docker/libcontainer/update-vendor.sh | grep -v 'github.com/codegangsta/cli' | grep -v 'github.com/Sirupsen/logrus')"

--- a/vendor/src/github.com/coreos/go-systemd/activation/listeners.go
+++ b/vendor/src/github.com/coreos/go-systemd/activation/listeners.go
@@ -30,7 +30,7 @@ func Listeners(unsetEnv bool) ([]net.Listener, error) {
 		var err error
 		listeners[i], err = net.FileListener(f)
 		if err != nil {
-			return nil, fmt.Errorf("Error setting up FileListener for fd %d: %v", f.Fd(), err)
+			return nil, fmt.Errorf("Error setting up FileListener for fd %d: %s", f.Fd(), err.Error())
 		}
 	}
 

--- a/vendor/src/github.com/docker/libcontainer/container.go
+++ b/vendor/src/github.com/docker/libcontainer/container.go
@@ -96,7 +96,7 @@ type Container interface {
 	//
 	// errors:
 	// Systemerror - System error.
-	Set() error
+	Set(config configs.Config) error
 
 	// Start a process inside the container. Returns error if process fails to
 	// start. You can track process lifecycle with passed Process structure.

--- a/vendor/src/github.com/docker/libcontainer/container_linux.go
+++ b/vendor/src/github.com/docker/libcontainer/container_linux.go
@@ -78,9 +78,10 @@ func (c *linuxContainer) Stats() (*Stats, error) {
 	return stats, nil
 }
 
-func (c *linuxContainer) Set() error {
+func (c *linuxContainer) Set(config configs.Config) error {
 	c.m.Lock()
 	defer c.m.Unlock()
+	c.config = &config
 	return c.cgroupManager.Set(c.config)
 }
 

--- a/vendor/src/github.com/docker/libcontainer/factory_linux.go
+++ b/vendor/src/github.com/docker/libcontainer/factory_linux.go
@@ -10,7 +10,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"syscall"
 
+	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/libcontainer/cgroups"
 	"github.com/docker/libcontainer/cgroups/fs"
 	"github.com/docker/libcontainer/cgroups/systemd"
@@ -73,6 +75,20 @@ func Cgroupfs(l *LinuxFactory) error {
 		return &fs.Manager{
 			Cgroups: config,
 			Paths:   paths,
+		}
+	}
+	return nil
+}
+
+// TmpfsRoot is an option func to mount LinuxFactory.Root to tmpfs.
+func TmpfsRoot(l *LinuxFactory) error {
+	mounted, err := mount.Mounted(l.Root)
+	if err != nil {
+		return err
+	}
+	if !mounted {
+		if err := syscall.Mount("tmpfs", l.Root, "tmpfs", 0, ""); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/vendor/src/github.com/docker/libcontainer/integration/template_test.go
+++ b/vendor/src/github.com/docker/libcontainer/integration/template_test.go
@@ -61,6 +61,26 @@ func newTemplateConfig(rootfs string) *configs.Config {
 		Hostname: "integration",
 		Mounts: []*configs.Mount{
 			{
+				Source:      "proc",
+				Destination: "/proc",
+				Device:      "proc",
+				Flags:       defaultMountFlags,
+			},
+			{
+				Source:      "tmpfs",
+				Destination: "/dev",
+				Device:      "tmpfs",
+				Flags:       syscall.MS_NOSUID | syscall.MS_STRICTATIME,
+				Data:        "mode=755",
+			},
+			{
+				Source:      "devpts",
+				Destination: "/dev/pts",
+				Device:      "devpts",
+				Flags:       syscall.MS_NOSUID | syscall.MS_NOEXEC,
+				Data:        "newinstance,ptmxmode=0666,mode=0620,gid=5",
+			},
+			{
 				Device:      "tmpfs",
 				Source:      "shm",
 				Destination: "/dev/shm",

--- a/vendor/src/github.com/docker/libcontainer/nsinit/config.go
+++ b/vendor/src/github.com/docker/libcontainer/nsinit/config.go
@@ -235,6 +235,26 @@ func getTemplate() *configs.Config {
 		},
 		Mounts: []*configs.Mount{
 			{
+				Source:      "proc",
+				Destination: "/proc",
+				Device:      "proc",
+				Flags:       defaultMountFlags,
+			},
+			{
+				Source:      "tmpfs",
+				Destination: "/dev",
+				Device:      "tmpfs",
+				Flags:       syscall.MS_NOSUID | syscall.MS_STRICTATIME,
+				Data:        "mode=755",
+			},
+			{
+				Source:      "devpts",
+				Destination: "/dev/pts",
+				Device:      "devpts",
+				Flags:       syscall.MS_NOSUID | syscall.MS_NOEXEC,
+				Data:        "newinstance,ptmxmode=0666,mode=0620,gid=5",
+			},
+			{
 				Device:      "tmpfs",
 				Source:      "shm",
 				Destination: "/dev/shm",

--- a/vendor/src/github.com/docker/libcontainer/user/user_test.go
+++ b/vendor/src/github.com/docker/libcontainer/user/user_test.go
@@ -198,7 +198,7 @@ this is just some garbage data
 
 		execUser, err := GetExecUser(test.ref, &defaultExecUser, passwd, group)
 		if err != nil {
-			t.Logf("got unexpected error when parsing '%s': %v", test.ref, err)
+			t.Logf("got unexpected error when parsing '%s': %s", test.ref, err.Error())
 			t.Fail()
 			continue
 		}
@@ -337,7 +337,7 @@ this is just some garbage data
 
 		execUser, err := GetExecUser(test.ref, &defaultExecUser, passwd, group)
 		if err != nil {
-			t.Logf("got unexpected error when parsing '%s': %v", test.ref, err)
+			t.Logf("got unexpected error when parsing '%s': %s", test.ref, err.Error())
 			t.Fail()
 			continue
 		}


### PR DESCRIPTION
- Moves all mounts to the config
- libcontainer Set API updated to take in a config
- Support for mounting root to tmpfs

Signed-off-by: Mrunal Patel mrunalp@gmail.com
