### PR TITLE
allow script to download image with tag

### DIFF
--- a/contrib/download-frozen-image.sh
+++ b/contrib/download-frozen-image.sh
@@ -62,6 +62,9 @@ while [ $# -gt 0 ]; do
 	ancestry=( ${ancestryJson//[\[\] \"]/} )
 	unset IFS
 
+	repo="${image%/*}"
+	image="${image#*/}"
+	imageFile=$image
 	if [ -s "$dir/tags-$imageFile.tmp" ]; then
 		echo -n ', ' >> "$dir/tags-$imageFile.tmp"
 	else


### PR DESCRIPTION
For supporting multi-arch images in the test framework (ex: ibm/busybox_z, etc) so that proper images are used in the tests I need support to parse the user/image:tag properly by the download-frozen image tool. 
Signed-off-by: Srini Brahmaroutu srbrahma@us.ibm.com
