### PR TITLE
Remove use of "DEBUG" env var from CLI and de-couple -D from --log-level

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -3,7 +3,6 @@ package client
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/docker/docker/api/types"
 	flag "github.com/docker/docker/pkg/mflag"
@@ -45,9 +44,8 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	fmt.Fprintf(cli.out, "Name: %s\n", info.Name)
 	fmt.Fprintf(cli.out, "ID: %s\n", info.ID)
 
-	if info.Debug || os.Getenv("DEBUG") != "" {
+	if info.Debug {
 		fmt.Fprintf(cli.out, "Debug mode (server): %v\n", info.Debug)
-		fmt.Fprintf(cli.out, "Debug mode (client): %v\n", os.Getenv("DEBUG") != "")
 		fmt.Fprintf(cli.out, "File Descriptors: %d\n", info.NFd)
 		fmt.Fprintf(cli.out, "Goroutines: %d\n", info.NGoroutines)
 		fmt.Fprintf(cli.out, "System Time: %s\n", info.SystemTime)

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -52,11 +52,8 @@ func main() {
 		setLogLevel(logrus.InfoLevel)
 	}
 
-	// -D, --debug, -l/--log-level=debug processing
-	// When/if -D is removed this block can be deleted
 	if *flDebug {
 		os.Setenv("DEBUG", "1")
-		setLogLevel(logrus.DebugLevel)
 	}
 
 	if len(flHosts) == 0 {

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -229,8 +229,8 @@ func (s *DockerDaemonSuite) TestDaemonFlagD(c *check.C) {
 		c.Fatal(err)
 	}
 	content, _ := ioutil.ReadFile(s.d.logFile.Name())
-	if !strings.Contains(string(content), `level=debug`) {
-		c.Fatalf(`Missing level="debug" in log file using -D:\n%s`, string(content))
+	if strings.Contains(string(content), `level=debug`) {
+		c.Fatalf(`Should not have level="debug" in log file using -D:\n%s`, string(content))
 	}
 }
 
@@ -239,8 +239,8 @@ func (s *DockerDaemonSuite) TestDaemonFlagDebug(c *check.C) {
 		c.Fatal(err)
 	}
 	content, _ := ioutil.ReadFile(s.d.logFile.Name())
-	if !strings.Contains(string(content), `level=debug`) {
-		c.Fatalf(`Missing level="debug" in log file using --debug:\n%s`, string(content))
+	if strings.Contains(string(content), `level=debug`) {
+		c.Fatalf(`Should not have level="debug" in log file using --debug:\n%s`, string(content))
 	}
 }
 
@@ -249,8 +249,8 @@ func (s *DockerDaemonSuite) TestDaemonFlagDebugLogLevelFatal(c *check.C) {
 		c.Fatal(err)
 	}
 	content, _ := ioutil.ReadFile(s.d.logFile.Name())
-	if !strings.Contains(string(content), `level=debug`) {
-		c.Fatalf(`Missing level="debug" in log file when using both --debug and --log-level=fatal:\n%s`, string(content))
+	if strings.Contains(string(content), `level=debug`) {
+		c.Fatalf(`Should not have level="debug" in log file when using both --debug and --log-level=fatal:\n%s`, string(content))
 	}
 }
 


### PR DESCRIPTION
Removes use of "DEBUG" env var from CLI because it doesn't actually do anything with it.
De-couple DEBUG from --log-level since they are two different concepts. See discussions below.

Signed-off-by: Doug Davis dug@us.ibm.com
