### PR TITLE
Makes headings in documentation consistent

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -25,7 +25,7 @@ pages:
 
 # Introduction:
 - ['index.md', 'About', 'Docker']
-- ['release-notes.md', 'About', 'Release Notes']
+- ['release-notes.md', 'About', 'Release notes']
 - ['introduction/index.md', '**HIDDEN**']
 - ['introduction/understanding-docker.md', 'About', 'Understanding Docker']
 
@@ -54,11 +54,11 @@ pages:
 - ['compose/install.md', 'Installation', 'Docker Compose']
 
 # User Guide:
-- ['userguide/index.md', 'User Guide', 'The Docker User Guide' ]
-- ['userguide/dockerhub.md', 'User Guide', 'Getting Started with Docker Hub' ]
-- ['userguide/dockerizing.md', 'User Guide', 'Dockerizing Applications' ]
-- ['userguide/usingdocker.md', 'User Guide', 'Working with Containers' ]
-- ['userguide/dockerimages.md', 'User Guide', 'Working with Docker Images' ]
+- ['userguide/index.md', 'User Guide', 'The Docker user guide' ]
+- ['userguide/dockerhub.md', 'User Guide', 'Getting started with Docker Hub' ]
+- ['userguide/dockerizing.md', 'User Guide', 'Dockerizing applications' ]
+- ['userguide/usingdocker.md', 'User Guide', 'Working with containers' ]
+- ['userguide/dockerimages.md', 'User Guide', 'Working with Docker images' ]
 - ['userguide/dockerlinks.md', 'User Guide', 'Linking containers together' ]
 - ['userguide/dockervolumes.md', 'User Guide', 'Managing data in containers' ]
 - ['userguide/labels-custom-metadata.md', 'User Guide', 'Apply custom metadata' ]
@@ -76,7 +76,7 @@ pages:
 - ['docker-hub/accounts.md', 'Docker Hub', 'Accounts']
 - ['docker-hub/repos.md', 'Docker Hub', 'Repositories']
 - ['docker-hub/builds.md', 'Docker Hub', 'Automated Builds']
-- ['docker-hub/official_repos.md', 'Docker Hub', 'Official Repo Guidelines']
+- ['docker-hub/official_repos.md', 'Docker Hub', 'Official repo guidelines']
 
 # Docker Hub Enterprise
 #- ['docker-hub-enterprise/index.md', '**HIDDEN**' ]
@@ -125,7 +125,7 @@ pages:
 - ['reference/commandline/cli.md', 'Reference', 'Docker command line']
 - ['reference/builder.md', 'Reference', 'Dockerfile']
 - ['faq.md', 'Reference', 'FAQ']
-- ['reference/run.md', 'Reference', 'Run Reference']
+- ['reference/run.md', 'Reference', 'Run reference']
 - ['compose/cli.md', 'Reference', 'Compose command line']
 - ['compose/yml.md', 'Reference', 'Compose yml']
 - ['compose/env.md', 'Reference', 'Compose ENV variables']
@@ -145,7 +145,7 @@ pages:
 - ['registry/spec/auth/token.md', 'Reference', '&nbsp;&nbsp;&nbsp;&nbsp;&blacksquare;&nbsp; Authenticate via central service' ]
 - ['reference/api/hub_registry_spec.md', 'Reference', 'Docker Hub and Registry 1.0']
 - ['reference/api/registry_api.md', 'Reference', '&nbsp;&nbsp;&nbsp;&nbsp;&blacksquare;&nbsp;Docker Registry API v1']
-- ['reference/api/registry_api_client_libraries.md', 'Reference', '&nbsp;&nbsp;&nbsp;&nbsp;&blacksquare;&nbsp;Docker Registry 1.0 API Client Libraries']
+- ['reference/api/registry_api_client_libraries.md', 'Reference', '&nbsp;&nbsp;&nbsp;&nbsp;&blacksquare;&nbsp;Docker Registry 1.0 API client libraries']
 #- ['reference/image-spec-v1.md', 'Reference', 'Docker Image Specification v1.0.0']
 - ['reference/api/docker-io_api.md', 'Reference', 'Docker Hub API']
 #- ['reference/image-spec-v1.md', 'Reference', 'Docker Image Specification v1.0.0']
@@ -169,8 +169,8 @@ pages:
 - ['reference/api/docker_remote_api_v1.2.md', '**HIDDEN**']
 - ['reference/api/docker_remote_api_v1.1.md', '**HIDDEN**']
 - ['reference/api/docker_remote_api_v1.0.md', '**HIDDEN**']
-- ['reference/api/remote_api_client_libraries.md', 'Reference', 'Docker Remote API Client Libraries']
-- ['reference/api/docker_io_accounts_api.md', 'Reference', 'Docker Hub Accounts API']
+- ['reference/api/remote_api_client_libraries.md', 'Reference', 'Docker Remote API client libraries']
+- ['reference/api/docker_io_accounts_api.md', 'Reference', 'Docker Hub accounts API']
 
 # Hidden registry files
 - ['registry/storage-drivers/azure.md', '**HIDDEN**' ]

--- a/docs/sources/articles/ambassador_pattern_linking.md
+++ b/docs/sources/articles/ambassador_pattern_linking.md
@@ -1,8 +1,8 @@
-page_title: Link via an Ambassador Container
+page_title: Link via an ambassador container
 page_description: Using the Ambassador pattern to abstract (network) services
 page_keywords: Examples, Usage, links, docker, documentation, examples, names, name, container naming
 
-# Link via an Ambassador Container
+# Link via an ambassador container
 
 ## Introduction
 
@@ -30,7 +30,7 @@ different docker host from the consumer.
 Using the `svendowideit/ambassador` container, the link wiring is
 controlled entirely from the `docker run` parameters.
 
-## Two host Example
+## Two host example
 
 Start actual Redis server on one Docker host
 

--- a/docs/sources/articles/b2d_volume_resize.md
+++ b/docs/sources/articles/b2d_volume_resize.md
@@ -1,5 +1,5 @@
-page_title: Resizing a Boot2Docker Volume	
-page_description: Resizing a Boot2Docker Volume in VirtualBox with GParted
+page_title: Resizing a Boot2Docker volume	
+page_description: Resizing a Boot2Docker volume in VirtualBox with GParted
 page_keywords: boot2docker, volume, virtualbox
 
 # Getting “no space left on device” errors with Boot2Docker?

--- a/docs/sources/articles/baseimages.md
+++ b/docs/sources/articles/baseimages.md
@@ -1,8 +1,8 @@
-page_title: Create a Base Image
+page_title: Create a base image
 page_description: How to create base images
 page_keywords: Examples, Usage, base image, docker, documentation, examples
 
-# Create a Base Image
+# Create a base image
 
 So you want to create your own [*Base Image*](
 /terms/image/#base-image)? Great!

--- a/docs/sources/articles/cfengine_process_management.md
+++ b/docs/sources/articles/cfengine_process_management.md
@@ -1,8 +1,8 @@
-page_title: Process Management with CFEngine
+page_title: Process management with CFEngine
 page_description: Managing containerized processes with CFEngine
 page_keywords: cfengine, process, management, usage, docker, documentation
 
-# Process Management with CFEngine
+# Process management with CFEngine
 
 Create Docker containers with managed processes.
 

--- a/docs/sources/articles/chef.md
+++ b/docs/sources/articles/chef.md
@@ -1,4 +1,4 @@
-page_title: Chef Usage
+page_title: Using Chef
 page_description: Installation and using Docker via Chef
 page_keywords: chef, installation, usage, docker, documentation
 

--- a/docs/sources/articles/dockerfile_best-practices.md
+++ b/docs/sources/articles/dockerfile_best-practices.md
@@ -1,4 +1,4 @@
-page_title: Best Practices for Writing Dockerfiles
+page_title: Best practices for writing Dockerfiles
 page_description: Hints, tips and guidelines for writing clean, reliable Dockerfiles
 page_keywords: Examples, Usage, base image, docker, documentation, dockerfile, best practices, hub, official repo
 
@@ -419,7 +419,7 @@ fail catastrophically if the new build's context is missing the resource being
 added. Adding a separate tag, as recommended above, will help mitigate this by
 allowing the `Dockerfile` author to make a choice.
 
-## Examples For Official Repositories
+## Examples for official repositories
 
 These Official Repos have exemplary `Dockerfile`s:
 
@@ -428,7 +428,7 @@ These Official Repos have exemplary `Dockerfile`s:
 * [Hy](https://registry.hub.docker.com/_/hylang/)
 * [Rails](https://registry.hub.docker.com/_/rails)
 
-## Additional Resources:
+## Additional resources:
 
 * [Dockerfile Reference](https://docs.docker.com/reference/builder/#onbuild)
 * [More about Base Images](https://docs.docker.com/articles/baseimages/)

--- a/docs/sources/articles/host_integration.md
+++ b/docs/sources/articles/host_integration.md
@@ -1,8 +1,8 @@
-page_title: Automatically Start Containers
+page_title: Automatically start containers
 page_description: How to generate scripts for upstart, systemd, etc.
 page_keywords: systemd, upstart, supervisor, docker, documentation, host integration
 
-# Automatically Start Containers
+# Automatically start containers
 
 As of Docker 1.2,
 [restart policies](/reference/commandline/cli/#restart-policies) are the
@@ -18,7 +18,7 @@ that depend on Docker containers), you can use a process manager like
 [supervisor](http://supervisord.org/) instead.
 
 
-## Using a Process Manager
+## Using a process manager
 
 Docker does not set any restart policies by default, but be aware that they will
 conflict with most process managers. So don't set restart policies if you are

--- a/docs/sources/articles/https.md
+++ b/docs/sources/articles/https.md
@@ -1,8 +1,8 @@
-page_title: Protecting the Docker daemon Socket with HTTPS
+page_title: Protecting the Docker daemon socket with HTTPS
 page_description: How to setup and run Docker with HTTPS
 page_keywords: docker, docs, article, example, https, daemon, tls, ca, certificate
 
-# Protecting the Docker daemon Socket with HTTPS
+# Protecting the Docker daemon socket with HTTPS
 
 By default, Docker runs via a non-networked Unix socket. It can also
 optionally communicate using a HTTP socket.
@@ -193,7 +193,7 @@ location using the environment variable `DOCKER_CERT_PATH`.
     $ export DOCKER_CERT_PATH=~/.docker/zone1/
     $ docker --tlsverify ps
 
-### Connecting to the Secure Docker port using `curl`
+### Connecting to the secure Docker port using `curl`
 
 To use `curl` to make test API requests, you need to use three extra command line
 flags:

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -1,8 +1,8 @@
-page_title: Network Configuration
+page_title: Network configuration
 page_description: Docker networking
 page_keywords: network, networking, bridge, docker, documentation
 
-# Network Configuration
+# Network configuration
 
 ## TL;DR
 
@@ -41,7 +41,7 @@ can use Docker options and — in advanced cases — raw Linux networking
 commands to tweak, supplement, or entirely replace Docker's default
 networking configuration.
 
-## Quick Guide to the Options
+## Quick guide to the options
 
 Here is a quick list of the networking-related Docker command-line
 options, in case it helps you find the section below that you are
@@ -601,9 +601,9 @@ You have to execute the `ip -6 neigh add proxy ...` command for every IPv6
 address in your Docker subnet. Unfortunately there is no functionality for
 adding a whole subnet by executing one command.
 
-### Docker IPv6 Cluster
+### Docker IPv6 cluster
 
-#### Switched Network Environment
+#### Switched network environment
 Using routable IPv6 addresses allows you to realize communication between
 containers on different hosts. Let's have a look at a simple Docker IPv6 cluster
 example:
@@ -649,7 +649,7 @@ the Docker subnet on the host, the container IP addresses and the routes on the
 containers. The configuration above the line is up to the user and can be
 adapted to the individual environment.
 
-#### Routed Network Environment
+#### Routed network environment
 
 In a routed network environment you replace the layer 2 switch with a layer 3
 router. Now the hosts just have to know their default gateway (the router) and
@@ -993,7 +993,7 @@ of the right to configure their own networks.  Using `ip netns exec` is
 what let us finish up the configuration without having to take the
 dangerous step of running the container itself with `--privileged=true`.
 
-## Tools and Examples
+## Tools and examples
 
 Before diving into the following sections on custom network topologies,
 you might be interested in glancing at a few external tools or examples

--- a/docs/sources/articles/puppet.md
+++ b/docs/sources/articles/puppet.md
@@ -1,4 +1,4 @@
-page_title: Puppet Usage
+page_title: Using Puppet
 page_description: Installating and using Puppet
 page_keywords: puppet, installation, usage, docker, documentation
 

--- a/docs/sources/articles/runmetrics.md
+++ b/docs/sources/articles/runmetrics.md
@@ -1,8 +1,8 @@
-page_title: Runtime Metrics
+page_title: Runtime metrics
 page_description: Measure the behavior of running containers
 page_keywords: docker, metrics, CPU, memory, disk, IO, run, runtime
 
-# Runtime Metrics
+# Runtime metrics
 
 Linux Containers rely on [control groups](
 https://www.kernel.org/doc/Documentation/cgroups/cgroups.txt)
@@ -11,7 +11,7 @@ CPU, memory, and block I/O usage. You can access those metrics and
 obtain network usage metrics as well. This is relevant for "pure" LXC
 containers, as well as for Docker containers.
 
-## Control Groups
+## Control groups
 
 Control groups are exposed through a pseudo-filesystem. In recent
 distros, you should find this filesystem under `/sys/fs/cgroup`. Under
@@ -28,7 +28,7 @@ To figure out where your control groups are mounted, you can run:
 
     $ grep cgroup /proc/mounts
 
-## Enumerating Cgroups
+## Enumerating cgroups
 
 You can look into `/proc/cgroups` to see the different control group subsystems
 known to the system, the hierarchy they belong to, and how many groups they contain.
@@ -39,7 +39,7 @@ the hierarchy mountpoint; e.g., `/` means “this process has not been assigned 
 a particular group”, while `/lxc/pumpkin` means that the process is likely to be
 a member of a container named `pumpkin`.
 
-## Finding the Cgroup for a Given Container
+## Finding the cgroup for a given container
 
 For each container, one cgroup will be created in each hierarchy. On
 older systems with older versions of the LXC userland tools, the name of
@@ -55,12 +55,12 @@ look it up with `docker inspect` or `docker ps --no-trunc`.
 Putting everything together to look at the memory metrics for a Docker
 container, take a look at `/sys/fs/cgroup/memory/lxc/<longid>/`.
 
-## Metrics from Cgroups: Memory, CPU, Block IO
+## Metrics from cgroups: memory, CPU, block I/O
 
 For each subsystem (memory, CPU, and block I/O), you will find one or
 more pseudo-files containing statistics.
 
-### Memory Metrics: `memory.stat`
+### Memory metrics: `memory.stat`
 
 Memory metrics are found in the "memory" cgroup. Note that the memory
 control group adds a little overhead, because it does very fine-grained
@@ -262,7 +262,7 @@ relevant ones:
    not perform more I/O, its queue size can increase just because the
    device load increases because of other devices.
 
-## Network Metrics
+## Network metrics
 
 Network metrics are not exposed directly by control groups. There is a
 good explanation for that: network interfaces exist within the context

--- a/docs/sources/articles/security.md
+++ b/docs/sources/articles/security.md
@@ -1,8 +1,8 @@
-page_title: Docker Security
+page_title: Docker security
 page_description: Review of the Docker Daemon attack surface
 page_keywords: Docker, Docker documentation, security
 
-# Docker Security
+# Docker security
 
 There are three major areas to consider when reviewing Docker security:
 
@@ -14,7 +14,7 @@ There are three major areas to consider when reviewing Docker security:
  - the "hardening" security features of the kernel and how they
    interact with containers.
 
-## Kernel Namespaces
+## Kernel namespaces
 
 Docker containers are very similar to LXC containers, and they have
 similar security features. When you start a container with `docker
@@ -53,7 +53,7 @@ http://en.wikipedia.org/wiki/OpenVZ) in such a way that they could be
 merged within the mainstream kernel. And OpenVZ was initially released
 in 2005, so both the design and the implementation are pretty mature.
 
-## Control Groups
+## Control groups
 
 Control Groups are another key component of Linux Containers. They
 implement resource accounting and limiting. They provide many
@@ -72,7 +72,7 @@ when some applications start to misbehave.
 Control Groups have been around for a while as well: the code was
 started in 2006, and initially merged in kernel 2.6.24.
 
-## Docker Daemon Attack Surface
+## Docker daemon attack surface
 
 Running containers (and applications) with Docker implies running the
 Docker daemon. This daemon currently requires `root` privileges, and you
@@ -132,7 +132,7 @@ containers controlled by Docker. Of course, it is fine to keep your
 favorite admin tools (probably at least an SSH server), as well as
 existing monitoring/supervision processes (e.g., NRPE, collectd, etc).
 
-## Linux Kernel Capabilities
+## Linux kernel capabilities
 
 By default, Docker starts containers with a restricted set of
 capabilities. What does that mean?
@@ -206,7 +206,7 @@ capability removal, or less secure through the addition of capabilities.
 The best practice for users would be to remove all capabilities except
 those explicitly required for their processes.
 
-## Other Kernel Security Features
+## Other kernel security features
 
 Capabilities are just one of the many security features provided by
 modern Linux kernels. It is also possible to leverage existing,

--- a/docs/sources/articles/systemd.md
+++ b/docs/sources/articles/systemd.md
@@ -1,8 +1,8 @@
-page_title: Controlling and configuring Docker using Systemd
-page_description: Controlling and configuring Docker using Systemd
+page_title: Controlling and configuring Docker using systemd
+page_description: Controlling and configuring Docker using systemd
 page_keywords: docker, daemon, systemd, configuration
 
-# Controlling and configuring Docker using Systemd
+# Controlling and configuring Docker using systemd
 
 Many Linux distributions use systemd to start the Docker daemon. This document
 shows a few examples of how to customise Docker's settings.
@@ -64,7 +64,7 @@ setting `OPTIONS`:
 You can also set other environment variables in this file, for example, the
 `HTTP_PROXY` environment variables described below.
 
-### HTTP Proxy
+### HTTP proxy
 
 This example overrides the default `docker.service` file.
 

--- a/docs/sources/docker-hub-enterprise/install-config.md
+++ b/docs/sources/docker-hub-enterprise/install-config.md
@@ -1,8 +1,8 @@
-page_title: Using Docker Hub Enterprise Installation
-page_description: Docker Hub Enterprise Installation
+page_title: Using Docker Hub Enterprise installation
+page_description: Docker Hub Enterprise installation
 page_keywords: docker hub enterprise
 
-# Docker Hub Enterprise Installation
+# Docker Hub Enterprise installation
 
 Documenation coming soon.
 

--- a/docs/sources/docker-hub/accounts.md
+++ b/docs/sources/docker-hub/accounts.md
@@ -4,7 +4,7 @@ page_keywords: Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub
 
 # Accounts on Docker Hub
 
-## Docker Hub Accounts
+## Docker Hub accounts
 
 You can `search` for Docker images and `pull` them from [Docker
 Hub](https://hub.docker.com) without signing in or even having an
@@ -12,7 +12,7 @@ account. However, in order to `push` images, leave comments or to *star*
 a repository, you are going to need a [Docker
 Hub](https://hub.docker.com) account.
 
-### Registration for a Docker Hub Account
+### Registration for a Docker Hub account
 
 You can get a [Docker Hub](https://hub.docker.com) account by
 [signing up for one here](https://hub.docker.com/account/signup/). A valid
@@ -32,7 +32,7 @@ If you can't access your account for some reason, you can reset your password
 from the [*Password Reset*](https://hub.docker.com/account/forgot-password/)
 page.
 
-## Organizations & Groups
+## Organizations and groups
 
 Also available on the Docker Hub are organizations and groups that allow
 you to collaborate across your organization or team. You can see what

--- a/docs/sources/docker-hub/builds.md
+++ b/docs/sources/docker-hub/builds.md
@@ -83,7 +83,7 @@ You will be able to review and revoke Docker Hub's access by visiting the
 > using the "Start Build" button on the Hub, or if the webhook on the GitHub repository
 > still exists, will be triggered by any subsequent commits.
 
-### Auto builds and Limited linked GitHub accounts.
+### Auto builds and limited linked GitHub accounts.
 
 If you selected to link your GitHub account with only a "Limited" link, then
 after creating your automated build, you will need to either manually trigger a
@@ -101,7 +101,7 @@ section, "Revoke access".
 
 You can now re-link your account at any time.
 
-### GitHub Organizations
+### GitHub organizations
 
 GitHub organizations and private repositories forked from organizations will be
 made available to auto build using the "Docker Hub Registry" application, which
@@ -205,7 +205,7 @@ can be limited to read-only access to just the repositories required to build.
   </tbody>
 </table>
 
-### GitHub Service hooks
+### GitHub service hooks
 
 The GitHub Service hook allows GitHub to notify the Docker Hub when something has
 been committed to that git repository. You will need to add the Service Hook manually

--- a/docs/sources/docker-hub/home.md
+++ b/docs/sources/docker-hub/home.md
@@ -1,8 +1,8 @@
-page_title: The Docker Hub Registry Help
+page_title: The Docker Hub Registry help
 page_description: The Docker Registry help documentation home
 page_keywords: Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub, docs, documentation
 
-# The Docker Hub Registry Help
+# The Docker Hub Registry help
 
 ## Introduction
 

--- a/docs/sources/docker-hub/index.md
+++ b/docs/sources/docker-hub/index.md
@@ -1,4 +1,4 @@
-page_title: The Docker Hub Help
+page_title: The Docker Hub help
 page_description: The Docker Help documentation home
 page_keywords: Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub, docs, documentation, accounts, organizations, repositories, groups
 
@@ -16,7 +16,7 @@ account and manage your organizations and groups.
 Find out how to share your Docker images in [Docker Hub
 repositories](repos/) and how to store and manage private images.
 
-## [Automated Builds](builds/)
+## [Automated builds](builds/)
 
 Learn how to automate your build and deploy pipeline with [Automated
 Builds](builds/)

--- a/docs/sources/docker-hub/official_repos.md
+++ b/docs/sources/docker-hub/official_repos.md
@@ -1,8 +1,8 @@
-page_title: Guidelines for Official Repositories on Docker Hub
+page_title: Guidelines for official repositories on Docker Hub
 page_description: Guidelines for Official Repositories on Docker Hub
 page_keywords: Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub, docs, official, image, documentation
 
-# Guidelines for Creating and Documenting Official Repositories
+# Guidelines for creating and documenting official repositories
 
 ## Introduction
 
@@ -18,7 +18,7 @@ This document consists of two major sections:
 along with best practices for creating those items
 * Examples embodying those practices
 
-## Expected Files & Resources
+## Expected files and resources
 
 ### A Git repository
 
@@ -92,7 +92,7 @@ In terms of content, the long description must include the following sections:
 * How-to/usage
 * Issues & contributions
 
-#### Overview & links
+#### Overview and links
 
 This section should provide:
 
@@ -109,7 +109,7 @@ A section that describes how to run and use the image, including common use
 cases and example `Dockerfile`s (if applicable). Try to provide clear, step-by-
 step instructions wherever possible.
 
-##### Issues & contributions
+##### Issues and contributions
 
 In this section, point users to any resources that can help them contribute to
 the project. Include contribution guidelines and any specific instructions

--- a/docs/sources/docker-hub/repos.md
+++ b/docs/sources/docker-hub/repos.md
@@ -1,8 +1,8 @@
-page_title: Repositories and Images on Docker Hub
-page_description: Repositories and Images on Docker Hub
+page_title: Repositories and images on Docker Hub
+page_description: Repositories and images on Docker Hub
 page_keywords: Docker, docker, registry, accounts, plans, Dockerfile, Docker Hub, webhooks, docs, documentation
 
-# Repositories and Images on Docker Hub
+# Repositories and images on Docker Hub
 
 ![repositories](/docker-hub/hub-images/repos.png)
 
@@ -51,7 +51,7 @@ private to public.
 You can also collaborate on Docker Hub with organizations and groups.
 You can read more about that [here](accounts/).
 
-## Official Repositories
+## Official repositories
 
 The Docker Hub contains a number of [official
 repositories](http://registry.hub.docker.com/official). These are
@@ -67,7 +67,7 @@ optimized and up-to-date image to power your applications.
 > organization, product or team you can see more information
 > [here](https://github.com/docker/stackbrew).
 
-## Private Repositories
+## Private repositories
 
 Private repositories allow you to have repositories that contain images
 that you want to keep private, either to your own account or within an

--- a/docs/sources/examples.md
+++ b/docs/sources/examples.md
@@ -1,9 +1,9 @@
 # Examples
 
- - [Dockerizing a Node.js Web App](nodejs_web_app/)
- - [Dockerizing a Redis Service](running_redis_service/)
- - [Dockerizing an SSH Daemon Service](running_ssh_service/)
- - [Dockerizing a CouchDB Service](couchdb_data_volumes/)
- - [Dockerizing a PostgreSQL Service](postgresql_service/)
+ - [Dockerizing a Node.js web app](nodejs_web_app/)
+ - [Dockerizing a Redis service](running_redis_service/)
+ - [Dockerizing an SSH daemon service](running_ssh_service/)
+ - [Dockerizing a CouchDB service](couchdb_data_volumes/)
+ - [Dockerizing a PostgreSQL service](postgresql_service/)
  - [Dockerizing MongoDB](mongodb/)
- - [Dockerizing a Riak Service](running_riak_service/)
+ - [Dockerizing a Riak service](running_riak_service/)

--- a/docs/sources/examples/apt-cacher-ng.md
+++ b/docs/sources/examples/apt-cacher-ng.md
@@ -2,7 +2,7 @@ page_title: Dockerizing an apt-cacher-ng service
 page_description: Installing and running an apt-cacher-ng service
 page_keywords: docker, example, package installation, networking, debian, ubuntu
 
-# Dockerizing an Apt-Cacher-ng Service
+# Dockerizing an apt-cacher-ng service
 
 > **Note**: 
 > - **If you don't like sudo** then see [*Giving non-root

--- a/docs/sources/examples/couchdb_data_volumes.md
+++ b/docs/sources/examples/couchdb_data_volumes.md
@@ -1,8 +1,8 @@
-page_title: Dockerizing a CouchDB Service
+page_title: Dockerizing a CouchDB service
 page_description: Sharing data between 2 couchdb databases
 page_keywords: docker, example, package installation, networking, couchdb, data volumes
 
-# Dockerizing a CouchDB Service
+# Dockerizing a CouchDB service
 
 > **Note**: 
 > - **If you don't like sudo** then see [*Giving non-root

--- a/docs/sources/examples/nodejs_web_app.md
+++ b/docs/sources/examples/nodejs_web_app.md
@@ -1,8 +1,8 @@
-page_title: Dockerizing a Node.js Web App
+page_title: Dockerizing a Node.js web app
 page_description: Installing and running a Node.js app with Docker
 page_keywords: docker, example, package installation, node, centos
 
-# Dockerizing a Node.js Web App
+# Dockerizing a Node.js web app
 
 > **Note**: 
 > - **If you don't like sudo** then see [*Giving non-root

--- a/docs/sources/examples/running_redis_service.md
+++ b/docs/sources/examples/running_redis_service.md
@@ -2,12 +2,12 @@ page_title: Dockerizing a Redis service
 page_description: Installing and running an redis service
 page_keywords: docker, example, package installation, networking, redis
 
-# Dockerizing a Redis Service
+# Dockerizing a Redis service
 
 Very simple, no frills, Redis service attached to a web application
 using a link.
 
-## Create a docker container for Redis
+## Create a Docker container for Redis
 
 Firstly, we create a `Dockerfile` for our new Redis
 image.

--- a/docs/sources/examples/running_riak_service.md
+++ b/docs/sources/examples/running_riak_service.md
@@ -2,7 +2,7 @@ page_title: Dockerizing a Riak service
 page_description: Build a Docker image with Riak pre-installed
 page_keywords: docker, example, package installation, networking, riak
 
-# Dockerizing a Riak Service
+# Dockerizing a Riak service
 
 The goal of this example is to show you how to build a Docker image with
 Riak pre-installed.

--- a/docs/sources/examples/running_ssh_service.md
+++ b/docs/sources/examples/running_ssh_service.md
@@ -2,7 +2,7 @@ page_title: Dockerizing an SSH service
 page_description: Installing and running an SSHd service on Docker
 page_keywords: docker, example, package installation, networking
 
-# Dockerizing an SSH Daemon Service
+# Dockerizing an SSH daemon service
 
 ## Build an `eg_sshd` image
 

--- a/docs/sources/http-routingtable.md
+++ b/docs/sources/http-routingtable.md
@@ -1,4 +1,4 @@
-# HTTP Routing Table
+# HTTP routing table
 
 [**/api**](#cap-/api) | [**/auth**](#cap-/auth) |
 [**/build**](#cap-/build) | [**/commit**](#cap-/commit) |

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -75,18 +75,18 @@ The [Understanding Docker section](introduction/understanding-docker.md) will he
  - See how Docker compares to virtual machines
  - See some common use cases.
 
-### Installation Guides
+### Installation guides
 
 The [installation section](/installation/#installation) will show you how to
 install Docker on a variety of platforms.
 
 
-### Docker User Guide
+### Docker user guide
 
 To learn about Docker in more detail and to answer questions about usage and
 implementation, check out the [Docker User Guide](/userguide/).
 
-## Release Notes
+## Release notes
 
 A summary of the changes in each release in the current series can now be found
 on the separate [Release Notes page](/release-notes/)

--- a/docs/sources/installation/azure.md
+++ b/docs/sources/installation/azure.md
@@ -1,4 +1,4 @@
-page_title: Installation on Microsoft Azure Platform
+page_title: Installation on Microsoft Azure platform
 page_description: Instructions for creating a Docker-ready virtual machine on Microsoft Azure cloud platform.
 page_keywords: Docker, Docker documentation, installation, azure, microsoft
 

--- a/docs/sources/installation/binaries.md
+++ b/docs/sources/installation/binaries.md
@@ -1,4 +1,4 @@
-page_title: Installation from Binaries
+page_title: Installation from binaries
 page_description: Instructions for installing Docker as a binary. Mostly meant for hackers who want to try out Docker on a variety of environments.
 page_keywords: binaries, installation, docker, documentation, linux
 
@@ -78,7 +78,7 @@ exhibit unexpected behaviour.
 > vendor for the system, and might break regulations and security
 > policies in heavily regulated environments.
 
-## Get the docker binary
+## Get the Docker binary
 
 You can download either the latest release binary or a specific version.
 After downloading a binary file, you must set the file's execute bit to run it.
@@ -141,7 +141,7 @@ For example:
 
     https://get.docker.com/builds/Darwin/x86_64/docker-1.6.0
 
-###  Get the Windows binary
+### Get the Windows binary
  
 You can only download the Windows client binary for version `1.6.0` onwards.
 Moreover, the binary is only a client, you cannot use it to run the `docker` daemon.
@@ -164,7 +164,7 @@ For example:
     https://get.docker.com/builds/Windows/x86_64/docker-1.6.0.exe
 
 
-## Run the docker daemon
+## Run the Docker daemon
 
     # start the docker in daemon mode from the directory you unpacked
     $ sudo ./docker -d &

--- a/docs/sources/installation/cruxlinux.md
+++ b/docs/sources/installation/cruxlinux.md
@@ -20,7 +20,7 @@ Assuming you have contrib enabled, update your ports tree and install docker (*a
     # prt-get depinst docker
 
 
-## Kernel Requirements
+## Kernel requirements
 
 To have a working **CRUX+Docker** Host you must ensure your Kernel has
 the necessary modules enabled for the Docker Daemon to function correctly.

--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -162,7 +162,7 @@ Initialize and run `boot2docker` from the command line, do the following:
 		$ docker run hello-world
 
 
-## Basic Boot2Docker Exercises
+## Basic Boot2Docker exercises
 
 At this point, you should have `boot2docker` running and the `docker` client
 environment initialized. To verify this, run the following commands:
@@ -314,7 +314,7 @@ section.
 	The installer places Boot2Docker in your "Applications" folder.
 
 
-## Learning more and Acknowledgement
+## Learning more and acknowledgement
 
 
 Use `boot2docker help` to list the full command line reference. For more

--- a/docs/sources/installation/oracle.md
+++ b/docs/sources/installation/oracle.md
@@ -110,7 +110,7 @@ service.
 On Oracle Linux 7, you can use a `systemd.mount` definition and modify the
 Docker `systemd.service` to depend on the btrfs mount defined in systemd.
 
-### SElinux Support on Oracle Linux 7
+### SElinux support on Oracle Linux 7
 SElinux must be set to `Permissive` or `Disabled` in `/etc/sysconfig/selinux` to
 use the btrfs storage engine on Oracle Linux 7.
 

--- a/docs/sources/installation/rhel.md
+++ b/docs/sources/installation/rhel.md
@@ -16,7 +16,7 @@ running on kernels shipped by the distribution. There are kernel changes which
 will cause issues if one decides to step outside that box and run
 non-distribution kernel packages.
 
-## Red Hat Enterprise Linux 7 Installation
+## Red Hat Enterprise Linux 7 installation
 
 **Red Hat Enterprise Linux 7 (64 bit)** has [shipped with
 Docker](https://access.redhat.com/site/products/red-hat-enterprise-linux/docker-and-containers).
@@ -41,7 +41,7 @@ Portal](https://access.redhat.com/).
 
 Please continue with the [Starting the Docker daemon](#starting-the-docker-daemon).
 
-## Red Hat Enterprise Linux 6.5 Installation
+## Red Hat Enterprise Linux 6.5 installation
 
 You will need **64 bit** [RHEL
 6.5](https://access.redhat.com/site/articles/3078#RHEL6) or later, with

--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -127,7 +127,7 @@ install Docker using the following:
 
 	This command downloads a test image and runs it in a container.
 
-## Optional Configurations for Docker on Ubuntu 
+## Optional configurations for Docker on Ubuntu 
 
 This section contains optional procedures for configuring your Ubuntu to work
 better with Docker.
@@ -137,7 +137,7 @@ better with Docker.
 * [Enable UFW forwarding](#enable-ufw-forwarding) 
 * [Configure a DNS server for use by Docker](#configure-a-dns-server-for-docker)
 
-### Create a docker group		
+### Create a Docker group		
 
 The `docker` daemon binds to a Unix socket instead of a TCP port. By default
 that Unix socket is owned by the user `root` and other users can access it with

--- a/docs/sources/installation/windows.md
+++ b/docs/sources/installation/windows.md
@@ -59,7 +59,7 @@ Let's try the `hello-world` example image. Run
 This should download the very small `hello-world` image and print a
 `Hello from Docker.` message.
 
-## Using docker from Windows Command Line Prompt (cmd.exe)
+## Using Docker from Windows Command Line Prompt (cmd.exe)
 
 Launch a Windows Command Line Prompt (cmd.exe).
 
@@ -77,7 +77,7 @@ to your console window and you are ready to run docker commands such as
 
 ![](/installation/images/windows-boot2docker-cmd.png)
 
-## Using docker from PowerShell
+## Using Docker from PowerShell
 
 Launch a PowerShell window, then you need to add `ssh.exe` to your PATH:
 

--- a/docs/sources/introduction/understanding-docker.md
+++ b/docs/sources/introduction/understanding-docker.md
@@ -109,7 +109,7 @@ Docker containers. Docker provides a simple way to build new images or update ex
 images, or you can download Docker images that other people have already created.
 Docker images are the **build** component of Docker.
 
-#### Docker Registries
+#### Docker registries
 Docker registries hold images. These are public or private stores from which you upload
 or download images. The public Docker registry is called
 [Docker Hub](http://hub.docker.com). It provides a huge collection of existing
@@ -135,7 +135,7 @@ So far, we've learned that:
 
 Let's look at how these elements combine together to make Docker work.
 
-### How does a Docker Image work? 
+### How does a Docker image work? 
 We've already seen that Docker images are read-only templates from which Docker
 containers are launched. Each image consists of a series of layers. Docker
 makes use of [union file systems](http://en.wikipedia.org/wiki/UnionFS) to
@@ -280,7 +280,7 @@ BSD Jails or Solaris Zones.
 ### Installing Docker
 Visit the [installation section](/installation/#installation).
 
-### The Docker User Guide
+### The Docker user guide
 [Learn Docker in depth](/userguide/).
 
 

--- a/docs/sources/project/advanced-contributing.md
+++ b/docs/sources/project/advanced-contributing.md
@@ -137,7 +137,7 @@ The following provides greater detail on the process:
 
 14. Acceptance and merge!
 
-## About the Advanced process
+## About the advanced process
 
 Docker is a large project. Our core team gets a great many design proposals.
 Design proposal discussions can span days, weeks, and longer. The number of comments can reach the 100s.

--- a/docs/sources/project/coding-style.md
+++ b/docs/sources/project/coding-style.md
@@ -1,8 +1,8 @@
-page_title: Coding Style Checklist
+page_title: Coding style checklist
 page_description: List of guidelines for coding Docker contributions
 page_keywords: change, commit, squash, request, pull request, test, unit test, integration tests, Go, gofmt, LGTM
 
-# Coding Style Checklist
+# Coding style checklist
 
 This checklist summarizes the material you experienced working through [make a
 code contribution](/project/make-a-contribution) and [advanced

--- a/docs/sources/project/create-pr.md
+++ b/docs/sources/project/create-pr.md
@@ -11,7 +11,7 @@ repository into the `docker/docker` repository.
 You can see <a href="https://github.com/docker/docker/pulls" target="_blank">the
 list of active pull requests to Docker</a> on GitHub.
 
-## Check Your Work
+## Check your work
 
 Before you create a pull request, check your work.
 

--- a/docs/sources/project/doc-style.md
+++ b/docs/sources/project/doc-style.md
@@ -1,4 +1,4 @@
-page_title: Style Guide for Docker Documentation
+page_title: Style guide for Docker documentation
 page_description: Style guide for Docker documentation describing standards and conventions for contributors
 page_keywords: style, guide, docker, documentation
 

--- a/docs/sources/project/review-pr.md
+++ b/docs/sources/project/review-pr.md
@@ -1,9 +1,9 @@
-page_title: Participate in the PR Review
+page_title: Participate in the PR review
 page_description: Basic workflow for Docker contributions
 page_keywords: contribute, pull request, review, workflow, beginner, squash, commit
 
 
-# Participate in the PR Review
+# Participate in the PR review
 
 Creating a pull request is nearly the end of the contribution process. At this
 point, your code is reviewed both by our continuous integration (CI) systems and
@@ -45,7 +45,7 @@ So, they value your time and will try to work efficiently with you by keeping
 their comments specific and brief. If they ask you to make a change, you'll
 need to update your pull request with additional changes.
 
-## Update an Existing Pull Request
+## Update an existing pull request
 
 To update your existing pull request:
 

--- a/docs/sources/reference/api/docker-io_api.md
+++ b/docs/sources/reference/api/docker-io_api.md
@@ -10,7 +10,7 @@ page_keywords: API, Docker, index, REST, documentation, Docker Hub, registry
 
 # Repositories
 
-## User Repository
+## User repository
 
 ### Create a user repository
 
@@ -93,7 +93,7 @@ Status Codes:
 - **401** – Unauthorized
 - **403** – Account is not Active
 
-## Library Repository
+## Library repository
 
 ### Create a library repository
 
@@ -182,9 +182,9 @@ Status Codes:
 - **401** – Unauthorized
 - **403** – Account is not Active
 
-# Repository Images
+# Repository images
 
-## User Repository Images
+## User repository images
 
 ### Update user repository images
 
@@ -256,7 +256,7 @@ Status Codes:
 - **200** – OK
 - **404** – Not found
 
-## Library Repository Images
+## Library repository images
 
 ### Update library repository images
 
@@ -326,9 +326,9 @@ Status Codes:
 - **200** – OK
 - **404** – Not found
 
-# Repository Authorization
+# Repository authorization
 
-## Library Repository
+## Library repository
 
 ### Authorize a token for a library
 
@@ -361,7 +361,7 @@ Status Codes:
 - **403** – Permission denied
 - **404** – Not found
 
-## User Repository
+## User repository
 
 ### Authorize a token for a user repository
 
@@ -397,7 +397,7 @@ Status Codes:
 
 ## Users
 
-### User Login
+### User login
 
 `GET /v1/users/`
 
@@ -424,7 +424,7 @@ Status Codes:
 - **401** – Unauthorized
 - **403** – Account is not Active
 
-### User Register
+### User register
 
 `POST /v1/users/`
 
@@ -461,7 +461,7 @@ Status Codes:
 - **201** – User Created
 - **400** – Errors (invalid json, missing or invalid fields, etc)
 
-### Update User
+### Update user
 
 `PUT /v1/users/(username)/`
 

--- a/docs/sources/reference/api/docker_io_accounts_api.md
+++ b/docs/sources/reference/api/docker_io_accounts_api.md
@@ -1,8 +1,8 @@
-page_title: docker.io Accounts API
+page_title: docker.io accounts API
 page_description: API Documentation for docker.io accounts.
 page_keywords: API, Docker, accounts, REST, documentation
 
-# docker.io Accounts API
+# docker.io accounts API
 
 ## Get a single user
 

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -40,7 +40,7 @@ You can still call an old version of the API using
 
 ## v1.19
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.19*](/reference/api/docker_remote_api_v1.19/)
 
@@ -49,7 +49,7 @@ You can still call an old version of the API using
 
 ## v1.18
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.18*](/reference/api/docker_remote_api_v1.18/)
 
@@ -96,7 +96,7 @@ Add `Warnings` field to response.
 
 ## v1.17
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.17*](/reference/api/docker_remote_api_v1.17/)
 
@@ -154,7 +154,7 @@ This endpoint now returns the labels associated with each image (`Labels`).
 
 ## v1.16
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.16*](/reference/api/docker_remote_api_v1.16/)
 
@@ -182,7 +182,7 @@ You can now copy data which is contained in a volume.
 
 ## v1.15
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.15*](/reference/api/docker_remote_api_v1.15/)
 
@@ -196,7 +196,7 @@ Previously this was only available when starting a container.
 
 ## v1.14
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.14*](/reference/api/docker_remote_api_v1.14/)
 
@@ -222,7 +222,7 @@ the `tag` parameter at the same time will return an error.
 
 ## v1.13
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.13*](/reference/api/docker_remote_api_v1.13/)
 
@@ -250,7 +250,7 @@ Added a `pause` parameter (default `true`) to pause the container during commit
 
 ## v1.12
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.12*](/reference/api/docker_remote_api_v1.12/)
 
@@ -275,7 +275,7 @@ The `insert` endpoint has been removed.
 
 ## v1.11
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.11*](/reference/api/docker_remote_api_v1.11/)
 
@@ -298,7 +298,7 @@ This url is preferred method for getting container logs now.
 
 ## v1.10
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.10*](/reference/api/docker_remote_api_v1.10/)
 
@@ -321,7 +321,7 @@ You can now use the force parameter to force delete a
 
 ## v1.9
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.9*](/reference/api/docker_remote_api_v1.9/)
 
@@ -337,7 +337,7 @@ accepting an AuthConfig object must be updated.
 
 ## v1.8
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.8*](/reference/api/docker_remote_api_v1.8/)
 
@@ -369,7 +369,7 @@ without having to parse the string.
 
 ## v1.7
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.7*](/reference/api/docker_remote_api_v1.7/)
 
@@ -468,7 +468,7 @@ output is now generated in the client, using the
 
 ## v1.6
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.6*](/reference/api/docker_remote_api_v1.6/)
 
@@ -486,7 +486,7 @@ previous API version didn't change. Stdout and stderr are merged.
 
 ## v1.5
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.5*](/reference/api/docker_remote_api_v1.5/)
 
@@ -513,7 +513,7 @@ port mapping.
 
 ## v1.4
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.4*](/reference/api/docker_remote_api_v1.4/)
 
@@ -540,7 +540,7 @@ Image's name added in the events
 docker v0.5.0
 [51f6c4a](https://github.com/docker/docker/commit/51f6c4a7372450d164c61e0054daf0223ddbd909)
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.3*](/reference/api/docker_remote_api_v1.3/)
 
@@ -580,7 +580,7 @@ Start containers (/containers/<id>/start):
 docker v0.4.2
 [2e7649b](https://github.com/docker/docker/commit/2e7649beda7c820793bd46766cbc2cfeace7b168)
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.2*](/reference/api/docker_remote_api_v1.2/)
 
@@ -612,7 +612,7 @@ deleted/untagged.
 docker v0.4.0
 [a8ae398](https://github.com/docker/docker/commit/a8ae398bf52e97148ee7bd0d5868de2e15bd297f)
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.1*](/reference/api/docker_remote_api_v1.1/)
 
@@ -639,7 +639,7 @@ Uses json stream instead of HTML hijack, it looks like this:
 docker v0.3.4
 [8d73740](https://github.com/docker/docker/commit/8d73740343778651c09160cde9661f5f387b36f4)
 
-### Full Documentation
+### Full documentation
 
 [*Docker Remote API v1.0*](/reference/api/docker_remote_api_v1.0/)
 

--- a/docs/sources/reference/api/docker_remote_api_v1.9.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.9.md
@@ -675,7 +675,7 @@ Status Codes:
 
 ## 2.2 Images
 
-### List Images
+### List images
 
 `GET /images/json`
 
@@ -1119,7 +1119,7 @@ Status Codes:
 -   **200** – no error
 -   **500** – server error
 
-### Show the docker version information
+### Show the Docker version information
 
 `GET /version`
 
@@ -1343,7 +1343,7 @@ Here are the steps of `docker run` :
 In this version of the API, /attach, uses hijacking to transport stdin,
 stdout and stderr on the same socket. This might change in the future.
 
-## 3.3 CORS Requests
+## 3.3 CORS requests
 
 To enable cross origin requests to the remote api add the flag
 "--api-enable-cors" when running docker in daemon mode.

--- a/docs/sources/reference/api/hub_registry_spec.md
+++ b/docs/sources/reference/api/hub_registry_spec.md
@@ -1,4 +1,4 @@
-page_title: Registry Documentation
+page_title: Registry documentation
 page_description: Documentation for docker Registry and Registry API
 page_keywords: docker, registry, api, hub
 
@@ -679,7 +679,7 @@ On every request, a special header can be returned:
 On the next request, the client will always pick a server from this
 list.
 
-## Authentication & Authorization
+## Authentication and authorization
 
 ### On the Docker Hub
 
@@ -747,7 +747,7 @@ Next request:
     GET /(...)
     Cookie: session="wD/J7LqL5ctqw8haL10vgfhrb2Q=?foo=UydiYXInCnAxCi4=&timestamp=RjEzNjYzMTQ5NDcuNDc0NjQzCi4="
 
-## Document Version
+## Document version
 
  - 1.0 : May 6th 2013 : initial release
  - 1.1 : June 1st 2013 : Added Delete Repository and way to handle new

--- a/docs/sources/reference/api/registry_api_client_libraries.md
+++ b/docs/sources/reference/api/registry_api_client_libraries.md
@@ -1,8 +1,8 @@
-page_title: Registry API Client Libraries
+page_title: Registry API client libraries
 page_description: Various client libraries available to use with the Docker registry API
 page_keywords: API, Docker, index, registry, REST, documentation, clients, C#, Erlang, Go, Groovy, Java, JavaScript, Perl, PHP, Python, Ruby, Rust, Scala
 
-# Docker Registry 1.0 API Client Libraries
+# Docker Registry 1.0 API client libraries
 
 These libraries have not been tested by the Docker maintainers for
 compatibility. Please file issues with the library owners. If you find

--- a/docs/sources/reference/api/remote_api_client_libraries.md
+++ b/docs/sources/reference/api/remote_api_client_libraries.md
@@ -1,8 +1,8 @@
-page_title: Remote API Client Libraries
+page_title: Remote API client libraries
 page_description: Various client libraries available to use with the Docker remote API
 page_keywords: API, Docker, index, registry, REST, documentation, clients, C#, Erlang, Go, Groovy, Java, JavaScript, Perl, PHP, Python, Ruby, Rust, Scala
 
-# Docker Remote API Client Libraries
+# Docker Remote API client libraries
 
 These libraries have not been tested by the Docker maintainers for
 compatibility. Please file issues with the library owners. If you find

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -1,8 +1,8 @@
-page_title: Dockerfile Reference
+page_title: Dockerfile reference
 page_description: Dockerfiles use a simple DSL which allows you to automate the steps you would normally manually take to create an image.
 page_keywords: builder, docker, Dockerfile, automation, image creation
 
-# Dockerfile Reference
+# Dockerfile reference
 
 **Docker can build images automatically** by reading the instructions
 from a `Dockerfile`. A `Dockerfile` is a text document that contains all
@@ -105,7 +105,7 @@ be treated as an argument. This allows statements like:
 Here is the set of instructions you can use in a `Dockerfile` for building
 images.
 
-### Environment Replacement
+### Environment replacement
 
 > **Note**: prior to 1.3, `Dockerfile` environment variables were handled
 > similarly, in that they would be replaced as described below. However, there
@@ -288,7 +288,7 @@ guide](/articles/dockerfile_best-practices/#build-cache) for more information.
 The cache for `RUN` instructions can be invalidated by `ADD` instructions. See
 [below](#add) for details.
 
-### Known Issues (RUN)
+### Known issues (RUN)
 
 - [Issue 783](https://github.com/docker/docker/issues/783) is about file
   permissions problems that can occur when using the AUFS file system. You
@@ -973,7 +973,7 @@ For example you might add something like this:
 
 > **Warning**: The `ONBUILD` instruction may not trigger `FROM` or `MAINTAINER` instructions.
 
-## Dockerfile Examples
+## Dockerfile examples
 
     # Nginx
     #

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -24,7 +24,7 @@ the `docker` command, your system administrator can create a Unix group called
 For more information about installing Docker or `sudo` configuration, refer to
 the [installation](/installation) instructions for your operating system.
 
-## Environment Variables
+## Environment variables
 
 For easy reference, the following list of environment variables are supported
 by the `docker` command line:
@@ -48,7 +48,7 @@ These Go environment variables are case-insensitive. See the
 [Go specification](http://golang.org/pkg/net/http/) for details on these
 variables.
 
-## Configuration Files
+## Configuration files
 
 The Docker command line stores its configuration files in a directory called
 `.docker` within your `HOME` directory. Docker manages most of the files in
@@ -2210,7 +2210,7 @@ application change:
    `--rm` option means that when the container exits, the container's layer is
    removed.
 
-#### Restart Policies
+#### Restart policies
 
 Use Docker's `--restart` to specify a container's *restart policy*. A restart
 policy controls whether the Docker daemon restarts a container after exit.

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -156,7 +156,7 @@ Images using the v2 or later image format have a content-addressable identifier
 called a digest. As long as the input used to generate the image is unchanged,
 the digest value is predictable and referenceable.
 
-## PID Settings (--pid)
+## PID settings (--pid)
     --pid=""  : Set the PID (Process) Namespace mode for the container,
            'host': use the host's PID namespace inside the container
 
@@ -177,7 +177,7 @@ within the container.
 This command would allow you to use `strace` inside the container on pid 1234 on
 the host.
 
-## IPC Settings (--ipc)
+## IPC settings (--ipc)
 
     --ipc=""  : Set the IPC mode for the container,
                  'container:<name|id>': reuses another container's IPC namespace

--- a/docs/sources/release-notes.md
+++ b/docs/sources/release-notes.md
@@ -1,8 +1,8 @@
-page_title: Docker 1.x Series Release Notes
-page_description: Release Notes for Docker 1.x.
+page_title: Docker 1.x series release notes
+page_description: Release notes for Docker 1.x.
 page_keywords: docker, documentation, about, technology, understanding, release
 
-# Release Notes Version 1.6.0
+# Release notes version 1.6.0
 (2015-04-16)
 
 You can view release notes for earlier version of Docker by selecting the
@@ -12,7 +12,7 @@ blog](https://blog.docker.com/2015/04/docker-release-1-6/).
 
 
 
-## Docker Engine 1.6.0 Features
+## Docker Engine 1.6.0 features
 
 For a complete list of engine patches, fixes, and other improvements, see the
 [merge PR on GitHub](https://github.com/docker/docker/pull/11635). You'll also
@@ -30,7 +30,7 @@ repository](https://github.com/docker/docker/blob/master/CHANGELOG.md).
 | Ulimits                      | You can now specify the default `ulimit` settings for all containers when configuring the daemon. For example:`docker -d --default-ulimit nproc=1024:2048` See [Default Ulimits](http://docs.docker.com/reference/commandline/cli/#default-ulimits) in this documentation.                                                                                                                                                                                   |
 | Commit and import Dockerfile | You can now make changes to images on the fly without having to re-build the entire image. The feature `commit --change` and `import --change` allows you to apply standard changes to a new image. These are expressed in the Dockerfile syntax and used to modify the image. For details on how to use these, see the [commit](http://docs.docker.com/reference/commandline/cli/#commit) and [import](http://docs.docker.com/reference/commandline/cli/#import). |
 
-### Known Issues in Engine
+### Known issues in Engine
 
 This section lists significant known issues present in Docker as of release date.
 For an exhaustive list of issues, see [the issues list on the project
@@ -53,7 +53,7 @@ issues. You might have to flush your cookies if it doesn't work right away.
 For more information, see the [Docker forum
 post](https://forums.docker.com/t/new-safari-in-yosemite-issue/300).
 
-## Docker Registry 2.0 Features
+## Docker Registry 2.0 features
 
 This release includes Registry 2.0. The Docker Registry is a central server for
 pushing and pulling images. In this release, it was completely rewritten in Go

--- a/docs/sources/terms/container.md
+++ b/docs/sources/terms/container.md
@@ -17,7 +17,7 @@ Image*](/terms/image)
 and some additional information like its unique id, networking
 configuration, and resource limits is called a **container**.
 
-## Container State
+## Container state
 
 Containers can change, and so they have state. A container may be
 **running** or **exited**.

--- a/docs/sources/terms/filesystem.md
+++ b/docs/sources/terms/filesystem.md
@@ -1,8 +1,8 @@
-page_title: File Systems
+page_title: File system
 page_description: How Linux organizes its persistent storage
 page_keywords: containers, files, linux
 
-# File System
+# File system
 
 ## Introduction
 

--- a/docs/sources/terms/image.md
+++ b/docs/sources/terms/image.md
@@ -1,4 +1,4 @@
-page_title: Images
+page_title: Image
 page_description: Definition of an image
 page_keywords: containers, lxc, concepts, explanation, image, container
 
@@ -19,7 +19,7 @@ images do not have state.
 
 ![](/terms/images/docker-filesystems-debianrw.png)
 
-## Parent Image
+## Parent image
 
 ![](/terms/images/docker-filesystems-multilayer.png)
 
@@ -27,7 +27,7 @@ Each image may depend on one more image which forms the layer beneath
 it. We sometimes say that the lower image is the **parent** of the upper
 image.
 
-## Base Image
+## Base image
 
 An image that has no parent is a **base image**.
 

--- a/docs/sources/terms/registry.md
+++ b/docs/sources/terms/registry.md
@@ -14,7 +14,7 @@ The default registry can be accessed using a browser at
 [Docker Hub](https://hub.docker.com) or using the
 `docker search` command.
 
-## Further Reading
+## Further reading
 
 For more information see [*Working with
 Repositories*](/userguide/dockerrepos/#working-with-the-repository)

--- a/docs/sources/userguide/dockerhub.md
+++ b/docs/sources/userguide/dockerhub.md
@@ -2,7 +2,7 @@ page_title: Getting started with Docker Hub
 page_description: Introductory guide to getting an account on Docker Hub
 page_keywords: documentation, docs, the docker guide, docker guide, docker, docker platform, virtualization framework, docker.io, central service, services, how to, container, containers, automation, collaboration, collaborators, registry, repo, repository, technology, github webhooks, trusted builds
 
-# Getting Started with Docker Hub
+# Getting started with Docker Hub
 
 
 This section provides a quick introduction to the [Docker Hub](https://hub.docker.com),
@@ -21,7 +21,7 @@ most out of Docker. To do this, it provides services such as:
 In order to use Docker Hub, you will first need to register and create an account. Don't
 worry, creating an account is simple and free.
 
-## Creating a Docker Hub Account
+## Creating a Docker Hub account
 
 There are two ways for you to register and create an account:
 

--- a/docs/sources/userguide/dockerimages.md
+++ b/docs/sources/userguide/dockerimages.md
@@ -1,8 +1,8 @@
-page_title: Working with Docker Images
+page_title: Working with Docker images
 page_description: How to work with Docker images.
 page_keywords: documentation, docs, the docker guide, docker guide, docker, docker platform, virtualization framework, docker.io, Docker images, Docker image, image management, Docker repos, Docker repositories, docker, docker tag, docker tags, Docker Hub, collaboration
 
-# Working with Docker Images
+# Working with Docker images
 
 In the [introduction](/introduction/understanding-docker/) we've discovered that Docker
 images are the basis of containers. In the

--- a/docs/sources/userguide/dockerizing.md
+++ b/docs/sources/userguide/dockerizing.md
@@ -1,8 +1,8 @@
-page_title: Dockerizing Applications: A "Hello world"
+page_title: Dockerizing applications: A "Hello world"
 page_description: A simple "Hello world" exercise that introduced you to Docker.
 page_keywords: docker guide, docker, docker platform, virtualization framework, how to, dockerize, dockerizing apps, dockerizing applications, container, containers
 
-# Dockerizing Applications: A "Hello world"
+# Dockerizing applications: A "Hello world"
 
 *So what's this Docker thing all about?*
 
@@ -48,7 +48,7 @@ So what happened to our container after that? Well Docker containers
 only run as long as the command you specify is active. Here, as soon as
 `Hello world` was echoed, the container stopped.
 
-## An Interactive Container
+## An interactive container
 
 Let's try the `docker run` command again, this time specifying a new
 command to run in our container.
@@ -90,7 +90,7 @@ use the `exit` command or enter Ctrl-D to finish.
 As with our previous container, once the Bash shell process has
 finished, the container is stopped.
 
-## A Daemonized Hello world
+## A daemonized Hello world
 
 Now a container that runs a command and then exits has some uses but
 it's not overly helpful. Let's create a container that runs as a daemon,

--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -1,8 +1,8 @@
-page_title: Linking Containers Together
+page_title: Linking containers together
 page_description: Learn how to connect Docker containers together.
 page_keywords: Examples, Usage, user guide, links, linking, docker, documentation, examples, names, name, container naming, port, map, network port, network
 
-# Linking Containers Together
+# Linking containers together
 
 In [the Using Docker section](/userguide/usingdocker), you saw how you can
 connect to a service running inside a Docker container via a network
@@ -11,7 +11,7 @@ applications running inside Docker containers. In this section, we'll briefly re
 connecting via a network port and then we'll introduce you to another method of access:
 container linking.
 
-## Connect using Network port mapping
+## Connect using network port mapping
 
 In [the Using Docker section](/userguide/usingdocker), you created a
 container that ran a Python Flask application:
@@ -175,7 +175,7 @@ recipient container in two ways:
 * Environment variables,
 * Updating the `/etc/hosts` file.
 
-### Environment Variables
+### Environment variables
 
 Docker creates several environment variables when you link containers. Docker
 automatically creates environment variables in the target container based on

--- a/docs/sources/userguide/dockerrepos.md
+++ b/docs/sources/userguide/dockerrepos.md
@@ -101,7 +101,7 @@ information [here](http://docs.docker.com/docker-hub/).
 * Automated Builds
 * Webhooks
 
-### Private Repositories
+### Private repositories
 
 Sometimes you have images you don't want to make public and share with
 everyone. So Docker Hub allows you to have private repositories. You can
@@ -150,7 +150,7 @@ repository.
 You can create multiple Automated Builds per repository and configure them
 to point to specific `Dockerfile`'s or Git branches.
 
-#### Build Triggers
+#### Build triggers
 
 Automated Builds can also be triggered via a URL on Docker Hub. This
 allows you to rebuild an Automated build image on demand.

--- a/docs/sources/userguide/dockervolumes.md
+++ b/docs/sources/userguide/dockervolumes.md
@@ -1,8 +1,8 @@
-page_title: Managing Data in Containers
+page_title: Managing data in containers
 page_description: How to manage data inside your Docker containers.
 page_keywords: Examples, Usage, volume, docker, documentation, user guide, data, volumes
 
-# Managing Data in Containers
+# Managing data in containers
 
 So far we've been introduced to some [basic Docker
 concepts](/userguide/usingdocker/), seen how to work with [Docker
@@ -73,7 +73,7 @@ volumes. The output should look something similar to the following:
 You will notice in the above 'Volumes' is specifying the location on the host and 
 'VolumesRW' is specifying that the volume is read/write.
 
-### Mount a Host Directory as a Data Volume
+### Mount a host directory as a data volume
 
 In addition to creating a volume using the `-v` flag you can also mount a
 directory from your Docker daemon's host into a container.
@@ -116,7 +116,7 @@ read-only.
 Here we've mounted the same `/src/webapp` directory but we've added the `ro`
 option to specify that the mount should be read-only.
 
-### Mount a Host File as a Data Volume
+### Mount a host file as a data volume
 
 The `-v` flag can also be used to mount a single file  - instead of *just* 
 directories - from the host machine.
@@ -134,7 +134,7 @@ history of the commands typed while in the container.
 > you want to edit the mounted file, it is often easiest to instead mount the 
 > parent directory.
 
-## Creating and mounting a Data Volume Container
+## Creating and mounting a data volume container
 
 If you have some persistent data that you want to share between
 containers, or want to use from non-persistent containers, it's best to

--- a/docs/sources/userguide/index.md
+++ b/docs/sources/userguide/index.md
@@ -1,8 +1,8 @@
-page_title: The Docker User Guide
-page_description: The Docker User Guide home page
+page_title: The Docker user guide
+page_description: The Docker user guide home page
 page_keywords: docker, introduction, documentation, about, technology, docker.io, user, guide, user's, manual, platform, framework, virtualization, home, intro
 
-# Welcome to the Docker User Guide
+# Welcome to the Docker user guide
 
 In the [Introduction](/) you got a taste of what Docker is and how it
 works. In this guide we're going to take you through the fundamentals of
@@ -19,7 +19,7 @@ We’ll teach you how to use Docker to:
 We've broken this guide into major sections that take you through
 the Docker life cycle:
 
-## Getting Started with Docker Hub
+## Getting started with Docker Hub
 
 *How do I use Docker Hub?*
 
@@ -29,7 +29,7 @@ environment. To learn more:
 
 Go to [Using Docker Hub](/userguide/dockerhub).
 
-## Dockerizing Applications: A "Hello world"
+## Dockerizing applications: A "Hello world"
 
 *How do I run applications inside containers?*
 
@@ -38,7 +38,7 @@ applications. To learn how to Dockerize applications and run them:
 
 Go to [Dockerizing Applications](/userguide/dockerizing).
 
-## Working with Containers
+## Working with containers
 
 *How do I manage my containers?*
 
@@ -48,7 +48,7 @@ about how to inspect, monitor and manage containers:
 
 Go to [Working With Containers](/userguide/usingdocker).
 
-## Working with Docker Images
+## Working with Docker images
 
 *How can I access, share and build my own images?*
 
@@ -57,7 +57,7 @@ learn how to build your own application images with Docker.
 
 Go to [Working with Docker Images](/userguide/dockerimages).
 
-## Linking Containers Together
+## Linking containers together
 
 Until now we've seen how to build individual applications inside Docker
 containers. Now learn how to build whole application stacks with Docker
@@ -65,7 +65,7 @@ by linking together multiple Docker containers.
 
 Go to [Linking Containers Together](/userguide/dockerlinks).
 
-## Managing Data in Containers
+## Managing data in containers
 
 Now we know how to link Docker containers together the next step is
 learning how to manage data, volumes and mounts inside our containers.

--- a/docs/sources/userguide/level1.md
+++ b/docs/sources/userguide/level1.md
@@ -1,10 +1,10 @@
-page_title: Docker Images Test
+page_title: Docker images test
 page_description: How to work with Docker images.
 page_keywords: documentation, docs, the docker guide, docker guide, docker, docker platform, virtualization framework, docker.io, Docker images, Docker image, image management, Docker repos, Docker repositories, docker, docker tag, docker tags, Docker Hub, collaboration
 
 <a title="back" class="dockerfile back" href="/userguide/dockerimages/#creating-our-own-images">Back</a>
 
-# Dockerfile Tutorial
+# Dockerfile tutorial
 
 ## Test your Dockerfile knowledge - Level 1
 

--- a/docs/sources/userguide/level2.md
+++ b/docs/sources/userguide/level2.md
@@ -1,10 +1,10 @@
-page_title: Docker Images Test
+page_title: Docker images test
 page_description: How to work with Docker images.
 page_keywords: documentation, docs, the docker guide, docker guide, docker, docker platform, virtualization framework, docker.io, Docker images, Docker image, image management, Docker repos, Docker repositories, docker, docker tag, docker tags, Docker Hub, collaboration
 
 <a title="back" class="dockerfile back" href="/userguide/dockerimages/#creating-our-own-images">Back</a>
 
-#Dockerfile Tutorial
+#Dockerfile tutorial
 
 ## Test your Dockerfile knowledge - Level 2
 

--- a/docs/sources/userguide/usingdocker.md
+++ b/docs/sources/userguide/usingdocker.md
@@ -1,8 +1,8 @@
-page_title: Working with Containers
+page_title: Working with containers
 page_description: Learn how to manage and operate Docker containers.
 page_keywords: docker, the docker guide, documentation, docker.io, monitoring containers, docker top, docker inspect, docker port, ports, docker logs, log, Logs
 
-# Working with Containers
+# Working with containers
 
 In the [last section of the Docker User Guide](/userguide/dockerizing)
 we launched our first containers. We launched two containers using the
@@ -91,7 +91,7 @@ This will display the help text and all available flags:
 > You can see a full list of Docker's commands
 > [here](/reference/commandline/cli/).
 
-## Running a Web Application in Docker
+## Running a web application in Docker
 
 So now we've learnt a bit more about the `docker` client let's move onto
 the important stuff: running more containers. So far none of the
@@ -121,7 +121,7 @@ Lastly, we've specified a command for our container to run: `python app.py`. Thi
 > reference](/reference/commandline/cli/#run) and the [Docker Run
 > Reference](/reference/run/).
 
-## Viewing our Web Application Container
+## Viewing our web application container
 
 Now let's see our running container using the `docker ps` command.
 
@@ -189,7 +189,7 @@ Our Python application is live!
 > 
 > In this case you'd browse to http://192.168.59.103:49155 for the above example.
 
-## A Network Port Shortcut
+## A network port shortcut
 
 Using the `docker ps` command to return the mapped port is a bit clumsy so
 Docker has a useful shortcut we can use: `docker port`. To use `docker port` we
@@ -202,7 +202,7 @@ corresponding public-facing port.
 In this case we've looked up what port is mapped externally to port 5000 inside
 the container.
 
-## Viewing the Web Application's Logs
+## Viewing the web application's logs
 
 Let's also find out a bit more about what's happening with our application and
 use another of the commands we've learnt, `docker logs`.
@@ -217,7 +217,7 @@ logs` command to act like the `tail -f` command and watch the
 container's standard out. We can see here the logs from Flask showing
 the application running on port 5000 and the access log entries for it.
 
-## Looking at our Web Application Container's processes
+## Looking at our web application container's processes
 
 In addition to the container's logs we can also examine the processes
 running inside it using the `docker top` command.
@@ -229,7 +229,7 @@ running inside it using the `docker top` command.
 Here we can see our `python app.py` command is the only process running inside
 the container.
 
-## Inspecting our Web Application Container
+## Inspecting our web application container
 
 Lastly, we can take a low-level dive into our Docker container using the
 `docker inspect` command. It returns a JSON hash of useful configuration
@@ -258,7 +258,7 @@ specific element, for example to return the container's IP address we would:
     $ docker inspect -f '{{ .NetworkSettings.IPAddress }}' nostalgic_morse
     172.17.0.5
 
-## Stopping our Web Application Container
+## Stopping our web application container
 
 Okay we've seen web application working. Now let's stop it using the
 `docker stop` command and the name of our container: `nostalgic_morse`.
@@ -271,7 +271,7 @@ been stopped.
 
     $ docker ps -l
 
-## Restarting our Web Application Container
+## Restarting our web application container
 
 Oops! Just after you stopped the container you get a call to say another
 developer needs the container back. From here you have two choices: you
@@ -289,7 +289,7 @@ responds.
 > Also available is the `docker restart` command that runs a stop and
 > then start on the container.
 
-## Removing our Web Application Container
+## Removing our web application container
 
 Your colleague has let you know that they've now finished with the container
 and won't need it again. So let's remove it using the `docker rm` command.


### PR DESCRIPTION
This PR makes the headings of the documentation site more consistent, mostly by changing the capitalization (following the documentation style guidelines).
I manually walked through all the files and checked all the headings, so hopefully I tackled all inconsistencies :sweat_smile:

I skipped the older API references (I only did v1.9) and man pages, but I did update `mkdocs.yml`.

Fixes #10673.

If I missed something, or if I made some other mistake, please let me know and I'll fix it ASAP :blush:
