### PR TITLE
fix a minor inspect format issue

### DIFF
--- a/api/client/inspect.go
+++ b/api/client/inspect.go
@@ -34,7 +34,7 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 	}
 
 	indented := new(bytes.Buffer)
-	indented.WriteByte('[')
+	indented.WriteString("[\n")
 	status := 0
 	isImage := false
 


### PR DESCRIPTION
Before, inspect cont1 cont2 shows:

```
[{
    xxx
}
,{
    xxx
}
]
```

After, it shows:

```
[
{
   xxx
}
,{
    xxx
}
]
```

Because `func (*Encoder) Encode` always followed by a newline character,
so it's difficult to put '}' and ']' one the same line.

To get symmetry, above is our choice.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
