### PR TITLE
Fix copy from a "created" container. Fixes #14420

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -23,6 +23,7 @@ import (
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/broadcastwriter"
+	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonlog"
 	"github.com/docker/docker/pkg/mount"
@@ -625,6 +626,14 @@ func (container *Container) Copy(resource string) (io.ReadCloser, error) {
 		var dest string
 		dest, err = container.GetResourcePath(m.Destination)
 		if err != nil {
+			return nil, err
+		}
+		var stat os.FileInfo
+		stat, err = os.Stat(m.Source)
+		if err != nil {
+			return nil, err
+		}
+		if err = fileutils.CreateIfNotExists(dest, stat.IsDir()); err != nil {
 			return nil, err
 		}
 		if err = mount.Mount(m.Source, dest, "bind", "rbind,ro"); err != nil {

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -632,3 +632,20 @@ func (s *DockerSuite) TestCopyAndRestart(c *check.C) {
 		c.Fatalf("expected %q but got %q", expectedMsg, msg)
 	}
 }
+
+func (s *DockerSuite) TestCopyCreatedContainer(c *check.C) {
+	out, err := exec.Command(dockerBinary, "create", "--name", "test_cp", "-v", "/test", "busybox").CombinedOutput()
+	if err != nil {
+		c.Fatalf(string(out), err)
+	}
+
+	tmpDir, err := ioutil.TempDir("", "test")
+	if err != nil {
+		c.Fatalf("unable to make temporary directory: %s", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	out, err = exec.Command(dockerBinary, "cp", "test_cp:/bin/sh", tmpDir).CombinedOutput()
+	if err != nil {
+		c.Fatalf(string(out), err)
+	}
+}

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -167,3 +167,23 @@ func ReadSymlinkedDirectory(path string) (string, error) {
 	}
 	return realPath, nil
 }
+
+// CreateIfNotExists creates a file or a directory only if it does not already exist.
+func CreateIfNotExists(path string, isDir bool) error {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			if isDir {
+				return os.MkdirAll(path, 0755)
+			}
+			if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+				return err
+			}
+			f, err := os.OpenFile(path, os.O_CREATE, 0755)
+			if err != nil {
+				return err
+			}
+			f.Close()
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

Fixes #14420 

steps to reproduce:

<pre><code>
docker create --name test_cp -v /test busybox
docker cp test_cp:/bin/sh .
Error response from daemon: Could not find the file /bin/sh in container test_cp
</code></pre>

This issues happened because the mountpoint of  `VOLUME` in just `created` container
is not create yet, so `if err := mount.Mount(m.Source, dest, "bind", "rbind,ro"); err != nil {` 
will fail with `no such file`.
