### PR TITLE
Add LABEL config check to runconfig compare

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4585,14 +4585,29 @@ func TestBuildLabelsCache(t *testing.T) {
 		`FROM busybox
 		LABEL Vendor=Acme1`, true)
 	if err != nil || id1 == id2 {
-		t.Fatalf("Build 2 should have worked & NOT used cache(%s,%s): %v", id1, id2, err)
+		t.Fatalf("Build 3 should have worked & NOT used cache(%s,%s): %v", id1, id2, err)
 	}
 
 	id2, err = buildImage(name,
 		`FROM busybox
 		LABEL Vendor Acme`, true) // Note: " " and "=" should be same
 	if err != nil || id1 != id2 {
-		t.Fatalf("Build 3 should have worked & used cache(%s,%s): %v", id1, id2, err)
+		t.Fatalf("Build 4 should have worked & used cache(%s,%s): %v", id1, id2, err)
+	}
+
+	// Now make sure the cache isn't used by mistake
+	id1, err = buildImage(name,
+		`FROM busybox
+       LABEL f1=b1 f2=b2`, false)
+	if err != nil {
+		t.Fatalf("Build 5 should have worked: %q", err)
+	}
+
+	id2, err = buildImage(name,
+		`FROM busybox
+       LABEL f1="b1 f2=b2"`, true)
+	if err != nil || id1 == id2 {
+		t.Fatalf("Build 6 should have worked & NOT used the cache(%s,%s): %q", id1, id2, err)
 	}
 
 	logDone("build - label cache")

--- a/runconfig/compare.go
+++ b/runconfig/compare.go
@@ -19,6 +19,7 @@ func Compare(a, b *Config) bool {
 	}
 	if len(a.Cmd) != len(b.Cmd) ||
 		len(a.Env) != len(b.Env) ||
+		len(a.Labels) != len(b.Labels) ||
 		len(a.PortSpecs) != len(b.PortSpecs) ||
 		len(a.ExposedPorts) != len(b.ExposedPorts) ||
 		len(a.Entrypoint) != len(b.Entrypoint) ||
@@ -33,6 +34,11 @@ func Compare(a, b *Config) bool {
 	}
 	for i := 0; i < len(a.Env); i++ {
 		if a.Env[i] != b.Env[i] {
+			return false
+		}
+	}
+	for k, v := range a.Labels {
+		if v != b.Labels[k] {
 			return false
 		}
 	}


### PR DESCRIPTION
I was playing with LABELs this morning and noticed that these two Dockerfiles resulted in using the same cache:

```
FROM busybox
LABEL f1=b1 f2=b2

FROM busybox
LABEL f1='b1 f2=b2'
```

Without this PR we won't do a proper cache check because we skip the
labels part of the config.

Signed-off-by: Doug Davis dug@us.ibm.com
