### PR TITLE
Remove hacky "cp .../Dockerfile.build ." in "build-deb"

### DIFF
--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -56,15 +56,11 @@ DEST=$1
 			RUN { echo '$debSource (${debVersion}-0~${suite}) $suite; urgency=low'; echo; echo '  * Version: $VERSION'; echo; echo " -- $debMaintainer  $debDate"; } > debian/changelog && cat >&2 debian/changelog
 			RUN dpkg-buildpackage -uc -us
 		EOF
-		cp -a "$DEST/$version/Dockerfile.build" . # can't use $DEST because it's in .dockerignore...
 		tempImage="docker-temp/build-deb:$version"
-		( set -x && docker build -t "$tempImage" -f Dockerfile.build . )
+		( set -x && docker build -t "$tempImage" -f "$DEST/$version/Dockerfile.build" . )
 		docker run --rm "$tempImage" bash -c 'cd .. && tar -c *_*' | tar -xvC "$DEST/$version"
 		docker rmi "$tempImage"
 	done
-
-	# clean up after ourselves
-	rm -f Dockerfile.build
 
 	source "${MAKEDIR}/.integration-daemon-stop"
 ) 2>&1 | tee -a "$DEST/test.log"


### PR DESCRIPTION
Turns out that `-f` on a file that's in `.dockerignore` actually does work.  No idea why it wasn't when I was doing this before, but oh well! :metal:

@jfrazelle if this merges, you'll want to apply the same change in #12917 :heart:
