### PR TITLE
move syslog-tag to syslog.New function

### DIFF
--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -11,26 +11,25 @@ import (
 
 type Syslog struct {
 	writer *syslog.Writer
-	tag    string
 }
 
 func New(tag string) (logger.Logger, error) {
-	log, err := syslog.New(syslog.LOG_USER, path.Base(os.Args[0]))
+	syslogTag := fmt.Sprintf("%s: <%s> ", path.Base(os.Args[0]), tag)
+	log, err := syslog.New(syslog.LOG_USER, syslogTag)
+	fmt.Println(err)
 	if err != nil {
 		return nil, err
 	}
 	return &Syslog{
 		writer: log,
-		tag:    tag,
 	}, nil
 }
 
 func (s *Syslog) Log(msg *logger.Message) error {
-	logMessage := fmt.Sprintf("%s: %s", s.tag, msg.Line)
 	if msg.Source == "stderr" {
-		return s.writer.Err(logMessage)
+		return s.writer.Err(string(msg.Line))
 	}
-	return s.writer.Info(logMessage)
+	return s.writer.Info(string(msg.Line))
 }
 
 func (s *Syslog) Close() error {


### PR DESCRIPTION
move syslog-tag to syslog.New()
With tremendous log, this may cost less.
`<tag>` makes it easy to parse the log. 

Signed-off-by: Deng Guangxing dengguangxing@huawei.com
