### PR TITLE
Handle binary remote contexts when creating builder jobs.

### DIFF
--- a/builder/job_test.go
+++ b/builder/job_test.go
@@ -1,0 +1,113 @@
+package builder
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+)
+
+var textPlainDockerfile = "FROM busybox"
+var binaryContext = []byte{0xFD, 0x37, 0x7A, 0x58, 0x5A, 0x00} //xz magic
+
+func TestInspectEmptyResponse(t *testing.T) {
+	ct := "application/octet-stream"
+	br := ioutil.NopCloser(bytes.NewReader([]byte("")))
+	contentType, bReader, err := inspectResponse(ct, br, 0)
+	if err == nil {
+		t.Fatalf("Should have generated an error for an empty response")
+	}
+	if contentType != "application/octet-stream" {
+		t.Fatalf("Content type should be 'application/octet-stream' but is %q", contentType)
+	}
+	body, err := ioutil.ReadAll(bReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) != 0 {
+		t.Fatal("response body should remain empty")
+	}
+}
+
+func TestInspectResponseBinary(t *testing.T) {
+	ct := "application/octet-stream"
+	br := ioutil.NopCloser(bytes.NewReader(binaryContext))
+	contentType, bReader, err := inspectResponse(ct, br, len(binaryContext))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contentType != "application/octet-stream" {
+		t.Fatalf("Content type should be 'application/octet-stream' but is %q", contentType)
+	}
+	body, err := ioutil.ReadAll(bReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(body) != len(binaryContext) {
+		t.Fatalf("Wrong response size %d, should be == len(binaryContext)", len(body))
+	}
+	for i := range body {
+		if body[i] != binaryContext[i] {
+			t.Fatalf("Corrupted response body at byte index %d", i)
+		}
+	}
+}
+
+func TestResponseUnsupportedContentType(t *testing.T) {
+	content := []byte(textPlainDockerfile)
+	ct := "application/json"
+	br := ioutil.NopCloser(bytes.NewReader(content))
+	contentType, bReader, err := inspectResponse(ct, br, len(textPlainDockerfile))
+
+	if err == nil {
+		t.Fatal("Should have returned an error on content-type 'application/json'")
+	}
+	if contentType != ct {
+		t.Fatalf("Should not have altered content-type: orig: %s, altered: %s", ct, contentType)
+	}
+	body, err := ioutil.ReadAll(bReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != textPlainDockerfile {
+		t.Fatalf("Corrupted response body %s", body)
+	}
+}
+
+func TestInspectResponseTextSimple(t *testing.T) {
+	content := []byte(textPlainDockerfile)
+	ct := "text/plain"
+	br := ioutil.NopCloser(bytes.NewReader(content))
+	contentType, bReader, err := inspectResponse(ct, br, len(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contentType != "text/plain" {
+		t.Fatalf("Content type should be 'text/plain' but is %q", contentType)
+	}
+	body, err := ioutil.ReadAll(bReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != textPlainDockerfile {
+		t.Fatalf("Corrupted response body %s", body)
+	}
+}
+
+func TestInspectResponseEmptyContentType(t *testing.T) {
+	content := []byte(textPlainDockerfile)
+	br := ioutil.NopCloser(bytes.NewReader(content))
+	contentType, bodyReader, err := inspectResponse("", br, len(content))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contentType != "text/plain" {
+		t.Fatalf("Content type should be 'text/plain' but is %q", contentType)
+	}
+	body, err := ioutil.ReadAll(bodyReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != textPlainDockerfile {
+		t.Fatalf("Corrupted response body %s", body)
+	}
+}

--- a/builder/support.go
+++ b/builder/support.go
@@ -1,8 +1,17 @@
 package builder
 
 import (
+	"regexp"
 	"strings"
 )
+
+const acceptableRemoteMIME = `(?:application/(?:(?:x\-)?tar|octet\-stream|((?:x\-)?(?:gzip|bzip2?|xz)))|(?:text/plain))`
+
+var mimeRe = regexp.MustCompile(acceptableRemoteMIME)
+
+func selectAcceptableMIME(ct string) string {
+	return mimeRe.FindString(ct)
+}
 
 func handleJsonArgs(args []string, attributes map[string]bool) []string {
 	if len(args) == 0 {

--- a/builder/support_test.go
+++ b/builder/support_test.go
@@ -1,0 +1,41 @@
+package builder
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSelectAcceptableMIME(t *testing.T) {
+	validMimeStrings := []string{
+		"application/x-bzip2",
+		"application/bzip2",
+		"application/gzip",
+		"application/x-gzip",
+		"application/x-xz",
+		"application/xz",
+		"application/tar",
+		"application/x-tar",
+		"application/octet-stream",
+		"text/plain",
+	}
+
+	invalidMimeStrings := []string{
+		"",
+		"application/octet",
+		"application/json",
+	}
+
+	for _, m := range invalidMimeStrings {
+		if len(selectAcceptableMIME(m)) > 0 {
+			err := fmt.Errorf("Should not have accepted %q", m)
+			t.Fatal(err)
+		}
+	}
+
+	for _, m := range validMimeStrings {
+		if str := selectAcceptableMIME(m); str == "" {
+			err := fmt.Errorf("Should have accepted %q", m)
+			t.Fatal(err)
+		}
+	}
+}

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -1181,13 +1181,17 @@ or being killed.
 
 Query Parameters:
 
--   **dockerfile** - Path within the build context to the Dockerfile. This is 
-        ignored if `remote` is specified and points to an individual filename.
--   **t** – A repository name (and optionally a tag) to apply to
+-   **dockerfile** - Path within the build context to the `Dockerfile`. This is
+        ignored if `remote` is specified and points to an external `Dockerfile`.
+-   **t** – Repository name (and optionally a tag) to be applied to
         the resulting image in case of success.
--   **remote** – A Git repository URI or HTTP/HTTPS URI build source. If the 
-        URI specifies a filename, the file's contents are placed into a file 
-		called `Dockerfile`.
+-   **remote** – A Git repository URI or HTTP/HTTPS context URI. If the
+        URI points to a single text file, the file's contents are placed into
+        a file called `Dockerfile` and the image is built from that file. If
+        the URI points to a tarball, the file is downloaded by the daemon and
+        the contents therein used as the context for the build. If the URI
+        points to a tarball and the `dockerfile` parameter is also specified,
+        there must be a file with the corresponding path inside the tarball.
 -   **q** – Suppress verbose build output.
 -   **nocache** – Do not use the cache when building the image.
 -   **pull** - Attempt to pull the image even if an older image exists locally.

--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -37,13 +37,18 @@ daemon, not by the CLI, so the whole context must be transferred to the daemon.
 The Docker CLI reports "Sending build context to Docker daemon" when the context is sent to 
 the daemon.
 
-When a single Dockerfile is given as the URL, then no context is set.
-When a Git repository is set as the **URL**, the repository is used
-as context.
+When the URL to a tarball archive or to a single Dockerfile is given, no context is sent from
+the client to the Docker daemon. When a Git repository is set as the **URL**, the repository is
+cloned locally and then sent as the context.
 
 # OPTIONS
 **-f**, **--file**=*PATH/Dockerfile*
-   Path to the Dockerfile to use. If the path is a relative path then it must be relative to the current directory. The file must be within the build context. The default is *Dockerfile*.
+   Path to the Dockerfile to use. If the path is a relative path and you are
+   building from a local directory, then the path must be relative to that
+   directory. If you are building from a remote URL pointing to either a
+   tarball or a Git repository, then the path must be relative to the root of
+   the remote context. In all cases, the file must be within the build context.
+   The default is *Dockerfile*.
 
 **--force-rm**=*true*|*false*
    Always remove intermediate containers, even after unsuccessful builds. The default is *false*.
@@ -208,6 +213,17 @@ repository.
     docker build github.com/scollier/Fedora-Dockerfiles/tree/master/apache
 
 Note: You can set an arbitrary Git repository via the `git://` schema.
+
+## Building an image using a URL to a tarball'ed context
+
+This will send the URL itself to the Docker daemon. The daemon will fetch the
+tarball archive, decompress it and use its contents as the build context. If you
+pass an *-f PATH/Dockerfile* option as well, the system will look for that file
+inside the contents of the tarball.
+
+    docker build -f dev/Dockerfile https://10.10.10.1/docker/context.tar.gz
+
+Note: supported compression formats are 'xz', 'bzip2', 'gzip' and 'identity' (no compression).
 
 # HISTORY
 March 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/pkg/httputils/mimetype.go
+++ b/pkg/httputils/mimetype.go
@@ -1,0 +1,30 @@
+package httputils
+
+import (
+	"mime"
+	"net/http"
+)
+
+var MimeTypes = struct {
+	TextPlain   string
+	Tar         string
+	OctetStream string
+}{"text/plain", "application/tar", "application/octet-stream"}
+
+// DetectContentType returns a best guess representation of the MIME
+// content type for the bytes at c.  The value detected by
+// http.DetectContentType is guaranteed not be nil, defaulting to
+// application/octet-stream when a better guess cannot be made. The
+// result of this detection is then run through mime.ParseMediaType()
+// which separates it from any parameters.
+// Note that calling this function does not advance the Reader at r
+func DetectContentType(c []byte) (string, map[string]string, error) {
+
+	ct := http.DetectContentType(c)
+	contentType, args, err := mime.ParseMediaType(ct)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return contentType, args, nil
+}


### PR DESCRIPTION
Add support for fetching compressed remote contexts from the `remote` query parameter in `/build`, as described in #12078.

Signed-off-by: Moysés Borges moysesb@gmail.com

closes #12078 
