### PR TITLE
Don't show error on daemon side when inspect image

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -93,7 +93,8 @@ func (graph *Graph) Exists(id string) bool {
 func (graph *Graph) Get(name string) (*image.Image, error) {
 	id, err := graph.idIndex.Get(name)
 	if err != nil {
-		return nil, fmt.Errorf("could not find image: %v", err)
+		// Could not find image, return standard error
+		return nil, err
 	}
 	img, err := image.LoadImage(graph.ImageRoot(id))
 	if err != nil {

--- a/graph/service.go
+++ b/graph/service.go
@@ -26,7 +26,7 @@ func (s *TagStore) LookupRaw(name string) ([]byte, error) {
 func (s *TagStore) Lookup(name string) (*types.ImageInspect, error) {
 	image, err := s.LookupImage(name)
 	if err != nil || image == nil {
-		return nil, fmt.Errorf("No such image: %s", name)
+		return nil, err
 	}
 
 	imageInspect := &types.ImageInspect{

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -210,8 +210,8 @@ func (s *DockerRegistrySuite) TestRemoveImageByDigest(c *check.C) {
 	// try to inspect again - it should error this time
 	if _, err := inspectField(imageReference, "Id"); err == nil {
 		c.Fatalf("unexpected nil err trying to inspect what should be a non-existent image")
-	} else if !strings.Contains(err.Error(), "No such image") {
-		c.Fatalf("expected 'No such image' output, got %v", err)
+	} else if !strings.Contains(err.Error(), "no such id") {
+		c.Fatalf("expected 'no such id' output, got %v", err)
 	}
 }
 

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -208,7 +208,7 @@ func waitInspect(name, expr, expected string, timeout int) error {
 		cmd := exec.Command(dockerBinary, "inspect", "-f", expr, name)
 		out, _, err := runCommandWithOutput(cmd)
 		if err != nil {
-			if !strings.Contains(out, "No such") {
+			if !strings.Contains(out, "no such id") {
 				return fmt.Errorf("error executing docker inspect: %v\n%s", err, out)
 			}
 			select {

--- a/pkg/errtype/errtype.go
+++ b/pkg/errtype/errtype.go
@@ -1,0 +1,29 @@
+package errtype
+
+import (
+	"fmt"
+)
+
+type NotFoundError struct {
+	property string
+	value    string
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("no such %s: %s", e.property, e.value)
+}
+
+func NewNotFoundError(p, v string) error {
+	return &NotFoundError{
+		property: p,
+		value:    v,
+	}
+}
+
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(*NotFoundError)
+	return ok
+}

--- a/pkg/truncindex/truncindex.go
+++ b/pkg/truncindex/truncindex.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/docker/docker/pkg/errtype"
 	"github.com/tchap/go-patricia/patricia"
 )
 
@@ -106,5 +107,5 @@ func (idx *TruncIndex) Get(s string) (string, error) {
 	if id != "" {
 		return id, nil
 	}
-	return "", fmt.Errorf("no such id: %s", s)
+	return "", errtype.NewNotFoundError("id", s)
 }


### PR DESCRIPTION
Fixes: #10773

Container or image not found should not be daemon's fault, so
we can return error to client, but don't show error on daemon side.

This commit introduce an errtype package, this could be the first
step we standard err types in Docker in necessary places.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
