### PR TITLE
Display problem while failing to load nf_nat module

### DIFF
--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/Sirupsen/logrus"
@@ -107,8 +108,8 @@ func newDriver() driverapi.Driver {
 func Init(dc driverapi.DriverCallback) error {
 	// try to modprobe bridge first
 	// see gh#12177
-	if out, err := exec.Command("modprobe", "-va", "bridge", "nf_nat", "br_netfilter").Output(); err != nil {
-		logrus.Warnf("Running modprobe bridge nf_nat failed with message: %s, error: %v", out, err)
+	if out, err := exec.Command("modprobe", "-va", "bridge", "nf_nat", "br_netfilter").CombinedOutput(); err != nil {
+		logrus.Warnf("Running modprobe bridge nf_nat failed with message: `%s`, error: %v", strings.TrimSpace(string(out)), err)
 	}
 	c := driverapi.Capability{
 		Scope: driverapi.LocalScope,


### PR DESCRIPTION
As modprobe uses stderr for failure details, Output(), that only reads stdout, should be replaced by CombinedOutput(), that reads stdout and stderr.

See issue #13967.
