### PR TITLE
Fixes deb package for Ubuntu 15.04 compatibility

### DIFF
--- a/contrib/init/systemd-ubuntu/docker.service
+++ b/contrib/init/systemd-ubuntu/docker.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=http://docs.docker.com
+After=network.target docker.socket
+Requires=docker.socket
+
+[Service]
+EnvironmentFile=/etc/default/docker
+ExecStart=/usr/bin/docker -d -H fd:// $DOCKER_OPTS
+MountFlags=slave
+LimitNOFILE=1048576
+LimitNPROC=1048576
+LimitCORE=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/init/systemd-ubuntu/docker.socket
+++ b/contrib/init/systemd-ubuntu/docker.socket
@@ -1,0 +1,12 @@
+[Unit]
+Description=Docker Socket for the API
+PartOf=docker.service
+
+[Socket]
+ListenStream=/var/run/docker.sock
+SocketMode=0660
+SocketUser=root
+SocketGroup=docker
+
+[Install]
+WantedBy=sockets.target

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -51,7 +51,7 @@ bundle_ubuntu() {
 	mkdir -p "$DIR/etc/default"
 	cp contrib/init/sysvinit-debian/docker.default "$DIR/etc/default/docker"
 	mkdir -p "$DIR/lib/systemd/system"
-	cp contrib/init/systemd/docker.{service,socket} "$DIR/lib/systemd/system/"
+	cp contrib/init/systemd-ubuntu/docker.{service,socket} "$DIR/lib/systemd/system/"
 
 	# Include contributed completions
 	mkdir -p "$DIR/etc/bash_completion.d"
@@ -95,6 +95,13 @@ if ! { [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upsta
 	# we only need to do this if upstart isn't in charge
 	update-rc.d docker defaults > /dev/null || true
 fi
+
+# If the system uses systemd, the configuration file format changes
+# We need to update it accordingly (removing variable exports)
+if [ -d /run/systemd/system ] ; then
+	sed -i -e "s/^export //" -e "s/#export /#/" /etc/default/docker 2>/dev/null || true
+fi
+
 if [ -n "$2" ]; then
 	_dh_action=restart
 else

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -166,6 +166,8 @@ EOF
 			--config-files /etc/init/docker.conf \
 			--config-files /etc/init.d/docker \
 			--config-files /etc/default/docker \
+			--config-files /lib/systemd/system/docker.service \
+			--config-files /lib/systemd/system/docker.socket \
 			--deb-compression gz \
 			-t deb .
 		# TODO replace "Suggests: cgroup-lite" with "Recommends: cgroupfs-mount | cgroup-lite" once cgroupfs-mount is available


### PR DESCRIPTION
Ubuntu 15.04 introduces systemd as a replacement for upstart/SysV. As a result, docker startup script does not load variables from `/etc/default/variables`. This pull request is a proposition on how to fix that.

Associated issues: #12926 and #13384 
