### PR TITLE
Revert shared container rootfs

### DIFF
--- a/daemon/execdriver/driver_linux.go
+++ b/daemon/execdriver/driver_linux.go
@@ -24,6 +24,7 @@ func InitContainer(c *Command) *configs.Config {
 	container.Devices = c.AutoCreatedDevices
 	container.Rootfs = c.Rootfs
 	container.Readonlyfs = c.ReadonlyRootfs
+	container.Privatefs = true
 
 	// check to see if we are running in ramdisk to disable pivot root
 	container.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""


### PR DESCRIPTION
This is breaking various setups where the host's rootfs is mount shared
correctly and breaks live migration with bind mounts.

Fixes #13775

Signed-off-by: Michael Crosby crosbymichael@gmail.com
