### PR TITLE
Windows: NewDriver() re-baseline parms

### DIFF
--- a/daemon/execdriver/execdrivers/execdrivers_windows.go
+++ b/daemon/execdriver/execdrivers/execdrivers_windows.go
@@ -10,7 +10,7 @@ import (
 	"github.com/docker/docker/pkg/sysinfo"
 )
 
-func NewDriver(name, root, libPath, initPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
+func NewDriver(name string, options []string, root, libPath, initPath string, sysInfo *sysinfo.SysInfo) (execdriver.Driver, error) {
 	switch name {
 	case "windows":
 		return windows.NewDriver(root, initPath)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli @jfrazelle 

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This fixes the parameters to NewDriver() for the Windows execdrivers. This was changed on Linux through commit id 2afcd10202283478cbafb21e8c5f90f1236acccc - this just brings Windows back in line to master
