### PR TITLE
Initialize LogConfig in daemon mode

### DIFF
--- a/docker/daemon.go
+++ b/docker/daemon.go
@@ -76,6 +76,7 @@ func NewDaemonCli() *DaemonCli {
 
 	// TODO(tiborvass): remove InstallFlags?
 	daemonConfig := new(daemon.Config)
+	daemonConfig.LogConfig.Config = make(map[string]string)
 	daemonConfig.InstallFlags(daemonFlags, presentInHelp)
 	daemonConfig.InstallFlags(flag.CommandLine, absentFromHelp)
 	registryOptions := new(registry.Options)
@@ -209,10 +210,6 @@ func (cli *DaemonCli) CmdDaemon(args ...string) error {
 				logrus.Error(err)
 			}
 		}()
-	}
-
-	if cli.LogConfig.Config == nil {
-		cli.LogConfig.Config = make(map[string]string)
 	}
 
 	serverConfig := &apiserver.Config{


### PR DESCRIPTION
LogConfig needs to be initialized before `InstallFlags` is called in order to make --log-opt work in daemon mode.

This fixes:
https://github.com/docker/docker/issues/15509
https://github.com/docker/docker/issues/15475
https://github.com/docker/docker/issues/15575

Signed-off-by: Marius Sturm marius@graylog.com
