### PR TITLE
Enable "netgo" library when we build with gccgo

### DIFF
--- a/hack/make/.dockerinit-gccgo
+++ b/hack/make/.dockerinit-gccgo
@@ -12,6 +12,7 @@ go build --compiler=gccgo \
 		-g
 		-Wl,--no-export-dynamic
 		$EXTLDFLAGS_STATIC_DOCKER
+		-lnetgo
 	" \
 	./dockerinit
 

--- a/hack/make/gccgo
+++ b/hack/make/gccgo
@@ -8,6 +8,9 @@ BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
 
 source "$(dirname "$BASH_SOURCE")/.go-autogen"
 
+if [[ "${BUILDFLAGS[@]}" =~ 'netgo ' ]]; then
+	EXTLDFLAGS_STATIC_DOCKER+=' -lnetgo'
+fi
 go build -compiler=gccgo \
 	-o "$DEST/$BINARY_FULLNAME" \
 	"${BUILDFLAGS[@]}" \


### PR DESCRIPTION
Addresses the issue that [GCCGO cannot enable the "netgo" build tag](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63731). A statically linked binary needs to enable `netgo` to avoid the issue that [GILBC may encounter a segmentation fault at DNS lookup](https://sourceware.org/bugzilla/show_bug.cgi?id=10652). While GOLANG 1.4 or later resolves this issue by reinstalling `netgo` library (#9449), GCCGO cannot do it during compilation.

Revision [221906](https://gcc.gnu.org/viewcvs/gcc/?pathrev=221906) or later of the GCCGO trunk provides a new `libnetgo.a` library which enables `netgo` build tag. ~~While we don't have to enable `netgo` in a dynamically linked binary (#6553), static linking eliminates dynamic dependencies to a trunk version of the compiler.~~
