### PR TITLE
Introduce a dedicated unconfined AA policy

### DIFF
--- a/contrib/apparmor/docker
+++ b/contrib/apparmor/docker
@@ -23,3 +23,15 @@ profile docker-default flags=(attach_disconnected,mediate_deleted) {
   deny /sys/firmware/efi/efivars/** rwklx,
   deny /sys/kernel/security/** rwklx,
 }
+
+profile docker-unconfined flags=(attach_disconnected,mediate_deleted) {
+  #include <abstractions/base>
+
+  network,
+  capability,
+  file,
+  umount,
+  mount,
+  pivot_root,
+  change_profile -> *,
+}

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -198,7 +198,7 @@ func (d *driver) setPrivileged(container *configs.Config) (err error) {
 	container.Devices = hostDevices
 
 	if apparmor.IsEnabled() {
-		container.AppArmorProfile = "unconfined"
+		container.AppArmorProfile = "docker-unconfined"
 	}
 
 	return nil


### PR DESCRIPTION
By using the 'unconfined' policy for privileged
containers, we have inherited the host's apparmor
policies, which really make no sense in the
context of the container's filesystem.

For instance, policies written against
the paths of binaries such as '/usr/sbin/tcpdump'
can be easily circumvented by moving the binary
within the container filesystem.

Fixes #5490 #14550

Signed-off-by: Eric Windisch eric@windisch.us
