### PR TITLE
Rename 'Fds' to 'File Descriptors' in docker info

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -81,7 +81,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		}
 		fmt.Fprintf(cli.out, "Debug mode (client): %v\n", os.Getenv("DEBUG") != "")
 		if remoteInfo.Exists("NFd") {
-			fmt.Fprintf(cli.out, "Fds: %d\n", remoteInfo.GetInt("NFd"))
+			fmt.Fprintf(cli.out, "File Descriptors: %d\n", remoteInfo.GetInt("NFd"))
 		}
 		if remoteInfo.Exists("NGoroutines") {
 			fmt.Fprintf(cli.out, "Goroutines: %d\n", remoteInfo.GetInt("NGoroutines"))

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1333,7 +1333,7 @@ For example:
     Total Memory: 2 GiB
     Debug mode (server): false
     Debug mode (client): true
-    Fds: 10
+    File Descriptors: 10
     Goroutines: 9
     System Time: Tue Mar 10 18:38:57 UTC 2015
     EventsListeners: 0

--- a/docs/sources/userguide/labels-custom-metadata.md
+++ b/docs/sources/userguide/labels-custom-metadata.md
@@ -179,7 +179,7 @@ These labels appear as part of the `docker info` output for the daemon:
     ID: RC3P:JTCT:32YS:XYSB:YUBG:VFED:AAJZ:W3YW:76XO:D7NN:TEVU:UCRW
     Debug mode (server): false
     Debug mode (client): true
-    Fds: 11
+    File Descriptors: 11
     Goroutines: 14
     EventsListeners: 0
     Init Path: /usr/bin/docker

--- a/integration/z_final_test.go
+++ b/integration/z_final_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func displayFdGoroutines(t *testing.T) {
-	t.Logf("Fds: %d, Goroutines: %d", utils.GetTotalUsedFds(), runtime.NumGoroutine())
+	t.Logf("File Descriptors: %d, Goroutines: %d", utils.GetTotalUsedFds(), runtime.NumGoroutine())
 }
 
 func TestFinal(t *testing.T) {
 	nuke(globalDaemon)
-	t.Logf("Start Fds: %d, Start Goroutines: %d", startFds, startGoroutines)
+	t.Logf("Start File Descriptors: %d, Start Goroutines: %d", startFds, startGoroutines)
 	displayFdGoroutines(t)
 }


### PR DESCRIPTION
This makes the docker info more readable. Also change a log line
in a test file renaming Fds

Signed-off-by: Ankush Agarwal ankushagarwal11@gmail.com
