### PR TITLE
Do not hide user provided network mounts [v2]

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -363,6 +363,26 @@ func (container *Container) GetSize() (int64, int64) {
 	return sizeRw, sizeRootfs
 }
 
+// Attempt to set the network mounts given a provided destination and
+// the path to use for it; return true if the given destination was a
+// network mount file
+func (container *Container) trySetNetworkMount(destination string, path string) bool {
+	if destination == "/etc/resolv.conf" {
+		container.ResolvConfPath = path
+		return true
+	}
+	if destination == "/etc/hostname" {
+		container.HostnamePath = path
+		return true
+	}
+	if destination == "/etc/hosts" {
+		container.HostsPath = path
+		return true
+	}
+
+	return false
+}
+
 func (container *Container) buildHostnameFile() error {
 	hostnamePath, err := container.GetRootResourcePath("hostname")
 	if err != nil {

--- a/daemon/volumes_linux.go
+++ b/daemon/volumes_linux.go
@@ -36,12 +36,13 @@ func (container *Container) setupMounts() ([]execdriver.Mount, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		mounts = append(mounts, execdriver.Mount{
-			Source:      path,
-			Destination: m.Destination,
-			Writable:    m.RW,
-		})
+		if !container.trySetNetworkMount(m.Destination, path) {
+			mounts = append(mounts, execdriver.Mount{
+				Source:      path,
+				Destination: m.Destination,
+				Writable:    m.RW,
+			})
+		}
 	}
 
 	mounts = sortMounts(mounts)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2516,3 +2516,25 @@ func (s *DockerSuite) TestRunWriteFilteredProc(c *check.C) {
 		}
 	}
 }
+
+func (s *DockerSuite) TestRunNetworkFilesBindMount(c *check.C) {
+	testRequires(c, SameHostDaemon)
+	name := "test-nwfiles-mount"
+
+	f, err := ioutil.TempFile("", name)
+	c.Assert(err, check.IsNil)
+
+	filename := f.Name()
+	defer os.Remove(filename)
+
+	expected := "test123"
+
+	err = ioutil.WriteFile(filename, []byte(expected), 0644)
+	c.Assert(err, check.IsNil)
+
+	var actual string
+	actual, _ = dockerCmd(c, "run", "-v", filename+":/etc/resolv.conf", "busybox", "cat", "/etc/resolv.conf")
+	if actual != expected {
+		c.Fatalf("expected resolv.conf be: %q, but was: %q", expected, actual)
+	}
+}


### PR DESCRIPTION
Prevent the docker daemon from mounting the created network files over
those provided by the user via -v command line option. This would otherwise
hide the one provide by the user.
The benefit of this is that a user can provide these network files using the
-v command line option and place them in a size-limited filesystem.

Signed-off-by: Stefan Berger stefanb@us.ibm.com
