### PR TITLE
Windows: Fork execdrivers.go for Windows execdriver

### DIFF
--- a/daemon/execdriver/execdrivers/execdrivers_linux.go
+++ b/daemon/execdriver/execdrivers/execdrivers_linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package execdrivers
 
 import (

--- a/daemon/execdriver/execdrivers/execdrivers_windows.go
+++ b/daemon/execdriver/execdrivers/execdrivers_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+
+package execdrivers
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/daemon/execdriver"
+	"github.com/docker/docker/daemon/execdriver/windows"
+	"github.com/docker/docker/pkg/sysinfo"
+)
+
+func NewDriver(name, root, libPath, initPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
+	switch name {
+	case "windows":
+		return windows.NewDriver(root, initPath)
+	}
+	return nil, fmt.Errorf("unknown exec driver %s", name)
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This PR splits daemon/execdriver/execdrivers/execdriver.go for Linux and Windows support. (The Windows execdriver itself will be in a later PR). 
