### PR TITLE
Support content trust offline

### DIFF
--- a/integration-cli/docker_cli_push_test.go
+++ b/integration-cli/docker_cli_push_test.go
@@ -154,7 +154,7 @@ func (s *DockerTrustSuite) TestTrustedPushWithFaillingServer(c *check.C) {
 		c.Fatalf("Missing error while running trusted push w/ no server")
 	}
 
-	if !strings.Contains(string(out), "Error establishing connection to notary repository") {
+	if !strings.Contains(string(out), "error contacting notary server") {
 		c.Fatalf("Missing expected output on trusted push:\n%s", out)
 	}
 }


### PR DESCRIPTION
Ignore ping errors in notary repository setup since Notary is capable of acting in offline mode, making use of cache TUF data. When ping is not successful, notary should still be attempted without error.
