### PR TITLE
make windows cross compile static daemon work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y \
 	createrepo \
 	curl \
 	dpkg-sig \
+	gcc-mingw-w64 \
 	git \
 	iptables \
 	libapparmor-dev \

--- a/hack/make/binary
+++ b/hack/make/binary
@@ -7,6 +7,18 @@ BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
 
 source "${MAKEDIR}/.go-autogen"
 
+(
+if [ "$(go env GOOS)/$(go env GOARCH)" != "$(go env GOHOSTOS)/$(go env GOHOSTARCH)" ]; then
+	# must be cross-compiling!
+	case "$(go env GOOS)/$(go env GOARCH)" in
+		windows/amd64)
+			export CC=x86_64-w64-mingw32-gcc
+			export CGO_ENABLED=1
+			export LDFLAGS_STATIC_DOCKER="${LDFLAGS_STATIC_DOCKER/-linkmode external/} -extld=${CC}"
+			;;
+	esac
+fi
+
 echo "Building: $DEST/$BINARY_FULLNAME"
 go build \
 	-o "$DEST/$BINARY_FULLNAME" \
@@ -16,6 +28,7 @@ go build \
 		$LDFLAGS_STATIC_DOCKER
 	" \
 	./docker
+)
 
 echo "Created binary: $DEST/$BINARY_FULLNAME"
 ln -sf "$BINARY_FULLNAME" "$DEST/docker$BINARY_EXTENSION"

--- a/hack/make/cross
+++ b/hack/make/cross
@@ -5,6 +5,7 @@ set -e
 declare -A daemonSupporting
 daemonSupporting=(
 	[linux/amd64]=1
+	[windows/amd64]=1
 )
 
 # if we have our linux/amd64 version compiled, let's symlink it in


### PR DESCRIPTION
we can cross compile the static windows daemon from linux to windows 64 with x86_64-minggw-gcc

i read the docs. we do not need to build on a windows host now.

ping @tianon @icecrime @jhowardmsft 
