### PR TITLE
Fix for Daemon crashing when wildcards are used for COPY/ADD

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -156,6 +156,7 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowDecomp
 			dest,
 			allowRemote,
 			allowDecompression,
+			true,
 		); err != nil {
 			return err
 		}
@@ -226,7 +227,7 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowDecomp
 	return nil
 }
 
-func calcCopyInfo(b *Builder, cmdName string, cInfos *[]*copyInfo, origPath string, destPath string, allowRemote bool, allowDecompression bool) error {
+func calcCopyInfo(b *Builder, cmdName string, cInfos *[]*copyInfo, origPath string, destPath string, allowRemote bool, allowDecompression bool, allowWildcards bool) error {
 
 	if origPath != "" && origPath[0] == '/' && len(origPath) > 1 {
 		origPath = origPath[1:]
@@ -351,7 +352,7 @@ func calcCopyInfo(b *Builder, cmdName string, cInfos *[]*copyInfo, origPath stri
 	}
 
 	// Deal with wildcards
-	if ContainsWildcards(origPath) {
+	if allowWildcards && ContainsWildcards(origPath) {
 		for _, fileInfo := range b.context.GetSums() {
 			if fileInfo.Name() == "" {
 				continue
@@ -361,7 +362,9 @@ func calcCopyInfo(b *Builder, cmdName string, cInfos *[]*copyInfo, origPath stri
 				continue
 			}
 
-			calcCopyInfo(b, cmdName, cInfos, fileInfo.Name(), destPath, allowRemote, allowDecompression)
+			// Note we set allowWildcards to false in case the name has
+			// a * in it
+			calcCopyInfo(b, cmdName, cInfos, fileInfo.Name(), destPath, allowRemote, allowDecompression, false)
 		}
 		return nil
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -1113,10 +1113,10 @@ func (s *DockerSuite) TestBuildCopyWildcard(c *check.C) {
 			"dir/nested_dir/nest_nest_file": "2 times nested",
 			"dirt": "dirty",
 		})
-	defer ctx.Close()
 	if err != nil {
 		c.Fatal(err)
 	}
+	defer ctx.Close()
 
 	id1, err := buildImageFromContext(name, ctx, true)
 	if err != nil {
@@ -1153,6 +1153,31 @@ func (s *DockerSuite) TestBuildCopyWildcardNoFind(c *check.C) {
 		c.Fatalf("Wrong error %v, must be about no source files", err)
 	}
 
+}
+
+func (s *DockerSuite) TestBuildCopyWildcardInName(c *check.C) {
+	name := "testcopywildcardinname"
+	defer deleteImages(name)
+	ctx, err := fakeContext(`FROM busybox
+	COPY *.txt /tmp/
+	RUN [ "$(cat /tmp/\*.txt)" = 'hi there' ]
+	`, map[string]string{"*.txt": "hi there"})
+
+	if err != nil {
+		// Normally we would do c.Fatal(err) here but given that
+		// the odds of this failing are so rare, it must be because
+		// the OS we're running the client on doesn't support * in
+		// filenames (like windows).  So, instead of failing the test
+		// just let it pass. Then we don't need to explicitly
+		// say which OSs this works on or not.
+		return
+	}
+	defer ctx.Close()
+
+	_, err = buildImageFromContext(name, ctx, true)
+	if err != nil {
+		c.Fatalf("should have built: %q", err)
+	}
 }
 
 func (s *DockerSuite) TestBuildCopyWildcardCache(c *check.C) {

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -663,7 +663,6 @@ func fakeContextAddDockerfile(ctx *FakeContext, dockerfile string) error {
 func fakeContext(dockerfile string, files map[string]string) (*FakeContext, error) {
 	ctx, err := fakeContextWithFiles(files)
 	if err != nil {
-		ctx.Close()
 		return nil, err
 	}
 	if err := fakeContextAddDockerfile(ctx, dockerfile); err != nil {


### PR DESCRIPTION
in the filename and the command itself

Closes #12267

Signed-off-by: Doug Davis dug@us.ibm.com
