### PR TITLE
Adding Group Metatag

### DIFF
--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -2,6 +2,7 @@ Name: docker-engine
 Version: %{_version}
 Release: %{_release}%{?dist}
 Summary: The open-source application container engine
+Group: Tools/Docker
 
 License: ASL 2.0
 Source: %{name}.tar.gz


### PR DESCRIPTION
Adding Group Metatag to hack/make/.build-rpm/docker-engine.spec file. Fixes #14404

Signed-off-by: evalle shmarnev@gmail.com
