### PR TITLE
Windows: Don't build Linux graph drivers

### DIFF
--- a/daemon/daemon_aufs.go
+++ b/daemon/daemon_aufs.go
@@ -1,4 +1,4 @@
-// +build !exclude_graphdriver_aufs
+// +build !exclude_graphdriver_aufs,linux
 
 package daemon
 

--- a/daemon/daemon_btrfs.go
+++ b/daemon/daemon_btrfs.go
@@ -1,4 +1,4 @@
-// +build !exclude_graphdriver_btrfs
+// +build !exclude_graphdriver_btrfs,linux
 
 package daemon
 

--- a/daemon/daemon_devicemapper.go
+++ b/daemon/daemon_devicemapper.go
@@ -1,4 +1,4 @@
-// +build !exclude_graphdriver_devicemapper
+// +build !exclude_graphdriver_devicemapper,linux
 
 package daemon
 

--- a/daemon/daemon_no_aufs.go
+++ b/daemon/daemon_no_aufs.go
@@ -1,4 +1,4 @@
-// +build exclude_graphdriver_aufs
+// +build exclude_graphdriver_aufs,linux
 
 package daemon
 

--- a/daemon/daemon_overlay.go
+++ b/daemon/daemon_overlay.go
@@ -1,4 +1,4 @@
-// +build !exclude_graphdriver_overlay
+// +build !exclude_graphdriver_overlay,linux
 
 package daemon
 

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -1,20 +1,22 @@
+// +build linux
+
 /*
 
 aufs driver directory structure
 
-.
-├── layers // Metadata of layers
-│   ├── 1
-│   ├── 2
-│   └── 3
-├── diff  // Content of the layer
-│   ├── 1  // Contains layers that need to be mounted for the id
-│   ├── 2
-│   └── 3
-└── mnt    // Mount points for the rw layers to be mounted
-    ├── 1
-    ├── 2
-    └── 3
+  .
+  ├── layers // Metadata of layers
+  │   ├── 1
+  │   ├── 2
+  │   └── 3
+  ├── diff  // Content of the layer
+  │   ├── 1  // Contains layers that need to be mounted for the id
+  │   ├── 2
+  │   └── 3
+  └── mnt    // Mount points for the rw layers to be mounted
+      ├── 1
+      ├── 2
+      └── 3
 
 */
 

--- a/daemon/graphdriver/aufs/aufs_test.go
+++ b/daemon/graphdriver/aufs/aufs_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package aufs
 
 import (

--- a/daemon/graphdriver/aufs/dirs.go
+++ b/daemon/graphdriver/aufs/dirs.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package aufs
 
 import (

--- a/daemon/graphdriver/aufs/migrate.go
+++ b/daemon/graphdriver/aufs/migrate.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package aufs
 
 import (

--- a/daemon/graphdriver/aufs/mount.go
+++ b/daemon/graphdriver/aufs/mount.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package aufs
 
 import (

--- a/daemon/graphdriver/aufs/mount_unsupported.go
+++ b/daemon/graphdriver/aufs/mount_unsupported.go
@@ -7,5 +7,5 @@ import "errors"
 const MsRemount = 0
 
 func mount(source string, target string, fstype string, flags uintptr, data string) (err error) {
-	return errors.New("mount is not implemented on darwin")
+	return errors.New("mount is not implemented on this platform")
 }

--- a/daemon/graphdriver/btrfs/btrfs_test.go
+++ b/daemon/graphdriver/btrfs/btrfs_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package btrfs
 
 import (

--- a/daemon/graphdriver/overlay/overlay_test.go
+++ b/daemon/graphdriver/overlay/overlay_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package overlay
 
 import (

--- a/daemon/graphdriver/overlay/overlay_unsupported.go
+++ b/daemon/graphdriver/overlay/overlay_unsupported.go
@@ -1,0 +1,3 @@
+// +build !linux
+
+package overlay

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package vfs
 
 import (
@@ -7,6 +9,7 @@ import (
 
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/chrootarchive"
+	"github.com/docker/docker/pkg/system"
 	"github.com/docker/libcontainer/label"
 )
 
@@ -39,7 +42,7 @@ func (d *Driver) Cleanup() error {
 
 func (d *Driver) Create(id, parent string) error {
 	dir := d.dir(id)
-	if err := os.MkdirAll(path.Dir(dir), 0700); err != nil {
+	if err := system.MkdirAll(path.Dir(dir), 0700); err != nil {
 		return err
 	}
 	if err := os.Mkdir(dir, 0755); err != nil {

--- a/daemon/graphdriver/vfs/driver_unsupported.go
+++ b/daemon/graphdriver/vfs/driver_unsupported.go
@@ -1,0 +1,3 @@
+// +build !linux
+
+package vfs

--- a/daemon/graphdriver/vfs/vfs_test.go
+++ b/daemon/graphdriver/vfs/vfs_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package vfs
 
 import (


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This change stops the Linux-specific graph drivers from building on Windows.
