### PR TITLE
Minor typo: remove redundant dot in error message in runconfig/parse.go

### DIFF
--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -251,7 +251,7 @@ func (s *DockerSuite) TestLinksNetworkHostContainer(c *check.C) {
 	}
 
 	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", "--name", "should_fail", "--link", "host_container:tester", "busybox", "true"))
-	if err == nil || !strings.Contains(out, "--net=host can't be used with links. This would result in undefined behavior.") {
+	if err == nil || !strings.Contains(out, "--net=host can't be used with links. This would result in undefined behavior") {
 		c.Fatalf("Running container linking to a container with --net host should have failed: %s", out)
 	}
 

--- a/pkg/mflag/flag.go
+++ b/pkg/mflag/flag.go
@@ -1085,7 +1085,7 @@ func (cmd *FlagSet) ReportError(str string, withHelp bool) {
 			str += ". See '" + os.Args[0] + " " + cmd.Name() + " --help'"
 		}
 	}
-	fmt.Fprintf(cmd.Out(), "docker: %s.\n", str)
+	fmt.Fprintf(cmd.Out(), "docker: %s\n", str)
 	os.Exit(1)
 }
 

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -14,12 +14,12 @@ import (
 )
 
 var (
-	ErrConflictContainerNetworkAndLinks = fmt.Errorf("Conflicting options: --net=container can't be used with links. This would result in undefined behavior.")
-	ErrConflictNetworkAndDns            = fmt.Errorf("Conflicting options: --dns and the network mode (--net).")
+	ErrConflictContainerNetworkAndLinks = fmt.Errorf("Conflicting options: --net=container can't be used with links. This would result in undefined behavior")
+	ErrConflictNetworkAndDns            = fmt.Errorf("Conflicting options: --dns and the network mode (--net)")
 	ErrConflictNetworkHostname          = fmt.Errorf("Conflicting options: -h and the network mode (--net)")
-	ErrConflictHostNetworkAndLinks      = fmt.Errorf("Conflicting options: --net=host can't be used with links. This would result in undefined behavior.")
-	ErrConflictContainerNetworkAndMac   = fmt.Errorf("Conflicting options: --mac-address and the network mode (--net).")
-	ErrConflictNetworkHosts             = fmt.Errorf("Conflicting options: --add-host and the network mode (--net).")
+	ErrConflictHostNetworkAndLinks      = fmt.Errorf("Conflicting options: --net=host can't be used with links. This would result in undefined behavior")
+	ErrConflictContainerNetworkAndMac   = fmt.Errorf("Conflicting options: --mac-address and the network mode (--net)")
+	ErrConflictNetworkHosts             = fmt.Errorf("Conflicting options: --add-host and the network mode (--net)")
 )
 
 func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSet, error) {


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Since https://github.com/docker/docker/blob/master/pkg/mflag/flag.go#L1088 `fmt.Fprintf(cmd.Out(), "docker: %s.\n", str)` has a trailing `.` in error message, so there is no need a trailing `.` in the error message in `runconfig/parse.go`.  Or else it will be like this
`docker: Conflicting options: --dns and the network mode (--net).. See 'docker run --help'.`
it's a bit of weird.
