### PR TITLE
Fix unit-test build error on ARM64

### DIFF
--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -873,7 +873,8 @@ func getNlink(path string) (uint64, error) {
 	if !ok {
 		return 0, fmt.Errorf("expected type *syscall.Stat_t, got %t", stat.Sys())
 	}
-	return statT.Nlink, nil
+	// We need this conversion on ARM64
+	return uint64(statT.Nlink), nil
 }
 
 func getInode(path string) (uint64, error) {


### PR DESCRIPTION
I'm not sure about this, but on ARM64 using gccgo, I got this error when doing unit-test:

```
# _/go/src/github.com/docker/docker/pkg/archive
./archive_test.go:876:14: error: incompatible type for return value 1 (cannot use type uint32 as type uint64)
  return statT.Nlink, nil
              ^
```

But according to https://golang.org/pkg/syscall/#Stat_t, statT.Nlink should be uint64.
Don't know what really happened.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
