### PR TITLE
docker: Unmount -init layer root before taking a snapshot

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -81,11 +81,15 @@ func (daemon *Daemon) createRootfs(container *Container) error {
 	if err != nil {
 		return err
 	}
-	defer daemon.driver.Put(initID)
 
 	if err := setupInitLayer(initPath); err != nil {
+		daemon.driver.Put(initID)
 		return err
 	}
+
+	// We want to unmount init layer before we take snapshot of it
+	// for the actual container.
+	daemon.driver.Put(initID)
 
 	if err := daemon.driver.Create(container.ID, initID); err != nil {
 		return err


### PR DESCRIPTION
Fixes #14853 

When we are creating a container, first we call into graph driver to take
snapshot of image and create root for container-init. Then we write some
files to it and call into graph driver again to create container root
from container-init as base.

Once we have written files to container-init root, we don't unmount it
before taking a snapshot of it. Looks like with XFS it leaves it in such
a state that when we mount the container root, it goes into log recovery
path.

Jul 22 10:24:54 vm2-f22 kernel: XFS (dm-6): Mounting V4 Filesystem
Jul 22 10:24:54 vm2-f22 kernel: XFS (dm-6): Starting recovery (logdev: internal)
Jul 22 10:24:54 vm2-f22 kernel: XFS (dm-6): Ending recovery (logdev: internal)

This should not be required. So let us unmount container-init before use
it  as a base for container root and then XFS does not go into this
internal recovery path.

Somebody had raised this issue for ext4 sometime back and proposed the same
change. I had shot it down at that point of time. I think now time has
come for this change.

Signed-off-by: Vivek Goyal vgoyal@redhat.com
