### PR TITLE
    Dockefile: expand ENV and LABLE command to remove items

### DIFF
--- a/builder/parser/line_parsers.go
+++ b/builder/parser/line_parsers.go
@@ -153,13 +153,18 @@ func parseNameVal(rest string, key string) (*Node, map[string]bool, error) {
 		rootnode = node
 		strs := TOKEN_WHITESPACE.Split(rest, 2)
 
-		if len(strs) < 2 {
-			return nil, nil, fmt.Errorf(key + " must have two arguments")
+		if len(strs) < 1 {
+			return nil, nil, fmt.Errorf(key + " at least have one arguments")
+		} else if len(strs) == 1 {
+			node.Value = strs[0]
+			node.Next = &Node{}
+
+		} else {
+			node.Value = strs[0]
+			node.Next = &Node{}
+			node.Next.Value = strs[1]
 		}
 
-		node.Value = strs[0]
-		node.Next = &Node{}
-		node.Next.Value = strs[1]
 	} else {
 		var prevNode *Node
 		for i, word := range words {

--- a/builder/parser/testfiles-negative/env_no_value/Dockerfile
+++ b/builder/parser/testfiles-negative/env_no_value/Dockerfile
@@ -1,3 +1,0 @@
-FROM busybox
-
-ENV PATH

--- a/runconfig/merge.go
+++ b/runconfig/merge.go
@@ -117,7 +117,11 @@ func Merge(userConf, imageConf *Config) error {
 	}
 	if imageConf.Labels != nil {
 		for l := range userConf.Labels {
-			imageConf.Labels[l] = userConf.Labels[l]
+			if userConf.Labels[l] == "" {
+				delete(imageConf.Labels, l)
+			} else {
+				imageConf.Labels[l] = userConf.Labels[l]
+			}
 		}
 		userConf.Labels = imageConf.Labels
 	}


### PR DESCRIPTION
 ENV needs two args(key/value). we can not unset a variable.
 With this patch, we can only pass key to ENV, then we can
 unset this variable.
Related Issue: #11922 

LABLE command is very similar to ENV command.
