### PR TITLE
Boot2Docker Cleanup 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,8 +83,8 @@ own.
 	container with this image.
 
 	The container exposes port 8000 on the localhost so that you can connect and
-	see your changes. If you are running Boot2Docker, use the `boot2docker ip`
-	to get the address of your server.
+	see your changes. If you use Docker Machine, the `docker-machine ip
+	<machine-name>` command gives you the address of your server.
 
 6.  Check your writing for style and mechanical errors.
 
@@ -154,18 +154,20 @@ update the root docs pages by running
 
      	$ make AWS_S3_BUCKET=dowideit-docs BUILD_ROOT=yes docs-release
 
-### Errors publishing using Boot2Docker
+### Errors publishing using a Docker Machine VM
 
-Sometimes, in a Boot2Docker environment, the publishing procedure returns this
+Sometimes, in a Windows or Mac environment, the publishing procedure returns this
 error:
 
 	Post http:///var/run/docker.sock/build?rm=1&t=docker-docs%3Apost-1.2.0-docs_update-2:
 	dial unix /var/run/docker.sock: no such file or directory.
 
-If this happens, set the Docker host. Run the following command to set the
+If this happens, set the Docker host. Run the following command to get the
 variables in your shell:
 
-		$ eval "$(boot2docker shellinit)"
+		docker-machine env <machine-name>
+		
+Then, set your environment accordingly.
 
 ## Cherry-picking documentation changes to update an existing release.
 

--- a/docs/articles/basics.md
+++ b/docs/articles/basics.md
@@ -47,10 +47,6 @@ image cache.
 > characters of the full image ID - which can be found using
 > `docker inspect` or `docker images --no-trunc=true`.
 
-> **Note:** if you are using a remote Docker daemon, such as Boot2Docker, 
-> then _do not_ type the `sudo` before the `docker` commands shown in the
-> documentation's examples.
-
 ## Running an interactive shell
 
 To run an interactive shell in the Ubuntu image:

--- a/docs/articles/https.md
+++ b/docs/articles/https.md
@@ -58,7 +58,7 @@ First generate CA private and public keys:
     State or Province Name (full name) [Some-State]:Queensland
     Locality Name (eg, city) []:Brisbane
     Organization Name (eg, company) [Internet Widgits Pty Ltd]:Docker Inc
-    Organizational Unit Name (eg, section) []:Boot2Docker
+    Organizational Unit Name (eg, section) []:Sales
     Common Name (e.g. server FQDN or YOUR name) []:$HOST
     Email Address []:Sven@home.org.au
 

--- a/docs/installation/windows.md
+++ b/docs/installation/windows.md
@@ -311,40 +311,36 @@ installer](https://www.docker.com/toolbox).
 
 ## Container port redirection
 
-If you are curious, the username for the Docker default user is `docker`
-and the password is `tcuser`.
+If you are curious, the username for the Docker default user is `docker` and the
+password is `tcuser`. The latest version of `docker-machine` sets up a host only
+network adaptor which provides access to the container's ports.
 
-The latest version of `boot2docker` sets up a host only network adaptor which
-provides access to the container's ports.
+If you run a container with a published port:
 
-If you run a container with an exposed port:
+    $ docker run --rm -i -t -p 80:80 nginx
 
-    docker run --rm -i -t -p 80:80 nginx
+Then you should be able to access that nginx server using the IP address
+reported to you using:
 
-Then you should be able to access that nginx server using the IP address reported
-to you using:
+    $ docker-machine ip
 
-    boot2docker ip
-
-Typically, it is 192.168.59.103, but it could get changed by VirtualBox's DHCP
-implementation.
-
-For further information or to report issues, please see the [Boot2Docker site](http://boot2docker.io)
+Typically, the IP is 192.168.59.103, but it could get changed by VirtualBox's
+DHCP implementation.
 
 ## Login with PUTTY instead of using the CMD
 
-Boot2Docker generates and uses the public/private key pair in your `%USERPROFILE%\.ssh`
-directory so to log in you need to use the private key from this same directory.
-
-The private key needs to be converted into the format PuTTY uses.
-
-You can do this with
+Docker Machine generates and uses the public/private key pair in your
+`%USERPROFILE%\.ssh` directory so to log in you need to use the private key from
+this same directory. The private key needs to be converted into the format PuTTY
+uses. You can do this with
 [puttygen](http://www.chiark.greenend.org.uk/~sgtatham/putty/download.html):
 
-- Open `puttygen.exe` and load ("File"->"Load" menu) the private key from
+1. Open `puttygen.exe` and load ("File"->"Load" menu) the private key from
   `%USERPROFILE%\.ssh\id_boot2docker`
-- then click: "Save Private Key".
-- Then use the saved file to login with PuTTY using `docker@127.0.0.1:2022`.
+
+2. Click "Save Private Key".
+
+3.  Use the saved file to login with PuTTY using `docker@127.0.0.1:2022`.
 
 ## Uninstallation
 

--- a/docs/misc/faq.md
+++ b/docs/misc/faq.md
@@ -33,7 +33,7 @@ Docker currently runs only on Linux, but you can use VirtualBox to run Docker in
 a virtual machine on your box, and get the best of both worlds. Check out the
 [*Mac OS X*](/installation/mac/) and [*Microsoft
 Windows*](/installation/windows/) installation guides. The small Linux
-distribution boot2docker can be run inside virtual machines on these two
+distribution Docker Machine can be run inside virtual machines on these two
 operating systems.
 
 >**Note:** if you are using a remote Docker daemon on a VM through Docker

--- a/docs/project/set-up-dev-env.md
+++ b/docs/project/set-up-dev-env.md
@@ -29,7 +29,7 @@ you continue working with your fork on this branch.
 
 ##  Clean your host of Docker artifacts
 
-Docker developers run the latest stable release of the Docker software (with Boot2Docker if their machine is Mac OS X). They clean their local
+Docker developers run the latest stable release of the Docker software (with Docker Machine if their machine is Mac OS X). They clean their local
 hosts of unnecessary Docker artifacts such as stopped containers or unused
 images. Cleaning unnecessary artifacts isn't strictly necessary, but it is
 good practice, so it is included here.

--- a/docs/project/set-up-git.md
+++ b/docs/project/set-up-git.md
@@ -57,8 +57,8 @@ target="_blank">docker/docker repository</a>.
 
         $ cd ~
         
-  In Windows, you'll work in your Boot2Docker window instead of Powershell or
-  a `cmd` window.
+    In Windows, you'll work in your Docker Quickstart Terminal window instead of
+    Powershell or a `cmd` window.
 
 6. Create a `repos` directory.
 

--- a/docs/project/test-and-docs.md
+++ b/docs/project/test-and-docs.md
@@ -258,9 +258,9 @@ can browse the docs.
 
 4. Enter the URL in your browser.
 
-    If you are running Boot2Docker, replace the default localhost address
+    If you are using Docker Machine, replace the default localhost address
     (0.0.0.0) with your DOCKERHOST value. You can get this value at any time by
-    entering `boot2docker ip` at the command line.
+    entering `docker-machine ip <machine-name>` at the command line.
 
 5. Once in the documentation, look for the red notice to verify you are seeing the correct build.
 

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -10,10 +10,6 @@ parent = "smn_cli"
 
 # Using the command line
 
-> **Note:** If you are using a remote Docker daemon, such as Boot2Docker,
-> then _do not_ type the `sudo` before the `docker` commands shown in the
-> documentation's examples.
-
 To list available commands, either run `docker` with no parameters
 or execute `docker help`:
 

--- a/docs/userguide/dockerimages.md
+++ b/docs/userguide/dockerimages.md
@@ -256,7 +256,7 @@ Let's create a directory and a `Dockerfile` first.
     $ cd sinatra
     $ touch Dockerfile
 
-If you are using Boot2Docker on Windows, you may access your host
+If you are using Docker Machine on Windows, you may access your host
 directory by `cd` to `/c/Users/your_user_name`.
 
 Each instruction creates a new layer of the image. Let's look at a simple

--- a/docs/userguide/dockerizing.md
+++ b/docs/userguide/dockerizing.md
@@ -15,9 +15,10 @@ parent = "smn_applied"
 Docker allows you to run applications inside containers. Running an
 application inside a container takes a single command: `docker run`.
 
-> **Note:** if you are using a remote Docker daemon, such as Boot2Docker, 
-> then _do not_ type the `sudo` before the `docker` commands shown in the
-> documentation's examples.
+>**Note**: Depending on your Docker system configuration, you may be required to
+>preface each `docker` command on this page with `sudo`. To avoid this behavior,
+>your system administrator can create a Unix group called `docker` and add users
+>to it. 
 
 ## Hello world
 

--- a/docs/userguide/dockervolumes.md
+++ b/docs/userguide/dockervolumes.md
@@ -90,13 +90,13 @@ You will notice in the above 'Volumes' is specifying the location on the host an
 In addition to creating a volume using the `-v` flag you can also mount a
 directory from your Docker daemon's host into a container.
 
-> **Note:**
-> If you are using Boot2Docker, your Docker daemon only has limited access to
-> your OS X/Windows filesystem. Boot2Docker tries to auto-share your `/Users`
-> (OS X) or `C:\Users` (Windows) directory - and so you can mount files or directories
-> using `docker run -v /Users/<path>:/<container path> ...` (OS X) or
-> `docker run -v /c/Users/<path>:/<container path ...` (Windows). All other paths
-> come from the Boot2Docker virtual machine's filesystem.
+>**Note**: If you are using Docker Machine on Mac or Windows, your Docker daemon
+>only has limited access to your OS X/Windows filesystem. Docker Machine tries
+>to auto-share your `/Users` (OS X) or `C:\Users` (Windows) directory - and so
+>you can mount files or directories using `docker run -v
+>/Users/<path>:/<container path> ...` (OS X) or `docker run -v
+>/c/Users/<path>:/<container path ...` (Windows). All other paths come from your
+>virtual machine's filesystem.
 
     $ docker run -d -P --name web -v /src/webapp:/opt/webapp training/webapp python app.py
 


### PR DESCRIPTION
- Remove references to sudo in basics.md; see sudo instructions top of file
- Removing references to Boot2Docker replacing with Docker Machine
- Removing sudo warnings in instances where appropriate (no sudo in file)

Signed-off-by: Mary Anthony mary@docker.com
