### PR TITLE
Check mount mode in parseBindMountSpec()

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -230,7 +230,10 @@ func parseBindMountSpec(spec string) (string, string, bool, error) {
 	case 3:
 		path = arr[0]
 		mountToPath = arr[1]
-		writable = validMountMode(arr[2]) && arr[2] == "rw"
+		if !validMountMode(arr[2]) {
+			return "", "", false, fmt.Errorf("invalid mode for volume: %s", arr[2])
+		}
+		writable = (arr[2] == "rw")
 	default:
 		return "", "", false, fmt.Errorf("Invalid volume specification: %s", spec)
 	}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -531,6 +531,21 @@ func TestRunVolumesMountedAsReadonly(t *testing.T) {
 	logDone("run - volumes as readonly mount")
 }
 
+func TestVolumesMountedModeCheck(t *testing.T) {
+	defer deleteAllContainers()
+
+	cmd := exec.Command(dockerBinary, "run", "-d", "-v", "/test:/test:abc", "busybox", "/bin/sh")
+	if _, err := runCommand(cmd); err == nil {
+		t.Fatalf("run should fail because volume mode is illegal")
+	}
+	cmd = exec.Command(dockerBinary, "run", "-d", "-v", "/test:/test:", "busybox", "/bin/sh")
+	if _, err := runCommand(cmd); err == nil {
+		t.Fatalf("run should fail because volume mode is illegal: err info %v", err)
+	}
+
+	logDone("run - volumes mount mode check")
+}
+
 func TestRunVolumesFromInReadonlyMode(t *testing.T) {
 	defer deleteAllContainers()
 	cmd := exec.Command(dockerBinary, "run", "--name", "parent", "-v", "/test", "busybox", "true")


### PR DESCRIPTION
parseVolumesFromSpec() checkes the return value of validMountMode(), and  parseBindMountSpec() does not.

So, following mode will not come up with error:

``` bash
$ sudo docker run --rm -ti -v /home/test:/test/:r   ubuntu mount | grep '\/test'
/dev/disk/by-uuid/f979d672-1256-4252-a04b-f865a902d329 on /test type ext4 (ro,relatime,errors=remount-ro,data=ordered)
$ sudo docker run --rm -ti -v /home/test:/test/:rwr   ubuntu mount | grep '\/test'
/dev/disk/by-uuid/f979d672-1256-4252-a04b-f865a902d329 on /test type ext4 (ro,relatime,errors=remount-ro,data=ordered)
$ sudo docker run --rm -ti -v /home/test:/test/:fff   ubuntu mount | grep '\/test'
/dev/disk/by-uuid/f979d672-1256-4252-a04b-f865a902d329 on /test type ext4 (ro,relatime,errors=remount-ro,data=ordered)
$ sudo docker run --rm -ti -v /home/test:/test/:   ubuntu mount | grep '\/test'
/dev/disk/by-uuid/f979d672-1256-4252-a04b-f865a902d329 on /test type ext4 (ro,relatime,errors=remount-ro,data=ordered)
```

Signed-off-by: Deng Guangxing dengguangxing@huawei.com
