### PR TITLE
Windows: hostconfig on start

### DIFF
--- a/daemon/start.go
+++ b/daemon/start.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/docker/docker/runconfig"
 )
@@ -24,11 +25,18 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConf
 		return err
 	}
 
-	// This is kept for backward compatibility - hostconfig should be passed when
-	// creating a container, not during start.
-	if hostConfig != nil {
-		if err := daemon.setHostConfig(container, hostConfig); err != nil {
-			return err
+	// Windows does not have the backwards compatibilty issue here.
+	if runtime.GOOS != "windows" {
+		// This is kept for backward compatibility - hostconfig should be passed when
+		// creating a container, not during start.
+		if hostConfig != nil {
+			if err := daemon.setHostConfig(container, hostConfig); err != nil {
+				return err
+			}
+		}
+	} else {
+		if hostConfig != nil {
+			return fmt.Errorf("Supplying a hostconfig on start is not supported. It should be supplied on create")
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. This addresses a backwards compatibility issue which doesn't affect Windows, hence the Windows daemon errors out. (Specifically if a hostConfig is passed to start.)
