### PR TITLE
Fix some broken cross references

### DIFF
--- a/docs/docker-hub/index.md
+++ b/docs/docker-hub/index.md
@@ -16,23 +16,23 @@ management, user and team collaboration, and lifecycle workflow automation.
 
 ![DockerHub](/docker-hub/hub-images/hub.png)
 
-## [Finding and pulling images](./userguide.md)
+## [Finding and pulling images](userguide.md)
 
-Find out how to [use the Docker Hub](./userguide.md) to find and pull Docker
+Find out how to [use the Docker Hub](userguide.md) to find and pull Docker
 images to run or build upon.
 
-## [Accounts](./accounts.md)
+## [Accounts](accounts.md)
 
-[Learn how to create](./accounts.md) a Docker Hub
+[Learn how to create](accounts.md) a Docker Hub
 account and manage your organizations and groups.
 
-## [Your Repositories](./repos.md)
+## [Your Repositories](repos.md)
 
 Find out how to share your Docker images in [Docker Hub
-repositories](./repos.md) and how to store and manage private images.
+repositories](repos.md) and how to store and manage private images.
 
-## [Automated builds](./builds.md)
+## [Automated builds](builds.md)
 
 Learn how to automate your build and deploy pipeline with [Automated
-Builds](./builds.md)
+Builds](builds.md)
 

--- a/docs/docker-hub/repos.md
+++ b/docs/docker-hub/repos.md
@@ -19,7 +19,7 @@ organization account.
 
 Alternatively, if the source code for your Docker image is on GitHub or Bitbucket,
 you can use an "Automated build" repository, which is built by the Docker Hub
-services. See the [automated builds documentation](./builds.md) to read about
+services. See the [automated builds documentation](builds.md) to read about
 the extra functionality provided by those services.
 
 ![repositories](/docker-hub/hub-images/repos.png)

--- a/docs/docker-hub/userguide.md
+++ b/docs/docker-hub/userguide.md
@@ -33,7 +33,7 @@ you can look at your profile page on [Docker Hub](https://hub.docker.com).
 
 ## Pulling, running and building images
 
-You can find more information on [working with Docker images](../userguide/dockerimages.md).
+You can find more information on [working with Docker images](/userguide/dockerimages/).
 
 ## Official Repositories
 
@@ -58,6 +58,6 @@ The Docker Hub provides you and your team with a place to build and ship Docker 
 Collections of Docker images are managed using repositories - 
 
 You can configure two types of repositories to manage on the Docker Hub:
-[Repositories](./repos.md), which allow you to push images to the Hub from your local Docker daemon,
-and [Automated Builds](./builds.md), which allow you to configure GitHub or Bitbucket to
+[Repositories](repos.md), which allow you to push images to the Hub from your local Docker daemon,
+and [Automated Builds](builds.md), which allow you to configure GitHub or Bitbucket to
 trigger the Hub to rebuild repositories when changes are made to the repository.

--- a/docs/touch-up.sh
+++ b/docs/touch-up.sh
@@ -11,10 +11,10 @@ for i in ls -l /docs/content/*
         y=${i##*/}
         find $i -type f -name "*.md" -exec sed -i.old \
         -e '/^<!.*metadata]>/g' \
+	-e '/(https:\/\//!s/(\([^)]*\.md\))/({{< relref "\1" >}})/g' \
         -e '/^<!.*end-metadata.*>/g' {} \;
     fi
 done
-
 
 
 


### PR DESCRIPTION
Signed-off-by: Sven Dowideit SvenDowideit@home.org.au

I finally tracked the issue down after finding the broken link to `[run](run.md)` in `refernce/commandline/daemon.md`

tl;dr is that Hugo does not support github syle cross referencing, you need to write `[run]({{< relref "run.md" >}})`
