### PR TITLE
Remove trailing whitespaces from .md files in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ After a release, documentation updates are continually merged into `master` as
 they occur. This work includes new documentation for forthcoming features, bug
 fixes, and other updates. Docker's CI system automatically builds and updates
 the `master` documentation after each merge and posts it to
-[http://docs.master.dockerproject.com](http://docs.master.dockerproject.com). 
+[http://docs.master.dockerproject.com](http://docs.master.dockerproject.com).
 
 Periodically, the Docker maintainers update `docs.docker.com` between official
 releases of Docker. They do this by cherry-picking commits from `master`,
@@ -52,7 +52,7 @@ own.
 
 	By basing from `master` your work is automatically included in the next
 	release. It also allows docs maintainers to easily cherry-pick your changes
-	into the `docs` release branch. 
+	into the `docs` release branch.
 
 4. Modify existing or add new `.md` files to the `docs/sources` directory.
 
@@ -67,15 +67,15 @@ own.
 	run a container running the Docker documentation website. To build the
 	documentation site, enter `make docs` at the root of your `docker/docker`
 	fork:
-	
+
 		$ make docs
 		.... (lots of output) ....
 		docker run --rm -it  -e AWS_S3_BUCKET -p 8000:8000 "docker-docs:master" mkdocs serve
 		Running at: http://0.0.0.0:8000/
 		Live reload enabled.
 		Hold ctrl+c to quit.
-	
-	
+
+
 	The build creates an image containing all the required tools, adds the local
 	`docs/` directory and generates the HTML files. Then, it runs a Docker
 	container with this image.
@@ -178,13 +178,13 @@ For example, to update the current release's docs, do the following:
 1. Go to your `docker/docker` fork and get the latest from master.
 
     	$ git fetch upstream
-        
+
 2. Checkout a new branch based on `upstream/docs`.
 
 	You should give your new branch a descriptive name.
 
 		$ git checkout -b post-1.2.0-docs-update-1 upstream/docs
-	
+
 3. In a browser window, open [https://github.com/docker/docker/commits/master].
 
 4. Locate the merges you want to publish.
@@ -196,9 +196,9 @@ For example, to update the current release's docs, do the following:
 5. Copy the commit SHA from GitHub.
 
 6. Cherry-pick the commit.
-	
+
 	 	$ git cherry-pick -x fe845c4
-	
+
 7. Repeat until you have cherry-picked everything you want to merge.
 
 8. Push your changes to your fork.
@@ -220,13 +220,13 @@ For example, to update the current release's docs, do the following:
 13. Fetch your merged pull request from `docs`.
 
 		$ git fetch upstream/docs
-	
+
 14. Ensure your branch is clean and set to the latest.
 
    	 	$ git reset --hard upstream/docs
-    
+
 15. Copy the `awsconfig` file into the `docs` directory.
-    
+
 16. Make the beta documentation
 
     	$ make AWS_S3_BUCKET=beta-docs.docker.io BUILD_ROOT=yes docs-release
@@ -288,9 +288,9 @@ When using Docker on Mac OSX the man pages will be missing by default. You can m
    with the docker containers.
 
         $ git clone https://github.com/docker/docker.git
-		
+
 2. Build the docker image.
-   
+
         $ cd docker/docs/man
         $ docker build -t docker/md2man .
 

--- a/docs/man/Dockerfile.5.md
+++ b/docs/man/Dockerfile.5.md
@@ -26,7 +26,7 @@ For example:
 
 # DESCRIPTION
 
-A Dockerfile is a file that automates the steps of creating a Docker image. 
+A Dockerfile is a file that automates the steps of creating a Docker image.
 A Dockerfile is similar to a Makefile.
 
 # USAGE
@@ -142,7 +142,7 @@ A Dockerfile is similar to a Makefile.
   ```
 
   -- To make the container run the same executable every time, use **ENTRYPOINT** in
-  combination with **CMD**. 
+  combination with **CMD**.
   If the user specifies arguments to `docker run`, the specified commands
   override the default in **CMD**.
   Do not confuse **RUN** with **CMD**. **RUN** runs a command and commits the result.
@@ -160,8 +160,8 @@ A Dockerfile is similar to a Makefile.
   ```
 
   An image can have more than one label. To specify multiple labels, separate
-  each key-value pair by a space. 
-  
+  each key-value pair by a space.
+
   Labels are additive including `LABEL`s in `FROM` images. As the system
   encounters and then applies a new label, new `key`s override any previous
   labels with identical keys.
@@ -178,7 +178,7 @@ A Dockerfile is similar to a Makefile.
 **ENV**
   -- `ENV <key> <value>`
   The **ENV** instruction sets the environment variable <key> to
-  the value `<value>`. This value is passed to all future 
+  the value `<value>`. This value is passed to all future
   RUN, **ENTRYPOINT**, and **CMD** instructions. This is
   functionally equivalent to prefixing the command with `<key>=<value>`.  The
   environment variables that are set with **ENV** persist when a container is run
@@ -205,7 +205,7 @@ A Dockerfile is similar to a Makefile.
   then they must be relative to the source directory that is being built
   (the context of the build). The `<dest>` is the absolute path, or path relative
   to **WORKDIR**, into which the source is copied inside the target container.
-  All new files and directories are created with mode 0755 and with the uid 
+  All new files and directories are created with mode 0755 and with the uid
   and gid of **0**.
 
 **COPY**
@@ -310,8 +310,8 @@ A Dockerfile is similar to a Makefile.
   You can register any build instruction as a trigger. A trigger is useful if
   you are defining an image to use as a base for building other images. For
   example, if you are defining an application build environment or a daemon that
-  is customized with a user-specific configuration.  
-  
+  is customized with a user-specific configuration.
+
   Consider an image intended as a reusable python application builder. It must
   add application source code to a particular directory, and might need a build
   script called after that. You can't just call **ADD** and **RUN** now, because

--- a/docs/man/docker-build.1.md
+++ b/docs/man/docker-build.1.md
@@ -28,9 +28,9 @@ directory to the Docker daemon. The contents of this directory would
 be used by **ADD** commands found within the Dockerfile.
 
 Warning, this will send a lot of data to the Docker daemon depending
-on the contents of the current directory. The build is run by the Docker 
-daemon, not by the CLI, so the whole context must be transferred to the daemon. 
-The Docker CLI reports "Sending build context to Docker daemon" when the context is sent to 
+on the contents of the current directory. The build is run by the Docker
+daemon, not by the CLI, so the whole context must be transferred to the daemon.
+The Docker CLI reports "Sending build context to Docker daemon" when the context is sent to
 the daemon.
 
 When a single Dockerfile is given as the URL, then no context is set.
@@ -92,7 +92,7 @@ instruction into the specified target.
 ## Building an image and naming that image
 
 A good practice is to give a name to the image you are building. There are
-no hard rules here but it is best to give the names consideration. 
+no hard rules here but it is best to give the names consideration.
 
 The **-t**/**--tag** flag is used to rename an image. Here are some examples:
 
@@ -101,8 +101,8 @@ Though it is not a good practice, image names can be arbitrary:
     docker build -t myimage .
 
 A better approach is to provide a fully qualified and meaningful repository,
-name, and tag (where the tag in this context means the qualifier after 
-the ":"). In this example we build a JBoss image for the Fedora repository 
+name, and tag (where the tag in this context means the qualifier after
+the ":"). In this example we build a JBoss image for the Fedora repository
 and give it the version 1.0:
 
     docker build -t fedora/jboss:1.0
@@ -118,7 +118,7 @@ If you do not provide a version tag then Docker will assign `latest`:
 
 When you list the images, the image above will have the tag `latest`.
 
-So renaming an image is arbitrary but consideration should be given to 
+So renaming an image is arbitrary but consideration should be given to
 a useful convention that makes sense for consumers and should also take
 into account Docker community conventions.
 

--- a/docs/man/docker-cp.1.md
+++ b/docs/man/docker-cp.1.md
@@ -12,9 +12,9 @@ CONTAINER:PATH HOSTDIR|-
 
 # DESCRIPTION
 
-Copy files or folders from a `CONTAINER:PATH` to the `HOSTDIR` or to `STDOUT`. 
+Copy files or folders from a `CONTAINER:PATH` to the `HOSTDIR` or to `STDOUT`.
 The `CONTAINER:PATH` is relative to the root of the container's filesystem. You
-can copy from either a running or stopped container. 
+can copy from either a running or stopped container.
 
 The `PATH` can be a file or directory. The `docker cp` command assumes all
 `PATH` values start at the `/` (root) directory. This means supplying the
@@ -35,7 +35,7 @@ the leading slash in the command. If you execute this command from your home dir
 
 		$ docker cp compassionate_darwin:tmp/foo tmp
 
-Docker creates a `~/tmp/foo` subdirectory.  
+Docker creates a `~/tmp/foo` subdirectory.
 
 When copying files to an existing `HOSTDIR`, the `cp` command adds the new files to
 the directory. For example, this command:
@@ -51,7 +51,7 @@ Your host's `/tmp/foo` directory will contain both files:
 
 		$ ls /tmp/foo
 		myfile.txt secondfile.txt
-		
+
 Finally, use '-' to write the data as a `tar` file to STDOUT.
 
 # OPTIONS

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -159,7 +159,7 @@ This value should always larger than **-m**, so you should alway use this with *
 **-p**, **--publish**=[]
    Publish a container's port, or a range of ports, to the host
                                format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
-                               Both hostPort and containerPort can be specified as a range of ports. 
+                               Both hostPort and containerPort can be specified as a range of ports.
                                When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range. (e.g., `-p 1234-1236:1234-1236/tcp`)
                                (use 'docker port' to see the actual mapping)
 

--- a/docs/man/docker-exec.1.md
+++ b/docs/man/docker-exec.1.md
@@ -14,7 +14,7 @@ CONTAINER COMMAND [ARG...]
 
 # DESCRIPTION
 
-Run a process in a running container. 
+Run a process in a running container.
 
 The command started using `docker exec` will only run while the container's primary
 process (`PID 1`) is running, and will not be restarted if the container is restarted.

--- a/docs/man/docker-login.1.md
+++ b/docs/man/docker-login.1.md
@@ -2,7 +2,7 @@
 % Docker Community
 % JUNE 2014
 # NAME
-docker-login - Register or log in to a Docker registry. 
+docker-login - Register or log in to a Docker registry.
 
 # SYNOPSIS
 **docker login**

--- a/docs/man/docker-logout.1.md
+++ b/docs/man/docker-logout.1.md
@@ -12,7 +12,7 @@ docker-logout - Log out from a Docker Registry Service.
 Log out of a Docker Registry Service located on the specified `SERVER`. You can
 specify a URL or a `hostname` for the `SERVER` value. If you do not specify a
 `SERVER`, the command attempts to log you out of Docker's public registry
-located at `https://registry-1.docker.io/` by default.  
+located at `https://registry-1.docker.io/` by default.
 
 # OPTIONS
 There are no available options.

--- a/docs/man/docker-pull.1.md
+++ b/docs/man/docker-pull.1.md
@@ -7,7 +7,7 @@ docker-pull - Pull an image or a repository from a registry
 # SYNOPSIS
 **docker pull**
 [**-a**|**--all-tags**[=*false*]]
-[**--help**] 
+[**--help**]
 NAME[:TAG] | [REGISTRY_HOST[:REGISTRY_PORT]/]NAME[:TAG]
 
 # DESCRIPTION
@@ -17,7 +17,7 @@ there is more than one image for a repository (e.g., fedora) then all
 images for that repository name are pulled down including any tags.
 
 If you do not specify a `REGISTRY_HOST`, the command uses Docker's public
-registry located at `registry-1.docker.io` by default. 
+registry located at `registry-1.docker.io` by default.
 
 # OPTIONS
 **-a**, **--all-tags**=*true*|*false*
@@ -53,9 +53,9 @@ registry located at `registry-1.docker.io` by default.
 
     $ docker pull registry.hub.docker.com/fedora:20
     Pulling repository fedora
-    3f2fed40e4b0: Download complete 
-    511136ea3c5a: Download complete 
-    fd241224e9cf: Download complete 
+    3f2fed40e4b0: Download complete
+    511136ea3c5a: Download complete
+    fd241224e9cf: Download complete
 
     Status: Downloaded newer image for registry.hub.docker.com/fedora:20
 

--- a/docs/man/docker-push.1.md
+++ b/docs/man/docker-push.1.md
@@ -13,7 +13,7 @@ NAME[:TAG] | [REGISTRY_HOST[:REGISTRY_PORT]/]NAME[:TAG]
 
 This command pushes an image or a repository to a registry. If you do not
 specify a `REGISTRY_HOST`, the command uses Docker's public registry located at
-`registry-1.docker.io` by default. 
+`registry-1.docker.io` by default.
 
 # OPTIONS
 **--help**

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -283,7 +283,7 @@ ports and the exposed ports, use `docker port`.
 **-p**, **--publish**=[]
    Publish a container's port, or range of ports, to the host.
                                format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
-                               Both hostPort and containerPort can be specified as a range of ports. 
+                               Both hostPort and containerPort can be specified as a range of ports.
                                When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range. (e.g., `-p 1234-1236:1234-1236/tcp`)
                                (use 'docker port' to see the actual mapping)
 
@@ -314,7 +314,7 @@ its root filesystem mounted as read only prohibiting any writes.
 
 **--restart**="no"
    Restart policy to apply when a container exits (no, on-failure[:max-retry], always)
-      
+
 **--rm**=*true*|*false*
    Automatically remove the container when it exits (incompatible with -d). The default is *false*.
 
@@ -363,14 +363,14 @@ read-write. See examples.
    Mount volumes from the specified container(s)
 
    Mounts already mounted volumes from a source container onto another
-   container. You must supply the source's container-id. To share 
+   container. You must supply the source's container-id. To share
    a volume, use the **--volumes-from** option when running
-   the target container. You can share volumes even if the source container 
+   the target container. You can share volumes even if the source container
    is not running.
 
-   By default, Docker mounts the volumes in the same mode (read-write or 
-   read-only) as it is mounted in the source container. Optionally, you 
-   can change this by suffixing the container-id with either the `:ro` or 
+   By default, Docker mounts the volumes in the same mode (read-write or
+   read-only) as it is mounted in the source container. Optionally, you
+   can change this by suffixing the container-id with either the `:ro` or
    `:rw ` keyword.
 
    If the location of the volume from the source container overlaps with
@@ -426,8 +426,8 @@ Host shows a shared memory segment with 7 pids attached, happens to be from http
  $ sudo ipcs -m
 
  ------ Shared Memory Segments --------
- key        shmid      owner      perms      bytes      nattch     status      
- 0x01128e25 0          root       600        1000       7                       
+ key        shmid      owner      perms      bytes      nattch     status
+ 0x01128e25 0          root       600        1000       7
 ```
 
 Now run a regular container, and it correctly does NOT see the shared memory segment from the host:
@@ -435,8 +435,8 @@ Now run a regular container, and it correctly does NOT see the shared memory seg
 ```
  $ docker run -it shm ipcs -m
 
- ------ Shared Memory Segments --------	
- key        shmid      owner      perms      bytes      nattch     status      
+ ------ Shared Memory Segments --------
+ key        shmid      owner      perms      bytes      nattch     status
 ```
 
 Run a container with the new `--ipc=host` option, and it now sees the shared memory segment from the host httpd:
@@ -445,8 +445,8 @@ Run a container with the new `--ipc=host` option, and it now sees the shared mem
  $ docker run -it --ipc=host shm ipcs -m
 
  ------ Shared Memory Segments --------
- key        shmid      owner      perms      bytes      nattch     status      
- 0x01128e25 0          root       600        1000       7                   
+ key        shmid      owner      perms      bytes      nattch     status
+ 0x01128e25 0          root       600        1000       7
 ```
 Testing `--ipc=container:CONTAINERID` mode:
 
@@ -457,15 +457,15 @@ Start a container with a program to create a shared memory segment:
  $ sudo ipcs -m
 
  ------ Shared Memory Segments --------
- key        shmid      owner      perms      bytes      nattch     status      
- 0x0000162e 0          root       666        27         1                       
+ key        shmid      owner      perms      bytes      nattch     status
+ 0x0000162e 0          root       666        27         1
 ```
 Create a 2nd container correctly shows no shared memory segment from 1st container:
 ```
  $ docker run shm ipcs -m
 
  ------ Shared Memory Segments --------
- key        shmid      owner      perms      bytes      nattch     status      
+ key        shmid      owner      perms      bytes      nattch     status
 ```
 
 Create a 3rd container using the new --ipc=container:CONTAINERID option, now it shows the shared memory segment from the first:
@@ -475,7 +475,7 @@ Create a 3rd container using the new --ipc=container:CONTAINERID option, now it 
  $ sudo ipcs -m
 
  ------ Shared Memory Segments --------
- key        shmid      owner      perms      bytes      nattch     status      
+ key        shmid      owner      perms      bytes      nattch     status
  0x0000162e 0          root       666        27         1
 ```
 

--- a/docs/man/docker-tag.1.md
+++ b/docs/man/docker-tag.1.md
@@ -12,10 +12,10 @@ IMAGE[:TAG] [REGISTRY_HOST/][USERNAME/]NAME[:TAG]
 
 # DESCRIPTION
 Assigns a new alias to an image in a registry. An alias refers to the
-entire image name including the optional `TAG` after the ':'. 
+entire image name including the optional `TAG` after the ':'.
 
 If you do not specify a `REGISTRY_HOST`, the command uses Docker's public
-registry located at `registry-1.docker.io` by default. 
+registry located at `registry-1.docker.io` by default.
 
 # "OPTIONS"
 **-f**, **--force**=*true*|*false*
@@ -44,7 +44,7 @@ Note that here TAG is a part of the overall name or "tag".
 
 ## Giving an image a new alias
 
-Here is an example of aliasing an image (e.g., 0e5574283393) as "httpd" and 
+Here is an example of aliasing an image (e.g., 0e5574283393) as "httpd" and
 tagging it into the "fedora" repository with "version1.0":
 
     docker tag 0e5574283393 fedora/httpd:version1.0

--- a/docs/sources/articles/b2d_volume_resize.md
+++ b/docs/sources/articles/b2d_volume_resize.md
@@ -1,17 +1,17 @@
-page_title: Resizing a Boot2Docker Volume	
+page_title: Resizing a Boot2Docker Volume
 page_description: Resizing a Boot2Docker Volume in VirtualBox with GParted
 page_keywords: boot2docker, volume, virtualbox
 
 # Getting “no space left on device” errors with Boot2Docker?
 
 If you're using Boot2Docker with a large number of images, or the images you're
-working with are very large, your pulls might start failing with "no space left 
-on device" errors when the Boot2Docker volume fills up. The solution is to 
-increase the volume size by first cloning it, then resizing it using a disk 
-partitioning tool. 
+working with are very large, your pulls might start failing with "no space left
+on device" errors when the Boot2Docker volume fills up. The solution is to
+increase the volume size by first cloning it, then resizing it using a disk
+partitioning tool.
 
 We recommend [GParted](http://gparted.sourceforge.net/download.php/index.php).
-The tool comes as a bootable ISO, is a free download, and works well with 
+The tool comes as a bootable ISO, is a free download, and works well with
 VirtualBox.
 
 ## 1. Stop Boot2Docker
@@ -22,9 +22,9 @@ Issue the command to stop the Boot2Docker VM on the command line:
 
 ## 2. Clone the VMDK image to a VDI image
 
-Boot2Docker ships with a VMDK image, which can’t be resized by VirtualBox’s 
-native tools. We will instead create a VDI volume and clone the VMDK volume to 
-it. 
+Boot2Docker ships with a VMDK image, which can’t be resized by VirtualBox’s
+native tools. We will instead create a VDI volume and clone the VMDK volume to
+it.
 
 Using the command line VirtualBox tools, clone the VMDK image to a VDI image:
 
@@ -32,20 +32,20 @@ Using the command line VirtualBox tools, clone the VMDK image to a VDI image:
 
 ## 3. Resize the VDI volume
 
-Choose a size that will be appropriate for your needs. If you’re spinning up a 
-lot of containers, or your containers are particularly large, larger will be 
+Choose a size that will be appropriate for your needs. If you’re spinning up a
+lot of containers, or your containers are particularly large, larger will be
 better:
 
     $ vboxmanage modifyhd /full/path/to/<newVDIimage>.vdi --resize <size in MB>
 
-## 4. Download a disk partitioning tool ISO 
+## 4. Download a disk partitioning tool ISO
 
-To resize the volume, we'll use [GParted](http://gparted.sourceforge.net/download.php/). 
-Once you've downloaded the tool, add the ISO to the Boot2Docker VM IDE bus. 
-You might need to create the bus before you can add the ISO. 
+To resize the volume, we'll use [GParted](http://gparted.sourceforge.net/download.php/).
+Once you've downloaded the tool, add the ISO to the Boot2Docker VM IDE bus.
+You might need to create the bus before you can add the ISO.
 
-> **Note:** 
-> It's important that you choose a partitioning tool that is available as an ISO so 
+> **Note:**
+> It's important that you choose a partitioning tool that is available as an ISO so
 > that the Boot2Docker VM can be booted with it.
 
 <table>
@@ -57,42 +57,42 @@ You might need to create the bus before you can add the ISO.
 	</tr>
 </table>
 
-## 5. Add the new VDI image 
+## 5. Add the new VDI image
 
-In the settings for the Boot2Docker image in VirtualBox, remove the VMDK image 
+In the settings for the Boot2Docker image in VirtualBox, remove the VMDK image
 from the SATA contoller and add the VDI image.
 
 <img src="/articles/b2d_volume_images/add_volume.png">
 
 ## 6. Verify the boot order
 
-In the **System** settings for the Boot2Docker VM, make sure that **CD/DVD** is 
+In the **System** settings for the Boot2Docker VM, make sure that **CD/DVD** is
 at the top of the **Boot Order** list.
 
 <img src="/articles/b2d_volume_images/boot_order.png">
 
 ## 7. Boot to the disk partitioning ISO
 
-Manually start the Boot2Docker VM in VirtualBox, and the disk partitioning ISO 
-should start up. Using GParted, choose the **GParted Live (default settings)** 
-option. Choose the default keyboard, language, and XWindows settings, and the 
-GParted tool will start up and display the VDI volume you created. Right click 
-on the VDI and choose **Resize/Move**. 
+Manually start the Boot2Docker VM in VirtualBox, and the disk partitioning ISO
+should start up. Using GParted, choose the **GParted Live (default settings)**
+option. Choose the default keyboard, language, and XWindows settings, and the
+GParted tool will start up and display the VDI volume you created. Right click
+on the VDI and choose **Resize/Move**.
 
 <img src="/articles/b2d_volume_images/gparted.png">
 
-Drag the slider representing the volume to the maximum available size, click 
-**Resize/Move**, and then **Apply**. 
+Drag the slider representing the volume to the maximum available size, click
+**Resize/Move**, and then **Apply**.
 
 <img src="/articles/b2d_volume_images/gparted2.png">
 
-Quit GParted and shut down the VM. Remove the GParted ISO from the IDE controller 
+Quit GParted and shut down the VM. Remove the GParted ISO from the IDE controller
 for the Boot2Docker VM in VirtualBox.
 
-## 8. Start the Boot2Docker VM 
+## 8. Start the Boot2Docker VM
 
-Fire up the Boot2Docker VM manually in VirtualBox. The VM should log in 
-automatically, but if it doesn't, the credentials are `docker/tcuser`. Using 
+Fire up the Boot2Docker VM manually in VirtualBox. The VM should log in
+automatically, but if it doesn't, the credentials are `docker/tcuser`. Using
 the `df -h` command, verify that your changes took effect.
 
 <img src="/articles/b2d_volume_images/verify.png">

--- a/docs/sources/articles/basics.md
+++ b/docs/sources/articles/basics.md
@@ -13,7 +13,7 @@ your Docker install, run the following command:
 If you get `docker: command not found` or something like
 `/var/lib/docker/repositories: permission denied` you may have an
 incomplete Docker installation or insufficient privileges to access
-Docker on your machine. Please 
+Docker on your machine. Please
 
 Additionally, depending on your Docker system configuration, you may be required
 to preface each `docker` command with `sudo`. To avoid having to use `sudo` with

--- a/docs/sources/articles/certificates.md
+++ b/docs/sources/articles/certificates.md
@@ -45,15 +45,15 @@ Our example is set up like this:
 ## Creating the client certificates
 
 You will use OpenSSL's `genrsa` and `req` commands to first generate an RSA
-key and then use the key to create the certificate.   
+key and then use the key to create the certificate.
 
     $ openssl genrsa -out client.key 1024
     $ openssl req -new -x509 -text -key client.key -out client.cert
 
-> **Warning:**: 
+> **Warning:**:
 > Using TLS and managing a CA is an advanced topic.
 > You should be familiar with OpenSSL, x509, and TLS before
-> attempting to use them in production. 
+> attempting to use them in production.
 
 > **Warning:**
 > These TLS commands will only generate a working set of certificates on Linux.

--- a/docs/sources/articles/dockerfile_best-practices.md
+++ b/docs/sources/articles/dockerfile_best-practices.md
@@ -9,7 +9,7 @@ page_keywords: Examples, Usage, base image, docker, documentation, dockerfile, b
 Docker can build images automatically by reading the instructions from a
 `Dockerfile`, a text file that contains all the commands, in order, needed to
 build a given image. `Dockerfile`s adhere to a specific format and use a
-specific set of instructions. You can learn the basics on the 
+specific set of instructions. You can learn the basics on the
 [Dockerfile Reference](https://docs.docker.com/reference/builder/) page. If
 you’re new to writing `Dockerfile`s, you should start there.
 
@@ -191,7 +191,7 @@ Writing the instruction this way also helps you avoid potential duplication of
 a given package because it is much easier to read than an instruction like:
 
     RUN apt-get install -y package-foo && apt-get install -y package-bar
-    
+
 ### [`CMD`](https://docs.docker.com/reference/builder/#cmd)
 
 The `CMD` instruction should be used to run the software contained by your
@@ -208,7 +208,7 @@ perl, etc), for example, `CMD ["perl", "-de0"]`, `CMD ["python"]`, or
 `CMD` should rarely be used in the manner of `CMD [“param”, “param”]` in
 conjunction with [`ENTRYPOINT`](https://docs.docker.com/reference/builder/#entrypoint), unless
 you and your expected users are already quite familiar with how `ENTRYPOINT`
-works. 
+works.
 
 ### [`EXPOSE`](https://docs.docker.com/reference/builder/#expose)
 
@@ -384,7 +384,7 @@ You should avoid installing or using `sudo` since it has unpredictable TTY and
 signal-forwarding behavior that can cause more problems than it solves. If
 you absolutely need functionality similar to `sudo` (e.g., initializing the
 daemon as root but running it as non-root), you may be able to use
-[“gosu”](https://github.com/tianon/gosu). 
+[“gosu”](https://github.com/tianon/gosu).
 
 Lastly, to reduce layers and complexity, avoid switching `USER` back
 and forth frequently.
@@ -401,7 +401,7 @@ troubleshoot, and maintain.
 `ONBUILD` is only useful for images that are going to be built `FROM` a given
 image. For example, you would use `ONBUILD` for a language stack image that
 builds arbitrary user software written in that language within the
-`Dockerfile`, as you can see in [Ruby’s `ONBUILD` variants](https://github.com/docker-library/ruby/blob/master/2.1/onbuild/Dockerfile). 
+`Dockerfile`, as you can see in [Ruby’s `ONBUILD` variants](https://github.com/docker-library/ruby/blob/master/2.1/onbuild/Dockerfile).
 
 Images built from `ONBUILD` should get a separate tag, for example:
 `ruby:1.9-onbuild` or `ruby:2.0-onbuild`.
@@ -425,5 +425,5 @@ These Official Repos have exemplary `Dockerfile`s:
 * [Dockerfile Reference](https://docs.docker.com/reference/builder/#onbuild)
 * [More about Base Images](https://docs.docker.com/articles/baseimages/)
 * [More about Automated Builds](https://docs.docker.com/docker-hub/builds/)
-* [Guidelines for Creating Official 
+* [Guidelines for Creating Official
 Repositories](https://docs.docker.com/docker-hub/official_repos/)

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -191,7 +191,7 @@ the daemon filters out all localhost IP address `nameserver` entries from
 the host's original file.
 
 Filtering is necessary because all localhost addresses on the host are
-unreachable from the container's network.  After this filtering, if there 
+unreachable from the container's network.  After this filtering, if there
 are no more `nameserver` entries left in the container's `/etc/resolv.conf`
 file, the daemon adds public Google DNS nameservers
 (8.8.8.8 and 8.8.4.4) to the container's DNS configuration.  If IPv6 is
@@ -209,7 +209,7 @@ notifier active which will watch for changes to the host DNS configuration.
 
 > **Note**:
 > The file change notifier relies on the Linux kernel's inotify feature.
-> Because this feature is currently incompatible with the overlay filesystem 
+> Because this feature is currently incompatible with the overlay filesystem
 > driver, a Docker daemon using "overlay" will not be able to take advantage
 > of the `/etc/resolv.conf` auto-update feature.
 
@@ -221,7 +221,7 @@ of a facility to ensure atomic writes of the `resolv.conf` file while the
 container is running. If the container's `resolv.conf` has been edited since
 it was started with the default configuration, no replacement will be
 attempted as it would overwrite the changes performed by the container.
-If the options (`--dns` or `--dns-search`) have been used to modify the 
+If the options (`--dns` or `--dns-search`) have been used to modify the
 default host configuration, then the replacement with an updated host's
 `/etc/resolv.conf` will not happen as well.
 
@@ -639,7 +639,7 @@ on every host.
 
 In this scenario containers of the same host can communicate directly with each
 other. The traffic between containers on different hosts will be routed via
-their hosts and the router. For example packet from `Container1-1` to 
+their hosts and the router. For example packet from `Container1-1` to
 `Container2-1` will be routed through `Host1`, `Router` and `Host2` until it
 arrives at `Container2-1`.
 

--- a/docs/sources/articles/registry_mirror.md
+++ b/docs/sources/articles/registry_mirror.md
@@ -61,7 +61,7 @@ With your mirror running, pull an image that you haven't pulled before (using
     $ time docker pull node:latest
     Pulling repository node
     [...]
-    
+
     real   1m14.078s
     user   0m0.176s
     sys    0m0.120s
@@ -75,7 +75,7 @@ Finally, re-pull the image:
     $ time docker pull node:latest
     Pulling repository node
     [...]
-    
+
     real   0m51.376s
     user   0m0.120s
     sys    0m0.116s

--- a/docs/sources/articles/runmetrics.md
+++ b/docs/sources/articles/runmetrics.md
@@ -113,7 +113,7 @@ indicates the number of page faults which happened since the creation of
 the cgroup; this number can never decrease).
 
 
- - **cache:**  
+ - **cache:**
    the amount of memory used by the processes of this control group
    that can be associated precisely with a block on a block device.
    When you read from and write to files on disk, this amount will
@@ -123,16 +123,16 @@ the cgroup; this number can never decrease).
    `mmap`). It also accounts for the memory used by
    `tmpfs` mounts, though the reasons are unclear.
 
- - **rss:**  
+ - **rss:**
    the amount of memory that *doesn't* correspond to anything on disk:
    stacks, heaps, and anonymous memory maps.
 
- - **mapped_file:**  
+ - **mapped_file:**
    indicates the amount of memory mapped by the processes in the
    control group. It doesn't give you information about *how much*
    memory is used; it rather tells you *how* it is used.
 
- - **pgfault and pgmajfault:**  
+ - **pgfault and pgmajfault:**
    indicate the number of times that a process of the cgroup triggered
    a "page fault" and a "major fault", respectively. A page fault
    happens when a process accesses a part of its virtual memory space
@@ -151,10 +151,10 @@ the cgroup; this number can never decrease).
    it just has to duplicate an existing page, or allocate an empty
    page, it's a regular (or "minor") fault.
 
- - **swap:**  
+ - **swap:**
    the amount of swap currently used by the processes in this cgroup.
 
- - **active_anon and inactive_anon:**  
+ - **active_anon and inactive_anon:**
    the amount of *anonymous* memory that has been identified has
    respectively *active* and *inactive* by the kernel. "Anonymous"
    memory is the memory that is *not* linked to disk pages. In other
@@ -169,7 +169,7 @@ the cgroup; this number can never decrease).
    retagged "active". When the kernel is almost out of memory, and time
    comes to swap out to disk, the kernel will swap "inactive" pages.
 
- - **active_file and inactive_file:**  
+ - **active_file and inactive_file:**
    cache memory, with *active* and *inactive* similar to the *anon*
    memory above. The exact formula is cache = **active_file** +
    **inactive_file** + **tmpfs**. The exact rules used by the kernel
@@ -180,14 +180,14 @@ the cgroup; this number can never decrease).
    since it can be reclaimed immediately (while anonymous pages and
    dirty/modified pages have to be written to disk first).
 
- - **unevictable:**  
+ - **unevictable:**
    the amount of memory that cannot be reclaimed; generally, it will
    account for memory that has been "locked" with `mlock`.
    It is often used by crypto frameworks to make sure that
    secret keys and other sensitive material never gets swapped out to
    disk.
 
- - **memory and memsw limits:**  
+ - **memory and memsw limits:**
    These are not really metrics, but a reminder of the limits applied
    to this cgroup. The first one indicates the maximum amount of
    physical memory that can be used by the processes of this control
@@ -235,21 +235,21 @@ file in the kernel documentation, here is a short list of the most
 relevant ones:
 
 
- - **blkio.sectors:**  
+ - **blkio.sectors:**
    contain the number of 512-bytes sectors read and written by the
    processes member of the cgroup, device by device. Reads and writes
    are merged in a single counter.
 
- - **blkio.io_service_bytes:**  
+ - **blkio.io_service_bytes:**
    indicates the number of bytes read and written by the cgroup. It has
    4 counters per device, because for each device, it differentiates
    between synchronous vs. asynchronous I/O, and reads vs. writes.
 
- - **blkio.io_serviced:**  
+ - **blkio.io_serviced:**
    the number of I/O operations performed, regardless of their size. It
    also has 4 counters per device.
 
- - **blkio.io_queued:**  
+ - **blkio.io_queued:**
    indicates the number of I/O operations currently queued for this
    cgroup. In other words, if the cgroup isn't doing any I/O, this will
    be zero. Note that the opposite is not true. In other words, if

--- a/docs/sources/articles/security.md
+++ b/docs/sources/articles/security.md
@@ -122,7 +122,7 @@ privilege separation.
 
 Eventually, it is expected that the Docker daemon will run restricted
 privileges, delegating operations well-audited sub-processes,
-each with its own (very limited) scope of Linux capabilities, 
+each with its own (very limited) scope of Linux capabilities,
 virtual network setup, filesystem management, etc. That is, most likely,
 pieces of the Docker engine itself will run inside of containers.
 

--- a/docs/sources/articles/systemd.md
+++ b/docs/sources/articles/systemd.md
@@ -24,7 +24,7 @@ If you want Docker to start at boot, you should also:
 ## Custom Docker daemon options
 
 There are a number of ways to configure the daemon flags and environment variables
-for your Docker daemon. 
+for your Docker daemon.
 
 If the `docker.service` file is set to use an `EnvironmentFile`
 (often pointing to `/etc/sysconfig/docker`) then you can modify the

--- a/docs/sources/docker-hub/builds.md
+++ b/docs/sources/docker-hub/builds.md
@@ -20,7 +20,7 @@ Automated Builds have several advantages:
 image was built exactly as specified.
 
 * The `Dockerfile` will be available to anyone with access to
-your repository on the Docker Hub registry. 
+your repository on the Docker Hub registry.
 
 * Because the process is automated, Automated Builds help to
 make sure that your repository is always up to date.
@@ -39,10 +39,10 @@ In order to set up an Automated Build, you need to first link your
 [Docker Hub](https://hub.docker.com) account with a GitHub account.
 This will allow the registry to see your repositories.
 
-> *Note:* 
+> *Note:*
 > Automated Builds currently require *read* and *write* access since
 > [Docker Hub](https://hub.docker.com) needs to setup a GitHub service
-> hook. We have no choice here, this is how GitHub manages permissions, sorry! 
+> hook. We have no choice here, this is how GitHub manages permissions, sorry!
 > We do guarantee nothing else will be touched in your account.
 
 To get started, log into your Docker Hub account and click the
@@ -114,7 +114,7 @@ can be limited to read-only access to just the repositories required to build.
     </tr>
   </tbody>
 </table>
-     
+
 ### GitHub Organizations
 
 GitHub organizations will appear once your membership to that organization is
@@ -249,7 +249,7 @@ $ curl --data "build=true" -X POST https://registry.hub.docker.com/u/svendowidei
 OK
 ```
 
-> **Note:** 
+> **Note:**
 > You can only trigger one build at a time and no more than one
 > every five minutes. If you already have a build pending, or if you
 > recently submitted a build request, those requests *will be ignored*.

--- a/docs/sources/docker-hub/official_repos.md
+++ b/docs/sources/docker-hub/official_repos.md
@@ -56,7 +56,7 @@ latest`and `ruby:onbuild`, or `ruby:2` and  `ruby:2-onbuild`
 
 Include a brief description of your image (in plaintext). Only one description
 is required; you don’t need additional descriptions for each tag. The file
-should also: 
+should also:
 
 * Be named `README-short.txt`
 * Reside in the repo for the “latest” tag
@@ -66,7 +66,7 @@ should also:
 
 Include a logo of your company or the product (png format preferred). Only one
 logo is required; you don’t need additional logo files for each tag. The logo
-file should have the following characteristics: 
+file should have the following characteristics:
 
 * Be named `logo.png`
 * Should reside in the repo for the “latest” tag
@@ -77,9 +77,9 @@ can be made based on the logo needed
 
 ### A long description
 
-Include a comprehensive description of your image (in Markdown format, GitHub 
+Include a comprehensive description of your image (in Markdown format, GitHub
 flavor preferred). Only one description is required; you don’t need additional
-descriptions for each tag. The file should also: 
+descriptions for each tag. The file should also:
 
 * Be named `README.md`
 * Reside in the repo for the “latest” tag
@@ -173,7 +173,7 @@ Test it by visiting `http://container-ip:3000` in a browser. On the other hand, 
 Then go to `http://localhost:8080` or `http://host-ip:8080` in a browser.
 ```
 
-For more examples, take a look at these repos: 
+For more examples, take a look at these repos:
 
 * [Go](https://github.com/docker-library/golang)
 * [PostgreSQL](https://github.com/docker-library/postgres)

--- a/docs/sources/examples/apt-cacher-ng.md
+++ b/docs/sources/examples/apt-cacher-ng.md
@@ -4,7 +4,7 @@ page_keywords: docker, example, package installation, networking, debian, ubuntu
 
 # Dockerizing an Apt-Cacher-ng Service
 
-> **Note**: 
+> **Note**:
 > - **If you don't like sudo** then see [*Giving non-root
 >   access*](/installation/binaries/#giving-non-root-access).
 > - **If you're using OS X or docker via TCP** then you shouldn't use

--- a/docs/sources/examples/couchdb_data_volumes.md
+++ b/docs/sources/examples/couchdb_data_volumes.md
@@ -4,7 +4,7 @@ page_keywords: docker, example, package installation, networking, couchdb, data 
 
 # Dockerizing a CouchDB Service
 
-> **Note**: 
+> **Note**:
 > - **If you don't like sudo** then see [*Giving non-root
 >   access*](/installation/binaries/#giving-non-root-access)
 

--- a/docs/sources/examples/mongodb.md
+++ b/docs/sources/examples/mongodb.md
@@ -18,8 +18,8 @@ instances will bring several benefits, such as:
  - Based on globally accessible and shareable images.
 
 > **Note:**
-> 
-> If you do **_not_** like `sudo`, you might want to check out: 
+>
+> If you do **_not_** like `sudo`, you might want to check out:
 > [*Giving non-root access*](/installation/binaries/#giving-non-root-access).
 
 ## Creating a Dockerfile for MongoDB
@@ -69,7 +69,7 @@ After this initial preparation we can update our packages and install MongoDB.
 
 > **Tip:** You can install a specific version of MongoDB by using a list
 > of required packages with versions, e.g.:
-> 
+>
 >     RUN apt-get update && apt-get install -y mongodb-org=2.6.1 mongodb-org-server=2.6.1 mongodb-org-shell=2.6.1 mongodb-org-mongos=2.6.1 mongodb-org-tools=2.6.1
 
 MongoDB requires a data directory. Let's create it as the final step of our
@@ -91,7 +91,7 @@ the `EXPOSE` instruction.
 Now save the file and let's build our image.
 
 > **Note:**
-> 
+>
 > The full version of this `Dockerfile` can be found [here](/examples/mongodb/Dockerfile).
 
 ## Building the MongoDB Docker image
@@ -144,7 +144,7 @@ as daemon process(es).
     $ docker logs mongo_instance_001
 
     # Playing with MongoDB
-    # Usage: mongo --port <port you get from `docker ps`> 
+    # Usage: mongo --port <port you get from `docker ps`>
     $ mongo --port 12345
 
  - [Linking containers](/userguide/dockerlinks)

--- a/docs/sources/examples/nodejs_web_app.md
+++ b/docs/sources/examples/nodejs_web_app.md
@@ -4,7 +4,7 @@ page_keywords: docker, example, package installation, node, centos
 
 # Dockerizing a Node.js Web App
 
-> **Note**: 
+> **Note**:
 > - **If you don't like sudo** then see [*Giving non-root
 >   access*](/installation/binaries/#giving-non-root-access)
 

--- a/docs/sources/examples/postgresql_service.md
+++ b/docs/sources/examples/postgresql_service.md
@@ -4,7 +4,7 @@ page_keywords: docker, example, package installation, postgresql
 
 # Dockerizing PostgreSQL
 
-> **Note**: 
+> **Note**:
 > - **If you don't like sudo** then see [*Giving non-root
 >   access*](/installation/binaries/#giving-non-root-access)
 
@@ -15,7 +15,7 @@ Hub](http://hub.docker.com), you can create one yourself.
 
 Start by creating a new `Dockerfile`:
 
-> **Note**: 
+> **Note**:
 > This PostgreSQL setup is for development-only purposes. Refer to the
 > PostgreSQL documentation to fine-tune these settings so that it is
 > suitably secure.
@@ -55,7 +55,7 @@ Start by creating a new `Dockerfile`:
         createdb -O docker docker
 
     # Adjust PostgreSQL configuration so that remote connections to the
-    # database are possible. 
+    # database are possible.
     RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.3/main/pg_hba.conf
 
     # And add ``listen_addresses`` to ``/etc/postgresql/9.3/main/postgresql.conf``
@@ -82,7 +82,7 @@ There are 2 ways to connect to the PostgreSQL server. We can use [*Link
 Containers*](/userguide/dockerlinks), or we can access it from our host
 (or the network).
 
-> **Note**: 
+> **Note**:
 > The `--rm` removes the container and its image when
 > the container exits successfully.
 

--- a/docs/sources/examples/running_riak_service.md
+++ b/docs/sources/examples/running_riak_service.md
@@ -20,7 +20,7 @@ of. We'll use [Ubuntu](https://registry.hub.docker.com/_/ubuntu/) (tag:
     # Riak
     #
     # VERSION       0.1.1
-    
+
     # Use the Ubuntu base image provided by dotCloud
     FROM ubuntu:trusty
     MAINTAINER Hector Castro hector@basho.com
@@ -45,9 +45,9 @@ Then we install and setup a few dependencies:
         apt-get install -y supervisor riak=2.0.5-1
 
     RUN mkdir -p /var/log/supervisor
-    
+
     RUN locale-gen en_US en_US.UTF-8
-    
+
     COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 After that, we modify Riak's configuration:
@@ -77,7 +77,7 @@ Populate it with the following program definitions:
 
     [supervisord]
     nodaemon=true
-    
+
     [program:riak]
     command=bash -c "/usr/sbin/riak console"
     numprocs=1

--- a/docs/sources/faq.md
+++ b/docs/sources/faq.md
@@ -145,19 +145,19 @@ the container will continue to as well. You can see a more substantial example
 
 Linux:
 
- - Ubuntu 12.04, 13.04 et al 
- - Fedora 19/20+ 
- - RHEL 6.5+ 
- - CentOS 6+ 
- - Gentoo 
- - ArchLinux 
- - openSUSE 12.3+ 
+ - Ubuntu 12.04, 13.04 et al
+ - Fedora 19/20+
+ - RHEL 6.5+
+ - CentOS 6+
+ - Gentoo
+ - ArchLinux
+ - openSUSE 12.3+
  - CRUX 3.0+
 
 Cloud:
 
- - Amazon EC2 
- - Google Compute Engine 
+ - Amazon EC2
+ - Google Compute Engine
  - Rackspace
 
 ### How do I report a security issue with Docker?
@@ -253,11 +253,11 @@ how to do this, check the documentation for your OS.
 You can find more answers on:
 
 
-- [Docker user mailinglist](https://groups.google.com/d/forum/docker-user) 
-- [Docker developer mailinglist](https://groups.google.com/d/forum/docker-dev) 
-- [IRC, docker on freenode](irc://chat.freenode.net#docker) 
-- [GitHub](https://github.com/docker/docker) 
-- [Ask questions on Stackoverflow](http://stackoverflow.com/search?q=docker) 
+- [Docker user mailinglist](https://groups.google.com/d/forum/docker-user)
+- [Docker developer mailinglist](https://groups.google.com/d/forum/docker-dev)
+- [IRC, docker on freenode](irc://chat.freenode.net#docker)
+- [GitHub](https://github.com/docker/docker)
+- [Ask questions on Stackoverflow](http://stackoverflow.com/search?q=docker)
 - [Join the conversation on Twitter](http://twitter.com/docker)
 
 Looking for something else to read? Checkout the [User Guide](/userguide/).

--- a/docs/sources/http-routingtable.md
+++ b/docs/sources/http-routingtable.md
@@ -8,8 +8,8 @@
 [**/version**](#cap-/version)
 
   -- -------------------------------------------------------------------------------------------------------------------------------------------------------------------- ----
-                                                                                                                                                                          
-     **/api**                                                                                                                                                             
+      
+     **/api**
      [`GET /api/v1.1/o/authorize/`](../reference/api/docker_io_oauth_api/#get--api-v1.1-o-authorize-)                                                              **
      [`POST /api/v1.1/o/token/`](../reference/api/docker_io_oauth_api/#post--api-v1.1-o-token-)                                                                    **
      [`GET /api/v1.1/users/:username/`](../reference/api/docker_io_accounts_api/#get--api-v1.1-users--username-)                                                   **
@@ -18,18 +18,18 @@
      [`PATCH /api/v1.1/users/:username/emails/`](../reference/api/docker_io_accounts_api/#patch--api-v1.1-users--username-emails-)                                 **
      [`POST /api/v1.1/users/:username/emails/`](../reference/api/docker_io_accounts_api/#post--api-v1.1-users--username-emails-)                                   **
      [`DELETE /api/v1.1/users/:username/emails/`](../reference/api/docker_io_accounts_api/#delete--api-v1.1-users--username-emails-)                               **
-                                                                                                                                                                          
-     **/auth**                                                                                                                                                            
+      
+     **/auth**
      [`GET /auth`](../reference/api/docker_remote_api/#get--auth)                                                                                                  **
      [`POST /auth`](../reference/api/docker_remote_api_v1.9/#post--auth)                                                                                           **
-                                                                                                                                                                          
-     **/build**                                                                                                                                                           
+      
+     **/build**
      [`POST /build`](../reference/api/docker_remote_api_v1.9/#post--build)                                                                                         **
-                                                                                                                                                                          
-     **/commit**                                                                                                                                                          
+      
+     **/commit**
      [`POST /commit`](../reference/api/docker_remote_api_v1.9/#post--commit)                                                                                       **
-                                                                                                                                                                          
-     **/containers**                                                                                                                                                      
+      
+     **/containers**
      [`DELETE /containers/(id)`](../reference/api/docker_remote_api_v1.9/#delete--containers-(id))                                                                 **
      [`POST /containers/(id)/attach`](../reference/api/docker_remote_api_v1.9/#post--containers-(id)-attach)                                                       **
      [`GET /containers/(id)/changes`](../reference/api/docker_remote_api_v1.9/#get--containers-(id)-changes)                                                       **
@@ -45,14 +45,14 @@
      [`POST /containers/create`](/reference/api/docker_remote_api_v1.9/#create-a-container)                                                                 **
      [`GET /containers/json`](../reference/api/docker_remote_api_v1.9/#get--containers-json)                                                                       **
      [`POST /containers/(id)/resize`](../reference/api/docker_remote_api_v1.9/#get--containers-resize)                                                                  **
-                                                                                                                                                                          
-     **/events**                                                                                                                                                          
+      
+     **/events**
      [`GET /events`](../reference/api/docker_remote_api_v1.9/#get--events)                                                                                         **
-                                                                                                                                                                          
-     **/events:**                                                                                                                                                         
+      
+     **/events:**
      [`GET /events:`](../reference/api/docker_remote_api/#get--events-)                                                                                            **
-                                                                                                                                                                          
-     **/images**                                                                                                                                                          
+      
+     **/images**
      [`GET /images/(format)`](../reference/api/archive/docker_remote_api_v1.6/#get--images-(format))                                                               **
      [`DELETE /images/(name)`](../reference/api/docker_remote_api_v1.9/#delete--images-(name))                                                                     **
      [`GET /images/(name)/get`](../reference/api/docker_remote_api_v1.9/#get--images-(name)-get)                                                                   **
@@ -67,11 +67,11 @@
      [`POST /images/load`](../reference/api/docker_remote_api_v1.9/#post--images-load)                                                                             **
      [`GET /images/search`](../reference/api/docker_remote_api_v1.9/#get--images-search)                                                                           **
      [`GET /images/viz`](../reference/api/docker_remote_api/#get--images-viz)                                                                                      **
-                                                                                                                                                                          
-     **/info**                                                                                                                                                            
+      
+     **/info**
      [`GET /info`](../reference/api/docker_remote_api_v1.9/#get--info)                                                                                             **
-                                                                                                                                                                          
-     **/v1**                                                                                                                                                              
+      
+     **/v1**
      [`GET /v1/_ping`](../reference/api/registry_api/#get--v1-_ping)                                                                                               **
      [`GET /v1/images/(image_id)/ancestry`](../reference/api/registry_api/#get--v1-images-(image_id)-ancestry)                                                     **
      [`GET /v1/images/(image_id)/json`](../reference/api/registry_api/#get--v1-images-(image_id)-json)                                                             **
@@ -97,8 +97,8 @@
      [`GET /v1/users`](../reference/api/index_api/#get--v1-users)                                                                                                  **
      [`POST /v1/users`](../reference/api/index_api/#post--v1-users)                                                                                                **
      [`PUT /v1/users/(username)/`](../reference/api/index_api/#put--v1-users-(username)-)                                                                          **
-                                                                                                                                                                          
-     **/version**                                                                                                                                                         
+      
+     **/version**
      [`GET /version`](../reference/api/docker_remote_api_v1.9/#get--version)                                                                                       **
   -- -------------------------------------------------------------------------------------------------------------------------------------------------------------------- ----
 

--- a/docs/sources/include/no-remote-sudo.md
+++ b/docs/sources/include/no-remote-sudo.md
@@ -1,3 +1,3 @@
-> **Note:** if you are using a remote Docker daemon, such as Boot2Docker, 
+> **Note:** if you are using a remote Docker daemon, such as Boot2Docker,
 > then _do not_ type the `sudo` before the `docker` commands shown in the
 > documentation's examples.

--- a/docs/sources/installation/azure.md
+++ b/docs/sources/installation/azure.md
@@ -13,7 +13,7 @@ machines on Azure:
 
 * [Docker Virtual Machine Extensions on Azure][1]
     * [How to use the Docker VM Extension from Azure Cross-Platform Interface][2]
-    * [How to use the Docker VM Extension with the Azure Portal][3] 
+    * [How to use the Docker VM Extension with the Azure Portal][3]
 * [Using Docker Machine with Azure][4]
 
 ## What next?

--- a/docs/sources/installation/binaries.md
+++ b/docs/sources/installation/binaries.md
@@ -108,7 +108,7 @@ starts. The `docker` daemon must always run as the root user, but if you
 run the `docker` client as a user in the *docker* group then you don't
 need to add `sudo` to all the client commands.
 
-> **Warning**: 
+> **Warning**:
 > The *docker* group (or the group specified with `-G`) is root-equivalent;
 > see [*Docker Daemon Attack Surface*](
 > /articles/security/#docker-daemon-attack-surface) details.

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -62,7 +62,7 @@ which is officially supported by Docker.
 2. Restart your system. This is necessary for Debian to use your new kernel.
 
 3. Install Docker using the get.docker.com script:
- 
+
     `curl -sSL https://get.docker.com/ | sh`
 
 ## Giving non-root access

--- a/docs/sources/installation/gentoolinux.md
+++ b/docs/sources/installation/gentoolinux.md
@@ -9,13 +9,13 @@ Installing Docker on Gentoo Linux can be accomplished using one of two ways: the
 Official project page of [Gentoo Docker](https://wiki.gentoo.org/wiki/Project:Docker) team.
 
 ## Official way
-The first and recommended way if you are looking for a stable  
-experience is to use the official `app-emulation/docker` package directly  
+The first and recommended way if you are looking for a stable
+experience is to use the official `app-emulation/docker` package directly
 from the tree.
 
-If any issues arise from this ebuild including, missing kernel 
-configuration flags or dependencies, open a bug 
-on the Gentoo [Bugzilla](https://bugs.gentoo.org) assigned to `docker AT gentoo DOT org` 
+If any issues arise from this ebuild including, missing kernel
+configuration flags or dependencies, open a bug
+on the Gentoo [Bugzilla](https://bugs.gentoo.org) assigned to `docker AT gentoo DOT org`
 or join and ask in the official
 [IRC](http://webchat.freenode.net?channels=%23gentoo-containers&uio=d4) channel on the Freenode network.
 
@@ -28,9 +28,9 @@ up-to-date documentation for properly installing and using the overlay
 can be found in the [overlay](https://github.com/tianon/docker-overlay/blob/master/README.md#using-this-overlay).
 
 If any issues arise from this ebuild or the resulting binary, including
-and especially missing kernel configuration flags or dependencies, 
-open an [issue](https://github.com/tianon/docker-overlay/issues) on 
-the `docker-overlay` repository or ping `tianon` directly in the `#docker` 
+and especially missing kernel configuration flags or dependencies,
+open an [issue](https://github.com/tianon/docker-overlay/issues) on
+the `docker-overlay` repository or ping `tianon` directly in the `#docker`
 IRC channel on the Freenode network.
 
 ## Installation
@@ -56,8 +56,8 @@ prompt for all necessary kernel options.
 
     $ sudo emerge -av app-emulation/docker
 
->Note: Sometimes there is a disparity between the latest versions 
->in the official **Gentoo tree** and the **docker-overlay**.  
+>Note: Sometimes there is a disparity between the latest versions
+>in the official **Gentoo tree** and the **docker-overlay**.
 >Please be patient, and the latest version should propagate shortly.
 
 ## Starting Docker
@@ -66,12 +66,12 @@ Ensure that you are running a kernel that includes all the necessary
 modules and configuration (and optionally for device-mapper
 and AUFS or Btrfs, depending on the storage driver you've decided to use).
 
-To use Docker, the `docker` daemon must be running as **root**.  
-To use Docker as a **non-root** user, add yourself to the **docker** 
+To use Docker, the `docker` daemon must be running as **root**.
+To use Docker as a **non-root** user, add yourself to the **docker**
 group by running the following command:
 
     $ sudo usermod -a -G docker user
- 
+
 ### OpenRC
 
 To start the `docker` daemon:
@@ -91,7 +91,7 @@ To start the `docker` daemon:
 To start on system boot:
 
     $ sudo systemctl enable docker
-   
+
 If you need to add an HTTP Proxy, set a different directory or partition for the
 Docker runtime files, or make other customizations, read our systemd article to
 learn how to [customize your systemd Docker daemon options](/articles/systemd/).

--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -186,7 +186,7 @@ Work through this section to try some practical container tasks using `boot2dock
 2. Display your running container with `docker ps` command
 
 		CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS              PORTS                                           NAMES
-		5fb65ff765e9        nginx:latest        "nginx -g 'daemon of   3 minutes ago       Up 3 minutes        0.0.0.0:49156->443/tcp, 0.0.0.0:49157->80/tcp   web  
+		5fb65ff765e9        nginx:latest        "nginx -g 'daemon of   3 minutes ago       Up 3 minutes        0.0.0.0:49156->443/tcp, 0.0.0.0:49157->80/tcp   web
 
 	At this point, you can see `nginx` is running as a daemon.
 

--- a/docs/sources/installation/rhel.md
+++ b/docs/sources/installation/rhel.md
@@ -31,7 +31,7 @@ Docker is located in the *extras* channel. To install Docker:
 
 2. Install Docker:
 
-        $ sudo yum install docker 
+        $ sudo yum install docker
 
 Additional installation, configuration, and usage information,
 including a [Get Started with Docker Containers in Red Hat

--- a/docs/sources/installation/softlayer.md
+++ b/docs/sources/installation/softlayer.md
@@ -1,4 +1,4 @@
-page_title: Installation on IBM SoftLayer 
+page_title: Installation on IBM SoftLayer
 page_description: Installation instructions for Docker on IBM Softlayer.
 page_keywords: IBM SoftLayer, virtualization, cloud, docker, documentation, installation
 

--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -1,13 +1,13 @@
-page_title: Installation on Ubuntu 
-page_description: Instructions for installing Docker on Ubuntu. 
+page_title: Installation on Ubuntu
+page_description: Instructions for installing Docker on Ubuntu.
 page_keywords: Docker, Docker documentation, requirements, virtualbox, installation, ubuntu
 
 #Ubuntu
 
 Docker is supported on these Ubuntu operating systems:
 
-- Ubuntu Trusty 14.04 (LTS) 
-- Ubuntu Precise 12.04 (LTS) 
+- Ubuntu Trusty 14.04 (LTS)
+- Ubuntu Precise 12.04 (LTS)
 - Ubuntu Saucy 13.10
 
 This page instructs you to install using Docker-managed release packages and
@@ -28,7 +28,7 @@ and frequently panic under certain conditions.
 To check your current kernel version, open a terminal and use `uname -r` to display
 your kernel version:
 
-	$ uname -r 
+	$ uname -r
 	3.11.0-15-generic
 
 >**Caution** Some Ubuntu OS versions **require a version higher than 3.10** to
@@ -121,17 +121,17 @@ install Docker using the following:
 
 	This command downloads a test image and runs it in a container.
 
-## Optional Configurations for Docker on Ubuntu 
+## Optional Configurations for Docker on Ubuntu
 
 This section contains optional procedures for configuring your Ubuntu to work
 better with Docker.
 
-* [Create a docker group](#create-a-docker-group) 
-* [Adjust memory and swap accounting](#adjust-memory-and-swap-accounting) 
-* [Enable UFW forwarding](#enable-ufw-forwarding) 
+* [Create a docker group](#create-a-docker-group)
+* [Adjust memory and swap accounting](#adjust-memory-and-swap-accounting)
+* [Enable UFW forwarding](#enable-ufw-forwarding)
 * [Configure a DNS server for use by Docker](#configure-a-dns-server-for-docker)
 
-### Create a docker group		
+### Create a docker group
 
 The `docker` daemon binds to a Unix socket instead of a TCP port. By default
 that Unix socket is owned by the user `root` and other users can access it with

--- a/docs/sources/introduction/understanding-docker.md
+++ b/docs/sources/introduction/understanding-docker.md
@@ -89,16 +89,16 @@ As shown in the diagram above, the Docker daemon runs on a host machine. The
 user does not directly interact with the daemon, but instead through the Docker
 client.
 
-### The Docker client 
+### The Docker client
 The Docker client, in the form of the `docker` binary, is the primary user
 interface to Docker. It accepts commands from the user and communicates back and
 forth with a Docker daemon.
 
-### Inside Docker 
+### Inside Docker
 To understand Docker's internals, you need to know about three components:
 
-* Docker images. 
-* Docker registries. 
+* Docker images.
+* Docker registries.
 * Docker containers.
 
 #### Docker images
@@ -114,7 +114,7 @@ Docker registries hold images. These are public or private stores from which you
 or download images. The public Docker registry is called
 [Docker Hub](http://hub.docker.com). It provides a huge collection of existing
 images for your use. These can be images you create yourself or you
-can use images that others have previously created. Docker registries are the 
+can use images that others have previously created. Docker registries are the
 **distribution** component of Docker.
 
 ####Docker containers
@@ -124,7 +124,7 @@ image. Docker containers can be run, started, stopped, moved, and deleted. Each
 container is an isolated and secure application platform. Docker containers are the
  **run** component of Docker.
 
-##So how does Docker work? 
+##So how does Docker work?
 So far, we've learned that:
 
 1. You can build Docker images that hold your applications.
@@ -135,7 +135,7 @@ So far, we've learned that:
 
 Let's look at how these elements combine together to make Docker work.
 
-### How does a Docker Image work? 
+### How does a Docker Image work?
 We've already seen that Docker images are read-only templates from which Docker
 containers are launched. Each image consists of a series of layers. Docker
 makes use of [union file systems](http://en.wikipedia.org/wiki/UnionFS) to
@@ -162,8 +162,8 @@ Docker images are then built from these base images using a simple, descriptive
 set of steps we call *instructions*. Each instruction creates a new layer in our
 image. Instructions include actions like:
 
-* Run a command. 
-* Add a file or directory. 
+* Run a command.
+* Add a file or directory.
 * Create an environment variable.
 * What process to run when launching a container from this image.
 
@@ -173,7 +173,7 @@ returns a final image.
 
 ### How does a Docker registry work?
 The Docker registry is the store for your Docker images. Once you build a Docker
-image you can *push* it to a public registry [Docker Hub](https://hub.docker.com) or to 
+image you can *push* it to a public registry [Docker Hub](https://hub.docker.com) or to
 your own registry running behind your firewall.
 
 Using the Docker client, you can search for already published images and then
@@ -206,7 +206,7 @@ minimum the Docker client needs to tell the Docker daemon to run the container
 is:
 
 * What Docker image to build the container from, here `ubuntu`, a base Ubuntu
-image; 
+image;
 * The command you want to run inside the container when it is launched,
 here `/bin/bash`, to start the Bash shell inside the new container.
 
@@ -217,16 +217,16 @@ In order, Docker does the following:
 - **Pulls the `ubuntu` image:** Docker checks for the presence of the `ubuntu`
 image and, if it doesn't exist locally on the host, then Docker downloads it from
 [Docker Hub](https://hub.docker.com). If the image already exists, then Docker
-uses it for the new container. 
+uses it for the new container.
 - **Creates a new container:** Once Docker has the image, it uses it to create a
-container. 
-- **Allocates a filesystem and mounts a read-write _layer_:** The container is created in 
+container.
+- **Allocates a filesystem and mounts a read-write _layer_:** The container is created in
 the file system and a read-write layer is added to the image.
-- **Allocates a network / bridge interface:** Creates a network interface that allows the 
-Docker container to talk to the local host. 
-- **Sets up an IP address:** Finds and attaches an available IP address from a pool. 
-- **Executes a process that you specify:** Runs your application, and; 
-- **Captures and provides application output:** Connects and logs standard input, outputs 
+- **Allocates a network / bridge interface:** Creates a network interface that allows the
+Docker container to talk to the local host.
+- **Sets up an IP address:** Finds and attaches an available IP address from a pool.
+- **Executes a process that you specify:** Runs your application, and;
+- **Captures and provides application output:** Connects and logs standard input, outputs
 and errors for you to see how your application is running.
 
 You now have a running container! From here you can manage your container, interact with
@@ -246,12 +246,12 @@ namespace and does not have access outside it.
 
 Some of the namespaces that Docker uses are:
 
- - **The `pid` namespace:** Used for process isolation (PID: Process ID). 
+ - **The `pid` namespace:** Used for process isolation (PID: Process ID).
  - **The `net` namespace:** Used for managing network interfaces (NET:
- Networking). 
+ Networking).
  - **The `ipc` namespace:** Used for managing access to IPC
- resources (IPC: InterProcess Communication). 
- - **The `mnt` namespace:** Used for managing mount-points (MNT: Mount). 
+ resources (IPC: InterProcess Communication).
+ - **The `mnt` namespace:** Used for managing mount-points (MNT: Mount).
  - **The `uts` namespace:** Used for isolating kernel and version identifiers. (UTS: Unix
 Timesharing System).
 
@@ -269,10 +269,10 @@ making them very lightweight and fast. Docker uses union file systems to provide
 the building blocks for containers. Docker can make use of several union file system variants
 including: AUFS, btrfs, vfs, and DeviceMapper.
 
-### Container format 
+### Container format
 Docker combines these components into a wrapper we call a container format. The
 default container format is called `libcontainer`. Docker also supports
-traditional Linux containers using [LXC](https://linuxcontainers.org/). In the 
+traditional Linux containers using [LXC](https://linuxcontainers.org/). In the
 future, Docker may support other container formats, for example, by integrating with
 BSD Jails or Solaris Zones.
 

--- a/docs/sources/project/advanced-contributing.md
+++ b/docs/sources/project/advanced-contributing.md
@@ -37,7 +37,7 @@ altering the external behavior. To make this type of proposal:
     **Cleanup:** _short title_
 
     If your changes required logic changes, note that in your request.
-	
+
 5. Work through Docker's review process until merge.
 
 
@@ -67,8 +67,8 @@ The following provides greater detail on the process:
 
     The design proposals are <a
     href="https://github.com/docker/docker/pulls?q=is%3Aopen+is%3Apr+label%
-    3AProposal" target="_blank">all online in our GitHub pull requests</a>. 
-    
+    3AProposal" target="_blank">all online in our GitHub pull requests</a>.
+
 3. Talk to the community about your idea.
 
     We have lots of <a href="../get-help/" target="_blank">community forums</a>
@@ -77,10 +77,10 @@ The following provides greater detail on the process:
 
 4. Fork `docker/docker` and clone the repo to your local host.
 
-5. Create a new Markdown file in the area you wish to change.  
+5. Create a new Markdown file in the area you wish to change.
 
     For example, if you want to redesign our daemon create a new file under the
-    `daemon/` folder. 
+    `daemon/` folder.
 
 6. Name the file descriptively, for example `redesign-daemon-proposal.md`.
 
@@ -95,7 +95,7 @@ The following provides greater detail on the process:
     * Which design/implementation do you think is best and why?
     * What are the risks or limitations of your proposal?
 
-    This is your chance to convince people your idea is sound. 
+    This is your chance to convince people your idea is sound.
 
 8. Submit your proposal in a pull request to `docker/docker`.
 
@@ -115,7 +115,7 @@ The following provides greater detail on the process:
 10. Pull request accepted.
 
     Your request may also be rejected. Not every idea is a good fit for Docker.
-    Let's assume though your proposal succeeded. 
+    Let's assume though your proposal succeeded.
 
 11. Implement your idea.
 
@@ -133,7 +133,7 @@ The following provides greater detail on the process:
 13. Review and iterate on your code.
 
     If you are making a large code change, you can expect greater scrutiny
-    during this phase. 
+    during this phase.
 
 14. Acceptance and merge!
 

--- a/docs/sources/project/coding-style.md
+++ b/docs/sources/project/coding-style.md
@@ -19,7 +19,7 @@ that is program code or code that is documentation code.
 * Run `gofmt -s -w file.go` on each changed file before
   committing your changes. Most editors have plug-ins that do this automatically.
 
-* Update the documentation when creating or modifying features. 
+* Update the documentation when creating or modifying features.
 
 * Commits that fix or close an issue should reference them in the commit message
   `Closes #XXXX` or `Fixes #XXXX`. Mentions help by automatically closing the
@@ -36,11 +36,11 @@ that is program code or code that is documentation code.
 
 ## Tests and testing
 
-* Submit unit tests for your changes. 
+* Submit unit tests for your changes.
 
-* Make use of the builtin Go test framework built. 
+* Make use of the builtin Go test framework built.
 
-* Use existing Docker test files (`name_test.go`) for inspiration. 
+* Use existing Docker test files (`name_test.go`) for inspiration.
 
 * Run <a href="../test-and-docs" target="_blank">the full test suite</a> on your
   branch before submitting a pull request.
@@ -57,14 +57,14 @@ that is program code or code that is documentation code.
   mixed into the PR.
 
 * Before the pull request, squash your commits into logical units of work using
-  `git rebase -i` and `git push -f`. 
+  `git rebase -i` and `git push -f`.
 
 * Include documentation changes in the same commit so that a revert would
   remove all traces of the feature or fix.
 
 * Reference each issue in your pull request description (`#XXXX`)
 
-## Respond to pull requests reviews 
+## Respond to pull requests reviews
 
 * Docker maintainers use LGTM (**l**ooks-**g**ood-**t**o-**m**e) in PR comments
   to indicate acceptance.

--- a/docs/sources/project/create-pr.md
+++ b/docs/sources/project/create-pr.md
@@ -15,7 +15,7 @@ list of active pull requests to Docker</a> on GitHub.
 
 Before you create a pull request, check your work.
 
-1. In a terminal window, go to the root of your `docker-fork` repository. 
+1. In a terminal window, go to the root of your `docker-fork` repository.
 
         $ cd ~/repos/docker-fork
 
@@ -29,8 +29,8 @@ Before you create a pull request, check your work.
 		$ make test
 
 	All the tests should pass. If they don't, find out why and correct the
-	situation. 
-    
+	situation.
+
 4. Optionally, if modified the documentation, build the documentation:
 
 		$ make docs
@@ -39,7 +39,7 @@ Before you create a pull request, check your work.
 
 ## Rebase your branch
 
-Always rebase and squash your commits before making a pull request. 
+Always rebase and squash your commits before making a pull request.
 
 1. Fetch any of the last minute changes from `docker/docker`.
 
@@ -56,9 +56,9 @@ Always rebase and squash your commits before making a pull request.
         pick 1a79f55 Tweak some of the other text for grammar
         pick 53e4983 Fix a link
         pick 3ce07bb Add a new line about RHEL
-        
+
     If you run into trouble, `git --rebase abort` removes any changes and gets
-    you back to where you started. 
+    you back to where you started.
 
 4. Squash the `pick` keyword with `squash` on all but the first commit.
 
@@ -67,7 +67,7 @@ Always rebase and squash your commits before making a pull request.
         squash 3ce07bb Add a new line about RHEL
 
     After closing the file, `git` opens your editor again to edit the commit
-    message. 
+    message.
 
 5. Edit and save your commit message.
 
@@ -78,7 +78,7 @@ Always rebase and squash your commits before making a pull request.
 8. Push any changes to your fork on GitHub.
 
         $ git push origin 11038-fix-rhel-link
-        
+
 ## Create a PR on GitHub
 
 You create and manage PRs on GitHub:
@@ -92,7 +92,7 @@ You create and manage PRs on GitHub:
 
 2. Click "Compare & pull request."
 
-    The system displays the pull request dialog. 
+    The system displays the pull request dialog.
 
     ![PR dialog](/project/images/to_from_pr.png)
 

--- a/docs/sources/project/doc-style.md
+++ b/docs/sources/project/doc-style.md
@@ -10,7 +10,7 @@ Over time, different publishing communities have written standards for the style
 and grammar they prefer in their publications. These standards are called
 [style guides](http://en.wikipedia.org/wiki/Style_guide). Generally, Docker’s
 documentation uses the standards described in the
-[Associated Press's (AP) style guide](http://en.wikipedia.org/wiki/AP_Stylebook). 
+[Associated Press's (AP) style guide](http://en.wikipedia.org/wiki/AP_Stylebook).
 If a question about syntactical, grammatical, or lexical practice comes up,
 refer to the AP guide first. If you don’t have a copy of (or online subscription
 to) the AP guide, you can almost always find an answer to a specific question by
@@ -97,7 +97,7 @@ pick one and stick to it. Which one you choose is up to you. One common
 convention is to use the pronoun of the author's gender, but if you prefer to
 default to "he" or "she", that's fine too.
 
-### Capitalization 
+### Capitalization
 
 #### In general
 
@@ -123,7 +123,7 @@ for titles](http://www.quickanddirtytips.com/education/grammar/capitalizing-titl
 
 ## Periods
 
-We prefer one space after a period at the end of a sentence, not two. 
+We prefer one space after a period at the end of a sentence, not two.
 
 See [lists](#lists) below for how to punctuate list items.
 
@@ -181,7 +181,7 @@ say what it is: "This thing is …"
 
 ### Preferred usages
 
-#### Login vs. log in. 
+#### Login vs. log in.
 
 A "login" is a noun (one word), as in "Enter your login". "Log in" is a compound
 verb (two words), as in "Log in to the terminal".
@@ -197,7 +197,7 @@ position on this controversial topic, we won't change our mind, and that’s tha
 We require `code font` styling (monospace, sans-serif) for all text that refers
 to a command or other input or output from the CLI. This includes file paths
 (e.g., `/etc/hosts/docker.conf`). If you enclose text in backticks (`) markdown
-will style the text as code. 
+will style the text as code.
 
 Text from a CLI should be quoted verbatim, even if it contains errors or its
 style contradicts this guide. You can add "(sic)" after the quote to indicate
@@ -210,7 +210,7 @@ the GUI. E.g., Click "Continue" to save the settings.
 Text that refers to a keyboard command or hotkey is  capitalized (e.g., Ctrl-D).
 
 When writing CLI examples, give the user hints by making the examples resemble
-exactly what they see in their shell: 
+exactly what they see in their shell:
 
 * Indent shell examples by 4 spaces so they get rendered as code blocks.
 * Start typed commands with `$ ` (dollar space), so that they are easily
@@ -237,7 +237,7 @@ following:
 Writing a PR that is singular in focus and has clear objectives will encourage
 all of the above. Done correctly, the process allows reviewers (maintainers and
 community members) to validate the claims of the documentation and identify
-potential problems in communication or presentation. 
+potential problems in communication or presentation.
 
 ### Commit messages
 
@@ -263,7 +263,7 @@ Usually, graphics should go in the same directory as the .md file that
 references them, or in a subdirectory for images if one already exists.
 
 The preferred file format for graphics is PNG, but GIF and JPG are also
-acceptable. 
+acceptable.
 
 If you are referring to a specific part of the UI in an image, use
 call-outs (circles and arrows or lines) to highlight what you’re referring to.

--- a/docs/sources/project/find-an-issue.md
+++ b/docs/sources/project/find-an-issue.md
@@ -49,7 +49,7 @@ working with our known issues.
 
 An existing issue is something reported by a Docker user. As issues come in,
 our maintainers triage them. Triage is its own topic. For now, it is important
-for you to know that triage includes ranking issues according to difficulty. 
+for you to know that triage includes ranking issues according to difficulty.
 
 Triaged issues have one of these labels:
 
@@ -96,7 +96,7 @@ In this section, you find and claim an open documentation lines issue.
 
 2. Click on the "Issues" link.
 
-    A list of the open issues appears. 
+    A list of the open issues appears.
 
     ![Open issues](/project/images/issue_list.png)
 
@@ -108,14 +108,14 @@ In this section, you find and claim an open documentation lines issue.
 
 5. Open an issue that interests you.
 
-    The comments on the issues can tell you both the problem and the potential 
+    The comments on the issues can tell you both the problem and the potential
     solution.
 
 6. Make sure that no other user has chosen to work on the issue.
 
     We don't allow external contributors to assign issues to themselves. So, you
     need to read the comments to find if a user claimed the issue by leaving a
-    `#dibs` comment on the issue.  
+    `#dibs` comment on the issue.
 
 7. When you find an open issue that both interests you and is unclaimed, add a
 `#dibs` comment.
@@ -202,7 +202,7 @@ To sync your repository:
 
         $ git push origin
         Username for 'https://github.com': moxiegirl
-        Password for 'https://moxiegirl@github.com': 
+        Password for 'https://moxiegirl@github.com':
         Counting objects: 223, done.
         Compressing objects: 100% (38/38), done.
         Writing objects: 100% (69/69), 8.76 KiB | 0 bytes/s, done.

--- a/docs/sources/project/get-help.md
+++ b/docs/sources/project/get-help.md
@@ -23,8 +23,8 @@ community members and developers.
     <td>
       <p>
         IRC a direct line to our most knowledgeable Docker users.
-        The <code>#docker</code> and <code>#docker-dev</code> group on 
-        <strong>irc.freenode.net</strong>. IRC was first created in 1988. 
+        The <code>#docker</code> and <code>#docker-dev</code> group on
+        <strong>irc.freenode.net</strong>. IRC was first created in 1988.
         So, it is a rich chat protocol but it can overwhelm new users. You can search
         <a href="https://botbot.me/freenode/docker/#" target="_blank">our chat archives</a>.
       </p>
@@ -36,9 +36,9 @@ community members and developers.
     <td>
       There are two groups.
       <a href="https://groups.google.com/forum/#!forum/docker-user" target="_blank">Docker-user</a>
-      is for people using Docker containers. 
-      The <a href="https://groups.google.com/forum/#!forum/docker-dev" target="_blank">docker-dev</a> 
-      group is for contributors and other people contributing to the Docker 
+      is for people using Docker containers.
+      The <a href="https://groups.google.com/forum/#!forum/docker-dev" target="_blank">docker-dev</a>
+      group is for contributors and other people contributing to the Docker
       project.
     </td>
   </tr>
@@ -46,14 +46,14 @@ community members and developers.
     <td>Twitter</td>
     <td>
       You can follow <a href="https://twitter.com/docker/" target="_blank">Docker's twitter</a>
-      to get updates on our products. You can also tweet us questions or just 
+      to get updates on our products. You can also tweet us questions or just
       share blogs or stories.
     </td>
   </tr>
   <tr>
     <td>Stack Overflow</td>
     <td>
-      Stack Overflow has over 7000K Docker questions listed. We regularly 
+      Stack Overflow has over 7000K Docker questions listed. We regularly
       monitor <a href="http://stackoverflow.com/search?tab=newest&q=docker" target="_blank">Docker questions</a>
       and so do many other knowledgeable Docker users.
     </td>
@@ -63,8 +63,8 @@ community members and developers.
 
 ## IRC Quickstart
 
-IRC can also be overwhelming for new users. This quickstart shows you 
-the easiest way to connect to IRC. 
+IRC can also be overwhelming for new users. This quickstart shows you
+the easiest way to connect to IRC.
 
 1. In your browser open <a href="http://webchat.freenode.net" target="_blank">http://webchat.freenode.net</a>
 
@@ -91,7 +91,7 @@ the easiest way to connect to IRC.
 3. Click "Connect".
 
     The system connects you to chat. You'll see a lot of text. At the bottom of
-    the display is a command line. Just above the command line the system asks 
+    the display is a command line. Just above the command line the system asks
     you to register.
 
     ![Login screen](/project/images/irc_after_login.png)
@@ -131,7 +131,7 @@ the easiest way to connect to IRC.
 
 ### Tips and learning more about IRC
 
-Next time you return to log into chat, you'll need to re-enter your password 
+Next time you return to log into chat, you'll need to re-enter your password
 on the command line using this command:
 
     /msg NickServ identify <password>
@@ -140,8 +140,8 @@ If you forget or lose your password see <a
 href="https://freenode.net/faq.shtml#sendpass" target="_blank">the FAQ on
 freenode.net</a> to learn how to recover it.
 
-This quickstart was meant to get you up and into IRC very quickly. If you find 
-IRC useful there is a lot more to learn. Drupal, another open source project, 
+This quickstart was meant to get you up and into IRC very quickly. If you find
+IRC useful there is a lot more to learn. Drupal, another open source project,
 actually has <a href="https://www.drupal.org/irc/setting-up" target="_blank">
-written a lot of good documentation about using IRC</a> for their project 
+written a lot of good documentation about using IRC</a> for their project
 (thanks Drupal!).

--- a/docs/sources/project/make-a-contribution.md
+++ b/docs/sources/project/make-a-contribution.md
@@ -23,7 +23,7 @@ for fixing simple issues looks like this:
 
 All Docker repositories have code and documentation. You use this same workflow
 for either content type. For example, you can find and fix doc or code issues.
-Also, you can propose a new Docker feature or propose a new Docker tutorial. 
+Also, you can propose a new Docker feature or propose a new Docker tutorial.
 
 Some workflow stages do have slight differences for code or documentation
 contributions. When you reach that point in the flow, we make sure to tell you.

--- a/docs/sources/project/review-pr.md
+++ b/docs/sources/project/review-pr.md
@@ -7,7 +7,7 @@ page_keywords: contribute, pull request, review, workflow, beginner, squash, com
 
 Creating a pull request is nearly the end of the contribution process. At this
 point, your code is reviewed both by our continuous integration (CI) systems and
-by our maintainers. 
+by our maintainers.
 
 The CI system is an automated system. The maintainers are human beings that also
 work on Docker.  You need to understand and work with both the "bots" and the
@@ -22,22 +22,22 @@ problem, he'll send an email through your GitHub user account:
 
 ![Gordon](/project/images/gordon.jpeg)
 
-Our build bot system starts building your changes while Gordon sends any emails. 
+Our build bot system starts building your changes while Gordon sends any emails.
 
 The build system double-checks your work by compiling your code with Docker's master
 code. Building includes running the same tests you ran locally. If you forgot
 to run tests or missed something in fixing problems, the automated build is our
-safety check. 
+safety check.
 
 After Gordon and the bots, the "beings" review your work. Docker maintainers look
 at your pull request and comment on it. The shortest comment you might see is
 `LGTM` which means **l**ooks-**g**ood-**t**o-**m**e. If you get an `LGTM`, that
-is a good thing, you passed that review. 
+is a good thing, you passed that review.
 
 For complex changes, maintainers may ask you questions or ask you to change
 something about your submission. All maintainer comments on a PR go to the
-email address associated with your GitHub account. Any GitHub user who 
-"participates" in a PR receives an email to. Participating means creating or 
+email address associated with your GitHub account. Any GitHub user who
+"participates" in a PR receives an email to. Participating means creating or
 commenting on a PR.
 
 Our maintainers are very experienced Docker users and open source contributors.
@@ -53,13 +53,13 @@ To update your existing pull request:
 
 2. Commit the change with the `git commit --amend` command.
 
-    	$ git commit --amend 
+    	$ git commit --amend
 
     Git opens an editor containing your last commit message.
 
 3. Adjust your last comment to reflect this new change.
 
-        Added a new sentence per Anaud's suggestion	
+        Added a new sentence per Anaud's suggestion
 
         Signed-off-by: Mary Anthony <mary@docker.com>
 
@@ -89,12 +89,12 @@ To update your existing pull request:
 A change requires LGTMs from an absolute majority of an affected component's
 maintainers. For example, if you change `docs/` and `registry/` code, an
 absolute majority of the `docs/` and the `registry/` maintainers must approve
-your PR. Once you get approval, we merge your pull request into Docker's 
-`master` code branch. 
+your PR. Once you get approval, we merge your pull request into Docker's
+`master` code branch.
 
 ## After the merge
 
-It can take time to see a merged pull request in Docker's official release. 
+It can take time to see a merged pull request in Docker's official release.
 A master build is available almost immediately though. Docker builds and
 updates its development binaries after each merge to `master`.
 
@@ -107,18 +107,18 @@ updates its development binaries after each merge to `master`.
     You might want to run the binary in a container though. This
     will keep your local host environment clean.
 
-4. View any documentation changes at <a href="http://docs.master.dockerproject.com/" target="_blank">docs.master.dockerproject.com</a>. 
+4. View any documentation changes at <a href="http://docs.master.dockerproject.com/" target="_blank">docs.master.dockerproject.com</a>.
 
 Once you've verified everything merged, feel free to delete your feature branch
-from your fork. For information on how to do this, 
+from your fork. For information on how to do this,
 <a href="https://help.github.com/articles/deleting-unused-branches/" target="_blank">
-see the GitHub help on deleting branches</a>.  
+see the GitHub help on deleting branches</a>.
 
 ## Where to go next
 
 At this point, you have completed all the basic tasks in our contributors guide.
 If you enjoyed contributing, let us know by completing another beginner
-issue or two. We really appreciate the help. 
+issue or two. We really appreciate the help.
 
-If you are very experienced and want to make a major change, go on to 
+If you are very experienced and want to make a major change, go on to
 [learn about advanced contributing](/project/advanced-contributing).

--- a/docs/sources/project/set-up-dev-env.md
+++ b/docs/sources/project/set-up-dev-env.md
@@ -8,10 +8,10 @@ In this section, you learn to develop like a member of Docker's core team.
 The `docker` repository includes a `Dockerfile` at its root. This file defines
 Docker's development environment.  The `Dockerfile` lists the environment's
 dependencies: system libraries and binaries, Go environment, Go dependencies,
-etc. 
+etc.
 
 Docker's development environment is itself, ultimately a Docker container.
-You use the `docker` repository and its `Dockerfile` to create a Docker image, 
+You use the `docker` repository and its `Dockerfile` to create a Docker image,
 run a Docker container, and develop code in the container. Docker itself builds,
 tests, and releases new Docker versions using this container.
 
@@ -80,10 +80,10 @@ To remove unnecessary artifacts,
     the resulting list. To remove just one image, use the `docker rmi ID`
     command.
 
-	
+
 ## Build an image
 
-If you followed the last procedure, your host is clean of unnecessary images 
+If you followed the last procedure, your host is clean of unnecessary images
 and containers. In this section, you build an image from the Docker development
 environment.
 
@@ -95,8 +95,8 @@ environment.
 
 3. Change into the root of your forked repository.
 
-        $ cd ~/repos/docker-fork 
-        
+        $ cd ~/repos/docker-fork
+
 	If you are following along with this guide, you created a `dry-run-test`
 	branch when you <a href="/project/set-up-git" target="_blank"> set up Git for
 	contributing</a>.
@@ -104,7 +104,7 @@ environment.
 4. Ensure you are on your `dry-run-test` branch.
 
         $ git checkout dry-run-test
-        
+
     If you get a message that the branch doesn't exist, add the `-b` flag (git checkout -b dry-run-test) so the
     command both creates the branch and checks it out.
 
@@ -181,7 +181,7 @@ environment.
     Locate your new `dry-run-test` image in the list. You should also see a
     number of `ubuntu` images. The build process creates these. They are the
     ancestors of your new Docker development image. When you next rebuild your
-    image, the build process reuses these ancestors images if they exist. 
+    image, the build process reuses these ancestors images if they exist.
 
     Keeping the ancestor images improves the build performance. When you rebuild
     the child image, the build process uses the local ancestors rather than
@@ -206,7 +206,7 @@ build and run a `docker` binary in your container.
 2. In a terminal, create a new container from your `dry-run-test` image.
 
         $ docker run --privileged --rm -ti dry-run-test /bin/bash
-        root@5f8630b873fe:/go/src/github.com/docker/docker# 
+        root@5f8630b873fe:/go/src/github.com/docker/docker#
 
     The command creates a container from your `dry-run-test` image. It opens an
     interactive terminal (`-ti`) running a `/bin/bash shell`.  The
@@ -222,16 +222,16 @@ build and run a `docker` binary in your container.
     ![List example](/project/images/list_example.png)
 
 
-3. Investigate your container bit. 
+3. Investigate your container bit.
 
     If you do a `go version` you'll find the `go` language is part of the
-    container. 
+    container.
 
         root@31ed86e9ddcf:/go/src/github.com/docker/docker# go version
         go version go1.4.2 linux/amd64
 
     Similarly, if you do a `docker version` you find the container
-    has no `docker` binary. 
+    has no `docker` binary.
 
         root@31ed86e9ddcf:/go/src/github.com/docker/docker# docker version
         bash: docker: command not found
@@ -245,7 +245,7 @@ with the `make.sh` script.
 
     You only call `hack/make.sh` to build a binary _inside_ a Docker
     development container as you are now. On your host, you'll use `make`
-    commands (more about this later). 
+    commands (more about this later).
 
     As it makes the binary, the `make.sh` script reports the build's progress.
     When the command completes successfully, you should see the following
@@ -253,7 +253,7 @@ with the `make.sh` script.
 
 	---> Making bundle: binary (in bundles/1.5.0-dev/binary)
 	Created binary: /go/src/github.com/docker/docker/bundles/1.5.0-dev/binary/docker-1.5.0-dev
-	
+
 5. List all the contents of the `binary` directory.
 
         root@5f8630b873fe:/go/src/github.com/docker/docker#  ls bundles/1.5.0-dev/binary/
@@ -322,7 +322,7 @@ with the `make.sh` script.
     development container. One terminal is running a debug session. The other
     terminal is displaying a `bash` prompt.
 
-12. At the prompt, test the Docker client by running the `hello-world` container.	
+12. At the prompt, test the Docker client by running the `hello-world` container.
 
         root@9337c96e017a:/go/src/github.com/docker/docker#  docker run hello-world
 
@@ -361,7 +361,7 @@ container.
         $ pwd
         /Users/mary/go/src/github.com/moxiegirl/docker-fork
 
-    Your location will be different because it reflects your environment. 
+    Your location will be different because it reflects your environment.
 
 3. Create a container using `dry-run-test`, but this time, mount your repository
 onto the `/go` directory inside the container.
@@ -376,7 +376,7 @@ onto the `/go` directory inside the container.
         ls: cannot access binary: No such file or directory
 
     Your `dry-run-test` image does not retain any of the changes you made inside
-    the container.  This is the expected behavior for a container. 
+    the container.  This is the expected behavior for a container.
 
 5. In a fresh terminal on your local host, change to the `docker-fork` root.
 
@@ -395,7 +395,7 @@ onto the `/go` directory inside the container.
 7. Back in the terminal running the container, list your `binary` directory.
 
         root@074626fc4b43:/go/src/github.com/docker/docker# ls bundles/1.5.0-dev/binary
-        docker	docker-1.5.0-dev  docker-1.5.0-dev.md5	docker-1.5.0-dev.sha256 
+        docker	docker-1.5.0-dev  docker-1.5.0-dev.md5	docker-1.5.0-dev.sha256
 
     The compiled binaries created from your repository on your local host are
     now available inside your running Docker development container.
@@ -407,13 +407,13 @@ onto the `/go` directory inside the container.
     * start `docker -dD` to launch the Docker daemon inside the container
     * run `docker ps` on local host to get the development container's name
     * connect to your running container `docker exec -it container_name bash`
-    * use the `docker run hello-world` command to create and run a container 
+    * use the `docker run hello-world` command to create and run a container
       inside your development container
 
 ## Where to go next
 
 Congratulations, you have successfully achieved Docker inception. At this point,
 you've set up your development environment and verified almost all the essential
-processes you need to contribute. Of course, before you start contributing, 
+processes you need to contribute. Of course, before you start contributing,
 [you'll need to learn one more piece of the development environment, the test
 framework](/project/test-and-docs/).

--- a/docs/sources/project/set-up-git.md
+++ b/docs/sources/project/set-up-git.md
@@ -1,12 +1,12 @@
 page_title: Configure Git for contributing
 page_description: Describes how to set up your local machine and repository
-page_keywords: GitHub account, repository, clone, fork, branch, upstream, Git, Go, make, 
+page_keywords: GitHub account, repository, clone, fork, branch, upstream, Git, Go, make,
 
 # Configure Git for contributing
 
 Work through this page to configure Git and a repository you'll use throughout
 the Contributor Guide. The work you do further in the guide, depends on the work
-you do here. 
+you do here.
 
 ## Fork and clone the Docker code
 
@@ -17,7 +17,7 @@ originates.
 As you make contributions, you change your fork's code. When you are ready,
 you make a pull request back to the original Docker repository. If you aren't
 familiar with this workflow, don't worry, this guide walks you through all the
-steps. 
+steps.
 
 To fork and clone Docker:
 
@@ -37,7 +37,7 @@ target="_blank">docker/docker repository</a>.
 4. Copy your fork's clone URL from GitHub.
 
     GitHub allows you to use HTTPS or SSH protocols for clones. You can use the
-    `git` command line or clients like Subversion to clone a repository. 
+    `git` command line or clients like Subversion to clone a repository.
 
     ![Copy clone URL](/project/images/copy_url.png)
 
@@ -70,11 +70,11 @@ target="_blank">docker/docker repository</a>.
         $ cd docker-fork
 
     Take a moment to familiarize yourself with the repository's contents. List
-    the contents. 
+    the contents.
 
 ##  Set your signature and an upstream remote
 
-When you contribute to Docker, you must certify you agree with the 
+When you contribute to Docker, you must certify you agree with the
 <a href="http://developercertificate.org/" target="_blank">Developer Certificate of Origin</a>.
 You indicate your agreement by signing your `git` commits like this:
 
@@ -104,7 +104,7 @@ To configure your username, email, and add a remote:
 
         $ git config --local user.email "emailname@mycompany.com"
 
-4. Set your local repo to track changes upstream, on the `docker` repository. 
+4. Set your local repo to track changes upstream, on the `docker` repository.
 
         $ git remote add upstream https://github.com/docker/docker.git
 
@@ -136,7 +136,7 @@ To configure your username, email, and add a remote:
 
 As you change code in your fork, make your changes on a repository branch.
 The branch name should reflect what you are working on. In this section, you
-create a branch, make a change, and push it up to your fork. 
+create a branch, make a change, and push it up to your fork.
 
 This branch is just for testing your config for this guide. The changes are part
 of a dry run, so the branch name will be dry-run-test. To create and push
@@ -159,12 +159,12 @@ the branch to your fork on GitHub:
           master
 
     The current branch has an * (asterisk) marker. So, these results shows you
-    are on the right branch. 
+    are on the right branch.
 
 4. Create a `TEST.md` file in the repository's root.
 
         $ touch TEST.md
-	
+
 5. Edit the file and add your email and location.
 
     ![Add your information](/project/images/contributor-edit.png)
@@ -173,15 +173,15 @@ the branch to your fork on GitHub:
 
 6. Close and save the file.
 
-7. Check the status of your branch. 
+7. Check the status of your branch.
 
         $ git status
         On branch dry-run-test
         Untracked files:
           (use "git add <file>..." to include in what will be committed)
-    
+
             TEST.md
-    
+
         nothing added to commit but untracked files present (use "git add" to track)
 
 	You've only changed the one file. It is untracked so far by git.
@@ -209,7 +209,7 @@ the branch to your fork on GitHub:
 
         $ git push --set-upstream origin dry-run-test
         Username for 'https://github.com': moxiegirl
-        Password for 'https://moxiegirl@github.com': 
+        Password for 'https://moxiegirl@github.com':
 
     Git prompts you for your GitHub username and password. Then, the command
     returns a result.

--- a/docs/sources/project/software-required.md
+++ b/docs/sources/project/software-required.md
@@ -1,6 +1,6 @@
 page_title: Get the required software
 page_description: Describes the software required to contribute to Docker
-page_keywords: GitHub account, repository, Docker, Git, Go, make, 
+page_keywords: GitHub account, repository, Docker, Git, Go, make,
 
 # Get the required software
 
@@ -8,7 +8,7 @@ Before you begin contributing you must have:
 
 *  a GitHub account
 * `git`
-* `make` 
+* `make`
 * `docker`
 
 You'll notice that `go`, the language that Docker is written in, is not listed.
@@ -22,14 +22,14 @@ href="https://github.com" target="_blank">GitHub account</a>. A free account is
 fine. All the Docker project repositories are public and visible to everyone.
 
 You should also have some experience using both the GitHub application and `git`
-on the command line. 
+on the command line.
 
 ### Install git
 
 Install `git` on your local system. You can check if `git` is on already on your
 system and properly installed with the following command:
 
-    $ git --version 
+    $ git --version
 
 
 This documentation is written using `git` version 2.2.2. Your version may be
@@ -40,17 +40,17 @@ different depending on your OS.
 Install `make`. You can check if `make` is on your system with the following
 command:
 
-    $ make -v 
+    $ make -v
 
 This documentation is written using GNU Make 3.81. Your version may be different
 depending on your OS.
 
-### Install or upgrade Docker 
+### Install or upgrade Docker
 
-If you haven't already, install the Docker software using the 
+If you haven't already, install the Docker software using the
 <a href="/installation" target="_blank">instructions for your operating system</a>.
 If you have an existing installation, check your version and make sure you have
-the latest Docker. 
+the latest Docker.
 
 To check if `docker` is already installed on Linux:
 

--- a/docs/sources/project/test-and-docs.md
+++ b/docs/sources/project/test-and-docs.md
@@ -27,7 +27,7 @@ this throughout the Docker repo. Use these files for inspiration when writing
 your own tests. For information on Go's test framework, see <a
 href="http://golang.org/pkg/testing/" target="_blank">Go's testing package
 documentation</a> and the <a href="http://golang.org/cmd/go/#hdr-Test_packages"
-target="_blank">go test help</a>. 
+target="_blank">go test help</a>.
 
 You are responsible for _unit testing_ your contribution when you add new or
 change existing Docker code. A unit test is a piece of code that invokes a
@@ -121,7 +121,7 @@ Run the entire test suite on your current repository:
         .................................................................
         ----------------------------------------------------------------------
         Ran 65 tests in 89.266s
- 
+
 
 ### Run test targets inside the development container
 
@@ -157,7 +157,7 @@ Most test targets require that you build these precursor targets first:
 `dynbinary binary cross`
 
 
-## Running individual or multiple named tests 
+## Running individual or multiple named tests
 
 You can use the `TESTFLAGS` environment variable to run a single test. The
 flag's value is passed as arguments to the `go test` command. For example, from

--- a/docs/sources/project/who-written-for.md
+++ b/docs/sources/project/who-written-for.md
@@ -2,7 +2,7 @@ page_title: README first
 page_description: Introduction to project contribution at Docker
 page_keywords: Gordon, introduction, turtle, machine, libcontainer, how to
 
-# README first 
+# README first
 
 This section of the documentation contains a guide for Docker users who want to
 contribute code or documentation to the Docker project. As a community, we

--- a/docs/sources/project/work-issue.md
+++ b/docs/sources/project/work-issue.md
@@ -7,7 +7,7 @@ page_keywords: contribute, pull request, review, workflow, beginner, squash, com
 
 The work you do for your issue depends on the specific issue you picked.
 This section gives you a step-by-step workflow. Where appropriate, it provides
-command examples. 
+command examples.
 
 However, this is a generalized workflow, depending on your issue you may repeat
 steps or even skip some. How much time the work takes depends on you --- you
@@ -21,14 +21,14 @@ Follow this workflow as you work:
 
     If you are changing code, review the <a href="../coding-style"
     target="_blank">coding style guide</a>. Changing documentation? Review the
-    <a href="../doc-style" target="_blank">documentation style guide</a>. 
-	
+    <a href="../doc-style" target="_blank">documentation style guide</a>.
+
 2. Make changes in your feature branch.
 
     Your feature branch you created in the last section. Here you use the
     development container. If you are making a code change, you can mount your
     source into a development container and iterate that way. For documentation
-    alone, you can work on your local host. 
+    alone, you can work on your local host.
 
     Make sure you don't change files in the `vendor` directory and its
     subdirectories; they contain third-party dependency code. Review <a
@@ -42,15 +42,15 @@ Follow this workflow as you work:
     runs the entire test suite and `make docs` builds the documentation. If you
     forgot the other test targets, see the documentation for <a
     href="../test-and-docs" target="_blank">testing both code and
-    documentation</a>.  
-	
+    documentation</a>.
+
 4. For code changes, add unit tests if appropriate.
 
     If you add new functionality or change existing functionality, you should
     add a unit test also. Use the existing test files for inspiration. Aren't
     sure if you need tests? Skip this step; you can add them later in the
     process if necessary.
-	
+
 5. Format your source files correctly.
 
     <table>
@@ -111,7 +111,7 @@ Follow this workflow as you work:
 
         $ git push origin
         Username for 'https://github.com': moxiegirl
-        Password for 'https://moxiegirl@github.com': 
+        Password for 'https://moxiegirl@github.com':
         Counting objects: 60, done.
         Compressing objects: 100% (7/7), done.
         Writing objects: 100% (7/7), 582 bytes | 0 bytes/s, done.
@@ -131,19 +131,19 @@ After you push a new branch, you should verify it on GitHub:
 3. Select your branch from the dropdown.
 
 	![Find branch](/project/images/locate_branch.png)
-	
+
 4. Use the "Compare" button to compare the differences between your branch and master.
 
 	 Depending how long you've been working on your branch, your branch maybe
-	 behind Docker's upstream repository. 
-	 
+	 behind Docker's upstream repository.
+
 5. Review the commits.
 
 	 Make sure your branch only shows the work you've done.
-	 
+
 ## Pull and rebase frequently
 
-You should pull and rebase frequently as you work.  
+You should pull and rebase frequently as you work.
 
 1. Return to the terminal on your local machine.
 
@@ -161,22 +161,22 @@ You should pull and rebase frequently as you work.
 4. Rebase your master with the local copy of Docker's `master` branch.
 
 		 $ git rebase -i upstream/master
-   
+
   	This command starts an interactive rebase to rewrite all the commits from
 	Docker's `upstream/master` onto your local branch, and then re-apply each of
 	your commits on top of the upstream changes. If you aren't familiar or
   	comfortable with rebase, you can <a
   	href="http://nathanleclaire.com/blog/2014/09/14/dont-be-scared-of-git-
   	rebase" target="_blank">learn more about rebasing</a> on the web.
-  
+
 5. Rebase opens an editor with a list of commits.
 
-			pick 1a79f55 Tweak some of the other text for grammar 
-			pick 53e4983 Fix a link 
+			pick 1a79f55 Tweak some of the other text for grammar
+			pick 53e4983 Fix a link
 			pick 3ce07bb Add a new line about RHEL
-        
+
   	If you run into trouble, `git --rebase abort` removes any changes and gets
-  	you back to where you started. 
+  	you back to where you started.
 
 6. Squash the `pick` keyword with `squash` on all but the first commit.
 
@@ -185,7 +185,7 @@ You should pull and rebase frequently as you work.
 			squash 3ce07bb Add a new line about RHEL
 
   	After closing the file, `git` opens your editor again to edit the commit
-  	message. 
+  	message.
 
 7. Edit the commit message to reflect the entire change.
 

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -10,7 +10,7 @@ page_keywords: API, Docker, rcli, REST, documentation
    or `--tlsverify`) as with Boot2Docker 1.3.0, then you need to add extra
    parameters to `curl` or `wget` when making test API requests:
    `curl --insecure --cert ~/.docker/cert.pem --key ~/.docker/key.pem https://boot2docker:2376/images/json`
-   or 
+   or
    `wget --no-check-certificate --certificate=$DOCKER_CERT_PATH/cert.pem --private-key=$DOCKER_CERT_PATH/key.pem https://boot2docker:2376/images/json -O - -q`
  - If a group named `docker` exists on your system, docker will apply
    ownership of the socket to the group.
@@ -25,7 +25,7 @@ page_keywords: API, Docker, rcli, REST, documentation
    "serveraddress" : "string", "auth": ""}`. Notice that `auth` is to be left
    empty, `serveraddress` is a domain/ip without protocol, and that double
    quotes (instead of single ones) are required.
- - The Remote API uses an open schema model.  In this model, unknown 
+ - The Remote API uses an open schema model.  In this model, unknown
    properties in incoming messages will be ignored.
    Client applications need to take this into account to ensure
    they will not break when talking to newer Docker daemons.
@@ -234,7 +234,7 @@ the `tag` parameter at the same time will return an error.
 The `HostConfig.Links` field is now filled correctly
 
 **New!**
-`Sockets` parameter added to the `/info` endpoint listing all the sockets the 
+`Sockets` parameter added to the `/info` endpoint listing all the sockets the
 daemon is configured to listen on.
 
 `POST /containers/(name)/start`
@@ -562,7 +562,7 @@ Builder (/build):
    intermediary buffers
  - Simpler, less memory usage, less disk usage and faster
 
-> **Warning**: 
+> **Warning**:
 > The /build improvements are not reverse-compatible. Pre 1.3 clients will
 > break on /build.
 

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -1971,4 +1971,4 @@ This might change in the future.
 To set cross origin requests to the remote api, please add flag "--api-enable-cors"
 when running docker in daemon mode.
 
-    $ docker -d -H="192.168.1.9:2375" --api-enable-cors 
+    $ docker -d -H="192.168.1.9:2375" --api-enable-cors

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -1149,12 +1149,12 @@ or being killed.
 
 Query Parameters:
 
--   **dockerfile** - path within the build context to the Dockerfile. This is 
+-   **dockerfile** - path within the build context to the Dockerfile. This is
         ignored if `remote` is specified and points to an individual filename.
 -   **t** – repository name (and optionally a tag) to be applied to
         the resulting image in case of success
--   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the 
-        URI specifies a filename, the file's contents are placed into a file 
+-   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
+        URI specifies a filename, the file's contents are placed into a file
 		called `Dockerfile`.
 -   **q** – suppress verbose build output
 -   **nocache** – do not use the cache when building the image
@@ -2058,7 +2058,7 @@ This might change in the future.
 
 ## 3.3 CORS Requests
 
-To set cross origin requests to the remote api please give values to 
+To set cross origin requests to the remote api please give values to
 "--api-cors-header" when running docker in daemon mode. Set * will allow all,
 default or blank means CORS disabled
 

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -1149,12 +1149,12 @@ or being killed.
 
 Query Parameters:
 
--   **dockerfile** - path within the build context to the Dockerfile. This is 
+-   **dockerfile** - path within the build context to the Dockerfile. This is
         ignored if `remote` is specified and points to an individual filename.
 -   **t** – repository name (and optionally a tag) to be applied to
         the resulting image in case of success
--   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the 
-        URI specifies a filename, the file's contents are placed into a file 
+-   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the
+        URI specifies a filename, the file's contents are placed into a file
 		called `Dockerfile`.
 -   **q** – suppress verbose build output
 -   **nocache** – do not use the cache when building the image
@@ -2058,7 +2058,7 @@ This might change in the future.
 
 ## 3.3 CORS Requests
 
-To set cross origin requests to the remote api please give values to 
+To set cross origin requests to the remote api please give values to
 "--api-cors-header" when running docker in daemon mode. Set * will allow all,
 default or blank means CORS disabled
 

--- a/docs/sources/reference/api/registry_api_client_libraries.md
+++ b/docs/sources/reference/api/registry_api_client_libraries.md
@@ -7,7 +7,7 @@ page_keywords: API, Docker, index, registry, REST, documentation, clients, C#, E
 These libraries have not been tested by the Docker maintainers for
 compatibility. Please file issues with the library owners. If you find
 more library implementations, please submit a PR with an update to this page
-or open an issue in the [Docker](https://github.com/docker/docker/issues) 
+or open an issue in the [Docker](https://github.com/docker/docker/issues)
 project and we will add the libraries here.
 
 

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -34,7 +34,7 @@ whole context must be transferred to the daemon. The Docker CLI reports
 "Sending build context to Docker daemon" when the context is sent to the daemon.
 
 > **Warning**
-> Avoid using your root directory, `/`, as the root of the source repository. The 
+> Avoid using your root directory, `/`, as the root of the source repository. The
 > `docker build` command will use whatever directory contains the Dockerfile as the build
 > context (including all of its subdirectories). The build context will be sent to the
 > Docker daemon before building the image, which means if you use `/` as the source
@@ -165,7 +165,7 @@ throughout the entire command.  In other words, in this example:
     ENV abc=bye def=$abc
     ENV ghi=$abc
 
-will result in `def` having a value of `hello`, not `bye`.  However, 
+will result in `def` having a value of `hello`, not `bye`.  However,
 `ghi` will have a value of `bye` because it is not part of the same command
 that set `abc` to `bye`.
 
@@ -180,7 +180,7 @@ that will be excluded from the context. Globbing is done using Go's
 > **Note**:
 > The `.dockerignore` file can even be used to ignore the `Dockerfile` and
 > `.dockerignore` files. This might be useful if you are copying files from
-> the root of the build context into your new containter but do not want to 
+> the root of the build context into your new containter but do not want to
 > include the `Dockerfile` or `.dockerignore` files (e.g. `ADD . /someDir/`).
 
 The following example shows the use of the `.dockerignore` file to exclude the
@@ -273,13 +273,13 @@ commands using a base image that does not contain `/bin/sh`.
 > Unlike the *shell* form, the *exec* form does not invoke a command shell.
 > This means that normal shell processing does not happen. For example,
 > `RUN [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
-> If you want shell processing then either use the *shell* form or execute 
+> If you want shell processing then either use the *shell* form or execute
 > a shell directly, for example: `RUN [ "sh", "-c", "echo", "$HOME" ]`.
 
 The cache for `RUN` instructions isn't invalidated automatically during
-the next build. The cache for an instruction like 
-`RUN apt-get dist-upgrade -y` will be reused during the next build.  The 
-cache for `RUN` instructions can be invalidated by using the `--no-cache` 
+the next build. The cache for an instruction like
+`RUN apt-get dist-upgrade -y` will be reused during the next build.  The
+cache for `RUN` instructions can be invalidated by using the `--no-cache`
 flag, for example `docker build --no-cache`.
 
 See the [`Dockerfile` Best Practices
@@ -318,8 +318,8 @@ the executable, in which case you must specify an `ENTRYPOINT`
 instruction as well.
 
 > **Note**:
-> If `CMD` is used to provide default arguments for the `ENTRYPOINT` 
-> instruction, both the `CMD` and `ENTRYPOINT` instructions should be specified 
+> If `CMD` is used to provide default arguments for the `ENTRYPOINT`
+> instruction, both the `CMD` and `ENTRYPOINT` instructions should be specified
 > with the JSON array format.
 
 > **Note**:
@@ -330,7 +330,7 @@ instruction as well.
 > Unlike the *shell* form, the *exec* form does not invoke a command shell.
 > This means that normal shell processing does not happen. For example,
 > `CMD [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
-> If you want shell processing then either use the *shell* form or execute 
+> If you want shell processing then either use the *shell* form or execute
 > a shell directly, for example: `CMD [ "sh", "-c", "echo", "$HOME" ]`.
 
 When used in the shell or exec formats, the `CMD` instruction sets the command
@@ -384,11 +384,11 @@ key-value pair by an EOL.
 Docker recommends combining labels in a single `LABEL` instruction where
 possible. Each `LABEL` instruction produces a new layer which can result in an
 inefficient image if you use many labels. This example results in four image
-layers. 
-    
+layers.
+
 Labels are additive including `LABEL`s in `FROM` images. As the system
 encounters and then applies a new label, new `key`s override any previous labels
-with identical keys.    
+with identical keys.
 
 To view an image's labels, use the `docker inspect` command.
 
@@ -419,12 +419,12 @@ commands and can be [replaced inline](#environment-replacement) in many as well.
 
 The `ENV` instruction has two forms. The first form, `ENV <key> <value>`,
 will set a single variable to a value. The entire string after the first
-space will be treated as the `<value>` - including characters such as 
+space will be treated as the `<value>` - including characters such as
 spaces and quotes.
 
-The second form, `ENV <key>=<value> ...`, allows for multiple variables to 
-be set at one time. Notice that the second form uses the equals sign (=) 
-in the syntax, while the first form does not. Like command line parsing, 
+The second form, `ENV <key>=<value> ...`, allows for multiple variables to
+be set at one time. Notice that the second form uses the equals sign (=)
+in the syntax, while the first form does not. Like command line parsing,
 quotes and backslashes can be used to include spaces within values.
 
 For example:
@@ -438,7 +438,7 @@ and
     ENV myDog Rex The Dog
     ENV myCat fluffy
 
-will yield the same net results in the final container, but the first form 
+will yield the same net results in the final container, but the first form
 does it all in one layer.
 
 The environment variables set using `ENV` will persist when a container is run
@@ -460,10 +460,10 @@ ADD has two forms:
 whitespace)
 
 The `ADD` instruction copies new files, directories or remote file URLs from `<src>`
-and adds them to the filesystem of the container at the path `<dest>`.  
+and adds them to the filesystem of the container at the path `<dest>`.
 
-Multiple `<src>` resource may be specified but if they are files or 
-directories then they must be relative to the source directory that is 
+Multiple `<src>` resource may be specified but if they are files or
+directories then they must be relative to the source directory that is
 being built (the context of the build).
 
 Each `<src>` may contain wildcards and matching will be done using Go's
@@ -526,8 +526,8 @@ The copy obeys the following rules:
   appropriate filename can be discovered in this case (`http://example.com`
   will not work).
 
-- If `<src>` is a directory, the entire contents of the directory are copied, 
-  including filesystem metadata. 
+- If `<src>` is a directory, the entire contents of the directory are copied,
+  including filesystem metadata.
 > **Note**:
 > The directory itself is not copied, just its contents.
 
@@ -546,7 +546,7 @@ The copy obeys the following rules:
   at `<dest>/base(<src>)`.
 
 - If multiple `<src>` resources are specified, either directly or due to the
-  use of a wildcard, then `<dest>` must be a directory, and it must end with 
+  use of a wildcard, then `<dest>` must be a directory, and it must end with
   a slash `/`.
 
 - If `<dest>` does not end with a trailing slash, it will be considered a
@@ -594,8 +594,8 @@ The copy obeys the following rules:
   `docker build` is to send the context directory (and subdirectories) to the
   docker daemon.
 
-- If `<src>` is a directory, the entire contents of the directory are copied, 
-  including filesystem metadata. 
+- If `<src>` is a directory, the entire contents of the directory are copied,
+  including filesystem metadata.
 > **Note**:
 > The directory itself is not copied, just its contents.
 
@@ -605,7 +605,7 @@ The copy obeys the following rules:
   at `<dest>/base(<src>)`.
 
 - If multiple `<src>` resources are specified, either directly or due to the
-  use of a wildcard, then `<dest>` must be a directory, and it must end with 
+  use of a wildcard, then `<dest>` must be a directory, and it must end with
   a slash `/`.
 
 - If `<dest>` does not end with a trailing slash, it will be considered a
@@ -634,7 +634,7 @@ Command line arguments to `docker run <image>` will be appended after all
 elements in an *exec* form `ENTRYPOINT`, and will override all elements specified
 using `CMD`.
 This allows arguments to be passed to the entry point, i.e., `docker run <image> -d`
-will pass the `-d` argument to the entry point. 
+will pass the `-d` argument to the entry point.
 You can override the `ENTRYPOINT` instruction using the `docker run --entrypoint`
 flag.
 
@@ -665,10 +665,10 @@ When you run the container, you can see that `top` is the only process:
     %Cpu(s):  0.1 us,  0.1 sy,  0.0 ni, 99.7 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
     KiB Mem:   2056668 total,  1616832 used,   439836 free,    99352 buffers
     KiB Swap:  1441840 total,        0 used,  1441840 free.  1324440 cached Mem
-    
+
       PID USER      PR  NI    VIRT    RES    SHR S %CPU %MEM     TIME+ COMMAND
         1 root      20   0   19744   2336   2080 R  0.0  0.1   0:00.04 top
-    
+
 To examine the result further, you can use `docker exec`:
 
     $ docker exec -it test ps aux
@@ -772,7 +772,7 @@ sys	0m 0.03s
 > Unlike the *shell* form, the *exec* form does not invoke a command shell.
 > This means that normal shell processing does not happen. For example,
 > `ENTRYPOINT [ "echo", "$HOME" ]` will not do variable substitution on `$HOME`.
-> If you want shell processing then either use the *shell* form or execute 
+> If you want shell processing then either use the *shell* form or execute
 > a shell directly, for example: `ENTRYPOINT [ "sh", "-c", "echo", "$HOME" ]`.
 > Variables that are defined in the `Dockerfile`using `ENV`, will be substituted by
 > the `Dockerfile` parser.
@@ -846,12 +846,12 @@ and marks it as holding externally mounted volumes from native host or other
 containers. The value can be a JSON array, `VOLUME ["/var/log/"]`, or a plain
 string with multiple arguments, such as `VOLUME /var/log` or `VOLUME /var/log
 /var/db`.  For more information/examples and mounting instructions via the
-Docker client, refer to 
+Docker client, refer to
 [*Share Directories via Volumes*](/userguide/dockervolumes/#volume)
 documentation.
 
-The `docker run` command initializes the newly created volume with any data 
-that exists at the specified location within the base image. For example, 
+The `docker run` command initializes the newly created volume with any data
+that exists at the specified location within the base image. For example,
 consider the following Dockerfile snippet:
 
     FROM ubuntu
@@ -860,7 +860,7 @@ consider the following Dockerfile snippet:
     VOLUME /myvol
 
 This Dockerfile results in an image that causes `docker run`, to
-create a new mount point at `/myvol` and copy the  `greating` file 
+create a new mount point at `/myvol` and copy the  `greating` file
 into the newly created volume.
 
 > **Note**:

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -37,7 +37,7 @@ settings affect:
  * network settings
  * runtime constraints on CPU and memory
  * privileges and LXC configuration
- 
+
 An image developer may set defaults for these same settings when they create the
 image using the `docker build` command. Operators, however, can override all
 defaults set by the developer using the `run` options.  And, operators can also
@@ -180,12 +180,12 @@ the host.
 
 By default, all containers have the IPC namespace enabled.
 
-IPC (POSIX/SysV IPC) namespace provides separation of named shared memory 
+IPC (POSIX/SysV IPC) namespace provides separation of named shared memory
 segments, semaphores and message queues.
 
 Shared memory segments are used to accelerate inter-process communication at
 memory speed, rather than through pipes or through the network stack. Shared
-memory is commonly used by databases and custom-built (typically C/OpenMPI, 
+memory is commonly used by databases and custom-built (typically C/OpenMPI,
 C++/using boost libraries) high performance applications for scientific
 computing and financial services industries. If these types of applications
 are broken into multiple containers, you might need to share the IPC mechanisms
@@ -307,7 +307,7 @@ running the `redis-cli` command and connecting to the Redis server over the
 
 Your container will have lines in `/etc/hosts` which define the hostname of the
 container itself as well as `localhost` and a few other common things.  The
-`--add-host` flag can be used to add additional lines to `/etc/hosts`.  
+`--add-host` flag can be used to add additional lines to `/etc/hosts`.
 
     $ docker run -it --add-host db-static:86.75.30.9 ubuntu cat /etc/hosts
     172.17.0.22     09d03f76bf2c
@@ -342,7 +342,7 @@ Docker supports the following restart policies:
     <tr>
       <td><strong>no</strong></td>
       <td>
-        Do not automatically restart the container when it exits. This is the 
+        Do not automatically restart the container when it exits. This is the
         default.
       </td>
     </tr>
@@ -354,7 +354,7 @@ Docker supports the following restart policies:
       </td>
       <td>
         Restart only if the container exits with a non-zero exit status.
-        Optionally, limit the number of restart retries the Docker 
+        Optionally, limit the number of restart retries the Docker
         daemon attempts.
       </td>
     </tr>
@@ -393,7 +393,7 @@ Or, to get the last time the container was (re)started;
     $ docker inspect -f "{{ .State.StartedAt }}" my-container
     # 2015-03-04T23:47:07.691840179Z
 
-You cannot set any restart policy in combination with 
+You cannot set any restart policy in combination with
 ["clean up (--rm)"](#clean-up-rm). Setting both `--restart` and `--rm`
 results in an error.
 
@@ -406,7 +406,7 @@ so that if the container exits, Docker will restart it.
 
     $ docker run --restart=on-failure:10 redis
 
-This will run the `redis` container with a restart policy of **on-failure** 
+This will run the `redis` container with a restart policy of **on-failure**
 and a maximum restart count of 10.  If the `redis` container exits with a
 non-zero exit status more than 10 times in a row Docker will abort trying to
 restart the container. Providing a maximum restart limit is only valid for the
@@ -430,7 +430,7 @@ the container exits**, you can add the `--rm` flag:
     --security-opt="label:type:TYPE"   : Set the label type for the container
     --security-opt="label:level:LEVEL" : Set the label level for the container
     --security-opt="label:disable"     : Turn off label confinement for the container
-    --security-opt="apparmor:PROFILE"  : Set the apparmor profile to be applied 
+    --security-opt="apparmor:PROFILE"  : Set the apparmor profile to be applied
                                          to the container
 
 You can override the default labeling scheme for each container by specifying
@@ -826,9 +826,9 @@ or override the Dockerfile's exposed defaults:
     --expose=[]: Expose a port or a range of ports from the container
                 without publishing it to your host
     -P=false   : Publish all exposed ports to the host interfaces
-    -p=[]      : Publish a container᾿s port or a range of ports to the host 
+    -p=[]      : Publish a container᾿s port or a range of ports to the host
                    format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
-                   Both hostPort and containerPort can be specified as a range of ports. 
+                   Both hostPort and containerPort can be specified as a range of ports.
                    When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range. (e.g., `-p 1234-1236:1234-1236/tcp`)
                    (use 'docker port' to see the actual mapping)
     --link=""  : Add link to another container (<name or id>:alias)
@@ -876,13 +876,13 @@ variables automatically:
  </tr>
  <tr>
   <td><code>HOSTNAME</code></td>
-  <td> 
+  <td>
     The hostname associated with the container
   </td>
  </tr>
  <tr>
   <td><code>PATH</code></td>
-  <td> 
+  <td>
     Includes popular directories, such as :<br>
     <code>/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin</code>
   </td>
@@ -897,8 +897,8 @@ as a result of the container being linked with another container. See
 the [*Container Links*](/userguide/dockerlinks/#container-linking)
 section for more details.
 
-Additionally, the operator can **set any environment variable** in the 
-container by using one or more `-e` flags, even overriding those mentioned 
+Additionally, the operator can **set any environment variable** in the
+container by using one or more `-e` flags, even overriding those mentioned
 above, or already defined by the developer with a Dockerfile `ENV`:
 
     $ docker run -e "deep=purple" --rm ubuntu /bin/bash -c export
@@ -978,7 +978,7 @@ container's `/etc/hosts` entry will be automatically updated.
     --volumes-from="": Mount all volumes from the given container(s)
 
 The volumes commands are complex enough to have their own documentation
-in section [*Managing data in 
+in section [*Managing data in
 containers*](/userguide/dockervolumes). A developer can define
 one or more `VOLUME`'s associated with an image, but only the operator
 can give access from one container to another (or from a container to a

--- a/docs/sources/userguide/dockerimages.md
+++ b/docs/sources/userguide/dockerimages.md
@@ -72,7 +72,7 @@ If instead we wanted to run an Ubuntu 12.04 image we'd use:
 If you don't specify a variant, for example you just use `ubuntu`, then Docker
 will default to using the `ubuntu:latest` image.
 
-> **Tip:** 
+> **Tip:**
 > We recommend you always use a specific tagged image, for example
 > `ubuntu:12.04`. That way you always know exactly what variant of an image is
 > being used.
@@ -177,7 +177,7 @@ we'd like to update.
     $ docker run -t -i training/sinatra /bin/bash
     root@0b2616b0e5a8:/#
 
-> **Note:** 
+> **Note:**
 > Take note of the container ID that has been created, `0b2616b0e5a8`, as we'll
 > need it in a moment.
 
@@ -271,14 +271,14 @@ a command inside the image, for example installing a package. Here we're
 updating our APT cache, installing Ruby and RubyGems and then installing the
 Sinatra gem.
 
-> **Note:** 
+> **Note:**
 > There are [a lot more instructions available to us in a Dockerfile](/reference/builder).
 
 Now let's take our `Dockerfile` and use the `docker build` command to build an image.
 
     $ docker build -t ouruser/sinatra:v2 .
     Sending build context to Docker daemon 2.048 kB
-    Sending build context to Docker daemon 
+    Sending build context to Docker daemon
     Step 0 : FROM ubuntu:14.04
      ---> e54ca5efa2e9
     Step 1 : MAINTAINER Kate Smith <ksmith@example.com>
@@ -463,9 +463,9 @@ instructions have executed we're left with the `97feabe5d2ed` image
 (also helpfully tagged as `ouruser/sinatra:v2`) and all intermediate
 containers will get removed to clean things up.
 
-> **Note:** 
+> **Note:**
 > An image can't have more than 127 layers regardless of the storage driver.
-> This limitation is set globally to encourage optimization of the overall 
+> This limitation is set globally to encourage optimization of the overall
 > size of images.
 
 We can then create a container from our new image.
@@ -473,7 +473,7 @@ We can then create a container from our new image.
     $ docker run -t -i ouruser/sinatra:v2 /bin/bash
     root@8196968dac35:/#
 
-> **Note:** 
+> **Note:**
 > This is just a brief introduction to creating images. We've
 > skipped a whole bunch of other instructions that you can use. We'll see more of
 > those instructions in later sections of the Guide or you can refer to the

--- a/docs/sources/userguide/dockerizing.md
+++ b/docs/sources/userguide/dockerizing.md
@@ -123,7 +123,7 @@ a really long string:
 This really long string is called a *container ID*. It uniquely
 identifies a container so we can work with it.
 
-> **Note:** 
+> **Note:**
 > The container ID is a bit long and unwieldy and a bit later
 > on we'll see a shorter ID and some ways to name our containers to make
 > working with them easier.
@@ -145,9 +145,9 @@ information about it, starting with a shorter variant of its container ID:
 
 We can also see the image we used to build it, `ubuntu:14.04`, the command it
 is running, its status and an automatically assigned name,
-`insane_babbage`. 
+`insane_babbage`.
 
-> **Note:** 
+> **Note:**
 > Docker automatically names any containers you start, a
 > little later on we'll see how you can specify your own names.
 

--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -18,7 +18,7 @@ container that ran a Python Flask application:
 
     $ docker run -d -P training/webapp python app.py
 
-> **Note:** 
+> **Note:**
 > Containers have an internal network and an IP address
 > (as we saw when we used the `docker inspect` command to show the container's
 > IP address in the [Using Docker](/userguide/usingdocker/) section).
@@ -35,7 +35,7 @@ range* on your Docker host. Next, when `docker ps` was run, you saw that port
     bc533791f3f5  training/webapp:latest  python app.py 5 seconds ago  Up 2 seconds  0.0.0.0:49155->5000/tcp  nostalgic_morse
 
 You also saw how you can bind a container's ports to a specific port using
-the `-p` flag. Here port 80 of the host is mapped to port 5000 of the 
+the `-p` flag. Here port 80 of the host is mapped to port 5000 of the
 container:
 
     $ docker run -d -p 80:5000 training/webapp python app.py
@@ -70,7 +70,7 @@ configurations. For example, if you've bound the container port to the
     $ docker port nostalgic_morse 5000
     127.0.0.1:49155
 
-> **Note:** 
+> **Note:**
 > The `-p` flag can be used multiple times to configure multiple ports.
 
 ## Connect with the linking system
@@ -114,7 +114,7 @@ You can also use `docker inspect` to return the container's name.
     $ docker inspect -f "{{ .Name }}" aed84ee21bde
     /web
 
-> **Note:** 
+> **Note:**
 > Container names have to be unique. That means you can only call
 > one container `web`. If you want to re-use a container name you must delete
 > the old container (with `docker rm`) before you can create a new
@@ -179,7 +179,7 @@ recipient container in two ways:
 
 Docker creates several environment variables when you link containers. Docker
 automatically creates environment variables in the target container based on
-the `--link` parameters.  It will also expose all environment variables 
+the `--link` parameters.  It will also expose all environment variables
 originating from Docker from the source container. These include variables from:
 
 * the `ENV` commands in the source container's Dockerfile
@@ -232,8 +232,8 @@ that port is used for both tcp and udp, then the tcp one is specified.
 
 Finally, Docker also exposes each Docker originated environment variable
 from the source container as an environment variable in the target. For each
-variable Docker creates an `<alias>_ENV_<name>` variable in the target 
-container. The variable's value is set to the value Docker used when it 
+variable Docker creates an `<alias>_ENV_<name>` variable in the target
+container. The variable's value is set to the value Docker used when it
 started the source container.
 
 Returning back to our database example, you can run the `env`
@@ -285,7 +285,7 @@ container:
 
 You can see two relevant host entries. The first is an entry for the `web`
 container that uses the Container ID as a host name. The second entry uses the
-link alias to reference the IP address of the `db` container. In addition to 
+link alias to reference the IP address of the `db` container. In addition to
 the alias you provide, the linked container's name--if unique from the alias
 provided to the `--link` parameter--and the linked container's hostname will
 also be added in `/etc/hosts` for the linked container's IP address. You can ping
@@ -298,7 +298,7 @@ that host now via any of these entries:
     56 bytes from 172.17.0.5: icmp_seq=1 ttl=64 time=0.250 ms
     56 bytes from 172.17.0.5: icmp_seq=2 ttl=64 time=0.256 ms
 
-> **Note:** 
+> **Note:**
 > In the example, you'll note you had to install `ping` because it was not included
 > in the container initially.
 
@@ -306,7 +306,7 @@ Here, you used the `ping` command to ping the `db` container using its host entr
 which resolves to `172.17.0.5`. You can use this host entry to configure an application
 to make use of your `db` container.
 
-> **Note:** 
+> **Note:**
 > You can link multiple recipient containers to a single source. For
 > example, you could have multiple (differently named) web containers attached to your
 >`db` container.

--- a/docs/sources/userguide/dockervolumes.md
+++ b/docs/sources/userguide/dockervolumes.md
@@ -21,20 +21,20 @@ Docker.
 
 A *data volume* is a specially-designated directory within one or more
 containers that bypasses the [*Union File
-System*](/terms/layer/#union-file-system). Data volumes provide several 
+System*](/terms/layer/#union-file-system). Data volumes provide several
 useful features for persistent or shared data:
 
 - Volumes are initialized when a container is created. If the container's
-  base image contains data at the specified mount point, that data is 
+  base image contains data at the specified mount point, that data is
   copied into the new volume.
 - Data volumes can be shared and reused among containers.
 - Changes to a data volume are made directly.
 - Changes to a data volume will not be included when you update an image.
 - Data volumes persist even if the container itself is deleted.
 
-Data volumes are designed to persist data, independent of the container's life 
-cycle. Docker therefore *never* automatically delete volumes when you remove 
-a container, nor will it "garbage collect" volumes that are no longer 
+Data volumes are designed to persist data, independent of the container's life
+cycle. Docker therefore *never* automatically delete volumes when you remove
+a container, nor will it "garbage collect" volumes that are no longer
 referenced by a container.
 
 ### Adding a data volume
@@ -48,7 +48,7 @@ application container.
 
 This will create a new volume inside a container at `/webapp`.
 
-> **Note:** 
+> **Note:**
 > You can also use the `VOLUME` instruction in a `Dockerfile` to add one or
 > more new volumes to any container created from that image.
 
@@ -70,7 +70,7 @@ volumes. The output should look something similar to the following:
     }
     ...
 
-You will notice in the above 'Volumes' is specifying the location on the host and 
+You will notice in the above 'Volumes' is specifying the location on the host and
 'VolumesRW' is specifying that the volume is read/write.
 
 ### Mount a Host Directory as a Data Volume
@@ -102,7 +102,7 @@ we change the source code. The directory on the host must be specified as an
 absolute path and if the directory doesn't exist Docker will automatically
 create it for you.
 
-> **Note:** 
+> **Note:**
 > This is not available from a `Dockerfile` due to the portability
 > and sharing purpose of built images. The host directory is, by its nature,
 > host-dependent, so a host directory specified in a `Dockerfile` probably
@@ -118,20 +118,20 @@ option to specify that the mount should be read-only.
 
 ### Mount a Host File as a Data Volume
 
-The `-v` flag can also be used to mount a single file  - instead of *just* 
+The `-v` flag can also be used to mount a single file  - instead of *just*
 directories - from the host machine.
 
     $ docker run --rm -it -v ~/.bash_history:/.bash_history ubuntu /bin/bash
 
-This will drop you into a bash shell in a new container, you will have your bash 
-history from the host and when you exit the container, the host will have the 
+This will drop you into a bash shell in a new container, you will have your bash
+history from the host and when you exit the container, the host will have the
 history of the commands typed while in the container.
 
-> **Note:** 
-> Many tools used to edit files including `vi` and `sed --in-place` may result 
+> **Note:**
+> Many tools used to edit files including `vi` and `sed --in-place` may result
 > in an inode change. Since Docker v1.1.0, this will produce an error such as
-> "*sed: cannot rename ./sedKdJ9Dy: Device or resource busy*". In the case where 
-> you want to edit the mounted file, it is often easiest to instead mount the 
+> "*sed: cannot rename ./sedKdJ9Dy: Device or resource busy*". In the case where
+> you want to edit the mounted file, it is often easiest to instead mount the
 > parent directory.
 
 ## Creating and mounting a Data Volume Container
@@ -174,9 +174,9 @@ be deleted.  To delete the volume from disk, you must explicitly call
 `docker rm -v` against the last container with a reference to the volume. This
 allows you to upgrade, or effectively migrate data volumes between containers.
 
-> **Note:** Docker will not warn you when removing a container *without* 
+> **Note:** Docker will not warn you when removing a container *without*
 > providing the `-v` option to delete its volumes. If you remove containers
-> without using the `-v` option, you may end up with "dangling" volumes; 
+> without using the `-v` option, you may end up with "dangling" volumes;
 > volumes that are no longer referenced by a container.
 > Dangling volumes are difficult to get rid of and can take up a large amount
 > of disk space. We're working on improving volume management and you can check

--- a/docs/sources/userguide/labels-custom-metadata.md
+++ b/docs/sources/userguide/labels-custom-metadata.md
@@ -114,7 +114,7 @@ Wrapping is allowed by using a backslash (`\`) as continuation marker:
 
 Docker recommends you add multiple labels in a single `LABEL` instruction. Using
 individual instructions for each label can result in an inefficient image. This
-is because each `LABEL` instruction in a Dockerfile produces a new IMAGE layer. 
+is because each `LABEL` instruction in a Dockerfile produces a new IMAGE layer.
 
 You can view the labels via the `docker inspect` command:
 

--- a/docs/sources/userguide/level2.md
+++ b/docs/sources/userguide/level2.md
@@ -36,7 +36,7 @@ What is the Dockerfile instruction to specify the base image?<br>
 	<input type="text" class="level">
 	<div style="display:none;" id="level2_error7" class="alert alert-error level_error">The right answer was <code>ENTRYPOINT</code> or <code>CMD</code></div><br>
 	<p>
-	
+
 	<div class="alert alert-success" id="all_good" style="display:none;">Congratulations, you made no mistake!<br />
 	Tell the world <a href="https://twitter.com/share" class="twitter-share-button" data-url="http://www.docker.io/learn/dockerfile/level1/" data-text="I just successfully answered questions of the #Dockerfile tutorial Level 1. What's your score?" data-via="docker" >Tweet</a><br />
 	And try the next challenge: <a href="#fill-the-dockerfile">Fill the Dockerfile</a>
@@ -86,10 +86,10 @@ RUN apt-get install -y <input id="gcc" class="l_fill" type="text"><br>
 <br>
 <button class="btn btn-primary" id="check_level2_fill">Check the Dockerfile</button></p>
 </div>
-    
+
 ## What's next?
 <p>
-Thanks for going through our tutorial! We will be posting Level 3 in the future. 
+Thanks for going through our tutorial! We will be posting Level 3 in the future.
 
 To improve your Dockerfile writing skills even further, visit the <a href="https://docs.docker.com/articles/dockerfile_best-practices/">Dockerfile best practices page</a>.
 

--- a/docs/sources/userguide/usingdocker.md
+++ b/docs/sources/userguide/usingdocker.md
@@ -87,7 +87,7 @@ This will display the help text and all available flags:
       --no-stdin=false: Do not attach stdin
       --sig-proxy=true: Proxify all received signal to the process (non-TTY mode only)
 
-> **Note:** 
+> **Note:**
 > You can see a full list of Docker's commands
 > [here](/reference/commandline/cli/).
 
@@ -116,7 +116,7 @@ application.
 
 Lastly, we've specified a command for our container to run: `python app.py`. This launches our web application.
 
-> **Note:** 
+> **Note:**
 > You can see more detail on the `docker run` command in the [command
 > reference](/reference/commandline/cli/#run) and the [Docker Run
 > Reference](/reference/run/).
@@ -133,7 +133,7 @@ You can see we've specified a new flag, `-l`, for the `docker ps`
 command. This tells the `docker ps` command to return the details of the
 *last* container started.
 
-> **Note:** 
+> **Note:**
 > By default, the `docker ps` command only shows information about running
 > containers. If you want to see stopped containers too use the `-a` flag.
 
@@ -147,7 +147,7 @@ column.
 When we passed the `-P` flag to the `docker run` command Docker mapped any
 ports exposed in our image to our host.
 
-> **Note:** 
+> **Note:**
 > We'll learn more about how to expose ports in Docker images when
 > [we learn how to build images](/userguide/dockerimages).
 
@@ -181,12 +181,13 @@ Our Python application is live!
 > **Note:**
 > If you have used the `boot2docker` virtual machine on OS X, Windows or Linux,
 > you'll need to get the IP of the virtual host instead of using localhost.
+
 > You can do this by running the following outside of the `boot2docker` shell
 > (i.e., from your comment line or terminal application).
-> 
+>
 >     $ boot2docker ip
 >     The VM's Host only interface IP address is: 192.168.59.103
-> 
+>
 > In this case you'd browse to http://192.168.59.103:49155 for the above example.
 
 ## A Network Port Shortcut
@@ -285,7 +286,7 @@ Now quickly run `docker ps -l` again to see the running container is
 back up or browse to the container's URL to see if the application
 responds.
 
-> **Note:** 
+> **Note:**
 > Also available is the `docker restart` command that runs a stop and
 > then start on the container.
 


### PR DESCRIPTION
Cleanup .md files by removing all trailing whitespaces.

Maybe this can be enforced in the future by a jenkins build test. ping @jfrazelle as I see her name in all Jenkins builds

Signed-off-by: Ankush Agarwal ankushagarwal11@gmail.com
