### PR TITLE
Error out if client API version is too old

### DIFF
--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -138,7 +138,7 @@ func (cli *DockerCli) hijack(method, path string, setRawTerminal bool, in io.Rea
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest(method, fmt.Sprintf("/v%s%s", api.APIVERSION, path), params)
+	req, err := http.NewRequest(method, fmt.Sprintf("/v%s%s", api.Version, path), params)
 	if err != nil {
 		return err
 	}

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -53,7 +53,7 @@ func (cli *DockerCli) clientRequest(method, path string, in io.Reader, headers m
 	if expectedPayload && in == nil {
 		in = bytes.NewReader([]byte{})
 	}
-	req, err := http.NewRequest(method, fmt.Sprintf("/v%s%s", api.APIVERSION, path), in)
+	req, err := http.NewRequest(method, fmt.Sprintf("/v%s%s", api.Version, path), in)
 	if err != nil {
 		return nil, nil, -1, err
 	}

--- a/api/client/version.go
+++ b/api/client/version.go
@@ -26,7 +26,7 @@ func (cli *DockerCli) CmdVersion(args ...string) error {
 	if dockerversion.VERSION != "" {
 		fmt.Fprintf(cli.out, "Client version: %s\n", dockerversion.VERSION)
 	}
-	fmt.Fprintf(cli.out, "Client API version: %s\n", api.APIVERSION)
+	fmt.Fprintf(cli.out, "Client API version: %s\n", api.Version)
 	fmt.Fprintf(cli.out, "Go version (client): %s\n", runtime.Version())
 	if dockerversion.GITCOMMIT != "" {
 		fmt.Fprintf(cli.out, "Git commit (client): %s\n", dockerversion.GITCOMMIT)

--- a/api/common.go
+++ b/api/common.go
@@ -16,8 +16,14 @@ import (
 
 // Common constants for daemon and client.
 const (
-	APIVERSION            version.Version = "1.20"       // Current REST API version
-	DefaultDockerfileName string          = "Dockerfile" // Default filename with Docker commands, read by docker build
+	// Current REST API version
+	Version version.Version = "1.20"
+
+	// Minimun REST API version supported
+	MinVersion version.Version = "1.12"
+
+	// Default filename with Docker commands, read by docker build
+	DefaultDockerfileName string = "Dockerfile"
 )
 
 type ByPrivatePort []types.Port

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -244,7 +244,7 @@ func (s *Server) postAuth(version version.Version, w http.ResponseWriter, r *htt
 func (s *Server) getVersion(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v := &types.Version{
 		Version:    dockerversion.VERSION,
-		ApiVersion: api.APIVERSION,
+		ApiVersion: api.Version,
 		GitCommit:  dockerversion.GITCOMMIT,
 		GoVersion:  runtime.Version(),
 		Os:         runtime.GOOS,
@@ -1477,14 +1477,18 @@ func makeHttpHandler(logging bool, localMethod string, localRoute string, handle
 		}
 		version := version.Version(mux.Vars(r)["version"])
 		if version == "" {
-			version = api.APIVERSION
+			version = api.Version
 		}
 		if corsHeaders != "" {
 			writeCorsHeaders(w, r, corsHeaders)
 		}
 
-		if version.GreaterThan(api.APIVERSION) {
-			http.Error(w, fmt.Errorf("client is newer than server (client API version: %s, server API version: %s)", version, api.APIVERSION).Error(), http.StatusBadRequest)
+		if version.GreaterThan(api.Version) {
+			http.Error(w, fmt.Errorf("client is newer than server (client API version: %s, server API version: %s)", version, api.Version).Error(), http.StatusBadRequest)
+			return
+		}
+		if version.LessThan(api.MinVersion) {
+			http.Error(w, fmt.Errorf("client is too old, minimum supported API version is %s, please upgrade your client to a newer version", api.MinVersion).Error(), http.StatusBadRequest)
 			return
 		}
 


### PR DESCRIPTION
While at it, I've modified api consts against lint errors (will split it out if it's not ok)

Signed-off-by: Antonio Murdaca runcom@linux.com
