### PR TITLE
contrib/init: unshare mount namespace for inits

### DIFF
--- a/contrib/init/openrc/docker.initd
+++ b/contrib/init/openrc/docker.initd
@@ -7,6 +7,7 @@ DOCKER_LOGFILE=${DOCKER_LOGFILE:-/var/log/${SVCNAME}.log}
 DOCKER_PIDFILE=${DOCKER_PIDFILE:-/run/${SVCNAME}.pid}
 DOCKER_BINARY=${DOCKER_BINARY:-/usr/bin/docker}
 DOCKER_OPTS=${DOCKER_OPTS:-}
+UNSHARE_BINARY=${UNSHARE_BINARY:-/usr/bin/unshare}
 
 start() {
 	checkpath -f -m 0644 -o root:docker "$DOCKER_LOGFILE"
@@ -16,11 +17,12 @@ start() {
 
 	ebegin "Starting docker daemon"
 	start-stop-daemon --start --background \
-		--exec "$DOCKER_BINARY" \
+		--exec "$UNSHARE_BINARY" \
 		--pidfile "$DOCKER_PIDFILE" \
 		--stdout "$DOCKER_LOGFILE" \
 		--stderr "$DOCKER_LOGFILE" \
-		-- -d -p "$DOCKER_PIDFILE" \
+		-- --mount \
+		-- "$DOCKER_BINARY" -d -p "$DOCKER_PIDFILE" \
 		$DOCKER_OPTS
 	eend $?
 }

--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -30,6 +30,7 @@ DOCKER_SSD_PIDFILE=/var/run/$BASE-ssd.pid
 DOCKER_LOGFILE=/var/log/$BASE.log
 DOCKER_OPTS=
 DOCKER_DESC="Docker"
+UNSHARE=${UNSHARE:-/usr/bin/unshare}
 
 # Get lsb functions
 . /lib/lsb/init-functions
@@ -99,11 +100,11 @@ case "$1" in
 		log_begin_msg "Starting $DOCKER_DESC: $BASE"
 		start-stop-daemon --start --background \
 			--no-close \
-			--exec "$DOCKER" \
+			--exec "$UNSHARE" \
 			--pidfile "$DOCKER_SSD_PIDFILE" \
 			--make-pidfile \
-			-- \
-				-d -p "$DOCKER_PIDFILE" \
+			-- --mount \
+			-- "$DOCKER" -d -p "$DOCKER_PIDFILE" \
 				$DOCKER_OPTS \
 					>> "$DOCKER_LOGFILE" 2>&1
 		log_end_msg $?

--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -37,7 +37,7 @@ script
 	if [ -f /etc/default/$UPSTART_JOB ]; then
 		. /etc/default/$UPSTART_JOB
 	fi
-	exec "$DOCKER" -d $DOCKER_OPTS
+	exec unshare -m -- "$DOCKER" -d $DOCKER_OPTS
 end script
 
 # Don't emit "started" event until docker.sock is ready.


### PR DESCRIPTION
- openrc
- sysvinit-debian
- upstart

Signed-off-by: Vincent Batts vbatts@redhat.com
