### PR TITLE
remove redundant mount/unmount calls on commit

### DIFF
--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -23,11 +23,6 @@ func (daemon *Daemon) Commit(container *Container, repository, tag, comment, aut
 		defer container.Unpause()
 	}
 
-	if err := container.Mount(); err != nil {
-		return nil, err
-	}
-	defer container.Unmount()
-
 	rwTar, err := container.ExportRw()
 	if err != nil {
 		return nil, err

--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -828,20 +828,15 @@ func (container *Container) verifyDaemonSettings() {
 }
 
 func (container *Container) ExportRw() (archive.Archive, error) {
-	if err := container.Mount(); err != nil {
-		return nil, err
-	}
 	if container.daemon == nil {
 		return nil, fmt.Errorf("Can't load storage driver for unregistered container %s", container.ID)
 	}
 	archive, err := container.daemon.Diff(container)
 	if err != nil {
-		container.Unmount()
 		return nil, err
 	}
 	return ioutils.NewReadCloserWrapper(archive, func() error {
 			err := archive.Close()
-			container.Unmount()
 			return err
 		}),
 		nil


### PR DESCRIPTION
daemon.Diff already implements mounting for nativegraphdriver and
aufs which does diffing on its owns does not need the container to be mounted.
So new filesystem driver should mount filesystems on their own if it is needed
to implement Diff(). This issue was reported by @kvasdopil while working on a
freebsd port, because freebsd does not allow mount an already mounted
filesystem. Also it saves some cycles for other operating systems as well.

Signed-off-by: Jörg Thalheim joerg@higgsboson.tk
