### PR TITLE
Do not hide user provided network mounts

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -1067,9 +1067,9 @@ func copyEscapable(dst io.Writer, src io.ReadCloser) (written int64, err error) 
 	return written, err
 }
 
-func (container *Container) networkMounts() []execdriver.Mount {
+func (container *Container) networkMounts(usermounts map[string]bool) []execdriver.Mount {
 	var mounts []execdriver.Mount
-	if container.ResolvConfPath != "" {
+	if _, given := usermounts["/etc/resolv.conf"]; given != true && container.ResolvConfPath != "" {
 		label.SetFileLabel(container.ResolvConfPath, container.MountLabel)
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.ResolvConfPath,
@@ -1078,7 +1078,7 @@ func (container *Container) networkMounts() []execdriver.Mount {
 			Private:     true,
 		})
 	}
-	if container.HostnamePath != "" {
+	if _, given := usermounts["/etc/hostname"]; given != true && container.HostnamePath != "" {
 		label.SetFileLabel(container.HostnamePath, container.MountLabel)
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.HostnamePath,
@@ -1087,7 +1087,7 @@ func (container *Container) networkMounts() []execdriver.Mount {
 			Private:     true,
 		})
 	}
-	if container.HostsPath != "" {
+	if _, given := usermounts["/etc/hosts"]; given != true && container.HostsPath != "" {
 		label.SetFileLabel(container.HostsPath, container.MountLabel)
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.HostsPath,

--- a/daemon/container_linux.go
+++ b/daemon/container_linux.go
@@ -1076,6 +1076,7 @@ func (container *Container) DisableLink(name string) {
 
 func (container *Container) UnmountVolumes(forceSyscall bool) error {
 	var volumeMounts []mountPoint
+	var usermounts = make(map[string]bool)
 
 	for _, mntPoint := range container.MountPoints {
 		dest, err := container.GetResourcePath(mntPoint.Destination)
@@ -1084,9 +1085,10 @@ func (container *Container) UnmountVolumes(forceSyscall bool) error {
 		}
 
 		volumeMounts = append(volumeMounts, mountPoint{Destination: dest, Volume: mntPoint.Volume})
+		usermounts[mntPoint.Destination] = true
 	}
 
-	for _, mnt := range container.networkMounts() {
+	for _, mnt := range container.networkMounts(usermounts) {
 		dest, err := container.GetResourcePath(mnt.Destination)
 		if err != nil {
 			return err

--- a/daemon/volumes_linux.go
+++ b/daemon/volumes_linux.go
@@ -31,6 +31,7 @@ func copyOwnership(source, destination string) error {
 
 func (container *Container) setupMounts() ([]execdriver.Mount, error) {
 	var mounts []execdriver.Mount
+	var usermounts = make(map[string]bool)
 	for _, m := range container.MountPoints {
 		path, err := m.Setup()
 		if err != nil {
@@ -42,10 +43,11 @@ func (container *Container) setupMounts() ([]execdriver.Mount, error) {
 			Destination: m.Destination,
 			Writable:    m.RW,
 		})
+		usermounts[m.Destination] = true
 	}
 
 	mounts = sortMounts(mounts)
-	return append(mounts, container.networkMounts()...), nil
+	return append(mounts, container.networkMounts(usermounts)...), nil
 }
 
 func sortMounts(m []execdriver.Mount) []execdriver.Mount {


### PR DESCRIPTION
Prevent the docker daemon from mounting the created network files
over those provided by the user, thus hiding the ones provided by the user.
The benfit of this is that a user can provide the network files using the
-v command line option and place them in a size-limited filesystem.

Signed-off-by: Stefan Berger stefanb@linux.vnet.ibm.com
