### PR TITLE
Update shell completion on docker ps for ancestor

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -965,7 +965,7 @@ _docker_ps() {
 			__docker_containers_all
 			;;
 		--filter|-f)
-			COMPREPLY=( $( compgen -S = -W "exited id label name status" -- "$cur" ) )
+			COMPREPLY=( $( compgen -S = -W "ancestor exited id label name status" -- "$cur" ) )
 			compopt -o nospace
 			return
 			;;


### PR DESCRIPTION
I feel a little dumb to do this PR because I should have though about it on #14570 :sweat_smile:. This adds the bash completion for the `ancestor` filter.

I thought I would add this to `zsh` and `fish` completion too but didn't find the filter completion.. so it's just a one-line.. :smile_cat:.

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
