### PR TITLE
Adding support for GITHUB IGNORES to the engine Dockerfile

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER Sven Dowideit <SvenDowideit@docker.com> (@SvenDowideit)
 ENV COMPOSE_BRANCH release
 ENV SWARM_BRANCH v0.2.0
 ENV MACHINE_BRANCH master
-ENV DISTRIB_BRANCH release/2.0
+ENV DISTRIB_BRANCH docs
 
 
 # TODO: need the full repo source to get the git version info
@@ -61,7 +61,14 @@ ADD https://raw.githubusercontent.com/docker/distribution/${DISTRIB_BRANCH}/docs
 RUN sed -i.old '1s;^;no_version_dropdown: true;' \
   /docs/sources/registry/*.md \
   /docs/sources/registry/spec/*.md \
-  /docs/sources/registry/spec/auth/*.md
+  /docs/sources/registry/spec/auth/*.md \
+  /docs/sources/registry/storage-drivers/*.md 
+
+RUN sed -i.old  -e '/^<!--GITHUB/g' -e '/^IGNORES-->/g'\
+  /docs/sources/registry/*.md \
+  /docs/sources/registry/spec/*.md \
+  /docs/sources/registry/spec/auth/*.md \
+  /docs/sources/registry/storage-drivers/*.md 
 
 #######################
 # Docker Swarm


### PR DESCRIPTION
GITHUB IGNORES block the mkdocs header like this:

```
<!--GITHUB
page_title: Deploying a registry server
page_description: Explains how to deploy a registry server
page_keywords: registry, service, images, repository
IGNORES-->
```

Then, you use a **sed** in the Dockerfile to strip the comment tags out and leave the "meat" of the mkdocs header behind.

```
RUN sed -i.old  -e '/^<!--GITHUB/g' -e '/^IGNORES-->/g'\
  /docs/sources/registry/*.md \
  /docs/sources/registry/spec/*.md \
  /docs/sources/registry/spec/auth/*.md \
  /docs/sources/registry/storage-drivers/*.md 
```

I've tested it on Distribution with make docs and works like a charm.   Currently, we aren't requiring GITHUB IGNORES in our files except in the `docker/distribution` repo where the team specifically asked for functionality like this.

Signed-off-by: Mary Anthony mary@docker.com
