### PR TITLE
don't allow deleting the image of running containers

### DIFF
--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -151,7 +151,7 @@ func (daemon *Daemon) canDeleteImage(imgID string, force bool) error {
 		parent, err := daemon.Repositories().LookupImage(container.ImageID)
 		if err != nil {
 			if daemon.Graph().IsNotExist(err, container.ImageID) {
-				return nil
+				continue
 			}
 			return err
 		}


### PR DESCRIPTION
Try to fix #13261

The problem described in #13261 can be reproduced with the following script:

``` bash
#!/bin/bash
# Build 2 images for testing.
echo -e "FROM busybox\nRUN echo a"|docker build -t test1 -
echo -e "FROM busybox\nRUN echo b"|docker build -t test2 -

# First let's start a long-running container.
docker run -d test1 sleep 300

# Create another container and force remove its image.
docker run --name=TEST2 test2 true
docker rmi -f test2

# At this point the images of any running containers that were created
# before TEST2 can be removed regardless of the -f flag.
docker rmi test1
```

The problem was introduced by #9204. 
