### PR TITLE
Expand /info: Expose OSType (GOOS), Architecture (GOARCH)

### DIFF
--- a/api/client/info.go
+++ b/api/client/info.go
@@ -46,6 +46,8 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	ioutils.FprintfIfNotEmpty(cli.out, "Logging Driver: %s\n", info.LoggingDriver)
 	ioutils.FprintfIfNotEmpty(cli.out, "Kernel Version: %s\n", info.KernelVersion)
 	ioutils.FprintfIfNotEmpty(cli.out, "Operating System: %s\n", info.OperatingSystem)
+	ioutils.FprintfIfNotEmpty(cli.out, "OSType: %s\n", info.OSType)
+	ioutils.FprintfIfNotEmpty(cli.out, "Architecture: %s\n", info.Architecture)
 	fmt.Fprintf(cli.out, "CPUs: %d\n", info.NCPU)
 	fmt.Fprintf(cli.out, "Total Memory: %s\n", units.BytesSize(float64(info.MemTotal)))
 	ioutils.FprintfIfNotEmpty(cli.out, "Name: %s\n", info.Name)

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -202,6 +202,8 @@ type Info struct {
 	NEventsListener    int
 	KernelVersion      string
 	OperatingSystem    string
+	OSType             string
+	Architecture       string
 	IndexServerAddress string
 	RegistryConfig     *registry.ServiceConfig
 	InitSha1           string

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -83,6 +83,8 @@ func (daemon *Daemon) SystemInfo(ctx context.Context) (*types.Info, error) {
 		KernelVersion:      kernelVersion,
 		OperatingSystem:    operatingSystem,
 		IndexServerAddress: registry.IndexServer,
+		OSType:             runtime.GOOS,
+		Architecture:       runtime.GOARCH,
 		RegistryConfig:     daemon.RegistryService.Config,
 		InitSha1:           dockerversion.INITSHA1,
 		InitPath:           initPath,

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -1817,6 +1817,7 @@ Display system-wide information
     Content-Type: application/json
 
     {
+        "Architecture": "amd64",
         "Containers": 11,
         "CpuCfsPeriod": true,
         "CpuCfsQuota": true,
@@ -1847,6 +1848,7 @@ Display system-wide information
         "Name": "prod-server-42",
         "NoProxy": "9.81.1.160",
         "OomKillDisable": true,
+        "OSType": "linux",
         "OperatingSystem": "Boot2Docker",
         "RegistryConfig": {
             "IndexConfigs": {

--- a/docs/reference/commandline/info.md
+++ b/docs/reference/commandline/info.md
@@ -30,6 +30,8 @@ For example:
     Execution Driver: native-0.2
     Logging Driver: json-file
     Kernel Version: 3.19.0-22-generic
+    OSType: linux
+    Architecture: amd64
     Operating System: Ubuntu 15.04
     CPUs: 24
     Total Memory: 62.86 GiB

--- a/integration-cli/docker_api_info_test.go
+++ b/integration-cli/docker_api_info_test.go
@@ -23,6 +23,8 @@ func (s *DockerSuite) TestInfoApi(c *check.C) {
 		"LoggingDriver",
 		"OperatingSystem",
 		"NCPU",
+		"OSType",
+		"Architecture",
 		"MemTotal",
 		"KernelVersion",
 		"Driver",

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -17,6 +17,8 @@ func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
 		"Containers:",
 		"Images:",
 		"Execution Driver:",
+		"OSType:",
+		"Architecture:",
 		"Logging Driver:",
 		"Operating System:",
 		"CPUs:",

--- a/man/docker-info.1.md
+++ b/man/docker-info.1.md
@@ -41,6 +41,8 @@ Here is a sample output:
     Logging Driver: json-file
     Kernel Version: 3.13.0-24-generic
     Operating System: Ubuntu 14.04 LTS
+    OSType: linux
+    Architecture: amd64
     CPUs: 1
     Total Memory: 2 GiB
 


### PR DESCRIPTION
This change amends the diagnostic output of `/info`, to add two more keys. This supports Swarm's effort of helping users target multi-architecture Swarm clusters. See #13634. 

These keys were introduced:
- OSType (runtime.GOOS)
- Architecture (runtime.GOARCH)

:sparkles: to @runcom, who helped out a lot with this.
