### PR TITLE
Proposal: Introduce introspection via files on the fs

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -484,11 +484,64 @@ func (container *Container) Start() (err error) {
 	if err := populateCommand(container, env); err != nil {
 		return err
 	}
+	if err := container.buildIntrospectionFiles(); err != nil {
+		logrus.Errorf("error creating introspection files: %v", err)
+	}
 	if err := container.setupMounts(); err != nil {
 		return err
 	}
 
 	return container.waitForStart()
+}
+
+func (container *Container) buildIntrospectionFiles() error {
+	iPath, err := container.GetRootResourcePath("/introspection")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(iPath, 0755); err != nil {
+		return err
+	}
+	netPath := filepath.Join(iPath, "net")
+	if err := os.MkdirAll(filepath.Join(netPath), 0755); err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(netPath, "ip4"), []byte(container.NetworkSettings.IPAddress), 0644); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(filepath.Join(netPath, "ip6"), []byte(container.NetworkSettings.GlobalIPv6Address), 0644); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(filepath.Join(iPath, "id"), []byte(container.ID+" "+container.Name), 0644); err != nil {
+		return err
+	}
+
+	portFiles := make(map[string]*os.File)
+	defer func() {
+		for _, f := range portFiles {
+			defer f.Close()
+		}
+	}()
+	for port, binds := range container.NetworkSettings.Ports {
+		var out string
+		for _, bind := range binds {
+			out = out + bind.HostIp + ":" + bind.HostPort + " "
+		}
+		proto := port.Proto()
+		if _, exists := portFiles[proto]; !exists {
+			f, err := os.OpenFile(filepath.Join(netPath, proto), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0644)
+			if err != nil {
+				return err
+			}
+			portFiles[proto] = f
+		}
+		if _, err := portFiles[proto].WriteString(port.Port() + " " + out + "\n"); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (container *Container) Run() error {
@@ -731,6 +784,14 @@ func (container *Container) cleanup() {
 	for _, eConfig := range container.execCommands.s {
 		container.daemon.unregisterExecCommand(eConfig)
 	}
+
+	// remove introspection
+	iPath, err := container.GetRootResourcePath("/introspection")
+	if err != nil {
+		logrus.Debug(err)
+		return
+	}
+	os.RemoveAll(iPath)
 }
 
 func (container *Container) KillSig(sig int) error {

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -249,6 +249,10 @@ func (container *Container) specialMounts() []execdriver.Mount {
 	if container.HostsPath != "" {
 		mounts = append(mounts, execdriver.Mount{Source: container.HostsPath, Destination: "/etc/hosts", Writable: !container.hostConfig.ReadonlyRootfs, Private: true})
 	}
+	if path, err := container.GetRootResourcePath("/introspection"); err == nil {
+		logrus.Debugf("mounting introspection")
+		mounts = append(mounts, execdriver.Mount{Source: path, Destination: "/var/run/docker/introspection", Writable: false, Private: true})
+	}
 	return mounts
 }
 


### PR DESCRIPTION
Wasn't quite sure how/where to document this so just did a PoC in code.
If this is something we want we can discuss what should/should not be exposed here and update code for code-review.
I felt like this was better than using a socket which has been discussed in the past.
Also could just change to writing a single json file...
I like the current implementation over a json file for usability reasons... kinda like inspect /proc.

Treat introspection kinda like /proc where we create files which get
bind-mounted into the container @ /var/run/docker/introspection/ which
contain information we wish to expose via introspection. These get
re-built on each container start.

In PoC, a user can get exposed port info by doing `cat /var/run/docker/introspection/net/ports/<port>-<proto>`
