### PR TITLE
Support LABEL as change for `docker commit`

### DIFF
--- a/builder/job.go
+++ b/builder/job.go
@@ -34,6 +34,8 @@ var validCommitCommands = map[string]bool{
 	"volume":     true,
 	"expose":     true,
 	"onbuild":    true,
+	"label":      true,
+	"maintainer": true,
 }
 
 type Config struct {

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -223,6 +223,13 @@ func (s *DockerSuite) TestCommitChange(c *check.C) {
 		"--change", "ENV DEBUG true",
 		"--change", "ENV test 1",
 		"--change", "ENV PATH /foo",
+		"--change", "LABEL foo bar",
+		"--change", "CMD [\"/bin/sh\"]",
+		"--change", "WORKDIR /opt",
+		"--change", "ENTRYPOINT [\"/bin/sh\"]",
+		"--change", "USER testuser",
+		"--change", "VOLUME /var/lib/docker",
+		"--change", "ONBUILD /usr/local/bin/python-build --dir /app/src",
 		"test", "test-commit")
 	imageId, _, err := runCommandWithOutput(cmd)
 	if err != nil {
@@ -233,6 +240,13 @@ func (s *DockerSuite) TestCommitChange(c *check.C) {
 	expected := map[string]string{
 		"Config.ExposedPorts": "map[8080/tcp:{}]",
 		"Config.Env":          "[DEBUG=true test=1 PATH=/foo]",
+		"Config.Labels":       "map[foo:bar]",
+		"Config.Cmd":          "{[/bin/sh]}",
+		"Config.WorkingDir":   "/opt",
+		"Config.Entrypoint":   "{[/bin/sh]}",
+		"Config.User":         "testuser",
+		"Config.Volumes":      "map[/var/lib/docker:{}]",
+		"Config.OnBuild":      "[/usr/local/bin/python-build --dir /app/src]",
 	}
 
 	for conf, value := range expected {


### PR DESCRIPTION
just adding label to whitelist for commit command

The docs imply that LABEL is supported as a change field, but it is not on the whitelist.

I have tested this locally and it was successful, but I'm not sure if this is all that is really required to support label as a change field for commit.
