### PR TITLE
fix copying file from overlay volume path

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -937,10 +937,20 @@ func (container *Container) Copy(resource string) (io.ReadCloser, error) {
 	}
 
 	// Check if this is actually in a volume
+	var (
+		tmpMnt  *Mount
+		pathLen = 0
+	)
 	for _, mnt := range container.VolumeMounts() {
 		if len(mnt.MountToPath) > 0 && strings.HasPrefix(resource, mnt.MountToPath[1:]) {
-			return mnt.Export(resource)
+			if len(mnt.MountToPath) > pathLen {
+				tmpMnt = mnt
+				pathLen = len(mnt.MountToPath)
+			}
 		}
+	}
+	if tmpMnt != nil {
+		return tmpMnt.Export(resource)
 	}
 
 	stat, err := os.Stat(basePath)


### PR DESCRIPTION
$docker run -v /a:/layer1/ -v /b:/layer1/layer2 XXX
$docker cp ContainerID:/layer1/layer2/xxx failed with:
    FATA[0000] Error response from daemon: Could
not find the file /layer1/layer2/xxx in container.

This commit fix this.

Signed-off-by: Deng Guangxing dengguangxing@huawei.com
