### PR TITLE
Increase timeout on TestRunOOMExitCode test

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3281,7 +3281,7 @@ func TestRunOOMExitCode(t *testing.T) {
 	go func() {
 		defer close(done)
 
-		runCmd := exec.Command(dockerBinary, "run", "-m", "4MB", "busybox", "sh", "-c", "x=a; while true; do x=$x$x; done")
+		runCmd := exec.Command(dockerBinary, "run", "-m", "4MB", "busybox", "sh", "-c", "x=a; while true; do x=$x$x$x$x; done")
 		out, exitCode, _ := runCommandWithOutput(runCmd)
 		if expected := 137; exitCode != expected {
 			t.Fatalf("wrong exit code for OOM container: expected %d, got %d (output: %q)", expected, exitCode, out)
@@ -3290,7 +3290,7 @@ func TestRunOOMExitCode(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(3 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("Timeout waiting for container to die on OOM")
 	}
 


### PR DESCRIPTION
I can never get it to work for me when its just 3 seconds.
With this change it generates the OOM message around 17 seconds, but
I increased the timeout to 30 for people with slower machines

Signed-off-by: Doug Davis dug@us.ibm.com
