### PR TITLE
Add fixes for integration-cli tests w/ --net none

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -149,6 +149,7 @@ func TestEventsImageUntagDelete(t *testing.T) {
 
 func TestEventsImagePull(t *testing.T) {
 	since := daemonTime(t).Unix()
+	testRequires(t, Network)
 
 	defer deleteImages("hello-world")
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -147,6 +147,7 @@ func TestRunLeakyFileDescriptors(t *testing.T) {
 // it should be possible to lookup Google DNS
 // this will fail when Internet access is unavailable
 func TestRunLookupGoogleDns(t *testing.T) {
+	testRequires(t, Network)
 	defer deleteAllContainers()
 
 	out, _, _, err := runCommandWithStdoutStderr(exec.Command(dockerBinary, "run", "busybox", "nslookup", "google.com"))

--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -8,6 +8,7 @@ import (
 
 // search for repos named  "registry" on the central registry
 func TestSearchOnCentralRegistry(t *testing.T) {
+	testRequires(t, Network)
 	searchCmd := exec.Command(dockerBinary, "search", "busybox")
 	out, exitCode, err := runCommandWithOutput(searchCmd)
 	if err != nil || exitCode != 0 {


### PR DESCRIPTION
Adds network to integration tests that were failing without network.

Fixes #10964
Fixes #10968

Signed-off-by: Jake Champlin jake.champlin.27@gmail.com
