### PR TITLE
Allow branch name in vendor-helper script

### DIFF
--- a/hack/.vendor-helpers.sh
+++ b/hack/.vendor-helpers.sh
@@ -28,7 +28,7 @@ clone() {
 	case "$vcs" in
 		git)
 			git clone --quiet --no-checkout "$url" "$target"
-			( cd "$target" && git reset --quiet --hard "$rev" )
+			( cd "$target" && git checkout --quiet "$rev" && git reset --quiet --hard "$rev" )
 			;;
 		hg)
 			hg clone --quiet --updaterev "$rev" "$url" "$target"


### PR DESCRIPTION
With this, you can specify a branch name in the
vendor script instead of a commit ID. This makes it easier
to quickly test changes in dep'd repos outside of the DIND
environment.

Signed-off-by: Christy Perez christy@linux.vnet.ibm.com
