### PR TITLE
make binary: do not ignore unresolved symbols

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -152,7 +152,7 @@ TESTFLAGS+=" -test.timeout=${TIMEOUT}"
 
 # A few more flags that are specific just to building a completely-static binary (see hack/make/binary)
 # PLEASE do not use these anywhere else.
-EXTLDFLAGS_STATIC_DOCKER="$EXTLDFLAGS_STATIC -lpthread -Wl,--unresolved-symbols=ignore-in-object-files"
+EXTLDFLAGS_STATIC_DOCKER="$EXTLDFLAGS_STATIC -lpthread -ldl"
 LDFLAGS_STATIC_DOCKER="
 	$LDFLAGS_STATIC
 	-extldflags \"$EXTLDFLAGS_STATIC_DOCKER\"


### PR DESCRIPTION
TL;DR: stop building static binary that may fail

Linker flag --unresolved-symbols=ignore-in-shared-libs was added
in commit 06d0843 two years ago for the static build case, presumably
to avoid dealing with problem of missing libraries.

For the record, this is what ld(1) man page says:

```
--unresolved-symbols=method
   Determine how to handle unresolved symbols.  There are four
   possible values for method:
        .........
    ignore-in-shared-libs
       Report unresolved symbols that come from regular object files,
       but ignore them if they come from shared libraries.  This can
       be useful when creating a dynamic binary and it is known that
       all the shared libraries that it should be referencing are
       included on the linker's command line.
```

Here, the flag is not used for its purpose ("creating a dynamic binary")
and does more harm than good. Instead of complaining about missing symbols
as it should do if some libraries are missing from LIBS/LDFLAGS, it lets
ld create a binary with unresolved symbols, ike this:

```
 $ readelf -s bundles/1.7.1/binary/docker-1.7.1 | grep -w UND
 ........
 21029: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND dlopen
 .........
```

Such binary is working just fine -- until code calls one of those
functions, then it crashes (for apparently no reason, i.e. it is
impossible to tell why from the diagnistics printed).

In other words, adding this flag allows to build a static binary
with missing libraries, hiding the problem from both a developer
(who forgot to add a library to #cgo: LDFLAGS -- I was one such
developer a few days ago when I was working on ploop graphdriver)
and from a user (who expects the binary to work without crashing,
and it does that until the code calls a function in one of those
libraries).

Removing the flag immediately unveils the problem (as it should):

```
    /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../x86_64-linux-gnu/libsqlite3.a(sqlite3.o):
    In function `unixDlError':
    (.text+0x20971): undefined reference to `dlerror'
    /usr/lib/gcc/x86_64-linux-gnu/4.8/../../../x86_64-linux-gnu/libsqlite3.a(sqlite3.o):
    In function `unixDlClose':
    (.text+0x8814): undefined reference to `dlclose'
```

The problem is, gosqlite package says:

```
    #cgo LDFLAGS: -lsqlite3
```

which is enough for dynamic linking, as indirect dependencies (i.e.
libraries required by libsqlite3.so) are listed in .so file and will be
resolved dynamically by ldd upon executing the binary.

For static linking though, one has to list all the required libraries,
both direct and indirect. For libraries with pkgconfig support the
list of required libraries can be obtained with pkg-config:

```
    $ pkg-config --libs sqlite3 # dynamic linking case
    -lsqlite3
    $ pkg-config --libs --static sqlite3 # static case
    -lsqlite3 -ldl -lpthread
```

It seems that all one has to do is to fix gosqlite this way:

``` udiff
    -#cgo LDFLAGS: -lsqlite3
    +#cgo pkg-config: sqlite3
```

Unfortunately, cmd/go doesn't know that it needs to pass --static flag to pkg-config in case of static linking (see https://github.com/golang/go/issues/12058).

So, for one, one has to do one of these things:

1 Patch sqlite.go like this:

``` udiff
    -#cgo LDFLAGS: -lsqlite3
    +#cgo pkg-config: --static sqlite3
```

(this is exactly what I do in goploop, see https://github.com/kolyshkin/goploop/commit/e9aa072f51)

2 Patch sqlite.go like this:

``` udiff
    -#cgo LDFLAGS: -lsqlite3
    +#cgo LDFLAGS: -lsqlite3 -ldl -lpthread
```

(I would submit this patch to gosqlite but it seems that
https://code.google.com/p/gosqlite/ is deserted and not maintained,
and patching it here is not right as it is "vendored")

3 Explicitly add `-ldl` for the static link case.
This is what this patch does.

4 Fork sqlite to github and maintain it there. Personally I am not
ready for that, as I'm neither a Go expert nor gosqlite user.

Now, solution this commit uses (3) doesn't look like a clear one, but nevertheless it makes
the build much better than it was before.

Signed-off-by: Kir Kolyshkin kir@openvz.org
