### PR TITLE
Fixes logDone format

### DIFF
--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -36,7 +36,7 @@ func TestRmiWithContainerFails(t *testing.T) {
 
 	deleteContainer(cleanedContainerID)
 
-	logDone("rmi- container using image while rmi, should not remove image name")
+	logDone("rmi - container using image while rmi, should not remove image name")
 }
 
 func TestRmiTag(t *testing.T) {
@@ -74,7 +74,7 @@ func TestRmiTag(t *testing.T) {
 		}
 
 	}
-	logDone("rmi - tag,rmi- tagging the same images multiple times then removing tags")
+	logDone("rmi - tag,rmi - tagging the same images multiple times then removing tags")
 }
 
 func TestRmiTagWithExistingContainers(t *testing.T) {
@@ -169,5 +169,5 @@ func TestRmiBlank(t *testing.T) {
 	if strings.Contains(out, "No such image") {
 		t.Fatalf("Wrong error message generated: %s", out)
 	}
-	logDone("rmi- blank image name")
+	logDone("rmi - blank image name")
 }


### PR DESCRIPTION
Closes #12042 - Added uniform spacing in integration-cli/docker_cli_rmi_test.go to fix the "rmi-" to "rmi -". Ran and verified test output displays correctly.

Signed-off-by: Megan Kostick mkostick@us.ibm.com
