### PR TITLE
Fixing fail message in TestRunDeviceDirectory

### DIFF
--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -196,7 +196,7 @@ func TestRunDeviceDirectory(t *testing.T) {
 	}
 
 	if actual := strings.Trim(out, "\r\n"); !strings.Contains(out, "seq") {
-		t.Fatalf("expected output /dev/othersnd/timer, received %s", actual)
+		t.Fatalf("expected output /dev/othersnd/seq, received %s", actual)
 	}
 
 	logDone("run - test --device directory mounts all internal devices")


### PR DESCRIPTION
Updated the fail message so the expected output is 'seq' instead of 'timer'. Fixes #12146 

Signed-off-by: Megan Kostick mkostick@us.ibm.com
