### PR TITLE
Fix changed google cloud URLs

### DIFF
--- a/docs/installation/google.md
+++ b/docs/installation/google.md
@@ -41,7 +41,7 @@ parent = "smn_cloud"
 Read more about [deploying Containers on Google Cloud Platform][5].
 
 [1]: https://cloud.google.com/console
-[2]: https://developers.google.com/compute/docs/signup
-[3]: https://developers.google.com/cloud/sdk
-[4]: https://developers.google.com/compute/docs/containers#container-optimized_google_compute_engine_images
-[5]: https://developers.google.com/compute/docs/containers
+[2]: https://cloud.google.com/compute/docs/signup
+[3]: https://cloud.google.com/sdk
+[4]: https://cloud.google.com/compute/docs/containers/container_vms
+[5]: https://cloud.google.com/compute/docs/containers


### PR DESCRIPTION
All documentation has been moved to cloud.google.com.

Signed-off-by: Nick Andrew nick@nick-andrew.net
