### PR TITLE
Add a note about PID 1 not terminating automatically on signal

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -516,10 +516,16 @@ interactively.  You can attach to the same contained process multiple times
 simultaneously, screen sharing style, or quickly view the progress of your
 daemonized process.
 
-You can detach from the container (and leave it running) with `CTRL-p CTRL-q`
-(for a quiet exit) or `CTRL-c` which will send a `SIGKILL` to the container.
-When you are attached to a container, and exit its main process, the process's
-exit code will be returned to the client.
+You can detach from the container and leave it running with `CTRL-p
+CTRL-q` (for a quiet exit) or with `CTRL-c` if `--sig-proxy` is false.
+
+If `--sig-proxy` is true (the default),`CTRL-c` sends a `SIGINT`
+to the container.
+
+>**Note**: A process running as PID 1 inside a container is treated
+>specially by Linux: it ignores any signal with the default action.
+>So, the process will not terminate on `SIGINT` or `SIGTERM` unless it is
+>coded to do so.
 
 It is forbidden to redirect the standard input of a `docker attach` command while
 attaching to a tty-enabled container (i.e.: launched with `-t`).

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -111,6 +111,11 @@ as you'll see in later examples.  Specifying `-t` is forbidden when the client
 standard output is redirected or piped, such as in:
 `echo test | docker run -i busybox cat`.
 
+>**Note**: A process running as PID 1 inside a container is treated
+>specially by Linux: it ignores any signal with the default action.
+>So, the process will not terminate on `SIGINT` or `SIGTERM` unless it is
+>coded to do so.
+
 ## Container identification
 
 ### Name (--name)


### PR DESCRIPTION
As raised in #12022, processes that do not deliberately catch and exit on SIGINT/SIGTERM do not terminate as expected when they are running as PID 1, which is a very common case inside a Docker container.  This confused me for a while, so I thought it would be better to mention it in the Docker documentation.

The note I am proposing is rather terse, but hopefully enough to find information via Google.  I am open to guidance on how to improve the readability.

I have added the same note in the two places that SIGINT and/or SIGTERM are mentioned in the existing documentation. 

I also propose to change the statement that CTRL-c sends a SIGKILL - my tests say this is not the case, and it is certainly unexpected.

closes #12022
