### PR TITLE
graphdriver: promote overlay above vfs

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -39,9 +39,8 @@ var (
 		"aufs",
 		"btrfs",
 		"devicemapper",
-		"vfs",
-		// experimental, has to be enabled manually for now
 		"overlay",
+		"vfs",
 	}
 
 	ErrNotSupported   = errors.New("driver not supported")


### PR DESCRIPTION
It's about time to let folks not hit 'vfs', when 'overlay' is supported
on their kernel. Especially now that v3.18.y is a long-term kernel.

/cc @unclejack @jfrazelle 

Signed-off-by: Vincent Batts vbatts@redhat.com
