### PR TITLE
Fix duplicate layers in manifest

### DIFF
--- a/graph/push.go
+++ b/graph/push.go
@@ -349,7 +349,7 @@ func (s *TagStore) pushV2Repository(r *registry.Session, localRepo Repository, o
 		}
 
 		layersSeen := make(map[string]bool)
-		layers := []*image.Image{layer}
+		layers := []*image.Image{}
 		for ; layer != nil; layer, err = s.graph.GetParent(layer) {
 			if err != nil {
 				return err


### PR DESCRIPTION
Currently the layer array is initialized with the first layer then the first layer is appened to the layer list. Adding the first layer twice causes the layer to appear twice in the manifest, making a duplicate push and pull attempt occur.
