### PR TITLE
registry: don't send kernel version

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -19,7 +19,6 @@ import (
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/autogen/dockerversion"
-	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/tlsconfig"
 	"github.com/docker/docker/pkg/useragent"
 )
@@ -40,9 +39,6 @@ func init() {
 	httpVersion = append(httpVersion, useragent.VersionInfo{"docker", dockerversion.VERSION})
 	httpVersion = append(httpVersion, useragent.VersionInfo{"go", runtime.Version()})
 	httpVersion = append(httpVersion, useragent.VersionInfo{"git-commit", dockerversion.GITCOMMIT})
-	if kernelVersion, err := kernel.GetKernelVersion(); err == nil {
-		httpVersion = append(httpVersion, useragent.VersionInfo{"kernel", kernelVersion.String()})
-	}
 	httpVersion = append(httpVersion, useragent.VersionInfo{"os", runtime.GOOS})
 	httpVersion = append(httpVersion, useragent.VersionInfo{"arch", runtime.GOARCH})
 


### PR DESCRIPTION
This PR makes Docker stop sending the kernel version to the registry. This disclosure of information could lead to potential security risks. Collection of such information should be opt in.

Collecting information about the kernel version of a Docker daemon at the company or organization level should be done via docker info, not through the Docker registry.
