### PR TITLE
Support INCLUDE in Dockerfiles

### DIFF
--- a/builder/dockerfile/command/command.go
+++ b/builder/dockerfile/command/command.go
@@ -12,6 +12,7 @@ const (
 	Expose      = "expose"
 	From        = "from"
 	Healthcheck = "healthcheck"
+	Include     = "include"
 	Label       = "label"
 	Maintainer  = "maintainer"
 	Onbuild     = "onbuild"
@@ -34,6 +35,7 @@ var Commands = map[string]struct{}{
 	Expose:      {},
 	From:        {},
 	Healthcheck: {},
+	Include:     {},
 	Label:       {},
 	Maintainer:  {},
 	Onbuild:     {},

--- a/builder/dockerfile/evaluator.go
+++ b/builder/dockerfile/evaluator.go
@@ -31,6 +31,7 @@ import (
 
 // Environment variable interpolation will happen on these statements only.
 var replaceEnvAllowed = map[string]bool{
+	command.Include:    true,
 	command.Env:        true,
 	command.Label:      true,
 	command.Add:        true,
@@ -69,6 +70,7 @@ func init() {
 		command.Expose:      expose,
 		command.From:        from,
 		command.Healthcheck: healthcheck,
+		command.Include:     include,
 		command.Label:       label,
 		command.Maintainer:  maintainer,
 		command.Onbuild:     onbuild,

--- a/builder/dockerfile/parser/parser.go
+++ b/builder/dockerfile/parser/parser.go
@@ -82,6 +82,7 @@ func init() {
 		command.Expose:      parseStringsWhitespaceDelimited,
 		command.From:        parseString,
 		command.Healthcheck: parseHealthConfig,
+		command.Include:     parseString,
 		command.Label:       parseLabel,
 		command.Maintainer:  parseString,
 		command.Onbuild:     parseSubCommand,

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -361,6 +361,7 @@ the `Dockerfile`:
 * `WORKDIR`
 * `VOLUME`
 * `STOPSIGNAL`
+* `INCLUDE`
 
 as well as:
 
@@ -1747,6 +1748,15 @@ The `SHELL` instruction can also be used on Linux should an alternate shell be
 required such as `zsh`, `csh`, `tcsh` and others.
 
 The `SHELL` feature was added in Docker 1.12.
+
+## INCLUDE
+
+    INCLUDE path/to/file
+
+The `INCLUDE` instruction tells the `Dockerfile` parser to read in the
+specified file and process its contents before continuing with the current
+file. All commands in the referenced file will be processed as if they
+were included as part of the current file.
 
 ## Dockerfile examples
 


### PR DESCRIPTION
Note that as of now this is just a syntax feature. Meaning it just pulls
in the included Dockerfile and continues parsing. If the target Dockerfile
has a FROM then it is processed and new image will be created.

Once moby/moby#10775 is merged, I'd like to add a flag like:
   INCLUDE --no-from ...
which will tell it to skip the FROM so that the modifications will be done
within the same/current image.

Also, note that you can do:  INLCUDE myfile.${foo}

Closes: moby/moby#735 

also relates to https://github.com/docker/docker/issues/3378

Signed-off-by: Doug Davis dug@us.ibm.com