### PR TITLE
Add buildflag to differentiate when container is being used in build

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -207,6 +207,7 @@ func (b *Builder) runContextCommand(args []string, allowRemote bool, allowDecomp
 	if err != nil {
 		return err
 	}
+	container.SetHostConfig(&runconfig.HostConfig{BuildFlag: true})
 	b.TmpContainers[container.ID] = struct{}{}
 
 	if err := container.Mount(); err != nil {

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -217,6 +217,7 @@ type HostConfig struct {
 	Ulimits         []*ulimit.Ulimit
 	LogConfig       LogConfig
 	CgroupParent    string // Parent cgroup.
+	BuildFlag       bool
 }
 
 func MergeConfigs(config *Config, hostConfig *HostConfig) *ContainerConfigWrapper {

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -349,6 +349,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		CapDrop:         flCapDrop.GetAll(),
 		RestartPolicy:   restartPolicy,
 		SecurityOpt:     flSecurityOpt.GetAll(),
+		BuildFlag:       false,
 		ReadonlyRootfs:  *flReadonlyRootfs,
 		Ulimits:         flUlimits.GetList(),
 		LogConfig:       LogConfig{Type: *flLoggingDriver, Config: loggingOpts},


### PR DESCRIPTION
With patches like our /run or /tmp patch we would like to only do this when running as a standard container, not as a build container.   This flag allows us to differentiate.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
