### PR TITLE
delete "defer deleteContainer" on tests

### DIFF
--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -140,7 +140,6 @@ func (s *DockerSuite) TestCreateByDigest(c *check.C) {
 	if err != nil {
 		c.Fatalf("error creating by digest: %s, %v", out, err)
 	}
-	defer deleteContainer(containerName)
 
 	res, err := inspectField(containerName, "Config.Image")
 	if err != nil {
@@ -168,7 +167,6 @@ func (s *DockerSuite) TestRunByDigest(c *check.C) {
 	if err != nil {
 		c.Fatalf("error run by digest: %s, %v", out, err)
 	}
-	defer deleteContainer(containerName)
 
 	foundRegex := regexp.MustCompile("found=([^\n]+)")
 	matches := foundRegex.FindStringSubmatch(out)

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -32,7 +32,6 @@ func (s *DockerSuite) TestCpGarbagePath(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	out, _ = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
@@ -90,7 +89,6 @@ func (s *DockerSuite) TestCpRelativePath(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	out, _ = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
@@ -156,7 +154,6 @@ func (s *DockerSuite) TestCpAbsolutePath(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	out, _ = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
@@ -216,7 +213,6 @@ func (s *DockerSuite) TestCpAbsoluteSymlink(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	out, _ = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
@@ -276,7 +272,6 @@ func (s *DockerSuite) TestCpSymlinkComponent(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	out, _ = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
@@ -337,7 +332,6 @@ func (s *DockerSuite) TestCpUnprivilegedUser(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	out, _ = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
@@ -379,7 +373,6 @@ func (s *DockerSuite) TestCpSpecialFiles(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	out, _ = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
@@ -525,7 +518,6 @@ func (s *DockerSuite) TestCpToDot(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	out, _ = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
@@ -559,7 +551,6 @@ func (s *DockerSuite) TestCpToStdout(c *check.C) {
 	}
 
 	cID := strings.TrimSpace(out)
-	defer deleteContainer(cID)
 
 	out, _ = dockerCmd(c, "wait", cID)
 	if strings.TrimSpace(out) != "0" {
@@ -588,7 +579,6 @@ func (s *DockerSuite) TestCpNameHasColon(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	out, _ = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {

--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -13,7 +13,6 @@ func (s *DockerSuite) TestExportContainerAndImportImage(c *check.C) {
 	containerID := "testexportcontainerandimportimage"
 
 	defer deleteImages("repo/testexp:v1")
-	defer deleteContainer(containerID)
 
 	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", containerID, "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
@@ -53,7 +52,6 @@ func (s *DockerSuite) TestExportContainerWithOutputAndImportImage(c *check.C) {
 	containerID := "testexportcontainerwithoutputandimportimage"
 
 	defer deleteImages("repo/testexp:v1")
-	defer deleteContainer(containerID)
 
 	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", containerID, "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -85,7 +85,6 @@ func (s *DockerSuite) TestHistoryNonExistentImage(c *check.C) {
 
 func (s *DockerSuite) TestHistoryImageWithComment(c *check.C) {
 	name := "testhistoryimagewithcomment"
-	defer deleteContainer(name)
 	defer deleteImages(name)
 
 	// make a image through docker commit <container id> [ -m messages ]

--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -14,7 +14,6 @@ func (s *DockerSuite) TestImportDisplay(c *check.C) {
 		c.Fatal("failed to create a container", out, err)
 	}
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	out, _, err = runCommandPipelineWithOutput(
 		exec.Command(dockerBinary, "export", cleanedContainerID),

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -287,7 +287,6 @@ func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	stopSlowRead := make(chan bool)
 

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -216,7 +216,6 @@ func (s *DockerSuite) TestSaveAndLoadRepoFlags(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	repoName := "foobar-save-load-test"
 
@@ -298,7 +297,6 @@ func (s *DockerSuite) TestSaveRepoWithMultipleImages(c *check.C) {
 			c.Fatalf("failed to create a container: %v %v", out, err)
 		}
 		cleanedContainerID := strings.TrimSpace(out)
-		defer deleteContainer(cleanedContainerID)
 
 		commitCmd := exec.Command(dockerBinary, "commit", cleanedContainerID, tag)
 		if out, _, err = runCommandWithOutput(commitCmd); err != nil {

--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -15,7 +15,6 @@ func (s *DockerSuite) TestTopMultipleArgs(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-	defer deleteContainer(cleanedContainerID)
 
 	topCmd := exec.Command(dockerBinary, "top", cleanedContainerID, "-o", "pid")
 	out, _, err = runCommandWithOutput(topCmd)


### PR DESCRIPTION
Since docker test suite is now using gocheck, `defer
deleteContainer(…)` is not needed anymore.

Fixes #12705

Signed-off-by: Vincent Demeester vincent@sbr.pm
