### PR TITLE
Use ContainerCommitResponse struct for Commit cmd

### DIFF
--- a/api/client/commit.go
+++ b/api/client/commit.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/docker/docker/engine"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/parsers"
@@ -57,9 +57,10 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	}
 
 	var (
-		config *runconfig.Config
-		env    engine.Env
+		config   *runconfig.Config
+		response types.ContainerCommitResponse
 	)
+
 	if *flConfig != "" {
 		config = &runconfig.Config{}
 		if err := json.Unmarshal([]byte(*flConfig), config); err != nil {
@@ -70,10 +71,11 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 	if err != nil {
 		return err
 	}
-	if err := env.Decode(stream); err != nil {
+
+	if err := json.NewDecoder(stream).Decode(&response); err != nil {
 		return err
 	}
 
-	fmt.Fprintf(cli.out, "%s\n", env.Get("Id"))
+	fmt.Fprintln(cli.out, response.ID)
 	return nil
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -507,7 +507,6 @@ func postCommit(eng *engine.Engine, version version.Version, w http.ResponseWrit
 	}
 	var (
 		config       engine.Env
-		env          engine.Env
 		job          = eng.Job("commit", r.Form.Get("container"))
 		stdoutBuffer = bytes.NewBuffer(nil)
 	)
@@ -537,8 +536,9 @@ func postCommit(eng *engine.Engine, version version.Version, w http.ResponseWrit
 	if err := job.Run(); err != nil {
 		return err
 	}
-	env.Set("Id", engine.Tail(stdoutBuffer, 1))
-	return writeJSONEnv(w, http.StatusCreated, env)
+	return writeJSON(w, http.StatusCreated, &types.ContainerCommitResponse{
+		ID: engine.Tail(stdoutBuffer, 1),
+	})
 }
 
 // Creates an image from Pull or from Import

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -30,3 +30,8 @@ type ContainerWaitResponse struct {
 	// StatusCode is the status code of the wait job
 	StatusCode int `json:"StatusCode"`
 }
+
+// POST "/commit?container="+containerID
+type ContainerCommitResponse struct {
+	ID string `json:"Id"`
+}


### PR DESCRIPTION
Addresses #11612 and is based on [this diff](https://github.com/docker/docker/pull/11665/files#diff-44a527ea72ea9572e1cf71c7f1e2a0f0L1175).
