### PR TITLE
Copy edits for typos

### DIFF
--- a/docs/sources/articles/b2d_volume_resize.md
+++ b/docs/sources/articles/b2d_volume_resize.md
@@ -60,7 +60,7 @@ You might need to create the bus before you can add the ISO.
 ## 5. Add the new VDI image 
 
 In the settings for the Boot2Docker image in VirtualBox, remove the VMDK image 
-from the SATA contoller and add the VDI image.
+from the SATA controller and add the VDI image.
 
 <img src="/articles/b2d_volume_images/add_volume.png">
 

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -576,7 +576,7 @@ As soon as the router wants to send an IPv6 packet to the first container it
 will transmit a neighbor solicitation request, asking, who has
 `2001:db8::c009`? But it will get no answer because noone on this subnet has
 this address. The container with this address is hidden behind the Docker host.
-The Docker host has to listen to neighbor solication requests for the container
+The Docker host has to listen to neighbor solicitation requests for the container
 address and send a response that itself is the device that is responsible for
 the address. This is done by a Kernel feature called `NDP Proxy`. You can
 enable it by executing

--- a/docs/sources/articles/puppet.md
+++ b/docs/sources/articles/puppet.md
@@ -1,5 +1,5 @@
 page_title: Using Puppet
-page_description: Installating and using Puppet
+page_description: Installing and using Puppet
 page_keywords: puppet, installation, usage, docker, documentation
 
 # Using Puppet

--- a/docs/sources/articles/security.md
+++ b/docs/sources/articles/security.md
@@ -249,7 +249,7 @@ may still be utilized by Docker containers on supported kernels,
 by directly using the clone syscall, or utilizing the 'unshare'
 utility. Using this, some users may find it possible to drop
 more capabilities from their process as user namespaces provide
-an artifical capabilities set. Likewise, however, this artifical
+an artificial capabilities set. Likewise, however, this artificial
 capabilities set may require use of 'capsh' to restrict the
 user-namespace capabilities set when using 'unshare'.
 

--- a/docs/sources/installation/SUSE.md
+++ b/docs/sources/installation/SUSE.md
@@ -8,7 +8,7 @@ Docker is available in **openSUSE 12.3 and later**. Please note that due
 to its current limitations Docker is able to run only **64 bit** architecture.
 
 Docker is not part of the official repositories of openSUSE 12.3 and
-openSUSE 13.1. Hence  it is neccessary to add the [Virtualization
+openSUSE 13.1. Hence  it is necessary to add the [Virtualization
 repository](https://build.opensuse.org/project/show/Virtualization) from
 [OBS](https://build.opensuse.org/) to install the `docker` package.
 

--- a/docs/sources/project/create-pr.md
+++ b/docs/sources/project/create-pr.md
@@ -77,7 +77,7 @@ Always rebase and squash your commits before making a pull request.
 
 		`git commit -s`
 
-		Make sure your message includes <a href="./set-up-git" target="_blank>your signature</a>.
+    Make sure your message includes <a href="./set-up-git" target="_blank>your signature</a>.
 
 7. Force push any changes to your fork on GitHub.
 

--- a/docs/sources/project/review-pr.md
+++ b/docs/sources/project/review-pr.md
@@ -14,7 +14,7 @@ work on Docker.  You need to understand and work with both the "bots" and the
 "beings" to review your contribution.
 
 
-## How we proces your review
+## How we process your review
 
 First to review your pull request is Gordon. Gordon is fast. He checks your
 pull request (PR) for common problems like a missing signature. If Gordon finds a

--- a/docs/sources/project/test-and-docs.md
+++ b/docs/sources/project/test-and-docs.md
@@ -40,7 +40,7 @@ units each have unit tests and then, together, integration tests that test the
 interface between the components. The `integration` and `integration-cli`
 directories in the Docker repository contain integration test code.
 
-Testing is its own speciality. If you aren't familiar with testing techniques,
+Testing is its own specialty. If you aren't familiar with testing techniques,
 there is a lot of information available to you on the Web. For now, you should
 understand that, the Docker maintainers may ask you to write a new test or
 change an existing one.

--- a/docs/sources/reference/api/docker_remote_api_v1.10.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.10.md
@@ -1047,7 +1047,7 @@ Query Parameters:
     Request Headers:
 
 -   **Content-type** – should be set to `"application/tar"`.
--   **X-Registry-Config** – base64-encoded ConfigFile objec
+-   **X-Registry-Config** – base64-encoded ConfigFile object
 
 Status Codes:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.11.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.11.md
@@ -1053,7 +1053,7 @@ Query Parameters:
     Request Headers:
 
 -   **Content-type** – should be set to `"application/tar"`.
--   **X-Registry-Config** – base64-encoded ConfigFile objec
+-   **X-Registry-Config** – base64-encoded ConfigFile object
 
 Status Codes:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.12.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.12.md
@@ -1115,7 +1115,7 @@ Query Parameters:
     Request Headers:
 
 -   **Content-type** – should be set to `"application/tar"`.
--   **X-Registry-Config** – base64-encoded ConfigFile objec
+-   **X-Registry-Config** – base64-encoded ConfigFile object
 
 Status Codes:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.13.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.13.md
@@ -1104,7 +1104,7 @@ Query Parameters:
     Request Headers:
 
 -   **Content-type** – should be set to `"application/tar"`.
--   **X-Registry-Config** – base64-encoded ConfigFile objec
+-   **X-Registry-Config** – base64-encoded ConfigFile object
 
 Status Codes:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.14.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.14.md
@@ -1114,7 +1114,7 @@ Query Parameters:
     Request Headers:
 
 -   **Content-type** – should be set to `"application/tar"`.
--   **X-Registry-Config** – base64-encoded ConfigFile objec
+-   **X-Registry-Config** – base64-encoded ConfigFile object
 
 Status Codes:
 

--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -1261,7 +1261,7 @@ Query Parameters:
     Request Headers:
 
 -   **Content-type** – should be set to `"application/tar"`.
--   **X-Registry-Config** – base64-encoded ConfigFile objec
+-   **X-Registry-Config** – base64-encoded ConfigFile object
 
 Status Codes:
 
@@ -1495,7 +1495,7 @@ Get a tarball containing all images and metadata for the repository specified
 by `name`.
 
 If `name` is a specific name and tag (e.g. ubuntu:latest), then only that image
-(and its parents) are returned. If `name` is an image ID, similarly only tha
+(and its parents) are returned. If `name` is an image ID, similarly only that
 image (and its parents) are returned, but with the exclusion of the
 'repositories' file in the tarball, as there were no image names referenced.
 

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -1262,7 +1262,7 @@ Query Parameters:
     Request Headers:
 
 -   **Content-type** – should be set to `"application/tar"`.
--   **X-Registry-Config** – base64-encoded ConfigFile objec
+-   **X-Registry-Config** – base64-encoded ConfigFile object
 
 Status Codes:
 
@@ -1509,7 +1509,7 @@ Get a tarball containing all images and metadata for the repository specified
 by `name`.
 
 If `name` is a specific name and tag (e.g. ubuntu:latest), then only that image
-(and its parents) are returned. If `name` is an image ID, similarly only tha
+(and its parents) are returned. If `name` is an image ID, similarly only that
 image (and its parents) are returned, but with the exclusion of the
 'repositories' file in the tarball, as there were no image names referenced.
 

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -1140,7 +1140,7 @@ Query Parameters:
     Request Headers:
 
 -   **Content-type** – should be set to `"application/tar"`.
--   **X-Registry-Config** – base64-encoded ConfigFile objec
+-   **X-Registry-Config** – base64-encoded ConfigFile object
 
 Status Codes:
 
@@ -1675,7 +1675,7 @@ Get a tarball containing all images and metadata for the repository specified
 by `name`.
 
 If `name` is a specific name and tag (e.g. ubuntu:latest), then only that image
-(and its parents) are returned. If `name` is an image ID, similarly only tha
+(and its parents) are returned. If `name` is an image ID, similarly only that
 image (and its parents) are returned, but with the exclusion of the
 'repositories' file in the tarball, as there were no image names referenced.
 

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -1250,7 +1250,7 @@ Query Parameters:
     Request Headers:
 
 -   **Content-type** – should be set to `"application/tar"`.
--   **X-Registry-Config** – base64-encoded ConfigFile objec
+-   **X-Registry-Config** – base64-encoded ConfigFile object
 
 Status Codes:
 
@@ -1791,7 +1791,7 @@ Get a tarball containing all images and metadata for the repository specified
 by `name`.
 
 If `name` is a specific name and tag (e.g. ubuntu:latest), then only that image
-(and its parents) are returned. If `name` is an image ID, similarly only tha
+(and its parents) are returned. If `name` is an image ID, similarly only that
 image (and its parents) are returned, but with the exclusion of the
 'repositories' file in the tarball, as there were no image names referenced.
 

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -1253,7 +1253,7 @@ Query Parameters:
     Request Headers:
 
 -   **Content-type** – should be set to `"application/tar"`.
--   **X-Registry-Config** – base64-encoded ConfigFile objec
+-   **X-Registry-Config** – base64-encoded ConfigFile object
 
 Status Codes:
 
@@ -1794,7 +1794,7 @@ Get a tarball containing all images and metadata for the repository specified
 by `name`.
 
 If `name` is a specific name and tag (e.g. ubuntu:latest), then only that image
-(and its parents) are returned. If `name` is an image ID, similarly only tha
+(and its parents) are returned. If `name` is an image ID, similarly only that
 image (and its parents) are returned, but with the exclusion of the
 'repositories' file in the tarball, as there were no image names referenced.
 

--- a/docs/sources/reference/api/docker_remote_api_v1.9.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.9.md
@@ -1052,7 +1052,7 @@ Query Parameters:
     Request Headers:
 
 -   **Content-type** – should be set to `"application/tar"`.
--   **X-Registry-Config** – base64-encoded ConfigFile objec
+-   **X-Registry-Config** – base64-encoded ConfigFile object
 
 Status Codes:
 

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -128,7 +128,7 @@ modifiers as specified below:
 
 * `${variable:-word}` indicates that if `variable` is set then the result
   will be that value. If `variable` is not set then `word` will be the result.
-* `${variable:+word}` indiates that if `variable` is set then `word` will be
+* `${variable:+word}` indicates that if `variable` is set then `word` will be
   the result, otherwise the result is the empty string.
 
 In all cases, `word` can be any string, including additional environment
@@ -158,7 +158,7 @@ The instructions that handle environment variables in the `Dockerfile` are:
 `ONBUILD` instructions are **NOT** supported for environment replacement, even
 the instructions above.
 
-Environment variable subtitution will use the same value for each variable
+Environment variable substitution will use the same value for each variable
 throughout the entire command.  In other words, in this example:
 
     ENV abc=hello
@@ -299,7 +299,7 @@ The cache for `RUN` instructions can be invalidated by `ADD` instructions. See
   the layers with `dirperm1` option. More details on `dirperm1` option can be
   found at [`aufs` man page](http://aufs.sourceforge.net/aufs3/man.html)
 
-  If your system doesnt have support for `dirperm1`, the issue describes a workaround.
+  If your system doesn't have support for `dirperm1`, the issue describes a workaround.
 
 ## CMD
 
@@ -368,7 +368,7 @@ default specified in `CMD`.
 
 The `LABEL` instruction adds metadata to an image. A `LABEL` is a
 key-value pair. To include spaces within a `LABEL` value, use quotes and
-blackslashes as you would in command-line parsing.
+backslashes as you would in command-line parsing.
 
     LABEL "com.example.vendor"="ACME Incorporated"
 

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -380,7 +380,7 @@ This means the daemon will wait for 100 ms, then 200 ms, 400, 800, 1600,
 and so on until either the `on-failure` limit is hit, or when you `docker stop`
 or `docker rm -f` the container.
 
-If a container is succesfully restarted (the container is started and runs
+If a container is successfully restarted (the container is started and runs
 for at least 10 seconds), the delay is reset to its default value of 100 ms.
 
 You can specify the maximum amount of times Docker will try to restart the


### PR DESCRIPTION
Most of these are minor copy edits for typos.
There is one formatting change in create-pr.md to unindent a sentence.

Signed-off-by: Ed Costello epc@epcostello.com
