### PR TITLE
docs: add missing accent mark around docker command

### DIFF
--- a/docs/man/docker-commit.1.md
+++ b/docs/man/docker-commit.1.md
@@ -38,7 +38,7 @@ Using an existing container's name or ID you can create a new image.
 ## Creating a new image from an existing container
 An existing Fedora based container has had Apache installed while running
 in interactive mode with the bash shell. Apache is also running. To
-create a new image run docker ps to find the container's ID and then run:
+create a new image run `docker ps` to find the container's ID and then run:
 
     # docker commit -m="Added Apache to Fedora base image" \
       -a="A D Ministrator" 98bd7fc99854 fedora/fedora_httpd:20
@@ -46,7 +46,7 @@ create a new image run docker ps to find the container's ID and then run:
 ## Apply specified Dockerfile instructions while committing the image
 If an existing container was created without the DEBUG environment
 variable set to "true", you can create a new image based on that
-container by first getting the container's ID with docker ps and
+container by first getting the container's ID with `docker ps` and
 then running:
 
     # docker commit -c="ENV DEBUG true" 98bd7fc99854 debug-image


### PR DESCRIPTION
As we did everywhere.

Signed-off-by: Chen Hanxiao chenhanxiao@cn.fujitsu.com
