### PR TITLE
Privileged exec

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -417,7 +417,7 @@ _docker_exec() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--detach -d --help --interactive -i -t --tty -u --user" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--detach -d --help --interactive -i --privileged -t --tty -u --user" -- "$cur" ) )
 			;;
 		*)
 			__docker_containers_running

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -128,6 +128,7 @@ func (d *Daemon) ContainerExecCreate(config *runconfig.ExecConfig) (string, erro
 		Entrypoint: entrypoint,
 		Arguments:  args,
 		User:       config.User,
+		Privileged: config.Privileged,
 	}
 
 	execConfig := &execConfig{

--- a/daemon/execdriver/native/exec.go
+++ b/daemon/execdriver/native/exec.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/libcontainer/utils"
 )
 
-// TODO(vishh): Add support for running in privileged mode.
 func (d *driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, startCallback execdriver.StartCallback) (int, error) {
 	active := d.activeContainers[c.ID]
 	if active == nil {
@@ -26,6 +25,10 @@ func (d *driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 		Env:  c.ProcessConfig.Env,
 		Cwd:  c.WorkingDir,
 		User: processConfig.User,
+	}
+
+	if processConfig.Privileged {
+		p.Capabilities = execdriver.GetAllCapabilities()
 	}
 
 	config := active.Config()

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -1286,6 +1286,7 @@ relative to the current time on the client machine:
 
       -d, --detach=false         Detached mode: run command in the background
       -i, --interactive=false    Keep STDIN open even if not attached
+      --privileged=false         Give extended privileges to the command
       -t, --tty=false            Allocate a pseudo-TTY
       -u, --user=                Username or UID (format: <name|uid>[:<group|gid>])
 

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -635,3 +635,28 @@ func (s *DockerSuite) TestExecWithUser(c *check.C) {
 	}
 
 }
+
+func (s *DockerSuite) TestExecWithPrivileged(c *check.C) {
+
+	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "parent", "--cap-drop=ALL", "busybox", "top")
+	if out, _, err := runCommandWithOutput(runCmd); err != nil {
+		c.Fatal(out, err)
+	}
+
+	cmd := exec.Command(dockerBinary, "exec", "parent", "sh", "-c", "mknod /tmp/sda b 8 0")
+	out, _, err := runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "Operation not permitted") {
+		c.Fatalf("exec mknod in --cap-drop=ALL container without --privileged should failed")
+	}
+
+	cmd = exec.Command(dockerBinary, "exec", "--privileged", "parent", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(err, out)
+	}
+
+	if actual := strings.TrimSpace(out); actual != "ok" {
+		c.Fatalf("exec mknod in --cap-drop=ALL container with --privileged failed: %v, output: %q", err, out)
+	}
+
+}

--- a/man/docker-exec.1.md
+++ b/man/docker-exec.1.md
@@ -9,6 +9,7 @@ docker-exec - Run a command in a running container
 [**-d**|**--detach**[=*false*]]
 [**--help**]
 [**-i**|**--interactive**[=*false*]]
+[**--privileged**[=*false*]]
 [**-t**|**--tty**[=*false*]]
 [**-u**|**--user**[=*USER*]]
 CONTAINER COMMAND [ARG...]
@@ -32,6 +33,13 @@ container is unpaused, and then run
 
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.
+
+**--privileged**=*true*|*false*
+   Give extended privileges to the process to run in a running container. The default is *false*.
+
+   By default, the process run by docker exec in a running container
+have the same capabilities of the container. By setting --privileged will give
+all the capabilities to the process.
 
 **-t**, **--tty**=*true*|*false*
    Allocate a pseudo-TTY. The default is *false*.

--- a/runconfig/exec.go
+++ b/runconfig/exec.go
@@ -18,12 +18,13 @@ type ExecConfig struct {
 
 func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 	var (
-		flStdin   = cmd.Bool([]string{"i", "-interactive"}, false, "Keep STDIN open even if not attached")
-		flTty     = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
-		flDetach  = cmd.Bool([]string{"d", "-detach"}, false, "Detached mode: run command in the background")
-		flUser    = cmd.String([]string{"u", "-user"}, "", "Username or UID (format: <name|uid>[:<group|gid>])")
-		execCmd   []string
-		container string
+		flStdin      = cmd.Bool([]string{"i", "-interactive"}, false, "Keep STDIN open even if not attached")
+		flTty        = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
+		flDetach     = cmd.Bool([]string{"d", "-detach"}, false, "Detached mode: run command in the background")
+		flUser       = cmd.String([]string{"u", "-user"}, "", "Username or UID (format: <name|uid>[:<group|gid>])")
+		flPrivileged = cmd.Bool([]string{"-privileged"}, false, "Give extended privileges to the command")
+		execCmd      []string
+		container    string
 	)
 	cmd.Require(flag.Min, 2)
 	if err := cmd.ParseFlags(args, true); err != nil {
@@ -34,13 +35,12 @@ func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 	execCmd = parsedArgs[1:]
 
 	execConfig := &ExecConfig{
-		User: *flUser,
-		// TODO(vishh): Expose 'Privileged' once it is supported.
-		// +		//Privileged:   job.GetenvBool("Privileged"),
-		Tty:       *flTty,
-		Cmd:       execCmd,
-		Container: container,
-		Detach:    *flDetach,
+		User:       *flUser,
+		Privileged: *flPrivileged,
+		Tty:        *flTty,
+		Cmd:        execCmd,
+		Container:  container,
+		Detach:     *flDetach,
 	}
 
 	// If -d is not set, attach to everything by default


### PR DESCRIPTION
This restores the --privileged flag for docker exec. It also adds a test that verifies that neither subsequent execs nor the original process is granted permissions after running a privileged exec (which was the reason it was previously reverted).
