### PR TITLE
clarify RLIMIT_AS is disabled, explain how to edit DOCKER_OPTS 

### DIFF
--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -121,8 +121,23 @@ Finally, several networking options can only be provided when calling
  *  `-P` or `--publish-all=true|false` — see
     [Binding container ports](#binding-ports)
 
-The following sections tackle all of the above topics in an order that
-moves roughly from simplest to most complex.
+To supply networking options to the Docker server at startup, use the
+`DOCKER_OPTS` in the Docker upstart configuration file. For Ubuntu, edit the
+variable in `/etc/default/docker` and `/etc/sysconfig/docker` for Centos.
+
+The following example illustrates how to configure Docker on Ubuntu to recognize a
+newly build bridge. Edit the `/etc/default/docker` file:
+
+    $ echo 'DOCKER_OPTS="-b=bridge0"' >> /etc/default/docker 
+
+Then, restart the Docker server.
+
+    $ sudo service docker start
+
+For additional information on bridges, see [building your own
+bridge](#building-your-own-bridge) later on this page.
+
+The following sections tackle all of the above topics in an order that we can move roughly from simplest to most complex.
 
 ## Configuring DNS
 
@@ -296,8 +311,7 @@ system level, by two factors.
     policy to `DROP` if `--icc=false`.
 
 It is a strategic question whether to leave `--icc=true` or change it to
-`--icc=false` (on Ubuntu, by editing the `DOCKER_OPTS` variable in
-`/etc/default/docker` and restarting the Docker server) so that
+`--icc=false` so that
 `iptables` will protect other containers — and the main host — from
 having arbitrary ports probed or accessed by a container that gets
 compromised.
@@ -426,8 +440,7 @@ you can use either `-p IP:host_port:container_port` or `-p IP::port` to
 specify the external interface for one particular binding.
 
 Or if you always want Docker port forwards to bind to one specific IP
-address, you can edit your system-wide Docker server settings (on
-Ubuntu, by editing `DOCKER_OPTS` in `/etc/default/docker`) and add the
+address, you can edit your system-wide Docker server settings and add the
 option `--ip=IP_ADDRESS`.  Remember to restart your Docker server after
 editing this setting.
 
@@ -692,9 +705,6 @@ options are configurable at server startup:
 
  *  `--mtu=BYTES` — override the maximum packet length on `docker0`.
 
-On Ubuntu you would add these to the `DOCKER_OPTS` setting in
-`/etc/default/docker` on your Docker host and restarting the Docker
-service.
 
 Once you have one or more containers up and running, you can confirm
 that Docker has properly connected them to the `docker0` bridge by

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -122,15 +122,17 @@ Finally, several networking options can only be provided when calling
     [Binding container ports](#binding-ports)
 
 To supply networking options to the Docker server at startup, use the
-`DOCKER_OPTS` in the Docker upstart configuration file. For Ubuntu, edit the
-variable in `/etc/default/docker` and `/etc/sysconfig/docker` for Centos.
+`DOCKER_OPTS` variable in the Docker upstart configuration file. For Ubuntu, edit the
+variable in `/etc/default/docker` or `/etc/sysconfig/docker` for CentOS.
 
 The following example illustrates how to configure Docker on Ubuntu to recognize a
-newly build bridge. Edit the `/etc/default/docker` file:
+newly built bridge. 
+
+Edit the `/etc/default/docker` file:
 
     $ echo 'DOCKER_OPTS="-b=bridge0"' >> /etc/default/docker 
 
-Then, restart the Docker server.
+Then restart the Docker server.
 
     $ sudo service docker start
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -2195,6 +2195,8 @@ available in the default container, you can set these using the `--ulimit` flag.
 > If you do not provide a `hard limit`, the `soft limit` will be used for both
 values. If no `ulimits` are set, they will be inherited from the default `ulimits`
 set on the daemon.
+> `as` option is disabled for now. In other words, the following script is not supported:
+>   `$docker run -it --ulimit as=1024 fedora /bin/bash`
 
 ## save
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -2196,7 +2196,7 @@ available in the default container, you can set these using the `--ulimit` flag.
 values. If no `ulimits` are set, they will be inherited from the default `ulimits`
 set on the daemon.
 > `as` option is disabled now. In other words, the following script is not supported:
->   `$docker run -it --ulimit as=1024 fedora /bin/bash`
+>   `$ docker run -it --ulimit as=1024 fedora /bin/bash`
 
 ## save
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -2195,7 +2195,7 @@ available in the default container, you can set these using the `--ulimit` flag.
 > If you do not provide a `hard limit`, the `soft limit` will be used for both
 values. If no `ulimits` are set, they will be inherited from the default `ulimits`
 set on the daemon.
-> `as` option is disabled for now. In other words, the following script is not supported:
+> `as` option is disabled now. In other words, the following script is not supported:
 >   `$docker run -it --ulimit as=1024 fedora /bin/bash`
 
 ## save


### PR DESCRIPTION
fix issue #11676 , #11754 
1 Clarify the RLIMIT_AS for --ulimit is no longer supported.
2 Explain how to edit DOCKER_OPTS for both ubuntu and centos.
Signed-off-by: Simei He hesimei@zju.edu.cn
