### PR TITLE
Windows: Fix up container again

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1087,26 +1087,6 @@ func (container *Container) shouldRestart() bool {
 		(container.hostConfig.RestartPolicy.Name == "on-failure" && container.ExitCode != 0)
 }
 
-func (container *Container) UnmountVolumes(forceSyscall bool) error {
-	for _, m := range container.MountPoints {
-		dest, err := container.GetResourcePath(m.Destination)
-		if err != nil {
-			return err
-		}
-
-		if forceSyscall {
-			syscall.Unmount(dest, 0)
-		}
-
-		if m.Volume != nil {
-			if err := m.Volume.Unmount(); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 func (container *Container) copyImagePathContent(v volume.Volume, destination string) error {
 	rootfs, err := symlink.FollowSymlinkInScope(filepath.Join(container.basefs, destination), container.basefs)
 	if err != nil {

--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -954,3 +954,23 @@ func (container *Container) DisableLink(name string) {
 		}
 	}
 }
+
+func (container *Container) UnmountVolumes(forceSyscall bool) error {
+	for _, m := range container.MountPoints {
+		dest, err := container.GetResourcePath(m.Destination)
+		if err != nil {
+			return err
+		}
+
+		if forceSyscall {
+			syscall.Unmount(dest, 0)
+		}
+
+		if m.Volume != nil {
+			if err := m.Volume.Unmount(); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -165,3 +165,7 @@ func disableAllActiveLinks(container *Container) {
 
 func (container *Container) DisableLink(name string) {
 }
+
+func (container *Container) UnmountVolumes(forceSyscall bool) error {
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli @calavera 

This PR is part of the proposal described in issue 10662 to port the docker daemon to Windows. Fixup to daemon\container*.go to get back to building on Windows again.
