### PR TITLE
libcontainer: handle SYS_setns not existing but __NR_setns does.

### DIFF
--- a/vendor/src/github.com/docker/libcontainer/nsenter/nsexec.c
+++ b/vendor/src/github.com/docker/libcontainer/nsenter/nsexec.c
@@ -40,6 +40,9 @@ static int child_func(void *_arg)
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 14
 #define _GNU_SOURCE
 #include "syscall.h"
+#if defined(__NR_setns) && !defined(SYS_setns)
+#define SYS_setns __NR_setns
+#endif
 #ifdef SYS_setns
 int setns(int fd, int nstype)
 {


### PR DESCRIPTION
On some older Fedora distros `SYS_setns` was not defined, but `__NR_setns` is a usable replacement.
