### PR TITLE
Fix mangled hack/vendor.sh rebase

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -50,19 +50,10 @@ clone git github.com/go-fsnotify/fsnotify v1.2.0
 clone git github.com/gorilla/context 14f550f51a
 clone git github.com/gorilla/mux e444e69cbd
 clone git github.com/kr/pty 05017fcccf
+clone git github.com/mistifyio/go-zfs v2.1.0
 clone git github.com/tchap/go-patricia v2.1.0
 clone hg code.google.com/p/go.net 84a4013f96e0
 clone hg code.google.com/p/gosqlite 74691fb6f837
-
-clone git github.com/docker/libtrust 230dfd18c232
-
-clone git github.com/Sirupsen/logrus v0.7.2
-
-clone git github.com/go-fsnotify/fsnotify v1.2.0
-
-clone git github.com/go-check/check 64131543e7896d5bcc6bd5a76287eb75ea96c673
-
-clone git github.com/mistifyio/go-zfs v2.1.0
 
 # get distribution packages
 clone git github.com/docker/distribution d957768537c5af40e4f4cd96871f7b2bde9e2923


### PR DESCRIPTION
#9411 included a rebase of `vendor.sh` that got a little manged. :+1:

``` console
$ rm -rf vendor
$ ./hack/vendor.sh
github.com/Sirupsen/logrus @ v0.7.3: clone, rm VCS, rm vendor, done
github.com/docker/libtrust @ 230dfd18c232: clone, rm VCS, rm vendor, done
github.com/go-check/check @ 64131543e7896d5bcc6bd5a76287eb75ea96c673: clone, rm VCS, rm vendor, done
github.com/go-fsnotify/fsnotify @ v1.2.0: clone, rm VCS, rm vendor, done
github.com/gorilla/context @ 14f550f51a: clone, rm VCS, rm vendor, done
github.com/gorilla/mux @ e444e69cbd: clone, rm VCS, rm vendor, done
github.com/kr/pty @ 05017fcccf: clone, rm VCS, rm vendor, done
github.com/mistifyio/go-zfs @ v2.1.0: clone, rm VCS, rm vendor, done
github.com/tchap/go-patricia @ v2.1.0: clone, rm VCS, rm vendor, done
code.google.com/p/go.net @ 84a4013f96e0: clone, rm VCS, rm vendor, done
code.google.com/p/gosqlite @ 74691fb6f837: clone, rm VCS, rm vendor, done
github.com/docker/distribution @ d957768537c5af40e4f4cd96871f7b2bde9e2923: clone, rm VCS, rm vendor, done
github.com/docker/libcontainer @ 90f8aa670f1f424041059060c7c63fe4dee2e441: clone, rm VCS, rm vendor, done
github.com/coreos/go-systemd @ v2: clone, rm VCS, rm vendor, done
github.com/godbus/dbus @ v2: clone, rm VCS, rm vendor, done
github.com/syndtr/gocapability @ 66ef2aa7a23ba682594e2b6f74cf40c0692b49fb: clone, rm VCS, rm vendor, done
$ git status vendor/
On branch fix-bad-vendor.sh-rebase
nothing to commit, working directory clean
```

(showing that nothing functionally changes here besides removing the rebase artifacts)
