### PR TITLE
Add links and correct locations in project/README.md

### DIFF
--- a/project/README.md
+++ b/project/README.md
@@ -1,17 +1,17 @@
 # Hacking on Docker
 
-The hack/ directory holds information and tools for everyone involved in the process of creating and
+The `project/` directory holds information and tools for everyone involved in the process of creating and
 distributing Docker, specifically:
 
 ## Guides
 
-If you're a *contributor* or aspiring contributor, you should read CONTRIBUTORS.md.
+If you're a *contributor* or aspiring contributor, you should read [CONTRIBUTORS.md](../CONTRIBUTING.md).
 
-If you're a *maintainer* or aspiring maintainer, you should read MAINTAINERS.md.
+If you're a *maintainer* or aspiring maintainer, you should read [MAINTAINERS](../MAINTAINERS).
 
-If you're a *packager* or aspiring packager, you should read PACKAGERS.md.
+If you're a *packager* or aspiring packager, you should read [PACKAGERS.md](./PACKAGERS.md).
 
-If you're a maintainer in charge of a *release*, you should read RELEASE-CHECKLIST.md.
+If you're a maintainer in charge of a *release*, you should read [RELEASE-CHECKLIST.md](./RELEASE-CHECKLIST.md).
 
 ## Roadmap
 
@@ -20,5 +20,5 @@ A high-level roadmap is available at [ROADMAP.md](../ROADMAP.md).
 
 ## Build tools
 
-make.sh is the primary build tool for docker. It is used for compiling the official binary,
+[hack/make.sh](../hack/make.sh) is the primary build tool for docker. It is used for compiling the official binary,
 running the test suite, and pushing releases.


### PR DESCRIPTION
After removing the duplicate ROADMAP in a separate PR, a few other
issues were noted in README.md which are fixed here:
- the directory is project, not hack
- make.sh is no longer in the current dir since hack/ is not project/
  anymore
- MAINTAINERS is no longer here as a markdown file, but is a TOML file
  in the root of the project
- links were added to all files to make it easier to follow from here
  to the appropriate location

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
