### PR TITLE
opts/envfile: trim all leading whitespace in a line

### DIFF
--- a/opts/envfile.go
+++ b/opts/envfile.go
@@ -26,13 +26,12 @@ func ParseEnvFile(filename string) ([]string, error) {
 	lines := []string{}
 	scanner := bufio.NewScanner(fh)
 	for scanner.Scan() {
-		line := scanner.Text()
+		// trim the line from all leading whitespace first
+		line := strings.TrimLeft(scanner.Text(), whiteSpaces)
 		// line is not empty, and not starting with '#'
 		if len(line) > 0 && !strings.HasPrefix(line, "#") {
 			data := strings.SplitN(line, "=", 2)
-
-			// trim the front of a variable, but nothing else
-			variable := strings.TrimLeft(data[0], whiteSpaces)
+			variable := data[0]
 
 			if !EnvironmentVariableRegexp.MatchString(variable) {
 				return []string{}, ErrBadEnvVariable{fmt.Sprintf("variable '%s' is not a valid environment variable", variable)}

--- a/opts/envfile_test.go
+++ b/opts/envfile_test.go
@@ -29,7 +29,12 @@ func TestParseEnvFileGoodFile(t *testing.T) {
 
 _foobar=foobaz
 `
-
+	// Adding a newline + a line with pure whitespace.
+	// This is being done like this instead of the block above
+	// because it's common for editors to trim trailing whitespace
+	// from lines, which becomes annoying since that's the
+	// exact thing we need to test.
+	content += "\n    \t  "
 	tmpFile := tmpFileWithContent(content, t)
 	defer os.Remove(tmpFile)
 


### PR DESCRIPTION
Rather than just trimming before a variable, we should trim the line first.

This prevents a line with whitespace only to not break docker.
