### PR TITLE
registry tests assumes /go/bin is in the PATH

### DIFF
--- a/hack/make/test-integration-cli
+++ b/hack/make/test-integration-cli
@@ -12,6 +12,7 @@ bundle_test_integration_cli() {
 
 	bundle .integration-daemon-setup
 
+	export PATH=$PATH:/go/bin
 	bundle_test_integration_cli
 
 	bundle .integration-daemon-stop


### PR DESCRIPTION
It is assumed that registryv2 binary under /go/bin is always in the path, when compiling with gccgo /go/bin is not in the path.This PR fixes that issue.
Signed-off-by: Srini Brahmaroutu srbrahma@us.ibm.com
