### PR TITLE
Check sysinfo for Cpuset cpu.shares and blkio

### DIFF
--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -166,6 +166,11 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 			return warnings, fmt.Errorf("Invalid value: %v, valid memory swappiness range is 0-100.", swappiness)
 		}
 	}
+	if hostConfig.CPUShares > 0 && !daemon.SystemConfig().CPUShares {
+		warnings = append(warnings, "Your kernel does not support CPU shares. Shares discarded.")
+		logrus.Warnf("Your kernel does not support CPU shares. Shares discarded.")
+		hostConfig.CPUShares = 0
+	}
 	if hostConfig.CPUPeriod > 0 && !daemon.SystemConfig().CPUCfsPeriod {
 		warnings = append(warnings, "Your kernel does not support CPU cfs period. Period discarded.")
 		logrus.Warnf("Your kernel does not support CPU cfs period. Period discarded.")
@@ -175,6 +180,17 @@ func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostC
 		warnings = append(warnings, "Your kernel does not support CPU cfs quota. Quota discarded.")
 		logrus.Warnf("Your kernel does not support CPU cfs quota. Quota discarded.")
 		hostConfig.CPUQuota = 0
+	}
+	if (hostConfig.CpusetCpus != "" || hostConfig.CpusetMems != "") && !daemon.SystemConfig().Cpuset {
+		warnings = append(warnings, "Your kernel does not support cpuset. Cpuset discarded.")
+		logrus.Warnf("Your kernel does not support cpuset. Cpuset discarded.")
+		hostConfig.CpusetCpus = ""
+		hostConfig.CpusetMems = ""
+	}
+	if hostConfig.BlkioWeight > 0 && !daemon.SystemConfig().BlkioWeight {
+		warnings = append(warnings, "Your kernel does not support Block I/O weight. Weight discarded.")
+		logrus.Warnf("Your kernel does not support Block I/O weight. Weight discarded.")
+		hostConfig.BlkioWeight = 0
 	}
 	if hostConfig.BlkioWeight > 0 && (hostConfig.BlkioWeight < 10 || hostConfig.BlkioWeight > 1000) {
 		return warnings, fmt.Errorf("Range of blkio weight is from 10 to 1000.")

--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -8,6 +8,8 @@ type SysInfo struct {
 
 	*cgroupMemInfo
 	*cgroupCPUInfo
+	*cgroupBlkioInfo
+	*cgroupCpusetInfo
 
 	// Whether IPv4 forwarding is supported or not, if this was disabled, networking will not work
 	IPv4ForwardingDisabled bool
@@ -37,9 +39,22 @@ type cgroupMemInfo struct {
 }
 
 type cgroupCPUInfo struct {
+	// Whether CPU shares is supported or not
+	CPUShares bool
+
 	// Whether CPU CFS(Completely Fair Scheduler) period is supported or not
 	CPUCfsPeriod bool
 
 	// Whether CPU CFS(Completely Fair Scheduler) quota is supported or not
 	CPUCfsQuota bool
+}
+
+type cgroupBlkioInfo struct {
+	// Whether Block IO weight is supported or not
+	BlkioWeight bool
+}
+
+type cgroupCpusetInfo struct {
+	// Whether Cpuset is supported or not
+	Cpuset bool
 }


### PR DESCRIPTION
Carried: #14015

If kernel is compiled with CONFIG_FAIR_GROUP_SCHED disabled cpu.shares
doesn't exist.
If kernel is compiled with CONFIG_CFQ_GROUP_IOSCHED disabled blkio.weight
doesn't exist.
If kernel is compiled with CONFIG_CPUSETS disabled cpuset won't be
supported.

We need to handle these conditions by checking sysinfo and verifying them.

Signed-off-by: Zefan Li lizefan@huawei.com
Signed-off-by: Qiang Huang h.huangqiang@huawei.com
