### PR TITLE
add devices cgroup check as hard requirement

### DIFF
--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -58,5 +58,11 @@ func New(quiet bool) *SysInfo {
 	} else {
 		sysInfo.AppArmor = true
 	}
+
+	// Check if Devices cgroup is mounted, it is hard requirement for container security.
+	if _, err := cgroups.FindCgroupMountpoint("devices"); err != nil {
+		logrus.Fatalf("Error mounting devices cgroup: %v", err)
+	}
+
 	return sysInfo
 }

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -23,20 +23,16 @@ func New(quiet bool) *SysInfo {
 	sysInfo := &SysInfo{}
 	if cgroupMemoryMountpoint, err := cgroups.FindCgroupMountpoint("memory"); err != nil {
 		if !quiet {
-			logrus.Warnf("%v", err)
+			logrus.Warnf("Your kernel does not support cgroup memory limit: %v", err)
 		}
 	} else {
-		_, err1 := ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.limit_in_bytes"))
-		_, err2 := ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.soft_limit_in_bytes"))
-		sysInfo.MemoryLimit = err1 == nil && err2 == nil
-		if !sysInfo.MemoryLimit && !quiet {
-			logrus.Warn("Your kernel does not support cgroup memory limit.")
-		}
+		// If memory cgroup is mounted, MemoryLimit is always enabled.
+		sysInfo.MemoryLimit = true
 
-		_, err = ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.memsw.limit_in_bytes"))
-		sysInfo.SwapLimit = err == nil
+		_, err1 := ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.memsw.limit_in_bytes"))
+		sysInfo.SwapLimit = err1 == nil
 		if !sysInfo.SwapLimit && !quiet {
-			logrus.Warn("Your kernel does not support cgroup swap limit.")
+			logrus.Warn("Your kernel does not support swap memory limit.")
 		}
 	}
 


### PR DESCRIPTION
Devices cgroup is required for container security,  because without it a container will have unrestricted access to device nodes, libcontainer will take that as a hard requirement, we should warn users if they happen to have this umounted.
