### PR TITLE
Updating hashcode links to commands

### DIFF
--- a/docs/articles/configuring.md
+++ b/docs/articles/configuring.md
@@ -57,7 +57,7 @@ These options :
 - Set `tls` to true with the server certificate and key specified using `--tlscert` and `--tlskey` respectively
 - Listen for connections on `tcp://192.168.59.3:2376`
 
-The command line reference has the [complete list of daemon flags](/reference/commandline/cli/#daemon)
+The command line reference has the [complete list of daemon flags](/reference/commandline/daemon)
 with explanations.
 
 ## Ubuntu
@@ -114,7 +114,7 @@ These options :
 - Set `tls` to true with the server certificate and key specified using `--tlscert` and `--tlskey` respectively
 - Listen for connections on `tcp://192.168.59.3:2376`
 
-The command line reference has the [complete list of daemon flags](/reference/commandline/cli/#daemon)
+The command line reference has the [complete list of daemon flags](/reference/commandline/daemon)
 with explanations.
 
 
@@ -207,7 +207,7 @@ These options :
 - Set `tls` to true with the server certificate and key specified using `--tlscert` and `--tlskey` respectively
 - Listen for connections on `tcp://192.168.59.3:2376`
 
-The command line reference has the [complete list of daemon flags](/reference/commandline/cli/#daemon)
+The command line reference has the [complete list of daemon flags](/reference/commandline/daemon)
 with explanations.
 
 5. Save and close the file.

--- a/docs/reference/builder.md
+++ b/docs/reference/builder.md
@@ -25,7 +25,7 @@ Dockerfile knowledge with the [Dockerfile tutorial](/userguide/level1).
 
 ## Usage
 
-To [*build*](/reference/commandline/cli/#build) an image from a source repository,
+To [*build*](/reference/commandline/build) an image from a source repository,
 create a description file called `Dockerfile` at the root of your repository.
 This file will describe the steps to assemble the image.
 
@@ -890,7 +890,7 @@ containers. The value can be a JSON array, `VOLUME ["/var/log/"]`, or a plain
 string with multiple arguments, such as `VOLUME /var/log` or `VOLUME /var/log
 /var/db`.  For more information/examples and mounting instructions via the
 Docker client, refer to 
-[*Share Directories via Volumes*](/userguide/dockervolumes/#volume)
+[*Share Directories via Volumes*](/userguide/dockervolumes/#mount-a-host-directory-as-a-data-volume)
 documentation.
 
 The `docker run` command initializes the newly created volume with any data 

--- a/docs/reference/run.md
+++ b/docs/reference/run.md
@@ -23,7 +23,7 @@ its own networking, and its own isolated process tree.  The
 defaults related to the binary to run, the networking to expose, and
 more, but `docker run` gives final control to the operator who starts
 the container from the image. That's the main reason
-[*run*](/reference/commandline/cli/#run) has more options than any
+[*run*](/reference/commandline/run) has more options than any
 other `docker` command.
 
 ## General form
@@ -87,7 +87,7 @@ In detached mode (`-d=true` or just `-d`), all I/O should be done
 through network connections or shared volumes because the container is
 no longer listening to the command line where you executed `docker run`.
 You can reattach to a detached container with `docker`
-[*attach*](/reference/commandline/cli/#attach). If you choose to run a
+[*attach*](/reference/commandline/attach). If you choose to run a
 container in the detached mode, then you cannot use the `--rm` option.
 
 ### Foreground
@@ -360,8 +360,8 @@ Using the `--restart` flag on Docker run you can specify a restart policy for
 how a container should or should not be restarted on exit.
 
 When a restart policy is active on a container, it will be shown as either `Up`
-or `Restarting` in [`docker ps`](/reference/commandline/cli/#ps). It can also be
-useful to use [`docker events`](/reference/commandline/cli/#events) to see the
+or `Restarting` in [`docker ps`](/reference/commandline/ps). It can also be
+useful to use [`docker events`](/reference/commandline/events) to see the
 restart policy in effect.
 
 Docker supports the following restart policies:
@@ -417,7 +417,7 @@ You can specify the maximum amount of times Docker will try to restart the
 container when using the **on-failure** policy.  The default is that Docker
 will try forever to restart the container. The number of (attempted) restarts
 for a container can be obtained via [`docker inspect`](
-/reference/commandline/cli/#inspect). For example, to get the number of restarts
+/reference/commandline/inspect). For example, to get the number of restarts
 for container "my-container";
 
     $ docker inspect -f "{{ .RestartCount }}" my-container
@@ -1048,7 +1048,7 @@ variables automatically:
 
 The container may also include environment variables defined
 as a result of the container being linked with another container. See
-the [*Container Links*](/userguide/dockerlinks/#container-linking)
+the [*Container Links*](/userguide/dockerlinks/#connect-with-the-linking-system)
 section for more details.
 
 Additionally, the operator can **set any environment variable** in the

--- a/docs/userguide/usingdocker.md
+++ b/docs/userguide/usingdocker.md
@@ -110,7 +110,7 @@ Lastly, we've specified a command for our container to run: `python app.py`. Thi
 
 > **Note:** 
 > You can see more detail on the `docker run` command in the [command
-> reference](/reference/commandline/cli/#run) and the [Docker Run
+> reference](/reference/commandline/run) and the [Docker Run
 > Reference](/reference/run/).
 
 ## Viewing our web application container


### PR DESCRIPTION
Old links to the cli were not resolving in some key pages; this fixes that.

Signed-off-by: Mary Anthony mary@docker.com
