### PR TITLE
Mount points from json configuration.

### DIFF
--- a/daemon/mount_point.go
+++ b/daemon/mount_point.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/docker/volume"
+	"github.com/docker/libcontainer/label"
+)
+
+type mountPointExported struct {
+	Name        string `json:",omitempty"`
+	Driver      string `json:",omitempty"`
+	Source      string `json:",omitempty"`
+	Mode        string `json:",omitempty"`
+	Destination string
+}
+
+type mountPoint struct {
+	Name        string
+	Destination string
+	Driver      string
+	RW          bool
+	Volume      volume.Volume `json:"-"`
+	Source      string
+	Relabel     string
+}
+
+func (m *mountPoint) Setup() (string, error) {
+	if m.Volume != nil {
+		return m.Volume.Mount()
+	}
+
+	if len(m.Source) > 0 {
+		if _, err := os.Stat(m.Source); err != nil {
+			if !os.IsNotExist(err) {
+				return "", err
+			}
+			if err := os.MkdirAll(m.Source, 0755); err != nil {
+				return "", err
+			}
+		}
+		return m.Source, nil
+	}
+
+	return "", fmt.Errorf("Unable to setup mount point, neither source nor volume defined")
+}
+
+func (m *mountPoint) Path() string {
+	if m.Volume != nil {
+		return m.Volume.Path()
+	}
+
+	return m.Source
+}
+
+func (m *mountPoint) createVolume() error {
+	v, err := createVolume(m.Name, m.Driver)
+	if err != nil {
+		return err
+	}
+	m.Volume = v
+	m.Source = v.Path()
+	// Since this is just a named volume and not a typical bind, set to shared mode `z`
+	if m.Relabel == "" {
+		m.Relabel = "z"
+	}
+
+	return nil
+}
+
+func (m *mountPoint) isBindMount() bool {
+	return len(m.Name) == 0 || len(m.Driver) == 0
+}
+
+func (m *mountPoint) applyLabel(containerLabel string) error {
+	return label.Relabel(m.Source, containerLabel, m.Relabel)
+}
+
+// BackwardsCompatible decides whether this mount point can be
+// used in old versions of Docker or not.
+// Only bind mounts and local volumes can be used in old versions of Docker.
+func (m *mountPoint) backwardsCompatible() bool {
+	return len(m.Source) > 0 || m.Driver == volume.DefaultDriverName
+}

--- a/daemon/volumes_experimental_unit_test.go
+++ b/daemon/volumes_experimental_unit_test.go
@@ -5,7 +5,6 @@ package daemon
 import (
 	"testing"
 
-	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/volume"
 	"github.com/docker/docker/volume/drivers"
 )
@@ -34,29 +33,27 @@ func TestGetVolumeDriver(t *testing.T) {
 
 func TestParseBindMount(t *testing.T) {
 	cases := []struct {
-		bind       string
-		driver     string
-		expDest    string
-		expSource  string
-		expName    string
-		expDriver  string
-		mountLabel string
-		expRW      bool
-		fail       bool
+		bind      string
+		driver    string
+		expDest   string
+		expSource string
+		expName   string
+		expDriver string
+		expRW     bool
+		fail      bool
 	}{
-		{"/tmp:/tmp", "", "/tmp", "/tmp", "", "", "", true, false},
-		{"/tmp:/tmp:ro", "", "/tmp", "/tmp", "", "", "", false, false},
-		{"/tmp:/tmp:rw", "", "/tmp", "/tmp", "", "", "", true, false},
-		{"/tmp:/tmp:foo", "", "/tmp", "/tmp", "", "", "", false, true},
-		{"name:/tmp", "", "/tmp", "", "name", "local", "", true, false},
-		{"name:/tmp", "external", "/tmp", "", "name", "external", "", true, false},
-		{"name:/tmp:ro", "local", "/tmp", "", "name", "local", "", false, false},
-		{"local/name:/tmp:rw", "", "/tmp", "", "local/name", "local", "", true, false},
+		{"/tmp:/tmp", "", "/tmp", "/tmp", "", "", true, false},
+		{"/tmp:/tmp:ro", "", "/tmp", "/tmp", "", "", false, false},
+		{"/tmp:/tmp:rw", "", "/tmp", "/tmp", "", "", true, false},
+		{"/tmp:/tmp:foo", "", "/tmp", "/tmp", "", "", false, true},
+		{"name:/tmp", "", "/tmp", "", "name", "local", true, false},
+		{"name:/tmp", "external", "/tmp", "", "name", "external", true, false},
+		{"name:/tmp:ro", "local", "/tmp", "", "name", "local", false, false},
+		{"local/name:/tmp:rw", "", "/tmp", "", "local/name", "local", true, false},
 	}
 
 	for _, c := range cases {
-		conf := &runconfig.Config{VolumeDriver: c.driver}
-		m, err := parseBindMount(c.bind, c.mountLabel, conf)
+		m, err := parseBindMount(c.bind, c.driver)
 		if c.fail {
 			if err == nil {
 				t.Fatalf("Expected error, was nil, for spec %s\n", c.bind)

--- a/daemon/volumes_stubs_unit_test.go
+++ b/daemon/volumes_stubs_unit_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/volume"
 	"github.com/docker/docker/volume/drivers"
 	"github.com/docker/docker/volume/local"
@@ -54,8 +53,7 @@ func TestParseBindMount(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		conf := &runconfig.Config{}
-		m, err := parseBindMount(c.bind, c.mountLabel, conf)
+		m, err := parseBindMount(c.bind, "")
 		if c.fail {
 			if err == nil {
 				t.Fatalf("Expected error, was nil, for spec %s\n", c.bind)

--- a/daemon/volumes_unit_test.go
+++ b/daemon/volumes_unit_test.go
@@ -2,7 +2,7 @@ package daemon
 
 import "testing"
 
-func TestParseVolumeFrom(t *testing.T) {
+func TestParseVolumeFromContainer(t *testing.T) {
 	cases := []struct {
 		spec    string
 		expId   string
@@ -17,7 +17,7 @@ func TestParseVolumeFrom(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		id, mode, err := parseVolumesFrom(c.spec)
+		id, mode, err := parseVolumesFromContainer(c.spec)
 		if c.fail {
 			if err == nil {
 				t.Fatalf("Expected error, was nil, for spec %s\n", c.spec)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -3202,5 +3202,20 @@ func (s *DockerSuite) TestRunContainerNetModeWithExposePort(c *check.C) {
 	if err == nil || !strings.Contains(out, "Conflicting options: --expose and the network mode (--expose)") {
 		c.Fatalf("run --net=container with --expose should error out")
 	}
+}
 
+func (s *DockerSuite) TestRunWithVolumesFromFile(c *check.C) {
+	tmp, _ := ioutil.TempDir("", "volumes-from-test-")
+	defer os.RemoveAll(tmp)
+
+	volumesFile := filepath.Join(tmp, "volumes.json")
+	data := []byte(`[{"Name": "data", "Destination": "/data"}]`)
+	err := ioutil.WriteFile(volumesFile, data, 0644)
+	c.Assert(err, check.IsNil)
+
+	runCmd := exec.Command(dockerBinary, "run", "--volumes-from", "@"+volumesFile, "busybox", "ls", "/data")
+	out, stderr, exitCode, err := runCommandWithStdoutStderr(runCmd)
+	if err != nil && exitCode != 0 {
+		c.Fatal("2", out, stderr, err)
+	}
 }


### PR DESCRIPTION
Expand `--volumes-from` to accept a host path to a json file.
It uses cURL's convention of using an `@` as a prefix to identify the argument as a file path.

The JSON configuration is an array of mount point hashes. These are the attributes to represent a mount point:
- Name: Volume name. Can be empty to auto assign a random name.
- Driver: Volume driver, allows external driver names. Can be empty to use the `local` driver.
- Source: Bind mount source. Can be empty if this is not a bind mount.
- Destination: Path to mount the volume inside the container.
- Mode: Mount mode. Can be empty to use `rw` by default. It accepts the same options `--volume` takes.

Example:

```
[
  {
    // Local volume, it uses the default driver
    "Name": "data",
    "Destination": "/data"
  },
  {
    // External volume, it uses the flocker driver
    "Name": "flocker-volume",
    "Driver": "flocker",
    "Destination": "/flocker",
    "Mode": "ro,Z"
  },
  {
    // Bind mount
    "Source": "/mnt/data",
    "Destination": "/mnt/data",
    "Mode": "rw,z"
  }
]
```

This allows to configure a container with different volume drivers using `docker run`.
It also opens the door to further development, like a `docker volume` command.
Said command can turn its options into a similar document in the client side for the daemon to understand.

Signed-off-by: David Calavera david.calavera@gmail.com
