### PR TITLE
daemon.md: do fix placement of exec driver heading

### DIFF
--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -357,9 +357,6 @@ options for `zfs` start with `zfs`.
     > Otherwise, set this flag for migrating existing Docker daemons to
     > a daemon with a supported environment.
 
-
-## Docker execdriver option
-
 Currently supported options of `zfs`:
 
  * `zfs.fsname`


### PR DESCRIPTION
Options for zfs storage driver were incorrectly placed
under 'exec driver options' header. Move the header to
the correct place.

Now, this is the second time I am fixing this. First time
it was commit 68efb27, but the following commit 9af7afb
screwed it up again, so the header appears twice now.

Get rid of the the wrong one.

Cc: David Calavera david.calavera@gmail.com
Signed-off-by: Kir Kolyshkin kir@openvz.org
