### PR TITLE
Ensure the cleanup jobs in the deferrer are executed on error

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -254,28 +254,28 @@ func (container *Container) Start() (err error) {
 		}
 	}()
 
-	if err := container.Mount(); err != nil {
+	if err = container.Mount(); err != nil {
 		return err
 	}
 
 	// No-op if non-Windows. Once the container filesystem is mounted,
 	// prepare the layer to boot using the Windows driver.
-	if err := container.PrepareStorage(); err != nil {
+	if err = container.PrepareStorage(); err != nil {
 		return err
 	}
 
-	if err := container.initializeNetworking(); err != nil {
+	if err = container.initializeNetworking(); err != nil {
 		return err
 	}
 	linkedEnv, err := container.setupLinkedContainers()
 	if err != nil {
 		return err
 	}
-	if err := container.setupWorkingDirectory(); err != nil {
+	if err = container.setupWorkingDirectory(); err != nil {
 		return err
 	}
 	env := container.createDaemonEnvironment(linkedEnv)
-	if err := populateCommand(container, env); err != nil {
+	if err = populateCommand(container, env); err != nil {
 		return err
 	}
 
@@ -612,7 +612,7 @@ func (container *Container) Copy(resource string) (rc io.ReadCloser, err error) 
 		}
 	}()
 
-	if err := container.Mount(); err != nil {
+	if err = container.Mount(); err != nil {
 		return nil, err
 	}
 
@@ -625,7 +625,7 @@ func (container *Container) Copy(resource string) (rc io.ReadCloser, err error) 
 		}
 	}()
 
-	if err := container.mountVolumes(); err != nil {
+	if err = container.mountVolumes(); err != nil {
 		return nil, err
 	}
 
@@ -654,7 +654,7 @@ func (container *Container) Copy(resource string) (rc io.ReadCloser, err error) 
 		return nil, err
 	}
 
-	if err := container.PrepareStorage(); err != nil {
+	if err = container.PrepareStorage(); err != nil {
 		container.Unmount()
 		return nil, err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -621,25 +621,25 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 
 	// Verify logging driver type
 	if config.LogConfig.Type != "none" {
-		if _, err := logger.GetLogDriver(config.LogConfig.Type); err != nil {
+		if _, err = logger.GetLogDriver(config.LogConfig.Type); err != nil {
 			return nil, fmt.Errorf("error finding the logging driver: %v", err)
 		}
 	}
 	logrus.Debugf("Using default logging driver %s", config.LogConfig.Type)
 
 	// Configure and validate the kernels security support
-	if err := configureKernelSecuritySupport(config, d.driver.String()); err != nil {
+	if err = configureKernelSecuritySupport(config, d.driver.String()); err != nil {
 		return nil, err
 	}
 
 	daemonRepo := filepath.Join(config.Root, "containers")
 
-	if err := system.MkdirAll(daemonRepo, 0700); err != nil {
+	if err = system.MkdirAll(daemonRepo, 0700); err != nil {
 		return nil, err
 	}
 
 	// Migrate the container if it is aufs and aufs is enabled
-	if err := migrateIfDownlevel(d.driver, config.Root); err != nil {
+	if err = migrateIfDownlevel(d.driver, config.Root); err != nil {
 		return nil, err
 	}
 
@@ -650,7 +650,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	}
 
 	// Configure the volumes driver
-	if err := configureVolumes(config); err != nil {
+	if err = configureVolumes(config); err != nil {
 		return nil, err
 	}
 
@@ -661,7 +661,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 
 	trustDir := filepath.Join(config.Root, "trust")
 
-	if err := system.MkdirAll(trustDir, 0700); err != nil {
+	if err = system.MkdirAll(trustDir, 0700); err != nil {
 		return nil, err
 	}
 	trustService, err := trust.NewTrustStore(trustDir)
@@ -698,7 +698,8 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 
 	var sysInitPath string
 	if config.ExecDriver == "lxc" {
-		initPath, err := configureSysInit(config)
+		var initPath string
+		initPath, err = configureSysInit(config)
 		if err != nil {
 			return nil, err
 		}
@@ -734,7 +735,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	d.root = config.Root
 	go d.execCommandGC()
 
-	if err := d.restore(); err != nil {
+	if err = d.restore(); err != nil {
 		return nil, err
 	}
 

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -109,7 +109,7 @@ func (daemon *Daemon) rm(container *Container, forceRemove bool) (err error) {
 		}
 	}()
 
-	if _, err := daemon.containerGraph.Purge(container.ID); err != nil {
+	if _, err = daemon.containerGraph.Purge(container.ID); err != nil {
 		logrus.Debugf("Unable to remove container from link graph: %s", err)
 	}
 
@@ -120,7 +120,7 @@ func (daemon *Daemon) rm(container *Container, forceRemove bool) (err error) {
 	// There will not be an -init on Windows, so don't fail by not attempting to delete it
 	if runtime.GOOS != "windows" {
 		initID := fmt.Sprintf("%s-init", container.ID)
-		if err := daemon.driver.Remove(initID); err != nil {
+		if err = daemon.driver.Remove(initID); err != nil {
 			return fmt.Errorf("Driver %s failed to remove init filesystem %s: %s", daemon.driver, initID, err)
 		}
 	}

--- a/daemon/graphdriver/fsdiff.go
+++ b/daemon/graphdriver/fsdiff.go
@@ -3,6 +3,7 @@
 package graphdriver
 
 import (
+	"io"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -48,12 +49,13 @@ func (gdw *naiveDiffDriver) Diff(id, parent string) (arch archive.Archive, err e
 	}()
 
 	if parent == "" {
-		archive, err := archive.Tar(layerFs, archive.Uncompressed)
+		var ar io.ReadCloser
+		ar, err = archive.Tar(layerFs, archive.Uncompressed)
 		if err != nil {
 			return nil, err
 		}
-		return ioutils.NewReadCloserWrapper(archive, func() error {
-			err := archive.Close()
+		return ioutils.NewReadCloserWrapper(ar, func() error {
+			err := ar.Close()
 			driver.Put(id)
 			return err
 		}), nil

--- a/daemon/graphdriver/overlay/overlay.go
+++ b/daemon/graphdriver/overlay/overlay.go
@@ -440,7 +440,7 @@ func (d *Driver) ApplyDiff(id string, parent string, diff archive.Reader) (size 
 	}
 
 	rootDir := path.Join(dir, "root")
-	if err := os.Rename(tmpRootDir, rootDir); err != nil {
+	if err = os.Rename(tmpRootDir, rootDir); err != nil {
 		return 0, err
 	}
 

--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -245,7 +245,8 @@ func (p *v2Puller) pullV2Tag(tag, taggedName string) (verified bool, err error) 
 	}()
 
 	for i := len(manifest.FSLayers) - 1; i >= 0; i-- {
-		img, err := image.NewImgJSON([]byte(manifest.History[i].V1Compatibility))
+		var img *image.Image
+		img, err = image.NewImgJSON([]byte(manifest.History[i].V1Compatibility))
 		if err != nil {
 			logrus.Debugf("error getting image v1 json: %v", err)
 			return false, err
@@ -273,7 +274,7 @@ func (p *v2Puller) pullV2Tag(tag, taggedName string) (verified bool, err error) 
 	for i := len(downloads) - 1; i >= 0; i-- {
 		d := &downloads[i]
 		if d.err != nil {
-			if err := <-d.err; err != nil {
+			if err = <-d.err; err != nil {
 				return false, err
 			}
 		}
@@ -299,7 +300,7 @@ func (p *v2Puller) pullV2Tag(tag, taggedName string) (verified bool, err error) 
 					return false, err
 				}
 
-				if err := p.graph.SetDigest(d.img.ID, d.digest); err != nil {
+				if err = p.graph.SetDigest(d.img.ID, d.digest); err != nil {
 					return false, err
 				}
 
@@ -319,7 +320,8 @@ func (p *v2Puller) pullV2Tag(tag, taggedName string) (verified bool, err error) 
 
 	// Check for new tag if no layers downloaded
 	if !tagUpdated {
-		repo, err := p.Get(p.repoInfo.LocalName)
+		var repo Repository
+		repo, err = p.Get(p.repoInfo.LocalName)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
Some of the cleanup jobs in the deferrer depend on an 'err' variable that would be assigned later on. 
But this is a bit fragile because it's quite usual to use

``` go
if err := func(); err != nil {
    return err
}
```

to handle errors in go.
In such cases a new local 'err' variable will be created and the outer 'err' that the deferrer depends on won't be assigned so this will prevent the cleanup jobs from executing.

Signed-off-by: Shijiang Wei mountkin@gmail.com
