### PR TITLE
change memory usage display

### DIFF
--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -99,9 +99,9 @@ func (s *containerStats) Display(w io.Writer) error {
 	fmt.Fprintf(w, "%s\t%.2f%%\t%s/%s\t%.2f%%\t%s/%s\n",
 		s.Name,
 		s.CPUPercentage,
-		units.BytesSize(s.Memory), units.BytesSize(s.MemoryLimit),
+		units.HumanSize(s.Memory), units.HumanSize(s.MemoryLimit),
 		s.MemoryPercentage,
-		units.BytesSize(s.NetworkRx), units.BytesSize(s.NetworkTx))
+		units.HumanSize(s.NetworkRx), units.HumanSize(s.NetworkTx))
 	return nil
 }
 

--- a/api/client/stats_unit_test.go
+++ b/api/client/stats_unit_test.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+func TestDisplay(t *testing.T) {
+	c := &containerStats{
+		Name:             "app",
+		CPUPercentage:    30.0,
+		Memory:           100 * 1024 * 1024.0,
+		MemoryLimit:      2048 * 1024 * 1024.0,
+		MemoryPercentage: 100.0 / 2048.0 * 100.0,
+		NetworkRx:        100 * 1024 * 1024,
+		NetworkTx:        800 * 1024 * 1024,
+		mu:               sync.RWMutex{},
+	}
+	var b bytes.Buffer
+	if err := c.Display(&b); err != nil {
+		t.Fatalf("c.Display() gave error: %s", err)
+	}
+	got := b.String()
+	want := "app\t30.00%\t104.9 MB/2.147 GB\t4.88%\t104.9 MB/838.9 MB\n"
+	if got != want {
+		t.Fatalf("c.Display() = %q, want %q", got, want)
+	}
+}

--- a/docs/man/docker-stats.1.md
+++ b/docs/man/docker-stats.1.md
@@ -24,5 +24,5 @@ Run **docker stats** with multiple containers.
     $ docker stats redis1 redis2
     CONTAINER           CPU %               MEM USAGE/LIMIT     MEM %               NET I/O
     redis1              0.07%               796 KiB/64 MiB      1.21%               788 B/648 B
-    redis2              0.07%               2.746 MiB/64 MiB    4.29%               1.266 KiB/648 B
+    redis2              0.07%               2.746 MB/64 MB      4.29%               1.266 KB/648 B
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -2336,7 +2336,7 @@ Running `docker stats` on multiple containers
     $ docker stats redis1 redis2
     CONTAINER           CPU %               MEM USAGE/LIMIT     MEM %               NET I/O
     redis1              0.07%               796 KiB/64 MiB      1.21%               788 B/648 B
-    redis2              0.07%               2.746 MiB/64 MiB    4.29%               1.266 KiB/648 B
+    redis2              0.07%               2.746 MB/64 MB      4.29%               1.266 KB/648 B
 
 
 The `docker stats` command will only return a live stream of data for running


### PR DESCRIPTION
Using standard unix postfixes, for example GiB will be GB .
Add unit test for display.
It's a UI fix, fixes #10824 .

Libcontainer change is here [#506](https://github.com/docker/libcontainer/pull/506)

cc @resouer

Signed-off-by: Sun Jianbo wonderflow@zju.edu.cn
