### PR TITLE
Unuseful container that started failure should be deleted automaticly

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -181,8 +181,9 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		}
 	}
 
+	var ErrStartContainerFailureAndDeleted error = nil
 	defer func() {
-		if *flAutoRemove {
+		if *flAutoRemove || ErrStartContainerFailureAndDeleted != nil {
 			if _, _, err = readBody(cli.call("DELETE", "/containers/"+createResponse.ID+"?v=1", nil, nil)); err != nil {
 				logrus.Errorf("Error deleting container: %s", err)
 			}
@@ -191,6 +192,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 
 	//start the container
 	if _, _, err = readBody(cli.call("POST", "/containers/"+createResponse.ID+"/start", nil, nil)); err != nil {
+		ErrStartContainerFailureAndDeleted = err
 		return err
 	}
 

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -52,8 +52,8 @@ func TestEventsContainerFailStartDie(t *testing.T) {
 		t.Fatalf("Missing expected event")
 	}
 
-	startEvent := strings.Fields(events[len(events)-3])
-	dieEvent := strings.Fields(events[len(events)-2])
+	startEvent := strings.Fields(events[len(events)-4])
+	dieEvent := strings.Fields(events[len(events)-3])
 
 	if startEvent[len(startEvent)-1] != "start" {
 		t.Fatalf("event should be start, not %#v", startEvent)
@@ -310,6 +310,7 @@ func TestEventsFilterContainerID(t *testing.T) {
 	}
 	container2 := stripTrailingCharacters(out)
 
+	time.Sleep(1000 * time.Millisecond)
 	for _, s := range []string{container1, container2, container1[:12], container2[:12]} {
 		eventsCmd := exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(t).Unix()), "--filter", fmt.Sprintf("container=%s", s))
 		out, _, err := runCommandWithOutput(eventsCmd)

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -115,18 +115,14 @@ func TestStartRecordError(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error but got none, output %q", out)
 	}
-	stateErr, err = inspectField("test2", "State.Error")
-	if err != nil {
-		t.Fatalf("Failed to inspect %q state's error, got error %q", "test2", err)
-	}
-	expected := "port is already allocated"
-	if stateErr == "" || !strings.Contains(stateErr, expected) {
-		t.Fatalf("State.Error(%q) does not include %q", stateErr, expected)
+
+	if !strings.Contains(out, "port is already allocated") {
+		t.Fatal("Expected error but got none")
 	}
 
 	// Expect the conflict to be resolved when we stop the initial container
 	dockerCmd(t, "stop", "test")
-	dockerCmd(t, "start", "test2")
+	dockerCmd(t, "run", "-d", "-p", "9999:9999", "--name", "test2", "busybox", "top")
 	stateErr, err = inspectField("test2", "State.Error")
 	if err != nil {
 		t.Fatalf("Failed to inspect %q state's error, got error %q", "test", err)


### PR DESCRIPTION
Operations:

```
mabin@mabin-PC:~/work/osc/pr/docker$ sudo docker run -idt ubuntu:14.04 /bin/bas
93d414b89fb38f1cd0779fd7a558da61479db876b4e758613119eeb8e6e09fed
FATA[0000] Error response from daemon: Cannot start container 93d414b89fb38f1cd0779fd7a558da61479db876b4e758613119eeb8e6e09fed: [8] System error: exec: "/bin/bas": stat /bin/bas: no such file or directory 
mabin@mabin-PC:~/work/osc/pr/docker$ sudo docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
93d414b89fb3        ubuntu:14.04        "/bin/bas"          5 seconds ago                                               silly_almeida       
mabin@mabin-PC:~/work/osc/pr/docker$ 
```

When i ran a container with wrong or non-existent command, daemon reported FATA error "Cannot start container", but it can be found by "docker ps" command. In my opinion,maybe the failed container should be deleted automaticly because it's unuseful.
