### PR TITLE
Enhance check-config.sh

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -26,6 +26,12 @@ fi
 is_set() {
 	zgrep "CONFIG_$1=[y|m]" "$CONFIG" > /dev/null
 }
+is_set_in_kernel() {
+	zgrep "CONFIG_$1=y" "$CONFIG" > /dev/null
+}
+is_set_as_module() {
+	zgrep "CONFIG_$1=m" "$CONFIG" > /dev/null
+}
 
 # see https://en.wikipedia.org/wiki/ANSI_escape_code#Colors
 declare -A colors=(
@@ -70,8 +76,10 @@ wrap_warning() {
 }
 
 check_flag() {
-	if is_set "$1"; then
+	if is_set_in_kernel "$1"; then
 		wrap_good "CONFIG_$1" 'enabled'
+	elif is_set_as_module "$1"; then
+		wrap_good "CONFIG_$1" 'enabled (as module)'
 	else
 		wrap_bad "CONFIG_$1" 'missing'
 	fi


### PR DESCRIPTION
Currently check-config.sh just said enable or missing, when I used
a fresh kernel, made check-config.sh happy, still can't start
container. It take me days debuging kernel and Docker and finally
found it's because I enabled some CONFIGs as modules and never
loaded these modules.

So I think it's necessary to let check-config.sh told users which
configs are enabled as modules.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
