### PR TITLE
graphdriver/overlay: make-private overlay's home

### DIFF
--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -16,6 +16,7 @@ import (
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/chrootarchive"
+	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/libcontainer/label"
 )
 
@@ -125,6 +126,10 @@ func Init(home string, options []string) (graphdriver.Driver, error) {
 
 	// Create the driver home dir
 	if err := os.MkdirAll(home, 0755); err != nil && !os.IsExist(err) {
+		return nil, err
+	}
+
+	if err := mount.MakePrivate(home); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Found when investigating https://github.com/docker/docker/issues/13775#issuecomment-110847225

AUFS, btrfs, and devicemapper already do this as well.

Signed-off-by: Vincent Batts vbatts@redhat.com
