### PR TITLE
Windows: Fix filepath vs path in image.go

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"time"
@@ -55,7 +55,7 @@ func LoadImage(root string) (*Image, error) {
 		return nil, err
 	}
 
-	if buf, err := ioutil.ReadFile(path.Join(root, "layersize")); err != nil {
+	if buf, err := ioutil.ReadFile(filepath.Join(root, "layersize")); err != nil {
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
@@ -107,21 +107,21 @@ func (img *Image) SetGraph(graph Graph) {
 
 // SaveSize stores the current `size` value of `img` in the directory `root`.
 func (img *Image) SaveSize(root string) error {
-	if err := ioutil.WriteFile(path.Join(root, "layersize"), []byte(strconv.Itoa(int(img.Size))), 0600); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(root, "layersize"), []byte(strconv.Itoa(int(img.Size))), 0600); err != nil {
 		return fmt.Errorf("Error storing image size in %s/layersize: %s", root, err)
 	}
 	return nil
 }
 
 func (img *Image) SaveCheckSum(root, checksum string) error {
-	if err := ioutil.WriteFile(path.Join(root, "checksum"), []byte(checksum), 0600); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(root, "checksum"), []byte(checksum), 0600); err != nil {
 		return fmt.Errorf("Error storing checksum in %s/checksum: %s", root, err)
 	}
 	return nil
 }
 
 func (img *Image) GetCheckSum(root string) (string, error) {
-	cs, err := ioutil.ReadFile(path.Join(root, "checksum"))
+	cs, err := ioutil.ReadFile(filepath.Join(root, "checksum"))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", nil
@@ -132,7 +132,7 @@ func (img *Image) GetCheckSum(root string) (string, error) {
 }
 
 func jsonPath(root string) string {
-	return path.Join(root, "json")
+	return filepath.Join(root, "json")
 }
 
 func (img *Image) RawJson() ([]byte, error) {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This fixes the use of path to filepath in docker\image\image.go
