### PR TITLE
Windows: Fix use of IsAbs check

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1049,7 +1049,7 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, 
 
 	// First perform verification of settings common across all platforms.
 	if config != nil {
-		if config.WorkingDir != "" && !filepath.IsAbs(config.WorkingDir) {
+		if config.WorkingDir != "" && !system.IsAbs(config.WorkingDir) {
 			return nil, fmt.Errorf("The working directory '%s' is invalid. It needs to be an absolute path.", config.WorkingDir)
 		}
 	}

--- a/pkg/system/filesys.go
+++ b/pkg/system/filesys.go
@@ -4,10 +4,16 @@ package system
 
 import (
 	"os"
+	"path/filepath"
 )
 
 // MkdirAll creates a directory named path along with any necessary parents,
 // with permission specified by attribute perm for all dir created.
 func MkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)
+}
+
+// IsAbs is a platform-specific wrapper for filepath.IsAbs.
+func IsAbs(path string) bool {
+	return filepath.IsAbs(path)
 }

--- a/pkg/system/filesys_windows.go
+++ b/pkg/system/filesys_windows.go
@@ -4,7 +4,9 @@ package system
 
 import (
 	"os"
+	"path/filepath"
 	"regexp"
+	"strings"
 	"syscall"
 )
 
@@ -61,4 +63,20 @@ func MkdirAll(path string, perm os.FileMode) error {
 		return err
 	}
 	return nil
+}
+
+// IsAbs is a platform-specific wrapper for filepath.IsAbs. On Windows,
+// golang filepath.IsAbs does not consider a path \windows\system32 as absolute
+// as it doesn't start with a drive-letter/colon combination. However, in
+// docker we need to verify things such as WORKDIR /windows/system32 in
+// a Dockerfile (which gets translated to \windows\system32 when being processed
+// by the daemon. This SHOULD be treated as absolute from a docker processing
+// perspective.
+func IsAbs(path string) bool {
+	if !filepath.IsAbs(path) {
+		if !strings.HasPrefix(path, string(os.PathSeparator)) {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli. This allows the Windows daemon to treat a path such as /app (as would be used in a WORKDIR dockerfile command) to be treated as absolute, even though technically from a Windows perspective it isn't. More info in the block comment added to the code.
