### PR TITLE
Windows: refactor stats

### DIFF
--- a/api/types/stats.go
+++ b/api/types/stats.go
@@ -48,6 +48,7 @@ type MemoryStats struct {
 	Limit   uint64 `json:"limit"`
 }
 
+// TODO Windows: This can be factored out
 type BlkioStatEntry struct {
 	Major uint64 `json:"major"`
 	Minor uint64 `json:"minor"`
@@ -55,6 +56,7 @@ type BlkioStatEntry struct {
 	Value uint64 `json:"value"`
 }
 
+// TODO Windows: This can be factored out
 type BlkioStats struct {
 	// number of bytes tranferred to and from the block device
 	IoServiceBytesRecursive []BlkioStatEntry `json:"io_service_bytes_recursive"`
@@ -67,6 +69,7 @@ type BlkioStats struct {
 	SectorsRecursive        []BlkioStatEntry `json:"sectors_recursive"`
 }
 
+// TODO Windows: This will require refactoring
 type Network struct {
 	RxBytes   uint64 `json:"rx_bytes"`
 	RxPackets uint64 `json:"rx_packets"`

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -4,10 +4,7 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/daemon/execdriver"
-	"github.com/docker/libcontainer"
-	"github.com/docker/libcontainer/cgroups"
 )
 
 func (daemon *Daemon) ContainerStats(name string, stream bool, out io.Writer) error {
@@ -32,71 +29,4 @@ func (daemon *Daemon) ContainerStats(name string, stream bool, out io.Writer) er
 		}
 	}
 	return nil
-}
-
-// convertToAPITypes converts the libcontainer.Stats to the api specific
-// structs.  This is done to preserve API compatibility and versioning.
-func convertToAPITypes(ls *libcontainer.Stats) *types.Stats {
-	s := &types.Stats{}
-	if ls.Interfaces != nil {
-		s.Network = types.Network{}
-		for _, iface := range ls.Interfaces {
-			s.Network.RxBytes += iface.RxBytes
-			s.Network.RxPackets += iface.RxPackets
-			s.Network.RxErrors += iface.RxErrors
-			s.Network.RxDropped += iface.RxDropped
-			s.Network.TxBytes += iface.TxBytes
-			s.Network.TxPackets += iface.TxPackets
-			s.Network.TxErrors += iface.TxErrors
-			s.Network.TxDropped += iface.TxDropped
-		}
-	}
-	cs := ls.CgroupStats
-	if cs != nil {
-		s.BlkioStats = types.BlkioStats{
-			IoServiceBytesRecursive: copyBlkioEntry(cs.BlkioStats.IoServiceBytesRecursive),
-			IoServicedRecursive:     copyBlkioEntry(cs.BlkioStats.IoServicedRecursive),
-			IoQueuedRecursive:       copyBlkioEntry(cs.BlkioStats.IoQueuedRecursive),
-			IoServiceTimeRecursive:  copyBlkioEntry(cs.BlkioStats.IoServiceTimeRecursive),
-			IoWaitTimeRecursive:     copyBlkioEntry(cs.BlkioStats.IoWaitTimeRecursive),
-			IoMergedRecursive:       copyBlkioEntry(cs.BlkioStats.IoMergedRecursive),
-			IoTimeRecursive:         copyBlkioEntry(cs.BlkioStats.IoTimeRecursive),
-			SectorsRecursive:        copyBlkioEntry(cs.BlkioStats.SectorsRecursive),
-		}
-		cpu := cs.CpuStats
-		s.CpuStats = types.CpuStats{
-			CpuUsage: types.CpuUsage{
-				TotalUsage:        cpu.CpuUsage.TotalUsage,
-				PercpuUsage:       cpu.CpuUsage.PercpuUsage,
-				UsageInKernelmode: cpu.CpuUsage.UsageInKernelmode,
-				UsageInUsermode:   cpu.CpuUsage.UsageInUsermode,
-			},
-			ThrottlingData: types.ThrottlingData{
-				Periods:          cpu.ThrottlingData.Periods,
-				ThrottledPeriods: cpu.ThrottlingData.ThrottledPeriods,
-				ThrottledTime:    cpu.ThrottlingData.ThrottledTime,
-			},
-		}
-		mem := cs.MemoryStats
-		s.MemoryStats = types.MemoryStats{
-			Usage:    mem.Usage,
-			MaxUsage: mem.MaxUsage,
-			Stats:    mem.Stats,
-			Failcnt:  mem.Failcnt,
-		}
-	}
-	return s
-}
-
-func copyBlkioEntry(entries []cgroups.BlkioStatEntry) []types.BlkioStatEntry {
-	out := make([]types.BlkioStatEntry, len(entries))
-	for i, re := range entries {
-		out[i] = types.BlkioStatEntry{
-			Major: re.Major,
-			Minor: re.Minor,
-			Op:    re.Op,
-			Value: re.Value,
-		}
-	}
-	return out
 }

--- a/daemon/stats_linux.go
+++ b/daemon/stats_linux.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/libcontainer"
+	"github.com/docker/libcontainer/cgroups"
+)
+
+// convertToAPITypes converts the libcontainer.Stats to the api specific
+// structs.  This is done to preserve API compatibility and versioning.
+func convertToAPITypes(ls *libcontainer.Stats) *types.Stats {
+	s := &types.Stats{}
+	if ls.Interfaces != nil {
+		s.Network = types.Network{}
+		for _, iface := range ls.Interfaces {
+			s.Network.RxBytes += iface.RxBytes
+			s.Network.RxPackets += iface.RxPackets
+			s.Network.RxErrors += iface.RxErrors
+			s.Network.RxDropped += iface.RxDropped
+			s.Network.TxBytes += iface.TxBytes
+			s.Network.TxPackets += iface.TxPackets
+			s.Network.TxErrors += iface.TxErrors
+			s.Network.TxDropped += iface.TxDropped
+		}
+	}
+
+	cs := ls.CgroupStats
+	if cs != nil {
+		s.BlkioStats = types.BlkioStats{
+			IoServiceBytesRecursive: copyBlkioEntry(cs.BlkioStats.IoServiceBytesRecursive),
+			IoServicedRecursive:     copyBlkioEntry(cs.BlkioStats.IoServicedRecursive),
+			IoQueuedRecursive:       copyBlkioEntry(cs.BlkioStats.IoQueuedRecursive),
+			IoServiceTimeRecursive:  copyBlkioEntry(cs.BlkioStats.IoServiceTimeRecursive),
+			IoWaitTimeRecursive:     copyBlkioEntry(cs.BlkioStats.IoWaitTimeRecursive),
+			IoMergedRecursive:       copyBlkioEntry(cs.BlkioStats.IoMergedRecursive),
+			IoTimeRecursive:         copyBlkioEntry(cs.BlkioStats.IoTimeRecursive),
+			SectorsRecursive:        copyBlkioEntry(cs.BlkioStats.SectorsRecursive),
+		}
+		cpu := cs.CpuStats
+		s.CpuStats = types.CpuStats{
+			CpuUsage: types.CpuUsage{
+				TotalUsage:        cpu.CpuUsage.TotalUsage,
+				PercpuUsage:       cpu.CpuUsage.PercpuUsage,
+				UsageInKernelmode: cpu.CpuUsage.UsageInKernelmode,
+				UsageInUsermode:   cpu.CpuUsage.UsageInUsermode,
+			},
+			ThrottlingData: types.ThrottlingData{
+				Periods:          cpu.ThrottlingData.Periods,
+				ThrottledPeriods: cpu.ThrottlingData.ThrottledPeriods,
+				ThrottledTime:    cpu.ThrottlingData.ThrottledTime,
+			},
+		}
+		mem := cs.MemoryStats
+		s.MemoryStats = types.MemoryStats{
+			Usage:    mem.Usage,
+			MaxUsage: mem.MaxUsage,
+			Stats:    mem.Stats,
+			Failcnt:  mem.Failcnt,
+		}
+	}
+
+	return s
+}
+
+func copyBlkioEntry(entries []cgroups.BlkioStatEntry) []types.BlkioStatEntry {
+	out := make([]types.BlkioStatEntry, len(entries))
+	for i, re := range entries {
+		out[i] = types.BlkioStatEntry{
+			Major: re.Major,
+			Minor: re.Minor,
+			Op:    re.Op,
+			Value: re.Value,
+		}
+	}
+	return out
+}

--- a/daemon/stats_windows.go
+++ b/daemon/stats_windows.go
@@ -1,0 +1,14 @@
+package daemon
+
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/libcontainer"
+)
+
+// convertToAPITypes converts the libcontainer.Stats to the api specific
+// structs.  This is done to preserve API compatibility and versioning.
+func convertToAPITypes(ls *libcontainer.Stats) *types.Stats {
+	// TODO Windows. Refactor accordingly to fill in stats.
+	s := &types.Stats{}
+	return s
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This removes the cgroup dependency from stats, and moves the entire stats filling out into "TODO Windows" as the current stats are not applicable in their current form to Windows Server containers. Linux behaviour is unchanged
