### PR TITLE
Docker update command implementation

### DIFF
--- a/api/client/update.go
+++ b/api/client/update.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/registry"
+)
+
+func (cli *DockerCli) CmdUpdate(args ...string) error {
+	cmd := cli.Subcmd("update", "[REPOSITORY]", "Update images", true)
+	dryRun := cmd.Bool([]string{"d", "-dry-run"}, false, "Only show out of date images")
+
+	cmd.Require(flag.Max, 1)
+
+	cmd.ParseFlags(args, true)
+
+	v := url.Values{}
+	if *dryRun {
+		v.Set("dry_run", "1")
+	}
+
+	authConfigs := cli.configFile.AuthConfigs
+	update := func(authConfigs map[string]registry.AuthConfig) error {
+		buf, err := json.Marshal(authConfigs)
+		if err != nil {
+			return err
+		}
+		registryAuthHeader := []string{
+			base64.URLEncoding.EncodeToString(buf),
+		}
+		return cli.stream("POST", "/images/update?"+v.Encode(), nil, cli.out, map[string][]string{
+			"X-Registry-Auth": registryAuthHeader,
+		})
+	}
+
+	if err := update(authConfigs); err != nil {
+		if strings.Contains(err.Error(), "Status 401") {
+			fmt.Fprintln(cli.out, "\nAt least one repository requires login before updating")
+		}
+		return err
+	}
+	return nil
+}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -938,6 +938,55 @@ func (s *Server) postContainersCreate(eng *engine.Engine, version version.Versio
 	})
 }
 
+func (s *Server) postImagesUpdate(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	var (
+		dryRun = boolValue(r, "dry_run")
+	)
+
+	if err := parseForm(r); err != nil {
+		return err
+	}
+
+	authEncoded := r.Header.Get("X-Registry-Auth")
+	authConfigs := &map[string]registry.AuthConfig{}
+	if authEncoded != "" {
+		authJson := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authEncoded))
+		if err := json.NewDecoder(authJson).Decode(authConfigs); err != nil {
+			// for a update it is not an error if no auth was given
+			// to increase compatibility with the existing api it is defaulting to be empty
+			authConfigs = &map[string]registry.AuthConfig{}
+		}
+	}
+
+	metaHeaders := map[string][]string{}
+	for k, v := range r.Header {
+		if strings.HasPrefix(k, "X-Meta-") {
+			metaHeaders[k] = v
+		}
+	}
+
+	imagesUpdateConfig := &graph.ImagesUpdateConfig{
+		Parallel:    version.GreaterThan("1.3"),
+		MetaHeaders: metaHeaders,
+		AuthConfigs: authConfigs,
+		OutStream:   utils.NewWriteFlusher(w),
+		DryRun:      dryRun,
+	}
+
+	if version.GreaterThan("1.0") {
+		imagesUpdateConfig.Json = true
+		w.Header().Set("Content-Type", "application/json")
+	} else {
+		imagesUpdateConfig.Json = false
+	}
+
+	if err := s.daemon.Repositories().Update(imagesUpdateConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (s *Server) postContainersRestart(eng *engine.Engine, version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -1589,6 +1638,7 @@ func createRouter(s *Server, eng *engine.Engine) *mux.Router {
 			"/build":                        s.postBuild,
 			"/images/create":                s.postImagesCreate,
 			"/images/load":                  s.postImagesLoad,
+			"/images/update":                s.postImagesUpdate,
 			"/images/{name:.*}/push":        s.postImagesPush,
 			"/images/{name:.*}/tag":         s.postImagesTag,
 			"/containers/create":            s.postContainersCreate,

--- a/graph/update.go
+++ b/graph/update.go
@@ -1,0 +1,288 @@
+package graph
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/pkg/streamformatter"
+	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/docker/registry"
+)
+
+type ImagesUpdateConfig struct {
+	DryRun      bool
+	MetaHeaders map[string][]string
+	AuthConfigs *map[string]registry.AuthConfig
+	Json        bool
+	OutStream   io.Writer
+	Parallel    bool
+}
+
+func (s *TagStore) Update(imagesUpdateConfig *ImagesUpdateConfig) error {
+	var (
+		sf           = streamformatter.NewStreamFormatter(imagesUpdateConfig.Json)
+		tags_to_pull []string
+	)
+
+	dry_run := imagesUpdateConfig.DryRun
+
+	for name, repository := range s.Repositories {
+		repoInfo, err := s.registryService.ResolveRepository(name)
+		if err != nil {
+			logrus.Errorf("Error: couldn't load repoInfo for %s: %s", name, err)
+			continue
+		}
+		endpoint, err := repoInfo.GetEndpoint()
+		if err != nil {
+			logrus.Errorf("Error: coudln't find endpoint for %s: %s", name, err)
+			continue
+		}
+
+		authConfig := s.ResolveAuthConfig(*imagesUpdateConfig.AuthConfigs, repoInfo.Index)
+
+		r, err := registry.NewSession(&authConfig, registry.HTTPRequestFactory(imagesUpdateConfig.MetaHeaders), endpoint, true)
+		if err != nil {
+			logrus.Debugf("Warning: coudln't start http session for %s: %s", name, err)
+			continue
+		}
+
+		//V2
+		fallbackToV1 := true
+		if len(repoInfo.Index.Mirrors) == 0 && ((repoInfo.Official && repoInfo.Index.Official) || endpoint.Version == registry.APIVersion2) {
+			if repoInfo.Official {
+				s.trustService.UpdateBase()
+			}
+
+			logrus.Debugf("checking v2 registry with local name %q", repoInfo.LocalName)
+
+			tags_to_pull, err = s.checkV2Repository(r, imagesUpdateConfig.OutStream, repository, repoInfo, sf)
+			if err == nil {
+				fallbackToV1 = false
+			} else if err != registry.ErrDoesNotExist && err != ErrV2RegistryUnavailable {
+				logrus.Errorf("Error from V2 registry: %s", err)
+			} else {
+				logrus.Debug("image does not exist on v2 registry, falling back to v1")
+			}
+		}
+
+		//V1
+		if fallbackToV1 {
+			tags_to_pull, err = s.checkRepository(r, imagesUpdateConfig.OutStream, repository, repoInfo, sf)
+			if err != nil {
+				imagesUpdateConfig.OutStream.Write(sf.FormatStatus(repoInfo.CanonicalName, err.Error(), nil))
+				continue
+			}
+		}
+
+		if len(tags_to_pull) == 0 || dry_run {
+			if dry_run {
+				logrus.Debug("Dry run, not pulling anything")
+			} else {
+				logrus.Debug("All images up to date")
+			}
+		} else {
+			for _, tag_to_pull := range tags_to_pull {
+
+				imagePullConfig := &ImagePullConfig{
+					Parallel:    imagesUpdateConfig.Parallel,
+					MetaHeaders: imagesUpdateConfig.MetaHeaders,
+					AuthConfig:  &authConfig,
+					OutStream:   imagesUpdateConfig.OutStream,
+					Json:        imagesUpdateConfig.Json,
+				}
+
+				if err = s.Pull(name, tag_to_pull, imagePullConfig); err != nil {
+					logrus.Errorf("Error pulling repository %s tag %s %s", name, tag_to_pull, err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (s *TagStore) checkRepository(r *registry.Session, out io.Writer, repository Repository, repoInfo *registry.RepositoryInfo, sf *streamformatter.StreamFormatter) ([]string, error) {
+	repoData, err := r.GetRepositoryData(repoInfo.RemoteName)
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP code: 404") {
+			return nil, fmt.Errorf("Error: image %s not found", repoInfo.RemoteName)
+		}
+		// Unexpected HTTP error
+		return nil, err
+	}
+
+	out.Write(sf.FormatStatus(repoInfo.CanonicalName, "Checking repository, registry V1"))
+
+	tags_to_pull := make([]string, 0, len(repository))
+
+	for tag, imgID := range repository {
+		if tag == "" {
+			continue
+		}
+
+		out.Write(sf.FormatProgress(repoInfo.CanonicalName, fmt.Sprintf("Checking for new version of image (%s)", tag), nil))
+		success := false
+		var err error
+		var is_outdated bool
+
+		for _, ep := range repoInfo.Index.Mirrors {
+			if is_outdated, err = s.checkImageID(r, out, imgID, tag, repoInfo.RemoteName, ep, repoData.Tokens, sf); err != nil {
+				// Don't report errors when pulling from mirrors.
+				logrus.Debugf("Error checking for new version of image (%s) in %s, mirror: %s, %s", tag, repoInfo.CanonicalName, ep, err)
+				continue
+			}
+			if is_outdated {
+				tags_to_pull = append(tags_to_pull, tag)
+			}
+			success = true
+			break
+		}
+		if !success {
+			for _, ep := range repoData.Endpoints {
+				if is_outdated, err = s.checkImageID(r, out, imgID, tag, repoInfo.RemoteName, ep, repoData.Tokens, sf); err != nil {
+					// It's not ideal that only the last error is returned, it would be better to concatenate the errors.
+					// As the error is also given to the output stream the user will see the error.
+					out.Write(sf.FormatProgress(stringid.TruncateID(imgID), fmt.Sprintf("Error checking for new version of image(%s) in %s, endpoint: %s, %s", tag, repoInfo.CanonicalName, ep, err), nil))
+					continue
+				}
+				if is_outdated {
+					tags_to_pull = append(tags_to_pull, tag)
+				}
+				success = true
+				break
+			}
+		}
+		out.Write(sf.FormatProgress(stringid.TruncateID(imgID), "Checking complete", nil))
+	}
+
+	return tags_to_pull, nil
+}
+
+func (s *TagStore) checkV2Repository(r *registry.Session, out io.Writer, repository Repository, repoInfo *registry.RepositoryInfo, sf *streamformatter.StreamFormatter) ([]string, error) {
+	endpoint, err := r.V2RegistryEndpoint(repoInfo.Index)
+	if err != nil {
+		if repoInfo.Index.Official {
+			logrus.Debugf("Unable to pull from V2 registry, falling back to v1: %s", err)
+			return nil, ErrV2RegistryUnavailable
+		}
+		return nil, fmt.Errorf("error getting registry endpoint: %s", err)
+	}
+
+	out.Write(sf.FormatStatus(repoInfo.CanonicalName, "Checking repository, registry V2"))
+	auth, err := r.GetV2Authorization(endpoint, repoInfo.RemoteName, true)
+	if err != nil {
+		return nil, fmt.Errorf("error getting authorization: %s", err)
+	}
+
+	var is_outdated bool
+	tags_to_pull := make([]string, 0, len(repository))
+
+	for tag, imgID := range repository {
+		if is_outdated, err = s.checkImageIDV2(r, out, imgID, tag, repoInfo, endpoint, auth, sf); err != nil {
+			logrus.Debugf("Error checking for new version of image (%s) in %s, mirror: %s, %s", tag, repoInfo.CanonicalName, endpoint, err)
+			continue
+		}
+		if is_outdated {
+			tags_to_pull = append(tags_to_pull, tag)
+		}
+	}
+	return tags_to_pull, nil
+}
+
+func (s *TagStore) checkImageID(r *registry.Session, out io.Writer, imgID, tag string, repository_name string, endpoint string, token []string, sf *streamformatter.StreamFormatter) (bool, error) {
+	remoteImgID, err := r.GetImageIDForTag(tag, repository_name, endpoint, token)
+	if err != nil {
+		return false, err
+	}
+
+	image_outdated := remoteImgID != imgID
+
+	if image_outdated {
+		out.Write(sf.FormatProgress(tag, fmt.Sprintf("Image is outdated, local id: %s, remote id: %s", imgID, remoteImgID), nil))
+	} else {
+		out.Write(sf.FormatProgress(tag, fmt.Sprintf("Image is up to date, id: %s", imgID), nil))
+	}
+
+	return image_outdated, nil
+}
+
+func (s *TagStore) checkImageIDV2(r *registry.Session, out io.Writer, imgID, tag string, repoInfo *registry.RepositoryInfo, endpoint *registry.Endpoint, auth *registry.RequestAuthorization, sf *streamformatter.StreamFormatter) (bool, error) {
+
+	logrus.Debugf("Checking tag version in V2 registry: %q", tag)
+
+	manifestBytes, manifestDigest, err := r.GetV2ImageManifest(endpoint, repoInfo.RemoteName, tag, auth)
+	if err != nil {
+		return false, err
+	}
+
+	// loadManifest ensures that the manifest payload has the expected digest
+	// if the tag is a digest reference.
+	manifest, verified, err := s.loadManifest(manifestBytes, manifestDigest, tag)
+	if err != nil {
+		return false, fmt.Errorf("error verifying manifest: %s", err)
+	}
+
+	if err := checkValidManifest(manifest); err != nil {
+		return false, err
+	}
+
+	if verified {
+		logrus.Printf("Image manifest for %s:%s has been verified", repoInfo.CanonicalName, tag)
+	}
+
+	for i := len(manifest.FSLayers) - 1; i >= 0; i-- {
+		var (
+			imgJSON = []byte(manifest.History[i].V1Compatibility)
+		)
+
+		img, err := image.NewImgJSON(imgJSON)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse json: %s", err)
+		}
+
+		// Check if it doesn't exist
+		if !s.graph.Exists(img.ID) {
+			out.Write(sf.FormatProgress(tag, fmt.Sprintf("Image is outdated, local id: %s, remote id: %s", imgID, img.ID), nil))
+			return true, nil
+		}
+	}
+
+	out.Write(sf.FormatProgress(tag, fmt.Sprintf("Image is up to date, id: %s", imgID), nil))
+	return false, nil
+}
+
+// this method matches a auth configuration to a server address or a url
+func (s *TagStore) ResolveAuthConfig(configs map[string]registry.AuthConfig, index *registry.IndexInfo) registry.AuthConfig {
+	configKey := index.GetAuthConfigKey()
+	// First try the happy case
+	if c, found := configs[configKey]; found || index.Official {
+		return c
+	}
+
+	convertToHostname := func(url string) string {
+		stripped := url
+		if strings.HasPrefix(url, "http://") {
+			stripped = strings.Replace(url, "http://", "", 1)
+		} else if strings.HasPrefix(url, "https://") {
+			stripped = strings.Replace(url, "https://", "", 1)
+		}
+
+		nameParts := strings.SplitN(stripped, "/", 2)
+
+		return nameParts[0]
+	}
+
+	// Maybe they have a legacy config file, we will iterate the keys converting
+	// them to the new format and testing
+	for registry, config := range configs {
+		if configKey == convertToHostname(registry) {
+			return config
+		}
+	}
+
+	// When all else fails, return an empty auth config
+	return registry.AuthConfig{}
+}

--- a/integration-cli/docker_cli_update_test.go
+++ b/integration-cli/docker_cli_update_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestUpdateDryRun(c *check.C) {
+	RunUpdateTest(s, c, true)
+}
+
+func (s *DockerSuite) TestUpdateWithPull(c *check.C) {
+	RunUpdateTest(s, c, false)
+}
+
+func RunUpdateTest(s *DockerSuite, c *check.C, dry_run bool) {
+	defer setupRegistry(c)()
+
+	name := "testupdateimage"
+	repoName := fmt.Sprintf("%v/dockercli/%s", privateRegistryURL, name)
+
+	oldName := repoName + ":old"
+
+	defer deleteImages(repoName, oldName)
+
+	//build version 1 ("old" version)
+	_, err := buildImage(oldName, `FROM busybox
+RUN echo "A"`, true)
+
+	if err != nil {
+		c.Fatal("Error building image", err)
+	}
+
+	//build version 2 ("latest" version)
+	_, err = buildImage(repoName, `FROM busybox
+RUN echo "A"
+RUN echo "B"`, true)
+
+	if err != nil {
+		c.Fatal("Error building image", err)
+	}
+
+	//push the latest version to repo, and delete local copy
+	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "push", repoName)); err != nil {
+		c.Fatalf("pushing the image to the private registry has failed: %s, %v", out, err)
+	}
+
+	deleteImages(repoName)
+
+	//mark the old version as latest
+	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "tag", oldName, repoName)); err != nil {
+		c.Fatalf("Failed to tag image %v: error %v, output %q", repoName, err, out)
+	}
+
+	//now do the update
+	if dry_run {
+		out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "update", "--dry-run"))
+		if err != nil {
+			c.Fatalf("update command failed: %s, %v", out, err)
+		}
+	} else {
+		out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "update"))
+		if err != nil {
+			c.Fatalf("update command failed: %s, %v", out, err)
+		}
+	}
+
+	//get the list of local images and check wheter update had any effect
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "images"))
+	if err != nil {
+		c.Fatalf("Failed to get list of images: %s, %v", out, err)
+	}
+
+	match1 := regexp.MustCompile("dockercli/testupdateimage\\s+latest\\s+([a-z0-9]+)\\s").FindAllStringSubmatch(out, -1)
+	match2 := regexp.MustCompile("dockercli/testupdateimage\\s+old\\s+([a-z0-9]+)\\s").FindAllStringSubmatch(out, -1)
+
+	if len(match1) < 1 || len(match2) < 1 || len(match1[0]) < 2 || len(match2[0]) < 2 {
+		c.Fatalf("Images to update are not present in the list")
+	}
+
+	if dry_run {
+		if match1[0][1] != match2[0][1] {
+			//the latest should be the same as old (since we didn't pull)
+			c.Fatalf("Update ignored --dry-run paramater")
+		}
+	} else {
+		if match1[0][1] == match2[0][1] {
+			//the latest should be different from the old (since we pulled)
+			c.Fatalf("Update didn't pull the latest version")
+		}
+	}
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -167,6 +167,16 @@ func TestEndpoint(t *testing.T) {
 	}
 }
 
+func TestGetRemoteIDForTag(t *testing.T) {
+	r := spawnTestRegistrySession(t)
+	imgID, err := r.GetImageIDForTag("latest", REPO, makeURL("/v1/"), token)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEqual(t, imgID, "42d718c941f5c532ac049bf0b0ab53f0062f09a03afd4aa4a02c098e46032b9d",
+		"Unexpected image ID")
+}
+
 func TestGetRemoteHistory(t *testing.T) {
 	r := spawnTestRegistrySession(t)
 	hist, err := r.GetRemoteHistory(imageID, makeURL("/v1/"), token)


### PR DESCRIPTION
**Adds update command to Docker. Fixes #4239**

Docker update command works in two modes. By default, it checks for outdated images, prints them and performs a pull. If run with --dry-run (-d), the pull doesn't happen.

I'd be glad to know:
- if there's any intrest for such commnad to be part of Docker
- if the implementation is correct (code-wise)
- If the produced output is OK ( maybe less human friendly more machine friendly?)

There's an integration test fot the cli and unit test for GetImageIDForTag (which is used to check IDs in v1 registries). Docs are currently, but I would like to get it reviewed anyway. Thanks for any feedback. (My first PR for Docker)
Signed-off-by: Vladimir Jurenka jurenka@jurenka.skenka jurenka@jurenka.sk
