### PR TITLE
Check for apparmor file before reading it

### DIFF
--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -28,7 +28,7 @@ fi
 
 if [ -z "$DOCKER_TEST_HOST" ]; then
 	# Start apparmor if it is enabled
-	if [ "$(cat /sys/module/apparmor/parameters/enabled)" == "Y" ]; then
+	if [ -e "/sys/module/apparmor/parameters/enabled" ] && [ "$(cat /sys/module/apparmor/parameters/enabled)" == "Y" ]; then
 		# reset container variable so apparmor profile is applied to process
 		# see https://github.com/docker/libcontainer/blob/master/apparmor/apparmor.go#L16
 		export container=""

--- a/hack/make/.integration-daemon-stop
+++ b/hack/make/.integration-daemon-stop
@@ -12,7 +12,7 @@ done
 
 if [ -z "$DOCKER_TEST_HOST" ]; then
 	# Stop apparmor if it is enabled
-	if [ "$(cat /sys/module/apparmor/parameters/enabled)" == "Y" ]; then
+	if [ -e "/sys/module/apparmor/parameters/enabled" ] && [ "$(cat /sys/module/apparmor/parameters/enabled)" == "Y" ]; then
 		(
 			set -x
 			/etc/init.d/apparmor stop


### PR DESCRIPTION
I ran a single integration test and got an error that the file
/sys/module/apparmor/parameters/enabled doesn't exist. I don't have
apparmor installed. So, just check the file first to avoid a confusing
error.

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
