### PR TITLE
Fix broken link in README.md to point to the correct place in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Docker can be used to run short-lived commands, long-running daemons
 (app servers, databases, etc.), interactive shell sessions, etc.
 
 You can find a [list of real-world
-examples](https://docs.docker.com/examples/) in the
+examples](https://docs.docker.com/examples/mongodb/) in the
 documentation.
 
 Under the hood


### PR DESCRIPTION
- Update the broken "list of real-world examples" link to point to the proper place in the Applied Docker category under Use Docker section in the docs

Signed-off by: Artur Meyster meyster.artur@gmail.com
