### PR TITLE
Add detection for F2Fs and JFS

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -14,20 +14,22 @@ import (
 type FsMagic uint32
 
 const (
-	FsMagicBtrfs       = FsMagic(0x9123683E)
 	FsMagicAufs        = FsMagic(0x61756673)
-	FsMagicExtfs       = FsMagic(0x0000EF53)
+	FsMagicBtrfs       = FsMagic(0x9123683E)
 	FsMagicCramfs      = FsMagic(0x28cd3d45)
-	FsMagicRamFs       = FsMagic(0x858458f6)
-	FsMagicTmpFs       = FsMagic(0x01021994)
-	FsMagicSquashFs    = FsMagic(0x73717368)
+	FsMagicExtfs       = FsMagic(0x0000EF53)
+	FsMagicF2fs        = FsMagic(0xF2F52010)
+	FsMagicJffs2Fs     = FsMagic(0x000072b6)
+	FsMagicJfs         = FsMagic(0x3153464a)
 	FsMagicNfsFs       = FsMagic(0x00006969)
+	FsMagicRamFs       = FsMagic(0x858458f6)
 	FsMagicReiserFs    = FsMagic(0x52654973)
 	FsMagicSmbFs       = FsMagic(0x0000517B)
-	FsMagicJffs2Fs     = FsMagic(0x000072b6)
-	FsMagicZfs         = FsMagic(0x2fc12fc1)
-	FsMagicXfs         = FsMagic(0x58465342)
+	FsMagicSquashFs    = FsMagic(0x73717368)
+	FsMagicTmpFs       = FsMagic(0x01021994)
 	FsMagicUnsupported = FsMagic(0x00000000)
+	FsMagicXfs         = FsMagic(0x58465342)
+	FsMagicZfs         = FsMagic(0x2fc12fc1)
 )
 
 var (
@@ -50,18 +52,20 @@ var (
 	FsNames = map[FsMagic]string{
 		FsMagicAufs:        "aufs",
 		FsMagicBtrfs:       "btrfs",
-		FsMagicExtfs:       "extfs",
 		FsMagicCramfs:      "cramfs",
-		FsMagicRamFs:       "ramfs",
-		FsMagicTmpFs:       "tmpfs",
-		FsMagicSquashFs:    "squashfs",
+		FsMagicExtfs:       "extfs",
+		FsMagicF2fs:        "f2fs",
+		FsMagicJffs2Fs:     "jffs2",
+		FsMagicJfs:         "jfs",
 		FsMagicNfsFs:       "nfs",
+		FsMagicRamFs:       "ramfs",
 		FsMagicReiserFs:    "reiserfs",
 		FsMagicSmbFs:       "smb",
-		FsMagicJffs2Fs:     "jffs2",
-		FsMagicZfs:         "zfs",
-		FsMagicXfs:         "xfs",
+		FsMagicSquashFs:    "squashfs",
+		FsMagicTmpFs:       "tmpfs",
 		FsMagicUnsupported: "unsupported",
+		FsMagicXfs:         "xfs",
+		FsMagicZfs:         "zfs",
 	}
 )
 


### PR DESCRIPTION
Added in the magic bits for the F2Fs and JFS filesystem, so `docker info` will display the `Backing Filesystem:` info as expected. Fixes #12324 

Signed-off-by: Megan Kostick mkostick@us.ibm.com
