### PR TITLE
Don't mount /proc as ro

### DIFF
--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -85,7 +85,7 @@ func (d *Driver) createContainer(c *execdriver.Command) (*configs.Config, error)
 		}
 
 		/* These paths must be remounted as r/o */
-		container.ReadonlyPaths = append(container.ReadonlyPaths, "/proc", "/dev")
+		container.ReadonlyPaths = append(container.ReadonlyPaths, "/dev")
 	}
 
 	if err := d.setupMounts(container, c); err != nil {

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -543,3 +543,10 @@ func (s *DockerSuite) TestExecWithImageUser(c *check.C) {
 		c.Fatalf("exec with user by id expected dockerio user got %s", out)
 	}
 }
+
+func (s *DockerSuite) TestExecOnReadonlyContainer(c *check.C) {
+	dockerCmd(c, "run", "-d", "--read-only", "--name", "parent", "busybox", "top")
+	if _, status := dockerCmd(c, "exec", "parent", "true"); status != 0 {
+		c.Fatalf("exec into a read-only container failed with exit status %d", status)
+	}
+}

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2242,7 +2242,7 @@ func (s *DockerSuite) TestRunContainerWithWritableRootfs(c *check.C) {
 func (s *DockerSuite) TestRunContainerWithReadonlyRootfs(c *check.C) {
 	testRequires(c, NativeExecDriver)
 
-	for _, f := range []string{"/file", "/etc/hosts", "/etc/resolv.conf", "/etc/hostname", "/proc/uptime", "/sys/kernel", "/dev/.dont.touch.me"} {
+	for _, f := range []string{"/file", "/etc/hosts", "/etc/resolv.conf", "/etc/hostname", "/sys/kernel", "/dev/.dont.touch.me"} {
 		testReadOnlyFile(f, c)
 	}
 }


### PR DESCRIPTION
This caused a regression with LSM labeling.

Fixes #15135

Signed-off-by: Michael Crosby crosbymichael@gmail.com
