### PR TITLE
add support --net=container with --mac-address, --add-host error out

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1107,7 +1107,7 @@ func (container *Container) setupContainerDns() error {
 		return err
 	}
 
-	if config.NetworkMode != "host" {
+	if config.NetworkMode.IsBridge() || config.NetworkMode.IsNone() {
 		// check configurations for any container/daemon dns settings
 		if len(config.Dns) > 0 || len(daemon.config.Dns) > 0 || len(config.DnsSearch) > 0 || len(daemon.config.DnsSearch) > 0 {
 			var (

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -282,7 +282,8 @@ With the networking mode set to `host` a container will share the host's
 network stack and all interfaces from the host will be available to the
 container.  The container's hostname will match the hostname on the host
 system.  Publishing ports and linking to other containers will not work
-when sharing the host's network stack.
+when sharing the host's network stack. Note that `--add-host` `--hostname`
+`--dns` `--dns-search` and `--mac-address` is invalid in `host` netmode.
 
 Compared to the default `bridge` mode, the `host` mode gives *significantly*
 better networking performance since it uses the host's native networking stack
@@ -298,7 +299,9 @@ or a High Performance Web Server.
 
 With the networking mode set to `container` a container will share the
 network stack of another container.  The other container's name must be
-provided in the format of `--net container:<name|id>`.
+provided in the format of `--net container:<name|id>`. Note that `--add-host` 
+`--hostname` `--dns` `--dns-search` and `--mac-address` is invalid 
+in `container` netmode.
 
 Example running a Redis container with Redis binding to `localhost` then
 running the `redis-cli` command and connecting to the Redis server over the

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -371,6 +371,33 @@ func (s *DockerSuite) TestRunLinkToContainerNetMode(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestRunContainerNetModeWithDnsMacHosts(c *check.C) {
+	cmd := exec.Command(dockerBinary, "run", "-d", "--name", "parent", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--dns", "1.2.3.4", "--net=container:parent", "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "Conflicting options: --dns and the network mode") {
+		c.Fatalf("run --net=container with --dns should error out")
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--mac-address", "92:d0:c6:0a:29:33", "--net=container:parent", "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "--mac-address and the network mode") {
+		c.Fatalf("run --net=container with --mac-address should error out")
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--add-host", "test:192.168.2.109", "--net=container:parent", "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "--add-host and the network mode") {
+		c.Fatalf("run --net=container with --add-host should error out")
+	}
+
+}
+
 func (s *DockerSuite) TestRunModeNetContainerHostname(c *check.C) {
 	testRequires(c, ExecSupport)
 	cmd := exec.Command(dockerBinary, "run", "-i", "-d", "--name", "parent", "busybox", "top")

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -21,6 +21,10 @@ func (n NetworkMode) IsPrivate() bool {
 	return !(n.IsHost() || n.IsContainer() || n.IsNone())
 }
 
+func (n NetworkMode) IsBridge() bool {
+	return n == "bridge"
+}
+
 func (n NetworkMode) IsHost() bool {
 	return n == "host"
 }


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

There are two commits in this PR, the first one is to do clean up 
for `--net=container` with `--link`. The previous code suppose to 
prevent user from using `--link` with `--net=container`, 
but the code `if *flNetMode == "container"` never work 
because the value of `*flNetMode` should 
be like this `container:xxxx`, so both of us think `--net=container` 
with `--link` is a desired behavior,
so I created PR #11369 (sorry for didn't realize it wasn't a
 desired behavior at that time). What should
we do?  revert #11369 and prevent user from using `--link` 
with `--net=container` or keep #11369 and clean up the 
invalid conflict checking? ping @LK4D4  @estesp  @icecrime 

The second commits is to fix `--net=container` with `--dns` no error out, 
it's the same problem, `if *flNetMode == "container" && flDns.Len() > 0`  
never work. Since a container with `--net=container`
means it have the same `dns, hosts, mac address` with its parent, 
`--add-host, --mac-address` is invalid on creation, 
so we should error out when user use these option on creation with `--net=container`
