### PR TITLE
golint fixes for cliconfig

### DIFF
--- a/api/client/hijack.go
+++ b/api/client/hijack.go
@@ -145,7 +145,7 @@ func (cli *DockerCli) hijack(method, path string, setRawTerminal bool, in io.Rea
 
 	// Add CLI Config's HTTP Headers BEFORE we set the Docker headers
 	// then the user can't change OUR headers
-	for k, v := range cli.configFile.HttpHeaders {
+	for k, v := range cli.configFile.HTTPHeaders {
 		req.Header.Set(k, v)
 	}
 

--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -72,7 +72,7 @@ func (cli *DockerCli) clientRequest(method, path string, in io.Reader, headers m
 
 	// Add CLI Config's HTTP Headers BEFORE we set the Docker headers
 	// then the user can't change OUR headers
-	for k, v := range cli.configFile.HttpHeaders {
+	for k, v := range cli.configFile.HTTPHeaders {
 		req.Header.Set(k, v)
 	}
 

--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -3,7 +3,6 @@ package cliconfig
 import (
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -15,19 +14,18 @@ import (
 )
 
 const (
-	// Where we store the config file
-	CONFIGFILE     = "config.json"
-	OLD_CONFIGFILE = ".dockercfg"
+	// ConfigFile is the name of config file
+	ConfigFileName = "config.json"
+	oldConfigfile  = ".dockercfg"
 
 	// This constant is only used for really old config files when the
 	// URL wasn't saved as part of the config file and it was just
 	// assumed to be this value.
-	DEFAULT_INDEXSERVER = "https://index.docker.io/v1/"
+	defaultIndexserver = "https://index.docker.io/v1/"
 )
 
 var (
-	configDir            = os.Getenv("DOCKER_CONFIG")
-	ErrConfigFileMissing = errors.New("The Auth config file is missing")
+	configDir = os.Getenv("DOCKER_CONFIG")
 )
 
 func init() {
@@ -36,15 +34,17 @@ func init() {
 	}
 }
 
+// ConfigDir returns the directory the configuration file is stored in
 func ConfigDir() string {
 	return configDir
 }
 
+// SetConfigDir sets the directory the configuration file is stored in
 func SetConfigDir(dir string) {
 	configDir = dir
 }
 
-// Registry Auth Info
+// AuthConfig contains authorization information for connecting to a Registry
 type AuthConfig struct {
 	Username      string `json:"username,omitempty"`
 	Password      string `json:"password,omitempty"`
@@ -53,22 +53,24 @@ type AuthConfig struct {
 	ServerAddress string `json:"serveraddress,omitempty"`
 }
 
-// ~/.docker/config.json file info
+// ConfigFile ~/.docker/config.json file info
 type ConfigFile struct {
 	AuthConfigs map[string]AuthConfig `json:"auths"`
-	HttpHeaders map[string]string     `json:"HttpHeaders,omitempty"`
+	HTTPHeaders map[string]string     `json:"HttpHeaders,omitempty"`
 	filename    string                // Note: not serialized - for internal use only
 }
 
+// NewConfigFile initilizes an empty configuration file for the given filename 'fn'
 func NewConfigFile(fn string) *ConfigFile {
 	return &ConfigFile{
 		AuthConfigs: make(map[string]AuthConfig),
-		HttpHeaders: make(map[string]string),
+		HTTPHeaders: make(map[string]string),
 		filename:    fn,
 	}
 }
 
-// load up the auth config information and return values
+// Load reads the configuration files in the given directory, and sets up
+// the auth config information and return values.
 // FIXME: use the internal golang config parser
 func Load(configDir string) (*ConfigFile, error) {
 	if configDir == "" {
@@ -77,7 +79,7 @@ func Load(configDir string) (*ConfigFile, error) {
 
 	configFile := ConfigFile{
 		AuthConfigs: make(map[string]AuthConfig),
-		filename:    filepath.Join(configDir, CONFIGFILE),
+		filename:    filepath.Join(configDir, ConfigFileName),
 	}
 
 	// Try happy path first - latest config file
@@ -110,8 +112,7 @@ func Load(configDir string) (*ConfigFile, error) {
 	}
 
 	// Can't find latest config file so check for the old one
-	confFile := filepath.Join(homedir.Get(), OLD_CONFIGFILE)
-
+	confFile := filepath.Join(homedir.Get(), oldConfigfile)
 	if _, err := os.Stat(confFile); err != nil {
 		return &configFile, nil //missing file is not an error
 	}
@@ -140,8 +141,8 @@ func Load(configDir string) (*ConfigFile, error) {
 			return &configFile, fmt.Errorf("Invalid Auth config file")
 		}
 		authConfig.Email = origEmail[1]
-		authConfig.ServerAddress = DEFAULT_INDEXSERVER
-		configFile.AuthConfigs[DEFAULT_INDEXSERVER] = authConfig
+		authConfig.ServerAddress = defaultIndexserver
+		configFile.AuthConfigs[defaultIndexserver] = authConfig
 	} else {
 		for k, authConfig := range configFile.AuthConfigs {
 			authConfig.Username, authConfig.Password, err = DecodeAuth(authConfig.Auth)
@@ -156,12 +157,13 @@ func Load(configDir string) (*ConfigFile, error) {
 	return &configFile, nil
 }
 
+// Save encodes and writes out all the authorization information
 func (configFile *ConfigFile) Save() error {
 	// Encode sensitive data into a new/temp struct
 	tmpAuthConfigs := make(map[string]AuthConfig, len(configFile.AuthConfigs))
 	for k, authConfig := range configFile.AuthConfigs {
 		authCopy := authConfig
-
+		// encode and save the authstring, while blanking out the original fields
 		authCopy.Auth = EncodeAuth(&authCopy)
 		authCopy.Username = ""
 		authCopy.Password = ""
@@ -189,11 +191,12 @@ func (configFile *ConfigFile) Save() error {
 	return nil
 }
 
-func (config *ConfigFile) Filename() string {
-	return config.filename
+// Filename returns the name of the configuration file
+func (configFile *ConfigFile) Filename() string {
+	return configFile.filename
 }
 
-// create a base64 encoded auth string to store in config
+// EncodeAuth creates a base64 encoded string to containing authorization information
 func EncodeAuth(authConfig *AuthConfig) string {
 	authStr := authConfig.Username + ":" + authConfig.Password
 	msg := []byte(authStr)
@@ -202,7 +205,7 @@ func EncodeAuth(authConfig *AuthConfig) string {
 	return string(encoded)
 }
 
-// decode the auth string
+// DecodeAuth decodes a base64 encoded string and returns username and password
 func DecodeAuth(authStr string) (string, string, error) {
 	decLen := base64.StdEncoding.DecodedLen(len(authStr))
 	decoded := make([]byte, decLen)

--- a/cliconfig/config_test.go
+++ b/cliconfig/config_test.go
@@ -25,7 +25,7 @@ func TestMissingFile(t *testing.T) {
 		t.Fatalf("Failed to save: %q", err)
 	}
 
-	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, ConfigFileName))
 	if !strings.Contains(string(buf), `"auths":`) {
 		t.Fatalf("Should have save in new form: %s", string(buf))
 	}
@@ -47,7 +47,7 @@ func TestSaveFileToDirs(t *testing.T) {
 		t.Fatalf("Failed to save: %q", err)
 	}
 
-	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, ConfigFileName))
 	if !strings.Contains(string(buf), `"auths":`) {
 		t.Fatalf("Should have save in new form: %s", string(buf))
 	}
@@ -55,7 +55,7 @@ func TestSaveFileToDirs(t *testing.T) {
 
 func TestEmptyFile(t *testing.T) {
 	tmpHome, _ := ioutil.TempDir("", "config-test")
-	fn := filepath.Join(tmpHome, CONFIGFILE)
+	fn := filepath.Join(tmpHome, ConfigFileName)
 	ioutil.WriteFile(fn, []byte(""), 0600)
 
 	_, err := Load(tmpHome)
@@ -66,7 +66,7 @@ func TestEmptyFile(t *testing.T) {
 
 func TestEmptyJson(t *testing.T) {
 	tmpHome, _ := ioutil.TempDir("", "config-test")
-	fn := filepath.Join(tmpHome, CONFIGFILE)
+	fn := filepath.Join(tmpHome, ConfigFileName)
 	ioutil.WriteFile(fn, []byte("{}"), 0600)
 
 	config, err := Load(tmpHome)
@@ -80,7 +80,7 @@ func TestEmptyJson(t *testing.T) {
 		t.Fatalf("Failed to save: %q", err)
 	}
 
-	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, ConfigFileName))
 	if !strings.Contains(string(buf), `"auths":`) {
 		t.Fatalf("Should have save in new form: %s", string(buf))
 	}
@@ -100,7 +100,7 @@ func TestOldJson(t *testing.T) {
 	defer func() { os.Setenv(homeKey, homeVal) }()
 	os.Setenv(homeKey, tmpHome)
 
-	fn := filepath.Join(tmpHome, OLD_CONFIGFILE)
+	fn := filepath.Join(tmpHome, oldConfigfile)
 	js := `{"https://index.docker.io/v1/":{"auth":"am9lam9lOmhlbGxv","email":"user@example.com"}}`
 	ioutil.WriteFile(fn, []byte(js), 0600)
 
@@ -120,7 +120,7 @@ func TestOldJson(t *testing.T) {
 		t.Fatalf("Failed to save: %q", err)
 	}
 
-	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, ConfigFileName))
 	if !strings.Contains(string(buf), `"auths":`) ||
 		!strings.Contains(string(buf), "user@example.com") {
 		t.Fatalf("Should have save in new form: %s", string(buf))
@@ -129,7 +129,7 @@ func TestOldJson(t *testing.T) {
 
 func TestNewJson(t *testing.T) {
 	tmpHome, _ := ioutil.TempDir("", "config-test")
-	fn := filepath.Join(tmpHome, CONFIGFILE)
+	fn := filepath.Join(tmpHome, ConfigFileName)
 	js := ` { "auths": { "https://index.docker.io/v1/": { "auth": "am9lam9lOmhlbGxv", "email": "user@example.com" } } }`
 	ioutil.WriteFile(fn, []byte(js), 0600)
 
@@ -149,7 +149,7 @@ func TestNewJson(t *testing.T) {
 		t.Fatalf("Failed to save: %q", err)
 	}
 
-	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, CONFIGFILE))
+	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, ConfigFileName))
 	if !strings.Contains(string(buf), `"auths":`) ||
 		!strings.Contains(string(buf), "user@example.com") {
 		t.Fatalf("Should have save in new form: %s", string(buf))

--- a/registry/auth_test.go
+++ b/registry/auth_test.go
@@ -34,7 +34,7 @@ func setupTempConfigFile() (*cliconfig.ConfigFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	root = filepath.Join(root, cliconfig.CONFIGFILE)
+	root = filepath.Join(root, cliconfig.ConfigFileName)
 	configFile := cliconfig.NewConfigFile(root)
 
 	for _, registry := range []string{"testIndex", INDEXSERVER} {


### PR DESCRIPTION
my part for #14756
- fully capitalize HTTP in HTTPHeaders
- comment for CONFIGFILE
- camelcase and privatize oldConfigfile, defaultIndexserver, errConfigFileMissing
- comments for methods and functions throughout
- external references to renamed variable changed

Signed-off-by: Morgan Bauer mbauer@us.ibm.com
