### PR TITLE
docs: fix anchor link on Ubuntu installation page

### DIFF
--- a/docs/installation/ubuntulinux.md
+++ b/docs/installation/ubuntulinux.md
@@ -95,7 +95,7 @@ To upgrade your kernel and install the additional packages, do the following:
 
         $ sudo reboot
 
-5. After your system reboots, go ahead and [install Docker](#installing-docker-on-ubuntu).
+5. After your system reboots, go ahead and [install Docker](#installation).
 
 ## Installation
 


### PR DESCRIPTION
Minor fix; the "install docker" link pointed to a non-existing anchor

ping @moxiegirl 
