### PR TITLE
Windows: Fix absolute checks

### DIFF
--- a/api/client/cp.go
+++ b/api/client/cp.go
@@ -15,6 +15,7 @@ import (
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/pkg/archive"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/pkg/system"
 )
 
 type copyDirection int
@@ -101,7 +102,7 @@ func (cli *DockerCli) CmdCp(args ...string) error {
 // client, a `:` could be part of an absolute Windows path, in which case it
 // is immediately proceeded by a backslash.
 func splitCpArg(arg string) (container, path string) {
-	if filepath.IsAbs(arg) {
+	if system.IsAbs(arg) {
 		// Explicit local absolute path, e.g., `C:\foo` or `/foo`.
 		return "", arg
 	}
@@ -236,7 +237,7 @@ func (cli *DockerCli) copyToContainer(srcPath, dstContainer, dstPath string) (er
 	// If the destination is a symbolic link, we should evaluate it.
 	if err == nil && dstStat.Mode&os.ModeSymlink != 0 {
 		linkTarget := dstStat.LinkTarget
-		if !filepath.IsAbs(linkTarget) {
+		if !system.IsAbs(linkTarget) {
 			// Join with the parent directory.
 			dstParent, _ := archive.SplitPathDirEntry(dstPath)
 			linkTarget = filepath.Join(dstParent, linkTarget)

--- a/builder/internals.go
+++ b/builder/internals.go
@@ -270,7 +270,7 @@ func calcCopyInfo(b *builder, cmdName string, cInfos *[]*copyInfo, origPath stri
 
 	// Twiddle the destPath when its a relative path - meaning, make it
 	// relative to the WORKINGDIR
-	if !filepath.IsAbs(destPath) {
+	if !system.IsAbs(destPath) {
 		hasSlash := strings.HasSuffix(destPath, string(os.PathSeparator))
 		destPath = filepath.Join(string(os.PathSeparator), filepath.FromSlash(b.Config.WorkingDir), destPath)
 

--- a/pkg/archive/copy.go
+++ b/pkg/archive/copy.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/system"
 )
 
 // Errors used or returned by this file.
@@ -210,7 +211,7 @@ func CopyInfoDestinationPath(path string) (info CopyInfo, err error) {
 			return CopyInfo{}, err
 		}
 
-		if !filepath.IsAbs(linkTarget) {
+		if !system.IsAbs(linkTarget) {
 			// Join with the parent directory.
 			dstParent, _ := SplitPathDirEntry(path)
 			linkTarget = filepath.Join(dstParent, linkTarget)

--- a/pkg/symlink/fs.go
+++ b/pkg/symlink/fs.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/docker/docker/pkg/system"
 )
 
 // FollowSymlinkInScope is a wrapper around evalSymlinksInScope that returns an
@@ -120,7 +122,7 @@ func evalSymlinksInScope(path, root string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if filepath.IsAbs(dest) {
+		if system.IsAbs(dest) {
 			b.Reset()
 		}
 		path = dest + string(filepath.Separator) + path


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli @stefanscherer. Fixes #15817.

Corrects the use of IsAbs in the builder, and also tidies the abomination of code which was previously in the workdir handling (my fault...) into something WAY clearer.
