### PR TITLE
Updated runmetrics article to use up-to-date cgroup paths

### DIFF
--- a/docs/articles/runmetrics.md
+++ b/docs/articles/runmetrics.md
@@ -78,7 +78,7 @@ in `docker ps`, its long ID might be something like
 look it up with `docker inspect` or `docker ps --no-trunc`.
 
 Putting everything together to look at the memory metrics for a Docker
-container, take a look at `/sys/fs/cgroup/memory/lxc/<longid>/`.
+container, take a look at `/sys/fs/cgroup/memory/docker/<longid>/`.
 
 ## Metrics from cgroups: memory, CPU, block I/O
 
@@ -396,7 +396,7 @@ control group (i.e., in the container). Pick any one of them.
 Putting everything together, if the "short ID" of a container is held in
 the environment variable `$CID`, then you can do this:
 
-    $ TASKS=/sys/fs/cgroup/devices/$CID*/tasks
+    $ TASKS=/sys/fs/cgroup/devices/docker/$CID*/tasks
     $ PID=$(head -n 1 $TASKS)
     $ mkdir -p /var/run/netns
     $ ln -sf /proc/$PID/ns/net /var/run/netns/$CID


### PR DESCRIPTION
These path updates should hopefully address the out-of-date cgroup paths that were mentioned in: #7866 and #10463

Signed-off-by: Tom Barlow tomwbarlow@gmail.com
