### PR TITLE
Ignore blank lines in getCgroupPaths

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -112,6 +112,10 @@ func TestRunWithUlimits(t *testing.T) {
 func getCgroupPaths(test string) map[string]string {
 	cgroupPaths := map[string]string{}
 	for _, line := range strings.Split(test, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
 		parts := strings.Split(line, ":")
 		if len(parts) != 3 {
 			fmt.Printf("unexpected file format for /proc/self/cgroup - %q\n", line)


### PR DESCRIPTION
w/o this I would see:

```
  unexpected file format for /proc/self/cgroup - ""
```

while running the cgroup tests

Signed-off-by: Doug Davis dug@us.ibm.com
