### PR TITLE
Switch syslog to log the container name if available, not ID

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1421,7 +1421,11 @@ func (container *Container) startLogging() error {
 		}
 		l = dl
 	case "syslog":
-		dl, err := syslog.New(container.ID[:12])
+		tag := container.ID[:12]
+		if len(container.Name) > 1 {
+			tag = container.Name[1:]
+		}
+		dl, err := syslog.New(tag)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
As I've been using the syslog integration I've found the usability to be quite poor.  Logging the container ID is often not useful.  For "system" level thing I most always run them as ephemeral, which means on each system boot I delete the container and create a new one.  When you do this the ID obviously changes.  If I look back at the syslog from some time ago I can no longer correlate log messages to container because there is no reference for the ID.  By using the container name, if you name your containers, you at least get some better way to correlate log messages.
