### PR TITLE
Fix typo in the api remote reference for links

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.15.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.15.md
@@ -207,8 +207,8 @@ Json Parameters:
           volume for the container), `host_path:container_path` (to bind-mount
           a host path into the container), or `host_path:container_path:ro`
           (to make the bind-mount read-only inside the container).
-  -   **Links** - A list of links for the container.  Each link entry should be of
-        of the form "container_name:alias".
+  -   **Links** - A list of links for the container.  Each link entry should be
+        in the form of "container_name:alias".
   -   **LxcConf** - LXC specific configurations.  These configurations will only
         work when using the `lxc` execution driver.
   -   **PortBindings** - A map of exposed container ports and the host port they

--- a/docs/sources/reference/api/docker_remote_api_v1.16.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.16.md
@@ -207,8 +207,8 @@ Json Parameters:
           volume for the container), `host_path:container_path` (to bind-mount
           a host path into the container), or `host_path:container_path:ro`
           (to make the bind-mount read-only inside the container).
-  -   **Links** - A list of links for the container.  Each link entry should be of
-        of the form "container_name:alias".
+  -   **Links** - A list of links for the container.  Each link entry should be
+        in the form of "container_name:alias".
   -   **LxcConf** - LXC specific configurations.  These configurations will only
         work when using the `lxc` execution driver.
   -   **PortBindings** - A map of exposed container ports and the host port they

--- a/docs/sources/reference/api/docker_remote_api_v1.17.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.17.md
@@ -207,8 +207,8 @@ Json Parameters:
           volume for the container), `host_path:container_path` (to bind-mount
           a host path into the container), or `host_path:container_path:ro`
           (to make the bind-mount read-only inside the container).
-  -   **Links** - A list of links for the container.  Each link entry should be of
-        of the form "container_name:alias".
+  -   **Links** - A list of links for the container.  Each link entry should be
+        in the form of "container_name:alias".
   -   **LxcConf** - LXC specific configurations.  These configurations will only
         work when using the `lxc` execution driver.
   -   **PortBindings** - A map of exposed container ports and the host port they

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -218,8 +218,8 @@ Json Parameters:
             volume for the container), `host_path:container_path` (to bind-mount
             a host path into the container), or `host_path:container_path:ro`
             (to make the bind-mount read-only inside the container).
-    -   **Links** - A list of links for the container. Each link entry should be of
-          of the form `container_name:alias`.
+    -   **Links** - A list of links for the container. Each link entry should be
+          in the form of `container_name:alias`.
     -   **LxcConf** - LXC specific configurations. These configurations will only
           work when using the `lxc` execution driver.
     -   **PortBindings** - A map of exposed container ports and the host port they

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -222,8 +222,8 @@ Json Parameters:
             volume for the container), `host_path:container_path` (to bind-mount
             a host path into the container), or `host_path:container_path:ro`
             (to make the bind-mount read-only inside the container).
-    -   **Links** - A list of links for the container. Each link entry should be of
-          of the form `container_name:alias`.
+    -   **Links** - A list of links for the container. Each link entry should be
+          in the form of `container_name:alias`.
     -   **LxcConf** - LXC specific configurations. These configurations will only
           work when using the `lxc` execution driver.
     -   **PortBindings** - A map of exposed container ports and the host port they


### PR DESCRIPTION
/cc @thaJeztah @moxiegirl

Spotted this double **of** (not sure though, I've also fixed where this was needed as well)

Signed-off-by: Antonio Murdaca me@runcom.ninja
