### PR TITLE
time duration should be nano seconds, gccgo treats it as zero

### DIFF
--- a/pkg/plugins/client.go
+++ b/pkg/plugins/client.go
@@ -102,5 +102,5 @@ func backoff(retries int) time.Duration {
 }
 
 func abort(start time.Time, timeOff time.Duration) bool {
-	return timeOff+time.Since(start) > time.Duration(defaultTimeOut)*time.Second
+	return timeOff+time.Since(start) >= time.Duration(defaultTimeOut)*time.Second
 }


### PR DESCRIPTION
Due to gccgo time duration issue the computation here will always fail with gccgo compiler. A bug is filed with go https://github.com/golang/go/issues/11222
The PR is to work around this issue.
Signed-off-by: Srini Brahmaroutu srbrahma@us.ibm.com
