### PR TITLE
Remove unused TtyTerminal interface

### DIFF
--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -39,10 +39,6 @@ type Terminal interface {
 	Resize(height, width int) error
 }
 
-type TtyTerminal interface {
-	Master() libcontainer.Console
-}
-
 // ExitStatus provides exit reasons for a container.
 type ExitStatus struct {
 	// The exit code with which the container exited.

--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -808,10 +808,6 @@ func NewTtyConsole(processConfig *execdriver.ProcessConfig, pipes *execdriver.Pi
 	return tty, nil
 }
 
-func (t *TtyConsole) Master() *os.File {
-	return t.MasterPty
-}
-
 func (t *TtyConsole) Resize(h, w int) error {
 	return term.SetWinsize(t.MasterPty.Fd(), &term.Winsize{Height: uint16(h), Width: uint16(w)})
 }

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -374,10 +374,6 @@ func NewTtyConsole(console libcontainer.Console, pipes *execdriver.Pipes, rootui
 	return tty, nil
 }
 
-func (t *TtyConsole) Master() libcontainer.Console {
-	return t.console
-}
-
 func (t *TtyConsole) Resize(h, w int) error {
 	return term.SetWinsize(t.console.Fd(), &term.Winsize{Height: uint16(h), Width: uint16(w)})
 }


### PR DESCRIPTION
It was used only by integration tests, which now gone.
