### PR TITLE
Add Linux Mint 17.x and 13 support to install.sh

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -154,6 +154,27 @@ do_install() {
 			fi
 		;;
 
+		linuxmint)
+			# Linux Mint is a fork of Ubuntu, for repository purposes
+			lsb_dist="ubuntu"
+
+			if command_exists lsb_release; then
+				dist_maj_ver="$(lsb_release --release | cut -f2)"
+				dist_maj_ver=$(echo $dist_maj_ver | awk  '{ string=substr($0, 1, 2); print string; }' )
+			fi
+
+			case "$dist_maj_ver" in
+				# Linux Mint 17.x versions are forks of Ubuntu Trusty, for repository purposes
+				17)
+					dist_version="trusty"
+				;;
+				# Linux Mint 13 is fork of Ubuntu Precise, for repository purposes
+				13)
+					dist_version="precise"
+				;;
+			esac
+		;;
+
 		debian)
 			dist_version="$(cat /etc/debian_version | sed 's/\/.*//' | sed 's/\..*//')"
 			case "$dist_version" in


### PR DESCRIPTION
Works on my machine:

DISTRIB_ID=LinuxMint
DISTRIB_RELEASE=17.2
DISTRIB_CODENAME=rafaela
DISTRIB_DESCRIPTION="Linux Mint 17.2 Rafaela"

Signed-off-by: Ed Solis edsfocci@gmail.com
