### PR TITLE
Remove container name not empty check

### DIFF
--- a/api/client/diff.go
+++ b/api/client/diff.go
@@ -21,6 +21,10 @@ func (cli *DockerCli) CmdDiff(args ...string) error {
 	cmd.Require(flag.Exact, 1)
 	cmd.ParseFlags(args, true)
 
+	if cmd.Arg(0) == "" {
+		return fmt.Errorf("Container name cannot be empty")
+	}
+
 	rdr, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/changes", nil, nil)
 	if err != nil {
 		return err

--- a/api/client/rm.go
+++ b/api/client/rm.go
@@ -30,6 +30,10 @@ func (cli *DockerCli) CmdRm(args ...string) error {
 
 	var encounteredError error
 	for _, name := range cmd.Args() {
+		if name == "" {
+			return fmt.Errorf("Container name cannot be empty")
+		}
+
 		_, _, err := readBody(cli.call("DELETE", "/containers/"+name+"?"+val.Encode(), nil, nil))
 		if err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -466,10 +466,6 @@ func getContainersChanges(eng *engine.Engine, version version.Version, w http.Re
 	}
 
 	name := vars["name"]
-	if name == "" {
-		return fmt.Errorf("Container name cannot be empty")
-	}
-
 	d := getDaemon(eng)
 	cont, err := d.Get(name)
 	if err != nil {
@@ -883,10 +879,6 @@ func deleteContainers(eng *engine.Engine, version version.Version, w http.Respon
 	}
 
 	name := vars["name"]
-	if name == "" {
-		return fmt.Errorf("Container name cannot be empty")
-	}
-
 	d := getDaemon(eng)
 	config := &daemon.ContainerRmConfig{
 		ForceRemove:  toBool(r.Form.Get("force")),
@@ -895,6 +887,10 @@ func deleteContainers(eng *engine.Engine, version version.Version, w http.Respon
 	}
 
 	if err := d.ContainerRm(name, config); err != nil {
+		// Force a 404 for the empty string
+		if strings.Contains(strings.ToLower(err.Error()), "prefix can't be empty") {
+			return fmt.Errorf("no such id: \"\"")
+		}
 		return err
 	}
 


### PR DESCRIPTION
Removed the unneeded not empty container name check from getContainersChanges and deleteContainers. Fixes #12251 

Signed-off-by: Megan Kostick mkostick@us.ibm.com
