### PR TITLE
Add --rootmount={shared:private:slave} flags to set rootfs mount 

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -34,6 +34,7 @@ type CommonConfig struct {
 	TrustKeyPath   string
 	DefaultNetwork string
 	NetworkKVStore string
+	RootMount      string
 }
 
 // InstallCommonFlags adds command-line options to the top-level flag parser for
@@ -58,4 +59,5 @@ func (config *Config) InstallCommonFlags() {
 	opts.LabelListVar(&config.Labels, []string{"-label"}, "Set key=value labels to the daemon")
 	flag.StringVar(&config.LogConfig.Type, []string{"-log-driver"}, "json-file", "Default driver for container logs")
 	opts.LogOptsVar(config.LogConfig.Config, []string{"-log-opt"}, "Set log driver options")
+	flag.StringVar(&config.RootMount, []string{"-root-mount"}, runconfig.DefaultRootMount, "Rootfs mount propogation mode")
 }

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -290,6 +290,7 @@ func populateCommand(c *Container, env []string) error {
 		ID:                 c.ID,
 		Rootfs:             c.RootfsPath(),
 		ReadonlyRootfs:     c.hostConfig.ReadonlyRootfs,
+		RootMount:          c.Config.RootMount,
 		InitPath:           "/.dockerinit",
 		WorkingDir:         c.Config.WorkingDir,
 		Network:            en,

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -155,7 +155,8 @@ type ProcessConfig struct {
 // Process wrapps an os/exec.Cmd to add more metadata
 type Command struct {
 	ID                 string            `json:"id"`
-	Rootfs             string            `json:"rootfs"` // root fs of the container
+	Rootfs             string            `json:"rootfs"`     // root fs of the container
+	RootMount          string            `json:"root_mount"` // rootfs mount propogation mode
 	ReadonlyRootfs     bool              `json:"readonly_rootfs"`
 	InitPath           string            `json:"initpath"` // dockerinit
 	WorkingDir         string            `json:"working_dir"`

--- a/daemon/execdriver/driver_linux.go
+++ b/daemon/execdriver/driver_linux.go
@@ -24,7 +24,7 @@ func InitContainer(c *Command) *configs.Config {
 	container.Devices = c.AutoCreatedDevices
 	container.Rootfs = c.Rootfs
 	container.Readonlyfs = c.ReadonlyRootfs
-	container.Privatefs = true
+	container.RootMount = c.RootMount
 
 	// check to see if we are running in ramdisk to disable pivot root
 	container.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -137,6 +137,7 @@ type Config struct {
 	MacAddress      string
 	OnBuild         []string
 	Labels          map[string]string
+	RootMount       string // rootfs mount propogation mode: shared/slave/private
 }
 
 type ContainerConfigWrapper struct {

--- a/vendor/src/github.com/docker/libcontainer/configs/config.go
+++ b/vendor/src/github.com/docker/libcontainer/configs/config.go
@@ -72,8 +72,11 @@ type Config struct {
 	// bind mounts are writtable.
 	Readonlyfs bool `json:"readonlyfs"`
 
-	// Privatefs will mount the container's rootfs as private where mount points from the parent will not propogate
-	Privatefs bool `json:"privatefs"`
+	// RootMount is the rootfs mount mode, it is one of the followings:
+	// "private": rootfs is mounted as MS_PRIVATE
+	// "shared":  rootfs is mounted as MS_SHARED
+	// "slave":   rootfs is mounted as MS_SLAVE
+	RootMount string `json:"root_mount"`
 
 	// Mounts specify additional source and destination paths that will be mounted inside the container's
 	// rootfs and mount namespace if specified


### PR DESCRIPTION
This is the docker part of https://github.com/docker/libcontainer/pull/632

It implements [a rootfs mount propagation flag](https://github.com/docker/libcontainer/pull/632#issuecomment-112177281)
