### PR TITLE
non-root start docker daemon and run container

### DIFF
--- a/contrib/gencap.sh
+++ b/contrib/gencap.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+path=$PATH
+path=${path//:/ }
+
+execpath(){
+    if [ -L $2 ] ; then
+        bin=`ls -l $2`
+	A=${bin##*-> }
+	if [[ ${A:0:1} != "/" ]] ; then
+            echo "setcap" $3 $1/$A
+            setcap $3 $1/$A
+        else
+            echo "setcap" $3 $A
+            setcap $3 $A
+        fi
+    else
+        echo "setcap" $3 $2
+        setcap $3 $2
+    fi
+}
+
+execsetcap(){
+    for dir in $path
+    do
+        file=$dir/$1
+        if [ -f $file ] ; then
+            execpath $dir $file $2
+            break
+        fi
+    done
+}
+
+execsetcap docker cap_chown,cap_dac_override,cap_fsetid,cap_fowner,cap_mknod,cap_net_raw,cap_net_admin,cap_setgid,cap_setuid,cap_setfcap,cap_setpcap,cap_net_bind_service,cap_sys_chroot,cap_kill,cap_audit_write,cap_sys_admin=ep
+execsetcap iptables cap_net_admin,cap_net_raw=ei
+execsetcap mkfs.ext4 cap_dac_override=ei
+execsetcap tune2fs cap_dac_override=ei

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -224,9 +224,9 @@ func checkConfigOptions(config *Config) error {
 
 // checkSystem validates platform-specific requirements
 func checkSystem() error {
-	if os.Geteuid() != 0 {
-		return fmt.Errorf("The Docker daemon needs to be run as root")
-	}
+	//if os.Geteuid() != 0 {
+	//	return fmt.Errorf("The Docker daemon needs to be run as root")
+	//}
 	if err := checkKernel(); err != nil {
 		return err
 	}

--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -23,6 +22,7 @@ import (
 	"github.com/docker/docker/pkg/devicemapper"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/units"
+	"github.com/inheritcap"
 	"github.com/opencontainers/runc/libcontainer/label"
 )
 
@@ -495,16 +495,16 @@ func (devices *DeviceSet) createFilesystem(info *devInfo) error {
 	var err error
 	switch devices.filesystem {
 	case "xfs":
-		err = exec.Command("mkfs.xfs", args...).Run()
+		err = inheritcap.Command("mkfs.xfs", args...).Run()
 	case "ext4":
-		err = exec.Command("mkfs.ext4", append([]string{"-E", "nodiscard,lazy_itable_init=0,lazy_journal_init=0"}, args...)...).Run()
+		err = inheritcap.Command("mkfs.ext4", append([]string{"-E", "nodiscard,lazy_itable_init=0,lazy_journal_init=0"}, args...)...).Run()
 		if err != nil {
-			err = exec.Command("mkfs.ext4", append([]string{"-E", "nodiscard,lazy_itable_init=0"}, args...)...).Run()
+			err = inheritcap.Command("mkfs.ext4", append([]string{"-E", "nodiscard,lazy_itable_init=0"}, args...)...).Run()
 		}
 		if err != nil {
 			return err
 		}
-		err = exec.Command("tune2fs", append([]string{"-c", "-1", "-i", "0"}, devname)...).Run()
+		err = inheritcap.Command("tune2fs", append([]string{"-c", "-1", "-i", "0"}, devname)...).Run()
 	default:
 		err = fmt.Errorf("Unsupported filesystem type %s", devices.filesystem)
 	}
@@ -701,7 +701,7 @@ func (devices *DeviceSet) loadMetadata(hash string) *devInfo {
 }
 
 func getDeviceUUID(device string) (string, error) {
-	out, err := exec.Command("blkid", "-s", "UUID", "-o", "value", device).Output()
+	out, err := inheritcap.Command("blkid", "-s", "UUID", "-o", "value", device).Output()
 	if err != nil {
 		logrus.Debugf("Failed to find uuid for device %s:%v", device, err)
 		return "", err

--- a/vendor/src/github.com/docker/libnetwork/iptables/iptables.go
+++ b/vendor/src/github.com/docker/libnetwork/iptables/iptables.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/inheritcap"
 )
 
 // Action signifies the iptable action.
@@ -67,7 +68,7 @@ func initCheck() error {
 			return ErrIptablesNotFound
 		}
 		iptablesPath = path
-		supportsXlock = exec.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
+		supportsXlock = inheritcap.Command(iptablesPath, "--wait", "-L", "-n").Run() == nil
 	}
 	return nil
 }
@@ -296,7 +297,7 @@ func Exists(table Table, chain string, rule ...string) bool {
 	// parse "iptables -S" for the rule (this checks rules in a specific chain
 	// in a specific table)
 	ruleString := strings.Join(rule, " ")
-	existingRules, _ := exec.Command(iptablesPath, "-t", string(table), "-S", chain).Output()
+	existingRules, _ := inheritcap.Command(iptablesPath, "-t", string(table), "-S", chain).Output()
 
 	return strings.Contains(string(existingRules), ruleString)
 }
@@ -323,7 +324,7 @@ func Raw(args ...string) ([]byte, error) {
 
 	logrus.Debugf("%s, %v", iptablesPath, args)
 
-	output, err := exec.Command(iptablesPath, args...).CombinedOutput()
+	output, err := inheritcap.Command(iptablesPath, args...).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("iptables failed: iptables %v: %s (%s)", strings.Join(args, " "), output, err)
 	}

--- a/vendor/src/github.com/inheritcap/inheritcap.go
+++ b/vendor/src/github.com/inheritcap/inheritcap.go
@@ -1,0 +1,45 @@
+package inheritcap
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/syndtr/gocapability/capability"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func checkInheritable() {
+	c, err := capability.NewPid(os.Getpid())
+	if err != nil {
+		logrus.Errorf("capability.NewPid: %v", err)
+		return
+	}
+
+	if c.Empty(capability.INHERITABLE) {
+		for i := capability.Cap(0); i <= capability.CAP_LAST_CAP; i++ {
+			if c.Get(capability.EFFECTIVE, i) {
+				c.Set(capability.INHERITABLE, i)
+			}
+		}
+		c.Apply(capability.CAPS)
+	}
+}
+
+func Command(name string, arg ...string) *exec.Cmd {
+	if os.Geteuid() != 0 {
+		checkInheritable()
+	}
+
+	cmd := &exec.Cmd{
+		Path: name,
+		Args: append([]string{name}, arg...),
+	}
+	if filepath.Base(name) == name {
+		if lp, err := exec.LookPath(name); err != nil {
+			logrus.Errorf("LookPath %s error: %v", name, err)
+		} else {
+			cmd.Path = lp
+		}
+	}
+	return cmd
+}


### PR DESCRIPTION
with the capability of binary and process, this pr get a way to start docker daemon and run a container with non-root 

set the capability of binary 

```
[root@localhost docker]# chmod +x contrib/gencap.sh 
[root@localhost docker]# contrib/gencap.sh
```

start docker daemon, systemd need root user, so add --exec-opt native.cgroupdriver=cgroupfs

```
[hello@localhost ~]$ docker -d --exec-opt native.cgroupdriver=cgroupfs -D 
...
DEBU[0000] /usr/sbin/iptables, [-t filter -C FORWARD -o docker0 -j DOCKER] 
INFO[0000] Daemon has completed initialization          
INFO[0000] Docker daemon                                 commit=d315e8d execdriver=native-0.2 graphdriver=devicemapper version=1.9.0-dev
```

run container

```
[hello@localhost ~]$ docker run --rm -ti ubuntu bash
groups: cannot find name for group ID 1000
I have no name!@12deb8235f1c:/$ ls  
bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
I have no name!@12deb8235f1c:/$ exit
exit
[hello@localhost ~]$ docker run --rm -ti -u root ubuntu bash
root@9c440be431df:/# pwd
/
root@9c440be431df:/# 
```

we can compile docker with non-root 

```
[root@localhost ~]# setcap all=ep /usr/bin/docker
...
[hello@localhost ~]$ docker -d --exec-opt native.cgroupdriver=cgroupfs -D 
```

```
[hello@localhost docker]$ docker run --rm --privileged -t -i  -v `pwd`/vendor/src:/go/src -v `pwd`:/go/src/github.com/docker/docker -u root dockercore/docker ./hack/make.sh binary

bundles/1.9.0-dev already exists. Removing.

---> Making bundle: binary (in bundles/1.9.0-dev/binary)
Building: bundles/1.9.0-dev/binary/docker-1.9.0-dev
Created binary: bundles/1.9.0-dev/binary/docker-1.9.0-dev

```

Signed-off-by: keloyang yangshukui@huawei.com
