### PR TITLE
Updates man page generation to use go-md2man v1.0.2

### DIFF
--- a/man/Dockerfile
+++ b/man/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.3
+FROM golang:1.4
 RUN mkdir -p /go/src/github.com/cpuguy83
 RUN mkdir -p /go/src/github.com/cpuguy83 \
-    && git clone -b v1 https://github.com/cpuguy83/go-md2man.git /go/src/github.com/cpuguy83/go-md2man \
+    && git clone -b v1.0.1 https://github.com/cpuguy83/go-md2man.git /go/src/github.com/cpuguy83/go-md2man \
     && cd /go/src/github.com/cpuguy83/go-md2man \
     && go get -v ./...
 CMD ["/go/bin/go-md2man", "--help"]


### PR DESCRIPTION
This update includes a patch that fixes the indention issue where
codeblocks cause all further text to be indented.

Fixes #12866

Signed-off-by: Brian Exelbierd bex@pobox.com
