### PR TITLE
Replace kernel in user agent with more detailed OS

### DIFF
--- a/pkg/parsers/operatingsystem/operatingsystem_darwin.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_darwin.go
@@ -1,0 +1,12 @@
+package operatingsystem
+
+// GetOperatingSystem gets the name of the current operating system.
+func GetOperatingSystem() (string, error) {
+	return "Darwin", nil
+}
+
+// IsContainerized returns true if we are running inside a container.
+// No-op on Darwin, always returns false.
+func IsContainerized() (bool, error) {
+	return false, nil
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -21,7 +21,7 @@ import (
 	"github.com/docker/distribution/registry/client"
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/autogen/dockerversion"
-	"github.com/docker/docker/pkg/parsers/kernel"
+	"github.com/docker/docker/pkg/parsers/operatingsystem"
 	"github.com/docker/docker/pkg/tlsconfig"
 	"github.com/docker/docker/pkg/useragent"
 )
@@ -42,10 +42,11 @@ func init() {
 	httpVersion = append(httpVersion, useragent.VersionInfo{"docker", dockerversion.VERSION})
 	httpVersion = append(httpVersion, useragent.VersionInfo{"go", runtime.Version()})
 	httpVersion = append(httpVersion, useragent.VersionInfo{"git-commit", dockerversion.GITCOMMIT})
-	if kernelVersion, err := kernel.GetKernelVersion(); err == nil {
-		httpVersion = append(httpVersion, useragent.VersionInfo{"kernel", kernelVersion.String()})
+	osVersion, err := operatingsystem.GetOperatingSystem()
+	if err != nil {
+		osVersion = runtime.GOOS
 	}
-	httpVersion = append(httpVersion, useragent.VersionInfo{"os", runtime.GOOS})
+	httpVersion = append(httpVersion, useragent.VersionInfo{"os", strings.Replace(osVersion, " ", "_", -1)})
 	httpVersion = append(httpVersion, useragent.VersionInfo{"arch", runtime.GOARCH})
 
 	dockerUserAgent = useragent.AppendVersions("", httpVersion...)


### PR DESCRIPTION
Looks a bit like this:

```
docker/1.8.0-dev go/go1.4.2 git-commit/bfccd32-dirty os/Ubuntu_14.04.2_LTS arch/amd64
```

This is a follow-up to #14089.

Registry operators (e.g. Docker Hub) use this data to better understand their users. Exposing the kernel version a user is using could be a potential security risk. A detailed operating system is a more useful piece of data, with less of a risk.

Docker, Inc uses the data from Hub to understand what operating systems users are using so we can prioritise features, OS support, etc. I'd really like to find a way to release aggregate anonymous data so the entire community can benefit. A WIP...
