### PR TITLE
Align 'docker commit' docs with the code

### DIFF
--- a/builder/job.go
+++ b/builder/job.go
@@ -32,16 +32,15 @@ const maxPreambleLength = 100
 
 // whitelist of commands allowed for a commit/import
 var validCommitCommands = map[string]bool{
-	"entrypoint": true,
 	"cmd":        true,
-	"user":       true,
-	"workdir":    true,
+	"entrypoint": true,
 	"env":        true,
-	"volume":     true,
 	"expose":     true,
-	"onbuild":    true,
 	"label":      true,
-	"maintainer": true,
+	"onbuild":    true,
+	"user":       true,
+	"volume":     true,
+	"workdir":    true,
 }
 
 type Config struct {

--- a/docs/reference/commandline/commit.md
+++ b/docs/reference/commandline/commit.md
@@ -35,7 +35,7 @@ undesired, set the 'p' option to false.
 
 The `--change` option will apply `Dockerfile` instructions to the image that is
 created.  Supported `Dockerfile` instructions:
-`CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
+`CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`LABEL`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
 
 ## Commit a container
 

--- a/man/docker-commit.1.md
+++ b/man/docker-commit.1.md
@@ -29,7 +29,7 @@ people.
 
 **-c** , **--change**=[]
    Apply specified Dockerfile instructions while committing the image
-   Supported Dockerfile instructions: `CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
+   Supported Dockerfile instructions: `CMD`|`ENTRYPOINT`|`ENV`|`EXPOSE`|`LABEL`|`ONBUILD`|`USER`|`VOLUME`|`WORKDIR`
 
 **--help**
   Print usage statement


### PR DESCRIPTION
It was missing some variants and 'maintainer' isn't actually supported.
Also sorted the list of allowed cmds in the code just to make it easier
to diff with the docs.

Signed-off-by: Doug Davis dug@us.ibm.com
