### PR TITLE
Windows: Plumb through -b on daemon

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -15,6 +15,7 @@ const (
 // common across platforms.
 type CommonConfig struct {
 	AutoRestart    bool
+	Bridge         bridgeConfig // Bridge holds bridge network specific configuration.
 	Context        map[string][]string
 	CorsHeaders    string
 	DisableBridge  bool

--- a/daemon/config_linux.go
+++ b/daemon/config_linux.go
@@ -22,8 +22,6 @@ type Config struct {
 
 	// Fields below here are platform specific.
 
-	// Bridge holds bridge network specific configuration.
-	Bridge               bridgeConfig
 	EnableSelinuxSupport bool
 	SocketGroup          string
 	Ulimits              map[string]*ulimit.Ulimit

--- a/daemon/config_windows.go
+++ b/daemon/config_windows.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"os"
+
+	flag "github.com/docker/docker/pkg/mflag"
 )
 
 var (
@@ -9,6 +11,12 @@ var (
 	defaultGraph   = os.Getenv("programdata") + string(os.PathSeparator) + "docker"
 	defaultExec    = "windows"
 )
+
+// bridgeConfig stores all the bridge driver specific
+// configuration.
+type bridgeConfig struct {
+	VirtualSwitchName string
+}
 
 // Config defines the configuration of a docker daemon.
 // These are the configuration settings that you pass
@@ -28,6 +36,6 @@ func (config *Config) InstallFlags() {
 	// First handle install flags which are consistent cross-platform
 	config.InstallCommonFlags()
 
-	// Then platform-specific install flags. There are none presently on Windows
-
+	// Then platform-specific install flags.
+	flag.StringVar(&config.Bridge.VirtualSwitchName, []string{"b", "-bridge"}, "", "Attach containers to a virtual switch")
 }

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -80,6 +80,7 @@ func populateCommand(c *Container, env []string) error {
 			network := c.NetworkSettings
 			en.Interface = &execdriver.NetworkInterface{
 				MacAddress: network.MacAddress,
+				Bridge:     c.daemon.config.Bridge.VirtualSwitchName,
 			}
 		}
 	default:
@@ -156,12 +157,6 @@ func (container *Container) GetSize() (int64, int64) {
 }
 
 func (container *Container) AllocateNetwork() error {
-
-	// TODO Windows. This needs reworking with libnetwork. In the
-	// proof-of-concept for //build conference, the Windows daemon
-	// invoked eng.Job("allocate_interface) passing through
-	// RequestedMac.
-
 	return nil
 }
 
@@ -174,11 +169,9 @@ func (container *Container) ExportRw() (archive.Archive, error) {
 }
 
 func (container *Container) ReleaseNetwork() {
-	// TODO Windows. Rework with libnetwork
 }
 
 func (container *Container) RestoreNetwork() error {
-	// TODO Windows. Rework with libnetwork
 	return nil
 }
 

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -15,6 +15,8 @@ import (
 	"github.com/microsoft/hcsshim"
 )
 
+const DefaultVirtualSwitch = "Virtual Switch"
+
 func (daemon *Daemon) Changes(container *Container) ([]archive.Change, error) {
 	return daemon.driver.Changes(container.ID, container.ImageID)
 }
@@ -125,7 +127,10 @@ func isBridgeNetworkDisabled(config *Config) bool {
 }
 
 func initNetworkController(config *Config) (libnetwork.NetworkController, error) {
-	// TODO Windows
+	// Set the name of the virtual switch if not specified by -b on daemon start
+	if config.Bridge.VirtualSwitchName == "" {
+		config.Bridge.VirtualSwitchName = DefaultVirtualSwitch
+	}
 	return nil, nil
 }
 

--- a/daemon/execdriver/windows/run.go
+++ b/daemon/execdriver/windows/run.go
@@ -81,10 +81,6 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 	}
 
 	if c.Network.Interface != nil {
-
-		// TODO Windows: Temporary
-		c.Network.Interface.Bridge = "Virtual Switch"
-
 		dev := device{
 			DeviceType: "Network",
 			Connection: &networkConnection{
@@ -101,7 +97,11 @@ func (d *driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 			}
 		}
 
+		logrus.Debugf("Virtual switch '%s', mac='%s'", c.Network.Interface.Bridge, c.Network.Interface.MacAddress)
+
 		cu.Devices = append(cu.Devices, dev)
+	} else {
+		logrus.Debugln("No network interface")
 	}
 
 	configurationb, err := json.Marshal(cu)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. This adds the plumbing to allow the Windows daemon to support -b to specify the name of the bridge (aka Hyper-V virtual switch in the Windows world) that containers should connect to by default.
