### PR TITLE
Fix trigger count and output

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -531,7 +531,11 @@ func (b *builder) processImageFrom(img *image.Image) error {
 
 	// Process ONBUILD triggers if they exist
 	if nTriggers := len(b.Config.OnBuild); nTriggers != 0 {
-		fmt.Fprintf(b.ErrStream, "# Executing %d build triggers\n", nTriggers)
+		word := "trigger"
+		if nTriggers > 1 {
+			word = "triggers"
+		}
+		fmt.Fprintf(b.ErrStream, "# Executing %d build %s...\n", nTriggers, word)
 	}
 
 	// Copy the ONBUILD triggers, and remove them from the config, since the config will be committed.
@@ -539,7 +543,7 @@ func (b *builder) processImageFrom(img *image.Image) error {
 	b.Config.OnBuild = []string{}
 
 	// parse the ONBUILD triggers by invoking the parser
-	for stepN, step := range onBuildTriggers {
+	for _, step := range onBuildTriggers {
 		ast, err := parser.Parse(strings.NewReader(step))
 		if err != nil {
 			return err
@@ -552,8 +556,6 @@ func (b *builder) processImageFrom(img *image.Image) error {
 			case "MAINTAINER", "FROM":
 				return fmt.Errorf("%s isn't allowed as an ONBUILD trigger", n.Value)
 			}
-
-			fmt.Fprintf(b.OutStream, "Trigger %d, %s\n", stepN, step)
 
 			if err := b.dispatch(i, n); err != nil {
 				return err

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4255,10 +4255,9 @@ func (s *DockerSuite) TestBuildOnBuildOutput(c *check.C) {
 		c.Fatal(err)
 	}
 
-	if !strings.Contains(out, "Trigger 0, RUN echo foo") {
-		c.Fatal("failed to find the ONBUILD output", out)
+	if !strings.Contains(out, "# Executing 1 build trigger") {
+		c.Fatal("failed to find the build trigger output", out)
 	}
-
 }
 
 func (s *DockerSuite) TestBuildInvalidTag(c *check.C) {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Relating to #15826, this fixes the same for trigger (kind of indirectly though as it removes it!). It also fixes the output so that is doesn't say `Executing 1 build triggers`. Removes the redundant `Trigger 0 <some command>` as that same thing is output anyway in the regular builder output. Sample bad output shown below

![capture](https://cloud.githubusercontent.com/assets/10522484/9511445/bc1d31d2-4c2b-11e5-9453-1ff6de865b2d.JPG)
