### PR TITLE
registry: debugTransport should print with testing.T.Log

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -200,23 +200,26 @@ func DockerHeaders(metaHeaders http.Header) []transport.RequestModifier {
 	return modifiers
 }
 
-type debugTransport struct{ http.RoundTripper }
+type debugTransport struct {
+	http.RoundTripper
+	log func(...interface{})
+}
 
 func (tr debugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	dump, err := httputil.DumpRequestOut(req, false)
 	if err != nil {
-		fmt.Println("could not dump request")
+		tr.log("could not dump request")
 	}
-	fmt.Println(string(dump))
+	tr.log(string(dump))
 	resp, err := tr.RoundTripper.RoundTrip(req)
 	if err != nil {
 		return nil, err
 	}
 	dump, err = httputil.DumpResponse(resp, false)
 	if err != nil {
-		fmt.Println("could not dump response")
+		tr.log("could not dump response")
 	}
-	fmt.Println(string(dump))
+	tr.log(string(dump))
 	return resp, err
 }
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -26,7 +26,7 @@ func spawnTestRegistrySession(t *testing.T) *Session {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var tr http.RoundTripper = debugTransport{NewTransport(ReceiveTimeout, endpoint.IsSecure)}
+	var tr http.RoundTripper = debugTransport{NewTransport(ReceiveTimeout, endpoint.IsSecure), t.Log}
 	tr = transport.NewTransport(AuthTransport(tr, authConfig, false), DockerHeaders(nil)...)
 	client := HTTPClient(tr)
 	r, err := NewSession(client, authConfig, endpoint)


### PR DESCRIPTION
It should not print to STDOUT so that it only prints the debugTransport
output if there was an error in one of the registry tests.

Signed-off-by: Tibor Vass tibor@docker.com

Ping @crosbymichael @jfrazelle 
