### PR TITLE
Make v2 push have v1-fallback behavior consistent with pull.

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -482,6 +482,10 @@ func (s *TagStore) pullV2Repository(r *registry.Session, out io.Writer, repoInfo
 	if err != nil {
 		return fmt.Errorf("error getting authorization: %s", err)
 	}
+	if !auth.CanAuthorizeV2() {
+		return ErrV2RegistryUnavailable
+	}
+
 	var layersDownloaded bool
 	if tag == "" {
 		logrus.Debugf("Pulling tag list from V2 registry for %s", repoInfo.CanonicalName)

--- a/graph/push.go
+++ b/graph/push.go
@@ -322,6 +322,9 @@ func (s *TagStore) pushV2Repository(r *registry.Session, localRepo Repository, o
 	if err != nil {
 		return fmt.Errorf("error getting authorization: %s", err)
 	}
+	if !auth.CanAuthorizeV2() {
+		return ErrV2RegistryUnavailable
+	}
 
 	for _, tag := range tags {
 		logrus.Debugf("Pushing repository: %s:%s", repoInfo.CanonicalName, tag)
@@ -549,6 +552,7 @@ func (s *TagStore) Push(localName string, imagePushConfig *ImagePushConfig) erro
 		if err != ErrV2RegistryUnavailable {
 			return fmt.Errorf("Error pushing to registry: %s", err)
 		}
+		logrus.Debug("V2 registry is unavailable, falling back on V1")
 	}
 
 	if err := s.pushRepository(r, imagePushConfig.OutStream, repoInfo, localRepo, imagePushConfig.Tag, sf); err != nil {


### PR DESCRIPTION
This change removes the "official" special casing from the top of `pu[ll,sh]V2Repository` and changes the `pushV2Repository` callsite to fall back on v1 (logging the v2 error), which is consistent with the behavior of the v2 pull logic.

Signed-off-by: Matt Moore mattmoor@google.com
