### PR TITLE
overlay should be higher priority than devicemapper

### DIFF
--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -31,8 +31,8 @@ var (
 		"aufs",
 		"btrfs",
 		"zfs",
-		"devicemapper",
 		"overlay",
+		"devicemapper",
 		"vfs",
 	}
 


### PR DESCRIPTION
we know for a fact devicemapper still has issues, we also know it is far more likely overlay is far more likely to work
