### PR TITLE
Use ReadLine instead of ReadBytes to prevent daemon from OOM caused b…

### DIFF
--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/docker/daemon/logger"
 	"github.com/docker/docker/pkg/timeutils"
 	"github.com/go-check/check"
 )
@@ -22,8 +23,10 @@ func (s *DockerSuite) TestLogsContainerSmallerThanPage(c *check.C) {
 
 	dockerCmd(c, "wait", cleanedContainerID)
 	out, _ = dockerCmd(c, "logs", cleanedContainerID)
-	if len(out) != testLen+1 {
-		c.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
+	// Each line up to MaxBytesPerLine bytes
+	expectedLen := testLen + testLen/logger.MaxBytesPerLine + 1
+	if len(out) != expectedLen {
+		c.Fatalf("Expected log length of %d, received %d\n", expectedLen, len(out))
 	}
 }
 
@@ -36,9 +39,10 @@ func (s *DockerSuite) TestLogsContainerBiggerThanPage(c *check.C) {
 	dockerCmd(c, "wait", cleanedContainerID)
 
 	out, _ = dockerCmd(c, "logs", cleanedContainerID)
-
-	if len(out) != testLen+1 {
-		c.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
+	// Each line up to MaxBytesPerLine bytes
+	expectedLen := testLen + testLen/logger.MaxBytesPerLine + 1
+	if len(out) != expectedLen {
+		c.Fatalf("Expected log length of %d, received %d\n", expectedLen, len(out))
 	}
 }
 
@@ -51,9 +55,10 @@ func (s *DockerSuite) TestLogsContainerMuchBiggerThanPage(c *check.C) {
 	dockerCmd(c, "wait", cleanedContainerID)
 
 	out, _ = dockerCmd(c, "logs", cleanedContainerID)
-
-	if len(out) != testLen+1 {
-		c.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
+	// Each line up to MaxBytesPerLine bytes
+	expectedLen := testLen + testLen/logger.MaxBytesPerLine + 1
+	if len(out) != expectedLen {
+		c.Fatalf("Expected log length of %d, received %d\n", expectedLen, len(out))
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Chun Chen ramichen@tencent.com

If a single line is huge, see https://github.com/docker/docker/issues/9139#issuecomment-67390145, it costs so much to buffer the whole line in the memory. We could use `ReadLine` instead of `ReadBytes` to fix such case. The default buf size is 4096 bytes in `bufio` which I think is enough for most cases. If you think it's necessary to add an option for users to config the size, I can update the patch.
