### PR TITLE
fix device test on lxc...

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -175,6 +175,7 @@ func TestRunContainerWithCgroupParentAbsPath(t *testing.T) {
 }
 
 func TestRunDeviceDirectory(t *testing.T) {
+	testRequires(t, NativeExecDriver)
 	defer deleteAllContainers()
 	cmd := exec.Command(dockerBinary, "run", "--device", "/dev/snd:/dev/snd", "busybox", "sh", "-c", "ls /dev/snd/")
 


### PR DESCRIPTION
on lxc in contianers there are no dirs with devices in /dev, but this works outside a container... so this just doesnt work in dind for the test

```
# on lxc outside container
root@jenkins-ubuntu-lxc-2:~# docker run --device /dev/snd:/dev/snd busybox ls /dev/snd
seq
timer

# on lxc in a contianer shell
root@e5126dc73ece:/go/src/github.com/docker/docker# ls /dev/        
agpgart   fd     loop7   mixer2      ram11  ram8       smpte3   tty6
audio     full   mem     mixer3      ram12  ram9       sndstat  tty7
audio1    fuse   midi0   mpu401data  ram13  random     stderr   tty8
audio2    kmem   midi00  mpu401stat  ram14  rmidi0     stdin    tty9
audio3    kmsg   midi01  null        ram15  rmidi1     stdout   urandom
audioctl  loop0  midi02  port        ram16  rmidi2     tty  zero
console   loop1  midi03  ptmx        ram2   rmidi3     tty0
core      loop2  midi1   pts         ram3   sequencer  tty1
dsp   loop3  midi2   ram         ram4   shm        tty2
dsp1      loop4  midi3   ram0        ram5   smpte0     tty3
dsp2      loop5  mixer   ram1        ram6   smpte1     tty4
dsp3      loop6  mixer1  ram10       ram7   smpte2     tty5
```

see nothing in /dev/ in the contianer is a dir... so idk
