### PR TITLE
Update dind "/tmp" mounting to be optional

### DIFF
--- a/hack/dind
+++ b/hack/dind
@@ -105,8 +105,10 @@ if ! grep -qw devices /proc/1/cgroup; then
 	echo >&2 'WARNING: it looks like the "devices" cgroup is not mounted.'
 fi
 
-# Mount /tmp
-mount -t tmpfs none /tmp
+# Mount /tmp (conditionally)
+if ! mountpoint -q /tmp; then
+	mount -t tmpfs none /tmp
+fi
 
 if [ $# -gt 0 ]; then
 	exec "$@"


### PR DESCRIPTION
This allows someone running the image to use `-v` to mount a non-tmpfs `/tmp` into their image if they so require/desire.

cc @jfrazelle
