### PR TITLE
Fix "squeeze" detection in contrib/mkimage/debootstrap

### DIFF
--- a/contrib/mkimage/debootstrap
+++ b/contrib/mkimage/debootstrap
@@ -176,11 +176,19 @@ if [ -z "$DONT_TOUCH_SOURCES_LIST" ]; then
 						s/ $suite / ${suite}-updates /
 					" "$rootfsDir/etc/apt/sources.list"
 					echo "deb http://security.debian.org $suite/updates main" >> "$rootfsDir/etc/apt/sources.list"
-					# LTS
-					if [ "$suite" = 'squeeze' -o "$suite" = 'oldstable' ]; then
-						head -1 "$rootfsDir/etc/apt/sources.list" \
-							| sed "s/ $suite / squeeze-lts /" \
-								>> "$rootfsDir/etc/apt/sources.list"
+					# squeeze-lts
+					if [ -f "$rootfsDir/etc/debian_version" ]; then
+						ltsSuite=
+						case "$(cat "$rootfsDir/etc/debian_version")" in
+							6.*) ltsSuite='squeeze-lts' ;;
+							#7.*) ltsSuite='wheezy-lts' ;;
+							#8.*) ltsSuite='jessie-lts' ;;
+						esac
+						if [ "$ltsSuite" ]; then
+							head -1 "$rootfsDir/etc/apt/sources.list" \
+								| sed "s/ $suite / $ltsSuite /" \
+									>> "$rootfsDir/etc/apt/sources.list"
+						fi
 					fi
 				)
 			fi


### PR DESCRIPTION
This stops us from erroneously adding "squeeze-lts" to "oldstable" which is now "wheezy", not "squeeze" (but "oldoldstable" _is_ squeeze, hence the new check on `/etc/debian_version` being `6.*` instead, and done as a `case` for the eventual addition of `wheezy-lts`, etc).
