### PR TITLE
Make daemon to start with no userlandproxy by default

### DIFF
--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -74,7 +74,7 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.Var(opts.NewIPOpt(&config.Bridge.DefaultGatewayIPv6, ""), []string{"-default-gateway-v6"}, usageFn("Container default gateway IPv6 address"))
 	cmd.BoolVar(&config.Bridge.InterContainerCommunication, []string{"#icc", "-icc"}, true, usageFn("Enable inter-container communication"))
 	cmd.Var(opts.NewIPOpt(&config.Bridge.DefaultIP, "0.0.0.0"), []string{"#ip", "-ip"}, usageFn("Default IP when binding container ports"))
-	cmd.BoolVar(&config.Bridge.EnableUserlandProxy, []string{"-userland-proxy"}, true, usageFn("Use userland proxy for loopback traffic"))
+	cmd.BoolVar(&config.Bridge.EnableUserlandProxy, []string{"-userland-proxy"}, false, usageFn("Use userland proxy for loopback traffic"))
 	cmd.BoolVar(&config.EnableCors, []string{"#api-enable-cors", "#-api-enable-cors"}, false, usageFn("Enable CORS headers in the remote API, this is deprecated by --api-cors-header"))
 	cmd.StringVar(&config.CorsHeaders, []string{"-api-cors-header"}, "", usageFn("Set CORS headers in the remote API"))
 

--- a/docs/articles/networking.md
+++ b/docs/articles/networking.md
@@ -471,7 +471,7 @@ editing this setting.
 > container. In such conflicting situation, Docker created iptables rules will
 > take precedence and route to the container.
 
-The `--userland-proxy` parameter, true by default, provides a userland
+The `--userland-proxy` parameter, false by default, provides a userland
 implementation for inter-container and outside-to-container communication. When
 disabled, Docker uses both an additional `MASQUERADE` iptable rule and the
 `net.ipv4.route_localnet` kernel parameter which allow the host machine to

--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -56,7 +56,7 @@ weight=1
       --tlscert="~/.docker/cert.pem"         Path to TLS certificate file
       --tlskey="~/.docker/key.pem"           Path to TLS key file
       --tlsverify=false                      Use TLS and verify the remote
-      --userland-proxy=true                  Use userland proxy for loopback traffic
+      --userland-proxy=false                  Use userland proxy for loopback traffic
 
 Options with [] may be specified multiple times.
 

--- a/hack/make/.integration-daemon-start
+++ b/hack/make/.integration-daemon-start
@@ -14,7 +14,7 @@ exec 41>&1 42>&2
 
 export DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
 export DOCKER_EXECDRIVER=${DOCKER_EXECDRIVER:-native}
-export DOCKER_USERLANDPROXY=${DOCKER_USERLANDPROXY:-true}
+export DOCKER_USERLANDPROXY=${DOCKER_USERLANDPROXY:-false}
 
 # example usage: DOCKER_STORAGE_OPTS="dm.basesize=20G,dm.loopdatasize=200G"
 storage_params=""

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -860,7 +860,6 @@ func (s *DockerDaemonSuite) TestDaemonIP(c *check.C) {
 	out, err := d.Cmd("run", "-d", "-p", "8000:8000", "busybox", "top")
 	c.Assert(err, check.NotNil,
 		check.Commentf("Running a container must fail with an invalid --ip option"))
-	c.Assert(strings.Contains(out, "Error starting userland proxy"), check.Equals, true)
 
 	ifName := "dummy"
 	out, err = createInterface(c, "dummy", ifName, ipStr)

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -69,7 +69,7 @@ func NewDaemon(c *check.C) *Daemon {
 		c.Fatalf("Could not create %s/graph directory", daemonFolder)
 	}
 
-	userlandProxy := true
+	userlandProxy := false
 	if env := os.Getenv("DOCKER_USERLANDPROXY"); env != "" {
 		if val, err := strconv.ParseBool(env); err != nil {
 			userlandProxy = val

--- a/man/docker.1.md
+++ b/man/docker.1.md
@@ -161,7 +161,7 @@ unix://[/path/to/socket] to use.
   Default is false.
 
 **--userland-proxy**=*true*|*false*
-    Rely on a userland proxy implementation for inter-container and outside-to-container loopback communications. Default is true.
+    Rely on a userland proxy implementation for inter-container and outside-to-container loopback communications. Default is false.
 
 **-v**, **--version**=*true*|*false*
   Print version information and quit. Default is false.


### PR DESCRIPTION
This PR makes a user visible behavior change with userland
proxy disabled by default and rely on hairpin NAT to be enabled
by default. This may not work in older (unsupported) kernels
where the user will be forced to enable userlandproxy if needed.

```
  - Updated the Docs
  - Changed the integration-cli to start with userlandproxy
desiabled by default.
```

Fixes #14856 

Signed-off-by: Jana Radhakrishnan mrjana@docker.com
