### PR TITLE
Remove pointers from the SysInfo struct.

### DIFF
--- a/pkg/sysinfo/sysinfo.go
+++ b/pkg/sysinfo/sysinfo.go
@@ -6,10 +6,10 @@ type SysInfo struct {
 	// Whether the kernel supports AppArmor or not
 	AppArmor bool
 
-	*cgroupMemInfo
-	*cgroupCPUInfo
-	*cgroupBlkioInfo
-	*cgroupCpusetInfo
+	cgroupMemInfo
+	cgroupCPUInfo
+	cgroupBlkioInfo
+	cgroupCpusetInfo
 
 	// Whether IPv4 forwarding is supported or not, if this was disabled, networking will not work
 	IPv4ForwardingDisabled bool

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -33,89 +33,96 @@ func New(quiet bool) *SysInfo {
 	return sysInfo
 }
 
-func checkCgroupMem(quiet bool) *cgroupMemInfo {
-	info := &cgroupMemInfo{}
+// checkCgroupMem reads the memory information from the memory cgroup mount point.
+func checkCgroupMem(quiet bool) cgroupMemInfo {
 	mountPoint, err := cgroups.FindCgroupMountpoint("memory")
 	if err != nil {
 		if !quiet {
 			logrus.Warnf("Your kernel does not support cgroup memory limit: %v", err)
 		}
-		return info
+		return cgroupMemInfo{}
 	}
-	info.MemoryLimit = true
 
-	info.SwapLimit = cgroupEnabled(mountPoint, "memory.memsw.limit_in_bytes")
-	if !quiet && !info.SwapLimit {
+	swapLimit := cgroupEnabled(mountPoint, "memory.memsw.limit_in_bytes")
+	if !quiet && !swapLimit {
 		logrus.Warn("Your kernel does not support swap memory limit.")
 	}
-	info.OomKillDisable = cgroupEnabled(mountPoint, "memory.oom_control")
-	if !quiet && !info.OomKillDisable {
+	oomKillDisable := cgroupEnabled(mountPoint, "memory.oom_control")
+	if !quiet && !oomKillDisable {
 		logrus.Warnf("Your kernel does not support oom control.")
 	}
-	info.MemorySwappiness = cgroupEnabled(mountPoint, "memory.swappiness")
-	if !quiet && !info.MemorySwappiness {
+	memorySwappiness := cgroupEnabled(mountPoint, "memory.swappiness")
+	if !quiet && !memorySwappiness {
 		logrus.Warnf("Your kernel does not support memory swappiness.")
 	}
 
-	return info
+	return cgroupMemInfo{
+		MemoryLimit:      true,
+		SwapLimit:        swapLimit,
+		OomKillDisable:   oomKillDisable,
+		MemorySwappiness: memorySwappiness,
+	}
 }
 
-func checkCgroupCPU(quiet bool) *cgroupCPUInfo {
-	info := &cgroupCPUInfo{}
+// checkCgroupCPU reads the cpu information from the cpu cgroup mount point.
+func checkCgroupCPU(quiet bool) cgroupCPUInfo {
 	mountPoint, err := cgroups.FindCgroupMountpoint("cpu")
 	if err != nil {
 		if !quiet {
 			logrus.Warn(err)
 		}
-		return info
+		return cgroupCPUInfo{}
 	}
 
-	info.CPUShares = cgroupEnabled(mountPoint, "cpu.shares")
-	if !quiet && !info.CPUShares {
+	cpuShares := cgroupEnabled(mountPoint, "cpu.shares")
+	if !quiet && !cpuShares {
 		logrus.Warn("Your kernel does not support cgroup cpu shares")
 	}
 
-	info.CPUCfsPeriod = cgroupEnabled(mountPoint, "cpu.cfs_period_us")
-	if !quiet && !info.CPUCfsPeriod {
+	cpuCfsPeriod := cgroupEnabled(mountPoint, "cpu.cfs_period_us")
+	if !quiet && !cpuCfsPeriod {
 		logrus.Warn("Your kernel does not support cgroup cfs period")
 	}
 
-	info.CPUCfsQuota = cgroupEnabled(mountPoint, "cpu.cfs_quota_us")
-	if !quiet && !info.CPUCfsQuota {
+	cpuCfsQuota := cgroupEnabled(mountPoint, "cpu.cfs_quota_us")
+	if !quiet && !cpuCfsQuota {
 		logrus.Warn("Your kernel does not support cgroup cfs quotas")
 	}
-	return info
+	return cgroupCPUInfo{
+		CPUShares:    cpuShares,
+		CPUCfsPeriod: cpuCfsPeriod,
+		CPUCfsQuota:  cpuCfsQuota,
+	}
 }
 
-func checkCgroupBlkioInfo(quiet bool) *cgroupBlkioInfo {
-	info := &cgroupBlkioInfo{}
+// checkCgroupBlkioInfo reads the blkio information from the blkio cgroup mount point.
+func checkCgroupBlkioInfo(quiet bool) cgroupBlkioInfo {
 	mountPoint, err := cgroups.FindCgroupMountpoint("blkio")
 	if err != nil {
 		if !quiet {
 			logrus.Warn(err)
 		}
-		return info
+		return cgroupBlkioInfo{}
 	}
 
-	info.BlkioWeight = cgroupEnabled(mountPoint, "blkio.weight")
-	if !quiet && !info.BlkioWeight {
+	w := cgroupEnabled(mountPoint, "blkio.weight")
+	if !quiet && !w {
 		logrus.Warn("Your kernel does not support cgroup blkio weight")
 	}
-	return info
+	return cgroupBlkioInfo{BlkioWeight: w}
 }
 
-func checkCgroupCpusetInfo(quiet bool) *cgroupCpusetInfo {
-	info := &cgroupCpusetInfo{}
+// checkCgroupCpusetInfo reads the cpuset information from the cpuset cgroup mount point.
+func checkCgroupCpusetInfo(quiet bool) cgroupCpusetInfo {
 	_, err := cgroups.FindCgroupMountpoint("cpuset")
 	if err != nil {
 		if !quiet {
 			logrus.Warn(err)
 		}
-		return info
+		return cgroupCpusetInfo{}
 	}
 
-	info.Cpuset = true
-	return info
+	return cgroupCpusetInfo{Cpuset: true}
 }
 
 func cgroupEnabled(mountPoint, name string) bool {


### PR DESCRIPTION
Because they can just be values.

Signed-off-by: David Calavera david.calavera@gmail.com
