### PR TITLE
add note in docs about DOCKER_HOST env var overriding unix socket config

### DIFF
--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -175,6 +175,12 @@ To create the `docker` group and add your user:
 
         $ docker run hello-world
 
+	If this fails with a message similar to this:
+
+		Cannot connect to the Docker daemon. Is 'docker -d' running on this host?
+
+	Check that the `DOCKER_HOST` environment variable is not set for your shell.
+	If it is, unset it.
 
 ### Adjust memory and swap accounting
 


### PR DESCRIPTION
when trying to use docker without sudo and the DOCKER_HOST env var is set docker tries to connect to the specified host instead of using the unix socket.
