### PR TITLE
Correctly format API error on image pull

### DIFF
--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -98,8 +98,13 @@ func (s *DockerSuite) TestPullImageFromCentralRegistry(c *check.C) {
 
 // pulling a non-existing image from the central registry should return a non-zero exit code
 func (s *DockerSuite) TestPullNonExistingImage(c *check.C) {
-	pullCmd := exec.Command(dockerBinary, "pull", "fooblahblah1234")
-	if out, _, err := runCommandWithOutput(pullCmd); err == nil {
+	testRequires(c, Network)
+
+	name := "sadfsadfasdf"
+	pullCmd := exec.Command(dockerBinary, "pull", name)
+	out, _, err := runCommandWithOutput(pullCmd)
+
+	if err == nil || !strings.Contains(out, fmt.Sprintf("Error: image library/%s:latest not found", name)) {
 		c.Fatalf("expected non-zero exit status when pulling non-existing image: %s", out)
 	}
 }


### PR DESCRIPTION
Recent changes caused some API errors to not be properly formatted. In the case of pull, the _job_ output used to always be formatted in JSON, but since ditching the job framework for this operation everything except errors were being formatted correctly.

Now, where we had this on docker 1.6.0:

``` bash
$ docker pull aoeuaoeu
Pulling repository aoeuaoeu
FATA[0003] Error: image library/aoeuaoeu:latest not found
```

And then had this on master (1.7.0-dev)

![wrong1](https://cloud.githubusercontent.com/assets/1203611/7277819/b2333846-e944-11e4-8511-ad3236f5db19.PNG)

We now have this again:

``` bash
$ docker pull aoeuaeu             
Pulling repository aoeuaeu
FATA[0002] Error: image library/aoeuaeu:latest not found
```
