### PR TITLE
fix build test by adding --no-cache

### DIFF
--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5555,7 +5555,7 @@ func TestBuildResourceConstraintsAreUsed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command(dockerBinary, "build", "--rm=false", "--memory=64m", "--memory-swap=-1", "--cpuset-cpus=0", "--cpu-shares=100", "-t", name, ".")
+	cmd := exec.Command(dockerBinary, "build", "--no-cache", "--rm=false", "--memory=64m", "--memory-swap=-1", "--cpuset-cpus=0", "--cpu-shares=100", "-t", name, ".")
 	cmd.Dir = ctx.Dir
 
 	out, _, err := runCommandWithOutput(cmd)


### PR DESCRIPTION
Testcase TestBuildResourceConstraintsAreUsed run build without
--no-cache, so if you run this test twice, it will fail the
second time.
TESTFLAGS='-v -run ^TestBuildResourceConstraintsAreUsed$' ./hack/make.sh binary test-integration-cli
[PASSED]
TESTFLAGS='-v -run ^TestBuildResourceConstraintsAreUsed$' ./hack/make.sh binary test-integration-cli
[FAIL]
Because we'll use cID to inspect field and will get empty cID
if we have cache.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
