### PR TITLE
Add --net=container with --publish --expose --publish-all error out

### DIFF
--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -319,7 +319,8 @@ With the networking mode set to `container` a container will share the
 network stack of another container.  The other container's name must be
 provided in the format of `--net container:<name|id>`. Note that `--add-host` 
 `--hostname` `--dns` `--dns-search` and `--mac-address` is invalid 
-in `container` netmode.
+in `container` netmode, and `--publish` `--publish-all` `--expose` are also
+invalid in `container` netmode.
 
 Example running a Redis container with Redis binding to `localhost` then
 running the `redis-cli` command and connecting to the Redis server over the

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -20,6 +20,8 @@ var (
 	ErrConflictHostNetworkAndLinks      = fmt.Errorf("Conflicting options: --net=host can't be used with links. This would result in undefined behavior")
 	ErrConflictContainerNetworkAndMac   = fmt.Errorf("Conflicting options: --mac-address and the network mode (--net)")
 	ErrConflictNetworkHosts             = fmt.Errorf("Conflicting options: --add-host and the network mode (--net)")
+	ErrConflictNetworkPublishPorts      = fmt.Errorf("Conflicting options: -p, -P, --publish-all, --publish and the network mode (--net)")
+	ErrConflictNetworkExposePorts       = fmt.Errorf("Conflicting options: --expose and the network mode (--expose)")
 )
 
 func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSet, error) {
@@ -143,6 +145,13 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		return nil, nil, cmd, ErrConflictContainerNetworkAndMac
 	}
 
+	if netMode.IsContainer() && (flPublish.Len() > 0 || *flPublishAll == true) {
+		return nil, nil, cmd, ErrConflictNetworkPublishPorts
+	}
+
+	if netMode.IsContainer() && flExpose.Len() > 0 {
+		return nil, nil, cmd, ErrConflictNetworkExposePorts
+	}
 	// Validate the input mac address
 	if *flMacAddress != "" {
 		if _, err := opts.ValidateMACAddress(*flMacAddress); err != nil {


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Create a container with `--net=container`, the `--publish` `--publish-all` and `--expose`
is invalid, we should info the user to not use `--net=container` with `--publish` `--publish-all` and `--expose`
