### PR TITLE
Include apparmor/docker only when it exists.

### DIFF
--- a/hack/make/ubuntu
+++ b/hack/make/ubuntu
@@ -73,8 +73,10 @@ bundle_ubuntu() {
 	done
 
 	# Include contributed apparmor policy
-	mkdir -p "$DIR/etc/apparmor.d/"
-	cp contrib/apparmor/* "$DIR/etc/apparmor.d/"
+	if [ -d contrib/apparmor ]; then
+		mkdir -p "$DIR/etc/apparmor.d/"
+		cp contrib/apparmor/* "$DIR/etc/apparmor.d/"
+	fi
 
 	# Copy the binary
 	# This will fail if the binary bundle hasn't been built


### PR DESCRIPTION
Signed-off-by: David Calavera david.calavera@gmail.com
