### PR TITLE
Fix random error in cli events test

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -311,6 +311,10 @@ func TestEventsFilterContainerID(t *testing.T) {
 	container2 := stripTrailingCharacters(out)
 
 	for _, s := range []string{container1, container2, container1[:12], container2[:12]} {
+		if err := waitInspect(s, "{{.State.Running}}", "false", 5); err != nil {
+			t.Fatalf("Failed to get container %s state, error: %s", s, err)
+		}
+
 		eventsCmd := exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(t).Unix()), "--filter", fmt.Sprintf("container=%s", s))
 		out, _, err := runCommandWithOutput(eventsCmd)
 		if err != nil {
@@ -338,6 +342,10 @@ func TestEventsFilterContainerName(t *testing.T) {
 	}
 
 	for _, s := range []string{"container_1", "container_2"} {
+		if err := waitInspect(s, "{{.State.Running}}", "false", 5); err != nil {
+			t.Fatalf("Failed to get container %s state, error: %s", s, err)
+		}
+
 		eventsCmd := exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(t).Unix()), "--filter", fmt.Sprintf("container=%s", s))
 		out, _, err := runCommandWithOutput(eventsCmd)
 		if err != nil {


### PR DESCRIPTION
---> Making bundle: test-integration-cli (in bundles/1.5.0-dev/test-integration-cli)
+++ exec docker --daemon --debug --host unix:///go/src/github.com/docker/docker/bundles/1.5.0-dev/test-integration-cli/docker.sock --storage-driver vfs --exec-driver native --pidfile /go/src/github.com/docker/docker/bundles/1.5.0-dev/test-integration-cli/docker.pid
+++ tar -cC /docker-frozen-images .
+++ docker load
+++ tar -cC /go/src/github.com/docker/docker/bundles/1.5.0-dev/test-integration-cli/emptyfs .
+++ docker load
- go test -test.timeout=30m github.com/docker/docker/integration-cli
  [PASSED]: events - untags are logged
  [PASSED]: events - container unwilling to start logs die
  [PASSED]: events - limited to 64 entries
  [PASSED]: events - container create, start, die, destroy is logged
  [PASSED]: events - image untag, delete is logged
  [PASSED]: events - image pull is logged
  [PASSED]: events - image import is logged
  [PASSED]: events - filters
  [PASSED]: events - filters using image
  --- FAIL: TestEventsFilterContainerID (1.19s)
  docker_cli_events_test.go:357: Expected 3 events, got 2: [2015-03-31T03:17:31.000000000Z 838ef58f451674f4ae4625823a7aeb14d2a29f5a10e8d1261f20cf25f380f61f: (from busybox:latest) create 2015-03-31T03:17:31.000000000Z 838ef58f451674f4ae4625823a7aeb14d2a29f5a10e8d1261f20cf25f380f61f: (from busybox:latest) start]
  [PASSED]: events - filters using container name
  FAIL
  coverage: 15.2% of statements
  exit status 1
  FAIL    github.com/docker/docker/integration-cli    43.925s
  ++++ cat /go/src/github.com/docker/docker/bundles/1.5.0-dev/test-integration-cli/docker.pid
  +++ kill 673
  make: **\* [test-integration-cli] 错误 1

need to take a sleep to wait the container is end of run.
