### PR TITLE
Increase upstart kill timeout to 20 seconds

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -7,6 +7,8 @@ limit nproc 524288 1048576
 
 respawn
 
+kill timeout 20
+
 pre-start script
 	# see also https://github.com/tianon/cgroupfs-mount/blob/master/cgroupfs-mount
 	if grep -v '^#' /etc/fstab | grep -q cgroup \


### PR DESCRIPTION
Give Docker more time to kill containers before upstart kills Docker.
The default kill timeout is 5 seconds.
This will help decrease the chance of but not eliminate the chance of
orphaned container processes.
