### PR TITLE
Windows: chrootarchive refactor

### DIFF
--- a/pkg/chrootarchive/archive_test.go
+++ b/pkg/chrootarchive/archive_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/reexec"
+	"github.com/docker/docker/pkg/system"
 )
 
 func init() {
@@ -28,7 +28,7 @@ func TestChrootTarUntar(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := os.MkdirAll(src, 0700); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := ioutil.WriteFile(filepath.Join(src, "toto"), []byte("hello toto"), 0644); err != nil {
@@ -42,7 +42,7 @@ func TestChrootTarUntar(t *testing.T) {
 		t.Fatal(err)
 	}
 	dest := filepath.Join(tmpdir, "src")
-	if err := os.MkdirAll(dest, 0700); err != nil {
+	if err := system.MkdirAll(dest, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := Untar(stream, dest, &archive.TarOptions{ExcludePatterns: []string{"lolo"}}); err != nil {
@@ -59,7 +59,7 @@ func TestChrootUntarWithHugeExcludesList(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := os.MkdirAll(src, 0700); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := ioutil.WriteFile(filepath.Join(src, "toto"), []byte("hello toto"), 0644); err != nil {
@@ -70,7 +70,7 @@ func TestChrootUntarWithHugeExcludesList(t *testing.T) {
 		t.Fatal(err)
 	}
 	dest := filepath.Join(tmpdir, "dest")
-	if err := os.MkdirAll(dest, 0700); err != nil {
+	if err := system.MkdirAll(dest, 0700); err != nil {
 		t.Fatal(err)
 	}
 	options := &archive.TarOptions{}
@@ -101,11 +101,11 @@ func prepareSourceDirectory(numberOfFiles int, targetPath string, makeSymLinks b
 	fileData := []byte("fooo")
 	for n := 0; n < numberOfFiles; n++ {
 		fileName := fmt.Sprintf("file-%d", n)
-		if err := ioutil.WriteFile(path.Join(targetPath, fileName), fileData, 0700); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(targetPath, fileName), fileData, 0700); err != nil {
 			return 0, err
 		}
 		if makeSymLinks {
-			if err := os.Symlink(path.Join(targetPath, fileName), path.Join(targetPath, fileName+"-link")); err != nil {
+			if err := os.Symlink(filepath.Join(targetPath, fileName), filepath.Join(targetPath, fileName+"-link")); err != nil {
 				return 0, err
 			}
 		}
@@ -157,7 +157,7 @@ func TestChrootTarUntarWithSymlink(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := os.MkdirAll(src, 0700); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := prepareSourceDirectory(10, src, true); err != nil {
@@ -179,7 +179,7 @@ func TestChrootCopyWithTar(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := os.MkdirAll(src, 0700); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := prepareSourceDirectory(10, src, true); err != nil {
@@ -225,7 +225,7 @@ func TestChrootCopyFileWithTar(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := os.MkdirAll(src, 0700); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := prepareSourceDirectory(10, src, true); err != nil {
@@ -268,7 +268,7 @@ func TestChrootUntarPath(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := os.MkdirAll(src, 0700); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := prepareSourceDirectory(10, src, true); err != nil {
@@ -329,7 +329,7 @@ func TestChrootUntarEmptyArchiveFromSlowReader(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	dest := filepath.Join(tmpdir, "dest")
-	if err := os.MkdirAll(dest, 0700); err != nil {
+	if err := system.MkdirAll(dest, 0700); err != nil {
 		t.Fatal(err)
 	}
 	stream := &slowEmptyTarReader{size: 10240, chunkSize: 1024}
@@ -345,7 +345,7 @@ func TestChrootApplyEmptyArchiveFromSlowReader(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	dest := filepath.Join(tmpdir, "dest")
-	if err := os.MkdirAll(dest, 0700); err != nil {
+	if err := system.MkdirAll(dest, 0700); err != nil {
 		t.Fatal(err)
 	}
 	stream := &slowEmptyTarReader{size: 10240, chunkSize: 1024}
@@ -361,7 +361,7 @@ func TestChrootApplyDotDotFile(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	src := filepath.Join(tmpdir, "src")
-	if err := os.MkdirAll(src, 0700); err != nil {
+	if err := system.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := ioutil.WriteFile(filepath.Join(src, "..gitme"), []byte(""), 0644); err != nil {
@@ -372,7 +372,7 @@ func TestChrootApplyDotDotFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	dest := filepath.Join(tmpdir, "dest")
-	if err := os.MkdirAll(dest, 0700); err != nil {
+	if err := system.MkdirAll(dest, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := ApplyLayer(dest, stream); err != nil {

--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -1,0 +1,14 @@
+// +build !windows
+
+package chrootarchive
+
+import (
+	"syscall"
+)
+
+func chroot(path string) error {
+	if err := syscall.Chroot(path); err != nil {
+		return err
+	}
+	return syscall.Chdir("/")
+}

--- a/pkg/chrootarchive/archive_windows.go
+++ b/pkg/chrootarchive/archive_windows.go
@@ -1,0 +1,6 @@
+package chrootarchive
+
+// chroot is not supported by Windows
+func chroot(path string) error {
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This fixes the chrootarchive package to work on Windows, but in a non-chroot fashion (as chroot isn't supported on Windows...).  It also corrects the use of os.Mkdirall to system.Mkdirall to work consistently on Windows, and uses path rather than filepath where needed.
