### PR TITLE
Add cmdline docs for signing and verification flows

### DIFF
--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -45,6 +45,8 @@ by the `docker` command line:
   unsuitable for Docker.
 * `DOCKER_RAMDISK` If set this will disable 'pivot_root'.
 * `DOCKER_TLS_VERIFY` When set Docker uses TLS and verifies the remote.
+* `DOCKER_NOTARY` When set Docker uses notary to sign and verify images.
+  Equates to `--untrusted=false` for build, create, pull, push, run.
 * `DOCKER_TMPDIR` Location for temporary Docker files.
 
 Because Docker is developed using 'Go', you can also use any environment

--- a/docs/reference/commandline/create.md
+++ b/docs/reference/commandline/create.md
@@ -59,6 +59,7 @@ Creates a new container.
       --restart="no"             Restart policy (no, on-failure[:max-retry], always)
       --security-opt=[]          Security options
       -t, --tty=false            Allocate a pseudo-TTY
+      --untrusted                Skip image verification
       -u, --user=""              Username or UID
       -v, --volume=[]            Bind mount a volume
       --volumes-from=[]          Mount volumes from the specified container(s)

--- a/docs/reference/commandline/pull.md
+++ b/docs/reference/commandline/pull.md
@@ -16,6 +16,7 @@ weight=1
     Pull an image or a repository from the registry
 
       -a, --all-tags=false    Download all tagged images in the repository
+      --untrusted             Skip image verification
 
 Most of your images will be created on top of a base image from the
 [Docker Hub](https://hub.docker.com) registry.

--- a/docs/reference/commandline/push.md
+++ b/docs/reference/commandline/push.md
@@ -15,5 +15,7 @@ weight=1
 
     Push an image or a repository to the registry
 
+    --untrusted                Skip image signing
+
 Use `docker push` to share your images to the [Docker Hub](https://hub.docker.com)
 registry or to a self-hosted one.

--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -62,6 +62,7 @@ weight=1
       --sig-proxy=true           Proxy received signals to the process
       -t, --tty=false            Allocate a pseudo-TTY
       -u, --user=""              Username or UID (format: <name|uid>[:<group|gid>])
+      --untrusted                Skip image verification
       -v, --volume=[]            Bind mount a volume
       --volumes-from=[]          Mount volumes from the specified container(s)
       -w, --workdir=""           Working directory inside the container


### PR DESCRIPTION
In order to address issue #2700 we have been working on design and implementation of a system for trusted distribution of Docker images

We'd like to solicit feedback on our design. Please find our [design document](https://docs.google.com/document/d/1Xn9kuhICOFj_P37ZWng8LeR_32NAj4Ytm42XAVWuTHw/edit?usp=sharing) for more details on this proposal.

To briefly summarize the proposal, a new environment variable, DOCKER_NOTARY, will enable signing and verification on push, pull, create and run. This flag will cause signing to happen on push and verification to happen on pull, create, and run. The signing and verification functionality will be implemented in the Docker client through [notary](github.com/docker/notary)'s implementation of The Update Framework.

Signed-off-by: Nathan McCauley nathan.mccauley@docker.com
