### PR TITLE
Fix install failure on CentOS 7 with lsb_release

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -121,6 +121,7 @@ do_install() {
 		lsb_dist="$(lsb_release -si)"
 		dist_version="$(lsb_release --codename | cut -f2)"
 	fi
+	[ "$lsb_dist" = "CentOS" ] && unset lsb_dist # don't relay on lsb_release for CentOS
 	if [ -z "$lsb_dist" ] && [ -r /etc/lsb-release ]; then
 		lsb_dist="$(. /etc/lsb-release && echo "$DISTRIB_ID")"
 		dist_version="$(. /etc/lsb-release && echo "$DISTRIB_CODENAME")"


### PR DESCRIPTION
CentOS 7 has a codename of "Core", which makes
this install script fetch
`https://yum.dockerproject.org/repo/main/centos/Core/repodata/repomd.xml`
instead of
`https://yum.dockerproject.org/repo/main/centos/7/repodata/repomd.xml`

Details can be found in comments.

Signed-off-by: Penghan Wang ph.wang@daocloud.io
