### PR TITLE
Add link to Systemd article in Debian Jessie docs, fix typo

### DIFF
--- a/docs/installation/debian.md
+++ b/docs/installation/debian.md
@@ -39,9 +39,13 @@ To verify that everything has worked as expected:
 This command downloads and runs the `hello-world` image in a container. When the
 container runs, it prints an informational message. Then, it exits.
 
+If you need to add an HTTP Proxy, set a different directory or partition for the
+Docker runtime files, or make other customizations, read our Systemd article to
+learn how to [customize your Systemd Docker daemon options](/articles/systemd/).
+
 > **Note**:
 > If you want to enable memory and swap accounting see
-> [this](/installation/ubuntulinux/#memory-and-swap-accounting).
+> [this](/installation/ubuntulinux/#adjust-memory-and-swap-accounting).
 
 ### Uninstallation
 


### PR DESCRIPTION
Had a lot of trouble getting started on Jessie behind proxy. After a lot of searching came across the Systemd article. Copied the lines from the Fedora docs. 

Fixes typo in the existing link in Notes section.

Signed-off-by: Chander G chandergovind@gmail.com
