### PR TITLE
Use distribution's ValidateRepositoryName for remote name validation. 

### DIFF
--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -111,20 +111,20 @@ func (s *DockerSuite) TestTagExistedNameWithForce(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestTagWithSuffixHyphen(c *check.C) {
+func (s *DockerSuite) TestTagWithPrefixHyphen(c *check.C) {
 	if err := pullImageIfNotExist("busybox:latest"); err != nil {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 	// test repository name begin with '-'
 	tagCmd := exec.Command(dockerBinary, "tag", "busybox:latest", "-busybox:test")
 	out, _, err := runCommandWithOutput(tagCmd)
-	if err == nil || !strings.Contains(out, "Invalid repository name (-busybox). Cannot begin or end with a hyphen") {
+	if err == nil || !strings.Contains(out, "repository name component must match") {
 		c.Fatal("tag a name begin with '-' should failed")
 	}
 	// test namespace name begin with '-'
 	tagCmd = exec.Command(dockerBinary, "tag", "busybox:latest", "-test/busybox:test")
 	out, _, err = runCommandWithOutput(tagCmd)
-	if err == nil || !strings.Contains(out, "Invalid namespace name (-test). Cannot begin or end with a hyphen") {
+	if err == nil || !strings.Contains(out, "repository name component must match") {
 		c.Fatal("tag a name begin with '-' should failed")
 	}
 	// test index name begin wiht '-'

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -742,9 +742,6 @@ func TestValidRemoteName(t *testing.T) {
 		// Allow embedded hyphens.
 		"docker-rules/docker",
 
-		// Allow underscores everywhere (as opposed to hyphens).
-		"____/____",
-
 		//Username doc and image name docker being tested.
 		"doc/docker",
 	}
@@ -768,6 +765,11 @@ func TestValidRemoteName(t *testing.T) {
 		"-docker/docker",
 		"docker-/docker",
 		"-docker-/docker",
+
+		// Don't allow underscores everywhere (as opposed to hyphens).
+		"____/____",
+
+		"_docker/_docker",
 
 		// Disallow consecutive hyphens.
 		"dock--er/docker",


### PR DESCRIPTION
Signed-off-by: Shishir Mahajan shishir.mahajan@redhat.com
