### PR TITLE
Make docker ps --size show virtual size really work

### DIFF
--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -336,7 +336,7 @@ func (container *Container) GetSize() (int64, int64) {
 		sizeRw = -1
 	}
 
-	if _, err = os.Stat(container.basefs); err != nil {
+	if _, err = os.Stat(container.basefs); err == nil {
 		if sizeRootfs, err = directory.Size(container.basefs); err != nil {
 			sizeRootfs = -1
 		}

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -304,7 +304,7 @@ func (s *DockerSuite) TestPsListContainersSize(c *check.C) {
 	}
 	expectedSize := fmt.Sprintf("%d B", (2 + baseBytes))
 	foundSize := lines[1][sizeIndex:]
-	if foundSize != expectedSize {
+	if !strings.Contains(foundSize, expectedSize) {
 		c.Fatalf("Expected size %q, got %q", expectedSize, foundSize)
 	}
 
@@ -665,4 +665,18 @@ func (s *DockerSuite) TestPsGroupPortRange(c *check.C) {
 		c.Fatalf("docker ps output should have had the port range %q: %s", portRange, string(out))
 	}
 
+}
+
+func (s *DockerSuite) TestPsWithSize(c *check.C) {
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "--name", "sizetest", "busybox", "top"))
+	if err != nil {
+		c.Fatal(out, err)
+	}
+	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "ps", "--size"))
+	if err != nil {
+		c.Fatal(out, err)
+	}
+	if !strings.Contains(out, "virtual") {
+		c.Fatalf("docker ps with --size should show virtual size of container")
+	}
 }


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

`docker ps --size` is desired to show the virtual size of the container,
the virtual size is an important value because it is the size of the `docker export`
content. But the previous code make this never work due to the wrong logical
judge. 
