### PR TITLE
Clean up: remove redundant '\n' in Create

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -70,7 +70,7 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 		return nil, nil, err
 	}
 	if !config.NetworkDisabled && daemon.SystemConfig().IPv4ForwardingDisabled {
-		warnings = append(warnings, "IPv4 forwarding is disabled.\n")
+		warnings = append(warnings, "IPv4 forwarding is disabled.")
 	}
 	if hostConfig == nil {
 		hostConfig = &runconfig.HostConfig{}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

`\n` in `warnings = append(warnings, "IPv4 forwarding is disabled.\n")` is 
redundant since https://github.com/docker/docker/blob/master/api/client/create.go#L124 has output with `\n`

<pre><code>[l00284783@localhost docker]$ docker run -ti busybox
WARNING: IPv4 forwarding is disabled.

/ #
</code></pre>
