### PR TITLE
Remove useless debug message

### DIFF
--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -91,8 +91,6 @@ func NewDriver(root, initPath string, options []string) (*driver, error) {
 		}
 	}
 
-	logrus.Debugf("Using %v as native.cgroupdriver", cgm)
-
 	f, err := libcontainer.New(
 		root,
 		cgm,


### PR DESCRIPTION
It shows address of function which isn't very useful.
