### PR TITLE
Skip TestPullVerified

### DIFF
--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -55,6 +55,8 @@ func TestPullImageWithAliases(t *testing.T) {
 
 // pulling library/hello-world should show verified message
 func TestPullVerified(t *testing.T) {
+	t.Skip("Skipping hub dependent test")
+
 	// Image must be pulled from central repository to get verified message
 	// unless keychain is manually updated to contain the daemon's sign key.
 


### PR DESCRIPTION
Since 1.6.0 delivery and hub infrastructure operations, `TestPullVerified` is not systematically failing: skip the test until we figure out a more reliable way to implement it.

Closes: #12467
