### PR TITLE
tempDir (in the root dir), must be created after the root dir.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -608,17 +608,6 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	// set up SIGUSR1 handler to dump Go routine stacks
 	setupSigusr1Trap()
 
-	// set up the tmpDir to use a canonical path
-	tmp, err := tempDir(config.Root)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to get the TempDir under %s: %s", config.Root, err)
-	}
-	realTmp, err := fileutils.ReadSymlinkedDirectory(tmp)
-	if err != nil {
-		return nil, fmt.Errorf("Unable to get the full path to the TempDir (%s): %s", tmp, err)
-	}
-	os.Setenv("TMPDIR", realTmp)
-
 	// get the canonical path to the Docker root directory
 	var realRoot string
 	if _, err := os.Stat(config.Root); err != nil && os.IsNotExist(err) {
@@ -634,6 +623,17 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	if err := system.MkdirAll(config.Root, 0700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
+
+	// set up the tmpDir to use a canonical path
+	tmp, err := tempDir(config.Root)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get the TempDir under %s: %s", config.Root, err)
+	}
+	realTmp, err := fileutils.ReadSymlinkedDirectory(tmp)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to get the full path to the TempDir (%s): %s", tmp, err)
+	}
+	os.Setenv("TMPDIR", realTmp)
 
 	// Set the default driver
 	graphdriver.DefaultDriver = config.GraphDriver


### PR DESCRIPTION
The temporary directory, that is located in the root directory must be created after the root directory itself.

Before this patch, the root directory was created by MkdirAll, in the tempDir function. Here is a test that proves it: we create the rootDir with 710 credentials, and the tempDir with the 701 one (this is only for test purposes, creating a directory with such credentials is useless).

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -631,7 +631,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
        }
        config.Root = realRoot
        // Create the root directory if it doesn't exists
-       if err := system.MkdirAll(config.Root, 0700); err != nil && !os.IsExist(err) {
+       if err := system.MkdirAll(config.Root, 0710); err != nil && !os.IsExist(err) {
                return nil, err
        }

@@ -944,7 +944,7 @@ func tempDir(rootDir string) (string, error) {
        if tmpDir = os.Getenv("DOCKER_TMPDIR"); tmpDir == "" {
                tmpDir = filepath.Join(rootDir, "tmp")
        }
-       return tmpDir, system.MkdirAll(tmpDir, 0700)
+       return tmpDir, system.MkdirAll(tmpDir, 0701)
 }

 func (daemon *Daemon) setHostConfig(container *Container, hostConfig *runconfig.HostConfig) error {

 # rm -rf /var/lib/docker
 # docker -d &
 # ls -ld /var/lib/docker
drwx-----x 9 root root 4096 Jun 23 14:48 /var/lib/docker
