### PR TITLE
Windows: Remove erroneous comment only (no code change)

### DIFF
--- a/daemon/execdriver/windows/ttyconsole.go
+++ b/daemon/execdriver/windows/ttyconsole.go
@@ -21,8 +21,6 @@ func NewTtyConsole(id string, processid uint32) *TtyConsole {
 }
 
 func (t *TtyConsole) Resize(h, w int) error {
-	// TODO Windows: This is not implemented in HCS. Needs plumbing through
-	// along with mechanism for buffering
 	return hcsshim.ResizeConsoleInComputeSystem(t.id, t.processid, h, w)
 }
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Removes a comment which is no longer true in the Windows execdriver. No actual code changes.
