### PR TITLE
Remove Job from PS API

### DIFF
--- a/api/client/ps.go
+++ b/api/client/ps.go
@@ -153,7 +153,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\t%s\t%s\t%s\t", ID, image, command,
 			units.HumanDuration(time.Now().UTC().Sub(time.Unix(int64(container.Created), 0))),
-			container.Status, api.NewDisplayablePorts(container.Ports), strings.Join(names, ","))
+			container.Status, api.DisplayablePorts(container.Ports), strings.Join(names, ","))
 
 		if *size {
 			if container.SizeRootFs > 0 {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -122,7 +122,6 @@ func (daemon *Daemon) Install(eng *engine.Engine) error {
 		"container_rename":  daemon.ContainerRename,
 		"container_inspect": daemon.ContainerInspect,
 		"container_stats":   daemon.ContainerStats,
-		"containers":        daemon.Containers,
 		"create":            daemon.ContainerCreate,
 		"rm":                daemon.ContainerRm,
 		"export":            daemon.ContainerExport,


### PR DESCRIPTION
One step closer to removing engine.Table too  :-)

In case people wonder, the code at: https://github.com/docker/docker/compare/master...duglin:RemoveJobPS?expand=1#diff-44a527ea72ea9572e1cf71c7f1e2a0f0L401  appears to be broken based on testing that @jfrazelle and I did.  It always return an empty list and in order for that if-statement to even be executed it requires a CLI to use v1.4 API - which is pretty darn old - way way pre-Docker 1.0.0.   I think its safe to remove it.

Signed-off-by: Doug Davis dug@us.ibm.com
