### PR TITLE
Add rootfs mountpropagation flags

### DIFF
--- a/daemon/config.go
+++ b/daemon/config.go
@@ -33,6 +33,7 @@ type CommonConfig struct {
 	TrustKeyPath   string
 	DefaultNetwork string
 	NetworkKVStore string
+	RootMount      string
 }
 
 // InstallCommonFlags adds command-line options to the top-level flag parser for

--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -77,6 +77,7 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.BoolVar(&config.Bridge.EnableUserlandProxy, []string{"-userland-proxy"}, true, usageFn("Use userland proxy for loopback traffic"))
 	cmd.BoolVar(&config.EnableCors, []string{"#api-enable-cors", "#-api-enable-cors"}, false, usageFn("Enable CORS headers in the remote API, this is deprecated by --api-cors-header"))
 	cmd.StringVar(&config.CorsHeaders, []string{"-api-cors-header"}, "", usageFn("Set CORS headers in the remote API"))
+	cmd.StringVar(&config.RootMount, []string{"-root-mount"}, "", usageFn("Rootfs mount propogation mode"))
 
 	config.attachExperimentalFlags(cmd, usageFn)
 }

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -278,6 +278,7 @@ func populateCommand(c *Container, env []string) error {
 		ID:                 c.ID,
 		Rootfs:             c.RootfsPath(),
 		ReadonlyRootfs:     c.hostConfig.ReadonlyRootfs,
+		RootMount:          c.Config.RootMount,
 		InitPath:           "/.dockerinit",
 		WorkingDir:         c.Config.WorkingDir,
 		Network:            en,

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -177,7 +177,8 @@ type Command struct {
 	ID                 string            `json:"id"`
 	Rootfs             string            `json:"rootfs"` // root fs of the container
 	ReadonlyRootfs     bool              `json:"readonly_rootfs"`
-	InitPath           string            `json:"initpath"` // dockerinit
+	RootMount          string            `json:"root_mount"` // rootfs mount propogation mode
+	InitPath           string            `json:"initpath"`   // dockerinit
 	WorkingDir         string            `json:"working_dir"`
 	ConfigPath         string            `json:"config_path"` // this should be able to be removed when the lxc template is moved into the driver
 	Network            *Network          `json:"network"`

--- a/daemon/execdriver/driver_unix.go
+++ b/daemon/execdriver/driver_unix.go
@@ -25,6 +25,12 @@ type Network struct {
 	HostNetworking bool   `json:"host_networking"`
 }
 
+var mountPropagationMapping = map[string]configs.MountPropagationMode{
+	"container_private": configs.MNT_RPRIVATE,
+	"container_slave":   configs.MNT_RSLAVE,
+	"container_shared":  configs.MNT_RSHARED,
+}
+
 // InitContainer is the initialization of a container config.
 // It returns the initial configs for a container. It's mostly
 // defined by the default template.
@@ -37,8 +43,12 @@ func InitContainer(c *Command) *configs.Config {
 	container.Devices = c.AutoCreatedDevices
 	container.Rootfs = c.Rootfs
 	container.Readonlyfs = c.ReadonlyRootfs
-	container.Privatefs = true
 
+	if p, exists := mountPropagationMapping[c.RootMount]; exists {
+		container.RootfsMountPropagation = p
+	} else {
+		container.RootfsMountPropagation = mountPropagationMapping["container_private"]
+	}
 	// check to see if we are running in ramdisk to disable pivot root
 	container.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""
 

--- a/runconfig/config.go
+++ b/runconfig/config.go
@@ -156,6 +156,7 @@ type Config struct {
 	MacAddress      string                // Mac Address of the container
 	OnBuild         []string              // ONBUILD metadata that were defined on the image Dockerfile
 	Labels          map[string]string     // List of labels set to this container
+	RootMount       string                // rootfs mount propogation mode: shared/slave/private
 }
 
 // DecodeContainerConfig decodes a json encoded config into a ContainerConfigWrapper

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/configs/config.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/configs/config.go
@@ -72,8 +72,12 @@ type Config struct {
 	// bind mounts are writtable.
 	Readonlyfs bool `json:"readonlyfs"`
 
-	// Privatefs will mount the container's rootfs as private where mount points from the parent will not propogate
-	Privatefs bool `json:"privatefs"`
+	// RootfsMountPropagation is the rootfs mount propagation mode.
+	// On linux it is one of the followings:
+	// "rprivate": rootfs is mounted as recursively private.
+	// (MS_PRIVATE | MS_REC)
+	// "rslave": rootfs is mounted as recursively slave (MS_SLAVE | MS_REC)
+	RootfsMountPropagation MountPropagationMode `json:"rootfsPropagation"`
 
 	// Mounts specify additional source and destination paths that will be mounted inside the container's
 	// rootfs and mount namespace if specified

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/configs/mountpropagation.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/configs/mountpropagation.go
@@ -1,0 +1,3 @@
+package configs
+
+type MountPropagationMode string

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/configs/mountpropagation_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/configs/mountpropagation_linux.go
@@ -1,0 +1,9 @@
+// +build linux
+
+package configs
+
+const (
+	MNT_RPRIVATE MountPropagationMode = "rprivate"
+	MNT_RSLAVE   MountPropagationMode = "rslave"
+	MNT_RSHARED  MountPropagationMode = "rshared"
+)

--- a/vendor/src/github.com/opencontainers/runc/libcontainer/console_linux.go
+++ b/vendor/src/github.com/opencontainers/runc/libcontainer/console_linux.go
@@ -89,7 +89,14 @@ func (c *linuxConsole) mount(rootfs, mountLabel string, uid, gid int) error {
 	if f != nil {
 		f.Close()
 	}
-	return syscall.Mount(c.slavePath, dest, "bind", syscall.MS_BIND, "")
+	if err := syscall.Mount(c.slavePath, dest, "bind", syscall.MS_BIND, ""); err != nil {
+		return err
+	}
+
+	if err := syscall.Mount("", dest, "", syscall.MS_PRIVATE, ""); err != nil {
+		return err
+	}
+	return nil
 }
 
 // dupStdio opens the slavePath for the console and dups the fds to the current


### PR DESCRIPTION
This is to replace previous pull request #14097. It currently depends on unmerged libcontainer patch from https://github.com/opencontainers/runc/issues/208

Configure rootfs mount propagation through `--rootmount` flag:
To set the rootfs mount propagation to shared: `docker run --rootmount=container_shared fedora`
To set the rootfs mount propagation to private: `docker run --rootmount=container_private fedora`
To set the rootfs mount propagation to slave: `docker run --rootmount=container_slave fedora`

A sample output of `--rootmount=container_shared` is

``` console
# docker run -ti --net=host --rootmount=container_shared --privileged -v /test:/test centos  findmnt -o TARGET,PROPAGATION |grep test
|-/test                               shared
```

A sample output of `--rootmount=container_slave` is

``` console
# docker run -ti --net=host --rootmount=container_slave --privileged -v /test:/test centos  findmnt -o TARGET,PROPAGATION |grep test
|-/test                               private,slave
```

Use cases for different propagation modes are

|  | Propogation | Container mounts dir | Host mounts dir | Use case |
| --- | --- | --- | --- | --- |
| 1 | Shared | Both container and host see the dir | Both container and host see the dir | Use a container to mount filesystems on the host so other containers can see it |
| 2 | Slave | container sees dir but host cannot | Both container and host see the dir | automount, etc |
| 3 | Private | container sees dir but host doesn't | host sees dir but container doesn't | current default |
