### PR TITLE
Add -H|--human command-line flag to `docker history`

### DIFF
--- a/api/client/history.go
+++ b/api/client/history.go
@@ -18,6 +18,7 @@ import (
 // Usage: docker history [OPTIONS] IMAGE
 func (cli *DockerCli) CmdHistory(args ...string) error {
 	cmd := cli.Subcmd("history", "IMAGE", "Show the history of an image", true)
+	human := cmd.Bool([]string{"H", "-human"}, true, "Print sizes and dates in human readable format")
 	quiet := cmd.Bool([]string{"q", "-quiet"}, false, "Only show numeric IDs")
 	noTrunc := cmd.Bool([]string{"#notrunc", "-no-trunc"}, false, "Don't truncate output")
 	cmd.Require(flag.Exact, 1)
@@ -46,14 +47,24 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 			fmt.Fprintf(w, stringid.TruncateID(entry.ID))
 		}
 		if !*quiet {
-			if *noTrunc {
+			if *human {
+				fmt.Fprintf(w, "\t%s ago\t", units.HumanDuration(time.Now().UTC().Sub(time.Unix(entry.Created, 0))))
+			} else {
 				fmt.Fprintf(w, "\t%s\t", time.Unix(entry.Created, 0).Format(time.RFC3339))
+			}
+
+			if *noTrunc {
 				fmt.Fprintf(w, "%s\t", entry.CreatedBy)
 			} else {
-				fmt.Fprintf(w, "\t%s ago\t", units.HumanDuration(time.Now().UTC().Sub(time.Unix(entry.Created, 0))))
 				fmt.Fprintf(w, "%s\t", stringutils.Truncate(entry.CreatedBy, 45))
 			}
-			fmt.Fprintf(w, "%s\t", units.HumanSize(float64(entry.Size)))
+
+			if *human {
+				fmt.Fprintf(w, "%s\t", units.HumanSize(float64(entry.Size)))
+			} else {
+				fmt.Fprintf(w, "%d\t", entry.Size)
+			}
+
 			fmt.Fprintf(w, "%s", entry.Comment)
 		}
 		fmt.Fprintf(w, "\n")

--- a/api/client/history.go
+++ b/api/client/history.go
@@ -46,11 +46,11 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 			fmt.Fprintf(w, stringid.TruncateID(entry.ID))
 		}
 		if !*quiet {
-			fmt.Fprintf(w, "\t%s ago\t", units.HumanDuration(time.Now().UTC().Sub(time.Unix(entry.Created, 0))))
-
 			if *noTrunc {
+				fmt.Fprintf(w, "\t%s\t", time.Unix(entry.Created, 0).Format(time.RFC3339))
 				fmt.Fprintf(w, "%s\t", entry.CreatedBy)
 			} else {
+				fmt.Fprintf(w, "\t%s ago\t", units.HumanDuration(time.Now().UTC().Sub(time.Unix(entry.Created, 0))))
 				fmt.Fprintf(w, "%s\t", stringutils.Truncate(entry.CreatedBy, 45))
 			}
 			fmt.Fprintf(w, "%s\t", units.HumanSize(float64(entry.Size)))

--- a/docs/man/docker-history.1.md
+++ b/docs/man/docker-history.1.md
@@ -19,6 +19,9 @@ Show the history of when and how an image was created.
 **--help**
   Print usage statement
 
+**-H**. **--human**=*true*|*false*
+    Print sizes and dates in human readable format. The default is *true*.
+
 **--no-trunc**=*true*|*false*
    Don't truncate output. The default is *false*.
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1191,6 +1191,7 @@ This will create a new Bash session in the container `ubuntu_bash`.
 
     Show the history of an image
 
+      -H, --human=true     Print sizes and dates in human readable format
       --no-trunc=false     Don't truncate output
       -q, --quiet=false    Only show numeric IDs
 


### PR DESCRIPTION
Carry #11551 by adding a new command-line flag. If this is accepted, I'll follow with a similar PR for `docker ps`.

closes #11413
