### PR TITLE
Update netns to 5478c060110032f972e86a1f844fdb9a2f008f2c

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -55,8 +55,8 @@ clone hg code.google.com/p/go.net 84a4013f96e0
 clone hg code.google.com/p/gosqlite 74691fb6f837
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork f72ad20491e8c46d9664da3f32a0eddb301e7c8d
-clone git github.com/vishvananda/netns 008d17ae001344769b031375bdb38a86219154c6
+clone git github.com/docker/libnetwork 147d3e5773ccd72881ac92384b22597eeb6dc736
+clone git github.com/vishvananda/netns 5478c060110032f972e86a1f844fdb9a2f008f2c
 clone git github.com/vishvananda/netlink 8eb64238879fed52fd51c5b30ad20b928fb4c36c
 
 # get distribution packages

--- a/vendor/src/github.com/vishvananda/netns/netns.go
+++ b/vendor/src/github.com/vishvananda/netns/netns.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"syscall"
 )
+
 // NsHandle is a handle to a network namespace. It can be cast directly
 // to an int and used as a file descriptor.
 type NsHandle int

--- a/vendor/src/github.com/vishvananda/netns/netns_linux.go
+++ b/vendor/src/github.com/vishvananda/netns/netns_linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netns
 
 import (

--- a/vendor/src/github.com/vishvananda/netns/netns_linux_386.go
+++ b/vendor/src/github.com/vishvananda/netns/netns_linux_386.go
@@ -1,3 +1,5 @@
+// +build linux,386
+
 package netns
 
 const (

--- a/vendor/src/github.com/vishvananda/netns/netns_linux_amd64.go
+++ b/vendor/src/github.com/vishvananda/netns/netns_linux_amd64.go
@@ -1,3 +1,5 @@
+// +build linux,amd64
+
 package netns
 
 const (

--- a/vendor/src/github.com/vishvananda/netns/netns_linux_arm.go
+++ b/vendor/src/github.com/vishvananda/netns/netns_linux_arm.go
@@ -1,3 +1,5 @@
+// +build linux,arm
+
 package netns
 
 const (

--- a/vendor/src/github.com/vishvananda/netns/netns_linux_ppc64le.go
+++ b/vendor/src/github.com/vishvananda/netns/netns_linux_ppc64le.go
@@ -1,0 +1,7 @@
+// +build linux,ppc64le
+
+package netns
+
+const (
+	SYS_SETNS = 350
+)

--- a/vendor/src/github.com/vishvananda/netns/netns_unspecified.go
+++ b/vendor/src/github.com/vishvananda/netns/netns_unspecified.go
@@ -10,26 +10,26 @@ var (
 	ErrNotImplemented = errors.New("not implemented")
 )
 
-func Set(ns Namespace) (err error) {
+func Set(ns NsHandle) (err error) {
 	return ErrNotImplemented
 }
 
-func New() (ns Namespace, err error) {
+func New() (ns NsHandle, err error) {
 	return -1, ErrNotImplemented
 }
 
-func Get() (Namespace, error) {
+func Get() (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
-func GetFromName(name string) (Namespace, error) {
+func GetFromName(name string) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
-func GetFromPid(pid int) (Namespace, error) {
+func GetFromPid(pid int) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
-func GetFromDocker(id string) (Namespace, error) {
+func GetFromDocker(id string) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }


### PR DESCRIPTION
Existing version of netns do not have requisite syscall entry for Power(ppc64le)
arch. Consequently the current upstream version of docker fails to create containers
with networking enabled.
This patch updates netns to latest commit to add ppc64le syscall entry.

Signed-off-by: Pradipta Kr. Banerjee bpradip@in.ibm.com
