### PR TITLE
Fix automatically publish ports without --publish-all or --publish

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3186,3 +3186,14 @@ func (s *DockerSuite) TestRunUnshareProc(c *check.C) {
 		c.Fatalf("unshare should have failed with permission denied, got: %s, %v", out, err)
 	}
 }
+
+func (s *DockerSuite) TestRunPublishPort(c *check.C) {
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "--name", "test", "--expose", "8080", "busybox", "top"))
+	c.Assert(err, check.IsNil)
+	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "port", "test"))
+	c.Assert(err, check.IsNil)
+	out = strings.Trim(out, "\r\n")
+	if out != "" {
+		c.Fatalf("run without --publish-all should not publish port, out should be nil, but got: %s", out)
+	}
+}

--- a/nat/sort.go
+++ b/nat/sort.go
@@ -60,10 +60,10 @@ func SortPortMap(ports []Port, bindings PortMap) {
 			for _, b := range binding {
 				s = append(s, portMapEntry{port: p, binding: b})
 			}
+			bindings[p] = []PortBinding{}
 		} else {
 			s = append(s, portMapEntry{port: p})
 		}
-		bindings[p] = []PortBinding{}
 	}
 
 	sort.Sort(s)
@@ -79,7 +79,9 @@ func SortPortMap(ports []Port, bindings PortMap) {
 			i++
 		}
 		// reorder bindings for this port
-		bindings[entry.port] = append(bindings[entry.port], entry.binding)
+		if _, ok := bindings[entry.port]; ok {
+			bindings[entry.port] = append(bindings[entry.port], entry.binding)
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

The container should only publish the ports with --publish-all or --publish.
But with #12148 , the docker will publish the ports if you don't have 
--publish-all or --publish, this is definitely not the desired behaviour.
For example: 
`docker run --name test -d registry`   image `registry` has a exposed port `5000`

<pre><code>[l00284783@localhost docker]$ docker run --name test -d registry
41fa47a08d19d9112b4e9977099a8fbf40feb8abb1764edbd3ab24032254a332</code></pre>

but we don't publish any port on run cli, but we can see the port `5000` has been published

<pre><code>[l00284783@localhost docker]$ docker port test
5000/tcp -> 0.0.0.0:32769
[l00284783@localhost docker]$ docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS                     NAMES
41fa47a08d19        registry            "docker-registry"   2 minutes ago       Up 2 minutes        0.0.0.0:32769->5000/tcp   test             
[l00284783@localhost docker]$</code></pre>

and we can access to this port

<pre><code>[l00284783@localhost docker]$ curl 127.0.0.1:32769
"\"docker-registry server\""[l00284783@localhost docker]$</code></pre>


I think this patch can fix this, ping @LK4D4 
