### PR TITLE
Prevent Upstart post-start stanza from hanging

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -49,7 +49,7 @@ post-start script
 	fi
 	if ! printf "%s" "$DOCKER_OPTS" | grep -qE -e '-H|--host'; then
 		while ! [ -e /var/run/docker.sock ]; do
-			initctl status $UPSTART_JOB | grep -q "stop/" && exit 1
+			initctl status $UPSTART_JOB | grep -qE "(stop|respawn)/" && exit 1
 			echo "Waiting for /var/run/docker.sock"
 			sleep 0.1
 		done


### PR DESCRIPTION
Once the job has failed and is respawned, the status becomes `docker respawn/post-start` after subsequent failures (as opposed to `docker stop/post-start`), so the post-start script needs to take this into account.

I could not find specific documentation on the job transitioning to the `respawn/post-start` state, but this was observed on Ubuntu 14.04.2.
