### PR TITLE
Remove duplicate call to net.ParseIP

### DIFF
--- a/opts/ip.go
+++ b/opts/ip.go
@@ -22,10 +22,10 @@ func (o *IpOpt) Set(val string) error {
 	if ip == nil {
 		return fmt.Errorf("%s is not an ip address", val)
 	}
-	(*o.IP) = net.ParseIP(val)
+	*o.IP = ip
 	return nil
 }
 
 func (o *IpOpt) String() string {
-	return (*o.IP).String()
+	return o.IP.String()
 }


### PR DESCRIPTION
and a little cleanup

Signed-off-by: Doug Davis dug@us.ibm.com
