### PR TITLE
update release script and release process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,6 @@ RUN apt-get update && apt-get install -y \
 	python-pip \
 	python-websocket \
 	reprepro \
-	ruby1.9.1 \
-	ruby1.9.1-dev \
 	s3cmd=1.1.0* \
 	ubuntu-zfs \
 	libzfs-dev \
@@ -117,9 +115,6 @@ RUN git clone https://github.com/golang/tools.git /go/src/golang.org/x/tools \
 	&& (cd /go/src/golang.org/x/tools && git checkout -q $GO_TOOLS_COMMIT) \
 	&& go install -v golang.org/x/tools/cmd/cover \
 	&& go install -v golang.org/x/tools/cmd/vet
-
-# TODO replace FPM with some very minimal debhelper stuff
-RUN gem install --no-rdoc --no-ri fpm --version 1.3.2
 
 # Install registry
 ENV REGISTRY_COMMIT 2317f721a3d8428215a2b65da4ae85212ed473b4

--- a/project/RELEASE-CHECKLIST.md
+++ b/project/RELEASE-CHECKLIST.md
@@ -176,7 +176,18 @@ That last command will give you the proper link to visit to ensure that you
 open the PR against the "release" branch instead of accidentally against
 "master" (like so many brave souls before you already have).
 
-### 7. Publish release candidate binaries
+### 7. Build release candidate rpms and debs
+
+```bash
+docker build -t docker .
+docker run \
+    --rm -t --privileged \
+    -v $(pwd)/bundles:/go/src/github.com/docker/docker/bundles \
+    docker \
+    hack/make.sh binary build-deb build-rpm
+```
+
+### 8. Publish release candidate binaries, debs, and rpms
 
 To run this you will need access to the release credentials. Get them from the
 Core maintainers.
@@ -186,20 +197,25 @@ Replace "..." with the respective credentials:
 ```bash
 docker build -t docker .
 docker run \
-       -e AWS_S3_BUCKET=test.docker.com \
-       -e AWS_ACCESS_KEY="..." \
-       -e AWS_SECRET_KEY="..." \
-       -e GPG_PASSPHRASE="..." \
-       -i -t --privileged \
-       docker \
-       hack/release.sh
+    -v /volumes/repos:/repos \ # volume where the repo is locally
+    -e DOCKER_RELEASE_DIR=/repos \ # set directory for the release
+    -e AWS_S3_BUCKET=test.docker.com \ # static binaries are still pushed to s3
+    -e AWS_ACCESS_KEY="..." \
+    -e AWS_SECRET_KEY="..." \
+    -v $(pwd)/bundles:/go/src/github.com/docker/docker/bundles \
+    -v $HOME/.gnupg:/root/.gnupg \ # gpg keys for signing debs/rpms
+    -e GPG_PASSPHRASE="..." \
+    -i -t --privileged \
+    docker \
+    hack/release.sh
 ```
 
 It will run the test suite, build the binaries and packages, and upload to the
 specified bucket, so this is a good time to verify that you're running against
 **test**.docker.com.
 
-After the binaries and packages are uploaded to test.docker.com, make sure
+After the binaries are uploaded to test.docker.com and the packages are on 
+apt.dockerproject.org and yum.dockerproject.org, make sure
 they get tested in both Ubuntu and Debian for any obvious installation
 issues or runtime issues.
 
@@ -214,7 +230,7 @@ Announcing on multiple medias is the best way to get some help testing! An easy
 way to get some useful links for sharing:
 
 ```bash
-echo "Ubuntu/Debian: https://test.docker.com/ubuntu or curl -sSL https://test.docker.com/ | sh"
+echo "Ubuntu/Debian: curl -sSL https://test.docker.com/ | sh"
 echo "Linux 64bit binary: https://test.docker.com/builds/Linux/x86_64/docker-${VERSION#v}"
 echo "Darwin/OSX 64bit client binary: https://test.docker.com/builds/Darwin/x86_64/docker-${VERSION#v}"
 echo "Darwin/OSX 32bit client binary: https://test.docker.com/builds/Darwin/i386/docker-${VERSION#v}"
@@ -229,7 +245,7 @@ We recommend announcing the release candidate on:
 - The [docker-maintainers](https://groups.google.com/a/dockerproject.org/forum/#!forum/maintainers) group
 - Any social media that can bring some attention to the release candidate
 
-### 8. Iterate on successive release candidates
+### 9. Iterate on successive release candidates
 
 Spend several days along with the community explicitly investing time and
 resources to try and break Docker in every possible way, documenting any
@@ -279,7 +295,7 @@ git push -f $GITHUBUSER bump_$VERSION
 Repeat step 6 to tag the code, publish new binaries, announce availability, and
 get help testing.
 
-### 9. Finalize the bump branch
+### 10. Finalize the bump branch
 
 When you're happy with the quality of a release candidate, you can move on and
 create the real thing.
@@ -295,25 +311,41 @@ git commit --amend
 
 You will then repeat step 6 to publish the binaries to test
 
-### 10. Get 2 other maintainers to validate the pull request
+### 11. Get 2 other maintainers to validate the pull request
 
-### 11. Publish final binaries
+### 12. Build final rpms and debs
+
+```bash
+docker build -t docker .
+docker run \
+    --rm -t --privileged \
+    -v $(pwd)/bundles:/go/src/github.com/docker/docker/bundles \
+    docker \
+    hack/make.sh binary build-deb build-rpm
+```
+
+### 13. Publish final binaries, debs, and rpms
 
 Once they're tested and reasonably believed to be working, run against
 get.docker.com:
 
 ```bash
+docker build -t docker .
 docker run \
-       -e AWS_S3_BUCKET=get.docker.com \
-       -e AWS_ACCESS_KEY="..." \
-       -e AWS_SECRET_KEY="..." \
-       -e GPG_PASSPHRASE="..." \
-       -i -t --privileged \
-       docker \
-       hack/release.sh
+    -v /volumes/repos:/repos \ # volume where the repo is locally
+    -e DOCKER_RELEASE_DIR=/repos \ # set directory for the release
+    -e AWS_S3_BUCKET=get.docker.com \ # static binaries are still pushed to s3
+    -e AWS_ACCESS_KEY="..." \
+    -e AWS_SECRET_KEY="..." \
+    -v $(pwd)/bundles:/go/src/github.com/docker/docker/bundles \
+    -v $HOME/.gnupg:/root/.gnupg \ # gpg keys for signing debs/rpms
+    -e GPG_PASSPHRASE="..." \
+    -i -t --privileged \
+    docker \
+    hack/release.sh
 ```
 
-### 12. Apply tag
+### 14. Apply tag
 
 It's very important that we don't make the tag until after the official
 release is uploaded to get.docker.com!
@@ -323,12 +355,12 @@ git tag -a $VERSION -m $VERSION bump_$VERSION
 git push origin $VERSION
 ```
 
-### 13. Go to github to merge the `bump_$VERSION` branch into release
+### 15. Go to github to merge the `bump_$VERSION` branch into release
 
 Don't forget to push that pretty blue button to delete the leftover
 branch afterwards!
 
-### 14. Update the docs branch
+### 16. Update the docs branch
 
 If this is a MAJOR.MINOR.0 release, you need to make an branch for the previous release's
 documentation:
@@ -360,7 +392,7 @@ distributed CDN system) is flushed. The `make docs-release` command will do this
 _if_ the `DISTRIBUTION_ID` is set correctly - this will take at least 15 minutes to run
 and you can check its progress with the CDN Cloudfront Chrome addin.
 
-### 15. Create a new pull request to merge your bump commit back into master
+### 17. Create a new pull request to merge your bump commit back into master
 
 ```bash
 git checkout master
@@ -374,14 +406,14 @@ echo "https://github.com/$GITHUBUSER/docker/compare/docker:master...$GITHUBUSER:
 Again, get two maintainers to validate, then merge, then push that pretty
 blue button to delete your branch.
 
-### 16. Update the VERSION files
+### 18. Update the VERSION files
 
 Now that version X.Y.Z is out, time to start working on the next! Update the
 content of the `VERSION` file to be the next minor (incrementing Y) and add the
 `-dev` suffix. For example, after 1.5.0 release, the `VERSION` file gets
 updated to `1.6.0-dev` (as in "1.6.0 in the making").
 
-### 17. Rejoice and Evangelize!
+### 19. Rejoice and Evangelize!
 
 Congratulations! You're done.
 


### PR DESCRIPTION
I have moved the release script changes and release process changes to a seperate PR from https://github.com/docker/docker/pull/14638 because we have no dedcided if we are still going to push 1.8.0 to the old repos.

So this merge is optional if we decide not to push to the old repo. We can still do old and new repo pushes without it ;)

ping @icecrime 
