### PR TITLE
Fixing Wheezy link on debian installation page

### DIFF
--- a/docs/installation/debian.md
+++ b/docs/installation/debian.md
@@ -13,7 +13,7 @@ parent = "smn_linux"
 Docker is supported on the following versions of Debian:
 
  - [*Debian 8.0 Jessie (64-bit)*](#debian-jessie-80-64-bit)
- - [*Debian 7.7 Wheezy (64-bit)*](#debian-wheezystable-7x-64-bit)
+ - [*Debian 7.7 Wheezy (64-bit)*](#debian-wheezy-stable-7-x-64-bit)
 
 ## Debian Jessie 8.0 (64-bit)
 


### PR DESCRIPTION
Fix: #14287

Correct wheezy link on debian installation doc by added two - in the link.
The link in the right menu is already good and match the corrected changed link.

Signed-off-by: Quentin Tayssier qtayssier@gmail.com
