### PR TITLE
Enable bash completion in build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y \
 	apparmor \
 	aufs-tools \
 	automake \
+	bash-completion \
 	btrfs-tools \
 	build-essential \
 	curl \
@@ -141,6 +142,9 @@ ENV DOCKER_BUILDTAGS apparmor selinux btrfs_noversion
 
 # Let us use a .bashrc file
 RUN ln -sfv $PWD/.bashrc ~/.bashrc
+
+# Register Docker's bash completion.
+RUN ln -sv $PWD/contrib/completion/bash/docker /etc/bash_completion.d/docker
 
 # Get useful and necessary Hub images so we can "docker load" locally instead of pulling
 COPY contrib/download-frozen-image.sh /go/src/github.com/docker/docker/contrib/


### PR DESCRIPTION
Bash completion should be available to bash users in the Docker build environment.

Currently, you manually have to `apt-get install bash-completion`, then initialize it (`. /etc/bash_completion`) and manually call the completion script (`. contrib/completion/bash/docker`).

This PR takes care for the installation and docker-specific steps. Assuming that you have your custom `.bashrc` in the project root (see #11112) and that it initializes bash_completion, bash completion now works out of the box.

The user can still decide whether or not to activate bash completion by including or not its initialization in `.bashrc`.

cc @tianon @jfrazelle @tiborvass 
