### PR TITLE
fix #12188 integration-cli: use "top" instead of "sleep" to avoid timeout

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -19,7 +19,7 @@ import (
 func TestExec(t *testing.T) {
 	defer deleteAllContainers()
 
-	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "testing", "busybox", "sh", "-c", "echo test > /tmp/file && sleep 100")
+	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "testing", "busybox", "sh", "-c", "echo test > /tmp/file && top")
 	if out, _, _, err := runCommandWithStdoutStderr(runCmd); err != nil {
 		t.Fatal(out, err)
 	}
@@ -82,7 +82,7 @@ func TestExecInteractiveStdinClose(t *testing.T) {
 func TestExecInteractive(t *testing.T) {
 	defer deleteAllContainers()
 
-	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "testing", "busybox", "sh", "-c", "echo test > /tmp/file && sleep 100")
+	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "testing", "busybox", "sh", "-c", "echo test > /tmp/file && top")
 	if out, _, _, err := runCommandWithStdoutStderr(runCmd); err != nil {
 		t.Fatal(out, err)
 	}
@@ -500,12 +500,12 @@ func TestLinksPingLinkedContainersOnRename(t *testing.T) {
 	defer deleteAllContainers()
 
 	var out string
-	out, _, _ = dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
+	out, _, _ = dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "top")
 	idA := strings.TrimSpace(out)
 	if idA == "" {
 		t.Fatal(out, "id should not be nil")
 	}
-	out, _, _ = dockerCmd(t, "run", "-d", "--link", "container1:alias1", "--name", "container2", "busybox", "sleep", "10")
+	out, _, _ = dockerCmd(t, "run", "-d", "--link", "container1:alias1", "--name", "container2", "busybox", "top")
 	idB := strings.TrimSpace(out)
 	if idB == "" {
 		t.Fatal(out, "id should not be nil")

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestKillContainer(t *testing.T) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", "sleep 10")
+	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		t.Fatal(out, err)
@@ -37,11 +37,11 @@ func TestKillContainer(t *testing.T) {
 
 	deleteContainer(cleanedContainerID)
 
-	logDone("kill - kill container running sleep 10")
+	logDone("kill - kill container running top")
 }
 
 func TestKillDifferentUserContainer(t *testing.T) {
-	runCmd := exec.Command(dockerBinary, "run", "-u", "daemon", "-d", "busybox", "sh", "-c", "sleep 10")
+	runCmd := exec.Command(dockerBinary, "run", "-u", "daemon", "-d", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		t.Fatal(out, err)
@@ -71,5 +71,5 @@ func TestKillDifferentUserContainer(t *testing.T) {
 
 	deleteContainer(cleanedContainerID)
 
-	logDone("kill - kill container running sleep 10 from a different user")
+	logDone("kill - kill container running top from a different user")
 }

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -110,9 +110,9 @@ func TestLinksPingLinkedContainers(t *testing.T) {
 func TestLinksPingLinkedContainersAfterRename(t *testing.T) {
 	defer deleteAllContainers()
 
-	out, _, _ := dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
+	out, _, _ := dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "top")
 	idA := strings.TrimSpace(out)
-	out, _, _ = dockerCmd(t, "run", "-d", "--name", "container2", "busybox", "sleep", "10")
+	out, _, _ = dockerCmd(t, "run", "-d", "--name", "container2", "busybox", "top")
 	idB := strings.TrimSpace(out)
 	dockerCmd(t, "rename", "container1", "container_new")
 	dockerCmd(t, "run", "--rm", "--link", "container_new:alias1", "--link", "container2:alias2", "busybox", "sh", "-c", "ping -c 1 alias1 -W 1 && ping -c 1 alias2 -W 1")
@@ -126,8 +126,8 @@ func TestLinksIpTablesRulesWhenLinkAndUnlink(t *testing.T) {
 	testRequires(t, SameHostDaemon)
 	defer deleteAllContainers()
 
-	dockerCmd(t, "run", "-d", "--name", "child", "--publish", "8080:80", "busybox", "sleep", "10")
-	dockerCmd(t, "run", "-d", "--name", "parent", "--link", "child:http", "busybox", "sleep", "10")
+	dockerCmd(t, "run", "-d", "--name", "child", "--publish", "8080:80", "busybox", "top")
+	dockerCmd(t, "run", "-d", "--name", "parent", "--link", "child:http", "busybox", "top")
 
 	childIP := findContainerIP(t, "child")
 	parentIP := findContainerIP(t, "parent")
@@ -155,9 +155,9 @@ func TestLinksInspectLinksStarted(t *testing.T) {
 		result   []string
 	)
 	defer deleteAllContainers()
-	dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
-	dockerCmd(t, "run", "-d", "--name", "container2", "busybox", "sleep", "10")
-	dockerCmd(t, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "sleep", "10")
+	dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "top")
+	dockerCmd(t, "run", "-d", "--name", "container2", "busybox", "top")
+	dockerCmd(t, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "top")
 	links, err := inspectFieldJSON("testinspectlink", "HostConfig.Links")
 	if err != nil {
 		t.Fatal(err)
@@ -184,8 +184,8 @@ func TestLinksInspectLinksStopped(t *testing.T) {
 		result   []string
 	)
 	defer deleteAllContainers()
-	dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "sleep", "10")
-	dockerCmd(t, "run", "-d", "--name", "container2", "busybox", "sleep", "10")
+	dockerCmd(t, "run", "-d", "--name", "container1", "busybox", "top")
+	dockerCmd(t, "run", "-d", "--name", "container2", "busybox", "top")
 	dockerCmd(t, "run", "-d", "--name", "testinspectlink", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "true")
 	links, err := inspectFieldJSON("testinspectlink", "HostConfig.Links")
 	if err != nil {

--- a/integration-cli/docker_cli_pause_test.go
+++ b/integration-cli/docker_cli_pause_test.go
@@ -14,7 +14,7 @@ func TestPause(t *testing.T) {
 	name := "testeventpause"
 	out, _, _ := dockerCmd(t, "images", "-q")
 	image := strings.Split(out, "\n")[0]
-	dockerCmd(t, "run", "-d", "--name", name, image, "sleep", "2")
+	dockerCmd(t, "run", "-d", "--name", name, image, "top")
 
 	dockerCmd(t, "pause", name)
 	pausedContainers, err := getSliceOfPausedContainers()
@@ -44,11 +44,6 @@ func TestPause(t *testing.T) {
 		t.Fatalf("event should be unpause, not %#v", unpauseEvent)
 	}
 
-	waitCmd := exec.Command(dockerBinary, "wait", name)
-	if waitOut, _, err := runCommandWithOutput(waitCmd); err != nil {
-		t.Fatalf("error thrown while waiting for container: %s, %v", waitOut, err)
-	}
-
 	logDone("pause - pause/unpause is logged")
 }
 
@@ -63,7 +58,7 @@ func TestPauseMultipleContainers(t *testing.T) {
 	out, _, _ := dockerCmd(t, "images", "-q")
 	image := strings.Split(out, "\n")[0]
 	for _, name := range containers {
-		dockerCmd(t, "run", "-d", "--name", name, image, "sleep", "2")
+		dockerCmd(t, "run", "-d", "--name", name, image, "top")
 	}
 	dockerCmd(t, append([]string{"pause"}, containers...)...)
 	pausedContainers, err := getSliceOfPausedContainers()
@@ -98,13 +93,6 @@ func TestPauseMultipleContainers(t *testing.T) {
 	for _, unpauseEvent := range unpauseEvents {
 		if unpauseEvent[len(unpauseEvent)-1] != "unpause" {
 			t.Fatalf("event should be unpause, not %#v", unpauseEvent)
-		}
-	}
-
-	for _, name := range containers {
-		waitCmd := exec.Command(dockerBinary, "wait", name)
-		if waitOut, _, err := runCommandWithOutput(waitCmd); err != nil {
-			t.Fatalf("error thrown while waiting for container: %s, %v", waitOut, err)
 		}
 	}
 

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -377,7 +377,7 @@ func TestPsListContainersFilterID(t *testing.T) {
 	firstID := strings.TrimSpace(out)
 
 	// start another container
-	runCmd = exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", "sleep 360")
+	runCmd = exec.Command(dockerBinary, "run", "-d", "busybox", "top")
 	if out, _, err = runCommandWithOutput(runCmd); err != nil {
 		t.Fatal(out, err)
 	}
@@ -407,7 +407,7 @@ func TestPsListContainersFilterName(t *testing.T) {
 	firstID := strings.TrimSpace(out)
 
 	// start another container
-	runCmd = exec.Command(dockerBinary, "run", "-d", "--name=b_name_to_match", "busybox", "sh", "-c", "sleep 360")
+	runCmd = exec.Command(dockerBinary, "run", "-d", "--name=b_name_to_match", "busybox", "top")
 	if out, _, err = runCommandWithOutput(runCmd); err != nil {
 		t.Fatal(out, err)
 	}

--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestTopMultipleArgs(t *testing.T) {
-	runCmd := exec.Command(dockerBinary, "run", "-i", "-d", "busybox", "sleep", "20")
+	runCmd := exec.Command(dockerBinary, "run", "-i", "-d", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		t.Fatalf("failed to start the container: %s, %v", out, err)
@@ -30,7 +30,7 @@ func TestTopMultipleArgs(t *testing.T) {
 }
 
 func TestTopNonPrivileged(t *testing.T) {
-	runCmd := exec.Command(dockerBinary, "run", "-i", "-d", "busybox", "sleep", "20")
+	runCmd := exec.Command(dockerBinary, "run", "-i", "-d", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		t.Fatalf("failed to start the container: %s, %v", out, err)
@@ -57,19 +57,19 @@ func TestTopNonPrivileged(t *testing.T) {
 
 	deleteContainer(cleanedContainerID)
 
-	if !strings.Contains(out1, "sleep 20") && !strings.Contains(out2, "sleep 20") {
-		t.Fatal("top should've listed `sleep 20` in the process list, but failed twice")
-	} else if !strings.Contains(out1, "sleep 20") {
-		t.Fatal("top should've listed `sleep 20` in the process list, but failed the first time")
-	} else if !strings.Contains(out2, "sleep 20") {
-		t.Fatal("top should've listed `sleep 20` in the process list, but failed the second itime")
+	if !strings.Contains(out1, "top") && !strings.Contains(out2, "top") {
+		t.Fatal("top should've listed `top` in the process list, but failed twice")
+	} else if !strings.Contains(out1, "top") {
+		t.Fatal("top should've listed `top` in the process list, but failed the first time")
+	} else if !strings.Contains(out2, "top") {
+		t.Fatal("top should've listed `top` in the process list, but failed the second itime")
 	}
 
-	logDone("top - sleep process should be listed in non privileged mode")
+	logDone("top - top process should be listed in non privileged mode")
 }
 
 func TestTopPrivileged(t *testing.T) {
-	runCmd := exec.Command(dockerBinary, "run", "--privileged", "-i", "-d", "busybox", "sleep", "20")
+	runCmd := exec.Command(dockerBinary, "run", "--privileged", "-i", "-d", "busybox", "top")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		t.Fatalf("failed to start the container: %s, %v", out, err)
@@ -96,13 +96,13 @@ func TestTopPrivileged(t *testing.T) {
 
 	deleteContainer(cleanedContainerID)
 
-	if !strings.Contains(out1, "sleep 20") && !strings.Contains(out2, "sleep 20") {
-		t.Fatal("top should've listed `sleep 20` in the process list, but failed twice")
-	} else if !strings.Contains(out1, "sleep 20") {
-		t.Fatal("top should've listed `sleep 20` in the process list, but failed the first time")
-	} else if !strings.Contains(out2, "sleep 20") {
-		t.Fatal("top should've listed `sleep 20` in the process list, but failed the second itime")
+	if !strings.Contains(out1, "top") && !strings.Contains(out2, "top") {
+		t.Fatal("top should've listed `top` in the process list, but failed twice")
+	} else if !strings.Contains(out1, "top") {
+		t.Fatal("top should've listed `top` in the process list, but failed the first time")
+	} else if !strings.Contains(out2, "top") {
+		t.Fatal("top should've listed `top` in the process list, but failed the second itime")
 	}
 
-	logDone("top - sleep process should be listed in privileged mode")
+	logDone("top - top process should be listed in privileged mode")
 }


### PR DESCRIPTION
Attempt 2 - Updated most of the sleep tests (there's still a few left where sleep is applicable).

Fix #12188

Signed-off-by: Todd Whiteman todd.whiteman@joyent.com
