### PR TITLE
Fix broken link in automated build doc

### DIFF
--- a/docs/userguide/dockerrepos.md
+++ b/docs/userguide/dockerrepos.md
@@ -145,9 +145,7 @@ build and, in a few minutes, you should see your new Automated Build on the [Doc
 Registry. It will stay in sync with your GitHub and Bitbucket repository until you
 deactivate the Automated Build.
 
-If you want to see the status of your Automated Builds, you can go to your
-[Automated Builds page](https://registry.hub.docker.com/builds/) on the Docker Hub,
-and it will show you the status of your builds and their build history.
+To check the output and status of your Automated Build repositories, click on a repository name within the ["Your Repositories" page](https://registry.hub.docker.com/repos/). Automated Builds are indicated by a check-mark icon next to the repository name. Within the repository details page, you may click on the "Build Details" tab to view the status and output of all builds triggered by the Docker Hub.
 
 Once you've created an Automated Build you can deactivate or delete it. You
 cannot, however, push to an Automated Build with the `docker push` command.
@@ -175,4 +173,3 @@ webhooks](https://docs.docker.com/docker-hub/repos/#webhooks)
 ## Next steps
 
 Go and use Docker!
-


### PR DESCRIPTION
Trying to fix a broken link to https://registry.hub.docker.com/builds/ (404 error)

Required re-writing this a bit to direct users to where they can find this info currently.
