### PR TITLE
TestExecStopNotHanging: log output as string

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -321,7 +321,8 @@ func (s *DockerSuite) TestExecParseError(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecStopNotHanging(c *check.C) {
-	if out, err := exec.Command(dockerBinary, "run", "-d", "--name", "testing", "busybox", "top").CombinedOutput(); err != nil {
+	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "testing", "busybox", "top")
+	if out, _, err := runCommandWithOutput(runCmd); err != nil {
 		c.Fatal(out, err)
 	}
 


### PR DESCRIPTION
When cmd failed, log its ouput as string instead of byte array to prevent test log like: [49 53 ....] exit status 1.

For example: https://jenkins.dockerproject.org/job/Docker-PRs/9713/console

```
FAIL: docker_cli_exec_test.go:323: DockerSuite.TestExecStopNotHanging

docker_cli_exec_test.go:325:
    c.Fatal(out, err)
... Error: [49 53 100 52 97 52 54 99 54 101 99 100 57 50 99 99 98 97 54 51 48 53 97 55 48 56 51 101 55 102 98 57 57 57 54 52 97 101 51 56 50 49 56 97 53 50 99 99 49 102 56 48 98 98 54 101 51 51 52 101 97 51 48 49 10 69 114 114 111 114 32 114 101 115 112 111 110 115 101 32 102 114 111 109 32 100 97 101 109 111 110 58 32 67 97 110 110 111 116 32 115 116 97 114 116 32 99 111 110 116 97 105 110 101 114 32 49 53 100 52 97 52 54 99 54 101 99 100 57 50 99 99 98 97 54 51 48 53 97 55 48 56 51 101 55 102 98 57 57 57 54 52 97 101 51 56 50 49 56 97 53 50 99 99 49 102 56 48 98 98 54 101 51 51 52 101 97 51 48 49 58 32 76 105 110 107 32 110 111 116 32 102 111 117 110 100 10] exit status 1
```
