### PR TITLE
Revert change to make ParseDevice unexported

### DIFF
--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -283,7 +283,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 	// parse device mappings
 	deviceMappings := []DeviceMapping{}
 	for _, device := range flDevices.GetAll() {
-		deviceMapping, err := parseDevice(device)
+		deviceMapping, err := ParseDevice(device)
 		if err != nil {
 			return nil, nil, cmd, err
 		}
@@ -487,7 +487,8 @@ func parseKeyValueOpts(opts opts.ListOpts) ([]KeyValuePair, error) {
 	return out, nil
 }
 
-func parseDevice(device string) (DeviceMapping, error) {
+// ParseDevice parses a device mapping string to a DeviceMapping struct
+func ParseDevice(device string) (DeviceMapping, error) {
 	src := ""
 	dst := ""
 	permissions := "rwm"


### PR DESCRIPTION
This reverts the change in 5170a2c096 that made ParseDevice unexported.  `golint` complained that this function should be documented or unexported.  I've added documentation.  I need this method to be public as I use it other projects such as libcompose to parse device mapping strings in the exact same fashion as Docker.

Signed-off-by: Darren Shepherd darren@rancher.com
