### PR TITLE
Fix DOCKER_TLS_VERIFY being ignored

### DIFF
--- a/docker/docker.go
+++ b/docker/docker.go
@@ -86,7 +86,8 @@ func main() {
 
 	// Regardless of whether the user sets it to true or false, if they
 	// specify --tlsverify at all then we need to turn on tls
-	if flag.IsSet("-tlsverify") {
+	// *flTlsVerify can be true even if not set due to DOCKER_TLS_VERIFY env var, so we need to check that here as well
+	if flag.IsSet("-tlsverify") || *flTlsVerify {
 		*flTls = true
 	}
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1264,3 +1264,14 @@ func (s *DockerDaemonSuite) TestDaemonRestartCleanupNetns(c *check.C) {
 	c.Assert(err, check.Not(check.IsNil), check.Commentf("Output: %s", out))
 	// c.Assert(out, check.Equals, "", check.Commentf("Output: %s", out))
 }
+
+// tests regression detailed in #13964 where DOCKER_TLS_VERIFY env is ignored
+func (s *DockerDaemonSuite) TestDaemonNoTlsCliTlsVerifyWithEnv(c *check.C) {
+	host := "tcp://localhost:4271"
+	c.Assert(s.d.Start("-H", host), check.IsNil)
+	cmd := exec.Command(dockerBinary, "-H", host, "info")
+	cmd.Env = []string{"DOCKER_TLS_VERIFY=1", "DOCKER_CERT_PATH=fixtures/https"}
+	out, _, err := runCommandWithOutput(cmd)
+	c.Assert(err, check.Not(check.IsNil), check.Commentf("%s", out))
+	c.Assert(strings.Contains(out, "error occurred trying to connect"), check.Equals, true)
+}


### PR DESCRIPTION
DOCEKR_TLS_VERIFY was being ignored because we were just checking if the
`-tlsverify` flag was set, not the actual value, which is defaulted to
the value of `os.Getenv("DOCKER_TLS_VERIFY") != ""`

The problem that this specifically fixes is where the client has set the
`DOCKER_TLS_VERIFY` env var but is connecting to a daemon that is not
verifed.

Closes #13964
