### PR TITLE
Windows: Commit() rwTar defer close

### DIFF
--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -32,7 +32,11 @@ func (daemon *Daemon) Commit(container *Container, repository, tag, comment, aut
 	if err != nil {
 		return nil, err
 	}
-	defer rwTar.Close()
+	defer func() {
+		if rwTar != nil {
+			rwTar.Close()
+		}
+	}()
 
 	// Create a new image from the container's base layers + a new layer from container changes
 	var (


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This allows the in the Windows implementation rwTar returned from container.ExportRw() to be nil.
