### PR TITLE
Add building the RPM to the make process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ RUN apt-get update && apt-get install -y \
 	python-pip \
 	python-websocket \
 	reprepro \
+	rpm \
 	ruby1.9.1 \
 	ruby1.9.1-dev \
 	s3cmd=1.1.0* \

--- a/Dockerfile.centos
+++ b/Dockerfile.centos
@@ -1,0 +1,36 @@
+# This file creates a CentOS docker container which can be used to create the Docker
+# RPMs, however it shouldn't be called directly.
+#
+
+FROM centos:7.0.1406
+MAINTAINER Patrick Devine <patrick@docker.com> (@pdev110)
+
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
+
+# Packaged dependencies
+RUN yum groupinstall -y "Development Tools"
+
+RUN yum install -y \
+	btrfs-progs-devel \
+	device-mapper-devel \
+	glibc-static \
+	libselinux-devel \
+	sqlite-devel
+
+VOLUME /go
+
+ENV LXC_VERSION 1.0.7
+ENV GO_VERSION 1.4.2
+ENV PATH /go/bin:/usr/local/go/bin:$PATH
+ENV GOPATH /go:/go/src/github.com/docker/docker/vendor
+ENV GOFMT_VERSION 1.3.3
+
+# Add an unprivileged user to be used for tests which need it
+RUN groupadd -r docker
+RUN useradd --create-home --gid docker unprivilegeduser
+
+WORKDIR /go/src/github.com/docker/docker
+ENV DOCKER_BUILDTAGS selinux btrfs_noversion
+
+# Wrap all commands in the "docker-in-docker" script to allow nested containers
+#ENTRYPOINT ["hack/dind"]

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -259,7 +259,7 @@ main() {
 	# We want this to fail if the bundles already exist and cannot be removed.
 	# This is to avoid mixing bundles from different versions of the code.
 	mkdir -p bundles
-	if [ -e "bundles/$VERSION" ]; then
+	if [ -e "bundles/$VERSION" ] && [ -z ${KEEPBUNDLE} ]; then
 		echo "bundles/$VERSION already exists. Removing."
 		rm -fr bundles/$VERSION && mkdir bundles/$VERSION || exit 1
 		echo

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -2,7 +2,7 @@
 
 # see test-integration-cli for example usage of this script
 
-export PATH="$DEST/../binary:$DEST/../dynbinary:$DEST/../gccgo:$DEST/../dyngccgo:$PATH"
+export PATH="$DEST/../dynbinary:$DEST/../binary:$DEST/../gccgo:$DEST/../dyngccgo:$PATH"
 
 if ! command -v docker &> /dev/null; then
 	echo >&2 'error: binary or dynbinary must be run before .integration-daemon-start'

--- a/hack/make/dind-dynbinary
+++ b/hack/make/dind-dynbinary
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+DEST=$1
+DOCKERBIN=$DEST/../binary/docker
+BUILDDIR=$DEST/../dynbinary/
+RPM_PATH=$DEST/../rpm/
+
+build_rpm() {
+	if [ ! -x $DOCKERBIN ]; then
+		echo "No docker binary was found to execute.  This step requires 'binary' to be run first."
+		exit 1
+	fi
+
+	$DOCKERBIN -d 2>/dev/null &
+	$DOCKERBIN build -t centos-build -f Dockerfile.centos ./
+	$DOCKERBIN run -it --rm --privileged -v /go:/go -v /usr/local:/usr/local -e "KEEPBUNDLE=true" --name centos-build-container centos-build hack/make.sh dynbinary
+
+	# turn off the docker daemon
+	$DOCKERBIN rmi centos-build
+	cat /var/run/docker.pid | xargs kill
+}
+
+build_rpm

--- a/hack/make/rpm
+++ b/hack/make/rpm
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+DEST=$1
+
+# XXX - The package version in CentOS gets messed up and inserts a '~'
+#       (including the single quote) if we use the same package
+#       version scheme as the deb packages.  This doesn't work with
+#       rpmbuild.
+PKGVERSION="${VERSION}"
+# if we have a "-dev" suffix or have change in Git, let's make this package version more complex so it works better
+if [[ "$VERSION" == *-dev ]] || [ -n "$(git status --porcelain)" ]; then
+	GIT_UNIX="$(git log -1 --pretty='%at')"
+	GIT_DATE="$(date --date "@$GIT_UNIX" +'%Y%m%d.%H%M%S')"
+	GIT_COMMIT="$(git log -1 --pretty='%h')"
+	GIT_VERSION="git${GIT_DATE}.0.${GIT_COMMIT}"
+	# GIT_VERSION is now something like 'git20150128.112847.0.17e840a'
+	PKGVERSION="$PKGVERSION~$GIT_VERSION"
+fi
+
+# $ dpkg --compare-versions 1.5.0 gt 1.5.0~rc1 && echo true || echo false
+# true
+# $ dpkg --compare-versions 1.5.0~rc1 gt 1.5.0~git20150128.112847.17e840a && echo true || echo false
+# true
+# $ dpkg --compare-versions 1.5.0~git20150128.112847.17e840a gt 1.5.0~dev~git20150128.112847.17e840a && echo true || echo false
+# true
+
+# ie, 1.5.0 > 1.5.0~rc1 > 1.5.0~git20150128.112847.17e840a > 1.5.0~dev~git20150128.112847.17e840a
+
+PACKAGE_ARCHITECTURE=`uname -i`
+
+PACKAGE_URL="http://www.docker.com/"
+PACKAGE_MAINTAINER="support@docker.com"
+PACKAGE_DESCRIPTION="Linux container runtime
+Docker complements LXC with a high-level API which operates at the process
+level. It runs unix processes with strong guarantees of isolation and
+repeatability across servers.
+Docker is a great building block for automating distributed systems:
+large-scale web deployments, database clusters, continuous deployment systems,
+private PaaS, service-oriented architectures, etc."
+PACKAGE_LICENSE="Apache-2.0"
+
+# bundle the RPM using FPM -- we may want to change this to rpmbuild at some point
+bundle_rpm() {
+	DIR=$DEST/build
+
+	# Include our udev rules
+	mkdir -p $DIR/etc/udev/rules.d
+	cp contrib/udev/80-docker.rules $DIR/etc/udev/rules.d/
+
+	mkdir -p $DIR/lib/systemd/system
+	cp contrib/init/systemd/docker.{service,socket} $DIR/lib/systemd/system/
+
+	# Include contributed completions
+	mkdir -p $DIR/etc/bash_completion.d
+	cp contrib/completion/bash/docker $DIR/etc/bash_completion.d/
+	mkdir -p $DIR/usr/share/zsh/vendor-completions
+	cp contrib/completion/zsh/_docker $DIR/usr/share/zsh/vendor-completions/
+	mkdir -p $DIR/etc/fish/completions
+	cp contrib/completion/fish/docker.fish $DIR/etc/fish/completions/
+
+	# Include contributed man pages
+	docs/man/md2man-all.sh -q
+	manRoot="$DIR/usr/share/man"
+	mkdir -p "$manRoot"
+	for manDir in docs/man/man?; do
+		manBase="$(basename "$manDir")" # "man1"
+		for manFile in "$manDir"/*; do
+			manName="$(basename "$manFile")" # "docker-build.1"
+			mkdir -p "$manRoot/$manBase"
+			gzip -c "$manFile" > "$manRoot/$manBase/$manName.gz"
+		done
+	done
+
+	# Copy the binary
+	# This will fail if the dynbinary bundle hasn't been built
+	mkdir -p $DIR/usr/bin
+	cp $DEST/../dynbinary/docker-$VERSION $DIR/usr/bin/docker
+	cp $DEST/../dynbinary/dockerinit-$VERSION $DIR/usr/bin/dockerinit
+
+	# Generate postinst/prerm/postrm scripts
+	cat > $DEST/postinst <<'EOF'
+EOF
+
+	cat > $DEST/preinst <<'EOF'
+if ! getent group docker > /dev/null; then
+	groupadd --system docker
+fi
+EOF
+
+	cat > $DEST/prerm <<'EOF'
+EOF
+
+	cat > $DEST/postrm <<'EOF'
+## In case this system is running systemd, we make systemd reload the unit files
+## to pick up changes.
+#if [ -d /run/systemd/system ] ; then
+#	systemctl --system daemon-reload > /dev/null || true
+#fi
+EOF
+
+	chmod +x $DEST/postinst $DEST/prerm $DEST/postrm $DEST/preinst
+
+	(
+		# switch directories so we create *.deb in the right folder
+		cd $DEST
+
+		# create lxc-docker-VERSION package
+		fpm -s dir -C $DIR \
+			--name lxc-docker-$VERSION --version "$PKGVERSION" \
+			--before-install $DEST/preinst \
+			--after-install $DEST/postinst \
+			--before-remove $DEST/prerm \
+			--after-remove $DEST/postrm \
+			--architecture "$PACKAGE_ARCHITECTURE" \
+			--prefix / \
+			--depends iptables \
+			--depends xz \
+			--depends device-mapper-libs \
+			--depends libselinux \
+			--depends libsepol \
+			--depends sqlite \
+			--description "$PACKAGE_DESCRIPTION" \
+			--maintainer "$PACKAGE_MAINTAINER" \
+			--conflicts docker \
+			--conflicts docker.io \
+			--conflicts lxc-docker-virtual-package \
+			--provides lxc-docker \
+			--provides lxc-docker-virtual-package \
+			--replaces lxc-docker \
+			--replaces lxc-docker-virtual-package \
+			--url "$PACKAGE_URL" \
+			--license "$PACKAGE_LICENSE" \
+			--config-files /etc/udev/rules.d/80-docker.rules \
+			--rpm-compression gzip \
+			-t rpm .
+#		# TODO replace "Suggests: cgroup-lite" with "Recommends: cgroupfs-mount | cgroup-lite" once cgroupfs-mount is available
+
+		fpm -s empty \
+			--name lxc-docker --version "$PKGVERSION" \
+			--architecture "$PACKAGE_ARCHITECTURE" \
+			--depends lxc-docker-$VERSION \
+			--description "$PACKAGE_DESCRIPTION" \
+			--maintainer "$PACKAGE_MAINTAINER" \
+			--url "$PACKAGE_URL" \
+			--license "$PACKAGE_LICENSE" \
+			--rpm-compression gzip \
+			-t rpm
+	)
+
+	# clean up after ourselves so we have a clean output directory
+	rm $DEST/postinst $DEST/prerm $DEST/postrm $DEST/preinst
+	rm -r $DIR
+}
+
+bundle_rpm

--- a/hack/make/rpm
+++ b/hack/make/rpm
@@ -47,8 +47,56 @@ bundle_rpm() {
 	mkdir -p $DIR/etc/udev/rules.d
 	cp contrib/udev/80-docker.rules $DIR/etc/udev/rules.d/
 
-	mkdir -p $DIR/lib/systemd/system
-	cp contrib/init/systemd/docker.{service,socket} $DIR/lib/systemd/system/
+	mkdir -p $DIR/usr/lib/systemd/system
+	cp contrib/init/systemd/docker.{service,socket} $DIR/usr/lib/systemd/system
+
+	cat > $DIR/usr/lib/systemd/system/docker.service <<'EOF'
+[Unit]
+Description=Docker Application Container Engine
+Documentation=http://docs.docker.com
+After=network.target docker.socket
+Requires=docker.socket
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/sysconfig/docker
+EnvironmentFile=-/etc/sysconfig/docker-storage
+ExecStart=/usr/bin/docker -d $OPTIONS $DOCKER_STORAGE_OPTIONS
+LimitNOFILE=1048576
+LimitNPROC=1048576
+MountFlags=private
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  mkdir -p $DIR/etc/sysconfig
+	cat > $DIR/etc/sysconfig/docker <<'EOF'
+# /etc/sysconfig/docker
+
+# Modify these options if you want to change the way the docker daemon runs
+OPTIONS=--selinux-enabled -H fd://
+
+# Location used for temporary files, such as those created by
+# docker load and build operations. Default is /var/lib/docker/tmp
+# Can be overriden by setting the following environment variable.
+# DOCKER_TMPDIR=/var/tmp
+EOF
+
+cat > $DIR/etc/sysconfig/docker-storage <<'EOF'
+# By default, Docker uses a loopback-mounted sparse file in
+# /var/lib/docker.  The loopback makes it slower, and there are some
+# restrictive defaults, such as 100GB max storage.
+
+# If your installation did not set a custom storage for Docker, you
+# may do it below.
+
+# Example: Use a custom pair of raw logical volumes (one for metadata,
+# one for data).
+# DOCKER_STORAGE_OPTIONS = --storage-opt dm.metadatadev=/dev/mylogvol/my-docker-metadata --storage-opt dm.datadev=/dev/mylogvol/my-docker-data
+
+DOCKER_STORAGE_OPTIONS=
+EOF
 
 	# Include contributed completions
 	mkdir -p $DIR/etc/bash_completion.d
@@ -107,6 +155,7 @@ EOF
 		# create lxc-docker-VERSION package
 		fpm -s dir -C $DIR \
 			--name lxc-docker-$VERSION --version "$PKGVERSION" \
+			--epoch 7 \
 			--before-install $DEST/preinst \
 			--after-install $DEST/postinst \
 			--before-remove $DEST/prerm \
@@ -115,7 +164,8 @@ EOF
 			--prefix / \
 			--depends iptables \
 			--depends xz \
-			--depends device-mapper-libs \
+			--depends "systemd >= 208-20" \
+			--depends "device-mapper-libs >= 7:1.02.90-1" \
 			--depends libselinux \
 			--depends libsepol \
 			--depends sqlite \
@@ -130,21 +180,10 @@ EOF
 			--replaces lxc-docker-virtual-package \
 			--url "$PACKAGE_URL" \
 			--license "$PACKAGE_LICENSE" \
-			--config-files /etc/udev/rules.d/80-docker.rules \
+			--config-files etc/sysconfig \
+			--config-files etc/udev/rules.d/80-docker.rules \
 			--rpm-compression gzip \
 			-t rpm .
-#		# TODO replace "Suggests: cgroup-lite" with "Recommends: cgroupfs-mount | cgroup-lite" once cgroupfs-mount is available
-
-		fpm -s empty \
-			--name lxc-docker --version "$PKGVERSION" \
-			--architecture "$PACKAGE_ARCHITECTURE" \
-			--depends lxc-docker-$VERSION \
-			--description "$PACKAGE_DESCRIPTION" \
-			--maintainer "$PACKAGE_MAINTAINER" \
-			--url "$PACKAGE_URL" \
-			--license "$PACKAGE_LICENSE" \
-			--rpm-compression gzip \
-			-t rpm
 	)
 
 	# clean up after ourselves so we have a clean output directory

--- a/hack/make/rpm
+++ b/hack/make/rpm
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 DEST=$1
+PACKAGE_NAME=${PACKAGE_NAME:-docker-engine}
 
 # XXX - The package version in CentOS gets messed up and inserts a '~'
 #       (including the single quote) if we use the same package
@@ -152,9 +153,9 @@ EOF
 		# switch directories so we create *.deb in the right folder
 		cd $DEST
 
-		# create lxc-docker-VERSION package
+		# create PACKAGE_NAME-VERSION package
 		fpm -s dir -C $DIR \
-			--name lxc-docker-$VERSION --version "$PKGVERSION" \
+			--name $PACKAGE_NAME-$VERSION --version "$PKGVERSION" \
 			--epoch 7 \
 			--before-install $DEST/preinst \
 			--after-install $DEST/postinst \
@@ -166,18 +167,16 @@ EOF
 			--depends xz \
 			--depends "systemd >= 208-20" \
 			--depends "device-mapper-libs >= 7:1.02.90-1" \
+			--depends "device-mapper-event-libs >= 7:1.02.90-1" \
 			--depends libselinux \
 			--depends libsepol \
 			--depends sqlite \
 			--description "$PACKAGE_DESCRIPTION" \
 			--maintainer "$PACKAGE_MAINTAINER" \
 			--conflicts docker \
-			--conflicts docker.io \
+			--conflicts docker-io \
 			--conflicts lxc-docker-virtual-package \
-			--provides lxc-docker \
-			--provides lxc-docker-virtual-package \
-			--replaces lxc-docker \
-			--replaces lxc-docker-virtual-package \
+			--conflicts lxc-docker \
 			--url "$PACKAGE_URL" \
 			--license "$PACKAGE_LICENSE" \
 			--config-files etc/sysconfig \


### PR DESCRIPTION
This change uses docker-in-docker to build a centos build container
during the build process which then creates the dynamically linked
binary.  This is done because statically linked binaries on Centos/
RHEL/Fedora are a non-starter, and we want the release process to
not be disrupted.  To create the RPMs, you can use the command:

hack/make.sh binary dind-rpm

which will first create the statically linked docker binary which is
then used to run docker-in-docker to run a centos build container.
