### PR TITLE
Add truncindex errors as types

### DIFF
--- a/pkg/truncindex/errors.go
+++ b/pkg/truncindex/errors.go
@@ -1,0 +1,45 @@
+package truncindex
+
+import "fmt"
+
+type ErrEmptyPrefix struct{}
+
+func (err ErrEmptyPrefix) Error() string {
+	return fmt.Sprint("Prefix can't be empty")
+}
+
+type ErrAmbiguousPrefix struct{}
+
+func (err ErrAmbiguousPrefix) Error() string {
+	return fmt.Sprint("Multiple IDs found with provided prefix")
+}
+
+type ErrNoSuchID struct {
+	ID string
+}
+
+func (err ErrNoSuchID) Error() string {
+	return fmt.Sprintf("no such id: '%s'", err.ID)
+}
+
+type ErrIllegalChar struct{}
+
+func (err ErrIllegalChar) Error() string {
+	return fmt.Sprint("illegal character: ' '")
+}
+
+type ErrIDAlreadyExists struct {
+	ID string
+}
+
+func (err ErrIDAlreadyExists) Error() string {
+	return fmt.Sprintf("id already exists: '%s'", err.ID)
+}
+
+type ErrInsertFailed struct {
+	ID string
+}
+
+func (err ErrInsertFailed) Error() string {
+	return fmt.Sprintf("failed to insert id: %s", err.ID)
+}

--- a/pkg/truncindex/truncindex.go
+++ b/pkg/truncindex/truncindex.go
@@ -1,17 +1,10 @@
 package truncindex
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 	"sync"
 
 	"github.com/tchap/go-patricia/patricia"
-)
-
-var (
-	ErrEmptyPrefix     = errors.New("Prefix can't be empty")
-	ErrAmbiguousPrefix = errors.New("Multiple IDs found with provided prefix")
 )
 
 // TruncIndex allows the retrieval of string identifiers by any of their unique prefixes.
@@ -39,17 +32,17 @@ func NewTruncIndex(ids []string) (idx *TruncIndex) {
 
 func (idx *TruncIndex) addID(id string) error {
 	if strings.Contains(id, " ") {
-		return fmt.Errorf("illegal character: ' '")
+		return ErrIllegalChar{}
 	}
 	if id == "" {
-		return ErrEmptyPrefix
+		return ErrEmptyPrefix{}
 	}
 	if _, exists := idx.ids[id]; exists {
-		return fmt.Errorf("id already exists: '%s'", id)
+		return ErrIDAlreadyExists{ID: id}
 	}
 	idx.ids[id] = struct{}{}
 	if inserted := idx.trie.Insert(patricia.Prefix(id), struct{}{}); !inserted {
-		return fmt.Errorf("failed to insert id: %s", id)
+		return ErrInsertFailed{ID: id}
 	}
 	return nil
 }
@@ -70,11 +63,11 @@ func (idx *TruncIndex) Delete(id string) error {
 	idx.Lock()
 	defer idx.Unlock()
 	if _, exists := idx.ids[id]; !exists || id == "" {
-		return fmt.Errorf("no such id: '%s'", id)
+		return ErrNoSuchID{ID: id}
 	}
 	delete(idx.ids, id)
 	if deleted := idx.trie.Delete(patricia.Prefix(id)); !deleted {
-		return fmt.Errorf("no such id: '%s'", id)
+		return ErrNoSuchID{ID: id}
 	}
 	return nil
 }
@@ -83,7 +76,7 @@ func (idx *TruncIndex) Delete(id string) error {
 // with the given prefix, an error is thrown.
 func (idx *TruncIndex) Get(s string) (string, error) {
 	if s == "" {
-		return "", ErrEmptyPrefix
+		return "", ErrEmptyPrefix{}
 	}
 	var (
 		id string
@@ -92,7 +85,7 @@ func (idx *TruncIndex) Get(s string) (string, error) {
 		if id != "" {
 			// we haven't found the ID if there are two or more IDs
 			id = ""
-			return ErrAmbiguousPrefix
+			return ErrAmbiguousPrefix{}
 		}
 		id = string(prefix)
 		return nil
@@ -106,5 +99,5 @@ func (idx *TruncIndex) Get(s string) (string, error) {
 	if id != "" {
 		return id, nil
 	}
-	return "", fmt.Errorf("no such id: %s", s)
+	return "", ErrNoSuchID{ID: s}
 }


### PR DESCRIPTION
This could better serve in checking errors by their type instead of relying on checking whether `err.Error()` contains which string we expect or not. I think this could be also useful when (and if) docker will support i18n. I'm planning to replace error strings checking in other pr(s) (like in server code).

Signed-off-by: Antonio Murdaca me@runcom.ninja
