### PR TITLE
Remove empty line after client.CmdInspect docstring#12706

### DIFF
--- a/api/client/inspect.go
+++ b/api/client/inspect.go
@@ -13,7 +13,6 @@ import (
 )
 
 // CmdInspect displays low-level information on one or more containers or images.
-//
 // Usage: docker inspect [OPTIONS] CONTAINER|IMAGE [CONTAINER|IMAGE...]
 
 func (cli *DockerCli) CmdInspect(args ...string) error {


### PR DESCRIPTION
fix #12706
Signed-off-by: Daniel Zhang jmzwcn@gmail.com
