### PR TITLE
Remove dead code in registry package

### DIFF
--- a/registry/types.go
+++ b/registry/types.go
@@ -33,23 +33,6 @@ type RegistryInfo struct {
 	Standalone bool   `json:"standalone"`
 }
 
-type FSLayer struct {
-	BlobSum string `json:"blobSum"`
-}
-
-type ManifestHistory struct {
-	V1Compatibility string `json:"v1Compatibility"`
-}
-
-type ManifestData struct {
-	Name          string             `json:"name"`
-	Tag           string             `json:"tag"`
-	Architecture  string             `json:"architecture"`
-	FSLayers      []*FSLayer         `json:"fsLayers"`
-	History       []*ManifestHistory `json:"history"`
-	SchemaVersion int                `json:"schemaVersion"`
-}
-
 type APIVersion int
 
 func (av APIVersion) String() string {


### PR DESCRIPTION
The only uses of RequestAuthorization and its associated functions were
removed in 19515a7ad859b28c474d81e756ac245afcd968e3 ("Update graph to
use vendored distribution client for the v2 codepath")

Signed-off-by: Aaron Lehmann aaron.lehmann@docker.com
