### PR TITLE
Documentation: Start Docker service after install

### DIFF
--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -130,9 +130,9 @@ install Docker using the following:
 
 4. Verify `docker` is installed correctly.
 
-        $ sudo docker run hello-world
+        $ sudo service docker start; sudo docker run hello-world
 
-    This command downloads a test image and runs it in a container.
+    This command starts `docker` service, downloads a test image, and runs it in a container.
 
 ## Optional configurations for Docker on Ubuntu 
 


### PR DESCRIPTION
When an Ubuntu user installs Docker without running `sudo service docker start`, the `hello-world` test does not work on freshly installed Docker.

Signed-off-by: Yiming Zong ymzong@users.noreply.github.com
