### PR TITLE
syslog Close() - Remove redunant nil check, s.writer cannot be nil

### DIFF
--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -43,10 +43,7 @@ func (s *Syslog) Log(msg *logger.Message) error {
 }
 
 func (s *Syslog) Close() error {
-	if s.writer != nil {
-		return s.writer.Close()
-	}
-	return nil
+	return s.writer.Close()
 }
 
 func (s *Syslog) Name() string {


### PR DESCRIPTION
Fixes #11650

Signed-off-by: Antonio Murdaca me@runcom.ninja
