### PR TITLE
Fix a regression in `docker import` on error from URL

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -717,14 +717,17 @@ func (s *Server) postImagesCreate(version version.Version, w http.ResponseWriter
 			OutStream: output,
 		}
 
-		newConfig, err := builder.BuildFromConfig(s.daemon, &runconfig.Config{}, imageImportConfig.Changes)
+		// 'err' MUST NOT be defined within this block, we need any error
+		// generated from the download to be available to the output
+		// stream processing below
+		var newConfig *runconfig.Config
+		newConfig, err = builder.BuildFromConfig(s.daemon, &runconfig.Config{}, imageImportConfig.Changes)
 		if err != nil {
 			return err
 		}
 		imageImportConfig.ContainerConfig = newConfig
 
 		err = s.daemon.Repositories().Import(src, repo, tag, imageImportConfig)
-
 	}
 	if err != nil {
 		if !output.Flushed() {

--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -39,3 +39,14 @@ func (s *DockerSuite) TestImportDisplay(c *check.C) {
 	}
 
 }
+
+func (s *DockerSuite) TestImportBadURL(c *check.C) {
+	runCmd := exec.Command(dockerBinary, "import", "http://nourl/bad")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err == nil {
+		c.Fatal("import was supposed to fail but didn't")
+	}
+	if !strings.Contains(out, "dial tcp") {
+		c.Fatalf("expected an error msg but didn't get one:\n%s", out)
+	}
+}


### PR DESCRIPTION
when the daemon can't download the image from a `docker import` the
error message was lost due to 'err' being redefined with a block by
mistake.  This removes the ":" from "... err := " which fixes it.

Signed-off-by: Doug Davis dug@us.ibm.com
