### PR TITLE
Windows: Factor out stat collector

### DIFF
--- a/daemon/stats_collector_unix.go
+++ b/daemon/stats_collector_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package daemon
 
 import (

--- a/daemon/stats_collector_windows.go
+++ b/daemon/stats_collector_windows.go
@@ -1,0 +1,31 @@
+package daemon
+
+import "time"
+
+// newStatsCollector returns a new statsCollector for collection stats
+// for a registered container at the specified interval. The collector allows
+// non-running containers to be added and will start processing stats when
+// they are started.
+func newStatsCollector(interval time.Duration) *statsCollector {
+	return &statsCollector{}
+}
+
+// statsCollector manages and provides container resource stats
+type statsCollector struct {
+}
+
+// collect registers the container with the collector and adds it to
+// the event loop for collection on the specified interval returning
+// a channel for the subscriber to receive on.
+func (s *statsCollector) collect(c *Container) chan interface{} {
+	return nil
+}
+
+// stopCollection closes the channels for all subscribers and removes
+// the container from metrics collection.
+func (s *statsCollector) stopCollection(c *Container) {
+}
+
+// unsubscribe removes a specific subscriber from receiving updates for a container's stats.
+func (s *statsCollector) unsubscribe(c *Container, ch chan interface{}) {
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows.  The Linux implementation of the stat collector in the daemon is not suitable for use on Windows. Effectively factored this out to a no-op on the Windows daemon.
