### PR TITLE
Add test coverage for pkg/tarsum

### DIFF
--- a/pkg/tarsum/builder_context_test.go
+++ b/pkg/tarsum/builder_context_test.go
@@ -1,0 +1,63 @@
+package tarsum
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+// Try to remove tarsum (in the BuilderContext) that do not exists, won't change a thing
+func TestTarSumRemoveNonExistent(t *testing.T) {
+	filename := "testdata/46af0962ab5afeb5ce6740d4d91652e69206fc991fd5328c1a94d364ad00e457/layer.tar"
+	reader, err := os.Open(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts, err := NewTarSum(reader, false, Version0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read and discard bytes so that it populates sums
+	_, err = io.Copy(ioutil.Discard, ts)
+	if err != nil {
+		t.Errorf("failed to read from %s: %s", filename, err)
+	}
+
+	expected := len(ts.GetSums())
+
+	ts.(BuilderContext).Remove("")
+	ts.(BuilderContext).Remove("Anything")
+
+	if len(ts.GetSums()) != expected {
+		t.Fatalf("Expected %v sums, go %v.", expected, ts.GetSums())
+	}
+}
+
+// Remove a tarsum (in the BuilderContext)
+func TestTarSumRemove(t *testing.T) {
+	filename := "testdata/46af0962ab5afeb5ce6740d4d91652e69206fc991fd5328c1a94d364ad00e457/layer.tar"
+	reader, err := os.Open(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts, err := NewTarSum(reader, false, Version0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read and discard bytes so that it populates sums
+	_, err = io.Copy(ioutil.Discard, ts)
+	if err != nil {
+		t.Errorf("failed to read from %s: %s", filename, err)
+	}
+
+	expected := len(ts.GetSums()) - 1
+
+	ts.(BuilderContext).Remove("etc/sudoers")
+
+	if len(ts.GetSums()) != expected {
+		t.Fatalf("Expected %v sums, go %v.", expected, len(ts.GetSums()))
+	}
+}

--- a/pkg/tarsum/fileinfosums.go
+++ b/pkg/tarsum/fileinfosums.go
@@ -51,15 +51,6 @@ func (fis FileInfoSums) GetAllFile(name string) FileInfoSums {
 	return f
 }
 
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
 func (fis FileInfoSums) GetDuplicatePaths() (dups FileInfoSums) {
 	seen := make(map[string]int, len(fis)) // allocate earl. no need to grow this map.
 	for i := range fis {

--- a/pkg/tarsum/fileinfosums_test.go
+++ b/pkg/tarsum/fileinfosums_test.go
@@ -42,4 +42,21 @@ func TestSortFileInfoSums(t *testing.T) {
 	if gotFis.Pos() != 4 {
 		t.Errorf("Expected %d, got %d", 4, gotFis.Pos())
 	}
+
+	fis = newFileInfoSums()
+	fis.SortByPos()
+	if fis[0].Pos() != 0 {
+		t.Errorf("sorted fileInfoSums by Pos should order them by position.")
+	}
+
+	fis = newFileInfoSums()
+	expected = "deadbeef1"
+	gotFileInfoSum := fis.GetFile("dup1")
+	if gotFileInfoSum.Sum() != expected {
+		t.Errorf("Expected %q, got %q", expected, gotFileInfoSum)
+	}
+	if fis.GetFile("noPresent") != nil {
+		t.Errorf("Should have return nil if name not found.")
+	}
+
 }

--- a/pkg/tarsum/versioning_test.go
+++ b/pkg/tarsum/versioning_test.go
@@ -4,6 +4,25 @@ import (
 	"testing"
 )
 
+func TestVersionLabelForChecksum(t *testing.T) {
+	version := VersionLabelForChecksum("tarsum+sha256:deadbeef")
+	if version != "tarsum" {
+		t.Fatalf("Version should have been 'tarsum', was %v", version)
+	}
+	version = VersionLabelForChecksum("tarsum.v1+sha256:deadbeef")
+	if version != "tarsum.v1" {
+		t.Fatalf("Version should have been 'tarsum.v1', was %v", version)
+	}
+	version = VersionLabelForChecksum("something+somethingelse")
+	if version != "something" {
+		t.Fatalf("Version should have been 'something', was %v", version)
+	}
+	version = VersionLabelForChecksum("invalidChecksum")
+	if version != "" {
+		t.Fatalf("Version should have been empty, was %v", version)
+	}
+}
+
 func TestVersion(t *testing.T) {
 	expected := "tarsum"
 	var v Version
@@ -52,4 +71,28 @@ func TestGetVersion(t *testing.T) {
 	if err != ErrNotVersion {
 		t.Fatalf("%q : %s", err, str)
 	}
+}
+
+func TestGetVersions(t *testing.T) {
+	expected := []Version{
+		Version0,
+		Version1,
+		VersionDev,
+	}
+	versions := GetVersions()
+	if len(versions) != len(expected) {
+		t.Fatalf("Expected %v versions, got %v", len(expected), len(versions))
+	}
+	if !containsVersion(versions, expected[0]) || !containsVersion(versions, expected[1]) || !containsVersion(versions, expected[2]) {
+		t.Fatalf("Expected [%v], got [%v]", expected, versions)
+	}
+}
+
+func containsVersion(versions []Version, version Version) bool {
+	for _, v := range versions {
+		if v == version {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Add some coverage on pkg/tarsum.

``` bash
# From
+ go test -test.timeout=30m github.com/docker/docker/pkg/tarsum
PASS
coverage: 70.0% of statements
# To
+ go test -test.timeout=30m github.com/docker/docker/pkg/tarsum
PASS
coverage: 90.3% of statements
```

And removing unused code. I was also wondering about the following :
- tarsum.go :
  NewTarSumHash could be non exported (for now)
  NewTarSumForLabel is never used, except for the tests
- fileinfosums.go:
  SortByPos is never used, except for the tests
- versionning.go:
  GetVersions is never used, expect for the tests

Signed-off-by: Vincent Demeester vincent@sbr.pm
