### PR TITLE
Improve sockRequest and sockRequestRaw check

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -33,8 +33,8 @@ func (s *DockerSuite) TestContainerApiGetAll(c *check.C) {
 	}
 
 	status, body, err := sockRequest("GET", "/containers/json?all=1", nil)
-	c.Assert(status, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusOK)
 
 	var inspectJSON []struct {
 		Names []string
@@ -59,8 +59,8 @@ func (s *DockerSuite) TestContainerApiGetJSONNoFieldsOmitted(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	status, body, err := sockRequest("GET", "/containers/json?all=1", nil)
-	c.Assert(status, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusOK)
 
 	// empty Labels field triggered this bug, make sense to check for everything
 	// cause even Ports for instance can trigger this bug
@@ -99,8 +99,8 @@ func (s *DockerSuite) TestContainerPsOmitFields(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	status, body, err := sockRequest("GET", "/containers/json?all=1", nil)
-	c.Assert(status, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusOK)
 
 	var resp []containerPs
 	err = json.Unmarshal(body, &resp)
@@ -133,8 +133,8 @@ func (s *DockerSuite) TestContainerApiGetExport(c *check.C) {
 	}
 
 	status, body, err := sockRequest("GET", "/containers/"+name+"/export", nil)
-	c.Assert(status, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusOK)
 
 	found := false
 	for tarReader := tar.NewReader(bytes.NewReader(body)); ; {
@@ -165,8 +165,8 @@ func (s *DockerSuite) TestContainerApiGetChanges(c *check.C) {
 	}
 
 	status, body, err := sockRequest("GET", "/containers/"+name+"/changes", nil)
-	c.Assert(status, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusOK)
 
 	changes := []struct {
 		Kind int
@@ -196,16 +196,16 @@ func (s *DockerSuite) TestContainerApiStartVolumeBinds(c *check.C) {
 	}
 
 	status, _, err := sockRequest("POST", "/containers/create?name="+name, config)
-	c.Assert(status, check.Equals, http.StatusCreated)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusCreated)
 
 	bindPath := randomUnixTmpDirPath("test")
 	config = map[string]interface{}{
 		"Binds": []string{bindPath + ":/tmp"},
 	}
 	status, _, err = sockRequest("POST", "/containers/"+name+"/start", config)
-	c.Assert(status, check.Equals, http.StatusNoContent)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNoContent)
 
 	pth, err := inspectFieldMap(name, "Volumes", "/tmp")
 	if err != nil {
@@ -226,8 +226,8 @@ func (s *DockerSuite) TestContainerApiStartDupVolumeBinds(c *check.C) {
 	}
 
 	status, _, err := sockRequest("POST", "/containers/create?name="+name, config)
-	c.Assert(status, check.Equals, http.StatusCreated)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusCreated)
 
 	bindPath1 := randomUnixTmpDirPath("test1")
 	bindPath2 := randomUnixTmpDirPath("test2")
@@ -236,8 +236,8 @@ func (s *DockerSuite) TestContainerApiStartDupVolumeBinds(c *check.C) {
 		"Binds": []string{bindPath1 + ":/tmp", bindPath2 + ":/tmp"},
 	}
 	status, body, err := sockRequest("POST", "/containers/"+name+"/start", config)
-	c.Assert(status, check.Equals, http.StatusInternalServerError)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusInternalServerError)
 
 	if !strings.Contains(string(body), "Duplicate bind") {
 		c.Fatalf("Expected failure due to duplicate bind mounts to same path, instead got: %q with error: %v", string(body), err)
@@ -259,15 +259,15 @@ func (s *DockerSuite) TestContainerApiStartVolumesFrom(c *check.C) {
 	}
 
 	status, _, err := sockRequest("POST", "/containers/create?name="+name, config)
-	c.Assert(status, check.Equals, http.StatusCreated)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusCreated)
 
 	config = map[string]interface{}{
 		"VolumesFrom": []string{volName},
 	}
 	status, _, err = sockRequest("POST", "/containers/"+name+"/start", config)
-	c.Assert(status, check.Equals, http.StatusNoContent)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNoContent)
 
 	pth, err := inspectFieldMap(name, "Volumes", volPath)
 	if err != nil {
@@ -461,8 +461,8 @@ func (s *DockerSuite) TestGetStoppedContainerStats(c *check.C) {
 		// We'll never get return for GET stats from sockRequest as of now,
 		// just send request and see if panic or error would happen on daemon side.
 		status, _, err := sockRequest("GET", "/containers/"+name+"/stats", nil)
-		c.Assert(status, check.Equals, http.StatusOK)
 		c.Assert(err, check.IsNil)
+		c.Assert(status, check.Equals, http.StatusOK)
 	}()
 
 	// allow some time to send request and let daemon deal with it
@@ -491,8 +491,8 @@ func (s *DockerSuite) TestBuildApiDockerfilePath(c *check.C) {
 	}
 
 	res, body, err := sockRequestRaw("POST", "/build?dockerfile=../Dockerfile", buffer, "application/x-tar")
-	c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
 
 	out, err := readBody(body)
 	if err != nil {
@@ -517,8 +517,8 @@ RUN find /tmp/`,
 	defer server.Close()
 
 	res, body, err := sockRequestRaw("POST", "/build?dockerfile=baz&remote="+server.URL()+"/testD", nil, "application/json")
-	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 
 	buf, err := readBody(body)
 	if err != nil {
@@ -630,8 +630,8 @@ RUN echo from dockerfile`,
 	defer git.Close()
 
 	res, body, err := sockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json")
-	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 
 	buf, err := readBody(body)
 	if err != nil {
@@ -658,8 +658,8 @@ RUN echo from Dockerfile`,
 
 	// Make sure it tries to 'dockerfile' query param value
 	res, body, err := sockRequestRaw("POST", "/build?dockerfile=baz&remote="+git.RepoURL, nil, "application/json")
-	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 
 	buf, err := readBody(body)
 	if err != nil {
@@ -687,8 +687,8 @@ RUN echo from dockerfile`,
 
 	// Make sure it tries to 'dockerfile' query param value
 	res, body, err := sockRequestRaw("POST", "/build?remote="+git.RepoURL, nil, "application/json")
-	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
 
 	buf, err := readBody(body)
 	if err != nil {
@@ -720,8 +720,8 @@ func (s *DockerSuite) TestBuildApiDockerfileSymlink(c *check.C) {
 	}
 
 	res, body, err := sockRequestRaw("POST", "/build", buffer, "application/x-tar")
-	c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
 
 	out, err := readBody(body)
 	if err != nil {
@@ -756,8 +756,8 @@ func (s *DockerSuite) TestPostContainerBindNormalVolume(c *check.C) {
 
 	bindSpec := map[string][]string{"Binds": {fooDir + ":/foo"}}
 	status, _, err := sockRequest("POST", "/containers/two/start", bindSpec)
-	c.Assert(status, check.Equals, http.StatusNoContent)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNoContent)
 
 	fooDir2, err := inspectFieldMap("two", "Volumes", "/foo")
 	if err != nil {
@@ -780,8 +780,8 @@ func (s *DockerSuite) TestContainerApiPause(c *check.C) {
 	ContainerID := strings.TrimSpace(out)
 
 	status, _, err := sockRequest("POST", "/containers/"+ContainerID+"/pause", nil)
-	c.Assert(status, check.Equals, http.StatusNoContent)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNoContent)
 
 	pausedContainers, err := getSliceOfPausedContainers()
 
@@ -794,8 +794,8 @@ func (s *DockerSuite) TestContainerApiPause(c *check.C) {
 	}
 
 	status, _, err = sockRequest("POST", "/containers/"+ContainerID+"/unpause", nil)
-	c.Assert(status, check.Equals, http.StatusNoContent)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNoContent)
 
 	pausedContainers, err = getSliceOfPausedContainers()
 
@@ -824,8 +824,8 @@ func (s *DockerSuite) TestContainerApiTop(c *check.C) {
 	}
 	var top topResp
 	status, b, err := sockRequest("GET", "/containers/"+id+"/top?ps_args=aux", nil)
-	c.Assert(status, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusOK)
 
 	if err := json.Unmarshal(b, &top); err != nil {
 		c.Fatal(err)
@@ -858,8 +858,8 @@ func (s *DockerSuite) TestContainerApiCommit(c *check.C) {
 
 	name := "TestContainerApiCommit"
 	status, b, err := sockRequest("POST", "/commit?repo="+name+"&testtag=tag&container="+cName, nil)
-	c.Assert(status, check.Equals, http.StatusCreated)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusCreated)
 
 	type resp struct {
 		Id string
@@ -896,8 +896,8 @@ func (s *DockerSuite) TestContainerApiCommitWithLabelInConfig(c *check.C) {
 
 	name := "TestContainerApiCommitWithConfig"
 	status, b, err := sockRequest("POST", "/commit?repo="+name+"&container="+cName, config)
-	c.Assert(status, check.Equals, http.StatusCreated)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusCreated)
 
 	type resp struct {
 		Id string
@@ -941,8 +941,8 @@ func (s *DockerSuite) TestContainerApiCreate(c *check.C) {
 	}
 
 	status, b, err := sockRequest("POST", "/containers/create", config)
-	c.Assert(status, check.Equals, http.StatusCreated)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusCreated)
 
 	type createResp struct {
 		Id string
@@ -1148,8 +1148,8 @@ func (s *DockerSuite) TestContainerApiInvalidPortSyntax(c *check.C) {
 				}`
 
 	res, body, err := sockRequestRaw("POST", "/containers/create", strings.NewReader(config), "application/json")
-	c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusInternalServerError)
 
 	b, err := readBody(body)
 	if err != nil {
@@ -1185,8 +1185,8 @@ func (s *DockerSuite) TestContainerApiPostCreateNull(c *check.C) {
 		"OnBuild":null}`
 
 	res, body, err := sockRequestRaw("POST", "/containers/create", strings.NewReader(config), "application/json")
-	c.Assert(res.StatusCode, check.Equals, http.StatusCreated)
 	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusCreated)
 
 	b, err := readBody(body)
 	if err != nil {
@@ -1229,7 +1229,8 @@ func (s *DockerSuite) TestCreateWithTooLowMemoryLimit(c *check.C) {
 		"Memory":    524287
 	}`
 
-	res, body, _ := sockRequestRaw("POST", "/containers/create", strings.NewReader(config), "application/json")
+	res, body, err := sockRequestRaw("POST", "/containers/create", strings.NewReader(config), "application/json")
+	c.Assert(err, check.IsNil)
 	b, err2 := readBody(body)
 	if err2 != nil {
 		c.Fatal(err2)
@@ -1252,7 +1253,8 @@ func (s *DockerSuite) TestStartWithTooLowMemoryLimit(c *check.C) {
                 "Memory":    524287
         }`
 
-	res, body, _ := sockRequestRaw("POST", "/containers/"+containerID+"/start", strings.NewReader(config), "application/json")
+	res, body, err := sockRequestRaw("POST", "/containers/"+containerID+"/start", strings.NewReader(config), "application/json")
+	c.Assert(err, check.IsNil)
 	b, err2 := readBody(body)
 	if err2 != nil {
 		c.Fatal(err2)
@@ -1270,10 +1272,9 @@ func (s *DockerSuite) TestContainerApiRename(c *check.C) {
 	containerID := strings.TrimSpace(out)
 	newName := "TestContainerApiRenameNew"
 	statusCode, _, err := sockRequest("POST", "/containers/"+containerID+"/rename?name="+newName, nil)
-
+	c.Assert(err, check.IsNil)
 	// 204 No Content is expected, not 200
 	c.Assert(statusCode, check.Equals, http.StatusNoContent)
-	c.Assert(err, check.IsNil)
 
 	name, err := inspectField(containerID, "Name")
 	if name != "/"+newName {
@@ -1290,8 +1291,8 @@ func (s *DockerSuite) TestContainerApiKill(c *check.C) {
 	}
 
 	status, _, err := sockRequest("POST", "/containers/"+name+"/kill", nil)
-	c.Assert(status, check.Equals, http.StatusNoContent)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNoContent)
 
 	state, err := inspectField(name, "State.Running")
 	if err != nil {
@@ -1311,8 +1312,8 @@ func (s *DockerSuite) TestContainerApiRestart(c *check.C) {
 	}
 
 	status, _, err := sockRequest("POST", "/containers/"+name+"/restart?t=1", nil)
-	c.Assert(status, check.Equals, http.StatusNoContent)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNoContent)
 
 	if err := waitInspect(name, "{{ .State.Restarting  }} {{ .State.Running  }}", "false true", 5); err != nil {
 		c.Fatal(err)
@@ -1330,8 +1331,8 @@ func (s *DockerSuite) TestContainerApiRestartNotimeoutParam(c *check.C) {
 	c.Assert(waitRun(id), check.IsNil)
 
 	status, _, err := sockRequest("POST", "/containers/"+name+"/restart", nil)
-	c.Assert(status, check.Equals, http.StatusNoContent)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNoContent)
 
 	if err := waitInspect(name, "{{ .State.Restarting  }} {{ .State.Running  }}", "false true", 5); err != nil {
 		c.Fatal(err)
@@ -1347,18 +1348,18 @@ func (s *DockerSuite) TestContainerApiStart(c *check.C) {
 	}
 
 	status, _, err := sockRequest("POST", "/containers/create?name="+name, config)
-	c.Assert(status, check.Equals, http.StatusCreated)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusCreated)
 
 	conf := make(map[string]interface{})
 	status, _, err = sockRequest("POST", "/containers/"+name+"/start", conf)
-	c.Assert(status, check.Equals, http.StatusNoContent)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNoContent)
 
 	// second call to start should give 304
 	status, _, err = sockRequest("POST", "/containers/"+name+"/start", conf)
-	c.Assert(status, check.Equals, http.StatusNotModified)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNotModified)
 }
 
 func (s *DockerSuite) TestContainerApiStop(c *check.C) {
@@ -1370,8 +1371,8 @@ func (s *DockerSuite) TestContainerApiStop(c *check.C) {
 	}
 
 	status, _, err := sockRequest("POST", "/containers/"+name+"/stop?t=1", nil)
-	c.Assert(status, check.Equals, http.StatusNoContent)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNoContent)
 
 	if err := waitInspect(name, "{{ .State.Running  }}", "false", 5); err != nil {
 		c.Fatal(err)
@@ -1379,8 +1380,8 @@ func (s *DockerSuite) TestContainerApiStop(c *check.C) {
 
 	// second call to start should give 304
 	status, _, err = sockRequest("POST", "/containers/"+name+"/stop?t=1", nil)
-	c.Assert(status, check.Equals, http.StatusNotModified)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNotModified)
 }
 
 func (s *DockerSuite) TestContainerApiWait(c *check.C) {
@@ -1392,8 +1393,8 @@ func (s *DockerSuite) TestContainerApiWait(c *check.C) {
 	}
 
 	status, body, err := sockRequest("POST", "/containers/"+name+"/wait", nil)
-	c.Assert(status, check.Equals, http.StatusOK)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusOK)
 
 	if err := waitInspect(name, "{{ .State.Running  }}", "false", 5); err != nil {
 		c.Fatal(err)
@@ -1562,8 +1563,8 @@ func (s *DockerSuite) TestContainerApiDeleteConflict(c *check.C) {
 	c.Assert(waitRun(id), check.IsNil)
 
 	status, _, err := sockRequest("DELETE", "/containers/"+id, nil)
-	c.Assert(status, check.Equals, http.StatusConflict)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusConflict)
 }
 
 func (s *DockerSuite) TestContainerApiDeleteRemoveVolume(c *check.C) {
@@ -1583,8 +1584,8 @@ func (s *DockerSuite) TestContainerApiDeleteRemoveVolume(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	status, _, err := sockRequest("DELETE", "/containers/"+id+"?v=1&force=1", nil)
-	c.Assert(status, check.Equals, http.StatusNoContent)
 	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNoContent)
 
 	if _, err := os.Stat(vol); !os.IsNotExist(err) {
 		c.Fatalf("expected to get ErrNotExist error, got %v", err)
@@ -1651,10 +1652,9 @@ func (s *DockerSuite) TestPostContainerStop(c *check.C) {
 	c.Assert(waitRun(containerID), check.IsNil)
 
 	statusCode, _, err := sockRequest("POST", "/containers/"+containerID+"/stop", nil)
-
+	c.Assert(err, check.IsNil)
 	// 204 No Content is expected, not 200
 	c.Assert(statusCode, check.Equals, http.StatusNoContent)
-	c.Assert(err, check.IsNil)
 
 	if err := waitInspect(containerID, "{{ .State.Running  }}", "false", 5); err != nil {
 		c.Fatal(err)


### PR DESCRIPTION
Fix: #14362 
Fixes: #14362

Improve error check on SocketRequest and SocketRequestRaw on:
integration-cli/docker_api_containers_test.go

Signed-off-by: Quentin Tayssier qtayssier@gmail.com
