### PR TITLE
Docs: Copy edits for typos

### DIFF
--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -233,7 +233,7 @@ options for `zfs` start with `zfs`.
     >**Note**: This option configures devicemapper loopback, which should not be used in production.
 
     Specifies the size to use when creating the loopback file for the
-    "metadadata" device which is used for the thin pool. The default size
+    "metadata" device which is used for the thin pool. The default size
     is 2G. The file is sparse, so it will not initially take up
     this much space.
 

--- a/docs/reference/commandline/import.md
+++ b/docs/reference/commandline/import.md
@@ -21,7 +21,7 @@ weight=1
 
 You can specify a `URL` or `-` (dash) to take data directly from `STDIN`. The
 `URL` can point to an archive (.tar, .tar.gz, .tgz, .bzip, .tar.xz, or .txz)
-containing a fileystem or to an individual file on the Docker host.  If you
+containing a filesystem or to an individual file on the Docker host.  If you
 specify an archive, Docker untars it in the container relative to the `/`
 (root). If you specify an individual file, you must specify the full path within
 the host. To import from a remote location, specify a `URI` that begins with the

--- a/docs/reference/commandline/ps.md
+++ b/docs/reference/commandline/ps.md
@@ -77,7 +77,7 @@ Placeholder | Description
 `.Ports` | Exposed ports.
 `.Status` | Container status.
 `.Size` | Container disk size.
-`.Labels` | All labels asigned to the container.
+`.Labels` | All labels assigned to the container.
 `.Label` | Value of a specific label for this container. For example `{{.Label "com.docker.swarm.cpu"}}`
 
 When using the `--format` option, the `ps` command will either output the data exactly as the template


### PR DESCRIPTION
Only affects /docs directory.
Also, in `docs/reference/commandline/daemon.md` line 191 I think the reference to _thinp_ in `features, automatic thinp metadata checking when lvm activates the thin-pool, etc` should probably be _thinpool_ but wasn't certain from the context.
