### PR TITLE
Prevent deadlock on --net=container:<self>

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1515,6 +1515,9 @@ func (container *Container) getNetworkedContainer() (*Container, error) {
 		if err != nil {
 			return nil, err
 		}
+		if container == nc {
+			return nil, fmt.Errorf("cannot join own network")
+		}
 		if !nc.IsRunning() {
 			return nil, fmt.Errorf("cannot join network of a non running container: %s", parts[1])
 		}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2657,6 +2657,14 @@ func (s *DockerSuite) TestContainerNetworkMode(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestContainerNetworkModeToSelf(c *check.C) {
+	cmd := exec.Command(dockerBinary, "run", "--name=me", "--net=container:me", "busybox", "true")
+	out, _, err := runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "cannot join own network") {
+		c.Fatalf("using container net mode to self should result in an error")
+	}
+}
+
 func (s *DockerSuite) TestRunModePidHost(c *check.C) {
 	testRequires(c, NativeExecDriver, SameHostDaemon)
 


### PR DESCRIPTION
Fixes #12606.
At least, it would have prevented the deadlock I saw.

To be honest, I don't know why there were containers being created on my machine attempting to `--net=container:<self>` in the first place. Other people have access to the daemon, but inspect output was indicating that the full container id had been used (i.e. `--net=container:<cid>`) which is obviously impossible because you can't know the cid before you create the container.
So I wonder if there's a second bug which has been auto-populating that field? It'll be interesting to see if people start hitting this new error message.
