### PR TITLE
docs: Add more places docker.service can be at

### DIFF
--- a/docs/sources/articles/systemd.md
+++ b/docs/sources/articles/systemd.md
@@ -30,8 +30,8 @@ If the `docker.service` file is set to use an `EnvironmentFile`
 (often pointing to `/etc/sysconfig/docker`) then you can modify the
 referenced file.
 
-Or, you may need to edit the `docker.service` file, which can be in `/usr/lib/systemd/system`
-or `/etc/systemd/service`.
+Or, you may need to edit the `docker.service` file, which can be in
+`/usr/lib/systemd/system`, `/etc/systemd/service`, or `/lib/systemd/system`.
 
 ### Runtime directory and storage driver
 


### PR DESCRIPTION
More systemd goodness. Documenting where `docker.service` lives under Ubuntu 15.

Signed-off-by: Ahmet Alp Balkan ahmetalpbalkan@gmail.com
