### PR TITLE
#6141 Allowing configfile to be overwritten with an environment variable...

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -457,7 +457,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 		return err
 	}
 	registry.SaveConfig(cli.configFile)
-	fmt.Fprintf(cli.out, "WARNING: login credentials saved in %s.\n", path.Join(homedir.Get(), registry.CONFIGFILE))
+	fmt.Fprintf(cli.out, "WARNING: login credentials saved in %s.\n", registry.ConfFile)
 
 	if out2.Get("Status") != "" {
 		fmt.Fprintf(cli.out, "%s\n", out2.Get("Status"))

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -25,6 +25,7 @@ const (
 
 var (
 	ErrConfigFileMissing = errors.New("The Auth config file is missing")
+	ConfFile = ""
 )
 
 type AuthConfig struct {
@@ -164,14 +165,15 @@ func decodeAuth(authStr string) (string, string, error) {
 // FIXME: use the internal golang config parser
 func LoadConfig(rootPath string) (*ConfigFile, error) {
 	configFile := ConfigFile{Configs: make(map[string]AuthConfig), rootPath: rootPath}
-	confFile := os.Getenv("DOCKER_CFG")
-	if confFile == "" {
-		confFile = path.Join(rootPath, CONFIGFILE)
+	ConfFile = os.Getenv("DOCKER_CFG")
+	if ConfFile == "" {
+		fmt.Println("No environment variable found")
+		ConfFile = path.Join(rootPath, CONFIGFILE)
 	}
-	if _, err := os.Stat(confFile); err != nil {
+	if _, err := os.Stat(ConfFile); err != nil {
 		return &configFile, nil //missing file is not an error
 	}
-	b, err := ioutil.ReadFile(confFile)
+	b, err := ioutil.ReadFile(ConfFile)
 	if err != nil {
 		return &configFile, err
 	}
@@ -214,12 +216,13 @@ func LoadConfig(rootPath string) (*ConfigFile, error) {
 
 // save the auth config
 func SaveConfig(configFile *ConfigFile) error {
-	confFile := os.Getenv("DOCKER_CFG")
-	if confFile == "" {
-		confFile = path.Join(configFile.rootPath, CONFIGFILE)
+	ConfFile = os.Getenv("DOCKER_CFG")
+	if ConfFile == "" {
+		fmt.Println("No environment variable found")
+		ConfFile = path.Join(configFile.rootPath, CONFIGFILE)
 	}
 	if len(configFile.Configs) == 0 {
-		os.Remove(confFile)
+		os.Remove(ConfFile)
 		return nil
 	}
 
@@ -238,7 +241,7 @@ func SaveConfig(configFile *ConfigFile) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(confFile, b, 0600)
+	err = ioutil.WriteFile(ConfFile, b, 0600)
 	if err != nil {
 		return err
 	}

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -164,7 +164,10 @@ func decodeAuth(authStr string) (string, string, error) {
 // FIXME: use the internal golang config parser
 func LoadConfig(rootPath string) (*ConfigFile, error) {
 	configFile := ConfigFile{Configs: make(map[string]AuthConfig), rootPath: rootPath}
-	confFile := path.Join(rootPath, CONFIGFILE)
+	confFile := os.Getenv("DOCKER_CFG")
+	if confFile == "" {
+		confFile = path.Join(rootPath, CONFIGFILE)
+	}
 	if _, err := os.Stat(confFile); err != nil {
 		return &configFile, nil //missing file is not an error
 	}
@@ -211,7 +214,10 @@ func LoadConfig(rootPath string) (*ConfigFile, error) {
 
 // save the auth config
 func SaveConfig(configFile *ConfigFile) error {
-	confFile := path.Join(configFile.rootPath, CONFIGFILE)
+	confFile := os.Getenv("DOCKER_CFG")
+	if confFile == "" {
+		confFile = path.Join(configFile.rootPath, CONFIGFILE)
+	}
 	if len(configFile.Configs) == 0 {
 		os.Remove(confFile)
 		return nil


### PR DESCRIPTION
This allows the .dockercfg location to be overwritten with an environment variable, DOCKER_CFG.
