### PR TITLE
Fix TestRenameStoppedContainer race

### DIFF
--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -4,11 +4,11 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestRenameStoppedContainer(c *check.C) {
-
 	runCmd := exec.Command(dockerBinary, "run", "--name", "first_name", "-d", "busybox", "sh")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
@@ -25,7 +25,8 @@ func (s *DockerSuite) TestRenameStoppedContainer(c *check.C) {
 
 	name, err := inspectField(cleanedContainerID, "Name")
 
-	runCmd = exec.Command(dockerBinary, "rename", "first_name", "new_name")
+	newName := "new_name" + stringid.GenerateRandomID()
+	runCmd = exec.Command(dockerBinary, "rename", "first_name", newName)
 	out, _, err = runCommandWithOutput(runCmd)
 	if err != nil {
 		c.Fatalf(out, err)
@@ -35,22 +36,22 @@ func (s *DockerSuite) TestRenameStoppedContainer(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	if name != "/new_name" {
+	if name != "/"+newName {
 		c.Fatal("Failed to rename container ", name)
 	}
 
 }
 
 func (s *DockerSuite) TestRenameRunningContainer(c *check.C) {
-
 	runCmd := exec.Command(dockerBinary, "run", "--name", "first_name", "-d", "busybox", "sh")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		c.Fatalf(out, err)
 	}
 
+	newName := "new_name" + stringid.GenerateRandomID()
 	cleanedContainerID := strings.TrimSpace(out)
-	runCmd = exec.Command(dockerBinary, "rename", "first_name", "new_name")
+	runCmd = exec.Command(dockerBinary, "rename", "first_name", newName)
 	out, _, err = runCommandWithOutput(runCmd)
 	if err != nil {
 		c.Fatalf(out, err)
@@ -60,31 +61,30 @@ func (s *DockerSuite) TestRenameRunningContainer(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	if name != "/new_name" {
+	if name != "/"+newName {
 		c.Fatal("Failed to rename container ")
 	}
-
 }
 
 func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
-
 	runCmd := exec.Command(dockerBinary, "run", "--name", "first_name", "-d", "busybox", "sh")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		c.Fatalf(out, err)
 	}
 
-	runCmd = exec.Command(dockerBinary, "rename", "first_name", "new_name")
+	newName := "new_name" + stringid.GenerateRandomID()
+	runCmd = exec.Command(dockerBinary, "rename", "first_name", newName)
 	out, _, err = runCommandWithOutput(runCmd)
 	if err != nil {
 		c.Fatalf(out, err)
 	}
 
-	name, err := inspectField("new_name", "Name")
+	name, err := inspectField(newName, "Name")
 	if err != nil {
 		c.Fatal(err)
 	}
-	if name != "/new_name" {
+	if name != "/"+newName {
 		c.Fatal("Failed to rename container ")
 	}
 
@@ -92,7 +92,6 @@ func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
 	if err == nil && !strings.Contains(err.Error(), "No such image or container: first_name") {
 		c.Fatal(err)
 	}
-
 }
 
 func (s *DockerSuite) TestRenameInvalidName(c *check.C) {
@@ -110,5 +109,4 @@ func (s *DockerSuite) TestRenameInvalidName(c *check.C) {
 	if out, _, err := runCommandWithOutput(runCmd); err != nil || !strings.Contains(out, "myname") {
 		c.Fatalf("Output of docker ps should have included 'myname': %s\n%v", out, err)
 	}
-
 }


### PR DESCRIPTION
https://github.com/docker/docker/pull/12505#issuecomment-95593215

I think the daemon hasn't already deleted the previous container when the test suite jump to the next test (above all when tests are in the same file like this and get executed consequently)

Signed-off-by: Antonio Murdaca me@runcom.ninja
