### PR TITLE
Fix partial manifest push

### DIFF
--- a/graph/push.go
+++ b/graph/push.go
@@ -44,13 +44,12 @@ func (s *TagStore) NewPusher(endpoint registry.APIEndpoint, localRepo Repository
 	switch endpoint.Version {
 	case registry.APIVersion2:
 		return &v2Pusher{
-			TagStore:   s,
-			endpoint:   endpoint,
-			localRepo:  localRepo,
-			repoInfo:   repoInfo,
-			config:     imagePushConfig,
-			sf:         sf,
-			layersSeen: make(map[string]bool),
+			TagStore:  s,
+			endpoint:  endpoint,
+			localRepo: localRepo,
+			repoInfo:  repoInfo,
+			config:    imagePushConfig,
+			sf:        sf,
 		}, nil
 	case registry.APIVersion1:
 		return &v1Pusher{

--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -60,32 +60,7 @@ func (s *DockerRegistrySuite) TestPushMultipleTags(c *check.C) {
 
 	dockerCmd(c, "tag", "busybox", repoTag2)
 
-	out, _ := dockerCmd(c, "push", repoName)
-
-	// There should be no duplicate hashes in the output
-	imageSuccessfullyPushed := ": Image successfully pushed"
-	imageAlreadyExists := ": Image already exists"
-	imagePushHashes := make(map[string]struct{})
-	outputLines := strings.Split(out, "\n")
-	for _, outputLine := range outputLines {
-		if strings.Contains(outputLine, imageSuccessfullyPushed) {
-			hash := strings.TrimSuffix(outputLine, imageSuccessfullyPushed)
-			if _, present := imagePushHashes[hash]; present {
-				c.Fatalf("Duplicate image push: %s", outputLine)
-			}
-			imagePushHashes[hash] = struct{}{}
-		} else if strings.Contains(outputLine, imageAlreadyExists) {
-			hash := strings.TrimSuffix(outputLine, imageAlreadyExists)
-			if _, present := imagePushHashes[hash]; present {
-				c.Fatalf("Duplicate image push: %s", outputLine)
-			}
-			imagePushHashes[hash] = struct{}{}
-		}
-	}
-
-	if len(imagePushHashes) == 0 {
-		c.Fatal(`Expected at least one line containing "Image successfully pushed"`)
-	}
+	dockerCmd(c, "push", repoName)
 }
 
 func (s *DockerRegistrySuite) TestPushInterrupt(c *check.C) {


### PR DESCRIPTION
Rather than working around the issue, we suggest to revert the problematic PR, and drop the optimization of not pushing the same layer twice.
- Revert #14484
- Keep the updated regression test introduced in #15539

Fixes #15536.
