### PR TITLE
Fix race in stats cli and native driver

### DIFF
--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -37,7 +37,9 @@ func (s *containerStats) Collect(cli *DockerCli, streamStats bool) {
 	}
 	stream, _, err := cli.call("GET", "/containers/"+s.Name+"/stats?"+v.Encode(), nil, nil)
 	if err != nil {
+		s.mu.Lock()
 		s.err = err
+		s.mu.Unlock()
 		return
 	}
 	defer stream.Close()

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -335,7 +335,9 @@ func (d *driver) Clean(id string) error {
 }
 
 func (d *driver) Stats(id string) (*execdriver.ResourceStats, error) {
+	d.Lock()
 	c := d.activeContainers[id]
+	d.Unlock()
 	if c == nil {
 		return nil, execdriver.ErrNotRunning
 	}

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -259,7 +259,9 @@ func (d *driver) Kill(c *execdriver.Command, sig int) error {
 }
 
 func (d *driver) Pause(c *execdriver.Command) error {
+	d.Lock()
 	active := d.activeContainers[c.ID]
+	d.Unlock()
 	if active == nil {
 		return fmt.Errorf("active container for %s does not exist", c.ID)
 	}
@@ -267,7 +269,9 @@ func (d *driver) Pause(c *execdriver.Command) error {
 }
 
 func (d *driver) Unpause(c *execdriver.Command) error {
+	d.Lock()
 	active := d.activeContainers[c.ID]
+	d.Unlock()
 	if active == nil {
 		return fmt.Errorf("active container for %s does not exist", c.ID)
 	}


### PR DESCRIPTION
Race in native driver can be verified with `while true; do docker run -d busybox true | xargs docker stats --no-stream; sleep .1; done` (race detector logs: https://gist.github.com/runcom/c8be5b347dfc1deddba3)

Fix in `api/client/stats.go` I'm finding a way to reproduce cause I triggered it and moved on and forgot to keep a note..

I don't know if these fixes are ok..if this isn't the way or we don't want this I'll close this

ping @LK4D4 

Signed-off-by: Antonio Murdaca me@runcom.ninja
