### PR TITLE
do not install docker-engine policy in debs

### DIFF
--- a/hack/make/.build-deb/docker-engine.install
+++ b/hack/make/.build-deb/docker-engine.install
@@ -9,4 +9,4 @@ contrib/init/systemd/docker.socket lib/systemd/system/
 contrib/mk* usr/share/docker-engine/contrib/
 contrib/nuke-graph-directory.sh usr/share/docker-engine/contrib/
 contrib/syntax/nano/Dockerfile.nanorc usr/share/nano/
-contrib/apparmor/* etc/apparmor.d/
+#contrib/apparmor/* etc/apparmor.d/

--- a/hack/make/.build-deb/rules
+++ b/hack/make/.build-deb/rules
@@ -34,7 +34,6 @@ override_dh_installudev:
 
 override_dh_install:
 	dh_install
-	dh_apparmor --profile-name=docker-engine -pdocker-engine
 
 %:
 	dh $@ --with=bash-completion $(shell command -v dh_systemd_enable > /dev/null 2>&1 && echo --with=systemd)


### PR DESCRIPTION
this is for release, this is a new policy and the conventions used in it are not compatible with the apparmor version in ubuntu 12.04, there could be other things broken with it as well

i think it is too risky for the release... but we can add it back after, the docker-default policy in the binary is still there so I think this is fine for the time being.

fixes https://github.com/docker/docker/issues/15340
