### PR TITLE
RPM Fixups

### DIFF
--- a/contrib/init/systemd-redhat/docker.service
+++ b/contrib/init/systemd-redhat/docker.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=http://docs.docker.com
+After=network.target docker.socket
+Requires=docker.socket
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/sysconfig/docker
+EnvironmentFile=-/etc/sysconfig/docker-storage
+ExecStart=/usr/bin/docker -d $DOCKER_OPTIONS $DOCKER_STORAGE_OPTIONS
+MountFlags=slave
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+MountFlags=private
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/init/systemd-redhat/docker.socket
+++ b/contrib/init/systemd-redhat/docker.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description=Docker Socket for the API
+PartOf=docker.service
+
+[Socket]
+ListenStream=/var/run/docker.sock
+SocketMode=0660
+SocketUser=root
+SocketGroup=docker
+
+[Install]
+WantedBy=sockets.target

--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -30,6 +30,7 @@ lockfile="/var/lock/subsys/$prog"
 logfile="/var/log/$prog"
 
 [ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+[ -e /etc/sysconfig/$prog-storage ] && . /etc/sysconfig/$prog-storage
 
 prestart() {
     service cgconfig status > /dev/null
@@ -49,7 +50,7 @@ start() {
         prestart
         printf "Starting $prog:\t"
         echo "\n$(date)\n" >> $logfile
-        "$unshare" -m -- $exec -d $other_args &>> $logfile &
+        "$unshare" -m -- $exec -d $DOCKER_OPTIONS $DOCKER_STORAGE_OPTIONS &>> $logfile &
         pid=$!
         touch $lockfile
         # wait up to 10 seconds for the pidfile to exist.  see

--- a/contrib/init/sysvinit-redhat/docker.sysconfig
+++ b/contrib/init/sysvinit-redhat/docker.sysconfig
@@ -1,7 +1,9 @@
 # /etc/sysconfig/docker
-#
-# Other arguments to pass to the docker daemon process
-# These will be parsed by the sysv initscript and appended
-# to the arguments list passed to docker -d
 
-other_args=""
+# Modify these options if you want to change the way the docker daemon runs
+DOCKER_OPTIONS=--selinux-enabled -H fd://
+
+# Location used for temporary files, such as those created by
+# docker load and build operations. Default is /var/lib/docker/tmp
+# Can be overriden by setting the following environment variable.
+# DOCKER_TMPDIR=/var/tmp

--- a/contrib/init/sysvinit-redhat/docker.sysconfig-storage
+++ b/contrib/init/sysvinit-redhat/docker.sysconfig-storage
@@ -1,0 +1,12 @@
+# By default, Docker uses a loopback-mounted sparse file in
+# /var/lib/docker.  The loopback makes it slower, and there are some
+# restrictive defaults, such as 100GB max storage.
+
+# If your installation did not set a custom storage for Docker, you
+# may do it below.
+
+# Example: Use a custom pair of raw logical volumes (one for metadata,
+# one for data).
+# DOCKER_STORAGE_OPTIONS = --storage-opt dm.metadatadev=/dev/mylogvol/my-docker-metadata --storage-opt dm.datadev=/dev/mylogvol/my-docker-data
+DOCKER_STORAGE_OPTIONS=
+

--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -35,6 +35,7 @@ Requires(preun): initscripts
 
 # required packages on install
 Requires: /bin/sh
+Requires: docker-selinux
 Requires: iptables
 Requires: libc.so.6
 Requires: libcgroup
@@ -96,11 +97,12 @@ install -d $RPM_BUILD_ROOT/%{_initddir}
 
 %if 0%{?is_systemd}
 install -d $RPM_BUILD_ROOT/%{_unitdir}
-install -p -m 644 contrib/init/systemd/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
-install -p -m 644 contrib/init/systemd/docker.socket $RPM_BUILD_ROOT/%{_unitdir}/docker.socket
+install -p -m 644 contrib/init/systemd-redhat/docker.service $RPM_BUILD_ROOT/%{_unitdir}/docker.service
+install -p -m 644 contrib/init/systemd-redhat/docker.socket $RPM_BUILD_ROOT/%{_unitdir}/docker.socket
 %endif
 
 install -p -m 644 contrib/init/sysvinit-redhat/docker.sysconfig $RPM_BUILD_ROOT/etc/sysconfig/docker
+install -p -m 644 contrib/init/sysvinit-redhat/docker.sysconfig-storage $RPM_BUILD_ROOT/etc/sysconfig/docker-storage
 install -p -m 755 contrib/init/sysvinit-redhat/docker $RPM_BUILD_ROOT/%{_initddir}/docker
 
 # add bash completions
@@ -139,6 +141,7 @@ install -p -m 644 contrib/syntax/nano/Dockerfile.nanorc $RPM_BUILD_ROOT/usr/shar
 /%{_unitdir}/docker.socket
 %endif
 /etc/sysconfig/docker
+/etc/sysconfig/docker-storage
 /%{_initddir}/docker
 /usr/share/bash-completion/completions/docker
 /usr/share/zsh/vendor-completions/_docker


### PR DESCRIPTION
Spruce up the sysconfig files and turn SELinux on by default for RPM installations.

Signed-off-by: Patrick Devine patrick.devine@docker.com
