### PR TITLE
Truncating image id is docker ps to a length of 12

### DIFF
--- a/api/client/ps/custom.go
+++ b/api/client/ps/custom.go
@@ -64,6 +64,9 @@ func (c *containerContext) Image() string {
 	if c.c.Image == "" {
 		return "<no image>"
 	}
+	if c.trunc {
+		return stringutils.Truncate(c.c.Image, 12)
+	}
 	return c.c.Image
 }
 


### PR DESCRIPTION
Truncating image id is `docker ps` to a length of 12. Fixes #15418

Signed-off-by: Mohammed Aaqib Ansari maaquib@gmail.com
