### PR TITLE
Get Mtu from default route

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -36,6 +36,7 @@ import (
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/trust"
+	"github.com/docker/libcontainer/netlink"
 	"github.com/docker/libnetwork"
 )
 
@@ -589,6 +590,8 @@ func (daemon *Daemon) RegisterLinks(container *Container, hostConfig *runconfig.
 }
 
 func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemon, err error) {
+	setDefaultMtu(config)
+
 	// Ensure we have compatible configuration options
 	if err := checkConfigOptions(config); err != nil {
 		return nil, err
@@ -980,4 +983,31 @@ func (daemon *Daemon) newBaseContainer(id string) CommonContainer {
 		execCommands: newExecStore(),
 		root:         daemon.containerRoot(id),
 	}
+}
+
+func setDefaultMtu(config *Config) {
+	// do nothing if the config does not have the default 0 value.
+	if config.Mtu != 0 {
+		return
+	}
+	config.Mtu = defaultNetworkMtu
+	if routeMtu, err := getDefaultRouteMtu(); err == nil {
+		config.Mtu = routeMtu
+	}
+}
+
+var errNoDefaultRoute = errors.New("no default route was found")
+
+// getDefaultRouteMtu returns the MTU for the default route's interface.
+func getDefaultRouteMtu() (int, error) {
+	routes, err := netlink.NetworkGetRoutes()
+	if err != nil {
+		return 0, err
+	}
+	for _, r := range routes {
+		if r.Default {
+			return r.Iface.MTU, nil
+		}
+	}
+	return 0, errNoDefaultRoute
 }


### PR DESCRIPTION
If no Mtu value is provided to the docker daemon, get the mtu from the
default route's interface.  If there is no default route, default to a
mtu of 1500.

Fixes #13952

Testing:

``` bash
root@c26c83e35d24:/go/src/github.com/docker/docker# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default 
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
36: eth0: <BROADCAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default 
    link/ether 02:42:65:1b:b8:78 brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.2/16 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::42:65ff:fe1b:b878/64 scope link 
       valid_lft forever preferred_lft forever
root@c26c83e35d24:/go/src/github.com/docker/docker# ip link set mtu 1460 eth0
root@c26c83e35d24:/go/src/github.com/docker/docker# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default 
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
36: eth0: <BROADCAST,UP,LOWER_UP> mtu 1460 qdisc noqueue state UP group default 
    link/ether 02:42:65:1b:b8:78 brd ff:ff:ff:ff:ff:ff
    inet 172.17.0.2/16 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::42:65ff:fe1b:b878/64 scope link 
       valid_lft forever preferred_lft forever
root@c26c83e35d24:/go/src/github.com/docker/docker# docker -d -s vfs &

root@c26c83e35d24:/go/src/github.com/docker/docker# docker pull busybox
root@c26c83e35d24:/go/src/github.com/docker/docker# docker run busybox ifconfig
eth0      Link encap:Ethernet  HWaddr 02:42:AC:12:2A:03  
          inet addr:172.18.42.3  Bcast:0.0.0.0  Mask:255.255.255.0
          UP BROADCAST  MTU:1460  Metric:1
          RX packets:1 errors:0 dropped:0 overruns:0 frame:0
          TX packets:2 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0 
          RX bytes:90 (90.0 B)  TX bytes:180 (180.0 B)
```

Signed-off-by: Michael Crosby crosbymichael@gmail.com
