### PR TITLE
Fix preallocated bridge networks

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -22,7 +22,7 @@ clone git golang.org/x/net 3cffabab72adf04f8e3b01c5baf775361837b5fe https://gith
 clone hg code.google.com/p/gosqlite 74691fb6f837
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork 31139cdb513aea5ad1ed08b60d4350a68b4c96db
+clone git github.com/docker/libnetwork 78fc31ddc425fb379765c6b7ab5b96748bd8fc08
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/drivers/bridge/setup_ipv4.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/bridge/setup_ipv4.go
@@ -31,9 +31,9 @@ func init() {
 		bridgeNetworks = append(bridgeNetworks, &net.IPNet{IP: []byte{10, byte(i), 42, 1}, Mask: mask})
 	}
 	// 192.168.[42-44].1/24
-	mask[2] = 255
+	mask24 := []byte{255, 255, 255, 0}
 	for i := 42; i < 45; i++ {
-		bridgeNetworks = append(bridgeNetworks, &net.IPNet{IP: []byte{192, 168, byte(i), 1}, Mask: mask})
+		bridgeNetworks = append(bridgeNetworks, &net.IPNet{IP: []byte{192, 168, byte(i), 1}, Mask: mask24})
 	}
 }
 


### PR DESCRIPTION
- Because of a bug, all the statically preallocated
  bridge networks have /24 as network mask,
  breaking older behavior.
- Unit test added in libnetwork.
- Closes #15268 

Signed-off-by: Alessandro Boch aboch@docker.com
