### PR TITLE
Fix volume symlink check

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -189,13 +189,13 @@ func (container *Container) parseVolumeMountConfig() (map[string]*Mount, error) 
 		if _, exists := container.Volumes[path]; exists {
 			continue
 		}
-		realpath, err := symlink.FollowSymlinkInScope(filepath.Join(container.basefs, path), container.basefs)
+		realPath, err := container.getResourcePath(path)
 		if err != nil {
 			return nil, fmt.Errorf("failed to evaluate the absolute path of symlink")
 		}
-		if stat, err := os.Stat(realpath); err == nil {
+		if stat, err := os.Stat(realPath); err == nil {
 			if !stat.IsDir() {
-				return nil, fmt.Errorf("file exists at %s, can't create volume there", realpath)
+				return nil, fmt.Errorf("file exists at %s, can't create volume there", realPath)
 			}
 		}
 

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -189,10 +189,13 @@ func (container *Container) parseVolumeMountConfig() (map[string]*Mount, error) 
 		if _, exists := container.Volumes[path]; exists {
 			continue
 		}
-
-		if stat, err := os.Stat(filepath.Join(container.basefs, path)); err == nil {
+		realpath, err := symlink.FollowSymlinkInScope(filepath.Join(container.basefs, path), container.basefs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate the absolute path of symlink")
+		}
+		if stat, err := os.Stat(realpath); err == nil {
 			if !stat.IsDir() {
-				return nil, fmt.Errorf("file exists at %s, can't create volume there")
+				return nil, fmt.Errorf("file exists at %s, can't create volume there", realpath)
 			}
 		}
 


### PR DESCRIPTION
Fixes #11862
carry of #11866

This fixes a seemingly obscure but bad issue caused when introducing volume path checking to make sure the volume path is not a file. (#10112)

The issue only seems obscure but I was able to hit it with my current setup with 1.6-rc2 with a compose config as such:

``` yaml
volumes:
    - "/var/run/docker.sock:/var/run/docker.sock"
```

I think because compose is first creating a container with a volume path of `/var/run/docker.sock` and then only applies the bind mount on start (instead of creating the bind directly), and since `/var/run` is a symlink to `/run` in debian based distros...
This triggers the path checking (as in the above mentioned PR) on create and never gets to the actual start.

Basically the issue is this:

Create a container with a symlink which points to a path (within the container) that matches an existing path on the host which is a file (not a dir).
