### PR TITLE
Add refcount pkg and use with overlayfs

### DIFF
--- a/pkg/refcount/counter.go
+++ b/pkg/refcount/counter.go
@@ -1,0 +1,125 @@
+package refcount
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+func New() *Counter {
+	return &Counter{
+		d: make(map[interface{}]*data),
+	}
+}
+
+// Counter holds reference counts for active objects along with
+// additional metadata.
+type Counter struct {
+	m sync.Mutex
+	d map[interface{}]*data
+}
+
+type data struct {
+	count int64
+	value interface{}
+}
+
+func (d *data) incr() int64 {
+	return atomic.AddInt64(&d.count, 1)
+}
+
+func (d *data) decr() int64 {
+	return atomic.AddInt64(&d.count, -1)
+}
+
+// Count returns the current reference count for an object.
+func (c *Counter) Count(k interface{}) int64 {
+	c.m.Lock()
+	defer c.m.Unlock()
+	d := c.d[k]
+	if d == nil {
+		return 0
+	}
+	return d.count
+}
+
+// Incr increments the reference count for k.
+func (c *Counter) Incr(k interface{}) int64 {
+	c.m.Lock()
+	defer c.m.Unlock()
+	d := c.d[k]
+	if d == nil {
+		d = &data{}
+		c.d[k] = d
+	}
+	return d.incr()
+}
+
+// Decr decrements the reference count for k.
+func (c *Counter) Decr(k interface{}) int64 {
+	c.m.Lock()
+	defer c.m.Unlock()
+	d := c.d[k]
+	if d == nil {
+		d = &data{}
+		c.d[k] = d
+	}
+	return d.decr()
+}
+
+// Set sets the value v for k.
+func (c *Counter) Set(k, v interface{}) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	d := c.d[k]
+	if d == nil {
+		d = &data{}
+		c.d[k] = d
+	}
+	d.value = v
+}
+
+// SetIncr sets the value for k and atomically increments the reference count.
+func (c *Counter) SetIncr(k, v interface{}) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	d := c.d[k]
+	if d == nil {
+		d = &data{}
+		c.d[k] = d
+	}
+	d.value = v
+	d.incr()
+}
+
+// Get returns the value for k.  If k does not exist within the counter false
+// is returned as the first return result.  If the value does exist the first
+// return result is true along with the value.
+func (c *Counter) Get(k interface{}) (bool, interface{}) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	d := c.d[k]
+	if d == nil {
+		return false, nil
+	}
+	return true, d.value
+}
+
+// GetIncr increments the count for k and returns the associated value.
+// If k does not exist in the counter the first return result is false with a nil value.
+// If k does exist then the first return result is true and the value is returned.  Without the
+// count being incremented.
+func (c *Counter) GetIncr(k interface{}) (bool, interface{}) {
+	c.m.Lock()
+	defer c.m.Unlock()
+	d := c.d[k]
+	if d == nil {
+		return false, nil
+	}
+	d.incr()
+	return true, d.value
+}
+
+// Delete removes the specified key from the counter.
+func (c *Counter) Delete(k interface{}) {
+	delete(c.d, k)
+}

--- a/pkg/refcount/counter_test.go
+++ b/pkg/refcount/counter_test.go
@@ -1,0 +1,127 @@
+package refcount
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestSimpleIncrDecr(t *testing.T) {
+	const k = "test"
+	c := New()
+	c.Incr(k)
+	count := c.Count(k)
+	if count != 1 {
+		t.Fatalf("count should be 1 but received %d", count)
+	}
+	c.Decr(k)
+	count = c.Count(k)
+	if count != 0 {
+		t.Fatalf("count should be 0 but received %d", count)
+	}
+}
+
+func TestConcurrentIncr(t *testing.T) {
+	const k = "test"
+	c := New()
+	g := sync.WaitGroup{}
+	g.Add(5)
+	for i := 0; i < 5; i++ {
+		go func() {
+			defer g.Done()
+			c.Incr(k)
+		}()
+	}
+	g.Wait()
+	count := c.Count(k)
+	if count != 5 {
+		t.Fatalf("count should be 5 but received %d", count)
+	}
+}
+
+func TestSetGetValue(t *testing.T) {
+	const k = "test"
+	value := 3
+	c := New()
+	c.Set(k, value)
+	gotit, v := c.Get(k)
+	if !gotit {
+		t.Fatal("should have received a value for key")
+	}
+	if v == nil {
+		t.Fatal("value should not be nil for key")
+	}
+	three, ok := v.(int)
+	if !ok {
+		t.Fatal("wrong value type for key")
+	}
+	if three != 3 {
+		t.Fatalf("expected value to be 3 but received %d", three)
+	}
+}
+
+func TestGetIncr(t *testing.T) {
+	const k = "test"
+	value := 3
+	c := New()
+	c.Set(k, value)
+	c.Incr(k)
+	gotit, v := c.GetIncr(k)
+	if !gotit {
+		t.Fatal("should have received a value for key")
+	}
+	if v == nil {
+		t.Fatal("value should not be nil for key")
+	}
+	three, ok := v.(int)
+	if !ok {
+		t.Fatal("wrong value type for key")
+	}
+	if three != 3 {
+		t.Fatalf("expected value to be 3 but received %d", three)
+	}
+	count := c.Count(k)
+	if count != 2 {
+		t.Fatalf("expected count to be 2 but received %d", count)
+	}
+}
+
+func TestSetIncr(t *testing.T) {
+	const k = "test"
+	value := 3
+	c := New()
+	c.SetIncr(k, value)
+	gotit, v := c.Get(k)
+	if !gotit {
+		t.Fatal("should have received a value for key")
+	}
+	if v == nil {
+		t.Fatal("value should not be nil for key")
+	}
+	three, ok := v.(int)
+	if !ok {
+		t.Fatal("wrong value type for key")
+	}
+	if three != 3 {
+		t.Fatalf("expected value to be 3 but received %d", three)
+	}
+	count := c.Count(k)
+	if count != 1 {
+		t.Fatalf("expected count to be 1 but received %d", count)
+	}
+}
+
+func TestDelete(t *testing.T) {
+	const k = "test"
+	value := 3
+	c := New()
+	c.Set(k, value)
+	gotit, _ := c.Get(k)
+	if !gotit {
+		t.Fatal("value was not added for key")
+	}
+	c.Delete(k)
+	gotit, _ = c.Get(k)
+	if gotit {
+		t.Fatal("value still exists for key")
+	}
+}


### PR DESCRIPTION
All of the graphdrivers have reference counting does in their own way.  This adds a new package `refcount` that handles reference counting and value storage in a concurrent safe way.  

This PR also updates overlayfs to replace it's reference counting implementation to use the package. 

```
PASS
coverage: 92.3% of statements
ok      github.com/docker/docker/pkg/refcount   0.002s
```
