### PR TITLE
Fix sysinfo regression

### DIFF
--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -38,7 +38,7 @@ func checkCgroupMem(quiet bool) *cgroupMemInfo {
 		if !quiet {
 			logrus.Warnf("Your kernel does not support cgroup memory limit: %v", err)
 		}
-		return nil
+		return info
 	}
 	info.MemoryLimit = true
 
@@ -61,7 +61,7 @@ func checkCgroupCpu(quiet bool) *cgroupCpuInfo {
 		if !quiet {
 			logrus.Warn(err)
 		}
-		return nil
+		return info
 	}
 
 	info.CpuCfsPeriod = cgroupEnabled(mountPoint, "cpu.cfs_period_us")


### PR DESCRIPTION
The cleanup to sysinfo package introduced a regression.

If memory cgroup isn't supported and --memory is specified when
starting a container, we should return info instead of nil in
checkCgroupMem(), otherwise we'll access a nil pointer.

Signed-off-by: Zefan Li lizefan@huawei.com
