### PR TITLE
Update doc with usage of the scratch image

### DIFF
--- a/docs/sources/articles/baseimages.md
+++ b/docs/sources/articles/baseimages.md
@@ -41,22 +41,19 @@ GitHub Repo:
  - [Debian / Ubuntu](
    https://github.com/docker/docker/blob/master/contrib/mkimage-debootstrap.sh)
 
-## Creating a simple base image using `scratch`
+## Creating a simple base image using scratch
 
-There is a special repository in the Docker registry called `scratch`, which
-was created using an empty tar file:
+You can use Docker's reserved, minimal image, `scratch`, as a starting point for building containers. Using the `scratch` "image" signals to the build process that you want the next command in the `Dockerfile` to be the first filesystem layer in your image.
 
-    $ tar cv --files-from /dev/null | docker import - scratch
-
-which you can `docker pull`. You can then use that
-image to base your new minimal containers `FROM`:
+While `scratch` appears in Docker's repository on the hub, you can't pull it, run it, or tag any image with the name `scratch`. Instead, you can refer to it in your `Dockerfile`. For example, to create a minimal container using `scratch`:
 
     FROM scratch
-    COPY true-asm /true
-    CMD ["/true"]
+    ADD hello /
+    CMD ["/hello"]
 
-The `Dockerfile` above is from an extremely minimal image - [tianon/true](
-https://github.com/tianon/dockerfiles/tree/master/true).
+This example creates the hello-world image used in the tutorials.
+If you want to test it out, you can clone [the image repo](https://github.com/docker-library/hello-world)
+
 
 ## More resources
 


### PR DESCRIPTION
The scratch image used to be a regular image, but as of
commit 8936789919c5c8004f346f44a3452d1521818b60 it is a
special case, and cannot be used with 'docker pull.'

Update this doc to reflect the new behavior and clear up
confusion surrounding this image.

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
