### PR TITLE
For --net=host do not create a new UTS namespace

### DIFF
--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -91,6 +91,8 @@ func generateIfaceName() (string, error) {
 func (d *driver) createNetwork(container *configs.Config, c *execdriver.Command) error {
 	if c.Network.HostNetworking {
 		container.Namespaces.Remove(configs.NEWNET)
+		container.Namespaces.Remove(configs.NEWUTS)
+		container.Hostname = ""
 		return nil
 	}
 


### PR DESCRIPTION
Currently Docker create a UTS namespace when `--net=host` is used.  I honestly don't know why and this change scares me a bit because of that.  But... this change is quite simple in that we don't set the hostname or create UTS namespace if the network mode is host.
