### PR TITLE
respect -H in bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -27,7 +27,7 @@
 # This order should be applied to lists, alternatives and code blocks.
 
 __docker_q() {
-	docker 2>/dev/null "$@"
+	docker ${host:+-H "$host"} 2>/dev/null "$@"
 }
 
 __docker_containers_all() {
@@ -1182,6 +1182,7 @@ _docker() {
 	"
 
 	local main_options_with_args_glob=$(__docker_to_extglob "$main_options_with_args")
+	local host
 
 	COMPREPLY=()
 	local cur prev words cword
@@ -1191,6 +1192,11 @@ _docker() {
 	local counter=1
 	while [ $counter -lt $cword ]; do
 		case "${words[$counter]}" in
+			# save host so that completion can use custom daemon
+			--host|-H)
+				(( counter++ ))
+				host="${words[$counter]}"
+				;;
 			$main_options_with_args_glob )
 				(( counter++ ))
 				;;


### PR DESCRIPTION
At present, bash completion ignores custom docker daemon settings specified with `-H`. 
This is nasty if you work with swarm and get completions for the local docker instance.

This PR applies any global `-H` setting from the commandline to docker invocations needed for gathering completions.
