### PR TITLE
Add golint to the development toolbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,6 +117,11 @@ RUN git clone https://github.com/golang/tools.git /go/src/golang.org/x/tools \
 	&& (cd /go/src/golang.org/x/tools && git checkout -q $GO_TOOLS_COMMIT) \
 	&& go install -v golang.org/x/tools/cmd/cover \
 	&& go install -v golang.org/x/tools/cmd/vet
+# Grab Go's lint tool
+ENV GO_LINT_COMMIT f42f5c1c440621302702cb0741e9d2ca547ae80f
+RUN git clone https://github.com/golang/lint.git /go/src/github.com/golang/lint \
+	&& (cd /go/src/github.com/golang/lint && git checkout -q $GO_LINT_COMMIT) \
+	&& go install -v github.com/golang/lint/golint
 
 # TODO replace FPM with some very minimal debhelper stuff
 RUN gem install --no-rdoc --no-ri fpm --version 1.3.2

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-docker-py: build
 	$(DOCKER_RUN_DOCKER) hack/make.sh binary test-docker-py
 
 validate: build
-	$(DOCKER_RUN_DOCKER) hack/make.sh validate-dco validate-gofmt validate-pkg validate-test validate-toml validate-vet
+	$(DOCKER_RUN_DOCKER) hack/make.sh validate-dco validate-gofmt validate-pkg validate-lint validate-test validate-toml validate-vet
 
 shell: build
 	$(DOCKER_RUN_DOCKER) bash

--- a/hack/make/validate-lint
+++ b/hack/make/validate-lint
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+source "${MAKEDIR}/.validate"
+
+# We will eventually get to the point when packages should be the complete list
+# of subpackages, vendoring excluded, as given by:
+#  go list ./... | grep -v "^github.com/docker/docker/vendor"
+packages=(
+	builder/parser/dumper
+	daemon/events
+	daemon/execdriver/native/template
+	daemon/network
+	cliconfig
+	docker
+	dockerinit
+	pkg/chrootarchive
+	pkg/directory
+	pkg/fileutils
+	pkg/homedir
+	pkg/listenbuffer
+	pkg/mflag/example
+	pkg/promise
+	pkg/pubsub
+	pkg/random
+	pkg/symlink
+	pkg/timeutils
+	pkg/tlsconfig
+	pkg/urlutil
+	pkg/version
+)
+
+errors=()
+for p in "$packages"; do
+	failedLint=$(golint "github.com/docker/docker/$p")
+	if [ "$failedLint" ]; then
+		errors+=( "$failedLint"  )
+	fi
+done
+
+if [ ${#errors[@]} -eq 0 ]; then
+	echo 'Congratulations!  All Go source files have been linted.'
+else
+	{
+		echo "Errors from golint:"
+		echo "${errors[@]}"
+		echo
+		echo 'Please fix the above errors. You can test via "golint" and commit the result.'
+		echo
+	} >&2
+	false
+fi


### PR DESCRIPTION
Add golint to the Dockerfile, and a `validate-lint` task to the Makefile.

Currently, the linter will process a harcoded list of packages that will expand as we fix more warnings. Eventually, the linter should process all subpackages of the repo (excluding vendored code).

Contributes to #14756.

Ping @jfrazelle @tianon!
