### PR TITLE
Only complete repos with "docker pull -a"

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -679,6 +679,14 @@ _docker_pull() {
 		*)
 			local counter=$(__docker_pos_first_nonflag)
 			if [ $cword -eq $counter ]; then
+				for arg in "${COMP_WORDS[@]}"; do
+					case "$arg" in
+						--all-tags|-a)
+							__docker_image_repos
+							return
+							;;
+					esac
+				done
 				__docker_image_repos_and_tags
 			fi
 			;;


### PR DESCRIPTION
With this, `docker pull deb<tab>` will show all `debian:*` tags, as before, but `docker pull -a deb<tab>` will complete directly to just `debian`. :+1:
