### PR TITLE
fix inspect format result

### DIFF
--- a/api/client/inspect.go
+++ b/api/client/inspect.go
@@ -57,9 +57,14 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 				continue
 			}
 		} else {
-			// Has template, will render
 			var value interface{}
-			if err := json.Unmarshal(obj, &value); err != nil {
+
+			// Do not use `json.Unmarshal()` because unmarshal JSON into
+			// an interface value, Unmarshal stores JSON numbers in
+			// float64, which is different from `json.Indent()` does.
+			dec := json.NewDecoder(bytes.NewReader(obj))
+			dec.UseNumber()
+			if err := dec.Decode(&value); err != nil {
 				fmt.Fprintf(cli.err, "%s\n", err)
 				status = 1
 				continue

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5383,11 +5383,11 @@ func (s *DockerSuite) TestBuildResourceConstraintsAreUsed(c *check.C) {
 	cID := strings.TrimSpace(out)
 
 	type hostConfig struct {
-		Memory     float64 // Use float64 here since the json decoder sees it that way
-		MemorySwap int
+		Memory     int64
+		MemorySwap int64
 		CpusetCpus string
 		CpusetMems string
-		CpuShares  int
+		CpuShares  int64
 	}
 
 	cfg, err := inspectFieldJSON(cID, "HostConfig")
@@ -5399,10 +5399,9 @@ func (s *DockerSuite) TestBuildResourceConstraintsAreUsed(c *check.C) {
 	if err := json.Unmarshal([]byte(cfg), &c1); err != nil {
 		c.Fatal(err, cfg)
 	}
-	mem := int64(c1.Memory)
-	if mem != 67108864 || c1.MemorySwap != -1 || c1.CpusetCpus != "0" || c1.CpusetMems != "0" || c1.CpuShares != 100 {
+	if c1.Memory != 67108864 || c1.MemorySwap != -1 || c1.CpusetCpus != "0" || c1.CpusetMems != "0" || c1.CpuShares != 100 {
 		c.Fatalf("resource constraints not set properly:\nMemory: %d, MemSwap: %d, CpusetCpus: %s, CpusetMems: %s, CpuShares: %d",
-			mem, c1.MemorySwap, c1.CpusetCpus, c1.CpusetMems, c1.CpuShares)
+			c1.Memory, c1.MemorySwap, c1.CpusetCpus, c1.CpusetMems, c1.CpuShares)
 	}
 
 	// Make sure constraints aren't saved to image
@@ -5416,10 +5415,9 @@ func (s *DockerSuite) TestBuildResourceConstraintsAreUsed(c *check.C) {
 	if err := json.Unmarshal([]byte(cfg), &c2); err != nil {
 		c.Fatal(err, cfg)
 	}
-	mem = int64(c2.Memory)
-	if mem == 67108864 || c2.MemorySwap == -1 || c2.CpusetCpus == "0" || c2.CpusetMems == "0" || c2.CpuShares == 100 {
+	if c2.Memory == 67108864 || c2.MemorySwap == -1 || c2.CpusetCpus == "0" || c2.CpusetMems == "0" || c2.CpuShares == 100 {
 		c.Fatalf("resource constraints leaked from build:\nMemory: %d, MemSwap: %d, CpusetCpus: %s, CpusetMems: %s, CpuShares: %d",
-			mem, c2.MemorySwap, c2.CpusetCpus, c2.CpusetMems, c2.CpuShares)
+			c2.Memory, c2.MemorySwap, c2.CpusetCpus, c2.CpusetMems, c2.CpuShares)
 	}
 
 }

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -21,3 +21,23 @@ func (s *DockerSuite) TestInspectImage(c *check.C) {
 	}
 
 }
+
+func (s *DockerSuite) TestInspectInt64(c *check.C) {
+	runCmd := exec.Command(dockerBinary, "run", "-d", "-m=300M", "busybox", "true")
+	out, _, _, err := runCommandWithStdoutStderr(runCmd)
+	if err != nil {
+		c.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+
+	out = strings.TrimSpace(out)
+
+	inspectCmd := exec.Command(dockerBinary, "inspect", "-f", "{{.HostConfig.Memory}}", out)
+	inspectOut, _, err := runCommandWithOutput(inspectCmd)
+	if err != nil {
+		c.Fatalf("failed to inspect container: %v, output: %q", err, inspectOut)
+	}
+
+	if strings.TrimSpace(inspectOut) != "314572800" {
+		c.Fatalf("inspect got wrong value, got: %q, expected: 314572800", inspectOut)
+	}
+}


### PR DESCRIPTION
Currently `docker inspect -f` use json.Unmarshal() unmarshal
to interface, it will store all JSON numbers in float64, so
we use `docker inspect 4f0d73b75a0d | grep Memory` and
`docker inspect -f {{.HostConfig.Memory}} 4f0d73b75a0d` will
get different values.
