### PR TITLE
Remove unused runconfig.Config.SecurityOpt field

### DIFF
--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -33,7 +33,6 @@ type Config struct {
 	NetworkDisabled bool
 	MacAddress      string
 	OnBuild         []string
-	SecurityOpt     []string
 	Labels          map[string]string
 }
 


### PR DESCRIPTION
The `runconfig.Config.SecurityOpt` was incorrectly reintroduced by #9882 (thanks @shin- for noticing :wink:).
