### PR TITLE
Fix build with resource limit which system not support.

### DIFF
--- a/api/server/container.go
+++ b/api/server/container.go
@@ -399,13 +399,13 @@ func (s *Server) postContainersCreate(version version.Version, w http.ResponseWr
 	}
 	adjustCPUShares := version.LessThan("1.19")
 
-	containerID, warnings, err := s.daemon.ContainerCreate(name, config, hostConfig, adjustCPUShares)
+	container, warnings, err := s.daemon.ContainerCreate(name, config, hostConfig, adjustCPUShares)
 	if err != nil {
 		return err
 	}
 
 	return writeJSON(w, http.StatusCreated, &types.ContainerCreateResponse{
-		ID:       containerID,
+		ID:       container.ID,
 		Warnings: warnings,
 	})
 }

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -230,7 +230,7 @@ func (b *builder) runContextCommand(args []string, allowRemote bool, allowDecomp
 		return nil
 	}
 
-	container, _, err := b.Daemon.Create(b.Config, nil, "")
+	container, _, err := b.Daemon.ContainerCreate("", b.Config, nil, true)
 	if err != nil {
 		return err
 	}
@@ -613,7 +613,7 @@ func (b *builder) create() (*daemon.Container, error) {
 	config := *b.Config
 
 	// Create the container
-	c, warnings, err := b.Daemon.Create(b.Config, hostConfig, "")
+	c, warnings, err := b.Daemon.ContainerCreate("", b.Config, hostConfig, true)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -11,15 +11,15 @@ import (
 	"github.com/opencontainers/runc/libcontainer/label"
 )
 
-func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hostConfig *runconfig.HostConfig, adjustCPUShares bool) (string, []string, error) {
+func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hostConfig *runconfig.HostConfig, adjustCPUShares bool) (*Container, []string, error) {
 	if config == nil {
-		return "", nil, fmt.Errorf("Config cannot be empty in order to create a container")
+		return nil, nil, fmt.Errorf("Config cannot be empty in order to create a container")
 	}
 
 	warnings, err := daemon.verifyContainerSettings(hostConfig, config)
 	daemon.adaptContainerSettings(hostConfig, adjustCPUShares)
 	if err != nil {
-		return "", warnings, err
+		return nil, warnings, err
 	}
 
 	container, buildWarnings, err := daemon.Create(config, hostConfig, name)
@@ -29,14 +29,14 @@ func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hos
 			if tag == "" {
 				tag = tags.DefaultTag
 			}
-			return "", warnings, fmt.Errorf("No such image: %s (tag: %s)", config.Image, tag)
+			return nil, warnings, fmt.Errorf("No such image: %s (tag: %s)", config.Image, tag)
 		}
-		return "", warnings, err
+		return nil, warnings, err
 	}
 
 	warnings = append(warnings, buildWarnings...)
 
-	return container.ID, warnings, nil
+	return container, warnings, nil
 }
 
 // Create creates a new container from the given configuration with a given name.


### PR DESCRIPTION
If docker build with resource limit which is not support by kernel, 
the build will failed.
Reproduce:
on a `WARNING: No swap limit support` machine

<pre><code>$ docker build --memory-swap 1000M --memory=800M -t test:v1 .
Sending build context to Docker daemon 2.048 kB
Step 0 : FROM busybox
 ---> 4986bf8c1536
Step 1 : ENV test test1
 ---> Running in 1d3f4bc3ee96
 ---> 8e0046f66b00
Removing intermediate container 1d3f4bc3ee96
Step 2 : RUN echo "Hello world"
 ---> Running in 51c4a7776f78
[8] System error: open /sys/fs/cgroup/memory/docker/51c4a7776f78ca9b5abd86f8c6a8ed7616a6c86b30da48cc2e78e237e70902f9/memory.memsw.limit_in_bytes: permission denied</code></pre>

This will failed without any warning.

The second commit is to remove the redundant ip_forward check, because https://github.com/docker/docker/blob/master/daemon/daemon_unix.go#L185 has done that.

ping @duglin  @tiborvass 
