### PR TITLE
Ensure images downloaded by pullTagV2 are always cleaned up

### DIFF
--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -244,22 +244,32 @@ func (p *v2Puller) pullV2Tag(tag, taggedName string) (bool, error) {
 		go p.download(&downloads[i])
 	}
 
+	// Register the images serially. We must wait for all downloads to complete if one fails,
+	// in order to cleanup the others.
+	var firstErr error
 	var tagUpdated bool
 	for i := len(downloads) - 1; i >= 0; i-- {
-		d := &downloads[i]
-		if d.err != nil {
-			if err := <-d.err; err != nil {
-				return false, err
-			}
-		}
-		verified = verified && d.verified
-		if d.layer != nil {
-			// if tmpFile is empty assume download and extracted elsewhere
-			defer os.Remove(d.tmpFile.Name())
-			defer d.tmpFile.Close()
-			d.tmpFile.Seek(0, 0)
-			if d.tmpFile != nil {
+		registerFunc := func(d *downloadInfo, pullAborted bool) error {
+			// Cleanup is guaranteed to be invoked only after the download routine exits.
+			defer func() {
+				if d.tmpFile != nil {
+					d.tmpFile.Close()
+					os.Remove(d.tmpFile.Name())
+				}
+			}()
 
+			if d.err != nil {
+				if err := <-d.err; err != nil {
+					return err
+				}
+			}
+
+			if pullAborted {
+				return nil
+			}
+
+			if d.tmpFile != nil {
+				d.tmpFile.Seek(0, 0)
 				reader := progressreader.New(progressreader.Config{
 					In:        d.tmpFile,
 					Out:       out,
@@ -272,20 +282,30 @@ func (p *v2Puller) pullV2Tag(tag, taggedName string) (bool, error) {
 
 				err = p.graph.Register(d.img, reader)
 				if err != nil {
-					return false, err
+					return err
 				}
 
 				if err := p.graph.SetDigest(d.img.ID, d.digest); err != nil {
-					return false, err
+					return err
 				}
 
+				out.Write(p.sf.FormatProgress(stringid.TruncateID(d.img.ID), "Pull complete", nil))
+				tagUpdated = true
 				// FIXME: Pool release here for parallel tag pull (ensures any downloads block until fully extracted)
+			} else {
+				out.Write(p.sf.FormatProgress(stringid.TruncateID(d.img.ID), "Already exists", nil))
 			}
-			out.Write(p.sf.FormatProgress(stringid.TruncateID(d.img.ID), "Pull complete", nil))
-			tagUpdated = true
-		} else {
-			out.Write(p.sf.FormatProgress(stringid.TruncateID(d.img.ID), "Already exists", nil))
+			return nil
 		}
+		err := registerFunc(&downloads[i], firstErr != nil)
+		verified = verified && downloads[i].verified
+		if firstErr != nil {
+			firstErr = err
+		}
+	}
+
+	if firstErr != nil {
+		return false, firstErr
 	}
 
 	manifestDigest, _, err := digestFromManifest(manifest, p.repoInfo.LocalName)


### PR DESCRIPTION
Previously, if only some of the downloads succeed, we would not close and delete the file handles. This does change the behavior of the registration to block on all downloads completing (whereas previously it would exit early after the first failure), which is necessary to ensure cleanup is only performed after the download portion has completed.

(We could also refactor the download function to take a signal when the registration has completed so it could wait and then clean itself up, but this would be a bit more involved.)

fixes https://github.com/docker/docker/issues/14506
