### PR TITLE
add MEMCG_SWAP_ENABLED to check-config.sh

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -151,8 +151,14 @@ check_flags "${flags[@]}"
 echo
 
 echo 'Optional Features:'
+{
+	check_flags MEMCG_SWAP 
+	check_flags MEMCG_SWAP_ENABLED
+	if  is_set MEMCG_SWAP && ! is_set MEMCG_SWAP_ENABLED; then
+		echo "    $(wrap_color '(note that cgroup swap accounting is not enabled in your kernel config, you can enable it by setting boot option "swapaccount=1")' bold black)"
+	fi
+}
 flags=(
-	MEMCG_SWAP
 	RESOURCE_COUNTERS
 	CGROUP_PERF
 )


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
In my machine, docker info show
`WARNING: No swap limit support`
so I use `check-config.sh` to check if my kernel config is right, it shows

<pre><code>Optional Features:
- CONFIG_MEMCG_SWAP: enabled
- CONFIG_RESOURCE_COUNTERS: enabled
- CONFIG_CGROUP_PERF: enabled</code></pre>

It's a bit of misleading, there is no any config missing.

To use swap memory limit in cgroup, we have  to turn on 
both  `MEMCG_SWAP` and `MEMCG_SWAP_ENABLED` ,
if not turn on `MEMCG_SWAP_ENABLED`, there is no `memory.memsw.xxx`
in `cgroup/memory/` unless the user enable it in `bootopt` on machine boot.

So I think it's better to check `MEMCG_SWAP_ENABLED`, it can tell the user
what is missing and what they can do if  docker info show 
`WARNING: No swap limit support` and they want use swap limit.
