### PR TITLE
[graph] Use a pipe for downloads to write progress

### DIFF
--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -446,7 +446,7 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredManifest(c *check.C) {
 	imageReference := fmt.Sprintf("%s@%s", repoName, manifestDigest)
 	out, exitStatus, _ := dockerCmdWithError("pull", imageReference)
 	if exitStatus == 0 {
-		c.Fatalf("expected a zero exit status but got %d: %s", exitStatus, out)
+		c.Fatalf("expected a non-zero exit status but got %d: %s", exitStatus, out)
 	}
 
 	expectedErrorMsg := fmt.Sprintf("image verification failed for digest %s", manifestDigest)


### PR DESCRIPTION
The process of pulling an image spawns a new goroutine for each layer in the
image manifest. If any of these downloads fail we would stop everything and
return the error, even though other goroutines would still be running and
writing output through a progress reader which is attached to an http response
writer. Since the request handler had already returned from the first error,
the http server panics when one of these download goroutines makes a write to
the response writer buffer.

This patch prevents this crash in the daemon http server by waiting for all of
the download goroutines to complete, even if one of them fails. Only then does
it return, terminating the request handler.
