### PR TITLE
builder/internals: set up network as bridge

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -561,6 +561,7 @@ func (b *Builder) create() (*daemon.Container, error) {
 		CgroupParent: b.cgroupParent,
 		Memory:       b.memory,
 		MemorySwap:   b.memorySwap,
+		NetworkMode:  "bridge",
 	}
 
 	config := *b.Config


### PR DESCRIPTION
This change makes builder use the bridge configuration. Not having this configuration leads to failing to set up the network properly.
