### PR TITLE
Test infrastructure for cross platform

### DIFF
--- a/integration-cli/docker_cli_version_test.go
+++ b/integration-cli/docker_cli_version_test.go
@@ -26,3 +26,38 @@ func (s *DockerSuite) TestVersionEnsureSucceeds(c *check.C) {
 		}
 	}
 }
+
+// ensure the Windows daemon return the correct platform string
+func (s *DockerSuite) TestVersionPlatform_w(c *check.C) {
+	testRequires(c, DaemonIsWindows)
+	testVersionPlatform(c, "windows/amd64")
+}
+
+// ensure the Linux daemon return the correct platform string
+func (s *DockerSuite) TestVersionPlatform_l(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	testVersionPlatform(c, "linux/amd64")
+}
+
+func testVersionPlatform(c *check.C, platform string) {
+	out, _ := dockerCmd(c, "version")
+	expected := "OS/Arch:      " + platform
+
+	split := strings.Split(out, "\n")
+	if len(split) < 14 { // To avoid invalid indexing in loop below
+		c.Errorf("got %d lines from version", len(split))
+	}
+
+	// Verify the second 'OS/Arch' matches the platform. Experimental has
+	// more lines of output than 'regular'
+	bFound := false
+	for i := 14; i < len(split); i++ {
+		if strings.Contains(split[i], expected) {
+			bFound = true
+			break
+		}
+	}
+	if !bFound {
+		c.Errorf("Could not find server '%s' in '%s'", expected, out)
+	}
+}

--- a/integration-cli/requirements.go
+++ b/integration-cli/requirements.go
@@ -24,6 +24,14 @@ type testRequirement struct {
 var (
 	daemonExecDriver string
 
+	DaemonIsWindows = testRequirement{
+		func() bool { return daemonPlatform == "windows" },
+		"Test requires a Windows daemon",
+	}
+	DaemonIsLinux = testRequirement{
+		func() bool { return daemonPlatform == "linux" },
+		"Test requires a Linux daemon",
+	}
 	SameHostDaemon = testRequirement{
 		func() bool { return isLocalDaemon },
 		"Test requires docker daemon to runs on the same machine as CLI",


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli. This adds some test infrastructure in preparation for Windows daemon CI. Specifically it adds two new requirements (DaemonIsLinux and DaemonIsWindows), and a couple of tests to exercise this (one for Linux and one for Windows). 

As for naming conventions - I ended up with a suffix of _w and _l. This way, they will be shown next to each other in alphabetical order, and is short/succinct. 
