### PR TITLE
systemd: set service type to notify.

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -5,6 +5,7 @@ After=network.target docker.socket
 Requires=docker.socket
 
 [Service]
+Type=notify
 ExecStart=/usr/bin/docker daemon -H fd://
 MountFlags=slave
 LimitNOFILE=1048576


### PR DESCRIPTION
Currently the service type is 'simple', the default, meaning that
docker.service is considered to be started straight after
spawning. This is incorrect as there is significant amount of time
between spawning and docker ready to accept connections on the passed
sockets. Docker does implement systemd socket activate and
notification protocol, and send the ready signal to systemd, once it
is ready. However for systemd to take those notifications into
account, the service file type should be set to notify.

Signed-off-by: Dimitri John Ledkov dimitri.j.ledkov@intel.com
