### PR TITLE
making `docker history` output timestamps with `--no-trunc`

### DIFF
--- a/api/client/history.go
+++ b/api/client/history.go
@@ -46,11 +46,11 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 			fmt.Fprintf(w, stringid.TruncateID(entry.ID))
 		}
 		if !*quiet {
-			fmt.Fprintf(w, "\t%s ago\t", units.HumanDuration(time.Now().UTC().Sub(time.Unix(entry.Created, 0))))
-
 			if *noTrunc {
+				fmt.Fprintf(w, "\t%s\t", time.Unix(entry.Created, 0).Format(time.RFC3339))
 				fmt.Fprintf(w, "%s\t", entry.CreatedBy)
 			} else {
+				fmt.Fprintf(w, "\t%s ago\t", units.HumanDuration(time.Now().UTC().Sub(time.Unix(entry.Created, 0))))
 				fmt.Fprintf(w, "%s\t", utils.Trunc(entry.CreatedBy, 45))
 			}
 			fmt.Fprintf(w, "%s", units.HumanSize(float64(entry.Size)))


### PR DESCRIPTION
Reports the layer's created timestamp in RFC3339 format when `--no-trunc` is used.

For example:

```
# docker history hello-world
IMAGE               CREATED             CREATED BY                                      SIZE
e45a5af57b00        11 weeks ago        /bin/sh -c #(nop) CMD [/hello]                  0 B
31cbccb51277        11 weeks ago        /bin/sh -c #(nop) ADD file:25f7e227e118ddc844   910 B
511136ea3c5a        21 months ago                                                       0 B
# docker history --no-trunc hello-world
IMAGE                                                              CREATED                CREATED BY                                                                                         SIZE
e45a5af57b00862e5ef5782a9925979a02ba2b12dff832fd0991335f4a11e5c5   2014-12-31T22:57:59Z   /bin/sh -c #(nop) CMD [/hello]                                                                     0 B
31cbccb51277105ba3ae35ce33c22b69c9e3f1002e76e4c736a2e8ebff9d7b5d   2014-12-31T22:57:58Z   /bin/sh -c #(nop) ADD file:25f7e227e118ddc844c0dc0ec2dc765e8bb558fffb5bc546b4b609ad5a41c1fd in /   910 B
511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158   2013-06-13T21:03:50Z                                                                                                      0 B
```

Fixes #11413

Signed-off-by: Dave Henderson Dave.Henderson@ca.ibm.com
