### PR TITLE
Fix option validation for log-drivers without it

### DIFF
--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -115,5 +115,5 @@ func ValidateLogOpts(name string, cfg map[string]string) error {
 	if l != nil {
 		return l(cfg)
 	}
-	return fmt.Errorf("Log Opts are not valid for [%s] driver", name)
+	return nil
 }


### PR DESCRIPTION
There is no option validation for "journald" log-driver, so it makes no
sense to fail in that case.
Pro-hint: now journald isn't working in master :)
