### PR TITLE
Fix silent failure in RedHat sysvinit script

### DIFF
--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -41,7 +41,14 @@ prestart() {
 }
 
 start() {
-    [ -x $exec ] || exit 5
+    if [ ! -x $exec ]; then
+      if [ ! -e $exec ]; then
+        echo "Docker executable $exec not found"
+      else
+        echo "You do not have permission to execute the Docker executable $exec"
+      fi	      
+      exit 5
+    fi
 
     check_for_cleanup
 


### PR DESCRIPTION
The docker script in contrib/init/sysvinit-redhat will fail silently on
a start if Docker is not installed in the default /usr/bin/ location.
While a non-zero exit code is returned the user will receive no visible
indication (i.e. error message) as to why Docker was not started.

This commit changes the logic so that in the case that the docker
executable is not found in the expected location or the user does not
have execute permissions on the executable appropriate error messages
are now shown to the user as well as exiting with a non-zero exit code

Signed-off-by: Rob Vesse rvesse@dotnetrdf.org
