### PR TITLE
Refactor server to use daemon as the service layer in controllers

### DIFF
--- a/daemon/changes.go
+++ b/daemon/changes.go
@@ -1,0 +1,13 @@
+package daemon
+
+import "github.com/docker/docker/pkg/archive"
+
+// ContainerChanges returns a list of container fs changes
+func (daemon *Daemon) ContainerChanges(name string) ([]archive.Change, error) {
+	container, err := daemon.Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return container.Changes()
+}

--- a/daemon/copy.go
+++ b/daemon/copy.go
@@ -1,0 +1,16 @@
+package daemon
+
+import "io"
+
+func (daemon *Daemon) ContainerCopy(name string, res string) (io.ReadCloser, error) {
+	container, err := daemon.Get(name)
+	if err != nil {
+		return nil, err
+	}
+
+	if res[0] == '/' {
+		res = res[1:]
+	}
+
+	return container.Copy(res)
+}

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -1,0 +1,18 @@
+package daemon
+
+import "fmt"
+
+// ContainerPause pauses a container
+func (daemon *Daemon) ContainerPause(name string) error {
+	container, err := daemon.Get(name)
+	if err != nil {
+		return err
+	}
+
+	if err := container.Pause(); err != nil {
+		return fmt.Errorf("Cannot pause container %s: %s", name, err)
+	}
+	container.LogEvent("pause")
+
+	return nil
+}

--- a/daemon/resize.go
+++ b/daemon/resize.go
@@ -1,12 +1,19 @@
 package daemon
 
+func (daemon *Daemon) ContainerResize(name string, height, width int) error {
+	container, err := daemon.Get(name)
+	if err != nil {
+		return err
+	}
+
+	return container.Resize(height, width)
+}
+
 func (daemon *Daemon) ContainerExecResize(name string, height, width int) error {
 	execConfig, err := daemon.getExecConfig(name)
 	if err != nil {
 		return err
 	}
-	if err := execConfig.Resize(height, width); err != nil {
-		return err
-	}
-	return nil
+
+	return execConfig.Resize(height, width)
 }

--- a/daemon/unpause.go
+++ b/daemon/unpause.go
@@ -1,0 +1,18 @@
+package daemon
+
+import "fmt"
+
+// ContainerUnpause unpauses a container
+func (daemon *Daemon) ContainerUnpause(name string) error {
+	container, err := daemon.Get(name)
+	if err != nil {
+		return err
+	}
+
+	if err := container.Unpause(); err != nil {
+		return fmt.Errorf("Cannot unpause container %s: %s", name, err)
+	}
+	container.LogEvent("unpause")
+
+	return nil
+}


### PR DESCRIPTION
There's only one left which I plan to address soon in another pr if this is ok (container attach always tricky)
Anyway I like the idea of using the daemon as the service layer of the api's controllers (IIRC I was discussing this on IRC with someone a while ago) instead of directly using the container instance (there were actions that directly used a container after d.Get(name) and other using daemon methods). This avoids mixing daemon&container used in api server code, gives daemon a "full" public interface for dealing with containers' actions and avoids having logic in controllers.

Signed-off-by: Antonio Murdaca me@runcom.ninja
