### PR TITLE
Inspect show right LogPath in json-file driver

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1405,6 +1405,7 @@ func (container *Container) startLogging() error {
 		if err != nil {
 			return err
 		}
+		container.LogPath = pth
 
 		dl, err := jsonfilelog.New(pth)
 		if err != nil {

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -359,7 +359,10 @@ Return low-level information on the container `id`
 				"MaximumRetryCount": 2,
 				"Name": "on-failure"
 			},
-           "LogConfig": { "Type": "json-file", Config: {} },
+			"LogConfig": {
+				"Config": null,
+				"Type": "json-file"
+			},
 			"SecurityOpt": null,
 			"VolumesFrom": null,
 			"Ulimits": [{}]

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -359,7 +359,10 @@ Return low-level information on the container `id`
 				"MaximumRetryCount": 2,
 				"Name": "on-failure"
 			},
-           "LogConfig": { "Type": "json-file", "Config": {} },
+			"LogConfig": {
+				"Config": null,
+				"Type": "json-file"
+			},
 			"SecurityOpt": null,
 			"VolumesFrom": null,
 			"Ulimits": [{}]


### PR DESCRIPTION
`docker inspect` show empty LogPath even in json-file logging driver.

``` bash
$ dock inspect test
    "LogPath": "",
```

now it looks like:

``` bash
$ dock inspect test
    "LogPath": "/var/lib/docker/containers/62ee3c82a19e20de8156dfd285187ee3b3b63de414edef63f9335973fb908f71/62ee3c82a19e20de8156dfd285187ee3b3b63de414edef63f9335973fb908f71-json.log",
```

Signed-off-by: Deng Guangxing dengguangxing@huawei.com
