### PR TITLE
Fix upstart issue if machine isn't shutdown cleanly

### DIFF
--- a/contrib/init/upstart/docker.conf
+++ b/contrib/init/upstart/docker.conf
@@ -30,6 +30,7 @@ pre-start script
 			fi
 		done
 	)
+	rm -f /var/run/docker.sock
 end script
 
 script


### PR DESCRIPTION
Addresses issue #14272.  Fix script to wait for docker process to fully start before emitting started.   System is waiting for unix socket file to appear, but there's one leftover from last time.   Remove it in pre-start script.
