### PR TITLE
Prevent fallback to v1 registry for digest pulls

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -88,6 +88,10 @@ func (s *TagStore) Pull(image string, tag string, imagePullConfig *ImagePullConf
 		logrus.Debug("image does not exist on v2 registry, falling back to v1")
 	}
 
+	if utils.DigestReference(tag) {
+		return fmt.Errorf("pulling with digest reference failed from v2 registry")
+	}
+
 	logrus.Debugf("pulling v1 repository with local name %q", repoInfo.LocalName)
 	if err = s.pullRepository(r, imagePullConfig.OutStream, repoInfo, tag, sf, imagePullConfig.Parallel); err != nil {
 		return err

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -115,6 +115,16 @@ func (s *DockerRegistrySuite) TestPullByDigest(c *check.C) {
 	}
 }
 
+func (s *DockerRegistrySuite) TestPullByDigestNoFallback(c *check.C) {
+	// pull from the registry using the <name>@<digest> reference
+	imageReference := fmt.Sprintf("%s@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", repoName)
+	cmd := exec.Command(dockerBinary, "pull", imageReference)
+	out, _, err := runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "pulling with digest reference failed from v2 registry") {
+		c.Fatalf("expected non-zero exit status and correct error message when pulling non-existing image: %s", out)
+	}
+}
+
 func (s *DockerRegistrySuite) TestCreateByDigest(c *check.C) {
 	pushDigest, err := setupImage()
 	if err != nil {


### PR DESCRIPTION
Prevent fallback to v1 registry when pull is for a digest. The intention of the user is to download a verified image if explicitly pulling with a digest and falling back to v1 registry circumvents that protection.

Fixes #12879.
