### PR TITLE
Fix layer exclusion bug on multiple tag push

### DIFF
--- a/graph/push.go
+++ b/graph/push.go
@@ -44,13 +44,13 @@ func (s *TagStore) NewPusher(endpoint registry.APIEndpoint, localRepo Repository
 	switch endpoint.Version {
 	case registry.APIVersion2:
 		return &v2Pusher{
-			TagStore:   s,
-			endpoint:   endpoint,
-			localRepo:  localRepo,
-			repoInfo:   repoInfo,
-			config:     imagePushConfig,
-			sf:         sf,
-			layersSeen: make(map[string]bool),
+			TagStore:     s,
+			endpoint:     endpoint,
+			localRepo:    localRepo,
+			repoInfo:     repoInfo,
+			config:       imagePushConfig,
+			sf:           sf,
+			layersPushed: make(map[string]bool),
 		}, nil
 	case registry.APIVersion1:
 		return &v1Pusher{

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -86,6 +86,39 @@ func (s *DockerRegistrySuite) TestPushMultipleTags(c *check.C) {
 	if len(imagePushHashes) == 0 {
 		c.Fatal(`Expected at least one line containing "Image successfully pushed"`)
 	}
+
+	// Ensure layer list is equivalent for repoTag1 and repoTag2
+	out1, _ := dockerCmd(c, "pull", repoTag1)
+	if strings.Contains(out1, "Tag t1 not found") {
+		c.Fatalf("Unable to pull pushed image: %s", out1)
+	}
+	var out1Lines []string
+	for _, outputLine := range strings.Split(out1, "\n") {
+		if strings.Contains(outputLine, imageAlreadyExists) {
+			out1Lines = append(out1Lines, outputLine)
+		}
+	}
+
+	out2, _ := dockerCmd(c, "pull", repoTag2)
+	if strings.Contains(out2, "Tag t2 not found") {
+		c.Fatalf("Unable to pull pushed image: %s", out1)
+	}
+	var out2Lines []string
+	for _, outputLine := range strings.Split(out2, "\n") {
+		if strings.Contains(outputLine, imageAlreadyExists) {
+			out1Lines = append(out1Lines, outputLine)
+		}
+	}
+
+	if len(out1Lines) != len(out2Lines) {
+		c.Fatalf("Mismatched output length:\n%s\n%s", out1, out2)
+	}
+
+	for i := range out1Lines {
+		if out1Lines[i] != out2Lines[i] {
+			c.Fatalf("Mismatched output line:\n%s\n%s", out1Lines[i], out2Lines[i])
+		}
+	}
 }
 
 func (s *DockerRegistrySuite) TestPushInterrupt(c *check.C) {


### PR DESCRIPTION
Ensure that layers are not excluded from manifests based on previous pushes.
Continue skipping pushes on layers which were pushed by a previous tag.

fixes #15536
