### PR TITLE
Update docker commit man page re: volumes

### DIFF
--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -25,6 +25,9 @@ image. This allows you debug a container by running an interactive shell, or to
 export a working dataset to another server. Generally, it is better to use
 Dockerfiles to manage your images in a documented and maintainable way.
 
+The commit operation will not include any data contained in
+volumes mounted inside the container.
+
 By default, the container being committed and its processes will be paused
 while the image is committed. This reduces the likelihood of encountering data
 corruption during the process of creating the commit.  If this behavior is

--- a/man/docker-commit.1.md
+++ b/man/docker-commit.1.md
@@ -14,7 +14,14 @@ docker-commit - Create a new image from a container's changes
 CONTAINER [REPOSITORY[:TAG]]
 
 # DESCRIPTION
-Using an existing container's name or ID you can create a new image.
+Create a new image from an existing container specified by name or
+container ID.  The new image will contain the contents of the
+container filesystem, *excluding* any data volumes.
+
+While the `docker commit` command is a convenient way of extending an
+existing image, you should prefer the use of a Dockerfile and `docker
+build` for generating images that you intend to share with other
+people.
 
 # OPTIONS
 **-a**, **--author**=""


### PR DESCRIPTION
Update the man page for 'docker commit' to make explicit the fact that
'commit' does not save data in volumes.

Addresses comments in #7583

Signed-off-by: Lars Kellogg-Stedman lars@redhat.com
