### PR TITLE
add log opts flag to pass in logging options

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -80,6 +80,7 @@ func (config *Config) InstallFlags() {
 	opts.UlimitMapVar(config.Ulimits, []string{"-default-ulimit"}, "Set default ulimits for containers")
 	flag.StringVar(&config.LogConfig.Type, []string{"-log-driver"}, "json-file", "Default driver for container logs")
 	flag.BoolVar(&config.Bridge.EnableUserlandProxy, []string{"-userland-proxy"}, true, "Use userland proxy for loopback traffic")
+	opts.LogOptsVar(config.LogConfig.Config, []string{"-log-opt"}, "Set log driver options")
 }
 
 func getDefaultNetworkMtu() int {

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -32,6 +32,9 @@ var (
 )
 
 func init() {
+	if daemonCfg.LogConfig.Config == nil {
+		daemonCfg.LogConfig.Config = make(map[string]string)
+	}
 	daemonCfg.InstallFlags()
 	registryCfg.InstallFlags()
 }

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -849,6 +849,10 @@ command is not available for this logging driver
 
 Journald logging driver for Docker. Writes log messages to journald; the container id will be stored in the journal's `CONTAINER_ID` field. `docker logs` command is not available for this logging driver.  For detailed information on working with this logging driver, see [the journald logging driver](reference/logging/journald) reference documentation.
 
+#### Log Opts : 
+
+Logging options for configuring a log driver. The following log options are supported: [none]
+
 ## Overriding Dockerfile image defaults
 
 When a developer builds an image from a [*Dockerfile*](/reference/builder)

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -1,6 +1,7 @@
 package opts
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -26,6 +27,31 @@ func TestValidateIPAddress(t *testing.T) {
 		t.Fatalf("ValidateIPAddress(`random invalid string`) got %s %s", ret, err)
 	}
 
+}
+
+func TestMapOpts(t *testing.T) {
+	tmpMap := make(map[string]string)
+	o := newMapOpt(tmpMap, logOptsValidator)
+	o.Set("max-size=1")
+	if o.String() != "map[max-size:1]" {
+		t.Errorf("%s != [map[max-size:1]", o.String())
+	}
+
+	o.Set("max-file=2")
+	if len(tmpMap) != 2 {
+		t.Errorf("map length %d != 2", len(tmpMap))
+	}
+
+	if tmpMap["max-file"] != "2" {
+		t.Errorf("max-file = %s != 2", tmpMap["max-file"])
+	}
+
+	if tmpMap["max-size"] != "1" {
+		t.Errorf("max-size = %s != 1", tmpMap["max-size"])
+	}
+	if o.Set("dummy-val=3") == nil {
+		t.Errorf("validator is not being called")
+	}
 }
 
 func TestValidateMACAddress(t *testing.T) {
@@ -151,4 +177,13 @@ func TestValidateExtraHosts(t *testing.T) {
 			}
 		}
 	}
+}
+
+func logOptsValidator(val string) (string, error) {
+	allowedKeys := map[string]string{"max-size": "1", "max-file": "2"}
+	vals := strings.Split(val, "=")
+	if allowedKeys[vals[0]] != "" {
+		return val, nil
+	}
+	return "", fmt.Errorf("invalid key %s", vals[0])
 }


### PR DESCRIPTION
As per the discussions on this -- https://github.com/docker/docker/pull/11485/files

I'm dividing #11485 into two Pull requests, one for log-opts and one for `max-size` and `max-file` options.

This is the PR for log-opts.

@ibuildthecloud
@tiborvass 
@LK4D4 
