### PR TITLE
Fix to pass runconfig.LogConfig.Config to constructor of logging drivers

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1463,7 +1463,7 @@ func (container *Container) getLogger() (logger.Logger, error) {
 			return nil, err
 		}
 	}
-	return c(ctx)
+	return c(ctx, cfg.Config)
 }
 
 func (container *Container) startLogging() error {

--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Creator is a method that builds a logging driver instance with given context
-type Creator func(Context) (Logger, error)
+type Creator func(Context, map[string]string) (Logger, error)
 
 // Context provides enough information for a logging driver to do its function
 type Context struct {

--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -23,7 +23,7 @@ func init() {
 	}
 }
 
-func New(ctx logger.Context) (logger.Logger, error) {
+func New(ctx logger.Context, config map[string]string) (logger.Logger, error) {
 	if !journal.Enabled() {
 		return nil, fmt.Errorf("journald is not enabled on this host")
 	}

--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 // New creates new JSONFileLogger which writes to filename
-func New(ctx logger.Context) (logger.Logger, error) {
+func New(ctx logger.Context, config map[string]string) (logger.Logger, error) {
 	log, err := os.OpenFile(ctx.LogPath, os.O_RDWR|os.O_APPEND|os.O_CREATE, 0600)
 	if err != nil {
 		return nil, err

--- a/daemon/logger/jsonfilelog/jsonfilelog_test.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog_test.go
@@ -22,7 +22,7 @@ func TestJSONFileLogger(t *testing.T) {
 	l, err := New(logger.Context{
 		ContainerID: cid,
 		LogPath:     filename,
-	})
+	}, map[string]string{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func BenchmarkJSONFileLogger(b *testing.B) {
 	l, err := New(logger.Context{
 		ContainerID: cid,
 		LogPath:     filename,
-	})
+	}, map[string]string{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -25,7 +25,7 @@ func init() {
 	}
 }
 
-func New(ctx logger.Context) (logger.Logger, error) {
+func New(ctx logger.Context, config map[string]string) (logger.Logger, error) {
 	tag := ctx.ContainerID[:12]
 	log, err := syslog.New(syslog.LOG_DAEMON, fmt.Sprintf("%s/%s", path.Base(os.Args[0]), tag))
 	if err != nil {


### PR DESCRIPTION
There are no way to get values specified with `--log-opt` on #12226 .
This pull-request is to add an argument to pass it.
