### PR TITLE
Remove out of date comment

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -38,7 +38,6 @@ func (cid *cidFile) Write(id string) error {
 //
 // Usage: docker run [OPTIONS] IMAGE [COMMAND] [ARG...]
 func (cli *DockerCli) CmdRun(args ...string) error {
-	// FIXME: just use runconfig.Parse already
 	cmd := cli.Subcmd("run", "IMAGE [COMMAND] [ARG...]", "Run a command in a new container", true)
 
 	// These are flags not stored in Config/HostConfig


### PR DESCRIPTION
That comment isn't valid anymore. Method was fixed 6 months later to use runconfig.Parse (used to be api/client/commands.go)

Signed-off-by: Ahmet Alp Balkan
