### PR TITLE
fix the url in article "Best practices for writing Dockerfiles"

### DIFF
--- a/docs/articles/dockerfile_best-practices.md
+++ b/docs/articles/dockerfile_best-practices.md
@@ -290,7 +290,7 @@ things like:
 And instead, do something like:
 
     RUN mkdir -p /usr/src/things \
-        && curl -SL http://example.com/big.tar.gz \
+        && curl -SL http://example.com/big.tar.xz \
         | tar -xJC /usr/src/things \
         && make -C /usr/src/things all
 


### PR DESCRIPTION
From context on next line,`tar -xJC` implies the file is `big.tar.xz` instead of `big.tar.gz`.
