### PR TITLE
Picking up missed out vendor files via hack/vendor.sh

### DIFF
--- a/vendor/src/github.com/Sirupsen/logrus/README.md
+++ b/vendor/src/github.com/Sirupsen/logrus/README.md
@@ -324,7 +324,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 
 #### Logger as an `io.Writer`
 
-Logrus can be transformed into an `io.Writer`. That writer is the end of an `io.Pipe` and it is your responsibility to close it.
+Logrus can be transormed into an `io.Writer`. That writer is the end of an `io.Pipe` and it is your responsibility to close it.
 
 ```go
 w := logger.Writer()

--- a/vendor/src/github.com/docker/libcontainer/CONTRIBUTING.md
+++ b/vendor/src/github.com/docker/libcontainer/CONTRIBUTING.md
@@ -24,21 +24,21 @@ The following packages are required to compile libcontainer natively.
 - git
 - cgutils
 
-You can develop on OS X, but you are limited to Dockerfile-based builds only.
+You can develop on OSX, but you are limited to Dockerfile-based builds only.
 
 ### Building libcontainer from Dockerfile
 
     make all
 
 This is the easiest way of building libcontainer.
-As this build is done using Docker, you can even run this from [OS X](https://github.com/boot2docker/boot2docker)
+As this build is done using Docker, you can even run this from [OSX](https://github.com/boot2docker/boot2docker)
 
 ### Testing changes with "nsinit"
 
     make sh
 
 This will create an container that runs `nsinit exec sh` on a busybox rootfs with the configuration from ['minimal.json'](https://github.com/docker/libcontainer/blob/master/sample_configs/minimal.json).
-Like the previous command, you can run this on OS X too!
+Like the previous command, you can run this on OSX too!
 
 ### Building libcontainer directly
 

--- a/vendor/src/github.com/docker/libcontainer/ROADMAP.md
+++ b/vendor/src/github.com/docker/libcontainer/ROADMAP.md
@@ -3,7 +3,7 @@
 This document is a high-level overview of where we want to take libcontainer next.
 It is a curated selection of planned improvements which are either important, difficult, or both.
 
-For a more complete view of planned and requested improvements, see [the GitHub issues](https://github.com/docker/libcontainer/issues).
+For a more complete view of planned and requested improvements, see [the Github issues](https://github.com/docker/libcontainer/issues).
 
 To suggest changes to the roadmap, including additions, please write the change as if it were already in effect, and make a pull request.
 

--- a/vendor/src/github.com/docker/libcontainer/SPEC.md
+++ b/vendor/src/github.com/docker/libcontainer/SPEC.md
@@ -60,7 +60,7 @@ are required to be mounted within the rootfs that the runtime will setup.
 After a container's filesystems are mounted within the newly created 
 mount namespace `/dev` will need to be populated with a set of device nodes.
 It is expected that a rootfs does not need to have any device nodes specified
-for `/dev` within the rootfs as the container will setup the correct devices
+for `/dev` witin the rootfs as the container will setup the correct devices
 that are required for executing a container's process.
 
 |      Path    | Mode |   Access   |

--- a/vendor/src/github.com/docker/libcontainer/console_linux.go
+++ b/vendor/src/github.com/docker/libcontainer/console_linux.go
@@ -44,7 +44,7 @@ func newConsoleFromPath(slavePath string) *linuxConsole {
 	}
 }
 
-// linuxConsole is a linux pseudo TTY for use within a container.
+// linuxConsole is a linux psuedo TTY for use within a container.
 type linuxConsole struct {
 	master    *os.File
 	slavePath string

--- a/vendor/src/github.com/docker/libcontainer/nsenter/README.md
+++ b/vendor/src/github.com/docker/libcontainer/nsenter/README.md
@@ -18,7 +18,7 @@ which will give the process of the container that should be joined. Namespaces f
 be found from `/proc/[pid]/ns` and set by `setns` syscall.
 
 And then get the pipe number from `_LIBCONTAINER_INITPIPE`, error message could
-be transferred through it. If tty is added, `_LIBCONTAINER_CONSOLE_PATH` will 
+be transfered through it. If tty is added, `_LIBCONTAINER_CONSOLE_PATH` will 
 have value and start a console for output.
 
 Finally, `nsexec()` will clone a child process , exit the parent process and let 

--- a/vendor/src/github.com/docker/libtrust/util.go
+++ b/vendor/src/github.com/docker/libtrust/util.go
@@ -16,7 +16,7 @@ import (
 )
 
 // joseBase64UrlEncode encodes the given data using the standard base64 url
-// encoding format but with all trailing '=' characters omitted in accordance
+// encoding format but with all trailing '=' characters ommitted in accordance
 // with the jose specification.
 // http://tools.ietf.org/html/draft-ietf-jose-json-web-signature-31#section-2
 func joseBase64UrlEncode(b []byte) string {

--- a/vendor/src/github.com/mistifyio/go-zfs/CONTRIBUTING.md
+++ b/vendor/src/github.com/mistifyio/go-zfs/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We always welcome contributions to help make `go-zfs` better. Please take a mome
 
 ### Reporting issues ###
 
-We use [GitHub issues](https://github.com/mistifyio/go-zfs/issues) to track bug reports, feature requests, and submitting pull requests.
+We use [Github issues](https://github.com/mistifyio/go-zfs/issues) to track bug reports, feature requests, and submitting pull requests.
 
 If you find a bug:
 

--- a/vendor/src/github.com/mistifyio/go-zfs/README.md
+++ b/vendor/src/github.com/mistifyio/go-zfs/README.md
@@ -29,7 +29,7 @@ The tests have decent examples for most functions.
 
 ```go
 //assuming a zpool named test
-//error handling omitted
+//error handling ommitted
 
 
 f, err := zfs.CreateFilesystem("test/snapshot-test", nil)

--- a/vendor/src/github.com/vishvananda/netlink/README.md
+++ b/vendor/src/github.com/vishvananda/netlink/README.md
@@ -8,7 +8,7 @@ the kernel. It can be used to add and remove interfaces, set ip addresses
 and routes, and configure ipsec. Netlink communication requires elevated
 privileges, so in most cases this code needs to be run as root. Since
 low-level netlink messages are inscrutable at best, the library attempts
-to provide an api that is loosely modeled on the CLI provided by iproute2.
+to provide an api that is loosely modeled on the CLI provied by iproute2.
 Actions like `ip link add` will be accomplished via a similarly named
 function like AddLink(). This library began its life as a fork of the
 netlink functionality in

--- a/vendor/src/github.com/vishvananda/netns/README.md
+++ b/vendor/src/github.com/vishvananda/netns/README.md
@@ -38,7 +38,7 @@ func main() {
     newns, _ := netns.New()
     defer newns.Close()
 
-    // Do something with the network namespace
+    // Do something with tne network namespace
     ifaces, _ := net.Interfaces()
     fmt.Printf("Interfaces: %v\n", ifaces)
 


### PR DESCRIPTION
while working on another PR, I noticed that hack/vendor.sh was picking
up unrelated files. Maybe a previous update to the hack/vendor.sh failed
to run the script and push the vendor changes ?

All of them seem to be typo changes....

Signed-off-by: Madhu Venugopal madhu@docker.com
