### PR TITLE
Fixing race condition on private key backup how-to

### DIFF
--- a/docs/security/trust/trust_key_mng.md
+++ b/docs/security/trust/trust_key_mng.md
@@ -45,8 +45,7 @@ The Docker client stores the keys in the `~/.docker/trust/private` directory.
 Before backing them up, you should `tar` them into an archive:
 
 ```bash
-$ tar -zcvf private_keys_backup.tar.gz ~/.docker/trust/private
-$ chmod 600 private_keys_backup.tar.gz
+$ umask 077; tar -zcvf private_keys_backup.tar.gz ~/.docker/trust/private; umask 022
 ```
 
 ## Lost keys


### PR DESCRIPTION
Even though all private keys are always encrypted at rest we should fix this race condition between creating the tar and changing the perms.

Signed-off-by: Diogo Monica diogo@docker.com
