### PR TITLE
Windows: Revendor hcsshim@f674a70f1306dbe20b3a516bedd3285d85db60d9

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -12,7 +12,7 @@ clone git github.com/go-check/check 64131543e7896d5bcc6bd5a76287eb75ea96c673
 clone git github.com/gorilla/context 14f550f51a
 clone git github.com/gorilla/mux e444e69cbd
 clone git github.com/kr/pty 5cf931ef8f
-clone git github.com/microsoft/hcsshim 2f540b26beafc3d4aded4fc9799af261a1a91352
+clone git github.com/microsoft/hcsshim f674a70f1306dbe20b3a516bedd3285d85db60d9
 clone git github.com/mistifyio/go-zfs v2.1.1
 clone git github.com/natefinch/npipe 0938d701e50e580f5925c773055eb6d6b32a0cbc
 clone git github.com/tchap/go-patricia v2.1.0

--- a/vendor/src/github.com/microsoft/hcsshim/createcomputesystem.go
+++ b/vendor/src/github.com/microsoft/hcsshim/createcomputesystem.go
@@ -23,19 +23,6 @@ func CreateComputeSystem(id string, configuration string) error {
 		return err
 	}
 
-	/*
-		Example configuration JSON below. RootDevicePath MUST use \\ not \ as path
-		separator. TODO Windows: Update this JSON sample with final API.
-
-		{
-		    "SystemType" : "Container",
-			"Name" : "ContainerName",
-		    "RootDevicePath" : "C:\\Containers\\test",
-			"IsDummy" : true
-		}
-
-	*/
-
 	// Convert id to uint16 pointers for calling the procedure
 	idp, err := syscall.UTF16PtrFromString(id)
 	if err != nil {

--- a/vendor/src/github.com/microsoft/hcsshim/createprocess.go
+++ b/vendor/src/github.com/microsoft/hcsshim/createprocess.go
@@ -54,7 +54,7 @@ func CreateProcessInComputeSystem(id string, params CreateProcessParams) (proces
 
 	paramsJson, err := json.Marshal(params)
 	if err != nil {
-		err = fmt.Errorf(title+" - Failed to marshall params %s %s", params, err)
+		err = fmt.Errorf(title+" - Failed to marshall params %v %s", params, err)
 		return 0, err
 	}
 
@@ -79,7 +79,7 @@ func CreateProcessInComputeSystem(id string, params CreateProcessParams) (proces
 	use(unsafe.Pointer(paramsJsonp))
 
 	if r1 != 0 {
-		err = fmt.Errorf(title+" - Win32 API call returned error r1=%d err=%s id=%s params=%s", r1, syscall.Errno(r1), id, params)
+		err = fmt.Errorf(title+" - Win32 API call returned error r1=%d err=%s id=%s params=%v", r1, syscall.Errno(r1), id, params)
 		logrus.Error(err)
 		return 0, err
 	}

--- a/vendor/src/github.com/microsoft/hcsshim/getlayermountpath.go
+++ b/vendor/src/github.com/microsoft/hcsshim/getlayermountpath.go
@@ -75,7 +75,7 @@ func GetLayerMountPath(info DriverInfo, id string) (string, error) {
 	use(unsafe.Pointer(idp))
 
 	if r1 != 0 {
-		err = fmt.Errorf(title+" - Second Win32 API call returned error r1=%d errno=%d id=%s flavour=%d",
+		err = fmt.Errorf(title+" - Second Win32 API call returned error r1=%d err=%s id=%s flavour=%d",
 			r1, syscall.Errno(r1), id, info.Flavour)
 		logrus.Error(err)
 		return "", err

--- a/vendor/src/github.com/microsoft/hcsshim/getsharedbaseimages.go
+++ b/vendor/src/github.com/microsoft/hcsshim/getsharedbaseimages.go
@@ -1,0 +1,53 @@
+package hcsshim
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+
+	"github.com/Sirupsen/logrus"
+)
+
+func GetSharedBaseImages() (imageData string, err error) {
+	title := "hcsshim::GetSharedBaseImages "
+
+	// Load the DLL and get a handle to the procedure we need
+	dll, proc, err := loadAndFind(procGetSharedBaseImages)
+	if dll != nil {
+		defer dll.Release()
+	}
+	if err != nil {
+		return
+	}
+
+	// Load the OLE DLL and get a handle to the CoTaskMemFree procedure
+	dll2, proc2, err := loadAndFindFromDll(oleDLLName, procCoTaskMemFree)
+	if dll2 != nil {
+		defer dll2.Release()
+	}
+	if err != nil {
+		return
+	}
+
+	var output uintptr
+
+	// Call the procedure again
+	logrus.Debugf("Calling proc")
+	r1, _, _ := proc.Call(
+		uintptr(unsafe.Pointer(&output)))
+
+	if r1 != 0 {
+		err = fmt.Errorf(title+" - Win32 API call returned error r1=%d errno=%s",
+			r1, syscall.Errno(r1))
+		logrus.Error(err)
+		return
+	}
+
+	// Defer the cleanup of the memory using CoTaskMemFree
+	defer proc2.Call(output)
+
+	imageData = syscall.UTF16ToString((*[1 << 30]uint16)(unsafe.Pointer(output))[:])
+	logrus.Debugf(title+" - succeeded output=%s", imageData)
+
+	return
+}

--- a/vendor/src/github.com/microsoft/hcsshim/hcsshim.go
+++ b/vendor/src/github.com/microsoft/hcsshim/hcsshim.go
@@ -26,43 +26,55 @@ const (
 	procResizeConsoleInComputeSystem    = "ResizeConsoleInComputeSystem"
 
 	// Storage related functions in the shim DLL
-	procLayerExists        = "LayerExists"
-	procCreateLayer        = "CreateLayer"
-	procDestroyLayer       = "DestroyLayer"
-	procActivateLayer      = "ActivateLayer"
-	procDeactivateLayer    = "DeactivateLayer"
-	procGetLayerMountPath  = "GetLayerMountPath"
-	procCopyLayer          = "CopyLayer"
-	procCreateSandboxLayer = "CreateSandboxLayer"
-	procPrepareLayer       = "PrepareLayer"
-	procUnprepareLayer     = "UnprepareLayer"
-	procExportLayer        = "ExportLayer"
-	procImportLayer        = "ImportLayer"
+	procLayerExists         = "LayerExists"
+	procCreateLayer         = "CreateLayer"
+	procDestroyLayer        = "DestroyLayer"
+	procActivateLayer       = "ActivateLayer"
+	procDeactivateLayer     = "DeactivateLayer"
+	procGetLayerMountPath   = "GetLayerMountPath"
+	procCopyLayer           = "CopyLayer"
+	procCreateSandboxLayer  = "CreateSandboxLayer"
+	procPrepareLayer        = "PrepareLayer"
+	procUnprepareLayer      = "UnprepareLayer"
+	procExportLayer         = "ExportLayer"
+	procImportLayer         = "ImportLayer"
+	procGetSharedBaseImages = "GetBaseImages"
+
+	// Name of the standard OLE dll
+	oleDLLName = "Ole32.dll"
+
+	// Utility functions
+	procCoTaskMemFree = "CoTaskMemFree"
 )
 
-// loadAndFind finds a procedure in the DLL. Note we do NOT do lazy loading as
+// loadAndFindFromDll finds a procedure in the given DLL. Note we do NOT do lazy loading as
 // go is particularly unfriendly in the case of a mismatch. By that - it panics
 // if a function can't be found. By explicitly loading, we can control error
 // handling gracefully without the daemon terminating.
-func loadAndFind(procedure string) (dll *syscall.DLL, proc *syscall.Proc, err error) {
+func loadAndFindFromDll(dllName, procedure string) (dll *syscall.DLL, proc *syscall.Proc, err error) {
+	logrus.Debugf("hcsshim::loadAndFindFromDll %s %s", dllName, procedure)
 
-	logrus.Debugf("hcsshim::loadAndFind %s", procedure)
-
-	dll, err = syscall.LoadDLL(shimDLLName)
+	dll, err = syscall.LoadDLL(dllName)
 	if err != nil {
-		err = fmt.Errorf("Failed to load %s - error %s", shimDLLName, err)
+		err = fmt.Errorf("Failed to load %s - error %s", dllName, err)
 		logrus.Error(err)
-		return nil, nil, err
+		return
 	}
 
 	proc, err = dll.FindProc(procedure)
 	if err != nil {
-		err = fmt.Errorf("Failed to find %s in %s", procedure, shimDLLName)
+		err = fmt.Errorf("Failed to find %s in %s", procedure, dllName)
 		logrus.Error(err)
-		return nil, nil, err
+		return
 	}
 
-	return dll, proc, nil
+	return
+}
+
+// loadAndFind finds a procedure in the shim DLL.
+func loadAndFind(procedure string) (*syscall.DLL, *syscall.Proc, error) {
+
+	return loadAndFindFromDll(shimDLLName, procedure)
 }
 
 // use is a no-op, but the compiler cannot see that it is.


### PR DESCRIPTION
Signed-off-by: John Howard John.Howard@microsoft.com

@swernli. This updates HCS shim for the Windows daemon to f674a70f1306dbe20b3a516bedd3285d85db60d9. This corrects a couple of logging errors, and adds support for shared base images.
