### PR TITLE
add documentation clarifying behavior of VOLUME instruction

### DIFF
--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -913,6 +913,10 @@ create a new mount point at `/myvol` and copy the  `greeting` file
 into the newly created volume.
 
 > **Note**:
+> If any build steps change the data within the volume after it has been
+> declared, those changes will be discarded.
+
+> **Note**:
 > The list is parsed as a JSON array, which means that
 > you must use double-quotes (") around words not single-quotes (').
 


### PR DESCRIPTION
This clarifies the behavior of the `VOLUME` instruction within a build, noting that further changes will be discarded.

This seems to come as a surprise to many users, and is the result of frequent issues: #15333 #14385 #13117 #12051 #14122
