### PR TITLE
12553 fix typo

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -576,7 +576,7 @@ func TestVolumesFromGetsProperMode(t *testing.T) {
 	if _, err := runCommand(cmd); err != nil {
 		t.Fatal(err)
 	}
-	// Expect this "rw" mode to be be ignored since the inheritted volume is "ro"
+	// Expect this "rw" mode to be be ignored since the inherited volume is "ro"
 	cmd = exec.Command(dockerBinary, "run", "--volumes-from", "parent:rw", "busybox", "touch", "/test/file")
 	if _, err := runCommand(cmd); err == nil {
 		t.Fatal("Expected volumes-from to inherit read-only volume even when passing in `rw`")


### PR DESCRIPTION
Started in response to https://github.com/docker/docker/issues/12553 but that looks like it has already been fixed. Grepped the codebase and found one more.
