### PR TITLE
Fix output for inspect non exist container

### DIFF
--- a/api/client/inspect.go
+++ b/api/client/inspect.go
@@ -108,7 +108,7 @@ func (cli *DockerCli) CmdInspect(args ...string) error {
 	}
 	indented.WriteString("]\n")
 
-	if tmpl == nil {
+	if tmpl == nil && status == 0 {
 		if _, err := io.Copy(cli.out, indented); err != nil {
 			return err
 		}


### PR DESCRIPTION
Before:
$ docker inspect adsf
Error: No such image or container: adsf
[]

After:
$ docker inspect adsf
Error: No such image or container: adsf

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
