### PR TITLE
Change syslog format and facility

### DIFF
--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -14,7 +14,7 @@ type Syslog struct {
 }
 
 func New(tag string) (logger.Logger, error) {
-	log, err := syslog.New(syslog.LOG_USER, fmt.Sprintf("%s: <%s> ", path.Base(os.Args[0]), tag))
+	log, err := syslog.New(syslog.LOG_DAEMON, fmt.Sprintf("%s/%s", path.Base(os.Args[0]), tag))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This patch changes three things
1. Set facility to LOG_DAEMON
2. Remove ": " from tag so that the tag + pid become a single column in
   the log
3. Log the container name and not the ID as the ID is often ephemeral
   and hard to correlate with events in the past

This is an implementation of the my comments on #12377

In the end running `docker run --name test --rm --log-driver syslog ubuntu echo hi` will yield the following log in Ubuntu

```
Apr 15 00:16:05 inotmac docker<test>[30851]: hi
```

Fix #12377
