### PR TITLE
Remove prefix dots from inspects in tests

### DIFF
--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -485,7 +485,7 @@ func (s *DockerRegistrySuite) TestDeleteImageByIDOnlyPulledByDigest(c *check.C) 
 	}
 	// just in case...
 
-	imageID, err := inspectField(imageReference, ".Id")
+	imageID, err := inspectField(imageReference, "Id")
 	if err != nil {
 		c.Fatalf("error inspecting image id: %v", err)
 	}

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -112,7 +112,7 @@ func (s *DockerSuite) TestRestartWithVolumes(c *check.C) {
 		c.Errorf("expect 1 volume received %s", out)
 	}
 
-	volumes, err := inspectField(cleanedContainerID, ".Volumes")
+	volumes, err := inspectField(cleanedContainerID, "Volumes")
 	c.Assert(err, check.IsNil)
 
 	runCmd = exec.Command(dockerBinary, "restart", cleanedContainerID)
@@ -130,7 +130,7 @@ func (s *DockerSuite) TestRestartWithVolumes(c *check.C) {
 		c.Errorf("expect 1 volume after restart received %s", out)
 	}
 
-	volumesAfterRestart, err := inspectField(cleanedContainerID, ".Volumes")
+	volumesAfterRestart, err := inspectField(cleanedContainerID, "Volumes")
 	c.Assert(err, check.IsNil)
 
 	if volumes != volumesAfterRestart {


### PR DESCRIPTION
Dots prepended to key in inspectField function
