### PR TITLE
Update validate-lint to lint all go files

### DIFF
--- a/hack/make/validate-lint
+++ b/hack/make/validate-lint
@@ -41,7 +41,9 @@ packages=(
 
 errors=()
 for p in "${packages[@]}"; do
-	failedLint=$(golint "$p")
+	# Run golint on package/*.go file explicitly to validate all go files
+	# and not just the ones for the current platform.
+	failedLint=$(golint "$p"/*.go)
 	if [ "$failedLint" ]; then
 		errors+=( "$failedLint" )
 	fi


### PR DESCRIPTION
By default, using go with package will only validate the go file for the current platform (or at last misses file_windows.go for example). This tries to fix that as we will tend to miss other platform for files.

The way I did it feels a little bit ugly though :sweat:. 
If it feels like overkill, feel free to close it :blush:.

<del>PS: the build should fail for now as there is some files in the current list of package that needs to be linted.</del> oh :stuck_out_tongue_closed_eyes:  it seems validate-lint is not run by default for now :blush:.

Signed-off-by: Vincent Demeester vincent@sbr.pm
