### PR TITLE
Fix vendoring for fluent-logger-golang

### DIFF
--- a/vendor/src/github.com/fluent/fluent-logger-golang/fluent/fluent.go
+++ b/vendor/src/github.com/fluent/fluent-logger-golang/fluent/fluent.go
@@ -3,6 +3,7 @@ package fluent
 import (
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"net"
 	"reflect"
@@ -33,7 +34,7 @@ type Config struct {
 
 type Fluent struct {
 	Config
-	conn         net.Conn
+	conn         io.WriteCloser
 	pending      []byte
 	reconnecting bool
 	mu           sync.Mutex

--- a/vendor/src/github.com/fluent/fluent-logger-golang/fluent/version.go
+++ b/vendor/src/github.com/fluent/fluent-logger-golang/fluent/version.go
@@ -1,3 +1,3 @@
 package fluent
 
-const Version = "0.5.1"
+const Version = "1.0.0"


### PR DESCRIPTION
Done just by running hack/vendor.sh
