### PR TITLE
Remove not needed call to container.readHostConfig()

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -178,11 +178,13 @@ func (container *Container) readHostConfig() error {
 		return nil
 	}
 
-	data, err := ioutil.ReadFile(pth)
+	f, err := os.Open(pth)
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(data, container.hostConfig)
+	defer f.Close()
+
+	return json.NewDecoder(f).Decode(&container.hostConfig)
 }
 
 func (container *Container) WriteHostConfig() error {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -194,8 +194,6 @@ func (daemon *Daemon) load(id string) (*Container, error) {
 		return container, fmt.Errorf("Container %s is stored at %s", container.ID, id)
 	}
 
-	container.readHostConfig()
-
 	return container, nil
 }
 


### PR DESCRIPTION
`container.readHostConfig()` is called only inside `container.FromDisk()` to just get a json decoding error.
The second call after `container.FromDisk()` in https://github.com/docker/docker/blob/master/daemon/daemon.go#L197 isn't needed (to my best knowledge)

EDIT
would create a beginner issue but I need a check on what I'm doing here about removing readHostConfig (and also move that Unmarshal refactor to another pr) wdyt @LK4D4 ? I can then close this and someone will handle this removal

Signed-off-by: Antonio Murdaca me@runcom.ninja
