### PR TITLE
recongnizing elementary OS and pretending it is Ubuntu Trusty

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -120,6 +120,10 @@ do_install() {
 	if command_exists lsb_release; then
 		lsb_dist="$(lsb_release -si)"
 		dist_version="$(lsb_release --codename | cut -f2)"
+		if [ "$lsb_dist" = "elementary OS" ] && [ "$dist_version" = "freya" ]; then
+			lsb_dist='ubuntu'
+			dist_version='trusty'
+		fi
 	fi
 	if [ -z "$lsb_dist" ] && [ -r /etc/lsb-release ]; then
 		lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"


### PR DESCRIPTION
Elementary Freya is the latest release of Elementary OS: https://elementary.io/
It is based on Ubuntu 14.04 LTS, codename Trusty.

Tested it installs and works.
Works when running docker in sudo. Could not get it to work without sudo.
