### PR TITLE
Remove *.rej pattern from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 #  please consider a global .gitignore https://help.github.com/articles/ignoring-files
 *.exe
 *.orig
-*.rej
 *.test
 .*.swp
 .DS_Store


### PR DESCRIPTION
Don't why people want to ignore it because these rej files really
generated for good reasons. I use `git apply --reject` a lot, it's
the recommended way if `git am` won't work, if we ignore *.rej, I
don't know which files are failed to be applied (throw log or use
`find` is too much trouble).

I know Linux didn't ignore *.rej, it's added once, and removed, we
can see the reason from:
http://lkml.iu.edu/hypermail/linux/kernel/0805.0/0643.html

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
