### PR TITLE
WIP - Implement direct-commits on build ADD/COPY

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -837,10 +837,6 @@ func (daemon *Daemon) UnsubscribeToContainerStats(name string, ch chan interface
 	return nil
 }
 
-// FIXME: this is a convenience function for integration tests
-// which need direct access to daemon.graph.
-// Once the tests switch to using engine and jobs, this method
-// can go away.
 func (daemon *Daemon) Graph() *graph.Graph {
 	return daemon.graph
 }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -657,6 +657,79 @@ func CopyWithTar(src, dst string) error {
 	return defaultArchiver.CopyWithTar(src, dst)
 }
 
+/* Unpacks to a Tar stream */
+func UnpackTarStream(decompressedArchive io.Reader, dest string, options *TarOptions) (io.ReadCloser, error) {
+	var err error
+
+	tarStreamReader, tarStreamWriter := io.Pipe()
+	defer tarStreamWriter.Close()
+	
+	tr := tar.NewReader(decompressedArchive)
+	tw := tar.NewWriter(tarStreamWriter)
+	defer tw.Close()
+
+	// Iterate through the files in the archive.
+	errC := promise.Go(func() error {
+		for {
+			hdr, err := tr.Next()
+			if err == io.EOF {
+				// end of tar archive
+				break
+			}
+			if err != nil {
+				return err
+			}
+			hdr.Name = filepath.Clean(filepath.Join(dest, hdr.Name))
+			logrus.Debugf("UnpackTarStream: setting header name to %s", hdr.Name)
+
+			tw.WriteHeader(hdr)
+
+			logrus.Debugf("UnpackTarStream: performing io.Copy")
+			if _, err = io.Copy(tw, tr); err != nil {
+				return err
+			}
+
+			logrus.Debugf("UnpackTarStream: loop")
+		}
+		logrus.Debugf("UnpackTarStream: goroutine return")
+		return nil
+	})
+	defer func() {
+		if er := <-errC; err != nil {
+			err = er
+		}
+	}()
+
+	logrus.Debugf("UnpackTarStream: return")
+	return tarStreamReader, nil
+}
+
+// Decompresses a file to a tarstream, rebasing to destination.
+func (archiver *Archiver) UntarTar(archive io.Reader, dest string, options *TarOptions) (io.ReadCloser, error) {
+	if archive == nil {
+		return nil, fmt.Errorf("Empty archive")
+	}
+	dest = filepath.Clean(dest)
+	if options == nil {
+		options = &TarOptions{}
+	}
+	if options.ExcludePatterns == nil {
+		options.ExcludePatterns = []string{}
+	}
+	decompressedArchive, err := DecompressStream(archive)
+	if err != nil {
+		return nil, err
+	}
+	defer decompressedArchive.Close()
+	return UnpackTarStream(decompressedArchive, dest, options)
+}
+
+// UntarTar is a convenience function which calls Untar and Tar, with the output of one piped into the other.
+// If either Tar or Untar fails, UntarTar aborts and returns the error.
+func UntarTar(src io.Reader, dst string, options *TarOptions) (io.ReadCloser, error) {
+	return defaultArchiver.UntarTar(src, dst, options)
+}
+
 func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 	logrus.Debugf("CopyFileWithTar(%s, %s)", src, dst)
 	srcSt, err := os.Stat(src)


### PR DESCRIPTION
WIP - Seeking design review / feedback.

Historically, when adding files via build's ADD/COPY, tars
may be created, extracted, then committed. The commit then
creates another tar structure, piped into the graph driver.

This commit simplifies this process greatly by passing tar files
directly into the graph driver, eliminating the need to extract
to disk and re-tar these contents.

This patch is still a work in progress.
