### PR TITLE
Various spelling and documentation fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Prohibit mount of /sys
 
 #### Runtime
-- Update Apparmor policy to not allow mounts
+- Update AppArmor policy to not allow mounts
 
 ## 1.6.0 (2015-04-07)
 
@@ -309,7 +309,7 @@
 
 #### Hack
 * Clean up "go test" output from "make test" to be much more readable/scannable.
-* Excluse more "definitely not unit tested Go source code" directories from hack/make/test.
+* Exclude more "definitely not unit tested Go source code" directories from hack/make/test.
 + Generate md5 and sha256 hashes when building, and upload them via hack/release.sh.
 - Include contributed completions in Ubuntu PPA.
 + Add cli integration tests.
@@ -589,7 +589,7 @@ With the ongoing changes to the networking and execution subsystems of docker te
 * The ADD instruction now supports caching, which avoids unnecessarily re-uploading the same source content again and again when it hasn’t changed
 * The new ONBUILD instruction adds to your image a “trigger” instruction to be executed at a later time, when the image is used as the base for another build
 * Docker now ships with an experimental storage driver which uses the BTRFS filesystem for copy-on-write
-* Docker is officially supported on Mac OSX
+* Docker is officially supported on Mac OS X
 * The Docker daemon supports systemd socket activation
 
 ## 0.7.6 (2014-01-14)
@@ -643,12 +643,12 @@ With the ongoing changes to the networking and execution subsystems of docker te
 - Fix ADD caching issue with . prefixed path
 - Fix docker build on devicemapper by reverting sparse file tar option
 - Fix issue with file caching and prevent wrong cache hit
-* Use same error handling while unmarshalling  CMD and ENTRYPOINT
+* Use same error handling while unmarshalling CMD and ENTRYPOINT
 
 #### Documentation
 
 * Simplify and streamline Amazon Quickstart
-* Install instructions use unprefixed fedora image
+* Install instructions use unprefixed Fedora image
 * Update instructions for mtu flag for Docker on GCE
 + Add Ubuntu Saucy to installation
 - Fix for wrong version warning on master instead of latest
@@ -823,7 +823,7 @@ With the ongoing changes to the networking and execution subsystems of docker te
 * Improve unit tests
 * The test suite now runs all tests even if one fails
 * Refactor C in Go (Devmapper)
-- Fix OSX compilation
+- Fix OS X compilation
 
 ## 0.7.0 (2013-11-25)
 
@@ -841,7 +841,7 @@ With the ongoing changes to the networking and execution subsystems of docker te
 
 #### Runtime
 
-* Improve stability, fixes some race conditons
+* Improve stability, fixes some race conditions
 * Skip the volumes mounted when deleting the volumes of container.
 * Fix layer size computation: handle hard links correctly
 * Use the work Path for docker cp CONTAINER:PATH

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,7 +220,7 @@ set of patches that should be reviewed together: for example, upgrading the
 version of a vendored dependency and taking advantage of its now available new
 feature constitute two separate units of work. Implementing a new function and
 calling it in another file constitute a single logical unit of work. The very
-high majory of submissions should have a single commit, so if in doubt: squash
+high majority of submissions should have a single commit, so if in doubt: squash
 down to one.
 
 After every commit, [make sure the test suite passes]
@@ -317,7 +317,7 @@ maintainer to make a difference on the project!
 
 ### IRC meetings
 
-There are two monthly meetings taking place on #docker-dev IRC to accomodate all
+There are two monthly meetings taking place on #docker-dev IRC to accommodate all
 timezones. Anybody can propose a topic for discussion prior to the meeting.
 
 If you feel the conversation is going off-topic, feel free to point it out.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@
 #  -e GPG_PASSPHRASE=gloubiboulga \
 #  docker hack/release.sh
 #
-# Note: Apparmor used to mess with privileged mode, but this is no longer
+# Note: AppArmor used to mess with privileged mode, but this is no longer
 # the case. Therefore, you don't have to disable it anymore.
 #
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ security@docker.com and not by creating a github issue.
 
 A common method for distributing applications and sandboxing their
 execution is to use virtual machines, or VMs. Typical VM formats are
-VMWare's vmdk, Oracle Virtualbox's vdi, and Amazon EC2's ami. In theory
+VMWare's vmdk, Oracle VirtualBox's vdi, and Amazon EC2's ami. In theory
 these formats should allow every developer to automatically package
 their application into a "machine" for easy distribution and deployment.
 In practice, that almost never happens, for a few reasons:

--- a/builder/parser/testfiles/docker/Dockerfile
+++ b/builder/parser/testfiles/docker/Dockerfile
@@ -19,7 +19,7 @@
 #  -e GPG_PASSPHRASE=gloubiboulga \
 #  docker hack/release.sh
 #
-# Note: Apparmor used to mess with privileged mode, but this is no longer
+# Note: AppArmor used to mess with privileged mode, but this is no longer
 # the case. Therefore, you don't have to disable it anymore.
 #
 

--- a/contrib/syntax/textmate/README.md
+++ b/contrib/syntax/textmate/README.md
@@ -1,16 +1,16 @@
 # Docker.tmbundle
 
-Dockerfile syntaxt highlighting for TextMate and Sublime Text.
+Dockerfile syntax highlighting for TextMate and Sublime Text.
 
 ## Install
 
 ### Sublime Text
 
-Available for Sublime Text under [package control](https://sublime.wbond.net/packages/Dockerfile%20Syntax%20Highlighting).
+Available for Sublime Text under [Package Control](https://sublime.wbond.net/packages/Dockerfile%20Syntax%20Highlighting).
 Search for *Dockerfile Syntax Highlighting*
 
 ### TextMate 2
 
-Copy the directory `Docker.tmbundle` (showed as a Package in OSX) to `~/Library/Application Support/TextMate/Managed/Bundles`
+Copy the directory `Docker.tmbundle` (shown as a Package in OS X) to `~/Library/Application Support/TextMate/Managed/Bundles`
 
-enjoy.
+Enjoy.

--- a/daemon/graphdriver/devmapper/README.md
+++ b/daemon/graphdriver/devmapper/README.md
@@ -262,7 +262,7 @@ Here is the list of supported options:
     device. And devices automatically goes away when last user of device
     exits.
 
-    For example, when contianer exits, its associated thin device is
+    For example, when container exits, its associated thin device is
     removed. If that devices has leaked into some other mount namespace
     can can't be removed now, container exit will still be successful
     and this option will just schedule device for deferred removal and

--- a/docs/README.md
+++ b/docs/README.md
@@ -280,9 +280,9 @@ aws cloudfront  create-invalidation --profile docs.docker.com --distribution-id 
 aws cloudfront  create-invalidation --profile docs.docker.com --distribution-id $DISTRIBUTION_ID --invalidation-batch '{"Paths":{"Quantity":1, "Items":["/v1.1/reference/api/docker_io_oauth_api/"]},"CallerReference":"6Mar2015sventest1"}'
 ```
 
-### Generate the man pages for Mac OSX
+### Generate the man pages for Mac OS X
 
-When using Docker on Mac OSX the man pages will be missing by default. You can manually generate them by following these steps:
+When using Docker on Mac OS X the man pages will be missing by default. You can manually generate them by following these steps:
 
 1. Checkout the docker source. You must clone into your `/Users` directory because Boot2Docker can only share this path
    with the docker containers.

--- a/docs/man/docker-build.1.md
+++ b/docs/man/docker-build.1.md
@@ -200,9 +200,9 @@ into account Docker community conventions.
 
 ## Building an image using a URL
 
-This will clone the specified Github repository from the URL and use it
+This will clone the specified GitHub repository from the URL and use it
 as context. The Dockerfile at the root of the repository is used as
-Dockerfile. This only works if the Github repository is a dedicated
+Dockerfile. This only works if the GitHub repository is a dedicated
 repository.
 
     docker build github.com/scollier/Fedora-Dockerfiles/tree/master/apache

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -80,7 +80,7 @@ IMAGE [COMMAND] [ARG...]
 **--cgroup-parent**=""
    Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 
-**--cpu-peroid**=0
+**--cpu-period**=0
     Limit the CPU CFS (Completely Fair Scheduler) period
 
 **--cpuset-cpus**=""

--- a/docs/man/docker-export.1.md
+++ b/docs/man/docker-export.1.md
@@ -41,4 +41,4 @@ and import the contents of the tarball into it, then optionally tag it.
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
-Janurary 2015, updated by Joseph Kern (josephakern at gmail dot com)
+January 2015, updated by Joseph Kern (josephakern at gmail dot com)

--- a/docs/sources/articles/security.md
+++ b/docs/sources/articles/security.md
@@ -262,7 +262,7 @@ Docker containers are, by default, quite secure; especially if you take
 care of running your processes inside the containers as non-privileged
 users (i.e., non-`root`).
 
-You can add an extra layer of safety by enabling Apparmor, SELinux,
+You can add an extra layer of safety by enabling AppArmor, SELinux,
 GRSEC, or your favorite hardening solution.
 
 Last but not least, if you see interesting security features in other

--- a/docs/sources/docker-hub-enterprise/release-notes.md
+++ b/docs/sources/docker-hub-enterprise/release-notes.md
@@ -21,8 +21,8 @@ page_keywords: docker, documentation, about, technology, understanding, enterpri
 ### CS Docker Engine 1.6.2-cs5
 (21 May 2015)
 
-For customers running Docker Engine on [supported versions of RedHat Enterprise
-Linux](https://www.docker.com/enterprise/support/) with [SELinux
+For customers running Docker Engine on [supported versions of Red Hat Enterprise
+Linux (RHEL)](https://www.docker.com/enterprise/support/) with [SELinux
 enabled](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/
 6/html/Security-Enhanced_Linux/sect-Security-Enhanced_Linux-Working_with_SELinux
 -Enabling_and_Disabling_SELinux.html), the `docker build` and `docker run`

--- a/docs/sources/docker-hub/builds.md
+++ b/docs/sources/docker-hub/builds.md
@@ -225,7 +225,7 @@ Follow the steps below to configure the GitHub Service hooks for your Automated 
     <tr>
       <td>1.</td>
       <td><img src="/docker-hub/hub-images/gh_settings.png"></td>
-      <td>Log in to Github.com, and go to your Repository page. Click on "Settings" on
+      <td>Log in to GitHub.com, and go to your Repository page. Click on "Settings" on
       the right side of the page. You must have admin privileges to the repository in order to do this.</td>
     </tr>
     <tr>

--- a/docs/sources/docker-hub/official_repos.md
+++ b/docs/sources/docker-hub/official_repos.md
@@ -35,7 +35,7 @@ publishing all Official Repositories content. This team works in collaboration
 with upstream software maintainers, security experts, and the broader Docker
 community.
 
-While it is preferrable to have upstream software authors maintaining their
+While it is preferable to have upstream software authors maintaining their
 corresponding Official Repositories, this is not a strict requirement. Creating
 and maintaining images for Official Repositories is a public process. It takes
 place openly on GitHub where participation is encouraged. Anyone can provide
@@ -92,9 +92,9 @@ Official Repository is "generally useful" to the large Python developer
 community, whereas an obscure text adventure game written in Python last week is
 not.
 
-When a new proposal is accepted, the author becomes responsibile for keeping
+When a new proposal is accepted, the author becomes responsible for keeping
 their images up-to-date and responding to user feedback.  The Official
-Repositories team becomes responsibile for publishing the images and
+Repositories team becomes responsible for publishing the images and
 documentation on Docker Hub.  Updates to the Official Repository follow the same
 pull request process, though with less review. The Official Repositories team
 ultimately acts as a gatekeeper for all changes, which helps mitigate the risk

--- a/docs/sources/experimental/experimental.md
+++ b/docs/sources/experimental/experimental.md
@@ -8,7 +8,7 @@ experimental as of the current release. Experimental features are **not** ready
 for production. They are provided for test and evaluation in your sandbox
 environments.  
 
-The information below describes each feature and the Github pull requests and
+The information below describes each feature and the GitHub pull requests and
 issues associated with it. If necessary, links are provided to additional
 documentation on an issue.  As an active Docker user and community member,
 please feel free to provide any feedback on these features you wish.

--- a/docs/sources/installation/binaries.md
+++ b/docs/sources/installation/binaries.md
@@ -87,7 +87,7 @@ To set the file's execute bit on Linux and OS X:
 
     $ chmod +x docker
 
-To get the list of stable release version numbers from Github, view the
+To get the list of stable release version numbers from GitHub, view the
 `docker/docker` [releases page](https://github.com/docker/docker/releases). 
 
 > **Note**

--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -346,7 +346,7 @@ Use `boot2docker help` to list the full command line reference. For more
 information about using SSH or SCP to access the Boot2Docker VM, see the README
 at  [Boot2Docker repository](https://github.com/boot2docker/boot2docker).
 
-Thanks to Chris Jones whose [blog](http://goo.gl/Be6cCk)  inspired me to redo
-this page.
+Thanks to Chris Jones whose [blog](http://viget.com/extend/how-to-use-docker-on-os-x-the-missing-guide)  
+inspired me to redo this page.
 
 Continue with the [Docker User Guide](/userguide/).

--- a/docs/sources/installation/softlayer.md
+++ b/docs/sources/installation/softlayer.md
@@ -1,5 +1,5 @@
 page_title: Installation on IBM SoftLayer 
-page_description: Installation instructions for Docker on IBM Softlayer.
+page_description: Installation instructions for Docker on IBM SoftLayer.
 page_keywords: IBM SoftLayer, virtualization, cloud, docker, documentation, installation
 
 # IBM SoftLayer

--- a/docs/sources/installation/windows.md
+++ b/docs/sources/installation/windows.md
@@ -130,7 +130,7 @@ to you using:
 
     boot2docker ip
 
-Typically, it is 192.168.59.103, but it could get changed by Virtualbox's DHCP
+Typically, it is 192.168.59.103, but it could get changed by VirtualBox's DHCP
 implementation.
 
 For further information or to report issues, please see the [Boot2Docker site](http://boot2docker.io)

--- a/docs/sources/project/advanced-contributing.md
+++ b/docs/sources/project/advanced-contributing.md
@@ -147,6 +147,6 @@ Making a pull request with a design proposal simplifies this process:
 * you can leave comments on specific design proposal line
 * replies around line are easy to track
 * as a proposal changes and is updated, pages reset as line items resolve
-* Github maintains the entire history
+* GitHub maintains the entire history
 
 While proposals in pull requests do not end up merged into a master repository, they provide a convenient tool for managing the design process.

--- a/docs/sources/project/doc-style.md
+++ b/docs/sources/project/doc-style.md
@@ -207,7 +207,7 @@ Text taken from a GUI (e.g., menu text or button text) should appear in "double
 quotes". The text should take the exact same capitalisation, etc. as appears in
 the GUI. E.g., Click "Continue" to save the settings.
 
-Text that refers to a keyboard command or hotkey is  capitalized (e.g., Ctrl-D).
+Text that refers to a keyboard command or hotkey is capitalized (e.g., Ctrl-D).
 
 When writing CLI examples, give the user hints by making the examples resemble
 exactly what they see in their shell: 

--- a/docs/sources/project/set-up-git.md
+++ b/docs/sources/project/set-up-git.md
@@ -225,7 +225,7 @@ the branch to your fork on GitHub:
          * [new branch]      dry-run-test -> dry-run-test
         Branch dry-run-test set up to track remote branch dry-run-test from origin.
 
-9. Open your browser to Github.
+9. Open your browser to GitHub.
 
 10. Navigate to your Docker fork.
 

--- a/docs/sources/project/software-req-win.md
+++ b/docs/sources/project/software-req-win.md
@@ -191,8 +191,8 @@ In this section, you install the Go language. Then, you build the source so that
 
 ## Get the Docker repository
 
-In this step, you start a Git `bash` terminal and get the Docker source code from
-Github. 
+In this step, you start a Git `bash` terminal and get the Docker source code 
+from GitHub. 
 
 1. Locate the **Git Bash** program and start it.
 

--- a/docs/sources/reference/api/docker_remote_api_v1.6.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.6.md
@@ -178,7 +178,7 @@ Status Codes:
              "Warnings":[]
         }
 
-    **Second, start (using the ID returned above) the image we jus
+    **Second, start (using the ID returned above) the image we just
     created, mapping the ssh port 22 to something on the host**:
 
         POST /containers/e90e34656806/start HTTP/1.1
@@ -190,7 +190,7 @@ Status Codes:
 
 **Example response**:
 
-        HTTP/1.1 204 No Conten
+        HTTP/1.1 204 No Content
         Content-Type: text/plain; charset=utf-8
         Content-Length: 0
 

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -662,7 +662,7 @@ is returned by the `docker attach` command to its caller too:
       --memory-swap=""         Total memory (memory + swap), `-1` to disable swap
       -c, --cpu-shares         CPU Shares (relative weight)
       --cpuset-mems=""         MEMs in which to allow execution, e.g. `0-3`, `0,1`
-      --cpuset-cpus=""         CPUs in which to allow exection, e.g. `0-3`, `0,1`
+      --cpuset-cpus=""         CPUs in which to allow execution, e.g. `0-3`, `0,1`
       --cgroup-parent=""       Optional parent cgroup for the container
 
 Builds Docker images from a Dockerfile and a "context". A build's context is
@@ -677,7 +677,7 @@ and its submodules using a `git clone --depth 1 --recursive` command.
 This command runs in a temporary directory on your local host.
 After the command succeeds, the directory is sent to the Docker daemon as the context.
 Local clones give you the ability to access private repositories using
-local user credentials, VPN's, and so forth.
+local user credentials, VPNs, and so forth.
 
 Git URLs accept context configuration in their fragment section, separated by a colon `:`.
 The first part represents the reference that Git will check out, this can be either

--- a/docs/sources/reference/glossary.md
+++ b/docs/sources/reference/glossary.md
@@ -90,7 +90,7 @@ Docker and its components. It provides the following services:
 - Docker image hosting
 - User authentication
 - Automated image builds and work-flow tools such as build triggers and web hooks
-- Integration with GitHub and BitBucket
+- Integration with GitHub and Bitbucket
 
 
 ## Dockerfile

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -1017,7 +1017,7 @@ variables automatically:
   </td>
  <tr>
   <td><code>TERM</code></td>
-  <td><code>xterm</code> if the container is allocated a psuedo-TTY</td>
+  <td><code>xterm</code> if the container is allocated a pseudo-TTY</td>
  </tr>
 </table>
 

--- a/docs/sources/release-notes.md
+++ b/docs/sources/release-notes.md
@@ -40,7 +40,7 @@ repository](https://github.com/docker/docker/issues/).
 An idiosyncrasy in AUFS prevented permissions from propagating predictably
 between upper and lower layers. This caused issues with accessing private
 keys, database instances, etc.  This issue was closed in this release:
-[Github Issue 783](https://github.com/docker/docker/issues/783).
+[GitHub Issue 783](https://github.com/docker/docker/issues/783).
 
 
 * *Docker Hub incompatible with Safari 8*

--- a/docs/sources/userguide/dockerhub.md
+++ b/docs/sources/userguide/dockerhub.md
@@ -16,7 +16,7 @@ most out of Docker. To do this, it provides services such as:
 * User authentication.
 * Automated image builds and work-flow tools such as build triggers and web
   hooks.
-* Integration with GitHub and BitBucket.
+* Integration with GitHub and Bitbucket.
 
 In order to use Docker Hub, you will first need to register and create an account. Don't
 worry, creating an account is simple and free.

--- a/docs/sources/userguide/dockerrepos.md
+++ b/docs/sources/userguide/dockerrepos.md
@@ -118,16 +118,16 @@ manage private repositories. You can learn how to create and manage an organizat
 ### Automated Builds
 
 Automated Builds automate the building and updating of images from
-[GitHub](https://www.github.com) or [BitBucket](http://bitbucket.com), directly on Docker
-Hub. It works by adding a commit hook to your selected GitHub or BitBucket repository,
+[GitHub](https://www.github.com) or [Bitbucket](http://bitbucket.com), directly on Docker
+Hub. It works by adding a commit hook to your selected GitHub or Bitbucket repository,
 triggering a build and update when you push a commit.
 
 #### To setup an Automated Build
 
 1.  Create a [Docker Hub account](https://hub.docker.com/) and login.
-2.  Link your GitHub or BitBucket account through the ["Link Accounts"](https://registry.hub.docker.com/account/accounts/) menu.
+2.  Link your GitHub or Bitbucket account through the ["Link Accounts"](https://registry.hub.docker.com/account/accounts/) menu.
 3.  [Configure an Automated Build](https://registry.hub.docker.com/builds/add/).
-4.  Pick a GitHub or BitBucket project that has a `Dockerfile` that you want to build.
+4.  Pick a GitHub or Bitbucket project that has a `Dockerfile` that you want to build.
 5.  Pick the branch you want to build (the default is the `master` branch).
 6.  Give the Automated Build a name.
 7.  Assign an optional Docker tag to the Build.
@@ -135,7 +135,7 @@ triggering a build and update when you push a commit.
 
 Once the Automated Build is configured it will automatically trigger a
 build and, in a few minutes, you should see your new Automated Build on the [Docker Hub](https://hub.docker.com)
-Registry. It will stay in sync with your GitHub and BitBucket repository until you
+Registry. It will stay in sync with your GitHub and Bitbucket repository until you
 deactivate the Automated Build.
 
 If you want to see the status of your Automated Builds, you can go to your
@@ -144,7 +144,7 @@ and it will show you the status of your builds and their build history.
 
 Once you've created an Automated Build you can deactivate or delete it. You
 cannot, however, push to an Automated Build with the `docker push` command.
-You can only manage it by committing code to your GitHub or BitBucket
+You can only manage it by committing code to your GitHub or Bitbucket
 repository.
 
 You can create multiple Automated Builds per repository and configure them

--- a/docs/sources/userguide/dockervolumes.md
+++ b/docs/sources/userguide/dockervolumes.md
@@ -80,9 +80,9 @@ directory from your Docker daemon's host into a container.
 
 > **Note:**
 > If you are using Boot2Docker, your Docker daemon only has limited access to
-> your OSX/Windows filesystem. Boot2Docker tries to auto-share your `/Users`
-> (OSX) or `C:\Users` (Windows) directory - and so you can mount files or directories
-> using `docker run -v /Users/<path>:/<container path> ...` (OSX) or
+> your OS X/Windows filesystem. Boot2Docker tries to auto-share your `/Users`
+> (OS X) or `C:\Users` (Windows) directory - and so you can mount files or directories
+> using `docker run -v /Users/<path>:/<container path> ...` (OS X) or
 > `docker run -v /c/Users/<path>:/<container path ...` (Windows). All other paths
 > come from the Boot2Docker virtual machine's filesystem.
 

--- a/docs/sources/userguide/level2.md
+++ b/docs/sources/userguide/level2.md
@@ -74,7 +74,7 @@ RUN apt-get install -y <input id="gcc" class="l_fill" type="text"><br>
 <input id="run6" class="l_fill" type="text">cd redis-stable && make && make install<br>
 &#35; launch redis when starting the image
 <input id="entrypoint" class="l_fill" type="text"> ["redis-server"]<br>
-&#35; run as user dameon
+&#35; run as user daemon
 <input id="user" class="l_fill" type="text"> daemon<br>
 &#35; expose port 6379
 <input id="expose" class="l_fill" type="text"> 6379

--- a/image/spec/v1.md
+++ b/image/spec/v1.md
@@ -52,7 +52,7 @@ This specification uses the following terms:
     </dt>
     <dd>
         Each layer is given an ID upon its creation. It is 
-        represented as a hexidecimal encoding of 256 bits, e.g.,
+        represented as a hexadecimal encoding of 256 bits, e.g.,
         <code>a9561eb1b190625c9adb5a9513e72c4dedafc1cb2d4c5236c9a6957ec7dfd5a9</code>.
         Image IDs should be sufficiently random so as to be globally unique.
         32 bytes read from <code>/dev/urandom</code> is sufficient for all
@@ -109,7 +109,7 @@ This specification uses the following terms:
         characters <code>[._-]</code>, however it MAY contain additional
         <code>/</code> and <code>:</code> characters for organizational
         purposes, with the last <code>:</code> character being interpreted
-        dividing the repository component of the name from the tag suffic
+        dividing the repository component of the name from the tag suffix
         component.
     </dd>
 </dl>
@@ -176,7 +176,7 @@ Here is an example image JSON file:
         should be omitted. A collection of images may share many of the same
         ancestor layers. This organizational structure is strictly a tree with
         any one layer having either no parent or a single parent and zero or
-        more decendent layers. Cycles are not allowed and implementations
+        more descendent layers. Cycles are not allowed and implementations
         should be careful to avoid creating them or iterating through a cycle
         indefinitely.
     </dd>

--- a/pkg/tarsum/tarsum_spec.md
+++ b/pkg/tarsum/tarsum_spec.md
@@ -167,7 +167,7 @@ order ( and the corresponding representation of its value):
 * 'devmajor' - string of the integer
 * 'devminor' - string of the integer
 
-For >= Version1, the extented attribute headers ("SCHILY.xattr." prefixed pax
+For >= Version1, the extended attribute headers ("SCHILY.xattr." prefixed pax
 headers) included after the above list. These xattrs key/values are first
 sorted by the keys.
 

--- a/project/IRC-ADMINISTRATION.md
+++ b/project/IRC-ADMINISTRATION.md
@@ -16,7 +16,7 @@ with "access" privileges for a particular channel.
 
 A similar command is used to give someone a particular access level.  For
 example, to add a new maintainer to the `#docker-maintainers` access list so
-that they can contribute to the dicsussions (after they've been merged
+that they can contribute to the discussions (after they've been merged
 appropriately in a `MAINTAINERS` file, of course), one would use `/msg ChanServ
 ACCESS #docker-maintainers ADD <nick> maintainer`.
 

--- a/project/ISSUE-TRIAGE.md
+++ b/project/ISSUE-TRIAGE.md
@@ -1,4 +1,4 @@
-Triaging of issue
+Triaging of issues
 ------------------
 
 Triage provides an important way to contribute to an open source project.  Triage helps ensure issues resolve quickly by:  
@@ -9,7 +9,7 @@ Triage provides an important way to contribute to an open source project.  Triag
 
 - Lowering the issue count by preventing duplicate issues.
 
-- Streamling the development process by preventing duplicate discussions.
+- Streamlining the development process by preventing duplicate discussions.
 
 If you don't have time to code, consider helping with triage. The community will thank you for saving them time by spending some of yours.
 

--- a/project/ROADMAP.md
+++ b/project/ROADMAP.md
@@ -3,7 +3,7 @@
 This document is a high-level overview of where we want to take Docker.
 It is a curated selection of planned improvements which are either important, difficult, or both.
 
-For a more complete view of planned and requested improvements, see [the Github issues](https://github.com/docker/docker/issues).
+For a more complete view of planned and requested improvements, see [the GitHub issues](https://github.com/docker/docker/issues).
 
 To suggest changes to the roadmap, including additions, please write the change as if it were already in effect, and make a pull request.
 

--- a/vendor/src/github.com/Sirupsen/logrus/README.md
+++ b/vendor/src/github.com/Sirupsen/logrus/README.md
@@ -323,7 +323,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 
 #### Logger as an `io.Writer`
 
-Logrus can be transormed into an `io.Writer`. That writer is the end of an `io.Pipe` and it is your responsibility to close it.
+Logrus can be transformed into an `io.Writer`. That writer is the end of an `io.Pipe` and it is your responsibility to close it.
 
 ```go
 w := logger.Writer()

--- a/vendor/src/github.com/docker/libcontainer/CONTRIBUTING.md
+++ b/vendor/src/github.com/docker/libcontainer/CONTRIBUTING.md
@@ -24,21 +24,21 @@ The following packages are required to compile libcontainer natively.
 - git
 - cgutils
 
-You can develop on OSX, but you are limited to Dockerfile-based builds only.
+You can develop on OS X, but you are limited to Dockerfile-based builds only.
 
 ### Building libcontainer from Dockerfile
 
     make all
 
 This is the easiest way of building libcontainer.
-As this build is done using Docker, you can even run this from [OSX](https://github.com/boot2docker/boot2docker)
+As this build is done using Docker, you can even run this from [OS X](https://github.com/boot2docker/boot2docker)
 
 ### Testing changes with "nsinit"
 
     make sh
 
 This will create an container that runs `nsinit exec sh` on a busybox rootfs with the configuration from ['minimal.json'](https://github.com/docker/libcontainer/blob/master/sample_configs/minimal.json).
-Like the previous command, you can run this on OSX too!
+Like the previous command, you can run this on OS X too!
 
 ### Building libcontainer directly
 

--- a/vendor/src/github.com/docker/libcontainer/ROADMAP.md
+++ b/vendor/src/github.com/docker/libcontainer/ROADMAP.md
@@ -3,7 +3,7 @@
 This document is a high-level overview of where we want to take libcontainer next.
 It is a curated selection of planned improvements which are either important, difficult, or both.
 
-For a more complete view of planned and requested improvements, see [the Github issues](https://github.com/docker/libcontainer/issues).
+For a more complete view of planned and requested improvements, see [the GitHub issues](https://github.com/docker/libcontainer/issues).
 
 To suggest changes to the roadmap, including additions, please write the change as if it were already in effect, and make a pull request.
 

--- a/vendor/src/github.com/docker/libcontainer/SPEC.md
+++ b/vendor/src/github.com/docker/libcontainer/SPEC.md
@@ -60,7 +60,7 @@ are required to be mounted within the rootfs that the runtime will setup.
 After a container's filesystems are mounted within the newly created 
 mount namespace `/dev` will need to be populated with a set of device nodes.
 It is expected that a rootfs does not need to have any device nodes specified
-for `/dev` witin the rootfs as the container will setup the correct devices
+for `/dev` within the rootfs as the container will setup the correct devices
 that are required for executing a container's process.
 
 |      Path    | Mode |   Access   |

--- a/vendor/src/github.com/docker/libcontainer/console_linux.go
+++ b/vendor/src/github.com/docker/libcontainer/console_linux.go
@@ -46,7 +46,7 @@ func newConsoleFromPath(slavePath string) *linuxConsole {
 	}
 }
 
-// linuxConsole is a linux psuedo TTY for use within a container.
+// linuxConsole is a linux pseudo TTY for use within a container.
 type linuxConsole struct {
 	master    *os.File
 	slavePath string

--- a/vendor/src/github.com/docker/libcontainer/nsenter/README.md
+++ b/vendor/src/github.com/docker/libcontainer/nsenter/README.md
@@ -18,7 +18,7 @@ which will give the process of the container that should be joined. Namespaces f
 be found from `/proc/[pid]/ns` and set by `setns` syscall.
 
 And then get the pipe number from `_LIBCONTAINER_INITPIPE`, error message could
-be transfered through it. If tty is added, `_LIBCONTAINER_CONSOLE_PATH` will 
+be transferred through it. If tty is added, `_LIBCONTAINER_CONSOLE_PATH` will 
 have value and start a console for output.
 
 Finally, `nsexec()` will clone a child process , exit the parent process and let 

--- a/vendor/src/github.com/docker/libnetwork/docs/bridge.md
+++ b/vendor/src/github.com/docker/libnetwork/docs/bridge.md
@@ -1,7 +1,7 @@
 Bridge Driver
 =============
 
-The bridge driver is an implementation that uses Linux Bridging and iptables to provide connectvity for containers
+The bridge driver is an implementation that uses Linux Bridging and iptables to provide connectivity for containers
 It creates a single bridge, called `docker0` by default, and attaches a `veth pair` between the bridge and every endpoint.
 
 ## Configuration

--- a/vendor/src/github.com/docker/libnetwork/docs/design.md
+++ b/vendor/src/github.com/docker/libnetwork/docs/design.md
@@ -2,7 +2,7 @@ Design
 ======
 
 The vision and goals of libnetwork are highlighted in [roadmap](../ROADMAP.md).
-This document describes how libnetwork has been designed in order to acheive this.
+This document describes how libnetwork has been designed in order to achieve this.
 Requirements for individual releases can be found on the [Project Page](https://github.com/docker/libnetwork/wiki)
 
 Many of the design decisions are inspired by the learnings from the Docker networking design as of Docker v1.6.
@@ -59,7 +59,7 @@ Networks consist of *many* endpoints
 `Options` provides a generic and flexible mechanism to pass `Driver` specific configuration option from the user to the `Driver` directly. `Options` are just key-value pairs of data with `key` represented by a string and `value` represented by a generic object (such as golang `interface{}`). Libnetwork will operate on the `Options` ONLY if the  `key` matches any of the well-known `Label` defined in the `net-labels` package. `Options` also encompasses `Labels` as explained below. `Options` are generally NOT end-user visible (in UI), while `Labels` are.
 
 ***Labels***
-`Labels` are very similar to `Options` & infact they  are just a subset of `Options`. `Labels` are typically end-user visible and are represented in the UI explicitely using the `--labels` option. They are passed from the UI to the `Driver` so that `Driver` can make use of it and perform any `Driver` specific operation (such as a subnet to allocate IP-Addresses from in a Network).
+`Labels` are very similar to `Options` & in fact they are just a subset of `Options`. `Labels` are typically end-user visible and are represented in the UI explicitly using the `--labels` option. They are passed from the UI to the `Driver` so that `Driver` can make use of it and perform any `Driver` specific operation (such as a subnet to allocate IP-Addresses from in a Network).
 
 ## CNM Lifecycle
 
@@ -91,7 +91,7 @@ Consumers of the CNM, like Docker for example, interact through the CNM Objects 
 
 ### Networks & Endpoints
 
-LibNetwork's Network and Endpoint APIs are primiarly for managing the corresponding Objects and book-keeping them to provide a level of abstraction as required by the CNM. It delegates the actual implementation to the drivers which  realizes the functionality as promised in the CNM. For more information on these details, please see [the drivers section](#Drivers)
+LibNetwork's Network and Endpoint APIs are primarily for managing the corresponding Objects and book-keeping them to provide a level of abstraction as required by the CNM. It delegates the actual implementation to the drivers which  realizes the functionality as promised in the CNM. For more information on these details, please see [the drivers section](#Drivers)
 
 ### Sandbox
 
@@ -104,7 +104,7 @@ Netlink is also used to manage the routing table in the namespace.
 
 ## API
 
-Drivers are essentially an extension of libnetwork and provides the actual implementation for all of the LibNetwork APIs defined above. Hence there is an 1-1 correspondance for all the `Network` and `Endpoint` APIs, which includes :
+Drivers are essentially an extension of libnetwork and provides the actual implementation for all of the LibNetwork APIs defined above. Hence there is an 1-1 correspondence for all the `Network` and `Endpoint` APIs, which includes :
 * `driver.Config`
 * `driver.CreateNetwork`
 * `driver.DeleteNetwork`

--- a/vendor/src/github.com/docker/libnetwork/test/integration/README.md
+++ b/vendor/src/github.com/docker/libnetwork/test/integration/README.md
@@ -18,13 +18,13 @@ Integration tests are written in *bash* using the
 
 1. Bats (https://github.com/sstephenson/bats#installing-bats-from-source)
 2. Docker Machine (https://github.com/docker/machine)
-3. Virtualbox (as a Docker machine driver)
+3. VirtualBox (as a Docker machine driver)
 
 ## Running integration tests
 
 * Start by [installing] (https://github.com/sstephenson/bats#installing-bats-from-source) *bats* on your system.
 * If not done already, [install](https://docs.docker.com/machine/) *docker-machine* into /usr/bin
-* Make sure Virtualbox is installed as well, which will be used by docker-machine as a driver to launch VMs
+* Make sure VirtualBox is installed as well, which will be used by docker-machine as a driver to launch VMs
 
 In order to run all integration tests, pass *bats* the test path:
 ```

--- a/vendor/src/github.com/docker/libtrust/util.go
+++ b/vendor/src/github.com/docker/libtrust/util.go
@@ -16,7 +16,7 @@ import (
 )
 
 // joseBase64UrlEncode encodes the given data using the standard base64 url
-// encoding format but with all trailing '=' characters ommitted in accordance
+// encoding format but with all trailing '=' characters omitted in accordance
 // with the jose specification.
 // http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-31#section-2
 func joseBase64UrlEncode(b []byte) string {

--- a/vendor/src/github.com/mistifyio/go-zfs/CONTRIBUTING.md
+++ b/vendor/src/github.com/mistifyio/go-zfs/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We always welcome contributions to help make `go-zfs` better. Please take a mome
 
 ### Reporting issues ###
 
-We use [Github issues](https://github.com/mistifyio/go-zfs/issues) to track bug reports, feature requests, and submitting pull requests.
+We use [GitHub issues](https://github.com/mistifyio/go-zfs/issues) to track bug reports, feature requests, and submitting pull requests.
 
 If you find a bug:
 

--- a/vendor/src/github.com/mistifyio/go-zfs/README.md
+++ b/vendor/src/github.com/mistifyio/go-zfs/README.md
@@ -29,7 +29,7 @@ The tests have decent examples for most functions.
 
 ```go
 //assuming a zpool named test
-//error handling ommitted
+//error handling omitted
 
 
 f, err := zfs.CreateFilesystem("test/snapshot-test", nil)

--- a/vendor/src/github.com/vishvananda/netlink/README.md
+++ b/vendor/src/github.com/vishvananda/netlink/README.md
@@ -8,7 +8,7 @@ the kernel. It can be used to add and remove interfaces, set ip addresses
 and routes, and configure ipsec. Netlink communication requires elevated
 privileges, so in most cases this code needs to be run as root. Since
 low-level netlink messages are inscrutable at best, the library attempts
-to provide an api that is loosely modeled on the CLI provied by iproute2.
+to provide an api that is loosely modeled on the CLI provided by iproute2.
 Actions like `ip link add` will be accomplished via a similarly named
 function like AddLink(). This library began its life as a fork of the
 netlink functionality in

--- a/vendor/src/github.com/vishvananda/netns/README.md
+++ b/vendor/src/github.com/vishvananda/netns/README.md
@@ -38,7 +38,7 @@ func main() {
     newns, _ := netns.New()
     defer newns.Close()
 
-    // Do something with tne network namespace
+    // Do something with the network namespace
     ifaces, _ := net.Interfaces()
     fmt.Printf("Interfaces: %v\n", ifaces)
 


### PR DESCRIPTION
- Fix capitalisation of the following names: AppArmor, BitBucket,
  Fedora, GitHub, Package Control, SoftLayer, VirtualBox
- Fix spacing of the following phrases: OS X, Red Hat
- Remove stray spaces
- Replace goo.gl short link with full link
- Various spelling corrections

Signed-off-by: Alex Chan alex@alexwlchan.net
