### PR TITLE
Remove "stupid" wording

### DIFF
--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -57,7 +57,7 @@ var (
 		// Here we don't follow the convention of using the 1st IP of the range for the gateway.
 		// This is to use the same gateway IPs as the /24 ranges, which predate the /16 ranges.
 		// In theory this shouldn't matter - in practice there's bound to be a few scripts relying
-		// on the internal addressing or other stupid things like that.
+		// on the internal addressing or other things like that.
 		// They shouldn't, but hey, let's not break them unless we really have to.
 		"172.17.42.1/16", // Don't use 172.16.0.0/16, it conflicts with EC2 DNS 172.16.0.23
 		"10.0.42.1/16",   // Don't even try using the entire /8, that's too intrusive

--- a/graph/service.go
+++ b/graph/service.go
@@ -68,7 +68,7 @@ func (s *TagStore) CmdSet(job *engine.Job) error {
 	}
 	// We have to pass an *image.Image object, even though it will be completely
 	// ignored in favor of the redundant json data.
-	// FIXME: the current prototype of Graph.Register is stupid and redundant.
+	// FIXME: the current prototype of Graph.Register is redundant.
 	img, err := image.NewImgJSON(imgJSON)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hi,
going through the source code I found comments using the word "stupid".

In order to create a more welcome environment for future developers, I thought it'd be a good idea to remove them. After all, depending on the context, "stupid" solutions can be quite smart.
