### PR TITLE
Fixing JSON Tags

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -79,13 +79,13 @@ type Port struct {
 
 type Container struct {
 	ID         string            `json:"Id"`
-	Names      []string          `json:,omitempty"`
-	Image      string            `json:,omitempty"`
-	Command    string            `json:,omitempty"`
-	Created    int               `json:,omitempty"`
-	Ports      []Port            `json:,omitempty"`
-	SizeRw     int               `json:,omitempty"`
-	SizeRootFs int               `json:,omitempty"`
-	Labels     map[string]string `json:,omitempty"`
-	Status     string            `json:,omitempty"`
+	Names      []string          `json:",omitempty"`
+	Image      string            `json:",omitempty"`
+	Command    string            `json:",omitempty"`
+	Created    int               `json:",omitempty"`
+	Ports      []Port            `json:",omitempty"`
+	SizeRw     int               `json:",omitempty"`
+	SizeRootFs int               `json:",omitempty"`
+	Labels     map[string]string `json:",omitempty"`
+	Status     string            `json:",omitempty"`
 }


### PR DESCRIPTION
Added missing `"` before `,` in api/types/types.go for the Container struct. Fixes #12189 

Signed-off-by: Megan Kostick mkostick@us.ibm.com
