### PR TITLE
Apparmor engine

### DIFF
--- a/contrib/apparmor/docker-engine
+++ b/contrib/apparmor/docker-engine
@@ -24,6 +24,7 @@ profile /usr/bin/docker (attach_disconnected) {
   file,
 
   ptrace peer=@{profile_name},
+  ptrace (trace) peer=docker-default,
 
   /usr/bin/docker pix,
   /sbin/xtables-multi rCix,

--- a/contrib/apparmor/docker-engine
+++ b/contrib/apparmor/docker-engine
@@ -25,6 +25,7 @@ profile /usr/bin/docker (attach_disconnected) {
 
   ptrace peer=@{profile_name},
   ptrace (trace) peer=docker-default,
+  deny ptrace peer=/usr/bin/docker///bin/ps,
 
   /usr/bin/docker pix,
   /sbin/xtables-multi rCix,
@@ -32,6 +33,7 @@ profile /usr/bin/docker (attach_disconnected) {
   /sbin/modprobe rCx,
   /sbin/auplink rCx,
   /usr/bin/xz rCx,
+  /bin/ps rCx,
 
   # Transitions
   change_profile -> docker-*,
@@ -68,5 +70,10 @@ profile /usr/bin/docker (attach_disconnected) {
   # xz works via pipes, so we do not need access to the filesystem.
   profile /usr/bin/xz {
    signal (receive) peer=/usr/bin/docker,
+  }
+  profile /bin/ps {
+   file,
+   capability,
+   deny ptrace,
   }
 }


### PR DESCRIPTION
The following two patches fix ptrace and /bin/ps related apparmor denials. Presumably none of the performed actions are malicious and therefore can be allowed by the profile.
