### PR TITLE
Allow to use semicolon as volume flag separator.

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -56,7 +56,9 @@ func parseBindMount(spec string, mountLabel string, config *runconfig.Config) (*
 	bind := &mountPoint{
 		RW: true,
 	}
-	arr := strings.Split(spec, ":")
+
+	separator := volumeSeparator(spec)
+	arr := strings.Split(spec, separator)
 
 	switch len(arr) {
 	case 2:
@@ -98,7 +100,8 @@ func parseVolumesFrom(spec string) (string, string, error) {
 		return "", "", fmt.Errorf("malformed volumes-from specification: %s", spec)
 	}
 
-	specParts := strings.SplitN(spec, ":", 2)
+	separator := volumeSeparator(spec)
+	specParts := strings.SplitN(spec, separator, 2)
 	id := specParts[0]
 	mode := "rw"
 
@@ -301,4 +304,12 @@ func removeVolume(v volume.Volume) error {
 		return nil
 	}
 	return vd.Remove(v)
+}
+
+func volumeSeparator(spec string) string {
+	separator := ":"
+	if strings.Contains(spec, ";") {
+		separator = ";"
+	}
+	return separator
 }

--- a/daemon/volumes_experimental_unit_test.go
+++ b/daemon/volumes_experimental_unit_test.go
@@ -52,6 +52,14 @@ func TestParseBindMount(t *testing.T) {
 		{"name:/tmp", "external", "/tmp", "", "name", "external", "", true, false},
 		{"name:/tmp:ro", "local", "/tmp", "", "name", "local", "", false, false},
 		{"local/name:/tmp:rw", "", "/tmp", "", "local/name", "local", "", true, false},
+		{"/tmp;/tmp", "", "/tmp", "/tmp", "", "", "", true, false},
+		{"/tmp;/tmp;ro", "", "/tmp", "/tmp", "", "", "", false, false},
+		{"/tmp;/tmp;rw", "", "/tmp", "/tmp", "", "", "", true, false},
+		{"/tmp;/tmp;foo", "", "/tmp", "/tmp", "", "", "", false, true},
+		{"name;/tmp", "", "/tmp", "", "name", "local", "", true, false},
+		{"name;/tmp", "external", "/tmp", "", "name", "external", "", true, false},
+		{"name;/tmp;ro", "local", "/tmp", "", "name", "local", "", false, false},
+		{"local/name;/tmp;rw", "", "/tmp", "", "local/name", "local", "", true, false},
 	}
 
 	for _, c := range cases {

--- a/daemon/volumes_stubs_unit_test.go
+++ b/daemon/volumes_stubs_unit_test.go
@@ -51,6 +51,12 @@ func TestParseBindMount(t *testing.T) {
 		{"/tmp:/tmp:foo", "/tmp", "/tmp", "", "", false, true},
 		{"name:/tmp", "", "", "", "", false, true},
 		{"local/name:/tmp:rw", "", "", "", "", true, true},
+		{"/tmp;/tmp", "/tmp", "/tmp", "", "", true, false},
+		{"/tmp;/tmp;ro", "/tmp", "/tmp", "", "", false, false},
+		{"/tmp;/tmp;rw", "/tmp", "/tmp", "", "", true, false},
+		{"/tmp;/tmp;foo", "/tmp", "/tmp", "", "", false, true},
+		{"name;/tmp", "", "", "", "", false, true},
+		{"local/name;/tmp;rw", "", "", "", "", true, true},
 	}
 
 	for _, c := range cases {

--- a/daemon/volumes_unit_test.go
+++ b/daemon/volumes_unit_test.go
@@ -14,6 +14,9 @@ func TestParseVolumeFrom(t *testing.T) {
 		{"foobar:rw", "foobar", "rw", false},
 		{"foobar:ro", "foobar", "ro", false},
 		{"foobar:baz", "", "", true},
+		{"foobar;rw", "foobar", "rw", false},
+		{"foobar;ro", "foobar", "ro", false},
+		{"foobar;baz", "", "", true},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
So we can support bind mounting windows paths, like:

```
> docker run -v C:\system32;/system32;rw
```

I'm sure this needs some documentation, but I don't know where to put it. I'll take suggestions.

Fixes #8604

Signed-off-by: David Calavera david.calavera@gmail.com
