### PR TITLE
Adding support for elementary OS distro in install script.

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -51,6 +51,32 @@ echo_docker_as_nonroot() {
 	EOF
 }
 
+# Check if this is a forked Linux distro
+check_forked() {
+	# Check for lsb_release command existence, it usually exists in forked distros
+	if command_exists lsb_release; then
+		# Check if the `-u` option is supported
+		lsb_release -a -u > /dev/null 2>&1
+
+		# Check if the command has exited successfully, it means we're in a forked distro
+		if [ "$?" = "0" ]; then
+			# Print info about current distro
+			cat <<-EOF
+			You're using '$lsb_dist' version '$dist_version'.
+			EOF
+
+			# Get the upstream release info
+			lsb_dist=$(lsb_release -a -u 2>&1 | tr '[:upper:]' '[:lower:]' | grep -E 'id' | cut -d ':' -f 2 | tr -d '[[:space:]]')
+			dist_version=$(lsb_release -a -u 2>&1 | tr '[:upper:]' '[:lower:]' | grep -E 'codename' | cut -d ':' -f 2 | tr -d '[[:space:]]')
+
+			# Print info about upstream distro
+			cat <<-EOF
+			Upstream release is '$lsb_dist' version '$dist_version'.
+			EOF
+		fi
+	fi
+}
+
 do_install() {
 	case "$(uname -m)" in
 		*64)
@@ -187,8 +213,11 @@ do_install() {
 
 
 	esac
-		
 
+	# Check if this is a forked Linux distro
+	check_forked
+
+	# Run setup for each distro accordingly
 	case "$lsb_dist" in
 		amzn)
 			(


### PR DESCRIPTION
Adding support for elementary OS in the installer script.

The script will query the upstream release from the command `$ lsb_release -a -u`, so, it's now very easy to add support for more forked distros.

~~I don't know what are the side effects of checking the upstream release for all distros. For that reason, I've restricted this check to elementary OS, which I've been able to test.~~

I've tested this in elementary OS 0.3 (freya) and it's working just fine.

Credits to Daniel Foré and Cody Garver from elementary OS for [helping me out to achieve this](http://elementaryos.stackexchange.com/a/769).

**TL;DR:**
We've tested the command in some distros (based and non-based in Debian/Ubuntu) and have achieved a solution that should work across all distros. It'll check for the existince and success of the command `lsb_release -a -u` to then retrieve the upstream release info.
