### PR TITLE
Windows: Don't sigsegv on docker info

### DIFF
--- a/daemon/info.go
+++ b/daemon/info.go
@@ -82,10 +82,15 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		InitSha1:           dockerversion.INITSHA1,
 		InitPath:           initPath,
 		NCPU:               runtime.NumCPU(),
-		MemTotal:           meminfo.MemTotal,
 		DockerRootDir:      daemon.Config().Root,
 		Labels:             daemon.Config().Labels,
 		ExperimentalBuild:  utils.ExperimentalBuild(),
+	}
+
+	// TODO Windows. system.ReadMemInfo isn't implemented, so attempting
+	// to access members of meminfo will cause a SIGSEGV.
+	if runtime.GOOS != "windows" {
+		v.MemTotal = meminfo.MemTotal
 	}
 
 	if httpProxy := os.Getenv("http_proxy"); httpProxy != "" {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. This PR enables docker info to respond from the Windows daemon without causing a SIGSEGV when accessing an unimplemented struct member.
