### PR TITLE
Add a client-daemon authentication framework

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -52,6 +52,8 @@ type DockerCli struct {
 	isTerminalOut bool
 	// transport holds the client transport instance.
 	transport *http.Transport
+	// authResponders provide ways to authenticate to servers
+	authResponders *map[string]*[]AuthResponder
 }
 
 var funcMap = template.FuncMap{
@@ -217,20 +219,23 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, keyFile string, proto, a
 		fmt.Fprintf(err, "WARNING: Error loading config file:%v\n", e)
 	}
 
+	authResponders := createAuthResponders()
+
 	return &DockerCli{
-		proto:         proto,
-		addr:          addr,
-		configFile:    configFile,
-		in:            in,
-		out:           out,
-		err:           err,
-		keyFile:       keyFile,
-		inFd:          inFd,
-		outFd:         outFd,
-		isTerminalIn:  isTerminalIn,
-		isTerminalOut: isTerminalOut,
-		tlsConfig:     tlsConfig,
-		scheme:        scheme,
-		transport:     tr,
+		proto:          proto,
+		addr:           addr,
+		configFile:     configFile,
+		in:             in,
+		out:            out,
+		err:            err,
+		keyFile:        keyFile,
+		inFd:           inFd,
+		outFd:          outFd,
+		isTerminalIn:   isTerminalIn,
+		isTerminalOut:  isTerminalOut,
+		tlsConfig:      tlsConfig,
+		scheme:         scheme,
+		transport:      tr,
+		authResponders: &authResponders,
 	}
 }

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -29,14 +29,59 @@ import (
 	"github.com/docker/docker/registry"
 )
 
+// AuthResponder is an interface that wraps the Scheme and AuthRespond methods.
+//
+// At initialization time, an implementation of AuthResponder should register
+// itself by calling RegisterAuthResponder.
+type AuthResponder interface {
+	// Scheme should return the name of the authorization scheme for which
+	// the responder should be called.
+	Scheme() string
+	// AuthRespond, given the authentication header value associated with
+	// the scheme that it implements, can decide if the request should be
+	// retried.  If it returns true, then the request is retransmitted to
+	// the server, presumably because it has added an authentication header
+	// which it believes the server will accept.
+	AuthRespond(cli *DockerCli, challenge string, req *http.Request) (bool, error)
+}
+
+// AuthResponderCreator either creates a new AuthResponder, or returns nil
+type AuthResponderCreator func() AuthResponder
+
 var (
-	errConnectionRefused = errors.New("Cannot connect to the Docker daemon. Is 'docker -d' running on this host?")
+	authResponderCreators = []AuthResponderCreator{}
+	errConnectionRefused  = errors.New("Cannot connect to the Docker daemon. Is 'docker -d' running on this host?")
 )
 
 type serverResponse struct {
 	body       io.ReadCloser
 	header     http.Header
 	statusCode int
+}
+
+// RegisterAuthResponder registers a function which will be called at startup
+// to create an AuthResponder.
+func RegisterAuthResponder(arc AuthResponderCreator) {
+	authResponderCreators = append(authResponderCreators, arc)
+}
+
+// Run through all of the registered responder creators and build a map of
+// lists of responders.
+func createAuthResponders() map[string]*[]AuthResponder {
+	ars := make(map[string]*[]AuthResponder)
+	for _, arc := range authResponderCreators {
+		responder := arc()
+		if responder != nil {
+			scheme := responder.Scheme()
+			if ars[scheme] != nil {
+				slice := append(*(ars[scheme]), responder)
+				ars[scheme] = &slice
+			} else {
+				ars[scheme] = &[]AuthResponder{responder}
+			}
+		}
+	}
+	return ars
 }
 
 // HTTPClient creates a new HTTP client with the cli's client transport instance.
@@ -52,6 +97,45 @@ func (cli *DockerCli) encodeData(data interface{}) (*bytes.Buffer, error) {
 		}
 	}
 	return params, nil
+}
+
+// sendHTTPRequest transmits the passed-in request using HTTPClient.Do.  If the
+// server's response indicates that the server requires that the client
+// authenticate, it calls the corresponding authenticator, and if it produces
+// data, retransmits the request.
+func (cli *DockerCli) sendHTTPRequest(req *http.Request) (*http.Response, error) {
+	retryWithUpdatedAuthn := false
+	resp, err := cli.HTTPClient().Do(req)
+	if err == nil && resp.StatusCode == 401 {
+		ah := resp.Header[http.CanonicalHeaderKey("WWW-Authenticate")]
+		for _, challenge := range ah {
+			tokens := strings.Split(strings.Replace(challenge, "\t", " ", -1), " ")
+			responders := (*cli.authResponders)[tokens[0]]
+			if responders != nil {
+				for _, responder := range *responders {
+					retryWithUpdatedAuthn, err = responder.AuthRespond(cli, challenge, req)
+					if retryWithUpdatedAuthn {
+						logrus.Debugf("handler for \"%s\" produced data", tokens[0])
+						break
+					} else {
+						logrus.Debugf("handler for \"%s\" failed to produce data", tokens[0])
+					}
+				}
+			} else {
+				logrus.Debugf("no handler for \"%s\"", tokens[0])
+			}
+		}
+		if len(ah) == 0 {
+			err = fmt.Errorf("No authenticators available.")
+		} else if err != nil {
+			err = fmt.Errorf("%v. Unable to authenticate to docker daemon.", err)
+		} else if !retryWithUpdatedAuthn {
+			err = fmt.Errorf("Unable to authenticate to docker daemon.")
+		} else {
+			resp, err = cli.HTTPClient().Do(req)
+		}
+	}
+	return resp, err
 }
 
 func (cli *DockerCli) clientRequest(method, path string, in io.Reader, headers map[string][]string) (*serverResponse, error) {
@@ -90,7 +174,7 @@ func (cli *DockerCli) clientRequest(method, path string, in io.Reader, headers m
 		req.Header.Set("Content-Type", "text/plain")
 	}
 
-	resp, err := cli.HTTPClient().Do(req)
+	resp, err := cli.sendHTTPRequest(req)
 	if resp != nil {
 		serverResp.statusCode = resp.StatusCode
 	}

--- a/api/server/authn.go
+++ b/api/server/authn.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/gorilla/context"
+)
+
+// User represents an authenticated remote user.  We know at least one of the
+// user's name (if not "") and UID (if HaveUid is true), and possibly both.
+type User struct {
+	Name    string
+	HaveUid bool
+	Uid     uint32
+}
+
+type contextKey int
+
+// AuthnUser is the key to use with context.Get() to retrieve an http.Request's
+// authenticated user, if the user was authenticated, like so:
+//   import "github.com/gorilla/context"
+//   user, authed = context.Get(r, server.AuthnUser).(server.User)
+const AuthnUser contextKey = iota
+
+// Authenticator is an interface that wraps the GetChallenge and CheckResponse
+// methods, which are implemented for each accepted authentication scheme.
+//
+// At initialization time, an implementation of Authenticator should register
+// itself by calling the RegisterAuthenticator function.
+//
+// If authentication is not required, Authenticator methods will not be called.
+type Authenticator interface {
+	// If an incoming request includes an authorization header, each
+	// authenticator's CheckResponse method will be called to verify it in turn.
+	// If any returns an error, then authentication has failed.  If any returns a
+	// User, then authentication has succeeded.  If none return a usable User, then
+	// authentication has failed.
+	GetChallenge(w http.ResponseWriter, r *http.Request) error
+	// If there is no authorization header in the request, each authenticator's
+	// GetChallenge method will be called to add a suitable challenge header to the
+	// not-authorized response.  If any returns an error, then an error will be
+	// sent to the client.
+	CheckResponse(w http.ResponseWriter, r *http.Request) (User, error)
+}
+
+// AuthenticatorCreator either creates a new Authenticator, or returns nil
+type AuthenticatorCreater func(options ServerAuthOptions) Authenticator
+
+var authenticatorCreaters = []AuthenticatorCreater{}
+
+// RegisterAuthenticator registers a function which will be called at startup
+// to create an Authenticator.
+func RegisterAuthenticator(ac AuthenticatorCreater) {
+	authenticatorCreaters = append(authenticatorCreaters, ac)
+}
+
+// Run through all of the registered authenticator callback creators and build
+// a list of authenticating functions.
+func createAuthenticators(c *ServerConfig) []Authenticator {
+	authenticators := []Authenticator{}
+	for _, ac := range authenticatorCreaters {
+		authenticator := ac(c.AuthOptions)
+		if authenticator != nil {
+			authenticators = append(authenticators, authenticator)
+		}
+	}
+	return authenticators
+}
+
+func (s *Server) httpAuthenticate(w http.ResponseWriter, r *http.Request, options ServerAuthOptions) (User, error) {
+	err401 := errors.New("wrong login/password")
+	if len(s.authenticators) == 0 {
+		return User{}, errors.New("authentication of clients is required but not supported")
+	}
+	for _, auther := range s.authenticators {
+		if len(r.Header["Authorization"]) == 0 {
+			err := auther.GetChallenge(w, r)
+			if err != nil {
+				return User{}, err
+			}
+		} else {
+			user, err := auther.CheckResponse(w, r)
+			if err != nil {
+				return User{}, err
+			}
+			if user.Name != "" || user.HaveUid {
+				context.Set(r, AuthnUser, user)
+				return user, nil
+			}
+		}
+	}
+	if len(r.Header["Authorization"]) == 0 {
+		logrus.Info("rejecting unauthenticated request")
+	} else {
+		logrus.Error("authentication failed for request")
+	}
+	return User{}, err401
+}

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -115,6 +115,8 @@ func mainDaemon() {
 	}
 	serverConfig = setPlatformServerConfig(serverConfig, daemonCfg)
 
+	serverConfig.AuthOptions.RequireAuthn = *flRequireAuthn
+
 	if *flTls {
 		if *flTlsVerify {
 			tlsOptions.ClientAuth = tls.RequireAndVerifyClientCert

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -25,8 +25,9 @@ func (a byName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a byName) Less(i, j int) bool { return a[i].name < a[j].name }
 
 var (
-	dockerCertPath  = os.Getenv("DOCKER_CERT_PATH")
-	dockerTlsVerify = os.Getenv("DOCKER_TLS_VERIFY") != ""
+	dockerCertPath     = os.Getenv("DOCKER_CERT_PATH")
+	dockerTlsVerify    = os.Getenv("DOCKER_TLS_VERIFY") != ""
+	dockerRequireAuthn = false
 
 	dockerCommands = []command{
 		{"attach", "Attach to a running container"},
@@ -86,13 +87,14 @@ func getDaemonConfDir() string {
 }
 
 var (
-	flVersion   = flag.Bool([]string{"v", "-version"}, false, "Print version information and quit")
-	flDaemon    = flag.Bool([]string{"d", "-daemon"}, false, "Enable daemon mode")
-	flDebug     = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
-	flLogLevel  = flag.String([]string{"l", "-log-level"}, "info", "Set the logging level")
-	flTls       = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by --tlsverify")
-	flHelp      = flag.Bool([]string{"h", "-help"}, false, "Print usage")
-	flTlsVerify = flag.Bool([]string{"-tlsverify"}, dockerTlsVerify, "Use TLS and verify the remote")
+	flVersion      = flag.Bool([]string{"v", "-version"}, false, "Print version information and quit")
+	flDaemon       = flag.Bool([]string{"d", "-daemon"}, false, "Enable daemon mode")
+	flDebug        = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
+	flLogLevel     = flag.String([]string{"l", "-log-level"}, "info", "Set the logging level")
+	flTls          = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by --tlsverify")
+	flHelp         = flag.Bool([]string{"h", "-help"}, false, "Print usage")
+	flTlsVerify    = flag.Bool([]string{"-tlsverify"}, dockerTlsVerify, "Use TLS and verify the remote")
+	flRequireAuthn = flag.Bool([]string{"a", "-authn"}, dockerRequireAuthn, "Require daemon clients to authenticate")
 
 	// these are initialized in init() below since their default values depend on dockerCertPath which isn't fully initialized until init() runs
 	tlsOptions tlsconfig.Options

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -18,6 +18,13 @@ parent = "smn_remoteapi"
    `curl --insecure --cert ~/.docker/cert.pem --key ~/.docker/key.pem https://boot2docker:2376/images/json`
    or 
    `wget --no-check-certificate --certificate=$DOCKER_CERT_PATH/cert.pem --private-key=$DOCKER_CERT_PATH/key.pem https://boot2docker:2376/images/json -O - -q`
+ - If the Docker daemon is set to require that clients authenticate to it when
+   interacting with it, then you need to add extra parameters to `curl` or
+   `wget` when making test API requests:
+   `curl --basic -u user:password https://dockerhost:2375/images/json`
+   `curl --negotiate -u : https://dockerhost:2376/images/json`
+   or
+   `wget --http-user=user --ask-password https://dockerhost:2376/images/json -O - -q`
  - If a group named `docker` exists on your system, docker will apply
    ownership of the socket to the group.
  - The API tends to be REST, but for some complex commands, like attach

--- a/man/docker.1.md
+++ b/man/docker.1.md
@@ -26,6 +26,9 @@ To see the man page for a command run **man docker <command>**.
 **-h**, **--help**
   Print usage statement
 
+**-a**, **--authn**=*true*|*false*
+  Require clients to authenticate to the docker daemon when issuing requests; the historical default is false
+
 **--api-cors-header**=""
   Set CORS headers in the remote API. Default is cors disabled. Give urls like "http://foo, http://bar, ...". Give "*" to allow all.
 


### PR DESCRIPTION
This patch adds a basic framework for requiring clients to authenticate to the daemon when issuing requests to it.  This is just the plumbing and wiring in the logic in both the client and the server.

The client and server both contain module-local lists of functions which create and return handlers for authentication schemes.  The implementations will be expected to register themselves at initialization time.  On clients, the functions are used to create a set of AuthResponders which is indexed in the client map by the authentication schemes that they implement.  On servers, the functions are used to create a set of Authenticators, each of which gets a crack at every client request.

The client will call the AuthResponders for a particular scheme if it receives a 401 error, and if any of them signal that the client should try again after that AuthResponder has had a chance to modify the request, it will do so.  This is essentially transparent to the caller, though if we need to be able to suppress responders that end up needing to prompt the user for information, that'll have to change.

The server will call either the GetChallenge methods or CheckResponse methods of its Authenticators for each request, depending on whether or not the incoming request includes any authorization headers.  If
CheckResponse indicates that the client's identity has been verified, information about the authenticated user will be added to the request structure as a shared value so that it can be used by handlers.  We use the gorilla/context library to store it so that it can't be mistaken for a value parsed out of the request URI, and because we already use context by way of using gorilla/mux.

Client and server implementations for Basic and Negotiate, and logic to use syscall.GetsockoptUcred on Unixy hosts, has been prototyped on top of this, but unless there's a preference otherwise, I'd like to get the framework API sorted out before dealing with those.
