### PR TITLE
Add docs for ip-forward

### DIFF
--- a/docs/man/docker.1.md
+++ b/docs/man/docker.1.md
@@ -84,7 +84,9 @@ unix://[/path/to/socket] to use.
   Default IP address to use when binding container ports. Default is `0.0.0.0`.
 
 **--ip-forward**=*true*|*false*
-  Docker will enable IP forwarding. Default is true. If `--fixed-cidr-v6` is set. IPv6 forwarding will be activated, too. This may reject Router Advertisements and interfere with the host's existing IPv6 configuration. For more information please consult the documentation about "Advanced Networking - IPv6".
+  Enables IP forwarding on the Docker host. The default is `true`. This flag interacts with the IP forwarding setting on your host system's kernel. If your system has IP forwarding disabled, this setting enables it. If your system has IP forwarding enabled, setting this flag to `--ip-forward=false` has no effect.
+
+  This setting will also enable IPv6 forwarding if you have both `--ip-forward=true` and `--fixed-cidr-v6` set. Note that this may reject Router Advertisements and interfere with the host's existing IPv6 configuration. For more information, please consult the documentation about "Advanced Networking - IPv6".
 
 **--ip-masq**=*true*|*false*
   Enable IP masquerading for bridge's IP range. Default is true.

--- a/docs/sources/articles/networking.md
+++ b/docs/sources/articles/networking.md
@@ -269,7 +269,9 @@ Whether a container can talk to the world is governed by two factors.
     containers if this parameter is `1`.  Usually you will simply leave
     the Docker server at its default setting `--ip-forward=true` and
     Docker will go set `ip_forward` to `1` for you when the server
-    starts up. To check the setting or turn it on manually:
+    starts up. If you set `--ip-forward=false` and your system's kernel
+    has it enabled, the `--ip-forward=false` option has no effect.
+    To check the setting on your kernel or to turn it on manually:
 
         $ sysctl net.ipv4.conf.all.forwarding
         net.ipv4.conf.all.forwarding = 0


### PR DESCRIPTION
As discussed in https://github.com/docker/docker/pull/12990, `--ip-forward=false` doesn't mean disable `ip-forward`, we should clarify that in docs.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
