### PR TITLE
Do not try to cleanupMounts if daemon.repository is empty

### DIFF
--- a/daemon/daemon_linux.go
+++ b/daemon/daemon_linux.go
@@ -12,6 +12,9 @@ import (
 
 // cleanupMounts umounts shm/mqueue mounts for old containers
 func (daemon *Daemon) cleanupMounts() error {
+	if daemon.repository == "" {
+		return nil
+	}
 	logrus.Debugf("Cleaning up old shm/mqueue mounts: start.")
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {

--- a/integration-cli/docker_cli_daemon_test.go
+++ b/integration-cli/docker_cli_daemon_test.go
@@ -1624,3 +1624,11 @@ func (s *DockerDaemonSuite) TestDaemonWideLogConfig(c *check.C) {
 		c.Fatalf("Unexpected log-opt: %s, expected map[max-size:1k]", cfg)
 	}
 }
+
+func (s *DockerDaemonSuite) TestDaemonCleanupMounts(c *check.C) {
+	c.Assert(s.d.Start("--log-driver=bogus"), check.NotNil)
+	content, _ := ioutil.ReadFile(s.d.logFile.Name())
+	if strings.Contains(string(content), "Cleaning up old shm/mqueue mounts") {
+		c.Fatalf("Daemon should not clean up shm/mqueue if repository is empty")
+	}
+}


### PR DESCRIPTION
Signed-off-by: Chun Chen ramichen@tencent.com

```
ESC[37mDEBUESC[0m[0000] Cleaning up old shm/mqueue mounts: start.    
ESC[37mDEBUESC[0m[0000] Unmounting /run/shm 
```

I'm seeing such logs. It is because if daemon fails to start during init, `daemon.repository` can be empty and thus `strings.HasPrefix(fields[4], daemon.repository)` will pass 
