### PR TITLE
remove ip_forward warning completely

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -80,9 +80,6 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	if !info.SwapLimit {
 		fmt.Fprintf(cli.err, "WARNING: No swap limit support\n")
 	}
-	if !info.IPv4Forwarding {
-		fmt.Fprintf(cli.err, "WARNING: IPv4 forwarding is disabled.\n")
-	}
 	if info.Labels != nil {
 		fmt.Fprintln(cli.out, "Labels:")
 		for _, attribute := range info.Labels {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -153,7 +153,6 @@ type Info struct {
 	MemoryLimit        bool
 	SwapLimit          bool
 	CpuCfsQuota        bool
-	IPv4Forwarding     bool
 	Debug              bool
 	NFd                int
 	NGoroutines        int

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1303,9 +1303,6 @@ func (container *Container) verifyDaemonSettings() {
 		logrus.Warnf("Your kernel does not support swap limit capabilities. Limitation discarded.")
 		container.hostConfig.MemorySwap = -1
 	}
-	if container.daemon.sysInfo.IPv4ForwardingDisabled {
-		logrus.Warnf("IPv4 forwarding is disabled. Networking will not work")
-	}
 }
 
 func (container *Container) setupLinkedContainers() ([]string, error) {

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -66,9 +66,6 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 	if warnings, err = daemon.mergeAndVerifyConfig(config, img); err != nil {
 		return nil, nil, err
 	}
-	if !config.NetworkDisabled && daemon.SystemConfig().IPv4ForwardingDisabled {
-		warnings = append(warnings, "IPv4 forwarding is disabled.\n")
-	}
 	if hostConfig == nil {
 		hostConfig = &runconfig.HostConfig{}
 	}

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -65,7 +65,6 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		MemoryLimit:        daemon.SystemConfig().MemoryLimit,
 		SwapLimit:          daemon.SystemConfig().SwapLimit,
 		CpuCfsQuota:        daemon.SystemConfig().CpuCfsQuota,
-		IPv4Forwarding:     !daemon.SystemConfig().IPv4ForwardingDisabled,
 		Debug:              os.Getenv("DEBUG") != "",
 		NFd:                fileutils.GetTotalUsedFds(),
 		NGoroutines:        runtime.NumGoroutine(),

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -1617,7 +1617,6 @@ Display system-wide information
              "IndexServerAddress":["https://index.docker.io/v1/"],
              "MemoryLimit":true,
              "SwapLimit":false,
-             "IPv4Forwarding":true,
              "Labels":["storage=ssd"],
              "DockerRootDir": "/var/lib/docker",
              "HttpProxy": "http://test:test@localhost:8080"

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -4,8 +4,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"strconv"
-	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libcontainer/cgroups"
@@ -13,11 +11,10 @@ import (
 
 // SysInfo stores information about which features a kernel supports.
 type SysInfo struct {
-	MemoryLimit            bool
-	SwapLimit              bool
-	CpuCfsQuota            bool
-	IPv4ForwardingDisabled bool
-	AppArmor               bool
+	MemoryLimit bool
+	SwapLimit   bool
+	CpuCfsQuota bool
+	AppArmor    bool
 }
 
 // New returns a new SysInfo, using the filesystem to detect which features the kernel supports.
@@ -47,17 +44,6 @@ func New(quiet bool) *SysInfo {
 		sysInfo.CpuCfsQuota = err1 == nil
 		if !sysInfo.CpuCfsQuota && !quiet {
 			logrus.Warn("Your kernel does not support cgroup cfs quotas")
-		}
-	}
-
-	// Checek if ipv4_forward is disabled.
-	if data, err := ioutil.ReadFile("/proc/sys/net/ipv4/ip_forward"); os.IsNotExist(err) {
-		sysInfo.IPv4ForwardingDisabled = true
-	} else {
-		if enabled, _ := strconv.Atoi(strings.TrimSpace(string(data))); enabled == 0 {
-			sysInfo.IPv4ForwardingDisabled = true
-		} else {
-			sysInfo.IPv4ForwardingDisabled = false
 		}
 	}
 


### PR DESCRIPTION
It is disscussed in https://github.com/docker/docker/issues/2396, got
a conclusion and enable ip-forward by default in
https://github.com/docker/docker/pull/3801, and then remove ip_forward
warning in https://github.com/docker/docker/pull/3811. But it didn't
remove it cleanly and somehow someone added it back.

Let's remove it completely this time

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
