### PR TITLE
Add AppArmor policy for the engine

### DIFF
--- a/contrib/apparmor/docker
+++ b/contrib/apparmor/docker
@@ -1,4 +1,8 @@
+#include <tunables/global>
+
 profile docker-default flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
   network,
   capability,
   file,

--- a/contrib/apparmor/docker
+++ b/contrib/apparmor/docker
@@ -2,12 +2,15 @@ profile docker-default flags=(attach_disconnected,mediate_deleted) {
   network,
   capability,
   file,
-  umount,
 
   deny @{PROC}/sys/fs/** wklx,
+  deny @{PROC}/fs/** wklx,
   deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/timer_stats rwklx,
+  deny @{PROC}/latency_stats rwklx,
   deny @{PROC}/mem rwklx,
   deny @{PROC}/kmem rwklx,
+  deny @{PROC}/kcore rwklx,
   deny @{PROC}/sys/kernel/[^s][^h][^m]* wklx,
   deny @{PROC}/sys/kernel/*/** wklx,
 

--- a/contrib/apparmor/docker
+++ b/contrib/apparmor/docker
@@ -1,0 +1,23 @@
+profile docker-default flags=(attach_disconnected,mediate_deleted) {
+  network,
+  capability,
+  file,
+  umount,
+
+  deny @{PROC}/sys/fs/** wklx,
+  deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/mem rwklx,
+  deny @{PROC}/kmem rwklx,
+  deny @{PROC}/sys/kernel/[^s][^h][^m]* wklx,
+  deny @{PROC}/sys/kernel/*/** wklx,
+
+  deny mount,
+
+  deny /sys/[^f]*/** wklx,
+  deny /sys/f[^s]*/** wklx,
+  deny /sys/fs/[^c]*/** wklx,
+  deny /sys/fs/c[^g]*/** wklx,
+  deny /sys/fs/cg[^r]*/** wklx,
+  deny /sys/firmware/efi/efivars/** rwklx,
+  deny /sys/kernel/security/** rwklx,
+}

--- a/contrib/apparmor/docker
+++ b/contrib/apparmor/docker
@@ -12,8 +12,6 @@ profile docker-default flags=(attach_disconnected,mediate_deleted) {
   deny @{PROC}/sysrq-trigger rwklx,
   deny @{PROC}/timer_stats rwklx,
   deny @{PROC}/latency_stats rwklx,
-  deny @{PROC}/mem rwklx,
-  deny @{PROC}/kmem rwklx,
   deny @{PROC}/kcore rwklx,
   deny @{PROC}/sys/kernel/[^s][^h][^m]* wklx,
   deny @{PROC}/sys/kernel/*/** wklx,

--- a/contrib/apparmor/docker-engine
+++ b/contrib/apparmor/docker-engine
@@ -1,0 +1,99 @@
+profile /usr/bin/docker flags=(attach_disconnected) {
+  #include <abstractions/base>
+
+  # Prevent following links to these files during container setup.
+  deny /etc/** mkl,
+  deny /dev/** kl,
+  deny /sys/** mkl,
+  deny /proc/** mkl,
+
+  signal (receive) peer=@{profile_name},
+  signal (receive) peer=unconfined,
+  signal (send),
+  ipc rw,
+  capability,
+
+  /etc/apparmor.d/docker rw,
+  /var/lib/docker/tmp/** rw,
+  /var/run/docker.sock rw,
+  /var/lib/docker/** rwklm,
+  /dev/** rw,
+  owner /** rw,
+
+  /sbin/apparmor_parser rCix,
+  /sbin/xtables-multi rCix,
+  /sbin/iptables rCx,
+  /sbin/modprobe rCx,
+  /usr/bin/docker rcx,
+  /sbin/auplink rCx,
+  /usr/bin/xz rCx,
+
+  # Transitions
+  change_profile -> docker-*,
+  change_profile -> unconfined,
+
+  # Applied to reexec
+  profile /usr/bin/docker flags=(attach_disconnected) {
+   deny /proc/* rw,
+   deny /proc/sys/** w,
+   deny /sys/** rw,
+
+   deny /etc/** mkl,
+   deny /dev/** kl,
+   deny /sys/** mkl,
+   deny /proc/** mkl,
+
+   signal (receive) peer=@{profile_name},
+   signal (receive) peer=/usr/bin/docker,
+   network,
+   file,
+   mount -> /,
+   mount -> /var/lib/docker/**,
+   umount,
+   pivot_root /var/lib/docker/**,
+
+   /usr/bin/docker rix,
+
+   capability chown,
+   capability fowner,
+   capability sys_chroot,
+   capability net_admin,
+   capability net_bind_service,
+   capability dac_override,
+   capability mknod,
+   capability sys_admin,
+  }
+  profile /sbin/iptables {
+   signal (receive) peer=/usr/bin/docker,
+   capability net_admin,
+  }
+  profile /sbin/auplink flags=(audit,attach_disconnected) {
+   signal (receive) peer=/usr/bin/docker,
+   capability sys_admin,
+   /var/lib/docker/aufs/** rw,
+   /lib/** r,
+   /apparmor/.null r,
+   /dev/null rw,
+   /etc/ld.so.cache r,
+   /sbin/auplink rm,
+   /proc/[0-9]*/mounts rw,
+   /proc/fs/aufs/** rw,
+   /sys/fs/aufs/** rw,
+  }
+  profile /sbin/modprobe {
+   signal (receive) peer=/usr/bin/docker,
+   capability sys_module,
+   file,
+  }
+  # xz works via pipes, so we do not need access to the filesystem.
+  profile /usr/bin/xz {
+   signal (receive) peer=/usr/bin/docker,
+  }
+
+  # Client requirements...
+  /var/run/docker.sock rw,
+  /proc/sys/net/core/somaxconn r,
+  /proc/sys/kernel/cap_last_cap r,
+  /run/docker.sock rw,
+  owner /** rw,
+}

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -20,7 +20,6 @@ import (
 	sysinfo "github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/libcontainer"
-	"github.com/docker/libcontainer/apparmor"
 	"github.com/docker/libcontainer/cgroups/systemd"
 	"github.com/docker/libcontainer/configs"
 	"github.com/docker/libcontainer/system"
@@ -48,10 +47,6 @@ func NewDriver(root, initPath string, options []string) (*driver, error) {
 	}
 
 	if err := sysinfo.MkdirAll(root, 0700); err != nil {
-		return nil, err
-	}
-	// native driver root is at docker_root/execdriver/native. Put apparmor at docker_root
-	if err := apparmor.InstallDefaultProfile(); err != nil {
 		return nil, err
 	}
 

--- a/hack/make/.build-deb/docker-engine.install
+++ b/hack/make/.build-deb/docker-engine.install
@@ -9,3 +9,4 @@ contrib/init/systemd/docker.socket lib/systemd/system/
 contrib/mk* usr/share/docker-engine/contrib/
 contrib/nuke-graph-directory.sh usr/share/docker-engine/contrib/
 contrib/syntax/nano/Dockerfile.nanorc usr/share/nano/
+contrib/apparmor/* etc/apparmor.d/

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -77,6 +77,7 @@ bundle_ubuntu() {
 	# Include contributed apparmor policy
 	mkdir -p "$DIR/etc/apparmor.d/"
 	cp contrib/apparmor/docker "$DIR/etc/apparmor.d/"
+	cp contrib/apparmor/docker-engine "$DIR/etc/apparmor.d/"
 
 	# Copy the binary
 	# This will fail if the binary bundle hasn't been built
@@ -97,6 +98,7 @@ fi
 
 if ( aa-status --enabled ); then
 	/sbin/apparmor_parser -r -W -T /etc/apparmor.d/docker
+	/sbin/apparmor_parser -r -W -T /etc/apparmor.d/docker-engine
 fi
 
 if ! { [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; }; then

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -95,6 +95,10 @@ if [ "$1" = 'configure' ] && [ -z "$2" ]; then
 	fi
 fi
 
+if [ -x /sbin/apparmor_parser ]; then
+	/sbin/apparmor_parser -r -W -T /etc/apparmor.d/ docker
+fi
+
 if ! { [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; }; then
 	# we only need to do this if upstart isn't in charge
 	update-rc.d docker defaults > /dev/null || true
@@ -154,6 +158,7 @@ EOF
 			--deb-recommends ca-certificates \
 			--deb-recommends git \
 			--deb-recommends xz-utils \
+			--deb-recommends apparmor \
 			--deb-recommends 'cgroupfs-mount | cgroup-lite' \
 			--description "$PACKAGE_DESCRIPTION" \
 			--maintainer "$PACKAGE_MAINTAINER" \

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -95,8 +95,8 @@ if [ "$1" = 'configure' ] && [ -z "$2" ]; then
 	fi
 fi
 
-if [ -x /sbin/apparmor_parser ]; then
-	/sbin/apparmor_parser -r -W -T /etc/apparmor.d/ docker
+if ( aa-status --enabled ); then
+	/sbin/apparmor_parser -r -W -T /etc/apparmor.d/docker
 fi
 
 if ! { [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; }; then

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -74,6 +74,10 @@ bundle_ubuntu() {
 		done
 	done
 
+	# Include contributed apparmor policy
+	mkdir -p "$DIR/etc/apparmor.d/"
+	cp contrib/apparmor/docker "$DIR/etc/apparmor.d/"
+
 	# Copy the binary
 	# This will fail if the binary bundle hasn't been built
 	mkdir -p "$DIR/usr/bin"

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3191,3 +3191,45 @@ func (s *DockerSuite) TestRunPublishPort(c *check.C) {
 		c.Fatalf("run without --publish-all should not publish port, out should be nil, but got: %s", out)
 	}
 }
+
+func (s *DockerSuite) TestRunReadFilteredProc(c *check.C) {
+	testRequires(c, Apparmor)
+
+	testReadPaths := []string{
+		"/proc/latency_stats",
+		"/proc/timer_stats",
+		"/proc/kcore",
+	}
+	for i, filePath := range testReadPaths {
+		name := fmt.Sprintf("procsieve-%d", i)
+
+		shellCmd := fmt.Sprintf("exec 3<%s", filePath)
+		runCmd := exec.Command(dockerBinary, "run", "--privileged", "--security-opt", "apparmor:docker-default", "--name", name, "busybox", "sh", "-c", shellCmd)
+		if out, exitCode, err := runCommandWithOutput(runCmd); err == nil || exitCode == 0 {
+			c.Fatalf("Open FD for read should have failed with permission denied, got: %s, %v", out, err)
+		}
+	}
+}
+
+func (s *DockerSuite) TestRunWriteFilteredProc(c *check.C) {
+	testRequires(c, Apparmor)
+
+	testWritePaths := []string{
+		/* modprobe and core_pattern should both be denied by generic
+		 * policy of denials for /proc/sys/kernel. These files have been
+		 * picked to be checked as they are particularly sensitive to writes */
+		"/proc/sys/kernel/modprobe",
+		"/proc/sys/kernel/core_pattern",
+		"/proc/sysrq-trigger",
+		"/proc/kcore",
+	}
+	for i, filePath := range testWritePaths {
+		name := fmt.Sprintf("writeprocsieve-%d", i)
+
+		shellCmd := fmt.Sprintf("exec 3>%s", filePath)
+		runCmd := exec.Command(dockerBinary, "run", "--privileged", "--security-opt", "apparmor:docker-default", "--name", name, "busybox", "sh", "-c", shellCmd)
+		if out, exitCode, err := runCommandWithOutput(runCmd); err == nil || exitCode == 0 {
+			c.Fatalf("Open FD for write should have failed with permission denied, got: %s, %v", out, err)
+		}
+	}
+}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3117,7 +3117,10 @@ func (s *DockerSuite) TestRunWriteToProcAsound(c *check.C) {
 func (s *DockerSuite) TestRunReadProcTimer(c *check.C) {
 	testRequires(c, NativeExecDriver)
 	out, code, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "busybox", "cat", "/proc/timer_stats"))
-	if err != nil || code != 0 {
+	if code != 0 {
+		return
+	}
+	if err != nil {
 		c.Fatal(err)
 	}
 	if strings.Trim(out, "\n ") != "" {
@@ -3134,7 +3137,10 @@ func (s *DockerSuite) TestRunReadProcLatency(c *check.C) {
 		return
 	}
 	out, code, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "busybox", "cat", "/proc/latency_stats"))
-	if err != nil || code != 0 {
+	if code != 0 {
+		return
+	}
+	if err != nil {
 		c.Fatal(err)
 	}
 	if strings.Trim(out, "\n ") != "" {


### PR DESCRIPTION
Wraps the engine itself with an AppArmor policy.

This restricts what may be done via a reexec,
or through applications we call out to, such as 'xz'.

Significantly, this policy restricts the policies
to which a container may be spawned into. By default,
users will be able to transition to an unconfined
policy or any policy prefaced with 'docker-'.

Local operators may add new local policies prefaced
with 'docker-' without needing to modify this policy.
Operators choosing to disable privileged containers
will need to modify this policy to remove access
to change_policy to unconfined.

Builds on top of PR #13144.
