### PR TITLE
systemd that doesn't use DefaultDependencies=false should run a container successfully

### DIFF
--- a/vendor/src/github.com/docker/libcontainer/cgroups/systemd/apply_systemd.go
+++ b/vendor/src/github.com/docker/libcontainer/cgroups/systemd/apply_systemd.go
@@ -91,7 +91,7 @@ func UseSystemd() bool {
 		ddf := newProp("DefaultDependencies", false)
 		if _, err := theConn.StartTransientUnit("docker-systemd-test-default-dependencies.scope", "replace", ddf); err != nil {
 			if dbusError, ok := err.(dbus.Error); ok {
-				if dbusError.Name == "org.freedesktop.DBus.Error.PropertyReadOnly" {
+				if dbusError.Name == "org.freedesktop.DBus.Error.PropertyReadOnly" || dbusError.Name == "org.freedesktop.systemd1.UnitExists" {
 					hasTransientDefaultDependencies = false
 				}
 			}


### PR DESCRIPTION
systemd that doesn't use DefaultDependencies=false should run a container successfully

see the issue:https://github.com/docker/docker/issues/11639

Signed-off-by: Chen Chao chenchao@qiyi.com
