### PR TITLE
Docs adding uninstall instructions

### DIFF
--- a/docs/sources/installation/SUSE.md
+++ b/docs/sources/installation/SUSE.md
@@ -28,7 +28,7 @@ Docker is available in **SUSE Linux Enterprise 12 and later**. Please note that
 due to its current limitations Docker is able to run only on **64 bit**
 architecture.
 
-# Installation
+## Installation
 
 Install the Docker package.
 
@@ -75,6 +75,20 @@ hand to ensure the `FW_ROUTE` flag is set to `yes` like so:
 If you need to add an HTTP Proxy, set a different directory or partition for the
 Docker runtime files, or make other customizations, read our systemd article to
 learn how to [customize your systemd Docker daemon options](/articles/systemd/).
+
+## Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo zypper rm docker
+
+The above command will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.
 
 ## What's next
 

--- a/docs/sources/installation/archlinux.md
+++ b/docs/sources/installation/archlinux.md
@@ -30,13 +30,13 @@ in the packages. The core dependencies are:
 
 For the normal package a simple
 
-    pacman -S docker
+    $ sudo pacman -S docker
 
 is all that is needed.
 
 For the AUR package execute:
 
-    yaourt -S docker-git
+    $ sudo yaourt -S docker-git
 
 The instructions here assume **yaourt** is installed. See [Arch User
 Repository](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages)
@@ -59,3 +59,21 @@ To start on system boot:
 If you need to add an HTTP Proxy, set a different directory or partition for the
 Docker runtime files, or make other customizations, read our systemd article to
 learn how to [customize your systemd Docker daemon options](/articles/systemd/).
+
+## Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo pacman -R docker
+
+To uninstall the Docker package and dependencies that are no longer needed:
+
+    $ sudo pacman -Rns docker
+
+The above commands will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.

--- a/docs/sources/installation/centos.md
+++ b/docs/sources/installation/centos.md
@@ -25,7 +25,10 @@ To run Docker on [CentOS-6.5](http://www.centos.org) or later, you will need
 kernel version 2.6.32-431 or higher as this has specific kernel fixes to allow
 Docker to run.
 
-## Installing Docker - CentOS-7
+## CentOS-7
+
+### Installation
+
 Docker is included by default in the CentOS-Extras repository. To install
 run the following command:
 
@@ -33,7 +36,23 @@ run the following command:
 
 Please continue with the [Starting the Docker daemon](#starting-the-docker-daemon).
 
-## Installing Docker - CentOS-6.5
+### Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo yum -y remove docker
+
+The above command will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.
+
+## CentOS-6.5
+
+### Installation
 
 For CentOS-6.5, the Docker package is part of [Extra Packages
 for Enterprise Linux (EPEL)](https://fedoraproject.org/wiki/EPEL) repository,
@@ -56,6 +75,20 @@ Next, let's install the `docker-io` package which will install Docker on our hos
     $ sudo yum install docker-io
 
 Please continue with the [Starting the Docker daemon](#starting-the-docker-daemon).
+
+### Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo yum -y remove docker-io
+
+The above command will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.
 
 ## Manual installation of latest Docker release
 

--- a/docs/sources/installation/cruxlinux.md
+++ b/docs/sources/installation/cruxlinux.md
@@ -15,9 +15,9 @@ The `docker` port will build and install the latest tagged version of Docker.
 
 ## Installation
 
-Assuming you have contrib enabled, update your ports tree and install docker (*as root*):
+Assuming you have contrib enabled, update your ports tree and install docker:
 
-    # prt-get depinst docker
+    $ sudo prt-get depinst docker
 
 
 ## Kernel requirements
@@ -27,7 +27,7 @@ the necessary modules enabled for the Docker Daemon to function correctly.
 
 Please read the `README`:
 
-    $ prt-get readme docker
+    $ sudo prt-get readme docker
 
 The `docker` port installs the `contrib/check-config.sh` script
 provided by the Docker contributors for checking your kernel
@@ -39,9 +39,9 @@ To check your Kernel configuration run:
 
 ## Starting Docker
 
-There is a rc script created for Docker. To start the Docker service (*as root*):
+There is a rc script created for Docker. To start the Docker service:
 
-    # /etc/rc.d/docker start
+    $ sudo /etc/rc.d/docker start
 
 To start on system boot:
 
@@ -59,6 +59,20 @@ or use it as part of your `FROM` line in your `Dockerfile(s)`.
 
 There are also user contributed [CRUX based image(s)](https://registry.hub.docker.com/repos/crux/) on the Docker Hub.
 
+
+## Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo prt-get remove docker
+
+The above command will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.
 
 ## Issues
 

--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -37,6 +37,24 @@ container runs, it prints an informational message. Then, it exits.
 > If you want to enable memory and swap accounting see
 > [this](/installation/ubuntulinux/#memory-and-swap-accounting).
 
+### Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo apt-get purge docker-io
+
+To uninstall the Docker package and dependencies that are no longer needed:
+
+    $ sudo apt-get autoremove --purge docker-io
+
+The above commands will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.
+
 ## Debian Wheezy/Stable 7.x (64-bit)
 
 Docker requires Kernel 3.8+, while Wheezy ships with Kernel 3.2 (for more details
@@ -73,6 +91,24 @@ which is officially supported by Docker.
 >add the key directly using the following:
 >
 >       $ wget -qO- https://get.docker.com/gpg | sudo apt-key add -
+
+### Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo apt-get purge lxc-docker
+
+To uninstall the Docker package and dependencies that are no longer needed:
+
+    $ sudo apt-get autoremove --purge lxc-docker
+
+The above commands will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.
 
 ## Giving non-root access
 

--- a/docs/sources/installation/fedora.md
+++ b/docs/sources/installation/fedora.md
@@ -13,19 +13,37 @@ Currently the Fedora project will only support Docker when running on kernels
 shipped by the distribution. There are kernel changes which will cause issues
 if one decides to step outside that box and run non-distribution kernel packages.
 
-## Fedora 21 and later installation
+## Fedora 21 and later
 
-Install the `docker` package which will install Docker on our host.
+### Installation
+
+Install the Docker package which will install Docker on our host.
 
     $ sudo yum -y install docker
 
-To update the `docker` package:
+To update the Docker package:
 
     $ sudo yum -y update docker
 
 Please continue with the [Starting the Docker daemon](#starting-the-docker-daemon).
 
-## Fedora 20 installation
+### Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo yum -y remove docker
+
+The above command will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.
+
+## Fedora 20
+
+### Installation
 
 For `Fedora 20`, there is a package name conflict with a system tray application
 and its executable, so the Docker RPM package was called `docker-io`.
@@ -36,11 +54,25 @@ package first.
     $ sudo yum -y remove docker
     $ sudo yum -y install docker-io
 
-To update the `docker` package:
+To update the Docker package:
 
     $ sudo yum -y update docker-io
 
 Please continue with the [Starting the Docker daemon](#starting-the-docker-daemon).
+
+### Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo yum -y remove docker-io
+
+The above command will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.
 
 ## Starting the Docker daemon
 

--- a/docs/sources/installation/frugalware.md
+++ b/docs/sources/installation/frugalware.md
@@ -28,7 +28,7 @@ in the packages. The core dependencies are:
 
 A simple
 
-    pacman -S lxc-docker
+    $ sudo pacman -S lxc-docker
 
 is all that is needed.
 
@@ -48,3 +48,21 @@ To start on system boot:
 If you need to add an HTTP Proxy, set a different directory or partition for the
 Docker runtime files, or make other customizations, read our systemd article to
 learn how to [customize your systemd Docker daemon options](/articles/systemd/).
+
+## Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo pacman -R lxc-docker
+
+To uninstall the Docker package and dependencies that are no longer needed:
+
+    $ sudo pacman -Rns lxc-docker
+
+The above commands will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.

--- a/docs/sources/installation/gentoolinux.md
+++ b/docs/sources/installation/gentoolinux.md
@@ -95,3 +95,21 @@ To start on system boot:
 If you need to add an HTTP Proxy, set a different directory or partition for the
 Docker runtime files, or make other customizations, read our systemd article to
 learn how to [customize your systemd Docker daemon options](/articles/systemd/).
+
+## Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo emerge -cav app-emulation/docker
+
+To uninstall the Docker package and dependencies that are no longer needed:
+
+    $ sudo emerge -C app-emulation/docker
+
+The above commands will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.

--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -2,7 +2,7 @@ page_title: Installation on Mac OS X
 page_description: Instructions for installing Docker on OS X using boot2docker.
 page_keywords: Docker, Docker documentation, requirements, boot2docker, VirtualBox, SSH, Linux, OSX, OS X, Mac
 
-# Install Docker on Mac OS X
+# Mac OS X
 
 You can install Docker using Boot2Docker to run `docker` commands at your command-line.
 Choose this installation if you are familiar with the command-line or plan to
@@ -55,17 +55,17 @@ When you start the `boot2docker` process, the VM is assigned an IP address. Unde
 practice, work through the exercises on this page.
 
 
-### Install Boot2Docker
+### Installation
 
 1. Go to the [boot2docker/osx-installer ](
-https://github.com/boot2docker/osx-installer/releases/latest) release page.
+   https://github.com/boot2docker/osx-installer/releases/latest) release page.
 
 4. Download Boot2Docker by clicking `Boot2Docker-x.x.x.pkg` in the "Downloads"
-section.
+   section.
 
 3. Install Boot2Docker by double-clicking the package.
 
-	The installer places Boot2Docker in your "Applications" folder.
+    The installer places Boot2Docker in your "Applications" folder.
 
 The installation places the `docker` and `boot2docker` binaries in your
 `/usr/local/bin` directory.
@@ -96,30 +96,32 @@ application:
 Once the launch completes, you can run `docker` commands. A good way to verify
 your setup succeeded is to run the `hello-world` container.
 
-		$ docker run hello-world
-		Unable to find image 'hello-world:latest' locally
-		511136ea3c5a: Pull complete
-		31cbccb51277: Pull complete
-		e45a5af57b00: Pull complete
-		hello-world:latest: The image you are pulling has been verified. Important: image verification is a tech preview feature and should not be relied on to provide security.
-		Status: Downloaded newer image for hello-world:latest
-		Hello from Docker.
-		This message shows that your installation appears to be working correctly.
+    $ docker run hello-world
+    Unable to find image 'hello-world:latest' locally
+    511136ea3c5a: Pull complete
+    31cbccb51277: Pull complete
+    e45a5af57b00: Pull complete
+    hello-world:latest: The image you are pulling has been verified.
+    Important: image verification is a tech preview feature and should not be
+    relied on to provide security.
+    Status: Downloaded newer image for hello-world:latest
+    Hello from Docker.
+    This message shows that your installation appears to be working correctly.
 
-		To generate this message, Docker took the following steps:
-		 1. The Docker client contacted the Docker daemon.
-		 2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
-			(Assuming it was not already locally available.)
-		 3. The Docker daemon created a new container from that image which runs the
-			executable that produces the output you are currently reading.
-		 4. The Docker daemon streamed that output to the Docker client, which sent it
-			to your terminal.
+    To generate this message, Docker took the following steps:
+    1. The Docker client contacted the Docker daemon.
+    2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
+       (Assuming it was not already locally available.)
+    3. The Docker daemon created a new container from that image which runs the
+       executable that produces the output you are currently reading.
+    4. The Docker daemon streamed that output to the Docker client, which sent it
+       to your terminal.
 
-		To try something more ambitious, you can run an Ubuntu container with:
-		 $ docker run -it ubuntu bash
+    To try something more ambitious, you can run an Ubuntu container with:
+    $ docker run -it ubuntu bash
 
-		For more examples and ideas, visit:
-		 http://docs.docker.com/userguide/
+    For more examples and ideas, visit:
+    http://docs.docker.com/userguide/
 
 
 A more typical way to start and stop `boot2docker` is using the command line.
@@ -130,36 +132,36 @@ Initialize and run `boot2docker` from the command line, do the following:
 
 1. Create a new Boot2Docker VM.
 
-		$ boot2docker init
+        $ boot2docker init
 
-	This creates a new virtual machine. You only need to run this command once.
+    This creates a new virtual machine. You only need to run this command once.
 
 2. Start the `boot2docker` VM.
 
-		$ boot2docker start
+        $ boot2docker start
 
 3. Display the environment variables for the Docker client.
 
-		$ boot2docker shellinit
-		Writing /Users/mary/.boot2docker/certs/boot2docker-vm/ca.pem
-		Writing /Users/mary/.boot2docker/certs/boot2docker-vm/cert.pem
-		Writing /Users/mary/.boot2docker/certs/boot2docker-vm/key.pem
-			export DOCKER_HOST=tcp://192.168.59.103:2376
-			export DOCKER_CERT_PATH=/Users/mary/.boot2docker/certs/boot2docker-vm
-			export DOCKER_TLS_VERIFY=1
+        $ boot2docker shellinit
+        Writing /Users/mary/.boot2docker/certs/boot2docker-vm/ca.pem
+        Writing /Users/mary/.boot2docker/certs/boot2docker-vm/cert.pem
+        Writing /Users/mary/.boot2docker/certs/boot2docker-vm/key.pem
+            export DOCKER_HOST=tcp://192.168.59.103:2376
+            export DOCKER_CERT_PATH=/Users/mary/.boot2docker/certs/boot2docker-vm
+            export DOCKER_TLS_VERIFY=1
 
-	The specific paths and address on your machine will be different.
+    The specific paths and address on your machine will be different.
 
 4. To set the environment variables in your shell do the following:
 
-		$ eval "$(boot2docker shellinit)"
+        $ eval "$(boot2docker shellinit)"
 
-	You can also set them manually by using the `export` commands `boot2docker`
-	returns.
+    You can also set them manually by using the `export` commands `boot2docker`
+    returns.
 
 5. Run the `hello-world` container to verify your setup.
 
-		$ docker run hello-world
+        $ docker run hello-world
 
 
 ## Basic Boot2Docker exercises
@@ -167,8 +169,8 @@ Initialize and run `boot2docker` from the command line, do the following:
 At this point, you should have `boot2docker` running and the `docker` client
 environment initialized. To verify this, run the following commands:
 
-	$ boot2docker status
-	$ docker version
+    $ boot2docker status
+    $ docker version
 
 Work through this section to try some practical container tasks using `boot2docker` VM.
 
@@ -176,52 +178,52 @@ Work through this section to try some practical container tasks using `boot2dock
 
 1. Start an NGINX container on the DOCKER_HOST.
 
-		$ docker run -d -P --name web nginx
+        $ docker run -d -P --name web nginx
 
-	Normally, the `docker run` commands starts a container, runs it, and then
-	exits. The `-d` flag keeps the container running in the background
-	after the `docker run` command completes. The `-P` flag publishes exposed ports from the
-	container to your local host; this lets you access them from your Mac.
+    Normally, the `docker run` commands starts a container, runs it, and then
+    exits. The `-d` flag keeps the container running in the background
+    after the `docker run` command completes. The `-P` flag publishes exposed ports from the
+    container to your local host; this lets you access them from your Mac.
 
 2. Display your running container with `docker ps` command
 
-		CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS              PORTS                                           NAMES
-		5fb65ff765e9        nginx:latest        "nginx -g 'daemon of   3 minutes ago       Up 3 minutes        0.0.0.0:49156->443/tcp, 0.0.0.0:49157->80/tcp   web  
+        CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS              PORTS                                           NAMES
+        5fb65ff765e9        nginx:latest        "nginx -g 'daemon of   3 minutes ago       Up 3 minutes        0.0.0.0:49156->443/tcp, 0.0.0.0:49157->80/tcp   web  
 
-	At this point, you can see `nginx` is running as a daemon.
+    At this point, you can see `nginx` is running as a daemon.
 
 3. View just the container's ports.
 
-		$ docker port web
-		443/tcp -> 0.0.0.0:49156
-		80/tcp -> 0.0.0.0:49157
+        $ docker port web
+        443/tcp -> 0.0.0.0:49156
+        80/tcp -> 0.0.0.0:49157
 
-	This tells you that the `web` container's port `80` is mapped to port
-	`49157` on your Docker host.
+    This tells you that the `web` container's port `80` is mapped to port
+    `49157` on your Docker host.
 
 4. Enter the `http://localhost:49157` address (`localhost` is `0.0.0.0`) in your browser:
 
-	   ![Bad Address](/installation/images/bad_host.png)
+    ![Bad Address](/installation/images/bad_host.png)
 
-	This didn't work. The reason it doesn't work is your `DOCKER_HOST` address is
-	not the localhost address (0.0.0.0) but is instead the address of the
-	`boot2docker` VM.
+    This didn't work. The reason it doesn't work is your `DOCKER_HOST` address is
+    not the localhost address (0.0.0.0) but is instead the address of the
+    `boot2docker` VM.
 
 5. Get the address of the `boot2docker` VM.
 
-		$ boot2docker ip
-		192.168.59.103
+        $ boot2docker ip
+        192.168.59.103
 
 6. Enter the `http://192.168.59.103:49157` address in your browser:
 
-	![Correct Addressing](/installation/images/good_host.png)
+    ![Correct Addressing](/installation/images/good_host.png)
 
-	Success!
+    Success!
 
 7. To stop and then remove your running `nginx` container, do the following:
 
-		$ docker stop web
-		$ docker rm web
+        $ docker stop web
+        $ docker rm web
 
 ### Mount a volume on the container
 
@@ -231,46 +233,46 @@ The next exercise demonstrates how to do this.
 
 1. Change to your user `$HOME` directory.
 
-		$ cd $HOME
+        $ cd $HOME
 
 2. Make a new `site` directory.
 
-		$ mkdir site
+        $ mkdir site
 
 3. Change into the `site` directory.
 
-		$ cd site
+        $ cd site
 
 4. Create a new `index.html` file.
 
-		$ echo "my new site" > index.html
+        $ echo "my new site" > index.html
 
 5. Start a new `nginx` container and replace the `html` folder with your `site` directory.
 
-		$ docker run -d -P -v $HOME/site:/usr/share/nginx/html --name mysite nginx
+        $ docker run -d -P -v $HOME/site:/usr/share/nginx/html --name mysite nginx
 
 6. Get the `mysite` container's port.
 
-		$ docker port mysite
-		80/tcp -> 0.0.0.0:49166
-		443/tcp -> 0.0.0.0:49165
+        $ docker port mysite
+        80/tcp -> 0.0.0.0:49166
+        443/tcp -> 0.0.0.0:49165
 
 7. Open the site in a browser:
 
-	![My site page](/installation/images/newsite_view.png)
+    ![My site page](/installation/images/newsite_view.png)
 
 8. Try adding a page to your `$HOME/site` in real time.
 
-		$ echo "This is cool" > cool.html
+        $ echo "This is cool" > cool.html
 
 9. Open the new page in the browser.
 
-	![Cool page](/installation/images/cool_view.png)
+    ![Cool page](/installation/images/cool_view.png)
 
 9. Stop and then remove your running `mysite` container.
 
-		$ docker stop mysite
-		$ docker rm mysite
+        $ docker stop mysite
+        $ docker rm mysite
 
 ## Upgrade Boot2Docker
 
@@ -286,11 +288,11 @@ To upgrade from 1.4.1 or greater, you can do this:
 
 2. Stop the `boot2docker` application.
 
-		$ boot2docker stop
+        $ boot2docker stop
 
 3. Run the upgrade command.
 
-		$ boot2docker upgrade
+        $ boot2docker upgrade
 
 
 ### Use the installer
@@ -301,21 +303,45 @@ To upgrade any version of Boot2Docker, do this:
 
 2. Stop the `boot2docker` application.
 
-		$ boot2docker stop
+        $ boot2docker stop
 
 3. Go to the [boot2docker/osx-installer ](
    https://github.com/boot2docker/osx-installer/releases/latest) release page.
 
 4. Download Boot2Docker by clicking `Boot2Docker-x.x.x.pkg` in the "Downloads"
-section.
+   section.
 
 2. Install Boot2Docker by double-clicking the package.
 
-	The installer places Boot2Docker in your "Applications" folder.
+    The installer places Boot2Docker in your "Applications" folder.
+
+
+## Uninstallation 
+
+1. Go to the [boot2docker/osx-installer ](
+   https://github.com/boot2docker/osx-installer/releases/latest) release page. 
+
+2. Download the source code by clicking `Source code (zip)` or
+   `Source code (tar.gz)` in the "Downloads" section.
+
+3. Extract the source code.
+
+4. Open a terminal on your local machine.
+
+5. Change to the directory where you extracted the source code:
+
+        $ cd <path to extracted source code>
+
+6. Make sure the uninstall.sh script is executable:
+
+        $ chmod +x uninstall.sh
+
+7. Run the uninstall.sh script:
+
+        $ ./uninstall.sh
 
 
 ## Learning more and acknowledgement
-
 
 Use `boot2docker help` to list the full command line reference. For more
 information about using SSH or SCP to access the Boot2Docker VM, see the README

--- a/docs/sources/installation/oracle.md
+++ b/docs/sources/installation/oracle.md
@@ -43,35 +43,35 @@ To enable the *addons* repository:
 `/etc/yum.repos.d/public-yum-ol7.repo`
 and set `enabled=1` in the `[ol6_addons]` or the `[ol7_addons]` stanza.
 
-## To install Docker:
+## Installation 
 
 1. Ensure the appropriate *addons* channel or repository has been enabled.
 
 2. Use yum to install the Docker package:
 
-		$ sudo yum install docker
+        $ sudo yum install docker
 
-## To start Docker:
+## Starting Docker 
 
 1. Now that it's installed, start the Docker daemon:
 
-	1. On Oracle Linux 6:
+    1. On Oracle Linux 6:
 
-	    	$ sudo service docker start
+            $ sudo service docker start
 
-	2. On Oracle Linux 7:
+    2. On Oracle Linux 7:
 
-			$ sudo systemctl start docker.service
+            $ sudo systemctl start docker.service
 
 2. If you want the Docker daemon to start automatically at boot:
 
-	1. On Oracle Linux 6:
+    1. On Oracle Linux 6:
 
-	    	$ sudo chkconfig docker on
+            $ sudo chkconfig docker on
 
-	2. On Oracle Linux 7:
+    2. On Oracle Linux 7:
 
-			$ sudo systemctl enable docker.service
+            $ sudo systemctl enable docker.service
 
 **Done!**
 
@@ -98,6 +98,20 @@ To enable btrfs support on Oracle Linux:
 2. Restart the Docker daemon:
 
 You can now continue with the [Docker User Guide](/userguide/).
+
+## Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo yum -y remove docker
+
+The above command will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.
 
 ## Known issues
 

--- a/docs/sources/installation/rhel.md
+++ b/docs/sources/installation/rhel.md
@@ -16,7 +16,9 @@ running on kernels shipped by the distribution. There are kernel changes which
 will cause issues if one decides to step outside that box and run
 non-distribution kernel packages.
 
-## Red Hat Enterprise Linux 7 installation
+## Red Hat Enterprise Linux 7
+
+### Installation
 
 **Red Hat Enterprise Linux 7 (64 bit)** has [shipped with
 Docker](https://access.redhat.com/site/products/red-hat-enterprise-linux/docker-and-containers).
@@ -41,7 +43,21 @@ Portal](https://access.redhat.com/).
 
 Please continue with the [Starting the Docker daemon](#starting-the-docker-daemon).
 
-## Red Hat Enterprise Linux 6.6 installation
+### Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo yum -y remove docker
+
+The above command will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.
+
+## Red Hat Enterprise Linux 6.6
 
 You will need **64 bit** [RHEL
 6.6](https://access.redhat.com/site/articles/3078#RHEL6) or later, with
@@ -66,7 +82,7 @@ non-distro kernel packages.
 >  vulnerabilities and severe bugs (such as those found in kernel 2.6.32)
 > are fixed.
 
-## Installation
+###  Installation
 
 Firstly, you need to install the EPEL repository. Please follow the
 [EPEL installation
@@ -89,6 +105,20 @@ To update the `docker-io` package
     $ sudo yum -y update docker-io
 
 Please continue with the [Starting the Docker daemon](#starting-the-docker-daemon).
+
+### Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo yum -y remove docker-io
+
+The above command will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.
 
 ## Starting the Docker daemon
 
@@ -117,7 +147,6 @@ Continue with the [User Guide](/userguide/).
 If you need to add an HTTP Proxy, set a different directory or partition for the
 Docker runtime files, or make other customizations, read our Systemd article to
 learn how to [customize your Systemd Docker daemon options](/articles/systemd/).
-
 
 ## Issues?
 

--- a/docs/sources/installation/ubuntulinux.md
+++ b/docs/sources/installation/ubuntulinux.md
@@ -28,8 +28,8 @@ and frequently panic under certain conditions.
 To check your current kernel version, open a terminal and use `uname -r` to display
 your kernel version:
 
-	$ uname -r 
-	3.11.0-15-generic
+    $ uname -r 
+    3.11.0-15-generic
 
 >**Caution** Some Ubuntu OS versions **require a version higher than 3.10** to
 >run Docker, see the prerequisites on this page that apply to your Ubuntu
@@ -72,17 +72,17 @@ To upgrade your kernel and install the additional packages, do the following:
 
 2. Update your package manager.
 
-		$ sudo apt-get update
+        $ sudo apt-get update
 
 3. Install both the required and optional packages.
 
-		$ sudo apt-get install linux-image-generic-lts-trusty
+        $ sudo apt-get install linux-image-generic-lts-trusty
 
-	Depending on your environment, you may install more as described in the preceding table.
+    Depending on your environment, you may install more as described in the preceding table.
 
 4. Reboot your host.
 
-		$ sudo reboot
+        $ sudo reboot
 
 5. After your system reboots, go ahead and [install Docker](#installing-docker-on-ubuntu).
 
@@ -92,7 +92,7 @@ To upgrade your kernel and install the additional packages, do the following:
 Docker uses AUFS as the default storage backend. If you don't have this
 prerequisite installed, Docker's installation process adds it.
 
-##Installing Docker on Ubuntu
+##Installation
 
 Make sure you have installed the prerequisites for your Ubuntu version. Then,
 install Docker using the following:
@@ -101,19 +101,19 @@ install Docker using the following:
 
 2. Verify that you have `wget` installed.
 
-		$ which wget
+        $ which wget
 
-	 If `wget` isn't installed, install it after updating your manager:
+    If `wget` isn't installed, install it after updating your manager:
 
-		$ sudo apt-get update
-		$ sudo apt-get install wget
+        $ sudo apt-get update
+        $ sudo apt-get install wget
 
 3. Get the latest Docker package.
 
-		$ wget -qO- https://get.docker.com/ | sh
+        $ wget -qO- https://get.docker.com/ | sh
 
-	 The system prompts you for your `sudo` password. Then, it downloads and
-	 installs Docker and its dependencies.
+    The system prompts you for your `sudo` password. Then, it downloads and
+    installs Docker and its dependencies.
 >**Note**: If your company is behind a filtering proxy, you may find that the
 >`apt-key`
 >command fails for the Docker repo during installation. To work around this,
@@ -123,9 +123,9 @@ install Docker using the following:
 
 4. Verify `docker` is installed correctly.
 
-		$ sudo docker run hello-world
+        $ sudo docker run hello-world
 
-	This command downloads a test image and runs it in a container.
+    This command downloads a test image and runs it in a container.
 
 ## Optional configurations for Docker on Ubuntu 
 
@@ -155,19 +155,19 @@ To create the `docker` group and add your user:
 
 1. Log into Ubuntu as a user with `sudo` privileges.
 
-	 This procedure assumes you log in as the `ubuntu` user.
+    This procedure assumes you log in as the `ubuntu` user.
 
 3. Create the `docker` group and add your user.
 
-		$ sudo usermod -aG docker ubuntu
+        $ sudo usermod -aG docker ubuntu
 
 3. Log out and log back in.
 
-	This ensures your user is running with the correct permissions.
+    This ensures your user is running with the correct permissions.
 
 4. Verify your work by running `docker` without `sudo`.
 
-		$ docker run hello-world
+        $ docker run hello-world
 
 
 ### Adjust memory and swap accounting
@@ -187,13 +187,13 @@ following.
 
 3. Set the `GRUB_CMDLINE_LINUX` value as follows:
 
-    	GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
+        GRUB_CMDLINE_LINUX="cgroup_enable=memory swapaccount=1"
 
 4. Save and close the file.
 
 5. Update GRUB.
 
-		$ sudo update-grub
+        $ sudo update-grub
 
 6. Reboot your system.
 
@@ -216,25 +216,25 @@ To configure UFW and allow incoming connections on the Docker port:
 
 2. Verify that UFW is installed and enabled.
 
-		$ sudo ufw status
+        $ sudo ufw status
 
 3. Open the `/etc/default/ufw` file for editing.
 
-		$ sudo nano /etc/default/ufw
+        $ sudo nano /etc/default/ufw
 
 4. Set the `DEFAULT_FORWARD_POLICY` policy to:
 
-    	DEFAULT_FORWARD_POLICY="ACCEPT"
+        DEFAULT_FORWARD_POLICY="ACCEPT"
 
 5. Save and close the file.
 
 6. Reload UFW to use the new setting.
 
-		$ sudo ufw reload
+        $ sudo ufw reload
 
 7. Allow incoming connections on the Docker port.
 
-		$ sudo ufw allow 2375/tcp
+        $ sudo ufw allow 2375/tcp
 
 ### Configure a DNS server for use by Docker
 
@@ -262,25 +262,25 @@ To specify a DNS server for use by Docker:
 
 2. Open the `/etc/default/docker` file for editing.
 
-     	$ sudo nano /etc/default/docker
+        $ sudo nano /etc/default/docker
 
 3. Add a setting for Docker.
 
-      	DOCKER_OPTS="--dns 8.8.8.8"
+        DOCKER_OPTS="--dns 8.8.8.8"
 
     Replace `8.8.8.8` with a local DNS server such as `192.168.1.1`. You can also
     specify multiple DNS servers. Separated them with spaces, for example:
 
-      	--dns 8.8.8.8 --dns 192.168.1.1
+        --dns 8.8.8.8 --dns 192.168.1.1
 
-	>**Warning**: If you're doing this on a laptop which connects to various
-	>networks, make sure to choose a public DNS server.
+    >**Warning**: If you're doing this on a laptop which connects to various
+    >networks, make sure to choose a public DNS server.
 
 4. Save and close the file.
 
 5. Restart the Docker daemon.
 
-    	$ sudo restart docker
+        $ sudo restart docker
 
 
 &nbsp;
@@ -291,22 +291,39 @@ NetworkManager (this might slow your network).
 
 1. Open the `/etc/NetworkManager/NetworkManager.conf` file for editing.
 
-		$ sudo nano /etc/NetworkManager/NetworkManager.conf
+        $ sudo nano /etc/NetworkManager/NetworkManager.conf
 
 2. Comment out the `dns=dsnmasq` line:
 
-		dns=dnsmasq
+        dns=dnsmasq
 
 3. Save and close the file.
 
 4. Restart both the NetworkManager and Docker.
 
-		$ sudo restart network-manager $ sudo restart docker
+        $ sudo restart network-manager $ sudo restart docker
 
 
 ## Upgrade Docker
 
-To install the latest version of Docker, use the standard `-N` flag with `wget`:
+To install the latest version of Docker with `wget`:
 
-	$ wget -qO- https://get.docker.com/ | sh
+    $ wget -qO- https://get.docker.com/ | sh
 
+## Uninstallation
+
+To uninstall the Docker package:
+
+    $ sudo apt-get purge lxc-docker
+
+To uninstall the Docker package and dependencies that are no longer needed:
+
+    $ sudo apt-get autoremove --purge lxc-docker
+
+The above commands will not remove images, containers, volumes, or user created
+configuration files on your host. If you wish to delete all images, containers,
+and volumes run the following command:
+
+    $ rm -rf /var/lib/docker
+
+You must delete the user created configuration files manually.

--- a/docs/sources/installation/windows.md
+++ b/docs/sources/installation/windows.md
@@ -67,7 +67,7 @@ Boot2Docker command requires `ssh.exe` to be in the PATH, therefore we need to
 include `bin` folder of the Git installation (which has ssh.exe) to the `%PATH%`
 environment variable by running:
 
-	set PATH=%PATH%;"c:\Program Files (x86)\Git\bin"
+    set PATH=%PATH%;"c:\Program Files (x86)\Git\bin"
 
 and then we can run the `boot2docker start` command to start the Boot2Docker VM.
 (Run `boot2docker init` command if you get an error saying machine does not
@@ -81,7 +81,7 @@ to your console window and you are ready to run docker commands such as
 
 Launch a PowerShell window, then you need to add `ssh.exe` to your PATH:
 
-	$Env:Path = "${Env:Path};c:\Program Files (x86)\Git\bin"
+    $Env:Path = "${Env:Path};c:\Program Files (x86)\Git\bin"
 
 and after running `boot2docker start` command it will print PowerShell commands
 to set the environment variables to connect Docker running inside VM. Run these
@@ -149,6 +149,12 @@ You can do this with
   `%USERPROFILE%\.ssh\id_boot2docker`
 - then click: "Save Private Key".
 - Then use the saved file to login with PuTTY using `docker@127.0.0.1:2022`.
+
+## Uninstallation
+
+You can uninstall Boot2Docker using Window's standard process for removing programs.
+This process does not remove the `docker-install.exe` file. You must delete that file
+yourself.
 
 ## References
 


### PR DESCRIPTION
Added uninstall instructions for Docker and Boot2Docker where applicable. Fixes #12824 

This included the following operating systems: Ubuntu, Mac OS X, Windows, Arch Linux, CentOS, CRUX Linux, Debian, Fedora, FrugalWare, Gentoo, RHEL, Oracle, SUSE

I don't have access to all OSs, so feedback is greatly appreciated!

Signed-off-by: Megan Kostick mkostick@us.ibm.com
