### PR TITLE
Remove distribution source code from /go/src

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,8 @@ RUN set -x \
 	&& git clone https://github.com/docker/distribution.git /go/src/github.com/docker/distribution \
 	&& (cd /go/src/github.com/docker/distribution && git checkout -q $REGISTRY_COMMIT) \
 	&& GOPATH=/go/src/github.com/docker/distribution/Godeps/_workspace:/go \
-		go build -o /go/bin/registry-v2 github.com/docker/distribution/cmd/registry
+		go build -o /go/bin/registry-v2 github.com/docker/distribution/cmd/registry \
+	&& rm -rf /go/src/github.com/docker/distribution/
 
 # Get the "docker-py" source so we can run their integration tests
 ENV DOCKER_PY_COMMIT 91985b239764fe54714fa0a93d52aa362357d251


### PR DESCRIPTION
We already vendor distribution under ./vendor, but
because the GOPATH is /go:/go/src/github.com/.../vendor
Go will always compile the source code at /go not in ./vendor.

Apart from the fact that it is very inconvenient during
development, it was also a time-bomb: someone vendors a fix
from upstream distribution, but forgets to update
REGISTRY_COMMIT in the Dockerfile, and the binary doesn't get
the fix.

Signed-off-by: Tibor Vass tibor@docker.com
