### PR TITLE
return error when failed to read http response body

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -71,7 +71,7 @@ func (c *Client) callWithRetry(serviceMethod string, args interface{}, ret inter
 		if resp.StatusCode != http.StatusOK {
 			remoteErr, err := ioutil.ReadAll(resp.Body)
 			if err != nil {
-				return nil
+				return fmt.Errorf("Plugin Error: %s", err)
 			}
 			return fmt.Errorf("Plugin Error: %s", remoteErr)
 		}


### PR DESCRIPTION
It doesn't make sense that swallow error returned by ReadAll() func silently. I think it's better to either return the error to caller or return nil after log error, only return nil can't give enough debug info to user and developer.

Signed-off-by: Zhang Wei zhangwei555@huawei.com
