### PR TITLE
Don't wrap 'cp' help too soon.

### DIFF
--- a/api/client/cp.go
+++ b/api/client/cp.go
@@ -16,7 +16,7 @@ import (
 //
 // Usage: docker cp CONTAINER:PATH HOSTDIR
 func (cli *DockerCli) CmdCp(args ...string) error {
-	cmd := cli.Subcmd("cp", "CONTAINER:PATH HOSTDIR|-", "Copy files/folders from a PATH on the container to a HOSTDIR on the host\nrunning the command. Use '-' to write the data\nas a tar file to STDOUT.", true)
+	cmd := cli.Subcmd("cp", "CONTAINER:PATH HOSTDIR|-", "Copy files/folders from a PATH on the container to a HOSTDIR on the host\nrunning the command. Use '-' to write the data as a tar file to STDOUT.", true)
 	cmd.Require(flag.Exact, 2)
 
 	cmd.ParseFlags(args, true)


### PR DESCRIPTION
Minor thing but docker cp --help was:

```
Copy files/folders from a PATH on the container to a HOSTDIR on the host
running the command. Use '-' to write the data
as a tar file to STDOUT.
```

This changes it to:

```
Copy files/folders from a PATH on the container to a HOSTDIR on the host
running the command. Use '-' to write the data as a tar file to STDOUT.
```

The \n made the output look funky.

Signed-off-by: Doug Davis dug@us.ibm.com
