### PR TITLE
Fix pull on client disconnect

### DIFF
--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -77,7 +77,7 @@ func (p *v2Puller) pullV2Repository(tag string) (err error) {
 	if err != nil {
 		if c != nil {
 			// Another pull of the same repository is already taking place; just wait for it to finish
-			p.sf.FormatStatus("", "Repository %s already being pulled by another client. Waiting.", p.repoInfo.CanonicalName)
+			p.config.OutStream.Write(p.sf.FormatStatus("", "Repository %s already being pulled by another client. Waiting.", p.repoInfo.CanonicalName))
 			<-c
 			return nil
 		}
@@ -223,6 +223,9 @@ func (p *v2Puller) pullV2Tag(tag, taggedName string) (verified bool, err error) 
 	go func() {
 		if _, err := io.Copy(out, pipeReader); err != nil {
 			logrus.Errorf("error copying from layer download progress reader: %s", err)
+			if err := pipeReader.CloseWithError(err); err != nil {
+				logrus.Errorf("error closing the progress reader: %s", err)
+			}
 		}
 	}()
 	defer func() {


### PR DESCRIPTION
Fixes #15589

Not quite sure if `discard` is a best solution here but seemed more robust than letting all the progress logging know that they are not needed any more. The issue is that progress logger's writes block because there are no readers in the other side of the pipe any more.

Regarding the other pull issues we have for `1.8.1` they may be related, but not sure because they are much harder to reproduce. 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
