### PR TITLE
add INSECURE_REGISTRY to docker.service systemd config

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -6,7 +6,8 @@ Requires=docker.socket
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/docker daemon -H fd://
+EnvironmentFile=-/etc/sysconfig/docker
+ExecStart=/usr/bin/docker daemon -H fd:// $INSECURE_REGISTRY
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
Add INSECURE_REGISTRY setting to docker.service systemd config. Addresses issue #15590. This will allow docker to link to an insecure registry without having to override the RPMs service file or duplicate service startup.
