### PR TITLE
builder: avoid parsing null- string to nil slice (issue #15634)

### DIFF
--- a/builder/parser/line_parsers.go
+++ b/builder/parser/line_parsers.go
@@ -234,7 +234,7 @@ func parseString(rest string) (*Node, map[string]bool, error) {
 func parseJSON(rest string) (*Node, map[string]bool, error) {
 	rest = strings.TrimLeftFunc(rest, unicode.IsSpace)
 	if !strings.HasPrefix(rest, "[") {
-		return nil, nil, fmt.Errorf("Error parsing \"%s\" as a JSON array", rest)
+		return nil, nil, fmt.Errorf(`Error parsing "%s" as a JSON array`, rest)
 	}
 
 	var myJSON []interface{}

--- a/builder/parser/line_parsers.go
+++ b/builder/parser/line_parsers.go
@@ -232,6 +232,11 @@ func parseString(rest string) (*Node, map[string]bool, error) {
 
 // parseJSON converts JSON arrays to an AST.
 func parseJSON(rest string) (*Node, map[string]bool, error) {
+	rest = strings.TrimLeftFunc(rest, unicode.IsSpace)
+	if !strings.HasPrefix(rest, "[") {
+		return nil, nil, fmt.Errorf("Error parsing \"%s\" as a JSON array", rest)
+	}
+
 	var myJSON []interface{}
 	if err := json.NewDecoder(strings.NewReader(rest)).Decode(&myJSON); err != nil {
 		return nil, nil, err

--- a/builder/parser/testfiles/ADD-COPY-with-JSON/Dockerfile
+++ b/builder/parser/testfiles/ADD-COPY-with-JSON/Dockerfile
@@ -3,6 +3,8 @@ MAINTAINER	Seongyeol Lim <seongyeol37@gmail.com>
 
 COPY	.	/go/src/github.com/docker/docker
 ADD		.	/
+ADD		null /
+COPY	nullfile /tmp
 ADD		[ "vimrc", "/tmp" ]
 COPY	[ "bashrc", "/tmp" ]
 COPY	[ "test file", "/tmp" ]

--- a/builder/parser/testfiles/ADD-COPY-with-JSON/result
+++ b/builder/parser/testfiles/ADD-COPY-with-JSON/result
@@ -2,6 +2,8 @@
 (maintainer "Seongyeol Lim <seongyeol37@gmail.com>")
 (copy "." "/go/src/github.com/docker/docker")
 (add "." "/")
+(add "null" "/")
+(copy "nullfile" "/tmp")
 (add "vimrc" "/tmp")
 (copy "bashrc" "/tmp")
 (copy "test file" "/tmp")

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5461,13 +5461,9 @@ func (s *DockerSuite) TestBuildNullStringInAddCopyVolume(c *check.C) {
 			"nullfile": "test2",
 		},
 	)
-
-	if err != nil {
-		c.Fatal(err)
-	}
 	defer ctx.Close()
+	c.Assert(err, check.IsNil)
 
-	if _, err := buildImageFromContext(name, ctx, true); err != nil {
-		c.Fatal(err)
-	}
+	_, err = buildImageFromContext(name, ctx, true)
+	c.Assert(err, check.IsNil)
 }

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -5444,3 +5444,30 @@ func (s *DockerTrustSuite) TestBuildContextDirIsSymlink(c *check.C) {
 		c.Fatalf("build failed with exit status %d: %s", exitStatus, out)
 	}
 }
+
+// Issue #15634: COPY fails when path starts with "null"
+func (s *DockerSuite) TestBuildNullStringInAddCopyVolume(c *check.C) {
+	name := "testbuildnullstringinaddcopyvolume"
+
+	ctx, err := fakeContext(`
+		FROM busybox
+		
+		ADD null /
+		COPY nullfile /
+		VOLUME nullvolume
+		`,
+		map[string]string{
+			"null":     "test1",
+			"nullfile": "test2",
+		},
+	)
+
+	if err != nil {
+		c.Fatal(err)
+	}
+	defer ctx.Close()
+
+	if _, err := buildImageFromContext(name, ctx, true); err != nil {
+		c.Fatal(err)
+	}
+}


### PR DESCRIPTION
Fixes #15634

Currently parsing args in `ADD`, `COPY` and `VOLUME` instructions uses `Decoder.Decode()` first, and it binds `nil` if given bytes start with `null`.

This PR fixes to avoid parsing `null` string to `nil` slice by checking if the string starts with `[`.

Signed-off-by: Soshi Katsuta katsuta_soshi@cyberagent.co.jp
