### PR TITLE
Cleanup exited detached exec jobs

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -246,5 +246,11 @@ func (d *Daemon) Exec(c *Container, execConfig *execConfig, pipes *execdriver.Pi
 	execConfig.ExitCode = exitStatus
 	execConfig.Running = false
 
+	// There is no use in keeping the execConfig structure alive is the job is running detached,
+	// because the CLI doesn't output the ExecID and there is no way to attach to it.
+	if !execConfig.OpenStdin && !execConfig.OpenStdout && !execConfig.OpenStderr {
+		d.unregisterExecCommand(execConfig)
+	}
+
 	return exitStatus, err
 }


### PR DESCRIPTION
Exec is a second class citizen that should mostly be used for debugging
purpose. It doesn't offer the same attach/wait/delete functionalities
that containers do which makes it impossible to implement the proper
client workflow of retrieving the exitCode before properly deleting all
traces of the exec structure.

This patch aims at offering a workaround _without_ expanding the scope
of exec functionalities by making the execConfig cleanup automatic for
any detached exec job. This is basically saying that you cannot retrieve
the exitStatus of a detached exec job, which I think is an acceptable
tradeoff.

This could be a partial resolution for #14444.
