### PR TITLE
Added missing code example in the RM command reference 

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1661,6 +1661,8 @@ containers removing all network communication.
 The main process inside the container referenced under the link `/redis` will receive
 `SIGKILL`, then the container will be removed.
 
+    $ docker rm $(docker ps -a -q)
+
 This command will delete all stopped containers. The command `docker ps
 -a -q` will return all existing container IDs and pass them to the `rm`
 command which will delete them. Any running containers will not be


### PR DESCRIPTION
Added missing code example for command to delete all stopped containers

Fixes #11527 

Signed-off-by: Natalie Parker nparker@omnifone.com
