### PR TITLE
Update "hack/vendor.sh" to be more explicit

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -36,26 +36,23 @@ clone() {
 	echo -n 'rm VCS, '
 	( cd $target_dir && rm -rf .{git,hg} )
 
+	echo -n 'rm vendor, '
+	( cd $target_dir && rm -rf vendor Godeps/_workspace )
+
 	echo done
 }
 
-clone git github.com/kr/pty 05017fcccf
-
-clone git github.com/gorilla/context 14f550f51a
-
-clone git github.com/gorilla/mux e444e69cbd
-
-clone git github.com/tchap/go-patricia v2.1.0
-
-clone hg code.google.com/p/go.net 84a4013f96e0
-
-clone hg code.google.com/p/gosqlite 74691fb6f837
-
+# the following lines are in sorted order, FYI
+clone git github.com/Sirupsen/logrus v0.7.3 # logrus is a common dependency among multiple deps
 clone git github.com/docker/libtrust 230dfd18c232
-
-clone git github.com/go-fsnotify/fsnotify v1.2.0
-
 clone git github.com/go-check/check 64131543e7896d5bcc6bd5a76287eb75ea96c673
+clone git github.com/go-fsnotify/fsnotify v1.2.0
+clone git github.com/gorilla/context 14f550f51a
+clone git github.com/gorilla/mux e444e69cbd
+clone git github.com/kr/pty 05017fcccf
+clone git github.com/tchap/go-patricia v2.1.0
+clone hg code.google.com/p/go.net 84a4013f96e0
+clone hg code.google.com/p/gosqlite 74691fb6f837
 
 # get distribution packages
 clone git github.com/docker/distribution d957768537c5af40e4f4cd96871f7b2bde9e2923
@@ -67,8 +64,8 @@ mv tmp-digest src/github.com/docker/distribution/digest
 mkdir -p src/github.com/docker/distribution/registry
 mv tmp-api src/github.com/docker/distribution/registry/api
 
-clone git github.com/docker/libcontainer 1b471834b45063b61e0aedefbb1739a8f34b414e
-# see src/github.com/docker/libcontainer/update-vendor.sh which is the "source of truth" for libcontainer deps (just like this file)
-rm -rf src/github.com/docker/libcontainer/vendor
-eval "$(grep '^clone ' src/github.com/docker/libcontainer/update-vendor.sh | grep -v 'github.com/codegangsta/cli')"
-# we exclude "github.com/codegangsta/cli" here because it's only needed for "nsinit", which Docker doesn't include
+clone git github.com/docker/libcontainer 90f8aa670f1f424041059060c7c63fe4dee2e441
+# libcontainer deps (see src/github.com/docker/libcontainer/update-vendor.sh)
+clone git github.com/coreos/go-systemd v2
+clone git github.com/godbus/dbus v2
+clone git github.com/syndtr/gocapability 8e4cdcb

--- a/vendor/src/github.com/docker/libcontainer/.gitignore
+++ b/vendor/src/github.com/docker/libcontainer/.gitignore
@@ -1,2 +1,3 @@
 bundles
 nsinit/nsinit
+vendor/pkg

--- a/vendor/src/github.com/docker/libcontainer/SPEC.md
+++ b/vendor/src/github.com/docker/libcontainer/SPEC.md
@@ -15,7 +15,7 @@ with a strong security configuration.
 ### System Requirements and Compatibility
 
 Minimum requirements:
-* Kernel version - 3.8 recommended 2.6.2x minimum(with backported patches) 
+* Kernel version - 3.10 recommended 2.6.2x minimum(with backported patches)
 * Mounted cgroups with each subsystem in its own hierarchy
 
 
@@ -28,11 +28,9 @@ Minimum requirements:
 | CLONE_NEWIPC  |    1    |
 | CLONE_NEWNET  |    1    |
 | CLONE_NEWNS   |    1    |
-| CLONE_NEWUSER |    0    |
+| CLONE_NEWUSER |    1    |
 
-In v1 the user namespace is not enabled by default for support of older kernels
-where the user namespace feature is not fully implemented.  Namespaces are 
-created for the container via the `clone` syscall.  
+Namespaces are created for the container via the `clone` syscall.  
 
 
 ### Filesystem
@@ -143,6 +141,7 @@ system resources like cpu, memory, and device access.
 | blkio      | 1       |
 | perf_event | 1       |
 | freezer    | 1       |
+| hugetlb    | 1       |
 
 
 All cgroup subsystem are joined so that statistics can be collected from
@@ -165,6 +164,7 @@ provide a good default for security and flexibility for the applications.
 | -------------------- | ------- |
 | CAP_NET_RAW          | 1       |
 | CAP_NET_BIND_SERVICE | 1       |
+| CAP_AUDIT_READ       | 1       |
 | CAP_AUDIT_WRITE      | 1       |
 | CAP_DAC_OVERRIDE     | 1       |
 | CAP_SETFCAP          | 1       |
@@ -304,6 +304,7 @@ a container.
 | Pause          | Pause all processes inside the container                           |
 | Resume         | Resume all processes inside the container if paused                |
 | Exec           | Execute a new process inside of the container  ( requires setns )  |
+| Set            | Setup configs of the container after it's created                  |
 
 ### Execute a new process inside of a running container.
 

--- a/vendor/src/github.com/docker/libcontainer/cgroups/fs/stats_util_test.go
+++ b/vendor/src/github.com/docker/libcontainer/cgroups/fs/stats_util_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libcontainer/cgroups"
 )
 
@@ -23,75 +23,75 @@ func blkioStatEntryEquals(expected, actual []cgroups.BlkioStatEntry) error {
 
 func expectBlkioStatsEquals(t *testing.T, expected, actual cgroups.BlkioStats) {
 	if err := blkioStatEntryEquals(expected.IoServiceBytesRecursive, actual.IoServiceBytesRecursive); err != nil {
-		log.Printf("blkio IoServiceBytesRecursive do not match - %s\n", err)
+		logrus.Printf("blkio IoServiceBytesRecursive do not match - %s\n", err)
 		t.Fail()
 	}
 
 	if err := blkioStatEntryEquals(expected.IoServicedRecursive, actual.IoServicedRecursive); err != nil {
-		log.Printf("blkio IoServicedRecursive do not match - %s\n", err)
+		logrus.Printf("blkio IoServicedRecursive do not match - %s\n", err)
 		t.Fail()
 	}
 
 	if err := blkioStatEntryEquals(expected.IoQueuedRecursive, actual.IoQueuedRecursive); err != nil {
-		log.Printf("blkio IoQueuedRecursive do not match - %s\n", err)
+		logrus.Printf("blkio IoQueuedRecursive do not match - %s\n", err)
 		t.Fail()
 	}
 
 	if err := blkioStatEntryEquals(expected.SectorsRecursive, actual.SectorsRecursive); err != nil {
-		log.Printf("blkio SectorsRecursive do not match - %s\n", err)
+		logrus.Printf("blkio SectorsRecursive do not match - %s\n", err)
 		t.Fail()
 	}
 
 	if err := blkioStatEntryEquals(expected.IoServiceTimeRecursive, actual.IoServiceTimeRecursive); err != nil {
-		log.Printf("blkio IoServiceTimeRecursive do not match - %s\n", err)
+		logrus.Printf("blkio IoServiceTimeRecursive do not match - %s\n", err)
 		t.Fail()
 	}
 
 	if err := blkioStatEntryEquals(expected.IoWaitTimeRecursive, actual.IoWaitTimeRecursive); err != nil {
-		log.Printf("blkio IoWaitTimeRecursive do not match - %s\n", err)
+		logrus.Printf("blkio IoWaitTimeRecursive do not match - %s\n", err)
 		t.Fail()
 	}
 
 	if err := blkioStatEntryEquals(expected.IoMergedRecursive, actual.IoMergedRecursive); err != nil {
-		log.Printf("blkio IoMergedRecursive do not match - %v vs %v\n", expected.IoMergedRecursive, actual.IoMergedRecursive)
+		logrus.Printf("blkio IoMergedRecursive do not match - %v vs %v\n", expected.IoMergedRecursive, actual.IoMergedRecursive)
 		t.Fail()
 	}
 
 	if err := blkioStatEntryEquals(expected.IoTimeRecursive, actual.IoTimeRecursive); err != nil {
-		log.Printf("blkio IoTimeRecursive do not match - %s\n", err)
+		logrus.Printf("blkio IoTimeRecursive do not match - %s\n", err)
 		t.Fail()
 	}
 }
 
 func expectThrottlingDataEquals(t *testing.T, expected, actual cgroups.ThrottlingData) {
 	if expected != actual {
-		log.Printf("Expected throttling data %v but found %v\n", expected, actual)
+		logrus.Printf("Expected throttling data %v but found %v\n", expected, actual)
 		t.Fail()
 	}
 }
 
 func expectMemoryStatEquals(t *testing.T, expected, actual cgroups.MemoryStats) {
 	if expected.Usage != actual.Usage {
-		log.Printf("Expected memory usage %d but found %d\n", expected.Usage, actual.Usage)
+		logrus.Printf("Expected memory usage %d but found %d\n", expected.Usage, actual.Usage)
 		t.Fail()
 	}
 	if expected.MaxUsage != actual.MaxUsage {
-		log.Printf("Expected memory max usage %d but found %d\n", expected.MaxUsage, actual.MaxUsage)
+		logrus.Printf("Expected memory max usage %d but found %d\n", expected.MaxUsage, actual.MaxUsage)
 		t.Fail()
 	}
 	for key, expValue := range expected.Stats {
 		actValue, ok := actual.Stats[key]
 		if !ok {
-			log.Printf("Expected memory stat key %s not found\n", key)
+			logrus.Printf("Expected memory stat key %s not found\n", key)
 			t.Fail()
 		}
 		if expValue != actValue {
-			log.Printf("Expected memory stat value %d but found %d\n", expValue, actValue)
+			logrus.Printf("Expected memory stat value %d but found %d\n", expValue, actValue)
 			t.Fail()
 		}
 	}
 	if expected.Failcnt != actual.Failcnt {
-		log.Printf("Expected memory failcnt %d but found %d\n", expected.Failcnt, actual.Failcnt)
+		logrus.Printf("Expected memory failcnt %d but found %d\n", expected.Failcnt, actual.Failcnt)
 		t.Fail()
 	}
 }

--- a/vendor/src/github.com/docker/libcontainer/container_linux.go
+++ b/vendor/src/github.com/docker/libcontainer/container_linux.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"syscall"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libcontainer/cgroups"
 	"github.com/docker/libcontainer/configs"
 )
@@ -102,7 +102,7 @@ func (c *linuxContainer) Start(process *Process) error {
 	if err := parent.start(); err != nil {
 		// terminate the process to ensure that it properly is reaped.
 		if err := parent.terminate(); err != nil {
-			log.Warn(err)
+			logrus.Warn(err)
 		}
 		return newSystemError(err)
 	}
@@ -227,7 +227,7 @@ func (c *linuxContainer) Destroy() error {
 	}
 	if !c.config.Namespaces.Contains(configs.NEWPID) {
 		if err := killCgroupProcesses(c.cgroupManager); err != nil {
-			log.Warn(err)
+			logrus.Warn(err)
 		}
 	}
 	err = c.cgroupManager.Destroy()

--- a/vendor/src/github.com/docker/libcontainer/init_linux.go
+++ b/vendor/src/github.com/docker/libcontainer/init_linux.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"syscall"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libcontainer/cgroups"
 	"github.com/docker/libcontainer/configs"
 	"github.com/docker/libcontainer/netlink"
@@ -234,7 +234,7 @@ func setupRlimits(config *configs.Config) error {
 func killCgroupProcesses(m cgroups.Manager) error {
 	var procs []*os.Process
 	if err := m.Freeze(configs.Frozen); err != nil {
-		log.Warn(err)
+		logrus.Warn(err)
 	}
 	pids, err := m.GetPids()
 	if err != nil {
@@ -245,16 +245,16 @@ func killCgroupProcesses(m cgroups.Manager) error {
 		if p, err := os.FindProcess(pid); err == nil {
 			procs = append(procs, p)
 			if err := p.Kill(); err != nil {
-				log.Warn(err)
+				logrus.Warn(err)
 			}
 		}
 	}
 	if err := m.Freeze(configs.Thawed); err != nil {
-		log.Warn(err)
+		logrus.Warn(err)
 	}
 	for _, p := range procs {
 		if _, err := p.Wait(); err != nil {
-			log.Warn(err)
+			logrus.Warn(err)
 		}
 	}
 	return nil

--- a/vendor/src/github.com/docker/libcontainer/integration/exec_test.go
+++ b/vendor/src/github.com/docker/libcontainer/integration/exec_test.go
@@ -204,9 +204,6 @@ func TestEnter(t *testing.T) {
 
 	config := newTemplateConfig(rootfs)
 
-	factory, err := libcontainer.New(root, libcontainer.Cgroupfs)
-	ok(t, err)
-
 	container, err := factory.Create("test", config)
 	ok(t, err)
 	defer container.Destroy()
@@ -294,9 +291,6 @@ func TestProcessEnv(t *testing.T) {
 
 	config := newTemplateConfig(rootfs)
 
-	factory, err := libcontainer.New(root, libcontainer.Cgroupfs)
-	ok(t, err)
-
 	container, err := factory.Create("test", config)
 	ok(t, err)
 	defer container.Destroy()
@@ -345,9 +339,6 @@ func TestProcessCaps(t *testing.T) {
 	defer remove(rootfs)
 
 	config := newTemplateConfig(rootfs)
-
-	factory, err := libcontainer.New(root, libcontainer.Cgroupfs)
-	ok(t, err)
 
 	container, err := factory.Create("test", config)
 	ok(t, err)
@@ -427,15 +418,12 @@ func testFreeze(t *testing.T, systemd bool) {
 	defer remove(rootfs)
 
 	config := newTemplateConfig(rootfs)
-	cgm := libcontainer.Cgroupfs
+	f := factory
 	if systemd {
-		cgm = libcontainer.SystemdCgroups
+		f = systemdFactory
 	}
 
-	factory, err := libcontainer.New(root, cgm)
-	ok(t, err)
-
-	container, err := factory.Create("test", config)
+	container, err := f.Create("test", config)
 	ok(t, err)
 	defer container.Destroy()
 
@@ -539,11 +527,6 @@ func TestContainerState(t *testing.T) {
 		{Type: configs.NEWNET},
 	})
 
-	factory, err := libcontainer.New(root, libcontainer.Cgroupfs)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	container, err := factory.Create("test", config)
 	if err != nil {
 		t.Fatal(err)
@@ -594,11 +577,6 @@ func TestPassExtraFiles(t *testing.T) {
 	defer remove(rootfs)
 
 	config := newTemplateConfig(rootfs)
-
-	factory, err := libcontainer.New(rootfs, libcontainer.Cgroupfs)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	container, err := factory.Create("test", config)
 	if err != nil {
@@ -673,7 +651,7 @@ func TestMountCmds(t *testing.T) {
 	config := newTemplateConfig(rootfs)
 	config.Mounts = append(config.Mounts, &configs.Mount{
 		Source:      tmpDir,
-		Destination: filepath.Join(rootfs, "tmp"),
+		Destination: "/tmp",
 		Device:      "bind",
 		Flags:       syscall.MS_BIND | syscall.MS_REC,
 		PremountCmds: []configs.Command{
@@ -685,11 +663,6 @@ func TestMountCmds(t *testing.T) {
 			{Path: "cp", Args: []string{filepath.Join(rootfs, "tmp", "world"), filepath.Join(rootfs, "tmp", "world-backup")}},
 		},
 	})
-
-	factory, err := libcontainer.New(root, libcontainer.Cgroupfs)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	container, err := factory.Create("test", config)
 	if err != nil {
@@ -737,9 +710,6 @@ func TestSystemProperties(t *testing.T) {
 	config.SystemProperties = map[string]string{
 		"kernel.shmmni": "8192",
 	}
-
-	factory, err := libcontainer.New(root, libcontainer.Cgroupfs)
-	ok(t, err)
 
 	container, err := factory.Create("test", config)
 	ok(t, err)

--- a/vendor/src/github.com/docker/libcontainer/integration/utils_test.go
+++ b/vendor/src/github.com/docker/libcontainer/integration/utils_test.go
@@ -79,19 +79,13 @@ func copyBusybox(dest string) error {
 }
 
 func newContainer(config *configs.Config) (libcontainer.Container, error) {
-	cgm := libcontainer.Cgroupfs
+	f := factory
+
 	if config.Cgroups != nil && config.Cgroups.Slice == "system.slice" {
-		cgm = libcontainer.SystemdCgroups
+		f = systemdFactory
 	}
 
-	factory, err := libcontainer.New(".",
-		libcontainer.InitArgs(os.Args[0], "init", "--"),
-		cgm,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return factory.Create("testCT", config)
+	return f.Create("testCT", config)
 }
 
 // runContainer runs the container with the specific config and arguments

--- a/vendor/src/github.com/docker/libcontainer/nsinit/init.go
+++ b/vendor/src/github.com/docker/libcontainer/nsinit/init.go
@@ -3,7 +3,7 @@ package main
 import (
 	"runtime"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/docker/libcontainer"
 	_ "github.com/docker/libcontainer/nsenter"
@@ -13,7 +13,7 @@ var initCommand = cli.Command{
 	Name:  "init",
 	Usage: "runs the init process inside the namespace",
 	Action: func(context *cli.Context) {
-		log.SetLevel(log.DebugLevel)
+		logrus.SetLevel(logrus.DebugLevel)
 		runtime.GOMAXPROCS(1)
 		runtime.LockOSThread()
 		factory, err := libcontainer.New("")

--- a/vendor/src/github.com/docker/libcontainer/nsinit/main.go
+++ b/vendor/src/github.com/docker/libcontainer/nsinit/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 )
 
@@ -29,18 +29,18 @@ func main() {
 	}
 	app.Before = func(context *cli.Context) error {
 		if context.GlobalBool("debug") {
-			log.SetLevel(log.DebugLevel)
+			logrus.SetLevel(logrus.DebugLevel)
 		}
 		if path := context.GlobalString("log-file"); path != "" {
 			f, err := os.Create(path)
 			if err != nil {
 				return err
 			}
-			log.SetOutput(f)
+			logrus.SetOutput(f)
 		}
 		return nil
 	}
 	if err := app.Run(os.Args); err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 }

--- a/vendor/src/github.com/docker/libcontainer/nsinit/oom.go
+++ b/vendor/src/github.com/docker/libcontainer/nsinit/oom.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 )
 
@@ -14,16 +14,16 @@ var oomCommand = cli.Command{
 	Action: func(context *cli.Context) {
 		container, err := getContainer(context)
 		if err != nil {
-			log.Fatal(err)
+			logrus.Fatal(err)
 		}
 		n, err := container.NotifyOOM()
 		if err != nil {
-			log.Fatal(err)
+			logrus.Fatal(err)
 		}
 		for x := range n {
 			// hack for calm down go1.4 gofmt
 			_ = x
-			log.Printf("OOM notification received")
+			logrus.Printf("OOM notification received")
 		}
 	},
 }

--- a/vendor/src/github.com/docker/libcontainer/nsinit/pause.go
+++ b/vendor/src/github.com/docker/libcontainer/nsinit/pause.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 )
 
@@ -14,10 +14,10 @@ var pauseCommand = cli.Command{
 	Action: func(context *cli.Context) {
 		container, err := getContainer(context)
 		if err != nil {
-			log.Fatal(err)
+			logrus.Fatal(err)
 		}
 		if err = container.Pause(); err != nil {
-			log.Fatal(err)
+			logrus.Fatal(err)
 		}
 	},
 }
@@ -31,10 +31,10 @@ var unpauseCommand = cli.Command{
 	Action: func(context *cli.Context) {
 		container, err := getContainer(context)
 		if err != nil {
-			log.Fatal(err)
+			logrus.Fatal(err)
 		}
 		if err = container.Resume(); err != nil {
-			log.Fatal(err)
+			logrus.Fatal(err)
 		}
 	},
 }

--- a/vendor/src/github.com/docker/libcontainer/nsinit/utils.go
+++ b/vendor/src/github.com/docker/libcontainer/nsinit/utils.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"os"
 
 	"github.com/codegangsta/cli"
@@ -36,7 +36,7 @@ func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
 		if systemd.UseSystemd() {
 			cgm = libcontainer.SystemdCgroups
 		} else {
-			log.Warn("systemd cgroup flag passed, but systemd support for managing cgroups is not available.")
+			logrus.Warn("systemd cgroup flag passed, but systemd support for managing cgroups is not available.")
 		}
 	}
 	return libcontainer.New(context.GlobalString("root"), cgm)


### PR DESCRIPTION
Previously, we've taken advantage of the fact that libcontainer's `update-vendor.sh` is the same syntax as Docker's `vendor.sh` with some shell magic.  This changes that to copy libcontainer's dependencies into this file explicitly so that we can scale to more projects with varying methods of vendoring (assuming they don't use import re-writing, which screws up everyone).

We'll need to stay diligent in making sure this list matches what's in libcontainer's `update-vendor.sh` (minus the not-required codegangsta/cli dep), but that's a fair trade-off for being able to scale our dependency model better (and track new discrete dependencies more directly).

cc @LK4D4 @crosbymichael @mavenugo @mrjana
