### PR TITLE
Remove RC4 from the list of registry cipher suites

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -20,6 +20,7 @@ import (
 	"github.com/docker/docker/autogen/dockerversion"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/timeoutconn"
+	"github.com/docker/docker/pkg/tlsconfig"
 	"github.com/docker/docker/pkg/transport"
 	"github.com/docker/docker/pkg/useragent"
 )
@@ -141,6 +142,7 @@ func NewTransport(timeout TimeoutType, secure bool) http.RoundTripper {
 		// Avoid fallback to SSL protocols < TLS1.0
 		MinVersion:         tls.VersionTLS10,
 		InsecureSkipVerify: !secure,
+		CipherSuites:       tlsconfig.DefaultServerAcceptedCiphers,
 	}
 
 	tr := &http.Transport{


### PR DESCRIPTION
The registry client's TLS configuration used the
default cipher list, including RC4. This change
copies the default cipher list from Golang 1.4 and
removes RC4 from that list. RC4 ciphers are considered
weak and vulnerable to a number of attacks.

Signed-off-by: Eric Windisch eric@windisch.us
