### PR TITLE
Cleanup:Remove redundant log in pkg/pidfile/pidfile.go

### DIFF
--- a/pkg/pidfile/pidfile.go
+++ b/pkg/pidfile/pidfile.go
@@ -3,7 +3,6 @@ package pidfile
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -37,7 +36,6 @@ func New(path string) (*PidFile, error) {
 
 func (file PidFile) Remove() error {
 	if err := os.Remove(file.path); err != nil {
-		log.Printf("Error removing %s: %s", file.path, err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
The log in pkg/pidfile/pidfile.go is redundant, since the caller
will print the log infomation.

<pre><code>DEBU[0335] Clean shutdown succeded
2015/05/15 15:20:47 Error removing /var/run/docker.pid: remove /var/run/docker.pid: no such file or directory
ERRO[0335] remove /var/run/docker.pid: no such file or directory
</code></pre>

And if we want keep this log we should use `logrus` but not `log`
to keep the log consistent.
