### PR TITLE
update reference to config file

### DIFF
--- a/docs/userguide/dockerrepos.md
+++ b/docs/userguide/dockerrepos.md
@@ -43,7 +43,7 @@ e-mail address. It will then automatically log you in. You can now commit and
 push your own images up to your repos on Docker Hub.
 
 > **Note:**
-> Your authentication credentials will be stored in the `.dockercfg`
+> Your authentication credentials will be stored in the `~/.docker/config.json`
 > authentication file in your home directory.
 
 ## Searching for images

--- a/man/docker-login.1.md
+++ b/man/docker-login.1.md
@@ -20,7 +20,7 @@ do not specify a `SERVER`, the command uses Docker's public registry located at
 
 You can log into any public or private repository for which you have
 credentials.  When you log in, the command stores encoded credentials in
-`$HOME/.dockercfg` on Linux or `%USERPROFILE%/.dockercfg` on Windows.
+`$HOME/.docker/config.json` on Linux or `%USERPROFILE%/.docker/config.json` on Windows.
 
 # OPTIONS
 **-e**, **--email**=""


### PR DESCRIPTION
`docker login` in 1.7 produces a config file in `~/docker/config.json`
instead of a `~/.dockercfg`.

Signed-off-by: Nate Brennand nate.brennand@clever.com
