### PR TITLE
contrib/systemd: override docker daemon opts from config file

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -5,7 +5,8 @@ After=network.target docker.socket
 Requires=docker.socket
 
 [Service]
-ExecStart=/usr/bin/docker -d -H fd://
+ExecStart=/usr/bin/docker -d -H fd:// $DOCKER_OPTS
+EnvironmentFile=-/etc/default/docker
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
It allows _Docker Machine_ to provision _Ubuntu 15.04_ (first Ubuntu with systemd by default)

See: https://github.com/docker/machine/blob/4a54559233db5de3ecff8416df5fab4262ea8a24/libmachine/provision/ubuntu.go#L25

---

A standard user-defined `/etc/default/docker` file:

``` bash
DOCKER_OPTS='
-H unix:///var/run/docker.sock
--storage-driver aufs
'
```

A _Docker Machine_ generated `/etc/default/docker` file:

``` bash
DOCKER_OPTS='
-H tcp://0.0.0.0:2376
-H unix:///var/run/docker.sock
--storage-driver overlay
--tlsverify
--tlscacert /etc/docker/ca.pem
--tlscert /etc/docker/server.pem
--tlskey /etc/docker/server-key.pem
--label provider=scaleway
'
```

This patch works if `/etc/default/docker` does not exist
