### PR TITLE
Windows: Hook up user supplied MAC

### DIFF
--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -77,9 +77,8 @@ func populateCommand(c *Container, env []string) error {
 	case "none":
 	case "default", "": // empty string to support existing containers
 		if !c.Config.NetworkDisabled {
-			network := c.NetworkSettings
 			en.Interface = &execdriver.NetworkInterface{
-				MacAddress: network.MacAddress,
+				MacAddress: c.Config.MacAddress,
 				Bridge:     c.daemon.config.Bridge.VirtualSwitchName,
 			}
 		}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. Very simple fix to ensure the user supplied MAC address to docker run is populated correctly.
