### PR TITLE
Remove RPM specific dependencies

### DIFF
--- a/hack/make/.build-rpm/docker-engine.spec
+++ b/hack/make/.build-rpm/docker-engine.spec
@@ -37,10 +37,7 @@ Requires(preun): initscripts
 # required packages on install
 Requires: /bin/sh
 Requires: iptables
-Requires: libc.so.6
 Requires: libcgroup
-Requires: libpthread.so.0
-Requires: libsqlite3.so.0
 Requires: tar
 Requires: xz
 %if 0%{?fedora} >= 21


### PR DESCRIPTION
Let RPM auto-generate the dependencies on libraries during build. RPM will still generate the correct dependencies with the right architecture:

```
# rpm -qpR docker-engine-1.8.0-0.0.20150708.023155.gitf9aefd1.el7.centos.x86_64.rpm
...
libc.so.6()(64bit)
libc.so.6(GLIBC_2.14)(64bit)
libc.so.6(GLIBC_2.2.5)(64bit)
libc.so.6(GLIBC_2.4)(64bit)
libc.so.6(GLIBC_2.9)(64bit)
libdevmapper.so.1.02()(64bit)
libdevmapper.so.1.02(Base)(64bit)
libpthread.so.0()(64bit)
libpthread.so.0(GLIBC_2.2.5)(64bit)
libsqlite3.so.0()(64bit)
...
```

This resolves issue #14042 on all current RPM platforms. Tested on CentOS 6 and 7; Fedora 20, 21, 22.

Signed-off-by: Avi Miller avi.miller@oracle.com
