### PR TITLE
Fix docker daemon start with old running container which use thirdparty volume plugin

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -194,14 +194,6 @@ func (daemon *Daemon) register(container *Container, updateSuffixarray bool) err
 	// we'll waste time if we update it for every container
 	daemon.idIndex.Add(container.ID)
 
-	if err := daemon.verifyVolumesInfo(container); err != nil {
-		return err
-	}
-
-	if err := container.prepareMountPoints(); err != nil {
-		return err
-	}
-
 	if container.IsRunning() {
 		logrus.Debugf("killing old running container %s", container.ID)
 		// Set exit code to 128 + SIGKILL (9) to properly represent unsuccessful exit
@@ -219,6 +211,14 @@ func (daemon *Daemon) register(container *Container, updateSuffixarray bool) err
 		if err := container.ToDisk(); err != nil {
 			logrus.Errorf("Error saving stopped state to disk: %v", err)
 		}
+	}
+
+	if err := daemon.verifyVolumesInfo(container); err != nil {
+		return err
+	}
+
+	if err := container.prepareMountPoints(); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei
Fixes #15720.
The docker daemon dies(kill -9 $(cat /var/run/docker.pid) could leave some containers with state 
`"Running": true`
For example, on my system, I user kill -9 to kill the docker daemon, and the state of the running container has a state `"Running": true,`

<pre><code>root@ubuntu:/var/lib/docker/containers/d95e7fc1f3b4046707cbd6dd9c90704302d850196eb9bfbc59a9f388c91825d9# cat config.json | jq .
{
  "State": {
    "Running": true,
    "Paused": false,
</code></pre>


On the next daemon start, the daemon will detect these containers and stop
them(https://github.com/docker/docker/blob/master/daemon/daemon.go#L205)

But if these old running containers use a thirdparty volume plugin and the thirdparty
plugin is not running, `container.prepareMountPoints()` (https://github.com/docker/docker/blob/master/daemon/daemon.go#L201)
will failed and exit the `register`, and the old running container will still
has a `Running : true`. This will cause some issues:
these containers sill be shown on `docker ps`
but `docker stop` `docker kill` `docker rm` these containers
will causes a daemon exception.
