### PR TITLE
names-generator: use local random instance

### DIFF
--- a/pkg/namesgenerator/names-generator.go
+++ b/pkg/namesgenerator/names-generator.go
@@ -302,19 +302,19 @@ var (
 		// Ada Yonath - an Israeli crystallographer, the first woman from the Middle East to win a Nobel prize in the sciences. https://en.wikipedia.org/wiki/Ada_Yonath
 		"yonath",
 	}
+
+	rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
 )
 
 func GetRandomName(retry int) string {
-	rand.Seed(time.Now().UnixNano())
-
 begin:
-	name := fmt.Sprintf("%s_%s", left[rand.Intn(len(left))], right[rand.Intn(len(right))])
+	name := fmt.Sprintf("%s_%s", left[rnd.Intn(len(left))], right[rnd.Intn(len(right))])
 	if name == "boring_wozniak" /* Steve Wozniak is not boring */ {
 		goto begin
 	}
 
 	if retry > 0 {
-		name = fmt.Sprintf("%s%d", name, rand.Intn(10))
+		name = fmt.Sprintf("%s%d", name, rnd.Intn(10))
 	}
 	return name
 }


### PR DESCRIPTION
Minor change: Instead of seeding/polluting the global `rand.Random` instance,
creating a local `rand.Random` instance which provides the same level of randomness.

Signed-off-by: Ahmet Alp Balkan 
