### PR TITLE
Add gradle docker remote api plugin

### DIFF
--- a/docs/reference/api/registry_api_client_libraries.md
+++ b/docs/reference/api/registry_api_client_libraries.md
@@ -26,20 +26,20 @@ project and we will add the libraries here.
     <col width="11%">
   </colgroup>
   <thead valign="bottom">
-    <tr class="row-odd"><th class="head">Language/Framework</th>
+    <tr><th class="head">Language/Framework</th>
       <th class="head">Name</th>
       <th class="head">Repository</th>
       <th class="head">Status</th>
     </tr>
   </thead>
   <tbody valign = "top">
-    <tr class="row-even">
+    <tr>
       <td>JavaScript (AngularJS) <strong>WebUI</strong></td>
       <td>docker-registry-frontend</td>
       <td><a class="reference external" href="https://github.com/kwk/docker-registry-frontend">https://github.com/kwk/docker-registry-frontend</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>Go</td>
       <td>docker-reg-client</td>
       <td><a class="reference external" href="https://github.com/CenturyLinkLabs/docker-reg-client">https://github.com/CenturyLinkLabs/docker-reg-client</a></td>

--- a/docs/reference/api/remote_api_client_libraries.md
+++ b/docs/reference/api/remote_api_client_libraries.md
@@ -23,172 +23,173 @@ will add the libraries here.
     <col width="11%">
   </colgroup>
   <thead valign="bottom">
-    <tr class="row-odd"><th class="head">Language/Framework</th>
+    <tr>
+      <th class="head">Language/Framework</th>
       <th class="head">Name</th>
       <th class="head">Repository</th>
       <th class="head">Status</th>
     </tr>
   </thead>
   <tbody valign = "top">
-    <tr class="row-even">
+    <tr>
       <td>C#</td>
       <td>Docker.DotNet</td>
       <td><a class="reference external" href="https://github.com/ahmetalpbalkan/Docker.DotNet">https://github.com/ahmetalpbalkan/Docker.DotNet</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-even">
+    <tr>
       <td>C++</td>
       <td>lasote/docker_client</td>
       <td><a class="reference external" href="http://www.biicode.com/lasote/docker_client">http://www.biicode.com/lasote/docker_client (Biicode C++ dependency manager)</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>Erlang</td>
       <td>erldocker</td>
       <td><a class="reference external" href="https://github.com/proger/erldocker">https://github.com/proger/erldocker</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-even">
+    <tr>
       <td>Dart</td>
       <td>bwu_docker</td>
       <td><a class="reference external" href="https://github.com/bwu-dart/bwu_docker">https://github.com/bwu-dart/bwu_docker</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>Go</td>
       <td>go-dockerclient</td>
       <td><a class="reference external" href="https://github.com/fsouza/go-dockerclient">https://github.com/fsouza/go-dockerclient</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-even">
+    <tr>
       <td>Go</td>
       <td>dockerclient</td>
       <td><a class="reference external" href="https://github.com/samalba/dockerclient">https://github.com/samalba/dockerclient</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>Groovy</td>
       <td>docker-client</td>
       <td><a class="reference external" href="https://github.com/gesellix-docker/docker-client">https://github.com/gesellix-docker/docker-client</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-even">
+    <tr>
       <td>Haskell</td>
       <td>docker-hs</td>
       <td><a class="reference external" href="https://github.com/denibertovic/docker-hs">https://github.com/denibertovic/docker-hs</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>Java</td>
       <td>docker-java</td>
       <td><a class="reference external" href="https://github.com/docker-java/docker-java">https://github.com/docker-java/docker-java</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-even">
+    <tr>
       <td>Java</td>
       <td>docker-client</td>
       <td><a class="reference external" href="https://github.com/spotify/docker-client">https://github.com/spotify/docker-client</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>Java</td>
       <td>jclouds-docker</td>
       <td><a class="reference external" href="https://github.com/jclouds/jclouds-labs/tree/master/docker">https://github.com/jclouds/jclouds-labs/tree/master/docker</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-even">
+    <tr>
       <td>JavaScript (NodeJS)</td>
       <td>dockerode</td>
       <td><a class="reference external" href="https://github.com/apocas/dockerode">https://github.com/apocas/dockerode</a>
   Install via NPM: <cite>npm install dockerode</cite></td>
       <td>Active</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>JavaScript (NodeJS)</td>
       <td>docker.io</td>
       <td><a class="reference external" href="https://github.com/appersonlabs/docker.io">https://github.com/appersonlabs/docker.io</a>
   Install via NPM: <cite>npm install docker.io</cite></td>
       <td>Active</td>
     </tr>
-    <tr class="row-even">
+    <tr>
       <td>JavaScript</td>
       <td>docker-js</td>
       <td><a class="reference external" href="https://github.com/dgoujard/docker-js">https://github.com/dgoujard/docker-js</a></td>
       <td>Outdated</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>JavaScript (Angular) <strong>WebUI</strong></td>
       <td>docker-cp</td>
       <td><a class="reference external" href="https://github.com/13W/docker-cp">https://github.com/13W/docker-cp</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-even">
+    <tr>
       <td>JavaScript (Angular) <strong>WebUI</strong></td>
       <td>dockerui</td>
       <td><a class="reference external" href="https://github.com/crosbymichael/dockerui">https://github.com/crosbymichael/dockerui</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>JavaScript (Angular) <strong>WebUI</strong></td>
       <td>dockery</td>
       <td><a class="reference external" href="https://github.com/lexandro/dockery">https://github.com/lexandro/dockery</a></td>
       <td>Active</td>
     </tr>    
-    <tr class="row-even">
+    <tr>
       <td>Perl</td>
       <td>Net::Docker</td>
       <td><a class="reference external" href="https://metacpan.org/pod/Net::Docker">https://metacpan.org/pod/Net::Docker</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>Perl</td>
       <td>Eixo::Docker</td>
       <td><a class="reference external" href="https://github.com/alambike/eixo-docker">https://github.com/alambike/eixo-docker</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-even">
+    <tr>
       <td>PHP</td>
       <td>Alvine</td>
       <td><a class="reference external" href="http://pear.alvine.io/">http://pear.alvine.io/</a> (alpha)</td>
       <td>Active</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>PHP</td>
       <td>Docker-PHP</td>
       <td><a class="reference external" href="http://stage1.github.io/docker-php/">http://stage1.github.io/docker-php/</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-even">
+    <tr>
       <td>Python</td>
       <td>docker-py</td>
       <td><a class="reference external" href="https://github.com/docker/docker-py">https://github.com/docker/docker-py</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>Ruby</td>
       <td>docker-api</td>
       <td><a class="reference external" href="https://github.com/swipely/docker-api">https://github.com/swipely/docker-api</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-even">
+    <tr>
       <td>Ruby</td>
       <td>docker-client</td>
       <td><a class="reference external" href="https://github.com/geku/docker-client">https://github.com/geku/docker-client</a></td>
       <td>Outdated</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>Rust</td>
       <td>docker-rust</td>
       <td><a class="reference external" href="https://github.com/abh1nav/docker-rust">https://github.com/abh1nav/docker-rust</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-even">
+    <tr>
       <td>Scala</td>
       <td>tugboat</td>
       <td><a class="reference external" href="https://github.com/softprops/tugboat">https://github.com/softprops/tugboat</a></td>
       <td>Active</td>
     </tr>
-    <tr class="row-odd">
+    <tr>
       <td>Scala</td>
       <td>reactive-docker</td>
       <td><a class="reference external" href="https://github.com/almoehi/reactive-docker">https://github.com/almoehi/reactive-docker</a></td>

--- a/docs/reference/api/remote_api_client_libraries.md
+++ b/docs/reference/api/remote_api_client_libraries.md
@@ -68,9 +68,15 @@ will add the libraries here.
       <td>Active</td>
     </tr>
     <tr>
+      <td>Gradle</td>
+      <td>gradle-docker-plugin</td>
+      <td><a class="reference external" href="https://github.com/gesellix/gradle-docker-plugin">https://github.com/gesellix/gradle-docker-plugin</a></td>
+      <td>Active</td>
+    </tr>
+    <tr>
       <td>Groovy</td>
       <td>docker-client</td>
-      <td><a class="reference external" href="https://github.com/gesellix-docker/docker-client">https://github.com/gesellix-docker/docker-client</a></td>
+      <td><a class="reference external" href="https://github.com/gesellix/docker-client">https://github.com/gesellix/docker-client</a></td>
       <td>Active</td>
     </tr>
     <tr>


### PR DESCRIPTION
Apart from adding a Gradle Docker plugin and updating the url to the Groovy docker-client this PR also removes the `row-even` and `row-odd` classes. I don't have the impression that they're used in the current docs (didn't find any styles for both classes) and I would also suggest to use `tr:nth-child(odd)` and `tr:nth-child(even)` pseudo classes instead.

If this PR gets merged, do I have to add another PR for the docs branch?
