### PR TITLE
Remove sprious `fmt.Printf` from test

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -705,7 +705,6 @@ func TestExecWithPrivileged(t *testing.T) {
 
 	cmd := exec.Command(dockerBinary, "exec", "parent", "sh", "-c", "mknod /tmp/sda b 8 0")
 	out, _, err := runCommandWithOutput(cmd)
-	fmt.Printf("%s", out)
 	if err == nil || !strings.Contains(out, "Operation not permitted") {
 		t.Fatalf("exec mknod in --cap-drop=ALL container without --privileged should failed")
 	}


### PR DESCRIPTION
Should close #12378 
