### PR TITLE
bug fix: close http response body no longer in use

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -68,6 +68,7 @@ func (c *Client) callWithRetry(serviceMethod string, args interface{}, ret inter
 			continue
 		}
 
+		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			remoteErr, err := ioutil.ReadAll(resp.Body)
 			if err != nil {


### PR DESCRIPTION
This is a potential risk which will probably exhaust server file descriptor resource, so invoke response.Body.Close() explicitly

Signed-off-by: Zhang Wei zhangwei555@huawei.com
