### PR TITLE
term/winconsole: Identify tty correctly, fix resize problem

### DIFF
--- a/pkg/term/winconsole/console_windows.go
+++ b/pkg/term/winconsole/console_windows.go
@@ -241,8 +241,6 @@ func StdStreams() (stdIn io.ReadCloser, stdOut io.Writer, stdErr io.Writer) {
 		}
 		handler.screenBufferInfo = screenBufferInfo
 
-		// Set the window size
-		SetWindowSize(stdoutHandle, DEFAULT_WIDTH, DEFAULT_HEIGHT, DEFAULT_HEIGHT)
 		buffer = make([]CHAR_INFO, screenBufferInfo.MaximumWindowSize.X*screenBufferInfo.MaximumWindowSize.Y)
 
 		stdOut = &terminalWriter{
@@ -279,6 +277,12 @@ func GetHandleInfo(in interface{}) (uintptr, bool) {
 	}
 	if tr, ok := in.(*terminalReader); ok {
 		if file, ok := tr.wrappedReader.(*os.File); ok {
+			inFd = file.Fd()
+			isTerminalIn = IsTerminal(inFd)
+		}
+	}
+	if tr, ok := in.(*terminalWriter); ok {
+		if file, ok := tr.wrappedWriter.(*os.File); ok {
 			inFd = file.Fd()
 			isTerminalIn = IsTerminal(inFd)
 		}


### PR DESCRIPTION
This change fixes a bug where stdout/stderr handles are not identified
correctly as file descriptors on windows.

Previously we used to set the window size to fixed size to fit the default
tty size on the host (80x24) because we couldn't find out why 
`monitorTtySize` wasn't called at all. Turns out it was a bug we fixed here.
Now the attach/exec commands can correctly get the terminal size from windows.

We still do not `monitorTtySize()` correctly on windows and update the tty
size on the host-side, in order to fix that we'll provide a
platform-specific `monitorTtySize` implementation in the future.

:exclamation: :exclamation: @jfrazelle it would be great to **cherry-pick** this fix to 1.6 release branch as we got plenty of feedback saying "every time I run docker.exe it resizes my terminal, _it's annoying_". :exclamation: :exclamation:

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @tiborvass @sachin-jayant-joshi
