### PR TITLE
Fix #15212: Add "Label" key to output of /containers/json

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -49,6 +49,11 @@ List containers
                      "Created": 1367854155,
                      "Status": "Exit 0",
                      "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                     "Labels": {
+                             "com.example.vendor": "Acme",
+                             "com.example.license": "GPL",
+                             "com.example.version": "1.0"
+                     },
                      "SizeRw": 12288,
                      "SizeRootFs": 0
              },
@@ -60,6 +65,7 @@ List containers
                      "Created": 1367854155,
                      "Status": "Exit 0",
                      "Ports": [],
+                     "Labels": {},
                      "SizeRw": 12288,
                      "SizeRootFs": 0
              },
@@ -71,6 +77,7 @@ List containers
                      "Created": 1367854154,
                      "Status": "Exit 0",
                      "Ports":[],
+                     "Labels": {},
                      "SizeRw":12288,
                      "SizeRootFs":0
              },
@@ -82,6 +89,7 @@ List containers
                      "Created": 1367854152,
                      "Status": "Exit 0",
                      "Ports": [],
+                     "Labels": {},
                      "SizeRw": 12288,
                      "SizeRootFs": 0
              }

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -51,6 +51,11 @@ List containers
                  "Created": 1367854155,
                  "Status": "Exit 0",
                  "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                 "Labels": {
+                         "com.example.vendor": "Acme",
+                         "com.example.license": "GPL",
+                         "com.example.version": "1.0"
+                 },
                  "SizeRw": 12288,
                  "SizeRootFs": 0
          },
@@ -62,6 +67,7 @@ List containers
                  "Created": 1367854155,
                  "Status": "Exit 0",
                  "Ports": [],
+                 "Labels": {},
                  "SizeRw": 12288,
                  "SizeRootFs": 0
          },
@@ -73,6 +79,7 @@ List containers
                  "Created": 1367854154,
                  "Status": "Exit 0",
                  "Ports":[],
+                 "Labels": {},
                  "SizeRw":12288,
                  "SizeRootFs":0
          },
@@ -84,6 +91,7 @@ List containers
                  "Created": 1367854152,
                  "Status": "Exit 0",
                  "Ports": [],
+                 "Labels": {},
                  "SizeRw": 12288,
                  "SizeRootFs": 0
          }

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -51,6 +51,11 @@ List containers
                  "Created": 1367854155,
                  "Status": "Exit 0",
                  "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                 "Labels": {
+                         "com.example.vendor": "Acme",
+                         "com.example.license": "GPL",
+                         "com.example.version": "1.0"
+                 },
                  "SizeRw": 12288,
                  "SizeRootFs": 0
          },
@@ -62,6 +67,7 @@ List containers
                  "Created": 1367854155,
                  "Status": "Exit 0",
                  "Ports": [],
+                 "Labels": {},
                  "SizeRw": 12288,
                  "SizeRootFs": 0
          },
@@ -73,6 +79,7 @@ List containers
                  "Created": 1367854154,
                  "Status": "Exit 0",
                  "Ports":[],
+                 "Labels": {},
                  "SizeRw":12288,
                  "SizeRootFs":0
          },
@@ -84,6 +91,7 @@ List containers
                  "Created": 1367854152,
                  "Status": "Exit 0",
                  "Ports": [],
+                 "Labels": {},
                  "SizeRw": 12288,
                  "SizeRootFs": 0
          }

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -51,6 +51,11 @@ List containers
                  "Created": 1367854155,
                  "Status": "Exit 0",
                  "Ports": [{"PrivatePort": 2222, "PublicPort": 3333, "Type": "tcp"}],
+                 "Labels": {
+                         "com.example.vendor": "Acme",
+                         "com.example.license": "GPL",
+                         "com.example.version": "1.0"
+                 },
                  "SizeRw": 12288,
                  "SizeRootFs": 0
          },
@@ -62,6 +67,7 @@ List containers
                  "Created": 1367854155,
                  "Status": "Exit 0",
                  "Ports": [],
+                 "Labels": {},
                  "SizeRw": 12288,
                  "SizeRootFs": 0
          },
@@ -73,6 +79,7 @@ List containers
                  "Created": 1367854154,
                  "Status": "Exit 0",
                  "Ports":[],
+                 "Labels": {},
                  "SizeRw":12288,
                  "SizeRootFs":0
          },
@@ -84,6 +91,7 @@ List containers
                  "Created": 1367854152,
                  "Status": "Exit 0",
                  "Ports": [],
+                 "Labels": {},
                  "SizeRw": 12288,
                  "SizeRootFs": 0
          }


### PR DESCRIPTION
1. I only updated the latest version. Not sure if I need to apply retroactively.
2. Following the current convention, I did not explain what the key does under /containers/json. I assume the reader can look up the definition under /containers/create.

Please review.

Signed-off-by: Charles Chan charleswhchan@users.noreply.github.com
