### PR TITLE
Fix Compose 1.2 changelog link

### DIFF
--- a/docs/misc/release-notes.md
+++ b/docs/misc/release-notes.md
@@ -102,7 +102,7 @@ here](https://docs.docker.com/registry/spec/api/).
 
 For a complete list of compose patches, fixes, and other improvements, see the
 [changelog in the project
-repository](https://github.com/docker/compose/blob/master/CHANGES.md). The
+repository](https://github.com/docker/compose/blob/1.2.0/CHANGES.md). The
 project also makes a [set of release
 notes](https://github.com/docker/compose/releases/tag/1.2.0) on the project.
 


### PR DESCRIPTION
Hardcode the release tag, so that:
- it goes straight to the changes for 1.2, not whatever the current version is
- it still works now that we've [renamed CHANGES.md to CHANGELOG.md](https://github.com/docker/compose/pull/1847)
