### PR TITLE
Remove daemon check for TEST

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -246,7 +246,7 @@ func (daemon *Daemon) restore() error {
 	}
 
 	var (
-		debug         = (os.Getenv("DEBUG") != "" || os.Getenv("TEST") != "")
+		debug         = os.Getenv("DEBUG") != ""
 		currentDriver = daemon.driver.String()
 		containers    = make(map[string]*cr)
 	)


### PR DESCRIPTION
Closes #3745 🐧.

I think `DEBUG` is still used (might be wrong though) but `TEST` is not and should not. And according to https://github.com/docker/docker/issues/3745#issuecomment-76035979 there is now nothing in `integration` — all has been migrated to `integration-cli` and not using the `TEST` environment variable.

This feels a little _cheap_ but :sweat_smile: 🐸.

Signed-off-by: Vincent Demeester vincent@sbr.pm
