### PR TITLE
docker/daemon: set umask to the default on startup

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -91,6 +91,10 @@ func mainDaemon() {
 
 	logrus.SetFormatter(&logrus.TextFormatter{TimestampFormat: timeutils.RFC3339NanoFixed})
 
+	if err := setDefaultUmask(); err != nil {
+		logrus.Fatalf("Failed to set umask: %v", err)
+	}
+
 	var pfile *pidfile.PidFile
 	if daemonCfg.Pidfile != "" {
 		pf, err := pidfile.New(daemonCfg.Pidfile)

--- a/docker/daemon_unix.go
+++ b/docker/daemon_unix.go
@@ -3,7 +3,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"syscall"
 
 	apiserver "github.com/docker/docker/api/server"
 	"github.com/docker/docker/daemon"
@@ -27,4 +29,16 @@ func currentUserIsOwner(f string) bool {
 		}
 	}
 	return false
+}
+
+// setDefaultUmask sets the umask to 0022 to avoid problems
+// caused by custom umask
+func setDefaultUmask() error {
+	desiredUmask := 0022
+	syscall.Umask(desiredUmask)
+	if umask := syscall.Umask(desiredUmask); umask != desiredUmask {
+		return fmt.Errorf("failed to set umask: expected %#o, got %#o", desiredUmask, umask)
+	}
+
+	return nil
 }

--- a/docker/daemon_windows.go
+++ b/docker/daemon_windows.go
@@ -16,3 +16,8 @@ func setPlatformServerConfig(serverConfig *apiserver.ServerConfig, daemonCfg *da
 func currentUserIsOwner(f string) bool {
 	return false
 }
+
+// setDefaultUmask doesn't do anything on windows
+func setDefaultUmask() error {
+	return nil
+}


### PR DESCRIPTION
This sets up the umask so that it's the same on all systems.

Fixes #12745
Fixes #13823
