### PR TITLE
Fixed code formatting on docs.docker.com

### DIFF
--- a/docs/sources/project/set-up-dev-env.md
+++ b/docs/sources/project/set-up-dev-env.md
@@ -75,8 +75,8 @@ To remove unnecessary artifacts,
         $ docker rmi -f $(docker images -q -a -f dangling=true)
 
     This command uses `docker images` to list all images (`-a` flag) by numeric
-    IDs (`-q` flag) and filter them to find dangling images (`-f
-    dangling=true`). Then, the `docker rmi` command forcibly (`-f` flag) removes
+    IDs (`-q` flag) and filter them to find dangling images (`-f dangling=true`).
+    Then, the `docker rmi` command forcibly (`-f` flag) removes
     the resulting list. To remove just one image, use the `docker rmi ID`
     command.
 


### PR DESCRIPTION
Now it looks a bit weird:

![image](https://cloud.githubusercontent.com/assets/89186/6880900/2ff87a18-d557-11e4-9a0c-20d51f0cda11.png)

Line length is exactly 80 chars now. Site builder should be fixed instead, though.
