### PR TITLE
test-unit: fix TESTFLAGS doc

### DIFF
--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -12,7 +12,7 @@ TEXTRESET=$'\033[0m' # reset the foreground colour
 # If $TESTFLAGS is set in the environment, it is passed as extra arguments to 'go test'.
 # You can use this to select certain tests to run, eg.
 #
-#   TESTFLAGS='-run ^TestBuild$' ./hack/make.sh test-unit
+#   TESTFLAGS='-test.run ^TestBuild$' ./hack/make.sh test-unit
 #
 bundle_test_unit() {
 	{


### PR DESCRIPTION
Using `-run` produce the following error:

```
+ go test -run ^TestImageGetCached -test.timeout=30m github.com/docker/docker/api
flag provided but not defined: -run
Usage of /go/src/github.com/docker/docker/bundles/1.5.0-dev/test-unit/precompiled/./api.test:
...
  -test.run="": regular expression to select tests and examples to run
```
