### PR TITLE
Allow RHEL init script to detect daemon start pid failure

### DIFF
--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -58,7 +58,13 @@ start() {
         while [ ! -f $pidfile -a $tries -lt 10 ]; do
             sleep 1
             tries=$((tries + 1))
+            echo -n '.'
         done
+        if [ ! -f $pidfile ]; then
+          failure
+          echo
+          exit 1
+        fi
         success
         echo
     else


### PR DESCRIPTION
If you have some kind of bogus `other_args` in `/etc/sysconfig/docker` the start script will report "started" but it's full of lies. This enhances the flow so that if the pidfile never shows up (failure to start) you get a proper failure message.

I also added dots for fun.

Signed-off-by: Jeff Minard jeff.minard@creditkarma.com
