### PR TITLE
builder: avoid parsing null string to nil slice (issue #15634)

### DIFF
--- a/builder/parser/line_parsers.go
+++ b/builder/parser/line_parsers.go
@@ -232,6 +232,11 @@ func parseString(rest string) (*Node, map[string]bool, error) {
 
 // parseJSON converts JSON arrays to an AST.
 func parseJSON(rest string) (*Node, map[string]bool, error) {
+	rest = strings.TrimLeftFunc(rest, unicode.IsSpace)
+	if rest[0] != '[' {
+		return nil, nil, errors.New("Error parsing \"" + rest + "\" as a JSON array")
+	}
+
 	var myJSON []interface{}
 	if err := json.NewDecoder(strings.NewReader(rest)).Decode(&myJSON); err != nil {
 		return nil, nil, err

--- a/builder/parser/testfiles/ADD-COPY-with-JSON/Dockerfile
+++ b/builder/parser/testfiles/ADD-COPY-with-JSON/Dockerfile
@@ -3,6 +3,8 @@ MAINTAINER	Seongyeol Lim <seongyeol37@gmail.com>
 
 COPY	.	/go/src/github.com/docker/docker
 ADD		.	/
+ADD		null /
+COPY	nullfile /tmp
 ADD		[ "vimrc", "/tmp" ]
 COPY	[ "bashrc", "/tmp" ]
 COPY	[ "test file", "/tmp" ]

--- a/builder/parser/testfiles/ADD-COPY-with-JSON/result
+++ b/builder/parser/testfiles/ADD-COPY-with-JSON/result
@@ -2,6 +2,8 @@
 (maintainer "Seongyeol Lim <seongyeol37@gmail.com>")
 (copy "." "/go/src/github.com/docker/docker")
 (add "." "/")
+(add "null" "/")
+(copy "nullfile" "/tmp")
 (add "vimrc" "/tmp")
 (copy "bashrc" "/tmp")
 (copy "test file" "/tmp")


### PR DESCRIPTION
Fixes #15634

Fix to avoid parsing `null` string in `ADD`, `COPY` and `VOLUME` step to nil slice by checking if the string starts with `[`.

Signed-off-by: Soshi Katsuta katsuta_soshi@cyberagent.co.jp
