### PR TITLE
Fix unshare test in distros that are not Ubuntu 14.04.

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2450,7 +2450,8 @@ func (s *DockerSuite) TestRunUnshareProc(c *check.C) {
 
 	/* Ensure still fails if running privileged with the default policy */
 	name = "crashoverride"
-	if out, _, err := dockerCmdWithError("run", "--privileged", "--security-opt", "apparmor:docker-default", "--name", name, "jess/unshare", "unshare", "-p", "-m", "-f", "-r", "mount", "-t", "proc", "none", "/proc"); err == nil || !strings.Contains(out, "Permission denied") {
+	out, _, err := dockerCmdWithError("run", "--privileged", "--security-opt", "apparmor:docker-default", "--name", name, "jess/unshare", "unshare", "-p", "-m", "-f", "-r", "mount", "-t", "proc", "none", "/proc")
+	if err == nil || !strings.Contains(out, "Permission denied") || !strings.Contains(out, "Operation not permitted") {
 		c.Fatalf("unshare should have failed with permission denied, got: %s, %v", out, err)
 	}
 }


### PR DESCRIPTION
Newer distros use "Operation not permitted" :(

/cc @jfrazelle

Signed-off-by: David Calavera david.calavera@gmail.com
