### PR TITLE
Add format description in run doc

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -505,18 +505,18 @@ parent group.
 The operator can also adjust the performance parameters of the
 container:
 
-| Option                               |  Description                                                                                      |
-|--------------------------------------|---------------------------------------------------------------------------------------------|
-| `-m`, `--memory="" `                 | Memory limit (format: , where unit = b, k, m or g)                                          |
-| `--memory-swap=""`                   | Total memory limit (memory + swap, format: , where unit = b, k, m or g)                     |
-| `-c`, `--cpu-shares=0`               | CPU shares (relative weight)                                                                |
-| `--cpu-period=0`                     | Limit the CPU CFS (Completely Fair Scheduler) period                                        |
-| `--cpuset-cpus="" `                  | CPUs in which to allow execution (0-3, 0,1)                                                 |
-| `--cpuset-mems=""`                   | Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems. |
-| `--cpu-quota=0`                      | Limit the CPU CFS (Completely Fair Scheduler) quota                                         |
-| `--blkio-weight=0`                   | Block IO weight (relative weight) accepts a weight value between 10 and 1000.               |
-| `--oom-kill-disable=true` or `false` | Whether to disable OOM Killer for the container or not.                                     |
-| `--memory-swappiness=""  `           | Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.        |
+| Option                     |  Description                                                                                |
+|----------------------------|---------------------------------------------------------------------------------------------|
+| `-m`, `--memory="" `       | Memory limit (format: `<number>[<unit>]`, where unit = b, k, m or g)                        |
+| `--memory-swap=""`         | Total memory limit (memory + swap, format: `<number>[<unit>]`, where unit = b, k, m or g)   |
+| `-c`, `--cpu-shares=0`     | CPU shares (relative weight)                                                                |
+| `--cpu-period=0`           | Limit the CPU CFS (Completely Fair Scheduler) period                                        |
+| `--cpuset-cpus="" `        | CPUs in which to allow execution (0-3, 0,1)                                                 |
+| `--cpuset-mems=""`         | Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems. |
+| `--cpu-quota=0`            | Limit the CPU CFS (Completely Fair Scheduler) quota                                         |
+| `--blkio-weight=0`         | Block IO weight (relative weight) accepts a weight value between 10 and 1000.               |
+| `--oom-kill-disable=false` | Whether to disable OOM Killer for the container or not.                                     |
+| `--memory-swappiness=""  ` | Tune a container's memory swappiness behavior. Accepts an integer between 0 and 100.        |
 
 ### Memory constraints
 


### PR DESCRIPTION
And only set false to --oom-kill-disable, we just need the default
value to show.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
