### PR TITLE
Do not omit empty json field in /containers/json api response

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -101,16 +101,16 @@ type Port struct {
 }
 
 type Container struct {
-	ID         string            `json:"Id"`
-	Names      []string          `json:",omitempty"`
-	Image      string            `json:",omitempty"`
-	Command    string            `json:",omitempty"`
-	Created    int               `json:",omitempty"`
-	Ports      []Port            `json:",omitempty"`
-	SizeRw     int               `json:",omitempty"`
-	SizeRootFs int               `json:",omitempty"`
-	Labels     map[string]string `json:",omitempty"`
-	Status     string            `json:",omitempty"`
+	ID         string `json:"Id"`
+	Names      []string
+	Image      string
+	Command    string
+	Created    int
+	Ports      []Port
+	SizeRw     int
+	SizeRootFs int
+	Labels     map[string]string
+	Status     string
 }
 
 // POST "/containers/"+containerID+"/copy"


### PR DESCRIPTION
fixes #13691 

old engine code was using env https://github.com/docker/docker/blob/v1.6.2/daemon/list.go#L165
`env.SetJson` (aka `env.SetList`) kept empty fields

Signed-off-by: Antonio Murdaca runcom@linux.com
