### PR TITLE
Windows: Wrong build tag in runconfig

### DIFF
--- a/runconfig/hostconfig_windows.go
+++ b/runconfig/hostconfig_windows.go
@@ -1,5 +1,3 @@
-// +build !windows
-
 package runconfig
 
 func (n NetworkMode) IsDefault() bool {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Stupid, stupid bug on my part. Completely wrong build tag in runconfig\hostconfig_windows.go. Removed entirely.
