### PR TITLE
Minor fix of TestLogsStderrInStdout

### DIFF
--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -115,7 +115,7 @@ func (s *DockerSuite) TestLogsStderrInStdout(c *check.C) {
 
 	stdout, stderr, _ := dockerCmdWithStdoutStderr(c, "logs", cleanedContainerID)
 	if stderr != "" {
-		c.Fatalf("Expected empty stderr stream, got %v", stdout)
+		c.Fatalf("Expected empty stderr stream, got %v", stderr)
 	}
 
 	stdout = strings.TrimSpace(stdout)


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

we should print `stderr` but not `stdout` in 
`c.Fatalf("Expected empty stderr stream, got %v", stdout)`
