### PR TITLE
Remove engine.Status, replace with standard go error

### DIFF
--- a/api/server/server_linux.go
+++ b/api/server/server_linux.go
@@ -90,7 +90,7 @@ func serveFd(addr string, job *engine.Job) error {
 }
 
 // Called through eng.Job("acceptconnections")
-func AcceptConnections(job *engine.Job) engine.Status {
+func AcceptConnections(job *engine.Job) error {
 	// Tell the init daemon we are accepting requests
 	go systemd.SdNotify("READY=1")
 
@@ -99,5 +99,5 @@ func AcceptConnections(job *engine.Job) engine.Status {
 		close(activationLock)
 	}
 
-	return engine.StatusOK
+	return nil
 }

--- a/api/server/server_unit_test.go
+++ b/api/server/server_unit_test.go
@@ -63,7 +63,7 @@ func TesthttpError(t *testing.T) {
 func TestGetVersion(t *testing.T) {
 	eng := engine.New()
 	var called bool
-	eng.Register("version", func(job *engine.Job) engine.Status {
+	eng.Register("version", func(job *engine.Job) error {
 		called = true
 		v := &engine.Env{}
 		v.SetJson("Version", "42.1")
@@ -72,9 +72,9 @@ func TestGetVersion(t *testing.T) {
 		v.Set("Os", "Linux")
 		v.Set("Arch", "x86_64")
 		if _, err := v.WriteTo(job.Stdout); err != nil {
-			return job.Error(err)
+			return err
 		}
-		return engine.StatusOK
+		return nil
 	})
 	r := serveRequest("GET", "/version", nil, eng, t)
 	if !called {
@@ -92,15 +92,15 @@ func TestGetVersion(t *testing.T) {
 func TestGetInfo(t *testing.T) {
 	eng := engine.New()
 	var called bool
-	eng.Register("info", func(job *engine.Job) engine.Status {
+	eng.Register("info", func(job *engine.Job) error {
 		called = true
 		v := &engine.Env{}
 		v.SetInt("Containers", 1)
 		v.SetInt("Images", 42000)
 		if _, err := v.WriteTo(job.Stdout); err != nil {
-			return job.Error(err)
+			return err
 		}
-		return engine.StatusOK
+		return nil
 	})
 	r := serveRequest("GET", "/info", nil, eng, t)
 	if !called {
@@ -119,13 +119,13 @@ func TestGetInfo(t *testing.T) {
 func TestGetImagesJSON(t *testing.T) {
 	eng := engine.New()
 	var called bool
-	eng.Register("images", func(job *engine.Job) engine.Status {
+	eng.Register("images", func(job *engine.Job) error {
 		called = true
 		v := createEnvFromGetImagesJSONStruct(sampleImage)
 		if _, err := v.WriteTo(job.Stdout); err != nil {
-			return job.Error(err)
+			return err
 		}
-		return engine.StatusOK
+		return nil
 	})
 	r := serveRequest("GET", "/images/json", nil, eng, t)
 	if !called {
@@ -145,9 +145,9 @@ func TestGetImagesJSON(t *testing.T) {
 func TestGetImagesJSONFilter(t *testing.T) {
 	eng := engine.New()
 	filter := "nothing"
-	eng.Register("images", func(job *engine.Job) engine.Status {
+	eng.Register("images", func(job *engine.Job) error {
 		filter = job.Getenv("filter")
-		return engine.StatusOK
+		return nil
 	})
 	serveRequest("GET", "/images/json?filter=aaaa", nil, eng, t)
 	if filter != "aaaa" {
@@ -158,9 +158,9 @@ func TestGetImagesJSONFilter(t *testing.T) {
 func TestGetImagesJSONFilters(t *testing.T) {
 	eng := engine.New()
 	filter := "nothing"
-	eng.Register("images", func(job *engine.Job) engine.Status {
+	eng.Register("images", func(job *engine.Job) error {
 		filter = job.Getenv("filters")
-		return engine.StatusOK
+		return nil
 	})
 	serveRequest("GET", "/images/json?filters=nnnn", nil, eng, t)
 	if filter != "nnnn" {
@@ -171,9 +171,9 @@ func TestGetImagesJSONFilters(t *testing.T) {
 func TestGetImagesJSONAll(t *testing.T) {
 	eng := engine.New()
 	allFilter := "-1"
-	eng.Register("images", func(job *engine.Job) engine.Status {
+	eng.Register("images", func(job *engine.Job) error {
 		allFilter = job.Getenv("all")
-		return engine.StatusOK
+		return nil
 	})
 	serveRequest("GET", "/images/json?all=1", nil, eng, t)
 	if allFilter != "1" {
@@ -184,14 +184,14 @@ func TestGetImagesJSONAll(t *testing.T) {
 func TestGetImagesJSONLegacyFormat(t *testing.T) {
 	eng := engine.New()
 	var called bool
-	eng.Register("images", func(job *engine.Job) engine.Status {
+	eng.Register("images", func(job *engine.Job) error {
 		called = true
 		outsLegacy := engine.NewTable("Created", 0)
 		outsLegacy.Add(createEnvFromGetImagesJSONStruct(sampleImage))
 		if _, err := outsLegacy.WriteListTo(job.Stdout); err != nil {
-			return job.Error(err)
+			return err
 		}
-		return engine.StatusOK
+		return nil
 	})
 	r := serveRequestUsingVersion("GET", "/images/json", "1.6", nil, eng, t)
 	if !called {
@@ -219,7 +219,7 @@ func TestGetContainersByName(t *testing.T) {
 	eng := engine.New()
 	name := "container_name"
 	var called bool
-	eng.Register("container_inspect", func(job *engine.Job) engine.Status {
+	eng.Register("container_inspect", func(job *engine.Job) error {
 		called = true
 		if job.Args[0] != name {
 			t.Errorf("name != '%s': %#v", name, job.Args[0])
@@ -232,9 +232,9 @@ func TestGetContainersByName(t *testing.T) {
 		v := &engine.Env{}
 		v.SetBool("dirty", true)
 		if _, err := v.WriteTo(job.Stdout); err != nil {
-			return job.Error(err)
+			return err
 		}
-		return engine.StatusOK
+		return nil
 	})
 	r := serveRequest("GET", "/containers/"+name+"/json", nil, eng, t)
 	if !called {
@@ -253,7 +253,7 @@ func TestGetContainersByName(t *testing.T) {
 func TestGetEvents(t *testing.T) {
 	eng := engine.New()
 	var called bool
-	eng.Register("events", func(job *engine.Job) engine.Status {
+	eng.Register("events", func(job *engine.Job) error {
 		called = true
 		since := job.Getenv("since")
 		if since != "1" {
@@ -267,9 +267,9 @@ func TestGetEvents(t *testing.T) {
 		v.Set("since", since)
 		v.Set("until", until)
 		if _, err := v.WriteTo(job.Stdout); err != nil {
-			return job.Error(err)
+			return err
 		}
-		return engine.StatusOK
+		return nil
 	})
 	r := serveRequest("GET", "/events?since=1&until=0", nil, eng, t)
 	if !called {
@@ -295,7 +295,7 @@ func TestLogs(t *testing.T) {
 	eng := engine.New()
 	var inspect bool
 	var logs bool
-	eng.Register("container_inspect", func(job *engine.Job) engine.Status {
+	eng.Register("container_inspect", func(job *engine.Job) error {
 		inspect = true
 		if len(job.Args) == 0 {
 			t.Fatal("Job arguments is empty")
@@ -303,10 +303,10 @@ func TestLogs(t *testing.T) {
 		if job.Args[0] != "test" {
 			t.Fatalf("Container name %s, must be test", job.Args[0])
 		}
-		return engine.StatusOK
+		return nil
 	})
 	expected := "logs"
-	eng.Register("logs", func(job *engine.Job) engine.Status {
+	eng.Register("logs", func(job *engine.Job) error {
 		logs = true
 		if len(job.Args) == 0 {
 			t.Fatal("Job arguments is empty")
@@ -331,7 +331,7 @@ func TestLogs(t *testing.T) {
 			t.Fatalf("timestamps %s, must be 1", timestamps)
 		}
 		job.Stdout.Write([]byte(expected))
-		return engine.StatusOK
+		return nil
 	})
 	r := serveRequest("GET", "/containers/test/logs?follow=1&stdout=1&timestamps=1", nil, eng, t)
 	if r.Code != http.StatusOK {
@@ -353,7 +353,7 @@ func TestLogsNoStreams(t *testing.T) {
 	eng := engine.New()
 	var inspect bool
 	var logs bool
-	eng.Register("container_inspect", func(job *engine.Job) engine.Status {
+	eng.Register("container_inspect", func(job *engine.Job) error {
 		inspect = true
 		if len(job.Args) == 0 {
 			t.Fatal("Job arguments is empty")
@@ -361,11 +361,11 @@ func TestLogsNoStreams(t *testing.T) {
 		if job.Args[0] != "test" {
 			t.Fatalf("Container name %s, must be test", job.Args[0])
 		}
-		return engine.StatusOK
+		return nil
 	})
-	eng.Register("logs", func(job *engine.Job) engine.Status {
+	eng.Register("logs", func(job *engine.Job) error {
 		logs = true
-		return engine.StatusOK
+		return nil
 	})
 	r := serveRequest("GET", "/containers/test/logs", nil, eng, t)
 	if r.Code != http.StatusBadRequest {
@@ -388,7 +388,7 @@ func TestGetImagesHistory(t *testing.T) {
 	eng := engine.New()
 	imageName := "docker-test-image"
 	var called bool
-	eng.Register("history", func(job *engine.Job) engine.Status {
+	eng.Register("history", func(job *engine.Job) error {
 		called = true
 		if len(job.Args) == 0 {
 			t.Fatal("Job arguments is empty")
@@ -398,9 +398,9 @@ func TestGetImagesHistory(t *testing.T) {
 		}
 		v := &engine.Env{}
 		if _, err := v.WriteTo(job.Stdout); err != nil {
-			return job.Error(err)
+			return err
 		}
-		return engine.StatusOK
+		return nil
 	})
 	r := serveRequest("GET", "/images/"+imageName+"/history", nil, eng, t)
 	if !called {
@@ -418,7 +418,7 @@ func TestGetImagesByName(t *testing.T) {
 	eng := engine.New()
 	name := "image_name"
 	var called bool
-	eng.Register("image_inspect", func(job *engine.Job) engine.Status {
+	eng.Register("image_inspect", func(job *engine.Job) error {
 		called = true
 		if job.Args[0] != name {
 			t.Fatalf("name != '%s': %#v", name, job.Args[0])
@@ -431,9 +431,9 @@ func TestGetImagesByName(t *testing.T) {
 		v := &engine.Env{}
 		v.SetBool("dirty", true)
 		if _, err := v.WriteTo(job.Stdout); err != nil {
-			return job.Error(err)
+			return err
 		}
-		return engine.StatusOK
+		return nil
 	})
 	r := serveRequest("GET", "/images/"+name+"/json", nil, eng, t)
 	if !called {
@@ -455,7 +455,7 @@ func TestDeleteContainers(t *testing.T) {
 	eng := engine.New()
 	name := "foo"
 	var called bool
-	eng.Register("rm", func(job *engine.Job) engine.Status {
+	eng.Register("rm", func(job *engine.Job) error {
 		called = true
 		if len(job.Args) == 0 {
 			t.Fatalf("Job arguments is empty")
@@ -463,7 +463,7 @@ func TestDeleteContainers(t *testing.T) {
 		if job.Args[0] != name {
 			t.Fatalf("name != '%s': %#v", name, job.Args[0])
 		}
-		return engine.StatusOK
+		return nil
 	})
 	r := serveRequest("DELETE", "/containers/"+name, nil, eng, t)
 	if !called {

--- a/builtins/builtins.go
+++ b/builtins/builtins.go
@@ -57,7 +57,7 @@ func daemon(eng *engine.Engine) error {
 }
 
 // builtins jobs independent of any subsystem
-func dockerVersion(job *engine.Job) engine.Status {
+func dockerVersion(job *engine.Job) error {
 	v := &engine.Env{}
 	v.SetJson("Version", dockerversion.VERSION)
 	v.SetJson("ApiVersion", api.APIVERSION)
@@ -69,7 +69,7 @@ func dockerVersion(job *engine.Job) engine.Status {
 		v.Set("KernelVersion", kernelVersion.String())
 	}
 	if _, err := v.WriteTo(job.Stdout); err != nil {
-		return job.Error(err)
+		return err
 	}
-	return engine.StatusOK
+	return nil
 }

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -14,9 +15,9 @@ import (
 	"github.com/docker/docker/utils"
 )
 
-func (daemon *Daemon) ContainerAttach(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerAttach(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("Usage: %s CONTAINER\n", job.Name)
+		return fmt.Errorf("Usage: %s CONTAINER\n", job.Name)
 	}
 
 	var (
@@ -30,7 +31,7 @@ func (daemon *Daemon) ContainerAttach(job *engine.Job) engine.Status {
 
 	container, err := daemon.Get(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 
 	//logs
@@ -108,7 +109,7 @@ func (daemon *Daemon) ContainerAttach(job *engine.Job) engine.Status {
 			container.WaitStop(-1 * time.Second)
 		}
 	}
-	return engine.StatusOK
+	return nil
 }
 
 func (daemon *Daemon) Attach(streamConfig *StreamConfig, openStdin, stdinOnce, tty bool, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) chan error {

--- a/daemon/changes.go
+++ b/daemon/changes.go
@@ -1,37 +1,39 @@
 package daemon
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/engine"
 )
 
-func (daemon *Daemon) ContainerChanges(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerChanges(job *engine.Job) error {
 	if n := len(job.Args); n != 1 {
-		return job.Errorf("Usage: %s CONTAINER", job.Name)
+		return fmt.Errorf("Usage: %s CONTAINER", job.Name)
 	}
 	name := job.Args[0]
 
-	container, error := daemon.Get(name)
-	if error != nil {
-		return job.Error(error)
+	container, err := daemon.Get(name)
+	if err != nil {
+		return err
 	}
 
 	outs := engine.NewTable("", 0)
 	changes, err := container.Changes()
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 
 	for _, change := range changes {
 		out := &engine.Env{}
 		if err := out.Import(change); err != nil {
-			return job.Error(err)
+			return err
 		}
 		outs.Add(out)
 	}
 
 	if _, err := outs.WriteListTo(job.Stdout); err != nil {
-		return job.Error(err)
+		return err
 	}
 
-	return engine.StatusOK
+	return nil
 }

--- a/daemon/copy.go
+++ b/daemon/copy.go
@@ -1,14 +1,15 @@
 package daemon
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/docker/docker/engine"
 )
 
-func (daemon *Daemon) ContainerCopy(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerCopy(job *engine.Job) error {
 	if len(job.Args) != 2 {
-		return job.Errorf("Usage: %s CONTAINER RESOURCE\n", job.Name)
+		return fmt.Errorf("Usage: %s CONTAINER RESOURCE\n", job.Name)
 	}
 
 	var (
@@ -18,17 +19,17 @@ func (daemon *Daemon) ContainerCopy(job *engine.Job) engine.Status {
 
 	container, err := daemon.Get(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 
 	data, err := container.Copy(resource)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	defer data.Close()
 
 	if _, err := io.Copy(job.Stdout, data); err != nil {
-		return job.Error(err)
+		return err
 	}
-	return engine.StatusOK
+	return nil
 }

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -1,33 +1,34 @@
 package daemon
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/docker/docker/engine"
 )
 
-func (daemon *Daemon) ContainerExport(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerExport(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("Usage: %s container_id", job.Name)
+		return fmt.Errorf("Usage: %s container_id", job.Name)
 	}
 	name := job.Args[0]
 
 	container, err := daemon.Get(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 
 	data, err := container.Export()
 	if err != nil {
-		return job.Errorf("%s: %s", name, err)
+		return fmt.Errorf("%s: %s", name, err)
 	}
 	defer data.Close()
 
 	// Stream the entire contents of the container (basically a volatile snapshot)
 	if _, err := io.Copy(job.Stdout, data); err != nil {
-		return job.Errorf("%s: %s", name, err)
+		return fmt.Errorf("%s: %s", name, err)
 	}
 	// FIXME: factor job-specific LogEvent to engine.Job.Run()
 	container.LogEvent("export")
-	return engine.StatusOK
+	return nil
 }

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -12,21 +12,21 @@ import (
 	"github.com/docker/docker/utils"
 )
 
-func (daemon *Daemon) ImageDelete(job *engine.Job) engine.Status {
+func (daemon *Daemon) ImageDelete(job *engine.Job) error {
 	if n := len(job.Args); n != 1 {
-		return job.Errorf("Usage: %s IMAGE", job.Name)
+		return fmt.Errorf("Usage: %s IMAGE", job.Name)
 	}
 	imgs := engine.NewTable("", 0)
 	if err := daemon.DeleteImage(job.Eng, job.Args[0], imgs, true, job.GetenvBool("force"), job.GetenvBool("noprune")); err != nil {
-		return job.Error(err)
+		return err
 	}
 	if len(imgs.Data) == 0 {
-		return job.Errorf("Conflict, %s wasn't deleted", job.Args[0])
+		return fmt.Errorf("Conflict, %s wasn't deleted", job.Args[0])
 	}
 	if _, err := imgs.WriteListTo(job.Stdout); err != nil {
-		return job.Error(err)
+		return err
 	}
-	return engine.StatusOK
+	return nil
 }
 
 // FIXME: make this private and use the job instead

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -15,7 +15,7 @@ import (
 	"github.com/docker/docker/utils"
 )
 
-func (daemon *Daemon) CmdInfo(job *engine.Job) engine.Status {
+func (daemon *Daemon) CmdInfo(job *engine.Job) error {
 	images, _ := daemon.Graph().Map()
 	var imgcount int
 	if images == nil {
@@ -54,16 +54,16 @@ func (daemon *Daemon) CmdInfo(job *engine.Job) engine.Status {
 	cjob := job.Eng.Job("subscribers_count")
 	env, _ := cjob.Stdout.AddEnv()
 	if err := cjob.Run(); err != nil {
-		return job.Error(err)
+		return err
 	}
 	registryJob := job.Eng.Job("registry_config")
 	registryEnv, _ := registryJob.Stdout.AddEnv()
 	if err := registryJob.Run(); err != nil {
-		return job.Error(err)
+		return err
 	}
 	registryConfig := registry.ServiceConfig{}
 	if err := registryEnv.GetJson("config", &registryConfig); err != nil {
-		return job.Error(err)
+		return err
 	}
 	v := &engine.Env{}
 	v.SetJson("ID", daemon.ID)
@@ -104,7 +104,7 @@ func (daemon *Daemon) CmdInfo(job *engine.Job) engine.Status {
 	}
 	v.SetList("Labels", daemon.Config().Labels)
 	if _, err := v.WriteTo(job.Stdout); err != nil {
-		return job.Error(err)
+		return err
 	}
-	return engine.StatusOK
+	return nil
 }

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -8,14 +8,14 @@ import (
 	"github.com/docker/docker/runconfig"
 )
 
-func (daemon *Daemon) ContainerInspect(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerInspect(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("usage: %s NAME", job.Name)
+		return fmt.Errorf("usage: %s NAME", job.Name)
 	}
 	name := job.Args[0]
 	container, err := daemon.Get(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 
 	container.Lock()
@@ -26,10 +26,10 @@ func (daemon *Daemon) ContainerInspect(job *engine.Job) engine.Status {
 			HostConfig *runconfig.HostConfig
 		}{container, container.hostConfig})
 		if err != nil {
-			return job.Error(err)
+			return err
 		}
 		job.Stdout.Write(b)
-		return engine.StatusOK
+		return nil
 	}
 
 	out := &engine.Env{}
@@ -75,25 +75,25 @@ func (daemon *Daemon) ContainerInspect(job *engine.Job) engine.Status {
 
 	container.hostConfig.Links = nil
 	if _, err := out.WriteTo(job.Stdout); err != nil {
-		return job.Error(err)
+		return err
 	}
-	return engine.StatusOK
+	return nil
 }
 
-func (daemon *Daemon) ContainerExecInspect(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerExecInspect(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("usage: %s ID", job.Name)
+		return fmt.Errorf("usage: %s ID", job.Name)
 	}
 	id := job.Args[0]
 	eConfig, err := daemon.getExecConfig(id)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 
 	b, err := json.Marshal(*eConfig)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	job.Stdout.Write(b)
-	return engine.StatusOK
+	return nil
 }

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -20,7 +20,7 @@ func (daemon *Daemon) List() []*Container {
 	return daemon.containers.List()
 }
 
-func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
+func (daemon *Daemon) Containers(job *engine.Job) error {
 	var (
 		foundBefore bool
 		displayed   int
@@ -36,13 +36,13 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 
 	psFilters, err := filters.FromParam(job.Getenv("filters"))
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	if i, ok := psFilters["exited"]; ok {
 		for _, value := range i {
 			code, err := strconv.Atoi(value)
 			if err != nil {
-				return job.Error(err)
+				return err
 			}
 			filt_exited = append(filt_exited, code)
 		}
@@ -65,14 +65,14 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 	if before != "" {
 		beforeCont, err = daemon.Get(before)
 		if err != nil {
-			return job.Error(err)
+			return err
 		}
 	}
 
 	if since != "" {
 		sinceCont, err = daemon.Get(since)
 		if err != nil {
-			return job.Error(err)
+			return err
 		}
 	}
 
@@ -170,14 +170,14 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 	for _, container := range daemon.List() {
 		if err := writeCont(container); err != nil {
 			if err != errLast {
-				return job.Error(err)
+				return err
 			}
 			break
 		}
 	}
 	outs.ReverseSort()
 	if _, err := outs.WriteListTo(job.Stdout); err != nil {
-		return job.Error(err)
+		return err
 	}
-	return engine.StatusOK
+	return nil
 }

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -16,9 +16,9 @@ import (
 	"github.com/docker/docker/pkg/timeutils"
 )
 
-func (daemon *Daemon) ContainerLogs(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerLogs(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("Usage: %s CONTAINER\n", job.Name)
+		return fmt.Errorf("Usage: %s CONTAINER\n", job.Name)
 	}
 
 	var (
@@ -32,7 +32,7 @@ func (daemon *Daemon) ContainerLogs(job *engine.Job) engine.Status {
 		format string
 	)
 	if !(stdout || stderr) {
-		return job.Errorf("You must choose at least one stream")
+		return fmt.Errorf("You must choose at least one stream")
 	}
 	if times {
 		format = timeutils.RFC3339NanoFixed
@@ -42,10 +42,10 @@ func (daemon *Daemon) ContainerLogs(job *engine.Job) engine.Status {
 	}
 	container, err := daemon.Get(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	if container.LogDriverType() != "json-file" {
-		return job.Errorf("\"logs\" endpoint is supported only for \"json-file\" logging driver")
+		return fmt.Errorf("\"logs\" endpoint is supported only for \"json-file\" logging driver")
 	}
 	cLog, err := container.ReadLog("json")
 	if err != nil && os.IsNotExist(err) {
@@ -83,7 +83,7 @@ func (daemon *Daemon) ContainerLogs(job *engine.Job) engine.Status {
 				f := cLog.(*os.File)
 				ls, err := tailfile.TailFile(f, lines)
 				if err != nil {
-					return job.Error(err)
+					return err
 				}
 				tmp := bytes.NewBuffer([]byte{})
 				for _, l := range ls {
@@ -148,5 +148,5 @@ func (daemon *Daemon) ContainerLogs(job *engine.Job) engine.Status {
 		}
 
 	}
-	return engine.StatusOK
+	return nil
 }

--- a/daemon/networkdriver/bridge/driver_test.go
+++ b/daemon/networkdriver/bridge/driver_test.go
@@ -60,22 +60,22 @@ func TestAllocatePortDetection(t *testing.T) {
 
 	// Init driver
 	job := eng.Job("initdriver")
-	if res := InitDriver(job); res != engine.StatusOK {
+	if res := InitDriver(job); res != nil {
 		t.Fatal("Failed to initialize network driver")
 	}
 
 	// Allocate interface
 	job = eng.Job("allocate_interface", "container_id")
-	if res := Allocate(job); res != engine.StatusOK {
+	if res := Allocate(job); res != nil {
 		t.Fatal("Failed to allocate network interface")
 	}
 
 	// Allocate same port twice, expect failure on second call
 	job = newPortAllocationJob(eng, freePort)
-	if res := AllocatePort(job); res != engine.StatusOK {
+	if res := AllocatePort(job); res != nil {
 		t.Fatal("Failed to find a free port to allocate")
 	}
-	if res := AllocatePort(job); res == engine.StatusOK {
+	if res := AllocatePort(job); res == nil {
 		t.Fatal("Duplicate port allocation granted by AllocatePort")
 	}
 }
@@ -88,19 +88,19 @@ func TestHostnameFormatChecking(t *testing.T) {
 
 	// Init driver
 	job := eng.Job("initdriver")
-	if res := InitDriver(job); res != engine.StatusOK {
+	if res := InitDriver(job); res != nil {
 		t.Fatal("Failed to initialize network driver")
 	}
 
 	// Allocate interface
 	job = eng.Job("allocate_interface", "container_id")
-	if res := Allocate(job); res != engine.StatusOK {
+	if res := Allocate(job); res != nil {
 		t.Fatal("Failed to allocate network interface")
 	}
 
 	// Allocate port with invalid HostIP, expect failure with Bad Request http status
 	job = newPortAllocationJobWithInvalidHostIP(eng, freePort)
-	if res := AllocatePort(job); res == engine.StatusOK {
+	if res := AllocatePort(job); res == nil {
 		t.Fatal("Failed to check invalid HostIP")
 	}
 }
@@ -129,11 +129,11 @@ func newInterfaceAllocation(t *testing.T, input engine.Env) (output engine.Env) 
 	<-done
 
 	if input.Exists("expectFail") && input.GetBool("expectFail") {
-		if res == engine.StatusOK {
+		if res == nil {
 			t.Fatal("Doesn't fail to allocate network interface")
 		}
 	} else {
-		if res != engine.StatusOK {
+		if res != nil {
 			t.Fatal("Failed to allocate network interface")
 		}
 	}
@@ -244,13 +244,13 @@ func TestLinkContainers(t *testing.T) {
 
 	// Init driver
 	job := eng.Job("initdriver")
-	if res := InitDriver(job); res != engine.StatusOK {
+	if res := InitDriver(job); res != nil {
 		t.Fatal("Failed to initialize network driver")
 	}
 
 	// Allocate interface
 	job = eng.Job("allocate_interface", "container_id")
-	if res := Allocate(job); res != engine.StatusOK {
+	if res := Allocate(job); res != nil {
 		t.Fatal("Failed to allocate network interface")
 	}
 
@@ -267,7 +267,7 @@ func TestLinkContainers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if res := LinkContainers(job); res != engine.StatusOK {
+	if res := LinkContainers(job); res != nil {
 		t.Fatalf("LinkContainers failed")
 	}
 

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -1,37 +1,39 @@
 package daemon
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/engine"
 )
 
-func (daemon *Daemon) ContainerPause(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerPause(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("Usage: %s CONTAINER", job.Name)
+		return fmt.Errorf("Usage: %s CONTAINER", job.Name)
 	}
 	name := job.Args[0]
 	container, err := daemon.Get(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	if err := container.Pause(); err != nil {
-		return job.Errorf("Cannot pause container %s: %s", name, err)
+		return fmt.Errorf("Cannot pause container %s: %s", name, err)
 	}
 	container.LogEvent("pause")
-	return engine.StatusOK
+	return nil
 }
 
-func (daemon *Daemon) ContainerUnpause(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerUnpause(job *engine.Job) error {
 	if n := len(job.Args); n < 1 || n > 2 {
-		return job.Errorf("Usage: %s CONTAINER", job.Name)
+		return fmt.Errorf("Usage: %s CONTAINER", job.Name)
 	}
 	name := job.Args[0]
 	container, err := daemon.Get(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	if err := container.Unpause(); err != nil {
-		return job.Errorf("Cannot unpause container %s: %s", name, err)
+		return fmt.Errorf("Cannot unpause container %s: %s", name, err)
 	}
 	container.LogEvent("unpause")
-	return engine.StatusOK
+	return nil
 }

--- a/daemon/resize.go
+++ b/daemon/resize.go
@@ -1,53 +1,54 @@
 package daemon
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/docker/docker/engine"
 )
 
-func (daemon *Daemon) ContainerResize(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerResize(job *engine.Job) error {
 	if len(job.Args) != 3 {
-		return job.Errorf("Not enough arguments. Usage: %s CONTAINER HEIGHT WIDTH\n", job.Name)
+		return fmt.Errorf("Not enough arguments. Usage: %s CONTAINER HEIGHT WIDTH\n", job.Name)
 	}
 	name := job.Args[0]
 	height, err := strconv.Atoi(job.Args[1])
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	width, err := strconv.Atoi(job.Args[2])
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	container, err := daemon.Get(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	if err := container.Resize(height, width); err != nil {
-		return job.Error(err)
+		return err
 	}
-	return engine.StatusOK
+	return nil
 }
 
-func (daemon *Daemon) ContainerExecResize(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerExecResize(job *engine.Job) error {
 	if len(job.Args) != 3 {
-		return job.Errorf("Not enough arguments. Usage: %s EXEC HEIGHT WIDTH\n", job.Name)
+		return fmt.Errorf("Not enough arguments. Usage: %s EXEC HEIGHT WIDTH\n", job.Name)
 	}
 	name := job.Args[0]
 	height, err := strconv.Atoi(job.Args[1])
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	width, err := strconv.Atoi(job.Args[2])
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	execConfig, err := daemon.getExecConfig(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	if err := execConfig.Resize(height, width); err != nil {
-		return job.Error(err)
+		return err
 	}
-	return engine.StatusOK
+	return nil
 }

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -1,12 +1,14 @@
 package daemon
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/engine"
 )
 
-func (daemon *Daemon) ContainerRestart(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerRestart(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("Usage: %s CONTAINER\n", job.Name)
+		return fmt.Errorf("Usage: %s CONTAINER\n", job.Name)
 	}
 	var (
 		name = job.Args[0]
@@ -17,11 +19,11 @@ func (daemon *Daemon) ContainerRestart(job *engine.Job) engine.Status {
 	}
 	container, err := daemon.Get(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	if err := container.Restart(int(t)); err != nil {
-		return job.Errorf("Cannot restart container %s: %s\n", name, err)
+		return fmt.Errorf("Cannot restart container %s: %s\n", name, err)
 	}
 	container.LogEvent("restart")
-	return engine.StatusOK
+	return nil
 }

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -1,13 +1,15 @@
 package daemon
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/runconfig"
 )
 
-func (daemon *Daemon) ContainerStart(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerStart(job *engine.Job) error {
 	if len(job.Args) < 1 {
-		return job.Errorf("Usage: %s container_id", job.Name)
+		return fmt.Errorf("Usage: %s container_id", job.Name)
 	}
 	var (
 		name = job.Args[0]
@@ -15,15 +17,15 @@ func (daemon *Daemon) ContainerStart(job *engine.Job) engine.Status {
 
 	container, err := daemon.Get(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 
 	if container.IsPaused() {
-		return job.Errorf("Cannot start a paused container, try unpause instead.")
+		return fmt.Errorf("Cannot start a paused container, try unpause instead.")
 	}
 
 	if container.IsRunning() {
-		return job.Errorf("Container already started")
+		return fmt.Errorf("Container already started")
 	}
 
 	// If no environment was set, then no hostconfig was passed.
@@ -32,15 +34,15 @@ func (daemon *Daemon) ContainerStart(job *engine.Job) engine.Status {
 	if len(job.Environ()) > 0 {
 		hostConfig := runconfig.ContainerHostConfigFromJob(job)
 		if err := daemon.setHostConfig(container, hostConfig); err != nil {
-			return job.Error(err)
+			return err
 		}
 	}
 	if err := container.Start(); err != nil {
 		container.LogEvent("die")
-		return job.Errorf("Cannot start container %s: %s", name, err)
+		return fmt.Errorf("Cannot start container %s: %s", name, err)
 	}
 
-	return engine.StatusOK
+	return nil
 }
 
 func (daemon *Daemon) setHostConfig(container *Container, hostConfig *runconfig.HostConfig) error {

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -10,10 +10,10 @@ import (
 	"github.com/docker/libcontainer/cgroups"
 )
 
-func (daemon *Daemon) ContainerStats(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerStats(job *engine.Job) error {
 	updates, err := daemon.SubscribeToContainerStats(job.Args[0])
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	enc := json.NewEncoder(job.Stdout)
 	for v := range updates {
@@ -25,10 +25,10 @@ func (daemon *Daemon) ContainerStats(job *engine.Job) engine.Status {
 		if err := enc.Encode(ss); err != nil {
 			// TODO: handle the specific broken pipe
 			daemon.UnsubscribeToContainerStats(job.Args[0], updates)
-			return job.Error(err)
+			return err
 		}
 	}
-	return engine.StatusOK
+	return nil
 }
 
 // convertToAPITypes converts the libcontainer.Stats to the api specific

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -1,12 +1,14 @@
 package daemon
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/engine"
 )
 
-func (daemon *Daemon) ContainerStop(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerStop(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("Usage: %s CONTAINER\n", job.Name)
+		return fmt.Errorf("Usage: %s CONTAINER\n", job.Name)
 	}
 	var (
 		name = job.Args[0]
@@ -17,14 +19,14 @@ func (daemon *Daemon) ContainerStop(job *engine.Job) engine.Status {
 	}
 	container, err := daemon.Get(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	if !container.IsRunning() {
-		return job.Errorf("Container already stopped")
+		return fmt.Errorf("Container already stopped")
 	}
 	if err := container.Stop(int(t)); err != nil {
-		return job.Errorf("Cannot stop container %s: %s\n", name, err)
+		return fmt.Errorf("Cannot stop container %s: %s\n", name, err)
 	}
 	container.LogEvent("stop")
-	return engine.StatusOK
+	return nil
 }

--- a/daemon/wait.go
+++ b/daemon/wait.go
@@ -1,21 +1,22 @@
 package daemon
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/docker/docker/engine"
 )
 
-func (daemon *Daemon) ContainerWait(job *engine.Job) engine.Status {
+func (daemon *Daemon) ContainerWait(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("Usage: %s", job.Name)
+		return fmt.Errorf("Usage: %s", job.Name)
 	}
 	name := job.Args[0]
 	container, err := daemon.Get(name)
 	if err != nil {
-		return job.Errorf("%s: %v", job.Name, err)
+		return fmt.Errorf("%s: %v", job.Name, err)
 	}
 	status, _ := container.WaitStop(-1 * time.Second)
 	job.Printf("%d\n", status)
-	return engine.StatusOK
+	return nil
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -21,7 +21,7 @@ type Installer interface {
 	Install(*Engine) error
 }
 
-type Handler func(*Job) Status
+type Handler func(*Job) error
 
 var globalHandlers map[string]Handler
 
@@ -84,11 +84,11 @@ func New() *Engine {
 		Stdin:    os.Stdin,
 		Logging:  true,
 	}
-	eng.Register("commands", func(job *Job) Status {
+	eng.Register("commands", func(job *Job) error {
 		for _, name := range eng.commands() {
 			job.Printf("%s\n", name)
 		}
-		return StatusOK
+		return nil
 	})
 	// Copy existing global handlers
 	for k, v := range globalHandlers {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -45,9 +45,9 @@ func TestJob(t *testing.T) {
 		t.Fatalf("job1.handler should be empty")
 	}
 
-	h := func(j *Job) Status {
+	h := func(j *Job) error {
 		j.Printf("%s\n", j.Name)
-		return 42
+		return nil
 	}
 
 	eng.Register("dummy2", h)
@@ -58,7 +58,7 @@ func TestJob(t *testing.T) {
 		t.Fatalf("job2.handler shouldn't be nil")
 	}
 
-	if job2.handler(job2) != 42 {
+	if job2.handler(job2) != nil {
 		t.Fatalf("handler dummy2 was not found in job2")
 	}
 }
@@ -76,7 +76,7 @@ func TestEngineShutdown(t *testing.T) {
 
 func TestEngineCommands(t *testing.T) {
 	eng := New()
-	handler := func(job *Job) Status { return StatusOK }
+	handler := func(job *Job) error { return nil }
 	eng.Register("foo", handler)
 	eng.Register("bar", handler)
 	eng.Register("echo", handler)
@@ -105,9 +105,9 @@ func TestParseJob(t *testing.T) {
 	eng := New()
 	// Verify that the resulting job calls to the right place
 	var called bool
-	eng.Register("echo", func(job *Job) Status {
+	eng.Register("echo", func(job *Job) error {
 		called = true
-		return StatusOK
+		return nil
 	})
 	input := "echo DEBUG=1 hello world VERBOSITY=42"
 	job, err := eng.ParseJob(input)
@@ -140,9 +140,9 @@ func TestParseJob(t *testing.T) {
 func TestCatchallEmptyName(t *testing.T) {
 	eng := New()
 	var called bool
-	eng.RegisterCatchall(func(job *Job) Status {
+	eng.RegisterCatchall(func(job *Job) error {
 		called = true
-		return StatusOK
+		return nil
 	})
 	err := eng.Job("").Run()
 	if err == nil {
@@ -164,7 +164,7 @@ func TestNestedJobSharedOutput(t *testing.T) {
 		wrapOutput   bool
 	)
 
-	outerHandler = func(job *Job) Status {
+	outerHandler = func(job *Job) error {
 		job.Stdout.Write([]byte("outer1"))
 
 		innerJob := job.Eng.Job("innerJob")
@@ -184,13 +184,13 @@ func TestNestedJobSharedOutput(t *testing.T) {
 		// closed output.
 		job.Stdout.Write([]byte(" outer2"))
 
-		return StatusOK
+		return nil
 	}
 
-	innerHandler = func(job *Job) Status {
+	innerHandler = func(job *Job) error {
 		job.Stdout.Write([]byte(" inner"))
 
-		return StatusOK
+		return nil
 	}
 
 	eng := New()

--- a/engine/job.go
+++ b/engine/job.go
@@ -32,7 +32,7 @@ type Job struct {
 	Stderr  *Output
 	Stdin   *Input
 	handler Handler
-	status  Status
+	err     error
 	end     time.Time
 	closeIO bool
 
@@ -43,17 +43,8 @@ type Job struct {
 	cancelOnce sync.Once
 }
 
-type Status int
-
-const (
-	StatusOK       Status = 0
-	StatusErr      Status = 1
-	StatusNotFound Status = 127
-)
-
 // Run executes the job and blocks until the job completes.
-// If the job returns a failure status, an error is returned
-// which includes the status.
+// If the job fails it returns an error
 func (job *Job) Run() error {
 	if job.Eng.IsShutdown() && !job.GetenvBool("overrideShutdown") {
 		return fmt.Errorf("engine is shutdown")
@@ -78,16 +69,16 @@ func (job *Job) Run() error {
 	if job.Eng.Logging {
 		log.Infof("+job %s", job.CallString())
 		defer func() {
-			log.Infof("-job %s%s", job.CallString(), job.StatusString())
+			// what if err is nil?
+			log.Infof("-job %s%s", job.CallString(), job.err)
 		}()
 	}
 	var errorMessage = bytes.NewBuffer(nil)
 	job.Stderr.Add(errorMessage)
 	if job.handler == nil {
-		job.Errorf("%s: command not found", job.Name)
-		job.status = 127
+		job.err = fmt.Errorf("%s: command not found", job.Name)
 	} else {
-		job.status = job.handler(job)
+		job.err = job.handler(job)
 		job.end = time.Now()
 	}
 	if job.closeIO {
@@ -102,34 +93,12 @@ func (job *Job) Run() error {
 			return err
 		}
 	}
-	if job.status != 0 {
-		return fmt.Errorf("%s", Tail(errorMessage, 1))
-	}
 
-	return nil
+	return job.err
 }
 
 func (job *Job) CallString() string {
 	return fmt.Sprintf("%s(%s)", job.Name, strings.Join(job.Args, ", "))
-}
-
-func (job *Job) StatusString() string {
-	// If the job hasn't completed, status string is empty
-	if job.end.IsZero() {
-		return ""
-	}
-	var okerr string
-	if job.status == StatusOK {
-		okerr = "OK"
-	} else {
-		okerr = "ERR"
-	}
-	return fmt.Sprintf(" = %s (%d)", okerr, job.status)
-}
-
-// String returns a human-readable description of `job`
-func (job *Job) String() string {
-	return fmt.Sprintf("%s.%s%s", job.Eng, job.CallString(), job.StatusString())
 }
 
 func (job *Job) Env() *Env {
@@ -233,23 +202,6 @@ func (job *Job) Logf(format string, args ...interface{}) (n int, err error) {
 
 func (job *Job) Printf(format string, args ...interface{}) (n int, err error) {
 	return fmt.Fprintf(job.Stdout, format, args...)
-}
-
-func (job *Job) Errorf(format string, args ...interface{}) Status {
-	if format[len(format)-1] != '\n' {
-		format = format + "\n"
-	}
-	fmt.Fprintf(job.Stderr, format, args...)
-	return StatusErr
-}
-
-func (job *Job) Error(err error) Status {
-	fmt.Fprintf(job.Stderr, "%s\n", err)
-	return StatusErr
-}
-
-func (job *Job) StatusCode() int {
-	return int(job.status)
 }
 
 func (job *Job) SetCloseIO(val bool) {

--- a/engine/job_test.go
+++ b/engine/job_test.go
@@ -2,43 +2,35 @@ package engine
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"testing"
 )
 
-func TestJobStatusOK(t *testing.T) {
+func TestJobOK(t *testing.T) {
 	eng := New()
-	eng.Register("return_ok", func(job *Job) Status { return StatusOK })
+	eng.Register("return_ok", func(job *Job) error { return nil })
 	err := eng.Job("return_ok").Run()
 	if err != nil {
 		t.Fatalf("Expected: err=%v\nReceived: err=%v", nil, err)
 	}
 }
 
-func TestJobStatusErr(t *testing.T) {
+func TestJobErr(t *testing.T) {
 	eng := New()
-	eng.Register("return_err", func(job *Job) Status { return StatusErr })
+	eng.Register("return_err", func(job *Job) error { return errors.New("return_err") })
 	err := eng.Job("return_err").Run()
 	if err == nil {
-		t.Fatalf("When a job returns StatusErr, Run() should return an error")
-	}
-}
-
-func TestJobStatusNotFound(t *testing.T) {
-	eng := New()
-	eng.Register("return_not_found", func(job *Job) Status { return StatusNotFound })
-	err := eng.Job("return_not_found").Run()
-	if err == nil {
-		t.Fatalf("When a job returns StatusNotFound, Run() should return an error")
+		t.Fatalf("When a job returns error, Run() should return an error")
 	}
 }
 
 func TestJobStdoutString(t *testing.T) {
 	eng := New()
 	// FIXME: test multiple combinations of output and status
-	eng.Register("say_something_in_stdout", func(job *Job) Status {
+	eng.Register("say_something_in_stdout", func(job *Job) error {
 		job.Printf("Hello world\n")
-		return StatusOK
+		return nil
 	})
 
 	job := eng.Job("say_something_in_stdout")
@@ -51,25 +43,5 @@ func TestJobStdoutString(t *testing.T) {
 	var output = Tail(outputBuffer, 1)
 	if expectedOutput := "Hello world"; output != expectedOutput {
 		t.Fatalf("Stdout last line:\nExpected: %v\nReceived: %v", expectedOutput, output)
-	}
-}
-
-func TestJobStderrString(t *testing.T) {
-	eng := New()
-	// FIXME: test multiple combinations of output and status
-	eng.Register("say_something_in_stderr", func(job *Job) Status {
-		job.Errorf("Something might happen\nHere it comes!\nOh no...\nSomething happened\n")
-		return StatusOK
-	})
-
-	job := eng.Job("say_something_in_stderr")
-	var outputBuffer = bytes.NewBuffer(nil)
-	job.Stderr.Add(outputBuffer)
-	if err := job.Run(); err != nil {
-		t.Fatal(err)
-	}
-	var output = Tail(outputBuffer, 1)
-	if expectedOutput := "Something happened"; output != expectedOutput {
-		t.Fatalf("Stderr last line:\nExpected: %v\nReceived: %v", expectedOutput, output)
 	}
 }

--- a/engine/shutdown_test.go
+++ b/engine/shutdown_test.go
@@ -19,9 +19,9 @@ func TestShutdownEmpty(t *testing.T) {
 func TestShutdownAfterRun(t *testing.T) {
 	eng := New()
 	var called bool
-	eng.Register("foo", func(job *Job) Status {
+	eng.Register("foo", func(job *Job) error {
 		called = true
-		return StatusOK
+		return nil
 	})
 	if err := eng.Job("foo").Run(); err != nil {
 		t.Fatal(err)
@@ -42,10 +42,10 @@ func TestShutdownDuringRun(t *testing.T) {
 	)
 	eng := New()
 	var completed bool
-	eng.Register("foo", func(job *Job) Status {
+	eng.Register("foo", func(job *Job) error {
 		time.Sleep(jobDelay)
 		completed = true
-		return StatusOK
+		return nil
 	})
 	go eng.Job("foo").Run()
 	time.Sleep(50 * time.Millisecond)

--- a/graph/export.go
+++ b/graph/export.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -19,14 +20,14 @@ import (
 // uncompressed tar ball.
 // name is the set of tags to export.
 // out is the writer where the images are written to.
-func (s *TagStore) CmdImageExport(job *engine.Job) engine.Status {
+func (s *TagStore) CmdImageExport(job *engine.Job) error {
 	if len(job.Args) < 1 {
-		return job.Errorf("Usage: %s IMAGE [IMAGE...]\n", job.Name)
+		return fmt.Errorf("Usage: %s IMAGE [IMAGE...]\n", job.Name)
 	}
 	// get image json
 	tempdir, err := ioutil.TempDir("", "docker-export-")
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	defer os.RemoveAll(tempdir)
 
@@ -48,13 +49,13 @@ func (s *TagStore) CmdImageExport(job *engine.Job) engine.Status {
 			for tag, id := range rootRepo {
 				addKey(name, tag, id)
 				if err := s.exportImage(job.Eng, id, tempdir); err != nil {
-					return job.Error(err)
+					return err
 				}
 			}
 		} else {
 			img, err := s.LookupImage(name)
 			if err != nil {
-				return job.Error(err)
+				return err
 			}
 
 			if img != nil {
@@ -67,13 +68,13 @@ func (s *TagStore) CmdImageExport(job *engine.Job) engine.Status {
 					addKey(repoName, repoTag, img.ID)
 				}
 				if err := s.exportImage(job.Eng, img.ID, tempdir); err != nil {
-					return job.Error(err)
+					return err
 				}
 
 			} else {
 				// this must be an ID that didn't get looked up just right?
 				if err := s.exportImage(job.Eng, name, tempdir); err != nil {
-					return job.Error(err)
+					return err
 				}
 			}
 		}
@@ -83,7 +84,7 @@ func (s *TagStore) CmdImageExport(job *engine.Job) engine.Status {
 	if len(rootRepoMap) > 0 {
 		rootRepoJson, _ := json.Marshal(rootRepoMap)
 		if err := ioutil.WriteFile(path.Join(tempdir, "repositories"), rootRepoJson, os.FileMode(0644)); err != nil {
-			return job.Error(err)
+			return err
 		}
 	} else {
 		log.Debugf("There were no repositories to write")
@@ -91,15 +92,15 @@ func (s *TagStore) CmdImageExport(job *engine.Job) engine.Status {
 
 	fs, err := archive.Tar(tempdir, archive.Uncompressed)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	defer fs.Close()
 
 	if _, err := io.Copy(job.Stdout, fs); err != nil {
-		return job.Error(err)
+		return err
 	}
 	log.Debugf("End export job: %s", job.Name)
-	return engine.StatusOK
+	return nil
 }
 
 // FIXME: this should be a top-level function, not a class method

--- a/graph/history.go
+++ b/graph/history.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/docker/docker/engine"
@@ -8,14 +9,14 @@ import (
 	"github.com/docker/docker/utils"
 )
 
-func (s *TagStore) CmdHistory(job *engine.Job) engine.Status {
+func (s *TagStore) CmdHistory(job *engine.Job) error {
 	if n := len(job.Args); n != 1 {
-		return job.Errorf("Usage: %s IMAGE", job.Name)
+		return fmt.Errorf("Usage: %s IMAGE", job.Name)
 	}
 	name := job.Args[0]
 	foundImage, err := s.LookupImage(name)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 
 	lookupMap := make(map[string][]string)
@@ -41,7 +42,7 @@ func (s *TagStore) CmdHistory(job *engine.Job) engine.Status {
 		return nil
 	})
 	if _, err := outs.WriteListTo(job.Stdout); err != nil {
-		return job.Error(err)
+		return err
 	}
-	return engine.StatusOK
+	return nil
 }

--- a/graph/list.go
+++ b/graph/list.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"fmt"
 	"log"
 	"path"
 	"strings"
@@ -16,7 +17,7 @@ var acceptedImageFilterTags = map[string]struct{}{
 	"label":    {},
 }
 
-func (s *TagStore) CmdImages(job *engine.Job) engine.Status {
+func (s *TagStore) CmdImages(job *engine.Job) error {
 	var (
 		allImages   map[string]*image.Image
 		err         error
@@ -26,11 +27,11 @@ func (s *TagStore) CmdImages(job *engine.Job) engine.Status {
 
 	imageFilters, err := filters.FromParam(job.Getenv("filters"))
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	for name := range imageFilters {
 		if _, ok := acceptedImageFilterTags[name]; !ok {
-			return job.Errorf("Invalid filter '%s'", name)
+			return fmt.Errorf("Invalid filter '%s'", name)
 		}
 	}
 
@@ -50,7 +51,7 @@ func (s *TagStore) CmdImages(job *engine.Job) engine.Status {
 		allImages, err = s.graph.Heads()
 	}
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	lookup := make(map[string]*engine.Env)
 	s.Lock()
@@ -133,7 +134,7 @@ func (s *TagStore) CmdImages(job *engine.Job) engine.Status {
 
 	outs.ReverseSort()
 	if _, err := outs.WriteListTo(job.Stdout); err != nil {
-		return job.Error(err)
+		return err
 	}
-	return engine.StatusOK
+	return nil
 }

--- a/graph/load_unsupported.go
+++ b/graph/load_unsupported.go
@@ -3,9 +3,11 @@
 package graph
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/engine"
 )
 
-func (s *TagStore) CmdLoad(job *engine.Job) engine.Status {
-	return job.Errorf("CmdLoad is not supported on this platform")
+func (s *TagStore) CmdLoad(job *engine.Job) error {
+	return fmt.Errorf("CmdLoad is not supported on this platform")
 }

--- a/graph/service.go
+++ b/graph/service.go
@@ -55,36 +55,36 @@ func (s *TagStore) Install(eng *engine.Engine) error {
 //			That is a requirement of the current registry client implementation,
 //			because a re-encoded json might invalidate the image checksum at
 //			the next upload, even with functionaly identical content.
-func (s *TagStore) CmdSet(job *engine.Job) engine.Status {
+func (s *TagStore) CmdSet(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("usage: %s NAME", job.Name)
+		return fmt.Errorf("usage: %s NAME", job.Name)
 	}
 	var (
 		imgJSON = []byte(job.Getenv("json"))
 		layer   = job.Stdin
 	)
 	if len(imgJSON) == 0 {
-		return job.Errorf("mandatory key 'json' is not set")
+		return fmt.Errorf("mandatory key 'json' is not set")
 	}
 	// We have to pass an *image.Image object, even though it will be completely
 	// ignored in favor of the redundant json data.
 	// FIXME: the current prototype of Graph.Register is stupid and redundant.
 	img, err := image.NewImgJSON(imgJSON)
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	if err := s.graph.Register(img, layer); err != nil {
-		return job.Error(err)
+		return err
 	}
-	return engine.StatusOK
+	return nil
 }
 
 // CmdGet returns information about an image.
 // If the image doesn't exist, an empty object is returned, to allow
 // checking for an image's existence.
-func (s *TagStore) CmdGet(job *engine.Job) engine.Status {
+func (s *TagStore) CmdGet(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("usage: %s NAME", job.Name)
+		return fmt.Errorf("usage: %s NAME", job.Name)
 	}
 	name := job.Args[0]
 	res := &engine.Env{}
@@ -92,7 +92,7 @@ func (s *TagStore) CmdGet(job *engine.Job) engine.Status {
 	// Note: if the image doesn't exist, LookupImage returns
 	// nil, nil.
 	if err != nil {
-		return job.Error(err)
+		return err
 	}
 	if img != nil {
 		// We don't directly expose all fields of the Image objects,
@@ -116,23 +116,23 @@ func (s *TagStore) CmdGet(job *engine.Job) engine.Status {
 		res.SetJson("Parent", img.Parent)
 	}
 	res.WriteTo(job.Stdout)
-	return engine.StatusOK
+	return nil
 }
 
 // CmdLookup return an image encoded in JSON
-func (s *TagStore) CmdLookup(job *engine.Job) engine.Status {
+func (s *TagStore) CmdLookup(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("usage: %s NAME", job.Name)
+		return fmt.Errorf("usage: %s NAME", job.Name)
 	}
 	name := job.Args[0]
 	if image, err := s.LookupImage(name); err == nil && image != nil {
 		if job.GetenvBool("raw") {
 			b, err := image.RawJson()
 			if err != nil {
-				return job.Error(err)
+				return err
 			}
 			job.Stdout.Write(b)
-			return engine.StatusOK
+			return nil
 		}
 
 		out := &engine.Env{}
@@ -150,32 +150,32 @@ func (s *TagStore) CmdLookup(job *engine.Job) engine.Status {
 		out.SetInt64("Size", image.Size)
 		out.SetInt64("VirtualSize", image.GetParentsSize(0)+image.Size)
 		if _, err = out.WriteTo(job.Stdout); err != nil {
-			return job.Error(err)
+			return err
 		}
-		return engine.StatusOK
+		return nil
 	}
-	return job.Errorf("No such image: %s", name)
+	return fmt.Errorf("No such image: %s", name)
 }
 
 // CmdTarLayer return the tarLayer of the image
-func (s *TagStore) CmdTarLayer(job *engine.Job) engine.Status {
+func (s *TagStore) CmdTarLayer(job *engine.Job) error {
 	if len(job.Args) != 1 {
-		return job.Errorf("usage: %s NAME", job.Name)
+		return fmt.Errorf("usage: %s NAME", job.Name)
 	}
 	name := job.Args[0]
 	if image, err := s.LookupImage(name); err == nil && image != nil {
 		fs, err := image.TarLayer()
 		if err != nil {
-			return job.Error(err)
+			return err
 		}
 		defer fs.Close()
 
 		written, err := io.Copy(job.Stdout, fs)
 		if err != nil {
-			return job.Error(err)
+			return err
 		}
 		log.Debugf("rendered layer for %s of [%d] size", image.ID, written)
-		return engine.StatusOK
+		return nil
 	}
-	return job.Errorf("No such image: %s", name)
+	return fmt.Errorf("No such image: %s", name)
 }

--- a/graph/tag.go
+++ b/graph/tag.go
@@ -1,19 +1,18 @@
 package graph
 
 import (
+	"fmt"
+
 	"github.com/docker/docker/engine"
 )
 
-func (s *TagStore) CmdTag(job *engine.Job) engine.Status {
+func (s *TagStore) CmdTag(job *engine.Job) error {
 	if len(job.Args) != 2 && len(job.Args) != 3 {
-		return job.Errorf("Usage: %s IMAGE REPOSITORY [TAG]\n", job.Name)
+		return fmt.Errorf("Usage: %s IMAGE REPOSITORY [TAG]\n", job.Name)
 	}
 	var tag string
 	if len(job.Args) == 3 {
 		tag = job.Args[2]
 	}
-	if err := s.Set(job.Args[1], tag, job.Args[0], job.GetenvBool("force")); err != nil {
-		return job.Error(err)
-	}
-	return engine.StatusOK
+	return s.Set(job.Args[1], tag, job.Args[0], job.GetenvBool("force"))
 }

--- a/graph/viz.go
+++ b/graph/viz.go
@@ -1,16 +1,17 @@
 package graph
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/image"
 )
 
-func (s *TagStore) CmdViz(job *engine.Job) engine.Status {
+func (s *TagStore) CmdViz(job *engine.Job) error {
 	images, _ := s.graph.Map()
 	if images == nil {
-		return engine.StatusOK
+		return nil
 	}
 	job.Stdout.Write([]byte("digraph docker {\n"))
 
@@ -21,7 +22,7 @@ func (s *TagStore) CmdViz(job *engine.Job) engine.Status {
 	for _, image := range images {
 		parentImage, err = image.GetParent()
 		if err != nil {
-			return job.Errorf("Error while getting parent image: %v", err)
+			return fmt.Errorf("Error while getting parent image: %v", err)
 		}
 		if parentImage != nil {
 			job.Stdout.Write([]byte(" \"" + parentImage.ID + "\" -> \"" + image.ID + "\"\n"))
@@ -34,5 +35,5 @@ func (s *TagStore) CmdViz(job *engine.Job) engine.Status {
 		job.Stdout.Write([]byte(" \"" + id + "\" [label=\"" + id + "\\n" + strings.Join(repos, "\\n") + "\",shape=box,fillcolor=\"paleturquoise\",style=\"filled,rounded\"];\n"))
 	}
 	job.Stdout.Write([]byte(" base [style=invisible]\n}\n"))
-	return engine.StatusOK
+	return nil
 }


### PR DESCRIPTION
Resolve: #11731 

Replaced each occurrence of `engine.Status` as return value with `error`
Replaced each occurrence of `return job.Errorf(".....")`  with `return fmt.Errorf(".....")`
Replaced each occurrence of `return job.Error(err)` with `return err`

~~`job.Errorf(".....")` is still used to write to `job.Stderr` in:~~

~~\- https://github.com/docker/docker/blob/master/daemon/create.go#L33~~
~~\- https://github.com/docker/docker/blob/master/daemon/create.go#L38~~
~~\- https://github.com/docker/docker/blob/master/daemon/create.go#L61~~
~~\- https://github.com/docker/docker/blob/master/daemon/create.go#L69~~

~~`job.Error(".....")` is commented out in `engine/job.go` because I'm not sure if this was a bug:~~

~~\- https://github.com/docker/docker/compare/docker:master...runcom:11731-remove-engine-status?expand=1#diff-ac0e2781c79665472b1d2ac6418f70afL28~~

`Job` has now an `err` field to keep track of the returned error ~~(even if it's just used in aux methods like `String()` but I did want to maintain compatibility as much as possible)~~

@crosbymichael

Signed-off-by: Antonio Murdaca me@runcom.ninja
