### PR TITLE
Fixed #14036 - add two new options to the `exec` command

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -417,7 +417,7 @@ _docker_exec() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--detach -d --help --interactive -i -t --tty -u --user" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--detach -d --help --interactive -i -t --tty -u --user -e --env --env-file" -- "$cur" ) )
 			;;
 		*)
 			__docker_containers_running

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -128,6 +128,7 @@ func (d *Daemon) ContainerExecCreate(config *runconfig.ExecConfig) (string, erro
 		Entrypoint: entrypoint,
 		Arguments:  args,
 		User:       config.User,
+		Env:        config.Env,
 	}
 
 	execConfig := &execConfig{

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -140,6 +140,7 @@ type ProcessConfig struct {
 
 	Privileged bool     `json:"privileged"`
 	User       string   `json:"user"`
+	Env        []string `json:"env"`
 	Tty        bool     `json:"tty"`
 	Entrypoint string   `json:"entrypoint"`
 	Arguments  []string `json:"arguments"`

--- a/daemon/execdriver/native/exec.go
+++ b/daemon/execdriver/native/exec.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/docker/docker/daemon/execdriver"
+	tools "github.com/docker/docker/utils"
 	"github.com/docker/libcontainer"
 	_ "github.com/docker/libcontainer/nsenter"
 	"github.com/docker/libcontainer/utils"
@@ -21,9 +22,11 @@ func (d *driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 		return -1, fmt.Errorf("No active container exists with ID %s", c.ID)
 	}
 
+	env := tools.ReplaceOrAppendEnvValues(c.ProcessConfig.Env, processConfig.Env)
+
 	p := &libcontainer.Process{
 		Args: append([]string{processConfig.Entrypoint}, processConfig.Arguments...),
-		Env:  c.ProcessConfig.Env,
+		Env:  env,
 		Cwd:  c.WorkingDir,
 		User: processConfig.User,
 	}

--- a/docs/reference/commandline/exec.md
+++ b/docs/reference/commandline/exec.md
@@ -19,6 +19,8 @@ weight=1
       -i, --interactive=false    Keep STDIN open even if not attached
       -t, --tty=false            Allocate a pseudo-TTY
       -u, --user=                Username or UID (format: <name|uid>[:<group|gid>])
+      -e, --env=[]               Set environment variables
+      --env-file=[]              Read in a file of environment variables
 
 The `docker exec` command runs a new command in a running container.
 

--- a/runconfig/exec.go
+++ b/runconfig/exec.go
@@ -1,11 +1,13 @@
 package runconfig
 
 import (
+	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 )
 
 type ExecConfig struct {
 	User         string
+	Env          []string
 	Privileged   bool
 	Tty          bool
 	Container    string
@@ -22,9 +24,14 @@ func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 		flTty     = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
 		flDetach  = cmd.Bool([]string{"d", "-detach"}, false, "Detached mode: run command in the background")
 		flUser    = cmd.String([]string{"u", "-user"}, "", "Username or UID (format: <name|uid>[:<group|gid>])")
+		flEnv     = opts.NewListOpts(opts.ValidateEnv)
+		flEnvFile = opts.NewListOpts(nil)
 		execCmd   []string
 		container string
 	)
+	cmd.Var(&flEnv, []string{"e", "-env"}, "Set environment variables")
+	cmd.Var(&flEnvFile, []string{"-env-file"}, "Read in a file of environment variables")
+
 	cmd.Require(flag.Min, 2)
 	if err := cmd.ParseFlags(args, true); err != nil {
 		return nil, err
@@ -32,6 +39,12 @@ func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 	container = cmd.Arg(0)
 	parsedArgs := cmd.Args()
 	execCmd = parsedArgs[1:]
+
+	// collect all the environment variables for the container
+	envVariables, err := readKVStrings(flEnvFile.GetAll(), flEnv.GetAll())
+	if err != nil {
+		return nil, err
+	}
 
 	execConfig := &ExecConfig{
 		User: *flUser,
@@ -41,6 +54,7 @@ func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 		Cmd:       execCmd,
 		Container: container,
 		Detach:    *flDetach,
+		Env:       envVariables,
 	}
 
 	// If -d is not set, attach to everything by default


### PR DESCRIPTION
```
-e, --env=[]               Set environment variables
--env-file=[]              Read in a file of environment variables
```

Fixed #14036
Signed-off-by: Henry Huang henry.s.huang@gmail.com
