### PR TITLE
Add docker ps ancestor filter for image

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -6,7 +6,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/graphdb"
 	"github.com/docker/docker/pkg/nat"
 	"github.com/docker/docker/pkg/parsers/filters"
@@ -28,13 +30,15 @@ type ContainersConfig struct {
 
 func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, error) {
 	var (
-		foundBefore bool
-		displayed   int
-		all         = config.All
-		n           = config.Limit
-		psFilters   filters.Args
-		filtExited  []int
+		foundBefore    bool
+		displayed      int
+		ancestorFilter bool
+		all            = config.All
+		n              = config.Limit
+		psFilters      filters.Args
+		filtExited     []int
 	)
+	imagesFilter := map[string]bool{}
 	containers := []*types.Container{}
 
 	psFilters, err := filters.FromParam(config.Filters)
@@ -61,6 +65,27 @@ func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, 
 			}
 		}
 	}
+
+	if ancestors, ok := psFilters["ancestor"]; ok {
+		ancestorFilter = true
+		byParents := daemon.Graph().ByParent()
+		// The idea is to walk the graph down the most "efficient" way.
+		for _, ancestor := range ancestors {
+			// First, get the imageId of the ancestor filter (yay)
+			image, err := daemon.Repositories().LookupImage(ancestor)
+			if err != nil {
+				logrus.Warnf("Error while looking up for image %v", ancestor)
+				continue
+			}
+			if imagesFilter[ancestor] {
+				// Already seen this ancestor, skip it
+				continue
+			}
+			// Then walk down the graph and put the imageIds in imagesFilter
+			populateImageFilterByParents(imagesFilter, image.ID, byParents)
+		}
+	}
+
 	names := map[string][]string{}
 	daemon.ContainerGraph().Walk("/", func(p string, e *graphdb.Entity) error {
 		names[e.ID()] = append(names[e.ID()], p)
@@ -131,6 +156,16 @@ func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, 
 		if !psFilters.Match("status", container.State.StateString()) {
 			return nil
 		}
+
+		if ancestorFilter {
+			if len(imagesFilter) == 0 {
+				return nil
+			}
+			if !imagesFilter[container.ImageID] {
+				return nil
+			}
+		}
+
 		displayed++
 		newC := &types.Container{
 			ID:    container.ID,
@@ -242,4 +277,15 @@ func (daemon *Daemon) Volumes(filter string) ([]*types.Volume, error) {
 		volumesOut = append(volumesOut, volumeToAPIType(v))
 	}
 	return volumesOut, nil
+}
+
+func populateImageFilterByParents(ancestorMap map[string]bool, imageID string, byParents map[string][]*image.Image) {
+	if !ancestorMap[imageID] {
+		if images, ok := byParents[imageID]; ok {
+			for _, image := range images {
+				populateImageFilterByParents(ancestorMap, image.ID, byParents)
+			}
+		}
+		ancestorMap[imageID] = true
+	}
 }

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -50,6 +50,7 @@ The currently supported filters are:
 * name (container's name)
 * exited (int - the code of exited containers. Only useful with `--all`)
 * status (created|restarting|running|paused|exited)
+* ancestor (`<image-name>[:<tag>]`,  `<image id>` or `<image@digest>`) - filters containers that were created from the given image or a descendant.
 
 ## Successfully exited containers
 

--- a/man/docker-ps.1.md
+++ b/man/docker-ps.1.md
@@ -41,6 +41,8 @@ the running containers.
                           status=(created|restarting|running|paused|exited)
                           name=<string> - container's name
                           id=<ID> - container's ID
+                          ancestor=(<image-name>[:tag]|<image-id>|<image@digest>) - filters containers that were
+                          created from the given image or a descendant.
 
 **-l**, **--latest**=*true*|*false*
    Show only the latest created container, include non-running ones. The default is *false*.


### PR DESCRIPTION
Makes it possible to filter containers by image _ancestor_, using `--filter=ancestor=busybox` or `--filter=ancestor=8c2e06607696`. This is related to #13365, and for the image filter, it's actually ask sometimes on irc 🐸.

The `ancestor` filter support the following _notation_:
- [x] image
- [x] image:tag
- [X] image@digest
- [x] short-id
- [x] full-id

Still to do :
- [X] Support multiple `--filter=ancestor`
- [X] Complete integration tests with short-id to make sure it works
- [X] Add integration tests with `image@digest`

Signed-off-by: Vincent Demeester vincent@sbr.pm
