### PR TITLE
Windows: Move daemon check back centrally

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -43,8 +43,7 @@ var (
 	validContainerNameChars   = `[a-zA-Z0-9][a-zA-Z0-9_.-]`
 	validContainerNamePattern = regexp.MustCompile(`^/?` + validContainerNameChars + `+$`)
 
-	// TODO Windows. Change this once daemon is up and running.
-	ErrSystemNotSupported = errors.New("The Docker daemon is only supported on linux")
+	ErrSystemNotSupported = errors.New("The Docker daemon is not supported on this platform.")
 )
 
 type contStore struct {
@@ -562,7 +561,12 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	// Do we have a disabled network?
 	config.DisableBridge = isBridgeNetworkDisabled(config)
 
-	// Check that the system is supported and we have sufficient privileges
+	// Verify the platform is supported as a daemon
+	if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
+		return nil, ErrSystemNotSupported
+	}
+
+	// Validate platform-specific requirements
 	if err := checkSystem(); err != nil {
 		return nil, err
 	}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"syscall"
 
@@ -197,13 +196,8 @@ func checkConfigOptions(config *Config) error {
 	return nil
 }
 
-// checkSystem validates the system is supported and we have sufficient privileges
+// checkSystem validates platform-specific requirements
 func checkSystem() error {
-	// TODO Windows. Once daemon is running on Windows, move this code back to
-	// NewDaemon() in daemon.go, and extend the check to support Windows.
-	if runtime.GOOS != "linux" {
-		return ErrSystemNotSupported
-	}
 	if os.Geteuid() != 0 {
 		return fmt.Errorf("The Docker daemon needs to be run as root")
 	}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"fmt"
 	"os"
-	"runtime"
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
@@ -82,15 +81,9 @@ func checkConfigOptions(config *Config) error {
 	return nil
 }
 
-// checkSystem validates the system is supported and we have sufficient privileges
+// checkSystem validates platform-specific requirements
 func checkSystem() error {
 	var dwVersion uint32
-
-	// TODO Windows. Once daemon is running on Windows, move this code back to
-	// NewDaemon() in daemon.go, and extend the check to support Windows.
-	if runtime.GOOS != "linux" && runtime.GOOS != "windows" {
-		return ErrSystemNotSupported
-	}
 
 	// TODO Windows. May need at some point to ensure have elevation and
 	// possibly LocalSystem.


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. The start of the "TODO Windows:" clean-up. This moves the check for platform daemon support back to the right place.
