### PR TITLE
doc: add a notice about memory accounting overhead

### DIFF
--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -190,9 +190,14 @@ When users run Docker, they may see these messages when working with an image:
     WARNING: Your kernel does not support cgroup swap limit. WARNING: Your
     kernel does not support swap limit capabilities. Limitation discarded.
 
-To prevent these messages, enable memory and swap accounting on your system. To
-enable these on system using GNU GRUB (GNU GRand Unified Bootloader), do the
-following.
+To prevent these messages, enable memory and swap accounting on your
+system.  Enabling memory and swap accounting does induce both a memory
+overhead and a performance degradation even when Docker is not in
+use. The memory overhead is about 1% of the total available
+memory. The performance degradation is roughly 10%.
+
+To enable memory and swap on system using GNU GRUB (GNU GRand Unified
+Bootloader), do the following:
 
 1. Log into Ubuntu as a user with `sudo` privileges.
 


### PR DESCRIPTION
The documentation for Debian and Ubuntu explains how to enable memory
and swap accounting but doesn't explain why it is disabled in the first
place. The problem with those subsystems is that they incurs a
performance hit even when not used at all. Add this explanation.

The provided figure are quite vague. The memory overhead is easily
verifiable. It is for example cited in [RedHat documentation](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Resource_Management_Guide/sec-memory.html). For the
performance hit, maybe the performance is better now, but a few years
ago, it was said to be [between 6 and 15%](https://lwn.net/Articles/517562/).

The goal is that people don't just enable memory accounting if they
don't have a use for it.

Signed-off-by: Vincent Bernat vincent@bernat.im
