### PR TITLE
Fix firewalld callback.

### DIFF
--- a/links/links.go
+++ b/links/links.go
@@ -145,7 +145,7 @@ func (l *Link) Enable() error {
 		return err
 	}
 	// call this on Firewalld reload
-	iptables.OnReloaded(func() { l.toggle("-I", false) })
+	iptables.OnReloaded(func() { l.toggle("-A", false) })
 	l.IsEnabled = true
 	return nil
 }


### PR DESCRIPTION
It needs to be called with same args as the one 4 lines above.

Not sure why there's been "-I", maybe some relic from pre cc89b30
