### PR TITLE
pkg: mount: golint

### DIFF
--- a/hack/make/validate-lint
+++ b/hack/make/validate-lint
@@ -21,6 +21,7 @@ packages=(
 	pkg/homedir
 	pkg/listenbuffer
 	pkg/mflag/example
+	pkg/mount
 	pkg/namesgenerator
 	pkg/promise
 	pkg/pubsub

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -5,7 +5,7 @@ import (
 )
 
 // GetMounts retrieves a list of mounts for the current running process.
-func GetMounts() ([]*MountInfo, error) {
+func GetMounts() ([]*Info, error) {
 	return parseMountTable()
 }
 

--- a/pkg/mount/mountinfo.go
+++ b/pkg/mount/mountinfo.go
@@ -1,10 +1,10 @@
 package mount
 
-// MountInfo reveals information about a particular mounted filesystem. This
+// Info reveals information about a particular mounted filesystem. This
 // struct is populated from the content in the /proc/<pid>/mountinfo file.
-type MountInfo struct {
-	// Id is a unique identifier of the mount (may be reused after umount).
-	Id int
+type Info struct {
+	// ID is a unique identifier of the mount (may be reused after umount).
+	ID int
 
 	// Parent indicates the ID of the mount parent (or of self for the top of the
 	// mount tree).

--- a/pkg/mount/mountinfo_freebsd.go
+++ b/pkg/mount/mountinfo_freebsd.go
@@ -15,7 +15,7 @@ import (
 
 // Parse /proc/self/mountinfo because comparing Dev and ino does not work from
 // bind mounts.
-func parseMountTable() ([]*MountInfo, error) {
+func parseMountTable() ([]*Info, error) {
 	var rawEntries *C.struct_statfs
 
 	count := int(C.getmntinfo(&rawEntries, C.MNT_WAIT))
@@ -29,9 +29,9 @@ func parseMountTable() ([]*MountInfo, error) {
 	header.Len = count
 	header.Data = uintptr(unsafe.Pointer(rawEntries))
 
-	var out []*MountInfo
+	var out []*Info
 	for _, entry := range entries {
-		var mountinfo MountInfo
+		var mountinfo Info
 		mountinfo.Mountpoint = C.GoString(&entry.f_mntonname[0])
 		mountinfo.Source = C.GoString(&entry.f_mntfromname[0])
 		mountinfo.Fstype = C.GoString(&entry.f_fstypename[0])

--- a/pkg/mount/mountinfo_linux.go
+++ b/pkg/mount/mountinfo_linux.go
@@ -30,7 +30,7 @@ const (
 
 // Parse /proc/self/mountinfo because comparing Dev and ino does not work from
 // bind mounts
-func parseMountTable() ([]*MountInfo, error) {
+func parseMountTable() ([]*Info, error) {
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {
 		return nil, err
@@ -40,10 +40,10 @@ func parseMountTable() ([]*MountInfo, error) {
 	return parseInfoFile(f)
 }
 
-func parseInfoFile(r io.Reader) ([]*MountInfo, error) {
+func parseInfoFile(r io.Reader) ([]*Info, error) {
 	var (
 		s   = bufio.NewScanner(r)
-		out = []*MountInfo{}
+		out = []*Info{}
 	)
 
 	for s.Scan() {
@@ -52,13 +52,13 @@ func parseInfoFile(r io.Reader) ([]*MountInfo, error) {
 		}
 
 		var (
-			p              = &MountInfo{}
+			p              = &Info{}
 			text           = s.Text()
 			optionalFields string
 		)
 
 		if _, err := fmt.Sscanf(text, mountinfoFormat,
-			&p.Id, &p.Parent, &p.Major, &p.Minor,
+			&p.ID, &p.Parent, &p.Major, &p.Minor,
 			&p.Root, &p.Mountpoint, &p.Opts, &optionalFields); err != nil {
 			return nil, fmt.Errorf("Scanning '%s' failed: %s", text, err)
 		}
@@ -84,7 +84,7 @@ func parseInfoFile(r io.Reader) ([]*MountInfo, error) {
 // PidMountInfo collects the mounts for a specific process ID. If the process
 // ID is unknown, it is better to use `GetMounts` which will inspect
 // "/proc/self/mountinfo" instead.
-func PidMountInfo(pid int) ([]*MountInfo, error) {
+func PidMountInfo(pid int) ([]*Info, error) {
 	f, err := os.Open(fmt.Sprintf("/proc/%d/mountinfo", pid))
 	if err != nil {
 		return nil, err

--- a/pkg/mount/mountinfo_linux_test.go
+++ b/pkg/mount/mountinfo_linux_test.go
@@ -457,8 +457,8 @@ func TestParseFedoraMountinfoFields(t *testing.T) {
 	if len(infos) != expectedLength {
 		t.Fatalf("Expected %d entries, got %d", expectedLength, len(infos))
 	}
-	mi := MountInfo{
-		Id:         15,
+	mi := Info{
+		ID:         15,
 		Parent:     35,
 		Major:      0,
 		Minor:      3,

--- a/pkg/mount/mountinfo_unsupported.go
+++ b/pkg/mount/mountinfo_unsupported.go
@@ -7,6 +7,6 @@ import (
 	"runtime"
 )
 
-func parseMountTable() ([]*MountInfo, error) {
+func parseMountTable() ([]*Info, error) {
 	return nil, fmt.Errorf("mount.parseMountTable is not implemented on %s/%s", runtime.GOOS, runtime.GOARCH)
 }


### PR DESCRIPTION
Fix the following warnings:

```
pkg/mount/mountinfo.go:5:6: type name will be used as mount.MountInfo by other packages, and that stutters; consider calling this Info
pkg/mount/mountinfo.go:7:2: struct field Id should be ID
```

I can rename `pkg/mount/mountinfo*` to just `pkg/mouont/info*` if someone prefer

Signed-off-by: Antonio Murdaca runcom@linux.com
