### PR TITLE
Remove `stripTrailingCharacters` from tests

### DIFF
--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,7 +23,7 @@ func TestGetContainersAttachWebsocket(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	config, err := websocket.NewConfig(
 		"/containers/"+cleanedContainerID+"/attach/ws?stream=1&stdin=1&stdout=1&stderr=1",
 		"http://localhost",

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -15,7 +16,7 @@ func TestInspectApiContainerResponse(t *testing.T) {
 		t.Fatalf("failed to create a container: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	// test on json marshal version
 	// and latest version

--- a/integration-cli/docker_api_resize_test.go
+++ b/integration-cli/docker_api_resize_test.go
@@ -13,7 +13,7 @@ func TestResizeApiResponse(t *testing.T) {
 		t.Fatalf(out, err)
 	}
 	defer deleteAllContainers()
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=40&w=40"
 	_, err = sockRequest("POST", endpoint, nil)
@@ -31,7 +31,7 @@ func TestResizeApiResponseWhenContainerNotStarted(t *testing.T) {
 		t.Fatalf(out, err)
 	}
 	defer deleteAllContainers()
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	// make sure the exited cintainer is not running
 	runCmd = exec.Command(dockerBinary, "wait", cleanedContainerID)

--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -21,7 +21,7 @@ func TestAttachClosedOnContainerStop(t *testing.T) {
 		t.Fatalf("failed to start container: %v (%v)", out, err)
 	}
 
-	id := stripTrailingCharacters(out)
+	id := strings.TrimSpace(out)
 	if err := waitRun(id); err != nil {
 		t.Fatal(err)
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -492,7 +492,7 @@ func TestBuildOnBuildForbiddenMaintainerInSourceImage(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	commitCmd := exec.Command(dockerBinary, "commit", "--run", "{\"OnBuild\":[\"MAINTAINER docker.io\"]}", cleanedContainerID, "onbuild")
 
@@ -526,7 +526,7 @@ func TestBuildOnBuildForbiddenFromInSourceImage(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	commitCmd := exec.Command(dockerBinary, "commit", "--run", "{\"OnBuild\":[\"FROM busybox\"]}", cleanedContainerID, "onbuild")
 
@@ -560,7 +560,7 @@ func TestBuildOnBuildForbiddenChainedInSourceImage(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	commitCmd := exec.Command(dockerBinary, "commit", "--run", "{\"OnBuild\":[\"ONBUILD RUN ls\"]}", cleanedContainerID, "onbuild")
 
@@ -5534,7 +5534,7 @@ func TestBuildResourceConstraintsAreUsed(t *testing.T) {
 		t.Fatal(err, out)
 	}
 
-	cID := stripTrailingCharacters(out)
+	cID := strings.TrimSpace(out)
 
 	type hostConfig struct {
 		Memory     float64 // Use float64 here since the json decoder sees it that way

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -13,7 +13,7 @@ func TestCommitAfterContainerIsDone(t *testing.T) {
 		t.Fatalf("failed to run container: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	waitCmd := exec.Command(dockerBinary, "wait", cleanedContainerID)
 	if _, _, err = runCommandWithOutput(waitCmd); err != nil {
@@ -26,7 +26,7 @@ func TestCommitAfterContainerIsDone(t *testing.T) {
 		t.Fatalf("failed to commit container to image: %s, %v", out, err)
 	}
 
-	cleanedImageID := stripTrailingCharacters(out)
+	cleanedImageID := strings.TrimSpace(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedImageID)
 	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
@@ -46,7 +46,7 @@ func TestCommitWithoutPause(t *testing.T) {
 		t.Fatalf("failed to run container: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	waitCmd := exec.Command(dockerBinary, "wait", cleanedContainerID)
 	if _, _, err = runCommandWithOutput(waitCmd); err != nil {
@@ -59,7 +59,7 @@ func TestCommitWithoutPause(t *testing.T) {
 		t.Fatalf("failed to commit container to image: %s, %v", out, err)
 	}
 
-	cleanedImageID := stripTrailingCharacters(out)
+	cleanedImageID := strings.TrimSpace(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedImageID)
 	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
@@ -82,7 +82,7 @@ func TestCommitPausedContainer(t *testing.T) {
 		t.Fatalf("failed to run container: %v, output: %q", err, out)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	cmd = exec.Command(dockerBinary, "pause", cleanedContainerID)
 	out, _, _, err = runCommandWithStdoutStderr(cmd)
 	if err != nil {
@@ -94,7 +94,7 @@ func TestCommitPausedContainer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to commit container to image: %s, %v", out, err)
 	}
-	cleanedImageID := stripTrailingCharacters(out)
+	cleanedImageID := strings.TrimSpace(out)
 	defer deleteImages(cleanedImageID)
 
 	cmd = exec.Command(dockerBinary, "inspect", "-f", "{{.State.Paused}}", cleanedContainerID)

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -30,11 +30,11 @@ func TestCpGarbagePath(t *testing.T) {
 		t.Fatal("failed to create a container", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
-	if err != nil || stripTrailingCharacters(out) != "0" {
+	if err != nil || strings.TrimSpace(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
@@ -92,11 +92,11 @@ func TestCpRelativePath(t *testing.T) {
 		t.Fatal("failed to create a container", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
-	if err != nil || stripTrailingCharacters(out) != "0" {
+	if err != nil || strings.TrimSpace(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
@@ -162,11 +162,11 @@ func TestCpAbsolutePath(t *testing.T) {
 		t.Fatal("failed to create a container", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
-	if err != nil || stripTrailingCharacters(out) != "0" {
+	if err != nil || strings.TrimSpace(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
@@ -226,11 +226,11 @@ func TestCpAbsoluteSymlink(t *testing.T) {
 		t.Fatal("failed to create a container", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
-	if err != nil || stripTrailingCharacters(out) != "0" {
+	if err != nil || strings.TrimSpace(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
@@ -290,11 +290,11 @@ func TestCpSymlinkComponent(t *testing.T) {
 		t.Fatal("failed to create a container", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
-	if err != nil || stripTrailingCharacters(out) != "0" {
+	if err != nil || strings.TrimSpace(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
@@ -355,11 +355,11 @@ func TestCpUnprivilegedUser(t *testing.T) {
 		t.Fatal("failed to create a container", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
-	if err != nil || stripTrailingCharacters(out) != "0" {
+	if err != nil || strings.TrimSpace(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
@@ -398,11 +398,11 @@ func TestCpSpecialFiles(t *testing.T) {
 		t.Fatal("failed to create a container", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
-	if err != nil || stripTrailingCharacters(out) != "0" {
+	if err != nil || strings.TrimSpace(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
@@ -471,11 +471,11 @@ func TestCpVolumePath(t *testing.T) {
 		t.Fatal("failed to create a container", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
-	if err != nil || stripTrailingCharacters(out) != "0" {
+	if err != nil || strings.TrimSpace(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
@@ -562,11 +562,11 @@ func TestCpToDot(t *testing.T) {
 		t.Fatal("failed to create a container", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	out, _, err = dockerCmd(t, "wait", cleanedContainerID)
-	if err != nil || stripTrailingCharacters(out) != "0" {
+	if err != nil || strings.TrimSpace(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
@@ -600,11 +600,11 @@ func TestCpToStdout(t *testing.T) {
 		t.Fatalf("failed to create a container:%s\n%s", out, err)
 	}
 
-	cID := stripTrailingCharacters(out)
+	cID := strings.TrimSpace(out)
 	defer deleteContainer(cID)
 
 	out, _, err = dockerCmd(t, "wait", cID)
-	if err != nil || stripTrailingCharacters(out) != "0" {
+	if err != nil || strings.TrimSpace(out) != "0" {
 		t.Fatalf("failed to set up container:%s\n%s", out, err)
 	}
 

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -21,7 +22,7 @@ func TestCreateArgs(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
 	out, _, err = runCommandWithOutput(inspectCmd)
@@ -73,7 +74,7 @@ func TestCreateHostConfig(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
 	out, _, err = runCommandWithOutput(inspectCmd)
@@ -114,7 +115,7 @@ func TestCreateWithPortRange(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
 	out, _, err = runCommandWithOutput(inspectCmd)
@@ -163,7 +164,7 @@ func TestCreateWithiLargePortRange(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
 	out, _, err = runCommandWithOutput(inspectCmd)
@@ -213,7 +214,7 @@ func TestCreateEchoStdout(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "start", "-ai", cleanedContainerID)
 	out, _, _, err = runCommandWithStdoutStderr(runCmd)

--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -15,7 +15,7 @@ func TestDiffFilenameShownInOutput(t *testing.T) {
 		t.Fatalf("failed to start the container: %s, %v", out, err)
 	}
 
-	cleanCID := stripTrailingCharacters(out)
+	cleanCID := strings.TrimSpace(out)
 
 	diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
 	out, _, err = runCommandWithOutput(diffCmd)
@@ -52,7 +52,7 @@ func TestDiffEnsureDockerinitFilesAreIgnored(t *testing.T) {
 			t.Fatal(out, err)
 		}
 
-		cleanCID := stripTrailingCharacters(out)
+		cleanCID := strings.TrimSpace(out)
 
 		diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
 		out, _, err = runCommandWithOutput(diffCmd)
@@ -79,7 +79,7 @@ func TestDiffEnsureOnlyKmsgAndPtmx(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanCID := stripTrailingCharacters(out)
+	cleanCID := strings.TrimSpace(out)
 
 	diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
 	out, _, err = runCommandWithOutput(diffCmd)

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -182,7 +182,7 @@ func TestEventsImageImport(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to create a container", out, err)
 	}
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	out, _, err = runCommandPipelineWithOutput(
 		exec.Command(dockerBinary, "export", cleanedContainerID),
@@ -258,13 +258,13 @@ func TestEventsFilterImageName(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	container1 := stripTrailingCharacters(out)
+	container1 := strings.TrimSpace(out)
 
 	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", "--name", "container_2", "-d", "busybox", "true"))
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	container2 := stripTrailingCharacters(out)
+	container2 := strings.TrimSpace(out)
 
 	for _, s := range []string{"busybox", "busybox:latest"} {
 		eventsCmd := exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(t).Unix()), "--filter", fmt.Sprintf("image=%s", s))
@@ -302,13 +302,13 @@ func TestEventsFilterContainerID(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	container1 := stripTrailingCharacters(out)
+	container1 := strings.TrimSpace(out)
 
 	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "busybox", "true"))
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	container2 := stripTrailingCharacters(out)
+	container2 := strings.TrimSpace(out)
 
 	for _, s := range []string{container1, container2, container1[:12], container2[:12]} {
 		eventsCmd := exec.Command(dockerBinary, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(t).Unix()), "--filter", fmt.Sprintf("container=%s", s))

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -141,7 +141,7 @@ func TestExecAfterContainerRestart(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "restart", cleanedContainerID)
 	if out, _, err = runCommandWithOutput(runCmd); err != nil {
@@ -253,7 +253,7 @@ func TestExecPausedContainer(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	ContainerID := stripTrailingCharacters(out)
+	ContainerID := strings.TrimSpace(out)
 
 	pausedCmd := exec.Command(dockerBinary, "pause", "testing")
 	out, _, _, err = runCommandWithStdoutStderr(pausedCmd)
@@ -501,12 +501,12 @@ func TestLinksPingLinkedContainersOnRename(t *testing.T) {
 
 	var out string
 	out, _, _ = dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
-	idA := stripTrailingCharacters(out)
+	idA := strings.TrimSpace(out)
 	if idA == "" {
 		t.Fatal(out, "id should not be nil")
 	}
 	out, _, _ = dockerCmd(t, "run", "-d", "--link", "container1:alias1", "--name", "container2", "busybox", "sleep", "10")
-	idB := stripTrailingCharacters(out)
+	idB := strings.TrimSpace(out)
 	if idB == "" {
 		t.Fatal(out, "id should not be nil")
 	}

--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -15,7 +15,7 @@ func TestExportContainerAndImportImage(t *testing.T) {
 		t.Fatal("failed to create a container", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
 	out, _, err = runCommandWithOutput(inspectCmd)
@@ -35,7 +35,7 @@ func TestExportContainerAndImportImage(t *testing.T) {
 		t.Fatalf("failed to import image: %s, %v", out, err)
 	}
 
-	cleanedImageID := stripTrailingCharacters(out)
+	cleanedImageID := strings.TrimSpace(out)
 
 	inspectCmd = exec.Command(dockerBinary, "inspect", cleanedImageID)
 	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
@@ -56,7 +56,7 @@ func TestExportContainerWithOutputAndImportImage(t *testing.T) {
 		t.Fatal("failed to create a container", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
 	out, _, err = runCommandWithOutput(inspectCmd)
@@ -81,7 +81,7 @@ func TestExportContainerWithOutputAndImportImage(t *testing.T) {
 		t.Fatalf("failed to import image: %s, %v", out, err)
 	}
 
-	cleanedImageID := stripTrailingCharacters(out)
+	cleanedImageID := strings.TrimSpace(out)
 
 	inspectCmd = exec.Command(dockerBinary, "inspect", cleanedImageID)
 	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {

--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -12,7 +12,7 @@ func TestImportDisplay(t *testing.T) {
 	if err != nil {
 		t.Fatal("failed to create a container", out, err)
 	}
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	out, _, err = runCommandPipelineWithOutput(

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -13,7 +13,7 @@ func TestKillContainer(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
 	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
@@ -47,7 +47,7 @@ func TestKillDifferentUserContainer(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
 	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -111,9 +111,9 @@ func TestLinksPingLinkedContainersAfterRename(t *testing.T) {
 	defer deleteAllContainers()
 
 	out, _, _ := dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
-	idA := stripTrailingCharacters(out)
+	idA := strings.TrimSpace(out)
 	out, _, _ = dockerCmd(t, "run", "-d", "--name", "container2", "busybox", "sleep", "10")
-	idB := stripTrailingCharacters(out)
+	idB := strings.TrimSpace(out)
 	dockerCmd(t, "rename", "container1", "container_new")
 	dockerCmd(t, "run", "--rm", "--link", "container_new:alias1", "--link", "container2:alias2", "busybox", "sh", "-c", "ping -c 1 alias1 -W 1 && ping -c 1 alias2 -W 1")
 	dockerCmd(t, "kill", idA)

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -20,7 +20,7 @@ func TestLogsContainerSmallerThanPage(t *testing.T) {
 		t.Fatalf("run failed with errors: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
@@ -47,7 +47,7 @@ func TestLogsContainerBiggerThanPage(t *testing.T) {
 		t.Fatalf("run failed with errors: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
@@ -74,7 +74,7 @@ func TestLogsContainerMuchBiggerThanPage(t *testing.T) {
 		t.Fatalf("run failed with errors: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
@@ -101,7 +101,7 @@ func TestLogsTimestamps(t *testing.T) {
 		t.Fatalf("run failed with errors: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", "-t", cleanedContainerID)
@@ -144,7 +144,7 @@ func TestLogsSeparateStderr(t *testing.T) {
 		t.Fatalf("run failed with errors: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
@@ -176,7 +176,7 @@ func TestLogsStderrInStdout(t *testing.T) {
 		t.Fatalf("run failed with errors: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
@@ -208,7 +208,7 @@ func TestLogsTail(t *testing.T) {
 		t.Fatalf("run failed with errors: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", "--tail", "5", cleanedContainerID)
@@ -259,7 +259,7 @@ func TestLogsFollowStopped(t *testing.T) {
 		t.Fatalf("run failed with errors: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
 	logsCmd := exec.Command(dockerBinary, "logs", "-f", cleanedContainerID)
@@ -294,7 +294,7 @@ func TestLogsFollowSlowStdoutConsumer(t *testing.T) {
 		t.Fatalf("run failed with errors: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	stopSlowRead := make(chan bool)

--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -33,7 +33,7 @@ func TestNetworkNat(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "run", "busybox", "sh", "-c", fmt.Sprintf("echo hello world | nc -w 30 %s 8080", ifaceIP))
 	out, _, err = runCommandWithOutput(runCmd)

--- a/integration-cli/docker_cli_port_test.go
+++ b/integration-cli/docker_cli_port_test.go
@@ -16,7 +16,7 @@ func TestPortList(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	firstID := stripTrailingCharacters(out)
+	firstID := strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "port", firstID, "80")
 	out, _, err = runCommandWithOutput(runCmd)
@@ -52,7 +52,7 @@ func TestPortList(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	ID := stripTrailingCharacters(out)
+	ID := strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "port", ID, "80")
 	out, _, err = runCommandWithOutput(runCmd)
@@ -93,7 +93,7 @@ func TestPortList(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	ID = stripTrailingCharacters(out)
+	ID = strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "port", ID, "80")
 	out, _, err = runCommandWithOutput(runCmd)

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -18,14 +18,14 @@ func TestPsListContainers(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	firstID := stripTrailingCharacters(out)
+	firstID := strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	out, _, err = runCommandWithOutput(runCmd)
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	secondID := stripTrailingCharacters(out)
+	secondID := strings.TrimSpace(out)
 
 	// not long running
 	runCmd = exec.Command(dockerBinary, "run", "-d", "busybox", "true")
@@ -33,14 +33,14 @@ func TestPsListContainers(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	thirdID := stripTrailingCharacters(out)
+	thirdID := strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	out, _, err = runCommandWithOutput(runCmd)
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	fourthID := stripTrailingCharacters(out)
+	fourthID := strings.TrimSpace(out)
 
 	// make sure third one is not running
 	runCmd = exec.Command(dockerBinary, "wait", thirdID)
@@ -312,7 +312,7 @@ func TestPsListContainersFilterStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	firstID := stripTrailingCharacters(out)
+	firstID := strings.TrimSpace(out)
 
 	// make sure the exited cintainer is not running
 	runCmd = exec.Command(dockerBinary, "wait", firstID)
@@ -326,7 +326,7 @@ func TestPsListContainersFilterStatus(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	secondID := stripTrailingCharacters(out)
+	secondID := strings.TrimSpace(out)
 
 	// filter containers by exited
 	runCmd = exec.Command(dockerBinary, "ps", "-q", "--filter=status=exited")
@@ -361,7 +361,7 @@ func TestPsListContainersFilterID(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	firstID := stripTrailingCharacters(out)
+	firstID := strings.TrimSpace(out)
 
 	// start another container
 	runCmd = exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", "sleep 360")
@@ -391,7 +391,7 @@ func TestPsListContainersFilterName(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	firstID := stripTrailingCharacters(out)
+	firstID := strings.TrimSpace(out)
 
 	// start another container
 	runCmd = exec.Command(dockerBinary, "run", "-d", "--name=b_name_to_match", "busybox", "sh", "-c", "sleep 360")
@@ -419,21 +419,21 @@ func TestPsListContainersFilterLabel(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	firstID := stripTrailingCharacters(out)
+	firstID := strings.TrimSpace(out)
 
 	// start another container
 	runCmd = exec.Command(dockerBinary, "run", "-d", "-l", "match=me too", "busybox")
 	if out, _, err = runCommandWithOutput(runCmd); err != nil {
 		t.Fatal(out, err)
 	}
-	secondID := stripTrailingCharacters(out)
+	secondID := strings.TrimSpace(out)
 
 	// start third container
 	runCmd = exec.Command(dockerBinary, "run", "-d", "-l", "nomatch=me", "busybox")
 	if out, _, err = runCommandWithOutput(runCmd); err != nil {
 		t.Fatal(out, err)
 	}
-	thirdID := stripTrailingCharacters(out)
+	thirdID := strings.TrimSpace(out)
 
 	// filter containers by exact match
 	runCmd = exec.Command(dockerBinary, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me")

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -15,7 +15,7 @@ func TestRenameStoppedContainer(t *testing.T) {
 		t.Fatalf(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "wait", cleanedContainerID)
 	out, _, err = runCommandWithOutput(runCmd)
@@ -51,7 +51,7 @@ func TestRenameRunningContainer(t *testing.T) {
 		t.Fatalf(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	runCmd = exec.Command(dockerBinary, "rename", "first_name", "new_name")
 	out, _, err = runCommandWithOutput(runCmd)
 	if err != nil {

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -16,7 +16,7 @@ func TestRestartStoppedContainer(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "wait", cleanedContainerID)
 	if out, _, err = runCommandWithOutput(runCmd); err != nil {
@@ -60,7 +60,7 @@ func TestRestartRunningContainer(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	time.Sleep(1 * time.Second)
 
@@ -104,7 +104,7 @@ func TestRestartWithVolumes(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "inspect", "--format", "{{ len .Volumes }}", cleanedContainerID)
 	out, _, err = runCommandWithOutput(runCmd)

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -16,7 +16,7 @@ func TestRmiWithContainerFails(t *testing.T) {
 		t.Fatalf("failed to create a container: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	// try to delete the image
 	runCmd = exec.Command(dockerBinary, "rmi", "busybox")

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -199,7 +199,7 @@ func TestRunStdinPipe(t *testing.T) {
 		t.Fatalf("failed to run container: %v, output: %q", err, out)
 	}
 
-	out = stripTrailingCharacters(out)
+	out = strings.TrimSpace(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", out)
 	if out, _, err := runCommandWithOutput(inspectCmd); err != nil {
@@ -217,7 +217,7 @@ func TestRunStdinPipe(t *testing.T) {
 		t.Fatalf("error thrown while trying to get container logs: %s, %v", logsOut, err)
 	}
 
-	containerLogs := stripTrailingCharacters(logsOut)
+	containerLogs := strings.TrimSpace(logsOut)
 
 	if containerLogs != "blahblah" {
 		t.Errorf("logs didn't print the container's logs %s", containerLogs)
@@ -241,7 +241,7 @@ func TestRunDetachedContainerIDPrinting(t *testing.T) {
 		t.Fatalf("failed to run container: %v, output: %q", err, out)
 	}
 
-	out = stripTrailingCharacters(out)
+	out = strings.TrimSpace(out)
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", out)
 	if inspectOut, _, err := runCommandWithOutput(inspectCmd); err != nil {
@@ -259,7 +259,7 @@ func TestRunDetachedContainerIDPrinting(t *testing.T) {
 		t.Fatalf("rm failed to remove container: %s, %v", rmOut, err)
 	}
 
-	rmOut = stripTrailingCharacters(rmOut)
+	rmOut = strings.TrimSpace(rmOut)
 	if rmOut != out {
 		t.Errorf("rm didn't print the container ID %s %s", out, rmOut)
 	}
@@ -277,7 +277,7 @@ func TestRunWorkingDirectory(t *testing.T) {
 		t.Fatalf("failed to run container: %v, output: %q", err, out)
 	}
 
-	out = stripTrailingCharacters(out)
+	out = strings.TrimSpace(out)
 
 	if out != "/root" {
 		t.Errorf("-w failed to set working directory")
@@ -289,7 +289,7 @@ func TestRunWorkingDirectory(t *testing.T) {
 		t.Fatal(out, err)
 	}
 
-	out = stripTrailingCharacters(out)
+	out = strings.TrimSpace(out)
 
 	if out != "/root" {
 		t.Errorf("--workdir failed to set working directory")
@@ -2215,7 +2215,7 @@ func TestRunWriteHostsFileAndNotCommit(t *testing.T) {
 func eqToBaseDiff(out string, t *testing.T) bool {
 	cmd := exec.Command(dockerBinary, "run", "-d", "busybox", "echo", "hello")
 	out1, _, err := runCommandWithOutput(cmd)
-	cID := stripTrailingCharacters(out1)
+	cID := strings.TrimSpace(out1)
 	cmd = exec.Command(dockerBinary, "diff", cID)
 	baseDiff, _, err := runCommandWithOutput(cmd)
 	if err != nil {

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -20,7 +20,7 @@ func TestSaveXzAndLoadRepoStdout(t *testing.T) {
 		t.Fatalf("failed to create a container: %v %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	repoName := "foobar-save-load-test-xz-gz"
 
@@ -77,7 +77,7 @@ func TestSaveXzGzAndLoadRepoStdout(t *testing.T) {
 		t.Fatalf("failed to create a container: %v %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	repoName := "foobar-save-load-test-xz-gz"
 
@@ -142,7 +142,7 @@ func TestSaveSingleTag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get repo ID: %s, %v", out, err)
 	}
-	cleanedImageID := stripTrailingCharacters(out)
+	cleanedImageID := strings.TrimSpace(out)
 
 	out, _, err = runCommandPipelineWithOutput(
 		exec.Command(dockerBinary, "save", fmt.Sprintf("%v:latest", repoName)),
@@ -170,7 +170,7 @@ func TestSaveImageId(t *testing.T) {
 		t.Fatalf("failed to get repo ID: %s, %v", out, err)
 	}
 
-	cleanedLongImageID := stripTrailingCharacters(out)
+	cleanedLongImageID := strings.TrimSpace(out)
 
 	idShortCmd := exec.Command(dockerBinary, "images", "-q", repoName)
 	out, _, err = runCommandWithOutput(idShortCmd)
@@ -178,7 +178,7 @@ func TestSaveImageId(t *testing.T) {
 		t.Fatalf("failed to get repo short ID: %s, %v", out, err)
 	}
 
-	cleanedShortImageID := stripTrailingCharacters(out)
+	cleanedShortImageID := strings.TrimSpace(out)
 
 	saveCmd := exec.Command(dockerBinary, "save", cleanedShortImageID)
 	tarCmd := exec.Command("tar", "t")
@@ -218,7 +218,7 @@ func TestSaveAndLoadRepoFlags(t *testing.T) {
 		t.Fatalf("failed to create a container: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	repoName := "foobar-save-load-test"
@@ -302,14 +302,14 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 		if out, _, err = runCommandWithOutput(runCmd); err != nil {
 			t.Fatalf("failed to create a container: %v %v", out, err)
 		}
-		cleanedContainerID := stripTrailingCharacters(out)
+		cleanedContainerID := strings.TrimSpace(out)
 		defer deleteContainer(cleanedContainerID)
 
 		commitCmd := exec.Command(dockerBinary, "commit", cleanedContainerID, tag)
 		if out, _, err = runCommandWithOutput(commitCmd); err != nil {
 			t.Fatalf("failed to commit container: %v %v", out, err)
 		}
-		imageID := stripTrailingCharacters(out)
+		imageID := strings.TrimSpace(out)
 		return imageID
 	}
 
@@ -333,7 +333,7 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to save multiple images: %s, %v", out, err)
 	}
-	actual := strings.Split(stripTrailingCharacters(out), "\n")
+	actual := strings.Split(strings.TrimSpace(out), "\n")
 
 	// make the list of expected layers
 	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "history", "-q", "--no-trunc", "busybox:latest"))
@@ -341,7 +341,7 @@ func TestSaveRepoWithMultipleImages(t *testing.T) {
 		t.Fatalf("failed to get history: %s, %v", out, err)
 	}
 
-	expected := append(strings.Split(stripTrailingCharacters(out), "\n"), idFoo, idBar)
+	expected := append(strings.Split(strings.TrimSpace(out), "\n"), idFoo, idBar)
 
 	sort.Strings(actual)
 	sort.Strings(expected)

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker/vendor/src/github.com/kr/pty"
@@ -20,7 +21,7 @@ func TestSaveAndLoadRepoStdout(t *testing.T) {
 		t.Fatalf("failed to create a container: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	repoName := "foobar-save-load-test"
 

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -49,7 +49,7 @@ func TestStartAttachCorrectExitCode(t *testing.T) {
 		t.Fatalf("failed to run container: %v, output: %q", err, out)
 	}
 
-	out = stripTrailingCharacters(out)
+	out = strings.TrimSpace(out)
 
 	// make sure the container has exited before trying the "start -a"
 	waitCmd := exec.Command(dockerBinary, "wait", out)

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -32,7 +32,7 @@ func TestTagUnprefixedRepoByID(t *testing.T) {
 		t.Fatalf("failed to get the image ID of busybox: %s, %v", out, err)
 	}
 
-	cleanedImageID := stripTrailingCharacters(out)
+	cleanedImageID := strings.TrimSpace(out)
 	tagCmd := exec.Command(dockerBinary, "tag", cleanedImageID, "testfoobarbaz")
 	if out, _, err = runCommandWithOutput(tagCmd); err != nil {
 		t.Fatal(out, err)

--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -13,7 +13,7 @@ func TestTopMultipleArgs(t *testing.T) {
 		t.Fatalf("failed to start the container: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 	defer deleteContainer(cleanedContainerID)
 
 	topCmd := exec.Command(dockerBinary, "top", cleanedContainerID, "-o", "pid")
@@ -36,7 +36,7 @@ func TestTopNonPrivileged(t *testing.T) {
 		t.Fatalf("failed to start the container: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	topCmd := exec.Command(dockerBinary, "top", cleanedContainerID)
 	out1, _, err := runCommandWithOutput(topCmd)
@@ -75,7 +75,7 @@ func TestTopPrivileged(t *testing.T) {
 		t.Fatalf("failed to start the container: %s, %v", out, err)
 	}
 
-	cleanedContainerID := stripTrailingCharacters(out)
+	cleanedContainerID := strings.TrimSpace(out)
 
 	topCmd := exec.Command(dockerBinary, "top", cleanedContainerID)
 	out1, _, err := runCommandWithOutput(topCmd)

--- a/integration-cli/docker_cli_wait_test.go
+++ b/integration-cli/docker_cli_wait_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 )
@@ -15,7 +16,7 @@ func TestWaitNonBlockedExitZero(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	containerID := stripTrailingCharacters(out)
+	containerID := strings.TrimSpace(out)
 
 	status := "true"
 	for i := 0; status != "false"; i++ {
@@ -24,7 +25,7 @@ func TestWaitNonBlockedExitZero(t *testing.T) {
 		if err != nil {
 			t.Fatal(status, err)
 		}
-		status = stripTrailingCharacters(status)
+		status = strings.TrimSpace(status)
 
 		time.Sleep(time.Second)
 		if i >= 60 {
@@ -35,7 +36,7 @@ func TestWaitNonBlockedExitZero(t *testing.T) {
 	runCmd = exec.Command(dockerBinary, "wait", containerID)
 	out, _, err = runCommandWithOutput(runCmd)
 
-	if err != nil || stripTrailingCharacters(out) != "0" {
+	if err != nil || strings.TrimSpace(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
@@ -51,12 +52,12 @@ func TestWaitBlockedExitZero(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	containerID := stripTrailingCharacters(out)
+	containerID := strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "wait", containerID)
 	out, _, err = runCommandWithOutput(runCmd)
 
-	if err != nil || stripTrailingCharacters(out) != "0" {
+	if err != nil || strings.TrimSpace(out) != "0" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
@@ -72,7 +73,7 @@ func TestWaitNonBlockedExitRandom(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	containerID := stripTrailingCharacters(out)
+	containerID := strings.TrimSpace(out)
 
 	status := "true"
 	for i := 0; status != "false"; i++ {
@@ -81,7 +82,7 @@ func TestWaitNonBlockedExitRandom(t *testing.T) {
 		if err != nil {
 			t.Fatal(status, err)
 		}
-		status = stripTrailingCharacters(status)
+		status = strings.TrimSpace(status)
 
 		time.Sleep(time.Second)
 		if i >= 60 {
@@ -92,7 +93,7 @@ func TestWaitNonBlockedExitRandom(t *testing.T) {
 	runCmd = exec.Command(dockerBinary, "wait", containerID)
 	out, _, err = runCommandWithOutput(runCmd)
 
-	if err != nil || stripTrailingCharacters(out) != "99" {
+	if err != nil || strings.TrimSpace(out) != "99" {
 		t.Fatal("failed to set up container", out, err)
 	}
 
@@ -108,12 +109,12 @@ func TestWaitBlockedExitRandom(t *testing.T) {
 	if err != nil {
 		t.Fatal(out, err)
 	}
-	containerID := stripTrailingCharacters(out)
+	containerID := strings.TrimSpace(out)
 
 	runCmd = exec.Command(dockerBinary, "wait", containerID)
 	out, _, err = runCommandWithOutput(runCmd)
 
-	if err != nil || stripTrailingCharacters(out) != "99" {
+	if err != nil || strings.TrimSpace(out) != "99" {
 		t.Fatal("failed to set up container", out, err)
 	}
 

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -526,7 +526,7 @@ func getContainerCount() (int, error) {
 	lines := strings.Split(out, "\n")
 	for _, line := range lines {
 		if strings.Contains(line, containers) {
-			output := stripTrailingCharacters(line)
+			output := strings.TrimSpace(line)
 			output = strings.TrimLeft(output, containers)
 			output = strings.Trim(output, " ")
 			containerCount, err := strconv.Atoi(output)

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -169,10 +169,6 @@ func logDone(message string) {
 	fmt.Printf("[PASSED]: %.69s\n", message)
 }
 
-func stripTrailingCharacters(target string) string {
-	return strings.TrimSpace(target)
-}
-
 func unmarshalJSON(data []byte, result interface{}) error {
 	err := json.Unmarshal(data, result)
 	if err != nil {


### PR DESCRIPTION
This was just an alias to `strings.TrimSpace`
