### PR TITLE
Don't globally lock on driver initialization

### DIFF
--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -51,14 +51,20 @@ func Unregister(name string) bool {
 // there is a VolumeDriver plugin available with the given name.
 func Lookup(name string) (volume.Driver, error) {
 	drivers.Lock()
-	defer drivers.Unlock()
 	ext, ok := drivers.extensions[name]
+	drivers.Unlock()
 	if ok {
 		return ext, nil
 	}
 	pl, err := plugins.Get(name, "VolumeDriver")
 	if err != nil {
 		return nil, fmt.Errorf("Error looking up volume plugin %s: %v", name, err)
+	}
+
+	drivers.Lock()
+	defer drivers.Unlock()
+	if ext, ok := drivers.extensions[name]; ok {
+		return ext, nil
 	}
 
 	d := NewVolumeDriver(name, pl.Client)


### PR DESCRIPTION
This patch makes it such that plugin initialization is synchronized based on the plugin name and not globally.  Basically this patch makes it possible to run a volume driver from a container.  Before this patch on initialization everything would get blocked while timing out on a single driver initialization.  Since it was blocked, the container providing the driver could never start.

It would be swell if it was possible to run a plugin from a container.
