### PR TITLE
api/server: fix profiler HTTP serving

### DIFF
--- a/api/server/profiler.go
+++ b/api/server/profiler.go
@@ -9,12 +9,9 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func NewProfiler() http.Handler {
-	var (
-		p = &Profiler{}
-		r = mux.NewRouter()
-	)
-	r.HandleFunc("/vars", p.expVars)
+func ProfilerSetup(mainRouter *mux.Router, path string) {
+	var r = mainRouter.PathPrefix(path).Subrouter()
+	r.HandleFunc("/vars", expVars)
 	r.HandleFunc("/pprof/", pprof.Index)
 	r.HandleFunc("/pprof/cmdline", pprof.Cmdline)
 	r.HandleFunc("/pprof/profile", pprof.Profile)
@@ -23,21 +20,10 @@ func NewProfiler() http.Handler {
 	r.HandleFunc("/pprof/heap", pprof.Handler("heap").ServeHTTP)
 	r.HandleFunc("/pprof/goroutine", pprof.Handler("goroutine").ServeHTTP)
 	r.HandleFunc("/pprof/threadcreate", pprof.Handler("threadcreate").ServeHTTP)
-	p.r = r
-	return p
-}
-
-// Profiler enables pprof and expvar support via a HTTP API.
-type Profiler struct {
-	r *mux.Router
-}
-
-func (p *Profiler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	p.r.ServeHTTP(w, r)
 }
 
 // Replicated from expvar.go as not public.
-func (p *Profiler) expVars(w http.ResponseWriter, r *http.Request) {
+func expVars(w http.ResponseWriter, r *http.Request) {
 	first := true
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	fmt.Fprintf(w, "{\n")

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1300,7 +1300,7 @@ func makeHttpHandler(eng *engine.Engine, logging bool, localMethod string, local
 func createRouter(eng *engine.Engine, logging, enableCors bool, corsHeaders string, dockerVersion string) *mux.Router {
 	r := mux.NewRouter()
 	if os.Getenv("DEBUG") != "" {
-		r.Handle("/debug", NewProfiler())
+		ProfilerSetup(r, "/debug/")
 	}
 	m := map[string]map[string]HttpApiFunc{
 		"GET": {


### PR DESCRIPTION
This PR fixes the serving of the profiler over HTTP.
