### PR TITLE
Proposal: builder: add LAYER command

### DIFF
--- a/builder/command/command.go
+++ b/builder/command/command.go
@@ -7,6 +7,7 @@ const (
 	Maintainer = "maintainer"
 	Add        = "add"
 	Copy       = "copy"
+	Layer      = "layer"
 	From       = "from"
 	Onbuild    = "onbuild"
 	Workdir    = "workdir"
@@ -25,6 +26,7 @@ var Commands = map[string]struct{}{
 	Maintainer: {},
 	Add:        {},
 	Copy:       {},
+	Layer:      {},
 	From:       {},
 	Onbuild:    {},
 	Workdir:    {},

--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -160,7 +160,7 @@ func add(b *Builder, args []string, attributes map[string]bool, original string)
 		return err
 	}
 
-	return b.runContextCommand(args, true, true, "ADD")
+	return b.runContextCommand(args, true, true, "ADD", "")
 }
 
 // COPY foo /path
@@ -176,7 +176,33 @@ func dispatchCopy(b *Builder, args []string, attributes map[string]bool, origina
 		return err
 	}
 
-	return b.runContextCommand(args, false, false, "COPY")
+	return b.runContextCommand(args, false, false, "COPY", "")
+}
+
+// LAYER foo [sha256:sum]
+//
+// Add the layer to the root filesystem. Tarball argument is required
+// and Remote URL (git, http) handling exist here, if present checksum
+// is verified.
+//
+func layer(b *Builder, args []string, attributes map[string]bool, original string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("LAYER requires at least one argument")
+	}
+	if len(args) > 2 {
+		return fmt.Errorf("LAYER requires no more than two arguments")
+	}
+
+	if err := b.BuilderFlags.Parse(); err != nil {
+		return err
+	}
+
+	sum := ""
+	if len(args) == 2 {
+		sum = args[1]
+	}
+	args = append(args[:1], "/")
+	return b.runContextCommand(args, true, true, "LAYER", sum)
 }
 
 // FROM imagename

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -47,6 +47,7 @@ var replaceEnvAllowed = map[string]struct{}{
 	command.Label:   {},
 	command.Add:     {},
 	command.Copy:    {},
+	command.Layer:   {},
 	command.Workdir: {},
 	command.Expose:  {},
 	command.Volume:  {},
@@ -62,6 +63,7 @@ func init() {
 		command.Maintainer: maintainer,
 		command.Add:        add,
 		command.Copy:       dispatchCopy, // copy() is a go builtin
+		command.Layer:      layer,        // copy() is a go builtin
 		command.From:       from,
 		command.Onbuild:    onbuild,
 		command.Workdir:    workdir,

--- a/builder/parser/parser.go
+++ b/builder/parser/parser.go
@@ -56,6 +56,7 @@ func init() {
 		command.From:       parseString,
 		command.Add:        parseMaybeJSONToList,
 		command.Copy:       parseMaybeJSONToList,
+		command.Layer:      parseMaybeJSONToList,
 		command.Run:        parseMaybeJSON,
 		command.Cmd:        parseMaybeJSON,
 		command.Entrypoint: parseMaybeJSON,


### PR DESCRIPTION
The `LAYER` command fetch a remote layer, verify it against a given
checksum and merge it with the current image rootfs.

It combines two mutually exclusive "features" of `ADD`:
- fetching remote urls
- ability to extract archives

to allow building images by composing a set of remote layer tarballs.

It could also be seen as the `Dockerfile`'s equivalent of `docker import` with the caveat that it can _layer_ on top of existing images.

_The current implementation is a rushed and hacky proof of concept to illustrate
 the design proposal with minimal change to the existing builder._

Usage:
- busybox

```
FROM scratch
LAYER http://dl-3.alpinelinux.org/alpine/latest-stable/main/x86_64/busybox-static-1.23.2-r0.apk\
      sha256:92dda33f9b863aed1c9f5f4a4a5dcd4c921b614d36c40cb8ee0f60c565d91ef3
```

```
👺docker build --no-cache -t minibox -f Dockerfile.minibox . && docker images minibox
Sending build context to Docker daemon 15.68 MB
Sending build context to Docker daemon
Step 0 : FROM scratch
 --->
Step 1 : LAYER http://dl-3.alpinelinux.org/alpine/latest-stable/main/x86_64/busybox-static-1.23.2-r0.apk sha256:92dda33f9b863aed1c9f5f4a4a5dcd4c921b614d36c40cb8ee0f60c565d91ef3
Downloading 562.9 kB/562.9 kB
 ---> 52f61f367cbf
Removing intermediate container db3742214dd6
Successfully built 52f61f367cbf
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
minibox             latest              52f61f367cbf        6 seconds ago       908.5 kB
```
- nginx

```
FROM scratch
LAYER http://morpheus.2f30.org/0.0/packages/x86_64/nginx%231.6.0.pkg.tgz \
      sha256:fef9032b05408d1b62ffdc7638d8d9d6f27b67f63f2e0ee134ffbbd38683bb0e
```

```
🍊docker build --no-cache -t minginx -f Dockerfile.minginx . && docker images minginx
Sending build context to Docker daemon 15.68 MB
Sending build context to Docker daemon
Step 0 : FROM scratch
 --->
Step 1 : LAYER http://morpheus.2f30.org/0.0/packages/x86_64/nginx%231.6.0.pkg.tgz sha256:fef9032b05408d1b62ffdc7638d8d9d6f27b67f63f2e0ee134ffbbd38683bb0e
Downloading 602.3 kB/602.3 kB
 ---> 7baf6f5627a0
Removing intermediate container a5a6e4cc9bad
Successfully built 7baf6f5627a0
REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
minginx             latest              7baf6f5627a0        4 seconds ago       1.986 MB
```
- busybox + nginx

```
FROM scratch
LAYER http://dl-3.alpinelinux.org/alpine/latest-stable/main/x86_64/busybox-static-1.23.2-r0.apk\
      sha256:92dda33f9b863aed1c9f5f4a4a5dcd4c921b614d36c40cb8ee0f60c565d91ef3
LAYER http://morpheus.2f30.org/0.0/packages/x86_64/nginx%231.6.0.pkg.tgz \
      sha256:fef9032b05408d1b62ffdc7638d8d9d6f27b67f63f2e0ee134ffbbd38683bb0e
```

It enables the following use cases:
- compose docker image declaratively from multiple layers/archives.
- validate remote dependencies.
- make it easy to build context-less image w/ `FROM scratch`.
- enable auto-build with `FROM scratch` w/o polluting the git repository
  with tarballs.
- static verification and in place upgrade of layers.

The final implementation should meet the following requirements:
- do not break existing behavior of `ADD` and `COPY`.
- follow the same caching behavior as `ADD` and `COPY`.
- add additional image metadata on the provenance and the checksum the
  layer.
- enable verification of non-overlapping layers without enforcing it.
- provide CLI and API equivalents.

The proposal in its current form arguably presents the following
disavantages:
- new `Dockerfile` command to learn instead of extending `ADD` or`COPY`.
- surface explicitly the notion of layers in the Dockerfile domain,
  while it was mostly implicit in the current `Dockerfile`
  implementation (one layer per line).
- duplicate part of the `FROM` command role of importing third party
  layers into an image.
