### PR TITLE
Fix create volume in a directory which is a symbolic link

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -189,10 +189,13 @@ func (container *Container) parseVolumeMountConfig() (map[string]*Mount, error) 
 		if _, exists := container.Volumes[path]; exists {
 			continue
 		}
-
-		if stat, err := os.Stat(filepath.Join(container.basefs, path)); err == nil {
+		realpath, err := symlink.FollowSymlinkInScope(filepath.Join(container.basefs, path), container.basefs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate the absolute path of symlink")
+		}
+		if stat, err := os.Stat(realpath); err == nil {
 			if !stat.IsDir() {
-				return nil, fmt.Errorf("file exists at %s, can't create volume there")
+				return nil, fmt.Errorf("file exists at %s, can't create volume there", realpath)
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Fixes #11862 

You can reproduce this on `ubuntu:14.04` machine use `ubuntu:14.04` images
by steps:
`1.sudo touch /var/run/gordon`
`2.docker run --rm -ti --volume /var/run/gordon ubuntu:14.04 /bin/bash`

This is because `/var/run` is a symlink to `/run` in rootfs of 
ubuntu:14.04. And  when do `parseVolumeMountConfig`
the container has not create a mount namespace, so the symlink of
container's will link to the host, so the error happened.
