### PR TITLE
Fix check for upstart not detecting properly

### DIFF
--- a/contrib/init/sysvinit-debian/docker
+++ b/contrib/init/sysvinit-debian/docker
@@ -39,17 +39,19 @@ if [ -f /etc/default/$BASE ]; then
 	. /etc/default/$BASE
 fi
 
-# see also init_is_upstart in /lib/lsb/init-functions (which isn't available in Ubuntu 12.04, or we'd use it)
-if [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; then
-	log_failure_msg "$DOCKER_DESC is managed via upstart, try using service $BASE $1"
-	exit 1
-fi
-
 # Check docker is present
 if [ ! -x $DOCKER ]; then
 	log_failure_msg "$DOCKER not present or not executable"
 	exit 1
 fi
+
+check_init() {
+	 # see also init_is_upstart in /lib/lsb/init-functions (which isn't available in Ubuntu 12.04, or we'd use it directly)
+	 if [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; then        
+                log_failure_msg "$DOCKER_DESC is managed via upstart, try using service $BASE $1"
+                exit 1
+         fi
+}
 
 fail_unless_root() {
 	if [ "$(id -u)" != '0' ]; then
@@ -83,6 +85,8 @@ cgroupfs_mount() {
 
 case "$1" in
 	start)
+		check_init
+		
 		fail_unless_root
 
 		cgroupfs_mount
@@ -111,6 +115,7 @@ case "$1" in
 		;;
 
 	stop)
+		check_init
 		fail_unless_root
 		log_begin_msg "Stopping $DOCKER_DESC: $BASE"
 		start-stop-daemon --stop --pidfile "$DOCKER_SSD_PIDFILE"
@@ -118,6 +123,7 @@ case "$1" in
 		;;
 
 	restart)
+		check_init
 		fail_unless_root
 		docker_pid=`cat "$DOCKER_SSD_PIDFILE" 2>/dev/null`
 		[ -n "$docker_pid" ] \
@@ -127,16 +133,18 @@ case "$1" in
 		;;
 
 	force-reload)
+		check_init
 		fail_unless_root
 		$0 restart
 		;;
 
 	status)
+		check_init
 		status_of_proc -p "$DOCKER_SSD_PIDFILE" "$DOCKER" "$DOCKER_DESC"
 		;;
 
 	*)
-		echo "Usage: $0 {start|stop|restart|status}"
+		echo "Usage: service docker {start|stop|restart|status}"
 		exit 1
 		;;
 esac


### PR DESCRIPTION
##### Associated Issue:
#13031

This will now properly check whether /etc/init.d/docker or service docker is
invoking the script and respond to the user accordingly. 

Prior to this change the script was checking for `init_is_upstart` outside of the action switch which doesn't work. I made the changes to reflect the [proper](https://wiki.ubuntu.com/UpstartCompatibleInitScripts) way of doing this by checking within the switch.
##### Comments:

Line 42 mentioned /lib/lsb/init-functions aren't available in Ubuntu 12.04, but a few [lines above](https://github.com/docker/docker/blob/ea0ccea62ee9669ce554fc9e9f5661046d86bc81/contrib/init/sysvinit-debian/docker#L36) we do `. /lib/lsb/init-functions` and in testing, since `set -e` is at the top, docker will fail anyways with:
`/etc/init.d/docker: 36: .: Can't open /lib/lsb/init-functions` when there is a typo in the command `sudo service docker rasdf` 

I also modified line 146 because in some cases it will say the usage is `/etc/init.d/docker`

Signed-off-by: Steven Richards steven@axiomzen.co
