### PR TITLE
Add docker stats --no-stream show cpu usage

### DIFF
--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -46,7 +46,6 @@ func (s *containerStats) Collect(cli *DockerCli, streamStats bool) {
 	var (
 		previousCPU    uint64
 		previousSystem uint64
-		start          = true
 		dec            = json.NewDecoder(stream)
 		u              = make(chan error, 1)
 	)
@@ -61,10 +60,9 @@ func (s *containerStats) Collect(cli *DockerCli, streamStats bool) {
 				memPercent = float64(v.MemoryStats.Usage) / float64(v.MemoryStats.Limit) * 100.0
 				cpuPercent = 0.0
 			)
-			if !start {
-				cpuPercent = calculateCPUPercent(previousCPU, previousSystem, v)
-			}
-			start = false
+			previousCPU = v.PreCpuStats.CpuUsage.TotalUsage
+			previousSystem = v.PreCpuStats.SystemUsage
+			cpuPercent = calculateCPUPercent(previousCPU, previousSystem, v)
 			s.mu.Lock()
 			s.CPUPercentage = cpuPercent
 			s.Memory = float64(v.MemoryStats.Usage)
@@ -73,8 +71,6 @@ func (s *containerStats) Collect(cli *DockerCli, streamStats bool) {
 			s.NetworkRx = float64(v.Network.RxBytes)
 			s.NetworkTx = float64(v.Network.TxBytes)
 			s.mu.Unlock()
-			previousCPU = v.CpuStats.CpuUsage.TotalUsage
-			previousSystem = v.CpuStats.SystemUsage
 			u <- nil
 			if !streamStats {
 				return
@@ -151,7 +147,7 @@ func (cli *DockerCli) CmdStats(args ...string) error {
 	}
 	// do a quick pause so that any failed connections for containers that do not exist are able to be
 	// evicted before we display the initial or default values.
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(1500 * time.Millisecond)
 	var errs []string
 	for _, c := range cStats {
 		c.mu.Lock()

--- a/api/types/stats.go
+++ b/api/types/stats.go
@@ -84,6 +84,7 @@ type Network struct {
 type Stats struct {
 	Read        time.Time   `json:"read"`
 	Network     Network     `json:"network,omitempty"`
+	PreCpuStats CpuStats    `json:"precpu_stats,omitempty"`
 	CpuStats    CpuStats    `json:"cpu_stats,omitempty"`
 	MemoryStats MemoryStats `json:"memory_stats,omitempty"`
 	BlkioStats  BlkioStats  `json:"blkio_stats,omitempty"`

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -2,9 +2,9 @@ package daemon
 
 import (
 	"encoding/json"
-	"io"
-
+	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/daemon/execdriver"
+	"io"
 )
 
 func (daemon *Daemon) ContainerStats(name string, stream bool, out io.Writer) error {
@@ -12,13 +12,23 @@ func (daemon *Daemon) ContainerStats(name string, stream bool, out io.Writer) er
 	if err != nil {
 		return err
 	}
+	var pre_cpu_stats types.CpuStats
+	for first_v := range updates {
+		first_update := first_v.(*execdriver.ResourceStats)
+		first_stats := convertToAPITypes(first_update.Stats)
+		pre_cpu_stats = first_stats.CpuStats
+		pre_cpu_stats.SystemUsage = first_update.SystemUsage
+		break
+	}
 	enc := json.NewEncoder(out)
 	for v := range updates {
 		update := v.(*execdriver.ResourceStats)
 		ss := convertToAPITypes(update.Stats)
+		ss.PreCpuStats = pre_cpu_stats
 		ss.MemoryStats.Limit = uint64(update.MemoryLimit)
 		ss.Read = update.Read
 		ss.CpuStats.SystemUsage = update.SystemUsage
+		pre_cpu_stats = ss.CpuStats
 		if err := enc.Encode(ss); err != nil {
 			// TODO: handle the specific broken pipe
 			daemon.UnsubscribeToContainerStats(name, updates)

--- a/integration-cli/docker_api_stats.go
+++ b/integration-cli/docker_api_stats.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/docker/docker/api/types"
+	"github.com/go-check/check"
+	"strings"
+	"time"
+)
+
+func (s *DockerSuite) TestCliStatsNoStreamGetCpu(c *check.C) {
+	out, _ := dockerCmd(c, "run", "-d", "--cpu-quota=2000", "busybox", "/bin/sh", "-c", "while true;do echo 'Hello';done")
+
+	id := strings.TrimSpace(out)
+	if err := waitRun(id); err != nil {
+		c.Fatal(err)
+	}
+	ch := make(chan error)
+	var v *types.Stats
+	go func() {
+		_, body, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=1", id), nil, "")
+		if err != nil {
+			ch <- err
+		}
+		dec := json.NewDecoder(body)
+		if err := dec.Decode(&v); err != nil {
+			ch <- err
+		}
+		ch <- nil
+	}()
+	select {
+	case e := <-ch:
+		if e == nil {
+			var cpuPercent = 0.0
+			cpuDelta := float64(v.CpuStats.CpuUsage.TotalUsage - v.PreCpuStats.CpuUsage.TotalUsage)
+			systemDelta := float64(v.CpuStats.SystemUsage - v.PreCpuStats.SystemUsage)
+			cpuPercent = (cpuDelta / systemDelta) * float64(len(v.CpuStats.CpuUsage.PercpuUsage)) * 100.0
+			if cpuPercent < 1.8 || cpuPercent > 2.2 {
+				c.Fatal("docker stats with no-stream get cpu usage failed")
+			}
+
+		}
+	case <-time.After(4 * time.Second):
+		c.Fatal("docker stats with no-stream timeout")
+	}
+
+}

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -29,7 +29,7 @@ func (s *DockerSuite) TestCliStatsNoStream(c *check.C) {
 		if err != nil {
 			c.Fatalf("Error running stats: %v", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(3 * time.Second):
 		statsCmd.Process.Kill()
 		c.Fatalf("stats did not return immediately when not streaming")
 	}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

The `CPU %` of `docker stats --no-stream` is always `0.0`
even though the real time cpu usage is not zero of the container.
It's quite weird or misleading when user what use `docker stats --no-stream`
to get the cpu usage of the container. This PR add docker stats --no-stream to
show the cpu usage.

Before:

<pre><code>[l00284783@localhost ~]$ docker stats --no-stream abc
CONTAINER           CPU %               MEM USAGE/LIMIT     MEM %               NET I/O
abc                 0.00%               196.6 kB/4.143 GB   0.00%               734 B/258 B</code></pre>


After:

<pre><code>[l00284783@localhost ~]$ docker stats --no-stream abc
CONTAINER           CPU %               MEM USAGE/LIMIT     MEM %               NET I/O
abc                 5.07%               200.7 kB/4.143 GB   0.00%               664 B/258 B
</code></pre>


ping @cpuguy83 
