### PR TITLE
RestartPolicy methods instead of strings checking

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -122,7 +122,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 			fmt.Fprintf(cli.out, "%s\n", createResponse.ID)
 		}()
 	}
-	if *flAutoRemove && (hostConfig.RestartPolicy.Name == "always" || hostConfig.RestartPolicy.Name == "on-failure") {
+	if *flAutoRemove && (hostConfig.RestartPolicy.IsAlways() || hostConfig.RestartPolicy.IsOnFailure()) {
 		return ErrConflictRestartPolicyAndAutoRemove
 	}
 	// We need to instantiate the chan because the select needs it. It can

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -325,8 +325,8 @@ func (daemon *Daemon) restore() error {
 		logrus.Debug("Restarting containers...")
 
 		for _, container := range registeredContainers {
-			if container.hostConfig.RestartPolicy.Name == "always" ||
-				(container.hostConfig.RestartPolicy.Name == "on-failure" && container.ExitCode != 0) {
+			if container.hostConfig.RestartPolicy.IsAlways() ||
+				(container.hostConfig.RestartPolicy.IsOnFailure() && container.ExitCode != 0) {
 				logrus.Debugf("Starting container %s", container.ID)
 
 				if err := container.Start(); err != nil {

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -223,10 +223,10 @@ func (m *containerMonitor) shouldRestart(exitCode int) bool {
 		return false
 	}
 
-	switch m.restartPolicy.Name {
-	case "always":
+	switch {
+	case m.restartPolicy.IsAlways():
 		return true
-	case "on-failure":
+	case m.restartPolicy.IsOnFailure():
 		// the default value of 0 for MaximumRetryCount means that we will not enforce a maximum count
 		if max := m.restartPolicy.MaximumRetryCount; max != 0 && m.failureCount > max {
 			logrus.Debugf("stopping restart of container %s because maximum failure could of %d has been reached",

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -129,6 +129,18 @@ type RestartPolicy struct {
 	MaximumRetryCount int
 }
 
+func (rp *RestartPolicy) IsNone() bool {
+	return rp.Name == "no"
+}
+
+func (rp *RestartPolicy) IsAlways() bool {
+	return rp.Name == "always"
+}
+
+func (rp *RestartPolicy) IsOnFailure() bool {
+	return rp.Name == "on-failure"
+}
+
 type LogConfig struct {
 	Type   string
 	Config map[string]string


### PR DESCRIPTION
`IsNone` is added for consistency though not used anywhere now

Signed-off-by: Antonio Murdaca me@runcom.ninja
