### PR TITLE
Adding environment variables for sub projects

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -4,6 +4,15 @@
 FROM docs/base:latest
 MAINTAINER Sven Dowideit <SvenDowideit@docker.com> (@SvenDowideit)
 
+# This section ensures we pull the correct version of each
+# sub project
+ENV COMPOSE_BRANCH release
+ENV SWARM_BRANCH v0.1.0
+ENV MACHINE_BRANCH v0.1.0
+ENV DISTRIB_BRANCH master
+
+
+
 # TODO: need the full repo source to get the git version info
 COPY . /src
 
@@ -25,56 +34,57 @@ COPY ./release.sh release.sh
 
 
 # Docker Distribution
-#ADD https://raw.githubusercontent.com/moxiegirl/distribution/doc-tooling-changes/docs/mkdocs.yml /docs/mkdocs-distribution.yml
+# 
+#ADD https://raw.githubusercontent.com/docker/distribution/${DISTRIB_BRANCH}/docs/mkdocs.yml /docs/mkdocs-distribution.yml
 
-ADD https://raw.githubusercontent.com/moxiegirl/distribution/doc-tooling-changes/docs/overview.md /docs/sources/distribution/overview.md
-RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/distribution/overview.md
+#ADD https://raw.githubusercontent.com/docker/distribution/${DISTRIB_BRANCH}/docs/overview.md /docs/sources/distribution/overview.md
+#RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/distribution/overview.md
 
-ADD https://raw.githubusercontent.com/moxiegirl/distribution/doc-tooling-changes/docs/install.md /docs/sources/distribution/install.md
-RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/distribution/install.md
+#ADD https://raw.githubusercontent.com/docker/distribution/${DISTRIB_BRANCH}/docs/install.md /docs/sources/distribution/install.md
+#RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/distribution/install.md
 
-ADD https://raw.githubusercontent.com/moxiegirl/distribution/doc-tooling-changes/docs/architecture.md /docs/sources/distribution/architecture.md
-RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/distribution/architecture.md
+#ADD https://raw.githubusercontent.com/docker/distribution/${DISTRIB_BRANCH}/docs/architecture.md /docs/sources/distribution/architecture.md
+#RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/distribution/architecture.md
 
 
 # Docker Swarm
-#ADD https://raw.githubusercontent.com/docker/swarm/master/docs/mkdocs.yml /docs/mkdocs-swarm.yml
-ADD https://raw.githubusercontent.com/docker/swarm/master/docs/index.md /docs/sources/swarm/index.md
+#ADD https://raw.githubusercontent.com/docker/swarm/${SWARM_BRANCH}/docs/mkdocs.yml /docs/mkdocs-swarm.yml
+ADD https://raw.githubusercontent.com/docker/swarm/${SWARM_BRANCH}/docs/index.md /docs/sources/swarm/index.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/swarm/index.md
-ADD https://raw.githubusercontent.com/docker/swarm/master/discovery/README.md /docs/sources/swarm/discovery.md
+ADD https://raw.githubusercontent.com/docker/swarm/${SWARM_BRANCH}/discovery/README.md /docs/sources/swarm/discovery.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/swarm/discovery.md
-ADD https://raw.githubusercontent.com/docker/swarm/master/api/README.md /docs/sources/swarm/API.md
+ADD https://raw.githubusercontent.com/docker/swarm/${SWARM_BRANCH}/api/README.md /docs/sources/swarm/API.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/swarm/API.md
-ADD https://raw.githubusercontent.com/docker/swarm/master/scheduler/filter/README.md /docs/sources/swarm/scheduler/filter.md
+ADD https://raw.githubusercontent.com/docker/swarm/${SWARM_BRANCH}/scheduler/filter/README.md /docs/sources/swarm/scheduler/filter.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/swarm/scheduler/filter.md
-ADD https://raw.githubusercontent.com/docker/swarm/master/scheduler/strategy/README.md /docs/sources/swarm/scheduler/strategy.md
+ADD https://raw.githubusercontent.com/docker/swarm/${SWARM_BRANCH}/scheduler/strategy/README.md /docs/sources/swarm/scheduler/strategy.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/swarm/scheduler/strategy.md
 
 # Docker Machine
-#ADD https://raw.githubusercontent.com/docker/machine/master/docs/mkdocs.yml /docs/mkdocs-machine.yml
-ADD https://raw.githubusercontent.com/docker/machine/master/docs/index.md /docs/sources/machine/index.md
+#ADD https://raw.githubusercontent.com/docker/machine/${MACHINE_BRANCH}/docs/mkdocs.yml /docs/mkdocs-machine.yml
+ADD https://raw.githubusercontent.com/docker/machine/${MACHINE_BRANCH}/docs/index.md /docs/sources/machine/index.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/machine/index.md
 
 # Docker Compose
-#ADD https://raw.githubusercontent.com/docker/compose/master/docs/mkdocs.yml /docs/mkdocs-compose.yml
-ADD https://raw.githubusercontent.com/docker/compose/master/docs/index.md /docs/sources/compose/index.md
+#ADD https://raw.githubusercontent.com/docker/compose/${COMPOSE_BRANCH}/docs/mkdocs.yml /docs/mkdocs-compose.yml
+ADD https://raw.githubusercontent.com/docker/compose/${COMPOSE_BRANCH}/docs/index.md /docs/sources/compose/index.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/compose/index.md
-ADD https://raw.githubusercontent.com/docker/compose/master/docs/install.md /docs/sources/compose/install.md
+ADD https://raw.githubusercontent.com/docker/compose/${COMPOSE_BRANCH}/docs/install.md /docs/sources/compose/install.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/compose/install.md
-ADD https://raw.githubusercontent.com/docker/compose/master/docs/cli.md /docs/sources/compose/cli.md
+ADD https://raw.githubusercontent.com/docker/compose/${COMPOSE_BRANCH}/docs/cli.md /docs/sources/compose/cli.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/compose/cli.md
-ADD https://raw.githubusercontent.com/docker/compose/master/docs/yml.md /docs/sources/compose/yml.md
+ADD https://raw.githubusercontent.com/docker/compose/${COMPOSE_BRANCH}/docs/yml.md /docs/sources/compose/yml.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/compose/yml.md
-ADD https://raw.githubusercontent.com/docker/compose/master/docs/env.md /docs/sources/compose/env.md
+ADD https://raw.githubusercontent.com/docker/compose/${COMPOSE_BRANCH}/docs/env.md /docs/sources/compose/env.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/compose/env.md
-ADD https://raw.githubusercontent.com/docker/compose/master/docs/completion.md /docs/sources/compose/completion.md
+ADD https://raw.githubusercontent.com/docker/compose/${COMPOSE_BRANCH}/docs/completion.md /docs/sources/compose/completion.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/compose/completion.md
 
-ADD https://raw.githubusercontent.com/docker/compose/master/docs/django.md /docs/sources/compose/django.md
+ADD https://raw.githubusercontent.com/docker/compose/${COMPOSE_BRANCH}/docs/django.md /docs/sources/compose/django.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/compose/django.md
-ADD https://raw.githubusercontent.com/docker/compose/master/docs/rails.md /docs/sources/compose/rails.md
+ADD https://raw.githubusercontent.com/docker/compose/${COMPOSE_BRANCH}/docs/rails.md /docs/sources/compose/rails.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/compose/rails.md
-ADD https://raw.githubusercontent.com/docker/compose/master/docs/wordpress.md /docs/sources/compose/wordpress.md
+ADD https://raw.githubusercontent.com/docker/compose/${COMPOSE_BRANCH}/docs/wordpress.md /docs/sources/compose/wordpress.md
 RUN sed -i.old '1s;^;no_version_dropdown: true;' /docs/sources/compose/wordpress.md
 
 # Then build everything together, ready for mkdocs


### PR DESCRIPTION
The docker/docker documentation Makefile is used to make and push live docs.docker.com. This includes the documentation from the sub-projects such as Swarm, Compose, etc.  The `Dockerfile` was pulling uniformly from `master` for these projects.  This caused the early release of some Compose material when commits were cherry-picked say, for the birthday, and pushed live.

This is also fixing broken make docs:  fixes #12186 

I've added environment variables to this file so we can pick from specific branches or tags for the particular branches.

Signed-off-by: Mary Anthony mary@docker.com
