### PR TITLE
Windows [TP3] - make docker cp functional

### DIFF
--- a/api/server/form.go
+++ b/api/server/form.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -43,7 +44,7 @@ func archiveFormValues(r *http.Request, vars map[string]string) (archiveOptions,
 	}
 
 	name := vars["name"]
-	path := r.Form.Get("path")
+	path := filepath.FromSlash(r.Form.Get("path"))
 
 	switch {
 	case name == "":

--- a/pkg/archive/copy_unix.go
+++ b/pkg/archive/copy_unix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package archive
+
+import (
+	"path/filepath"
+)
+
+func normalizePath(path string) string {
+	return filepath.ToSlash(path)
+}

--- a/pkg/archive/copy_windows.go
+++ b/pkg/archive/copy_windows.go
@@ -1,0 +1,9 @@
+package archive
+
+import (
+	"path/filepath"
+)
+
+func normalizePath(path string) string {
+	return filepath.FromSlash(path)
+}

--- a/pkg/symlink/fs.go
+++ b/pkg/symlink/fs.go
@@ -14,13 +14,14 @@ import (
 	"strings"
 )
 
-// FollowSymlinkInScope is a wrapper around evalSymlinksInScope that returns an absolute path
+// FollowSymlinkInScope is a wrapper around evalSymlinksInScope that returns an
+// absolute path. This function handles paths in a platform-agnostic manner.
 func FollowSymlinkInScope(path, root string) (string, error) {
-	path, err := filepath.Abs(path)
+	path, err := filepath.Abs(filepath.FromSlash(path))
 	if err != nil {
 		return "", err
 	}
-	root, err = filepath.Abs(root)
+	root, err = filepath.Abs(filepath.FromSlash(root))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. This gets docker cp running against a Windows container.
