### PR TITLE
Fix restart docker daemon with paused containers

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1570,3 +1570,41 @@ func (s *DockerDaemonSuite) TestDaemonWideLogConfig(c *check.C) {
 		c.Fatalf("Unexpected log-opt: %s, expected map[max-size:1k]", cfg)
 	}
 }
+
+func (s *DockerDaemonSuite) TestDaemonRestartWithPausedContainer(c *check.C) {
+	if err := s.d.StartWithBusybox(); err != nil {
+		c.Fatal(err)
+	}
+	if out, err := s.d.Cmd("run", "-i", "-d", "--name", "test", "busybox", "top"); err != nil {
+		c.Fatal(err, out)
+	}
+	if out, err := s.d.Cmd("pause", "test"); err != nil {
+		c.Fatal(err, out)
+	}
+	if err := s.d.Restart(); err != nil {
+		c.Fatal(err)
+	}
+
+	errchan := make(chan error)
+	go func() {
+		out, err := s.d.Cmd("start", "test")
+		if err != nil {
+			errchan <- fmt.Errorf("%v:\n%s", err, out)
+		}
+		name := strings.TrimSpace(out)
+		if name != "test" {
+			errchan <- fmt.Errorf("Paused container start error on docker daemon restart, expected 'test' but got '%s'", name)
+		}
+		close(errchan)
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		c.Fatal("Waiting on start a container timed out")
+	case err := <-errchan:
+		if err != nil {
+			c.Fatal(err)
+		}
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

I think this is better fix than #12802 .
Restarting docker daemon with paused containers really caused a big problem,
the paused containers will can't be start on docker daemon restart, and if the 
paused containers happened to have a restart policy `restart=always`, the daemon will hang.
So, I think we should prevent these from happening. 
This fix is to send 15 to container and then unpause it, this is just what
the kernel designed for. If we want terminate a process in freezer cgroup,
we should send terminate signal to this process and then unfreeze it, and then this process will
terminate. In this way, it will not case unsafe problem.
ping @LK4D4 @aluzzardi @tiborvass @jfrazelle @cpuguy83 
cc @lexandro 

But if we just want to keep it work like it does today, pls feel free to close  :)
