### PR TITLE
Decoder does not work properly with nested pointers using gcc

### DIFF
--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -132,15 +132,36 @@ type Config struct {
 
 type ContainerConfigWrapper struct {
 	*Config
-	*hostConfigWrapper
+	InnerHostConfig *HostConfig `json:"HostConfig,omitempty"`
+	Cpuset          string      `json:",omitempty"` // Deprecated. Exported for backwards compatibility.
+	*HostConfig                 // Deprecated. Exported to read attrubutes from json that are not in the inner host config structure.
+
 }
 
-func (c ContainerConfigWrapper) HostConfig() *HostConfig {
-	if c.hostConfigWrapper == nil {
-		return new(HostConfig)
+func (w *ContainerConfigWrapper) GetHostConfig() *HostConfig {
+	hc := w.HostConfig
+
+	if hc == nil && w.InnerHostConfig != nil {
+		hc = w.InnerHostConfig
+	} else if w.InnerHostConfig != nil {
+		if hc.Memory != 0 && w.InnerHostConfig.Memory == 0 {
+			w.InnerHostConfig.Memory = hc.Memory
+		}
+		if hc.MemorySwap != 0 && w.InnerHostConfig.MemorySwap == 0 {
+			w.InnerHostConfig.MemorySwap = hc.MemorySwap
+		}
+		if hc.CpuShares != 0 && w.InnerHostConfig.CpuShares == 0 {
+			w.InnerHostConfig.CpuShares = hc.CpuShares
+		}
+
+		hc = w.InnerHostConfig
 	}
 
-	return c.hostConfigWrapper.GetHostConfig()
+	if hc != nil && w.Cpuset != "" && hc.CpusetCpus == "" {
+		hc.CpusetCpus = w.Cpuset
+	}
+
+	return hc
 }
 
 // DecodeContainerConfig decodes a json encoded config into a ContainerConfigWrapper
@@ -155,5 +176,5 @@ func DecodeContainerConfig(src io.Reader) (*Config, *HostConfig, error) {
 		return nil, nil, err
 	}
 
-	return w.Config, w.HostConfig(), nil
+	return w.Config, w.GetHostConfig(), nil
 }

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -234,47 +234,15 @@ type HostConfig struct {
 func MergeConfigs(config *Config, hostConfig *HostConfig) *ContainerConfigWrapper {
 	return &ContainerConfigWrapper{
 		config,
-		&hostConfigWrapper{InnerHostConfig: hostConfig},
+		hostConfig,
+		"", nil,
 	}
-}
-
-type hostConfigWrapper struct {
-	InnerHostConfig *HostConfig `json:"HostConfig,omitempty"`
-	Cpuset          string      `json:",omitempty"` // Deprecated. Exported for backwards compatibility.
-
-	*HostConfig // Deprecated. Exported to read attrubutes from json that are not in the inner host config structure.
-}
-
-func (w hostConfigWrapper) GetHostConfig() *HostConfig {
-	hc := w.HostConfig
-
-	if hc == nil && w.InnerHostConfig != nil {
-		hc = w.InnerHostConfig
-	} else if w.InnerHostConfig != nil {
-		if hc.Memory != 0 && w.InnerHostConfig.Memory == 0 {
-			w.InnerHostConfig.Memory = hc.Memory
-		}
-		if hc.MemorySwap != 0 && w.InnerHostConfig.MemorySwap == 0 {
-			w.InnerHostConfig.MemorySwap = hc.MemorySwap
-		}
-		if hc.CpuShares != 0 && w.InnerHostConfig.CpuShares == 0 {
-			w.InnerHostConfig.CpuShares = hc.CpuShares
-		}
-
-		hc = w.InnerHostConfig
-	}
-
-	if hc != nil && w.Cpuset != "" && hc.CpusetCpus == "" {
-		hc.CpusetCpus = w.Cpuset
-	}
-
-	return hc
 }
 
 func DecodeHostConfig(src io.Reader) (*HostConfig, error) {
 	decoder := json.NewDecoder(src)
 
-	var w hostConfigWrapper
+	var w ContainerConfigWrapper
 	if err := decoder.Decode(&w); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
the runconfig/config_test TestDecodeContainerConfig test is failing when compiled with gccgo. There is a bug files with gccgo specifically to address the decoder issue. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66138
I believe there is no reason to add these fields to the top level structure and hence this PR.

Signed-off-by: Srini Brahmaroutu srbrahma@us.ibm.com
