### PR TITLE
Patch set to support systemd as PID1 in container

### DIFF
--- a/api/client/stop.go
+++ b/api/client/stop.go
@@ -12,6 +12,7 @@ import (
 // CmdStop stops one or more running containers.
 //
 // A running container is stopped by first sending SIGTERM and then SIGKILL if the container fails to stop within a grace period (the default is 10 seconds).
+// If the container is running in Init="systemd" mode, docker will send the SIGRTMIN+3 signal
 //
 // Usage: docker stop [OPTIONS] CONTAINER [CONTAINER...]
 func (cli *DockerCli) CmdStop(args ...string) error {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -951,6 +951,7 @@ _docker_run() {
 		--expose
 		--group-add
 		--hostname -h
+		--init
 		--ipc
 		--label -l
 		--label-file
@@ -1032,6 +1033,10 @@ _docker_run() {
 		--env|-e)
 			COMPREPLY=( $( compgen -e -- "$cur" ) )
 			compopt -o nospace
+			return
+			;;
+		--init)
+			COMPREPLY=( $( compgen -W 'systemd' -- "$cur" ) )
 			return
 			;;
 		--ipc)

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -131,6 +131,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l group-add -d
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -s h -l hostname -d 'Container host name'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l help -d 'Print usage'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -s i -l interactive -d 'Keep STDIN open even if not attached'
+complete -c docker -A -f -n '__fish_seen_subcommand_from create' -s a -l init -d 'Init to systemd.'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l ipc -d 'Default is to create a private IPC namespace (POSIX SysV IPC) for the container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l link -d 'Add link to another container in the form of <name|id>:alias'
 complete -c docker -A -f -n '__fish_seen_subcommand_from create' -l lxc-conf -d '(lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"'
@@ -300,6 +301,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from rmi' -a '(__fish_print_
 # run
 complete -c docker -f -n '__fish_docker_no_subcommand' -a run -d 'Run a command in a new container'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -s a -l attach -d 'Attach to STDIN, STDOUT or STDERR.'
+complete -c docker -A -f -n '__fish_seen_subcommand_from run' -s a -l init -d 'Init to systemd.'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -l add-host -d 'Add a custom host-to-IP mapping (host:ip)'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -s c -l cpu-shares -d 'CPU shares (relative weight)'
 complete -c docker -A -f -n '__fish_seen_subcommand_from run' -l cap-add -d 'Add Linux capabilities'

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -477,8 +477,14 @@ func (container *Container) Stop(seconds int) error {
 	}
 
 	// 1. Send a SIGTERM
-	if err := container.killPossiblyDeadProcess(15); err != nil {
-		logrus.Infof("Failed to send SIGTERM to the process, force killing")
+	sig := 15
+	sigString := "SIGTERM"
+	if container.Config.Init == "systemd" {
+		sig = 35 //signal.
+		sigString = "SIGRTMIN + 3"
+	}
+	if err := container.killPossiblyDeadProcess(sig); err != nil {
+		logrus.Infof(fmt.Sprintf("Failed to send %s to the process, force killing", sigString))
 		if err := container.killPossiblyDeadProcess(9); err != nil {
 			return err
 		}

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -146,6 +146,7 @@ func (container *Container) createDaemonEnvironment(linkedEnv []string) []string
 	// because the env on the container can override certain default values
 	// we need to replace the 'env' keys where they match and append anything
 	// else.
+	env = append(env, fmt.Sprintf("container_uuid=%s", convertUUID(container.ID)))
 	env = utils.ReplaceOrAppendEnvValues(env, container.Config.Env)
 
 	return env

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -123,6 +123,12 @@ func (daemon *Daemon) rm(container *Container, forceRemove bool) (err error) {
 		}
 	}
 
+	if path := journalPath(container.ID); path != "" {
+		if err = os.RemoveAll(path); err != nil {
+			return fmt.Errorf("Unable to remove journal content %v: %v", container.ID, err)
+		}
+	}
+
 	if err = os.RemoveAll(container.root); err != nil {
 		return fmt.Errorf("Unable to remove filesystem for %v: %v", container.ID, err)
 	}

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -177,4 +177,5 @@ type Command struct {
 	FirstStart         bool              `json:"first_start"`
 	LayerPaths         []string          `json:"layer_paths"` // Windows needs to know the layer paths and folder for a command
 	LayerFolder        string            `json:"layer_folder"`
+	TmpDir             string            `json:"tmpdir"` // Directory used to store docker tmpdirs.
 }

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -223,6 +225,34 @@ func (d *driver) setupRlimits(container *configs.Config, c *execdriver.Command) 
 	}
 }
 
+func (d *driver) genPremountCmd(c *execdriver.Command, fullDest string, dest string) []configs.Command {
+	var premount []configs.Command
+	tarFile := fmt.Sprintf("%s/%s.tar", c.TmpDir, strings.Replace(dest, "/", "_", -1))
+	if _, err := os.Stat(fullDest); err == nil {
+		premount = append(premount, configs.Command{
+			Path: "/usr/bin/tar",
+			Args: []string{"-cf", tarFile, "-C", fullDest, "."},
+		})
+	}
+	return premount
+}
+
+func (d *driver) genPostmountCmd(c *execdriver.Command, fullDest string, dest string) []configs.Command {
+	var postmount []configs.Command
+	if _, err := os.Stat(fullDest); os.IsNotExist(err) {
+		return postmount
+	}
+	tarFile := fmt.Sprintf("%s/%s.tar", c.TmpDir, strings.Replace(dest, "/", "_", -1))
+	postmount = append(postmount, configs.Command{
+		Path: "/usr/bin/tar",
+		Args: []string{"-xf", tarFile, "-C", fullDest, "."},
+	})
+	return append(postmount, configs.Command{
+		Path: "/usr/bin/rm",
+		Args: []string{"-f", tarFile},
+	})
+}
+
 func (d *driver) setupMounts(container *configs.Config, c *execdriver.Command) error {
 	userMounts := make(map[string]struct{})
 	for _, m := range c.Mounts {
@@ -243,6 +273,20 @@ func (d *driver) setupMounts(container *configs.Config, c *execdriver.Command) e
 	container.Mounts = defaultMounts
 
 	for _, m := range c.Mounts {
+		if m.Source == "tmpfs" {
+			dest := filepath.Join(c.Rootfs, m.Destination)
+			flags := syscall.MS_NOSUID | syscall.MS_NODEV
+			container.Mounts = append(container.Mounts, &configs.Mount{
+				Source:        m.Source,
+				Destination:   m.Destination,
+				Device:        "tmpfs",
+				Data:          "mode=755,size=65536k",
+				Flags:         flags,
+				PremountCmds:  d.genPremountCmd(c, dest, m.Destination),
+				PostmountCmds: d.genPostmountCmd(c, dest, m.Destination),
+			})
+			continue
+		}
 		flags := syscall.MS_BIND | syscall.MS_REC
 		if !m.Writable {
 			flags |= syscall.MS_RDONLY

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -5,6 +5,7 @@ package native
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -112,6 +113,13 @@ type execOutput struct {
 
 func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (execdriver.ExitStatus, error) {
 	// take the Command and populate the libcontainer.Config from it
+	var err error
+	c.TmpDir, err = ioutil.TempDir("", c.ID)
+	if err != nil {
+		return execdriver.ExitStatus{ExitCode: -1}, err
+	}
+	defer os.RemoveAll(c.TmpDir)
+
 	container, err := d.createContainer(c)
 	if err != nil {
 		return execdriver.ExitStatus{ExitCode: -1}, err

--- a/daemon/utils_unix.go
+++ b/daemon/utils_unix.go
@@ -5,6 +5,7 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/docker/docker/runconfig"
@@ -49,4 +50,13 @@ func mergeLxcConfIntoOptions(hostConfig *runconfig.HostConfig) ([]string, error)
 
 func convertUUID(id string) string {
 	return fmt.Sprintf("%s-%s-%s-%s-%.12s", id[0:8], id[8:12], id[12:16], id[16:20], id[20:])
+}
+
+func journalPath(id string) string {
+	finfo, err := os.Stat("/var/log/journal")
+	if err != nil || !finfo.IsDir() {
+		return ""
+	}
+
+	return fmt.Sprintf("/var/log/journal/%.32s", id)
 }

--- a/daemon/utils_unix.go
+++ b/daemon/utils_unix.go
@@ -46,3 +46,7 @@ func mergeLxcConfIntoOptions(hostConfig *runconfig.HostConfig) ([]string, error)
 
 	return out, nil
 }
+
+func convertUUID(id string) string {
+	return fmt.Sprintf("%s-%s-%s-%s-%.12s", id[0:8], id[8:12], id[12:16], id[16:20], id[20:])
+}

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1067,6 +1067,7 @@ container by using one or more `-e` flags, even overriding those mentioned
 above, or already defined by the developer with a Dockerfile `ENV`:
 
     $ docker run -e "deep=purple" --rm ubuntu /bin/bash -c export
+    declare -x container_uuid="be84194d-87f9-08c2-b2e1-67311f4409f5"
     declare -x HOME="/"
     declare -x HOSTNAME="85bc26a0e200"
     declare -x OLDPWD

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -66,6 +66,7 @@ following options.
  - [Container Identification](#container-identification)
      - [Name (--name)](#name-name)
      - [PID Equivalent](#pid-equivalent)
+ - [INIT Settings (--init)](#ipc-settings-ipc)
  - [IPC Settings (--ipc)](#ipc-settings-ipc)
  - [Network Settings](#network-settings)
  - [Restart Policies (--restart)](#restart-policies-restart)
@@ -200,6 +201,17 @@ more advanced use case would be changing the host's hostname from a container.
 
 > **Note**: `--uts="host"` gives the container full access to change the
 > hostname of the host and is therefore considered insecure.
+
+## INIT settings (--init)
+
+    --init=""  : Enable a pre-configured profile for running init systems within containers.
+	       'systemd': Changes the way docker runs a container, based on the systemd container specification.
+	       * Mounts "/run" as a tmpfs,
+	       * mounts /sys/fs/cgroup into the container as a read/only volume
+	       * Adds container_uuid environment variable.
+	       * Sets up volume mount /var/log/journald/UUID. Allowing journald data within the container to be seen by the host journalctl. 
+
+    	       Default: No profile is enabled.
 
 ## IPC settings (--ipc)
 

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -29,6 +29,7 @@ docker-create - Create a new container
 [**-h**|**--hostname**[=*HOSTNAME*]]
 [**--help**]
 [**-i**|**--interactive**[=*false*]]
+[**--init**[=*INITSYSTEM*]]
 [**--ipc**[=*IPC*]]
 [**-l**|**--label**[=*[]*]]
 [**--label-file**[=*[]*]]
@@ -142,6 +143,17 @@ two memory nodes.
 
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.
+
+**--init**=""
+
+	Enable a pre-configured profile for running init systems within containers.
+	Default: No profile is enabled.
+
+   	      'systemd': Changes the way docker runs a container, based on the systemd container specification.
+	      * Mounts "/run" as a tmpfs,
+	      * mounts /sys/fs/cgroup into the container as a read/only volume
+	      * Adds container_uuid environment variable.
+	      * Sets up volume mount /var/log/journald/UUID. Allowing journald data within the container to be seen by the host journalctl. 
 
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -198,6 +198,9 @@ is the case the **--dns** flags is necessary for every run.
 environment variables that are available for the process that will be launched
 inside of the container.
 
+   The container_uuid is set automatically with a 32 character truncated
+Container ID in standard UUID format.
+
 **--entrypoint**=""
    Overwrite the default ENTRYPOINT of the image
 
@@ -565,6 +568,7 @@ Running the **env** command in the linker container shows environment variables
  with the LT (alias) context (**LT_**)
 
     # env
+    container_uuid=be84194d-87f9-08c2-b2e1-67311f4409f5
     HOSTNAME=668231cb0978
     TERM=xterm
     LT_PORT_80_TCP=tcp://172.17.0.3:80

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -30,6 +30,7 @@ docker-run - Run a command in a new container
 [**-h**|**--hostname**[=*HOSTNAME*]]
 [**--help**]
 [**-i**|**--interactive**[=*false*]]
+[**--init**[=*INITSYSTEM*]]
 [**--ipc**[=*IPC*]]
 [**-l**|**--label**[=*[]*]]
 [**--label-file**[=*[]*]]
@@ -236,6 +237,17 @@ ENTRYPOINT.
    Keep STDIN open even if not attached. The default is *false*.
 
    When set to true, keep stdin open even if not attached. The default is false.
+
+**--init**=""
+
+	Enable a pre-configured profile for running init systems within containers.
+	Default: No profile is enabled.
+
+   	      'systemd': Changes the way docker runs a container, based on the systemd container specification.
+	      * Mounts "/run" as a tmpfs,
+	      * mounts /sys/fs/cgroup into the container as a read/only volume
+	      * Adds container_uuid environment variable.
+	      * Sets up volume mount /var/log/journald/UUID. Allowing journald data within the container to be seen by the host journalctl. 
 
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container

--- a/pkg/systemd/register.go
+++ b/pkg/systemd/register.go
@@ -1,0 +1,69 @@
+// +build linux
+
+package systemd
+
+import (
+	"encoding/hex"
+	"os"
+
+	//	"github.com/coreos/go-systemd/util/"
+	"github.com/godbus/dbus"
+)
+
+var conn *dbus.Conn
+
+// Remove once IsRunningSystemd is available in go-systemd/util
+func IsRunningSystemd() bool {
+	s, err := os.Stat("/run/systemd/system")
+	if err != nil {
+		return false
+	}
+
+	return s.IsDir()
+}
+
+// RegisterMachine with systemd on the host system
+func RegisterMachine(name string, id string, pid int, root_directory string) error {
+	var (
+		av  []byte
+		err error
+	)
+	if !IsRunningSystemd() {
+		return nil
+	}
+
+	if conn == nil {
+		conn, err = dbus.SystemBus()
+		if err != nil {
+			return (err)
+		}
+	}
+
+	av, err = hex.DecodeString(id[0:32])
+	if err != nil {
+		return err
+	}
+
+	obj := conn.Object("org.freedesktop.machine1", "/org/freedesktop/machine1")
+	return obj.Call("org.freedesktop.machine1.Manager.RegisterMachine", 0, name[0:64], av, "docker", "container", uint32(pid), root_directory).Err
+}
+
+// TerminateMachine registered with systemd on the host system
+func TerminateMachine(name string) error {
+	var (
+		err error
+	)
+	if !IsRunningSystemd() {
+		return nil
+	}
+
+	if conn == nil {
+		conn, err = dbus.SystemBus()
+		if err != nil {
+			return (err)
+		}
+	}
+
+	obj := conn.Object("org.freedesktop.machine1", "/org/freedesktop/machine1")
+	return obj.Call("org.freedesktop.machine1.Manager.TerminateMachine", 0, name).Err
+}

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -156,6 +156,7 @@ type Config struct {
 	MacAddress      string                // Mac Address of the container
 	OnBuild         []string              // ONBUILD metadata that were defined on the image Dockerfile
 	Labels          map[string]string     // List of labels set to this container
+	Init            string
 }
 
 // ContainerConfigWrapper is a Config wrapper that hold the container Config (portable)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -105,6 +105,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flLoggingDriver   = cmd.String([]string{"-log-driver"}, "", "Logging driver for container")
 		flCgroupParent    = cmd.String([]string{"-cgroup-parent"}, "", "Optional parent cgroup for the container")
 		flVolumeDriver    = cmd.String([]string{"-volume-driver"}, "", "Optional volume driver for the container")
+		flInit            = cmd.String([]string{"-init"}, "", "Run container following specified init system container method (systemd)")
 	)
 
 	cmd.Var(&flAttach, []string{"a", "-attach"}, "Attach to STDIN, STDOUT or STDERR")
@@ -347,6 +348,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		WorkingDir:      *flWorkingDir,
 		Labels:          convertKVStringsToMap(labels),
 		VolumeDriver:    *flVolumeDriver,
+		Init:            *flInit,
 	}
 
 	hostConfig := &HostConfig{


### PR DESCRIPTION
This patch set combines a few patches to allow systemd to fully function in a non privileged container

I am closeing down some pull requests for /run and journald and putting them all behind a 

docker run --systemd option.

This patch set includes a couple of patches that should get merged without using the systemd pull.
