### PR TITLE
Fix golint errors in docker/api/client

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -97,6 +97,11 @@ func (cli *DockerCli) Cmd(args ...string) error {
 	return cli.CmdHelp()
 }
 
+// Subcmd is a subcommand of the main "docker" command.
+// A subcommand represents an action that can be performed
+// from the Docker command line client.
+//
+// To see all available subcommands, run "docker --help".
 func (cli *DockerCli) Subcmd(name, signature, description string, exitOnError bool) *flag.FlagSet {
 	var errorHandling flag.ErrorHandling
 	if exitOnError {
@@ -121,6 +126,8 @@ func (cli *DockerCli) Subcmd(name, signature, description string, exitOnError bo
 	return flags
 }
 
+// CheckTtyInput checks if we are trying to attach to a container tty
+// from a non-tty client input stream, and if so, returns an error.
 func (cli *DockerCli) CheckTtyInput(attachStdin, ttyMode bool) error {
 	// In order to attach to a container tty, input stream for the client must
 	// be a tty itself: redirecting or piping the client standard input is

--- a/api/client/images.go
+++ b/api/client/images.go
@@ -19,19 +19,19 @@ import (
 )
 
 // FIXME: --viz and --tree are deprecated. Remove them in a future version.
-func (cli *DockerCli) WalkTree(noTrunc bool, images []*types.Image, byParent map[string][]*types.Image, prefix string, printNode func(cli *DockerCli, noTrunc bool, image *types.Image, prefix string)) {
+func (cli *DockerCli) walkTree(noTrunc bool, images []*types.Image, byParent map[string][]*types.Image, prefix string, printNode func(cli *DockerCli, noTrunc bool, image *types.Image, prefix string)) {
 	length := len(images)
 	if length > 1 {
 		for index, image := range images {
 			if index+1 == length {
 				printNode(cli, noTrunc, image, prefix+"└─")
 				if subimages, exists := byParent[image.ID]; exists {
-					cli.WalkTree(noTrunc, subimages, byParent, prefix+"  ", printNode)
+					cli.walkTree(noTrunc, subimages, byParent, prefix+"  ", printNode)
 				}
 			} else {
 				printNode(cli, noTrunc, image, prefix+"\u251C─")
 				if subimages, exists := byParent[image.ID]; exists {
-					cli.WalkTree(noTrunc, subimages, byParent, prefix+"\u2502 ", printNode)
+					cli.walkTree(noTrunc, subimages, byParent, prefix+"\u2502 ", printNode)
 				}
 			}
 		}
@@ -39,7 +39,7 @@ func (cli *DockerCli) WalkTree(noTrunc bool, images []*types.Image, byParent map
 		for _, image := range images {
 			printNode(cli, noTrunc, image, prefix+"└─")
 			if subimages, exists := byParent[image.ID]; exists {
-				cli.WalkTree(noTrunc, subimages, byParent, prefix+"  ", printNode)
+				cli.walkTree(noTrunc, subimages, byParent, prefix+"  ", printNode)
 			}
 		}
 	}
@@ -181,9 +181,9 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 
 		if startImage != nil {
 			root := []*types.Image{startImage}
-			cli.WalkTree(*noTrunc, root, byParent, "", printNode)
+			cli.walkTree(*noTrunc, root, byParent, "", printNode)
 		} else if matchName == "" {
-			cli.WalkTree(*noTrunc, roots, byParent, "", printNode)
+			cli.walkTree(*noTrunc, roots, byParent, "", printNode)
 		}
 		if *flViz {
 			fmt.Fprintf(cli.out, " base [style=invisible]\n}\n")

--- a/api/client/rm.go
+++ b/api/client/rm.go
@@ -7,6 +7,9 @@ import (
 	flag "github.com/docker/docker/pkg/mflag"
 )
 
+// CmdRm removes one or more containers.
+//
+// Usage: docker rm [OPTIONS] CONTAINER [CONTAINER...]
 func (cli *DockerCli) CmdRm(args ...string) error {
 	cmd := cli.Subcmd("rm", "CONTAINER [CONTAINER...]", "Remove one or more containers", true)
 	v := cmd.Bool([]string{"v", "-volumes"}, false, "Remove the volumes associated with the container")

--- a/api/client/search.go
+++ b/api/client/search.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/registry"
 )
 
+// ByStars sorts search results in ascending order by number of stars.
 type ByStars []registry.SearchResult
 
 func (r ByStars) Len() int           { return len(r) }

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -29,9 +29,10 @@ import (
 )
 
 var (
-	ErrConnectionRefused = errors.New("Cannot connect to the Docker daemon. Is 'docker -d' running on this host?")
+	errConnectionRefused = errors.New("Cannot connect to the Docker daemon. Is 'docker -d' running on this host?")
 )
 
+// HTTPClient creates a new HTP client with the cli's client transport instance.
 func (cli *DockerCli) HTTPClient() *http.Client {
 	return &http.Client{Transport: cli.transport}
 }
@@ -93,7 +94,7 @@ func (cli *DockerCli) clientRequest(method, path string, in io.Reader, headers m
 	}
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
-			return nil, "", statusCode, ErrConnectionRefused
+			return nil, "", statusCode, errConnectionRefused
 		}
 
 		if cli.tlsConfig == nil {
@@ -250,7 +251,7 @@ func getExitCode(cli *DockerCli, containerID string) (bool, int, error) {
 	stream, _, err := cli.call("GET", "/containers/"+containerID+"/json", nil, nil)
 	if err != nil {
 		// If we can't connect, then the daemon probably died.
-		if err != ErrConnectionRefused {
+		if err != errConnectionRefused {
 			return false, -1, err
 		}
 		return false, -1, nil
@@ -271,7 +272,7 @@ func getExecExitCode(cli *DockerCli, execID string) (bool, int, error) {
 	stream, _, err := cli.call("GET", "/exec/"+execID+"/json", nil, nil)
 	if err != nil {
 		// If we can't connect, then the daemon probably died.
-		if err != ErrConnectionRefused {
+		if err != errConnectionRefused {
 			return false, -1, err
 		}
 		return false, -1, nil


### PR DESCRIPTION
This commit fixes remaining <code>golint</code> issues in the api/client package, mostly around docs for exported methods and types.

<code>WalkTree</code> and <code>ErrConnectionRefused</code> look like they don't need to be exported since they're only used in their respective packages (I checked Github and sourcegraph.com for potential usages across other repos), and <code>WalkTree</code> is deprecated anyway.
