### PR TITLE
Remove job from container_inspect

### DIFF
--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -1,10 +1,11 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/url"
 
-	"github.com/docker/docker/engine"
+	"github.com/docker/docker/api/types"
 	flag "github.com/docker/docker/pkg/mflag"
 )
 
@@ -29,12 +30,12 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 		return err
 	}
 
-	env := engine.Env{}
-	if err := env.Decode(stream); err != nil {
+	var c types.ContainerJSON
+	if err := json.NewDecoder(stream).Decode(&c); err != nil {
 		return err
 	}
 
-	if env.GetSubEnv("HostConfig").GetSubEnv("LogConfig").Get("Type") != "json-file" {
+	if c.HostConfig.LogConfig.Type != "json-file" {
 		return fmt.Errorf("\"logs\" command is supported only for \"json-file\" logging driver")
 	}
 
@@ -51,5 +52,5 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 	}
 	v.Set("tail", *tail)
 
-	return cli.streamHelper("GET", "/containers/"+name+"/logs?"+v.Encode(), env.GetSubEnv("Config").GetBool("Tty"), nil, cli.out, cli.err, nil)
+	return cli.streamHelper("GET", "/containers/"+name+"/logs?"+v.Encode(), c.Config.Tty, nil, cli.out, cli.err, nil)
 }

--- a/api/common.go
+++ b/api/common.go
@@ -10,26 +10,15 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/version"
 	"github.com/docker/libtrust"
 )
 
 // Common constants for daemon and client.
 const (
-	APIVERSION            version.Version = "1.19"                 // Current REST API version
-	DEFAULTHTTPHOST                       = "127.0.0.1"            // Default HTTP Host used if only port is provided to -H flag e.g. docker -d -H tcp://:8080
-	DEFAULTUNIXSOCKET                     = "/var/run/docker.sock" // Docker daemon by default always listens on the default unix socket
-	DefaultDockerfileName string          = "Dockerfile"           // Default filename with Docker commands, read by docker build
+	APIVERSION            version.Version = "1.19"       // Current REST API version
+	DefaultDockerfileName string          = "Dockerfile" // Default filename with Docker commands, read by docker build
 )
-
-func ValidateHost(val string) (string, error) {
-	host, err := parsers.ParseHost(DEFAULTHTTPHOST, DEFAULTUNIXSOCKET, val)
-	if err != nil {
-		return val, err
-	}
-	return host, nil
-}
 
 type ByPrivatePort []types.Port
 

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -1,6 +1,12 @@
 package types
 
-import "github.com/docker/docker/pkg/version"
+import (
+	"time"
+
+	"github.com/docker/docker/daemon/network"
+	"github.com/docker/docker/pkg/version"
+	"github.com/docker/docker/runconfig"
+)
 
 // ContainerCreateResponse contains the information returned to a client on the
 // creation of a new container.
@@ -161,4 +167,44 @@ type ExecStartCheck struct {
 	Detach bool
 	// Check if there's a tty
 	Tty bool
+}
+
+type ContainerState struct {
+	Running    bool
+	Paused     bool
+	Restarting bool
+	OOMKilled  bool
+	Dead       bool
+	Pid        int
+	ExitCode   int
+	Error      string
+	StartedAt  time.Time
+	FinishedAt time.Time
+}
+
+// GET "/containers/{name:.*}/json"
+type ContainerJSON struct {
+	Id              string
+	Created         time.Time
+	Path            string
+	Args            []string
+	Config          *runconfig.Config
+	State           *ContainerState
+	Image           string
+	NetworkSettings *network.Settings
+	ResolvConfPath  string
+	HostnamePath    string
+	HostsPath       string
+	LogPath         string
+	Name            string
+	RestartCount    int
+	Driver          string
+	ExecDriver      string
+	MountLabel      string
+	ProcessLabel    string
+	Volumes         map[string]string
+	VolumesRW       map[string]bool
+	AppArmorProfile string
+	ExecIDs         []string
+	HostConfig      *runconfig.HostConfig
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -116,13 +116,6 @@ type Daemon struct {
 
 // Install installs daemon capabilities to eng.
 func (daemon *Daemon) Install(eng *engine.Engine) error {
-	for name, method := range map[string]engine.Handler{
-		"container_inspect": daemon.ContainerInspect,
-	} {
-		if err := eng.Register(name, method); err != nil {
-			return err
-		}
-	}
 	if err := daemon.Repositories().Install(eng); err != nil {
 		return err
 	}

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -1,83 +1,92 @@
 package daemon
 
 import (
-	"encoding/json"
 	"fmt"
 
-	"github.com/docker/docker/engine"
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/runconfig"
 )
 
-func (daemon *Daemon) ContainerInspect(job *engine.Job) error {
-	if len(job.Args) != 1 {
-		return fmt.Errorf("usage: %s NAME", job.Name)
-	}
-	name := job.Args[0]
+type ContainerJSONRaw struct {
+	*Container
+	HostConfig *runconfig.HostConfig
+}
+
+func (daemon *Daemon) ContainerInspectRaw(name string) (*ContainerJSONRaw, error) {
 	container, err := daemon.Get(name)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	container.Lock()
 	defer container.Unlock()
-	if job.GetenvBool("raw") {
-		b, err := json.Marshal(&struct {
-			*Container
-			HostConfig *runconfig.HostConfig
-		}{container, container.hostConfig})
-		if err != nil {
-			return err
-		}
-		job.Stdout.Write(b)
-		return nil
+
+	return &ContainerJSONRaw{container, container.hostConfig}, nil
+}
+
+func (daemon *Daemon) ContainerInspect(name string) (*types.ContainerJSON, error) {
+	container, err := daemon.Get(name)
+	if err != nil {
+		return nil, err
 	}
 
-	out := &engine.Env{}
-	out.SetJson("Id", container.ID)
-	out.SetAuto("Created", container.Created)
-	out.SetJson("Path", container.Path)
-	out.SetList("Args", container.Args)
-	out.SetJson("Config", container.Config)
-	out.SetJson("State", container.State)
-	out.Set("Image", container.ImageID)
-	out.SetJson("NetworkSettings", container.NetworkSettings)
-	out.Set("ResolvConfPath", container.ResolvConfPath)
-	out.Set("HostnamePath", container.HostnamePath)
-	out.Set("HostsPath", container.HostsPath)
-	out.Set("LogPath", container.LogPath)
-	out.SetJson("Name", container.Name)
-	out.SetInt("RestartCount", container.RestartCount)
-	out.Set("Driver", container.Driver)
-	out.Set("ExecDriver", container.ExecDriver)
-	out.Set("MountLabel", container.MountLabel)
-	out.Set("ProcessLabel", container.ProcessLabel)
-	out.SetJson("Volumes", container.Volumes)
-	out.SetJson("VolumesRW", container.VolumesRW)
-	out.SetJson("AppArmorProfile", container.AppArmorProfile)
+	container.Lock()
+	defer container.Unlock()
 
-	out.SetList("ExecIDs", container.GetExecIDs())
+	// make a copy to play with
+	hostConfig := *container.hostConfig
 
 	if children, err := daemon.Children(container.Name); err == nil {
 		for linkAlias, child := range children {
-			container.hostConfig.Links = append(container.hostConfig.Links, fmt.Sprintf("%s:%s", child.Name, linkAlias))
+			hostConfig.Links = append(hostConfig.Links, fmt.Sprintf("%s:%s", child.Name, linkAlias))
 		}
 	}
 	// we need this trick to preserve empty log driver, so
 	// container will use daemon defaults even if daemon change them
-	if container.hostConfig.LogConfig.Type == "" {
-		container.hostConfig.LogConfig = daemon.defaultLogConfig
-		defer func() {
-			container.hostConfig.LogConfig = runconfig.LogConfig{}
-		}()
+	if hostConfig.LogConfig.Type == "" {
+		hostConfig.LogConfig = daemon.defaultLogConfig
 	}
 
-	out.SetJson("HostConfig", container.hostConfig)
-
-	container.hostConfig.Links = nil
-	if _, err := out.WriteTo(job.Stdout); err != nil {
-		return err
+	containerState := &types.ContainerState{
+		Running:    container.State.Running,
+		Paused:     container.State.Paused,
+		Restarting: container.State.Restarting,
+		OOMKilled:  container.State.OOMKilled,
+		Dead:       container.State.Dead,
+		Pid:        container.State.Pid,
+		ExitCode:   container.State.ExitCode,
+		Error:      container.State.Error,
+		StartedAt:  container.State.StartedAt,
+		FinishedAt: container.State.FinishedAt,
 	}
-	return nil
+
+	contJSON := &types.ContainerJSON{
+		Id:              container.ID,
+		Created:         container.Created,
+		Path:            container.Path,
+		Args:            container.Args,
+		Config:          container.Config,
+		State:           containerState,
+		Image:           container.ImageID,
+		NetworkSettings: container.NetworkSettings,
+		ResolvConfPath:  container.ResolvConfPath,
+		HostnamePath:    container.HostnamePath,
+		HostsPath:       container.HostsPath,
+		LogPath:         container.LogPath,
+		Name:            container.Name,
+		RestartCount:    container.RestartCount,
+		Driver:          container.Driver,
+		ExecDriver:      container.ExecDriver,
+		MountLabel:      container.MountLabel,
+		ProcessLabel:    container.ProcessLabel,
+		Volumes:         container.Volumes,
+		VolumesRW:       container.VolumesRW,
+		AppArmorProfile: container.AppArmorProfile,
+		ExecIDs:         container.GetExecIDs(),
+		HostConfig:      &hostConfig,
+	}
+
+	return contJSON, nil
 }
 
 func (daemon *Daemon) ContainerExecInspect(id string) (*execConfig, error) {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/client"
 	"github.com/docker/docker/autogen/dockerversion"
+	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/docker/pkg/term"
@@ -63,9 +63,9 @@ func main() {
 		defaultHost := os.Getenv("DOCKER_HOST")
 		if defaultHost == "" || *flDaemon {
 			// If we do not have a host, default to unix socket
-			defaultHost = fmt.Sprintf("unix://%s", api.DEFAULTUNIXSOCKET)
+			defaultHost = fmt.Sprintf("unix://%s", opts.DefaultUnixSocket)
 		}
-		defaultHost, err := api.ValidateHost(defaultHost)
+		defaultHost, err := opts.ValidateHost(defaultHost)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/docker/docker/api"
+	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/stringutils"
 	"github.com/go-check/check"
@@ -274,7 +274,7 @@ func (d *Daemon) LogfileName() string {
 }
 
 func daemonHost() string {
-	daemonUrlStr := "unix://" + api.DEFAULTUNIXSOCKET
+	daemonUrlStr := "unix://" + opts.DefaultUnixSocket
 	if daemonHostVar := os.Getenv("DOCKER_HOST"); daemonHostVar != "" {
 		daemonUrlStr = daemonHostVar
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -239,16 +239,6 @@ func ReplaceOrAppendEnvValues(defaults, overrides []string) []string {
 	return defaults
 }
 
-func DoesEnvExist(name string) bool {
-	for _, entry := range os.Environ() {
-		parts := strings.SplitN(entry, "=", 2)
-		if parts[0] == name {
-			return true
-		}
-	}
-	return false
-}
-
 // ValidateContextDirectory checks if all the contents of the directory
 // can be read and returns an error if some files can't be read
 // symlinks which point to non-existing files don't trigger an error


### PR DESCRIPTION
/cc @LK4D4 @cpuguy83 @duglin @icecrime 

I'm opening this to get suggestions to finalize this work. Basically I'd like suggestions about `ContainerJSON` struct in `daemon` 
It can't be put into `api/types` because it depends on `runconfig` which in turn depends on `api`
Clients that could use this struct are for instance `api/client/logs` and I wouldn't import `daemon` code here so I just created a type struct to extract the info I needed from the json response, is this that bad? Basically I like the idea to non couple client/server/daemon and just extract infos needed with a custom struct just to have a type to decode into (yes you have to maintain two things then but clients always adjust in response to server/api changes isn't it?).

Tests will probably fail because this isn't yet finished. but logs tests run ok with this modifications! I'll fix everything later.

Signed-off-by: Antonio Murdaca me@runcom.ninja
