### PR TITLE
Remove use of 'bash' from our tests

### DIFF
--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -69,7 +69,8 @@ func (s *DockerSuite) TestInspectImageFilterInt(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectContainerFilterInt(c *check.C) {
-	runCmd := exec.Command("bash", "-c", `echo "blahblah" | docker run -i -a stdin busybox cat`)
+	runCmd := exec.Command(dockerBinary, "run", "-i", "-a", "stdin", "busybox", "cat")
+	runCmd.Stdin = strings.NewReader("blahblah")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
 		c.Fatalf("failed to run container: %v, output: %q", err, out)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -179,7 +179,8 @@ func (s *DockerSuite) TestRunExitCodeOne(c *check.C) {
 // it should be possible to pipe in data via stdin to a process running in a container
 // some versions of lxc might make this test fail
 func (s *DockerSuite) TestRunStdinPipe(c *check.C) {
-	runCmd := exec.Command("bash", "-c", `echo "blahblah" | docker run -i -a stdin busybox cat`)
+	runCmd := exec.Command(dockerBinary, "run", "-i", "-a", "stdin", "busybox", "cat")
+	runCmd.Stdin = strings.NewReader("blahblah")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
 		c.Fatalf("failed to run container: %v, output: %q", err, out)

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"bytes"
-	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -41,17 +41,25 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 		c.Fatalf("the repo should exist before saving it: %s, %v", before, err)
 	}
 
-	saveCmdTemplate := `%v save %v > /tmp/foobar-save-load-test.tar`
-	saveCmdFinal := fmt.Sprintf(saveCmdTemplate, dockerBinary, repoName)
-	saveCmd := exec.Command("bash", "-c", saveCmdFinal)
-	if out, _, err = runCommandWithOutput(saveCmd); err != nil {
-		c.Fatalf("failed to save repo: %s, %v", out, err)
+	tmpFile, err := ioutil.TempFile("", "foobar-save-load-test.tar")
+	c.Assert(err, check.IsNil)
+	defer os.Remove(tmpFile.Name())
+
+	saveCmd := exec.Command(dockerBinary, "save", repoName)
+	saveCmd.Stdout = tmpFile
+
+	if _, err = runCommand(saveCmd); err != nil {
+		c.Fatalf("failed to save repo: %v", err)
 	}
+
+	tmpFile, err = os.Open(tmpFile.Name())
+	c.Assert(err, check.IsNil)
 
 	deleteImages(repoName)
 
-	loadCmdFinal := `cat /tmp/foobar-save-load-test.tar | docker load`
-	loadCmd := exec.Command("bash", "-c", loadCmdFinal)
+	loadCmd := exec.Command(dockerBinary, "load")
+	loadCmd.Stdin = tmpFile
+
 	if out, _, err = runCommandWithOutput(loadCmd); err != nil {
 		c.Fatalf("failed to load repo: %s, %v", out, err)
 	}
@@ -68,8 +76,6 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 
 	deleteContainer(cleanedContainerID)
 	deleteImages(repoName)
-
-	os.Remove("/tmp/foobar-save-load-test.tar")
 
 	pty, tty, err := pty.Open()
 	if err != nil {


### PR DESCRIPTION
Not 100% sure why our Windows test don't complain about some of these,
I'm guessing its because we have bash as part of some git package, but
either way we really shouldn't require bash to run our tests unless we
really need to - which in these cases we don't

Signed-off-by: Doug Davis dug@us.ibm.com
