### PR TITLE
Cleanup container LogEvent calls

### DIFF
--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -61,5 +61,6 @@ func (daemon *Daemon) Commit(container *Container, repository, tag, comment, aut
 			return img, err
 		}
 	}
+	container.LogEvent("commit")
 	return img, nil
 }

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -242,6 +242,7 @@ func (container *Container) Start() (err error) {
 			}
 			container.toDisk()
 			container.cleanup()
+			container.LogEvent("die")
 		}
 	}()
 
@@ -375,7 +376,11 @@ func (container *Container) KillSig(sig int) error {
 		return nil
 	}
 
-	return container.daemon.Kill(container, sig)
+	if err := container.daemon.Kill(container, sig); err != nil {
+		return err
+	}
+	container.LogEvent("kill")
+	return nil
 }
 
 // Wrapper aroung KillSig() suppressing "no such process" error.
@@ -406,6 +411,7 @@ func (container *Container) Pause() error {
 		return err
 	}
 	container.Paused = true
+	container.LogEvent("pause")
 	return nil
 }
 
@@ -427,6 +433,7 @@ func (container *Container) Unpause() error {
 		return err
 	}
 	container.Paused = false
+	container.LogEvent("unpause")
 	return nil
 }
 
@@ -488,6 +495,7 @@ func (container *Container) Stop(seconds int) error {
 		}
 	}
 
+	container.LogEvent("stop")
 	return nil
 }
 
@@ -502,14 +510,24 @@ func (container *Container) Restart(seconds int) error {
 	if err := container.Stop(seconds); err != nil {
 		return err
 	}
-	return container.Start()
+
+	if err := container.Start(); err != nil {
+		return err
+	}
+
+	container.LogEvent("restart")
+	return nil
 }
 
 func (container *Container) Resize(h, w int) error {
 	if !container.IsRunning() {
 		return fmt.Errorf("Cannot resize container %s, container is not running", container.ID)
 	}
-	return container.command.ProcessConfig.Terminal.Resize(h, w)
+	if err := container.command.ProcessConfig.Terminal.Resize(h, w); err != nil {
+		return err
+	}
+	container.LogEvent("resize")
+	return nil
 }
 
 func (container *Container) Export() (archive.Archive, error) {
@@ -522,12 +540,13 @@ func (container *Container) Export() (archive.Archive, error) {
 		container.Unmount()
 		return nil, err
 	}
-	return ioutils.NewReadCloserWrapper(archive, func() error {
-			err := archive.Close()
-			container.Unmount()
-			return err
-		}),
-		nil
+	arch := ioutils.NewReadCloserWrapper(archive, func() error {
+		err := archive.Close()
+		container.Unmount()
+		return err
+	})
+	container.LogEvent("export")
+	return arch, err
 }
 
 func (container *Container) Mount() error {
@@ -628,13 +647,14 @@ func (container *Container) Copy(resource string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ioutils.NewReadCloserWrapper(archive, func() error {
-			err := archive.Close()
-			container.UnmountVolumes(true)
-			container.Unmount()
-			return err
-		}),
-		nil
+	reader := ioutils.NewReadCloserWrapper(archive, func() error {
+		err := archive.Close()
+		container.UnmountVolumes(true)
+		container.Unmount()
+		return err
+	})
+	container.LogEvent("copy")
+	return reader, nil
 }
 
 // Returns true if the container exposes a certain port
@@ -826,6 +846,7 @@ func (c *Container) Attach(stdin io.ReadCloser, stdout io.Writer, stderr io.Writ
 }
 
 func (c *Container) AttachWithLogs(stdin io.ReadCloser, stdout, stderr io.Writer, logs, stream bool) error {
+
 	if logs {
 		logDriver, err := c.getLogger()
 		cLog, err := logDriver.GetReader()
@@ -854,6 +875,8 @@ func (c *Container) AttachWithLogs(stdin io.ReadCloser, stdout, stderr io.Writer
 			}
 		}
 	}
+
+	c.LogEvent("attach")
 
 	//stream
 	if stream {

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -39,7 +39,6 @@ func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hos
 		return "", warnings, err
 	}
 
-	container.LogEvent("create")
 	warnings = append(warnings, buildWarnings...)
 
 	return container.ID, warnings, nil
@@ -142,6 +141,7 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 	if err := container.ToDisk(); err != nil {
 		return nil, nil, err
 	}
+	container.LogEvent("create")
 	return container, warnings, nil
 }
 

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -48,8 +48,6 @@ func (daemon *Daemon) ContainerRm(name string, config *ContainerRmConfig) error 
 		return fmt.Errorf("Cannot destroy container %s: %v", name, err)
 	}
 
-	container.LogEvent("destroy")
-
 	if config.RemoveVolume {
 		container.removeMountPoints()
 	}
@@ -102,6 +100,7 @@ func (daemon *Daemon) rm(container *Container, forceRemove bool) (err error) {
 			daemon.idIndex.Delete(container.ID)
 			daemon.containers.Delete(container.ID)
 			os.RemoveAll(container.root)
+			container.LogEvent("destroy")
 		}
 	}()
 
@@ -130,6 +129,7 @@ func (daemon *Daemon) rm(container *Container, forceRemove bool) (err error) {
 	daemon.idIndex.Delete(container.ID)
 	daemon.containers.Delete(container.ID)
 
+	container.LogEvent("destroy")
 	return nil
 }
 

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -141,9 +141,9 @@ func (d *Daemon) ContainerExecCreate(config *runconfig.ExecConfig) (string, erro
 		Running:       false,
 	}
 
-	container.LogEvent("exec_create: " + execConfig.ProcessConfig.Entrypoint + " " + strings.Join(execConfig.ProcessConfig.Arguments, " "))
-
 	d.registerExecCommand(execConfig)
+
+	container.LogEvent("exec_create: " + execConfig.ProcessConfig.Entrypoint + " " + strings.Join(execConfig.ProcessConfig.Arguments, " "))
 
 	return execConfig.ID, nil
 

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -21,7 +21,5 @@ func (daemon *Daemon) ContainerExport(name string, out io.Writer) error {
 	if _, err := io.Copy(out, data); err != nil {
 		return fmt.Errorf("%s: %s", name, err)
 	}
-	// FIXME: factor job-specific LogEvent to engine.Job.Run()
-	container.LogEvent("export")
 	return nil
 }

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -26,6 +26,5 @@ func (daemon *Daemon) ContainerKill(name string, sig uint64) error {
 			return fmt.Errorf("Cannot kill container %s: %s", name, err)
 		}
 	}
-	container.LogEvent("kill")
 	return nil
 }

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -12,7 +12,6 @@ func (daemon *Daemon) ContainerPause(name string) error {
 	if err := container.Pause(); err != nil {
 		return fmt.Errorf("Cannot pause container %s: %s", name, err)
 	}
-	container.LogEvent("pause")
 
 	return nil
 }

--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -40,5 +40,6 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 		return err
 	}
 
+	container.LogEvent("rename")
 	return nil
 }

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -10,6 +10,5 @@ func (daemon *Daemon) ContainerRestart(name string, seconds int) error {
 	if err := container.Restart(seconds); err != nil {
 		return fmt.Errorf("Cannot restart container %s: %s\n", name, err)
 	}
-	container.LogEvent("restart")
 	return nil
 }

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -33,7 +33,6 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConf
 	}
 
 	if err := container.Start(); err != nil {
-		container.LogEvent("die")
 		return fmt.Errorf("Cannot start container %s: %s", name, err)
 	}
 

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -13,6 +13,5 @@ func (daemon *Daemon) ContainerStop(name string, seconds int) error {
 	if err := container.Stop(seconds); err != nil {
 		return fmt.Errorf("Cannot stop container %s: %s\n", name, err)
 	}
-	container.LogEvent("stop")
 	return nil
 }

--- a/daemon/top.go
+++ b/daemon/top.go
@@ -68,5 +68,6 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.Container
 			}
 		}
 	}
+	container.LogEvent("top")
 	return procList, nil
 }

--- a/daemon/unpause.go
+++ b/daemon/unpause.go
@@ -12,7 +12,6 @@ func (daemon *Daemon) ContainerUnpause(name string) error {
 	if err := container.Unpause(); err != nil {
 		return fmt.Errorf("Cannot unpause container %s: %s", name, err)
 	}
-	container.LogEvent("unpause")
 
 	return nil
 }

--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -1794,7 +1794,7 @@ polling (using since).
 
 Docker containers report the following events:
 
-    create, destroy, die, exec_create, exec_start, export, kill, oom, pause, restart, start, stop, unpause
+    attach, commit, copy, create, destroy, die, exec_create, exec_start, export, kill, oom, pause, rename, resize, restart, start, stop, top, unpause
 
 and Docker images report:
 


### PR DESCRIPTION
Move some calls to container.LogEvent down lower so that there's
less of a chance of them being missed. Also add a few more events
that appear to have been missed.

Added testcases for new events: commit, copy, resize, attach, rename, top

Signed-off-by: Doug Davis dug@us.ibm.com
