### PR TITLE
skip devicemapper unit tests when udev sync not supported

### DIFF
--- a/daemon/graphdriver/graphtest/graphtest.go
+++ b/daemon/graphdriver/graphtest/graphtest.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/pkg/devicemapper"
 )
 
 var (
@@ -74,7 +75,7 @@ func newDriver(t *testing.T, name string) *Driver {
 	d, err := graphdriver.GetDriver(name, root, nil)
 	if err != nil {
 		t.Logf("graphdriver: %v\n", err)
-		if err == graphdriver.ErrNotSupported || err == graphdriver.ErrPrerequisites || err == graphdriver.ErrIncompatibleFS {
+		if err == graphdriver.ErrNotSupported || err == graphdriver.ErrPrerequisites || err == graphdriver.ErrIncompatibleFS || (name == "devicemapper" && !devicemapper.UdevSetSyncSupport(true)) {
 			t.Skipf("Driver %s not supported", name)
 		}
 		t.Fatal(err)


### PR DESCRIPTION
also skip devicemapper unit tests when udev sync not supported

I was seeing:

```
+ go test -test.timeout=30m github.com/docker/docker/pkg/mount
--- FAIL: TestMounted (0.00s)
    mount_test.go:56: Error found less than 3 fields post '-' in "314 313 0:73 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs  rw"
--- FAIL: TestMountReadonly (0.00s)
    mount_test.go:107: Error found less than 3 fields post '-' in "314 313 0:73 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs  rw"
--- FAIL: TestGetMounts (0.00s)
    mount_test.go:124: Error found less than 3 fields post '-' in "314 313 0:73 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs  rw"
--- FAIL: TestSubtreePrivate (0.00s)
    sharedsubtree_linux_test.go:56: Error found less than 3 fields post '-' in "314 313 0:73 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs  rw"
--- FAIL: TestSubtreeShared (0.00s)
    sharedsubtree_linux_test.go:143: Error found less than 3 fields post '-' in "314 313 0:73 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs  rw"
--- FAIL: TestSubtreeSharedSlave (0.00s)
    sharedsubtree_linux_test.go:222: Error found less than 3 fields post '-' in "314 313 0:73 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs  rw"
--- FAIL: TestSubtreeUnbindable (0.00s)
    sharedsubtree_linux_test.go:303: Error found less than 3 fields post '-' in "314 313 0:73 / /sys/fs/cgroup rw,nosuid,nodev,noexec,relatime - tmpfs  rw"
FAIL
coverage: 48.8% of statements
```

idk if this is only me...

ping @vbatts 
