### PR TITLE
Fix test TestEventsDefaultEmpty. Fixes #14360

### DIFF
--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -779,7 +779,7 @@ func (s *DockerSuite) TestEventsTop(c *check.C) {
 
 // #13753
 func (s *DockerSuite) TestEventsDefaultEmpty(c *check.C) {
-	dockerCmd(c, "run", "-d", "busybox")
+	dockerCmd(c, "run", "busybox")
 	out, _ := dockerCmd(c, "events", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	c.Assert(strings.TrimSpace(out), check.Equals, "")
 }


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Fixes #14360 

`docker run -d busybox` will create 3 events `create` `start` `die`, so `docker event` have a chance
to receive a `die`. 
