### PR TITLE
Remove incorrect option in docker install command

### DIFF
--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -308,5 +308,5 @@ NetworkManager (this might slow your network).
 
 To install the latest version of Docker, use the standard `-N` flag with `wget`:
 
-	$ wget -N -qO- https://get.docker.com/ | sh
+	$ wget -qO- https://get.docker.com/ | sh
 


### PR DESCRIPTION
The `-N` option is not compatible with the `-O` option of wget (see the man page).

The example command now matches the example in the script on http://get.docker.com/.
