### PR TITLE
Move AppArmor policy to contrib & deb packaging

### DIFF
--- a/contrib/apparmor/docker
+++ b/contrib/apparmor/docker
@@ -1,0 +1,25 @@
+#include <tunables/global>
+
+profile docker-default flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  network,
+  capability,
+  file,
+  umount,
+
+  deny @{PROC}/sys/fs/** wklx,
+  deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/sys/kernel/[^s][^h][^m]* wklx,
+  deny @{PROC}/sys/kernel/*/** wklx,
+
+  deny mount,
+
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/efi/efivars/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+}

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -20,7 +20,6 @@ import (
 	sysinfo "github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/libcontainer"
-	"github.com/docker/libcontainer/apparmor"
 	"github.com/docker/libcontainer/cgroups/systemd"
 	"github.com/docker/libcontainer/configs"
 	"github.com/docker/libcontainer/system"
@@ -48,10 +47,6 @@ func NewDriver(root, initPath string, options []string) (*driver, error) {
 	}
 
 	if err := sysinfo.MkdirAll(root, 0700); err != nil {
-		return nil, err
-	}
-	// native driver root is at docker_root/execdriver/native. Put apparmor at docker_root
-	if err := apparmor.InstallDefaultProfile(); err != nil {
 		return nil, err
 	}
 

--- a/hack/make/.build-deb/docker-engine.install
+++ b/hack/make/.build-deb/docker-engine.install
@@ -9,3 +9,4 @@ contrib/init/systemd/docker.socket lib/systemd/system/
 contrib/mk* usr/share/docker-engine/contrib/
 contrib/nuke-graph-directory.sh usr/share/docker-engine/contrib/
 contrib/syntax/nano/Dockerfile.nanorc usr/share/nano/
+contrib/apparmor/* etc/apparmor.d/

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -35,6 +35,8 @@ if [ -z "$DOCKER_TEST_HOST" ]; then
 		(
 			set -x
 			/etc/init.d/apparmor start
+
+			/sbin/apparmor_parser -r -W -T contrib/apparmor/
 		)
 	fi
 

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -72,6 +72,10 @@ bundle_ubuntu() {
 		done
 	done
 
+	# Include contributed apparmor policy
+	mkdir -p "$DIR/etc/apparmor.d/"
+	cp contrib/apparmor/docker "$DIR/etc/apparmor.d/"
+
 	# Copy the binary
 	# This will fail if the binary bundle hasn't been built
 	mkdir -p "$DIR/usr/bin"
@@ -87,6 +91,10 @@ if [ "$1" = 'configure' ] && [ -z "$2" ]; then
 	if ! getent group docker > /dev/null; then
 		groupadd --system docker
 	fi
+fi
+
+if ( aa-status --enabled ); then
+	/sbin/apparmor_parser -r -W -T /etc/apparmor.d/docker
 fi
 
 if ! { [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; }; then
@@ -149,6 +157,7 @@ EOF
 			--deb-recommends git \
 			--deb-recommends xz-utils \
 			--deb-recommends 'cgroupfs-mount | cgroup-lite' \
+			--deb-suggests apparmor \
 			--description "$PACKAGE_DESCRIPTION" \
 			--maintainer "$PACKAGE_MAINTAINER" \
 			--conflicts docker \


### PR DESCRIPTION
The automatic installation of AppArmor policies prevents the
management of custom, site-specific apparmor policies for the
default container profile. Furthermore, this change will allow
a future policy for the engine itself to be written without demanding
the engine be able to arbitrarily create and manage AppArmor policies.

This change also introduces tests for the AppArmor policy and
removes a couple ineffective rules.

Signed-off-by: Eric Windisch eric@windisch.us
