### PR TITLE
Do not force `syscall.Unmount` on container cleanup.

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -347,7 +347,7 @@ func (container *Container) cleanup() {
 		container.daemon.unregisterExecCommand(eConfig)
 	}
 
-	container.UnmountVolumes(true)
+	container.UnmountVolumes(false)
 }
 
 func (container *Container) KillSig(sig int) error {


### PR DESCRIPTION
This is not necessary and it's a regression from the old behavior.

Signed-off-by: David Calavera david.calavera@gmail.com
