### PR TITLE
Fixes intercontainer communication when firewalld is running

### DIFF
--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/setup_ip_tables.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/setup_ip_tables.go
@@ -149,7 +149,7 @@ func setIcc(bridgeIface string, iccEnable, insert bool) error {
 			iptables.Raw(append([]string{"-D", chain}, dropArgs...)...)
 
 			if !iptables.Exists(table, chain, acceptArgs...) {
-				if output, err := iptables.Raw(append([]string{"-A", chain}, acceptArgs...)...); err != nil {
+				if output, err := iptables.Raw(append([]string{"-I", chain}, acceptArgs...)...); err != nil {
 					return fmt.Errorf("Unable to allow intercontainer communication: %s", err.Error())
 				} else if len(output) != 0 {
 					return fmt.Errorf("Error enabling intercontainer communication: %s", output)


### PR DESCRIPTION
This fixes inter-container communication on systems running Firewalld. 
cc @rhatdan 

Signed-off-by: Alec Benson albenson@redhat.com
