### PR TITLE
Update docker_remote_api_v1.17.md

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.17.md
+++ b/docs/reference/api/docker_remote_api_v1.17.md
@@ -161,8 +161,8 @@ Create a container
                "CapDrop": ["MKNOD"],
                "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
                "NetworkMode": "bridge",
-               "Devices": []
-               "SecurityOpt": [""],
+               "Devices": [],
+               "SecurityOpt": [""]
             }
         }
 


### PR DESCRIPTION
HostConfig had misplaced comma(,) for Devices and SecurityOpt keys. Corrected comma position.
