### PR TITLE
api/client: merged the getExitCode and the getExecExitCode functions

### DIFF
--- a/api/client/attach.go
+++ b/api/client/attach.go
@@ -72,7 +72,7 @@ func (cli *DockerCli) CmdAttach(args ...string) error {
 		return err
 	}
 
-	_, status, err := getExitCode(cli, cmd.Arg(0))
+	_, status, err := getExitCode(cli, cmd.Arg(0), false)
 	if err != nil {
 		return err
 	}

--- a/api/client/exec.go
+++ b/api/client/exec.go
@@ -122,7 +122,7 @@ func (cli *DockerCli) CmdExec(args ...string) error {
 	}
 
 	var status int
-	if _, status, err = getExecExitCode(cli, execID); err != nil {
+	if _, status, err = getExitCode(cli, execID, true); err != nil {
 		return err
 	}
 

--- a/api/client/run.go
+++ b/api/client/run.go
@@ -232,7 +232,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		if _, _, err := readBody(cli.call("POST", "/containers/"+createResponse.ID+"/wait", nil, nil)); err != nil {
 			return err
 		}
-		if _, status, err = getExitCode(cli, createResponse.ID); err != nil {
+		if _, status, err = getExitCode(cli, createResponse.ID, false); err != nil {
 			return err
 		}
 	} else {
@@ -245,7 +245,7 @@ func (cli *DockerCli) CmdRun(args ...string) error {
 		} else {
 			// In TTY mode, there is a race: if the process dies too slowly, the state could
 			// be updated after the getExitCode call and result in the wrong exit code being reported
-			if _, status, err = getExitCode(cli, createResponse.ID); err != nil {
+			if _, status, err = getExitCode(cli, createResponse.ID, false); err != nil {
 				return err
 			}
 		}

--- a/api/client/start.go
+++ b/api/client/start.go
@@ -158,7 +158,7 @@ func (cli *DockerCli) CmdStart(args ...string) error {
 		if attchErr := <-cErr; attchErr != nil {
 			return attchErr
 		}
-		_, status, err := getExitCode(cli, cmd.Arg(0))
+		_, status, err := getExitCode(cli, cmd.Arg(0), false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This is the same idea as for the functions dealing with the size of the TTY.
Both the `getExitCode` and the `getExecExitCode` functions were almost
identical (only the endpoint was different), so it makes sense to merge them.

Moreover, because of this, a TODO mark has been removed.

Signed-off-by: Miquel Sabaté Solà msabate@suse.com
