### PR TITLE
Cleanup Daemon.verifyVolumesInfo() a bit

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -268,7 +268,7 @@ func (daemon *Daemon) verifyVolumesInfo(container *Container) error {
 
 	for destination, hostPath := range vols.Volumes {
 		vfsPath := filepath.Join(daemon.root, "vfs", "dir")
-		rw := vols.VolumesRW != nil && vols.VolumesRW[destination]
+		rw := vols.VolumesRW[destination]
 
 		if strings.HasPrefix(hostPath, vfsPath) {
 			id := filepath.Base(hostPath)


### PR DESCRIPTION
vols.VolumesRW has been initialized so it can't be nil. Furthermore
it's ok to read a nil map.

Signed-off-by: Zefan Li lizefan@huawei.com
