### PR TITLE
Add missing 'err' to Fatalf to help debug an issue

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -458,7 +458,7 @@ func (s *DockerSuite) TestInspectExecID(c *check.C) {
 	// Save execID for later
 	execID, err := inspectFilter(id, "index .ExecIDs 0")
 	if err != nil {
-		c.Fatalf("failed to get the exec id")
+		c.Fatalf("failed to get the exec id: %v", err)
 	}
 
 	// End the exec by closing its stdin, and wait for it to end


### PR DESCRIPTION
Signed-off-by: Doug Davis dug@us.ibm.com
