### PR TITLE
pkg/ioutils: lower bufReader reset timeout

### DIFF
--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -72,7 +72,7 @@ type bufReader struct {
 
 // NewBufReader returns a new bufReader.
 func NewBufReader(r io.Reader) io.ReadCloser {
-	timeout := rand.New(rndSrc).Intn(120) + 180
+	timeout := rand.New(rndSrc).Intn(90)
 
 	reader := &bufReader{
 		buf:                  &bytes.Buffer{},


### PR DESCRIPTION
This lowers the reset timeout for bufReader as a first step to help with the syslog memory usage issues.
