### PR TITLE
Send SIGKILL to containers if send SIGTERM failed when docker daemon exit

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1053,10 +1053,9 @@ func (daemon *Daemon) shutdown() error {
 
 			go func() {
 				defer group.Done()
-				if err := c.KillSig(15); err != nil {
-					logrus.Debugf("kill 15 error for %s - %s", c.ID, err)
+				if err := c.Stop(10); err != nil {
+					logrus.Infof("Stop container %s error - %v", c.ID, err)
 				}
-				c.WaitStop(-1 * time.Second)
 				logrus.Debugf("container stopped %s", c.ID)
 			}()
 		}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3281,7 +3281,7 @@ func TestRunOOMExitCode(t *testing.T) {
 	go func() {
 		defer close(done)
 
-		runCmd := exec.Command(dockerBinary, "run", "-m", "4MB", "busybox", "sh", "-c", "x=a; while true; do x=$x$x; done")
+		runCmd := exec.Command(dockerBinary, "run", "-m", "4MB", "busybox", "sh", "-c", "x=a; while true; do x=$x$x$x$x; done")
 		out, exitCode, _ := runCommandWithOutput(runCmd)
 		if expected := 137; exitCode != expected {
 			t.Fatalf("wrong exit code for OOM container: expected %d, got %d (output: %q)", expected, exitCode, out)
@@ -3290,7 +3290,7 @@ func TestRunOOMExitCode(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(3 * time.Second):
+	case <-time.After(30 * time.Second):
 		t.Fatal("Timeout waiting for container to die on OOM")
 	}
 


### PR DESCRIPTION
Send SIGKILL to containers if send SIGTERM failed or timeout when docker daemon exit. Prevent the daemon to wait forever if process in container ingore SIGTERM signal.

Signed-off-by: Ye Yin eyniy@qq.com
