### PR TITLE
Document the location of experimental binary

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -9,7 +9,7 @@ issues associated with it. If necessary, links are provided to additional
 documentation on an issue.  As an active Docker user and community member,
 please feel free to provide any feedback on these features you wish.
 
-## Install Docker experimental 
+## Install Docker experimental
 
 Unlike the regular Docker binary, the experimental channels is built and updated nightly on TO.BE.ANNOUNCED. From one day to the next, new features may appear, while existing experimental features may be refined or entirely removed.
 
@@ -41,6 +41,23 @@ Unlike the regular Docker binary, the experimental channels is built and updated
         $ sudo docker run hello-world
 
     This command downloads a test image and runs it in a container.
+
+### Get the Linux binary
+To download the latest experimental `docker` binary for Linux,
+use the following URLs:
+
+    https://experimental.docker.com/builds/Linux/i386/docker-latest
+
+    https://experimental.docker.com/builds/Linux/x86_64/docker-latest
+
+After downloading the appropriate binary, you can follow the instructions
+[here](https://docs.docker.com/installation/binaries/#get-the-docker-binary) to run the `docker` daemon.
+
+> **Note**
+>
+> 1) You can get the MD5 and SHA256 hashes by appending .md5 and .sha256 to the URLs respectively
+>
+> 2) You can get the compressed binaries by appending .tgz to the URLs
 
 ## Current experimental features
 


### PR DESCRIPTION
Some devs might want to download the binary directly,
especially for systems where the install script does not
work.

Signed-off-by: Ankush Agarwal ankushagarwal11@gmail.com
