### PR TITLE
integration-cli: fix printf verbs of wrong types

### DIFF
--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -122,7 +122,7 @@ func (s *DockerSuite) TestCreateWithPortRange(c *check.C) {
 			c.Fatalf("Expected 1 ports binding, for the port  %s but found %s", k, v)
 		}
 		if k.Port() != v[0].HostPort {
-			c.Fatalf("Expected host port %d to match published port  %d", k.Port(), v[0].HostPort)
+			c.Fatalf("Expected host port %s to match published port %s", k.Port(), v[0].HostPort)
 		}
 	}
 
@@ -161,7 +161,7 @@ func (s *DockerSuite) TestCreateWithiLargePortRange(c *check.C) {
 			c.Fatalf("Expected 1 ports binding, for the port  %s but found %s", k, v)
 		}
 		if k.Port() != v[0].HostPort {
-			c.Fatalf("Expected host port %d to match published port  %d", k.Port(), v[0].HostPort)
+			c.Fatalf("Expected host port %s to match published port %s", k.Port(), v[0].HostPort)
 		}
 	}
 

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -1895,7 +1895,7 @@ func (s *DockerSuite) TestRunAllowPortRangeThroughExpose(c *check.C) {
 			c.Fatalf("Port %d is out of range ", portnum)
 		}
 		if binding == nil || len(binding) != 1 || len(binding[0].HostPort) == 0 {
-			c.Fatalf("Port is not mapped for the port %d", port)
+			c.Fatalf("Port is not mapped for the port %s", port)
 		}
 	}
 }


### PR DESCRIPTION
`go vet` reports some printf verbs of wrong types in `integration-cli/`. I fixed them.

Signed-off-by: Soshi Katsuta katsuta_soshi@cyberagent.co.jp
