### PR TITLE
Windows: Set default exec driver to windows

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -76,7 +76,7 @@ func (config *Config) InstallCommonFlags() {
 	flag.StringVar(&config.Bridge.DefaultGatewayIPv6, []string{"-default-gateway-v6"}, "", "Container default gateway IPv6 address")
 	flag.BoolVar(&config.Bridge.InterContainerCommunication, []string{"#icc", "-icc"}, true, "Enable inter-container communication")
 	flag.StringVar(&config.GraphDriver, []string{"s", "-storage-driver"}, "", "Storage driver to use")
-	flag.StringVar(&config.ExecDriver, []string{"e", "-exec-driver"}, "native", "Exec driver to use")
+	flag.StringVar(&config.ExecDriver, []string{"e", "-exec-driver"}, defaultExec, "Exec driver to use")
 	flag.IntVar(&config.Mtu, []string{"#mtu", "-mtu"}, 0, "Set the containers network MTU")
 	flag.BoolVar(&config.EnableCors, []string{"#api-enable-cors", "#-api-enable-cors"}, false, "Enable CORS headers in the remote API, this is deprecated by --api-cors-header")
 	flag.StringVar(&config.CorsHeaders, []string{"-api-cors-header"}, "", "Set CORS headers in the remote API")

--- a/daemon/config_linux.go
+++ b/daemon/config_linux.go
@@ -9,6 +9,7 @@ import (
 var (
 	defaultPidFile = "/var/run/docker.pid"
 	defaultGraph   = "/var/lib/docker"
+	defaultExec    = "native"
 )
 
 // Config defines the configuration of a docker daemon.

--- a/daemon/config_windows.go
+++ b/daemon/config_windows.go
@@ -7,6 +7,7 @@ import (
 var (
 	defaultPidFile = os.Getenv("programdata") + string(os.PathSeparator) + "docker.pid"
 	defaultGraph   = os.Getenv("programdata") + string(os.PathSeparator) + "docker"
+	defaultExec    = "windows"
 )
 
 // Config defines the configuration of a docker daemon.


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. This sets the default exec driver for the Windows daemon to "windows". No change on Linux.
