### PR TITLE
warn, dont error if a profile fails to load

### DIFF
--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -64,7 +64,7 @@ func NewDriver(root, initPath string, options []string) (*Driver, error) {
 			// (possibly through another run, manually, or via system startup)
 			for _, policy := range apparmorProfiles {
 				if err := hasAppArmorProfileLoaded(policy); err != nil {
-					return nil, fmt.Errorf("AppArmor enabled on system but the %s profile could not be loaded.", policy)
+					logrus.Warnf("AppArmor enabled on system but the %s profile could not be loaded. In future versions of Docker we will error out here.", policy)
 				}
 			}
 		}


### PR DESCRIPTION
ping @ewindisch 

I think we should at least do a warn first for 1.8.0

just super worried about old distros like wheezy if people have apparmor enabled. We never errored out before.

ping @calavera @tiborvass @icecrime 
