### PR TITLE
Proposal: add mountPoint.Id to Volumes API

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -29,6 +29,7 @@ import (
 	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/nat"
 	"github.com/docker/docker/pkg/promise"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/symlink"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/volume"
@@ -1132,6 +1133,7 @@ func (container *Container) networkMounts() []execdriver.Mount {
 func (container *Container) addBindMountPoint(name, source, destination string, rw bool) {
 	container.MountPoints[destination] = &mountPoint{
 		Name:        name,
+		ID:          stringid.GenerateRandomID(),
 		Source:      source,
 		Destination: destination,
 		RW:          rw,
@@ -1141,6 +1143,7 @@ func (container *Container) addBindMountPoint(name, source, destination string, 
 func (container *Container) addLocalMountPoint(name, destination string, rw bool) {
 	container.MountPoints[destination] = &mountPoint{
 		Name:        name,
+		ID:          stringid.GenerateRandomID(),
 		Driver:      volume.DefaultDriverName,
 		Destination: destination,
 		RW:          rw,
@@ -1150,6 +1153,7 @@ func (container *Container) addLocalMountPoint(name, destination string, rw bool
 func (container *Container) addMountPointWithVolume(destination string, vol volume.Volume, rw bool) {
 	container.MountPoints[destination] = &mountPoint{
 		Name:        vol.Name(),
+		ID:          stringid.GenerateRandomID(),
 		Driver:      vol.DriverName(),
 		Destination: destination,
 		RW:          rw,
@@ -1164,7 +1168,7 @@ func (container *Container) isDestinationMounted(destination string) bool {
 func (container *Container) prepareMountPoints() error {
 	for _, config := range container.MountPoints {
 		if len(config.Driver) > 0 {
-			v, err := createVolume(config.Name, config.Driver)
+			v, err := createVolume(config.Name, config.ID, config.Driver)
 			if err != nil {
 				return err
 			}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -121,7 +121,8 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 			return nil, nil, fmt.Errorf("cannot mount volume over existing file, file exists %s", path)
 		}
 
-		v, err := createVolume(name, config.VolumeDriver)
+		id := stringid.GenerateRandomID()
+		v, err := createVolume(name, id, config.VolumeDriver)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -485,7 +485,7 @@ func TestRemoveLocalVolumesFollowingSymlinks(t *testing.T) {
 	}
 
 	m := c.MountPoints["/vol1"]
-	v, err := createVolume(m.Name, m.Driver)
+	v, err := createVolume(m.Name, m.ID, m.Driver)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/volumes_experimental_unit_test.go
+++ b/daemon/volumes_experimental_unit_test.go
@@ -12,9 +12,10 @@ import (
 
 type fakeDriver struct{}
 
-func (fakeDriver) Name() string                              { return "fake" }
-func (fakeDriver) Create(name string) (volume.Volume, error) { return nil, nil }
-func (fakeDriver) Remove(v volume.Volume) error              { return nil }
+func (fakeDriver) Name() string                                  { return "fake" }
+func (fakeDriver) Id() string                                    { return "fake" }
+func (fakeDriver) Create(name, id string) (volume.Volume, error) { return nil, nil }
+func (fakeDriver) Remove(v volume.Volume) error                  { return nil }
 
 func TestGetVolumeDriver(t *testing.T) {
 	_, err := getVolumeDriver("missing")

--- a/volume/drivers/adapter.go
+++ b/volume/drivers/adapter.go
@@ -11,30 +11,36 @@ func (a *volumeDriverAdapter) Name() string {
 	return a.name
 }
 
-func (a *volumeDriverAdapter) Create(name string) (volume.Volume, error) {
-	err := a.proxy.Create(name)
+func (a *volumeDriverAdapter) Create(name, id string) (volume.Volume, error) {
+	err := a.proxy.Create(name, id)
 	if err != nil {
 		return nil, err
 	}
 	return &volumeAdapter{
 		proxy:      a.proxy,
 		name:       name,
+		id:         id,
 		driverName: a.name}, nil
 }
 
 func (a *volumeDriverAdapter) Remove(v volume.Volume) error {
-	return a.proxy.Remove(v.Name())
+	return a.proxy.Remove(v.Name(), v.Id())
 }
 
 type volumeAdapter struct {
 	proxy      *volumeDriverProxy
 	name       string
+	id         string
 	driverName string
 	eMount     string // ephemeral host volume path
 }
 
 func (a *volumeAdapter) Name() string {
 	return a.name
+}
+
+func (a *volumeAdapter) Id() string {
+	return a.id
 }
 
 func (a *volumeAdapter) DriverName() string {
@@ -45,16 +51,16 @@ func (a *volumeAdapter) Path() string {
 	if len(a.eMount) > 0 {
 		return a.eMount
 	}
-	m, _ := a.proxy.Path(a.name)
+	m, _ := a.proxy.Path(a.name, a.id)
 	return m
 }
 
 func (a *volumeAdapter) Mount() (string, error) {
 	var err error
-	a.eMount, err = a.proxy.Mount(a.name)
+	a.eMount, err = a.proxy.Mount(a.name, a.id)
 	return a.eMount, err
 }
 
 func (a *volumeAdapter) Unmount() error {
-	return a.proxy.Unmount(a.name)
+	return a.proxy.Unmount(a.name, a.id)
 }

--- a/volume/drivers/api.go
+++ b/volume/drivers/api.go
@@ -11,7 +11,7 @@ func NewVolumeDriver(name string, c client) volume.Driver {
 
 type VolumeDriver interface {
 	// Create a volume with the given name
-	Create(name string) (err error)
+	Create(name, id string) (err error)
 	// Remove the volume with the given name
 	Remove(name string) (err error)
 	// Get the mountpoint of the given volume

--- a/volume/drivers/proxy.go
+++ b/volume/drivers/proxy.go
@@ -14,19 +14,21 @@ type volumeDriverProxy struct {
 
 type volumeDriverProxyCreateRequest struct {
 	Name string
+	Id   string
 }
 
 type volumeDriverProxyCreateResponse struct {
 	Err string
 }
 
-func (pp *volumeDriverProxy) Create(name string) (err error) {
+func (pp *volumeDriverProxy) Create(name, id string) (err error) {
 	var (
 		req volumeDriverProxyCreateRequest
 		ret volumeDriverProxyCreateResponse
 	)
 
 	req.Name = name
+	req.Id = id
 	if err = pp.Call("VolumeDriver.Create", req, &ret); err != nil {
 		return
 	}
@@ -40,19 +42,21 @@ func (pp *volumeDriverProxy) Create(name string) (err error) {
 
 type volumeDriverProxyRemoveRequest struct {
 	Name string
+	Id   string
 }
 
 type volumeDriverProxyRemoveResponse struct {
 	Err string
 }
 
-func (pp *volumeDriverProxy) Remove(name string) (err error) {
+func (pp *volumeDriverProxy) Remove(name, id string) (err error) {
 	var (
 		req volumeDriverProxyRemoveRequest
 		ret volumeDriverProxyRemoveResponse
 	)
 
 	req.Name = name
+	req.Id = id
 	if err = pp.Call("VolumeDriver.Remove", req, &ret); err != nil {
 		return
 	}
@@ -66,6 +70,7 @@ func (pp *volumeDriverProxy) Remove(name string) (err error) {
 
 type volumeDriverProxyPathRequest struct {
 	Name string
+	Id   string
 }
 
 type volumeDriverProxyPathResponse struct {
@@ -73,13 +78,14 @@ type volumeDriverProxyPathResponse struct {
 	Err        string
 }
 
-func (pp *volumeDriverProxy) Path(name string) (mountpoint string, err error) {
+func (pp *volumeDriverProxy) Path(name, id string) (mountpoint string, err error) {
 	var (
 		req volumeDriverProxyPathRequest
 		ret volumeDriverProxyPathResponse
 	)
 
 	req.Name = name
+	req.Id = id
 	if err = pp.Call("VolumeDriver.Path", req, &ret); err != nil {
 		return
 	}
@@ -95,6 +101,7 @@ func (pp *volumeDriverProxy) Path(name string) (mountpoint string, err error) {
 
 type volumeDriverProxyMountRequest struct {
 	Name string
+	Id   string
 }
 
 type volumeDriverProxyMountResponse struct {
@@ -102,13 +109,14 @@ type volumeDriverProxyMountResponse struct {
 	Err        string
 }
 
-func (pp *volumeDriverProxy) Mount(name string) (mountpoint string, err error) {
+func (pp *volumeDriverProxy) Mount(name, id string) (mountpoint string, err error) {
 	var (
 		req volumeDriverProxyMountRequest
 		ret volumeDriverProxyMountResponse
 	)
 
 	req.Name = name
+	req.Id = id
 	if err = pp.Call("VolumeDriver.Mount", req, &ret); err != nil {
 		return
 	}
@@ -124,19 +132,21 @@ func (pp *volumeDriverProxy) Mount(name string) (mountpoint string, err error) {
 
 type volumeDriverProxyUnmountRequest struct {
 	Name string
+	Id   string
 }
 
 type volumeDriverProxyUnmountResponse struct {
 	Err string
 }
 
-func (pp *volumeDriverProxy) Unmount(name string) (err error) {
+func (pp *volumeDriverProxy) Unmount(name, id string) (err error) {
 	var (
 		req volumeDriverProxyUnmountRequest
 		ret volumeDriverProxyUnmountResponse
 	)
 
 	req.Name = name
+	req.Id = id
 	if err = pp.Call("VolumeDriver.Unmount", req, &ret); err != nil {
 		return
 	}

--- a/volume/drivers/proxy_test.go
+++ b/volume/drivers/proxy_test.go
@@ -50,7 +50,7 @@ func TestVolumeRequestError(t *testing.T) {
 
 	driver := volumeDriverProxy{client}
 
-	if err = driver.Create("volume"); err == nil {
+	if err = driver.Create("volume", "id"); err == nil {
 		t.Fatal("Expected error, was nil")
 	}
 
@@ -58,7 +58,7 @@ func TestVolumeRequestError(t *testing.T) {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
 
-	_, err = driver.Mount("volume")
+	_, err = driver.Mount("volume", "id")
 	if err == nil {
 		t.Fatal("Expected error, was nil")
 	}
@@ -67,7 +67,7 @@ func TestVolumeRequestError(t *testing.T) {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
 
-	err = driver.Unmount("volume")
+	err = driver.Unmount("volume", "id")
 	if err == nil {
 		t.Fatal("Expected error, was nil")
 	}
@@ -76,7 +76,7 @@ func TestVolumeRequestError(t *testing.T) {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
 
-	err = driver.Remove("volume")
+	err = driver.Remove("volume", "id")
 	if err == nil {
 		t.Fatal("Expected error, was nil")
 	}
@@ -85,7 +85,7 @@ func TestVolumeRequestError(t *testing.T) {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}
 
-	_, err = driver.Path("volume")
+	_, err = driver.Path("volume", "id")
 	if err == nil {
 		t.Fatal("Expected error, was nil")
 	}

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -66,7 +66,7 @@ func (r *Root) Name() string {
 	return "local"
 }
 
-func (r *Root) Create(name string) (volume.Volume, error) {
+func (r *Root) Create(name, id string) (volume.Volume, error) {
 	r.m.Lock()
 	defer r.m.Unlock()
 
@@ -82,6 +82,7 @@ func (r *Root) Create(name string) (volume.Volume, error) {
 		v = &Volume{
 			driverName: r.Name(),
 			name:       name,
+			id:         id,
 			path:       path,
 		}
 		r.volumes[name] = v
@@ -138,6 +139,8 @@ type Volume struct {
 	usedCount int
 	// unique name of the volume
 	name string
+	// unique uid of the volume
+	id string
 	// path is the path on the host where the data lives
 	path string
 	// driverName is the name of the driver that created the volume.
@@ -146,6 +149,10 @@ type Volume struct {
 
 func (v *Volume) Name() string {
 	return v.name
+}
+
+func (v *Volume) Id() string {
+	return v.id
 }
 
 func (v *Volume) DriverName() string {

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -5,8 +5,8 @@ const DefaultDriverName = "local"
 type Driver interface {
 	// Name returns the name of the volume driver.
 	Name() string
-	// Create makes a new volume with the given id.
-	Create(string) (Volume, error)
+	// Create makes a new volume with the given name and id.
+	Create(string, string) (Volume, error)
 	// Remove deletes the volume.
 	Remove(Volume) error
 }
@@ -14,6 +14,8 @@ type Driver interface {
 type Volume interface {
 	// Name returns the name of the volume
 	Name() string
+	// Id returns the unique volume UID
+	Id() string
 	// DriverName returns the name of the driver which owns this volume.
 	DriverName() string
 	// Path returns the absolute path to the volume.


### PR DESCRIPTION
Signed-off-by: Sven Dowideit SvenDowideit@home.org.au

@calavera :)

this allows the volume plugin to deal with

`docker run --rm -it --volume-driver nfs -v 10.10.10.20/data:/data alpine ls -la /data`

without needing to reference count, by mounting the remote fs at `/var/lib/docker/volumes/_nfs/d5bc87dace8baa990f0b3debe6d874dc446b033f678cf67f660209741b185fb0/10.10.10.20/data`
