### PR TITLE
`docker cp`++

### DIFF
--- a/api/types/types.go
+++ b/api/types/types.go
@@ -266,3 +266,9 @@ type ContainerConfig struct {
 	CpuShares  int64
 	Cpuset     string
 }
+
+// ContainerGlobMatchesResponse is returned by
+// GET "/containers/{name:.*}/globMatches".
+type ContainerGlobMatchesResponse struct {
+	Matches []string `json:"matches"`
+}

--- a/integration-cli/docker_cli_cp_from_container_test.go
+++ b/integration-cli/docker_cli_cp_from_container_test.go
@@ -34,8 +34,8 @@ func (s *DockerSuite) TestCpFromErrSrcNotExists(c *check.C) {
 		c.Fatal("expected IsNotExist error, but got nil instead")
 	}
 
-	if !isCpNotExist(err) {
-		c.Fatalf("expected IsNotExist error, but got %T: %s", err, err)
+	if !isCpNoMatches(err) {
+		c.Fatalf("expected cpNoMatches error, but got %T: %s", err, err)
 	}
 }
 
@@ -53,8 +53,8 @@ func (s *DockerSuite) TestCpFromErrSrcNotDir(c *check.C) {
 		c.Fatal("expected IsNotDir error, but got nil instead")
 	}
 
-	if !isCpNotDir(err) {
-		c.Fatalf("expected IsNotDir error, but got %T: %s", err, err)
+	if !isCpNoMatches(err) {
+		c.Fatalf("expected cpNoMatches error, but got %T: %s", err, err)
 	}
 }
 

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -30,7 +30,7 @@ func (s *DockerSuite) TestCpLocalOnly(c *check.C) {
 		c.Fatal("expected failure, got success")
 	}
 
-	if !strings.Contains(err.Error(), "must specify at least one container source") {
+	if !strings.Contains(err.Error(), "must specify a container in source or destination") {
 		c.Fatalf("unexpected output: %s", err.Error())
 	}
 }

--- a/integration-cli/docker_cli_cp_to_container_test.go
+++ b/integration-cli/docker_cli_cp_to_container_test.go
@@ -66,7 +66,7 @@ func (s *DockerSuite) TestCpToErrSrcNotDir(c *check.C) {
 }
 
 // Test for error when SRC is a valid file or directory,
-// bu the DST parent directory does not exist.
+// but the DST parent directory does not exist.
 func (s *DockerSuite) TestCpToErrDstParentNotExists(c *check.C) {
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
 	defer deleteContainer(cID)

--- a/integration-cli/docker_cli_cp_utils.go
+++ b/integration-cli/docker_cli_cp_utils.go
@@ -228,6 +228,10 @@ func isCpNotExist(err error) bool {
 	return strings.Contains(err.Error(), "no such file or directory") || strings.Contains(err.Error(), "cannot find the file specified")
 }
 
+func isCpNoMatches(err error) bool {
+	return strings.Contains(err.Error(), "unable to match any container files")
+}
+
 func isCpDirNotExist(err error) bool {
 	return strings.Contains(err.Error(), archive.ErrDirNotExists.Error())
 }


### PR DESCRIPTION
This pull request builds on top of #13171 by adding support for container paths which contain shell globs, and general support for multiple source arguments when copying.
