### PR TITLE
add weight to daemon page so it renders in order

### DIFF
--- a/docs/reference/commandline/daemon.md
+++ b/docs/reference/commandline/daemon.md
@@ -5,6 +5,7 @@ description = "The daemon command description and usage"
 keywords = ["container, daemon, runtime"]
 [menu.main]
 parent = "smn_cli"
+weight=1
 +++
 <![end-metadata]-->
 


### PR DESCRIPTION
nit while reading the new daemon docs. The `daemon` subcommand is out of order.

How it is now:
<img width="339" alt="screen shot 2015-08-18 at 17 10 36" src="https://cloud.githubusercontent.com/assets/13337345/9346019/37e5e52c-45cc-11e5-97d0-69b1855f7026.png">

How it looks with this change (rendered with `make docs`):
<img width="344" alt="screen shot 2015-08-18 at 17 10 18" src="https://cloud.githubusercontent.com/assets/13337345/9346018/36a3a6f4-45cc-11e5-930c-14cc97841745.png">
