### PR TITLE
Docker stats: display Block IO stats

### DIFF
--- a/api/client/stats_unit_test.go
+++ b/api/client/stats_unit_test.go
@@ -15,6 +15,8 @@ func TestDisplay(t *testing.T) {
 		MemoryPercentage: 100.0 / 2048.0 * 100.0,
 		NetworkRx:        100 * 1024 * 1024,
 		NetworkTx:        800 * 1024 * 1024,
+		BlockRead:        100 * 1024 * 1024,
+		BlockWrite:       800 * 1024 * 1024,
 		mu:               sync.RWMutex{},
 	}
 	var b bytes.Buffer
@@ -22,7 +24,7 @@ func TestDisplay(t *testing.T) {
 		t.Fatalf("c.Display() gave error: %s", err)
 	}
 	got := b.String()
-	want := "app\t30.00%\t104.9 MB / 2.147 GB\t4.88%\t104.9 MB / 838.9 MB\n"
+	want := "app\t30.00%\t104.9 MB / 2.147 GB\t4.88%\t104.9 MB / 838.9 MB\t104.9 MB / 838.9 MB\n"
 	if got != want {
 		t.Fatalf("c.Display() = %q, want %q", got, want)
 	}

--- a/docs/articles/runmetrics.md
+++ b/docs/articles/runmetrics.md
@@ -21,9 +21,9 @@ and network IO metrics.
 The following is a sample output from the `docker stats` command
 
     $ docker stats redis1 redis2
-    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O
-    redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B
-    redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B
+    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
+    redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
+    redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
 
 
 The [docker stats](/reference/commandline/stats/) reference page has

--- a/docs/reference/commandline/stats.md
+++ b/docs/reference/commandline/stats.md
@@ -21,9 +21,9 @@ weight=1
 Running `docker stats` on multiple containers
 
     $ docker stats redis1 redis2
-    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O
-    redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B
-    redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B
+    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
+    redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
+    redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B
 
 
 The `docker stats` command will only return a live stream of data for running

--- a/man/docker-stats.1.md
+++ b/man/docker-stats.1.md
@@ -25,6 +25,6 @@ Display a live stream of one or more containers' resource usage statistics
 Run **docker stats** with multiple containers.
 
     $ docker stats redis1 redis2
-    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O
-    redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B
-    redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B
+    CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
+    redis1              0.07%               796 KB / 64 MB        1.21%               788 B / 648 B       3.568 MB / 512 KB
+    redis2              0.07%               2.746 MB / 64 MB      4.29%               1.266 KB / 648 B    12.4 MB / 0 B


### PR DESCRIPTION
Fixes #14951

Now `docker stats` act like this:

```
$ docker stats cbb117535f3c
CONTAINER           CPU %               MEM USAGE/LIMIT     MEM %               NET I/O             BLOCK I/O
cbb117535f3c        0.00%               9.601 MB/3.7 GB     0.26%               220.3 kB/14.04 kB   8.86 MB/180.2 kB
```

Signed-off-by: Zhang Wei zhangwei555@huawei.com
