### PR TITLE
Remove HostConfig,SetHostConfig from daemon.container

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -677,14 +677,6 @@ func (container *Container) Exposes(p nat.Port) bool {
 	return exists
 }
 
-func (container *Container) HostConfig() *runconfig.HostConfig {
-	return container.hostConfig
-}
-
-func (container *Container) SetHostConfig(hostConfig *runconfig.HostConfig) {
-	container.hostConfig = hostConfig
-}
-
 func (container *Container) getLogConfig() runconfig.LogConfig {
 	cfg := container.hostConfig.LogConfig
 	if cfg.Type != "" || len(cfg.Config) > 0 { // container has log driver configured

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -154,7 +154,7 @@ func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, 
 		}
 		newC.Created = int(container.Created.Unix())
 		newC.Status = container.State.String()
-		newC.HostConfig.NetworkMode = string(container.HostConfig().NetworkMode)
+		newC.HostConfig.NetworkMode = string(container.hostConfig.NetworkMode)
 
 		newC.Ports = []types.Port{}
 		for port, bindings := range container.NetworkSettings.Ports {


### PR DESCRIPTION
Never actually used outside of daemon package

Signed-off-by: Antonio Murdaca runcom@linux.com
