### PR TITLE
Migrate .dockercfg to .docker/config.json and support for HTTP Headers

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -286,10 +286,8 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 
 	v.Set("dockerfile", *dockerfileName)
 
-	cli.LoadConfigFile()
-
 	headers := http.Header(make(map[string][]string))
-	buf, err := json.Marshal(cli.configFile)
+	buf, err := json.Marshal(cli.configFile.AuthConfigs)
 	if err != nil {
 		return err
 	}

--- a/api/client/create.go
+++ b/api/client/create.go
@@ -37,9 +37,6 @@ func (cli *DockerCli) pullImageCustomOut(image string, out io.Writer) error {
 		return err
 	}
 
-	// Load the auth config file, to be able to pull the image
-	cli.LoadConfigFile()
-
 	// Resolve the Auth config relevant for this server
 	authConfig := cli.configFile.ResolveAuthConfig(repoInfo.Index)
 	buf, err := json.Marshal(authConfig)

--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -142,6 +142,13 @@ func (cli *DockerCli) hijack(method, path string, setRawTerminal bool, in io.Rea
 	if err != nil {
 		return err
 	}
+
+	// Add CLI Config's HTTP Headers BEFORE we set the Docker headers
+	// then the user can't change OUR headers
+	for k, v := range cli.configFile.HttpHeaders {
+		req.Header.Set(k, v)
+	}
+
 	req.Header.Set("User-Agent", "Docker-Client/"+dockerversion.VERSION)
 	req.Header.Set("Content-Type", "text/plain")
 	req.Header.Set("Connection", "Upgrade")

--- a/api/client/info.go
+++ b/api/client/info.go
@@ -68,8 +68,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	}
 
 	if info.IndexServerAddress != "" {
-		cli.LoadConfigFile()
-		u := cli.configFile.Configs[info.IndexServerAddress].Username
+		u := cli.configFile.AuthConfigs[info.IndexServerAddress].Username
 		if len(u) > 0 {
 			fmt.Fprintf(cli.out, "Username: %v\n", u)
 			fmt.Fprintf(cli.out, "Registry: %v\n", info.IndexServerAddress)

--- a/api/client/logout.go
+++ b/api/client/logout.go
@@ -22,14 +22,13 @@ func (cli *DockerCli) CmdLogout(args ...string) error {
 		serverAddress = cmd.Arg(0)
 	}
 
-	cli.LoadConfigFile()
-	if _, ok := cli.configFile.Configs[serverAddress]; !ok {
+	if _, ok := cli.configFile.AuthConfigs[serverAddress]; !ok {
 		fmt.Fprintf(cli.out, "Not logged in to %s\n", serverAddress)
 	} else {
 		fmt.Fprintf(cli.out, "Remove login credentials for %s\n", serverAddress)
-		delete(cli.configFile.Configs, serverAddress)
+		delete(cli.configFile.AuthConfigs, serverAddress)
 
-		if err := registry.SaveConfig(cli.configFile); err != nil {
+		if err := cli.configFile.Save(); err != nil {
 			return fmt.Errorf("Failed to save docker config: %v", err)
 		}
 	}

--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -42,8 +42,6 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 		return err
 	}
 
-	cli.LoadConfigFile()
-
 	_, _, err = cli.clientRequestAttemptLogin("POST", "/images/create?"+v.Encode(), nil, cli.out, repoInfo.Index, "pull")
 	return err
 }

--- a/api/client/push.go
+++ b/api/client/push.go
@@ -20,8 +20,6 @@ func (cli *DockerCli) CmdPush(args ...string) error {
 
 	name := cmd.Arg(0)
 
-	cli.LoadConfigFile()
-
 	remote, tag := parsers.ParseRepositoryTag(name)
 
 	// Resolve the Repository name from fqn to RepositoryInfo

--- a/api/client/search.go
+++ b/api/client/search.go
@@ -44,8 +44,6 @@ func (cli *DockerCli) CmdSearch(args ...string) error {
 		return err
 	}
 
-	cli.LoadConfigFile()
-
 	rdr, _, err := cli.clientRequestAttemptLogin("GET", "/images/search?"+v.Encode(), nil, nil, repoInfo.Index, "search")
 	if err != nil {
 		return err

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -101,8 +101,8 @@ type Builder struct {
 	// the final configs of the Dockerfile but dont want the layers
 	disableCommit bool
 
-	AuthConfig     *registry.AuthConfig
-	AuthConfigFile *registry.ConfigFile
+	AuthConfig *registry.AuthConfig
+	ConfigFile *registry.ConfigFile
 
 	// Deprecated, original writer used for ImagePull. To be removed.
 	OutOld          io.Writer

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -437,13 +437,13 @@ func (b *Builder) pullImage(name string) (*imagepkg.Image, error) {
 	}
 
 	pullRegistryAuth := b.AuthConfig
-	if len(b.AuthConfigFile.Configs) > 0 {
+	if len(b.ConfigFile.AuthConfigs) > 0 {
 		// The request came with a full auth config file, we prefer to use that
 		repoInfo, err := b.Daemon.RegistryService.ResolveRepository(remote)
 		if err != nil {
 			return nil, err
 		}
-		resolvedAuth := b.AuthConfigFile.ResolveAuthConfig(repoInfo.Index)
+		resolvedAuth := b.ConfigFile.ResolveAuthConfig(repoInfo.Index)
 		pullRegistryAuth = &resolvedAuth
 	}
 

--- a/builder/job.go
+++ b/builder/job.go
@@ -150,7 +150,7 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) error {
 		OutOld:          job.Stdout,
 		StreamFormatter: sf,
 		AuthConfig:      authConfig,
-		AuthConfigFile:  configFile,
+		ConfigFile:      configFile,
 		dockerfileName:  dockerfileName,
 		cpuShares:       cpuShares,
 		cpuSetCpus:      cpuSetCpus,

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -48,6 +48,35 @@ These Go environment variables are case-insensitive. See the
 [Go specification](http://golang.org/pkg/net/http/) for details on these
 variables.
 
+## Configuration Files
+
+The Docker command line stores its configuration files in a directory called
+`.docker` within your `HOME` directory. Docker manages most of the files in
+`.docker` and you should not modify them. However, you *can modify* the
+`.docker/config.json` file to control certain aspects of how the `docker`
+command behaves.
+
+Currently, you can modify the `docker` command behavior using environment 
+variables or command-line options. You can also use options within 
+`config.json` to modify some of the same behavior.  When using these 
+mechanisms, you must keep in mind the order of precedence among them. Command 
+line options override environment variables and environment variables override 
+properties you specify in a `config.json` file.
+
+The `config.json` file stores a JSON encoding of a single `HttpHeaders`
+property. The property specifies a set of headers to include in all
+messages sent from the Docker client to the daemon. Docker does not try to
+interpret or understand these header; it simply puts them into the messages.
+Docker does not allow these headers to change any headers it sets for itself.
+
+Following is a sample `config.json` file:
+
+    {
+      "HttpHeaders: {
+        "MyHeader": "MyValue"
+      }
+    }
+
 ## Help
 To list the help on any command just execute the command, followed by the `--help` option.
 

--- a/integration-cli/docker_cli_config_test.go
+++ b/integration-cli/docker_cli_config_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/docker/pkg/homedir"
+)
+
+func TestConfigHttpHeader(t *testing.T) {
+	testRequires(t, UnixCli) // Can't set/unset HOME on windows right now
+	// We either need a level of Go that supports Unsetenv (for cases
+	// when HOME/USERPROFILE isn't set), or we need to be able to use
+	// os/user but user.Current() only works if we aren't statically compiling
+
+	var headers map[string][]string
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			headers = r.Header
+		}))
+	defer server.Close()
+
+	homeKey := homedir.Key()
+	homeVal := homedir.Get()
+	tmpDir, _ := ioutil.TempDir("", "fake-home")
+	defer os.RemoveAll(tmpDir)
+
+	dotDocker := filepath.Join(tmpDir, ".docker")
+	os.Mkdir(dotDocker, 0600)
+	tmpCfg := filepath.Join(dotDocker, "config.json")
+
+	defer func() { os.Setenv(homeKey, homeVal) }()
+	os.Setenv(homeKey, tmpDir)
+
+	data := `{
+		"HttpHeaders": { "MyHeader": "MyValue" }
+	}`
+
+	err := ioutil.WriteFile(tmpCfg, []byte(data), 0600)
+	if err != nil {
+		t.Fatalf("Err creating file(%s): %v", tmpCfg, err)
+	}
+
+	cmd := exec.Command(dockerBinary, "-H="+server.URL[7:], "ps")
+	out, _, _ := runCommandWithOutput(cmd)
+
+	if headers["Myheader"] == nil || headers["Myheader"][0] != "MyValue" {
+		t.Fatalf("Missing/bad header: %q\nout:%v", headers, out)
+	}
+
+	logDone("config - add new http headers")
+}

--- a/registry/config_file_test.go
+++ b/registry/config_file_test.go
@@ -1,0 +1,135 @@
+package registry
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/pkg/homedir"
+)
+
+func TestMissingFile(t *testing.T) {
+	tmpHome, _ := ioutil.TempDir("", "config-test")
+
+	config, err := LoadConfig(tmpHome)
+	if err != nil {
+		t.Fatalf("Failed loading on missing file: %q", err)
+	}
+
+	// Now save it and make sure it shows up in new form
+	err = config.Save()
+	if err != nil {
+		t.Fatalf("Failed to save: %q", err)
+	}
+
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	if !strings.Contains(string(buf), `"auths":`) {
+		t.Fatalf("Should have save in new form: %s", string(buf))
+	}
+}
+
+func TestEmptyFile(t *testing.T) {
+	tmpHome, _ := ioutil.TempDir("", "config-test")
+	fn := filepath.Join(tmpHome, CONFIGFILE)
+	ioutil.WriteFile(fn, []byte(""), 0600)
+
+	_, err := LoadConfig(tmpHome)
+	if err == nil {
+		t.Fatalf("Was supposed to fail")
+	}
+}
+
+func TestEmptyJson(t *testing.T) {
+	tmpHome, _ := ioutil.TempDir("", "config-test")
+	fn := filepath.Join(tmpHome, CONFIGFILE)
+	ioutil.WriteFile(fn, []byte("{}"), 0600)
+
+	config, err := LoadConfig(tmpHome)
+	if err != nil {
+		t.Fatalf("Failed loading on empty json file: %q", err)
+	}
+
+	// Now save it and make sure it shows up in new form
+	err = config.Save()
+	if err != nil {
+		t.Fatalf("Failed to save: %q", err)
+	}
+
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	if !strings.Contains(string(buf), `"auths":`) {
+		t.Fatalf("Should have save in new form: %s", string(buf))
+	}
+}
+
+func TestOldJson(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		return
+	}
+
+	tmpHome, _ := ioutil.TempDir("", "config-test")
+	defer os.RemoveAll(tmpHome)
+
+	homeKey := homedir.Key()
+	homeVal := homedir.Get()
+
+	defer func() { os.Setenv(homeKey, homeVal) }()
+	os.Setenv(homeKey, tmpHome)
+
+	fn := filepath.Join(tmpHome, OLD_CONFIGFILE)
+	js := `{"https://index.docker.io/v1/":{"auth":"am9lam9lOmhlbGxv","email":"user@example.com"}}`
+	ioutil.WriteFile(fn, []byte(js), 0600)
+
+	config, err := LoadConfig(tmpHome)
+	if err != nil {
+		t.Fatalf("Failed loading on empty json file: %q", err)
+	}
+
+	ac := config.AuthConfigs["https://index.docker.io/v1/"]
+	if ac.Email != "user@example.com" || ac.Username != "joejoe" || ac.Password != "hello" {
+		t.Fatalf("Missing data from parsing:\n%q", config)
+	}
+
+	// Now save it and make sure it shows up in new form
+	err = config.Save()
+	if err != nil {
+		t.Fatalf("Failed to save: %q", err)
+	}
+
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	if !strings.Contains(string(buf), `"auths":`) ||
+		!strings.Contains(string(buf), "user@example.com") {
+		t.Fatalf("Should have save in new form: %s", string(buf))
+	}
+}
+
+func TestNewJson(t *testing.T) {
+	tmpHome, _ := ioutil.TempDir("", "config-test")
+	fn := filepath.Join(tmpHome, CONFIGFILE)
+	js := ` { "auths": { "https://index.docker.io/v1/": { "auth": "am9lam9lOmhlbGxv", "email": "user@example.com" } } }`
+	ioutil.WriteFile(fn, []byte(js), 0600)
+
+	config, err := LoadConfig(tmpHome)
+	if err != nil {
+		t.Fatalf("Failed loading on empty json file: %q", err)
+	}
+
+	ac := config.AuthConfigs["https://index.docker.io/v1/"]
+	if ac.Email != "user@example.com" || ac.Username != "joejoe" || ac.Password != "hello" {
+		t.Fatalf("Missing data from parsing:\n%q", config)
+	}
+
+	// Now save it and make sure it shows up in new form
+	err = config.Save()
+	if err != nil {
+		t.Fatalf("Failed to save: %q", err)
+	}
+
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	if !strings.Contains(string(buf), `"auths":`) ||
+		!strings.Contains(string(buf), "user@example.com") {
+		t.Fatalf("Should have save in new form: %s", string(buf))
+	}
+}


### PR DESCRIPTION
This PR does the following:
- migrated ~/.dockerfg to ~/.docker/config.json. The data is migrated
  but the old file remains in case its needed
- moves the auth json in that fie into an "auth" property so we can add new
  top-level properties w/o messing with the auth stuff
- adds support for an HttpHeaders property in ~/.docker/config.json
  which adds these http headers to all msgs from the cli

In a follow-on PR I'll move the config file process out from under
"registry" since it not specific to that any more. I didn't do it here
because I wanted the diff to be smaller so people can make sure I didn't
break/miss any auth code during my edits.

Signed-off-by: Doug Davis dug@us.ibm.com
