### PR TITLE
Proposal: Allow log streaming independent of log driver

### DIFF
--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -35,8 +35,12 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 		return err
 	}
 
-	if c.HostConfig.LogConfig.Type != "json-file" {
-		return fmt.Errorf("\"logs\" command is supported only for \"json-file\" logging driver")
+	var followAndRunningContainer = false
+	if *follow && c.State.Running {
+		followAndRunningContainer = true
+	}
+	if c.HostConfig.LogConfig.Type != "json-file" && !followAndRunningContainer {
+		return fmt.Errorf("\"logs\" command is supported only for \"json-file\" logging driver, or in follow mode only for all other drivers")
 	}
 
 	v := url.Values{}

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -54,74 +54,76 @@ func (daemon *Daemon) ContainerLogs(name string, config *ContainerLogsConfig) er
 		errStream = outStream
 	}
 
-	if container.LogDriverType() != "json-file" {
-		return fmt.Errorf("\"logs\" endpoint is supported only for \"json-file\" logging driver")
+	if container.LogDriverType() != "json-file" && !(config.Follow && container.IsRunning()) {
+		return fmt.Errorf("\"logs\" endpoint is supported only for \"json-file\" logging driver, or in follow mode only for all other drivers")
 	}
-	cLog, err := container.ReadLog("json")
-	if err != nil && os.IsNotExist(err) {
-		// Legacy logs
-		logrus.Debugf("Old logs format")
-		if config.UseStdout {
-			cLog, err := container.ReadLog("stdout")
-			if err != nil {
-				logrus.Errorf("Error reading logs (stdout): %s", err)
-			} else if _, err := io.Copy(outStream, cLog); err != nil {
-				logrus.Errorf("Error streaming logs (stdout): %s", err)
-			}
-		}
-		if config.UseStderr {
-			cLog, err := container.ReadLog("stderr")
-			if err != nil {
-				logrus.Errorf("Error reading logs (stderr): %s", err)
-			} else if _, err := io.Copy(errStream, cLog); err != nil {
-				logrus.Errorf("Error streaming logs (stderr): %s", err)
-			}
-		}
-	} else if err != nil {
-		logrus.Errorf("Error reading logs (json): %s", err)
-	} else {
-		if config.Tail != "all" {
-			var err error
-			lines, err = strconv.Atoi(config.Tail)
-			if err != nil {
-				logrus.Errorf("Failed to parse tail %s, error: %v, show all logs", config.Tail, err)
-				lines = -1
-			}
-		}
-		if lines != 0 {
-			if lines > 0 {
-				f := cLog.(*os.File)
-				ls, err := tailfile.TailFile(f, lines)
+	if container.LogDriverType() == "json-file" {
+		cLog, err := container.ReadLog("json")
+		if err != nil && os.IsNotExist(err) {
+			// Legacy logs
+			logrus.Debugf("Old logs format")
+			if config.UseStdout {
+				cLog, err := container.ReadLog("stdout")
 				if err != nil {
-					return err
+					logrus.Errorf("Error reading logs (stdout): %s", err)
+				} else if _, err := io.Copy(outStream, cLog); err != nil {
+					logrus.Errorf("Error streaming logs (stdout): %s", err)
 				}
-				tmp := bytes.NewBuffer([]byte{})
-				for _, l := range ls {
-					fmt.Fprintf(tmp, "%s\n", l)
-				}
-				cLog = tmp
 			}
-			dec := json.NewDecoder(cLog)
-			l := &jsonlog.JSONLog{}
-			for {
-				if err := dec.Decode(l); err == io.EOF {
-					break
-				} else if err != nil {
-					logrus.Errorf("Error streaming logs: %s", err)
-					break
+			if config.UseStderr {
+				cLog, err := container.ReadLog("stderr")
+				if err != nil {
+					logrus.Errorf("Error reading logs (stderr): %s", err)
+				} else if _, err := io.Copy(errStream, cLog); err != nil {
+					logrus.Errorf("Error streaming logs (stderr): %s", err)
 				}
-				logLine := l.Log
-				if config.Timestamps {
-					// format can be "" or time format, so here can't be error
-					logLine, _ = l.Format(format)
+			}
+		} else if err != nil {
+			logrus.Errorf("Error reading logs (json): %s", err)
+		} else {
+			if config.Tail != "all" {
+				var err error
+				lines, err = strconv.Atoi(config.Tail)
+				if err != nil {
+					logrus.Errorf("Failed to parse tail %s, error: %v, show all logs", config.Tail, err)
+					lines = -1
 				}
-				if l.Stream == "stdout" && config.UseStdout {
-					io.WriteString(outStream, logLine)
+			}
+			if lines != 0 {
+				if lines > 0 {
+					f := cLog.(*os.File)
+					ls, err := tailfile.TailFile(f, lines)
+					if err != nil {
+						return err
+					}
+					tmp := bytes.NewBuffer([]byte{})
+					for _, l := range ls {
+						fmt.Fprintf(tmp, "%s\n", l)
+					}
+					cLog = tmp
 				}
-				if l.Stream == "stderr" && config.UseStderr {
-					io.WriteString(errStream, logLine)
+				dec := json.NewDecoder(cLog)
+				l := &jsonlog.JSONLog{}
+				for {
+					if err := dec.Decode(l); err == io.EOF {
+						break
+					} else if err != nil {
+						logrus.Errorf("Error streaming logs: %s", err)
+						break
+					}
+					logLine := l.Log
+					if config.Timestamps {
+						// format can be "" or time format, so here can't be error
+						logLine, _ = l.Format(format)
+					}
+					if l.Stream == "stdout" && config.UseStdout {
+						io.WriteString(outStream, logLine)
+					}
+					if l.Stream == "stderr" && config.UseStderr {
+						io.WriteString(errStream, logLine)
+					}
+					l.Reset()
 				}
-				l.Reset()
 			}
 		}
 	}

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -135,7 +135,7 @@ two memory nodes.
 
 **--log-driver**="|*json-file*|*syslog*|*journald*|*none*"
   Logging driver for container. Default is defined by daemon `--log-driver` flag.
-  **Warning**: `docker logs` command works only for `json-file` logging driver.
+  **Warning**: `docker logs` command works only for `json-file` logging driver, or in follow mode only for all other drivers.
 
 **-m**, **--memory**=""
    Memory limit (format: <number><optional unit>, where unit = b, k, m or g)

--- a/docs/man/docker-logs.1.md
+++ b/docs/man/docker-logs.1.md
@@ -22,7 +22,7 @@ The **docker logs --follow** command combines commands **docker logs** and
 **docker attach**. It will first return all logs from the beginning and
 then continue streaming new output from the container’s stdout and stderr.
 
-**Warning**: This command works only for **json-file** logging driver.
+**Warning**: This command works only for **json-file** logging driver, or in follow mode only for all other drivers.
 
 # OPTIONS
 **--help**

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -240,7 +240,7 @@ which interface and port to use.
 
 **--log-driver**="|*json-file*|*syslog*|*journald*|*none*"
   Logging driver for container. Default is defined by daemon `--log-driver` flag.
-  **Warning**: `docker logs` command works only for `json-file` logging driver.
+  **Warning**: `docker logs` command works only for `json-file` logging driver, or in follow mode only for all other drivers.
 
 **-m**, **--memory**=""
    Memory limit (format: <number><optional unit>, where unit = b, k, m or g)

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -97,7 +97,7 @@ unix://[/path/to/socket] to use.
 
 **--log-driver**="*json-file*|*syslog*|*journald*|*none*"
   Default driver for container logs. Default is `json-file`.
-  **Warning**: `docker logs` command works only for `json-file` logging driver.
+  **Warning**: `docker logs` command works only for `json-file` logging driver, or in follow mode only for all other drivers.
 
 **--mtu**=VALUE
   Set the containers network mtu. Default is `0`.

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -463,7 +463,7 @@ Status Codes:
 Get stdout and stderr logs from the container ``id``
 
 > **Note**:
-> This endpoint works only for containers with `json-file` logging driver.
+> This endpoint works only for containers with `json-file` logging driver, or in follow mode only for all other drivers
 
 **Example request**:
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1595,7 +1595,7 @@ For example:
       --tail="all"              Number of lines to show from the end of the logs
 
 NOTE: this command is available only for containers with `json-file` logging
-driver.
+driver, or in follow mode only for all other drivers.
 
 The `docker logs` command batch-retrieves logs present at the time of execution.
 


### PR DESCRIPTION
I am very happy about the addition of log drivers in 1.6. I was looking forward to set the logging driver to `none` and to ship the logs off of the host using @progrium's [Logspout](https://github.com/gliderlabs/logspout). I like how Logspout externalizes the log routing, and how easy its module system made it for me to add an [HTTP target](https://github.com/raychaser/logspout-http). I am hoping to use this combination to deal with logs without having anything written to the disk on the host, and therefore not having to manage the disk space usage and I/O.

Alas, `--log-driver=none` disables the `/logs` API. Looking at the code, I can see why that is - `logs.go` clearly is reaching back to the JSON files written by the `jsonfile` driver to provide the API functionality. This makes sense, given that this API is designed to deal with a wide variety of use cases, including spitting back logs written by a container before the API invocation, and even logs written by a container that isn't running anymore.

In order to continue to use Logspout without `jsonfile`, I only need a live stream from the API - so the use case is much narrower. Looking at `logs.go` it seems that it should be possible to use the existing implementation for the `follow=true` case for running containers independently of the log driver. I realize that this does not enable all of the API functionality but it is better than nothing, and for me, all I seem to need.
