### PR TITLE
add library files for socat in mkimage-unittest.sh

### DIFF
--- a/contrib/mkimage-unittest.sh
+++ b/contrib/mkimage-unittest.sh
@@ -37,7 +37,9 @@ rm bin/init
 ln bin/busybox bin/init
 cp -P /lib/x86_64-linux-gnu/lib{pthread*,c*(-*),dl*(-*),nsl*(-*),nss_*,util*(-*),wrap,z}.so* lib
 cp /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 lib
-cp -P /usr/lib/x86_64-linux-gnu/lib{crypto,ssl}.so* lib
+cp /lib/x86_64-linux-gnu/libreadline.so* lib
+cp /lib/x86_64-linux-gnu/libtinfo.so* lib
+cp /usr/lib/x86_64-linux-gnu/lib{crypto,ssl}.so* lib
 for X in console null ptmx random stdin stdout stderr tty urandom zero
 do
     cp -a /dev/$X dev


### PR DESCRIPTION
in https://docs.docker.com/articles/ambassador_pattern_linking/
svendowideit/ambassador images is from docker-ut built using this script
and uses socat but socat complains as follows
socat: error while loading shared libraries: libreadline.so.5: cannot open shared object file: No such file or directory
socat: error while loading shared libraries: libssl.so.1.0.0: cannot open shared object file: No such file or directory
socat: error while loading shared libraries: libcrypto.so.1.0.0: cannot open shared object file: No such file or directory
socat: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory
/usr/lib/x86_64-linux-gnu/lib{crypto,ssl}.so\* lib are symlinks so removing -P option from cp
adding libreadline.so and libtinfo.so
