### PR TITLE
Add missing documentation to cli/import.md

### DIFF
--- a/docs/reference/commandline/import.md
+++ b/docs/reference/commandline/import.md
@@ -11,7 +11,7 @@ weight=1
 
 # import
 
-    Usage: docker import URL|- [REPOSITORY[:TAG]]
+    Usage: docker import file|URL|- [REPOSITORY[:TAG]]
 
     Create an empty filesystem image and import the contents of the
 	tarball (.tar, .tar.gz, .tgz, .bzip, .tar.xz, .txz) into it, then
@@ -19,10 +19,13 @@ weight=1
 
       -c, --change=[]     Apply specified Dockerfile instructions while importing the image
 
-URLs must start with `http` and point to a single file archive (.tar,
-.tar.gz, .tgz, .bzip, .tar.xz, or .txz) containing a root filesystem. If
-you would like to import from a local directory or archive, you can use
-the `-` parameter to take the data from `STDIN`.
+You can specify a `URL` or `-` (dash) to take data directly from `STDIN`. The
+`URL` can point to an archive (.tar, .tar.gz, .tgz, .bzip, .tar.xz, or .txz)
+containing a fileystem or to an individual file on the Docker host.  If you
+specify an archive, Docker untars it in the container relative to the `/`
+(root). If you specify an individual file, you must specify the full path within
+the host. To import from a remote location, specify a `URI` that begins with the
+`http://` or `https://` protocol.
 
 The `--change` option will apply `Dockerfile` instructions to the image
 that is created.
@@ -42,6 +45,10 @@ This will create a new untagged image.
 Import to docker via pipe and `STDIN`.
 
     $ cat exampleimage.tgz | docker import - exampleimagelocal:new
+
+Import to docker from a local archive.
+
+    $ docker import /path/to/exampleimage.tgz
 
 **Import from a local directory:**
 


### PR DESCRIPTION
PR #11907 added support for import using file (path), but it missed
the update of cli/import.md. This fixes that.

/cc @thaJeztah @moxiegirl 

Signed-off-by: Vincent Demeester vincent@sbr.pm
