### PR TITLE
Windows: [TP3] Enable NAT port mapping

### DIFF
--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -55,19 +55,23 @@ func (container *Container) setupWorkingDirectory() error {
 
 func populateCommand(c *Container, env []string) error {
 	en := &execdriver.Network{
-		Mtu:       c.daemon.config.Mtu,
 		Interface: nil,
 	}
 
 	parts := strings.SplitN(string(c.hostConfig.NetworkMode), ":", 2)
 	switch parts[0] {
-
 	case "none":
 	case "default", "": // empty string to support existing containers
 		if !c.Config.NetworkDisabled {
 			en.Interface = &execdriver.NetworkInterface{
-				MacAddress: c.Config.MacAddress,
-				Bridge:     c.daemon.config.Bridge.VirtualSwitchName,
+				MacAddress:   c.Config.MacAddress,
+				Bridge:       c.daemon.config.Bridge.VirtualSwitchName,
+				PortBindings: c.hostConfig.PortBindings,
+
+				// TODO Windows. Include IPAddress. There already is a
+				// property IPAddress on execDrive.CommonNetworkInterface,
+				// but there is no CLI option in docker to pass through
+				// an IPAddress on docker run.
 			}
 		}
 	default:

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -91,15 +91,6 @@ type Driver interface {
 	Stats(id string) (*ResourceStats, error)
 }
 
-// Network settings of the container
-type Network struct {
-	Interface      *NetworkInterface `json:"interface"` // if interface is nil then networking is disabled
-	Mtu            int               `json:"mtu"`
-	ContainerID    string            `json:"container_id"` // id of the container to join network.
-	NamespacePath  string            `json:"namespace_path"`
-	HostNetworking bool              `json:"host_networking"`
-}
-
 // Ipc settings of the container
 // It is for IPC namespace setting. Usually different containers
 // have their own IPC namespace, however this specifies to use
@@ -128,20 +119,6 @@ type Pid struct {
 // option.
 type UTS struct {
 	HostUTS bool `json:"host_uts"`
-}
-
-// NetworkInterface contains all network configs for a driver
-type NetworkInterface struct {
-	Gateway              string `json:"gateway"`
-	IPAddress            string `json:"ip"`
-	IPPrefixLen          int    `json:"ip_prefix_len"`
-	MacAddress           string `json:"mac"`
-	Bridge               string `json:"bridge"`
-	GlobalIPv6Address    string `json:"global_ipv6"`
-	LinkLocalIPv6Address string `json:"link_local_ipv6"`
-	GlobalIPv6PrefixLen  int    `json:"global_ipv6_prefix_len"`
-	IPv6Gateway          string `json:"ipv6_gateway"`
-	HairpinMode          bool   `json:"hairpin_mode"`
 }
 
 // Resources contains all resource configs for a driver.

--- a/daemon/execdriver/driver_unix.go
+++ b/daemon/execdriver/driver_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package execdriver
 
 import (
@@ -14,6 +16,14 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/configs"
 )
+
+// Network settings of the container
+type Network struct {
+	Mtu            int    `json:"mtu"`
+	ContainerID    string `json:"container_id"` // id of the container to join network.
+	NamespacePath  string `json:"namespace_path"`
+	HostNetworking bool   `json:"host_networking"`
+}
 
 // InitContainer is the initialization of a container config.
 // It returns the initial configs for a container. It's mostly

--- a/daemon/execdriver/driver_windows.go
+++ b/daemon/execdriver/driver_windows.go
@@ -1,0 +1,20 @@
+package execdriver
+
+import "github.com/docker/docker/pkg/nat"
+
+// Network settings of the container
+type Network struct {
+	Interface   *NetworkInterface `json:"interface"`
+	ContainerID string            `json:"container_id"` // id of the container to join network.
+}
+
+// NetworkInterface contains network configs for a driver
+type NetworkInterface struct {
+	MacAddress string `json:"mac"`
+	Bridge     string `json:"bridge"`
+	IPAddress  string `json:"ip"`
+
+	// PortBindings is the port mapping between the exposed port in the
+	// container and the port on the host.
+	PortBindings nat.PortMap `json:"port_bindings"`
+}

--- a/daemon/execdriver/lxc/lxc_template.go
+++ b/daemon/execdriver/lxc/lxc_template.go
@@ -128,17 +128,6 @@ lxc.{{$value}}
 {{end}}
 {{end}}
 
-{{if .Network.Interface}}
-{{if .Network.Interface.IPAddress}}
-lxc.network.ipv4 = {{.Network.Interface.IPAddress}}/{{.Network.Interface.IPPrefixLen}}
-{{end}}
-{{if .Network.Interface.Gateway}}
-lxc.network.ipv4.gateway = {{.Network.Interface.Gateway}}
-{{end}}
-{{if .Network.Interface.MacAddress}}
-lxc.network.hwaddr = {{.Network.Interface.MacAddress}}
-{{end}}
-{{end}}
 {{if .ProcessConfig.Env}}
 lxc.utsname = {{getHostname .ProcessConfig.Env}}
 {{end}}

--- a/daemon/execdriver/lxc/lxc_template_unit_test.go
+++ b/daemon/execdriver/lxc/lxc_template_unit_test.go
@@ -50,8 +50,7 @@ func TestLXCConfig(t *testing.T) {
 			CPUShares: int64(cpu),
 		},
 		Network: &execdriver.Network{
-			Mtu:       1500,
-			Interface: nil,
+			Mtu: 1500,
 		},
 		AllowedDevices: make([]*configs.Device, 0),
 		ProcessConfig:  execdriver.ProcessConfig{},
@@ -90,8 +89,7 @@ func TestCustomLxcConfig(t *testing.T) {
 			"lxc.cgroup.cpuset.cpus = 0,1",
 		},
 		Network: &execdriver.Network{
-			Mtu:       1500,
-			Interface: nil,
+			Mtu: 1500,
 		},
 		ProcessConfig: processConfig,
 	}
@@ -222,8 +220,7 @@ func TestCustomLxcConfigMounts(t *testing.T) {
 			"lxc.cgroup.cpuset.cpus = 0,1",
 		},
 		Network: &execdriver.Network{
-			Mtu:       1500,
-			Interface: nil,
+			Mtu: 1500,
 		},
 		Mounts:        mounts,
 		ProcessConfig: processConfig,
@@ -264,8 +261,7 @@ func TestCustomLxcConfigMisc(t *testing.T) {
 			"lxc.cgroup.cpuset.cpus = 0,1",
 		},
 		Network: &execdriver.Network{
-			Mtu:       1500,
-			Interface: nil,
+			Mtu: 1500,
 		},
 		ProcessConfig:   processConfig,
 		CapAdd:          []string{"net_admin", "syslog"},
@@ -317,8 +313,7 @@ func TestCustomLxcConfigMiscOverride(t *testing.T) {
 			"lxc.network.ipv4 = 172.0.0.1",
 		},
 		Network: &execdriver.Network{
-			Mtu:       1500,
-			Interface: nil,
+			Mtu: 1500,
 		},
 		ProcessConfig: processConfig,
 		CapAdd:        []string{"NET_ADMIN", "SYSLOG"},

--- a/daemon/network/settings.go
+++ b/daemon/network/settings.go
@@ -9,6 +9,7 @@ type Address struct {
 }
 
 // Settings stores configuration details about the daemon network config
+// TODO Windows. Many of these fields can be factored out.,
 type Settings struct {
 	Bridge                 string
 	EndpointID             string


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli @jstarks This adds support for NAT port mapping using docker run -p to the Windows daemon. 

EDIT: (Removed) It also refactors the NetworkInterface structure into platform specific capabilities.
