### PR TITLE
Systemd init script should support DOCKER_OPTS

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -6,7 +6,8 @@ Requires=docker.socket
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/docker daemon -H fd://
+EnvironmentFile=-/etc/default/docker
+ExecStart=/usr/bin/docker daemon $DOCKER_OPTS -H fd://
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
See #9889 (specifically, [here](https://github.com/docker/docker/issues/9889#issuecomment-109766580)). The systemd daemon should support `DOCKER_OPTS` the same as upstart and sysv do.
