### PR TITLE
Revert "Fix broken links at plugins documentation"

### DIFF
--- a/docs/extend/plugins.md
+++ b/docs/extend/plugins.md
@@ -17,7 +17,7 @@ plugins.
 ## Types of plugins
 
 Plugins extend Docker's functionality.  They come in specific types.  For
-example, a [volume plugin](/docs/extend/plugins_volume.md) might enable Docker
+example, a [volume plugin](/extend/plugins_volume) might enable Docker
 volumes to persist across multiple Docker hosts.
 
 Currently Docker supports volume and network driver plugins. In the future it
@@ -62,4 +62,4 @@ of the plugin for help. The Docker team may not be able to assist you.
 ## Writing a plugin
 
 If you are interested in writing a plugin for Docker, or seeing how they work
-under the hood, see the [docker plugins reference](/docs/extend/plugin_api.md).
+under the hood, see the [docker plugins reference](/extend/plugin_api).


### PR DESCRIPTION
This reverts commit 354147df012dd35f82e59e3511d9be4fc7610352 (PR #15787)

There is a known problem between the links for documentation created with `make docs` and documentation in github (Check #15546)
