### PR TITLE
docs: fix heading level of logging drivers

### DIFF
--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -742,17 +742,17 @@ familiar with using LXC directly.
 
 You can specify a different logging driver for the container than for the daemon.
 
-### Logging driver: none
+#### Logging driver: none
 
 Disables any logging for the container. `docker logs` won't be available with
 this driver.
 
-### Log driver: json-file
+#### Logging driver: json-file
 
 Default logging driver for Docker. Writes JSON messages to file. `docker logs`
 command is available only for this logging driver
 
-## Logging driver: syslog
+#### Logging driver: syslog
 
 Syslog logging driver for Docker. Writes log messages to syslog. `docker logs`
 command is not available for this logging driver


### PR DESCRIPTION
Syslog was a heading-2, but should be heading-3. Also changed "Log driver" to "logging driver" for JSON. Changed the headings to heading-4 to match the "network settings" section.

I think this section can still use some love  (probably use a table for the drivers), this just fixes some minor issues.
