### PR TITLE
Fix broken documentation links

### DIFF
--- a/experimental/README.md
+++ b/experimental/README.md
@@ -61,8 +61,8 @@ After downloading the appropriate binary, you can follow the instructions
 
 ## Current experimental features
 
-* [Support for Docker plugins](plugins.md)
-* [Volume plugins](plugins_volume.md)
+* [Support for Docker plugins](../docs/extend/plugins.md)
+* [Volume plugins](../docs/extend/plugins_volume.md)
 * [Network plugins](plugins_network.md)
 * [Native Multi-host networking](networking.md)
 * [Compose, Swarm and networking integration](compose_swarm_networking.md)


### PR DESCRIPTION
Note: I am using relative paths ... not sure if that's the way you handle this ;).
