### PR TITLE
Add support for installing on Linux Mint

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -154,6 +154,14 @@ do_install() {
 	fi
 
 	lsb_dist="$(echo "$lsb_dist" | tr '[:upper:]' '[:lower:]')"
+
+	# treat Linux Mint as Ubuntu
+	if [ "$lsb_dist" = 'linuxmint' ]; then
+		lsb_dist='ubuntu'
+		. /etc/upstream-release/lsb-release
+		dist_version=$DISTRIB_CODENAME
+	fi
+
 	case "$lsb_dist" in
 		amzn)
 			(


### PR DESCRIPTION
Resolves error message about unsupported platform.

Linux Mint is a Linux distribution based on Ubuntu and Debian.
Starting with Mint 17 and continuing until 2016, every release of
Linux Mint will be built on Ubuntu 14.04 LTS.
