### PR TITLE
Docs: update the devicemapper default basesize from 10G to 100G

### DIFF
--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -201,9 +201,9 @@ options for `zfs` start with `zfs`.
  *  `dm.basesize`
 
     Specifies the size to use when creating the base device, which limits the
-    size of images and containers. The default value is 10G. Note, thin devices
-    are inherently "sparse", so a 10G device which is mostly empty doesn't use
-    10 GB of space on the pool. However, the filesystem will use more space for
+    size of images and containers. The default value is 100G. Note, thin devices
+    are inherently "sparse", so a 100G device which is mostly empty doesn't use
+    100 GB of space on the pool. However, the filesystem will use more space for
     the empty case the larger the device is.
 
     This value affects the system-wide "base" empty filesystem

--- a/man/docker.1.md
+++ b/man/docker.1.md
@@ -342,9 +342,9 @@ Example use: `docker -d --storage-opt dm.thinpooldev=/dev/mapper/thin-pool`
 #### dm.basesize
 
 Specifies the size to use when creating the base device, which limits
-the size of images and containers. The default value is 10G. Note,
-thin devices are inherently "sparse", so a 10G device which is mostly
-empty doesn't use 10 GB of space on the pool. However, the filesystem
+the size of images and containers. The default value is 100G. Note,
+thin devices are inherently "sparse", so a 100G device which is mostly
+empty doesn't use 100 GB of space on the pool. However, the filesystem
 will use more space for base images the larger the device
 is. 
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
#14709  has changed default basesize to 100G, but the docs wasn't updated
