### PR TITLE
Update the documentation for run reference

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -772,45 +772,161 @@ In addition to `--privileged`, the operator can have fine grain control over the
 capabilities using `--cap-add` and `--cap-drop`. By default, Docker has a default
 list of capabilities that are kept. The following table lists the Linux capability options which can be added or dropped.
 
-| Capability Key | Capability Description |
-| :----------------- | :---------------| :-------------------- |
-| SETPCAP | Modify process capabilities. |
-| SYS_MODULE| Load and unload kernel modules. |
-| SYS_RAWIO | Perform I/O port operations (iopl(2) and ioperm(2)). |
-| SYS_PACCT | Use acct(2), switch process accounting on or off. |
-| SYS_ADMIN | Perform a range of system administration operations. |
-| SYS_NICE | Raise process nice value (nice(2), setpriority(2)) and change the nice value for arbitrary processes. |
-| SYS_RESOURCE | Override resource Limits. |
-| SYS_TIME | Set system clock (settimeofday(2), stime(2), adjtimex(2)); set real-time (hardware) clock. |
-| SYS_TTY_CONFIG | Use vhangup(2); employ various privileged ioctl(2) operations on virtual terminals. |
-| MKNOD | Create special files using mknod(2). |
-| AUDIT_WRITE | Write records to kernel auditing log. |
-| AUDIT_CONTROL | Enable and disable kernel auditing; change auditing filter rules; retrieve auditing status and filtering rules. |
-| MAC_OVERRIDE | Allow MAC configuration or state changes. Implemented for the Smack LSM. |
-| MAC_ADMIN | Override Mandatory Access Control (MAC). Implemented for the Smack Linux Security Module (LSM). |
-| NET_ADMIN | Perform various network-related operations. |
-| SYSLOG | Perform privileged syslog(2) operations.  |
-| CHOWN | Make arbitrary changes to file UIDs and GIDs (see chown(2)). |
-| NET_RAW | Use RAW and PACKET sockets. |
-| DAC_OVERRIDE | Bypass file read, write, and execute permission checks. |
-| FOWNER | Bypass permission checks on operations that normally require the file system UID of the process to match the UID of the file. |
-| DAC_READ_SEARCH | Bypass file read permission checks and directory read and execute permission checks. |
-| FSETID | Don't clear set-user-ID and set-group-ID permission bits when a file is modified. |
-| KILL | Bypass permission checks for sending signals. |
-| SETGID | Make arbitrary manipulations of process GIDs and supplementary GID list. |
-| SETUID | Make arbitrary manipulations of process UIDs. |
-| LINUX_IMMUTABLE | Set the FS_APPEND_FL and FS_IMMUTABLE_FL i-node flags. |
-| NET_BIND_SERVICE  | Bind a socket to internet domain privileged ports (port numbers less than 1024). |
-| NET_BROADCAST |  Make socket broadcasts, and listen to multicasts. |
-| IPC_LOCK | Lock memory (mlock(2), mlockall(2), mmap(2), shmctl(2)). |
-| IPC_OWNER | Bypass permission checks for operations on System V IPC objects. |
-| SYS_CHROOT | Use chroot(2), change root directory. |
-| SYS_PTRACE | Trace arbitrary processes using ptrace(2). |
-| SYS_BOOT | Use reboot(2) and kexec_load(2), reboot and load a new kernel for later execution. |
-| LEASE | Establish leases on arbitrary files (see fcntl(2)). |
-| SETFCAP | Set file capabilities.|
-| WAKE_ALARM | Trigger something that will wake up the system. |
-| BLOCK_SUSPEND | Employ features that can block system suspend. |
+
+<table>
+ <tr>
+  <th>Capability Key</th>
+  <th>Capability Description</th>
+ </tr>
+ <tr>
+  <td>SETPCAP</td>
+  <td>Modify process capabilities.</td>
+ </tr>
+ <tr>
+  <td>SYS_MODULE</td>
+  <td>Load and unload kernel modules.</td>
+ </tr>
+ <tr>
+  <td>SYS_RAWIO</td>
+  <td>Perform I/O port operations (iopl(2) and ioperm(2)).</td>
+ </tr>
+ <tr>
+  <td>SYS_PACCT</td>
+  <td>Use acct(2), switch process accounting on or off.</td>
+ </tr>
+ <tr>
+  <td>SYS_ADMIN</td>
+  <td>Perform a range of system administration operations.</td>
+ </tr>
+ <tr>
+  <td>SYS_NICE</td>
+  <td>Raise process nice value (nice(2), setpriority(2)) and change the nice value for arbitrary processes.</td>
+ </tr>
+ <tr>
+  <td>SYS_RESOURCE</td>
+  <td>Override resource Limits.</td>
+ </tr>
+ <tr>
+  <td>SYS_TIME</td>
+  <td>Set system clock (settimeofday(2), stime(2), adjtimex(2)); set real-time (hardware) clock.</td>
+ </tr>
+ <tr>
+  <td>SYS_TTY_CONFIG</td>
+  <td>Use vhangup(2); employ various privileged ioctl(2) operations on virtual terminals.</td>
+ </tr>
+ <tr>
+  <td>MKNOD</td>
+  <td>Create special files using mknod(2).</td>
+ </tr>
+ <tr>
+  <td>AUDIT_WRITE</td>
+  <td>Write records to kernel auditing log.</td>
+ </tr>
+ <tr>
+  <td>AUDIT_CONTROL</td>
+  <td>Enable and disable kernel auditing; change auditing filter rules; retrieve auditing status and filtering rules.</td>
+ </tr>
+ <tr>
+  <td>MAC_OVERRIDE</td>
+  <td>Allow MAC configuration or state changes. Implemented for the Smack LSM.</td>
+ </tr>
+ <tr>
+  <td>MAC_ADMIN</td>
+  <td>Override Mandatory Access Control (MAC). Implemented for the Smack Linux Security Module (LSM).</td>
+ </tr>
+ <tr>
+  <td>NET_ADMIN</td>
+  <td>Perform various network-related operations.</td>
+ </tr>
+ <tr>
+  <td>SYSLOG</td>
+  <td>Perform privileged syslog(2) operations.</td>
+ </tr>
+ <tr>
+  <td>CHOWN</td>
+  <td>Make arbitrary changes to file UIDs and GIDs (see chown(2)).</td>
+ </tr>
+ <tr>
+  <td>NET_RAW</td>
+  <td>Use RAW and PACKET sockets.</td>
+ </tr>
+ <tr>
+  <td>DAC_OVERRIDE</td>
+  <td>Bypass file read, write, and execute permission checks.</td>
+ </tr>
+ <tr>
+  <td>FOWNER</td>
+  <td>Bypass permission checks on operations that normally require the file system UID of the process to match the UID of the file.</td>
+ </tr>
+ <tr>
+  <td>DAC_READ_SEARCH</td>
+  <td>Bypass file read permission checks and directory read and execute permission checks.</td>
+ </tr>
+ <tr>
+  <td>FSETID</td>
+  <td>Don't clear set-user-ID and set-group-ID permission bits when a file is modified.</td>
+ </tr>
+ <tr>
+  <td>KILL</td>
+  <td>Bypass permission checks for sending signals.</td>
+ </tr>
+ <tr>
+  <td>SETGID</td>
+  <td>Make arbitrary manipulations of process GIDs and supplementary GID list.</td>
+ </tr>
+ <tr>
+  <td>SETUID</td>
+  <td>Make arbitrary manipulations of process UIDs.</td>
+ </tr>
+ <tr>
+  <td>LINUX_IMMUTABLE</td>
+  <td>Set the FS_APPEND_FL and FS_IMMUTABLE_FL i-node flags.</td>
+ </tr>
+ <tr>
+  <td>NET_BIND_SERVICE</td>
+  <td>Bind a socket to internet domain privileged ports (port numbers less than 1024).</td>
+ </tr>
+ <tr>
+  <td>NET_BROADCAST</td>
+  <td>Make socket broadcasts, and listen to multicasts.</td>
+ </tr>
+ <tr>
+  <td>IPC_LOCK</td>
+  <td>Lock memory (mlock(2), mlockall(2), mmap(2), shmctl(2)).</td>
+ </tr>
+ <tr>
+  <td>IPC_OWNER</td>
+  <td>Bypass permission checks for operations on System V IPC objects.</td>
+ </tr>
+ <tr>
+  <td>SYS_CHROOT</td>
+  <td>Use chroot(2), change root directory.</td>
+ </tr>
+ <tr>
+  <td>SYS_PTRACE</td>
+  <td>Trace arbitrary processes using ptrace(2).</td>
+ </tr>
+ <tr>
+  <td>SYS_BOOT</td>
+  <td>Use reboot(2) and kexec_load(2), reboot and load a new kernel for later execution.</td>
+ </tr>
+ <tr>
+  <td>LEASE</td>
+  <td>Establish leases on arbitrary files (see fcntl(2)).</td>
+ </tr>
+ <tr>
+  <td>SETFCAP</td>
+  <td>Set file capabilities.</td>
+ </tr>
+ <tr>
+  <td>WAKE_ALARM</td>
+  <td>Trigger something that will wake up the system.</td>
+ </tr>
+ <tr>
+  <td>BLOCK_SUSPEND</td>
+  <td>Employ features that can block system suspend.</td>
+ </tr>
+</table>
 
 Further reference information is available on the [capabilities(7) - Linux man page](http://linux.die.net/man/7/capabilities)
 


### PR DESCRIPTION
Fixed the messy table format for Linux capability options in run reference.
Fixed #14176
Signed-off-by: Henry Huang henry.s.huang@gmail.com
