### PR TITLE
Windows: Patch up compile after adjustCpuShares

### DIFF
--- a/api/server/server_windows.go
+++ b/api/server/server_windows.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 
 	"github.com/docker/docker/daemon"
+	"github.com/docker/docker/pkg/version"
+	"github.com/docker/docker/runconfig"
 )
 
 // NewServer sets up the required Server and does protocol specific checking.


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli. When the Linux change went in for adjustCpuShares, a couple of imports were missed on the Windows file fix. This PR allows api\server\server_windows to compile again.
