### PR TITLE
AppArmor Engine Policy complain-only & improve ruleset

### DIFF
--- a/contrib/apparmor/docker-engine
+++ b/contrib/apparmor/docker-engine
@@ -1,6 +1,6 @@
 @{DOCKER_GRAPH_PATH}=/var/lib/docker
 
-profile /usr/bin/docker (attach_disconnected) {
+profile /usr/bin/docker (attach_disconnected, complain) {
   # Prevent following links to these files during container setup.
   deny /etc/** mkl,
   deny /dev/** kl,
@@ -51,7 +51,7 @@ profile /usr/bin/docker (attach_disconnected) {
   change_profile -> docker-*,
   change_profile -> unconfined,
 
-  profile /bin/cat {
+  profile /bin/cat (complain) {
     /etc/ld.so.cache r,
     /lib/** r,
     /dev/null rw,
@@ -61,7 +61,7 @@ profile /usr/bin/docker (attach_disconnected) {
     # For reading in 'docker stats':
     /proc/[0-9]*/net/dev r,
   }
-  profile /bin/ps {
+  profile /bin/ps (complain) {
     /etc/ld.so.cache r,
     /etc/localtime r,
     /etc/passwd r,
@@ -89,11 +89,11 @@ profile /usr/bin/docker (attach_disconnected) {
     /proc/ r,
     /proc/tty/drivers r,
   }
-  profile /sbin/iptables {
+  profile /sbin/iptables (complain) {
     signal (receive) peer=/usr/bin/docker,
     capability net_admin,
   }
-  profile /sbin/auplink flags=(attach_disconnected) {
+  profile /sbin/auplink flags=(attach_disconnected, complain) {
     signal (receive) peer=/usr/bin/docker,
     capability sys_admin,
     capability dac_override,
@@ -112,7 +112,7 @@ profile /usr/bin/docker (attach_disconnected) {
     /proc/fs/aufs/** rw,
     /proc/[0-9]*/mounts rw,
   }
-  profile /sbin/modprobe /bin/kmod {
+  profile /sbin/modprobe /bin/kmod (complain) {
     signal (receive) peer=/usr/bin/docker,
     capability sys_module,
     /etc/ld.so.cache r,
@@ -126,7 +126,7 @@ profile /usr/bin/docker (attach_disconnected) {
     /etc/modprobe.d{/,/**} r,
   }
   # xz works via pipes, so we do not need access to the filesystem.
-  profile /usr/bin/xz {
+  profile /usr/bin/xz (complain) {
     signal (receive) peer=/usr/bin/docker,
     /etc/ld.so.cache r,
     /lib/** r,
@@ -134,7 +134,7 @@ profile /usr/bin/docker (attach_disconnected) {
     deny /proc/** rw,
     deny /sys/** rw,
   }
-  profile /sbin/xtables-multi (attach_disconnected) {
+  profile /sbin/xtables-multi (attach_disconnected, complain) {
     /etc/ld.so.cache r,
     /lib/** r,
     /sbin/xtables-multi rm,
@@ -144,7 +144,7 @@ profile /usr/bin/docker (attach_disconnected) {
     capability net_admin,
     network raw,
   }
-  profile /sbin/zfs (attach_disconnected) {
+  profile /sbin/zfs (attach_disconnected, complain) {
     file,
     capability,
   }

--- a/contrib/apparmor/docker-engine
+++ b/contrib/apparmor/docker-engine
@@ -21,51 +21,131 @@ profile /usr/bin/docker (attach_disconnected) {
   ipc rw,
   network,
   capability,
-  file,
+  owner /** rw,
+  /var/lib/docker/** rwl,
+
+  # For non-root client use:
+  /dev/urandom r,
+  /run/docker.sock rw,
+  /proc/** r,
+  /sys/kernel/mm/hugepages/ r,
+  /etc/localtime r,
 
   ptrace peer=@{profile_name},
+  ptrace (read) peer=docker-default,
+  deny ptrace (trace) peer=docker-default,
+  deny ptrace peer=/usr/bin/docker///bin/ps,
 
   /usr/bin/docker pix,
-  /sbin/xtables-multi rCix,
+  /sbin/xtables-multi rCx,
   /sbin/iptables rCx,
   /sbin/modprobe rCx,
   /sbin/auplink rCx,
+  /bin/kmod rCx,
   /usr/bin/xz rCx,
+  /bin/ps rCx,
+  /bin/cat rCx,
+  /sbin/zfs rCx,
 
   # Transitions
   change_profile -> docker-*,
   change_profile -> unconfined,
 
+  profile /bin/cat {
+    /etc/ld.so.cache r,
+    /lib/** r,
+    /dev/null rw,
+    /proc r,
+    /bin/cat mr,
+
+    # For reading in 'docker stats':
+    /proc/[0-9]*/net/dev r,
+  }
+  profile /bin/ps {
+    /etc/ld.so.cache r,
+    /etc/localtime r,
+    /etc/passwd r,
+    /etc/nsswitch.conf r,
+    /lib/** r,
+    /proc/[0-9]*/** r,
+    /dev/null rw,
+    /bin/ps mr,
+
+    # We don't need ptrace so we'll deny and ignore the error.
+    deny ptrace (read, trace),
+
+    # Quiet dac_override denials
+    deny capability dac_override,
+    deny capability dac_read_search,
+    deny capability sys_ptrace,
+
+    /dev/tty r,
+    /proc/stat r,
+    /proc/cpuinfo r,
+    /proc/meminfo r,
+    /proc/uptime r,
+    /sys/devices/system/cpu/online r,
+    /proc/sys/kernel/pid_max r,
+    /proc/ r,
+    /proc/tty/drivers r,
+  }
   profile /sbin/iptables {
-   signal (receive) peer=/usr/bin/docker,
-   capability net_admin,
+    signal (receive) peer=/usr/bin/docker,
+    capability net_admin,
   }
   profile /sbin/auplink flags=(attach_disconnected) {
-   signal (receive) peer=/usr/bin/docker,
-   capability sys_admin,
-   capability dac_override,
+    signal (receive) peer=/usr/bin/docker,
+    capability sys_admin,
+    capability dac_override,
 
-   @{DOCKER_GRAPH_PATH}/aufs/** rw,
-   # For user namespaces:
-   @{DOCKER_GRAPH_PATH}/[0-9]*.[0-9]*/** rw,
+    @{DOCKER_GRAPH_PATH}/aufs/** rw,
+    @{DOCKER_GRAPH_PATH}/tmp/** rw,
+    # For user namespaces:
+    @{DOCKER_GRAPH_PATH}/[0-9]*.[0-9]*/** rw,
 
-   # The following may be removed via delegates
-   /sys/fs/aufs/** r,
-   /lib/** r,
-   /apparmor/.null r,
-   /dev/null rw,
-   /etc/ld.so.cache r,
-   /sbin/auplink rm,
-   /proc/fs/aufs/** rw,
-   /proc/[0-9]*/mounts rw,
+    /sys/fs/aufs/** r,
+    /lib/** r,
+    /apparmor/.null r,
+    /dev/null rw,
+    /etc/ld.so.cache r,
+    /sbin/auplink rm,
+    /proc/fs/aufs/** rw,
+    /proc/[0-9]*/mounts rw,
   }
-  profile /sbin/modprobe {
-   signal (receive) peer=/usr/bin/docker,
-   capability sys_module,
-   file,
+  profile /sbin/modprobe /bin/kmod {
+    signal (receive) peer=/usr/bin/docker,
+    capability sys_module,
+    /etc/ld.so.cache r,
+    /lib/** r,
+    /dev/null rw,
+    /apparmor/.null rw,
+    /sbin/modprobe rm,
+    /bin/kmod rm,
+    /proc/cmdline r,
+    /sys/module/** r,
+    /etc/modprobe.d{/,/**} r,
   }
   # xz works via pipes, so we do not need access to the filesystem.
   profile /usr/bin/xz {
-   signal (receive) peer=/usr/bin/docker,
+    signal (receive) peer=/usr/bin/docker,
+    /etc/ld.so.cache r,
+    /lib/** r,
+    /usr/bin/xz rm,
+    deny /proc/** rw,
+    deny /sys/** rw,
+  }
+  profile /sbin/xtables-multi (attach_disconnected) {
+    /etc/ld.so.cache r,
+    /lib/** r,
+    /sbin/xtables-multi rm,
+    /apparmor/.null w,
+    /dev/null rw,
+    capability net_raw,
+    capability net_admin,
+    network raw,
+  }
+  profile /sbin/zfs (attach_disconnected) {
+    file,
+    capability,
   }
 }


### PR DESCRIPTION
To prevent breakages for users and to assess the
impact of the engine policy for users (especially those
on less common graph drivers), mark the policy as
complain-only until we are comfortable removing this
tag.

Implements the policies for the remaining binaries
called by the Docker engine and eliminates the
giant whitelisted 'all files' permission in favor
of granular whitelisting and child-specific policies.

Signed-off-by: Eric Windisch eric@windisch.us
