### PR TITLE
Fix circular import for windows vfs graphdriver

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/daemon/execdriver/execdrivers"
 	"github.com/docker/docker/daemon/graphdriver"
+	_ "github.com/docker/docker/daemon/graphdriver/vfs"
 	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/graph"

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/autogen/dockerversion"
 	"github.com/docker/docker/daemon/graphdriver"
-	_ "github.com/docker/docker/daemon/graphdriver/vfs"
 	"github.com/docker/docker/graph"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/fileutils"

--- a/daemon/graphdriver/driver_windows.go
+++ b/daemon/graphdriver/driver_windows.go
@@ -1,11 +1,5 @@
 package graphdriver
 
-import (
-	_ "github.com/docker/docker/daemon/graphdriver/vfs"
-
-	// TODO Windows - Add references to real graph driver when PR'd
-)
-
 type DiffDiskDriver interface {
 	Driver
 	CopyDiff(id, sourceId string) error


### PR DESCRIPTION
Not sure how #13494 passed tests, but it caused a circular import from graphdriver->vfs->graphdriver.
