### PR TITLE
Allow .dockerignore to ignore everything

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -175,7 +175,7 @@ func (cli *DockerCli) CmdBuild(args ...string) error {
 		}
 
 		if err := utils.ValidateContextDirectory(root, excludes); err != nil {
-			return fmt.Errorf("Error checking context is accessible: '%s'. Please check permissions and try again.", err)
+			return fmt.Errorf("Error checking context: '%s'.", err)
 		}
 		options := &archive.TarOptions{
 			Compression:     archive.Uncompressed,

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -40,7 +40,6 @@ func CleanPatterns(patterns []string) ([]string, [][]string, bool, error) {
 		}
 		if Exclusion(pattern) {
 			if len(pattern) == 1 {
-				logrus.Errorf("Illegal exclusion pattern: %s", pattern)
 				return nil, nil, false, errors.New("Illegal exclusion pattern: !")
 			}
 			exceptions = true
@@ -94,7 +93,6 @@ func OptimizedMatches(file string, patterns []string, patDirs [][]string) (bool,
 
 		match, err := filepath.Match(pattern, file)
 		if err != nil {
-			logrus.Errorf("Error matching: %s (pattern: %s)", file, pattern)
 			return false, err
 		}
 
@@ -114,6 +112,7 @@ func OptimizedMatches(file string, patterns []string, patDirs [][]string) (bool,
 	if matched {
 		logrus.Debugf("Skipping excluded path: %s", file)
 	}
+
 	return matched, nil
 }
 


### PR DESCRIPTION
Change CLI error msg because it was too specific and didn't make sense
when there were errors not related to inaccessible files.

Removed some log.Error() calls since they're not really errors we should
log. Returning the error will be enough.

Closes: #13417

Signed-off-by: Doug Davis dug@us.ibm.com
