### PR TITLE
Fix integration tests with testRequires(c, Network)

### DIFF
--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/go-check/check"
 )
@@ -37,7 +38,18 @@ var (
 	}
 	Network = TestRequirement{
 		func() bool {
-			resp, err := http.Get("http://hub.docker.com")
+			// Set a timeout on the GET at 15s
+			var timeout = time.Duration(15 * time.Second)
+			var url = "https://hub.docker.com"
+
+			client := http.Client{
+				Timeout: timeout,
+			}
+
+			resp, err := client.Get(url)
+			if err != nil && strings.Contains(err.Error(), "use of closed network connection") {
+				panic(fmt.Sprintf("Timeout for GET request on %s", url))
+			}
 			if resp != nil {
 				resp.Body.Close()
 			}


### PR DESCRIPTION
It seems http://hub.docker.com is not accessible anymore, so switching to https://hub.docker.com for testRequires(c, Network). Actually http://hub.docker.com redirect to https://hub.docker.com/... but doing a `wget http://hub.docker.com` waits for ever :sweat:.

<del>Let see if it's actually working on Janky and others</del> it does :sweat_smile:.

Wondering if we should check something else than https://hub.docker.com. And I'm not sure this change should even be needed, expect if we really want to use `https://` instead of `http://`.

Signed-off-by: Vincent Demeester vincent@sbr.pm
