### PR TITLE
Store layer digests on pull

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -654,6 +654,10 @@ func (s *TagStore) pullV2Tag(r *registry.Session, out io.Writer, endpoint *regis
 					return false, err
 				}
 
+				if err := s.graph.SetDigest(d.img.ID, d.digest); err != nil {
+					return false, err
+				}
+
 				// FIXME: Pool release here for parallel tag pull (ensures any downloads block until fully extracted)
 			}
 			out.Write(sf.FormatProgress(stringid.TruncateID(d.img.ID), "Pull complete", nil))


### PR DESCRIPTION
Currently digests are not stored on pull, causing a simple re-tag or re-push to send up all layers. Storing the digests on pull will allow subsequent pushes to the same repository to not push up content.

This does not address pushing content to a new repository. When content is pushed to a new repository, the digest will be recalculated. Since only one digest is currently stored, it may cause a new content push to the original repository.

Fixes #13883 
