### PR TITLE
Revert "Introduce a dedicated unconfined AA policy"

### DIFF
--- a/contrib/apparmor/docker
+++ b/contrib/apparmor/docker
@@ -23,15 +23,3 @@ profile docker-default flags=(attach_disconnected,mediate_deleted) {
   deny /sys/firmware/efi/efivars/** rwklx,
   deny /sys/kernel/security/** rwklx,
 }
-
-profile docker-unconfined flags=(attach_disconnected,mediate_deleted) {
-  #include <abstractions/base>
-
-  network,
-  capability,
-  file,
-  umount,
-  mount,
-  pivot_root,
-  change_profile -> *,
-}

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -198,7 +198,7 @@ func (d *driver) setPrivileged(container *configs.Config) (err error) {
 	container.Devices = hostDevices
 
 	if apparmor.IsEnabled() {
-		container.AppArmorProfile = "docker-unconfined"
+		container.AppArmorProfile = "unconfined"
 	}
 
 	return nil


### PR DESCRIPTION
This reverts commit 87376c3add7dcd48830060652554e7ae43d11881.
`docker run --privileged` was broken by this commit.

Signed-off-by: David Calavera david.calavera@gmail.com
