### PR TITLE
indicate HostConfig to be used for "create container" (add again)

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.16.md
+++ b/docs/reference/api/docker_remote_api_v1.16.md
@@ -511,70 +511,17 @@ Status Codes:
 
 Start the container `id`
 
+> **Note**:
+> For backwards compatibility, this endpoint accepts a `HostConfig` as JSON-encoded request body.
+> See [create a container](#create-a-container) for details.
+
 **Example request**:
 
         POST /containers/(id)/start HTTP/1.1
-        Content-Type: application/json
-
-        {
-             "Binds": ["/tmp:/tmp"],
-             "Links": ["redis3:redis"],
-             "LxcConf": {"lxc.utsname":"docker"},
-             "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
-             "PublishAllPorts": false,
-             "Privileged": false,
-             "Dns": ["8.8.8.8"],
-             "DnsSearch": [""],
-             "VolumesFrom": ["parent", "other:ro"],
-             "CapAdd": ["NET_ADMIN"],
-             "CapDrop": ["MKNOD"],
-             "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
-             "NetworkMode": "bridge",
-             "Devices": []
-        }
 
 **Example response**:
 
         HTTP/1.1 204 No Content
-
-Json Parameters:
-
--   **Binds** – A list of volume bindings for this container.  Each volume
-        binding is a string of the form `container_path` (to create a new
-        volume for the container), `host_path:container_path` (to bind-mount
-        a host path into the container), or `host_path:container_path:ro`
-        (to make the bind-mount read-only inside the container).
--   **Links** - A list of links for the container.  Each link entry should be of
-      of the form "container_name:alias".
--   **LxcConf** - LXC specific configurations.  These configurations will only
-      work when using the `lxc` execution driver.
--   **PortBindings** - A map of exposed container ports and the host port they
-      should map to. It should be specified in the form
-      `{ <port>/<protocol>: [{ "HostPort": "<port>" }] }`
-      Take note that `port` is specified as a string and not an integer value.
--   **PublishAllPorts** - Allocates a random host port for all of a container's
-      exposed ports. Specified as a boolean value.
--   **Privileged** - Gives the container full access to the host.  Specified as
-      a boolean value.
--   **Dns** - A list of dns servers for the container to use.
--   **DnsSearch** - A list of DNS search domains
--   **VolumesFrom** - A list of volumes to inherit from another container.
-      Specified in the form `<container name>[:<ro|rw>]`
--   **CapAdd** - A list of kernel capabilities to add to the container.
--   **Capdrop** - A list of kernel capabilities to drop from the container.
--   **RestartPolicy** – The behavior to apply when the container exits.  The
-        value is an object with a `Name` property of either `"always"` to
-        always restart or `"on-failure"` to restart only when the container
-        exit code is non-zero.  If `on-failure` is used, `MaximumRetryCount`
-        controls the number of times to retry before giving up.
-        The default is not to restart. (optional)
-        An ever increasing delay (double the previous delay, starting at 100mS)
-        is added before each restart to prevent flooding the server.
--   **NetworkMode** - Sets the networking mode for the container. Supported
-      values are: `bridge`, `host`, and `container:<name|id>`
--   **Devices** - A list of devices to add to the container specified in the
-      form
-      `{ "PathOnHost": "/dev/deviceName", "PathInContainer": "/dev/deviceName", "CgroupPermissions": "mrw"}`
 
 Status Codes:
 

--- a/docs/reference/api/docker_remote_api_v1.17.md
+++ b/docs/reference/api/docker_remote_api_v1.17.md
@@ -641,73 +641,17 @@ Status Codes:
 
 Start the container `id`
 
+> **Note**:
+> For backwards compatibility, this endpoint accepts a `HostConfig` as JSON-encoded request body.
+> See [create a container](#create-a-container) for details.
+
 **Example request**:
 
         POST /containers/(id)/start HTTP/1.1
-        Content-Type: application/json
-
-        {
-             "Binds": ["/tmp:/tmp"],
-             "Links": ["redis3:redis"],
-             "LxcConf": {"lxc.utsname":"docker"},
-             "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
-             "PublishAllPorts": false,
-             "Privileged": false,
-             "ReadonlyRootfs": false,
-             "Dns": ["8.8.8.8"],
-             "DnsSearch": [""],
-             "VolumesFrom": ["parent", "other:ro"],
-             "CapAdd": ["NET_ADMIN"],
-             "CapDrop": ["MKNOD"],
-             "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
-             "NetworkMode": "bridge",
-             "Devices": []
-        }
 
 **Example response**:
 
         HTTP/1.1 204 No Content
-
-Json Parameters:
-
--   **Binds** – A list of volume bindings for this container.  Each volume
-        binding is a string of the form `container_path` (to create a new
-        volume for the container), `host_path:container_path` (to bind-mount
-        a host path into the container), or `host_path:container_path:ro`
-        (to make the bind-mount read-only inside the container).
--   **Links** - A list of links for the container.  Each link entry should be of
-      of the form "container_name:alias".
--   **LxcConf** - LXC specific configurations.  These configurations will only
-      work when using the `lxc` execution driver.
--   **PortBindings** - A map of exposed container ports and the host port they
-      should map to. It should be specified in the form
-      `{ <port>/<protocol>: [{ "HostPort": "<port>" }] }`
-      Take note that `port` is specified as a string and not an integer value.
--   **PublishAllPorts** - Allocates a random host port for all of a container's
-      exposed ports. Specified as a boolean value.
--   **Privileged** - Gives the container full access to the host.  Specified as
-      a boolean value.
--   **ReadonlyRootfs** - Mount the container's root filesystem as read only.
-      Specified as a boolean value.
--   **Dns** - A list of dns servers for the container to use.
--   **DnsSearch** - A list of DNS search domains
--   **VolumesFrom** - A list of volumes to inherit from another container.
-      Specified in the form `<container name>[:<ro|rw>]`
--   **CapAdd** - A list of kernel capabilities to add to the container.
--   **Capdrop** - A list of kernel capabilities to drop from the container.
--   **RestartPolicy** – The behavior to apply when the container exits.  The
-        value is an object with a `Name` property of either `"always"` to
-        always restart or `"on-failure"` to restart only when the container
-        exit code is non-zero.  If `on-failure` is used, `MaximumRetryCount`
-        controls the number of times to retry before giving up.
-        The default is not to restart. (optional)
-        An ever increasing delay (double the previous delay, starting at 100mS)
-        is added before each restart to prevent flooding the server.
--   **NetworkMode** - Sets the networking mode for the container. Supported
-      values are: `bridge`, `host`, and `container:<name|id>`
--   **Devices** - A list of devices to add to the container specified in the
-      form
-      `{ "PathOnHost": "/dev/deviceName", "PathInContainer": "/dev/deviceName", "CgroupPermissions": "mrw"}`
 
 Status Codes:
 

--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -682,94 +682,17 @@ Status Codes:
 
 Start the container `id`
 
+> **Note**:
+> For backwards compatibility, this endpoint accepts a `HostConfig` as JSON-encoded request body.
+> See [create a container](#create-a-container) for details.
+
 **Example request**:
 
         POST /containers/(id)/start HTTP/1.1
-        Content-Type: application/json
-
-        {
-            "Binds": ["/tmp:/tmp"],
-            "Links": ["redis3:redis"],
-            "LxcConf": {"lxc.utsname":"docker"},
-            "Memory": 0,
-            "MemorySwap": 0,
-            "CpuShares": 512,
-            "CpusetCpus": "0,1",
-            "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
-            "PublishAllPorts": false,
-            "Privileged": false,
-            "ReadonlyRootfs": false,
-            "Dns": ["8.8.8.8"],
-            "DnsSearch": [""],
-            "ExtraHosts": null,
-            "VolumesFrom": ["parent", "other:ro"],
-            "CapAdd": ["NET_ADMIN"],
-            "CapDrop": ["MKNOD"],
-            "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
-            "NetworkMode": "bridge",
-            "Devices": [],
-            "Ulimits": [{}],
-            "LogConfig": { "Type": "json-file", Config: {} },
-            "SecurityOpt": [""],
-            "CgroupParent": ""
-        }
 
 **Example response**:
 
         HTTP/1.1 204 No Content
-
-Json Parameters:
-
--   **Binds** – A list of volume bindings for this container. Each volume
-        binding is a string of the form `container_path` (to create a new
-        volume for the container), `host_path:container_path` (to bind-mount
-        a host path into the container), or `host_path:container_path:ro`
-        (to make the bind-mount read-only inside the container).
--   **Links** - A list of links for the container. Each link entry should be of
-      of the form `container_name:alias`.
--   **LxcConf** - LXC specific configurations. These configurations will only
-      work when using the `lxc` execution driver.
--   **PortBindings** - A map of exposed container ports and the host port they
-      should map to. It should be specified in the form
-      `{ <port>/<protocol>: [{ "HostPort": "<port>" }] }`
-      Take note that `port` is specified as a string and not an integer value.
--   **PublishAllPorts** - Allocates a random host port for all of a container's
-      exposed ports. Specified as a boolean value.
--   **Privileged** - Gives the container full access to the host. Specified as
-      a boolean value.
--   **ReadonlyRootfs** - Mount the container's root filesystem as read only.
-      Specified as a boolean value.
--   **Dns** - A list of dns servers for the container to use.
--   **DnsSearch** - A list of DNS search domains
--   **ExtraHosts** - A list of hostnames/IP mappings to be added to the
-    container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
--   **VolumesFrom** - A list of volumes to inherit from another container.
-      Specified in the form `<container name>[:<ro|rw>]`
--   **CapAdd** - A list of kernel capabilities to add to the container.
--   **Capdrop** - A list of kernel capabilities to drop from the container.
--   **RestartPolicy** – The behavior to apply when the container exits.  The
-        value is an object with a `Name` property of either `"always"` to
-        always restart or `"on-failure"` to restart only when the container
-        exit code is non-zero.  If `on-failure` is used, `MaximumRetryCount`
-        controls the number of times to retry before giving up.
-        The default is not to restart. (optional)
-        An ever increasing delay (double the previous delay, starting at 100mS)
-        is added before each restart to prevent flooding the server.
--   **NetworkMode** - Sets the networking mode for the container. Supported
-      values are: `bridge`, `host`, and `container:<name|id>`
--   **Devices** - A list of devices to add to the container specified in the
-      form
-      `{ "PathOnHost": "/dev/deviceName", "PathInContainer": "/dev/deviceName", "CgroupPermissions": "mrw"}`
--   **Ulimits** - A list of ulimits to be set in the container, specified as
-      `{ "Name": <name>, "Soft": <soft limit>, "Hard": <hard limit> }`, for example:
-      `Ulimits: { "Name": "nofile", "Soft": 1024, "Hard", 2048 }}`
--   **SecurityOpt**: A list of string values to customize labels for MLS
-    systems, such as SELinux.
--   **LogConfig** - Log configuration for the container, specified as
-      `{ "Type": "<driver_name>", "Config": {"key1": "val1"}}`.
-      Available types: `json-file`, `syslog`, `none`.
-      `json-file` logging driver.
--   **CgroupParent** - Path to cgroups under which the cgroup for the container will be created. If the path is not absolute, the path is considered to be relative to the cgroups path of the init process. Cgroups will be created if they do not already exist.
 
 Status Codes:
 

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -701,93 +701,17 @@ Status Codes:
 
 Start the container `id`
 
+> **Note**:
+> For backwards compatibility, this endpoint accepts a `HostConfig` as JSON-encoded request body.
+> See [create a container](#create-a-container) for details.
+
 **Example request**:
 
-        POST /containers/(id)/start HTTP/1.1
-        Content-Type: application/json
-
-        {
-           "Binds": ["/tmp:/tmp"],
-           "Links": ["redis3:redis"],
-           "LxcConf": {"lxc.utsname":"docker"},
-           "Memory": 0,
-           "MemorySwap": 0,
-           "CpuShares": 512,
-           "CpusetCpus": "0,1",
-           "PortBindings": { "22/tcp": [{ "HostPort": "11022" }] },
-           "PublishAllPorts": false,
-           "Privileged": false,
-           "ReadonlyRootfs": false,
-           "Dns": ["8.8.8.8"],
-           "DnsSearch": [""],
-           "ExtraHosts": null,
-           "VolumesFrom": ["parent", "other:ro"],
-           "CapAdd": ["NET_ADMIN"],
-           "CapDrop": ["MKNOD"],
-           "RestartPolicy": { "Name": "", "MaximumRetryCount": 0 },
-           "NetworkMode": "bridge",
-           "Devices": [],
-           "Ulimits": [{}],
-           "LogConfig": { "Type": "json-file", "Config": {} },
-           "SecurityOpt": [""],
-           "CgroupParent": ""
-        }
+    POST /containers/(id)/start HTTP/1.1
 
 **Example response**:
 
-      HTTP/1.1 204 No Content
-
-Json Parameters:
-
--   **Binds** – A list of volume bindings for this container. Each volume binding is a string in one of these forms:
-       + `container_path` to create a new volume for the container
-       + `host_path:container_path` to bind-mount a host path into the container
-       + `host_path:container_path:ro` to make the bind-mount read-only inside the container.
--   **Links** - A list of links for the container. Each link entry should be of
-      of the form `container_name:alias`.
--   **LxcConf** - LXC specific configurations. These configurations only
-      work when using the `lxc` execution driver.
--   **PortBindings** - A map of exposed container ports and the host port they
-          should map to. A JSON object in the form
-          `{ <port>/<protocol>: [{ "HostPort": "<port>" }] }`
-          Take note that `port` is specified as a string and not an integer value.
--   **PublishAllPorts** - Allocates a random host port for all of a container's
-      exposed ports. Specified as a boolean value.
--   **Privileged** - Gives the container full access to the host. Specified as
-      a boolean value.
--   **ReadonlyRootfs** - Mount the container's root filesystem as read only.
-      Specified as a boolean value.
--   **Dns** - A list of dns servers for the container to use.
--   **DnsSearch** - A list of DNS search domains.
--   **ExtraHosts** - A list of hostnames/IP mappings to add to the
-    container's `/etc/hosts` file. Specified in the form `["hostname:IP"]`.
--   **VolumesFrom** - A list of volumes to inherit from another container.
-      Specified in the form `<container name>[:<ro|rw>]`
--   **CapAdd** - A list of kernel capabilities to add to the container.
--   **Capdrop** - A list of kernel capabilities to drop from the container.
--   **RestartPolicy** – The behavior to apply when the container exits.  The
-        value is an object with a `Name` property of either `"always"` to
-        always restart or `"on-failure"` to restart only when the container
-        exit code is non-zero.  If `on-failure` is used, `MaximumRetryCount`
-        controls the number of times to retry before giving up.
-        The default is not to restart. (optional)
-        An ever increasing delay (double the previous delay, starting at 100mS)
-        is added before each restart to prevent flooding the server.
--   **NetworkMode** - Sets the networking mode for the container. Supported
-      values are: `bridge`, `host`, and `container:<name|id>`
--   **Devices** - A list of devices to add to the container specified as a JSON object in the
-      form
-      `{ "PathOnHost": "/dev/deviceName", "PathInContainer": "/dev/deviceName", "CgroupPermissions": "mrw"}`
--   **Ulimits** - A list of ulimits to set in the container, specified as
-      `{ "Name": <name>, "Soft": <soft limit>, "Hard": <hard limit> }`, for example:
-      `Ulimits: { "Name": "nofile", "Soft": 1024, "Hard", 2048 }}`
--   **SecurityOpt**: A list of string values to customize labels for MLS
-    systems, such as SELinux.
--   **LogConfig** - Log configuration for the container, specified as
-      `{ "Type": "<driver_name>", "Config": {"key1": "val1"}}`.
-      Available types: `json-file`, `syslog`, `journald`, `none`.
-      `json-file` logging driver.
-    -   **CgroupParent** - Path to `cgroups` under which the container's `cgroup` is created. If the path is not absolute, the path is considered to be relative to the `cgroups` path of the init process. Cgroups are created if they do not already exist.
+    HTTP/1.1 204 No Content
 
 Status Codes:
 


### PR DESCRIPTION
As proposed in #13466 ([comment](https://github.com/docker/docker/issues/13466#issuecomment-121379461)) this re-adds a [commit from master](https://github.com/gesellix/docker/commit/16e649c589ce60ba56812a8fffb98aee34fceb94) originally applied with PR #13615 to be applied on the `docs` branch.

Is this the way to go for docs changes?
/cc @moxiegirl

Signed-off-by: Tobias Gesellchen tobias@gesellix.de
