### PR TITLE
Windows: Fix filepath in opts.go

### DIFF
--- a/opts/opts.go
+++ b/opts/opts.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -161,13 +161,13 @@ func ValidatePath(val string) (string, error) {
 	splited := strings.SplitN(val, ":", 2)
 	if len(splited) == 1 {
 		containerPath = splited[0]
-		val = path.Clean(splited[0])
+		val = filepath.Clean(splited[0])
 	} else {
 		containerPath = splited[1]
-		val = fmt.Sprintf("%s:%s", splited[0], path.Clean(splited[1]))
+		val = fmt.Sprintf("%s:%s", splited[0], filepath.Clean(splited[1]))
 	}
 
-	if !path.IsAbs(containerPath) {
+	if !filepath.IsAbs(containerPath) {
 		return val, fmt.Errorf("%s is not an absolute path", containerPath)
 	}
 	return val, nil


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com.
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. Simple fix to use filepath instead of path in opts.go
