### PR TITLE
reweight api doc for v1.21 to correct the order.

### DIFF
--- a/docs/reference/api/docker-io_api.md
+++ b/docs/reference/api/docker-io_api.md
@@ -5,6 +5,7 @@ description = "API Documentation for the Docker Hub API"
 keywords = ["API, Docker, index, REST, documentation, Docker Hub,  registry"]
 [menu.main]
 parent = "smn_remoteapi"
+weight = 99
 +++
 <![end-metadata]-->
 

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -5,7 +5,7 @@ description = "API Documentation for Docker"
 keywords = ["API, Docker, rcli, REST,  documentation"]
 [menu.main]
 parent="smn_remoteapi"
-weight = 1
+weight = 0
 +++
 <![end-metadata]-->
 


### PR DESCRIPTION
resolves #15810
<img width="329" alt="screen shot 2015-08-25 at 19 48 46" src="https://cloud.githubusercontent.com/assets/13337345/9484520/5dbe88bc-4b62-11e5-9916-cb08dbbcf526.png">

this is really only a temporary solution. and works at least partially by happenstance. 

`Docker Hub` and `Remote API` have the same weight now as `Remote API v1.21` (the default, of 0).

When 1.22 is added, all three of those files have to change, or everything from 1.21 down to the lowest version needs to be edited to be reweighted.

Several alternatives that all achieve the same things are possible:
1. give those top two a very high negative weight, and then proceed with 1.22 having a weight of -1, 1.23 -2, etc.
2. give all the versions a very high weight of perhaps 1000, and count backwards from that. (hopefully we do not run out of numbers before moving to v2.)
3. edit a bunch of files weights each time any new api version needs to be added.
