### PR TITLE
Implement DockerRegistrySuite in integration-cli

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -24,6 +24,10 @@ func (s *TimerSuite) TearDownTest(c *check.C) {
 	fmt.Printf("%-60s%.2f\n", c.TestName(), time.Since(s.start).Seconds())
 }
 
+func init() {
+	check.Suite(&DockerSuite{})
+}
+
 type DockerSuite struct {
 	TimerSuite
 }
@@ -34,4 +38,23 @@ func (s *DockerSuite) TearDownTest(c *check.C) {
 	s.TimerSuite.TearDownTest(c)
 }
 
-var _ = check.Suite(&DockerSuite{})
+func init() {
+	check.Suite(&DockerRegistrySuite{
+		ds: &DockerSuite{},
+	})
+}
+
+type DockerRegistrySuite struct {
+	ds  *DockerSuite
+	reg *testRegistryV2
+}
+
+func (s *DockerRegistrySuite) SetUpTest(c *check.C) {
+	s.reg = setupRegistry(c)
+	s.ds.SetUpTest(c)
+}
+
+func (s *DockerRegistrySuite) TearDownTest(c *check.C) {
+	s.reg.Close()
+	s.ds.TearDownTest(c)
+}

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -62,9 +62,7 @@ func setupImageWithTag(tag string) (string, error) {
 	return pushDigest, nil
 }
 
-func (s *DockerSuite) TestPullByTagDisplaysDigest(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestPullByTagDisplaysDigest(c *check.C) {
 	pushDigest, err := setupImage()
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
@@ -88,12 +86,9 @@ func (s *DockerSuite) TestPullByTagDisplaysDigest(c *check.C) {
 	if pushDigest != pullDigest {
 		c.Fatalf("push digest %q didn't match pull digest %q", pushDigest, pullDigest)
 	}
-
 }
 
-func (s *DockerSuite) TestPullByDigest(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestPullByDigest(c *check.C) {
 	pushDigest, err := setupImage()
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
@@ -118,12 +113,9 @@ func (s *DockerSuite) TestPullByDigest(c *check.C) {
 	if pushDigest != pullDigest {
 		c.Fatalf("push digest %q didn't match pull digest %q", pushDigest, pullDigest)
 	}
-
 }
 
-func (s *DockerSuite) TestCreateByDigest(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestCreateByDigest(c *check.C) {
 	pushDigest, err := setupImage()
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
@@ -145,12 +137,9 @@ func (s *DockerSuite) TestCreateByDigest(c *check.C) {
 	if res != imageReference {
 		c.Fatalf("unexpected Config.Image: %s (expected %s)", res, imageReference)
 	}
-
 }
 
-func (s *DockerSuite) TestRunByDigest(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestRunByDigest(c *check.C) {
 	pushDigest, err := setupImage()
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
@@ -181,12 +170,9 @@ func (s *DockerSuite) TestRunByDigest(c *check.C) {
 	if res != imageReference {
 		c.Fatalf("unexpected Config.Image: %s (expected %s)", res, imageReference)
 	}
-
 }
 
-func (s *DockerSuite) TestRemoveImageByDigest(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestRemoveImageByDigest(c *check.C) {
 	digest, err := setupImage()
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
@@ -217,12 +203,9 @@ func (s *DockerSuite) TestRemoveImageByDigest(c *check.C) {
 	} else if !strings.Contains(err.Error(), "No such image") {
 		c.Fatalf("expected 'No such image' output, got %v", err)
 	}
-
 }
 
-func (s *DockerSuite) TestBuildByDigest(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestBuildByDigest(c *check.C) {
 	digest, err := setupImage()
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
@@ -262,12 +245,9 @@ func (s *DockerSuite) TestBuildByDigest(c *check.C) {
 	if res != imageID {
 		c.Fatalf("Image %s, expected %s", res, imageID)
 	}
-
 }
 
-func (s *DockerSuite) TestTagByDigest(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestTagByDigest(c *check.C) {
 	digest, err := setupImage()
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
@@ -302,12 +282,9 @@ func (s *DockerSuite) TestTagByDigest(c *check.C) {
 	if tagID != expectedID {
 		c.Fatalf("expected image id %q, got %q", expectedID, tagID)
 	}
-
 }
 
-func (s *DockerSuite) TestListImagesWithoutDigests(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestListImagesWithoutDigests(c *check.C) {
 	digest, err := setupImage()
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
@@ -334,8 +311,7 @@ func (s *DockerSuite) TestListImagesWithoutDigests(c *check.C) {
 
 }
 
-func (s *DockerSuite) TestListImagesWithDigests(c *check.C) {
-	defer setupRegistry(c)()
+func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 
 	// setup image1
 	digest1, err := setupImageWithTag("tag1")
@@ -482,12 +458,9 @@ func (s *DockerSuite) TestListImagesWithDigests(c *check.C) {
 	if !busyboxRe.MatchString(out) {
 		c.Fatalf("expected %q: %s", busyboxRe.String(), out)
 	}
-
 }
 
-func (s *DockerSuite) TestDeleteImageByIDOnlyPulledByDigest(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestDeleteImageByIDOnlyPulledByDigest(c *check.C) {
 	pushDigest, err := setupImage()
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
@@ -511,5 +484,4 @@ func (s *DockerSuite) TestDeleteImageByIDOnlyPulledByDigest(c *check.C) {
 	if _, err := runCommand(cmd); err != nil {
 		c.Fatalf("error deleting image by id: %v", err)
 	}
-
 }

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -9,9 +9,7 @@ import (
 )
 
 // See issue docker/docker#8141
-func (s *DockerSuite) TestPullImageWithAliases(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestPullImageWithAliases(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
 
 	repos := []string{}
@@ -48,7 +46,6 @@ func (s *DockerSuite) TestPullImageWithAliases(c *check.C) {
 			c.Fatalf("Image %v shouldn't have been pulled down", repo)
 		}
 	}
-
 }
 
 // pulling library/hello-world should show verified message

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -13,9 +13,7 @@ import (
 )
 
 // pulling an image from the central registry should work
-func (s *DockerSuite) TestPushBusyboxImage(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestPushBusyboxImage(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
 	// tag the image to upload it to the private registry
 	tagCmd := exec.Command(dockerBinary, "tag", "busybox", repoName)
@@ -37,9 +35,7 @@ func (s *DockerSuite) TestPushUnprefixedRepo(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestPushUntagged(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestPushUntagged(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
 
 	expected := "Repository does not exist"
@@ -51,9 +47,7 @@ func (s *DockerSuite) TestPushUntagged(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestPushBadTag(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestPushBadTag(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/busybox:latest", privateRegistryURL)
 
 	expected := "does not exist"
@@ -65,9 +59,7 @@ func (s *DockerSuite) TestPushBadTag(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestPushMultipleTags(c *check.C) {
-	defer setupRegistry(c)()
-
+func (s *DockerRegistrySuite) TestPushMultipleTags(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
 	repoTag1 := fmt.Sprintf("%v/dockercli/busybox:t1", privateRegistryURL)
 	repoTag2 := fmt.Sprintf("%v/dockercli/busybox:t2", privateRegistryURL)
@@ -87,8 +79,7 @@ func (s *DockerSuite) TestPushMultipleTags(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestPushInterrupt(c *check.C) {
-	defer setupRegistry(c)()
+func (s *DockerRegistrySuite) TestPushInterrupt(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/busybox", privateRegistryURL)
 	// tag the image and upload it to the private registry
 	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "tag", "busybox", repoName)); err != nil {
@@ -118,8 +109,7 @@ func (s *DockerSuite) TestPushInterrupt(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestPushEmptyLayer(c *check.C) {
-	defer setupRegistry(c)()
+func (s *DockerRegistrySuite) TestPushEmptyLayer(c *check.C) {
 	repoName := fmt.Sprintf("%v/dockercli/emptylayer", privateRegistryURL)
 	emptyTarball, err := ioutil.TempFile("", "empty_tarball")
 	if err != nil {

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -1125,7 +1125,7 @@ func daemonTime(c *check.C) time.Time {
 	return dt
 }
 
-func setupRegistry(c *check.C) func() {
+func setupRegistry(c *check.C) *testRegistryV2 {
 	testRequires(c, RegistryHosting)
 	reg, err := newTestRegistryV2(c)
 	if err != nil {
@@ -1143,8 +1143,7 @@ func setupRegistry(c *check.C) func() {
 	if err != nil {
 		c.Fatal("Timeout waiting for test registry to become available")
 	}
-
-	return func() { reg.Close() }
+	return reg
 }
 
 // appendBaseEnv appends the minimum set of environment variables to exec the


### PR DESCRIPTION
To avoid manually creating and destroying registrys in tests.
