### PR TITLE
Fix undead containers

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -129,6 +129,7 @@ func (daemon *Daemon) commonRm(container *Container, forceRemove bool) (err erro
 		if err != nil && forceRemove {
 			daemon.idIndex.Delete(container.ID)
 			daemon.containers.Delete(container.ID)
+			os.RemoveAll(container.root)
 		}
 	}()
 


### PR DESCRIPTION
Fixes #12825

When a container has errors on removal, it gets flagged as dead.
If you `docker rm -f` a dead container the container is dereffed from
the daemon and doesn't show up on `docker ps` anymore... except that the
container JSON file may still be lingering around and becomes undead
when you restart the daemon.
