### PR TITLE
Fix release script to release _both_ .deb files

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -251,9 +251,10 @@ release_ubuntu() {
 		exit 1
 	}
 
+	local debfiles=( "bundles/$VERSION/ubuntu/"*.deb )
+
 	# Sign our packages
-	dpkg-sig -g "--passphrase $GPG_PASSPHRASE" -k releasedocker \
-		--sign builder "bundles/$VERSION/ubuntu/"*.deb
+	dpkg-sig -g "--passphrase $GPG_PASSPHRASE" -k releasedocker --sign builder "${debfiles[@]}"
 
 	# Setup the APT repo
 	APTDIR=bundles/$VERSION/ubuntu/apt
@@ -266,8 +267,7 @@ Architectures: amd64 i386
 EOF
 
 	# Add the DEB package to the APT repo
-	DEBFILE=( bundles/$VERSION/ubuntu/lxc-docker*.deb )
-	reprepro -b "$APTDIR" includedeb docker "$DEBFILE"
+	reprepro -b "$APTDIR" includedeb docker "${debfiles[@]}"
 
 	# Sign
 	for F in $(find $APTDIR -name Release); do


### PR DESCRIPTION
cc @jfrazelle 

We won't want to bring this in to fix `-rc2` (we'll work through that fix by hand), but we definitely _need_ this in for `-rc3` or actual release.
