### PR TITLE
Remove timer and use -check.v for tests formatting

### DIFF
--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -2,6 +2,7 @@
 set -e
 
 bundle_test_integration_cli() {
+	TESTFLAGS="$TESTFLAGS -check.v"
 	go_test_dir ./integration-cli
 }
 

--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/go-check/check"
 )
@@ -12,30 +10,16 @@ func Test(t *testing.T) {
 	check.TestingT(t)
 }
 
-type TimerSuite struct {
-	start time.Time
-}
-
-func (s *TimerSuite) SetUpTest(c *check.C) {
-	s.start = time.Now()
-}
-
-func (s *TimerSuite) TearDownTest(c *check.C) {
-	fmt.Printf("%-60s%.2f\n", c.TestName(), time.Since(s.start).Seconds())
-}
-
 func init() {
 	check.Suite(&DockerSuite{})
 }
 
 type DockerSuite struct {
-	TimerSuite
 }
 
 func (s *DockerSuite) TearDownTest(c *check.C) {
 	deleteAllContainers()
 	deleteAllImages()
-	s.TimerSuite.TearDownTest(c)
 }
 
 func init() {
@@ -51,7 +35,6 @@ type DockerRegistrySuite struct {
 
 func (s *DockerRegistrySuite) SetUpTest(c *check.C) {
 	s.reg = setupRegistry(c)
-	s.ds.SetUpTest(c)
 }
 
 func (s *DockerRegistrySuite) TearDownTest(c *check.C) {
@@ -72,7 +55,6 @@ type DockerDaemonSuite struct {
 
 func (s *DockerDaemonSuite) SetUpTest(c *check.C) {
 	s.d = NewDaemon(c)
-	s.ds.SetUpTest(c)
 }
 
 func (s *DockerDaemonSuite) TearDownTest(c *check.C) {

--- a/integration-cli/docker_cli_start_volume_driver_unix_test.go
+++ b/integration-cli/docker_cli_start_volume_driver_unix_test.go
@@ -40,7 +40,6 @@ type DockerExternalVolumeSuite struct {
 
 func (s *DockerExternalVolumeSuite) SetUpTest(c *check.C) {
 	s.d = NewDaemon(c)
-	s.ds.SetUpTest(c)
 	s.ec = &eventCounter{}
 
 }


### PR DESCRIPTION
Now it looks like:

```
PASS: docker_api_images_test.go:87: DockerSuite.TestApiImagesDelete     4.439s
PASS: docker_api_images_test.go:14: DockerSuite.TestApiImagesFilter     0.131s
PASS: docker_api_images_test.go:114: DockerSuite.TestApiImagesHistory   4.053s
PASS: docker_api_images_test.go:54: DockerSuite.TestApiImagesSaveAndLoad        4.143s
```
