### PR TITLE
Check Linux kernel version >= 3.10 [#13618]

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -91,6 +91,12 @@ func main() {
 	}
 
 	if *flDaemon {
+		// Check if the kernel version is supported for the daemon (GNU/Linux)
+		if ok, version := checkKernelVersion(); !ok {
+			fmt.Fprintf(os.Stderr, "The kernel version '%v' is not supported by Docker", version)
+			os.Exit(1)
+		}
+
 		if *flHelp {
 			flag.Usage()
 			return

--- a/docker/kernelcheck_linux.go
+++ b/docker/kernelcheck_linux.go
@@ -1,0 +1,20 @@
+// +build linux,!nokernelcheck
+
+package main
+
+import (
+	"github.com/docker/docker/pkg/parsers/kernel"
+)
+
+const (
+	MajorVersion = 3
+	MinorVersion = 10
+)
+
+func checkKernelVersion() (bool, *kernel.KernelVersionInfo) {
+	kernelVersion, _ := kernel.GetKernelVersion()
+
+	isValid := kernelVersion.Major >= MajorVersion && kernelVersion.Minor >= MinorVersion
+
+	return isValid, kernelVersion
+}

--- a/docker/nokernelcheck.go
+++ b/docker/nokernelcheck.go
@@ -1,0 +1,8 @@
+// +build nokernelcheck !linux
+
+package main
+
+// Do not check the kernel version, always return true
+func checkKernelVersion() (bool, string) {
+	return true, ""
+}

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -93,6 +93,10 @@ if [ ! "$GOPATH" ]; then
 	exit 1
 fi
 
+if [ "$NOKERNELCHECK" ]; then
+        DOCKER_BUILDTAGS+=" nokernelcheck"
+fi
+
 if [ "$DOCKER_EXPERIMENTAL" ]; then
 	echo >&2 '# WARNING! DOCKER_EXPERIMENTAL is set: building experimental features'
 	echo >&2


### PR DESCRIPTION
Should fix #13618 according to @unclejack [comment](https://github.com/docker/docker/issues/13618#issuecomment-107247798).
- Add a build flag `nokernelcheck` for disabling the check (useful for
  CentOS/RHEL 6 for example).
- The check is done only for the daemon part, in the "main".
- First time I fiddle around the `buildflags` ; and I'm not sure the name of file I choosed are right.
- Wasn't sure how to provide tests on this :cry:.
- Should probably add documentation, right ?
- Should probably do something upstream (for Centos/RHEL6) too, right ?

:wink: 🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
