### PR TITLE
Remove useless if-else

### DIFF
--- a/api/client/logout.go
+++ b/api/client/logout.go
@@ -26,13 +26,14 @@ func (cli *DockerCli) CmdLogout(args ...string) error {
 
 	if _, ok := cli.configFile.AuthConfigs[serverAddress]; !ok {
 		fmt.Fprintf(cli.out, "Not logged in to %s\n", serverAddress)
-	} else {
-		fmt.Fprintf(cli.out, "Remove login credentials for %s\n", serverAddress)
-		delete(cli.configFile.AuthConfigs, serverAddress)
-
-		if err := cli.configFile.Save(); err != nil {
-			return fmt.Errorf("Failed to save docker config: %v", err)
-		}
+		return nil
 	}
+
+	fmt.Fprintf(cli.out, "Remove login credentials for %s\n", serverAddress)
+	delete(cli.configFile.AuthConfigs, serverAddress)
+	if err := cli.configFile.Save(); err != nil {
+		return fmt.Errorf("Failed to save docker config: %v", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
It is better to use simple form without else.

Signed-off-by: Hu Keping hukeping@huawei.com
