### PR TITLE
Provide a struct to configure cli streaming

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -289,7 +289,13 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 	if context != nil {
 		headers.Set("Content-Type", "application/tar")
 	}
-	err = cli.stream("POST", fmt.Sprintf("/build?%s", v.Encode()), body, cli.out, headers)
+	sopts := &streamOpts{
+		rawTerminal: true,
+		in:          body,
+		out:         cli.out,
+		headers:     headers,
+	}
+	err = cli.stream("POST", fmt.Sprintf("/build?%s", v.Encode()), sopts)
 	if jerr, ok := err.(*jsonmessage.JSONError); ok {
 		// If no error code is set, default to 1
 		if jerr.Code == 0 {

--- a/api/client/create.go
+++ b/api/client/create.go
@@ -47,7 +47,12 @@ func (cli *DockerCli) pullImageCustomOut(image string, out io.Writer) error {
 	registryAuthHeader := []string{
 		base64.URLEncoding.EncodeToString(buf),
 	}
-	if err = cli.stream("POST", "/images/create?"+v.Encode(), nil, out, map[string][]string{"X-Registry-Auth": registryAuthHeader}); err != nil {
+	sopts := &streamOpts{
+		rawTerminal: true,
+		out:         out,
+		headers:     map[string][]string{"X-Registry-Auth": registryAuthHeader},
+	}
+	if err := cli.stream("POST", "/images/create?"+v.Encode(), sopts); err != nil {
 		return err
 	}
 	return nil

--- a/api/client/events.go
+++ b/api/client/events.go
@@ -63,7 +63,11 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 		}
 		v.Set("filters", filterJSON)
 	}
-	if err := cli.stream("GET", "/events?"+v.Encode(), nil, cli.out, nil); err != nil {
+	sopts := &streamOpts{
+		rawTerminal: true,
+		out:         cli.out,
+	}
+	if err := cli.stream("GET", "/events?"+v.Encode(), sopts); err != nil {
 		return err
 	}
 	return nil

--- a/api/client/export.go
+++ b/api/client/export.go
@@ -34,7 +34,11 @@ func (cli *DockerCli) CmdExport(args ...string) error {
 	}
 
 	image := cmd.Arg(0)
-	if err := cli.stream("GET", "/containers/"+image+"/export", nil, output, nil); err != nil {
+	sopts := &streamOpts{
+		rawTerminal: true,
+		out:         output,
+	}
+	if err := cli.stream("GET", "/containers/"+image+"/export", sopts); err != nil {
 		return err
 	}
 

--- a/api/client/import.go
+++ b/api/client/import.go
@@ -54,5 +54,11 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 		in = cli.in
 	}
 
-	return cli.stream("POST", "/images/create?"+v.Encode(), in, cli.out, nil)
+	sopts := &streamOpts{
+		rawTerminal: true,
+		in:          in,
+		out:         cli.out,
+	}
+
+	return cli.stream("POST", "/images/create?"+v.Encode(), sopts)
 }

--- a/api/client/load.go
+++ b/api/client/load.go
@@ -29,7 +29,12 @@ func (cli *DockerCli) CmdLoad(args ...string) error {
 			return err
 		}
 	}
-	if err := cli.stream("POST", "/images/load", input, cli.out, nil); err != nil {
+	sopts := &streamOpts{
+		rawTerminal: true,
+		in:          input,
+		out:         cli.out,
+	}
+	if err := cli.stream("POST", "/images/load", sopts); err != nil {
 		return err
 	}
 	return nil

--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -52,5 +52,11 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 	}
 	v.Set("tail", *tail)
 
-	return cli.streamHelper("GET", "/containers/"+name+"/logs?"+v.Encode(), c.Config.Tty, nil, cli.out, cli.err, nil)
+	sopts := &streamOpts{
+		rawTerminal: c.Config.Tty,
+		out:         cli.out,
+		err:         cli.err,
+	}
+
+	return cli.stream("GET", "/containers/"+name+"/logs?"+v.Encode(), sopts)
 }

--- a/api/client/save.go
+++ b/api/client/save.go
@@ -34,9 +34,14 @@ func (cli *DockerCli) CmdSave(args ...string) error {
 		return errors.New("Cowardly refusing to save to a terminal. Use the -o flag or redirect.")
 	}
 
+	sopts := &streamOpts{
+		rawTerminal: true,
+		out:         output,
+	}
+
 	if len(cmd.Args()) == 1 {
 		image := cmd.Arg(0)
-		if err := cli.stream("GET", "/images/"+image+"/get", nil, output, nil); err != nil {
+		if err := cli.stream("GET", "/images/"+image+"/get", sopts); err != nil {
 			return err
 		}
 	} else {
@@ -44,7 +49,7 @@ func (cli *DockerCli) CmdSave(args ...string) error {
 		for _, arg := range cmd.Args() {
 			v.Add("names", arg)
 		}
-		if err := cli.stream("GET", "/images/get?"+v.Encode(), nil, output, nil); err != nil {
+		if err := cli.stream("GET", "/images/get?"+v.Encode(), sopts); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Since `cli.stream` is accepting 5 arguments and `cli.streamHelper` is accepting 7,  I thought this could be done using a struct to configure the streaming even if most of the use cases in cli code now set `rawTerminal` to `true`. Feel free to close this if it's not ok of course, I just think it makes things more readable and understandable than just passing around that many number of arguments.
This also remove `streamHelper` which was only used by `CmdLogs`

Signed-off-by: Antonio Murdaca me@runcom.ninja
