### PR TITLE
Revert "Container don't inherit from image labels"

### DIFF
--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -229,7 +229,7 @@ func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
 	}
 
 	name := "test_create_labels_from_image"
-	expected := map[string]string{"k2": "x", "k3": "v3"}
+	expected := map[string]string{"k2": "x", "k3": "v3", "k1": "v1"}
 	dockerCmd(c, "create", "--name", name, "-l", "k2=x", "--label", "k3=v3", imageName)
 
 	actual := make(map[string]string)

--- a/runconfig/merge.go
+++ b/runconfig/merge.go
@@ -47,6 +47,16 @@ func Merge(userConf, imageConf *Config) error {
 		}
 	}
 
+	if userConf.Labels == nil {
+		userConf.Labels = map[string]string{}
+	}
+	if imageConf.Labels != nil {
+		for l := range userConf.Labels {
+			imageConf.Labels[l] = userConf.Labels[l]
+		}
+		userConf.Labels = imageConf.Labels
+	}
+
 	if userConf.Entrypoint.Len() == 0 {
 		if userConf.Cmd.Len() == 0 {
 			userConf.Cmd = imageConf.Cmd


### PR DESCRIPTION
This reverts commit 79621c7728ab83292ffd94d005f10ccebfba055b from https://github.com/docker/docker/pull/13772.

So here's the deal.  When labels were first added (in part by me) labels where copied from the image to the container.  The intention here is that labels followed the same behaviour of ENV in that the image contains a "template" of the configuration of the container that is created from the image.  It seemed perfectly logical to me that they would be copied.  #13772 Came about saying that "image labels" are different from "container labels."  I get that, but never really viewed labels in Config section of the image as "image labels".  If it was an Image label it probably should be a root element.  Anyhow, not super important.  The important thing here is that #13772 removed that behaviour of copying labels to the containers.

I objected to the change because it breaks our software but the counter argument was basically just to do two calls.  I couldn't really disagree so I let that go.  Now that 1.8 is out I realize I should have thought this through more, it's not just 2 calls, but many more.

Labels are returned in the API equivalent of `docker ps`.  This is to allow fast lookup of containers.  By not returning labels from images on `docker ps` it now become a N+1 call.  If I do `docker ps` and get back 100 containers, I now need to do 100 `docker inspect IMAGE` calls.  Now one could get smart and say, just do a `docker ps` and `docker images` and merge the result.  The problem there is that `docker images` is very slow.  In the end I don't know how to get back to the same level of performance I had before with out doing caching on the client side.

Please just revert this behaviour.  I'd propose we just add image labels as a separate thing and just say that what we currently have are container labels (defined in the same way the ENV vars are set on the image, but are really for the container).

@icecrime @crosbymichael 
