### PR TITLE
Make hack/make.sh work on FreeBSD

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -291,11 +291,8 @@ main() {
 	if [ "$(go env GOHOSTOS)" != 'windows' ]; then
 		# Windows and symlinks don't get along well
 
-		if [ "$(go env GOHOSTOS)" != 'freebsd' ]; then
-			ln -sfT "$VERSION" bundles/latest
-		else 
-			ln -sfh "$VERSION" bundles/latest
-		fi
+		rm -f bundles/latest
+		ln -s "$VERSION" bundles/latest
 	fi
 
 	if [ $# -lt 1 ]; then

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -290,7 +290,12 @@ main() {
 
 	if [ "$(go env GOHOSTOS)" != 'windows' ]; then
 		# Windows and symlinks don't get along well
-		ln -sfT "$VERSION" bundles/latest
+
+		if [ "$(go env GOHOSTOS)" != 'freebsd' ]; then
+			ln -sfT "$VERSION" bundles/latest
+		else 
+			ln -sfh "$VERSION" bundles/latest
+		fi
 	fi
 
 	if [ $# -lt 1 ]; then


### PR DESCRIPTION
On FreeBSD link command doesn't have -T flag, so we user -h instead.
