### PR TITLE
 Remove empty line after client.CmdInspect docstring

### DIFF
--- a/api/client/inspect.go
+++ b/api/client/inspect.go
@@ -15,7 +15,6 @@ import (
 // CmdInspect displays low-level information on one or more containers or images.
 //
 // Usage: docker inspect [OPTIONS] CONTAINER|IMAGE [CONTAINER|IMAGE...]
-
 func (cli *DockerCli) CmdInspect(args ...string) error {
 	cmd := cli.Subcmd("inspect", "CONTAINER|IMAGE [CONTAINER|IMAGE...]", "Return low-level information on a container or image", true)
 	tmplStr := cmd.String([]string{"f", "#format", "-format"}, "", "Format the output using the given go template")


### PR DESCRIPTION
fix #12706 
Signed-off-by: Daniel Zhang jmzwcn@gmail.com
