### PR TITLE
Integrating system logging into docker API calls

### DIFF
--- a/api/server/credentials_linux.go
+++ b/api/server/credentials_linux.go
@@ -1,0 +1,170 @@
+// +build linux
+
+package server
+
+// #include <stdlib.h>
+// #include "/usr/include/pwd.h"
+import "C"
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log/syslog"
+	"net/http"
+	"net/url"
+	"path"
+	"reflect"
+	"strconv"
+	"syscall"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/daemon"
+)
+
+//Gets the file descriptor
+func getFdFromWriter(w http.ResponseWriter) int {
+	//We must use introspection to pull the
+	//connection from the ResponseWriter object
+	//This is because the connection object is not exported by the writer.
+	writerVal := reflect.Indirect(reflect.ValueOf(w))
+	//Get the underlying http connection
+	httpconn := writerVal.FieldByName("conn")
+	httpconnVal := reflect.Indirect(httpconn)
+	//Get the underlying tcp connection
+	rwcPtr := httpconnVal.FieldByName("rwc").Elem()
+	rwc := reflect.Indirect(rwcPtr)
+	tcpconn := reflect.Indirect(rwc.FieldByName("conn"))
+	//Grab the underyling netfd
+	netfd := reflect.Indirect(tcpconn.FieldByName("fd"))
+	//Grab sysfd
+	sysfd := netfd.FieldByName("sysfd")
+	//Finally, we have the fd
+	return int(sysfd.Int())
+}
+
+//Gets the ucred given an http response writer
+func getUcred(fd int) (*syscall.Ucred, error) {
+	return syscall.GetsockoptUcred(fd, syscall.SOL_SOCKET, syscall.SO_PEERCRED)
+}
+
+//Gets the client's loginuid
+func getLoginUid(ucred *syscall.Ucred, fd int) (int, error) {
+	if _, err := syscall.Getpeername(fd); err != nil {
+		logrus.Errorf("Socket appears to have closed: %v", err)
+	}
+	loginuid, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/loginuid", ucred.Pid))
+	if err != nil {
+		logrus.Errorf("Error reading loginuid: %v", err)
+		return -1, err
+	}
+	loginuid_int, err := strconv.Atoi(string(loginuid))
+	if err != nil {
+		logrus.Errorf("Failed to convert loginuid to int: %v", err)
+	}
+	return loginuid_int, nil
+}
+
+//Given a loginUID, retrieves the current username
+func getpwuid(loginUID int) (string, error) {
+	pw_struct, err := C.getpwuid(C.__uid_t(loginUID))
+	if err != nil {
+		logrus.Errorf("Failed to get pwuid struct: %v", err)
+	}
+	name := C.GoString(pw_struct.pw_name)
+	return name, nil
+}
+
+//Retrieves the container and "action" (start, stop, kill, etc) from the http request
+func (s *Server) parseRequest(requrl string) (string, *daemon.Container) {
+	parsedurl, err := url.Parse(requrl)
+	if err != nil {
+		return "?", nil
+	}
+
+	action := path.Base(parsedurl.Path)
+	containerID := path.Base(path.Dir(parsedurl.Path))
+	c, err := s.daemon.Get(containerID)
+	if err != nil {
+		return action, nil
+	}
+	return action, c
+}
+
+//Traverses the config struct and grabs non-standard values for logging
+func parseConfig(config interface{}) string {
+	configReflect := reflect.ValueOf(config)
+	var result bytes.Buffer
+	for index := 0; index < configReflect.NumField(); index++ {
+		val := reflect.Indirect(configReflect.Field(index))
+		//Get the zero value of the struct's field
+		if val.IsValid() {
+			zeroVal := reflect.Zero(val.Type()).Interface()
+			//If the configuration value is not a zero value, then we store it
+			//We use deep equal here because some types cannot be compared with the standard equality operators
+			if val.Kind() == reflect.Bool || !reflect.DeepEqual(zeroVal, val.Interface()) {
+				fieldName := configReflect.Type().Field(index).Name
+				line := fmt.Sprintf("%s=%+v, ", fieldName, val.Interface())
+				result.WriteString(line)
+			}
+		}
+	}
+	return result.String()
+}
+
+//Constructs a partial log message containing the container's configuration settings
+func generateContainerConfigMsg(c *daemon.Container) string {
+	if c != nil {
+		config_stripped := parseConfig(*c.Config)
+		hostConfig_stripped := parseConfig(*c.HostConfig())
+		return fmt.Sprintf("ContainerID=%v, Config=%v HostConfig=%v", c.ID, config_stripped, hostConfig_stripped)
+	}
+	return ""
+}
+
+//Logs a docker API function and records the user that initiated the request using the authentication results
+func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
+	//Success determines if the authorization was successful or not
+	var message string
+	action, c := s.parseRequest(r.RequestURI)
+
+	switch action {
+	case "start":
+		message += generateContainerConfigMsg(c)
+		fallthrough
+	default:
+		//Get user credentials
+		fd := getFdFromWriter(w)
+		ucred, err := getUcred(fd)
+		if err != nil {
+			break
+		}
+		message = fmt.Sprintf("PID=%v, ", ucred.Pid) + message
+
+		//Get user loginuid
+		loginuid, err := getLoginUid(ucred, fd)
+		if err != nil {
+			break
+		}
+		message = fmt.Sprintf("LoginUID=%v, ", loginuid) + message
+
+		//Get username
+		username, err := getpwuid(loginuid)
+		if err != nil {
+			break
+		}
+		message = fmt.Sprintf("Username=%v, ", username) + message
+	}
+	message = fmt.Sprintf("{Action=%v, %s}", action, message)
+	logSyslog(message)
+	return nil
+}
+
+//Logs a message to the syslog
+func logSyslog(message string) {
+	logger, err := syslog.New(syslog.LOG_ALERT, "Docker")
+	defer logger.Close()
+	if err != nil {
+		fmt.Printf("Error logging to system log: %v", err)
+	}
+	logger.Info(message)
+}

--- a/api/server/credentials_windows.go
+++ b/api/server/credentials_windows.go
@@ -1,0 +1,10 @@
+// +build windows
+
+package server
+
+import "net/http"
+
+// Audit and system logging are unsupported in windows environments
+func (s *Server) LogAction(w http.ResponseWriter, r *http.Request) error {
+	return nil
+}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1478,7 +1478,7 @@ func (s *Server) initTcpSocket(addr string) (l net.Listener, err error) {
 	return
 }
 
-func makeHttpHandler(logging bool, localMethod string, localRoute string, handlerFunc HttpApiFunc, corsHeaders string, dockerVersion version.Version) http.HandlerFunc {
+func (s *Server) makeHttpHandler(logging bool, localMethod string, localRoute string, handlerFunc HttpApiFunc, corsHeaders string, dockerVersion version.Version) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// log the request
 		logrus.Debugf("Calling %s %s", localMethod, localRoute)
@@ -1604,7 +1604,7 @@ func createRouter(s *Server) *mux.Router {
 			localMethod := method
 
 			// build the handler function
-			f := makeHttpHandler(s.cfg.Logging, localMethod, localRoute, localFct, corsHeaders, version.Version(s.cfg.Version))
+			f := s.makeHttpHandler(s.cfg.Logging, localMethod, localRoute, localFct, corsHeaders, version.Version(s.cfg.Version))
 
 			// add the new route
 			if localRoute == "" {


### PR DESCRIPTION
This patch provides much needed system logging for docker's API functions. With this patch, when an API request is made, an entry will be added to the syslog. 

Important events will contain the action requested, the container's ID, the username and login UID of the user issuing the request, the process ID, and any initialized configuration settings. In an effort to reduce the size of the log message, uninitialized configuration parameters are not logged.

Here is an example of a start log: 

```
{Action=start, Username=abenson, LoginUID=1000, PID=3333, ContainerID=c367e0b0dbbac2d2f5b88a28b89526a857266f7914032277e97f7b635fa7b222, Config=Hostname=c367e0b0dbba, AttachStdin=true, AttachStdout=true, AttachStderr=true, Tty=true, OpenStdin=true, StdinOnce=true, Cmd={parts:[/bin/bash]}, Image=docker.io/centos, NetworkDisabled=false, Labels=map[],  HostConfig=LxcConf={values:[]}, OomKillDisable=false, Privileged=false, PortBindings=map[], PublishAllPorts=false, Devices=[], NetworkMode=default, RestartPolicy={Name:no MaximumRetryCount:0}, ReadonlyRootfs=false, LogConfig={Type: Config:map[]}, }
```

Less "interesting" events **(kill, stop, pause, etc)** create a smaller entry:

```
Jun 18 09:47:33 redhat-abenson Docker[16612]: {Action=kill, ID=84cf8f58643c243be40753b136006cd3a4b2579d601bc3281c2d289d8d2a6158, Username=abenson, LoginUID=1000, PID=32401, }
```

This patch makes it much easier to determine what any container on a system is doing, and also provides valuable insight about how users on a system are interacting with the daemon. This patch was developed with the help and support of @rhatdan at Red Hat.

Signed-off-by: Alec Benson albenson@redhat.com
