### PR TITLE
Minor fix: remove redundant tag name in error message of create failed.

### DIFF
--- a/integration-cli/docker_api_create_test.go
+++ b/integration-cli/docker_api_create_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/go-check/check"
+)
+
+func (s *DockerSuite) TestApiCreateWithNotExistImage(c *check.C) {
+	name := "test"
+	config := map[string]interface{}{
+		"Image":   "test456:v1",
+		"Volumes": map[string]struct{}{"/tmp": {}},
+	}
+
+	status, resp, err := sockRequest("POST", "/containers/create?name="+name, config)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNotFound)
+	expected := "No such image: test456:v1"
+	if !strings.Contains(string(resp), expected) {
+		c.Fatalf("expected: %s, got: %s", expected, string(resp))
+	}
+
+	config2 := map[string]interface{}{
+		"Image":   "test456",
+		"Volumes": map[string]struct{}{"/tmp": {}},
+	}
+
+	status, resp, err = sockRequest("POST", "/containers/create?name="+name, config2)
+	c.Assert(err, check.IsNil)
+	c.Assert(status, check.Equals, http.StatusNotFound)
+	expected = "No such image: test456:latest"
+	if !strings.Contains(string(resp), expected) {
+		c.Fatalf("expected: %s, got: %s", expected, string(resp))
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
When user rest API to create a container with a image which is 
not exist on local, the error message has a redundant tag.

<pre><code>$ curl -X POST http://9.81.1.183:2375/containers/create -H "Content-Type: application/json" -d '{
"Image": "test:v3"
}'
No such image: test:v3 (tag: v3)</code></pre>

and if we use a image use default tag, the error message seems good

<pre><code> curl -X POST http://9.81.1.183:2375/containers/create -H "Content-Type: application/json" -d '{
"Image": "test"
}'
No such image: test (tag: latest)</code></pre>
