### PR TITLE
cli_info_test: Check all required fields

### DIFF
--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -14,7 +14,18 @@ func TestInfoEnsureSucceeds(t *testing.T) {
 		t.Fatalf("failed to execute docker info: %s, %v", out, err)
 	}
 
-	stringsToCheck := []string{"Containers:", "Execution Driver:", "Logging Driver:", "Kernel Version:"}
+	// always shown fields
+	stringsToCheck := []string{
+		"ID:",
+		"Containers:",
+		"Images:",
+		"Execution Driver:",
+		"Logging Driver:",
+		"Operating System:",
+		"CPUs:",
+		"Total Memory:",
+		"Kernel Version:",
+		"Storage Driver:"}
 
 	for _, linePrefix := range stringsToCheck {
 		if !strings.Contains(out, linePrefix) {


### PR DESCRIPTION
`TestInfoEnsureSucceeds` is supposed to check existence of all
expected fields that are going to be shown in `docker info` command.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
