### PR TITLE
Modify man pages for image-naming

### DIFF
--- a/man/docker-build.1.md
+++ b/man/docker-build.1.md
@@ -171,8 +171,8 @@ instruction into the specified target.
 
 ## Building an image and naming that image
 
-A good practice is to give a name to the image you are building. There are
-no hard rules here but it is best to give the names consideration. 
+A good practice is to give a name to the image you are building. Note that 
+only a-z0-9-_. should be used for consistency.  There are no hard rules here but it is best to give the names consideration. 
 
 The **-t**/**--tag** flag is used to rename an image. Here are some examples:
 
@@ -190,7 +190,7 @@ and give it the version 1.0:
 The next example is for the "whenry" user repository and uses Fedora and
 JBoss and gives it the version 2.1 :
 
-    docker build -t whenry/fedora-jboss:V2.1
+    docker build -t whenry/fedora-jboss:v2.1
 
 If you do not provide a version tag then Docker will assign `latest`:
 
@@ -229,3 +229,4 @@ Note: supported compression formats are 'xz', 'bzip2', 'gzip' and 'identity' (no
 March 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
+June 2015, updated by Sally O'Malley <somalley@redhat.com>

--- a/man/docker-commit.1.md
+++ b/man/docker-commit.1.md
@@ -50,6 +50,9 @@ create a new image run `docker ps` to find the container's ID and then run:
     # docker commit -m="Added Apache to Fedora base image" \
       -a="A D Ministrator" 98bd7fc99854 fedora/fedora_httpd:20
 
+Note that only a-z0-9-_. are allowed when naming images from an 
+existing container.
+
 ## Apply specified Dockerfile instructions while committing the image
 If an existing container was created without the DEBUG environment
 variable set to "true", you can create a new image based on that
@@ -64,3 +67,4 @@ based on docker.com source material and in
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 July 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 Oct 2014, updated by Daniel, Dao Quang Minh <daniel at nitrous dot io>
+June 2015, updated by Sally O'Malley <somalley@redhat.com>

--- a/man/docker-push.1.md
+++ b/man/docker-push.1.md
@@ -24,7 +24,8 @@ specify a `REGISTRY_HOST`, the command uses Docker's public registry located at
 # Pushing a new image to a registry
 
 First save the new image by finding the container ID (using **docker ps**)
-and then committing it to a new image name:
+and then committing it to a new image name.  Note that only a-z0-9-_. are
+allowed when naming images:
 
     # docker commit c16378f943fe rhel-httpd
 
@@ -48,4 +49,4 @@ April 2014, Originally compiled by William Henry (whenry at redhat dot com)
 based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 April 2015, updated by Mary Anthony for v2 <mary@docker.com>
-
+June 2015, updated by Sally O'Malley <somalley@redhat.com>

--- a/man/docker-tag.1.md
+++ b/man/docker-tag.1.md
@@ -34,6 +34,7 @@ separated by a ':'
 **TAG**
    The tag you are assigning to the image.  Though this is arbitrary it is
 recommended to be used for a version to distinguish images with the same name.
+Also, for consistency tags should only include a-z0-9-_. .
 Note that here TAG is a part of the overall name or "tag".
 
 # OPTIONS
@@ -62,4 +63,4 @@ based on docker.com source material and internal work.
 June 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 July 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>
 April 2015, updated by Mary Anthony for v2 <mary@docker.com>
-
+June 2015, updated by Sally O'Malley <somalley@redhat.com>


### PR DESCRIPTION
This PR adds recommendations in man pages to use only [a-z0-9-_.] when naming and
tagging images.  The purpose of this is to add consistency and to make
image naming caps rules seem less arbitrary.  This PR addresses confusion with:
1. BaseImage:Tagged (not allowed)
2. baseimage:Tagged (allowed)
3. baseimage/tagged:V1 (allowed)
4. baseimage/Tagged:V1 (not allowed)

Signed-off-by: Sally O'Malley somalley@redhat.com
