### PR TITLE
fixed incorrect assumption on --bridge=none treated as disable network

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -17,7 +17,7 @@ type CommonConfig struct {
 	AutoRestart    bool
 	Context        map[string][]string
 	CorsHeaders    string
-	DisableNetwork bool
+	DisableBridge  bool
 	Dns            []string
 	DnsSearch      []string
 	EnableCors     bool

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -561,7 +561,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	}
 
 	// Do we have a disabled network?
-	config.DisableNetwork = isNetworkDisabled(config)
+	config.DisableBridge = isBridgeNetworkDisabled(config)
 
 	// Check that the system is supported and we have sufficient privileges
 	if err := checkSystem(); err != nil {
@@ -684,11 +684,9 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 		return nil, fmt.Errorf("Couldn't create Tag store: %s", err)
 	}
 
-	if !config.DisableNetwork {
-		d.netController, err = initNetworkController(config)
-		if err != nil {
-			return nil, fmt.Errorf("Error initializing network controller: %v", err)
-		}
+	d.netController, err = initNetworkController(config)
+	if err != nil {
+		return nil, fmt.Errorf("Error initializing network controller: %v", err)
 	}
 
 	graphdbPath := filepath.Join(config.Root, "linkgraph.db")

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -261,7 +261,7 @@ func configureSysInit(config *Config) (string, error) {
 	return sysInitPath, nil
 }
 
-func isNetworkDisabled(config *Config) bool {
+func isBridgeNetworkDisabled(config *Config) bool {
 	return config.Bridge.Iface == disableNetworkBridge
 }
 
@@ -329,12 +329,22 @@ func initNetworkController(config *Config) (libnetwork.NetworkController, error)
 		return nil, fmt.Errorf("Error creating default \"host\" network: %v", err)
 	}
 
-	// Initialize default driver "bridge"
+	if !config.DisableBridge {
+		// Initialize default driver "bridge"
+		if err := initBridgeDriver(controller, config); err != nil {
+			return nil, err
+		}
+	}
+
+	return controller, nil
+}
+
+func initBridgeDriver(controller libnetwork.NetworkController, config *Config) error {
 	option := options.Generic{
 		"EnableIPForwarding": config.Bridge.EnableIPForward}
 
 	if err := controller.ConfigureNetworkDriver("bridge", options.Generic{netlabel.GenericData: option}); err != nil {
-		return nil, fmt.Errorf("Error initializing bridge driver: %v", err)
+		return fmt.Errorf("Error initializing bridge driver: %v", err)
 	}
 
 	netOption := options.Generic{
@@ -349,7 +359,7 @@ func initNetworkController(config *Config) (libnetwork.NetworkController, error)
 	if config.Bridge.IP != "" {
 		ip, bipNet, err := net.ParseCIDR(config.Bridge.IP)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		bipNet.IP = ip
@@ -359,7 +369,7 @@ func initNetworkController(config *Config) (libnetwork.NetworkController, error)
 	if config.Bridge.FixedCIDR != "" {
 		_, fCIDR, err := net.ParseCIDR(config.Bridge.FixedCIDR)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		netOption["FixedCIDR"] = fCIDR
@@ -368,7 +378,7 @@ func initNetworkController(config *Config) (libnetwork.NetworkController, error)
 	if config.Bridge.FixedCIDRv6 != "" {
 		_, fCIDRv6, err := net.ParseCIDR(config.Bridge.FixedCIDRv6)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		netOption["FixedCIDRv6"] = fCIDRv6
@@ -388,16 +398,15 @@ func initNetworkController(config *Config) (libnetwork.NetworkController, error)
 	}
 
 	// Initialize default network on "bridge" with the same name
-	_, err = controller.NewNetwork("bridge", "bridge",
+	_, err := controller.NewNetwork("bridge", "bridge",
 		libnetwork.NetworkOptionGeneric(options.Generic{
 			netlabel.GenericData: netOption,
 			netlabel.EnableIPv6:  config.Bridge.EnableIPv6,
 		}))
 	if err != nil {
-		return nil, fmt.Errorf("Error creating default \"bridge\" network: %v", err)
+		return fmt.Errorf("Error creating default \"bridge\" network: %v", err)
 	}
-
-	return controller, nil
+	return nil
 }
 
 // setupInitLayer populates a directory with mountpoints suitable

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -96,7 +96,7 @@ func configureSysInit(config *Config) (string, error) {
 	return os.Getenv("TEMP"), nil
 }
 
-func isNetworkDisabled(config *Config) bool {
+func isBridgeNetworkDisabled(config *Config) bool {
 	return false
 }
 

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1207,7 +1207,17 @@ func (s *DockerDaemonSuite) TestRunContainerWithBridgeNone(c *check.C) {
 	out, err := s.d.Cmd("run", "--rm", "busybox", "ip", "l")
 	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
 	c.Assert(strings.Contains(out, "eth0"), check.Equals, false,
-		check.Commentf("There shouldn't be eth0 in container when network is disabled: %s", out))
+		check.Commentf("There shouldn't be eth0 in container in default(bridge) mode when bridge network is disabled: %s", out))
+
+	out, err = s.d.Cmd("run", "--rm", "--net=bridge", "busybox", "ip", "l")
+	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
+	c.Assert(strings.Contains(out, "eth0"), check.Equals, false,
+		check.Commentf("There shouldn't be eth0 in container in bridge mode when bridge network is disabled: %s", out))
+
+	out, err = s.d.Cmd("run", "--rm", "--net=host", "busybox", "ip", "l")
+	c.Assert(err, check.IsNil, check.Commentf("Output: %s", out))
+	c.Assert(strings.Contains(out, "eth0"), check.Equals, true,
+		check.Commentf("There should be eth0 in container when --net=host when bridge network is disabled: %s", out))
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithContainerRunning(t *check.C) {


### PR DESCRIPTION
libnetwork host, none and bridge driver initialization is incorrectly
disabled if the daemon flag --bridge=none. The expected behavior of
setting --bridge as none is to disable the bridge driver alone and let
all other modes to be operational.

Signed-off-by: Madhu Venugopal madhu@docker.com
