### PR TITLE
Stop SIGSEGV on test dial not reachable

### DIFF
--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -338,11 +338,9 @@ func sockRequest(method, endpoint string, data interface{}) (int, []byte, error)
 
 	res, body, err := sockRequestRaw(method, endpoint, jsonData, "application/json")
 	if err != nil {
-		b, _ := ioutil.ReadAll(body)
-		return -1, b, err
+		return -1, nil, err
 	}
-	var b []byte
-	b, err = readBody(body)
+	b, err := readBody(body)
 	return res.StatusCode, b, err
 }
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

(Found while testing against a remote daemon). If the daemon can't be dialed, the test with cause a panic as it assumes body is non-nil which may not be true. Adds checks for nil in sockRequest()
