### PR TITLE
Always bind mount bundles in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,8 @@ DOCKER_ENVS := \
 # note: we _cannot_ add "-e DOCKER_BUILDTAGS" here because even if it's unset in the shell, that would shadow the "ENV DOCKER_BUILDTAGS" set in our Dockerfile, which is very important for our official builds
 
 # to allow `make BIND_DIR=. shell` or `make BIND_DIR= test`
-# (default to no bind mount if DOCKER_HOST is set)
 # note: BINDDIR is supported for backwards-compatibility here
-BIND_DIR := $(if $(BINDDIR),$(BINDDIR),$(if $(DOCKER_HOST),,bundles))
+BIND_DIR := $(if $(BINDDIR),$(BINDDIR),bundles)
 DOCKER_MOUNT := $(if $(BIND_DIR),-v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/docker/docker/$(BIND_DIR)")
 
 # to allow `make DOCSDIR=docs docs-shell` (to create a bind mount in docs)


### PR DESCRIPTION
The Makefile relies on the existence of a `DOCKER_HOST` environment variable to determine if `bundles/` should be bind mounted. This is likely wrong for MacOS with boot2docker users where /Users happen to be mounted in the VM, and should more generally be tried before assuming it is not going to work.
