### PR TITLE
Add Container data to logger.Context via new struct

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -644,6 +644,13 @@ func (container *Container) getLogConfig() runconfig.LogConfig {
 	return container.daemon.defaultLogConfig
 }
 
+func (container *Container) getLoggerMetadata() *logger.ContainerMetadata {
+	return &logger.ContainerMetadata{
+		ID:   container.ID,
+		Name: container.Name,
+	}
+}
+
 func (container *Container) getLogger() (logger.Logger, error) {
 	cfg := container.getLogConfig()
 	c, err := logger.GetLogDriver(cfg.Type)
@@ -651,9 +658,8 @@ func (container *Container) getLogger() (logger.Logger, error) {
 		return nil, fmt.Errorf("Failed to get logging factory: %v", err)
 	}
 	ctx := logger.Context{
-		Config:        cfg.Config,
-		ContainerID:   container.ID,
-		ContainerName: container.Name,
+		Config:    cfg.Config,
+		Container: container.getLoggerMetadata(),
 	}
 
 	// Set logging file for "json-logger"

--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -8,12 +8,16 @@ import (
 // Creator is a method that builds a logging driver instance with given context
 type Creator func(Context) (Logger, error)
 
+type ContainerMetadata struct {
+	ID   string
+	Name string
+}
+
 // Context provides enough information for a logging driver to do its function
 type Context struct {
-	Config        map[string]string
-	ContainerID   string
-	ContainerName string
-	LogPath       string
+	Config    map[string]string
+	Container *ContainerMetadata
+	LogPath   string
 }
 
 type logdriverFactory struct {

--- a/daemon/logger/journald/journald.go
+++ b/daemon/logger/journald/journald.go
@@ -29,13 +29,13 @@ func New(ctx logger.Context) (logger.Logger, error) {
 	}
 	// Strip a leading slash so that people can search for
 	// CONTAINER_NAME=foo rather than CONTAINER_NAME=/foo.
-	name := ctx.ContainerName
+	name := ctx.Container.Name
 	if name[0] == '/' {
 		name = name[1:]
 	}
 	jmap := map[string]string{
-		"CONTAINER_ID":      ctx.ContainerID[:12],
-		"CONTAINER_ID_FULL": ctx.ContainerID,
+		"CONTAINER_ID":      ctx.Container.ID[:12],
+		"CONTAINER_ID_FULL": ctx.Container.ID,
 		"CONTAINER_NAME":    name}
 	return &Journald{Jmap: jmap}, nil
 }

--- a/daemon/logger/syslog/syslog.go
+++ b/daemon/logger/syslog/syslog.go
@@ -26,7 +26,7 @@ func init() {
 }
 
 func New(ctx logger.Context) (logger.Logger, error) {
-	tag := ctx.ContainerID[:12]
+	tag := ctx.Container.ID[:12]
 	log, err := syslog.New(syslog.LOG_DAEMON, fmt.Sprintf("%s/%s", path.Base(os.Args[0]), tag))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR basically abstract the need to clutter the `logger.Context` struct when loggers needs more data from a container than `ID` or `Name` (https://github.com/docker/docker/pull/13015/files#diff-6ce9e79ddb91a3f06352abe1f2c72ecbR1448)
Instead of passing the whole `daemon.Container` struct to `logger` (import cycle too) we pass in the context this new struct built from Container..
This PR just add `ID` and `Name` to this new struct but there can be many more 
This is a clean way to let the logger api provide all it needs to implement a new logger from scratch and ideally  there should be no need to do something outside of the logger driver api.

(I can call this new struct as you wish also..)

ping @LK4D4 @duglin @cpuguy83 

Signed-off-by: Antonio Murdaca me@runcom.ninja
