### PR TITLE
Windows: Build load.go

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api"
-	"github.com/docker/docker/graph"
+	"github.com/docker/docker/graph/tags"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -241,7 +241,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 			return err
 		}
 		if len(tag) > 0 {
-			if err := graph.ValidateTagName(tag); err != nil {
+			if err := tags.ValidateTagName(tag); err != nil {
 				return err
 			}
 		}

--- a/api/client/create.go
+++ b/api/client/create.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/graph"
+	"github.com/docker/docker/graph/tags"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/runconfig"
@@ -26,7 +26,7 @@ func (cli *DockerCli) pullImageCustomOut(image string, out io.Writer) error {
 	repos, tag := parsers.ParseRepositoryTag(image)
 	// pull only the image tagged 'latest' if no tag was specified
 	if tag == "" {
-		tag = graph.DEFAULTTAG
+		tag = tags.DEFAULTTAG
 	}
 	v.Set("fromImage", repos)
 	v.Set("tag", tag)
@@ -100,7 +100,7 @@ func (cli *DockerCli) createContainer(config *runconfig.Config, hostConfig *runc
 	if statusCode == 404 && strings.Contains(err.Error(), config.Image) {
 		repo, tag := parsers.ParseRepositoryTag(config.Image)
 		if tag == "" {
-			tag = graph.DEFAULTTAG
+			tag = tags.DEFAULTTAG
 		}
 		fmt.Fprintf(cli.err, "Unable to find image '%s' locally\n", utils.ImageReference(repo, tag))
 

--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"github.com/docker/docker/graph"
+	"github.com/docker/docker/graph/tags"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/registry"
@@ -28,7 +28,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 	)
 	taglessRemote, tag := parsers.ParseRepositoryTag(remote)
 	if tag == "" && !*allTags {
-		newRemote = utils.ImageReference(taglessRemote, graph.DEFAULTTAG)
+		newRemote = utils.ImageReference(taglessRemote, tags.DEFAULTTAG)
 	}
 	if tag != "" && *allTags {
 		return fmt.Errorf("tag can't be used with --all-tags/-a")

--- a/builder/job.go
+++ b/builder/job.go
@@ -13,7 +13,7 @@ import (
 	"github.com/docker/docker/builder/parser"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/daemon"
-	"github.com/docker/docker/graph"
+	"github.com/docker/docker/graph/tags"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/httputils"
 	"github.com/docker/docker/pkg/parsers"
@@ -99,7 +99,7 @@ func Build(d *daemon.Daemon, buildConfig *Config) error {
 			return err
 		}
 		if len(tag) > 0 {
-			if err := graph.ValidateTagName(tag); err != nil {
+			if err := tags.ValidateTagName(tag); err != nil {
 				return err
 			}
 		}

--- a/graph/load.go
+++ b/graph/load.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux windows
 
 package graph
 

--- a/graph/load_unsupported.go
+++ b/graph/load_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux,!windows
 
 package graph
 

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/docker/docker/daemon/events"
+	"github.com/docker/docker/graph/tags"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/stringid"
@@ -26,9 +27,8 @@ import (
 const DEFAULTTAG = "latest"
 
 var (
-	//FIXME these 2 regexes also exist in registry/v2/regexp.go
-	validTagName = regexp.MustCompile(`^[\w][\w.-]{0,127}$`)
-	validDigest  = regexp.MustCompile(`[a-zA-Z0-9-_+.]+:[a-fA-F0-9]+`)
+	//FIXME this regex also exists in registry/v2/regexp.go
+	validDigest = regexp.MustCompile(`[a-zA-Z0-9-_+.]+:[a-fA-F0-9]+`)
 )
 
 type TagStore struct {
@@ -248,12 +248,12 @@ func (store *TagStore) SetLoad(repoName, tag, imageName string, force bool, out 
 		return err
 	}
 	if tag == "" {
-		tag = DEFAULTTAG
+		tag = tags.DEFAULTTAG
 	}
 	if err := validateRepoName(repoName); err != nil {
 		return err
 	}
-	if err := ValidateTagName(tag); err != nil {
+	if err := tags.ValidateTagName(tag); err != nil {
 		return err
 	}
 	if err := store.reload(); err != nil {
@@ -380,17 +380,6 @@ func validateRepoName(name string) error {
 	}
 	if name == "scratch" {
 		return fmt.Errorf("'scratch' is a reserved name")
-	}
-	return nil
-}
-
-// ValidateTagName validates the name of a tag
-func ValidateTagName(name string) error {
-	if name == "" {
-		return fmt.Errorf("tag name can't be empty")
-	}
-	if !validTagName.MatchString(name) {
-		return fmt.Errorf("Illegal tag name (%s): only [A-Za-z0-9_.-] are allowed, minimum 1, maximum 128 in length", name)
 	}
 	return nil
 }

--- a/graph/tags/tags.go
+++ b/graph/tags/tags.go
@@ -1,0 +1,24 @@
+package tags
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const DEFAULTTAG = "latest"
+
+var (
+	//FIXME this regex also exists in registry/v2/regexp.go
+	validTagName = regexp.MustCompile(`^[\w][\w.-]{0,127}$`)
+)
+
+// ValidateTagName validates the name of a tag
+func ValidateTagName(name string) error {
+	if name == "" {
+		return fmt.Errorf("tag name can't be empty")
+	}
+	if !validTagName.MatchString(name) {
+		return fmt.Errorf("Illegal tag name (%s): only [A-Za-z0-9_.-] are allowed, minimum 1, maximum 128 in length", name)
+	}
+	return nil
+}

--- a/graph/tags/tags_unit_test.go
+++ b/graph/tags/tags_unit_test.go
@@ -1,0 +1,23 @@
+package tags
+
+import (
+	"testing"
+)
+
+func TestValidTagName(t *testing.T) {
+	validTags := []string{"9", "foo", "foo-test", "bar.baz.boo"}
+	for _, tag := range validTags {
+		if err := ValidateTagName(tag); err != nil {
+			t.Errorf("'%s' should've been a valid tag", tag)
+		}
+	}
+}
+
+func TestInvalidTagName(t *testing.T) {
+	validTags := []string{"-9", ".foo", "-test", ".", "-"}
+	for _, tag := range validTags {
+		if err := ValidateTagName(tag); err == nil {
+			t.Errorf("'%s' shouldn't have been a valid tag", tag)
+		}
+	}
+}

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -181,24 +181,6 @@ func TestLookupImage(t *testing.T) {
 	}
 }
 
-func TestValidTagName(t *testing.T) {
-	validTags := []string{"9", "foo", "foo-test", "bar.baz.boo"}
-	for _, tag := range validTags {
-		if err := ValidateTagName(tag); err != nil {
-			t.Errorf("'%s' should've been a valid tag", tag)
-		}
-	}
-}
-
-func TestInvalidTagName(t *testing.T) {
-	validTags := []string{"-9", ".foo", "-test", ".", "-"}
-	for _, tag := range validTags {
-		if err := ValidateTagName(tag); err == nil {
-			t.Errorf("'%s' shouldn't have been a valid tag", tag)
-		}
-	}
-}
-
 func TestValidateDigest(t *testing.T) {
 	tests := []struct {
 		input       string


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This PR ensures graph\load.go is compiled in for the Windows daemon, factoring out DEFAULTTAG and ValidateTagName to the pkg\tags directory to avoid the Windows client does not attempt to pull in the entire graph driver.
