### PR TITLE
Move TestPullClientDisconnect to DockerSuite, since it doesn't involve notary or a private registry

### DIFF
--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -371,7 +371,7 @@ func (s *DockerTrustSuite) TestTrustedPullWithExpiredSnapshot(c *check.C) {
 }
 
 // Test that pull continues after client has disconnected. #15589
-func (s *DockerTrustSuite) TestPullClientDisconnect(c *check.C) {
+func (s *DockerSuite) TestPullClientDisconnect(c *check.C) {
 	testRequires(c, Network)
 
 	repoName := "hello-world:latest"
@@ -404,5 +404,4 @@ func (s *DockerTrustSuite) TestPullClientDisconnect(c *check.C) {
 		}
 		time.Sleep(500 * time.Millisecond)
 	}
-
 }


### PR DESCRIPTION
Tiny followup to https://github.com/docker/docker/pull/15646
