### PR TITLE
Fix vet warning in devicemapper.

### DIFF
--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"syscall"
+	"unsafe"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -226,7 +227,7 @@ func (t *Task) GetDriverVersion() (string, error) {
 	return res, nil
 }
 
-func (t *Task) GetNextTarget(next uintptr) (nextPtr uintptr, start uint64,
+func (t *Task) GetNextTarget(next unsafe.Pointer) (nextPtr unsafe.Pointer, start uint64,
 	length uint64, targetType string, params string) {
 
 	return DmGetNextTarget(t.unmanaged, next, &start, &length,
@@ -512,7 +513,7 @@ func GetStatus(name string) (uint64, uint64, string, string, error) {
 		return 0, 0, "", "", fmt.Errorf("Non existing device %s", name)
 	}
 
-	_, start, length, targetType, params := task.GetNextTarget(0)
+	_, start, length, targetType, params := task.GetNextTarget(unsafe.Pointer(nil))
 	return start, length, targetType, params, nil
 }
 

--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -219,7 +219,7 @@ func dmTaskGetDriverVersionFct(task *CDmTask) string {
 	return C.GoString((*C.char)(buffer))
 }
 
-func dmGetNextTargetFct(task *CDmTask, next uintptr, start, length *uint64, target, params *string) uintptr {
+func dmGetNextTargetFct(task *CDmTask, next unsafe.Pointer, start, length *uint64, target, params *string) unsafe.Pointer {
 	var (
 		Cstart, Clength      C.uint64_t
 		CtargetType, Cparams *C.char
@@ -231,8 +231,8 @@ func dmGetNextTargetFct(task *CDmTask, next uintptr, start, length *uint64, targ
 		*params = C.GoString(Cparams)
 	}()
 
-	nextp := C.dm_get_next_target((*C.struct_dm_task)(task), unsafe.Pointer(next), &Cstart, &Clength, &CtargetType, &Cparams)
-	return uintptr(nextp)
+	nextp := C.dm_get_next_target((*C.struct_dm_task)(task), next, &Cstart, &Clength, &CtargetType, &Cparams)
+	return nextp
 }
 
 func dmUdevSetSyncSupportFct(syncWithUdev int) {


### PR DESCRIPTION
Uint pointer to unsafe.Pointer conversion was triggering warnings during go vet. I just changed the pointers datatypes to unsafe.Pointer for the hole GetNextTarget call chain. Fixes #11828

Signed-off-by: Félix Baylac-Jacqué baylac.felix@gmail.com
