### PR TITLE
Proposal: Support mount propagation

### DIFF
--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -239,6 +239,11 @@ func (d *driver) setupMounts(container *configs.Config, c *execdriver.Command) e
 		if m.Slave {
 			flags |= syscall.MS_SLAVE
 		}
+		// Add code to parse /foo:/foo:p to decide whether this should be set.
+		// m.Private should be true by default unless p is found
+		if m.Private {
+			flags |= syscall.MS_PRIVATE
+		}
 
 		container.Mounts = append(container.Mounts, &configs.Mount{
 			Source:      m.Source,

--- a/vendor/src/github.com/docker/libcontainer/rootfs_linux.go
+++ b/vendor/src/github.com/docker/libcontainer/rootfs_linux.go
@@ -122,7 +122,7 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 			}
 		}
 		if m.Flags&syscall.MS_PRIVATE != 0 {
-			if err := syscall.Mount("", dest, "none", uintptr(syscall.MS_PRIVATE), ""); err != nil {
+			if err := syscall.Mount("", dest, "none", uintptr(syscall.MS_PRIVATE|syscall.MS_REC), ""); err != nil {
 				return err
 			}
 		}
@@ -239,9 +239,9 @@ func mknodDevice(dest string, node *configs.Device) error {
 }
 
 func prepareRoot(config *configs.Config) error {
-	flag := syscall.MS_PRIVATE | syscall.MS_REC
+	flag := syscall.MS_PRIVATE
 	if config.NoPivotRoot {
-		flag = syscall.MS_SLAVE | syscall.MS_REC
+		flag = syscall.MS_SLAVE
 	}
 	if err := syscall.Mount("", "/", "", uintptr(flag), ""); err != nil {
 		return err


### PR DESCRIPTION
## Why

Currently in Docker all mounts in the container are set to private for mount propagation.  This proposal is to allow mount propagation to work in Docker such that containers can have shared or slave mounts with the host system.  The obvious use cause is something like `/media`.  As the host mount and umount things in that directory they will show up in the container.

The much cooler use case is something like ZFS or ceph.  If one was to set a shared mount at /mnt on the host you could have a container that pulls in the ZFS or ceph user land and manages the ZFS/ceph mounts from the container, but the mounts go to the host.  Then other containers can bind mount in folder from the mounts.

Other use cases are to allow running VirtualBox or VMware tools from a container since both of these tools do things with mounts.
## Design

A new `p` flag, standing for propagation, will be added to the volume mount parameter.  For example:

```
`/media:/media:rwp`
```

The `p` flag is only valid when specifying a host path.  It would be nice to support shared mount volumes between containers, but I think that could be done as a second PR.
## Implementation

**Note: The code in this PR is currently a sample of how this could be done.  And lacks the UI code**

Currently Docker creates the container root as basically `mount --rprivate`.  This means all submounts will be by default private.  I propose we change it so that we create the root as `make --private`.  Then each bind mount we do will by default have the `MS_PRIVATE` flag on it.  If the user specifies the `p` flag we will not set MS_PRIVATE on the bind mounts thus respecting the mount propagation of the source.
### Security??

I can't see any security issues, but it is worth noting.  The root of the container should always start with something that has no submounts.  By doing `--make-private` we ensure that that mount is in fact private and since there are no submounts, everything is private.  As we add more bind mounts they will default to `MS_PRIVATE`, but we should also mount then with `MS_REC` to ensure any submounts of the bind mount stay private.  This should result in the default configuration that all mounts are private.
