### PR TITLE
Windows: Stop commit on running container

### DIFF
--- a/builder/job.go
+++ b/builder/job.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -277,6 +278,11 @@ func Commit(name string, d *daemon.Daemon, c *CommitConfig) (string, error) {
 	container, err := d.Get(name)
 	if err != nil {
 		return "", err
+	}
+
+	// It is not possible to commit a running container on Windows
+	if runtime.GOOS == "windows" && container.IsRunning() {
+		return "", fmt.Errorf("Windows does not support commit of a running container")
 	}
 
 	if c.Config == nil {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli. Windows does not support committing a running container. This PR ensures that the user gets a nice error message. Without it, they get the following which is not very friendly :)

E:\go\src\github.com\docker\docker\docker>docker commit --author=john test
Error response from daemon: hcsshim::ExportLayer - Win32 API call returned error r1=2147549183 err=Catastrophic failure layerId=a7da0ac52b8d5f294cd8d455a40529745b823485d092d236f2d38cc45dcfe163 flavour=1 folder=C:\ProgramData\docker\windowsfilter\a7da0ac52b8d5f294cd8d455a40529745b823485d092d236f2d38cc45dcfe163-3964816900
