### PR TITLE
Bump go-md2man to 1.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -172,7 +172,7 @@ RUN ./contrib/download-frozen-image.sh /docker-frozen-images \
 # Download man page generator
 RUN set -x \
 	&& export GOPATH="$(mktemp -d)" \
-	&& git clone -b v1.0.1 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
+	&& git clone -b v1.0.3 https://github.com/cpuguy83/go-md2man.git "$GOPATH/src/github.com/cpuguy83/go-md2man" \
 	&& git clone -b v1.2 https://github.com/russross/blackfriday.git "$GOPATH/src/github.com/russross/blackfriday" \
 	&& go get -v -d github.com/cpuguy83/go-md2man \
 	&& go build -v -o /usr/local/bin/go-md2man github.com/cpuguy83/go-md2man \

--- a/man/Dockerfile
+++ b/man/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.4
 RUN mkdir -p /go/src/github.com/cpuguy83
 RUN mkdir -p /go/src/github.com/cpuguy83 \
-    && git clone -b v1.0.1 https://github.com/cpuguy83/go-md2man.git /go/src/github.com/cpuguy83/go-md2man \
+    && git clone -b v1.0.3 https://github.com/cpuguy83/go-md2man.git /go/src/github.com/cpuguy83/go-md2man \
     && cd /go/src/github.com/cpuguy83/go-md2man \
     && go get -v ./...
 CMD ["/go/bin/go-md2man", "--help"]


### PR DESCRIPTION
Fixes an issue with curly braces being escaped when they should not be.
This was particularly an issue in places where `--format '{{ ...  }}'`
is used in the man docs.
