### PR TITLE
Windows: factor out bridgeConfig from server+config

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -36,7 +36,6 @@ import (
 	"github.com/docker/docker/pkg/version"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
-	"github.com/docker/libnetwork/portallocator"
 )
 
 type ServerConfig struct {
@@ -1549,31 +1548,4 @@ func createRouter(s *Server) *mux.Router {
 	}
 
 	return r
-}
-
-func allocateDaemonPort(addr string) error {
-	host, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return err
-	}
-
-	intPort, err := strconv.Atoi(port)
-	if err != nil {
-		return err
-	}
-
-	var hostIPs []net.IP
-	if parsedIP := net.ParseIP(host); parsedIP != nil {
-		hostIPs = append(hostIPs, parsedIP)
-	} else if hostIPs, err = net.LookupIP(host); err != nil {
-		return fmt.Errorf("failed to lookup %s address in host specification", host)
-	}
-
-	pa := portallocator.Get()
-	for _, hostIP := range hostIPs {
-		if _, err := pa.RequestPort(hostIP, "tcp", intPort); err != nil {
-			return fmt.Errorf("failed to allocate daemon listening port %d (err: %v)", intPort, err)
-		}
-	}
-	return nil
 }

--- a/api/server/server_windows.go
+++ b/api/server/server_windows.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NewServer sets up the required Server and does protocol specific checking.
-func (s *Server) newServer(proto, addr string) (Server, error) {
+func (s *Server) newServer(proto, addr string) (serverCloser, error) {
 	var (
 		err error
 		l   net.Listener
@@ -22,6 +22,7 @@ func (s *Server) newServer(proto, addr string) (Server, error) {
 		if err != nil {
 			return nil, err
 		}
+
 	default:
 		return nil, errors.New("Invalid protocol format. Windows only supports tcp.")
 	}
@@ -42,4 +43,8 @@ func (s *Server) AcceptConnections(d *daemon.Daemon) {
 	default:
 		close(s.start)
 	}
+}
+
+func allocateDaemonPort(addr string) error {
+	return nil
 }

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -1,8 +1,6 @@
 package daemon
 
 import (
-	"net"
-
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/runconfig"
@@ -16,9 +14,7 @@ const (
 // CommonConfig defines the configuration of a docker daemon which are
 // common across platforms.
 type CommonConfig struct {
-	AutoRestart bool
-	// Bridge holds bridge network specific configuration.
-	Bridge         bridgeConfig
+	AutoRestart    bool
 	Context        map[string][]string
 	CorsHeaders    string
 	DisableNetwork bool
@@ -26,8 +22,10 @@ type CommonConfig struct {
 	DnsSearch      []string
 	EnableCors     bool
 	ExecDriver     string
+	ExecOptions    []string
 	ExecRoot       string
 	GraphDriver    string
+	GraphOptions   []string
 	Labels         []string
 	LogConfig      runconfig.LogConfig
 	Mtu            int
@@ -36,57 +34,26 @@ type CommonConfig struct {
 	TrustKeyPath   string
 }
 
-// bridgeConfig stores all the bridge driver specific
-// configuration.
-type bridgeConfig struct {
-	EnableIPv6                  bool
-	EnableIPTables              bool
-	EnableIPForward             bool
-	EnableIPMasq                bool
-	EnableUserlandProxy         bool
-	DefaultIP                   net.IP
-	Iface                       string
-	IP                          string
-	FixedCIDR                   string
-	FixedCIDRv6                 string
-	DefaultGatewayIPv4          string
-	DefaultGatewayIPv6          string
-	InterContainerCommunication bool
-}
-
 // InstallCommonFlags adds command-line options to the top-level flag parser for
 // the current process.
 // Subsequent calls to `flag.Parse` will populate config with values parsed
 // from the command-line.
-
 func (config *Config) InstallCommonFlags() {
+	opts.ListVar(&config.GraphOptions, []string{"-storage-opt"}, "Set storage driver options")
+	opts.ListVar(&config.ExecOptions, []string{"-exec-opt"}, "Set exec driver options")
 	flag.StringVar(&config.Pidfile, []string{"p", "-pidfile"}, defaultPidFile, "Path to use for daemon PID file")
 	flag.StringVar(&config.Root, []string{"g", "-graph"}, defaultGraph, "Root of the Docker runtime")
 	flag.StringVar(&config.ExecRoot, []string{"-exec-root"}, "/var/run/docker", "Root of the Docker execdriver")
 	flag.BoolVar(&config.AutoRestart, []string{"#r", "#-restart"}, true, "--restart on the daemon has been deprecated in favor of --restart policies on docker run")
-	flag.BoolVar(&config.Bridge.EnableIPTables, []string{"#iptables", "-iptables"}, true, "Enable addition of iptables rules")
-	flag.BoolVar(&config.Bridge.EnableIPForward, []string{"#ip-forward", "-ip-forward"}, true, "Enable net.ipv4.ip_forward")
-	flag.BoolVar(&config.Bridge.EnableIPMasq, []string{"-ip-masq"}, true, "Enable IP masquerading")
-	flag.BoolVar(&config.Bridge.EnableIPv6, []string{"-ipv6"}, false, "Enable IPv6 networking")
-	flag.StringVar(&config.Bridge.IP, []string{"#bip", "-bip"}, "", "Specify network bridge IP")
-	flag.StringVar(&config.Bridge.Iface, []string{"b", "-bridge"}, "", "Attach containers to a network bridge")
-	flag.StringVar(&config.Bridge.FixedCIDR, []string{"-fixed-cidr"}, "", "IPv4 subnet for fixed IPs")
-	flag.StringVar(&config.Bridge.FixedCIDRv6, []string{"-fixed-cidr-v6"}, "", "IPv6 subnet for fixed IPs")
-	flag.StringVar(&config.Bridge.DefaultGatewayIPv4, []string{"-default-gateway"}, "", "Container default gateway IPv4 address")
-	flag.StringVar(&config.Bridge.DefaultGatewayIPv6, []string{"-default-gateway-v6"}, "", "Container default gateway IPv6 address")
-	flag.BoolVar(&config.Bridge.InterContainerCommunication, []string{"#icc", "-icc"}, true, "Enable inter-container communication")
 	flag.StringVar(&config.GraphDriver, []string{"s", "-storage-driver"}, "", "Storage driver to use")
 	flag.StringVar(&config.ExecDriver, []string{"e", "-exec-driver"}, "native", "Exec driver to use")
 	flag.IntVar(&config.Mtu, []string{"#mtu", "-mtu"}, 0, "Set the containers network MTU")
 	flag.BoolVar(&config.EnableCors, []string{"#api-enable-cors", "#-api-enable-cors"}, false, "Enable CORS headers in the remote API, this is deprecated by --api-cors-header")
 	flag.StringVar(&config.CorsHeaders, []string{"-api-cors-header"}, "", "Set CORS headers in the remote API")
-	opts.IPVar(&config.Bridge.DefaultIP, []string{"#ip", "-ip"}, "0.0.0.0", "Default IP when binding container ports")
 	// FIXME: why the inconsistency between "hosts" and "sockets"?
 	opts.IPListVar(&config.Dns, []string{"#dns", "-dns"}, "DNS server to use")
 	opts.DnsSearchListVar(&config.DnsSearch, []string{"-dns-search"}, "DNS search domains to use")
 	opts.LabelListVar(&config.Labels, []string{"-label"}, "Set key=value labels to the daemon")
 	flag.StringVar(&config.LogConfig.Type, []string{"-log-driver"}, "json-file", "Default driver for container logs")
 	opts.LogOptsVar(config.LogConfig.Config, []string{"-log-opt"}, "Set log driver options")
-	flag.BoolVar(&config.Bridge.EnableUserlandProxy, []string{"-userland-proxy"}, true, "Use userland proxy for loopback traffic")
-
 }

--- a/daemon/config_linux.go
+++ b/daemon/config_linux.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"net"
+
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/ulimit"
@@ -18,11 +20,30 @@ type Config struct {
 	CommonConfig
 
 	// Fields below here are platform specific.
+
+	// Bridge holds bridge network specific configuration.
+	Bridge               bridgeConfig
 	EnableSelinuxSupport bool
-	ExecOptions          []string
-	GraphOptions         []string
 	SocketGroup          string
 	Ulimits              map[string]*ulimit.Ulimit
+}
+
+// bridgeConfig stores all the bridge driver specific
+// configuration.
+type bridgeConfig struct {
+	EnableIPv6                  bool
+	EnableIPTables              bool
+	EnableIPForward             bool
+	EnableIPMasq                bool
+	EnableUserlandProxy         bool
+	DefaultIP                   net.IP
+	Iface                       string
+	IP                          string
+	FixedCIDR                   string
+	FixedCIDRv6                 string
+	DefaultGatewayIPv4          string
+	DefaultGatewayIPv6          string
+	InterContainerCommunication bool
 }
 
 // InstallFlags adds command-line options to the top-level flag parser for
@@ -34,10 +55,21 @@ func (config *Config) InstallFlags() {
 	config.InstallCommonFlags()
 
 	// Then platform-specific install flags
-	opts.ListVar(&config.GraphOptions, []string{"-storage-opt"}, "Set storage driver options")
-	opts.ListVar(&config.ExecOptions, []string{"-exec-opt"}, "Set exec driver options")
 	flag.BoolVar(&config.EnableSelinuxSupport, []string{"-selinux-enabled"}, false, "Enable selinux support")
 	flag.StringVar(&config.SocketGroup, []string{"G", "-group"}, "docker", "Group for the unix socket")
 	config.Ulimits = make(map[string]*ulimit.Ulimit)
 	opts.UlimitMapVar(config.Ulimits, []string{"-default-ulimit"}, "Set default ulimits for containers")
+	flag.BoolVar(&config.Bridge.EnableIPTables, []string{"#iptables", "-iptables"}, true, "Enable addition of iptables rules")
+	flag.BoolVar(&config.Bridge.EnableIPForward, []string{"#ip-forward", "-ip-forward"}, true, "Enable net.ipv4.ip_forward")
+	flag.BoolVar(&config.Bridge.EnableIPMasq, []string{"-ip-masq"}, true, "Enable IP masquerading")
+	flag.BoolVar(&config.Bridge.EnableIPv6, []string{"-ipv6"}, false, "Enable IPv6 networking")
+	flag.StringVar(&config.Bridge.IP, []string{"#bip", "-bip"}, "", "Specify network bridge IP")
+	flag.StringVar(&config.Bridge.Iface, []string{"b", "-bridge"}, "", "Attach containers to a network bridge")
+	flag.StringVar(&config.Bridge.FixedCIDR, []string{"-fixed-cidr"}, "", "IPv4 subnet for fixed IPs")
+	flag.StringVar(&config.Bridge.FixedCIDRv6, []string{"-fixed-cidr-v6"}, "", "IPv6 subnet for fixed IPs")
+	flag.StringVar(&config.Bridge.DefaultGatewayIPv4, []string{"-default-gateway"}, "", "Container default gateway IPv4 address")
+	flag.StringVar(&config.Bridge.DefaultGatewayIPv6, []string{"-default-gateway-v6"}, "", "Container default gateway IPv6 address")
+	flag.BoolVar(&config.Bridge.InterContainerCommunication, []string{"#icc", "-icc"}, true, "Enable inter-container communication")
+	opts.IPVar(&config.Bridge.DefaultIP, []string{"#ip", "-ip"}, "0.0.0.0", "Default IP when binding container ports")
+	flag.BoolVar(&config.Bridge.EnableUserlandProxy, []string{"-userland-proxy"}, true, "Use userland proxy for loopback traffic")
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This removes the dependency of "bridge" from the Windows daemon from within api\server and daemon\config. Note there is more to do here to completely remove the dependency. This also brings back Exec and Graph options to common. @tiborvass was right :) While technically we don't have a use for them at present on Windows, the refactoring is significantly eased by leaving them in, and allowing for future usage of course. It also makes getting to the Windows daemon compiling (although non-functional) quicker.
