### PR TITLE
Fix implicit DeviceMapper selection

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -30,8 +30,7 @@ var (
 	DefaultDataLoopbackSize     int64  = 100 * 1024 * 1024 * 1024
 	DefaultMetaDataLoopbackSize int64  = 2 * 1024 * 1024 * 1024
 	DefaultBaseFsSize           uint64 = 10 * 1024 * 1024 * 1024
-	DefaultThinpBlockSize       uint32 = 128 // 64K = 128 512b sectors
-	DefaultUdevSyncOverride     bool   = false
+	DefaultThinpBlockSize       uint32 = 128      // 64K = 128 512b sectors
 	MaxDeviceId                 int    = 0xffffff // 24 bit, pool limit
 	DeviceIdMapSz               int    = (MaxDeviceId + 1) / 8
 	// We retry device removal so many a times that even error messages
@@ -90,23 +89,22 @@ type DeviceSet struct {
 	deviceIdMap   []byte
 
 	// Options
-	dataLoopbackSize      int64
-	metaDataLoopbackSize  int64
-	baseFsSize            uint64
-	filesystem            string
-	mountOptions          string
-	mkfsArgs              []string
-	dataDevice            string // block or loop dev
-	dataLoopFile          string // loopback file, if used
-	metadataDevice        string // block or loop dev
-	metadataLoopFile      string // loopback file, if used
-	doBlkDiscard          bool
-	thinpBlockSize        uint32
-	thinPoolDevice        string
-	Transaction           `json:"-"`
-	overrideUdevSyncCheck bool
-	deferredRemove        bool   // use deferred removal
-	BaseDeviceUUID        string //save UUID of base device
+	dataLoopbackSize     int64
+	metaDataLoopbackSize int64
+	baseFsSize           uint64
+	filesystem           string
+	mountOptions         string
+	mkfsArgs             []string
+	dataDevice           string // block or loop dev
+	dataLoopFile         string // loopback file, if used
+	metadataDevice       string // block or loop dev
+	metadataLoopFile     string // loopback file, if used
+	doBlkDiscard         bool
+	thinpBlockSize       uint32
+	thinPoolDevice       string
+	Transaction          `json:"-"`
+	deferredRemove       bool   // use deferred removal
+	BaseDeviceUUID       string //save UUID of base device
 }
 
 type DiskUsage struct {
@@ -1106,10 +1104,7 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 
 	// https://github.com/docker/docker/issues/4036
 	if supported := devicemapper.UdevSetSyncSupport(true); !supported {
-		logrus.Errorf("Udev sync is not supported. This will lead to unexpected behavior, data loss and errors. For more information, see https://docs.docker.com/reference/commandline/cli/#daemon-storage-driver-option")
-		if !devices.overrideUdevSyncCheck {
-			return graphdriver.ErrNotSupported
-		}
+		logrus.Warn("Udev sync is not supported. This will lead to unexpected behavior, data loss and errors. For more information, see https://docs.docker.com/reference/commandline/cli/#daemon-storage-driver-option")
 	}
 
 	if err := os.MkdirAll(devices.metadataDir(), 0700); err != nil && !os.IsExist(err) {
@@ -1791,16 +1786,15 @@ func NewDeviceSet(root string, doInit bool, options []string) (*DeviceSet, error
 	devicemapper.SetDevDir("/dev")
 
 	devices := &DeviceSet{
-		root:                  root,
-		MetaData:              MetaData{Devices: make(map[string]*DevInfo)},
-		dataLoopbackSize:      DefaultDataLoopbackSize,
-		metaDataLoopbackSize:  DefaultMetaDataLoopbackSize,
-		baseFsSize:            DefaultBaseFsSize,
-		overrideUdevSyncCheck: DefaultUdevSyncOverride,
-		filesystem:            "ext4",
-		doBlkDiscard:          true,
-		thinpBlockSize:        DefaultThinpBlockSize,
-		deviceIdMap:           make([]byte, DeviceIdMapSz),
+		root:                 root,
+		MetaData:             MetaData{Devices: make(map[string]*DevInfo)},
+		dataLoopbackSize:     DefaultDataLoopbackSize,
+		metaDataLoopbackSize: DefaultMetaDataLoopbackSize,
+		baseFsSize:           DefaultBaseFsSize,
+		filesystem:           "ext4",
+		doBlkDiscard:         true,
+		thinpBlockSize:       DefaultThinpBlockSize,
+		deviceIdMap:          make([]byte, DeviceIdMapSz),
 	}
 
 	foundBlkDiscard := false
@@ -1857,12 +1851,6 @@ func NewDeviceSet(root string, doInit bool, options []string) (*DeviceSet, error
 			}
 			// convert to 512b sectors
 			devices.thinpBlockSize = uint32(size) >> 9
-		case "dm.override_udev_sync_check":
-			devices.overrideUdevSyncCheck, err = strconv.ParseBool(val)
-			if err != nil {
-				return nil, err
-			}
-
 		case "dm.use_deferred_removal":
 			EnableDeferredRemoval, err = strconv.ParseBool(val)
 			if err != nil {

--- a/daemon/graphdriver/devmapper/devmapper_test.go
+++ b/daemon/graphdriver/devmapper/devmapper_test.go
@@ -13,7 +13,6 @@ func init() {
 	DefaultDataLoopbackSize = 300 * 1024 * 1024
 	DefaultMetaDataLoopbackSize = 200 * 1024 * 1024
 	DefaultBaseFsSize = 300 * 1024 * 1024
-	DefaultUdevSyncOverride = true
 	if err := graphtest.InitLoopbacks(); err != nil {
 		panic(err)
 	}

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -323,42 +323,6 @@ options for `zfs` start with `zfs`.
 
         $ docker -d --storage-opt dm.blkdiscard=false
 
- *  `dm.override_udev_sync_check`
-
-    Overrides the `udev` synchronization checks between `devicemapper` and `udev`.
-    `udev` is the device manager for the Linux kernel.
-
-    To view the `udev` sync support of a Docker daemon that is using the
-    `devicemapper` driver, run:
-
-        $ docker info
-        [...]
-        Udev Sync Supported: true
-        [...]
-
-    When `udev` sync support is `true`, then `devicemapper` and udev can
-    coordinate the activation and deactivation of devices for containers.
-
-    When `udev` sync support is `false`, a race condition occurs between
-    the`devicemapper` and `udev` during create and cleanup. The race condition
-    results in errors and failures. (For information on these failures, see
-    [docker#4036](https://github.com/docker/docker/issues/4036))
-
-    To allow the `docker` daemon to start, regardless of `udev` sync not being
-    supported, set `dm.override_udev_sync_check` to true:
-
-	$ docker -d --storage-opt dm.override_udev_sync_check=true
-
-    When this value is `true`, the  `devicemapper` continues and simply warns
-    you the errors are happening.
-
-    > **Note:**
-    > The ideal is to pursue a `docker` daemon and environment that does
-    > support synchronizing with `udev`. For further discussion on this
-    > topic, see [docker#4036](https://github.com/docker/docker/issues/4036).
-    > Otherwise, set this flag for migrating existing Docker daemons to
-    > a daemon with a supported environment.
-
 
 ## Docker execdriver option
 

--- a/man/docker.1.md
+++ b/man/docker.1.md
@@ -451,45 +451,6 @@ removed.
 
 Example use: `docker -d --storage-opt dm.blkdiscard=false`
 
-#### dm.override_udev_sync_check
-
-By default, the devicemapper backend attempts to synchronize with the
-`udev` device manager for the Linux kernel.  This option allows
-disabling that synchronization, to continue even though the
-configuration may be buggy.
-
-To view the `udev` sync support of a Docker daemon that is using the
-`devicemapper` driver, run:
-
-        $ docker info
-	[...]
-	 Udev Sync Supported: true
-	[...]
-
-When `udev` sync support is `true`, then `devicemapper` and `udev` can
-coordinate the activation and deactivation of devices for containers.
-
-When `udev` sync support is `false`, a race condition occurs between
-the`devicemapper` and `udev` during create and cleanup. The race
-condition results in errors and failures. (For information on these
-failures, see
-[docker#4036](https://github.com/docker/docker/issues/4036))
-
-To allow the `docker` daemon to start, regardless of whether `udev` sync is
-`false`, set `dm.override_udev_sync_check` to true:
-
-        $ docker -d --storage-opt dm.override_udev_sync_check=true
-
-When this value is `true`, the driver continues and simply warns you
-the errors are happening.
-
-**Note**: The ideal is to pursue a `docker` daemon and environment
-that does support synchronizing with `udev`. For further discussion on
-this topic, see
-[docker#4036](https://github.com/docker/docker/issues/4036).
-Otherwise, set this flag for migrating existing Docker daemons to a
-daemon with a supported environment.
-
 # EXEC DRIVER OPTIONS
 
 Use the **--exec-opt** flags to specify options to the exec-driver. The only


### PR DESCRIPTION
DeviceMapper must be explicitly selected because the Docker binary might not be linked to the right devmapper library.

With this change, Docker fails fast if the driver detection finds the devicemapper directory but the driver is not the default option.
It also makes Docker to fail fast if it detects two driver root directories.
The option `override_udev_sync_check` doesn't make sense anymore, since the user must be explicit to select devicemapper, so it's being removed.

Fixes #14035

Signed-off-by: David Calavera david.calavera@gmail.com
