### PR TITLE
fix 11646 to check volume path in server side

### DIFF
--- a/daemon/volumes_linux_unit_test.go
+++ b/daemon/volumes_linux_unit_test.go
@@ -52,6 +52,7 @@ func TestParseBindMount(t *testing.T) {
 		{"name:/tmp", "external", "/tmp", "", "name", "external", "", true, false},
 		{"name:/tmp:ro", "local", "/tmp", "", "name", "local", "", false, false},
 		{"local/name:/tmp:rw", "", "/tmp", "", "local/name", "local", "", true, false},
+		{"/tmp:tmp", "", "", "", "", "", "", true, true},
 	}
 
 	for _, c := range cases {

--- a/daemon/volumes_unit_test.go
+++ b/daemon/volumes_unit_test.go
@@ -2,7 +2,7 @@ package daemon
 
 import "testing"
 
-func TestParseVolumeFrom(t *testing.T) {
+func TestParseVolumesFrom(t *testing.T) {
 	cases := []struct {
 		spec    string
 		expId   string

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -81,6 +81,11 @@ func parseBindMount(spec string, mountLabel string, config *runconfig.Config) (*
 		return nil, fmt.Errorf("Invalid volume specification: %s", spec)
 	}
 
+	//validate the volumes destination path
+	if !filepath.IsAbs(bind.Destination) {
+		return nil, fmt.Errorf("Invalid volume destination path: %s mount path must be absolute.", bind.Destination)
+	}
+
 	name, source, err := parseVolumeSource(arr[0])
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
fixes #11646
1. fix `2) Is the path relative?` in docker server side.
2. move checks from createContainerPlatformSpecificSettings to parseVolumes

ping @cpuguy83  can you review this for us

/cc @resouer @xlgao-zju

Signed-off-by: xlgao-zju xlgao@zju.edu.cn
