### PR TITLE
Handle error if UntarPath fails

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -716,7 +716,7 @@ func (b *Builder) addContext(container *daemon.Container, orig, dest string, dec
 		if err := chrootarchive.UntarPath(origPath, tarDest); err == nil {
 			return nil
 		} else if err != io.EOF {
-			logrus.Debugf("Couldn't untar %s to %s: %s", origPath, tarDest, err)
+			return fmt.Errorf("Couldn't untar %s to %s: %s", origPath, tarDest, err)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This PR fixes an issue whereby if chrootarchive.UntarPath() fails in builder addContext, it is surfaced back through the call stack and back to the caller. Without this, if an error occurs, it appears to the caller (client) that the untar step in the build was successful where in reality it wasn't. (And of course, no one is likely to be running with the daemon in debug mode and looking at the output).
