### PR TITLE
Ignore .git in repo's .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
+.git
 bundles
 .gopath


### PR DESCRIPTION
Saves around 50 MB from being sent to context every time we run
`docker build .` in the repo root as far as I can tell on my setup.

Signed-off-by: Ahmet Alp Balkan
