### PR TITLE
Add nice error message

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -662,7 +662,7 @@ func postImagesPush(eng *engine.Engine, version version.Version, w http.Response
 	} else {
 		// the old format is supported for compatibility if there was no authConfig header
 		if err := json.NewDecoder(r.Body).Decode(authConfig); err != nil {
-			return err
+			return fmt.Errorf("Bad parameters and missing X-Registry-Auth: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Fixes #9315 
Fixes #10983 
Generally, when using Remote API to push images there needs a http Header
X-Registry-Auth.
For compatibility if there was no authConfig header, everything will be
okay if a proper JSON-http-body was applied.

But when both X-Registry-Auth Header and the Body are missing, due to
the function of decode JSON, it will return an EOF error which was not
very clear to user.

So I think we can make the respone error be more nice.

Signed-off-by: Hu Keping hukeping@huawei.com
