### PR TITLE
Add a new event for process exiting

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -253,6 +253,7 @@ func (container *Container) Start() (err error) {
 			container.toDisk()
 			container.cleanup()
 			container.LogEvent("die")
+			container.LogEvent("exit")
 		}
 	}()
 

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -362,6 +362,17 @@ func (container *Container) cleanup() {
 }
 
 func (container *Container) KillSig(sig int) error {
+	if err := container.killSig(sig); err != nil {
+		return err
+	}
+	container.LogEvent("kill")
+	return nil
+}
+
+// killSig sends the kill signal without logging the "kill" event, so that
+// the logging can be handled at the higher level.
+// E.g. for Kill() it should be logged after the container has died.
+func (container *Container) killSig(sig int) error {
 	logrus.Debugf("Sending %d to %s", sig, container.ID)
 	container.Lock()
 	defer container.Unlock()
@@ -389,13 +400,12 @@ func (container *Container) KillSig(sig int) error {
 	if err := container.daemon.Kill(container, sig); err != nil {
 		return err
 	}
-	container.LogEvent("kill")
 	return nil
 }
 
-// Wrapper aroung KillSig() suppressing "no such process" error.
+// Wrapper aroung killSig() suppressing "no such process" error.
 func (container *Container) killPossiblyDeadProcess(sig int) error {
-	err := container.KillSig(sig)
+	err := container.killSig(sig)
 	if err == syscall.ESRCH {
 		logrus.Debugf("Cannot kill process (pid=%d) with signal %d: no such process.", container.GetPid(), sig)
 		return nil
@@ -479,6 +489,7 @@ func (container *Container) Kill() error {
 	}
 
 	container.WaitStop(-1 * time.Second)
+	container.LogEvent("kill")
 	return nil
 }
 

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -162,6 +162,9 @@ func (m *containerMonitor) Start() error {
 				m.container.LogEvent("oom")
 			}
 			m.container.LogEvent("die")
+			if !m.shouldStop {
+				m.container.LogEvent("exit")
+			}
 			m.resetContainer(true)
 
 			// sleep with a small time increment between each restart to help avoid issues cased by quickly
@@ -179,6 +182,9 @@ func (m *containerMonitor) Start() error {
 			m.container.LogEvent("oom")
 		}
 		m.container.LogEvent("die")
+		if !m.shouldStop {
+			m.container.LogEvent("exit")
+		}
 		m.resetContainer(true)
 		return err
 	}

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -85,14 +85,18 @@ func (s *DockerSuite) TestEventsContainerFailStartDie(c *check.C) {
 		c.Fatalf("Missing expected event")
 	}
 
-	startEvent := strings.Fields(events[len(events)-3])
-	dieEvent := strings.Fields(events[len(events)-2])
+	startEvent := strings.Fields(events[len(events)-4])
+	dieEvent := strings.Fields(events[len(events)-3])
+	exitEvent := strings.Fields(events[len(events)-2])
 
 	if startEvent[len(startEvent)-1] != "start" {
 		c.Fatalf("event should be start, not %#v", startEvent)
 	}
 	if dieEvent[len(dieEvent)-1] != "die" {
 		c.Fatalf("event should be die, not %#v", dieEvent)
+	}
+	if exitEvent[len(exitEvent)-1] != "exit" {
+		c.Fatalf("event should be exit, not %#v", exitEvent)
 	}
 
 }
@@ -133,13 +137,14 @@ func (s *DockerSuite) TestEventsContainerEvents(c *check.C) {
 	out, _ := dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	events := strings.Split(out, "\n")
 	events = events[:len(events)-1]
-	if len(events) < 5 {
+	if len(events) < 6 {
 		c.Fatalf("Missing expected event")
 	}
-	createEvent := strings.Fields(events[len(events)-5])
-	attachEvent := strings.Fields(events[len(events)-4])
-	startEvent := strings.Fields(events[len(events)-3])
-	dieEvent := strings.Fields(events[len(events)-2])
+	createEvent := strings.Fields(events[len(events)-6])
+	attachEvent := strings.Fields(events[len(events)-5])
+	startEvent := strings.Fields(events[len(events)-4])
+	dieEvent := strings.Fields(events[len(events)-3])
+	exitEvent := strings.Fields(events[len(events)-2])
 	destroyEvent := strings.Fields(events[len(events)-1])
 	if createEvent[len(createEvent)-1] != "create" {
 		c.Fatalf("event should be create, not %#v", createEvent)
@@ -152,6 +157,9 @@ func (s *DockerSuite) TestEventsContainerEvents(c *check.C) {
 	}
 	if dieEvent[len(dieEvent)-1] != "die" {
 		c.Fatalf("event should be die, not %#v", dieEvent)
+	}
+	if exitEvent[len(exitEvent)-1] != "exit" {
+		c.Fatalf("event should be exit, not %#v", exitEvent)
 	}
 	if destroyEvent[len(destroyEvent)-1] != "destroy" {
 		c.Fatalf("event should be destroy, not %#v", destroyEvent)
@@ -170,10 +178,11 @@ func (s *DockerSuite) TestEventsContainerEventsSinceUnixEpoch(c *check.C) {
 	if len(events) < 5 {
 		c.Fatalf("Missing expected event")
 	}
-	createEvent := strings.Fields(events[len(events)-5])
-	attachEvent := strings.Fields(events[len(events)-4])
-	startEvent := strings.Fields(events[len(events)-3])
-	dieEvent := strings.Fields(events[len(events)-2])
+	createEvent := strings.Fields(events[len(events)-6])
+	attachEvent := strings.Fields(events[len(events)-5])
+	startEvent := strings.Fields(events[len(events)-4])
+	dieEvent := strings.Fields(events[len(events)-3])
+	exitEvent := strings.Fields(events[len(events)-2])
 	destroyEvent := strings.Fields(events[len(events)-1])
 	if createEvent[len(createEvent)-1] != "create" {
 		c.Fatalf("event should be create, not %#v", createEvent)
@@ -187,10 +196,75 @@ func (s *DockerSuite) TestEventsContainerEventsSinceUnixEpoch(c *check.C) {
 	if dieEvent[len(dieEvent)-1] != "die" {
 		c.Fatalf("event should be die, not %#v", dieEvent)
 	}
+	if exitEvent[len(exitEvent)-1] != "exit" {
+		c.Fatalf("event should be exit, not %#v", exitEvent)
+	}
 	if destroyEvent[len(destroyEvent)-1] != "destroy" {
 		c.Fatalf("event should be destroy, not %#v", destroyEvent)
 	}
 
+}
+
+func (s *DockerSuite) TestEventsContainerKill(c *check.C) {
+	dockerCmd(c, "run", "--name", "testeventkill", "-d", "busybox", "sleep", "10")
+	dockerCmd(c, "kill", "testeventkill")
+	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
+	out, exitCode, err := runCommandWithOutput(eventsCmd)
+	if exitCode != 0 || err != nil {
+		c.Fatalf("Failed to get events with exit code %d: %s", exitCode, err)
+	}
+	events := strings.Split(out, "\n")
+	events = events[:len(events)-1]
+	if len(events) < 4 {
+		c.Fatalf("Missing expected event, got: %#v", events)
+	}
+	createEvent := strings.Fields(events[len(events)-4])
+	startEvent := strings.Fields(events[len(events)-3])
+	dieEvent := strings.Fields(events[len(events)-2])
+	killEvent := strings.Fields(events[len(events)-1])
+	if createEvent[len(createEvent)-1] != "create" {
+		c.Fatalf("event should be create, not %#v", createEvent)
+	}
+	if startEvent[len(startEvent)-1] != "start" {
+		c.Fatalf("event should be start, not %#v", startEvent)
+	}
+	if dieEvent[len(dieEvent)-1] != "die" {
+		c.Fatalf("event should be die, not %#v", dieEvent)
+	}
+	if killEvent[len(killEvent)-1] != "kill" {
+		c.Fatalf("event should be kill not %#v", killEvent)
+	}
+}
+
+func (s *DockerSuite) TestEventsContainerStop(c *check.C) {
+	dockerCmd(c, "run", "--name", "testeventstop", "-d", "busybox", "top")
+	dockerCmd(c, "stop", "testeventstop")
+	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
+	out, exitCode, err := runCommandWithOutput(eventsCmd)
+	if exitCode != 0 || err != nil {
+		c.Fatalf("Failed to get events with exit code %d: %s", exitCode, err)
+	}
+	events := strings.Split(out, "\n")
+	events = events[:len(events)-1]
+	if len(events) < 4 {
+		c.Fatalf("Missing expected event, got: %#v", events)
+	}
+	createEvent := strings.Fields(events[len(events)-4])
+	startEvent := strings.Fields(events[len(events)-3])
+	dieEvent := strings.Fields(events[len(events)-2])
+	stopEvent := strings.Fields(events[len(events)-1])
+	if createEvent[len(createEvent)-1] != "create" {
+		c.Fatalf("event should be create, not %#v", createEvent)
+	}
+	if startEvent[len(startEvent)-1] != "start" {
+		c.Fatalf("event should be start, not %#v", startEvent)
+	}
+	if dieEvent[len(dieEvent)-1] != "die" {
+		c.Fatalf("event should be die, not %#v", dieEvent)
+	}
+	if stopEvent[len(stopEvent)-1] != "stop" {
+		c.Fatalf("event should be stop not %#v", stopEvent)
+	}
 }
 
 func (s *DockerSuite) TestEventsImageUntagDelete(c *check.C) {
@@ -390,8 +464,8 @@ func (s *DockerSuite) TestEventsFilterContainer(c *check.C) {
 	until := fmt.Sprintf("%d", daemonTime(c).Unix())
 
 	checkEvents := func(id string, events []string) error {
-		if len(events) != 4 { // create, attach, start, die
-			return fmt.Errorf("expected 3 events, got %v", events)
+		if len(events) != 5 { // create, attach, start, die, exit
+			return fmt.Errorf("expected 5 events, got %v", events)
 		}
 		for _, event := range events {
 			e := strings.Fields(event)


### PR DESCRIPTION
Send a new event when a container process exits without being requested. This
event can be used when a program needs to detect that a container exited
unexpectedly.

This event is sent after "die" when the exit was not expected for another
command like "stop", "kill", or "restart".

This addresses part of #10654 regarding how to distinguish unexpected exits, though the other part of that issue seems to be clarifying the documentation on the "die" event.

This event is currently called "process-exit" but I'm not attached to that name and it can be easily changed. Maybe just "exited" would be sufficient, since this is similar to the distinction of [`wait()`](http://man7.org/linux/man-pages/man2/wait.2.html) return codes, where `WIFEXITED(status)` is true if the process ended itself via `exit()` vs. `WIFSIGNALED(status)` when the process was ended via a signal.

Closes #9214
