### PR TITLE
Add a new event for process exiting

### DIFF
--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -159,6 +159,9 @@ func (m *containerMonitor) Start() error {
 				m.container.LogEvent("oom")
 			}
 			m.container.LogEvent("die")
+			if !m.shouldStop {
+				m.container.LogEvent("process-exit")
+			}
 			m.resetContainer(true)
 
 			// sleep with a small time increment between each restart to help avoid issues cased by quickly
@@ -176,6 +179,9 @@ func (m *containerMonitor) Start() error {
 			m.container.LogEvent("oom")
 		}
 		m.container.LogEvent("die")
+		if !m.shouldStop {
+			m.container.LogEvent("process-exit")
+		}
 		m.resetContainer(true)
 		return err
 	}

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -39,6 +39,7 @@ func (daemon *Daemon) ContainerStart(job *engine.Job) error {
 	}
 	if err := container.Start(); err != nil {
 		container.LogEvent("die")
+		container.LogEvent("process-exit")
 		return fmt.Errorf("Cannot start container %s: %s", name, err)
 	}
 

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -52,14 +52,18 @@ func TestEventsContainerFailStartDie(t *testing.T) {
 		t.Fatalf("Missing expected event")
 	}
 
-	startEvent := strings.Fields(events[len(events)-3])
-	dieEvent := strings.Fields(events[len(events)-2])
+	startEvent := strings.Fields(events[len(events)-4])
+	dieEvent := strings.Fields(events[len(events)-3])
+	exitEvent := strings.Fields(events[len(events)-2])
 
 	if startEvent[len(startEvent)-1] != "start" {
 		t.Fatalf("event should be start, not %#v", startEvent)
 	}
 	if dieEvent[len(dieEvent)-1] != "die" {
 		t.Fatalf("event should be die, not %#v", dieEvent)
+	}
+	if exitEvent[len(exitEvent)-1] != "process-exit" {
+		t.Fatalf("event should be process-exit, not %#v", exitEvent)
 	}
 
 	logDone("events - container unwilling to start logs die")
@@ -89,12 +93,13 @@ func TestEventsContainerEvents(t *testing.T) {
 	}
 	events := strings.Split(out, "\n")
 	events = events[:len(events)-1]
-	if len(events) < 4 {
+	if len(events) < 5 {
 		t.Fatalf("Missing expected event")
 	}
-	createEvent := strings.Fields(events[len(events)-4])
-	startEvent := strings.Fields(events[len(events)-3])
-	dieEvent := strings.Fields(events[len(events)-2])
+	createEvent := strings.Fields(events[len(events)-5])
+	startEvent := strings.Fields(events[len(events)-4])
+	dieEvent := strings.Fields(events[len(events)-3])
+	exitEvent := strings.Fields(events[len(events)-2])
 	destroyEvent := strings.Fields(events[len(events)-1])
 	if createEvent[len(createEvent)-1] != "create" {
 		t.Fatalf("event should be create, not %#v", createEvent)
@@ -105,11 +110,80 @@ func TestEventsContainerEvents(t *testing.T) {
 	if dieEvent[len(dieEvent)-1] != "die" {
 		t.Fatalf("event should be die, not %#v", dieEvent)
 	}
+	if exitEvent[len(exitEvent)-1] != "process-exit" {
+		t.Fatalf("event should be process-exit, not %#v", exitEvent)
+	}
 	if destroyEvent[len(destroyEvent)-1] != "destroy" {
 		t.Fatalf("event should be destroy, not %#v", destroyEvent)
 	}
 
-	logDone("events - container create, start, die, destroy is logged")
+	logDone("events - container create, start, die, process-exit, destroy is logged")
+}
+
+func TestEventsContainerKill(t *testing.T) {
+	dockerCmd(t, "run", "--name", "testeventkill", "-d", "busybox", "sleep", "10")
+	dockerCmd(t, "kill", "testeventkill")
+	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(t).Unix()))
+	out, exitCode, err := runCommandWithOutput(eventsCmd)
+	if exitCode != 0 || err != nil {
+		t.Fatalf("Failed to get events with exit code %d: %s", exitCode, err)
+	}
+	events := strings.Split(out, "\n")
+	events = events[:len(events)-1]
+	if len(events) < 4 {
+		t.Fatalf("Missing expected event, got: %#v", events)
+	}
+	createEvent := strings.Fields(events[len(events)-4])
+	startEvent := strings.Fields(events[len(events)-3])
+	dieEvent := strings.Fields(events[len(events)-2])
+	killEvent := strings.Fields(events[len(events)-1])
+	if createEvent[len(createEvent)-1] != "create" {
+		t.Fatalf("event should be create, not %#v", createEvent)
+	}
+	if startEvent[len(startEvent)-1] != "start" {
+		t.Fatalf("event should be start, not %#v", startEvent)
+	}
+	if dieEvent[len(dieEvent)-1] != "die" {
+		t.Fatalf("event should be die, not %#v", dieEvent)
+	}
+	if killEvent[len(killEvent)-1] != "kill" {
+		t.Fatalf("event should be kill not %#v", killEvent)
+	}
+
+	logDone("events - container create, start, die, kill, destroy is logged")
+}
+
+func TestEventsContainerStop(t *testing.T) {
+	dockerCmd(t, "run", "--name", "testeventstop", "-d", "busybox", "top")
+	dockerCmd(t, "stop", "testeventstop")
+	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(t).Unix()))
+	out, exitCode, err := runCommandWithOutput(eventsCmd)
+	if exitCode != 0 || err != nil {
+		t.Fatalf("Failed to get events with exit code %d: %s", exitCode, err)
+	}
+	events := strings.Split(out, "\n")
+	events = events[:len(events)-1]
+	if len(events) < 4 {
+		t.Fatalf("Missing expected event, got: %#v", events)
+	}
+	createEvent := strings.Fields(events[len(events)-4])
+	startEvent := strings.Fields(events[len(events)-3])
+	dieEvent := strings.Fields(events[len(events)-2])
+	stopEvent := strings.Fields(events[len(events)-1])
+	if createEvent[len(createEvent)-1] != "create" {
+		t.Fatalf("event should be create, not %#v", createEvent)
+	}
+	if startEvent[len(startEvent)-1] != "start" {
+		t.Fatalf("event should be start, not %#v", startEvent)
+	}
+	if dieEvent[len(dieEvent)-1] != "die" {
+		t.Fatalf("event should be die, not %#v", dieEvent)
+	}
+	if stopEvent[len(stopEvent)-1] != "stop" {
+		t.Fatalf("event should be stop not %#v", stopEvent)
+	}
+
+	logDone("events - container create, start, die, stop, destroy is logged")
 }
 
 func TestEventsImageUntagDelete(t *testing.T) {
@@ -317,8 +391,8 @@ func TestEventsFilterContainerID(t *testing.T) {
 		}
 		events := strings.Split(out, "\n")
 		events = events[:len(events)-1]
-		if len(events) == 0 || len(events) > 3 {
-			t.Fatalf("Expected 3 events, got %d: %v", len(events), events)
+		if len(events) == 0 || len(events) > 4 {
+			t.Fatalf("Expected 4 events, got %d: %v", len(events), events)
 		}
 		createEvent := strings.Fields(events[0])
 		if createEvent[len(createEvent)-1] != "create" {
@@ -330,10 +404,16 @@ func TestEventsFilterContainerID(t *testing.T) {
 				t.Fatalf("second event should be start, not %#v", startEvent)
 			}
 		}
-		if len(events) == 3 {
-			dieEvent := strings.Fields(events[len(events)-1])
+		if len(events) > 2 {
+			dieEvent := strings.Fields(events[2])
 			if dieEvent[len(dieEvent)-1] != "die" {
 				t.Fatalf("event should be die, not %#v", dieEvent)
+			}
+		}
+		if len(events) == 4 {
+			exitEvent := strings.Fields(events[len(events)-1])
+			if exitEvent[len(exitEvent)-1] != "process-exit" {
+				t.Fatalf("event should be process-exit, not %#v", exitEvent)
 			}
 		}
 	}
@@ -363,8 +443,8 @@ func TestEventsFilterContainerName(t *testing.T) {
 		}
 		events := strings.Split(out, "\n")
 		events = events[:len(events)-1]
-		if len(events) == 0 || len(events) > 3 {
-			t.Fatalf("Expected 3 events, got %d: %v", len(events), events)
+		if len(events) == 0 || len(events) > 4 {
+			t.Fatalf("Expected 4 events, got %d: %v", len(events), events)
 		}
 		createEvent := strings.Fields(events[0])
 		if createEvent[len(createEvent)-1] != "create" {
@@ -376,10 +456,16 @@ func TestEventsFilterContainerName(t *testing.T) {
 				t.Fatalf("second event should be start, not %#v", startEvent)
 			}
 		}
-		if len(events) == 3 {
-			dieEvent := strings.Fields(events[len(events)-1])
+		if len(events) > 2 {
+			dieEvent := strings.Fields(events[2])
 			if dieEvent[len(dieEvent)-1] != "die" {
 				t.Fatalf("event should be die, not %#v", dieEvent)
+			}
+		}
+		if len(events) == 4 {
+			exitEvent := strings.Fields(events[len(events)-1])
+			if exitEvent[len(exitEvent)-1] != "process-exit" {
+				t.Fatalf("event should be process-exit, not %#v", exitEvent)
 			}
 		}
 	}


### PR DESCRIPTION
Send a new event when a container process exits without being requested. This
event can be used when a program needs to detect that a container exited
unexpectedly.

This event is sent after "die" when the exit was not expected for another
command like "stop", "kill", or "restart".

This addresses part of #10654 regarding how to distinguish unexpected exits, though the other part of that issue seems to be clarifying the documentation on the "die" event.

This event is currently called "process-exit" but I'm not attached to that name and it can be easily changed. Maybe just "exited" would be sufficient, since this is similar to the distinction of [`wait()`](http://man7.org/linux/man-pages/man2/wait.2.html) return codes, where `WIFEXITED(status)` is true if the process ended itself via `exit()` vs. `WIFSIGNALED(status)` when the process was ended via a signal.
