### PR TITLE
Revert: Adapt container settings after verify platform container settings

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -16,8 +16,8 @@ func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hos
 		return "", nil, fmt.Errorf("Config cannot be empty in order to create a container")
 	}
 
-	warnings, err := daemon.verifyContainerSettings(hostConfig, config)
 	daemon.adaptContainerSettings(hostConfig, adjustCPUShares)
+	warnings, err := daemon.verifyContainerSettings(hostConfig, config)
 	if err != nil {
 		return "", warnings, err
 	}


### PR DESCRIPTION
Revert: #15369

We did have a bug there, and we pointed the right fix:
https://github.com/docker/docker/pull/15275#discussion_r36267890

and it's handled in:
https://github.com/calavera/docker/commit/4177b0bae04bb41dfff65ea87b2efb87811e08e6

So #15369 is not necessary, actually we set adapt before adjust for
safe consideration, see:
https://github.com/docker/docker/pull/13834#discussion_r32213019

So I think we should revert this one.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
