### PR TITLE
Set uuid.Loggerf to nop on client and to logrus.Warnf on daemon

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/docker/distribution/uuid"
 	"github.com/docker/docker/cli"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/opts"
@@ -98,6 +99,10 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, clientFlags *cli.ClientF
 	}
 
 	cli.init = func() error {
+
+		// ignore errors from uuid package when running client commands
+		uuid.Loggerf = func(string, ...interface{}) {}
+
 		clientFlags.PostParse()
 
 		hosts := clientFlags.Common.Hosts

--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/uuid"
 	apiserver "github.com/docker/docker/api/server"
 	"github.com/docker/docker/autogen/dockerversion"
 	"github.com/docker/docker/cli"
@@ -154,6 +155,9 @@ func getGlobalFlag() (globalFlag *flag.Flag) {
 
 // CmdDaemon is the daemon command, called the raw arguments after `docker daemon`.
 func (cli *DaemonCli) CmdDaemon(args ...string) error {
+	// warn from uuid package when running the daemon
+	uuid.Loggerf = logrus.Warnf
+
 	if *flDaemon {
 		// allow legacy forms `docker -D -d` and `docker -d -D`
 		logrus.Warn("please use 'docker daemon' instead.")


### PR DESCRIPTION
To fix the /dev/urandom related CI errors we're seeing

Signed-off-by: Tibor Vass tibor@docker.com
