### PR TITLE
VLAN Extension for libnetwork/bridge driver (by Dockercon 2015 Hackathon)

### DIFF
--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -775,10 +775,19 @@ func (container *Container) AllocateNetwork() error {
 		return nil
 	}
 
+	var networkName string
+	networkByName = false
+	n, err := controller.NetworkByName(string(mode))
+	if err == nil {
+		networkName = runconfig.NetworkMode("bridge")
+		networkByName = true
+	} else {
+		networkName = mode.NetworkName()
+	}
+
 	var networkDriver string
 	service := container.Config.PublishService
-	networkName := mode.NetworkName()
-	if mode.IsDefault() {
+	if !networkByName && mode.IsDefault() {
 		if service != "" {
 			service, networkName, networkDriver = parseService(controller, service)
 		} else {

--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -803,7 +803,7 @@ func (container *Container) AllocateNetwork() error {
 
 	mode = runconfig.NetworkMode(parts[0])
 	var networkName string
-	networkByName = false
+	var networkByName = false
 	n, err := controller.NetworkByName(string(mode))
 	if err == nil {
 		networkName = string(mode)
@@ -828,8 +828,6 @@ func (container *Container) AllocateNetwork() error {
 	if service == "" {
 		service = strings.Replace(container.Name, ".", "-", -1)
 	}
-
-	var err error
 
 	if ! networkByName {
 		n, err = controller.NetworkByName(networkName)

--- a/docs/articles/networking.md
+++ b/docs/articles/networking.md
@@ -124,7 +124,7 @@ Finally, several networking options can only be provided when calling
     [Configuring DNS](#dns) and
     [Communication between containers](#between-containers)
 
- *  `--net=bridge|none|container:NAME_or_ID|host` — see
+ *  `--net=bridge|none|container:NAME_or_ID|host|networkname|networkname:staticip` — see
     [How Docker networks a container](#container-networking)
 
  *  `--mac-address=MACADDRESS...` — see
@@ -141,11 +141,11 @@ To supply networking options to the Docker server at startup, use the
 variable in `/etc/default/docker` or `/etc/sysconfig/docker` for CentOS.
 
 The following example illustrates how to configure Docker on Ubuntu to recognize a
-newly built bridge. 
+newly built bridge.
 
 Edit the `/etc/default/docker` file:
 
-    $ echo 'DOCKER_OPTS="-b=bridge0"' >> /etc/default/docker 
+    $ echo 'DOCKER_OPTS="-b=bridge0"' >> /etc/default/docker
 
 Then restart the Docker server.
 
@@ -223,7 +223,7 @@ the daemon filters out all localhost IP address `nameserver` entries from
 the host's original file.
 
 Filtering is necessary because all localhost addresses on the host are
-unreachable from the container's network.  After this filtering, if there 
+unreachable from the container's network.  After this filtering, if there
 are no more `nameserver` entries left in the container's `/etc/resolv.conf`
 file, the daemon adds public Google DNS nameservers
 (8.8.8.8 and 8.8.4.4) to the container's DNS configuration.  If IPv6 is
@@ -241,7 +241,7 @@ notifier active which will watch for changes to the host DNS configuration.
 
 > **Note**:
 > The file change notifier relies on the Linux kernel's inotify feature.
-> Because this feature is currently incompatible with the overlay filesystem 
+> Because this feature is currently incompatible with the overlay filesystem
 > driver, a Docker daemon using "overlay" will not be able to take advantage
 > of the `/etc/resolv.conf` auto-update feature.
 
@@ -253,7 +253,7 @@ of a facility to ensure atomic writes of the `resolv.conf` file while the
 container is running. If the container's `resolv.conf` has been edited since
 it was started with the default configuration, no replacement will be
 attempted as it would overwrite the changes performed by the container.
-If the options (`--dns` or `--dns-search`) have been used to modify the 
+If the options (`--dns` or `--dns-search`) have been used to modify the
 default host configuration, then the replacement with an updated host's
 `/etc/resolv.conf` will not happen as well.
 
@@ -689,7 +689,7 @@ on every host.
 
 In this scenario containers of the same host can communicate directly with each
 other. The traffic between containers on different hosts will be routed via
-their hosts and the router. For example packet from `Container1-1` to 
+their hosts and the router. For example packet from `Container1-1` to
 `Container2-1` will be routed through `Host1`, `Router` and `Host2` until it
 arrives at `Container2-1`.
 
@@ -947,6 +947,15 @@ values.
     network stack but not to take any steps to configure its network,
     leaving you free to build any of the custom configurations explored
     in the last few sections of this document.
+
+ *  `--net=networkname` - Connects the container to the network bridge
+    that was for the specified `networkname` instead of the default
+    bridge.
+
+ *  `--net=networkname:ipaddress` - Connects the container to the network
+    bridge as above but also assigns a static IP address to the container.
+    The static IP address must not be used by another container and must
+    match the ip range that was created with the network.
 
 To get an idea of the steps that are necessary if you use `--net=none`
 as described in that last bullet point, here are the commands that you

--- a/experimental/networking.md
+++ b/experimental/networking.md
@@ -33,6 +33,18 @@ if you have loaded a networking plugin e.g `docker network create -d <plugin_nam
         $ docker network create -d overlay bar
         d9989793e2f5fe400a58ef77f706d03f668219688ee989ea68ea78b990fa2406
 
+You can additionally specify `--vlanid=` and `--ifname=` to create and attach an
+uplink interface to the bridge.  This enables external connectivity for the bridge.
+
+        $ docker network create -d bridge --vlanid=105 --ifname=eth0 cheetos
+        64e45e133127467f8c5c617e0e8952d4adca6a8f021be65a134a0fce89837a72
+
+In order to ensure containers on different hosts can communicate without a router, you must
+create networks with the same network parameters.  
+
+        $ docker network create -d bridge --vlanid=202 --ifname=eth0 --bip=172.16.2.1/24 --fixed-cidr=172.16.2.0/24 testing202
+
+
 `docker network ls` is used to display the currently configured networks
 
         $ docker network ls
@@ -63,7 +75,7 @@ If you no longer have need of a network, you can delete it with `docker network 
         cc455abccfeb        bridge              bridge
 
 Docker daemon supports a configuration flag `--default-network` which takes configuration value of format `NETWORK:DRIVER`, where,
-`NETWORK` is the name of the network created using the `docker network create` command and 
+`NETWORK` is the name of the network created using the `docker network create` command and
 `DRIVER` represents the in-built drivers such as bridge, overlay, container, host and none. or Remote drivers via Network Plugins.
 When a container is created and if the network mode (`--net`) is not specified, then this default network will be used to connect
 the container. If `--default-network` is not specified, the default network will be the `bridge` driver.
@@ -111,4 +123,3 @@ To remove the a service:
 
 Send us feedback and comments on [#](https://github.com/docker/docker/issues/?),
 or on the usual Google Groups (docker-user, docker-dev) and IRC channels.
-

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -61,6 +61,14 @@ func (n NetworkMode) IsNone() bool {
 	return n == "none"
 }
 
+func (n NetworkMode) HasIp() bool {
+	parts := strings.Split(string(n), ":")
+	if len(parts) == 2 {
+		return true
+	}
+	return false
+}
+
 type IpcMode string
 
 // IsPrivate indicates whether container use it's private ipc stack

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -490,8 +490,8 @@ func parseNetMode(netMode string) (NetworkMode, error) {
 		if len(parts) < 2 || parts[1] == "" {
 			return "", fmt.Errorf("invalid container format container:<name|id>")
 		}
-	default:
-		return "", fmt.Errorf("invalid --net: %s", netMode)
+//	default:
+//		return "", fmt.Errorf("invalid --net: %s", netMode)
 	}
 	return NetworkMode(netMode), nil
 }

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -490,8 +490,8 @@ func parseNetMode(netMode string) (NetworkMode, error) {
 		if len(parts) < 2 || parts[1] == "" {
 			return "", fmt.Errorf("invalid container format container:<name|id>")
 		}
-//	default:
-//		return "", fmt.Errorf("invalid --net: %s", netMode)
+		//	default:
+		//		return "", fmt.Errorf("invalid --net: %s", netMode)
 	}
 	return NetworkMode(netMode), nil
 }

--- a/vendor/src/github.com/docker/libnetwork/client/network.go
+++ b/vendor/src/github.com/docker/libnetwork/client/network.go
@@ -41,6 +41,8 @@ func (cli *NetworkCli) CmdNetwork(chain string, args ...string) error {
 func (cli *NetworkCli) CmdNetworkCreate(chain string, args ...string) error {
 	cmd := cli.Subcmd(chain, "create", "NETWORK-NAME", "Creates a new network with a name specified by the user", false)
 	flDriver := cmd.String([]string{"d", "-driver"}, "", "Driver to manage the Network")
+	vlanid := cmd.Int([]string{"v", "-vlanid"}, 0, "Vlan ID")
+	ifname := cmd.String([]string{"i", "-ifname"}, "", "The name of network interface to create sub-interface")
 	cmd.Require(flag.Exact, 1)
 	err := cmd.ParseFlags(args, true)
 	if err != nil {
@@ -49,6 +51,8 @@ func (cli *NetworkCli) CmdNetworkCreate(chain string, args ...string) error {
 
 	// Construct network create request body
 	ops := make(map[string]interface{})
+	ops["vlanid"] = vlanid
+	ops["ifname"] = ifname
 	nc := networkCreate{Name: cmd.Arg(0), NetworkType: *flDriver, Options: ops}
 	obj, _, err := readBody(cli.call("POST", "/networks", nc, nil))
 	if err != nil {

--- a/vendor/src/github.com/docker/libnetwork/client/network.go
+++ b/vendor/src/github.com/docker/libnetwork/client/network.go
@@ -43,6 +43,8 @@ func (cli *NetworkCli) CmdNetworkCreate(chain string, args ...string) error {
 	flDriver := cmd.String([]string{"d", "-driver"}, "", "Driver to manage the Network")
 	vlanid := cmd.Int([]string{"v", "-vlanid"}, 0, "Vlan ID")
 	ifname := cmd.String([]string{"i", "-ifname"}, "", "The name of network interface to create sub-interface")
+	bip := cmd.String([]string{"-bip"}, "", "Specify network bridge IP")
+	cidr := cmd.String([]string{"-fixed-cidr"}, "", "IPv4 subnet for fixed IPs")
 	cmd.Require(flag.Exact, 1)
 	err := cmd.ParseFlags(args, true)
 	if err != nil {
@@ -53,6 +55,8 @@ func (cli *NetworkCli) CmdNetworkCreate(chain string, args ...string) error {
 	ops := make(map[string]interface{})
 	ops["vlanid"] = vlanid
 	ops["ifname"] = ifname
+	ops["AddressIPv4"] = bip
+	ops["FixedCIDR"] = cidr
 	nc := networkCreate{Name: cmd.Arg(0), NetworkType: *flDriver, Options: ops}
 	obj, _, err := readBody(cli.call("POST", "/networks", nc, nil))
 	if err != nil {

--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -558,7 +558,7 @@ func (d *driver) CreateNetwork(id types.UUID, option map[string]interface{}) err
 	if err != nil {
 		return err
 	}
-	logrus.Infof("network config parsed: %#v", config)
+
 	networkList := d.getNetworks()
 	for _, nw := range networkList {
 		nw.Lock()
@@ -706,7 +706,7 @@ func newVlanInterface(name string) error {
 	cmd := "ip"
 	intSplit := strings.Split(name, ".")
 	if len(intSplit) != 2 {
-		return errors.New("invalid interface name, ie. eth0.100")
+		return errors.New("invalid interface name, ie. eth0")
 	}
 
 	args := []string{"link", "add", "link", intSplit[0], "name", name, "type", "vlan", "id", intSplit[1]}
@@ -716,7 +716,7 @@ func newVlanInterface(name string) error {
 			return errors.New(fmt.Sprintf((fmt.Sprint(err) + ": " + string(output))))
 		}
 	}
-	fmt.Println("Successfully created interface")
+	logrus.Infof("Created interface %s", name)
 	return nil
 }
 
@@ -727,7 +727,7 @@ func attachVlanInterface(name, bridgeName string) error {
 	if output, err := exec.Command(cmd, args...).CombinedOutput(); err != nil {
 		return errors.New(fmt.Sprintf((fmt.Sprint(err) + ": " + string(output))))
 	}
-	fmt.Println("Successfully added interface to bridge")
+	logrus.Infof("Added interface %s to bridge %s", name, bridgeName)
 	return nil
 }
 

--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -507,6 +507,22 @@ func parseNetworkOptions(option options.Generic) (*networkConfiguration, error) 
 	if _, ok := option["ifname"]; ok {
 		config.IfName = option["ifname"].(string)
 	}
+	if _, ok := option["AddressIPv4"]; ok {
+		_, bipNet, err := net.ParseCIDR(option["AddressIPv4"].(string))
+		if err != nil {
+			return nil, err
+		}
+		config.AddressIPv4 = bipNet
+		logrus.Infof("config.AddressIPv4: %#v", config.AddressIPv4)
+	}
+	if _, ok := option["FixedCIDR"]; ok {
+		_, fCIDR, err := net.ParseCIDR(option["FixedCIDR"].(string))
+		if err != nil {
+			return nil, err
+		}
+		config.FixedCIDR = fCIDR
+		logrus.Infof("config.FixedCIDR: %#v", config.FixedCIDR)
+	}
 
 	// Finally validate the configuration
 	if err = config.Validate(); err != nil {

--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -508,20 +508,32 @@ func parseNetworkOptions(option options.Generic) (*networkConfiguration, error) 
 		config.IfName = option["ifname"].(string)
 	}
 	if _, ok := option["AddressIPv4"]; ok {
-		_, bipNet, err := net.ParseCIDR(option["AddressIPv4"].(string))
-		if err != nil {
-			return nil, err
+
+		addressIPv4 := option["AddressIPv4"].(string)
+		if addressIPv4 != "" {
+			ip, netv4, err := net.ParseCIDR(option["AddressIPv4"].(string))
+			if err != nil {
+				return nil, err
+			}
+			bipNet := &net.IPNet{
+				IP:   ip,
+				Mask: netv4.Mask,
+			}
+
+			config.AddressIPv4 = bipNet
+			logrus.Infof("config.AddressIPv4: %#v", config.AddressIPv4)
 		}
-		config.AddressIPv4 = bipNet
-		logrus.Infof("config.AddressIPv4: %#v", config.AddressIPv4)
 	}
 	if _, ok := option["FixedCIDR"]; ok {
-		_, fCIDR, err := net.ParseCIDR(option["FixedCIDR"].(string))
-		if err != nil {
-			return nil, err
+		fixedCIDR := option["FixedCIDR"].(string)
+		if fixedCIDR != "" {
+			_, fCIDR, err := net.ParseCIDR(option["FixedCIDR"].(string))
+			if err != nil {
+				return nil, err
+			}
+			config.FixedCIDR = fCIDR
+			logrus.Infof("config.FixedCIDR: %#v", config.FixedCIDR)
 		}
-		config.FixedCIDR = fCIDR
-		logrus.Infof("config.FixedCIDR: %#v", config.FixedCIDR)
 	}
 
 	// Finally validate the configuration

--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -52,6 +52,8 @@ type networkConfiguration struct {
 	DefaultBindingIP      net.IP
 	AllowNonDefaultBridge bool
 	EnableUserlandProxy   bool
+	VlanId                int
+	IfName                string
 }
 
 // endpointConfiguration represents the user specified configuration for the sandbox endpoint
@@ -495,6 +497,14 @@ func parseNetworkOptions(option options.Generic) (*networkConfiguration, error) 
 		config.EnableIPv6 = option[netlabel.EnableIPv6].(bool)
 	}
 
+	// Process VLAN related options
+	if _, ok := option["vlanid"]; ok {
+		config.VlanId = int(option["vlanid"].(float64))
+	}
+	if _, ok := option["ifname"]; ok {
+		config.IfName = option["ifname"].(string)
+	}
+
 	// Finally validate the configuration
 	if err = config.Validate(); err != nil {
 		return nil, err
@@ -545,6 +555,7 @@ func (d *driver) CreateNetwork(id types.UUID, option map[string]interface{}) err
 	if err != nil {
 		return err
 	}
+	logrus.Infof("network config parsed: %#v", config)
 	networkList := d.getNetworks()
 	for _, nw := range networkList {
 		nw.Lock()

--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/bridge.go
@@ -687,12 +687,13 @@ func (d *driver) CreateNetwork(id types.UUID, option map[string]interface{}) err
 		return err
 	}
 
-	if config.BridgeName == "testing" {
-		if err := newVlanInterface("eth0.100"); err != nil {
+	if config.VlanId != 0 && config.IfName != "" {
+		ifnamevlan := strings.Join([]string{config.IfName, strconv.Itoa(config.VlanId)}, ".")
+		if err := newVlanInterface(ifnamevlan); err != nil {
 			return err
 		}
 
-		if err := attachVlanInterface("eth0.100", "testing"); err != nil {
+		if err := attachVlanInterface(ifnamevlan, config.BridgeName); err != nil {
 			return err
 		}
 	}

--- a/vendor/src/github.com/docker/libnetwork/netlabel/labels.go
+++ b/vendor/src/github.com/docker/libnetwork/netlabel/labels.go
@@ -21,4 +21,7 @@ const (
 
 	//EnableIPv6 constant represents enabling IPV6 at network level
 	EnableIPv6 = Prefix + ".enable_ipv6"
+
+	//IPv4
+	IPAddressv4 = Prefix + ".endpoint.ipaddressv4"
 )

--- a/vendor/src/github.com/docker/libnetwork/sandboxdata.go
+++ b/vendor/src/github.com/docker/libnetwork/sandboxdata.go
@@ -108,14 +108,14 @@ func (s *sandboxData) addEndpoint(ep *endpoint) error {
 
 	s.Lock()
 	heap.Push(&s.endpoints, ep)
-	highEp := s.endpoints[0]
+//	highEp := s.endpoints[0]
 	s.Unlock()
 
-	if ep == highEp {
-		if err := s.updateGateway(ep); err != nil {
-			return err
-		}
-	}
+//	if ep == highEp {
+//		if err := s.updateGateway(ep); err != nil {
+//			return err
+//		}
+//	}
 
 	s.Lock()
 	s.refCnt++


### PR DESCRIPTION
VLAN Extension for libnetwork/bridge driver.
VLAN is simple, but widely used in many enterprise systems. 
Enabling VLAN will spread Docker's use case and Enhancing security based on isolation. Our hack supoorts single and multipule hosts.

To create new network: 
# ./docker-1.8.0-dev network create -d bridge --vlanid=200 --ifname=eth0 –bip=x.y.z.w/q –fixed-cidr=x.y.z.w/q br200

To attach to new container:
# ./docker-1.8.0-dev run -itd --net=br200:<container-IP> ubuntu /bin/bash
