### PR TITLE
Add CFS_BANDWIDTH to check-config

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -161,6 +161,7 @@ echo 'Optional Features:'
 flags=(
 	RESOURCE_COUNTERS
 	CGROUP_PERF
+	CFS_BANDWIDTH
 )
 check_flags "${flags[@]}"
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Add support cpu cfs quota need to enable CFS_BANDWIDTH in kernel.
