### PR TITLE
fixes 11721 replace stringutils.GenerateRandomString with stringid.GenerateRandomID

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/ioutils"
-	"github.com/docker/docker/pkg/stringutils"
+	"github.com/docker/docker/pkg/stringid"
 )
 
 // Installer is a standard interface for objects which can "install" themselves
@@ -78,7 +78,7 @@ func (eng *Engine) RegisterCatchall(catchall Handler) {
 func New() *Engine {
 	eng := &Engine{
 		handlers: make(map[string]Handler),
-		id:       stringutils.GenerateRandomString(),
+		id:       stringid.GenerateRandomID(),
 		Stdout:   os.Stdout,
 		Stderr:   os.Stderr,
 		Stdin:    os.Stdin,

--- a/pkg/stringutils/stringutils.go
+++ b/pkg/stringutils/stringutils.go
@@ -1,22 +1,9 @@
 package stringutils
 
 import (
-	"crypto/rand"
-	"encoding/hex"
-	"io"
 	mathrand "math/rand"
 	"time"
 )
-
-// Generate 32 chars random string
-func GenerateRandomString() string {
-	id := make([]byte, 32)
-
-	if _, err := io.ReadFull(rand.Reader, id); err != nil {
-		panic(err) // This shouldn't happen
-	}
-	return hex.EncodeToString(id)
-}
 
 // Generate alpha only random stirng with length n
 func GenerateRandomAlphaOnlyString(n int) string {

--- a/pkg/stringutils/stringutils_test.go
+++ b/pkg/stringutils/stringutils_test.go
@@ -23,3 +23,58 @@ func TestRandomStringUniqueness(t *testing.T) {
 		set[str] = struct{}{}
 	}
 }
+
+func testLengthHelper(generator func(int) string, t *testing.T) {
+	expectedLength := 20
+	s := generator(expectedLength)
+	if len(s) != expectedLength {
+		t.Fatalf("Length of %s was %d but expected length %d", s, len(s), expectedLength)
+	}	
+}
+
+func testUniquenessHelper(generator func(int) string, t *testing.T) {
+	repeats := 25
+	set := make(map[string]struct{}, repeats)
+	for i := 0; i < repeats; i = i + 1 {
+		str := generator(64)
+		if len(str) != 64 {
+			t.Fatalf("Id returned is incorrect: %s", str)
+		}
+		if _, ok := set[str]; ok {
+			t.Fatalf("Random number is repeated")
+		}
+		set[str] = struct{}{}
+	}
+}
+
+func isASCII(s string) bool {
+	for _, c := range s {
+		if c > 127 {
+			return false
+		}
+	}
+	return true
+}
+
+func TestGenerateRandomAlphaOnlyStringLength(t *testing.T) {
+	testLengthHelper(GenerateRandomAlphaOnlyString, t)
+}
+
+func TestGenerateRandomAlphaOnlyStringUniqueness(t *testing.T) {
+	testUniquenessHelper(GenerateRandomAlphaOnlyString, t)
+}
+
+func TestGenerateRandomAsciiStringLength(t *testing.T) {
+	testLengthHelper(GenerateRandomAsciiString, t) 
+}
+
+func TestGenerateRandomAsciiStringUniqueness(t *testing.T) {
+	testUniquenessHelper(GenerateRandomAsciiString, t)
+}
+
+func TestGenerateRandomAsciiStringIsAscii(t *testing.T) {
+	str := GenerateRandomAsciiString(64)
+	if !isASCII(str) {
+		t.Fatalf("%s contained non-ascii characters", str)
+	}
+}

--- a/pkg/stringutils/stringutils_test.go
+++ b/pkg/stringutils/stringutils_test.go
@@ -2,34 +2,12 @@ package stringutils
 
 import "testing"
 
-func TestRandomString(t *testing.T) {
-	str := GenerateRandomString()
-	if len(str) != 64 {
-		t.Fatalf("Id returned is incorrect: %s", str)
-	}
-}
-
-func TestRandomStringUniqueness(t *testing.T) {
-	repeats := 25
-	set := make(map[string]struct{}, repeats)
-	for i := 0; i < repeats; i = i + 1 {
-		str := GenerateRandomString()
-		if len(str) != 64 {
-			t.Fatalf("Id returned is incorrect: %s", str)
-		}
-		if _, ok := set[str]; ok {
-			t.Fatalf("Random number is repeated")
-		}
-		set[str] = struct{}{}
-	}
-}
-
 func testLengthHelper(generator func(int) string, t *testing.T) {
 	expectedLength := 20
 	s := generator(expectedLength)
 	if len(s) != expectedLength {
 		t.Fatalf("Length of %s was %d but expected length %d", s, len(s), expectedLength)
-	}	
+	}
 }
 
 func testUniquenessHelper(generator func(int) string, t *testing.T) {
@@ -65,7 +43,7 @@ func TestGenerateRandomAlphaOnlyStringUniqueness(t *testing.T) {
 }
 
 func TestGenerateRandomAsciiStringLength(t *testing.T) {
-	testLengthHelper(GenerateRandomAsciiString, t) 
+	testLengthHelper(GenerateRandomAsciiString, t)
 }
 
 func TestGenerateRandomAsciiStringUniqueness(t *testing.T) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -24,7 +24,7 @@ import (
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonmessage"
-	"github.com/docker/docker/pkg/stringutils"
+	"github.com/docker/docker/pkg/stringid"
 )
 
 type KeyValuePair struct {
@@ -313,7 +313,7 @@ var globalTestID string
 // new directory.
 func TestDirectory(templateDir string) (dir string, err error) {
 	if globalTestID == "" {
-		globalTestID = stringutils.GenerateRandomString()[:4]
+		globalTestID = stringid.GenerateRandomID()[:4]
 	}
 	prefix := fmt.Sprintf("docker-test%s-%s-", globalTestID, GetCallerName(2))
 	if prefix == "" {


### PR DESCRIPTION
Fixes #11721.  It also adds some unit test coverage for the remaining functions in stringutils.
