### PR TITLE
Vendoring libnetwork bd3eecc96f3c05a4acef1bedcf74397bc6850d22

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -22,7 +22,7 @@ clone git golang.org/x/net 3cffabab72adf04f8e3b01c5baf775361837b5fe https://gith
 clone hg code.google.com/p/gosqlite 74691fb6f837
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork 78fc31ddc425fb379765c6b7ab5b96748bd8fc08
+clone git github.com/docker/libnetwork bd3eecc96f3c05a4acef1bedcf74397bc6850d22
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/endpoint.go
+++ b/vendor/src/github.com/docker/libnetwork/endpoint.go
@@ -415,7 +415,8 @@ func (ep *endpoint) Join(containerID string, options ...EndpointOption) error {
 	}
 	defer func() {
 		if err != nil {
-			if err = driver.Leave(nid, epid); err != nil {
+			// Do not alter global err variable, it's needed by the previous defer
+			if err := driver.Leave(nid, epid); err != nil {
 				log.Warnf("driver leave failed while rolling back join: %v", err)
 			}
 		}


### PR DESCRIPTION
- Fix a bug in the cleanup logic in Endpoint.Join() error path
  (Bug reported in this [comment](https://github.com/docker/docker/issues/15341#issuecomment-128175359))

Signed-off-by: Alessandro Boch aboch@docker.com
