### PR TITLE
registry: Do not push to mirrors

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -76,7 +76,7 @@ func (s *TagStore) Pull(image string, tag string, imagePullConfig *ImagePullConf
 		return err
 	}
 
-	endpoints, err := s.registryService.LookupEndpoints(repoInfo.CanonicalName)
+	endpoints, err := s.registryService.LookupPullEndpoints(repoInfo.CanonicalName)
 	if err != nil {
 		return err
 	}

--- a/graph/push.go
+++ b/graph/push.go
@@ -77,7 +77,7 @@ func (s *TagStore) Push(localName string, imagePushConfig *ImagePushConfig) erro
 		return err
 	}
 
-	endpoints, err := s.registryService.LookupEndpoints(repoInfo.CanonicalName)
+	endpoints, err := s.registryService.LookupPushEndpoints(repoInfo.CanonicalName)
 	if err != nil {
 		return err
 	}

--- a/registry/service.go
+++ b/registry/service.go
@@ -109,27 +109,40 @@ func (s *Service) tlsConfigForMirror(mirror string) (*tls.Config, error) {
 	return s.TLSConfig(mirrorURL.Host)
 }
 
-// LookupEndpoints creates an list of endpoints to try, in order of preference.
+// LookupPullEndpoints creates an list of endpoints to try to pull from, in order of preference.
 // It gives preference to v2 endpoints over v1, mirrors over the actual
 // registry, and HTTPS over plain HTTP.
-func (s *Service) LookupEndpoints(repoName string) (endpoints []APIEndpoint, err error) {
+func (s *Service) LookupPullEndpoints(repoName string) (endpoints []APIEndpoint, err error) {
+	return s.lookupEndpoints(repoName, false)
+}
+
+// LookupPushEndpoints creates an list of endpoints to try to push to, in order of preference.
+// It gives preference to v2 endpoints over v1, and HTTPS over plain HTTP.
+// Mirrors are not included.
+func (s *Service) LookupPushEndpoints(repoName string) (endpoints []APIEndpoint, err error) {
+	return s.lookupEndpoints(repoName, true)
+}
+
+func (s *Service) lookupEndpoints(repoName string, isPush bool) (endpoints []APIEndpoint, err error) {
 	var cfg = tlsconfig.ServerDefault
 	tlsConfig := &cfg
 	if strings.HasPrefix(repoName, DefaultNamespace+"/") {
-		// v2 mirrors
-		for _, mirror := range s.Config.Mirrors {
-			mirrorTLSConfig, err := s.tlsConfigForMirror(mirror)
-			if err != nil {
-				return nil, err
+		if !isPush {
+			// v2 mirrors for pull only
+			for _, mirror := range s.Config.Mirrors {
+				mirrorTLSConfig, err := s.tlsConfigForMirror(mirror)
+				if err != nil {
+					return nil, err
+				}
+				endpoints = append(endpoints, APIEndpoint{
+					URL: mirror,
+					// guess mirrors are v2
+					Version:      APIVersion2,
+					Mirror:       true,
+					TrimHostname: true,
+					TLSConfig:    mirrorTLSConfig,
+				})
 			}
-			endpoints = append(endpoints, APIEndpoint{
-				URL: mirror,
-				// guess mirrors are v2
-				Version:      APIVersion2,
-				Mirror:       true,
-				TrimHostname: true,
-				TLSConfig:    mirrorTLSConfig,
-			})
 		}
 		// v2 registry
 		endpoints = append(endpoints, APIEndpoint{


### PR DESCRIPTION
This patch splits LookupEndpoints into LookupPullEndpoints and
LookupPushEndpoints so that mirrors added with --registry-mirror are
skipped in the list returned by LookupPushEndpoints.

Fixes https://github.com/docker/distribution/issues/823

EDIT: the bug only affected v2 mirrors.

Signed-off-by: Tibor Vass tibor@docker.com
