### PR TITLE
pkg/namesgenerator: add a 'names-generator' binary

### DIFF
--- a/pkg/namesgenerator/cmd/names-generator/main.go
+++ b/pkg/namesgenerator/cmd/names-generator/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/pkg/namesgenerator"
+)
+
+func main() {
+	fmt.Println(namesgenerator.GetRandomName(0))
+}


### PR DESCRIPTION
This way, we can install this essential tool using `go get -v github.com/docker/docker/pkg/namesgenerator/cmd/names-generator`
