### PR TITLE
Remove deleteAllContainers call in test

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -773,7 +773,6 @@ func (s *DockerSuite) TestContainerApiPostCreateNull(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateWithTooLowMemoryLimit(c *check.C) {
-	defer deleteAllContainers()
 	config := `{
 		"Image":     "busybox",
 		"Cmd":       "ls",
@@ -795,8 +794,6 @@ func (s *DockerSuite) TestCreateWithTooLowMemoryLimit(c *check.C) {
 }
 
 func (s *DockerSuite) TestStartWithTooLowMemoryLimit(c *check.C) {
-	defer deleteAllContainers()
-
 	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "create", "busybox"))
 	if err != nil {
 		c.Fatal(err, out)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -2090,7 +2090,6 @@ func (s *DockerSuite) TestBuildRm(c *check.C) {
 		if containerCountBefore == containerCountAfter {
 			c.Fatalf("--rm=false should have left containers behind")
 		}
-		deleteAllContainers()
 		deleteImages(name)
 
 	}

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -14,7 +14,6 @@ import (
 
 // Make sure we can create a simple container with some args
 func (s *DockerSuite) TestCreateArgs(c *check.C) {
-
 	runCmd := exec.Command(dockerBinary, "create", "busybox", "command", "arg1", "arg2", "arg with space")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -256,9 +255,6 @@ func (s *DockerSuite) TestCreateLabels(c *check.C) {
 	if !reflect.DeepEqual(expected, actual) {
 		c.Fatalf("Expected %s got %s", expected, actual)
 	}
-
-	deleteAllContainers()
-
 }
 
 func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
@@ -287,9 +283,6 @@ func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
 	if !reflect.DeepEqual(expected, actual) {
 		c.Fatalf("Expected %s got %s", expected, actual)
 	}
-
-	deleteAllContainers()
-
 }
 
 func (s *DockerSuite) TestCreateHostnameWithNumber(c *check.C) {

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -478,9 +478,6 @@ func (s *DockerSuite) TestPsListContainersFilterLabel(c *check.C) {
 	if (!strings.Contains(containerOut, firstID) || !strings.Contains(containerOut, secondID)) || strings.Contains(containerOut, thirdID) {
 		c.Fatalf("Expected ids %s,%s, got %s for exited filter, output: %q", firstID, secondID, containerOut, out)
 	}
-
-	deleteAllContainers()
-
 }
 
 func (s *DockerSuite) TestPsListContainersFilterExited(c *check.C) {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1448,7 +1448,6 @@ func (s *DockerSuite) TestRunResolvconfUpdater(c *check.C) {
 
 	//cleanup
 	defer func() {
-		deleteAllContainers()
 		if err := ioutil.WriteFile("/etc/resolv.conf", resolvConfSystem, 0644); err != nil {
 			c.Fatal(err)
 		}
@@ -2380,7 +2379,6 @@ func (s *DockerSuite) TestRunVolumesNotRecreatedOnStart(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
 	// Clear out any remnants from other tests
-	deleteAllContainers()
 	info, err := ioutil.ReadDir(volumesConfigPath)
 	if err != nil {
 		c.Fatal(err)


### PR DESCRIPTION
Seems like we don't need these calls anymore https://github.com/docker/docker/blob/master/integration-cli/check_test.go#L30

note that however there are tests that need an explicit call to deleteAllContainer, for instance in this loop https://github.com/docker/docker/blob/master/integration-cli/docker_cli_exec_test.go#L586 (I prefer this instead of randomize the container name here, did it and reverted)

/cc @LK4D4 @duglin

Signed-off-by: Antonio Murdaca me@runcom.ninja
