### PR TITLE
Fix debian jessie installation documentation.

### DIFF
--- a/docs/installation/debian.md
+++ b/docs/installation/debian.md
@@ -17,41 +17,33 @@ Docker is supported on the following versions of Debian:
 
 ## Debian Jessie 8.0 (64-bit)
 
-Debian 8 comes with a 3.16.0 Linux kernel, the `docker.io` package can be found in the `jessie-backports` repository. Reasoning behind this can be found <a href="https://lists.debian.org/debian-release/2015/03/msg00685.html" target="_blank">here</a>. Instructions how to enable the backports repository can be found <a href="http://backports.debian.org/Instructions/" target="_blank">here</a>.
+Debian 8 comes with a 3.16.0 Linux kernel.
 
 > **Note**:
-> Debian contains a much older KDE3/GNOME2 package called ``docker``, so the
-> package and the executable are called ``docker.io``.
+> Debian contains a much older KDE3/GNOME2 package called ``docker``.
 
 ### Installation
 
-Make sure you enabled the `jessie-backports` repository, as stated above.
+1. Install Docker using the get.docker.com script:
 
-To install the latest Debian package (may not be the latest Docker release):
+    `curl -sSL https://get.docker.com/ | sh`
 
-    $ sudo apt-get update
-    $ sudo apt-get install docker.io
-
-To verify that everything has worked as expected:
-
-    $ sudo docker run --rm hello-world
-
-This command downloads and runs the `hello-world` image in a container. When the
-container runs, it prints an informational message. Then, it exits.
-
-> **Note**:
-> If you want to enable memory and swap accounting see
-> [this](/installation/ubuntulinux/#memory-and-swap-accounting).
+>**Note**: If your company is behind a filtering proxy, you may find that the
+>`apt-key`
+>command fails for the Docker repo during installation. To work around this,
+>add the key directly using the following:
+>
+>       $ wget -qO- https://get.docker.com/gpg | sudo apt-key add -
 
 ### Uninstallation
 
 To uninstall the Docker package:
 
-    $ sudo apt-get purge docker-io
+    $ sudo apt-get purge lxc-docker
 
 To uninstall the Docker package and dependencies that are no longer needed:
 
-    $ sudo apt-get autoremove --purge docker-io
+    $ sudo apt-get autoremove --purge lxc-docker
 
 The above commands will not remove images, containers, volumes, or user created
 configuration files on your host. If you wish to delete all images, containers,


### PR DESCRIPTION
Fixes https://github.com/docker/docker/issues/12861

Correct Debian Jessie installation documentation. Remove references to jessie-backports & rely completely on the install script.
