### PR TITLE
Missing exec-opt[] option in CommandLine docs

### DIFF
--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -151,6 +151,7 @@ expect an integer, and they can only be specified once.
       --dns-search=[]                        DNS search domains to use
       --default-ulimit=[]                    Set default ulimit settings for containers
       -e, --exec-driver="native"             Exec driver to use
+      --exec-opt=[]                          Set exec driver options
       --fixed-cidr=""                        IPv4 subnet for fixed IPs
       --fixed-cidr-v6=""                     IPv6 subnet for fixed IPs
       -G, --group="docker"                   Group for the unix socket


### PR DESCRIPTION
Signed-off-by: Shishir Mahajan shishir.mahajan@redhat.com
