### PR TITLE
Add missing return error check for container.WriteHostConfig() in container_linux.go

### DIFF
--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -761,7 +761,9 @@ func (container *Container) AllocateNetwork() error {
 		return fmt.Errorf("Updating join info failed: %v", err)
 	}
 
-	container.WriteHostConfig()
+	if err := container.WriteHostConfig(); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

WriteHostConfig() will return an error, the caller should check if 
the is nil or not.
