### PR TITLE
Windows: Info no containerized check

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -33,11 +33,15 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	if s, err := operatingsystem.GetOperatingSystem(); err == nil {
 		operatingSystem = s
 	}
-	if inContainer, err := operatingsystem.IsContainerized(); err != nil {
-		logrus.Errorf("Could not determine if daemon is containerized: %v", err)
-		operatingSystem += " (error determining if containerized)"
-	} else if inContainer {
-		operatingSystem += " (containerized)"
+
+	// Don't do containerized check on Windows
+	if runtime.GOOS != "windows" {
+		if inContainer, err := operatingsystem.IsContainerized(); err != nil {
+			logrus.Errorf("Could not determine if daemon is containerized: %v", err)
+			operatingSystem += " (error determining if containerized)"
+		} else if inContainer {
+			operatingSystem += " (containerized)"
+		}
 	}
 
 	meminfo, err := system.ReadMemInfo()


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This PR stops the containerized check during the info command on the Windows path.
