### PR TITLE
integration-cli: modify %s to %d in formatting an int

### DIFF
--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -385,7 +385,7 @@ func (s *DockerSuite) TestInspectExecID(c *check.C) {
 	}
 	sc, body, err = sockRequest("GET", "/exec/"+execID+"/json", nil)
 	if sc != http.StatusNotFound {
-		c.Fatalf("received status != 404: %s\n%s", sc, body)
+		c.Fatalf("received status != 404: %d\n%s", sc, body)
 	}
 }
 


### PR DESCRIPTION
`sc` is an `int` so fix to use `%d` instead of `%s`.

Signed-off-by: Soshi Katsuta katsuta_soshi@cyberagent.co.jp
