### PR TITLE
added usage counter to control volume operations

### DIFF
--- a/volume/drivers/api.go
+++ b/volume/drivers/api.go
@@ -7,7 +7,7 @@ import "github.com/docker/docker/volume"
 // NewVolumeDriver returns a driver has the given name mapped on the given client.
 func NewVolumeDriver(name string, c client) volume.Driver {
 	proxy := &volumeDriverProxy{c}
-	return &volumeDriverAdapter{name, proxy}
+	return &volumeDriverAdapter{name, proxy, make(map[string]*volumeAdapter)}
 }
 
 // VolumeDriver defines the available functions that volume plugins must implement.

--- a/volume/local/local.go
+++ b/volume/local/local.go
@@ -189,6 +189,11 @@ func (v *localVolume) Unmount() error {
 	return nil
 }
 
+// UsedCount is for statisfying the localVolume interface and, returning the used count of the volume.
+func (v *localVolume) UsedCount() int {
+	return v.usedCount
+}
+
 func (v *localVolume) use() {
 	v.m.Lock()
 	v.usedCount++

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -27,6 +27,8 @@ type Volume interface {
 	Mount() (string, error)
 	// Unmount unmounts the volume when it is no longer in use.
 	Unmount() error
+	// UsedCount returns the times the volume is being used currently
+	UsedCount() int
 }
 
 // read-write modes


### PR DESCRIPTION
Signed-off-by: Clinton Kitson clintonskitson@gmail.com

This commit adds a control feature for volumes similar to what is done in the local driver.  If running multiple containers that reference a single volume and using a volume driver, currently when removing any of the containers it will trigger an unmount/remove operation.  The counters are used to ensure that the volume is only attempted to be unmounted when all containers are done using the volume.

The counter is located on the volume/adapter and these are now tracked in a map of these volumes that is held on the volumeDriverAdapter.  Instead of creating new adapters for the same volume name, the map is now referenced so a single counter can be used.
