### PR TITLE
Proposal: disable streaming of responses on 'POST' api calls

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -537,10 +537,11 @@ func postImagesCreate(eng *engine.Engine, version version.Version, w http.Respon
 	}
 
 	var (
-		image = r.Form.Get("fromImage")
-		repo  = r.Form.Get("repo")
-		tag   = r.Form.Get("tag")
-		job   *engine.Job
+		image        = r.Form.Get("fromImage")
+		repo         = r.Form.Get("repo")
+		tag          = r.Form.Get("tag")
+		job          *engine.Job
+		stdoutBuffer = bytes.NewBuffer(nil)
 	)
 	authEncoded := r.Header.Get("X-Registry-Auth")
 	authConfig := &registry.AuthConfig{}
@@ -575,20 +576,16 @@ func postImagesCreate(eng *engine.Engine, version version.Version, w http.Respon
 		job.SetenvList("changes", r.Form["changes"])
 	}
 
+	job.Stdout.Add(stdoutBuffer)
 	if version.GreaterThan("1.0") {
 		job.SetenvBool("json", true)
-		streamJSON(job, w, true)
-	} else {
-		job.Stdout.Add(utils.NewWriteFlusher(w))
-	}
-	if err := job.Run(); err != nil {
-		if !job.Stdout.Used() {
-			return err
-		}
-		sf := streamformatter.NewStreamFormatter(version.GreaterThan("1.0"))
-		w.Write(sf.FormatError(err))
 	}
 
+	if err := job.Run(); err != nil {
+		return err
+	}
+
+	writeJSON(w, http.StatusOK, string(stdoutBuffer.Bytes()))
 	return nil
 }
 
@@ -660,18 +657,15 @@ func postImagesPush(eng *engine.Engine, version version.Version, w http.Response
 	job.Setenv("tag", r.Form.Get("tag"))
 	if version.GreaterThan("1.0") {
 		job.SetenvBool("json", true)
-		streamJSON(job, w, true)
-	} else {
-		job.Stdout.Add(utils.NewWriteFlusher(w))
 	}
+	var stdoutBuffer = bytes.NewBuffer(nil)
+	job.Stdout.Add(stdoutBuffer)
 
 	if err := job.Run(); err != nil {
-		if !job.Stdout.Used() {
-			return err
-		}
-		sf := streamformatter.NewStreamFormatter(version.GreaterThan("1.0"))
-		w.Write(sf.FormatError(err))
+		return err
 	}
+
+	writeJSON(w, http.StatusOK, string(stdoutBuffer.Bytes()))
 	return nil
 }
 
@@ -1027,6 +1021,7 @@ func postBuild(eng *engine.Engine, version version.Version, w http.ResponseWrite
 		configFileEncoded = r.Header.Get("X-Registry-Config")
 		configFile        = &registry.ConfigFile{}
 		job               = eng.Job("build")
+		stdoutBuffer      = bytes.NewBuffer(nil)
 	)
 
 	// This block can be removed when API versions prior to 1.9 are deprecated.
@@ -1051,11 +1046,9 @@ func postBuild(eng *engine.Engine, version version.Version, w http.ResponseWrite
 		}
 	}
 
+	job.Stdout.Add(stdoutBuffer)
 	if version.GreaterThanOrEqualTo("1.8") {
 		job.SetenvBool("json", true)
-		streamJSON(job, w, true)
-	} else {
-		job.Stdout.Add(utils.NewWriteFlusher(w))
 	}
 
 	if r.FormValue("forcerm") == "1" && version.GreaterThanOrEqualTo("1.12") {
@@ -1097,12 +1090,10 @@ func postBuild(eng *engine.Engine, version version.Version, w http.ResponseWrite
 	}
 
 	if err := job.Run(); err != nil {
-		if !job.Stdout.Used() {
-			return err
-		}
-		sf := streamformatter.NewStreamFormatter(version.GreaterThanOrEqualTo("1.8"))
-		w.Write(sf.FormatError(err))
+		return err
 	}
+
+	writeJSON(w, http.StatusOK, string(stdoutBuffer.Bytes()))
 	return nil
 }
 


### PR DESCRIPTION
Please see https://github.com/docker/docker/issues/11176 and https://github.com/docker/docker/pull/11375 for  background/more details about the issue.

This proposal disables streaming of responses on 'POST' api calls, which should fix the issue described at https://github.com/docker/docker/issues/11176. However:
- this change brakes cli client.
- this change might open a possibility of tcp timeouts on long calls.
- it is no longer possible to track the status of these calls.
