### PR TITLE
Use pointer for MemorySwappiness.

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -280,7 +280,11 @@ func populateCommand(c *Container, env []string) error {
 		BlkioWeight:      c.hostConfig.BlkioWeight,
 		Rlimits:          rlimits,
 		OomKillDisable:   c.hostConfig.OomKillDisable,
-		MemorySwappiness: c.hostConfig.MemorySwappiness,
+		MemorySwappiness: -1,
+	}
+
+	if c.hostConfig.MemorySwappiness != nil {
+		resources.MemorySwappiness = *c.hostConfig.MemorySwappiness
 	}
 
 	processConfig := execdriver.ProcessConfig{

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -177,13 +177,16 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, 
 	if hostConfig.Memory == 0 && hostConfig.MemorySwap > 0 {
 		return warnings, fmt.Errorf("You should always set the Memory limit when using Memoryswap limit, see usage.")
 	}
-	if hostConfig.MemorySwappiness != -1 && !daemon.SystemConfig().MemorySwappiness {
+	if hostConfig.MemorySwappiness != nil && !daemon.SystemConfig().MemorySwappiness {
 		warnings = append(warnings, "Your kernel does not support memory swappiness capabilities, memory swappiness discarded.")
 		logrus.Warnf("Your kernel does not support memory swappiness capabilities, memory swappiness discarded.")
-		hostConfig.MemorySwappiness = -1
+		hostConfig.MemorySwappiness = nil
 	}
-	if hostConfig.MemorySwappiness != -1 && (hostConfig.MemorySwappiness < 0 || hostConfig.MemorySwappiness > 100) {
-		return warnings, fmt.Errorf("Invalid value: %d, valid memory swappiness range is 0-100.", hostConfig.MemorySwappiness)
+	if hostConfig.MemorySwappiness != nil {
+		swappiness := *hostConfig.MemorySwappiness
+		if swappiness < -1 || swappiness > 100 {
+			return warnings, fmt.Errorf("Invalid value: %v, valid memory swappiness range is 0-100.", swappiness)
+		}
 	}
 	if hostConfig.CPUPeriod > 0 && !daemon.SystemConfig().CpuCfsPeriod {
 		warnings = append(warnings, "Your kernel does not support CPU cfs period. Period discarded.")

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -260,19 +260,19 @@ func NewCapList(caps []string) *CapList {
 // Here, "non-portable" means "dependent of the host we are running on".
 // Portable information *should* appear in Config.
 type HostConfig struct {
-	Binds            []string         // List of volume bindings for this container
-	ContainerIDFile  string           // File (path) where the containerId is written
-	LxcConf          *LxcConfig       // Additional lxc configuration
-	Memory           int64            // Memory limit (in bytes)
-	MemorySwap       int64            // Total memory usage (memory + swap); set `-1` to disable swap
-	CPUShares        int64            `json:"CpuShares"` // CPU shares (relative weight vs. other containers)
-	CPUPeriod        int64            `json:"CpuPeriod"` // CPU CFS (Completely Fair Scheduler) period
-	CpusetCpus       string           // CpusetCpus 0-2, 0,1
-	CpusetMems       string           // CpusetMems 0-2, 0,1
-	CPUQuota         int64            `json:"CpuQuota"` // CPU CFS (Completely Fair Scheduler) quota
-	BlkioWeight      int64            // Block IO weight (relative weight vs. other containers)
-	OomKillDisable   bool             // Whether to disable OOM Killer or not
-	MemorySwappiness int64            // Tuning container memory swappiness behaviour
+	Binds            []string   // List of volume bindings for this container
+	ContainerIDFile  string     // File (path) where the containerId is written
+	LxcConf          *LxcConfig // Additional lxc configuration
+	Memory           int64      // Memory limit (in bytes)
+	MemorySwap       int64      // Total memory usage (memory + swap); set `-1` to disable swap
+	CPUShares        int64      `json:"CpuShares"` // CPU shares (relative weight vs. other containers)
+	CPUPeriod        int64      `json:"CpuPeriod"` // CPU CFS (Completely Fair Scheduler) period
+	CpusetCpus       string     // CpusetCpus 0-2, 0,1
+	CpusetMems       string     // CpusetMems 0-2, 0,1
+	CPUQuota         int64      `json:"CpuQuota"` // CPU CFS (Completely Fair Scheduler) quota
+	BlkioWeight      int64      // Block IO weight (relative weight vs. other containers)
+	OomKillDisable   bool       // Whether to disable OOM Killer or not
+	MemorySwappiness *int64
 	Privileged       bool             // Is the container in privileged mode
 	PortBindings     nat.PortMap      // Port mapping between the exposed port (container) and the host
 	Links            []string         // List of links (in the name:alias form)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -362,7 +362,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		CPUQuota:         *flCPUQuota,
 		BlkioWeight:      *flBlkioWeight,
 		OomKillDisable:   *flOomKillDisable,
-		MemorySwappiness: swappiness,
+		MemorySwappiness: flSwappiness,
 		Privileged:       *flPrivileged,
 		PortBindings:     portBindings,
 		Links:            flLinks.GetAll(),


### PR DESCRIPTION
So we marshal/unmarshal its value properly when it's empty/missing/nil.

To consider instead of #14619.

Signed-off-by: David Calavera david.calavera@gmail.com
