### PR TITLE
Fix RUN err msg (again)

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -623,7 +623,7 @@ func (b *Builder) run(c *daemon.Container) error {
 	// Wait for it to finish
 	if ret, _ := c.WaitStop(-1 * time.Second); ret != 0 {
 		return &jsonmessage.JSONError{
-			Message: fmt.Sprintf("The command %q returned a non-zero code: %d", b.Config.Cmd.ToString(), ret),
+			Message: fmt.Sprintf("The command '%s' returned a non-zero code: %d", b.Config.Cmd.ToString(), ret),
 			Code:    ret,
 		}
 	}

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5416,12 +5416,12 @@ func (s *DockerSuite) TestBuildRUNErrMsg(c *check.C) {
 	name := "testbuildbadrunerrmsg"
 	_, out, err := buildImageWithOut(name, `
   FROM busybox
-  RUN badEXE a1 a2`, false)
+  RUN badEXE a1 \& a2	a3`, false) // tab between a2 and a3
 	if err == nil {
 		c.Fatal("Should have failed to build")
 	}
 
-	exp := `The command \"/bin/sh -c badEXE a1 a2\" returned a non-zero code: 127"`
+	exp := "The command '/bin/sh -c badEXE a1 \\\\& a2\\ta3' returned a non-zero code: 127"
 	if !strings.Contains(out, exp) {
 		c.Fatalf("RUN doesn't have the correct output:\nGot:%s\nExpected:%s", out, exp)
 	}


### PR DESCRIPTION
Previous fix used %q which incorrectly go-escaped things. For example:

```
RUN echoo A \& B    C   # tab between B and C
```

would result in the user seeing:

```
INFO[0000] The command '/bin/sh -c echoo A \\& B\tC' returned a non-zero code: 127
```

Note the double-\ and the \t instead of a tab character

The testcase had to double escape things due to logrus getting in the way
but I'm going to fix that in another PR because its a change to the UX.

Signed-off-by: Doug Davis dug@us.ibm.com
