### PR TITLE
Docs: Actually link to restart policy information

### DIFF
--- a/docs/articles/host_integration.md
+++ b/docs/articles/host_integration.md
@@ -12,7 +12,7 @@ weight = 99
 # Automatically start containers
 
 As of Docker 1.2,
-[restart policies](/reference/commandline/cli/#restart-policies) are the
+[restart policies](/reference/run/#restart-policies-restart) are the
 built-in Docker mechanism for restarting containers when they exit. If set,
 restart policies will be used when the Docker daemon starts up, as typically
 happens after a system boot. Restart policies will ensure that linked containers


### PR DESCRIPTION
on https://docs.docker.com/articles/host_integration/ https://docs.docker.com/reference/commandline/cli/#restart-policies is a broken link, so I replaced it.
Signed-off-by: jrabbit jackjrabbit@gmail.com
