### PR TITLE
Update truncindex.go

### DIFF
--- a/pkg/truncindex/truncindex.go
+++ b/pkg/truncindex/truncindex.go
@@ -17,7 +17,7 @@ var (
 func init() {
 	// Change patricia max prefix per node length,
 	// because our len(ID) always 64
-	patricia.MaxPrefixPerNode = 64
+	patricia.MaxPrefixPerNode(64)
 }
 
 // TruncIndex allows the retrieval of string identifiers by any of their unique prefixes.


### PR DESCRIPTION
MaxPrefixPerNode is instead by maxPrefixPerNode, use function MaxPrefixPerNode to set the value
