### PR TITLE
Do not attempt releasing network when not attached to any network

### DIFF
--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -917,6 +917,12 @@ func (container *Container) ReleaseNetwork() {
 		return
 	}
 
+	// If the container is not attached to any network do not try
+	// to release network and generate spurious error messages.
+	if container.NetworkSettings.NetworkID == "" {
+		return
+	}
+
 	n, err := container.daemon.netController.NetworkByID(container.NetworkSettings.NetworkID)
 	if err != nil {
 		logrus.Errorf("error locating network id %s: %v", container.NetworkSettings.NetworkID, err)


### PR DESCRIPTION
Sometimes container.cleanup() can be called from multiple paths
for the same container during error conditions from monitor and
regular startup path. So if the container network has been already
released do not try to release it again.

Fixes #13388 

Signed-off-by: Jana Radhakrishnan mrjana@docker.com
