### PR TITLE
pkg/plugins: add plugin name in discovery path

### DIFF
--- a/pkg/plugins/discovery.go
+++ b/pkg/plugins/discovery.go
@@ -34,12 +34,22 @@ func newLocalRegistry(path string) *LocalRegistry {
 }
 
 func (l *LocalRegistry) Plugin(name string) (*Plugin, error) {
-	filepath := filepath.Join(l.path, name)
-	specpath := filepath + ".spec"
+	basepath := filepath.Join(l.path, name, name)
+	specpath := basepath + ".spec"
 	if fi, err := os.Stat(specpath); err == nil {
 		return readPluginInfo(specpath, fi)
 	}
-	socketpath := filepath + ".sock"
+	socketpath := basepath + ".sock"
+	if fi, err := os.Stat(socketpath); err == nil {
+		return readPluginInfo(socketpath, fi)
+	}
+
+	basepath = filepath.Join(l.path, name)
+	specpath = basepath + ".spec"
+	if fi, err := os.Stat(specpath); err == nil {
+		return readPluginInfo(specpath, fi)
+	}
+	socketpath = basepath + ".sock"
 	if fi, err := os.Stat(socketpath); err == nil {
 		return readPluginInfo(socketpath, fi)
 	}


### PR DESCRIPTION
The current plugin discovery mecanism expect all the socket and spec to be located at the root of `/usr/share/docker/plugins`. When running a plugin in a container mounting `/usr/share/docker/plugins` as a volume can be problematic as it would give a plugin access to all other plugin sockets.

This patch add a lookup for `/usr/share/docker/plugins/{pluginname}/{pluginname}.sock` before fallbacking into `/usr/share/docker/plugins/{pluginname}.sock`.

Let me know if this need better testing (for the fallback, the spec), I rushed this quickly in the contributor room between two session.
