### PR TITLE
TestBuildCancelationKillsSleep sends exec cmd to stdout

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2031,7 +2031,6 @@ func TestBuildCancelationKillsSleep(t *testing.T) {
 
 	buildCmd := exec.Command(dockerBinary, "build", "-t", name, ".")
 	buildCmd.Dir = ctx.Dir
-	buildCmd.Stdout = os.Stdout
 
 	err = buildCmd.Start()
 	if err != nil {


### PR DESCRIPTION
and makes the testing output ugly.

This hides the output since it not used.

Signed-off-by: Doug Davis dug@us.ibm.com
