### PR TITLE
Fix v2 get all tags (carrying 11334)

### DIFF
--- a/registry/session_v2.go
+++ b/registry/session_v2.go
@@ -352,8 +352,8 @@ func (r *Session) PutV2ImageManifest(ep *Endpoint, imageName, tagName string, si
 }
 
 type remoteTags struct {
-	Name string
-	Tags []string
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
 }
 
 // Given a repository name, returns a json array of string tags

--- a/registry/session_v2.go
+++ b/registry/session_v2.go
@@ -352,8 +352,8 @@ func (r *Session) PutV2ImageManifest(ep *Endpoint, imageName, tagName string, si
 }
 
 type remoteTags struct {
-	name string
-	tags []string
+	Name string
+	Tags []string
 }
 
 // Given a repository name, returns a json array of string tags
@@ -393,5 +393,5 @@ func (r *Session) GetV2RemoteTags(ep *Endpoint, imageName string, auth *RequestA
 	if err != nil {
 		return nil, fmt.Errorf("Error while decoding the http response: %s", err)
 	}
-	return remote.tags, nil
+	return remote.Tags, nil
 }


### PR DESCRIPTION
Fixes unexported struct tags causing get all tags in v2 to fail

replaces #11334
