### PR TITLE
Windows: Fix windows to match linux after compile break

### DIFF
--- a/api/server/server_windows.go
+++ b/api/server/server_windows.go
@@ -11,28 +11,34 @@ import (
 )
 
 // NewServer sets up the required Server and does protocol specific checking.
-func (s *Server) newServer(proto, addr string) (serverCloser, error) {
+func (s *Server) newServer(proto, addr string) ([]serverCloser, error) {
 	var (
-		err error
-		l   net.Listener
+		ls []net.Listener
 	)
 	switch proto {
 	case "tcp":
-		l, err = s.initTcpSocket(addr)
+		l, err := s.initTcpSocket(addr)
 		if err != nil {
 			return nil, err
 		}
+		ls = append(ls, l)
 
 	default:
 		return nil, errors.New("Invalid protocol format. Windows only supports tcp.")
 	}
-	return &HttpServer{
-		&http.Server{
-			Addr:    addr,
-			Handler: s.router,
-		},
-		l,
-	}, nil
+
+	var res []serverCloser
+	for _, l := range ls {
+		res = append(res, &HttpServer{
+			&http.Server{
+				Addr:    addr,
+				Handler: s.router,
+			},
+			l,
+		})
+	}
+	return res, nil
+
 }
 
 func (s *Server) AcceptConnections(d *daemon.Daemon) {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. 

@lk4d4 This PR updates server_windows to match the change made to server_linux in #13559 which wasn't applied to the Windows variant causing Windows daemon compilation to break
