### PR TITLE
add container size info to inspect

### DIFF
--- a/api/server/router/local/inspect.go
+++ b/api/server/router/local/inspect.go
@@ -10,6 +10,7 @@ import (
 
 // getContainersByName inspects containers configuration and serializes it as json.
 func (s *router) getContainersByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+	displaySize := httputils.BoolValue(r, "size")
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
 	}
@@ -25,7 +26,7 @@ func (s *router) getContainersByName(ctx context.Context, w http.ResponseWriter,
 	case version.Equal("1.20"):
 		json, err = s.daemon.ContainerInspect120(vars["name"])
 	default:
-		json, err = s.daemon.ContainerInspect(vars["name"])
+		json, err = s.daemon.ContainerInspect(vars["name"], displaySize)
 	}
 
 	if err != nil {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -269,6 +269,8 @@ type ContainerJSONBase struct {
 	ExecIDs         []string
 	HostConfig      *runconfig.HostConfig
 	GraphDriver     GraphDriverData
+	SizeRw          *int64 `json:",omitempty"`
+	SizeRootFs      *int64 `json:",omitempty"`
 }
 
 // ContainerJSON is newly used struct along with MountPoint

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -207,6 +207,7 @@ complete -c docker -f -n '__fish_docker_no_subcommand' -a info -d 'Display syste
 complete -c docker -f -n '__fish_docker_no_subcommand' -a inspect -d 'Return low-level information on a container or image'
 complete -c docker -A -f -n '__fish_seen_subcommand_from inspect' -s f -l format -d 'Format the output using the given go template.'
 complete -c docker -A -f -n '__fish_seen_subcommand_from inspect' -l help -d 'Print usage'
+complete -c docker -A -f -n '__fish_seen_subcommand_from inspect' -s s -l size -d 'Display total file sizes if the type is container.'
 complete -c docker -A -f -n '__fish_seen_subcommand_from inspect' -a '(__fish_print_docker_images)' -d "Image"
 complete -c docker -A -f -n '__fish_seen_subcommand_from inspect' -a '(__fish_print_docker_containers all)' -d "Container"
 

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -548,6 +548,7 @@ __docker_subcommand() {
             _arguments \
                 $opts_help \
                 "($help -f --format=-)"{-f,--format=-}"[Format the output using the given go template]:template: " \
+                "($help -s --size)"{-s,--size}"[Display total file sizes if the type is container]" \
                 "($help)--type=-[Return JSON for specified type]:type:(image container)" \
                 "($help -)*: :->values" && ret=0
 

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -27,7 +27,7 @@ func (daemon *Daemon) ContainerInspectPre120(name string) (*v1p19.ContainerJSON,
 	container.Lock()
 	defer container.Unlock()
 
-	base, err := daemon.getInspectData(container)
+	base, err := daemon.getInspectData(container, false)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/inspect_windows.go
+++ b/daemon/inspect_windows.go
@@ -13,5 +13,5 @@ func addMountPoints(container *Container) []types.MountPoint {
 
 // ContainerInspectPre120 get containers for pre 1.20 APIs.
 func (daemon *Daemon) ContainerInspectPre120(name string) (*types.ContainerJSON, error) {
-	return daemon.ContainerInspect(name)
+	return daemon.ContainerInspect(name, false)
 }

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -92,6 +92,7 @@ list of DNS options to be used in the container.
 * `GET /info` now lists engine version information.
 * `GET /containers/json` will return `ImageID` of the image used by container.
 * `POST /exec/(name)/start` will now return an HTTP 409 when the container is either stopped or paused.
+* `GET /containers/(name)/json` now accepts a `size` parameter. Setting this parameter to '1' returns container size information in the `SizeRw` and `SizeRootFs` fields.
 
 ### v1.20 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -466,6 +466,26 @@ Return low-level information on the container `id`
 		]
 	}
 
+**Example request, with size information**:
+
+    GET /containers/4fa6e0f0c678/json?size=1 HTTP/1.1
+
+**Example response, with size information**:
+
+    HTTP/1.1 200 OK
+    Content-Type: application/json
+
+    {
+    ....
+    "SizeRw": 0,
+    "SizeRootFs": 972,
+    ....
+    }
+
+Query Parameters:
+
+-   **size** – 1/True/true or 0/False/false, return container size information. Default is `false`.
+
 Status Codes:
 
 -   **200** – no error

--- a/docs/reference/commandline/inspect.md
+++ b/docs/reference/commandline/inspect.md
@@ -18,6 +18,7 @@ parent = "smn_cli"
       --help=false            Print usage
       --type=container|image  Return JSON for specified type, permissible
                               values are "image" or "container"
+      -s, --size=false        Display total file sizes if the type is container
 
 By default, this will render all results in a JSON array. If a format is
 specified, the given template will be executed for each result.

--- a/man/docker-inspect.1.md
+++ b/man/docker-inspect.1.md
@@ -8,6 +8,7 @@ docker-inspect - Return low-level information on a container or image
 **docker inspect**
 [**--help**]
 [**-f**|**--format**[=*FORMAT*]]
+[**-s**|**--size**[=*false*]]
 [**--type**=*container*|*image*]
 CONTAINER|IMAGE [CONTAINER|IMAGE...]
 
@@ -24,6 +25,9 @@ each result.
 
 **-f**, **--format**=""
     Format the output using the given Go template.
+
+**-s**, **--size**=false
+    Display total file sizes if the type is container.
 
 **--type**=*container*|*image*
     Return JSON for specified type, permissible values are "image" or "container"
@@ -204,6 +208,18 @@ output:
 
 You can get more information about how to write a Go template from:
 https://golang.org/pkg/text/template/.
+
+## Getting size information on an container
+
+    $ docker inspect -s d2cc496561d6
+    [
+    {
+    ....
+    "SizeRw": 0,
+    "SizeRootFs": 972,
+    ....
+    }
+    ]
 
 ## Getting information on an image
 


### PR DESCRIPTION
Inspect image has size info but container doesnt.
this add container size info to inspect so we can get the size of an individual container
Fixes #15555

Signed-off-by: Zhang Kun zkazure@gmail.com
