### PR TITLE
WIP: Carry 15417 and add the ability to specify a search endpoint.

### DIFF
--- a/registry/config.go
+++ b/registry/config.go
@@ -26,8 +26,6 @@ const (
 	// DefaultRegistryVersionHeader is the name of the default HTTP header
 	// that carries Registry version info
 	DefaultRegistryVersionHeader = "Docker-Distribution-Api-Version"
-	// DefaultV1Registry is the URI of the default v1 registry
-	DefaultV1Registry = "https://index.docker.io"
 
 	// IndexServer is the v1 registry server used for user auth + account creation
 	IndexServer = DefaultV1Registry + "/v1/"

--- a/registry/config_unix.go
+++ b/registry/config_unix.go
@@ -3,11 +3,17 @@
 package registry
 
 const (
+	// DefaultV1Registry is the URI of the default v1 registry
+	DefaultV1Registry = "https://index.docker.io"
+
 	// DefaultV2Registry is the URI of the default v2 registry
 	DefaultV2Registry = "https://registry-1.docker.io"
 
 	// CertsDir is the directory where certificates are stored
 	CertsDir = "/etc/docker/certs.d"
+
+	// SearchURL is the url used by the search function
+	SearchURL = "https://index.docker.io/v1/"
 )
 
 // cleanPath is used to ensure that a directory name is valid on the target

--- a/registry/config_windows.go
+++ b/registry/config_windows.go
@@ -6,12 +6,20 @@ import (
 	"strings"
 )
 
-// DefaultV2Registry is the URI of the default (official) v2 registry.
-// This is the windows-specific endpoint.
-//
-// Currently it is a TEMPORARY link that allows Microsoft to continue
-// development of Docker Engine for Windows.
-const DefaultV2Registry = "https://ms-tp3.registry-1.docker.io"
+const (
+	// DefaultV1Registry is the URI of the default v1 registry
+	DefaultV1Registry = "https://registry-win-tp3.docker.io"
+
+	// DefaultV2Registry is the URI of the default (official) v2 registry.
+	// This is the windows-specific endpoint.
+	//
+	// Currently it is a TEMPORARY link that allows Microsoft to continue
+	// development of Docker Engine for Windows.
+	DefaultV2Registry = "https://registry-win-tp3.docker.io"
+
+	// SearchURL is the url used by the search function
+	SearchURL = DefaultV2Registry
+)
 
 // CertsDir is the directory where certificates are stored
 var CertsDir = os.Getenv("programdata") + `\docker\certs.d`

--- a/registry/endpoint.go
+++ b/registry/endpoint.go
@@ -111,11 +111,6 @@ func newEndpoint(address string, tlsConfig *tls.Config, metaHeaders http.Header)
 	return endpoint, nil
 }
 
-// GetEndpoint returns a new endpoint with the specified headers
-func (repoInfo *RepositoryInfo) GetEndpoint(metaHeaders http.Header) (*Endpoint, error) {
-	return NewEndpoint(repoInfo.Index, metaHeaders)
-}
-
 // Endpoint stores basic information about a registry endpoint.
 type Endpoint struct {
 	client         *http.Client


### PR DESCRIPTION
Carry #15417 to get Windows 10 tp3 registry endpoints.  Add a new constant to the registry `SearchURL` to enable a search endpoint to be specified.

This PR is not ready to merge yet for two reasons:
1. Searching a custom registry endpoint: e.g. `docker search registry.com:5000/foo` is not currently tested.  If anyone has some pointers how to do this, I would appreciate it.  My best guess is to create a integration test with an `httptest.Server` serving ping (`v2/`) and `search` endpoints then start a docker daemon with the test server URL as an insecure registry.  The test could then user the `httptest.Server` URL as the qualifed registry name in the search term.  It was not clear to me how to use custom daemon arguments in an integration test.
2. As-is, the tests on Windows will fail until there is a search endpoint for Windows images.

ping @dmp42 @tiborvass @jhowardmsft @icecrime 

Signed-off-by: Richard Scothern richard.scothern@docker.com
