### PR TITLE
Windows: Don't pull in all of resolvconf

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -9,7 +9,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/opts"
 	"github.com/docker/docker/pkg/promise"
-	"github.com/docker/docker/pkg/resolvconf"
+	"github.com/docker/docker/pkg/resolvconf/dns"
 	"github.com/docker/docker/pkg/signal"
 	"github.com/docker/docker/runconfig"
 )
@@ -65,7 +65,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		// localhost regexp to warn if they are trying to
 		// set a DNS to a localhost address
 		for _, dnsIP := range hostConfig.Dns {
-			if resolvconf.IsLocalhost(dnsIP) {
+			if dns.IsLocalhost(dnsIP) {
 				fmt.Fprintf(cli.err, "WARNING: Localhost DNS setting (--dns=%s) may fail in containers.\n", dnsIP)
 				break
 			}

--- a/pkg/resolvconf/dns/resolvconf.go
+++ b/pkg/resolvconf/dns/resolvconf.go
@@ -1,0 +1,16 @@
+package dns
+
+import (
+	"regexp"
+)
+
+const IpLocalhost = `((127\.([0-9]{1,3}.){2}[0-9]{1,3})|(::1))`
+
+var localhostIPRegexp = regexp.MustCompile(IpLocalhost)
+
+// IsLocalhost returns true if ip matches the localhost IP regular expression.
+// Used for determining if nameserver settings are being passed which are
+// localhost addresses
+func IsLocalhost(ip string) bool {
+	return localhostIPRegexp.MatchString(ip)
+}

--- a/pkg/resolvconf/resolvconf.go
+++ b/pkg/resolvconf/resolvconf.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/ioutils"
+	"github.com/docker/docker/pkg/resolvconf/dns"
 )
 
 var (
@@ -24,10 +25,8 @@ var (
 	// For readability and sufficiency for Docker purposes this seemed more reasonable than a
 	// 1000+ character regexp with exact and complete IPv6 validation
 	ipv6Address = `([0-9A-Fa-f]{0,4}:){2,7}([0-9A-Fa-f]{0,4})`
-	ipLocalhost = `((127\.([0-9]{1,3}.){2}[0-9]{1,3})|(::1))`
 
-	localhostIPRegexp = regexp.MustCompile(ipLocalhost)
-	localhostNSRegexp = regexp.MustCompile(`(?m)^nameserver\s+` + ipLocalhost + `\s*\n*`)
+	localhostNSRegexp = regexp.MustCompile(`(?m)^nameserver\s+` + dns.IpLocalhost + `\s*\n*`)
 	nsIPv6Regexp      = regexp.MustCompile(`(?m)^nameserver\s+` + ipv6Address + `\s*\n*`)
 	nsRegexp          = regexp.MustCompile(`^\s*nameserver\s*((` + ipv4Address + `)|(` + ipv6Address + `))\s*$`)
 	searchRegexp      = regexp.MustCompile(`^\s*search\s*(([^\s]+\s*)*)$`)
@@ -126,13 +125,6 @@ func getLines(input []byte, commentMarker []byte) [][]byte {
 		}
 	}
 	return output
-}
-
-// IsLocalhost returns true if ip matches the localhost IP regular expression.
-// Used for determining if nameserver settings are being passed which are
-// localhost addresses
-func IsLocalhost(ip string) bool {
-	return localhostIPRegexp.MatchString(ip)
 }
 
 // GetNameservers returns nameservers (if any) listed in /etc/resolv.conf


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This factors out the DNS check for IsLocalHost from pkg\resolvconf to pkg\resolvconf\dns. This avoids pulling in the rest of resolvconf on Windows builds which is not applicable.
