### PR TITLE
Removed `docs-test` from Makefile rules list

### DIFF
--- a/docs/project/test-and-docs.md
+++ b/docs/project/test-and-docs.md
@@ -82,10 +82,6 @@ is simply `test`. The make file contains several targets for testing:
     <td class="monospaced">test-docker-py</td>
     <td>Run the tests for Docker API client.</td>
   </tr>
-  <tr>
-    <td class="monospaced">docs-test</td>
-    <td>Runs the documentation test build.</td>
-  </tr>
 </table>
 
 Run the entire test suite on your current repository:


### PR DESCRIPTION
Rule `docs-test` does not exists in the Makefile:

``` bash
$ make docs-tests
make: *** No rule to make target 'docs-tests'.  Stop.
```

But it is still referenced in the docs. I removed the reference.

cc @moxiegirl 
