### PR TITLE
Always umount container rootfs and volumes on docker cp failed

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -622,11 +622,12 @@ func (container *Container) Copy(resource string) (io.ReadCloser, error) {
 		return nil, err
 	}
 	for _, m := range mounts {
-		dest, err := container.GetResourcePath(m.Destination)
+		var dest string
+		dest, err = container.GetResourcePath(m.Destination)
 		if err != nil {
 			return nil, err
 		}
-		if err := mount.Mount(m.Source, dest, "bind", "rbind,ro"); err != nil {
+		if err = mount.Mount(m.Source, dest, "bind", "rbind,ro"); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

If docker cp failed, the container's rootfs will still mounted, 
this is bad. this will cause the container have some problem to be removed.
I found this issue when I work on PR #14429 
steps to reproduce:

<pre><code>$ docker create -v /test busybox
0c3079c2a78fadf65aeb1ecfbcfaa2d8f9dc40a9e5c0cb56d391d9522b63a774
$ docker cp 0c3079c2a78fadf65aeb1ecfbcfaa2d8f9dc40a9e5c0cb56d391d9522b63a774:/bin/sh .
Error response from daemon: Could not find the file /bin/sh in container 0c3079c2a78fadf65aeb1ecfbcfaa2d8f9dc40a9e5c0cb56d391d9522b63a774
</code></pre>

docker cp failed but the rootfs of container is still mounted.

<pre><code>$ mount | grep 0c3079c2a78fadf65aeb1ecfbcfaa2d8f9dc40a9e5c0cb56d391d9522b63a774
overlay on /home/lei/var/overlay/0c3079c2a78fadf65aeb1ecfbcfaa2d8f9dc40a9e5c0cb56d391d9522b63a774/merged type overlay (rw,relatime,lowerdir=/home/lei/var/overlay/8c2e06607696bd4afb3d03b687e361cc43cf8ec1a4a725bc96e39f05ba97dd55/root,upperdir=/home/lei/var/overlay/0c3079c2a78fadf65aeb1ecfbcfaa2d8f9dc40a9e5c0cb56d391d9522b63a774/upper,workdir=/home/lei/var/overlay/0c3079c2a78fadf65aeb1ecfbcfaa2d8f9dc40a9e5c0cb56d391d9522b63a774/work)</code></pre>


try to remove the container:

<pre><code>$ docker rm 0c3079c2a78fadf65aeb1ecfbcfaa2d8f9dc40a9e5c0cb56d391d9522b63a774
Error response from daemon: Cannot destroy container 0c3079c2a78fadf65aeb1ecfbcfaa2d8f9dc40a9e5c0cb56d391d9522b63a774: Driver overlay failed to remove root filesystem 0c3079c2a78fadf65aeb1ecfbcfaa2d8f9dc40a9e5c0cb56d391d9522b63a774: readdirent: no such file or directory
Error: failed to remove containers: [0c3079c2a78fadf65aeb1ecfbcfaa2d8f9dc40a9e5c0cb56d391d9522b63a774]
</code></pre>
