### PR TITLE
docs: keep the style of docker-commit consistent with docker-import

### DIFF
--- a/docs/man/docker-commit.1.md
+++ b/docs/man/docker-commit.1.md
@@ -22,7 +22,7 @@ Using an existing container's name or ID you can create a new image.
 
 **-c** , **--change**=[]
    Apply specified Dockerfile instructions while committing the image
-   Supported Dockerfile instructions: ADD|CMD|ENTRYPOINT|ENV|EXPOSE|FROM|MAINTAINER|RUN|USER|LABEL|VOLUME|WORKDIR|COPY
+   Supported Dockerfile instructions: `ADD`|`CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`FROM`|`MAINTAINER`|`RUN`|`USER`|`LABEL`|`VOLUME`|`WORKDIR`|`COPY`
 
 **--help**
   Print usage statement


### PR DESCRIPTION
add a pair of accent mark around dockerfile commands
in docker-commit, as the same thing in docker-import.

Signed-off-by: Chen Hanxiao chenhanxiao@cn.fujitsu.com
