### PR TITLE
Cleanup: remove some useless code

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -252,7 +252,6 @@ func (container *Container) Start() (err error) {
 	if err := container.initializeNetworking(); err != nil {
 		return err
 	}
-	container.verifyDaemonSettings()
 	linkedEnv, err := container.setupLinkedContainers()
 	if err != nil {
 		return err

--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -832,21 +832,6 @@ func (container *Container) initializeNetworking() error {
 	return container.buildHostnameFile()
 }
 
-// Make sure the config is compatible with the current kernel
-func (container *Container) verifyDaemonSettings() {
-	if container.hostConfig.Memory > 0 && !container.daemon.sysInfo.MemoryLimit {
-		logrus.Warnf("Your kernel does not support memory limit capabilities. Limitation discarded.")
-		container.hostConfig.Memory = 0
-	}
-	if container.hostConfig.Memory > 0 && container.hostConfig.MemorySwap != -1 && !container.daemon.sysInfo.SwapLimit {
-		logrus.Warnf("Your kernel does not support swap limit capabilities. Limitation discarded.")
-		container.hostConfig.MemorySwap = -1
-	}
-	if container.daemon.sysInfo.IPv4ForwardingDisabled {
-		logrus.Warnf("IPv4 forwarding is disabled. Networking will not work")
-	}
-}
-
 func (container *Container) ExportRw() (archive.Archive, error) {
 	if container.daemon == nil {
 		return nil, fmt.Errorf("Can't load storage driver for unregistered container %s", container.ID)

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -59,9 +59,6 @@ func (container *Container) setupWorkingDirectory() error {
 	return nil
 }
 
-func (container *Container) verifyDaemonSettings() {
-}
-
 func populateCommand(c *Container, env []string) error {
 	en := &execdriver.Network{
 		Mtu:       c.daemon.config.Mtu,

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -19,7 +19,7 @@ func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hos
 		return "", nil, fmt.Errorf("Config cannot be empty in order to create a container")
 	}
 
-	warnings, err := daemon.verifyHostConfig(hostConfig)
+	warnings, err := daemon.verifyContainerSettings(hostConfig)
 	if err != nil {
 		return "", warnings, err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1166,7 +1166,7 @@ func checkKernel() error {
 	return nil
 }
 
-func (daemon *Daemon) verifyHostConfig(hostConfig *runconfig.HostConfig) ([]string, error) {
+func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig) ([]string, error) {
 	var warnings []string
 
 	if hostConfig == nil {
@@ -1181,10 +1181,12 @@ func (daemon *Daemon) verifyHostConfig(hostConfig *runconfig.HostConfig) ([]stri
 	}
 	if hostConfig.Memory > 0 && !daemon.SystemConfig().MemoryLimit {
 		warnings = append(warnings, "Your kernel does not support memory limit capabilities. Limitation discarded.")
+		logrus.Warnf("Your kernel does not support memory limit capabilities. Limitation discarded.")
 		hostConfig.Memory = 0
 	}
 	if hostConfig.Memory > 0 && hostConfig.MemorySwap != -1 && !daemon.SystemConfig().SwapLimit {
 		warnings = append(warnings, "Your kernel does not support swap limit capabilities, memory limited without swap.")
+		logrus.Warnf("Your kernel does not support swap limit capabilities, memory limited without swap.")
 		hostConfig.MemorySwap = -1
 	}
 	if hostConfig.Memory > 0 && hostConfig.MemorySwap > 0 && hostConfig.MemorySwap < hostConfig.Memory {
@@ -1195,10 +1197,12 @@ func (daemon *Daemon) verifyHostConfig(hostConfig *runconfig.HostConfig) ([]stri
 	}
 	if hostConfig.CpuPeriod > 0 && !daemon.SystemConfig().CpuCfsPeriod {
 		warnings = append(warnings, "Your kernel does not support CPU cfs period. Period discarded.")
+		logrus.Warnf("Your kernel does not support CPU cfs period. Period discarded.")
 		hostConfig.CpuPeriod = 0
 	}
 	if hostConfig.CpuQuota > 0 && !daemon.SystemConfig().CpuCfsQuota {
 		warnings = append(warnings, "Your kernel does not support CPU cfs quota. Quota discarded.")
+		logrus.Warnf("Your kernel does not support CPU cfs quota. Quota discarded.")
 		hostConfig.CpuQuota = 0
 	}
 	if hostConfig.BlkioWeight > 0 && (hostConfig.BlkioWeight < 10 || hostConfig.BlkioWeight > 1000) {
@@ -1208,7 +1212,10 @@ func (daemon *Daemon) verifyHostConfig(hostConfig *runconfig.HostConfig) ([]stri
 		hostConfig.OomKillDisable = false
 		return warnings, fmt.Errorf("Your kernel does not support oom kill disable.")
 	}
-
+	if daemon.SystemConfig().IPv4ForwardingDisabled {
+		warnings = append(warnings, "IPv4 forwarding is disabled. Networking will not work.")
+		logrus.Warnf("IPv4 forwarding is disabled. Networking will not work")
+	}
 	return warnings, nil
 }
 

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -20,7 +20,7 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConf
 		return fmt.Errorf("Container already started")
 	}
 
-	if _, err = daemon.verifyHostConfig(hostConfig); err != nil {
+	if _, err = daemon.verifyContainerSettings(hostConfig); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

`verifyHostConfig` and `verifyDaemonSettings` are doing some duplicate check, but `verifyHostConfig`
is called before `verifyDaemonSettings` , so some check in `verifyDaemonSettings` is useless. For example https://github.com/docker/docker/blob/master/daemon/container_linux.go#L817 is to check if support memory limit, but https://github.com/docker/docker/blob/master/daemon/daemon.go#L1190 also check the daemon settings and set the `hostConfig.Memory = 0` so the check in `verifyDaemonSettings` is useless and the warning log will not print.
