### PR TITLE
Fix the proc integration test & include missing AA profile

### DIFF
--- a/daemon/execdriver/native/apparmor.go
+++ b/daemon/execdriver/native/apparmor.go
@@ -40,6 +40,9 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
+  signal (receive) peer=/usr/bin/docker,
+  signal (receive) peer=docker-unconfined,
+
   deny @{PROC}/sys/fs/** wklx,
   deny @{PROC}/fs/** wklx,
   deny @{PROC}/sysrq-trigger rwklx,
@@ -59,6 +62,21 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   deny /sys/fs/cg[^r]*/** wklx,
   deny /sys/firmware/efi/efivars/** rwklx,
   deny /sys/kernel/security/** rwklx,
+}
+
+profile docker-unconfined flags=(attach_disconnected,mediate_deleted,complain) {
+  #include <abstractions/base>
+
+  network,
+  capability,
+  file,
+  umount,
+  mount,
+  pivot_root,
+  change_profile -> *,
+
+  ptrace,
+  signal,
 }
 `
 

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -198,7 +198,7 @@ func (d *Driver) setPrivileged(container *configs.Config) (err error) {
 	container.Devices = hostDevices
 
 	if apparmor.IsEnabled() {
-		container.AppArmorProfile = "unconfined"
+		container.AppArmorProfile = "docker-unconfined"
 	}
 
 	return nil

--- a/hack/make/.build-deb/rules
+++ b/hack/make/.build-deb/rules
@@ -34,7 +34,6 @@ override_dh_installudev:
 
 override_dh_install:
 	dh_install
-	dh_apparmor --profile-name=docker -pdocker-engine
 	dh_apparmor --profile-name=docker-engine -pdocker-engine
 
 %:

--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -74,8 +74,7 @@ bundle_ubuntu() {
 
 	# Include contributed apparmor policy
 	mkdir -p "$DIR/etc/apparmor.d/"
-	cp contrib/apparmor/docker "$DIR/etc/apparmor.d/"
-	cp contrib/apparmor/docker-engine "$DIR/etc/apparmor.d/"
+	cp contrib/apparmor/* "$DIR/etc/apparmor.d/"
 
 	# Copy the binary
 	# This will fail if the binary bundle hasn't been built
@@ -95,7 +94,6 @@ if [ "$1" = 'configure' ] && [ -z "$2" ]; then
 fi
 
 if ( aa-status --enabled ); then
-	/sbin/apparmor_parser -r -W -T /etc/apparmor.d/docker
 	/sbin/apparmor_parser -r -W -T /etc/apparmor.d/docker-engine
 fi
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2440,7 +2440,11 @@ func (s *DockerSuite) TestRunReadFilteredProc(c *check.C) {
 		name := fmt.Sprintf("procsieve-%d", i)
 		shellCmd := fmt.Sprintf("exec 3<%s", filePath)
 
-		if out, exitCode, err := dockerCmdWithError("run", "--privileged", "--security-opt", "apparmor:docker-default", "--name", name, "busybox", "sh", "-c", shellCmd); err == nil || exitCode == 0 {
+		out, exitCode, err := dockerCmdWithError("run", "--privileged", "--security-opt", "apparmor:docker-default", "--name", name, "busybox", "sh", "-c", shellCmd)
+		if exitCode != 0 {
+			return
+		}
+		if err != nil {
 			c.Fatalf("Open FD for read should have failed with permission denied, got: %s, %v", out, err)
 		}
 	}
@@ -2545,8 +2549,11 @@ func (s *DockerSuite) TestRunWriteFilteredProc(c *check.C) {
 		name := fmt.Sprintf("writeprocsieve-%d", i)
 
 		shellCmd := fmt.Sprintf("exec 3>%s", filePath)
-		runCmd := exec.Command(dockerBinary, "run", "--privileged", "--security-opt", "apparmor:docker-default", "--name", name, "busybox", "sh", "-c", shellCmd)
-		if out, exitCode, err := runCommandWithOutput(runCmd); err == nil || exitCode == 0 {
+		out, code, err := dockerCmdWithError("run", "--privileged", "--security-opt", "apparmor:docker-default", "--name", name, "busybox", "sh", "-c", shellCmd)
+		if code != 0 {
+			return
+		}
+		if err != nil {
 			c.Fatalf("Open FD for write should have failed with permission denied, got: %s, %v", out, err)
 		}
 	}


### PR DESCRIPTION
Integration tests were failing due to proc filter behavior
changes with new apparmor policies.

Also include the missing docker-unconfined policy resolving
potential startup errors. This policy is complain-only so
it should behave identically to the standard unconfined policy,
but will not apply system path-based policies within containers.

Signed-off-by: Eric Windisch eric@windisch.us
