### PR TITLE
Add "bundles/latest" symlink

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -255,6 +255,12 @@ main() {
 		rm -fr bundles/$VERSION && mkdir bundles/$VERSION || exit 1
 		echo
 	fi
+
+	if [ "$(go env GOHOSTOS)" != 'windows' ]; then
+		# Windows and symlinks don't get along well
+		ln -sfT $VERSION bundles/latest
+	fi
+
 	SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 	if [ $# -lt 1 ]; then
 		bundles=(${DEFAULT_BUNDLES[@]})


### PR DESCRIPTION
This is a symlink to the latest "bundle" that was assembled.  For example, if `VERSION` is currently `1.5.0-dev`, then `bundles/latest` will be a symlink to `bundles/1.5.0-dev` after an attempted build.

One interesting property of this is that after a successful `binary` build, we can `./bundles/latest/binary/docker -v` and get back something like `Docker version 1.5.0-dev, build 3ff6723-dirty`.
