### PR TITLE
reuse same code for setting pipes in run/exec

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -38,44 +38,6 @@ func (s *DockerSuite) TestExec(c *check.C) {
 
 }
 
-func (s *DockerSuite) TestExecInteractiveStdinClose(c *check.C) {
-	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-itd", "busybox", "/bin/cat"))
-	if err != nil {
-		c.Fatal(err)
-	}
-
-	contId := strings.TrimSpace(out)
-
-	returnchan := make(chan struct{})
-
-	go func() {
-		var err error
-		cmd := exec.Command(dockerBinary, "exec", "-i", contId, "/bin/ls", "/")
-		cmd.Stdin = os.Stdin
-		if err != nil {
-			c.Fatal(err)
-		}
-
-		out, err := cmd.CombinedOutput()
-		if err != nil {
-			c.Fatal(err, string(out))
-		}
-
-		if string(out) == "" {
-			c.Fatalf("Output was empty, likely blocked by standard input")
-		}
-
-		returnchan <- struct{}{}
-	}()
-
-	select {
-	case <-returnchan:
-	case <-time.After(10 * time.Second):
-		c.Fatal("timed out running docker exec")
-	}
-
-}
-
 func (s *DockerSuite) TestExecInteractive(c *check.C) {
 
 	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "testing", "busybox", "sh", "-c", "echo test > /tmp/file && top")

--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -1,0 +1,47 @@
+// +build !windows,!test_no_exec
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/go-check/check"
+	"github.com/kr/pty"
+)
+
+// regression test for #12546
+func (s *DockerSuite) TestExecInteractiveStdinClose(c *check.C) {
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-itd", "busybox", "/bin/cat"))
+	if err != nil {
+		c.Fatal(err)
+	}
+	contId := strings.TrimSpace(out)
+
+	cmd := exec.Command(dockerBinary, "exec", "-i", contId, "echo", "-n", "hello")
+	p, err := pty.Start(cmd)
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	b := bytes.NewBuffer(nil)
+	go io.Copy(b, p)
+
+	ch := make(chan error)
+	go func() { ch <- cmd.Wait() }()
+
+	select {
+	case err := <-ch:
+		if err != nil {
+			c.Errorf("cmd finished with error %v", err)
+		}
+		if output := b.String(); strings.TrimSpace(output) != "hello" {
+			c.Fatalf("Unexpected output %s", output)
+		}
+	case <-time.After(1 * time.Second):
+		c.Fatal("timed out running docker exec")
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/docker/docker/issues/12546

The command's stdin pipe has to be an *os.File, otherwise bad things happen. This tries to reuse some code of `run` to setup the pipes because `run` code path already took care of that.
