### PR TITLE
Add better client-side error for failed certificate verification

### DIFF
--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -102,6 +102,10 @@ func (cli *DockerCli) clientRequest(method, path string, in io.Reader, headers m
 		if cli.tlsConfig == nil {
 			return serverResp, fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?\n* Is your docker daemon up and running?", err)
 		}
+		if cli.tlsConfig != nil && strings.Contains(err.Error(), "remote error: bad certificate") {
+			return serverResp, fmt.Errorf("The server probably has client authentication (--tlsverify) enabled. Please check your TLS client certification settings: %v", err)
+		}
+
 		return serverResp, fmt.Errorf("An error occurred trying to connect: %v", err)
 	}
 


### PR DESCRIPTION
If the server/daemon is running with `--tlsverify` the tls "Dial" implementation will return it's own errors related to handshake and client certificate missing or denied.  These are not necessarily easily understood as they aren't clear:

```
An error occurred trying to connect: Get https://0.0.0.0:2371/v1.20/version: remote error: bad certificate
```

This adds a more meaningful error on the client side so the "bad
certificate" error coming from the TLS dial code has some context for
the user.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
