### PR TITLE
[api, builder] Fix build auth config

### DIFF
--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -98,8 +98,8 @@ type Builder struct {
 	// the final configs of the Dockerfile but dont want the layers
 	disableCommit bool
 
-	AuthConfig *cliconfig.AuthConfig
-	ConfigFile *cliconfig.ConfigFile
+	// Registry server auth configs used to pull images when handling `FROM`.
+	AuthConfigs map[string]cliconfig.AuthConfig
 
 	// Deprecated, original writer used for ImagePull. To be removed.
 	OutOld          io.Writer

--- a/builder/job.go
+++ b/builder/job.go
@@ -59,8 +59,7 @@ type Config struct {
 	CpuSetCpus     string
 	CpuSetMems     string
 	CgroupParent   string
-	AuthConfig     *cliconfig.AuthConfig
-	ConfigFile     *cliconfig.ConfigFile
+	AuthConfigs    map[string]cliconfig.AuthConfig
 
 	Stdout  io.Writer
 	Context io.ReadCloser
@@ -85,9 +84,8 @@ func (b *Config) WaitCancelled() <-chan struct{} {
 
 func NewBuildConfig() *Config {
 	return &Config{
-		AuthConfig: &cliconfig.AuthConfig{},
-		ConfigFile: &cliconfig.ConfigFile{},
-		cancelled:  make(chan struct{}),
+		AuthConfigs: map[string]cliconfig.AuthConfig{},
+		cancelled:   make(chan struct{}),
 	}
 }
 
@@ -190,8 +188,7 @@ func Build(d *daemon.Daemon, buildConfig *Config) error {
 		Pull:            buildConfig.Pull,
 		OutOld:          buildConfig.Stdout,
 		StreamFormatter: sf,
-		AuthConfig:      buildConfig.AuthConfig,
-		ConfigFile:      buildConfig.ConfigFile,
+		AuthConfigs:     buildConfig.AuthConfigs,
 		dockerfileName:  buildConfig.DockerfileName,
 		cpuShares:       buildConfig.CpuShares,
 		cpuPeriod:       buildConfig.CpuPeriod,


### PR DESCRIPTION
With the 1.7 release, we introduced a change to how we store registry
credentials, but the build API endpoint did not expect a change in the format
of that file. This patch fixes this problem so that you can again pull private
images during `docker build`.

fixes #14065
fixes #14092
fixes #14057
