### PR TITLE
`docker squash`: Consolidate image layers

### DIFF
--- a/api/client/squash.go
+++ b/api/client/squash.go
@@ -1,0 +1,70 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/graph/tags"
+	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/pkg/parsers"
+	"github.com/docker/docker/pkg/stringid"
+	"github.com/docker/docker/registry"
+)
+
+// CmdSquash merges filesystem layers of an image into a new image.
+//
+// Usage: docker squash IMAGE [ANCESTOR]
+func (cli *DockerCli) CmdSquash(args ...string) error {
+	cmd := cli.Subcmd("squash", []string{"IMAGE [ANCESTOR]"}, "Merge filesystem layers of an image into a new image", true)
+	cmd.Require(flag.Min, 1)
+	cmd.Require(flag.Max, 2)
+
+	repoTag := cmd.String([]string{"t", "-tag"}, "", "Repository name (and optionally a tag) for the image")
+	noTrunc := cmd.Bool([]string{"-no-trunc"}, false, "Don't truncate output")
+
+	cmd.ParseFlags(args, true)
+
+	// Set request parameters.
+	query := make(url.Values)
+
+	if cmd.NArg() > 1 {
+		query.Set("ancestor", cmd.Arg(1))
+	}
+
+	//Check if the given image name/tag can be resolved
+	if *repoTag != "" {
+		repository, tag := parsers.ParseRepositoryTag(*repoTag)
+		if err := registry.ValidateRepositoryName(repository); err != nil {
+			return err
+		}
+		if tag != "" {
+			if err := tags.ValidateTagName(tag); err != nil {
+				return err
+			}
+		}
+		query.Set("tag", *repoTag)
+	}
+
+	urlStr := fmt.Sprintf("/images/%s/squash?%s", cmd.Arg(0), query.Encode())
+
+	responseJSON, _, err := readBody(cli.call("POST", urlStr, nil, nil))
+	if err != nil {
+		return err
+	}
+
+	var response types.ImageSquashResponse
+	if err := json.Unmarshal(responseJSON, &response); err != nil {
+		return fmt.Errorf("unable to decode response: %s", err)
+	}
+
+	ID := response.ID
+	if !*noTrunc {
+		ID = stringid.TruncateID(ID)
+	}
+
+	fmt.Fprintln(cli.out, ID)
+
+	return nil
+}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -650,6 +650,29 @@ func (s *Server) postImagesTag(version version.Version, w http.ResponseWriter, r
 	return nil
 }
 
+func (s *Server) postImagesSquash(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if err := parseForm(r); err != nil {
+		return err
+	}
+	if vars == nil {
+		return fmt.Errorf("Missing parameter")
+	}
+
+	imgName := vars["name"]
+	ancestorName := r.Form.Get("ancestor")
+	tag := r.Form.Get("tag")
+
+	newImage, err := s.daemon.Repositories().Squash(imgName, ancestorName, tag)
+	if err != nil {
+		return err
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+
+	return json.NewEncoder(w).Encode(types.ImageSquashResponse{ID: newImage.ID})
+}
+
 func (s *Server) postCommit(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -1533,6 +1556,7 @@ func createRouter(s *Server) *mux.Router {
 			"/images/load":                  s.postImagesLoad,
 			"/images/{name:.*}/push":        s.postImagesPush,
 			"/images/{name:.*}/tag":         s.postImagesTag,
+			"/images/{name:.*}/squash":      s.postImagesSquash,
 			"/containers/create":            s.postContainersCreate,
 			"/containers/{name:.*}/kill":    s.postContainersKill,
 			"/containers/{name:.*}/pause":   s.postContainersPause,

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -41,6 +41,11 @@ type ContainerCommitResponse struct {
 	ID string `json:"Id"`
 }
 
+// ImageSquashResponse is returned by POST "/images/{name:.*}/squash"
+type ImageSquashResponse struct {
+	ID string `json:"id"`
+}
+
 // GET "/containers/{name:.*}/changes"
 type ContainerChange struct {
 	Kind int

--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -308,6 +308,15 @@ func (a *Driver) Put(id string) error {
 	return nil
 }
 
+// DiffAncestor produces an archive of the changes between the
+// specified layer and one of its ancestor layers which may be "".
+func (a *Driver) DiffAncestor(id, ancestor string) (archive.Archive, error) {
+	// AUFS doesn't have any clever structure which makes this
+	// task trivial in the way that it can with `Diff', so it can
+	// just be wrapped in a `naiveDiffDriver` for this task.
+	return graphdriver.NaiveDiffDriver(a).DiffAncestor(id, ancestor)
+}
+
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
 func (a *Driver) Diff(id, parent string) (archive.Archive, error) {

--- a/daemon/graphdriver/driver.go
+++ b/daemon/graphdriver/driver.go
@@ -68,9 +68,12 @@ type Driver interface {
 	// Diff produces an archive of the changes between the specified
 	// layer and its parent layer which may be "".
 	Diff(id, parent string) (archive.Archive, error)
+	// DiffAncestor produces an archive of the changes between the
+	// specified layer and one of its ancestor layers which may be "".
+	DiffAncestor(id, ancestor string) (archive.Archive, error)
 	// Changes produces a list of changes between the specified layer
 	// and its parent layer. If parent is "", then all changes will be ADD changes.
-	Changes(id, parent string) ([]archive.Change, error)
+	Changes(id, ancestor string) ([]archive.Change, error)
 	// ApplyDiff extracts the changeset from the given diff into the
 	// layer with the specified id and parent, returning the size of the
 	// new layer in bytes.

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -60,6 +60,7 @@ var (
 		{"run", "Run a command in a new container"},
 		{"save", "Save an image to a tar archive"},
 		{"search", "Search for an image on the Docker Hub"},
+		{"squash", "Merge filesystem layers of an image into a new image"},
 		{"start", "Start a stopped container"},
 		{"stats", "Display a stream of a containers' resource usage statistics"},
 		{"stop", "Stop a running container"},

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -68,6 +68,11 @@ Running `docker rmi` emits an **untag** event when removing an image name.  The 
 
 ### What's new
 
+`POST /images/(name)/squash`
+
+**New!**
+Create a new image by consolidating intermediate layers of another image.
+
 ## v1.19
 
 ### Full documentation

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -1441,6 +1441,44 @@ Status Codes:
 -   **409** – conflict
 -   **500** – server error
 
+### Squash image layers
+
+`POST /images/(name)/squash`
+
+Create a new image by consolidating intermediate layers of another image.
+
+**Example request**
+
+    POST /images/463a6ff37134/squash?ancestor=c12da83ee7c1 HTTP/1.1
+
+This request will combine all of the filesystem layers between `463a6ff37134`
+and its ancestor layer `c12da83ee7c1` into a new image layer.
+
+**Example response**
+
+    HTTP/1.1 201 Created
+    Content-Type: application/json
+
+    {"id": "7773c5ae0808468c66d260cf641c0fadf40f203211744918bef12f9553e32509"}
+
+On success, the response body will contain a JSON object containing the `id` of
+the new image.
+
+Query Parameters:
+
+- **ancestor** - The ancestor image layer to squash up to. All layers between
+    *name* and *ancestor* will be combined into a single layer. If omitted, all
+    layers in the image's ancestory will be squashed.
+- **tag** - Apply the given repository tag to the resulting squashed image.
+
+Status Codes:
+
+-   **200** - success, image ID of squashed layer is returned.
+-   **400** - client error. The image must be a decendant of *ancestor*, if
+    provided.
+-   **404** - no such image.
+-   **500** - server error.
+
 ### Search images
 
 `GET /images/search`

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -2461,6 +2461,100 @@ It is even useful to cherry-pick particular tags of an image repository
 
     $ docker save -o ubuntu.tar ubuntu:lucid ubuntu:saucy
 
+## squash
+
+This command combines the filesystem layers between an image and an ancestor
+image (or all layers if no ancestor is specified) into a new image.
+
+    Usage: docker squash [OPTIONS] IMAGE [ANCESTOR]
+
+    Merge filesystem layers of an image into a new image
+
+      --no-trunc=false     Don't truncate output
+      -t, --tag=""         Repository name (and optionally a tag) for the image
+
+You can use `docker squash` to consolidate all layer of an image to a new
+single-layered image. Let's inspect the history of the busybox image:
+
+    # docker history busybox
+    IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+    8c2e06607696        8 weeks ago         /bin/sh -c #(nop) CMD ["/bin/sh"]               0 B                 
+    6ce2e90b0bc7        8 weeks ago         /bin/sh -c #(nop) ADD file:8cf517d90fe79547c4   2.43 MB             
+    cf2616975b4a        8 weeks ago         /bin/sh -c #(nop) MAINTAINER Jérôme Petazzo     0 B
+
+It has 3 layers total, but we can now `squash` it and tag it as something else.
+
+    # docker squash --tag better_busybox busybox
+    ccbe958582b2
+
+Now we have these 2 images.
+
+    # docker images
+    REPOSITORY          TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
+    better_busybox      latest              ccbe958582b2        About a minute ago   2.43 MB
+    busybox             latest              8c2e06607696        8 weeks ago          2.43 MB
+
+But `better_busybox` only has a single layer in its history.
+
+    # docker history better_busybox
+    IMAGE               CREATED              CREATED BY          SIZE                COMMENT
+    ccbe958582b2        About a minute ago                       2.43 MB 
+
+
+You can also merge layers of a newly built image into a single layer relative
+to the base image. Let's build an image using this Dockerfile:
+
+
+    FROM busybox:latest
+    MAINTAINER Josh Hawn <josh.hawn@docker.com>
+    ADD docker/docs /docs
+    RUN echo hello > /hello.txt
+
+    # docker build -t test_build .
+    Sending build context to Docker daemon 93.87 MB
+    Step 0 : FROM busybox:latest
+     ---> 8c2e06607696
+    Step 1 : MAINTAINER Josh Hawn <josh.hawn@docker.com>
+     ---> Running in 0c2b29e087d5
+     ---> 4ac4b75a88f6
+    Removing intermediate container 0c2b29e087d5
+    Step 2 : ADD docker/docs /docs
+     ---> c9e50d91bc69
+    Removing intermediate container ad9e921d943f
+    Step 3 : RUN echo hello > /hello.txt
+     ---> Running in e15283387c37
+     ---> 49644b91f444
+    Removing intermediate container e15283387c37
+    Successfully built 49644b91f444
+
+And inspect the history of this new image:
+
+    # docker history test_build
+    IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+    49644b91f444        24 minutes ago      /bin/sh -c echo hello > /hello.txt              6 B                 
+    c9e50d91bc69        24 minutes ago      /bin/sh -c #(nop) ADD dir:24ae8a736955084e39d   8.537 MB            
+    4ac4b75a88f6        24 minutes ago      /bin/sh -c #(nop) MAINTAINER Josh Hawn <josh.   0 B                 
+    8c2e06607696        8 weeks ago         /bin/sh -c #(nop) CMD ["/bin/sh"]               0 B                 
+    6ce2e90b0bc7        8 weeks ago         /bin/sh -c #(nop) ADD file:8cf517d90fe79547c4   2.43 MB             
+    cf2616975b4a        8 weeks ago         /bin/sh -c #(nop) MAINTAINER Jérôme Petazzo     0 B
+
+See that it has 6 layers. That's 3 more than were already in the base image. We
+can squash these 3 into an image with one additional layer relative to the base
+image, and re-tag this new image.
+
+    # docker squash --tag test_build test_build busybox
+    97561533b0fa
+
+Now `test_build` only has a single new layer on top of the original 3 layers
+from `busybox`:
+
+    # docker history test_build
+    IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+    97561533b0fa        2 minutes ago                                                       8.537 MB            
+    8c2e06607696        8 weeks ago         /bin/sh -c #(nop) CMD ["/bin/sh"]               0 B                 
+    6ce2e90b0bc7        8 weeks ago         /bin/sh -c #(nop) ADD file:8cf517d90fe79547c4   2.43 MB             
+    cf2616975b4a        8 weeks ago         /bin/sh -c #(nop) MAINTAINER Jérôme Petazzo     0 B
+
 ## search
 
 Search [Docker Hub](https://hub.docker.com) for images

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -128,9 +128,10 @@ func (graph *Graph) Get(name string) (*image.Image, error) {
 }
 
 // Create creates a new image and registers it in the graph.
-func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, containerImage, comment, author string, containerConfig, config *runconfig.Config) (*image.Image, error) {
+func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, parentImgID, comment, author string, containerConfig, config *runconfig.Config) (*image.Image, error) {
 	img := &image.Image{
 		ID:            stringid.GenerateRandomID(),
+		Parent:        parentImgID,
 		Comment:       comment,
 		Created:       time.Now().UTC(),
 		DockerVersion: dockerversion.VERSION,
@@ -141,8 +142,10 @@ func (graph *Graph) Create(layerData archive.ArchiveReader, containerID, contain
 	}
 
 	if containerID != "" {
-		img.Parent = containerImage
 		img.Container = containerID
+	}
+
+	if containerConfig != nil {
 		img.ContainerConfig = *containerConfig
 	}
 

--- a/graph/squash.go
+++ b/graph/squash.go
@@ -1,0 +1,143 @@
+package graph
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/docker/docker/graph/tags"
+	"github.com/docker/docker/image"
+	"github.com/docker/docker/pkg/archive"
+	"github.com/docker/docker/pkg/parsers"
+	"github.com/docker/docker/registry"
+	"github.com/docker/docker/runconfig"
+)
+
+// Squash creates a new image that is a combination of all rootfs layers
+// between the image specified by the given name or ID and the image specified
+// by the given ancestor name or ID. The new image will have the specified
+// ancestor image as its direct parent. If *ancestorName* is empty then all
+// layers are are merged. The original image and layers are unaltered.
+func (store *TagStore) Squash(imgName, ancestorName, repoTag string) (*image.Image, error) {
+	repoName, tag := parsers.ParseRepositoryTag(repoTag)
+	if repoName != "" {
+		if err := registry.ValidateRepositoryName(repoName); err != nil {
+			return nil, err
+		}
+		if len(tag) > 0 {
+			if err := tags.ValidateTagName(tag); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	img, err := store.LookupImage(imgName)
+	if err != nil {
+		return nil, err
+	}
+
+	var ancestor *image.Image
+	if ancestorName != "" {
+		if ancestor, err = store.LookupImage(ancestorName); err != nil {
+			return nil, err
+		}
+	}
+
+	newImg, err := store.graph.Squash(img, ancestor)
+	if err != nil {
+		return nil, err
+	}
+
+	if repoName != "" {
+		if err := store.Tag(repoName, tag, newImg.ID, true); err != nil {
+			return nil, fmt.Errorf("unable to tag id %s: %v", newImg.ID, err)
+		}
+	}
+
+	return newImg, nil
+}
+
+// Squash consolidates all layers in between the given image and an ancestor
+// image into a single layer. Returns the newly created image. A nil ancestor
+// argument indicates that the layer should be squashed all the way to a single
+// new base image.
+func (graph *Graph) Squash(img, ancestor *image.Image) (squashedImage *image.Image, err error) {
+	if ancestor != nil && img.ID == ancestor.ID {
+		// No need to squash! They are the same image already!
+		return img, nil
+	}
+
+	var (
+		ancestorID string
+		squashDiff archive.Archive
+	)
+
+	if ancestor != nil {
+		ancestorID = ancestor.ID
+	}
+
+	log.Debugf("squashing image ID %q up to %q", img.ID, ancestorID)
+
+	if img.Parent == ancestorID {
+		// No need to squash! It's already only a single layer difference!
+		return img, nil
+	}
+
+	// We need to preserve the command history and comments of all the squashed
+	// layers.
+	var commands, comments []string
+
+	// Ensure that the ancestorID is an actual ancestor by walking the
+	// image history to find it. We'll use this sentinel error to exit the
+	// walk early and indicate that the ancestor was found. While walking the
+	// history, also add the commands to slice of squashed commands.
+	foundAncestor := errors.New("found ancestor")
+	err = graph.WalkHistory(img, func(img image.Image) error {
+		cmdString := "()"
+		if img.ContainerConfig.Cmd != nil {
+			cmdString = fmt.Sprintf("(%s)", img.ContainerConfig.Cmd.ToString())
+		}
+
+		commands = append(commands, cmdString)
+		comments = append(comments, fmt.Sprintf("(%q)", img.Comment))
+
+		if img.Parent == ancestorID {
+			return foundAncestor // Exit walk early.
+		}
+		return nil
+	})
+	if err == nil {
+		return nil, fmt.Errorf("unable to squash: %q is not an ancestor of %q", ancestorID, img.ID)
+	}
+	if err != foundAncestor {
+		return nil, err
+	}
+
+	// Reverse the commands and comments so that they read better as the image
+	// history.
+	for i := 0; i < len(commands)/2; i++ {
+		swapIdx := len(commands) - i - 1
+		commands[i], commands[swapIdx] = commands[swapIdx], commands[i]
+		comments[i], comments[swapIdx] = comments[swapIdx], comments[i]
+	}
+
+	// The special sauce! Actually getting an diff from the ancestor Image rootfs.
+	if squashDiff, err = graph.driver.DiffAncestor(img.ID, ancestorID); err != nil {
+		return nil, err
+	}
+	defer squashDiff.Close()
+
+	// Create a spoofed container config for preserved command history.
+	spoofedConfig := &runconfig.Config{
+		Cmd: runconfig.NewCommand(append([]string{"/bin/sh", "-c", "#(nop)", "SQUASH"}, strings.Join(commands, ", "))...),
+	}
+	comment := fmt.Sprintf("Squashed layer comments: %s", strings.Join(comments, ", "))
+
+	// Create it like any other image is created!
+	if squashedImage, err = graph.Create(squashDiff, "", ancestorID, comment, img.Author, spoofedConfig, img.Config); err != nil {
+		return nil, err
+	}
+
+	return squashedImage, nil
+}

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -229,7 +229,7 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 
 		}
 
-		expected := 39
+		expected := 40
 		if len(cmds) != expected {
 			c.Fatalf("Wrong # of cmds(%d), it should be: %d\nThe list:\n%q",
 				len(cmds), expected, cmds)

--- a/integration-cli/docker_cli_squash_test.go
+++ b/integration-cli/docker_cli_squash_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+
+	"github.com/go-check/check"
+)
+
+func squashImage(c *check.C, image, ancestor, tag string) (squashedImageID string) {
+	args := []string{"squash", "--no-trunc"}
+
+	if tag != "" {
+		args = append(args, "--tag", tag)
+	}
+
+	args = append(args, image)
+
+	if ancestor != "" {
+		args = append(args, ancestor)
+	}
+
+	out, exitCode, err := runCommandWithOutput(exec.Command(dockerBinary, args...))
+	if err != nil || exitCode != 0 {
+		c.Fatalf("failed to squash image: %s, %v", out, err)
+	}
+
+	return strings.TrimSpace(out)
+}
+
+func getImageHistory(c *check.C, image string) (layerIDs []string) {
+	// Get image history.
+	out, exitCode, err := runCommandWithOutput(exec.Command(dockerBinary, "history", "-q", "--no-trunc", image))
+	if err != nil || exitCode != 0 {
+		c.Fatalf("failed to get image history: %s, %v", out, err)
+	}
+
+	return strings.Split(strings.TrimSpace(out), "\n")
+}
+
+// TestSquashNop tries to squash an image that can't actually be squashed any
+// further either because it has no parent image layer or the specified
+// ancestor is itself.
+func (s *DockerSuite) TestSquashNop(c *check.C) {
+	squashedBusyboxID := squashImage(c, "busybox", "", "")
+
+	// Try squashing the squashed image again. This should produce the same
+	// ID because it has no ancestor layers.
+	squashedAgainID := squashImage(c, squashedBusyboxID, "", "")
+	if squashedAgainID != squashedBusyboxID {
+		c.Fatalf("expected squashing the image again to produce the same ID %q, but got %q", squashedBusyboxID, squashedAgainID)
+	}
+
+	// Try squashing busybox to busybox. This should also produce the same ID
+	// because ther are no ancestor layers between an image and itself.
+	busyboxLayerIDs := getImageHistory(c, "busybox")
+	squashedSelfID := squashImage(c, "busybox", "busybox", "")
+	if squashedSelfID != busyboxLayerIDs[0] {
+		c.Fatalf("expected squashing busybox to itself to produce the same ID %q, but got %q", busyboxLayerIDs[0], squashedSelfID)
+	}
+}
+
+// TestSquashAbsolute ensures that an image can be squashed completely to a new
+// single-layered image and that the new image behaves like the original.
+func (s *DockerSuite) TestSquashAbsolute(c *check.C) {
+	squashedBusyboxID := squashImage(c, "busybox", "", "")
+
+	// Ensure that there is only a single layer in the new image.
+	squashedImageHistory := getImageHistory(c, squashedBusyboxID)
+	if len(squashedImageHistory) != 1 {
+		c.Fatalf("expected absolutely-squashed image to have a single layer, it has %d.", len(squashedImageHistory))
+	}
+
+	if squashedBusyboxID != squashedImageHistory[0] {
+		c.Fatalf("expected the squashed image history to be only %q, but it is %v", squashedBusyboxID, squashedImageHistory)
+	}
+
+	// Do a test run of the new image.
+	out, exitCode, err := runCommandWithOutput(exec.Command(dockerBinary, "run", squashedBusyboxID, "echo", "hello"))
+	if err != nil || exitCode != 0 {
+		c.Fatalf("failed to run squashed image: %s, %v", out, err)
+	}
+
+	expectedOutput := "hello\n"
+	if out != expectedOutput {
+		c.Fatalf("unexpected output running squashed image: got %q, expected %q", out, expectedOutput)
+	}
+}
+
+func imageHistoriesEqual(history1, history2 []string) bool {
+	if len(history1) != len(history2) {
+		return false
+	}
+
+	for i, val := range history1 {
+		if val != history2[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (s *DockerSuite) TestSquashRelative(c *check.C) {
+	// Build a new image on top of the official busybox image.
+	testBuildImage := "testbuildimage"
+
+	if _, err := buildImage(
+		testBuildImage,
+		`FROM busybox
+MAINTAINER Tester McTest <tester@example.com>
+RUN echo hello foo > /root/foo.txt
+RUN echo hello bar > /root/bar.txt
+RUN echo hello baz > /root/baz.txt
+RUN rm /root/bar.txt`,
+		false,
+	); err != nil {
+		c.Fatalf("unable to build test image: %v", err)
+	}
+
+	busyboxLayers := getImageHistory(c, "busybox")
+	testBuildImageLayers := getImageHistory(c, testBuildImage)
+
+	numNewLayers := len(testBuildImageLayers) - len(busyboxLayers)
+	if numNewLayers != 5 {
+		c.Fatalf("expected the build to add 5 new layers but it added %d", numNewLayers)
+	}
+
+	// Squash the newly built image up to its base image, "busybox".
+	testBuildImageSquashed := squashImage(c, testBuildImage, "busybox", "")
+	squashedImageHistory := getImageHistory(c, testBuildImageSquashed)
+
+	expectedHistory := append([]string{testBuildImageSquashed}, busyboxLayers...)
+	if !imageHistoriesEqual(expectedHistory, squashedImageHistory) {
+		c.Fatalf("expected the squashed image history to be %v, but it is %v", expectedHistory, squashedImageHistory)
+	}
+
+	// Now ensure that the squashed image behaves the same as the unsquashed
+	// image.
+	expectedLsRootOutput, statusCode, err := runCommandWithOutput(exec.Command(dockerBinary, "run", testBuildImage, "ls", "/root"))
+	if err != nil || statusCode != 0 {
+		c.Fatalf("failed to 'ls /root' in %q: %s, %v", testBuildImage, expectedLsRootOutput, err)
+	}
+
+	squashedLSRootOutput, statusCode, err := runCommandWithOutput(exec.Command(dockerBinary, "run", testBuildImageSquashed, "ls", "/root"))
+	if err != nil || statusCode != 0 {
+		c.Fatalf("failed to 'ls /root' in %q: %s, %v", testBuildImageSquashed, squashedLSRootOutput, err)
+	}
+
+	if squashedLSRootOutput != expectedLsRootOutput {
+		c.Fatalf("expected 'ls /root' of squashed image to be %q, but it is %q", expectedLsRootOutput, squashedLSRootOutput)
+	}
+}
+
+func (s *DockerSuite) TestSquashTag(c *check.C) {
+	testTag := "squashed/busybox:test"
+	squashedBusyboxID := squashImage(c, "busybox", "", testTag)
+
+	// Ensure that tagging worked by comparing history.
+	historyByID := getImageHistory(c, squashedBusyboxID)
+	historyByTag := getImageHistory(c, testTag)
+
+	if !imageHistoriesEqual(historyByID, historyByTag) {
+		c.Fatalf("expected image history to be %v, but it is %v", historyByID, historyByTag)
+	}
+}

--- a/man/docker-squash.1.md
+++ b/man/docker-squash.1.md
@@ -1,0 +1,121 @@
+% DOCKER(1) Docker User Manuals
+% Docker Community
+% JUNE 2015
+# NAME
+docker-squash - Merge filesystem layers of an image into a new image
+
+# SYNOPSIS
+**docker squash**
+[**--help**]
+[**--no-trunc**[=*false*]]
+[**-t**|**--tag**[=*TAG*]]
+IMAGE [ANCESTOR]
+
+# DESCRIPTION
+
+This command combines the filesystem layers between an image and an ancestor
+image (or all layers if no ancestor is specified) into a new image.
+
+# OPTIONS
+**--help**
+  Print usage statement
+
+**--no-trunc**=*true*|*false*
+   Don't truncate output. The default is *false*.
+
+**-t**, **--tag**=""
+   Repository name (and optionally a tag) to be applied to the resulting image
+   in case of success.
+
+# EXAMPLES
+
+# Consolidating all layer of an image to a new single-layered image
+
+Let's inspect the history of the busybox image.
+
+    # docker history busybox
+    IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+    8c2e06607696        8 weeks ago         /bin/sh -c #(nop) CMD ["/bin/sh"]               0 B                 
+    6ce2e90b0bc7        8 weeks ago         /bin/sh -c #(nop) ADD file:8cf517d90fe79547c4   2.43 MB             
+    cf2616975b4a        8 weeks ago         /bin/sh -c #(nop) MAINTAINER Jérôme Petazzo     0 B
+
+It has 3 layers total, but we can now `squash` it and tag it as something else.
+
+    # docker squash busybox
+    ccbe958582b2
+    # docker tag ccbe958582b2 better_busybox
+
+Now we have these 2 images.
+
+    # docker images
+    REPOSITORY          TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
+    better_busybox      latest              ccbe958582b2        About a minute ago   2.43 MB
+    busybox             latest              8c2e06607696        8 weeks ago          2.43 MB
+
+But `better_busybox` only has a single layer in its history.
+
+    # docker history better_busybox
+    IMAGE               CREATED              CREATED BY          SIZE                COMMENT
+    ccbe958582b2        About a minute ago                       2.43 MB 
+
+
+# Merging layers of a newly built image into a single layer relative to the
+# base image.
+
+Let's build an image using this Dockerfile:
+
+
+    FROM busybox:latest
+    MAINTAINER Josh Hawn <josh.hawn@docker.com>
+    ADD docker/docs /docs
+    RUN echo hello > /hello.txt
+
+    # docker build -t test_build .
+    Sending build context to Docker daemon 93.87 MB
+    Step 0 : FROM busybox:latest
+     ---> 8c2e06607696
+    Step 1 : MAINTAINER Josh Hawn <josh.hawn@docker.com>
+     ---> Running in 0c2b29e087d5
+     ---> 4ac4b75a88f6
+    Removing intermediate container 0c2b29e087d5
+    Step 2 : ADD docker/docs /docs
+     ---> c9e50d91bc69
+    Removing intermediate container ad9e921d943f
+    Step 3 : RUN echo hello > /hello.txt
+     ---> Running in e15283387c37
+     ---> 49644b91f444
+    Removing intermediate container e15283387c37
+    Successfully built 49644b91f444
+
+And inspect the history of this new image:
+
+    # docker history test_build
+    IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+    49644b91f444        24 minutes ago      /bin/sh -c echo hello > /hello.txt              6 B                 
+    c9e50d91bc69        24 minutes ago      /bin/sh -c #(nop) ADD dir:24ae8a736955084e39d   8.537 MB            
+    4ac4b75a88f6        24 minutes ago      /bin/sh -c #(nop) MAINTAINER Josh Hawn <josh.   0 B                 
+    8c2e06607696        8 weeks ago         /bin/sh -c #(nop) CMD ["/bin/sh"]               0 B                 
+    6ce2e90b0bc7        8 weeks ago         /bin/sh -c #(nop) ADD file:8cf517d90fe79547c4   2.43 MB             
+    cf2616975b4a        8 weeks ago         /bin/sh -c #(nop) MAINTAINER Jérôme Petazzo     0 B
+
+See that it has 6 layers. That's 3 more than were already in the base image. We
+can squash these 3 into an image with one additional layer relative to the base
+image, and re-tag this new image.
+
+    # docker squash test_build busybox
+    97561533b0fa
+    # docker tag -f 97561533b0fa test_build
+
+Now `test_build` only has a single new layer on top of the original 3 layers
+from `busybox`:
+
+    # docker history test_build
+    IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+    97561533b0fa        2 minutes ago                                                       8.537 MB            
+    8c2e06607696        8 weeks ago         /bin/sh -c #(nop) CMD ["/bin/sh"]               0 B                 
+    6ce2e90b0bc7        8 weeks ago         /bin/sh -c #(nop) ADD file:8cf517d90fe79547c4   2.43 MB             
+    cf2616975b4a        8 weeks ago         /bin/sh -c #(nop) MAINTAINER Jérôme Petazzo     0 B
+
+# HISTORY
+June 2015, Originally compiled by Josh Hawn
+


### PR DESCRIPTION
This patch adds a new CLI command:

```
$ docker squash --help

Usage: docker squash [OPTIONS] IMAGE [ANCESTOR]

Merge filesystem layers of an image into a new image

  --help=false        Print usage
  --no-trunc=false    Don't truncate output
```

Example use cases:
- Consolidating all layer of an image to a new single-layered image.
  
  Let's inspect the history of the `busybox` image.
  
  ```
  $ docker history busybox
  IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
  8c2e06607696        8 weeks ago         /bin/sh -c #(nop) CMD ["/bin/sh"]               0 B                 
  6ce2e90b0bc7        8 weeks ago         /bin/sh -c #(nop) ADD file:8cf517d90fe79547c4   2.43 MB             
  cf2616975b4a        8 weeks ago         /bin/sh -c #(nop) MAINTAINER Jérôme Petazzo     0 B
  ```
  
  It has 3 layers total, but we can now `squash` it and tag it as something else.
  
  ```
  $ docker squash --tag better_busybox busybox
  ccbe958582b2
  ```
  
  Now we have these 2 images.
  
  ```
  $ docker images
  REPOSITORY          TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
  better_busybox      latest              ccbe958582b2        About a minute ago   2.43 MB
  busybox             latest              8c2e06607696        8 weeks ago          2.43 MB
  ```
  
  But `better_busybox` only has a single layer in its history.
  
  ```
  $ docker history better_busybox
  IMAGE               CREATED              CREATED BY          SIZE                COMMENT
  ccbe958582b2        About a minute ago                       2.43 MB 
  ```
- Merging layers of a newly built image into a single layer relative to the base image.
  
  Let's build an image using this Dockerfile:
  
  ``` Dockerfile
  FROM busybox:latest
  
  MAINTAINER Josh Hawn <josh.hawn@docker.com>
  
  ADD docker/docs /docs
  RUN echo hello > /hello.txt
  ```
  
  ```
  $ docker build -t test_build .
  Sending build context to Docker daemon 93.87 MB
  Step 0 : FROM busybox:latest
   ---> 8c2e06607696
  Step 1 : MAINTAINER Josh Hawn <josh.hawn@docker.com>
   ---> Running in 0c2b29e087d5
   ---> 4ac4b75a88f6
  Removing intermediate container 0c2b29e087d5
  Step 2 : ADD docker/docs /docs
   ---> c9e50d91bc69
  Removing intermediate container ad9e921d943f
  Step 3 : RUN echo hello > /hello.txt
   ---> Running in e15283387c37
   ---> 49644b91f444
  Removing intermediate container e15283387c37
  Successfully built 49644b91f444
  ```
  
  And inspect the history of this new image:
  
  ```
  $ docker history test_build
  IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
  49644b91f444        24 minutes ago      /bin/sh -c echo hello > /hello.txt              6 B                 
  c9e50d91bc69        24 minutes ago      /bin/sh -c #(nop) ADD dir:24ae8a736955084e39d   8.537 MB            
  4ac4b75a88f6        24 minutes ago      /bin/sh -c #(nop) MAINTAINER Josh Hawn <josh.   0 B                 
  8c2e06607696        8 weeks ago         /bin/sh -c #(nop) CMD ["/bin/sh"]               0 B                 
  6ce2e90b0bc7        8 weeks ago         /bin/sh -c #(nop) ADD file:8cf517d90fe79547c4   2.43 MB             
  cf2616975b4a        8 weeks ago         /bin/sh -c #(nop) MAINTAINER Jérôme Petazzo     0 B
  ```
  
  See that it has 6 layers. That's 3 more than were already in the base image. We can squash these 3 into an image with one additional layer relative to the base image, and re-tag this new image.
  
  ```
  $ docker squash --tag test_build test_build busybox
  ```
  
  Now `test_build` only has a single new layer on top of the original 3 layers from `busybox`:
  
  ```
  $ docker history test_build
  IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
  97561533b0fa        2 minutes ago                                                       8.537 MB            
  8c2e06607696        8 weeks ago         /bin/sh -c #(nop) CMD ["/bin/sh"]               0 B                 
  6ce2e90b0bc7        8 weeks ago         /bin/sh -c #(nop) ADD file:8cf517d90fe79547c4   2.43 MB             
  cf2616975b4a        8 weeks ago         /bin/sh -c #(nop) MAINTAINER Jérôme Petazzo     0 B
  ```
