### PR TITLE
Make gofmt use the filename previously referenced

### DIFF
--- a/docs/sources/project/work-issue.md
+++ b/docs/sources/project/work-issue.md
@@ -69,7 +69,7 @@ Follow this workflow as you work:
             For example, if you edited the `docker.go` file you would format the file
             like this:
             </p>
-            <p><code>$ gofmt -s -w file.go</code></p>
+            <p><code>$ gofmt -s -w docker.go</code></p>
             <p>
             Most file editors have a plugin to format for you. Check your editor's
             documentation.


### PR DESCRIPTION
The introductory text mentions formatting `docker.go`, but the subsequent code sample references `file.go` instead
