### PR TITLE
Fix wrong kill signal parsing

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -272,14 +272,20 @@ func (s *Server) postContainersKill(version version.Version, w http.ResponseWrit
 	name := vars["name"]
 
 	// If we have a signal, look at it. Otherwise, do nothing
-	if sigStr := vars["signal"]; sigStr != "" {
+	if sigStr := r.Form.Get("signal"); sigStr != "" {
 		// Check if we passed the signal as a number:
 		// The largest legal signal is 31, so let's parse on 5 bits
-		sig, err := strconv.ParseUint(sigStr, 10, 5)
+		sigN, err := strconv.ParseUint(sigStr, 10, 5)
 		if err != nil {
 			// The signal is not a number, treat it as a string (either like
 			// "KILL" or like "SIGKILL")
-			sig = uint64(signal.SignalMap[strings.TrimPrefix(sigStr, "SIG")])
+			syscallSig, ok := signal.SignalMap[strings.TrimPrefix(sigStr, "SIG")]
+			if !ok {
+				return fmt.Errorf("Invalid signal: %s", sigStr)
+			}
+			sig = uint64(syscallSig)
+		} else {
+			sig = sigN
 		}
 
 		if sig == 0 {


### PR DESCRIPTION
fixes #13665 

https://github.com/docker/docker/blob/v1.7.0-rc1/api/server/server.go#L274 `signal` isn't in `vars`
old code https://github.com/docker/docker/blob/v1.6.2/api/server/server.go#L215

this resulted in alwasy passing `0` as signal and being interpreted by the daemon as `SIGKILL`

/cc @aanand

```
DEBU[0016] Calling POST /containers/create              
INFO[0016] POST /v1.20/containers/create                
DEBU[0016] Calling POST /containers/{name:.*}/start     
INFO[0016] POST /v1.20/containers/9ace169f8625121a9d662b865f00d27a1b4f658d403d8a7ba74b425282f65506/start 
DEBU[0016] Calling POST /containers/{name:.*}/kill      
INFO[0016] POST /v1.20/containers/9ace169f8625121a9d662b865f00d27a1b4f658d403d8a7ba74b425282f65506/kill?signal=SIGWINCH 
DEBU[0016] Sending 28 to 9ace169f8625121a9d662b865f00d27a1b4f658d403d8a7ba74b425282f65506 
DEBU[0016] Calling GET /containers/{name:.*}/json       
INFO[0016] GET /v1.20/containers/9ace169f8625121a9d662b865f00d27a1b4f658d403d8a7ba74b425282f65506/json
```

Signed-off-by: Antonio Murdaca antonio.murdaca@gmail.com
