### PR TITLE
Fix send on closed channel bug

### DIFF
--- a/pkg/pubsub/publisher.go
+++ b/pkg/pubsub/publisher.go
@@ -68,6 +68,7 @@ func (p *Publisher) Publish(v interface{}) {
 func (p *Publisher) Close() {
 	p.m.Lock()
 	for sub := range p.subscribers {
+		delete(p.subscribers, sub)
 		close(sub)
 	}
 	p.m.Unlock()


### PR DESCRIPTION
Signed-off-by: Chun Chen chenchun.feed@gmail.com

```
time="2015-06-12T04:40:05+08:00" level=debug msg="Calling POST /containers/{name:.*}/kill" 
time="2015-06-12T04:40:05+08:00" level=info msg="POST /v1.18/containers/container_1433941759366_0378_01_000008_02/kill?signal=SIGTERM" 
time="2015-06-12T04:40:05+08:00" level=info msg="+job kill(container_1433941759366_0378_01_000008_02, SIGTERM)" 
time="2015-06-12T04:40:05+08:00" level=debug msg="Sending 15 to 6d2ed94d9d60b01fa08518eae9b15f6b248cf9d0fcd0a8a8d373840b7270cdac" 
time="2015-06-12T04:40:05+08:00" level=info msg="-job kill(container_1433941759366_0378_01_000008_02, SIGTERM) = OK (0)" 
time="2015-06-12T04:40:05+08:00" level=debug msg="Calling DELETE /containers/{name:.*}" 
time="2015-06-12T04:40:05+08:00" level=info msg="DELETE /v1.18/containers/container_1433941759366_0378_01_000008_02?force=1" 
time="2015-06-12T04:40:05+08:00" level=info msg="+job rm(container_1433941759366_0378_01_000008_02)" 
time="2015-06-12T04:40:05+08:00" level=debug msg="Sending 9 to 6d2ed94d9d60b01fa08518eae9b15f6b248cf9d0fcd0a8a8d373840b7270cdac" 
time="2015-06-12T04:40:05+08:00" level=info msg="-job container_stats(container_1433941759366_0378_01_000008_02) = OK (0)" 
panic: send on closed channel

goroutine 44 [running]:
github.com/docker/docker/pkg/pubsub.(*Publisher).Publish(0xc208a69830, 0xb04500, 0xc208bf43f0)
    /go/src/github.com/docker/docker/pkg/pubsub/publisher.go:59 +0x1b4
github.com/docker/docker/daemon.(*statsCollector).run(0xc208271d40)
    /go/src/github.com/docker/docker/daemon/stats_collector.go:94 +0x465
created by github.com/docker/docker/daemon.newStatsCollector
    /go/src/github.com/docker/docker/daemon/stats_collector.go:28 +0xc3

goroutine 1 [chan receive, 3941 minutes]:
main.mainDaemon()
    /go/src/github.com/docker/docker/docker/daemon.go:186 +0xc65
main.main()
    /go/src/github.com/docker/docker/docker/docker.go:83 +0x644

goroutine 5 [syscall, 3943 minutes]:
os/signal.loop()
    /usr/local/go/src/os/signal/signal_unix.go:21 +0x1f
created by os/signal.init·1
    /usr/local/go/src/os/signal/signal_unix.go:27 +0x35

goroutine 17 [syscall, 3943 minutes, locked to thread]:
runtime.goexit()
    /usr/local/go/src/runtime/asm_amd64.s:2232 +0x1

goroutine 9 [chan receive, 3943 minutes]:
github.com/docker/docker/pkg/signal.func·002()
    /go/src/github.com/docker/docker/pkg/signal/trap.go:30 +0x8f
created by github.com/docker/docker/pkg/signal.Trap
    /go/src/github.com/docker/docker/pkg/signal/trap.go:53 +0x357

goroutine 11 [chan receive, 3943 minutes]:
github.com/docker/docker/api/server.ServeApi(0xc20808c640, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/api/server/server.go:1610 +0x56e
github.com/docker/docker/engine.(*Job).Run(0xc20808c640, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
main.func·003()
    /go/src/github.com/docker/docker/docker/daemon.go:157 +0x3b
created by main.mainDaemon
    /go/src/github.com/docker/docker/docker/daemon.go:163 +0x85f

goroutine 12 [IO wait, 4 minutes]:
net.(*pollDesc).Wait(0xc20822e220, 0x72, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc20822e220, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).accept(0xc20822e1c0, 0x0, 0x7fce14fdef70, 0xc20870c5e8)
    /usr/local/go/src/net/fd_unix.go:419 +0x40b
net.(*TCPListener).AcceptTCP(0xc20802f118, 0xc2084cf9e8, 0x0, 0x0)
    /usr/local/go/src/net/tcpsock_posix.go:234 +0x4e
net.(*TCPListener).Accept(0xc20802f118, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/tcpsock_posix.go:244 +0x4c
github.com/docker/docker/pkg/listenbuffer.(*defaultListener).Accept(0xc2081f7c00, 0x0, 0x0, 0x0, 0x0)
    /go/src/github.com/docker/docker/pkg/listenbuffer/buffer.go:41 +0x67
net/http.(*Server).Serve(0xc20800d6e0, 0x7fce14fe5a20, 0xc2081f7c00, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:1728 +0x92
github.com/docker/docker/api/server.(*HttpServer).Serve(0xc20801ee80, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:50 +0x4d
github.com/docker/docker/api/server.func·007()
    /go/src/github.com/docker/docker/api/server/server.go:1602 +0x380
created by github.com/docker/docker/api/server.ServeApi
    /go/src/github.com/docker/docker/api/server/server.go:1606 +0x4f3

goroutine 13 [IO wait]:
net.(*pollDesc).Wait(0xc2080d9870, 0x72, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc2080d9870, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).accept(0xc2080d9810, 0x0, 0x7fce14fdef70, 0xc208972130)
    /usr/local/go/src/net/fd_unix.go:419 +0x40b
net.(*UnixListener).AcceptUnix(0xc2081c1de0, 0xc208c1cf40, 0x0, 0x0)
    /usr/local/go/src/net/unixsock_posix.go:282 +0x56
net.(*UnixListener).Accept(0xc2081c1de0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/unixsock_posix.go:293 +0x4c
github.com/docker/docker/pkg/listenbuffer.(*defaultListener).Accept(0xc2081c1e00, 0x0, 0x0, 0x0, 0x0)
    /go/src/github.com/docker/docker/pkg/listenbuffer/buffer.go:41 +0x67
net/http.(*Server).Serve(0xc2081d7ce0, 0x7fce14fe5a20, 0xc2081c1e00, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:1728 +0x92
github.com/docker/docker/api/server.(*HttpServer).Serve(0xc208188420, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:50 +0x4d
github.com/docker/docker/api/server.func·007()
    /go/src/github.com/docker/docker/api/server/server.go:1602 +0x380
created by github.com/docker/docker/api/server.ServeApi
    /go/src/github.com/docker/docker/api/server/server.go:1606 +0x4f3

goroutine 40 [chan receive, 3941 minutes]:
database/sql.(*DB).connectionOpener(0xc20826d540)
    /usr/local/go/src/database/sql/sql.go:589 +0x4c
created by database/sql.Open
    /usr/local/go/src/database/sql/sql.go:452 +0x31c

goroutine 41 [IO wait]:
net.(*pollDesc).Wait(0xc2080a1560, 0x72, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc2080a1560, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).readMsg(0xc2080a1500, 0xc208973b10, 0x10, 0x10, 0xc208b90820, 0x1000, 0x1000, 0xffffffffffffffff, 0x0, 0x0, ...)
    /usr/local/go/src/net/fd_unix.go:296 +0x54e
net.(*UnixConn).ReadMsgUnix(0xc20802e8b0, 0xc208973b10, 0x10, 0x10, 0xc208b90820, 0x1000, 0x1000, 0x3b, 0xc2089738f4, 0x4, ...)
    /usr/local/go/src/net/unixsock_posix.go:147 +0x167
github.com/godbus/dbus.(*oobReader).Read(0xc208b90800, 0xc208973b10, 0x10, 0x10, 0xc208b90800, 0x0, 0x0)
    /go/src/github.com/docker/docker/vendor/src/github.com/godbus/dbus/transport_unix.go:21 +0xc5
io.ReadAtLeast(0x7fce14fe7818, 0xc208b90800, 0xc208973b10, 0x10, 0x10, 0x10, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:298 +0xf1
io.ReadFull(0x7fce14fe7818, 0xc208b90800, 0xc208973b10, 0x10, 0x10, 0x3b, 0x0, 0x0)
    /usr/local/go/src/io/io.go:316 +0x6d
github.com/godbus/dbus.(*unixTransport).ReadMessage(0xc2082a5410, 0xc2082c1140, 0x0, 0x0)
    /go/src/github.com/docker/docker/vendor/src/github.com/godbus/dbus/transport_unix.go:85 +0x1bf
github.com/godbus/dbus.(*Conn).inWorker(0xc208086b40)
    /go/src/github.com/docker/docker/vendor/src/github.com/godbus/dbus/conn.go:248 +0x58
created by github.com/godbus/dbus.(*Conn).Auth
    /go/src/github.com/docker/docker/vendor/src/github.com/godbus/dbus/auth.go:118 +0xe84

goroutine 42 [chan receive]:
github.com/godbus/dbus.(*Conn).outWorker(0xc208086b40)
    /go/src/github.com/docker/docker/vendor/src/github.com/godbus/dbus/conn.go:370 +0x58
created by github.com/godbus/dbus.(*Conn).Auth
    /go/src/github.com/docker/docker/vendor/src/github.com/godbus/dbus/auth.go:119 +0xea1

goroutine 43 [chan receive]:
github.com/coreos/go-systemd/dbus.func·001()
    /go/src/github.com/docker/docker/vendor/src/github.com/coreos/go-systemd/dbus/subscription.go:70 +0x64
created by github.com/coreos/go-systemd/dbus.(*Conn).initDispatch
    /go/src/github.com/docker/docker/vendor/src/github.com/coreos/go-systemd/dbus/subscription.go:94 +0x11c

goroutine 45 [syscall, 997 minutes]:
syscall.Syscall(0x0, 0x9, 0xc20830beb8, 0x10000, 0x0, 0xc20823a360, 0xc2083d1800)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x9, 0xc20830beb8, 0x10000, 0x10000, 0x0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x9, 0xc20830beb8, 0x10000, 0x10000, 0x1, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
github.com/go-fsnotify/fsnotify.(*Watcher).readEvents(0xc208246400)
    /go/src/github.com/docker/docker/vendor/src/github.com/go-fsnotify/fsnotify/inotify.go:144 +0x12b
created by github.com/go-fsnotify/fsnotify.NewWatcher
    /go/src/github.com/docker/docker/vendor/src/github.com/go-fsnotify/fsnotify/inotify.go:47 +0x37c

goroutine 46 [select, 997 minutes]:
github.com/docker/docker/daemon.func·012()
    /go/src/github.com/docker/docker/daemon/daemon.go:440 +0x940
created by github.com/docker/docker/daemon.(*Daemon).setupResolvconfWatcher
    /go/src/github.com/docker/docker/daemon/daemon.go:475 +0x131

goroutine 85076 [chan receive]:
github.com/docker/docker/daemon.(*Daemon).ContainerStats(0xc2080cd860, 0xc208e40a00, 0x2)
    /go/src/github.com/docker/docker/daemon/stats.go:19 +0x1bd
github.com/docker/docker/daemon.*Daemon.ContainerStats·fm(0xc208e40a00, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:122 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc208e40a00, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.getContainersStats(0xc2080cc410, 0xc208a46556, 0x4, 0x7fce14fe7b88, 0xc208e40960, 0xc20831f380, 0xc2086ae4e0, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:433 +0x21c
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc208e40960, 0xc20831f380)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc2081afec0, 0x7fce14fe7b88, 0xc208e40960, 0xc20831f380)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809b270, 0x7fce14fe7b88, 0xc208e40960, 0xc20831f380)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc20800d6e0, 0x7fce14fe7b88, 0xc208e40960, 0xc20831f380)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc2084cf9a0)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 67016 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2084350b0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc208435080, 0xc20824e400, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863e3d0, 0xc20824e400, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc208435140)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 85194 [chan receive]:
github.com/docker/docker/daemon.wait(0xc208740720, 0xffffffffc4653600, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:83 +0x71
github.com/docker/docker/daemon.(*State).WaitStop(0xc208856e70, 0xffffffffc4653600, 0x29, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:124 +0xc7
github.com/docker/docker/daemon.(*Daemon).ContainerWait(0xc2080cd860, 0xc208e40500, 0x2)
    /go/src/github.com/docker/docker/daemon/wait.go:18 +0x345
github.com/docker/docker/daemon.*Daemon.ContainerWait·fm(0xc208e40500, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:137 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc208e40500, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.postContainersWait(0xc2080cc410, 0xc2086f4507, 0x4, 0x7fce14fe7b88, 0xc208e40460, 0xc208e691e0, 0xc208b815f0, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:883 +0x2e2
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc208e40460, 0xc208e691e0)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc20802cfc0, 0x7fce14fe7b88, 0xc208e40460, 0xc208e691e0)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809bf90, 0x7fce14fe7b88, 0xc208e40460, 0xc208e691e0)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc2081d7ce0, 0x7fce14fe7b88, 0xc208e40460, 0xc208e691e0)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc208e40320)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 56 [sleep]:
net.func·019()
    /usr/local/go/src/net/dnsclient_unix.go:240 +0x5a
created by net.loadConfig
    /usr/local/go/src/net/dnsclient_unix.go:269 +0x20c

goroutine 67529 [semacquire, 724 minutes]:
sync.(*Cond).Wait(0xc208297170)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc208297140, 0xc20898c145, 0xebb, 0xebb, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208d34c00, 0xc20887a2d0)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc2086a0480, 0xd3d510, 0x6, 0x7fce14ff4cd8, 0xc208297140)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 66886 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2080cef30)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc2080cef00, 0xc208ab3400, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863fd58, 0xc208ab3400, 0x400, 0x400, 0xc20863fbd0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc2080cf5c0)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 67036 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2082964b0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc208296480, 0xc208656000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc20873ff00, 0xc208656000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc20898a440, 0xd3d510, 0x6, 0x7fce14ff4cd8, 0xc208296480)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 85064 [syscall, 5 minutes]:
syscall.Syscall6(0x3d, 0x2e9b, 0xc208dc74ac, 0x0, 0xc2083db710, 0x0, 0x0, 0xc20839c000, 0x610935, 0x610994)
    /usr/local/go/src/syscall/asm_linux_amd64.s:46 +0x5
syscall.wait4(0x2e9b, 0xc208dc74ac, 0x0, 0xc2083db710, 0x90, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:124 +0x79
syscall.Wait4(0x2e9b, 0xc208dc74f4, 0x0, 0xc2083db710, 0x7fce14fdef70, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_linux.go:224 +0x60
os.(*Process).wait(0xc20828c880, 0x7898e7, 0x0, 0x0)
    /usr/local/go/src/os/exec_unix.go:22 +0x103
os.(*Process).Wait(0xc20828c880, 0xc208275d40, 0x0, 0x0)
    /usr/local/go/src/os/doc.go:45 +0x3a
os/exec.(*Cmd).Wait(0xc208c557c0, 0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:364 +0x23c
github.com/docker/libcontainer.(*initProcess).wait(0xc208261470, 0xc2088c0600, 0x0, 0x0)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process_linux.go:191 +0x3d
github.com/docker/libcontainer.Process.Wait(0xc20828c600, 0x2, 0x2, 0xc208471400, 0xa, 0x10, 0x1374598, 0x0, 0x1374598, 0x0, ...)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process.go:57 +0x11d
github.com/docker/libcontainer.Process.Wait·fm(0xc208dc7ae8, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:160 +0x58
github.com/docker/docker/daemon/execdriver/native.(*driver).Run(0xc2082c5ae0, 0xc208c10300, 0xc2084b30b0, 0xc2082e32f0, 0x0, 0x41b200, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:166 +0xc0c
github.com/docker/docker/daemon.(*Daemon).Run(0xc2080cd860, 0xc208890780, 0xc2084b30b0, 0xc2082e32f0, 0x0, 0xc2083b7200, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/daemon.go:1111 +0x95
github.com/docker/docker/daemon.(*containerMonitor).Start(0xc2080635e0, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/monitor.go:138 +0x464
github.com/docker/docker/daemon.*containerMonitor.Start·fm(0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/container.go:1453 +0x39
github.com/docker/docker/pkg/promise.func·001()
    /go/src/github.com/docker/docker/pkg/promise/promise.go:8 +0x2f
created by github.com/docker/docker/pkg/promise.Go
    /go/src/github.com/docker/docker/pkg/promise/promise.go:9 +0xfb

goroutine 67085 [chan receive, 740 minutes]:
github.com/docker/docker/daemon.wait(0xc2088e9860, 0xffffffffc4653600, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:83 +0x71
github.com/docker/docker/daemon.(*State).WaitStop(0xc2086392d0, 0xffffffffc4653600, 0x29, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:124 +0xc7
github.com/docker/docker/daemon.(*Daemon).ContainerWait(0xc2080cd860, 0xc208836d20, 0x2)
    /go/src/github.com/docker/docker/daemon/wait.go:18 +0x345
github.com/docker/docker/daemon.*Daemon.ContainerWait·fm(0xc208836d20, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:137 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc208836d20, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.postContainersWait(0xc2080cc410, 0xc208c24827, 0x4, 0x7fce14fe7b88, 0xc208836960, 0xc20897d6c0, 0xc2088e04e0, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:883 +0x2e2
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc208836960, 0xc20897d6c0)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc20802cfc0, 0x7fce14fe7b88, 0xc208836960, 0xc20897d6c0)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809bf90, 0x7fce14fe7b88, 0xc208836960, 0xc20897d6c0)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc2081d7ce0, 0x7fce14fe7b88, 0xc208836960, 0xc20897d6c0)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc2088368c0)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 66913 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x26, 0xc208704000, 0x8000, 0x12a05f200, 0x8000, 0x2)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x26, 0xc208704000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x26, 0xc208704000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863e7e0, 0xc208704000, 0x8000, 0x8000, 0xc208704000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863e7e0, 0xc208704000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc208270960, 0x7fce14fdef20, 0xc20863e7e0, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc2088ee3a0)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 67033 [syscall, 740 minutes]:
syscall.Syscall6(0x3d, 0x2b1a, 0xc208b0b4ac, 0x0, 0xc208af2990, 0x0, 0x0, 0xc20827fc00, 0x610935, 0x610994)
    /usr/local/go/src/syscall/asm_linux_amd64.s:46 +0x5
syscall.wait4(0x2b1a, 0xc208b0b4ac, 0x0, 0xc208af2990, 0x90, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:124 +0x79
syscall.Wait4(0x2b1a, 0xc208b0b4f4, 0x0, 0xc208af2990, 0x7fce14fdef70, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_linux.go:224 +0x60
os.(*Process).wait(0xc208b5e440, 0x7898e7, 0x0, 0x0)
    /usr/local/go/src/os/exec_unix.go:22 +0x103
os.(*Process).Wait(0xc208b5e440, 0xc208c90a20, 0x0, 0x0)
    /usr/local/go/src/os/doc.go:45 +0x3a
os/exec.(*Cmd).Wait(0xc2084b4b40, 0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:364 +0x23c
github.com/docker/libcontainer.(*initProcess).wait(0xc208a8f8c0, 0xc208712600, 0x0, 0x0)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process_linux.go:191 +0x3d
github.com/docker/libcontainer.Process.Wait(0xc208b5e000, 0x2, 0x2, 0xc20883a900, 0xa, 0x10, 0x1374598, 0x0, 0xc208b719e7, 0x7, ...)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process.go:57 +0x11d
github.com/docker/libcontainer.Process.Wait·fm(0xc208b0bae8, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:160 +0x58
github.com/docker/docker/daemon/execdriver/native.(*driver).Run(0xc2082c5ae0, 0xc208af4c00, 0xc208a8e720, 0xc208360810, 0x0, 0x41b200, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:166 +0xc0c
github.com/docker/docker/daemon.(*Daemon).Run(0xc2080cd860, 0xc208890d20, 0xc208a8e720, 0xc208360810, 0x0, 0xc208d36a00, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/daemon.go:1111 +0x95
github.com/docker/docker/daemon.(*containerMonitor).Start(0xc208856380, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/monitor.go:138 +0x464
github.com/docker/docker/daemon.*containerMonitor.Start·fm(0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/container.go:1453 +0x39
github.com/docker/docker/pkg/promise.func·001()
    /go/src/github.com/docker/docker/pkg/promise/promise.go:8 +0x2f
created by github.com/docker/docker/pkg/promise.Go
    /go/src/github.com/docker/docker/pkg/promise/promise.go:9 +0xfb

goroutine 85185 [syscall]:
syscall.Syscall6(0x3d, 0x5121, 0xc208ce34ac, 0x0, 0xc208698a20, 0x0, 0x0, 0xc20871c380, 0x610935, 0x610994)
    /usr/local/go/src/syscall/asm_linux_amd64.s:46 +0x5
syscall.wait4(0x5121, 0xc208ce34ac, 0x0, 0xc208698a20, 0x90, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:124 +0x79
syscall.Wait4(0x5121, 0xc208ce34f4, 0x0, 0xc208698a20, 0x7fce14fdef70, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_linux.go:224 +0x60
os.(*Process).wait(0xc208450d80, 0x7898e7, 0x0, 0x0)
    /usr/local/go/src/os/exec_unix.go:22 +0x103
os.(*Process).Wait(0xc208450d80, 0xc208afa3f0, 0x0, 0x0)
    /usr/local/go/src/os/doc.go:45 +0x3a
os/exec.(*Cmd).Wait(0xc208255cc0, 0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:364 +0x23c
github.com/docker/libcontainer.(*initProcess).wait(0xc2089a62a0, 0xc208a62700, 0x0, 0x0)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process_linux.go:191 +0x3d
github.com/docker/libcontainer.Process.Wait(0xc208450b00, 0x2, 0x2, 0xc20883bc00, 0xa, 0x10, 0x1374598, 0x0, 0x1374598, 0x0, ...)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process.go:57 +0x11d
github.com/docker/libcontainer.Process.Wait·fm(0xc208ce3ae8, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:160 +0x58
github.com/docker/docker/daemon/execdriver/native.(*driver).Run(0xc2082c5ae0, 0xc208e26000, 0xc208ac9770, 0xc2089737a0, 0x0, 0x41b200, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:166 +0xc0c
github.com/docker/docker/daemon.(*Daemon).Run(0xc2080cd860, 0xc208a20780, 0xc208ac9770, 0xc2089737a0, 0x0, 0xc208c84800, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/daemon.go:1111 +0x95
github.com/docker/docker/daemon.(*containerMonitor).Start(0xc208ba5f10, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/monitor.go:138 +0x464
github.com/docker/docker/daemon.*containerMonitor.Start·fm(0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/container.go:1453 +0x39
github.com/docker/docker/pkg/promise.func·001()
    /go/src/github.com/docker/docker/pkg/promise/promise.go:8 +0x2f
created by github.com/docker/docker/pkg/promise.Go
    /go/src/github.com/docker/docker/pkg/promise/promise.go:9 +0xfb

goroutine 67052 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x2c, 0xc20879b750, 0x8, 0x7fce14fdac40, 0xc20802a080, 0x7fce14fdac40)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x2c, 0xc20879b750, 0x8, 0x8, 0x200, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x2c, 0xc20879b750, 0x8, 0x8, 0xc208575c00, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863f208, 0xc20879b750, 0x8, 0x8, 0xc20839dc00, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863f208, 0xc20879b750, 0x8, 0x8, 0x6de8ed, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
github.com/docker/libcontainer.func·008()
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:51 +0x18c
created by github.com/docker/libcontainer.notifyOnOOM
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:61 +0x887

goroutine 67037 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc208296630)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc208296600, 0xc208657000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208ada000, 0xc208657000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc20898a440, 0xd3d4d0, 0x6, 0x7fce14ff4cd8, 0xc208296600)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 66903 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2080cf530)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc2080cf500, 0xc208ab2c00, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863e6d0, 0xc208ab2c00, 0x400, 0x400, 0xb10560, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc2080cf680)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 67017 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc208435230)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc208435200, 0xc20824e800, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863e3e0, 0xc20824e800, 0x400, 0x400, 0xb10560, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc2084352c0)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 85191 [syscall]:
syscall.Syscall(0x0, 0x53, 0xc208784000, 0x8000, 0x0, 0x8000, 0x0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x53, 0xc208784000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x53, 0xc208784000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20838a530, 0xc208784000, 0x8000, 0x8000, 0xc208784000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20838a530, 0xc208784000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc208ab6760, 0x7fce14fdef20, 0xc20838a530, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc208450c60)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 85065 [semacquire, 5 minutes]:
sync.(*Cond).Wait(0xc208296330)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc208296300, 0xc208d44400, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863e6f0, 0xc208d44400, 0x400, 0x400, 0xc20863e620, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc2082966c0)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 67104 [chan receive]:
github.com/docker/docker/daemon.(*Daemon).ContainerStats(0xc2080cd860, 0xc208216e60, 0x2)
    /go/src/github.com/docker/docker/daemon/stats.go:19 +0x1bd
github.com/docker/docker/daemon.*Daemon.ContainerStats·fm(0xc208216e60, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:122 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc208216e60, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.getContainersStats(0xc2080cc410, 0xc2089d8af6, 0x4, 0x7fce14fe7b88, 0xc2084cff40, 0xc208be2dd0, 0xc2085d7170, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:433 +0x21c
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc2084cff40, 0xc208be2dd0)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc2081afec0, 0x7fce14fe7b88, 0xc2084cff40, 0xc208be2dd0)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809b270, 0x7fce14fe7b88, 0xc2084cff40, 0xc208be2dd0)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc20800d6e0, 0x7fce14fe7b88, 0xc2084cff40, 0xc208be2dd0)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc2084cfb80)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 85165 [syscall]:
syscall.Syscall6(0x3d, 0x5101, 0xc208b0d4ac, 0x0, 0xc208726750, 0x0, 0x0, 0xc20839d500, 0x610935, 0x610994)
    /usr/local/go/src/syscall/asm_linux_amd64.s:46 +0x5
syscall.wait4(0x5101, 0xc208b0d4ac, 0x0, 0xc208726750, 0x90, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:124 +0x79
syscall.Wait4(0x5101, 0xc208b0d4f4, 0x0, 0xc208726750, 0x7fce14fdef70, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_linux.go:224 +0x60
os.(*Process).wait(0xc20828ddc0, 0x7898e7, 0x0, 0x0)
    /usr/local/go/src/os/exec_unix.go:22 +0x103
os.(*Process).Wait(0xc20828ddc0, 0xc208b5c810, 0x0, 0x0)
    /usr/local/go/src/os/doc.go:45 +0x3a
os/exec.(*Cmd).Wait(0xc2082c9680, 0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:364 +0x23c
github.com/docker/libcontainer.(*initProcess).wait(0xc2082d2fc0, 0xc208cdd880, 0x0, 0x0)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process_linux.go:191 +0x3d
github.com/docker/libcontainer.Process.Wait(0xc20828db80, 0x2, 0x2, 0xc208470400, 0xa, 0x10, 0x1374598, 0x0, 0x1374598, 0x0, ...)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process.go:57 +0x11d
github.com/docker/libcontainer.Process.Wait·fm(0xc208b0dae8, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:160 +0x58
github.com/docker/docker/daemon/execdriver/native.(*driver).Run(0xc2082c5ae0, 0xc208af5500, 0xc2082d2060, 0xc2083bb0a0, 0x0, 0x41b200, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:166 +0xc0c
github.com/docker/docker/daemon.(*Daemon).Run(0xc2080cd860, 0xc208a205a0, 0xc2082d2060, 0xc2083bb0a0, 0x0, 0xc208674800, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/daemon.go:1111 +0x95
github.com/docker/docker/daemon.(*containerMonitor).Start(0xc2088c5f10, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/monitor.go:138 +0x464
github.com/docker/docker/daemon.*containerMonitor.Start·fm(0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/container.go:1453 +0x39
github.com/docker/docker/pkg/promise.func·001()
    /go/src/github.com/docker/docker/pkg/promise/promise.go:8 +0x2f
created by github.com/docker/docker/pkg/promise.Go
    /go/src/github.com/docker/docker/pkg/promise/promise.go:9 +0xfb

goroutine 67025 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x2d, 0xc208256000, 0x8000, 0x0, 0x8000, 0x0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x2d, 0xc208256000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x2d, 0xc208256000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863e4a0, 0xc208256000, 0x8000, 0x8000, 0xc208256000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863e4a0, 0xc208256000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc20857ea80, 0x7fce14fdef20, 0xc20863e4a0, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc208d2db80)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 66902 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2080cf3b0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc2080cf380, 0xc208ab2800, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863e6c0, 0xc208ab2800, 0x400, 0x400, 0xc20863e620, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc2080cf440)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 67532 [syscall, 724 minutes]:
syscall.Syscall(0x0, 0x29, 0xc208728000, 0x8000, 0x31, 0x8000, 0x0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x29, 0xc208728000, 0x8000, 0x8000, 0x0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x29, 0xc208728000, 0x8000, 0x8000, 0x0, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863eb28, 0xc208728000, 0x8000, 0x8000, 0xc208ba6630, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863eb28, 0xc208728000, 0x8000, 0x8000, 0x31, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc2085e3ac0, 0x7fce14fdef20, 0xc20863eb28, 0x145, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc2088aed40)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 67530 [semacquire, 724 minutes]:
sync.(*Cond).Wait(0xc2082972f0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc2082972c0, 0xc20898d000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208d34d80, 0xc20898d000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc2086a0480, 0xd3d4d0, 0x6, 0x7fce14ff4cd8, 0xc2082972c0)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 67049 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2082979b0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc208297980, 0xc208c33000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208292b80, 0xc208c33000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc208bd3500, 0xd3d4d0, 0x6, 0x7fce14ff4cd8, 0xc208297980)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 85192 [syscall]:
syscall.Syscall(0x0, 0x55, 0xc208942000, 0x8000, 0x0, 0x8000, 0xc20871c380)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x55, 0xc208942000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x55, 0xc208942000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20838a550, 0xc208942000, 0x8000, 0x8000, 0xc208942000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20838a550, 0xc208942000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc208ab6720, 0x7fce14fdef20, 0xc20838a550, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc208450cc0)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 66887 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2080cee70)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc2080cee40, 0xc208b74000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc20866ec00, 0xc208b74000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc208ac3b80, 0xd3d510, 0x6, 0x7fce14ff4cd8, 0xc2080cee40)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 67043 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x36, 0xc2089c6000, 0x8000, 0x0, 0x8000, 0x0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x36, 0xc2089c6000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x36, 0xc2089c6000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863eef8, 0xc2089c6000, 0x8000, 0x8000, 0xc2089c6000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863eef8, 0xc2089c6000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc2085ad280, 0x7fce14fdef20, 0xc20863eef8, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc208b5e1e0)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 66890 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x20, 0xc208a82000, 0x8000, 0x0, 0x8000, 0xc20827e700)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x20, 0xc208a82000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x20, 0xc208a82000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863fe28, 0xc208a82000, 0x8000, 0x8000, 0xc208a82000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863fe28, 0xc208a82000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc20847e880, 0x7fce14fdef20, 0xc20863fe28, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc20826e560)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 67048 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc208297830)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc208297800, 0xc208c32000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208292b00, 0xc208c32000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc208bd3500, 0xd3d510, 0x6, 0x7fce14ff4cd8, 0xc208297800)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 67046 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc208297770)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc208297740, 0xc208a4b800, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863f158, 0xc208a4b800, 0x400, 0x400, 0xc20863ef78, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc208297800)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 67221 [chan receive]:
github.com/docker/docker/daemon.(*Daemon).ContainerStats(0xc2080cd860, 0xc2084cf720, 0x2)
    /go/src/github.com/docker/docker/daemon/stats.go:19 +0x1bd
github.com/docker/docker/daemon.*Daemon.ContainerStats·fm(0xc2084cf720, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:122 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc2084cf720, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.getContainersStats(0xc2080cc410, 0xc208c2a516, 0x4, 0x7fce14fe7b88, 0xc2084cf680, 0xc208ccd110, 0xc208c2a5d0, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:433 +0x21c
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc2084cf680, 0xc208ccd110)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc2081afec0, 0x7fce14fe7b88, 0xc2084cf680, 0xc208ccd110)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809b270, 0x7fce14fe7b88, 0xc2084cf680, 0xc208ccd110)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc20800d6e0, 0x7fce14fe7b88, 0xc2084cf680, 0xc208ccd110)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc2081e7400)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 85196 [chan receive]:
github.com/docker/docker/daemon.wait(0xc208965da0, 0xffffffffc4653600, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:83 +0x71
github.com/docker/docker/daemon.(*State).WaitStop(0xc20899dd50, 0xffffffffc4653600, 0x29, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:124 +0xc7
github.com/docker/docker/daemon.(*Daemon).ContainerWait(0xc2080cd860, 0xc208e40be0, 0x2)
    /go/src/github.com/docker/docker/daemon/wait.go:18 +0x345
github.com/docker/docker/daemon.*Daemon.ContainerWait·fm(0xc208e40be0, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:137 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc208e40be0, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.postContainersWait(0xc2080cc410, 0xc208911ea7, 0x4, 0x7fce14fe7b88, 0xc208e40b40, 0xc208e696c0, 0xc208afa600, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:883 +0x2e2
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc208e40b40, 0xc208e696c0)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc20802cfc0, 0x7fce14fe7b88, 0xc208e40b40, 0xc208e696c0)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809bf90, 0x7fce14fe7b88, 0xc208e40b40, 0xc208e696c0)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc2081d7ce0, 0x7fce14fe7b88, 0xc208e40b40, 0xc208e696c0)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc208e40aa0)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 85066 [semacquire, 5 minutes]:
sync.(*Cond).Wait(0xc208296870)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc208296840, 0xc208d44800, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863e700, 0xc208d44800, 0x400, 0x400, 0xb10560, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc2082969c0)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 66914 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x1e, 0xc208887750, 0x8, 0xc20859e000, 0x410ea5, 0xc208572120)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x1e, 0xc208887750, 0x8, 0x8, 0xd, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x1e, 0xc208887750, 0x8, 0x8, 0x415bb6, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863eba0, 0xc208887750, 0x8, 0x8, 0xc208a18700, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863eba0, 0xc208887750, 0x8, 0x8, 0xc208b70238, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
github.com/docker/libcontainer.func·008()
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:51 +0x18c
created by github.com/docker/libcontainer.notifyOnOOM
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:61 +0x887

goroutine 66915 [chan receive, 740 minutes]:
github.com/docker/docker/daemon.wait(0xc20800c960, 0xffffffffc4653600, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:83 +0x71
github.com/docker/docker/daemon.(*State).WaitStop(0xc208916930, 0xffffffffc4653600, 0x29, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:124 +0xc7
github.com/docker/docker/daemon.(*Daemon).ContainerWait(0xc2080cd860, 0xc2088365a0, 0x2)
    /go/src/github.com/docker/docker/daemon/wait.go:18 +0x345
github.com/docker/docker/daemon.*Daemon.ContainerWait·fm(0xc2088365a0, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:137 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc2088365a0, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.postContainersWait(0xc2080cc410, 0xc2089e65f7, 0x4, 0x7fce14fe7b88, 0xc208836500, 0xc208ccc1a0, 0xc2085c3a40, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:883 +0x2e2
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc208836500, 0xc208ccc1a0)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc20802cfc0, 0x7fce14fe7b88, 0xc208836500, 0xc208ccc1a0)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809bf90, 0x7fce14fe7b88, 0xc208836500, 0xc208ccc1a0)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc2081d7ce0, 0x7fce14fe7b88, 0xc208836500, 0xc208ccc1a0)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc208836460)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 85067 [semacquire, 5 minutes]:
sync.(*Cond).Wait(0xc2082966f0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc2082966c0, 0xc208d47000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208544f80, 0xc208d47000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc2087d3f80, 0xd3d510, 0x6, 0x7fce14ff4cd8, 0xc2082966c0)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 65680 [IO wait, 25 minutes]:
net.(*pollDesc).Wait(0xc208cb7950, 0x72, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc208cb7950, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).Read(0xc208cb78f0, 0xc208b3d000, 0x1000, 0x1000, 0x0, 0x7fce14fdef70, 0xc2082a46c0)
    /usr/local/go/src/net/fd_unix.go:242 +0x40f
net.(*conn).Read(0xc20844c900, 0xc208b3d000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/net.go:121 +0xdc
net/http.(*liveSwitchReader).Read(0xc208e418a8, 0xc208b3d000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:214 +0xab
io.(*LimitedReader).Read(0xc20882a5a0, 0xc208b3d000, 0x1000, 0x1000, 0x69a840, 0x0, 0x0)
    /usr/local/go/src/io/io.go:408 +0xce
bufio.(*Reader).fill(0xc20838d980)
    /usr/local/go/src/bufio/bufio.go:97 +0x1ce
bufio.(*Reader).ReadSlice(0xc20838d980, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:295 +0x257
bufio.(*Reader).ReadLine(0xc20838d980, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:324 +0x62
net/textproto.(*Reader).readLineSlice(0xc2083316e0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/textproto/reader.go:55 +0x9e
net/textproto.(*Reader).ReadLine(0xc2083316e0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/textproto/reader.go:36 +0x4f
net/http.ReadRequest(0xc20838d980, 0xc208be3ee0, 0x0, 0x0)
    /usr/local/go/src/net/http/request.go:598 +0xcb
net/http.(*conn).readRequest(0xc208e41860, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:586 +0x26f
net/http.(*conn).serve(0xc208e41860)
    /usr/local/go/src/net/http/server.go:1162 +0x69e
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 85187 [semacquire]:
sync.(*Cond).Wait(0xc208435530)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc208435500, 0xc20812fc00, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20838a488, 0xc20812fc00, 0x400, 0x400, 0xb10560, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc208435680)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 67044 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x38, 0xc2087a0000, 0x8000, 0x0, 0x8000, 0x0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x38, 0xc2087a0000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x38, 0xc2087a0000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863ef18, 0xc2087a0000, 0x8000, 0x8000, 0xc2087a0000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863ef18, 0xc2087a0000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc2085ad260, 0x7fce14fdef20, 0xc20863ef18, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc208b5e240)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 83583 [chan receive]:
github.com/docker/docker/daemon.(*Daemon).ContainerStats(0xc2080cd860, 0xc208e40820, 0x2)
    /go/src/github.com/docker/docker/daemon/stats.go:19 +0x1bd
github.com/docker/docker/daemon.*Daemon.ContainerStats·fm(0xc208e40820, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:122 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc208e40820, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.getContainersStats(0xc2080cc410, 0xc208a460a6, 0x4, 0x7fce14fe7b88, 0xc208e40780, 0xc20897c680, 0xc208bf5e00, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:433 +0x21c
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc208e40780, 0xc20897c680)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc2081afec0, 0x7fce14fe7b88, 0xc208e40780, 0xc20897c680)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809b270, 0x7fce14fe7b88, 0xc208e40780, 0xc20897c680)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc20800d6e0, 0x7fce14fe7b88, 0xc208e40780, 0xc20897c680)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc208e41900)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 67528 [semacquire, 724 minutes]:
sync.(*Cond).Wait(0xc208297230)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc208297200, 0xc208ab2400, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863ea78, 0xc208ab2400, 0x400, 0x400, 0x4235c8, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc2082972c0)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 67015 [syscall, 740 minutes]:
syscall.Syscall6(0x3d, 0x2ace, 0xc2083274ac, 0x0, 0xc2089cf680, 0x0, 0x0, 0xc208575c00, 0x610935, 0x610994)
    /usr/local/go/src/syscall/asm_linux_amd64.s:46 +0x5
syscall.wait4(0x2ace, 0xc2083274ac, 0x0, 0xc2089cf680, 0x90, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:124 +0x79
syscall.Wait4(0x2ace, 0xc2083274f4, 0x0, 0xc2089cf680, 0x7fce14fdef70, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_linux.go:224 +0x60
os.(*Process).wait(0xc208d3ee80, 0x7898e7, 0x0, 0x0)
    /usr/local/go/src/os/exec_unix.go:22 +0x103
os.(*Process).Wait(0xc208d3ee80, 0xc208380390, 0x0, 0x0)
    /usr/local/go/src/os/doc.go:45 +0x3a
os/exec.(*Cmd).Wait(0xc208838640, 0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:364 +0x23c
github.com/docker/libcontainer.(*initProcess).wait(0xc208c90bd0, 0xc208293c80, 0x0, 0x0)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process_linux.go:191 +0x3d
github.com/docker/libcontainer.Process.Wait(0xc208d2d9e0, 0x2, 0x2, 0xc208441700, 0xa, 0x10, 0x1374598, 0x0, 0xc2088d8747, 0x7, ...)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process.go:57 +0x11d
github.com/docker/libcontainer.Process.Wait·fm(0xc208327ae8, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:160 +0x58
github.com/docker/docker/daemon/execdriver/native.(*driver).Run(0xc2082c5ae0, 0xc208af4300, 0xc208c900c0, 0xc2086ada20, 0x0, 0x41b200, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:166 +0xc0c
github.com/docker/docker/daemon.(*Daemon).Run(0xc2080cd860, 0xc208890b40, 0xc208c900c0, 0xc2086ada20, 0x0, 0xc20869da00, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/daemon.go:1111 +0x95
github.com/docker/docker/daemon.(*containerMonitor).Start(0xc208ee9ab0, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/monitor.go:138 +0x464
github.com/docker/docker/daemon.*containerMonitor.Start·fm(0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/container.go:1453 +0x39
github.com/docker/docker/pkg/promise.func·001()
    /go/src/github.com/docker/docker/pkg/promise/promise.go:8 +0x2f
created by github.com/docker/docker/pkg/promise.Go
    /go/src/github.com/docker/docker/pkg/promise/promise.go:9 +0xfb

goroutine 67035 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc208296570)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc208296540, 0xc208907c00, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863ede8, 0xc208907c00, 0x400, 0x400, 0xb10560, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc208296600)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 67019 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2084352f0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc2084352c0, 0xc2084d9000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208713180, 0xc2084d9000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc208dba480, 0xd3d4d0, 0x6, 0x7fce14ff4cd8, 0xc2084352c0)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 85193 [syscall]:
syscall.Syscall(0x0, 0x4c, 0xc208ba8750, 0x8, 0x1001, 0x1000, 0xc208d34a00)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x4c, 0xc208ba8750, 0x8, 0x8, 0xc2085d1c80, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x4c, 0xc208ba8750, 0x8, 0x8, 0x0, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20838a8c8, 0xc208ba8750, 0x8, 0x8, 0xc20859e380, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20838a8c8, 0xc208ba8750, 0x8, 0x8, 0x0, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
github.com/docker/libcontainer.func·008()
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:51 +0x18c
created by github.com/docker/libcontainer.notifyOnOOM
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:61 +0x887

goroutine 66888 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2080cf5f0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc2080cf5c0, 0xc208b75000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc20866ec80, 0xc208b75000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc208ac3b80, 0xd3d4d0, 0x6, 0x7fce14ff4cd8, 0xc2080cf5c0)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 85172 [syscall]:
syscall.Syscall(0x0, 0x51, 0xc208f2e000, 0x8000, 0x0, 0x8000, 0xc20844d270)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x51, 0xc208f2e000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x51, 0xc208f2e000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20838aff0, 0xc208f2e000, 0x8000, 0x8000, 0xc208f2e000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20838aff0, 0xc208f2e000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc2083de220, 0x7fce14fdef20, 0xc20838aff0, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc20828dd20)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 66924 [chan receive, 740 minutes]:
github.com/docker/docker/daemon.wait(0xc20800db00, 0xffffffffc4653600, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:83 +0x71
github.com/docker/docker/daemon.(*State).WaitStop(0xc2086c2770, 0xffffffffc4653600, 0x29, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:124 +0xc7
github.com/docker/docker/daemon.(*Daemon).ContainerWait(0xc2080cd860, 0xc208836be0, 0x2)
    /go/src/github.com/docker/docker/daemon/wait.go:18 +0x345
github.com/docker/docker/daemon.*Daemon.ContainerWait·fm(0xc208836be0, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:137 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc208836be0, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.postContainersWait(0xc2080cc410, 0xc208cae4b7, 0x4, 0x7fce14fe7b88, 0xc208836b40, 0xc208ccc9c0, 0xc208ae0150, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:883 +0x2e2
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc208836b40, 0xc208ccc9c0)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc20802cfc0, 0x7fce14fe7b88, 0xc208836b40, 0xc208ccc9c0)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809bf90, 0x7fce14fe7b88, 0xc208836b40, 0xc208ccc9c0)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc2081d7ce0, 0x7fce14fe7b88, 0xc208836b40, 0xc208ccc9c0)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc208836a00)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 67098 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x44, 0xc208ba8f50, 0x8, 0x0, 0x0, 0x0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x44, 0xc208ba8f50, 0x8, 0x8, 0x0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x44, 0xc208ba8f50, 0x8, 0x8, 0x1, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863feb8, 0xc208ba8f50, 0x8, 0x8, 0xc208575500, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863feb8, 0xc208ba8f50, 0x8, 0x8, 0x100000001, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
github.com/docker/libcontainer.func·008()
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:51 +0x18c
created by github.com/docker/libcontainer.notifyOnOOM
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:61 +0x887

goroutine 67047 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2082978f0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc2082978c0, 0xc208a4bc00, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863f168, 0xc208a4bc00, 0x400, 0x400, 0xb10560, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc208297980)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 85186 [semacquire]:
sync.(*Cond).Wait(0xc208434ff0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc208434fc0, 0xc20812f800, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20838a478, 0xc20812f800, 0x400, 0x400, 0xc20838a3d8, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc208435380)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 67056 [chan receive, 740 minutes]:
github.com/docker/docker/daemon.wait(0xc208114c60, 0xffffffffc4653600, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:83 +0x71
github.com/docker/docker/daemon.(*State).WaitStop(0xc208c5ddc0, 0xffffffffc4653600, 0x29, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:124 +0xc7
github.com/docker/docker/daemon.(*Daemon).ContainerWait(0xc2080cd860, 0xc208e41180, 0x2)
    /go/src/github.com/docker/docker/daemon/wait.go:18 +0x345
github.com/docker/docker/daemon.*Daemon.ContainerWait·fm(0xc208e41180, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:137 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc208e41180, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.postContainersWait(0xc2080cc410, 0xc208a6f277, 0x4, 0x7fce14fe7b88, 0xc208e40f00, 0xc20897c410, 0xc208350060, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:883 +0x2e2
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc208e40f00, 0xc20897c410)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc20802cfc0, 0x7fce14fe7b88, 0xc208e40f00, 0xc20897c410)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809bf90, 0x7fce14fe7b88, 0xc208e40f00, 0xc20897c410)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc2081d7ce0, 0x7fce14fe7b88, 0xc208e40f00, 0xc20897c410)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc208e40e60)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 70969 [IO wait]:
net.(*pollDesc).Wait(0xc208ad4300, 0x72, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc208ad4300, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).Read(0xc208ad42a0, 0xc208848000, 0x1000, 0x1000, 0x0, 0x7fce14fdef70, 0xc2087accc8)
    /usr/local/go/src/net/fd_unix.go:242 +0x40f
net.(*conn).Read(0xc20838a3a0, 0xc208848000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/net.go:121 +0xdc
net/http.(*liveSwitchReader).Read(0xc2088367c8, 0xc208848000, 0x1000, 0x1000, 0xc208c30150, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:214 +0xab
io.(*LimitedReader).Read(0xc208d3fb20, 0xc208848000, 0x1000, 0x1000, 0xc208a77960, 0x0, 0x0)
    /usr/local/go/src/io/io.go:408 +0xce
bufio.(*Reader).fill(0xc208741440)
    /usr/local/go/src/bufio/bufio.go:97 +0x1ce
bufio.(*Reader).ReadSlice(0xc208741440, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:295 +0x257
bufio.(*Reader).ReadLine(0xc208741440, 0x0, 0x0, 0x0, 0xc2080cc400, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:324 +0x62
net/textproto.(*Reader).readLineSlice(0xc2082a6390, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/textproto/reader.go:55 +0x9e
net/textproto.(*Reader).ReadLine(0xc2082a6390, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/textproto/reader.go:36 +0x4f
net/http.ReadRequest(0xc208741440, 0xc208ccdad0, 0x0, 0x0)
    /usr/local/go/src/net/http/request.go:598 +0xcb
net/http.(*conn).readRequest(0xc208836780, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:586 +0x26f
net/http.(*conn).serve(0xc208836780)
    /usr/local/go/src/net/http/server.go:1162 +0x69e
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 84955 [IO wait]:
net.(*pollDesc).Wait(0xc20834ff00, 0x72, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc20834ff00, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).Read(0xc20834fea0, 0xc2086bc000, 0x1000, 0x1000, 0x0, 0x7fce14fdef70, 0xc208972c08)
    /usr/local/go/src/net/fd_unix.go:242 +0x40f
net.(*conn).Read(0xc20863f7e0, 0xc2086bc000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/net.go:121 +0xdc
net/http.(*liveSwitchReader).Read(0xc208e41ee8, 0xc2086bc000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:214 +0xab
io.(*LimitedReader).Read(0xc20882a3e0, 0xc2086bc000, 0x1000, 0x1000, 0xc2088cda50, 0x0, 0x0)
    /usr/local/go/src/io/io.go:408 +0xce
bufio.(*Reader).fill(0xc208740e40)
    /usr/local/go/src/bufio/bufio.go:97 +0x1ce
bufio.(*Reader).ReadSlice(0xc208740e40, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:295 +0x257
bufio.(*Reader).ReadLine(0xc208740e40, 0x0, 0x0, 0x0, 0xc2080cc400, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:324 +0x62
net/textproto.(*Reader).readLineSlice(0xc2089a7350, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/textproto/reader.go:55 +0x9e
net/textproto.(*Reader).ReadLine(0xc2089a7350, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/textproto/reader.go:36 +0x4f
net/http.ReadRequest(0xc208740e40, 0xc208ccd5f0, 0x0, 0x0)
    /usr/local/go/src/net/http/request.go:598 +0xcb
net/http.(*conn).readRequest(0xc208e41ea0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:586 +0x26f
net/http.(*conn).serve(0xc208e41ea0)
    /usr/local/go/src/net/http/server.go:1162 +0x69e
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 85166 [semacquire]:
sync.(*Cond).Wait(0xc2084346f0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc2084346c0, 0xc208234c00, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20838af40, 0xc208234c00, 0x400, 0x400, 0xc20838ad48, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc208434780)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 85075 [chan receive, 5 minutes]:
github.com/docker/docker/daemon.wait(0xc20885a600, 0xffffffffc4653600, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:83 +0x71
github.com/docker/docker/daemon.(*State).WaitStop(0xc208c62620, 0xffffffffc4653600, 0x29, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:124 +0xc7
github.com/docker/docker/daemon.(*Daemon).ContainerWait(0xc2080cd860, 0xc20826d860, 0x2)
    /go/src/github.com/docker/docker/daemon/wait.go:18 +0x345
github.com/docker/docker/daemon.*Daemon.ContainerWait·fm(0xc20826d860, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:137 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc20826d860, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.postContainersWait(0xc2080cc410, 0xc20837cc87, 0x4, 0x7fce14fe7b88, 0xc20826d7c0, 0xc208be25b0, 0xc208275e00, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:883 +0x2e2
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc20826d7c0, 0xc208be25b0)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc20802cfc0, 0x7fce14fe7b88, 0xc20826d7c0, 0xc208be25b0)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809bf90, 0x7fce14fe7b88, 0xc20826d7c0, 0xc208be25b0)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc2081d7ce0, 0x7fce14fe7b88, 0xc20826d7c0, 0xc208be25b0)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc20826d680)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 85189 [semacquire]:
sync.(*Cond).Wait(0xc2084356b0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc208435680, 0xc20841f000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208b9b680, 0xc20841f000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc208db7b40, 0xd3d4d0, 0x6, 0x7fce14ff4cd8, 0xc208435680)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 65815 [IO wait, 580 minutes]:
net.(*pollDesc).Wait(0xc208a24ca0, 0x72, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc208a24ca0, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).Read(0xc208a24c40, 0xc208b61000, 0x1000, 0x1000, 0x0, 0x7fce14fdef70, 0xc20892fa10)
    /usr/local/go/src/net/fd_unix.go:242 +0x40f
net.(*conn).Read(0xc20844ce80, 0xc208b61000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/net.go:121 +0xdc
net/http.(*liveSwitchReader).Read(0xc208e41088, 0xc208b61000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:214 +0xab
io.(*LimitedReader).Read(0xc208af6a40, 0xc208b61000, 0x1000, 0x1000, 0x69a840, 0x0, 0x0)
    /usr/local/go/src/io/io.go:408 +0xce
bufio.(*Reader).fill(0xc2084b76e0)
    /usr/local/go/src/bufio/bufio.go:97 +0x1ce
bufio.(*Reader).ReadSlice(0xc2084b76e0, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:295 +0x257
bufio.(*Reader).ReadLine(0xc2084b76e0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:324 +0x62
net/textproto.(*Reader).readLineSlice(0xc208676450, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/textproto/reader.go:55 +0x9e
net/textproto.(*Reader).ReadLine(0xc208676450, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/textproto/reader.go:36 +0x4f
net/http.ReadRequest(0xc2084b76e0, 0xc208df8f70, 0x0, 0x0)
    /usr/local/go/src/net/http/request.go:598 +0xcb
net/http.(*conn).readRequest(0xc208e41040, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:586 +0x26f
net/http.(*conn).serve(0xc208e41040)
    /usr/local/go/src/net/http/server.go:1162 +0x69e
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 85169 [semacquire]:
sync.(*Cond).Wait(0xc208434930)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc208434900, 0xc208c29000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc20839a300, 0xc208c29000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc208ac3380, 0xd3d4d0, 0x6, 0x7fce14ff4cd8, 0xc208434900)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 85068 [semacquire, 5 minutes]:
sync.(*Cond).Wait(0xc2082969f0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc2082969c0, 0xc208d48000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208545000, 0xc208d48000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc2087d3f80, 0xd3d4d0, 0x6, 0x7fce14ff4cd8, 0xc2082969c0)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 66885 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2080ce6f0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc2080ce6c0, 0xc208ab3000, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863fd48, 0xc208ab3000, 0x400, 0x400, 0xb10560, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc2080cee40)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 66891 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x22, 0xc208c6c000, 0x8000, 0x4261a8, 0x8000, 0x6015d0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x22, 0xc208c6c000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x22, 0xc208c6c000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863fe48, 0xc208c6c000, 0x8000, 0x8000, 0xc208c6c000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863fe48, 0xc208c6c000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc20847e860, 0x7fce14fdef20, 0xc20863fe48, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc20826e5a0)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 66904 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2080cf6b0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc2080cf680, 0xc208818000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208b7d780, 0xc208818000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc208a9bec0, 0xd3d4d0, 0x6, 0x7fce14ff4cd8, 0xc2080cf680)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 67018 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc208435170)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc208435140, 0xc20861a000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208713080, 0xc20861a000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc208dba480, 0xd3d510, 0x6, 0x7fce14ff4cd8, 0xc208435140)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 85171 [syscall]:
syscall.Syscall(0x0, 0x4d, 0xc208f3c000, 0x8000, 0x0, 0x8000, 0x0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x4d, 0xc208f3c000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x4d, 0xc208f3c000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20838afd0, 0xc208f3c000, 0x8000, 0x8000, 0xc208f3c000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20838afd0, 0xc208f3c000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc2083de260, 0x7fce14fdef20, 0xc20838afd0, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc20828dce0)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 67107 [chan receive]:
github.com/docker/docker/daemon.(*Daemon).ContainerStats(0xc2080cd860, 0xc208217ae0, 0x2)
    /go/src/github.com/docker/docker/daemon/stats.go:19 +0x1bd
github.com/docker/docker/daemon.*Daemon.ContainerStats·fm(0xc208217ae0, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:122 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc208217ae0, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.getContainersStats(0xc2080cc410, 0xc2089d9096, 0x4, 0x7fce14fe7b88, 0xc208217860, 0xc208be35f0, 0xc2085d7e60, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:433 +0x21c
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc208217860, 0xc208be35f0)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc2081afec0, 0x7fce14fe7b88, 0xc208217860, 0xc208be35f0)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809b270, 0x7fce14fe7b88, 0xc208217860, 0xc208be35f0)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc20800d6e0, 0x7fce14fe7b88, 0xc208217860, 0xc208be35f0)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc2084cfd60)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 67534 [syscall, 724 minutes]:
syscall.Syscall(0x0, 0x1d, 0xc208018750, 0x8, 0x0, 0x0, 0x46bbb1)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x1d, 0xc208018750, 0x8, 0x8, 0x0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x1d, 0xc208018750, 0x8, 0x8, 0xc200000001, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863f0b0, 0xc208018750, 0x8, 0x8, 0xc20871ce00, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863f0b0, 0xc208018750, 0x8, 0x8, 0x6de8ed, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
github.com/docker/libcontainer.func·008()
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:51 +0x18c
created by github.com/docker/libcontainer.notifyOnOOM
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:61 +0x887

goroutine 66912 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x24, 0xc208666000, 0x8000, 0x12a05f200, 0x8000, 0x2)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x24, 0xc208666000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x24, 0xc208666000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863e7c0, 0xc208666000, 0x8000, 0x8000, 0xc208666000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863e7c0, 0xc208666000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc208270980, 0x7fce14fdef20, 0xc20863e7c0, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc2088ee360)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 65816 [IO wait]:
net.(*pollDesc).Wait(0xc208a25640, 0x72, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc208a25640, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).Read(0xc208a255e0, 0xc208831000, 0x1000, 0x1000, 0x0, 0x7fce14fdef70, 0xc208361c10)
    /usr/local/go/src/net/fd_unix.go:242 +0x40f
net.(*conn).Read(0xc20844ce90, 0xc208831000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/net.go:121 +0xdc
net/http.(*liveSwitchReader).Read(0xc208e41268, 0xc208831000, 0x1000, 0x1000, 0xc208c30e00, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:214 +0xab
io.(*LimitedReader).Read(0xc208af7020, 0xc208831000, 0x1000, 0x1000, 0xc208aaf960, 0x0, 0x0)
    /usr/local/go/src/io/io.go:408 +0xce
bufio.(*Reader).fill(0xc2088e8300)
    /usr/local/go/src/bufio/bufio.go:97 +0x1ce
bufio.(*Reader).ReadSlice(0xc2088e8300, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:295 +0x257
bufio.(*Reader).ReadLine(0xc2088e8300, 0x0, 0x0, 0x0, 0xc2080cc400, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:324 +0x62
net/textproto.(*Reader).readLineSlice(0xc208afa4b0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/textproto/reader.go:55 +0x9e
net/textproto.(*Reader).ReadLine(0xc208afa4b0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/textproto/reader.go:36 +0x4f
net/http.ReadRequest(0xc2088e8300, 0xc20897c4e0, 0x0, 0x0)
    /usr/local/go/src/net/http/request.go:598 +0xcb
net/http.(*conn).readRequest(0xc208e41220, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:586 +0x26f
net/http.(*conn).serve(0xc208e41220)
    /usr/local/go/src/net/http/server.go:1162 +0x69e
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 67526 [syscall, 724 minutes]:
syscall.Syscall6(0x3d, 0x2242, 0xc2085554ac, 0x0, 0xc2083d43f0, 0x0, 0x0, 0xc208574000, 0x610935, 0x610994)
    /usr/local/go/src/syscall/asm_linux_amd64.s:46 +0x5
syscall.wait4(0x2242, 0xc2085554ac, 0x0, 0xc2083d43f0, 0x90, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:124 +0x79
syscall.Wait4(0x2242, 0xc2085554f4, 0x0, 0xc2083d43f0, 0x7fce14fdef70, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_linux.go:224 +0x60
os.(*Process).wait(0xc2088aee20, 0x7898e7, 0x0, 0x0)
    /usr/local/go/src/os/exec_unix.go:22 +0x103
os.(*Process).Wait(0xc2088aee20, 0xc208b6edb0, 0x0, 0x0)
    /usr/local/go/src/os/doc.go:45 +0x3a
os/exec.(*Cmd).Wait(0xc208c55040, 0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:364 +0x23c
github.com/docker/libcontainer.(*initProcess).wait(0xc2086d62d0, 0xc208adae80, 0x0, 0x0)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process_linux.go:191 +0x3d
github.com/docker/libcontainer.Process.Wait(0xc2088aebc0, 0x2, 0x2, 0xc2086a0340, 0x4, 0x4, 0x1374598, 0x0, 0x1374598, 0x0, ...)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process.go:57 +0x11d
github.com/docker/libcontainer.Process.Wait·fm(0xc208555ae8, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:160 +0x58
github.com/docker/docker/daemon/execdriver/native.(*driver).Run(0xc2082c5ae0, 0xc208c11500, 0xc2085a7830, 0xc208c3b720, 0x0, 0x41b200, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:166 +0xc0c
github.com/docker/docker/daemon.(*Daemon).Run(0xc2080cd860, 0xc208a203c0, 0xc2085a7830, 0xc208c3b720, 0x0, 0xc2087f4800, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/daemon.go:1111 +0x95
github.com/docker/docker/daemon.(*containerMonitor).Start(0xc20894c460, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/monitor.go:138 +0x464
github.com/docker/docker/daemon.*containerMonitor.Start·fm(0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/container.go:1453 +0x39
github.com/docker/docker/pkg/promise.func·001()
    /go/src/github.com/docker/docker/pkg/promise/promise.go:8 +0x2f
created by github.com/docker/docker/pkg/promise.Go
    /go/src/github.com/docker/docker/pkg/promise/promise.go:9 +0xfb

goroutine 66905 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2080cf470)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc2080cf440, 0xc208819000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208b7d800, 0xc208819000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc208a9bec0, 0xd3d510, 0x6, 0x7fce14ff4cd8, 0xc2080cf440)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 67099 [chan receive, 740 minutes]:
github.com/docker/docker/daemon.wait(0xc20824b140, 0xffffffffc4653600, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:83 +0x71
github.com/docker/docker/daemon.(*State).WaitStop(0xc20834f110, 0xffffffffc4653600, 0x29, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:124 +0xc7
github.com/docker/docker/daemon.(*Daemon).ContainerWait(0xc2080cd860, 0xc2084ce0a0, 0x2)
    /go/src/github.com/docker/docker/daemon/wait.go:18 +0x345
github.com/docker/docker/daemon.*Daemon.ContainerWait·fm(0xc2084ce0a0, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:137 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc2084ce0a0, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.postContainersWait(0xc2080cc410, 0xc208b6c287, 0x4, 0x7fce14fe7b88, 0xc2084ce000, 0xc208517a00, 0xc208b6efc0, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:883 +0x2e2
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc2084ce000, 0xc208517a00)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc20802cfc0, 0x7fce14fe7b88, 0xc2084ce000, 0xc208517a00)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809bf90, 0x7fce14fe7b88, 0xc2084ce000, 0xc208517a00)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc2081d7ce0, 0x7fce14fe7b88, 0xc2084ce000, 0xc208517a00)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc20826df40)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 67055 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x43, 0xc208820000, 0x8000, 0x0, 0x8000, 0x0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x43, 0xc208820000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x43, 0xc208820000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863f2e0, 0xc208820000, 0x8000, 0x8000, 0xc208820000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863f2e0, 0xc208820000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc2084f6860, 0x7fce14fdef20, 0xc20863f2e0, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc208c8c4a0)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 66901 [syscall, 740 minutes]:
syscall.Syscall6(0x3d, 0x29a9, 0xc2083294ac, 0x0, 0xc208939170, 0x0, 0x0, 0xc208574a80, 0x610935, 0x610994)
    /usr/local/go/src/syscall/asm_linux_amd64.s:46 +0x5
syscall.wait4(0x29a9, 0xc2083294ac, 0x0, 0xc208939170, 0x90, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:124 +0x79
syscall.Wait4(0x29a9, 0xc2083294f4, 0x0, 0xc208939170, 0x7fce14fdef70, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_linux.go:224 +0x60
os.(*Process).wait(0xc2088eec40, 0x7898e7, 0x0, 0x0)
    /usr/local/go/src/os/exec_unix.go:22 +0x103
os.(*Process).Wait(0xc2088eec40, 0xc2089c4840, 0x0, 0x0)
    /usr/local/go/src/os/doc.go:45 +0x3a
os/exec.(*Cmd).Wait(0xc208839680, 0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:364 +0x23c
github.com/docker/libcontainer.(*initProcess).wait(0xc208ae7dd0, 0xc20899ea00, 0x0, 0x0)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process_linux.go:191 +0x3d
github.com/docker/libcontainer.Process.Wait(0xc2088ee180, 0x2, 0x2, 0xc208440d00, 0xa, 0x10, 0x1374598, 0x0, 0xc2082d6867, 0x7, ...)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process.go:57 +0x11d
github.com/docker/libcontainer.Process.Wait·fm(0xc208329ae8, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:160 +0x58
github.com/docker/docker/daemon/execdriver/native.(*driver).Run(0xc2082c5ae0, 0xc208af4000, 0xc208ae6b70, 0xc2088d9b10, 0x0, 0x41b200, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:166 +0xc0c
github.com/docker/docker/daemon.(*Daemon).Run(0xc2080cd860, 0xc208a210e0, 0xc208ae6b70, 0xc2088d9b10, 0x0, 0xc208af8000, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/daemon.go:1111 +0x95
github.com/docker/docker/daemon.(*containerMonitor).Start(0xc20834e380, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/monitor.go:138 +0x464
github.com/docker/docker/daemon.*containerMonitor.Start·fm(0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/container.go:1453 +0x39
github.com/docker/docker/pkg/promise.func·001()
    /go/src/github.com/docker/docker/pkg/promise/promise.go:8 +0x2f
created by github.com/docker/docker/pkg/promise.Go
    /go/src/github.com/docker/docker/pkg/promise/promise.go:9 +0xfb

goroutine 85188 [semacquire]:
sync.(*Cond).Wait(0xc2084353b0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc208435380, 0xc2083ed000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc208b9b600, 0xc2083ed000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc208db7b40, 0xd3d510, 0x6, 0x7fce14ff4cd8, 0xc208435380)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 85168 [semacquire]:
sync.(*Cond).Wait(0xc2084347b0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
github.com/docker/docker/pkg/ioutils.(*bufReader).Read(0xc208434780, 0xc208c28000, 0x1000, 0x1000, 0x0, 0x7fce14fdac40, 0xc20802a080)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:207 +0x158
bufio.(*Scanner).Scan(0xc20839a100, 0xc208c28000)
    /usr/local/go/src/bufio/scan.go:180 +0x688
github.com/docker/docker/daemon/logger.(*Copier).copySrc(0xc208ac3380, 0xd3d510, 0x6, 0x7fce14ff4cd8, 0xc208434780)
    /go/src/github.com/docker/docker/daemon/logger/copier.go:44 +0x1a3
created by github.com/docker/docker/daemon/logger.(*Copier).Run
    /go/src/github.com/docker/docker/daemon/logger/copier.go:37 +0x11c

goroutine 66918 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x21, 0xc20801c750, 0x8, 0x3, 0x3, 0xc20833b060)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x21, 0xc20801c750, 0x8, 0x8, 0xd, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x21, 0xc20801c750, 0x8, 0x8, 0x133e820, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863ec68, 0xc20801c750, 0x8, 0x8, 0xc208922000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863ec68, 0xc20801c750, 0x8, 0x8, 0x5578f2, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
github.com/docker/libcontainer.func·008()
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:51 +0x18c
created by github.com/docker/libcontainer.notifyOnOOM
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:61 +0x887

goroutine 67024 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x2a, 0xc2086ce000, 0x8000, 0x0, 0x8000, 0x0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x2a, 0xc2086ce000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x2a, 0xc2086ce000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863e480, 0xc2086ce000, 0x8000, 0x8000, 0xc2086ce000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863e480, 0xc2086ce000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc20857eaa0, 0x7fce14fdef20, 0xc20863e480, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc208d2db40)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 67045 [syscall, 740 minutes]:
syscall.Syscall6(0x3d, 0x2b58, 0xc208a094ac, 0x0, 0xc20827d290, 0x0, 0x0, 0xc20871c000, 0x610935, 0x610994)
    /usr/local/go/src/syscall/asm_linux_amd64.s:46 +0x5
syscall.wait4(0x2b58, 0xc208a094ac, 0x0, 0xc20827d290, 0x90, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:124 +0x79
syscall.Wait4(0x2b58, 0xc208a094f4, 0x0, 0xc20827d290, 0x7fce14fdef70, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_linux.go:224 +0x60
os.(*Process).wait(0xc208af6360, 0x7898e7, 0x0, 0x0)
    /usr/local/go/src/os/exec_unix.go:22 +0x103
os.(*Process).Wait(0xc208af6360, 0xc2083f06f0, 0x0, 0x0)
    /usr/local/go/src/os/doc.go:45 +0x3a
os/exec.(*Cmd).Wait(0xc2084b5540, 0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:364 +0x23c
github.com/docker/libcontainer.(*initProcess).wait(0xc208381080, 0xc208541500, 0x0, 0x0)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process_linux.go:191 +0x3d
github.com/docker/libcontainer.Process.Wait(0xc208c8c220, 0x2, 0x2, 0xc20856c200, 0xa, 0x10, 0x1374598, 0x0, 0xc208c3b717, 0x7, ...)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process.go:57 +0x11d
github.com/docker/libcontainer.Process.Wait·fm(0xc208a09ae8, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:160 +0x58
github.com/docker/docker/daemon/execdriver/native.(*driver).Run(0xc2082c5ae0, 0xc208af4f00, 0xc20849c900, 0xc208780640, 0x0, 0x41b200, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:166 +0xc0c
github.com/docker/docker/daemon.(*Daemon).Run(0xc2080cd860, 0xc208890960, 0xc20849c900, 0xc208780640, 0x0, 0xc208d36c00, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/daemon.go:1111 +0x95
github.com/docker/docker/daemon.(*containerMonitor).Start(0xc208b78070, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/monitor.go:138 +0x464
github.com/docker/docker/daemon.*containerMonitor.Start·fm(0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/container.go:1453 +0x39
github.com/docker/docker/pkg/promise.func·001()
    /go/src/github.com/docker/docker/pkg/promise/promise.go:8 +0x2f
created by github.com/docker/docker/pkg/promise.Go
    /go/src/github.com/docker/docker/pkg/promise/promise.go:9 +0xfb

goroutine 85210 [select]:
github.com/docker/docker/daemon.wait(0xc20885a600, 0x2540be400, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:86 +0x25d
github.com/docker/docker/daemon.(*State).WaitStop(0xc208c62620, 0x2540be400, 0x0, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/state.go:124 +0xc7
github.com/docker/docker/daemon.(*Container).Kill(0xc208890780, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/container.go:768 +0xea
github.com/docker/docker/daemon.(*Daemon).ContainerRm(0xc2080cd860, 0xc208f5af00, 0x2)
    /go/src/github.com/docker/docker/daemon/delete.go:57 +0x707
github.com/docker/docker/daemon.*Daemon.ContainerRm·fm(0xc208f5af00, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:125 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc208f5af00, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.deleteContainers(0xc2080cc410, 0xc2084cd1a9, 0x4, 0x7fce14fe7b88, 0xc208f5ae60, 0xc208ccd040, 0xc2089a73e0, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:795 +0x39e
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc208f5ae60, 0xc208ccd040)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc2082474c0, 0x7fce14fe7b88, 0xc208f5ae60, 0xc208ccd040)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809bf90, 0x7fce14fe7b88, 0xc208f5ae60, 0xc208ccd040)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc2081d7ce0, 0x7fce14fe7b88, 0xc208f5ae60, 0xc208ccd040)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc208f5adc0)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 67074 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x1f, 0xc208797750, 0x8, 0x0, 0x0, 0x0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x1f, 0xc208797750, 0x8, 0x8, 0x0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x1f, 0xc208797750, 0x8, 0x8, 0x0, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863ebd0, 0xc208797750, 0x8, 0x8, 0xc208923500, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863ebd0, 0xc208797750, 0x8, 0x8, 0x0, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
github.com/docker/libcontainer.func·008()
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:51 +0x18c
created by github.com/docker/libcontainer.notifyOnOOM
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:61 +0x887

goroutine 67034 [semacquire, 740 minutes]:
sync.(*Cond).Wait(0xc2082963f0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc2082963c0, 0xc208907800, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863edd0, 0xc208907800, 0x400, 0x400, 0xc20863ecc0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc208296480)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 85195 [syscall]:
syscall.Syscall(0x0, 0x4f, 0xc208ba9750, 0x8, 0x0, 0x0, 0xc2081a41e0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x4f, 0xc208ba9750, 0x8, 0x8, 0xb13f80, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x4f, 0xc208ba9750, 0x8, 0x8, 0xc22aae714c, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20838a988, 0xc208ba9750, 0x8, 0x8, 0xc20839d180, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20838a988, 0xc208ba9750, 0x8, 0x8, 0xc2087dd900, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
github.com/docker/libcontainer.func·008()
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:51 +0x18c
created by github.com/docker/libcontainer.notifyOnOOM
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:61 +0x887

goroutine 66884 [syscall, 740 minutes]:
syscall.Syscall6(0x3d, 0x2988, 0xc208a794ac, 0x0, 0xc208938c60, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:46 +0x5
syscall.wait4(0x2988, 0xc208a794ac, 0x0, 0xc208938c60, 0x90, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:124 +0x79
syscall.Wait4(0x2988, 0xc208a794f4, 0x0, 0xc208938c60, 0x30, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_linux.go:224 +0x60
os.(*Process).wait(0xc20826ef40, 0x7898e7, 0x0, 0x0)
    /usr/local/go/src/os/exec_unix.go:22 +0x103
os.(*Process).Wait(0xc20826ef40, 0xc2085c3860, 0x0, 0x0)
    /usr/local/go/src/os/doc.go:45 +0x3a
os/exec.(*Cmd).Wait(0xc2080972c0, 0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:364 +0x23c
github.com/docker/libcontainer.(*initProcess).wait(0xc20860af60, 0xc2088e7380, 0x0, 0x0)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process_linux.go:191 +0x3d
github.com/docker/libcontainer.Process.Wait(0xc20826e380, 0x2, 0x2, 0xc2081a7900, 0xa, 0x10, 0x1374598, 0x0, 0xc2088d9ac7, 0x7, ...)
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/process.go:57 +0x11d
github.com/docker/libcontainer.Process.Wait·fm(0xc208a79ae8, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:160 +0x58
github.com/docker/docker/daemon/execdriver/native.(*driver).Run(0xc2082c5ae0, 0xc208422600, 0xc2083eb800, 0xc2082029d0, 0x0, 0x41b200, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/execdriver/native/driver.go:166 +0xc0c
github.com/docker/docker/daemon.(*Daemon).Run(0xc2080cd860, 0xc208890000, 0xc2083eb800, 0xc2082029d0, 0x0, 0xc2083c9000, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/daemon.go:1111 +0x95
github.com/docker/docker/daemon.(*containerMonitor).Start(0xc2089d1c70, 0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/monitor.go:138 +0x464
github.com/docker/docker/daemon.*containerMonitor.Start·fm(0x0, 0x0)
    /go/src/github.com/docker/docker/daemon/container.go:1453 +0x39
github.com/docker/docker/pkg/promise.func·001()
    /go/src/github.com/docker/docker/pkg/promise/promise.go:8 +0x2f
created by github.com/docker/docker/pkg/promise.Go
    /go/src/github.com/docker/docker/pkg/promise/promise.go:9 +0xfb

goroutine 67533 [syscall, 724 minutes]:
syscall.Syscall(0x0, 0x39, 0xc208dd0000, 0x8000, 0x0, 0x8000, 0xc20802fb30)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x39, 0xc208dd0000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x39, 0xc208dd0000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863eb48, 0xc208dd0000, 0x8000, 0x8000, 0xc208dd0000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863eb48, 0xc208dd0000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc2085e3aa0, 0x7fce14fdef20, 0xc20863eb48, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc2088aed80)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 84473 [IO wait]:
net.(*pollDesc).Wait(0xc208ad5db0, 0x72, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:84 +0x47
net.(*pollDesc).WaitRead(0xc208ad5db0, 0x0, 0x0)
    /usr/local/go/src/net/fd_poll_runtime.go:89 +0x43
net.(*netFD).Read(0xc208ad5d50, 0xc20848c000, 0x1000, 0x1000, 0x0, 0x7fce14fdef70, 0xc208361c10)
    /usr/local/go/src/net/fd_unix.go:242 +0x40f
net.(*conn).Read(0xc20863f638, 0xc20848c000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/net.go:121 +0xdc
net/http.(*liveSwitchReader).Read(0xc208de22c8, 0xc20848c000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:214 +0xab
io.(*LimitedReader).Read(0xc20877b880, 0xc20848c000, 0x1000, 0x1000, 0xc2088cd6f0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:408 +0xce
bufio.(*Reader).fill(0xc20885b380)
    /usr/local/go/src/bufio/bufio.go:97 +0x1ce
bufio.(*Reader).ReadSlice(0xc20885b380, 0xa, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:295 +0x257
bufio.(*Reader).ReadLine(0xc20885b380, 0x0, 0x0, 0x0, 0xc2080cc400, 0x0, 0x0)
    /usr/local/go/src/bufio/bufio.go:324 +0x62
net/textproto.(*Reader).readLineSlice(0xc208b5d260, 0x0, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/textproto/reader.go:55 +0x9e
net/textproto.(*Reader).ReadLine(0xc208b5d260, 0x0, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/textproto/reader.go:36 +0x4f
net/http.ReadRequest(0xc20885b380, 0xc20831f110, 0x0, 0x0)
    /usr/local/go/src/net/http/request.go:598 +0xcb
net/http.(*conn).readRequest(0xc208de2280, 0x0, 0x0, 0x0)
    /usr/local/go/src/net/http/server.go:586 +0x26f
net/http.(*conn).serve(0xc208de2280)
    /usr/local/go/src/net/http/server.go:1162 +0x69e
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 85167 [semacquire]:
sync.(*Cond).Wait(0xc208434870)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc208434840, 0xc208235000, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20838af50, 0xc208235000, 0x400, 0x400, 0xb10560, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc208434900)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 85074 [syscall, 5 minutes]:
syscall.Syscall(0x0, 0x25, 0xc2087e4750, 0x8, 0x2030203020302030, 0x2030203020302030, 0x2030203020302030)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x25, 0xc2087e4750, 0x8, 0x8, 0x2030203020302030, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x25, 0xc2087e4750, 0x8, 0x8, 0x2030203020302030, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863e260, 0xc2087e4750, 0x8, 0x8, 0xc208575180, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863e260, 0xc2087e4750, 0x8, 0x8, 0x2030203020302030, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
github.com/docker/libcontainer.func·008()
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:51 +0x18c
created by github.com/docker/libcontainer.notifyOnOOM
    /go/src/github.com/docker/docker/vendor/src/github.com/docker/libcontainer/notify_linux.go:61 +0x887

goroutine 67105 [chan receive]:
github.com/docker/docker/daemon.(*Daemon).ContainerStats(0xc2080cd860, 0xc2082175e0, 0x2)
    /go/src/github.com/docker/docker/daemon/stats.go:19 +0x1bd
github.com/docker/docker/daemon.*Daemon.ContainerStats·fm(0xc2082175e0, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:122 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc2082175e0, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.getContainersStats(0xc2080cc410, 0xc2089d8cd6, 0x4, 0x7fce14fe7b88, 0xc2082170e0, 0xc208be3110, 0xc2085d75c0, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:433 +0x21c
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc2082170e0, 0xc208be3110)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc2081afec0, 0x7fce14fe7b88, 0xc2082170e0, 0xc208be3110)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809b270, 0x7fce14fe7b88, 0xc2082170e0, 0xc208be3110)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc20800d6e0, 0x7fce14fe7b88, 0xc2082170e0, 0xc208be3110)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc2084cfc20)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 67054 [syscall, 740 minutes]:
syscall.Syscall(0x0, 0x41, 0xc208b10000, 0x8000, 0x0, 0x8000, 0x0)
    /usr/local/go/src/syscall/asm_linux_amd64.s:21 +0x5
syscall.read(0x41, 0xc208b10000, 0x8000, 0x8000, 0x13661d0, 0x0, 0x0)
    /usr/local/go/src/syscall/zsyscall_linux_amd64.go:867 +0x6e
syscall.Read(0x41, 0xc208b10000, 0x8000, 0x8000, 0xb3af40, 0x0, 0x0)
    /usr/local/go/src/syscall/syscall_unix.go:136 +0x58
os.(*File).read(0xc20863f2c0, 0xc208b10000, 0x8000, 0x8000, 0xc208b10000, 0x0, 0x0)
    /usr/local/go/src/os/file_unix.go:191 +0x5e
os.(*File).Read(0xc20863f2c0, 0xc208b10000, 0x8000, 0x8000, 0x8000, 0x0, 0x0)
    /usr/local/go/src/os/file.go:95 +0x91
io.Copy(0x7fce14ff4d00, 0xc2084f6880, 0x7fce14fdef20, 0xc20863f2c0, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/io.go:362 +0x1f6
os/exec.func·003(0x0, 0x0)
    /usr/local/go/src/os/exec/exec.go:221 +0x7d
os/exec.func·004(0xc208c8c460)
    /usr/local/go/src/os/exec/exec.go:328 +0x2d
created by os/exec.(*Cmd).Start
    /usr/local/go/src/os/exec/exec.go:329 +0xb6d

goroutine 67109 [chan receive]:
github.com/docker/docker/daemon.(*Daemon).ContainerStats(0xc2080cd860, 0xc208242500, 0x2)
    /go/src/github.com/docker/docker/daemon/stats.go:19 +0x1bd
github.com/docker/docker/daemon.*Daemon.ContainerStats·fm(0xc208242500, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:122 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc208242500, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.getContainersStats(0xc2080cc410, 0xc2089d9456, 0x4, 0x7fce14fe7b88, 0xc208242000, 0xc208be3c70, 0xc2088dfad0, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:433 +0x21c
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc208242000, 0xc208be3c70)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc2081afec0, 0x7fce14fe7b88, 0xc208242000, 0xc208be3c70)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809b270, 0x7fce14fe7b88, 0xc208242000, 0xc208be3c70)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc20800d6e0, 0x7fce14fe7b88, 0xc208242000, 0xc208be3c70)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc2084cfea0)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e

goroutine 67527 [semacquire, 724 minutes]:
sync.(*Cond).Wait(0xc2082970b0)
    /usr/local/go/src/sync/cond.go:62 +0x9e
io.(*pipe).read(0xc208297080, 0xc208ab2000, 0x400, 0x400, 0x0, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:52 +0x303
io.(*PipeReader).Read(0xc20863ea68, 0xc208ab2000, 0x400, 0x400, 0x31, 0x0, 0x0)
    /usr/local/go/src/io/pipe.go:134 +0x5b
github.com/docker/docker/pkg/ioutils.(*bufReader).drain(0xc208297140)
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:114 +0x10e
created by github.com/docker/docker/pkg/ioutils.NewBufReader
    /go/src/github.com/docker/docker/pkg/ioutils/readers.go:84 +0x2f3

goroutine 67106 [chan receive]:
github.com/docker/docker/daemon.(*Daemon).ContainerStats(0xc2080cd860, 0xc208216be0, 0x2)
    /go/src/github.com/docker/docker/daemon/stats.go:19 +0x1bd
github.com/docker/docker/daemon.*Daemon.ContainerStats·fm(0xc208216be0, 0x7fce14fe01e8)
    /go/src/github.com/docker/docker/daemon/daemon.go:122 +0x31
github.com/docker/docker/engine.(*Job).Run(0xc208216be0, 0x0, 0x0)
    /go/src/github.com/docker/docker/engine/job.go:90 +0x936
github.com/docker/docker/api/server.getContainersStats(0xc2080cc410, 0xc2089d8eb6, 0x4, 0x7fce14fe7b88, 0xc208216960, 0xc208be3380, 0xc2085d7a10, 0x0, 0x0)
    /go/src/github.com/docker/docker/api/server/server.go:433 +0x21c
github.com/docker/docker/api/server.func·003(0x7fce14fe7b88, 0xc208216960, 0xc208be3380)
    /go/src/github.com/docker/docker/api/server/server.go:1289 +0x951
net/http.HandlerFunc.ServeHTTP(0xc2081afec0, 0x7fce14fe7b88, 0xc208216960, 0xc208be3380)
    /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20809b270, 0x7fce14fe7b88, 0xc208216960, 0xc208be3380)
    /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x2b9
net/http.serverHandler.ServeHTTP(0xc20800d6e0, 0x7fce14fe7b88, 0xc208216960, 0xc208be3380)
    /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc2084cfcc0)
    /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1751 +0x35e
```

I saw docker daemon crashed due to "send on closed chan". This may happen because we only closed the chans during stoping container, see https://github.com/docker/docker/blob/master/daemon/stats_collector_unix.go#L63, while publisher may acquire the lock again and continue to put things into to chan, see https://github.com/docker/docker/blob/master/daemon/stats_collector_unix.go#L118.
