### PR TITLE
Fix DOCKER_OPTS not being honored on debian 8. Fixes #14130

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -5,7 +5,8 @@ After=network.target docker.socket
 Requires=docker.socket
 
 [Service]
-ExecStart=/usr/bin/docker -d -H fd://
+ExecStart=/usr/bin/docker -d -H fd:// $DOCKER_OPTS
+EnvironmentFile=-/etc/default/docker
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
Adds the default environment file /etc/default/docker to the default systemd configuration, and applies the DOCKER_OPTS variable to the daemon options.

This fixes DOCKER_OPTS not applying properly on debian 8 without hacking this file.

See #14130
