### PR TITLE
Proposal: Add support for using CLI plugins

### DIFF
--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -153,6 +153,13 @@ func (cli *DockerCli) clientRequestAttemptLogin(method, path string, in io.Reade
 	return body, statusCode, err
 }
 
+// Call is an externalized verion of call().
+// Didn't want to change all refs to call() just yet but will if these
+// changes are adopted.
+func (cli *DockerCli) Call(method, path string, data interface{}, headers map[string][]string) (io.ReadCloser, http.Header, int, error) {
+	return cli.call(method, path, data, headers)
+}
+
 func (cli *DockerCli) call(method, path string, data interface{}, headers map[string][]string) (io.ReadCloser, http.Header, int, error) {
 	params, err := cli.encodeData(data)
 	if err != nil {

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/docker/docker/api/client"
 	"github.com/docker/docker/autogen/dockerversion"
 	"github.com/docker/docker/opts"
+	"github.com/docker/docker/pkg/homedir"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/docker/pkg/term"
@@ -128,6 +130,11 @@ func main() {
 		}
 	}
 	cli := client.NewDockerCli(stdin, stdout, stderr, *flTrustKey, protoAddrParts[0], protoAddrParts[1], tlsConfig)
+
+	err := LoadPlugins(filepath.Join(homedir.Get(), ".docker/plugins/cli"), cli)
+	if err != nil {
+		logrus.Fatal(err)
+	}
 
 	if err := cli.Cmd(flag.Args()...); err != nil {
 		if sterr, ok := err.(client.StatusError); ok {

--- a/docker/plugin_utils.go
+++ b/docker/plugin_utils.go
@@ -1,0 +1,81 @@
+package main
+
+// This file contains the glue to connect pkg/plugins to the Docker CLI.
+// It will load all of the available plugins and provide the call-back
+// function that the plugin manager will invoke.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/api/client"
+	"github.com/docker/docker/pkg/plugin"
+)
+
+var cli *client.DockerCli
+
+func LoadPlugins(root string, c *client.DockerCli) error {
+	cli = c
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if path == root {
+			return nil
+		}
+
+		pi := plugin.NewPlugin(path, PluginProcessor) // Register it
+		err = pi.Start()                              // Start & load metadata
+		if err != nil {
+			return err
+		}
+
+		piName := pi.Config["Cmd"]
+		if piName != "" {
+			cli.Plugins()[piName] = pi
+			dockerCommands = append(dockerCommands, command{
+				piName,
+				pi.Config["Description"],
+			})
+		} else {
+			// No name so something is wrong - just stop if it still running
+			pi.Stop()
+		}
+		return nil
+	})
+	return err
+}
+
+// Process any incoming request from plugin.
+func PluginProcessor(m *plugin.Plugin, cmd string, buf []byte) ([]byte, error) {
+	switch cmd {
+	case "GetDockerHost":
+		return []byte(cli.DockerHost()), nil
+
+	case "CallDaemon":
+		type callArgs struct {
+			Method string
+			Path   string
+			Data   []byte
+		}
+		args := callArgs{}
+		if err := json.Unmarshal(buf, &args); err != nil {
+			return nil, err
+		}
+
+		rdr, _, _, err := cli.Call(args.Method, args.Path, args.Data, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		newBuf := new(bytes.Buffer)
+		if _, err = io.Copy(newBuf, rdr); err != nil {
+			return nil, err
+		}
+
+		return newBuf.Bytes(), nil
+	}
+
+	return nil, fmt.Errorf("Unknown command: %s", cmd)
+}

--- a/pkg/plugin/net.go
+++ b/pkg/plugin/net.go
@@ -1,0 +1,299 @@
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"sync"
+)
+
+const (
+	Noop     = iota
+	Oneway   = iota
+	Request  = iota
+	Response = iota
+)
+
+var nextID = 0
+
+var LogPrefix = ""
+
+func UniqueID() int {
+	nextID++
+	return nextID
+}
+
+type Connection struct {
+	readLock  sync.Mutex
+	writeLock sync.Mutex
+	id        int
+	inFile    *os.File
+	outFile   *os.File
+
+	channelsLock     sync.Mutex
+	responseChannels map[int]chan *Chunk
+
+	reqFn func(*Connection, *Chunk) *Chunk
+}
+
+type Chunk struct {
+	threadID  int
+	direction int // Oneway vs Request vs Response
+	cmd       string
+	buffer    []byte
+}
+
+func (c *Connection) Setup(in int, out int, reqFn func(*Connection, *Chunk) *Chunk) {
+	c.id = UniqueID()
+	c.inFile = os.NewFile(uintptr(in), "in")
+	c.outFile = os.NewFile(uintptr(out), "out")
+	c.reqFn = reqFn
+	c.responseChannels = map[int]chan *Chunk{}
+
+	go c.IncomingProcessor()
+}
+
+func (c *Connection) Close() {
+	c.inFile.Close()
+	c.outFile.Close()
+
+	// Close all channels, ignore any panics due to already being closed
+	c.channelsLock.Lock()
+	defer c.channelsLock.Unlock()
+	for _, v := range c.responseChannels {
+		func() {
+			/*
+				defer func() {
+					if r := recover(); r != nil {
+					}
+				}()
+			*/
+			close(v)
+		}()
+	}
+}
+
+func ReadNum(in *os.File) int {
+	num := 0
+	ch := []byte{'\000'}
+	for {
+		n, err := in.Read(ch)
+		if n < 0 || err != nil {
+			// fmt.Printf("%sErr in readnum(%d): %q\n", LogPrefix, n, err)
+			return -1
+		}
+		if ch[0] == 0 {
+			return num
+		}
+		num = (num * 10) + int(ch[0]-byte('0'))
+	}
+}
+
+func ReadStr(in *os.File) string {
+	str := ""
+	ch := []byte{'\000'}
+	for {
+		n, err := in.Read(ch)
+		if n < 0 || err != nil {
+			// fmt.Printf("%sErr in readstr(%d): %q\n", LogPrefix, n, err)
+			return "error"
+		}
+		if ch[0] == ' ' {
+			return str
+		}
+		str = str + string(ch)
+	}
+}
+
+func AddNum(buf []byte, num int) []byte {
+	tmpBuf := []byte{'\000'}
+	for num > 0 {
+		tmpBuf = append([]byte{byte('0') + byte(num%10)}, tmpBuf...)
+		num = num / 10
+	}
+	return append(buf, tmpBuf...)
+}
+
+func AddStr(buf []byte, str string) []byte {
+	buf = append(buf, []byte(str)...)
+	return append(buf, ' ')
+}
+
+func (c *Connection) ReadChunk() (*Chunk, error) {
+	c.readLock.Lock()
+	defer c.readLock.Unlock()
+
+	chunk := Chunk{}
+	size := 0
+
+	chunk.threadID = ReadNum(c.inFile)
+	chunk.direction = ReadNum(c.inFile)
+	chunk.cmd = ReadStr(c.inFile)
+	size = ReadNum(c.inFile)
+
+	if size < 0 {
+		return nil, fmt.Errorf("%sEOF1: %d", LogPrefix, size)
+	}
+
+	chunk.buffer = make([]byte, size)
+	n, err := c.inFile.Read(chunk.buffer)
+	if n != size || err != nil {
+		return nil, fmt.Errorf("%sEOF2(%d,%d): %q", LogPrefix, n, size, err)
+	}
+
+	return &chunk, nil
+}
+
+func (c *Connection) WriteChunk(chunk *Chunk) error {
+	c.writeLock.Lock()
+	defer c.writeLock.Unlock()
+
+	if chunk.threadID == 0 {
+		chunk.threadID = UniqueID()
+	}
+
+	buf := []byte{}
+
+	buf = AddNum(buf, chunk.threadID)
+	buf = AddNum(buf, chunk.direction)
+	buf = AddStr(buf, chunk.cmd)
+	buf = AddNum(buf, len(chunk.buffer))
+
+	n, err := c.outFile.Write(buf)
+	if n != len(buf) || err != nil {
+		return fmt.Errorf("%sEOF3(%d,%d): %q", LogPrefix, n, len(chunk.buffer), err)
+	}
+
+	n, err = c.outFile.Write(chunk.buffer)
+
+	if n != len(chunk.buffer) || err != nil {
+		return fmt.Errorf("%sEOF3(%d,%d): %q", LogPrefix, n, len(chunk.buffer), err)
+	}
+
+	return nil
+}
+
+func (c *Connection) IncomingProcessor() {
+	for {
+		chunk, err := c.ReadChunk()
+		if err != nil {
+			c.Close()
+			// fmt.Printf("Error reading chunk: %q\n", err)
+			break
+		}
+
+		if chunk.direction == Request || chunk.direction == Oneway {
+			go c.ProcessRequest(chunk)
+			continue
+		}
+
+		c.channelsLock.Lock()
+		responseChannel := c.responseChannels[chunk.threadID]
+		c.channelsLock.Unlock()
+
+		if responseChannel == nil {
+			// fmt.Printf("Can't find response channel")
+			continue
+		}
+
+		responseChannel <- chunk
+	}
+}
+
+func (c *Connection) ProcessRequest(inChunk *Chunk) {
+	outChunk := c.reqFn(c, inChunk)
+
+	if inChunk.direction == Request {
+		if outChunk == nil {
+			outChunk = &Chunk{}
+		}
+		if outChunk.direction == 0 {
+			outChunk.direction = Response
+		}
+		if outChunk.threadID == 0 {
+			outChunk.threadID = inChunk.threadID
+		}
+		if outChunk.cmd == "" {
+			outChunk.cmd = inChunk.cmd
+		}
+		c.WriteChunk(outChunk)
+	}
+}
+
+func (c *Connection) Call(cmd string, args string) (string, error) {
+	var buf []byte
+	if args != "" {
+		buf = []byte(args)
+	}
+
+	buf, err := c.CallBytes(cmd, buf)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func (c *Connection) CallBytes(cmd string, buf []byte) ([]byte, error) {
+	inChunk := Chunk{
+		cmd:       cmd,
+		direction: Request,
+		buffer:    buf,
+	}
+
+	outChunk, err := c.CallChunk(&inChunk)
+	if err != nil {
+		return nil, err
+	}
+
+	return outChunk.buffer, nil
+}
+
+func (c *Connection) CallChunk(inChunk *Chunk) (*Chunk, error) {
+	if inChunk.threadID == 0 {
+		inChunk.threadID = UniqueID()
+	}
+
+	responseChannel := make(chan *Chunk)
+	c.channelsLock.Lock()
+	c.responseChannels[inChunk.threadID] = responseChannel
+	c.channelsLock.Unlock()
+
+	if err := c.WriteChunk(inChunk); err != nil {
+		return nil, err
+	}
+
+	outChunk := <-responseChannel
+	delete(c.responseChannels, inChunk.threadID)
+
+	if outChunk == nil {
+		return nil, fmt.Errorf("Missing response chunk")
+	}
+
+	if outChunk.cmd == CmdError {
+		return nil, fmt.Errorf("%s", string(outChunk.buffer))
+	}
+
+	return outChunk, nil
+}
+
+func (c *Connection) Notify(cmd string, args string) error {
+	var buf []byte
+	if args != "" {
+		buf = []byte(args)
+	}
+
+	return c.NotifyBytes(cmd, buf)
+}
+
+func (c *Connection) NotifyBytes(cmd string, buf []byte) error {
+	inChunk := Chunk{
+		cmd:       cmd,
+		direction: Oneway,
+		buffer:    buf,
+	}
+
+	return c.NotifyChunk(&inChunk)
+}
+
+func (c *Connection) NotifyChunk(inChunk *Chunk) error {
+	return c.WriteChunk(inChunk)
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -1,0 +1,213 @@
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+)
+
+const (
+	CmdError = "cmd.error"
+	CmdPing  = "cmd.ping"
+	CmdStop  = "cmd.stop"
+
+	// From main to plugin
+	CmdGetMetadata = "GetMetadata"
+)
+
+// This first section defines things used by the 'plugin' side of the
+// plugin infrastructure
+// ==================================================================
+
+// Passed to the plugin so it can make calls back to the 'main' exe
+type Main struct {
+	Connection
+
+	start   func(c *Main)
+	request PluginRequestFunc
+	inFD    int
+	outFD   int
+}
+
+var ourMain Main
+
+type PluginRequestFunc func(c *Main, cmd string, buf []byte) ([]byte, error)
+
+// Register connects the plugin back to the main
+func Register(start func(c *Main), request PluginRequestFunc) error {
+	ourMain.start = start
+	ourMain.request = request
+
+	if len(os.Args) > 2 {
+		var e1, e2 error
+		ourMain.inFD, e1 = strconv.Atoi(os.Args[1])
+		ourMain.outFD, e2 = strconv.Atoi(os.Args[2])
+		if e1 != nil || e2 != nil {
+			return fmt.Errorf("Error setting up connectsion: %q %q", e1, e2)
+		}
+	} else {
+		// Just use stdin/out
+		ourMain.inFD = 0
+		ourMain.inFD = 1
+	}
+
+	ourMain.Setup(ourMain.inFD, ourMain.outFD, processChunkFromMain)
+
+	if ourMain.start != nil {
+		ourMain.start(&ourMain)
+	}
+
+	go func() {
+		for {
+			if _, err := ourMain.Call(CmdPing, ""); err != nil {
+				os.Exit(1)
+			}
+			time.Sleep(1 * time.Second)
+		}
+	}()
+
+	// If 'Request' is defined then sleep forever. Otherwise
+	// the executable will exit too soon
+	if ourMain.request != nil {
+		select {}
+	}
+
+	return nil
+}
+
+func processChunkFromMain(c *Connection, chunk *Chunk) *Chunk {
+	var buf []byte
+	var err error
+	var resCmd = chunk.cmd
+
+	switch chunk.cmd {
+	case CmdPing:
+		// no-op
+
+	case CmdStop:
+		c.Close()
+		os.Exit(0)
+
+	default:
+		// Must be user-defined so pass along to the plugin to deal with
+		buf, err = ourMain.request(&ourMain, chunk.cmd, chunk.buffer)
+	}
+
+	if chunk.direction == Oneway {
+		return nil
+	}
+
+	if err != nil {
+		resCmd = CmdError
+		buf = []byte(err.Error())
+	}
+
+	return &Chunk{
+		threadID:  chunk.threadID,
+		direction: Response,
+		cmd:       resCmd,
+		buffer:    buf,
+	}
+}
+
+// This section defines things used by the 'main' side of the
+// plugin infrastructure
+// ==================================================================
+
+// Used by the 'main' exe to call into the plugin
+type Plugin struct {
+	Connection
+	Config map[string]string
+
+	exePath string
+	fn      MainRequestFunc
+	name    string
+	cmd     *exec.Cmd
+
+	// Saved just so we don't gc the Files
+	r1, w1, r2, w2 *os.File
+}
+
+type MainRequestFunc func(p *Plugin, cmd string, buf []byte) ([]byte, error)
+
+func NewPlugin(exe string, fn MainRequestFunc) *Plugin {
+	return &Plugin{
+		exePath: exe,
+		fn:      fn,
+	}
+}
+
+func (p *Plugin) Start() error {
+	var e1, e2 error
+
+	p.r1, p.w1, e1 = os.Pipe()
+	p.r2, p.w2, e2 = os.Pipe()
+
+	if e1 != nil || e2 != nil {
+		return fmt.Errorf("Error setting up pipes: %q\n%q", e1, e2)
+	}
+
+	p.cmd = exec.Command(p.exePath, "3", "4")
+	p.cmd.Stdout = os.Stdout
+	p.cmd.ExtraFiles = []*os.File{p.r1, p.w2}
+
+	if err := p.cmd.Start(); err != nil {
+		return fmt.Errorf("Error starting plugin '%s': %q\n", p.exePath, err)
+	}
+
+	p.r1.Close()
+	p.w2.Close()
+
+	p.Setup(int(p.r2.Fd()), int(p.w1.Fd()), p.processChunkFromPlugin)
+
+	buf, err := p.CallBytes(CmdGetMetadata, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(buf, &p.Config); err != nil {
+		return err
+	}
+
+	return err
+}
+
+func (p *Plugin) Stop() {
+	p.NotifyBytes(CmdStop, nil)
+	p.Close()
+	p.cmd.Process.Kill()
+}
+
+func (p *Plugin) processChunkFromPlugin(c *Connection, inChunk *Chunk) *Chunk {
+	var resCmd string
+	var buf []byte
+	var err error
+
+	switch inChunk.cmd {
+	case CmdPing:
+		// no-op
+
+	default:
+		// Must be user-defined so pass along to the plugin to deal with
+		buf, err = p.fn(p, inChunk.cmd, inChunk.buffer)
+	}
+
+	if err != nil {
+		resCmd = CmdError
+		buf = []byte(err.Error())
+	}
+
+	if inChunk.direction == Oneway {
+		return nil
+	}
+
+	return &Chunk{
+		threadID:  inChunk.threadID,
+		direction: Response,
+		cmd:       resCmd,
+		buffer:    buf,
+	}
+}


### PR DESCRIPTION
This PR is the start of a plugin model for the CLI.

It uses the plugin infrastructure from https://github.com/duglin/plugin .

The  idea is that all cli plugins (exes found in ~/.docker/plugins/cli) are loaded upload CLI startup. hey are then visible from the `docker help` output (e.g. `ping` sample from https://github.com/duglin/plugin ).  Then `docker ping` will then invoke the `ping` exe to do its job. The `ping` executable can then call back into the CLI to ask it info or to issue a command to the daemon.  The CLI can (and does) ask the plugin for info - like its metadata to display on the `docker help` command.

It supports multi-threaded, bi-directional, communications between the two exes.  See the "sample1" sample in https://github.com/duglin/plugin for an example of 5000 parallel main->plugin requests, and 5000 plugin->main requests, all being executed at the same time.

I would suggest people grab the `ping` Docker plugin sample to see it in action and to see how a plugin can call the daemon (`GET /info` in this case) via the CLI.

I didn't add any docs yet, and I'm sure more clean-up is needed, but I wanted to see if this direction seems reasonable before I invested too much more time in it.

While it just deals with CLI plugins, I don't see any reason why the basic infrastructure couldn't be used for daemon-side plugins too - but I'm not sure I understand all of the requirements over there, so that's still TBD.

Ideally, I'd like to see this in v1.7 as "experimental" but I'm sure lots more discussions are needed and this PR is meant just to get those chats started.

Signed-off-by: Doug Davis dug@us.ibm.com
