### PR TITLE
Integration test refactors to use dockerCmd

### DIFF
--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -14,11 +13,7 @@ import (
 )
 
 func (s *DockerSuite) TestGetContainersAttachWebsocket(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-dit", "busybox", "cat")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf(out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-dit", "busybox", "cat")
 
 	rwc, err := sockConn(time.Duration(10 * time.Second))
 	if err != nil {
@@ -102,9 +97,7 @@ func (s *DockerSuite) TestGetContainersWsAttachContainerNotFound(c *check.C) {
 }
 
 func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-dit", "busybox", "cat")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	out, _ := dockerCmd(c, "run", "-dit", "busybox", "cat")
 
 	r, w := io.Pipe()
 	defer r.Close()
@@ -167,9 +160,7 @@ func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
 }
 
 func (s *DockerSuite) TestPostContainersAttachStderr(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-dit", "busybox", "/bin/sh", "-c", "cat >&2")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	out, _ := dockerCmd(c, "run", "-dit", "busybox", "/bin/sh", "-c", "cat >&2")
 
 	r, w := io.Pipe()
 	defer r.Close()

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -2,18 +2,13 @@ package main
 
 import (
 	"net/http"
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestExecResizeApiHeightWidthNoInt(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf(out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/exec/" + cleanedContainerID + "/resize?h=foo&w=bar"

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"os/exec"
 
 	"github.com/go-check/check"
 )
@@ -15,10 +14,7 @@ import (
 // Regression test for #9414
 func (s *DockerSuite) TestExecApiCreateNoCmd(c *check.C) {
 	name := "exec_test"
-	runCmd := exec.Command(dockerBinary, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
-	if out, _, err := runCommandWithOutput(runCmd); err != nil {
-		c.Fatal(out, err)
-	}
+	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
 	status, body, err := sockRequest("POST", fmt.Sprintf("/containers/%s/exec", name), map[string]interface{}{"Cmd": nil})
 	c.Assert(status, check.Equals, http.StatusInternalServerError)

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
-	"os/exec"
 	"strings"
 
 	"github.com/docker/docker/api/types"
@@ -16,9 +15,7 @@ func (s *DockerSuite) TestApiImagesFilter(c *check.C) {
 	name2 := "utest/docker:tag2"
 	name3 := "utest:5000/docker:tag3"
 	for _, n := range []string{name, name2, name3} {
-		if out, err := exec.Command(dockerBinary, "tag", "busybox", n).CombinedOutput(); err != nil {
-			c.Fatal(err, out)
-		}
+		dockerCmd(c, "tag", "busybox", n)
 	}
 	type image types.Image
 	getImages := func(filter string) []image {
@@ -65,9 +62,7 @@ func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 
 	defer body.Close()
 
-	if out, err := exec.Command(dockerBinary, "rmi", id).CombinedOutput(); err != nil {
-		c.Fatal(err, out)
-	}
+	dockerCmd(c, "rmi", id)
 
 	res, loadBody, err := sockRequestRaw("POST", "/images/load", body, "application/x-tar")
 	c.Assert(err, check.IsNil)
@@ -75,10 +70,7 @@ func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 
 	defer loadBody.Close()
 
-	inspectOut, err := exec.Command(dockerBinary, "inspect", "--format='{{ .Id }}'", id).CombinedOutput()
-	if err != nil {
-		c.Fatal(err, inspectOut)
-	}
+	inspectOut, _ := dockerCmd(c, "inspect", "--format='{{ .Id }}'", id)
 	if strings.TrimSpace(string(inspectOut)) != id {
 		c.Fatal("load did not work properly")
 	}
@@ -93,9 +85,7 @@ func (s *DockerSuite) TestApiImagesDelete(c *check.C) {
 	}
 	id := strings.TrimSpace(out)
 
-	if out, err := exec.Command(dockerBinary, "tag", name, "test:tag1").CombinedOutput(); err != nil {
-		c.Fatal(err, out)
-	}
+	dockerCmd(c, "tag", name, "test:tag1")
 
 	status, _, err := sockRequest("DELETE", "/images/"+id, nil)
 	c.Assert(status, check.Equals, http.StatusConflict)

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -3,18 +3,13 @@ package main
 import (
 	"encoding/json"
 	"net/http"
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestInspectApiContainerResponse(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf("failed to create a container: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)
 

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -46,10 +45,7 @@ func (s *DockerSuite) TestLogsApiWithStdout(c *check.C) {
 
 func (s *DockerSuite) TestLogsApiNoStdoutNorStderr(c *check.C) {
 	name := "logs_test"
-	runCmd := exec.Command(dockerBinary, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
-	if out, _, err := runCommandWithOutput(runCmd); err != nil {
-		c.Fatal(out, err)
-	}
+	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
 	status, body, err := sockRequest("GET", fmt.Sprintf("/containers/%s/logs", name), nil)
 	c.Assert(status, check.Equals, http.StatusBadRequest)
@@ -65,10 +61,7 @@ func (s *DockerSuite) TestLogsApiNoStdoutNorStderr(c *check.C) {
 func (s *DockerSuite) TestLogsApiFollowEmptyOutput(c *check.C) {
 	name := "logs_test"
 	t0 := time.Now()
-	runCmd := exec.Command(dockerBinary, "run", "-d", "-t", "--name", name, "busybox", "sleep", "10")
-	if out, _, err := runCommandWithOutput(runCmd); err != nil {
-		c.Fatal(out, err)
-	}
+	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "sleep", "10")
 
 	_, body, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/logs?follow=1&stdout=1&stderr=1&tail=all", name), bytes.NewBuffer(nil), "")
 	t1 := time.Now()

--- a/integration-cli/docker_api_resize_test.go
+++ b/integration-cli/docker_api_resize_test.go
@@ -2,18 +2,13 @@ package main
 
 import (
 	"net/http"
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestResizeApiResponse(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf(out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=40&w=40"
@@ -23,11 +18,7 @@ func (s *DockerSuite) TestResizeApiResponse(c *check.C) {
 }
 
 func (s *DockerSuite) TestResizeApiHeightWidthNoInt(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "top")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf(out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=foo&w=bar"
@@ -37,19 +28,11 @@ func (s *DockerSuite) TestResizeApiHeightWidthNoInt(c *check.C) {
 }
 
 func (s *DockerSuite) TestResizeApiResponseWhenContainerNotStarted(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf(out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	// make sure the exited container is not running
-	runCmd = exec.Command(dockerBinary, "wait", cleanedContainerID)
-	out, _, err = runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf(out, err)
-	}
+	dockerCmd(c, "wait", cleanedContainerID)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=40&w=40"
 	status, body, err := sockRequest("POST", endpoint, nil)

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -76,10 +76,7 @@ func (s *DockerSuite) TestAttachMultipleAndRestart(c *check.C) {
 		c.Fatalf("Attaches did not initialize properly")
 	}
 
-	cmd := exec.Command(dockerBinary, "kill", "attacher")
-	if _, err := runCommand(cmd); err != nil {
-		c.Fatal(err)
-	}
+	dockerCmd(c, "kill", "attacher")
 
 	select {
 	case <-endDone:
@@ -90,11 +87,7 @@ func (s *DockerSuite) TestAttachMultipleAndRestart(c *check.C) {
 }
 
 func (s *DockerSuite) TestAttachTtyWithoutStdin(c *check.C) {
-	cmd := exec.Command(dockerBinary, "run", "-d", "-ti", "busybox")
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("failed to start container: %v (%v)", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "-ti", "busybox")
 
 	id := strings.TrimSpace(out)
 	if err := waitRun(id); err != nil {

--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -16,11 +16,7 @@ import (
 // #9860
 func (s *DockerSuite) TestAttachClosedOnContainerStop(c *check.C) {
 
-	cmd := exec.Command(dockerBinary, "run", "-dti", "busybox", "sleep", "2")
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("failed to start container: %v (%v)", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-dti", "busybox", "sleep", "2")
 
 	id := strings.TrimSpace(out)
 	if err := waitRun(id); err != nil {
@@ -47,10 +43,8 @@ func (s *DockerSuite) TestAttachClosedOnContainerStop(c *check.C) {
 		}
 	}()
 
-	waitCmd := exec.Command(dockerBinary, "wait", id)
-	if out, _, err = runCommandWithOutput(waitCmd); err != nil {
-		c.Fatalf("error thrown while waiting for container: %s, %v", out, err)
-	}
+	dockerCmd(c, "wait", id)
+
 	select {
 	case err := <-errChan:
 		c.Assert(err, check.IsNil)

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"encoding/json"
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
@@ -22,14 +21,9 @@ func (s *DockerSuite) TestBuildResourceConstraintsAreUsed(c *check.C) {
 		c.Fatal(err)
 	}
 
-	cmd := exec.Command(dockerBinary, "build", "--no-cache", "--rm=false", "--memory=64m", "--memory-swap=-1", "--cpuset-cpus=0", "--cpuset-mems=0", "--cpu-shares=100", "--cpu-quota=8000", "-t", name, ".")
-	cmd.Dir = ctx.Dir
+	dockerCmdInDir(c, ctx.Dir, "build", "--no-cache", "--rm=false", "--memory=64m", "--memory-swap=-1", "--cpuset-cpus=0", "--cpuset-mems=0", "--cpu-shares=100", "--cpu-quota=8000", "-t", name, ".")
 
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(err, out)
-	}
-	out, _ = dockerCmd(c, "ps", "-lq")
+	out, _ := dockerCmd(c, "ps", "-lq")
 
 	cID := strings.TrimSpace(out)
 
@@ -57,7 +51,7 @@ func (s *DockerSuite) TestBuildResourceConstraintsAreUsed(c *check.C) {
 	}
 
 	// Make sure constraints aren't saved to image
-	_, _ = dockerCmd(c, "run", "--name=test", name)
+	dockerCmd(c, "run", "--name=test", name)
 
 	cfg, err = inspectFieldJSON("test", "HostConfig")
 	if err != nil {

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
 	"regexp"
 	"strings"
 
@@ -15,22 +14,18 @@ var (
 	digestRegex = regexp.MustCompile("Digest: ([^\n]+)")
 )
 
-func setupImage() (string, error) {
-	return setupImageWithTag("latest")
+func setupImage(c *check.C) (string, error) {
+	return setupImageWithTag(c, "latest")
 }
 
-func setupImageWithTag(tag string) (string, error) {
+func setupImageWithTag(c *check.C, tag string) (string, error) {
 	containerName := "busyboxbydigest"
 
-	cmd := exec.Command(dockerBinary, "run", "-d", "-e", "digest=1", "--name", containerName, "busybox")
-	if _, err := runCommand(cmd); err != nil {
-		return "", err
-	}
+	dockerCmd(c, "run", "-d", "-e", "digest=1", "--name", containerName, "busybox")
 
 	// tag the image to upload it to the private registry
 	repoAndTag := utils.ImageReference(repoName, tag)
-	cmd = exec.Command(dockerBinary, "commit", containerName, repoAndTag)
-	if out, _, err := runCommandWithOutput(cmd); err != nil {
+	if out, _, err := dockerCmdWithError(c, "commit", containerName, repoAndTag); err != nil {
 		return "", fmt.Errorf("image tagging failed: %s, %v", out, err)
 	}
 
@@ -40,16 +35,14 @@ func setupImageWithTag(tag string) (string, error) {
 	}
 
 	// push the image
-	cmd = exec.Command(dockerBinary, "push", repoAndTag)
-	out, _, err := runCommandWithOutput(cmd)
+	out, _, err := dockerCmdWithError(c, "push", repoAndTag)
 	if err != nil {
 		return "", fmt.Errorf("pushing the image to the private registry has failed: %s, %v", out, err)
 	}
 
 	// delete our local repo that we previously tagged
-	cmd = exec.Command(dockerBinary, "rmi", repoAndTag)
-	if out, _, err := runCommandWithOutput(cmd); err != nil {
-		return "", fmt.Errorf("error deleting images prior to real test: %s, %v", out, err)
+	if rmiout, _, err := dockerCmdWithError(c, "rmi", repoAndTag); err != nil {
+		return "", fmt.Errorf("error deleting images prior to real test: %s, %v", rmiout, err)
 	}
 
 	// the push output includes "Digest: <digest>", so find that
@@ -63,17 +56,13 @@ func setupImageWithTag(tag string) (string, error) {
 }
 
 func (s *DockerRegistrySuite) TestPullByTagDisplaysDigest(c *check.C) {
-	pushDigest, err := setupImage()
+	pushDigest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
 	}
 
 	// pull from the registry using the tag
-	cmd := exec.Command(dockerBinary, "pull", repoName)
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error pulling by tag: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "pull", repoName)
 
 	// the pull output includes "Digest: <digest>", so find that
 	matches := digestRegex.FindStringSubmatch(out)
@@ -89,18 +78,14 @@ func (s *DockerRegistrySuite) TestPullByTagDisplaysDigest(c *check.C) {
 }
 
 func (s *DockerRegistrySuite) TestPullByDigest(c *check.C) {
-	pushDigest, err := setupImage()
+	pushDigest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
 	}
 
 	// pull from the registry using the <name>@<digest> reference
 	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
-	cmd := exec.Command(dockerBinary, "pull", imageReference)
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error pulling by digest: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "pull", imageReference)
 
 	// the pull output includes "Digest: <digest>", so find that
 	matches := digestRegex.FindStringSubmatch(out)
@@ -118,15 +103,14 @@ func (s *DockerRegistrySuite) TestPullByDigest(c *check.C) {
 func (s *DockerRegistrySuite) TestPullByDigestNoFallback(c *check.C) {
 	// pull from the registry using the <name>@<digest> reference
 	imageReference := fmt.Sprintf("%s@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", repoName)
-	cmd := exec.Command(dockerBinary, "pull", imageReference)
-	out, _, err := runCommandWithOutput(cmd)
+	out, _, err := dockerCmdWithError(c, "pull", imageReference)
 	if err == nil || !strings.Contains(out, "pulling with digest reference failed from v2 registry") {
 		c.Fatalf("expected non-zero exit status and correct error message when pulling non-existing image: %s", out)
 	}
 }
 
 func (s *DockerRegistrySuite) TestCreateByDigest(c *check.C) {
-	pushDigest, err := setupImage()
+	pushDigest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
 	}
@@ -134,11 +118,7 @@ func (s *DockerRegistrySuite) TestCreateByDigest(c *check.C) {
 	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
 
 	containerName := "createByDigest"
-	cmd := exec.Command(dockerBinary, "create", "--name", containerName, imageReference)
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error creating by digest: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "create", "--name", containerName, imageReference)
 
 	res, err := inspectField(containerName, "Config.Image")
 	if err != nil {
@@ -150,7 +130,7 @@ func (s *DockerRegistrySuite) TestCreateByDigest(c *check.C) {
 }
 
 func (s *DockerRegistrySuite) TestRunByDigest(c *check.C) {
-	pushDigest, err := setupImage()
+	pushDigest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
 	}
@@ -158,11 +138,7 @@ func (s *DockerRegistrySuite) TestRunByDigest(c *check.C) {
 	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
 
 	containerName := "runByDigest"
-	cmd := exec.Command(dockerBinary, "run", "--name", containerName, imageReference, "sh", "-c", "echo found=$digest")
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error run by digest: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "--name", containerName, imageReference, "sh", "-c", "echo found=$digest")
 
 	foundRegex := regexp.MustCompile("found=([^\n]+)")
 	matches := foundRegex.FindStringSubmatch(out)
@@ -183,7 +159,7 @@ func (s *DockerRegistrySuite) TestRunByDigest(c *check.C) {
 }
 
 func (s *DockerRegistrySuite) TestRemoveImageByDigest(c *check.C) {
-	digest, err := setupImage()
+	digest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
 	}
@@ -191,11 +167,7 @@ func (s *DockerRegistrySuite) TestRemoveImageByDigest(c *check.C) {
 	imageReference := fmt.Sprintf("%s@%s", repoName, digest)
 
 	// pull from the registry using the <name>@<digest> reference
-	cmd := exec.Command(dockerBinary, "pull", imageReference)
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error pulling by digest: %s, %v", out, err)
-	}
+	dockerCmd(c, "pull", imageReference)
 
 	// make sure inspect runs ok
 	if _, err := inspectField(imageReference, "Id"); err != nil {
@@ -216,7 +188,7 @@ func (s *DockerRegistrySuite) TestRemoveImageByDigest(c *check.C) {
 }
 
 func (s *DockerRegistrySuite) TestBuildByDigest(c *check.C) {
-	digest, err := setupImage()
+	digest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
 	}
@@ -224,11 +196,7 @@ func (s *DockerRegistrySuite) TestBuildByDigest(c *check.C) {
 	imageReference := fmt.Sprintf("%s@%s", repoName, digest)
 
 	// pull from the registry using the <name>@<digest> reference
-	cmd := exec.Command(dockerBinary, "pull", imageReference)
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error pulling by digest: %s, %v", out, err)
-	}
+	dockerCmd(c, "pull", imageReference)
 
 	// get the image id
 	imageID, err := inspectField(imageReference, "Id")
@@ -258,7 +226,7 @@ func (s *DockerRegistrySuite) TestBuildByDigest(c *check.C) {
 }
 
 func (s *DockerRegistrySuite) TestTagByDigest(c *check.C) {
-	digest, err := setupImage()
+	digest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
 	}
@@ -266,18 +234,11 @@ func (s *DockerRegistrySuite) TestTagByDigest(c *check.C) {
 	imageReference := fmt.Sprintf("%s@%s", repoName, digest)
 
 	// pull from the registry using the <name>@<digest> reference
-	cmd := exec.Command(dockerBinary, "pull", imageReference)
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error pulling by digest: %s, %v", out, err)
-	}
+	dockerCmd(c, "pull", imageReference)
 
 	// tag it
 	tag := "tagbydigest"
-	cmd = exec.Command(dockerBinary, "tag", imageReference, tag)
-	if _, err := runCommand(cmd); err != nil {
-		c.Fatalf("unexpected error tagging: %v", err)
-	}
+	dockerCmd(c, "tag", imageReference, tag)
 
 	expectedID, err := inspectField(imageReference, "Id")
 	if err != nil {
@@ -295,7 +256,7 @@ func (s *DockerRegistrySuite) TestTagByDigest(c *check.C) {
 }
 
 func (s *DockerRegistrySuite) TestListImagesWithoutDigests(c *check.C) {
-	digest, err := setupImage()
+	digest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
 	}
@@ -303,17 +264,9 @@ func (s *DockerRegistrySuite) TestListImagesWithoutDigests(c *check.C) {
 	imageReference := fmt.Sprintf("%s@%s", repoName, digest)
 
 	// pull from the registry using the <name>@<digest> reference
-	cmd := exec.Command(dockerBinary, "pull", imageReference)
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error pulling by digest: %s, %v", out, err)
-	}
+	dockerCmd(c, "pull", imageReference)
 
-	cmd = exec.Command(dockerBinary, "images")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error listing images: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "images")
 
 	if strings.Contains(out, "DIGEST") {
 		c.Fatalf("list output should not have contained DIGEST header: %s", out)
@@ -324,7 +277,7 @@ func (s *DockerRegistrySuite) TestListImagesWithoutDigests(c *check.C) {
 func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 
 	// setup image1
-	digest1, err := setupImageWithTag("tag1")
+	digest1, err := setupImageWithTag(c, "tag1")
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
 	}
@@ -332,18 +285,10 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	c.Logf("imageReference1 = %s", imageReference1)
 
 	// pull image1 by digest
-	cmd := exec.Command(dockerBinary, "pull", imageReference1)
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error pulling by digest: %s, %v", out, err)
-	}
+	dockerCmd(c, "pull", imageReference1)
 
 	// list images
-	cmd = exec.Command(dockerBinary, "images", "--digests")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error listing images: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "images", "--digests")
 
 	// make sure repo shown, tag=<none>, digest = $digest1
 	re1 := regexp.MustCompile(`\s*` + repoName + `\s*<none>\s*` + digest1 + `\s`)
@@ -352,7 +297,7 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	}
 
 	// setup image2
-	digest2, err := setupImageWithTag("tag2")
+	digest2, err := setupImageWithTag(c, "tag2")
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
 	}
@@ -360,25 +305,13 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	c.Logf("imageReference2 = %s", imageReference2)
 
 	// pull image1 by digest
-	cmd = exec.Command(dockerBinary, "pull", imageReference1)
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error pulling by digest: %s, %v", out, err)
-	}
+	dockerCmd(c, "pull", imageReference1)
 
 	// pull image2 by digest
-	cmd = exec.Command(dockerBinary, "pull", imageReference2)
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error pulling by digest: %s, %v", out, err)
-	}
+	dockerCmd(c, "pull", imageReference2)
 
 	// list images
-	cmd = exec.Command(dockerBinary, "images", "--digests")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error listing images: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "images", "--digests")
 
 	// make sure repo shown, tag=<none>, digest = $digest1
 	if !re1.MatchString(out) {
@@ -392,18 +325,10 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	}
 
 	// pull tag1
-	cmd = exec.Command(dockerBinary, "pull", repoName+":tag1")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error pulling tag1: %s, %v", out, err)
-	}
+	dockerCmd(c, "pull", repoName+":tag1")
 
 	// list images
-	cmd = exec.Command(dockerBinary, "images", "--digests")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error listing images: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "images", "--digests")
 
 	// make sure image 1 has repo, tag, <none> AND repo, <none>, digest
 	reWithTag1 := regexp.MustCompile(`\s*` + repoName + `\s*tag1\s*<none>\s`)
@@ -420,18 +345,10 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	}
 
 	// pull tag 2
-	cmd = exec.Command(dockerBinary, "pull", repoName+":tag2")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error pulling tag2: %s, %v", out, err)
-	}
+	dockerCmd(c, "pull", repoName+":tag2")
 
 	// list images
-	cmd = exec.Command(dockerBinary, "images", "--digests")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error listing images: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "images", "--digests")
 
 	// make sure image 1 has repo, tag, digest
 	if !reWithTag1.MatchString(out) {
@@ -449,11 +366,7 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	}
 
 	// list images
-	cmd = exec.Command(dockerBinary, "images", "--digests")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error listing images: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "images", "--digests")
 
 	// make sure image 1 has repo, tag, digest
 	if !reWithTag1.MatchString(out) {
@@ -471,18 +384,14 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 }
 
 func (s *DockerRegistrySuite) TestDeleteImageByIDOnlyPulledByDigest(c *check.C) {
-	pushDigest, err := setupImage()
+	pushDigest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
 	}
 
 	// pull from the registry using the <name>@<digest> reference
 	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
-	cmd := exec.Command(dockerBinary, "pull", imageReference)
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error pulling by digest: %s, %v", out, err)
-	}
+	dockerCmd(c, "pull", imageReference)
 	// just in case...
 
 	imageID, err := inspectField(imageReference, "Id")
@@ -490,8 +399,5 @@ func (s *DockerRegistrySuite) TestDeleteImageByIDOnlyPulledByDigest(c *check.C) 
 		c.Fatalf("error inspecting image id: %v", err)
 	}
 
-	cmd = exec.Command(dockerBinary, "rmi", imageID)
-	if _, err := runCommand(cmd); err != nil {
-		c.Fatalf("error deleting image by id: %v", err)
-	}
+	dockerCmd(c, "rmi", imageID)
 }

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -1,91 +1,51 @@
 package main
 
 import (
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestCommitAfterContainerIsDone(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("failed to run container: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	waitCmd := exec.Command(dockerBinary, "wait", cleanedContainerID)
-	if _, _, err = runCommandWithOutput(waitCmd); err != nil {
-		c.Fatalf("error thrown while waiting for container: %s, %v", out, err)
-	}
+	dockerCmd(c, "wait", cleanedContainerID)
 
-	commitCmd := exec.Command(dockerBinary, "commit", cleanedContainerID)
-	out, _, err = runCommandWithOutput(commitCmd)
-	if err != nil {
-		c.Fatalf("failed to commit container to image: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "commit", cleanedContainerID)
 
 	cleanedImageID := strings.TrimSpace(out)
 
-	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedImageID)
-	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
-		c.Fatalf("failed to inspect image: %s, %v", out, err)
-	}
+	dockerCmd(c, "inspect", cleanedImageID)
 }
 
 func (s *DockerSuite) TestCommitWithoutPause(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("failed to run container: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	waitCmd := exec.Command(dockerBinary, "wait", cleanedContainerID)
-	if _, _, err = runCommandWithOutput(waitCmd); err != nil {
-		c.Fatalf("error thrown while waiting for container: %s, %v", out, err)
-	}
+	dockerCmd(c, "wait", cleanedContainerID)
 
-	commitCmd := exec.Command(dockerBinary, "commit", "-p=false", cleanedContainerID)
-	out, _, err = runCommandWithOutput(commitCmd)
-	if err != nil {
-		c.Fatalf("failed to commit container to image: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "commit", "-p=false", cleanedContainerID)
 
 	cleanedImageID := strings.TrimSpace(out)
 
-	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedImageID)
-	if out, _, err = runCommandWithOutput(inspectCmd); err != nil {
-		c.Fatalf("failed to inspect image: %s, %v", out, err)
-	}
+	dockerCmd(c, "inspect", cleanedImageID)
 }
 
 //test commit a paused container should not unpause it after commit
 func (s *DockerSuite) TestCommitPausedContainer(c *check.C) {
 	defer unpauseAllContainers()
-	cmd := exec.Command(dockerBinary, "run", "-i", "-d", "busybox")
-	out, _, _, err := runCommandWithStdoutStderr(cmd)
-	if err != nil {
-		c.Fatalf("failed to run container: %v, output: %q", err, out)
-	}
+	out, _ := dockerCmd(c, "run", "-i", "-d", "busybox")
 
 	cleanedContainerID := strings.TrimSpace(out)
-	cmd = exec.Command(dockerBinary, "pause", cleanedContainerID)
-	out, _, _, err = runCommandWithStdoutStderr(cmd)
-	if err != nil {
-		c.Fatalf("failed to pause container: %v, output: %q", err, out)
-	}
 
-	commitCmd := exec.Command(dockerBinary, "commit", cleanedContainerID)
-	out, _, err = runCommandWithOutput(commitCmd)
-	if err != nil {
-		c.Fatalf("failed to commit container to image: %s, %v", out, err)
-	}
+	dockerCmd(c, "pause", cleanedContainerID)
 
-	out, err = inspectField(cleanedContainerID, "State.Paused")
+	out, _ = dockerCmd(c, "commit", cleanedContainerID)
+
+	out, err := inspectField(cleanedContainerID, "State.Paused")
 	c.Assert(err, check.IsNil)
 	if !strings.Contains(out, "true") {
 		c.Fatalf("commit should not unpause a paused container")
@@ -94,24 +54,13 @@ func (s *DockerSuite) TestCommitPausedContainer(c *check.C) {
 
 func (s *DockerSuite) TestCommitNewFile(c *check.C) {
 
-	cmd := exec.Command(dockerBinary, "run", "--name", "commiter", "busybox", "/bin/sh", "-c", "echo koye > /foo")
-	if _, err := runCommand(cmd); err != nil {
-		c.Fatal(err)
-	}
+	dockerCmd(c, "run", "--name", "commiter", "busybox", "/bin/sh", "-c", "echo koye > /foo")
 
-	cmd = exec.Command(dockerBinary, "commit", "commiter")
-	imageID, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(err)
-	}
+	imageID, _ := dockerCmd(c, "commit", "commiter")
 	imageID = strings.Trim(imageID, "\r\n")
 
-	cmd = exec.Command(dockerBinary, "run", imageID, "cat", "/foo")
+	out, _ := dockerCmd(c, "run", imageID, "cat", "/foo")
 
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(err, out)
-	}
 	if actual := strings.Trim(out, "\r\n"); actual != "koye" {
 		c.Fatalf("expected output koye received %q", actual)
 	}
@@ -120,13 +69,9 @@ func (s *DockerSuite) TestCommitNewFile(c *check.C) {
 
 func (s *DockerSuite) TestCommitHardlink(c *check.C) {
 
-	cmd := exec.Command(dockerBinary, "run", "-t", "--name", "hardlinks", "busybox", "sh", "-c", "touch file1 && ln file1 file2 && ls -di file1 file2")
-	firstOuput, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(err)
-	}
+	firstOutput, _ := dockerCmd(c, "run", "-t", "--name", "hardlinks", "busybox", "sh", "-c", "touch file1 && ln file1 file2 && ls -di file1 file2")
 
-	chunks := strings.Split(strings.TrimSpace(firstOuput), " ")
+	chunks := strings.Split(strings.TrimSpace(firstOutput), " ")
 	inode := chunks[0]
 	found := false
 	for _, chunk := range chunks[1:] {
@@ -139,20 +84,12 @@ func (s *DockerSuite) TestCommitHardlink(c *check.C) {
 		c.Fatalf("Failed to create hardlink in a container. Expected to find %q in %q", inode, chunks[1:])
 	}
 
-	cmd = exec.Command(dockerBinary, "commit", "hardlinks", "hardlinks")
-	imageID, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(imageID, err)
-	}
+	imageID, _ := dockerCmd(c, "commit", "hardlinks", "hardlinks")
 	imageID = strings.Trim(imageID, "\r\n")
 
-	cmd = exec.Command(dockerBinary, "run", "-t", "hardlinks", "ls", "-di", "file1", "file2")
-	secondOuput, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(err)
-	}
+	secondOutput, _ := dockerCmd(c, "run", "-t", "hardlinks", "ls", "-di", "file1", "file2")
 
-	chunks = strings.Split(strings.TrimSpace(secondOuput), " ")
+	chunks = strings.Split(strings.TrimSpace(secondOutput), " ")
 	inode = chunks[0]
 	found = false
 	for _, chunk := range chunks[1:] {
@@ -169,56 +106,31 @@ func (s *DockerSuite) TestCommitHardlink(c *check.C) {
 
 func (s *DockerSuite) TestCommitTTY(c *check.C) {
 
-	cmd := exec.Command(dockerBinary, "run", "-t", "--name", "tty", "busybox", "/bin/ls")
-	if _, err := runCommand(cmd); err != nil {
-		c.Fatal(err)
-	}
+	dockerCmd(c, "run", "-t", "--name", "tty", "busybox", "/bin/ls")
 
-	cmd = exec.Command(dockerBinary, "commit", "tty", "ttytest")
-	imageID, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(err)
-	}
+	imageID, _ := dockerCmd(c, "commit", "tty", "ttytest")
 	imageID = strings.Trim(imageID, "\r\n")
 
-	cmd = exec.Command(dockerBinary, "run", "ttytest", "/bin/ls")
-	if _, err := runCommand(cmd); err != nil {
-		c.Fatal(err)
-	}
+	dockerCmd(c, "run", "ttytest", "/bin/ls")
 
 }
 
 func (s *DockerSuite) TestCommitWithHostBindMount(c *check.C) {
 
-	cmd := exec.Command(dockerBinary, "run", "--name", "bind-commit", "-v", "/dev/null:/winning", "busybox", "true")
-	if _, err := runCommand(cmd); err != nil {
-		c.Fatal(err)
-	}
+	dockerCmd(c, "run", "--name", "bind-commit", "-v", "/dev/null:/winning", "busybox", "true")
 
-	cmd = exec.Command(dockerBinary, "commit", "bind-commit", "bindtest")
-	imageID, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(imageID, err)
-	}
-
+	imageID, _ := dockerCmd(c, "commit", "bind-commit", "bindtest")
 	imageID = strings.Trim(imageID, "\r\n")
 
-	cmd = exec.Command(dockerBinary, "run", "bindtest", "true")
-
-	if _, err := runCommand(cmd); err != nil {
-		c.Fatal(err)
-	}
+	dockerCmd(c, "run", "bindtest", "true")
 
 }
 
 func (s *DockerSuite) TestCommitChange(c *check.C) {
 
-	cmd := exec.Command(dockerBinary, "run", "--name", "test", "busybox", "true")
-	if _, err := runCommand(cmd); err != nil {
-		c.Fatal(err)
-	}
+	dockerCmd(c, "run", "--name", "test", "busybox", "true")
 
-	cmd = exec.Command(dockerBinary, "commit",
+	imageID, _ := dockerCmd(c, "commit",
 		"--change", "EXPOSE 8080",
 		"--change", "ENV DEBUG true",
 		"--change", "ENV test 1",
@@ -231,11 +143,7 @@ func (s *DockerSuite) TestCommitChange(c *check.C) {
 		"--change", "VOLUME /var/lib/docker",
 		"--change", "ONBUILD /usr/local/bin/python-build --dir /app/src",
 		"test", "test-commit")
-	imageId, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(imageId, err)
-	}
-	imageId = strings.Trim(imageId, "\r\n")
+	imageID = strings.Trim(imageID, "\r\n")
 
 	expected := map[string]string{
 		"Config.ExposedPorts": "map[8080/tcp:{}]",
@@ -250,7 +158,7 @@ func (s *DockerSuite) TestCommitChange(c *check.C) {
 	}
 
 	for conf, value := range expected {
-		res, err := inspectField(imageId, conf)
+		res, err := inspectField(imageID, conf)
 		c.Assert(err, check.IsNil)
 		if res != value {
 			c.Errorf("%s('%s'), expected %s", conf, res, value)

--- a/integration-cli/docker_cli_config_test.go
+++ b/integration-cli/docker_cli_config_test.go
@@ -69,17 +69,16 @@ func (s *DockerSuite) TestConfigDir(c *check.C) {
 	cDir, _ := ioutil.TempDir("", "fake-home")
 
 	// First make sure pointing to empty dir doesn't generate an error
-	cmd := exec.Command(dockerBinary, "--config", cDir, "ps")
-	out, rc, err := runCommandWithOutput(cmd)
+	out, rc := dockerCmd(c, "--config", cDir, "ps")
 
-	if rc != 0 || err != nil {
-		c.Fatalf("ps1 didn't work:\nrc:%d\nout%s\nerr:%v", rc, out, err)
+	if rc != 0 {
+		c.Fatalf("ps1 didn't work:\nrc:%d\nout%s", rc, out)
 	}
 
 	// Test with env var too
-	cmd = exec.Command(dockerBinary, "ps")
+	cmd := exec.Command(dockerBinary, "ps")
 	cmd.Env = append(os.Environ(), "DOCKER_CONFIG="+cDir)
-	out, rc, err = runCommandWithOutput(cmd)
+	out, rc, err := runCommandWithOutput(cmd)
 
 	if rc != 0 || err != nil {
 		c.Fatalf("ps2 didn't work:\nrc:%d\nout%s\nerr:%v", rc, out, err)

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -61,7 +61,7 @@ func (s *DockerSuite) TestCpGarbagePath(c *check.C) {
 
 	path := path.Join("../../../../../../../../../../../../", cpFullPath)
 
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":"+path, tmpdir)
+	dockerCmd(c, "cp", cleanedContainerID+":"+path, tmpdir)
 
 	file, _ := os.Open(tmpname)
 	defer file.Close()
@@ -126,7 +126,7 @@ func (s *DockerSuite) TestCpRelativePath(c *check.C) {
 		c.Fatalf("path %s was assumed to be an absolute path", cpFullPath)
 	}
 
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":"+relPath, tmpdir)
+	dockerCmd(c, "cp", cleanedContainerID+":"+relPath, tmpdir)
 
 	file, _ := os.Open(tmpname)
 	defer file.Close()
@@ -184,7 +184,7 @@ func (s *DockerSuite) TestCpAbsolutePath(c *check.C) {
 
 	path := cpFullPath
 
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":"+path, tmpdir)
+	dockerCmd(c, "cp", cleanedContainerID+":"+path, tmpdir)
 
 	file, _ := os.Open(tmpname)
 	defer file.Close()
@@ -243,7 +243,7 @@ func (s *DockerSuite) TestCpAbsoluteSymlink(c *check.C) {
 
 	path := path.Join("/", "container_path")
 
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":"+path, tmpdir)
+	dockerCmd(c, "cp", cleanedContainerID+":"+path, tmpdir)
 
 	file, _ := os.Open(tmpname)
 	defer file.Close()
@@ -302,7 +302,7 @@ func (s *DockerSuite) TestCpSymlinkComponent(c *check.C) {
 
 	path := path.Join("/", "container_path", cpTestName)
 
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":"+path, tmpdir)
+	dockerCmd(c, "cp", cleanedContainerID+":"+path, tmpdir)
 
 	file, _ := os.Open(tmpname)
 	defer file.Close()
@@ -380,7 +380,7 @@ func (s *DockerSuite) TestCpSpecialFiles(c *check.C) {
 	}
 
 	// Copy actual /etc/resolv.conf
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":/etc/resolv.conf", outDir)
+	dockerCmd(c, "cp", cleanedContainerID+":/etc/resolv.conf", outDir)
 
 	expected, err := ioutil.ReadFile("/var/lib/docker/containers/" + cleanedContainerID + "/resolv.conf")
 	actual, err := ioutil.ReadFile(outDir + "/resolv.conf")
@@ -390,7 +390,7 @@ func (s *DockerSuite) TestCpSpecialFiles(c *check.C) {
 	}
 
 	// Copy actual /etc/hosts
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":/etc/hosts", outDir)
+	dockerCmd(c, "cp", cleanedContainerID+":/etc/hosts", outDir)
 
 	expected, err = ioutil.ReadFile("/var/lib/docker/containers/" + cleanedContainerID + "/hosts")
 	actual, err = ioutil.ReadFile(outDir + "/hosts")
@@ -400,7 +400,7 @@ func (s *DockerSuite) TestCpSpecialFiles(c *check.C) {
 	}
 
 	// Copy actual /etc/resolv.conf
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":/etc/hostname", outDir)
+	dockerCmd(c, "cp", cleanedContainerID+":/etc/hostname", outDir)
 
 	expected, err = ioutil.ReadFile("/var/lib/docker/containers/" + cleanedContainerID + "/hostname")
 	actual, err = ioutil.ReadFile(outDir + "/hostname")
@@ -442,7 +442,7 @@ func (s *DockerSuite) TestCpVolumePath(c *check.C) {
 	}
 
 	// Copy actual volume path
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":/foo", outDir)
+	dockerCmd(c, "cp", cleanedContainerID+":/foo", outDir)
 
 	stat, err := os.Stat(outDir + "/foo")
 	if err != nil {
@@ -460,7 +460,7 @@ func (s *DockerSuite) TestCpVolumePath(c *check.C) {
 	}
 
 	// Copy file nested in volume
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":/foo/bar", outDir)
+	dockerCmd(c, "cp", cleanedContainerID+":/foo/bar", outDir)
 
 	stat, err = os.Stat(outDir + "/bar")
 	if err != nil {
@@ -471,7 +471,7 @@ func (s *DockerSuite) TestCpVolumePath(c *check.C) {
 	}
 
 	// Copy Bind-mounted dir
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":/baz", outDir)
+	dockerCmd(c, "cp", cleanedContainerID+":/baz", outDir)
 	stat, err = os.Stat(outDir + "/baz")
 	if err != nil {
 		c.Fatal(err)
@@ -481,7 +481,7 @@ func (s *DockerSuite) TestCpVolumePath(c *check.C) {
 	}
 
 	// Copy file nested in bind-mounted dir
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":/baz/test", outDir)
+	dockerCmd(c, "cp", cleanedContainerID+":/baz/test", outDir)
 	fb, err := ioutil.ReadFile(outDir + "/baz/test")
 	if err != nil {
 		c.Fatal(err)
@@ -495,7 +495,7 @@ func (s *DockerSuite) TestCpVolumePath(c *check.C) {
 	}
 
 	// Copy bind-mounted file
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":/test", outDir)
+	dockerCmd(c, "cp", cleanedContainerID+":/test", outDir)
 	fb, err = ioutil.ReadFile(outDir + "/test")
 	if err != nil {
 		c.Fatal(err)
@@ -536,7 +536,7 @@ func (s *DockerSuite) TestCpToDot(c *check.C) {
 	if err := os.Chdir(tmpdir); err != nil {
 		c.Fatal(err)
 	}
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":/test", ".")
+	dockerCmd(c, "cp", cleanedContainerID+":/test", ".")
 	content, err := ioutil.ReadFile("./test")
 	if string(content) != "lololol\n" {
 		c.Fatalf("Wrong content in copied file %q, should be %q", content, "lololol\n")
@@ -589,7 +589,7 @@ func (s *DockerSuite) TestCpNameHasColon(c *check.C) {
 		c.Fatal(err)
 	}
 	defer os.RemoveAll(tmpdir)
-	_, _ = dockerCmd(c, "cp", cleanedContainerID+":/te:s:t", tmpdir)
+	dockerCmd(c, "cp", cleanedContainerID+":/te:s:t", tmpdir)
 	content, err := ioutil.ReadFile(tmpdir + "/te:s:t")
 	if string(content) != "lololol\n" {
 		c.Fatalf("Wrong content in copied file %q, should be %q", content, "lololol\n")
@@ -598,17 +598,12 @@ func (s *DockerSuite) TestCpNameHasColon(c *check.C) {
 
 func (s *DockerSuite) TestCopyAndRestart(c *check.C) {
 	expectedMsg := "hello"
-	out, err := exec.Command(dockerBinary, "run", "-d", "busybox", "echo", expectedMsg).CombinedOutput()
-	if err != nil {
-		c.Fatal(string(out), err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "echo", expectedMsg)
 	id := strings.TrimSpace(string(out))
 
-	if out, err = exec.Command(dockerBinary, "wait", id).CombinedOutput(); err != nil {
-		c.Fatalf("unable to wait for container: %s", err)
-	}
+	out, _ = dockerCmd(c, "wait", id)
 
-	status := strings.TrimSpace(string(out))
+	status := strings.TrimSpace(out)
 	if status != "0" {
 		c.Fatalf("container exited with status %s", status)
 	}
@@ -619,33 +614,23 @@ func (s *DockerSuite) TestCopyAndRestart(c *check.C) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	if _, err = exec.Command(dockerBinary, "cp", fmt.Sprintf("%s:/etc/issue", id), tmpDir).CombinedOutput(); err != nil {
-		c.Fatalf("unable to copy from busybox container: %s", err)
-	}
+	dockerCmd(c, "cp", fmt.Sprintf("%s:/etc/issue", id), tmpDir)
 
-	if out, err = exec.Command(dockerBinary, "start", "-a", id).CombinedOutput(); err != nil {
-		c.Fatalf("unable to start busybox container after copy: %s - %s", err, out)
-	}
+	out, _ = dockerCmd(c, "start", "-a", id)
 
-	msg := strings.TrimSpace(string(out))
+	msg := strings.TrimSpace(out)
 	if msg != expectedMsg {
 		c.Fatalf("expected %q but got %q", expectedMsg, msg)
 	}
 }
 
 func (s *DockerSuite) TestCopyCreatedContainer(c *check.C) {
-	out, err := exec.Command(dockerBinary, "create", "--name", "test_cp", "-v", "/test", "busybox").CombinedOutput()
-	if err != nil {
-		c.Fatalf(string(out), err)
-	}
+	dockerCmd(c, "create", "--name", "test_cp", "-v", "/test", "busybox")
 
 	tmpDir, err := ioutil.TempDir("", "test")
 	if err != nil {
 		c.Fatalf("unable to make temporary directory: %s", err)
 	}
 	defer os.RemoveAll(tmpDir)
-	out, err = exec.Command(dockerBinary, "cp", "test_cp:/bin/sh", tmpDir).CombinedOutput()
-	if err != nil {
-		c.Fatalf(string(out), err)
-	}
+	dockerCmd(c, "cp", "test_cp:/bin/sh", tmpDir)
 }

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"reflect"
 	"strings"
 	"time"
@@ -15,19 +14,11 @@ import (
 
 // Make sure we can create a simple container with some args
 func (s *DockerSuite) TestCreateArgs(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "create", "busybox", "command", "arg1", "arg2", "arg with space")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ := dockerCmd(c, "create", "busybox", "command", "arg1", "arg2", "arg with space")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	if err != nil {
-		c.Fatalf("out should've been a container id: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "inspect", cleanedContainerID)
 
 	containers := []struct {
 		ID      string
@@ -65,19 +56,11 @@ func (s *DockerSuite) TestCreateArgs(c *check.C) {
 // Make sure we can set hostconfig options too
 func (s *DockerSuite) TestCreateHostConfig(c *check.C) {
 
-	runCmd := exec.Command(dockerBinary, "create", "-P", "busybox", "echo")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ := dockerCmd(c, "create", "-P", "busybox", "echo")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	if err != nil {
-		c.Fatalf("out should've been a container id: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "inspect", cleanedContainerID)
 
 	containers := []struct {
 		HostConfig *struct {
@@ -104,19 +87,11 @@ func (s *DockerSuite) TestCreateHostConfig(c *check.C) {
 
 func (s *DockerSuite) TestCreateWithPortRange(c *check.C) {
 
-	runCmd := exec.Command(dockerBinary, "create", "-p", "3300-3303:3300-3303/tcp", "busybox", "echo")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ := dockerCmd(c, "create", "-p", "3300-3303:3300-3303/tcp", "busybox", "echo")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	if err != nil {
-		c.Fatalf("out should've been a container id: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "inspect", cleanedContainerID)
 
 	containers := []struct {
 		HostConfig *struct {
@@ -151,19 +126,11 @@ func (s *DockerSuite) TestCreateWithPortRange(c *check.C) {
 
 func (s *DockerSuite) TestCreateWithiLargePortRange(c *check.C) {
 
-	runCmd := exec.Command(dockerBinary, "create", "-p", "1-65535:1-65535/tcp", "busybox", "echo")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ := dockerCmd(c, "create", "-p", "1-65535:1-65535/tcp", "busybox", "echo")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	inspectCmd := exec.Command(dockerBinary, "inspect", cleanedContainerID)
-	out, _, err = runCommandWithOutput(inspectCmd)
-	if err != nil {
-		c.Fatalf("out should've been a container id: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "inspect", cleanedContainerID)
 
 	containers := []struct {
 		HostConfig *struct {
@@ -199,19 +166,11 @@ func (s *DockerSuite) TestCreateWithiLargePortRange(c *check.C) {
 // "test123" should be printed by docker create + start
 func (s *DockerSuite) TestCreateEchoStdout(c *check.C) {
 
-	runCmd := exec.Command(dockerBinary, "create", "busybox", "echo", "test123")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ := dockerCmd(c, "create", "busybox", "echo", "test123")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	runCmd = exec.Command(dockerBinary, "start", "-ai", cleanedContainerID)
-	out, _, _, err = runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ = dockerCmd(c, "start", "-ai", cleanedContainerID)
 
 	if out != "test123\n" {
 		c.Errorf("container should've printed 'test123', got %q", out)
@@ -223,9 +182,8 @@ func (s *DockerSuite) TestCreateVolumesCreated(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
 	name := "test_create_volume"
-	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "create", "--name", name, "-v", "/foo", "busybox")); err != nil {
-		c.Fatal(out, err)
-	}
+	dockerCmd(c, "create", "--name", name, "-v", "/foo", "busybox")
+
 	dir, err := inspectFieldMap(name, "Volumes", "/foo")
 	if err != nil {
 		c.Fatalf("Error getting volume host path: %q", err)
@@ -243,9 +201,7 @@ func (s *DockerSuite) TestCreateVolumesCreated(c *check.C) {
 func (s *DockerSuite) TestCreateLabels(c *check.C) {
 	name := "test_create_labels"
 	expected := map[string]string{"k1": "v1", "k2": "v2"}
-	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "create", "--name", name, "-l", "k1=v1", "--label", "k2=v2", "busybox")); err != nil {
-		c.Fatal(out, err)
-	}
+	dockerCmd(c, "create", "--name", name, "-l", "k1=v1", "--label", "k2=v2", "busybox")
 
 	actual := make(map[string]string)
 	err := inspectFieldAndMarshall(name, "Config.Labels", &actual)
@@ -270,9 +226,7 @@ func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
 
 	name := "test_create_labels_from_image"
 	expected := map[string]string{"k2": "x", "k3": "v3"}
-	if out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "create", "--name", name, "-l", "k2=x", "--label", "k3=v3", imageName)); err != nil {
-		c.Fatal(out, err)
-	}
+	dockerCmd(c, "create", "--name", name, "-l", "k2=x", "--label", "k3=v3", imageName)
 
 	actual := make(map[string]string)
 	err = inspectFieldAndMarshall(name, "Config.Labels", &actual)
@@ -297,47 +251,23 @@ func (s *DockerSuite) TestCreateRM(c *check.C) {
 	// "Created" state, and has ever been run. Test "rm -f" too.
 
 	// create a container
-	createCmd := exec.Command(dockerBinary, "create", "busybox")
-	out, _, err := runCommandWithOutput(createCmd)
-	if err != nil {
-		c.Fatalf("Failed to create container:%s\n%s", out, err)
-	}
+	out, _ := dockerCmd(c, "create", "busybox")
 	cID := strings.TrimSpace(out)
 
-	rmCmd := exec.Command(dockerBinary, "rm", cID)
-	out, _, err = runCommandWithOutput(rmCmd)
-	if err != nil {
-		c.Fatalf("Failed to rm container:%s\n%s", out, err)
-	}
+	dockerCmd(c, "rm", cID)
 
 	// Now do it again so we can "rm -f" this time
-	createCmd = exec.Command(dockerBinary, "create", "busybox")
-	out, _, err = runCommandWithOutput(createCmd)
-	if err != nil {
-		c.Fatalf("Failed to create 2nd container:%s\n%s", out, err)
-	}
+	out, _ = dockerCmd(c, "create", "busybox")
 
 	cID = strings.TrimSpace(out)
-	rmCmd = exec.Command(dockerBinary, "rm", "-f", cID)
-	out, _, err = runCommandWithOutput(rmCmd)
-	if err != nil {
-		c.Fatalf("Failed to rm -f container:%s\n%s", out, err)
-	}
+	dockerCmd(c, "rm", "-f", cID)
 }
 
 func (s *DockerSuite) TestCreateModeIpcContainer(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
-	cmd := exec.Command(dockerBinary, "create", "busybox")
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(err, out)
-	}
+	out, _ := dockerCmd(c, "create", "busybox")
 	id := strings.TrimSpace(out)
 
-	cmd = exec.Command(dockerBinary, "create", fmt.Sprintf("--ipc=container:%s", id), "busybox")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("Create container with ipc mode container should success with non running container: %s\n%s", out, err)
-	}
+	dockerCmd(c, "create", fmt.Sprintf("--ipc=container:%s", id), "busybox")
 }

--- a/integration-cli/docker_cli_pause_test.go
+++ b/integration-cli/docker_cli_pause_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
@@ -27,8 +26,7 @@ func (s *DockerSuite) TestPause(c *check.C) {
 
 	dockerCmd(c, "unpause", name)
 
-	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
-	out, _, _ = runCommandWithOutput(eventsCmd)
+	out, _ = dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	events := strings.Split(out, "\n")
 	if len(events) <= 1 {
 		c.Fatalf("Missing expected event")
@@ -69,8 +67,7 @@ func (s *DockerSuite) TestPauseMultipleContainers(c *check.C) {
 
 	dockerCmd(c, append([]string{"unpause"}, containers...)...)
 
-	eventsCmd := exec.Command(dockerBinary, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
-	out, _, _ = runCommandWithOutput(eventsCmd)
+	out, _ = dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	events := strings.Split(out, "\n")
 	if len(events) <= len(containers)*3-2 {
 		c.Fatalf("Missing expected event")

--- a/integration-cli/docker_cli_port_test.go
+++ b/integration-cli/docker_cli_port_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
 	"regexp"
 	"sort"
 	"strings"
@@ -13,64 +12,37 @@ import (
 func (s *DockerSuite) TestPortList(c *check.C) {
 
 	// one port
-	runCmd := exec.Command(dockerBinary, "run", "-d", "-p", "9876:80", "busybox", "top")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "-p", "9876:80", "busybox", "top")
 	firstID := strings.TrimSpace(out)
 
-	runCmd = exec.Command(dockerBinary, "port", firstID, "80")
-	out, _, err = runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ = dockerCmd(c, "port", firstID, "80")
 
 	if !assertPortList(c, out, []string{"0.0.0.0:9876"}) {
 		c.Error("Port list is not correct")
 	}
 
-	runCmd = exec.Command(dockerBinary, "port", firstID)
-	out, _, err = runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ = dockerCmd(c, "port", firstID)
 
 	if !assertPortList(c, out, []string{"80/tcp -> 0.0.0.0:9876"}) {
 		c.Error("Port list is not correct")
 	}
-	runCmd = exec.Command(dockerBinary, "rm", "-f", firstID)
-	if out, _, err = runCommandWithOutput(runCmd); err != nil {
-		c.Fatal(out, err)
-	}
+	dockerCmd(c, "rm", "-f", firstID)
 
 	// three port
-	runCmd = exec.Command(dockerBinary, "run", "-d",
+	out, _ = dockerCmd(c, "run", "-d",
 		"-p", "9876:80",
 		"-p", "9877:81",
 		"-p", "9878:82",
 		"busybox", "top")
-	out, _, err = runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
 	ID := strings.TrimSpace(out)
 
-	runCmd = exec.Command(dockerBinary, "port", ID, "80")
-	out, _, err = runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ = dockerCmd(c, "port", ID, "80")
 
 	if !assertPortList(c, out, []string{"0.0.0.0:9876"}) {
 		c.Error("Port list is not correct")
 	}
 
-	runCmd = exec.Command(dockerBinary, "port", ID)
-	out, _, err = runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ = dockerCmd(c, "port", ID)
 
 	if !assertPortList(c, out, []string{
 		"80/tcp -> 0.0.0.0:9876",
@@ -78,40 +50,24 @@ func (s *DockerSuite) TestPortList(c *check.C) {
 		"82/tcp -> 0.0.0.0:9878"}) {
 		c.Error("Port list is not correct")
 	}
-	runCmd = exec.Command(dockerBinary, "rm", "-f", ID)
-	out, _, err = runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	dockerCmd(c, "rm", "-f", ID)
 
 	// more and one port mapped to the same container port
-	runCmd = exec.Command(dockerBinary, "run", "-d",
+	out, _ = dockerCmd(c, "run", "-d",
 		"-p", "9876:80",
 		"-p", "9999:80",
 		"-p", "9877:81",
 		"-p", "9878:82",
 		"busybox", "top")
-	out, _, err = runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
 	ID = strings.TrimSpace(out)
 
-	runCmd = exec.Command(dockerBinary, "port", ID, "80")
-	out, _, err = runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ = dockerCmd(c, "port", ID, "80")
 
 	if !assertPortList(c, out, []string{"0.0.0.0:9876", "0.0.0.0:9999"}) {
 		c.Error("Port list is not correct")
 	}
 
-	runCmd = exec.Command(dockerBinary, "port", ID)
-	out, _, err = runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ = dockerCmd(c, "port", ID)
 
 	if !assertPortList(c, out, []string{
 		"80/tcp -> 0.0.0.0:9876",
@@ -120,10 +76,7 @@ func (s *DockerSuite) TestPortList(c *check.C) {
 		"82/tcp -> 0.0.0.0:9878"}) {
 		c.Error("Port list is not correct\n", out)
 	}
-	runCmd = exec.Command(dockerBinary, "rm", "-f", ID)
-	if out, _, err = runCommandWithOutput(runCmd); err != nil {
-		c.Fatal(out, err)
-	}
+	dockerCmd(c, "rm", "-f", ID)
 
 }
 
@@ -148,9 +101,7 @@ func assertPortList(c *check.C, out string, expected []string) bool {
 }
 
 func stopRemoveContainer(id string, c *check.C) {
-	runCmd := exec.Command(dockerBinary, "rm", "-f", id)
-	_, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd(c, "rm", "-f", id)
 }
 
 func (s *DockerSuite) TestUnpublishedPortsInPsOutput(c *check.C) {
@@ -159,31 +110,23 @@ func (s *DockerSuite) TestUnpublishedPortsInPsOutput(c *check.C) {
 	port2 := 443
 	expose1 := fmt.Sprintf("--expose=%d", port1)
 	expose2 := fmt.Sprintf("--expose=%d", port2)
-	runCmd := exec.Command(dockerBinary, "run", "-d", expose1, expose2, "busybox", "sleep", "5")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd(c, "run", "-d", expose1, expose2, "busybox", "sleep", "5")
 
 	// Check docker ps o/p for last created container reports the unpublished ports
 	unpPort1 := fmt.Sprintf("%d/tcp", port1)
 	unpPort2 := fmt.Sprintf("%d/tcp", port2)
-	runCmd = exec.Command(dockerBinary, "ps", "-n=1")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	out, _ := dockerCmd(c, "ps", "-n=1")
 	if !strings.Contains(out, unpPort1) || !strings.Contains(out, unpPort2) {
 		c.Errorf("Missing unpublished ports(s) (%s, %s) in docker ps output: %s", unpPort1, unpPort2, out)
 	}
 
 	// Run the container forcing to publish the exposed ports
-	runCmd = exec.Command(dockerBinary, "run", "-d", "-P", expose1, expose2, "busybox", "sleep", "5")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd(c, "run", "-d", "-P", expose1, expose2, "busybox", "sleep", "5")
 
 	// Check docker ps o/p for last created container reports the exposed ports in the port bindings
 	expBndRegx1 := regexp.MustCompile(`0.0.0.0:\d\d\d\d\d->` + unpPort1)
 	expBndRegx2 := regexp.MustCompile(`0.0.0.0:\d\d\d\d\d->` + unpPort2)
-	runCmd = exec.Command(dockerBinary, "ps", "-n=1")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	out, _ = dockerCmd(c, "ps", "-n=1")
 	if !expBndRegx1.MatchString(out) || !expBndRegx2.MatchString(out) {
 		c.Errorf("Cannot find expected port binding ports(s) (0.0.0.0:xxxxx->%s, 0.0.0.0:xxxxx->%s) in docker ps output:\n%s",
 			unpPort1, unpPort2, out)
@@ -193,17 +136,13 @@ func (s *DockerSuite) TestUnpublishedPortsInPsOutput(c *check.C) {
 	offset := 10000
 	pFlag1 := fmt.Sprintf("%d:%d", offset+port1, port1)
 	pFlag2 := fmt.Sprintf("%d:%d", offset+port2, port2)
-	runCmd = exec.Command(dockerBinary, "run", "-d", "-p", pFlag1, "-p", pFlag2, expose1, expose2, "busybox", "sleep", "5")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	out, _ = dockerCmd(c, "run", "-d", "-p", pFlag1, "-p", pFlag2, expose1, expose2, "busybox", "sleep", "5")
 	id := strings.TrimSpace(out)
 
 	// Check docker ps o/p for last created container reports the specified port mappings
 	expBnd1 := fmt.Sprintf("0.0.0.0:%d->%s", offset+port1, unpPort1)
 	expBnd2 := fmt.Sprintf("0.0.0.0:%d->%s", offset+port2, unpPort2)
-	runCmd = exec.Command(dockerBinary, "ps", "-n=1")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	out, _ = dockerCmd(c, "ps", "-n=1")
 	if !strings.Contains(out, expBnd1) || !strings.Contains(out, expBnd2) {
 		c.Errorf("Cannot find expected port binding(s) (%s, %s) in docker ps output: %s", expBnd1, expBnd2, out)
 	}
@@ -211,15 +150,11 @@ func (s *DockerSuite) TestUnpublishedPortsInPsOutput(c *check.C) {
 	stopRemoveContainer(id, c)
 
 	// Run the container with explicit port bindings and no exposed ports
-	runCmd = exec.Command(dockerBinary, "run", "-d", "-p", pFlag1, "-p", pFlag2, "busybox", "sleep", "5")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	out, _ = dockerCmd(c, "run", "-d", "-p", pFlag1, "-p", pFlag2, "busybox", "sleep", "5")
 	id = strings.TrimSpace(out)
 
 	// Check docker ps o/p for last created container reports the specified port mappings
-	runCmd = exec.Command(dockerBinary, "ps", "-n=1")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	out, _ = dockerCmd(c, "ps", "-n=1")
 	if !strings.Contains(out, expBnd1) || !strings.Contains(out, expBnd2) {
 		c.Errorf("Cannot find expected port binding(s) (%s, %s) in docker ps output: %s", expBnd1, expBnd2, out)
 	}
@@ -227,14 +162,10 @@ func (s *DockerSuite) TestUnpublishedPortsInPsOutput(c *check.C) {
 	stopRemoveContainer(id, c)
 
 	// Run the container with one unpublished exposed port and one explicit port binding
-	runCmd = exec.Command(dockerBinary, "run", "-d", expose1, "-p", pFlag2, "busybox", "sleep", "5")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd(c, "run", "-d", expose1, "-p", pFlag2, "busybox", "sleep", "5")
 
 	// Check docker ps o/p for last created container reports the specified unpublished port and port mapping
-	runCmd = exec.Command(dockerBinary, "ps", "-n=1")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	out, _ = dockerCmd(c, "ps", "-n=1")
 	if !strings.Contains(out, unpPort1) || !strings.Contains(out, expBnd2) {
 		c.Errorf("Missing unpublished ports or port binding (%s, %s) in docker ps output: %s", unpPort1, expBnd2, out)
 	}

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -550,6 +550,10 @@ func pullImageIfNotExist(image string) (err error) {
 	return
 }
 
+func dockerCmdWithError(c *check.C, args ...string) (string, int, error) {
+	return runCommandWithOutput(exec.Command(dockerBinary, args...))
+}
+
 func dockerCmd(c *check.C, args ...string) (string, int) {
 	out, status, err := runCommandWithOutput(exec.Command(dockerBinary, args...))
 	c.Assert(err, check.IsNil, check.Commentf("%q failed with errors: %s, %v", strings.Join(args, " "), out, err))


### PR DESCRIPTION
Part of #14603, this refactor the following integration-cli test files (and api too) to use as much as possible `dockerCmd`.
- integration-cli/docker_cli_attach_test.go
- integration-cli/docker_cli_attach_unix_test.go
- integration-cli/docker_cli_build_test.go
- integration-cli/docker_cli_build_unix_test.go
- integration-cli/docker_cli_by_digest_test.go
- integration-cli/docker_cli_commit_test.go
- integration-cli/docker_cli_config_test.go
- integration-cli/docker_cli_cp_test.go
- integration-cli/docker_cli_create_test.go
- integration-cli/docker_cli_pause_test.go
- integration-cli/docker_cli_port_test.go
- integration-cli/docker_cli_port_unix_test.go
- integration-cli/docker_cli_proxy_test.go
- integration-cli/docker_cli_ps_test.go
- integration-cli/docker_cli_pull_test.go
- integration-cli/docker_cli_push_test.go
- integration-cli/docker_api_attach_test.go
- integration-cli/docker_api_containers_test.go
- integration-cli/docker_api_events_test.go
- integration-cli/docker_api_exec_resize_test.go
- integration-cli/docker_api_exec_test.go
- integration-cli/docker_api_images_test.go
- integration-cli/docker_api_info_test.go

I think I got it all on my part of the issue :sweat_smile:. Depending on when #14623 will be ready and merged, some rebasing on my part might be needed.
