### PR TITLE
Add `docker ps --format` to bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -869,7 +869,7 @@ _docker_ps() {
 			compopt -o nospace
 			return
 			;;
-		-n)
+		--format|-n)
 			return
 			;;
 	esac
@@ -893,7 +893,7 @@ _docker_ps() {
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--all -a --before --filter -f --help --latest -l -n --no-trunc --quiet -q --size -s --since" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--all -a --before --filter -f --format --help --latest -l -n --no-trunc --quiet -q --size -s --since" -- "$cur" ) )
 			;;
 	esac
 }


### PR DESCRIPTION
This flag was added in #14699 and is included in the 1.8 bump PR (#15091), see [changelog](https://github.com/docker/docker/pull/15091/files#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR19).

ping @tianon @jfrazelle 
@calavera would be nice if this could be included in 1.8.
