### PR TITLE
Do not complete --cgroup-parent as _filedir

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -802,7 +802,7 @@ _docker_run() {
 			__docker_capabilities
 			return
 			;;
-		--cidfile|--cgroup-parent|--env-file|--label-file)
+		--cidfile|--env-file|--label-file)
 			_filedir
 			return
 			;;


### PR DESCRIPTION
This is a follow-up on 7d707360159852dde4e75fc5d4778c72abc44a03 as suggested by @tianon and me, see discussion in #11708
