### PR TITLE
Add build time to version and tidy output

### DIFF
--- a/api/client/version.go
+++ b/api/client/version.go
@@ -23,17 +23,21 @@ func (cli *DockerCli) CmdVersion(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
+	fmt.Println("Client:")
 	if dockerversion.VERSION != "" {
-		fmt.Fprintf(cli.out, "Client version: %s\n", dockerversion.VERSION)
+		fmt.Fprintf(cli.out, " Version:      %s\n", dockerversion.VERSION)
 	}
-	fmt.Fprintf(cli.out, "Client API version: %s\n", api.Version)
-	fmt.Fprintf(cli.out, "Go version (client): %s\n", runtime.Version())
+	fmt.Fprintf(cli.out, " API version:  %s\n", api.Version)
+	fmt.Fprintf(cli.out, " Go version:   %s\n", runtime.Version())
 	if dockerversion.GITCOMMIT != "" {
-		fmt.Fprintf(cli.out, "Git commit (client): %s\n", dockerversion.GITCOMMIT)
+		fmt.Fprintf(cli.out, " Git commit:   %s\n", dockerversion.GITCOMMIT)
 	}
-	fmt.Fprintf(cli.out, "OS/Arch (client): %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	if dockerversion.BUILDTIME != "" {
+		fmt.Fprintf(cli.out, " Built:        %s\n", dockerversion.BUILDTIME)
+	}
+	fmt.Fprintf(cli.out, " OS/Arch:      %s/%s\n", runtime.GOOS, runtime.GOARCH)
 	if utils.ExperimentalBuild() {
-		fmt.Fprintf(cli.out, "Experimental (client): true\n")
+		fmt.Fprintf(cli.out, " Experimental: true\n")
 	}
 
 	stream, _, _, err := cli.call("GET", "/version", nil, nil)
@@ -47,15 +51,20 @@ func (cli *DockerCli) CmdVersion(args ...string) error {
 		return err
 	}
 
-	fmt.Fprintf(cli.out, "Server version: %s\n", v.Version)
+	fmt.Println("\nServer:")
+	fmt.Fprintf(cli.out, " Version:      %s\n", v.Version)
 	if v.ApiVersion != "" {
-		fmt.Fprintf(cli.out, "Server API version: %s\n", v.ApiVersion)
+		fmt.Fprintf(cli.out, " API version:  %s\n", v.ApiVersion)
 	}
-	fmt.Fprintf(cli.out, "Go version (server): %s\n", v.GoVersion)
-	fmt.Fprintf(cli.out, "Git commit (server): %s\n", v.GitCommit)
-	fmt.Fprintf(cli.out, "OS/Arch (server): %s/%s\n", v.Os, v.Arch)
+	fmt.Fprintf(cli.out, " Go version:   %s\n", v.GoVersion)
+	fmt.Fprintf(cli.out, " Git commit:   %s\n", v.GitCommit)
+	if len(v.BuildTime) > 0 {
+		fmt.Fprintf(cli.out, " Built:        %s\n", v.BuildTime)
+	}
+	fmt.Fprintf(cli.out, " OS/Arch:      %s/%s\n", v.Os, v.Arch)
 	if v.Experimental {
-		fmt.Fprintf(cli.out, "Experimental (server): true\n")
+		fmt.Fprintf(cli.out, " Experimental: true\n")
 	}
+	fmt.Fprintf(cli.out, "\n")
 	return nil
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -249,6 +249,7 @@ func (s *Server) getVersion(version version.Version, w http.ResponseWriter, r *h
 		GoVersion:  runtime.Version(),
 		Os:         runtime.GOOS,
 		Arch:       runtime.GOARCH,
+		BuildTime:  dockerversion.BUILDTIME,
 	}
 
 	if version.GreaterThanOrEqualTo("1.19") {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -139,6 +139,7 @@ type Version struct {
 	Arch          string
 	KernelVersion string `json:",omitempty"`
 	Experimental  bool   `json:",omitempty"`
+	BuildTime     string `json:",omitempty"`
 }
 
 // GET "/info"

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -71,6 +71,7 @@ if command -v git &> /dev/null && git rev-parse &> /dev/null; then
 	if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
 		GITCOMMIT="$GITCOMMIT-dirty"
 	fi
+	BUILDTIME=$(date -u)
 elif [ "$DOCKER_GITCOMMIT" ]; then
 	GITCOMMIT="$DOCKER_GITCOMMIT"
 else

--- a/hack/make/.go-autogen
+++ b/hack/make/.go-autogen
@@ -10,6 +10,7 @@ package dockerversion
 var (
 	GITCOMMIT string = "$GITCOMMIT"
 	VERSION   string = "$VERSION"
+	BUILDTIME string = "$BUILDTIME"
 
 	IAMSTATIC string = "${IAMSTATIC:-true}"
 	INITSHA1  string = "$DOCKER_INITSHA1"

--- a/integration-cli/docker_cli_version_test.go
+++ b/integration-cli/docker_cli_version_test.go
@@ -15,23 +15,20 @@ func (s *DockerSuite) TestVersionEnsureSucceeds(c *check.C) {
 		c.Fatalf("failed to execute docker version: %s, %v", out, err)
 	}
 
-	stringsToCheck := []string{
-		"Client version:",
-		"Client API version:",
-		"Go version (client):",
-		"Git commit (client):",
-		"OS/Arch (client):",
-		"Server version:",
-		"Server API version:",
-		"Go version (server):",
-		"Git commit (server):",
-		"OS/Arch (server):",
+	stringsToCheck := map[string]int{
+		"Client:":       1,
+		"Server:":       1,
+		" Version:":     2,
+		" API version:": 2,
+		" Go version:":  2,
+		" Git commit:":  2,
+		" OS/Arch:":     2,
+		" Built:":       2,
 	}
 
-	for _, linePrefix := range stringsToCheck {
-		if !strings.Contains(out, linePrefix) {
-			c.Errorf("couldn't find string %v in output", linePrefix)
+	for k, v := range stringsToCheck {
+		if strings.Count(out, k) != v {
+			c.Errorf("%v expected %d instances found %d", k, v, strings.Count(out, k))
 		}
 	}
-
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This PR adds the  build date to the output from docker version (which I find extremely useful during development) and makes the output readable (IMHO). Of course, others might disagree ;)

![dockerversion](https://cloud.githubusercontent.com/assets/10522484/8259021/475be32c-166e-11e5-95c7-56e2c46e0b22.jpg)

(Note the screen shots include git branch - this has now been removed, see comments below)
