### PR TITLE
Add support for extending the .dockercfg file

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -285,8 +285,6 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 
 	v.Set("dockerfile", *dockerfileName)
 
-	cli.LoadConfigFile()
-
 	headers := http.Header(make(map[string][]string))
 	buf, err := json.Marshal(cli.configFile)
 	if err != nil {

--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -107,14 +107,6 @@ func (cli *DockerCli) Subcmd(name, signature, description string, exitOnError bo
 	return flags
 }
 
-func (cli *DockerCli) LoadConfigFile() (err error) {
-	cli.configFile, err = registry.LoadConfig(homedir.Get())
-	if err != nil {
-		fmt.Fprintf(cli.err, "WARNING: %s\n", err)
-	}
-	return err
-}
-
 func (cli *DockerCli) CheckTtyInput(attachStdin, ttyMode bool) error {
 	// In order to attach to a container tty, input stream for the client must
 	// be a tty itself: redirecting or piping the client standard input is
@@ -167,6 +159,11 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, keyFile string, proto, a
 		tr.Dial = (&net.Dialer{Timeout: timeout}).Dial
 	}
 
+	configFile, err2 := registry.LoadConfig(homedir.Get())
+	if err2 != nil {
+		fmt.Fprintf(err, "WARNING: %s\n", err2)
+	}
+
 	return &DockerCli{
 		proto:         proto,
 		addr:          addr,
@@ -181,5 +178,6 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, keyFile string, proto, a
 		tlsConfig:     tlsConfig,
 		scheme:        scheme,
 		transport:     tr,
+		configFile:    configFile,
 	}
 }

--- a/api/client/create.go
+++ b/api/client/create.go
@@ -36,9 +36,6 @@ func (cli *DockerCli) pullImageCustomOut(image string, out io.Writer) error {
 		return err
 	}
 
-	// Load the auth config file, to be able to pull the image
-	cli.LoadConfigFile()
-
 	// Resolve the Auth config relevant for this server
 	authConfig := cli.configFile.ResolveAuthConfig(repoInfo.Index)
 	buf, err := json.Marshal(authConfig)

--- a/api/client/info.go
+++ b/api/client/info.go
@@ -119,8 +119,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		fmt.Fprintf(cli.out, "No Proxy: %s\n", remoteInfo.Get("NoProxy"))
 	}
 	if len(remoteInfo.GetList("IndexServerAddress")) != 0 {
-		cli.LoadConfigFile()
-		u := cli.configFile.Configs[remoteInfo.Get("IndexServerAddress")].Username
+		u := cli.configFile.AuthConfigs[remoteInfo.Get("IndexServerAddress")].Username
 		if len(u) > 0 {
 			fmt.Fprintf(cli.out, "Username: %v\n", u)
 			fmt.Fprintf(cli.out, "Registry: %v\n", remoteInfo.GetList("IndexServerAddress"))

--- a/api/client/login.go
+++ b/api/client/login.go
@@ -57,8 +57,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 		return string(line)
 	}
 
-	cli.LoadConfigFile()
-	authconfig, ok := cli.configFile.Configs[serverAddress]
+	authconfig, ok := cli.configFile.AuthConfigs[serverAddress]
 	if !ok {
 		authconfig = registry.AuthConfig{}
 	}
@@ -114,11 +113,11 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	authconfig.Password = password
 	authconfig.Email = email
 	authconfig.ServerAddress = serverAddress
-	cli.configFile.Configs[serverAddress] = authconfig
+	cli.configFile.AuthConfigs[serverAddress] = authconfig
 
-	stream, statusCode, err := cli.call("POST", "/auth", cli.configFile.Configs[serverAddress], nil)
+	stream, statusCode, err := cli.call("POST", "/auth", cli.configFile.AuthConfigs[serverAddress], nil)
 	if statusCode == 401 {
-		delete(cli.configFile.Configs, serverAddress)
+		delete(cli.configFile.AuthConfigs, serverAddress)
 		registry.SaveConfig(cli.configFile)
 		return err
 	}
@@ -128,7 +127,8 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 
 	var response types.AuthResponse
 	if err := json.NewDecoder(stream).Decode(&response); err != nil {
-		cli.configFile, _ = registry.LoadConfig(homedir.Get())
+		// Upon error, remove entry
+		delete(cli.configFile.AuthConfigs, serverAddress)
 		return err
 	}
 

--- a/api/client/logout.go
+++ b/api/client/logout.go
@@ -23,12 +23,11 @@ func (cli *DockerCli) CmdLogout(args ...string) error {
 		serverAddress = cmd.Arg(0)
 	}
 
-	cli.LoadConfigFile()
-	if _, ok := cli.configFile.Configs[serverAddress]; !ok {
+	if _, ok := cli.configFile.AuthConfigs[serverAddress]; !ok {
 		fmt.Fprintf(cli.out, "Not logged in to %s\n", serverAddress)
 	} else {
 		fmt.Fprintf(cli.out, "Remove login credentials for %s\n", serverAddress)
-		delete(cli.configFile.Configs, serverAddress)
+		delete(cli.configFile.AuthConfigs, serverAddress)
 
 		if err := registry.SaveConfig(cli.configFile); err != nil {
 			return fmt.Errorf("Failed to save docker config: %v", err)

--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -42,8 +42,6 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 		return err
 	}
 
-	cli.LoadConfigFile()
-
 	_, _, err = cli.clientRequestAttemptLogin("POST", "/images/create?"+v.Encode(), nil, cli.out, repoInfo.Index, "pull")
 	return err
 }

--- a/api/client/push.go
+++ b/api/client/push.go
@@ -21,8 +21,6 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 
 	name := cmd.Arg(0)
 
-	cli.LoadConfigFile()
-
 	remote, tag := parsers.ParseRepositoryTag(name)
 
 	// Resolve the Repository name from fqn to RepositoryInfo

--- a/api/client/search.go
+++ b/api/client/search.go
@@ -37,8 +37,6 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 		return err
 	}
 
-	cli.LoadConfigFile()
-
 	body, statusCode, errReq := cli.clientRequestAttemptLogin("GET", "/images/search?"+v.Encode(), nil, nil, repoInfo.Index, "search")
 	rawBody, _, err := readBody(body, statusCode, errReq)
 	if err != nil {

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -437,7 +437,7 @@ func (b *Builder) pullImage(name string) (*imagepkg.Image, error) {
 	}
 	job := b.Engine.Job("pull", remote, tag)
 	pullRegistryAuth := b.AuthConfig
-	if len(b.AuthConfigFile.Configs) > 0 {
+	if len(b.AuthConfigFile.AuthConfigs) > 0 {
 		// The request came with a full auth config file, we prefer to use that
 		repoInfo, err := registry.ResolveRepositoryInfo(job, remote)
 		if err != nil {

--- a/registry/config_file_test.go
+++ b/registry/config_file_test.go
@@ -1,0 +1,144 @@
+package registry
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func pass() {
+	pc := make([]uintptr, 10)
+	runtime.Callers(0, pc)
+	fc := runtime.FuncForPC(pc[2])
+
+	fn, _ := fc.FileLine(2)
+	fn = regexp.MustCompilePOSIX(".*/([^/]*).go").FindStringSubmatch(fn)[1]
+
+	name := fc.Name()
+	name = regexp.MustCompilePOSIX(".*\\.(.*)").FindStringSubmatch(name)[1]
+
+	fmt.Printf(" PASS - %s: %s\n", fn, name)
+}
+
+func TestMissingFile(t *testing.T) {
+	tmpHome, _ := ioutil.TempDir("", "config-test")
+
+	config, err := LoadConfig(tmpHome)
+	if err != nil {
+		t.Fatalf("Failed loading on missing file: %q", err)
+	}
+
+	// Now save it and make sure it shows up in new form
+	err = SaveConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to save: %q", err)
+	}
+
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	if !strings.Contains(string(buf), `"auths":`) {
+		t.Fatalf("Should have save in new form: %s", string(buf))
+	}
+
+	pass()
+}
+
+func TestEmptyFile(t *testing.T) {
+	tmpHome, _ := ioutil.TempDir("", "config-test")
+	fn := filepath.Join(tmpHome, CONFIGFILE)
+	ioutil.WriteFile(fn, []byte(""), 0600)
+
+	_, err := LoadConfig(tmpHome)
+	if err == nil {
+		t.Fatalf("Was supposed to fail")
+	}
+
+	pass()
+}
+
+func TestEmptyJson(t *testing.T) {
+	tmpHome, _ := ioutil.TempDir("", "config-test")
+	fn := filepath.Join(tmpHome, CONFIGFILE)
+	ioutil.WriteFile(fn, []byte("{}"), 0600)
+
+	config, err := LoadConfig(tmpHome)
+	if err != nil {
+		t.Fatalf("Failed loading on empty json file: %q", err)
+	}
+
+	// Now save it and make sure it shows up in new form
+	err = SaveConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to save: %q", err)
+	}
+
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	if !strings.Contains(string(buf), `"auths":`) {
+		t.Fatalf("Should have save in new form: %s", string(buf))
+	}
+
+	pass()
+}
+
+func TestOldJson(t *testing.T) {
+	tmpHome, _ := ioutil.TempDir("", "config-test")
+	fn := filepath.Join(tmpHome, CONFIGFILE)
+	js := `{"https://index.docker.io/v1/":{"auth":"am9lam9lOmhlbGxv","email":"joe@gmail.com"}}`
+	ioutil.WriteFile(fn, []byte(js), 0600)
+
+	config, err := LoadConfig(tmpHome)
+	if err != nil {
+		t.Fatalf("Failed loading on empty json file: %q", err)
+	}
+
+	if config.AuthConfigs["https://index.docker.io/v1/"].Email != "joe@gmail.com" {
+		t.Fatalf("Missing data from parsing:\n%q", config)
+	}
+
+	// Now save it and make sure it shows up in new form
+	err = SaveConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to save: %q", err)
+	}
+
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	if !strings.Contains(string(buf), `"auths":`) ||
+		!strings.Contains(string(buf), "joe@gmail.com") {
+		t.Fatalf("Should have save in new form: %s", string(buf))
+	}
+
+	pass()
+}
+
+func TestNewJson(t *testing.T) {
+	tmpHome, _ := ioutil.TempDir("", "config-test")
+	fn := filepath.Join(tmpHome, CONFIGFILE)
+	js := ` { "auths": { "https://index.docker.io/v1/": { "auth": "am9lam9lOmhlbGxv", "email": "joe@gmail.com" } } }`
+	ioutil.WriteFile(fn, []byte(js), 0600)
+
+	config, err := LoadConfig(tmpHome)
+	if err != nil {
+		t.Fatalf("Failed loading on empty json file: %q", err)
+	}
+
+	if config.AuthConfigs["https://index.docker.io/v1/"].Email != "joe@gmail.com" {
+		t.Fatalf("Missing data from parsing:\n%q", config)
+	}
+
+	// Now save it and make sure it shows up in new form
+	err = SaveConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to save: %q", err)
+	}
+
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	if !strings.Contains(string(buf), `"auths":`) ||
+		!strings.Contains(string(buf), "joe@gmail.com") {
+		t.Fatalf("Should have save in new form: %s", string(buf))
+	}
+
+	pass()
+}


### PR DESCRIPTION
This PR does a couple of things:
- makes loading of the .dockercfg file part of the DockerCli creation so
  that we only need to load it once and not at lots of spots throughout
  the code
- moves the current auth stuff in the config struct down one level so that new
  fields can be added w/o breaking the existing auth config logic
- add testcases to verify that we can read .dockercfg files in the old
  and new format - but always save in the new format

Next steps if this is accepted:
- move the config file processing out from under 'registry' since it
  not registry specific any more
- see what additional fields might be needed - yes I have some in mind :-)

Signed-off-by: Doug Davis dug@us.ibm.com

/cc @crosbymichael @nathanleclaire
