### PR TITLE
Added openSUSE and SUSE Linux Enterprise support to install.sh

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -133,6 +133,21 @@ do_install() {
 			exit 0
 			;;
 
+		'opensuse project'|opensuse|'suse linux'|sled)
+			(
+				set -x
+				$sh_c 'sleep 3; zypper -n install docker'
+			)
+			if command_exists docker && [ -e /var/run/docker.sock ]; then
+				(
+					set -x
+					$sh_c 'docker version'
+				) || true
+			fi
+			echo_docker_as_nonroot
+			exit 0
+			;;
+
 		ubuntu|debian|linuxmint|'elementary os'|kali)
 			export DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Handle docker installation on openSUSE and SUSE Linux Enterprise via https://get.docker.io/
