### PR TITLE
Add --init opts for lxc driver to start /sbin/init

### DIFF
--- a/api/client/run.go
+++ b/api/client/run.go
@@ -55,7 +55,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		ErrConflictAttachDetach               = fmt.Errorf("Conflicting options: -a and -d")
 		ErrConflictRestartPolicyAndAutoRemove = fmt.Errorf("Conflicting options: --restart and --rm")
 		ErrConflictDetachAutoRemove           = fmt.Errorf("Conflicting options: --rm and -d")
-        ErrInitTtyorStdin                     = fmt.Errorf("Options Error: -i and -t is needed")
+		ErrInitTtyorStdin                     = fmt.Errorf("Options Error: -i and -t is needed")
 	)
 
 	config, hostConfig, cmd, err := runconfig.Parse(cmd, args)
@@ -76,7 +76,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 			}
 		}
 	}
-    config.Init = *flInit;
+	config.Init = *flInit
 	if config.Init {
 		if !config.OpenStdin || !config.Tty {
 			return ErrInitTtyorStdin

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -49,11 +49,13 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		flDetach     = cmd.Bool([]string{"d", "-detach"}, false, "Run container in background and print container ID")
 		flSigProxy   = cmd.Bool([]string{"-sig-proxy"}, true, "Proxy received signals to the process")
 		flName       = cmd.String([]string{"-name"}, "", "Assign a name to the container")
+		flInit       = cmd.Bool([]string{"-init"}, false, "start a container in init mode not need command and need -i and -t (only effective in lxc driver)")
 		flAttach     *opts.ListOpts
 
 		ErrConflictAttachDetach               = fmt.Errorf("Conflicting options: -a and -d")
 		ErrConflictRestartPolicyAndAutoRemove = fmt.Errorf("Conflicting options: --restart and --rm")
 		ErrConflictDetachAutoRemove           = fmt.Errorf("Conflicting options: --rm and -d")
+        ErrInitTtyorStdin                     = fmt.Errorf("Options Error: -i and -t is needed")
 	)
 
 	config, hostConfig, cmd, err := runconfig.Parse(cmd, args)
@@ -74,6 +76,13 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 			}
 		}
 	}
+    config.Init = *flInit;
+	if config.Init {
+		if !config.OpenStdin || !config.Tty {
+			return ErrInitTtyorStdin
+		}
+	}
+
 	if config.Image == "" {
 		cmd.Usage()
 		return nil

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -271,6 +271,7 @@ func populateCommand(c *Container, env []string) error {
 		Arguments:  c.Args,
 		Tty:        c.Config.Tty,
 		User:       c.Config.User,
+		Init:		c.Config.Init,
 	}
 
 	processConfig.SysProcAttr = &syscall.SysProcAttr{Setsid: true}

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -271,7 +271,7 @@ func populateCommand(c *Container, env []string) error {
 		Arguments:  c.Args,
 		Tty:        c.Config.Tty,
 		User:       c.Config.User,
-		Init:		c.Config.Init,
+		Init:       c.Config.Init,
 	}
 
 	processConfig.SysProcAttr = &syscall.SysProcAttr{Setsid: true}

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -72,8 +72,8 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 			return nil, nil, err
 		}
 	}
-	if err := daemon.InitModeinit(config); err != nil{
-	    return nil, nil, err
+	if err := daemon.InitModeinit(config); err != nil {
+		return nil, nil, err
 	}
 	if container, err = daemon.newContainer(name, config, imgID); err != nil {
 		return nil, nil, err

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -72,6 +72,9 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 			return nil, nil, err
 		}
 	}
+	if err := daemon.InitModeinit(config); err != nil{
+	    return nil, nil, err
+	}
 	if container, err = daemon.newContainer(name, config, imgID); err != nil {
 		return nil, nil, err
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -341,7 +341,7 @@ func (daemon *Daemon) mergeAndVerifyConfig(config *runconfig.Config, img *image.
 			return err
 		}
 	}
-	if config.Entrypoint.Len() == 0 && config.Cmd.Len() == 0 {
+	if config.Entrypoint.Len() == 0 && config.Cmd.Len() == 0 && !config.Init {	
 		return fmt.Errorf("No command specified")
 	}
 	return nil
@@ -450,6 +450,21 @@ func (daemon *Daemon) getEntrypointAndArgs(configEntrypoint *runconfig.Entrypoin
 	}
 	return entrypoint, args
 }
+
+func (daemon *Daemon) InitModeinit(config *runconfig.Config) error {
+	    if !config.Init{
+			        return nil
+						    }
+		    if strings.Contains(daemon.Config().ExecDriver,"native") {
+				       return  fmt.Errorf("Init mode is not supported by native drive.")
+						       }
+			    if config.Cmd.Len() != 0 || config.Entrypoint.Len() != 0 {
+					       return  fmt.Errorf("Command is not need in init mode.")
+							       }
+				    config.Cmd = runconfig.NewCommand("/sbin/init")
+						    return nil
+}
+
 
 func (daemon *Daemon) newContainer(name string, config *runconfig.Config, imgID string) (*Container, error) {
 	var (

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -341,7 +341,7 @@ func (daemon *Daemon) mergeAndVerifyConfig(config *runconfig.Config, img *image.
 			return err
 		}
 	}
-	if config.Entrypoint.Len() == 0 && config.Cmd.Len() == 0 && !config.Init {	
+	if config.Entrypoint.Len() == 0 && config.Cmd.Len() == 0 && !config.Init {
 		return fmt.Errorf("No command specified")
 	}
 	return nil
@@ -452,19 +452,18 @@ func (daemon *Daemon) getEntrypointAndArgs(configEntrypoint *runconfig.Entrypoin
 }
 
 func (daemon *Daemon) InitModeinit(config *runconfig.Config) error {
-	    if !config.Init{
-			        return nil
-						    }
-		    if strings.Contains(daemon.Config().ExecDriver,"native") {
-				       return  fmt.Errorf("Init mode is not supported by native drive.")
-						       }
-			    if config.Cmd.Len() != 0 || config.Entrypoint.Len() != 0 {
-					       return  fmt.Errorf("Command is not need in init mode.")
-							       }
-				    config.Cmd = runconfig.NewCommand("/sbin/init")
-						    return nil
+	if !config.Init {
+		return nil
+	}
+	if strings.Contains(daemon.Config().ExecDriver, "native") {
+		return fmt.Errorf("Init mode is not supported by native drive.")
+	}
+	if config.Cmd.Len() != 0 || config.Entrypoint.Len() != 0 {
+		return fmt.Errorf("Command is not need in init mode.")
+	}
+	config.Cmd = runconfig.NewCommand("/sbin/init")
+	return nil
 }
-
 
 func (daemon *Daemon) newContainer(name string, config *runconfig.Config, imgID string) (*Container, error) {
 	var (

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -190,7 +190,7 @@ type ProcessConfig struct {
 	Terminal    Terminal `json:"-"` // standard or tty terminal
 	Console     string   `json:"-"` // dev/console path
 	ConsoleSize [2]int   `json:"-"` // h,w of initial console size
-	Init		bool	 `json:"-"`
+	Init        bool     `json:"-"`
 }
 
 // Command wrapps an os/exec.Cmd to add more metadata

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -190,6 +190,7 @@ type ProcessConfig struct {
 	Terminal    Terminal `json:"-"` // standard or tty terminal
 	Console     string   `json:"-"` // dev/console path
 	ConsoleSize [2]int   `json:"-"` // h,w of initial console size
+	Init		bool	 `json:"-"`
 }
 
 // Command wrapps an os/exec.Cmd to add more metadata

--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -239,7 +239,7 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 	}
 
 	if d.sharedRoot {
-	// lxc-start really needs / to be non-shared, or all kinds of stuff break
+		// lxc-start really needs / to be non-shared, or all kinds of stuff break
 		// when lxc-start unmount things and those unmounts propagate to the main
 		// mount namespace.
 		// What we really want is to clone into a new namespace and then
@@ -773,7 +773,6 @@ func (d *Driver) generateLXCConfig(c *execdriver.Command) (string, error) {
 		}
 		return root, nil
 	}
-
 
 	if err := lxcTemplateCompiled.Execute(fo, struct {
 		*execdriver.Command

--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -212,32 +212,34 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, startCallba
 		}
 	}
 
-	params = append(params,
-		"--",
-		c.InitPath,
-	)
+	if !c.ProcessConfig.Init {
+		params = append(params,
+			"--",
+			c.InitPath,
+		)
 
-	if c.ProcessConfig.User != "" {
-		params = append(params, "-u", c.ProcessConfig.User)
-	}
-
-	if c.ProcessConfig.Privileged {
-		if d.apparmor {
-			params[0] = path.Join(d.root, "lxc-start-unconfined")
-
+		if c.ProcessConfig.User != "" {
+			params = append(params, "-u", c.ProcessConfig.User)
 		}
-		params = append(params, "-privileged")
-	}
 
-	if c.WorkingDir != "" {
-		params = append(params, "-w", c.WorkingDir)
-	}
+		if c.ProcessConfig.Privileged {
+			if d.apparmor {
+				params[0] = path.Join(d.root, "lxc-start-unconfined")
 
-	params = append(params, "--", c.ProcessConfig.Entrypoint)
-	params = append(params, c.ProcessConfig.Arguments...)
+			}
+			params = append(params, "-privileged")
+		}
+
+		if c.WorkingDir != "" {
+			params = append(params, "-w", c.WorkingDir)
+		}
+
+		params = append(params, "--", c.ProcessConfig.Entrypoint)
+		params = append(params, c.ProcessConfig.Arguments...)
+	}
 
 	if d.sharedRoot {
-		// lxc-start really needs / to be non-shared, or all kinds of stuff break
+	// lxc-start really needs / to be non-shared, or all kinds of stuff break
 		// when lxc-start unmount things and those unmounts propagate to the main
 		// mount namespace.
 		// What we really want is to clone into a new namespace and then
@@ -758,6 +760,20 @@ func (d *Driver) generateLXCConfig(c *execdriver.Command) (string, error) {
 		return "", err
 	}
 	defer fo.Close()
+
+	if c.ProcessConfig.Init {
+		if err := InitTemplateCompiled.Execute(fo, struct {
+			*execdriver.Command
+			AppArmor bool
+		}{
+			Command:  c,
+			AppArmor: d.apparmor,
+		}); err != nil {
+			return "", err
+		}
+		return root, nil
+	}
+
 
 	if err := lxcTemplateCompiled.Execute(fo, struct {
 		*execdriver.Command

--- a/daemon/execdriver/lxc/lxc_template.go
+++ b/daemon/execdriver/lxc/lxc_template.go
@@ -160,7 +160,7 @@ lxc.cap.drop = {{.}}
 {{end}}
 `
 
-const LxcInitTemplate =  `
+const LxcInitTemplate = `
 lxc.include = /usr/share/lxc/config/ubuntu.common.conf
 
 {{if .Network.Interface}}

--- a/daemon/execdriver/lxc/lxc_template.go
+++ b/daemon/execdriver/lxc/lxc_template.go
@@ -160,7 +160,46 @@ lxc.cap.drop = {{.}}
 {{end}}
 `
 
+const LxcInitTemplate =  `
+lxc.include = /usr/share/lxc/config/ubuntu.common.conf
+
+{{if .Network.Interface}}
+# network configuration
+lxc.network.type = veth
+lxc.network.link = lxcbr0
+lxc.network.name = eth0
+lxc.network.flags = up
+{{else if .Network.HostNetworking}}
+lxc.network.type = none
+{{else}}
+# network is disabled (-n=false)
+lxc.network.type = empty
+lxc.network.flags = up
+lxc.network.mtu = {{.Network.Mtu}}
+{{end}}
+
+# root filesystem
+{{$ROOTFS := .Rootfs}}
+lxc.rootfs = {{$ROOTFS}}
+
+# use a dedicated pts for the container (and limit the number of pseudo terminal
+# available)
+lxc.pts = 1024
+
+# disable the main console
+# lxc.console = none
+
+# no controlling tty at all
+lxc.tty = 1
+
+
+{{if .ProcessConfig.Env}}
+lxc.utsname = {{getHostname .ProcessConfig.Env}}
+{{end}}
+`
+
 var lxcTemplateCompiled *template.Template
+var InitTemplateCompiled *template.Template
 
 // Escape spaces in strings according to the fstab documentation, which is the
 // format for "lxc.mount.entry" lines in lxc.conf. See also "man 5 fstab".
@@ -257,6 +296,7 @@ func init() {
 		"getHostname":       getHostname,
 	}
 	lxcTemplateCompiled, err = template.New("lxc").Funcs(funcMap).Parse(LxcTemplate)
+	InitTemplateCompiled, err = template.New("lxc").Funcs(funcMap).Parse(LxcInitTemplate)
 	if err != nil {
 		panic(err)
 	}

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -156,7 +156,7 @@ type Config struct {
 	MacAddress      string                // Mac Address of the container
 	OnBuild         []string              // ONBUILD metadata that were defined on the image Dockerfile
 	Labels          map[string]string     // List of labels set to this container
-	Init			bool					//if start  in init mode in lxc driver.
+	Init            bool                  //if start  in init mode in lxc driver.
 }
 
 // ContainerConfigWrapper is a Config wrapper that hold the container Config (portable)

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -156,6 +156,7 @@ type Config struct {
 	MacAddress      string                // Mac Address of the container
 	OnBuild         []string              // ONBUILD metadata that were defined on the image Dockerfile
 	Labels          map[string]string     // List of labels set to this container
+	Init			bool					//if start  in init mode in lxc driver.
 }
 
 // ContainerConfigWrapper is a Config wrapper that hold the container Config (portable)


### PR DESCRIPTION
Add  --init opts for lxc driver to start sbin/init ,Your can start /sbin/init with --init opts in lxc driver.  Fix #15477 

Signed-off-by: dancewhale caoyuanzhi@kylinos.cn
