### PR TITLE
Remove references to boot2docker replace with docker-machine

### DIFF
--- a/docs/articles/b2d_volume_resize.md
+++ b/docs/articles/b2d_volume_resize.md
@@ -1,5 +1,6 @@
 <!--[metadata]>
 +++
+draft = "true"
 title = "Resizing a Boot2Docker volume	"
 description = "Resizing a Boot2Docker volume in VirtualBox with GParted"
 keywords = ["boot2docker, volume,  virtualbox"]

--- a/docs/examples/mongodb.md
+++ b/docs/examples/mongodb.md
@@ -158,8 +158,8 @@ as daemon process(es).
     # Usage: mongo --port <port you get from `docker ps`> 
     $ mongo --port 27017
 
-    # If using boot2docker
-    # Usage: mongo --port <port you get from `docker ps`>  --host <ip address from `boot2docker ip`>
+    # If using docker-machine
+    # Usage: mongo --port <port you get from `docker ps`>  --host <ip address from `docker-machine ip VM_NAME`>
     $ mongo --port 27017 --host 192.168.59.103
 
 > **Tip:**

--- a/docs/examples/nodejs_web_app.md
+++ b/docs/examples/nodejs_web_app.md
@@ -187,10 +187,10 @@ Now you can call your app using `curl` (install if needed via:
 
     Hello world
 
-If you use Boot2docker on OS X, the port is actually mapped to the Docker host VM,
-and you should use the following command:
+If you use Docker Machine on OS X, the port is actually mapped to the Docker
+host VM, and you should use the following command:
 
-    $ curl $(boot2docker ip):49160
+    $ curl $(docker-machine ip VM_NAME):49160
 
 We hope this tutorial helped you get up and running with Node.js and
 CentOS on Docker. You can get the full source code at

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -36,9 +36,9 @@ Windows*](../installation/windows/#windows) installation guides. The small Linux
 distribution boot2docker can be run inside virtual machines on these two
 operating systems.
 
-> **Note:** if you are using a remote Docker daemon, such as Boot2Docker, 
-> then _do not_ type the `sudo` before the `docker` commands shown in the
-> documentation's examples.
+>**Note:** if you are using a remote Docker daemon on a VM through Docker
+>Machine, then _do not_ type the `sudo` before the `docker` commands shown in
+>the documentation's examples.
 
 ### How do containers compare to virtual machines?
 

--- a/docs/project/set-up-dev-env.md
+++ b/docs/project/set-up-dev-env.md
@@ -96,9 +96,9 @@ environment.
 
 1. Open a terminal.
 
-    Mac users, use `boot2docker status` to make sure Boot2Docker is running. You
-    may need to run `eval "$(boot2docker shellinit)"` to initialize your shell
-    environment.
+    Mac users, use `docker-machine status` to make sure your VM is running. You
+    may need to run `eval "$(docker-machine env your_vm_name)"` to initialize your
+    shell environment.
 
 3. Change into the root of your forked repository.
 
@@ -207,8 +207,8 @@ build and run a `docker` binary in your container.
 
     ![Multiple terminals](/project/images/three_terms.png)
 
-    Mac OS X users, make sure you run `eval "$(boot2docker shellinit)"` in any new
-    terminals.
+    Mac OS X users, make sure you run `eval "$(docker-machine env your_vm_name)"` in
+    any new terminals.
 
 2. In a terminal, create a new container from your `dry-run-test` image.
 

--- a/docs/project/software-required.md
+++ b/docs/project/software-required.md
@@ -65,16 +65,15 @@ To check if `docker` is already installed on Linux:
     $ docker --version
     Docker version 1.5.0, build a8a31ef
 
-On Mac OS X or Windows, you should have installed Boot2Docker which includes
-Docker. You'll need to verify both Boot2Docker and then Docker. This
+On Mac OS X or Windows, you should have installed Docker Toolbox which includes
+Docker. You'll need to verify both Docker Machine and Docker. This
 documentation was written on OS X using the following versions.
 
-    $ boot2docker version
-    Boot2Docker-cli version: v1.5.0
-    Git commit: ccd9032
+    $ docker-machine --version
+    docker-machine version 0.3.0 (0a251fe)
 
     $ docker --version
-    Docker version 1.5.0, build a8a31ef
+    Docker version 1.7.0, build a8a31ef
 
 ## Linux users and sudo
 

--- a/docs/project/test-and-docs.md
+++ b/docs/project/test-and-docs.md
@@ -173,66 +173,6 @@ To run the same test inside your Docker development container, you do this:
 
     root@5f8630b873fe:/go/src/github.com/docker/docker# TESTFLAGS='-check.f TestBuild*' hack/make.sh binary test-integration-cli
 
-## If tests under Boot2Docker fail due to disk space errors
-
-Running the tests requires about 2GB of memory. If you are running your
-container on bare metal, that is you are not running with Boot2Docker, your
-Docker development container is able to take the memory it requires directly
-from your local host.
-
-If you are running Docker using Boot2Docker, the VM uses 2048MB by default.
-This means you can exceed the memory of your VM running tests in a Boot2Docker
-environment. When the test suite runs out of memory, it returns errors similar
-to the following:
-
-    server.go:1302 Error: Insertion failed because database is full: database or
-    disk is full
-
-    utils_test.go:179: Error copy: exit status 1 (cp: writing
-    '/tmp/docker-testd5c9-[...]': No space left on device
-
-To increase the memory on your VM, you need to reinitialize the Boot2Docker VM
-with new memory settings.
-
-1. Stop all running containers.
-
-2. View the current memory setting.
-
-        $ boot2docker info
-        {
-            "Name": "boot2docker-vm",
-            "UUID": "491736fd-4075-4be7-a6f5-1d4cdcf2cc74",
-            "Iso": "/Users/mary/.boot2docker/boot2docker.iso",
-            "State": "running",
-            "CPUs": 8,
-            "Memory": 2048,
-            "VRAM": 8,
-            "CfgFile": "/Users/mary/VirtualBox VMs/boot2docker-vm/boot2docker-vm.vbox",
-            "BaseFolder": "/Users/mary/VirtualBox VMs/boot2docker-vm",
-            "OSType": "",
-            "Flag": 0,
-            "BootOrder": null,
-            "DockerPort": 0,
-            "SSHPort": 2022,
-            "SerialFile": "/Users/mary/.boot2docker/boot2docker-vm.sock"
-        }
-
-
-3. Delete your existing `boot2docker` profile.
-
-        $ boot2docker delete
-
-4. Reinitialize `boot2docker` and specify a higher memory.
-
-        $ boot2docker init -m 5555
-
-5. Verify the memory was reset.
-
-        $ boot2docker info
-
-6. Restart your container and try your test again.
-
-
 ## Testing just the Windows client
 
 This explains how to test the Windows client on a Windows server set up as a

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -12,12 +12,11 @@ parent = "smn_remoteapi"
 
  - By default the Docker daemon listens on `unix:///var/run/docker.sock`
    and the client must have `root` access to interact with the daemon.
- - If the Docker daemon is set to use an encrypted TCP socket (`--tls`,
-   or `--tlsverify`) as with Boot2Docker 1.3.0, then you need to add extra
+ - If you are using `docker-machine`, the Docker daemon is on a virtual host that uses an encrypted TCP socket. In this situation, you need to add extra
    parameters to `curl` or `wget` when making test API requests:
-   `curl --insecure --cert ~/.docker/cert.pem --key ~/.docker/key.pem https://boot2docker:2376/images/json`
+   `curl --insecure --cert ~/.docker/cert.pem --key ~/.docker/key.pem https://YOUR_VM_IP:2376/images/json`
    or 
-   `wget --no-check-certificate --certificate=$DOCKER_CERT_PATH/cert.pem --private-key=$DOCKER_CERT_PATH/key.pem https://boot2docker:2376/images/json -O - -q`
+   `wget --no-check-certificate --certificate=$DOCKER_CERT_PATH/cert.pem --private-key=$DOCKER_CERT_PATH/key.pem https://your_vm_ip:2376/images/json -O - -q`
  - If a group named `docker` exists on your system, docker will apply
    ownership of the socket to the group.
  - The API tends to be REST, but for some complex commands, like attach

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -477,15 +477,15 @@ please check the [run](run.md) reference.
 
 IP masquerading uses address translation to allow containers without a public
 IP to talk to other machines on the Internet. This may interfere with some
-network topologies and can be disabled with --ip-masq=false.
+network topologies and can be disabled with `--ip-masq=false`.
 
 Docker supports softlinks for the Docker data directory (`/var/lib/docker`) and
 for `/var/lib/docker/tmp`. The `DOCKER_TMPDIR` and the data directory can be
 set like this:
 
-    DOCKER_TMPDIR=/mnt/disk2/tmp /usr/local/bin/docker daemon -D -g /var/lib/docker -H unix:// > /var/lib/boot2docker/docker.log 2>&1
+    DOCKER_TMPDIR=/mnt/disk2/tmp /usr/local/bin/docker daemon -D -g /var/lib/docker -H unix:// > /var/lib/docker-machine/docker.log 2>&1
     # or
     export DOCKER_TMPDIR=/mnt/disk2/tmp
-    /usr/local/bin/docker daemon -D -g /var/lib/docker -H unix:// > /var/lib/boot2docker/docker.log 2>&1
+    /usr/local/bin/docker daemon -D -g /var/lib/docker -H unix:// > /var/lib/docker-machine/docker.log 2>&1
 
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -22,11 +22,7 @@ Docker supports as a storage backend. It implements the
 ## boot2docker
 
 [boot2docker](http://boot2docker.io/) is a lightweight Linux distribution made
-specifically to run Docker containers. It is a common choice for a [VM](#virtual-machine)
-to run Docker on Windows and Mac OS X.
-
-boot2docker can also refer to the boot2docker management tool on Windows and
-Mac OS X which manages the boot2docker VM.
+specifically to run Docker containers. The boot2docker management tool for Mac and Windows was deprecated and replaced by [`docker-machine`](#machine) which you can install with the Docker Toolbox.
 
 ## btrfs
 
@@ -187,6 +183,11 @@ A tag is a label applied to a Docker image in a [repository](#repository).
 tags are how various images in a repository are distinguished from each other.
 
 *Note : This label is not related to the key=value labels set for docker daemon*
+
+## Toolbox
+
+Docker Toolbox is the installer for Mac and Windows users.
+
 
 ## Union file system
 

--- a/docs/userguide/usingdocker.md
+++ b/docs/userguide/usingdocker.md
@@ -166,15 +166,14 @@ see the application.
 Our Python application is live!
 
 > **Note:**
-> If you have used the `boot2docker` virtual machine on OS X, Windows or Linux,
+> If you have been using a virtual machine on OS X, Windows or Linux,
 > you'll need to get the IP of the virtual host instead of using localhost.
-> You can do this by running the following outside of the `boot2docker` shell
-> (i.e., from your comment line or terminal application).
+> You can do this by running the `docker-machine ip your_vm_name` from your  command line or terminal application, for example:
 > 
->     $ boot2docker ip
->     The VM's Host only interface IP address is: 192.168.59.103
+>     $ docker-machine ip my-docker-vm
+>     192.168.99.100
 > 
-> In this case you'd browse to http://192.168.59.103:49155 for the above example.
+> In this case you'd browse to http://192.168.99.100:49155 for the above example.
 
 ## A network port shortcut
 


### PR DESCRIPTION
- boot2docker is deprecated in the 1.8.0
- docker-machine replaces it
- this fixes #14563
- add Docker Toolbox where appropriate
- see https://github.com/docker/docker/pull/14565 for installation changes

Signed-off-by: Mary Anthony mary@docker.com
