### PR TITLE
Remove c.Fatal from goroutine in TestGetContainersAttachWebsocket

### DIFF
--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -40,24 +40,38 @@ func (s *DockerSuite) TestGetContainersAttachWebsocket(c *check.C) {
 
 	expected := []byte("hello")
 	actual := make([]byte, len(expected))
-	outChan := make(chan string)
+
+	outChan := make(chan error)
 	go func() {
-		if _, err := ws.Read(actual); err != nil {
-			c.Fatal(err)
-		}
-		outChan <- "done"
+		_, err := ws.Read(actual)
+		outChan <- err
+		close(outChan)
 	}()
 
-	inChan := make(chan string)
+	inChan := make(chan error)
 	go func() {
-		if _, err := ws.Write(expected); err != nil {
-			c.Fatal(err)
-		}
-		inChan <- "done"
+		_, err := ws.Write(expected)
+		inChan <- err
+		close(inChan)
 	}()
 
-	<-inChan
-	<-outChan
+	select {
+	case err := <-inChan:
+		if err != nil {
+			c.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		c.Fatal("Timeout writing to ws")
+	}
+
+	select {
+	case err := <-outChan:
+		if err != nil {
+			c.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		c.Fatal("Timeout reading from ws")
+	}
 
 	if !bytes.Equal(expected, actual) {
 		c.Fatal("Expected output on websocket to match input")


### PR DESCRIPTION
I'll look around for other cases like this and fix also

Signed-off-by: Antonio Murdaca me@runcom.ninja
