### PR TITLE
Fix RUN's error msg when it fails

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -619,7 +619,7 @@ func (b *Builder) run(c *daemon.Container) error {
 	// Wait for it to finish
 	if ret, _ := c.WaitStop(-1 * time.Second); ret != 0 {
 		return &jsonmessage.JSONError{
-			Message: fmt.Sprintf("The command %v returned a non-zero code: %d", b.Config.Cmd, ret),
+			Message: fmt.Sprintf("The command %q returned a non-zero code: %d", b.Config.Cmd.ToString(), ret),
 			Code:    ret,
 		}
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5384,3 +5384,20 @@ func (s *DockerSuite) TestBuildBadCmdFlag(c *check.C) {
 		c.Fatalf("Bad output\nGot:%s\n\nExpected to contain:%s\n", out, exp)
 	}
 }
+
+func (s *DockerSuite) TestBuildRUNErrMsg(c *check.C) {
+	// Test to make sure the bad command is quoted with just "s and
+	// not as a Go []string
+	name := "testbuildbadrunerrmsg"
+	_, out, err := buildImageWithOut(name, `
+  FROM busybox
+  RUN badEXE a1 a2`, false)
+	if err == nil {
+		c.Fatal("Should have failed to build")
+	}
+
+	exp := `The command \"/bin/sh -c badEXE a1 a2\" returned a non-zero code: 127"`
+	if !strings.Contains(out, exp) {
+		c.Fatalf("RUN doesn't have the correct output:\nGot:%s\nExpected:%s", out, exp)
+	}
+}

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -3,6 +3,7 @@ package runconfig
 import (
 	"encoding/json"
 	"io"
+	"strings"
 
 	"github.com/docker/docker/nat"
 )
@@ -57,6 +58,10 @@ func NewEntrypoint(parts ...string) *Entrypoint {
 
 type Command struct {
 	parts []string
+}
+
+func (e *Command) ToString() string {
+	return strings.Join(e.parts, " ")
 }
 
 func (e *Command) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
When RUN returns with a non-zero return code it prints the command
that was executed as a Go []string:

```
INFO[0000] The command &{[/bin/sh -c noop a1 a2]} returned a non-zero code: 127
```

instead it should look like this:

```
INFO[0000] The command "/bin/sh -c noop a1 a2" returned a non-zero code: 127
```

Signed-off-by: Doug Davis dug@us.ibm.com
