### PR TITLE
Man page fixes

### DIFF
--- a/man/docker-rmi.1.md
+++ b/man/docker-rmi.1.md
@@ -31,7 +31,7 @@ a registry. You cannot remove an image of a running container unless you use the
 
 ## Removing an image
 
-Here is an example of removing and image:
+Here is an example of removing an image:
 
     docker rmi fedora/httpd
 

--- a/man/docker-search.1.md
+++ b/man/docker-search.1.md
@@ -52,7 +52,7 @@ ranked 3 or higher:
 Search Docker Hub for the term 'fedora' and only display automated images
 ranked 1 or higher:
 
-    $ docker search -s 1 -t fedora
+    $ docker search -s 1 fedora
     NAME               DESCRIPTION                                     STARS OFFICIAL  AUTOMATED
     goldmann/wildfly   A WildFly application server running on a ...   3               [OK]
     tutum/fedora-20    Fedora 20 image with SSH access. For the r...   1               [OK]


### PR DESCRIPTION
Example in docker search has an extranious -t
docker rmi has a typo

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
