### PR TITLE
Docs: fix wrong example of API Exec

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -1875,7 +1875,7 @@ Sets up an exec instance in a running container `id`
        "Tty": false,
        "Cmd": [
                      "date"
-             ],
+             ]
       }
 
 **Example response**:
@@ -1917,7 +1917,7 @@ interactive session with the `exec` command.
 
     {
      "Detach": false,
-     "Tty": false,
+     "Tty": false
     }
 
 **Example response**:


### PR DESCRIPTION
The last "," should not shown up, otherwise you will get the error
back as below:
- invalid character '}' looking for beginning of object key string.

Signed-off-by: Hu Keping hukeping@huawei.com
