### PR TITLE
Add AppArmor policy for the docker binary

### DIFF
--- a/contrib/apparmor/docker-engine
+++ b/contrib/apparmor/docker-engine
@@ -1,0 +1,71 @@
+@{DOCKER_GRAPH_PATH}=/var/lib/docker
+
+profile /usr/bin/docker (attach_disconnected) {
+  # Prevent following links to these files during container setup.
+  deny /etc/** mkl,
+  deny /dev/** kl,
+  deny /sys/** mkl,
+  deny /proc/** mkl,
+
+  mount -> @{DOCKER_GRAPH_PATH}/**,
+  mount -> /,
+  mount -> /proc/**,
+  mount -> /sys/**,
+  mount -> /run/docker/netns/**,
+
+  umount,
+  pivot_root,
+  signal (receive) peer=@{profile_name},
+  signal (receive) peer=unconfined,
+  signal (send),
+  ipc rw,
+  network,
+  capability,
+  file,
+
+  ptrace peer=@{profile_name},
+
+  /usr/bin/docker pix,
+  /sbin/xtables-multi rCix,
+  /sbin/iptables rCx,
+  /sbin/modprobe rCx,
+  /sbin/auplink rCx,
+  /usr/bin/xz rCx,
+
+  # Transitions
+  change_profile -> docker-*,
+  change_profile -> unconfined,
+
+  profile /sbin/iptables {
+   signal (receive) peer=/usr/bin/docker,
+   capability net_admin,
+  }
+  profile /sbin/auplink flags=(attach_disconnected) {
+   signal (receive) peer=/usr/bin/docker,
+   capability sys_admin,
+   capability dac_override,
+
+   @{DOCKER_GRAPH_PATH}/aufs/** rw,
+   # For user namespaces:
+   @{DOCKER_GRAPH_PATH}/[0-9]*.[0-9]*/** rw,
+
+   # The following may be removed via delegates
+   /sys/fs/aufs/** r,
+   /lib/** r,
+   /apparmor/.null r,
+   /dev/null rw,
+   /etc/ld.so.cache r,
+   /sbin/auplink rm,
+   /proc/fs/aufs/** rw,
+   /proc/[0-9]*/mounts rw,
+  }
+  profile /sbin/modprobe {
+   signal (receive) peer=/usr/bin/docker,
+   capability sys_module,
+   file,
+  }
+  # xz works via pipes, so we do not need access to the filesystem.
+  profile /usr/bin/xz {
+   signal (receive) peer=/usr/bin/docker,
+  }
+}

--- a/hack/make/.build-deb/rules
+++ b/hack/make/.build-deb/rules
@@ -34,6 +34,7 @@ override_dh_installudev:
 
 override_dh_install:
 	dh_apparmor --profile-name=docker -pdocker-engine
+	dh_apparmor --profile-name=docker-engine -pdocker-engine
 
 %:
 	dh $@ --with=bash-completion $(shell command -v dh_systemd_enable > /dev/null 2>&1 && echo --with=systemd)

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -75,6 +75,7 @@ bundle_ubuntu() {
 	# Include contributed apparmor policy
 	mkdir -p "$DIR/etc/apparmor.d/"
 	cp contrib/apparmor/docker "$DIR/etc/apparmor.d/"
+	cp contrib/apparmor/docker-engine "$DIR/etc/apparmor.d/"
 
 	# Copy the binary
 	# This will fail if the binary bundle hasn't been built
@@ -95,6 +96,7 @@ fi
 
 if ( aa-status --enabled ); then
 	/sbin/apparmor_parser -r -W -T /etc/apparmor.d/docker
+	/sbin/apparmor_parser -r -W -T /etc/apparmor.d/docker-engine
 fi
 
 if ! { [ -x /sbin/initctl ] && /sbin/initctl version 2>/dev/null | grep -q upstart; }; then


### PR DESCRIPTION
Wraps the engine itself with an AppArmor policy.

This restricts what may be done by applications
we call out to, such as 'xz'.

Significantly, this policy also restricts the policies
to which a container may be spawned into. By default,
users will be able to transition to an unconfined
policy or any policy prefaced with 'docker-'.

Local operators may add new local policies prefaced
with 'docker-' without needing to modify this policy.
Operators choosing to disable privileged containers
will need to modify this policy to remove access
to change_policy to unconfined.

Signed-off-by: Eric Windisch eric@windisch.us
