### PR TITLE
Fix failure on adding source list for ubuntu

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -216,6 +216,7 @@ do_install() {
 				else
 					$sh_c "$curl ${url}gpg | apt-key add -"
 				fi
+				$sh_c "mkdir -p /etc/apt/sources.list.d"
 				$sh_c "echo deb ${url}ubuntu docker main > /etc/apt/sources.list.d/docker.list"
 				$sh_c 'sleep 3; apt-get update; apt-get install -y -q lxc-docker'
 			)


### PR DESCRIPTION
For hybrid cloud, some ubuntu vm images doesn't have the directory
`/etc/apt/sources.list.d` which cause failure on creating
`/etc/apt/sources.list.d/docker.list`.

To fix this issue, create this directory first (if it doesn't exist).
