### PR TITLE
Avoid nil pointer dereference while creating a container with an empty Config

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -658,10 +658,6 @@ func (s *Server) postCommit(version version.Version, w http.ResponseWriter, r *h
 		return err
 	}
 
-	if c == nil {
-		c = &runconfig.Config{}
-	}
-
 	containerCommitConfig := &daemon.ContainerCommitConfig{
 		Pause:   pause,
 		Repo:    r.Form.Get("repo"),

--- a/builder/job.go
+++ b/builder/job.go
@@ -221,6 +221,10 @@ func Commit(d *daemon.Daemon, name string, c *daemon.ContainerCommitConfig) (str
 		return "", err
 	}
 
+	if c.Config == nil {
+		c.Config = &runconfig.Config{}
+	}
+
 	newConfig, err := BuildFromConfig(d, c.Config, c.Changes)
 	if err != nil {
 		return "", err

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -15,6 +15,10 @@ import (
 )
 
 func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hostConfig *runconfig.HostConfig) (string, []string, error) {
+	if config == nil {
+		return "", nil, fmt.Errorf("Config cannot be empty in order to create a container")
+	}
+
 	warnings, err := daemon.verifyHostConfig(hostConfig)
 	if err != nil {
 		return "", warnings, err

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -836,6 +836,19 @@ func (s *DockerSuite) TestContainerApiCreate(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestContainerApiCreateEmptyConfig(c *check.C) {
+	config := map[string]interface{}{}
+
+	status, b, err := sockRequest("POST", "/containers/create", config)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusInternalServerError)
+
+	expected := "Config cannot be empty in order to create a container\n"
+	if body := string(b); body != expected {
+		c.Fatalf("Expected to get %q, got %q", expected, body)
+	}
+}
+
 func (s *DockerSuite) TestContainerApiCreateWithHostName(c *check.C) {
 	hostName := "test-host"
 	config := map[string]interface{}{

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -143,6 +143,10 @@ func (c ContainerConfigWrapper) HostConfig() *HostConfig {
 	return c.hostConfigWrapper.GetHostConfig()
 }
 
+// DecodeContainerConfig decodes a json encoded config into a ContainerConfigWrapper
+// struct and returns both a Config and an HostConfig struct
+// Be aware this function is not checking whether the resulted structs are nil,
+// it's your business to do so
 func DecodeContainerConfig(src io.Reader) (*Config, *HostConfig, error) {
 	decoder := json.NewDecoder(src)
 


### PR DESCRIPTION
Trying to create a container with an empty json object results in a nil pointer dereference panic. 
I found this on latest master (I haven't checked against other versions)

Step to reproduce:

```
root@1dadd042fabe:/go/src/github.com/docker/docker# curl -H "Content-Type: application/json" -X POST -d "{}" http://localhost:2375/containers/create
curl: (52) Empty reply from server
root@1dadd042fabe:/go/src/github.com/docker/docker#
```

and the resulted server side panic:

```
2015/06/06 16:28:04 http: panic serving [::1]:39607: runtime error: invalid memory address or nil pointer dereference
goroutine 46 [running]:
net/http.func·011()
    /usr/local/go/src/net/http/server.go:1130 +0xbb
github.com/docker/docker/daemon.(*Daemon).ContainerCreate(0xc2080b4380, 0x0, 0x0, 0x0, 0xc20841ed80, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
    /go/src/github.com/docker/docker/daemon/create.go:26 +0x128
github.com/docker/docker/api/server.(*Server).postContainersCreate(0xc2080c04c0, 0xdb8000, 0x4, 0x7f73d88a2320, 0xc208174be0, 0xc2080f5790, 0xc208409020, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:901 +0x219
github.com/docker/docker/api/server.*Server.(github.com/docker/docker/api/server.postContainersCreate)·fm(0xdb8000, 0x4, 0x7f73d88a2320, 0xc208174be0, 0xc2080f5790, 0xc208409020, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:1519 +0x7b
github.com/docker/docker/api/server.func·008(0x7f73d88a2320, 0xc208174be0, 0xc2080f5790)
    /go/src/github.com/docker/docker/api/server/server.go:1475 +0x91d
net/http.HandlerFunc.ServeHTTP(0xc208189a80, 0x7f73d88a2320, 0xc208174be0, 0xc2080f5790)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc2080db1d0, 0x7f73d88a2320, 0xc208174be0, 0xc2080f5790)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x297
net/http.serverHandler.ServeHTTP(0xc208062420, 0x7f73d88a2320, 0xc208174be0, 0xc2080f5790)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc208174aa0)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e
```

I checked other code paths from `DecodeContainerConfig` and they are safe checking the config against nil
Anyway this api call should return 400 Bad Request instead of 500 IMHO, but I'm seeking opinion about this, ping @duglin @calavera @LK4D4 

Signed-off-by: Antonio Murdaca runcom@linux.com
