### PR TITLE
Allow PID namespace to be shared between container

### DIFF
--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -196,7 +196,6 @@ func populateCommand(c *Container, env []string) error {
 	}
 
 	ipc := &execdriver.Ipc{}
-
 	if c.hostConfig.IpcMode.IsContainer() {
 		ic, err := c.getIpcContainer()
 		if err != nil {
@@ -208,7 +207,15 @@ func populateCommand(c *Container, env []string) error {
 	}
 
 	pid := &execdriver.Pid{}
-	pid.HostPid = c.hostConfig.PidMode.IsHost()
+	if c.hostConfig.PidMode.IsContainer() {
+		pc, err := c.getPidContainer()
+		if err != nil {
+			return err
+		}
+		pid.ContainerID = pc.ID
+	} else {
+		pid.HostPid = c.hostConfig.PidMode.IsHost()
+	}
 
 	uts := &execdriver.UTS{
 		HostUTS: c.hostConfig.UTSMode.IsHost(),
@@ -852,6 +859,18 @@ func (container *Container) getIpcContainer() (*Container, error) {
 	}
 	if !c.IsRunning() {
 		return nil, fmt.Errorf("cannot join IPC of a non running container: %s", containerID)
+	}
+	return c, nil
+}
+
+func (container *Container) getPidContainer() (*Container, error) {
+	containerID := container.hostConfig.PidMode.Container()
+	c, err := container.daemon.Get(containerID)
+	if err != nil {
+		return nil, err
+	}
+	if !c.IsRunning() {
+		return nil, fmt.Errorf("cannot join PID of a non running container: %s", containerID)
 	}
 	return c, nil
 }

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -154,5 +154,13 @@ func (daemon *Daemon) GenerateSecurityOpt(ipcMode runconfig.IpcMode, pidMode run
 
 		return label.DupSecOpt(c.ProcessLabel), nil
 	}
+	if pidContainer := pidMode.Container(); pidContainer != "" {
+		c, err := daemon.Get(pidContainer)
+		if err != nil {
+			return nil, err
+		}
+
+		return label.DupSecOpt(c.ProcessLabel), nil
+	}
 	return nil, nil
 }

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -84,7 +84,8 @@ type Ipc struct {
 
 // PID settings of the container
 type Pid struct {
-	HostPid bool `json:"host_pid"`
+	ContainerID string `json:"container_id"` // id of the container to join pid.
+	HostPid     bool   `json:"host_pid"`
 }
 
 // UTS settings of the container

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -146,6 +146,22 @@ func (d *driver) createPid(container *configs.Config, c *execdriver.Command) err
 		return nil
 	}
 
+	if c.Pid.ContainerID != "" {
+		d.Lock()
+		active := d.activeContainers[c.Pid.ContainerID]
+		d.Unlock()
+
+		if active == nil {
+			return fmt.Errorf("%s is not a valid running container to join", c.Pid.ContainerID)
+		}
+
+		state, err := active.State()
+		if err != nil {
+			return err
+		}
+		container.Namespaces.Add(configs.NEWPID, state.NamespacePaths[configs.NEWPID])
+	}
+
 	return nil
 }
 

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -128,8 +128,9 @@ two memory nodes.
 
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
-                               'container:<name|id>': reuses another container shared memory, semaphores and message queues
-                               'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+     'container:<name|id>': reuses another container shared memory, semaphores and message queues
+     'host': use the host shared memory, semaphores and message queues inside the container.
+     Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
 
 **-l**, **--label**=[]
    Adds metadata to a container (e.g., --label=com.example.key=value)
@@ -191,12 +192,13 @@ This value should always larger than **-m**, so you should alway use this with *
 
 **--pid**=host
    Set the PID mode for the container
-     **host**: use the host's PID namespace inside the container.
+     'container:<name|id>': reuses another container's PID namespace.
+     'host': use the host's PID namespace inside the container.
      Note: the host mode gives the container full access to local PID and is therefore considered insecure.
 
 **--uts**=host
    Set the UTS mode for the container
-     **host**: use the host's UTS namespace inside the container.
+     'host': use the host's UTS namespace inside the container.
      Note: the host mode gives the container access to changing the host's hostname and is therefore considered insecure.
 
 **--privileged**=*true*|*false*

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -229,8 +229,9 @@ ENTRYPOINT.
 
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
-                               'container:<name|id>': reuses another container shared memory, semaphores and message queues
-                               'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
+     'container:<name|id>': reuses another container shared memory, semaphores and message queues.
+     'host': use the host shared memory, semaphores and message queues inside the container.
+     Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
 
 **-l**, **--label**=[]
    Set metadata on the container (e.g., --label com.example.key=value)
@@ -321,12 +322,13 @@ ports and the exposed ports, use `docker port`.
 
 **--pid**=host
    Set the PID mode for the container
-     **host**: use the host's PID namespace inside the container.
+     'container:<name|id>': reuses another container's PID namespace.
+     'host': use the host's PID namespace inside the container.
      Note: the host mode gives the container full access to local PID and is therefore considered insecure.
 
 **--uts**=host
    Set the UTS mode for the container
-     **host**: use the host's UTS namespace inside the container.
+     'host': use the host's UTS namespace inside the container.
      Note: the host mode gives the container access to changing the host's hostname and is therefore considered insecure.
 
 **--privileged**=*true*|*false*

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -61,6 +61,7 @@ following options.
      - [Name (--name)](#name-name)
      - [PID Equivalent](#pid-equivalent)
  - [IPC Settings (--ipc)](#ipc-settings-ipc)
+ - [PID Settings (--pid)](#pid-settings-pid)
  - [Network Settings](#network-settings)
  - [Restart Policies (--restart)](#restart-policies-restart)
  - [Clean Up (--rm)](#clean-up-rm)
@@ -159,7 +160,8 @@ the digest value is predictable and referenceable.
 ## PID settings (--pid)
 
     --pid=""  : Set the PID (Process) Namespace mode for the container,
-           'host': use the host's PID namespace inside the container
+                 'container:<name|id>': reuses another container's PID namespace
+                 'host': use the host's PID namespace inside the container
 
 By default, all containers have the PID namespace enabled.
 
@@ -177,6 +179,15 @@ within the container.
 
 This command would allow you to use `strace` inside the container on pid 1234 on
 the host.
+
+For `--pid=container:<name|id>`, you could build a container with debugging
+tools like `strace` or `gdb`, and use these tools inside the container on
+processes in another container.
+
+    $ docker run --pid=container:test rhel7 strace -p 123
+
+This command would allow you to use `strace` inside the container on pid 123 in
+container test.
 
 ## UTS settings (--uts)
 

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -341,3 +341,20 @@ func (s *DockerSuite) TestCreateModeIpcContainer(c *check.C) {
 		c.Fatalf("Create container with ipc mode container should success with non running container: %s\n%s", out, err)
 	}
 }
+
+func (s *DockerSuite) TestCreateModePidContainer(c *check.C) {
+	testRequires(c, SameHostDaemon)
+
+	cmd := exec.Command(dockerBinary, "create", "busybox")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(err, out)
+	}
+	id := strings.TrimSpace(out)
+
+	cmd = exec.Command(dockerBinary, "create", fmt.Sprintf("--pid=container:%s", id), "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("Create container with pid mode container should success with non running container: %s\n%s", out, err)
+	}
+}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2695,6 +2695,60 @@ func (s *DockerSuite) TestRunModePidHost(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestRunModePidContainer(c *check.C) {
+	testRequires(c, SameHostDaemon)
+
+	cmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(err, out)
+	}
+	id := strings.TrimSpace(out)
+	state, err := inspectField(id, "State.Running")
+	c.Assert(err, check.IsNil)
+	c.Assert(state, check.Equals, "true")
+	pid1, err := inspectField(id, "State.Pid")
+	c.Assert(err, check.IsNil)
+
+	parentContainerPid, err := os.Readlink(fmt.Sprintf("/proc/%s/ns/pid", pid1))
+	c.Assert(err, check.IsNil)
+	cmd = exec.Command(dockerBinary, "run", fmt.Sprintf("--pid=container:%s", id), "busybox", "readlink", "/proc/self/ns/pid")
+	out2, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(err, out2)
+	}
+
+	out2 = strings.Trim(out2, "\n")
+	if parentContainerPid != out2 {
+		c.Fatalf("PID different with --pid=container:%s %s != %s\n", id, parentContainerPid, out2)
+	}
+}
+
+func (s *DockerSuite) TestRunModePidContainerNotExists(c *check.C) {
+	cmd := exec.Command(dockerBinary, "run", "-d", "--pid", "container:abcd1234", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if !strings.Contains(out, "abcd1234") || err == nil {
+		c.Fatalf("run PID from a non exists container should with correct error out")
+	}
+}
+
+func (s *DockerSuite) TestRunModePidContainerNotRunning(c *check.C) {
+	testRequires(c, SameHostDaemon)
+
+	cmd := exec.Command(dockerBinary, "create", "busybox")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(err, out)
+	}
+	id := strings.TrimSpace(out)
+
+	cmd = exec.Command(dockerBinary, "run", fmt.Sprintf("--pid=container:%s", id), "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err == nil {
+		c.Fatalf("Run container with pid mode container should fail with non running container: %s\n%s", out, err)
+	}
+}
+
 func (s *DockerSuite) TestRunModeUTSHost(c *check.C) {
 	testRequires(c, NativeExecDriver, SameHostDaemon)
 

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -101,21 +101,38 @@ type PidMode string
 
 // IsPrivate indicates whether container use it's private pid stack
 func (n PidMode) IsPrivate() bool {
-	return !(n.IsHost())
+	return !(n.IsHost() || n.IsContainer())
 }
 
 func (n PidMode) IsHost() bool {
 	return n == "host"
 }
 
+func (n PidMode) IsContainer() bool {
+	parts := strings.SplitN(string(n), ":", 2)
+	return len(parts) > 1 && parts[0] == "container"
+}
+
 func (n PidMode) Valid() bool {
 	parts := strings.Split(string(n), ":")
 	switch mode := parts[0]; mode {
 	case "", "host":
+	case "container":
+		if len(parts) != 2 || parts[1] == "" {
+			return false
+		}
 	default:
 		return false
 	}
 	return true
+}
+
+func (n PidMode) Container() string {
+	parts := strings.SplitN(string(n), ":", 2)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return ""
 }
 
 type DeviceMapping struct {


### PR DESCRIPTION
Closes: #10163

Share PID namespace with host is already supported, we can use
debug tools like strace in container on pids in host, it will be
cool if we can strace in container on pids in another container.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
