### PR TITLE
fix typo.

### DIFF
--- a/daemon/graphdriver/zfs/zfs.go
+++ b/daemon/graphdriver/zfs/zfs.go
@@ -86,7 +86,7 @@ func Init(base string, opt []string) (graphdriver.Driver, error) {
 	}
 
 	if rootDataset == nil {
-		return nil, fmt.Errorf("BUG: zfs get all -t filesystems -rHp '%s' should contain '%s'", options.fsName, options.fsName)
+		return nil, fmt.Errorf("BUG: zfs get all -t filesystem -rHp '%s' should contain '%s'", options.fsName, options.fsName)
 	}
 
 	d := &Driver{


### PR DESCRIPTION
Is this typo?
Argument that can `zfs` command of `-t (type)` option takes seems to be one of the `filesystem | volume | snapshot | bookmark`.

Signed-off-by: mapk0y mapk0y@gmail.com
