### PR TITLE
Windows: [TP3] Fixing Tar functions to support long paths.

### DIFF
--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -6,10 +6,25 @@ import (
 	"archive/tar"
 	"errors"
 	"os"
+	"path/filepath"
 	"syscall"
 
 	"github.com/docker/docker/pkg/system"
 )
+
+// fixVolumePathPrefix does platform specific processing to ensure that if
+// the path being passed in is not in a volume path format, convert it to one.
+func fixVolumePathPrefix(srcPath string) string {
+	return srcPath
+}
+
+// getWalkRoot calculates the root path when performing a TarWithOptions.
+// We use a seperate function as this is platform specific. On Linux, we
+// can't use filepath.Join(srcPath,include) because this will clean away
+// a trailing "." or "/" which may be important.
+func getWalkRoot(srcPath string, include string) string {
+	return srcPath + string(filepath.Separator) + include
+}
 
 // CanonicalTarNameForPath returns platform-specific filepath
 // to canonical posix-style path for tar archival. p is relative

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -6,8 +6,24 @@ import (
 	"archive/tar"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
+
+// fixVolumePathPrefix does platform specific processing to ensure that if
+// the path being passed in is not in a volume path format, convert it to one.
+func fixVolumePathPrefix(srcPath string) string {
+	if !strings.HasPrefix(srcPath, `\\?\`) {
+		srcPath = `\\?\` + srcPath
+	}
+	return srcPath
+}
+
+// getWalkRoot calculates the root path when performing a TarWithOptions.
+// We use a seperate function as this is platform specific.
+func getWalkRoot(srcPath string, include string) string {
+	return filepath.Join(srcPath, include)
+}
 
 // canonicalTarNameForPath returns platform-specific filepath
 // to canonical posix-style path for tar archival. p is relative

--- a/pkg/chrootarchive/diff_windows.go
+++ b/pkg/chrootarchive/diff_windows.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/docker/pkg/archive"
 )
@@ -14,6 +15,12 @@ import (
 // contents of the layer.
 func applyLayerHandler(dest string, layer archive.Reader, decompress bool) (size int64, err error) {
 	dest = filepath.Clean(dest)
+
+	// Ensure it is a Windows-style volume path
+	if !strings.HasPrefix(dest, `\\?\`) {
+		dest = `\\?\` + dest
+	}
+
 	if decompress {
 		decompressed, err := archive.DecompressStream(layer)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Stefan J. Wernli swernli@microsoft.com

@swernli @taylorb-microsoft @icecrime @jfrazelle 

This enables the use of long paths (volume paths starting \\?\....) as are used by the Windows daemon. This is a required fix for TP3.
