### PR TITLE
Ensure reader position is at the end after tailing

### DIFF
--- a/daemon/logger/jsonfilelog/jsonfilelog.go
+++ b/daemon/logger/jsonfilelog/jsonfilelog.go
@@ -267,7 +267,8 @@ func (l *JSONFileLogger) readLogs(logWatcher *logger.LogWatcher, config logger.R
 	if !config.Follow {
 		return
 	}
-	if config.Tail == 0 {
+
+	if config.Tail >= 0 {
 		latestFile.Seek(0, os.SEEK_END)
 	}
 


### PR DESCRIPTION
After tailing a file, if the number of lines requested is > the number
of lines in the file, this would cause a json unmarshalling error to
occur when we later try to go follow the file.
So brute force set it to the end if any tailing occurred.

There is potential that there could be some missing log messages if logs
are being written very quickly, however I was not able to make this
happen even with `while true; do echo hello; done`, so this is probably
acceptable.

While testing this I also found a panic in LogWatcher.Close can be
called twice due to a race. So instead of using a plain channel for this
notification, use pubsub Publisher to ensure close isn't called 2x on a
channel.

Fixes #15199
