### PR TITLE
Avoid 88-chars mountpoint length limit on freebsd

### DIFF
--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -212,7 +212,7 @@ func (d *Driver) ZfsPath(id string) string {
 }
 
 func (d *Driver) MountPath(id string) string {
-	return path.Join(d.options.mountPath, "graph", id)
+	return path.Join(d.options.mountPath, "graph", getMountpoint(id))
 }
 
 func (d *Driver) Create(id string, parent string) error {

--- a/daemon/graphdriver/zfs/zfs_freebsd.go
+++ b/daemon/graphdriver/zfs/zfs_freebsd.go
@@ -2,6 +2,7 @@ package zfs
 
 import (
 	"fmt"
+	"strings"
 	"syscall"
 
 	log "github.com/Sirupsen/logrus"
@@ -21,4 +22,17 @@ func checkRootdirFs(rootdir string) error {
 	}
 
 	return nil
+}
+
+func getMountpoint(id string) string {
+	maxlen := 12
+
+	// we need to preserve filesystem suffix
+	suffix := strings.SplitN(id, "-", 2)
+
+	if len(suffix) > 1 {
+		return id[:maxlen] + "-" + suffix[1]
+	}
+
+	return id[:maxlen]
 }

--- a/daemon/graphdriver/zfs/zfs_linux.go
+++ b/daemon/graphdriver/zfs/zfs_linux.go
@@ -21,3 +21,7 @@ func checkRootdirFs(rootdir string) error {
 
 	return nil
 }
+
+func getMountpoint(id string) string {
+	return id
+}

--- a/daemon/graphdriver/zfs/zfs_unsupported.go
+++ b/daemon/graphdriver/zfs/zfs_unsupported.go
@@ -5,3 +5,7 @@ package zfs
 func checkRootdirFs(rootdir string) error {
 	return nil
 }
+
+func getMountpoint(id string) string {
+	return id
+}


### PR DESCRIPTION
On FreeBSD mountpoints for historical reasons are limited with 88 chars length. To handle this, we use shorter ids as mountpoints.
