### PR TITLE
Windows: Start docker build working

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -489,7 +489,8 @@ func (b *Builder) processImageFrom(img *imagepkg.Image) error {
 		b.Config = img.Config
 	}
 
-	if len(b.Config.Env) == 0 {
+	// The default path will be blank on Windows (set by HCS)
+	if len(b.Config.Env) == 0 && daemon.DefaultPathEnv != "" {
 		b.Config.Env = append(b.Config.Env, "PATH="+daemon.DefaultPathEnv)
 	}
 

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -201,8 +201,11 @@ func (container *Container) LogEvent(action string) {
 //       symlinking to a different path) between using this method and using the
 //       path. See symlink.FollowSymlinkInScope for more details.
 func (container *Container) GetResourcePath(path string) (string, error) {
-	cleanPath := filepath.Join("/", path)
-	return symlink.FollowSymlinkInScope(filepath.Join(container.basefs, cleanPath), container.basefs)
+	// IMPORTANT - These are paths on the OS where the daemon is running, hence
+	// any filepath operations must be done in an OS agnostic way.
+	cleanPath := filepath.Join(string(os.PathSeparator), path)
+	r, e := symlink.FollowSymlinkInScope(filepath.Join(container.basefs, cleanPath), container.basefs)
+	return r, e
 }
 
 // Evaluates `path` in the scope of the container's root, with proper path
@@ -218,7 +221,9 @@ func (container *Container) GetResourcePath(path string) (string, error) {
 //       symlinking to a different path) between using this method and using the
 //       path. See symlink.FollowSymlinkInScope for more details.
 func (container *Container) GetRootResourcePath(path string) (string, error) {
-	cleanPath := filepath.Join("/", path)
+	// IMPORTANT - These are paths on the OS where the daemon is running, hence
+	// any filepath operations must be done in an OS agnostic way.
+	cleanPath := filepath.Join(string(os.PathSeparator), path)
 	return symlink.FollowSymlinkInScope(filepath.Join(container.root, cleanPath), container.root)
 }
 

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -10,8 +10,9 @@ import (
 	"github.com/docker/docker/pkg/archive"
 )
 
-// TODO Windows. A reasonable default at the moment.
-const DefaultPathEnv = `c:\windows\system32;c:\windows\system32\WindowsPowerShell\v1.0`
+// This is deliberately empty on Windows as the default path will be set by
+// the container. Docker has no context of what the default path should be.
+const DefaultPathEnv = ""
 
 type Container struct {
 	CommonContainer
@@ -48,7 +49,8 @@ func (container *Container) setupLinkedContainers() ([]string, error) {
 }
 
 func (container *Container) createDaemonEnvironment(linkedEnv []string) []string {
-	return nil
+	// On Windows, nothing to link. Just return the container environment.
+	return container.Config.Env
 }
 
 func (container *Container) initializeNetworking() error {

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -258,6 +258,7 @@ func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runc
 	return nil
 }
 
+// TODO Windows. Factor out as not relevant (as Windows daemon support not in pre-1.7)
 // verifyVolumesInfo ports volumes configured for the containers pre docker 1.7.
 // It reads the container configuration and creates valid mount points for the old volumes.
 func (daemon *Daemon) verifyVolumesInfo(container *Container) error {

--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -1,68 +1,23 @@
 package chrootarchive
 
 import (
-	"bytes"
-	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/docker/docker/pkg/archive"
-	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/docker/pkg/system"
 )
 
 var chrootArchiver = &archive.Archiver{Untar: Untar}
-
-func untar() {
-	runtime.LockOSThread()
-	flag.Parse()
-
-	var options *archive.TarOptions
-
-	if runtime.GOOS != "windows" {
-		//read the options from the pipe "ExtraFiles"
-		if err := json.NewDecoder(os.NewFile(3, "options")).Decode(&options); err != nil {
-			fatal(err)
-		}
-	} else {
-		if err := json.Unmarshal([]byte(os.Getenv("OPT")), &options); err != nil {
-			fatal(err)
-		}
-	}
-
-	if err := chroot(flag.Arg(0)); err != nil {
-		fatal(err)
-	}
-
-	// Explanation of Windows difference. Windows does not support chroot.
-	// untar() is a helper function for the command line in the format
-	// "docker docker-untar directory input". In Windows, directory will be
-	// something like <pathto>\docker-buildnnnnnnnnn. So, just use that directory
-	// directly instead.
-	//
-	// One example of where this is used is in the docker build command where the
-	// dockerfile will be unpacked to the machine on which the daemon runs.
-	rootPath := "/"
-	if runtime.GOOS == "windows" {
-		rootPath = flag.Arg(0)
-	}
-	if err := archive.Unpack(os.Stdin, rootPath, options); err != nil {
-		fatal(err)
-	}
-	// fully consume stdin in case it is zero padded
-	flush(os.Stdin)
-	os.Exit(0)
-}
 
 // Untar reads a stream of bytes from `archive`, parses it as a tar archive,
 // and unpacks it into the directory at `dest`.
 // The archive may be compressed with one of the following algorithms:
 //  identity (uncompressed), gzip, bzip2, xz.
 func Untar(tarArchive io.Reader, dest string, options *archive.TarOptions) error {
+
 	if tarArchive == nil {
 		return fmt.Errorf("Empty archive")
 	}
@@ -84,67 +39,9 @@ func Untar(tarArchive io.Reader, dest string, options *archive.TarOptions) error
 	if err != nil {
 		return err
 	}
-
-	var data []byte
-	var r, w *os.File
 	defer decompressedArchive.Close()
 
-	if runtime.GOOS != "windows" {
-		// We can't pass a potentially large exclude list directly via cmd line
-		// because we easily overrun the kernel's max argument/environment size
-		// when the full image list is passed (e.g. when this is used by
-		// `docker load`). We will marshall the options via a pipe to the
-		// child
-
-		// This solution won't work on Windows as it will fail in golang
-		// exec_windows.go as at the lowest layer because attr.Files > 3
-		r, w, err = os.Pipe()
-		if err != nil {
-			return fmt.Errorf("Untar pipe failure: %v", err)
-		}
-	} else {
-		// We can't pass the exclude list directly via cmd line
-		// because we easily overrun the shell max argument list length
-		// when the full image list is passed (e.g. when this is used
-		// by `docker load`). Instead we will add the JSON marshalled
-		// and placed in the env, which has significantly larger
-		// max size
-		data, err = json.Marshal(options)
-		if err != nil {
-			return fmt.Errorf("Untar json encode: %v", err)
-		}
-	}
-
-	cmd := reexec.Command("docker-untar", dest)
-	cmd.Stdin = decompressedArchive
-
-	if runtime.GOOS != "windows" {
-		cmd.ExtraFiles = append(cmd.ExtraFiles, r)
-		output := bytes.NewBuffer(nil)
-		cmd.Stdout = output
-		cmd.Stderr = output
-
-		if err := cmd.Start(); err != nil {
-			return fmt.Errorf("Untar error on re-exec cmd: %v", err)
-		}
-		//write the options to the pipe for the untar exec to read
-		if err := json.NewEncoder(w).Encode(options); err != nil {
-			return fmt.Errorf("Untar json encode to pipe failed: %v", err)
-		}
-		w.Close()
-
-		if err := cmd.Wait(); err != nil {
-			return fmt.Errorf("Untar re-exec error: %v: output: %s", err, output)
-		}
-		return nil
-	}
-	cmd.Env = append(cmd.Env, fmt.Sprintf("OPT=%s", data))
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("Untar %s %s", err, out)
-	}
-	return nil
-
+	return invokeUnpack(decompressedArchive, dest, options)
 }
 
 // TarUntar is a convenience function which calls Tar and Untar, with the output of one piped into the other.
@@ -165,8 +62,8 @@ func CopyWithTar(src, dst string) error {
 // for a single file. It copies a regular file from path `src` to
 // path `dst`, and preserves all its metadata.
 //
-// If `dst` ends with a trailing slash '/', the final destination path
-// will be `dst/base(src)`.
+// If `dst` ends with a trailing slash '/' ('\' on Windows), the final
+// destination path will be `dst/base(src)` or `dst\base(src)`
 func CopyFileWithTar(src, dst string) (err error) {
 	return chrootArchiver.CopyFileWithTar(src, dst)
 }

--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -3,7 +3,17 @@
 package chrootarchive
 
 import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
 	"syscall"
+
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/reexec"
 )
 
 func chroot(path string) error {
@@ -11,4 +21,65 @@ func chroot(path string) error {
 		return err
 	}
 	return syscall.Chdir("/")
+}
+
+// untar is the entry-point for docker-untar on re-exec. This is not used on
+// Windows as it does not support chroot, hence no point sandboxing through
+// chroot and rexec.
+func untar() {
+	runtime.LockOSThread()
+	flag.Parse()
+
+	var options *archive.TarOptions
+
+	//read the options from the pipe "ExtraFiles"
+	if err := json.NewDecoder(os.NewFile(3, "options")).Decode(&options); err != nil {
+		fatal(err)
+	}
+
+	if err := chroot(flag.Arg(0)); err != nil {
+		fatal(err)
+	}
+
+	if err := archive.Unpack(os.Stdin, "/", options); err != nil {
+		fatal(err)
+	}
+	// fully consume stdin in case it is zero padded
+	flush(os.Stdin)
+	os.Exit(0)
+}
+
+func invokeUnpack(decompressedArchive io.ReadCloser, dest string, options *archive.TarOptions) error {
+
+	// We can't pass a potentially large exclude list directly via cmd line
+	// because we easily overrun the kernel's max argument/environment size
+	// when the full image list is passed (e.g. when this is used by
+	// `docker load`). We will marshall the options via a pipe to the
+	// child
+	r, w, err := os.Pipe()
+	if err != nil {
+		return fmt.Errorf("Untar pipe failure: %v", err)
+	}
+
+	cmd := reexec.Command("docker-untar", dest)
+	cmd.Stdin = decompressedArchive
+
+	cmd.ExtraFiles = append(cmd.ExtraFiles, r)
+	output := bytes.NewBuffer(nil)
+	cmd.Stdout = output
+	cmd.Stderr = output
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("Untar error on re-exec cmd: %v", err)
+	}
+	//write the options to the pipe for the untar exec to read
+	if err := json.NewEncoder(w).Encode(options); err != nil {
+		return fmt.Errorf("Untar json encode to pipe failed: %v", err)
+	}
+	w.Close()
+
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("Untar re-exec error: %v: output: %s", err, output)
+	}
+	return nil
 }

--- a/pkg/chrootarchive/archive_windows.go
+++ b/pkg/chrootarchive/archive_windows.go
@@ -1,6 +1,21 @@
 package chrootarchive
 
+import (
+	"io"
+
+	"github.com/docker/docker/pkg/archive"
+)
+
 // chroot is not supported by Windows
 func chroot(path string) error {
 	return nil
+}
+
+func invokeUnpack(decompressedArchive io.ReadCloser,
+	dest string,
+	options *archive.TarOptions) error {
+	// Windows is different to Linux here because Windows does not support
+	// chroot. Hence there is no point sandboxing a chrooted process to
+	// do the unpack. We call inline instead within the daemon process.
+	return archive.Unpack(decompressedArchive, dest, options)
 }

--- a/pkg/chrootarchive/diff_windows.go
+++ b/pkg/chrootarchive/diff_windows.go
@@ -1,0 +1,32 @@
+package chrootarchive
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/pkg/archive"
+)
+
+func ApplyLayer(dest string, layer archive.ArchiveReader) (size int64, err error) {
+	dest = filepath.Clean(dest)
+	decompressed, err := archive.DecompressStream(layer)
+	if err != nil {
+		return 0, err
+	}
+	defer decompressed.Close()
+
+	tmpDir, err := ioutil.TempDir(os.Getenv("temp"), "temp-docker-extract")
+	if err != nil {
+		return 0, fmt.Errorf("ApplyLayer failed to create temp-docker-extract under %s. %s", dest, err)
+	}
+
+	s, err := archive.UnpackLayer(dest, decompressed)
+	os.RemoveAll(tmpDir)
+	if err != nil {
+		return 0, fmt.Errorf("ApplyLayer %s failed UnpackLayer to %s", err, dest)
+	}
+
+	return s, nil
+}

--- a/pkg/chrootarchive/init_unix.go
+++ b/pkg/chrootarchive/init_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package chrootarchive
 
 import (
@@ -10,8 +12,8 @@ import (
 )
 
 func init() {
-	reexec.Register("docker-untar", untar)
 	reexec.Register("docker-applyLayer", applyLayer)
+	reexec.Register("docker-untar", untar)
 }
 
 func fatal(err error) {

--- a/pkg/chrootarchive/init_windows.go
+++ b/pkg/chrootarchive/init_windows.go
@@ -1,0 +1,4 @@
+package chrootarchive
+
+func init() {
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli @unclejack @LK4D4 @icecrime @crosbymichael 

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. This PR gets docker build starting to work on the Windows daemon - COPY, ADD and WORKDIR are mostly operational. Note that at this current time, the path seperator in a Dockerfile is /, even on Windows. This does somewhat complicate the code to ensure the correct translation.  This PR also factors out reexec on chrootarchive (see #13231) on Windows as it is not needed due to chroot not being supported on Windows. Instead, the applyLayer/untar calls are made inline.

![dockerbuild](https://cloud.githubusercontent.com/assets/10522484/8072073/e86dd0a0-0ec5-11e5-813c-92a308625c1b.JPG)
