### PR TITLE
registry: allow fallback on unknown errors

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/api/v2"
+	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/autogen/dockerversion"
 	"github.com/docker/docker/pkg/parsers/kernel"
@@ -211,8 +212,14 @@ func ContinueOnError(err error) bool {
 		return ContinueOnError(v.Err)
 	case errcode.Error:
 		return shouldV2Fallback(v)
+	case *client.UnexpectedHTTPResponseError:
+		return true
 	}
-	return false
+	// let's be nice and fallback if the error is a completely
+	// unexpected one.
+	// If new errors have to be handled in some way, please
+	// add them to the switch above.
+	return true
 }
 
 // NewTransport returns a new HTTP transport. If tlsConfig is nil, it uses the


### PR DESCRIPTION
This patch fixes a bug where a user specifies a v1 mirror for
`--registry-mirror` and pull an image from the Hub.

It used to not fallback because of an unexpected error returned when
trying to JSON marshal nginx output.

We now ensure that any unexpected error falls back to the next endpoint
in the list.

Signed-off-by: Tibor Vass tibor@docker.com

Fixes #15130 
**Important Note**: v2 still has precedence over v1 mirrors, so specifying a v1 mirror to talk to a v2 endpoint will NOT work unless something blocks the v2 endpoint. Please use a v2 mirror in that case.
