### PR TITLE
enable installation on Cumulus Linux

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -152,7 +152,7 @@ do_install() {
 			exit 0
 			;;
 
-		ubuntu|debian|linuxmint|'elementary os'|kali)
+		ubuntu|debian|linuxmint|'elementary os'|kali|'cumulus networks')
 			export DEBIAN_FRONTEND=noninteractive
 
 			did_apt_get_update=


### PR DESCRIPTION
Debian installation works just fine for Cumulus Linux, so use the same installation procedure.

Signed-off-by: Andy Gospodarek gospo@cumulusnetworks.com
