### PR TITLE
Windows: Fixes panic on daemon binary

### DIFF
--- a/daemon/config_windows.go
+++ b/daemon/config_windows.go
@@ -37,5 +37,5 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	config.InstallCommonFlags(cmd, usageFn)
 
 	// Then platform-specific install flags.
-	flag.StringVar(&config.Bridge.VirtualSwitchName, []string{"b", "-bridge"}, "", "Attach containers to a virtual switch")
+	cmd.StringVar(&config.Bridge.VirtualSwitchName, []string{"b", "-bridge"}, "", "Attach containers to a virtual switch")
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@tibor @duglin. the new daemon command broken the Windows binary when built with the daemon tag - panics as b is redefined. There was a small change missed in commit 96ce3a194aab2807fdd638825b9ea7cb9ba55c36
