### PR TITLE
Switch to using only the RPM command to determine the distro version.

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -140,7 +140,7 @@ do_install() {
 	fi
 	if [ -z "$lsb_dist" ] && [ -r /etc/fedora-release ]; then
 		lsb_dist='fedora'
-		dist_version="$(rpm -q --whatprovides redhat-release --queryformat "%{VERSION\n")"
+		dist_version="$(rpm -q --whatprovides redhat-release --queryformat "%{VERSION}\n")"
 	fi
 	if [ -z "$lsb_dist" ]; then
 		if [ -r /etc/centos-release ] || [ -r /etc/redhat-release ]; then

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -140,12 +140,12 @@ do_install() {
 	fi
 	if [ -z "$lsb_dist" ] && [ -r /etc/fedora-release ]; then
 		lsb_dist='fedora'
-		dist_version="$(rpm -qa \*-release | cut -d"-" -f3 | head -n1)"
+		dist_version="$(rpm -q --whatprovides redhat-release --queryformat "%{VERSION\n")"
 	fi
 	if [ -z "$lsb_dist" ]; then
 		if [ -r /etc/centos-release ] || [ -r /etc/redhat-release ]; then
 			lsb_dist='centos'
-			dist_version="$(rpm -qa \*-release | cut -d"-" -f3 | head -n1)"
+			dist_version="$(rpm -q --whatprovides redhat-release --queryformat "%{VERSION}\n")"
 		fi
 	fi
 	if [ -z "$lsb_dist" ] && [ -r /etc/os-release ]; then


### PR DESCRIPTION
This is a better fix for #14902 to use only the RPM command to return the distro version.

Tested on:
- RHEL7
- CentOS 7
- Fedora 22
- Oracle Linux 6
- Oracle Linux 7

Signed-off-by: Avi Miller avi.miller@oracle.com
