### PR TITLE
Add kali to install script

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -126,7 +126,7 @@ do_install() {
 			exit 0
 			;;
 
-		ubuntu|debian|linuxmint|'elementary os')
+		ubuntu|debian|linuxmint|'elementary os'|kali)
 			export DEBIAN_FRONTEND=noninteractive
 
 			did_apt_get_update=


### PR DESCRIPTION
https://www.kali.org/ is a Debian derivative, and this script completes succesfully using the Ubuntu install path
