### PR TITLE
Fix nat integration tests

### DIFF
--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os/exec"
 	"strings"
@@ -9,15 +10,14 @@ import (
 	"github.com/go-check/check"
 )
 
-func startServerContainer(c *check.C, proto string, port int) string {
-	pStr := fmt.Sprintf("%d:%d", port, port)
-	bCmd := fmt.Sprintf("nc -lp %d && echo bye", port)
-	cmd := []string{"-d", "-p", pStr, "busybox", "sh", "-c", bCmd}
-	if proto == "udp" {
-		cmd = append(cmd, "-u")
-	}
-
+func startServerContainer(c *check.C, msg string, port int) string {
 	name := "server"
+	cmd := []string{
+		"-d",
+		"-p", fmt.Sprintf("%d:%d", port, port),
+		"busybox",
+		"sh", "-c", fmt.Sprintf("echo %q | nc -lp %d", msg, port),
+	}
 	if err := waitForContainer(name, cmd...); err != nil {
 		c.Fatalf("Failed to launch server container: %v", err)
 	}
@@ -60,52 +60,41 @@ func getContainerStatus(c *check.C, containerID string) string {
 
 func (s *DockerSuite) TestNetworkNat(c *check.C) {
 	testRequires(c, SameHostDaemon, NativeExecDriver)
-
-	srv := startServerContainer(c, "tcp", 8080)
-
-	// Spawn a new container which connects to the server through the
-	// interface address.
+	msg := "it works"
+	startServerContainer(c, msg, 8080)
 	endpoint := getExternalAddress(c)
-	runCmd := exec.Command(dockerBinary, "run", "busybox", "sh", "-c", fmt.Sprintf("echo hello world | nc -w 30 %s 8080", endpoint))
-	if out, _, err := runCommandWithOutput(runCmd); err != nil {
-		c.Fatalf("Failed to connect to server: %v (output: %q)", err, string(out))
+	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", endpoint.String(), 8080))
+	if err != nil {
+		c.Fatalf("Failed to connect to container (%v)", err)
 	}
-
-	result := getContainerLogs(c, srv)
-
-	// Ideally we'd like to check for "hello world" but sometimes
-	// nc doesn't show the data it received so instead let's look for
-	// the output of the 'echo bye' that should be printed once
-	// the nc command gets a connection
-	expected := "bye"
-	if !strings.Contains(result, expected) {
-		c.Fatalf("Unexpected output. Expected: %q, received: %q", expected, result)
+	data, err := ioutil.ReadAll(conn)
+	conn.Close()
+	if err != nil {
+		c.Fatal(err)
+	}
+	final := strings.TrimRight(string(data), "\n")
+	if final != msg {
+		c.Fatalf("Expected message %q but received %q", msg, final)
 	}
 }
 
 func (s *DockerSuite) TestNetworkLocalhostTCPNat(c *check.C) {
 	testRequires(c, SameHostDaemon, NativeExecDriver)
-
-	srv := startServerContainer(c, "tcp", 8081)
-
-	// Attempt to connect from the host to the listening container.
+	var (
+		msg = "hi yall"
+	)
+	startServerContainer(c, msg, 8081)
 	conn, err := net.Dial("tcp", "localhost:8081")
 	if err != nil {
 		c.Fatalf("Failed to connect to container (%v)", err)
 	}
-	if _, err := conn.Write([]byte("hello world\n")); err != nil {
+	data, err := ioutil.ReadAll(conn)
+	conn.Close()
+	if err != nil {
 		c.Fatal(err)
 	}
-	conn.Close()
-
-	result := getContainerLogs(c, srv)
-
-	// Ideally we'd like to check for "hello world" but sometimes
-	// nc doesn't show the data it received so instead let's look for
-	// the output of the 'echo bye' that should be printed once
-	// the nc command gets a connection
-	expected := "bye"
-	if !strings.Contains(result, expected) {
-		c.Fatalf("Unexpected output. Expected: %q, received: %q", expected, result)
+	final := strings.TrimRight(string(data), "\n")
+	if final != msg {
+		c.Fatalf("Expected message %q but received %q", msg, final)
 	}
 }


### PR DESCRIPTION
This removes complexity of current implementation and makes the test
correct and assert the right things.

Fixes #13556

Signed-off-by: Michael Crosby crosbymichael@gmail.com
