### PR TITLE
Fix progress reader output on close

### DIFF
--- a/pkg/progressreader/progressreader.go
+++ b/pkg/progressreader/progressreader.go
@@ -1,9 +1,10 @@
 package progressreader
 
 import (
+	"io"
+
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/streamformatter"
-	"io"
 )
 
 // Reader with progress bar
@@ -43,6 +44,7 @@ func (config *Config) Read(p []byte) (n int, err error) {
 	return read, err
 }
 func (config *Config) Close() error {
+	config.Current = config.Size
 	config.Out.Write(config.Formatter.FormatProgress(config.ID, config.Action, &jsonmessage.JSONProgress{Current: config.Current, Total: config.Size}))
 	return config.In.Close()
 }


### PR DESCRIPTION
Currently the progress reader won't close properly by not setting the close size.

This brings back the correct behavior before the refactor in https://github.com/docker/docker/commit/12b278d3540bc32699e8c2197b556188fd98b77b

fixes #11849

ping @jfrazelle 
