### PR TITLE
Fix api servers creation and daemon start order

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -98,31 +98,6 @@ func mainDaemon() {
 		}()
 	}
 
-	if err := migrateKey(); err != nil {
-		logrus.Fatal(err)
-	}
-	daemonCfg.TrustKeyPath = *flTrustKey
-
-	registryService := registry.NewService(registryCfg)
-	d, err := daemon.NewDaemon(daemonCfg, registryService)
-	if err != nil {
-		if pfile != nil {
-			if err := pfile.Remove(); err != nil {
-				logrus.Error(err)
-			}
-		}
-		logrus.Fatalf("Error starting daemon: %v", err)
-	}
-
-	logrus.Info("Daemon has completed initialization")
-
-	logrus.WithFields(logrus.Fields{
-		"version":     dockerversion.VERSION,
-		"commit":      dockerversion.GITCOMMIT,
-		"execdriver":  d.ExecutionDriver().Name(),
-		"graphdriver": d.GraphDriver().String(),
-	}).Info("Docker daemon")
-
 	serverConfig := &apiserver.ServerConfig{
 		Logging:     true,
 		EnableCors:  daemonCfg.EnableCors,
@@ -150,6 +125,31 @@ func mainDaemon() {
 		}
 		serveAPIWait <- nil
 	}()
+
+	if err := migrateKey(); err != nil {
+		logrus.Fatal(err)
+	}
+	daemonCfg.TrustKeyPath = *flTrustKey
+
+	registryService := registry.NewService(registryCfg)
+	d, err := daemon.NewDaemon(daemonCfg, registryService)
+	if err != nil {
+		if pfile != nil {
+			if err := pfile.Remove(); err != nil {
+				logrus.Error(err)
+			}
+		}
+		logrus.Fatalf("Error starting daemon: %v", err)
+	}
+
+	logrus.Info("Daemon has completed initialization")
+
+	logrus.WithFields(logrus.Fields{
+		"version":     dockerversion.VERSION,
+		"commit":      dockerversion.GITCOMMIT,
+		"execdriver":  d.ExecutionDriver().Name(),
+		"graphdriver": d.GraphDriver().String(),
+	}).Info("Docker daemon")
 
 	signal.Trap(func() {
 		api.Close()

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1160,3 +1160,13 @@ func pingContainers(c *check.C, d *Daemon, expectFailure bool) {
 	args = append(dargs, "rm", "-f", "container1")
 	runCommand(exec.Command(dockerBinary, args...))
 }
+
+func (s *DockerDaemonSuite) TestDaemonRestartWithSockerAsVolume(c *check.C) {
+	c.Assert(s.d.StartWithBusybox(), check.IsNil)
+
+	socket := filepath.Join(s.d.folder, "docker.sock")
+
+	out, err := s.d.Cmd("run", "-d", "-v", socket+":/sock", "busybox")
+	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
+	c.Assert(s.d.Restart(), check.IsNil)
+}


### PR DESCRIPTION
- daemon creation wasn't parallel to request buffering
- it was possible that empty volume will be created in
  /var/run/docker.sock by some container
