### PR TITLE
Add test coverage for pkg/stringutils

### DIFF
--- a/pkg/stringutils/stringutils_test.go
+++ b/pkg/stringutils/stringutils_test.go
@@ -85,3 +85,21 @@ func TestInSlice(t *testing.T) {
 		t.Fatalf("Expected string notinslice not to be in slice")
 	}
 }
+
+func TestShellQuoteArgumentsEmpty(t *testing.T) {
+	actual := ShellQuoteArguments([]string{})
+	expected := ""
+	if actual != expected {
+		t.Fatalf("Expected an empty string")
+	}
+}
+
+func TestShellQuoteArguments(t *testing.T) {
+	simpleString := "simpleString"
+	complexString := "This is a 'more' complex $tring with some special char *"
+	actual := ShellQuoteArguments([]string{simpleString, complexString})
+	expected := "simpleString 'This is a '\\''more'\\'' complex $tring with some special char *'"
+	if actual != expected {
+		t.Fatalf("Expected \"%v\", got \"%v\"", expected, actual)
+	}
+}


### PR DESCRIPTION
Again add some tests, really simple, this time on `stringutils`, the `ShellQuoteArguments` 🐸.

```
+ go test -test.timeout=30m github.com/docker/docker/pkg/stringutils
PASS
coverage: 100.0% of statements
```

(I'm shamelessly doing an _ad_ to this old PR https://github.com/docker/docker/pull/13255 — adding tests to `pkg/pools`)
Signed-off-by: Vincent Demeester vincent@sbr.pm
