### PR TITLE
Windows: Top (non-)implementation

### DIFF
--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -1,3 +1,5 @@
+//+build !windows
+
 package daemon
 
 import (

--- a/daemon/top_windows.go
+++ b/daemon/top_windows.go
@@ -1,0 +1,11 @@
+package daemon
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+)
+
+func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.ContainerProcessList, error) {
+	return nil, fmt.Errorf("Top is not supported on Windows")
+}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This gives a clear error message that docker top is not (yet) implemented on Windows. As opposed to the previous error 'GetPidsForContainer() not implemented'.
