### PR TITLE
Always set memory limit when using oom-kill-disable

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -148,7 +148,6 @@ type Info struct {
 	IPv4Forwarding     bool
 	Debug              bool
 	NFd                int
-	OomKillDisable     bool
 	NGoroutines        int
 	SystemTime         string
 	ExecutionDriver    string

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1177,9 +1177,8 @@ func (daemon *Daemon) verifyHostConfig(hostConfig *runconfig.HostConfig) ([]stri
 	if hostConfig.BlkioWeight > 0 && (hostConfig.BlkioWeight < 10 || hostConfig.BlkioWeight > 1000) {
 		return warnings, fmt.Errorf("Range of blkio weight is from 10 to 1000.")
 	}
-	if hostConfig.OomKillDisable && !daemon.SystemConfig().OomKillDisable {
-		hostConfig.OomKillDisable = false
-		return warnings, fmt.Errorf("Your kernel does not support oom kill disable.")
+	if hostConfig.OomKillDisable && hostConfig.Memory == 0 {
+		return warnings, fmt.Errorf("Your should always set the Memory limit when using oom kill disable.")
 	}
 
 	return warnings, nil

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -69,7 +69,6 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		IPv4Forwarding:     !daemon.SystemConfig().IPv4ForwardingDisabled,
 		Debug:              os.Getenv("DEBUG") != "",
 		NFd:                fileutils.GetTotalUsedFds(),
-		OomKillDisable:     daemon.SystemConfig().OomKillDisable,
 		NGoroutines:        runtime.NumGoroutine(),
 		SystemTime:         time.Now().Format(time.RFC3339Nano),
 		ExecutionDriver:    daemon.ExecutionDriver().Name(),

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -177,7 +177,7 @@ This value should always larger than **-m**, so you should alway use this with *
                                'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
 
 **--oom-kill-disable**=*true*|*false*
-	Whether to disable OOM Killer for the container or not.
+   Whether to disable OOM Killer for the container or not. Should alway use it with **-m** memory setting.
 
 **-P**, **--publish-all**=*true*|*false*
    Publish all exposed ports to random ports on the host interfaces. The default is *false*.

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -299,7 +299,7 @@ and foreground Docker containers.
                                'host': use the host network stack inside the container.  Note: the host mode gives the container full access to local system services such as D-bus and is therefore considered insecure.
 
 **--oom-kill-disable**=*true*|*false*
-   Whether to disable OOM Killer for the container or not.
+   Whether to disable OOM Killer for the container or not. Should alway use it with **-m** memory setting.
 
 **-P**, **--publish-all**=*true*|*false*
    Publish all exposed ports to random ports on the host interfaces. The default is *false*.

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -585,10 +585,9 @@ We set both memory and swap memory, so the processes in the container can use
 
 By default, Docker kills processes in a container if an out-of-memory (OOM)
 error occurs. To change this behaviour, use the `--oom-kill-disable` option.
-Only disable the OOM killer on containers where you have also set the
-`-m/--memory` option. If the `-m` flag is not set, this can result in the host
-running out of memory and require killing the host's system processes to free
-memory.
+It can be only used with `-m/--memory` option. Because if the `-m` flag is
+not set, this can result in the host running out of memory and require
+killing the host's system processes to free memory.
 
 Examples:
 
@@ -596,13 +595,6 @@ The following example limits the memory to 100M and disables the OOM killer for
 this container:
 
     $ docker run -ti -m 100M --oom-kill-disable ubuntu:14.04 /bin/bash
-
-The following example, illustrates a dangerous way to use the flag:
-
-    $ docker run -ti --oom-kill-disable ubuntu:14.04 /bin/bash
-
-The container has unlimited memory which can cause the host to run out memory
-and require killing system processes to free memory.
 
 ### CPU share constraint
 

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -19,7 +19,6 @@ type SysInfo struct {
 	CpuCfsQuota            bool
 	IPv4ForwardingDisabled bool
 	AppArmor               bool
-	OomKillDisable         bool
 }
 
 // New returns a new SysInfo, using the filesystem to detect which features the kernel supports.
@@ -37,12 +36,6 @@ func New(quiet bool) *SysInfo {
 		sysInfo.SwapLimit = err1 == nil
 		if !sysInfo.SwapLimit && !quiet {
 			logrus.Warn("Your kernel does not support swap memory limit.")
-		}
-
-		_, err = ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.oom_control"))
-		sysInfo.OomKillDisable = err == nil
-		if !sysInfo.OomKillDisable && !quiet {
-			logrus.Warnf("Your kernel does not support oom control.")
 		}
 	}
 


### PR DESCRIPTION
Use oom-kill-diable without memory limit could cause host oom
and important system processes be killed. Most users don't know
this risk and I think declared in doc is not enough.

So for security, we should only allow users use oom-kill-disable
with memory limit be set.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
