### PR TITLE
Windows: No unix_socket.go

### DIFF
--- a/api/server/unix_socket.go
+++ b/api/server/unix_socket.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package server
 
 import (


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. Very simple fix to not build unix_socket.go for the Windows daemon
