### PR TITLE
Windows: Remove meaningless warnings on docker info

### DIFF
--- a/api/client/attach.go
+++ b/api/client/attach.go
@@ -23,15 +23,15 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
-	stream, _, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, nil)
+	serverResp, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, nil)
 	if err != nil {
 		return err
 	}
 
-	defer stream.Close()
+	defer serverResp.body.Close()
 
 	var c types.ContainerJSON
-	if err := json.NewDecoder(stream).Decode(&c); err != nil {
+	if err := json.NewDecoder(serverResp.body).Decode(&c); err != nil {
 		return err
 	}
 

--- a/api/client/commit.go
+++ b/api/client/commit.go
@@ -67,14 +67,14 @@ func (cli *DockerCli) CmdCommit(args ...string) error {
 			return err
 		}
 	}
-	stream, _, _, err := cli.call("POST", "/commit?"+v.Encode(), config, nil)
+	serverResp, err := cli.call("POST", "/commit?"+v.Encode(), config, nil)
 	if err != nil {
 		return err
 	}
 
-	defer stream.Close()
+	defer serverResp.body.Close()
 
-	if err := json.NewDecoder(stream).Decode(&response); err != nil {
+	if err := json.NewDecoder(serverResp.body).Decode(&response); err != nil {
 		return err
 	}
 

--- a/api/client/cp.go
+++ b/api/client/cp.go
@@ -31,11 +31,11 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 	cfg := &types.CopyConfig{
 		Resource: info[1],
 	}
-	stream, _, statusCode, err := cli.call("POST", "/containers/"+info[0]+"/copy", cfg, nil)
-	if stream != nil {
-		defer stream.Close()
+	serverResp, err := cli.call("POST", "/containers/"+info[0]+"/copy", cfg, nil)
+	if serverResp.body != nil {
+		defer serverResp.body.Close()
 	}
-	if statusCode == 404 {
+	if serverResp.statusCode == 404 {
 		return fmt.Errorf("No such container: %v", info[0])
 	}
 	if err != nil {
@@ -43,11 +43,11 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 	}
 
 	hostPath := cmd.Arg(1)
-	if statusCode == 200 {
+	if serverResp.statusCode == 200 {
 		if hostPath == "-" {
-			_, err = io.Copy(cli.out, stream)
+			_, err = io.Copy(cli.out, serverResp.body)
 		} else {
-			err = archive.Untar(stream, hostPath, &archive.TarOptions{NoLchown: true})
+			err = archive.Untar(serverResp.body, hostPath, &archive.TarOptions{NoLchown: true})
 		}
 		if err != nil {
 			return err

--- a/api/client/diff.go
+++ b/api/client/diff.go
@@ -26,15 +26,15 @@ func (cli *DockerCli) CmdDiff(args ...string) error {
 		return fmt.Errorf("Container name cannot be empty")
 	}
 
-	rdr, _, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/changes", nil, nil)
+	serverResp, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/changes", nil, nil)
 	if err != nil {
 		return err
 	}
 
-	defer rdr.Close()
+	defer serverResp.body.Close()
 
 	changes := []types.ContainerChange{}
-	if err := json.NewDecoder(rdr).Decode(&changes); err != nil {
+	if err := json.NewDecoder(serverResp.body).Decode(&changes); err != nil {
 		return err
 	}
 

--- a/api/client/exec.go
+++ b/api/client/exec.go
@@ -23,15 +23,15 @@ func (cli *DockerCli) CmdExec(args ...string) error {
 		return StatusError{StatusCode: 1}
 	}
 
-	stream, _, _, err := cli.call("POST", "/containers/"+execConfig.Container+"/exec", execConfig, nil)
+	serverResp, err := cli.call("POST", "/containers/"+execConfig.Container+"/exec", execConfig, nil)
 	if err != nil {
 		return err
 	}
 
-	defer stream.Close()
+	defer serverResp.body.Close()
 
 	var response types.ContainerExecCreateResponse
-	if err := json.NewDecoder(stream).Decode(&response); err != nil {
+	if err := json.NewDecoder(serverResp.body).Decode(&response); err != nil {
 		return err
 	}
 

--- a/api/client/history.go
+++ b/api/client/history.go
@@ -25,15 +25,15 @@ func (cli *DockerCli) CmdHistory(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
-	rdr, _, _, err := cli.call("GET", "/images/"+cmd.Arg(0)+"/history", nil, nil)
+	serverResp, err := cli.call("GET", "/images/"+cmd.Arg(0)+"/history", nil, nil)
 	if err != nil {
 		return err
 	}
 
-	defer rdr.Close()
+	defer serverResp.body.Close()
 
 	history := []types.ImageHistory{}
-	if err := json.NewDecoder(rdr).Decode(&history); err != nil {
+	if err := json.NewDecoder(serverResp.body).Decode(&history); err != nil {
 		return err
 	}
 

--- a/api/client/images.go
+++ b/api/client/images.go
@@ -62,15 +62,15 @@ func (cli *DockerCli) CmdImages(args ...string) error {
 		v.Set("all", "1")
 	}
 
-	rdr, _, _, err := cli.call("GET", "/images/json?"+v.Encode(), nil, nil)
+	serverResp, err := cli.call("GET", "/images/json?"+v.Encode(), nil, nil)
 	if err != nil {
 		return err
 	}
 
-	defer rdr.Close()
+	defer serverResp.body.Close()
 
 	images := []types.Image{}
-	if err := json.NewDecoder(rdr).Decode(&images); err != nil {
+	if err := json.NewDecoder(serverResp.body).Decode(&images); err != nil {
 		return err
 	}
 

--- a/api/client/info.go
+++ b/api/client/info.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/pkg/httputils"
 	"github.com/docker/docker/pkg/ioutils"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/units"
@@ -19,15 +20,15 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
-	rdr, _, _, err := cli.call("GET", "/info", nil, nil)
+	serverResp, err := cli.call("GET", "/info", nil, nil)
 	if err != nil {
 		return err
 	}
 
-	defer rdr.Close()
+	defer serverResp.body.Close()
 
 	info := &types.Info{}
-	if err := json.NewDecoder(rdr).Decode(info); err != nil {
+	if err := json.NewDecoder(serverResp.body).Decode(info); err != nil {
 		return fmt.Errorf("Error reading remote info: %v", err)
 	}
 
@@ -70,21 +71,27 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 			fmt.Fprintf(cli.out, "Registry: %v\n", info.IndexServerAddress)
 		}
 	}
-	if !info.MemoryLimit {
-		fmt.Fprintf(cli.err, "WARNING: No memory limit support\n")
+	// Only output these warnings if the server supports these features
+	if h, err := httputils.ParseServerHeader(serverResp.header.Get("Server")); err == nil {
+		if h.OS != "windows" {
+			if !info.MemoryLimit {
+				fmt.Fprintf(cli.err, "WARNING: No memory limit support\n")
+			}
+			if !info.SwapLimit {
+				fmt.Fprintf(cli.err, "WARNING: No swap limit support\n")
+			}
+			if !info.IPv4Forwarding {
+				fmt.Fprintf(cli.err, "WARNING: IPv4 forwarding is disabled.\n")
+			}
+			if !info.BridgeNfIptables {
+				fmt.Fprintf(cli.err, "WARNING: bridge-nf-call-iptables is disabled\n")
+			}
+			if !info.BridgeNfIp6tables {
+				fmt.Fprintf(cli.err, "WARNING: bridge-nf-call-ip6tables is disabled\n")
+			}
+		}
 	}
-	if !info.SwapLimit {
-		fmt.Fprintf(cli.err, "WARNING: No swap limit support\n")
-	}
-	if !info.IPv4Forwarding {
-		fmt.Fprintf(cli.err, "WARNING: IPv4 forwarding is disabled.\n")
-	}
-	if !info.BridgeNfIptables {
-		fmt.Fprintf(cli.err, "WARNING: bridge-nf-call-iptables is disabled\n")
-	}
-	if !info.BridgeNfIp6tables {
-		fmt.Fprintf(cli.err, "WARNING: bridge-nf-call-ip6tables is disabled\n")
-	}
+
 	if info.Labels != nil {
 		fmt.Fprintln(cli.out, "Labels:")
 		for _, attribute := range info.Labels {

--- a/api/client/logs.go
+++ b/api/client/logs.go
@@ -26,13 +26,13 @@ func (cli *DockerCli) CmdLogs(args ...string) error {
 
 	name := cmd.Arg(0)
 
-	stream, _, _, err := cli.call("GET", "/containers/"+name+"/json", nil, nil)
+	serverResp, err := cli.call("GET", "/containers/"+name+"/json", nil, nil)
 	if err != nil {
 		return err
 	}
 
 	var c types.ContainerJSON
-	if err := json.NewDecoder(stream).Decode(&c); err != nil {
+	if err := json.NewDecoder(serverResp.body).Decode(&c); err != nil {
 		return err
 	}
 

--- a/api/client/network.go
+++ b/api/client/network.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (cli *DockerCli) CmdNetwork(args ...string) error {
-	nCli := nwclient.NewNetworkCli(cli.out, cli.err, nwclient.CallFunc(cli.call))
+	nCli := nwclient.NewNetworkCli(cli.out, cli.err, nwclient.CallFunc(cli.callWrapper))
 	args = append([]string{"network"}, args...)
 	return nCli.Cmd(os.Args[0], args...)
 }

--- a/api/client/port.go
+++ b/api/client/port.go
@@ -19,12 +19,12 @@ func (cli *DockerCli) CmdPort(args ...string) error {
 
 	cmd.ParseFlags(args, true)
 
-	stream, _, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, nil)
+	serverResp, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, nil)
 	if err != nil {
 		return err
 	}
 
-	defer stream.Close()
+	defer serverResp.body.Close()
 
 	var c struct {
 		NetworkSettings struct {
@@ -32,7 +32,7 @@ func (cli *DockerCli) CmdPort(args ...string) error {
 		}
 	}
 
-	if err := json.NewDecoder(stream).Decode(&c); err != nil {
+	if err := json.NewDecoder(serverResp.body).Decode(&c); err != nil {
 		return err
 	}
 

--- a/api/client/ps.go
+++ b/api/client/ps.go
@@ -86,15 +86,15 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 		v.Set("filters", filterJSON)
 	}
 
-	rdr, _, _, err := cli.call("GET", "/containers/json?"+v.Encode(), nil, nil)
+	serverResp, err := cli.call("GET", "/containers/json?"+v.Encode(), nil, nil)
 	if err != nil {
 		return err
 	}
 
-	defer rdr.Close()
+	defer serverResp.body.Close()
 
 	containers := []types.Container{}
-	if err := json.NewDecoder(rdr).Decode(&containers); err != nil {
+	if err := json.NewDecoder(serverResp.body).Decode(&containers); err != nil {
 		return err
 	}
 

--- a/api/client/rmi.go
+++ b/api/client/rmi.go
@@ -30,15 +30,15 @@ func (cli *DockerCli) CmdRmi(args ...string) error {
 
 	var errNames []string
 	for _, name := range cmd.Args() {
-		rdr, _, _, err := cli.call("DELETE", "/images/"+name+"?"+v.Encode(), nil, nil)
+		serverResp, err := cli.call("DELETE", "/images/"+name+"?"+v.Encode(), nil, nil)
 		if err != nil {
 			fmt.Fprintf(cli.err, "%s\n", err)
 			errNames = append(errNames, name)
 		} else {
-			defer rdr.Close()
+			defer serverResp.body.Close()
 
 			dels := []types.ImageDelete{}
-			if err := json.NewDecoder(rdr).Decode(&dels); err != nil {
+			if err := json.NewDecoder(serverResp.body).Decode(&dels); err != nil {
 				fmt.Fprintf(cli.err, "%s\n", err)
 				errNames = append(errNames, name)
 				continue

--- a/api/client/service.go
+++ b/api/client/service.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (cli *DockerCli) CmdService(args ...string) error {
-	nCli := nwclient.NewNetworkCli(cli.out, cli.err, nwclient.CallFunc(cli.call))
+	nCli := nwclient.NewNetworkCli(cli.out, cli.err, nwclient.CallFunc(cli.callWrapper))
 	args = append([]string{"service"}, args...)
 	return nCli.Cmd(os.Args[0], args...)
 }

--- a/api/client/start.go
+++ b/api/client/start.go
@@ -61,15 +61,15 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 			return fmt.Errorf("You cannot start and attach multiple containers at once.")
 		}
 
-		stream, _, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, nil)
+		serverResp, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/json", nil, nil)
 		if err != nil {
 			return err
 		}
 
-		defer stream.Close()
+		defer serverResp.body.Close()
 
 		var c types.ContainerJSON
-		if err := json.NewDecoder(stream).Decode(&c); err != nil {
+		if err := json.NewDecoder(serverResp.body).Decode(&c); err != nil {
 			return err
 		}
 

--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -35,7 +35,7 @@ func (s *containerStats) Collect(cli *DockerCli, streamStats bool) {
 	} else {
 		v.Set("stream", "0")
 	}
-	stream, _, _, err := cli.call("GET", "/containers/"+s.Name+"/stats?"+v.Encode(), nil, nil)
+	serverResp, err := cli.call("GET", "/containers/"+s.Name+"/stats?"+v.Encode(), nil, nil)
 	if err != nil {
 		s.mu.Lock()
 		s.err = err
@@ -43,12 +43,12 @@ func (s *containerStats) Collect(cli *DockerCli, streamStats bool) {
 		return
 	}
 
-	defer stream.Close()
+	defer serverResp.body.Close()
 
 	var (
 		previousCPU    uint64
 		previousSystem uint64
-		dec            = json.NewDecoder(stream)
+		dec            = json.NewDecoder(serverResp.body)
 		u              = make(chan error, 1)
 	)
 	go func() {

--- a/api/client/top.go
+++ b/api/client/top.go
@@ -25,15 +25,15 @@ func (cli *DockerCli) CmdTop(args ...string) error {
 		val.Set("ps_args", strings.Join(cmd.Args()[1:], " "))
 	}
 
-	stream, _, _, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/top?"+val.Encode(), nil, nil)
+	serverResp, err := cli.call("GET", "/containers/"+cmd.Arg(0)+"/top?"+val.Encode(), nil, nil)
 	if err != nil {
 		return err
 	}
 
-	defer stream.Close()
+	defer serverResp.body.Close()
 
 	procList := types.ContainerProcessList{}
-	if err := json.NewDecoder(stream).Decode(&procList); err != nil {
+	if err := json.NewDecoder(serverResp.body).Decode(&procList); err != nil {
 		return err
 	}
 

--- a/api/client/version.go
+++ b/api/client/version.go
@@ -40,15 +40,15 @@ func (cli *DockerCli) CmdVersion(args ...string) error {
 		fmt.Fprintf(cli.out, " Experimental: true\n")
 	}
 
-	stream, _, _, err := cli.call("GET", "/version", nil, nil)
+	serverResp, err := cli.call("GET", "/version", nil, nil)
 	if err != nil {
 		return err
 	}
 
-	defer stream.Close()
+	defer serverResp.body.Close()
 
 	var v types.Version
-	if err := json.NewDecoder(stream).Decode(&v); err != nil {
+	if err := json.NewDecoder(serverResp.body).Decode(&v); err != nil {
 		fmt.Fprintf(cli.err, "Error reading remote version: %s\n", err)
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Stops warnings from appearing when running docker info against a Windows daemon due to checking properties which are not supported on the platform.
