### PR TITLE
Docker cp handles resolv.conf, hostname & hosts, fixes #9998

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -944,6 +944,17 @@ func (container *Container) Copy(resource string) (io.ReadCloser, error) {
 		}
 	}
 
+	// Check if this is a special one (resolv.conf, hostname, ..)
+	if resource == "etc/resolv.conf" {
+		basePath = container.ResolvConfPath
+	}
+	if resource == "etc/hostname" {
+		basePath = container.HostnamePath
+	}
+	if resource == "etc/hosts" {
+		basePath = container.HostsPath
+	}
+
 	stat, err := os.Stat(basePath)
 	if err != nil {
 		container.Unmount()


### PR DESCRIPTION
Handles special files (`/etc/hostname`, `/etc/hosts` and `/etc/resolv.conf`) for the `cp` command. It won't be an empty file now, it's gonna use the _real_ content of the file.

Fixes #9998 

Signed-off-by: Vincent Demeester vincent@sbr.pm
