### PR TITLE
Update api documentation to add labels in commit

### DIFF
--- a/docs/sources/reference/api/docker_remote_api_v1.19.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.19.md
@@ -1752,6 +1752,10 @@ Create a new image from a container's changes
          "Volumes": {
                  "/tmp": {}
          },
+         "Labels": {
+                 "key1": "value1",
+                 "key2": "value2"
+          },
          "WorkingDir": "",
          "NetworkDisabled": false,
          "ExposedPorts": {

--- a/docs/sources/reference/api/docker_remote_api_v1.20.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.20.md
@@ -1743,6 +1743,10 @@ Create a new image from a container's changes
          "Volumes": {
                  "/tmp": {}
          },
+         "Labels": {
+                 "key1": "value1",
+                 "key2": "value2"
+          },
          "WorkingDir": "",
          "NetworkDisabled": false,
          "ExposedPorts": {


### PR DESCRIPTION
It is already possible to set labels at commit when using the API, but it is not present in the API documentation. This is a little bit related to #13178 but this just documentation of a current working behavior.

This PR adds the _Labels_ part in the "Example Request" in the documentation and an integration test too, to validate that this works.

Signed-off-by: Vincent Demeester vincent@sbr.pm
