### PR TITLE
Support compiling docker with local code.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ DOCKER_ENVS := \
 # (default to no bind mount if DOCKER_HOST is set)
 # note: BINDDIR is supported for backwards-compatibility here
 BIND_DIR := $(if $(BINDDIR),$(BINDDIR),$(if $(DOCKER_HOST),,bundles))
-DOCKER_MOUNT := $(if $(BIND_DIR),-v "$(CURDIR)/$(BIND_DIR):/go/src/github.com/docker/docker/$(BIND_DIR)")
+DOCKER_MOUNT := $(if $(BIND_DIR),-v "$(CURDIR):/go/src/github.com/docker/docker")
 
 # to allow `make DOCSDIR=docs docs-shell` (to create a bind mount in docs)
 DOCS_MOUNT := $(if $(DOCSDIR),-v $(CURDIR)/$(DOCSDIR):/$(DOCSDIR))


### PR DESCRIPTION
Each time when building local code, coders need to rebuild the Dockerfile. Because if not rebuild, cache image with older code will be used. So, if DOCKER_MOUNT the local code in to the container, the container will create the new binary(or something else) in bundle directory with local code.

Signed-off-by: xuxinkun xuxinkun@gmail.com
