### PR TITLE
Simplify dockerCmd

### DIFF
--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *DockerSuite) TestGetContainersAttachWebsocket(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-dit", "busybox", "cat")
+	out := dockerCmd(c, "run", "-dit", "busybox", "cat")
 
 	rwc, err := sockConn(time.Duration(10 * time.Second))
 	if err != nil {
@@ -97,7 +97,7 @@ func (s *DockerSuite) TestGetContainersWsAttachContainerNotFound(c *check.C) {
 }
 
 func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-dit", "busybox", "cat")
+	out := dockerCmd(c, "run", "-dit", "busybox", "cat")
 
 	r, w := io.Pipe()
 	defer r.Close()
@@ -160,7 +160,7 @@ func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
 }
 
 func (s *DockerSuite) TestPostContainersAttachStderr(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-dit", "busybox", "/bin/sh", "-c", "cat >&2")
+	out := dockerCmd(c, "run", "-dit", "busybox", "/bin/sh", "-c", "cat >&2")
 
 	r, w := io.Pipe()
 	defer r.Close()

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -306,7 +306,7 @@ func (s *DockerSuite) TestGetContainerStats(c *check.C) {
 }
 
 func (s *DockerSuite) TestGetContainerStatsRmRunning(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
 
 	buf := &channelBuffer{make(chan []byte, 1)}
@@ -463,7 +463,7 @@ func (s *DockerSuite) TestPostContainerBindNormalVolume(c *check.C) {
 
 func (s *DockerSuite) TestContainerApiPause(c *check.C) {
 	defer unpauseAllContainers()
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sleep", "30")
+	out := dockerCmd(c, "run", "-d", "busybox", "sleep", "30")
 	ContainerID := strings.TrimSpace(out)
 
 	status, _, err := sockRequest("POST", "/containers/"+ContainerID+"/pause", nil)
@@ -496,7 +496,7 @@ func (s *DockerSuite) TestContainerApiPause(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiTop(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "top")
 	id := strings.TrimSpace(string(out))
 	c.Assert(waitRun(id), check.IsNil)
 
@@ -648,7 +648,7 @@ func (s *DockerSuite) TestContainerApiCreate(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "start", "-a", container.ID)
+	out := dockerCmd(c, "start", "-a", container.ID)
 	if strings.TrimSpace(out) != "/test" {
 		c.Fatalf("expected output `/test`, got %q", out)
 	}
@@ -934,7 +934,7 @@ func (s *DockerSuite) TestCreateWithTooLowMemoryLimit(c *check.C) {
 }
 
 func (s *DockerSuite) TestStartWithTooLowMemoryLimit(c *check.C) {
-	out, _ := dockerCmd(c, "create", "busybox")
+	out := dockerCmd(c, "create", "busybox")
 
 	containerID := strings.TrimSpace(out)
 
@@ -955,7 +955,7 @@ func (s *DockerSuite) TestStartWithTooLowMemoryLimit(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiRename(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--name", "TestContainerApiRename", "-d", "busybox", "sh")
+	out := dockerCmd(c, "run", "--name", "TestContainerApiRename", "-d", "busybox", "sh")
 
 	containerID := strings.TrimSpace(out)
 	newName := "TestContainerApiRenameNew"
@@ -1002,7 +1002,7 @@ func (s *DockerSuite) TestContainerApiRestart(c *check.C) {
 
 func (s *DockerSuite) TestContainerApiRestartNotimeoutParam(c *check.C) {
 	name := "test-api-restart-no-timeout-param"
-	out, _ := dockerCmd(c, "run", "-di", "--name", name, "busybox", "top")
+	out := dockerCmd(c, "run", "-di", "--name", name, "busybox", "top")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
 
@@ -1146,7 +1146,7 @@ func (s *DockerSuite) TestContainerApiCopyContainerNotFound(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiDelete(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
@@ -1166,7 +1166,7 @@ func (s *DockerSuite) TestContainerApiDeleteNotExist(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiDeleteForce(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
@@ -1177,12 +1177,12 @@ func (s *DockerSuite) TestContainerApiDeleteForce(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiDeleteRemoveLinks(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "--name", "tlink1", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "--name", "tlink1", "busybox", "top")
 
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
 
-	out, _ = dockerCmd(c, "run", "--link", "tlink1:tlink1", "--name", "tlink2", "-d", "busybox", "top")
+	out = dockerCmd(c, "run", "--link", "tlink1:tlink1", "--name", "tlink2", "-d", "busybox", "top")
 
 	id2 := strings.TrimSpace(out)
 	c.Assert(waitRun(id2), check.IsNil)
@@ -1207,7 +1207,7 @@ func (s *DockerSuite) TestContainerApiDeleteRemoveLinks(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiDeleteConflict(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
@@ -1220,7 +1220,7 @@ func (s *DockerSuite) TestContainerApiDeleteConflict(c *check.C) {
 func (s *DockerSuite) TestContainerApiDeleteRemoveVolume(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
-	out, _ := dockerCmd(c, "run", "-d", "-v", "/testvolume", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "-v", "/testvolume", "busybox", "top")
 
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
@@ -1240,7 +1240,7 @@ func (s *DockerSuite) TestContainerApiDeleteRemoveVolume(c *check.C) {
 
 // Regression test for https://github.com/docker/docker/issues/6231
 func (s *DockerSuite) TestContainersApiChunkedEncoding(c *check.C) {
-	out, _ := dockerCmd(c, "create", "-v", "/foo", "busybox", "true")
+	out := dockerCmd(c, "create", "-v", "/foo", "busybox", "true")
 	id := strings.TrimSpace(out)
 
 	conn, err := sockConn(time.Duration(10 * time.Second))
@@ -1290,7 +1290,7 @@ func (s *DockerSuite) TestContainersApiChunkedEncoding(c *check.C) {
 }
 
 func (s *DockerSuite) TestPostContainerStop(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 
 	containerID := strings.TrimSpace(out)
 	c.Assert(waitRun(containerID), check.IsNil)
@@ -1314,7 +1314,7 @@ func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceEntrypoint(c *che
 	}{"busybox", "echo", []string{"hello", "world"}}
 	_, _, err := sockRequest("POST", "/containers/create?name=echotest", config)
 	c.Assert(err, check.IsNil)
-	out, _ := dockerCmd(c, "start", "-a", "echotest")
+	out := dockerCmd(c, "start", "-a", "echotest")
 	c.Assert(strings.TrimSpace(out), check.Equals, "hello world")
 
 	config2 := struct {
@@ -1324,7 +1324,7 @@ func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceEntrypoint(c *che
 	}{"busybox", []string{"echo"}, []string{"hello", "world"}}
 	_, _, err = sockRequest("POST", "/containers/create?name=echotest2", config2)
 	c.Assert(err, check.IsNil)
-	out, _ = dockerCmd(c, "start", "-a", "echotest2")
+	out = dockerCmd(c, "start", "-a", "echotest2")
 	c.Assert(strings.TrimSpace(out), check.Equals, "hello world")
 }
 
@@ -1337,7 +1337,7 @@ func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceCmd(c *check.C) {
 	}{"busybox", "echo", "hello world"}
 	_, _, err := sockRequest("POST", "/containers/create?name=echotest", config)
 	c.Assert(err, check.IsNil)
-	out, _ := dockerCmd(c, "start", "-a", "echotest")
+	out := dockerCmd(c, "start", "-a", "echotest")
 	c.Assert(strings.TrimSpace(out), check.Equals, "hello world")
 
 	config2 := struct {
@@ -1346,7 +1346,7 @@ func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceCmd(c *check.C) {
 	}{"busybox", []string{"echo", "hello", "world"}}
 	_, _, err = sockRequest("POST", "/containers/create?name=echotest2", config2)
 	c.Assert(err, check.IsNil)
-	out, _ = dockerCmd(c, "start", "-a", "echotest2")
+	out = dockerCmd(c, "start", "-a", "echotest2")
 	c.Assert(strings.TrimSpace(out), check.Equals, "hello world")
 }
 
@@ -1405,7 +1405,7 @@ func (s *DockerSuite) TestPostContainersStartWithLinksInHostConfig(c *check.C) {
 // #14640
 func (s *DockerSuite) TestPostContainersStartWithLinksInHostConfigIdLinked(c *check.C) {
 	name := "test-host-config-links"
-	out, _ := dockerCmd(c, "run", "--name", "link0", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "--name", "link0", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
 	dockerCmd(c, "create", "--name", name, "--link", id, "busybox", "top")
 

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *DockerSuite) TestExecResizeApiHeightWidthNoInt(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/exec/" + cleanedContainerID + "/resize?h=foo&w=bar"

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -70,7 +70,7 @@ func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 
 	defer loadBody.Close()
 
-	inspectOut, _ := dockerCmd(c, "inspect", "--format='{{ .Id }}'", id)
+	inspectOut := dockerCmd(c, "inspect", "--format='{{ .Id }}'", id)
 	if strings.TrimSpace(string(inspectOut)) != id {
 		c.Fatal("load did not work properly")
 	}

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *DockerSuite) TestInspectApiContainerResponse(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
+	out := dockerCmd(c, "run", "-d", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)
 	keysBase := []string{"Id", "State", "Created", "Path", "Args", "Config", "Image", "NetworkSettings",

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *DockerSuite) TestLogsApiWithStdout(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "-t", "busybox", "/bin/sh", "-c", "while true; do echo hello; sleep 1; done")
+	out := dockerCmd(c, "run", "-d", "-t", "busybox", "/bin/sh", "-c", "while true; do echo hello; sleep 1; done")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
 

--- a/integration-cli/docker_api_resize_test.go
+++ b/integration-cli/docker_api_resize_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *DockerSuite) TestResizeApiResponse(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=40&w=40"
@@ -18,7 +18,7 @@ func (s *DockerSuite) TestResizeApiResponse(c *check.C) {
 }
 
 func (s *DockerSuite) TestResizeApiHeightWidthNoInt(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	endpoint := "/containers/" + cleanedContainerID + "/resize?h=foo&w=bar"
@@ -28,7 +28,7 @@ func (s *DockerSuite) TestResizeApiHeightWidthNoInt(c *check.C) {
 }
 
 func (s *DockerSuite) TestResizeApiResponseWhenContainerNotStarted(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
+	out := dockerCmd(c, "run", "-d", "busybox", "true")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	// make sure the exited container is not running

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *DockerSuite) TestCliStatsNoStreamGetCpu(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true;do echo 'Hello'; usleep 100000; done")
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true;do echo 'Hello'; usleep 100000; done")
 
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
@@ -39,7 +39,7 @@ func (s *DockerSuite) TestCliStatsNoStreamGetCpu(c *check.C) {
 }
 
 func (s *DockerSuite) TestStoppedContainerStatsGoroutines(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo 1")
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo 1")
 	id := strings.TrimSpace(out)
 
 	getGoRoutines := func() int {
@@ -76,7 +76,7 @@ func (s *DockerSuite) TestStoppedContainerStatsGoroutines(c *check.C) {
 func (s *DockerSuite) TestApiNetworkStats(c *check.C) {
 	testRequires(c, SameHostDaemon)
 	// Run container for 30 secs
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
 

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -87,7 +87,7 @@ func (s *DockerSuite) TestAttachMultipleAndRestart(c *check.C) {
 }
 
 func (s *DockerSuite) TestAttachTtyWithoutStdin(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "-ti", "busybox")
+	out := dockerCmd(c, "run", "-d", "-ti", "busybox")
 
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
@@ -128,7 +128,7 @@ func (s *DockerSuite) TestAttachTtyWithoutStdin(c *check.C) {
 }
 
 func (s *DockerSuite) TestAttachDisconnect(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-di", "busybox", "/bin/cat")
+	out := dockerCmd(c, "run", "-di", "busybox", "/bin/cat")
 	id := strings.TrimSpace(out)
 
 	cmd := exec.Command(dockerBinary, "attach", id)

--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -16,7 +16,7 @@ import (
 // #9860
 func (s *DockerSuite) TestAttachClosedOnContainerStop(c *check.C) {
 
-	out, _ := dockerCmd(c, "run", "-dti", "busybox", "sleep", "2")
+	out := dockerCmd(c, "run", "-dti", "busybox", "sleep", "2")
 
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
@@ -131,7 +131,7 @@ func (s *DockerSuite) TestAttachAfterDetach(c *check.C) {
 
 // TestAttachDetach checks that attach in tty mode can be detached using the long container ID
 func (s *DockerSuite) TestAttachDetach(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-itd", "busybox", "cat")
+	out := dockerCmd(c, "run", "-itd", "busybox", "cat")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
 
@@ -201,7 +201,7 @@ func (s *DockerSuite) TestAttachDetach(c *check.C) {
 
 // TestAttachDetachTruncatedID checks that attach in tty mode can be detached
 func (s *DockerSuite) TestAttachDetachTruncatedID(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-itd", "busybox", "cat")
+	out := dockerCmd(c, "run", "-itd", "busybox", "cat")
 	id := stringid.TruncateID(strings.TrimSpace(out))
 	c.Assert(waitRun(id), check.IsNil)
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -76,7 +76,7 @@ func (s *DockerSuite) TestBuildShCmdJSONEntrypoint(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "--rm", name)
+	out := dockerCmd(c, "run", "--rm", name)
 
 	if strings.TrimSpace(out) != "/bin/sh -c echo test" {
 		c.Fatalf("CMD did not contain /bin/sh -c : %s", out)
@@ -415,7 +415,7 @@ func (s *DockerSuite) TestBuildEnvEscapes(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "-t", name)
+	out := dockerCmd(c, "run", "-t", name)
 
 	if strings.TrimSpace(out) != "$" {
 		c.Fatalf("Env TEST was not overwritten with bar when foo was supplied to dockerfile: was %q", strings.TrimSpace(out))
@@ -438,7 +438,7 @@ func (s *DockerSuite) TestBuildEnvOverwrite(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "-e", "TEST=bar", "-t", name)
+	out := dockerCmd(c, "run", "-e", "TEST=bar", "-t", name)
 
 	if strings.TrimSpace(out) != "bar" {
 		c.Fatalf("Env TEST was not overwritten with bar when foo was supplied to dockerfile: was %q", strings.TrimSpace(out))
@@ -449,7 +449,7 @@ func (s *DockerSuite) TestBuildEnvOverwrite(c *check.C) {
 func (s *DockerSuite) TestBuildOnBuildForbiddenMaintainerInSourceImage(c *check.C) {
 	name := "testbuildonbuildforbiddenmaintainerinsourceimage"
 
-	out, _ := dockerCmd(c, "create", "busybox", "true")
+	out := dockerCmd(c, "create", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -471,7 +471,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenMaintainerInSourceImage(c *check.
 func (s *DockerSuite) TestBuildOnBuildForbiddenFromInSourceImage(c *check.C) {
 	name := "testbuildonbuildforbiddenfrominsourceimage"
 
-	out, _ := dockerCmd(c, "create", "busybox", "true")
+	out := dockerCmd(c, "create", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -493,7 +493,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenFromInSourceImage(c *check.C) {
 func (s *DockerSuite) TestBuildOnBuildForbiddenChainedInSourceImage(c *check.C) {
 	name := "testbuildonbuildforbiddenchainedinsourceimage"
 
-	out, _ := dockerCmd(c, "create", "busybox", "true")
+	out := dockerCmd(c, "create", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -533,7 +533,7 @@ ONBUILD RUN ["true"]`,
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "-t", name2)
+	out := dockerCmd(c, "run", "-t", name2)
 
 	if !regexp.MustCompile(`(?m)^hello world`).MatchString(out) {
 		c.Fatal("did not get echo output from onbuild", out)
@@ -560,7 +560,7 @@ ONBUILD ENTRYPOINT ["echo"]`,
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "-t", name2)
+	out := dockerCmd(c, "run", "-t", name2)
 
 	if !regexp.MustCompile(`(?m)^hello world`).MatchString(out) {
 		c.Fatal("got malformed output from onbuild", out)
@@ -2999,7 +2999,7 @@ func (s *DockerSuite) TestBuildNoContext(c *check.C) {
 		c.Fatalf("build failed to complete: %v %v", out, err)
 	}
 
-	if out, _ := dockerCmd(c, "run", "--rm", "nocontext"); out != "ok\n" {
+	if out := dockerCmd(c, "run", "--rm", "nocontext"); out != "ok\n" {
 		c.Fatalf("run produced invalid output: %q, expected %q", out, "ok")
 	}
 }
@@ -3053,7 +3053,7 @@ func (s *DockerSuite) TestBuildWithVolumeOwnership(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "--rm", "testbuildimg", "ls", "-la", "/test")
+	out := dockerCmd(c, "run", "--rm", "testbuildimg", "ls", "-la", "/test")
 
 	if expected := "drw-------"; !strings.Contains(out, expected) {
 		c.Fatalf("expected %s received %s", expected, out)
@@ -3327,7 +3327,7 @@ func (s *DockerSuite) TestBuildVerifyIntString(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "inspect", name)
+	out := dockerCmd(c, "inspect", name)
 
 	if !strings.Contains(out, "\"123\"") {
 		c.Fatalf("Output does not contain the int as a string:\n%s", out)
@@ -4404,7 +4404,7 @@ func (s *DockerSuite) TestBuildEntrypointInheritanceInspect(c *check.C) {
 		c.Fatalf("Expected value %s not in Config.Entrypoint: %s", expected, res)
 	}
 
-	out, _ := dockerCmd(c, "run", "-t", name2)
+	out := dockerCmd(c, "run", "-t", name2)
 
 	expected = "quux"
 
@@ -4734,7 +4734,7 @@ CMD cat /foo/file`,
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "--rm", name)
+	out := dockerCmd(c, "run", "--rm", name)
 	if out != expected {
 		c.Fatalf("expected file contents for /foo/file to be %q but received %q", expected, out)
 	}
@@ -5393,14 +5393,10 @@ func (s *DockerTrustSuite) TestTrustedBuild(c *check.C) {
 	}
 
 	// We should also have a tag reference for the image.
-	if out, exitCode := dockerCmd(c, "inspect", repoName); exitCode != 0 {
-		c.Fatalf("unexpected exit code inspecting image %q: %d: %s", repoName, exitCode, out)
-	}
+	dockerCmd(c, "inspect", repoName)
 
 	// We should now be able to remove the tag reference.
-	if out, exitCode := dockerCmd(c, "rmi", repoName); exitCode != 0 {
-		c.Fatalf("unexpected exit code inspecting image %q: %d: %s", repoName, exitCode, out)
-	}
+	dockerCmd(c, "rmi", repoName)
 }
 
 func (s *DockerTrustSuite) TestTrustedBuildUntrustedTag(c *check.C) {
@@ -5457,9 +5453,7 @@ func (s *DockerTrustSuite) TestBuildContextDirIsSymlink(c *check.C) {
 
 	// Executing the build with the symlink as the specified context should
 	// *not* fail.
-	if out, exitStatus := dockerCmd(c, "build", contextSymlinkName); exitStatus != 0 {
-		c.Fatalf("build failed with exit status %d: %s", exitStatus, out)
-	}
+	dockerCmd(c, "build", contextSymlinkName)
 }
 
 // Issue #15634: COPY fails when path starts with "null"

--- a/integration-cli/docker_cli_build_unix_test.go
+++ b/integration-cli/docker_cli_build_unix_test.go
@@ -24,7 +24,7 @@ func (s *DockerSuite) TestBuildResourceConstraintsAreUsed(c *check.C) {
 
 	dockerCmdInDir(c, ctx.Dir, "build", "--no-cache", "--rm=false", "--memory=64m", "--memory-swap=-1", "--cpuset-cpus=0", "--cpuset-mems=0", "--cpu-shares=100", "--cpu-quota=8000", "--ulimit", "nofile=42", "-t", name, ".")
 
-	out, _ := dockerCmd(c, "ps", "-lq")
+	out := dockerCmd(c, "ps", "-lq")
 
 	cID := strings.TrimSpace(out)
 

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -66,7 +66,7 @@ func (s *DockerRegistrySuite) TestPullByTagDisplaysDigest(c *check.C) {
 	}
 
 	// pull from the registry using the tag
-	out, _ := dockerCmd(c, "pull", repoName)
+	out := dockerCmd(c, "pull", repoName)
 
 	// the pull output includes "Digest: <digest>", so find that
 	matches := digestRegex.FindStringSubmatch(out)
@@ -89,7 +89,7 @@ func (s *DockerRegistrySuite) TestPullByDigest(c *check.C) {
 
 	// pull from the registry using the <name>@<digest> reference
 	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
-	out, _ := dockerCmd(c, "pull", imageReference)
+	out := dockerCmd(c, "pull", imageReference)
 
 	// the pull output includes "Digest: <digest>", so find that
 	matches := digestRegex.FindStringSubmatch(out)
@@ -122,7 +122,7 @@ func (s *DockerRegistrySuite) TestCreateByDigest(c *check.C) {
 	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
 
 	containerName := "createByDigest"
-	out, _ := dockerCmd(c, "create", "--name", containerName, imageReference)
+	out := dockerCmd(c, "create", "--name", containerName, imageReference)
 
 	res, err := inspectField(containerName, "Config.Image")
 	if err != nil {
@@ -142,7 +142,7 @@ func (s *DockerRegistrySuite) TestRunByDigest(c *check.C) {
 	imageReference := fmt.Sprintf("%s@%s", repoName, pushDigest)
 
 	containerName := "runByDigest"
-	out, _ := dockerCmd(c, "run", "--name", containerName, imageReference, "sh", "-c", "echo found=$digest")
+	out := dockerCmd(c, "run", "--name", containerName, imageReference, "sh", "-c", "echo found=$digest")
 
 	foundRegex := regexp.MustCompile("found=([^\n]+)")
 	matches := foundRegex.FindStringSubmatch(out)
@@ -270,7 +270,7 @@ func (s *DockerRegistrySuite) TestListImagesWithoutDigests(c *check.C) {
 	// pull from the registry using the <name>@<digest> reference
 	dockerCmd(c, "pull", imageReference)
 
-	out, _ := dockerCmd(c, "images")
+	out := dockerCmd(c, "images")
 
 	if strings.Contains(out, "DIGEST") {
 		c.Fatalf("list output should not have contained DIGEST header: %s", out)
@@ -292,7 +292,7 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	dockerCmd(c, "pull", imageReference1)
 
 	// list images
-	out, _ := dockerCmd(c, "images", "--digests")
+	out := dockerCmd(c, "images", "--digests")
 
 	// make sure repo shown, tag=<none>, digest = $digest1
 	re1 := regexp.MustCompile(`\s*` + repoName + `\s*<none>\s*` + digest1.String() + `\s`)
@@ -315,7 +315,7 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	dockerCmd(c, "pull", imageReference2)
 
 	// list images
-	out, _ = dockerCmd(c, "images", "--digests")
+	out = dockerCmd(c, "images", "--digests")
 
 	// make sure repo shown, tag=<none>, digest = $digest1
 	if !re1.MatchString(out) {
@@ -332,7 +332,7 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	dockerCmd(c, "pull", repoName+":tag1")
 
 	// list images
-	out, _ = dockerCmd(c, "images", "--digests")
+	out = dockerCmd(c, "images", "--digests")
 
 	// make sure image 1 has repo, tag, <none> AND repo, <none>, digest
 	reWithTag1 := regexp.MustCompile(`\s*` + repoName + `\s*tag1\s*<none>\s`)
@@ -352,7 +352,7 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	dockerCmd(c, "pull", repoName+":tag2")
 
 	// list images
-	out, _ = dockerCmd(c, "images", "--digests")
+	out = dockerCmd(c, "images", "--digests")
 
 	// make sure image 1 has repo, tag, digest
 	if !reWithTag1.MatchString(out) {
@@ -370,7 +370,7 @@ func (s *DockerRegistrySuite) TestListImagesWithDigests(c *check.C) {
 	}
 
 	// list images
-	out, _ = dockerCmd(c, "images", "--digests")
+	out = dockerCmd(c, "images", "--digests")
 
 	// make sure image 1 has repo, tag, digest
 	if !reWithTag1.MatchString(out) {
@@ -404,23 +404,23 @@ func (s *DockerRegistrySuite) TestPsListContainersFilterAncestorImageByDigest(c 
 	c.Assert(err, check.IsNil)
 
 	// run a container based on that
-	out, _ := dockerCmd(c, "run", "-d", imageReference, "echo", "hello")
+	out := dockerCmd(c, "run", "-d", imageReference, "echo", "hello")
 	expectedID := strings.TrimSpace(out)
 
 	// run a container based on the a descendant of that too
-	out, _ = dockerCmd(c, "run", "-d", imageName1, "echo", "hello")
+	out = dockerCmd(c, "run", "-d", imageName1, "echo", "hello")
 	expectedID1 := strings.TrimSpace(out)
 
 	expectedIDs := []string{expectedID, expectedID1}
 
 	// Invalid imageReference
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", fmt.Sprintf("--filter=ancestor=busybox@%s", digest))
+	out = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", fmt.Sprintf("--filter=ancestor=busybox@%s", digest))
 	if strings.TrimSpace(out) != "" {
 		c.Fatalf("Expected filter container for %s ancestor filter to be empty, got %v", fmt.Sprintf("busybox@%s", digest), strings.TrimSpace(out))
 	}
 
 	// Valid imageReference
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=ancestor="+imageReference)
+	out = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=ancestor="+imageReference)
 	checkPsAncestorFilterOutput(c, out, imageReference, expectedIDs)
 }
 

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 func (s *DockerSuite) TestCommitAfterContainerIsDone(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
+	out := dockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
 	dockerCmd(c, "wait", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "commit", cleanedContainerID)
+	out = dockerCmd(c, "commit", cleanedContainerID)
 
 	cleanedImageID := strings.TrimSpace(out)
 
@@ -21,13 +21,13 @@ func (s *DockerSuite) TestCommitAfterContainerIsDone(c *check.C) {
 }
 
 func (s *DockerSuite) TestCommitWithoutPause(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
+	out := dockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
 	dockerCmd(c, "wait", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "commit", "-p=false", cleanedContainerID)
+	out = dockerCmd(c, "commit", "-p=false", cleanedContainerID)
 
 	cleanedImageID := strings.TrimSpace(out)
 
@@ -37,13 +37,13 @@ func (s *DockerSuite) TestCommitWithoutPause(c *check.C) {
 //test commit a paused container should not unpause it after commit
 func (s *DockerSuite) TestCommitPausedContainer(c *check.C) {
 	defer unpauseAllContainers()
-	out, _ := dockerCmd(c, "run", "-i", "-d", "busybox")
+	out := dockerCmd(c, "run", "-i", "-d", "busybox")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
 	dockerCmd(c, "pause", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "commit", cleanedContainerID)
+	out = dockerCmd(c, "commit", cleanedContainerID)
 
 	out, err := inspectField(cleanedContainerID, "State.Paused")
 	c.Assert(err, check.IsNil)
@@ -56,10 +56,10 @@ func (s *DockerSuite) TestCommitNewFile(c *check.C) {
 
 	dockerCmd(c, "run", "--name", "commiter", "busybox", "/bin/sh", "-c", "echo koye > /foo")
 
-	imageID, _ := dockerCmd(c, "commit", "commiter")
+	imageID := dockerCmd(c, "commit", "commiter")
 	imageID = strings.Trim(imageID, "\r\n")
 
-	out, _ := dockerCmd(c, "run", imageID, "cat", "/foo")
+	out := dockerCmd(c, "run", imageID, "cat", "/foo")
 
 	if actual := strings.Trim(out, "\r\n"); actual != "koye" {
 		c.Fatalf("expected output koye received %q", actual)
@@ -69,7 +69,7 @@ func (s *DockerSuite) TestCommitNewFile(c *check.C) {
 
 func (s *DockerSuite) TestCommitHardlink(c *check.C) {
 
-	firstOutput, _ := dockerCmd(c, "run", "-t", "--name", "hardlinks", "busybox", "sh", "-c", "touch file1 && ln file1 file2 && ls -di file1 file2")
+	firstOutput := dockerCmd(c, "run", "-t", "--name", "hardlinks", "busybox", "sh", "-c", "touch file1 && ln file1 file2 && ls -di file1 file2")
 
 	chunks := strings.Split(strings.TrimSpace(firstOutput), " ")
 	inode := chunks[0]
@@ -84,10 +84,10 @@ func (s *DockerSuite) TestCommitHardlink(c *check.C) {
 		c.Fatalf("Failed to create hardlink in a container. Expected to find %q in %q", inode, chunks[1:])
 	}
 
-	imageID, _ := dockerCmd(c, "commit", "hardlinks", "hardlinks")
+	imageID := dockerCmd(c, "commit", "hardlinks", "hardlinks")
 	imageID = strings.Trim(imageID, "\r\n")
 
-	secondOutput, _ := dockerCmd(c, "run", "-t", "hardlinks", "ls", "-di", "file1", "file2")
+	secondOutput := dockerCmd(c, "run", "-t", "hardlinks", "ls", "-di", "file1", "file2")
 
 	chunks = strings.Split(strings.TrimSpace(secondOutput), " ")
 	inode = chunks[0]
@@ -108,7 +108,7 @@ func (s *DockerSuite) TestCommitTTY(c *check.C) {
 
 	dockerCmd(c, "run", "-t", "--name", "tty", "busybox", "/bin/ls")
 
-	imageID, _ := dockerCmd(c, "commit", "tty", "ttytest")
+	imageID := dockerCmd(c, "commit", "tty", "ttytest")
 	imageID = strings.Trim(imageID, "\r\n")
 
 	dockerCmd(c, "run", "ttytest", "/bin/ls")
@@ -119,7 +119,7 @@ func (s *DockerSuite) TestCommitWithHostBindMount(c *check.C) {
 
 	dockerCmd(c, "run", "--name", "bind-commit", "-v", "/dev/null:/winning", "busybox", "true")
 
-	imageID, _ := dockerCmd(c, "commit", "bind-commit", "bindtest")
+	imageID := dockerCmd(c, "commit", "bind-commit", "bindtest")
 	imageID = strings.Trim(imageID, "\r\n")
 
 	dockerCmd(c, "run", "bindtest", "true")
@@ -130,7 +130,7 @@ func (s *DockerSuite) TestCommitChange(c *check.C) {
 
 	dockerCmd(c, "run", "--name", "test", "busybox", "true")
 
-	imageID, _ := dockerCmd(c, "commit",
+	imageID := dockerCmd(c, "commit",
 		"--change", "EXPOSE 8080",
 		"--change", "ENV DEBUG true",
 		"--change", "ENV test 1",
@@ -170,12 +170,12 @@ func (s *DockerSuite) TestCommitChange(c *check.C) {
 // TODO: commit --run is deprecated, remove this once --run is removed
 func (s *DockerSuite) TestCommitMergeConfigRun(c *check.C) {
 	name := "commit-test"
-	out, _ := dockerCmd(c, "run", "-d", "-e=FOO=bar", "busybox", "/bin/sh", "-c", "echo testing > /tmp/foo")
+	out := dockerCmd(c, "run", "-d", "-e=FOO=bar", "busybox", "/bin/sh", "-c", "echo testing > /tmp/foo")
 	id := strings.TrimSpace(out)
 
 	dockerCmd(c, "commit", `--run={"Cmd": ["cat", "/tmp/foo"]}`, id, "commit-test")
 
-	out, _ = dockerCmd(c, "run", "--name", name, "commit-test")
+	out = dockerCmd(c, "run", "--name", name, "commit-test")
 	if strings.TrimSpace(out) != "testing" {
 		c.Fatal("run config in committed container was not merged")
 	}

--- a/integration-cli/docker_cli_config_test.go
+++ b/integration-cli/docker_cli_config_test.go
@@ -72,16 +72,12 @@ func (s *DockerSuite) TestConfigDir(c *check.C) {
 	defer os.RemoveAll(cDir)
 
 	// First make sure pointing to empty dir doesn't generate an error
-	out, rc := dockerCmd(c, "--config", cDir, "ps")
-
-	if rc != 0 {
-		c.Fatalf("ps1 didn't work:\nrc:%d\nout%s", rc, out)
-	}
+	out := dockerCmd(c, "--config", cDir, "ps")
 
 	// Test with env var too
 	cmd := exec.Command(dockerBinary, "ps")
 	cmd.Env = append(os.Environ(), "DOCKER_CONFIG="+cDir)
-	out, rc, err = runCommandWithOutput(cmd)
+	out, rc, err := runCommandWithOutput(cmd)
 
 	if rc != 0 || err != nil {
 		c.Fatalf("ps2 didn't work:\nrc:%d\nout%s\nerr:%v", rc, out, err)

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -38,14 +38,11 @@ func (s *DockerSuite) TestCpLocalOnly(c *check.C) {
 // Test for #5656
 // Check that garbage paths don't escape the container's rootfs
 func (s *DockerSuite) TestCpGarbagePath(c *check.C) {
-	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
-	if exitCode != 0 {
-		c.Fatal("failed to create a container", out)
-	}
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", cleanedContainerID)
+	out = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -95,14 +92,11 @@ func (s *DockerSuite) TestCpGarbagePath(c *check.C) {
 
 // Check that relative paths are relative to the container's rootfs
 func (s *DockerSuite) TestCpRelativePath(c *check.C) {
-	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
-	if exitCode != 0 {
-		c.Fatal("failed to create a container", out)
-	}
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", cleanedContainerID)
+	out = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -160,14 +154,11 @@ func (s *DockerSuite) TestCpRelativePath(c *check.C) {
 
 // Check that absolute paths are relative to the container's rootfs
 func (s *DockerSuite) TestCpAbsolutePath(c *check.C) {
-	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
-	if exitCode != 0 {
-		c.Fatal("failed to create a container", out)
-	}
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", cleanedContainerID)
+	out = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -219,14 +210,11 @@ func (s *DockerSuite) TestCpAbsolutePath(c *check.C) {
 // Test for #5619
 // Check that absolute symlinks are still relative to the container's rootfs
 func (s *DockerSuite) TestCpAbsoluteSymlink(c *check.C) {
-	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpFullPath+" container_path")
-	if exitCode != 0 {
-		c.Fatal("failed to create a container", out)
-	}
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpFullPath+" container_path")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", cleanedContainerID)
+	out = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -271,14 +259,11 @@ func (s *DockerSuite) TestCpAbsoluteSymlink(c *check.C) {
 // Check that symlinks to a directory behave as expected when copying one from
 // a container.
 func (s *DockerSuite) TestCpFromSymlinkToDirectory(c *check.C) {
-	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpTestPathParent+" /dir_link")
-	if exitCode != 0 {
-		c.Fatal("failed to create a container", out)
-	}
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpTestPathParent+" /dir_link")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", cleanedContainerID)
+	out = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -340,10 +325,7 @@ func (s *DockerSuite) TestCpToSymlinkToDirectory(c *check.C) {
 
 	// Create a test container with a local volume. We will test by copying
 	// to the volume path in the container which we can then verify locally.
-	out, exitCode := dockerCmd(c, "create", "-v", testVol+":/testVol", "busybox")
-	if exitCode != 0 {
-		c.Fatal("failed to create a container", out)
-	}
+	out := dockerCmd(c, "create", "-v", testVol+":/testVol", "busybox")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -434,14 +416,11 @@ func (s *DockerSuite) TestCpToSymlinkToDirectory(c *check.C) {
 // Test for #5619
 // Check that symlinks which are part of the resource path are still relative to the container's rootfs
 func (s *DockerSuite) TestCpSymlinkComponent(c *check.C) {
-	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpTestPath+" container_path")
-	if exitCode != 0 {
-		c.Fatal("failed to create a container", out)
-	}
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpTestPath+" container_path")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", cleanedContainerID)
+	out = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -494,14 +473,11 @@ func (s *DockerSuite) TestCpSymlinkComponent(c *check.C) {
 func (s *DockerSuite) TestCpUnprivilegedUser(c *check.C) {
 	testRequires(c, UnixCli) // uses chmod/su: not available on windows
 
-	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "touch "+cpTestName)
-	if exitCode != 0 {
-		c.Fatal("failed to create a container", out)
-	}
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "touch "+cpTestName)
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", cleanedContainerID)
+	out = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -535,14 +511,11 @@ func (s *DockerSuite) TestCpSpecialFiles(c *check.C) {
 	}
 	defer os.RemoveAll(outDir)
 
-	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "touch /foo")
-	if exitCode != 0 {
-		c.Fatal("failed to create a container", out)
-	}
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "touch /foo")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", cleanedContainerID)
+	out = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -597,14 +570,11 @@ func (s *DockerSuite) TestCpVolumePath(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, exitCode := dockerCmd(c, "run", "-d", "-v", "/foo", "-v", tmpDir+"/test:/test", "-v", tmpDir+":/baz", "busybox", "/bin/sh", "-c", "touch /foo/bar")
-	if exitCode != 0 {
-		c.Fatal("failed to create a container", out)
-	}
+	out := dockerCmd(c, "run", "-d", "-v", "/foo", "-v", tmpDir+"/test:/test", "-v", tmpDir+":/baz", "busybox", "/bin/sh", "-c", "touch /foo/bar")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", cleanedContainerID)
+	out = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -679,14 +649,11 @@ func (s *DockerSuite) TestCpVolumePath(c *check.C) {
 }
 
 func (s *DockerSuite) TestCpToDot(c *check.C) {
-	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo lololol > /test")
-	if exitCode != 0 {
-		c.Fatal("failed to create a container", out)
-	}
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo lololol > /test")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", cleanedContainerID)
+	out = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -712,14 +679,11 @@ func (s *DockerSuite) TestCpToDot(c *check.C) {
 }
 
 func (s *DockerSuite) TestCpToStdout(c *check.C) {
-	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo lololol > /test")
-	if exitCode != 0 {
-		c.Fatalf("failed to create a container:%s\n", out)
-	}
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo lololol > /test")
 
 	cID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", cID)
+	out = dockerCmd(c, "wait", cID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatalf("failed to set up container:%s\n", out)
 	}
@@ -740,14 +704,11 @@ func (s *DockerSuite) TestCpToStdout(c *check.C) {
 func (s *DockerSuite) TestCpNameHasColon(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
-	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo lololol > /te:s:t")
-	if exitCode != 0 {
-		c.Fatal("failed to create a container", out)
-	}
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo lololol > /te:s:t")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "wait", cleanedContainerID)
+	out = dockerCmd(c, "wait", cleanedContainerID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -766,10 +727,10 @@ func (s *DockerSuite) TestCpNameHasColon(c *check.C) {
 
 func (s *DockerSuite) TestCopyAndRestart(c *check.C) {
 	expectedMsg := "hello"
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "echo", expectedMsg)
+	out := dockerCmd(c, "run", "-d", "busybox", "echo", expectedMsg)
 	id := strings.TrimSpace(string(out))
 
-	out, _ = dockerCmd(c, "wait", id)
+	out = dockerCmd(c, "wait", id)
 
 	status := strings.TrimSpace(out)
 	if status != "0" {
@@ -784,7 +745,7 @@ func (s *DockerSuite) TestCopyAndRestart(c *check.C) {
 
 	dockerCmd(c, "cp", fmt.Sprintf("%s:/etc/issue", id), tmpDir)
 
-	out, _ = dockerCmd(c, "start", "-a", id)
+	out = dockerCmd(c, "start", "-a", id)
 
 	msg := strings.TrimSpace(out)
 	if msg != expectedMsg {

--- a/integration-cli/docker_cli_cp_utils.go
+++ b/integration-cli/docker_cli_cp_utils.go
@@ -143,23 +143,14 @@ func makeTestContainer(c *check.C, options testContainerOptions) (containerID st
 
 	args = append(args, "busybox", "/bin/sh", "-c", options.command)
 
-	out, status := dockerCmd(c, args...)
-	if status != 0 {
-		c.Fatalf("failed to run container, status %d: %s", status, out)
-	}
+	out := dockerCmd(c, args...)
 
 	containerID = strings.TrimSpace(out)
 
-	out, status = dockerCmd(c, "wait", containerID)
-	if status != 0 {
-		c.Fatalf("failed to wait for test container container, status %d: %s", status, out)
-	}
+	out = dockerCmd(c, "wait", containerID)
 
 	if exitCode := strings.TrimSpace(out); exitCode != "0" {
-		logs, status := dockerCmd(c, "logs", containerID)
-		if status != 0 {
-			logs = "UNABLE TO GET LOGS"
-		}
+		logs := dockerCmd(c, "logs", containerID)
 		c.Fatalf("failed to make test container, exit code (%s): %s", exitCode, logs)
 	}
 

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -18,11 +18,11 @@ import (
 
 // Make sure we can create a simple container with some args
 func (s *DockerSuite) TestCreateArgs(c *check.C) {
-	out, _ := dockerCmd(c, "create", "busybox", "command", "arg1", "arg2", "arg with space")
+	out := dockerCmd(c, "create", "busybox", "command", "arg1", "arg2", "arg with space")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "inspect", cleanedContainerID)
+	out = dockerCmd(c, "inspect", cleanedContainerID)
 
 	containers := []struct {
 		ID      string
@@ -60,11 +60,11 @@ func (s *DockerSuite) TestCreateArgs(c *check.C) {
 // Make sure we can set hostconfig options too
 func (s *DockerSuite) TestCreateHostConfig(c *check.C) {
 
-	out, _ := dockerCmd(c, "create", "-P", "busybox", "echo")
+	out := dockerCmd(c, "create", "-P", "busybox", "echo")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "inspect", cleanedContainerID)
+	out = dockerCmd(c, "inspect", cleanedContainerID)
 
 	containers := []struct {
 		HostConfig *struct {
@@ -91,11 +91,11 @@ func (s *DockerSuite) TestCreateHostConfig(c *check.C) {
 
 func (s *DockerSuite) TestCreateWithPortRange(c *check.C) {
 
-	out, _ := dockerCmd(c, "create", "-p", "3300-3303:3300-3303/tcp", "busybox", "echo")
+	out := dockerCmd(c, "create", "-p", "3300-3303:3300-3303/tcp", "busybox", "echo")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "inspect", cleanedContainerID)
+	out = dockerCmd(c, "inspect", cleanedContainerID)
 
 	containers := []struct {
 		HostConfig *struct {
@@ -130,11 +130,11 @@ func (s *DockerSuite) TestCreateWithPortRange(c *check.C) {
 
 func (s *DockerSuite) TestCreateWithiLargePortRange(c *check.C) {
 
-	out, _ := dockerCmd(c, "create", "-p", "1-65535:1-65535/tcp", "busybox", "echo")
+	out := dockerCmd(c, "create", "-p", "1-65535:1-65535/tcp", "busybox", "echo")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "inspect", cleanedContainerID)
+	out = dockerCmd(c, "inspect", cleanedContainerID)
 
 	containers := []struct {
 		HostConfig *struct {
@@ -170,11 +170,11 @@ func (s *DockerSuite) TestCreateWithiLargePortRange(c *check.C) {
 // "test123" should be printed by docker create + start
 func (s *DockerSuite) TestCreateEchoStdout(c *check.C) {
 
-	out, _ := dockerCmd(c, "create", "busybox", "echo", "test123")
+	out := dockerCmd(c, "create", "busybox", "echo", "test123")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "start", "-ai", cleanedContainerID)
+	out = dockerCmd(c, "start", "-ai", cleanedContainerID)
 
 	if out != "test123\n" {
 		c.Errorf("container should've printed 'test123', got %q", out)
@@ -244,7 +244,7 @@ func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateHostnameWithNumber(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-h", "web.0", "busybox", "hostname")
+	out := dockerCmd(c, "run", "-h", "web.0", "busybox", "hostname")
 	if strings.TrimSpace(out) != "web.0" {
 		c.Fatalf("hostname not set, expected `web.0`, got: %s", out)
 	}
@@ -255,13 +255,13 @@ func (s *DockerSuite) TestCreateRM(c *check.C) {
 	// "Created" state, and has ever been run. Test "rm -f" too.
 
 	// create a container
-	out, _ := dockerCmd(c, "create", "busybox")
+	out := dockerCmd(c, "create", "busybox")
 	cID := strings.TrimSpace(out)
 
 	dockerCmd(c, "rm", cID)
 
 	// Now do it again so we can "rm -f" this time
-	out, _ = dockerCmd(c, "create", "busybox")
+	out = dockerCmd(c, "create", "busybox")
 
 	cID = strings.TrimSpace(out)
 	dockerCmd(c, "rm", "-f", cID)
@@ -270,7 +270,7 @@ func (s *DockerSuite) TestCreateRM(c *check.C) {
 func (s *DockerSuite) TestCreateModeIpcContainer(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
-	out, _ := dockerCmd(c, "create", "busybox")
+	out := dockerCmd(c, "create", "busybox")
 	id := strings.TrimSpace(out)
 
 	dockerCmd(c, "create", fmt.Sprintf("--ipc=container:%s", id), "busybox")

--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -9,10 +9,10 @@ import (
 // ensure that an added file shows up in docker diff
 func (s *DockerSuite) TestDiffFilenameShownInOutput(c *check.C) {
 	containerCmd := `echo foo > /root/bar`
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", containerCmd)
+	out := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", containerCmd)
 
 	cleanCID := strings.TrimSpace(out)
-	out, _ = dockerCmd(c, "diff", cleanCID)
+	out = dockerCmd(c, "diff", cleanCID)
 
 	found := false
 	for _, line := range strings.Split(out, "\n") {
@@ -35,10 +35,10 @@ func (s *DockerSuite) TestDiffEnsureDockerinitFilesAreIgnored(c *check.C) {
 	// we might not run into this problem from the first run, so start a few containers
 	for i := 0; i < containerCount; i++ {
 		containerCmd := `echo foo > /root/bar`
-		out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", containerCmd)
+		out := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", containerCmd)
 
 		cleanCID := strings.TrimSpace(out)
-		out, _ = dockerCmd(c, "diff", cleanCID)
+		out = dockerCmd(c, "diff", cleanCID)
 
 		for _, filename := range dockerinitFiles {
 			if strings.Contains(out, filename) {
@@ -49,10 +49,10 @@ func (s *DockerSuite) TestDiffEnsureDockerinitFilesAreIgnored(c *check.C) {
 }
 
 func (s *DockerSuite) TestDiffEnsureOnlyKmsgAndPtmx(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sleep", "0")
+	out := dockerCmd(c, "run", "-d", "busybox", "sleep", "0")
 
 	cleanCID := strings.TrimSpace(out)
-	out, _ = dockerCmd(c, "diff", cleanCID)
+	out = dockerCmd(c, "diff", cleanCID)
 
 	expected := map[string]bool{
 		"C /dev":         true,

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -35,7 +35,7 @@ func (s *DockerSuite) TestEventsTimestampFormats(c *check.C) {
 	// --since=$start must contain only the 'untag' event
 	for _, f := range []func(time.Time) string{unixTs, rfc3339, duration} {
 		since, until := f(start), f(end)
-		out, _ := dockerCmd(c, "events", "--since="+since, "--until="+until)
+		out := dockerCmd(c, "events", "--since="+since, "--until="+until)
 		events := strings.Split(strings.TrimSpace(out), "\n")
 		if len(events) != 2 {
 			c.Fatalf("unexpected events, was expecting only 2 events tag/untag (since=%s, until=%s) out=%s", since, until, out)
@@ -72,13 +72,13 @@ func (s *DockerSuite) TestEventsUntag(c *check.C) {
 
 func (s *DockerSuite) TestEventsContainerFailStartDie(c *check.C) {
 
-	out, _ := dockerCmd(c, "images", "-q")
+	out := dockerCmd(c, "images", "-q")
 	image := strings.Split(out, "\n")[0]
 	if _, _, err := dockerCmdWithError("run", "--name", "testeventdie", image, "blerg"); err == nil {
 		c.Fatalf("Container run with command blerg should have failed, but it did not")
 	}
 
-	out, _ = dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
+	out = dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	events := strings.Split(out, "\n")
 	if len(events) <= 1 {
 		c.Fatalf("Missing expected event")
@@ -119,7 +119,7 @@ func (s *DockerSuite) TestEventsLimit(c *check.C) {
 		}
 	}
 
-	out, _ := dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
+	out := dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	events := strings.Split(out, "\n")
 	nEvents := len(events) - 1
 	if nEvents != 64 {
@@ -129,7 +129,7 @@ func (s *DockerSuite) TestEventsLimit(c *check.C) {
 
 func (s *DockerSuite) TestEventsContainerEvents(c *check.C) {
 	dockerCmd(c, "run", "--rm", "busybox", "true")
-	out, _ := dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
+	out := dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	events := strings.Split(out, "\n")
 	events = events[:len(events)-1]
 	if len(events) < 5 {
@@ -162,7 +162,7 @@ func (s *DockerSuite) TestEventsContainerEventsSinceUnixEpoch(c *check.C) {
 	dockerCmd(c, "run", "--rm", "busybox", "true")
 	timeBeginning := time.Unix(0, 0).Format(time.RFC3339Nano)
 	timeBeginning = strings.Replace(timeBeginning, "Z", ".000000000Z", -1)
-	out, _ := dockerCmd(c, "events", fmt.Sprintf("--since='%s'", timeBeginning),
+	out := dockerCmd(c, "events", fmt.Sprintf("--since='%s'", timeBeginning),
 		fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	events := strings.Split(out, "\n")
 	events = events[:len(events)-1]
@@ -204,7 +204,7 @@ func (s *DockerSuite) TestEventsImageUntagDelete(c *check.C) {
 	if err := deleteImages(name); err != nil {
 		c.Fatal(err)
 	}
-	out, _ := dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
+	out := dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	events := strings.Split(out, "\n")
 
 	events = events[:len(events)-1]
@@ -227,7 +227,7 @@ func (s *DockerSuite) TestEventsImageTag(c *check.C) {
 	image := "testimageevents:tag"
 	dockerCmd(c, "tag", "busybox", image)
 
-	out, _ := dockerCmd(c, "events",
+	out := dockerCmd(c, "events",
 		fmt.Sprintf("--since=%d", since),
 		fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 
@@ -250,7 +250,7 @@ func (s *DockerSuite) TestEventsImagePull(c *check.C) {
 
 	dockerCmd(c, "pull", "hello-world")
 
-	out, _ := dockerCmd(c, "events",
+	out := dockerCmd(c, "events",
 		fmt.Sprintf("--since=%d", since),
 		fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 
@@ -290,7 +290,7 @@ func (s *DockerSuite) TestEventsImageImport(c *check.C) {
 		}
 	}()
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
+	out := dockerCmd(c, "run", "-d", "busybox", "true")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	out, _, err = runCommandPipelineWithOutput(
@@ -327,10 +327,10 @@ func (s *DockerSuite) TestEventsFilters(c *check.C) {
 	since := daemonTime(c).Unix()
 	dockerCmd(c, "run", "--rm", "busybox", "true")
 	dockerCmd(c, "run", "--rm", "busybox", "true")
-	out, _ := dockerCmd(c, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(c).Unix()), "--filter", "event=die")
+	out := dockerCmd(c, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(c).Unix()), "--filter", "event=die")
 	parseEvents(out, "die")
 
-	out, _ = dockerCmd(c, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(c).Unix()), "--filter", "event=die", "--filter", "event=start")
+	out = dockerCmd(c, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(c).Unix()), "--filter", "event=die", "--filter", "event=start")
 	parseEvents(out, "((die)|(start))")
 
 	// make sure we at least got 2 start events
@@ -344,14 +344,14 @@ func (s *DockerSuite) TestEventsFilters(c *check.C) {
 func (s *DockerSuite) TestEventsFilterImageName(c *check.C) {
 	since := daemonTime(c).Unix()
 
-	out, _ := dockerCmd(c, "run", "--name", "container_1", "-d", "busybox:latest", "true")
+	out := dockerCmd(c, "run", "--name", "container_1", "-d", "busybox:latest", "true")
 	container1 := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "run", "--name", "container_2", "-d", "busybox", "true")
+	out = dockerCmd(c, "run", "--name", "container_2", "-d", "busybox", "true")
 	container2 := strings.TrimSpace(out)
 
 	name := "busybox"
-	out, _ = dockerCmd(c, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(c).Unix()), "--filter", fmt.Sprintf("image=%s", name))
+	out = dockerCmd(c, "events", fmt.Sprintf("--since=%d", since), fmt.Sprintf("--until=%d", daemonTime(c).Unix()), "--filter", fmt.Sprintf("image=%s", name))
 	events := strings.Split(out, "\n")
 	events = events[:len(events)-1]
 	if len(events) == 0 {
@@ -409,14 +409,14 @@ func (s *DockerSuite) TestEventsFilterContainer(c *check.C) {
 
 	for name, ID := range nameID {
 		// filter by names
-		out, _ := dockerCmd(c, "events", "--since", since, "--until", until, "--filter", "container="+name)
+		out := dockerCmd(c, "events", "--since", since, "--until", until, "--filter", "container="+name)
 		events := strings.Split(strings.TrimSuffix(out, "\n"), "\n")
 		if err := checkEvents(ID, events); err != nil {
 			c.Fatal(err)
 		}
 
 		// filter by ID's
-		out, _ = dockerCmd(c, "events", "--since", since, "--until", until, "--filter", "container="+ID)
+		out = dockerCmd(c, "events", "--since", since, "--until", until, "--filter", "container="+ID)
 		events = strings.Split(strings.TrimSuffix(out, "\n"), "\n")
 		if err := checkEvents(ID, events); err != nil {
 			c.Fatal(err)
@@ -466,7 +466,7 @@ func (s *DockerSuite) TestEventsStreaming(c *check.C) {
 		}
 	}()
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox:latest", "true")
+	out := dockerCmd(c, "run", "-d", "busybox:latest", "true")
 	cleanedContainerID := strings.TrimSpace(out)
 	id <- cleanedContainerID
 
@@ -504,14 +504,14 @@ func (s *DockerSuite) TestEventsStreaming(c *check.C) {
 func (s *DockerSuite) TestEventsCommit(c *check.C) {
 	since := daemonTime(c).Unix()
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	cID := strings.TrimSpace(out)
 	c.Assert(waitRun(cID), check.IsNil)
 
 	dockerCmd(c, "commit", "-m", "test", cID)
 	dockerCmd(c, "stop", cID)
 
-	out, _ = dockerCmd(c, "events", "--since=0", "-f", "container="+cID, "--until="+strconv.Itoa(int(since)))
+	out = dockerCmd(c, "events", "--since=0", "-f", "container="+cID, "--until="+strconv.Itoa(int(since)))
 	if !strings.Contains(out, " commit\n") {
 		c.Fatalf("Missing 'commit' log event\n%s", out)
 	}
@@ -543,14 +543,14 @@ func (s *DockerSuite) TestEventsCopy(c *check.C) {
 
 	dockerCmd(c, "cp", "cptest:/tmp/file", tempFile.Name())
 
-	out, _ := dockerCmd(c, "events", "--since=0", "-f", "container=cptest", "--until="+strconv.Itoa(int(since)))
+	out := dockerCmd(c, "events", "--since=0", "-f", "container=cptest", "--until="+strconv.Itoa(int(since)))
 	if !strings.Contains(out, " archive-path\n") {
 		c.Fatalf("Missing 'archive-path' log event\n%s", out)
 	}
 
 	dockerCmd(c, "cp", tempFile.Name(), "cptest:/tmp/filecopy")
 
-	out, _ = dockerCmd(c, "events", "--since=0", "-f", "container=cptest", "--until="+strconv.Itoa(int(since)))
+	out = dockerCmd(c, "events", "--since=0", "-f", "container=cptest", "--until="+strconv.Itoa(int(since)))
 	if !strings.Contains(out, " extract-to-dir\n") {
 		c.Fatalf("Missing 'extract-to-dir' log event\n%s", out)
 	}
@@ -559,7 +559,7 @@ func (s *DockerSuite) TestEventsCopy(c *check.C) {
 func (s *DockerSuite) TestEventsResize(c *check.C) {
 	since := daemonTime(c).Unix()
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	cID := strings.TrimSpace(out)
 	c.Assert(waitRun(cID), check.IsNil)
 
@@ -570,7 +570,7 @@ func (s *DockerSuite) TestEventsResize(c *check.C) {
 
 	dockerCmd(c, "stop", cID)
 
-	out, _ = dockerCmd(c, "events", "--since=0", "-f", "container="+cID, "--until="+strconv.Itoa(int(since)))
+	out = dockerCmd(c, "events", "--since=0", "-f", "container="+cID, "--until="+strconv.Itoa(int(since)))
 	if !strings.Contains(out, " resize\n") {
 		c.Fatalf("Missing 'resize' log event\n%s", out)
 	}
@@ -579,7 +579,7 @@ func (s *DockerSuite) TestEventsResize(c *check.C) {
 func (s *DockerSuite) TestEventsAttach(c *check.C) {
 	since := daemonTime(c).Unix()
 
-	out, _ := dockerCmd(c, "run", "-di", "busybox", "/bin/cat")
+	out := dockerCmd(c, "run", "-di", "busybox", "/bin/cat")
 	cID := strings.TrimSpace(out)
 
 	cmd := exec.Command(dockerBinary, "attach", cID)
@@ -606,7 +606,7 @@ func (s *DockerSuite) TestEventsAttach(c *check.C) {
 
 	dockerCmd(c, "stop", cID)
 
-	out, _ = dockerCmd(c, "events", "--since=0", "-f", "container="+cID, "--until="+strconv.Itoa(int(since)))
+	out = dockerCmd(c, "events", "--since=0", "-f", "container="+cID, "--until="+strconv.Itoa(int(since)))
 	if !strings.Contains(out, " attach\n") {
 		c.Fatalf("Missing 'attach' log event\n%s", out)
 	}
@@ -618,7 +618,7 @@ func (s *DockerSuite) TestEventsRename(c *check.C) {
 	dockerCmd(c, "run", "--name", "oldName", "busybox", "true")
 	dockerCmd(c, "rename", "oldName", "newName")
 
-	out, _ := dockerCmd(c, "events", "--since=0", "-f", "container=newName", "--until="+strconv.Itoa(int(since)))
+	out := dockerCmd(c, "events", "--since=0", "-f", "container=newName", "--until="+strconv.Itoa(int(since)))
 	if !strings.Contains(out, " rename\n") {
 		c.Fatalf("Missing 'rename' log event\n%s", out)
 	}
@@ -627,14 +627,14 @@ func (s *DockerSuite) TestEventsRename(c *check.C) {
 func (s *DockerSuite) TestEventsTop(c *check.C) {
 	since := daemonTime(c).Unix()
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	cID := strings.TrimSpace(out)
 	c.Assert(waitRun(cID), check.IsNil)
 
 	dockerCmd(c, "top", cID)
 	dockerCmd(c, "stop", cID)
 
-	out, _ = dockerCmd(c, "events", "--since=0", "-f", "container="+cID, "--until="+strconv.Itoa(int(since)))
+	out = dockerCmd(c, "events", "--since=0", "-f", "container="+cID, "--until="+strconv.Itoa(int(since)))
 	if !strings.Contains(out, " top\n") {
 		c.Fatalf("Missing 'top' log event\n%s", out)
 	}
@@ -643,7 +643,7 @@ func (s *DockerSuite) TestEventsTop(c *check.C) {
 // #13753
 func (s *DockerSuite) TestEventsDefaultEmpty(c *check.C) {
 	dockerCmd(c, "run", "busybox")
-	out, _ := dockerCmd(c, "events", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
+	out := dockerCmd(c, "events", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	c.Assert(strings.TrimSpace(out), check.Equals, "")
 }
 
@@ -653,7 +653,7 @@ func (s *DockerRegistrySuite) TestEventsImageFilterPush(c *check.C) {
 	since := daemonTime(c).Unix()
 	repoName := fmt.Sprintf("%v/dockercli/testf", privateRegistryURL)
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	cID := strings.TrimSpace(out)
 	c.Assert(waitRun(cID), check.IsNil)
 
@@ -661,7 +661,7 @@ func (s *DockerRegistrySuite) TestEventsImageFilterPush(c *check.C) {
 	dockerCmd(c, "stop", cID)
 	dockerCmd(c, "push", repoName)
 
-	out, _ = dockerCmd(c, "events", "--since=0", "-f", "image="+repoName, "-f", "event=push", "--until="+strconv.Itoa(int(since)))
+	out = dockerCmd(c, "events", "--since=0", "-f", "image="+repoName, "-f", "event=push", "--until="+strconv.Itoa(int(since)))
 	if !strings.Contains(out, repoName+": push\n") {
 		c.Fatalf("Missing 'push' log event for image %s\n%s", repoName, out)
 	}

--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -15,7 +15,7 @@ import (
 
 // regression test for #12546
 func (s *DockerSuite) TestExecInteractiveStdinClose(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-itd", "busybox", "/bin/cat")
+	out := dockerCmd(c, "run", "-itd", "busybox", "/bin/cat")
 	contID := strings.TrimSpace(out)
 
 	cmd := exec.Command(dockerBinary, "exec", "-i", contID, "echo", "-n", "hello")

--- a/integration-cli/docker_cli_experimental_test.go
+++ b/integration-cli/docker_cli_experimental_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func (s *DockerSuite) TestExperimentalVersion(c *check.C) {
-	out, _ := dockerCmd(c, "version")
+	out := dockerCmd(c, "version")
 	for _, line := range strings.Split(out, "\n") {
 		if strings.HasPrefix(line, "Experimental (client):") || strings.HasPrefix(line, "Experimental (server):") {
 			c.Assert(line, check.Matches, "*true")
 		}
 	}
 
-	out, _ = dockerCmd(c, "-v")
+	out = dockerCmd(c, "-v")
 	if !strings.Contains(out, ", experimental") {
 		c.Fatalf("docker version did not contain experimental: %s", out)
 	}

--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -14,7 +14,7 @@ func (s *DockerSuite) TestExportContainerAndImportImage(c *check.C) {
 
 	dockerCmd(c, "run", "--name", containerID, "busybox", "true")
 
-	out, _ := dockerCmd(c, "export", containerID)
+	out := dockerCmd(c, "export", containerID)
 
 	importCmd := exec.Command(dockerBinary, "import", "-", "repo/testexp:v1")
 	importCmd.Stdin = strings.NewReader(out)

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -46,7 +46,7 @@ RUN echo "Z"`,
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "history", "testbuildhistory")
+	out := dockerCmd(c, "history", "testbuildhistory")
 	actualValues := strings.Split(out, "\n")[1:27]
 	expectedValues := [26]string{"Z", "Y", "X", "W", "V", "U", "T", "S", "R", "Q", "P", "O", "N", "M", "L", "K", "J", "I", "H", "G", "F", "E", "D", "C", "B", "A"}
 
@@ -85,7 +85,7 @@ func (s *DockerSuite) TestHistoryImageWithComment(c *check.C) {
 
 	// test docker history <image id> to check comment messages
 
-	out, _ := dockerCmd(c, "history", name)
+	out := dockerCmd(c, "history", name)
 	outputTabs := strings.Fields(strings.Split(out, "\n")[1])
 	actualValue := outputTabs[len(outputTabs)-1]
 
@@ -95,7 +95,7 @@ func (s *DockerSuite) TestHistoryImageWithComment(c *check.C) {
 }
 
 func (s *DockerSuite) TestHistoryHumanOptionFalse(c *check.C) {
-	out, _ := dockerCmd(c, "history", "--human=false", "busybox")
+	out := dockerCmd(c, "history", "--human=false", "busybox")
 	lines := strings.Split(out, "\n")
 	sizeColumnRegex, _ := regexp.Compile("SIZE +")
 	indices := sizeColumnRegex.FindStringIndex(lines[0])
@@ -113,7 +113,7 @@ func (s *DockerSuite) TestHistoryHumanOptionFalse(c *check.C) {
 }
 
 func (s *DockerSuite) TestHistoryHumanOptionTrue(c *check.C) {
-	out, _ := dockerCmd(c, "history", "--human=true", "busybox")
+	out := dockerCmd(c, "history", "--human=true", "busybox")
 	lines := strings.Split(out, "\n")
 	sizeColumnRegex, _ := regexp.Compile("SIZE +")
 	humanSizeRegex, _ := regexp.Compile("^\\d+.*B$") // Matches human sizes like 10 MB, 3.2 KB, etc

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *DockerSuite) TestImagesEnsureImageIsListed(c *check.C) {
-	out, _ := dockerCmd(c, "images")
+	out := dockerCmd(c, "images")
 	if !strings.Contains(out, "busybox") {
 		c.Fatal("images should've listed busybox")
 	}
@@ -29,13 +29,13 @@ func (s *DockerSuite) TestImagesEnsureImageWithTagIsListed(c *check.C) {
 		MAINTAINER dockerio1`, true)
 	c.Assert(err, check.IsNil)
 
-	out, _ := dockerCmd(c, "images", "imagewithtag:v1")
+	out := dockerCmd(c, "images", "imagewithtag:v1")
 
 	if !strings.Contains(out, "imagewithtag") || !strings.Contains(out, "v1") || strings.Contains(out, "v2") {
 		c.Fatal("images should've listed imagewithtag:v1 and not imagewithtag:v2")
 	}
 
-	out, _ = dockerCmd(c, "images", "imagewithtag")
+	out = dockerCmd(c, "images", "imagewithtag")
 
 	if !strings.Contains(out, "imagewithtag") || !strings.Contains(out, "v1") || !strings.Contains(out, "v2") {
 		c.Fatal("images should've listed imagewithtag:v1 and imagewithtag:v2")
@@ -43,7 +43,7 @@ func (s *DockerSuite) TestImagesEnsureImageWithTagIsListed(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesEnsureImageWithBadTagIsNotListed(c *check.C) {
-	out, _ := dockerCmd(c, "images", "busybox:nonexistent")
+	out := dockerCmd(c, "images", "busybox:nonexistent")
 
 	if strings.Contains(out, "busybox") {
 		c.Fatal("images should not have listed busybox")
@@ -73,7 +73,7 @@ func (s *DockerSuite) TestImagesOrderedByCreationDate(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "images", "-q", "--no-trunc")
+	out := dockerCmd(c, "images", "-q", "--no-trunc")
 	imgs := strings.Split(out, "\n")
 	if imgs[0] != id3 {
 		c.Fatalf("First image must be %s, got %s", id3, imgs[0])
@@ -118,13 +118,13 @@ func (s *DockerSuite) TestImagesFilterLabel(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match")
+	out := dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match")
 	out = strings.TrimSpace(out)
 	if (!strings.Contains(out, image1ID) && !strings.Contains(out, image2ID)) || strings.Contains(out, image3ID) {
 		c.Fatalf("Expected ids %s,%s got %s", image1ID, image2ID, out)
 	}
 
-	out, _ = dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match=me too")
+	out = dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match=me too")
 	out = strings.TrimSpace(out)
 	if out != image2ID {
 		c.Fatalf("Expected %s got %s", image2ID, out)
@@ -149,7 +149,7 @@ func (s *DockerSuite) TestImagesFilterSpaceTrimCase(c *check.C) {
 
 	imageListings := make([][]string, 5, 5)
 	for idx, filter := range filters {
-		out, _ := dockerCmd(c, "images", "-q", "-f", filter)
+		out := dockerCmd(c, "images", "-q", "-f", filter)
 		listing := strings.Split(out, "\n")
 		sort.Strings(listing)
 		imageListings[idx] = listing
@@ -171,17 +171,17 @@ func (s *DockerSuite) TestImagesFilterSpaceTrimCase(c *check.C) {
 
 func (s *DockerSuite) TestImagesEnsureDanglingImageOnlyListedOnce(c *check.C) {
 	// create container 1
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
+	out := dockerCmd(c, "run", "-d", "busybox", "true")
 	containerID1 := strings.TrimSpace(out)
 
 	// tag as foobox
-	out, _ = dockerCmd(c, "commit", containerID1, "foobox")
+	out = dockerCmd(c, "commit", containerID1, "foobox")
 	imageID := stringid.TruncateID(strings.TrimSpace(out))
 
 	// overwrite the tag, making the previous image dangling
 	dockerCmd(c, "tag", "-f", "busybox", "foobox")
 
-	out, _ = dockerCmd(c, "images", "-q", "-f", "dangling=true")
+	out = dockerCmd(c, "images", "-q", "-f", "dangling=true")
 	if e, a := 1, strings.Count(out, imageID); e != a {
 		c.Fatalf("expected 1 dangling image, got %d: %s", a, out)
 	}

--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *DockerSuite) TestImportDisplay(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
+	out := dockerCmd(c, "run", "-d", "busybox", "true")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	out, _, err := runCommandPipelineWithOutput(
@@ -28,7 +28,7 @@ func (s *DockerSuite) TestImportDisplay(c *check.C) {
 	}
 	image := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "run", "--rm", image, "true")
+	out = dockerCmd(c, "run", "--rm", image, "true")
 	if out != "" {
 		c.Fatalf("command output should've been nothing, was %q", out)
 	}
@@ -61,13 +61,13 @@ func (s *DockerSuite) TestImportFile(c *check.C) {
 		c.Fatal("failed to export a container", err)
 	}
 
-	out, _ := dockerCmd(c, "import", temporaryFile.Name())
+	out := dockerCmd(c, "import", temporaryFile.Name())
 	if n := strings.Count(out, "\n"); n != 1 {
 		c.Fatalf("display is messed up: %d '\\n' instead of 1:\n%s", n, out)
 	}
 	image := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "run", "--rm", image, "true")
+	out = dockerCmd(c, "run", "--rm", image, "true")
 	if out != "" {
 		c.Fatalf("command output should've been nothing, was %q", out)
 	}
@@ -91,13 +91,13 @@ func (s *DockerSuite) TestImportFileWithMessage(c *check.C) {
 	}
 
 	message := "Testing commit message"
-	out, _ := dockerCmd(c, "import", "-m", message, temporaryFile.Name())
+	out := dockerCmd(c, "import", "-m", message, temporaryFile.Name())
 	if n := strings.Count(out, "\n"); n != 1 {
 		c.Fatalf("display is messed up: %d '\\n' instead of 1:\n%s", n, out)
 	}
 	image := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "history", image)
+	out = dockerCmd(c, "history", image)
 	split := strings.Split(out, "\n")
 
 	if len(split) != 3 {
@@ -110,7 +110,7 @@ func (s *DockerSuite) TestImportFileWithMessage(c *check.C) {
 		c.Fatalf("expected %s in commit message, got %s", message, split[3])
 	}
 
-	out, _ = dockerCmd(c, "run", "--rm", image, "true")
+	out = dockerCmd(c, "run", "--rm", image, "true")
 	if out != "" {
 		c.Fatalf("command output should've been nothing, was %q", out)
 	}

--- a/integration-cli/docker_cli_info_test.go
+++ b/integration-cli/docker_cli_info_test.go
@@ -9,7 +9,7 @@ import (
 
 // ensure docker info succeeds
 func (s *DockerSuite) TestInfoEnsureSucceeds(c *check.C) {
-	out, _ := dockerCmd(c, "info")
+	out := dockerCmd(c, "info")
 
 	// always shown fields
 	stringsToCheck := []string{

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -50,7 +50,7 @@ func (s *DockerSuite) TestInspectDefault(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectStatus(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	out = strings.TrimSpace(out)
 
 	inspectOut, err := inspectField(out, "State.Status")
@@ -187,7 +187,7 @@ func (s *DockerSuite) TestInspectContainerFilterInt(c *check.C) {
 
 	//now get the exit code to verify
 	formatStr := fmt.Sprintf("--format='{{eq .State.ExitCode %d}}'", exitCode)
-	out, _ = dockerCmd(c, "inspect", formatStr, id)
+	out = dockerCmd(c, "inspect", formatStr, id)
 	if result, err := strconv.ParseBool(strings.TrimSuffix(out, "\n")); err != nil || !result {
 		c.Fatalf("Expected exitcode: %d for container: %s", exitCode, id)
 	}
@@ -224,7 +224,7 @@ func (s *DockerSuite) TestInspectImageGraphDriver(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
+	out := dockerCmd(c, "run", "-d", "busybox", "true")
 	out = strings.TrimSpace(out)
 
 	name, err := inspectField(out, "GraphDriver.Name")
@@ -298,7 +298,7 @@ func (s *DockerSuite) TestInspectBindMountPoint(c *check.C) {
 
 // #14947
 func (s *DockerSuite) TestInspectTimesAsRFC3339Nano(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
+	out := dockerCmd(c, "run", "-d", "busybox", "true")
 	id := strings.TrimSpace(out)
 	startedAt, err := inspectField(id, "State.StartedAt")
 	c.Assert(err, check.IsNil)

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -9,20 +9,20 @@ import (
 )
 
 func (s *DockerSuite) TestKillContainer(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 
 	dockerCmd(c, "kill", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "ps", "-q")
+	out = dockerCmd(c, "ps", "-q")
 	if strings.Contains(out, cleanedContainerID) {
 		c.Fatal("killed container is still running")
 	}
 }
 
 func (s *DockerSuite) TestKillofStoppedContainer(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
 	dockerCmd(c, "stop", cleanedContainerID)
@@ -32,13 +32,13 @@ func (s *DockerSuite) TestKillofStoppedContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestKillDifferentUserContainer(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-u", "daemon", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-u", "daemon", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 
 	dockerCmd(c, "kill", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "ps", "-q")
+	out = dockerCmd(c, "ps", "-q")
 	if strings.Contains(out, cleanedContainerID) {
 		c.Fatal("killed container is still running")
 	}
@@ -46,7 +46,7 @@ func (s *DockerSuite) TestKillDifferentUserContainer(c *check.C) {
 
 // regression test about correct signal parsing see #13665
 func (s *DockerSuite) TestKillWithSignal(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	cid := strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
 
@@ -59,7 +59,7 @@ func (s *DockerSuite) TestKillWithSignal(c *check.C) {
 }
 
 func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	cid := strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
 
@@ -74,7 +74,7 @@ func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
 		c.Fatal("Container should be in running state after an invalid signal")
 	}
 
-	out, _ = dockerCmd(c, "run", "-d", "busybox", "top")
+	out = dockerCmd(c, "run", "-d", "busybox", "top")
 	cid = strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
 

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -54,9 +54,9 @@ func (s *DockerSuite) TestLinksPingLinkedContainers(c *check.C) {
 
 func (s *DockerSuite) TestLinksPingLinkedContainersAfterRename(c *check.C) {
 
-	out, _ := dockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
 	idA := strings.TrimSpace(out)
-	out, _ = dockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top")
+	out = dockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top")
 	idB := strings.TrimSpace(out)
 	dockerCmd(c, "rename", "container1", "container_new")
 	dockerCmd(c, "run", "--rm", "--link", "container_new:alias1", "--link", "container2:alias2", "busybox", "sh", "-c", "ping -c 1 alias1 -W 1 && ping -c 1 alias2 -W 1")
@@ -131,10 +131,10 @@ func (s *DockerSuite) TestLinksNotStartedParentNotFail(c *check.C) {
 func (s *DockerSuite) TestLinksHostsFilesInject(c *check.C) {
 	testRequires(c, SameHostDaemon, ExecSupport)
 
-	out, _ := dockerCmd(c, "run", "-itd", "--name", "one", "busybox", "top")
+	out := dockerCmd(c, "run", "-itd", "--name", "one", "busybox", "top")
 	idOne := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "run", "-itd", "--name", "two", "--link", "one:onetwo", "busybox", "top")
+	out = dockerCmd(c, "run", "-itd", "--name", "two", "--link", "one:onetwo", "busybox", "top")
 	idTwo := strings.TrimSpace(out)
 
 	c.Assert(waitRun(idTwo), check.IsNil)
@@ -158,7 +158,7 @@ func (s *DockerSuite) TestLinksHostsFilesInject(c *check.C) {
 func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 	testRequires(c, SameHostDaemon, ExecSupport)
 	dockerCmd(c, "run", "-d", "--name", "one", "busybox", "top")
-	out, _ := dockerCmd(c, "run", "-d", "--name", "two", "--link", "one:onetwo", "--link", "one:one", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "--name", "two", "--link", "one:onetwo", "--link", "one:one", "busybox", "top")
 	id := strings.TrimSpace(string(out))
 
 	realIP, err := inspectField("one", "NetworkSettings.IPAddress")
@@ -202,7 +202,7 @@ func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 
 func (s *DockerSuite) TestLinksEnvs(c *check.C) {
 	dockerCmd(c, "run", "-d", "-e", "e1=", "-e", "e2=v2", "-e", "e3=v3=v3", "--name=first", "busybox", "top")
-	out, _ := dockerCmd(c, "run", "--name=second", "--link=first:first", "busybox", "env")
+	out := dockerCmd(c, "run", "--name=second", "--link=first:first", "busybox", "env")
 	if !strings.Contains(out, "FIRST_ENV_e1=\n") ||
 		!strings.Contains(out, "FIRST_ENV_e2=v2") ||
 		!strings.Contains(out, "FIRST_ENV_e3=v3=v3") {
@@ -211,12 +211,12 @@ func (s *DockerSuite) TestLinksEnvs(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinkShortDefinition(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "--name", "shortlinkdef", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "--name", "shortlinkdef", "busybox", "top")
 
 	cid := strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
 
-	out, _ = dockerCmd(c, "run", "-d", "--name", "link2", "--link", "shortlinkdef", "busybox", "top")
+	out = dockerCmd(c, "run", "-d", "--name", "link2", "--link", "shortlinkdef", "busybox", "top")
 
 	cid2 := strings.TrimSpace(out)
 	c.Assert(waitRun(cid2), check.IsNil)
@@ -235,7 +235,7 @@ func (s *DockerSuite) TestLinksNetworkHostContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksEtcHostsRegularFile(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--net=host", "busybox", "ls", "-la", "/etc/hosts")
+	out := dockerCmd(c, "run", "--net=host", "busybox", "ls", "-la", "/etc/hosts")
 	if !strings.HasPrefix(out, "-") {
 		c.Errorf("/etc/hosts should be a regular file")
 	}

--- a/integration-cli/docker_cli_links_unix_test.go
+++ b/integration-cli/docker_cli_links_unix_test.go
@@ -14,7 +14,7 @@ func (s *DockerSuite) TestLinksEtcHostsContentMatch(c *check.C) {
 	// same host as the daemon.
 	testRequires(c, SameHostDaemon)
 
-	out, _ := dockerCmd(c, "run", "--net=host", "busybox", "cat", "/etc/hosts")
+	out := dockerCmd(c, "run", "--net=host", "busybox", "cat", "/etc/hosts")
 	hosts, err := ioutil.ReadFile("/etc/hosts")
 	if os.IsNotExist(err) {
 		c.Skip("/etc/hosts does not exist, skip this test")

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -17,11 +17,11 @@ import (
 // This used to work, it test a log of PageSize-1 (gh#4851)
 func (s *DockerSuite) TestLogsContainerSmallerThanPage(c *check.C) {
 	testLen := 32767
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
+	out := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
 	cleanedContainerID := strings.TrimSpace(out)
 
 	dockerCmd(c, "wait", cleanedContainerID)
-	out, _ = dockerCmd(c, "logs", cleanedContainerID)
+	out = dockerCmd(c, "logs", cleanedContainerID)
 	if len(out) != testLen+1 {
 		c.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
 	}
@@ -30,12 +30,12 @@ func (s *DockerSuite) TestLogsContainerSmallerThanPage(c *check.C) {
 // Regression test: When going over the PageSize, it used to panic (gh#4851)
 func (s *DockerSuite) TestLogsContainerBiggerThanPage(c *check.C) {
 	testLen := 32768
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
+	out := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
 
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "wait", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "logs", cleanedContainerID)
+	out = dockerCmd(c, "logs", cleanedContainerID)
 
 	if len(out) != testLen+1 {
 		c.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
@@ -45,12 +45,12 @@ func (s *DockerSuite) TestLogsContainerBiggerThanPage(c *check.C) {
 // Regression test: When going much over the PageSize, it used to block (gh#4851)
 func (s *DockerSuite) TestLogsContainerMuchBiggerThanPage(c *check.C) {
 	testLen := 33000
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
+	out := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
 
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "wait", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "logs", cleanedContainerID)
+	out = dockerCmd(c, "logs", cleanedContainerID)
 
 	if len(out) != testLen+1 {
 		c.Fatalf("Expected log length of %d, received %d\n", testLen+1, len(out))
@@ -59,12 +59,12 @@ func (s *DockerSuite) TestLogsContainerMuchBiggerThanPage(c *check.C) {
 
 func (s *DockerSuite) TestLogsTimestamps(c *check.C) {
 	testLen := 100
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
+	out := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
 
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "wait", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "logs", "-t", cleanedContainerID)
+	out = dockerCmd(c, "logs", "-t", cleanedContainerID)
 
 	lines := strings.Split(out, "\n")
 
@@ -89,7 +89,7 @@ func (s *DockerSuite) TestLogsTimestamps(c *check.C) {
 
 func (s *DockerSuite) TestLogsSeparateStderr(c *check.C) {
 	msg := "stderr_log"
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
+	out := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
 
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "wait", cleanedContainerID)
@@ -108,7 +108,7 @@ func (s *DockerSuite) TestLogsSeparateStderr(c *check.C) {
 
 func (s *DockerSuite) TestLogsStderrInStdout(c *check.C) {
 	msg := "stderr_log"
-	out, _ := dockerCmd(c, "run", "-d", "-t", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
+	out := dockerCmd(c, "run", "-d", "-t", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
 
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "wait", cleanedContainerID)
@@ -126,19 +126,19 @@ func (s *DockerSuite) TestLogsStderrInStdout(c *check.C) {
 
 func (s *DockerSuite) TestLogsTail(c *check.C) {
 	testLen := 100
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
+	out := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
 
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "wait", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "logs", "--tail", "5", cleanedContainerID)
+	out = dockerCmd(c, "logs", "--tail", "5", cleanedContainerID)
 
 	lines := strings.Split(out, "\n")
 
 	if len(lines) != 6 {
 		c.Fatalf("Expected log %d lines, received %d\n", 6, len(lines))
 	}
-	out, _ = dockerCmd(c, "logs", "--tail", "all", cleanedContainerID)
+	out = dockerCmd(c, "logs", "--tail", "all", cleanedContainerID)
 
 	lines = strings.Split(out, "\n")
 
@@ -155,7 +155,7 @@ func (s *DockerSuite) TestLogsTail(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsFollowStopped(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
+	out := dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
 
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "wait", cleanedContainerID)
@@ -181,13 +181,13 @@ func (s *DockerSuite) TestLogsFollowStopped(c *check.C) {
 
 func (s *DockerSuite) TestLogsSince(c *check.C) {
 	name := "testlogssince"
-	out, _ := dockerCmd(c, "run", "--name="+name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do sleep 2; echo `date +%s` log$i; done")
+	out := dockerCmd(c, "run", "--name="+name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do sleep 2; echo `date +%s` log$i; done")
 
 	log2Line := strings.Split(strings.Split(out, "\n")[1], " ")
 	t, err := strconv.ParseInt(log2Line[0], 10, 64) // the timestamp log2 is written
 	c.Assert(err, check.IsNil)
 	since := t + 1 // add 1s so log1 & log2 doesn't show up
-	out, _ = dockerCmd(c, "logs", "-t", fmt.Sprintf("--since=%v", since), name)
+	out = dockerCmd(c, "logs", "-t", fmt.Sprintf("--since=%v", since), name)
 
 	// Skip 2 seconds
 	unexpected := []string{"log1", "log2"}
@@ -215,12 +215,12 @@ func (s *DockerSuite) TestLogsSince(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsSinceFutureFollow(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", `for i in $(seq 1 5); do date +%s; sleep 1; done`)
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", `for i in $(seq 1 5); do date +%s; sleep 1; done`)
 	cleanedContainerID := strings.TrimSpace(out)
 
 	now := daemonTime(c).Unix()
 	since := now + 2
-	out, _ = dockerCmd(c, "logs", "-f", fmt.Sprintf("--since=%v", since), cleanedContainerID)
+	out = dockerCmd(c, "logs", "-f", fmt.Sprintf("--since=%v", since), cleanedContainerID)
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 	if len(lines) == 0 {
 		c.Fatal("got no log lines")
@@ -238,7 +238,7 @@ func (s *DockerSuite) TestLogsSinceFutureFollow(c *check.C) {
 
 // Regression test for #8832
 func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", `usleep 200000;yes X | head -c 200000`)
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", `usleep 200000;yes X | head -c 200000`)
 
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -271,7 +271,7 @@ func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsFollowGoroutinesWithStdout(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true; do echo hello; sleep 2; done")
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true; do echo hello; sleep 2; done")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
 
@@ -322,7 +322,7 @@ func (s *DockerSuite) TestLogsFollowGoroutinesWithStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsFollowGoroutinesNoOutput(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true; do sleep 2; done")
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true; do sleep 2; done")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
 

--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -43,7 +43,7 @@ func getExternalAddress(c *check.C) net.IP {
 }
 
 func getContainerLogs(c *check.C, containerID string) string {
-	out, _ := dockerCmd(c, "logs", containerID)
+	out := dockerCmd(c, "logs", containerID)
 	return strings.Trim(out, "\r\n")
 }
 
@@ -99,7 +99,7 @@ func (s *DockerSuite) TestNetworkLoopbackNat(c *check.C) {
 	msg := "it works"
 	startServerContainer(c, msg, 8080)
 	endpoint := getExternalAddress(c)
-	out, _ := dockerCmd(c, "run", "-t", "--net=container:server", "busybox",
+	out := dockerCmd(c, "run", "-t", "--net=container:server", "busybox",
 		"sh", "-c", fmt.Sprintf("stty raw && nc -w 5 %s 8080", endpoint.String()))
 	final := strings.TrimRight(string(out), "\n")
 	if final != msg {

--- a/integration-cli/docker_cli_network_test.go
+++ b/integration-cli/docker_cli_network_test.go
@@ -21,7 +21,7 @@ func assertNwNotAvailable(c *check.C, name string) {
 }
 
 func isNwPresent(c *check.C, name string) bool {
-	out, _ := dockerCmd(c, "network", "ls")
+	out := dockerCmd(c, "network", "ls")
 	lines := strings.Split(out, "\n")
 	for i := 1; i < len(lines)-1; i++ {
 		if strings.Contains(lines[i], name) {

--- a/integration-cli/docker_cli_pause_test.go
+++ b/integration-cli/docker_cli_pause_test.go
@@ -24,7 +24,7 @@ func (s *DockerSuite) TestPause(c *check.C) {
 
 	dockerCmd(c, "unpause", name)
 
-	out, _ := dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
+	out := dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	events := strings.Split(out, "\n")
 	if len(events) <= 1 {
 		c.Fatalf("Missing expected event")
@@ -63,7 +63,7 @@ func (s *DockerSuite) TestPauseMultipleContainers(c *check.C) {
 
 	dockerCmd(c, append([]string{"unpause"}, containers...)...)
 
-	out, _ := dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
+	out := dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	events := strings.Split(out, "\n")
 	if len(events) <= len(containers)*3-2 {
 		c.Fatalf("Missing expected event")

--- a/integration-cli/docker_cli_port_test.go
+++ b/integration-cli/docker_cli_port_test.go
@@ -13,16 +13,16 @@ import (
 func (s *DockerSuite) TestPortList(c *check.C) {
 
 	// one port
-	out, _ := dockerCmd(c, "run", "-d", "-p", "9876:80", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "-p", "9876:80", "busybox", "top")
 	firstID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "port", firstID, "80")
+	out = dockerCmd(c, "port", firstID, "80")
 
 	if !assertPortList(c, out, []string{"0.0.0.0:9876"}) {
 		c.Error("Port list is not correct")
 	}
 
-	out, _ = dockerCmd(c, "port", firstID)
+	out = dockerCmd(c, "port", firstID)
 
 	if !assertPortList(c, out, []string{"80/tcp -> 0.0.0.0:9876"}) {
 		c.Error("Port list is not correct")
@@ -30,20 +30,20 @@ func (s *DockerSuite) TestPortList(c *check.C) {
 	dockerCmd(c, "rm", "-f", firstID)
 
 	// three port
-	out, _ = dockerCmd(c, "run", "-d",
+	out = dockerCmd(c, "run", "-d",
 		"-p", "9876:80",
 		"-p", "9877:81",
 		"-p", "9878:82",
 		"busybox", "top")
 	ID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "port", ID, "80")
+	out = dockerCmd(c, "port", ID, "80")
 
 	if !assertPortList(c, out, []string{"0.0.0.0:9876"}) {
 		c.Error("Port list is not correct")
 	}
 
-	out, _ = dockerCmd(c, "port", ID)
+	out = dockerCmd(c, "port", ID)
 
 	if !assertPortList(c, out, []string{
 		"80/tcp -> 0.0.0.0:9876",
@@ -54,7 +54,7 @@ func (s *DockerSuite) TestPortList(c *check.C) {
 	dockerCmd(c, "rm", "-f", ID)
 
 	// more and one port mapped to the same container port
-	out, _ = dockerCmd(c, "run", "-d",
+	out = dockerCmd(c, "run", "-d",
 		"-p", "9876:80",
 		"-p", "9999:80",
 		"-p", "9877:81",
@@ -62,13 +62,13 @@ func (s *DockerSuite) TestPortList(c *check.C) {
 		"busybox", "top")
 	ID = strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "port", ID, "80")
+	out = dockerCmd(c, "port", ID, "80")
 
 	if !assertPortList(c, out, []string{"0.0.0.0:9876", "0.0.0.0:9999"}) {
 		c.Error("Port list is not correct")
 	}
 
-	out, _ = dockerCmd(c, "port", ID)
+	out = dockerCmd(c, "port", ID)
 
 	if !assertPortList(c, out, []string{
 		"80/tcp -> 0.0.0.0:9876",
@@ -83,12 +83,12 @@ func (s *DockerSuite) TestPortList(c *check.C) {
 		// host port ranges used
 		IDs := make([]string, 3)
 		for i := 0; i < 3; i++ {
-			out, _ = dockerCmd(c, "run", "-d",
+			out = dockerCmd(c, "run", "-d",
 				"-p", "9090-9092:80",
 				"busybox", "top")
 			IDs[i] = strings.TrimSpace(out)
 
-			out, _ = dockerCmd(c, "port", IDs[i])
+			out = dockerCmd(c, "port", IDs[i])
 
 			if !assertPortList(c, out, []string{
 				fmt.Sprintf("80/tcp -> 0.0.0.0:%d", 9090+i)}) {
@@ -123,12 +123,12 @@ func (s *DockerSuite) TestPortList(c *check.C) {
 	}
 
 	// test host range:container range spec.
-	out, _ = dockerCmd(c, "run", "-d",
+	out = dockerCmd(c, "run", "-d",
 		"-p", "9800-9803:80-83",
 		"busybox", "top")
 	ID = strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "port", ID)
+	out = dockerCmd(c, "port", ID)
 
 	if !assertPortList(c, out, []string{
 		"80/tcp -> 0.0.0.0:9800",
@@ -140,13 +140,13 @@ func (s *DockerSuite) TestPortList(c *check.C) {
 	dockerCmd(c, "rm", "-f", ID)
 
 	// test mixing protocols in same port range
-	out, _ = dockerCmd(c, "run", "-d",
+	out = dockerCmd(c, "run", "-d",
 		"-p", "8000-8080:80",
 		"-p", "8000-8080:80/udp",
 		"busybox", "top")
 	ID = strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "port", ID)
+	out = dockerCmd(c, "port", ID)
 
 	if !assertPortList(c, out, []string{
 		"80/tcp -> 0.0.0.0:8000",
@@ -191,7 +191,7 @@ func (s *DockerSuite) TestUnpublishedPortsInPsOutput(c *check.C) {
 	// Check docker ps o/p for last created container reports the unpublished ports
 	unpPort1 := fmt.Sprintf("%d/tcp", port1)
 	unpPort2 := fmt.Sprintf("%d/tcp", port2)
-	out, _ := dockerCmd(c, "ps", "-n=1")
+	out := dockerCmd(c, "ps", "-n=1")
 	if !strings.Contains(out, unpPort1) || !strings.Contains(out, unpPort2) {
 		c.Errorf("Missing unpublished ports(s) (%s, %s) in docker ps output: %s", unpPort1, unpPort2, out)
 	}
@@ -202,7 +202,7 @@ func (s *DockerSuite) TestUnpublishedPortsInPsOutput(c *check.C) {
 	// Check docker ps o/p for last created container reports the exposed ports in the port bindings
 	expBndRegx1 := regexp.MustCompile(`0.0.0.0:\d\d\d\d\d->` + unpPort1)
 	expBndRegx2 := regexp.MustCompile(`0.0.0.0:\d\d\d\d\d->` + unpPort2)
-	out, _ = dockerCmd(c, "ps", "-n=1")
+	out = dockerCmd(c, "ps", "-n=1")
 	if !expBndRegx1.MatchString(out) || !expBndRegx2.MatchString(out) {
 		c.Errorf("Cannot find expected port binding ports(s) (0.0.0.0:xxxxx->%s, 0.0.0.0:xxxxx->%s) in docker ps output:\n%s",
 			unpPort1, unpPort2, out)
@@ -212,13 +212,13 @@ func (s *DockerSuite) TestUnpublishedPortsInPsOutput(c *check.C) {
 	offset := 10000
 	pFlag1 := fmt.Sprintf("%d:%d", offset+port1, port1)
 	pFlag2 := fmt.Sprintf("%d:%d", offset+port2, port2)
-	out, _ = dockerCmd(c, "run", "-d", "-p", pFlag1, "-p", pFlag2, expose1, expose2, "busybox", "sleep", "5")
+	out = dockerCmd(c, "run", "-d", "-p", pFlag1, "-p", pFlag2, expose1, expose2, "busybox", "sleep", "5")
 	id := strings.TrimSpace(out)
 
 	// Check docker ps o/p for last created container reports the specified port mappings
 	expBnd1 := fmt.Sprintf("0.0.0.0:%d->%s", offset+port1, unpPort1)
 	expBnd2 := fmt.Sprintf("0.0.0.0:%d->%s", offset+port2, unpPort2)
-	out, _ = dockerCmd(c, "ps", "-n=1")
+	out = dockerCmd(c, "ps", "-n=1")
 	if !strings.Contains(out, expBnd1) || !strings.Contains(out, expBnd2) {
 		c.Errorf("Cannot find expected port binding(s) (%s, %s) in docker ps output: %s", expBnd1, expBnd2, out)
 	}
@@ -226,11 +226,11 @@ func (s *DockerSuite) TestUnpublishedPortsInPsOutput(c *check.C) {
 	stopRemoveContainer(id, c)
 
 	// Run the container with explicit port bindings and no exposed ports
-	out, _ = dockerCmd(c, "run", "-d", "-p", pFlag1, "-p", pFlag2, "busybox", "sleep", "5")
+	out = dockerCmd(c, "run", "-d", "-p", pFlag1, "-p", pFlag2, "busybox", "sleep", "5")
 	id = strings.TrimSpace(out)
 
 	// Check docker ps o/p for last created container reports the specified port mappings
-	out, _ = dockerCmd(c, "ps", "-n=1")
+	out = dockerCmd(c, "ps", "-n=1")
 	if !strings.Contains(out, expBnd1) || !strings.Contains(out, expBnd2) {
 		c.Errorf("Cannot find expected port binding(s) (%s, %s) in docker ps output: %s", expBnd1, expBnd2, out)
 	}
@@ -241,18 +241,18 @@ func (s *DockerSuite) TestUnpublishedPortsInPsOutput(c *check.C) {
 	dockerCmd(c, "run", "-d", expose1, "-p", pFlag2, "busybox", "sleep", "5")
 
 	// Check docker ps o/p for last created container reports the specified unpublished port and port mapping
-	out, _ = dockerCmd(c, "ps", "-n=1")
+	out = dockerCmd(c, "ps", "-n=1")
 	if !strings.Contains(out, unpPort1) || !strings.Contains(out, expBnd2) {
 		c.Errorf("Missing unpublished ports or port binding (%s, %s) in docker ps output: %s", unpPort1, expBnd2, out)
 	}
 }
 
 func (s *DockerSuite) TestPortHostBinding(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "-p", "9876:80", "busybox",
+	out := dockerCmd(c, "run", "-d", "-p", "9876:80", "busybox",
 		"nc", "-l", "-p", "80")
 	firstID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "port", firstID, "80")
+	out = dockerCmd(c, "port", firstID, "80")
 
 	if !assertPortList(c, out, []string{"0.0.0.0:9876"}) {
 		c.Error("Port list is not correct")
@@ -270,11 +270,11 @@ func (s *DockerSuite) TestPortHostBinding(c *check.C) {
 }
 
 func (s *DockerSuite) TestPortExposeHostBinding(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "-P", "--expose", "80", "busybox",
+	out := dockerCmd(c, "run", "-d", "-P", "--expose", "80", "busybox",
 		"nc", "-l", "-p", "80")
 	firstID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "port", firstID, "80")
+	out = dockerCmd(c, "port", firstID, "80")
 
 	_, exposedPort, err := net.SplitHostPort(out)
 

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -18,17 +18,17 @@ import (
 )
 
 func (s *DockerSuite) TestPsListContainersBase(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	firstID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "run", "-d", "busybox", "top")
+	out = dockerCmd(c, "run", "-d", "busybox", "top")
 	secondID := strings.TrimSpace(out)
 
 	// not long running
-	out, _ = dockerCmd(c, "run", "-d", "busybox", "true")
+	out = dockerCmd(c, "run", "-d", "busybox", "true")
 	thirdID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "run", "-d", "busybox", "top")
+	out = dockerCmd(c, "run", "-d", "busybox", "top")
 	fourthID := strings.TrimSpace(out)
 
 	// make sure the second is running
@@ -41,13 +41,13 @@ func (s *DockerSuite) TestPsListContainersBase(c *check.C) {
 	c.Assert(waitRun(fourthID), check.IsNil)
 
 	// all
-	out, _ = dockerCmd(c, "ps", "-a")
+	out = dockerCmd(c, "ps", "-a")
 	if !assertContainerList(out, []string{fourthID, thirdID, secondID, firstID}) {
 		c.Errorf("ALL: Container list is not in the correct order: \n%s", out)
 	}
 
 	// running
-	out, _ = dockerCmd(c, "ps")
+	out = dockerCmd(c, "ps")
 	if !assertContainerList(out, []string{fourthID, secondID, firstID}) {
 		c.Errorf("RUNNING: Container list is not in the correct order: \n%s", out)
 	}
@@ -55,85 +55,85 @@ func (s *DockerSuite) TestPsListContainersBase(c *check.C) {
 	// from here all flag '-a' is ignored
 
 	// limit
-	out, _ = dockerCmd(c, "ps", "-n=2", "-a")
+	out = dockerCmd(c, "ps", "-n=2", "-a")
 	expected := []string{fourthID, thirdID}
 	if !assertContainerList(out, expected) {
 		c.Errorf("LIMIT & ALL: Container list is not in the correct order: \n%s", out)
 	}
 
-	out, _ = dockerCmd(c, "ps", "-n=2")
+	out = dockerCmd(c, "ps", "-n=2")
 	if !assertContainerList(out, expected) {
 		c.Errorf("LIMIT: Container list is not in the correct order: \n%s", out)
 	}
 
 	// since
-	out, _ = dockerCmd(c, "ps", "--since", firstID, "-a")
+	out = dockerCmd(c, "ps", "--since", firstID, "-a")
 	expected = []string{fourthID, thirdID, secondID}
 	if !assertContainerList(out, expected) {
 		c.Errorf("SINCE & ALL: Container list is not in the correct order: \n%s", out)
 	}
 
-	out, _ = dockerCmd(c, "ps", "--since", firstID)
+	out = dockerCmd(c, "ps", "--since", firstID)
 	if !assertContainerList(out, expected) {
 		c.Errorf("SINCE: Container list is not in the correct order: \n%s", out)
 	}
 
 	// before
-	out, _ = dockerCmd(c, "ps", "--before", thirdID, "-a")
+	out = dockerCmd(c, "ps", "--before", thirdID, "-a")
 	expected = []string{secondID, firstID}
 	if !assertContainerList(out, expected) {
 		c.Errorf("BEFORE & ALL: Container list is not in the correct order: \n%s", out)
 	}
 
-	out, _ = dockerCmd(c, "ps", "--before", thirdID)
+	out = dockerCmd(c, "ps", "--before", thirdID)
 	if !assertContainerList(out, expected) {
 		c.Errorf("BEFORE: Container list is not in the correct order: \n%s", out)
 	}
 
 	// since & before
-	out, _ = dockerCmd(c, "ps", "--since", firstID, "--before", fourthID, "-a")
+	out = dockerCmd(c, "ps", "--since", firstID, "--before", fourthID, "-a")
 	expected = []string{thirdID, secondID}
 	if !assertContainerList(out, expected) {
 		c.Errorf("SINCE, BEFORE & ALL: Container list is not in the correct order: \n%s", out)
 	}
 
-	out, _ = dockerCmd(c, "ps", "--since", firstID, "--before", fourthID)
+	out = dockerCmd(c, "ps", "--since", firstID, "--before", fourthID)
 	if !assertContainerList(out, expected) {
 		c.Errorf("SINCE, BEFORE: Container list is not in the correct order: \n%s", out)
 	}
 
 	// since & limit
-	out, _ = dockerCmd(c, "ps", "--since", firstID, "-n=2", "-a")
+	out = dockerCmd(c, "ps", "--since", firstID, "-n=2", "-a")
 	expected = []string{fourthID, thirdID}
 
 	if !assertContainerList(out, expected) {
 		c.Errorf("SINCE, LIMIT & ALL: Container list is not in the correct order: \n%s", out)
 	}
 
-	out, _ = dockerCmd(c, "ps", "--since", firstID, "-n=2")
+	out = dockerCmd(c, "ps", "--since", firstID, "-n=2")
 	if !assertContainerList(out, expected) {
 		c.Errorf("SINCE, LIMIT: Container list is not in the correct order: \n%s", out)
 	}
 
 	// before & limit
-	out, _ = dockerCmd(c, "ps", "--before", fourthID, "-n=1", "-a")
+	out = dockerCmd(c, "ps", "--before", fourthID, "-n=1", "-a")
 	expected = []string{thirdID}
 	if !assertContainerList(out, expected) {
 		c.Errorf("BEFORE, LIMIT & ALL: Container list is not in the correct order: \n%s", out)
 	}
 
-	out, _ = dockerCmd(c, "ps", "--before", fourthID, "-n=1")
+	out = dockerCmd(c, "ps", "--before", fourthID, "-n=1")
 	if !assertContainerList(out, expected) {
 		c.Errorf("BEFORE, LIMIT: Container list is not in the correct order: \n%s", out)
 	}
 
-	out, _ = dockerCmd(c, "ps", "--since", firstID, "--before", fourthID, "-n=1", "-a")
+	out = dockerCmd(c, "ps", "--since", firstID, "--before", fourthID, "-n=1", "-a")
 	expected = []string{thirdID}
 	if !assertContainerList(out, expected) {
 		c.Errorf("SINCE, BEFORE, LIMIT & ALL: Container list is not in the correct order: \n%s", out)
 	}
 
-	out, _ = dockerCmd(c, "ps", "--since", firstID, "--before", fourthID, "-n=1")
+	out = dockerCmd(c, "ps", "--since", firstID, "--before", fourthID, "-n=1")
 	if !assertContainerList(out, expected) {
 		c.Errorf("SINCE, BEFORE, LIMIT: Container list is not in the correct order: \n%s", out)
 	}
@@ -160,7 +160,7 @@ func assertContainerList(out string, expected []string) bool {
 func (s *DockerSuite) TestPsListContainersSize(c *check.C) {
 	dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
 
-	baseOut, _ := dockerCmd(c, "ps", "-s", "-n=1")
+	baseOut := dockerCmd(c, "ps", "-s", "-n=1")
 	baseLines := strings.Split(strings.Trim(baseOut, "\n "), "\n")
 	baseSizeIndex := strings.Index(baseLines[0], "SIZE")
 	baseFoundsize := baseLines[1][baseSizeIndex:]
@@ -170,7 +170,7 @@ func (s *DockerSuite) TestPsListContainersSize(c *check.C) {
 	}
 
 	name := "test_size"
-	out, _ := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo 1 > test")
+	out := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo 1 > test")
 	id, err := getIDByName(name)
 	if err != nil {
 		c.Fatal(err)
@@ -214,24 +214,24 @@ func (s *DockerSuite) TestPsListContainersFilterStatus(c *check.C) {
 	// this is because paused containers can't be controlled by signals
 
 	// start exited container
-	out, _ := dockerCmd(c, "run", "-d", "busybox")
+	out := dockerCmd(c, "run", "-d", "busybox")
 	firstID := strings.TrimSpace(out)
 
 	// make sure the exited cintainer is not running
 	dockerCmd(c, "wait", firstID)
 
 	// start running container
-	out, _ = dockerCmd(c, "run", "-itd", "busybox")
+	out = dockerCmd(c, "run", "-itd", "busybox")
 	secondID := strings.TrimSpace(out)
 
 	// filter containers by exited
-	out, _ = dockerCmd(c, "ps", "-q", "--filter=status=exited")
+	out = dockerCmd(c, "ps", "-q", "--filter=status=exited")
 	containerOut := strings.TrimSpace(out)
 	if containerOut != firstID[:12] {
 		c.Fatalf("Expected id %s, got %s for exited filter, output: %q", firstID[:12], containerOut, out)
 	}
 
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--filter=status=running")
+	out = dockerCmd(c, "ps", "-a", "-q", "--filter=status=running")
 	containerOut = strings.TrimSpace(out)
 	if containerOut != secondID[:12] {
 		c.Fatalf("Expected id %s, got %s for running filter, output: %q", secondID[:12], containerOut, out)
@@ -247,14 +247,14 @@ func (s *DockerSuite) TestPsListContainersFilterStatus(c *check.C) {
 func (s *DockerSuite) TestPsListContainersFilterID(c *check.C) {
 
 	// start container
-	out, _ := dockerCmd(c, "run", "-d", "busybox")
+	out := dockerCmd(c, "run", "-d", "busybox")
 	firstID := strings.TrimSpace(out)
 
 	// start another container
 	dockerCmd(c, "run", "-d", "busybox", "top")
 
 	// filter containers by id
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--filter=id="+firstID)
+	out = dockerCmd(c, "ps", "-a", "-q", "--filter=id="+firstID)
 	containerOut := strings.TrimSpace(out)
 	if containerOut != firstID[:12] {
 		c.Fatalf("Expected id %s, got %s for exited filter, output: %q", firstID[:12], containerOut, out)
@@ -265,14 +265,14 @@ func (s *DockerSuite) TestPsListContainersFilterID(c *check.C) {
 func (s *DockerSuite) TestPsListContainersFilterName(c *check.C) {
 
 	// start container
-	out, _ := dockerCmd(c, "run", "-d", "--name=a_name_to_match", "busybox")
+	out := dockerCmd(c, "run", "-d", "--name=a_name_to_match", "busybox")
 	firstID := strings.TrimSpace(out)
 
 	// start another container
 	dockerCmd(c, "run", "-d", "--name=b_name_to_match", "busybox", "top")
 
 	// filter containers by name
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--filter=name=a_name_to_match")
+	out = dockerCmd(c, "ps", "-a", "-q", "--filter=name=a_name_to_match")
 	containerOut := strings.TrimSpace(out)
 	if containerOut != firstID[:12] {
 		c.Fatalf("Expected id %s, got %s for exited filter, output: %q", firstID[:12], containerOut, out)
@@ -309,23 +309,23 @@ func (s *DockerSuite) TestPsListContainersFilterAncestorImage(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	// start containers
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
+	out := dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
 	firstID := strings.TrimSpace(out)
 
 	// start another container
-	out, _ = dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
+	out = dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
 	secondID := strings.TrimSpace(out)
 
 	// start third container
-	out, _ = dockerCmd(c, "run", "-d", imageName1, "echo", "hello")
+	out = dockerCmd(c, "run", "-d", imageName1, "echo", "hello")
 	thirdID := strings.TrimSpace(out)
 
 	// start fourth container
-	out, _ = dockerCmd(c, "run", "-d", imageName1Tagged, "echo", "hello")
+	out = dockerCmd(c, "run", "-d", imageName1Tagged, "echo", "hello")
 	fourthID := strings.TrimSpace(out)
 
 	// start fifth container
-	out, _ = dockerCmd(c, "run", "-d", imageName2, "echo", "hello")
+	out = dockerCmd(c, "run", "-d", imageName2, "echo", "hello")
 	fifthID := strings.TrimSpace(out)
 
 	var filterTestSuite = []struct {
@@ -352,12 +352,12 @@ func (s *DockerSuite) TestPsListContainersFilterAncestorImage(c *check.C) {
 	}
 
 	for _, filter := range filterTestSuite {
-		out, _ = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=ancestor="+filter.filterName)
+		out = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=ancestor="+filter.filterName)
 		checkPsAncestorFilterOutput(c, out, filter.filterName, filter.expectedIDs)
 	}
 
 	// Multiple ancestor filter
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=ancestor="+imageName2, "--filter=ancestor="+imageName1Tagged)
+	out = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=ancestor="+imageName2, "--filter=ancestor="+imageName1Tagged)
 	checkPsAncestorFilterOutput(c, out, imageName2+","+imageName1Tagged, []string{fourthID, fifthID})
 }
 
@@ -389,40 +389,40 @@ func checkPsAncestorFilterOutput(c *check.C, out string, filterName string, expe
 
 func (s *DockerSuite) TestPsListContainersFilterLabel(c *check.C) {
 	// start container
-	out, _ := dockerCmd(c, "run", "-d", "-l", "match=me", "-l", "second=tag", "busybox")
+	out := dockerCmd(c, "run", "-d", "-l", "match=me", "-l", "second=tag", "busybox")
 	firstID := strings.TrimSpace(out)
 
 	// start another container
-	out, _ = dockerCmd(c, "run", "-d", "-l", "match=me too", "busybox")
+	out = dockerCmd(c, "run", "-d", "-l", "match=me too", "busybox")
 	secondID := strings.TrimSpace(out)
 
 	// start third container
-	out, _ = dockerCmd(c, "run", "-d", "-l", "nomatch=me", "busybox")
+	out = dockerCmd(c, "run", "-d", "-l", "nomatch=me", "busybox")
 	thirdID := strings.TrimSpace(out)
 
 	// filter containers by exact match
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me")
+	out = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me")
 	containerOut := strings.TrimSpace(out)
 	if containerOut != firstID {
 		c.Fatalf("Expected id %s, got %s for exited filter, output: %q", firstID, containerOut, out)
 	}
 
 	// filter containers by two labels
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me", "--filter=label=second=tag")
+	out = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me", "--filter=label=second=tag")
 	containerOut = strings.TrimSpace(out)
 	if containerOut != firstID {
 		c.Fatalf("Expected id %s, got %s for exited filter, output: %q", firstID, containerOut, out)
 	}
 
 	// filter containers by two labels, but expect not found because of AND behavior
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me", "--filter=label=second=tag-no")
+	out = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=label=match=me", "--filter=label=second=tag-no")
 	containerOut = strings.TrimSpace(out)
 	if containerOut != "" {
 		c.Fatalf("Expected nothing, got %s for exited filter, output: %q", containerOut, out)
 	}
 
 	// filter containers by exact key
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=label=match")
+	out = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=label=match")
 	containerOut = strings.TrimSpace(out)
 	if (!strings.Contains(containerOut, firstID) || !strings.Contains(containerOut, secondID)) || strings.Contains(containerOut, thirdID) {
 		c.Fatalf("Expected ids %s,%s, got %s for exited filter, output: %q", firstID, secondID, containerOut, out)
@@ -463,7 +463,7 @@ func (s *DockerSuite) TestPsListContainersFilterExited(c *check.C) {
 	}
 
 	// filter containers by exited=0
-	out, _ := dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=exited=0")
+	out := dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=exited=0")
 	ids := strings.Split(strings.TrimSpace(out), "\n")
 	if len(ids) != 2 {
 		c.Fatalf("Should be 2 zero exited containers got %d: %s", len(ids), out)
@@ -475,7 +475,7 @@ func (s *DockerSuite) TestPsListContainersFilterExited(c *check.C) {
 		c.Fatalf("Second in list should be %q, got %q", firstZero, ids[1])
 	}
 
-	out, _ = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=exited=1")
+	out = dockerCmd(c, "ps", "-a", "-q", "--no-trunc", "--filter=exited=1")
 	ids = strings.Split(strings.TrimSpace(out), "\n")
 	if len(ids) != 2 {
 		c.Fatalf("Should be 2 zero exited containers got %d", len(ids))
@@ -494,22 +494,22 @@ func (s *DockerSuite) TestPsRightTagName(c *check.C) {
 	dockerCmd(c, "tag", "busybox", tag)
 
 	var id1 string
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	id1 = strings.TrimSpace(string(out))
 
 	var id2 string
-	out, _ = dockerCmd(c, "run", "-d", tag, "top")
+	out = dockerCmd(c, "run", "-d", tag, "top")
 	id2 = strings.TrimSpace(string(out))
 
 	var imageID string
-	out, _ = dockerCmd(c, "inspect", "-f", "{{.Id}}", "busybox")
+	out = dockerCmd(c, "inspect", "-f", "{{.Id}}", "busybox")
 	imageID = strings.TrimSpace(string(out))
 
 	var id3 string
-	out, _ = dockerCmd(c, "run", "-d", imageID, "top")
+	out = dockerCmd(c, "run", "-d", imageID, "top")
 	id3 = strings.TrimSpace(string(out))
 
-	out, _ = dockerCmd(c, "ps", "--no-trunc")
+	out = dockerCmd(c, "ps", "--no-trunc")
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
 	// skip header
 	lines = lines[1:]
@@ -541,7 +541,7 @@ func (s *DockerSuite) TestPsLinkedWithNoTrunc(c *check.C) {
 	dockerCmd(c, "run", "--name=first", "-d", "busybox", "top")
 	dockerCmd(c, "run", "--name=second", "--link=first:first", "-d", "busybox", "top")
 
-	out, _ := dockerCmd(c, "ps", "--no-trunc")
+	out := dockerCmd(c, "ps", "--no-trunc")
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
 	// strip header
 	lines = lines[1:]
@@ -561,7 +561,7 @@ func (s *DockerSuite) TestPsGroupPortRange(c *check.C) {
 	portRange := "3800-3900"
 	dockerCmd(c, "run", "-d", "--name", "porttest", "-p", portRange+":"+portRange, "busybox", "top")
 
-	out, _ := dockerCmd(c, "ps")
+	out := dockerCmd(c, "ps")
 
 	// check that the port range is in the output
 	if !strings.Contains(string(out), portRange) {
@@ -573,7 +573,7 @@ func (s *DockerSuite) TestPsGroupPortRange(c *check.C) {
 func (s *DockerSuite) TestPsWithSize(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", "sizetest", "busybox", "top")
 
-	out, _ := dockerCmd(c, "ps", "--size")
+	out := dockerCmd(c, "ps", "--size")
 	if !strings.Contains(out, "virtual") {
 		c.Fatalf("docker ps with --size should show virtual size of container")
 	}
@@ -581,18 +581,18 @@ func (s *DockerSuite) TestPsWithSize(c *check.C) {
 
 func (s *DockerSuite) TestPsListContainersFilterCreated(c *check.C) {
 	// create a container
-	out, _ := dockerCmd(c, "create", "busybox")
+	out := dockerCmd(c, "create", "busybox")
 	cID := strings.TrimSpace(out)
 	shortCID := cID[:12]
 
 	// Make sure it DOESN'T show up w/o a '-a' for normal 'ps'
-	out, _ = dockerCmd(c, "ps", "-q")
+	out = dockerCmd(c, "ps", "-q")
 	if strings.Contains(out, shortCID) {
 		c.Fatalf("Should have not seen '%s' in ps output:\n%s", shortCID, out)
 	}
 
 	// Make sure it DOES show up as 'Created' for 'ps -a'
-	out, _ = dockerCmd(c, "ps", "-a")
+	out = dockerCmd(c, "ps", "-a")
 
 	hits := 0
 	for _, line := range strings.Split(out, "\n") {
@@ -610,7 +610,7 @@ func (s *DockerSuite) TestPsListContainersFilterCreated(c *check.C) {
 	}
 
 	// filter containers by 'create' - note, no -a needed
-	out, _ = dockerCmd(c, "ps", "-q", "-f", "status=created")
+	out = dockerCmd(c, "ps", "-q", "-f", "status=created")
 	containerOut := strings.TrimSpace(out)
 	if !strings.HasPrefix(cID, containerOut) {
 		c.Fatalf("Expected id %s, got %s for filter, out: %s", cID, containerOut, out)
@@ -623,7 +623,7 @@ func (s *DockerSuite) TestPsFormatMultiNames(c *check.C) {
 	dockerCmd(c, "run", "--name=parent", "--link=child:linkedone", "-d", "busybox", "top")
 
 	//use the new format capabilities to only list the names and --no-trunc to get all names
-	out, _ := dockerCmd(c, "ps", "--format", "{{.Names}}", "--no-trunc")
+	out := dockerCmd(c, "ps", "--format", "{{.Names}}", "--no-trunc")
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
 	expected := []string{"parent", "child,parent/linkedone"}
 	var names []string
@@ -635,7 +635,7 @@ func (s *DockerSuite) TestPsFormatMultiNames(c *check.C) {
 	}
 
 	//now list without turning off truncation and make sure we only get the non-link names
-	out, _ = dockerCmd(c, "ps", "--format", "{{.Names}}")
+	out = dockerCmd(c, "ps", "--format", "{{.Names}}")
 	lines = strings.Split(strings.TrimSpace(string(out)), "\n")
 	expected = []string{"parent", "child"}
 	var truncNames []string
@@ -650,14 +650,14 @@ func (s *DockerSuite) TestPsFormatMultiNames(c *check.C) {
 
 func (s *DockerSuite) TestPsFormatHeaders(c *check.C) {
 	// make sure no-container "docker ps" still prints the header row
-	out, _ := dockerCmd(c, "ps", "--format", "table {{.ID}}")
+	out := dockerCmd(c, "ps", "--format", "table {{.ID}}")
 	if out != "CONTAINER ID\n" {
 		c.Fatalf(`Expected 'CONTAINER ID\n', got %v`, out)
 	}
 
 	// verify that "docker ps" with a container still prints the header row also
 	dockerCmd(c, "run", "--name=test", "-d", "busybox", "top")
-	out, _ = dockerCmd(c, "ps", "--format", "table {{.Names}}")
+	out = dockerCmd(c, "ps", "--format", "table {{.Names}}")
 	if out != "NAMES\ntest\n" {
 		c.Fatalf(`Expected 'NAMES\ntest\n', got %v`, out)
 	}
@@ -674,10 +674,10 @@ func (s *DockerSuite) TestPsDefaultFormatAndQuiet(c *check.C) {
 	err = ioutil.WriteFile(filepath.Join(d, "config.json"), []byte(config), 0644)
 	c.Assert(err, check.IsNil)
 
-	out, _ := dockerCmd(c, "run", "--name=test", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "--name=test", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "--config", d, "ps", "-q")
+	out = dockerCmd(c, "--config", d, "ps", "-q")
 	if !strings.HasPrefix(id, strings.TrimSpace(out)) {
 		c.Fatalf("Expected to print only the container id, got %v\n", out)
 	}

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -105,7 +105,7 @@ func (s *DockerSuite) TestPullImageOfficialNames(c *check.C) {
 		}
 
 		// ensure we don't have multiple image names.
-		out, _ = dockerCmd(c, "images")
+		out = dockerCmd(c, "images")
 		if strings.Contains(out, name) {
 			c.Errorf("images should not have listed '%s'", name)
 		}
@@ -136,11 +136,11 @@ func (s *DockerSuite) TestPullImageWithAllTagFromCentralRegistry(c *check.C) {
 
 	dockerCmd(c, "pull", "busybox")
 
-	outImageCmd, _ := dockerCmd(c, "images", "busybox")
+	outImageCmd := dockerCmd(c, "images", "busybox")
 
 	dockerCmd(c, "pull", "--all-tags=true", "busybox")
 
-	outImageAllTagCmd, _ := dockerCmd(c, "images", "busybox")
+	outImageAllTagCmd := dockerCmd(c, "images", "busybox")
 
 	if strings.Count(outImageCmd, "busybox") >= strings.Count(outImageAllTagCmd, "busybox") {
 		c.Fatalf("Pulling with all tags should get more images")
@@ -149,7 +149,7 @@ func (s *DockerSuite) TestPullImageWithAllTagFromCentralRegistry(c *check.C) {
 	// FIXME has probably no effect (tags already pushed)
 	dockerCmd(c, "pull", "-a", "busybox")
 
-	outImageAllTagCmd, _ = dockerCmd(c, "images", "busybox")
+	outImageAllTagCmd = dockerCmd(c, "images", "busybox")
 
 	if strings.Count(outImageCmd, "busybox") >= strings.Count(outImageAllTagCmd, "busybox") {
 		c.Fatalf("Pulling with all tags should get more images")

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -63,7 +63,7 @@ func (s *DockerRegistrySuite) TestPushMultipleTags(c *check.C) {
 	dockerCmd(c, "push", repoName)
 
 	// Ensure layer list is equivalent for repoTag1 and repoTag2
-	out1, _ := dockerCmd(c, "pull", repoTag1)
+	out1 := dockerCmd(c, "pull", repoTag1)
 	if strings.Contains(out1, "Tag t1 not found") {
 		c.Fatalf("Unable to pull pushed image: %s", out1)
 	}
@@ -75,7 +75,7 @@ func (s *DockerRegistrySuite) TestPushMultipleTags(c *check.C) {
 		}
 	}
 
-	out2, _ := dockerCmd(c, "pull", repoTag2)
+	out2 := dockerCmd(c, "pull", repoTag2)
 	if strings.Contains(out2, "Tag t2 not found") {
 		c.Fatalf("Unable to pull pushed image: %s", out1)
 	}

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (s *DockerSuite) TestRenameStoppedContainer(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--name", "first_name", "-d", "busybox", "sh")
+	out := dockerCmd(c, "run", "--name", "first_name", "-d", "busybox", "sh")
 
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "wait", cleanedContainerID)
@@ -28,7 +28,7 @@ func (s *DockerSuite) TestRenameStoppedContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRenameRunningContainer(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--name", "first_name", "-d", "busybox", "sh")
+	out := dockerCmd(c, "run", "--name", "first_name", "-d", "busybox", "sh")
 
 	newName := "new_name" + stringid.GenerateNonCryptoID()
 	cleanedContainerID := strings.TrimSpace(out)

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -7,39 +7,39 @@ import (
 )
 
 func (s *DockerSuite) TestRestartStoppedContainer(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "echo", "foobar")
+	out := dockerCmd(c, "run", "-d", "busybox", "echo", "foobar")
 
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "wait", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "logs", cleanedContainerID)
+	out = dockerCmd(c, "logs", cleanedContainerID)
 	if out != "foobar\n" {
 		c.Errorf("container should've printed 'foobar'")
 	}
 
 	dockerCmd(c, "restart", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "logs", cleanedContainerID)
+	out = dockerCmd(c, "logs", cleanedContainerID)
 	if out != "foobar\nfoobar\n" {
 		c.Errorf("container should've printed 'foobar' twice, got %v", out)
 	}
 }
 
 func (s *DockerSuite) TestRestartRunningContainer(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "echo foobar && sleep 30 && echo 'should not print this'")
+	out := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "echo foobar && sleep 30 && echo 'should not print this'")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
 	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 
-	out, _ = dockerCmd(c, "logs", cleanedContainerID)
+	out = dockerCmd(c, "logs", cleanedContainerID)
 	if out != "foobar\n" {
 		c.Errorf("container should've printed 'foobar'")
 	}
 
 	dockerCmd(c, "restart", "-t", "1", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "logs", cleanedContainerID)
+	out = dockerCmd(c, "logs", cleanedContainerID)
 
 	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 
@@ -50,10 +50,10 @@ func (s *DockerSuite) TestRestartRunningContainer(c *check.C) {
 
 // Test that restarting a container with a volume does not create a new volume on restart. Regression test for #819.
 func (s *DockerSuite) TestRestartWithVolumes(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "-v", "/test", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "-v", "/test", "busybox", "top")
 
 	cleanedContainerID := strings.TrimSpace(out)
-	out, _ = dockerCmd(c, "inspect", "--format", "{{ len .Mounts }}", cleanedContainerID)
+	out = dockerCmd(c, "inspect", "--format", "{{ len .Mounts }}", cleanedContainerID)
 
 	if out = strings.Trim(out, " \n\r"); out != "1" {
 		c.Errorf("expect 1 volume received %s", out)
@@ -64,7 +64,7 @@ func (s *DockerSuite) TestRestartWithVolumes(c *check.C) {
 
 	dockerCmd(c, "restart", cleanedContainerID)
 
-	out, _ = dockerCmd(c, "inspect", "--format", "{{ len .Mounts }}", cleanedContainerID)
+	out = dockerCmd(c, "inspect", "--format", "{{ len .Mounts }}", cleanedContainerID)
 	if out = strings.Trim(out, " \n\r"); out != "1" {
 		c.Errorf("expect 1 volume after restart received %s", out)
 	}
@@ -78,7 +78,7 @@ func (s *DockerSuite) TestRestartWithVolumes(c *check.C) {
 }
 
 func (s *DockerSuite) TestRestartPolicyNO(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "--restart=no", "busybox", "false")
+	out := dockerCmd(c, "run", "-d", "--restart=no", "busybox", "false")
 
 	id := strings.TrimSpace(string(out))
 	name, err := inspectField(id, "HostConfig.RestartPolicy.Name")
@@ -89,7 +89,7 @@ func (s *DockerSuite) TestRestartPolicyNO(c *check.C) {
 }
 
 func (s *DockerSuite) TestRestartPolicyAlways(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "--restart=always", "busybox", "false")
+	out := dockerCmd(c, "run", "-d", "--restart=always", "busybox", "false")
 
 	id := strings.TrimSpace(string(out))
 	name, err := inspectField(id, "HostConfig.RestartPolicy.Name")
@@ -108,7 +108,7 @@ func (s *DockerSuite) TestRestartPolicyAlways(c *check.C) {
 }
 
 func (s *DockerSuite) TestRestartPolicyOnFailure(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:1", "busybox", "false")
+	out := dockerCmd(c, "run", "-d", "--restart=on-failure:1", "busybox", "false")
 
 	id := strings.TrimSpace(string(out))
 	name, err := inspectField(id, "HostConfig.RestartPolicy.Name")
@@ -122,7 +122,7 @@ func (s *DockerSuite) TestRestartPolicyOnFailure(c *check.C) {
 // a good container with --restart=on-failure:3
 // MaximumRetryCount!=0; RestartCount=0
 func (s *DockerSuite) TestContainerRestartwithGoodContainer(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "true")
+	out := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "true")
 
 	id := strings.TrimSpace(string(out))
 	if err := waitInspect(id, "{{ .State.Restarting }} {{ .State.Running }}", "false false", 5); err != nil {

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -29,26 +29,26 @@ func (s *DockerSuite) TestRmiWithContainerFails(c *check.C) {
 	}
 
 	// make sure it didn't delete the busybox name
-	images, _ := dockerCmd(c, "images")
+	images := dockerCmd(c, "images")
 	if !strings.Contains(images, "busybox") {
 		c.Fatalf("The name 'busybox' should not have been removed from images: %q", images)
 	}
 }
 
 func (s *DockerSuite) TestRmiTag(c *check.C) {
-	imagesBefore, _ := dockerCmd(c, "images", "-a")
+	imagesBefore := dockerCmd(c, "images", "-a")
 	dockerCmd(c, "tag", "busybox", "utest:tag1")
 	dockerCmd(c, "tag", "busybox", "utest/docker:tag2")
 	dockerCmd(c, "tag", "busybox", "utest:5000/docker:tag3")
 	{
-		imagesAfter, _ := dockerCmd(c, "images", "-a")
+		imagesAfter := dockerCmd(c, "images", "-a")
 		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+3 {
 			c.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
 		}
 	}
 	dockerCmd(c, "rmi", "utest/docker:tag2")
 	{
-		imagesAfter, _ := dockerCmd(c, "images", "-a")
+		imagesAfter := dockerCmd(c, "images", "-a")
 		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+2 {
 			c.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
 		}
@@ -56,7 +56,7 @@ func (s *DockerSuite) TestRmiTag(c *check.C) {
 	}
 	dockerCmd(c, "rmi", "utest:5000/docker:tag3")
 	{
-		imagesAfter, _ := dockerCmd(c, "images", "-a")
+		imagesAfter := dockerCmd(c, "images", "-a")
 		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+1 {
 			c.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
 		}
@@ -64,7 +64,7 @@ func (s *DockerSuite) TestRmiTag(c *check.C) {
 	}
 	dockerCmd(c, "rmi", "utest:tag1")
 	{
-		imagesAfter, _ := dockerCmd(c, "images", "-a")
+		imagesAfter := dockerCmd(c, "images", "-a")
 		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+0 {
 			c.Fatalf("before: %q\n\nafter: %q\n", imagesBefore, imagesAfter)
 		}
@@ -84,11 +84,11 @@ func (s *DockerSuite) TestRmiImgIDMultipleTag(c *check.C) {
 		c.Fatalf("failed to commit a new busybox-one:%s, %v", out, err)
 	}
 
-	imagesBefore, _ := dockerCmd(c, "images", "-a")
+	imagesBefore := dockerCmd(c, "images", "-a")
 	dockerCmd(c, "tag", "busybox-one", "busybox-one:tag1")
 	dockerCmd(c, "tag", "busybox-one", "busybox-one:tag2")
 
-	imagesAfter, _ := dockerCmd(c, "images", "-a")
+	imagesAfter := dockerCmd(c, "images", "-a")
 	if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+2 {
 		c.Fatalf("tag busybox to create 2 more images with same imageID; docker images shows: %q\n", imagesAfter)
 	}
@@ -114,7 +114,7 @@ func (s *DockerSuite) TestRmiImgIDMultipleTag(c *check.C) {
 	dockerCmd(c, "stop", containerID)
 	dockerCmd(c, "rmi", "-f", imgID)
 
-	imagesAfter, _ = dockerCmd(c, "images", "-a")
+	imagesAfter = dockerCmd(c, "images", "-a")
 	if strings.Contains(imagesAfter, imgID[:12]) {
 		c.Fatalf("rmi -f %s failed, image still exists: %q\n\n", imgID, imagesAfter)
 	}
@@ -132,13 +132,13 @@ func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
 		c.Fatalf("failed to commit a new busybox-test:%s, %v", out, err)
 	}
 
-	imagesBefore, _ := dockerCmd(c, "images", "-a")
+	imagesBefore := dockerCmd(c, "images", "-a")
 	dockerCmd(c, "tag", "busybox-test", "utest:tag1")
 	dockerCmd(c, "tag", "busybox-test", "utest:tag2")
 	dockerCmd(c, "tag", "busybox-test", "utest/docker:tag3")
 	dockerCmd(c, "tag", "busybox-test", "utest:5000/docker:tag4")
 	{
-		imagesAfter, _ := dockerCmd(c, "images", "-a")
+		imagesAfter := dockerCmd(c, "images", "-a")
 		if strings.Count(imagesAfter, "\n") != strings.Count(imagesBefore, "\n")+4 {
 			c.Fatalf("tag busybox to create 4 more images with same imageID; docker images shows: %q\n", imagesAfter)
 		}
@@ -154,7 +154,7 @@ func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
 
 	dockerCmd(c, "rmi", "-f", imgID)
 	{
-		imagesAfter, _ := dockerCmd(c, "images", "-a")
+		imagesAfter := dockerCmd(c, "images", "-a")
 		if strings.Contains(imagesAfter, imgID[:12]) {
 			c.Fatalf("rmi -f %s failed, image still exists: %q\n\n", imgID, imagesAfter)
 		}
@@ -306,7 +306,7 @@ RUN echo 2 #layer2
 	_, err := buildImage(image, dockerfile, false)
 	c.Assert(err, check.IsNil)
 
-	out, _ := dockerCmd(c, "history", "-q", image)
+	out := dockerCmd(c, "history", "-q", image)
 	ids := strings.Split(out, "\n")
 	idToTag := ids[2]
 
@@ -317,7 +317,7 @@ RUN echo 2 #layer2
 	dockerCmd(c, "run", "-d", image, "true")
 
 	// See if the "tmp2" can be untagged.
-	out, _ = dockerCmd(c, "rmi", newTag)
+	out = dockerCmd(c, "rmi", newTag)
 	if d := strings.Count(out, "Untagged: "); d != 1 {
 		c.Log(out)
 		c.Fatalf("Expected 1 untagged entry got %d: %q", d, out)
@@ -325,7 +325,7 @@ RUN echo 2 #layer2
 
 	// Now let's add the tag again and create a container based on it.
 	dockerCmd(c, "tag", idToTag, newTag)
-	out, _ = dockerCmd(c, "run", "-d", newTag, "true")
+	out = dockerCmd(c, "run", "-d", newTag, "true")
 	cid := strings.TrimSpace(out)
 
 	// At this point we have 2 containers, one based on layer2 and another based on layer0.
@@ -337,7 +337,7 @@ RUN echo 2 #layer2
 	}
 
 	// Add the -f flag and test again.
-	out, _ = dockerCmd(c, "rmi", "-f", newTag)
+	out = dockerCmd(c, "rmi", "-f", newTag)
 	if !strings.Contains(out, fmt.Sprintf("Untagged: %s:latest", newTag)) {
 		c.Log(out)
 		c.Fatalf("%q should be allowed to untag with the -f flag", newTag)

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -25,7 +25,7 @@ import (
 
 // "test123" should be printed by docker run
 func (s *DockerSuite) TestRunEchoStdout(c *check.C) {
-	out, _ := dockerCmd(c, "run", "busybox", "echo", "test123")
+	out := dockerCmd(c, "run", "busybox", "echo", "test123")
 	if out != "test123\n" {
 		c.Fatalf("container should've printed 'test123'")
 	}
@@ -33,7 +33,7 @@ func (s *DockerSuite) TestRunEchoStdout(c *check.C) {
 
 // "test" should be printed
 func (s *DockerSuite) TestRunEchoNamedContainer(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--name", "testfoonamedcontainer", "busybox", "echo", "test")
+	out := dockerCmd(c, "run", "--name", "testfoonamedcontainer", "busybox", "echo", "test")
 	if out != "test\n" {
 		c.Errorf("container should've printed 'test'")
 	}
@@ -41,7 +41,7 @@ func (s *DockerSuite) TestRunEchoNamedContainer(c *check.C) {
 
 // docker run should not leak file descriptors
 func (s *DockerSuite) TestRunLeakyFileDescriptors(c *check.C) {
-	out, _ := dockerCmd(c, "run", "busybox", "ls", "-C", "/proc/self/fd")
+	out := dockerCmd(c, "run", "busybox", "ls", "-C", "/proc/self/fd")
 
 	// normally, we should only get 0, 1, and 2, but 3 gets created by "ls" when it does "opendir" on the "fd" directory
 	if out != "0  1  2  3\n" {
@@ -87,7 +87,7 @@ func (s *DockerSuite) TestRunStdinPipe(c *check.C) {
 	out = strings.TrimSpace(out)
 	dockerCmd(c, "wait", out)
 
-	logsOut, _ := dockerCmd(c, "logs", out)
+	logsOut := dockerCmd(c, "logs", out)
 
 	containerLogs := strings.TrimSpace(logsOut)
 	if containerLogs != "blahblah" {
@@ -99,12 +99,12 @@ func (s *DockerSuite) TestRunStdinPipe(c *check.C) {
 
 // the container's ID should be printed when starting a container in detached mode
 func (s *DockerSuite) TestRunDetachedContainerIDPrinting(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
+	out := dockerCmd(c, "run", "-d", "busybox", "true")
 
 	out = strings.TrimSpace(out)
 	dockerCmd(c, "wait", out)
 
-	rmOut, _ := dockerCmd(c, "rm", out)
+	rmOut := dockerCmd(c, "rm", out)
 
 	rmOut = strings.TrimSpace(rmOut)
 	if rmOut != out {
@@ -114,14 +114,14 @@ func (s *DockerSuite) TestRunDetachedContainerIDPrinting(c *check.C) {
 
 // the working directory should be set correctly
 func (s *DockerSuite) TestRunWorkingDirectory(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-w", "/root", "busybox", "pwd")
+	out := dockerCmd(c, "run", "-w", "/root", "busybox", "pwd")
 
 	out = strings.TrimSpace(out)
 	if out != "/root" {
 		c.Errorf("-w failed to set working directory")
 	}
 
-	out, _ = dockerCmd(c, "run", "--workdir", "/root", "busybox", "pwd")
+	out = dockerCmd(c, "run", "--workdir", "/root", "busybox", "pwd")
 	out = strings.TrimSpace(out)
 	if out != "/root" {
 		c.Errorf("--workdir failed to set working directory")
@@ -154,7 +154,7 @@ func (s *DockerSuite) TestRunLinksContainerWithContainerName(c *check.C) {
 	ip, err := inspectField("parent", "NetworkSettings.IPAddress")
 	c.Assert(err, check.IsNil)
 
-	out, _ := dockerCmd(c, "run", "--link", "parent:test", "busybox", "/bin/cat", "/etc/hosts")
+	out := dockerCmd(c, "run", "--link", "parent:test", "busybox", "/bin/cat", "/etc/hosts")
 	if !strings.Contains(out, ip+"	test") {
 		c.Fatalf("use a container name to link target failed")
 	}
@@ -162,13 +162,13 @@ func (s *DockerSuite) TestRunLinksContainerWithContainerName(c *check.C) {
 
 //test --link use container id to link target
 func (s *DockerSuite) TestRunLinksContainerWithContainerId(c *check.C) {
-	cID, _ := dockerCmd(c, "run", "-i", "-t", "-d", "busybox")
+	cID := dockerCmd(c, "run", "-i", "-t", "-d", "busybox")
 
 	cID = strings.TrimSpace(cID)
 	ip, err := inspectField(cID, "NetworkSettings.IPAddress")
 	c.Assert(err, check.IsNil)
 
-	out, _ := dockerCmd(c, "run", "--link", cID+":test", "busybox", "/bin/cat", "/etc/hosts")
+	out := dockerCmd(c, "run", "--link", cID+":test", "busybox", "/bin/cat", "/etc/hosts")
 	if !strings.Contains(out, ip+"	test") {
 		c.Fatalf("use a container id to link target failed")
 	}
@@ -187,15 +187,9 @@ func (s *DockerSuite) TestRunWithDaemonFlags(c *check.C) {
 
 // Regression test for #4979
 func (s *DockerSuite) TestRunWithVolumesFromExited(c *check.C) {
-	out, exitCode := dockerCmd(c, "run", "--name", "test-data", "--volume", "/some/dir", "busybox", "touch", "/some/dir/file")
-	if exitCode != 0 {
-		c.Fatal("1", out, exitCode)
-	}
+	dockerCmd(c, "run", "--name", "test-data", "--volume", "/some/dir", "busybox", "touch", "/some/dir/file")
 
-	out, exitCode = dockerCmd(c, "run", "--volumes-from", "test-data", "busybox", "cat", "/some/dir/file")
-	if exitCode != 0 {
-		c.Fatal("2", out, exitCode)
-	}
+	dockerCmd(c, "run", "--volumes-from", "test-data", "busybox", "cat", "/some/dir/file")
 }
 
 // Volume path is a symlink which also exists on the host, and the host side is a file not a dir
@@ -388,21 +382,21 @@ func (s *DockerSuite) TestRunExitCode(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunUserDefaultsToRoot(c *check.C) {
-	out, _ := dockerCmd(c, "run", "busybox", "id")
+	out := dockerCmd(c, "run", "busybox", "id")
 	if !strings.Contains(out, "uid=0(root) gid=0(root)") {
 		c.Fatalf("expected root user got %s", out)
 	}
 }
 
 func (s *DockerSuite) TestRunUserByName(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-u", "root", "busybox", "id")
+	out := dockerCmd(c, "run", "-u", "root", "busybox", "id")
 	if !strings.Contains(out, "uid=0(root) gid=0(root)") {
 		c.Fatalf("expected root user got %s", out)
 	}
 }
 
 func (s *DockerSuite) TestRunUserByID(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-u", "1", "busybox", "id")
+	out := dockerCmd(c, "run", "-u", "1", "busybox", "id")
 	if !strings.Contains(out, "uid=1(daemon) gid=1(daemon)") {
 		c.Fatalf("expected daemon user got %s", out)
 	}
@@ -601,21 +595,21 @@ func (s *DockerSuite) TestRunNetHostNotAllowedWithLinks(c *check.C) {
 // codepath is executed with "docker run -h <hostname>".  Both were manually
 // tested, but this testcase takes the simpler path of using "run -h .."
 func (s *DockerSuite) TestRunFullHostnameSet(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-h", "foo.bar.baz", "busybox", "hostname")
+	out := dockerCmd(c, "run", "-h", "foo.bar.baz", "busybox", "hostname")
 	if actual := strings.Trim(out, "\r\n"); actual != "foo.bar.baz" {
 		c.Fatalf("expected hostname 'foo.bar.baz', received %s", actual)
 	}
 }
 
 func (s *DockerSuite) TestRunPrivilegedCanMknod(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
+	out := dockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
 	}
 }
 
 func (s *DockerSuite) TestRunUnprivilegedCanMknod(c *check.C) {
-	out, _ := dockerCmd(c, "run", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
+	out := dockerCmd(c, "run", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
 	}
@@ -661,7 +655,7 @@ func (s *DockerSuite) TestRunCapDropALLCannotMknod(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapDropALLAddMknodCanMknod(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=MKNOD", "--cap-add=SETGID", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
+	out := dockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=MKNOD", "--cap-add=SETGID", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
@@ -676,7 +670,7 @@ func (s *DockerSuite) TestRunCapAddInvalid(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapAddCanDownInterface(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--cap-add=NET_ADMIN", "busybox", "sh", "-c", "ip link set eth0 down && echo ok")
+	out := dockerCmd(c, "run", "--cap-add=NET_ADMIN", "busybox", "sh", "-c", "ip link set eth0 down && echo ok")
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
@@ -684,7 +678,7 @@ func (s *DockerSuite) TestRunCapAddCanDownInterface(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapAddALLCanDownInterface(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--cap-add=ALL", "busybox", "sh", "-c", "ip link set eth0 down && echo ok")
+	out := dockerCmd(c, "run", "--cap-add=ALL", "busybox", "sh", "-c", "ip link set eth0 down && echo ok")
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
@@ -703,7 +697,7 @@ func (s *DockerSuite) TestRunCapAddALLDropNetAdminCanDownInterface(c *check.C) {
 
 func (s *DockerSuite) TestRunGroupAdd(c *check.C) {
 	testRequires(c, NativeExecDriver)
-	out, _ := dockerCmd(c, "run", "--group-add=audio", "--group-add=dbus", "--group-add=777", "busybox", "sh", "-c", "id")
+	out := dockerCmd(c, "run", "--group-add=audio", "--group-add=dbus", "--group-add=777", "busybox", "sh", "-c", "id")
 
 	groupsList := "uid=0(root) gid=0(root) groups=10(wheel),29(audio),81(dbus),777"
 	if actual := strings.Trim(out, "\r\n"); actual != groupsList {
@@ -712,7 +706,7 @@ func (s *DockerSuite) TestRunGroupAdd(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunPrivilegedCanMount(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "mount -t tmpfs none /tmp && echo ok")
+	out := dockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "mount -t tmpfs none /tmp && echo ok")
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
@@ -749,13 +743,11 @@ func (s *DockerSuite) TestRunProcNotWritableInNonPrivilegedContainers(c *check.C
 }
 
 func (s *DockerSuite) TestRunProcWritableInPrivilegedContainers(c *check.C) {
-	if _, code := dockerCmd(c, "run", "--privileged", "busybox", "touch", "/proc/sysrq-trigger"); code != 0 {
-		c.Fatalf("proc should be writable in privileged container")
-	}
+	dockerCmd(c, "run", "--privileged", "busybox", "touch", "/proc/sysrq-trigger")
 }
 
 func (s *DockerSuite) TestRunDeviceNumbers(c *check.C) {
-	out, _ := dockerCmd(c, "run", "busybox", "sh", "-c", "ls -l /dev/null")
+	out := dockerCmd(c, "run", "busybox", "sh", "-c", "ls -l /dev/null")
 	deviceLineFields := strings.Fields(out)
 	deviceLineFields[6] = ""
 	deviceLineFields[7] = ""
@@ -768,7 +760,7 @@ func (s *DockerSuite) TestRunDeviceNumbers(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunThatCharacterDevicesActLikeCharacterDevices(c *check.C) {
-	out, _ := dockerCmd(c, "run", "busybox", "sh", "-c", "dd if=/dev/zero of=/zero bs=1k count=5 2> /dev/null ; du -h /zero")
+	out := dockerCmd(c, "run", "busybox", "sh", "-c", "dd if=/dev/zero of=/zero bs=1k count=5 2> /dev/null ; du -h /zero")
 	if actual := strings.Trim(out, "\r\n"); actual[0] == '0' {
 		c.Fatalf("expected a new file called /zero to be create that is greater than 0 bytes long, but du says: %s", actual)
 	}
@@ -779,14 +771,14 @@ func (s *DockerSuite) TestRunUnprivilegedWithChroot(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunAddingOptionalDevices(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--device", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "ls /dev/nulo")
+	out := dockerCmd(c, "run", "--device", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "ls /dev/nulo")
 	if actual := strings.Trim(out, "\r\n"); actual != "/dev/nulo" {
 		c.Fatalf("expected output /dev/nulo, received %s", actual)
 	}
 }
 
 func (s *DockerSuite) TestRunAddingOptionalDevicesNoSrc(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--device", "/dev/zero:rw", "busybox", "sh", "-c", "ls /dev/zero")
+	out := dockerCmd(c, "run", "--device", "/dev/zero:rw", "busybox", "sh", "-c", "ls /dev/zero")
 	if actual := strings.Trim(out, "\r\n"); actual != "/dev/zero" {
 		c.Fatalf("expected output /dev/zero, received %s", actual)
 	}
@@ -802,13 +794,13 @@ func (s *DockerSuite) TestRunAddingOptionalDevicesInvalidMode(c *check.C) {
 func (s *DockerSuite) TestRunModeHostname(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
-	out, _ := dockerCmd(c, "run", "-h=testhostname", "busybox", "cat", "/etc/hostname")
+	out := dockerCmd(c, "run", "-h=testhostname", "busybox", "cat", "/etc/hostname")
 
 	if actual := strings.Trim(out, "\r\n"); actual != "testhostname" {
 		c.Fatalf("expected 'testhostname', but says: %q", actual)
 	}
 
-	out, _ = dockerCmd(c, "run", "--net=host", "busybox", "cat", "/etc/hostname")
+	out = dockerCmd(c, "run", "--net=host", "busybox", "cat", "/etc/hostname")
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -820,7 +812,7 @@ func (s *DockerSuite) TestRunModeHostname(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunRootWorkdir(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--workdir", "/", "busybox", "pwd")
+	out := dockerCmd(c, "run", "--workdir", "/", "busybox", "pwd")
 	if out != "/\n" {
 		c.Fatalf("pwd returned %q (expected /\\n)", s)
 	}
@@ -861,7 +853,7 @@ func (s *DockerSuite) TestRunDnsDefaultOptions(c *check.C) {
 		c.Fatal(err)
 	}
 
-	actual, _ := dockerCmd(c, "run", "busybox", "cat", "/etc/resolv.conf")
+	actual := dockerCmd(c, "run", "busybox", "cat", "/etc/resolv.conf")
 	// check that the actual defaults are appended to the commented out
 	// localhost resolver (which should be preserved)
 	// NOTE: if we ever change the defaults from google dns, this will break
@@ -904,7 +896,7 @@ func (s *DockerSuite) TestRunDnsOptionsBasedOnHostResolvConf(c *check.C) {
 	hostSearch := resolvconf.GetSearchDomains(origResolvConf)
 
 	var out string
-	out, _ = dockerCmd(c, "run", "--dns=127.0.0.1", "busybox", "cat", "/etc/resolv.conf")
+	out = dockerCmd(c, "run", "--dns=127.0.0.1", "busybox", "cat", "/etc/resolv.conf")
 
 	if actualNameservers := resolvconf.GetNameservers([]byte(out)); string(actualNameservers[0]) != "127.0.0.1" {
 		c.Fatalf("expected '127.0.0.1', but says: %q", string(actualNameservers[0]))
@@ -920,7 +912,7 @@ func (s *DockerSuite) TestRunDnsOptionsBasedOnHostResolvConf(c *check.C) {
 		}
 	}
 
-	out, _ = dockerCmd(c, "run", "--dns-search=mydomain", "busybox", "cat", "/etc/resolv.conf")
+	out = dockerCmd(c, "run", "--dns-search=mydomain", "busybox", "cat", "/etc/resolv.conf")
 
 	actualNameservers := resolvconf.GetNameservers([]byte(out))
 	if len(actualNameservers) != len(hostNamservers) {
@@ -956,7 +948,7 @@ func (s *DockerSuite) TestRunDnsOptionsBasedOnHostResolvConf(c *check.C) {
 	hostNamservers = resolvconf.GetNameservers(resolvConf)
 	hostSearch = resolvconf.GetSearchDomains(resolvConf)
 
-	out, _ = dockerCmd(c, "run", "busybox", "cat", "/etc/resolv.conf")
+	out = dockerCmd(c, "run", "busybox", "cat", "/etc/resolv.conf")
 	if actualNameservers = resolvconf.GetNameservers([]byte(out)); string(actualNameservers[0]) != "12.34.56.78" || len(actualNameservers) != 1 {
 		c.Fatalf("expected '12.34.56.78', but has: %v", actualNameservers)
 	}
@@ -1081,7 +1073,7 @@ func (s *DockerSuite) TestRunResolvconfUpdate(c *check.C) {
 	}
 
 	//3. test that a running container's resolv.conf is not modified while running
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	runningContainerID := strings.TrimSpace(out)
 
 	// replace resolv.conf
@@ -1178,7 +1170,7 @@ func (s *DockerSuite) TestRunResolvconfUpdate(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunAddHost(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--add-host=extra:86.75.30.9", "busybox", "grep", "extra", "/etc/hosts")
+	out := dockerCmd(c, "run", "--add-host=extra:86.75.30.9", "busybox", "grep", "extra", "/etc/hosts")
 
 	actual := strings.Trim(out, "\r\n")
 	if actual != "86.75.30.9\textra" {
@@ -1188,26 +1180,17 @@ func (s *DockerSuite) TestRunAddHost(c *check.C) {
 
 // Regression test for #6983
 func (s *DockerSuite) TestRunAttachStdErrOnlyTTYMode(c *check.C) {
-	_, exitCode := dockerCmd(c, "run", "-t", "-a", "stderr", "busybox", "true")
-	if exitCode != 0 {
-		c.Fatalf("Container should have exited with error code 0")
-	}
+	dockerCmd(c, "run", "-t", "-a", "stderr", "busybox", "true")
 }
 
 // Regression test for #6983
 func (s *DockerSuite) TestRunAttachStdOutOnlyTTYMode(c *check.C) {
-	_, exitCode := dockerCmd(c, "run", "-t", "-a", "stdout", "busybox", "true")
-	if exitCode != 0 {
-		c.Fatalf("Container should have exited with error code 0")
-	}
+	dockerCmd(c, "run", "-t", "-a", "stdout", "busybox", "true")
 }
 
 // Regression test for #6983
 func (s *DockerSuite) TestRunAttachStdOutAndErrTTYMode(c *check.C) {
-	_, exitCode := dockerCmd(c, "run", "-t", "-a", "stdout", "-a", "stderr", "busybox", "true")
-	if exitCode != 0 {
-		c.Fatalf("Container should have exited with error code 0")
-	}
+	dockerCmd(c, "run", "-t", "-a", "stdout", "-a", "stderr", "busybox", "true")
 }
 
 // Test for #10388 - this will run the same test as TestRunAttachStdOutAndErrTTYMode
@@ -1223,7 +1206,7 @@ func (s *DockerSuite) TestRunAttachWithDetach(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunState(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 
 	id := strings.TrimSpace(out)
 	state, err := inspectField(id, "State.Running")
@@ -1276,7 +1259,7 @@ func (s *DockerSuite) TestRunCopyVolumeUidGid(c *check.C) {
 	}
 
 	// Test that the uid and gid is copied from the image to the volume
-	out, _ := dockerCmd(c, "run", "--rm", "-v", "/hello", name, "sh", "-c", "ls -l / | grep hello | awk '{print $3\":\"$4}'")
+	out := dockerCmd(c, "run", "--rm", "-v", "/hello", name, "sh", "-c", "ls -l / | grep hello | awk '{print $3\":\"$4}'")
 	out = strings.TrimSpace(out)
 	if out != "dockerio:dockerio" {
 		c.Fatalf("Wrong /hello ownership: %s, expected dockerio:dockerio", out)
@@ -1295,7 +1278,7 @@ func (s *DockerSuite) TestRunCopyVolumeContent(c *check.C) {
 	}
 
 	// Test that the content is copied from the image to the volume
-	out, _ := dockerCmd(c, "run", "--rm", "-v", "/hello", name, "find", "/hello")
+	out := dockerCmd(c, "run", "--rm", "-v", "/hello", name, "find", "/hello")
 	if !(strings.Contains(out, "/hello/local/world") && strings.Contains(out, "/hello/local")) {
 		c.Fatal("Container failed to transfer content to volume")
 	}
@@ -1311,10 +1294,7 @@ func (s *DockerSuite) TestRunCleanupCmdOnEntrypoint(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, exit := dockerCmd(c, "run", "--entrypoint", "whoami", name)
-	if exit != 0 {
-		c.Fatalf("expected exit code 0 received %d, out: %q", exit, out)
-	}
+	out := dockerCmd(c, "run", "--entrypoint", "whoami", name)
 	out = strings.TrimSpace(out)
 	if out != "root" {
 		c.Fatalf("Expected output root, got %q", out)
@@ -1383,22 +1363,22 @@ func (s *DockerSuite) TestRunExitOnStdinClose(c *check.C) {
 // Test for #2267
 func (s *DockerSuite) TestRunWriteHostsFileAndNotCommit(c *check.C) {
 	name := "writehosts"
-	out, _ := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo test2267 >> /etc/hosts && cat /etc/hosts")
+	out := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo test2267 >> /etc/hosts && cat /etc/hosts")
 	if !strings.Contains(out, "test2267") {
 		c.Fatal("/etc/hosts should contain 'test2267'")
 	}
 
-	out, _ = dockerCmd(c, "diff", name)
+	out = dockerCmd(c, "diff", name)
 	if len(strings.Trim(out, "\r\n")) != 0 && !eqToBaseDiff(out, c) {
 		c.Fatal("diff should be empty")
 	}
 }
 
 func eqToBaseDiff(out string, c *check.C) bool {
-	out1, _ := dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
+	out1 := dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
 	cID := strings.TrimSpace(out1)
 
-	baseDiff, _ := dockerCmd(c, "diff", cID)
+	baseDiff := dockerCmd(c, "diff", cID)
 	baseArr := strings.Split(baseDiff, "\n")
 	sort.Strings(baseArr)
 	outArr := strings.Split(out, "\n")
@@ -1423,12 +1403,12 @@ func sliceEq(a, b []string) bool {
 // Test for #2267
 func (s *DockerSuite) TestRunWriteHostnameFileAndNotCommit(c *check.C) {
 	name := "writehostname"
-	out, _ := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo test2267 >> /etc/hostname && cat /etc/hostname")
+	out := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo test2267 >> /etc/hostname && cat /etc/hostname")
 	if !strings.Contains(out, "test2267") {
 		c.Fatal("/etc/hostname should contain 'test2267'")
 	}
 
-	out, _ = dockerCmd(c, "diff", name)
+	out = dockerCmd(c, "diff", name)
 	if len(strings.Trim(out, "\r\n")) != 0 && !eqToBaseDiff(out, c) {
 		c.Fatal("diff should be empty")
 	}
@@ -1437,12 +1417,12 @@ func (s *DockerSuite) TestRunWriteHostnameFileAndNotCommit(c *check.C) {
 // Test for #2267
 func (s *DockerSuite) TestRunWriteResolvFileAndNotCommit(c *check.C) {
 	name := "writeresolv"
-	out, _ := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo test2267 >> /etc/resolv.conf && cat /etc/resolv.conf")
+	out := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo test2267 >> /etc/resolv.conf && cat /etc/resolv.conf")
 	if !strings.Contains(out, "test2267") {
 		c.Fatal("/etc/resolv.conf should contain 'test2267'")
 	}
 
-	out, _ = dockerCmd(c, "diff", name)
+	out = dockerCmd(c, "diff", name)
 	if len(strings.Trim(out, "\r\n")) != 0 && !eqToBaseDiff(out, c) {
 		c.Fatal("diff should be empty")
 	}
@@ -1463,7 +1443,7 @@ func (s *DockerSuite) TestRunWithBadDevice(c *check.C) {
 
 func (s *DockerSuite) TestRunEntrypoint(c *check.C) {
 	name := "entrypoint"
-	out, _ := dockerCmd(c, "run", "--name", name, "--entrypoint", "/bin/echo", "busybox", "-n", "foobar")
+	out := dockerCmd(c, "run", "--name", name, "--entrypoint", "/bin/echo", "busybox", "-n", "foobar")
 
 	expected := "foobar"
 	if out != expected {
@@ -1483,7 +1463,7 @@ func (s *DockerSuite) TestRunBindMounts(c *check.C) {
 	writeFile(path.Join(tmpDir, "touch-me"), "", c)
 
 	// Test reading from a read-only bind mount
-	out, _ := dockerCmd(c, "run", "-v", fmt.Sprintf("%s:/tmp:ro", tmpDir), "busybox", "ls", "/tmp")
+	out := dockerCmd(c, "run", "-v", fmt.Sprintf("%s:/tmp:ro", tmpDir), "busybox", "ls", "/tmp")
 	if !strings.Contains(out, "touch-me") {
 		c.Fatal("Container failed to read from bind mount")
 	}
@@ -1541,7 +1521,7 @@ func (s *DockerSuite) TestRunCidFileCheckIDLength(c *check.C) {
 	tmpCidFile := path.Join(tmpDir, "cid")
 	defer os.RemoveAll(tmpDir)
 
-	out, _ := dockerCmd(c, "run", "-d", "--cidfile", tmpCidFile, "busybox", "true")
+	out := dockerCmd(c, "run", "-d", "--cidfile", tmpCidFile, "busybox", "true")
 
 	id := strings.TrimSpace(out)
 	buffer, err := ioutil.ReadFile(tmpCidFile)
@@ -1560,7 +1540,7 @@ func (s *DockerSuite) TestRunCidFileCheckIDLength(c *check.C) {
 func (s *DockerSuite) TestRunSetMacAddress(c *check.C) {
 	mac := "12:34:56:78:9a:bc"
 
-	out, _ := dockerCmd(c, "run", "-i", "--rm", fmt.Sprintf("--mac-address=%s", mac), "busybox", "/bin/sh", "-c", "ip link show eth0 | tail -1 | awk '{print $2}'")
+	out := dockerCmd(c, "run", "-i", "--rm", fmt.Sprintf("--mac-address=%s", mac), "busybox", "/bin/sh", "-c", "ip link show eth0 | tail -1 | awk '{print $2}'")
 
 	actualMac := strings.TrimSpace(out)
 	if actualMac != mac {
@@ -1570,7 +1550,7 @@ func (s *DockerSuite) TestRunSetMacAddress(c *check.C) {
 
 func (s *DockerSuite) TestRunInspectMacAddress(c *check.C) {
 	mac := "12:34:56:78:9a:bc"
-	out, _ := dockerCmd(c, "run", "-d", "--mac-address="+mac, "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "--mac-address="+mac, "busybox", "top")
 
 	id := strings.TrimSpace(out)
 	inspectedMac, err := inspectField(id, "NetworkSettings.MacAddress")
@@ -1592,7 +1572,7 @@ func (s *DockerSuite) TestRunWithInvalidMacAddress(c *check.C) {
 func (s *DockerSuite) TestRunDeallocatePortOnMissingIptablesRule(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
-	out, _ := dockerCmd(c, "run", "-d", "-p", "23:23", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "-p", "23:23", "busybox", "top")
 
 	id := strings.TrimSpace(out)
 	ip, err := inspectField(id, "NetworkSettings.IPAddress")
@@ -1628,10 +1608,10 @@ func (s *DockerSuite) TestRunPortInUse(c *check.C) {
 // https://github.com/docker/docker/issues/12148
 func (s *DockerSuite) TestRunAllocatePortInReservedRange(c *check.C) {
 	// allocate a dynamic port to get the most recent
-	out, _ := dockerCmd(c, "run", "-d", "-P", "-p", "80", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "-P", "-p", "80", "busybox", "top")
 
 	id := strings.TrimSpace(out)
-	out, _ = dockerCmd(c, "port", id, "80")
+	out = dockerCmd(c, "port", id, "80")
 
 	strPort := strings.Split(strings.TrimSpace(out), ":")[1]
 	port, err := strconv.ParseInt(strPort, 10, 64)
@@ -1713,17 +1693,17 @@ func (s *DockerSuite) TestRunReuseBindVolumeThatIsSymlink(c *check.C) {
 
 //GH#10604: Test an "/etc" volume doesn't overlay special bind mounts in container
 func (s *DockerSuite) TestRunCreateVolumeEtc(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--dns=127.0.0.1", "-v", "/etc", "busybox", "cat", "/etc/resolv.conf")
+	out := dockerCmd(c, "run", "--dns=127.0.0.1", "-v", "/etc", "busybox", "cat", "/etc/resolv.conf")
 	if !strings.Contains(out, "nameserver 127.0.0.1") {
 		c.Fatal("/etc volume mount hides /etc/resolv.conf")
 	}
 
-	out, _ = dockerCmd(c, "run", "-h=test123", "-v", "/etc", "busybox", "cat", "/etc/hostname")
+	out = dockerCmd(c, "run", "-h=test123", "-v", "/etc", "busybox", "cat", "/etc/hostname")
 	if !strings.Contains(out, "test123") {
 		c.Fatal("/etc volume mount hides /etc/hostname")
 	}
 
-	out, _ = dockerCmd(c, "run", "--add-host=test:192.168.0.1", "-v", "/etc", "busybox", "cat", "/etc/hosts")
+	out = dockerCmd(c, "run", "--add-host=test:192.168.0.1", "-v", "/etc", "busybox", "cat", "/etc/hosts")
 	out = strings.Replace(out, "\n", " ", -1)
 	if !strings.Contains(out, "192.168.0.1\ttest") || !strings.Contains(out, "127.0.0.1\tlocalhost") {
 		c.Fatal("/etc volume mount hides /etc/hosts")
@@ -1821,7 +1801,7 @@ func (s *DockerSuite) TestRunSlowStdoutConsumer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunAllowPortRangeThroughExpose(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "--expose", "3000-3003", "-P", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "--expose", "3000-3003", "-P", "busybox", "top")
 
 	id := strings.TrimSpace(out)
 	portstr, err := inspectFieldJSON(id, "NetworkSettings.Ports")
@@ -1852,7 +1832,7 @@ func (s *DockerSuite) TestRunExposePort(c *check.C) {
 
 func (s *DockerSuite) TestRunUnknownCommand(c *check.C) {
 	testRequires(c, NativeExecDriver)
-	out, _, _ := dockerCmdWithStdoutStderr(c, "create", "busybox", "/bin/nada")
+	out := dockerCmd(c, "create", "busybox", "/bin/nada")
 
 	cID := strings.TrimSpace(out)
 	_, _, err := dockerCmdWithError("start", cID)
@@ -1873,13 +1853,13 @@ func (s *DockerSuite) TestRunModeIpcHost(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "--ipc=host", "busybox", "readlink", "/proc/self/ns/ipc")
+	out := dockerCmd(c, "run", "--ipc=host", "busybox", "readlink", "/proc/self/ns/ipc")
 	out = strings.Trim(out, "\n")
 	if hostIpc != out {
 		c.Fatalf("IPC different with --ipc=host %s != %s\n", hostIpc, out)
 	}
 
-	out, _ = dockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/ipc")
+	out = dockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/ipc")
 	out = strings.Trim(out, "\n")
 	if hostIpc == out {
 		c.Fatalf("IPC should be different without --ipc=host %s == %s\n", hostIpc, out)
@@ -1889,7 +1869,7 @@ func (s *DockerSuite) TestRunModeIpcHost(c *check.C) {
 func (s *DockerSuite) TestRunModeIpcContainer(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 
 	id := strings.TrimSpace(out)
 	state, err := inspectField(id, "State.Running")
@@ -1905,7 +1885,7 @@ func (s *DockerSuite) TestRunModeIpcContainer(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ = dockerCmd(c, "run", fmt.Sprintf("--ipc=container:%s", id), "busybox", "readlink", "/proc/self/ns/ipc")
+	out = dockerCmd(c, "run", fmt.Sprintf("--ipc=container:%s", id), "busybox", "readlink", "/proc/self/ns/ipc")
 	out = strings.Trim(out, "\n")
 	if parentContainerIpc != out {
 		c.Fatalf("IPC different with --ipc=container:%s %s != %s\n", id, parentContainerIpc, out)
@@ -1922,7 +1902,7 @@ func (s *DockerSuite) TestRunModeIpcContainerNotExists(c *check.C) {
 func (s *DockerSuite) TestRunModeIpcContainerNotRunning(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
-	out, _ := dockerCmd(c, "create", "busybox")
+	out := dockerCmd(c, "create", "busybox")
 
 	id := strings.TrimSpace(out)
 	out, _, err := dockerCmdWithError("run", fmt.Sprintf("--ipc=container:%s", id), "busybox")
@@ -1934,7 +1914,7 @@ func (s *DockerSuite) TestRunModeIpcContainerNotRunning(c *check.C) {
 func (s *DockerSuite) TestContainerNetworkMode(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
 	pid1, err := inspectField(id, "State.Pid")
@@ -1945,7 +1925,7 @@ func (s *DockerSuite) TestContainerNetworkMode(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ = dockerCmd(c, "run", fmt.Sprintf("--net=container:%s", id), "busybox", "readlink", "/proc/self/ns/net")
+	out = dockerCmd(c, "run", fmt.Sprintf("--net=container:%s", id), "busybox", "readlink", "/proc/self/ns/net")
 	out = strings.Trim(out, "\n")
 	if parentContainerNet != out {
 		c.Fatalf("NET different with --net=container:%s %s != %s\n", id, parentContainerNet, out)
@@ -1960,13 +1940,13 @@ func (s *DockerSuite) TestRunModePidHost(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "--pid=host", "busybox", "readlink", "/proc/self/ns/pid")
+	out := dockerCmd(c, "run", "--pid=host", "busybox", "readlink", "/proc/self/ns/pid")
 	out = strings.Trim(out, "\n")
 	if hostPid != out {
 		c.Fatalf("PID different with --pid=host %s != %s\n", hostPid, out)
 	}
 
-	out, _ = dockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/pid")
+	out = dockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/pid")
 	out = strings.Trim(out, "\n")
 	if hostPid == out {
 		c.Fatalf("PID should be different without --pid=host %s == %s\n", hostPid, out)
@@ -1981,13 +1961,13 @@ func (s *DockerSuite) TestRunModeUTSHost(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "--uts=host", "busybox", "readlink", "/proc/self/ns/uts")
+	out := dockerCmd(c, "run", "--uts=host", "busybox", "readlink", "/proc/self/ns/uts")
 	out = strings.Trim(out, "\n")
 	if hostUTS != out {
 		c.Fatalf("UTS different with --uts=host %s != %s\n", hostUTS, out)
 	}
 
-	out, _ = dockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/uts")
+	out = dockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/uts")
 	out = strings.Trim(out, "\n")
 	if hostUTS == out {
 		c.Fatalf("UTS should be different without --uts=host %s == %s\n", hostUTS, out)
@@ -2014,10 +1994,10 @@ func (s *DockerSuite) TestRunTLSverify(c *check.C) {
 
 func (s *DockerSuite) TestRunPortFromDockerRangeInUse(c *check.C) {
 	// first find allocator current position
-	out, _ := dockerCmd(c, "run", "-d", "-p", ":80", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "-p", ":80", "busybox", "top")
 
 	id := strings.TrimSpace(out)
-	out, _ = dockerCmd(c, "port", id)
+	out = dockerCmd(c, "port", id)
 
 	out = strings.TrimSpace(out)
 	if out == "" {
@@ -2035,7 +2015,7 @@ func (s *DockerSuite) TestRunPortFromDockerRangeInUse(c *check.C) {
 	}
 	defer l.Close()
 
-	out, _ = dockerCmd(c, "run", "-d", "-p", ":80", "busybox", "top")
+	out = dockerCmd(c, "run", "-d", "-p", ":80", "busybox", "top")
 
 	id = strings.TrimSpace(out)
 	dockerCmd(c, "port", id)
@@ -2073,7 +2053,7 @@ func (s *DockerSuite) TestRunTtyWithPipe(c *check.C) {
 func (s *DockerSuite) TestRunNonLocalMacAddress(c *check.C) {
 	addr := "00:16:3E:08:00:50"
 
-	if out, _ := dockerCmd(c, "run", "--mac-address", addr, "busybox", "ifconfig"); !strings.Contains(out, addr) {
+	if out := dockerCmd(c, "run", "--mac-address", addr, "busybox", "ifconfig"); !strings.Contains(out, addr) {
 		c.Fatalf("Output should have contained %q: %s", addr, out)
 	}
 }
@@ -2086,13 +2066,13 @@ func (s *DockerSuite) TestRunNetHost(c *check.C) {
 		c.Fatal(err)
 	}
 
-	out, _ := dockerCmd(c, "run", "--net=host", "busybox", "readlink", "/proc/self/ns/net")
+	out := dockerCmd(c, "run", "--net=host", "busybox", "readlink", "/proc/self/ns/net")
 	out = strings.Trim(out, "\n")
 	if hostNet != out {
 		c.Fatalf("Net namespace different with --net=host %s != %s\n", hostNet, out)
 	}
 
-	out, _ = dockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/net")
+	out = dockerCmd(c, "run", "busybox", "readlink", "/proc/self/ns/net")
 	out = strings.Trim(out, "\n")
 	if hostNet == out {
 		c.Fatalf("Net namespace should be different without --net=host %s == %s\n", hostNet, out)
@@ -2116,7 +2096,7 @@ func (s *DockerSuite) TestRunNetContainerWhichHost(c *check.C) {
 
 	dockerCmd(c, "run", "-d", "--net=host", "--name=test", "busybox", "top")
 
-	out, _ := dockerCmd(c, "run", "--net=container:test", "busybox", "readlink", "/proc/self/ns/net")
+	out := dockerCmd(c, "run", "--net=container:test", "busybox", "readlink", "/proc/self/ns/net")
 	out = strings.Trim(out, "\n")
 	if hostNet != out {
 		c.Fatalf("Container should have host network namespace")
@@ -2124,7 +2104,7 @@ func (s *DockerSuite) TestRunNetContainerWhichHost(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunAllowPortRangeThroughPublish(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "--expose", "3000-3003", "-p", "3000-3003", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "--expose", "3000-3003", "-p", "3000-3003", "busybox", "top")
 
 	id := strings.TrimSpace(out)
 	portstr, err := inspectFieldJSON(id, "NetworkSettings.Ports")
@@ -2154,7 +2134,7 @@ func (s *DockerSuite) TestRunSetDefaultRestartPolicy(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunRestartMaxRetries(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "false")
+	out := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "false")
 
 	id := strings.TrimSpace(string(out))
 	if err := waitInspect(id, "{{ .State.Restarting }} {{ .State.Running }}", "false false", 10); err != nil {
@@ -2190,10 +2170,7 @@ func (s *DockerSuite) TestPermissionsPtsReadonlyRootfs(c *check.C) {
 	testRequires(c, NativeExecDriver)
 
 	// Ensure we have not broken writing /dev/pts
-	out, status := dockerCmd(c, "run", "--read-only", "--rm", "busybox", "mount")
-	if status != 0 {
-		c.Fatal("Could not obtain mounts when checking /dev/pts mntpnt.")
-	}
+	out := dockerCmd(c, "run", "--read-only", "--rm", "busybox", "mount")
 	expected := "type devpts (rw,"
 	if !strings.Contains(string(out), expected) {
 		c.Fatalf("expected output to contain %s but contains %s", expected, out)
@@ -2227,7 +2204,7 @@ func (s *DockerSuite) TestRunContainerWithReadonlyEtcHostsAndLinkedContainer(c *
 
 	dockerCmd(c, "run", "-d", "--name", "test-etc-hosts-ro-linked", "busybox", "top")
 
-	out, _ := dockerCmd(c, "run", "--read-only", "--link", "test-etc-hosts-ro-linked:testlinked", "busybox", "cat", "/etc/hosts")
+	out := dockerCmd(c, "run", "--read-only", "--link", "test-etc-hosts-ro-linked:testlinked", "busybox", "cat", "/etc/hosts")
 	if !strings.Contains(string(out), "testlinked") {
 		c.Fatal("Expected /etc/hosts to be updated even if --read-only enabled")
 	}
@@ -2236,7 +2213,7 @@ func (s *DockerSuite) TestRunContainerWithReadonlyEtcHostsAndLinkedContainer(c *
 func (s *DockerSuite) TestRunContainerWithReadonlyRootfsWithDnsFlag(c *check.C) {
 	testRequires(c, NativeExecDriver)
 
-	out, _ := dockerCmd(c, "run", "--read-only", "--dns", "1.1.1.1", "busybox", "/bin/cat", "/etc/resolv.conf")
+	out := dockerCmd(c, "run", "--read-only", "--dns", "1.1.1.1", "busybox", "/bin/cat", "/etc/resolv.conf")
 	if !strings.Contains(string(out), "1.1.1.1") {
 		c.Fatal("Expected /etc/resolv.conf to be updated even if --read-only enabled and --dns flag used")
 	}
@@ -2245,7 +2222,7 @@ func (s *DockerSuite) TestRunContainerWithReadonlyRootfsWithDnsFlag(c *check.C) 
 func (s *DockerSuite) TestRunContainerWithReadonlyRootfsWithAddHostFlag(c *check.C) {
 	testRequires(c, NativeExecDriver)
 
-	out, _ := dockerCmd(c, "run", "--read-only", "--add-host", "testreadonly:127.0.0.1", "busybox", "/bin/cat", "/etc/hosts")
+	out := dockerCmd(c, "run", "--read-only", "--add-host", "testreadonly:127.0.0.1", "busybox", "/bin/cat", "/etc/hosts")
 	if !strings.Contains(string(out), "testreadonly") {
 		c.Fatal("Expected /etc/hosts to be updated even if --read-only enabled and --add-host flag used")
 	}
@@ -2425,7 +2402,7 @@ func (s *DockerSuite) TestRunUnshareProc(c *check.C) {
 
 func (s *DockerSuite) TestRunPublishPort(c *check.C) {
 	dockerCmd(c, "run", "-d", "--name", "test", "--expose", "8080", "busybox", "top")
-	out, _ := dockerCmd(c, "port", "test")
+	out := dockerCmd(c, "port", "test")
 	out = strings.Trim(out, "\r\n")
 	if out != "" {
 		c.Fatalf("run without --publish-all should not publish port, out should be nil, but got: %s", out)
@@ -2436,10 +2413,7 @@ func (s *DockerSuite) TestRunPublishPort(c *check.C) {
 func (s *DockerSuite) TestDevicePermissions(c *check.C) {
 	testRequires(c, NativeExecDriver)
 	const permissions = "crw-rw-rw-"
-	out, status := dockerCmd(c, "run", "--device", "/dev/fuse:/dev/fuse:mrw", "busybox:latest", "ls", "-l", "/dev/fuse")
-	if status != 0 {
-		c.Fatalf("expected status 0, got %d", status)
-	}
+	out := dockerCmd(c, "run", "--device", "/dev/fuse:/dev/fuse:mrw", "busybox:latest", "ls", "-l", "/dev/fuse")
 	if !strings.HasPrefix(out, permissions) {
 		c.Fatalf("output should begin with %q, got %q", permissions, out)
 	}
@@ -2447,7 +2421,7 @@ func (s *DockerSuite) TestDevicePermissions(c *check.C) {
 
 func (s *DockerSuite) TestRunCapAddCHOWN(c *check.C) {
 	testRequires(c, NativeExecDriver)
-	out, _ := dockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=CHOWN", "busybox", "sh", "-c", "adduser -D -H newuser && chown newuser /home && echo ok")
+	out := dockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=CHOWN", "busybox", "sh", "-c", "adduser -D -H newuser && chown newuser /home && echo ok")
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
@@ -2510,7 +2484,7 @@ func (s *DockerSuite) TestRunNetworkFilesBindMount(c *check.C) {
 	nwfiles := []string{"/etc/resolv.conf", "/etc/hosts", "/etc/hostname"}
 
 	for i := range nwfiles {
-		actual, _ := dockerCmd(c, "run", "-v", filename+":"+nwfiles[i], "busybox", "cat", nwfiles[i])
+		actual := dockerCmd(c, "run", "-v", filename+":"+nwfiles[i], "busybox", "cat", nwfiles[i])
 		if actual != expected {
 			c.Fatalf("expected %s be: %q, but was: %q", nwfiles[i], expected, actual)
 		}
@@ -2542,10 +2516,7 @@ func (s *DockerSuite) TestRunNetworkFilesBindMountROFilesystem(c *check.C) {
 	nwfiles := []string{"/etc/resolv.conf", "/etc/hosts", "/etc/hostname"}
 
 	for i := range nwfiles {
-		_, exitCode := dockerCmd(c, "run", "-v", filename+":"+nwfiles[i], "--read-only", "busybox", "touch", nwfiles[i])
-		if exitCode != 0 {
-			c.Fatalf("run should not fail because %s is mounted writable on read-only root filesystem: exit code %d", nwfiles[i], exitCode)
-		}
+		dockerCmd(c, "run", "-v", filename+":"+nwfiles[i], "--read-only", "busybox", "touch", nwfiles[i])
 	}
 
 	for i := range nwfiles {
@@ -2716,7 +2687,7 @@ func (s *DockerTrustSuite) TestTrustedRunFromBadTrustServer(c *check.C) {
 func (s *DockerSuite) TestPtraceContainerProcsFromHost(c *check.C) {
 	testRequires(c, SameHostDaemon)
 
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
 	pid1, err := inspectField(id, "State.Pid")
@@ -2780,17 +2751,17 @@ func (s *DockerSuite) TestRunCreateContainerFailedCleanUp(c *check.C) {
 func (s *DockerSuite) TestRunNamedVolume(c *check.C) {
 	dockerCmd(c, "run", "--name=test", "-v", "testing:/foo", "busybox", "sh", "-c", "echo hello > /foo/bar")
 
-	out, _ := dockerCmd(c, "run", "--volumes-from", "test", "busybox", "sh", "-c", "cat /foo/bar")
+	out := dockerCmd(c, "run", "--volumes-from", "test", "busybox", "sh", "-c", "cat /foo/bar")
 	c.Assert(strings.TrimSpace(out), check.Equals, "hello")
 
-	out, _ = dockerCmd(c, "run", "-v", "testing:/foo", "busybox", "sh", "-c", "cat /foo/bar")
+	out = dockerCmd(c, "run", "-v", "testing:/foo", "busybox", "sh", "-c", "cat /foo/bar")
 	c.Assert(strings.TrimSpace(out), check.Equals, "hello")
 }
 
 func (s *DockerSuite) TestRunWithUlimits(c *check.C) {
 	testRequires(c, NativeExecDriver)
 
-	out, _ := dockerCmd(c, "run", "--name=testulimits", "--ulimit", "nofile=42", "busybox", "/bin/sh", "-c", "ulimit -n")
+	out := dockerCmd(c, "run", "--name=testulimits", "--ulimit", "nofile=42", "busybox", "/bin/sh", "-c", "ulimit -n")
 	ul := strings.TrimSpace(out)
 	if ul != "42" {
 		c.Fatalf("expected `ulimit -n` to be 42, got %s", ul)
@@ -2925,7 +2896,7 @@ func (s *DockerSuite) TestRunLinkToContainerNetMode(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunLoopbackOnlyExistsWhenNetworkingDisabled(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--net=none", "busybox", "ip", "-o", "-4", "a", "show", "up")
+	out := dockerCmd(c, "run", "--net=none", "busybox", "ip", "-o", "-4", "a", "show", "up")
 
 	var (
 		count = 0
@@ -2956,8 +2927,8 @@ func (s *DockerSuite) TestRunModeNetContainerHostname(c *check.C) {
 	testRequires(c, ExecSupport)
 
 	dockerCmd(c, "run", "-i", "-d", "--name", "parent", "busybox", "top")
-	out, _ := dockerCmd(c, "exec", "parent", "cat", "/etc/hostname")
-	out1, _ := dockerCmd(c, "run", "--net=container:parent", "busybox", "cat", "/etc/hostname")
+	out := dockerCmd(c, "exec", "parent", "cat", "/etc/hostname")
+	out1 := dockerCmd(c, "run", "--net=container:parent", "busybox", "cat", "/etc/hostname")
 
 	if out1 != out {
 		c.Fatal("containers with shared net namespace should have same hostname")

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -88,12 +88,12 @@ func (s *DockerSuite) TestRunWithVolumesIsRecursive(c *check.C) {
 func (s *DockerSuite) TestRunDeviceDirectory(c *check.C) {
 	testRequires(c, NativeExecDriver)
 
-	out, _ := dockerCmd(c, "run", "--device", "/dev/snd:/dev/snd", "busybox", "sh", "-c", "ls /dev/snd/")
+	out := dockerCmd(c, "run", "--device", "/dev/snd:/dev/snd", "busybox", "sh", "-c", "ls /dev/snd/")
 	if actual := strings.Trim(out, "\r\n"); !strings.Contains(out, "timer") {
 		c.Fatalf("expected output /dev/snd/timer, received %s", actual)
 	}
 
-	out, _ = dockerCmd(c, "run", "--device", "/dev/snd:/dev/othersnd", "busybox", "sh", "-c", "ls /dev/othersnd/")
+	out = dockerCmd(c, "run", "--device", "/dev/snd:/dev/othersnd", "busybox", "sh", "-c", "ls /dev/othersnd/")
 	if actual := strings.Trim(out, "\r\n"); !strings.Contains(out, "seq") {
 		c.Fatalf("expected output /dev/othersnd/seq, received %s", actual)
 	}
@@ -214,7 +214,7 @@ func (s *DockerSuite) TestRunWithKernelMemory(c *check.C) {
 // "test" should be printed
 func (s *DockerSuite) TestRunEchoStdoutWitCPUShares(c *check.C) {
 	testRequires(c, cpuShare)
-	out, _ := dockerCmd(c, "run", "-c", "1000", "busybox", "echo", "test")
+	out := dockerCmd(c, "run", "-c", "1000", "busybox", "echo", "test")
 	if out != "test\n" {
 		c.Errorf("container should've printed 'test'")
 	}
@@ -232,30 +232,22 @@ func (s *DockerSuite) TestRunEchoStdoutWithCPUSharesAndMemoryLimit(c *check.C) {
 
 func (s *DockerSuite) TestRunWithCpuset(c *check.C) {
 	testRequires(c, cgroupCpuset)
-	if _, code := dockerCmd(c, "run", "--cpuset", "0", "busybox", "true"); code != 0 {
-		c.Fatalf("container should run successfully with cpuset of 0")
-	}
+	dockerCmd(c, "run", "--cpuset", "0", "busybox", "true")
 }
 
 func (s *DockerSuite) TestRunWithCpusetCpus(c *check.C) {
 	testRequires(c, cgroupCpuset)
-	if _, code := dockerCmd(c, "run", "--cpuset-cpus", "0", "busybox", "true"); code != 0 {
-		c.Fatalf("container should run successfully with cpuset-cpus of 0")
-	}
+	dockerCmd(c, "run", "--cpuset-cpus", "0", "busybox", "true")
 }
 
 func (s *DockerSuite) TestRunWithCpusetMems(c *check.C) {
 	testRequires(c, cgroupCpuset)
-	if _, code := dockerCmd(c, "run", "--cpuset-mems", "0", "busybox", "true"); code != 0 {
-		c.Fatalf("container should run successfully with cpuset-mems of 0")
-	}
+	dockerCmd(c, "run", "--cpuset-mems", "0", "busybox", "true")
 }
 
 func (s *DockerSuite) TestRunWithBlkioWeight(c *check.C) {
 	testRequires(c, blkioWeight)
-	if _, code := dockerCmd(c, "run", "--blkio-weight", "300", "busybox", "true"); code != 0 {
-		c.Fatalf("container should run successfully with blkio-weight of 300")
-	}
+	dockerCmd(c, "run", "--blkio-weight", "300", "busybox", "true")
 }
 
 func (s *DockerSuite) TestRunWithBlkioInvalidWeight(c *check.C) {

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -19,7 +19,7 @@ func (s *DockerSuite) TestSaveXzAndLoadRepoStdout(c *check.C) {
 	dockerCmd(c, "run", "--name", name, "busybox", "true")
 
 	repoName := "foobar-save-load-test-xz-gz"
-	out, _ := dockerCmd(c, "commit", name, repoName)
+	out := dockerCmd(c, "commit", name, repoName)
 
 	dockerCmd(c, "inspect", repoName)
 
@@ -82,7 +82,7 @@ func (s *DockerSuite) TestSaveSingleTag(c *check.C) {
 	repoName := "foobar-save-single-tag-test"
 	dockerCmd(c, "tag", "busybox:latest", fmt.Sprintf("%v:latest", repoName))
 
-	out, _ := dockerCmd(c, "images", "-q", "--no-trunc", repoName)
+	out := dockerCmd(c, "images", "-q", "--no-trunc", repoName)
 	cleanedImageID := strings.TrimSpace(out)
 
 	out, _, err := runCommandPipelineWithOutput(
@@ -98,10 +98,10 @@ func (s *DockerSuite) TestSaveImageId(c *check.C) {
 	repoName := "foobar-save-image-id-test"
 	dockerCmd(c, "tag", "emptyfs:latest", fmt.Sprintf("%v:latest", repoName))
 
-	out, _ := dockerCmd(c, "images", "-q", "--no-trunc", repoName)
+	out := dockerCmd(c, "images", "-q", "--no-trunc", repoName)
 	cleanedLongImageID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "images", "-q", repoName)
+	out = dockerCmd(c, "images", "-q", repoName)
 	cleanedShortImageID := strings.TrimSpace(out)
 
 	saveCmd := exec.Command(dockerBinary, "save", cleanedShortImageID)
@@ -144,7 +144,7 @@ func (s *DockerSuite) TestSaveAndLoadRepoFlags(c *check.C) {
 	deleteImages(repoName)
 	dockerCmd(c, "commit", name, repoName)
 
-	before, _ := dockerCmd(c, "inspect", repoName)
+	before := dockerCmd(c, "inspect", repoName)
 
 	out, _, err := runCommandPipelineWithOutput(
 		exec.Command(dockerBinary, "save", repoName),
@@ -153,7 +153,7 @@ func (s *DockerSuite) TestSaveAndLoadRepoFlags(c *check.C) {
 		c.Fatalf("failed to save and load repo: %s, %v", out, err)
 	}
 
-	after, _ := dockerCmd(c, "inspect", repoName)
+	after := dockerCmd(c, "inspect", repoName)
 	if before != after {
 		c.Fatalf("inspect is not the same after a save / load")
 	}
@@ -184,10 +184,10 @@ func (s *DockerSuite) TestSaveRepoWithMultipleImages(c *check.C) {
 		var (
 			out string
 		)
-		out, _ = dockerCmd(c, "run", "-d", from, "true")
+		out = dockerCmd(c, "run", "-d", from, "true")
 		cleanedContainerID := strings.TrimSpace(out)
 
-		out, _ = dockerCmd(c, "commit", cleanedContainerID, tag)
+		out = dockerCmd(c, "commit", cleanedContainerID, tag)
 		imageID := strings.TrimSpace(out)
 		return imageID
 	}
@@ -213,7 +213,7 @@ func (s *DockerSuite) TestSaveRepoWithMultipleImages(c *check.C) {
 	actual := strings.Split(strings.TrimSpace(out), "\n")
 
 	// make the list of expected layers
-	out, _ = dockerCmd(c, "history", "-q", "--no-trunc", "busybox:latest")
+	out = dockerCmd(c, "history", "-q", "--no-trunc", "busybox:latest")
 	expected := append(strings.Split(strings.TrimSpace(out), "\n"), idFoo, idBar)
 
 	sort.Strings(actual)

--- a/integration-cli/docker_cli_save_load_unix_test.go
+++ b/integration-cli/docker_cli_save_load_unix_test.go
@@ -18,9 +18,9 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 	dockerCmd(c, "run", "--name", name, "busybox", "true")
 
 	repoName := "foobar-save-load-test"
-	out, _ := dockerCmd(c, "commit", name, repoName)
+	out := dockerCmd(c, "commit", name, repoName)
 
-	before, _ := dockerCmd(c, "inspect", repoName)
+	before := dockerCmd(c, "inspect", repoName)
 
 	tmpFile, err := ioutil.TempFile("", "foobar-save-load-test.tar")
 	c.Assert(err, check.IsNil)
@@ -45,7 +45,7 @@ func (s *DockerSuite) TestSaveAndLoadRepoStdout(c *check.C) {
 		c.Fatalf("failed to load repo: %s, %v", out, err)
 	}
 
-	after, _ := dockerCmd(c, "inspect", repoName)
+	after := dockerCmd(c, "inspect", repoName)
 
 	if before != after {
 		c.Fatalf("inspect is not the same after a save / load")

--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -10,10 +10,7 @@ import (
 func (s *DockerSuite) TestSearchOnCentralRegistry(c *check.C) {
 	testRequires(c, Network)
 
-	out, exitCode := dockerCmd(c, "search", "busybox")
-	if exitCode != 0 {
-		c.Fatalf("failed to search on the central registry: %s", out)
-	}
+	out := dockerCmd(c, "search", "busybox")
 
 	if !strings.Contains(out, "Busybox base image.") {
 		c.Fatal("couldn't find any repository named (or containing) 'Busybox base image.'")
@@ -43,30 +40,21 @@ func (s *DockerSuite) TestSearchStarsOptionWithWrongParameter(c *check.C) {
 func (s *DockerSuite) TestSearchCmdOptions(c *check.C) {
 	testRequires(c, Network)
 
-	out, exitCode := dockerCmd(c, "search", "--help")
-	if exitCode != 0 {
-		c.Fatalf("failed to get search help information: %s", out)
-	}
+	out := dockerCmd(c, "search", "--help")
 
 	if !strings.Contains(out, "Usage:\tdocker search [OPTIONS] TERM") {
 		c.Fatalf("failed to show docker search usage: %s", out)
 	}
 
-	outSearchCmd, exitCode := dockerCmd(c, "search", "busybox")
-	if exitCode != 0 {
-		c.Fatalf("failed to search on the central registry: %s", outSearchCmd)
-	}
+	outSearchCmd := dockerCmd(c, "search", "busybox")
 
-	outSearchCmdNotrunc, _ := dockerCmd(c, "search", "--no-trunc=true", "busybox")
+	outSearchCmdNotrunc := dockerCmd(c, "search", "--no-trunc=true", "busybox")
 
 	if len(outSearchCmd) > len(outSearchCmdNotrunc) {
 		c.Fatalf("The no-trunc option can't take effect.")
 	}
 
-	outSearchCmdautomated, exitCode := dockerCmd(c, "search", "--automated=true", "busybox") //The busybox is a busybox base image, not an AUTOMATED image.
-	if exitCode != 0 {
-		c.Fatalf("failed to search with automated=true on the central registry: %s", outSearchCmdautomated)
-	}
+	outSearchCmdautomated := dockerCmd(c, "search", "--automated=true", "busybox") //The busybox is a busybox base image, not an AUTOMATED image.
 
 	outSearchCmdautomatedSlice := strings.Split(outSearchCmdautomated, "\n")
 	for i := range outSearchCmdautomatedSlice {
@@ -75,17 +63,11 @@ func (s *DockerSuite) TestSearchCmdOptions(c *check.C) {
 		}
 	}
 
-	outSearchCmdStars, exitCode := dockerCmd(c, "search", "-s=2", "busybox")
-	if exitCode != 0 {
-		c.Fatalf("failed to search with stars=2 on the central registry: %s", outSearchCmdStars)
-	}
+	outSearchCmdStars := dockerCmd(c, "search", "-s=2", "busybox")
 
 	if strings.Count(outSearchCmdStars, "[OK]") > strings.Count(outSearchCmd, "[OK]") {
 		c.Fatalf("The quantity of images with stars should be less than that of all images: %s", outSearchCmdStars)
 	}
 
-	out, exitCode = dockerCmd(c, "search", "--stars=2", "--automated=true", "--no-trunc=true", "busybox")
-	if exitCode != 0 {
-		c.Fatalf("failed to search with stars&automated&no-trunc options on the central registry: %s", out)
-	}
+	dockerCmd(c, "search", "--stars=2", "--automated=true", "--no-trunc=true", "busybox")
 }

--- a/integration-cli/docker_cli_service_test.go
+++ b/integration-cli/docker_cli_service_test.go
@@ -60,7 +60,7 @@ func (s *DockerSuite) TestDockerServiceCreateDelete(c *check.C) {
 
 func (s *DockerSuite) TestDockerPublishServiceFlag(c *check.C) {
 	// Run saying the container is the backend for the specified service on the specified network
-	out, _ := dockerCmd(c, "run", "-d", "--expose=23", "--publish-service", "telnet.production", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "--expose=23", "--publish-service", "telnet.production", "busybox", "top")
 	cid := strings.TrimSpace(out)
 
 	// Verify container is attached in service ps o/p

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -61,7 +61,7 @@ func (s *DockerSuite) TestStartAttachSilent(c *check.C) {
 	// make sure the container has exited before trying the "start -a"
 	dockerCmd(c, "wait", name)
 
-	startOut, _ := dockerCmd(c, "start", "-a", name)
+	startOut := dockerCmd(c, "start", "-a", name)
 	if expected := "test\n"; startOut != expected {
 		c.Fatalf("start -a produced unexpected output: expected %q, got %q", expected, startOut)
 	}

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *DockerSuite) TestCliStatsNoStream(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
 

--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func (s *DockerSuite) TestTopMultipleArgs(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-i", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-i", "-d", "busybox", "top")
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out, _ = dockerCmd(c, "top", cleanedContainerID, "-o", "pid")
+	out = dockerCmd(c, "top", cleanedContainerID, "-o", "pid")
 	if !strings.Contains(out, "PID") {
 		c.Fatalf("did not see PID after top -o pid: %s", out)
 	}
@@ -19,12 +19,12 @@ func (s *DockerSuite) TestTopMultipleArgs(c *check.C) {
 }
 
 func (s *DockerSuite) TestTopNonPrivileged(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-i", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "-i", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out1, _ := dockerCmd(c, "top", cleanedContainerID)
-	out2, _ := dockerCmd(c, "top", cleanedContainerID)
-	out, _ = dockerCmd(c, "kill", cleanedContainerID)
+	out1 := dockerCmd(c, "top", cleanedContainerID)
+	out2 := dockerCmd(c, "top", cleanedContainerID)
+	out = dockerCmd(c, "kill", cleanedContainerID)
 
 	if !strings.Contains(out1, "top") && !strings.Contains(out2, "top") {
 		c.Fatal("top should've listed `top` in the process list, but failed twice")
@@ -37,12 +37,12 @@ func (s *DockerSuite) TestTopNonPrivileged(c *check.C) {
 }
 
 func (s *DockerSuite) TestTopPrivileged(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--privileged", "-i", "-d", "busybox", "top")
+	out := dockerCmd(c, "run", "--privileged", "-i", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
-	out1, _ := dockerCmd(c, "top", cleanedContainerID)
-	out2, _ := dockerCmd(c, "top", cleanedContainerID)
-	out, _ = dockerCmd(c, "kill", cleanedContainerID)
+	out1 := dockerCmd(c, "top", cleanedContainerID)
+	out2 := dockerCmd(c, "top", cleanedContainerID)
+	out = dockerCmd(c, "kill", cleanedContainerID)
 
 	if !strings.Contains(out1, "top") && !strings.Contains(out2, "top") {
 		c.Fatal("top should've listed `top` in the process list, but failed twice")

--- a/integration-cli/docker_cli_version_test.go
+++ b/integration-cli/docker_cli_version_test.go
@@ -8,7 +8,7 @@ import (
 
 // ensure docker version works
 func (s *DockerSuite) TestVersionEnsureSucceeds(c *check.C) {
-	out, _ := dockerCmd(c, "version")
+	out := dockerCmd(c, "version")
 	stringsToCheck := map[string]int{
 		"Client:":       1,
 		"Server:":       1,
@@ -40,7 +40,7 @@ func (s *DockerSuite) TestVersionPlatform_l(c *check.C) {
 }
 
 func testVersionPlatform(c *check.C, platform string) {
-	out, _ := dockerCmd(c, "version")
+	out := dockerCmd(c, "version")
 	expected := "OS/Arch:      " + platform
 
 	split := strings.Split(out, "\n")

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -13,7 +13,7 @@ func (s *DockerSuite) TestVolumeCliCreate(c *check.C) {
 	_, err := runCommand(exec.Command(dockerBinary, "volume", "create", "-d", "nosuchdriver"))
 	c.Assert(err, check.Not(check.IsNil))
 
-	out, _ := dockerCmd(c, "volume", "create", "--name=test")
+	out := dockerCmd(c, "volume", "create", "--name=test")
 	name := strings.TrimSpace(out)
 	c.Assert(name, check.Equals, "test")
 }
@@ -25,24 +25,24 @@ func (s *DockerSuite) TestVolumeCliInspect(c *check.C) {
 		check.Commentf("volume inspect should error on non-existant volume"),
 	)
 
-	out, _ := dockerCmd(c, "volume", "create")
+	out := dockerCmd(c, "volume", "create")
 	name := strings.TrimSpace(out)
-	out, _ = dockerCmd(c, "volume", "inspect", "--format='{{ .Name }}'", name)
+	out = dockerCmd(c, "volume", "inspect", "--format='{{ .Name }}'", name)
 	c.Assert(strings.TrimSpace(out), check.Equals, name)
 
 	dockerCmd(c, "volume", "create", "--name", "test")
-	out, _ = dockerCmd(c, "volume", "inspect", "--format='{{ .Name }}'", "test")
+	out = dockerCmd(c, "volume", "inspect", "--format='{{ .Name }}'", "test")
 	c.Assert(strings.TrimSpace(out), check.Equals, "test")
 }
 
 func (s *DockerSuite) TestVolumeCliLs(c *check.C) {
-	out, _ := dockerCmd(c, "volume", "create")
+	out := dockerCmd(c, "volume", "create")
 	id := strings.TrimSpace(out)
 
 	dockerCmd(c, "volume", "create", "--name", "test")
 	dockerCmd(c, "run", "-v", "/foo", "busybox", "ls", "/")
 
-	out, _ = dockerCmd(c, "volume", "ls")
+	out = dockerCmd(c, "volume", "ls")
 	outArr := strings.Split(strings.TrimSpace(out), "\n")
 	c.Assert(len(outArr), check.Equals, 4, check.Commentf("\n%s", out))
 
@@ -52,14 +52,14 @@ func (s *DockerSuite) TestVolumeCliLs(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumeCliRm(c *check.C) {
-	out, _ := dockerCmd(c, "volume", "create")
+	out := dockerCmd(c, "volume", "create")
 	id := strings.TrimSpace(out)
 
 	dockerCmd(c, "volume", "create", "--name", "test")
 	dockerCmd(c, "volume", "rm", id)
 	dockerCmd(c, "volume", "rm", "test")
 
-	out, _ = dockerCmd(c, "volume", "ls")
+	out = dockerCmd(c, "volume", "ls")
 	outArr := strings.Split(strings.TrimSpace(out), "\n")
 	c.Assert(len(outArr), check.Equals, 1, check.Commentf("%s\n", out))
 
@@ -71,13 +71,13 @@ func (s *DockerSuite) TestVolumeCliRm(c *check.C) {
 		check.Not(check.IsNil),
 		check.Commentf("Should not be able to remove volume that is in use by a container\n%s", out))
 
-	out, _ = dockerCmd(c, "run", "--volumes-from=test", "--name=test2", "busybox", "sh", "-c", "cat /foo/bar")
+	out = dockerCmd(c, "run", "--volumes-from=test", "--name=test2", "busybox", "sh", "-c", "cat /foo/bar")
 	c.Assert(strings.TrimSpace(out), check.Equals, "hello")
 	dockerCmd(c, "rm", "-fv", "test2")
 	dockerCmd(c, "volume", "inspect", volumeID)
 	dockerCmd(c, "rm", "-f", "test")
 
-	out, _ = dockerCmd(c, "run", "--name=test2", "-v", volumeID+":/foo", "busybox", "sh", "-c", "cat /foo/bar")
+	out = dockerCmd(c, "run", "--name=test2", "-v", volumeID+":/foo", "busybox", "sh", "-c", "cat /foo/bar")
 	c.Assert(strings.TrimSpace(out), check.Equals, "hello", check.Commentf("volume data was removed"))
 	dockerCmd(c, "rm", "test2")
 
@@ -90,7 +90,7 @@ func (s *DockerSuite) TestVolumeCliRm(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumeCliNoArgs(c *check.C) {
-	out, _ := dockerCmd(c, "volume")
+	out := dockerCmd(c, "volume")
 	// no args should produce the `volume ls` output
 	c.Assert(strings.Contains(out, "DRIVER"), check.Equals, true)
 

--- a/integration-cli/docker_cli_wait_test.go
+++ b/integration-cli/docker_cli_wait_test.go
@@ -11,14 +11,14 @@ import (
 
 // non-blocking wait with 0 exit code
 func (s *DockerSuite) TestWaitNonBlockedExitZero(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "true")
+	out := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "true")
 	containerID := strings.TrimSpace(out)
 
 	if err := waitInspect(containerID, "{{.State.Running}}", "false", 1); err != nil {
 		c.Fatal("Container should have stopped by now")
 	}
 
-	out, _ = dockerCmd(c, "wait", containerID)
+	out = dockerCmd(c, "wait", containerID)
 	if strings.TrimSpace(out) != "0" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -27,7 +27,7 @@ func (s *DockerSuite) TestWaitNonBlockedExitZero(c *check.C) {
 
 // blocking wait with 0 exit code
 func (s *DockerSuite) TestWaitBlockedExitZero(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "trap 'exit 0' TERM; while true; do sleep 0.01; done")
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "trap 'exit 0' TERM; while true; do sleep 0.01; done")
 	containerID := strings.TrimSpace(out)
 
 	c.Assert(waitRun(containerID), check.IsNil)
@@ -54,14 +54,14 @@ func (s *DockerSuite) TestWaitBlockedExitZero(c *check.C) {
 
 // non-blocking wait with random exit code
 func (s *DockerSuite) TestWaitNonBlockedExitRandom(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "exit 99")
+	out := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "exit 99")
 	containerID := strings.TrimSpace(out)
 
 	if err := waitInspect(containerID, "{{.State.Running}}", "false", 1); err != nil {
 		c.Fatal("Container should have stopped by now")
 	}
 
-	out, _ = dockerCmd(c, "wait", containerID)
+	out = dockerCmd(c, "wait", containerID)
 	if strings.TrimSpace(out) != "99" {
 		c.Fatal("failed to set up container", out)
 	}
@@ -70,7 +70,7 @@ func (s *DockerSuite) TestWaitNonBlockedExitRandom(c *check.C) {
 
 // blocking wait with random exit code
 func (s *DockerSuite) TestWaitBlockedExitRandom(c *check.C) {
-	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "trap 'exit 99' TERM; while true; do sleep 0.01; done")
+	out := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "trap 'exit 99' TERM; while true; do sleep 0.01; done")
 	containerID := strings.TrimSpace(out)
 	c.Assert(waitRun(containerID), check.IsNil)
 

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -642,10 +642,10 @@ func dockerCmdWithStdoutStderr(c *check.C, args ...string) (string, string, int)
 	return stdout, stderr, status
 }
 
-func dockerCmd(c *check.C, args ...string) (string, int) {
-	out, status, err := runCommandWithOutput(exec.Command(dockerBinary, args...))
-	c.Assert(err, check.IsNil, check.Commentf("%q failed with errors: %s, %v", strings.Join(args, " "), out, err))
-	return out, status
+func dockerCmd(c *check.C, args ...string) string {
+	out, exitCode, err := runCommandWithOutput(exec.Command(dockerBinary, args...))
+	c.Assert(err, check.IsNil, check.Commentf("%q failed with errors: %s, %v (%v)", strings.Join(args, " "), out, err, exitCode))
+	return out
 }
 
 // execute a docker command with a timeout
@@ -1034,10 +1034,7 @@ func getContainerState(c *check.C, id string) (int, bool, error) {
 		exitStatus int
 		running    bool
 	)
-	out, exitCode := dockerCmd(c, "inspect", "--format={{.State.Running}} {{.State.ExitCode}}", id)
-	if exitCode != 0 {
-		return 0, false, fmt.Errorf("%q doesn't exist: %s", id, out)
-	}
+	out := dockerCmd(c, "inspect", "--format={{.State.Running}} {{.State.ExitCode}}", id)
 
 	out = strings.Trim(out, "\n")
 	splitOutput := strings.Split(out, " ")

--- a/integration-cli/trust_server.go
+++ b/integration-cli/trust_server.go
@@ -154,9 +154,7 @@ func (s *DockerTrustSuite) setupTrustedImage(c *check.C, name string) string {
 		c.Fatalf("Missing expected output on trusted push:\n%s", out)
 	}
 
-	if out, status := dockerCmd(c, "rmi", repoName); status != 0 {
-		c.Fatalf("Error removing image %q\n%s", repoName, out)
-	}
+	dockerCmd(c, "rmi", repoName)
 
 	return repoName
 }


### PR DESCRIPTION
Looking back at #14603, there is still something that felt weird : we are using `dockerCmd` 99% of the time like this :

``` go
out, _ := dockerCmd(c, "ps")
```

The reason is the following : we don't really care about the error code in that case, because how it's written it will always be 0 if the method _passes_. If we look at https://github.com/docker/docker/blob/master/integration-cli/utils.go#L60 the error code will not be 0 if there is an error — and if there is a error, the assert is _KO_ and the test will fail. 🐧

I might miss something, and in that case feel free to close this one :wink:. 
🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
