### PR TITLE
Runtime sysinfo check

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -92,7 +92,6 @@ type Daemon struct {
 	graph            *graph.Graph
 	repositories     *graph.TagStore
 	idIndex          *truncindex.TruncIndex
-	sysInfo          *sysinfo.SysInfo
 	config           *Config
 	containerGraph   *graphdb.Database
 	driver           graphdriver.Driver
@@ -725,7 +724,6 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	d.graph = g
 	d.repositories = repositories
 	d.idIndex = truncindex.NewTruncIndex([]string{})
-	d.sysInfo = sysInfo
 	d.config = config
 	d.sysInitPath = sysInitPath
 	d.execDriver = ed
@@ -856,10 +854,6 @@ func (daemon *Daemon) Repositories() *graph.TagStore {
 
 func (daemon *Daemon) Config() *Config {
 	return daemon.config
-}
-
-func (daemon *Daemon) SystemConfig() *sysinfo.SysInfo {
-	return daemon.sysInfo
 }
 
 func (daemon *Daemon) SystemInitPath() string {

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/parsers/kernel"
+	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
@@ -148,7 +149,8 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, a
 // verifyPlatformContainerSettings performs platform-specific validation of the
 // hostconfig and config structures.
 func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostConfig, config *runconfig.Config) ([]string, error) {
-	var warnings []string
+	warnings := []string{}
+	sysInfo := sysinfo.New(false)
 
 	if hostConfig.LxcConf.Len() > 0 && !strings.Contains(daemon.ExecutionDriver().Name(), "lxc") {
 		return warnings, fmt.Errorf("Cannot use --lxc-conf with execdriver: %s", daemon.ExecutionDriver().Name())
@@ -156,12 +158,12 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 	if hostConfig.Memory != 0 && hostConfig.Memory < 4194304 {
 		return warnings, fmt.Errorf("Minimum memory limit allowed is 4MB")
 	}
-	if hostConfig.Memory > 0 && !daemon.SystemConfig().MemoryLimit {
+	if hostConfig.Memory > 0 && !sysInfo.MemoryLimit {
 		warnings = append(warnings, "Your kernel does not support memory limit capabilities. Limitation discarded.")
 		logrus.Warnf("Your kernel does not support memory limit capabilities. Limitation discarded.")
 		hostConfig.Memory = 0
 	}
-	if hostConfig.Memory > 0 && hostConfig.MemorySwap != -1 && !daemon.SystemConfig().SwapLimit {
+	if hostConfig.Memory > 0 && hostConfig.MemorySwap != -1 && !sysInfo.SwapLimit {
 		warnings = append(warnings, "Your kernel does not support swap limit capabilities, memory limited without swap.")
 		logrus.Warnf("Your kernel does not support swap limit capabilities, memory limited without swap.")
 		hostConfig.MemorySwap = -1
@@ -172,7 +174,7 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 	if hostConfig.Memory == 0 && hostConfig.MemorySwap > 0 {
 		return warnings, fmt.Errorf("You should always set the Memory limit when using Memoryswap limit, see usage.")
 	}
-	if hostConfig.MemorySwappiness != nil && !daemon.SystemConfig().MemorySwappiness {
+	if hostConfig.MemorySwappiness != nil && !sysInfo.MemorySwappiness {
 		warnings = append(warnings, "Your kernel does not support memory swappiness capabilities, memory swappiness discarded.")
 		logrus.Warnf("Your kernel does not support memory swappiness capabilities, memory swappiness discarded.")
 		hostConfig.MemorySwappiness = nil
@@ -183,12 +185,12 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 			return warnings, fmt.Errorf("Invalid value: %v, valid memory swappiness range is 0-100.", swappiness)
 		}
 	}
-	if hostConfig.CPUPeriod > 0 && !daemon.SystemConfig().CPUCfsPeriod {
+	if hostConfig.CPUPeriod > 0 && !sysInfo.CPUCfsPeriod {
 		warnings = append(warnings, "Your kernel does not support CPU cfs period. Period discarded.")
 		logrus.Warnf("Your kernel does not support CPU cfs period. Period discarded.")
 		hostConfig.CPUPeriod = 0
 	}
-	if hostConfig.CPUQuota > 0 && !daemon.SystemConfig().CPUCfsQuota {
+	if hostConfig.CPUQuota > 0 && !sysInfo.CPUCfsQuota {
 		warnings = append(warnings, "Your kernel does not support CPU cfs quota. Quota discarded.")
 		logrus.Warnf("Your kernel does not support CPU cfs quota. Quota discarded.")
 		hostConfig.CPUQuota = 0
@@ -196,11 +198,11 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 	if hostConfig.BlkioWeight > 0 && (hostConfig.BlkioWeight < 10 || hostConfig.BlkioWeight > 1000) {
 		return warnings, fmt.Errorf("Range of blkio weight is from 10 to 1000.")
 	}
-	if hostConfig.OomKillDisable && !daemon.SystemConfig().OomKillDisable {
+	if hostConfig.OomKillDisable && !sysInfo.OomKillDisable {
 		hostConfig.OomKillDisable = false
 		return warnings, fmt.Errorf("Your kernel does not support oom kill disable.")
 	}
-	if daemon.SystemConfig().IPv4ForwardingDisabled {
+	if sysInfo.IPv4ForwardingDisabled {
 		warnings = append(warnings, "IPv4 forwarding is disabled. Networking will not work.")
 		logrus.Warnf("IPv4 forwarding is disabled. Networking will not work")
 	}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -155,6 +155,8 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 	if hostConfig.LxcConf.Len() > 0 && !strings.Contains(daemon.ExecutionDriver().Name(), "lxc") {
 		return warnings, fmt.Errorf("Cannot use --lxc-conf with execdriver: %s", daemon.ExecutionDriver().Name())
 	}
+
+	// memory subsystem checks and adjustments
 	if hostConfig.Memory != 0 && hostConfig.Memory < 4194304 {
 		return warnings, fmt.Errorf("Minimum memory limit allowed is 4MB")
 	}
@@ -162,6 +164,7 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 		warnings = append(warnings, "Your kernel does not support memory limit capabilities. Limitation discarded.")
 		logrus.Warnf("Your kernel does not support memory limit capabilities. Limitation discarded.")
 		hostConfig.Memory = 0
+		hostConfig.MemorySwap = -1
 	}
 	if hostConfig.Memory > 0 && hostConfig.MemorySwap != -1 && !sysInfo.SwapLimit {
 		warnings = append(warnings, "Your kernel does not support swap limit capabilities, memory limited without swap.")
@@ -174,7 +177,7 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 	if hostConfig.Memory == 0 && hostConfig.MemorySwap > 0 {
 		return warnings, fmt.Errorf("You should always set the Memory limit when using Memoryswap limit, see usage.")
 	}
-	if hostConfig.MemorySwappiness != nil && !sysInfo.MemorySwappiness {
+	if hostConfig.MemorySwappiness != nil && *hostConfig.MemorySwappiness != -1 && !sysInfo.MemorySwappiness {
 		warnings = append(warnings, "Your kernel does not support memory swappiness capabilities, memory swappiness discarded.")
 		logrus.Warnf("Your kernel does not support memory swappiness capabilities, memory swappiness discarded.")
 		hostConfig.MemorySwappiness = nil
@@ -198,10 +201,12 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 	if hostConfig.BlkioWeight > 0 && (hostConfig.BlkioWeight < 10 || hostConfig.BlkioWeight > 1000) {
 		return warnings, fmt.Errorf("Range of blkio weight is from 10 to 1000.")
 	}
+
 	if hostConfig.OomKillDisable && !sysInfo.OomKillDisable {
 		hostConfig.OomKillDisable = false
 		return warnings, fmt.Errorf("Your kernel does not support oom kill disable.")
 	}
+
 	if sysInfo.IPv4ForwardingDisabled {
 		warnings = append(warnings, "IPv4 forwarding is disabled. Networking will not work.")
 		logrus.Warnf("IPv4 forwarding is disabled. Networking will not work")

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/parsers/operatingsystem"
+	"github.com/docker/docker/pkg/sysinfo"
 	"github.com/docker/docker/pkg/system"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/utils"
@@ -56,15 +57,17 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		initPath = daemon.SystemInitPath()
 	}
 
+	sysInfo := sysinfo.New(false)
+
 	v := &types.Info{
 		ID:                 daemon.ID,
 		Containers:         len(daemon.List()),
 		Images:             imgcount,
 		Driver:             daemon.GraphDriver().String(),
 		DriverStatus:       daemon.GraphDriver().Status(),
-		IPv4Forwarding:     !daemon.SystemConfig().IPv4ForwardingDisabled,
-		BridgeNfIptables:   !daemon.SystemConfig().BridgeNfCallIptablesDisabled,
-		BridgeNfIp6tables:  !daemon.SystemConfig().BridgeNfCallIP6tablesDisabled,
+		IPv4Forwarding:     !sysInfo.IPv4ForwardingDisabled,
+		BridgeNfIptables:   !sysInfo.BridgeNfCallIptablesDisabled,
+		BridgeNfIp6tables:  !sysInfo.BridgeNfCallIP6tablesDisabled,
 		Debug:              os.Getenv("DEBUG") != "",
 		NFd:                fileutils.GetTotalUsedFds(),
 		NGoroutines:        runtime.NumGoroutine(),
@@ -90,11 +93,11 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	// sysinfo.cgroupCpuInfo will be nil otherwise and cause a SIGSEGV if
 	// an attempt is made to access through them.
 	if runtime.GOOS != "windows" {
-		v.MemoryLimit = daemon.SystemConfig().MemoryLimit
-		v.SwapLimit = daemon.SystemConfig().SwapLimit
-		v.OomKillDisable = daemon.SystemConfig().OomKillDisable
-		v.CpuCfsPeriod = daemon.SystemConfig().CPUCfsPeriod
-		v.CpuCfsQuota = daemon.SystemConfig().CPUCfsQuota
+		v.MemoryLimit = sysInfo.MemoryLimit
+		v.SwapLimit = sysInfo.SwapLimit
+		v.OomKillDisable = sysInfo.OomKillDisable
+		v.CpuCfsPeriod = sysInfo.CPUCfsPeriod
+		v.CpuCfsQuota = sysInfo.CPUCfsQuota
 	}
 
 	if httpProxy := os.Getenv("http_proxy"); httpProxy != "" {

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -21,10 +21,6 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConf
 		return fmt.Errorf("Container already started")
 	}
 
-	if _, err = daemon.verifyContainerSettings(hostConfig, nil); err != nil {
-		return err
-	}
-
 	// Windows does not have the backwards compatibilty issue here.
 	if runtime.GOOS != "windows" {
 		// This is kept for backward compatibility - hostconfig should be passed when
@@ -38,6 +34,12 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConf
 		if hostConfig != nil {
 			return fmt.Errorf("Supplying a hostconfig on start is not supported. It should be supplied on create")
 		}
+	}
+
+	// check if hostConfig is in line with the current system settings.
+	// It may happen cgroups are umounted or the like.
+	if _, err = daemon.verifyContainerSettings(container.hostConfig, nil); err != nil {
+		return err
 	}
 
 	if err := container.Start(); err != nil {

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -10,7 +10,9 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 )
 
-// New returns a new SysInfo, using the filesystem to detect which features the kernel supports.
+// New returns a new SysInfo, using the filesystem to detect which features
+// the kernel supports. If `quiet` is `true` warnings are printed in logs
+// whenever an error occurs or misconfigurations are present.
 func New(quiet bool) *SysInfo {
 	sysInfo := &SysInfo{}
 	sysInfo.cgroupMemInfo = checkCgroupMem(quiet)

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -188,16 +188,16 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flMemory = parsedMemory
 	}
 
-	var MemorySwap int64
+	var memorySwap int64
 	if *flMemorySwap != "" {
 		if *flMemorySwap == "-1" {
-			MemorySwap = -1
+			memorySwap = -1
 		} else {
 			parsedMemorySwap, err := units.RAMInBytes(*flMemorySwap)
 			if err != nil {
 				return nil, nil, cmd, err
 			}
-			MemorySwap = parsedMemorySwap
+			memorySwap = parsedMemorySwap
 		}
 	}
 
@@ -354,7 +354,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		ContainerIDFile:  *flContainerIDFile,
 		LxcConf:          lxcConf,
 		Memory:           flMemory,
-		MemorySwap:       MemorySwap,
+		MemorySwap:       memorySwap,
 		CPUShares:        *flCPUShares,
 		CPUPeriod:        *flCPUPeriod,
 		CpusetCpus:       *flCpusetCpus,


### PR DESCRIPTION
fix #15159 

tl;dr (more in commit messages)

sysinfo is initialized and stored in the daemon struct at daemon startup
runtime system settings changes aren't reflected in sysinfo daemon field
errors from libcontainer complaining about write to non existent cgroup path when it wasn't supposed to not even write there

now if a cgroup is umounted at runtime (memory for instance) and a container had memory-swappiness enabled and it's started again, the error from libcontainer is gone and in daemon logs you get

```
WARN[0108] Your kernel does not support cgroup memory limit: mountpoint for memory not found 
WARN[0108] Your kernel does not support memory swappiness capabilities, memory swappiness discarded. 
WARN[0108] IPv4 forwarding is disabled. Networking will not work 
WARN[0109] Your kernel does not support OOM notifications: There is no path for "memory" in state
```

**NOTE: warnings are not printed to stdout/stderr while starting a container (as it's happening for `run`) with wrong memory swappiness but only in daemon-logs.** This is because start return StatusNoContent so would not be good to break that behavior and print the warnings there and also this is more of a sysadmin thing who watches for wrong behaviors in daemon logs (please someone confirm this also)

I've made sysinfo checks at runtime and removed the field from the daemon struct
hostConfig is checked at container's start too
