### PR TITLE
Fix daemon panic when release a nil network interface

### DIFF
--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -583,6 +583,7 @@ func Release(id string) {
 
 	if containerInterface == nil {
 		logrus.Warnf("No network information to release for %s", id)
+		return
 	}
 
 	for _, nat := range containerInterface.PortMappings {


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

This bug is caused by #12092 
when `if containerInterface == nil`, it should return, or else
it will case the docker daemon panic becasue of 
`for _, nat := range containerInterface.PortMappings`

I can reproduce on my machine, this is happened when I restart 
my docker daemon and there is one container which has `restart=always`  but
failed to start.

<pre><code>.WARN[0000] No network information to release for 72f412113ae9498dbff92b9b730849a3f20a24a00e7ee8999e6ba076de091698
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x6cea01]

goroutine 25 [running]:
runtime.panic(0xc51660, 0x1341473)
        /usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
github.com/docker/docker/daemon/networkdriver/bridge.Release(0xc20823cfc0, 0x40)
        /go/src/github.com/docker/docker/daemon/networkdriver/bridge/driver.go:588 +0x531</code></pre>
