### PR TITLE
V2 mirror support

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -69,7 +69,7 @@ func (s *TagStore) Pull(image string, tag string, imagePullConfig *ImagePullConf
 		}
 
 		if v2mirrorEndpoint != nil {
-			logrus.Debugf("Attempting pull from v2 mirror: %s", v2mirrorEndpoint.URL)
+			logrus.Debugf("Attempting to pull from v2 mirror: %s", v2mirrorEndpoint.URL)
 			return s.pullFromV2Mirror(v2mirrorEndpoint, v2mirrorRepoInfo, imagePullConfig, tag, sf, logName)
 		}
 	}
@@ -138,12 +138,10 @@ func makeMirrorRepoInfo(repoInfo *registry.RepositoryInfo, mirror string) *regis
 
 func configureV2Mirror(repoInfo *registry.RepositoryInfo, s *registry.Service) (*registry.Endpoint, *registry.RepositoryInfo, error) {
 	mirrors := repoInfo.Index.Mirrors
-	if len(mirrors) == 0 && !repoInfo.Index.Official {
-		officialIndex, err := s.ResolveIndex(registry.IndexServerName())
-		if err != nil {
-			return nil, nil, err
-		}
-		mirrors = officialIndex.Mirrors
+
+	if len(mirrors) == 0 {
+		// no mirrors configured
+		return nil, nil, nil
 	}
 
 	v1MirrorCount := 0

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -282,6 +282,8 @@ func (s *TagStore) pullRepository(r *registry.Session, out io.Writer, repoInfo *
 			var lastErr, err error
 			var isDownloaded bool
 			for _, ep := range repoInfo.Index.Mirrors {
+				// Ensure endpoint is v1
+				ep = ep + "v1/"
 				out.Write(sf.FormatProgress(stringid.TruncateID(img.ID), fmt.Sprintf("Pulling image (%s) from %s, mirror: %s", img.Tag, repoInfo.CanonicalName, ep), nil))
 				if isDownloaded, err = s.pullImage(r, out, img.ID, ep, repoData.Tokens, sf); err != nil {
 					// Don't report errors when pulling from mirrors.

--- a/registry/config.go
+++ b/registry/config.go
@@ -189,7 +189,7 @@ func ValidateMirror(val string) (string, error) {
 		return "", fmt.Errorf("Unsupported path/query/fragment at end of the URI")
 	}
 
-	return fmt.Sprintf("%s://%s/v1/", uri.Scheme, uri.Host), nil
+	return fmt.Sprintf("%s://%s/", uri.Scheme, uri.Host), nil
 }
 
 // ValidateIndexName validates an index name.
@@ -358,7 +358,9 @@ func (config *ServiceConfig) NewRepositoryInfo(reposName string) (*RepositoryInf
 		// *TODO: Decouple index name from hostname (via registry configuration?)
 		repoInfo.LocalName = repoInfo.Index.Name + "/" + repoInfo.RemoteName
 		repoInfo.CanonicalName = repoInfo.LocalName
+
 	}
+
 	return repoInfo, nil
 }
 


### PR DESCRIPTION
The v2 registry will act as a pull-through cache, and needs to be
handled differently by the client to the v1 registry mirror.

See https://github.com/docker/distribution/issues/459 for details

Configuration

Only one v2 registry can be configured as a mirror.  Acceptable configurations
in this chanage are: 0...n v1 mirrors or 1 v2 mirror.  A mixture of v1 and v2
mirrors is considered an error.

Pull

If a v2 mirror is configured, all pulls are redirected to that mirror.  The
mirror will serve the content locally or attempt a pull from the upstream mirror,
cache it locally, and then serve to the client.

Push

If an image is tagged to a mirror, it will be pushed to the mirror and be
stored locally there.  Otherwise, images are pushed to the hub.  This is 
unchanged behavior.

This change should not affect the v1 codepath.  

closes docker/distribution#84
Connects to docker/distribution#19,  docker/distribution#459
