### PR TITLE
Fix package on debugtrap_unsupported.go

### DIFF
--- a/daemon/debugtrap_unsupported.go
+++ b/daemon/debugtrap_unsupported.go
@@ -1,6 +1,6 @@
 // +build !linux,!darwin,!freebsd
 
-package signal
+package daemon
 
 func setupSigusr1Trap() {
 	return


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
Silly bug on daemon\debugtrap_unsupported.go which had the signal package rather than daemon as it should be.
