### PR TITLE
Define Docker's deprecation policy

### DIFF
--- a/docs/misc/deprecated.md
+++ b/docs/misc/deprecated.md
@@ -1,0 +1,58 @@
+<!--[metadata]>
++++
+title = "Docker Deprecated Features"
+description = "Deprecated Features."
+keywords = ["docker, documentation, about, technology, deprecate"]
+[menu.main]
+parent = "mn_use_docker"
++++
+<![end-metadata]-->
+
+# Deprecated Features
+
+The following list of features are deprecated.
+
+### Old Command Line Options
+**Deprecated In Release: [v1.8.0](/release-notes/#docker-engine-1-8-0)**
+
+**Target For Removal In Release: v1.10**
+
+The following single-dash (`-opt`) variant of certain command line options 
+are deprecated and replaced with double-dash options (`--opt`):
+
+    docker attach -nostdin
+    docker attach -sig-proxy
+    docker build -no-cache
+    docker build -rm
+    docker commit -author
+    docker commit -run
+    docker events -since
+    docker history -notrunc
+    docker images -notrunc
+    docker inspect -format
+    docker ps -beforeId
+    docker ps -notrunc
+    docker ps -sinceId
+    docker rm -link
+    docker run -cidfile
+    docker run -cpuset
+    docker run -dns
+    docker run -entrypoint
+    docker run -expose
+    docker run -link
+    docker run -lxc-conf
+    docker run -n
+    docker run -privileged
+    docker run -volumes-from
+    docker search -notrunc
+    docker search -stars
+    docker search -t
+    docker search -trusted
+    docker tag -force
+
+The following single-dash options are deprecated and have no replacement:
+
+    docker run --networking
+    docker ps --since-id
+    docker ps --before-id
+    docker search --trusted

--- a/docs/misc/index.md
+++ b/docs/misc/index.md
@@ -97,6 +97,21 @@ implementation, check out the [Docker User Guide](/userguide/).
 A summary of the changes in each release in the current series can now be found
 on the separate [Release Notes page](/release-notes/)
 
+## Feature Deprecation Policy
+
+As changes are made to Docker there may be times when existing features
+will need to be removed or replace with newer features. Before an existing
+feature is removed it will be labeled as "deprecated" within the documentation
+and will remain in Docker for, usually, at least 2 releases. After that time
+it may be removed.
+
+Users are expected to take note of the list of deprecated features each
+release and plan their migration away from those features, and (if applicable)
+towards the replacement features as soon as possible.
+
+The complete list of deprecated features can be found on the
+[Deprecated Features page](deprecated).
+
 ## Licensing
 
 Docker is licensed under the Apache License, Version 2.0. See

--- a/docs/misc/release-notes.md
+++ b/docs/misc/release-notes.md
@@ -9,6 +9,17 @@ parent = "smn_release_notes"
 +++
 <![end-metadata]-->
 
+# Deprecated Features
+
+To see the complete list of deprecated features please see the
+[Deprecated Features](deprecated) page.
+
+# Removed Features
+
+The following features have been removed in this release:
+
+* None!
+
 # Release notes version 1.6.0
 (2015-04-16)
 


### PR DESCRIPTION
Right now Docker's development is a bit constrained by the requirement to be backwards compatible.
Normally minor releases (e.g. 1.2 -> 1.3) are required to be backwards compatible, and that makes
a lot of sense for stable products that have a regular major release update schedule. 

However, Docker is still (relatively) new and as such some of the original design decisions are
no longer correct, but we are forced to support them for, what feels like, forever.  In addition,
there are cases where we decline to offer a better alternative because we would then feel 
compelled to support both forever - and usually having more than one way to do something is bad.

We have claimed to deprecate certian features in the past but it seems rare that we actually
follow through and remove support for them.

This PR attempts to formalize Docker's deprecation policy by doing a few things:
1 - makes it clear to our users what to expect with respect to backwards compatibility. See doc changes.
2 - gives us the freedom to removed deprecated features w/o having to wait for a major release,
    which has yet to happen (aside from v1.0)

There are several steps to this PR:
1 - decide if we want to even allow minor release removal of features at all
2 - if so, then decide what the proper timeframe is for keeping deprecrated features.
    This PR offers up a proposal of _2_ minor releases.
3 - pick a feature to use as a guinea pig. For now this PR has picked on `docker inspect <image>`
    just to show what the documention would look like. If we make it to step 3 in this process
    I suspect we may pick another feature.  But we can decide that later.

Signed-off-by: Doug Davis dug@us.ibm.com
