### PR TITLE
Update some contributions documentations

### DIFF
--- a/docs/project/coding-style.md
+++ b/docs/project/coding-style.md
@@ -26,6 +26,9 @@ program code and documentation code.
 * Run `gofmt -s -w file.go` on each changed file before
   committing your changes. Most editors have plug-ins that do this automatically.
 
+* Run `golint` on each changed file before
+  committing your changes.
+
 * Update the documentation when creating or modifying features. 
 
 * Commits that fix or close an issue should reference them in the commit message


### PR DESCRIPTION
Even though #14756 is not closed yet — but we're getting closed 🐧 — I think we should mention somewhere in the contributing docs that the modified file should pass the `golint` door :stuck_out_tongue_closed_eyes:.

This currently adds a golint entry to `coding-style.md` but I was wondering something : we do not talk about `make validate` on the contributing docs although it does most of the thing we're asking for a PR (validate-dco, validate-gofmt, validate-lint, validate-toml, validate-vet).

To explain this further, one of the _workflow_ I use when working on docker is the following (if it's a code one, not a doc one :yum:) :
- create my branch, doing my changes
- `make test` : well `make test-unit` or `make test-integration-cli` depending on where it's needed but in the end, `make test`.
- `make validate` so I'm sure everything is all right (`gofmt`, `golint`, etc..)
- and then I can push and PR

I'm not sure where to put it though — maybe in `docs/project/work-issue.md` (updating it to use `make` commands) or maybe in `docs/project/test-and-docs.md` (but feels a little out of context there). 🐸

/cc @thaJeztah @moxiegirl wdyt ?
Signed-off-by: Vincent Demeester vincent@sbr.pm
