### PR TITLE
do not print empty values in docker info

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/ioutils"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/units"
 )
@@ -29,20 +30,20 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 
 	fmt.Fprintf(cli.out, "Containers: %d\n", info.Containers)
 	fmt.Fprintf(cli.out, "Images: %d\n", info.Images)
-	fmt.Fprintf(cli.out, "Storage Driver: %s\n", info.Driver)
+	ioutils.FprintfIfNotEmpty(cli.out, "Storage Driver: %s\n", info.Driver)
 	if info.DriverStatus != nil {
 		for _, pair := range info.DriverStatus {
 			fmt.Fprintf(cli.out, " %s: %s\n", pair[0], pair[1])
 		}
 	}
-	fmt.Fprintf(cli.out, "Execution Driver: %s\n", info.ExecutionDriver)
-	fmt.Fprintf(cli.out, "Logging Driver: %s\n", info.LoggingDriver)
-	fmt.Fprintf(cli.out, "Kernel Version: %s\n", info.KernelVersion)
-	fmt.Fprintf(cli.out, "Operating System: %s\n", info.OperatingSystem)
+	ioutils.FprintfIfNotEmpty(cli.out, "Execution Driver: %s\n", info.ExecutionDriver)
+	ioutils.FprintfIfNotEmpty(cli.out, "Logging Driver: %s\n", info.LoggingDriver)
+	ioutils.FprintfIfNotEmpty(cli.out, "Kernel Version: %s\n", info.KernelVersion)
+	ioutils.FprintfIfNotEmpty(cli.out, "Operating System: %s\n", info.OperatingSystem)
 	fmt.Fprintf(cli.out, "CPUs: %d\n", info.NCPU)
 	fmt.Fprintf(cli.out, "Total Memory: %s\n", units.BytesSize(float64(info.MemTotal)))
-	fmt.Fprintf(cli.out, "Name: %s\n", info.Name)
-	fmt.Fprintf(cli.out, "ID: %s\n", info.ID)
+	ioutils.FprintfIfNotEmpty(cli.out, "Name: %s\n", info.Name)
+	ioutils.FprintfIfNotEmpty(cli.out, "ID: %s\n", info.ID)
 
 	if info.Debug {
 		fmt.Fprintf(cli.out, "Debug mode (server): %v\n", info.Debug)
@@ -55,15 +56,9 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 		fmt.Fprintf(cli.out, "Docker Root Dir: %s\n", info.DockerRootDir)
 	}
 
-	if info.HttpProxy != "" {
-		fmt.Fprintf(cli.out, "Http Proxy: %s\n", info.HttpProxy)
-	}
-	if info.HttpsProxy != "" {
-		fmt.Fprintf(cli.out, "Https Proxy: %s\n", info.HttpsProxy)
-	}
-	if info.NoProxy != "" {
-		fmt.Fprintf(cli.out, "No Proxy: %s\n", info.NoProxy)
-	}
+	ioutils.FprintfIfNotEmpty(cli.out, "Http Proxy: %s\n", info.HttpProxy)
+	ioutils.FprintfIfNotEmpty(cli.out, "Https Proxy: %s\n", info.HttpsProxy)
+	ioutils.FprintfIfNotEmpty(cli.out, "No Proxy: %s\n", info.NoProxy)
 
 	if info.IndexServerAddress != "" {
 		u := cli.configFile.AuthConfigs[info.IndexServerAddress].Username

--- a/pkg/ioutils/fmt.go
+++ b/pkg/ioutils/fmt.go
@@ -1,0 +1,14 @@
+package ioutils
+
+import (
+	"fmt"
+	"io"
+)
+
+// FprintfIfNotEmpty prints the string value if it's not empty
+func FprintfIfNotEmpty(w io.Writer, format, value string) (int, error) {
+	if value != "" {
+		return fmt.Fprintf(w, format, value)
+	}
+	return 0, nil
+}

--- a/pkg/ioutils/fmt_test.go
+++ b/pkg/ioutils/fmt_test.go
@@ -1,0 +1,17 @@
+package ioutils
+
+import "testing"
+
+func TestFprintfIfNotEmpty(t *testing.T) {
+	wc := NewWriteCounter(&NopWriter{})
+	n, _ := FprintfIfNotEmpty(wc, "foo%s", "")
+
+	if wc.Count != 0 || n != 0 {
+		t.Errorf("Wrong count: %v vs. %v vs. 0", wc.Count, n)
+	}
+
+	n, _ = FprintfIfNotEmpty(wc, "foo%s", "bar")
+	if wc.Count != 6 || n != 6 {
+		t.Errorf("Wrong count: %v vs. %v vs. 6", wc.Count, n)
+	}
+}


### PR DESCRIPTION
When jobs where removed in https://github.com/docker/docker/pull/12266 some 

`if value != ""` where omitted. It makes the docker info agains a swarm daemon looks bad.
This is my attempt to fix this.
