### PR TITLE
AppArmor deny 1.6.1 proc files & ptrace

### DIFF
--- a/contrib/apparmor/docker
+++ b/contrib/apparmor/docker
@@ -6,14 +6,19 @@ profile docker-default flags=(attach_disconnected,mediate_deleted) {
   network,
   capability,
   file,
-  umount,
 
   deny @{PROC}/sys/fs/** wklx,
+  deny @{PROC}/fs/** wklx,
   deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/timer_stats rwklx,
+  deny @{PROC}/latency_stats rwklx,
+  deny @{PROC}/kmem rwklx,
+  deny @{PROC}/kcore rwklx,
   deny @{PROC}/sys/kernel/[^s][^h][^m]* wklx,
   deny @{PROC}/sys/kernel/*/** wklx,
 
   deny mount,
+  deny ptrace,
 
   deny /sys/[^f]*/** wklx,
   deny /sys/f[^s]*/** wklx,


### PR DESCRIPTION
In 1.6.1, we added additional masks in
libcontainer for a number of files in proc.

This commit adds restrictions for these files
in the AppArmor policy for additional protection.
- /proc/fs
- /proc/timer_stats
- /proc/latency_stats
- /proc/kcore
- /proc/kmem

We also add a denial for ptrace. Ptrace was already
denied by the profile, but this quiets the audit messages
as users were seeing frequent logging of ptrace denials by
simply running 'ps' in their containers.

Signed-off-by: Eric Windisch eric@windisch.us
