### PR TITLE
Add docker exec run command as a different user and in privileged mode

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -407,7 +407,7 @@ _docker_events() {
 _docker_exec() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--detach -d --help --interactive -i -t --tty -u --user" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--detach -d --help --interactive -i --privileged -t --tty -u --user" -- "$cur" ) )
 			;;
 		*)
 			__docker_containers_running

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -407,7 +407,7 @@ _docker_events() {
 _docker_exec() {
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--detach -d --help --interactive -i -t --tty" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--detach -d --help --interactive -i -t --tty -u --user" -- "$cur" ) )
 			;;
 		*)
 			__docker_containers_running

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -139,6 +139,7 @@ func (d *Daemon) ContainerExecCreate(job *engine.Job) error {
 		Entrypoint: entrypoint,
 		Arguments:  args,
 		User:       config.User,
+		Privileged: config.Privileged,
 	}
 
 	execConfig := &execConfig{

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -138,6 +138,7 @@ func (d *Daemon) ContainerExecCreate(job *engine.Job) error {
 		Tty:        config.Tty,
 		Entrypoint: entrypoint,
 		Arguments:  args,
+		User:       config.User,
 	}
 
 	execConfig := &execConfig{

--- a/daemon/execdriver/native/exec.go
+++ b/daemon/execdriver/native/exec.go
@@ -14,7 +14,7 @@ import (
 	"github.com/docker/libcontainer/utils"
 )
 
-// TODO(vishh): Add support for running in privileged mode and running as a different user.
+// TODO(vishh): Add support for running in privileged mode.
 func (d *driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
 	active := d.activeContainers[c.ID]
 	if active == nil {
@@ -28,7 +28,7 @@ func (d *driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 		Args: append([]string{processConfig.Entrypoint}, processConfig.Arguments...),
 		Env:  c.ProcessConfig.Env,
 		Cwd:  c.WorkingDir,
-		User: c.ProcessConfig.User,
+		User: processConfig.User,
 	}
 
 	if processConfig.Tty {

--- a/daemon/execdriver/native/exec.go
+++ b/daemon/execdriver/native/exec.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/libcontainer/utils"
 )
 
-// TODO(vishh): Add support for running in privileged mode.
 func (d *driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
 	active := d.activeContainers[c.ID]
 	if active == nil {
@@ -29,6 +28,10 @@ func (d *driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 		Env:  c.ProcessConfig.Env,
 		Cwd:  c.WorkingDir,
 		User: processConfig.User,
+	}
+
+	if processConfig.Privileged {
+		p.Capabilities = execdriver.GetAllCapabilities()
 	}
 
 	if processConfig.Tty {

--- a/docs/man/docker-exec.1.md
+++ b/docs/man/docker-exec.1.md
@@ -9,6 +9,7 @@ docker-exec - Run a command in a running container
 [**-d**|**--detach**[=*false*]]
 [**--help**]
 [**-i**|**--interactive**[=*false*]]
+[**--privileged**[=*false*]]
 [**-t**|**--tty**[=*false*]]
 [**-u**|**--user**[=*USER*]]
 CONTAINER COMMAND [ARG...]
@@ -32,6 +33,13 @@ container is unpaused, and then run
 
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.
+
+**--privileged**=*true*|*false*
+   Give extended privileges to the process to run in a running container. The default is *false*.
+
+   By default, the process run by docker exec in a running container
+have the same capabilities of the container. By setting --privileged will give
+all the capabilities to the process.
 
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.

--- a/docs/man/docker-exec.1.md
+++ b/docs/man/docker-exec.1.md
@@ -10,6 +10,7 @@ docker-exec - Run a command in a running container
 [**--help**]
 [**-i**|**--interactive**[=*false*]]
 [**-t**|**--tty**[=*false*]]
+[**-u**|**--user**[=*USER*]]
 CONTAINER COMMAND [ARG...]
 
 # DESCRIPTION
@@ -34,6 +35,14 @@ container is unpaused, and then run
 
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.
+
+**-u**, **--user**=""
+   Sets the username or UID used and optionally the groupname or GID for the specified command.
+
+   The followings examples are all valid:
+   --user [user | user:group | uid | uid:gid | user:gid | uid:group ]
+
+   Without this argument the command will be run as root in the container.
 
 The **-t** option is incompatible with a redirection of the docker client
 standard input.

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1115,6 +1115,7 @@ You'll need two shells for this example.
       -d, --detach=false         Detached mode: run command in the background
       -i, --interactive=false    Keep STDIN open even if not attached
       -t, --tty=false            Allocate a pseudo-TTY
+      -u, --user=                Username or UID (format: <name|uid>[:<group|gid>])
 
 The `docker exec` command runs a new command in a running container.
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1114,6 +1114,7 @@ You'll need two shells for this example.
 
       -d, --detach=false         Detached mode: run command in the background
       -i, --interactive=false    Keep STDIN open even if not attached
+      --privileged=false         Give extended privileges to the command
       -t, --tty=false            Allocate a pseudo-TTY
       -u, --user=                Username or UID (format: <name|uid>[:<group|gid>])
 

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -665,3 +665,32 @@ func TestRunMutableNetworkFiles(t *testing.T) {
 	}
 	logDone("run - mutable network files")
 }
+
+func TestExecWithUser(t *testing.T) {
+	defer deleteAllContainers()
+
+	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "parent", "busybox", "top")
+	if out, _, err := runCommandWithOutput(runCmd); err != nil {
+		t.Fatal(out, err)
+	}
+
+	cmd := exec.Command(dockerBinary, "exec", "-u", "1", "parent", "id")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+	if !strings.Contains(out, "uid=1(daemon) gid=1(daemon)") {
+		t.Fatalf("exec with user by id expected daemon user got %s", out)
+	}
+
+	cmd = exec.Command(dockerBinary, "exec", "-u", "root", "parent", "id")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		t.Fatal(err, out)
+	}
+	if !strings.Contains(out, "uid=0(root) gid=0(root)") {
+		t.Fatalf("exec with user by root expected root user got %s", out)
+	}
+
+	logDone("exec - with user")
+}

--- a/runconfig/exec.go
+++ b/runconfig/exec.go
@@ -21,8 +21,7 @@ type ExecConfig struct {
 
 func ExecConfigFromJob(job *engine.Job) (*ExecConfig, error) {
 	execConfig := &ExecConfig{
-		// TODO(vishh): Expose 'User' once it is supported.
-		//User:         job.Getenv("User"),
+		User:         job.Getenv("User"),
 		// TODO(vishh): Expose 'Privileged' once it is supported.
 		//Privileged:   job.GetenvBool("Privileged"),
 		Tty:          job.GetenvBool("Tty"),
@@ -45,6 +44,7 @@ func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 		flStdin   = cmd.Bool([]string{"i", "-interactive"}, false, "Keep STDIN open even if not attached")
 		flTty     = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
 		flDetach  = cmd.Bool([]string{"d", "-detach"}, false, "Detached mode: run command in the background")
+		flUser    = cmd.String([]string{"u", "-user"}, "", "Username or UID (format: <name|uid>[:<group|gid>])")
 		execCmd   []string
 		container string
 	)
@@ -57,8 +57,7 @@ func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 	execCmd = parsedArgs[1:]
 
 	execConfig := &ExecConfig{
-		// TODO(vishh): Expose '-u' flag once it is supported.
-		User: "",
+		User: *flUser,
 		// TODO(vishh): Expose '-p' flag once it is supported.
 		Privileged: false,
 		Tty:        *flTty,

--- a/runconfig/exec.go
+++ b/runconfig/exec.go
@@ -22,8 +22,7 @@ type ExecConfig struct {
 func ExecConfigFromJob(job *engine.Job) (*ExecConfig, error) {
 	execConfig := &ExecConfig{
 		User:         job.Getenv("User"),
-		// TODO(vishh): Expose 'Privileged' once it is supported.
-		//Privileged:   job.GetenvBool("Privileged"),
+		Privileged:   job.GetenvBool("Privileged"),
 		Tty:          job.GetenvBool("Tty"),
 		AttachStdin:  job.GetenvBool("AttachStdin"),
 		AttachStderr: job.GetenvBool("AttachStderr"),
@@ -41,12 +40,13 @@ func ExecConfigFromJob(job *engine.Job) (*ExecConfig, error) {
 
 func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 	var (
-		flStdin   = cmd.Bool([]string{"i", "-interactive"}, false, "Keep STDIN open even if not attached")
-		flTty     = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
-		flDetach  = cmd.Bool([]string{"d", "-detach"}, false, "Detached mode: run command in the background")
-		flUser    = cmd.String([]string{"u", "-user"}, "", "Username or UID (format: <name|uid>[:<group|gid>])")
-		execCmd   []string
-		container string
+		flStdin      = cmd.Bool([]string{"i", "-interactive"}, false, "Keep STDIN open even if not attached")
+		flTty        = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
+		flDetach     = cmd.Bool([]string{"d", "-detach"}, false, "Detached mode: run command in the background")
+		flUser       = cmd.String([]string{"u", "-user"}, "", "Username or UID (format: <name|uid>[:<group|gid>])")
+		flPrivileged = cmd.Bool([]string{"-privileged"}, false, "Give extended privileges to the command")
+		execCmd      []string
+		container    string
 	)
 	cmd.Require(flag.Min, 2)
 	if err := cmd.ParseFlags(args, true); err != nil {
@@ -57,9 +57,8 @@ func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 	execCmd = parsedArgs[1:]
 
 	execConfig := &ExecConfig{
-		User: *flUser,
-		// TODO(vishh): Expose '-p' flag once it is supported.
-		Privileged: false,
+		User:       *flUser,
+		Privileged: *flPrivileged,
 		Tty:        *flTty,
 		Cmd:        execCmd,
 		Container:  container,


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

The first commit is to add docker exec running command as a
different user . 

The second commit is to add docker exec running command in privileged mode.
In some scenario, for example, we create a container without capabilities `MKNOD`
and when during container running, I have the need to  mknod in this container,
there is no way since it has no `MKNOD`, so I have to delete the container and
create a new container with `MKNOD` capabilites, but the container have this 
capabilites all the time, it's not security. So add the docker exec with 
privileged mode is necessary, at this scenario, I can
`docker exec` with `--privileged` to do the mknod

ping @jfrazelle  @estesp  @LK4D4 
