### PR TITLE
Don't split log writes by line

### DIFF
--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -42,17 +42,15 @@ func (l *TestLoggerText) Name() string {
 }
 
 func TestCopier(t *testing.T) {
-	stdoutLine := "Line that thinks that it is log line from docker stdout"
-	stderrLine := "Line that thinks that it is log line from docker stderr"
+	stdoutLine := "Line that thinks that it \n is log line from docker stdout"
+	stderrLine := "Line that thinks that it \n is log line from docker stderr"
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	for i := 0; i < 30; i++ {
-		if _, err := stdout.WriteString(stdoutLine + "\n"); err != nil {
-			t.Fatal(err)
-		}
-		if _, err := stderr.WriteString(stderrLine + "\n"); err != nil {
-			t.Fatal(err)
-		}
+	if _, err := stdout.WriteString(stdoutLine); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stderr.WriteString(stderrLine); err != nil {
+		t.Fatal(err)
 	}
 
 	var jsonBuf bytes.Buffer


### PR DESCRIPTION
I want to use this PR to discuss the current behaviour and suggest a different one.

Currently, if a Docker container logs a multi-line message in a single `write()` (e.g. `echo -en "foo\nbar\n"`), the copier splits those messages into lines, such that the log driver will receive one call to `Log()` per line (rather than one call to `Log()` per write that the container did). That behaviour somewhat breaks multi-line logging.

For a bit of context: We are playing around with implementing a Kafka logging driver for Docker (someone from the core team encouraged that and said other people might be interested) and we would like to send one Kafka message per "log event". Splitting the output of the container into lines would result in us sending multiple Kafka messages.

Thoughts?

@LK4D4 @crosbymichael @sirupsen @graemej
