### PR TITLE
Add test on archive.go (#11603)

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -388,22 +388,6 @@ func Tar(path string, compression Compression) (io.ReadCloser, error) {
 	return TarWithOptions(path, &TarOptions{Compression: compression})
 }
 
-func escapeName(name string) string {
-	escaped := make([]byte, 0)
-	for i, c := range []byte(name) {
-		if i == 0 && c == '/' {
-			continue
-		}
-		// all printable chars except "-" which is 0x2d
-		if (0x20 <= c && c <= 0x7E) && c != 0x2d {
-			escaped = append(escaped, c)
-		} else {
-			escaped = append(escaped, fmt.Sprintf("\\%03o", c)...)
-		}
-	}
-	return string(escaped)
-}
-
 // TarWithOptions creates an archive from the directory at `path`, only including files whose relative
 // paths are included in `options.IncludeFiles` (if non-nil) or not in `options.ExcludePatterns`.
 func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) {


### PR DESCRIPTION
Add some tests for `archive.go` to add more coverage to `pkg/archive` package. 

As I didn't write too many tests on Docker (or in go in general), this PR is more here to have a first feeback of how I'm doing it than to merge it right away ; so feel free to comment a lot ;-P. 

To "resolve" the #11603 issue I was thinking of submitting a PR for each file tested in `pkg/archive` (one for `archive{,_test}.go`, one for `diff.go`, etc.).

Signed-off-by: Vincent Demeester vincent@sbr.pm

Fixes #11603
