### PR TITLE
golint fix TLs->TLS in docker/

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -123,8 +123,8 @@ func mainDaemon() {
 	}
 	serverConfig = setPlatformServerConfig(serverConfig, daemonCfg)
 
-	if *flTlS {
-		if *flTlSVerify {
+	if *flTLS {
+		if *flTLSVerify {
 			tlsOptions.ClientAuth = tls.RequireAndVerifyClientCert
 		}
 		tlsConfig, err := tlsconfig.Server(tlsOptions)

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -123,8 +123,8 @@ func mainDaemon() {
 	}
 	serverConfig = setPlatformServerConfig(serverConfig, daemonCfg)
 
-	if *flTls {
-		if *flTlsVerify {
+	if *flTlS {
+		if *flTlSVerify {
 			tlsOptions.ClientAuth = tls.RequireAndVerifyClientCert
 		}
 		tlsConfig, err := tlsconfig.Server(tlsOptions)

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -92,8 +92,8 @@ func main() {
 	// Regardless of whether the user sets it to true or false, if they
 	// specify --tlsverify at all then we need to turn on tls
 	// *flTlsVerify can be true even if not set due to DOCKER_TLS_VERIFY env var, so we need to check that here as well
-	if flag.IsSet("-tlsverify") || *flTlsVerify {
-		*flTls = true
+	if flag.IsSet("-tlsverify") || *flTlSVerify {
+		*flTlS = true
 	}
 
 	if *flDaemon {
@@ -114,8 +114,8 @@ func main() {
 	protoAddrParts := strings.SplitN(flHosts[0], "://", 2)
 
 	var tlsConfig *tls.Config
-	if *flTls {
-		tlsOptions.InsecureSkipVerify = !*flTlsVerify
+	if *flTlS {
+		tlsOptions.InsecureSkipVerify = !*flTlSVerify
 		if !flag.IsSet("-tlscert") {
 			if _, err := os.Stat(tlsOptions.CertFile); os.IsNotExist(err) {
 				tlsOptions.CertFile = ""

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -92,8 +92,8 @@ func main() {
 	// Regardless of whether the user sets it to true or false, if they
 	// specify --tlsverify at all then we need to turn on tls
 	// *flTlsVerify can be true even if not set due to DOCKER_TLS_VERIFY env var, so we need to check that here as well
-	if flag.IsSet("-tlsverify") || *flTlSVerify {
-		*flTlS = true
+	if flag.IsSet("-tlsverify") || *flTLSVerify {
+		*flTLS = true
 	}
 
 	if *flDaemon {
@@ -114,8 +114,8 @@ func main() {
 	protoAddrParts := strings.SplitN(flHosts[0], "://", 2)
 
 	var tlsConfig *tls.Config
-	if *flTlS {
-		tlsOptions.InsecureSkipVerify = !*flTlSVerify
+	if *flTLS {
+		tlsOptions.InsecureSkipVerify = !*flTLSVerify
 		if !flag.IsSet("-tlscert") {
 			if _, err := os.Stat(tlsOptions.CertFile); os.IsNotExist(err) {
 				tlsOptions.CertFile = ""

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -26,7 +26,7 @@ func (a byName) Less(i, j int) bool { return a[i].name < a[j].name }
 
 var (
 	dockerCertPath  = os.Getenv("DOCKER_CERT_PATH")
-	dockerTlsVerify = os.Getenv("DOCKER_TLS_VERIFY") != ""
+	dockerTlSVerify = os.Getenv("DOCKER_TLS_VERIFY") != ""
 
 	dockerCommands = []command{
 		{"attach", "Attach to a running container"},
@@ -91,9 +91,9 @@ var (
 	flDaemon    = flag.Bool([]string{"d", "-daemon"}, false, "Enable daemon mode")
 	flDebug     = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
 	flLogLevel  = flag.String([]string{"l", "-log-level"}, "info", "Set the logging level")
-	flTls       = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by --tlsverify")
+	flTlS       = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by --tlsverify")
 	flHelp      = flag.Bool([]string{"h", "-help"}, false, "Print usage")
-	flTlsVerify = flag.Bool([]string{"-tlsverify"}, dockerTlsVerify, "Use TLS and verify the remote")
+	flTlSVerify = flag.Bool([]string{"-tlsverify"}, dockerTlSVerify, "Use TLS and verify the remote")
 
 	// these are initialized in init() below since their default values depend on dockerCertPath which isn't fully initialized until init() runs
 	tlsOptions tlsconfig.Options

--- a/docker/flags.go
+++ b/docker/flags.go
@@ -91,9 +91,9 @@ var (
 	flDaemon    = flag.Bool([]string{"d", "-daemon"}, false, "Enable daemon mode")
 	flDebug     = flag.Bool([]string{"D", "-debug"}, false, "Enable debug mode")
 	flLogLevel  = flag.String([]string{"l", "-log-level"}, "info", "Set the logging level")
-	flTlS       = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by --tlsverify")
+	flTLS       = flag.Bool([]string{"-tls"}, false, "Use TLS; implied by --tlsverify")
 	flHelp      = flag.Bool([]string{"h", "-help"}, false, "Print usage")
-	flTlSVerify = flag.Bool([]string{"-tlsverify"}, dockerTlSVerify, "Use TLS and verify the remote")
+	flTLSVerify = flag.Bool([]string{"-tlsverify"}, dockerTlSVerify, "Use TLS and verify the remote")
 
 	// these are initialized in init() below since their default values depend on dockerCertPath which isn't fully initialized until init() runs
 	tlsOptions tlsconfig.Options


### PR DESCRIPTION
golint errors mentioned in #14756

```
docker/flags.go:29:2: var dockerTlsVerify should be dockerTLSVerify
docker/flags.go:94:2: var flTls should be flTLS
docker/flags.go:96:2: var flTlsVerify should be flTLSVerify
```
