### PR TITLE
Add missing "ok" on "comma ok" idiom in test util

### DIFF
--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -23,7 +23,7 @@ import (
 func getExitCode(err error) (int, error) {
 	exitCode := 0
 	if exiterr, ok := err.(*exec.ExitError); ok {
-		if procExit := exiterr.Sys().(syscall.WaitStatus); ok {
+		if procExit, ok := exiterr.Sys().(syscall.WaitStatus); ok {
 			return procExit.ExitStatus(), nil
 		}
 	}


### PR DESCRIPTION
w/o this the "ok" we're checking is from the previous type assertion.

Signed-off-by: Doug Davis dug@us.ibm.com
