### PR TITLE
Proxy graph driver and proxydaemon

### DIFF
--- a/daemon/daemon_proxy.go
+++ b/daemon/daemon_proxy.go
@@ -1,0 +1,47 @@
+// +build linux
+
+package daemon
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/daemon/graphdriver"
+	_ "github.com/docker/docker/daemon/graphdriver/proxy"
+	"github.com/docker/docker/pkg/mflag"
+	"net"
+	"net/http"
+	"net/rpc"
+	"strings"
+)
+
+type ProxyConfig struct {
+	Root      string
+	CtName    string
+	ProtoAddr string
+}
+
+func (config *ProxyConfig) InstallProxyFlags(cmd *mflag.FlagSet, usageFn func(string) string) {
+	cmd.StringVar(&config.Root, []string{"R", "-root"}, defaultGraph, usageFn("Root of container runtime"))
+	cmd.StringVar(&config.CtName, []string{"C", "-ctname"}, "", usageFn("Container we work for"))
+	cmd.StringVar(&config.ProtoAddr, []string{"S", "-sockname"}, "", usageFn("Socket to listen"))
+}
+
+func StartProxyDaemon(config *ProxyConfig, cli *cli.Cli) {
+	p := new(graphdriver.ProxyAPI)
+	p.Root = config.Root
+	p.CtName = config.CtName
+	p.Cli = cli
+
+	if p.CtName == "" || config.ProtoAddr == "" {
+		logrus.Fatal("set both \"ctname\" and \"sockname\"")
+	}
+
+	rpc.Register(p)
+	rpc.HandleHTTP()
+	protoAddrParts := strings.SplitN(config.ProtoAddr, "://", 2)
+	l, e := net.Listen(protoAddrParts[0], protoAddrParts[1])
+	if e != nil {
+		logrus.Fatal("listen error:", e)
+	}
+	http.Serve(l, nil)
+}

--- a/daemon/daemon_proxy_unsupported.go
+++ b/daemon/daemon_proxy_unsupported.go
@@ -1,0 +1,21 @@
+// +build !linux
+
+package daemon
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/cli"
+	"github.com/docker/docker/pkg/mflag"
+)
+
+type ProxyConfig struct {
+	dummy bool
+}
+
+func (config *ProxyConfig) InstallProxyFlags(cmd *mflag.FlagSet, usageFn func(string) string) {
+	cmd.BoolVar(&config.dummy, []string{"dummy"}, true, usageFn("dummy"))
+}
+
+func StartProxyDaemon(config *ProxyConfig, cli *cli.Cli) {
+	logrus.Fatal("Unsupported platform")
+}

--- a/daemon/exec.go
+++ b/daemon/exec.go
@@ -152,6 +152,7 @@ func (d *Daemon) ContainerExecCreate(config *runconfig.ExecConfig) (string, erro
 		Entrypoint: entrypoint,
 		Arguments:  args,
 		User:       user,
+		Syscall:    config.Syscall,
 	}
 
 	execConfig := &execConfig{

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -167,6 +167,7 @@ type ProcessConfig struct {
 	Terminal    Terminal `json:"-"` // standard or tty terminal
 	Console     string   `json:"-"` // dev/console path
 	ConsoleSize [2]int   `json:"-"` // h,w of initial console size
+	Syscall     bool     `json:"syscall"`
 }
 
 // Command wrapps an os/exec.Cmd to add more metadata

--- a/daemon/execdriver/native/exec.go
+++ b/daemon/execdriver/native/exec.go
@@ -27,10 +27,15 @@ func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 	}
 
 	p := &libcontainer.Process{
-		Args: append([]string{processConfig.Entrypoint}, processConfig.Arguments...),
-		Env:  c.ProcessConfig.Env,
-		Cwd:  c.WorkingDir,
-		User: processConfig.User,
+		Args:    append([]string{processConfig.Entrypoint}, processConfig.Arguments...),
+		Env:     c.ProcessConfig.Env,
+		Cwd:     c.WorkingDir,
+		User:    processConfig.User,
+		Syscall: processConfig.Syscall,
+	}
+
+	if processConfig.Syscall {
+		p.Capabilities = execdriver.GetAllCapabilities()
 	}
 
 	config := active.Config()

--- a/daemon/graphdriver/proxy.go
+++ b/daemon/graphdriver/proxy.go
@@ -1,0 +1,303 @@
+// +build linux
+
+package graphdriver
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/docker/docker/cli"
+	"io"
+	"os"
+	"path"
+	"strings"
+	"syscall"
+)
+
+type ProxyAPI struct {
+	driver Driver
+	Root   string
+	CtName string
+	Cli    *cli.Cli
+	mounts map[string]string
+}
+
+////////////// Init ////////////////
+
+type InitArgs struct {
+	DriverName string
+	Home       string
+	Options    []string
+}
+
+type InitReply struct{}
+
+func (p *ProxyAPI) Init(args *InitArgs, reply *InitReply) error {
+	var err error
+	p.mounts = make(map[string]string)
+
+	if err := os.MkdirAll(p.Root+args.Home, 0755); err != nil {
+		return err
+	}
+
+	err = p.Cli.Run("exec", "-s", p.CtName, "mkdir", args.Home)
+	if err != nil {
+		return err
+	}
+	err = p.Cli.Run("exec", "-s", p.CtName, "mkdir", args.Home+"/"+args.DriverName)
+	if err != nil {
+		return err
+	}
+	err = p.Cli.Run("exec", "-s", p.CtName, "mkdir", args.Home+"/"+args.DriverName+"/mnt")
+	if err != nil {
+		return err
+	}
+
+	p.driver, err = GetDriver(args.DriverName, p.Root+args.Home, args.Options)
+	*reply = InitReply{}
+	return err
+}
+
+////////////// Status ////////////////
+
+type StatusArgs struct{}
+
+type StatusReply struct {
+	Status [][2]string
+}
+
+func (p *ProxyAPI) Status(args *StatusArgs, reply *StatusReply) error {
+	if p.driver == nil {
+		return fmt.Errorf("driver not initialized")
+	}
+
+	*reply = StatusReply{p.driver.Status()}
+	return nil
+}
+
+////////////// Create ////////////////
+
+type CreateArgs struct {
+	Id, Parent string
+}
+
+type CreateReply struct{}
+
+func (p *ProxyAPI) Create(args *CreateArgs, reply *CreateReply) error {
+	if p.driver == nil {
+		return fmt.Errorf("driver not initialized")
+	}
+
+	*reply = CreateReply{}
+	return p.driver.Create(args.Id, args.Parent)
+}
+
+////////////// Remove ////////////////
+
+type RemoveArgs struct {
+	Id string
+}
+
+type RemoveReply struct{}
+
+func (p *ProxyAPI) Remove(args *RemoveArgs, reply *RemoveReply) error {
+	if p.driver == nil {
+		return fmt.Errorf("driver not initialized")
+	}
+
+	*reply = RemoveReply{}
+	return p.driver.Remove(args.Id)
+}
+
+////////////// Get ////////////////
+
+type GetArgs struct {
+	Id, MountLabel string
+}
+
+type GetReply struct {
+	Dir string
+}
+
+func (p *ProxyAPI) Get(args *GetArgs, reply *GetReply) error {
+	if p.driver == nil {
+		return fmt.Errorf("driver not initialized")
+	}
+
+	pth, err := p.driver.Get(args.Id, args.MountLabel)
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasPrefix(pth, p.Root) {
+		p.driver.Put(args.Id)
+		return fmt.Errorf("Get(%s) returned path=%s without prefix=%s", args.Id, pth, p.Root)
+	}
+	client_path := strings.TrimPrefix(pth, p.Root)
+
+	var client_mp string
+	dev, mp, err := get_mount_point(pth, p.Root)
+	if err != nil {
+		goto Error
+	}
+	client_mp = strings.TrimPrefix(mp, p.Root)
+
+	err = p.Cli.Run("exec", "-s", p.CtName, "mkdir", client_mp)
+	if err != nil {
+		goto Error
+	}
+	err = p.Cli.Run("exec", "-s", p.CtName, "mount", "-t", "ext4", dev, client_mp)
+	if err != nil {
+		goto Error
+	}
+	p.mounts[args.Id] = client_mp
+
+	*reply = GetReply{client_path}
+	return nil
+
+Error:
+	p.driver.Put(args.Id)
+	return err
+}
+
+////////////// Put ////////////////
+
+type PutArgs struct {
+	Id string
+}
+
+type PutReply struct{}
+
+func (p *ProxyAPI) Put(args *PutArgs, reply *PutReply) error {
+	if p.driver == nil {
+		return fmt.Errorf("driver not initialized")
+	}
+
+	if _, ok := p.mounts[args.Id]; !ok {
+		return fmt.Errorf("ProxyAPI.Put mounts[%s] not exists", args.Id)
+	}
+
+	err := p.Cli.Run("exec", "-s", p.CtName, "umount", p.mounts[args.Id])
+	if err != nil {
+		fmt.Println("ProxyAPI.Put dock-umount error:", err)
+		return err
+	}
+	delete(p.mounts, args.Id)
+
+	p.driver.Put(args.Id)
+	*reply = PutReply{}
+	return nil
+}
+
+////////////// Exists ////////////////
+
+type ExistsArgs struct {
+	Id string
+}
+
+type ExistsReply struct {
+	Exists bool
+}
+
+func (p *ProxyAPI) Exists(args *ExistsArgs, reply *ExistsReply) error {
+	if p.driver == nil {
+		return fmt.Errorf("driver not initialized")
+	}
+
+	*reply = ExistsReply{p.driver.Exists(args.Id)}
+	return nil
+}
+
+////////////// Cleanup ////////////////
+
+type CleanupArgs struct{}
+
+type CleanupReply struct{}
+
+func (p *ProxyAPI) Cleanup(args *CleanupArgs, reply *CleanupReply) error {
+	if p.driver == nil {
+		return fmt.Errorf("driver not initialized")
+	}
+
+	*reply = CleanupReply{}
+	return p.driver.Cleanup()
+}
+
+////////////// GetMetadata ////////////////
+
+type GetMetadataArgs struct {
+	Id string
+}
+
+type GetMetadataReply struct {
+	MInfo map[string]string
+}
+
+func (p *ProxyAPI) GetMetadata(args *GetMetadataArgs, reply *GetMetadataReply) error {
+	if p.driver == nil {
+		return fmt.Errorf("driver not initialized")
+	}
+
+	minfo, err := p.driver.GetMetadata(args.Id)
+	if err != nil {
+		return err
+	}
+
+	*reply = GetMetadataReply{minfo}
+	return nil
+}
+
+////////////// a helper for Get ////////////////
+
+func get_mount_point(pth, root string) (dev, mp string, err error) {
+	dir := path.Dir(pth)
+
+	for {
+		s1 := syscall.Stat_t{}
+		err = syscall.Stat(pth, &s1)
+		if err != nil {
+			return
+		}
+
+		s2 := syscall.Stat_t{}
+		err = syscall.Stat(dir, &s2)
+		if err != nil {
+			return
+		}
+
+		if s1.Dev != s2.Dev {
+			mp = pth
+			break
+		}
+
+		if dir == root || !strings.HasPrefix(dir, root) {
+			err = fmt.Errorf("Cannot find mount point: path=%s root=%s dir=%s", pth, root, dir)
+			return
+		}
+
+		pth = dir
+		dir = path.Dir(pth)
+	}
+
+	mtab, err := os.Open("/etc/mtab")
+	if err != nil {
+		return
+	}
+	defer mtab.Close()
+
+	r := bufio.NewReader(mtab)
+	for {
+		var line []byte
+		line, _, err = r.ReadLine()
+		if err != nil {
+			if err == io.EOF {
+				err = fmt.Errorf("Cannot find device for path=%s", mp)
+			}
+			return
+		}
+		fields := strings.Fields(string(line))
+		if len(fields) > 1 && fields[1] == mp {
+			dev = fields[0]
+			return
+		}
+	}
+}

--- a/daemon/graphdriver/proxy/README.md
+++ b/daemon/graphdriver/proxy/README.md
@@ -1,0 +1,74 @@
+## proxy - a storage backend transparently redirecting all requests to another backend
+
+### Rationale
+
+It would be nice to run docker inside a container, but a docker graphdriver
+sometimes need access to critical system-wide resources. For example,
+devicemapper need access to /dev/loop and /dev/mapper/control, and it wants
+to format and mount ext4 filesystems over devmapper devices.
+
+Also, the superuser of container may mistakenly or maliciously modify the
+content of raw devices that inner filesystem and dm-thin target works on.
+Such modifications may havoc the whole host system and cannot be easily
+isolated as per-container errors.
+
+### Solution
+
+Run a docker daemon in proxy mode on host system (outside container). It
+listens on a unix socket (accessible from inside container) for commands from
+a docker daemon running inside container. These command set is exactly docker
+graphdriver API wrapped in the go net/rpc.
+
+Then run a docker daemon on top of proxy graphdriver inside container. The
+proxy graphdriver gets the address of remote server (i.e. host docker daemon
+in proxy mode) via "--storage-opt" options interface and connects to the server
+on startup. Then it transparently passes all incoming requests (in the form of
+graphdriver API) to the docker daemon in proxy mode on host system.
+
+The latter processes incoming Init request intelligently while passing all
+other requests transparently to the actual graphdriver.
+
+Such an approach factors out potentially dangerous operations to the trusted
+host environment (assuming that container superuser cannot modify binaries on
+host system) and also allow to keep per-container docker graphdriver files in
+a protected area dedicated to the container.
+
+### Step-by-step example
+
+The example assumes that the docker daemon is already running on the host
+system and a docker development container was started by:
+
+``docker run --privileged --rm --name devcon -ti -v /root/repos/docker-fork:/go/src/github.com/docker/docker devcon-image /bin/bash``
+
+Then, on the host system:
+
+``docker proxydaemon -R /protected -C devcon -S unix:///root/repos/docker-fork/sock``
+
+The command ``proxydaemon`` means start daemon in proxy mode.
+
+Here ``-R /protected`` specifies the prefix to be added to Init request. So, if
+the container user requested `/var/lib/docker` as the home of docker files, the
+host system will actually keep them in `/protected/var/lib/docker`.
+
+``-C devcon`` specifies the name of container (`devcon`) that
+given instance of proxy daemon works for.
+
+``-S host=unix:///root/repos/docker-fork/sock`` specifies the path
+to the unix socket for daemon-to-daemon communication. It must be visible
+from inside container.
+
+Secondly, inside container:
+
+``docker daemon -s proxy --storage-opt graphdriver=devicemapper --storage-opt proxyserver=unix:///go/src/github.com/docker/docker/sock``
+
+Here ``-s proxy`` forces using proxy graphdriver. ``--storage-opt`` passes next
+argument as an option for graphdriver. ``graphdriver=devicemapper`` specifies
+graphdriver to use on remote side (on the host system) and
+``proxyserver=unix:///go/src/github.com/docker/docker/sock`` specifies the path
+to communication unix socket. Of course, this must strictly match to the
+unix-socket path set for host docker daemon in proxy mode.
+
+Since now, a person can run all variety of ``docker run/pull/etc ...`` inside
+`devcon` container. The communication path to the host graphdriver must work
+transparently for the person. In the other words, the presence of the proxy server
+must be invisible for docker client inside container.

--- a/daemon/graphdriver/proxy/driver.go
+++ b/daemon/graphdriver/proxy/driver.go
@@ -1,0 +1,172 @@
+// +build linux
+
+package proxy
+
+import (
+	"fmt"
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/pkg/parsers"
+	"net/rpc"
+	"strings"
+)
+
+func init() {
+	graphdriver.Register("proxy", Init)
+}
+
+type Driver struct {
+	client *rpc.Client
+	home   string
+}
+
+func Init(home string, input_options []string) (graphdriver.Driver, error) {
+	var options []string = make([]string, 0)
+	var protoAddrParts []string = make([]string, 2)
+	var graphDriver string
+
+	foundProxyServer := false
+	foundGraphDriver := false
+	for _, option := range input_options {
+		key, val, err := parsers.ParseKeyValueOpt(option)
+		if err != nil {
+			options = append(options, option)
+			continue
+		}
+		key = strings.ToLower(key)
+		switch key {
+		case "proxyserver":
+			protoAddrParts = strings.SplitN(val, "://", 2)
+			foundProxyServer = true
+		case "graphdriver":
+			graphDriver = val
+			foundGraphDriver = true
+		default:
+			options = append(options, option)
+		}
+	}
+
+	if !foundProxyServer {
+		return nil, fmt.Errorf("proxyserver not specified")
+	}
+
+	if !foundGraphDriver {
+		logrus.Infof("Init: graphdriver not specified, using devicemapper")
+		graphDriver = "devicemapper"
+	}
+
+	client, err := rpc.DialHTTP(protoAddrParts[0], protoAddrParts[1])
+	if err != nil {
+		logrus.Errorf("dialing: %s", err)
+		return nil, err
+	}
+
+	args := &graphdriver.InitArgs{graphDriver, home, options}
+	var reply graphdriver.InitReply
+
+	err = client.Call("ProxyAPI.Init", &args, &reply)
+	if err != nil {
+		logrus.Errorf("ProxyAPI.Init: %s", err)
+		return nil, err
+	}
+
+	d := &Driver{
+		client: client,
+		home:   home,
+	}
+
+	return graphdriver.NaiveDiffDriver(d), nil
+}
+
+func (d *Driver) String() string {
+	return "proxy"
+}
+
+func (d *Driver) Status() [][2]string {
+	args := &graphdriver.StatusArgs{}
+	var reply graphdriver.StatusReply
+
+	err := d.client.Call("ProxyAPI.Status", &args, &reply)
+	if err != nil {
+		logrus.Errorf("ProxyAPI.Status: %s", err)
+		return nil
+	}
+	return reply.Status
+}
+
+func (d *Driver) Cleanup() error {
+	args := &graphdriver.CleanupArgs{}
+	var reply graphdriver.CleanupReply
+
+	err := d.client.Call("ProxyAPI.Cleanup", &args, &reply)
+	if err != nil {
+		logrus.Errorf("ProxyAPI.Cleanup: %s", err)
+	}
+	return err
+}
+
+func (d *Driver) Create(id, parent string) error {
+	args := &graphdriver.CreateArgs{id, parent}
+	var reply graphdriver.CreateReply
+
+	err := d.client.Call("ProxyAPI.Create", &args, &reply)
+	if err != nil {
+		logrus.Errorf("ProxyAPI.Create: %s", err)
+	}
+	return err
+}
+
+func (d *Driver) Remove(id string) error {
+	args := &graphdriver.RemoveArgs{id}
+	var reply graphdriver.RemoveReply
+
+	err := d.client.Call("ProxyAPI.Remove", &args, &reply)
+	if err != nil {
+		logrus.Errorf("ProxyAPI.Remove: %s", err)
+	}
+	return err
+}
+
+func (d *Driver) Get(id, mountLabel string) (string, error) {
+	args := &graphdriver.GetArgs{id, mountLabel}
+	var reply graphdriver.GetReply
+
+	err := d.client.Call("ProxyAPI.Get", &args, &reply)
+	if err != nil {
+		logrus.Errorf("ProxyAPI.Get: %s", err)
+	}
+	return reply.Dir, err
+}
+
+func (d *Driver) Put(id string) error {
+	args := &graphdriver.PutArgs{id}
+	var reply graphdriver.PutReply
+
+	err := d.client.Call("ProxyAPI.Put", &args, &reply)
+	if err != nil {
+		logrus.Errorf("ProxyAPI.Put: %s", err)
+	}
+	return err
+}
+
+func (d *Driver) Exists(id string) bool {
+	args := &graphdriver.ExistsArgs{id}
+	var reply graphdriver.ExistsReply
+
+	err := d.client.Call("ProxyAPI.Exists", &args, &reply)
+	if err != nil {
+		logrus.Errorf("ProxyAPI.Exists: %s", err)
+	}
+	return reply.Exists
+}
+
+func (d *Driver) GetMetadata(id string) (map[string]string, error) {
+	args := &graphdriver.GetMetadataArgs{id}
+	var reply graphdriver.GetMetadataReply
+
+	err := d.client.Call("ProxyAPI.GetMetadata", &args, &reply)
+	if err != nil {
+		logrus.Errorf("ProxyAPI.GetMetadata: %s", err)
+	}
+	return reply.MInfo, err
+}

--- a/docker/common.go
+++ b/docker/common.go
@@ -22,6 +22,7 @@ const (
 
 var (
 	daemonFlags *flag.FlagSet
+	proxyFlags  *flag.FlagSet
 	commonFlags = &cli.CommonFlags{FlagSet: new(flag.FlagSet)}
 
 	dockerCertPath  = os.Getenv("DOCKER_CERT_PATH")

--- a/docker/daemon_none.go
+++ b/docker/daemon_none.go
@@ -7,6 +7,7 @@ import "github.com/docker/docker/cli"
 const daemonUsage = ""
 
 var daemonCli cli.Handler
+var proxyCli cli.Handler
 
 // TODO: remove once `-d` is retired
 func handleGlobalDaemonFlag() {}

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -61,7 +61,7 @@ func main() {
 		return
 	}
 
-	c := cli.New(clientCli, daemonCli)
+	c := cli.New(clientCli, daemonCli, proxyCli)
 	if err := c.Run(flag.Args()...); err != nil {
 		if sterr, ok := err.(cli.StatusError); ok {
 			if sterr.Status != "" {

--- a/runconfig/exec.go
+++ b/runconfig/exec.go
@@ -15,6 +15,7 @@ type ExecConfig struct {
 	AttachStderr bool     // Attach the standard output
 	AttachStdout bool     // Attach the standard error
 	Detach       bool     // Execute in detach mode
+	Syscall      bool     // Interpret command as syscall
 	Cmd          []string // Execution commands and args
 }
 
@@ -28,6 +29,7 @@ func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 		flTty     = cmd.Bool([]string{"t", "-tty"}, false, "Allocate a pseudo-TTY")
 		flDetach  = cmd.Bool([]string{"d", "-detach"}, false, "Detached mode: run command in the background")
 		flUser    = cmd.String([]string{"u", "-user"}, "", "Username or UID (format: <name|uid>[:<group|gid>])")
+		flSyscall = cmd.Bool([]string{"s", "-syscall"}, false, "Syscall mode: interpret command as syscall name")
 		execCmd   []string
 		container string
 	)
@@ -47,6 +49,7 @@ func ParseExec(cmd *flag.FlagSet, args []string) (*ExecConfig, error) {
 		Cmd:       execCmd,
 		Container: container,
 		Detach:    *flDetach,
+		Syscall:   *flSyscall,
 	}
 
 	// If -d is not set, attach to everything by default

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/init_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/init_linux.go
@@ -50,6 +50,7 @@ type initConfig struct {
 	Console          string          `json:"console"`
 	Networks         []*network      `json:"network"`
 	PassedFilesCount int             `json:"passed_files_count"`
+	Syscall          bool            `json:"syscall"` // interpret Args as syscall
 }
 
 type initer interface {

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/process.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/process.go
@@ -49,6 +49,9 @@ type Process struct {
 	Capabilities []string
 
 	ops processOperations
+
+	// Interpret Args as syscall
+	Syscall bool
 }
 
 // Wait waits for the process to exit.

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/setns_init_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/setns_init_linux.go
@@ -3,7 +3,9 @@
 package libcontainer
 
 import (
+	"fmt"
 	"os"
+	"syscall"
 
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/label"
@@ -31,5 +33,55 @@ func (l *linuxSetnsInit) Init() error {
 			return err
 		}
 	}
-	return system.Execv(l.config.Args[0], l.config.Args[0:], os.Environ())
+
+	args := l.config.Args
+
+	if !l.config.Syscall {
+		return system.Execv(args[0], args[0:], os.Environ())
+	}
+
+	switch args[0] {
+	case "mount":
+		// args: mount -t <type> /dev/<device> <mount_point>
+		if len(args) != 5 || args[1] != "-t" {
+			return fmt.Errorf("syscall invalid format: %v", args)
+		}
+		fstype := args[2]
+		devname := args[3]
+		path := args[4]
+		if err := syscall.Mount(devname, path, fstype, syscall.MS_MGC_VAL, ""); err != nil {
+			return err
+		}
+	case "umount":
+		// args: umount <mount_point>
+		if len(l.config.Args) != 2 {
+			return fmt.Errorf("syscall invalid format: %v", args)
+		}
+		path := args[1]
+		if err := syscall.Unmount(path, syscall.MNT_DETACH); err != nil {
+			return err
+		}
+	case "mkdir":
+		// args: mkdir <path>
+		if len(l.config.Args) != 2 {
+			return fmt.Errorf("syscall invalid format: %v", args)
+		}
+		path := args[1]
+
+		st := syscall.Stat_t{}
+		err := syscall.Stat(path, &st)
+		if err == nil && st.Mode&syscall.S_IFDIR != 0 {
+			break
+		}
+
+		var mode uint32 = syscall.S_IRUSR | syscall.S_IWUSR | syscall.S_IXUSR
+		if err = syscall.Mkdir(path, mode); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("syscall %s is not implemented", args[0])
+	}
+
+	syscall.Exit(0)
+	panic("unreachable")
 }


### PR DESCRIPTION
## proxy - a storage backend transparently redirecting all requests to another backend
### Rationale

It would be nice to run docker inside a container, but a docker graphdriver
sometimes need access to critical system-wide resources. For example,
devicemapper need access to /dev/loop and /dev/mapper/control, and it wants
to format and mount ext4 filesystems over devmapper devices.

Also, the superuser of container may mistakenly or maliciously modify the
content of raw devices that inner filesystem and dm-thin target works on.
Such modifications may havoc the whole host system and cannot be easily
isolated as per-container errors.
### Solution

Run a docker daemon in proxy mode on host system (outside container). It
listens on a unix socket (accessible from inside container) for commands from
a docker daemon running inside container. These command set is exactly docker
graphdriver API wrapped in the go net/rpc.

Then run a docker daemon on top of proxy graphdriver inside container. The
proxy graphdriver gets the address of remote server (i.e. host docker daemon
in proxy mode) via "--storage-opt" options interface and connects to the server
on startup. Then it transparently passes all incoming requests (in the form of
graphdriver API) to the docker daemon in proxy mode on host system.

The latter processes incoming Init request intelligently while passing all
other requests transparently to the actual graphdriver.

Such an approach factors out potentially dangerous operations to the trusted
host environment (assuming that container superuser cannot modify binaries on
host system) and also allow to keep per-container docker graphdriver files in
a protected area dedicated to the container.
### Step-by-step example

The example assumes that the docker daemon is already running on the host
system and a docker development container was started by:

`docker run --privileged --rm --name devcon -ti -v /root/repos/docker-fork:/go/src/github.com/docker/docker devcon-image /bin/bash`

Then, on the host system:

`docker proxydaemon -R /protected -C devcon -S unix:///root/repos/docker-fork/sock`

The command `proxydaemon` means start daemon in proxy mode.

Here `-R /protected` specifies the prefix to be added to Init request. So, if
the container user requested `/var/lib/docker` as the home of docker files, the
host system will actually keep them in `/protected/var/lib/docker`.

`-C devcon` specifies the name of container (`devcon`) that
given instance of proxy daemon works for.

`-S host=unix:///root/repos/docker-fork/sock` specifies the path
to the unix socket for daemon-to-daemon communication. It must be visible
from inside container.

Secondly, inside container:

`docker daemon -s proxy --storage-opt graphdriver=devicemapper --storage-opt proxyserver=unix:///go/src/github.com/docker/docker/sock`

Here `-s proxy` forces using proxy graphdriver. `--storage-opt` passes next
argument as an option for graphdriver. `graphdriver=devicemapper` specifies
graphdriver to use on remote side (on the host system) and
`proxyserver=unix:///go/src/github.com/docker/docker/sock` specifies the path
to communication unix socket. Of course, this must strictly match to the
unix-socket path set for host docker daemon in proxy mode.

Since now, a person can run all variety of `docker run/pull/etc ...` inside
`devcon` container. The communication path to the host graphdriver must work
transparently for the person. In the other words, the presence of the proxy server
must be invisible for docker client inside container.
