### PR TITLE
Remove engine.Table from docker search and fix missing field

### DIFF
--- a/registry/types.go
+++ b/registry/types.go
@@ -5,6 +5,7 @@ type SearchResult struct {
 	IsOfficial  bool   `json:"is_official"`
 	Name        string `json:"name"`
 	IsTrusted   bool   `json:"is_trusted"`
+	IsAutomated bool   `json:"is_automated"`
 	Description string `json:"description"`
 }
 


### PR DESCRIPTION
And registry/SearchResults was missing the "is_automated" field.
I added it back in.

Pulled this 'table' removal one from the others because it fixed
a bug too

Signed-off-by: Doug Davis dug@us.ibm.com
