### PR TITLE
allow the user to untag the history layer of the image in use

### DIFF
--- a/pkg/truncindex/truncindex.go
+++ b/pkg/truncindex/truncindex.go
@@ -24,6 +24,25 @@ var (
 	ErrIllegalChar = errors.New("illegal character: ' '")
 )
 
+// ErrNotFound is returned when the ID doesn't exist in the TruncIndex.
+type ErrNotFound struct {
+	id string
+}
+
+// Error implements error interface.
+func (e ErrNotFound) Error() string {
+	return fmt.Sprintf("no such id: %s", e.id)
+}
+
+// IsNotFound checks if the error is an instance of ErrNotFound.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(ErrNotFound)
+	return ok
+}
+
 // TruncIndex allows the retrieval of string identifiers by any of their unique prefixes.
 // This is used to retrieve image and container IDs by more convenient shorthand prefixes.
 type TruncIndex struct {
@@ -116,7 +135,7 @@ func (idx *TruncIndex) Get(s string) (string, error) {
 	if id != "" {
 		return id, nil
 	}
-	return "", fmt.Errorf("no such id: %s", s)
+	return "", ErrNotFound{id: s}
 }
 
 // Iterate iterates over all stored IDs, and passes each of them to the given handler.


### PR DESCRIPTION
## The problem:

Given two images with the following history:

tmp1:

```
3e39722dd807
324914d76d1c
bf6ad78f79e6
```

tmp2:

```
324914d76d1c
bf6ad78f79e6
```

and there are some running containers based on the image `tmp1`, when I run `docker rmi tmp2`, it raises an error saying that `tmp2` is in use. It's a bit confusing. Moreover, I think in this case `tmp2` should be untagged instead of raising the error.
## How to reproduce:
1. Build an image with the following Dockerfile via `docker build -t tmp1 .`:
   
   ```
   FROM busybox
   RUN echo asdf >/tmp/1.txt
   RUN echo ghjk >/tmp/2.txt
   ```
2. Create a container from the image. `docker run -itd --name=tmp1 tmp1 sh`
3. Create another image whose history is overlapped with the previous image.
   This can be done in two ways:
   
   a) Build another image with the following Dockerfile via `docker build -t tmp2 .`:
   
   ```
     FROM busybox
     RUN echo asdf >/tmp/1.txt
     # RUN echo ghjk >/tmp/2.txt
   ```
   
   b)  `docker tag $(docker history -q tmp1|head -n 2|tail -n 1) tmp2`
4. `docker rmi tmp2` will return an error  
   
   ```
   Error response from daemon: Conflict, cannot delete f0ef9e6f70f9 because the running container 4f85b71ce1e7 is using it, stop it and use -f to force
   FATA[0000] Error: failed to remove one or more images
   ```
## Expected behaviors of docker rmi
- [x] the image should not be deleted (irrespective of the -f flag) if there are running containers using it.
- [x] the image should be deleted when the `-f` flag is provided if there are **only** stopped containers using it
- [x] if deleting by repo tag, and the image has multiple tags, the provided tag should be deleted (no matter there are containers using it or not).
- [ ] if deleting by repo tag and the image is the parent of another one with containers, the tag can be removed (this PR)
- [x] if deleting by ID and the imageID has multiple repo tags, 
  - [x] if there are running containers using the image, the image should not be deleted (irrespective of the -f flag)  (see #14116)
  - [x] otherwise the image can be deleted with the -f flag

PS: [x] is the current behavior, [ ] is not implemented
