### PR TITLE
AppArmor: Deny w to /proc/* files

### DIFF
--- a/daemon/execdriver/native/apparmor.go
+++ b/daemon/execdriver/native/apparmor.go
@@ -40,14 +40,11 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   file,
   umount,
 
-  deny @{PROC}/sys/fs/** wklx,
-  deny @{PROC}/fs/** wklx,
+  deny @{PROC}/{*,**^[0-9*],sys/kernel/shm*} wkx,
   deny @{PROC}/sysrq-trigger rwklx,
   deny @{PROC}/mem rwklx,
   deny @{PROC}/kmem rwklx,
   deny @{PROC}/kcore rwklx,
-  deny @{PROC}/sys/kernel/[^s][^h][^m]* wklx,
-  deny @{PROC}/sys/kernel/*/** wklx,
 
   deny mount,
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -2811,6 +2811,18 @@ func (s *DockerSuite) TestAppArmorTraceSelf(c *check.C) {
 	}
 }
 
+func (s *DockerSuite) TestAppArmorDeniesChmodProc(c *check.C) {
+	testRequires(c, SameHostDaemon, NativeExecDriver, Apparmor)
+	_, exitCode, _ := dockerCmdWithError("run", "busybox", "chmod", "744", "/proc/cpuinfo")
+	if exitCode == 0 {
+		// If our test failed, attempt to repair the host system...
+		_, exitCode, _ := dockerCmdWithError("run", "busybox", "chmod", "444", "/proc/cpuinfo")
+		if exitCode == 0 {
+			c.Fatal("AppArmor was unsuccessful in prohibiting chmod of /proc/* files.")
+		}
+	}
+}
+
 func (s *DockerSuite) TestRunCapAddSYSTIME(c *check.C) {
 	testRequires(c, NativeExecDriver)
 


### PR DESCRIPTION
Introduce a write denial for files at the root of /proc.

This prohibits root users from performing a chmod of those
files. The rules for denials in proc are also cleaned up,
making the rules better match their targets.

Locally tested on:
- Ubuntu precise (12.04) with AppArmor 2.7
- Ubuntu trusty (14.04) with AppArmor 2.8.95

Signed-off-by: Eric Windisch eric@windisch.us
