### PR TITLE
windows: monitorTtySize correctly by polling

### DIFF
--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -12,8 +12,10 @@ import (
 	"net/url"
 	"os"
 	gosignal "os/signal"
+	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api"
@@ -279,13 +281,29 @@ func getExecExitCode(cli *DockerCli, execID string) (bool, int, error) {
 func (cli *DockerCli) monitorTtySize(id string, isExec bool) error {
 	cli.resizeTty(id, isExec)
 
-	sigchan := make(chan os.Signal, 1)
-	gosignal.Notify(sigchan, signal.SIGWINCH)
-	go func() {
-		for _ = range sigchan {
-			cli.resizeTty(id, isExec)
-		}
-	}()
+	if runtime.GOOS == "windows" {
+		go func() {
+			prevW, prevH := cli.getTtySize()
+			for {
+				time.Sleep(time.Millisecond * 250)
+				w, h := cli.getTtySize()
+
+				if prevW != w || prevH != h {
+					cli.resizeTty(id, isExec)
+				}
+				prevW = w
+				prevH = h
+			}
+		}()
+	} else {
+		sigchan := make(chan os.Signal, 1)
+		gosignal.Notify(sigchan, signal.SIGWINCH)
+		go func() {
+			for _ = range sigchan {
+				cli.resizeTty(id, isExec)
+			}
+		}()
+	}
 	return nil
 }
 


### PR DESCRIPTION
This change makes `monitorTtySize` work correctly on windows by polling
into win32 API to get terminal size (because there's no SIGWINCH on
windows) and send it to the engine over Remove API properly.

Average `getTtySize` takes around 10-40 ms on an average windows machine 
as far as I can tell (used go benchmarks), therefore in a `for` loop, checking
**every 250ms** if the size has changed since previous measurement or not.
If so, making the rest API call to update the term size.

That should be good enough to emulate SIGWINCH semantics on Windows.

I'm not sure if there's a better way to do it on windows, if so,
somebody please send a link 'cause I could not find.

Also not sure if this should go to 1.6 or not, just a UX improvement.
# Demo:

![](http://cl.ly/image/3T0e0121460H/Screen%20Recording%202015-03-26%20at%2004.10%20PM.gif)
_(emphasis on sizes shown in the daemon logs)_ :smile:

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
