### PR TITLE
Proposal: allow to list tags of remote repositories

### DIFF
--- a/api/client/tag.go
+++ b/api/client/tag.go
@@ -1,41 +1,107 @@
 package client
 
 import (
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/url"
+	"text/tabwriter"
 
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/api/types"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/registry"
 )
 
+func (cli *DockerCli) listRemoteTags(names ...string) error {
+	var (
+		err          error
+		rdr          io.ReadCloser
+		repoTagLists []*types.RepositoryTagList
+	)
+
+	for _, name := range names {
+		_, tag := parsers.ParseRepositoryTag(name)
+		if tag != "" {
+			logrus.Warnf("Skipping repository %q due to excessive tag %q.", name, tag)
+			continue
+		}
+		// Resolve the Repository name from fqn to RepositoryInfo
+		repoInfo, err := registry.ParseRepositoryInfo(name)
+		if err != nil {
+			logrus.Warnf("Failed to parse repository info %q: %v", name, err)
+			continue
+		}
+		rdr, _, err = cli.clientRequestAttemptLogin("GET", "/images/"+name+"/tags", nil, nil, repoInfo.Index, "tag")
+		if err != nil {
+			logrus.Warnf("Failed to get remote tag list for %q: %v", name, err)
+			continue
+		}
+
+		tagList := types.RepositoryTagList{}
+		if err := json.NewDecoder(rdr).Decode(&tagList); err != nil {
+			logrus.Warnf("Failed to decode remote tag list for %q: %v", name, err)
+			continue
+		}
+		repoTagLists = append(repoTagLists, &tagList)
+	}
+
+	if len(repoTagLists) < 1 && err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(cli.out, 20, 1, 3, ' ', 0)
+	fmt.Fprintln(w, "REPOSITORY\tTAG\tIMAGE ID")
+
+	for _, tagList := range repoTagLists {
+		for _, tag := range tagList.TagList {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", tagList.Name, tag.Tag, tag.ImageID)
+		}
+	}
+
+	w.Flush()
+	return nil
+}
+
 // CmdTag tags an image into a repository.
 //
 // Usage: docker tag [OPTIONS] IMAGE[:TAG] [REGISTRYHOST/][USERNAME/]NAME[:TAG]
 func (cli *DockerCli) CmdTag(args ...string) error {
-	cmd := cli.Subcmd("tag", []string{"IMAGE[:TAG] [REGISTRYHOST/][USERNAME/]NAME[:TAG]"}, "Tag an image into a repository", true)
+	cmd := cli.Subcmd("tag", []string{
+		"IMAGE[:TAG] [REGISTRYHOST/][USERNAME/]NAME[:TAG]",
+		"-l [REGISTRYHOST/][USERNAME/]NAME...",
+	}, "Tag an image or list remote tags", true)
 	force := cmd.Bool([]string{"f", "#force", "-force"}, false, "Force")
-	cmd.Require(flag.Exact, 2)
+	list := cmd.Bool([]string{"l", "#list", "-list"}, false, "List tags of remote repositories")
+	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)
-
-	var (
-		repository, tag = parsers.ParseRepositoryTag(cmd.Arg(1))
-		v               = url.Values{}
-	)
-
-	//Check if the given image name can be resolved
-	if err := registry.ValidateRepositoryName(repository); err != nil {
-		return err
-	}
-	v.Set("repo", repository)
-	v.Set("tag", tag)
-
-	if *force {
-		v.Set("force", "1")
+	if !*list && cmd.NArg() != 2 {
+		cmd.ReportError("Tag command requires exactly 2 arguments.", true)
 	}
 
-	if _, _, err := readBody(cli.call("POST", "/images/"+cmd.Arg(0)+"/tag?"+v.Encode(), nil, nil)); err != nil {
-		return err
+	if *list {
+		return cli.listRemoteTags(cmd.Args()...)
+	} else {
+		var (
+			repository, tag = parsers.ParseRepositoryTag(cmd.Arg(1))
+			v               = url.Values{}
+		)
+
+		//Check if the given image name can be resolved
+		if err := registry.ValidateRepositoryName(repository); err != nil {
+			return err
+		}
+		v.Set("repo", repository)
+		v.Set("tag", tag)
+
+		if *force {
+			v.Set("force", "1")
+		}
+		if _, _, err := readBody(cli.call("POST", "/images/"+cmd.Arg(0)+"/tag?"+v.Encode(), nil, nil)); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1215,8 +1215,37 @@ func (s *Server) getImagesByName(version version.Version, w http.ResponseWriter,
 	if err != nil {
 		return err
 	}
-
 	return writeJSON(w, http.StatusOK, imageInspect)
+}
+
+func (s *Server) getImagesTags(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	name := vars["name"]
+	authEncoded := r.Header.Get("X-Registry-Auth")
+	authConfig := &cliconfig.AuthConfig{}
+	if authEncoded != "" {
+		authJson := base64.NewDecoder(base64.URLEncoding, strings.NewReader(authEncoded))
+		if err := json.NewDecoder(authJson).Decode(authConfig); err != nil {
+			// for a pull it is not an error if no auth was given
+			// to increase compatibility with the existing api it is defaulting to be empty
+			authConfig = &cliconfig.AuthConfig{}
+		}
+	}
+
+	metaHeaders := map[string][]string{}
+	for k, v := range r.Header {
+		if strings.HasPrefix(k, "X-Meta-") {
+			metaHeaders[k] = v
+		}
+	}
+	tagsConfig := &graph.TagsConfig{
+		MetaHeaders: metaHeaders,
+		AuthConfig:  authConfig,
+	}
+	tagList, err := s.daemon.Repositories().Tags(name, tagsConfig)
+	if err != nil {
+		return err
+	}
+	return writeJSON(w, http.StatusOK, tagList)
 }
 
 func (s *Server) postBuild(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -1529,6 +1558,7 @@ func createRouter(s *Server) *mux.Router {
 			"/images/{name:.*}/get":           s.getImagesGet,
 			"/images/{name:.*}/history":       s.getImagesHistory,
 			"/images/{name:.*}/json":          s.getImagesByName,
+			"/images/{name:.*}/tags":          s.getImagesTags,
 			"/containers/ps":                  s.getContainersJSON,
 			"/containers/json":                s.getContainersJSON,
 			"/containers/{name:.*}/export":    s.getContainersExport,

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -253,3 +253,15 @@ type ContainerConfig struct {
 	CpuShares  int64
 	Cpuset     string
 }
+
+type RepositoryTag struct {
+	Tag     string
+	ImageID string
+}
+
+// GET "/images/{name:.*}/tags"
+type RepositoryTagList struct {
+	// Fully qualified repository name
+	Name    string
+	TagList []*RepositoryTag
+}

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -375,6 +375,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from stop' -a '(__fish_print
 # tag
 complete -c docker -f -n '__fish_docker_no_subcommand' -a tag -d 'Tag an image into a repository'
 complete -c docker -A -f -n '__fish_seen_subcommand_from tag' -s f -l force -d 'Force'
+complete -c docker -A -f -n '__fish_seen_subcommand_from tag' -s l -l list -d 'List tags of remote repositories'
 complete -c docker -A -f -n '__fish_seen_subcommand_from tag' -l help -d 'Print usage'
 
 # top

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -375,7 +375,8 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from stop' -a '(__fish_print
 # tag
 complete -c docker -f -n '__fish_docker_no_subcommand' -a tag -d 'Tag an image into a repository'
 complete -c docker -A -f -n '__fish_seen_subcommand_from tag' -s f -l force -d 'Force'
-complete -c docker -A -f -n '__fish_seen_subcommand_from tag' -s l -l list -d 'List tags of remote repositories'
+complete -c docker -A -f -n '__fish_seen_subcommand_from tag' -s l -l list -d 'List repository tags'
+complete -c docker -A -f -n '__fish_seen_subcommand_from tag' -s r -l remote -d 'Force listing of remote repositories only'
 complete -c docker -A -f -n '__fish_seen_subcommand_from tag' -l help -d 'Print usage'
 
 # top

--- a/graph/list.go
+++ b/graph/list.go
@@ -182,7 +182,10 @@ func (s *TagStore) Tags(name string) (*types.RepositoryTagList, error) {
 	}
 
 	for ref, id := range repo {
-		tagList.TagList = append(tagList.TagList, &types.RepositoryTag{ref, id})
+		tagList.TagList = append(tagList.TagList, &types.RepositoryTag{
+			Tag:     ref,
+			ImageID: id,
+		})
 	}
 
 	sort.Sort(ByTagName(tagList.TagList))

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -123,7 +123,13 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 
 			// Check each line for lots of stuff
 			lines := strings.Split(out, "\n")
+			parsingUsage := false
 			for _, line := range lines {
+				if strings.HasPrefix(line, "Usage:") {
+					parsingUsage = true
+				} else if parsingUsage && line == "" {
+					parsingUsage = false
+				}
 				if len(line) > 80 {
 					c.Fatalf("Help for %q is too long(%d chars):\n%s", cmd,
 						len(line), line)
@@ -141,7 +147,7 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 				// If a line starts with 4 spaces then assume someone
 				// added a multi-line description for an option and we need
 				// to flag it
-				if strings.HasPrefix(line, "    ") {
+				if strings.HasPrefix(line, "    ") && !parsingUsage {
 					c.Fatalf("Help for %q should not have a multi-line option: %s", cmd, line)
 				}
 

--- a/man/docker-tag.1.md
+++ b/man/docker-tag.1.md
@@ -2,13 +2,17 @@
 % Docker Community
 % JUNE 2014
 # NAME
-docker-tag - Tag an image into a repository
+docker-tag - Tag an image or list remote tags
 
 # SYNOPSIS
 **docker tag**
 [**-f**|**--force**[=*false*]]
+IMAGE[:TAG] [REGISTRY_HOST/][USERNAME/]NAME[:TAG]  
+**docker tag**
+**-l**|**--list**[=*false*]
+[REGISTRYHOST/][USERNAME/]NAME...  
+**docker tag**
 [**--help**]
-IMAGE[:TAG] [REGISTRY_HOST/][USERNAME/]NAME[:TAG]
 
 # DESCRIPTION
 Assigns a new alias to an image in a registry. An alias refers to the
@@ -17,9 +21,15 @@ entire image name including the optional `TAG` after the ':'.
 If you do not specify a `REGISTRY_HOST`, the command uses Docker's public
 registry located at `registry-1.docker.io` by default. 
 
+If a **--list** option is set, tags of remote repositories specified will be
+listed.
+
 # "OPTIONS"
 **-f**, **--force**=*true*|*false*
    When set to true, force the alias. The default is *false*.
+
+**-l**, **--list**=*true*|*false*
+   List tags of remote repositories. The default is *false*.
 
 **REGISTRYHOST**
    The hostname of the registry if required. This may also include the port

--- a/man/docker-tag.1.md
+++ b/man/docker-tag.1.md
@@ -29,7 +29,10 @@ listed.
    When set to true, force the alias. The default is *false*.
 
 **-l**, **--list**=*true*|*false*
-   List tags of remote repositories. The default is *false*.
+   List repository tags. The default is *false*.
+
+**-r**, **--remote**=*true*|*false*
+   Force listing of remote repositories only.
 
 **REGISTRYHOST**
    The hostname of the registry if required. This may also include the port


### PR DESCRIPTION
Added new `--list` flag to `docker-tag` command:

```
Usage:  docker tag [OPTIONS] IMAGE[:TAG] [REGISTRYHOST/][USERNAME/]NAME[:TAG]
        docker tag [OPTIONS] -l [-r] [REGISTRYHOST/][USERNAME/]NAME...

Tag an image or list repository tags

  -f, --force=false     Force
  --help=false          Print usage
  -l, --list=false      List repository tags
  -r, --remote=false    Force listing of remote repositories only
```

It produces following output:

```
$ docker tag -l docker.io/fedora
REPOSITORY          TAG                 IMAGE ID
docker.io/fedora    20                  d7f0e75cf11fd6fe9fc3e676bb423f1504ea20da110d4d480f74cda8cb94f574
docker.io/fedora    21                  e26efd418c4841f7299832fe7689de3e820d91a16bb4cff5b72eb9b09d712753
docker.io/fedora    heisenbug           d7f0e75cf11fd6fe9fc3e676bb423f1504ea20da110d4d480f74cda8cb94f574
docker.io/fedora    latest              e26efd418c4841f7299832fe7689de3e820d91a16bb4cff5b72eb9b09d712753
docker.io/fedora    rawhide             f62b946038358811c82b9ce50601674a7e1b52ee742557429f244415064251b6
```

Quirks and TODOs:
- By default V1 registry enpoints are queried because they provide tags
  with associated image IDs. If not available, V2 endpoint will be
  tried. In such a case the output will lack image IDs though.

Resolves #14254
