### PR TITLE
Fix ignore `-q` flag in `docker ps` when there is a default format.

### DIFF
--- a/api/client/ps.go
+++ b/api/client/ps.go
@@ -95,7 +95,7 @@ func (cli *DockerCli) CmdPs(args ...string) error {
 
 	f := *format
 	if len(f) == 0 {
-		if len(cli.PsFormat()) > 0 {
+		if len(cli.PsFormat()) > 0 && !*quiet {
 			f = cli.PsFormat()
 		} else {
 			f = "table"


### PR DESCRIPTION
Docker ps default format should not take precedence over cli flags.
This happens effectively for other flags except `-q`.
We need to let the cli to set the format as table to print the
expected output with `-q`.

Signed-off-by: David Calavera david.calavera@gmail.com
