### PR TITLE
Add some basic doc for SysInfo

### DIFF
--- a/pkg/sysinfo/README.md
+++ b/pkg/sysinfo/README.md
@@ -1,0 +1,1 @@
+SysInfo stores information about which features a kernel supports.

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -9,6 +9,7 @@ import (
 	"github.com/docker/libcontainer/cgroups"
 )
 
+// SysInfo stores information about which features a kernel supports.
 type SysInfo struct {
 	MemoryLimit            bool
 	SwapLimit              bool
@@ -16,6 +17,7 @@ type SysInfo struct {
 	AppArmor               bool
 }
 
+// Returns a new SysInfo, using the filesystem to detect which features the kernel supports.
 func New(quiet bool) *SysInfo {
 	sysInfo := &SysInfo{}
 	if cgroupMemoryMountpoint, err := cgroups.FindCgroupMountpoint("memory"); err != nil {
@@ -37,7 +39,7 @@ func New(quiet bool) *SysInfo {
 		}
 	}
 
-	// Check if AppArmor seems to be enabled on this system.
+	// Check if AppArmor is supported
 	if _, err := os.Stat("/sys/kernel/security/apparmor"); os.IsNotExist(err) {
 		sysInfo.AppArmor = false
 	} else {

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -17,7 +17,7 @@ type SysInfo struct {
 	AppArmor               bool
 }
 
-// Returns a new SysInfo, using the filesystem to detect which features the kernel supports.
+// New returns a new SysInfo, using the filesystem to detect which features the kernel supports.
 func New(quiet bool) *SysInfo {
 	sysInfo := &SysInfo{}
 	if cgroupMemoryMountpoint, err := cgroups.FindCgroupMountpoint("memory"); err != nil {

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -39,7 +39,7 @@ func New(quiet bool) *SysInfo {
 		}
 	}
 
-	// Check if AppArmor is supported
+	// Check if AppArmor is supported.
 	if _, err := os.Stat("/sys/kernel/security/apparmor"); os.IsNotExist(err) {
 		sysInfo.AppArmor = false
 	} else {


### PR DESCRIPTION
- Added a README
- Added in-line documentation for the `SysInfo` type as well as `SysInfo.New(quiet bool)`.
- Changed comment about AppArmor since according to documentation, the existence of `/sys/kernel/security/apparmor` only means that AppArmor is loaded, not that it is necessarily enabled (see [here](http://wiki.apparmor.net/index.php/Kernel_interfaces)). I think saying that it's "enabled" can be confusing.

closes #11582

Signed-off-by: Eric Rafaloff erafaloff@gmail.com
