### PR TITLE
Add device deny option

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -337,7 +337,7 @@ func populateCommand(c *Container, env []string) error {
 
 	// Build lists of devices allowed and created within the container.
 	var userSpecifiedDevices []*configs.Device
-	for _, deviceMapping := range c.hostConfig.Devices {
+	for _, deviceMapping := range c.hostConfig.AllowedDevices {
 		devs, err := getDevicesFromPath(deviceMapping)
 		if err != nil {
 			return err
@@ -346,6 +346,16 @@ func populateCommand(c *Container, env []string) error {
 		userSpecifiedDevices = append(userSpecifiedDevices, devs...)
 	}
 	allowedDevices := append(configs.DefaultAllowedDevices, userSpecifiedDevices...)
+
+	var deniedDevices []*configs.Device
+	for _, deviceMapping := range c.hostConfig.DeniedDevices {
+		devs, err := getDevicesFromPath(deviceMapping)
+		if err != nil {
+			return err
+		}
+
+		deniedDevices = append(deniedDevices, devs...)
+	}
 
 	autoCreatedDevices := append(configs.DefaultAutoCreatedDevices, userSpecifiedDevices...)
 
@@ -412,6 +422,7 @@ func populateCommand(c *Container, env []string) error {
 		Pid:                pid,
 		Resources:          resources,
 		AllowedDevices:     allowedDevices,
+		DeniedDevices:      deniedDevices,
 		AutoCreatedDevices: autoCreatedDevices,
 		CapAdd:             c.hostConfig.CapAdd,
 		CapDrop:            c.hostConfig.CapDrop,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1140,6 +1140,16 @@ func (daemon *Daemon) verifyHostConfig(hostConfig *runconfig.HostConfig) ([]stri
 	if hostConfig.LxcConf.Len() > 0 && !strings.Contains(daemon.ExecutionDriver().Name(), "lxc") {
 		return warnings, fmt.Errorf("Cannot use --lxc-conf with execdriver: %s", daemon.ExecutionDriver().Name())
 	}
+	if len(hostConfig.DeniedDevices) > 0 && hostConfig.Privileged != true {
+		return warnings, fmt.Errorf("--device-deny should be used with --privileged")
+	}
+	if len(hostConfig.DeniedDevices) > 0 && len(hostConfig.AllowedDevices) > 0 {
+		return warnings, fmt.Errorf("--device-allow and --device-deny Can not be used together")
+	}
+	if len(hostConfig.AllowedDevices) > 0 && hostConfig.Privileged == true {
+		warnings = append(warnings, "The container hast got privilege. --device-allow will be discarded.")
+		hostConfig.AllowedDevices = []runconfig.DeviceMapping{}
+	}
 	if hostConfig.Memory != 0 && hostConfig.Memory < 4194304 {
 		return warnings, fmt.Errorf("Minimum memory limit allowed is 4MB")
 	}

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -158,6 +158,7 @@ type Command struct {
 	Resources          *Resources        `json:"resources"`
 	Mounts             []Mount           `json:"mounts"`
 	AllowedDevices     []*configs.Device `json:"allowed_devices"`
+	DeniedDevices      []*configs.Device `json:"denied_devices"`
 	AutoCreatedDevices []*configs.Device `json:"autocreated_devices"`
 	CapAdd             []string          `json:"cap_add"`
 	CapDrop            []string          `json:"cap_drop"`

--- a/daemon/execdriver/driver_linux.go
+++ b/daemon/execdriver/driver_linux.go
@@ -21,6 +21,7 @@ func InitContainer(c *Command) *configs.Config {
 	container.Hostname = getEnv("HOSTNAME", c.ProcessConfig.Env)
 	container.Cgroups.Name = c.ID
 	container.Cgroups.AllowedDevices = c.AllowedDevices
+	container.Cgroups.DeniedDevices = c.DeniedDevices
 	container.Devices = c.AutoCreatedDevices
 	container.Rootfs = c.Rootfs
 	container.Readonlyfs = c.ReadonlyRootfs

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -17,7 +17,8 @@ docker-create - Create a new container
 [**--cpuset-cpus**[=*CPUSET-CPUS*]]
 [**--cpuset-mems**[=*CPUSET-MEMS*]]
 [**--cpu-quota**[=*0*]]
-[**--device**[=*[]*]]
+[**--device-allow**[=*[]*]]
+[**--device-deny**[=*[]*]]
 [**--dns-search**[=*[]*]]
 [**--dns**[=*[]*]]
 [**-e**|**--env**[=*[]*]]
@@ -95,8 +96,11 @@ two memory nodes.
 **-cpu-quota**=0
    Limit the CPU CFS (Completely Fair Scheduler) quota
 
-**--device**=[]
-   Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc:rwm)
+**--device-allow**=[]
+   Allow the container to access a host device (e.g. --device-allow=/dev/sdc:/dev/xvdc:rwm)
+
+**--device-deny**=[]
+   Deny the container to access a host device (e.g. --device-deny=/dev/sdc:/dev/sdc:rwm)
 
 **--dns-search**=[]
    Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -18,7 +18,8 @@ docker-run - Run a command in a new container
 [**--cpuset-mems**[=*CPUSET-MEMS*]]
 [**-d**|**--detach**[=*false*]]
 [**--cpu-quota**[=*0*]]
-[**--device**[=*[]*]]
+[**--device-allow**[=*[]*]]
+[**--device-deny**[=*[]*]]
 [**--dns-search**[=*[]*]]
 [**--dns**[=*[]*]]
 [**-e**|**--env**[=*[]*]]
@@ -172,8 +173,11 @@ the detached mode, then you cannot use the **-rm** option.
    When attached in the tty mode, you can detach from a running container without
 stopping the process by pressing the keys CTRL-P CTRL-Q.
 
-**--device**=[]
-   Add a host device to the container (e.g. --device=/dev/sdc:/dev/xvdc:rwm)
+**--device-allow**=[]
+   Allow the container to access  a host device (e.g. --device-allow=/dev/sdc:/dev/xvdc:rwm)
+
+**--device-deny**=[]
+   Deny the container to access a host device (e.g. --device-deny=/dev/sdc:/dev/sdc:rwm)
 
 **--dns-search**=[]
    Set custom DNS search domains (Use --dns-search=. if you don't wish to set the search domain)

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -968,7 +968,8 @@ Creates a new container.
       --cpuset-mems=""           Memory nodes (MEMs) in which to allow execution (0-3, 0,1)
       --cpu-period=0             Limit the CPU CFS (Completely Fair Scheduler) period
       --cpu-quota=0              Limit the CPU CFS (Completely Fair Scheduler) quota
-      --device=[]                Add a host device to the container
+      --device-allow=[]          Allow the container to access a host device
+      --device-deny=[]           Deny the container to access a host device
       --dns=[]                   Set custom DNS servers
       --dns-search=[]            Set custom DNS search domains
       -e, --env=[]               Set environment variables
@@ -1927,7 +1928,8 @@ To remove an image using its digest:
       --cpu-period=0             Limit the CPU CFS (Completely Fair Scheduler) period
       --cpu-quota=0              Limit the CPU CFS (Completely Fair Scheduler) quota
       -d, --detach=false         Run container in background and print container ID
-      --device=[]                Add a host device to the container
+      --device-allow=[]          Allow the container to access a host device
+      --device-deny=[]           Deny the container to access a host device
       --dns=[]                   Set custom DNS servers
       --dns-search=[]            Set custom DNS search domains
       -e, --env=[]               Set environment variables
@@ -2194,41 +2196,41 @@ logs could be retrieved using `docker logs`. This is
 useful if you need to pipe a file or something else into a container and
 retrieve the container's ID once the container has finished running.
 
-   $ docker run --device=/dev/sdc:/dev/xvdc --device=/dev/sdd --device=/dev/zero:/dev/nulo -i -t ubuntu ls -l /dev/{xvdc,sdd,nulo}
+   $ docker run --device-allow=/dev/sdc:/dev/xvdc --device-allow=/dev/sdd --device-allow=/dev/zero:/dev/nulo -i -t ubuntu ls -l /dev/{xvdc,sdd,nulo}
    brw-rw---- 1 root disk 8, 2 Feb  9 16:05 /dev/xvdc
    brw-rw---- 1 root disk 8, 3 Feb  9 16:05 /dev/sdd
    crw-rw-rw- 1 root root 1, 5 Feb  9 16:05 /dev/nulo
 
-It is often necessary to directly expose devices to a container. The `--device`
+It is often necessary to directly expose devices to a container. The `--device-allow`
 option enables that.  For example, a specific block storage device or loop
 device or audio device can be added to an otherwise unprivileged container
 (without the `--privileged` flag) and have the application directly access it.
 
 By default, the container will be able to `read`, `write` and `mknod` these devices.
-This can be overridden using a third `:rwm` set of options to each `--device`
+This can be overridden using a third `:rwm` set of options to each `--device-allow`
 flag:
 
 
 ```
-	$ docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
+	$ docker run --device-allow=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
 
 	Command (m for help): q
-	$ docker run --device=/dev/sda:/dev/xvdc:r --rm -it ubuntu fdisk  /dev/xvdc
+	$ docker run --device-allow=/dev/sda:/dev/xvdc:r --rm -it ubuntu fdisk  /dev/xvdc
 	You will not be able to write the partition table.
 
 	Command (m for help): q
 
-	$ docker run --device=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
+	$ docker run --device-allow=/dev/sda:/dev/xvdc --rm -it ubuntu fdisk  /dev/xvdc
 
 	Command (m for help): q
 
-	$ docker run --device=/dev/sda:/dev/xvdc:m --rm -it ubuntu fdisk  /dev/xvdc
+	$ docker run --device-allow=/dev/sda:/dev/xvdc:m --rm -it ubuntu fdisk  /dev/xvdc
 	fdisk: unable to open /dev/xvdc: Operation not permitted
 ```
 
 > **Note:**
-> `--device` cannot be safely used with ephemeral devices. Block devices that
-> may be removed should not be added to untrusted containers with `--device`.
+> `--device-allow` cannot be safely used with ephemeral devices. Block devices that
+> may be removed should not be added to untrusted containers with `--device-allow`.
 
 **A complete example:**
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1258,7 +1258,7 @@ func (s *DockerSuite) TestRunUnprivilegedWithChroot(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunAddingOptionalDevices(c *check.C) {
-	cmd := exec.Command(dockerBinary, "run", "--device", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "ls /dev/nulo")
+	cmd := exec.Command(dockerBinary, "run", "--device-allow", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "ls /dev/nulo")
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
 		c.Fatal(err, out)
@@ -1266,6 +1266,19 @@ func (s *DockerSuite) TestRunAddingOptionalDevices(c *check.C) {
 
 	if actual := strings.Trim(out, "\r\n"); actual != "/dev/nulo" {
 		c.Fatalf("expected output /dev/nulo, received %s", actual)
+	}
+}
+
+func (s *DockerSuite) TestRunDenyingOptionalDevices(c *check.C) {
+	cmd := exec.Command(dockerBinary, "run", "--privileged", "--device-deny", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "echo hello > /dev/nulo")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(err, out)
+	}
+
+	out = strings.Trim(out, "\r\n")
+	if !strings.Contains(out, "Permission denied") {
+		c.Fatalf("expected output Permission denied, received %s", out)
 	}
 }
 
@@ -2046,7 +2059,7 @@ func (s *DockerSuite) TestRunWriteResolvFileAndNotCommit(c *check.C) {
 
 func (s *DockerSuite) TestRunWithBadDevice(c *check.C) {
 	name := "baddevice"
-	cmd := exec.Command(dockerBinary, "run", "--name", name, "--device", "/etc", "busybox", "true")
+	cmd := exec.Command(dockerBinary, "run", "--name", name, "--device-allow", "/etc", "busybox", "true")
 	out, _, err := runCommandWithOutput(cmd)
 	if err == nil {
 		c.Fatal("Run should fail with bad device")

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1272,13 +1272,13 @@ func (s *DockerSuite) TestRunAddingOptionalDevices(c *check.C) {
 func (s *DockerSuite) TestRunDenyingOptionalDevices(c *check.C) {
 	cmd := exec.Command(dockerBinary, "run", "--privileged", "--device-deny", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "echo hello > /dev/nulo")
 	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(err, out)
+	if err == nil {
+		c.Fatal("expected error, but successed")
 	}
 
 	out = strings.Trim(out, "\r\n")
-	if !strings.Contains(out, "Permission denied") {
-		c.Fatalf("expected output Permission denied, received %s", out)
+	if !strings.Contains(out, "operation not permitted") {
+		c.Fatalf("expected output operation not permitted, received %s", out)
 	}
 }
 

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -161,7 +161,7 @@ func (s *DockerSuite) TestRunContainerWithCgroupParentAbsPath(c *check.C) {
 
 func (s *DockerSuite) TestRunDeviceDirectory(c *check.C) {
 	testRequires(c, NativeExecDriver)
-	cmd := exec.Command(dockerBinary, "run", "--device", "/dev/snd:/dev/snd", "busybox", "sh", "-c", "ls /dev/snd/")
+	cmd := exec.Command(dockerBinary, "run", "--device-allow", "/dev/snd:/dev/snd", "busybox", "sh", "-c", "ls /dev/snd/")
 
 	out, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -172,7 +172,7 @@ func (s *DockerSuite) TestRunDeviceDirectory(c *check.C) {
 		c.Fatalf("expected output /dev/snd/timer, received %s", actual)
 	}
 
-	cmd = exec.Command(dockerBinary, "run", "--device", "/dev/snd:/dev/othersnd", "busybox", "sh", "-c", "ls /dev/othersnd/")
+	cmd = exec.Command(dockerBinary, "run", "--device-allow", "/dev/snd:/dev/othersnd", "busybox", "sh", "-c", "ls /dev/othersnd/")
 
 	out, _, err = runCommandWithOutput(cmd)
 	if err != nil {

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -183,7 +183,8 @@ type HostConfig struct {
 	DnsSearch       []string
 	ExtraHosts      []string
 	VolumesFrom     []string
-	Devices         []DeviceMapping
+	AllowedDevices  []DeviceMapping
+	DeniedDevices   []DeviceMapping
 	NetworkMode     NetworkMode
 	IpcMode         IpcMode
 	PidMode         PidMode


### PR DESCRIPTION
With this PR, we can use blacklist to control which host device the container can access.
For example:
docker run --privileged -it--device-deny=/dev/sda8:/dev/sda8:rm ubuntu:14.04 /bin/bash
