### PR TITLE
Windows: Fixup compile in daemon_windows.go

### DIFF
--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -42,7 +42,7 @@ func checkKernel() error {
 	return nil
 }
 
-func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, config *runconfig.HostConfig) ([]string, error) {
+func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, config *runconfig.Config) ([]string, error) {
 	// TODO Windows. Verifications TBC
 	return nil, nil
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. Easy fix to bring Windows daemon compilation back to working.
