### PR TITLE
Check container is running before trying to kill it and log kill event

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -155,7 +155,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		// And canonicalize dockerfile name to a platform-independent one
 		*dockerfileName, err = archive.CanonicalTarNameForPath(*dockerfileName)
 		if err != nil {
-			return fmt.Errorf("Cannot canonicalize dockerfile path %s: %v", dockerfileName, err)
+			return fmt.Errorf("Cannot canonicalize dockerfile path %s: %v", *dockerfileName, err)
 		}
 
 		if _, err = os.Lstat(filename); os.IsNotExist(err) {

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -721,7 +721,7 @@ func (container *Container) KillSig(sig int) error {
 	}
 
 	if !container.Running {
-		return nil
+		return fmt.Errorf("Cannot kill not running container %s", container.ID)
 	}
 
 	// signal to the monitor that it should not restart the container
@@ -770,7 +770,7 @@ func (container *Container) Unpause() error {
 
 func (container *Container) Kill() error {
 	if !container.IsRunning() {
-		return nil
+		return fmt.Errorf("Cannot kill not running container %s", container.ID)
 	}
 
 	// 1. Send SIGKILL

--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -53,9 +53,8 @@ func TestNetworkNat(t *testing.T) {
 		t.Fatalf("Unexpected output. Expected: %q, received: %q for iface %s", expected, out, ifaceIP)
 	}
 
-	killCmd := exec.Command(dockerBinary, "kill", cleanedContainerID)
-	if out, _, err = runCommandWithOutput(killCmd); err != nil {
-		t.Fatalf("failed to kill container: %s, %v", out, err)
+	if err := waitInspect(cleanedContainerID, "{{.State.Running}}", "false", 5); err != nil {
+		t.Fatal(err)
 	}
 
 	logDone("network - make sure nat works through the host")

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -575,7 +575,7 @@ func TestPostContainersAttach(t *testing.T) {
 	// Try to avoid the timeout in destroy. Best effort, don't check error
 	defer func() {
 		closeWrap(stdin, stdinPipe, stdout, stdoutPipe)
-		containerKill(eng, containerID, t)
+		//containerKill(eng, containerID, t)
 	}()
 
 	// Attach to it
@@ -651,7 +651,7 @@ func TestPostContainersAttachStderr(t *testing.T) {
 	// Try to avoid the timeout in destroy. Best effort, don't check error
 	defer func() {
 		closeWrap(stdin, stdinPipe, stdout, stdoutPipe)
-		containerKill(eng, containerID, t)
+		//containerKill(eng, containerID, t)
 	}()
 
 	// Attach to it


### PR DESCRIPTION
Fixes: #12083 

I'm opening this if the linked issue is ok, otherwise ignore (and sorry, close) this!

Also, I've modified `TestNetworkNat` in integration-cli because with this I discovered that at the end of the test, a kill command was run against the first container but the container was just stopped (received message with `nc` and exited) so now it would fail. Turns out that kill command wasn't needed there. (If I am right, but I highly doubt :))

There are also two other test failing because of this, `TestPostContainersAttach` and `TestPostContainersAttachStderr` under `integration/`, because they both try to kill an already stopped container. I've just commented the kill command but waiting feedbacks on what to do here.

Signed-off-by: Antonio Murdaca me@runcom.ninja
