### PR TITLE
Only explicitly deny ptrace for container-originated procs

### DIFF
--- a/daemon/execdriver/native/apparmor.go
+++ b/daemon/execdriver/native/apparmor.go
@@ -53,7 +53,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   deny @{PROC}/sys/kernel/*/** wklx,
 
   deny mount,
-  deny ptrace,
+  deny ptrace (trace) peer=docker-default,
 
   deny /sys/[^f]*/** wklx,
   deny /sys/f[^s]*/** wklx,


### PR DESCRIPTION
The 'deny ptrace' statement was supposed to only ignore
ptrace failures in the AUDIT log. However, ptrace was implicitly
allowed from unconfined processes (such as the docker daemon and
its integration tests) due to the abstractions/base include.

This rule narrows the definition such that it will only ignore
the failures originating inside of the container and will not
cause denials when the daemon or its tests ptrace inside processes.

Signed-off-by: Eric Windisch eric@windisch.us
