### PR TITLE
Fix "Getting started" link in userguide

### DIFF
--- a/docs/userguide/index.md
+++ b/docs/userguide/index.md
@@ -113,17 +113,17 @@ Go to [Docker Swarm user guide](/swarm/).
 
 ## Getting help
 
-* [Docker homepage](http://www.docker.com/)
+* [Docker homepage](https://www.docker.com/)
 * [Docker Hub](https://hub.docker.com)
-* [Docker blog](http://blog.docker.com/)
+* [Docker blog](https://blog.docker.com/)
 * [Docker documentation](https://docs.docker.com/)
-* [Docker Getting Started Guide](http://www.docker.com/gettingstarted/)
+* [Docker Getting Started Guide](https://docs.docker.com/mac/started/)
 * [Docker code on GitHub](https://github.com/docker/docker)
 * [Docker mailing
   list](https://groups.google.com/forum/#!forum/docker-user)
 * Docker on IRC: irc.freenode.net and channel #docker
-* [Docker on Twitter](http://twitter.com/docker)
-* Get [Docker help](http://stackoverflow.com/search?q=docker) on
+* [Docker on Twitter](https://twitter.com/docker)
+* Get [Docker help](https://stackoverflow.com/search?q=docker) on
   StackOverflow
-* [Docker.com](http://www.docker.com/)
+* [Docker.com](https://www.docker.com/)
 


### PR DESCRIPTION
This is a tiny fix (the current link leads nowhere) but :
- I added `/mac/started` for now but it feels not right. Should it be either platform dependent or pointing to `/started` that would show the "Getting started" guide for the different platform.
- <del>Currently there is `/mac/started` and `/windows/started`, so when on a unix platform other than mac, the /Get started/ links to `/mac/started`. Shouldn't we <del>add one for GNU/Linux 🐧 or</del> point to something else than `/mac/started` ?</del> Nevermind :blush:.
- Should I put `https` links ?

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
