### PR TITLE
Add and refactor tests for pkg/parsers{,*}

### DIFF
--- a/pkg/parsers/filters/parse_test.go
+++ b/pkg/parsers/filters/parse_test.go
@@ -30,33 +30,75 @@ func TestParseArgs(t *testing.T) {
 	}
 }
 
-func TestParam(t *testing.T) {
+func TestParseArgsEdgeCase(t *testing.T) {
+	var filters Args
+	args, err := ParseFlag("", filters)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if args == nil || len(args) != 0 {
+		t.Fatalf("Expected an empty Args (map), got %v", args)
+	}
+	if args, err = ParseFlag("anything", args); err == nil || err != ErrorBadFormat {
+		t.Fatalf("Expected ErrorBadFormat, got %v", err)
+	}
+}
+
+func TestToParam(t *testing.T) {
 	a := Args{
 		"created":    []string{"today"},
 		"image.name": []string{"ubuntu*", "*untu"},
 	}
 
-	v, err := ToParam(a)
+	_, err := ToParam(a)
 	if err != nil {
 		t.Errorf("failed to marshal the filters: %s", err)
 	}
-	v1, err := FromParam(v)
-	if err != nil {
-		t.Errorf("%s", err)
+}
+
+func TestFromParam(t *testing.T) {
+	invalids := []string{
+		"anything",
+		"['a','list']",
+		"{'key': 'value'}",
+		`{"key": "value"}`,
 	}
-	for key, vals := range v1 {
-		if _, ok := a[key]; !ok {
-			t.Errorf("could not find key %s in original set", key)
+	valids := map[string]Args{
+		`{"key": ["value"]}`: {
+			"key": {"value"},
+		},
+		`{"key": ["value1", "value2"]}`: {
+			"key": {"value1", "value2"},
+		},
+		`{"key1": ["value1"], "key2": ["value2"]}`: {
+			"key1": {"value1"},
+			"key2": {"value2"},
+		},
+	}
+	for _, invalid := range invalids {
+		if _, err := FromParam(invalid); err == nil {
+			t.Fatalf("Expected an error with %v, got nothing", invalid)
 		}
-		sort.Strings(vals)
-		sort.Strings(a[key])
-		if len(vals) != len(a[key]) {
-			t.Errorf("value lengths ought to match")
-			continue
+	}
+	for json, expectedArgs := range valids {
+		args, err := FromParam(json)
+		if err != nil {
+			t.Fatal(err)
 		}
-		for i := range vals {
-			if vals[i] != a[key][i] {
-				t.Errorf("expected %s, but got %s", a[key][i], vals[i])
+		if len(args) != len(expectedArgs) {
+			t.Fatalf("Expected %v, go %v", expectedArgs, args)
+		}
+		for key, expectedValues := range expectedArgs {
+			values := args[key]
+			sort.Strings(values)
+			sort.Strings(expectedValues)
+			if len(values) != len(expectedValues) {
+				t.Fatalf("Expected %v, go %v", expectedArgs, args)
+			}
+			for index, expectedValue := range expectedValues {
+				if values[index] != expectedValue {
+					t.Fatalf("Expected %v, go %v", expectedArgs, args)
+				}
 			}
 		}
 	}
@@ -74,5 +116,103 @@ func TestEmpty(t *testing.T) {
 	}
 	if len(a) != len(v1) {
 		t.Errorf("these should both be empty sets")
+	}
+}
+
+func TestArgsMatchKVList(t *testing.T) {
+	// empty sources
+	args := Args{
+		"created": []string{"today"},
+	}
+	if args.MatchKVList("created", map[string]string{}) {
+		t.Fatalf("Expected false for (%v,created), got true", args)
+	}
+	// Not empty sources
+	sources := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+	matches := map[*Args]string{
+		&Args{}: "field",
+		&Args{
+			"created": []string{"today"},
+			"labels":  []string{"key1"},
+		}: "labels",
+		&Args{
+			"created": []string{"today"},
+			"labels":  []string{"key1=value1"},
+		}: "labels",
+	}
+	differs := map[*Args]string{
+		&Args{
+			"created": []string{"today"},
+		}: "created",
+		&Args{
+			"created": []string{"today"},
+			"labels":  []string{"key4"},
+		}: "labels",
+		&Args{
+			"created": []string{"today"},
+			"labels":  []string{"key1=value3"},
+		}: "labels",
+	}
+	for args, field := range matches {
+		if args.MatchKVList(field, sources) != true {
+			t.Fatalf("Expected true for %v on %v, got false", sources, args)
+		}
+	}
+	for args, field := range differs {
+		if args.MatchKVList(field, sources) != false {
+			t.Fatalf("Expected false for %v on %v, got true", sources, args)
+		}
+	}
+}
+
+func TestArgsMatch(t *testing.T) {
+	source := "today"
+	matches := map[*Args]string{
+		&Args{}: "field",
+		&Args{
+			"created": []string{"today"},
+			"labels":  []string{"key1"},
+		}: "today",
+		&Args{
+			"created": []string{"to*"},
+		}: "created",
+		&Args{
+			"created": []string{"to(.*)"},
+		}: "created",
+		&Args{
+			"created": []string{"tod"},
+		}: "created",
+		&Args{
+			"created": []string{"anything", "to*"},
+		}: "created",
+	}
+	differs := map[*Args]string{
+		&Args{
+			"created": []string{"tomorrow"},
+		}: "created",
+		&Args{
+			"created": []string{"to(day"},
+		}: "created",
+		&Args{
+			"created": []string{"tom(.*)"},
+		}: "created",
+		&Args{
+			"created": []string{"today1"},
+			"labels":  []string{"today"},
+		}: "created",
+	}
+	for args, field := range matches {
+		if args.Match(field, source) != true {
+			t.Fatalf("Expected true for %v on %v, got false", source, args)
+		}
+	}
+	for args, field := range differs {
+		if args.Match(field, source) != false {
+			t.Fatalf("Expected false for %v on %v, got true", source, args)
+		}
 	}
 }

--- a/pkg/parsers/kernel/kernel_test.go
+++ b/pkg/parsers/kernel/kernel_test.go
@@ -1,6 +1,7 @@
 package kernel
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -11,7 +12,7 @@ func assertParseRelease(t *testing.T, release string, b *KernelVersionInfo, resu
 	a, _ = ParseRelease(release)
 
 	if r := CompareKernelVersion(a, b); r != result {
-		t.Fatalf("Unexpected kernel version comparison result. Found %d, expected %d", r, result)
+		t.Fatalf("Unexpected kernel version comparison result for (%v,%v). Found %d, expected %d", release, b, r, result)
 	}
 	if a.Flavor != b.Flavor {
 		t.Fatalf("Unexpected parsed kernel flavor.  Found %s, expected %s", a.Flavor, b.Flavor)
@@ -25,6 +26,20 @@ func TestParseRelease(t *testing.T) {
 	assertParseRelease(t, "3.8.0-19-generic", &KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0, Flavor: "-19-generic"}, 0)
 	assertParseRelease(t, "3.12.8tag", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 8, Flavor: "tag"}, 0)
 	assertParseRelease(t, "3.12-1-amd64", &KernelVersionInfo{Kernel: 3, Major: 12, Minor: 0, Flavor: "-1-amd64"}, 0)
+	assertParseRelease(t, "3.8.0", &KernelVersionInfo{Kernel: 4, Major: 8, Minor: 0}, -1)
+	// Errors
+	invalids := []string{
+		"3",
+		"a",
+		"a.a",
+		"a.a.a-a",
+	}
+	for _, invalid := range invalids {
+		expectedMessage := fmt.Sprintf("Can't parse kernel version %v", invalid)
+		if _, err := ParseRelease(invalid); err == nil || err.Error() != expectedMessage {
+
+		}
+	}
 }
 
 func assertKernelVersion(t *testing.T, a, b *KernelVersionInfo, result int) {
@@ -57,5 +72,21 @@ func TestCompareKernelVersion(t *testing.T) {
 	assertKernelVersion(t,
 		&KernelVersionInfo{Kernel: 3, Major: 0, Minor: 20},
 		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
+		-1)
+	assertKernelVersion(t,
+		&KernelVersionInfo{Kernel: 3, Major: 7, Minor: 20},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
+		-1)
+	assertKernelVersion(t,
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 20},
+		&KernelVersionInfo{Kernel: 3, Major: 7, Minor: 0},
+		1)
+	assertKernelVersion(t,
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 20},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
+		1)
+	assertKernelVersion(t,
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 0},
+		&KernelVersionInfo{Kernel: 3, Major: 8, Minor: 20},
 		-1)
 }

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -10,35 +10,38 @@ func TestParseHost(t *testing.T) {
 		defaultHttpHost = "127.0.0.1"
 		defaultUnix     = "/var/run/docker.sock"
 	)
-	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "0.0.0.0"); err == nil {
-		t.Errorf("tcp 0.0.0.0 address expected error return, but err == nil, got %s", addr)
+	invalids := map[string]string{
+		"0.0.0.0":              "Invalid bind address format: 0.0.0.0",
+		"tcp://":               "Invalid proto, expected tcp: ",
+		"tcp:a.b.c.d":          "Invalid bind address format: tcp:a.b.c.d",
+		"udp://127.0.0.1":      "Invalid bind address format: udp://127.0.0.1",
+		"udp://127.0.0.1:2375": "Invalid bind address format: udp://127.0.0.1:2375",
 	}
-	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "tcp://"); err == nil {
-		t.Errorf("default tcp:// address expected error return, but err == nil, got %s", addr)
+	valids := map[string]string{
+		"0.0.0.1:5555": "tcp://0.0.0.1:5555",
+		":6666":        "tcp://127.0.0.1:6666",
+		"tcp://:7777":  "tcp://127.0.0.1:7777",
+		"":             "unix:///var/run/docker.sock",
+		"unix:///run/docker.sock": "unix:///run/docker.sock",
+		"unix://":                 "unix:///var/run/docker.sock",
+		"fd://":                   "fd://",
+		"fd://something":          "fd://something",
 	}
-	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "0.0.0.1:5555"); err != nil || addr != "tcp://0.0.0.1:5555" {
-		t.Errorf("0.0.0.1:5555 -> expected tcp://0.0.0.1:5555, got %s", addr)
+	for invalidAddr, expectedError := range invalids {
+		if addr, err := ParseHost(defaultHttpHost, defaultUnix, invalidAddr); err == nil || err.Error() != expectedError {
+			t.Errorf("tcp %v address expected error %v return, got %s and addr %v", invalidAddr, expectedError, err, addr)
+		}
 	}
-	if addr, err := ParseHost(defaultHttpHost, defaultUnix, ":6666"); err != nil || addr != "tcp://127.0.0.1:6666" {
-		t.Errorf(":6666 -> expected tcp://127.0.0.1:6666, got %s", addr)
+	for validAddr, expectedAddr := range valids {
+		if addr, err := ParseHost(defaultHttpHost, defaultUnix, validAddr); err != nil || addr != expectedAddr {
+			t.Errorf("%v -> expected %v, got %v", validAddr, expectedAddr, addr)
+		}
 	}
-	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "tcp://:7777"); err != nil || addr != "tcp://127.0.0.1:7777" {
-		t.Errorf("tcp://:7777 -> expected tcp://127.0.0.1:7777, got %s", addr)
-	}
-	if addr, err := ParseHost(defaultHttpHost, defaultUnix, ""); err != nil || addr != "unix:///var/run/docker.sock" {
-		t.Errorf("empty argument -> expected unix:///var/run/docker.sock, got %s", addr)
-	}
-	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "unix:///var/run/docker.sock"); err != nil || addr != "unix:///var/run/docker.sock" {
-		t.Errorf("unix:///var/run/docker.sock -> expected unix:///var/run/docker.sock, got %s", addr)
-	}
-	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "unix://"); err != nil || addr != "unix:///var/run/docker.sock" {
-		t.Errorf("unix:///var/run/docker.sock -> expected unix:///var/run/docker.sock, got %s", addr)
-	}
-	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "udp://127.0.0.1"); err == nil {
-		t.Errorf("udp protocol address expected error return, but err == nil. Got %s", addr)
-	}
-	if addr, err := ParseHost(defaultHttpHost, defaultUnix, "udp://127.0.0.1:2375"); err == nil {
-		t.Errorf("udp protocol address expected error return, but err == nil. Got %s", addr)
+}
+
+func TestParseInvalidUnixAddrInvalid(t *testing.T) {
+	if _, err := ParseUnixAddr("unix://tcp://127.0.0.1", "unix:///var/run/docker.sock"); err == nil || err.Error() != "Invalid proto, expected unix: tcp://127.0.0.1" {
+		t.Fatalf("Expected an error, got %v", err)
 	}
 }
 
@@ -73,6 +76,9 @@ func TestParseRepositoryTag(t *testing.T) {
 }
 
 func TestParsePortMapping(t *testing.T) {
+	if _, err := PartParser("ip:public:private", "192.168.1.1:80"); err == nil {
+		t.Fatalf("Expected an error, got %v", err)
+	}
 	data, err := PartParser("ip:public:private", "192.168.1.1:80:8080")
 	if err != nil {
 		t.Fatal(err)
@@ -92,9 +98,52 @@ func TestParsePortMapping(t *testing.T) {
 	}
 }
 
+func TestParseKeyValueOpt(t *testing.T) {
+	invalids := map[string]string{
+		"":    "Unable to parse key/value option: ",
+		"key": "Unable to parse key/value option: key",
+	}
+	for invalid, expectedError := range invalids {
+		if _, _, err := ParseKeyValueOpt(invalid); err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error %v for %v, got %v", expectedError, invalid, err)
+		}
+	}
+	valids := map[string][]string{
+		"key=value":               {"key", "value"},
+		" key = value ":           {"key", "value"},
+		"key=value1=value2":       {"key", "value1=value2"},
+		" key = value1 = value2 ": {"key", "value1 = value2"},
+	}
+	for valid, expectedKeyValue := range valids {
+		key, value, err := ParseKeyValueOpt(valid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if key != expectedKeyValue[0] || value != expectedKeyValue[1] {
+			t.Fatalf("Expected {%v: %v} got {%v: %v}", expectedKeyValue[0], expectedKeyValue[1], key, value)
+		}
+	}
+}
+
 func TestParsePortRange(t *testing.T) {
 	if start, end, err := ParsePortRange("8000-8080"); err != nil || start != 8000 || end != 8080 {
 		t.Fatalf("Error: %s or Expecting {start,end} values {8000,8080} but found {%d,%d}.", err, start, end)
+	}
+}
+
+func TestParsePortRangeEmpty(t *testing.T) {
+	if _, _, err := ParsePortRange(""); err == nil || err.Error() != "Empty string specified for ports." {
+		t.Fatalf("Expected error 'Empty string specified for ports.', got %v", err)
+	}
+}
+
+func TestParsePortRangeWithNoRange(t *testing.T) {
+	start, end, err := ParsePortRange("8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if start != 8080 || end != 8080 {
+		t.Fatalf("Expected start and end to be the same and equal to 8080, but were %v and %v", start, end)
 	}
 }
 


### PR DESCRIPTION
Today, it's the time for `pkg/parsers` to get more coverage 🐸. It's smaller than https://github.com/docker/docker/pull/14134 or https://github.com/docker/docker/pull/13694, just few test refactor and additions.
- `pkg/parsers`

``` bash
# before
+ go test -test.timeout=30m github.com/docker/docker/pkg/parsers
PASS
coverage: 83.5% of statements
# after
+ go test -test.timeout=30m github.com/docker/docker/pkg/parsers
PASS
coverage: 98.7% of statements
```
- `pkg/parsers/filters`

``` bash
# before
PASS
coverage: 38.8% of statements
ok      _/home/vincent/src/docker/docker/pkg/parsers/filters    0.020s
# after
PASS
coverage: 98.0% of statements
ok      _/home/vincent/src/docker/docker/pkg/parsers/filters    0.016s
```
- `pkg/parsers/kernel`

``` bash
# before
PASS
coverage: 48.6% of statements
ok      _/home/vincent/src/docker/docker/pkg/parsers/kernel     0.019s
# after
PASS
coverage: 56.8% of statements
ok      _/home/vincent/src/docker/docker/pkg/parsers/kernel     0.016s
```

I was wondering something about platform dependent tests — shouldn't be needed but if needed — is a _build flag_ would not compile and this not run tests ? I didn't see any `…_windows_test.go` files :sweat_smile:.

Signed-off-by: Vincent Demeester vincent@sbr.pm
