### PR TITLE
Make "DEST" a make.sh construct instead of ad-hoc

### DIFF
--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -2,7 +2,7 @@
 
 # see test-integration-cli for example usage of this script
 
-export PATH="$DEST/../binary:$DEST/../dynbinary:$DEST/../gccgo:$DEST/../dyngccgo:$PATH"
+export PATH="$ABS_DEST/../binary:$ABS_DEST/../dynbinary:$ABS_DEST/../gccgo:$ABS_DEST/../dyngccgo:$PATH"
 
 if ! command -v docker &> /dev/null; then
 	echo >&2 'error: binary or dynbinary must be run before .integration-daemon-start'

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -1,15 +1,9 @@
 #!/bin/bash
 set -e
 
-DEST=$1
 BINARY_NAME="docker-$VERSION"
 BINARY_EXTENSION="$(binary_extension)"
 BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
-
-# Cygdrive paths don't play well with go build -o.
-if [[ "$(uname -s)" == CYGWIN* ]]; then
-	DEST=$(cygpath -mw $DEST)
-fi
 
 source "${MAKEDIR}/.go-autogen"
 

--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-DEST=$1
-
 # subshell so that we can export PATH without breaking other things
 (
 	source "${MAKEDIR}/.integration-daemon-start"

--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-DEST=$1
-
 # subshell so that we can export PATH without breaking other things
 (
 	source "$(dirname "$BASH_SOURCE")/.integration-daemon-start"

--- a/hack/make/cover
+++ b/hack/make/cover
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-DEST="$1"
-
 bundle_cover() {
 	coverprofiles=( "$DEST/../"*"/coverprofiles/"* )
 	for p in "${coverprofiles[@]}"; do

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-DEST=$1
-
 # explicit list of os/arch combos that support being a daemon
 declare -A daemonSupporting
 daemonSupporting=(
@@ -21,13 +19,15 @@ fi
 
 for platform in $DOCKER_CROSSPLATFORMS; do
 	(
-		mkdir -p "$DEST/$platform" # bundles/VERSION/cross/GOOS/GOARCH/docker-VERSION
+		export DEST="$DEST/$platform" # bundles/VERSION/cross/GOOS/GOARCH/docker-VERSION
+		mkdir -p "$DEST"
+		ABS_DEST="$(cd "$DEST" && pwd -P)"
 		export GOOS=${platform%/*}
 		export GOARCH=${platform##*/}
 		if [ -z "${daemonSupporting[$platform]}" ]; then
 			export LDFLAGS_STATIC_DOCKER="" # we just need a simple client for these platforms
 			export BUILDFLAGS=( "${ORIG_BUILDFLAGS[@]/ daemon/}" ) # remove the "daemon" build tag from platforms that aren't supported
 		fi
-		source "${MAKEDIR}/binary" "$DEST/$platform"
+		source "${MAKEDIR}/binary"
 	)
 done

--- a/hack/make/dynbinary
+++ b/hack/make/dynbinary
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-DEST=$1
-
 if [ -z "$DOCKER_CLIENTONLY" ]; then
 	source "${MAKEDIR}/.dockerinit"
 

--- a/hack/make/dyngccgo
+++ b/hack/make/dyngccgo
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-DEST=$1
-
 if [ -z "$DOCKER_CLIENTONLY" ]; then
 	source "${MAKEDIR}/.dockerinit-gccgo"
 

--- a/hack/make/gccgo
+++ b/hack/make/gccgo
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-DEST=$1
 BINARY_NAME="docker-$VERSION"
 BINARY_EXTENSION="$(binary_extension)"
 BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-DEST=$1
-
 # subshell so that we can export PATH without breaking other things
 (
 	source "${MAKEDIR}/.integration-daemon-start"

--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-DEST=$1
-
 bundle_test_integration_cli() {
 	go_test_dir ./integration-cli
 }

--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 
-DEST=$1
 : ${PARALLEL_JOBS:=$(nproc 2>/dev/null || echo 1)} # if nproc fails (usually because we don't have it), let's not parallelize by default
 
 RED=$'\033[31m'
@@ -26,10 +25,9 @@ bundle_test_unit() {
 			export LDFLAGS
 			export TESTFLAGS
 			export HAVE_GO_TEST_COVER
-			export DEST
 
 			# some hack to export array variables
-			export BUILDFLAGS_FILE="buildflags_file"
+			export BUILDFLAGS_FILE="$DEST/buildflags-file"
 			( IFS=$'\n'; echo "${BUILDFLAGS[*]}" ) > "$BUILDFLAGS_FILE"
 
 			if command -v parallel &> /dev/null; then
@@ -59,7 +57,7 @@ go_run_test_dir() {
 	while read dir; do
 		echo
 		echo '+ go test' $TESTFLAGS "${DOCKER_PKG}${dir#.}"
-		precompiled="$DEST/precompiled/$dir.test$(binary_extension)"
+		precompiled="$ABS_DEST/precompiled/$dir.test$(binary_extension)"
 		if ! ( cd "$dir" && test_env "$precompiled" $TESTFLAGS ); then
 			TESTS_FAILED+=("$dir")
 			echo

--- a/hack/make/tgz
+++ b/hack/make/tgz
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-DEST="$1"
 CROSS="$DEST/../cross"
 
 set -e

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-DEST=$1
-
 PKGVERSION="${VERSION//-/'~'}"
 # if we have a "-dev" suffix or have change in Git, let's make this package version more complex so it works better
 if [[ "$VERSION" == *-dev ]] || [ -n "$(git status --porcelain)" ]; then
@@ -37,7 +35,7 @@ PACKAGE_LICENSE="Apache-2.0"
 # Build docker as an ubuntu package using FPM and REPREPRO (sue me).
 # bundle_binary must be called first.
 bundle_ubuntu() {
-	DIR=$DEST/build
+	DIR="$ABS_DEST/build"
 
 	# Include our udev rules
 	mkdir -p "$DIR/etc/udev/rules.d"
@@ -140,9 +138,9 @@ EOF
 		# create lxc-docker-VERSION package
 		fpm -s dir -C "$DIR" \
 			--name "lxc-docker-$VERSION" --version "$PKGVERSION" \
-			--after-install "$DEST/postinst" \
-			--before-remove "$DEST/prerm" \
-			--after-remove "$DEST/postrm" \
+			--after-install "$ABS_DEST/postinst" \
+			--before-remove "$ABS_DEST/prerm" \
+			--after-remove "$ABS_DEST/postrm" \
 			--architecture "$PACKAGE_ARCHITECTURE" \
 			--prefix / \
 			--depends iptables \


### PR DESCRIPTION
Using "DEST" for our build artifacts inside individual bundlescripts was already well-established convention, but this officializes it by having `make.sh` itself set the variable and create the directory, also handling CYGWIN oddities in a single central place (instead of letting them spread outward from `hack/make/binary` like was definitely on their roadmap, whether they knew it or not; sneaky oddities).

This is what I described in https://github.com/docker/docker/pull/12583#issuecomment-100298767, but I realized that it was a useful change regardless of whether we go forward with that PR. :+1:
