### PR TITLE
Fix dockerize-disk.sh working in non-en locale

### DIFF
--- a/contrib/dockerize-disk.sh
+++ b/contrib/dockerize-disk.sh
@@ -74,7 +74,7 @@ mount -t aufs -o "br=$builddir/diff=rw${base_image_mounts},dio,xino=/dev/shm/auf
 
 # Update files
 cd $builddir
-diff -rq disk_image workdir \
+LC_ALL=C diff -rq disk_image workdir \
   | sed -re "s|Only in workdir(.*?): |DEL \1/|g;s|Only in disk_image(.*?): |ADD \1/|g;s|Files disk_image/(.+) and workdir/(.+) differ|UPDATE /\1|g" \
   | while read action entry; do
       case "$action" in


### PR DESCRIPTION
One part of script relies on messages that are
output by some system tool. In non-en locale
those messages get localized which breaks the
script.
This patch enforces en locale for that system
tool.

Fixes #14123
