### PR TITLE
Add test for net=container and links

### DIFF
--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -125,7 +125,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		return nil, nil, cmd, ErrConflictHostNetworkAndLinks
 	}
 
-	if *flNetMode == "container" && flLinks.Len() > 0 {
+	if strings.HasPrefix(*flNetMode, "container") && flLinks.Len() > 0 {
 		return nil, nil, cmd, ErrConflictContainerNetworkAndLinks
 	}
 

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -133,7 +133,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		return nil, nil, cmd, ErrConflictHostNetworkAndDns
 	}
 
-	if *flNetMode == "container" && flDns.Len() > 0 {
+	if strings.HasPrefix(*flNetMode, "container") && flDns.Len() > 0 {
 		return nil, nil, cmd, ErrConflictContainerNetworkAndDns
 	}
 

--- a/runconfig/parse_test.go
+++ b/runconfig/parse_test.go
@@ -57,3 +57,9 @@ func TestNetHostname(t *testing.T) {
 		t.Fatalf("Expected error ErrConflictNetworkHostname, got: %s", err)
 	}
 }
+
+func TestConflictContainerNetworkAndLinks(t *testing.T) {
+	if _, _, _, err := parseRun([]string{"--net=container:other", "--link=zip:zap", "img", "cmd"}); err != ErrConflictContainerNetworkAndLinks {
+		t.Fatalf("Expected error ErrConflictContainerNetworkAndLinks, got: %s", err)
+	}
+}


### PR DESCRIPTION
closes #9340
In writing a test for this we discovered that the check was wrong, hence the prefix change.
