### PR TITLE
README.md: fix cgroups/namespaces name and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ Under the hood
 Under the hood, Docker is built on the following components:
 
 * The
-  [cgroup](https://en.wikipedia.org/wiki/Cgroups)
+  [cgroups](https://www.kernel.org/doc/Documentation/cgroups/cgroups.txt)
   and
-  [namespacing](http://man7.org/linux/man-pages/man7/namespaces.7.html)
+  [namespaces](http://man7.org/linux/man-pages/man7/namespaces.7.html)
   capabilities of the Linux kernel
 * The [Go](https://golang.org) programming language
 * The [Docker Image Specification](https://github.com/docker/docker/blob/master/image/spec/v1.md)

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -323,9 +323,6 @@ options for `zfs` start with `zfs`.
 
         $ docker -d --storage-opt dm.blkdiscard=false
 
-
-## Docker execdriver option
-
 Currently supported options of `zfs`:
 
  * `zfs.fsname`
@@ -337,6 +334,8 @@ Currently supported options of `zfs`:
     Example use:
 
         $ docker -d -s zfs --storage-opt zfs.fsname=zroot/docker
+
+## Docker execdriver option
 
 The Docker daemon uses a specifically built `libcontainer` execution driver as
 its interface to the Linux kernel `namespaces`, `cgroups`, and `SELinux`.


### PR DESCRIPTION
These are two unrelated doc fixes.

First fixes names and links of cgroups and namespaces features in the Linux kernel.
Second fixes the wrong placement of a header in docker daemon cli doc, daemon.md
