### PR TITLE
api/client: have cli.call() return headers

### DIFF
--- a/api/client/attach.go
+++ b/api/client/attach.go
@@ -26,7 +26,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 	cmd.ParseFlags(args, true)
 	name := cmd.Arg(0)
 
-	stream, _, err := cli.call("GET", "/containers/"+name+"/json", nil, nil)
+	stream, _, _, err := cli.call("GET", "/containers/"+name+"/json", nil, nil)
 	if err != nil {
 		return err
 	}

--- a/api/client/commit.go
+++ b/api/client/commit.go
@@ -66,7 +66,7 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 			return err
 		}
 	}
-	stream, _, err := cli.call("POST", "/commit?"+v.Encode(), config, nil)
+	stream, _, _, err := cli.call("POST", "/commit?"+v.Encode(), config, nil)
 	if err != nil {
 		return err
 	}

--- a/api/client/cp.go
+++ b/api/client/cp.go
@@ -31,7 +31,7 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 	cfg := &types.CopyConfig{
 		Resource: info[1],
 	}
-	stream, statusCode, err := cli.call("POST", "/containers/"+info[0]+"/copy", cfg, nil)
+	stream, _, statusCode, err := cli.call("POST", "/containers/"+info[0]+"/copy", cfg, nil)
 	if stream != nil {
 		defer stream.Close()
 	}

--- a/api/client/create.go
+++ b/api/client/create.go
@@ -95,7 +95,7 @@ func (cli *DockerCli) createContainer(config *runconfig.Config, hostConfig *runc
 	}
 
 	//create the container
-	stream, statusCode, err := cli.call("POST", "/containers/create?"+containerValues.Encode(), mergedConfig, nil)
+	stream, _, statusCode, err := cli.call("POST", "/containers/create?"+containerValues.Encode(), mergedConfig, nil)
 	//if image not found try to pull it
 	if statusCode == 404 && strings.Contains(err.Error(), config.Image) {
 		repo, tag := parsers.ParseRepositoryTag(config.Image)
@@ -109,7 +109,7 @@ func (cli *DockerCli) createContainer(config *runconfig.Config, hostConfig *runc
 			return nil, err
 		}
 		// Retry
-		if stream, _, err = cli.call("POST", "/containers/create?"+containerValues.Encode(), mergedConfig, nil); err != nil {
+		if stream, _, _, err = cli.call("POST", "/containers/create?"+containerValues.Encode(), mergedConfig, nil); err != nil {
 			return nil, err
 		}
 	} else if err != nil {

--- a/api/client/diff.go
+++ b/api/client/diff.go
@@ -25,7 +25,7 @@ func (cli *DockerCli) CmdDiff(args ...string) error {
 		return fmt.Errorf("Container name cannot be empty")
 	}
 
-	rdr, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/changes", nil, nil)
+	rdr, _, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/changes", nil, nil)
 	if err != nil {
 		return err
 	}

--- a/api/client/exec.go
+++ b/api/client/exec.go
@@ -23,7 +23,7 @@ func (cli *DockerCli) CmdExec(args ...string) error {
 		return StatusError{StatusCode: 1}
 	}
 
-	stream, _, err := cli.call("POST", "/containers/"+execConfig.Container+"/exec", execConfig, nil)
+	stream, _, _, err := cli.call("POST", "/containers/"+execConfig.Container+"/exec", execConfig, nil)
 	if err != nil {
 		return err
 	}

--- a/api/client/history.go
+++ b/api/client/history.go
@@ -24,7 +24,7 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 	cmd.Require(flag.Exact, 1)
 	cmd.ParseFlags(args, true)
 
-	rdr, _, err := cli.call("GET", "/images/"+cmd.Arg(0)+"/history", nil, nil)
+	rdr, _, _, err := cli.call("GET", "/images/"+cmd.Arg(0)+"/history", nil, nil)
 	if err != nil {
 		return err
 	}

--- a/api/client/images.go
+++ b/api/client/images.go
@@ -61,7 +61,7 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 		v.Set("all", "1")
 	}
 
-	rdr, _, err := cli.call("GET", "/images/json?"+v.Encode(), nil, nil)
+	rdr, _, _, err := cli.call("GET", "/images/json?"+v.Encode(), nil, nil)
 	if err != nil {
 		return err
 	}

--- a/api/client/info.go
+++ b/api/client/info.go
@@ -18,7 +18,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	cmd.Require(flag.Exact, 0)
 	cmd.ParseFlags(args, true)
 
-	rdr, _, err := cli.call("GET", "/info", nil, nil)
+	rdr, _, _, err := cli.call("GET", "/info", nil, nil)
 	if err != nil {
 		return err
 	}

--- a/api/client/login.go
+++ b/api/client/login.go
@@ -113,7 +113,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	authconfig.ServerAddress = serverAddress
 	cli.configFile.AuthConfigs[serverAddress] = authconfig
 
-	stream, statusCode, err := cli.call("POST", "/auth", cli.configFile.AuthConfigs[serverAddress], nil)
+	stream, _, statusCode, err := cli.call("POST", "/auth", cli.configFile.AuthConfigs[serverAddress], nil)
 	if statusCode == 401 {
 		delete(cli.configFile.AuthConfigs, serverAddress)
 		if err2 := cli.configFile.Save(); err2 != nil {

--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -28,7 +28,7 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 
 	name := cmd.Arg(0)
 
-	stream, _, err := cli.call("GET", "/containers/"+name+"/json", nil, nil)
+	stream, _, _, err := cli.call("GET", "/containers/"+name+"/json", nil, nil)
 	if err != nil {
 		return err
 	}

--- a/api/client/port.go
+++ b/api/client/port.go
@@ -18,7 +18,7 @@ func (cli *DockerCli) CmdPort(args ...string) error {
 	cmd.Require(flag.Min, 1)
 	cmd.ParseFlags(args, true)
 
-	stream, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, nil)
+	stream, _, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, nil)
 	if err != nil {
 		return err
 	}

--- a/api/client/ps.go
+++ b/api/client/ps.go
@@ -86,7 +86,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 		v.Set("filters", filterJSON)
 	}
 
-	rdr, _, err := cli.call("GET", "/containers/json?"+v.Encode(), nil, nil)
+	rdr, _, _, err := cli.call("GET", "/containers/json?"+v.Encode(), nil, nil)
 	if err != nil {
 		return err
 	}

--- a/api/client/rmi.go
+++ b/api/client/rmi.go
@@ -31,7 +31,7 @@ func (cli *DockerCli) CmdRmi(args ...string) error {
 
 	var errNames []string
 	for _, name := range cmd.Args() {
-		rdr, _, err := cli.call("DELETE", "/images/"+name+"?"+v.Encode(), nil, nil)
+		rdr, _, _, err := cli.call("DELETE", "/images/"+name+"?"+v.Encode(), nil, nil)
 		if err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			errNames = append(errNames, name)

--- a/api/client/start.go
+++ b/api/client/start.go
@@ -61,7 +61,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 			return fmt.Errorf("You cannot start and attach multiple containers at once.")
 		}
 
-		stream, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, nil)
+		stream, _, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, nil)
 		if err != nil {
 			return err
 		}

--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -35,7 +35,7 @@ func (s *containerStats) Collect(cli *DockerCli, streamStats bool) {
 	} else {
 		v.Set("stream", "0")
 	}
-	stream, _, err := cli.call("GET", "/containers/"+s.Name+"/stats?"+v.Encode(), nil, nil)
+	stream, _, _, err := cli.call("GET", "/containers/"+s.Name+"/stats?"+v.Encode(), nil, nil)
 	if err != nil {
 		s.mu.Lock()
 		s.err = err

--- a/api/client/top.go
+++ b/api/client/top.go
@@ -25,7 +25,7 @@ func (cli *DockerCli) CmdTop(args ...string) error {
 		val.Set("ps_args", strings.Join(cmd.Args()[1:], " "))
 	}
 
-	stream, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/top?"+val.Encode(), nil, nil)
+	stream, _, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/top?"+val.Encode(), nil, nil)
 	if err != nil {
 		return err
 	}

--- a/api/client/version.go
+++ b/api/client/version.go
@@ -36,7 +36,7 @@ func (cli *DockerCli) CmdVersion(args ...string) error {
 		fmt.Fprintf(cli.out, "Experimental (client): true\n")
 	}
 
-	stream, _, err := cli.call("GET", "/version", nil, nil)
+	stream, _, _, err := cli.call("GET", "/version", nil, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Some command line options will soon need access to arbitrary response headers from the remote API. This patch adds all headers to the return values of `cli.clientRequest()` rather than the `Content-Type` header only, and bubbles the headers up to the return of `cli.call()`.
