### PR TITLE
integration-cli: do not check creation datetime, it can change

### DIFF
--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -158,7 +158,17 @@ func TestImagesFilterWhiteSpaceTrimmingAndLowerCasingWorking(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		date_start := strings.Index(out, "CREATED")
+		date_end := strings.Index(out, "VIRTUAL SIZE")
 		listing := strings.Split(out, "\n")
+		for _, str := range listing {
+			lenth := len(str)
+			if lenth == 0 {
+				continue
+			}
+			str = (str[0:date_start] + str[date_end:lenth])
+		}
+
 		sort.Strings(listing)
 		imageListings[idx] = listing
 	}

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -166,6 +166,7 @@ func TestImagesFilterWhiteSpaceTrimmingAndLowerCasingWorking(t *testing.T) {
 			if lenth == 0 {
 				continue
 			}
+			fmt.Print("Split intervals:", 0, date_start, date_end, lenth)
 			str = (str[0:date_start] + str[date_end:lenth])
 		}
 


### PR DESCRIPTION
In TestImagesFilterWhiteSpaceTrimmingAndLowerCasingWorking
if the time had changed between image listings, listings will be
different because they include creation time. Patch removes
creation time from comparison.
- check lenth != 0, in case of empty line

We got it running tests on v1.5.0 with vfs graph driver, for img
8ba30c03fa38 CREATED had changed from "3 minutes" to "4 minutes",
fail log:

```
out 0
<none>              <none>              77415989777c        4 minutes
ago       2.43 MB
<none>              <none>              8ba30c03fa38        3 minutes
ago       2.43 MB
<none>              <none>              d589e4d704ca        3 minutes
ago       2.43 MB
REPOSITORY          TAG                 IMAGE ID            CREATED
VIRTUAL SIZE
out 1
<none>              <none>              77415989777c        4 minutes
ago       2.43 MB
<none>              <none>              8ba30c03fa38        3 minutes
ago       2.43 MB
<none>              <none>              d589e4d704ca        3 minutes
ago       2.43 MB
REPOSITORY          TAG                 IMAGE ID            CREATED
VIRTUAL SIZE
out 2
<none>              <none>              77415989777c        4 minutes
ago       2.43 MB
<none>              <none>              8ba30c03fa38        4 minutes
ago       2.43 MB
<none>              <none>              d589e4d704ca        3 minutes
ago       2.43 MB
REPOSITORY          TAG                 IMAGE ID            CREATED
VIRTUAL SIZE
out 3
<none>              <none>              77415989777c        4 minutes
ago       2.43 MB
<none>              <none>              8ba30c03fa38        4 minutes
ago       2.43 MB
<none>              <none>              d589e4d704ca        3 minutes
ago       2.43 MB
REPOSITORY          TAG                 IMAGE ID            CREATED
VIRTUAL SIZE
out 4
<none>              <none>              77415989777c        4 minutes
ago       2.43 MB
<none>              <none>              8ba30c03fa38        4 minutes
ago       2.43 MB
<none>              <none>              d589e4d704ca        3 minutes
ago       2.43 MB
REPOSITORY          TAG                 IMAGE ID            CREATED
VIRTUAL SIZE
```

Signed-off-by: Pavel Tikhomirov ptikhomirov@parallels.com
