### PR TITLE
Allow auth over http.

### DIFF
--- a/registry/session.go
+++ b/registry/session.go
@@ -483,9 +483,6 @@ func (r *Session) PushImageJSONRegistry(imgData *ImgData, jsonRaw []byte, regist
 		return fmt.Errorf("Failed to upload metadata: %s", err)
 	}
 	defer res.Body.Close()
-	if res.StatusCode == 401 && strings.HasPrefix(registry, "http://") {
-		return httputils.NewHTTPRequestError("HTTP code 401, Docker will not send auth headers over HTTP.", res)
-	}
 	if res.StatusCode != 200 {
 		errBody, err := ioutil.ReadAll(res.Body)
 		if err != nil {


### PR DESCRIPTION
Because we cannot dictate the http rules.

Fixes #9570.

Signed-off-by: David Calavera david.calavera@gmail.com
