### PR TITLE
reference/run: Clarify the use of numeric UIDs

### DIFF
--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1151,7 +1151,7 @@ Dockerfile `USER` instruction, but the operator can override it:
 
     -u="": Username or UID
 
-> **Note:** if you pass numeric uid, it must be in range 0-2147483647.
+> **Note:** if you pass a numeric uid, it must be in the range 0-2147483647.
 
 ### WORKDIR
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1142,10 +1142,11 @@ volume mounted on the host).
 
 ### USER
 
-The default user within a container is `root` (id = 0), but if the
-developer created additional users, those are accessible too. The
-developer can set a default user to run the first process with the
-Dockerfile `USER` instruction, but the operator can override it:
+The default user within a container is `root` (id = 0), but if the developer
+created additional users, those are accessible by name.  When passing a numeric
+ID, the user doesn't have to exist in the container. The developer can set a
+default user to run the first process with the Dockerfile `USER` instruction,
+but the operator can override it:
 
     -u="": Username or UID
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1144,9 +1144,10 @@ volume mounted on the host).
 
 The default user within a container is `root` (id = 0), but if the developer
 created additional users, those are accessible by name.  When passing a numeric
-ID, the user doesn't have to exist in the container. The developer can set a
-default user to run the first process with the Dockerfile `USER` instruction,
-but the operator can override it:
+ID, the user doesn't have to exist in the container.
+
+The developer can set a default user to run the first process with the
+Dockerfile `USER` instruction, but the operator can override it:
 
     -u="": Username or UID
 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -1142,16 +1142,17 @@ volume mounted on the host).
 
 ### USER
 
-The default user within a container is `root` (id = 0), but if the developer
-created additional users, those are accessible by name.  When passing a numeric
-ID, the user doesn't have to exist in the container.
+`root` (id = 0) is the default user within a container. The image developer can
+create additional users. Those users are accessible by name.  When passing a numeric
+ID, the user does not have to exist in the container.
 
 The developer can set a default user to run the first process with the
-Dockerfile `USER` instruction, but the operator can override it:
+Dockerfile `USER` instruction. When starting a container, the operator can override
+the `USER` instruction by passing the `-u` option.
 
     -u="": Username or UID
 
-> **Note:** if you pass a numeric uid, it must be in the range 0-2147483647.
+> **Note:** if you pass a numeric uid, it must be in the range of 0-2147483647.
 
 ### WORKDIR
 


### PR DESCRIPTION
it is possible to pass an UID that has not been created inside the container, clarify this in the docs.
This should fix issue #14795

Signed-off-by: Kai Blin kai@samba.org
