### PR TITLE
Fix install.sh to handle non-zero exit codes when checking lsb_release

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -56,10 +56,13 @@ check_forked() {
 	# Check for lsb_release command existence, it usually exists in forked distros
 	if command_exists lsb_release; then
 		# Check if the `-u` option is supported
+		set +e
 		lsb_release -a -u > /dev/null 2>&1
+		lsb_release_exit_code=$?
+		set -e
 
 		# Check if the command has exited successfully, it means we're in a forked distro
-		if [ "$?" = "0" ]; then
+		if [ "$lsb_release_exit_code" = "0" ]; then
 			# Print info about current distro
 			cat <<-EOF
 			You're using '$lsb_dist' version '$dist_version'.


### PR DESCRIPTION
fixes #15425

Based on comments in #15425 and being unable to install RC3 on a clean ubuntu OS.

Example which failed:

```
$ docker run --rm -it -v $(pwd)/hack/install.sh:/install.sh ubuntu:latest /install.sh
$ echo $?
2
```

After my suggested fix the installation began:

```
$ docker run --rm -it -v $(pwd)/hack/install.sh:/install.sh ubuntu:latest /install.sh
+ sh -c sleep 3; apt-get update
Ign http://archive.ubuntu.com trusty InRelease
Ign http://archive.ubuntu.com trusty-updates InRelease
Ign http://archive.ubuntu.com trusty-security InRelease
Hit http://archive.ubuntu.com trusty Release.gpg
Get:1 http://archive.ubuntu.com trusty-updates Release.gpg [933 B]
Get:2 http://archive.ubuntu.com trusty-security Release.gpg [933 B]
Hit http://archive.ubuntu.com trusty Release
```

When I tried the image built from https://raw.githubusercontent.com/docker/docker/master/contrib/builder/deb/ubuntu-debootstrap-trusty/Dockerfile the original install.sh script worked. This was based off the suggested tests in  https://raw.githubusercontent.com/jfrazelle/docker/test-install-script/hack/make/test-install-script 

I'm not sure how ubuntu-debootstrap-trusty compares to ubuntu, hopefully someone on the Docker team can double check.

Signed-off-by: Ben Hall ben@benhall.me.uk
