### PR TITLE
Rename TestStartSilentAttach to TestStartAttachSilent

### DIFF
--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -69,7 +69,7 @@ func TestStartAttachCorrectExitCode(t *testing.T) {
 	logDone("start - correct exit code returned with -a")
 }
 
-func TestStartSilentAttach(t *testing.T) {
+func TestStartAttachSilent(t *testing.T) {
 	defer deleteAllContainers()
 
 	name := "teststartattachcorrectexitcode"


### PR DESCRIPTION
Renamed TestStartSilentAttach to TestStartAttachSilent, so all tests starting with TestStartAttach\* can be run using TESTFLAGS='-test.run TestStartAttach' make test-integration-cli
 Fixes #12119 

There are four tests now beginning with TestStartAttach*, and I have verified they all run as expected:
go test -test.run TestStartAttach -test.timeout=30m github.com/docker/docker/integration-cli
[PASSED]: start - error on start with attach exits
[PASSED]: start - correct exit code returned with -a
[PASSED]: start - don't echo container ID when attaching
[PASSED]: start - error on start and attach multiple containers at once
PASS
coverage: 7.1% of statements
ok      github.com/docker/docker/integration-cli    8.845s

Signed-off-by: Megan Kostick mkostick@us.ibm.com
