### PR TITLE
Cleanup links top level pkg

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -333,8 +333,6 @@ func (container *Container) isNetworkAllocated() bool {
 func (container *Container) cleanup() {
 	container.ReleaseNetwork()
 
-	disableAllActiveLinks(container)
-
 	if err := container.CleanupStorage(); err != nil {
 		logrus.Errorf("%v: Failed to cleanup storage: %v", container.ID, err)
 	}

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -155,17 +155,15 @@ func (container *Container) ExportRw() (archive.Archive, error) {
 	return nil, nil
 }
 
+func (container *Container) UpdateNetwork() error {
+	return nil
+}
+
 func (container *Container) ReleaseNetwork() {
 }
 
 func (container *Container) RestoreNetwork() error {
 	return nil
-}
-
-func disableAllActiveLinks(container *Container) {
-}
-
-func (container *Container) DisableLink(name string) {
 }
 
 func (container *Container) UnmountVolumes(forceSyscall bool) error {

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -32,14 +32,16 @@ func (daemon *Daemon) ContainerRm(name string, config *ContainerRmConfig) error 
 		if pe == nil {
 			return fmt.Errorf("Cannot get parent %s for name %s", parent, name)
 		}
-		parentContainer, _ := daemon.Get(pe.ID())
 
 		if err := daemon.ContainerGraph().Delete(name); err != nil {
 			return err
 		}
 
+		parentContainer, _ := daemon.Get(pe.ID())
 		if parentContainer != nil {
-			parentContainer.DisableLink(n)
+			if err := parentContainer.UpdateNetwork(); err != nil {
+				logrus.Debugf("Could not update network to remove link %s: %v", n, err)
+			}
 		}
 
 		return nil

--- a/daemon/links/links_test.go
+++ b/daemon/links/links_test.go
@@ -18,10 +18,7 @@ func TestLinkNaming(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[newPortNoError("tcp", "6379")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, ports)
-	if err != nil {
-		t.Fatal(err)
-	}
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker-1", nil, ports)
 
 	rawEnv := link.ToEnv()
 	env := make(map[string]string, len(rawEnv))
@@ -48,18 +45,9 @@ func TestLinkNew(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[newPortNoError("tcp", "6379")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, ports)
-	if err != nil {
-		t.Fatal(err)
-	}
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", nil, ports)
 
-	if link == nil {
-		t.FailNow()
-	}
 	if link.Name != "/db/docker" {
-		t.Fail()
-	}
-	if link.Alias() != "docker" {
 		t.Fail()
 	}
 	if link.ParentIP != "172.0.17.3" {
@@ -79,10 +67,7 @@ func TestLinkEnv(t *testing.T) {
 	ports := make(nat.PortSet)
 	ports[newPortNoError("tcp", "6379")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, ports)
-	if err != nil {
-		t.Fatal(err)
-	}
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, ports)
 
 	rawEnv := link.ToEnv()
 	env := make(map[string]string, len(rawEnv))
@@ -122,10 +107,7 @@ func TestLinkMultipleEnv(t *testing.T) {
 	ports[newPortNoError("tcp", "6380")] = struct{}{}
 	ports[newPortNoError("tcp", "6381")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, ports)
-	if err != nil {
-		t.Fatal(err)
-	}
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, ports)
 
 	rawEnv := link.ToEnv()
 	env := make(map[string]string, len(rawEnv))
@@ -171,10 +153,7 @@ func TestLinkPortRangeEnv(t *testing.T) {
 	ports[newPortNoError("tcp", "6380")] = struct{}{}
 	ports[newPortNoError("tcp", "6381")] = struct{}{}
 
-	link, err := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, ports)
-	if err != nil {
-		t.Fatal(err)
-	}
+	link := NewLink("172.0.17.3", "172.0.17.2", "/db/docker", []string{"PASSWORD=gordon"}, ports)
 
 	rawEnv := link.ToEnv()
 	env := make(map[string]string, len(rawEnv))


### PR DESCRIPTION
- remove `container.activeLinks` not really used anywhere
- wondering if top level `links` pkg make sense anymore since it's only doing `ToEnv` and `NewLink`
- `DisableLink` was only used in `daemon/delete` and apart from updating `activeLinks` (not necessary) it was calling `container.UpdateNetwork()`, now `container.UpdateNetwork()` is called directly in `daemon/delete`
- Move top level pkg links under daemon (but I guess we remove it also)

related to #14756 (if `links` pkg remains)

Signed-off-by: Antonio Murdaca runcom@linux.com
