### PR TITLE
mention dockviz alternative

### DIFF
--- a/docs/man/docker-images.1.md
+++ b/docs/man/docker-images.1.md
@@ -66,6 +66,11 @@ used in builds use **-a**:
 
     docker images -a
 
+Previously, the docker images command supported the --tree and --dot arguments,
+which displayed different visualizations of the image data. Docker core removed
+this functionality in the 1.7 version. If you liked this functionality, you can
+still find it in the third-party dockviz tool: https://github.com/justone/dockviz.
+
 ## Listing only the shortened image IDs
 
 Listing just the shortened image IDs. This can be useful for some automated

--- a/docs/sources/userguide/dockerimages.md
+++ b/docs/sources/userguide/dockerimages.md
@@ -54,6 +54,13 @@ We can see three crucial pieces of information about our images in the listing.
 * The tags for each image, for example `14.04`.
 * The image ID of each image.
 
+> **Note:**
+> Previously, the `docker images` command supported the `--tree` and `--dot`
+> arguments, which displayed different visualizations of the image data. Docker
+> core removed this functionality in the 1.7 version. If you liked this
+> functionality, you can still find it in
+> [the third-party dockviz tool](https://github.com/justone/dockviz).
+
 A repository potentially holds multiple variants of an image. In the case of
 our `ubuntu` image we can see multiple variants covering Ubuntu 10.04, 12.04,
 12.10, 13.04, 13.10 and 14.04. Each variant is identified by a tag and you can


### PR DESCRIPTION
This adds a little note to the docs and the man page for `docker images` that mentions [dockviz](https://github.com/justone/dockviz) as a way of getting the previous `--tree` and `--dot` visualization functionality.

I tried to phrase it in such a way as to indicate that dockviz isn't supported by Docker Inc.  Let me know if the wording needs to be changed or anything.

Thanks.

(cf. #12333 and #13431)
