### PR TITLE
Consider tag updated also in case repo does not exist

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -602,6 +602,8 @@ func (s *TagStore) pullV2Tag(eng *engine.Engine, r *registry.Session, out io.Wri
 			if _, exists := repo[tag]; !exists {
 				tagUpdated = true
 			}
+		} else {
+			tagUpdated = true
 		}
 	}
 


### PR DESCRIPTION
This trivial patch causes `The image you are pulling has been verified` status message to be produced also when the repository is pulled for the first time.

Associated test [TestPullVerified](https://github.com/miminar/docker/blob/bc0f1e0e098d49fff458679001fe4e2ae58c03d7/integration-cli/docker_cli_pull_test.go#L57) passes only because `hello-world:frozen` is already present among local images before the test is even started. If it were missing, it would fail on the first `t.Failf(...)`.

Signed-off-by: Michal Minar miminar@redhat.com
