### PR TITLE
pkg/broadcastwriter: avoid alloc w/ WriteString

### DIFF
--- a/pkg/broadcastwriter/broadcastwriter.go
+++ b/pkg/broadcastwriter/broadcastwriter.go
@@ -51,7 +51,7 @@ func (w *BroadcastWriter) Write(p []byte) (n int, err error) {
 	for {
 		line, err := w.buf.ReadString('\n')
 		if err != nil {
-			w.buf.Write([]byte(line))
+			w.buf.WriteString(line)
 			break
 		}
 		for stream, writers := range w.streams {


### PR DESCRIPTION
This PR makes broadcastwriter avoid converting a string to a slice of bytes first before writing. This helps with #9139.

```
benchmark                    old ns/op     new ns/op     delta
BenchmarkBroadcastWriter     1178209       1147391       -2.62%

benchmark                    old MB/s     new MB/s     speedup
BenchmarkBroadcastWriter     21.00        21.56        1.03x

benchmark                    old allocs     new allocs     delta
BenchmarkBroadcastWriter     1510           1505           -0.33%

benchmark                    old bytes     new bytes     delta
BenchmarkBroadcastWriter     64724         64482         -0.37%
```
