### PR TITLE
add the private flag for mount the rootfs with different flag when run a container.

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -278,6 +278,7 @@ func populateCommand(c *Container, env []string) error {
 		ID:                 c.ID,
 		Rootfs:             c.RootfsPath(),
 		ReadonlyRootfs:     c.hostConfig.ReadonlyRootfs,
+		PrivateRootfs:      c.hostConfig.PrivateRootfs,
 		InitPath:           "/.dockerinit",
 		WorkingDir:         c.Config.WorkingDir,
 		Network:            en,

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -177,6 +177,7 @@ type Command struct {
 	ID                 string            `json:"id"`
 	Rootfs             string            `json:"rootfs"` // root fs of the container
 	ReadonlyRootfs     bool              `json:"readonly_rootfs"`
+	PrivateRootfs      bool              `json:"private_rootfs"`
 	InitPath           string            `json:"initpath"` // dockerinit
 	WorkingDir         string            `json:"working_dir"`
 	ConfigPath         string            `json:"config_path"` // this should be able to be removed when the lxc template is moved into the driver

--- a/daemon/execdriver/driver_unix.go
+++ b/daemon/execdriver/driver_unix.go
@@ -37,7 +37,7 @@ func InitContainer(c *Command) *configs.Config {
 	container.Devices = c.AutoCreatedDevices
 	container.Rootfs = c.Rootfs
 	container.Readonlyfs = c.ReadonlyRootfs
-	container.Privatefs = true
+	container.Privatefs = c.PrivateRootfs
 
 	// check to see if we are running in ramdisk to disable pivot root
 	container.NoPivotRoot = os.Getenv("DOCKER_RAMDISK") != ""

--- a/runconfig/hostconfig.go
+++ b/runconfig/hostconfig.go
@@ -292,6 +292,7 @@ type HostConfig struct {
 	RestartPolicy    RestartPolicy    // Restart policy to be used for the container
 	SecurityOpt      []string         // List of string values to customize labels for MLS systems, such as SELinux.
 	ReadonlyRootfs   bool             // Is the container root filesystem in read-only
+	PrivateRootfs    bool             // Is the container root filesystem mount in private mode
 	Ulimits          []*ulimit.Ulimit // List of ulimits to be set in the container
 	LogConfig        LogConfig        // Configuration of the logs for this container
 	CgroupParent     string           // Parent cgroup.

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -88,6 +88,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flIpcMode         = cmd.String([]string{"-ipc"}, "", "IPC namespace to use")
 		flRestartPolicy   = cmd.String([]string{"-restart"}, "no", "Restart policy to apply when a container exits")
 		flReadonlyRootfs  = cmd.Bool([]string{"-read-only"}, false, "Mount the container's root filesystem as read only")
+		flPrivateRootfs   = cmd.Bool([]string{"-private"}, true, "Mount the container's root filesystem as private mount")
 		flLoggingDriver   = cmd.String([]string{"-log-driver"}, "", "Logging driver for container")
 		flCgroupParent    = cmd.String([]string{"-cgroup-parent"}, "", "Optional parent cgroup for the container")
 		flVolumeDriver    = cmd.String([]string{"-volume-driver"}, "", "Optional volume driver for the container")
@@ -347,6 +348,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		RestartPolicy:    restartPolicy,
 		SecurityOpt:      flSecurityOpt.GetAll(),
 		ReadonlyRootfs:   *flReadonlyRootfs,
+		PrivateRootfs:    *flPrivateRootfs,
 		Ulimits:          flUlimits.GetList(),
 		LogConfig:        LogConfig{Type: *flLoggingDriver, Config: loggingOpts},
 		CgroupParent:     *flCgroupParent,


### PR DESCRIPTION
1.the priavte flag is default true, which means mount the rootfs with --make-private.
2.if specify the private flag false, which means mount the rootfs with --make-slave.

Signed-off-by: Chao Chen chenchao@qiyi.com
