### PR TITLE
Have network files mounted read-only when -v parameter has 'ro' passed

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -1128,28 +1128,40 @@ func (container *Container) networkMounts() []execdriver.Mount {
 	}
 	if container.ResolvConfPath != "" {
 		label.Relabel(container.ResolvConfPath, container.MountLabel, mode)
+		writable := !container.hostConfig.ReadonlyRootfs
+		if m, exists := container.MountPoints["/etc/resolv.conf"]; exists {
+			writable = m.RW
+		}
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.ResolvConfPath,
 			Destination: "/etc/resolv.conf",
-			Writable:    !container.hostConfig.ReadonlyRootfs,
+			Writable:    writable,
 			Private:     true,
 		})
 	}
 	if container.HostnamePath != "" {
 		label.Relabel(container.HostnamePath, container.MountLabel, mode)
+		writable := !container.hostConfig.ReadonlyRootfs
+		if m, exists := container.MountPoints["/etc/hostname"]; exists {
+			writable = m.RW
+		}
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.HostnamePath,
 			Destination: "/etc/hostname",
-			Writable:    !container.hostConfig.ReadonlyRootfs,
+			Writable:    writable,
 			Private:     true,
 		})
 	}
 	if container.HostsPath != "" {
 		label.Relabel(container.HostsPath, container.MountLabel, mode)
+		writable := !container.hostConfig.ReadonlyRootfs
+		if m, exists := container.MountPoints["/etc/hosts"]; exists {
+			writable = m.RW
+		}
 		mounts = append(mounts, execdriver.Mount{
 			Source:      container.HostsPath,
 			Destination: "/etc/hosts",
-			Writable:    !container.hostConfig.ReadonlyRootfs,
+			Writable:    writable,
 			Private:     true,
 		})
 	}

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -1326,3 +1326,15 @@ func appendBaseEnv(env []string) []string {
 	}
 	return env
 }
+
+func createTmpFile(c *check.C, content string) string {
+	f, err := ioutil.TempFile("", "testfile")
+	c.Assert(err, check.IsNil)
+
+	filename := f.Name()
+
+	err = ioutil.WriteFile(filename, []byte(content), 0644)
+	c.Assert(err, check.IsNil)
+
+	return filename
+}


### PR DESCRIPTION
Signed-off-by: Stefan Berger stefanb@us.ibm.com
