### PR TITLE
added syscall.MS_MGC_VAL as VAL for linux in mount package

### DIFF
--- a/pkg/mount/flags.go
+++ b/pkg/mount/flags.go
@@ -49,6 +49,7 @@ func parseOptions(options string) (int, string) {
 		"norelatime":    {true, RELATIME},
 		"strictatime":   {false, STRICTATIME},
 		"nostrictatime": {true, STRICTATIME},
+		"val":           {false, VAL},
 	}
 
 	for _, o := range strings.Split(options, ",") {

--- a/pkg/mount/flags_freebsd.go
+++ b/pkg/mount/flags_freebsd.go
@@ -45,4 +45,5 @@ const (
 	RELATIME    = 0
 	REMOUNT     = 0
 	STRICTATIME = 0
+	VAL         = 0
 )

--- a/pkg/mount/flags_linux.go
+++ b/pkg/mount/flags_linux.go
@@ -82,4 +82,8 @@ const (
 	// it possible for the kernel to default to relatime or noatime but still
 	// allow userspace to override it.
 	STRICTATIME = syscall.MS_STRICTATIME
+
+	// VAL currently required for mount of device
+	// http://man7.org/linux/man-pages/man2/mount.2.html
+	VAL = syscall.MS_MGC_VAL
 )

--- a/pkg/mount/flags_unsupported.go
+++ b/pkg/mount/flags_unsupported.go
@@ -27,4 +27,5 @@ const (
 	STRICTATIME = 0
 	SYNCHRONOUS = 0
 	RDONLY      = 0
+	VAL         = 0
 )


### PR DESCRIPTION
- Added "val" flag for Linux

In order to make a generic mount for Linux devices, it looks like the syscall.MS_MGC_VAL flag must be present when issuing a mount command.  Otherwise, mounts must still take place outside of this package using syscall.Mount directly (see deviceset.go line 1477).

The "invalid argument" is returned unless the VAL flag is added when using flags like "private".

Signed-off-by: Clinton Kitson clintonskitson@gmail.com
