### PR TITLE
golint fixes for daemon/ package

### DIFF
--- a/api/server/server_experimental_unix.go
+++ b/api/server/server_experimental_unix.go
@@ -3,7 +3,7 @@
 package server
 
 func (s *Server) registerSubRouter() {
-	httpHandler := s.daemon.NetworkApiRouter()
+	httpHandler := s.daemon.NetworkAPIRouter()
 
 	subrouter := s.router.PathPrefix("/v{version:[0-9.]+}/networks").Subrouter()
 	subrouter.Methods("GET", "POST", "PUT", "DELETE").HandlerFunc(httpHandler)

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 )
 
+// ContainerAttachWithLogsConfig holds the streams to use when connecting to a container to view logs.
 type ContainerAttachWithLogsConfig struct {
 	InStream                       io.ReadCloser
 	OutStream                      io.Writer
@@ -13,6 +14,7 @@ type ContainerAttachWithLogsConfig struct {
 	Logs, Stream                   bool
 }
 
+// ContainerAttachWithLogs attaches to logs according to the config passed in. See ContainerAttachWithLogsConfig.
 func (daemon *Daemon) ContainerAttachWithLogs(container *Container, c *ContainerAttachWithLogsConfig) error {
 	var errStream io.Writer
 
@@ -36,15 +38,18 @@ func (daemon *Daemon) ContainerAttachWithLogs(container *Container, c *Container
 		stderr = errStream
 	}
 
-	return container.AttachWithLogs(stdin, stdout, stderr, c.Logs, c.Stream)
+	return container.attachWithLogs(stdin, stdout, stderr, c.Logs, c.Stream)
 }
 
+// ContainerWsAttachWithLogsConfig attach with websockets, since all
+// stream data is delegated to the websocket to handle, there
 type ContainerWsAttachWithLogsConfig struct {
 	InStream             io.ReadCloser
 	OutStream, ErrStream io.Writer
 	Logs, Stream         bool
 }
 
+// ContainerWsAttachWithLogs websocket connection
 func (daemon *Daemon) ContainerWsAttachWithLogs(container *Container, c *ContainerWsAttachWithLogsConfig) error {
-	return container.AttachWithLogs(c.InStream, c.OutStream, c.ErrStream, c.Logs, c.Stream)
+	return container.attachWithLogs(c.InStream, c.OutStream, c.ErrStream, c.Logs, c.Stream)
 }

--- a/daemon/changes.go
+++ b/daemon/changes.go
@@ -9,5 +9,5 @@ func (daemon *Daemon) ContainerChanges(name string) ([]archive.Change, error) {
 		return nil, err
 	}
 
-	return container.Changes()
+	return container.changes()
 }

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -5,6 +5,8 @@ import (
 	"github.com/docker/docker/runconfig"
 )
 
+// ContainerCommitConfig contains build configs for commit operation,
+// and is used when making a commit with the current state of the container.
 type ContainerCommitConfig struct {
 	Pause   bool
 	Repo    string
@@ -15,14 +17,14 @@ type ContainerCommitConfig struct {
 }
 
 // Commit creates a new filesystem image from the current state of a container.
-// The image can optionally be tagged into a repository
+// The image can optionally be tagged into a repository.
 func (daemon *Daemon) Commit(container *Container, c *ContainerCommitConfig) (*image.Image, error) {
-	if c.Pause && !container.IsPaused() {
-		container.Pause()
-		defer container.Unpause()
+	if c.Pause && !container.isPaused() {
+		container.pause()
+		defer container.unpause()
 	}
 
-	rwTar, err := container.ExportRw()
+	rwTar, err := container.exportRw()
 	if err != nil {
 		return nil, err
 	}
@@ -55,6 +57,6 @@ func (daemon *Daemon) Commit(container *Container, c *ContainerCommitConfig) (*i
 			return img, err
 		}
 	}
-	container.LogEvent("commit")
+	container.logEvent("commit")
 	return img, nil
 }

--- a/daemon/config.go
+++ b/daemon/config.go
@@ -18,8 +18,8 @@ type CommonConfig struct {
 	Bridge         bridgeConfig // Bridge holds bridge network specific configuration.
 	Context        map[string][]string
 	DisableBridge  bool
-	Dns            []string
-	DnsSearch      []string
+	DNS            []string
+	DNSSearch      []string
 	ExecDriver     string
 	ExecOptions    []string
 	ExecRoot       string
@@ -50,8 +50,8 @@ func (config *Config) InstallCommonFlags(cmd *flag.FlagSet, usageFn func(string)
 	cmd.StringVar(&config.ExecDriver, []string{"e", "-exec-driver"}, defaultExec, usageFn("Exec driver to use"))
 	cmd.IntVar(&config.Mtu, []string{"#mtu", "-mtu"}, 0, usageFn("Set the containers network MTU"))
 	// FIXME: why the inconsistency between "hosts" and "sockets"?
-	cmd.Var(opts.NewListOptsRef(&config.Dns, opts.ValidateIPAddress), []string{"#dns", "-dns"}, usageFn("DNS server to use"))
-	cmd.Var(opts.NewListOptsRef(&config.DnsSearch, opts.ValidateDNSSearch), []string{"-dns-search"}, usageFn("DNS search domains to use"))
+	cmd.Var(opts.NewListOptsRef(&config.DNS, opts.ValidateIPAddress), []string{"#dns", "-dns"}, usageFn("DNS server to use"))
+	cmd.Var(opts.NewListOptsRef(&config.DNSSearch, opts.ValidateDNSSearch), []string{"-dns-search"}, usageFn("DNS search domains to use"))
 	cmd.Var(opts.NewListOptsRef(&config.Labels, opts.ValidateLabel), []string{"-label"}, usageFn("Set key=value labels to the daemon"))
 	cmd.StringVar(&config.LogConfig.Type, []string{"-log-driver"}, "json-file", usageFn("Default driver for container logs"))
 	cmd.Var(opts.NewMapOpts(config.LogConfig.Config, nil), []string{"-log-opt"}, usageFn("Set log driver options"))

--- a/daemon/container.go
+++ b/daemon/container.go
@@ -34,13 +34,12 @@ import (
 )
 
 var (
-	ErrNotATTY                 = errors.New("The PTY is not a file")
-	ErrNoTTY                   = errors.New("No PTY found")
-	ErrContainerStart          = errors.New("The container failed to start. Unknown error")
-	ErrContainerStartTimeout   = errors.New("The container failed to start due to timed out.")
-	ErrContainerRootfsReadonly = errors.New("container rootfs is marked read-only")
+	// ErrRootFSReadOnly is returned when a container
+	// rootfs is marked readonly.
+	ErrRootFSReadOnly = errors.New("container rootfs is marked read-only")
 )
 
+// ErrContainerNotRunning holds the id of the container that is not running.
 type ErrContainerNotRunning struct {
 	id string
 }
@@ -49,48 +48,49 @@ func (e ErrContainerNotRunning) Error() string {
 	return fmt.Sprintf("Container %s is not running", e.id)
 }
 
-type StreamConfig struct {
+type streamConfig struct {
 	stdout    *broadcastwriter.BroadcastWriter
 	stderr    *broadcastwriter.BroadcastWriter
 	stdin     io.ReadCloser
 	stdinPipe io.WriteCloser
 }
 
-// CommonContainer holds the settings for a container which are applicable
-// across all platforms supported by the daemon.
+// CommonContainer holds the fields for a container which are
+// applicable across all platforms supported by the daemon.
 type CommonContainer struct {
-	StreamConfig
-
-	*State `json:"State"` // Needed for remote api version <= 1.11
-	root   string         // Path to the "home" of the container, including metadata.
-	basefs string         // Path to the graphdriver mountpoint
-
-	ID                       string
-	Created                  time.Time
-	Path                     string
-	Args                     []string
-	Config                   *runconfig.Config
-	ImageID                  string `json:"Image"`
-	NetworkSettings          *network.Settings
-	LogPath                  string
-	Name                     string
-	Driver                   string
-	ExecDriver               string
-	MountLabel, ProcessLabel string
-	RestartCount             int
-	HasBeenStartedBefore     bool
-	HasBeenManuallyStopped   bool // used for unless-stopped restart policy
-	hostConfig               *runconfig.HostConfig
-	command                  *execdriver.Command
-	monitor                  *containerMonitor
-	execCommands             *execStore
-	daemon                   *Daemon
+	streamConfig
+	// embed for Container to support states directly.
+	*State          `json:"State"` // Needed for remote api version <= 1.11
+	root            string         // Path to the "home" of the container, including metadata.
+	basefs          string         // Path to the graphdriver mountpoint
+	ID              string
+	Created         time.Time
+	Path            string
+	Args            []string
+	Config          *runconfig.Config
+	ImageID         string `json:"Image"`
+	NetworkSettings *network.Settings
+	LogPath         string
+	Name            string
+	Driver          string
+	ExecDriver      string
+	// MountLabel contains the options for the 'mount' command
+	MountLabel             string
+	ProcessLabel           string
+	RestartCount           int
+	HasBeenStartedBefore   bool
+	HasBeenManuallyStopped bool // used for unless-stopped restart policy
+	hostConfig             *runconfig.HostConfig
+	command                *execdriver.Command
+	monitor                *containerMonitor
+	execCommands           *execStore
+	daemon                 *Daemon
 	// logDriver for closing
 	logDriver logger.Logger
 	logCopier *logger.Copier
 }
 
-func (container *Container) FromDisk() error {
+func (container *Container) fromDisk() error {
 	pth, err := container.jsonPath()
 	if err != nil {
 		return err
@@ -131,10 +131,10 @@ func (container *Container) toDisk() error {
 		return err
 	}
 
-	return container.WriteHostConfig()
+	return container.writeHostConfig()
 }
 
-func (container *Container) ToDisk() error {
+func (container *Container) toDiskLocking() error {
 	container.Lock()
 	err := container.toDisk()
 	container.Unlock()
@@ -165,7 +165,7 @@ func (container *Container) readHostConfig() error {
 	return json.NewDecoder(f).Decode(&container.hostConfig)
 }
 
-func (container *Container) WriteHostConfig() error {
+func (container *Container) writeHostConfig() error {
 	data, err := json.Marshal(container.hostConfig)
 	if err != nil {
 		return err
@@ -179,7 +179,7 @@ func (container *Container) WriteHostConfig() error {
 	return ioutil.WriteFile(pth, data, 0666)
 }
 
-func (container *Container) LogEvent(action string) {
+func (container *Container) logEvent(action string) {
 	d := container.daemon
 	d.EventsService.Log(
 		action,
@@ -188,7 +188,7 @@ func (container *Container) LogEvent(action string) {
 	)
 }
 
-// Evaluates `path` in the scope of the container's basefs, with proper path
+// GetResourcePath evaluates `path` in the scope of the container's basefs, with proper path
 // sanitisation. Symlinks are all scoped to the basefs of the container, as
 // though the container's basefs was `/`.
 //
@@ -221,18 +221,18 @@ func (container *Container) GetResourcePath(path string) (string, error) {
 //       if no component of the returned path changes (such as a component
 //       symlinking to a different path) between using this method and using the
 //       path. See symlink.FollowSymlinkInScope for more details.
-func (container *Container) GetRootResourcePath(path string) (string, error) {
+func (container *Container) getRootResourcePath(path string) (string, error) {
 	// IMPORTANT - These are paths on the OS where the daemon is running, hence
 	// any filepath operations must be done in an OS agnostic way.
 	cleanPath := filepath.Join(string(os.PathSeparator), path)
 	return symlink.FollowSymlinkInScope(filepath.Join(container.root, cleanPath), container.root)
 }
 
-func (container *Container) ExportRw() (archive.Archive, error) {
+func (container *Container) exportContainerRw() (archive.Archive, error) {
 	if container.daemon == nil {
 		return nil, fmt.Errorf("Can't load storage driver for unregistered container %s", container.ID)
 	}
-	archive, err := container.daemon.Diff(container)
+	archive, err := container.daemon.diff(container)
 	if err != nil {
 		return nil, err
 	}
@@ -243,6 +243,10 @@ func (container *Container) ExportRw() (archive.Archive, error) {
 		nil
 }
 
+// Start prepares the container to run by setting up everything the
+// container needs, such as storage and networking, as well as links
+// between containers. The container is left waiting for a signal to
+// begin running.
 func (container *Container) Start() (err error) {
 	container.Lock()
 	defer container.Unlock()
@@ -266,7 +270,7 @@ func (container *Container) Start() (err error) {
 			}
 			container.toDisk()
 			container.cleanup()
-			container.LogEvent("die")
+			container.logEvent("die")
 		}
 	}()
 
@@ -302,7 +306,7 @@ func (container *Container) Start() (err error) {
 	return container.waitForStart()
 }
 
-func (container *Container) Run() error {
+func (container *Container) run() error {
 	if err := container.Start(); err != nil {
 		return err
 	}
@@ -311,7 +315,7 @@ func (container *Container) Run() error {
 	return nil
 }
 
-func (container *Container) Output() (output []byte, err error) {
+func (container *Container) output() (output []byte, err error) {
 	pipe := container.StdoutPipe()
 	defer pipe.Close()
 	if err := container.Start(); err != nil {
@@ -322,7 +326,7 @@ func (container *Container) Output() (output []byte, err error) {
 	return output, err
 }
 
-// StreamConfig.StdinPipe returns a WriteCloser which can be used to feed data
+// streamConfig.StdinPipe returns a WriteCloser which can be used to feed data
 // to the standard input of the container's active process.
 // Container.StdoutPipe and Container.StderrPipe each return a ReadCloser
 // which can be used to retrieve the standard output (and error) generated
@@ -330,17 +334,17 @@ func (container *Container) Output() (output []byte, err error) {
 // copied and delivered to all StdoutPipe and StderrPipe consumers, using
 // a kind of "broadcaster".
 
-func (streamConfig *StreamConfig) StdinPipe() io.WriteCloser {
+func (streamConfig *streamConfig) StdinPipe() io.WriteCloser {
 	return streamConfig.stdinPipe
 }
 
-func (streamConfig *StreamConfig) StdoutPipe() io.ReadCloser {
+func (streamConfig *streamConfig) StdoutPipe() io.ReadCloser {
 	reader, writer := io.Pipe()
 	streamConfig.stdout.AddWriter(writer)
 	return ioutils.NewBufReader(reader)
 }
 
-func (streamConfig *StreamConfig) StderrPipe() io.ReadCloser {
+func (streamConfig *streamConfig) StderrPipe() io.ReadCloser {
 	reader, writer := io.Pipe()
 	streamConfig.stderr.AddWriter(writer)
 	return ioutils.NewBufReader(reader)
@@ -353,7 +357,7 @@ func (container *Container) isNetworkAllocated() bool {
 // cleanup releases any network resources allocated to the container along with any rules
 // around how containers are linked together.  It also unmounts the container's root filesystem.
 func (container *Container) cleanup() {
-	container.ReleaseNetwork()
+	container.releaseNetwork()
 
 	if err := container.Unmount(); err != nil {
 		logrus.Errorf("%v: Failed to umount filesystem: %v", container.ID, err)
@@ -363,10 +367,15 @@ func (container *Container) cleanup() {
 		container.daemon.unregisterExecCommand(eConfig)
 	}
 
-	container.UnmountVolumes(false)
+	container.unmountVolumes(false)
 }
 
-func (container *Container) KillSig(sig int) error {
+// killSig sends the container the given signal. This wrapper for the
+// host specific kill command prepares the container before attempting
+// to send the signal. An error is returned if the container is paused
+// or not running, or if there is a problem returned from the
+// underlying kill command.
+func (container *Container) killSig(sig int) error {
 	logrus.Debugf("Sending %d to %s", sig, container.ID)
 	container.Lock()
 	defer container.Unlock()
@@ -391,24 +400,24 @@ func (container *Container) KillSig(sig int) error {
 		return nil
 	}
 
-	if err := container.daemon.Kill(container, sig); err != nil {
+	if err := container.daemon.kill(container, sig); err != nil {
 		return err
 	}
-	container.LogEvent("kill")
+	container.logEvent("kill")
 	return nil
 }
 
-// Wrapper aroung KillSig() suppressing "no such process" error.
+// Wrapper aroung killSig() suppressing "no such process" error.
 func (container *Container) killPossiblyDeadProcess(sig int) error {
-	err := container.KillSig(sig)
+	err := container.killSig(sig)
 	if err == syscall.ESRCH {
-		logrus.Debugf("Cannot kill process (pid=%d) with signal %d: no such process.", container.GetPid(), sig)
+		logrus.Debugf("Cannot kill process (pid=%d) with signal %d: no such process.", container.getPID(), sig)
 		return nil
 	}
 	return err
 }
 
-func (container *Container) Pause() error {
+func (container *Container) pause() error {
 	container.Lock()
 	defer container.Unlock()
 
@@ -426,11 +435,11 @@ func (container *Container) Pause() error {
 		return err
 	}
 	container.Paused = true
-	container.LogEvent("pause")
+	container.logEvent("pause")
 	return nil
 }
 
-func (container *Container) Unpause() error {
+func (container *Container) unpause() error {
 	container.Lock()
 	defer container.Unlock()
 
@@ -448,17 +457,18 @@ func (container *Container) Unpause() error {
 		return err
 	}
 	container.Paused = false
-	container.LogEvent("unpause")
+	container.logEvent("unpause")
 	return nil
 }
 
+// Kill forcefully terminates a container.
 func (container *Container) Kill() error {
 	if !container.IsRunning() {
 		return ErrContainerNotRunning{container.ID}
 	}
 
 	// 1. Send SIGKILL
-	if err := container.killPossiblyDeadProcess(9); err != nil {
+	if err := container.killPossiblyDeadProcess(int(syscall.SIGKILL)); err != nil {
 		// While normally we might "return err" here we're not going to
 		// because if we can't stop the container by this point then
 		// its probably because its already stopped. Meaning, between
@@ -487,15 +497,20 @@ func (container *Container) Kill() error {
 	return nil
 }
 
+// Stop halts a container by sending SIGTERM, waiting for the given
+// duration in seconds, and then calling SIGKILL and waiting for the
+// process to exit. If a negative duration is given, Stop will wait
+// for SIGTERM forever. If the container is not running Stop returns
+// immediately.
 func (container *Container) Stop(seconds int) error {
 	if !container.IsRunning() {
 		return nil
 	}
 
 	// 1. Send a SIGTERM
-	if err := container.killPossiblyDeadProcess(15); err != nil {
+	if err := container.killPossiblyDeadProcess(int(syscall.SIGTERM)); err != nil {
 		logrus.Infof("Failed to send SIGTERM to the process, force killing")
-		if err := container.killPossiblyDeadProcess(9); err != nil {
+		if err := container.killPossiblyDeadProcess(int(syscall.SIGKILL)); err != nil {
 			return err
 		}
 	}
@@ -510,10 +525,14 @@ func (container *Container) Stop(seconds int) error {
 		}
 	}
 
-	container.LogEvent("stop")
+	container.logEvent("stop")
 	return nil
 }
 
+// Restart attempts to gracefully stop and then start the
+// container. When stopping, wait for the given duration in seconds to
+// gracefully stop, before forcefully terminating the container. If
+// given a negative duration, wait forever for a graceful stop.
 func (container *Container) Restart(seconds int) error {
 	// Avoid unnecessarily unmounting and then directly mounting
 	// the container when the container stops and then starts
@@ -530,10 +549,12 @@ func (container *Container) Restart(seconds int) error {
 		return err
 	}
 
-	container.LogEvent("restart")
+	container.logEvent("restart")
 	return nil
 }
 
+// Resize changes the TTY of the process running inside the container
+// to the given height and width. The container must be running.
 func (container *Container) Resize(h, w int) error {
 	if !container.IsRunning() {
 		return ErrContainerNotRunning{container.ID}
@@ -541,11 +562,11 @@ func (container *Container) Resize(h, w int) error {
 	if err := container.command.ProcessConfig.Terminal.Resize(h, w); err != nil {
 		return err
 	}
-	container.LogEvent("resize")
+	container.logEvent("resize")
 	return nil
 }
 
-func (container *Container) Export() (archive.Archive, error) {
+func (container *Container) export() (archive.Archive, error) {
 	if err := container.Mount(); err != nil {
 		return nil, err
 	}
@@ -560,46 +581,45 @@ func (container *Container) Export() (archive.Archive, error) {
 		container.Unmount()
 		return err
 	})
-	container.LogEvent("export")
+	container.logEvent("export")
 	return arch, err
 }
 
+// Mount sets container.basefs
 func (container *Container) Mount() error {
 	return container.daemon.Mount(container)
 }
 
 func (container *Container) changes() ([]archive.Change, error) {
-	return container.daemon.Changes(container)
-}
-
-func (container *Container) Changes() ([]archive.Change, error) {
 	container.Lock()
 	defer container.Unlock()
-	return container.changes()
+	return container.daemon.changes(container)
 }
 
-func (container *Container) GetImage() (*image.Image, error) {
+func (container *Container) getImage() (*image.Image, error) {
 	if container.daemon == nil {
 		return nil, fmt.Errorf("Can't get image of unregistered container")
 	}
 	return container.daemon.graph.Get(container.ImageID)
 }
 
+// Unmount asks the daemon to release the layered filesystems that are
+// mounted by the container.
 func (container *Container) Unmount() error {
-	return container.daemon.Unmount(container)
+	return container.daemon.unmount(container)
 }
 
 func (container *Container) hostConfigPath() (string, error) {
-	return container.GetRootResourcePath("hostconfig.json")
+	return container.getRootResourcePath("hostconfig.json")
 }
 
 func (container *Container) jsonPath() (string, error) {
-	return container.GetRootResourcePath("config.json")
+	return container.getRootResourcePath("config.json")
 }
 
 // This method must be exported to be used from the lxc template
 // This directory is only usable when the container is running
-func (container *Container) RootfsPath() string {
+func (container *Container) rootfsPath() string {
 	return container.basefs
 }
 
@@ -610,7 +630,7 @@ func validateID(id string) error {
 	return nil
 }
 
-func (container *Container) Copy(resource string) (rc io.ReadCloser, err error) {
+func (container *Container) copy(resource string) (rc io.ReadCloser, err error) {
 	container.Lock()
 
 	defer func() {
@@ -629,7 +649,7 @@ func (container *Container) Copy(resource string) (rc io.ReadCloser, err error) 
 	defer func() {
 		if err != nil {
 			// unmount any volumes
-			container.UnmountVolumes(true)
+			container.unmountVolumes(true)
 			// unmount the container's rootfs
 			container.Unmount()
 		}
@@ -666,17 +686,17 @@ func (container *Container) Copy(resource string) (rc io.ReadCloser, err error) 
 
 	reader := ioutils.NewReadCloserWrapper(archive, func() error {
 		err := archive.Close()
-		container.UnmountVolumes(true)
+		container.unmountVolumes(true)
 		container.Unmount()
 		container.Unlock()
 		return err
 	})
-	container.LogEvent("copy")
+	container.logEvent("copy")
 	return reader, nil
 }
 
 // Returns true if the container exposes a certain port
-func (container *Container) Exposes(p nat.Port) bool {
+func (container *Container) exposes(p nat.Port) bool {
 	_, exists := container.Config.ExposedPorts[p]
 	return exists
 }
@@ -718,7 +738,7 @@ func (container *Container) getLogger() (logger.Logger, error) {
 
 	// Set logging file for "json-logger"
 	if cfg.Type == jsonfilelog.Name {
-		ctx.LogPath, err = container.GetRootResourcePath(fmt.Sprintf("%s-json.log", container.ID))
+		ctx.LogPath, err = container.getRootResourcePath(fmt.Sprintf("%s-json.log", container.ID))
 		if err != nil {
 			return nil, err
 		}
@@ -764,7 +784,7 @@ func (container *Container) waitForStart() error {
 	return nil
 }
 
-func (container *Container) GetProcessLabel() string {
+func (container *Container) getProcessLabel() string {
 	// even if we have a process label return "" if we are running
 	// in privileged mode
 	if container.hostConfig.Privileged {
@@ -773,31 +793,22 @@ func (container *Container) GetProcessLabel() string {
 	return container.ProcessLabel
 }
 
-func (container *Container) GetMountLabel() string {
+func (container *Container) getMountLabel() string {
 	if container.hostConfig.Privileged {
 		return ""
 	}
 	return container.MountLabel
 }
 
-func (container *Container) Stats() (*execdriver.ResourceStats, error) {
-	return container.daemon.Stats(container)
+func (container *Container) stats() (*execdriver.ResourceStats, error) {
+	return container.daemon.stats(container)
 }
 
-func (c *Container) LogDriverType() string {
-	c.Lock()
-	defer c.Unlock()
-	if c.hostConfig.LogConfig.Type == "" {
-		return c.daemon.defaultLogConfig.Type
-	}
-	return c.hostConfig.LogConfig.Type
-}
-
-func (container *Container) GetExecIDs() []string {
+func (container *Container) getExecIDs() []string {
 	return container.execCommands.List()
 }
 
-func (container *Container) Exec(execConfig *execConfig) error {
+func (container *Container) exec(ExecConfig *ExecConfig) error {
 	container.Lock()
 	defer container.Unlock()
 
@@ -810,16 +821,16 @@ func (container *Container) Exec(execConfig *execConfig) error {
 				c.Close()
 			}
 		}
-		close(execConfig.waitStart)
+		close(ExecConfig.waitStart)
 	}
 
 	// We use a callback here instead of a goroutine and an chan for
 	// synchronization purposes
-	cErr := promise.Go(func() error { return container.monitorExec(execConfig, callback) })
+	cErr := promise.Go(func() error { return container.monitorExec(ExecConfig, callback) })
 
 	// Exec should not return until the process is actually running
 	select {
-	case <-execConfig.waitStart:
+	case <-ExecConfig.waitStart:
 	case err := <-cErr:
 		return err
 	}
@@ -827,46 +838,48 @@ func (container *Container) Exec(execConfig *execConfig) error {
 	return nil
 }
 
-func (container *Container) monitorExec(execConfig *execConfig, callback execdriver.StartCallback) error {
+func (container *Container) monitorExec(ExecConfig *ExecConfig, callback execdriver.StartCallback) error {
 	var (
 		err      error
 		exitCode int
 	)
-	pipes := execdriver.NewPipes(execConfig.StreamConfig.stdin, execConfig.StreamConfig.stdout, execConfig.StreamConfig.stderr, execConfig.OpenStdin)
-	exitCode, err = container.daemon.Exec(container, execConfig, pipes, callback)
+	pipes := execdriver.NewPipes(ExecConfig.streamConfig.stdin, ExecConfig.streamConfig.stdout, ExecConfig.streamConfig.stderr, ExecConfig.OpenStdin)
+	exitCode, err = container.daemon.Exec(container, ExecConfig, pipes, callback)
 	if err != nil {
 		logrus.Errorf("Error running command in existing container %s: %s", container.ID, err)
 	}
 	logrus.Debugf("Exec task in container %s exited with code %d", container.ID, exitCode)
-	if execConfig.OpenStdin {
-		if err := execConfig.StreamConfig.stdin.Close(); err != nil {
+	if ExecConfig.OpenStdin {
+		if err := ExecConfig.streamConfig.stdin.Close(); err != nil {
 			logrus.Errorf("Error closing stdin while running in %s: %s", container.ID, err)
 		}
 	}
-	if err := execConfig.StreamConfig.stdout.Clean(); err != nil {
+	if err := ExecConfig.streamConfig.stdout.Clean(); err != nil {
 		logrus.Errorf("Error closing stdout while running in %s: %s", container.ID, err)
 	}
-	if err := execConfig.StreamConfig.stderr.Clean(); err != nil {
+	if err := ExecConfig.streamConfig.stderr.Clean(); err != nil {
 		logrus.Errorf("Error closing stderr while running in %s: %s", container.ID, err)
 	}
-	if execConfig.ProcessConfig.Terminal != nil {
-		if err := execConfig.ProcessConfig.Terminal.Close(); err != nil {
+	if ExecConfig.ProcessConfig.Terminal != nil {
+		if err := ExecConfig.ProcessConfig.Terminal.Close(); err != nil {
 			logrus.Errorf("Error closing terminal while running in container %s: %s", container.ID, err)
 		}
 	}
 	// remove the exec command from the container's store only and not the
 	// daemon's store so that the exec command can be inspected.
-	container.execCommands.Delete(execConfig.ID)
+	container.execCommands.Delete(ExecConfig.ID)
 	return err
 }
 
-func (c *Container) Attach(stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) chan error {
-	return attach(&c.StreamConfig, c.Config.OpenStdin, c.Config.StdinOnce, c.Config.Tty, stdin, stdout, stderr)
+// Attach connects to the container's TTY, delegating to standard
+// streams or websockets depending on the configuration.
+func (container *Container) Attach(stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) chan error {
+	return attach(&container.streamConfig, container.Config.OpenStdin, container.Config.StdinOnce, container.Config.Tty, stdin, stdout, stderr)
 }
 
-func (c *Container) AttachWithLogs(stdin io.ReadCloser, stdout, stderr io.Writer, logs, stream bool) error {
+func (container *Container) attachWithLogs(stdin io.ReadCloser, stdout, stderr io.Writer, logs, stream bool) error {
 	if logs {
-		logDriver, err := c.getLogger()
+		logDriver, err := container.getLogger()
 		if err != nil {
 			return err
 		}
@@ -896,7 +909,7 @@ func (c *Container) AttachWithLogs(stdin io.ReadCloser, stdout, stderr io.Writer
 		}
 	}
 
-	c.LogEvent("attach")
+	container.logEvent("attach")
 
 	//stream
 	if stream {
@@ -910,17 +923,17 @@ func (c *Container) AttachWithLogs(stdin io.ReadCloser, stdout, stderr io.Writer
 			}()
 			stdinPipe = r
 		}
-		<-c.Attach(stdinPipe, stdout, stderr)
+		<-container.Attach(stdinPipe, stdout, stderr)
 		// If we are in stdinonce mode, wait for the process to end
 		// otherwise, simply return
-		if c.Config.StdinOnce && !c.Config.Tty {
-			c.WaitStop(-1 * time.Second)
+		if container.Config.StdinOnce && !container.Config.Tty {
+			container.WaitStop(-1 * time.Second)
 		}
 	}
 	return nil
 }
 
-func attach(streamConfig *StreamConfig, openStdin, stdinOnce, tty bool, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) chan error {
+func attach(streamConfig *streamConfig, openStdin, stdinOnce, tty bool, stdin io.ReadCloser, stdout io.Writer, stderr io.Writer) chan error {
 	var (
 		cStdout, cStderr io.ReadCloser
 		cStdin           io.WriteCloser

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opencontainers/runc/libcontainer/label"
 )
 
+// ContainerCreate takes configs and creates a container.
 func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hostConfig *runconfig.HostConfig, adjustCPUShares bool) (*Container, []string, error) {
 	if config == nil {
 		return nil, nil, fmt.Errorf("Config cannot be empty in order to create a container")
@@ -70,7 +71,7 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 		hostConfig = &runconfig.HostConfig{}
 	}
 	if hostConfig.SecurityOpt == nil {
-		hostConfig.SecurityOpt, err = daemon.GenerateSecurityOpt(hostConfig.IpcMode, hostConfig.PidMode)
+		hostConfig.SecurityOpt, err = daemon.generateSecurityOpt(hostConfig.IpcMode, hostConfig.PidMode)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -104,15 +105,15 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 		return nil, nil, err
 	}
 
-	if err := container.ToDisk(); err != nil {
+	if err := container.toDiskLocking(); err != nil {
 		logrus.Errorf("Error saving new container to disk: %v", err)
 		return nil, nil, err
 	}
-	container.LogEvent("create")
+	container.logEvent("create")
 	return container, warnings, nil
 }
 
-func (daemon *Daemon) GenerateSecurityOpt(ipcMode runconfig.IpcMode, pidMode runconfig.PidMode) ([]string, error) {
+func (daemon *Daemon) generateSecurityOpt(ipcMode runconfig.IpcMode, pidMode runconfig.PidMode) ([]string, error) {
 	if ipcMode.IsHost() || pidMode.IsHost() {
 		return label.DisableSecOpt(), nil
 	}

--- a/daemon/daemon_btrfs.go
+++ b/daemon/daemon_btrfs.go
@@ -3,5 +3,6 @@
 package daemon
 
 import (
+	// register the btrfs graphdriver
 	_ "github.com/docker/docker/daemon/graphdriver/btrfs"
 )

--- a/daemon/daemon_devicemapper.go
+++ b/daemon/daemon_devicemapper.go
@@ -3,5 +3,6 @@
 package daemon
 
 import (
+	// register the devmapper graphdriver
 	_ "github.com/docker/docker/daemon/graphdriver/devmapper"
 )

--- a/daemon/daemon_overlay.go
+++ b/daemon/daemon_overlay.go
@@ -3,5 +3,6 @@
 package daemon
 
 import (
+	// register the overlay graphdriver
 	_ "github.com/docker/docker/daemon/graphdriver/overlay"
 )

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -86,9 +86,9 @@ func TestGet(t *testing.T) {
 	graph.Set(c5.Name, c5.ID)
 
 	daemon := &Daemon{
-		containers:     store,
-		idIndex:        index,
-		containerGraph: graph,
+		containers:       store,
+		idIndex:          index,
+		containerGraphDB: graph,
 	}
 
 	if container, _ := daemon.Get("3cdbd1aa394fd68559fd1441d6eff2ab7c1e6363582c82febfaa8045df3bd8de"); container != c2 {
@@ -130,15 +130,15 @@ func TestLoadWithVolume(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	containerId := "d59df5276e7b219d510fe70565e0404bc06350e0d4b43fe961f22f339980170e"
-	containerPath := filepath.Join(tmp, containerId)
+	containerID := "d59df5276e7b219d510fe70565e0404bc06350e0d4b43fe961f22f339980170e"
+	containerPath := filepath.Join(tmp, containerID)
 	if err := os.MkdirAll(containerPath, 0755); err != nil {
 		t.Fatal(err)
 	}
 
-	hostVolumeId := stringid.GenerateNonCryptoID()
-	vfsPath := filepath.Join(tmp, "vfs", "dir", hostVolumeId)
-	volumePath := filepath.Join(tmp, "volumes", hostVolumeId)
+	hostVolumeID := stringid.GenerateNonCryptoID()
+	vfsPath := filepath.Join(tmp, "vfs", "dir", hostVolumeID)
+	volumePath := filepath.Join(tmp, "volumes", hostVolumeID)
 
 	if err := os.MkdirAll(vfsPath, 0755); err != nil {
 		t.Fatal(err)
@@ -187,7 +187,7 @@ func TestLoadWithVolume(t *testing.T) {
 	}
 	defer volumedrivers.Unregister(volume.DefaultDriverName)
 
-	c, err := daemon.load(containerId)
+	c, err := daemon.load(containerID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,8 +202,8 @@ func TestLoadWithVolume(t *testing.T) {
 	}
 
 	m := c.MountPoints["/vol1"]
-	if m.Name != hostVolumeId {
-		t.Fatalf("Expected mount name to be %s, was %s\n", hostVolumeId, m.Name)
+	if m.Name != hostVolumeID {
+		t.Fatalf("Expected mount name to be %s, was %s\n", hostVolumeID, m.Name)
 	}
 
 	if m.Destination != "/vol1" {
@@ -235,8 +235,8 @@ func TestLoadWithBindMount(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	containerId := "d59df5276e7b219d510fe70565e0404bc06350e0d4b43fe961f22f339980170e"
-	containerPath := filepath.Join(tmp, containerId)
+	containerID := "d59df5276e7b219d510fe70565e0404bc06350e0d4b43fe961f22f339980170e"
+	containerPath := filepath.Join(tmp, containerID)
 	if err = os.MkdirAll(containerPath, 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -275,7 +275,7 @@ func TestLoadWithBindMount(t *testing.T) {
 	}
 	defer volumedrivers.Unregister(volume.DefaultDriverName)
 
-	c, err := daemon.load(containerId)
+	c, err := daemon.load(containerID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,14 +314,14 @@ func TestLoadWithVolume17RC(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	containerId := "d59df5276e7b219d510fe70565e0404bc06350e0d4b43fe961f22f339980170e"
-	containerPath := filepath.Join(tmp, containerId)
+	containerID := "d59df5276e7b219d510fe70565e0404bc06350e0d4b43fe961f22f339980170e"
+	containerPath := filepath.Join(tmp, containerID)
 	if err := os.MkdirAll(containerPath, 0755); err != nil {
 		t.Fatal(err)
 	}
 
-	hostVolumeId := "6a3c03fc4a4e588561a543cc3bdd50089e27bd11bbb0e551e19bf735e2514101"
-	volumePath := filepath.Join(tmp, "volumes", hostVolumeId)
+	hostVolumeID := "6a3c03fc4a4e588561a543cc3bdd50089e27bd11bbb0e551e19bf735e2514101"
+	volumePath := filepath.Join(tmp, "volumes", hostVolumeID)
 
 	if err := os.MkdirAll(volumePath, 0755); err != nil {
 		t.Fatal(err)
@@ -366,7 +366,7 @@ func TestLoadWithVolume17RC(t *testing.T) {
 	}
 	defer volumedrivers.Unregister(volume.DefaultDriverName)
 
-	c, err := daemon.load(containerId)
+	c, err := daemon.load(containerID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,8 +381,8 @@ func TestLoadWithVolume17RC(t *testing.T) {
 	}
 
 	m := c.MountPoints["/vol1"]
-	if m.Name != hostVolumeId {
-		t.Fatalf("Expected mount name to be %s, was %s\n", hostVolumeId, m.Name)
+	if m.Name != hostVolumeID {
+		t.Fatalf("Expected mount name to be %s, was %s\n", hostVolumeID, m.Name)
 	}
 
 	if m.Destination != "/vol1" {
@@ -414,15 +414,15 @@ func TestRemoveLocalVolumesFollowingSymlinks(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	containerId := "d59df5276e7b219d510fe70565e0404bc06350e0d4b43fe961f22f339980170e"
-	containerPath := filepath.Join(tmp, containerId)
+	containerID := "d59df5276e7b219d510fe70565e0404bc06350e0d4b43fe961f22f339980170e"
+	containerPath := filepath.Join(tmp, containerID)
 	if err := os.MkdirAll(containerPath, 0755); err != nil {
 		t.Fatal(err)
 	}
 
-	hostVolumeId := stringid.GenerateNonCryptoID()
-	vfsPath := filepath.Join(tmp, "vfs", "dir", hostVolumeId)
-	volumePath := filepath.Join(tmp, "volumes", hostVolumeId)
+	hostVolumeID := stringid.GenerateNonCryptoID()
+	vfsPath := filepath.Join(tmp, "vfs", "dir", hostVolumeID)
+	volumePath := filepath.Join(tmp, "volumes", hostVolumeID)
 
 	if err := os.MkdirAll(vfsPath, 0755); err != nil {
 		t.Fatal(err)
@@ -471,7 +471,7 @@ func TestRemoveLocalVolumesFollowingSymlinks(t *testing.T) {
 	}
 	defer volumedrivers.Unregister(volume.DefaultDriverName)
 
-	c, err := daemon.load(containerId)
+	c, err := daemon.load(containerID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -63,7 +63,7 @@ func parseSecurityOpt(container *Container, config *runconfig.HostConfig) error 
 	return err
 }
 
-func CheckKernelVersion(k, major, minor int) bool {
+func checkKernelVersion(k, major, minor int) bool {
 	if v, err := kernel.GetKernelVersion(); err != nil {
 		logrus.Warnf("%s", err)
 	} else {
@@ -82,7 +82,7 @@ func checkKernel() error {
 	// without actually causing a kernel panic, so we need this workaround until
 	// the circumstances of pre-3.10 crashes are clearer.
 	// For details see https://github.com/docker/docker/issues/407
-	if !CheckKernelVersion(3, 10, 0) {
+	if !checkKernelVersion(3, 10, 0) {
 		v, _ := kernel.GetKernelVersion()
 		if os.Getenv("DOCKER_NOWARN_KERNEL_VERSION") == "" {
 			logrus.Warnf("Your Linux kernel version %s can be unstable running docker. Please upgrade your kernel to 3.10.0.", v.String())
@@ -161,7 +161,7 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 		logrus.Warnf("Your kernel does not support kernel memory limit capabilities. Limitation discarded.")
 		hostConfig.KernelMemory = 0
 	}
-	if hostConfig.KernelMemory > 0 && !CheckKernelVersion(4, 0, 0) {
+	if hostConfig.KernelMemory > 0 && !checkKernelVersion(4, 0, 0) {
 		warnings = append(warnings, "You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
 		logrus.Warnf("You specified a kernel memory limit on a kernel older than 4.0. Kernel memory limits are experimental on older kernels, it won't work as expected and can cause your system to be unstable.")
 	}
@@ -194,7 +194,6 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 	if hostConfig.BlkioWeight > 0 && (hostConfig.BlkioWeight < 10 || hostConfig.BlkioWeight > 1000) {
 		return warnings, fmt.Errorf("Range of blkio weight is from 10 to 1000.")
 	}
-
 	if hostConfig.OomKillDisable && !sysInfo.OomKillDisable {
 		hostConfig.OomKillDisable = false
 		return warnings, fmt.Errorf("Your kernel does not support oom kill disable.")
@@ -494,11 +493,14 @@ func setupInitLayer(initLayer string) error {
 	return nil
 }
 
-func (daemon *Daemon) NetworkApiRouter() func(w http.ResponseWriter, req *http.Request) {
+// NetworkAPIRouter implements a feature for server-experimental,
+// directly calling into libnetwork.
+func (daemon *Daemon) NetworkAPIRouter() func(w http.ResponseWriter, req *http.Request) {
 	return nwapi.NewHTTPHandler(daemon.netController)
 }
 
-func (daemon *Daemon) RegisterLinks(container *Container, hostConfig *runconfig.HostConfig) error {
+// registerLinks writes the links to a file.
+func (daemon *Daemon) registerLinks(container *Container, hostConfig *runconfig.HostConfig) error {
 	if hostConfig == nil || hostConfig.Links == nil {
 		return nil
 	}
@@ -523,7 +525,7 @@ func (daemon *Daemon) RegisterLinks(container *Container, hostConfig *runconfig.
 		if child.hostConfig.NetworkMode.IsHost() {
 			return runconfig.ErrConflictHostNetworkAndLinks
 		}
-		if err := daemon.RegisterLink(container, child, alias); err != nil {
+		if err := daemon.registerLink(container, child, alias); err != nil {
 			return err
 		}
 	}
@@ -531,7 +533,7 @@ func (daemon *Daemon) RegisterLinks(container *Container, hostConfig *runconfig.
 	// After we load all the links into the daemon
 	// set them to nil on the hostconfig
 	hostConfig.Links = nil
-	if err := container.WriteHostConfig(); err != nil {
+	if err := container.writeHostConfig(); err != nil {
 		return err
 	}
 

--- a/daemon/daemon_zfs.go
+++ b/daemon/daemon_zfs.go
@@ -3,5 +3,6 @@
 package daemon
 
 import (
+	// register the zfs driver
 	_ "github.com/docker/docker/daemon/graphdriver/zfs"
 )

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -8,10 +8,15 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
+// ContainerRmConfig is a holder for passing in runtime config.
 type ContainerRmConfig struct {
 	ForceRemove, RemoveVolume, RemoveLink bool
 }
 
+// ContainerRm removes the container id from the filesystem. An error
+// is returned if the container is not found, or if the remove
+// fails. If the remove succeeds, the container name is released, and
+// network links are removed.
 func (daemon *Daemon) ContainerRm(name string, config *ContainerRmConfig) error {
 	container, err := daemon.Get(name)
 	if err != nil {
@@ -27,18 +32,18 @@ func (daemon *Daemon) ContainerRm(name string, config *ContainerRmConfig) error 
 		if parent == "/" {
 			return fmt.Errorf("Conflict, cannot remove the default name of the container")
 		}
-		pe := daemon.ContainerGraph().Get(parent)
+		pe := daemon.containerGraph().Get(parent)
 		if pe == nil {
 			return fmt.Errorf("Cannot get parent %s for name %s", parent, name)
 		}
 
-		if err := daemon.ContainerGraph().Delete(name); err != nil {
+		if err := daemon.containerGraph().Delete(name); err != nil {
 			return err
 		}
 
 		parentContainer, _ := daemon.Get(pe.ID())
 		if parentContainer != nil {
-			if err := parentContainer.UpdateNetwork(); err != nil {
+			if err := parentContainer.updateNetwork(); err != nil {
 				logrus.Debugf("Could not update network to remove link %s: %v", n, err)
 			}
 		}
@@ -75,23 +80,23 @@ func (daemon *Daemon) rm(container *Container, forceRemove bool) (err error) {
 	}
 
 	// Container state RemovalInProgress should be used to avoid races.
-	if err = container.SetRemovalInProgress(); err != nil {
+	if err = container.setRemovalInProgress(); err != nil {
 		return fmt.Errorf("Failed to set container state to RemovalInProgress: %s", err)
 	}
 
-	defer container.ResetRemovalInProgress()
+	defer container.resetRemovalInProgress()
 
 	if err = container.Stop(3); err != nil {
 		return err
 	}
 
 	// Mark container dead. We don't want anybody to be restarting it.
-	container.SetDead()
+	container.setDead()
 
 	// Save container state to disk. So that if error happens before
 	// container meta file got removed from disk, then a restart of
 	// docker should not make a dead container alive.
-	if err := container.ToDisk(); err != nil {
+	if err := container.toDiskLocking(); err != nil {
 		logrus.Errorf("Error saving dying container to disk: %v", err)
 	}
 
@@ -102,11 +107,11 @@ func (daemon *Daemon) rm(container *Container, forceRemove bool) (err error) {
 			daemon.idIndex.Delete(container.ID)
 			daemon.containers.Delete(container.ID)
 			os.RemoveAll(container.root)
-			container.LogEvent("destroy")
+			container.logEvent("destroy")
 		}
 	}()
 
-	if _, err := daemon.containerGraph.Purge(container.ID); err != nil {
+	if _, err := daemon.containerGraphDB.Purge(container.ID); err != nil {
 		logrus.Debugf("Unable to remove container from link graph: %s", err)
 	}
 
@@ -131,7 +136,7 @@ func (daemon *Daemon) rm(container *Container, forceRemove bool) (err error) {
 	daemon.idIndex.Delete(container.ID)
 	daemon.containers.Delete(container.ID)
 
-	container.LogEvent("destroy")
+	container.logEvent("destroy")
 	return nil
 }
 

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -5,13 +5,15 @@ import (
 	"io"
 )
 
+// ContainerExport writes the contents of the container to the given
+// writer. An error is returned if the container cannot be found.
 func (daemon *Daemon) ContainerExport(name string, out io.Writer) error {
 	container, err := daemon.Get(name)
 	if err != nil {
 		return err
 	}
 
-	data, err := container.Export()
+	data, err := container.export()
 	if err != nil {
 		return fmt.Errorf("%s: %s", name, err)
 	}

--- a/daemon/history.go
+++ b/daemon/history.go
@@ -22,10 +22,11 @@ func (history *History) Swap(i, j int) {
 	containers[i], containers[j] = containers[j], containers[i]
 }
 
+// Add the given container to history.
 func (history *History) Add(container *Container) {
 	*history = append(*history, container)
 }
 
-func (history *History) Sort() {
+func (history *History) sort() {
 	sort.Sort(history)
 }

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/utils"
 )
 
+// ImageDelete removes the image from the filesystem.
 // FIXME: remove ImageDelete's dependency on Daemon, then move to graph/
 func (daemon *Daemon) ImageDelete(name string, force, noprune bool) ([]types.ImageDelete, error) {
 	list := []types.ImageDelete{}

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/utils"
 )
 
+// SystemInfo returns information about the host server the daemon is running on.
 func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 	images := daemon.Graph().Map()
 	var imgcount int
@@ -50,11 +51,14 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		logrus.Errorf("Could not read system memory info: %v", err)
 	}
 
-	// if we still have the original dockerinit binary from before we copied it locally, let's return the path to that, since that's more intuitive (the copied path is trivial to derive by hand given VERSION)
+	// if we still have the original dockerinit binary from before
+	// we copied it locally, let's return the path to that, since
+	// that's more intuitive (the copied path is trivial to derive
+	// by hand given VERSION)
 	initPath := utils.DockerInitPath("")
 	if initPath == "" {
 		// if that fails, we'll just return the path from the daemon
-		initPath = daemon.SystemInitPath()
+		initPath = daemon.systemInitPath()
 	}
 
 	sysInfo := sysinfo.New(false)
@@ -83,8 +87,8 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		InitPath:           initPath,
 		NCPU:               runtime.NumCPU(),
 		MemTotal:           meminfo.MemTotal,
-		DockerRootDir:      daemon.Config().Root,
-		Labels:             daemon.Config().Labels,
+		DockerRootDir:      daemon.config().Root,
+		Labels:             daemon.config().Labels,
 		ExperimentalBuild:  utils.ExperimentalBuild(),
 	}
 

--- a/daemon/inspect.go
+++ b/daemon/inspect.go
@@ -7,6 +7,9 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
+// ContainerInspect returns low-level information about a
+// container. Returns an error if the container cannot be found, or if
+// there is an error getting the data.
 func (daemon *Daemon) ContainerInspect(name string) (*types.ContainerJSON, error) {
 	container, err := daemon.Get(name)
 	if err != nil {
@@ -30,7 +33,7 @@ func (daemon *Daemon) getInspectData(container *Container) (*types.ContainerJSON
 	// make a copy to play with
 	hostConfig := *container.hostConfig
 
-	if children, err := daemon.Children(container.Name); err == nil {
+	if children, err := daemon.children(container.Name); err == nil {
 		for linkAlias, child := range children {
 			hostConfig.Links = append(hostConfig.Links, fmt.Sprintf("%s:%s", child.Name, linkAlias))
 		}
@@ -73,7 +76,7 @@ func (daemon *Daemon) getInspectData(container *Container) (*types.ContainerJSON
 		ExecDriver:      container.ExecDriver,
 		MountLabel:      container.MountLabel,
 		ProcessLabel:    container.ProcessLabel,
-		ExecIDs:         container.GetExecIDs(),
+		ExecIDs:         container.getExecIDs(),
 		HostConfig:      &hostConfig,
 	}
 
@@ -90,7 +93,9 @@ func (daemon *Daemon) getInspectData(container *Container) (*types.ContainerJSON
 	return contJSONBase, nil
 }
 
-func (daemon *Daemon) ContainerExecInspect(id string) (*execConfig, error) {
+// ContainerExecInspect returns low-level information about the exec
+// command. An error is returned if the exec cannot be found.
+func (daemon *Daemon) ContainerExecInspect(id string) (*ExecConfig, error) {
 	eConfig, err := daemon.getExecConfig(id)
 	if err != nil {
 		return nil, err
@@ -98,6 +103,8 @@ func (daemon *Daemon) ContainerExecInspect(id string) (*execConfig, error) {
 	return eConfig, nil
 }
 
+// VolumeInspect looks up a volume by name. An error is returned if
+// the volume cannot be found.
 func (daemon *Daemon) VolumeInspect(name string) (*types.Volume, error) {
 	v, err := daemon.volumes.Get(name)
 	if err != nil {

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -14,6 +14,7 @@ func setPlatformSpecificContainerFields(container *Container, contJSONBase *type
 	return contJSONBase
 }
 
+// ContainerInspectPre120 is for backwards compatibility with pre v1.20 clients.
 func (daemon *Daemon) ContainerInspectPre120(name string) (*types.ContainerJSONPre120, error) {
 	container, err := daemon.Get(name)
 	if err != nil {

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -19,7 +19,7 @@ func (daemon *Daemon) ContainerKill(name string, sig uint64) error {
 		}
 	} else {
 		// Otherwise, just send the requested signal
-		if err := container.KillSig(int(sig)); err != nil {
+		if err := container.killSig(int(sig)); err != nil {
 			return err
 		}
 	}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -17,15 +17,24 @@ func (daemon *Daemon) List() []*Container {
 	return daemon.containers.List()
 }
 
+// ContainersConfig is a struct for configuring the command to list
+// containers.
 type ContainersConfig struct {
-	All     bool
-	Since   string
-	Before  string
-	Limit   int
-	Size    bool
+	// if true show all containers, otherwise only running containers.
+	All bool
+	// show all containers created after this container id
+	Since string
+	// show all containers created before this container id
+	Before string
+	// number of containers to return at most
+	Limit int
+	// if true include the sizes of the containers
+	Size bool
+	// return only containers that match filters
 	Filters string
 }
 
+// Containers returns a list of all the containers.
 func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, error) {
 	var (
 		foundBefore bool
@@ -62,7 +71,7 @@ func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, 
 		}
 	}
 	names := map[string][]string{}
-	daemon.ContainerGraph().Walk("/", func(p string, e *graphdb.Entity) error {
+	daemon.containerGraph().Walk("/", func(p string, e *graphdb.Entity) error {
 		names[e.ID()] = append(names[e.ID()], p)
 		return nil
 	}, 1)
@@ -195,7 +204,7 @@ func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, 
 		}
 
 		if config.Size {
-			sizeRw, sizeRootFs := container.GetSize()
+			sizeRw, sizeRootFs := container.getSize()
 			newC.SizeRw = sizeRw
 			newC.SizeRootFs = sizeRootFs
 		}
@@ -215,6 +224,8 @@ func (daemon *Daemon) Containers(config *ContainersConfig) ([]*types.Container, 
 	return containers, nil
 }
 
+// Volumes lists known volumes, using the filter to restrict the range
+// of volumes returned.
 func (daemon *Daemon) Volumes(filter string) ([]*types.Volume, error) {
 	var volumesOut []*types.Volume
 	volFilters, err := filters.FromParam(filter)

--- a/daemon/logdrivers_linux.go
+++ b/daemon/logdrivers_linux.go
@@ -1,8 +1,8 @@
 package daemon
 
-// Importing packages here only to make sure their init gets called and
-// therefore they register themselves to the logdriver factory.
 import (
+	// Importing packages here only to make sure their init gets called and
+	// therefore they register themselves to the logdriver factory.
 	_ "github.com/docker/docker/daemon/logger/fluentd"
 	_ "github.com/docker/docker/daemon/logger/gelf"
 	_ "github.com/docker/docker/daemon/logger/journald"

--- a/daemon/logdrivers_windows.go
+++ b/daemon/logdrivers_windows.go
@@ -1,7 +1,7 @@
 package daemon
 
-// Importing packages here only to make sure their init gets called and
-// therefore they register themselves to the logdriver factory.
 import (
+	// Importing packages here only to make sure their init gets called and
+	// therefore they register themselves to the logdriver factory.
 	_ "github.com/docker/docker/daemon/logger/jsonfilelog"
 )

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -11,15 +11,25 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 )
 
+// ContainerLogsConfig holds configs for logging operations. Exists
+// for users of the daemon to to pass it a logging configuration.
 type ContainerLogsConfig struct {
-	Follow, Timestamps   bool
-	Tail                 string
-	Since                time.Time
+	// if true stream log output
+	Follow bool
+	// if true include timestamps for each line of log output
+	Timestamps bool
+	// return that many lines of log output from the end
+	Tail string
+	// filter logs by returning on those entries after this time
+	Since time.Time
+	// whether or not to show stdout and stderr as well as log entries.
 	UseStdout, UseStderr bool
 	OutStream            io.Writer
 	Stop                 <-chan bool
 }
 
+// ContainerLogs hooks up a container's stdout and stderr streams
+// configured with the given struct.
 func (daemon *Daemon) ContainerLogs(container *Container, config *ContainerLogsConfig) error {
 	if !(config.UseStdout || config.UseStderr) {
 		return fmt.Errorf("You must choose at least one stream")

--- a/daemon/monitor.go
+++ b/daemon/monitor.go
@@ -138,11 +138,11 @@ func (m *containerMonitor) Start() error {
 
 		pipes := execdriver.NewPipes(m.container.stdin, m.container.stdout, m.container.stderr, m.container.Config.OpenStdin)
 
-		m.container.LogEvent("start")
+		m.container.logEvent("start")
 
 		m.lastStartTime = time.Now()
 
-		if exitStatus, err = m.container.daemon.Run(m.container, pipes, m.callback); err != nil {
+		if exitStatus, err = m.container.daemon.run(m.container, pipes, m.callback); err != nil {
 			// if we receive an internal error from the initial start of a container then lets
 			// return it instead of entering the restart loop
 			if m.container.RestartCount == 0 {
@@ -161,11 +161,11 @@ func (m *containerMonitor) Start() error {
 		m.resetMonitor(err == nil && exitStatus.ExitCode == 0)
 
 		if m.shouldRestart(exitStatus.ExitCode) {
-			m.container.SetRestarting(&exitStatus)
+			m.container.setRestarting(&exitStatus)
 			if exitStatus.OOMKilled {
-				m.container.LogEvent("oom")
+				m.container.logEvent("oom")
 			}
-			m.container.LogEvent("die")
+			m.container.logEvent("die")
 			m.resetContainer(true)
 
 			// sleep with a small time increment between each restart to help avoid issues cased by quickly
@@ -180,9 +180,9 @@ func (m *containerMonitor) Start() error {
 			continue
 		}
 		if exitStatus.OOMKilled {
-			m.container.LogEvent("oom")
+			m.container.logEvent("oom")
 		}
-		m.container.LogEvent("die")
+		m.container.logEvent("die")
 		m.resetContainer(true)
 		return err
 	}
@@ -270,7 +270,7 @@ func (m *containerMonitor) callback(processConfig *execdriver.ProcessConfig, pid
 		close(m.startSignal)
 	}
 
-	if err := m.container.ToDisk(); err != nil {
+	if err := m.container.toDiskLocking(); err != nil {
 		logrus.Errorf("Error saving container to disk: %v", err)
 	}
 }

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -9,7 +9,7 @@ func (daemon *Daemon) ContainerPause(name string) error {
 		return err
 	}
 
-	if err := container.Pause(); err != nil {
+	if err := container.pause(); err != nil {
 		return fmt.Errorf("Cannot pause container %s: %s", name, err)
 	}
 

--- a/daemon/rename.go
+++ b/daemon/rename.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 )
 
+// ContainerRename changes the name of a container, using the oldName
+// to find the container. An error is returned if newName is already
+// reserved.
 func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 	if oldName == "" || newName == "" {
 		return fmt.Errorf("usage: docker rename OLD_NAME NEW_NAME")
@@ -27,10 +30,10 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 	undo := func() {
 		container.Name = oldName
 		daemon.reserveName(container.ID, oldName)
-		daemon.containerGraph.Delete(newName)
+		daemon.containerGraphDB.Delete(newName)
 	}
 
-	if err := daemon.containerGraph.Delete(oldName); err != nil {
+	if err := daemon.containerGraphDB.Delete(oldName); err != nil {
 		undo()
 		return fmt.Errorf("Failed to delete container %q: %v", oldName, err)
 	}
@@ -40,6 +43,6 @@ func (daemon *Daemon) ContainerRename(oldName, newName string) error {
 		return err
 	}
 
-	container.LogEvent("rename")
+	container.logEvent("rename")
 	return nil
 }

--- a/daemon/resize.go
+++ b/daemon/resize.go
@@ -1,5 +1,7 @@
 package daemon
 
+// ContainerResize changes the size of the TTY of the process running
+// in the container with the given name to the given height and width.
 func (daemon *Daemon) ContainerResize(name string, height, width int) error {
 	container, err := daemon.Get(name)
 	if err != nil {
@@ -9,11 +11,14 @@ func (daemon *Daemon) ContainerResize(name string, height, width int) error {
 	return container.Resize(height, width)
 }
 
+// ContainerExecResize changes the size of the TTY of the process
+// running in the exec with the given name to the given height and
+// width.
 func (daemon *Daemon) ContainerExecResize(name string, height, width int) error {
-	execConfig, err := daemon.getExecConfig(name)
+	ExecConfig, err := daemon.getExecConfig(name)
 	if err != nil {
 		return err
 	}
 
-	return execConfig.Resize(height, width)
+	return ExecConfig.resize(height, width)
 }

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -2,6 +2,12 @@ package daemon
 
 import "fmt"
 
+// ContainerRestart stops and starts a container. It attempts to
+// gracefully stop the container within the given timeout, forcefully
+// stopping it if the timeout is exceeded. If given a negative
+// timeout, ContainerRestart will wait forever until a graceful
+// stop. Returns an error if the container cannot be found, or if
+// there is an underlying error at any stage of the restart.
 func (daemon *Daemon) ContainerRestart(name string, seconds int) error {
 	container, err := daemon.Get(name)
 	if err != nil {

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -7,13 +7,14 @@ import (
 	"github.com/docker/docker/runconfig"
 )
 
+// ContainerStart starts a container.
 func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConfig) error {
 	container, err := daemon.Get(name)
 	if err != nil {
 		return err
 	}
 
-	if container.IsPaused() {
+	if container.isPaused() {
 		return fmt.Errorf("Cannot start a paused container, try unpause instead.")
 	}
 

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -2,6 +2,12 @@ package daemon
 
 import "fmt"
 
+// ContainerStop looks for the given container and terminates it,
+// waiting the given number of seconds before forcefully killing the
+// container. If a negative number of seconds is given, ContainerStop
+// will wait for a graceful termination. An error is returned if the
+// container is not found, is already stopped, or if there is a
+// problem stopping the container.
 func (daemon *Daemon) ContainerStop(name string, seconds int) error {
 	container, err := daemon.Get(name)
 	if err != nil {

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -11,6 +11,11 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
+// ContainerTop lists the processes running inside of the given
+// container by calling ps with the given args, or with the flags
+// "-ef" if no args are given.  An error is returned if the container
+// is not found, or is not running, or if there are any problems
+// running ps, or parsing the output.
 func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.ContainerProcessList, error) {
 	if psArgs == "" {
 		psArgs = "-ef"
@@ -50,6 +55,7 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.Container
 		return nil, fmt.Errorf("Couldn't find PID field in ps output")
 	}
 
+	// loop through the output and extract the PID from each line
 	for _, line := range lines[1:] {
 		if len(line) == 0 {
 			continue
@@ -70,6 +76,6 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.Container
 			}
 		}
 	}
-	container.LogEvent("top")
+	container.logEvent("top")
 	return procList, nil
 }

--- a/daemon/top_windows.go
+++ b/daemon/top_windows.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
+// ContainerTop is not supported on Windows and returns an error.
 func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.ContainerProcessList, error) {
 	return nil, fmt.Errorf("Top is not supported on Windows")
 }

--- a/daemon/unpause.go
+++ b/daemon/unpause.go
@@ -9,7 +9,7 @@ func (daemon *Daemon) ContainerUnpause(name string) error {
 		return err
 	}
 
-	if err := container.Unpause(); err != nil {
+	if err := container.unpause(); err != nil {
 		return fmt.Errorf("Cannot unpause container %s: %s", name, err)
 	}
 

--- a/daemon/volumes_unit_test.go
+++ b/daemon/volumes_unit_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestParseVolumeFrom(t *testing.T) {
 	cases := []struct {
 		spec    string
-		expId   string
+		expID   string
 		expMode string
 		fail    bool
 	}{
@@ -25,8 +25,8 @@ func TestParseVolumeFrom(t *testing.T) {
 			continue
 		}
 
-		if id != c.expId {
-			t.Fatalf("Expected id %s, was %s, for spec %s\n", c.expId, id, c.spec)
+		if id != c.expID {
+			t.Fatalf("Expected id %s, was %s, for spec %s\n", c.expID, id, c.spec)
 		}
 		if mode != c.expMode {
 			t.Fatalf("Expected mode %s, was %s for spec %s\n", c.expMode, mode, c.spec)

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -249,7 +249,7 @@ func (daemon *Daemon) verifyVolumesInfo(container *Container) error {
 			}
 		}
 
-		return container.ToDisk()
+		return container.toDiskLocking()
 	}
 
 	return nil

--- a/daemon/wait.go
+++ b/daemon/wait.go
@@ -2,6 +2,11 @@ package daemon
 
 import "time"
 
+// ContainerWait stops processing until the given container is
+// stopped. If the container is not found, an error is returned. On a
+// successful stop, the exit code of the container is returned. On a
+// timeout, an error is returned. If you want to wait forever, supply
+// a negative duration for the timeout.
 func (daemon *Daemon) ContainerWait(name string, timeout time.Duration) (int, error) {
 	container, err := daemon.Get(name)
 	if err != nil {

--- a/hack/make/validate-lint
+++ b/hack/make/validate-lint
@@ -18,6 +18,7 @@ packages=(
 	builder/parser
 	builder/parser/dumper
 	cliconfig
+	daemon
 	daemon/events
 	daemon/execdriver
 	daemon/execdriver/execdrivers


### PR DESCRIPTION
~~One linter advice yet:
`daemon/inspect.go:100:56: exported method ContainerExecInspect returns unexported type *daemon.execConfig, which can be annoying to use`
Suggestions for addressing it?~~

There are a surprising (to me) amount of things that became non-exported.

There some comments with "perhaps" in them that  I was not sure if I should take action on.

There are some renames with *Locking because all the functions did was add locking around an existing unexported function.

Some of the comments need work as to the exact details.

A partial history of individual commits can be found in my forked repo in the "split-commits" branch.

for #14756
