### PR TITLE
Use HTTPS links for URLs in READMEs / comments / docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ However, there might be a way to implement that feature *on top of* Docker.
     <td>Stack Overflow</td>
     <td>
       Stack Overflow has over 7000K Docker questions listed. We regularly 
-      monitor <a href="http://stackoverflow.com/search?tab=newest&q=docker" target="_blank">Docker questions</a>
+      monitor <a href="https://stackoverflow.com/search?tab=newest&q=docker" target="_blank">Docker questions</a>
       and so do many other knowledgeable Docker users.
     </td>
   </tr>

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -182,7 +182,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -37,7 +37,7 @@ project from a great one.
 		text = """
 Docker follows the timeless, highly efficient and totally unfair system
 known as [Benevolent dictator for
-life](http://en.wikipedia.org/wiki/Benevolent_Dictator_for_Life), with
+life](https://en.wikipedia.org/wiki/Benevolent_Dictator_for_Life), with
 yours truly, Solomon Hykes, in the role of BDFL. This means that all
 decisions are made, by default, by Solomon. Since making every decision
 myself would be highly un-scalable, in practice decisions are spread

--- a/NOTICE
+++ b/NOTICE
@@ -1,7 +1,7 @@
 Docker
 Copyright 2012-2015 Docker, Inc.
 
-This product includes software developed at Docker, Inc. (http://www.docker.com).
+This product includes software developed at Docker, Inc. (https://www.docker.com).
 
 This product contains software (https://github.com/kr/pty) developed
 by Keith Rarick, licensed under the MIT License.
@@ -14,6 +14,6 @@ United States and other governments.
 It is your responsibility to ensure that your use and/or transfer does not
 violate applicable laws.
 
-For more information, please see http://www.bis.doc.gov
+For more information, please see https://www.bis.doc.gov
 
-See also http://www.apache.org/dev/crypto.html and/or seek legal counsel.
+See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ databases, and backend services without depending on a particular stack
 or provider.
 
 Docker began as an open-source implementation of the deployment engine which
-powers [dotCloud](http://dotcloud.com), a popular Platform-as-a-Service.
+powers [dotCloud](https://dotcloud.com), a popular Platform-as-a-Service.
 It benefits directly from the experience accumulated over several years
 of large-scale operation and support of hundreds of thousands of
 applications and databases.
@@ -56,12 +56,12 @@ By contrast, Docker relies on a different sandboxing method known as
 *containerization*. Unlike traditional virtualization, containerization
 takes place at the kernel level. Most modern operating system kernels
 now support the primitives necessary for containerization, including
-Linux with [openvz](http://openvz.org),
+Linux with [openvz](https://openvz.org),
 [vserver](http://linux-vserver.org) and more recently
 [lxc](http://lxc.sourceforge.net), Solaris with
-[zones](http://docs.oracle.com/cd/E26502_01/html/E29024/preface-1.html#scrolltoc),
+[zones](https://docs.oracle.com/cd/E26502_01/html/E29024/preface-1.html#scrolltoc),
 and FreeBSD with
-[Jails](http://www.freebsd.org/doc/handbook/jails.html).
+[Jails](https://www.freebsd.org/doc/handbook/jails.html).
 
 Docker builds on top of these low-level primitives to offer developers a
 portable format and runtime environment that solves all four problems.
@@ -115,7 +115,7 @@ This is usually difficult for several reasons:
 Docker solves the problem of dependency hell by giving the developer a simple
 way to express *all* their application's dependencies in one place, while
 streamlining the process of assembling them. If this makes you think of
-[XKCD 927](http://xkcd.com/927/), don't worry. Docker doesn't
+[XKCD 927](https://xkcd.com/927/), don't worry. Docker doesn't
 *replace* your favorite packaging systems. It simply orchestrates
 their use in a simple and repeatable way. How does it do that? With
 layers.
@@ -147,10 +147,10 @@ Docker can be installed on your local machine as well as servers - both
 bare metal and virtualized.  It is available as a binary on most modern
 Linux systems, or as a VM on Windows, Mac and other systems.
 
-We also offer an [interactive tutorial](http://www.docker.com/tryit/)
+We also offer an [interactive tutorial](https://www.docker.com/tryit/)
 for quickly learning the basics of using Docker.
 
-For up-to-date install instructions, see the [Docs](http://docs.docker.com).
+For up-to-date install instructions, see the [Docs](https://docs.docker.com).
 
 Usage examples
 ==============
@@ -159,7 +159,7 @@ Docker can be used to run short-lived commands, long-running daemons
 (app servers, databases, etc.), interactive shell sessions, etc.
 
 You can find a [list of real-world
-examples](http://docs.docker.com/examples/) in the
+examples](https://docs.docker.com/examples/) in the
 documentation.
 
 Under the hood
@@ -172,7 +172,7 @@ Under the hood, Docker is built on the following components:
   and
   [namespacing](http://blog.dotcloud.com/under-the-hood-linux-kernels-on-dotcloud-part)
   capabilities of the Linux kernel
-* The [Go](http://golang.org) programming language
+* The [Go](https://golang.org) programming language
 * The [Docker Image Specification](https://github.com/docker/docker/blob/master/image/spec/v1.md)
 * The [Libcontainer Specification](https://github.com/docker/libcontainer/blob/master/SPEC.md)
 
@@ -218,7 +218,7 @@ United States and other governments.
 It is your responsibility to ensure that your use and/or transfer does not
 violate applicable laws.
 
-For more information, please see http://www.bis.doc.gov
+For more information, please see https://www.bis.doc.gov
 
 
 Licensing

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -956,7 +956,7 @@ func postContainersStart(eng *engine.Engine, version version.Version, w http.Res
 
 	// If contentLength is -1, we can assumed chunked encoding
 	// or more technically that the length is unknown
-	// http://golang.org/src/pkg/net/http/request.go#L139
+	// https://golang.org/src/pkg/net/http/request.go#L139
 	// net/http otherwise seems to swallow any headers related to chunked encoding
 	// including r.TransferEncoding
 	// allow a nil body for backwards compatibility

--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -27,7 +27,7 @@ is_set() {
 	zgrep "CONFIG_$1=[y|m]" "$CONFIG" > /dev/null
 }
 
-# see http://en.wikipedia.org/wiki/ANSI_escape_code#Colors
+# see https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
 declare -A colors=(
 	[black]=30
 	[red]=31

--- a/contrib/project-stats.sh
+++ b/contrib/project-stats.sh
@@ -3,7 +3,7 @@
 ## Run this script from the root of the docker repository
 ## to query project stats useful to the maintainers.
 ## You will need to install `pulls` and `issues` from
-## http://github.com/crosbymichael/pulls
+## https://github.com/crosbymichael/pulls
 
 set -e
 

--- a/contrib/syntax/vim/doc/dockerfile.txt
+++ b/contrib/syntax/vim/doc/dockerfile.txt
@@ -1,6 +1,6 @@
 *dockerfile.txt*  Syntax highlighting for Dockerfiles
 
-Author: Honza Pokorny <http://honza.ca>
+Author: Honza Pokorny <https://honza.ca>
 License: BSD
 
 INSTALLATION                                                     *installation*

--- a/contrib/syntax/vim/syntax/dockerfile.vim
+++ b/contrib/syntax/vim/syntax/dockerfile.vim
@@ -1,5 +1,5 @@
 " dockerfile.vim - Syntax highlighting for Dockerfiles
-" Maintainer:   Honza Pokorny <http://honza.ca>
+" Maintainer:   Honza Pokorny <https://honza.ca>
 " Version:      0.5
 
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -957,7 +957,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine, registryService 
 	localCopy := path.Join(config.Root, "init", fmt.Sprintf("dockerinit-%s", dockerversion.VERSION))
 	sysInitPath := utils.DockerInitPath(localCopy)
 	if sysInitPath == "" {
-		return nil, fmt.Errorf("Could not locate dockerinit: This usually means docker was built incorrectly. See http://docs.docker.com/contributing/devenvironment for official build instructions.")
+		return nil, fmt.Errorf("Could not locate dockerinit: This usually means docker was built incorrectly. See https://docs.docker.com/contributing/devenvironment for official build instructions.")
 	}
 
 	if sysInitPath != localCopy {
@@ -1227,7 +1227,7 @@ func checkKernel() error {
 	// Unfortunately we can't test for the feature "does not cause a kernel panic"
 	// without actually causing a kernel panic, so we need this workaround until
 	// the circumstances of pre-3.8 crashes are clearer.
-	// For details see http://github.com/docker/docker/issues/407
+	// For details see https://github.com/docker/docker/issues/407
 	if k, err := kernel.GetKernelVersion(); err != nil {
 		logrus.Warnf("%s", err)
 	} else {

--- a/daemon/execdriver/lxc/lxc_template.go
+++ b/daemon/execdriver/lxc/lxc_template.go
@@ -62,7 +62,7 @@ lxc.pivotdir = lxc_putold
 # NOTICE: These mounts must be applied within the namespace
 {{if .ProcessConfig.Privileged}}
 # WARNING: mounting procfs and/or sysfs read-write is a known attack vector.
-# See e.g. http://blog.zx2c4.com/749 and http://bit.ly/T9CkqJ
+# See e.g. http://blog.zx2c4.com/749 and https://bit.ly/T9CkqJ
 # We mount them read-write here, but later, dockerinit will call the Restrict() function to remount them read-only.
 # We cannot mount them directly read-only, because that would prevent loading AppArmor profiles.
 lxc.mount.entry = proc {{escapeFstabSpaces $ROOTFS}}/proc proc nosuid,nodev,noexec 0 0

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 The source for Docker documentation is in this directory under `sources/`. Our
 documentation uses extended Markdown, as implemented by
 [MkDocs](http://mkdocs.org).  The current release of the Docker documentation
-resides on [http://docs.docker.com](http://docs.docker.com).
+resides on [https://docs.docker.com](https://docs.docker.com).
 
 ## Understanding the documentation branches and processes
 
@@ -11,7 +11,7 @@ Docker has two primary branches for documentation:
 
 | Branch   | Description                    | URL (published via commit-hook)                                              |
 |----------|--------------------------------|------------------------------------------------------------------------------|
-| `docs`   | Official release documentation | [http://docs.docker.com](http://docs.docker.com)                             |
+| `docs`   | Official release documentation | [https://docs.docker.com](https://docs.docker.com)                             |
 | `master` | Merged but unreleased development work    | [http://docs.master.dockerproject.com](http://docs.master.dockerproject.com) |
 
 Additions and updates to upcoming releases are made in a feature branch off of

--- a/docs/man/README.md
+++ b/docs/man/README.md
@@ -30,4 +30,4 @@ The `md2man` Docker container will process the Markdown files and generate
 the man pages inside the `docker/docs/man/man1` directory using
 Docker volumes. For more information on Docker volumes see the man page for
 `docker run` and also look at the article [Sharing Directories via Volumes]
-(http://docs.docker.com/use/working_with_volumes/).
+(https://docs.docker.com/use/working_with_volumes/).

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -416,7 +416,7 @@ you’d like to connect instead, as in:
 
 ## Sharing IPC between containers
 
-Using shm_server.c available here: http://www.cs.cf.ac.uk/Dave/C/node27.html
+Using shm_server.c available here: https://www.cs.cf.ac.uk/Dave/C/node27.html
 
 Testing `--ipc=host` mode:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Docker Documentation
-#site_url: http://docs.docker.com/
+#site_url: https://docs.docker.com/
 site_url: /
 site_description: Documentation for fast and lightweight Docker container based virtualization framework.
 site_favicon: img/favicon.png

--- a/engine/env.go
+++ b/engine/env.go
@@ -210,7 +210,7 @@ func (env *Env) SetAuto(k string, v interface{}) {
 
 	// FIXME: we fix-convert float values to int, because
 	// encoding/json decodes integers to float64, but cannot encode them back.
-	// (See http://golang.org/src/pkg/encoding/json/decode.go#L46)
+	// (See https://golang.org/src/pkg/encoding/json/decode.go#L46)
 	if fval, ok := v.(float64); ok {
 		env.SetInt64(k, int64(fval))
 	} else if sval, ok := v.(string); ok {
@@ -245,7 +245,7 @@ func (env *Env) Encode(dst io.Writer) error {
 		if err := json.Unmarshal([]byte(v), &val); err == nil {
 			// FIXME: we fix-convert float values to int, because
 			// encoding/json decodes integers to float64, but cannot encode them back.
-			// (See http://golang.org/src/pkg/encoding/json/decode.go#L46)
+			// (See https://golang.org/src/pkg/encoding/json/decode.go#L46)
 			m[k] = changeFloats(val)
 		} else {
 			m[k] = v

--- a/hack/dind
+++ b/hack/dind
@@ -3,7 +3,7 @@ set -e
 
 # DinD: a wrapper script which allows docker to be run inside a docker container.
 # Original version by Jerome Petazzoni <jerome@docker.com>
-# See the blog post: http://blog.docker.com/2013/09/docker-can-now-run-within-docker/
+# See the blog post: https://blog.docker.com/2013/09/docker-can-now-run-within-docker/
 #
 # This script should be executed inside a docker container in privilieged mode
 # ('docker run --privileged', introduced in docker 0.6).

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -6,7 +6,7 @@ set -e
 #
 # Requirements:
 # - The current directory should be a checkout of the docker source code
-#   (http://github.com/docker/docker). Whatever version is checked out
+#   (https://github.com/docker/docker). Whatever version is checked out
 #   will be built.
 # - The VERSION file, at the root of the repository, should exist, and
 #   will be used as Docker binary version and package version.
@@ -85,7 +85,7 @@ if [ "$AUTO_GOPATH" ]; then
 fi
 
 if [ ! "$GOPATH" ]; then
-	echo >&2 'error: missing GOPATH; please see http://golang.org/doc/code.html#GOPATH'
+	echo >&2 'error: missing GOPATH; please see https://golang.org/doc/code.html#GOPATH'
 	echo >&2 '  alternatively, set AUTO_GOPATH=1'
 	exit 1
 fi

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -23,7 +23,7 @@ fi
 # ie, 1.5.0 > 1.5.0~rc1 > 1.5.0~git20150128.112847.17e840a > 1.5.0~dev~git20150128.112847.17e840a
 
 PACKAGE_ARCHITECTURE="$(dpkg-architecture -qDEB_HOST_ARCH)"
-PACKAGE_URL="http://www.docker.com/"
+PACKAGE_URL="https://www.docker.com/"
 PACKAGE_MAINTAINER="support@docker.com"
 PACKAGE_DESCRIPTION="Linux container runtime
 Docker complements LXC with a high-level API which operates at the process

--- a/integration-cli/docker_cli_proxy_test.go
+++ b/integration-cli/docker_cli_proxy_test.go
@@ -21,7 +21,7 @@ func TestCliProxyDisableProxyUnixSock(t *testing.T) {
 }
 
 // Can't use localhost here since go has a special case to not use proxy if connecting to localhost
-// See http://golang.org/pkg/net/http/#ProxyFromEnvironment
+// See https://golang.org/pkg/net/http/#ProxyFromEnvironment
 func TestCliProxyProxyTCPSock(t *testing.T) {
 	testRequires(t, SameHostDaemon)
 	// get the IP to use to connect since we can't use localhost

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -932,7 +932,7 @@ func TestConstainersStartChunkedEncodingHostConfig(t *testing.T) {
 	req.Header.Add("Content-Type", "application/json")
 	// This is a cheat to make the http request do chunked encoding
 	// Otherwise (just setting the Content-Encoding to chunked) net/http will overwrite
-	// http://golang.org/src/pkg/net/http/request.go?s=11980:12172
+	// https://golang.org/src/pkg/net/http/request.go?s=11980:12172
 	req.ContentLength = -1
 	server.ServeRequest(eng, api.APIVERSION, r, req)
 	assertHttpNotError(r, t)

--- a/project/GOVERNANCE.md
+++ b/project/GOVERNANCE.md
@@ -4,7 +4,7 @@ In the spirit of openness, Docker created a Governance Advisory Board, and commi
 All output from the meetings should be considered proposals only, and are subject to the review and approval of the community and the project leadership.
 
 The materials from the first Docker Governance Advisory Board meeting, held on October 28, 2014, are available at 
-[Google Docs Folder](http://goo.gl/Alfj8r)
+[Google Docs Folder](https://goo.gl/Alfj8r)
 
 These include:
 

--- a/project/PACKAGERS.md
+++ b/project/PACKAGERS.md
@@ -47,7 +47,7 @@ To build Docker, you will need the following:
 * A recent version of Git and Mercurial
 * Go version 1.3 or later
 * A clean checkout of the source added to a valid [Go
-  workspace](http://golang.org/doc/code.html#Workspaces) under the path
+  workspace](https://golang.org/doc/code.html#Workspaces) under the path
   *src/github.com/docker/docker* (unless you plan to use `AUTO_GOPATH`,
   explained in more detail below)
 
@@ -237,9 +237,9 @@ are as follows (in order):
   installed at "/usr/bin/docker", then "/usr/bin/dockerinit" will be the first
   place this file is searched for)
 * "/usr/libexec/docker/dockerinit" or "/usr/local/libexec/docker/dockerinit"
-  ([FHS 3.0 Draft](http://www.linuxbase.org/betaspecs/fhs/fhs.html#usrlibexec))
+  ([FHS 3.0 Draft](https://www.linuxbase.org/betaspecs/fhs/fhs.html#usrlibexec))
 * "/usr/lib/docker/dockerinit" or "/usr/local/lib/docker/dockerinit" ([FHS
-  2.3](http://refspecs.linuxfoundation.org/FHS_2.3/fhs-2.3.html#USRLIBLIBRARIESFORPROGRAMMINGANDPA))
+  2.3](https://refspecs.linuxfoundation.org/FHS_2.3/fhs-2.3.html#USRLIBLIBRARIESFORPROGRAMMINGANDPA))
 
 If (and please, only if) one of the paths above is insufficient due to distro
 policy or similar issues, you may use the `DOCKER_INITPATH` environment variable

--- a/project/RELEASE-CHECKLIST.md
+++ b/project/RELEASE-CHECKLIST.md
@@ -145,7 +145,7 @@ To test locally:
 make docs
 ```
 
-To make a shared test at http://beta-docs.docker.io:
+To make a shared test at https://beta-docs.docker.io:
 
 (You will need the `awsconfig` file added to the `docs/` dir)
 
@@ -341,7 +341,7 @@ git push -f origin docs
 make AWS_S3_BUCKET=docs.docker.com BUILD_ROOT=yes DISTRIBUTION_ID=C2K6......FL2F docs-release
 ```
 
-The docs will appear on http://docs.docker.com/ (though there may be cached
+The docs will appear on https://docs.docker.com/ (though there may be cached
 versions, so its worth checking http://docs.docker.com.s3-website-us-east-1.amazonaws.com/).
 For more information about documentation releases, see `docs/README.md`.
 

--- a/project/TOOLS.md
+++ b/project/TOOLS.md
@@ -14,11 +14,11 @@ we run Docker in Docker to test.
 
 Leeroy is a Go application which integrates Jenkins with 
 GitHub pull requests. Leeroy uses 
-[GitHub hooks](http://developer.github.com/v3/repos/hooks/) 
+[GitHub hooks](https://developer.github.com/v3/repos/hooks/) 
 to listen for pull request notifications and starts jobs on your Jenkins 
 server.  Using the Jenkins [notification plugin][jnp], Leeroy updates the 
 pull request using GitHub's 
-[status API](http://developer.github.com/v3/repos/statuses/)
+[status API](https://developer.github.com/v3/repos/statuses/)
 with pending, success, failure, or error statuses.
 
 The leeroy repository is maintained at

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -127,12 +127,12 @@ func DockerInitPath(localCopy string) string {
 		filepath.Join(filepath.Dir(selfPath), "dockerinit"),
 
 		// FHS 3.0 Draft: "/usr/libexec includes internal binaries that are not intended to be executed directly by users or shell scripts. Applications may use a single subdirectory under /usr/libexec."
-		// http://www.linuxbase.org/betaspecs/fhs/fhs.html#usrlibexec
+		// https://www.linuxbase.org/betaspecs/fhs/fhs.html#usrlibexec
 		"/usr/libexec/docker/dockerinit",
 		"/usr/local/libexec/docker/dockerinit",
 
 		// FHS 2.3: "/usr/lib includes object files, libraries, and internal binaries that are not intended to be executed directly by users or shell scripts."
-		// http://refspecs.linuxfoundation.org/FHS_2.3/fhs-2.3.html#USRLIBLIBRARIESFORPROGRAMMINGANDPA
+		// https://refspecs.linuxfoundation.org/FHS_2.3/fhs-2.3.html#USRLIBLIBRARIESFORPROGRAMMINGANDPA
 		"/usr/lib/docker/dockerinit",
 		"/usr/local/lib/docker/dockerinit",
 	}


### PR DESCRIPTION
Changes all HTTP links to HTTPS links where appropriate
in comments, README files, LICENSE files, man pages, 
and top-level documentation. Does not change the bulk of
documentation which will follow in a separate PR, nor does
it change any use of HTTP URLs in the source itself besides
where such URLs may be simply printed as usage.
