### PR TITLE
fix a panic when the exec fails to start

### DIFF
--- a/api/server/exec.go
+++ b/api/server/exec.go
@@ -65,7 +65,7 @@ func (s *Server) postContainerExecStart(version version.Version, w http.Response
 	}
 	var (
 		execName                  = vars["name"]
-		stdin                     io.ReadCloser
+		stdin, inStream           io.ReadCloser
 		stdout, stderr, outStream io.Writer
 	)
 
@@ -77,7 +77,7 @@ func (s *Server) postContainerExecStart(version version.Version, w http.Response
 	if !execStartCheck.Detach {
 		var err error
 		// Setting up the streaming http interface.
-		inStream, outStream, err := hijackServer(w)
+		inStream, outStream, err = hijackServer(w)
 		if err != nil {
 			return err
 		}
@@ -95,6 +95,8 @@ func (s *Server) postContainerExecStart(version version.Version, w http.Response
 			stderr = stdcopy.NewStdWriter(outStream, stdcopy.Stderr)
 			stdout = stdcopy.NewStdWriter(outStream, stdcopy.Stdout)
 		}
+	} else {
+		outStream = w
 	}
 
 	// Now run the user process in container.

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -595,3 +595,14 @@ func (s *DockerSuite) TestExecOnReadonlyContainer(c *check.C) {
 		c.Fatalf("exec into a read-only container failed with exit status %d", status)
 	}
 }
+
+// #15750
+func (s *DockerSuite) TestExecStartFails(c *check.C) {
+	name := "exec-15750"
+	dockerCmd(c, "run", "-d", "--name", name, "busybox", "top")
+
+	_, errmsg, status := dockerCmdWithStdoutStderr(nil, "exec", name, "no-such-cmd")
+	if status == 255 && !strings.Contains(errmsg, "executable file not found") {
+		c.Fatal("exec error message not received. The daemon might had crashed")
+	}
+}

--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -602,7 +602,9 @@ func dockerCmdWithError(args ...string) (string, int, error) {
 
 func dockerCmdWithStdoutStderr(c *check.C, args ...string) (string, string, int) {
 	stdout, stderr, status, err := runCommandWithStdoutStderr(exec.Command(dockerBinary, args...))
-	c.Assert(err, check.IsNil, check.Commentf("%q failed with errors: %s, %v", strings.Join(args, " "), stderr, err))
+	if c != nil {
+		c.Assert(err, check.IsNil, check.Commentf("%q failed with errors: %s, %v", strings.Join(args, " "), stderr, err))
+	}
 	return stdout, stderr, status
 }
 


### PR DESCRIPTION
The panic can be reproduced with the latest master build by `docker exec -it CONTAINER command-not-exists`

Stack trace:

```
^[[31mERRO^[[0m[37311] Error running command in existing container 21c802e55f6ebe683d75e1ad4179d369143c0ee3b20d3741819e0de682d3da2d: [8] System error: exec: "dfsd": executable file not found in $PATH
^[[37mDEBU^[[0m[37311] Exec task in container 21c802e55f6ebe683d75e1ad4179d369143c0ee3b20d3741819e0de682d3da2d exited with code -1
^[[37mDEBU^[[0m[37311] attach: stdout: end
2015/08/21 20:08:10 http: panic serving @: runtime error: invalid memory address or nil pointer dereference
goroutine 15364 [running]:
net/http.func·011()
  /usr/local/go/src/net/http/server.go:1130 +0xbb
fmt.Fprintf(0x0, 0x0, 0x11dba30, 0x24, 0xc20925b8f8, 0x1, 0x1, 0x0, 0x0, 0x0)
  /usr/local/go/src/fmt/print.go:189 +0xa6
github.com/docker/docker/api/server.(*Server).postContainerExecStart(0xc2080a5800, 0xc208792367, 0x4, 0x7fb83c5e3828, 0xc2085ccdc0, 0xc208b5b040, 0xc209201b60, 0x0, 0x0)
  /go/src/github.com/docker/docker/api/server/exec.go:102 +0xa1c
github.com/docker/docker/api/server.*Server.(github.com/docker/docker/api/server.postContainerExecStart)·fm(0xc208792367, 0x4, 0x7fb83c5e3828, 0xc2085ccdc0, 0xc208b5b040, 0xc209201b60, 0x0, 0x0)
  /go/src/github.com/docker/docker/api/server/server.go:352 +0x7b
github.com/docker/docker/api/server.func·008(0x7fb83c5e3828, 0xc2085ccdc0, 0xc208b5b040)
  /go/src/github.com/docker/docker/api/server/server.go:292 +0xc8f
net/http.HandlerFunc.ServeHTTP(0xc20814ddc0, 0x7fb83c5e3828, 0xc2085ccdc0, 0xc208b5b040)
  /usr/local/go/src/net/http/server.go:1265 +0x41
github.com/gorilla/mux.(*Router).ServeHTTP(0xc2080f6960, 0x7fb83c5e3828, 0xc2085ccdc0, 0xc208b5b040)
  /go/src/github.com/docker/docker/vendor/src/github.com/gorilla/mux/mux.go:98 +0x297
net/http.serverHandler.ServeHTTP(0xc20806cc60, 0x7fb83c5e3828, 0xc2085ccdc0, 0xc208b5b040)
  /usr/local/go/src/net/http/server.go:1703 +0x19a
net/http.(*conn).serve(0xc2085ccd20)
  /usr/local/go/src/net/http/server.go:1204 +0xb57
created by net/http.(*Server).Serve
  /usr/local/go/src/net/http/server.go:1751 +0x35e
```

ping @cpuguy83 

Signed-off-by: Shijiang Wei mountkin@gmail.com
