### PR TITLE
Add support for multiple image on docker push

### DIFF
--- a/api/client/push.go
+++ b/api/client/push.go
@@ -10,44 +10,70 @@ import (
 	"github.com/docker/docker/registry"
 )
 
-// CmdPush pushes an image or repository to the registry.
+// CmdPush pushes one or more images or repositories to the registry.
 //
 // Usage: docker push NAME[:TAG]
 func (cli *DockerCli) CmdPush(args ...string) error {
-	cmd := Cli.Subcmd("push", []string{"NAME[:TAG]"}, "Push an image or a repository to a registry", true)
+	cmd := Cli.Subcmd("push", []string{"NAME[:TAG] [NAME[:TAG]...]"}, "Push one or more images or repositories to a registry", true)
 	addTrustedFlags(cmd, false)
-	cmd.Require(flag.Exact, 1)
+	cmd.Require(flag.Min, 1)
 
 	cmd.ParseFlags(args, true)
 
-	remote, tag := parsers.ParseRepositoryTag(cmd.Arg(0))
+	var errNames []string
 
-	// Resolve the Repository name from fqn to RepositoryInfo
-	repoInfo, err := registry.ParseRepositoryInfo(remote)
-	if err != nil {
-		return err
+	// Grouping tags by remote (if any)
+	repositories := make(map[string][]string)
+
+	for _, arg := range cmd.Args() {
+		remote, tag := parsers.ParseRepositoryTag(arg)
+		repositories[remote] = append(repositories[remote], tag)
 	}
-	// Resolve the Auth config relevant for this server
-	authConfig := registry.ResolveAuthConfig(cli.configFile, repoInfo.Index)
-	// If we're not using a custom registry, we know the restrictions
-	// applied to repository names and can warn the user in advance.
-	// Custom repositories can have different rules, and we must also
-	// allow pushing by image ID.
-	if repoInfo.Official {
-		username := authConfig.Username
-		if username == "" {
-			username = "<user>"
+
+	for remote, tags := range repositories {
+
+		// Resolve the Repository name from fqn to RepositoryInfo
+		repoInfo, err := registry.ParseRepositoryInfo(remote)
+		if err != nil {
+			fmt.Fprintf(cli.err, "%s\n", err)
+			errNames = append(errNames, fmt.Sprintf("%s:%s", remote, tags))
+			continue
 		}
-		return fmt.Errorf("You cannot push a \"root\" repository. Please rename your repository to <user>/<repo> (ex: %s/%s)", username, repoInfo.LocalName)
+		// Resolve the Auth config relevant for this server
+		authConfig := registry.ResolveAuthConfig(cli.configFile, repoInfo.Index)
+		// If we're not using a custom registry, we know the restrictions
+		// applied to repository names and can warn the user in advance.
+		// Custom repositories can have different rules, and we must also
+		// allow pushing by image ID.
+		if repoInfo.Official {
+			username := authConfig.Username
+			if username == "" {
+				username = "<user>"
+			}
+			fmt.Fprintf(cli.err, "You cannot push a \"root\" repository. Please rename your repository to <user>/<repo> (ex: %s/%s)\n", username, repoInfo.LocalName)
+			errNames = append(errNames, fmt.Sprintf("%s:%s", remote, tags))
+			continue
+		}
+
+		if isTrusted() {
+			return cli.trustedPush(repoInfo, tags, authConfig)
+		}
+
+		v := url.Values{}
+		for _, tag := range tags {
+			v.Add("tag", tag)
+		}
+
+		_, _, err = cli.clientRequestAttemptLogin("POST", "/images/"+remote+"/push?"+v.Encode(), nil, cli.out, repoInfo.Index, "push")
+		if err != nil {
+			fmt.Fprintf(cli.err, "%s\n", err)
+			errNames = append(errNames, fmt.Sprintf("%s:%s", remote, tags))
+		} else {
+			fmt.Fprint(cli.out, "\n")
+		}
 	}
-
-	if isTrusted() {
-		return cli.trustedPush(repoInfo, tag, authConfig)
+	if len(errNames) > 0 {
+		return fmt.Errorf("Error: failed to push images: %v", errNames)
 	}
-
-	v := url.Values{}
-	v.Set("tag", tag)
-
-	_, _, err = cli.clientRequestAttemptLogin("POST", "/images/"+remote+"/push?"+v.Encode(), nil, cli.out, repoInfo.Index, "push")
-	return err
+	return nil
 }


### PR DESCRIPTION
Fixes #7336 : makes it possible to push multiple images at once (and thus multiple tags without pushing all of them).

It groups tags for the same repository and sends a request to the daemon for each repository with the tags. _This does not change the way images are pushed_.

``` bash
$ docker push vdemeester/image:v1 vdemeester/image:v2 vdemeester/another-image
# - (first) asks the daemon to push vdemeester/image with tags v1 & v2 only (not all tags)
# - (then) asks the daemon to push vdemeester/another-image (all tags)
```

The push(es) are done sequentially (not in parallel). 

If there is an error while pushing, it's handled the same way as `docker rm` commands (or `rmi`, …) : it will log out the error pushes and print a message at the end, that should look like : `Err: failed to push images: [errorimage:[] another:[v1 v2]]`.
- I don't like too much the error message at the end (especially the `:[]` part), but it's purely aesthetics so it can wait a bit after design review.
- API & documentation will have to be update but it can wait for docs review.

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
