### PR TITLE
Update run.md

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -430,7 +430,7 @@ You cannot set any restart policy in combination with
 ["clean up (--rm)"](#clean-up-rm). Setting both `--restart` and `--rm`
 results in an error.
 
-###Examples
+### Examples
 
     $ docker run --restart=always redis
 


### PR DESCRIPTION
Put a space after the `###` in the Example section. On the github parser the result file looks ok, but in the docker page (https://docs.docker.com/reference/run/) looks ugly.
