### PR TITLE
Update documentation according to opts updates (#13694)

### DIFF
--- a/docs/reference/commandline/run.md
+++ b/docs/reference/commandline/run.md
@@ -208,19 +208,39 @@ An example of a file passed with `--env-file`
     # this is a comment
     TEST_APP_DEST_HOST=10.10.0.127
     TEST_APP_DEST_PORT=8888
+    _TEST_BAR=FOO
+    TEST_APP_42=magic
+    helloWorld=true
+    # 123qwe=bar <- is not valid
 
     # pass through this variable from the caller
     TEST_PASSTHROUGH
-    $ sudo TEST_PASSTHROUGH=howdy docker run --env-file ./env.list busybox env
-    HOME=/
+    $ TEST_PASSTHROUGH=howdy docker run --env-file ./env.list busybox env
     PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     HOSTNAME=5198e0745561
     TEST_FOO=BAR
     TEST_APP_DEST_HOST=10.10.0.127
     TEST_APP_DEST_PORT=8888
+    _TEST_BAR=FOO
+    TEST_APP_42=magic
+    helloWorld=true
     TEST_PASSTHROUGH=howdy
+    HOME=/root
 
-    $ docker run --name console -t -i ubuntu bash
+    $ docker run --env-file ./env.list busybox env
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    HOSTNAME=5198e0745561
+    TEST_FOO=BAR
+    TEST_APP_DEST_HOST=10.10.0.127
+    TEST_APP_DEST_PORT=8888
+    _TEST_BAR=FOO
+    TEST_APP_42=magic
+    helloWorld=true
+    TEST_PASSTHROUGH=
+    HOME=/root
+
+> **Note**: Environment variables names must consist solely of letters, numbers,
+> and underscores - and cannot start with a number.
 
 A label is a a `key=value` pair that applies metadata to a container. To label a container with two labels:
 

--- a/docs/userguide/dockervolumes.md
+++ b/docs/userguide/dockervolumes.md
@@ -59,6 +59,11 @@ This will create a new volume inside a container at `/webapp`.
 > You can also use the `VOLUME` instruction in a `Dockerfile` to add one or
 > more new volumes to any container created from that image.
 
+Docker volumes default to mount in read-write mode, but you can also set it to be mounted read-only.
+
+    $ docker run -d -P --name web -v /opt/webapp:ro training/webapp python app.py
+
+
 ### Locating a volume
 
 You can locate the volume on the host by utilizing the 'docker inspect' command.
@@ -119,8 +124,7 @@ create it for you.
 > host-dependent, so a host directory specified in a `Dockerfile` probably
 > wouldn't work on all hosts.
 
-Docker defaults to a read-write volume but we can also mount a directory
-read-only.
+Docker volumes default to mount in read-write mode, but you can also set it to be mounted read-only.
 
     $ docker run -d -P --name web -v /src/webapp:/opt/webapp:ro training/webapp python app.py
 
@@ -191,7 +195,7 @@ allows you to upgrade, or effectively migrate data volumes between containers.
 > volumes that are no longer referenced by a container.
 > Dangling volumes are difficult to get rid of and can take up a large amount
 > of disk space. We're working on improving volume management and you can check
-> progress on this in [pull request #8484](https://github.com/docker/docker/pull/8484)
+> progress on this in [pull request #14214](https://github.com/docker/docker/pull/14214)
 
 ## Backup, restore, or migrate data volumes
 


### PR DESCRIPTION
With #13694 two small things have changed :
- `--env` and `--envfile` are now validated according to the following definition : _"Environment variables set by the user must have a name consisting solely of alphabetics, numerics, and underscores - the first of which must not be numeric."_.
- It's possible to use `-v containerPath:ro` as option for `run` (and `create`, …).

I realized I did not think of the documentation when submitting #13694, so this ones try to update the few things it should.
- Add a _Note_ on the env validation
- Add an example of `-v containerPath:ro`
- Update the link to the PR for volume management (#14214)

Signed-off-by: Vincent Demeester vincent@sbr.pm
