### PR TITLE
Adjust vim ftdetect to match "Dockerfile", "dockerfile", and "Dockerfile.*" which are all reasonably safe to assume "this is a Dockerfile"

### DIFF
--- a/contrib/syntax/vim/ftdetect/dockerfile.vim
+++ b/contrib/syntax/vim/ftdetect/dockerfile.vim
@@ -1,1 +1,1 @@
-au BufNewFile,BufRead Dockerfile set filetype=dockerfile
+au BufNewFile,BufRead [Dd]ockerfile,Dockerfile.* set filetype=dockerfile


### PR DESCRIPTION
Here's the companion to that last one, @jfrazelle. :wink:  (much less exciting, but still useful)

This makes our own `Dockerfile.simple` highlight correctly, and anything like `Dockerfile.template`, etc, which are common things people name things that they want to use with `docker build -f` (that I've personally seen or used in the wild).
