### PR TITLE
[WIP] Docker ps custom formatting.

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -146,6 +146,10 @@ func (cli *DockerCli) CheckTtyInput(attachStdin, ttyMode bool) error {
 	return nil
 }
 
+func (cli *DockerCli) PsFormat() string {
+	return cli.configFile.PsFormat
+}
+
 // NewDockerCli returns a DockerCli instance with IO output and error streams set by in, out and err.
 // The key file, protocol (i.e. unix) and address are passed in as strings, along with the tls.Config. If the tls.Config
 // is set the client scheme will be set to https.

--- a/api/client/ps/custom.go
+++ b/api/client/ps/custom.go
@@ -1,0 +1,203 @@
+package ps
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+	"time"
+
+	"github.com/docker/docker/api"
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/docker/pkg/stringutils"
+	"github.com/docker/docker/pkg/units"
+)
+
+const (
+	tableKey = "table"
+
+	idHeader         = "CONTAINER ID"
+	imageHeader      = "IMAGE"
+	namesHeader      = "NAMES"
+	commandHeader    = "COMMAND"
+	createdAtHeader  = "CREATED AT"
+	runningForHeader = "CREATED"
+	statusHeader     = "STATUS"
+	portsHeader      = "PORTS"
+	sizeHeader       = "SIZE"
+	labelsHeader     = "LABELS"
+)
+
+type containerContext struct {
+	trunc  bool
+	header []string
+	c      types.Container
+}
+
+func (c *containerContext) ID() string {
+	c.addHeader(idHeader)
+	if c.trunc {
+		return stringid.TruncateID(c.c.ID)
+	}
+	return c.c.ID
+}
+
+func (c *containerContext) Names() string {
+	c.addHeader(namesHeader)
+	names := stripNamePrefix(c.c.Names)
+	if c.trunc {
+		for _, name := range names {
+			if len(strings.Split(name, "/")) == 1 {
+				names = []string{name}
+				break
+			}
+		}
+	}
+	return strings.Join(names, ",")
+}
+
+func (c *containerContext) Image() string {
+	c.addHeader(imageHeader)
+	if c.c.Image == "" {
+		return "<no image>"
+	}
+	return c.c.Image
+}
+
+func (c *containerContext) Command() string {
+	c.addHeader(commandHeader)
+	command := c.c.Command
+	if c.trunc {
+		command = stringutils.Truncate(command, 20)
+	}
+	return strconv.Quote(command)
+}
+
+func (c *containerContext) CreatedAt() string {
+	c.addHeader(createdAtHeader)
+	return time.Unix(int64(c.c.Created), 0).String()
+}
+
+func (c *containerContext) RunningFor() string {
+	c.addHeader(runningForHeader)
+	createdAt := time.Unix(int64(c.c.Created), 0)
+	return units.HumanDuration(time.Now().UTC().Sub(createdAt))
+}
+
+func (c *containerContext) Ports() string {
+	c.addHeader(portsHeader)
+	return api.DisplayablePorts(c.c.Ports)
+}
+
+func (c *containerContext) Status() string {
+	c.addHeader(statusHeader)
+	return c.c.Status
+}
+
+func (c *containerContext) Size() string {
+	c.addHeader(sizeHeader)
+	srw := units.HumanSize(float64(c.c.SizeRw))
+	sv := units.HumanSize(float64(c.c.SizeRootFs))
+
+	sf := srw
+	if c.c.SizeRootFs > 0 {
+		sf = fmt.Sprintf("%s (virtual %s)", srw, sv)
+	}
+	return sf
+}
+
+func (c *containerContext) Labels() string {
+	c.addHeader(labelsHeader)
+	if c.c.Labels == nil {
+		return ""
+	}
+
+	var joinLabels []string
+	for k, v := range c.c.Labels {
+		joinLabels = append(joinLabels, fmt.Sprintf("%s=%s", k, v))
+	}
+	return strings.Join(joinLabels, ",")
+}
+
+func (c *containerContext) Label(name string) string {
+	n := strings.Split(name, ".")
+	c.addHeader(n[len(n)-1])
+
+	if c.c.Labels == nil {
+		return ""
+	}
+	return c.c.Labels[name]
+}
+
+func (c *containerContext) Header() string {
+	if c.header == nil {
+		return ""
+	}
+	return strings.Join(c.header, "\t")
+}
+
+func (c *containerContext) addHeader(header string) {
+	if c.header == nil {
+		c.header = []string{}
+	}
+	c.header = append(c.header, strings.ToUpper(header))
+}
+
+func customFormat(ctx Context, containers []types.Container) {
+	var (
+		table  bool
+		header string
+		format = ctx.Format
+		buffer = bytes.NewBufferString("")
+	)
+
+	if strings.HasPrefix(ctx.Format, tableKey) {
+		table = true
+		format = format[len(tableKey):]
+	}
+
+	format = strings.Trim(format, " ")
+	format = strings.Replace(format, `\t`, "\t", -1)
+	format = strings.Replace(format, `\n`, "\n", -1)
+
+	tmpl, err := template.New("ps template").Parse(format)
+	if err != nil {
+		buffer.WriteString(fmt.Sprintf("Invalid `docker ps` format: %v\n", err))
+	}
+
+	for _, container := range containers {
+		containerCtx := &containerContext{
+			trunc: ctx.Trunc,
+			c:     container,
+		}
+		if err := tmpl.Execute(buffer, containerCtx); err != nil {
+			buffer = bytes.NewBufferString(fmt.Sprintf("Invalid `docker ps` format: %v\n", err))
+			break
+		}
+		if table && len(header) == 0 {
+			header = containerCtx.Header()
+		}
+		buffer.WriteString("\n")
+	}
+
+	if table {
+		t := tabwriter.NewWriter(ctx.Output, 20, 1, 3, ' ', 0)
+		t.Write([]byte(header))
+		t.Write([]byte("\n"))
+		buffer.WriteTo(t)
+		t.Flush()
+	} else {
+		buffer.WriteTo(ctx.Output)
+	}
+}
+
+func stripNamePrefix(ss []string) []string {
+	for i, s := range ss {
+		ss[i] = s[1:]
+	}
+
+	return ss
+}

--- a/api/client/ps/formatter.go
+++ b/api/client/ps/formatter.go
@@ -1,0 +1,68 @@
+package ps
+
+import (
+	"io"
+
+	"github.com/docker/docker/api/types"
+)
+
+const (
+	tableFormatKey = "table"
+	rawFormatKey   = "raw"
+)
+
+type Context struct {
+	Output io.Writer
+	Format string
+	Size   bool
+	Quiet  bool
+	Trunc  bool
+}
+
+func Format(ctx Context, containers []types.Container) {
+	switch ctx.Format {
+	case tableFormatKey:
+		tableFormat(ctx, containers)
+	case rawFormatKey:
+		rawFormat(ctx, containers)
+	default:
+		customFormat(ctx, containers)
+	}
+}
+
+func rawFormat(ctx Context, containers []types.Container) {
+	if ctx.Quiet {
+		ctx.Format = `container_id: {{.ID}}`
+	} else {
+		ctx.Format = `container_id: {{.ID}}
+image: {{.Image}}
+command: {{.Command}}
+created_at: {{.CreatedAt}}
+status: {{.Status}}
+names: {{.Names}}
+labels: {{.Labels}}
+ports: {{.Ports}}
+`
+
+		if ctx.Size {
+			ctx.Format += `size: {{.Size}}
+`
+		}
+	}
+
+	customFormat(ctx, containers)
+}
+
+func tableFormat(ctx Context, containers []types.Container) {
+	if ctx.Quiet {
+		ctx.Format = `{{.ID}}`
+	} else {
+		if ctx.Size {
+			ctx.Format = "table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.RunningFor}} ago\t{{.Status}}\t{{.Ports}}\t{{.Names}}\t{{.Size}}"
+		} else {
+			ctx.Format = "table {{.ID}}\t{{.Image}}\t{{.Command}}\t{{.RunningFor}} ago\t{{.Status}}\t{{.Ports}}\t{{.Names}}"
+		}
+	}
+
+	customFormat(ctx, containers)
+}

--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -41,6 +41,7 @@ type AuthConfig struct {
 type ConfigFile struct {
 	AuthConfigs map[string]AuthConfig `json:"auths"`
 	HttpHeaders map[string]string     `json:"HttpHeaders,omitempty"`
+	PsFormat    string                `json:"psFormat,omitempty"`
 	filename    string                // Note: not serialized - for internal use only
 }
 

--- a/cliconfig/config_file_test.go
+++ b/cliconfig/config_file_test.go
@@ -155,3 +155,34 @@ func TestNewJson(t *testing.T) {
 		t.Fatalf("Should have save in new form: %s", string(buf))
 	}
 }
+
+func TestJsonWithPsFormat(t *testing.T) {
+	tmpHome, _ := ioutil.TempDir("", "config-test")
+	fn := filepath.Join(tmpHome, CONFIGFILE)
+	js := `{
+		"auths": { "https://index.docker.io/v1/": { "auth": "am9lam9lOmhlbGxv", "email": "user@example.com" } },
+		"psFormat": "table {{.ID}}\\t{{.Label \"com.docker.label.cpu\"}}"
+}`
+	ioutil.WriteFile(fn, []byte(js), 0600)
+
+	config, err := Load(tmpHome)
+	if err != nil {
+		t.Fatalf("Failed loading on empty json file: %q", err)
+	}
+
+	if config.PsFormat != `table {{.ID}}\t{{.Label "com.docker.label.cpu"}}` {
+		t.Fatalf("Unknown ps format: %s\n", config.PsFormat)
+	}
+
+	// Now save it and make sure it shows up in new form
+	err = config.Save()
+	if err != nil {
+		t.Fatalf("Failed to save: %q", err)
+	}
+
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	if !strings.Contains(string(buf), `"psFormat":`) ||
+		!strings.Contains(string(buf), "{{.ID}}") {
+		t.Fatalf("Should have save in new form: %s", string(buf))
+	}
+}

--- a/docs/man/docker-ps.1.md
+++ b/docs/man/docker-ps.1.md
@@ -16,6 +16,7 @@ docker-ps - List containers
 [**-q**|**--quiet**[=*false*]]
 [**-s**|**--size**[=*false*]]
 [**--since**[=*SINCE*]]
+[**-F**|**--format**=*"TEMPLATE"*]
 
 
 # DESCRIPTION
@@ -59,6 +60,20 @@ the running containers.
 **--since**=""
    Show only containers created since Id or Name, include non-running ones.
 
+**-F**, **--format**=*"TEMPLATE"*
+   Pretty-print containers using a Go template.
+   Valid placeholders:
+      .ID - Container ID
+      .Image - Image ID
+      .Command - Quoted command
+      .CreatedAt - Time when the container was created.
+      .RunningFor - Elapsed time since the container was started.
+      .Ports - Exposed ports.
+      .Status - Container status.
+      .Size - Container disk size.
+      .Labels - All labels asigned to the container.
+      .Label - Value of a specific label for this container. For example `{{.Label "com.docker.swarm.cpu"}}`
+
 # EXAMPLES
 # Display all containers, including non-running
 
@@ -81,6 +96,32 @@ the running containers.
 
     # docker ps -a -q --filter=name=determined_torvalds
     c1d3b0166030
+
+# Display containers with their commands
+
+    # docker ps --format "{{.ID}}: {{.Command}}"
+    a87ecb4f327c: /bin/sh -c #(nop) MA
+    01946d9d34d8: /bin/sh -c #(nop) MA
+    c1d3b0166030: /bin/sh -c yum -y up
+    41d50ecd2f57: /bin/sh -c #(nop) MA
+
+# Display containers with their labels in a table
+
+    # docker ps --format "table {{.ID}}\t{{.Labels}}"
+    CONTAINER ID        LABELS
+    a87ecb4f327c        com.docker.swarm.node=ubuntu,com.docker.swarm.storage=ssd
+    01946d9d34d8
+    c1d3b0166030        com.docker.swarm.node=debian,com.docker.swarm.cpu=6
+    41d50ecd2f57        com.docker.swarm.node=fedora,com.docker.swarm.cpu=3,com.docker.swarm.storage=ssd
+
+# Display containers with their node label in a table
+
+    # docker ps --format 'table {{.ID}}\t{{(.Label "com.docker.swarm.node")}}'
+    CONTAINER ID        NODE
+    a87ecb4f327c        ubuntu
+    01946d9d34d8
+    c1d3b0166030        debian
+    41d50ecd2f57        fedora
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -63,18 +63,25 @@ mechanisms, you must keep in mind the order of precedence among them. Command
 line options override environment variables and environment variables override 
 properties you specify in a `config.json` file.
 
-The `config.json` file stores a JSON encoding of a single `HttpHeaders`
-property. The property specifies a set of headers to include in all
+The `config.json` file stores a JSON encoding of several properties:
+
+The property `HttpHeaders` specifies a set of headers to include in all
 messages sent from the Docker client to the daemon. Docker does not try to
 interpret or understand these header; it simply puts them into the messages.
 Docker does not allow these headers to change any headers it sets for itself.
+
+The property `psFormat` specifies the default format for `docker ps` output.
+When the flag `--format` is not set in the arguments calling that command,
+Docker's client uses this property. If this property is not set, the client
+falls back to the default table format.
 
 Following is a sample `config.json` file:
 
     {
       "HttpHeaders: {
         "MyHeader": "MyValue"
-      }
+      },
+      "psFormat": "table {{.ID}}\\t{{.Image}}\\t{{.Command}}\\t{{.Labels}}"
     }
 
 ## Help


### PR DESCRIPTION
This is a generalization of #11943 and #10255 to allow awesome custom formatting!

It follows Docker convention to expose a go template to allow formatting. The default table format for `docker ps` can be expressed as:

```
table {{.ID}}\t{{.ImageId}}\t{{.Command}}...
```

This also allows to display all the labels for a container with `{{.Labels}}` or a specific label with `{{(.Label "com.docker.cpu")}}`

TODO:
- [x] Allow to change the default format by configuration, so swarm can show label columns 
- [ ] Test
- [x] Documentation

Signed-off-by: David Calavera david.calavera@gmail.com
