### PR TITLE
Bring /info API doc in line with the actual response.

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -158,6 +158,7 @@ pages:
 - ['reference/api/docker-io_api.md', 'Reference', 'Docker Hub API']
 #- ['reference/image-spec-v1.md', 'Reference', 'Docker Image Specification v1.0.0']
 - ['reference/api/docker_remote_api.md', 'Reference', 'Docker Remote API']
+- ['reference/api/docker_remote_api_v1.19.md', 'Reference', 'Docker Remote API v1.19']
 - ['reference/api/docker_remote_api_v1.18.md', 'Reference', 'Docker Remote API v1.18']
 - ['reference/api/docker_remote_api_v1.17.md', 'Reference', 'Docker Remote API v1.17']
 - ['reference/api/docker_remote_api_v1.16.md', 'Reference', 'Docker Remote API v1.16']

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -58,6 +58,16 @@ disconnect
 
 This endpoint now accepts a `since` timestamp parameter.
 
+`GET /info`
+
+**New!**
+
+The fields `Debug`, `IPv4Forwarding`, `MemoryLimit`, and `SwapLimit`
+are now returned as boolean instead of as an int.
+
+In addition, the end point now returns the new boolean fields
+`CpuCfsPeriod`, `CpuCfsQuota`, and `OomKillDisable`.
+
 ## v1.18
 
 ### Full documentation

--- a/docs/sources/reference/api/docker_remote_api_v1.18.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.18.md
@@ -1594,35 +1594,50 @@ Display system-wide information
         Content-Type: application/json
 
         {
-             "Containers":11,
-             "Images":16,
-             "Driver":"btrfs",
-             "DriverStatus": [[""]],
-             "ExecutionDriver":"native-0.1",
-             "KernelVersion":"3.12.0-1-amd64"
-             "NCPU":1,
-             "MemTotal":2099236864,
-             "Name":"prod-server-42",
-             "ID":"7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS",
-             "Debug":false,
-             "NFd": 11,
-             "NGoroutines":21,
-             "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
-             "NEventsListener":0,
-             "InitPath":"/usr/bin/docker",
-             "InitSha1":"",
-             "IndexServerAddress":["https://index.docker.io/v1/"],
-             "MemoryLimit":true,
-             "SwapLimit":false,
-             "IPv4Forwarding":true,
-             "Labels":["storage=ssd"],
-             "DockerRootDir": "/var/lib/docker",
-             "HttpProxy": "http://test:test@localhost:8080"
-             "HttpsProxy": "https://test:test@localhost:8080"
-             "NoProxy": "9.81.1.160"
-             "OperatingSystem": "Boot2Docker",
+            "Containers": 11,
+            "Debug": 0,
+            "DockerRootDir": "/var/lib/docker",
+            "Driver": "btrfs",
+            "DriverStatus": [[""]],
+            "ExecutionDriver": "native-0.1",
+            "HttpProxy": "http://test:test@localhost:8080",
+            "HttpsProxy": "https://test:test@localhost:8080",
+            "ID": "7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS",
+            "IPv4Forwarding": 1,
+            "Images": 16,
+            "IndexServerAddress": "https://index.docker.io/v1/",
+            "InitPath": "/usr/bin/docker",
+            "InitSha1": "",
+            "KernelVersion": "3.12.0-1-amd64",
+            "Labels": [
+                "storage=ssd"
+            ],
+            "MemTotal": 2099236864,
+            "MemoryLimit": 1,
+            "NCPU": 1,
+            "NEventsListener": 0,
+            "NFd": 11,
+            "NGoroutines": 21,
+            "Name": "prod-server-42",
+            "NoProxy": "9.81.1.160",
+            "OperatingSystem": "Boot2Docker",
+            "RegistryConfig": {
+                "IndexConfigs": {
+                    "docker.io": {
+                        "Mirrors": null,
+                        "Name": "docker.io",
+                        "Official": true,
+                        "Secure": true
+                    }
+                },
+                "InsecureRegistryCIDRs": [
+                    "127.0.0.0/8"
+                ]
+            },
+            "SwapLimit": 0,
+            "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
         }
-
+        
 Status Codes:
 
 -   **200** – no error

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -1612,33 +1612,51 @@ Display system-wide information
         Content-Type: application/json
 
         {
-             "Containers":11,
-             "Images":16,
-             "Driver":"btrfs",
-             "DriverStatus": [[""]],
-             "ExecutionDriver":"native-0.1",
-             "KernelVersion":"3.12.0-1-amd64"
-             "NCPU":1,
-             "MemTotal":2099236864,
-             "Name":"prod-server-42",
-             "ID":"7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS",
-             "Debug":false,
-             "NFd": 11,
-             "NGoroutines":21,
-             "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
-             "NEventsListener":0,
-             "InitPath":"/usr/bin/docker",
-             "InitSha1":"",
-             "IndexServerAddress":["https://index.docker.io/v1/"],
-             "MemoryLimit":true,
-             "SwapLimit":false,
-             "IPv4Forwarding":true,
-             "Labels":["storage=ssd"],
-             "DockerRootDir": "/var/lib/docker",
-             "HttpProxy": "http://test:test@localhost:8080"
-             "HttpsProxy": "https://test:test@localhost:8080"
-             "NoProxy": "9.81.1.160"
-             "OperatingSystem": "Boot2Docker",
+            "Containers": 11,
+            "CpuCfsPeriod": true,
+            "CpuCfsQuota": true,
+            "Debug": false,
+            "DockerRootDir": "/var/lib/docker",
+            "Driver": "btrfs",
+            "DriverStatus": [[""]],
+            "ExecutionDriver": "native-0.1",
+            "HttpProxy": "http://test:test@localhost:8080",
+            "HttpsProxy": "https://test:test@localhost:8080",
+            "ID": "7TRN:IPZB:QYBB:VPBQ:UMPP:KARE:6ZNR:XE6T:7EWV:PKF4:ZOJD:TPYS",
+            "IPv4Forwarding": true,
+            "Images": 16,
+            "IndexServerAddress": "https://index.docker.io/v1/",
+            "InitPath": "/usr/bin/docker",
+            "InitSha1": "",
+            "KernelVersion": "3.12.0-1-amd64",
+            "Labels": [
+                "storage=ssd"
+            ],
+            "MemTotal": 2099236864,
+            "MemoryLimit": true,
+            "NCPU": 1,
+            "NEventsListener": 0,
+            "NFd": 11,
+            "NGoroutines": 21,
+            "Name": "prod-server-42",
+            "NoProxy": "9.81.1.160",
+            "OomKillDisable": true,
+            "OperatingSystem": "Boot2Docker",
+            "RegistryConfig": {
+                "IndexConfigs": {
+                    "docker.io": {
+                        "Mirrors": null,
+                        "Name": "docker.io",
+                        "Official": true,
+                        "Secure": true
+                    }
+                },
+                "InsecureRegistryCIDRs": [
+                    "127.0.0.0/8"
+                ]
+            },
+            "SwapLimit": false,
+            "SystemTime": "2015-03-10T11:11:23.730591467-07:00"
         }
 
 Status Codes:


### PR DESCRIPTION
The fix handles versions 1.18 and 1.19.

Closes #13139.

In addition to "Debug" and "IndexServerAddress" changes, I found that 1.18 doc didn't list the field "RegistryConfig" so I added it as well. 

In addition, 1.19 doc was not linked to from `mkdocs.yml` so I added that link. Please let me know if there is any problem with this.
