### PR TITLE
Document that load supports compressed tarballs.

### DIFF
--- a/docs/reference/commandline/load.md
+++ b/docs/reference/commandline/load.md
@@ -15,14 +15,14 @@ weight=1
 
     Load an image from a tar archive or STDIN
 
-      -i, --input=""     Read from a tar archive file, instead of STDIN
+      -i, --input=""     Read from a tar archive file, instead of STDIN. The tarball may be compressed with gzip, bzip, or xz
 
 Loads a tarred repository from a file or the standard input stream.
 Restores both images and tags.
 
     $ docker images
     REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
-    $ docker load < busybox.tar
+    $ docker load < busybox.tar.gz
     $ docker images
     REPOSITORY          TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
     busybox             latest              769b9341d937        7 weeks ago         2.489 MB


### PR DESCRIPTION
`docker load` supports tarballs in uncompressed, gzip, bzip, and xz compressions.

As per
https://github.com/docker/docker/blob/ecdbf868842f702e2b824aa1e11097809d48a659/pkg/archive/archive.go#L96

Signed-off-by: Andy Rothfusz github@developersupport.net
