### PR TITLE
Windows: Fix docker/master daemon compile again

### DIFF
--- a/graph/graph_windows.go
+++ b/graph/graph_windows.go
@@ -120,7 +120,7 @@ func (graph *Graph) storeImage(img *image.Image, layerData archive.ArchiveReader
 		}
 	}
 
-	if err := graph.saveSize(root, int(img.Size)); err != nil {
+	if err := graph.saveSize(root, img.Size); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@icecrime Fixes up Windows daemon compilation again. Commit 1f61084d83aea37b212468aaa975020094b7f7c9 broke it.
