### PR TITLE
cli: Better wording for daemon --log-driver

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -83,7 +83,7 @@ func (config *Config) InstallFlags() {
 	opts.LabelListVar(&config.Labels, []string{"-label"}, "Set key=value labels to the daemon")
 	config.Ulimits = make(map[string]*ulimit.Ulimit)
 	opts.UlimitMapVar(config.Ulimits, []string{"-default-ulimit"}, "Set default ulimits for containers")
-	flag.StringVar(&config.LogConfig.Type, []string{"-log-driver"}, "json-file", "Containers logging driver")
+	flag.StringVar(&config.LogConfig.Type, []string{"-log-driver"}, "json-file", "Default driver for container logs")
 }
 
 func getDefaultNetworkMtu() int {

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -90,7 +90,7 @@ unix://[/path/to/socket] to use.
   Set key=value labels to the daemon (displayed in `docker info`)
 
 **--log-driver**="*json-file*|*syslog*|*none*"
-  Container's logging driver. Default is `default`.
+  Default driver for container logs. Default is `json-file`.
   **Warning**: `docker logs` command works only for `json-file` logging driver.
 
 **--mtu**=VALUE

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -134,7 +134,7 @@ expect an integer, and they can only be specified once.
       --ipv6=false                           Enable IPv6 networking
       -l, --log-level="info"                 Set the logging level
       --label=[]                             Set key=value labels to the daemon
-      --log-driver="json-file"               Container's logging driver (json-file/none)
+      --log-driver="json-file"               Default driver for container logs
       --mtu=0                                Set the containers network MTU
       -p, --pidfile="/var/run/docker.pid"    Path to use for daemon PID file
       --registry-mirror=[]                   Preferred Docker registry mirror


### PR DESCRIPTION
This flag is passed to the daemon CLI. In my opinion, "Container's
logging driver" is not accurate and refers to 'one container'.

``` diff
-      --log-driver="json-file"               Container's logging driver (json-file/none)
+      --log-driver="json-file"               Default driver for container logs
```

Also the `syslog` driver was missing from the list. Having the list
of all logging drivers won't scale here (should be <80 chars per line)
and we have `rotation` driver coming up in the pipeline as well (gh11485).

Bonus: maybe we can say "Default logging driver for container logs" but this is longer.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
cc: @LK4D4 
