### PR TITLE
Swap build-* to use UTC instead of local time

### DIFF
--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -e
 
-# subshell so that we can export PATH without breaking other things
+# subshell so that we can export PATH and TZ without breaking other things
 (
+	export TZ=UTC # make sure our "date" variables are UTC-based
+
 	source "${MAKEDIR}/.integration-daemon-start"
 
 	# TODO consider using frozen images for the dockercore/builder-deb tags

--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -e
 
-# subshell so that we can export PATH without breaking other things
+# subshell so that we can export PATH and TZ without breaking other things
 (
+	export TZ=UTC # make sure our "date" variables are UTC-based
+
 	source "$(dirname "$BASH_SOURCE")/.integration-daemon-start"
 
 	# TODO consider using frozen images for the dockercore/builder-rpm tags


### PR DESCRIPTION
This makes for much more consistent version numbers (ie, no matter whose machine we build it on, the latest commit will generate the same version number).
