### PR TITLE
Doc fixes in daemon/logger, update NewCopier method

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -735,10 +735,7 @@ func (container *Container) startLogging() error {
 		return fmt.Errorf("Failed to initialize logging driver: %v", err)
 	}
 
-	copier, err := logger.NewCopier(container.ID, map[string]io.Reader{"stdout": container.StdoutPipe(), "stderr": container.StderrPipe()}, l)
-	if err != nil {
-		return err
-	}
+	copier := logger.NewCopier(container.ID, map[string]io.Reader{"stdout": container.StdoutPipe(), "stderr": container.StderrPipe()}, l)
 	container.logCopier = copier
 	copier.Run()
 	container.logDriver = l

--- a/daemon/logger/copier.go
+++ b/daemon/logger/copier.go
@@ -14,7 +14,7 @@ import (
 // ContainerID and Timestamp.
 // Writes are concurrent, so you need implement some sync in your logger
 type Copier struct {
-	// cid is container id for which we copying logs
+	// cid is the container id for which we are copying logs
 	cid string
 	// srcs is map of name -> reader pairs, for example "stdout", "stderr"
 	srcs     map[string]io.Reader
@@ -22,13 +22,13 @@ type Copier struct {
 	copyJobs sync.WaitGroup
 }
 
-// NewCopier creates new Copier
-func NewCopier(cid string, srcs map[string]io.Reader, dst Logger) (*Copier, error) {
+// NewCopier creates a new Copier
+func NewCopier(cid string, srcs map[string]io.Reader, dst Logger) *Copier {
 	return &Copier{
 		cid:  cid,
 		srcs: srcs,
 		dst:  dst,
-	}, nil
+	}
 }
 
 // Run starts logs copying

--- a/daemon/logger/copier_test.go
+++ b/daemon/logger/copier_test.go
@@ -50,15 +50,12 @@ func TestCopier(t *testing.T) {
 	jsonLog := &TestLoggerJSON{Encoder: json.NewEncoder(&jsonBuf)}
 
 	cid := "a7317399f3f857173c6179d44823594f8294678dea9999662e5c625b5a1c7657"
-	c, err := NewCopier(cid,
+	c := NewCopier(cid,
 		map[string]io.Reader{
 			"stdout": &stdout,
 			"stderr": &stderr,
 		},
 		jsonLog)
-	if err != nil {
-		t.Fatal(err)
-	}
 	c.Run()
 	wait := make(chan struct{})
 	go func() {


### PR DESCRIPTION
NewCopier always returned `nil` as the error. Refactored to remove the error return.
