### PR TITLE
Validate status= filter to docker ps

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -53,6 +53,9 @@ func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, 
 
 	if i, ok := psFilters["status"]; ok {
 		for _, value := range i {
+			if !isValidStateString(value) {
+				return nil, errors.New("Unrecognised filter value for status")
+			}
 			if value == "exited" || value == "created" {
 				all = true
 			}

--- a/daemon/state.go
+++ b/daemon/state.go
@@ -86,6 +86,18 @@ func (s *State) StateString() string {
 	return "exited"
 }
 
+func isValidStateString(s string) bool {
+	if s != "paused" &&
+		s != "restarting" &&
+		s != "running" &&
+		s != "dead" &&
+		s != "created" &&
+		s != "exited" {
+		return false
+	}
+	return true
+}
+
 func wait(waitChan <-chan struct{}, timeout time.Duration) error {
 	if timeout < 0 {
 		<-waitChan

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -236,6 +236,11 @@ func (s *DockerSuite) TestPsListContainersFilterStatus(c *check.C) {
 		c.Fatalf("Expected id %s, got %s for running filter, output: %q", secondID[:12], containerOut, out)
 	}
 
+	out, _, _ = dockerCmdWithTimeout(time.Second*60, "ps", "-a", "-q", "--filter=status=rubbish")
+	if !strings.Contains(out, "Unrecognised filter value for status") {
+		c.Fatalf("Expected error response due to invalid status filter output: %q", out)
+	}
+
 }
 
 func (s *DockerSuite) TestPsListContainersFilterID(c *check.C) {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Additional validation of docker ps --filter="status=something" to ensure 'something' is valid in the context of possible container statuses (statii?)
