### PR TITLE
Windows: Stupid copy/paste error

### DIFF
--- a/daemon/execdriver/windows/terminatekill.go
+++ b/daemon/execdriver/windows/terminatekill.go
@@ -37,7 +37,7 @@ func kill(id string, pid int) error {
 
 	} else {
 		// Shutdown the compute system
-		if err = hcsshim.TerminateComputeSystem(id); err != nil {
+		if err = hcsshim.ShutdownComputeSystem(id); err != nil {
 			logrus.Errorf("Failed to shutdown %s - %s", id, err)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. Found a silly typo in the else path calling the wrong function.
