### PR TITLE
Proposal: Port Allocations from a Host Range and Host Port Persistence Policies

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -802,6 +802,8 @@ _docker_run() {
 		--publish -p
 		--restart
 		--security-opt
+		--port-persistence
+		--port-range
 		--user -u
 		--ulimit
 		--volumes-from

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -407,6 +407,8 @@ __docker_subcommand () {
                 '--rm[Remove intermediate containers when it exits]' \
                 '*--security-opt=-[Security options]:security option: ' \
                 '--sig-proxy[Proxy all received signals to the process (non-TTY mode only)]' \
+                '--port-persistence=-[Persistence Policy for ports allocated from range]:policy:(static soft hard)' \
+                '--port-range=-[Range of ports from which to dynamically allocate]:_ports' \
                 {-t,--tty}'[Allocate a pseudo-tty]' \
                 {-u,--user=-}'[Username or UID]:user:_users' \
                 '*-v[Bind mount a volume]:volume: '\

--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -765,10 +765,10 @@ func AllocatePort(id string, port nat.Port, binding nat.PortBinding, start int, 
 
 	network.PortMappings = append(network.PortMappings, host)
 
-	var portRange string
-	if start == 0 && end == 0 {
+	portRange := ""
+	if start == 0 && end == 0 && hostPort == 0 {
 		portRange = fmt.Sprintf("%d-%d", portMapper.Allocator.Begin, portMapper.Allocator.End)
-	} else {
+	} else if start != 0 {
 		portRange = fmt.Sprintf("%d-%d", start, end)
 	}
 

--- a/daemon/networkdriver/portallocator/portallocator_test.go
+++ b/daemon/networkdriver/portallocator/portallocator_test.go
@@ -8,7 +8,7 @@ import (
 func TestRequestNewPort(t *testing.T) {
 	p := New()
 
-	port, err := p.RequestPort(defaultIP, "tcp", 0)
+	port, err := p.RequestPort(defaultIP, "tcp", 0, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -21,7 +21,7 @@ func TestRequestNewPort(t *testing.T) {
 func TestRequestSpecificPort(t *testing.T) {
 	p := New()
 
-	port, err := p.RequestPort(defaultIP, "tcp", 5000)
+	port, err := p.RequestPort(defaultIP, "tcp", 5000, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -33,7 +33,7 @@ func TestRequestSpecificPort(t *testing.T) {
 func TestReleasePort(t *testing.T) {
 	p := New()
 
-	port, err := p.RequestPort(defaultIP, "tcp", 5000)
+	port, err := p.RequestPort(defaultIP, "tcp", 5000, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestReleasePort(t *testing.T) {
 func TestReuseReleasedPort(t *testing.T) {
 	p := New()
 
-	port, err := p.RequestPort(defaultIP, "tcp", 5000)
+	port, err := p.RequestPort(defaultIP, "tcp", 5000, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestReuseReleasedPort(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	port, err = p.RequestPort(defaultIP, "tcp", 5000)
+	port, err = p.RequestPort(defaultIP, "tcp", 5000, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestReuseReleasedPort(t *testing.T) {
 func TestReleaseUnreadledPort(t *testing.T) {
 	p := New()
 
-	port, err := p.RequestPort(defaultIP, "tcp", 5000)
+	port, err := p.RequestPort(defaultIP, "tcp", 5000, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestReleaseUnreadledPort(t *testing.T) {
 		t.Fatalf("Expected port 5000 got %d", port)
 	}
 
-	port, err = p.RequestPort(defaultIP, "tcp", 5000)
+	port, err = p.RequestPort(defaultIP, "tcp", 5000, 0, 0)
 
 	switch err.(type) {
 	case ErrPortAlreadyAllocated:
@@ -88,7 +88,7 @@ func TestReleaseUnreadledPort(t *testing.T) {
 }
 
 func TestUnknowProtocol(t *testing.T) {
-	if _, err := New().RequestPort(defaultIP, "tcpp", 0); err != ErrUnknownProtocol {
+	if _, err := New().RequestPort(defaultIP, "tcpp", 0, 0, 0); err != ErrUnknownProtocol {
 		t.Fatalf("Expected error %s got %s", ErrUnknownProtocol, err)
 	}
 }
@@ -97,7 +97,7 @@ func TestAllocateAllPorts(t *testing.T) {
 	p := New()
 
 	for i := 0; i <= p.End-p.Begin; i++ {
-		port, err := p.RequestPort(defaultIP, "tcp", 0)
+		port, err := p.RequestPort(defaultIP, "tcp", 0, 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -107,11 +107,11 @@ func TestAllocateAllPorts(t *testing.T) {
 		}
 	}
 
-	if _, err := p.RequestPort(defaultIP, "tcp", 0); err != ErrAllPortsAllocated {
+	if _, err := p.RequestPort(defaultIP, "tcp", 0, 0, 0); err != ErrAllPortsAllocated {
 		t.Fatalf("Expected error %s got %s", ErrAllPortsAllocated, err)
 	}
 
-	_, err := p.RequestPort(defaultIP, "udp", 0)
+	_, err := p.RequestPort(defaultIP, "udp", 0, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +121,7 @@ func TestAllocateAllPorts(t *testing.T) {
 	if err := p.ReleasePort(defaultIP, "tcp", port); err != nil {
 		t.Fatal(err)
 	}
-	newPort, err := p.RequestPort(defaultIP, "tcp", 0)
+	newPort, err := p.RequestPort(defaultIP, "tcp", 0, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestAllocateAllPorts(t *testing.T) {
 	if err := p.ReleasePort(defaultIP, "tcp", newPort); err != nil {
 		t.Fatal(err)
 	}
-	port, err = p.RequestPort(defaultIP, "tcp", 0)
+	port, err = p.RequestPort(defaultIP, "tcp", 0, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,7 +148,7 @@ func BenchmarkAllocatePorts(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		for i := 0; i <= p.End-p.Begin; i++ {
-			port, err := p.RequestPort(defaultIP, "tcp", 0)
+			port, err := p.RequestPort(defaultIP, "tcp", 0, 0, 0)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -166,12 +166,12 @@ func TestPortAllocation(t *testing.T) {
 
 	ip := net.ParseIP("192.168.0.1")
 	ip2 := net.ParseIP("192.168.0.2")
-	if port, err := p.RequestPort(ip, "tcp", 80); err != nil {
+	if port, err := p.RequestPort(ip, "tcp", 80, 0, 0); err != nil {
 		t.Fatal(err)
 	} else if port != 80 {
 		t.Fatalf("Acquire(80) should return 80, not %d", port)
 	}
-	port, err := p.RequestPort(ip, "tcp", 0)
+	port, err := p.RequestPort(ip, "tcp", 0, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,41 +179,41 @@ func TestPortAllocation(t *testing.T) {
 		t.Fatalf("Acquire(0) should return a non-zero port")
 	}
 
-	if _, err := p.RequestPort(ip, "tcp", port); err == nil {
+	if _, err := p.RequestPort(ip, "tcp", port, 0, 0); err == nil {
 		t.Fatalf("Acquiring a port already in use should return an error")
 	}
 
-	if newPort, err := p.RequestPort(ip, "tcp", 0); err != nil {
+	if newPort, err := p.RequestPort(ip, "tcp", 0, 0, 0); err != nil {
 		t.Fatal(err)
 	} else if newPort == port {
 		t.Fatalf("Acquire(0) allocated the same port twice: %d", port)
 	}
 
-	if _, err := p.RequestPort(ip, "tcp", 80); err == nil {
+	if _, err := p.RequestPort(ip, "tcp", 80, 0, 0); err == nil {
 		t.Fatalf("Acquiring a port already in use should return an error")
 	}
-	if _, err := p.RequestPort(ip2, "tcp", 80); err != nil {
+	if _, err := p.RequestPort(ip2, "tcp", 80, 0, 0); err != nil {
 		t.Fatalf("It should be possible to allocate the same port on a different interface")
 	}
-	if _, err := p.RequestPort(ip2, "tcp", 80); err == nil {
+	if _, err := p.RequestPort(ip2, "tcp", 80, 0, 0); err == nil {
 		t.Fatalf("Acquiring a port already in use should return an error")
 	}
 	if err := p.ReleasePort(ip, "tcp", 80); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := p.RequestPort(ip, "tcp", 80); err != nil {
+	if _, err := p.RequestPort(ip, "tcp", 80, 0, 0); err != nil {
 		t.Fatal(err)
 	}
 
-	port, err = p.RequestPort(ip, "tcp", 0)
+	port, err = p.RequestPort(ip, "tcp", 0, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	port2, err := p.RequestPort(ip, "tcp", port+1)
+	port2, err := p.RequestPort(ip, "tcp", port+1, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	port3, err := p.RequestPort(ip, "tcp", 0)
+	port3, err := p.RequestPort(ip, "tcp", 0, 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -222,16 +222,79 @@ func TestPortAllocation(t *testing.T) {
 	}
 }
 
+func TestPortAllocationWithCustomStaticRange(t *testing.T) {
+	p := New()
+	start, end := 8081, 8082
+
+	//get an ephemeral port
+	port1, err := p.RequestPort(defaultIP, "tcp", 0, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//get a port from the range
+	port2, err := p.RequestPort(defaultIP, "tcp", 0, start, end)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port2 < start || port2 > end {
+		t.Fatalf("Expected a port between %d and %d, got %d", start, end, port2)
+	}
+	//get another ephemeral port (should be > port1)
+	port3, err := p.RequestPort(defaultIP, "tcp", 0, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port3 < port1 {
+		t.Fatalf("Expected new port > %d in the ephemeral range, got %d", port1, port3)
+	}
+	//get another (and in this case the only other) port from the range
+	port4, err := p.RequestPort(defaultIP, "tcp", 0, start, end)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port4 < start || port4 > end {
+		t.Fatalf("Expected a port between %d and %d, got %d", start, end, port4)
+	}
+	if port4 == port2 {
+		t.Fatal("Allocated the same port from a custom range")
+	}
+	//request 3rd port from the range of 2
+	if _, err := p.RequestPort(defaultIP, "tcp", 0, start, end); err != ErrAllPortsAllocated {
+		t.Fatalf("Expected error %s got %s", ErrAllPortsAllocated, err)
+	}
+
+}
+
+func TestReallocationInStaticRange(t *testing.T) {
+	p := New()
+	start, end := 8085, 8090
+
+	//get a port from the range
+	port1, err := p.RequestPort(defaultIP, "tcp", 0, start, end)
+	if err != nil {
+		t.Fatal(err)
+	}
+	//request the same port again, expect different port
+	port2, err := p.RequestPort(defaultIP, "tcp", port1, start, end)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port2 == port1 {
+		t.Fatal("Allocated busy port from custom range")
+	}
+
+}
+
 func TestNoDuplicateBPR(t *testing.T) {
 	p := New()
 
-	if port, err := p.RequestPort(defaultIP, "tcp", p.Begin); err != nil {
+	if port, err := p.RequestPort(defaultIP, "tcp", p.Begin, 0, 0); err != nil {
 		t.Fatal(err)
 	} else if port != p.Begin {
 		t.Fatalf("Expected port %d got %d", p.Begin, port)
 	}
 
-	if port, err := p.RequestPort(defaultIP, "tcp", 0); err != nil {
+	if port, err := p.RequestPort(defaultIP, "tcp", 0, 0, 0); err != nil {
 		t.Fatal(err)
 	} else if port == p.Begin {
 		t.Fatalf("Acquire(0) allocated the same port twice: %d", port)

--- a/daemon/networkdriver/portmapper/mapper.go
+++ b/daemon/networkdriver/portmapper/mapper.go
@@ -51,7 +51,7 @@ func (pm *PortMapper) SetIptablesChain(c *iptables.Chain) {
 	pm.chain = c
 }
 
-func (pm *PortMapper) Map(container net.Addr, hostIP net.IP, hostPort int, useProxy bool) (host net.Addr, err error) {
+func (pm *PortMapper) Map(container net.Addr, hostIP net.IP, hostPort int, start int, end int, useProxy bool) (host net.Addr, err error) {
 	pm.lock.Lock()
 	defer pm.lock.Unlock()
 
@@ -64,7 +64,7 @@ func (pm *PortMapper) Map(container net.Addr, hostIP net.IP, hostPort int, usePr
 	switch container.(type) {
 	case *net.TCPAddr:
 		proto = "tcp"
-		if allocatedHostPort, err = pm.Allocator.RequestPort(hostIP, proto, hostPort); err != nil {
+		if allocatedHostPort, err = pm.Allocator.RequestPort(hostIP, proto, hostPort, start, end); err != nil {
 			return nil, err
 		}
 
@@ -79,7 +79,7 @@ func (pm *PortMapper) Map(container net.Addr, hostIP net.IP, hostPort int, usePr
 		}
 	case *net.UDPAddr:
 		proto = "udp"
-		if allocatedHostPort, err = pm.Allocator.RequestPort(hostIP, proto, hostPort); err != nil {
+		if allocatedHostPort, err = pm.Allocator.RequestPort(hostIP, proto, hostPort, start, end); err != nil {
 			return nil, err
 		}
 

--- a/daemon/networkdriver/portmapper/mapper_test.go
+++ b/daemon/networkdriver/portmapper/mapper_test.go
@@ -44,22 +44,22 @@ func TestMapPorts(t *testing.T) {
 		return (addr1.Network() == addr2.Network()) && (addr1.String() == addr2.String())
 	}
 
-	if host, err := pm.Map(srcAddr1, dstIp1, 80, true); err != nil {
+	if host, err := pm.Map(srcAddr1, dstIp1, 80, 0, 0, true); err != nil {
 		t.Fatalf("Failed to allocate port: %s", err)
 	} else if !addrEqual(dstAddr1, host) {
 		t.Fatalf("Incorrect mapping result: expected %s:%s, got %s:%s",
 			dstAddr1.String(), dstAddr1.Network(), host.String(), host.Network())
 	}
 
-	if _, err := pm.Map(srcAddr1, dstIp1, 80, true); err == nil {
+	if _, err := pm.Map(srcAddr1, dstIp1, 80, 0, 0, true); err == nil {
 		t.Fatalf("Port is in use - mapping should have failed")
 	}
 
-	if _, err := pm.Map(srcAddr2, dstIp1, 80, true); err == nil {
+	if _, err := pm.Map(srcAddr2, dstIp1, 80, 0, 0, true); err == nil {
 		t.Fatalf("Port is in use - mapping should have failed")
 	}
 
-	if _, err := pm.Map(srcAddr2, dstIp2, 80, true); err != nil {
+	if _, err := pm.Map(srcAddr2, dstIp2, 80, 0, 0, true); err != nil {
 		t.Fatalf("Failed to allocate port: %s", err)
 	}
 
@@ -127,14 +127,14 @@ func TestMapAllPortsSingleInterface(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		start, end := pm.Allocator.Begin, pm.Allocator.End
 		for i := start; i < end; i++ {
-			if host, err = pm.Map(srcAddr1, dstIp1, 0, true); err != nil {
+			if host, err = pm.Map(srcAddr1, dstIp1, 0, 0, 0, true); err != nil {
 				t.Fatal(err)
 			}
 
 			hosts = append(hosts, host)
 		}
 
-		if _, err := pm.Map(srcAddr1, dstIp1, start, true); err == nil {
+		if _, err := pm.Map(srcAddr1, dstIp1, start, 0, 0, true); err == nil {
 			t.Fatalf("Port %d should be bound but is not", start)
 		}
 

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -44,6 +44,8 @@ docker-create - Create a new container
 [**--read-only**[=*false*]]
 [**--restart**[=*RESTART*]]
 [**--security-opt**[=*[]*]]
+[**--port-persistence**[=*static*]]
+[**--port-range**[=*[]*]]
 [**-t**|**--tty**[=*false*]]
 [**-u**|**--user**[=*USER*]]
 [**-v**|**--volume**[=*[]*]]
@@ -195,6 +197,16 @@ This value should always larger than **-m**, so you should alway use this with *
 
 **--security-opt**=[]
    Security Options
+
+**--port-persistence**=*static*|*soft*|*hard*
+   Apply persistence policy to dynamically allocated host ports
+                               'static': Dynamic ports will always be re-allocated on restart
+                               'soft': Try to preserve the dynamic host ports on restart, re-allocate from original range if port is in use
+                               'hard': Try to preserve the dynamic host ports on restart, error if port is in use
+
+**--port-range**=[]
+   Assign the next available host port(s) from this range and bind to dynamically published ports from the container (for use with -p or -P).
+                               format: startPort-endPort
 
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.

--- a/docs/man/docker-inspect.1.md
+++ b/docs/man/docker-inspect.1.md
@@ -100,7 +100,8 @@ To get information on a container use its ID or instance name:
                 "80/tcp": [
                     {
                         "HostIp": "0.0.0.0",
-                        "HostPort": "80"
+                        "HostPort": "80",
+                        "PortRange": ""
                     }
                 ]
             },

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -47,6 +47,8 @@ docker-run - Run a command in a new container
 [**--rm**[=*false*]]
 [**--security-opt**[=*[]*]]
 [**--sig-proxy**[=*true*]]
+[**--port-persistence**[=*static*]]
+[**--port-range**[=*[]*]]
 [**-t**|**--tty**[=*false*]]
 [**-u**|**--user**[=*USER*]]
 [**-v**|**--volume**[=*[]*]]
@@ -349,6 +351,16 @@ its root filesystem mounted as read only prohibiting any writes.
 
 **--sig-proxy**=*true*|*false*
    Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true*.
+
+**--port-persistence**=*static*|*soft*|*hard*
+   Apply persistence policy to dynamically allocated host ports
+                               'static': Dynamic ports will always be re-allocated on restart
+                               'soft': Try to preserve the dynamic host ports on restart, re-allocate from original range if port is in use
+                               'hard': Try to preserve the dynamic host ports on restart, error if port is in use
+
+**--port-range**=[]
+   Assign the next available host port(s) from this range and bind to dynamically published ports from the container (for use with -p or -P).
+                               format: startPort-endPort
 
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -130,6 +130,9 @@ Finally, several networking options can only be provided when calling
  *  `-P` or `--publish-all=true|false` — see
     [Binding container ports](#binding-ports)
 
+ *  `--port-range=RANGE` — see
+    [Binding container ports](#binding-ports)
+
 To supply networking options to the Docker server at startup, use the
 `DOCKER_OPTS` variable in the Docker upstart configuration file. For Ubuntu, edit the
 variable in `/etc/default/docker` or `/etc/sysconfig/docker` for CentOS.
@@ -421,7 +424,22 @@ typically ranging from 32768 to 61000.
 Mapping can be specified explicitly using `-p SPEC` or `--publish=SPEC` option.
 It allows you to particularize which port on docker server - which can be any
 port at all, not just one within the *ephemeral port range* — you want mapped
-to which port in the container.
+to which port in the container. When a container restarts, any ports initially
+allocated from the *ephemeral port range* will be mapped to a new available
+port, whereas an explicitly specified port will not be changed for the life
+of the container.
+
+You can optionally supply `--port-range=RANGE` which overrides the *ephemeral
+port range* for dynamic allocations on this container. Used in combination
+with `--port-persistence=soft|hard`, the dynamic ports can persist across
+container restarts. `soft` persistence will try to preserve the previously
+allocated port, but re-allocate from the original range if the port is in use.
+`hard` persistence will preserve the port as if the container was started with
+`-p X:Y`; if the allocated port is busy on restart, the container will fail to
+start.
+
+Note that any persistence policy will apply to ALL dynamically allocated ports
+for this container, whether from a custom range or the ephemeral range.
 
 Either way, you should be able to peek at what Docker has accomplished
 in your network stack by examining your NAT tables.

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -976,6 +976,8 @@ Creates a new container.
       --read-only=false          Mount the container's root filesystem as read only
       --restart="no"             Restart policy (no, on-failure[:max-retry], always)
       --security-opt=[]          Security options
+      --port-persistence=static  Persistence policy for dynamic ports (static, soft, hard)
+      --port-range=[]            Range of host ports to use for dynamic allocation
       -t, --tty=false            Allocate a pseudo-TTY
       -u, --user=""              Username or UID
       -v, --volume=[]            Bind mount a volume
@@ -1938,6 +1940,8 @@ To remove an image using its digest:
       --rm=false                 Automatically remove the container when it exits
       --security-opt=[]          Security Options
       --sig-proxy=true           Proxy received signals to the process
+      --port-persistence=static  Persistence policy for dynamic ports (static, soft, hard)
+      --port-range=[]            Range of host ports to use for dynamic allocation
       -t, --tty=false            Allocate a pseudo-TTY
       -u, --user=""              Username or UID (format: <name|uid>[:<group|gid>])
       -v, --volume=[]            Bind mount a volume

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -893,7 +893,9 @@ or override the Dockerfile's exposed defaults:
     -p=[]      : Publish a container᾿s port or a range of ports to the host 
                    format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
                    Both hostPort and containerPort can be specified as a range of ports. 
+                   When containerPort is a range, hostPort must also be a range.
                    When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range. (e.g., `-p 1234-1236:1234-1236/tcp`)
+                   Specifying a range for hostPort with a single containerPort, the hostPort will be dynamically allocated an available port in the range.
                    (use 'docker port' to see the actual mapping)
     --link=""  : Add link to another container (<name or id>:alias)
 

--- a/docs/sources/userguide/dockerlinks.md
+++ b/docs/sources/userguide/dockerlinks.md
@@ -62,6 +62,14 @@ You can also bind UDP ports by adding a trailing `/udp`. For example:
 
     $ docker run -d -p 127.0.0.1:80:5000/udp training/webapp python app.py
 
+You can also specify a range of host ports from which to dynamically allocate,
+instead of using the default *ephemeral port range*
+
+    $ docker run -d -p 8000-9000:5000 training/webapp python app.py
+
+This would bind port 5000 in the container to the next available port
+between 8000 and 9000 on the host.
+
 You also learned about the useful `docker port` shortcut which showed us the
 current port bindings. This is also useful for showing you specific port
 configurations. For example, if you've bound the container port to the

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -171,6 +171,7 @@ type HostConfig struct {
 	OomKillDisable  bool // Whether to disable OOM Killer or not
 	Privileged      bool
 	PortBindings    nat.PortMap
+	PortPersistence string // static | soft | hard
 	Links           []string
 	PublishAllPorts bool
 	Dns             []string

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -73,7 +73,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flLoggingDriver   = cmd.String([]string{"-log-driver"}, "", "Logging driver for container")
 		flCgroupParent    = cmd.String([]string{"-cgroup-parent"}, "", "Optional parent cgroup for the container")
 		flPortRange       = cmd.String([]string{"-port-range"}, "", "Port range to use for dynamic allocation")
-		flPortPersistence = cmd.String([]string{"-port-persistence"}, "static", "Persistence policy for dynamically allocated ports (static|soft|hard)")
+		flPortPersistence = cmd.String([]string{"-port-persistence"}, "", "Persistence policy for dynamic ports")
 	)
 
 	cmd.Var(&flAttach, []string{"a", "-attach"}, "Attach to STDIN, STDOUT or STDERR")


### PR DESCRIPTION
Inspired by the great work of @cezarsa over in #10052, this PR adds `PortRange` to the container HostConfig and provides the `--static-port-range` command line argument for `create` and `run`.

If a range is provided, any published ports without a specified hostPort will be allocated an available host port from the provided range. Once allocated, the port is written to the HostConfig and persists as if the container had been started with `-p X:Y`.

The change allows a user/sysadmin to define a range of ports on a host exclusively for docker containers to use outside of the standard ephemeral range, but still leaves the ephemeral range available for any other true 'dynamic' allocations when they are desired.
