### PR TITLE
reexec: Use in-memory binary /proc/self/exe on linux instead of os.Args[0]

### DIFF
--- a/pkg/reexec/command_linux.go
+++ b/pkg/reexec/command_linux.go
@@ -7,10 +7,16 @@ import (
 	"syscall"
 )
 
+// Self returns the path to the current process's binary.
+// Returns "/proc/self/exe".
+func Self() string {
+	return "/proc/self/exe"
+}
+
 // Command returns *exec.Cmd which have Path as current binary. Also it setting
 // SysProcAttr.Pdeathsig to SIGTERM.
-// For example if current binary is "docker" at "/usr/bin", then cmd.Path will
-// be set to "/usr/bin/docker".
+// This will use the in-memory version (/proc/self/exe) of the current binary,
+// it is thus safe to delete or replace the on-disk binary (os.Args[0]).
 func Command(args ...string) *exec.Cmd {
 	return &exec.Cmd{
 		Path: Self(),

--- a/pkg/reexec/command_windows.go
+++ b/pkg/reexec/command_windows.go
@@ -6,6 +6,12 @@ import (
 	"os/exec"
 )
 
+// Self returns the path to the current process's binary.
+// Uses os.Args[0].
+func Self() string {
+	return naiveSelf()
+}
+
 // Command returns *exec.Cmd which have Path as current binary.
 // For example if current binary is "docker.exe" at "C:\", then cmd.Path will
 // be set to "C:\docker.exe".

--- a/pkg/reexec/reexec.go
+++ b/pkg/reexec/reexec.go
@@ -30,8 +30,7 @@ func Init() bool {
 	return false
 }
 
-// Self returns the path to the current processes binary
-func Self() string {
+func naiveSelf() string {
 	name := os.Args[0]
 	if filepath.Base(name) == name {
 		if lp, err := exec.LookPath(name); err == nil {


### PR DESCRIPTION
This keeps reexec working properly even if the on-disk binary was replaced.

Signed-off-by: Tibor Vass tibor@docker.com

Consequently it allows you to test client-only binaries locally:

```
$ make shell
root@ad752426b4c3:/go/src/github.com/docker/docker# ./hack/make.sh binary; ./bundles/latest/binary/docker -d -D &> /tmp/docker.log & DOCKER_TEST_HOST=unix:///var/run/docker.sock DOCKER_CLIENTONLY=1 ./hack/make.sh binary test-integration-cli 
```
