### PR TITLE
Fix wrong swappiness value from REST api

### DIFF
--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -176,6 +176,12 @@ func (w *ContainerConfigWrapper) GetHostConfig() *HostConfig {
 	if hc == nil {
 		hc = w.InnerHostConfig
 	} else {
+		if len(hc.Binds) > 0 && len(w.InnerHostConfig.Binds) == 0 {
+			w.InnerHostConfig.Binds = hc.Binds
+		}
+		if hc.LxcConf != nil && w.InnerHostConfig.LxcConf == nil {
+			w.InnerHostConfig.LxcConf = hc.LxcConf
+		}
 		if hc.Memory != 0 && w.InnerHostConfig.Memory == 0 {
 			w.InnerHostConfig.Memory = hc.Memory
 		}
@@ -184,6 +190,40 @@ func (w *ContainerConfigWrapper) GetHostConfig() *HostConfig {
 		}
 		if hc.CPUShares != 0 && w.InnerHostConfig.CPUShares == 0 {
 			w.InnerHostConfig.CPUShares = hc.CPUShares
+		}
+		if hc.CpusetCpus != "" && w.InnerHostConfig.CpusetCpus == "" {
+			w.InnerHostConfig.CpusetCpus = hc.CpusetCpus
+		}
+		if hc.PortBindings != nil && w.InnerHostConfig.PortBindings == nil {
+			w.InnerHostConfig.PortBindings = hc.PortBindings
+		}
+		if hc.Privileged != false && w.InnerHostConfig.Privileged == false {
+			w.InnerHostConfig.Privileged = hc.Privileged
+		}
+		if len(hc.DNS) > 0 && len(w.InnerHostConfig.DNS) == 0 {
+			w.InnerHostConfig.DNS = hc.DNS
+		}
+		if len(hc.DNSSearch) > 0 && len(w.InnerHostConfig.DNSSearch) == 0 {
+			w.InnerHostConfig.DNSSearch = hc.DNSSearch
+		}
+		if len(hc.ExtraHosts) > 0 && len(w.InnerHostConfig.ExtraHosts) == 0 {
+			w.InnerHostConfig.ExtraHosts = hc.ExtraHosts
+		}
+		if len(hc.VolumesFrom) > 0 && len(w.InnerHostConfig.VolumesFrom) == 0 {
+			w.InnerHostConfig.VolumesFrom = hc.VolumesFrom
+		}
+		if len(hc.Devices) > 0 && len(w.InnerHostConfig.Devices) == 0 {
+			w.InnerHostConfig.Devices = hc.Devices
+		}
+		if hc.CapAdd != nil && w.InnerHostConfig.CapAdd == nil {
+			w.InnerHostConfig.CapAdd = hc.CapAdd
+		}
+		if hc.CapDrop != nil && w.InnerHostConfig.CapDrop == nil {
+			w.InnerHostConfig.CapDrop = hc.CapDrop
+		}
+		if hc.RestartPolicy.Name != "" && w.InnerHostConfig.RestartPolicy.Name == "" {
+			w.InnerHostConfig.RestartPolicy.Name = hc.RestartPolicy.Name
+			w.InnerHostConfig.RestartPolicy.MaximumRetryCount = hc.RestartPolicy.MaximumRetryCount
 		}
 
 		hc = w.InnerHostConfig

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -314,6 +314,12 @@ func DecodeHostConfig(src io.Reader) (*HostConfig, error) {
 	decoder := json.NewDecoder(src)
 
 	var w ContainerConfigWrapper
+
+	// Decode will assign type initial values to these absent fields, but for
+	// some json fields, type initial values have some meaning, we need to assign
+	// real default values before Decode them.
+	w.InnerHostConfig = &HostConfig{}
+	w.InnerHostConfig.MemorySwappiness = -1
 	if err := decoder.Decode(&w); err != nil {
 		return nil, err
 	}

--- a/runconfig/hostconfig_test.go
+++ b/runconfig/hostconfig_test.go
@@ -251,6 +251,10 @@ func TestDecodeHostConfig(t *testing.T) {
 			t.Fatalf("Expected privileged false, found %v\n", c.Privileged)
 		}
 
+		if c.MemorySwappiness != -1 {
+			t.Fatalf("Expected MemorySwappiness -1, found %v\n", c.MemorySwappiness)
+		}
+
 		if l := len(c.Binds); l != 1 {
 			t.Fatalf("Expected 1 bind, found %d\n", l)
 		}


### PR DESCRIPTION
We added memory swappiness support recently, but for old
usage without MemorySwappiness field in json, the default
would be 0, and assigned to cgroup, which is not excepted.

We need to add the real default value -1 before decode
json file.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
