### PR TITLE
Allow HEAD requests to container archives via CORS.

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -227,7 +227,7 @@ func writeCorsHeaders(w http.ResponseWriter, r *http.Request, corsHeaders string
 	logrus.Debugf("CORS header is enabled and set to: %s", corsHeaders)
 	w.Header().Add("Access-Control-Allow-Origin", corsHeaders)
 	w.Header().Add("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, X-Registry-Auth")
-	w.Header().Add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT, OPTIONS")
+	w.Header().Add("Access-Control-Allow-Methods", "HEAD, GET, POST, DELETE, PUT, OPTIONS")
 }
 
 func (s *Server) ping(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {


### PR DESCRIPTION
Add HEAD to Access-Control-Allow-Methods.

/cc @jlhawn 

Signed-off-by: David Calavera david.calavera@gmail.com
