### PR TITLE
Set default bridge name as docker0

### DIFF
--- a/daemon/config_unix.go
+++ b/daemon/config_unix.go
@@ -8,6 +8,7 @@ import (
 	"github.com/docker/docker/opts"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/ulimit"
+	"github.com/docker/libnetwork/drivers/bridge"
 )
 
 var (
@@ -67,7 +68,7 @@ func (config *Config) InstallFlags(cmd *flag.FlagSet, usageFn func(string) strin
 	cmd.BoolVar(&config.Bridge.EnableIPMasq, []string{"-ip-masq"}, true, usageFn("Enable IP masquerading"))
 	cmd.BoolVar(&config.Bridge.EnableIPv6, []string{"-ipv6"}, false, usageFn("Enable IPv6 networking"))
 	cmd.StringVar(&config.Bridge.IP, []string{"#bip", "-bip"}, "", usageFn("Specify network bridge IP"))
-	cmd.StringVar(&config.Bridge.Iface, []string{"b", "-bridge"}, "", usageFn("Attach containers to a network bridge"))
+	cmd.StringVar(&config.Bridge.Iface, []string{"b", "-bridge"}, bridge.DefaultBridgeName, usageFn("Attach containers to a network bridge"))
 	cmd.StringVar(&config.Bridge.FixedCIDR, []string{"-fixed-cidr"}, "", usageFn("IPv4 subnet for fixed IPs"))
 	cmd.StringVar(&config.Bridge.FixedCIDRv6, []string{"-fixed-cidr-v6"}, "", usageFn("IPv6 subnet for fixed IPs"))
 	cmd.Var(opts.NewIpOpt(&config.Bridge.DefaultGatewayIPv4, ""), []string{"-default-gateway"}, usageFn("Container default gateway IPv4 address"))

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -640,7 +640,7 @@ func (container *Container) updateNetworkSettings(n libnetwork.Network, ep libne
 		return err
 	}
 
-	if container.hostConfig.NetworkMode == runconfig.NetworkMode("bridge") {
+	if container.hostConfig.NetworkMode == runconfig.NetworkMode("default") {
 		networkSettings.Bridge = container.daemon.config.Bridge.Iface
 	}
 


### PR DESCRIPTION
Fixmissing default bridge name

Signed-off-by: Hui Kang hkang.sunysb@gmail.com
