### PR TITLE
Trusted build servers moved to AWS and use an elastic IP

### DIFF
--- a/docs/docker-hub/builds.md
+++ b/docs/docker-hub/builds.md
@@ -393,14 +393,11 @@ payload:
 }
 ```
 
-Webhooks are available under the Settings menu of each Repository.
+Webhooks are available under the Settings menu of each Repository.  
+Use a tool like [requestb.in](http://requestb.in/) to test your webhook.
 
-> **Note:** If you want to test your webhook out we recommend using
-> a tool like [requestb.in](http://requestb.in/).
-
-> **Note**: The Docker Hub servers are currently in the IP range
-> `162.242.195.64 - 162.242.195.127`, so you can restrict your webhooks to
-> accept webhook requests from that set of IP addresses.
+> **Note**: The Docker Hub servers use an elastic IP range, so you can't
+> filter requests by IP.
 
 ### Webhook chains
 

--- a/docs/docker-hub/repos.md
+++ b/docs/docker-hub/repos.md
@@ -135,9 +135,8 @@ similar to the example shown below.
 
 For testing, you can try an HTTP request tool like [requestb.in](http://requestb.in/).
 
-> **Note**: The Docker Hub servers are currently in the IP range
-> `162.242.195.64 - 162.242.195.127`, so you can restrict your webhooks to
-> accept webhook requests from that set of IP addresses.
+> **Note**: The Docker Hub servers use an elastic IP range, so you can't
+> filter requests by IP.
 
 ### Webhook chains
 


### PR DESCRIPTION
Signed-off-by: Sven Dowideit SvenDowideit@home.org.au

see https://forums.docker.com/t/webhook-ip-changed/2194
