### PR TITLE
Clarify interactive behavior

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -111,6 +111,17 @@ specify to which of the three standard streams (`STDIN`, `STDOUT`,
 
     $ docker run -a stdin -a stdout -i -t ubuntu /bin/bash
 
+If you specify `-i` without STDIN attached, you may encounter unexpected results.  
+Consider the following example:
+
+    $ docker run -a stderr -a stdout -i --sig-proxy=true ubuntu bash
+
+Any tty-generated signals (ctrl-c, etc) will appear to be ignored.  Note, 
+however, when --sig-proxy=false tty signals are generated and the client 
+responds (not the container).  For this reason, unless you have a use for 
+running -i without STDIN attached, it is recommended to run -i with 
+-a stdin or leave the -a out to attach to STDIN by default.
+
 For interactive processes (like a shell), you must use `-i -t` together in
 order to allocate a tty for the container process. `-i -t` is often written `-it`
 as you'll see in later examples.  Specifying `-t` is forbidden when the client

--- a/man/docker-create.1.md
+++ b/man/docker-create.1.md
@@ -136,6 +136,8 @@ two memory nodes.
 
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.
+   
+   Note:  If set to true but not attached to STDIN, input may be silently discarded (see example below).
 
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
@@ -239,6 +241,22 @@ This value should always larger than **-m**, so you should always use this with 
 
 **-w**, **--workdir**=""
    Working directory inside the container
+
+# EXAMPLES
+
+## Running a container with --interactive and without attaching to STDIN
+
+Input will be silently discarded if STDIN is not attached, resulting in 
+possibly unexpected behavior.
+
+    # docker run -a stderr -a stdout -i --sig-proxy=true ubuntu bash
+
+In this example, tty-generated signals (ctrl-c, etc) will appear to be ignored, despite 
+use of --interactive and --sig-proxy.  Note, if --sig-proxy=false (the default) all 
+tty-signals are generated and the client responds (not the container).  Because 
+of this possibly confusing behavior, unless there is a specific use for running with 
+--interactive without attaching to STDIN, it is recommended to run -i with -a stdin 
+or leave the -a out to attach to STDIN by default.
 
 # HISTORY
 August 2014, updated by Sven Dowideit <SvenDowideit@home.org.au>

--- a/man/docker-run.1.md
+++ b/man/docker-run.1.md
@@ -225,8 +225,8 @@ ENTRYPOINT.
 
 **-i**, **--interactive**=*true*|*false*
    Keep STDIN open even if not attached. The default is *false*.
-
-   When set to true, keep stdin open even if not attached. The default is false.
+   
+   Note:  If set to true but not attached to STDIN, input may be silently discarded (see example below).
 
 **--ipc**=""
    Default is to create a private IPC namespace (POSIX SysV IPC) for the container
@@ -469,6 +469,20 @@ If you do not specify -a then Docker will attach everything (stdin,stdout,stderr
 you’d like to connect instead, as in:
 
     # docker run -a stdin -a stdout -i -t fedora /bin/bash
+
+## Running a container with --interactive and without attaching to STDIN
+
+Input will be silently discarded if STDIN is not attached, resulting in 
+possibly unexpected behavior.
+
+    # docker run -a stderr -a stdout -i --sig-proxy=true ubuntu bash
+
+In this example, any tty-generated signals (ctrl-c, etc) will appear to be ignored, despite 
+use of --interactive and sig-proxy.  Note, if --sig-proxy=false (the default) all 
+tty-signals are generated and the client responds (not the container).  Because of this 
+possibly confusing behavior, unless there is a specific use for running with --interactive 
+without attaching to STDIN, it is recommended to run -i with -a stdin or leave the -a out to 
+attach to STDIN by default.
 
 ## Sharing IPC between containers
 


### PR DESCRIPTION
This PR clarifies the behavior of --interactive when STDIN is not
attached.  It is in consideration of the example:

  docker run -i -a stderr -a stdout --sig-proxy=true ubuntu bash

Signed-off-by: Sally O'Malley somalley@redhat.com
