### PR TITLE
Use dockerCmd when possible

### DIFF
--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1276,13 +1276,12 @@ func pingContainers(c *check.C, d *Daemon, expectFailure bool) {
 	}
 
 	args := append(dargs, "run", "-d", "--name", "container1", "busybox", "top")
-	_, err := runCommand(exec.Command(dockerBinary, args...))
-	c.Assert(err, check.IsNil)
+	dockerCmd(c, args...)
 
 	args = append(dargs, "run", "--rm", "--link", "container1:alias1", "busybox", "sh", "-c")
 	pingCmd := "ping -c 1 %s -W 1"
 	args = append(args, fmt.Sprintf(pingCmd, "alias1"))
-	_, err = runCommand(exec.Command(dockerBinary, args...))
+	_, _, err := dockerCmdWithError(c, args...)
 
 	if expectFailure {
 		c.Assert(err, check.NotNil)
@@ -1291,7 +1290,7 @@ func pingContainers(c *check.C, d *Daemon, expectFailure bool) {
 	}
 
 	args = append(dargs, "rm", "-f", "container1")
-	runCommand(exec.Command(dockerBinary, args...))
+	dockerCmd(c, args...)
 }
 
 func (s *DockerDaemonSuite) TestDaemonRestartWithSocketAsVolume(c *check.C) {

--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
@@ -10,19 +9,10 @@ import (
 // ensure that an added file shows up in docker diff
 func (s *DockerSuite) TestDiffFilenameShownInOutput(c *check.C) {
 	containerCmd := `echo foo > /root/bar`
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", containerCmd)
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf("failed to start the container: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", containerCmd)
 
 	cleanCID := strings.TrimSpace(out)
-
-	diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
-	out, _, err = runCommandWithOutput(diffCmd)
-	if err != nil {
-		c.Fatalf("failed to run diff: %s %v", out, err)
-	}
+	out, _ = dockerCmd(c, "diff", cleanCID)
 
 	found := false
 	for _, line := range strings.Split(out, "\n") {
@@ -45,20 +35,10 @@ func (s *DockerSuite) TestDiffEnsureDockerinitFilesAreIgnored(c *check.C) {
 	// we might not run into this problem from the first run, so start a few containers
 	for i := 0; i < containerCount; i++ {
 		containerCmd := `echo foo > /root/bar`
-		runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", containerCmd)
-		out, _, err := runCommandWithOutput(runCmd)
-
-		if err != nil {
-			c.Fatal(out, err)
-		}
+		out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", containerCmd)
 
 		cleanCID := strings.TrimSpace(out)
-
-		diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
-		out, _, err = runCommandWithOutput(diffCmd)
-		if err != nil {
-			c.Fatalf("failed to run diff: %s, %v", out, err)
-		}
+		out, _ = dockerCmd(c, "diff", cleanCID)
 
 		for _, filename := range dockerinitFiles {
 			if strings.Contains(out, filename) {
@@ -69,19 +49,10 @@ func (s *DockerSuite) TestDiffEnsureDockerinitFilesAreIgnored(c *check.C) {
 }
 
 func (s *DockerSuite) TestDiffEnsureOnlyKmsgAndPtmx(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sleep", "0")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sleep", "0")
 
 	cleanCID := strings.TrimSpace(out)
-
-	diffCmd := exec.Command(dockerBinary, "diff", cleanCID)
-	out, _, err = runCommandWithOutput(diffCmd)
-	if err != nil {
-		c.Fatalf("failed to run diff: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "diff", cleanCID)
 
 	expected := map[string]bool{
 		"C /dev":         true,
@@ -111,7 +82,7 @@ func (s *DockerSuite) TestDiffEnsureOnlyKmsgAndPtmx(c *check.C) {
 
 // https://github.com/docker/docker/pull/14381#discussion_r33859347
 func (s *DockerSuite) TestDiffEmptyArgClientError(c *check.C) {
-	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "diff", ""))
+	out, _, err := dockerCmdWithError(c, "diff", "")
 	c.Assert(err, check.NotNil)
 	c.Assert(strings.TrimSpace(out), check.Equals, "Container name cannot be empty")
 }

--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -15,10 +15,7 @@ import (
 
 // regression test for #12546
 func (s *DockerSuite) TestExecInteractiveStdinClose(c *check.C) {
-	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-itd", "busybox", "/bin/cat"))
-	if err != nil {
-		c.Fatal(err)
-	}
+	out, _ := dockerCmd(c, "run", "-itd", "busybox", "/bin/cat")
 	contId := strings.TrimSpace(out)
 
 	cmd := exec.Command(dockerBinary, "exec", "-i", contId, "echo", "-n", "hello")

--- a/integration-cli/docker_cli_experimental_test.go
+++ b/integration-cli/docker_cli_experimental_test.go
@@ -3,27 +3,21 @@
 package main
 
 import (
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestExperimentalVersion(c *check.C) {
-	versionCmd := exec.Command(dockerBinary, "version")
-	out, _, err := runCommandWithOutput(versionCmd)
-	if err != nil {
-		c.Fatalf("failed to execute docker version: %s, %v", out, err)
-	}
-
+	out, _ := dockerCmd(c, "version")
 	for _, line := range strings.Split(out, "\n") {
 		if strings.HasPrefix(line, "Experimental (client):") || strings.HasPrefix(line, "Experimental (server):") {
 			c.Assert(line, check.Matches, "*true")
 		}
 	}
 
-	versionCmd = exec.Command(dockerBinary, "-v")
-	if out, _, err = runCommandWithOutput(versionCmd); err != nil || !strings.Contains(out, ", experimental") {
-		c.Fatalf("docker version did not contain experimental: %s, %v", out, err)
+	out, _ = dockerCmd(c, "-v")
+	if !strings.Contains(out, ", experimental") {
+		c.Fatalf("docker version did not contain experimental: %s", out)
 	}
 }

--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -12,20 +12,13 @@ import (
 func (s *DockerSuite) TestExportContainerAndImportImage(c *check.C) {
 	containerID := "testexportcontainerandimportimage"
 
-	runCmd := exec.Command(dockerBinary, "run", "--name", containerID, "busybox", "true")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal("failed to create a container", out, err)
-	}
+	dockerCmd(c, "run", "--name", containerID, "busybox", "true")
 
-	exportCmd := exec.Command(dockerBinary, "export", containerID)
-	if out, _, err = runCommandWithOutput(exportCmd); err != nil {
-		c.Fatalf("failed to export container: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "export", containerID)
 
 	importCmd := exec.Command(dockerBinary, "import", "-", "repo/testexp:v1")
 	importCmd.Stdin = strings.NewReader(out)
-	out, _, err = runCommandWithOutput(importCmd)
+	out, _, err := runCommandWithOutput(importCmd)
 	if err != nil {
 		c.Fatalf("failed to import image: %s, %v", out, err)
 	}
@@ -40,20 +33,11 @@ func (s *DockerSuite) TestExportContainerAndImportImage(c *check.C) {
 func (s *DockerSuite) TestExportContainerWithOutputAndImportImage(c *check.C) {
 	containerID := "testexportcontainerwithoutputandimportimage"
 
-	runCmd := exec.Command(dockerBinary, "run", "--name", containerID, "busybox", "true")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal("failed to create a container", out, err)
-	}
-
+	dockerCmd(c, "run", "--name", containerID, "busybox", "true")
+	dockerCmd(c, "export", "--output=testexp.tar", containerID)
 	defer os.Remove("testexp.tar")
 
-	exportCmd := exec.Command(dockerBinary, "export", "--output=testexp.tar", containerID)
-	if out, _, err = runCommandWithOutput(exportCmd); err != nil {
-		c.Fatalf("failed to export container: %s, %v", out, err)
-	}
-
-	out, _, err = runCommandWithOutput(exec.Command("cat", "testexp.tar"))
+	out, _, err := runCommandWithOutput(exec.Command("cat", "testexp.tar"))
 	if err != nil {
 		c.Fatal(out, err)
 	}

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
 	"reflect"
 	"sort"
 	"strings"
@@ -13,16 +12,10 @@ import (
 )
 
 func (s *DockerSuite) TestImagesEnsureImageIsListed(c *check.C) {
-	imagesCmd := exec.Command(dockerBinary, "images")
-	out, _, err := runCommandWithOutput(imagesCmd)
-	if err != nil {
-		c.Fatalf("listing images failed with errors: %s, %v", out, err)
-	}
-
+	out, _ := dockerCmd(c, "images")
 	if !strings.Contains(out, "busybox") {
 		c.Fatal("images should've listed busybox")
 	}
-
 }
 
 func (s *DockerSuite) TestImagesOrderedByCreationDate(c *check.C) {
@@ -47,10 +40,7 @@ func (s *DockerSuite) TestImagesOrderedByCreationDate(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "images", "-q", "--no-trunc"))
-	if err != nil {
-		c.Fatalf("listing images failed with errors: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "images", "-q", "--no-trunc")
 	imgs := strings.Split(out, "\n")
 	if imgs[0] != id3 {
 		c.Fatalf("First image must be %s, got %s", id3, imgs[0])
@@ -61,16 +51,13 @@ func (s *DockerSuite) TestImagesOrderedByCreationDate(c *check.C) {
 	if imgs[2] != id1 {
 		c.Fatalf("Third image must be %s, got %s", id1, imgs[2])
 	}
-
 }
 
 func (s *DockerSuite) TestImagesErrorWithInvalidFilterNameTest(c *check.C) {
-	imagesCmd := exec.Command(dockerBinary, "images", "-f", "FOO=123")
-	out, _, err := runCommandWithOutput(imagesCmd)
-	if !strings.Contains(out, "Invalid filter") {
-		c.Fatalf("error should occur when listing images with invalid filter name FOO, %s, %v", out, err)
+	out, _, err := dockerCmdWithError(c, "images", "-f", "FOO=123")
+	if err == nil || !strings.Contains(out, "Invalid filter") {
+		c.Fatalf("error should occur when listing images with invalid filter name FOO, %s", out)
 	}
-
 }
 
 func (s *DockerSuite) TestImagesFilterLabel(c *check.C) {
@@ -98,28 +85,17 @@ func (s *DockerSuite) TestImagesFilterLabel(c *check.C) {
 		c.Fatal(err)
 	}
 
-	cmd := exec.Command(dockerBinary, "images", "--no-trunc", "-q", "-f", "label=match")
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ := dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match")
 	out = strings.TrimSpace(out)
-
 	if (!strings.Contains(out, image1ID) && !strings.Contains(out, image2ID)) || strings.Contains(out, image3ID) {
 		c.Fatalf("Expected ids %s,%s got %s", image1ID, image2ID, out)
 	}
 
-	cmd = exec.Command(dockerBinary, "images", "--no-trunc", "-q", "-f", "label=match=me too")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ = dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match=me too")
 	out = strings.TrimSpace(out)
-
 	if out != image2ID {
 		c.Fatalf("Expected %s got %s", image2ID, out)
 	}
-
 }
 
 func (s *DockerSuite) TestImagesFilterSpaceTrimCase(c *check.C) {
@@ -140,11 +116,7 @@ func (s *DockerSuite) TestImagesFilterSpaceTrimCase(c *check.C) {
 
 	imageListings := make([][]string, 5, 5)
 	for idx, filter := range filters {
-		cmd := exec.Command(dockerBinary, "images", "-q", "-f", filter)
-		out, _, err := runCommandWithOutput(cmd)
-		if err != nil {
-			c.Fatal(err)
-		}
+		out, _ := dockerCmd(c, "images", "-q", "-f", filter)
 		listing := strings.Split(out, "\n")
 		sort.Strings(listing)
 		imageListings[idx] = listing
@@ -162,42 +134,22 @@ func (s *DockerSuite) TestImagesFilterSpaceTrimCase(c *check.C) {
 			c.Fatalf("All output must be the same")
 		}
 	}
-
 }
 
 func (s *DockerSuite) TestImagesEnsureDanglingImageOnlyListedOnce(c *check.C) {
-
 	// create container 1
-	cmd := exec.Command(dockerBinary, "run", "-d", "busybox", "true")
-	out, _, err := runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error running busybox: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	containerId1 := strings.TrimSpace(out)
 
 	// tag as foobox
-	cmd = exec.Command(dockerBinary, "commit", containerId1, "foobox")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error tagging foobox: %s", err)
-	}
+	out, _ = dockerCmd(c, "commit", containerId1, "foobox")
 	imageId := stringid.TruncateID(strings.TrimSpace(out))
 
 	// overwrite the tag, making the previous image dangling
-	cmd = exec.Command(dockerBinary, "tag", "-f", "busybox", "foobox")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("error tagging foobox: %s", err)
-	}
+	dockerCmd(c, "tag", "-f", "busybox", "foobox")
 
-	cmd = exec.Command(dockerBinary, "images", "-q", "-f", "dangling=true")
-	out, _, err = runCommandWithOutput(cmd)
-	if err != nil {
-		c.Fatalf("listing images failed with errors: %s, %v", out, err)
-	}
-
+	out, _ = dockerCmd(c, "images", "-q", "-f", "dangling=true")
 	if e, a := 1, strings.Count(out, imageId); e != a {
 		c.Fatalf("expected 1 dangling image, got %d: %s", a, out)
 	}
-
 }

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os/exec"
 	"strings"
 
 	"github.com/docker/docker/utils"
@@ -10,11 +9,7 @@ import (
 
 // ensure docker info succeeds
 func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
-	versionCmd := exec.Command(dockerBinary, "info")
-	out, exitCode, err := runCommandWithOutput(versionCmd)
-	if err != nil || exitCode != 0 {
-		c.Fatalf("failed to execute docker info: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "info")
 
 	// always shown fields
 	stringsToCheck := []string{


### PR DESCRIPTION
Addresses: #14603

integration-cli/docker_cli_daemon_experimental_test.go (hqhq)
integration-cli/docker_cli_daemon_test.go (hqhq)
integration-cli/docker_cli_diff_test.go (hqhq)
integration-cli/docker_cli_events_test.go (hqhq)
integration-cli/docker_cli_events_unix_test.go (hqhq)
integration-cli/docker_cli_exec_test.go (hqhq)
integration-cli/docker_cli_exec_unix_test.go (hqhq)
integration-cli/docker_cli_experimental_test.go (hqhq)
integration-cli/docker_cli_export_import_test.go (hqhq)
integration-cli/docker_cli_help_test.go (hqhq)
integration-cli/docker_cli_history_test.go (hqhq)
integration-cli/docker_cli_images_test.go (hqhq)
integration-cli/docker_cli_import_test.go (hqhq)
integration-cli/docker_cli_info_test.go (hqhq)
integration-cli/docker_cli_inspect_test.go (hqhq)
integration-cli/docker_cli_kill_test.go (hqhq)

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
