### PR TITLE
Always remove volume when not `local`

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1071,17 +1071,6 @@ func (container *Container) prepareMountPoints() error {
 	return nil
 }
 
-func (container *Container) removeMountPoints() error {
-	for _, m := range container.MountPoints {
-		if m.Volume != nil {
-			if err := removeVolume(m.Volume); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 func (container *Container) shouldRestart() bool {
 	return container.hostConfig.RestartPolicy.Name == "always" ||
 		(container.hostConfig.RestartPolicy.Name == "on-failure" && container.ExitCode != 0)

--- a/integration-cli/docker_cli_start_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_start_volume_driver_unix_test.go
@@ -233,7 +233,7 @@ func (s DockerExternalVolumeSuite) TestStartExternalVolumeDriverDeleteContainer(
 		c.Fatal(err)
 	}
 
-	if _, err := s.d.Cmd("rm", "-fv", "vol-test1"); err != nil {
+	if _, err := s.d.Cmd("rm", "-f", "vol-test1"); err != nil {
 		c.Fatal(err)
 	}
 


### PR DESCRIPTION
This makes sure that volume drivers which are not `local` can accurately
ref-count.

Incidentally with the `local` driver, if a container has a volume and it
is not removed with `docker rm -v`, the ref count will get messed up
sicne the driver doesn't get the remove request (which is where it's
counting)... only way to be able to remove such volumes would be to
restart the daemon to reset the ref counter.
