### PR TITLE
Allow copying files/dirs to a container - simpler implementation

### DIFF
--- a/api/client/cp.go
+++ b/api/client/cp.go
@@ -3,6 +3,10 @@ package client
 import (
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -12,46 +16,162 @@ import (
 
 // CmdCp copies files/folders from a path on the container to a directory on the host running the command.
 //
-// If HOSTDIR is '-', the data is written as a tar file to STDOUT.
+// If PATH is '-' for the first arg, the data is sent to the server from STDIN.
+// If PATH is '-' for the second arg, the data is written as a tar file to STDOUT.
 //
-// Usage: docker cp CONTAINER:PATH HOSTDIR
+// Usage: docker cp [CONTAINER:PATH PATH|-] | [PATH|- CONTAINER:PATH]
 func (cli *DockerCli) CmdCp(args ...string) error {
-	cmd := cli.Subcmd("cp", "CONTAINER:PATH HOSTDIR|-", "Copy files/folders from a PATH on the container to a HOSTDIR on the host\nrunning the command. Use '-' to write the data as a tar file to STDOUT.", true)
+	cmd := cli.Subcmd("cp", "[CONTAINER:PATH PATH|-]|[PATH|- CONTAINER:PATH]", "Copy file/folder to/from a container", true)
+	flPause := cmd.Bool([]string{"-pause"}, false, "Pasues the container while copying")
 	cmd.Require(flag.Exact, 2)
-
 	cmd.ParseFlags(args, true)
 
-	// deal with path name with `:`
-	info := strings.SplitN(cmd.Arg(0), ":", 2)
-
-	if len(info) != 2 {
-		return fmt.Errorf("Error: Path not specified")
+	args = cmd.Args()
+	if args[0] == "-" && args[1] == "-" {
+		return fmt.Errorf("invalid arguments, can't use `-` for source and destination")
 	}
 
-	cfg := &types.CopyConfig{
-		Resource: info[1],
+	// first let's skip some guess work.. if this is an absolute path, it's our local path
+	// <container:path> should never be absolute
+	if filepath.IsAbs(args[0]) {
+		// assume args[0] is a local path
+		s, ok := parseMaybePath(args[0], true)
+		if !ok {
+			return fmt.Errorf("source path is not valid: %s", args[0])
+		}
+
+		parts := strings.SplitN(args[1], ":", 2)
+		if len(parts) < 2 {
+			return fmt.Errorf("Invalid format for destination argument: %s", args[1])
+		}
+		return cli.copyPut(s, parts[1], parts[0], *flPause)
 	}
-	stream, statusCode, err := cli.call("POST", "/containers/"+info[0]+"/copy", cfg, nil)
+
+	if filepath.IsAbs(args[1]) {
+		// assume args[1] is a local path
+		s, ok := parseMaybePath(args[1], false)
+		if !ok {
+			return fmt.Errorf("Invalid format for destination argument: %s", args[1])
+		}
+		parts := strings.SplitN(args[0], ":", 2)
+		if len(parts) < 2 {
+			return fmt.Errorf("Invalid format for destination argument: %s", args[1])
+		}
+		return cli.copyGet(s, parts[1], parts[0], *flPause)
+	}
+
+	if s, ok := parseMaybePath(args[0], true); ok {
+		parts := strings.SplitN(args[1], ":", 2)
+		if len(parts) < 2 {
+			// ok well, let's see if arg[0] looks like container:path even though it did look like a file path
+			parts = strings.SplitN(args[0], ":", 2)
+			if len(parts) < 2 {
+				return fmt.Errorf("Invalid format for container:path")
+			}
+			s, ok = parseMaybePath(args[1], false)
+			if !ok {
+				return fmt.Errorf("Invalid format for destination argument: %s", args[1])
+			}
+			return cli.copyGet(s, parts[1], parts[0], *flPause)
+		}
+		return cli.copyPut(s, parts[1], parts[0], *flPause)
+	}
+
+	s, ok := parseMaybePath(args[1], false)
+	if !ok {
+		return fmt.Errorf("Invalid format for destination argument: %s", args[1])
+	}
+	parts := strings.SplitN(args[0], ":", 2)
+	if len(parts) < 2 {
+		return fmt.Errorf("Invalid format for container:path")
+	}
+	return cli.copyGet(s, parts[1], parts[0], *flPause)
+}
+
+func parseMaybePath(s string, useStat bool) (string, bool) {
+	if s == "-" {
+		return s, true
+	}
+	absPath, err := filepath.Abs(s)
+	if err != nil {
+		return "", false
+	}
+	cleanPath := filepath.Clean(absPath)
+
+	if useStat {
+		if _, err := os.Stat(cleanPath); err != nil {
+			return "", false
+		}
+	}
+	return cleanPath, true
+}
+
+func (cli *DockerCli) copyGet(local, remote, container string, pause bool) error {
+	cfg := &types.CopyConfig{Resource: remote, Pause: pause}
+	stream, statusCode, err := cli.call("GET", "/containers/"+container+"/copy", cfg, nil)
 	if stream != nil {
 		defer stream.Close()
 	}
 	if statusCode == 404 {
-		return fmt.Errorf("No such container: %v", info[0])
+		return fmt.Errorf("No such container: %v", container)
 	}
 	if err != nil {
 		return err
 	}
 
-	hostPath := cmd.Arg(1)
 	if statusCode == 200 {
-		if hostPath == "-" {
+		if local == "-" {
 			_, err = io.Copy(cli.out, stream)
 		} else {
-			err = archive.Untar(stream, hostPath, &archive.TarOptions{NoLchown: true})
+			err = archive.Untar(stream, local, &archive.TarOptions{NoLchown: true})
 		}
 		if err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (cli *DockerCli) copyPut(local, remote, container string, pause bool) error {
+	v := url.Values{}
+	v.Set("to", remote)
+	if pause {
+		v.Set("pause", "1")
+	}
+
+	var data io.ReadCloser
+	if local == "-" {
+		data = cli.in
+	} else {
+		stat, err := os.Stat(local)
+		if err != nil {
+			return err
+		}
+		var filter []string
+		if !stat.IsDir() {
+			d, f := filepath.Split(local)
+			local = d
+			filter = []string{f}
+		} else {
+			filter = []string{filepath.Base(local)}
+			local = filepath.Dir(local)
+		}
+
+		data, err = archive.TarWithOptions(local, &archive.TarOptions{
+			Compression:  archive.Uncompressed,
+			IncludeFiles: filter,
+		})
+
+		defer data.Close()
+	}
+	headers := http.Header(make(map[string][]string))
+	headers.Add("Content-Type", "application/tar")
+
+	sopts := &streamOpts{
+		rawTerminal: true,
+		in:          data,
+		out:         cli.out,
+		headers:     headers,
+	}
+	return cli.stream("POST", "/containers/"+container+"/copy?"+v.Encode(), sopts)
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -125,6 +125,7 @@ type Container struct {
 // POST "/containers/"+containerID+"/copy"
 type CopyConfig struct {
 	Resource string
+	Pause    bool
 }
 
 // GET "/containers/{name:.*}/top"

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -31,6 +31,7 @@ import (
 	"github.com/docker/docker/nat"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/broadcastwriter"
+	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/directory"
 	"github.com/docker/docker/pkg/etchosts"
 	"github.com/docker/docker/pkg/ioutils"
@@ -987,7 +988,7 @@ func (container *Container) GetSize() (int64, int64) {
 	return sizeRw, sizeRootfs
 }
 
-func (container *Container) Copy(resource string) (io.ReadCloser, error) {
+func (container *Container) GetFile(resource string) (io.ReadCloser, error) {
 	container.Lock()
 	defer container.Unlock()
 	var err error
@@ -1044,6 +1045,37 @@ func (container *Container) Copy(resource string) (io.ReadCloser, error) {
 			return err
 		}),
 		nil
+}
+
+// PutFile copies the archive to the specified destination in the container
+func (container *Container) PutFile(to string, data archive.ArchiveReader) error {
+	container.Lock()
+	defer container.Unlock()
+	var err error
+
+	if err := container.Mount(); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			container.Unmount()
+		}
+	}()
+	if err = container.mountVolumes(); err != nil {
+		container.unmountVolumes()
+		return err
+	}
+	defer func() {
+		if err != nil {
+			container.unmountVolumes()
+		}
+	}()
+
+	basePath, err := container.GetResourcePath(to)
+	if err != nil {
+		return err
+	}
+	return chrootarchive.Untar(data, basePath, &archive.TarOptions{NoLchown: true})
 }
 
 // Returns true if the container exposes a certain port

--- a/docs/man/docker-cp.1.md
+++ b/docs/man/docker-cp.1.md
@@ -2,17 +2,18 @@
 % Docker Community
 % JUNE 2014
 # NAME
-docker-cp - Copy files or folders from a container's PATH to a HOSTDIR
+docker-cp - Copy files or folders from a container's PATH to a LOCALPATH
 or to STDOUT.
 
 # SYNOPSIS
 **docker cp**
+[**--pause**]
 [**--help**]
-CONTAINER:PATH HOSTDIR|-
+CONTAINER:PATH|LOCALPATH|- CONTAINER:PATH|LOCALPATH|-
 
 # DESCRIPTION
 
-Copy files or folders from a `CONTAINER:PATH` to the `HOSTDIR` or to `STDOUT`. 
+Copy files or folders from a `CONTAINER:PATH` to the `LOCALPATH` or to `STDOUT`. 
 The `CONTAINER:PATH` is relative to the root of the container's filesystem. You
 can copy from either a running or stopped container. 
 
@@ -22,8 +23,8 @@ initial forward slash is optional; The command sees
 `compassionate_darwin:/tmp/foo/myfile.txt` and
 `compassionate_darwin:tmp/foo/myfile.txt` as identical.
 
-The `HOSTDIR` refers to a directory on the host. If you do not specify an
-absolute path for your `HOSTDIR` value, Docker creates the directory relative to
+The `LOCALPATH` refers to a directory on the host. If you do not specify an
+absolute path for your `LOCALPATH` value, Docker creates the directory relative to
 where you run the `docker cp` command. For example, suppose you want to copy the
 `/tmp/foo` directory from a container to the `/tmp` directory on your host. If
 you run `docker cp` in your `~` (home) directory on the host:
@@ -37,7 +38,7 @@ the leading slash in the command. If you execute this command from your home dir
 
 Docker creates a `~/tmp/foo` subdirectory.  
 
-When copying files to an existing `HOSTDIR`, the `cp` command adds the new files to
+When copying files to an existing `LOCALPATH`, the `cp` command adds the new files to
 the directory. For example, this command:
 
 		$ docker cp sharp_ptolemy:/tmp/foo/myfile.txt /tmp
@@ -47,12 +48,21 @@ you repeat the command but change the filename:
 
 		$ docker cp sharp_ptolemy:/tmp/foo/secondfile.txt /tmp
 
-Your host's `/tmp/foo` directory will contain both files:
+Your `/tmp/foo` directory will contain both files:
 
 		$ ls /tmp/foo
 		myfile.txt secondfile.txt
-		
-Finally, use '-' to write the data as a `tar` file to STDOUT.
+
+You can also copy a local file or directory into a container:
+
+  $ mkdir /tmp/foo && touch /tmp/foo/bar
+  $ docker cp /tmp/foo sharp_ptolemy:/tmp
+
+This will copy `/tmp/foo` into `/tmp/` of the container
+
+It is recommended when using `docker cp` to use the `--pause` flag to ensure no
+files are being written to or read from while copying.
+
 
 # OPTIONS
 **--help**
@@ -68,3 +78,4 @@ the exited container to the current dir on the host:
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+May 2015, updated by Brian Goff <cpuguy83@gmail.com>

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -52,6 +52,21 @@ You can still call an old version of the API using
 You can now supply a `stream` bool to get only one set of stats and
 disconnect
 
+`GET /containers/(id)/copy`
+
+**New!**
+Copy files/dirs from container.  
+This used to be `POST /containers/(id)/copy`
+
+**New!**
+Now accepts `pause` boolean flag, which will pause the container while copying.
+
+`POST /containers/(id)/copy`
+
+**New!**
+Copy tar stream into container at specified `to` location
+
+
 ## v1.18
 
 ### Full documentation

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -1097,7 +1097,7 @@ Status Codes:
 
 ### Copy files or folders from a container
 
-`POST /containers/(id)/copy`
+`GET /containers/(id)/copy`
 
 Copy files or folders of container `id`
 
@@ -1108,6 +1108,7 @@ Copy files or folders of container `id`
 
         {
              "Resource": "test.txt"
+             "Pause": true
         }
 
 **Example response**:
@@ -1122,6 +1123,29 @@ Status Codes:
 -   **200** – no error
 -   **404** – no such container
 -   **500** – server error
+
+`POST /containers/(id)/copy`
+
+Copy tar stream into container `id`
+
+**Example request**:
+
+        POST /containers/4fa6e0f0c678/copy?to=/foo HTTP/1.1
+        Content-Type: application/x-tar
+
+        {{ TAR STREAM }}
+
+**Example response**:
+
+        HTTP/1.1 204 No Content
+
+Status Codes:
+
+-   **204** – no error
+-   **404** – no such container
+-   **500** – server error
+
+
 
 ## 2.2 Images
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -923,13 +923,13 @@ Supported `Dockerfile` instructions:
 
 ## cp
 
-Copy files or folders from a container's filesystem to the directory on the
-host.  Use '-' to write the data as a tar file to `STDOUT`. `CONTAINER:PATH` is
-relative to the root of the container's filesystem.
+Copy files or folders from a container's filesystem to the specified local
+directory.  Use '-' to write the data as a tar file to `STDOUT`. `CONTAINER:PATH`
+is relative to the root of the container's filesystem.
 
-    Usage: docker cp CONTAINER:PATH HOSTDIR|-
+    Usage: docker cp CONTAINER:PATH|LOCALPATH|- CONTAINER:PATH|LOCALPATH|-
 
-    Copy files/folders from the PATH to the HOSTDIR.
+    Copy files/folders to or from the container
 
 
 ## create

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1054,7 +1054,7 @@ func (s *DockerSuite) TestContainerApiCopy(c *check.C) {
 		Resource: "/test.txt",
 	}
 
-	status, body, err := sockRequest("POST", "/containers/"+name+"/copy", postData)
+	status, body, err := sockRequest("GET", "/containers/"+name+"/copy", postData)
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusOK)
 
@@ -1085,7 +1085,7 @@ func (s *DockerSuite) TestContainerApiCopyResourcePathEmpty(c *check.C) {
 		Resource: "",
 	}
 
-	status, body, err := sockRequest("POST", "/containers/"+name+"/copy", postData)
+	status, body, err := sockRequest("GET", "/containers/"+name+"/copy", postData)
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusInternalServerError)
 	c.Assert(string(body), check.Matches, "Path cannot be empty\n")
@@ -1101,7 +1101,7 @@ func (s *DockerSuite) TestContainerApiCopyResourcePathNotFound(c *check.C) {
 		Resource: "/notexist",
 	}
 
-	status, body, err := sockRequest("POST", "/containers/"+name+"/copy", postData)
+	status, body, err := sockRequest("GET", "/containers/"+name+"/copy", postData)
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusInternalServerError)
 	c.Assert(string(body), check.Matches, "Could not find the file /notexist in container "+name+"\n")
@@ -1112,7 +1112,7 @@ func (s *DockerSuite) TestContainerApiCopyContainerNotFound(c *check.C) {
 		Resource: "/something",
 	}
 
-	status, _, err := sockRequest("POST", "/containers/notexists/copy", postData)
+	status, _, err := sockRequest("GET", "/containers/notexists/copy", postData)
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusNotFound)
 }


### PR DESCRIPTION
This is a simpler implementation of #10198

Does not support copying files between containers, though this could be done via:

```
$ docker cp <container>:<path> - | docker cp - <container2>:<path>
```

When copying from a container it will use `GET /containers/<id>/copy`, copying to a container would be `POST /containers/<id>/copy?to=<path>`
The `postContainersCopy` method will proxy to `getContainersCopy` for older API versions.

Closes #10198 #5846
