### PR TITLE
Ensure all the running containers are killed on daemon shutdown

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1003,8 +1003,9 @@ func (daemon *Daemon) Shutdown() error {
 
 				go func() {
 					defer group.Done()
-					if err := c.KillSig(15); err != nil {
-						logrus.Debugf("kill 15 error for %s - %s", c.ID, err)
+					// If container failed to exit in 10 seconds of SIGTERM, then using the force
+					if err := c.Stop(10); err != nil {
+						logrus.Errorf("Stop container %s with error: %v", c.ID, err)
 					}
 					c.WaitStop(-1 * time.Second)
 					logrus.Debugf("container stopped %s", c.ID)

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1165,3 +1165,19 @@ func (s *DockerDaemonSuite) TestRunContainerWithBridgeNone(c *check.C) {
 	c.Assert(strings.Contains(out, "eth0"), check.Equals, false,
 		check.Commentf("There shouldn't be eth0 in container when network is disabled: %s", out))
 }
+
+func (s *DockerDaemonSuite) TestDaemonRestartWithContainerRunning(t *check.C) {
+	if err := s.d.StartWithBusybox(); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := s.d.Cmd("run", "-ti", "-d", "--name", "test", "busybox"); err != nil {
+		t.Fatal(out, err)
+	}
+	if err := s.d.Restart(); err != nil {
+		t.Fatal(err)
+	}
+	// Container 'test' should be removed without error
+	if out, err := s.d.Cmd("rm", "test"); err != nil {
+		t.Fatal(out, err)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

On daemon shutdown, the daemon will be killed in 10s whether the running 
containers are killed or not( the running containers are supposed to be killed in 10s). 
This will cause some problems for the containers which are not killed in 10s. One
problem is that it will cause an error when remove  these containers on daemon next
start.The reason is that the container rootfs is still mounted. The containers' rootfs supposed
to be unmounted when the container is killed. 
Steps to reproduce(`storage driver: overlay`):
Step 1. Run a container `docker run -ti --name test busybox`

<pre><code>[l00284783@localhost docker]$ docker run -ti --name test busybox
/ #
</code></pre>

Step 2. Shutdown the docker daemon

<pre><code>^CINFO[0127] Received signal 'interrupt', starting shutdown of docker...
DEBU[0127] starting clean shutdown of all containers...
DEBU[0127] stopping aeb7a17120cd72e045d30e727b36a56b71663f700a69212c08b9060c8964b992
DEBU[0127] Sending 15 to aeb7a17120cd72e045d30e727b36a56b71663f700a69212c08b9060c8964b992
INFO[0127] -job serveapi(unix:///var/run/docker.sock) OK</code></pre>

Step 3. restart the docker daemon
Step 4. Remove  the container `test` which is the container run on step 1

<pre><code>[l00284783@localhost docker]$ docker rm test
Error response from daemon: Cannot destroy container test: Driver overlay failed to remove root filesystem aeb7a17120cd72e045d30e727b36a56b71663f700a69212c08b9060c8964b992: readdirent: no such file or directory
FATA[0000] Error: failed to remove one or more containers</code></pre>

I have test with storage `overlay` and `devicemapper`, have the same problem. `devicemapper`
will show `device busy`

What cause this is that container `test` isn't killed in 10s, but the docker daemon timeout and 
killed, so the cleanup of the container is not done and leave the container with its rootfs still mounted.  

My fixed is use `container.stop(10)` instead of `c.KillSig(15)`, 
`container.stop(10)` will send `SIGTERM` to container and wait 10s,
if the container failed to exit within 10s of SIGTERM, then send `SIGKILL`.
And change the daemon shutdown timeout from `10s` to `15s`

WDYT? ping @cpuguy83  @estesp  @LK4D4  @jfrazelle 
