### PR TITLE
Introduce daemon event 'tag' upon image tagging

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/version"
 	"github.com/docker/docker/runconfig"
+	"github.com/docker/docker/utils"
 )
 
 type ServerConfig struct {
@@ -701,9 +702,11 @@ func (s *Server) postImagesTag(version version.Version, w http.ResponseWriter, r
 	repo := r.Form.Get("repo")
 	tag := r.Form.Get("tag")
 	force := boolValue(r, "force")
-	if err := s.daemon.Repositories().Tag(repo, tag, vars["name"], force); err != nil {
+	name := vars["name"]
+	if err := s.daemon.Repositories().Tag(repo, tag, name, force); err != nil {
 		return err
 	}
+	s.daemon.EventsService.Log("tag", utils.ImageReference(repo, tag), "")
 	w.WriteHeader(http.StatusCreated)
 	return nil
 }


### PR DESCRIPTION
This change introduces `tag` event upon`docker tag` operation. Untag (rmi) has daemon events but this one does not.

So the operation:

```
$ docker tag busybox foo:bar
$ docker rmi foo:bar
```

Used to be just

```
$ docker events
2015-05-15T01:09:11.000000000Z foo:bar: untag
```

Now:

```
$ docker events
2015-05-15T01:09:01.000000000Z foo:bar: tag
2015-05-15T01:09:11.000000000Z foo:bar: untag
```

Signed-off-by: Ahmet Alp Balkan
cc: @duglin 
