### PR TITLE
Documentation: Split apt-get example onto multiple lines

### DIFF
--- a/docs/articles/dockerfile_best-practices.md
+++ b/docs/articles/dockerfile_best-practices.md
@@ -154,7 +154,10 @@ updated, use `apt-get install -y foo` and it will update automatically.
 
 * Do write instructions like:
 
-    RUN apt-get update && apt-get install -y package-bar package-foo package-baz
+        RUN apt-get update && apt-get install -y \
+            package-bar \
+            package-baz \
+            package-foo
 
 Writing the instruction this way not only makes it easier to read
 and maintain, but also, by including `apt-get update`, ensures that the cache


### PR DESCRIPTION
Following the best practice, reformat the documentation for RUN command.

> RUN
> As always, to make your Dockerfile more readable, understandable, and maintainable, put long or 
> complex RUN statements on multiple lines separated with backslashes.
