### PR TITLE
Windows: Simple import error on config_windows.go

### DIFF
--- a/daemon/config_windows.go
+++ b/daemon/config_windows.go
@@ -2,8 +2,6 @@ package daemon
 
 import (
 	"os"
-
-	flag "github.com/docker/docker/pkg/mflag"
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. This fixes the imports on config_windows.go so that it will compile with the Windows daemon. Trivial fix.
