### PR TITLE
zsh: remove Vincent Bernat from reviewers for ZSH completion

### DIFF
--- a/contrib/completion/zsh/REVIEWERS
+++ b/contrib/completion/zsh/REVIEWERS
@@ -1,3 +1,2 @@
 Tianon Gravi <admwiggin@gmail.com> (@tianon)
 Jessie Frazelle <jess@docker.com> (@jfrazelle)
-Vincent Bernat <vincent@bernat.im> (@vincentbernat)


### PR DESCRIPTION
There have been some pretty invasive changes and I am not comfortable anymore to be considered as a reviewer for the current code.
