### PR TITLE
Avoid ServeApi race condition

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	activationLock chan struct{}
+	activationLock chan struct{} = make(chan struct{})
 )
 
 type HttpServer struct {
@@ -1593,7 +1593,6 @@ func ServeApi(job *engine.Job) error {
 		protoAddrs = job.Args
 		chErrors   = make(chan error, len(protoAddrs))
 	)
-	activationLock = make(chan struct{})
 
 	for _, protoAddr := range protoAddrs {
 		protoAddrParts := strings.SplitN(protoAddr, "://", 2)


### PR DESCRIPTION
If job "acceptconnections" is called before "serveapi" the API Accept()
method will hang forever waiting for activation.  This is due to the fact
that when "acceptconnections" ran the activation channel was nil.

Signed-off-by: Darren Shepherd darren@rancher.com
