### PR TITLE
Migrate data from old vfs paths to new local volumes path.

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/volume"
@@ -272,6 +273,9 @@ func (daemon *Daemon) verifyVolumesInfo(container *Container) error {
 
 		if strings.HasPrefix(hostPath, vfsPath) {
 			id := filepath.Base(hostPath)
+			if err := daemon.migrateVolume(id, hostPath); err != nil {
+				return err
+			}
 			container.addLocalMountPoint(id, destination, rw)
 		} else { // Bind mount
 			id, source, err := parseVolumeSource(hostPath)
@@ -285,6 +289,37 @@ func (daemon *Daemon) verifyVolumesInfo(container *Container) error {
 	}
 
 	return container.ToDisk()
+}
+
+// migrateVolume moves the contents of a volume created pre Docker 1.7
+// to the location expected by the local driver. Steps:
+// 1. Save old directory that includes old volume's config json file.
+// 2. Move virtual directory with content to where the local driver expects it to be.
+// 3. Remove the backup of the old volume config.
+func (daemon *Daemon) migrateVolume(id, vfs string) error {
+	volumeInfo := filepath.Join(daemon.root, defaultVolumesPathName, id)
+	backup := filepath.Join(daemon.root, defaultVolumesPathName, id+".back")
+
+	var err error
+	if err = os.Rename(volumeInfo, backup); err != nil {
+		return err
+	}
+	defer func() {
+		// Put old configuration back in place in case one of the next steps fails.
+		if err != nil {
+			os.Rename(backup, volumeInfo)
+		}
+	}()
+
+	if err = os.Rename(vfs, volumeInfo); err != nil {
+		return err
+	}
+
+	if err = os.RemoveAll(backup); err != nil {
+		logrus.Errorf("Unable to remove volume info backup directory %s: %v", backup, err)
+	}
+
+	return nil
 }
 
 func createVolume(name, driverName string) (volume.Volume, error) {


### PR DESCRIPTION
This is a bug upgrading from Docker 1.6 to Docker 1.7.

Before:

![dockercompat-before](https://cloud.githubusercontent.com/assets/1050/7973206/02cc065a-0a08-11e5-9cd3-4f9f971f0a12.gif)

After:

![dockercompat-after](https://cloud.githubusercontent.com/assets/1050/7973209/06f585b2-0a08-11e5-86be-30193da83bf4.gif)

Signed-off-by: David Calavera david.calavera@gmail.com
