### PR TITLE
Unconditionally use AuthTransport.

### DIFF
--- a/registry/session.go
+++ b/registry/session.go
@@ -158,9 +158,9 @@ func NewSession(client *http.Client, authConfig *cliconfig.AuthConfig, endpoint 
 		}
 	}
 
-	if endpoint.Version == APIVersion1 {
-		client.Transport = AuthTransport(client.Transport, authConfig, alwaysSetBasicAuth)
-	}
+	// Annotate the transport unconditionally so that v2 can
+	// properly fallback on v1 when an image is not found.
+	client.Transport = AuthTransport(client.Transport, authConfig, alwaysSetBasicAuth)
 
 	jar, err := cookiejar.New(nil)
 	if err != nil {


### PR DESCRIPTION
Today, endpoints implementing v2 cannot properly fallback to v1 because the underlying transport that deals with authentication (Basic / Token) doesn't get annotated.

This doesn't affect DockerHub because the DockerHub endpoint appears as 'https://index.docker.io/v1/' (in .dockercfg), and the 'v1' tricks this logic just long enough that the transport is always annotated for DockerHub accesses.

Signed-off-by: Matt Moore mattmoor@google.com
