### PR TITLE
graphtest: filter out lost+found dir entry

### DIFF
--- a/daemon/graphdriver/graphtest/graphtest.go
+++ b/daemon/graphdriver/graphtest/graphtest.go
@@ -151,6 +151,25 @@ func verifyFile(t *testing.T, path string, mode os.FileMode, uid, gid uint32) {
 
 }
 
+// readDir reads a directory just like ioutil.ReadDir()
+// then hides specific files (currently "lost+found")
+// so the tests don't "see" it
+func readDir(dir string) ([]os.FileInfo, error) {
+	a, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	b := a[:0]
+	for _, x := range a {
+		if x.Name() != "lost+found" { // ext4 always have this dir
+			b = append(b, x)
+		}
+	}
+
+	return b, nil
+}
+
 // DriverTestCreateEmpty creates an new image and verifies it is empty and the right metadata
 func DriverTestCreateEmpty(t *testing.T, drivername string) {
 	driver := GetDriver(t, drivername)
@@ -172,7 +191,7 @@ func DriverTestCreateEmpty(t *testing.T, drivername string) {
 	verifyFile(t, dir, 0755|os.ModeDir, 0, 0)
 
 	// Verify that the directory is empty
-	fis, err := ioutil.ReadDir(dir)
+	fis, err := readDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +250,7 @@ func verifyBase(t *testing.T, driver graphdriver.Driver, name string) {
 	file := path.Join(dir, "a file")
 	verifyFile(t, file, 0222|os.ModeSetuid, 0, 0)
 
-	fis, err := ioutil.ReadDir(dir)
+	fis, err := readDir(dir)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Ploop graph driver [1] provides its own ext4 filesystem to every
container. It so happens that ext4 root comes with lost+found
directory, causing failures from DriverTestCreateEmpty() and
DriverTestCreateBase() tests on ploop.

While I am not yet ready to submit ploop graph driver for review,
this change looks simple enough to push.

Note that filtering is done without any additional allocations,
as described in https://github.com/golang/go/wiki/SliceTricks.

Signed-off-by: Kir Kolyshkin kir@openvz.org

[1] https://github.com/kolyshkin/docker/tree/ploop/daemon/graphdriver/ploop
