### PR TITLE
Windows: Block 'FROM scratch'

### DIFF
--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -194,7 +194,11 @@ func from(b *builder, args []string, attributes map[string]bool, original string
 
 	name := args[0]
 
+	// Windows cannot support a container with no base image.
 	if name == NoBaseImageSpecifier {
+		if runtime.GOOS == "windows" {
+			return fmt.Errorf("Windows does not support FROM scratch")
+		}
 		b.image = ""
 		b.noBaseImage = true
 		return nil


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli @jfrazelle As it is impossible for the Windows daemon to support the concept of 'FROM scratch', giving an error message if it's attempted.

https://github.com/docker/docker/pull/15579#issuecomment-131275308
