### PR TITLE
Proposal: add --rm flag to stop command

### DIFF
--- a/api/client/stop.go
+++ b/api/client/stop.go
@@ -5,23 +5,28 @@ import (
 	"net/url"
 	"strconv"
 
+	"github.com/Sirupsen/logrus"
 	flag "github.com/docker/docker/pkg/mflag"
 )
 
 // CmdStop stops one or more running containers.
 //
-// A running container is stopped by first sending SIGTERM and then SIGKILL if the container fails to stop within a grace period (the default is 10 seconds).
+// A running container is stopped by first sending SIGTERM and then SIGKILL if
+// the container fails to stop within a grace period (the default is 10 seconds).
+// If --rm flag is supplied the container will be deleted along with any volume
+// associated to it when it stops.
 //
 // Usage: docker stop [OPTIONS] CONTAINER [CONTAINER...]
 func (cli *DockerCli) CmdStop(args ...string) error {
 	cmd := cli.Subcmd("stop", "CONTAINER [CONTAINER...]", "Stop a running container by sending SIGTERM and then SIGKILL after a\ngrace period", true)
-	nSeconds := cmd.Int([]string{"t", "-time"}, 10, "Seconds to wait for stop before killing it")
+	flSeconds := cmd.Int([]string{"t", "-time"}, 10, "Seconds to wait for stop before killing it")
+	flRemove := cmd.Bool([]string{"#rm", "-rm"}, false, "Automatically remove the container and the volumes associated to it when it stops")
 	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)
 
 	v := url.Values{}
-	v.Set("t", strconv.Itoa(*nSeconds))
+	v.Set("t", strconv.Itoa(*flSeconds))
 
 	var encounteredError error
 	for _, name := range cmd.Args() {
@@ -30,6 +35,11 @@ func (cli *DockerCli) CmdStop(args ...string) error {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			encounteredError = fmt.Errorf("Error: failed to stop one or more containers")
 		} else {
+			if *flRemove {
+				if _, _, err = readBody(cli.call("DELETE", "/containers/"+name+"?v=1", nil, nil)); err != nil {
+					logrus.Errorf("Error deleting container: %s", err)
+				}
+			}
 			fmt.Fprintf(cli.out, "%s\n", name)
 		}
 	}

--- a/docs/man/docker-stop.1.md
+++ b/docs/man/docker-stop.1.md
@@ -8,6 +8,7 @@ docker-stop - Stop a running container by sending SIGTERM and then SIGKILL after
 **docker stop**
 [**--help**]
 [**-t**|**--time**[=*10*]]
+[**--rm**[=*false*]]
 CONTAINER [CONTAINER...]
 
 # DESCRIPTION
@@ -20,6 +21,9 @@ Stop a running container (Send SIGTERM, and then SIGKILL after
 
 **-t**, **--time**=10
    Number of seconds to wait for the container to stop before killing it. Default is 10 seconds.
+
+**--rm**=*true*|*false*
+   Automatically remove the container and the volumes associated to it when it stops. The default is *false*.
 
 #See also
 **docker-start(1)** to restart a stopped container.

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -706,6 +706,8 @@ Stop the container `id`
 Query Parameters:
 
 -   **t** – number of seconds to wait before killing the container
+-   **r** – 1/True/true or 0/False/false, Remove the container and
+        the volumes associated to it when it stops. Default false
 
 Status Codes:
 

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -34,7 +34,7 @@ whole context must be transferred to the daemon. The Docker CLI reports
 "Sending build context to Docker daemon" when the context is sent to the daemon.
 
 > **Warning**
-> Avoid using your root directory, `/`, as the root of the source repository. The 
+> Avoid using your root directory, `/`, as the root of the source repository. The
 > `docker build` command will use whatever directory contains the Dockerfile as the build
 > context (including all of its subdirectories). The build context will be sent to the
 > Docker daemon before building the image, which means if you use `/` as the source
@@ -634,7 +634,7 @@ Command line arguments to `docker run <image>` will be appended after all
 elements in an *exec* form `ENTRYPOINT`, and will override all elements specified
 using `CMD`.
 This allows arguments to be passed to the entry point, i.e., `docker run <image> -d`
-will pass the `-d` argument to the entry point. 
+will pass the `-d` argument to the entry point.
 You can override the `ENTRYPOINT` instruction using the `docker run --entrypoint`
 flag.
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -2284,6 +2284,7 @@ containers. Stopped containers will not return any data.
 	grace period
 
       -t, --time=10      Seconds to wait for stop before killing it
+      --rm=false         Automatically remove the container and the volumes associated to it when it stops
 
 The main process inside the container will receive `SIGTERM`, and after a
 grace period, `SIGKILL`.

--- a/integration-cli/docker_cli_stop_test.go
+++ b/integration-cli/docker_cli_stop_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestStopContainerWithRmFlag(t *testing.T) {
+	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sleep", "100")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		t.Fatal(out, err)
+	}
+
+	cleanedContainerID := stripTrailingCharacters(out)
+
+	stopCmdWithRm := exec.Command(dockerBinary, "stop", "--rm", cleanedContainerID)
+	out, _, err = runCommandWithOutput(stopCmdWithRm)
+	if err != nil {
+		t.Fatal(out, err)
+	}
+
+	outputID := stripTrailingCharacters(out)
+	if outputID != cleanedContainerID {
+		t.Fatalf("Expected to get %s, got %s", cleanedContainerID, outputID)
+	}
+
+	out, err = getAllContainers()
+	if err != nil {
+		t.Fatal(out, err)
+	}
+
+	if out != "" {
+		t.Fatal("Expected not to have containers", out)
+	}
+
+	logDone("stop - container is removed if stopped with --rm")
+}


### PR DESCRIPTION
I personally find this useful when working with `run -d` and each time having to stop and rm the container in two commands.

Signed-off-by: Antonio Murdaca me@runcom.ninja
