### PR TITLE
Move zfs options doc to the storage section.

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -474,8 +474,6 @@ Currently supported options of `devicemapper`:
     > Otherwise, set this flag for migrating existing Docker daemons to
     > a daemon with a supported environment.
 
-### Docker execdriver option
-
 Currently supported options of `zfs`:
 
  * `zfs.fsname`
@@ -487,6 +485,8 @@ Currently supported options of `zfs`:
     Example use:
 
         $ docker -d -s zfs --storage-opt zfs.fsname=zroot/docker
+
+### Docker execdriver option
 
 The Docker daemon uses a specifically built `libcontainer` execution driver as
 its interface to the Linux kernel `namespaces`, `cgroups`, and `SELinux`.


### PR DESCRIPTION
Zfs options belong to the storage section, but they were added under the exec driver section.

Signed-off-by: David Calavera david.calavera@gmail.com
