### PR TITLE
Clean tests from not needed inspect call

### DIFF
--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -12,16 +12,10 @@ import (
 func (s *DockerSuite) TestExportContainerAndImportImage(c *check.C) {
 	containerID := "testexportcontainerandimportimage"
 
-	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", containerID, "busybox", "true")
+	runCmd := exec.Command(dockerBinary, "run", "--name", containerID, "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		c.Fatal("failed to create a container", out, err)
-	}
-
-	inspectCmd := exec.Command(dockerBinary, "inspect", containerID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	if err != nil {
-		c.Fatalf("output should've been a container id: %s %s ", containerID, err)
 	}
 
 	exportCmd := exec.Command(dockerBinary, "export", containerID)
@@ -37,28 +31,19 @@ func (s *DockerSuite) TestExportContainerAndImportImage(c *check.C) {
 	}
 
 	cleanedImageID := strings.TrimSpace(out)
-
-	inspectCmd = exec.Command(dockerBinary, "inspect", cleanedImageID)
-	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
-		c.Fatalf("output should've been an image id: %s, %v", out, err)
+	if cleanedImageID == "" {
+		c.Fatalf("output should have been an image id, got: %s", out)
 	}
-
 }
 
 // Used to test output flag in the export command
 func (s *DockerSuite) TestExportContainerWithOutputAndImportImage(c *check.C) {
 	containerID := "testexportcontainerwithoutputandimportimage"
 
-	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", containerID, "busybox", "true")
+	runCmd := exec.Command(dockerBinary, "run", "--name", containerID, "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		c.Fatal("failed to create a container", out, err)
-	}
-
-	inspectCmd := exec.Command(dockerBinary, "inspect", containerID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	if err != nil {
-		c.Fatalf("output should've been a container id: %s %s ", containerID, err)
 	}
 
 	defer os.Remove("testexp.tar")
@@ -81,10 +66,7 @@ func (s *DockerSuite) TestExportContainerWithOutputAndImportImage(c *check.C) {
 	}
 
 	cleanedImageID := strings.TrimSpace(out)
-
-	inspectCmd = exec.Command(dockerBinary, "inspect", cleanedImageID)
-	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
-		c.Fatalf("output should've been an image id: %s, %v", out, err)
+	if cleanedImageID == "" {
+		c.Fatalf("output should have been an image id, got: %s", out)
 	}
-
 }

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -15,11 +15,7 @@ func (s *DockerSuite) TestKillContainer(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-
-	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
-		c.Fatalf("out should've been a container id: %s, %v", out, err)
-	}
+	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 
 	killCmd := exec.Command(dockerBinary, "kill", cleanedContainerID)
 	if out, _, err = runCommandWithOutput(killCmd); err != nil {
@@ -48,11 +44,7 @@ func (s *DockerSuite) TestKillDifferentUserContainer(c *check.C) {
 	}
 
 	cleanedContainerID := strings.TrimSpace(out)
-
-	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
-		c.Fatalf("out should've been a container id: %s, %v", out, err)
-	}
+	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 
 	killCmd := exec.Command(dockerBinary, "kill", cleanedContainerID)
 	if out, _, err = runCommandWithOutput(killCmd); err != nil {

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -186,12 +186,6 @@ func (s *DockerSuite) TestRunStdinPipe(c *check.C) {
 	}
 
 	out = strings.TrimSpace(out)
-
-	inspectCmd := exec.Command(dockerBinary, "inspect", out)
-	if out, _, err := runCommandWithOutput(inspectCmd); err != nil {
-		c.Fatalf("out should've been a container id: %s %v", out, err)
-	}
-
 	waitCmd := exec.Command(dockerBinary, "wait", out)
 	if waitOut, _, err := runCommandWithOutput(waitCmd); err != nil {
 		c.Fatalf("error thrown while waiting for container: %s, %v", waitOut, err)
@@ -224,12 +218,6 @@ func (s *DockerSuite) TestRunDetachedContainerIDPrinting(c *check.C) {
 	}
 
 	out = strings.TrimSpace(out)
-
-	inspectCmd := exec.Command(dockerBinary, "inspect", out)
-	if inspectOut, _, err := runCommandWithOutput(inspectCmd); err != nil {
-		c.Fatalf("out should've been a container id: %s %v", inspectOut, err)
-	}
-
 	waitCmd := exec.Command(dockerBinary, "wait", out)
 	if waitOut, _, err := runCommandWithOutput(waitCmd); err != nil {
 		c.Fatalf("error thrown while waiting for container: %s, %v", waitOut, err)

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -15,29 +15,22 @@ import (
 
 // save a repo using gz compression and try to load it using stdout
 func (s *DockerSuite) TestSaveXzAndLoadRepoStdout(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
+	name := "test-save-xz-and-load-repo-stdout"
+	runCmd := exec.Command(dockerBinary, "run", "--name", name, "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		c.Fatalf("failed to create a container: %v %v", out, err)
 	}
 
-	cleanedContainerID := strings.TrimSpace(out)
-
 	repoName := "foobar-save-load-test-xz-gz"
 
-	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	if err != nil {
-		c.Fatalf("output should've been a container id: %v %v", cleanedContainerID, err)
-	}
-
-	commitCmd := exec.Command(dockerBinary, "commit", cleanedContainerID, repoName)
+	commitCmd := exec.Command(dockerBinary, "commit", name, repoName)
 	out, _, err = runCommandWithOutput(commitCmd)
 	if err != nil {
 		c.Fatalf("failed to commit container: %v %v", out, err)
 	}
 
-	inspectCmd = exec.Command(dockerBinary, "inspect", repoName)
+	inspectCmd := exec.Command(dockerBinary, "inspect", repoName)
 	before, _, err := runCommandWithOutput(inspectCmd)
 	if err != nil {
 		c.Fatalf("the repo should exist before saving it: %v %v", before, err)
@@ -71,29 +64,22 @@ func (s *DockerSuite) TestSaveXzAndLoadRepoStdout(c *check.C) {
 
 // save a repo using xz+gz compression and try to load it using stdout
 func (s *DockerSuite) TestSaveXzGzAndLoadRepoStdout(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
+	name := "test-save-xz-gz-and-load-repo-stdout"
+	runCmd := exec.Command(dockerBinary, "run", "--name", name, "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		c.Fatalf("failed to create a container: %v %v", out, err)
 	}
 
-	cleanedContainerID := strings.TrimSpace(out)
-
 	repoName := "foobar-save-load-test-xz-gz"
 
-	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	if err != nil {
-		c.Fatalf("output should've been a container id: %v %v", cleanedContainerID, err)
-	}
-
-	commitCmd := exec.Command(dockerBinary, "commit", cleanedContainerID, repoName)
+	commitCmd := exec.Command(dockerBinary, "commit", name, repoName)
 	out, _, err = runCommandWithOutput(commitCmd)
 	if err != nil {
 		c.Fatalf("failed to commit container: %v %v", out, err)
 	}
 
-	inspectCmd = exec.Command(dockerBinary, "inspect", repoName)
+	inspectCmd := exec.Command(dockerBinary, "inspect", repoName)
 	before, _, err := runCommandWithOutput(inspectCmd)
 	if err != nil {
 		c.Fatalf("the repo should exist before saving it: %v %v", before, err)
@@ -121,10 +107,6 @@ func (s *DockerSuite) TestSaveXzGzAndLoadRepoStdout(c *check.C) {
 	if err == nil {
 		c.Fatalf("the repo should not exist: %v", after)
 	}
-
-	deleteContainer(cleanedContainerID)
-	deleteImages(repoName)
-
 }
 
 func (s *DockerSuite) TestSaveSingleTag(c *check.C) {
@@ -207,28 +189,21 @@ func (s *DockerSuite) TestSaveImageId(c *check.C) {
 
 // save a repo and try to load it using flags
 func (s *DockerSuite) TestSaveAndLoadRepoFlags(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
+	name := "test-save-and-load-repo-flags"
+	runCmd := exec.Command(dockerBinary, "run", "--name", name, "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		c.Fatalf("failed to create a container: %s, %v", out, err)
 	}
-
-	cleanedContainerID := strings.TrimSpace(out)
-
 	repoName := "foobar-save-load-test"
 
-	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
-		c.Fatalf("output should've been a container id: %s, %v", out, err)
-	}
-
-	commitCmd := exec.Command(dockerBinary, "commit", cleanedContainerID, repoName)
+	commitCmd := exec.Command(dockerBinary, "commit", name, repoName)
 	deleteImages(repoName)
 	if out, _, err = runCommandWithOutput(commitCmd); err != nil {
 		c.Fatalf("failed to commit container: %s, %v", out, err)
 	}
 
-	inspectCmd = exec.Command(dockerBinary, "inspect", repoName)
+	inspectCmd := exec.Command(dockerBinary, "inspect", repoName)
 	before, _, err := runCommandWithOutput(inspectCmd)
 	if err != nil {
 		c.Fatalf("the repo should exist before saving it: %s, %v", before, err)
@@ -251,7 +226,6 @@ func (s *DockerSuite) TestSaveAndLoadRepoFlags(c *check.C) {
 	if before != after {
 		c.Fatalf("inspect is not the same after a save / load")
 	}
-
 }
 
 func (s *DockerSuite) TestSaveMultipleNames(c *check.C) {

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/docker/docker/vendor/src/github.com/kr/pty"
 	"github.com/go-check/check"
@@ -15,27 +14,21 @@ import (
 
 // save a repo and try to load it using stdout
 func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
+	name := "test-save-and-load-repo-stdout"
+	runCmd := exec.Command(dockerBinary, "run", "--name", name, "busybox", "true")
 	out, _, err := runCommandWithOutput(runCmd)
 	if err != nil {
 		c.Fatalf("failed to create a container: %s, %v", out, err)
 	}
 
-	cleanedContainerID := strings.TrimSpace(out)
-
 	repoName := "foobar-save-load-test"
 
-	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
-		c.Fatalf("output should've been a container id: %s, %v", out, err)
-	}
-
-	commitCmd := exec.Command(dockerBinary, "commit", cleanedContainerID, repoName)
+	commitCmd := exec.Command(dockerBinary, "commit", name, repoName)
 	if out, _, err = runCommandWithOutput(commitCmd); err != nil {
 		c.Fatalf("failed to commit container: %s, %v", out, err)
 	}
 
-	inspectCmd = exec.Command(dockerBinary, "inspect", repoName)
+	inspectCmd := exec.Command(dockerBinary, "inspect", repoName)
 	before, _, err := runCommandWithOutput(inspectCmd)
 	if err != nil {
 		c.Fatalf("the repo should exist before saving it: %s, %v", before, err)
@@ -66,7 +59,6 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 		c.Fatalf("inspect is not the same after a save / load")
 	}
 
-	deleteContainer(cleanedContainerID)
 	deleteImages(repoName)
 
 	os.Remove("/tmp/foobar-save-load-test.tar")


### PR DESCRIPTION
I'm not suuuper sure about this but these calls seem really not needed because, I don't know, what are these checking? Seems like a call to check the container was created but I think it isn't needed cause the next calls with reference to a not created container would fail anyway. In case I'm wrong I'll close this of course.
kinda related to #13279

Signed-off-by: Antonio Murdaca me@runcom.ninja
