### PR TITLE
Allow `--privileged` for build.

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -56,6 +56,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	flMemorySwap := cmd.String([]string{"-memory-swap"}, "", "Total memory (memory + swap), '-1' to disable swap")
 	flCPUShares := cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 	flCPUSetCpus := cmd.String([]string{"-cpuset-cpus"}, "", "CPUs in which to allow execution (0-3, 0,1)")
+	flPrivileged := cmd.Bool([]string{"-privileged"}, false, "Give extended privileges to the build's containers")
 
 	cmd.Require(flag.Exact, 1)
 	cmd.ParseFlags(args, true)
@@ -275,6 +276,10 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 
 	if *pull {
 		v.Set("pull", "1")
+	}
+
+	if *flPrivileged {
+		v.Set("privileged", "1")
 	}
 
 	v.Set("cpusetcpus", *flCPUSetCpus)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1210,6 +1210,7 @@ func postBuild(eng *engine.Engine, version version.Version, w http.ResponseWrite
 	job.Setenv("memory", r.FormValue("memory"))
 	job.Setenv("cpusetcpus", r.FormValue("cpusetcpus"))
 	job.Setenv("cpushares", r.FormValue("cpushares"))
+	job.Setenv("privileged", r.FormValue("privileged"))
 
 	// Job cancellation. Note: not all job types support this.
 	if closeNotifier, ok := w.(http.CloseNotifier); ok {

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -122,11 +122,7 @@ type Builder struct {
 	contextPath    string        // the path of the temporary directory the local context is unpacked to (server side)
 	noBaseImage    bool          // indicates that this build does not start from any base image, but is being built from an empty file system.
 
-	// Set resource restrictions for build containers
-	cpuSetCpus string
-	cpuShares  int64
-	memory     int64
-	memorySwap int64
+	hostConfig *runconfig.HostConfig
 
 	cancelled <-chan struct{} // When closed, job was cancelled.
 }

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -34,7 +34,6 @@ import (
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/pkg/tarsum"
 	"github.com/docker/docker/pkg/urlutil"
-	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
 )
 
@@ -538,17 +537,10 @@ func (b *Builder) create() (*daemon.Container, error) {
 	}
 	b.Config.Image = b.image
 
-	hostConfig := &runconfig.HostConfig{
-		CpuShares:  b.cpuShares,
-		CpusetCpus: b.cpuSetCpus,
-		Memory:     b.memory,
-		MemorySwap: b.memorySwap,
-	}
-
 	config := *b.Config
 
 	// Create the container
-	c, warnings, err := b.Daemon.Create(b.Config, hostConfig, "")
+	c, warnings, err := b.Daemon.Create(b.Config, b.hostConfig, "")
 	if err != nil {
 		return nil, err
 	}

--- a/builder/job.go
+++ b/builder/job.go
@@ -63,6 +63,7 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) error {
 		memorySwap     = job.GetenvInt64("memswap")
 		cpuShares      = job.GetenvInt64("cpushares")
 		cpuSetCpus     = job.Getenv("cpusetcpus")
+		privileged     = job.GetenvBool("privileged")
 		authConfig     = &registry.AuthConfig{}
 		configFile     = &registry.ConfigFile{}
 		tag            string
@@ -151,11 +152,14 @@ func (b *BuilderJob) CmdBuild(job *engine.Job) error {
 		AuthConfig:      authConfig,
 		AuthConfigFile:  configFile,
 		dockerfileName:  dockerfileName,
-		cpuShares:       cpuShares,
-		cpuSetCpus:      cpuSetCpus,
-		memory:          memory,
-		memorySwap:      memorySwap,
-		cancelled:       job.WaitCancelled(),
+		hostConfig: &runconfig.HostConfig{
+			CpuShares:  cpuShares,
+			CpusetCpus: cpuSetCpus,
+			Memory:     memory,
+			MemorySwap: memorySwap,
+			Privileged: privileged,
+		},
+		cancelled: job.WaitCancelled(),
 	}
 
 	id, err := builder.Run(context)

--- a/docs/man/docker-build.1.md
+++ b/docs/man/docker-build.1.md
@@ -18,6 +18,7 @@ docker-build - Build a new image from the source code at PATH
 [**--memory-swap**[=*MEMORY-SWAP*]]
 [**-c**|**--cpu-shares**[=*0*]]
 [**--cpuset-cpus**[=*CPUSET-CPUS*]]
+[**--privileged**[=*false*]]
 
 PATH | URL | -
 
@@ -61,6 +62,27 @@ as context.
 
 **-t**, **--tag**=""
    Repository name (and optionally a tag) to be applied to the resulting image in case of success
+
+**-m**, **--memory**=""
+   Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
+
+   Allows you to constrain the memory available to a container. If the host
+supports swap memory, then the **-m** memory setting can be larger than physical
+RAM. If a limit of 0 is specified (not using **-m**), the container's memory is
+not limited. The actual limit may be rounded up to a multiple of the operating
+system's page size (the value would be very large, that's millions of trillions).
+
+**--memory-swap**=""
+   Total memory limit (memory + swap)
+
+**-c**, **--cpu-shares**=0
+   CPU shares (relative weight)
+
+**--cpuset-cpus**=""
+   CPUs in which to allow execution (0-3, 0,1)
+
+**--prvileged**=*true*|*false*
+   Give extended privileges to all containers used for this build
 
 # EXAMPLES
 

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -46,6 +46,10 @@ You can still call an old version of the API using
 
 ### What's new
 
+`POST /build`
+
+**New!**
+Builds can now use privileged mode for all `RUN` commands.
 
 ## v1.18
 

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -1164,6 +1164,7 @@ Query Parameters:
 -   **memswap** - Total memory (memory + swap), `-1` to disable swap
 -   **cpushares** - CPU shares (relative weight)
 -   **cpusetcpus** - CPUs in which to allow exection, e.g., `0-3`, `0,1`
+-   **privileged** - Use privileged mode for all `RUN` commands in a build
 
     Request Headers:
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -556,6 +556,7 @@ is returned by the `docker attach` command to its caller too:
       --memory-swap=""         Total memory (memory + swap), `-1` to disable swap
       -c, --cpu-shares         CPU Shares (relative weight)
       --cpuset-cpus=""         CPUs in which to allow execution, e.g. `0-3`, `0,1`
+      --privileged=false       Give extended privileges to all containers used for this build
 
 Builds Docker images from a Dockerfile and a "context". A build's context is
 the files located in the specified `PATH` or `URL`.  The build process can


### PR DESCRIPTION
Closed #1916

This runs _all_ `RUN` commands with `--privileged`. The reason being (instead of introducing a new command) is that if 1 step in the build has privileged, they might as well all have privileged, so introducing something like `RUNP` (as suggested in the referenced issue above) seems superfluous.
