### PR TITLE
Proposal: add --label to docker ps

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -400,6 +400,7 @@ func getContainersJSON(eng *engine.Engine, version version.Version, w http.Respo
 	job.Setenv("before", r.Form.Get("before"))
 	job.Setenv("limit", r.Form.Get("limit"))
 	job.Setenv("filters", r.Form.Get("filters"))
+	job.SetenvList("labels", r.Form["labels"])
 
 	if version.GreaterThanOrEqualTo("1.5") {
 		streamJSON(job, w, false)

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -29,6 +29,7 @@ func (daemon *Daemon) Containers(job *engine.Job) error {
 		before      = job.Getenv("before")
 		n           = job.GetenvInt("limit")
 		size        = job.GetenvBool("size")
+		labels      = job.GetenvList("labels")
 		psFilters   filters.Args
 		filtExited  []int
 	)
@@ -162,6 +163,7 @@ func (daemon *Daemon) Containers(job *engine.Job) error {
 			out.SetInt64("SizeRw", sizeRw)
 			out.SetInt64("SizeRootFs", sizeRootFs)
 		}
+		out.SetList("Display", labels)
 		out.SetJson("Labels", container.Config.Labels)
 		outs.Add(out)
 		return nil


### PR DESCRIPTION
**I didn't write the documentation yet, because I'd like to know what you think beforehand.**

I'd like to add a `--label` to `docker ps` so if you do 

```
docker run busybox true
docker run --label storage=ssd busybox true
docker ps --label storage
```

you get

```
CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS                      PORTS               NAMES               STORAGE
8abd15ea641f        busybox:latest      "true"                 33 minutes ago      Exited (0) 33 minutes ago                       kickass_pare        ssd
6dd6e51818be        busybox:latest      "true"                 33 minutes ago      Exited (0) 33 minutes ago                       suspicious_bardeen
```

**Everything could be done client side, but I decided to go through the daemon, so, it the future the daemon could add mandatory labels to display.** (key `Display` in the JSON)

If this PR gets merged, we are going to use this feature in Swarm to add a mandatory label `node`, so `docker ps` will output:

```
CONTAINER ID        IMAGE               COMMAND             CREATED              STATUS                          PORTS               NAMES          NODE
24f6565be282        busybox:latest      "ls"                19 seconds ago                                                           berserk_bell   ubuntu-1
481f2a3d6a74        busybox:latest      "ls"                About a minute ago   Exited (0) About a minute ago                       insane_fermi   ubuntu-2
```
