### PR TITLE
Add new "validate-pkg" bundlescript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ test-docker-py: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary test-docker-py
 
 validate: build
-	$(DOCKER_RUN_DOCKER) hack/make.sh validate-dco validate-gofmt validate-test validate-toml validate-vet
+	$(DOCKER_RUN_DOCKER) hack/make.sh validate-dco validate-gofmt validate-pkg validate-test validate-toml validate-vet
 
 shell: build
 	$(DOCKER_RUN_DOCKER) bash

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -46,6 +46,7 @@ echo
 DEFAULT_BUNDLES=(
 	validate-dco
 	validate-gofmt
+	validate-pkg
 	validate-test
 	validate-toml
 	validate-vet

--- a/hack/make/validate-pkg
+++ b/hack/make/validate-pkg
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+source "${MAKEDIR}/.validate"
+
+IFS=$'\n'
+files=( $(validate_diff --diff-filter=ACMR --name-only -- 'pkg/*.go' || true) )
+unset IFS
+
+badFiles=()
+for f in "${files[@]}"; do
+	IFS=$'\n'
+	badImports=( $(go list -e -f '{{ join .Deps "\n" }}' "$f" | sort -u | grep -vE '^github.com/docker/docker/pkg/' | grep -E '^github.com/docker/docker' || true) )
+	unset IFS
+
+	for import in "${badImports[@]}"; do
+		badFiles+=( "$f imports $import" )
+	done
+done
+
+if [ ${#badFiles[@]} -eq 0 ]; then
+	echo 'Congratulations! "./pkg/..." is safely isolated from internal code.'
+else
+	{
+		echo 'These files import internal code: (either directly or indirectly)'
+		for f in "${badFiles[@]}"; do
+			echo " - $f"
+		done
+		echo
+	} >&2
+	false
+fi


### PR DESCRIPTION
This helps ensure that `github.com/docker/docker/pkg/...` is actually safe to use in isolation (ie, doesn't import anything from `github.com/docker/docker` except other things from `pkg` or vendored dependencies).

Adding `github.com/docker/docker/utils` to the imports of `pkg/version/version.go`:

```
---> Making bundle: validate-pkg (in bundles/1.7.0-dev/validate-pkg)
These files import internal code: (either directly or indirectly)
 - pkg/version/version.go imports github.com/docker/docker/autogen/dockerversion
 - pkg/version/version.go imports github.com/docker/docker/utils
```

And then removing it again:

```
---> Making bundle: validate-pkg (in bundles/1.7.0-dev/validate-pkg)
Congratulations! "./pkg/..." is safely isolated from internal code.
```

This helps us avoid https://github.com/docker/docker/issues/11699.
