### PR TITLE
Allow starting a container with an existing hostConfig which contains links

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -481,7 +481,6 @@ func (daemon *Daemon) NetworkApiRouter() func(w http.ResponseWriter, req *http.R
 }
 
 func (daemon *Daemon) RegisterLinks(container *Container, hostConfig *runconfig.HostConfig) error {
-
 	if hostConfig == nil || hostConfig.Links == nil {
 		return nil
 	}

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1614,3 +1614,48 @@ func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceCapAddDrop(c *che
 	c.Assert(err, check.IsNil)
 	c.Assert(status, check.Equals, http.StatusCreated)
 }
+
+// #14640
+func (s *DockerSuite) TestPostContainersStartWithoutLinksInHostConfig(c *check.C) {
+	name := "test-host-config-links"
+	dockerCmd(c, "create", "--name", name, "busybox", "top")
+
+	hc, err := inspectFieldJSON(name, "HostConfig")
+	c.Assert(err, check.IsNil)
+	config := `{"HostConfig":` + hc + `}`
+
+	res, _, err := sockRequestRaw("POST", "/containers/"+name+"/start", strings.NewReader(config), "application/json")
+	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusNoContent)
+}
+
+// #14640
+func (s *DockerSuite) TestPostContainersStartWithLinksInHostConfig(c *check.C) {
+	name := "test-host-config-links"
+	dockerCmd(c, "run", "--name", "foo", "-d", "busybox", "top")
+	dockerCmd(c, "create", "--name", name, "--link", "foo:bar", "busybox", "top")
+
+	hc, err := inspectFieldJSON(name, "HostConfig")
+	c.Assert(err, check.IsNil)
+	config := `{"HostConfig":` + hc + `}`
+
+	res, _, err := sockRequestRaw("POST", "/containers/"+name+"/start", strings.NewReader(config), "application/json")
+	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusNoContent)
+}
+
+// #14640
+func (s *DockerSuite) TestPostContainersStartWithLinksInHostConfigIdLinked(c *check.C) {
+	name := "test-host-config-links"
+	out, _ := dockerCmd(c, "run", "--name", "link0", "-d", "busybox", "top")
+	id := strings.TrimSpace(out)
+	dockerCmd(c, "create", "--name", name, "--link", id, "busybox", "top")
+
+	hc, err := inspectFieldJSON(name, "HostConfig")
+	c.Assert(err, check.IsNil)
+	config := `{"HostConfig":` + hc + `}`
+
+	res, _, err := sockRequestRaw("POST", "/containers/"+name+"/start", strings.NewReader(config), "application/json")
+	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusNoContent)
+}

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -3,6 +3,7 @@ package parsers
 import (
 	"fmt"
 	"net/url"
+	"path"
 	"runtime"
 	"strconv"
 	"strings"
@@ -157,6 +158,13 @@ func ParseLink(val string) (string, string, error) {
 	}
 	if len(arr) == 1 {
 		return val, val, nil
+	}
+	// This is kept because we can actually get an HostConfig with links
+	// from an already created container and the format is not `foo:bar`
+	// but `/foo:/c1/bar`
+	if strings.HasPrefix(arr[0], "/") {
+		_, alias := path.Split(arr[1])
+		return arr[0][1:], alias, nil
 	}
 	return arr[0], arr[1], nil
 }


### PR DESCRIPTION
Fix #14640
Since we're allowing starting a container with an existing hostConfig (I've added a test for this) I don't see why having an hostConfig with links should actually error out. This is fixing this behavior (by correctly parsing an _hostConfig link_ and I preferred this over changing the output of inspect but this may be questionable) and hopefully we could deprecate starting a container with an hostConfig soon as per #14777

Signed-off-by: Antonio Murdaca runcom@linux.com
