### PR TITLE
Start running container should return error

### DIFF
--- a/api/client/start.go
+++ b/api/client/start.go
@@ -125,7 +125,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 			if !*attach && !*openStdin {
 				// attach and openStdin is false means it could be starting multiple containers
 				// when a container start failed, show the error message and start next
-				fmt.Fprintf(cli.err, "%s\n", err)
+				fmt.Fprintf(cli.err, "Star container `%s` with error:%s\n", name, err.Error())
 				encounteredError = fmt.Errorf("Error: failed to start one or more containers")
 			} else {
 				encounteredError = err

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -940,10 +940,6 @@ func postContainersStart(eng *engine.Engine, version version.Version, w http.Res
 	}
 
 	if err := getDaemon(eng).ContainerStart(vars["name"], hostConfig); err != nil {
-		if err.Error() == "Container already started" {
-			w.WriteHeader(http.StatusNotModified)
-			return nil
-		}
 		return err
 	}
 	w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
Start running container should return error.
Use `docker start -ai` to start a running container, it will 
attach to the container(just like `docker attach`), is it a desired behavior? 
I think it should return an error to tell the user the container is already started.

I know the fix will break the API, just feel free to close this if it is not need.
