### PR TITLE
Test for two containers in --net=host

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3178,3 +3178,10 @@ func (s *DockerSuite) TestMountIntoSys(c *check.C) {
 		c.Fatal("container should be able to mount into /sys/fs/cgroup")
 	}
 }
+
+func (s *DockerSuite) TestTwoContainersInNetHost(c *check.C) {
+	dockerCmd(c, "run", "-d", "--net=host", "--name=first", "busybox", "top")
+	dockerCmd(c, "run", "-d", "--net=host", "--name=second", "busybox", "top")
+	dockerCmd(c, "stop", "first")
+	dockerCmd(c, "stop", "second")
+}


### PR DESCRIPTION
This is test for regression which was encountered during libnetwork
merging.
