### PR TITLE
Fix spelling mistakes in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -317,7 +317,7 @@ maintainer to make a difference on the project!
 
 ### IRC meetings
 
-There are two monthly meetings taking place on #docker-dev IRC to accomodate all
+There are two monthly meetings taking place on #docker-dev IRC to accommodate all
 timezones. Anybody can propose a topic for discussion prior to the meeting.
 
 If you feel the conversation is going off-topic, feel free to point it out.

--- a/docs/man/docker-export.1.md
+++ b/docs/man/docker-export.1.md
@@ -41,4 +41,4 @@ and import the contents of the tarball into it, then optionally tag it.
 April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
-Janurary 2015, updated by Joseph Kern (josephakern at gmail dot com)
+January 2015, updated by Joseph Kern (josephakern at gmail dot com)

--- a/docs/sources/docker-hub/official_repos.md
+++ b/docs/sources/docker-hub/official_repos.md
@@ -35,7 +35,7 @@ publishing all Official Repositories content. This team works in collaboration
 with upstream software maintainers, security experts, and the broader Docker
 community.
 
-While it is preferrable to have upstream software authors maintaining their
+While it is preferable to have upstream software authors maintaining their
 corresponding Official Repositories, this is not a strict requirement. Creating
 and maintaining images for Official Repositories is a public process. It takes
 place openly on GitHub where participation is encouraged. Anyone can provide
@@ -92,9 +92,9 @@ Official Repository is "generally useful" to the large Python developer
 community, whereas an obscure text adventure game written in Python last week is
 not.
 
-When a new proposal is accepted, the author becomes responsibile for keeping
+When a new proposal is accepted, the author becomes responsible for keeping
 their images up-to-date and responding to user feedback.  The Official
-Repositories team becomes responsibile for publishing the images and
+Repositories team becomes responsible for publishing the images and
 documentation on Docker Hub.  Updates to the Official Repository follow the same
 pull request process, though with less review. The Official Repositories team
 ultimately acts as a gatekeeper for all changes, which helps mitigate the risk

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -689,7 +689,7 @@ process is returned by the `docker attach` command to its caller too:
       --memory-swap=""         Total memory (memory + swap), `-1` to disable swap
       -c, --cpu-shares         CPU Shares (relative weight)
       --cpuset-mems=""         MEMs in which to allow execution, e.g. `0-3`, `0,1`
-      --cpuset-cpus=""         CPUs in which to allow exection, e.g. `0-3`, `0,1`
+      --cpuset-cpus=""         CPUs in which to allow execution, e.g. `0-3`, `0,1`
       --cgroup-parent=""       Optional parent cgroup for the container
 
 Builds Docker images from a Dockerfile and a "context". A build's context is
@@ -759,7 +759,7 @@ client is killed for any reason.
 
 > **Note:**
 > Currently only the "run" phase of the build can be canceled until pull
-> cancelation is implemented).
+> cancellation is implemented).
 
 ### Return code
 

--- a/image/spec/v1.md
+++ b/image/spec/v1.md
@@ -176,7 +176,7 @@ Here is an example image JSON file:
         should be omitted. A collection of images may share many of the same
         ancestor layers. This organizational structure is strictly a tree with
         any one layer having either no parent or a single parent and zero or
-        more decendent layers. Cycles are not allowed and implementations
+        more descendent layers. Cycles are not allowed and implementations
         should be careful to avoid creating them or iterating through a cycle
         indefinitely.
     </dd>


### PR DESCRIPTION
While reading  some of the docs I noticed a few errors, so I ran
misspellings (https://pypi.python.org/pypi/misspellings) on markdown files
