### PR TITLE
Quieter debug logging for clean exec commands

### DIFF
--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -268,7 +268,9 @@ func (d *Daemon) execCommandGC() {
 				}
 			}
 		}
-		logrus.Debugf("clean %d unused exec commands", cleaned)
+		if cleaned > 0 {
+			logrus.Debugf("clean %d unused exec commands", cleaned)
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@crosbymichael. This makes an idle daemon running in debug mode a little quieter - no outputting if there are no unused exec commands cleaned.
