### PR TITLE
Refactor: use dockerCmd when possible in integraiton-cli tests

### DIFF
--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -2,18 +2,16 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
+	"github.com/go-check/check"
 	"reflect"
 	"regexp"
 	"strings"
 	"time"
-
-	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestLinksPingUnlinkedContainers(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "--rm", "busybox", "sh", "-c", "ping -c 1 alias1 -W 1 && ping -c 1 alias2 -W 1")
-	exitCode, err := runCommand(runCmd)
+
+	_, exitCode, err := dockerCmdWithError(c, "run", "--rm", "busybox", "sh", "-c", "ping -c 1 alias1 -W 1 && ping -c 1 alias2 -W 1")
 
 	if exitCode == 0 {
 		c.Fatal("run ping did not fail")
@@ -26,8 +24,7 @@ func (s *DockerSuite) TestLinksPingUnlinkedContainers(c *check.C) {
 // Test for appropriate error when calling --link with an invalid target container
 func (s *DockerSuite) TestLinksInvalidContainerTarget(c *check.C) {
 
-	runCmd := exec.Command(dockerBinary, "run", "--link", "bogus:alias", "busybox", "true")
-	out, _, err := runCommandWithOutput(runCmd)
+	out, _, err := dockerCmdWithError(c, "run", "--link", "bogus:alias", "busybox", "true")
 
 	if err == nil {
 		c.Fatal("an invalid container target should produce an error")
@@ -40,14 +37,8 @@ func (s *DockerSuite) TestLinksInvalidContainerTarget(c *check.C) {
 
 func (s *DockerSuite) TestLinksPingLinkedContainers(c *check.C) {
 
-	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "container1", "--hostname", "fred", "busybox", "top")
-	if _, err := runCommand(runCmd); err != nil {
-		c.Fatal(err)
-	}
-	runCmd = exec.Command(dockerBinary, "run", "-d", "--name", "container2", "--hostname", "wilma", "busybox", "top")
-	if _, err := runCommand(runCmd); err != nil {
-		c.Fatal(err)
-	}
+	dockerCmd(c, "run", "-d", "--name", "container1", "--hostname", "fred", "busybox", "top")
+	dockerCmd(c, "run", "-d", "--name", "container2", "--hostname", "wilma", "busybox", "top")
 
 	runArgs := []string{"run", "--rm", "--link", "container1:alias1", "--link", "container2:alias2", "busybox", "sh", "-c"}
 	pingCmd := "ping -c 1 %s -W 1 && ping -c 1 %s -W 1"
@@ -131,38 +122,20 @@ func (s *DockerSuite) TestLinksInspectLinksStopped(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksNotStartedParentNotFail(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "create", "--name=first", "busybox", "top")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
-	runCmd = exec.Command(dockerBinary, "create", "--name=second", "--link=first:first", "busybox", "top")
-	out, _, _, err = runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
-	runCmd = exec.Command(dockerBinary, "start", "first")
-	out, _, _, err = runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+
+	dockerCmd(c, "create", "--name=first", "busybox", "top")
+	dockerCmd(c, "create", "--name=second", "--link=first:first", "busybox", "top")
+	dockerCmd(c, "start", "first")
+
 }
 
 func (s *DockerSuite) TestLinksHostsFilesInject(c *check.C) {
 	testRequires(c, SameHostDaemon, ExecSupport)
 
-	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-itd", "--name", "one", "busybox", "top"))
-	if err != nil {
-		c.Fatal(err, out)
-	}
-
+	out, _ := dockerCmd(c, "run", "-itd", "--name", "one", "busybox", "top")
 	idOne := strings.TrimSpace(out)
 
-	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", "-itd", "--name", "two", "--link", "one:onetwo", "busybox", "top"))
-	if err != nil {
-		c.Fatal(err, out)
-	}
-
+	out, _ = dockerCmd(c, "run", "-itd", "--name", "two", "--link", "one:onetwo", "busybox", "top")
 	idTwo := strings.TrimSpace(out)
 
 	time.Sleep(1 * time.Second)
@@ -185,14 +158,8 @@ func (s *DockerSuite) TestLinksHostsFilesInject(c *check.C) {
 
 func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 	testRequires(c, SameHostDaemon, ExecSupport)
-
-	if out, err := exec.Command(dockerBinary, "run", "-d", "--name", "one", "busybox", "top").CombinedOutput(); err != nil {
-		c.Fatal(err, string(out))
-	}
-	out, err := exec.Command(dockerBinary, "run", "-d", "--name", "two", "--link", "one:onetwo", "--link", "one:one", "busybox", "top").CombinedOutput()
-	if err != nil {
-		c.Fatal(err, string(out))
-	}
+	dockerCmd(c, "run", "-d", "--name", "one", "busybox", "top")
+	out, _ := dockerCmd(c, "run", "-d", "--name", "two", "--link", "one:onetwo", "--link", "one:one", "busybox", "top")
 	id := strings.TrimSpace(string(out))
 
 	realIP, err := inspectField("one", "NetworkSettings.IPAddress")
@@ -217,9 +184,7 @@ func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 	if ip := getIP(content, "onetwo"); ip != realIP {
 		c.Fatalf("For 'onetwo' alias expected IP: %s, got: %s", realIP, ip)
 	}
-	if out, err := exec.Command(dockerBinary, "restart", "one").CombinedOutput(); err != nil {
-		c.Fatal(err, string(out))
-	}
+	dockerCmd(c, "restart", "one")
 	realIP, err = inspectField("one", "NetworkSettings.IPAddress")
 	if err != nil {
 		c.Fatal(err)
@@ -237,19 +202,8 @@ func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksEnvs(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "-e", "e1=", "-e", "e2=v2", "-e", "e3=v3=v3", "--name=first", "busybox", "top")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("Run of first failed: %s\n%s", out, err)
-	}
-
-	runCmd = exec.Command(dockerBinary, "run", "--name=second", "--link=first:first", "busybox", "env")
-
-	out, stde, rc, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil || rc != 0 {
-		c.Fatalf("run of 2nd failed: rc: %d, out: %s\n err: %s", rc, out, stde)
-	}
-
+	dockerCmd(c, "run", "-d", "-e", "e1=", "-e", "e2=v2", "-e", "e3=v3=v3", "--name=first", "busybox", "top")
+	out, _ := dockerCmd(c, "run", "--name=second", "--link=first:first", "busybox", "env")
 	if !strings.Contains(out, "FIRST_ENV_e1=\n") ||
 		!strings.Contains(out, "FIRST_ENV_e2=v2") ||
 		!strings.Contains(out, "FIRST_ENV_e3=v3=v3") {
@@ -258,16 +212,12 @@ func (s *DockerSuite) TestLinksEnvs(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinkShortDefinition(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "--name", "shortlinkdef", "busybox", "top")
-	out, _, err := runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	out, _ := dockerCmd(c, "run", "-d", "--name", "shortlinkdef", "busybox", "top")
 
 	cid := strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
 
-	runCmd = exec.Command(dockerBinary, "run", "-d", "--name", "link2", "--link", "shortlinkdef", "busybox", "top")
-	out, _, err = runCommandWithOutput(runCmd)
-	c.Assert(err, check.IsNil)
+	out, _ = dockerCmd(c, "run", "-d", "--name", "link2", "--link", "shortlinkdef", "busybox", "top")
 
 	cid2 := strings.TrimSpace(out)
 	c.Assert(waitRun(cid2), check.IsNil)

--- a/integration-cli/docker_cli_links_unix_test.go
+++ b/integration-cli/docker_cli_links_unix_test.go
@@ -5,19 +5,13 @@ package main
 import (
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestLinksEtcHostsRegularFile(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "--net=host", "busybox", "ls", "-la", "/etc/hosts")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
-
+	out, _ := dockerCmd(c, "run", "--net=host", "busybox", "ls", "-la", "/etc/hosts")
 	if !strings.HasPrefix(out, "-") {
 		c.Errorf("/etc/hosts should be a regular file")
 	}
@@ -26,12 +20,7 @@ func (s *DockerSuite) TestLinksEtcHostsRegularFile(c *check.C) {
 func (s *DockerSuite) TestLinksEtcHostsContentMatch(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
-	runCmd := exec.Command(dockerBinary, "run", "--net=host", "busybox", "cat", "/etc/hosts")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
-
+	out, _ := dockerCmd(c, "run", "--net=host", "busybox", "cat", "/etc/hosts")
 	hosts, err := ioutil.ReadFile("/etc/hosts")
 	if os.IsNotExist(err) {
 		c.Skip("/etc/hosts does not exist, skip this test")
@@ -44,13 +33,8 @@ func (s *DockerSuite) TestLinksEtcHostsContentMatch(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksNetworkHostContainer(c *check.C) {
-
-	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "--net", "host", "--name", "host_container", "busybox", "top"))
-	if err != nil {
-		c.Fatal(err, out)
-	}
-
-	out, _, err = runCommandWithOutput(exec.Command(dockerBinary, "run", "--name", "should_fail", "--link", "host_container:tester", "busybox", "true"))
+	dockerCmd(c, "run", "-d", "--net", "host", "--name", "host_container", "busybox", "top")
+	out, _, err := dockerCmdWithError(c, "run", "--name", "should_fail", "--link", "host_container:tester", "busybox", "true")
 	if err == nil || !strings.Contains(out, "--net=host can't be used with links. This would result in undefined behavior") {
 		c.Fatalf("Running container linking to a container with --net host should have failed: %s", out)
 	}

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -17,21 +17,11 @@ import (
 // This used to work, it test a log of PageSize-1 (gh#4851)
 func (s *DockerSuite) TestLogsContainerSmallerThanPage(c *check.C) {
 	testLen := 32767
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("run failed with errors: %s, %v", out, err)
-	}
-
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
 	cleanedContainerID := strings.TrimSpace(out)
-	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
 
-	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
-	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	if err != nil {
-		c.Fatalf("failed to log container: %s, %v", out, err)
-	}
-
+	dockerCmd(c, "wait", cleanedContainerID)
+	out, _ = dockerCmd(c, "logs", cleanedContainerID)
 	if len(out) != testLen+1 {
 		c.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
 	}
@@ -40,20 +30,12 @@ func (s *DockerSuite) TestLogsContainerSmallerThanPage(c *check.C) {
 // Regression test: When going over the PageSize, it used to panic (gh#4851)
 func (s *DockerSuite) TestLogsContainerBiggerThanPage(c *check.C) {
 	testLen := 32768
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("run failed with errors: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
 
 	cleanedContainerID := strings.TrimSpace(out)
-	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
+	dockerCmd(c, "wait", cleanedContainerID)
 
-	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
-	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	if err != nil {
-		c.Fatalf("failed to log container: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "logs", cleanedContainerID)
 
 	if len(out) != testLen+1 {
 		c.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
@@ -63,20 +45,12 @@ func (s *DockerSuite) TestLogsContainerBiggerThanPage(c *check.C) {
 // Regression test: When going much over the PageSize, it used to block (gh#4851)
 func (s *DockerSuite) TestLogsContainerMuchBiggerThanPage(c *check.C) {
 	testLen := 33000
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("run failed with errors: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
 
 	cleanedContainerID := strings.TrimSpace(out)
-	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
+	dockerCmd(c, "wait", cleanedContainerID)
 
-	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
-	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	if err != nil {
-		c.Fatalf("failed to log container: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "logs", cleanedContainerID)
 
 	if len(out) != testLen+1 {
 		c.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
@@ -85,21 +59,12 @@ func (s *DockerSuite) TestLogsContainerMuchBiggerThanPage(c *check.C) {
 
 func (s *DockerSuite) TestLogsTimestamps(c *check.C) {
 	testLen := 100
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
-
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("run failed with errors: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
 
 	cleanedContainerID := strings.TrimSpace(out)
-	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
+	dockerCmd(c, "wait", cleanedContainerID)
 
-	logsCmd := exec.Command(dockerBinary, "logs", "-t", cleanedContainerID)
-	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	if err != nil {
-		c.Fatalf("failed to log container: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "logs", "-t", cleanedContainerID)
 
 	lines := strings.Split(out, "\n")
 
@@ -124,21 +89,12 @@ func (s *DockerSuite) TestLogsTimestamps(c *check.C) {
 
 func (s *DockerSuite) TestLogsSeparateStderr(c *check.C) {
 	msg := "stderr_log"
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
-
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("run failed with errors: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
 
 	cleanedContainerID := strings.TrimSpace(out)
-	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
+	dockerCmd(c, "wait", cleanedContainerID)
 
-	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
-	stdout, stderr, _, err := runCommandWithStdoutStderr(logsCmd)
-	if err != nil {
-		c.Fatalf("failed to log container: %s, %v", out, err)
-	}
+	stdout, stderr, _ := dockerCmdWithStdoutStderr(c, "logs", cleanedContainerID)
 
 	if stdout != "" {
 		c.Fatalf("Expected empty stdout stream, got %v", stdout)
@@ -152,22 +108,12 @@ func (s *DockerSuite) TestLogsSeparateStderr(c *check.C) {
 
 func (s *DockerSuite) TestLogsStderrInStdout(c *check.C) {
 	msg := "stderr_log"
-	runCmd := exec.Command(dockerBinary, "run", "-d", "-t", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
-
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("run failed with errors: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "-t", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
 
 	cleanedContainerID := strings.TrimSpace(out)
-	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
+	dockerCmd(c, "wait", cleanedContainerID)
 
-	logsCmd := exec.Command(dockerBinary, "logs", cleanedContainerID)
-	stdout, stderr, _, err := runCommandWithStdoutStderr(logsCmd)
-	if err != nil {
-		c.Fatalf("failed to log container: %s, %v", out, err)
-	}
-
+	stdout, stderr, _ := dockerCmdWithStdoutStderr(c, "logs", cleanedContainerID)
 	if stderr != "" {
 		c.Fatalf("Expected empty stderr stream, got %v", stdout)
 	}
@@ -180,45 +126,26 @@ func (s *DockerSuite) TestLogsStderrInStdout(c *check.C) {
 
 func (s *DockerSuite) TestLogsTail(c *check.C) {
 	testLen := 100
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
-
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("run failed with errors: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
 
 	cleanedContainerID := strings.TrimSpace(out)
-	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
+	dockerCmd(c, "wait", cleanedContainerID)
 
-	logsCmd := exec.Command(dockerBinary, "logs", "--tail", "5", cleanedContainerID)
-	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	if err != nil {
-		c.Fatalf("failed to log container: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "logs", "--tail", "5", cleanedContainerID)
 
 	lines := strings.Split(out, "\n")
 
 	if len(lines) != 6 {
 		c.Fatalf("Expected log %d lines, received %d\n", 6, len(lines))
 	}
-
-	logsCmd = exec.Command(dockerBinary, "logs", "--tail", "all", cleanedContainerID)
-	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	if err != nil {
-		c.Fatalf("failed to log container: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "logs", "--tail", "all", cleanedContainerID)
 
 	lines = strings.Split(out, "\n")
 
 	if len(lines) != testLen+1 {
 		c.Fatalf("Expected log %d lines, received %d\n", testLen+1, len(lines))
 	}
-
-	logsCmd = exec.Command(dockerBinary, "logs", "--tail", "random", cleanedContainerID)
-	out, _, _, err = runCommandWithStdoutStderr(logsCmd)
-	if err != nil {
-		c.Fatalf("failed to log container: %s, %v", out, err)
-	}
+	out, _, _ = dockerCmdWithStdoutStderr(c, "logs", "--tail", "random", cleanedContainerID)
 
 	lines = strings.Split(out, "\n")
 
@@ -228,15 +155,10 @@ func (s *DockerSuite) TestLogsTail(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsFollowStopped(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "echo", "hello")
-
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("run failed with errors: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
 
 	cleanedContainerID := strings.TrimSpace(out)
-	exec.Command(dockerBinary, "wait", cleanedContainerID).Run()
+	dockerCmd(c, "wait", cleanedContainerID)
 
 	logsCmd := exec.Command(dockerBinary, "logs", "-f", cleanedContainerID)
 	if err := logsCmd.Start(); err != nil {
@@ -259,22 +181,13 @@ func (s *DockerSuite) TestLogsFollowStopped(c *check.C) {
 
 func (s *DockerSuite) TestLogsSince(c *check.C) {
 	name := "testlogssince"
-	runCmd := exec.Command(dockerBinary, "run", "--name="+name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do sleep 2; echo `date +%s` log$i; done")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf("run failed with errors: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "--name="+name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do sleep 2; echo `date +%s` log$i; done")
 
 	log2Line := strings.Split(strings.Split(out, "\n")[1], " ")
 	t, err := strconv.ParseInt(log2Line[0], 10, 64) // the timestamp log2 is writen
 	c.Assert(err, check.IsNil)
 	since := t + 1 // add 1s so log1 & log2 doesn't show up
-	logsCmd := exec.Command(dockerBinary, "logs", "-t", fmt.Sprintf("--since=%v", since), name)
-
-	out, _, err = runCommandWithOutput(logsCmd)
-	if err != nil {
-		c.Fatalf("failed to log container: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "logs", "-t", fmt.Sprintf("--since=%v", since), name)
 
 	// Skip 2 seconds
 	unexpected := []string{"log1", "log2"}
@@ -283,7 +196,6 @@ func (s *DockerSuite) TestLogsSince(c *check.C) {
 			c.Fatalf("unexpected log message returned=%v, since=%v\nout=%v", v, since, out)
 		}
 	}
-
 	// Test with default value specified and parameter omitted
 	expected := []string{"log1", "log2", "log3"}
 	for _, cmd := range []*exec.Cmd{
@@ -303,20 +215,12 @@ func (s *DockerSuite) TestLogsSince(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsSinceFutureFollow(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "/bin/sh", "-c", `for i in $(seq 1 5); do date +%s; sleep 1; done`)
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf("run failed with errors: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", `for i in $(seq 1 5); do date +%s; sleep 1; done`)
 	cleanedContainerID := strings.TrimSpace(out)
 
 	now := daemonTime(c).Unix()
 	since := now + 2
-	logCmd := exec.Command(dockerBinary, "logs", "-f", fmt.Sprintf("--since=%v", since), cleanedContainerID)
-	out, _, err = runCommandWithOutput(logCmd)
-	if err != nil {
-		c.Fatalf("failed to log container: %s, %v", out, err)
-	}
+	out, _ = dockerCmd(c, "logs", "-f", fmt.Sprintf("--since=%v", since), cleanedContainerID)
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 	if len(lines) == 0 {
 		c.Fatal("got no log lines")
@@ -334,12 +238,7 @@ func (s *DockerSuite) TestLogsSinceFutureFollow(c *check.C) {
 
 // Regression test for #8832
 func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "/bin/sh", "-c", `usleep 200000;yes X | head -c 200000`)
-
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	if err != nil {
-		c.Fatalf("run failed with errors: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", `usleep 200000;yes X | head -c 200000`)
 
 	cleanedContainerID := strings.TrimSpace(out)
 

--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
@@ -44,11 +43,7 @@ func getExternalAddress(c *check.C) net.IP {
 }
 
 func getContainerLogs(c *check.C, containerID string) string {
-	runCmd := exec.Command(dockerBinary, "logs", containerID)
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ := dockerCmd(c, "logs", containerID)
 	return strings.Trim(out, "\r\n")
 }
 
@@ -104,12 +99,8 @@ func (s *DockerSuite) TestNetworkLoopbackNat(c *check.C) {
 	msg := "it works"
 	startServerContainer(c, msg, 8080)
 	endpoint := getExternalAddress(c)
-	runCmd := exec.Command(dockerBinary, "run", "-t", "--net=container:server", "busybox",
+	out, _ := dockerCmd(c, "run", "-t", "--net=container:server", "busybox",
 		"sh", "-c", fmt.Sprintf("stty raw && nc -w 5 %s 8080", endpoint.String()))
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
 	final := strings.TrimRight(string(out), "\n")
 	if final != msg {
 		c.Fatalf("Expected message %q but received %q", msg, final)

--- a/integration-cli/docker_cli_network_test.go
+++ b/integration-cli/docker_cli_network_test.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
@@ -22,9 +21,7 @@ func assertNwNotAvailable(c *check.C, name string) {
 }
 
 func isNwPresent(c *check.C, name string) bool {
-	runCmd := exec.Command(dockerBinary, "network", "ls")
-	out, _, _, err := runCommandWithStdoutStderr(runCmd)
-	c.Assert(err, check.IsNil)
+	out, _ := dockerCmd(c, "network", "ls")
 	lines := strings.Split(out, "\n")
 	for i := 1; i < len(lines)-1; i++ {
 		if strings.Contains(lines[i], name) {
@@ -42,13 +39,9 @@ func (s *DockerSuite) TestDockerNetworkLsDefault(c *check.C) {
 }
 
 func (s *DockerSuite) TestDockerNetworkCreateDelete(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "network", "create", "test")
-	_, _, _, err := runCommandWithStdoutStderr(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd(c, "network", "create", "test")
 	assertNwIsAvailable(c, "test")
 
-	runCmd = exec.Command(dockerBinary, "network", "rm", "test")
-	_, _, _, err = runCommandWithStdoutStderr(runCmd)
-	c.Assert(err, check.IsNil)
+	dockerCmd(c, "network", "rm", "test")
 	assertNwNotAvailable(c, "test")
 }

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -9,10 +9,7 @@ import (
 )
 
 func (s *DockerSuite) TestCliStatsNoStream(c *check.C) {
-	out, _, err := runCommandWithOutput(exec.Command(dockerBinary, "run", "-d", "busybox", "top"))
-	if err != nil {
-		c.Fatalf("Error on container creation: %v, output: %s", err, out)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
 	if err := waitRun(id); err != nil {
 		c.Fatalf("error waiting for container to start: %v", err)

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os/exec"
 	"strings"
 
 	"github.com/docker/docker/pkg/stringutils"
@@ -14,20 +13,14 @@ func (s *DockerSuite) TestTagUnprefixedRepoByName(c *check.C) {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 
-	tagCmd := exec.Command(dockerBinary, "tag", "busybox:latest", "testfoobarbaz")
-	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
-		c.Fatal(out, err)
-	}
+	dockerCmd(c, "tag", "busybox:latest", "testfoobarbaz")
 }
 
 // tagging an image by ID in a new unprefixed repo should work
 func (s *DockerSuite) TestTagUnprefixedRepoByID(c *check.C) {
 	imageID, err := inspectField("busybox", "Id")
 	c.Assert(err, check.IsNil)
-	tagCmd := exec.Command(dockerBinary, "tag", imageID, "testfoobarbaz")
-	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
-		c.Fatal(out, err)
-	}
+	dockerCmd(c, "tag", imageID, "testfoobarbaz")
 }
 
 // ensure we don't allow the use of invalid repository names; these tag operations should fail
@@ -36,8 +29,7 @@ func (s *DockerSuite) TestTagInvalidUnprefixedRepo(c *check.C) {
 	invalidRepos := []string{"fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd"}
 
 	for _, repo := range invalidRepos {
-		tagCmd := exec.Command(dockerBinary, "tag", "busybox", repo)
-		_, _, err := runCommandWithOutput(tagCmd)
+		_, _, err := dockerCmdWithError(c, "tag", "busybox", repo)
 		if err == nil {
 			c.Fatalf("tag busybox %v should have failed", repo)
 		}
@@ -51,8 +43,7 @@ func (s *DockerSuite) TestTagInvalidPrefixedRepo(c *check.C) {
 	invalidTags := []string{"repo:fo$z$", "repo:Foo@3cc", "repo:Foo$3", "repo:Foo*3", "repo:Fo^3", "repo:Foo!3", "repo:%goodbye", "repo:#hashtagit", "repo:F)xcz(", "repo:-foo", "repo:..", longTag}
 
 	for _, repotag := range invalidTags {
-		tagCmd := exec.Command(dockerBinary, "tag", "busybox", repotag)
-		_, _, err := runCommandWithOutput(tagCmd)
+		_, _, err := dockerCmdWithError(c, "tag", "busybox", repotag)
 		if err == nil {
 			c.Fatalf("tag busybox %v should have failed", repotag)
 		}
@@ -68,8 +59,7 @@ func (s *DockerSuite) TestTagValidPrefixedRepo(c *check.C) {
 	validRepos := []string{"fooo/bar", "fooaa/test", "foooo:t"}
 
 	for _, repo := range validRepos {
-		tagCmd := exec.Command(dockerBinary, "tag", "busybox:latest", repo)
-		_, _, err := runCommandWithOutput(tagCmd)
+		_, _, err := dockerCmdWithError(c, "tag", "busybox:latest", repo)
 		if err != nil {
 			c.Errorf("tag busybox %v should have worked: %s", repo, err)
 			continue
@@ -84,12 +74,8 @@ func (s *DockerSuite) TestTagExistedNameWithoutForce(c *check.C) {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 
-	tagCmd := exec.Command(dockerBinary, "tag", "busybox:latest", "busybox:test")
-	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
-		c.Fatal(out, err)
-	}
-	tagCmd = exec.Command(dockerBinary, "tag", "busybox:latest", "busybox:test")
-	out, _, err := runCommandWithOutput(tagCmd)
+	dockerCmd(c, "tag", "busybox:latest", "busybox:test")
+	out, _, err := dockerCmdWithError(c, "tag", "busybox:latest", "busybox:test")
 	if err == nil || !strings.Contains(out, "Conflict: Tag test is already set to image") {
 		c.Fatal("tag busybox busybox:test should have failed,because busybox:test is existed")
 	}
@@ -101,14 +87,8 @@ func (s *DockerSuite) TestTagExistedNameWithForce(c *check.C) {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 
-	tagCmd := exec.Command(dockerBinary, "tag", "busybox:latest", "busybox:test")
-	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
-		c.Fatal(out, err)
-	}
-	tagCmd = exec.Command(dockerBinary, "tag", "-f", "busybox:latest", "busybox:test")
-	if out, _, err := runCommandWithOutput(tagCmd); err != nil {
-		c.Fatal(out, err)
-	}
+	dockerCmd(c, "tag", "busybox:latest", "busybox:test")
+	dockerCmd(c, "tag", "-f", "busybox:latest", "busybox:test")
 }
 
 func (s *DockerSuite) TestTagWithPrefixHyphen(c *check.C) {
@@ -116,20 +96,17 @@ func (s *DockerSuite) TestTagWithPrefixHyphen(c *check.C) {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
 	// test repository name begin with '-'
-	tagCmd := exec.Command(dockerBinary, "tag", "busybox:latest", "-busybox:test")
-	out, _, err := runCommandWithOutput(tagCmd)
+	out, _, err := dockerCmdWithError(c, "tag", "busybox:latest", "-busybox:test")
 	if err == nil || !strings.Contains(out, "repository name component must match") {
 		c.Fatal("tag a name begin with '-' should failed")
 	}
 	// test namespace name begin with '-'
-	tagCmd = exec.Command(dockerBinary, "tag", "busybox:latest", "-test/busybox:test")
-	out, _, err = runCommandWithOutput(tagCmd)
+	out, _, err = dockerCmdWithError(c, "tag", "busybox:latest", "-test/busybox:test")
 	if err == nil || !strings.Contains(out, "repository name component must match") {
 		c.Fatal("tag a name begin with '-' should failed")
 	}
 	// test index name begin wiht '-'
-	tagCmd = exec.Command(dockerBinary, "tag", "busybox:latest", "-index:5000/busybox:test")
-	out, _, err = runCommandWithOutput(tagCmd)
+	out, _, err = dockerCmdWithError(c, "tag", "busybox:latest", "-index:5000/busybox:test")
 	if err == nil || !strings.Contains(out, "Invalid index name (-index:5000). Cannot begin or end with a hyphen") {
 		c.Fatal("tag a name begin with '-' should failed")
 	}
@@ -147,16 +124,14 @@ func (s *DockerSuite) TestTagOfficialNames(c *check.C) {
 	}
 
 	for _, name := range names {
-		tagCmd := exec.Command(dockerBinary, "tag", "-f", "busybox:latest", name+":latest")
-		out, exitCode, err := runCommandWithOutput(tagCmd)
+		out, exitCode, err := dockerCmdWithError(c, "tag", "-f", "busybox:latest", name+":latest")
 		if err != nil || exitCode != 0 {
 			c.Errorf("tag busybox %v should have worked: %s, %s", name, err, out)
 			continue
 		}
 
 		// ensure we don't have multiple tag names.
-		imagesCmd := exec.Command(dockerBinary, "images")
-		out, _, err = runCommandWithOutput(imagesCmd)
+		out, _, err = dockerCmdWithError(c, "images")
 		if err != nil {
 			c.Errorf("listing images failed with errors: %v, %s", err, out)
 		} else if strings.Contains(out, name) {
@@ -166,8 +141,7 @@ func (s *DockerSuite) TestTagOfficialNames(c *check.C) {
 	}
 
 	for _, name := range names {
-		tagCmd := exec.Command(dockerBinary, "tag", "-f", name+":latest", "fooo/bar:latest")
-		_, exitCode, err := runCommandWithOutput(tagCmd)
+		_, exitCode, err := dockerCmdWithError(c, "tag", "-f", name+":latest", "fooo/bar:latest")
 		if err != nil || exitCode != 0 {
 			c.Errorf("tag %v fooo/bar should have worked: %s", name, err)
 			continue

--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -1,27 +1,17 @@
 package main
 
 import (
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
 )
 
 func (s *DockerSuite) TestTopMultipleArgs(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-i", "-d", "busybox", "top")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf("failed to start the container: %s, %v", out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-i", "-d", "busybox", "top")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	topCmd := exec.Command(dockerBinary, "top", cleanedContainerID, "-o", "pid")
-	out, _, err = runCommandWithOutput(topCmd)
-	if err != nil {
-		c.Fatalf("failed to run top: %s, %v", out, err)
-	}
-
+	out, _ = dockerCmd(c, "top", cleanedContainerID, "-o", "pid")
 	if !strings.Contains(out, "PID") {
 		c.Fatalf("did not see PID after top -o pid: %s", out)
 	}
@@ -29,30 +19,12 @@ func (s *DockerSuite) TestTopMultipleArgs(c *check.C) {
 }
 
 func (s *DockerSuite) TestTopNonPrivileged(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "-i", "-d", "busybox", "top")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf("failed to start the container: %s, %v", out, err)
-	}
-
+	out, _ := dockerCmd(c, "run", "-i", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
-	topCmd := exec.Command(dockerBinary, "top", cleanedContainerID)
-	out1, _, err := runCommandWithOutput(topCmd)
-	if err != nil {
-		c.Fatalf("failed to run top: %s, %v", out1, err)
-	}
-
-	topCmd = exec.Command(dockerBinary, "top", cleanedContainerID)
-	out2, _, err := runCommandWithOutput(topCmd)
-	if err != nil {
-		c.Fatalf("failed to run top: %s, %v", out2, err)
-	}
-
-	killCmd := exec.Command(dockerBinary, "kill", cleanedContainerID)
-	if out, _, err = runCommandWithOutput(killCmd); err != nil {
-		c.Fatalf("failed to kill container: %s, %v", out, err)
-	}
+	out1, _ := dockerCmd(c, "top", cleanedContainerID)
+	out2, _ := dockerCmd(c, "top", cleanedContainerID)
+	out, _ = dockerCmd(c, "kill", cleanedContainerID)
 
 	if !strings.Contains(out1, "top") && !strings.Contains(out2, "top") {
 		c.Fatal("top should've listed `top` in the process list, but failed twice")
@@ -65,30 +37,12 @@ func (s *DockerSuite) TestTopNonPrivileged(c *check.C) {
 }
 
 func (s *DockerSuite) TestTopPrivileged(c *check.C) {
-	runCmd := exec.Command(dockerBinary, "run", "--privileged", "-i", "-d", "busybox", "top")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatalf("failed to start the container: %s, %v", out, err)
-	}
-
+	out, _ := dockerCmd(c, "run", "--privileged", "-i", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
-	topCmd := exec.Command(dockerBinary, "top", cleanedContainerID)
-	out1, _, err := runCommandWithOutput(topCmd)
-	if err != nil {
-		c.Fatalf("failed to run top: %s, %v", out1, err)
-	}
-
-	topCmd = exec.Command(dockerBinary, "top", cleanedContainerID)
-	out2, _, err := runCommandWithOutput(topCmd)
-	if err != nil {
-		c.Fatalf("failed to run top: %s, %v", out2, err)
-	}
-
-	killCmd := exec.Command(dockerBinary, "kill", cleanedContainerID)
-	if out, _, err = runCommandWithOutput(killCmd); err != nil {
-		c.Fatalf("failed to kill container: %s, %v", out, err)
-	}
+	out1, _ := dockerCmd(c, "top", cleanedContainerID)
+	out2, _ := dockerCmd(c, "top", cleanedContainerID)
+	out, _ = dockerCmd(c, "kill", cleanedContainerID)
 
 	if !strings.Contains(out1, "top") && !strings.Contains(out2, "top") {
 		c.Fatal("top should've listed `top` in the process list, but failed twice")

--- a/integration-cli/docker_cli_version_test.go
+++ b/integration-cli/docker_cli_version_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"os/exec"
 	"strings"
 
 	"github.com/go-check/check"
@@ -9,12 +8,7 @@ import (
 
 // ensure docker version works
 func (s *DockerSuite) TestVersionEnsureSucceeds(c *check.C) {
-	versionCmd := exec.Command(dockerBinary, "version")
-	out, _, err := runCommandWithOutput(versionCmd)
-	if err != nil {
-		c.Fatalf("failed to execute docker version: %s, %v", out, err)
-	}
-
+	out, _ := dockerCmd(c, "version")
 	stringsToCheck := map[string]int{
 		"Client:":       1,
 		"Server:":       1,

--- a/integration-cli/docker_cli_wait_test.go
+++ b/integration-cli/docker_cli_wait_test.go
@@ -11,15 +11,11 @@ import (
 
 // non-blocking wait with 0 exit code
 func (s *DockerSuite) TestWaitNonBlockedExitZero(c *check.C) {
-
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", "true")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "true")
 	containerID := strings.TrimSpace(out)
 
 	status := "true"
+	var err error
 	for i := 0; status != "false"; i++ {
 		status, err = inspectField(containerID, "State.Running")
 		c.Assert(err, check.IsNil)
@@ -30,11 +26,9 @@ func (s *DockerSuite) TestWaitNonBlockedExitZero(c *check.C) {
 		}
 	}
 
-	runCmd = exec.Command(dockerBinary, "wait", containerID)
-	out, _, err = runCommandWithOutput(runCmd)
-
-	if err != nil || strings.TrimSpace(out) != "0" {
-		c.Fatal("failed to set up container", out, err)
+	out, _ = dockerCmd(c, "wait", containerID)
+	if strings.TrimSpace(out) != "0" {
+		c.Fatal("failed to set up container", out)
 	}
 
 }
@@ -70,15 +64,11 @@ func (s *DockerSuite) TestWaitBlockedExitZero(c *check.C) {
 
 // non-blocking wait with random exit code
 func (s *DockerSuite) TestWaitNonBlockedExitRandom(c *check.C) {
-
-	runCmd := exec.Command(dockerBinary, "run", "-d", "busybox", "sh", "-c", "exit 99")
-	out, _, err := runCommandWithOutput(runCmd)
-	if err != nil {
-		c.Fatal(out, err)
-	}
+	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "exit 99")
 	containerID := strings.TrimSpace(out)
 
 	status := "true"
+	var err error
 	for i := 0; status != "false"; i++ {
 		status, err = inspectField(containerID, "State.Running")
 		c.Assert(err, check.IsNil)
@@ -89,11 +79,9 @@ func (s *DockerSuite) TestWaitNonBlockedExitRandom(c *check.C) {
 		}
 	}
 
-	runCmd = exec.Command(dockerBinary, "wait", containerID)
-	out, _, err = runCommandWithOutput(runCmd)
-
-	if err != nil || strings.TrimSpace(out) != "99" {
-		c.Fatal("failed to set up container", out, err)
+	out, _ = dockerCmd(c, "wait", containerID)
+	if strings.TrimSpace(out) != "99" {
+		c.Fatal("failed to set up container", out)
 	}
 
 }

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -554,6 +554,12 @@ func dockerCmdWithError(c *check.C, args ...string) (string, int, error) {
 	return runCommandWithOutput(exec.Command(dockerBinary, args...))
 }
 
+func dockerCmdWithStdoutStderr(c *check.C, args ...string) (string, string, int) {
+	stdout, stderr, status, err := runCommandWithStdoutStderr(exec.Command(dockerBinary, args...))
+	c.Assert(err, check.IsNil, check.Commentf("%q failed with errors: %s, %v", strings.Join(args, " "), stderr, err))
+	return stdout, stderr, status
+}
+
 func dockerCmd(c *check.C, args ...string) (string, int) {
 	out, status, err := runCommandWithOutput(exec.Command(dockerBinary, args...))
 	c.Assert(err, check.IsNil, check.Commentf("%q failed with errors: %s, %v", strings.Join(args, " "), out, err))


### PR DESCRIPTION
Part of #14603 
    integration-cli/docker_cli_links_test.go (coolljt0725)
    integration-cli/docker_cli_links_unix_test.go (coolljt0725)
    integration-cli/docker_cli_logs_test.go (coolljt0725)
    integration-cli/docker_cli_nat_test.go (coolljt0725)
    integration-cli/docker_cli_network_test.go (coolljt0725)
    integration-cli/docker_cli_stats_test.go (coolljt0725)
    integration-cli/docker_cli_tag_test.go (coolljt0725)
    integration-cli/docker_cli_top_test.go (coolljt0725)
    integration-cli/docker_cli_version_test.go (coolljt0725)
    integration-cli/docker_cli_wait_test.go (coolljt0725
