### PR TITLE
Correct the message of pause and unpause a non-running container

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -396,14 +396,14 @@ func (container *Container) Pause() error {
 	container.Lock()
 	defer container.Unlock()
 
+	// We cannot Pause the container which is not running
+	if !container.Running {
+		return fmt.Errorf("Container %s is not running, cannot pause a non-running container", container.ID)
+	}
+
 	// We cannot Pause the container which is already paused
 	if container.Paused {
 		return fmt.Errorf("Container %s is already paused", container.ID)
-	}
-
-	// We cannot Pause the container which is not running
-	if !container.Running {
-		return fmt.Errorf("Container %s is not running", container.ID)
 	}
 
 	if err := container.daemon.execDriver.Pause(container.command); err != nil {
@@ -418,14 +418,14 @@ func (container *Container) Unpause() error {
 	container.Lock()
 	defer container.Unlock()
 
-	// We cannot unpause the container which is not paused
-	if !container.Paused {
-		return fmt.Errorf("Container %s is not paused, so what", container.ID)
-	}
-
 	// We cannot unpause the container which is not running
 	if !container.Running {
-		return fmt.Errorf("Container %s is not running", container.ID)
+		return fmt.Errorf("Container %s is not running, cannot unpause a non-running container", container.ID)
+	}
+
+	// We cannot unpause the container which is not paused
+	if !container.Paused {
+		return fmt.Errorf("Container %s is not paused", container.ID)
 	}
 
 	if err := container.daemon.execDriver.Unpause(container.command); err != nil {


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

We should check if the container is running or not then check
if the container is paused or not, because a not running container 
is definitely  not paused. Or else if we unpause a not running container,
the error message will show `Container is not paused` this is misleading.

BTW I remove the `so what`  in the error message of container is not paused,
I don't know if we have a `so what` here is good or not since english is not my first
language. :)(
