### PR TITLE
Using container NetworkDisabled to fix #13725

### DIFF
--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -183,7 +183,7 @@ func getDevicesFromPath(deviceMapping runconfig.DeviceMapping) (devs []*configs.
 
 func populateCommand(c *Container, env []string) error {
 	var en *execdriver.Network
-	if !c.daemon.config.DisableNetwork {
+	if !c.Config.NetworkDisabled {
 		en = &execdriver.Network{
 			NamespacePath: c.NetworkSettings.SandboxKey,
 		}


### PR DESCRIPTION
container.config.NetworkDisabled is set for both daemon's
DisableNetwork and --networking=false case. Hence using
this flag instead to fix #13725.

There is an existing integration-test to catch this issue,
but it is working for the wrong reasons.

Signed-off-by: Madhu Venugopal madhu@docker.com
