### PR TITLE
Preinitialize MountPoints to avoid assigning to a nil map

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -161,6 +161,7 @@ func (daemon *Daemon) load(id string) (*Container, error) {
 		CommonContainer: CommonContainer{
 			State:        NewState(),
 			root:         daemon.containerRoot(id),
+			MountPoints:  make(map[string]*mountPoint),
 			execCommands: newExecStore(),
 		},
 	}


### PR DESCRIPTION
Fixes #13435
