### PR TITLE
Fix #15659 : filter by label for docker images commited

### DIFF
--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -100,35 +100,40 @@ func (s *DockerSuite) TestImagesFilterLabel(c *check.C) {
 	image1ID, err := buildImage(imageName1,
 		`FROM scratch
 		 LABEL match me`, true)
-	if err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(err, check.IsNil)
 
 	image2ID, err := buildImage(imageName2,
 		`FROM scratch
 		 LABEL match="me too"`, true)
-	if err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(err, check.IsNil)
 
 	image3ID, err := buildImage(imageName3,
 		`FROM scratch
 		 LABEL nomatch me`, true)
-	if err != nil {
-		c.Fatal(err)
-	}
+	c.Assert(err, check.IsNil)
 
 	out, _ := dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match")
 	out = strings.TrimSpace(out)
-	if (!strings.Contains(out, image1ID) && !strings.Contains(out, image2ID)) || strings.Contains(out, image3ID) {
-		c.Fatalf("Expected ids %s,%s got %s", image1ID, image2ID, out)
-	}
+	c.Assert(out, check.Matches, fmt.Sprintf("[\\s\\w]*%s[\\s\\w]*", image1ID))
+	c.Assert(out, check.Matches, fmt.Sprintf("[\\s\\w]*%s[\\s\\w]*", image2ID))
+	c.Assert(out, check.Not(check.Matches), fmt.Sprintf("[\\s\\w]*%s[\\s\\w]*", image3ID))
 
 	out, _ = dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=match=me too")
 	out = strings.TrimSpace(out)
-	if out != image2ID {
-		c.Fatalf("Expected %s got %s", image2ID, out)
-	}
+	c.Assert(out, check.Equals, image2ID)
+}
+
+// Regression : #15659
+func (s *DockerSuite) TestImagesFilterLabelWithCommit(c *check.C) {
+	// Create a container
+	dockerCmd(c, "run", "--name", "bar", "busybox", "/bin/sh")
+	// Commit with labels "using changes"
+	out, _ := dockerCmd(c, "commit", "-c", "LABEL foo.version=1.0.0-1", "-c", "LABEL foo.name=bar", "-c", "LABEL foo.author=starlord", "bar", "bar:1.0.0-1")
+	imageID := strings.TrimSpace(out)
+
+	out, _ = dockerCmd(c, "images", "--no-trunc", "-q", "-f", "label=foo.version=1.0.0-1")
+	out = strings.TrimSpace(out)
+	c.Assert(out, check.Equals, imageID)
 }
 
 func (s *DockerSuite) TestImagesFilterSpaceTrimCase(c *check.C) {

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -104,6 +104,10 @@ func (s *DockerSuite) TestSaveImageId(c *check.C) {
 	out, _ = dockerCmd(c, "images", "-q", repoName)
 	cleanedShortImageID := strings.TrimSpace(out)
 
+	// Make sure IDs are not empty
+	c.Assert(cleanedLongImageID, check.Not(check.Equals), "", check.Commentf("Id should not be empty."))
+	c.Assert(cleanedShortImageID, check.Not(check.Equals), "", check.Commentf("Id should not be empty."))
+
 	saveCmd := exec.Command(dockerBinary, "save", cleanedShortImageID)
 	tarCmd := exec.Command("tar", "t")
 


### PR DESCRIPTION
Fixes #15659.

The filter in `graph/list.go` looks for `image.ContainerConfig.Labels` 🐧.
When building using a `Dockerfile` using `LABEL`, the _inspect_ looks like this :

``` json
[{
    // […]
    "ContainerConfig": {
        "Labels": {
            "foo.version": "1.0.0-1",
            "foo.name": "bar",
            "foo.author": "starlord",
        }
    }
    // […]
    "Config": {
        "Labels": {
            "foo.version": "1.0.0-1",
            "foo.name": "bar",
            "foo.author": "starlord",
        }
     }
}]
```

When it is commited using the `c` flags (like : `docker commit -c "LABEL foo.version=1.0.0-1" -c "LABEL foo.name=bar" -c "LABEL foo.author=starlord" bar bar:1.0.0-1`), the inspect looks like this :

``` json
[{
    // […]
    "ContainerConfig": {
        "Labels": {}
    }
    // […]
    "Config": {
        "Labels": {
            "foo.version": "1.0.0-1",
            "foo.name": "bar",
            "foo.author": "starlord",
        }
     }
}]
```

Something is not coherent between the `commit` and the `build` then. The current state of this PR is fixing it by probably doing a bad thing :sweat:. I think this is might be related to the don't propagate image labels to images but, not sure…
🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
