### PR TITLE
adding elementary OS to install script

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -126,7 +126,7 @@ do_install() {
 			exit 0
 			;;
 
-		ubuntu|debian|linuxmint)
+		ubuntu|debian|linuxmint|'elementary os')
 			export DEBIAN_FRONTEND=noninteractive
 
 			did_apt_get_update=


### PR DESCRIPTION
It's basically just an Ubuntu, I'm a total noob but I've tried it on elementary OS "Freya" and it worked.

It's worth mentioning that I needed to install lsb-core first though because there was no LSB modules available.

```
sudo apt-get install lsb-core
```

[solution to no LSB modules available](http://askubuntu.com/questions/230766/how-lsb-module-affects-system-and-can-be-made-available-to-the-system)
