### PR TITLE
Only request a single repository tag when pulling a specific image:tag

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -219,8 +219,18 @@ func (s *TagStore) pullRepository(r *registry.Session, out io.Writer, repoInfo *
 	}
 
 	logrus.Debugf("Retrieving the tag list")
-	tagsList, err := r.GetRemoteTags(repoData.Endpoints, repoInfo.RemoteName)
+	tagsList := make(map[string]string)
+	if askedTag == "" {
+		tagsList, err = r.GetRemoteTags(repoData.Endpoints, repoInfo.RemoteName)
+	} else {
+		var tagId string
+		tagId, err = r.GetRemoteTag(repoData.Endpoints, repoInfo.RemoteName, askedTag)
+		tagsList[askedTag] = tagId
+	}
 	if err != nil {
+		if err == registry.ErrRepoNotFound && askedTag != "" {
+			return fmt.Errorf("Tag %s not found in repository %s", askedTag, repoInfo.CanonicalName)
+		}
 		logrus.Errorf("unable to get remote tags: %s", err)
 		return err
 	}

--- a/registry/registry_mock_test.go
+++ b/registry/registry_mock_test.go
@@ -81,6 +81,7 @@ var (
 	testRepositories = map[string]map[string]string{
 		"foo42/bar": {
 			"latest": "42d718c941f5c532ac049bf0b0ab53f0062f09a03afd4aa4a02c098e46032b9d",
+			"test":   "42d718c941f5c532ac049bf0b0ab53f0062f09a03afd4aa4a02c098e46032b9d",
 		},
 	}
 	mockHosts = map[string][]net.IP{

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -211,18 +211,33 @@ func TestGetRemoteImageLayer(t *testing.T) {
 	}
 }
 
+func TestGetRemoteTag(t *testing.T) {
+	r := spawnTestRegistrySession(t)
+	tag, err := r.GetRemoteTag([]string{makeURL("/v1/")}, REPO, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEqual(t, tag, imageID, "Expected tag test to map to "+imageID)
+
+	_, err = r.GetRemoteTag([]string{makeURL("/v1/")}, "foo42/baz", "foo")
+	if err != ErrRepoNotFound {
+		t.Fatal("Expected ErrRepoNotFound error when fetching tag for bogus repo")
+	}
+}
+
 func TestGetRemoteTags(t *testing.T) {
 	r := spawnTestRegistrySession(t)
 	tags, err := r.GetRemoteTags([]string{makeURL("/v1/")}, REPO)
 	if err != nil {
 		t.Fatal(err)
 	}
-	assertEqual(t, len(tags), 1, "Expected one tag")
+	assertEqual(t, len(tags), 2, "Expected two tags")
 	assertEqual(t, tags["latest"], imageID, "Expected tag latest to map to "+imageID)
+	assertEqual(t, tags["test"], imageID, "Expected tag test to map to "+imageID)
 
 	_, err = r.GetRemoteTags([]string{makeURL("/v1/")}, "foo42/baz")
-	if err == nil {
-		t.Fatal("Expected error when fetching tags for bogus repo")
+	if err != ErrRepoNotFound {
+		t.Fatal("Expected ErrRepoNotFound error when fetching tags for bogus repo")
 	}
 }
 


### PR DESCRIPTION
Currently when performing a docker pull, we call GetRemoteTags which pulls all tags for a repository, even though we are only interested in a single tag.  This request causes the pull to time out if there are a large number of tags on a given repository.

This PR changes GetRemoteTags to only pull the tag we are interested in, greatly reducing pull times in some scenarios.
