### PR TITLE
Fix CI

### DIFF
--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -65,7 +65,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flCpuShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCpusetCpus      = cmd.String([]string{"#-cpuset", "-cpuset-cpus"}, "", "CPUs in which to allow execution (0-3, 0,1)")
 		flCpusetMems      = cmd.String([]string{"-cpuset-mems"}, "", "MEMs in which to allow execution (0-3, 0,1)")
-		flCpuQuota        = cmd.Int64([]string{"-cpu-quota"}, 0, "Limit the CPU CFS (Completely Fair Scheduler) quota")
+		flCpuQuota        = cmd.Int64([]string{"-cpu-quota"}, 0, "Limit the CPU CFS quota")
 		flNetMode         = cmd.String([]string{"-net"}, "bridge", "Set the Network mode for the container")
 		flMacAddress      = cmd.String([]string{"-mac-address"}, "", "Container MAC address (e.g. 92:d0:c6:0a:29:33)")
 		flIpcMode         = cmd.String([]string{"-ipc"}, "", "IPC namespace to use")


### PR DESCRIPTION
The help message of cpu quota is over 80 chars, so it failed the
TestHelpTextVerify test.

Error as below:

```
FAIL: docker_cli_help_test.go:14: DockerSuite.TestHelpTextVerify

docker_cli_help_test.go:115:
    c.Fatalf("Help for %q is too long(%d chars):\n%s", cmd,
        len(line), line)
... Error: Help for "create" is too long(81 chars):
  --cpu-quota=0               Limit the CPU CFS (Completely Fair Scheduler) quota
```

Signed-off-by: Hu Keping hukeping@huawei.com
