### PR TITLE
change go tools to use certain commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,12 +102,15 @@ RUN cd /usr/local/go/src \
 ENV GOFMT_VERSION 1.3.3
 RUN curl -sSL https://storage.googleapis.com/golang/go${GOFMT_VERSION}.$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C /go/bin -xz --strip-components=2 go/bin/gofmt
 
+# Update this sha when we upgrade to go 1.5.0
+ENV GO_TOOLS_COMMIT 069d2f3bcb68257b627205f0486d6cc69a231ff9
 # Grab Go's cover tool for dead-simple code coverage testing
-RUN go get golang.org/x/tools/cmd/cover
-
 # Grab Go's vet tool for examining go code to find suspicious constructs
 # and help prevent errors that the compiler might not catch
-RUN go get golang.org/x/tools/cmd/vet
+RUN git clone https://github.com/golang/tools.git /go/src/golang.org/x/tools \
+	&& (cd /go/src/golang.org/x/tools && git checkout -q $GO_TOOLS_COMMIT) \
+	&& go install -v golang.org/x/tools/cmd/cover \
+	&& go install -v golang.org/x/tools/cmd/vet
 
 # TODO replace FPM with some very minimal debhelper stuff
 RUN gem install --no-rdoc --no-ri fpm --version 1.3.2


### PR DESCRIPTION
vet tool was updated to work with go tip (unreleased, 1.5.0)

and it takes us a week or so to update our go version after they release sooo this will eventually resurface whether or not they revert the commit (see golang/go#10446)

fixes CI, ping @LK4D4 @tianon 
