### PR TITLE
Documentation: fix the design proposal link in advanced contribution page

### DIFF
--- a/docs/sources/project/advanced-contributing.md
+++ b/docs/sources/project/advanced-contributing.md
@@ -67,7 +67,7 @@ The following provides greater detail on the process:
 
     The design proposals are <a
     href="https://github.com/docker/docker/pulls?q=is%3Aopen+is%3Apr+label%
-    3AProposal" target="_blank">all online in our GitHub pull requests</a>. 
+    3Akind%2Fproposal" target="_blank">all online in our GitHub pull requests</a>. 
     
 3. Talk to the community about your idea.
 


### PR DESCRIPTION
Hi,

This is a tiny tiny fix in the documentation page `advanced_contributing.md`. The link for the Design proposal pull request is broken. The label used for proposal used to be _Proposal_ and is now _kind/proposal_.

This just fixes that `:-P`.
