### PR TITLE
Windows: Fix cgroup regression

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -743,8 +743,9 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	}
 
 	sysInfo := sysinfo.New(false)
-	// Check if Devices cgroup is mounted, it is hard requirement for container security.
-	if !sysInfo.CgroupDevicesEnabled {
+	// Check if Devices cgroup is mounted, it is hard requirement for container security,
+	// on Linux/FreeBSD.
+	if runtime.GOOS != "windows" && !sysInfo.CgroupDevicesEnabled {
 		return nil, fmt.Errorf("Devices cgroup isn't mounted")
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@cpuguy83. This removes the hard check for CgroupDevicesEnabled which isn't applicable on Windows.
