### PR TITLE
Fix links app _NAME exposed

### DIFF
--- a/links/links.go
+++ b/links/links.go
@@ -101,7 +101,7 @@ func (l *Link) ToEnv() []string {
 	}
 
 	// Load the linked container's name into the environment
-	env = append(env, fmt.Sprintf("%s_NAME=%s", alias, l.Name))
+	env = append(env, fmt.Sprintf("%s_NAME=%s", alias, l.Alias()))
 
 	if l.ChildEnvironment != nil {
 		for _, v := range l.ChildEnvironment {

--- a/links/links_test.go
+++ b/links/links_test.go
@@ -102,8 +102,8 @@ func TestLinkEnv(t *testing.T) {
 	if env["DOCKER_PORT_6379_TCP_PORT"] != "6379" {
 		t.Fatalf("Expected 6379, got %s", env["DOCKER_PORT_6379_TCP_PORT"])
 	}
-	if env["DOCKER_NAME"] != "/db/docker" {
-		t.Fatalf("Expected /db/docker, got %s", env["DOCKER_NAME"])
+	if env["DOCKER_NAME"] != "docker" {
+		t.Fatalf("Expected docker, got %s", env["DOCKER_NAME"])
 	}
 	if env["DOCKER_ENV_PASSWORD"] != "gordon" {
 		t.Fatalf("Expected gordon, got %s", env["DOCKER_ENV_PASSWORD"])
@@ -151,8 +151,8 @@ func TestLinkMultipleEnv(t *testing.T) {
 	if env["DOCKER_PORT_6379_TCP_PORT_END"] != "6381" {
 		t.Fatalf("Expected 6381, got %s", env["DOCKER_PORT_6379_TCP_PORT_END"])
 	}
-	if env["DOCKER_NAME"] != "/db/docker" {
-		t.Fatalf("Expected /db/docker, got %s", env["DOCKER_NAME"])
+	if env["DOCKER_NAME"] != "docker" {
+		t.Fatalf("Expected docker, got %s", env["DOCKER_NAME"])
 	}
 	if env["DOCKER_ENV_PASSWORD"] != "gordon" {
 		t.Fatalf("Expected gordon, got %s", env["DOCKER_ENV_PASSWORD"])
@@ -201,8 +201,8 @@ func TestLinkPortRangeEnv(t *testing.T) {
 	if env["DOCKER_PORT_6379_TCP_PORT_END"] != "6381" {
 		t.Fatalf("Expected 6381, got %s", env["DOCKER_PORT_6379_TCP_PORT_END"])
 	}
-	if env["DOCKER_NAME"] != "/db/docker" {
-		t.Fatalf("Expected /db/docker, got %s", env["DOCKER_NAME"])
+	if env["DOCKER_NAME"] != "docker" {
+		t.Fatalf("Expected docker, got %s", env["DOCKER_NAME"])
 	}
 	if env["DOCKER_ENV_PASSWORD"] != "gordon" {
 		t.Fatalf("Expected gordon, got %s", env["DOCKER_ENV_PASSWORD"])


### PR DESCRIPTION
seems just wrong that we expose the db path `/some/thing` in the env variables as `%s_NAME` (Am I missing something?)

Before:
`APP1_NAME=/app2/app1`
After:
`APP1_NAME=app1`

it's correct to have the db path in HostConfig tho so it was just a matter of exposed env vars inside the container

fixes #13459

Signed-off-by: Antonio Murdaca me@runcom.ninja
