### PR TITLE
[Fix 15246] bash completion fails on systems with bash 3.2

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -342,8 +342,6 @@ _docker_docker() {
 			;;
 	esac
 
-	__docker_complete_log_driver_options && return
-
 	case "$cur" in
 		-*)
 			COMPREPLY=( $( compgen -W "$boolean_options $global_options_with_args" -- "$cur" ) )
@@ -564,6 +562,9 @@ _docker_daemon() {
 			;;
 	esac
 
+	__docker_complete_log_driver_options && return
+
+	# completions for --storage-opt
 	case "${words[$cword-2]}$prev=" in
 		*dm.blkdiscard=*)
 			COMPREPLY=( $( compgen -W "false true" -- "${cur#=}" ) )


### PR DESCRIPTION
`--log-opt` was incorrectly ported to the new `daemon` subcommand structure, with two consequences:
- completion of `docker daemon --log-opt` does not work
- On systems with the outdated Bash 3.2 (current MacBooks), completion of `docker` and `docker <any subcommand>` fails with  _bash: words: bad array subscript_, see #15246

ping @jfrazelle @tianon
@calavera If there is going to be a 1.8.2 release, please cherry-pick this into it because it is a bug.
