### PR TITLE
Fix env with '=' is not available in linked containers. Fixes #12763

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -371,6 +371,23 @@ func (s *DockerSuite) TestRunLinkToContainerNetMode(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestRunLinkEnvironment(c *check.C) {
+	testRequires(c, ExecSupport)
+	cmd := exec.Command(dockerBinary, "run", "-id", "--name", "parent", "-e", "FOO=BAR=QUX", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(err, out)
+	}
+	cmd = exec.Command(dockerBinary, "run", "--link", "parent:parent", "busybox", "env")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(err, out)
+	}
+	if !strings.Contains(out, "PARENT_ENV_FOO=BAR=QUX") {
+		c.Fatal("Env with '=' sign should available in linked containers")
+	}
+}
+
 func (s *DockerSuite) TestRunModeNetContainerHostname(c *check.C) {
 	testRequires(c, ExecSupport)
 	cmd := exec.Command(dockerBinary, "run", "-i", "-d", "--name", "parent", "busybox", "top")

--- a/links/links.go
+++ b/links/links.go
@@ -107,8 +107,8 @@ func (l *Link) ToEnv() []string {
 
 	if l.ChildEnvironment != nil {
 		for _, v := range l.ChildEnvironment {
-			parts := strings.Split(v, "=")
-			if len(parts) != 2 {
+			parts := strings.SplitN(v, "=", 2)
+			if len(parts) < 2 {
 				continue
 			}
 			// Ignore a few variables that are added during docker build (and not really relevant to linked containers)


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Fixes #12763 
@duglin  Are you working on it? We just meet the same problem
and I have take a look at it and found the problem.
But if you have done, pls feel free to close this.
