### PR TITLE
Break long command to avoid cropping

### DIFF
--- a/docs/installation/mac.md
+++ b/docs/installation/mac.md
@@ -345,7 +345,8 @@ The next exercise demonstrates how to do this.
 
 5. Start a new `nginx` container and replace the `html` folder with your `site` directory.
 
-        $ docker run -d -P -v $HOME/site:/usr/share/nginx/html --name mysite nginx
+        $ docker run -d -P -v $HOME/site:/usr/share/nginx/html \
+          --name mysite nginx
 
 6. Get the `mysite` container's port.
 


### PR DESCRIPTION
Broke the long command line in two to avoid having it cropped on https://docs.docker.com/installation/mac/.

Tested and checked that the generated docs look good now.

Fixes #14558

Signed-off-by: Francesc Campoy campoy@google.com
