### PR TITLE
Set exit code of old running container as 137

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -207,8 +207,8 @@ func (daemon *Daemon) register(container *Container, updateSuffixarray bool) err
 
 	if container.IsRunning() {
 		logrus.Debugf("killing old running container %s", container.ID)
-
-		container.SetStopped(&execdriver.ExitStatus{ExitCode: 0})
+		// Set exit code to 128 + SIGKILL (9) to properly represent unsuccessful exit
+		container.SetStopped(&execdriver.ExitStatus{ExitCode: 137})
 
 		// use the current driver and ensure that the container is dead x.x
 		cmd := &execdriver.Command{

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -1845,6 +1845,21 @@ The currently supported filters are:
 
 This shows all the containers that have exited with status of '0'
 
+##### Killed containers
+
+You can use a filter to locate containers that exited with status of `137` meaning a `SIGKILL(9)` killed them.
+
+    $ docker ps -a --filter 'exited=137'
+    CONTAINER ID        IMAGE               COMMAND                CREATED             STATUS                       PORTS               NAMES
+    b3e1c0ed5bfe        ubuntu:latest       "sleep 1000"           12 seconds ago      Exited (137) 5 seconds ago                       grave_kowalevski
+    a2eb5558d669        redis:latest        "/entrypoint.sh redi   2 hours ago         Exited (137) 2 hours ago                         sharp_lalande
+
+Any of these events a result in `137` status:
+
+* the `init` process of the container is killed manually
+* `docker kill` kills the container
+* Docker daemon restarts which kills all old running containers
+
 ## pull
 
     Usage: docker pull [OPTIONS] NAME[:TAG] | [REGISTRY_HOST[:REGISTRY_PORT]/]NAME[:TAG]


### PR DESCRIPTION
Signed-off-by: Chun Chen chenchun.feed@gmail.com

We are running docker containers on a large cluster and we depend on the exit code of container to determine whether it succeed to complete or not.
Since old containers are killed by docker daemon after restarting daemon, I think it makes sense to set exit code to 137 other than 0. 
