### PR TITLE
Small changes from #11967 for review comments

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	activationLock chan struct{} = make(chan struct{})
+	activationLock = make(chan struct{})
 )
 
 type HttpServer struct {

--- a/api/server/server_windows.go
+++ b/api/server/server_windows.go
@@ -39,10 +39,12 @@ func NewServer(proto, addr string, job *engine.Job) (Server, error) {
 }
 
 // Called through eng.Job("acceptconnections")
-func AcceptConnections(job *engine.Job) engine.Status {
+func AcceptConnections(job *engine.Job) error {
 	// close the lock so the listeners start accepting connections
-	if activationLock != nil {
+	select {
+	case <-activationLock:
+	default:
 		close(activationLock)
 	}
-	return engine.StatusOK
+	return nil
 }


### PR DESCRIPTION
Infer type in server.go and also make server_windows.go consistent with server_linux.go.  I have no clue how server_windows.go is used but I'd hate to see the docker daemon on windows hit the same race condition.
