### PR TITLE
Fix COPY/ADD quoted/json form

### DIFF
--- a/docs/man/Dockerfile.5.md
+++ b/docs/man/Dockerfile.5.md
@@ -196,7 +196,7 @@ A Dockerfile is similar to a Makefile.
   ADD <src> <dest>
 
   # Required for paths with whitespace
-  ADD ["<src>", "<dest>"]
+  ADD ["<src>",... "<dest>"]
   ```
 
   The **ADD** instruction copies new files, directories
@@ -215,7 +215,7 @@ A Dockerfile is similar to a Makefile.
   COPY <src> <dest>
 
   # Required for paths with whitespace
-  COPY ["<src>", "<dest>"]
+  COPY ["<src>",... "<dest>"]
   ```
 
   The **COPY** instruction copies new files from `<src>` and

--- a/docs/sources/reference/builder.md
+++ b/docs/sources/reference/builder.md
@@ -492,7 +492,7 @@ change them using `docker run --env <key>=<value>`.
 ADD has two forms:
 
 - `ADD <src>... <dest>`
-- `ADD ["<src>"... "<dest>"]` (this form is required for paths containing
+- `ADD ["<src>",... "<dest>"]` (this form is required for paths containing
 whitespace)
 
 The `ADD` instruction copies new files, directories or remote file URLs from `<src>`
@@ -596,7 +596,7 @@ The copy obeys the following rules:
 COPY has two forms:
 
 - `COPY <src>... <dest>`
-- `COPY ["<src>"... "<dest>"]` (this form is required for paths containing
+- `COPY ["<src>",... "<dest>"]` (this form is required for paths containing
 whitespace)
 
 The `COPY` instruction copies new files or directories from `<src>`


### PR DESCRIPTION
Minor tweak to the quoted/json form and made man page look like the Dockerfile
docs.  W/o the `,` people may think there should be a space delimited list.

Signed-off-by: Doug Davis dug@us.ibm.com
