### PR TITLE
Fix oom kill disable issue

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -24,11 +24,6 @@ func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hos
 		return "", warnings, fmt.Errorf("The working directory '%s' is invalid. It needs to be an absolute path.", config.WorkingDir)
 	}
 
-	if !daemon.SystemConfig().OomKillDisable {
-		hostConfig.OomKillDisable = false
-		return "", warnings, fmt.Errorf("Your kernel does not support oom kill disable.")
-	}
-
 	container, buildWarnings, err := daemon.Create(config, hostConfig, name)
 	if err != nil {
 		if daemon.Graph().IsNotExist(err, config.Image) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1181,6 +1181,10 @@ func (daemon *Daemon) verifyHostConfig(hostConfig *runconfig.HostConfig) ([]stri
 	if hostConfig.BlkioWeight > 0 && (hostConfig.BlkioWeight < 10 || hostConfig.BlkioWeight > 1000) {
 		return warnings, fmt.Errorf("Range of blkio weight is from 10 to 1000.")
 	}
+	if hostConfig.OomKillDisable && !daemon.SystemConfig().OomKillDisable {
+		hostConfig.OomKillDisable = false
+		return warnings, fmt.Errorf("Your kernel does not support oom kill disable.")
+	}
 
 	return warnings, nil
 }


### PR DESCRIPTION
It should not be hard limit, we should only check oom kill disable
when user using it.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
