### PR TITLE
Revert: "Add cgroup bind mount by default"

### DIFF
--- a/daemon/execdriver/native/template/default_template.go
+++ b/daemon/execdriver/native/template/default_template.go
@@ -80,12 +80,6 @@ func New() *configs.Config {
 				Device:      "sysfs",
 				Flags:       defaultMountFlags | syscall.MS_RDONLY,
 			},
-			{
-				Source:      "cgroup",
-				Destination: "/sys/fs/cgroup",
-				Device:      "cgroup",
-				Flags:       defaultMountFlags | syscall.MS_RDONLY,
-			},
 		},
 		MaskPaths: []string{
 			"/proc/kcore",

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -159,21 +159,6 @@ func (s *DockerSuite) TestRunContainerWithCgroupParentAbsPath(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestRunContainerWithCgroupMountRO(c *check.C) {
-	testRequires(c, NativeExecDriver)
-
-	filename := "/sys/fs/cgroup/devices/test123"
-	cmd := exec.Command(dockerBinary, "run", "busybox", "touch", filename)
-	out, _, err := runCommandWithOutput(cmd)
-	if err == nil {
-		c.Fatal("expected cgroup mount point to be read-only, touch file should fail")
-	}
-	expected := "Read-only file system"
-	if !strings.Contains(out, expected) {
-		c.Fatalf("expected output from failure to contain %s but contains %s", expected, out)
-	}
-}
-
 func (s *DockerSuite) TestRunDeviceDirectory(c *check.C) {
 	testRequires(c, NativeExecDriver)
 	cmd := exec.Command(dockerBinary, "run", "--device", "/dev/snd:/dev/snd", "busybox", "sh", "-c", "ls /dev/snd/")


### PR DESCRIPTION
Fixes: #14543

Add cgroup bind mount as read-only breaks docker-in-docker,
because it needs to create new files in cgroup mount point in
docker which can not.

The fix would be to allow cgroup mount as rw in some conditions
like --privileged, but currently libcontainer hardcoded cgroup
mount as read-only, we need to fix libcontainer part, after it
merged to Docker then we can add cgroup mount on Docker side
correctly.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
