### PR TITLE
Add tag option to syslog

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1441,7 +1441,11 @@ func (container *Container) startLogging() error {
 		}
 		l = dl
 	case "syslog":
-		dl, err := syslog.New(container.ID[:12])
+		tag := container.hostConfig.LogConfig.Config["tag"]
+		if tag == "" {
+			tag = container.ID[:12]
+		}
+		dl, err := syslog.New(tag)
 		if err != nil {
 			return err
 		}

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -388,10 +388,22 @@ func convertKVStringsToMap(values []string) map[string]string {
 
 func parseLoggingOpts(loggingDriver string, loggingOpts []string) (map[string]string, error) {
 	loggingOptsMap := convertKVStringsToMap(loggingOpts)
-	if loggingDriver == "none" && len(loggingOpts) > 0 {
-		return map[string]string{}, fmt.Errorf("Invalid logging opts for driver %s", loggingDriver)
+	if loggingDriver == "none" || loggingDriver == "json-file" {
+		if len(loggingOpts) > 0 {
+			return nil, fmt.Errorf("%s does not accept any log options", loggingDriver)
+		}
 	}
-	//TODO - validation step
+
+	if loggingDriver == "syslog" {
+		for k, v := range loggingOptsMap {
+			switch k {
+			case "tag":
+			default:
+				return nil, fmt.Errorf("Invalid option and value: %s=%s", k, v)
+			}
+		}
+	}
+
 	return loggingOptsMap, nil
 }
 


### PR DESCRIPTION
**Note: This PR is based off of #12422.  Both this and that PR need to be rebased**

Currently the syslog tag is the container ID.  This PR allows the user to specify any value for the tag.  More context in #12391
