### PR TITLE
make docker-engine RPM configuration backward compatible with older 1.6 docker RPMs

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -5,7 +5,14 @@ After=network.target docker.socket
 Requires=docker.socket
 
 [Service]
-ExecStart=/usr/bin/docker -d -H fd://
+EnvironmentFile=-/etc/sysconfig/docker
+EnvironmentFile=-/etc/sysconfig/docker-storage
+EnvironmentFile=-/etc/sysconfig/docker-network
+ExecStart=/usr/bin/docker -d -H fd:// $OPTIONS \
+      $DOCKER_STORAGE_OPTIONS \
+      $DOCKER_NETWORK_OPTIONS \
+      $BLOCK_REGISTRY \
+      $INSECURE_REGISTRY
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
At some point in the conversion from the docker RPM to
the docker-engine RPM, the ability to source configuration files
in /etc/sysconfig/docker, etc was lost.

This commit adds them back in.

Specifically, this is an issue in the CentOS7 docker-engine 1.7 RPM
referenced on this page: https://docs.docker.com/installation/centos/

Related issues include:
https://github.com/docker/docker/issues/14323
https://github.com/docker/docker/issues/14319
https://github.com/docker/docker/issues/14130
https://github.com/docker/docker/issues/13923
https://github.com/docker/docker/issues/14149
https://github.com/docker/docker/issues/10551
https://github.com/docker/docker/issues/12087
