### PR TITLE
Changed package name to docker.io in Debian install docs

### DIFF
--- a/docs/sources/installation/debian.md
+++ b/docs/sources/installation/debian.md
@@ -41,11 +41,11 @@ container runs, it prints an informational message. Then, it exits.
 
 To uninstall the Docker package:
 
-    $ sudo apt-get purge docker-io
+    $ sudo apt-get purge docker.io
 
 To uninstall the Docker package and dependencies that are no longer needed:
 
-    $ sudo apt-get autoremove --purge docker-io
+    $ sudo apt-get autoremove --purge docker.io
 
 The above commands will not remove images, containers, volumes, or user created
 configuration files on your host. If you wish to delete all images, containers,


### PR DESCRIPTION
In the Debian installation docs there was mention of a docker-io package
upon 'apt-get purge'. This should, imo, be docker.io.

Signed-off-by: Mijndert Stuij mijndert@mijndertstuij.nl
