### PR TITLE
prompt a cli login if receive 401 from registry v2 auth server

### DIFF
--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -132,6 +132,7 @@ func (cli *DockerCli) clientRequestAttemptLogin(method, path string, in io.Reade
 			// we may need to change the status code.
 			if strings.Contains(err.Error(), "Authentication is required") ||
 				strings.Contains(err.Error(), "Status 401") ||
+				strings.Contains(err.Error(), "401 Unauthorized") ||
 				strings.Contains(err.Error(), "status code 401") {
 				statusCode = http.StatusUnauthorized
 			}


### PR DESCRIPTION
Docker should prompt to do a login if not yet login with auth server (registry v2) fix #13925 

Signed-off-by: tgic farmer1992@gmail.com
