### PR TITLE
lol 108 chars ETOOMANY

### DIFF
--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -58,7 +58,7 @@ func NewDaemon(c *check.C) *Daemon {
 		c.Fatal("Please set the DEST environment variable")
 	}
 
-	dir := filepath.Join(dest, fmt.Sprintf("daemon%d", time.Now().UnixNano()%100000000))
+	dir := filepath.Join(dest, fmt.Sprintf("d%d", time.Now().UnixNano()%100000000))
 	daemonFolder, err := filepath.Abs(dir)
 	if err != nil {
 		c.Fatalf("Could not make %q an absolute path: %v", dir, err)


### PR DESCRIPTION
Fixes #13407 

daemon start was failing with:

```
time="2015-05-22T16:48:14.291032778Z" level=fatal msg="Shutting down due to ServeAPI error: listen unix /go/src/github.com/docker/docker/bundles/1.7.0-dev-experimental/test-integration-cli/daemon1774954/docker.sock: bind: invalid argument" 
```

see https://github.com/golang/go/issues/6895: "the 108-character socket path limitation is for compatibility with other platforms"

it was 110 chars vs 108 max

LMAO
