### PR TITLE
Label /etc/resolv.conf, /etc/hosts ... correctly in shared network co…

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -1161,8 +1161,12 @@ func (container *Container) CleanupStorage() error {
 
 func (container *Container) networkMounts() []execdriver.Mount {
 	var mounts []execdriver.Mount
+	mode := "Z"
+	if container.hostConfig.NetworkMode.IsContainer() {
+		mode = "z"
+	}
 	if container.ResolvConfPath != "" {
-		label.SetFileLabel(container.ResolvConfPath, container.MountLabel)
+		label.Relabel(container.ResolvConfPath, container.MountLabel, mode)
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.ResolvConfPath,
 			Destination: "/etc/resolv.conf",
@@ -1171,7 +1175,7 @@ func (container *Container) networkMounts() []execdriver.Mount {
 		})
 	}
 	if container.HostnamePath != "" {
-		label.SetFileLabel(container.HostnamePath, container.MountLabel)
+		label.Relabel(container.HostnamePath, container.MountLabel, mode)
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.HostnamePath,
 			Destination: "/etc/hostname",
@@ -1180,7 +1184,7 @@ func (container *Container) networkMounts() []execdriver.Mount {
 		})
 	}
 	if container.HostsPath != "" {
-		label.SetFileLabel(container.HostsPath, container.MountLabel)
+		label.Relabel(container.HostsPath, container.MountLabel, mode)
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.HostsPath,
 			Destination: "/etc/hosts",


### PR DESCRIPTION
…ntainers

If I run two containers with the same network they share the same /etc/resolv.conf.
The current code changes the labels of the /etc/resolv.conf currently to the
private label which causes it to be unusable in the first container.

This patch changes the labels to a shared label if more then one container
will use the content.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
