### PR TITLE
Make list of commands for help less static

### DIFF
--- a/docker/flags.go
+++ b/docker/flags.go
@@ -5,15 +5,69 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/homedir"
 	flag "github.com/docker/docker/pkg/mflag"
 )
 
+type command struct {
+	name        string
+	description string
+}
+
+type byName []command
+
+func (a byName) Len() int           { return len(a) }
+func (a byName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byName) Less(i, j int) bool { return a[i].name < a[j].name }
+
 var (
 	dockerCertPath  = os.Getenv("DOCKER_CERT_PATH")
 	dockerTlsVerify = os.Getenv("DOCKER_TLS_VERIFY") != ""
+
+	dockerCommands = []command{
+		{"attach", "Attach to a running container"},
+		{"build", "Build an image from a Dockerfile"},
+		{"commit", "Create a new image from a container's changes"},
+		{"cp", "Copy files/folders from a container's filesystem to the host path"},
+		{"create", "Create a new container"},
+		{"diff", "Inspect changes on a container's filesystem"},
+		{"events", "Get real time events from the server"},
+		{"exec", "Run a command in a running container"},
+		{"export", "Stream the contents of a container as a tar archive"},
+		{"history", "Show the history of an image"},
+		{"images", "List images"},
+		{"import", "Create a new filesystem image from the contents of a tarball"},
+		{"info", "Display system-wide information"},
+		{"inspect", "Return low-level information on a container or image"},
+		{"kill", "Kill a running container"},
+		{"load", "Load an image from a tar archive"},
+		{"login", "Register or log in to a Docker registry server"},
+		{"logout", "Log out from a Docker registry server"},
+		{"logs", "Fetch the logs of a container"},
+		{"port", "Lookup the public-facing port that is NAT-ed to PRIVATE_PORT"},
+		{"pause", "Pause all processes within a container"},
+		{"ps", "List containers"},
+		{"pull", "Pull an image or a repository from a Docker registry server"},
+		{"push", "Push an image or a repository to a Docker registry server"},
+		{"rename", "Rename an existing container"},
+		{"restart", "Restart a running container"},
+		{"rm", "Remove one or more containers"},
+		{"rmi", "Remove one or more images"},
+		{"run", "Run a command in a new container"},
+		{"save", "Save an image to a tar archive"},
+		{"search", "Search for an image on the Docker Hub"},
+		{"start", "Start a stopped container"},
+		{"stats", "Display a stream of a containers' resource usage statistics"},
+		{"stop", "Stop a running container"},
+		{"tag", "Tag an image into a repository"},
+		{"top", "Lookup the running processes of a container"},
+		{"unpause", "Unpause a paused container"},
+		{"version", "Show the Docker version information"},
+		{"wait", "Block until a container stops, then print its exit code"},
+	}
 )
 
 func init() {
@@ -75,49 +129,12 @@ func init() {
 
 		help := "\nCommands:\n"
 
-		for _, command := range [][]string{
-			{"attach", "Attach to a running container"},
-			{"build", "Build an image from a Dockerfile"},
-			{"commit", "Create a new image from a container's changes"},
-			{"cp", "Copy files/folders from a container's filesystem to the host path"},
-			{"create", "Create a new container"},
-			{"diff", "Inspect changes on a container's filesystem"},
-			{"events", "Get real time events from the server"},
-			{"exec", "Run a command in a running container"},
-			{"export", "Stream the contents of a container as a tar archive"},
-			{"history", "Show the history of an image"},
-			{"images", "List images"},
-			{"import", "Create a new filesystem image from the contents of a tarball"},
-			{"info", "Display system-wide information"},
-			{"inspect", "Return low-level information on a container or image"},
-			{"kill", "Kill a running container"},
-			{"load", "Load an image from a tar archive"},
-			{"login", "Register or log in to a Docker registry server"},
-			{"logout", "Log out from a Docker registry server"},
-			{"logs", "Fetch the logs of a container"},
-			{"port", "Lookup the public-facing port that is NAT-ed to PRIVATE_PORT"},
-			{"pause", "Pause all processes within a container"},
-			{"ps", "List containers"},
-			{"pull", "Pull an image or a repository from a Docker registry server"},
-			{"push", "Push an image or a repository to a Docker registry server"},
-			{"rename", "Rename an existing container"},
-			{"restart", "Restart a running container"},
-			{"rm", "Remove one or more containers"},
-			{"rmi", "Remove one or more images"},
-			{"run", "Run a command in a new container"},
-			{"save", "Save an image to a tar archive"},
-			{"search", "Search for an image on the Docker Hub"},
-			{"start", "Start a stopped container"},
-			{"stats", "Display a stream of a containers' resource usage statistics"},
-			{"stop", "Stop a running container"},
-			{"tag", "Tag an image into a repository"},
-			{"top", "Lookup the running processes of a container"},
-			{"unpause", "Unpause a paused container"},
-			{"version", "Show the Docker version information"},
-			{"wait", "Block until a container stops, then print its exit code"},
-		} {
-			help += fmt.Sprintf("    %-10.10s%s\n", command[0], command[1])
+		sort.Sort(byName(dockerCommands))
+
+		for _, cmd := range dockerCommands {
+			help += fmt.Sprintf("    %-10.10s%s\n", cmd.name, cmd.description)
 		}
+
 		help += "\nRun 'docker COMMAND --help' for more information on a command."
 		fmt.Fprintf(os.Stdout, "%s\n", help)
 	}


### PR DESCRIPTION
Before this PR the list of commands that were printed for the help
text was statically put into the flags.Usage() function via main.init(). This
made it impossible to modify later on when we add new commands
via plugins.

This PR moves the list of commands (name & description) into a structure
that is sorted and printed dynamically by the Usage func.  This will allow
the code to add to the list of commands after the init() func is done
but before the help text is printed for the user.

This just moves code around - it should have no UX impact at all.

Signed-off-by: Doug Davis dug@us.ibm.com
