### PR TITLE
use CustomSize replace intToString

### DIFF
--- a/pkg/units/size.go
+++ b/pkg/units/size.go
@@ -37,23 +37,25 @@ var (
 var decimapAbbrs = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"}
 var binaryAbbrs = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"}
 
+// CustomSize returns a human-readable approximation of a size
+// using custom format
+func CustomSize(format string, size float64, base float64, _map []string) string {
+	i := 0
+	for size >= base {
+		size = size / base
+		i++
+	}
+	return fmt.Sprintf(format, size, _map[i])
+}
+
 // HumanSize returns a human-readable approximation of a size
 // using SI standard (eg. "44kB", "17MB")
 func HumanSize(size float64) string {
-	return intToString(float64(size), 1000.0, decimapAbbrs)
+	return CustomSize("%.4g %s", float64(size), 1000.0, decimapAbbrs)
 }
 
 func BytesSize(size float64) string {
-	return intToString(size, 1024.0, binaryAbbrs)
-}
-
-func intToString(size, unit float64, _map []string) string {
-	i := 0
-	for size >= unit {
-		size = size / unit
-		i++
-	}
-	return fmt.Sprintf("%.4g %s", size, _map[i])
+	return CustomSize("%.4g %s", size, 1024.0, binaryAbbrs)
 }
 
 // FromHumanSize returns an integer from a human-readable specification of a


### PR DESCRIPTION
Signed-off-by: Ma Shimiao mashimiao.fnst@cn.fujitsu.com
With this change, we can use custom format.
As we know, 1024kB = 1MB in kernel.
Without this change, we can't convert 1024kB to 1MB by functions in size.go, it's very inconvenient.
