### PR TITLE
cp: add support for copy filename with ":"

### DIFF
--- a/api/client/cp.go
+++ b/api/client/cp.go
@@ -21,7 +21,8 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
-	info := strings.Split(cmd.Arg(0), ":")
+	// deal with path name with `:`
+	info := strings.SplitN(cmd.Arg(0), ":", 2)
 
 	if len(info) != 2 {
 		return fmt.Errorf("Error: Path not specified")


### PR DESCRIPTION
We use ":" as separator for CONTAINER:PATH.
This patch enables copy filename with ":"
to host.

Signed-off-by: Chen Hanxiao chenhanxiao@cn.fujitsu.com
