### PR TITLE
Specify running `boot2docker ip` on host

### DIFF
--- a/docs/sources/userguide/usingdocker.md
+++ b/docs/sources/userguide/usingdocker.md
@@ -179,10 +179,10 @@ see the application.
 Our Python application is live!
 
 > **Note:**
-> If you have used the boot2docker virtual machine on OS X, Windows or Linux,
+> If you have used the `boot2docker` virtual machine on OS X, Windows or Linux,
 > you'll need to get the IP of the virtual host instead of using localhost.
-> You can do this by running the following in
-> the boot2docker shell.
+> You can do this by running the following outside of the `boot2docker` shell
+> (i.e., from your comment line or terminal application).
 > 
 >     $ boot2docker ip
 >     The VM's Host only interface IP address is: 192.168.59.103


### PR DESCRIPTION
Carry of #11925.
