### PR TITLE
cache container ip

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -581,7 +581,7 @@ func (container *Container) AllocateNetwork() error {
 		eng = container.daemon.eng
 	)
 
-	networkSettings, err := bridge.Allocate(container.ID, container.Config.MacAddress, "", "")
+	networkSettings, err := bridge.Allocate(container.ID, container.Config.MacAddress, "", "", container.Name)
 	if err != nil {
 		return err
 	}
@@ -665,7 +665,7 @@ func (container *Container) RestoreNetwork() error {
 	eng := container.daemon.eng
 
 	// Re-allocate the interface with the same IP and MAC address.
-	if _, err := bridge.Allocate(container.ID, container.NetworkSettings.MacAddress, container.NetworkSettings.IPAddress, ""); err != nil {
+	if _, err := bridge.Allocate(container.ID, container.NetworkSettings.MacAddress, container.NetworkSettings.IPAddress, "", container.Name); err != nil {
 		return err
 	}
 

--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -319,7 +319,7 @@ func InitDriver(config *Config) error {
 	}
 
 	// Block BridgeIP in IP allocator
-	ipAllocator.RequestIP(bridgeIPv4Network, bridgeIPv4Network.IP)
+	ipAllocator.RequestIP(bridgeIPv4Network, bridgeIPv4Network.IP, "bridge"+bridgeIPv4Network.String())
 
 	if config.EnableIptables {
 		iptables.OnReloaded(portMapper.ReMapAll) // call this on Firewalld reload
@@ -516,7 +516,7 @@ func requestDefaultGateway(requestedGateway string, network *net.IPNet) (gateway
 			return nil, fmt.Errorf("Gateway ip %s must be part of the network %s", requestedGateway, network.String())
 		}
 
-		ipAllocator.RequestIP(network, gateway)
+		ipAllocator.RequestIP(network, gateway, "DG"+network.String())
 	}
 
 	return gateway, nil
@@ -569,7 +569,7 @@ func linkLocalIPv6FromMac(mac string) (string, error) {
 }
 
 // Allocate a network interface
-func Allocate(id, requestedMac, requestedIP, requestedIPv6 string) (*network.Settings, error) {
+func Allocate(id, requestedMac, requestedIP, requestedIPv6 string, name string) (*network.Settings, error) {
 	var (
 		ip            net.IP
 		mac           net.HardwareAddr
@@ -579,7 +579,7 @@ func Allocate(id, requestedMac, requestedIP, requestedIPv6 string) (*network.Set
 		defaultGWIPv6 net.IP
 	)
 
-	ip, err = ipAllocator.RequestIP(bridgeIPv4Network, net.ParseIP(requestedIP))
+	ip, err = ipAllocator.RequestIP(bridgeIPv4Network, net.ParseIP(requestedIP), name)
 	if err != nil {
 		return nil, err
 	}
@@ -601,7 +601,7 @@ func Allocate(id, requestedMac, requestedIP, requestedIPv6 string) (*network.Set
 			}
 		}
 
-		globalIPv6, err = ipAllocator.RequestIP(globalIPv6Network, ipv6)
+		globalIPv6, err = ipAllocator.RequestIP(globalIPv6Network, ipv6, name)
 		if err != nil {
 			logrus.Errorf("Allocator: RequestIP v6: %v", err)
 			return nil, err

--- a/daemon/networkdriver/bridge/driver_test.go
+++ b/daemon/networkdriver/bridge/driver_test.go
@@ -39,7 +39,7 @@ func TestAllocatePortDetection(t *testing.T) {
 	}
 
 	// Allocate interface
-	if _, err := Allocate("container_id", "", "", ""); err != nil {
+	if _, err := Allocate("container_id", "", "", "", "container_name"); err != nil {
 		t.Fatal("Failed to allocate network interface")
 	}
 
@@ -63,7 +63,7 @@ func TestHostnameFormatChecking(t *testing.T) {
 	}
 
 	// Allocate interface
-	if _, err := Allocate("container_id", "", "", ""); err != nil {
+	if _, err := Allocate("container_id", "", "", "", "container_name"); err != nil {
 		t.Fatal("Failed to allocate network interface")
 	}
 
@@ -81,7 +81,7 @@ func newInterfaceAllocation(t *testing.T, globalIPv6 *net.IPNet, requestedMac, r
 		globalIPv6Network = globalIPv6
 	}
 
-	networkSettings, err := Allocate("container_id", requestedMac, requestedIP, requestedIPv6)
+	networkSettings, err := Allocate("container_id", requestedMac, requestedIP, requestedIPv6, "container_name")
 	if err == nil && expectFail {
 		t.Fatal("Doesn't fail to allocate network interface")
 	} else if err != nil && !expectFail {
@@ -172,7 +172,7 @@ func TestLinkContainers(t *testing.T) {
 	}
 
 	// Allocate interface
-	if _, err := Allocate("container_id", "", "", ""); err != nil {
+	if _, err := Allocate("container_id", "", "", "", "container_name"); err != nil {
 		t.Fatal("Failed to allocate network interface")
 	}
 

--- a/daemon/networkdriver/ipallocator/allocator_test.go
+++ b/daemon/networkdriver/ipallocator/allocator_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"strconv"
 	"testing"
 )
 
@@ -59,7 +60,7 @@ func TestRequestNewIps(t *testing.T) {
 	var err error
 
 	for i := 1; i < 10; i++ {
-		ip, err = a.RequestIP(network, nil)
+		ip, err = a.RequestIP(network, nil, "name_"+strconv.Itoa(i))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -72,7 +73,7 @@ func TestRequestNewIps(t *testing.T) {
 	if err := a.ReleaseIP(network, ip); err != nil {
 		t.Fatal(err)
 	}
-	ip, err = a.RequestIP(network, nil)
+	ip, err = a.RequestIP(network, nil, "name_a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +93,7 @@ func TestRequestNewIpV6(t *testing.T) {
 	var ip net.IP
 	var err error
 	for i := 1; i < 10; i++ {
-		ip, err = a.RequestIP(network, nil)
+		ip, err = a.RequestIP(network, nil, "name_"+strconv.Itoa(i))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -105,7 +106,7 @@ func TestRequestNewIpV6(t *testing.T) {
 	if err := a.ReleaseIP(network, ip); err != nil {
 		t.Fatal(err)
 	}
-	ip, err = a.RequestIP(network, nil)
+	ip, err = a.RequestIP(network, nil, "name_a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +123,7 @@ func TestReleaseIp(t *testing.T) {
 		Mask: []byte{255, 255, 255, 0},
 	}
 
-	ip, err := a.RequestIP(network, nil)
+	ip, err := a.RequestIP(network, nil, "name_a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +141,7 @@ func TestReleaseIpV6(t *testing.T) {
 		Mask: []byte{255, 255, 255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0}, // /64 netmask
 	}
 
-	ip, err := a.RequestIP(network, nil)
+	ip, err := a.RequestIP(network, nil, "name_a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +158,7 @@ func TestGetReleasedIp(t *testing.T) {
 		Mask: []byte{255, 255, 255, 0},
 	}
 
-	ip, err := a.RequestIP(network, nil)
+	ip, err := a.RequestIP(network, nil, "name_a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +169,7 @@ func TestGetReleasedIp(t *testing.T) {
 	}
 
 	for i := 0; i < 253; i++ {
-		_, err = a.RequestIP(network, nil)
+		_, err = a.RequestIP(network, nil, "name_"+strconv.Itoa(i))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -178,7 +179,7 @@ func TestGetReleasedIp(t *testing.T) {
 		}
 	}
 
-	ip, err = a.RequestIP(network, nil)
+	ip, err = a.RequestIP(network, nil, "name_a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +197,7 @@ func TestGetReleasedIpV6(t *testing.T) {
 		Mask: []byte{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 0},
 	}
 
-	ip, err := a.RequestIP(network, nil)
+	ip, err := a.RequestIP(network, nil, "name_a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,7 +208,7 @@ func TestGetReleasedIpV6(t *testing.T) {
 	}
 
 	for i := 0; i < 253; i++ {
-		_, err = a.RequestIP(network, nil)
+		_, err = a.RequestIP(network, nil, "name_"+strconv.Itoa(i))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -217,7 +218,7 @@ func TestGetReleasedIpV6(t *testing.T) {
 		}
 	}
 
-	ip, err = a.RequestIP(network, nil)
+	ip, err = a.RequestIP(network, nil, "name_a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,17 +239,17 @@ func TestRequestSpecificIp(t *testing.T) {
 	ip := net.ParseIP("192.168.0.5")
 
 	// Request a "good" IP.
-	if _, err := a.RequestIP(network, ip); err != nil {
+	if _, err := a.RequestIP(network, ip, "name_a"); err != nil {
 		t.Fatal(err)
 	}
 
 	// Request the same IP again.
-	if _, err := a.RequestIP(network, ip); err != ErrIPAlreadyAllocated {
+	if _, err := a.RequestIP(network, ip, "name_a"); err != ErrIPAlreadyAllocated {
 		t.Fatalf("Got the same IP twice: %#v", err)
 	}
 
 	// Request an out of range IP.
-	if _, err := a.RequestIP(network, net.ParseIP("192.168.0.42")); err != ErrIPOutOfRange {
+	if _, err := a.RequestIP(network, net.ParseIP("192.168.0.42"), "name_a"); err != ErrIPOutOfRange {
 		t.Fatalf("Got an out of range IP: %#v", err)
 	}
 }
@@ -264,17 +265,17 @@ func TestRequestSpecificIpV6(t *testing.T) {
 	ip := net.ParseIP("2a00:1450::5")
 
 	// Request a "good" IP.
-	if _, err := a.RequestIP(network, ip); err != nil {
+	if _, err := a.RequestIP(network, ip, "name_a"); err != nil {
 		t.Fatal(err)
 	}
 
 	// Request the same IP again.
-	if _, err := a.RequestIP(network, ip); err != ErrIPAlreadyAllocated {
+	if _, err := a.RequestIP(network, ip, "name_a"); err != ErrIPAlreadyAllocated {
 		t.Fatalf("Got the same IP twice: %#v", err)
 	}
 
 	// Request an out of range IP.
-	if _, err := a.RequestIP(network, net.ParseIP("2a00:1500::1")); err != ErrIPOutOfRange {
+	if _, err := a.RequestIP(network, net.ParseIP("2a00:1500::1"), "name_a"); err != ErrIPOutOfRange {
 		t.Fatalf("Got an out of range IP: %#v", err)
 	}
 }
@@ -301,7 +302,7 @@ func TestIPAllocator(t *testing.T) {
 	// Check that we get 6 IPs, from 127.0.0.1–127.0.0.6, in that
 	// order.
 	for i := 0; i < 6; i++ {
-		ip, err := a.RequestIP(network, nil)
+		ip, err := a.RequestIP(network, nil, "name_"+strconv.Itoa(i))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -337,9 +338,9 @@ func TestIPAllocator(t *testing.T) {
 	//  ↑
 
 	// Check that there are no more IPs
-	ip, err := a.RequestIP(network, nil)
+	ip, err := a.RequestIP(network, nil, "name_a")
 	if err == nil {
-		t.Fatalf("There shouldn't be any IP addresses at this point, got %s\n", ip)
+		t.Fatalf("There shouldn't be any IP addresses at this point, got %s", ip)
 	}
 
 	// Release some IPs in non-sequential order
@@ -365,18 +366,18 @@ func TestIPAllocator(t *testing.T) {
 	// with the first released IP
 	newIPs := make([]net.IP, 3)
 	for i := 0; i < 3; i++ {
-		ip, err := a.RequestIP(network, nil)
+		ip, err := a.RequestIP(network, nil, "name_new"+strconv.Itoa(i))
 		if err != nil {
 			t.Fatal(err)
 		}
 
 		newIPs[i] = ip
 	}
-	assertIPEquals(t, expectedIPs[2], newIPs[0])
-	assertIPEquals(t, expectedIPs[3], newIPs[1])
+	assertIPEquals(t, expectedIPs[3], newIPs[0])
+	assertIPEquals(t, expectedIPs[2], newIPs[1])
 	assertIPEquals(t, expectedIPs[4], newIPs[2])
 
-	_, err = a.RequestIP(network, nil)
+	_, err = a.RequestIP(network, nil, "name_a")
 	if err == nil {
 		t.Fatal("There shouldn't be any IP addresses at this point")
 	}
@@ -393,7 +394,7 @@ func TestAllocateFirstIP(t *testing.T) {
 	firstIP := network.IP.To4().Mask(network.Mask)
 	first := big.NewInt(0).Add(ipToBigInt(firstIP), big.NewInt(1))
 
-	ip, err := a.RequestIP(network, nil)
+	ip, err := a.RequestIP(network, nil, "name_a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -418,8 +419,10 @@ func TestAllocateAllIps(t *testing.T) {
 		isFirst        = true
 	)
 
+	var ix int = 0
 	for err == nil {
-		current, err = a.RequestIP(network, nil)
+		current, err = a.RequestIP(network, nil, "name_"+strconv.Itoa(ix))
+		ix++
 		if isFirst {
 			first = current
 			isFirst = false
@@ -430,15 +433,18 @@ func TestAllocateAllIps(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := a.RequestIP(network, nil); err != ErrNoAvailableIPs {
+	ix++
+	if _, err := a.RequestIP(network, nil, "name_"+strconv.Itoa(ix)); err != ErrNoAvailableIPs {
 		t.Fatal(err)
 	}
 
+	ix++
 	if err := a.ReleaseIP(network, first); err != nil {
 		t.Fatal(err)
 	}
 
-	again, err := a.RequestIP(network, nil)
+	ix++
+	again, err := a.RequestIP(network, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -446,7 +452,8 @@ func TestAllocateAllIps(t *testing.T) {
 	assertIPEquals(t, first, again)
 
 	// ensure that alloc.last == alloc.begin won't result in dead loop
-	if _, err := a.RequestIP(network, nil); err != ErrNoAvailableIPs {
+	ix++
+	if _, err := a.RequestIP(network, nil, "name_"+strconv.Itoa(ix)); err != ErrNoAvailableIPs {
 		t.Fatal(err)
 	}
 
@@ -456,7 +463,8 @@ func TestAllocateAllIps(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ret, err := a.RequestIP(network, nil)
+	ix++
+	ret, err := a.RequestIP(network, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -467,7 +475,8 @@ func TestAllocateAllIps(t *testing.T) {
 	last := net.IPv4(192, 168, 0, 254)
 	setLastTo(t, a, network, last)
 
-	ret, err = a.RequestIP(network, nil)
+	ix++
+	ret, err = a.RequestIP(network, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -478,7 +487,7 @@ func TestAllocateAllIps(t *testing.T) {
 	mid := net.IPv4(192, 168, 0, 7)
 	setLastTo(t, a, network, mid)
 
-	ret, err = a.RequestIP(network, nil)
+	ret, err = a.RequestIP(network, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -493,7 +502,7 @@ func setLastTo(t *testing.T, a *IPAllocator, network *net.IPNet, ip net.IP) {
 		t.Fatal(err)
 	}
 
-	ret, err := a.RequestIP(network, nil)
+	ret, err := a.RequestIP(network, nil, "name_a")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -535,39 +544,48 @@ func TestAllocateDifferentSubnets(t *testing.T) {
 		8: net.ParseIP("2a00:1632::2"),
 	}
 
-	ip11, err := a.RequestIP(network1, nil)
+	var ix int
+	ip11, err := a.RequestIP(network1, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
-	ip12, err := a.RequestIP(network1, nil)
+	ix++
+	ip12, err := a.RequestIP(network1, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
-	ip21, err := a.RequestIP(network2, nil)
+	ix++
+	ip21, err := a.RequestIP(network2, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
-	ip22, err := a.RequestIP(network2, nil)
+	ix++
+	ip22, err := a.RequestIP(network2, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
-	ip31, err := a.RequestIP(network3, nil)
+	ix++
+	ip31, err := a.RequestIP(network3, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
-	ip32, err := a.RequestIP(network3, nil)
+	ix++
+	ip32, err := a.RequestIP(network3, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
-	ip33, err := a.RequestIP(network3, nil)
+	ix++
+	ip33, err := a.RequestIP(network3, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
-	ip41, err := a.RequestIP(network4, nil)
+	ix++
+	ip41, err := a.RequestIP(network4, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
-	ip42, err := a.RequestIP(network4, nil)
+	ix++
+	ip42, err := a.RequestIP(network4, nil, "name_"+strconv.Itoa(ix))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -643,24 +661,82 @@ func TestAllocateFromRange(t *testing.T) {
 		4: net.IPv4(192, 168, 0, 13),
 		5: net.IPv4(192, 168, 0, 14),
 	}
-	for _, ip := range expectedIPs {
-		rip, err := a.RequestIP(network, nil)
+	for ix, ip := range expectedIPs {
+		rip, err := a.RequestIP(network, nil, "name_"+strconv.Itoa(ix))
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertIPEquals(t, ip, rip)
 	}
 
-	if _, err := a.RequestIP(network, nil); err != ErrNoAvailableIPs {
+	if _, err := a.RequestIP(network, nil, "name_a"); err != ErrNoAvailableIPs {
 		t.Fatalf("Expected ErrNoAvailableIPs error, got %v", err)
 	}
-	for _, ip := range expectedIPs {
+	for ix, ip := range expectedIPs {
 		a.ReleaseIP(network, ip)
-		rip, err := a.RequestIP(network, nil)
+		rip, err := a.RequestIP(network, nil, "name_"+strconv.Itoa(ix))
 		if err != nil {
 			t.Fatal(err)
 		}
 		assertIPEquals(t, ip, rip)
+	}
+}
+
+func TestRecycledIp(t *testing.T) {
+	a := New()
+
+	network := &net.IPNet{
+		IP:   []byte{192, 168, 0, 1},
+		Mask: []byte{255, 255, 255, 248},
+	}
+
+	var err error
+	for rid := 0; rid < 6; rid++ {
+		if _, err = a.RequestIP(network, nil, "name_"+strconv.Itoa(rid)); err != nil {
+			t.Fatalf("IP request number %d err=%v", rid, err)
+		}
+	}
+
+	t.Log("test reCycled ip")
+	var recycledIp net.IP
+	ip := net.IPv4(192, 168, 0, 1)
+	a.ReleaseIP(network, ip)
+	if recycledIp, err = a.RequestIP(network, nil, "name_4"); err != nil {
+		t.Fatal(err)
+	}
+
+	assertIPEquals(t, ip, recycledIp)
+}
+
+func TestRequestCachedName(t *testing.T) {
+	a := New()
+
+	network := &net.IPNet{
+		IP:   []byte{192, 168, 0, 1},
+		Mask: []byte{255, 255, 255, 248},
+	}
+
+	var ip net.IP
+	var err error
+
+	history := make(map[string]string)
+	for req := 0; req < 6; req++ {
+		ip, err = a.RequestIP(network, nil, "name"+strconv.Itoa(req))
+		history["name"+strconv.Itoa(req)] = ip.String()
+		a.ReleaseIP(network, ip)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for req := 0; req < 6; req++ {
+		ip, err = a.RequestIP(network, nil, "name"+strconv.Itoa(req))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ip.String() != history["name"+strconv.Itoa(req)] {
+			t.Fatalf("Allocate from cache expected %s got %s", history["name"+strconv.Itoa(req)], ip.String())
+		}
 	}
 }
 
@@ -681,7 +757,7 @@ func BenchmarkRequestIP(b *testing.B) {
 		a := New()
 
 		for j := 0; j < 253; j++ {
-			_, err := a.RequestIP(network, nil)
+			_, err := a.RequestIP(network, nil, "name_"+strconv.Itoa(j))
 			if err != nil {
 				b.Fatal(err)
 			}


### PR DESCRIPTION
Simple DHCP style, ip caching but by name.
If the IP is free re-allocate the same IP back to a restarted or recreated container.
Otherwise allocate from a never used IP, otherwise recycle the oldest released IP

Signed-off-by: Sam Abed sam.abed@gmail.com
