### PR TITLE
Fix login

### DIFF
--- a/api/client/login.go
+++ b/api/client/login.go
@@ -123,7 +123,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	}
 
 	var response types.AuthResponse
-	if err := json.NewDecoder(stream).Decode(response); err != nil {
+	if err := json.NewDecoder(stream).Decode(&response); err != nil {
 		cli.configFile, _ = registry.LoadConfig(homedir.Get())
 		return err
 	}


### PR DESCRIPTION
Right now it returns:

```
FATA[0001] json: Unmarshal(non-pointer types.AuthResponse)
```

Signed-off-by: Doug Davis dug@us.ibm.com
