### PR TITLE
Add ability to see when an image has last been used by a container

### DIFF
--- a/api/client/history.go
+++ b/api/client/history.go
@@ -36,7 +36,7 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 
 	w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
 	if !*quiet {
-		fmt.Fprintln(w, "IMAGE\tCREATED\tCREATED BY\tSIZE\tCOMMENT")
+		fmt.Fprintln(w, "IMAGE\tCREATED\tLAST USED\tCREATED BY\tSIZE\tCOMMENT")
 	}
 
 	for _, entry := range history {
@@ -50,6 +50,12 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 				fmt.Fprintf(w, "\t%s ago\t", units.HumanDuration(time.Now().UTC().Sub(time.Unix(entry.Created, 0))))
 			} else {
 				fmt.Fprintf(w, "\t%s\t", time.Unix(entry.Created, 0).Format(time.RFC3339))
+			}
+
+			if *human {
+				fmt.Fprintf(w, "%s ago\t", units.HumanDuration(time.Now().UTC().Sub(time.Unix(entry.LastUsed, 0))))
+			} else {
+				fmt.Fprintf(w, "%s\t", time.Unix(entry.LastUsed, 0).Format(time.RFC3339))
 			}
 
 			if *noTrunc {

--- a/api/client/images.go
+++ b/api/client/images.go
@@ -74,9 +74,9 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 	w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
 	if !*quiet {
 		if *showDigests {
-			fmt.Fprintln(w, "REPOSITORY\tTAG\tDIGEST\tIMAGE ID\tCREATED\tVIRTUAL SIZE")
+			fmt.Fprintln(w, "REPOSITORY\tTAG\tDIGEST\tIMAGE ID\tCREATED\tLAST USED\tVIRTUAL SIZE")
 		} else {
-			fmt.Fprintln(w, "REPOSITORY\tTAG\tIMAGE ID\tCREATED\tVIRTUAL SIZE")
+			fmt.Fprintln(w, "REPOSITORY\tTAG\tIMAGE ID\tCREATED\tLAST USED\tVIRTUAL SIZE")
 		}
 	}
 
@@ -109,9 +109,20 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 
 			if !*quiet {
 				if *showDigests {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s ago\t%s\n", repo, tag, digest, ID, units.HumanDuration(time.Now().UTC().Sub(time.Unix(int64(image.Created), 0))), units.HumanSize(float64(image.VirtualSize)))
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s ago\t%s ago\t%s\n",
+						repo,
+						tag, digest, ID,
+						units.HumanDuration(time.Now().UTC().Sub(time.Unix(int64(image.Created), 0))),
+						units.HumanDuration(time.Now().UTC().Sub(time.Unix(int64(image.LastUsed), 0))),
+						units.HumanSize(float64(image.VirtualSize)))
 				} else {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\t%s\n", repo, tag, ID, units.HumanDuration(time.Now().UTC().Sub(time.Unix(int64(image.Created), 0))), units.HumanSize(float64(image.VirtualSize)))
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s ago\t%s ago\t%s\n",
+						repo,
+						tag,
+						ID,
+						units.HumanDuration(time.Now().UTC().Sub(time.Unix(int64(image.Created), 0))),
+						units.HumanDuration(time.Now().UTC().Sub(time.Unix(int64(image.LastUsed), 0))),
+						units.HumanSize(float64(image.VirtualSize)))
 				}
 			} else {
 				fmt.Fprintln(w, ID)

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -55,6 +55,7 @@ type ImageHistory struct {
 	Tags      []string
 	Size      int64
 	Comment   string
+	LastUsed  int64
 }
 
 // DELETE "/images/{name:.*}"
@@ -73,6 +74,7 @@ type Image struct {
 	Size        int
 	VirtualSize int
 	Labels      map[string]string
+	LastUsed    int
 }
 
 // GET "/images/{name:.*}/json"
@@ -90,6 +92,7 @@ type ImageInspect struct {
 	Os              string
 	Size            int64
 	VirtualSize     int64
+	LastUsed        time.Time
 }
 
 // GET  "/containers/json"

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -270,6 +270,10 @@ func (container *Container) Start() (err error) {
 	}
 
 	container.command.Mounts = mounts
+
+	img, _ := container.GetImage()
+	img.UpdateLastUsed()
+
 	return container.waitForStart()
 }
 
@@ -462,6 +466,10 @@ func (container *Container) Kill() error {
 	}
 
 	container.WaitStop(-1 * time.Second)
+
+	img, _ := container.GetImage()
+	img.UpdateLastUsed()
+
 	return nil
 }
 
@@ -487,6 +495,9 @@ func (container *Container) Stop(seconds int) error {
 			return err
 		}
 	}
+
+	img, _ := container.GetImage()
+	img.UpdateLastUsed()
 
 	return nil
 }

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -142,6 +142,10 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 	if err := container.ToDisk(); err != nil {
 		return nil, nil, err
 	}
+
+	//Update image Last used
+	img.UpdateLastUsed()
+
 	return container, warnings, nil
 }
 

--- a/docs/man/docker-history.1.md
+++ b/docs/man/docker-history.1.md
@@ -30,22 +30,23 @@ Show the history of when and how an image was created.
 
 # EXAMPLES
     $ docker history fedora
-    IMAGE          CREATED          CREATED BY                                      SIZE                COMMENT
-    105182bb5e8b   5 days ago       /bin/sh -c #(nop) ADD file:71356d2ad59aa3119d   372.7 MB
-    73bd853d2ea5   13 days ago      /bin/sh -c #(nop) MAINTAINER Lokesh Mandvekar   0 B
-    511136ea3c5a   10 months ago                                                    0 B                 Imported from -
+    IMAGE          CREATED           LAST USED        CREATED BY                                      SIZE                COMMENT
+    105182bb5e8b   5 days ago        10 minutes ago   /bin/sh -c #(nop) ADD file:71356d2ad59aa3119d   372.7 MB
+    73bd853d2ea5   13 days ago       10 minutes ago   /bin/sh -c #(nop) MAINTAINER Lokesh Mandvekar   0 B
+    511136ea3c5a   10 months ago     10 minutes ago                                                   0 B                 Imported from -
 
 ## Display comments in the image history
 The `docker commit` command has a **-m** flag for adding comments to the image. These comments will be displayed in the image history.
 
     $ sudo docker history docker:scm
-    IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
-    2ac9d1098bf1        3 months ago        /bin/bash                                       241.4 MB            Added Apache to Fedora base image
-    88b42ffd1f7c        5 months ago        /bin/sh -c #(nop) ADD file:1fd8d7f9f6557cafc7   373.7 MB            
-    c69cab00d6ef        5 months ago        /bin/sh -c #(nop) MAINTAINER Lokesh Mandvekar   0 B                 
-    511136ea3c5a        19 months ago                                                       0 B                 Imported from -
+    IMAGE               CREATED         LAST USED      CREATED BY                                      SIZE                COMMENT
+    2ac9d1098bf1        3 months ago    6 hours ago    /bin/bash                                       241.4 MB            Added Apache to Fedora base image
+    88b42ffd1f7c        5 months ago    6 hours ago    /bin/sh -c #(nop) ADD file:1fd8d7f9f6557cafc7   373.7 MB
+    c69cab00d6ef        5 months ago    6 hours ago    /bin/sh -c #(nop) MAINTAINER Lokesh Mandvekar   0 B
+    511136ea3c5a        19 months ago   6 hours ago                                                    0 B                 Imported from -
 
 # HISTORY
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+May 2015, updated by Xabier Larrakoetxea <slok69@gmail.com>

--- a/docs/man/docker-images.1.md
+++ b/docs/man/docker-images.1.md
@@ -59,7 +59,7 @@ To list the images in a local repository (not the registry) run:
 
 The list will contain the image repository name, a tag for the image, and an
 image ID, when it was created and its virtual size. Columns: REPOSITORY, TAG,
-IMAGE ID, CREATED, and VIRTUAL SIZE.
+IMAGE ID, CREATED, LAST USED and VIRTUAL SIZE.
 
 To get a verbose list of images which contains all the intermediate images
 used in builds use **-a**:
@@ -82,3 +82,4 @@ tools.
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+May 2015, updated by Xabier Larrakoetxea <slok69@gmail.com>

--- a/docs/man/docker-inspect.1.md
+++ b/docs/man/docker-inspect.1.md
@@ -257,7 +257,8 @@ on it.
         "Os": "linux",
         "Parent": "c2b774c744afc5bea603b5e6c5218539e506649326de3ea0135182f299d0519a",
         "Size": 0,
-        "VirtualSize": 613136466
+        "VirtualSize": 613136466,
+        "LastUsed": "2015-05-31T14:44:50.882592191Z"
     }]
 
 # HISTORY
@@ -265,3 +266,4 @@ April 2014, originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 April 2015, updated by Qiang Huang <h.huangqiang@huawei.com>
+May 2015, updated by Xabier Larrakoetxea <slok69@gmail.com>

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -129,6 +129,7 @@ func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, contain
 		Config:        config,
 		Architecture:  runtime.GOARCH,
 		OS:            runtime.GOOS,
+		LastUsed:      time.Now().UTC(),
 	}
 
 	if containerID != "" {
@@ -194,6 +195,11 @@ func (graph *Graph) Register(img *image.Image, layerData archive.ArchiveReader) 
 		return err
 	}
 	graph.idIndex.Add(img.ID)
+
+	// finally set the last used timestamp to all the graph, we put here instead
+	// of in StoreImage to not update the whole graph in each layer creation of
+	// the build, pull, load or tag
+	img.UpdateLastUsed()
 	return nil
 }
 

--- a/graph/history.go
+++ b/graph/history.go
@@ -35,6 +35,7 @@ func (s *TagStore) History(name string) ([]*types.ImageHistory, error) {
 			Tags:      lookupMap[img.ID],
 			Size:      img.Size,
 			Comment:   img.Comment,
+			LastUsed:  img.LastUsed.Unix(),
 		})
 		return nil
 	})

--- a/graph/list.go
+++ b/graph/list.go
@@ -105,6 +105,7 @@ func (s *TagStore) Images(config *ImagesConfig) ([]*types.Image, error) {
 					newImage.Size = int(image.Size)
 					newImage.VirtualSize = int(image.GetParentsSize(0) + image.Size)
 					newImage.Labels = image.ContainerConfig.Labels
+					newImage.LastUsed = int(image.LastUsed.Unix())
 
 					if utils.DigestReference(ref) {
 						newImage.RepoTags = []string{}
@@ -142,6 +143,7 @@ func (s *TagStore) Images(config *ImagesConfig) ([]*types.Image, error) {
 			newImage.Size = int(image.Size)
 			newImage.VirtualSize = int(image.GetParentsSize(0) + image.Size)
 			newImage.Labels = image.ContainerConfig.Labels
+			newImage.LastUsed = int(image.LastUsed.Unix())
 
 			images = append(images, newImage)
 		}

--- a/graph/service.go
+++ b/graph/service.go
@@ -43,6 +43,7 @@ func (s *TagStore) Lookup(name string) (*types.ImageInspect, error) {
 		Os:              image.OS,
 		Size:            image.Size,
 		VirtualSize:     image.GetParentsSize(0) + image.Size,
+		LastUsed:        image.LastUsed,
 	}
 
 	return imageInspect, nil

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -280,7 +280,14 @@ func (store *TagStore) SetLoad(repoName, tag, imageName string, force bool, out 
 		store.Repositories[repoName] = repo
 	}
 	repo[tag] = img.ID
-	return store.save()
+
+	err = store.save()
+	if err != nil {
+		return err
+	}
+
+	img.UpdateLastUsed()
+	return nil
 }
 
 // SetDigest creates a digest reference to an image ID.

--- a/image/spec/v1.md
+++ b/image/spec/v1.md
@@ -51,7 +51,7 @@ This specification uses the following terms:
         Image ID <a name="id_desc"></a>
     </dt>
     <dd>
-        Each layer is given an ID upon its creation. It is 
+        Each layer is given an ID upon its creation. It is
         represented as a hexidecimal encoding of 256 bits, e.g.,
         <code>a9561eb1b190625c9adb5a9513e72c4dedafc1cb2d4c5236c9a6957ec7dfd5a9</code>.
         Image IDs should be sufficiently random so as to be globally unique.
@@ -119,11 +119,12 @@ This specification uses the following terms:
 Here is an example image JSON file:
 
 ```
-{  
+{
     "id": "a9561eb1b190625c9adb5a9513e72c4dedafc1cb2d4c5236c9a6957ec7dfd5a9",
     "parent": "c6e3cedcda2e3982a1a6760e178355e8e65f7b80e4e5248743fa3549d284e024",
     "checksum": "tarsum.v1+sha256:e58fcf7418d2390dec8e8fb69d88c06ec07039d651fedc3aa72af9972e7d046b",
     "created": "2014-10-13T21:19:18.674353812Z",
+    "LastUsed": "2015-05-31T08:17:07.423017756Z",
     "author": "Alyssa P. Hacker &ltalyspdev@example.com&gt",
     "architecture": "amd64",
     "os": "linux",
@@ -133,10 +134,10 @@ Here is an example image JSON file:
         "Memory": 2048,
         "MemorySwap": 4096,
         "CpuShares": 8,
-        "ExposedPorts": {  
+        "ExposedPorts": {
             "8080/tcp": {}
         },
-        "Env": [  
+        "Env": [
             "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
             "FOO=docker_is_a_really",
             "BAR=great_tool_you_know"
@@ -186,6 +187,23 @@ Here is an example image JSON file:
     <dd>
         ISO-8601 formatted combined date and time at which the image was
         created.
+    </dd>
+    <dt>
+        LastUsed <code>string</code>
+    </dt>
+    <dd>
+        ISO-8601 formatted combined date and time at which the image was used
+        for the last time. This filed is updated on (action on image or
+        a parent on the graph of images):
+        <ul>
+            <li>image build</li>
+            <li>image pull</li>
+            <li>image load</li>
+            <li>image tag</li>
+            <li>container create</li>
+            <li>container start</li>
+            <li>container stop</li>
+        </ul>
     </dd>
     <dt>
         author <code>string</code>
@@ -538,8 +556,8 @@ metadata schema:
 And the `repositories` file is another JSON file which describes names/tags:
 
 ```
-{  
-    "busybox":{  
+{
+    "busybox":{
         "latest":"5785b62b697b99a5af6cd5d0aabc804d5748abbb6d3d07da5d1d3795f2dcc83e"
     }
 }

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"regexp"
 
 	"github.com/docker/docker/vendor/src/github.com/kr/pty"
 	"github.com/go-check/check"
@@ -30,6 +31,9 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 
 	inspectCmd := exec.Command(dockerBinary, "inspect", repoName)
 	before, _, err := runCommandWithOutput(inspectCmd)
+	// The images will not be the same for the last used field
+	re := regexp.MustCompile("\"LastUsed\": \".+\"")
+	before = re.ReplaceAllString(before, "\"LastUsed\": ")
 	if err != nil {
 		c.Fatalf("the repo should exist before saving it: %s, %v", before, err)
 	}
@@ -59,6 +63,8 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 
 	inspectCmd = exec.Command(dockerBinary, "inspect", repoName)
 	after, _, err := runCommandWithOutput(inspectCmd)
+	after = re.ReplaceAllString(after, "\"LastUsed\": ")
+
 	if err != nil {
 		c.Fatalf("the repo should exist after loading it: %s %v", after, err)
 	}

--- a/integration-cli/docker_cli_stop_test.go
+++ b/integration-cli/docker_cli_stop_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os/exec"
+	"regexp"
+	"time"
+
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestStopImageLastUsed(c *check.C) {
+
+	var cmd *exec.Cmd
+	imageName := "busybox"
+	containerName := "testLastUse"
+	re := regexp.MustCompile("\"LastUsed\": \"(.+)\"")
+
+	cmd = exec.Command(dockerBinary, "run", "-d", "--name", containerName, imageName, "top")
+	runCommand(cmd)
+
+	// Check last used of the image
+	cmd = exec.Command(dockerBinary, "inspect", imageName)
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(out, err)
+	}
+	tBefore, err := time.Parse(time.RFC3339, re.FindAllStringSubmatch(out, -1)[0][1])
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	//sleep some time and then stop to check if was used the image
+	time.Sleep(2 * time.Second)
+	cmd = exec.Command(dockerBinary, "stop", containerName)
+	runCommand(cmd)
+
+	cmd = exec.Command(dockerBinary, "inspect", imageName)
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(out, err)
+	}
+	tAfter, err := time.Parse(time.RFC3339, re.FindAllStringSubmatch(out, -1)[0][1])
+	if err != nil {
+		c.Fatal(err)
+	}
+
+	// Check that the Last used inspect of future is after the inspect of the past
+	if !tAfter.After(tBefore) {
+		c.Fatalf("Image last used should be in the future: %s > %s", tAfter, tBefore)
+	}
+}


### PR DESCRIPTION
With this pull request now the images graph updates its last used time when one or more of these actions occur:
- Image
  - build
  - pull
  - load
  - tag
- Container
  - create
  - start
  - stop

Now images config has a new field named `LastUsed`, uses the same type as `Created`, (time.Time)
So whenever the actions listeed before occurs, it walks all over the image grahp updating the `LastUsed` field.

I set the update `LastUsed` in the actions described on the opened issue and the ones that I think that have more sense but If there are actions that you think that will be good to add or remove, would be an easy change, so lets discuss :)

Closes #4237
