### PR TITLE
Allow access to full logging context in `fluentd-tag`.

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -718,6 +718,7 @@ func (container *Container) getLogger() (logger.Logger, error) {
 		ContainerImageID:    container.ImageID,
 		ContainerImageName:  container.Config.Image,
 		ContainerCreated:    container.Created,
+		ContainerConfig:     container.Config,
 	}
 
 	// Set logging file for "json-logger"

--- a/daemon/logger/factory.go
+++ b/daemon/logger/factory.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/docker/docker/runconfig"
 )
 
 // Creator builds a logging driver instance with given context.
@@ -25,6 +27,7 @@ type Context struct {
 	ContainerImageID    string
 	ContainerImageName  string
 	ContainerCreated    time.Time
+	ContainerConfig     *runconfig.Config
 	LogPath             string
 }
 

--- a/daemon/logger/fluentd/fluentd.go
+++ b/daemon/logger/fluentd/fluentd.go
@@ -23,12 +23,6 @@ type fluentd struct {
 	writer        *fluent.Fluent
 }
 
-type receiver struct {
-	ID     string
-	FullID string
-	Name   string
-}
-
 const (
 	name             = "fluentd"
 	defaultHostName  = "localhost"
@@ -69,17 +63,12 @@ func parseConfig(ctx logger.Context) (string, int, string, error) {
 	}
 
 	if config["fluentd-tag"] != "" {
-		receiver := &receiver{
-			ID:     ctx.ContainerID[:12],
-			FullID: ctx.ContainerID,
-			Name:   ctx.ContainerName,
-		}
 		tmpl, err := template.New("tag").Parse(config["fluentd-tag"])
 		if err != nil {
 			return "", 0, "", err
 		}
 		buf := new(bytes.Buffer)
-		if err := tmpl.Execute(buf, receiver); err != nil {
+		if err := tmpl.Execute(buf, ctx); err != nil {
 			return "", 0, "", err
 		}
 		tag = buf.String()


### PR DESCRIPTION
For ECS containers the unique identifier is stored as a label. The easiest way to access this is by exposing the whole config object to the `fluentd-tag` option. The `fluentd-tag` used for ECS would then be:

```
{{index .ContainerConfig.Labels "com.amazonaws.ecs.task-arn"}}
```

It's not quite backwards compatible, but it's much more flexible; the existing structure is redundant and not necessary with Go templates.

e.g. `{{.ID}}` becomes `{{.ContainerID}}`
