### PR TITLE
Remove waiting because another client is pulling repository

### DIFF
--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -72,18 +72,6 @@ func (p *v2Puller) pullV2Repository(tag string) (err error) {
 
 	}
 
-	c, err := p.poolAdd("pull", taggedName)
-	if err != nil {
-		if c != nil {
-			// Another pull of the same repository is already taking place; just wait for it to finish
-			p.sf.FormatStatus("", "Repository %s already being pulled by another client. Waiting.", p.repoInfo.CanonicalName)
-			<-c
-			return nil
-		}
-		return err
-	}
-	defer p.poolRemove("pull", taggedName)
-
 	var layersDownloaded bool
 	for _, tag := range tags {
 		// pulledNew is true if either new layers were downloaded OR if existing images were newly tagged


### PR DESCRIPTION
Instead wait as before, on layers being pulled by other clients, but only on the layers.

This PR is a minimal useful change. I view this PR as a canary in the coal mine.

I'm currently in the process of implementing (v2 only) pull cancellation using `x/net/context`, with techniques similar to those I used in #9774. [Progress can be seen over here on `pwaller/docker`](https://github.com/pwaller/docker/commits/pull-cancellation).

My intent is to have reference counting at the layer level, e.g, if you have two clients pulling images with layers `A`, `B` and `C`, images `I1=(A <- B)` and `I2=(A <- C)` and `I1` is cancelled, then only layer `B` is aborted and all others succeed. This seems like the only reasonable thing to do, as opposed to two independent `pull` commands interacting with each other.
### Rationale for this pull request

Implementing "pull" cancellation is made much more complicated if it has to track who-is-waiting-on-what at two granularities (layer AND repository). So this is a straightforward simplification.

Everything should still work as before except that clients now always report that individual layers are being pulled by other clients instead of the whole repository.

I'm interested to hear if anyone thinks this will break existing workflows sufficiently that we can't have this change.

It may break clients who expect to see exactly "`Repository %s already being pulled by another client. Waiting.`" when there are two pulls in flight, but this might be worthwhile anyway.

I've run the tests locally, but if they fail in the cloud, please ping me.

/xref #6928 

Signed-off-by: Peter Waller &lt;p@pwaller.net&gt;
