### PR TITLE
Proposal: depreciate lxc exec driver

### DIFF
--- a/daemon/execdriver/execdrivers/execdrivers.go
+++ b/daemon/execdriver/execdrivers/execdrivers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/daemon/execdriver/lxc"
 	"github.com/docker/docker/daemon/execdriver/native"
@@ -13,6 +14,8 @@ import (
 func NewDriver(name string, options []string, root, libPath, initPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
 	switch name {
 	case "lxc":
+		// we are depreciating lxc
+		logrus.Warn("The lxc driver is being depreciated. Please switch to the native driver.")
 		// we want to give the lxc driver the full docker root because it needs
 		// to access and write config and template files in /var/lib/docker/containers/*
 		// to be backwards compatible

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -447,10 +447,9 @@ Currently supported options are:
 The Docker daemon uses a specifically built `libcontainer` execution driver as its
 interface to the Linux kernel `namespaces`, `cgroups`, and `SELinux`.
 
-There is still legacy support for the original [LXC userspace tools](
-https://linuxcontainers.org/) via the `lxc` execution driver, however, this is
-not where the primary development of new functionality is taking place.
-Add `-e lxc` to the daemon flags to use the `lxc` execution driver.
+Legacy support for the original [LXC userspace tools](
+https://linuxcontainers.org/) via the `lxc` execution driver is being
+depreciated. Add `-e lxc` to the daemon flags to use the `lxc` execution driver.
 
 #### Options for the native execdriver
 

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -87,7 +87,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 	cmd.Var(&flDnsSearch, []string{"-dns-search"}, "Set custom DNS search domains")
 	cmd.Var(&flExtraHosts, []string{"-add-host"}, "Add a custom host-to-IP mapping (host:ip)")
 	cmd.Var(&flVolumesFrom, []string{"#volumes-from", "-volumes-from"}, "Mount volumes from the specified container(s)")
-	cmd.Var(&flLxcOpts, []string{"#lxc-conf", "-lxc-conf"}, "Add custom lxc options")
+	cmd.Var(&flLxcOpts, []string{"#lxc-conf", "#-lxc-conf"}, "Add custom lxc options")
 	cmd.Var(&flCapAdd, []string{"-cap-add"}, "Add Linux capabilities")
 	cmd.Var(&flCapDrop, []string{"-cap-drop"}, "Drop Linux capabilities")
 	cmd.Var(&flSecurityOpt, []string{"-security-opt"}, "Security Options")


### PR DESCRIPTION
Seems like there are newer versions of LXC that are being requested to be supported but I do not believe we can support this long term, not to mention it does not have all the features of the native execdriver. 

LXC has been great to us, but I think it is time to move on.
