### PR TITLE
Unify rpm and deb package names

### DIFF
--- a/hack/make/build-deb
+++ b/hack/make/build-deb
@@ -8,25 +8,24 @@ set -e
 
 	# TODO consider using frozen images for the dockercore/builder-deb tags
 
-	tilde='~' # ouch Bash 4.2 vs 4.3, you keel me
-	debVersion="${VERSION//-/$tilde}" # using \~ or '~' here works in 4.3, but not 4.2; just ~ causes $HOME to be inserted, hence the $tilde
+	debVersion="${VERSION%%-*}"
 	# if we have a "-dev" suffix or have change in Git, let's make this package version more complex so it works better
 	if [[ "$VERSION" == *-dev ]] || [ -n "$(git status --porcelain)" ]; then
 		gitUnix="$(git log -1 --pretty='%at')"
 		gitDate="$(date --date "@$gitUnix" +'%Y%m%d.%H%M%S')"
 		gitCommit="$(git log -1 --pretty='%h')"
-		gitVersion="git${gitDate}.0.${gitCommit}"
-		# gitVersion is now something like 'git20150128.112847.0.17e840a'
-		debVersion="$debVersion~$gitVersion"
+		gitVersion="${gitDate}.git${gitCommit}"
+		# gitVersion is now something like '20150128.112847.git17e840a'
+		debVersion="$debVersion-$gitVersion"
 
 		# $ dpkg --compare-versions 1.5.0 gt 1.5.0~rc1 && echo true || echo false
 		# true
 		# $ dpkg --compare-versions 1.5.0~rc1 gt 1.5.0~git20150128.112847.17e840a && echo true || echo false
 		# true
-		# $ dpkg --compare-versions 1.5.0~git20150128.112847.17e840a gt 1.5.0~dev~git20150128.112847.17e840a && echo true || echo false
+		# $ dpkg --compare-versions 1.5.0-20150128.112847.git17e840a gt 1.5.0~dev-20150128.112847.git17e840a && echo true || echo false
 		# true
 
-		# ie, 1.5.0 > 1.5.0~rc1 > 1.5.0~git20150128.112847.17e840a > 1.5.0~dev~git20150128.112847.17e840a
+		# ie, 1.5.0 > 1.5.0~rc1 > 1.5.0-20150128.112847.git17e840a > 1.5.0~dev-20150128.112847.git17e840a
 	fi
 
 	debSource="$(awk -F ': ' '$1 == "Source" { print $2; exit }' hack/make/.build-deb/control)"
@@ -58,7 +57,7 @@ set -e
 		fi
 		cat >> "$DEST/$version/Dockerfile.build" <<-EOF
 			RUN ln -sfv hack/make/.build-deb debian
-			RUN { echo '$debSource (${debVersion}-0~${suite}) $suite; urgency=low'; echo; echo '  * Version: $VERSION'; echo; echo " -- $debMaintainer  $debDate"; } > debian/changelog && cat >&2 debian/changelog
+			RUN { echo '$debSource (${debVersion}.${suite}) $suite; urgency=low'; echo; echo '  * Version: $VERSION'; echo; echo " -- $debMaintainer  $debDate"; } > debian/changelog && cat >&2 debian/changelog
 			RUN dpkg-buildpackage -uc -us
 		EOF
 		tempImage="docker-temp/build-deb:$version"

--- a/hack/make/build-rpm
+++ b/hack/make/build-rpm
@@ -16,7 +16,7 @@ set -e
 	# rpmRelease versioning is as follows
 	# Docker 1.7.0:  version=1.7.0, release=1
 	# Docker 1.7.0-rc1: version=1.7.0, release=0.1.rc1
-	# Docker 1.7.0-dev nightly: version=1.7.0, release=0.0.YYYYMMDD.HHMMSS.gitHASH
+	# Docker 1.7.0-dev nightly: version=1.7.0, release=YYYYMMDD.HHMMSS.gitHASH
 
 	# if we have a "-rc*" suffix, set appropriate release
 	if [[ "$VERSION" == *-rc* ]]; then
@@ -31,7 +31,7 @@ set -e
 		gitCommit="$(git log -1 --pretty='%h')"
 		gitVersion="${gitDate}.git${gitCommit}"
 		# gitVersion is now something like '20150128.112847.17e840a'
-		rpmRelease="0.0.$gitVersion"
+		rpmRelease="$gitVersion"
 	fi
 
 	rpmPackager="$(awk -F ': ' '$1 == "Packager" { print $2; exit }' hack/make/.build-rpm/${rpmName}.spec)"


### PR DESCRIPTION
Before this patch, if we have change in Git, we got packages like:
docker-engine-1.7.1-0.0.20150723.082336.git455aacb.el7.centos.x86_64.rpm
docker-engine_1.7.1~git20150723.082336.0.455aacb-0~trusty_amd64.deb

After this patch, we'll get:
docker-engine-1.8.1-20150825.032454.git734509e.el7.centos.x86_64.rpm
docker-engine_1.8.1-20150825.032454.git734509e.trusty_amd64.deb

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
