### PR TITLE
Move WriteFlusher out of utils into ioutils

### DIFF
--- a/graph/push.go
+++ b/graph/push.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/progressreader"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/stringid"
@@ -212,7 +213,7 @@ func (s *TagStore) pushRepository(r *registry.Session, out io.Writer,
 	repoInfo *registry.RepositoryInfo, localRepo map[string]string,
 	tag string, sf *streamformatter.StreamFormatter) error {
 	logrus.Debugf("Local repo: %s", localRepo)
-	out = utils.NewWriteFlusher(out)
+	out = ioutils.NewWriteFlusher(out)
 	imgList, tags, err := s.getImageList(localRepo, tag)
 	if err != nil {
 		return err
@@ -246,7 +247,7 @@ func (s *TagStore) pushRepository(r *registry.Session, out io.Writer,
 }
 
 func (s *TagStore) pushImage(r *registry.Session, out io.Writer, imgID, ep string, token []string, sf *streamformatter.StreamFormatter) (checksum string, err error) {
-	out = utils.NewWriteFlusher(out)
+	out = ioutils.NewWriteFlusher(out)
 	jsonRaw, err := ioutil.ReadFile(filepath.Join(s.graph.Root, imgID, "json"))
 	if err != nil {
 		return "", fmt.Errorf("Cannot retrieve the path for {%s}: %s", imgID, err)

--- a/pkg/ioutils/writeflusher.go
+++ b/pkg/ioutils/writeflusher.go
@@ -1,0 +1,47 @@
+package ioutils
+
+import (
+	"io"
+	"net/http"
+	"sync"
+)
+
+type WriteFlusher struct {
+	sync.Mutex
+	w       io.Writer
+	flusher http.Flusher
+	flushed bool
+}
+
+func (wf *WriteFlusher) Write(b []byte) (n int, err error) {
+	wf.Lock()
+	defer wf.Unlock()
+	n, err = wf.w.Write(b)
+	wf.flushed = true
+	wf.flusher.Flush()
+	return n, err
+}
+
+// Flush the stream immediately.
+func (wf *WriteFlusher) Flush() {
+	wf.Lock()
+	defer wf.Unlock()
+	wf.flushed = true
+	wf.flusher.Flush()
+}
+
+func (wf *WriteFlusher) Flushed() bool {
+	wf.Lock()
+	defer wf.Unlock()
+	return wf.flushed
+}
+
+func NewWriteFlusher(w io.Writer) *WriteFlusher {
+	var flusher http.Flusher
+	if f, ok := w.(http.Flusher); ok {
+		flusher = f
+	} else {
+		flusher = &NopFlusher{}
+	}
+	return &WriteFlusher{w: w, flusher: flusher}
+}


### PR DESCRIPTION
See https://github.com/samalba/dockerclient/pull/103#issuecomment-100033199 for more context.

The gist is that `dockerclient` needs to use a `WriteFlusher`, and that's the only reason it has to touch `utils`.  `WriteFlusher` is self-contained, so it might as well move to `pkg/ioutils` or `pkg/httputils` like the `FIXME` in the code states.  I chose `ioutils`, but I'm happy to switch it over to `httputils` if that's the consensus.

This is one of those things that can lead to problems with #11699 (since `github.com/docker/docker/utils` is _not_ an explicitly externally-importable path; only `pkg/` is).

cc @aluzzardi @vieux
