### PR TITLE
Correct getEnv split.

### DIFF
--- a/daemon/execdriver/driver_linux.go
+++ b/daemon/execdriver/driver_linux.go
@@ -38,7 +38,7 @@ func InitContainer(c *Command) *configs.Config {
 
 func getEnv(key string, env []string) string {
 	for _, pair := range env {
-		parts := strings.Split(pair, "=")
+		parts := strings.SplitN(pair, "=", 2)
 		if parts[0] == key {
 			return parts[1]
 		}


### PR DESCRIPTION
In theory, `=` are valid characted in environment values. In practice, this function is only used to get the HOSTNAME, which cannot include any `=` values, but we might end up using this function for something else in the future. And it won't parse the environment properly.

Signed-off-by: David Calavera david.calavera@gmail.com
