### PR TITLE
Fix weird terminal output format

### DIFF
--- a/pkg/term/tc_linux_cgo.go
+++ b/pkg/term/tc_linux_cgo.go
@@ -24,6 +24,7 @@ func MakeRaw(fd uintptr) (*State, error) {
 	newState := oldState.termios
 
 	C.cfmakeraw((*C.struct_termios)(unsafe.Pointer(&newState)))
+	newState.Oflag = newState.Oflag | C.OPOST
 	if err := tcset(fd, &newState); err != 0 {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
On the docker cli, if use `-D` to show the debug message, the output message is weird.
This is an example:

<pre><code>[l00284783@localhost docker]$ docker -D start -ai test
/ # exit
DEBU[0002] [hijack] End of stdout
                                                        DEBU[0002] CmdStart() returned, defer waiting for hijack to finish.</pre></code>
The expected output shuld be:
<pre><code>DEBU[0002] [hijack] End of stdout
DEBU[0002] CmdStart() returned, defer waiting for hijack to finish.</code></pre>


The reason is that in `pkg/term/tc_linux_cgo.go`, the terminal attribute would disable `OPOST`
on `cfmakeraw`, it should be on.
