### PR TITLE
Remove fsync in archive.NewTempArchive

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -254,9 +254,6 @@ func bufferToFile(f *os.File, src io.Reader) (int64, digest.Digest, error) {
 	if err != nil {
 		return 0, "", err
 	}
-	if err = f.Sync(); err != nil {
-		return 0, "", err
-	}
 	n, err := f.Seek(0, os.SEEK_CUR)
 	if err != nil {
 		return 0, "", err

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -794,9 +794,6 @@ func NewTempArchive(src Archive, dir string) (*TempArchive, error) {
 	if _, err := io.Copy(f, src); err != nil {
 		return nil, err
 	}
-	if err = f.Sync(); err != nil {
-		return nil, err
-	}
 	if _, err := f.Seek(0, 0); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes the "Buffering to disk" part of `docker push` 70% faster in my use-case (having already applied #12833, and to be clear, we're talking 11s -> 3s).

AIUI, fsync'ing here serves no valuable purpose: if the drive's operation is interrupted, so it the program's, and this archive has no value other than the immediate and transient one.

Is my assumption incorrect in some way?
