### PR TITLE
Remove redundant `\n` in daemon/daemon.go

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1233,18 +1233,18 @@ func (daemon *Daemon) verifyHostConfig(hostConfig *runconfig.HostConfig) ([]stri
 		return warnings, fmt.Errorf("Minimum memory limit allowed is 4MB")
 	}
 	if hostConfig.Memory > 0 && !daemon.SystemConfig().MemoryLimit {
-		warnings = append(warnings, "Your kernel does not support memory limit capabilities. Limitation discarded.\n")
+		warnings = append(warnings, "Your kernel does not support memory limit capabilities. Limitation discarded.")
 		hostConfig.Memory = 0
 	}
 	if hostConfig.Memory > 0 && hostConfig.MemorySwap != -1 && !daemon.SystemConfig().SwapLimit {
-		warnings = append(warnings, "Your kernel does not support swap limit capabilities. Limitation discarded.\n")
+		warnings = append(warnings, "Your kernel does not support swap limit capabilities, memory limited without swap.")
 		hostConfig.MemorySwap = -1
 	}
 	if hostConfig.Memory > 0 && hostConfig.MemorySwap > 0 && hostConfig.MemorySwap < hostConfig.Memory {
-		return warnings, fmt.Errorf("Minimum memoryswap limit should be larger than memory limit, see usage.\n")
+		return warnings, fmt.Errorf("Minimum memoryswap limit should be larger than memory limit, see usage.")
 	}
 	if hostConfig.Memory == 0 && hostConfig.MemorySwap > 0 {
-		return warnings, fmt.Errorf("You should always set the Memory limit when using Memoryswap limit, see usage.\n")
+		return warnings, fmt.Errorf("You should always set the Memory limit when using Memoryswap limit, see usage.")
 	}
 
 	return warnings, nil


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
The `\n` in `warnings` and error in `verifyHostConfig` is redundant, since
https://github.com/docker/docker/blob/master/api/client/create.go#L122 will print the warning
messages with `\n` and `logrus.Errof` is also print the error message with `\n`, so there is really no 
need to add a `\n` here, this will lead a result like this which is a bit of weird.

<pre><code>lei@lei-virtual-machine:~/docker/runconfig$ docker run -ti  -m 100M  ubuntu:14.04
WARNING: Your kernel does not support swap limit capabilities. Limitation discarded.

root@51daa7ea0bd2:/#
</code></pre>
