### PR TITLE
Windows: Refactor daemon

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1161,6 +1161,7 @@ _docker() {
 		--dns-search
 		--exec-driver -e
 		--exec-opt
+		--exec-root
 		--fixed-cidr
 		--fixed-cidr-v6
 		--graph -g

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -25,6 +25,7 @@ type CommonConfig struct {
 	DnsSearch      []string
 	EnableCors     bool
 	ExecDriver     string
+	ExecRoot       string
 	GraphDriver    string
 	Labels         []string
 	LogConfig      runconfig.LogConfig
@@ -38,9 +39,11 @@ type CommonConfig struct {
 // the current process.
 // Subsequent calls to `flag.Parse` will populate config with values parsed
 // from the command-line.
+
 func (config *Config) InstallCommonFlags() {
 	flag.StringVar(&config.Pidfile, []string{"p", "-pidfile"}, defaultPidFile, "Path to use for daemon PID file")
 	flag.StringVar(&config.Root, []string{"g", "-graph"}, defaultGraph, "Root of the Docker runtime")
+	flag.StringVar(&config.ExecRoot, []string{"-exec-root"}, "/var/run/docker", "Root of the Docker execdriver")
 	flag.BoolVar(&config.AutoRestart, []string{"#r", "#-restart"}, true, "--restart on the daemon has been deprecated in favor of --restart policies on docker run")
 	flag.BoolVar(&config.Bridge.EnableIptables, []string{"#iptables", "-iptables"}, true, "Enable addition of iptables rules")
 	flag.BoolVar(&config.Bridge.EnableIpForward, []string{"#ip-forward", "-ip-forward"}, true, "Enable net.ipv4.ip_forward")

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -911,8 +911,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	}
 
 	sysInfo := sysinfo.New(false)
-	const runDir = "/var/run/docker"
-	ed, err := execdrivers.NewDriver(config.ExecDriver, config.ExecOptions, runDir, config.Root, sysInitPath, sysInfo)
+	ed, err := execdrivers.NewDriver(config.ExecDriver, config.ExecOptions, config.ExecRoot, config.Root, sysInitPath, sysInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -113,6 +113,13 @@ func mainDaemon() {
 		TlsCert:     *flCert,
 		TlsKey:      *flKey,
 	}
+	serverConfig = setPlatformServerConfig(serverConfig, daemonCfg)
+	
+	
+func setPlatformServerConfig(serverConfig *apiserver.ServerConfig, daemonCfg *daemon.Config) (*apiserver.ServerConfig)	 {
+	serverConfig.SocketGroup = daemonCfg.SocketGroup
+	return serverConfig
+}
 
 	api := apiserver.New(serverConfig)
 

--- a/docker/daemon_linux.go
+++ b/docker/daemon_linux.go
@@ -1,0 +1,12 @@
+// +build daemon,linux
+
+package main
+
+import (
+	apiserver "github.com/docker/docker/api/server"
+)
+
+func setPlatformServerConfig(serverConfig *apiserver.ServerConfig, daemonCfg *daemon.Config) *apiserver.ServerConfig {
+	serverConfig.SocketGroup = daemonCfg.SocketGroup
+	return serverConfig
+}

--- a/docker/daemon_windows.go
+++ b/docker/daemon_windows.go
@@ -1,0 +1,11 @@
+// +build daemon,windows
+
+package main
+
+import (
+	apiserver "github.com/docker/docker/api/server"
+)
+
+func setPlatformServerConfig(serverConfig *apiserver.ServerConfig, daemonCfg *daemon.Config) *apiserver.ServerConfig {
+	return serverConfig
+}

--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -56,6 +56,9 @@ To see the man page for a command run **man docker <command>**.
 **--exec-opt**=[]
   Set exec driver options. See EXEC DRIVER OPTIONS.
 
+**--exec-root**=""
+  Path to use as the root of the Docker execdriver. Default is `/var/run/docker`.
+
 **--fixed-cidr**=""
   IPv4 subnet for fixed IPs (e.g., 10.20.0.0/16); this subnet must be nested in the bridge subnet (which is defined by \-b or \-\-bip)
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -152,6 +152,7 @@ expect an integer, and they can only be specified once.
       --default-ulimit=[]                    Set default ulimit settings for containers
       -e, --exec-driver="native"             Exec driver to use
       --exec-opt=[]                          Set exec driver options
+      --exec-root="/var/run/docker"          Root of the Docker execdriver
       --fixed-cidr=""                        IPv4 subnet for fixed IPs
       --fixed-cidr-v6=""                     IPv6 subnet for fixed IPs
       -G, --group="docker"                   Group for the unix socket


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This PR splits daemon\daemon.go into platform specific parts, thus for example, removing the dependency on vfs and lxc in the Windows daemon. It also corrects the use of filepath instead of path. 
