### PR TITLE
Fix api/containers/commit calling builder.Commit

### DIFF
--- a/api/server/image.go
+++ b/api/server/image.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/graph"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/parsers"
@@ -43,23 +44,22 @@ func (s *Server) postCommit(version version.Version, w http.ResponseWriter, r *h
 		return err
 	}
 
-	commitCfg := &builder.CommitConfig{
+	commitCfg := &daemon.ContainerCommitConfig{
 		Pause:   pause,
 		Repo:    r.Form.Get("repo"),
 		Tag:     r.Form.Get("tag"),
 		Author:  r.Form.Get("author"),
 		Comment: r.Form.Get("comment"),
-		Changes: r.Form["changes"],
 		Config:  c,
 	}
 
-	imgID, err := builder.Commit(cname, s.daemon, commitCfg)
+	img, err := s.daemon.Commit(cname, commitCfg)
 	if err != nil {
 		return err
 	}
 
 	return writeJSON(w, http.StatusCreated, &types.ContainerCommitResponse{
-		ID: imgID,
+		ID: img.ID,
 	})
 }
 

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -109,10 +109,6 @@ func (b *builder) commit(id string, autoCmd *runconfig.Command, comment string) 
 		}
 		defer container.Unmount()
 	}
-	container, err := b.Daemon.Get(id)
-	if err != nil {
-		return err
-	}
 
 	// Note: Actually copy the struct
 	autoConfig := *b.Config
@@ -125,7 +121,7 @@ func (b *builder) commit(id string, autoCmd *runconfig.Command, comment string) 
 	}
 
 	// Commit the container
-	image, err := b.Daemon.Commit(container, commitCfg)
+	image, err := b.Daemon.Commit(id, commitCfg)
 	if err != nil {
 		return err
 	}

--- a/builder/job.go
+++ b/builder/job.go
@@ -272,43 +272,6 @@ type CommitConfig struct {
 	Config  *runconfig.Config
 }
 
-// Commit will create a new image from a container's changes
-func Commit(name string, d *daemon.Daemon, c *CommitConfig) (string, error) {
-	container, err := d.Get(name)
-	if err != nil {
-		return "", err
-	}
-
-	if c.Config == nil {
-		c.Config = &runconfig.Config{}
-	}
-
-	newConfig, err := BuildFromConfig(d, c.Config, c.Changes)
-	if err != nil {
-		return "", err
-	}
-
-	if err := runconfig.Merge(newConfig, container.Config); err != nil {
-		return "", err
-	}
-
-	commitCfg := &daemon.ContainerCommitConfig{
-		Pause:   c.Pause,
-		Repo:    c.Repo,
-		Tag:     c.Tag,
-		Author:  c.Author,
-		Comment: c.Comment,
-		Config:  newConfig,
-	}
-
-	img, err := d.Commit(container, commitCfg)
-	if err != nil {
-		return "", err
-	}
-
-	return img.ID, nil
-}
-
 // inspectResponse looks into the http response data at r to determine whether its
 // content-type is on the list of acceptable content types for remote build contexts.
 // This function returns:

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -16,7 +16,11 @@ type ContainerCommitConfig struct {
 
 // Commit creates a new filesystem image from the current state of a container.
 // The image can optionally be tagged into a repository
-func (daemon *Daemon) Commit(container *Container, c *ContainerCommitConfig) (*image.Image, error) {
+func (daemon *Daemon) Commit(name string, c *ContainerCommitConfig) (*image.Image, error) {
+	container, err := daemon.Get(name)
+	if err != nil {
+		return nil, err
+	}
 	if c.Pause && !container.IsPaused() {
 		container.Pause()
 		defer container.Unpause()

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -1,6 +1,9 @@
 package daemon
 
 import (
+	"fmt"
+	"runtime"
+
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/runconfig"
 )
@@ -21,6 +24,13 @@ func (daemon *Daemon) Commit(name string, c *ContainerCommitConfig) (*image.Imag
 	if err != nil {
 		return nil, err
 	}
+
+	if runtime.GOOS == "windows" {
+		if container.IsRunning() {
+			return nil, fmt.Errorf("Windows does not support commit of a running container")
+		}
+	}
+
 	if c.Pause && !container.IsPaused() {
 		container.Pause()
 		defer container.Unpause()


### PR DESCRIPTION
This API is not a builder API and shouldn't be calling it.
Furthermore, the builder's own commit call was calling daemon.Commit and
nothing else was using builder.Commit other than api/containers/commit
