### PR TITLE
Refactor verifyHostConfig: change to verifyConfigs and add verify config

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -19,16 +19,9 @@ func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hos
 		return "", nil, fmt.Errorf("Config cannot be empty in order to create a container")
 	}
 
-	warnings, err := daemon.verifyContainerSettings(hostConfig)
+	warnings, err := daemon.verifyContainerSettings(hostConfig, config)
 	if err != nil {
 		return "", warnings, err
-	}
-
-	// The check for a valid workdir path is made on the server rather than in the
-	// client. This is because we don't know the type of path (Linux or Windows)
-	// to validate on the client.
-	if config.WorkingDir != "" && !filepath.IsAbs(config.WorkingDir) {
-		return "", warnings, fmt.Errorf("The working directory '%s' is invalid. It needs to be an absolute path.", config.WorkingDir)
 	}
 
 	container, buildWarnings, err := daemon.Create(config, hostConfig, name)

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -112,8 +112,17 @@ func checkKernel() error {
 	return nil
 }
 
-func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig) ([]string, error) {
+func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, config *runconfig.Config) ([]string, error) {
 	var warnings []string
+
+	if config != nil {
+		// The check for a valid workdir path is made on the server rather than in the
+		// client. This is because we don't know the type of path (Linux or Windows)
+		// to validate on the client.
+		if config.WorkingDir != "" && !filepath.IsAbs(config.WorkingDir) {
+			return warnings, fmt.Errorf("The working directory '%s' is invalid. It needs to be an absolute path.", config.WorkingDir)
+		}
+	}
 
 	if hostConfig == nil {
 		return warnings, nil

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -42,7 +42,7 @@ func checkKernel() error {
 	return nil
 }
 
-func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig) ([]string, error) {
+func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, config *runconfig.HostConfig) ([]string, error) {
 	// TODO Windows. Verifications TBC
 	return nil, nil
 }

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -20,7 +20,7 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConf
 		return fmt.Errorf("Container already started")
 	}
 
-	if _, err = daemon.verifyContainerSettings(hostConfig); err != nil {
+	if _, err = daemon.verifyContainerSettings(hostConfig, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Change verifyHostConfig to verifyConifigs and 
add verify config. In this way we can verify some config
which is conflict with hostConfig in the same function and on the daemon side.
