### PR TITLE
Validate import tarball

### DIFF
--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -41,3 +41,37 @@ func TestImportDisplay(t *testing.T) {
 
 	logDone("import - display is fine, imported image runs")
 }
+
+func TestImportFromSaveStdout(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatalf("failed to create a container: %v %v", out, err)
+	}
+	cleanedContainerID := strings.TrimSpace(out)
+	defer deleteContainer(cleanedContainerID)
+
+	repoName := "foobar-save-load-test-tar"
+
+	commitCmd := exec.Command(dockerBinary, "commit", cleanedContainerID, repoName)
+	out, _, err = runCommandWithOutput(commitCmd)
+	if err != nil {
+		t.Fatalf("failed to commit container: %v %v", out, err)
+	}
+
+	saveCommand := exec.Command(dockerBinary, "save", repoName)
+	repoTarball, _, err := runCommandWithOutput(saveCommand)
+	if err != nil {
+		t.Fatalf("failed to save repo: %v %v", repoTarball, err)
+	}
+	deleteImages(repoName)
+
+	importCmd := exec.Command(dockerBinary, "import", "-", "test:latest")
+	importCmd.Stdin = strings.NewReader(repoTarball)
+	out, _, err = runCommandWithOutput(importCmd)
+	if err == nil {
+		t.Fatalf("expected error, but succeeded with no error and output: %v", out)
+	}
+
+	logDone("import - importing previously saved image gives an error")
+}

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -47,7 +47,7 @@ func TestSaveXzAndLoadRepoStdout(t *testing.T) {
 		exec.Command("xz", "-c"),
 		exec.Command("gzip", "-c"))
 	if err != nil {
-		t.Fatalf("failed to save repo: %v %v", out, err)
+		t.Fatalf("failed to save repo: %v %v", repoTarball, err)
 	}
 	deleteImages(repoName)
 


### PR DESCRIPTION
Validate `docker import` tarball and warn user if she's trying to import a previously `docker save`'ed image. Fixes: #10385 

Signed-off-by: Antonio Murdaca me@runcom.ninja
