### PR TITLE
Remove key file when migration fails.

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -100,6 +100,7 @@ func migrateKey() (err error) {
 				err = os.Remove(oldPath)
 			} else {
 				logrus.Warnf("Key migration failed, key file not removed at %s", oldPath)
+				os.Remove(newPath)
 			}
 		}()
 


### PR DESCRIPTION
We can leave the key file in an unexpected state if the migration fails before we write on it.
This changes the migration behavior to remove the new file if there is any error.

Fixes #15247

/cc @diogomonica, @ibuildthecloud

Signed-off-by: David Calavera david.calavera@gmail.com
