### PR TITLE
Fixing statusCode checks for sockRequest

### DIFF
--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -18,10 +18,6 @@ func (s *DockerSuite) TestExecResizeApiHeightWidthNoInt(c *check.C) {
 
 	endpoint := "/exec/" + cleanedContainerID + "/resize?h=foo&w=bar"
 	status, _, err := sockRequest("POST", endpoint, nil)
-	if err == nil {
-		c.Fatal("Expected exec resize Request to fail")
-	}
-	if status != http.StatusInternalServerError {
-		c.Fatalf("Status expected %d, got %d", http.StatusInternalServerError, status)
-	}
+	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	c.Assert(err, check.IsNil)
 }

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"os/exec"
 
 	"github.com/go-check/check"
@@ -18,8 +19,11 @@ func (s *DockerSuite) TestExecApiCreateNoCmd(c *check.C) {
 		c.Fatal(out, err)
 	}
 
-	_, body, err := sockRequest("POST", fmt.Sprintf("/containers/%s/exec", name), map[string]interface{}{"Cmd": nil})
-	if err == nil || !bytes.Contains(body, []byte("No exec command specified")) {
-		c.Fatalf("Expected error when creating exec command with no Cmd specified: %q", err)
+	status, body, err := sockRequest("POST", fmt.Sprintf("/containers/%s/exec", name), map[string]interface{}{"Cmd": nil})
+	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	c.Assert(err, check.IsNil)
+
+	if !bytes.Contains(body, []byte("No exec command specified")) {
+		c.Fatalf("Expected message when creating exec command with no Cmd specified")
 	}
 }

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/url"
 	"os/exec"
 	"strings"
@@ -11,10 +12,9 @@ import (
 )
 
 func (s *DockerSuite) TestLegacyImages(c *check.C) {
-	_, body, err := sockRequest("GET", "/v1.6/images/json", nil)
-	if err != nil {
-		c.Fatalf("Error on GET: %s", err)
-	}
+	status, body, err := sockRequest("GET", "/v1.6/images/json", nil)
+	c.Assert(status, check.Equals, http.StatusOK)
+	c.Assert(err, check.IsNil)
 
 	images := []types.LegacyImage{}
 	if err = json.Unmarshal(body, &images); err != nil {
@@ -40,10 +40,10 @@ func (s *DockerSuite) TestApiImagesFilter(c *check.C) {
 	getImages := func(filter string) []image {
 		v := url.Values{}
 		v.Set("filter", filter)
-		_, b, err := sockRequest("GET", "/images/json?"+v.Encode(), nil)
-		if err != nil {
-			c.Fatal(err)
-		}
+		status, b, err := sockRequest("GET", "/images/json?"+v.Encode(), nil)
+		c.Assert(status, check.Equals, http.StatusOK)
+		c.Assert(err, check.IsNil)
+
 		var images []image
 		if err := json.Unmarshal(b, &images); err != nil {
 			c.Fatal(err)
@@ -76,20 +76,20 @@ func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 	id := strings.TrimSpace(out)
 	defer deleteImages("saveandload")
 
-	_, body, err := sockRequestRaw("GET", "/images/"+id+"/get", nil, "")
-	if err != nil {
-		c.Fatal(err)
-	}
+	status, body, err := sockRequestRaw("GET", "/images/"+id+"/get", nil, "")
+	c.Assert(status, check.Equals, http.StatusOK)
+	c.Assert(err, check.IsNil)
+
 	defer body.Close()
 
 	if out, err := exec.Command(dockerBinary, "rmi", id).CombinedOutput(); err != nil {
 		c.Fatal(err, out)
 	}
 
-	_, loadBody, err := sockRequestRaw("POST", "/images/load", body, "application/x-tar")
-	if err != nil {
-		c.Fatal(err)
-	}
+	status, loadBody, err := sockRequestRaw("POST", "/images/load", body, "application/x-tar")
+	c.Assert(status, check.Equals, http.StatusOK)
+	c.Assert(err, check.IsNil)
+
 	defer loadBody.Close()
 
 	inspectOut, err := exec.Command(dockerBinary, "inspect", "--format='{{ .Id }}'", id).CombinedOutput()

--- a/integration-cli/docker_api_info_test.go
+++ b/integration-cli/docker_api_info_test.go
@@ -10,10 +10,9 @@ import (
 func (s *DockerSuite) TestInfoApi(c *check.C) {
 	endpoint := "/info"
 
-	statusCode, body, err := sockRequest("GET", endpoint, nil)
-	if err != nil || statusCode != http.StatusOK {
-		c.Fatalf("Expected %d from info request, got %d", http.StatusOK, statusCode)
-	}
+	status, body, err := sockRequest("GET", endpoint, nil)
+	c.Assert(status, check.Equals, http.StatusOK)
+	c.Assert(err, check.IsNil)
 
 	// always shown fields
 	stringsToCheck := []string{

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
 	"os/exec"
 	"strings"
 
@@ -26,10 +27,9 @@ func (s *DockerSuite) TestInspectApiContainerResponse(c *check.C) {
 		if testVersion != "latest" {
 			endpoint = "/" + testVersion + endpoint
 		}
-		_, body, err := sockRequest("GET", endpoint, nil)
-		if err != nil {
-			c.Fatalf("sockRequest failed for %s version: %v", testVersion, err)
-		}
+		status, body, err := sockRequest("GET", endpoint, nil)
+		c.Assert(status, check.Equals, http.StatusOK)
+		c.Assert(err, check.IsNil)
 
 		var inspectJSON map[string]interface{}
 		if err = json.Unmarshal(body, &inspectJSON); err != nil {

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -17,11 +17,9 @@ func (s *DockerSuite) TestLogsApiWithStdout(c *check.C) {
 		c.Fatal(out, err)
 	}
 
-	statusCode, body, err := sockRequest("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&timestamps=1", name), nil)
-
-	if err != nil || statusCode != http.StatusOK {
-		c.Fatalf("Expected %d from logs request, got %d", http.StatusOK, statusCode)
-	}
+	status, body, err := sockRequest("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&timestamps=1", name), nil)
+	c.Assert(status, check.Equals, http.StatusOK)
+	c.Assert(err, check.IsNil)
 
 	if !bytes.Contains(body, []byte(name)) {
 		c.Fatalf("Expected %s, got %s", name, string(body[:]))
@@ -35,11 +33,9 @@ func (s *DockerSuite) TestLogsApiNoStdoutNorStderr(c *check.C) {
 		c.Fatal(out, err)
 	}
 
-	statusCode, body, err := sockRequest("GET", fmt.Sprintf("/containers/%s/logs", name), nil)
-
-	if err == nil || statusCode != http.StatusBadRequest {
-		c.Fatalf("Expected %d from logs request, got %d", http.StatusBadRequest, statusCode)
-	}
+	status, body, err := sockRequest("GET", fmt.Sprintf("/containers/%s/logs", name), nil)
+	c.Assert(status, check.Equals, http.StatusBadRequest)
+	c.Assert(err, check.IsNil)
 
 	expected := "Bad parameters: you must choose at least one stream"
 	if !bytes.Contains(body, []byte(expected)) {

--- a/integration-cli/docker_api_resize_test.go
+++ b/integration-cli/docker_api_resize_test.go
@@ -17,10 +17,9 @@ func (s *DockerSuite) TestResizeApiResponse(c *check.C) {
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=40&w=40"
-	_, _, err = sockRequest("POST", endpoint, nil)
-	if err != nil {
-		c.Fatalf("resize Request failed %v", err)
-	}
+	status, _, err := sockRequest("POST", endpoint, nil)
+	c.Assert(status, check.Equals, http.StatusOK)
+	c.Assert(err, check.IsNil)
 }
 
 func (s *DockerSuite) TestResizeApiHeightWidthNoInt(c *check.C) {
@@ -33,12 +32,8 @@ func (s *DockerSuite) TestResizeApiHeightWidthNoInt(c *check.C) {
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=foo&w=bar"
 	status, _, err := sockRequest("POST", endpoint, nil)
-	if err == nil {
-		c.Fatal("Expected resize Request to fail")
-	}
-	if status != http.StatusInternalServerError {
-		c.Fatalf("Status expected %d, got %d", http.StatusInternalServerError, status)
-	}
+	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	c.Assert(err, check.IsNil)
 }
 
 func (s *DockerSuite) TestResizeApiResponseWhenContainerNotStarted(c *check.C) {
@@ -57,10 +52,10 @@ func (s *DockerSuite) TestResizeApiResponseWhenContainerNotStarted(c *check.C) {
 	}
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=40&w=40"
-	_, body, err := sockRequest("POST", endpoint, nil)
-	if err == nil {
-		c.Fatalf("resize should fail when container is not started")
-	}
+	status, body, err := sockRequest("POST", endpoint, nil)
+	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	c.Assert(err, check.IsNil)
+
 	if !strings.Contains(string(body), "Cannot resize container") && !strings.Contains(string(body), cleanedContainerID) {
 		c.Fatalf("resize should fail with message 'Cannot resize container' but instead received %s", string(body))
 	}

--- a/integration-cli/docker_api_version_test.go
+++ b/integration-cli/docker_api_version_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"net/http"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/autogen/dockerversion"
@@ -9,10 +10,10 @@ import (
 )
 
 func (s *DockerSuite) TestGetVersion(c *check.C) {
-	_, body, err := sockRequest("GET", "/version", nil)
-	if err != nil {
-		c.Fatal(err)
-	}
+	status, body, err := sockRequest("GET", "/version", nil)
+	c.Assert(status, check.Equals, http.StatusOK)
+	c.Assert(err, check.IsNil)
+
 	var v types.Version
 	if err := json.Unmarshal(body, &v); err != nil {
 		c.Fatal(err)

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -60,13 +60,8 @@ func (s *DockerSuite) TestRmRunningContainerCheckError409(c *check.C) {
 
 	endpoint := "/containers/foo"
 	status, _, err := sockRequest("DELETE", endpoint, nil)
-
-	if err == nil {
-		c.Fatalf("Expected error, can't rm a running container")
-	} else if status != http.StatusConflict {
-		c.Fatalf("Expected error to contain '409 Conflict' but found %s", err)
-	}
-
+	c.Assert(status, check.Equals, http.StatusConflict)
+	c.Assert(err, check.IsNil)
 }
 
 func (s *DockerSuite) TestRmForceRemoveRunningContainer(c *check.C) {

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -350,9 +350,6 @@ func sockRequestRaw(method, endpoint string, data io.Reader, ct string) (int, io
 		defer client.Close()
 		return resp.Body.Close()
 	})
-	if resp.StatusCode != http.StatusOK {
-		return resp.StatusCode, body, fmt.Errorf("received status != 200 OK: %s", resp.Status)
-	}
 
 	return resp.StatusCode, body, err
 }
@@ -1062,10 +1059,9 @@ func daemonTime(c *check.C) time.Time {
 		return time.Now()
 	}
 
-	_, body, err := sockRequest("GET", "/info", nil)
-	if err != nil {
-		c.Fatalf("daemonTime: failed to get /info: %v", err)
-	}
+	status, body, err := sockRequest("GET", "/info", nil)
+	c.Assert(status, check.Equals, http.StatusOK)
+	c.Assert(err, check.IsNil)
 
 	type infoJSON struct {
 		SystemTime string

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -58,8 +58,8 @@ var (
 		func() bool {
 			if daemonExecDriver == "" {
 				// get daemon info
-				_, body, err := sockRequest("GET", "/info", nil)
-				if err != nil {
+				status, body, err := sockRequest("GET", "/info", nil)
+				if err != nil || status != http.StatusOK {
 					log.Fatalf("sockRequest failed for /info: %v", err)
 				}
 


### PR DESCRIPTION
Updated status checking for `sockRequest` and `sockRequestRaw`, along with necessary test logic changes.

The statusCode is now checked in the `sockRequest` func, and we no longer assume a statusCode of 200 (`http.StatusOK`) for all return values. The caller specifies what statusCode is expected, by passing it in as an additional parameter to `sockRequest`. Some of the tests call `sockRequestRaw` directly, so I added status checking from within the test itself.

All integration-cli tests pass currently.

Fixes #12449 

Signed-off-by: Megan Kostick mkostick@us.ibm.com
