### PR TITLE
Container don't inherit from image labels

### DIFF
--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -269,7 +269,7 @@ func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
 	}
 
 	name := "test_create_labels_from_image"
-	expected := map[string]string{"k2": "x", "k3": "v3", "k1": "v1"}
+	expected := map[string]string{"k2": "x", "k3": "v3"}
 	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "create", "--name", name, "-l", "k2=x", "--label", "k3=v3", imageName)); err != nil {
 		c.Fatal(out, err)
 	}

--- a/runconfig/merge.go
+++ b/runconfig/merge.go
@@ -41,16 +41,6 @@ func Merge(userConf, imageConf *Config) error {
 		}
 	}
 
-	if userConf.Labels == nil {
-		userConf.Labels = map[string]string{}
-	}
-	if imageConf.Labels != nil {
-		for l := range userConf.Labels {
-			imageConf.Labels[l] = userConf.Labels[l]
-		}
-		userConf.Labels = imageConf.Labels
-	}
-
 	if userConf.Entrypoint.Len() == 0 {
 		if userConf.Cmd.Len() == 0 {
 			userConf.Cmd = imageConf.Cmd


### PR DESCRIPTION
Labels are metadata that apply to a particular resource: image, container, maybe volumes and networks in the future. We shouldn't have containers inherit from its image labels: they are not the same objects, and labels cannot be interpreted in the way.

It remains possible to apply metadata to an image using the LABEL Dockerfile instruction, to query them using `docker inspect <img>`, or to filter images on them using `docker images --filter <key>=<value>`.

Fixes #13770.

Signed-off-by: Arnaud Porterie arnaud.porterie@docker.com
