### PR TITLE
Windows: No ZFS graphdriver

### DIFF
--- a/daemon/daemon_zfs.go
+++ b/daemon/daemon_zfs.go
@@ -1,4 +1,4 @@
-// +build !exclude_graphdriver_zfs
+// +build !exclude_graphdriver_zfs,linux
 
 package daemon
 

--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package zfs
 
 import (

--- a/daemon/graphdriver/zfs/zfs_test.go
+++ b/daemon/graphdriver/zfs/zfs_test.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package zfs
 
 import (

--- a/daemon/graphdriver/zfs/zfs_unsupported.go
+++ b/daemon/graphdriver/zfs/zfs_unsupported.go
@@ -1,0 +1,3 @@
+// +build !linux
+
+package zfs


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. Looks like ZFS came in recently. Change so that it doesn't build on the Windows daemon
