### PR TITLE
Update docker-py commit to current master (~1.3.1 release)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -131,7 +131,7 @@ RUN set -x \
 	&& rm -rf "$GOPATH"
 
 # Get the "docker-py" source so we can run their integration tests
-ENV DOCKER_PY_COMMIT 91985b239764fe54714fa0a93d52aa362357d251
+ENV DOCKER_PY_COMMIT 8a87001d09852058f08a807ab6e8491d57ca1e88
 RUN git clone https://github.com/docker/docker-py.git /docker-py \
 	&& cd /docker-py \
 	&& git checkout -q $DOCKER_PY_COMMIT

--- a/hack/make/test-docker-py
+++ b/hack/make/test-docker-py
@@ -12,7 +12,7 @@ set -e
 	}
 
 	# exporting PYTHONPATH to import "docker" from our local docker-py
-	test_env PYTHONPATH="$dockerPy" python "$dockerPy/tests/integration_test.py"
+	test_env PYTHONPATH="$dockerPy" NOT_ON_HOST=true python "$dockerPy/tests/integration_test.py"
 
 	bundle .integration-daemon-stop
 ) 2>&1 | tee -a "$DEST/test.log"


### PR DESCRIPTION
The docker-py commit used in the standard `Dockerfile` is from Feb. 2015
and is out of date with the current API level and since then has included
fixes for items like the new docker cli config location as well as registry
v2 changes/API responses as well.

Docker-DCO-1.1-Signed-off-by: Phil Estes estesp@linux.vnet.ibm.com (github: estesp)
