### PR TITLE
Check volume path to make sure its not the empty string

### DIFF
--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -427,6 +427,10 @@ func volume(b *Builder, args []string, attributes map[string]bool, original stri
 		b.Config.Volumes = map[string]struct{}{}
 	}
 	for _, v := range args {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return fmt.Errorf("Volume specified can not be an empty string")
+		}
 		b.Config.Volumes[v] = struct{}{}
 	}
 	if err := b.commit("", b.Config.Cmd, fmt.Sprintf("VOLUME %v", args)); err != nil {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5408,3 +5408,19 @@ func TestBuildResourceConstraintsAreUsed(t *testing.T) {
 
 	logDone("build - resource constraints applied")
 }
+
+func TestBuildEmptyStringVolume(t *testing.T) {
+	name := "testbuildemptystringvolume"
+	defer deleteImages(name)
+
+	_, err := buildImage(name, `
+  FROM busybox
+  ENV foo=""
+  VOLUME $foo
+  `, false)
+	if err == nil {
+		t.Fatal("Should have failed to build")
+	}
+
+	logDone("build - empty string volume")
+}


### PR DESCRIPTION
With this Dockerfile

```
FROM ubuntu
ENV ABC=""
VOLUME $ABC
```

It builds ok but then at run time I get this error:

FATA[0002] Error response from daemon: Cannot start container 8902b4a7aaf5c4e4b11a38070d392db465fa97ad88c91c8b38dda5ab8149ccac: [8] System error: no such file or directory

Because the Volume config shows "" as the path.  This PR checks for "" as
the path and stops it at build time.

Signed-off-by: Doug Davis dug@us.ibm.com

/cc @cpuguy83 
