### PR TITLE
Fix issue with exec TTY caused by 15446

### DIFF
--- a/api/server/exec.go
+++ b/api/server/exec.go
@@ -65,7 +65,7 @@ func (s *Server) postContainerExecStart(version version.Version, w http.Response
 	}
 	var (
 		execName                  = vars["name"]
-		stdin, inStream           io.ReadCloser
+		stdin                     io.ReadCloser
 		stdout, stderr, outStream io.Writer
 	)
 
@@ -77,7 +77,7 @@ func (s *Server) postContainerExecStart(version version.Version, w http.Response
 	if !execStartCheck.Detach {
 		var err error
 		// Setting up the streaming http interface.
-		inStream, outStream, err = hijackServer(w)
+		inStream, outStream, err := hijackServer(w)
 		if err != nil {
 			return err
 		}
@@ -89,11 +89,12 @@ func (s *Server) postContainerExecStart(version version.Version, w http.Response
 			fmt.Fprintf(outStream, "HTTP/1.1 200 OK\r\nContent-Type: application/vnd.docker.raw-stream\r\n\r\n")
 		}
 
+		stdin = inStream
+		stdout = outStream
 		if !execStartCheck.Tty {
 			stderr = stdcopy.NewStdWriter(outStream, stdcopy.Stderr)
 			stdout = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
 		}
-		stdin = inStream
 	}
 
 	// Now run the user process in container.

--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -42,3 +42,31 @@ func (s *DockerSuite) TestExecInteractiveStdinClose(c *check.C) {
 		c.Fatal("timed out running docker exec")
 	}
 }
+
+func (s *DockerSuite) TestExecTTY(c *check.C) {
+	dockerCmd(c, "run", "-d", "--name=test", "busybox", "sh", "-c", "echo hello > /foo && top")
+
+	cmd := exec.Command(dockerBinary, "exec", "-it", "test", "sh")
+	p, err := pty.Start(cmd)
+	c.Assert(err, check.IsNil)
+	defer p.Close()
+
+	_, err = p.Write([]byte("cat /foo && exit\n"))
+	c.Assert(err, check.IsNil)
+
+	chErr := make(chan error)
+	go func() {
+		chErr <- cmd.Wait()
+	}()
+	select {
+	case err := <-chErr:
+		c.Assert(err, check.IsNil)
+	case <-time.After(3 * time.Second):
+		c.Fatal("timeout waiting for exec to exit")
+	}
+
+	buf := make([]byte, 256)
+	read, err := p.Read(buf)
+	c.Assert(err, check.IsNil)
+	c.Assert(bytes.Contains(buf, []byte("hello")), check.Equals, true, check.Commentf(string(buf[:read])))
+}


### PR DESCRIPTION
Fixes #15570
The bool logic around setting up the TTY ended up getting flipped
accidentally.
Also added a test for exec with TTY.
