### PR TITLE
Return failure if docker pid file still not exists after waiting dock…

### DIFF
--- a/contrib/init/sysvinit-redhat/docker
+++ b/contrib/init/sysvinit-redhat/docker
@@ -59,8 +59,15 @@ start() {
             sleep 1
             tries=$((tries + 1))
         done
-        success
-        echo
+        if ! [ -f $pidfile ]; then
+            failure
+            echo
+            printf "$pidfile not exists after waiting docker to initialize for 10 seconds, probably something is wrong, you can check docker logs at $logfile ...\n"
+            exit 7
+        else
+            success
+            echo
+        fi
     else
         failure
         echo


### PR DESCRIPTION
…er to start for 10 seconds

Signed-off-by: Chun Chen ramichen@tencent.com

I've seen several times that `service docker start` succeeds even docker daemon fails to start and I think its reasonable to choose failure rather than success if daemon can't create pid file after 10 seconds waiting.

Before:

```
[root@docker-10-149-27-182 /data/home/gaia/chenchun]# service docker start
Starting docker (via systemctl):                           [  OK  ]
[root@docker-10-149-27-182 /data/home/gaia/chenchun]# 
[root@docker-10-149-27-182 /data/home/gaia/chenchun]# docker ps
FATA[0000] Get http:///var/run/docker.sock/v1.18/containers/json: dial unix /var/run/docker.sock: no such file or directory. Are you trying to connect to a TLS-enabled daemon without TLS?
```

After:

```
[root@docker-10-149-27-182 /data/home/gaia/chenchun]# service docker start
Starting docker (via systemctl):  Job for docker.service failed. See 'systemctl status docker.service' and 'journalctl -xn' for details.
                                                           [FAILED]
[root@docker-10-149-27-182 /data/home/gaia/chenchun]# 
[root@docker-10-149-27-182 /data/home/gaia/chenchun]# systemctl status -l docker.service
docker.service - LSB: start and stop docker
   Loaded: loaded (/etc/rc.d/init.d/docker)
   Active: failed (Result: exit-code) since Tue 2015-08-11 17:37:10 CST; 4s ago
  Process: 1944 ExecStart=/etc/rc.d/init.d/docker start (code=exited, status=7)

Aug 11 17:37:00 docker-10-149-27-182 docker[1944]: Redirecting to /bin/systemctl status  cgconfig.service
Aug 11 17:37:10 docker-10-149-27-182 docker[1944]: Starting docker:        [FAILED]
Aug 11 17:37:10 docker-10-149-27-182 docker[1944]: /var/run/docker.pid not exists after waiting docker to initialize for 10 seconds, probably something is wrong, you can check docker logs at /gaia/docker/var/lib/docker/docker ...
Aug 11 17:37:10 docker-10-149-27-182 systemd[1]: docker.service: control process exited, code=exited status=7
Aug 11 17:37:10 docker-10-149-27-182 systemd[1]: Failed to start LSB: start and stop docker.
Aug 11 17:37:10 docker-10-149-27-182 systemd[1]: Unit docker.service entered failed state.
```
