### PR TITLE
Fix TestBuildResourceConstraintsAreUsed Cpuset test

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5524,7 +5524,7 @@ func TestBuildResourceConstraintsAreUsed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command(dockerBinary, "build", "--rm=false", "--memory=64m", "--memory-swap=-1", "--cpuset-cpus=1", "--cpu-shares=100", "-t", name, ".")
+	cmd := exec.Command(dockerBinary, "build", "--rm=false", "--memory=64m", "--memory-swap=-1", "--cpuset-cpus=0", "--cpu-shares=100", "-t", name, ".")
 	cmd.Dir = ctx.Dir
 
 	out, _, err := runCommandWithOutput(cmd)
@@ -5555,7 +5555,7 @@ func TestBuildResourceConstraintsAreUsed(t *testing.T) {
 		t.Fatal(err, cfg)
 	}
 	mem := int64(c1.Memory)
-	if mem != 67108864 || c1.MemorySwap != -1 || c1.CpusetCpus != "1" || c1.CpuShares != 100 {
+	if mem != 67108864 || c1.MemorySwap != -1 || c1.CpusetCpus != "0" || c1.CpuShares != 100 {
 		t.Fatalf("resource constraints not set properly:\nMemory: %d, MemSwap: %d, CpusetCpus: %s, CpuShares: %d",
 			mem, c1.MemorySwap, c1.CpusetCpus, c1.CpuShares)
 	}
@@ -5574,7 +5574,7 @@ func TestBuildResourceConstraintsAreUsed(t *testing.T) {
 		t.Fatal(err, cfg)
 	}
 	mem = int64(c2.Memory)
-	if mem == 67108864 || c2.MemorySwap == -1 || c2.CpusetCpus == "1" || c2.CpuShares == 100 {
+	if mem == 67108864 || c2.MemorySwap == -1 || c2.CpusetCpus == "0" || c2.CpuShares == 100 {
 		t.Fatalf("resource constraints leaked from build:\nMemory: %d, MemSwap: %d, CpusetCpus: %s, CpuShares: %d",
 			mem, c2.MemorySwap, c2.CpusetCpus, c2.CpuShares)
 	}


### PR DESCRIPTION
Set cpuset to "0" so that it works on single core machines.
W/o this (and set to "1") we'll see something like this error
when running:
System error: write /cgroup/cpuset/docker/66689499bbd08cd8dccc9b7bfd1d6b34e85d73ce8c84d3c69b5e91944322da60/docker/79d7c548b58c85c4cfad6cd01eb7c3b30db254d1014c496137edd93ddc528a6f/cpuset.cpus: invalid argument"

/cc @cpuguy83 
Signed-off-by: Doug Davis dug@us.ibm.com
