### PR TITLE
Skip DockerSuite.TestExecResizeImmediatelyAfterExecStart on lxc

### DIFF
--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -23,6 +23,8 @@ func (s *DockerSuite) TestExecResizeApiHeightWidthNoInt(c *check.C) {
 
 // Part of #14845
 func (s *DockerSuite) TestExecResizeImmediatelyAfterExecStart(c *check.C) {
+	testRequires(c, NativeExecDriver)
+
 	name := "exec_resize_test"
 	dockerCmd(c, "run", "-d", "-i", "-t", "--name", name, "--restart", "always", "busybox", "/bin/sh")
 


### PR DESCRIPTION
Fixes https://github.com/docker/docker/issues/15054
