### PR TITLE
logging: use logrus fields

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -114,12 +114,12 @@ func mainDaemon() {
 			return
 		}
 
-		logrus.Infof("docker daemon: %s %s; execdriver: %s; graphdriver: %s",
-			dockerversion.VERSION,
-			dockerversion.GITCOMMIT,
-			d.ExecutionDriver().Name(),
-			d.GraphDriver().String(),
-		)
+		logrus.WithFields(logrus.Fields{
+			"version":     dockerversion.VERSION,
+			"commit":      dockerversion.GITCOMMIT,
+			"execdriver":  d.ExecutionDriver().Name(),
+			"graphdriver": d.GraphDriver().String(),
+		}).Info("Docker daemon")
 
 		if err := d.Install(eng); err != nil {
 			daemonInitWait <- err


### PR DESCRIPTION
There are many cases in the Docker daemon that could benefit from using fields instead of the `printf`-family of functions. Fields are one of the major reasons I built Logrus, after being frustrated again and again in production with poor logs that could've greatly benefited from including from more contextual information. Some of the benefits in my mind:
- **Strong mental model**. When I write production code nowadays and write a log statement, I always start with a `WithFields` and ask myself: If I had to debug this error, what would be the most useful information to include? I didn't find the mental model to be as strong with `printf`-style functions
- **Easier to glance**. Look below for an example of this. Another example is debugging a value being passed around many places, it's easy to see where it gets changed when the fields are sorted.
- **More modular**.  In the future as we allow people to customize the daemon logging more (e.g. the driver work currently going on), fields can also help provide more flexibility for those drivers.
- **Log indexers**. Fields work a lot better with logging indexers (e.g. Splunk, Logstash, etc.) as the `key=value` format is extremely common and parsed by default by most indexers. Currently in the Docker source code mostly `:` is used, which is tougher to parse and most indexers don't do it by default.

There are many hundreds of cases in Docker of `printf`-style logging that could be replaced with fields, and this PR doesn't do much. It's simply to discuss the issue of whether we should use more field-based logging in Docker (with some example code).

**Before**
![screen shot 2015-03-21 at 22 25 25](https://cloud.githubusercontent.com/assets/97400/6767762/dd25dde8-d01b-11e4-9cd5-9f3b29e1f912.png)

**After**
![screen shot 2015-03-21 at 22 44 11](https://cloud.githubusercontent.com/assets/97400/6767760/d2d4db96-d01b-11e4-944a-620310960769.png)

**Downsides**
- **Performance**. With an extreme amount of debugging level logging, allocating a map for a subset of those logging statements can mean a performance hit (mostly from GC). I don't think this will be an issue in Docker. If we ever see it becoming an issue, a new Logrus API can be added (and may be anyway) where `WithFields` takes arguments in pairs instead of allocating a map.
- **Coupling with Logrus**. This couples Docker's logging more with Logrus. Regardless, I think there's value in creating a culture in the code-base of adding fields and if another logger is chosen in the future it should be possible to script a complete transformation in the code base if the API is different. The hard work is not the API, the work is in decoupling the fields from the messages.

If we agree that this is a direction to move forward, I'll follow this PR up converting more of the existing examples that benefit from this into field-based logging.

@crosbymichael @jfrazelle @LK4D4 @tiborvass 
