### PR TITLE
Tidy platform common bits in diff

### DIFF
--- a/pkg/chrootarchive/diff.go
+++ b/pkg/chrootarchive/diff.go
@@ -1,0 +1,19 @@
+package chrootarchive
+
+import "github.com/docker/docker/pkg/archive"
+
+// ApplyLayer parses a diff in the standard layer format from `layer`,
+// and applies it to the directory `dest`. The stream `layer` can only be
+// uncompressed.
+// Returns the size in bytes of the contents of the layer.
+func ApplyLayer(dest string, layer archive.ArchiveReader) (size int64, err error) {
+	return applyLayerHandler(dest, layer, true)
+}
+
+// ApplyUncompressedLayer parses a diff in the standard layer format from
+// `layer`, and applies it to the directory `dest`. The stream `layer`
+// can only be uncompressed.
+// Returns the size in bytes of the contents of the layer.
+func ApplyUncompressedLayer(dest string, layer archive.ArchiveReader) (int64, error) {
+	return applyLayerHandler(dest, layer, false)
+}

--- a/pkg/chrootarchive/diff_unix.go
+++ b/pkg/chrootarchive/diff_unix.go
@@ -65,22 +65,9 @@ func applyLayer() {
 	os.Exit(0)
 }
 
-// ApplyLayer parses a diff in the standard layer format from `layer`,
-// and applies it to the directory `dest`. The stream `layer` can only be
-// uncompressed.
-// Returns the size in bytes of the contents of the layer.
-func ApplyLayer(dest string, layer archive.ArchiveReader) (size int64, err error) {
-	return applyLayerHandler(dest, layer, true)
-}
-
-// ApplyUncompressedLayer parses a diff in the standard layer format from
-// `layer`, and applies it to the directory `dest`. The stream `layer`
-// can only be uncompressed.
-// Returns the size in bytes of the contents of the layer.
-func ApplyUncompressedLayer(dest string, layer archive.ArchiveReader) (int64, error) {
-	return applyLayerHandler(dest, layer, false)
-}
-
+// applyLayerHandler parses a diff in the standard layer format from `layer`, and
+// applies it to the directory `dest`. Returns the size in bytes of the
+// contents of the layer.
 func applyLayerHandler(dest string, layer archive.ArchiveReader, decompress bool) (size int64, err error) {
 	dest = filepath.Clean(dest)
 	if decompress {

--- a/pkg/chrootarchive/diff_windows.go
+++ b/pkg/chrootarchive/diff_windows.go
@@ -9,23 +9,7 @@ import (
 	"github.com/docker/docker/pkg/archive"
 )
 
-// ApplyLayer parses a diff in the standard layer format from `layer`,
-// and applies it to the directory `dest`. The stream `layer` can only be
-// uncompressed.
-// Returns the size in bytes of the contents of the layer.
-func ApplyLayer(dest string, layer archive.ArchiveReader) (size int64, err error) {
-	return applyLayerHandler(dest, layer, true)
-}
-
-// ApplyUncompressedLayer parses a diff in the standard layer format from
-// `layer`, and applies it to the directory `dest`. The stream `layer`
-// can only be uncompressed.
-// Returns the size in bytes of the contents of the layer.
-func ApplyUncompressedLayer(dest string, layer archive.ArchiveReader) (int64, error) {
-	return applyLayerHandler(dest, layer, false)
-}
-
-// ApplyLayer parses a diff in the standard layer format from `layer`, and
+// applyLayerHandler parses a diff in the standard layer format from `layer`, and
 // applies it to the directory `dest`. Returns the size in bytes of the
 // contents of the layer.
 func applyLayerHandler(dest string, layer archive.ArchiveReader, decompress bool) (size int64, err error) {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

There were a couple of identical functions in both pkg\chrootarchive\diff_windows and diff_unix.go. Have put these in a common file.
