### PR TITLE
Only use fallback to short IDs when obvious.

### DIFF
--- a/graph/tags.go
+++ b/graph/tags.go
@@ -335,9 +335,12 @@ func (store *TagStore) GetImage(repoName, refOrID string) (*image.Image, error) 
 	}
 
 	// If no matching tag is found, search through images for a matching image id
-	for _, revision := range repo {
-		if strings.HasPrefix(revision, refOrID) {
-			return store.graph.Get(revision)
+	// iff it looks like a short ID or would look like a short ID
+	if stringid.IsShortID(stringid.TruncateID(refOrID)) {
+		for _, revision := range repo {
+			if strings.HasPrefix(revision, refOrID) {
+				return store.graph.Get(revision)
+			}
 		}
 	}
 

--- a/pkg/stringid/stringid.go
+++ b/pkg/stringid/stringid.go
@@ -4,19 +4,27 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"io"
+	"regexp"
 	"strconv"
 )
+
+const shortLen = 12
+
+// Determine if an arbitrary string *looks like* a short ID.
+func IsShortID(id string) bool {
+	return regexp.MustCompile("^[a-z0-9]{12}$").MatchString(id)
+}
 
 // TruncateID returns a shorthand version of a string identifier for convenience.
 // A collision with other shorthands is very unlikely, but possible.
 // In case of a collision a lookup with TruncIndex.Get() will fail, and the caller
 // will need to use a langer prefix, or the full-length Id.
 func TruncateID(id string) string {
-	shortLen := 12
+	trimTo := shortLen
 	if len(id) < shortLen {
-		shortLen = len(id)
+		trimTo = len(id)
 	}
-	return id[:shortLen]
+	return id[:trimTo]
 }
 
 // GenerateRandomID returns an unique id

--- a/pkg/stringid/stringid_test.go
+++ b/pkg/stringid/stringid_test.go
@@ -1,6 +1,9 @@
 package stringid
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestGenerateRandomID(t *testing.T) {
 	id := GenerateRandomID()
@@ -31,5 +34,23 @@ func TestShortenIdInvalid(t *testing.T) {
 	truncID := TruncateID(id)
 	if len(truncID) != len(id) {
 		t.Fatalf("Id returned is incorrect: truncate on %s returned %s", id, truncID)
+	}
+}
+
+func TestIsShortIDNonHex(t *testing.T) {
+	id := "some non-hex value"
+	if IsShortID(id) {
+		t.Fatalf("%s is not a short ID", id)
+	}
+}
+
+func TestIsShortIDNotCorrectSize(t *testing.T) {
+	id := strings.Repeat("a", shortLen+1)
+	if IsShortID(id) {
+		t.Fatalf("%s is not a short ID", id)
+	}
+	id = strings.Repeat("a", shortLen-1)
+	if IsShortID(id) {
+		t.Fatalf("%s is not a short ID", id)
 	}
 }


### PR DESCRIPTION
As reported in #11294, the Docker daemon will execute contains it
shouldn't run in the event that a requested tag is present in an image's
ID. This leads to the wrong image being started up silently.

This change reduces the risk of such a collision by using the short ID
iff the actual refOrTag looks like a short ID (not that it necessarily
is).

Signed-off-by: Richard Burnison rburnison@ebay.com
