### PR TITLE
Make version check return 400 instead of 404

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1426,7 +1426,7 @@ func makeHttpHandler(logging bool, localMethod string, localRoute string, handle
 		}
 
 		if version.GreaterThan(api.APIVERSION) {
-			http.Error(w, fmt.Errorf("client and server don't have same version (client API version: %s, server API version: %s)", version, api.APIVERSION).Error(), http.StatusNotFound)
+			http.Error(w, fmt.Errorf("client and server don't have same version (client API version: %s, server API version: %s)", version, api.APIVERSION).Error(), http.StatusBadRequest)
 			return
 		}
 

--- a/docs/sources/reference/api/docker_remote_api.md
+++ b/docs/sources/reference/api/docker_remote_api.md
@@ -46,6 +46,11 @@ You can still call an old version of the API using
 
 ### What's new
 
+**New!**
+When the daemon detects a version mismatch with the client, usually when
+the client is newer than the daemon, an HTTP 400 is now returned instead
+of a 404.
+
 `GET /containers/(id)/stats`
 
 **New!**

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -13,6 +13,8 @@ page_keywords: API, Docker, rcli, REST, documentation
  - The API tends to be REST, but for some complex commands, like `attach`
    or `pull`, the HTTP connection is hijacked to transport `STDOUT`,
    `STDIN` and `STDERR`.
+ - When the client API version is newer than the daemon's an HTTP
+   `400 Bad Request` error message is returned.
 
 # 2. Endpoints
 

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"net/http"
+	"net/http/httputil"
+	"time"
 
 	"github.com/go-check/check"
 )
@@ -22,4 +24,19 @@ func (s *DockerSuite) TestApiGetEnabledCors(c *check.C) {
 	//c.Log(res.Header)
 	//c.Assert(res.Header.Get("Access-Control-Allow-Origin"), check.Equals, "*")
 	//c.Assert(res.Header.Get("Access-Control-Allow-Headers"), check.Equals, "Origin, X-Requested-With, Content-Type, Accept, X-Registry-Auth")
+}
+
+func (s *DockerSuite) TestVersionStatusCode(c *check.C) {
+	conn, err := sockConn(time.Duration(10 * time.Second))
+	c.Assert(err, check.IsNil)
+
+	client := httputil.NewClientConn(conn, nil)
+	defer client.Close()
+
+	req, err := http.NewRequest("GET", "/v999.0/version", nil)
+	c.Assert(err, check.IsNil)
+	req.Header.Set("User-Agent", "Docker-Client/999.0")
+
+	res, err := client.Do(req)
+	c.Assert(res.StatusCode, check.Equals, http.StatusBadRequest)
 }


### PR DESCRIPTION
Because 404 is just wrong 

Closes: #13321

Signed-off-by: Doug Davis dug@us.ibm.com
