### PR TITLE
Fix container unmount networkMounts

### DIFF
--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -956,21 +956,37 @@ func (container *Container) DisableLink(name string) {
 }
 
 func (container *Container) UnmountVolumes(forceSyscall bool) error {
-	for _, m := range container.MountPoints {
-		dest, err := container.GetResourcePath(m.Destination)
+	var volumeMounts []mountPoint
+
+	for _, mntPoint := range container.MountPoints {
+		dest, err := container.GetResourcePath(mntPoint.Destination)
 		if err != nil {
 			return err
 		}
 
-		if forceSyscall {
-			syscall.Unmount(dest, 0)
+		volumeMounts = append(volumeMounts, mountPoint{Destination: dest, Volume: mntPoint.Volume})
+	}
+
+	for _, mnt := range container.networkMounts() {
+		dest, err := container.GetResourcePath(mnt.Destination)
+		if err != nil {
+			return err
 		}
 
-		if m.Volume != nil {
-			if err := m.Volume.Unmount(); err != nil {
+		volumeMounts = append(volumeMounts, mountPoint{Destination: dest})
+	}
+
+	for _, volumeMount := range volumeMounts {
+		if forceSyscall {
+			syscall.Unmount(volumeMount.Destination, 0)
+		}
+
+		if volumeMount.Volume != nil {
+			if err := volumeMount.Volume.Unmount(); err != nil {
 				return err
 			}
 		}
 	}
+
 	return nil
 }

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -8,7 +8,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/volume"
@@ -113,20 +112,6 @@ func validMountMode(mode string) bool {
 		"ro": true,
 	}
 	return validModes[mode]
-}
-
-func (container *Container) specialMounts() []execdriver.Mount {
-	var mounts []execdriver.Mount
-	if container.ResolvConfPath != "" {
-		mounts = append(mounts, execdriver.Mount{Source: container.ResolvConfPath, Destination: "/etc/resolv.conf", Writable: !container.hostConfig.ReadonlyRootfs, Private: true})
-	}
-	if container.HostnamePath != "" {
-		mounts = append(mounts, execdriver.Mount{Source: container.HostnamePath, Destination: "/etc/hostname", Writable: !container.hostConfig.ReadonlyRootfs, Private: true})
-	}
-	if container.HostsPath != "" {
-		mounts = append(mounts, execdriver.Mount{Source: container.HostsPath, Destination: "/etc/hosts", Writable: !container.hostConfig.ReadonlyRootfs, Private: true})
-	}
-	return mounts
 }
 
 func copyExistingContents(source, destination string) error {

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -596,3 +596,40 @@ func (s *DockerSuite) TestCpNameHasColon(c *check.C) {
 		c.Fatalf("Wrong content in copied file %q, should be %q", content, "lololol\n")
 	}
 }
+
+func (s *DockerSuite) TestCopyAndRestart(c *check.C) {
+	expectedMsg := "hello"
+	out, err := exec.Command(dockerBinary, "run", "-d", "busybox", "echo", expectedMsg).CombinedOutput()
+	if err != nil {
+		c.Fatal(string(out), err)
+	}
+	id := strings.TrimSpace(string(out))
+
+	if out, err = exec.Command(dockerBinary, "wait", id).CombinedOutput(); err != nil {
+		c.Fatalf("unable to wait for container: %s", err)
+	}
+
+	status := strings.TrimSpace(string(out))
+	if status != "0" {
+		c.Fatalf("container exited with status %s", status)
+	}
+
+	tmpDir, err := ioutil.TempDir("", "test-docker-restart-after-copy-")
+	if err != nil {
+		c.Fatalf("unable to make temporary directory: %s", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if _, err = exec.Command(dockerBinary, "cp", fmt.Sprintf("%s:/etc/issue", id), tmpDir).CombinedOutput(); err != nil {
+		c.Fatalf("unable to copy from busybox container: %s", err)
+	}
+
+	if out, err = exec.Command(dockerBinary, "start", "-a", id).CombinedOutput(); err != nil {
+		c.Fatalf("unable to start busybox container after copy: %s - %s", err, out)
+	}
+
+	msg := strings.TrimSpace(string(out))
+	if msg != expectedMsg {
+		c.Fatalf("expected %q but got %q", expectedMsg, msg)
+	}
+}


### PR DESCRIPTION
UnmountVolumes used to also unmount 'specialMounts' but it no longer does after
a recent refactor of volumes. This patch corrects this behavior to include
unmounting of `networkMounts` which replaces `specialMounts` (now dead code).
