### PR TITLE
Propigate the daemon's HTTP_PROXY to build jobs

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -162,6 +162,11 @@ The instructions that handle environment variables in the `Dockerfile` are:
 * `VOLUME`
 * `USER`
 
+The special environment variables `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`
+will be automatically propigated from the Docker daemon's environment for `RUN`
+commands only. These values are only used for the duration of the build and are
+not included in the image configuration.
+
 `ONBUILD` instructions are **NOT** supported for environment replacement, even
 the instructions above.
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5358,3 +5358,31 @@ func (s *DockerSuite) TestBuildRUNErrMsg(c *check.C) {
 		c.Fatalf("RUN doesn't have the correct output:\nGot:%s\nExpected:%s", out, exp)
 	}
 }
+
+func (s *DockerSuite) TestBuildWithHttpProxy(c *check.C) {
+	_, out, err := buildImageWithOut("testbuildhttpproxy", `
+	FROM busybox
+	RUN env
+	`, false)
+
+	proxyStrings := []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+	for _, str := range proxyStrings {
+		if !strings.Contains(out, str+"=") {
+			c.Fatalf("expected env in build container to include HTTP_PROXY, HTTPS_PROXY, and NO_PROXY values")
+		}
+	}
+
+	out, err = inspectFieldJSON("testbuildhttpproxy", "Config.Env")
+	c.Assert(err, check.IsNil)
+
+	var cfg []string
+	c.Assert(json.Unmarshal([]byte(out), &cfg), check.IsNil)
+
+	for _, e := range cfg {
+		for _, proxy := range proxyStrings {
+			if strings.Contains(e, proxy) {
+				c.Fatalf("HTTP_PROXY settings were commited to the image:\n%v", cfg)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Adds `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`, to the containers
created for `RUN` commands. These settings are not commited to the image
and are only used for the duration of the `RUN` command.

Closes #4962
