### PR TITLE
Clarify behavior of --interactive when STDIN not attached

### DIFF
--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -104,6 +104,8 @@ IMAGE [COMMAND] [ARG...]
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.
 
+   Forward input to container's STDIN if exposed by --attach or --tty options. Note that input will be silently discarded if STDIN is not attached.
+
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
                                'container:<name|id>': reuses another container shared memory, semaphores and message queues

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -197,7 +197,7 @@ ENTRYPOINT.
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.
 
-   When set to true, keep stdin open even if not attached. The default is false.
+   Forward input to container's STDIN if exposed by --attach or --tty options. Note that input will be silently discarded if STDIN is not attached.
 
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container


### PR DESCRIPTION
When 'docker run' or 'docker create' are called without --tty and without STDIN attached, input is silently discarded. This is somewhat confusing, to the point where it was reported as a bug (https://bugzilla.redhat.com/show_bug.cgi?id=1189865), but doesn't seem to be harmful behavior. Documenting this should help prevent future confusion.
