### PR TITLE
Remove pkg/systemd from validate-lint

### DIFF
--- a/hack/make/validate-lint
+++ b/hack/make/validate-lint
@@ -74,7 +74,6 @@ packages=(
 	pkg/stringid
 	pkg/stringutils
 	pkg/sysinfo
-	pkg/systemd
 	pkg/symlink
 	pkg/tailfile
 	pkg/tarsum


### PR DESCRIPTION
Following #15330, `pkg/systemd` doesn't exists anymore, removing it from `validate-lint` 🐧. This is a tiny tiny thingy just to avoid this in build :

``` bash
---> Making bundle: validate-lint (in bundles/1.8.0-dev/validate-lint)

pkg/archive/example_changes.go is in package main, not archive

cannot find package "pkg/systemd/*.go" in any of:
    /usr/local/go/src/pkg/systemd/*.go (from $GOROOT)
    /go/src/pkg/systemd/*.go (from $GOPATH)
    /go/src/github.com/docker/docker/vendor/src/pkg/systemd/*.go
Congratulations!  All Go source files have been linted.
```

Another question while I'm on `validate-lint`, what about "pkg/archive/example_changes.go is in package main, not archive" ? It's an example, that's why the error, should we just ignore it, etc… ? 

It's a real small change and in the end, we will revisit the file to not explicitly list all the package to lint, so feel free to close if not needed 🐸.

Signed-off-by: Vincent Demeester vincent@sbr.pm
