### PR TITLE
Allow docker pull to pull multiple repos/images

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1569,9 +1569,9 @@ This shows all the containers that have exited with status of '0'
 
 ## pull
 
-    Usage: docker pull [OPTIONS] NAME[:TAG]
+    Usage: docker pull [OPTIONS] NAME[:TAG] [NAME[:TAG]...]
 
-    Pull an image or a repository from the registry
+    Pull images or repositories from the registry.
 
       -a, --all-tags=false    Download all tagged images in the repository
 
@@ -1591,6 +1591,9 @@ use `docker pull`:
 
     $ sudo docker pull debian
     # will pull the debian:latest image and its intermediate layers
+    $ sudo docker pull debian ubuntu busybox
+    # will pull debian:latest, ubuntu:latest and busybox:latest images and 
+    # their intermediate layers
     $ sudo docker pull debian:testing
     # will pull the image named debian:testing and any intermediate
     # layers it is based on.

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -134,3 +134,13 @@ func TestPullImageOfficialNames(t *testing.T) {
 	}
 	logDone("pull - pull official names")
 }
+
+// Pull multiple images
+func TestPullMultipleImages(t *testing.T) {
+	pullCmd := exec.Command(dockerBinary, "pull", "hello-world", "busybox")
+	_, exitCode, err := runCommandWithOutput(pullCmd)
+	if err != nil || exitCode != 0 {
+		t.Fatalf("Pulling multiple images failed")
+	}
+	logDone("pull - pull multiple images")
+}


### PR DESCRIPTION
This is a client side change to the docker pull command. It updates the command to allow for multiple images/repos to be specified as arguments instead of just one.

It loops through the list of repos/images passed and pulls them individually just like the original command. 

-- Mountain View docker.party

Signed-off-by: Ankush Agarwal ankushagarwal11@gmail.com
