### PR TITLE
Windows: Factor out LXC

### DIFF
--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package lxc
 
 import (

--- a/daemon/execdriver/lxc/info.go
+++ b/daemon/execdriver/lxc/info.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package lxc
 
 import (

--- a/daemon/execdriver/lxc/info_test.go
+++ b/daemon/execdriver/lxc/info_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package lxc
 
 import (

--- a/daemon/execdriver/lxc/init.go
+++ b/daemon/execdriver/lxc/init.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package lxc
 
 import (

--- a/daemon/execdriver/lxc/lxc_init_linux.go
+++ b/daemon/execdriver/lxc/lxc_init_linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package lxc
 
 import (

--- a/daemon/execdriver/lxc/lxc_init_unsupported.go
+++ b/daemon/execdriver/lxc/lxc_init_unsupported.go
@@ -3,5 +3,5 @@
 package lxc
 
 func finalizeNamespace(args *InitArgs) error {
-	panic("Not supported on darwin")
+	panic("Not supported on this platform")
 }

--- a/daemon/execdriver/lxc/lxc_template.go
+++ b/daemon/execdriver/lxc/lxc_template.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package lxc
 
 import (


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This change factors out the LXC exec driver on Windows where it is not required.
