### PR TITLE
btrfs: #ifdef for build version

### DIFF
--- a/daemon/graphdriver/btrfs/btrfs.go
+++ b/daemon/graphdriver/btrfs/btrfs.go
@@ -61,6 +61,9 @@ func (d *Driver) String() string {
 
 func (d *Driver) Status() [][2]string {
 	status := [][2]string{}
+	if bv := BtrfsBuildVersion(); bv != "-" {
+		status = append(status, [2]string{"Build Version", bv})
+	}
 	if lv := BtrfsLibVersion(); lv != -1 {
 		status = append(status, [2]string{"Library Version", fmt.Sprintf("%d", lv)})
 	}

--- a/daemon/graphdriver/btrfs/version.go
+++ b/daemon/graphdriver/btrfs/version.go
@@ -5,16 +5,21 @@ package btrfs
 /*
 #include <btrfs/version.h>
 
-// because around version 3.16, they did not define lib version yet
-int my_btrfs_lib_version() {
-#ifdef BTRFS_LIB_VERSION
-  return BTRFS_LIB_VERSION;
-#else
-  return -1;
+// around version 3.16, they did not define lib version yet
+#ifndef BTRFS_LIB_VERSION
+#define BTRFS_LIB_VERSION -1
 #endif
-}
+
+// upstream had removed it, but now it will be coming back
+#ifndef BTRFS_BUILD_VERSION
+#define BTRFS_BUILD_VERSION "-"
+#endif
 */
 import "C"
+
+func BtrfsBuildVersion() string {
+	return string(C.BTRFS_BUILD_VERSION)
+}
 
 func BtrfsLibVersion() int {
 	return int(C.BTRFS_LIB_VERSION)

--- a/daemon/graphdriver/btrfs/version_none.go
+++ b/daemon/graphdriver/btrfs/version_none.go
@@ -5,6 +5,10 @@ package btrfs
 // TODO(vbatts) remove this work-around once supported linux distros are on
 // btrfs utililties of >= 3.16.1
 
+func BtrfsBuildVersion() string {
+	return "-"
+}
+
 func BtrfsLibVersion() int {
 	return -1
 }


### PR DESCRIPTION
We removed it, because upstream removed it. But now it will be coming
back, so work with it either way.

ping @lsm5 @tianon

ref: 
- https://github.com/docker/docker/pull/11417
- https://github.com/tianon/docker-overlay/issues/38#issuecomment-86105345

Signed-off-by: Vincent Batts vbatts@redhat.com
