### PR TITLE
Make explanation consistent with command

### DIFF
--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -283,7 +283,7 @@ To specify a DNS server for use by Docker:
 **Or, as an alternative to the previous procedure,** disable `dnsmasq` in
 NetworkManager (this might slow your network).
 
-1. Open the `/etc/default/docker` file for editing.
+1. Open the `/etc/NetworkManager/NetworkManager.conf` file for editing.
 
 		$ sudo nano /etc/NetworkManager/NetworkManager.conf
 


### PR DESCRIPTION
To reduce confusion of the reader.  Fixes a likely cut & paste error.
