### PR TITLE
Allow images built for P and Z to be used for testing

### DIFF
--- a/hack/make/.ensure-images
+++ b/hack/make/.ensure-images
@@ -1,0 +1,15 @@
+for image in `docker images | awk '{print $1}'`; do
+if ( [ -z "${image##*busybox_p}" ] || [ -z "${image##*busybox_z}" ] ); then
+        echo "tag $image as busybox"
+        docker tag $image busybox:latest
+        docker rmi $image
+elif ( [ -z "${image##*hello-world_p}" ] || [ -z "${image##*hello-world_z}" ] ); then
+        echo "tag $image as hello-world"
+        docker tag $image:frozen hello-world:frozen
+        docker rmi $image:frozen
+elif ( [ -z "${image##*unshare_p}" ] || [ -z "$image##*unshare_z}" ] ); then
+        echo "tag $image as unshare"
+        docker tag $image:latest jess/unshare:latest
+        docker rmi $image
+fi
+done

--- a/hack/make/.integration-daemon-setup
+++ b/hack/make/.integration-daemon-setup
@@ -2,4 +2,5 @@
 
 bundle .ensure-emptyfs
 bundle .ensure-frozen-images
+bundle .ensure-images
 bundle .ensure-httpserver


### PR DESCRIPTION
This PR will convert the Power and Z specific images required to run integration tests to proper names so that the tests can use them to run properly.

Signed-off-by: Srini Brahmaroutu srbrahma@us.ibm.com
