### PR TITLE
Allow forward slash prefix to container name when running docker rm

### DIFF
--- a/api/client/rm.go
+++ b/api/client/rm.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -30,6 +31,7 @@ func (cli *DockerCli) CmdRm(args ...string) error {
 
 	var encounteredError error
 	for _, name := range cmd.Args() {
+		name = strings.TrimPrefix(name, "/")
 		_, _, err := readBody(cli.call("DELETE", "/containers/"+name+"?"+val.Encode(), nil, nil))
 		if err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -140,6 +140,22 @@ func TestRmInvalidContainer(t *testing.T) {
 	logDone("rm - delete unknown container")
 }
 
+func TestRmContainerNameWithSlash(t *testing.T) {
+	defer deleteAllContainers()
+
+	cmd := exec.Command(dockerBinary, "run", "--name", "testContainer", "busybox", "true")
+	if _, err := runCommand(cmd); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd = exec.Command(dockerBinary, "rm", "/testContainer")
+	if out, _, err := runCommandWithOutput(cmd); err != nil {
+		t.Fatal(out, err)
+	}
+
+	logDone("rm - removed container with name prefix /")
+}
+
 func createRunningContainer(t *testing.T, name string) {
 	cmd := exec.Command(dockerBinary, "run", "-dt", "--name", name, "busybox", "top")
 	if _, err := runCommand(cmd); err != nil {


### PR DESCRIPTION
Addresses #6898
Signed-off-by: Srini Brahmaroutu srbrahma@us.ibm.com
