### PR TITLE
Fix-11752 add capabilities list information table.

### DIFF
--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -635,7 +635,7 @@ This can be overridden using a third `:rwm` set of options to each `--device` fl
 
 In addition to `--privileged`, the operator can have fine grain control over the
 capabilities using `--cap-add` and `--cap-drop`. By default, Docker has a default
-list of capabilities that are kept. Here is a table to list the reference information on capabilities.
+list of capabilities that are kept. The following table lists the Linux capability options which can be added or dropped.
 
 | Capability Key | Capability Description |
 | :----------------- | :---------------| :-------------------- |
@@ -645,7 +645,7 @@ list of capabilities that are kept. Here is a table to list the reference inform
 | SYS_PACCT | Use acct(2), switch process accounting on or off. |
 | SYS_ADMIN | Perform a range of system administration operations. |
 | SYS_NICE | Raise process nice value (nice(2), setpriority(2)) and change the nice value for arbitrary processes. |
-| SYS_RESOURCE | Override Resource Limits. |
+| SYS_RESOURCE | Override resource Limits. |
 | SYS_TIME | Set system clock (settimeofday(2), stime(2), adjtimex(2)); set real-time (hardware) clock. |
 | SYS_TTY_CONFIG | Use vhangup(2); employ various privileged ioctl(2) operations on virtual terminals. |
 | MKNOD | Create special files using mknod(2). |
@@ -665,7 +665,7 @@ list of capabilities that are kept. Here is a table to list the reference inform
 | SETGID | Make arbitrary manipulations of process GIDs and supplementary GID list. |
 | SETUID | Make arbitrary manipulations of process UIDs. |
 | LINUX_IMMUTABLE | Set the FS_APPEND_FL and FS_IMMUTABLE_FL i-node flags. |
-| NET_BIND_SERVICE  | Bind a socket to Internet domain privileged ports (port numbers less than 1024). |
+| NET_BIND_SERVICE  | Bind a socket to internet domain privileged ports (port numbers less than 1024). |
 | NET_BROADCAST |  Make socket broadcasts, and listen to multicasts. |
 | IPC_LOCK | Lock memory (mlock(2), mlockall(2), mmap(2), shmctl(2)). |
 | IPC_OWNER | Bypass permission checks for operations on System V IPC objects. |
@@ -677,7 +677,7 @@ list of capabilities that are kept. Here is a table to list the reference inform
 | WAKE_ALARM | Trigger something that will wake up the system. |
 | BLOCK_SUSPEND | Employ features that can block system suspend. |
 
-For futher understanding, please check [capabilities(7) - Linux man page](http://linux.die.net/man/7/capabilities)
+Further reference information is available on the [capabilities(7) - Linux man page](http://linux.die.net/man/7/capabilities)
 
 Both flags support the value `all`, so if the
 operator wants to have all capabilities but `MKNOD` they could use:

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -635,7 +635,50 @@ This can be overridden using a third `:rwm` set of options to each `--device` fl
 
 In addition to `--privileged`, the operator can have fine grain control over the
 capabilities using `--cap-add` and `--cap-drop`. By default, Docker has a default
-list of capabilities that are kept. Both flags support the value `all`, so if the
+list of capabilities that are kept. Here is a table to list the reference information on capabilities.
+
+| Capability Key     | Capability Value | Capability Description |
+| :----------------- | :---------------| :-------------------- |
+| SETPCAP | capability.CAP_SETPCAP | Modify process capabilities. |
+| SYS_MODULE | capability.CAP_SYS_MODULE | Load and unload kernel modules. |
+| SYS_RAWIO | capability.CAP_SYS_RAWIO | Perform I/O port operations (iopl(2) and ioperm(2)). |
+| SYS_PACCT | capability.CAP_SYS_PACCT | Use acct(2), switch process accounting on or off. |
+| SYS_ADMIN | capability.CAP_SYS_ADMIN | Perform a range of system administration operations. |
+| SYS_NICE | capability.CAP_SYS_NICE | Raise process nice value (nice(2), setpriority(2)) and change the nice value for arbitrary processes. |
+| SYS_RESOURCE | capability.CAP_SYS_RESOURCE | Override Resource Limits. |
+| SYS_TIME | capability.CAP_SYS_TIME | Set system clock (settimeofday(2), stime(2), adjtimex(2)); set real-time (hardware) clock. |
+| SYS_TTY_CONFIG | capability.CAP_SYS_TTY_CONFIG | Use vhangup(2); employ various privileged ioctl(2) operations on virtual terminals. |
+| MKNOD | capability.CAP_MKNOD | Create special files using mknod(2). |
+| AUDIT_WRITE | capability.CAP_AUDIT_WRITE | Write records to kernel auditing log. |
+| AUDIT_CONTROL | capability.CAP_AUDIT_CONTROL  | Enable and disable kernel auditing; change auditing filter rules; retrieve auditing status and filtering rules. |
+| MAC_OVERRIDE | capability.CAP_MAC_OVERRIDE | Allow MAC configuration or state changes. Implemented for the Smack LSM. |
+| MAC_ADMIN | capability.CAP_MAC_ADMIN | Override Mandatory Access Control (MAC). Implemented for the Smack Linux Security Module (LSM). |
+| NET_ADMIN | capability.CAP_NET_ADMIN | Perform various network-related operations. |
+| SYSLOG | capability.CAP_SYSLOG | Perform privileged syslog(2) operations.  |
+| CHOWN | capability.CAP_CHOWN | Make arbitrary changes to file UIDs and GIDs (see chown(2)). |
+| NET_RAW | capability.CAP_NET_RAW  | Use RAW and PACKET sockets. |
+| DAC_OVERRIDE | capability.CAP_DAC_OVERRIDE | Bypass file read, write, and execute permission checks. |
+| FOWNER | capability.CAP_FOWNER | Bypass permission checks on operations that normally require the file system UID of the process to match the UID of the file. |
+| DAC_READ_SEARCH | capability.CAP_DAC_READ_SEARCH | Bypass file read permission checks and directory read and execute permission checks. |
+| FSETID | capability.CAP_FSETID | Don't clear set-user-ID and set-group-ID permission bits when a file is modified. |
+| KILL | apability.CAP_KILL | Bypass permission checks for sending signals. |
+| SETGID | capability.CAP_SETGID | Make arbitrary manipulations of process GIDs and supplementary GID list. |
+| SETUID | capability.CAP_SETUID | Make arbitrary manipulations of process UIDs. |
+| LINUX_IMMUTABLE | capability.CAP_LINUX_IMMUTABLE | Set the FS_APPEND_FL and FS_IMMUTABLE_FL i-node flags. |
+| NET_BIND_SERVICE | capability.CAP_NET_BIND_SERVICE | Bind a socket to Internet domain privileged ports (port numbers less than 1024). |
+| NET_BROADCAST | capability.CAP_NET_BROADCAST} | Make socket broadcasts, and listen to multicasts. |
+| IPC_LOCK | capability.CAP_IPC_LOCK | Lock memory (mlock(2), mlockall(2), mmap(2), shmctl(2)). |
+| IPC_OWNER | capability.CAP_IPC_OWNER | Bypass permission checks for operations on System V IPC objects. |
+| SYS_CHROOT | capability.CAP_SYS_CHROOT | Use chroot(2), change root directory. |
+| SYS_PTRACE | capability.CAP_SYS_PTRACE | Trace arbitrary processes using ptrace(2). |
+| SYS_BOOT | capability.CAP_SYS_BOOT | Use reboot(2) and kexec_load(2), reboot and load a new kernel for later execution. |
+| LEASE | capability.CAP_LEASE | Establish leases on arbitrary files (see fcntl(2)). |
+| SETFCAP | capability.CAP_SETFCAP | Set file capabilities.|
+| WAKE_ALARM | capability.CAP_WAKE_ALARM | Trigger something that will wake up the system. |
+| BLOCK_SUSPEND | capability.CAP_BLOCK_SUSPEND | Employ features that can block system suspend. |
+
+
+Both flags support the value `all`, so if the
 operator wants to have all capabilities but `MKNOD` they could use:
 
     $ docker run --cap-add=ALL --cap-drop=MKNOD ...

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -637,46 +637,47 @@ In addition to `--privileged`, the operator can have fine grain control over the
 capabilities using `--cap-add` and `--cap-drop`. By default, Docker has a default
 list of capabilities that are kept. Here is a table to list the reference information on capabilities.
 
-| Capability Key     | Capability Value | Capability Description |
+| Capability Key | Capability Description |
 | :----------------- | :---------------| :-------------------- |
-| SETPCAP | capability.CAP_SETPCAP | Modify process capabilities. |
-| SYS_MODULE | capability.CAP_SYS_MODULE | Load and unload kernel modules. |
-| SYS_RAWIO | capability.CAP_SYS_RAWIO | Perform I/O port operations (iopl(2) and ioperm(2)). |
-| SYS_PACCT | capability.CAP_SYS_PACCT | Use acct(2), switch process accounting on or off. |
-| SYS_ADMIN | capability.CAP_SYS_ADMIN | Perform a range of system administration operations. |
-| SYS_NICE | capability.CAP_SYS_NICE | Raise process nice value (nice(2), setpriority(2)) and change the nice value for arbitrary processes. |
-| SYS_RESOURCE | capability.CAP_SYS_RESOURCE | Override Resource Limits. |
-| SYS_TIME | capability.CAP_SYS_TIME | Set system clock (settimeofday(2), stime(2), adjtimex(2)); set real-time (hardware) clock. |
-| SYS_TTY_CONFIG | capability.CAP_SYS_TTY_CONFIG | Use vhangup(2); employ various privileged ioctl(2) operations on virtual terminals. |
-| MKNOD | capability.CAP_MKNOD | Create special files using mknod(2). |
-| AUDIT_WRITE | capability.CAP_AUDIT_WRITE | Write records to kernel auditing log. |
-| AUDIT_CONTROL | capability.CAP_AUDIT_CONTROL  | Enable and disable kernel auditing; change auditing filter rules; retrieve auditing status and filtering rules. |
-| MAC_OVERRIDE | capability.CAP_MAC_OVERRIDE | Allow MAC configuration or state changes. Implemented for the Smack LSM. |
-| MAC_ADMIN | capability.CAP_MAC_ADMIN | Override Mandatory Access Control (MAC). Implemented for the Smack Linux Security Module (LSM). |
-| NET_ADMIN | capability.CAP_NET_ADMIN | Perform various network-related operations. |
-| SYSLOG | capability.CAP_SYSLOG | Perform privileged syslog(2) operations.  |
-| CHOWN | capability.CAP_CHOWN | Make arbitrary changes to file UIDs and GIDs (see chown(2)). |
-| NET_RAW | capability.CAP_NET_RAW  | Use RAW and PACKET sockets. |
-| DAC_OVERRIDE | capability.CAP_DAC_OVERRIDE | Bypass file read, write, and execute permission checks. |
-| FOWNER | capability.CAP_FOWNER | Bypass permission checks on operations that normally require the file system UID of the process to match the UID of the file. |
-| DAC_READ_SEARCH | capability.CAP_DAC_READ_SEARCH | Bypass file read permission checks and directory read and execute permission checks. |
-| FSETID | capability.CAP_FSETID | Don't clear set-user-ID and set-group-ID permission bits when a file is modified. |
-| KILL | apability.CAP_KILL | Bypass permission checks for sending signals. |
-| SETGID | capability.CAP_SETGID | Make arbitrary manipulations of process GIDs and supplementary GID list. |
-| SETUID | capability.CAP_SETUID | Make arbitrary manipulations of process UIDs. |
-| LINUX_IMMUTABLE | capability.CAP_LINUX_IMMUTABLE | Set the FS_APPEND_FL and FS_IMMUTABLE_FL i-node flags. |
-| NET_BIND_SERVICE | capability.CAP_NET_BIND_SERVICE | Bind a socket to Internet domain privileged ports (port numbers less than 1024). |
-| NET_BROADCAST | capability.CAP_NET_BROADCAST} | Make socket broadcasts, and listen to multicasts. |
-| IPC_LOCK | capability.CAP_IPC_LOCK | Lock memory (mlock(2), mlockall(2), mmap(2), shmctl(2)). |
-| IPC_OWNER | capability.CAP_IPC_OWNER | Bypass permission checks for operations on System V IPC objects. |
-| SYS_CHROOT | capability.CAP_SYS_CHROOT | Use chroot(2), change root directory. |
-| SYS_PTRACE | capability.CAP_SYS_PTRACE | Trace arbitrary processes using ptrace(2). |
-| SYS_BOOT | capability.CAP_SYS_BOOT | Use reboot(2) and kexec_load(2), reboot and load a new kernel for later execution. |
-| LEASE | capability.CAP_LEASE | Establish leases on arbitrary files (see fcntl(2)). |
-| SETFCAP | capability.CAP_SETFCAP | Set file capabilities.|
-| WAKE_ALARM | capability.CAP_WAKE_ALARM | Trigger something that will wake up the system. |
-| BLOCK_SUSPEND | capability.CAP_BLOCK_SUSPEND | Employ features that can block system suspend. |
+| SETPCAP | Modify process capabilities. |
+| SYS_MODULE| Load and unload kernel modules. |
+| SYS_RAWIO | Perform I/O port operations (iopl(2) and ioperm(2)). |
+| SYS_PACCT | Use acct(2), switch process accounting on or off. |
+| SYS_ADMIN | Perform a range of system administration operations. |
+| SYS_NICE | Raise process nice value (nice(2), setpriority(2)) and change the nice value for arbitrary processes. |
+| SYS_RESOURCE | Override Resource Limits. |
+| SYS_TIME | Set system clock (settimeofday(2), stime(2), adjtimex(2)); set real-time (hardware) clock. |
+| SYS_TTY_CONFIG | Use vhangup(2); employ various privileged ioctl(2) operations on virtual terminals. |
+| MKNOD | Create special files using mknod(2). |
+| AUDIT_WRITE | Write records to kernel auditing log. |
+| AUDIT_CONTROL | Enable and disable kernel auditing; change auditing filter rules; retrieve auditing status and filtering rules. |
+| MAC_OVERRIDE | Allow MAC configuration or state changes. Implemented for the Smack LSM. |
+| MAC_ADMIN | Override Mandatory Access Control (MAC). Implemented for the Smack Linux Security Module (LSM). |
+| NET_ADMIN | Perform various network-related operations. |
+| SYSLOG | Perform privileged syslog(2) operations.  |
+| CHOWN | Make arbitrary changes to file UIDs and GIDs (see chown(2)). |
+| NET_RAW | Use RAW and PACKET sockets. |
+| DAC_OVERRIDE | Bypass file read, write, and execute permission checks. |
+| FOWNER | Bypass permission checks on operations that normally require the file system UID of the process to match the UID of the file. |
+| DAC_READ_SEARCH | Bypass file read permission checks and directory read and execute permission checks. |
+| FSETID | Don't clear set-user-ID and set-group-ID permission bits when a file is modified. |
+| KILL | Bypass permission checks for sending signals. |
+| SETGID | Make arbitrary manipulations of process GIDs and supplementary GID list. |
+| SETUID | Make arbitrary manipulations of process UIDs. |
+| LINUX_IMMUTABLE | Set the FS_APPEND_FL and FS_IMMUTABLE_FL i-node flags. |
+| NET_BIND_SERVICE  | Bind a socket to Internet domain privileged ports (port numbers less than 1024). |
+| NET_BROADCAST |  Make socket broadcasts, and listen to multicasts. |
+| IPC_LOCK | Lock memory (mlock(2), mlockall(2), mmap(2), shmctl(2)). |
+| IPC_OWNER | Bypass permission checks for operations on System V IPC objects. |
+| SYS_CHROOT | Use chroot(2), change root directory. |
+| SYS_PTRACE | Trace arbitrary processes using ptrace(2). |
+| SYS_BOOT | Use reboot(2) and kexec_load(2), reboot and load a new kernel for later execution. |
+| LEASE | Establish leases on arbitrary files (see fcntl(2)). |
+| SETFCAP | Set file capabilities.|
+| WAKE_ALARM | Trigger something that will wake up the system. |
+| BLOCK_SUSPEND | Employ features that can block system suspend. |
 
+For futher understanding, please check [capabilities(7) - Linux man page](http://linux.die.net/man/7/capabilities)
 
 Both flags support the value `all`, so if the
 operator wants to have all capabilities but `MKNOD` they could use:


### PR DESCRIPTION
Fixes https://github.com/docker/docker/issues/11752

We have added the capabilities table in order to make how to set cap to docker clear.

Signed-off-by: Chen Qiu 21321229@zju.edu.cn Harry Zhang harryzhang@zju.edu.cn
