### PR TITLE
Fix InspectExecID test

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -449,7 +449,7 @@ func (s *DockerSuite) TestInspectExecID(c *check.C) {
 		if out != "[]" && out != "<no value>" {
 			break
 		}
-		if i == tries {
+		if i+1 == tries {
 			c.Fatalf("ExecIDs should not be empty, got: %s", out)
 		}
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
The check for the end of the loop was off by one which is why we saw
errors on the following inpsect() call instead of a timeout

Signed-off-by: Doug Davis dug@us.ibm.com
