### PR TITLE
fix the panic caused by resizing a starting exec

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -812,8 +812,6 @@ func (container *Container) Exec(execConfig *execConfig) error {
 	container.Lock()
 	defer container.Unlock()
 
-	waitStart := make(chan struct{})
-
 	callback := func(processConfig *execdriver.ProcessConfig, pid int) {
 		if processConfig.Tty {
 			// The callback is called after the process Start()
@@ -823,7 +821,7 @@ func (container *Container) Exec(execConfig *execConfig) error {
 				c.Close()
 			}
 		}
-		close(waitStart)
+		close(execConfig.waitStart)
 	}
 
 	// We use a callback here instead of a goroutine and an chan for
@@ -832,7 +830,7 @@ func (container *Container) Exec(execConfig *execConfig) error {
 
 	// Exec should not return until the process is actually running
 	select {
-	case <-waitStart:
+	case <-execConfig.waitStart:
 	case err := <-cErr:
 		return err
 	}

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -29,6 +29,9 @@ type execConfig struct {
 	OpenStdout bool
 	Container  *Container
 	canRemove  bool
+
+	// waitStart will be closed immediately after the exec is really started.
+	waitStart chan struct{}
 }
 
 type execStore struct {
@@ -70,6 +73,11 @@ func (e *execStore) List() []string {
 }
 
 func (execConfig *execConfig) Resize(h, w int) error {
+	select {
+	case <-execConfig.waitStart:
+	case <-time.After(time.Second):
+		return fmt.Errorf("Exec %s is not running, so it can not be resized.", execConfig.ID)
+	}
 	return execConfig.ProcessConfig.Terminal.Resize(h, w)
 }
 
@@ -146,6 +154,7 @@ func (d *Daemon) ContainerExecCreate(config *runconfig.ExecConfig) (string, erro
 		ProcessConfig: processConfig,
 		Container:     container,
 		Running:       false,
+		waitStart:     make(chan struct{}),
 	}
 
 	d.registerExecCommand(execConfig)

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -15,4 +19,60 @@ func (s *DockerSuite) TestExecResizeApiHeightWidthNoInt(c *check.C) {
 	status, _, err := sockRequest("POST", endpoint, nil)
 	c.Assert(status, check.Equals, http.StatusInternalServerError)
 	c.Assert(err, check.IsNil)
+}
+
+// Part of #14845
+func (s *DockerSuite) TestExecResizeImmediatelyAfterExecStart(c *check.C) {
+	name := "exec_resize_test"
+	dockerCmd(c, "run", "-d", "-i", "-t", "--name", name, "--restart", "always", "busybox", "/bin/sh")
+
+	// The panic happens when daemon.ContainerExecStart is called but the
+	// container.Exec is not called.
+	// Because the panic is not 100% reproducible, we send the requests concurrently
+	// to increase the probability that the problem is triggered.
+	n := 10
+	ch := make(chan struct{})
+	for i := 0; i < n; i++ {
+		go func() {
+			defer func() {
+				ch <- struct{}{}
+			}()
+
+			data := map[string]interface{}{
+				"AttachStdin": true,
+				"Cmd":         []string{"/bin/sh"},
+			}
+			status, body, err := sockRequest("POST", fmt.Sprintf("/containers/%s/exec", name), data)
+			c.Assert(err, check.IsNil)
+			c.Assert(status, check.Equals, http.StatusCreated)
+
+			out := map[string]string{}
+			err = json.Unmarshal(body, &out)
+			c.Assert(err, check.IsNil)
+
+			execID := out["Id"]
+			if len(execID) < 1 {
+				c.Fatal("ExecCreate got invalid execID")
+			}
+
+			payload := bytes.NewBufferString(`{"Tty":true}`)
+			conn, _, err := sockRequestHijack("POST", fmt.Sprintf("/exec/%s/start", execID), payload, "application/json")
+			c.Assert(err, check.IsNil)
+			defer conn.Close()
+
+			_, rc, err := sockRequestRaw("POST", fmt.Sprintf("/exec/%s/resize?h=24&w=80", execID), nil, "text/plain")
+			// It's probably a panic of the daemon if io.ErrUnexpectedEOF is returned.
+			if err == io.ErrUnexpectedEOF {
+				c.Fatal("The daemon might have crashed.")
+			}
+
+			if err == nil {
+				rc.Close()
+			}
+		}()
+	}
+
+	for i := 0; i < n; i++ {
+		<-ch
+	}
 }


### PR DESCRIPTION
If resize an exec that is not fully started, the daemon will panic with the following info:

```
2015/07/22 19:44:14 http: panic serving @: runtime error: invalid memory address or nil pointer dereference^M
goroutine 12502 [running]:^M
net/http.func·011()^M
  /usr/local/go/src/net/http/server.go:1130 +0xbb^M
github.com/docker/docker/daemon.(*execConfig).Resize(0xc208191600, 0x27, 0x93, 0x0, 0x0)^M
  /go/src/github.com/docker/docker/daemon/exec.go:70 +0x67^M
github.com/docker/docker/daemon.(*Daemon).ContainerExecResize(0xc20806b180, 0xc20815b041, 0x40, 0x27, 0x93, 0x0, 0x0)^M
  /go/src/github.com/docker/docker/daemon/resize.go:18 +0x99^M
github.com/docker/docker/api/server.(*Server).postContainerExecResize(0xc2080b1100, 0xc20815b037, 0x4, 0x7f103863d9f8, 0xc2080c6500, 0xc2089031e0, 0xc208dab5f0, 0x0, 0x0)^M
  /go/src/github.com/docker/docker/api/server/server.go:1422 +0x2ca^M
github.com/docker/docker/api/server.*Server.(github.com/docker/docker/api/server.postContainerExecResize)·fm(0xc20815b037, 0x4, 0x7f103863d9f8, 0xc2080c6500, 0xc2089031e0, 0xc208dab5f0, 0x0, 0x0)^M
  /go/src/github.com/docker/docker/api/server/server.go:1546 +0x7b^M
github.com/docker/docker/api/server.func·008(0x7f103863d9f8, 0xc2080c6500, 0xc2089031e0)^M
  /go/src/github.com/docker/docker/api/server/server.go:1489 +0x91d^M
net/http.HandlerFunc.ServeHTTP(0xc20814f800, 0x7f103863d9f8, 0xc2080c6500, 0xc2089031e0)^M
  /usr/local/go/src/net/http/server.go:1265 +0x41^M
github.com/gorilla/mux.(*Router).ServeHTTP(0xc2080f51d0, 0x7f103863d9f8, 0xc2080c6500, 0xc2089031e0)^M
  /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x297^M
net/http.serverHandler.ServeHTTP(0xc2080518c0, 0x7f103863d9f8, 0xc2080c6500, 0xc2089031e0)^M
  /usr/local/go/src/net/http/server.go:1703 +0x19a^M
net/http.(*conn).serve(0xc2081575e0)^M
  /usr/local/go/src/net/http/server.go:1204 +0xb57^M
created by net/http.(*Server).Serve^M
  /usr/local/go/src/net/http/server.go:1751 +0x35e^M
```

The `execConfig.ProcessConfig.Terminal` is assigned by `setupPipes` in daemon/execdriver/native/driver.go. Before the call to `setupPipes` it's a nil pointer, which caused the panic.

This PR fixes part of #14845. But I've no idea why it panicked during daemon shutdown.
Signed-off-by: Shijiang Wei mountkin@gmail.com
