### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ Under the hood
 Under the hood, Docker is built on the following components:
 
 * The
-  [cgroup](http://blog.dotcloud.com/kernel-secrets-from-the-paas-garage-part-24-c)
+  [cgroup](https://en.wikipedia.org/wiki/Cgroups)
   and
-  [namespacing](http://blog.dotcloud.com/under-the-hood-linux-kernels-on-dotcloud-part)
+  [namespacing](http://man7.org/linux/man-pages/man7/namespaces.7.html)
   capabilities of the Linux kernel
 * The [Go](https://golang.org) programming language
 * The [Docker Image Specification](https://github.com/docker/docker/blob/master/image/spec/v1.md)


### PR DESCRIPTION
cgroups and namespaces links are broken. They point to blog.dotcloud.com which is dead. Updating the links to point to informative pages.
