### PR TITLE
Remove log config check from client

### DIFF
--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/url"
 
 	"github.com/docker/docker/api/types"
@@ -35,10 +34,6 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 	var c types.ContainerJSON
 	if err := json.NewDecoder(stream).Decode(&c); err != nil {
 		return err
-	}
-
-	if logType := c.HostConfig.LogConfig.Type; logType != "json-file" {
-		return fmt.Errorf("\"logs\" command is supported only for \"json-file\" logging driver (got: %s)", logType)
 	}
 
 	v := url.Values{}

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -32,6 +32,7 @@ func (daemon *Daemon) ContainerLogs(name string, config *ContainerLogsConfig) er
 		lines  = -1
 		format string
 	)
+
 	if !(config.UseStdout || config.UseStderr) {
 		return fmt.Errorf("You must choose at least one stream")
 	}
@@ -47,6 +48,10 @@ func (daemon *Daemon) ContainerLogs(name string, config *ContainerLogsConfig) er
 		return err
 	}
 
+	if container.LogDriverType() != jsonfilelog.Name {
+		return fmt.Errorf("\"logs\" endpoint is supported only for \"json-file\" logging driver")
+	}
+
 	var (
 		outStream = config.OutStream
 		errStream io.Writer
@@ -58,9 +63,6 @@ func (daemon *Daemon) ContainerLogs(name string, config *ContainerLogsConfig) er
 		errStream = outStream
 	}
 
-	if container.LogDriverType() != jsonfilelog.Name {
-		return fmt.Errorf("\"logs\" endpoint is supported only for \"json-file\" logging driver")
-	}
 	logDriver, err := container.getLogger()
 	cLog, err := logDriver.GetReader()
 	if err != nil {


### PR DESCRIPTION
It's just repeated in daemon and we have always to updated this point too if logic changes
I've moved this check in daemon as soon as we get the container also
but maybe I'm missing something (I'll close this if it's the case)

looking into tests error

Signed-off-by: Antonio Murdaca me@runcom.ninja
