### PR TITLE
Fix restarting docker daemon with paused containers

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1004,6 +1004,12 @@ func (daemon *Daemon) shutdown() error {
 
 			go func() {
 				defer group.Done()
+				if c.IsPaused() {
+					logrus.Debugf("container '%s' is paused, unpause it first", c.ID)
+					if err := c.Unpause(); err != nil {
+						logrus.Debugf("unpause container '%s' with error %s", c.ID, err.Error())
+					}
+				}
 				if err := c.KillSig(15); err != nil {
 					logrus.Debugf("kill 15 error for %s - %s", c.ID, err)
 				}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Fixes #12797 

Restart docker daemon with paused containers will lead
these paused containers can't be start, we should unpause these containers and then stop these 
containers on docker daemon shutdown.
ping @cpuguy83  WDYT?
