### PR TITLE
Log memory swap capabilities properly.

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1286,7 +1286,7 @@ func (container *Container) verifyDaemonSettings() {
 		logrus.Warnf("Your kernel does not support memory limit capabilities. Limitation discarded.")
 		container.hostConfig.Memory = 0
 	}
-	if container.hostConfig.Memory > 0 && !container.daemon.sysInfo.SwapLimit {
+	if container.hostConfig.Memory > 0 && container.hostConfig.MemorySwap != -1 && !container.daemon.sysInfo.SwapLimit {
 		logrus.Warnf("Your kernel does not support swap limit capabilities. Limitation discarded.")
 		container.hostConfig.MemorySwap = -1
 	}


### PR DESCRIPTION
Check whether the swap limit capabilities are disabled or not only when memory swap is set to greater than 0.

Signed-off-by: David Calavera david.calavera@gmail.com
