### PR TITLE
execdriver/utils.go: add CAP_AUDIT_READ

### DIFF
--- a/daemon/execdriver/utils.go
+++ b/daemon/execdriver/utils.go
@@ -46,6 +46,7 @@ var capabilityList = Capabilities{
 	{Key: "SETFCAP", Value: capability.CAP_SETFCAP},
 	{Key: "WAKE_ALARM", Value: capability.CAP_WAKE_ALARM},
 	{Key: "BLOCK_SUSPEND", Value: capability.CAP_BLOCK_SUSPEND},
+	{Key: "AUDIT_READ", Value: capability.CAP_AUDIT_READ},
 }
 
 type (


### PR DESCRIPTION
Finish addition of CAP_AUDIT_READ such that audit_read and all pass the capability as listed in bash completion and in syndtr/gocapability/capability.

Tested locally using a recently built libcap and capsh against 3.19 series kernel headers on ubuntu and using capsh --supports and --print to confirm cap gets added.
