### PR TITLE
Windows: reexec pkg supported

### DIFF
--- a/pkg/reexec/command_windows.go
+++ b/pkg/reexec/command_windows.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows
+// +build windows
 
 package reexec
 
@@ -7,5 +7,8 @@ import (
 )
 
 func Command(args ...string) *exec.Cmd {
-	return nil
+	return &exec.Cmd{
+		Path: Self(),
+		Args: args,
+	}
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This changes the reexec package to be supported on Windows.
