### PR TITLE
Go Scheduler issue with sync.Mutex

### DIFF
--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -189,6 +189,7 @@ func (r *bufReader) drain() {
 		reuseCount++
 		r.wait.Signal()
 		r.Unlock()
+		callSchedulerIfNecessary()
 		if err != nil {
 			break
 		}

--- a/pkg/ioutils/readers_test.go
+++ b/pkg/ioutils/readers_test.go
@@ -45,7 +45,7 @@ func TestReaderErrWrapperReadOnError(t *testing.T) {
 func TestReaderErrWrapperRead(t *testing.T) {
 	reader := strings.NewReader("a string reader.")
 	wrapper := NewReaderErrWrapper(reader, func() {
-		t.Fatalf("readErrWrapper should not have called the anonymous function on failure")
+		t.Fatalf("readErrWrapper should not have called the anonymous function")
 	})
 	// Read 20 byte (should be ok with the string above)
 	num, err := wrapper.Read(make([]byte, 20))

--- a/pkg/ioutils/scheduler.go
+++ b/pkg/ioutils/scheduler.go
@@ -1,0 +1,6 @@
+// +build !gccgo
+
+package ioutils
+
+func callSchedulerIfNecessary() {
+}

--- a/pkg/ioutils/scheduler_gccgo.go
+++ b/pkg/ioutils/scheduler_gccgo.go
@@ -1,0 +1,13 @@
+// +build gccgo
+
+package ioutils
+
+import (
+	"runtime"
+)
+
+func callSchedulerIfNecessary() {
+	//allow or force Go scheduler to switch context, without explicitly
+	//forcing this will make it hang when using gccgo implementation
+	runtime.Gosched()
+}


### PR DESCRIPTION
Unit test hangs due to that bufReader.drain() in pkg/ioutils/readers.go of Docker has a loop which calls Mutex.Lock() and Mutex.Unlock() successively. While the API document does not state explicitly, the type sync.Mutex is a low-level synchronization primitive and does not guarantee fairness.
This PR addresses the issue.

Signed-off-by: Srini Brahmaroutu srbrahma@us.ibm.com
