### PR TITLE
Extend sleep/timeout for ngoroutine check

### DIFF
--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -432,7 +432,7 @@ func (s *DockerSuite) TestLogsFollowGoroutinesWithStdout(c *check.C) {
 	c.Assert(cmd.Process.Kill(), check.IsNil)
 
 	// NGoroutines is not updated right away, so we need to wait before failing
-	t := time.After(5 * time.Second)
+	t := time.After(30 * time.Second)
 	for {
 		select {
 		case <-t:
@@ -441,7 +441,7 @@ func (s *DockerSuite) TestLogsFollowGoroutinesWithStdout(c *check.C) {
 			if nroutines == getNGoroutines() {
 				return
 			}
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #13233

In cases where this is failing it's ok to have the test take extra time,
but we don't want it to fail because of some race/performance
differences between systems.
So make the timeout go to 30s and double the sleep time in between
checks so it's not pounding the daemon quite so fast.

Originally I couldn't make this test fail (pre-change), but changed
graphdrivers and saw a failure pretty quickly.
This change seems to smooth that out.

Signed-off-by: Brian Goff cpuguy83@gmail.com
