### PR TITLE
Make .docker dir have 0700 perms not 0600

### DIFF
--- a/registry/auth.go
+++ b/registry/auth.go
@@ -261,7 +261,7 @@ func (configFile *ConfigFile) Save() error {
 		return err
 	}
 
-	if err := os.MkdirAll(filepath.Dir(configFile.filename), 0600); err != nil {
+	if err := os.MkdirAll(filepath.Dir(configFile.filename), 0700); err != nil {
 		return err
 	}
 

--- a/registry/config_file_test.go
+++ b/registry/config_file_test.go
@@ -31,6 +31,28 @@ func TestMissingFile(t *testing.T) {
 	}
 }
 
+func TestSaveFileToDirs(t *testing.T) {
+	tmpHome, _ := ioutil.TempDir("", "config-test")
+
+	tmpHome += "/.docker"
+
+	config, err := LoadConfig(tmpHome)
+	if err != nil {
+		t.Fatalf("Failed loading on missing file: %q", err)
+	}
+
+	// Now save it and make sure it shows up in new form
+	err = config.Save()
+	if err != nil {
+		t.Fatalf("Failed to save: %q", err)
+	}
+
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	if !strings.Contains(string(buf), `"auths":`) {
+		t.Fatalf("Should have save in new form: %s", string(buf))
+	}
+}
+
 func TestEmptyFile(t *testing.T) {
 	tmpHome, _ := ioutil.TempDir("", "config-test")
 	fn := filepath.Join(tmpHome, CONFIGFILE)


### PR DESCRIPTION
Thanks to @dmcgowan for noticing.

Added a testcase to make sure Save() can create the dir and then
read from it.

ping @dmcgowan 

Signed-off-by: Doug Davis dug@us.ibm.com
