### PR TITLE
Remove reference to docker/libcontainer

### DIFF
--- a/docs/project/who-written-for.md
+++ b/docs/project/who-written-for.md
@@ -8,7 +8,7 @@ parent = "smn_develop"
 +++
 <![end-metadata]-->
 
-# README first 
+# README first
 
 This section of the documentation contains a guide for Docker users who want to
 contribute code or documentation to the Docker project. As a community, we
@@ -20,7 +20,7 @@ target="_blank">community guidelines</a> before continuing.
 
 The Docker project consists of not just one but several repositories on GitHub.
 So, in addition to the `docker/docker` repository, there is the
-`docker/libcontainer` repo, the `docker/machine` repo, and several more.
+`docker/compose` repo, the `docker/machine` repo, and several more.
 Contribute to any of these and you contribute to the Docker project.
 
 Not all Docker repositories use the Go language. Also, each repository has its


### PR DESCRIPTION
Since even the README in libcontainer shows the project is moved I thought it could make sense to remove this reference and use docker/compose instead (could have been any other docker repo, just name another and I'll update if compose is not ok)

Signed-off-by: Antonio Murdaca runcom@linux.com
