### PR TITLE
docs: Markdown format fix around LogConfig param

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -257,10 +257,9 @@ Json Parameters:
         `Ulimits: { "Name": "nofile", "Soft": 1024, "Hard", 2048 }}`
   -   **SecurityOpt**: A list of string values to customize labels for MLS
       systems, such as SELinux.
-  -   **LogConfig** - Logging configuration to container, format
-        `{ "Type": "<driver_name>", "Config": {"key1": "val1"}}
+  -   **LogConfig** - Logging configuration to container, format:
+        `{ "Type": "<driver_name>", "Config": {"key1": "val1"}}`.
         Available types: `json-file`, `syslog`, `none`.
-        `json-file` logging driver.
   -   **CgroupParent** - Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 
 Query Parameters:

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -257,10 +257,9 @@ Json Parameters:
         `Ulimits: { "Name": "nofile", "Soft": 1024, "Hard", 2048 }}`
   -   **SecurityOpt**: A list of string values to customize labels for MLS
       systems, such as SELinux.
-  -   **LogConfig** - Logging configuration to container, format
-        `{ "Type": "<driver_name>", "Config": {"key1": "val1"}}
+  -   **LogConfig** - Logging configuration to container, format:
+        `{ "Type": "<driver_name>", "Config": {"key1": "val1"}}`.
         Available types: `json-file`, `syslog`, `none`.
-        `json-file` logging driver.
   -   **CgroupParent** - Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 
 Query Parameters:


### PR DESCRIPTION
Fixed markup in Remote API docs 1.18/1.19.

> Before:
> ![](http://cl.ly/image/1p3U292d1D3Z/Image%202015-04-08%20at%204.17.10%20PM.png)

@jfrazelle up to you if you want to cherry-pick to 1.6 `release` branch.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
