### PR TITLE
Check dockerinit only if lxc driver is used

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -698,9 +698,13 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 
 	d.containerGraph = graph
 
-	sysInitPath, err := configureSysInit(config)
-	if err != nil {
-		return nil, err
+	var sysInitPath string
+	if config.ExecDriver == "lxc" {
+		initPath, err := configureSysInit(config)
+		if err != nil {
+			return nil, err
+		}
+		sysInitPath = initPath
 	}
 
 	sysInfo := sysinfo.New(false)


### PR DESCRIPTION
This allow you to run dynamically linked docker without compiling
dockerinit.
