### PR TITLE
Removal of the regex to replace ips

### DIFF
--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -267,14 +266,7 @@ func Exists(table Table, chain string, rule ...string) bool {
 	ruleString := strings.Join(rule, " ")
 	existingRules, _ := exec.Command(iptablesPath, "-t", string(table), "-S", chain).Output()
 
-	// regex to replace ips in rule
-	// because MASQUERADE rule will not be exactly what was passed
-	re := regexp.MustCompile(`[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2}`)
-
-	return strings.Contains(
-		re.ReplaceAllString(string(existingRules), "?"),
-		re.ReplaceAllString(ruleString, "?"),
-	)
+	return strings.Contains(string(existingRules), ruleString)
 }
 
 // Call 'iptables' system command, passing supplied arguments


### PR DESCRIPTION
When Docker starts with the docker0's IP 172.17.42.1/16 , there is an iptable rule like this 

```
POSTROUTING -s 172.17.0.0/16 ! -o docker0 -j MASQUERADE
```

If i changed the docker0' IP to 192.168.100.1/24 and restarted the Docker. it does not add a new iptable rule like 

```
POSTROUTING -s 192.168.100.0/24 ! -o docker0 -j MASQUERADE
```

Because the `func Exists(table Table, chain string, rule ...string) bool`return true. This is caused by  that ip is  replaced by "?" .

This leads Docker containers can not communicate with the wider world.

cc @resouer

Signed-off-by: Mingzhen Feng fmzhen@zju.edu.cn
