### PR TITLE
Fast path for archive.Changes generation on overlay

### DIFF
--- a/pkg/system/stat.go
+++ b/pkg/system/stat.go
@@ -12,6 +12,8 @@ type Stat_t struct {
 	gid  uint32
 	rdev uint64
 	size int64
+	ino  uint64
+	dev  uint64
 	mtim syscall.Timespec
 }
 
@@ -33,6 +35,14 @@ func (s Stat_t) Rdev() uint64 {
 
 func (s Stat_t) Size() int64 {
 	return s.size
+}
+
+func (s Stat_t) Ino() uint64 {
+	return s.ino
+}
+
+func (s Stat_t) Dev() uint64 {
+	return s.dev
 }
 
 func (s Stat_t) Mtim() syscall.Timespec {

--- a/pkg/system/stat_linux.go
+++ b/pkg/system/stat_linux.go
@@ -11,6 +11,8 @@ func fromStatT(s *syscall.Stat_t) (*Stat_t, error) {
 		uid:  s.Uid,
 		gid:  s.Gid,
 		rdev: s.Rdev,
+		ino:  s.Ino,
+		dev:  s.Dev,
 		mtim: s.Mtim}, nil
 }
 

--- a/pkg/system/stat_test.go
+++ b/pkg/system/stat_test.go
@@ -31,6 +31,12 @@ func TestFromStatT(t *testing.T) {
 	if stat.Rdev != s.Rdev() {
 		t.Fatal("got invalid rdev")
 	}
+	if stat.Dev != s.Dev() {
+		t.Fatal("got invalid dev")
+	}
+	if stat.Ino != s.Ino() {
+		t.Fatal("got invalid ino")
+	}
 	if stat.Mtim != s.Mtim() {
 		t.Fatal("got invalid mtim")
 	}

--- a/pkg/system/stat_unsupported.go
+++ b/pkg/system/stat_unsupported.go
@@ -13,5 +13,7 @@ func fromStatT(s *syscall.Stat_t) (*Stat_t, error) {
 		uid:  s.Uid,
 		gid:  s.Gid,
 		rdev: uint64(s.Rdev),
+		dev:  uint64(s.Dev),
+		ino:  uint64(s.Ino),
 		mtim: s.Mtimespec}, nil
 }


### PR DESCRIPTION
Pushing layers where several thousand files have changed is quite slow. This is because of how `archive.Changes` is generated.

With the `overlay` storage driver (and really any other), we know that if the `ino` and `dev` fields of a `stat_t` match, it is definitely the same file.

There's a comment here to the effect of not being able to trust these, and it's true -- we can't assume that a non-match implies differing files, but we do know that a match means they're identical.

This should speed various operations substantially: certainly on overlay, and possibly on other backends also.
