### PR TITLE
Add volume drivers

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -864,12 +864,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine, registryService 
 		return nil, err
 	}
 
-	volumesDriver, err := graphdriver.GetDriver("vfs", config.Root, config.GraphOptions)
-	if err != nil {
-		return nil, err
-	}
-
-	volumes, err := volumes.NewRepository(filepath.Join(config.Root, "volumes"), volumesDriver)
+	volumes, err := volumes.NewRepository(filepath.Join(config.Root, "volumes"), filepath.Join(config.Root, "volume-data"))
 	if err != nil {
 		return nil, err
 	}

--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -18,7 +18,7 @@ var (
 
 	dockerBasePath       = "/var/lib/docker"
 	volumesConfigPath    = dockerBasePath + "/volumes"
-	volumesStoragePath   = dockerBasePath + "/vfs/dir"
+	volumesStoragePath   = dockerBasePath + "/volume-data"
 	containerStoragePath = dockerBasePath + "/containers"
 
 	runtimePath    = "/var/run/docker"

--- a/volumes/volume_test.go
+++ b/volumes/volume_test.go
@@ -1,55 +1,37 @@
 package volumes
 
-import (
-	"os"
-	"testing"
+import "testing"
 
-	"github.com/docker/docker/pkg/stringutils"
-)
+type dummyDriver struct{}
+
+func (d *dummyDriver) Create(path string) error {
+	return nil
+}
+func (d *dummyDriver) Remove(path string) error {
+	return nil
+}
+func (d *dummyDriver) Link(path, id string) error {
+	return nil
+}
+func (d *dummyDriver) Unlink(path, id string) error {
+	return nil
+}
+func (d *dummyDriver) Exists(path string) bool {
+	return true
+}
 
 func TestContainers(t *testing.T) {
-	v := &Volume{containers: make(map[string]struct{})}
+	v := &Volume{containers: make(map[string]struct{}), driver: &dummyDriver{}}
 	id := "1234"
 
-	v.AddContainer(id)
+	v.Link(id)
 
 	if v.Containers()[0] != id {
 		t.Fatalf("adding a container ref failed")
 	}
 
-	v.RemoveContainer(id)
+	v.Unlink(id)
 	if len(v.Containers()) != 0 {
 		t.Fatalf("removing container failed")
-	}
-}
-
-// os.Stat(v.Path) is returning ErrNotExist, initialize catch it and try to
-// mkdir v.Path but it dies and correctly returns the error
-func TestInitializeCannotMkdirOnNonExistentPath(t *testing.T) {
-	v := &Volume{Path: "nonexistentpath"}
-
-	err := v.initialize()
-	if err == nil {
-		t.Fatal("Expected not to initialize volume with a non existent path")
-	}
-
-	if !os.IsNotExist(err) {
-		t.Fatalf("Expected to get ErrNotExist error, got %s", err)
-	}
-}
-
-// os.Stat(v.Path) is NOT returning ErrNotExist so skip and return error from
-// initialize
-func TestInitializeCannotStatPathFileNameTooLong(t *testing.T) {
-	// ENAMETOOLONG
-	v := &Volume{Path: stringutils.GenerateRandomAlphaOnlyString(300)}
-
-	err := v.initialize()
-	if err == nil {
-		t.Fatal("Expected not to initialize volume with a non existent path")
-	}
-
-	if os.IsNotExist(err) {
-		t.Fatal("Expected to not get ErrNotExist")
 	}
 }

--- a/volumes/volumedriver/driver.go
+++ b/volumes/volumedriver/driver.go
@@ -1,0 +1,52 @@
+package volumedriver
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	drivers        map[string]*RegisteredDriver
+	DriverNotExist = errors.New("volume driver does not exist")
+	DriverExist    = errors.New("volume driver exists")
+)
+
+type Driver interface {
+	// Create creates a new volume at the specified path
+	Create(path string) error
+	// Remove attempts to remove the volume
+	Remove(path string) error
+	// Link tells the driver that a container is now using referenced volume
+	Link(path, containerID string) error
+	// Unlink tells the driver when a container has stopped using the referenced volume
+	Unlink(path, containerID string) error
+	// Exists returns weather the volume exists
+	Exists(path string) bool
+}
+
+type InitFunc func(options map[string]string) (Driver, error)
+
+type RegisteredDriver struct {
+	New InitFunc
+}
+
+func init() {
+	drivers = make(map[string]*RegisteredDriver)
+}
+
+func Register(name string, initFunc InitFunc) error {
+	if _, exists := drivers[name]; exists {
+		return fmt.Errorf("%v - %s", DriverExist, name)
+	}
+	drivers[name] = &RegisteredDriver{initFunc}
+	return nil
+}
+
+// TODO: expose driver options
+func NewDriver(name string) (Driver, error) {
+	var opts map[string]string
+	if d, exists := drivers[name]; exists {
+		return d.New(opts)
+	}
+	return nil, fmt.Errorf("%v - %s", DriverNotExist, name)
+}

--- a/volumes/volumedriver/host/driver.go
+++ b/volumes/volumedriver/host/driver.go
@@ -1,0 +1,47 @@
+package host
+
+import (
+	"os"
+
+	"github.com/docker/docker/volumes/volumedriver"
+)
+
+const DriverName = "host"
+
+func init() {
+	volumedriver.Register(DriverName, Init)
+}
+
+func Init(_ map[string]string) (volumedriver.Driver, error) {
+	return &Driver{}, nil
+}
+
+type Driver struct{}
+
+func (d *Driver) Create(path string) error {
+	_, err := os.Stat(path)
+	if err != nil && os.IsNotExist(err) {
+		return os.MkdirAll(path, 0700)
+	}
+	return err
+}
+
+func (d *Driver) Remove(path string) error {
+	// don't remove volumes from this driver
+	return nil
+}
+
+func (d *Driver) Link(path, containerID string) error {
+	return nil
+}
+
+func (d *Driver) Unlink(path, containerID string) error {
+	return nil
+}
+
+func (d *Driver) Exists(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	return true
+}

--- a/volumes/volumedriver/host/driver_test.go
+++ b/volumes/volumedriver/host/driver_test.go
@@ -1,0 +1,23 @@
+package host
+
+import (
+	"os"
+	"testing"
+
+	"github.com/docker/docker/pkg/stringutils"
+)
+
+// os.Stat(v.Path) is NOT returning ErrNotExist so skip and return error from
+// initialize
+func TestCannotStatPathFileNameTooLong(t *testing.T) {
+	driver := &Driver{}
+
+	err := driver.Create(stringutils.GenerateRandomAlphaOnlyString(300))
+	if err == nil {
+		t.Fatal("Expected not to mkdir with path that is too long")
+	}
+
+	if os.IsNotExist(err) {
+		t.Fatal("Expected to not get ErrNotExist")
+	}
+}

--- a/volumes/volumedriver/vfs/driver.go
+++ b/volumes/volumedriver/vfs/driver.go
@@ -1,0 +1,43 @@
+package vfs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/docker/volumes/volumedriver"
+	"github.com/docker/docker/volumes/volumedriver/host"
+)
+
+type Driver struct {
+	*host.Driver
+}
+
+const DriverName = "vfs"
+
+func init() {
+	volumedriver.Register(DriverName, Init)
+}
+
+func Init(options map[string]string) (volumedriver.Driver, error) {
+	return &Driver{&host.Driver{}}, nil
+}
+
+func (d *Driver) Remove(path string) error {
+	return os.RemoveAll(path)
+}
+
+func (d *Driver) Create(path string) error {
+	stat, err := os.Stat(path)
+	if err != nil && os.IsNotExist(err) {
+		return os.MkdirAll(path, 0700)
+	}
+	if err != nil {
+		return err
+	}
+
+	if !stat.IsDir() {
+		return fmt.Errorf("file exists at path %s, can't create %s volume", path, DriverName)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Stop using vfs graphrdriver for volumes.
Create new driver interface for volumes which implements what we need for vfs and binds ("vfs" and "host" drivers).

This implements just the things we need in the drivers to get current functionality with volume drivers.
Future improvements would include:
- passing options to driver init
- passing options to volume init (e.g. `docker run -v /foo:rw,opt1=bar,opt2`)
- new driver to be used for communicating with (future) plugin system

Also potential new drivers that could be built in:
- fuse driver for remote volumes
- fuse driver for better handling of bind-mount uid/gids
- ???
### Some implementation details

Volume drivers are pretty dumb in general and really enforces the concept of the system (or use in the case of the host driver) requesting ~~a volume~~ some place to store data to be placed at some host path which later gets bind-mounted into the container.

The volume repo object manages (as it already does today) ref counting and generating paths to be used for volumes, then just passes the generated path to the volume driver with the expectation that the volume driver just creates the volume at the given path.
Partly this is to keep the implementation of new volume drivers pretty small, but also to help ensure that the "host" driver (aka bind mounts) can itself be implemented as a volume driver.
