### PR TITLE
Windows: Security warning based on server OS

### DIFF
--- a/api/client/create.go
+++ b/api/client/create.go
@@ -52,7 +52,7 @@ func (cli *DockerCli) pullImageCustomOut(image string, out io.Writer) error {
 		out:         out,
 		headers:     map[string][]string{"X-Registry-Auth": registryAuthHeader},
 	}
-	if err := cli.stream("POST", "/images/create?"+v.Encode(), sopts); err != nil {
+	if _, err := cli.stream("POST", "/images/create?"+v.Encode(), sopts); err != nil {
 		return err
 	}
 	return nil

--- a/api/client/events.go
+++ b/api/client/events.go
@@ -55,7 +55,7 @@ func (cli *DockerCli) CmdEvents(args ...string) error {
 		rawTerminal: true,
 		out:         cli.out,
 	}
-	if err := cli.stream("GET", "/events?"+v.Encode(), sopts); err != nil {
+	if _, err := cli.stream("GET", "/events?"+v.Encode(), sopts); err != nil {
 		return err
 	}
 	return nil

--- a/api/client/export.go
+++ b/api/client/export.go
@@ -38,7 +38,7 @@ func (cli *DockerCli) CmdExport(args ...string) error {
 		rawTerminal: true,
 		out:         output,
 	}
-	if err := cli.stream("GET", "/containers/"+image+"/export", sopts); err != nil {
+	if _, err := cli.stream("GET", "/containers/"+image+"/export", sopts); err != nil {
 		return err
 	}
 

--- a/api/client/import.go
+++ b/api/client/import.go
@@ -71,5 +71,6 @@ func (cli *DockerCli) CmdImport(args ...string) error {
 		out:         cli.out,
 	}
 
-	return cli.stream("POST", "/images/create?"+v.Encode(), sopts)
+	_, err := cli.stream("POST", "/images/create?"+v.Encode(), sopts)
+	return err
 }

--- a/api/client/load.go
+++ b/api/client/load.go
@@ -34,7 +34,7 @@ func (cli *DockerCli) CmdLoad(args ...string) error {
 		in:          input,
 		out:         cli.out,
 	}
-	if err := cli.stream("POST", "/images/load", sopts); err != nil {
+	if _, err := cli.stream("POST", "/images/load", sopts); err != nil {
 		return err
 	}
 	return nil

--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -65,5 +65,6 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 		err:         cli.err,
 	}
 
-	return cli.stream("GET", "/containers/"+name+"/logs?"+v.Encode(), sopts)
+	_, err = cli.stream("GET", "/containers/"+name+"/logs?"+v.Encode(), sopts)
+	return err
 }

--- a/api/client/save.go
+++ b/api/client/save.go
@@ -41,7 +41,7 @@ func (cli *DockerCli) CmdSave(args ...string) error {
 
 	if len(cmd.Args()) == 1 {
 		image := cmd.Arg(0)
-		if err := cli.stream("GET", "/images/"+image+"/get", sopts); err != nil {
+		if _, err := cli.stream("GET", "/images/"+image+"/get", sopts); err != nil {
 			return err
 		}
 	} else {
@@ -49,7 +49,7 @@ func (cli *DockerCli) CmdSave(args ...string) error {
 		for _, arg := range cmd.Args() {
 			v.Add("names", arg)
 		}
-		if err := cli.stream("GET", "/images/get?"+v.Encode(), sopts); err != nil {
+		if _, err := cli.stream("GET", "/images/get?"+v.Encode(), sopts); err != nil {
 			return err
 		}
 	}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1502,6 +1502,8 @@ func makeHttpHandler(logging bool, localMethod string, localRoute string, handle
 			return
 		}
 
+		w.Header().Set("Server", "Docker/"+dockerversion.VERSION+" ("+runtime.GOOS+")")
+
 		if err := handlerFunc(version, w, r, mux.Vars(r)); err != nil {
 			logrus.Errorf("Handler for %s %s returned error: %s", localMethod, localRoute, err)
 			httpError(w, err)

--- a/pkg/httputils/httputils.go
+++ b/pkg/httputils/httputils.go
@@ -1,8 +1,11 @@
 package httputils
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
+	"strings"
 
 	"github.com/docker/docker/pkg/jsonmessage"
 )
@@ -24,4 +27,32 @@ func NewHTTPRequestError(msg string, res *http.Response) error {
 		Message: msg,
 		Code:    res.StatusCode,
 	}
+}
+
+type ServerHeader struct {
+	App string // docker
+	Ver string // 1.8.0-dev
+	OS  string // windows or linux
+}
+
+// parseServerHeader extracts pieces from am HTTP server header
+// which is in the format "docker/version (os)" eg docker/1.8.0-dev (windows)
+func ParseServerHeader(hdr string) (*ServerHeader, error) {
+	re := regexp.MustCompile(`.*\((.+)\).*$`)
+	r := &ServerHeader{}
+	if matches := re.FindStringSubmatch(hdr); matches != nil {
+		r.OS = matches[1]
+		parts := strings.Split(hdr, "/")
+		if len(parts) != 2 {
+			return nil, errors.New("Bad header: '/' missing")
+		}
+		r.App = parts[0]
+		v := strings.Split(parts[1], " ")
+		if len(v) != 2 {
+			return nil, errors.New("Bad header: Expected single space")
+		}
+		r.Ver = v[0]
+		return r, nil
+	}
+	return nil, errors.New("Bad header: Failed regex match")
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com
@swernli @duglin @tiborvass 

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. This fixes the problem whereby the Windows client always output a security message about file permissions on the basis that the daemon was running on Linux. As we now have a Windows daemon up and running, the daemon now returns it's OS on the build call. That is parsed by the client, and if the daemon isn't Windows (to also allow for FreeBSD...), only then does it output the security message.

Note: As a result of this change, the daemon will return a Server HTTP header such as "Docker/1.7.0-dev (Linux)" mirroring HTTP standards (http://en.wikipedia.org/wiki/List_of_HTTP_header_fields#Response_fields)
