### PR TITLE
Do not hide user provided network mounts [v2]

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -363,6 +363,21 @@ func (container *Container) GetSize() (int64, int64) {
 	return sizeRw, sizeRootfs
 }
 
+// If the user provides bind-mounts for the network files, we make sure
+// that the container sees those files
+func (container *Container) fixupNetworkMounts(usermounts map[string]string) {
+	if path, given := usermounts["/etc/resolv.conf"]; given == true {
+		container.ResolvConfPath = path
+	}
+	if path, given := usermounts["/etc/hostname"]; given == true {
+		container.HostnamePath = path
+	}
+	if path, given := usermounts["/etc/hosts"]; given == true {
+		container.HostsPath = path
+	}
+}
+
+
 func (container *Container) buildHostnameFile() error {
 	hostnamePath, err := container.GetRootResourcePath("hostname")
 	if err != nil {

--- a/daemon/volumes_linux.go
+++ b/daemon/volumes_linux.go
@@ -31,6 +31,7 @@ func copyOwnership(source, destination string) error {
 
 func (container *Container) setupMounts() ([]execdriver.Mount, error) {
 	var mounts []execdriver.Mount
+	var usermounts = make(map[string]string)
 	for _, m := range container.MountPoints {
 		path, err := m.Setup()
 		if err != nil {
@@ -42,8 +43,10 @@ func (container *Container) setupMounts() ([]execdriver.Mount, error) {
 			Destination: m.Destination,
 			Writable:    m.RW,
 		})
+		usermounts[m.Destination] = path
 	}
 
+	container.fixupNetworkMounts(usermounts)
 	mounts = sortMounts(mounts)
 	return append(mounts, container.networkMounts()...), nil
 }


### PR DESCRIPTION
Prevent the docker daemon from mounting the created network files over
those provided by the user via -v command line option. This would otherwise
hide the one provide by the user.
The benefit of this is that a user can provide these network files using the
-v command line option and place them in a size-limited filesystem.
