### PR TITLE
Add docker run --net=network:<net-name>

### DIFF
--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -803,6 +803,11 @@ func (container *Container) AllocateNetwork() error {
 		return fmt.Errorf("conflicting options: publishing a service and network mode")
 	}
 
+	if mode.IsNetwork() {
+		parts := strings.SplitN(string(mode), ":", 2)
+		networkName = parts[1]
+	}
+
 	if service == "" {
 		// dot character "." has a special meaning to support SERVICE[.NETWORK] format.
 		// For backward compatiblity, replacing "." with "-", instead of failing

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -36,6 +36,8 @@ func (n NetworkMode) NetworkName() string {
 		return "host"
 	} else if n.IsContainer() {
 		return "container"
+	} else if n.IsNetwork() {
+		return "network"
 	} else if n.IsNone() {
 		return "none"
 	} else if n.IsDefault() {
@@ -55,6 +57,11 @@ func (n NetworkMode) IsHost() bool {
 func (n NetworkMode) IsContainer() bool {
 	parts := strings.SplitN(string(n), ":", 2)
 	return len(parts) > 1 && parts[0] == "container"
+}
+
+func (n NetworkMode) IsNetwork() bool {
+	parts := strings.SplitN(string(n), ":", 2)
+	return len(parts) > 1 && parts[0] == "network"
 }
 
 func (n NetworkMode) IsNone() bool {

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -467,7 +467,7 @@ func parseNetMode(netMode string) (NetworkMode, error) {
 	parts := strings.Split(netMode, ":")
 	switch mode := parts[0]; mode {
 	case "default", "bridge", "none", "host":
-	case "container":
+	case "container", "network":
 		if len(parts) < 2 || parts[1] == "" {
 			return "", fmt.Errorf("invalid container format container:<name|id>")
 		}


### PR DESCRIPTION
As per networking BoF, add the missing UI to have a container join an
extant network.  There is a wart whereby a service is actually created and
published with the same name as the container.  Before committing this,
I would argue to fix that and hide that detail of the implementation.

Signed-off-by: Tim Hockin thockin@google.com

@squaremo @mavenugo @mrjana @lxpollitt @ibuildthecloud @errordeveloper @vbatts @bfirsh @mrunalp @rajatchopra
