### PR TITLE
integration-cli: make TestPsGroupPortRange fast

### DIFF
--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -638,7 +638,7 @@ func TestPsLinkedWithNoTrunc(t *testing.T) {
 func TestPsGroupPortRange(t *testing.T) {
 	defer deleteAllContainers()
 
-	portRange := "3300-3900"
+	portRange := "3800-3900"
 	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "--name", "porttest", "-p", portRange+":"+portRange, "busybox", "top"))
 	if err != nil {
 		t.Fatal(out, err)


### PR DESCRIPTION
This PR reduces the number of ports in the port range. This change makes this test run in 4 seconds. It used to take 45 seconds to run this test.
