### PR TITLE
Fix wrong graphdb refs paths purging

### DIFF
--- a/pkg/graphdb/graphdb_test.go
+++ b/pkg/graphdb/graphdb_test.go
@@ -472,8 +472,8 @@ func TestPurgeId(t *testing.T) {
 
 	db.Set("/webapp", "1")
 
-	if db.Refs("1") != 1 {
-		t.Fatal("Expect reference count to be 1")
+	if c := db.Refs("1"); c != 1 {
+		t.Fatalf("Expect reference count to be 1, got %d", c)
 	}
 
 	db.Set("/db", "2")
@@ -484,7 +484,45 @@ func TestPurgeId(t *testing.T) {
 		t.Fatal(err)
 	}
 	if count != 2 {
-		t.Fatal("Expected 2 references to be removed")
+		t.Fatalf("Expected 2 references to be removed, got %d", count)
+	}
+}
+
+// Regression test https://github.com/docker/docker/issues/12334
+func TestPurgeIdRefPaths(t *testing.T) {
+	db, dbpath := newTestDb(t)
+	defer destroyTestDb(dbpath)
+
+	db.Set("/webapp", "1")
+	db.Set("/db", "2")
+
+	db.Set("/db/webapp", "1")
+
+	if c := db.Refs("1"); c != 2 {
+		t.Fatalf("Expected 2 reference for webapp, got %d", c)
+	}
+	if c := db.Refs("2"); c != 1 {
+		t.Fatalf("Expected 1 reference for db, got %d", c)
+	}
+
+	if rp := db.RefPaths("2"); len(rp) != 1 {
+		t.Fatalf("Expected 1 reference path for db, got %d", len(rp))
+	}
+
+	count, err := db.Purge("2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if count != 2 {
+		t.Fatalf("Expected 2 rows to be removed, got %d", count)
+	}
+
+	if c := db.Refs("2"); c != 0 {
+		t.Fatalf("Expected 0 reference for db, got %d", c)
+	}
+	if c := db.Refs("1"); c != 1 {
+		t.Fatalf("Expected 1 reference for webapp, got %d", c)
 	}
 }
 


### PR DESCRIPTION
Fixes: #12334

When deleting (purging) a container, linked containers were not updating correctly meaning they were left with the `parent_id` referencing a deleted container.
The solution is to just delete the edge (container) that has `parent_id` referencing to the deleted container. Updating this row is not necessary because there's just a row for that container.

Maybe this let you undestand better.
After `docker run -d --name fixgraph busybox top` and `docker run -d --name fixgraphtest --link fixgraph:fixgraph busybox` run, the sqlite db looks like this:

![Pre](https://i.imgur.com/QUf7wpw.png)

After `docker rm fixgraphtest` the table looks like:

![Post](https://i.imgur.com/FPN6yy1.png)

So due to to row `258` is still there the error in the issue is thrown. Hence this fix.

Hope this won't break something because it seems to not have showed up till now even if this error was present in previous release (tested on both 1.6.0-rc5/6 and stock 1.5.0). Also I'm not aware if leaving that row was intentional for debugging purpose or something else. 

I'll add a regression test asap if this is confirmed.

/cc @cpuguy83 @LK4D4 @crosbymichael 

Signed-off-by: Antonio Murdaca me@runcom.ninja
