### PR TITLE
Fix positive case test.

### DIFF
--- a/pkg/ulimit/ulimit_test.go
+++ b/pkg/ulimit/ulimit_test.go
@@ -3,8 +3,13 @@ package ulimit
 import "testing"
 
 func TestParseValid(t *testing.T) {
-	u1 := &Ulimit{"nofile", 1024, 512}
-	if u2, _ := Parse("nofile=512:1024"); u1 == u2 {
+	u1 := &Ulimit{
+		Name: "nofile",
+		Hard: 1024,
+		Soft: 512,
+	}
+
+	if u2, _ := Parse("nofile=512:1024"); *u1 != *u2 {
 		t.Fatalf("expected %s, but got %s", u1.String(), u2.String())
 	}
 }


### PR DESCRIPTION
Signed-off-by: Allen Madsen blatyo@gmail.com
#11779 was incorrect. It was testing that two pointers were not equal instead that the structs were equal.
