### PR TITLE
Add struct to configure Builder commit

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -659,7 +659,7 @@ func (s *Server) postCommit(version version.Version, w http.ResponseWriter, r *h
 		return err
 	}
 
-	cont := r.Form.Get("container")
+	cname := r.Form.Get("container")
 
 	pause := boolValue(r, "pause")
 	if r.FormValue("pause") == "" && version.GreaterThanOrEqualTo("1.13") {
@@ -671,7 +671,7 @@ func (s *Server) postCommit(version version.Version, w http.ResponseWriter, r *h
 		return err
 	}
 
-	containerCommitConfig := &daemon.ContainerCommitConfig{
+	commitCfg := &builder.BuilderCommitConfig{
 		Pause:   pause,
 		Repo:    r.Form.Get("repo"),
 		Tag:     r.Form.Get("tag"),
@@ -681,7 +681,7 @@ func (s *Server) postCommit(version version.Version, w http.ResponseWriter, r *h
 		Config:  c,
 	}
 
-	imgID, err := builder.Commit(s.daemon, cont, containerCommitConfig)
+	imgID, err := builder.Commit(cname, s.daemon, commitCfg)
 	if err != nil {
 		return err
 	}

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -107,8 +107,14 @@ func (b *Builder) commit(id string, autoCmd *runconfig.Command, comment string) 
 	autoConfig := *b.Config
 	autoConfig.Cmd = autoCmd
 
+	commitCfg := &daemon.ContainerCommitConfig{
+		Author: b.maintainer,
+		Pause:  true,
+		Config: &autoConfig,
+	}
+
 	// Commit the container
-	image, err := b.Daemon.Commit(container, "", "", "", b.maintainer, true, &autoConfig)
+	image, err := b.Daemon.Commit(container, commitCfg)
 	if err != nil {
 		return err
 	}

--- a/builder/job.go
+++ b/builder/job.go
@@ -215,7 +215,17 @@ func BuildFromConfig(d *daemon.Daemon, c *runconfig.Config, changes []string) (*
 	return builder.Config, nil
 }
 
-func Commit(d *daemon.Daemon, name string, c *daemon.ContainerCommitConfig) (string, error) {
+type BuilderCommitConfig struct {
+	Pause   bool
+	Repo    string
+	Tag     string
+	Author  string
+	Comment string
+	Changes []string
+	Config  *runconfig.Config
+}
+
+func Commit(name string, d *daemon.Daemon, c *BuilderCommitConfig) (string, error) {
 	container, err := d.Get(name)
 	if err != nil {
 		return "", err
@@ -234,7 +244,16 @@ func Commit(d *daemon.Daemon, name string, c *daemon.ContainerCommitConfig) (str
 		return "", err
 	}
 
-	img, err := d.Commit(container, c.Repo, c.Tag, c.Comment, c.Author, c.Pause, newConfig)
+	commitCfg := &daemon.ContainerCommitConfig{
+		Pause:   c.Pause,
+		Repo:    c.Repo,
+		Tag:     c.Tag,
+		Author:  c.Author,
+		Comment: c.Comment,
+		Config:  newConfig,
+	}
+
+	img, err := d.Commit(container, commitCfg)
 	if err != nil {
 		return "", err
 	}

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -11,14 +11,13 @@ type ContainerCommitConfig struct {
 	Tag     string
 	Author  string
 	Comment string
-	Changes []string
 	Config  *runconfig.Config
 }
 
 // Commit creates a new filesystem image from the current state of a container.
 // The image can optionally be tagged into a repository
-func (daemon *Daemon) Commit(container *Container, repository, tag, comment, author string, pause bool, config *runconfig.Config) (*image.Image, error) {
-	if pause && !container.IsPaused() {
+func (daemon *Daemon) Commit(container *Container, c *ContainerCommitConfig) (*image.Image, error) {
+	if c.Pause && !container.IsPaused() {
 		container.Pause()
 		defer container.Unpause()
 	}
@@ -45,14 +44,14 @@ func (daemon *Daemon) Commit(container *Container, repository, tag, comment, aut
 		containerConfig = container.Config
 	}
 
-	img, err := daemon.graph.Create(rwTar, containerID, parentImageID, comment, author, containerConfig, config)
+	img, err := daemon.graph.Create(rwTar, containerID, parentImageID, c.Comment, c.Author, containerConfig, c.Config)
 	if err != nil {
 		return nil, err
 	}
 
 	// Register the image if needed
-	if repository != "" {
-		if err := daemon.repositories.Tag(repository, tag, img.ID, true); err != nil {
+	if c.Repo != "" {
+		if err := daemon.repositories.Tag(c.Repo, c.Tag, img.ID, true); err != nil {
 			return img, err
 		}
 	}


### PR DESCRIPTION
I don't remember why `ContainerCommitConfig` was defined in `daemon` and used in `builder`

Signed-off-by: Antonio Murdaca runcom@linux.com
