### PR TITLE
integration-cli: in TestPsListContainersSize, check for no containers

### DIFF
--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -286,6 +286,9 @@ func TestPsListContainersSize(t *testing.T) {
 		t.Fatal(out, err)
 	}
 	lines := strings.Split(strings.Trim(out, "\n "), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("Expected 2 lines for 'ps -s -n=1' output, got %d", len(lines))
+	}
 	sizeIndex := strings.Index(lines[0], "SIZE")
 	idIndex := strings.Index(lines[0], "CONTAINER ID")
 	foundID := lines[1][idIndex : idIndex+12]


### PR DESCRIPTION
When no containers are returned, go test would then abort with:
  panic: runtime error: index out of range

Signed-off-by: Todd Whiteman todd.whiteman@joyent.com
