### PR TITLE
Remove API codepaths < 1.12

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -92,15 +92,6 @@ type ImageInspect struct {
 	VirtualSize     int64
 }
 
-type LegacyImage struct {
-	ID          string `json:"Id"`
-	Repository  string
-	Tag         string
-	Created     int
-	Size        int
-	VirtualSize int
-}
-
 // GET  "/containers/json"
 type Port struct {
 	IP          string

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -458,10 +458,8 @@ func (b *Builder) pullImage(name string) (*imagepkg.Image, error) {
 	}
 
 	imagePullConfig := &graph.ImagePullConfig{
-		Parallel:   true,
 		AuthConfig: pullRegistryAuth,
 		OutStream:  ioutils.NopWriteCloser(b.OutOld),
-		Json:       b.StreamFormatter.Json(),
 	}
 
 	if err := b.Daemon.Repositories().Pull(remote, tag, imagePullConfig); err != nil {

--- a/builder/job.go
+++ b/builder/job.go
@@ -45,7 +45,6 @@ type Config struct {
 	Remove         bool
 	ForceRemove    bool
 	Pull           bool
-	JSONFormat     bool
 	Memory         int64
 	MemorySwap     int64
 	CpuShares      int64
@@ -142,7 +141,7 @@ func Build(d *daemon.Daemon, buildConfig *Config) error {
 	}
 	defer context.Close()
 
-	sf := streamformatter.NewStreamFormatter(buildConfig.JSONFormat)
+	sf := streamformatter.NewStreamFormatter(true)
 
 	builder := &Builder{
 		Daemon: d,

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -12,18 +12,6 @@ type ContainerJSONRaw struct {
 	HostConfig *runconfig.HostConfig
 }
 
-func (daemon *Daemon) ContainerInspectRaw(name string) (*ContainerJSONRaw, error) {
-	container, err := daemon.Get(name)
-	if err != nil {
-		return nil, err
-	}
-
-	container.Lock()
-	defer container.Unlock()
-
-	return &ContainerJSONRaw{container, container.hostConfig}, nil
-}
-
 func (daemon *Daemon) ContainerInspect(name string) (*types.ContainerJSON, error) {
 	container, err := daemon.Get(name)
 	if err != nil {

--- a/graph/import.go
+++ b/graph/import.go
@@ -16,14 +16,13 @@ import (
 type ImageImportConfig struct {
 	Changes         []string
 	InConfig        io.ReadCloser
-	Json            bool
 	OutStream       io.Writer
 	ContainerConfig *runconfig.Config
 }
 
 func (s *TagStore) Import(src string, repo string, tag string, imageImportConfig *ImageImportConfig) error {
 	var (
-		sf      = streamformatter.NewStreamFormatter(imageImportConfig.Json)
+		sf      = streamformatter.NewStreamFormatter(true)
 		archive archive.ArchiveReader
 		resp    *http.Response
 	)

--- a/graph/push.go
+++ b/graph/push.go
@@ -30,7 +30,6 @@ type ImagePushConfig struct {
 	MetaHeaders map[string][]string
 	AuthConfig  *cliconfig.AuthConfig
 	Tag         string
-	Json        bool
 	OutStream   io.Writer
 }
 
@@ -496,7 +495,7 @@ func (s *TagStore) pushV2Image(r *registry.Session, img *image.Image, endpoint *
 // FIXME: Allow to interrupt current push when new push of same image is done.
 func (s *TagStore) Push(localName string, imagePushConfig *ImagePushConfig) error {
 	var (
-		sf = streamformatter.NewStreamFormatter(imagePushConfig.Json)
+		sf = streamformatter.NewStreamFormatter(true)
 	)
 
 	// Resolve the Repository name from fqn to RepositoryInfo

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -11,21 +11,6 @@ import (
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestLegacyImages(c *check.C) {
-	status, body, err := sockRequest("GET", "/v1.6/images/json", nil)
-	c.Assert(status, check.Equals, http.StatusOK)
-	c.Assert(err, check.IsNil)
-
-	images := []types.LegacyImage{}
-	if err = json.Unmarshal(body, &images); err != nil {
-		c.Fatalf("Error on unmarshal: %s", err)
-	}
-
-	if len(images) == 0 || images[0].Tag == "" || images[0].Repository == "" {
-		c.Fatalf("Bad data: %q", images)
-	}
-}
-
 func (s *DockerSuite) TestApiImagesFilter(c *check.C) {
 	name := "utest:tag1"
 	name2 := "utest/docker:tag2"

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -18,40 +18,27 @@ func (s *DockerSuite) TestInspectApiContainerResponse(c *check.C) {
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	// test on json marshal version
-	// and latest version
-	testVersions := []string{"v1.11", "latest"}
+	endpoint := "/containers/" + cleanedContainerID + "/json"
+	status, body, err := sockRequest("GET", endpoint, nil)
+	c.Assert(status, check.Equals, http.StatusOK)
+	c.Assert(err, check.IsNil)
 
-	for _, testVersion := range testVersions {
-		endpoint := "/containers/" + cleanedContainerID + "/json"
-		if testVersion != "latest" {
-			endpoint = "/" + testVersion + endpoint
-		}
-		status, body, err := sockRequest("GET", endpoint, nil)
-		c.Assert(status, check.Equals, http.StatusOK)
-		c.Assert(err, check.IsNil)
+	var inspectJSON map[string]interface{}
+	if err = json.Unmarshal(body, &inspectJSON); err != nil {
+		c.Fatalf("unable to unmarshal body for latest version: %v", err)
+	}
 
-		var inspectJSON map[string]interface{}
-		if err = json.Unmarshal(body, &inspectJSON); err != nil {
-			c.Fatalf("unable to unmarshal body for %s version: %v", testVersion, err)
-		}
+	keys := []string{"State", "Created", "Path", "Args", "Config", "Image", "NetworkSettings", "ResolvConfPath", "HostnamePath", "HostsPath", "LogPath", "Name", "Driver", "ExecDriver", "MountLabel", "ProcessLabel", "Volumes", "VolumesRW"}
 
-		keys := []string{"State", "Created", "Path", "Args", "Config", "Image", "NetworkSettings", "ResolvConfPath", "HostnamePath", "HostsPath", "LogPath", "Name", "Driver", "ExecDriver", "MountLabel", "ProcessLabel", "Volumes", "VolumesRW"}
+	keys = append(keys, "Id")
 
-		if testVersion == "v1.11" {
-			keys = append(keys, "ID")
-		} else {
-			keys = append(keys, "Id")
+	for _, key := range keys {
+		if _, ok := inspectJSON[key]; !ok {
+			c.Fatalf("%s does not exist in response for latest version", key)
 		}
-
-		for _, key := range keys {
-			if _, ok := inspectJSON[key]; !ok {
-				c.Fatalf("%s does not exist in response for %s version", key, testVersion)
-			}
-		}
-		//Issue #6830: type not properly converted to JSON/back
-		if _, ok := inspectJSON["Path"].(bool); ok {
-			c.Fatalf("Path of `true` should not be converted to boolean `true` via JSON marshalling")
-		}
+	}
+	//Issue #6830: type not properly converted to JSON/back
+	if _, ok := inspectJSON["Path"].(bool); ok {
+		c.Fatalf("Path of `true` should not be converted to boolean `true` via JSON marshalling")
 	}
 }


### PR DESCRIPTION
Quite sure everything is ok but I think I could still miss something (for instance, removing `Json` field from `Image(.*)Config`)

/cc @tiborvass @LK4D4  

Signed-off-by: Antonio Murdaca me@runcom.ninja
