### PR TITLE
fix docker rm name issue

### DIFF
--- a/api/client/rm.go
+++ b/api/client/rm.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	flag "github.com/docker/docker/pkg/mflag"
 )
@@ -36,6 +37,7 @@ func (cli *DockerCli) CmdRm(args ...string) error {
 		if name == "" {
 			return fmt.Errorf("Container name cannot be empty")
 		}
+		name = strings.Trim(name, "/")
 
 		_, _, err := readBody(cli.call("DELETE", "/containers/"+name+"?"+val.Encode(), nil, nil))
 		if err != nil {


### PR DESCRIPTION
Addresses https://github.com/docker/docker/issues/12308

This is a workaround, I didn't find the root cause. This issue is strange,  `docker rm /db` won't even trigger router handler function. But the leading slash won't affect other commands. So this workaround just make the behavior the same as other commands.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
