### PR TITLE
#14474 skip DockerSuite.TestRunCapAddCHOWN on lxc

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2469,6 +2469,7 @@ func (s *DockerSuite) TestDevicePermissions(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapAddCHOWN(c *check.C) {
+	testRequires(c, NativeExecDriver)
 	out, _ := dockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=CHOWN", "busybox", "sh", "-c", "adduser -D -H newuser && chown newuser /home && echo ok")
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {


### PR DESCRIPTION
To skip DockerSuite.TestRunCapAddCHOWN, I add a test requirement that return false in that test case
Fixes #14475 

Signed-off-by: Zhang Kun zkazure@gmail.com
