### PR TITLE
removed unnecessary tabs from /usr/sbin/policy-rc.d, and /sbin/initctl for mkimage.sh debootstrap

### DIFF
--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -37,7 +37,7 @@ rootfs_chroot() {
 
 # prevent init scripts from running during install/update
 echo >&2 "+ echo exit 101 > '$rootfsDir/usr/sbin/policy-rc.d'"
-cat > "$rootfsDir/usr/sbin/policy-rc.d" <<'EOF'
+cat > "$rootfsDir/usr/sbin/policy-rc.d" <<-'EOF'
 	#!/bin/sh
 
 	# For most Docker users, "apt-get install" only happens during "docker build",


### PR DESCRIPTION
`contrib/mkimage.sh debootstrap` creates a debian image which
has unnecessary tabs in /usr/sbin/policy-rc.d, and /sbin/initctl.

```
% sudo contrib/mkimage.sh debootstrap --arch=amd64 --variant=minbase --components=main stable http://ftp.jp.debian.org/debian                   
+ mkdir -p /var/tmp/docker-mkimage.kqap1CTM6d/rootfs
+ debootstrap --arch=amd64 --variant=minbase --components=main stable /var/tmp/docker-mkimage.kqap1CTM6d/rootfs http://ftp.jp.debian.org/debian
I: Retrieving Release 
I: Retrieving Release.gpg 
I: Checking Release signature
:
(snip)
:
Removing intermediate container 735f944a4e73
Successfully built cdea84963ea8
+ rm -rf /var/tmp/docker-mkimage.kqap1CTM6d
% docker run --rm cdea84963ea8 cat /usr/sbin/policy-rc.d
    #!/bin/sh

    # For most Docker users, "apt-get install" only happens during "docker build",
    # where starting services doesn't work and often fails in humorous ways. This
    # prevents those failures by stopping the services from attempting to start.

    exit 101
% docker run --rm cdea84963ea8 cat /sbin/initctl
    #!/bin/sh

    # For most Docker users, "apt-get install" only happens during "docker build",
    # where starting services doesn't work and often fails in humorous ways. This
    # prevents those failures by stopping the services from attempting to start.

    exit 101
```

This pull request removes those tabs.

```
% git checkout fix/debootstrap
Switched to branch 'fix/debootstrap'
Your branch is up-to-date with 'origin/fix/debootstrap'.
% sudo contrib/mkimage.sh debootstrap --arch=amd64 --variant=minbase --components=main stable http://ftp.jp.debian.org/debian
+ mkdir -p /var/tmp/docker-mkimage.uePTXpg4pc/rootfs
+ debootstrap --arch=amd64 --variant=minbase --components=main stable /var/tmp/docker-mkimage.uePTXpg4pc/rootfs http://ftp.jp.debian.org/debian
I: Retrieving Release 
I: Retrieving Release.gpg 
I: Checking Release signature
:
(snip)
:
Removing intermediate container f51d632cb42d
Successfully built d21a4c46d84d
+ rm -rf /var/tmp/docker-mkimage.uePTXpg4pc
% docker run --rm d21a4c46d84d cat /usr/sbin/policy-rc.d
#!/bin/sh

# For most Docker users, "apt-get install" only happens during "docker build",
# where starting services doesn't work and often fails in humorous ways. This
# prevents those failures by stopping the services from attempting to start.

exit 101
% docker run --rm d21a4c46d84d cat /sbin/initctl
#!/bin/sh

# For most Docker users, "apt-get install" only happens during "docker build",
# where starting services doesn't work and often fails in humorous ways. This
# prevents those failures by stopping the services from attempting to start.

exit 0
```
