### PR TITLE
Add back top-level "make docs"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,3 +70,6 @@ build: bundles
 
 bundles:
 	mkdir bundles
+
+docs:
+	$(MAKE) -C docs docs


### PR DESCRIPTION
Just to make life easier on devs so they don't need to 'cd' into
the docs dir just to test their docs edits.  This doesn't do anything
more than "cd docs && make docs" so that all of the smarts are still
in the docs's Makefile and not in docker's.

Signed-off-by: Doug Davis dug@us.ibm.com
