### PR TITLE
Removing .idea from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@
 .git/
 .gopath/
 .hg/
-.idea
 .vagrant*
 Vagrantfile
 a.out


### PR DESCRIPTION
The project cannot include every editor's
ignore files. Contributers can use a local
global gitignore : https://help.github.com/articles/ignoring-files
