### PR TITLE
Add distro to user agent

### DIFF
--- a/pkg/parsers/operatingsystem/operatingsystem_darwin.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_darwin.go
@@ -1,0 +1,12 @@
+package operatingsystem
+
+// GetOperatingSystem gets the name of the current operating system.
+func GetOperatingSystem() (string, error) {
+	return "Darwin", nil
+}
+
+// IsContainerized returns true if we are running inside a container.
+// No-op on Darwin, always returns false.
+func IsContainerized() (bool, error) {
+	return false, nil
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -22,6 +22,7 @@ import (
 	"github.com/docker/distribution/registry/client/transport"
 	"github.com/docker/docker/autogen/dockerversion"
 	"github.com/docker/docker/pkg/parsers/kernel"
+	"github.com/docker/docker/pkg/parsers/operatingsystem"
 	"github.com/docker/docker/pkg/tlsconfig"
 	"github.com/docker/docker/pkg/useragent"
 )
@@ -47,6 +48,9 @@ func init() {
 	}
 	httpVersion = append(httpVersion, useragent.VersionInfo{"os", runtime.GOOS})
 	httpVersion = append(httpVersion, useragent.VersionInfo{"arch", runtime.GOARCH})
+	if osVersion, err := operatingsystem.GetOperatingSystem(); err != nil {
+		httpVersion = append(httpVersion, useragent.VersionInfo{"distro", strings.Replace(osVersion, " ", "_", -1)})
+	}
 
 	dockerUserAgent = useragent.AppendVersions("", httpVersion...)
 }


### PR DESCRIPTION
Registry operators (e.g. Docker Hub) can use this data to better understand their users.

E.g. the new boot2docker kernel is indistinguishable from Debian, so we have no idea whether people are using it or not.

Supercedes #15203.
