### PR TITLE
fix(docs): removed extra quote character in heading

### DIFF
--- a/docs/articles/basics.md
+++ b/docs/articles/basics.md
@@ -8,7 +8,7 @@ parent = "smn_containers"
 +++
 <![end-metadata]-->
 
-# "Get started with containers
+# Get started with containers
 
 This guide assumes you have a working installation of Docker. To verify Docker is 
 installed, use the following command:


### PR DESCRIPTION
docs: Removed an extraneous quote character " in the heading from the articles/basics.md

Signed-off-by: Jeremy Price jprice.rhit@gmail.com
