### PR TITLE
Windows: Pass temp environment through

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -219,6 +219,7 @@ test_env() {
 		GOPATH="$GOPATH" \
 		HOME="$DEST/fake-HOME" \
 		PATH="$PATH" \
+		TEMP="$TEMP" \
 		TEST_DOCKERINIT_PATH="$TEST_DOCKERINIT_PATH" \
 		"$@"
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli @jfrazelle @tianon @ahmetalpbalkan

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. 

There's a problem when running the integration tests on a Windows machine (client) targeting a Linux daemon. Eventually go test goes through the following call-stack to create a temporary directory in the format go-build123456789
- ioutils.TempDir("", "go-build")
- os.TempDir()
- syscall.GetTempPath()
- win32::GetTempPathW()

If you take a look at the Win32 documentation for GetTempPathW at https://msdn.microsoft.com/en-us/library/windows/desktop/aa364992(v=vs.85).aspx, it states the order in which the path is chosen is based, in order, on TMP, TEMP, USERPROFILE, the Windows directory. 

Without this fix, it means that running the tests is attempting to create directories under c:\windows. This fails unless the user is elevated (against best practices). Even then, it's really not a good idea putting temporary junk in your Windows directory!

I suspect your Azure Windows machines might be filling up with junk under the %windows% directory until this fix is merged - work checking :) Same applies for fake-contextnnnnnnnnn and docker-test-git-reponnnnnnnnn directories.
