### PR TITLE
fallback to interface with docker inspect

### DIFF
--- a/api/client/inspect.go
+++ b/api/client/inspect.go
@@ -59,7 +59,8 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 				continue
 			}
 		} else {
-			dec := json.NewDecoder(bytes.NewReader(obj))
+			rdr := bytes.NewReader(obj)
+			dec := json.NewDecoder(rdr)
 
 			if isImage {
 				inspPtr := types.ImageInspect{}
@@ -69,7 +70,14 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 					continue
 				}
 				if err := tmpl.Execute(cli.out, inspPtr); err != nil {
-					return err
+					rdr.Seek(0, 0)
+					var raw interface{}
+					if err := dec.Decode(&raw); err != nil {
+						return err
+					}
+					if err = tmpl.Execute(cli.out, raw); err != nil {
+						return err
+					}
 				}
 			} else {
 				inspPtr := types.ContainerJSON{}
@@ -79,8 +87,14 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 					continue
 				}
 				if err := tmpl.Execute(cli.out, inspPtr); err != nil {
-					return err
-
+					rdr.Seek(0, 0)
+					var raw interface{}
+					if err := dec.Decode(&raw); err != nil {
+						return err
+					}
+					if err = tmpl.Execute(cli.out, raw); err != nil {
+						return err
+					}
 				}
 			}
 			cli.out.Write([]byte{'\n'})


### PR DESCRIPTION
The PR https://github.com/docker/docker/pull/11839 broke a few things in swarm (see https://github.com/docker/swarm/issues/717)

If there is a template error, we fallback to the old way.
