### PR TITLE
Change restarting Docker daemon command in CentOS

### DIFF
--- a/docs/articles/configuring.md
+++ b/docs/articles/configuring.md
@@ -215,7 +215,7 @@ with explanations.
 6. Restart the `docker` daemon.
 
     ```
-    $ sudo service docker restart
+    $ sudo systemctl restart docker
     ```
 
 7. Verify that the `docker` daemon is running as specified with the `ps` command.


### PR DESCRIPTION
Signed-off-by: bin liu liubin0329@gmail.com

I think it's better to use the CentOS/Fedora way to restart a service like other part mentioned in this document.

Thanks.
