### PR TITLE
update stats.go,Update "docker stats " calculations 

### DIFF
--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -196,7 +196,7 @@ func calculateCPUPercent(previousCPU, previousSystem uint64, v *types.Stats) flo
 	)
 
 	if systemDelta > 0.0 && cpuDelta > 0.0 {
-		cpuPercent = (cpuDelta / systemDelta) * float64(len(v.CpuStats.CpuUsage.PercpuUsage)) * 100.0
+		cpuPercent = (cpuDelta / systemDelta) * 100.0
 	}
 	return cpuPercent
 }


### PR DESCRIPTION
bug fix https://github.com/docker/docker/issues/13626

When I read source code about " docker stat", the current is : 
cpuPercent = (cpuDelta / systemDelta) \* float64(len(v.CpuStats.CpuUsage.PercpuUsage)) 
https://github.com/docker/docker/blob/0d445685b8d628a938790e50517f3fb949b300e0/api/client/stats.go#L199

I do not understand why " \* float64(len(v.CpuStats.CpuUsage.PercpuUsage)) ", (cpuDelta / systemDelta) is Correct。

cpuDelta = float64(v.CpuStats.CpuUsage.TotalUsage - previousCPU)
systemDelta = float64(v.CpuStats.SystemUsage - previousSystem)

so total cpu delta / total system delta is correct , not need to multiplied by CPU kernal count.
