### PR TITLE
Add the swappiness tuning option to docker.

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -150,6 +150,7 @@ type Info struct {
 	Debug              bool
 	NFd                int
 	OomKillDisable     bool
+	MemSwappiness      bool
 	NGoroutines        int
 	SystemTime         string
 	ExecutionDriver    string

--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -271,6 +271,7 @@ func populateCommand(c *Container, env []string) error {
 		BlkioWeight:    c.hostConfig.BlkioWeight,
 		Rlimits:        rlimits,
 		OomKillDisable: c.hostConfig.OomKillDisable,
+		MemSwappiness:  c.hostConfig.MemSwappiness,
 	}
 
 	processConfig := execdriver.ProcessConfig{

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1203,6 +1203,9 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig) 
 		hostConfig.OomKillDisable = false
 		return warnings, fmt.Errorf("Your kernel does not support oom kill disable.")
 	}
+	if hostConfig.MemSwappiness < 0 || hostConfig.MemSwappiness > 100 {
+		return warnings, fmt.Errorf("Range of swappiness is from 0 to 100.")
+	}
 	if daemon.SystemConfig().IPv4ForwardingDisabled {
 		warnings = append(warnings, "IPv4 forwarding is disabled. Networking will not work.")
 		logrus.Warnf("IPv4 forwarding is disabled. Networking will not work")

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -117,6 +117,7 @@ type Resources struct {
 	BlkioWeight    int64            `json:"blkio_weight"`
 	Rlimits        []*ulimit.Rlimit `json:"rlimits"`
 	OomKillDisable bool             `json:"oom_kill_disable"`
+	MemSwappiness  int64            `json:"swappiness"`
 }
 
 type ResourceStats struct {

--- a/daemon/execdriver/driver_linux.go
+++ b/daemon/execdriver/driver_linux.go
@@ -57,6 +57,7 @@ func SetupCgroups(container *configs.Config, c *Command) error {
 		container.Cgroups.CpuQuota = c.Resources.CpuQuota
 		container.Cgroups.BlkioWeight = c.Resources.BlkioWeight
 		container.Cgroups.OomKillDisable = c.Resources.OomKillDisable
+		container.Cgroups.MemSwappiness = c.Resources.MemSwappiness
 	}
 
 	return nil

--- a/daemon/execdriver/lxc/lxc_template.go
+++ b/daemon/execdriver/lxc/lxc_template.go
@@ -112,6 +112,9 @@ lxc.cgroup.blkio.weight = {{.Resources.BlkioWeight}}
 {{if .Resources.OomKillDisable}}
 lxc.cgroup.memory.oom_control = {{.Resources.OomKillDisable}}
 {{end}}
+{{if .Resources.MemSwappiness}}
+lxc.cgroup.memory.swappiness = {{.Resources.MemSwappiness}}
+{{end}}
 {{end}}
 
 {{if .LxcConfig}}

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -70,6 +70,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		Debug:              os.Getenv("DEBUG") != "",
 		NFd:                fileutils.GetTotalUsedFds(),
 		OomKillDisable:     daemon.SystemConfig().OomKillDisable,
+		MemSwappiness:      daemon.SystemConfig().MemSwappiness,
 		NGoroutines:        runtime.NumGoroutine(),
 		SystemTime:         time.Now().Format(time.RFC3339Nano),
 		ExecutionDriver:    daemon.ExecutionDriver().Name(),

--- a/docs/man/docker-create.1.md
+++ b/docs/man/docker-create.1.md
@@ -48,6 +48,7 @@ docker-create - Create a new container
 [**--read-only**[=*false*]]
 [**--restart**[=*RESTART*]]
 [**--security-opt**[=*[]*]]
+[**--mem-swappiness**[=*60*]]
 [**-t**|**--tty**[=*false*]]
 [**-u**|**--user**[=*USER*]]
 [**-v**|**--volume**[=*[]*]]
@@ -224,6 +225,9 @@ This value should always larger than **-m**, so you should always use this with 
 
 **--security-opt**=[]
    Security Options
+
+**--mem-swappiness**=*60*
+   Tuning the memory swappiness of container. The value in the range of 0-100 is accepted.
 
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.

--- a/docs/man/docker-run.1.md
+++ b/docs/man/docker-run.1.md
@@ -51,6 +51,7 @@ docker-run - Run a command in a new container
 [**--rm**[=*false*]]
 [**--security-opt**[=*[]*]]
 [**--sig-proxy**[=*true*]]
+[**--mem-swappiness**[=*60*]]
 [**-t**|**--tty**[=*false*]]
 [**-u**|**--user**[=*USER*]]
 [**-v**|**--volume**[=*[]*]]
@@ -370,6 +371,9 @@ its root filesystem mounted as read only prohibiting any writes.
 
 **--sig-proxy**=*true*|*false*
    Proxy received signals to the process (non-TTY mode only). SIGCHLD, SIGSTOP, and SIGKILL are not proxied. The default is *true*.
+
+**--mem-swappiness**=*60*
+   Tuning the memory swappiness of container. The value in the range of 0-100 is accepted.
 
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.

--- a/docs/sources/reference/api/docker_remote_api_v1.20.md
+++ b/docs/sources/reference/api/docker_remote_api_v1.20.md
@@ -153,6 +153,7 @@ Create a container
              "CpusetCpus": "0,1",
              "CpusetMems": "0,1",
              "BlkioWeight": 300,
+             "MemSwappiness": 60,
              "OomKillDisable": false,
              "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
              "PublishAllPorts": false,
@@ -201,6 +202,7 @@ Json Parameters:
 -   **CpusetCpus** - String value containing the `cgroups CpusetCpus` to use.
 -   **CpusetMems** - Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
 -   **BlkioWeight** - Block IO weight (relative weight) accepts a weight value between 10 and 1000.
+-   **MemSwappiness** - Integer Value, Tuning Container memory swappiness. Accepts value between 0 and 100. 
 -   **OomKillDisable** - Boolean value, whether to disable OOM Killer for the container or not.
 -   **AttachStdin** - Boolean value, attaches to `stdin`.
 -   **AttachStdout** - Boolean value, attaches to `stdout`.

--- a/docs/sources/reference/commandline/cli.md
+++ b/docs/sources/reference/commandline/cli.md
@@ -1020,6 +1020,7 @@ Creates a new container.
       --read-only=false          Mount the container's root filesystem as read only
       --restart="no"             Restart policy (no, on-failure[:max-retry], always)
       --security-opt=[]          Security options
+      --mem-swapiness=[]         Tuning container memory swappiness (accepted value 0-100)
       -t, --tty=false            Allocate a pseudo-TTY
       -u, --user=""              Username or UID
       -v, --volume=[]            Bind mount a volume

--- a/docs/sources/reference/run.md
+++ b/docs/sources/reference/run.md
@@ -507,6 +507,7 @@ container:
     --cpu-quota=0: Limit the CPU CFS (Completely Fair Scheduler) quota
     --blkio-weight=0: Block IO weight (relative weight) accepts a weight value between 10 and 1000.
     --oom-kill-disable=true|false: Whether to disable OOM Killer for the container or not.
+    --mem-swappiness=60: Tuning the swappiness behavior of container accepts value between 0 and 100.
 
 ### Memory constraints
 
@@ -603,6 +604,17 @@ The following example, illustrates a dangerous way to use the flag:
 
 The container has unlimited memory which can cause the host to run out memory
 and require killing system processes to free memory.
+
+### Swappiness constraint
+By default, some percenatge of anonymous pages of container can be swapped out.
+(mem-swappiness=60). But we can change the behavior by setting the value between 0
+(do not try to swap anon pages normally), 100 (more anon pages considered for
+swapping). This is helpful to retain the working set of container to avoid
+performance penalty of swapping.
+
+Example,
+
+    $ docker run -ti --mem-swappiness=0 ubuntu:14.04 /bin/bash
 
 ### CPU share constraint
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -61,6 +61,15 @@ func (s *DockerSuite) TestRunWithoutMemoryswapLimit(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestRunWithSwappiness(c *check.C) {
+	testRequires(c, NativeExecDriver)
+	runCmd := exec.Command(dockerBinary, "run", "--mem-swappiness", "0", "busybox", "true")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		c.Fatalf("failed to run container, output: %q", out)
+	}
+}
+
 // "test" should be printed
 func (s *DockerSuite) TestRunEchoStdoutWitCPULimit(c *check.C) {
 	runCmd := exec.Command(dockerBinary, "run", "-c", "1000", "busybox", "echo", "test")

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -10,4 +10,5 @@ type SysInfo struct {
 	IPv4ForwardingDisabled bool
 	AppArmor               bool
 	OomKillDisable         bool
+	MemSwappiness          bool
 }

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -33,6 +33,11 @@ func New(quiet bool) *SysInfo {
 		if !sysInfo.OomKillDisable && !quiet {
 			logrus.Warnf("Your kernel does not support oom control.")
 		}
+		_, err = ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.swappiness"))
+		sysInfo.MemSwappiness = err == nil
+		if !sysInfo.MemSwappiness && !quiet {
+			logrus.Warnf("Your kernel does not support container swappiness control.")
+		}
 	}
 
 	if cgroupCpuMountpoint, err := cgroups.FindCgroupMountpoint("cpu"); err != nil {

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -208,6 +208,7 @@ type HostConfig struct {
 	CpuQuota        int64
 	BlkioWeight     int64 // Block IO weight (relative weight vs. other containers)
 	OomKillDisable  bool  // Whether to disable OOM Killer or not
+	MemSwappiness   int64 // Tuning container memory swappiness behaviour
 	Privileged      bool
 	PortBindings    nat.PortMap
 	Links           []string

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -57,6 +57,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flStdin           = cmd.Bool([]string{"i", "-interactive"}, false, "Keep STDIN open even if not attached")
 		flTty             = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
 		flOomKillDisable  = cmd.Bool([]string{"-oom-kill-disable"}, false, "Disable OOM Killer")
+		flSwappiness      = cmd.Int64([]string{"-mem-swappiness"}, 60, "Tuning container memory swappiness")
 		flContainerIDFile = cmd.String([]string{"#cidfile", "-cidfile"}, "", "Write the container ID to the file")
 		flEntrypoint      = cmd.String([]string{"#entrypoint", "-entrypoint"}, "", "Overwrite the default ENTRYPOINT of the image")
 		flHostname        = cmd.String([]string{"h", "-hostname"}, "", "Container host name")
@@ -333,6 +334,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		CpuQuota:        *flCpuQuota,
 		BlkioWeight:     *flBlkioWeight,
 		OomKillDisable:  *flOomKillDisable,
+		MemSwappiness:   *flSwappiness,
 		Privileged:      *flPrivileged,
 		PortBindings:    portBindings,
 		Links:           flLinks.GetAll(),


### PR DESCRIPTION
Swappiness option takes 0-100, and helps to tune swappiness
behavior per container.

Signed-off-by: Raghavendra K T raghavendra.kt@linux.vnet.ibm.com
