### PR TITLE
graphdriver: promote overlay driver to first

### DIFF
--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -38,10 +38,10 @@ var (
 	drivers map[string]InitFunc
 	// Slice of drivers that should be used in an order
 	priority = []string{
+		"overlay",
 		"aufs",
 		"btrfs",
 		"devicemapper",
-		"overlay",
 		"vfs",
 	}
 


### PR DESCRIPTION
Upgrade overlayfs to first place, now that this will not break driver
usage on existing installs.

Splitting this PR out from https://github.com/docker/docker/pull/11999#issuecomment-92523265

Issue https://github.com/docker/docker/issues/12327 and https://github.com/docker/docker/issues/12080 flagged `overlay` for further review.

Notable `overlay` issues to sort out:
- [ ] expected behavior of unix sockets
- [ ] `open("foo.txt", O_RDONLY); open("foo.txt", O_RDWR)`

@LK4D4 @jfrazelle @crosbymichael 

Signed-off-by: Vincent Batts vbatts@redhat.com
