### PR TITLE
Fix vet warning

### DIFF
--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -493,7 +493,7 @@ func TestTarWithBlockCharFifo(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(changes) > 0 {
-		t.Fatalf("Tar with special device (block, char, fifo) should keep them (recreate them when untar) : %s", changes)
+		t.Fatalf("Tar with special device (block, char, fifo) should keep them (recreate them when untar) : %v", changes)
 	}
 }
 


### PR DESCRIPTION
pkg/archive/archive_test.go:496: arg changes for printf verb %s of wrong type: []archive.Change
