### PR TITLE
Don't check running container at create time

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -114,9 +114,6 @@ func (daemon *Daemon) GenerateSecurityOpt(ipcMode runconfig.IpcMode, pidMode run
 		if err != nil {
 			return nil, err
 		}
-		if !c.IsRunning() {
-			return nil, fmt.Errorf("cannot join IPC of a non running container: %s", ipcContainer)
-		}
 
 		return label.DupSecOpt(c.ProcessLabel), nil
 	}

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"reflect"
@@ -321,5 +322,22 @@ func (s *DockerSuite) TestCreateRM(c *check.C) {
 	out, _, err = runCommandWithOutput(rmCmd)
 	if err != nil {
 		c.Fatalf("Failed to rm -f container:%s\n%s", out, err)
+	}
+}
+
+func (s *DockerSuite) TestCreateModeIpcContainer(c *check.C) {
+	testRequires(c, SameHostDaemon)
+
+	cmd := exec.Command(dockerBinary, "create", "busybox")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(err, out)
+	}
+	id := strings.TrimSpace(out)
+
+	cmd = exec.Command(dockerBinary, "create", fmt.Sprintf("--ipc=container:%s", id), "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("Create container with ipc mode container should success with non running container: %s\n%s", out, err)
 	}
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2659,6 +2659,23 @@ func (s *DockerSuite) TestRunModeIpcContainerNotExists(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestRunModeIpcContainerNotRunning(c *check.C) {
+	testRequires(c, SameHostDaemon)
+
+	cmd := exec.Command(dockerBinary, "create", "busybox")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(err, out)
+	}
+	id := strings.TrimSpace(out)
+
+	cmd = exec.Command(dockerBinary, "run", fmt.Sprintf("--ipc=container:%s", id), "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err == nil {
+		c.Fatalf("Run container with ipc mode container should fail with non running container: %s\n%s", out, err)
+	}
+}
+
 func (s *DockerSuite) TestContainerNetworkMode(c *check.C) {
 	testRequires(c, SameHostDaemon)
 


### PR DESCRIPTION
We should let user create container even if the container he wants
join is not running, that check should be done at start time.

In this case, the running check is done by getIpcContainer() when
we start container.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
