### PR TITLE
Windows: Test infrastructure plumbing

### DIFF
--- a/integration-cli/docker_test_vars.go
+++ b/integration-cli/docker_test_vars.go
@@ -28,6 +28,12 @@ var (
 	// isLocalDaemon is true if the daemon under test is on the same
 	// host as the CLI.
 	isLocalDaemon bool
+
+	// daemonPlatform is held globally so that tests can make intelligent
+	// decisions on how to configure themselves according to the platform
+	// of the daemon. This is initialised in docker_utils by sending
+	// a version call to the daemon and examining the response header.
+	daemonPlatform string
 )
 
 func init() {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli @jstarks

This PR is part of the proposal described in docker/docker issue 10662 to port the docker daemon to Windows. This PR adds infrastructure plumbing so that tests in the integration-cli can use the global 'daemonPlatform' variable to make intelligent choices through knowing what OS the daemon is running on. Obvious examples might be ping where /c means different things between Windows and Linux, or the name of the base image to run against. It does not change any tests at this point - that is a much bigger job to go through them all. But this bit of infrastructure is essential to that goal (of running integration-cli against a Windows daemon).
