### PR TITLE
Expose whole Response struct in sockRequestRaw

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -339,8 +339,8 @@ func (s *DockerSuite) TestBuildApiDockerfilePath(c *check.C) {
 		c.Fatalf("failed to close tar archive: %v", err)
 	}
 
-	status, body, err := sockRequestRaw("POST", "/build?dockerfile=../Dockerfile", buffer, "application/x-tar")
-	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	res, body, err := sockRequestRaw("POST", "/build?dockerfile=../Dockerfile", buffer, "application/x-tar")
+	c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
 	c.Assert(err, check.IsNil)
 
 	out, err := readBody(body)
@@ -365,8 +365,8 @@ RUN find /tmp/`,
 	}
 	defer server.Close()
 
-	status, body, err := sockRequestRaw("POST", "/build?dockerfile=baz&remote="+server.URL()+"/testD", nil, "application/json")
-	c.Assert(status, check.Equals, http.StatusOK)
+	res, body, err := sockRequestRaw("POST", "/build?dockerfile=baz&remote="+server.URL()+"/testD", nil, "application/json")
+	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
 
 	buf, err := readBody(body)
@@ -393,8 +393,8 @@ RUN echo from dockerfile`,
 	}
 	defer git.Close()
 
-	status, body, err := sockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json")
-	c.Assert(status, check.Equals, http.StatusOK)
+	res, body, err := sockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json")
+	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
 
 	buf, err := readBody(body)
@@ -421,8 +421,8 @@ RUN echo from Dockerfile`,
 	defer git.Close()
 
 	// Make sure it tries to 'dockerfile' query param value
-	status, body, err := sockRequestRaw("POST", "/build?dockerfile=baz&remote="+git.RepoURL, nil, "application/json")
-	c.Assert(status, check.Equals, http.StatusOK)
+	res, body, err := sockRequestRaw("POST", "/build?dockerfile=baz&remote="+git.RepoURL, nil, "application/json")
+	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
 
 	buf, err := readBody(body)
@@ -450,8 +450,8 @@ RUN echo from dockerfile`,
 	defer git.Close()
 
 	// Make sure it tries to 'dockerfile' query param value
-	status, body, err := sockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json")
-	c.Assert(status, check.Equals, http.StatusOK)
+	res, body, err := sockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json")
+	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
 
 	buf, err := readBody(body)
@@ -483,8 +483,8 @@ func (s *DockerSuite) TestBuildApiDockerfileSymlink(c *check.C) {
 		c.Fatalf("failed to close tar archive: %v", err)
 	}
 
-	status, body, err := sockRequestRaw("POST", "/build", buffer, "application/x-tar")
-	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	res, body, err := sockRequestRaw("POST", "/build", buffer, "application/x-tar")
+	c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
 	c.Assert(err, check.IsNil)
 
 	out, err := readBody(body)
@@ -720,7 +720,7 @@ func (s *DockerSuite) TestContainerApiVerifyHeader(c *check.C) {
 		"Image": "busybox",
 	}
 
-	create := func(ct string) (int, io.ReadCloser, error) {
+	create := func(ct string) (*http.Response, io.ReadCloser, error) {
 		jsonData := bytes.NewBuffer(nil)
 		if err := json.NewEncoder(jsonData).Encode(config); err != nil {
 			c.Fatal(err)
@@ -729,21 +729,21 @@ func (s *DockerSuite) TestContainerApiVerifyHeader(c *check.C) {
 	}
 
 	// Try with no content-type
-	status, body, err := create("")
-	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	res, body, err := create("")
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
 	body.Close()
 
 	// Try with wrong content-type
-	status, body, err = create("application/xml")
-	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	res, body, err = create("application/xml")
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
 	body.Close()
 
 	// now application/json
-	status, body, err = create("application/json")
-	c.Assert(status, check.Equals, http.StatusCreated)
+	res, body, err = create("application/json")
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusCreated)
 	body.Close()
 }
 
@@ -774,8 +774,8 @@ func (s *DockerSuite) TestContainerApiPostCreateNull(c *check.C) {
 		"NetworkDisabled":false,
 		"OnBuild":null}`
 
-	status, body, err := sockRequestRaw("POST", "/containers/create", strings.NewReader(config), "application/json")
-	c.Assert(status, check.Equals, http.StatusCreated)
+	res, body, err := sockRequestRaw("POST", "/containers/create", strings.NewReader(config), "application/json")
+	c.Assert(res.StatusCode, check.Equals, http.StatusCreated)
 	c.Assert(err, check.IsNil)
 
 	b, err := readBody(body)
@@ -808,13 +808,13 @@ func (s *DockerSuite) TestCreateWithTooLowMemoryLimit(c *check.C) {
 		"Memory":    524287
 	}`
 
-	status, body, _ := sockRequestRaw("POST", "/containers/create", strings.NewReader(config), "application/json")
+	res, body, _ := sockRequestRaw("POST", "/containers/create", strings.NewReader(config), "application/json")
 	b, err2 := readBody(body)
 	if err2 != nil {
 		c.Fatal(err2)
 	}
 
-	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
 	c.Assert(strings.Contains(string(b), "Minimum memory limit allowed is 4MB"), check.Equals, true)
 }
 
@@ -831,13 +831,13 @@ func (s *DockerSuite) TestStartWithTooLowMemoryLimit(c *check.C) {
                 "Memory":    524287
         }`
 
-	status, body, _ := sockRequestRaw("POST", "/containers/"+containerID+"/start", strings.NewReader(config), "application/json")
+	res, body, _ := sockRequestRaw("POST", "/containers/"+containerID+"/start", strings.NewReader(config), "application/json")
 	b, err2 := readBody(body)
 	if err2 != nil {
 		c.Fatal(err2)
 	}
 
-	c.Assert(status, check.Equals, http.StatusInternalServerError)
+	c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
 	c.Assert(strings.Contains(string(b), "Minimum memory limit allowed is 4MB"), check.Equals, true)
 }
 

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -74,9 +74,9 @@ func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 	}
 	id := strings.TrimSpace(out)
 
-	status, body, err := sockRequestRaw("GET", "/images/"+id+"/get", nil, "")
-	c.Assert(status, check.Equals, http.StatusOK)
+	res, body, err := sockRequestRaw("GET", "/images/"+id+"/get", nil, "")
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 
 	defer body.Close()
 
@@ -84,9 +84,9 @@ func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 		c.Fatal(err, out)
 	}
 
-	status, loadBody, err := sockRequestRaw("POST", "/images/load", body, "application/x-tar")
-	c.Assert(status, check.Equals, http.StatusOK)
+	res, loadBody, err := sockRequestRaw("POST", "/images/load", body, "application/x-tar")
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 
 	defer loadBody.Close()
 

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -20,22 +20,22 @@ func (s *DockerSuite) TestLogsApiWithStdout(c *check.C) {
 	}
 
 	type logOut struct {
-		out    string
-		status int
-		err    error
+		out string
+		res *http.Response
+		err error
 	}
 	chLog := make(chan logOut)
 
 	go func() {
-		statusCode, body, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&timestamps=1", id), nil, "")
+		res, body, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&timestamps=1", id), nil, "")
 		out, _ := bufio.NewReader(body).ReadString('\n')
-		chLog <- logOut{strings.TrimSpace(out), statusCode, err}
+		chLog <- logOut{strings.TrimSpace(out), res, err}
 	}()
 
 	select {
 	case l := <-chLog:
-		c.Assert(l.status, check.Equals, http.StatusOK)
 		c.Assert(l.err, check.IsNil)
+		c.Assert(l.res.StatusCode, check.Equals, http.StatusOK)
 		if !strings.HasSuffix(l.out, "hello") {
 			c.Fatalf("expected log output to container 'hello', but it does not")
 		}


### PR DESCRIPTION
`sockRequestRaw` and `sockRequest` now just differ in what they return by just one return type (`[]byte` vs `io.Reader`).
I'd like to access more fields of an `http.Response` if I use `sockRequestRaw`, not just the StatusCode (for this there's already `sockRequest`). I could just need to access `Header` strings.
I'm against adding a new return value when we can directly expose the Response, just my thought. Doing the other way means everytime we need a new field we add it to the return values...
I see `sockRequestRaw` as more low level and due to this I think make sense to expose the whole Response. Of course, who uses this must check before that err is not nil before accessing response fields and as it's now, people have to close the body if using `sockRequestRaw` so same deal.

Signed-off-by: Antonio Murdaca me@runcom.ninja
