### PR TITLE
Docs: remove networkdriver from README.md in daemon

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -3,7 +3,6 @@ This directory contains code pertaining to running containers and storing images
 Code pertaining to running containers:
 
  - execdriver
- - networkdriver
 
 Code pertaining to storing images:
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

networkdriver has already removed from daemon, but the README.md not update.

ping @thaJeztah  @moxiegirl 
