### PR TITLE
Show actual number of elements restored

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -70,7 +70,7 @@ func (graph *Graph) restore() error {
 		}
 	}
 	graph.idIndex = truncindex.NewTruncIndex(ids)
-	logrus.Debugf("Restored %d elements", len(dir))
+	logrus.Debugf("Restored %d elements", len(ids))
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli.  Dead simple fix - the number of elements being restored written out to the log wasn't correct.
