### PR TITLE
Fix wrong Content-Type returned by /images/search API

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -818,7 +818,7 @@ func (s *Server) getImagesSearch(version version.Version, w http.ResponseWriter,
 	if err != nil {
 		return err
 	}
-	return json.NewEncoder(w).Encode(query.Results)
+	return writeJSON(w, http.StatusOK, query.Results)
 }
 
 func (s *Server) postImagesPush(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -120,3 +120,14 @@ func (s *DockerSuite) TestApiImagesHistory(c *check.C) {
 	c.Assert(len(historydata), check.Not(check.Equals), 0)
 	c.Assert(historydata[0].Tags[0], check.Equals, "test-api-images-history:latest")
 }
+
+// #14846
+func (s *DockerSuite) TestApiImagesSearchJSONContentType(c *check.C) {
+	testRequires(c, Network)
+
+	res, b, err := sockRequestRaw("GET", "/images/search?term=test", nil, "application/json")
+	b.Close()
+	c.Assert(err, check.IsNil)
+	c.Assert(res.StatusCode, check.Equals, http.StatusOK)
+	c.Assert(res.Header.Get("Content-Type"), check.Equals, "application/json")
+}


### PR DESCRIPTION
/images/search was replying with Content-Type text/plain instead
of application/json.
Fix #14846

Signed-off-by: Antonio Murdaca runcom@linux.com
