### PR TITLE
Api typed errors

### DIFF
--- a/api/server/error.go
+++ b/api/server/error.go
@@ -1,0 +1,10 @@
+package server
+
+type apiError struct {
+	error
+	respCode int
+}
+
+func newApiError(err error, status int) error {
+	return &apiError{err, status}
+}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -593,6 +593,11 @@ func (s *Server) getContainersStats(version version.Version, w http.ResponseWrit
 		closeNotifier = notifier.CloseNotify()
 	}
 
+	container, err := s.daemon.Get(vars["name"])
+	if err != nil {
+		return newApiError(err, http.StatusNotFound)
+	}
+
 	config := &daemon.ContainerStatsConfig{
 		Stream:    stream,
 		OutStream: out,

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -829,20 +829,12 @@ func (daemon *Daemon) Stats(c *Container) (*execdriver.ResourceStats, error) {
 	return daemon.execDriver.Stats(c.ID)
 }
 
-func (daemon *Daemon) SubscribeToContainerStats(name string) (chan interface{}, error) {
-	c, err := daemon.Get(name)
-	if err != nil {
-		return nil, err
-	}
+func (daemon *Daemon) SubscribeToContainerStats(c *Container) (chan interface{}, error) {
 	ch := daemon.statsCollector.collect(c)
 	return ch, nil
 }
 
-func (daemon *Daemon) UnsubscribeToContainerStats(name string, ch chan interface{}) error {
-	c, err := daemon.Get(name)
-	if err != nil {
-		return err
-	}
+func (daemon *Daemon) UnsubscribeToContainerStats(c *Container, ch chan interface{}) error {
 	daemon.statsCollector.unsubscribe(c, ch)
 	return nil
 }

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os/exec"
 	"runtime"
 	"strconv"
@@ -117,4 +118,12 @@ func getNetworkStats(c *check.C, id string) types.Network {
 	body.Close()
 
 	return st.Network
+}
+
+func (s *DockerSuite) TestStatsApiContainerNotExist(c *check.C) {
+	resp, _, err := sockRequestRaw("GET", "/containers/nosuchcontainer/stats", nil, "")
+	c.Assert(err, check.IsNil)
+	resp.Body.Close()
+
+	c.Assert(resp.StatusCode, check.Equals, http.StatusNotFound)
 }


### PR DESCRIPTION
Start using typed errors for API endpoints.
This makes sure that rep codes returned by the API are explicit rather than implied by the error string.

This is just the first one up for discussion, could probably knock out the rest (and get some tests for these!) if everyone pitches in pretty quickly.
