### PR TITLE
Add bridge-nf-call-iptables/bridge-nf-call-ipv6tables to docker info

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -76,6 +76,12 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	if !info.IPv4Forwarding {
 		fmt.Fprintf(cli.err, "WARNING: IPv4 forwarding is disabled.\n")
 	}
+	if !info.BridgeNfIptables {
+		fmt.Fprintf(cli.err, "WARNING: bridge-nf-call-iptables is disabled\n")
+	}
+	if !info.BridgeNfIp6tables {
+		fmt.Fprintf(cli.err, "WARNING: bridge-nf-call-ip6tables is disabled\n")
+	}
 	if info.Labels != nil {
 		fmt.Fprintln(cli.out, "Labels:")
 		for _, attribute := range info.Labels {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -153,6 +153,8 @@ type Info struct {
 	CpuCfsPeriod       bool
 	CpuCfsQuota        bool
 	IPv4Forwarding     bool
+	BridgeNfIptables   bool
+	BridgeNfIp6tables  bool
 	Debug              bool
 	NFd                int
 	OomKillDisable     bool

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -67,6 +67,8 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		CpuCfsPeriod:       daemon.SystemConfig().CpuCfsPeriod,
 		CpuCfsQuota:        daemon.SystemConfig().CpuCfsQuota,
 		IPv4Forwarding:     !daemon.SystemConfig().IPv4ForwardingDisabled,
+		BridgeNfIptables:   !daemon.SystemConfig().BridgeNfCallIptablesDisabled,
+		BridgeNfIp6tables:  !daemon.SystemConfig().BridgeNfCallIp6tablesDisabled,
 		Debug:              os.Getenv("DEBUG") != "",
 		NFd:                fileutils.GetTotalUsedFds(),
 		OomKillDisable:     daemon.SystemConfig().OomKillDisable,

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -3,11 +3,13 @@ package sysinfo
 // SysInfo stores information about which features a kernel supports.
 // TODO Windows: Factor out platform specific capabilities.
 type SysInfo struct {
-	MemoryLimit            bool
-	SwapLimit              bool
-	CpuCfsPeriod           bool
-	CpuCfsQuota            bool
-	IPv4ForwardingDisabled bool
-	AppArmor               bool
-	OomKillDisable         bool
+	MemoryLimit                   bool
+	SwapLimit                     bool
+	CpuCfsPeriod                  bool
+	CpuCfsQuota                   bool
+	IPv4ForwardingDisabled        bool
+	AppArmor                      bool
+	OomKillDisable                bool
+	BridgeNfCallIptablesDisabled  bool
+	BridgeNfCallIp6tablesDisabled bool
 }

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -63,6 +63,21 @@ func New(quiet bool) *SysInfo {
 		}
 	}
 
+	// Check if bridge-nf-call-iptables is disabled.
+	if data, err := ioutil.ReadFile("/proc/sys/net/bridge/bridge-nf-call-iptables"); os.IsNotExist(err) {
+		sysInfo.BridgeNfCallIptablesDisabled = true
+	} else {
+		enabled, _ := strconv.Atoi(strings.TrimSpace(string(data)))
+		sysInfo.BridgeNfCallIptablesDisabled = enabled == 0
+	}
+	// Check if bridge-nf-call-ip6tables is disabled.
+	if data, err := ioutil.ReadFile("/proc/sys/net/bridge/bridge-nf-call-ip6tables"); os.IsNotExist(err) {
+		sysInfo.BridgeNfCallIp6tablesDisabled = true
+	} else {
+		enabled, _ := strconv.Atoi(strings.TrimSpace(string(data)))
+		sysInfo.BridgeNfCallIp6tablesDisabled = enabled == 0
+	}
+
 	// Check if AppArmor is supported.
 	if _, err := os.Stat("/sys/kernel/security/apparmor"); os.IsNotExist(err) {
 		sysInfo.AppArmor = false


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
Enable inter-container communication need enable `bridge-nf-call-iptables` and 
`bridge-nf-call-ip6table`(ipv6 package). Add these params to docker info to 
tell the user if icc is enable and disabled on this host.
#11405 will check these params on docker daemon starting, but we still need

a interface to tell the user if these has enabled or not just like we do on `ip_forward`
