### PR TITLE
Fixing Mac Boot2Docker installation doc

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -64,7 +64,7 @@ practice, work through the exercises on this page.
 
 3. Install Boot2Docker by double-clicking the package.
 
-    The installer places Boot2Docker in your "Applications" folder.
+    The installer places Boot2Docker and VirtualBox in your "Applications" folder.
 
 The installation places the `docker` and `boot2docker` binaries in your
 `/usr/local/bin` directory.


### PR DESCRIPTION
Edited the Mac Boot2Docker installation doc to reflect that VirtualBox also appears in the "Applications" folder along with Boot2Docker after the install. Fixes #13345 

Signed-off-by: Anchal Agrawal aagrawa4@illinois.edu
