### PR TITLE
mkimage-arch: set default C.UTF-8 locale

### DIFF
--- a/contrib/mkimage-arch.sh
+++ b/contrib/mkimage-arch.sh
@@ -14,6 +14,8 @@ hash expect &>/dev/null || {
 	exit 1
 }
 
+export LANG="C.UTF-8"
+
 ROOTFS=$(mktemp -d ${TMPDIR:-/var/tmp}/rootfs-archlinux-XXXXXXXXXX)
 chmod 755 $ROOTFS
 


### PR DESCRIPTION
It may not work fine when doing expect script if setting other locale.

Signed-off-by: Jun-Ru Chang jrjang@gmail.com
