### PR TITLE
more friendly message for when docker daemon is not running.

### DIFF
--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -89,7 +89,7 @@ func (cli *DockerCli) clientRequest(method, path string, in io.Reader, headers m
 		}
 
 		if cli.tlsConfig == nil {
-			return nil, nil, statusCode, fmt.Errorf("%v. Are you trying to connect to a TLS-enabled daemon without TLS?", err)
+			return nil, nil, statusCode, fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?\n* Is your docker daemon up and running?", err)
 		}
 		return nil, nil, statusCode, fmt.Errorf("An error occurred trying to connect: %v", err)
 	}


### PR DESCRIPTION
make error message when running commands while daemon is down more user-friendly.

```
docker@54.175.201.239 ~: sudo service docker stop
docker stop/waiting
docker@54.175.201.239 ~: docker images
Get http:///var/run/docker.sock/v1.19/images/json: dial unix /var/run/docker.sock: no such file or directory. Are you trying to connect to a TLS-enabled daemon without TLS?
```
