### PR TITLE
integ-cli: fix bug and race in TestBuildSpaces

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5124,9 +5124,13 @@ func TestBuildSpaces(t *testing.T) {
 		t.Fatal("Build 2 was supposed to fail, but didn't")
 	}
 
+	removeLogTimestamps := func(s string) string {
+		return regexp.MustCompile(`time="(.*?)"`).ReplaceAllString(s, `time=[TIMESTAMP]`)
+	}
+
 	// Skip over the times
-	e1 := err1.Error()[strings.Index(err1.Error(), `level=`):]
-	e2 := err2.Error()[strings.Index(err1.Error(), `level=`):]
+	e1 := removeLogTimestamps(err1.Error())
+	e2 := removeLogTimestamps(err2.Error())
 
 	// Ignore whitespace since that's what were verifying doesn't change stuff
 	if strings.Replace(e1, " ", "", -1) != strings.Replace(e2, " ", "", -1) {
@@ -5139,8 +5143,8 @@ func TestBuildSpaces(t *testing.T) {
 	}
 
 	// Skip over the times
-	e1 = err1.Error()[strings.Index(err1.Error(), `level=`):]
-	e2 = err2.Error()[strings.Index(err1.Error(), `level=`):]
+	e1 = removeLogTimestamps(err1.Error())
+	e2 = removeLogTimestamps(err2.Error())
 
 	// Ignore whitespace since that's what were verifying doesn't change stuff
 	if strings.Replace(e1, " ", "", -1) != strings.Replace(e2, " ", "", -1) {
@@ -5153,8 +5157,8 @@ func TestBuildSpaces(t *testing.T) {
 	}
 
 	// Skip over the times
-	e1 = err1.Error()[strings.Index(err1.Error(), `level=`):]
-	e2 = err2.Error()[strings.Index(err1.Error(), `level=`):]
+	e1 = removeLogTimestamps(err1.Error())
+	e2 = removeLogTimestamps(err2.Error())
 
 	// Ignore whitespace since that's what were verifying doesn't change stuff
 	if strings.Replace(e1, " ", "", -1) != strings.Replace(e2, " ", "", -1) {


### PR DESCRIPTION
`TestBuildSpaces` is used to do string manipulation to redact timestamps
from compared cmd output. However it was assuming there is going to be
only one `time=".."` in the output --not the case on windows. Therefore
I wrote a regexp to redact all log timestamps.  This test is currently failing randomly
since test cannot replaces all timestamps correctly.

Also the test used to have a copy/paste bug (see err1/err2). This fixes
that, too.

cc: @jfrazelle @duglin 
Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
