### PR TITLE
Remove read index that causes dead lock.

### DIFF
--- a/pkg/truncindex/truncindex.go
+++ b/pkg/truncindex/truncindex.go
@@ -121,8 +121,6 @@ func (idx *TruncIndex) Get(s string) (string, error) {
 
 // Iterate iterates over all stored IDs, and passes each of them to the given handler.
 func (idx *TruncIndex) Iterate(handler func(id string)) {
-	idx.RLock()
-	defer idx.RUnlock()
 	idx.trie.Visit(func(prefix patricia.Prefix, item patricia.Item) error {
 		handler(string(prefix))
 		return nil


### PR DESCRIPTION
Let the iterator to lock the index when it needs it.

Tests provided by @mountkin.

Fixes #15195 
Fixes #15087
Fixes #15205

/cc @vbatts

Signed-off-by: David Calavera david.calavera@gmail.com
