### PR TITLE
Fix error message on firewalld init

### DIFF
--- a/daemon/networkdriver/bridge/driver.go
+++ b/daemon/networkdriver/bridge/driver.go
@@ -232,7 +232,9 @@ func InitDriver(config *Config) error {
 	}
 
 	if config.EnableIptables {
-		iptables.FirewalldInit()
+		if err := iptables.FirewalldInit(); err != nil {
+			logrus.Debugf("Error initializing firewalld: %v", err)
+		}
 	}
 
 	// Configure iptables for link support

--- a/pkg/iptables/firewalld_test.go
+++ b/pkg/iptables/firewalld_test.go
@@ -7,7 +7,12 @@ import (
 )
 
 func TestFirewalldInit(t *testing.T) {
-	FirewalldInit()
+	if !checkRunning() {
+		t.Skip("firewalld is not running")
+	}
+	if err := FirewalldInit(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestReloaded(t *testing.T) {


### PR DESCRIPTION
If firewalld is not installed (or I suppose not running), firewalld was
producing an error in the daemon init logs, even though firewalld is not
required for iptables stuff to function.
The firewalld library code was also logging directly to logrus instead
of returning errors.

Moved logging code higher up in the stack and changed firewalld code to
return errors where appropriate.

Signed-off-by: Brian Goff cpuguy83@gmail.com
