### PR TITLE
Pass --log-opts map to logdrivers

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1452,6 +1452,7 @@ func (container *Container) getLogger() (logger.Logger, error) {
 		return nil, fmt.Errorf("Failed to get logging factory: %v", err)
 	}
 	ctx := logger.Context{
+		Config:        cfg.Config,
 		ContainerID:   container.ID,
 		ContainerName: container.Name,
 	}

--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -10,6 +10,7 @@ type Creator func(Context) (Logger, error)
 
 // Context provides enough information for a logging driver to do its function
 type Context struct {
+	Config        map[string]string
 	ContainerID   string
 	ContainerName string
 	LogPath       string


### PR DESCRIPTION
This change passes the `--log-opts` map to the each log driver's constructor through `logger.Context`.

cc: @LK4D4 @tagomoris
