### PR TITLE
Check cgroup controllers existence

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -165,6 +165,11 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, 
 		logrus.Warnf("Your kernel does not support CPU cfs quota. Quota discarded.")
 		hostConfig.CpuQuota = 0
 	}
+	if hostConfig.BlkioWeight > 0 && !daemon.SystemConfig().BlkioWeight {
+		warnings = append(warnings, "Your kernel does not support Block I/O weight. Weight discarded.")
+		logrus.Warnf("Your kernel does not support Block I/O weight. Weight discarded.")
+		hostConfig.BlkioWeight = 0
+	}
 	if hostConfig.BlkioWeight > 0 && (hostConfig.BlkioWeight < 10 || hostConfig.BlkioWeight > 1000) {
 		return warnings, fmt.Errorf("Range of blkio weight is from 10 to 1000.")
 	}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -150,6 +150,11 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, 
 	if hostConfig.Memory == 0 && hostConfig.MemorySwap > 0 {
 		return warnings, fmt.Errorf("You should always set the Memory limit when using Memoryswap limit, see usage.")
 	}
+	if hostConfig.CpuShares > 0 && !daemon.SystemConfig().CpuShares {
+		warnings = append(warnings, "Your kernel does not support CPU cfs shares. Shares discarded.")
+		logrus.Warnf("Your kernel does not support CPU cfs shares. Shares discarded.")
+		hostConfig.CpuShares = 0
+	}
 	if hostConfig.CpuPeriod > 0 && !daemon.SystemConfig().CpuCfsPeriod {
 		warnings = append(warnings, "Your kernel does not support CPU cfs period. Period discarded.")
 		logrus.Warnf("Your kernel does not support CPU cfs period. Period discarded.")

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -165,6 +165,12 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, 
 		logrus.Warnf("Your kernel does not support CPU cfs quota. Quota discarded.")
 		hostConfig.CpuQuota = 0
 	}
+	if (hostConfig.CpusetCpus != "" || hostConfig.CpusetMems != "") && !daemon.SystemConfig().Cpuset {
+		warnings = append(warnings, "Your kernel does not support cpuset. Cpuset discarded.")
+		logrus.Warnf("Your kernel does not support cpuset. Cpuset discarded.")
+		hostConfig.CpusetCpus = ""
+		hostConfig.CpusetMems = ""
+	}
 	if hostConfig.BlkioWeight > 0 && !daemon.SystemConfig().BlkioWeight {
 		warnings = append(warnings, "Your kernel does not support Block I/O weight. Weight discarded.")
 		logrus.Warnf("Your kernel does not support Block I/O weight. Weight discarded.")

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -6,6 +6,7 @@ type SysInfo struct {
 	AppArmor bool
 	*cgroupMemInfo
 	*cgroupCpuInfo
+	*cgroupBlkioInfo
 	IPv4ForwardingDisabled        bool
 	BridgeNfCallIptablesDisabled  bool
 	BridgeNfCallIp6tablesDisabled bool
@@ -22,4 +23,8 @@ type cgroupCpuInfo struct {
 	CpuShares    bool
 	CpuCfsPeriod bool
 	CpuCfsQuota  bool
+}
+
+type cgroupBlkioInfo struct {
+	BlkioWeight bool
 }

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -7,6 +7,7 @@ type SysInfo struct {
 	*cgroupMemInfo
 	*cgroupCpuInfo
 	*cgroupBlkioInfo
+	*cgroupCpusetInfo
 	IPv4ForwardingDisabled        bool
 	BridgeNfCallIptablesDisabled  bool
 	BridgeNfCallIp6tablesDisabled bool
@@ -27,4 +28,8 @@ type cgroupCpuInfo struct {
 
 type cgroupBlkioInfo struct {
 	BlkioWeight bool
+}
+
+type cgroupCpusetInfo struct {
+	Cpuset bool
 }

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -19,6 +19,7 @@ type cgroupMemInfo struct {
 }
 
 type cgroupCpuInfo struct {
+	CpuShares    bool
 	CpuCfsPeriod bool
 	CpuCfsQuota  bool
 }

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -99,6 +99,20 @@ func checkCgroupBlkioInfo(quiet bool) *cgroupBlkioInfo {
 	return info
 }
 
+func checkCgroupCpusetInfo(quiet bool) *cgroupCpusetInfo {
+	info := &cgroupCpusetInfo{}
+	_, err := cgroups.FindCgroupMountpoint("cpuset")
+	if err != nil {
+		if !quiet {
+			logrus.Warn(err)
+		}
+		return info
+	}
+
+	info.Cpuset = true
+	return info
+}
+
 func cgroupEnabled(mountPoint, name string) bool {
 	_, err := os.Stat(path.Join(mountPoint, name))
 	return err == nil

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -73,6 +73,11 @@ func checkCgroupCpu(quiet bool) *cgroupCpuInfo {
 	if !quiet && !info.CpuCfsQuota {
 		logrus.Warn("Your kernel does not support cgroup cfs quotas")
 	}
+
+	info.CpuShares = cgroupEnabled(mountPoint, "cpu.shares")
+	if !quiet && !info.CpuShares {
+		logrus.Warn("Your kernel does not support cgroup cpu shares")
+	}
 	return info
 }
 

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -15,6 +15,7 @@ func New(quiet bool) *SysInfo {
 	sysInfo := &SysInfo{}
 	sysInfo.cgroupMemInfo = checkCgroupMem(quiet)
 	sysInfo.cgroupCpuInfo = checkCgroupCpu(quiet)
+	sysInfo.cgroupBlkioInfo = checkCgroupBlkioInfo(quiet)
 
 	_, err := cgroups.FindCgroupMountpoint("devices")
 	sysInfo.CgroupDevicesEnabled = err == nil
@@ -77,6 +78,23 @@ func checkCgroupCpu(quiet bool) *cgroupCpuInfo {
 	info.CpuShares = cgroupEnabled(mountPoint, "cpu.shares")
 	if !quiet && !info.CpuShares {
 		logrus.Warn("Your kernel does not support cgroup cpu shares")
+	}
+	return info
+}
+
+func checkCgroupBlkioInfo(quiet bool) *cgroupBlkioInfo {
+	info := &cgroupBlkioInfo{}
+	mountPoint, err := cgroups.FindCgroupMountpoint("blkio")
+	if err != nil {
+		if !quiet {
+			logrus.Warn(err)
+		}
+		return info
+	}
+
+	info.BlkioWeight = cgroupEnabled(mountPoint, "blkio.weight")
+	if !quiet && !info.BlkioWeight {
+		logrus.Warn("Your kernel does not support cgroup blkio weight")
 	}
 	return info
 }


### PR DESCRIPTION
We already have checks for MemoryLimit, CpuPeriod and CpuQuota, but there's no check for Cpuset, CpuShares and BlkioWeight. As a result docker will fail to start containers if those settings are specified but the underlying kernel doesn't support them.
