### PR TITLE
Fix TestApiImagesDelete for --net none build

### DIFF
--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -100,6 +100,7 @@ func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 }
 
 func (s *DockerSuite) TestApiImagesDelete(c *check.C) {
+	testRequires(c, Network)
 	name := "test-api-images-delete"
 	out, err := buildImage(name, "FROM hello-world\nENV FOO bar", false)
 	if err != nil {


### PR DESCRIPTION
/cc @jfrazelle 

fixes #12907

I thought to not build an image here and use busybox but I don't want to use it cause it's used all around tests and I don't feel comfortable doing this. However if it's ok for you I'll use busybox

Signed-off-by: Antonio Murdaca me@runcom.ninja
