### PR TITLE
Windows: Pass fixed long path for filepath.Walk

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -41,7 +41,7 @@ import (
 )
 
 func (b *builder) readContext(context io.Reader) (err error) {
-	tmpdirPath, err := ioutil.TempDir("", "docker-build")
+	tmpdirPath, err := getTempDir("", "docker-build")
 	if err != nil {
 		return
 	}
@@ -304,7 +304,7 @@ func calcCopyInfo(b *builder, cmdName string, cInfos *[]*copyInfo, origPath stri
 		}
 
 		// Create a tmp dir
-		tmpDirName, err := ioutil.TempDir(b.contextPath, "docker-remote")
+		tmpDirName, err := getTempDir(b.contextPath, "docker-remote")
 		if err != nil {
 			return err
 		}

--- a/builder/internals_unix.go
+++ b/builder/internals_unix.go
@@ -3,9 +3,14 @@
 package builder
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 )
+
+func getTempDir(dir, prefix string) (string, error) {
+	return ioutil.TempDir(dir, prefix)
+}
 
 func fixPermissions(source, destination string, uid, gid int, destExisted bool) error {
 	// If the destination didn't already exist, or the destination isn't a

--- a/builder/internals_windows.go
+++ b/builder/internals_windows.go
@@ -2,6 +2,24 @@
 
 package builder
 
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func getTempDir(dir, prefix string) (string, error) {
+
+	tempDir, err := ioutil.TempDir(dir, prefix)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(tempDir, `\\?\`) {
+		tempDir = `\\?\` + tempDir
+	}
+
+	return tempDir, nil
+}
+
 func fixPermissions(source, destination string, uid, gid int, destExisted bool) error {
 	// chown is not supported on Windows
 	return nil

--- a/pkg/chrootarchive/archive_windows.go
+++ b/pkg/chrootarchive/archive_windows.go
@@ -2,6 +2,7 @@ package chrootarchive
 
 import (
 	"io"
+	"strings"
 
 	"github.com/docker/docker/pkg/archive"
 )
@@ -17,5 +18,8 @@ func invokeUnpack(decompressedArchive io.ReadCloser,
 	// Windows is different to Linux here because Windows does not support
 	// chroot. Hence there is no point sandboxing a chrooted process to
 	// do the unpack. We call inline instead within the daemon process.
+	if !strings.HasPrefix(dest, `\\?\`) {
+		dest = `\\?\` + dest
+	}
 	return archive.Unpack(decompressedArchive, dest, options)
 }

--- a/pkg/directory/directory_windows.go
+++ b/pkg/directory/directory_windows.go
@@ -5,10 +5,18 @@ package directory
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Size walks a directory tree and returns its total size in bytes.
 func Size(dir string) (size int64, err error) {
+	fixedPath, err := filepath.Abs(dir)
+	if err != nil {
+		return
+	}
+	if !strings.HasPrefix(fixedPath, `\\?\`) {
+		fixedPath = `\\?\` + fixedPath
+	}
 	err = filepath.Walk(dir, func(d string, fileInfo os.FileInfo, e error) error {
 		// Ignore directory sizes
 		if fileInfo == nil {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -199,9 +199,13 @@ func ReplaceOrAppendEnvValues(defaults, overrides []string) []string {
 // can be read and returns an error if some files can't be read
 // symlinks which point to non-existing files don't trigger an error
 func ValidateContextDirectory(srcPath string, excludes []string) error {
-	return filepath.Walk(filepath.Join(srcPath, "."), func(filePath string, f os.FileInfo, err error) error {
+	contextRoot, err := getContextRoot(srcPath)
+	if err != nil {
+		return err
+	}
+	return filepath.Walk(contextRoot, func(filePath string, f os.FileInfo, err error) error {
 		// skip this directory/file if it's not in the path, it won't get added to the context
-		if relFilePath, err := filepath.Rel(srcPath, filePath); err != nil {
+		if relFilePath, err := filepath.Rel(contextRoot, filePath); err != nil {
 			return err
 		} else if skip, err := fileutils.Matches(relFilePath, excludes); err != nil {
 			return err

--- a/utils/utils_unix.go
+++ b/utils/utils_unix.go
@@ -1,0 +1,11 @@
+// +build !windows
+
+package utils
+
+import (
+	"path/filepath"
+)
+
+func getContextRoot(srcPath string) (string, error) {
+	return filepath.Join(srcPath, "."), nil
+}

--- a/utils/utils_windows.go
+++ b/utils/utils_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+
+package utils
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+func getContextRoot(srcPath string) (string, error) {
+	cr, err := filepath.Abs(srcPath)
+	if err != nil {
+		return "", err
+	}
+	if !strings.HasPrefix(cr, `\\?\`) {
+		cr = `\\?\` + cr
+	}
+	return cr, nil
+}


### PR DESCRIPTION
Signed-off-by: Stefan J. Wernli swernli@microsoft.com

@jhowardmsft  @jstarks @jfrazelle @stevvooe @StefanScherer
This is the fix for issue https://github.com/docker/docker/issues/15775.  Adding more places where we do the correct prepending of <code>"\\?\"</code> in order to trigger long path handling in Windows.  Tested to confirm that build still works as expected, and no longer errors out with deep paths.
