### PR TITLE
skip checkOrigin during websocket handshake

### DIFF
--- a/api/server/container.go
+++ b/api/server/container.go
@@ -528,7 +528,8 @@ func (s *Server) wsContainersAttach(version version.Version, w http.ResponseWrit
 			logrus.Errorf("Error attaching websocket: %s", err)
 		}
 	})
-	h.ServeHTTP(w, r)
+	ws := websocket.Server{Handler: h, Handshake: nil}
+	ws.ServeHTTP(w, r)
 
 	return nil
 }


### PR DESCRIPTION
This commit allows a non-browser client to use the `/containers/.../attach/ws` remote api endpoint. It effectively disables the check for an `Origin` header during handshake as [described in the websocket library](https://github.com/golang/net/blob/master/websocket/server.go#L97). I'd be happy with this change landing in the upcoming Docker 1.8 release, but I'm open for suggestions on a better solution. Thanks!

Signed-off-by: Tobias Gesellchen tobias@gesellix.de

Closes #14742 
