### PR TITLE
Windows: Block docker push for TP3

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -819,6 +819,10 @@ func (s *Server) getImagesSearch(version version.Version, w http.ResponseWriter,
 }
 
 func (s *Server) postImagesPush(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("The preview release of the Windows docker daemon does not support push")
+	}
+
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
 	}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@taylorb-microsoft @swernli @icecrime.  This PR blocks the ability (for the Windows Server TP3 release) for the daemon to support push operations. This is to stop the Windows base image inadvertently being pushed to dockerhub.
