### PR TITLE
Fix docker stats show blkio when there are multiple block device  

### DIFF
--- a/api/client/stats.go
+++ b/api/client/stats.go
@@ -211,9 +211,9 @@ func calculateBlockIO(blkio types.BlkioStats) (blkRead uint64, blkWrite uint64) 
 	for _, bioEntry := range blkio.IoServiceBytesRecursive {
 		switch strings.ToLower(bioEntry.Op) {
 		case "read":
-			blkRead = bioEntry.Value
+			blkRead = blkRead + bioEntry.Value
 		case "write":
-			blkWrite = bioEntry.Value
+			blkWrite = blkWrite + bioEntry.Value
 		}
 	}
 	return

--- a/api/client/stats_unit_test.go
+++ b/api/client/stats_unit_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"sync"
 	"testing"
+
+	"github.com/docker/docker/api/types"
 )
 
 func TestDisplay(t *testing.T) {
@@ -27,5 +29,18 @@ func TestDisplay(t *testing.T) {
 	want := "app\t30.00%\t104.9 MB / 2.147 GB\t4.88%\t104.9 MB / 838.9 MB\t104.9 MB / 838.9 MB\n"
 	if got != want {
 		t.Fatalf("c.Display() = %q, want %q", got, want)
+	}
+}
+
+func TestCalculBlockIO(t *testing.T) {
+	blkio := types.BlkioStats{
+		IoServiceBytesRecursive: []types.BlkioStatEntry{{8, 0, "read", 1234}, {8, 1, "read", 4567}, {8, 0, "write", 123}, {8, 1, "write", 456}},
+	}
+	blkRead, blkWrite := calculateBlockIO(blkio)
+	if blkRead != 5801 {
+		t.Fatalf("blkRead = %d, want 5801", blkRead)
+	}
+	if blkWrite != 579 {
+		t.Fatalf("blkWrite = %d, want 579", blkWrite)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

There could be multiple block device in a system, and the docker stats should show the total 
block read/write bytes of these devices.  
for example, on my system 

<pre><code>root@ubuntu:/sys/fs/cgroup/blkio/docker/66d9d6f46ad76b4465280a012550fa02b43c8d34200fc95ff465ae1e6f327042# cat blkio.throttle.io_service_bytes
8:0 Read 2565890048
8:0 Write 0
8:0 Sync 0
8:0 Async 2565890048
8:0 Total 2565890048
252:0 Read 0
252:0 Write 0
252:0 Sync 0
252:0 Async 0
252:0 Total 0
Total 2565890048</code></pre>

but the docker stats only display the statistic of device `252:0`
This is a bug of client since the the daemon has return the statistic of all block devices.
