### PR TITLE
Fix wrong docker fork dir in when build and test

### DIFF
--- a/docs/sources/project/test-and-docs.md
+++ b/docs/sources/project/test-and-docs.md
@@ -249,7 +249,8 @@ can browse the docs.
 
 1. In a terminal, change to the root of your `docker-fork` repository.
 
-        $ cd ~/repos/dry-run-test
+        # 'docker-fork' should be name of your docker fork dir
+        $ cd ~/repos/docker-fork
 
 2. Make sure you are in your feature branch.
 


### PR DESCRIPTION
I encountered a bug when doing build and test based on official guide, the original description is confusing and I think we should make it right by changing it to forked docker dir

Signed-off-by: resouer resouer@163.com
