### PR TITLE
Validate repo name before image pull

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -39,6 +39,10 @@ func (s *TagStore) Pull(image string, tag string, imagePullConfig *ImagePullConf
 		return err
 	}
 
+	if err := validateRepoName(repoInfo.LocalName); err != nil {
+		return err
+	}
+
 	c, err := s.poolAdd("pull", utils.ImageReference(repoInfo.LocalName, tag))
 	if err != nil {
 		if c != nil {

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -134,3 +134,22 @@ func (s *DockerSuite) TestPullImageOfficialNames(c *check.C) {
 		}
 	}
 }
+
+func (s *DockerSuite) TestPullScratchNotAllowed(c *check.C) {
+	testRequires(c, Network)
+
+	pullCmd := exec.Command(dockerBinary, "pull", "scratch")
+	out, exitCode, err := runCommandWithOutput(pullCmd)
+	if err == nil {
+		c.Fatal("expected pull of scratch to fail, but it didn't")
+	}
+	if exitCode != 1 {
+		c.Fatalf("pulling scratch expected exit code 1, got %d", exitCode)
+	}
+	if strings.Contains(out, "Pulling repository scratch") {
+		c.Fatalf("pulling scratch should not have begun: %s", out)
+	}
+	if !strings.Contains(out, "'scratch' is a reserved name") {
+		c.Fatalf("unexpected output pulling scratch: %s", out)
+	}
+}


### PR DESCRIPTION
Checks for reserved 'scratch' image name.

fixes #12281
closes #12527
