### PR TITLE
Add email parameter for token auth for docker login

### DIFF
--- a/registry/auth.go
+++ b/registry/auth.go
@@ -84,7 +84,7 @@ func (auth *RequestAuthorization) getToken() (string, error) {
 				params[k] = v
 			}
 			params["scope"] = fmt.Sprintf("%s:%s:%s", auth.resource, auth.scope, strings.Join(auth.actions, ","))
-			token, err := getToken(auth.authConfig.Username, auth.authConfig.Password, params, auth.registryEndpoint, client, factory)
+			token, err := getToken(auth.authConfig.Username, auth.authConfig.Password, auth.authConfig.Email, params, auth.registryEndpoint, client, factory)
 			if err != nil {
 				return "", err
 			}
@@ -403,7 +403,7 @@ func tryV2BasicAuthLogin(authConfig *AuthConfig, params map[string]string, regis
 }
 
 func tryV2TokenAuthLogin(authConfig *AuthConfig, params map[string]string, registryEndpoint *Endpoint, client *http.Client, factory *utils.HTTPRequestFactory) error {
-	token, err := getToken(authConfig.Username, authConfig.Password, params, registryEndpoint, client, factory)
+	token, err := getToken(authConfig.Username, authConfig.Password, authConfig.Email, params, registryEndpoint, client, factory)
 	if err != nil {
 		return err
 	}

--- a/registry/token.go
+++ b/registry/token.go
@@ -15,7 +15,7 @@ type tokenResponse struct {
 	Token string `json:"token"`
 }
 
-func getToken(username, password string, params map[string]string, registryEndpoint *Endpoint, client *http.Client, factory *utils.HTTPRequestFactory) (token string, err error) {
+func getToken(username, password string, email string, params map[string]string, registryEndpoint *Endpoint, client *http.Client, factory *utils.HTTPRequestFactory) (token string, err error) {
 	realm, ok := params["realm"]
 	if !ok {
 		return "", errors.New("no realm specified for token auth challenge")
@@ -49,6 +49,10 @@ func getToken(username, password string, params map[string]string, registryEndpo
 
 	for _, scopeField := range strings.Fields(scope) {
 		reqParams.Add("scope", scopeField)
+	}
+
+	if scope == "" {
+		reqParams.Add("email", email)
 	}
 
 	if username != "" {

--- a/registry/token.go
+++ b/registry/token.go
@@ -51,7 +51,7 @@ func getToken(username, password string, email string, params map[string]string,
 		reqParams.Add("scope", scopeField)
 	}
 
-	if scope == "" {
+	if email != "" {
 		reqParams.Add("email", email)
 	}
 


### PR DESCRIPTION
This adds an `email` parameter for token authentication for the new registry authentication model when `docker login` is performed, without this, the only information transmitted is `username` and `password`.

The auth service should be able to have the email address to be able to provide password resets, amongst other administrative tasks.

https://github.com/docker/distribution/issues/308
