### PR TITLE
[docs] Add instruction to start docker on Ubuntu

### DIFF
--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -127,7 +127,7 @@ install Docker using the following:
     >
     >       $ wget -qO- https://get.docker.com/gpg | sudo apt-key add -
 
-4. Start `docker`.
+4. Start the `docker` daemon.
 
         $ sudo service docker start
 

--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -127,7 +127,11 @@ install Docker using the following:
     >
     >       $ wget -qO- https://get.docker.com/gpg | sudo apt-key add -
 
-4. Verify `docker` is installed correctly.
+4. Start `docker`.
+
+        $ sudo service docker start
+
+5. Verify `docker` is installed correctly.
 
         $ sudo docker run hello-world
 


### PR DESCRIPTION
I just tried the installation but docker didn't start automatically. So I had to execute the newly added command in order to get the hello-world verification running.
