### PR TITLE
Expose old config field for api < 1.19

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1141,6 +1141,14 @@ func (s *Server) getContainersByName(version version.Version, w http.ResponseWri
 		return fmt.Errorf("Missing parameter")
 	}
 
+	if version.LessThan("1.19") {
+		containerJSONRaw, err := s.daemon.ContainerInspectRaw(vars["name"])
+		if err != nil {
+			return err
+		}
+		return writeJSON(w, http.StatusOK, containerJSONRaw)
+	}
+
 	containerJSON, err := s.daemon.ContainerInspect(vars["name"])
 	if err != nil {
 		return err

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -195,12 +195,11 @@ type ContainerState struct {
 }
 
 // GET "/containers/{name:.*}/json"
-type ContainerJSON struct {
+type ContainerJSONBase struct {
 	Id              string
 	Created         time.Time
 	Path            string
 	Args            []string
-	Config          *runconfig.Config
 	State           *ContainerState
 	Image           string
 	NetworkSettings *network.Settings
@@ -219,4 +218,25 @@ type ContainerJSON struct {
 	AppArmorProfile string
 	ExecIDs         []string
 	HostConfig      *runconfig.HostConfig
+}
+
+type ContainerJSON struct {
+	*ContainerJSONBase
+	Config *runconfig.Config
+}
+
+// backcompatibility struct along with ContainerConfig
+type ContainerJSONRaw struct {
+	*ContainerJSONBase
+	Config *ContainerConfig
+}
+
+type ContainerConfig struct {
+	*runconfig.Config
+
+	// backward compatibility, they now live in HostConfig
+	Memory     int64
+	MemorySwap int64
+	CpuShares  int64
+	Cpuset     string
 }


### PR DESCRIPTION
/cc @icecrime @calavera @aanand

I tried everything (99.9999% sure) before going with a second function just for < 1.19 code path :angel: 
fixes #13663

Signed-off-by: Antonio Murdaca me@runcom.ninja
