### PR TITLE
time.Sleep in integration tests — comment and waitRun/waitInspect

### DIFF
--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -767,9 +767,7 @@ func (s *DockerSuite) TestContainerApiPause(c *check.C) {
 func (s *DockerSuite) TestContainerApiTop(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "top")
 	id := strings.TrimSpace(string(out))
-	if err := waitRun(id); err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(waitRun(id), check.IsNil)
 
 	type topResp struct {
 		Titles    []string

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -14,9 +14,7 @@ import (
 func (s *DockerSuite) TestLogsApiWithStdout(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "-t", "busybox", "/bin/sh", "-c", "while true; do echo hello; sleep 1; done")
 	id := strings.TrimSpace(out)
-	if err := waitRun(id); err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(waitRun(id), check.IsNil)
 
 	type logOut struct {
 		out string

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -17,8 +17,7 @@ func (s *DockerSuite) TestCliStatsNoStreamGetCpu(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true;do echo 'Hello'; usleep 100000; done")
 
 	id := strings.TrimSpace(out)
-	err := waitRun(id)
-	c.Assert(err, check.IsNil)
+	c.Assert(waitRun(id), check.IsNil)
 
 	resp, body, err := sockRequestRaw("GET", fmt.Sprintf("/containers/%s/stats?stream=false", id), nil, "")
 	c.Assert(err, check.IsNil)
@@ -79,8 +78,7 @@ func (s *DockerSuite) TestApiNetworkStats(c *check.C) {
 	// Run container for 30 secs
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
-	err := waitRun(id)
-	c.Assert(err, check.IsNil)
+	c.Assert(waitRun(id), check.IsNil)
 
 	// Retrieve the container address
 	contIP := findContainerIP(c, id)

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -90,9 +90,7 @@ func (s *DockerSuite) TestAttachTtyWithoutStdin(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "-ti", "busybox")
 
 	id := strings.TrimSpace(out)
-	if err := waitRun(id); err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(waitRun(id), check.IsNil)
 
 	defer func() {
 		cmd := exec.Command(dockerBinary, "kill", id)

--- a/integration-cli/docker_cli_attach_unix_test.go
+++ b/integration-cli/docker_cli_attach_unix_test.go
@@ -19,9 +19,7 @@ func (s *DockerSuite) TestAttachClosedOnContainerStop(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-dti", "busybox", "sleep", "2")
 
 	id := strings.TrimSpace(out)
-	if err := waitRun(id); err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(waitRun(id), check.IsNil)
 
 	errChan := make(chan error)
 	go func() {
@@ -73,10 +71,8 @@ func (s *DockerSuite) TestAttachAfterDetach(c *check.C) {
 		close(errChan)
 	}()
 
-	time.Sleep(500 * time.Millisecond)
-	if err := waitRun(name); err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(waitRun(name), check.IsNil)
+
 	cpty.Write([]byte{16})
 	time.Sleep(100 * time.Millisecond)
 	cpty.Write([]byte{17})
@@ -137,9 +133,7 @@ func (s *DockerSuite) TestAttachAfterDetach(c *check.C) {
 func (s *DockerSuite) TestAttachDetach(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-itd", "busybox", "cat")
 	id := strings.TrimSpace(out)
-	if err := waitRun(id); err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(waitRun(id), check.IsNil)
 
 	cpty, tty, err := pty.Open()
 	if err != nil {
@@ -157,9 +151,7 @@ func (s *DockerSuite) TestAttachDetach(c *check.C) {
 	if err := cmd.Start(); err != nil {
 		c.Fatal(err)
 	}
-	if err := waitRun(id); err != nil {
-		c.Fatalf("error waiting for container to start: %v", err)
-	}
+	c.Assert(waitRun(id), check.IsNil)
 
 	if _, err := cpty.Write([]byte("hello\n")); err != nil {
 		c.Fatal(err)
@@ -211,9 +203,7 @@ func (s *DockerSuite) TestAttachDetach(c *check.C) {
 func (s *DockerSuite) TestAttachDetachTruncatedID(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-itd", "busybox", "cat")
 	id := stringid.TruncateID(strings.TrimSpace(out))
-	if err := waitRun(id); err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(waitRun(id), check.IsNil)
 
 	cpty, tty, err := pty.Open()
 	if err != nil {

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -20,12 +20,11 @@ func (s *DockerSuite) TestEventsTimestampFormats(c *check.C) {
 	image := "busybox"
 
 	// Start stopwatch, generate an event
-	time.Sleep(time.Second) // so that we don't grab events from previous test occurred in the same second
+	time.Sleep(1 * time.Second) // so that we don't grab events from previous test occured in the same second
 	start := daemonTime(c)
-	time.Sleep(time.Second) // remote API precision is only a second, wait a while before creating an event
 	dockerCmd(c, "tag", image, "timestamptest:1")
 	dockerCmd(c, "rmi", "timestamptest:1")
-	time.Sleep(time.Second) // so that until > since
+	time.Sleep(1 * time.Second) // so that until > since
 	end := daemonTime(c)
 
 	// List of available time formats to --since
@@ -223,7 +222,7 @@ func (s *DockerSuite) TestEventsImageUntagDelete(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsImageTag(c *check.C) {
-	time.Sleep(time.Second * 2) // because API has seconds granularity
+	time.Sleep(1 * time.Second) // because API has seconds granularity
 	since := daemonTime(c).Unix()
 	image := "testimageevents:tag"
 	dockerCmd(c, "tag", "busybox", image)

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -186,9 +186,7 @@ func (s *DockerSuite) TestExecTtyCloseStdin(c *check.C) {
 func (s *DockerSuite) TestExecTtyWithoutStdin(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "-ti", "busybox")
 	id := strings.TrimSpace(out)
-	if err := waitRun(id); err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(waitRun(id), check.IsNil)
 
 	errChan := make(chan error)
 	go func() {

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -25,14 +25,14 @@ func (s *DockerSuite) TestImagesOrderedByCreationDate(c *check.C) {
 	if err != nil {
 		c.Fatal(err)
 	}
-	time.Sleep(time.Second)
+	time.Sleep(1 * time.Second)
 	id2, err := buildImage("order:test_c",
 		`FROM scratch
 		MAINTAINER dockerio2`, true)
 	if err != nil {
 		c.Fatal(err)
 	}
-	time.Sleep(time.Second)
+	time.Sleep(1 * time.Second)
 	id3, err := buildImage("order:test_b",
 		`FROM scratch
 		MAINTAINER dockerio3`, true)

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
-	"time"
 )
 
 func (s *DockerSuite) TestLinksPingUnlinkedContainers(c *check.C) {
@@ -138,7 +137,7 @@ func (s *DockerSuite) TestLinksHostsFilesInject(c *check.C) {
 	out, _ = dockerCmd(c, "run", "-itd", "--name", "two", "--link", "one:onetwo", "busybox", "top")
 	idTwo := strings.TrimSpace(out)
 
-	time.Sleep(1 * time.Second)
+	c.Assert(waitRun(idTwo), check.IsNil)
 
 	contentOne, err := readContainerFileWithExec(idOne, "/etc/hosts")
 	if err != nil {

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -27,17 +27,13 @@ func (s *DockerSuite) TestPsListContainers(c *check.C) {
 	fourthID := strings.TrimSpace(out)
 
 	// make sure the second is running
-	if err := waitRun(secondID); err != nil {
-		c.Fatalf("waiting for container failed: %v", err)
-	}
+	c.Assert(waitRun(secondID), check.IsNil)
 
 	// make sure third one is not running
 	dockerCmd(c, "wait", thirdID)
 
 	// make sure the forth is running
-	if err := waitRun(fourthID); err != nil {
-		c.Fatalf("waiting for container failed: %v", err)
-	}
+	c.Assert(waitRun(fourthID), check.IsNil)
 
 	// all
 	out, _ = dockerCmd(c, "ps", "-a")

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"strings"
-	"time"
 
 	"github.com/go-check/check"
 )
@@ -31,7 +30,7 @@ func (s *DockerSuite) TestRestartRunningContainer(c *check.C) {
 
 	cleanedContainerID := strings.TrimSpace(out)
 
-	time.Sleep(1 * time.Second)
+	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 
 	out, _ = dockerCmd(c, "logs", cleanedContainerID)
 	if out != "foobar\n" {
@@ -42,7 +41,7 @@ func (s *DockerSuite) TestRestartRunningContainer(c *check.C) {
 
 	out, _ = dockerCmd(c, "logs", cleanedContainerID)
 
-	time.Sleep(1 * time.Second)
+	c.Assert(waitRun(cleanedContainerID), check.IsNil)
 
 	if out != "foobar\nfoobar\n" {
 		c.Errorf("container should've printed 'foobar' twice")

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1995,9 +1995,7 @@ func (s *DockerSuite) TestContainerNetworkMode(c *check.C) {
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
-	if err := waitRun(id); err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(waitRun(id), check.IsNil)
 	pid1, err := inspectField(id, "State.Pid")
 	c.Assert(err, check.IsNil)
 
@@ -2362,7 +2360,8 @@ func (s *DockerSuite) TestRunPidHostWithChildIsKillable(c *check.C) {
 	name := "ibuildthecloud"
 	dockerCmd(c, "run", "-d", "--pid=host", "--name", name, "busybox", "sh", "-c", "sleep 30; echo hi")
 
-	time.Sleep(1 * time.Second)
+	c.Assert(waitRun(name), check.IsNil)
+
 	errchan := make(chan error)
 	go func() {
 		if out, _, err := dockerCmdWithError("kill", name); err != nil {
@@ -2778,9 +2777,7 @@ func (s *DockerSuite) TestPtraceContainerProcsFromHost(c *check.C) {
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
-	if err := waitRun(id); err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(waitRun(id), check.IsNil)
 	pid1, err := inspectField(id, "State.Pid")
 	c.Assert(err, check.IsNil)
 

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -198,9 +198,7 @@ func (s *DockerSuite) TestRunAttachDetach(c *check.C) {
 	if err := cmd.Start(); err != nil {
 		c.Fatal(err)
 	}
-	if err := waitRun(name); err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(waitRun(name), check.IsNil)
 
 	if _, err := cpty.Write([]byte("hello\n")); err != nil {
 		c.Fatal(err)

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -11,9 +11,7 @@ import (
 func (s *DockerSuite) TestCliStatsNoStream(c *check.C) {
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
-	if err := waitRun(id); err != nil {
-		c.Fatalf("error waiting for container to start: %v", err)
-	}
+	c.Assert(waitRun(id), check.IsNil)
 
 	statsCmd := exec.Command(dockerBinary, "stats", "--no-stream", id)
 	chErr := make(chan error)

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -1238,9 +1238,11 @@ func runCommandAndReadContainerFile(filename string, cmd *exec.Cmd) ([]byte, err
 		return nil, fmt.Errorf("%v: %q", err, out)
 	}
 
-	time.Sleep(1 * time.Second)
-
 	contID := strings.TrimSpace(out)
+
+	if err := waitRun(contID); err != nil {
+		return nil, fmt.Errorf("%v: %q", contID, err)
+	}
 
 	return readContainerFile(contID, filename)
 }

--- a/integration-cli/utils.go
+++ b/integration-cli/utils.go
@@ -196,10 +196,14 @@ func waitForContainer(contID string, args ...string) error {
 	return nil
 }
 
+// waitRun will wait for the specified container to be running, maximum 5 seconds.
 func waitRun(contID string) error {
 	return waitInspect(contID, "{{.State.Running}}", "true", 5)
 }
 
+// waitInspect will wait for the specified container to have the specified string
+// in the inspect output. It will wait until the specified timeout (in seconds)
+// is reached.
 func waitInspect(name, expr, expected string, timeout int) error {
 	after := time.After(time.Duration(timeout) * time.Second)
 


### PR DESCRIPTION
Following the discussion in https://github.com/docker/docker/pull/13501#discussion_r36549317 , remove what seems unnecessary time.Sleep (1 second even) and comment the ones that seemed necessary.
- The comments are also here to see if the `Sleep` time is not too much (for these ones).
- Sometimes `time.Sleep(1 * time.Second)` and sometimes `time.Sleep(time.Second)`, update it to make them all look the same.

🐸

<del>Edit : The lines I wanted to remove are needed to be sure the image are build in a correct order so… I reduced the time to see if it still works — but it makes this PR a little more worthless so feel free to close while I'm sleeping :sweat_smile:.</del>


Signed-off-by: Vincent Demeester vincent@sbr.pm
