### PR TITLE
Ignore files with prefix -test.go vendoring dependencies.

### DIFF
--- a/hack/.vendor-helpers.sh
+++ b/hack/.vendor-helpers.sh
@@ -111,7 +111,7 @@ clean() {
 	done
 
 	echo -n 'pruning unused files, '
-	find vendor -type f -name '*_test.go' -exec rm '{}' +
+	find vendor -type f -name '*[_-]test.go' -exec rm '{}' +
 
 	echo done
 }


### PR DESCRIPTION
Because they can include test helpers with references to test frameworks that we don't need to import.

/cc @tianon, @jfrazelle, @mavenugo 

Signed-off-by: David Calavera david.calavera@gmail.com
