### PR TITLE
devmapper: Emit warning messages when using loopback, update docs

### DIFF
--- a/daemon/graphdriver/devmapper/README.md
+++ b/daemon/graphdriver/devmapper/README.md
@@ -3,12 +3,21 @@
 ### Theory of operation
 
 The device mapper graphdriver uses the device mapper thin provisioning
-module (dm-thinp) to implement CoW snapshots. For each devicemapper
-graph location (typically `/var/lib/docker/devicemapper`, $graph below)
-a thin pool is created based on two block devices, one for data and
-one for metadata.  By default these block devices are created
-automatically by using loopback mounts of automatically created sparse
-files.
+module (dm-thinp) to implement CoW snapshots.  The preferred model is
+to have a thin pool reserved outside of Docker, and passed to the
+daemon via the `--storage-opt dm.thinpooldev` option.
+
+As a fallback if no thin pool is provided, loopback files will be
+created.  Loopback is very slow, but can be used without any
+pre-configuration of storage.  It is *strongly recommended* to not use
+loopback in production.  Ensure your docker daemon has a
+`--storage-opt dm.thinpooldev` argument provided.
+
+In loopback, each devicemapper graph location (typically
+`/var/lib/docker/devicemapper`, $graph below) a thin pool is created
+based on two block devices, one for data and one for metadata.  By
+default these block devices are created automatically by using
+loopback mounts of automatically created sparse files.
 
 The default loopback files used are `$graph/devicemapper/data` and
 `$graph/devicemapper/metadata`. Additional metadata required to map
@@ -164,6 +173,8 @@ Here is the list of supported options:
 
  *  `dm.datadev`
 
+    (Deprecated, use dm.thinpooldev)
+
     Specifies a custom blockdevice to use for data for the thin pool.
 
     If using a block device for device mapper storage, ideally both
@@ -175,6 +186,8 @@ Here is the list of supported options:
     ``docker -d --storage-opt dm.datadev=/dev/sdb1 --storage-opt dm.metadatadev=/dev/sdc1``
 
  *  `dm.metadatadev`
+
+    (Deprecated, use dm.thinpooldev)
 
     Specifies a custom blockdevice to use for metadata for the thin
     pool.

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -1096,6 +1096,14 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 		}
 	}
 
+	if devices.thinPoolDevice == "" {
+		if devices.metadataLoopFile != "" || devices.dataLoopFile != "" {
+			logrus.Errorf("WARNING: LOOP DEVICE FALLBACK: No --storage-opt dm.thinpooldev specified; Usage of loopback is very strongly discouraged for production use.  Use --storage-opt dm.thinpooldev instead.  For more information see `man docker`")
+		} else {
+			logrus.Warnf("WARNING: Usage of --storage-opt dm.datadev or dm.metadatadev is strongly discouraged for production use.  Use --storage-opt dm.thinpooldev instead.  For more information see `man docker`")
+		}
+	}
+
 	// If we didn't just create the data or metadata image, we need to
 	// load the transaction id and migrate old metadata
 	if !createdLoopback {


### PR DESCRIPTION
We really want people to use `dm.thinpooldev` as it's most performant.
Loopback is convenient for dev scenarios but the message "don't use
this in production" is not coming across strongly enough.  Fix that by
both noting it in the `README.md` here as well as by emitting warning
messages.
