### PR TITLE
Check for nil before using HostConfig to adjustCpuShares

### DIFF
--- a/api/server/server_linux.go
+++ b/api/server/server_linux.go
@@ -109,7 +109,7 @@ func allocateDaemonPort(addr string) error {
 
 func adjustCpuShares(version version.Version, hostConfig *runconfig.HostConfig) {
 	if version.LessThan("1.19") {
-		if hostConfig.CpuShares > 0 {
+		if hostConfig != nil && hostConfig.CpuShares > 0 {
 			// Handle unsupported CpuShares
 			if hostConfig.CpuShares < linuxMinCpuShares {
 				logrus.Warnf("Changing requested CpuShares of %d to minimum allowed of %d", hostConfig.CpuShares, linuxMinCpuShares)

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -1687,3 +1687,13 @@ func (s *DockerSuite) TestPostContainersStartWithLinksInHostConfigIdLinked(c *ch
 	c.Assert(res.StatusCode, check.Equals, http.StatusNoContent)
 	b.Close()
 }
+
+// #14915
+func (s *DockerSuite) TestContainersApiCreateNoHostConfig118(c *check.C) {
+	config := struct {
+		Image string
+	}{"busybox"}
+	status, _, err := sockRequest("POST", "/v1.18/containers/create", config)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusCreated)
+}


### PR DESCRIPTION
Hi,

This fixes #14915 for me.

The remote API in master does not work for a /container/create request that comes in with a missing HostConfig sub-object. Docker will dereference a nil pointer.

The 'adjustCpuShares' function expects a valid HostConfig object.

It appears that the commit for https://github.com/docker/docker/pull/13218 changed the behavior of the decoder, to no longer create a new HostConfig object if none was specified over the API. That change appears to have broken the create call. With this fix applied, the issue no longer occurs.

Thanks!

Signed-off-by: Stephen Rust srust@blockbridge.com
