### PR TITLE
Initialize swappiness in libcontainer cgroups template

### DIFF
--- a/daemon/execdriver/native/template/default_template.go
+++ b/daemon/execdriver/native/template/default_template.go
@@ -36,8 +36,9 @@ func New() *configs.Config {
 			{Type: "NEWNET"},
 		}),
 		Cgroups: &configs.Cgroup{
-			Parent:          "docker",
-			AllowAllDevices: false,
+			Parent:           "docker",
+			AllowAllDevices:  false,
+			MemorySwappiness: -1,
 		},
 		Mounts: []*configs.Mount{
 			{


### PR DESCRIPTION
By default, the cgroup setting in libcontainer's `configs.Cgroup` for
memory swappiness will default to 0, which is a valid choice for memory
swappiness, but that means by default every container's memory
swappiness will be set to zero instead of the default 60, which is
probably not what users are expecting.

When the swappiness UI PR comes into Docker, there will be docker run
controls to set this per container, but for now we want to make sure
_not_ to change the default, as well as work around an older kernel
issue that refuses to allow it to be set when cgroup hiearchies are in
use.

See docker/libcontainer#639 for more information.  Also see closed PR #13882 which can probably be reconsidered now that the libcontainer update PR has been merged.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
