### PR TITLE
Proposal: Change --publish=SPEC to allow binding to custom host port ranges

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -729,10 +729,15 @@ func (container *Container) buildCreateEndpointOptions() ([]libnetwork.EndpointO
 		for i := 0; i < len(binding); i++ {
 			pbCopy := pb.GetCopy()
 			newP, err := nat.NewPort(nat.SplitProtoPort(binding[i].HostPort))
+			var portStart, portEnd int
+			if err == nil {
+				portStart, portEnd, err = newP.Range()
+			}
 			if err != nil {
 				return nil, fmt.Errorf("Error parsing HostPort value(%s):%v", binding[i].HostPort, err)
 			}
-			pbCopy.HostPort = uint16(newP.Int())
+			pbCopy.HostPort = uint16(portStart)
+			pbCopy.HostPortEnd = uint16(portEnd)
 			pbCopy.HostIP = net.ParseIP(binding[i].HostIP)
 			pbList = append(pbList, pbCopy)
 		}

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -984,6 +984,7 @@ or override the Dockerfile's exposed defaults:
                    format: ip:hostPort:containerPort | ip::containerPort | hostPort:containerPort | containerPort
                    Both hostPort and containerPort can be specified as a range of ports.
                    When specifying ranges for both, the number of container ports in the range must match the number of host ports in the range. (e.g., `-p 1234-1236:1234-1236/tcp`)
+                   When specifying a range for hostPort only, the containerPort must not be a range.  In this case the container port is published somewhere within the specified hostPort range. (e.g., `-p 1234-1236:1234/tcp`)
                    (use 'docker port' to see the actual mapping)
     --link=""  : Add link to another container (<name or id>:alias or <name or id>)
 

--- a/docs/userguide/dockerlinks.md
+++ b/docs/userguide/dockerlinks.md
@@ -50,6 +50,14 @@ container:
 And you saw why this isn't such a great idea because it constrains you to
 only one container on that specific port.
 
+Instead, you may specify a range of host ports to bind a container port to
+that is different than the default *ephemeral port range*:
+
+    $ docker run -d -p 8000-9000:5000 training/webapp python app.py
+
+This would bind port 5000 in the container to a randomly available port
+between 8000 and 9000 on the host.
+
 There are also a few other ways you can configure the `-p` flag. By
 default the `-p` flag will bind the specified port to all interfaces on
 the host machine. But you can also specify a binding to a specific

--- a/pkg/nat/sort.go
+++ b/pkg/nat/sort.go
@@ -2,8 +2,9 @@ package nat
 
 import (
 	"sort"
-	"strconv"
 	"strings"
+
+	"github.com/docker/docker/pkg/parsers"
 )
 
 type portSorter struct {
@@ -88,8 +89,8 @@ func SortPortMap(ports []Port, bindings PortMap) {
 	}
 }
 
-func toInt(s string) int64 {
-	i, err := strconv.ParseInt(s, 10, 64)
+func toInt(s string) uint64 {
+	i, _, err := parsers.ParsePortRange(s)
 	if err != nil {
 		i = 0
 	}


### PR DESCRIPTION
This PR is similar to #12622, but is more narrow and focuses purely on the publish SPEC.  This change would allow specifying a range for the hostPort of a publish SPEC (iff containerPort is not a range), which would override the default binding to ephemeral ports and instead bind within the specified hostPort range:

Example:

```
$ docker run -d -p 8000-9000:5000 training/webapp python app.py
```

This would bind port 5000 in the container to a randomly available port between 8000 and 9000 on the host.
