### PR TITLE
Make which cross binary fails clearer

### DIFF
--- a/hack/make/binary
+++ b/hack/make/binary
@@ -13,6 +13,7 @@ fi
 
 source "${MAKEDIR}/.go-autogen"
 
+echo "Building: $DEST/$BINARY_FULLNAME"
 go build \
 	-o "$DEST/$BINARY_FULLNAME" \
 	"${BUILDFLAGS[@]}" \


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

Simple change which ensures that the name of the binary which is trying to be cross-built is output before the compile starts. Previously, if the compile did fail, the binary being built indicating which platform/arch failed is never actually output.
