### PR TITLE
Fix panic on devicemapper initialization

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -691,6 +691,9 @@ func getDeviceUUID(device string) (string, error) {
 }
 
 func (devices *DeviceSet) verifyBaseDeviceUUID(baseInfo *DevInfo) error {
+	devices.Lock()
+	defer devices.Unlock()
+
 	if err := devices.activateDeviceIfNeeded(baseInfo); err != nil {
 		return err
 	}
@@ -710,6 +713,9 @@ func (devices *DeviceSet) verifyBaseDeviceUUID(baseInfo *DevInfo) error {
 }
 
 func (devices *DeviceSet) saveBaseDeviceUUID(baseInfo *DevInfo) error {
+	devices.Lock()
+	defer devices.Unlock()
+
 	if err := devices.activateDeviceIfNeeded(baseInfo); err != nil {
 		return err
 	}


### PR DESCRIPTION
The ability to save and verify base device UUID (#13896) introduced a
situation where the initialization would panic when removing the device
returns EBUSY.

Functions `verifyBaseDeviceUUID` and `saveBaseDeviceUUID` now take the
lock on the `DeviceSet`, which solves the problem as `removeDevice`
assumes it owns the lock.

Fixes #14451.

Signed-off-by: Arnaud Porterie arnaud.porterie@docker.com
