### PR TITLE
Update docker_remote_api.md

### DIFF
--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -113,7 +113,7 @@ of a 404.
 You can now supply a `stream` bool to get only one set of stats and
 disconnect
 
-`GET /containers(id)/logs`
+`GET /containers/(id)/logs`
 
 **New!**
 
@@ -143,6 +143,7 @@ In addition, the end point now returns the new boolean fields
 This endpoint now returns `Os`, `Arch` and `KernelVersion`.
 
 `POST /containers/create`
+
 `POST /containers/(id)/start`
 
 **New!**


### PR DESCRIPTION
Minor fixes:
- v1.19: GET /containers/(id)/logs - add missing '/'
- v1.18: Break up POST /containers/create and POST /containers/(id)/start into separate lines.

Signed-off-by: Charles Chan charleswhchan@users.noreply.github.com
