### PR TITLE
Fix docker rename help not consistent with other commands

### DIFF
--- a/api/client/rename.go
+++ b/api/client/rename.go
@@ -1,20 +1,19 @@
 package client
 
-import "fmt"
+import (
+	"fmt"
+
+	flag "github.com/docker/docker/pkg/mflag"
+)
 
 // CmdRename renames a container.
 //
 // Usage: docker rename OLD_NAME NEW_NAME
 func (cli *DockerCli) CmdRename(args ...string) error {
 	cmd := cli.Subcmd("rename", "OLD_NAME NEW_NAME", "Rename a container", true)
-	if err := cmd.Parse(args); err != nil {
-		return nil
-	}
+	cmd.Require(flag.Exact, 2)
+	cmd.ParseFlags(args, true)
 
-	if cmd.NArg() != 2 {
-		cmd.Usage()
-		return nil
-	}
 	oldName := cmd.Arg(0)
 	newName := cmd.Arg(1)
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
The docker command help messages should be like this
`docker: "run" requires a minimum of 1 argument. See 'docker run --help'.`
but the docker rename doesn't, it's not consistent with other commands,
I think it should be consistent.
