### PR TITLE
Documentation improvements and code cleanups for graph package

### DIFF
--- a/api/client/build.go
+++ b/api/client/build.go
@@ -526,7 +526,7 @@ func rewriteDockerfileFrom(dockerfileName string, translator func(string, regist
 			// Replace the line with a resolved "FROM repo@digest"
 			repo, tag := parsers.ParseRepositoryTag(matches[1])
 			if tag == "" {
-				tag = tags.DEFAULTTAG
+				tag = tags.DefaultTag
 			}
 			ref := registry.ParseReference(tag)
 

--- a/api/client/create.go
+++ b/api/client/create.go
@@ -26,7 +26,7 @@ func (cli *DockerCli) pullImageCustomOut(image string, out io.Writer) error {
 	repos, tag := parsers.ParseRepositoryTag(image)
 	// pull only the image tagged 'latest' if no tag was specified
 	if tag == "" {
-		tag = tags.DEFAULTTAG
+		tag = tags.DefaultTag
 	}
 	v.Set("fromImage", repos)
 	v.Set("tag", tag)
@@ -96,7 +96,7 @@ func (cli *DockerCli) createContainer(config *runconfig.Config, hostConfig *runc
 
 	repo, tag := parsers.ParseRepositoryTag(config.Image)
 	if tag == "" {
-		tag = tags.DEFAULTTAG
+		tag = tags.DefaultTag
 	}
 
 	ref := registry.ParseReference(tag)

--- a/api/client/pull.go
+++ b/api/client/pull.go
@@ -25,7 +25,7 @@ func (cli *DockerCli) CmdPull(args ...string) error {
 
 	taglessRemote, tag := parsers.ParseRepositoryTag(remote)
 	if tag == "" && !*allTags {
-		tag = tags.DEFAULTTAG
+		tag = tags.DefaultTag
 		fmt.Fprintf(cli.out, "Using default tag: %s\n", tag)
 	} else if tag != "" && *allTags {
 		return fmt.Errorf("tag can't be used with --all-tags/-a")

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/graph"
+	"github.com/docker/docker/graph/tags"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/runconfig"
@@ -27,7 +27,7 @@ func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hos
 		if daemon.Graph().IsNotExist(err, config.Image) {
 			_, tag := parsers.ParseRepositoryTag(config.Image)
 			if tag == "" {
-				tag = graph.DefaultTag
+				tag = tags.DefaultTag
 			}
 			return "", warnings, fmt.Errorf("No such image: %s (tag: %s)", config.Image, tag)
 		}

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/graph"
+	"github.com/docker/docker/graph/tags"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/stringid"
@@ -27,16 +27,13 @@ func (daemon *Daemon) ImageDelete(name string, force, noprune bool) ([]types.Ima
 }
 
 func (daemon *Daemon) imgDeleteHelper(name string, list *[]types.ImageDelete, first, force, noprune bool) error {
-	var (
-		repoName, tag string
-		tags          = []string{}
-	)
+	var repoName, tag string
 	repoAndTags := make(map[string][]string)
 
 	// FIXME: please respect DRY and centralize repo+tag parsing in a single central place! -- shykes
 	repoName, tag = parsers.ParseRepositoryTag(name)
 	if tag == "" {
-		tag = graph.DefaultTag
+		tag = tags.DefaultTag
 	}
 
 	if name == "" {
@@ -111,7 +108,7 @@ func (daemon *Daemon) imgDeleteHelper(name string, list *[]types.ImageDelete, fi
 			}
 		}
 	}
-	tags = daemon.Repositories().ByID()[img.ID]
+	tags := daemon.Repositories().ByID()[img.ID]
 	if (len(tags) <= 1 && repoName == "") || len(tags) == 0 {
 		if len(byParents[img.ID]) == 0 {
 			if err := daemon.Repositories().DeleteAll(img.ID); err != nil {

--- a/graph/export.go
+++ b/graph/export.go
@@ -13,21 +13,12 @@ import (
 	"github.com/docker/docker/registry"
 )
 
-// ImageExportConfig holds list of names to be exported to a output stream.
-// All images with the given tag and all versions
-// containing the same tag are exported. The resulting output is an
-// uncompressed tar ball.
-type ImageExportConfig struct {
-	// Names is the set of tags to export.
-	Names []string
-	// OutStream is the writer where the images are written to.
-	Outstream io.Writer
-}
-
-// ImageExport exports list of images to a output stream specified in the config.
-// The exported images are archived into a tar when written to the output stream.
-func (s *TagStore) ImageExport(imageExportConfig *ImageExportConfig) error {
-
+// ImageExport exports list of images to a output stream specified in the
+// config. The exported images are archived into a tar when written to the
+// output stream. All images with the given tag and all versions containing the
+// same tag are exported. names is the set of tags to export, and outStream
+// is the writer which the images are written to.
+func (s *TagStore) ImageExport(names []string, outStream io.Writer) error {
 	// get image json
 	tempdir, err := ioutil.TempDir("", "docker-export-")
 	if err != nil {
@@ -44,7 +35,7 @@ func (s *TagStore) ImageExport(imageExportConfig *ImageExportConfig) error {
 			repo[tag] = id
 		}
 	}
-	for _, name := range imageExportConfig.Names {
+	for _, name := range names {
 		name = registry.NormalizeLocalName(name)
 		logrus.Debugf("Serializing %s", name)
 		rootRepo := s.Repositories[name]
@@ -107,7 +98,7 @@ func (s *TagStore) ImageExport(imageExportConfig *ImageExportConfig) error {
 	}
 	defer fs.Close()
 
-	if _, err := io.Copy(imageExportConfig.Outstream, fs); err != nil {
+	if _, err := io.Copy(outStream, fs); err != nil {
 		return err
 	}
 	logrus.Debugf("End export image")

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -152,10 +152,11 @@ func (graph *Graph) restore() error {
 	return nil
 }
 
-// IsNotExist detects whether an image exists by parsing the incoming error message.
-// FIXME: Implement error subclass instead of looking at the error text
-// Note: This is the way golang implements os.IsNotExists on Plan9
+// IsNotExist detects whether an image exists by parsing the incoming error
+// message.
 func (graph *Graph) IsNotExist(err error, id string) bool {
+	// FIXME: Implement error subclass instead of looking at the error text
+	// Note: This is the way golang implements os.IsNotExists on Plan9
 	return err != nil && (strings.Contains(strings.ToLower(err.Error()), "does not exist") || strings.Contains(strings.ToLower(err.Error()), "no such")) && strings.Contains(err.Error(), id)
 }
 
@@ -415,13 +416,13 @@ func (graph *Graph) ByParent() map[string][]*image.Image {
 	return byParent
 }
 
-// Retain keeps the images and layers that are in pulling chain so that they are not deleted.
-// If not, they may be deleted by rmi with dangling condition.
+// Retain keeps the images and layers that are in the pulling chain so that
+// they are not deleted. If not retained, they may be deleted by rmi.
 func (graph *Graph) Retain(sessionID string, layerIDs ...string) {
 	graph.retained.Add(sessionID, layerIDs)
 }
 
-// Release removes the referenced image id from the provided set of layers.
+// Release removes the referenced image ID from the provided set of layers.
 func (graph *Graph) Release(sessionID string, layerIDs ...string) {
 	graph.retained.Delete(sessionID, layerIDs)
 }

--- a/graph/history.go
+++ b/graph/history.go
@@ -67,7 +67,8 @@ func (graph *Graph) CheckDepth(img *image.Image) error {
 	return nil
 }
 
-// History returns a list of ImageHistory for the specified image name by walking the image lineage.
+// History returns a slice of ImageHistory structures for the specified image
+// name by walking the image lineage.
 func (s *TagStore) History(name string) ([]*types.ImageHistory, error) {
 	foundImage, err := s.LookupImage(name)
 	if err != nil {
@@ -102,7 +103,7 @@ func (s *TagStore) History(name string) ([]*types.ImageHistory, error) {
 	return history, err
 }
 
-// GetParent returns the parent image.
+// GetParent returns the parent image for the specified image.
 func (graph *Graph) GetParent(img *image.Image) (*image.Image, error) {
 	if img.Parent == "" {
 		return nil, nil
@@ -110,12 +111,12 @@ func (graph *Graph) GetParent(img *image.Image) (*image.Image, error) {
 	return graph.Get(img.Parent)
 }
 
-// GetParentsSize returns the size of the parent.
-func (graph *Graph) GetParentsSize(img *image.Image, size int64) int64 {
+// GetParentsSize returns the combined size of all parent images. If there is
+// no parent image or it's unavailable, it returns 0.
+func (graph *Graph) GetParentsSize(img *image.Image) int64 {
 	parentImage, err := graph.GetParent(img)
 	if err != nil || parentImage == nil {
-		return size
+		return 0
 	}
-	size += parentImage.Size
-	return graph.GetParentsSize(parentImage, size)
+	return parentImage.Size + graph.GetParentsSize(parentImage)
 }

--- a/graph/load.go
+++ b/graph/load.go
@@ -71,7 +71,7 @@ func (s *TagStore) Load(inTar io.ReadCloser, outStream io.Writer) error {
 
 	for imageName, tagMap := range repositories {
 		for tag, address := range tagMap {
-			if err := s.SetLoad(imageName, tag, address, true, outStream); err != nil {
+			if err := s.setLoad(imageName, tag, address, true, outStream); err != nil {
 				return err
 			}
 		}

--- a/graph/push.go
+++ b/graph/push.go
@@ -12,17 +12,21 @@ import (
 
 // ImagePushConfig stores push configuration.
 type ImagePushConfig struct {
-	// MetaHeaders store meta data about the image (DockerHeaders with prefix X-Meta- in the request).
+	// MetaHeaders store HTTP headers with metadata about the image
+	// (DockerHeaders with prefix X-Meta- in the request).
 	MetaHeaders map[string][]string
-	// AuthConfig holds authentication information for authorizing with the registry.
+	// AuthConfig holds authentication credentials for authenticating with
+	// the registry.
 	AuthConfig *cliconfig.AuthConfig
-	// Tag is the specific variant of the image to be pushed, this tag used when image is pushed. If no tag is provided, all tags will be pushed.
+	// Tag is the specific variant of the image to be pushed.
+	// If no tag is provided, all tags will be pushed.
 	Tag string
-	// OutStream is the output writer for showing the status of the push operation.
+	// OutStream is the output writer for showing the status of the push
+	// operation.
 	OutStream io.Writer
 }
 
-// Pusher is an interface to define Push behavior.
+// Pusher is an interface that abstracts pushing for different API versions.
 type Pusher interface {
 	// Push tries to push the image configured at the creation of Pusher.
 	// Push returns an error if any, as well as a boolean that determines whether to retry Push on the next configured endpoint.
@@ -31,7 +35,11 @@ type Pusher interface {
 	Push() (fallback bool, err error)
 }
 
-// NewPusher returns a new instance of an implementation conforming to Pusher interface.
+// NewPusher creates a new Pusher interface that will push to either a v1 or v2
+// registry. The endpoint argument contains a Version field that determines
+// whether a v1 or v2 pusher will be created. The other parameters are passed
+// through to the underlying pusher implementation for use during the actual
+// push operation.
 func (s *TagStore) NewPusher(endpoint registry.APIEndpoint, localRepo Repository, repoInfo *registry.RepositoryInfo, imagePushConfig *ImagePushConfig, sf *streamformatter.StreamFormatter) (Pusher, error) {
 	switch endpoint.Version {
 	case registry.APIVersion2:
@@ -57,10 +65,10 @@ func (s *TagStore) NewPusher(endpoint registry.APIEndpoint, localRepo Repository
 	return nil, fmt.Errorf("unknown version %d for registry %s", endpoint.Version, endpoint.URL)
 }
 
-// FIXME: Allow to interrupt current push when new push of same image is done.
-
-// Push a image to the repo.
+// Push initiates a push operation on the repository named localName.
 func (s *TagStore) Push(localName string, imagePushConfig *ImagePushConfig) error {
+	// FIXME: Allow to interrupt current push when new push of same image is done.
+
 	var sf = streamformatter.NewJSONStreamFormatter()
 
 	// Resolve the Repository name from fqn to RepositoryInfo

--- a/graph/registry.go
+++ b/graph/registry.go
@@ -27,7 +27,9 @@ func (dcs dumbCredentialStore) Basic(*url.URL) (string, string) {
 	return dcs.auth.Username, dcs.auth.Password
 }
 
-// NewV2Repository creates a v2 only repository.
+// NewV2Repository returns a repository (v2 only). It creates a HTTP transport
+// providing timeout settings and authentication support, and also verifies the
+// remote API version.
 func NewV2Repository(repoInfo *registry.RepositoryInfo, endpoint registry.APIEndpoint, metaHeaders http.Header, authConfig *cliconfig.AuthConfig) (distribution.Repository, error) {
 	ctx := context.Background()
 

--- a/graph/service.go
+++ b/graph/service.go
@@ -10,6 +10,8 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
+// lookupRaw looks up an image by name in a TagStore and returns the raw JSON
+// describing the image.
 func (s *TagStore) lookupRaw(name string) ([]byte, error) {
 	image, err := s.LookupImage(name)
 	if err != nil || image == nil {
@@ -24,7 +26,8 @@ func (s *TagStore) lookupRaw(name string) ([]byte, error) {
 	return imageInspectRaw, nil
 }
 
-// Lookup return an image encoded in JSON
+// Lookup looks up an image by name in a TagStore and returns it as an
+// ImageInspect structure.
 func (s *TagStore) Lookup(name string) (*types.ImageInspect, error) {
 	image, err := s.LookupImage(name)
 	if err != nil || image == nil {
@@ -44,7 +47,7 @@ func (s *TagStore) Lookup(name string) (*types.ImageInspect, error) {
 		Architecture:    image.Architecture,
 		Os:              image.OS,
 		Size:            image.Size,
-		VirtualSize:     s.graph.GetParentsSize(image, 0) + image.Size,
+		VirtualSize:     s.graph.GetParentsSize(image) + image.Size,
 	}
 
 	imageInspect.GraphDriver.Name = s.graph.driver.String()

--- a/graph/tags/tags.go
+++ b/graph/tags/tags.go
@@ -6,8 +6,12 @@ import (
 	"github.com/docker/distribution/registry/api/v2"
 )
 
-const DEFAULTTAG = "latest"
+// DefaultTag is the default tag for the case where no explicit tag is
+// specified.
+const DefaultTag = "latest"
 
+// ErrTagInvalidFormat is an error type used when the tag name has invalid
+// characters or is longer than allowed.
 type ErrTagInvalidFormat struct {
 	name string
 }

--- a/graph/tags_unit_test.go
+++ b/graph/tags_unit_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/daemon/graphdriver"
 	_ "github.com/docker/docker/daemon/graphdriver/vfs" // import the vfs driver so it is used in the tests
+	"github.com/docker/docker/graph/tags"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/trust"
 	"github.com/docker/docker/utils"
@@ -119,17 +120,17 @@ func TestLookupImage(t *testing.T) {
 		testOfficialImageName + ":" + testOfficialImageID,
 		testOfficialImageName + ":" + testOfficialImageIDShort,
 		testOfficialImageName,
-		testOfficialImageName + ":" + DefaultTag,
+		testOfficialImageName + ":" + tags.DefaultTag,
 		"docker.io/" + testOfficialImageName,
-		"docker.io/" + testOfficialImageName + ":" + DefaultTag,
+		"docker.io/" + testOfficialImageName + ":" + tags.DefaultTag,
 		"index.docker.io/" + testOfficialImageName,
-		"index.docker.io/" + testOfficialImageName + ":" + DefaultTag,
+		"index.docker.io/" + testOfficialImageName + ":" + tags.DefaultTag,
 		"library/" + testOfficialImageName,
-		"library/" + testOfficialImageName + ":" + DefaultTag,
+		"library/" + testOfficialImageName + ":" + tags.DefaultTag,
 		"docker.io/library/" + testOfficialImageName,
-		"docker.io/library/" + testOfficialImageName + ":" + DefaultTag,
+		"docker.io/library/" + testOfficialImageName + ":" + tags.DefaultTag,
 		"index.docker.io/library/" + testOfficialImageName,
-		"index.docker.io/library/" + testOfficialImageName + ":" + DefaultTag,
+		"index.docker.io/library/" + testOfficialImageName + ":" + tags.DefaultTag,
 	}
 
 	privateLookups := []string{
@@ -138,7 +139,7 @@ func TestLookupImage(t *testing.T) {
 		testPrivateImageName + ":" + testPrivateImageID,
 		testPrivateImageName + ":" + testPrivateImageIDShort,
 		testPrivateImageName,
-		testPrivateImageName + ":" + DefaultTag,
+		testPrivateImageName + ":" + tags.DefaultTag,
 	}
 
 	invalidLookups := []string{


### PR DESCRIPTION
Expand the godoc documentation for the graph package.

Centralize DefaultTag in the graphs/tag package instead of defining it
twice.

Remove some unnecessary "config" structs that are only used to pass
a few parameters to a function.

Simplify the GetParentsSize function - there's no reason for it to take
an accumulator argument.

Unexport some functions that aren't needed outside the package.
