### PR TITLE
Fix link to examples documentation

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,23 @@
+<!--[metadata]>
++++
+title = "Applied Docker"
+description = "Provides examples for using Docker"
+keywords = ["dockerize, dockerizing apps, dockerizing applications, container,  containers"]
+[menu.main]
+identifier = "smn_applied"
+parent = "mn_use_docker"
+weight = 8	
++++
+<![end-metadata]-->
+
+# Examples
+
+This section contains the following:
+
+* [Dockerizing MongoDB](mongodb.md)
+* [Dockerizing PostgreSQL](postgresql_service.md)    
+* [Dockerizing a CouchDB service](couchdb_data_volumes.md)         
+* [Dockerizing a Node.js web app](nodejs_web_app.md)
+* [Dockerizing a Redis service](running_redis_service.md)
+* [Dockerizing an apt-cacher-ng service](apt-cacher-ng.md)
+* [Dockerizing applications: A 'Hello world'](/userguide/dockerizing)


### PR DESCRIPTION
https://docs.docker.com/examples/ just leads to a blank page.

Alternatively this could be an index or some other anchor, but at least this change makes it go to a working page.
