### PR TITLE
Tar up contents of child directory onto tmpfs if mounted over

### DIFF
--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -175,4 +175,5 @@ type Command struct {
 	LxcConfig          []string          `json:"lxc_config"`
 	AppArmorProfile    string            `json:"apparmor_profile"`
 	CgroupParent       string            `json:"cgroup_parent"` // The parent cgroup for this command.
+	TmpDir             string            `json:"tmpdir"`        // Directory used to store docker tmpdirs.
 }

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -5,6 +5,7 @@ package native
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -118,6 +119,13 @@ type execOutput struct {
 
 func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (execdriver.ExitStatus, error) {
 	// take the Command and populate the libcontainer.Config from it
+	var err error
+	c.TmpDir, err = ioutil.TempDir("", c.ID)
+	if err != nil {
+		return execdriver.ExitStatus{ExitCode: -1}, err
+	}
+	defer os.RemoveAll(c.TmpDir)
+
 	container, err := d.createContainer(c)
 	if err != nil {
 		return execdriver.ExitStatus{ExitCode: -1}, err

--- a/daemon/volumes_stubs.go
+++ b/daemon/volumes_stubs.go
@@ -16,7 +16,7 @@ func getVolumeDriver(_ string) (volume.Driver, error) {
 }
 
 func parseVolumeSource(spec string, _ *runconfig.Config) (string, string, error) {
-	if !filepath.IsAbs(spec) {
+	if spec != "tmpfs" && !filepath.IsAbs(spec) {
 		return "", "", fmt.Errorf("cannot bind mount volume: %s volume paths must be absolute.", spec)
 	}
 

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -219,6 +219,7 @@ This value should always larger than **-m**, so you should always use this with 
 
 **-v**, **--volume**=[]
    Bind mount a volume (e.g., from the host: -v /host:/container, from Docker: -v /container)
+   Mount a tmpfs volume (e.g., -v tmpfs:/tmp, will mount a tmpfs at /tmp within the container, this command will copy the underlying content into the /tmpfs)
 
 **--volumes-from**=[]
    Mount volumes from the specified container(s)

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -387,6 +387,7 @@ standard input.
 
 **-v**, **--volume**=[]
    Bind mount a volume (e.g., from the host: -v /host:/container, from Docker: -v /container)
+   Mount a tmpfs volume (e.g., -v tmpfs:/tmp, will mount a tmpfs at /tmp within the container, this command will copy the underlying content into the /tmpfs)
 
    The **-v** option can be used one or
 more times to add one or more mounts to a container. These mounts can then be
@@ -438,6 +439,15 @@ set a different default with the Dockerfile WORKDIR instruction. The operator
 can override the working directory by using the **-w** option.
 
 # EXAMPLES
+
+## Running container in Read-Only mode
+
+If you want to secure a container in such a way that the container content can
+not be modified you can use the --read-only switch.  You probably will need to
+mount tmpfs directories in /run and maybe /tmp so the applications have space
+to write temporary data.
+
+    # docker run -v --read-only -v tmpfs:/run -v tmpfs:/tmp -i -t fedora /bin/bash
 
 ## Exposing log messages from the container to the host's log
 

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -1104,6 +1104,8 @@ container's `/etc/hosts` entry will be automatically updated.
 
     -v=[]: Create a bind mount with: [host-dir]:[container-dir]:[rw|ro].
            If "container-dir" is missing, then docker creates a new volume.
+    -v=[]: Create a tmpfs mount with: tmpfs:[container-dir].
+           Underlying content from the "container-dir" is copied into the tmpfs.
     --volumes-from="": Mount all volumes from the given container(s)
 
 The volumes commands are complex enough to have their own documentation


### PR DESCRIPTION
This patch will use the new PreMount and PostMount hooks to "tar"
up the contents of the base image on top of tmpfs mount points.

We want to add support for /run and /tmp on tmpfs and Michael Chrosby idea to
add --tmpfs PATH would require a patch like this.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
