### PR TITLE
Update vendoring

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -55,7 +55,7 @@ clone hg code.google.com/p/go.net 84a4013f96e0
 clone hg code.google.com/p/gosqlite 74691fb6f837
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork 4ded6fe3641b71863cc5985652930ce40efc3af4
+clone git github.com/docker/libnetwork 005bc475ee49a36ef2ad9c112d1b5ccdaba277d4
 clone git github.com/vishvananda/netns 008d17ae001344769b031375bdb38a86219154c6
 clone git github.com/vishvananda/netlink 8eb64238879fed52fd51c5b30ad20b928fb4c36c
 

--- a/vendor/src/github.com/docker/distribution/digest/digester_resumable_test.go
+++ b/vendor/src/github.com/docker/distribution/digest/digester_resumable_test.go
@@ -1,0 +1,21 @@
+// +build !noresumabledigest
+
+package digest
+
+import (
+	"testing"
+
+	"github.com/stevvooe/resumable"
+	_ "github.com/stevvooe/resumable/sha256"
+)
+
+// TestResumableDetection just ensures that the resumable capability of a hash
+// is exposed through the digester type, which is just a hash plus a Digest
+// method.
+func TestResumableDetection(t *testing.T) {
+	d := Canonical.New()
+
+	if _, ok := d.Hash().(resumable.Hash); !ok {
+		t.Fatalf("expected digester to implement resumable.Hash: %#v, %v", d, d.Hash())
+	}
+}

--- a/vendor/src/github.com/docker/libnetwork/portallocator/portallocator.go
+++ b/vendor/src/github.com/docker/libnetwork/portallocator/portallocator.go
@@ -7,8 +7,6 @@ import (
 	"net"
 	"os"
 	"sync"
-
-	"github.com/Sirupsen/logrus"
 )
 
 const (
@@ -94,7 +92,6 @@ func Get() *PortAllocator {
 func newInstance() *PortAllocator {
 	start, end, err := getDynamicPortRange()
 	if err != nil {
-		logrus.Warn(err)
 		start, end = DefaultPortRangeStart, DefaultPortRangeEnd
 	}
 	return &PortAllocator{


### PR DESCRIPTION
- Update libnetwork to `005bc475ee49a36ef2ad9c112d1b5ccdaba277d4`
- Synchronize changes to distribution (was missing _test.go file): I'm assuming somebody forgot to `git add` it earlier.

Closes #13373.
