### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-Docker: the Linux container engine
-==================================
+Docker: the container engine
+============================
 
 Docker is an open source project to pack, ship and run any application
 as a lightweight container.
 
 Docker containers are both *hardware-agnostic* and *platform-agnostic*.
 This means they can run anywhere, from your laptop to the largest
-EC2 compute instance and everything in between - and they don't require
+cloud compute instance and everything in between - and they don't require
 you to use a particular language, framework or packaging system. That
 makes them great building blocks for deploying and scaling web apps,
 databases, and backend services without depending on a particular stack


### PR DESCRIPTION
Signed-off-by: John Howard John.Howard@microsoft.com

'Genericisms' in README.md. Removed Linux from title due to the Windows daemon, and rather than reference EC2, made it generic for cloud.
