### PR TITLE
show the right image name in job log and docker ps

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -203,7 +203,7 @@ func (container *Container) LogEvent(action string) {
 	d.EventsService.Log(
 		action,
 		container.ID,
-		d.Repositories().ImageName(container.ImageID),
+		container.Config.Image,
 	)
 }
 

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -7,12 +7,9 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/graph"
 	"github.com/docker/docker/nat"
 	"github.com/docker/docker/pkg/graphdb"
-	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/parsers/filters"
-	"github.com/docker/docker/utils"
 )
 
 // List returns an array of all containers registered in the daemon.
@@ -136,12 +133,7 @@ func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, 
 			ID:    container.ID,
 			Names: names[container.ID],
 		}
-		img := container.Config.Image
-		_, tag := parsers.ParseRepositoryTag(container.Config.Image)
-		if tag == "" {
-			img = utils.ImageReference(img, graph.DEFAULTTAG)
-		}
-		newC.Image = img
+		newC.Image = container.Config.Image
 		if len(container.Args) > 0 {
 			args := []string{}
 			for _, arg := range container.Args {

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2009,8 +2009,16 @@ func TestBuildCancelationKillsSleep(t *testing.T) {
 		}()
 
 		var started, died bool
-		matchStart := regexp.MustCompile(" \\(from busybox\\:latest\\) start$")
-		matchDie := regexp.MustCompile(" \\(from busybox\\:latest\\) die$")
+		var imageID string
+
+		if out, err := exec.Command(dockerBinary, "inspect", "-f", "{{.Id}}", "busybox").CombinedOutput(); err != nil {
+			t.Fatalf("failed to get the image ID of busybox: %s, %v", out, err)
+		} else {
+			imageID = strings.TrimSpace(string(out))
+		}
+
+		matchStart := regexp.MustCompile(" \\(from " + imageID + "\\) start$")
+		matchDie := regexp.MustCompile(" \\(from " + imageID + "\\) die$")
 
 		//
 		// Read lines of `docker events` looking for container start and stop.


### PR DESCRIPTION
### introduction

It is a new version of PR #10479 . 

> When we tag an Image with several names and we run one of them,
> The "create" job will log this event with
> +job log(create, containerID, Imagename).
> And the "Imagename" is always the first one (sorted). It is the
> same to "start/stop/rm" jobs. So use the correct name instand.

 I have discuss this with @LK4D4. We all think we should show just as what we type. He afraid that this may introduce break change. @tiborvass thinks we can show ubuntu:latest in the first case and 8eaa4ff0 in the second case. 

But  because when we start a container with Image ID. We cannot record a related image:tag in log.
So this will introduce a break change(not image:tag format).  So my patched does following.
### Image List

---

| Image tag | ImageID |
| --- | --- |
| a-ubuntu:latest | 8eaa4ff0 |
| ubuntu:latest | 8eaa4ff0 |
| z-ubunutu:latest | 8eaa4ff0 |
### behavior before  this patch series

---

| No | cmd | behaviour |
| --- | --- | --- |
| 1 | docker run -ti ubuntu bash | +jog(create, containerid, a-ubuntu:latest) |
| 3 | docker run -ti ubuntu:latest bash | +jog(create, containerid, a-ubuntu:latest) |
| 2 | docker run -ti 8eaa4ff0 bash | +jog(create, containerid, a-ubuntu:latest) |

---
### behavior  after this patch series

---

| No | cmd | behaviour |
| --- | --- | --- |
| 1 | docker run -ti ubuntu bash | +jog(create, containerid, ubuntu) |
| 3 | docker run -ti ubuntu:latest bash | +jog(create, containerid, ubuntu:latest) |
| 2 | docker run -ti 8eaa4ff0 bash | +jog(create, containerid, 8eaa4ff0) |

---
### extra changes
- Because the daemon log behavior has changed. It affects "docker events", which was used several times in ci. So I also fix these issues.
- docker ps also has similar issues. Fix them
