### PR TITLE
Graph.Register should clean-up created layer on failure.

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -276,10 +276,14 @@ func (graph *Graph) Register(img *image.Image, layerData archive.Reader) (err er
 
 	// Apply the diff/layer
 	if err := graph.storeImage(img, layerData, tmp); err != nil {
+		// Clean-up the created root filesystem if storing the image failed.
+		graph.driver.Remove(img.ID)
 		return err
 	}
 	// Commit
 	if err := os.Rename(tmp, graph.imageRoot(img.ID)); err != nil {
+		// Clean-up the created root filesystem on failure.
+		graph.driver.Remove(img.ID)
 		return err
 	}
 	graph.idIndex.Add(img.ID)


### PR DESCRIPTION
Signed-off-by: Stefan J. Wernli swernli@microsoft.com

If Graph.storeImage fails (or the os.Rename that comes afterward) during Graph.Register, the layer created in the filesystem is left behind.  While it will get cleaned up if a layer with the same ID is registered later, this does not account for cases where the correct resolution for users is to pull a different image.
