### PR TITLE
Fix Windows CI fail due to GH13866

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 #  if you want to ignore files created by your editor/tools,
 #  please consider a global .gitignore https://help.github.com/articles/ignoring-files
 *.exe
+*.exe~
 *.orig
 *.rej
 *.test

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"os/exec"
 	"reflect"
 	"regexp"
@@ -12,38 +10,6 @@ import (
 
 	"github.com/go-check/check"
 )
-
-func (s *DockerSuite) TestLinksEtcHostsRegularFile(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "--net=host", "busybox", "ls", "-la", "/etc/hosts")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
-
-	if !strings.HasPrefix(out, "-") {
-		c.Errorf("/etc/hosts should be a regular file")
-	}
-}
-
-func (s *DockerSuite) TestLinksEtcHostsContentMatch(c *check.C) {
-	testRequires(c, SameHostDaemon)
-
-	runCmd := exec.Command(dockerBinary, "run", "--net=host", "busybox", "cat", "/etc/hosts")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
-
-	hosts, err := ioutil.ReadFile("/etc/hosts")
-	if os.IsNotExist(err) {
-		c.Skip("/etc/hosts does not exist, skip this test")
-	}
-
-	if out != string(hosts) {
-		c.Errorf("container")
-	}
-
-}
 
 func (s *DockerSuite) TestLinksPingUnlinkedContainers(c *check.C) {
 	runCmd := exec.Command(dockerBinary, "run", "--rm", "busybox", "sh", "-c", "ping -c 1 alias1 -W 1 && ping -c 1 alias2 -W 1")
@@ -213,20 +179,6 @@ func (s *DockerSuite) TestLinksHostsFilesInject(c *check.C) {
 
 	if !strings.Contains(string(contentTwo), "onetwo") {
 		c.Fatal("Host is not present in updated hosts file", string(contentTwo))
-	}
-
-}
-
-func (s *DockerSuite) TestLinksNetworkHostContainer(c *check.C) {
-
-	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "--net", "host", "--name", "host_container", "busybox", "top"))
-	if err != nil {
-		c.Fatal(err, out)
-	}
-
-	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", "--name", "should_fail", "--link", "host_container:tester", "busybox", "true"))
-	if err == nil || !strings.Contains(out, "--net=host can't be used with links. This would result in undefined behavior") {
-		c.Fatalf("Running container linking to a container with --net host should have failed: %s", out)
 	}
 
 }

--- a/integration-cli/docker_cli_links_unix_test.go
+++ b/integration-cli/docker_cli_links_unix_test.go
@@ -1,0 +1,58 @@
+// +build !windows
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestLinksEtcHostsRegularFile(c *check.C) {
+	runCmd := exec.Command(dockerBinary, "run", "--net=host", "busybox", "ls", "-la", "/etc/hosts")
+	out, _, _, err := runCommandWithStdoutStderr(runCmd)
+	if err != nil {
+		c.Fatal(out, err)
+	}
+
+	if !strings.HasPrefix(out, "-") {
+		c.Errorf("/etc/hosts should be a regular file")
+	}
+}
+
+func (s *DockerSuite) TestLinksEtcHostsContentMatch(c *check.C) {
+	testRequires(c, SameHostDaemon)
+
+	runCmd := exec.Command(dockerBinary, "run", "--net=host", "busybox", "cat", "/etc/hosts")
+	out, _, _, err := runCommandWithStdoutStderr(runCmd)
+	if err != nil {
+		c.Fatal(out, err)
+	}
+
+	hosts, err := ioutil.ReadFile("/etc/hosts")
+	if os.IsNotExist(err) {
+		c.Skip("/etc/hosts does not exist, skip this test")
+	}
+
+	if out != string(hosts) {
+		c.Errorf("container")
+	}
+
+}
+
+func (s *DockerSuite) TestLinksNetworkHostContainer(c *check.C) {
+
+	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "--net", "host", "--name", "host_container", "busybox", "top"))
+	if err != nil {
+		c.Fatal(err, out)
+	}
+
+	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", "--name", "should_fail", "--link", "host_container:tester", "busybox", "true"))
+	if err == nil || !strings.Contains(out, "--net=host can't be used with links. This would result in undefined behavior") {
+		c.Fatalf("Running container linking to a container with --net host should have failed: %s", out)
+	}
+
+}

--- a/integration-cli/docker_cli_port_unix_test.go
+++ b/integration-cli/docker_cli_port_unix_test.go
@@ -1,0 +1,87 @@
+// +build !windows
+
+package main
+
+import (
+	"net"
+	"os/exec"
+	"strings"
+
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestPortHostBinding(c *check.C) {
+	runCmd := exec.Command(dockerBinary, "run", "-d", "-p", "9876:80", "busybox",
+		"nc", "-l", "-p", "80")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		c.Fatal(out, err)
+	}
+	firstID := strings.TrimSpace(out)
+
+	runCmd = exec.Command(dockerBinary, "port", firstID, "80")
+	out, _, err = runCommandWithOutput(runCmd)
+	if err != nil {
+		c.Fatal(out, err)
+	}
+
+	if !assertPortList(c, out, []string{"0.0.0.0:9876"}) {
+		c.Error("Port list is not correct")
+	}
+
+	runCmd = exec.Command(dockerBinary, "run", "--net=host", "busybox",
+		"nc", "localhost", "9876")
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		c.Fatal(out, err)
+	}
+
+	runCmd = exec.Command(dockerBinary, "rm", "-f", firstID)
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		c.Fatal(out, err)
+	}
+
+	runCmd = exec.Command(dockerBinary, "run", "--net=host", "busybox",
+		"nc", "localhost", "9876")
+	if out, _, err = runCommandWithOutput(runCmd); err == nil {
+		c.Error("Port is still bound after the Container is removed")
+	}
+}
+
+func (s *DockerSuite) TestPortExposeHostBinding(c *check.C) {
+	runCmd := exec.Command(dockerBinary, "run", "-d", "-P", "--expose", "80", "busybox",
+		"nc", "-l", "-p", "80")
+	out, _, err := runCommandWithOutput(runCmd)
+	if err != nil {
+		c.Fatal(out, err)
+	}
+	firstID := strings.TrimSpace(out)
+
+	runCmd = exec.Command(dockerBinary, "port", firstID, "80")
+	out, _, err = runCommandWithOutput(runCmd)
+	if err != nil {
+		c.Fatal(out, err)
+	}
+
+	_, exposedPort, err := net.SplitHostPort(out)
+
+	if err != nil {
+		c.Fatal(out, err)
+	}
+
+	runCmd = exec.Command(dockerBinary, "run", "--net=host", "busybox",
+		"nc", "localhost", strings.TrimSpace(exposedPort))
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		c.Fatal(out, err)
+	}
+
+	runCmd = exec.Command(dockerBinary, "rm", "-f", firstID)
+	if out, _, err = runCommandWithOutput(runCmd); err != nil {
+		c.Fatal(out, err)
+	}
+
+	runCmd = exec.Command(dockerBinary, "run", "--net=host", "busybox",
+		"nc", "localhost", strings.TrimSpace(exposedPort))
+	if out, _, err = runCommandWithOutput(runCmd); err == nil {
+		c.Error("Port is still bound after the Container is removed")
+	}
+}

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -285,3 +285,193 @@ func (s *DockerSuite) TestRunWithCpuPeriod(c *check.C) {
 		c.Fatalf("setting the CPU CFS period failed")
 	}
 }
+
+func (s *DockerSuite) TestRunOOMExitCode(c *check.C) {
+	testRequires(c, OomControl)
+	errChan := make(chan error)
+	go func() {
+		defer close(errChan)
+		runCmd := exec.Command(dockerBinary, "run", "-m", "4MB", "busybox", "sh", "-c", "x=a; while true; do x=$x$x$x$x; done")
+		out, exitCode, _ := runCommandWithOutput(runCmd)
+		if expected := 137; exitCode != expected {
+			errChan <- fmt.Errorf("wrong exit code for OOM container: expected %d, got %d (output: %q)", expected, exitCode, out)
+		}
+	}()
+
+	select {
+	case err := <-errChan:
+		c.Assert(err, check.IsNil)
+	case <-time.After(30 * time.Second):
+		c.Fatal("Timeout waiting for container to die on OOM")
+	}
+}
+
+func (s *DockerSuite) TestContainerNetworkModeToSelf(c *check.C) {
+	cmd := exec.Command(dockerBinary, "run", "--name=me", "--net=container:me", "busybox", "true")
+	out, _, err := runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "cannot join own network") {
+		c.Fatalf("using container net mode to self should result in an error")
+	}
+}
+
+func (s *DockerSuite) TestRunContainerNetModeWithDnsMacHosts(c *check.C) {
+	cmd := exec.Command(dockerBinary, "run", "-d", "--name", "parent", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--dns", "1.2.3.4", "--net=container:parent", "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "Conflicting options: --dns and the network mode") {
+		c.Fatalf("run --net=container with --dns should error out")
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--mac-address", "92:d0:c6:0a:29:33", "--net=container:parent", "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "--mac-address and the network mode") {
+		c.Fatalf("run --net=container with --mac-address should error out")
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--add-host", "test:192.168.2.109", "--net=container:parent", "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "--add-host and the network mode") {
+		c.Fatalf("run --net=container with --add-host should error out")
+	}
+
+}
+
+func (s *DockerSuite) TestRunContainerNetModeWithExposePort(c *check.C) {
+	cmd := exec.Command(dockerBinary, "run", "-d", "--name", "parent", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "-p", "5000:5000", "--net=container:parent", "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "Conflicting options: -p, -P, --publish-all, --publish and the network mode (--net)") {
+		c.Fatalf("run --net=container with -p should error out")
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "-P", "--net=container:parent", "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "Conflicting options: -p, -P, --publish-all, --publish and the network mode (--net)") {
+		c.Fatalf("run --net=container with -P should error out")
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--expose", "5000", "--net=container:parent", "busybox")
+	out, _, err = runCommandWithOutput(cmd)
+	if err == nil || !strings.Contains(out, "Conflicting options: --expose and the network mode (--expose)") {
+		c.Fatalf("run --net=container with --expose should error out")
+	}
+
+}
+
+func (s *DockerSuite) TestRunLinkToContainerNetMode(c *check.C) {
+	cmd := exec.Command(dockerBinary, "run", "--name", "test", "-d", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+	cmd = exec.Command(dockerBinary, "run", "--name", "parent", "-d", "--net=container:test", "busybox", "top")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+	cmd = exec.Command(dockerBinary, "run", "-d", "--link=parent:parent", "busybox", "top")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--name", "child", "-d", "--net=container:parent", "busybox", "top")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+	cmd = exec.Command(dockerBinary, "run", "-d", "--link=child:child", "busybox", "top")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+}
+
+func (s *DockerSuite) TestRunLoopbackOnlyExistsWhenNetworkingDisabled(c *check.C) {
+	cmd := exec.Command(dockerBinary, "run", "--net=none", "busybox", "ip", "-o", "-4", "a", "show", "up")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(err, out)
+	}
+
+	var (
+		count = 0
+		parts = strings.Split(out, "\n")
+	)
+
+	for _, l := range parts {
+		if l != "" {
+			count++
+		}
+	}
+
+	if count != 1 {
+		c.Fatalf("Wrong interface count in container %d", count)
+	}
+
+	if !strings.HasPrefix(out, "1: lo") {
+		c.Fatalf("Wrong interface in test container: expected [1: lo], got %s", out)
+	}
+}
+
+// Issue #4681
+func (s *DockerSuite) TestRunLoopbackWhenNetworkDisabled(c *check.C) {
+	cmd := exec.Command(dockerBinary, "run", "--net=none", "busybox", "ping", "-c", "1", "127.0.0.1")
+	if _, err := runCommand(cmd); err != nil {
+		c.Fatal(err)
+	}
+}
+
+func (s *DockerSuite) TestRunModeNetContainerHostname(c *check.C) {
+	testRequires(c, ExecSupport)
+	cmd := exec.Command(dockerBinary, "run", "-i", "-d", "--name", "parent", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("failed to run container: %v, output: %q", err, out)
+	}
+	cmd = exec.Command(dockerBinary, "exec", "parent", "cat", "/etc/hostname")
+	out, _, err = runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("failed to exec command: %v, output: %q", err, out)
+	}
+
+	cmd = exec.Command(dockerBinary, "run", "--net=container:parent", "busybox", "cat", "/etc/hostname")
+	out1, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatalf("failed to run container: %v, output: %q", err, out1)
+	}
+	if out1 != out {
+		c.Fatal("containers with shared net namespace should have same hostname")
+	}
+}
+
+func (s *DockerSuite) TestRunNetworkNotInitializedNoneMode(c *check.C) {
+	cmd := exec.Command(dockerBinary, "run", "-d", "--net=none", "busybox", "top")
+	out, _, err := runCommandWithOutput(cmd)
+	if err != nil {
+		c.Fatal(err)
+	}
+	id := strings.TrimSpace(out)
+	res, err := inspectField(id, "NetworkSettings.IPAddress")
+	c.Assert(err, check.IsNil)
+	if res != "" {
+		c.Fatalf("For 'none' mode network must not be initialized, but container got IP: %s", res)
+	}
+}
+
+func (s *DockerSuite) TestTwoContainersInNetHost(c *check.C) {
+	dockerCmd(c, "run", "-d", "--net=host", "--name=first", "busybox", "top")
+	dockerCmd(c, "run", "-d", "--net=host", "--name=second", "busybox", "top")
+	dockerCmd(c, "stop", "first")
+	dockerCmd(c, "stop", "second")
+}

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -7,11 +7,9 @@ import (
 	"log"
 	"net/http"
 	"os/exec"
-	"path"
 	"strings"
 	"time"
 
-	"github.com/docker/libcontainer/cgroups"
 	"github.com/go-check/check"
 )
 
@@ -120,24 +118,6 @@ var (
 			return false
 		},
 		"Test requires support for IPv6",
-	}
-	OomControl = TestRequirement{
-		func() bool {
-			cgroupMemoryMountpoint, err := cgroups.FindCgroupMountpoint("memory")
-			if err != nil {
-				return false
-			}
-			if _, err := ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.memsw.limit_in_bytes")); err != nil {
-				return false
-			}
-
-			if _, err = ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.oom_control")); err != nil {
-				return false
-			}
-			return true
-
-		},
-		"Test requires Oom control enabled.",
 	}
 )
 

--- a/integration-cli/requirements_unix.go
+++ b/integration-cli/requirements_unix.go
@@ -36,4 +36,22 @@ var (
 		},
 		"Test requires an environment that supports cgroup cfs quota.",
 	}
+	OomControl = TestRequirement{
+		func() bool {
+			cgroupMemoryMountpoint, err := cgroups.FindCgroupMountpoint("memory")
+			if err != nil {
+				return false
+			}
+			if _, err := ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.memsw.limit_in_bytes")); err != nil {
+				return false
+			}
+
+			if _, err = ioutil.ReadFile(path.Join(cgroupMemoryMountpoint, "memory.oom_control")); err != nil {
+				return false
+			}
+			return true
+
+		},
+		"Test requires Oom control enabled.",
+	}
 )

--- a/runconfig/parse_windows.go
+++ b/runconfig/parse_windows.go
@@ -8,7 +8,7 @@ import (
 func parseNetMode(netMode string) (NetworkMode, error) {
 	parts := strings.Split(netMode, ":")
 	switch mode := parts[0]; mode {
-	case "default":
+	case "default", "none":
 	default:
 		return "", fmt.Errorf("invalid --net: %s", netMode)
 	}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@jfrazelle @crosbymichael @swernli @brahmaroutu

This fixes the Windows CI tests not running problem due to putting cgroup requirements in a non-Linux test file introduced through #13866. 

(Have pinged Jess offline as to why the Windows CI shows green even with the error)
Download of images into 'bundles/1.8.0-dev/test-integration-cli/frozen-images' complete.
Use something like the following to load the result into a Docker daemon:
  tar -cC 'bundles/1.8.0-dev/test-integration-cli/frozen-images' . | docker load
++++ tar -cC bundles/1.8.0-dev/test-integration-cli/frozen-images .
++++ docker load
---> Making bundle: .ensure-httpserver (in bundles/1.8.0-dev/test-integration-cli)
SECURITY WARNING: You are building a Docker image from Windows against a non-Windows Docker host. All files and directories added to build context will have '-rwxr-xr-x' permissions. It is recommended to double check and reset permissions for sensitive files and directories.
- go test -test.timeout=60m -check.v github.com/docker/docker/integration-cli
  # github.com/docker/docker/integration-cli
  C:\Jenkins\gopath\src\github.com\docker\docker\integration-cli\requirements.go:126: undefined: cgroups.FindCgroupMountpoint
  FAIL    github.com/docker/docker/integration-cli [build failed]
- unset DOCKER_CLIENTONLY
- hack/make.sh binary
  # WARNING! I don't seem to be running in the Docker container.
  # The result of this command might be an incorrect build, and will not be
  #   officially supported.
  #
  # Try this instead: make all
  #
