### PR TITLE
Don't check RESOURCE_COUNTERS in new kernel

### DIFF
--- a/contrib/check-config.sh
+++ b/contrib/check-config.sh
@@ -23,6 +23,11 @@ if ! command -v zgrep &> /dev/null; then
 	}
 fi
 
+kernelVersion="$(uname -r)"
+kernelMajor="${kernelVersion%%.*}"
+kernelMinor="${kernelVersion#$kernelMajor.}"
+kernelMinor="${kernelMinor%%.*}"
+
 is_set() {
 	zgrep "CONFIG_$1=[y|m]" "$CONFIG" > /dev/null
 }
@@ -182,8 +187,12 @@ echo 'Optional Features:'
 		echo "    $(wrap_color '(note that cgroup swap accounting is not enabled in your kernel config, you can enable it by setting boot option "swapaccount=1")' bold black)"
 	fi
 }
+
+if [ "$kernelMajor" -lt 3 ] || [ "$kernelMajor" -eq 3 -a "$kernelMinor" -le 18 ]; then
+	check_flags RESOURCE_COUNTERS
+fi
+
 flags=(
-	RESOURCE_COUNTERS
 	BLK_CGROUP
 	IOSCHED_CFQ
 	CGROUP_PERF


### PR DESCRIPTION
Closes: #13543

It's remove in 3.19 and have no replacement.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
