### PR TITLE
Fix network connectivity problem for non-root users

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -55,7 +55,7 @@ clone hg code.google.com/p/go.net 84a4013f96e0
 clone hg code.google.com/p/gosqlite 74691fb6f837
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork v0.2
+clone git github.com/docker/libnetwork b39597744b0978fe4aeb9f3a099ba42f7b6c4a1f
 clone git github.com/vishvananda/netns 008d17ae001344769b031375bdb38a86219154c6
 clone git github.com/vishvananda/netlink 8eb64238879fed52fd51c5b30ad20b928fb4c36c
 

--- a/vendor/src/github.com/docker/libnetwork/endpoint.go
+++ b/vendor/src/github.com/docker/libnetwork/endpoint.go
@@ -548,6 +548,11 @@ func (ep *endpoint) updateDNS(resolvConf []byte) error {
 		return err
 	}
 
+	// Change the perms to 0644 since ioutil.TempFile creates it by default as 0600
+	if err := os.Chmod(tmpResolvFile.Name(), 0644); err != nil {
+		return err
+	}
+
 	// write the updates to the temp files
 	if err = ioutil.WriteFile(tmpHashFile.Name(), []byte(newHash), 0644); err != nil {
 		return err

--- a/vendor/src/github.com/docker/libnetwork/libnetwork_test.go
+++ b/vendor/src/github.com/docker/libnetwork/libnetwork_test.go
@@ -1137,6 +1137,16 @@ func TestResolvConf(t *testing.T) {
 		}
 	}()
 
+	finfo, err := os.Stat(resolvConfPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmode := (os.FileMode)(0644)
+	if finfo.Mode() != fmode {
+		t.Fatalf("Expected file mode %s, got %s", fmode.String(), finfo.Mode().String())
+	}
+
 	content, err := ioutil.ReadFile(resolvConfPath)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
If a container was started with a non-root user the container
may not be able to resolve DNS names because of too restrictive
permission in the /etc/resolv.conf container file. This problem
is in how this file gets created in libnetwork and ths PR
attempts to fix the issue by vendoring in the libnetwork code
with the fix.

Signed-off-by: Jana Radhakrishnan mrjana@docker.com
