### PR TITLE
Use a slice instead of a map of io.WriteClosers in broadcastwriter

### DIFF
--- a/pkg/broadcastwriter/broadcastwriter_test.go
+++ b/pkg/broadcastwriter/broadcastwriter_test.go
@@ -3,6 +3,7 @@ package broadcastwriter
 import (
 	"bytes"
 	"errors"
+	"strings"
 
 	"testing"
 )
@@ -80,6 +81,23 @@ func TestBroadcastWriter(t *testing.T) {
 	}
 	if bufferC.String() != "barfailtest" {
 		t.Errorf("Buffer contains %v", bufferC.String())
+	}
+
+	// Test4: Test eviction on multiple simultaneous failures
+	bufferB.failOnWrite = true
+	bufferC.failOnWrite = true
+	bufferD := &dummyWriter{}
+	writer.AddWriter(bufferD)
+	writer.Write([]byte("yo"))
+	writer.Write([]byte("ink"))
+	if strings.Contains(bufferB.String(), "yoink") {
+		t.Errorf("bufferB received write. contents: %q", bufferB)
+	}
+	if strings.Contains(bufferC.String(), "yoink") {
+		t.Errorf("bufferC received write. contents: %q", bufferC)
+	}
+	if g, w := bufferD.String(), "yoink"; g != w {
+		t.Errorf("bufferD = %q, want %q", g, w)
 	}
 
 	writer.Clean()


### PR DESCRIPTION
Maps rely on the keys being comparable.
Using an interface type as the map key is dangerous,
because some interface types are not comparable.
I talked about this in my "Stupid Gopher Tricks" talk:
    https://talks.golang.org/2015/tricks.slide

In this case, if the user-provided writer is backed by a slice
(such as io.MultiWriter) then the code will panic at run time.
