### PR TITLE
Fix Put without Get in overlay

### DIFF
--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -318,6 +318,14 @@ func (d *Driver) Put(id string) error {
 	mount := d.active[id]
 	if mount == nil {
 		logrus.Debugf("Put on a non-mounted device %s", id)
+		// but it might be still here
+		if d.Exists(id) {
+			mergedDir := path.Join(d.dir(id), "merged")
+			err := syscall.Unmount(mergedDir, 0)
+			if err != nil {
+				logrus.Debugf("Failed to unmount %s overlay: %v", id, err)
+			}
+		}
 		return nil
 	}
 


### PR DESCRIPTION
It is called for example on daemon start after crash
It prevents spoiling system with overlay mounts.
