### PR TITLE
Fix - Download button does not download

### DIFF
--- a/docs/sources/installation/mac.md
+++ b/docs/sources/installation/mac.md
@@ -9,7 +9,7 @@ Choose this installation if you are familiar with the command-line or plan to
 contribute to the Docker project on GitHub.
 
 [<img src="/installation/images/kitematic.png" alt="Download Kitematic"
-style="float:right;">](/kitematic/)
+style="float:right;">](https://kitematic.com/download)
 
 Alternatively, you may want to try <a id="inlinelink" href="https://kitematic.com/"
 target="_blank">Kitematic</a>, an application that lets you set up Docker and


### PR DESCRIPTION
Fix - Download button does not download 

Users got confused when Kitematic is not being downloaded after clicking on the download button, and instead got brought to a screen to teach them how to download Kitematic. 

The additional step caused a significant drop in Kitematic downloads. This pull request fixes the issue, to allow users to directly download Kitematic after clicking on the Download button.
