### PR TITLE
Do not check and return strconv.Atoi error in api container restart

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -917,10 +917,7 @@ func (s *Server) postContainersRestart(version version.Version, w http.ResponseW
 		return fmt.Errorf("Missing parameter")
 	}
 
-	timeout, err := strconv.Atoi(r.Form.Get("t"))
-	if err != nil {
-		return err
-	}
+	timeout, _ := strconv.Atoi(r.Form.Get("t"))
 
 	if err := s.daemon.ContainerRestart(vars["name"], timeout); err != nil {
 		return err

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -899,6 +899,25 @@ func (s *DockerSuite) TestContainerApiRestart(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestContainerApiRestartNotimeoutParam(c *check.C) {
+	name := "test-api-restart-no-timeout-param"
+	runCmd := exec.Command(dockerBinary, "run", "-di", "--name", name, "busybox", "top")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		c.Fatalf("Error on container creation: %v, output: %q", err, out)
+	}
+	id := strings.TrimSpace(out)
+	c.Assert(waitRun(id), check.IsNil)
+
+	status, _, err := sockRequest("POST", "/containers/"+name+"/restart", nil)
+	c.Assert(status, check.Equals, http.StatusNoContent)
+	c.Assert(err, check.IsNil)
+
+	if err := waitInspect(name, "{{ .State.Restarting  }} {{ .State.Running  }}", "false true", 5); err != nil {
+		c.Fatal(err)
+	}
+}
+
 func (s *DockerSuite) TestContainerApiStart(c *check.C) {
 	name := "testing-start"
 	config := map[string]interface{}{


### PR DESCRIPTION
fixes #12607 
related to #12679 (turns out this pr haven't fixed the related issue, cause I was still getting 500 from container restart api call without a timeout in query string)

more info at:
https://github.com/docker/docker/commit/e41192a3f8cbfbbfecde03f58a3b2be2b1afd836#commitcomment-10831466

/cc @LK4D4 @calavera 

Signed-off-by: Antonio Murdaca me@runcom.ninja
