### PR TITLE
SizeRW & SizeRootFs omitted if empty in /container/json call

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -107,8 +107,8 @@ type Container struct {
 	Command    string
 	Created    int
 	Ports      []Port
-	SizeRw     int
-	SizeRootFs int
+	SizeRw     int `json:",omitempty"`
+	SizeRootFs int `json:",omitempty"`
 	Labels     map[string]string
 	Status     string
 }

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -71,8 +71,6 @@ func (s *DockerSuite) TestContainerApiGetJSONNoFieldsOmitted(c *check.C) {
 		"Command",
 		"Created",
 		"Ports",
-		"SizeRw",
-		"SizeRootFs",
 		"Labels",
 		"Status",
 	}


### PR DESCRIPTION
because of https://github.com/docker/docker/blob/v1.6.2/daemon/list.go#L160

ping @icecrime 

Signed-off-by: Antonio Murdaca runcom@linux.com
