### PR TITLE
Replace latest log by logrus

### DIFF
--- a/daemon/execdriver/lxc/init.go
+++ b/daemon/execdriver/lxc/init.go
@@ -6,13 +6,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
 	"syscall"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/reexec"
 )
 
@@ -50,7 +50,7 @@ func initializer() {
 	args := getArgs()
 
 	if err := setupNamespace(args); err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 }
 
@@ -65,7 +65,7 @@ func setupNamespace(args *InitArgs) error {
 
 	path, err := exec.LookPath(args.Args[0])
 	if err != nil {
-		log.Printf("Unable to locate %v", args.Args[0])
+		logrus.Infof("Unable to locate %v", args.Args[0])
 		os.Exit(127)
 	}
 

--- a/graph/list.go
+++ b/graph/list.go
@@ -2,11 +2,11 @@ package graph
 
 import (
 	"fmt"
-	"log"
 	"path"
 	"sort"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/parsers/filters"
@@ -79,7 +79,7 @@ func (s *TagStore) Images(config *ImagesConfig) ([]*types.Image, error) {
 			imgRef := utils.ImageReference(repoName, ref)
 			image, err := s.graph.Get(id)
 			if err != nil {
-				log.Printf("Warning: couldn't load %s from %s: %s", id, imgRef, err)
+				logrus.Warnf("couldn't load %s from %s: %s", id, imgRef, err)
 				continue
 			}
 


### PR DESCRIPTION
Related to #11618 and #11614 somehow. Just took a look around for import of `"log"` and replaced the ones that were not annotated (in `client.go`).

If these `log` usage are meant to be (instead of using `logrus`), feel free to close this PR :wink:.

Signed-off-by: Vincent Demeester vincent@sbr.pm
