### PR TITLE
Windows: Allow VFS

### DIFF
--- a/daemon/graphdriver/driver_windows.go
+++ b/daemon/graphdriver/driver_windows.go
@@ -1,26 +1,25 @@
 package graphdriver
 
+import (
+	_ "github.com/docker/docker/daemon/graphdriver/vfs"
+
+	// TODO Windows - Add references to real graph driver when PR'd
+)
+
 type DiffDiskDriver interface {
 	Driver
 	CopyDiff(id, sourceId string) error
 }
 
-const (
-	FsMagicWindows = FsMagic(0xa1b1830f)
-)
-
 var (
-	// Slice of drivers that should be used in an order
+	// Slice of drivers that should be used in order
 	priority = []string{
 		"windows",
-	}
-
-	FsNames = map[FsMagic]string{
-		FsMagicWindows:     "windows",
-		FsMagicUnsupported: "unsupported",
+		"vfs",
 	}
 )
 
 func GetFSMagic(rootpath string) (FsMagic, error) {
-	return FsMagicWindows, nil
+	// Note it is OK to return FsMagicUnsupported on Windows.
+	return FsMagicUnsupported, nil
 }

--- a/daemon/graphdriver/vfs/driver.go
+++ b/daemon/graphdriver/vfs/driver.go
@@ -5,7 +5,7 @@ package vfs
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/chrootarchive"
@@ -42,7 +42,7 @@ func (d *Driver) Cleanup() error {
 
 func (d *Driver) Create(id, parent string) error {
 	dir := d.dir(id)
-	if err := system.MkdirAll(path.Dir(dir), 0700); err != nil {
+	if err := system.MkdirAll(filepath.Dir(dir), 0700); err != nil {
 		return err
 	}
 	if err := os.Mkdir(dir, 0755); err != nil {
@@ -66,7 +66,7 @@ func (d *Driver) Create(id, parent string) error {
 }
 
 func (d *Driver) dir(id string) string {
-	return path.Join(d.home, "dir", path.Base(id))
+	return filepath.Join(d.home, "dir", filepath.Base(id))
 }
 
 func (d *Driver) Remove(id string) error {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. This enables the use of the VFS graphdriver on the Windows specifically for the development of the Windows daemon without the need to have full Windows containers support on the back-end.

BTW - The Windows daemon is starting to limp now on the 1.7 dev codebase :)
![daemon limps](https://cloud.githubusercontent.com/assets/10522484/7824999/b491778c-03bc-11e5-909c-3c75380422db.GIF)

![Uploading info2.JPG…]()
