### PR TITLE
Rename development builds to be in the "docker-dev" repo instead of "docker"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ DOCS_MOUNT := $(if $(DOCSDIR),-v $(CURDIR)/$(DOCSDIR):/$(DOCSDIR))
 DOCSPORT := 8000
 
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
-DOCKER_IMAGE := docker$(if $(GIT_BRANCH),:$(GIT_BRANCH))
+DOCKER_IMAGE := docker-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 DOCKER_DOCS_IMAGE := docker-docs$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 
 DOCKER_RUN_DOCKER := docker run --rm -it --privileged $(DOCKER_ENVS) $(DOCKER_MOUNT) "$(DOCKER_IMAGE)"


### PR DESCRIPTION
See https://github.com/docker-library/docker/issues/2 for some of the context around this; essentially, we're looking to create an official `docker` image that includes the Docker CLI (and the dependencies necessary for easy Docker-in-Docker), but it makes sense to use the `docker` namespace for that image.  The `docker-dev` official image is already builds of Docker's own `Dockerfile` (but specifically of releases), so this seemed like a good fit. :+1:

Closes https://github.com/docker-library/docker/issues/2
