### PR TITLE
Make build cache ignore mtime

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -50,7 +50,7 @@ func (b *Builder) readContext(context io.Reader) error {
 		return err
 	}
 
-	if b.context, err = tarsum.NewTarSum(decompressedStream, true, tarsum.Version0); err != nil {
+	if b.context, err = tarsum.NewTarSum(decompressedStream, true, tarsum.Version1); err != nil {
 		return err
 	}
 
@@ -345,7 +345,7 @@ func calcCopyInfo(b *Builder, cmdName string, cInfos *[]*copyInfo, origPath stri
 		if err != nil {
 			return err
 		}
-		tarSum, err := tarsum.NewTarSum(r, true, tarsum.Version0)
+		tarSum, err := tarsum.NewTarSum(r, true, tarsum.Version1)
 		if err != nil {
 			return err
 		}

--- a/docs/sources/articles/dockerfile_best-practices.md
+++ b/docs/sources/articles/dockerfile_best-practices.md
@@ -103,7 +103,8 @@ a little more examination and explanation.
 being put into the image are examined. Specifically, a checksum is done
 of the file(s) and then that checksum is used during the cache lookup.
 If anything has changed in the file(s), including its metadata,
-then the cache is invalidated.
+then the cache is invalidated. The last-modified and last-accessed times of the
+file(s) are not considered in these checksums.
 
 * Aside from the `ADD` and `COPY` commands cache checking will not look at the
 files in the container to determine a cache match. For example, when processing

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -519,8 +519,8 @@ All new files and directories are created with a UID and GID of 0.
 In the case where `<src>` is a remote file URL, the destination will
 have permissions of 600. If the remote file being retrieved has an HTTP
 `Last-Modified` header, the timestamp from that header will be used
-to set the `mtime` on the destination file. Then, like any other file
-processed during an `ADD`, `mtime` will be included in the determination
+to set the `mtime` on the destination file. However, like any other file
+processed during an `ADD`, `mtime` will not be included in the determination
 of whether or not the file has changed and the cache should be updated.
 
 > **Note**:


### PR DESCRIPTION
Build cache uses pgk/tarsum to get a digest of content which is
ADD'd or COPY'd during a build. The builder has always used v0 of
the tarsum algorithm which includes mtimes however since the whole
file is hashed anyway, the mtime doesn't really provide any extra
information about whether the file has changed and many version
control tools like Git strip mtime from files when they are cloned.

This patch updates the build subsystem to use v1 of Tarsum which
explicitly ignores mtime when calculating a digest. Now ADD and
COPY will result in a cache hit if only the mtime and not the file
contents have changed.

NOTE: Tarsum is NOT a meant to be a cryptographically secure hash
function. It is a best-effort approach to determining if two sets of
filesystem content are different.
