### PR TITLE
Windows: Daemon compile was broken

### DIFF
--- a/daemon/execdriver/windows/info.go
+++ b/daemon/execdriver/windows/info.go
@@ -6,7 +6,7 @@ import "github.com/docker/docker/daemon/execdriver"
 
 type info struct {
 	ID     string
-	driver *driver
+	driver *Driver
 }
 
 // Info implements the exec driver Driver interface.


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@icecrime. After a golint PR being merged, the Windows daemon does not build on master any more. This fixes it.
