### PR TITLE
Remove cgroup read-only flag when privileged

### DIFF
--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -48,6 +48,13 @@ func (d *driver) createContainer(c *execdriver.Command) (*configs.Config, error)
 			container.ReadonlyPaths = nil
 		}
 
+		// clear readonly for cgroup
+		for i := range container.Mounts {
+			if container.Mounts[i].Device == "cgroup" {
+				container.Mounts[i].Flags &= ^syscall.MS_RDONLY
+			}
+		}
+
 		container.MaskPaths = nil
 		if err := d.setPrivileged(container); err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes: #14543

It needs libcontainer fix from:
https://github.com/opencontainers/runc/pull/91

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
