### PR TITLE
Skipping test TestRunCapAddSYSTIME on lxc

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2777,5 +2777,7 @@ func (s *DockerSuite) TestAppArmorTraceSelf(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapAddSYSTIME(c *check.C) {
+	testRequires(c, NativeExecDriver)
+
 	dockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=SYS_TIME", "busybox", "sh", "-c", "grep ^CapEff /proc/self/status | sed 's/^CapEff:\t//' | grep ^0000000002000000$")
 }


### PR DESCRIPTION
Skipping test TestRunCapAddSYSTIME on lxc. Fixes #15217

Signed-off-by: Mohammed Aaqib Ansari maaquib@gmail.com
