### PR TITLE
Gpg passphrase rpm sign fix

### DIFF
--- a/hack/make/release-rpm
+++ b/hack/make/release-rpm
@@ -57,7 +57,7 @@ for distro in "${distros[@]}"; do
 			rpm --import /tmp/gpg
 
 			# sign the rpms
-			rpm \
+			echo "yes" | setsid rpm \
 				--define '_gpg_name releasedocker' \
 				--define '_signature gpg' \
 				--define '__gpg_check_password_cmd /bin/true' \


### PR DESCRIPTION
rpm command was _still_ prompting during signing, even though we pass the passphrase AND say that the prompt command is /bin/true

tested and this works to fix the problem AND sign with the passphrase since we were already passing it

ping @tianon 
