### PR TITLE
Adapt container settings after verify platform container settings.

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -16,8 +16,8 @@ func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hos
 		return "", nil, fmt.Errorf("Config cannot be empty in order to create a container")
 	}
 
-	daemon.adaptContainerSettings(hostConfig, adjustCPUShares)
 	warnings, err := daemon.verifyContainerSettings(hostConfig, config)
+	daemon.adaptContainerSettings(hostConfig, adjustCPUShares)
 	if err != nil {
 		return "", warnings, err
 	}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
we should adapt container settings after verify platform container settings.
Because if on a no memory cgroup system,
I run a command line
`docker run -ti -m 1000M busybox`
`daemon.adaptContainerSettings` (https://github.com/docker/docker/blob/master/daemon/daemon_unix.go#L144)
will set `hostConfig.MemorySwap` to `0`
and then call `daemon.verifyContainerSettings`
https://github.com/docker/docker/blob/master/daemon/daemon_unix.go#L162 will set 
`hostConfig.Memory` to `0` since it's on a no memory cgroup,
then https://github.com/docker/docker/blob/master/daemon/daemon_unix.go#L172
will return an error since `hostConfig.Memory=0` and `hostConfig.MemorySwap > 0`
This is no a desired behavior.
