### PR TITLE
[Blocking] Windows: Daemon build is currently broken

### DIFF
--- a/api/server/server_windows.go
+++ b/api/server/server_windows.go
@@ -19,7 +19,7 @@ func (s *Server) newServer(proto, addr string) ([]serverCloser, error) {
 	)
 	switch proto {
 	case "tcp":
-		l, err := s.initTcpSocket(addr)
+		l, err := s.initTCPSocket(addr)
 		if err != nil {
 			return nil, err
 		}
@@ -31,7 +31,7 @@ func (s *Server) newServer(proto, addr string) ([]serverCloser, error) {
 
 	var res []serverCloser
 	for _, l := range ls {
-		res = append(res, &HttpServer{
+		res = append(res, &HTTPServer{
 			&http.Server{
 				Addr:    addr,
 				Handler: s.router,

--- a/pkg/chrootarchive/diff_windows.go
+++ b/pkg/chrootarchive/diff_windows.go
@@ -9,23 +9,43 @@ import (
 	"github.com/docker/docker/pkg/archive"
 )
 
+// ApplyLayer parses a diff in the standard layer format from `layer`,
+// and applies it to the directory `dest`. The stream `layer` can only be
+// uncompressed.
+// Returns the size in bytes of the contents of the layer.
+func ApplyLayer(dest string, layer archive.ArchiveReader) (size int64, err error) {
+	return applyLayerHandler(dest, layer, true)
+}
+
+// ApplyUncompressedLayer parses a diff in the standard layer format from
+// `layer`, and applies it to the directory `dest`. The stream `layer`
+// can only be uncompressed.
+// Returns the size in bytes of the contents of the layer.
+func ApplyUncompressedLayer(dest string, layer archive.ArchiveReader) (int64, error) {
+	return applyLayerHandler(dest, layer, false)
+}
+
 // ApplyLayer parses a diff in the standard layer format from `layer`, and
 // applies it to the directory `dest`. Returns the size in bytes of the
 // contents of the layer.
-func ApplyLayer(dest string, layer archive.ArchiveReader) (size int64, err error) {
+func applyLayerHandler(dest string, layer archive.ArchiveReader, decompress bool) (size int64, err error) {
 	dest = filepath.Clean(dest)
-	decompressed, err := archive.DecompressStream(layer)
-	if err != nil {
-		return 0, err
+	if decompress {
+		decompressed, err := archive.DecompressStream(layer)
+		if err != nil {
+			return 0, err
+		}
+		defer decompressed.Close()
+
+		layer = decompressed
 	}
-	defer decompressed.Close()
 
 	tmpDir, err := ioutil.TempDir(os.Getenv("temp"), "temp-docker-extract")
 	if err != nil {
 		return 0, fmt.Errorf("ApplyLayer failed to create temp-docker-extract under %s. %s", dest, err)
 	}
 
-	s, err := archive.UnpackLayer(dest, decompressed)
+	s, err := archive.UnpackLayer(dest, layer)
 	os.RemoveAll(tmpDir)
 	if err != nil {
 		return 0, fmt.Errorf("ApplyLayer %s failed UnpackLayer to %s", err, dest)


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@vbatts @icecrime @calavera @cpuguy83 @swernli @jstarks @jfrazelle 

The Windows daemon build is currently broken after merges today. Merges have been taking place ignoring Windows CI build errors. This fixes that. @vbatts can you double-check the diff_windows.go change. I believe I have it right, but would like your input to be sure.
