### PR TITLE
add --format flag to `docker version`

### DIFF
--- a/docs/reference/commandline/version.md
+++ b/docs/reference/commandline/version.md
@@ -15,8 +15,17 @@ weight=1
 
     Show the Docker version information.
 
-Show the Docker version, API version, Go version, Git commit, Build date/time,
-and OS/architecture of both Docker client and daemon. Example use:
+      -f, --format=""    Format the output using the given go template
+
+By default, this will render all version information in an easy to read
+layout. If a format is specified, the given template will be executed instead.
+
+Go's [text/template](http://golang.org/pkg/text/template/) package
+describes all the details of the format.
+
+## Examples
+
+**Default output:**
 
     $ docker version
 	Client:
@@ -34,3 +43,14 @@ and OS/architecture of both Docker client and daemon. Example use:
 	 Git commit:   f5bae0a
 	 Built:        Tue Jun 23 17:56:00 UTC 2015
 	 OS/Arch:      linux/amd64
+
+**Get server version:**
+
+    $ docker version --format '{{.Server.Version}}'
+	1.8.0
+
+**Dump raw data:**
+
+    $ docker version --format '{{json .}}'
+    {"Client":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"},"ServerOK":true,"Server":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","KernelVersion":"3.13.2-gentoo","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"}}
+

--- a/man/docker-version.1.md
+++ b/man/docker-version.1.md
@@ -6,19 +6,25 @@ docker-version - Show the Docker version information.
 
 # SYNOPSIS
 **docker version**
+[**--help**]
+[**-f**|**--format**[=*FORMAT*]]
 
 # DESCRIPTION
 This command displays version information for both the Docker client and 
 daemon. 
 
 # OPTIONS
-There are no available options.
+**--help**
+    Print usage statement
+
+**-f**, **--format**=""
+    Format the output using the given go template.
 
 # EXAMPLES
 
 ## Display Docker version information
 
-Here is a sample output:
+The default output:
 
     $ docker version
 	Client:
@@ -36,7 +42,21 @@ Here is a sample output:
 	 Git commit:   f5bae0a
 	 Built:        Tue Jun 23 17:56:00 UTC 2015
 	 OS/Arch:      linux/amd64
+
+Get server version:
+
+    $ docker version --format '{{.Server.Version}}'
+	1.8.0
+
+Dump raw data:
+
+To view all available fields, you can use the format `{{json .}}`.
+
+    $ docker version --format '{{json .}}'
+    {"Client":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"},"ServerOK":true,"Server":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","KernelVersion":"3.13.2-gentoo","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"}}
+
 	
 # HISTORY
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 June 2015, updated by John Howard <jhoward@microsoft.com>
+June 2015, updated by Patrick Hemmer <patrick.hemmer@gmail.com


### PR DESCRIPTION
This adds the `--format` flag to `docker version`.

Closes #14186 

**Default output:**

```
$ docker version
Client:
 Version:      1.8.0
 API version:  1.20
 Go version:   go1.4.2
 Git commit:   f5bae0a
 Built:        Tue Jun 23 17:56:00 UTC 2015
 OS/Arch:      linux/amd64

Server:
 Version:      1.8.0
 API version:  1.20
 Go version:   go1.4.2
 Git commit:   f5bae0a
 Built:        Tue Jun 23 17:56:00 UTC 2015
 OS/Arch:      linux/amd64
```

**Get server version:**

```
$ docker version --format '{{.Server.Version}}'
1.8.0
```

**Dump raw data:**

```
$ docker version --format '{{json .}}'
{"Client":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"},"ServerOK":true,"Server":{"Version":"1.8.0","ApiVersion":"1.20","GitCommit":"f5bae0a","GoVersion":"go1.4.2","Os":"linux","Arch":"amd64","KernelVersion":"3.13.2-gentoo","BuildTime":"Tue Jun 23 17:56:00 UTC 2015"}}
```

**Dead server:**

```
$ docker version
Client:
 Version:      1.8.0-dev
 API version:  1.20
 Go version:   go1.4.1
 Git commit:   2a8293f-dirty
 Built:        Fri Jun 26 01:38:16 UTC 2015
 OS/Arch:      linux/amd64
Get http:///var/run/docker.sock/v1.20/version: dial unix /var/run/docker.sock: no such file or directory. Are you trying to connect to a TLS-enabled daemon without TLS?
```

_(error goes to STDERR, allowing capturing STDOUT to still work if only client data is needed)_
