### PR TITLE
Better checking for LogsFollowGoroutinesWithStdout

### DIFF
--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -436,9 +436,11 @@ func (s *DockerSuite) TestLogsFollowGoroutinesWithStdout(c *check.C) {
 	for {
 		select {
 		case <-t:
-			c.Assert(nroutines, check.Equals, getNGoroutines())
+			if n := getNGoroutines(); n > nroutines {
+				c.Fatalf("leaked goroutines: expected less than or equal to %d, got: %d", nroutines, n)
+			}
 		default:
-			if nroutines == getNGoroutines() {
+			if n := getNGoroutines(); n <= nroutines {
 				return
 			}
 			time.Sleep(200 * time.Millisecond)


### PR DESCRIPTION
Closes #13358
fix 2, if goroutines are fewer, that's ok too.
