### PR TITLE
Fix a broken link to .dockerignore

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -51,7 +51,7 @@ In most cases, it's best to put each Dockerfile in an empty directory. Then,
 only add the files needed for building the Dockerfile to the directory. To
 increase the build's performance, you can exclude files and directories by
 adding a `.dockerignore` file to the directory.  For information about how to
-[create a `.dockerignore` file](#the-dockerignore-file) on this page.
+[create a `.dockerignore` file](#dockerignore-file) on this page.
 
 You can specify a repository and tag at which to save the new image if
 the build succeeds:


### PR DESCRIPTION
Looks like there was one link was missed when updating the .dockerignore
references on the CLI page.

Tested by running `make docs` and browsing locally.

Signed-off-by: Chris McKinnel chrismckinnel@gmail.com
