### PR TITLE
Respect shell globs when running `docker cp`.

### DIFF
--- a/daemon/container_unit_test.go
+++ b/daemon/container_unit_test.go
@@ -1,8 +1,9 @@
 package daemon
 
 import (
-	"github.com/docker/docker/nat"
 	"testing"
+
+	"github.com/docker/docker/nat"
 )
 
 func TestParseNetworkOptsPrivateOnly(t *testing.T) {
@@ -192,6 +193,48 @@ func TestValidContainerNames(t *testing.T) {
 	for _, name := range validNames {
 		if !validContainerNamePattern.MatchString(name) {
 			t.Fatalf("%q is a valid container name and was returned as invalid.", name)
+		}
+	}
+}
+
+func TestFindSignificantParent(t *testing.T) {
+	cases := []struct {
+		paths []string
+		exp   string
+	}{
+		{
+			[]string{
+				"/etc/foo/bar/baz/qux",
+				"/etc/foo/qux",
+				"/etc/foo",
+				"/etc/foo/bar/baz",
+				"/etc/bar",
+				"/etc/foo/bar",
+			}, "/etc/",
+		},
+		{
+			[]string{
+				"/etc/foo/bar/baz/qux",
+				"/etc/foo/qux",
+				"/etc/foo",
+				"/etc/foo/bar/baz",
+				"/etc/foo/bar",
+			}, "/etc/",
+		},
+		{
+			[]string{
+				"/var/lib",
+				"/etc/bar/baz",
+			}, "/",
+		},
+		{
+			[]string{"/var/lib"}, "/var/",
+		},
+	}
+
+	for _, c := range cases {
+		if b := findSignificantParent(c.paths); b != c.exp {
+			t.Fatalf("Expected %s, was %s\n", c.exp, b)
 		}
 	}
 }

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -976,6 +976,9 @@ relative to the root of the container's filesystem.
 
     Copy files/folders from the PATH to the HOSTDIR.
 
+This command respects shell globs inside the container's filesystem. For instance:
+
+    docker cp CONTAINER:/tmp/* /tmp
 
 ## create
 

--- a/pkg/symlink/fs_test.go
+++ b/pkg/symlink/fs_test.go
@@ -400,3 +400,17 @@ func TestFollowSymlinkNoLexicalCleaning(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestFollowSymlinkWildcard(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "TestFollowSymlinkWildcard")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+	if err := makeFs(tmpdir, []dirOrLink{{path: "testdata/fs/a/d", target: "/b"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := testSymlink(tmpdir, "testdata/fs/a/d/c/*", "testdata/b/c/*", "testdata"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Fixes #6013

/cc @huslage, @jlhawn

Signed-off-by: David Calavera david.calavera@gmail.com
