### PR TITLE
Remove unused parameter in NewTtyConsole

### DIFF
--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -361,7 +361,7 @@ type TtyConsole struct {
 	console libcontainer.Console
 }
 
-func NewTtyConsole(console libcontainer.Console, pipes *execdriver.Pipes, rootuid int) (*TtyConsole, error) {
+func NewTtyConsole(console libcontainer.Console, pipes *execdriver.Pipes) (*TtyConsole, error) {
 	tty := &TtyConsole{
 		console: console,
 	}
@@ -417,7 +417,7 @@ func setupPipes(container *configs.Config, processConfig *execdriver.ProcessConf
 		if err != nil {
 			return err
 		}
-		term, err = NewTtyConsole(cons, pipes, rootuid)
+		term, err = NewTtyConsole(cons, pipes)
 	} else {
 		p.Stdout = pipes.Stdout
 		p.Stderr = pipes.Stderr


### PR DESCRIPTION
It's introduced in
68ba5f0b69c9f38 (Execdriver implementation on new libcontainer API)

But I don't see reson why we need it.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
