### PR TITLE
Fail fail when the ps format template is invalid.

### DIFF
--- a/api/client/ps/custom.go
+++ b/api/client/ps/custom.go
@@ -170,9 +170,11 @@ func customFormat(ctx Context, containers []types.Container) {
 		format += "\t{{.Size}}"
 	}
 
-	tmpl, err := template.New("ps template").Parse(format)
+	tmpl, err := template.New("").Parse(format)
 	if err != nil {
-		buffer.WriteString(fmt.Sprintf("Invalid `docker ps` format: %v\n", err))
+		buffer.WriteString(fmt.Sprintf("Template parsing error: %v\n", err))
+		buffer.WriteTo(ctx.Output)
+		return
 	}
 
 	for _, container := range containers {
@@ -181,8 +183,9 @@ func customFormat(ctx Context, containers []types.Container) {
 			c:     container,
 		}
 		if err := tmpl.Execute(buffer, containerCtx); err != nil {
-			buffer = bytes.NewBufferString(fmt.Sprintf("Invalid `docker ps` format: %v\n", err))
-			break
+			buffer = bytes.NewBufferString(fmt.Sprintf("Template parsing error: %v\n", err))
+			buffer.WriteTo(ctx.Output)
+			return
 		}
 		if table && len(header) == 0 {
 			header = containerCtx.fullHeader()

--- a/api/client/ps/custom_test.go
+++ b/api/client/ps/custom_test.go
@@ -1,6 +1,7 @@
 package ps
 
 import (
+	"bytes"
 	"reflect"
 	"strings"
 	"testing"
@@ -10,7 +11,7 @@ import (
 	"github.com/docker/docker/pkg/stringid"
 )
 
-func TestContainerContextID(t *testing.T) {
+func TestContainerPsContext(t *testing.T) {
 	containerID := stringid.GenerateRandomID()
 	unix := time.Now().Unix()
 
@@ -84,5 +85,18 @@ func TestContainerContextID(t *testing.T) {
 	if h != "SWARM ID\tNODE NAME" {
 		t.Fatalf("Expected %s, was %s\n", "SWARM ID\tNODE NAME", h)
 
+	}
+}
+
+func TestContainerPsFormatError(t *testing.T) {
+	out := bytes.NewBufferString("")
+	ctx := Context{
+		Format: "{{InvalidFunction}}",
+		Output: out,
+	}
+
+	customFormat(ctx, make([]types.Container, 0))
+	if out.String() != "Template parsing error: template: :1: function \"InvalidFunction\" not defined\n" {
+		t.Fatalf("Expected format error, got `%v`\n", out.String())
 	}
 }


### PR DESCRIPTION
Fixes an error continuing execution when the parsing fails.

```
root@gfs-client-1:~# docker ps --format "{{ID}}"
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x18 pc=0x8eaa32]

goroutine 1 [running]:
text/template.errRecover(0xc2081453c8)
    /usr/local/go/src/text/template/exec.go:100 +0xbc
text/template.(*Template).Execute(0x0, 0x7f24c55c4190, 0xc2080c89a0, 0xf248a0, 0xc2081520c0, 0x0, 0x0)
    /usr/local/go/src/text/template/exec.go:137 +0x242
github.com/docker/docker/api/client/ps.customFormat(0x7f24c55c1218, 0xc208038008, 0x7fff2a9828fb, 0x6, 0x10000, 0xc2080f2c80, 0x1, 0x4)
    /usr/src/docker/.gopath/src/github.com/docker/docker/api/client/ps/custom.go:183 +0x6ae
github.com/docker/docker/api/client/ps.Format(0x7f24c55c1218, 0xc208038008, 0x7fff2a9828fb, 0x6, 0x10000, 0xc2080f2c80, 0x1, 0x4)
    /usr/src/docker/.gopath/src/github.com/docker/docker/api/client/ps/formatter.go:32 +0x170
github.com/docker/docker/api/client.(*DockerCli).CmdPs(0xc208152000, 0xc20800a020, 0x2, 0x2, 0x0, 0x0)
    /usr/src/docker/.gopath/src/github.com/docker/docker/api/client/ps.go:113 +0x1859
reflect.callMethod(0xc208154180, 0xc208145ce0)
    /usr/local/go/src/reflect/value.go:605 +0x179
reflect.methodValueCall(0xc20800a020, 0x2, 0x2, 0x1, 0xc208154180, 0x0, 0x0, 0xc208154180, 0x0, 0x45128f, ...)
    /usr/local/go/src/reflect/asm_amd64.s:29 +0x36
github.com/docker/docker/cli.(*Cli).Run(0xc208154000, 0xc20800a010, 0x3, 0x3, 0x0, 0x0)
    /usr/src/docker/.gopath/src/github.com/docker/docker/cli/cli.go:89 +0x38e
main.main()
    /usr/src/docker/docker/docker.go:69 +0x428
```

Signed-off-by: David Calavera david.calavera@gmail.com
