### PR TITLE
Replace "sleep" by "top" in test implementation

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -94,7 +94,7 @@ type containerPs struct {
 func (s *DockerSuite) TestContainerPsOmitFields(c *check.C) {
 	name := "pstest"
 	port := 80
-	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", name, "--expose", strconv.Itoa(port), "busybox", "sleep", "5")
+	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", name, "--expose", strconv.Itoa(port), "busybox", "top")
 	_, err := runCommand(runCmd)
 	c.Assert(err, check.IsNil)
 


### PR DESCRIPTION
Eliminate any chance of race condition by replacing a call to sleep by a
call to top, and rely on test cleanup logic to have it exit cleanly.

Ref https://github.com/docker/docker/pull/13902#discussion_r32333904
