### PR TITLE
Windows: Factor out ulimit and refactor hostconfig

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -554,16 +554,27 @@ func (b *Builder) create() (*daemon.Container, error) {
 	}
 	b.Config.Image = b.image
 
-	hostConfig := &runconfig.HostConfig{
-		CpuShares:    b.cpuShares,
-		CpuPeriod:    b.cpuPeriod,
-		CpuQuota:     b.cpuQuota,
-		CpusetCpus:   b.cpuSetCpus,
-		CpusetMems:   b.cpuSetMems,
-		CgroupParent: b.cgroupParent,
-		Memory:       b.memory,
-		MemorySwap:   b.memorySwap,
-	}
+	// Note, after factoring out HostConfig to platform specific pieces and
+	// common, it was impossible to do the following type of thing as
+	// compilation fails (is this a bug in GO?).
+	//		hostConfig := &runconfig.HostConfig{
+	//			CommonHostConfig: CommonHostConfig{
+	//				CpuShares:  b.cpuShares,
+	//				...
+	// It's only a problem here were we have runconfig.HostConfig. In the
+	// runconfig package where hostConfig := &HostConfig{ ..., this is fine.
+	// Hence flattening this out.
+
+	hostConfig := &runconfig.HostConfig{}
+	hostConfig.CpuShares = b.cpuShares
+	hostConfig.CpuPeriod = b.cpuPeriod
+	hostConfig.CpuQuota = b.cpuQuota
+	hostConfig.CpusetCpus = b.cpuSetCpus
+	hostConfig.CpusetMems = b.cpuSetMems
+	hostConfig.Memory = b.memory
+	hostConfig.MemorySwap = b.memorySwap
+
+	setPlatformSpecificHostConfig(b, hostConfig)
 
 	config := *b.Config
 

--- a/builder/internals_linux.go
+++ b/builder/internals_linux.go
@@ -1,0 +1,9 @@
+package builder
+
+import (
+	"github.com/docker/docker/runconfig"
+)
+
+func setPlatformSpecificHostConfig(b *Builder, hostConfig *runconfig.HostConfig) {
+	hostConfig.CgroupParent = b.cgroupParent
+}

--- a/builder/internals_windows.go
+++ b/builder/internals_windows.go
@@ -1,0 +1,8 @@
+package builder
+
+import (
+	"github.com/docker/docker/runconfig"
+)
+
+func setPlatformSpecificHostConfig(b *Builder, hostConfig *runconfig.HostConfig) {
+}

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -10,7 +10,6 @@ import (
 
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/parsers"
-	"github.com/docker/docker/pkg/ulimit"
 )
 
 var (
@@ -54,10 +53,6 @@ func IPVar(value *net.IP, names []string, defaultValue, usage string) {
 
 func LabelListVar(values *[]string, names []string, usage string) {
 	flag.Var(newListOptsRef(values, ValidateLabel), names, usage)
-}
-
-func UlimitMapVar(values map[string]*ulimit.Ulimit, names []string, usage string) {
-	flag.Var(NewUlimitOpt(values), names, usage)
 }
 
 // ListOpts type
@@ -269,18 +264,6 @@ func validateDomain(val string) (string, error) {
 		return string(ns[1]), nil
 	}
 	return "", fmt.Errorf("%s is not a valid domain", val)
-}
-
-func ValidateExtraHost(val string) (string, error) {
-	// allow for IPv6 addresses in extra hosts by only splitting on first ":"
-	arr := strings.SplitN(val, ":", 2)
-	if len(arr) != 2 || len(arr[0]) == 0 {
-		return "", fmt.Errorf("bad format for add-host: %q", val)
-	}
-	if _, err := ValidateIPAddress(arr[1]); err != nil {
-		return "", fmt.Errorf("invalid IP address in add-host: %q", arr[1])
-	}
-	return val, nil
 }
 
 func ValidateLabel(val string) (string, error) {

--- a/opts/opts_linux.go
+++ b/opts/opts_linux.go
@@ -1,0 +1,18 @@
+package opts
+
+import (
+	"fmt"
+	"strings"
+)
+
+func ValidateExtraHost(val string) (string, error) {
+	// allow for IPv6 addresses in extra hosts by only splitting on first ":"
+	arr := strings.SplitN(val, ":", 2)
+	if len(arr) != 2 || len(arr[0]) == 0 {
+		return "", fmt.Errorf("bad format for add-host: %q", val)
+	}
+	if _, err := ValidateIPAddress(arr[1]); err != nil {
+		return "", fmt.Errorf("invalid IP address in add-host: %q", arr[1])
+	}
+	return val, nil
+}

--- a/opts/ulimit.go
+++ b/opts/ulimit.go
@@ -1,8 +1,11 @@
+// +build linux
+
 package opts
 
 import (
 	"fmt"
 
+	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/ulimit"
 )
 
@@ -41,4 +44,8 @@ func (o *UlimitOpt) GetList() []*ulimit.Ulimit {
 	}
 
 	return ulimits
+}
+
+func UlimitMapVar(values map[string]*ulimit.Ulimit, names []string, usage string) {
+	flag.Var(NewUlimitOpt(values), names, usage)
 }

--- a/runconfig/hostconfig_linux.go
+++ b/runconfig/hostconfig_linux.go
@@ -1,0 +1,145 @@
+// +build linux
+
+package runconfig
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/docker/docker/pkg/ulimit"
+)
+
+type IpcMode string
+
+// IsPrivate indicates whether container use it's private ipc stack
+func (n IpcMode) IsPrivate() bool {
+	return !(n.IsHost() || n.IsContainer())
+}
+
+func (n IpcMode) IsHost() bool {
+	return n == "host"
+}
+
+func (n IpcMode) IsContainer() bool {
+	parts := strings.SplitN(string(n), ":", 2)
+	return len(parts) > 1 && parts[0] == "container"
+}
+
+func (n IpcMode) Valid() bool {
+	parts := strings.Split(string(n), ":")
+	switch mode := parts[0]; mode {
+	case "", "host":
+	case "container":
+		if len(parts) != 2 || parts[1] == "" {
+			return false
+		}
+	default:
+		return false
+	}
+	return true
+}
+
+func (n IpcMode) Container() string {
+	parts := strings.SplitN(string(n), ":", 2)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return ""
+}
+
+type PidMode string
+
+// IsPrivate indicates whether container use it's private pid stack
+func (n PidMode) IsPrivate() bool {
+	return !(n.IsHost())
+}
+
+func (n PidMode) IsHost() bool {
+	return n == "host"
+}
+
+func (n PidMode) Valid() bool {
+	parts := strings.Split(string(n), ":")
+	switch mode := parts[0]; mode {
+	case "", "host":
+	default:
+		return false
+	}
+	return true
+}
+
+type DeviceMapping struct {
+	PathOnHost        string
+	PathInContainer   string
+	CgroupPermissions string
+}
+
+type LxcConfig struct {
+	values []KeyValuePair
+}
+
+func (c *LxcConfig) MarshalJSON() ([]byte, error) {
+	if c == nil {
+		return []byte{}, nil
+	}
+	return json.Marshal(c.Slice())
+}
+
+func (c *LxcConfig) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+
+	var kv []KeyValuePair
+	if err := json.Unmarshal(b, &kv); err != nil {
+		var h map[string]string
+		if err := json.Unmarshal(b, &h); err != nil {
+			return err
+		}
+		for k, v := range h {
+			kv = append(kv, KeyValuePair{k, v})
+		}
+	}
+	c.values = kv
+
+	return nil
+}
+
+func (c *LxcConfig) Len() int {
+	if c == nil {
+		return 0
+	}
+	return len(c.values)
+}
+
+func (c *LxcConfig) Slice() []KeyValuePair {
+	if c == nil {
+		return nil
+	}
+	return c.values
+}
+
+func NewLxcConfig(values []KeyValuePair) *LxcConfig {
+	return &LxcConfig{values}
+}
+
+type HostConfig struct {
+	CommonHostConfig
+
+	// Fields below here are platform specific.
+	LxcConf        *LxcConfig
+	BlkioWeight    int64 // Block IO weight (relative weight vs. other containers)
+	OomKillDisable bool  // Whether to disable OOM Killer or not
+	Privileged     bool
+	ExtraHosts     []string
+	VolumesFrom    []string
+	Devices        []DeviceMapping
+	IpcMode        IpcMode
+	CapAdd         []string
+	CapDrop        []string
+	SecurityOpt    []string
+	ReadonlyRootfs bool
+	PidMode        PidMode
+	Ulimits        []*ulimit.Ulimit
+	CgroupParent   string // Parent cgroup.
+}

--- a/runconfig/hostconfig_unsupported.go
+++ b/runconfig/hostconfig_unsupported.go
@@ -1,0 +1,7 @@
+// +build !windows,!linux
+
+package runconfig
+
+type HostConfig struct {
+	CommonHostConfig
+}

--- a/runconfig/hostconfig_windows.go
+++ b/runconfig/hostconfig_windows.go
@@ -1,0 +1,10 @@
+// +build windows
+
+package runconfig
+
+type HostConfig struct {
+	CommonHostConfig
+
+	// Fields below here are platform specific. There are none currently
+	// for the Windows platform.
+}

--- a/runconfig/parse_linux.go
+++ b/runconfig/parse_linux.go
@@ -1,0 +1,130 @@
+// +build linux
+
+package runconfig
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/opts"
+	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/pkg/ulimit"
+)
+
+var (
+	ErrConflictNetworkHosts = fmt.Errorf("Conflicting options: --add-host and the network mode (--net).")
+)
+
+func parsePlatformSpecific(cmd *flag.FlagSet, hostconfig *HostConfig, netMode NetworkMode) error {
+
+	// TODO Windows: For the daemon to compile on Windows, references to all
+	// of these fields needs to be factored out. However, waiting for other
+	// PRs to be merged before this can be done as those files already have
+	// other changes pending. For example GH12884
+
+	var (
+		ulimits          = make(map[string]*ulimit.Ulimit)
+		flUlimits        = opts.NewUlimitOpt(ulimits)
+		flLxcOpts        = opts.NewListOpts(nil)
+		flDevices        = opts.NewListOpts(opts.ValidatePath)
+		flIpcMode        = cmd.String([]string{"-ipc"}, "", "IPC namespace to use")
+		flPidMode        = cmd.String([]string{"-pid"}, "", "PID namespace to use")
+		flBlkioWeight    = cmd.Int64([]string{"-blkio-weight"}, 0, "Block IO (relative weight), between 10 and 1000")
+		flOomKillDisable = cmd.Bool([]string{"-oom-kill-disable"}, false, "Disable OOM Killer")
+		flPrivileged     = cmd.Bool([]string{"#privileged", "-privileged"}, false, "Give extended privileges to this container")
+		flExtraHosts     = opts.NewListOpts(opts.ValidateExtraHost)
+		flVolumesFrom    = opts.NewListOpts(nil)
+		flCapAdd         = opts.NewListOpts(nil)
+		flCapDrop        = opts.NewListOpts(nil)
+		flSecurityOpt    = opts.NewListOpts(nil)
+		flReadonlyRootfs = cmd.Bool([]string{"-read-only"}, false, "Mount the container's root filesystem as read only")
+		flCgroupParent   = cmd.String([]string{"-cgroup-parent"}, "", "Optional parent cgroup for the container")
+	)
+
+	cmd.Var(flUlimits, []string{"-ulimit"}, "Ulimit options")
+	cmd.Var(&flLxcOpts, []string{"#lxc-conf", "-lxc-conf"}, "Add custom lxc options")
+	cmd.Var(&flDevices, []string{"-device"}, "Add a host device to the container")
+	cmd.Var(&flExtraHosts, []string{"-add-host"}, "Add a custom host-to-IP mapping (host:ip)")
+	cmd.Var(&flVolumesFrom, []string{"#volumes-from", "-volumes-from"}, "Mount volumes from the specified container(s)")
+	cmd.Var(&flCapAdd, []string{"-cap-add"}, "Add Linux capabilities")
+	cmd.Var(&flCapDrop, []string{"-cap-drop"}, "Drop Linux capabilities")
+	cmd.Var(&flSecurityOpt, []string{"-security-opt"}, "Security Options")
+
+	lc, err := parseKeyValueOpts(flLxcOpts)
+	if err != nil {
+		return err
+	}
+	lxcConf := NewLxcConfig(lc)
+
+	// parse device mappings
+	deviceMappings := []DeviceMapping{}
+	for _, device := range flDevices.GetAll() {
+		deviceMapping, err := ParseDevice(device)
+		if err != nil {
+			return err
+		}
+		deviceMappings = append(deviceMappings, deviceMapping)
+	}
+
+	ipcMode := IpcMode(*flIpcMode)
+	if !ipcMode.Valid() {
+		return fmt.Errorf("--ipc: invalid IPC mode")
+	}
+
+	pidMode := PidMode(*flPidMode)
+	if !pidMode.Valid() {
+		return fmt.Errorf("--pid: invalid PID mode")
+	}
+
+	if (netMode.IsContainer() || netMode.IsHost()) && flExtraHosts.Len() > 0 {
+		return ErrConflictNetworkHosts
+	}
+
+	hostconfig.Ulimits = flUlimits.GetList()
+	hostconfig.LxcConf = lxcConf
+	hostconfig.Devices = deviceMappings
+	hostconfig.IpcMode = ipcMode
+	hostconfig.PidMode = pidMode
+	hostconfig.BlkioWeight = *flBlkioWeight
+	hostconfig.OomKillDisable = *flOomKillDisable
+	hostconfig.Privileged = *flPrivileged
+	hostconfig.ExtraHosts = flExtraHosts.GetAll()
+	hostconfig.VolumesFrom = flVolumesFrom.GetAll()
+	hostconfig.CapAdd = flCapAdd.GetAll()
+	hostconfig.CapDrop = flCapDrop.GetAll()
+	hostconfig.SecurityOpt = flSecurityOpt.GetAll()
+	hostconfig.ReadonlyRootfs = *flReadonlyRootfs
+	hostconfig.CgroupParent = *flCgroupParent
+
+	return nil
+}
+
+func ParseDevice(device string) (DeviceMapping, error) {
+	src := ""
+	dst := ""
+	permissions := "rwm"
+	arr := strings.Split(device, ":")
+	switch len(arr) {
+	case 3:
+		permissions = arr[2]
+		fallthrough
+	case 2:
+		dst = arr[1]
+		fallthrough
+	case 1:
+		src = arr[0]
+	default:
+		return DeviceMapping{}, fmt.Errorf("Invalid device specification: %s", device)
+	}
+
+	if dst == "" {
+		dst = src
+	}
+
+	deviceMapping := DeviceMapping{
+		PathOnHost:        src,
+		PathInContainer:   dst,
+		CgroupPermissions: permissions,
+	}
+	return deviceMapping, nil
+}

--- a/runconfig/parse_unsupported.go
+++ b/runconfig/parse_unsupported.go
@@ -1,0 +1,11 @@
+// +build !windows,!linux
+
+package runconfig
+
+import (
+	flag "github.com/docker/docker/pkg/mflag"
+)
+
+func parsePlatformSpecific(cmd *flag.FlagSet, hostconfig *HostConfig, netMode NetworkMode) error {
+	return nil
+}

--- a/runconfig/parse_windows.go
+++ b/runconfig/parse_windows.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package runconfig
+
+import (
+	flag "github.com/docker/docker/pkg/mflag"
+)
+
+// There are no platform specific flags to parse currently on Windows
+func parsePlatformSpecific(cmd *flag.FlagSet, hostconfig *HostConfig, netMode NetworkMode) error {
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This PR starts refactoring runconfig.HostConfig into platform specific parts for the daemon, which enables the removal of the dependency of ulimit on the Windows daemon. Before the Windows daemon will successfully compile, references to any of the Linux platform-specific fields need to be factored out which will touch a large number of files. However, before that can be done, to avoid merge conflicts, other PRs need to be merged such as GH12884.
