### PR TITLE
Add embedded shell script highlight to vim syntax

### DIFF
--- a/contrib/syntax/vim/syntax/dockerfile.vim
+++ b/contrib/syntax/vim/syntax/dockerfile.vim
@@ -21,3 +21,11 @@ syntax match dockerfileComment "\v^\s*#.*$"
 highlight link dockerfileComment Comment
 
 set commentstring=#\ %s
+
+" match "RUN", "CMD", and "ENTRYPOINT" lines, and parse them as shell
+let s:current_syntax = b:current_syntax
+unlet b:current_syntax
+syntax include @SH syntax/sh.vim
+let b:current_syntax = s:current_syntax
+syntax region shLine matchgroup=dockerfileKeyword start=/\v^\s*(RUN|CMD|ENTRYPOINT)\s/ end=/\v$/ contains=@SH
+" since @SH will handle "\" as part of the same line automatically, this "just works" for line continuation too, but with the caveat that it will highlight "RUN echo '" followed by a newline as if it were a block because the "'" is shell line continuation...  not sure how to fix that just yet (TODO)


### PR DESCRIPTION
This highlights `RUN`, `CMD`, and `ENTRYPOINT` lines using shell highlighting.  It doesn't bother detecting the JSON forms, but that's OK because JSON arrays highlight pretty reasonably with shell highlights. :smile:

Just for you, @jfrazelle. :wink:
