### PR TITLE
Make install.sh use HKPS instead of unencrypted hkp forced on Port 80

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -189,9 +189,9 @@ do_install() {
 			(
 				set -x
 				if [ "https://get.docker.com/" = "$url" ]; then
-					$sh_c "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
+					$sh_c "apt-key adv --keyserver hkps.pool.sks-keyservers.net --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9"
 				elif [ "https://test.docker.com/" = "$url" ]; then
-					$sh_c "apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 740B314AE3941731B942C66ADF4FD13717AAD7D6"
+					$sh_c "apt-key adv --keyserver hkps.pool.sks-keyservers.net --recv-keys 740B314AE3941731B942C66ADF4FD13717AAD7D6"
 				else
 					$sh_c "$curl ${url}gpg | apt-key add -"
 				fi


### PR DESCRIPTION
The script which should be used to install docker via `get.docker.com` uses unencrypted HKP to get the Key for the Debian-Repository.

It would be fairly easy to switch to HKPS. `sks-keyservers.net` do maintain a HKPS pool which listens on Port 443. See https://sks-keyservers.net/overview-of-pools.php.

This pull requests changes the behaviour to get the keys.

Note that I have not checked if there are other scripts which are trying to import a Key using unencrypted HKP. If Port 443 should be firewalled, it might make sense to add a note that the keys should get downloaded manually using Port 80. But if Port 443 is firewalled/unavailable, a user who wants to install/update docker should know how to get the key in a secure way.
