### PR TITLE
Fix login and search TLS configuration

### DIFF
--- a/registry/endpoint.go
+++ b/registry/endpoint.go
@@ -13,7 +13,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client/transport"
-	"github.com/docker/docker/pkg/tlsconfig"
 )
 
 // for mocking in unit tests
@@ -45,10 +44,11 @@ func scanForAPIVersion(address string) (string, APIVersion) {
 
 // NewEndpoint parses the given address to return a registry endpoint.
 func NewEndpoint(index *IndexInfo, metaHeaders http.Header) (*Endpoint, error) {
-	// *TODO: Allow per-registry configuration of endpoints.
-	tlsConfig := tlsconfig.ServerDefault
-	tlsConfig.InsecureSkipVerify = !index.Secure
-	endpoint, err := newEndpoint(index.GetAuthConfigKey(), &tlsConfig, metaHeaders)
+	tlsConfig, err := newTLSConfig(index.Name, index.Secure)
+	if err != nil {
+		return nil, err
+	}
+	endpoint, err := newEndpoint(index.GetAuthConfigKey(), tlsConfig, metaHeaders)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -49,6 +49,23 @@ func init() {
 	dockerUserAgent = useragent.AppendVersions("", httpVersion...)
 }
 
+func newTLSConfig(hostname string, isSecure bool) (*tls.Config, error) {
+	// PreferredServerCipherSuites should have no effect
+	tlsConfig := tlsconfig.ServerDefault
+
+	tlsConfig.InsecureSkipVerify = !isSecure
+
+	if isSecure {
+		hostDir := filepath.Join(CertsDir, hostname)
+		logrus.Debugf("hostDir: %s", hostDir)
+		if err := ReadCertsDirectory(&tlsConfig, hostDir); err != nil {
+			return nil, err
+		}
+	}
+
+	return &tlsConfig, nil
+}
+
 func hasFile(files []os.FileInfo, name string) bool {
 	for _, f := range files {
 		if f.Name() == name {

--- a/registry/service.go
+++ b/registry/service.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/tlsconfig"
@@ -99,22 +97,7 @@ func (e APIEndpoint) ToV1Endpoint(metaHeaders http.Header) (*Endpoint, error) {
 
 // TLSConfig constructs a client TLS configuration based on server defaults
 func (s *Service) TLSConfig(hostname string) (*tls.Config, error) {
-	// PreferredServerCipherSuites should have no effect
-	tlsConfig := tlsconfig.ServerDefault
-
-	isSecure := s.Config.isSecureIndex(hostname)
-
-	tlsConfig.InsecureSkipVerify = !isSecure
-
-	if isSecure {
-		hostDir := filepath.Join(CertsDir, hostname)
-		logrus.Debugf("hostDir: %s", hostDir)
-		if err := ReadCertsDirectory(&tlsConfig, hostDir); err != nil {
-			return nil, err
-		}
-	}
-
-	return &tlsConfig, nil
+	return newTLSConfig(hostname, s.Config.isSecureIndex(hostname))
 }
 
 func (s *Service) tlsConfigForMirror(mirror string) (*tls.Config, error) {


### PR DESCRIPTION
Currently login and search do not load per registry certificates.
This is a regression caused by the last refactor since this was recently fixed.

This was discovered and validated by the distribution integration tests which were recently fixed for 1.8. Testing these cases is difficult with the Docker cli integration tests is difficult due to the need for simulating different server TLS configurations.
https://github.com/docker/distribution/tree/master/contrib/docker-integration
