### PR TITLE
Fix "docker ps" with no containers regression

### DIFF
--- a/api/client/ps/custom.go
+++ b/api/client/ps/custom.go
@@ -191,6 +191,13 @@ func customFormat(ctx Context, containers []types.Container) {
 	}
 
 	if table {
+		if len(header) == 0 {
+			// if we still don't have a header, we didn't have any containers so we need to fake it to get the right headers from the template
+			containerCtx := &containerContext{}
+			tmpl.Execute(bytes.NewBufferString(""), containerCtx)
+			header = containerCtx.fullHeader()
+		}
+
 		t := tabwriter.NewWriter(ctx.Output, 20, 1, 3, ' ', 0)
 		t.Write([]byte(header))
 		t.Write([]byte("\n"))

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -539,3 +539,18 @@ func (s *DockerSuite) TestPsFormatMultiNames(c *check.C) {
 	}
 
 }
+
+func (s *DockerSuite) TestPsFormatHeaders(c *check.C) {
+	// make sure no-container "docker ps" still prints the header row
+	out, _ := dockerCmd(c, "ps", "--format", "table {{.ID}}")
+	if out != "CONTAINER ID\n" {
+		c.Fatalf(`Expected 'CONTAINER ID\n', got %v`, out)
+	}
+
+	// verify that "docker ps" with a container still prints the header row also
+	dockerCmd(c, "run", "--name=test", "-d", "busybox", "top")
+	out, _ = dockerCmd(c, "ps", "--format", "table {{.Names}}")
+	if out != "NAMES\ntest\n" {
+		c.Fatalf(`Expected 'NAMES\ntest\n', got %v`, out)
+	}
+}


### PR DESCRIPTION
The header row was not being printed when "docker ps" was invoked without containers thanks to the new format support, and we instead received a single blank line.

https://github.com/docker/docker/pull/14699/files#r35364230
