### PR TITLE
devicemapper: Change default basesize to 100G

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -29,7 +29,7 @@ import (
 var (
 	DefaultDataLoopbackSize     int64  = 100 * 1024 * 1024 * 1024
 	DefaultMetaDataLoopbackSize int64  = 2 * 1024 * 1024 * 1024
-	DefaultBaseFsSize           uint64 = 10 * 1024 * 1024 * 1024
+	DefaultBaseFsSize           uint64 = 100 * 1024 * 1024 * 1024
 	DefaultThinpBlockSize       uint32 = 128 // 64K = 128 512b sectors
 	DefaultUdevSyncOverride     bool   = false
 	MaxDeviceId                 int    = 0xffffff // 24 bit, pool limit


### PR DESCRIPTION
Fixes issue #14678 

Current default basesize is 10G. Change it to 100G. Reason being that for
some people 10G is turning out to be too small and we don't have capabilities
to grow it dyamically.

This is just overcommitting and no real space is allocated till container
actually writes data. And this is no different then fs based graphdrivers
where virtual size of a container root is unlimited.

Signed-off-by: Vivek Goyal vgoyal@redhat.com
