### PR TITLE
Windows: Split ContainerExecCreate

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/execdriver"
-	"github.com/docker/docker/daemon/execdriver/lxc"
 	"github.com/docker/docker/pkg/broadcastwriter"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/promise"
@@ -112,8 +111,9 @@ func (d *Daemon) getActiveContainer(name string) (*Container, error) {
 
 func (d *Daemon) ContainerExecCreate(config *runconfig.ExecConfig) (string, error) {
 
-	if strings.HasPrefix(d.execDriver.Name(), lxc.DriverName) {
-		return "", lxc.ErrExec
+	// On Windows, this check will always pass
+	if lxccheck := lxcCheck(d.execDriver.Name()); lxccheck != nil {
+		return "", lxccheck
 	}
 
 	container, err := d.getActiveContainer(config.Container)

--- a/daemon/exec_linux.go
+++ b/daemon/exec_linux.go
@@ -1,0 +1,16 @@
+// +build linux
+
+package daemon
+
+import (
+	"strings"
+
+	"github.com/docker/docker/daemon/execdriver/lxc"
+)
+
+func lxcCheck(drivername string) error {
+	if strings.HasPrefix(drivername, lxc.DriverName) {
+		return lxc.ErrExec
+	}
+	return nil
+}

--- a/daemon/exec_windows.go
+++ b/daemon/exec_windows.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package daemon
+
+func lxcCheck(DriverName string) error {
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This refactors the ContainerExecCreate call so that the Windows version does not have a dependency on LXC.

REOPENED in #12978
