### PR TITLE
Fixes docker events since beginning of unix time

### DIFF
--- a/events/events.go
+++ b/events/events.go
@@ -59,7 +59,7 @@ func (e *Events) Get(job *engine.Job) error {
 	}
 
 	// If no until, disable timeout
-	if until == 0 {
+	if job.Getenv("until") == "" {
 		timeout.Stop()
 	}
 
@@ -70,7 +70,7 @@ func (e *Events) Get(job *engine.Job) error {
 	job.Stdout.Write(nil)
 
 	// Resend every event in the [since, until] time interval.
-	if since != 0 {
+	if job.Getenv("since") != "" {
 		if err := e.writeCurrent(job, since, until, eventFilters); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes issue #11555
Applied a workaround to check if since and until flags are valid or not.

Signed-off-by: André Martins martins@noironetworks.com
