### PR TITLE
pkg/pubsub: Don't use time.After if there is no timeout

### DIFF
--- a/pkg/pubsub/publisher.go
+++ b/pkg/pubsub/publisher.go
@@ -58,9 +58,16 @@ func (p *Publisher) Publish(v interface{}) {
 	p.m.RLock()
 	for sub := range p.subscribers {
 		// send under a select as to not block if the receiver is unavailable
+		if p.timeout > 0 {
+			select {
+			case sub <- v:
+			case <-time.After(p.timeout):
+			}
+			continue
+		}
 		select {
 		case sub <- v:
-		case <-time.After(p.timeout):
+		default:
 		}
 	}
 	p.m.RUnlock()

--- a/pkg/pubsub/publisher.go
+++ b/pkg/pubsub/publisher.go
@@ -19,6 +19,8 @@ func NewPublisher(publishTimeout time.Duration, buffer int) *Publisher {
 
 type subscriber chan interface{}
 
+// Publisher is basic pub/sub structure. Allows to send events and subscribe
+// to them. Can be safely used from multiple goroutines.
 type Publisher struct {
 	m           sync.RWMutex
 	buffer      int


### PR DESCRIPTION
Here is benchmark comparison in case when deny condition is only buffer size of channel(timeout disabled):

```
benchmark           old ns/op      new ns/op      delta
BenchmarkPubSub     1045873090     1003671134     -4.04%

benchmark           old allocs     new allocs     delta
BenchmarkPubSub     151053         1053           -99.30%

benchmark           old bytes     new bytes     delta
BenchmarkPubSub     9619360       19360         -99.80%
```

Also I added docstring to main datastructure of package.
