### PR TITLE
zsh: update zsh completion for docker command

### DIFF
--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -7,6 +7,7 @@
 #
 # contributors:
 #   - Felix Riedel
+#   - Steve Durrheimer
 #   - Vincent Bernat
 #
 # license:
@@ -38,7 +39,9 @@
 #
 
 __docker_get_containers() {
-    local kind expl
+    [[ $PREFIX = -* ]] && return 1
+    integer ret=1
+    local kind
     declare -a running stopped lines args
 
     kind=$1
@@ -82,54 +85,77 @@ __docker_get_containers() {
             s="${name}:${(l:15:: :::)${${line[${begin[CREATED]},${end[CREATED]}]/ ago/}%% ##}}"
             s="$s, ${${${line[${begin[IMAGE]},${end[IMAGE]}]}/:/\\:}%% ##}"
             if [[ ${line[${begin[STATUS]},${end[STATUS]}]} = Exit* ]]; then
-                stopped=($stopped $s)
+                stopped=($stopped ${s#*/})
             else
-                running=($running $s)
+                running=($running ${s#*/})
             fi
         done
     done
 
-    [[ $kind = (running|all) ]] && _describe -t containers-running "running containers" running
-    [[ $kind = (stopped|all) ]] && _describe -t containers-stopped "stopped containers" stopped
+    [[ $kind = (running|all) ]] && _describe -t containers-running "running containers" running "$@" && ret=0
+    [[ $kind = (stopped|all) ]] && _describe -t containers-stopped "stopped containers" stopped "$@" && ret=0
+    return ret
 }
 
 __docker_stoppedcontainers() {
+    [[ $PREFIX = -* ]] && return 1
     __docker_get_containers stopped "$@"
 }
 
 __docker_runningcontainers() {
+    [[ $PREFIX = -* ]] && return 1
     __docker_get_containers running "$@"
 }
 
 __docker_containers() {
+    [[ $PREFIX = -* ]] && return 1
     __docker_get_containers all "$@"
 }
 
 __docker_images() {
-    local expl
+    [[ $PREFIX = -* ]] && return 1
+    integer ret=1
     declare -a images
-    images=(${${${${(f)"$(_call_program commands docker $docker_options images)"}[2,-1]}/ ##/\\:}%% *})
-    images=(${${images%\\:<none>}#<none>} ${${${(f)"$(_call_program commands docker $docker_options images)"}[2,-1]}/(#b)([^ ]##) ##([^ ]##) ##([^ ]##)*/${match[3]}:${(r:15:: :::)match[2]} in ${match[1]}})
-    _describe -t docker-images "images" images
+    images=(${${${(f)"$(_call_program commands docker $docker_options images)"}[2,-1]}/(#b)([^ ]##) ##([^ ]##) ##([^ ]##)*/${match[3]}:${(r:15:: :::)match[2]} in ${match[1]}})
+    _describe -t docker-images "images" images && ret=0
+    __docker_repositories_with_tags && ret=0
+    return ret
 }
 
-__docker_tags() {
-    local expl
-    declare -a tags
-    tags=(${${${${${(f)"$(_call_program commands docker $docker_options images)"}#* }## #}%% *}[2,-1]})
-    _describe -t docker-tags "tags" tags
+__docker_repositories() {
+    [[ $PREFIX = -* ]] && return 1
+    declare -a repos
+    repos=(${${${(f)"$(_call_program commands docker $docker_options images)"}%% *}[2,-1]})
+    repos=(${repos#<none>})
+    _describe -t docker-repos "repositories" repos
 }
 
 __docker_repositories_with_tags() {
-    if compset -P '*:'; then
-        __docker_tags
-    else
-        __docker_repositories -qS ":"
-    fi
+    [[ $PREFIX = -* ]] && return 1
+    integer ret=1
+    declare -a repos onlyrepos matched
+    declare m
+    repos=(${${${${(f)"$(_call_program commands docker $docker_options images)"}[2,-1]}/ ##/:::}%% *})
+    repos=(${${repos%:::<none>}#<none>})
+    # Check if we have a prefix-match for the current prefix.
+    onlyrepos=(${repos%::*})
+    for m in $onlyrepos; do
+        [[ ${PREFIX##${~~m}} != ${PREFIX} ]] && {
+            # Yes, complete with tags
+            repos=(${${repos/:::/:}/:/\\:})
+            _describe -t docker-repos-with-tags "repositories with tags" repos && ret=0
+            return ret
+        }
+    done
+    # No, only complete repositories
+    onlyrepos=(${${repos%:::*}/:/\\:})
+    _describe -t docker-repos "repositories" onlyrepos -qS : && ret=0
+
+    return ret
 }
 
 __docker_search() {
-    # declare -a dockersearch
+    [[ $PREFIX = -* ]] && return 1
     local cache_policy
     zstyle -s ":completion:${curcontext}:" cache-policy cache_policy
     if [[ -z "$cache_policy" ]]; then
@@ -152,20 +178,11 @@ __docker_search() {
 }
 
 __docker_caching_policy() {
-  oldp=( "$1(Nmh+1)" )     # 1 hour
-  (( ${#oldp} ))
-}
-
-
-__docker_repositories() {
-    local expl
-    declare -a repos
-    repos=(${${${(f)"$(_call_program commands docker $docker_options images)"}%% *}[2,-1]})
-    _describe -t docker-repos "repositories" repos "$@"
+  oldp=( "$1"(Nmh+1) )     # 1 hour
+  (( $#oldp ))
 }
 
 __docker_commands() {
-    # local -a  _docker_subcommands
     local cache_policy
 
     zstyle -s ":completion:${curcontext}:" cache-policy cache_policy
@@ -177,7 +194,7 @@ __docker_commands() {
         && ! _retrieve_cache docker_subcommands;
     then
         local -a lines
-        lines=(${(f)"$(_call_program commands docker $docker_options 2>&1)"})
+        lines=(${(f)"$(_call_program commands docker 2>&1)"})
         _docker_subcommands=(${${${lines[$((${lines[(i)Commands:]} + 1)),${lines[(I)    *]}]}## #}/ ##/:})
         _docker_subcommands=($_docker_subcommands 'help:Show help for a command')
         _store_cache docker_subcommands _docker_subcommands
@@ -186,122 +203,124 @@ __docker_commands() {
 }
 
 __docker_subcommand() {
-    local -a _command_args
+    local -a _command_args opts_help opts_cpumem opts_create
+    local expl help="-h --help"
+    integer ret=1
+
+    opts_help=("(: -)"{-h,--help}"[Print usage]")
+    opts_cpumem=(
+        "($help -c --cpu-shares)"{-c,--cpu-shares=-}"[CPU shares (relative weight)]:CPU shares:(0 10 100 200 500 800 1000)"
+        "($help)--cgroup-parent=-[Parent cgroup for the container]:cgroup: "
+        "($help)--cpu-period=-[Limit the CPU CFS (Completely Fair Scheduler) period]:CPU period: "
+        "($help)--cpu-quota=-[Limit the CPU CFS (Completely Fair Scheduler) quota]:CPU quota: "
+        "($help)--cpuset-cpus=-[CPUs in which to allow execution]:CPUs: "
+        "($help)--cpuset-mems=-[MEMs in which to allow execution]:MEMs: "
+        "($help -m --memory)"{-m,--memory=-}"[Memory limit]:Memory limit: "
+        "($help)--memory-swap=-[Total memory limit with swap]:Memory limit: "
+    )
+    opts_create=(
+        "($help -a --attach)"{-a,--attach=-}"[Attach to stdin, stdout or stderr]:device:(STDIN STDOUT STDERR)"
+        "($help)*--add-host=-[Add a custom host-to-IP mapping]:host\:ip mapping: "
+        "($help)--blkio-weight=-[Block IO (relative weight), between 10 and 1000]:Block IO weight:(10 100 500 1000)"
+        "($help)*--cap-add=-[Add Linux capabilities]:capability: "
+        "($help)*--cap-drop=-[Drop Linux capabilities]:capability: "
+        "($help)--cidfile=-[Write the container ID to the file]:CID file:_files"
+        "($help)*--device=-[Add a host device to the container]:device:_files"
+        "($help)*--dns=-[Set custom dns servers]:dns server: "
+        "($help)*--dns-search=-[Set custom DNS search domains]:dns domains: "
+        "($help)*"{-e,--env=-}"[Set environment variables]:environment variable: "
+        "($help)--entrypoint=-[Overwrite the default entrypoint of the image]:entry point: "
+        "($help)*--env-file=-[Read environment variables from a file]:environment file:_files"
+        "($help)*--expose=-[Expose a port from the container without publishing it]: "
+        "($help)*--group-add=-[Add additional groups to run as]:group:_groups"
+        "($help -h --hostname)"{-h,--hostname=-}"[Container host name]:hostname:_hosts"
+        "($help -i --interactive)"{-i,--interactive}"[Keep stdin open even if not attached]"
+        "($help)--ipc=-[IPC namespace to use]:IPC namespace: "
+        "($help)*--link=-[Add link to another container]:link:->link"
+        "($help)*"{-l,--label=-}"[Set meta data on a container]:label: "
+        "($help)--log-driver=-[Default driver for container logs]:Logging driver:(json-file syslog journald gelf fluentd none)"
+        "($help)*--log-opt=-[Log driver specific options]:log driver options: "
+        "($help)*--lxc-conf=-[Add custom lxc options]:lxc options: "
+        "($help)--mac-address=-[Container MAC address]:MAC address: "
+        "($help)--name=-[Container name]:name: "
+        "($help)--net=-[Network mode]:network mode:(bridge none container host)"
+        "($help)--oom-kill-disable[Disable OOM Killer]"
+        "($help -P --publish-all)"{-P,--publish-all}"[Publish all exposed ports]"
+        "($help)*"{-p,--publish=-}"[Expose a container's port to the host]:port:_ports"
+        "($help)--pid=-[PID namespace to use]:PID: "
+        "($help)--privileged[Give extended privileges to this container]"
+        "($help)--read-only[Mount the container's root filesystem as read only]"
+        "($help)--restart=-[Restart policy]:restart policy:(no on-failure always)"
+        "($help)*--security-opt=-[Security options]:security option: "
+        "($help -t --tty)"{-t,--tty}"[Allocate a pseudo-tty]"
+        "($help -u --user)"{-u,--user=-}"[Username or UID]:user:_users"
+        "($help)*--ulimit=-[ulimit options]:ulimit: "
+        "($help)*-v[Bind mount a volume]:volume: "
+        "($help)*--volumes-from=-[Mount volumes from the specified container]:volume: "
+        "($help -w --workdir)"{-w,--workdir=-}"[Working directory inside the container]:directory:_directories"
+    )
+
     case "$words[1]" in
         (attach)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '--no-stdin[Do not attach stdin]' \
-                '--sig-proxy[Proxy all received signals to the process (non-TTY mode only)]' \
-                ':containers:__docker_runningcontainers' && ret=0
+                $opts_help \
+                "($help)--no-stdin[Do not attach stdin]" \
+                "($help)--sig-proxy[Proxy all received signals to the process (non-TTY mode only)]" \
+                "($help -):containers:__docker_runningcontainers" && ret=0
             ;;
         (build)
             _arguments \
-                '(-c --cpu-share)'{-c,--cpu-share=-}'[CPU shares (relative weight)]:CPU shares: ' \
-                '--cgroup-parent=-[Optional parent cgroup for the container]:cgroup parent: ' \
-                '--cpu-period=-[Limit the CPU CFS (Completely Fair Scheduler) period]:CPU period: ' \
-                '--cpu-quota=-[Limit the CPU CFS (Completely Fair Scheduler) quota]:CPU quota: ' \
-                '--cpuset-cpus=-[CPUs in which to allow execution (0-3, 0,1)]:CPUs: ' \
-                '--cpuset-mems=-[MEMs in which to allow execution (0-3, 0,1)]:MEMs: ' \
-                '(-f --file)'{-f,--file=-}"[Name of the Dockerfile (Default is 'PATH/Dockerfile')]:Dockerfile:_files" \
-                '--force-rm[Always remove intermediate containers]' \
-                '(- :)--help[Print usage]' \
-                '(-m --memory)'{-m,--memory=-}'[Memory limit]:Memory limit: ' \
-                '--memory-swap=-[Total memory (memory + swap), '-1' to disable swap]' \
-                '--no-cache[Do not use cache when building the image]' \
-                '--pull[Always attempt to pull a newer version of the image]' \
-                '(-q --quiet)'{-q,--quiet}'[Suppress the verbose output generated by the containers]' \
-                '--rm[Remove intermediate containers after a successful build]' \
-                '(-t --tag)'{-t,--tag=-}'[Repository name (and optionally a tag) for the image]:repository:__docker_repositories_with_tags' \
-                ':path or URL:_directories' && ret=0
+                $opts_help \
+                $opts_cpumem \
+                "($help -f --file)"{-f,--file=-}"[Name of the Dockerfile]:Dockerfile:_files" \
+                "($help)--force-rm[Always remove intermediate containers]" \
+                "($help)--no-cache[Do not use cache when building the image]" \
+                "($help)--pull[Attempt to pull a newer version of the image]" \
+                "($help -q --quiet)"{-q,--quiet}"[Suppress verbose build output]" \
+                "($help)--rm[Remove intermediate containers after a successful build]" \
+                "($help -t --tag)"{-t,--tag=-}"[Repository, name and tag for the image]: :__docker_repositories_with_tags" \
+                "($help -):path or URL:_directories" && ret=0
             ;;
         (commit)
             _arguments \
-                '(-a --author)'{-a,--author=-}'[Author]:author: ' \
-                '*'{-c,--change=-}'[Apply Dockerfile instruction to the created image]' \
-                '(- :)--help[Print usage]' \
-                '(-m --message)'{-m,--message=-}'[Commit message]:message: ' \
-                '(-p --pause)'{-p,--pause}'[Pause container during commit]' \
-                ':container:__docker_containers' \
-                ':repository:__docker_repositories_with_tags' && ret=0
+                $opts_help \
+                "($help -a --author)"{-a,--author=-}"[Author]:author: " \
+                "($help -c --change)*"{-c,--change=-}"[Apply Dockerfile instruction to the created image]:Dockerfile:_files" \
+                "($help -m --message)"{-m,--message=-}"[Commit message]:message: " \
+                "($help -p --pause)"{-p,--pause}"[Pause container during commit]" \
+                "($help -):container:__docker_containers" \
+                "($help -): :__docker_repositories_with_tags" && ret=0
             ;;
         (cp)
             _arguments \
-                '(- :)--help[Print usage]' \
-                ':container:->container' \
-                ':hostpath:_files' && ret=0
+                $opts_help \
+                "($help -)1:container:->container" \
+                "($help -)2:hostpath:_files" && ret=0
             case $state in
                 (container)
-                    if compset -P '*:'; then
-                        _files
+                    if compset -P "*:"; then
+                        _files && ret=0
                     else
-                        __docker_containers -qS ":"
+                        __docker_containers -qS ":" && ret=0
                     fi
                     ;;
             esac
             ;;
         (create)
             _arguments \
-                '*'{-a,--attach=-}'[Attach to STDIN, STDOUT or STDERR]:STD:(STDIN STDOUT STDERR)' \
-                '*--add-host=-[Add a custom host-to-IP mapping (host:ip)]:host\:ip mapping: ' \
-                '--blkio-weight=-[Block IO (relative weight), between 10 and 1000]:Block IO weight: ' \
-                '(-c --cpu-shares)'{-c,--cpu-shares=-}'[CPU shares (relative weight)]:CPU shares:(0 10 100 200 500 800 1000)' \
-                '*--cap-add=-[Add Linux capabilities]:capability: ' \
-                '*--cap-drop=-[Drop Linux capabilities]:capability: ' \
-                '--cgroup-parent=-[Optional parent cgroup for the container]:cgroup parent: ' \
-                '--cidfile=-[Write the container ID to the file]:CID:_files' \
-                '--cpu-period=-[Limit CPU CFS (Completely Fair Scheduler) period]:CPU period: ' \
-                '--cpu-quota=-[Limit the CPU CFS quota]:CPU quota: ' \
-                '--cpuset-cpus=-[CPUs in which to allow execution (0-3, 0,1)]:CPUs: ' \
-                '--cpuset-mems=-[MEMs in which to allow execution (0-3, 0,1)]:MEMs: ' \
-                '*--device=-[Add a host device to the container]:device:_files' \
-                '*--dns=-[Set custom dns servers]:dns server: ' \
-                '*--dns-search=-[Set custom DNS search domains]:dns domains: ' \
-                '*'{-e,--env=-}'[Set environment variables]:environment variable: ' \
-                '--entrypoint=-[Overwrite the default ENTRYPOINT of the image]:entry point: ' \
-                '*--env-file=-[Read in a file of environment variables]:environment file:_files' \
-                '*--expose=-[Expose a port or a range of ports]:port or a range of ports: ' \
-                '(-h --hostname)'{-h,--hostname=-}'[Container host name]:hostname:_hosts' \
-                '(- :)--help[Print usage]' \
-                '(-i --interactive)'{-i,--interactive}'[Keep STDIN open even if not attached]' \
-                '--ipc=-[IPC namespace to use]:IPC namespace: ' \
-                '*'{-l,--label=-}'[Set meta data on a container]:Label: ' \
-                '*--label-file=-[Read in a line delimited file of labels]' \
-                '*--link=-[Add link to another container]:link:->link' \
-                '--log-driver=-[Logging driver for container]:Logging driver:(json-file syslog journald gelf fluentd none)' \
-                '*--log-opt=-[Log driver options]:Log driver options: ' \
-                '*--lxc-conf=-[Add custom lxc options]:lxc options: ' \
-                '(-m --memory)'{-m,--memory=-}'[Memory limit (in bytes)]:Memory limit: ' \
-                '--mac-address=-[Container MAC address (e.g. 92:d0:c6:0a:29:33)]:MAC address: ' \
-                "--memory-swap=-[Total memory (memory + swap), '-1' to disable swap]:Total memory: " \
-                '--name=-[Assign a name to the container]:name: ' \
-                '--net=-[Set the Network mode for the container]:network mode:(bridge none container host)' \
-                '--oom-kill-disable[Disable OOM Killer]' \
-                '(-P --publish-all)'{-P,--publish-all}'[Publish all exposed ports to random ports]' \
-                '*'{-p,--publish=-}"[Publish a container's port(s) to the host]:port:_ports" \
-                '--pid=-[PID namespace to use]:PID: ' \
-                '--privileged[Give extended privileges to this container]' \
-                "--read-only[Mount the container's root filesystem as read only]" \
-                '--restart=-[Restart policy]:restart policy:(no on-failure always)' \
-                '--rm[Remove intermediate containers when it exits]' \
-                '*--security-opt=-[Security options]:security option: ' \
-                '(-t --tty)'{-t,--tty}'[Allocate a pseudo-TTY]' \
-                '(-u --user)'{-u,--user=-}'[Username or UID]:user:_users' \
-                '*--ulimit=-[Ulimit options]:ulimit: ' \
-                '--uts=-[UTS namespace to use]:UTS: ' \
-                '*'{-v,--volume=-}'[Bind mount a volume]:volume: ' \
-                '*--volumes-from=-[Mount volumes from the specified container]:volume: ' \
-                '(-w --workdir)'{-w,--workdir=-}'[Working directory inside the container]:directory:_directories' \
-                '(-):images:__docker_images' \
-                '(-):command: _command_names -e' \
-                '*::arguments: _normal' && ret=0
+                $opts_help \
+                $opts_cpumem \
+                $opts_create \
+                "($help -): :__docker_images" \
+                "($help -):command: _command_names -e" \
+                "($help -)*::arguments: _normal" && ret=0
 
             case $state in
                 (link)
-                    if compset -P '*:'; then
-                        _wanted alias expl 'Alias' compadd -E ""
+                    if compset -P "*:"; then
+                        _wanted alias expl "Alias" compadd -E "" && ret=0
                     else
-                        __docker_runningcontainers -qS ":"
+                        __docker_runningcontainers -qS ":" && ret=0
                     fi
                     ;;
             esac
@@ -309,239 +328,190 @@ __docker_subcommand() {
             ;;
         (diff)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '*:containers:__docker_containers' && ret=0
+                $opts_help \
+                "($help -)*:containers:__docker_containers" && ret=0
             ;;
         (events)
             _arguments \
-                '*'{-f,--filter=-}'[Filter output based on conditions provided]:filter: ' \
-                '(- :)--help[Print usage]' \
-                '--since=-[Show all events created since timestamp]:timestamp: ' \
-                '--until=-[Stream events until this timestamp]:timestamp: ' && ret=0
+                $opts_help \
+                "($help)*"{-f,--filter=-}"[Filter values]:filter: " \
+                "($help)--since=-[Events created since this timestamp]:timestamp: " \
+                "($help)--until=-[Events created until this timestamp]:timestamp: " && ret=0
             ;;
         (exec)
             local state
             _arguments \
-                '(-d --detach)'{-d,--detach}'[Detached mode: run command in the background]' \
-                '(- :)--help[Print usage]' \
-                '(-i --interactive)'{-i,--interactive}'[Keep STDIN open even if not attached]' \
-                '(-t --tty)'{-t,--tty}'[Allocate a pseudo-TTY]' \
-                '(-u --user)'{-u,--user=-}'[Username or UID]:User: ' \
-                ':containers:__docker_runningcontainers' \
-                '*::command:->anycommand' && ret=0
+                $opts_help \
+                "($help -d --detach)"{-d,--detach}"[Detached mode: leave the container running in the background]" \
+                "($help -i --interactive)"{-i,--interactive}"[Keep stdin open even if not attached]" \
+                "($help -t --tty)"{-t,--tty}"[Allocate a pseudo-tty]" \
+                "($help -u --user)"{-u,--user=-}"[Username or UID]:user:_users" \
+                "($help -):containers:__docker_runningcontainers" \
+                "($help -)*::command:->anycommand" && ret=0
 
             case $state in
                 (anycommand)
                     shift 1 words
                     (( CURRENT-- ))
-                    _normal
+                    _normal && ret=0
                     ;;
             esac
-
-            return ret
             ;;
         (export)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '(-o --output)'{-o,--output=-}'[Write to a file, instead of STDOUT]:file: ' \
-                '*:containers:__docker_containers' && ret=0
+                $opts_help \
+                "($help -o --output)"{-o,--output=-}"[Write to a file, instead of stdout]:output file:_files" \
+                "($help -)*:containers:__docker_containers" && ret=0
             ;;
         (history)
             _arguments \
-                '(-H --human)'{-H,--human}'[Print sizes and dates in human readable format]' \
-                '(- :)--help[Print usage]' \
-                '--no-trunc[Do not truncate output]' \
-                '(-q --quiet)'{-q,--quiet}'[Only show numeric IDs]' \
-                '*:images:__docker_images' && ret=0
+                $opts_help \
+                "($help -H --human)"{-H,--human}"[Print sizes and dates in human readable format]" \
+                "($help)--no-trunc[Do not truncate output]" \
+                "($help -q --quiet)"{-q,--quiet}"[Only show numeric IDs]" \
+                "($help -)*: :__docker_images" && ret=0
             ;;
         (images)
             _arguments \
-                '(-a --all)'{-a,--all}'[Show all images (default hides intermediate images)]' \
-                '--digests[Show digests]' \
-                '*'{-f,--filter=-}'[Filter output based on conditions provided]:filter: ' \
-                '(- :)--help[Print usage]' \
-                '--no-trunc[Do not truncate output]' \
-                '(-q --quiet)'{-q,--quiet}'[Only show numeric IDs]' \
-                ':repository:__docker_repositories' && ret=0
+                $opts_help \
+                "($help -a --all)"{-a,--all}"[Show all images]" \
+                "($help)--digest[Show digests]" \
+                "($help)*"{-f,--filter=-}"[Filter values]:filter: " \
+                "($help)--no-trunc[Do not truncate output]" \
+                "($help -q --quiet)"{-q,--quiet}"[Only show numeric IDs]" \
+                "($help -): :__docker_repositories" && ret=0
             ;;
         (import)
             _arguments \
-                '*'{-c,--change=-}'[Apply Dockerfile instruction to the created image]' \
-                '(- :)--help[Print usage]' \
-                ':URL:(http:// file://)' \
-                ':repository:__docker_repositories_with_tags' && ret=0
+                $opts_help \
+                "($help -c --change)*"{-c,--change=-}"[Apply Dockerfile instruction to the created image]:Dockerfile:_files" \
+                "($help -):URL:(- http:// file://)" \
+                "($help -): :__docker_repositories_with_tags" && ret=0
             ;;
         (info|version)
             _arguments \
-                '(- :)--help[Print usage]' && ret=0
+                $opts_help && ret=0
             ;;
         (inspect)
             _arguments \
-                '(-f --format)'{-f,--format=-}'[Format the output using the given go template]:template: ' \
-                '(- :)--help[Print usage]' \
-                '--type=-[Return JSON for specified type, permissible values are "image" or "container"]:type:(image container)' \
-                '*:containers:__docker_containers' && ret=0
+                $opts_help \
+                "($help -f --format=-)"{-f,--format=-}"[Format the output using the given go template]:template: " \
+                "($help)--type=-[Return JSON for specified type]:type:(image container)" \
+                "($help -)*:containers:__docker_containers" && ret=0
             ;;
         (kill)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '(-s --signal)'{-s,--signal=-}'[Signal to send to the container]:signal:_signals' \
-                '*:containers:__docker_runningcontainers' && ret=0
+                $opts_help \
+                "($help -s --signal)"{-s,--signal=-}"[Signal to send]:signal:_signals" \
+                "($help -)*:containers:__docker_runningcontainers" && ret=0
             ;;
         (load)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '(-i --input)'{-i,--input=-}'[Read from a tar archive file, instead of STDIN]:archive file:_files -g "*.((tar|TAR)(.gz|.GZ|.Z|.bz2|.lzma|.xz|)|(tbz|tgz|txz))(-.)"' && ret=0
+                $opts_help \
+                "($help -i --input)"{-i,--input=-}"[Read from tar archive file]:archive file:_files -g "*.((tar|TAR)(.gz|.GZ|.Z|.bz2|.lzma|.xz|)|(tbz|tgz|txz))(-.)"" && ret=0
             ;;
         (login)
             _arguments \
-                '(-e --email)'{-e,--email=-}'[Email]:email: ' \
-                '(- :)--help[Print usage]' \
-                '(-p --password)'{-p,--password=-}'[Password]:password: ' \
-                '(-u --user)'{-u,--user=-}'[Username]:username: ' \
-                '1:server:->string' && ret=0
+                $opts_help \
+                "($help -e --email)"{-e,--email=-}"[Email]:email: " \
+                "($help -p --password)"{-p,--password=-}"[Password]:password: " \
+                "($help -u --user)"{-u,--user=-}"[Username]:username: " \
+                "($help -)1:server: " && ret=0
             ;;
         (logout)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '1:server:->string' && ret=0
+                $opts_help \
+                "($help -)1:server: " && ret=0
             ;;
         (logs)
             _arguments \
-                '(-f --follow)'{-f,--follow}'[Follow log output]' \
-                '(- :)--help[Print usage]' \
-                '--since=-[Show logs since timestamp]:timestamp: ' \
-                '(-t --timestamps)'{-t,--timestamps}'[Show timestamps]' \
-                '--tail=-[Number of lines to show from the end of the logs]:lines:(1 10 20 50 all)' \
-                '*:containers:__docker_containers' && ret=0
+                $opts_help \
+                "($help -f --follow)"{-f,--follow}"[Follow log output]" \
+                "($help -s --since)"{-s,--since=-}"[Show logs since this timestamp]:timestamp: " \
+                "($help -t --timestamps)"{-t,--timestamps}"[Show timestamps]" \
+                "($help)--tail=-[Output the last K lines]:lines:(1 10 20 50 all)" \
+                "($help -)*:containers:__docker_containers" && ret=0
             ;;
         (pause|unpause)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '*:containers:__docker_runningcontainers' && ret=0
+                $opts_help \
+                "($help -)*:containers:__docker_runningcontainers" && ret=0
             ;;
         (port)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '1:containers:__docker_runningcontainers' \
-                '2:port:_ports' && ret=0
+                $opts_help \
+                "($help -)1:containers:__docker_runningcontainers" \
+                "($help -)2:port:_ports" && ret=0
             ;;
         (ps)
             _arguments \
-                '(-a --all)'{-a,--all}'[how all containers (default shows just running)]' \
-                '--before=-[Show only container created before Id or Name]:containers:__docker_containers' \
-                '*'{-f,--filter=-}'[Filter output based on conditions provided]:filter: ' \
-                '(- :)--help[Print usage]' \
-                '(-l --latest)'{-l,--latest}'[Show the latest created container, include non-running]' \
-                '-n[Show n last created containers, include non-running]:n:(1 5 10 25 50)' \
-                '--no-trunc[Do not truncate output]' \
-                '(-q --quiet)'{-q,--quiet}'[Only show numeric IDs]' \
-                '(-s --size)'{-s,--size}'[Display total file sizes]' \
-                '--since=-[Show created since Id or Name, include non-running]:containers:__docker_containers' && ret=0
+                $opts_help \
+                "($help -a --all)"{-a,--all}"[Show all containers]" \
+                "($help)--before=-[Show only container created before...]:containers:__docker_containers" \
+                "($help)*"{-f,--filter=-}"[Filter values]:filter: " \
+                "($help -l --latest)"{-l,--latest}"[Show only the latest created container]" \
+                "($help)-n[Show n last created containers, include non-running one]:n:(1 5 10 25 50)" \
+                "($help)--no-trunc[Do not truncate output]" \
+                "($help -q --quiet)"{-q,--quiet}"[Only show numeric IDs]" \
+                "($help -s --size)"{-s,--size}"[Display total file sizes]" \
+                "($help)--since=-[Show only containers created since...]:containers:__docker_containers" && ret=0
             ;;
         (pull)
             _arguments \
-                '(-a --all-tags)'{-a,--all-tags}'[Download all tagged images in the repository]' \
-                '(- :)--help[Print usage]' \
-                ':name:__docker_search' && ret=0
+                $opts_help \
+                "($help -a --all-tags)"{-a,--all-tags}"[Download all tagged images]" \
+                "($help -):name:__docker_search" && ret=0
             ;;
         (push)
             _arguments \
-                '(- :)--help[Print usage]' \
-                ':images:__docker_images' && ret=0
+                $opts_help \
+                "($help -): :__docker_images" && ret=0
             ;;
         (rename)
             _arguments \
-                '(- :)--help[Print usage]' \
-                ':old name:__docker_containers' \
-                ':new name: ' && ret=0
+                $opts_help \
+                "($help -):old name:__docker_containers" \
+                "($help -):new name: " && ret=0
             ;;
         (restart|stop)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '(-t --time)'{-t,--time=-}'[Seconds to wait for stop before killing the container]:seconds to before killing:(1 5 10 30 60)' \
-                '*:containers:__docker_runningcontainers' && ret=0
+                $opts_help \
+                "($help -t --time=-)"{-t,--time=-}"[Number of seconds to try to stop for before killing the container]:seconds to before killing:(1 5 10 30 60)" \
+                "($help -)*:containers:__docker_runningcontainers" && ret=0
             ;;
         (rm)
             _arguments \
-                '(-f --force)'{-f,--force}'[Force the removal of a running container (uses SIGKILL)]' \
-                '(- :)--help[Print usage]' \
-                '(-l --link)'{-l,--link}'[Remove the specified link and not the underlying container]' \
-                '(-v --volumes)'{-v,--volumes}'[Remove the volumes associated to the container]' \
-                '*:containers:__docker_stoppedcontainers' && ret=0
+                $opts_help \
+                "($help -f --force)"{-f,--force}"[Force removal]" \
+                "($help -l --link)"{-l,--link}"[Remove the specified link and not the underlying container]" \
+                "($help -v --volumes)"{-v,--volumes}"[Remove the volumes associated to the container]" \
+                "($help -)*:containers:__docker_stoppedcontainers" && ret=0
             ;;
         (rmi)
             _arguments \
-                '(-f --force)'{-f,--force}'[Force removal of the image]' \
-                '(- :)--help[Print usage]' \
-                '--no-prune[Do not delete untagged parents]' \
-                '*:images:__docker_images' && ret=0
+                $opts_help \
+                "($help -f --force)"{-f,--force}"[Force removal]" \
+                "($help)--no-prune[Do not delete untagged parents]" \
+                "($help -)*: :__docker_images" && ret=0
             ;;
         (run)
             _arguments \
-                '*'{-a,--attach=-}'[Attach to STDIN, STDOUT or STDERR]:STD:(STDIN STDOUT STDERR)' \
-                '*--add-host=-[Add a custom host-to-IP mapping (host\:ip)]:host\:ip mapping: ' \
-                '--blkio-weight=-[Block IO (relative weight), between 10 and 1000]:Block IO weight: ' \
-                '(-c --cpu-shares)'{-c,--cpu-shares=-}'[CPU shares (relative weight)]:CPU shares:(0 10 100 200 500 800 1000)' \
-                '*--cap-add=-[Add Linux capabilities]:capability: ' \
-                '*--cap-drop=-[Drop Linux capabilities]:capability: ' \
-                '--cgroup-parent=-[Optional parent cgroup for the container]:cgroup parent: ' \
-                '--cidfile=-[Write the container ID to the file]:CID file:_files' \
-                '--cpu-period=-[Limit CPU CFS (Completely Fair Scheduler) period]:CPU period: ' \
-                '--cpu-quota=-[Limit the CPU CFS quota]:CPU quota: ' \
-                '--cpuset-cpus=-[CPUs in which to allow execution (0-3, 0,1)]:CPUs: ' \
-                '--cpuset-mems=-[MEMs in which to allow execution (0-3, 0,1)]:MEMs: ' \
-                '(-d --detach)'{-d,--detach}'[Run container in background and print container ID]' \
-                '*--device=-[Add a host device to the container]:device:_files' \
-                '*--dns=-[Set custom dns servers]:dns server: ' \
-                '*--dns-search=-[Set custom DNS search domains]:dns domains: ' \
-                '*'{-e,--env=-}'[Set environment variables]:environment variable: ' \
-                '--entrypoint=-[Overwrite the default ENTRYPOINT of the image]:entry point: ' \
-                '*--env-file=-[Read in a file of environment variables]:environment file:_files' \
-                '*--expose=-[Expose a port or a range of ports]:port or a range of ports: ' \
-                '*--group-add=-[Add additional groups to run as]:group: ' \
-                '(-h --hostname)'{-h,--hostname=-}'[Container host name]:hostname:_hosts' \
-                '(- :)--help[Print usage]' \
-                '(-i --interactive)'{-i,--interactive}'[Keep STDIN open even if not attached]' \
-                '--ipc=-[IPC namespace to use]:IPC: ' \
-                '*'{-l,--label=-}'[Set meta data on a container]:Label: ' \
-                '*--label-file=-[Read in a line delimited file of labels]' \
-                '*--link=-[Add link to another container]:link:->link' \
-                '--log-driver=-[Logging driver for container]:Logging driver:(json-file syslog journald gelf fluentd none)' \
-                '*--log-opt=-[Log driver options]:Log driver options: ' \
-                '*--lxc-conf=-[Add custom lxc options]:lxc options: ' \
-                '(-m --memory)'{-m,--memory=-}'[Memory limit (in bytes)]:Memory limit: ' \
-                '--mac-address=-[Container MAC address (e.g. 92:d0:c6:0a:29:33)]:MAC address: ' \
-                "--memory-swap=-[Total memory (memory + swap), '-1' to disable swap]:Total memory: " \
-                '--name=-[Assign a name to the container]:name: ' \
-                '--net=-[Set the Network mode for the container]:network mode:(bridge none container host)' \
-                '--oom-kill-disable[Disable OOM Killer]' \
-                '(-P --publish-all)'{-P,--publish-all}'[Publish all exposed ports to random ports]' \
-                '*'{-p,--publish=-}"[Publish a container's port(s) to the host]:port:_ports" \
-                '--pid=-[PID namespace to use]:PID: ' \
-                '--privileged[Give extended privileges to this container]' \
-                "--read-only[Mount the container's root filesystem as read only]" \
-                '--restart=-[Restart policy]:restart policy:(no on-failure always)' \
-                '--rm[Remove intermediate containers when it exits]' \
-                '*--security-opt=-[Security options]:security option: ' \
-                '--sig-proxy[Proxy all received signals to the process (non-TTY mode only)]' \
-                '(-t --tty)'{-t,--tty}'[Allocate a pseudo-TTY]' \
-                '(-u --user)'{-u,--user=-}'[Username or UID]:user:_users' \
-                '*--ulimit=-[Ulimit options]:ulimit: ' \
-                '--uts=-[UTS namespace to use]:UTS: ' \
-                '*'{-v,--volume=-}'[Bind mount a volume]:volume: ' \
-                '*--volumes-from=-[Mount volumes from the specified container]:volume: ' \
-                '(-w --workdir)'{-w,--workdir=-}'[Working directory inside the container]:directory:_directories' \
-                '(-):images:__docker_images' \
-                '(-):command: _command_names -e' \
-                '*::arguments: _normal' && ret=0
+                $opts_help \
+                $opts_cpumem \
+                $opts_create \
+                "($help -d --detach)"{-d,--detach}"[Detached mode: leave the container running in the background]" \
+                "($help)--rm[Remove intermediate containers when it exits]" \
+                "($help)--sig-proxy[Proxy all received signals to the process (non-TTY mode only)]" \
+                "($help -): :__docker_images" \
+                "($help -):command: _command_names -e" \
+                "($help -)*::arguments: _normal" && ret=0
 
             case $state in
                 (link)
-                    if compset -P '*:'; then
-                        _wanted alias expl 'Alias' compadd -E ""
+                    if compset -P "*:"; then
+                        _wanted alias expl "Alias" compadd -E "" && ret=0
                     else
-                        __docker_runningcontainers -qS ":"
+                        __docker_runningcontainers -qS ":" && ret=0
                     fi
                     ;;
             esac
@@ -549,62 +519,61 @@ __docker_subcommand() {
             ;;
         (save)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '(-o --output)'{-o,--output=-}'[Write to file]:file: ' \
-                '*:images:__docker_images' && ret=0
+                $opts_help \
+                "($help -o --output)"{-o,--output=-}"[Write to file]:file:_files" \
+                "($help -)*: :__docker_images" && ret=0
             ;;
         (search)
             _arguments \
-                '--automated[Only show automated builds]' \
-                '(- :)--help[Print usage]' \
-                '--no-trunc[Do not truncate output]' \
-                '(-s --stars)'{-s,--stars=-}'[Only display with at least X stars]:stars:(0 10 100 1000)' \
-                '1:term:->string' && ret=0
+                $opts_help \
+                "($help)--automated[Only show automated builds]" \
+                "($help)--no-trunc[Do not truncate output]" \
+                "($help -s --stars)"{-s,--stars=-}"[Only display with at least X stars]:stars:(0 10 100 1000)" \
+                "($help -):term: " && ret=0
             ;;
         (start)
             _arguments \
-                '(-a --attach)'{-a,--attach}'[Attach STDOUT/STDERR and forward signals]' \
-                '(- :)--help[Print usage]' \
-                '(-i --interactive)'{-i,--interactive}"[Attach container's STDIN]" \
-                '*:containers:__docker_stoppedcontainers' && ret=0
+                $opts_help \
+                "($help -a --attach)"{-a,--attach}"[Attach container's stdout/stderr and forward all signals]" \
+                "($help -i --interactive)"{-i,--interactive}"[Attach container's stding]" \
+                "($help -)*:containers:__docker_stoppedcontainers" && ret=0
             ;;
         (stats)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '--no-stream[Disable streaming stats and only pull the first result]' \
-                '*:containers:__docker_runningcontainers' && ret=0
+                $opts_help \
+                "($help)--no-stream[Disable streaming stats and only pull the first result]" \
+                "($help -)*:containers:__docker_runningcontainers" && ret=0
             ;;
         (tag)
             _arguments \
-                '(-f --force)'{-f,--force}'[force]' \
-                '(- :)--help[Print usage]' \
-                ':image:__docker_images' \
-                ':repository:__docker_repositories_with_tags' && ret=0
+                $opts_help \
+                "($help -f --force)"{-f,--force}"[force]"\
+                "($help -):source:__docker_images"\
+                "($help -):destination:__docker_repositories_with_tags" && ret=0
             ;;
         (top)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '1:containers:__docker_runningcontainers' \
-                '(-)*:: :->ps-arguments' && ret=0
+                $opts_help \
+                "($help -)1:containers:__docker_runningcontainers" \
+                "($help -)*:: :->ps-arguments" && ret=0
             case $state in
                 (ps-arguments)
-                    _ps
+                    _ps && ret=0
                     ;;
             esac
 
             ;;
         (wait)
             _arguments \
-                '(- :)--help[Print usage]' \
-                '*:containers:__docker_runningcontainers' && ret=0
+                $opts_help \
+                "($help -)*:containers:__docker_runningcontainers" && ret=0
             ;;
         (help)
-            _arguments ':subcommand:__docker_commands' && ret=0
+            _arguments ":subcommand:__docker_commands" && ret=0
             ;;
-        (*)
-            _message 'Unknown sub command'
     esac
 
+    return ret
 }
 
 _docker() {
@@ -615,70 +584,59 @@ _docker() {
         return
     fi
 
-    local curcontext="$curcontext" state line
-    typeset -A opt_args
+    local curcontext="$curcontext" state line help="-h --help"
     integer ret=1
+    typeset -A opt_args
 
     _arguments -C \
-        '--api-cors-header=-[Set CORS headers in the remote API]:CORS headers: ' \
-        '(-b --bridge)'{-b,--bridge=-}'[Attach containers to a network bridge]:bridge: ' \
-        '--bip=-[Specify network bridge IP]' \
-        '(-D --debug)'{-D,--debug}'[Enable debug mode]' \
-        '(-d --daeamon)'{-d,--daemon}'[Enable daemon mode]' \
-        '--default-gateway[Container default gateway IPv4 address]:IPv4 address: ' \
-        '--default-gateway-v6[Container default gateway IPv6 address]:IPv6 address: ' \
-        '*--dns=-[DNS server to use]:DNS: ' \
-        '*--dns-search=-[DNS search domains to use]' \
-        '*--default-ulimit=-[Set default ulimit settings for containers]:ulimit: ' \
-        '(-e --exec-driver)'{-e,--exec-driver=-}'[Exec driver to use]:driver:(native lxc Windows)' \
-        '*--exec-opt=-[Set exec driver options]:exec driver options: ' \
-        '--exec-root=-[Root of the Docker execdriver (default: /var/run/docker)]:PATH:_directories' \
-        '--fixed-cidr=-[IPv4 subnet for fixed IPs]:IPv4 subnet: ' \
-        '--fixed-cidr-v6=-[IPv6 subnet for fixed IPs]:IPv6 subnet: ' \
-        '(-G --group)'{-G,--group=-}'[Group for the unix socket (default: docker)]:group:_groups' \
-        '(-g --graph)'{-g,--graph=-}'[Root of the Docker runtime (default: /var/lib/docker)]:PATH:_directories' \
-        '(-H --host)'{-H,--host=-}'[tcp://host:port to bind/connect to]:host: ' \
-        '(-h --help)'{-h,--help}'[Print usage]' \
-        '--icc[Enable inter-container communication]' \
-        '*--insecure-registry=-[Enable insecure registry communication]:registry: ' \
-        '--ip=-[Default IP when binding container ports (default: 0.0.0.0)]' \
-        '--ip-forward=-[Enable net.ipv4.ip_forward]:enable:(true false)' \
-        '--ip-masq=-[Enable IP masquerading]:enable:(true false)' \
-        '--iptables=-[Enable addition of iptables rules]:enable:(true false)' \
-        '--ipv6[Enable IPv6 networking]' \
-        '(-l --log-level)'{-l,--log-level=-}'[Set the logging level]:level:(debug info warn error fatal)' \
-        '*--label=-[Set key=value labels to the daemon]:label: ' \
-        '--log-driver=-[Default driver for container logs (default: json-file)]:Logging driver:(json-file syslog journald gelf fluentd none)' \
-        '*--log-opt=-[Log driver specific options]:log driver options: ' \
-        '--mtu=-[Set the containers network MTU (default: 0)]' \
-        '(-p --pidfile)'{-p,--pidfile=-}'[Path to use for daemon PID file (default: /var/run/docker.pid)]:PID file PATH: ' \
-        '*--registry-mirror=-[Preferred Docker registry mirror]:registry mirror: ' \
-        '(-s --storage-driver)'{-s,--storage-driver=-}'[Storage driver to use]:driver:(aufs devicemapper btrfs zfs overlay)' \
-        '--selinux-enabled[Enable selinux support]' \
-        '*--storage-opt=-[Set storage driver options]:storage driver options: ' \
-        '--tls[Use TLS; implied by --tlsverify]' \
-        '--tlscacert=-[Trust certs signed only by this CA (default: ~/.docker/ca.pem)]' \
-        '--tlscert=-[Path to TLS certificate file (default: ~/.docker/cert.pem)]' \
-        '--tlskey=-[Path to TLS key file (default: ~/.docker/key.pem)]' \
-        '--tlsverify[Use TLS and verify the remote]' \
-        '--userland-proxy=-[Use userland proxy for loopback traffic]:enable:(true false)' \
-        '(-v --version)'{-v,--version}'[Print version information and quit]' \
-        '(-): :->command' \
-        '(-)*:: :->option-or-argument' && ret=0
+        "(: -)"{-h,--help}"[Print usage]" \
+        "($help)--api-cors-header=-[Set CORS headers in the remote API]:CORS headers: " \
+        "($help -b --bridge)"{-b,--bridge=-}"[Attach containers to a network bridge]:bridge:_net_interfaces" \
+        "($help)--bip=-[Specify network bridge IP]" \
+        "($help -D --debug)"{-D,--debug}"[Enable debug mode]" \
+        "($help -d --daeamon)"{-d,--daemon}"[Enable daemon mode]" \
+        "($help)--default-gateway[Container default gateway IPv4 address]:IPv4 address: " \
+        "($help)--default-gateway-v6[Container default gateway IPv6 address]:IPv6 address: " \
+        "($help)*--dns=-[DNS server to use]:DNS: " \
+        "($help)*--dns-search=-[DNS search domains to use]" \
+        "($help)*--default-ulimit=-[Set default ulimit settings for containers]:ulimit: " \
+        "($help -e --exec-driver)"{-e,--exec-driver=-}"[Exec driver to use]:driver:(native lxc windows)" \
+        "($help)*--exec-opt=-[Set exec driver options]:exec driver options: " \
+        "($help)--exec-root=-[Root of the Docker execdriver]:path:_directories" \
+        "($help)--fixed-cidr=-[IPv4 subnet for fixed IPs]:IPv4 subnet: " \
+        "($help)--fixed-cidr-v6=-[IPv6 subnet for fixed IPs]:IPv6 subnet: " \
+        "($help -G --group)"{-G,--group=-}"[Group for the unix socket]:group:_groups" \
+        "($help -g --graph)"{-g,--graph=-}"[Root of the Docker runtime]:path:_directories" \
+        "($help -H --host)"{-H,--host=-}"[tcp://host:port to bind/connect to]:host: " \
+        "($help)--icc[Enable inter-container communication]" \
+        "($help)*--insecure-registry=-[Enable insecure registry communication]:registry: " \
+        "($help)--ip=-[Default IP when binding container ports]" \
+        "($help)--ip-forward[Enable net.ipv4.ip_forward]" \
+        "($help)--ip-masq[Enable IP masquerading]" \
+        "($help)--iptables[Enable addition of iptables rules]" \
+        "($help)--ipv6[Enable IPv6 networking]" \
+        "($help -l --log-level)"{-l,--log-level=-}"[Set the logging level]:level:(debug info warn error fatal)" \
+        "($help)*--label=-[Set key=value labels to the daemon]:label: " \
+        "($help)--log-driver=-[Default driver for container logs]:Logging driver:(json-file syslog journald gelf fluentd none)" \
+        "($help)*--log-opt=-[Log driver specific options]:log driver options: " \
+        "($help)--mtu=-[Set the containers network MTU]:mtu:(0 576 1420 1500 9000)" \
+        "($help -p --pidfile)"{-p,--pidfile=-}"[Path to use for daemon PID file]:PID file:_files" \
+        "($help)*--registry-mirror=-[Preferred Docker registry mirror]:registry mirror: " \
+        "($help -s --storage-driver)"{-s,--storage-driver=-}"[Storage driver to use]:driver:(aufs devicemapper btrfs zfs overlay)" \
+        "($help)--selinux-enabled[Enable selinux support]" \
+        "($help)*--storage-opt=-[Set storage driver options]:storage driver options: " \
+        "($help)--tls[Use TLS]" \
+        "($help)--tlscacert=-[Trust certs signed only by this CA]:PEM file:_files -g "*.(pem|crt)"" \
+        "($help)--tlscert=-[Path to TLS certificate file]:PEM file:_files -g "*.(pem|crt)"" \
+        "($help)--tlskey=-[Path to TLS key file]:Key file:_files -g "*.(pem|key)"" \
+        "($help)--tlsverify[Use TLS and verify the remote]" \
+        "($help)--userland-proxy[Use userland proxy for loopback traffic]" \
+        "($help -v --version)"{-v,--version}"[Print version information and quit]" \
+        "($help -): :->command" \
+        "($help -)*:: :->option-or-argument" && ret=0
 
-    local counter=1
-    while [ $counter -lt ${#words} ]; do
-        case "${words[$counter]}" in
-            --host|-H)
-                (( counter++ ))
-                host="${words[$counter]}"
-                ;;
-            *)
-                ;;
-        esac
-        (( counter++ ))
-    done
-    docker_options=${host:+-H "$host"}
+    local host=${opt_args[-H]}${opt_args[--host]}
+    local docker_options=${host:+--host $host}
 
     case $state in
         (command)


### PR DESCRIPTION
zsh completion is updated with the content of
felixr/docker-zsh-completion.
- felixr/docker-zsh-completion@a93e1cb7bd5a Fix completion of repositories with tags
- felixr/docker-zsh-completion@590ea7059698 Respect provided `--host` flag when invoking docker
- felixr/docker-zsh-completion@6c557babaa3c Several cosmetic improvements
- felixr/docker-zsh-completion@5b63cc591a5c Update completion for `inspect`
- felixr/docker-zsh-completion@b7d8f2f7cc92 Order completions alphabetically
- felixr/docker-zsh-completion@63f6a0622496 Factor completion for `build`, `create` and `run`
- felixr/docker-zsh-completion@ade49ee47f9c Enforce positional arguments being last
- felixr/docker-zsh-completion@850b6b6d95e6 Update completion for build/commit/export/exec/history/import
- felixr/docker-zsh-completion@01bfd8c075dc Remove completion for `insert` and duplicate of `import`
- felixr/docker-zsh-completion@c64a1d730a90 Update completion for `stats` to add `--no-stream` flag
- felixr/docker-zsh-completion@5e81d78b5270 Update completion for `log` to add `--since` flag
- felixr/docker-zsh-completion@b3c146a1a222 Update completion for `run` to add `--group-add` flag
- felixr/docker-zsh-completion@8d4f196ad825 Don't trigger expensive completion function for flags
- felixr/docker-zsh-completion@bd5aaa124d9d Add completion for `--help` everywhere
- felixr/docker-zsh-completion@3a67a0e8c421 Return appropriate status code on completion
- felixr/docker-zsh-completion@4dfcb450eaeb Add Steve as a regular contributor.
- felixr/docker-zsh-completion@996a1c6def35 Add completion for top-level flags
- felixr/docker-zsh-completion@b6df75905f2e Ensure short/long option are not allowed twice
- felixr/docker-zsh-completion@75b6a500a04a Complete repositories with tags only on repository match
- felixr/docker-zsh-completion@5e6292135fcc Factorize completion of images/repositories/tags
- felixr/docker-zsh-completion@1c504eb6779d Handle repositories with ":"
- felixr/docker-zsh-completion@0a05bf818bbc Update completion for `pause' and`unpause'
- felixr/docker-zsh-completion@b3a63253e2bc Containers name can include Swarm host

In summary:
- Swarm support
- Handling repositories with ":"
- Rework how completion of images/repositories/tags work:
  - felixr/docker-zsh-completion@5e6292135fcc
  - felixr/docker-zsh-completion@75b6a500a04a
  - felixr/docker-zsh-completion@a93e1cb7bd5a

The remaining changes are here to sync changes done in Docker repository
(mostly from PR #14074 and #14555, by @sdurrheimer). With some minor changes:
- boolean flags don't complete their arguments (true/false)
- reuse of `--host` argument is done with `$opt_arg` to avoid parsing
  error
- build/create/run common options are factorized out
- `--help` flag is handled differently
- `pause` and `unpause` accepts several containers as far as I know, so
  the change is reverted
- some more, but difficult to notice (more completion for some flags I think)

Some labels are reverted, mostly because I did the merge by copy/pasting
new options instead of modifying existing options.

This commit is partial. The way the `--help` option is handled triggered
a major change due to the way things are quoted. Those changes were
partially and programmaticaly reverted in this commit only to minimize
the changes to review. The next commit will restore the full changes.

Signed-off-by: Vincent Bernat vincent@bernat.im
