### PR TITLE
Have docker register its machine with systemd

### DIFF
--- a/pkg/systemd/register.go
+++ b/pkg/systemd/register.go
@@ -1,0 +1,56 @@
+// +build linux
+
+package systemd
+
+import (
+	"encoding/hex"
+	"github.com/godbus/dbus"
+)
+
+var conn *dbus.Conn
+
+// RegisterMachine with systemd on the host system
+func RegisterMachine(name string, id string, pid int, root_directory string) error {
+	var (
+		av  []byte
+		err error
+	)
+	if !SdBooted() {
+		return nil
+	}
+
+	if conn == nil {
+		conn, err = dbus.SystemBus()
+		if err != nil {
+			return (err)
+		}
+	}
+
+	av, err = hex.DecodeString(id[0:32])
+	if err != nil {
+		return err
+	}
+
+	obj := conn.Object("org.freedesktop.machine1", "/org/freedesktop/machine1")
+	return obj.Call("org.freedesktop.machine1.Manager.RegisterMachine", 0, name[0:64], av, "docker", "container", uint32(pid), root_directory).Err
+}
+
+// TerminateMachine registered with systemd on the host system
+func TerminateMachine(name string) error {
+	var (
+		err error
+	)
+	if !SdBooted() {
+		return nil
+	}
+
+	if conn == nil {
+		conn, err = dbus.SystemBus()
+		if err != nil {
+			return (err)
+		}
+	}
+
+	obj := conn.Object("org.freedesktop.machine1", "/org/freedesktop/machine1")
+	return obj.Call("org.freedesktop.machine1.Manager.TerminateMachine", 0, name).Err
+}


### PR DESCRIPTION
This patch will register the container with machinectl.  This will allow tools
on the container like machinectl and eventually journalctl to interact with the
container.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
