### PR TITLE
Ploop graphdriver v2

### DIFF
--- a/daemon/daemon_ploop.go
+++ b/daemon/daemon_ploop.go
@@ -1,0 +1,8 @@
+// +build !exclude_graphdriver_ploop,linux
+
+package daemon
+
+import (
+	// register the ploop graphdriver
+	_ "github.com/docker/docker/daemon/graphdriver/ploop"
+)

--- a/daemon/graphdriver/driver_linux.go
+++ b/daemon/graphdriver/driver_linux.go
@@ -50,6 +50,7 @@ var (
 		"zfs",
 		"devicemapper",
 		"overlay",
+		"ploop",
 		"vfs",
 	}
 

--- a/daemon/graphdriver/ploop/README.md
+++ b/daemon/graphdriver/ploop/README.md
@@ -1,0 +1,63 @@
+## Docker ploop graphdriver
+
+This document describes how to run the Docker ploop graphdriver.
+
+Ploop is the enhanced block loop device, developed for
+[OpenVZ](https://openvz.org/) since around 2008 and used in production
+since 2012. To know more about ploop, see
+[openvz.org/Ploop](https://openvz.org/Ploop).
+
+This driver is built upon the following stack of software:
+* [kernel ploop driver](https://github.com/OpenVZ/vzkernel/tree/branch-rh7-3.10.0-229.7.2-ovz/drivers/block/ploop)
+* [ploop command line tool](https://github.com/kolyshkin/ploop)
+* [Go ploop library](https://github.com/kolyshkin/goploop-cli)
+
+### Prerequisites
+
+To use this, you need to have:
+* ploop Linux kernel modules
+* ploop command line tool
+* ext4 file system for ``/var/lib/docker`` (or wherever the root of the Docker runtime is)
+
+Any system with ploop kernel modules and working Docker will do,
+but currently it appears that VZ7 is the only such system.
+
+A work is currently underway to provide ploop kernel modules
+compilable for the upstream kernel. Once finished, this document will be
+updated accordingly.
+
+Note you can either install the full VZ7 system, or just the kernel.
+For the latter option, you need a CentOS/RHEL 7 system ready.
+For VZ7 installation, see
+[openvz.org/Quick_install](https://openvz.org/Quick_install)).
+
+### Testing
+
+The driver undergone some functionality, performance, and stress testing.
+Currently there are no known bugs.
+
+One good stress test creating and removing many images in parallel is
+[github.com/crosbymichael/docker-stress](https://github.com/crosbymichael/docker-stress):
+
+```
+go get github.com/crosbymichael/docker-stress
+docker-stress --containers 50 -c 200 -k 3s
+```
+
+Another stress test used is [github.com/spotify/docker-stress](https://github.com/spotify/docker-stress).
+
+### Limitations
+
+* This driver uses shared deltas (via hardlinks), a feature not officially supported by ''libploop'' yet (but it works fine).
+* Ploop dynamic resize is not used, all images and containers are of the same size (seems that Docker does not have a concept of a per-container disk space limit).
+
+### TODO
+
+* Maybe move clone with hardlinking code to ``goploop-cli`` (or even ``libploop``)?
+* Implement changed files tracker to optimize ``Diff()``/``Changes()``
+
+## See also
+* [openvz.org/Ploop](https://openvz.org/Ploop) -- ploop home page
+* [github.com/kolyshkin/ploop](https://github.com/kolyshkin/ploop) -- ploop C library and tool
+* [github.com/kolyshkin/goploop-cli](https://github.com/kolyshkin/goploop-cli) -- Go ploop library that uses ploop command line tool
+* [github.com/kolyshkin/goploop](https://github.com/kolyshkin/goploop-cli) -- Go ploop library that uses ploop C library

--- a/daemon/graphdriver/ploop/paths.go
+++ b/daemon/graphdriver/ploop/paths.go
@@ -1,0 +1,28 @@
+package ploop
+
+import "path"
+
+const (
+	ddxml = "DiskDescriptor.xml"
+)
+
+// Returns path to ploop image directory for given id
+func (d *Driver) dir(id string) string {
+	// Assuming that id doesn't contain "/" characters
+	return path.Join(d.home, "img", id)
+}
+
+// Returns path to ploop's DiskDescriptor.xml for given id
+func (d *Driver) dd(id string) string {
+	return path.Join(d.dir(id), ddxml)
+}
+
+// Returns path to ploop's image for given id
+func (d *Driver) img(id string) string {
+	return path.Join(d.dir(id), imagePrefix)
+}
+
+// Returns a mount point for given id
+func (d *Driver) mnt(id string) string {
+	return path.Join(d.home, "mnt", id)
+}

--- a/daemon/graphdriver/ploop/ploop.go
+++ b/daemon/graphdriver/ploop/ploop.go
@@ -1,0 +1,547 @@
+// +build linux
+
+package ploop
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/daemon/graphdriver"
+	"github.com/docker/docker/pkg/parsers"
+	"github.com/docker/docker/pkg/units"
+	"github.com/kolyshkin/goploop-cli"
+	"github.com/opencontainers/runc/libcontainer/label"
+)
+
+const (
+	imagePrefix = "root.hdd"
+)
+
+func init() {
+	logrus.Debugf("[ploop] init")
+	graphdriver.Register("ploop", Init)
+}
+
+type mount struct {
+	count  int32
+	device string
+}
+
+// Driver holds some internal information about the ploop driver instance.
+type Driver struct {
+	home    string
+	master  string
+	size    uint64
+	mode    ploop.ImageMode
+	clog    uint
+	mountsM sync.RWMutex
+	mounts  map[string]*mount
+}
+
+// Init returns a new ploop graphdriver. Arguments are root directory
+// to hold ploop images, and an array of options in the form key=value.
+//
+// Currently available options are:
+//
+// * ploop.size: maximum size of a filesystem inside a ploop image.
+//   Value is in bytes, unless a suffix (K, M, G etc.) is given.
+//   Default is 8GiB.
+//
+// * ploop.mode: one of "expanded", "preallocated", or "raw". D
+//   Default is "expanded".
+//
+// * ploop.clog: cluster block size log, 6 to 15. Cluster block size is
+//   512 * 2^clog bytes, for example for clog=10 it will be 512 * 2^10 = 512K.
+//   Default is 9 (i.e. 256 kilobytes).
+//
+// * ploop.libdebug: enable ploop library debugging. A value is an integer,
+//   the more the value is, the more debug is printed. Some possible values
+//   are:
+//     0 - only errors
+//     1 - above plus warnings
+//     3 - above plus debug info
+//     4 - above plus timestamps for profiling
+//     5 - above plus commands being executed (for goploop-cli only)
+//   Default depends on the underlying ploop driver.
+func Init(home string, opt []string) (graphdriver.Driver, error) {
+	logrus.Debugf("[ploop] Init(home=%s)", home)
+
+	// defaults
+	m := ploop.Expanded
+	var s int64 = 8589934592 // 8GiB
+	var cl int64 = 9         // 9 is for 256K cluster block, 11 for 1M etc.
+
+	for _, option := range opt {
+		key, val, err := parsers.ParseKeyValueOpt(option)
+		if err != nil {
+			return nil, err
+		}
+		key = strings.ToLower(key)
+		switch key {
+		case "ploop.size":
+			s, err = units.RAMInBytes(val)
+			if err != nil {
+				logrus.Errorf("[ploop] Bad value for ploop.size: %s", val)
+				return nil, err
+			}
+		case "ploop.mode":
+			m, err = ploop.ParseImageMode(val)
+			if err != nil {
+				logrus.Errorf("[ploop] Bad value for ploop.mode: %s", val)
+				return nil, err
+			}
+		case "ploop.clog":
+			cl, err = strconv.ParseInt(val, 10, 8)
+			if err != nil || cl < 6 || cl > 16 {
+				return nil, fmt.Errorf("[ploop] Bad value for ploop.clog: %s", val)
+			}
+		case "ploop.libdebug":
+			libDebug, err := strconv.Atoi(val)
+			if err != nil {
+				return nil, fmt.Errorf("[ploop] Bad value for ploop.libdebug: %s", val)
+			}
+			ploop.SetVerboseLevel(libDebug)
+		default:
+			return nil, fmt.Errorf("[ploop] Unknown option %s", key)
+		}
+	}
+
+	d := &Driver{
+		home:   home,
+		master: path.Join(home, "master"),
+		mode:   m,
+		size:   uint64(s >> 10), // convert to KB
+		clog:   uint(cl),
+		mounts: make(map[string]*mount),
+	}
+
+	// Remove old master image as image params might have changed,
+	// ignoring the error if it's not there
+	d.removeMaster(true)
+
+	// create needed base dirs so we don't have to use MkdirAll() later
+	dirs := []string{d.dir(""), d.mnt(""), d.master}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return nil, err
+		}
+	}
+
+	// Create a new master image
+	file := path.Join(d.master, imagePrefix)
+	cp := ploop.CreateParam{Size: d.size, Mode: d.mode, File: file, CLog: d.clog, Flags: ploop.NoLazy}
+
+	if err := ploop.Create(&cp); err != nil {
+		logrus.Warnf("[ploop] Create(): %s", err)
+		logrus.Warnf("Can't create ploop image! Maybe some prerequisites are not met?")
+		logrus.Warnf("Make sure you have ext4 filesystem in %s.", home)
+		logrus.Warnf("Check that ploop, e2fsprogs and parted are installed.")
+		return nil, graphdriver.ErrPrerequisites
+	}
+
+	return graphdriver.NaiveDiffDriver(d), nil
+}
+
+func (d *Driver) String() string {
+	return "ploop"
+}
+
+// Status returns information about the ploop driver, shown by 'docker info'.
+// Currently it returns the following information:
+// * "Home directory" -- root directory for ploop images
+// * "Ploop mode" -- ploop image mode (expanded, preallocated, or raw)
+// * "Ploop image size" -- size of a filesystem within a ploop image
+// * "Disk space used/total/available" -- same as du for ploop home dir
+// * "Active device count" -- number of currently active ploop devices
+// * "Active devices" -- list of currently active ploop devices
+func (d *Driver) Status() [][2]string {
+	var buf syscall.Statfs_t
+	syscall.Statfs(d.home, &buf)
+	bs := uint64(buf.Bsize)
+	total := buf.Blocks * bs
+	free := buf.Bfree * bs
+	used := (buf.Blocks - buf.Bfree) * bs
+
+	d.mountsM.RLock()
+	devCount := len(d.mounts)
+	var devices string
+	for _, m := range d.mounts {
+		if m.count > 0 {
+			devices = devices + " " + m.device[5:]
+		}
+	}
+	d.mountsM.RUnlock()
+
+	status := [][2]string{
+		{"Home directory", d.home},
+		{"Ploop mode", d.mode.String()},
+		{"Ploop image size", units.BytesSize(float64(d.size << 10))},
+		{"Disk space used", units.BytesSize(float64(used))},
+		{"Disk space total", units.BytesSize(float64(total))},
+		{"Disk space available", units.BytesSize(float64(free))},
+		{"Active device count", strconv.Itoa(devCount)},
+		{"Active devices", devices},
+		/*
+			{"Total images", xxx},
+			{"Mounted devices", xxx},
+		*/
+	}
+
+	return status
+}
+
+// GetMetadata returns image/container metadata related to graph driver.
+// Currently this driver returns:
+//  * "Device" - ploop device name
+//  * "DiskDescriptor" - path to DiskDescriptor.xml
+//  * "MountPoint" - mount point
+//  * "MountCount" - how many times Get() was called
+func (d *Driver) GetMetadata(id string) (map[string]string, error) {
+	logrus.Debugf("[ploop] GetMetadata(id=%s)", id)
+	var device string
+	var count int32
+
+	d.mountsM.RLock()
+	m, ok := d.mounts[id]
+	if ok {
+		device = m.device
+		count = m.count
+	}
+	d.mountsM.RUnlock()
+	if !ok {
+		return nil, nil
+	}
+	if count < 1 {
+		return nil, nil
+	}
+
+	data := make(map[string]string)
+	dd := d.dd(id)
+
+	data["Device"] = device
+	data["DiskDescriptor"] = dd
+	data["MountPoint"] = d.mnt(id)
+	data["MountCount"] = strconv.Itoa(int(count))
+	return data, nil
+}
+
+func (d *Driver) removeMaster(ignoreOpenError bool) {
+	// Master image might be mounted
+	p, err := ploop.Open(path.Join(d.master, ddxml))
+	if err == nil {
+		if m, _ := p.IsMounted(); m {
+			p.Umount() // ignore errors
+		}
+		p.Close()
+	} else if !ignoreOpenError {
+		logrus.Warn(err)
+	}
+	// Remove master image
+	if err := os.RemoveAll(d.master); err != nil {
+		logrus.Warn(err) // might not be fatal but worth reporting
+	}
+}
+
+// Cleanup unmounts all non-Put() mounts, and removes
+// the master image created on Init().
+func (d *Driver) Cleanup() error {
+	logrus.Debugf("[ploop] Cleanup()")
+
+	d.removeMaster(false)
+
+	d.mountsM.Lock()
+	for id, m := range d.mounts {
+		logrus.Warnf("[ploop] Cleanup: unexpected ploop device %s, unmounting", m.device)
+		if err := ploop.UmountByDevice(m.device); err != nil && !ploop.IsNotMounted(err) {
+			logrus.Warnf("[ploop] Cleanup: %s", err)
+		} else {
+			delete(d.mounts, id)
+		}
+	}
+	d.mountsM.Unlock()
+
+	return nil
+}
+
+func (d *Driver) create(id string) error {
+	return copyDir(d.master, d.dir(id))
+}
+
+// add some info to our parent
+func markParent(id, parent, dir, pdir string) error {
+	// 1 symlink us to parent, just for the sake of debugging
+	rpdir := path.Join("..", parent)
+	if err := os.Symlink(rpdir, path.Join(dir, "parent")); err != nil {
+		logrus.Errorf("[ploop] markParent: %s", err)
+		return err
+	}
+
+	return nil
+}
+
+// clone creates a copy of a parent ploop
+func (d *Driver) clone(id, parent string) error {
+	dd := d.dd(id)
+	dir := d.dir(id)
+	pdd := d.dd(parent)
+	pdir := d.dir(parent)
+
+	// FIXME: lock parent delta!!
+
+	// see if we can reuse a snapshot
+	snap, err := readVal(pdir, "uuid-for-children")
+	if err != nil {
+		logrus.Errorf("[ploop] clone(): readVal: %s", err)
+		return err
+	}
+	if snap == "" {
+		// create a snapshot
+		logrus.Debugf("[ploop] clone(): creating snapshot for %s", id)
+		pp, err := ploop.Open(pdd)
+		if err != nil {
+			return err
+		}
+
+		snap, err = pp.Snapshot()
+		if err != nil {
+			pp.Close()
+			return err
+		}
+
+		pp.Close() // save dd.xml now!
+
+		// save snapshot for future children
+		writeVal(pdir, "uuid-for-children", snap)
+	} else {
+		logrus.Debugf("[ploop] clone(): reusing snapshot %s from %s", snap, id)
+	}
+
+	markParent(id, parent, dir, pdir)
+
+	// copy dd.xml from parent dir
+	if err := copyFile(pdd, dd); err != nil {
+		return err
+	}
+
+	// hardlink images from parent dir
+	files, err := ioutil.ReadDir(pdir)
+	if err != nil {
+		return err
+	}
+	for _, fi := range files {
+		name := fi.Name()
+		// TODO: maybe filter out non-files
+		if !strings.HasPrefix(name, imagePrefix) {
+			//			logrus.Debugf("[ploop] clone: skip %s", name)
+			continue
+		}
+		src := path.Join(pdir, name)
+		dst := path.Join(dir, name)
+		//		logrus.Debugf("[ploop] clone: hardlink %s", name)
+		if err = os.Link(src, dst); err != nil {
+			return err
+		}
+	}
+
+	// switch to snapshot, removing old top delta
+	p, err := ploop.Open(dd)
+	if err != nil {
+		return err
+	}
+	defer p.Close()
+
+	logrus.Debugf("[ploop] id=%s SwitchSnapshot(%s)", id, snap)
+	if err = p.SwitchSnapshot(snap); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Create creates a new ploop image, by cloning either a parent image
+// (if parent is set) or an initial (master) image.
+func (d *Driver) Create(id, parent string) error {
+	logrus.Debugf("[ploop] Create(id=%s, parent=%s)", id, parent)
+
+	// Assuming Create is called for non-existing stuff only
+	dir := d.dir(id)
+	err := os.Mkdir(dir, 0700)
+	if err != nil {
+		return err
+	}
+
+	if parent == "" {
+		err = d.create(id)
+	} else {
+		err = d.clone(id, parent)
+	}
+
+	if err != nil {
+		os.RemoveAll(dir)
+		return err
+	}
+
+	// Make sure the mount point exists
+	mdir := d.mnt(id)
+	err = os.Mkdir(mdir, 0755)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Remove deletes a given ploop image.
+func (d *Driver) Remove(id string) error {
+	logrus.Debugf("[ploop] Remove(id=%s)", id)
+
+	// Check if ploop was properly Get/Put:ed and is therefore unmounted
+again:
+	d.mountsM.Lock()
+	_, ok := d.mounts[id]
+	d.mountsM.Unlock()
+	if ok {
+		logrus.Warnf("[ploop] Remove(id=%s): unexpected on non-Put()", id)
+		d.Put(id)
+		goto again
+	}
+
+	dirs := []string{d.dir(id), d.mnt(id)}
+	for _, d := range dirs {
+		if err := os.RemoveAll(d); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Get mounts a given image and returns its mountpoint.
+func (d *Driver) Get(id, mountLabel string) (string, error) {
+	mnt := d.mnt(id)
+
+	d.mountsM.Lock()
+	m, ok := d.mounts[id]
+	if ok {
+		if m.count > 0 {
+			atomic.AddInt32(&m.count, 1)
+			logrus.Debugf("[ploop] skip Get(id=%s), dev=%s, count=%d", id, m.device, m.count)
+			d.mountsM.Unlock()
+			return mnt, nil
+		}
+		logrus.Warnf("[ploop] Get() id=%s, dev=%s: unexpected count=%d", id, m.device, m.count)
+	} else {
+		m = new(mount)
+		d.mounts[id] = m
+	}
+	d.mountsM.Unlock()
+
+	logrus.Debugf("[ploop] Get(id=%s)", id)
+	var mp ploop.MountParam
+
+	dd := d.dd(id)
+	dir := d.dir(id)
+	mp.Target = mnt
+	mp.Data = label.FormatMountLabel("", mountLabel)
+
+	// Open ploop descriptor
+	p, err := ploop.Open(dd)
+	if err != nil {
+		return "", err
+	}
+	defer p.Close()
+
+	_, err = os.Stat(path.Join(dir, "uuid-for-children"))
+	if err == nil {
+		// This snapshot was already used to clone children from,
+		// so we assume it won't be modified and mount it read-only.
+		// If this assumption is not true (i.e. write access is needed)
+		// we need to invalidate the snapshot by calling
+		//	removeVal(dir, "uuid-for-children")
+		// and then we can mount it read/write without fear.
+		mp.Readonly = true
+	} else if !os.IsNotExist(err) {
+		logrus.Warnf("[ploop] Unexpected error: %s", err)
+	}
+
+	// Mount
+	dev, err := p.Mount(&mp)
+	if err != nil {
+		return "", err
+	}
+
+	m.device = dev
+	atomic.AddInt32(&m.count, 1)
+
+	return mnt, nil
+}
+
+// Put unmounts a given image.
+func (d *Driver) Put(id string) error {
+	d.mountsM.Lock()
+	m, ok := d.mounts[id]
+	if ok {
+		if m.count > 1 {
+			atomic.AddInt32(&m.count, -1)
+			logrus.Debugf("[ploop] skip Put(id=%s), dev=%s, count=%d", id, m.device, m.count)
+			d.mountsM.Unlock()
+			return nil
+		} else if m.count == 1 {
+			atomic.AddInt32(&m.count, -1)
+		} else if m.count < 1 {
+			logrus.Warnf("[ploop] Put(id=%s), dev=%s, unexpected count=%d", id, m.device, m.count)
+		}
+	}
+	d.mountsM.Unlock()
+
+	logrus.Debugf("[ploop] Put(id=%s)", id)
+
+	dd := d.dd(id)
+	p, err := ploop.Open(dd)
+	if err != nil {
+		return err
+	}
+	defer p.Close()
+
+	err = p.Umount()
+	/* Ignore "not mounted" error */
+	if err != nil && ploop.IsNotMounted(err) {
+		err = nil
+	}
+
+	if err != nil {
+		logrus.Errorf("[ploop] Umount(%s): %s", id, err)
+		return err
+	}
+
+	d.mountsM.Lock()
+	delete(d.mounts, id)
+	d.mountsM.Unlock()
+
+	return nil
+}
+
+// Exists checks if a given image exists.
+func (d *Driver) Exists(id string) bool {
+	logrus.Debugf("[ploop] Exists(id=%s)", id)
+
+	// Check if DiskDescriptor.xml is there
+	dd := d.dd(id)
+	_, err := os.Stat(dd)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logrus.Errorf("[ploop] Unexpected error from stat(): %s", err)
+		}
+		return false
+	}
+
+	return true
+}

--- a/daemon/graphdriver/ploop/ploop_test.go
+++ b/daemon/graphdriver/ploop/ploop_test.go
@@ -1,0 +1,30 @@
+// +build linux
+
+package ploop
+
+import (
+	"github.com/docker/docker/daemon/graphdriver/graphtest"
+	"testing"
+)
+
+// This avoids creating a new driver for each test if all tests are run
+// Make sure to put new tests between TestPloopSetup and TestPloopTeardown
+func TestPloopSetup(t *testing.T) {
+	graphtest.GetDriver(t, "ploop")
+}
+
+func TestPloopCreateEmpty(t *testing.T) {
+	graphtest.DriverTestCreateEmpty(t, "ploop")
+}
+
+func TestPloopCreateBase(t *testing.T) {
+	graphtest.DriverTestCreateBase(t, "ploop")
+}
+
+func TestPloopCreateSnap(t *testing.T) {
+	graphtest.DriverTestCreateSnap(t, "ploop")
+}
+
+func TestPloopTeardown(t *testing.T) {
+	graphtest.PutDriver(t)
+}

--- a/daemon/graphdriver/ploop/ploop_unsupported.go
+++ b/daemon/graphdriver/ploop/ploop_unsupported.go
@@ -1,0 +1,3 @@
+// +build !linux
+
+package ploop

--- a/daemon/graphdriver/ploop/utils.go
+++ b/daemon/graphdriver/ploop/utils.go
@@ -1,0 +1,101 @@
+package ploop
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"syscall"
+)
+
+func syncAndClose(file *os.File) error {
+	err := syscall.Fdatasync(int(file.Fd()))
+	err2 := file.Close()
+	if err2 != nil {
+		return err2
+	}
+	return err
+}
+
+// copyFile copies a file (like command-line cp)
+func copyFile(src, dst string) (err error) {
+	s, err := os.Open(src)
+	if err != nil {
+		return
+	}
+
+	d, err := os.Create(dst)
+	if err != nil {
+		s.Close()
+		return
+	}
+
+	_, err = io.Copy(d, s)
+	s.Close()
+	if err != nil {
+		d.Close()
+		os.Remove(dst)
+		return
+	}
+	go syncAndClose(d)
+
+	// TODO: chown/chmod maybe?
+	return nil
+}
+
+// copyDir copies a directory (non-recursively, i.e. only files
+func copyDir(sdir, ddir string) (err error) {
+	files, err := ioutil.ReadDir(sdir)
+	if err != nil {
+		return err
+	}
+	for _, fi := range files {
+		name := fi.Name()
+		src := path.Join(sdir, name)
+		dst := path.Join(ddir, name)
+		// filter out non-files
+		if !fi.Mode().IsRegular() {
+			//			log.Warnf("[ploop] unexpected non-file %s", src)
+			continue
+		}
+		if err = copyFile(src, dst); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeVal(dir, id, val string) error {
+	m := os.O_WRONLY | os.O_CREATE | os.O_EXCL
+	fd, err := os.OpenFile(path.Join(dir, id), m, 0644)
+	if err != nil {
+		return err
+	}
+
+	_, err = fd.WriteString(val)
+	if err != nil {
+		return err
+	}
+
+	err = fd.Close()
+
+	return err
+}
+
+func readVal(dir, id string) (string, error) {
+	buf, err := ioutil.ReadFile(path.Join(dir, id))
+	if err == nil {
+		return string(buf), nil
+	}
+
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+
+	return "", err
+}
+
+func removeVal(dir, id string) error {
+	return os.Remove(path.Join(dir, id))
+}

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -10,6 +10,7 @@ clone git github.com/Azure/go-ansiterm 70b2c90b260171e829f1ebd7c17f600c11858dbe
 clone git github.com/Sirupsen/logrus v0.8.2 # logrus is a common dependency among multiple deps
 clone git github.com/docker/libtrust 9cbd2a1374f46905c68a4eb3694a130610adc62a
 clone git github.com/go-check/check 64131543e7896d5bcc6bd5a76287eb75ea96c673
+clone git github.com/kolyshkin/goploop-cli 5365b44
 clone git github.com/gorilla/context 14f550f51a
 clone git github.com/gorilla/mux e444e69cbd
 clone git github.com/kr/pty 5cf931ef8f

--- a/vendor/src/github.com/kolyshkin/goploop-cli/.gitignore
+++ b/vendor/src/github.com/kolyshkin/goploop-cli/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/src/github.com/kolyshkin/goploop-cli/LICENSE
+++ b/vendor/src/github.com/kolyshkin/goploop-cli/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/src/github.com/kolyshkin/goploop-cli/Makefile
+++ b/vendor/src/github.com/kolyshkin/goploop-cli/Makefile
@@ -1,0 +1,15 @@
+CGO_LDFLAGS	:= -l:libploop.a
+export CGO_LDFLAGS
+
+all: build
+
+build:
+	go build -v
+
+test:
+	go test -v .
+
+bench:
+	go test -v -run=XXX -bench=. -benchtime=10s
+
+.PHONY: all build test bench

--- a/vendor/src/github.com/kolyshkin/goploop-cli/README.md
+++ b/vendor/src/github.com/kolyshkin/goploop-cli/README.md
@@ -1,0 +1,91 @@
+# goploop-cli [![GoDoc](https://godoc.org/github.com/kolyshkin/goploop-cli?status.png)](https://godoc.org/github.com/kolyshkin/goploop-cli)
+
+This is a Go wrapper for [ploop](https://github.com/kolyshkin/ploop),
+a command line tool to manage ploop. It is designed to be a drop-in
+replacement for [goploop](https://github.com/kolyshkin/goploop) for
+those who don't like goploop build/link dependencies on a few C libraries.
+
+## Changes from goploop
+
+The differences between this package and [goploop](https://github.com/kolyshkin/goploop)
+are:
+
+* goploop calls ploop C library, while goploop-cli calls ploop command line tool
+* goploop has a few build time dependencies, goploop-cli has no such requirements
+* goploop has no runtime dependencies if built statically; goploop-cli requires ploop tool during runtime
+* goploop is a bit more efficient than goploop-cli (as latter has to do fork/exec); see details below
+* goploop-cli currently have some limitations (see below)
+
+Due to command line tool limitations, the following methods are currently not implemented, as compared to goploop:
+* ``SetLogFile()`` and ``SetLogLevel()`` are missing
+* ``GetTopDelta()`` is missing
+* ``SnapshotSwitchExtended()`` is missing
+
+The following methods differ:
+* ``GetFSInfo()`` returns BlockSize=1K instead of actual filesystem block size
+* ``Resize()`` ignores ``offline`` argument (ploop tool automatically chooses whether to do online or offline resize)
+* ``UUID()`` is implemented in pure Go
+
+### Performance comparison
+
+For most operations such as ``Create``, ``Mount``, ``Snapshot`` etc., there is no noticeable difference in performance, as these operations are pretty time consuming per se, so fork/exec overhead is negligible.
+
+Some quick testing (inside a VM on a laptop) shows that
+* method ``IsMounted()`` is about 25 times slower
+* method ``FSInfo()`` is about 5 times slower
+* method ``ImageInfo()`` is about 10 times slower
+* the overhead of fork/exec is apparently about 0.001 seconds per call
+
+Here are benchmark results for goploop-cli:
+```
+[goploop-cli]# go test -v -run=XXX -bench=. -benchtime=10s
+BenchmarkMountUmount      10  1012960549 ns/op
+BenchmarkIsMounted     10000     1130291 ns/op
+BenchmarkFSInfo        10000     1306527 ns/op
+BenchmarkImageInfo     10000     1188473 ns/op
+```
+Here are benchmark results for goploop:
+```
+[goploop]# go test -v -run=XXX -bench=. -benchtime=10s
+BenchmarkMountUmount      10  1016400056 ns/op
+BenchmarkIsMounted    300000       42948 ns/op
+BenchmarkFSInfo       100000      224346 ns/op
+BenchmarkImageInfo    100000      127287 ns/op
+```
+## What is ploop?
+
+Ploop is a loopback block device (a.k.a. "filesystem in a file"),
+not unlike [loop](https://en.wikipedia.org/wiki/Loop_device)
+but with better performance and more features, including:
+
+* thin provisioning (image grows on demand)
+* dynamic resize (both grow and shrink)
+* instant online snapshots
+* online snapshot merge
+* optimized image migration with write tracker (ploop copy)
+
+Ploop is implemented in the kernel and is currently available
+in OpenVZ RHEL6 and RHEL7 based kernels. For more information
+about ploop, see [openvz.org/Ploop](https://openvz.org/Ploop).
+
+## Prerequisites
+
+You need to have
+* ext4 formatted partition (note RHEL/CentOS 7 installer uses xfs by default, that won't work!)
+* ploop-enabled kernel installed
+* ploop package installed
+
+Currently, all the above comes with OpenVZ, please see [openvz.org/Quick_installation](https://openvz.org/Quick_installation).
+
+## Usage
+
+This package is used by Docker ploop graphdriver, see https://github.com/kolyshkin/docker/tree/ploop/daemon/graphdriver/ploop
+
+For primitive examples of how to use the package, see [ploop_test.go](ploop_test.go).
+
+## See also
+
+* [goploop](https://github.com/kolyshkin/goploop) -- an alternative implementation using libploop
+* [openvz.org/Ploop](https://openvz.org/Ploop) -- more information about ploop
+* [ploop(8)](https://openvz.org/Man/ploop.8) man page
+* [OpenVZ](https://openvz.org)

--- a/vendor/src/github.com/kolyshkin/goploop-cli/ploop.go
+++ b/vendor/src/github.com/kolyshkin/goploop-cli/ploop.go
@@ -1,0 +1,367 @@
+package ploop
+
+import (
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Ploop is a class representing a ploop
+type Ploop struct {
+	dd string
+}
+
+// Possible SetVerboseLevel arguments
+const (
+	unsetVerbosity int = -111
+	NoConsole          = -2
+	NoStdout           = -1
+	Timestamps         = 4
+	ShowCommands       = 5
+)
+
+var verbosity = unsetVerbosity
+var verbosityOpt = []string{""}
+
+// SetVerboseLevel sets a level of verbosity when logging to stdout/stderr
+func SetVerboseLevel(v int) {
+	verbosity = v
+	verbosityOpt = []string{"-v" + strconv.Itoa(verbosity)}
+}
+
+var once sync.Once
+
+// load ploop modules
+func loadKmod() {
+	// try to load ploop modules
+	modules := []string{"ploop", "pfmt_ploop1", "pfmt_raw", "pio_direct", "pio_nfs", "pio_kaio"}
+	for _, m := range modules {
+		exec.Command("modprobe", m).Run()
+	}
+}
+
+// Open opens a ploop DiskDescriptor.xml, most ploop operations require it
+func Open(file string) (Ploop, error) {
+	var d Ploop
+
+	once.Do(loadKmod)
+
+	d.dd = file
+	return d, nil
+}
+
+// Close closes a ploop disk descriptor when it is no longer needed
+func (d Ploop) Close() {
+	d.dd = ""
+}
+
+// ImageMode is a type for CreateParam.Mode field
+type ImageMode string
+
+// Possible values for ImageMode
+const (
+	Expanded     ImageMode = "expanded"
+	Preallocated ImageMode = "preallocated"
+	Raw          ImageMode = "raw"
+)
+
+// ParseImageMode converts a string to ImageMode value
+func ParseImageMode(s string) (ImageMode, error) {
+	switch strings.ToLower(s) {
+	case "expanded":
+		return Expanded, nil
+	case "preallocated":
+		return Preallocated, nil
+	case "raw":
+		return Raw, nil
+	default:
+		return Expanded, &Err{c: E_PARAM, s: "ParseImageMode: unknown mode " + s}
+	}
+}
+
+// String converts an ImageMode value to string
+func (m ImageMode) String() string {
+	return string(m)
+}
+
+// CreateFlags is a type for CreateParam.Flags
+type CreateFlags int
+
+// Possible values for CreateFlags
+const (
+	NoLazy CreateFlags = 1 << iota
+)
+
+// CreateParam is a set of parameters for a newly created ploop
+type CreateParam struct {
+	Size  uint64      // image size, in kilobytes (FS size is about 10% smaller)
+	Mode  ImageMode   // image mode
+	File  string      // path to and a file name for base delta image
+	CLog  uint        // cluster block size log (6 to 15, default 11)
+	Flags CreateFlags // flags
+}
+
+// Create creates a ploop image and its DiskDescriptor.xml
+func Create(p *CreateParam) error {
+	once.Do(loadKmod)
+
+	// default image file name
+	if p.File == "" {
+		p.File = "root.hdd"
+	}
+
+	args := []string{"init", "-s", strconv.FormatUint(p.Size, 10) + "K"}
+	if p.Mode != "" {
+		args = append(args, "-f", string(p.Mode))
+	}
+	if p.CLog != 0 {
+		// ploop cluster block size, in 512-byte sectors
+		// default is 1M cluster block size (CLog=11)
+		// 2^11 = 2048 sectors, 2048*512 = 1M
+		blocksize := 1 << p.CLog
+		args = append(args, "-b", strconv.Itoa(blocksize))
+	}
+	if p.Flags != 0 {
+		if p.Flags&NoLazy == NoLazy {
+			args = append(args, "--nolazy")
+		}
+	}
+	args = append(args, p.File)
+
+	return ploop(args...)
+}
+
+// MountParam is a set of parameters to pass to Mount()
+type MountParam struct {
+	UUID     string // snapshot uuid (empty for top delta)
+	Target   string // mount point (empty if no mount is needed)
+	Data     string // auxiliary mount options
+	Readonly bool   // mount read-only
+	Fsck     bool   // do fsck before mounting inner FS
+}
+
+// Input is like this (with or without a timestamp, depending on verbosity):
+// [ 0.001234] Adding delta dev=/dev/ploop12345 ...
+// Adding delta dev=/dev/ploop12345 ...
+var reAddDelta = regexp.MustCompile(`(?m)^(?:\[[0-9. ]+\] )*Adding delta dev=(/dev/ploop\d+) `)
+
+// Mount creates a ploop device and (optionally) mounts it
+func (d Ploop) Mount(p *MountParam) (string, error) {
+	args := []string{"mount"}
+	if p.Readonly {
+		args = append(args, "-r")
+	}
+	if p.Fsck {
+		args = append(args, "-F")
+	}
+	if p.Target != "" {
+		args = append(args, "-m", p.Target)
+	}
+	if p.Data != "" {
+		args = append(args, "-o", p.Data)
+	}
+	args = append(args, d.dd)
+
+	dev := ""
+	out, err := ploopOut(args...)
+	if err == nil {
+		// Figure out what device we have
+		m := reAddDelta.FindStringSubmatch(out)
+		if len(m) != 2 {
+			return "", &Err{c: -1,
+				s: "Can't parse ploop mount output:\n" + out}
+		}
+		dev = m[1]
+	}
+
+	return dev, err
+}
+
+// Umount unmounts the ploop filesystem and dismantles the device
+func (d Ploop) Umount() error {
+	return ploop("umount", d.dd)
+}
+
+// UmountByDevice unmounts the ploop filesystem and dismantles the device.
+// Unlike Umount(), this is a lower-level function meaning it can be less
+// safe and should generally not be used.
+func UmountByDevice(dev string) error {
+	return ploop("umount", "-d", dev)
+}
+
+// Resize changes the ploop size. Offline flag is ignored
+// by this implementation, as ploop tool automatically chooses
+// whether do to offline resize (if device is not mounted).
+func (d Ploop) Resize(size uint64, offline bool) error {
+	return ploop("resize", "-s", strconv.FormatUint(size, 10)+"K", d.dd)
+}
+
+// Snapshot creates a ploop snapshot, returning its uuid
+func (d Ploop) Snapshot() (string, error) {
+	uuid, err := UUID()
+	if err != nil {
+		return "", err
+	}
+
+	return uuid, ploop("snapshot", "-u", uuid, d.dd)
+}
+
+// SwitchSnapshot switches to a specified snapshot,
+// creates a new empty delta on top of it, and makes it a top one
+// (i.e. the one new data will be written to).
+// Old top delta (i.e. data modified since the last snapshot) is lost.
+func (d Ploop) SwitchSnapshot(uuid string) error {
+	return ploop("snapshot-switch", "-u", uuid, d.dd)
+}
+
+// DeleteSnapshot deletes a snapshot (merging it down if necessary)
+func (d Ploop) DeleteSnapshot(uuid string) error {
+	return ploop("snapshot-delete", "-u", uuid, d.dd)
+}
+
+// ReplaceFlag is a type for ReplaceParam.Flags field
+type ReplaceFlag int
+
+// Possible values for ReplaceParam.Flags field
+const (
+	_ = iota
+	// KeepName renames the new file to old file name after replace;
+	// note that if this option is used the old file is removed.
+	KeepName ReplaceFlag = iota
+)
+
+// ReplaceParam is a set of parameters to Replace()
+type ReplaceParam struct {
+	File string // new image file name
+	// Image to be replaced is specified by either
+	// uuid, current file name, or level,
+	// in the above order of preference.
+	UUID    string
+	CurFile string
+	Level   int
+	Flags   ReplaceFlag
+}
+
+// Replace replaces a ploop image to a different (but identical) one
+func (d Ploop) Replace(p *ReplaceParam) error {
+	args := []string{"replace"}
+	if p.UUID != "" {
+		args = append(args, "-u", p.UUID)
+	} else if p.CurFile != "" {
+		args = append(args, "-o", p.CurFile)
+	} else {
+		args = append(args, "-l", strconv.Itoa(p.Level))
+	}
+
+	if p.Flags != 0 {
+		if p.Flags&KeepName == KeepName {
+			args = append(args, "-k")
+		}
+	}
+	args = append(args, "-i", p.File)
+	args = append(args, d.dd)
+
+	return ploop(args...)
+}
+
+// device:	/dev/ploop25579
+var reDevice = regexp.MustCompile(`(?m)^device:\s+(/dev/ploop\d+)$`)
+
+func (d Ploop) getDevice() (string, error) {
+	dev := ""
+	out, err := ploopOut("-v-1", "info", "-d", d.dd)
+	if err == nil {
+		// Figure out what device we have
+		m := reDevice.FindStringSubmatch(out)
+		if len(m) > 1 {
+			dev = m[1]
+		}
+	}
+	return dev, err
+}
+
+// IsMounted returns true if ploop is mounted
+func (d Ploop) IsMounted() (bool, error) {
+	dev, err := d.getDevice()
+	return dev != "", err
+}
+
+// FSInfoData holds information about ploop inner file system
+type FSInfoData struct {
+	BlockSize  uint64
+	Blocks     uint64
+	BlocksFree uint64
+	Inodes     uint64
+	InodesFree uint64
+}
+
+//   resource           Size           Used
+//  1k-blocks       10188052          36888
+//     inodes         655360             12
+var reFSInfo = regexp.MustCompile(`
+\s+1k-blocks\s+(\d+)\s+(\d+)
+\s+inodes\s+(\d+)\s+(\d+)
+`)
+
+// FSInfo gets info of ploop's inner file system
+func FSInfo(file string) (FSInfoData, error) {
+	once.Do(loadKmod)
+	var info FSInfoData
+
+	out, err := ploopOut("-v-1", "info", file)
+	if err == nil {
+		info.BlockSize = 1024 // ploop info reports in 1-k blocks
+		i := reFSInfo.FindStringSubmatch(out)
+		if len(i) != 5 {
+			return info, &Err{c: -1,
+				s: "Can't parse ploop info output:\n" + out}
+		}
+
+		info.Blocks, _ = strconv.ParseUint(i[1], 10, 64)
+		blocksUsed, _ := strconv.ParseUint(i[2], 10, 64)
+		info.BlocksFree = info.Blocks - blocksUsed
+
+		info.Inodes, _ = strconv.ParseUint(i[3], 10, 64)
+		inodesUsed, _ := strconv.ParseUint(i[4], 10, 64)
+		info.InodesFree = info.Inodes - inodesUsed
+	}
+
+	return info, err
+}
+
+// ImageInfoData holds information about ploop image
+type ImageInfoData struct {
+	Blocks    uint64
+	BlockSize uint32
+	Version   int
+}
+
+// size:	20971520
+// blocksize:	2048
+// fmt_version:	2
+var reImageInfo = regexp.MustCompile(`\n*size:\s+(\d+)
+blocksize:\s+(\d+)
+fmt_version:\s+(\d*)
+`)
+
+// ImageInfo gets information about a ploop image
+func (d Ploop) ImageInfo() (ImageInfoData, error) {
+	var info ImageInfoData
+
+	out, err := ploopOut("-v-1", "info", "-s", d.dd)
+	if err == nil {
+		i := reImageInfo.FindStringSubmatch(out)
+		if len(i) != 4 {
+			return info, &Err{c: -1,
+				s: "Can't parse ploop info -s output:\n" + out}
+		}
+		info.Blocks, _ = strconv.ParseUint(i[1], 10, 64)
+		bs, _ := strconv.ParseUint(i[2], 10, 32)
+		info.BlockSize = uint32(bs)
+		info.Version, _ = strconv.Atoi(i[3])
+	}
+
+	return info, err
+}

--- a/vendor/src/github.com/kolyshkin/goploop-cli/ploop_error.go
+++ b/vendor/src/github.com/kolyshkin/goploop-cli/ploop_error.go
@@ -1,0 +1,123 @@
+package ploop
+
+import "fmt"
+
+type Err struct {
+	c int
+	s string
+}
+
+// SYSEXIT_* errors
+const (
+	_ = iota
+	E_CREAT
+	E_DEVICE
+	E_DEVIOC
+	E_OPEN
+	E_MALLOC
+	E_READ
+	E_WRITE
+	E_RESERVED_8
+	E_SYSFS
+	E_RESERVED_10
+	E_PLOOPFMT
+	E_SYS
+	E_PROTOCOL
+	E_LOOP
+	E_FSTAT
+	E_FSYNC
+	E_EBUSY
+	E_FLOCK
+	E_FTRUNCATE
+	E_FALLOCATE
+	E_MOUNT
+	E_UMOUNT
+	E_LOCK
+	E_MKFS
+	E_RESERVED_25
+	E_RESIZE_FS
+	E_MKDIR
+	E_RENAME
+	E_ABORT
+	E_RELOC
+	E_RESERVED_31
+	E_RESERVED_32
+	E_CHANGE_GPT
+	E_RESERVED_34
+	E_UNLINK
+	E_MKNOD
+	E_PLOOPINUSE
+	E_PARAM
+	E_DISKDESCR
+	E_DEV_NOT_MOUNTED
+	E_FSCK
+	E_RESERVED_42
+	E_NOSNAP
+)
+
+var ErrCodes = []string{
+	E_CREAT:           "E_CREAT",
+	E_DEVICE:          "E_DEVICE",
+	E_DEVIOC:          "E_DEVIOC",
+	E_OPEN:            "E_OPEN",
+	E_MALLOC:          "E_MALLOC",
+	E_READ:            "E_READ",
+	E_WRITE:           "E_WRITE",
+	E_RESERVED_8:      "E_RESERVED",
+	E_SYSFS:           "E_SYSFS",
+	E_RESERVED_10:     "E_RESERVED",
+	E_PLOOPFMT:        "E_PLOOPFMT",
+	E_SYS:             "E_SYS",
+	E_PROTOCOL:        "E_PROTOCOL",
+	E_LOOP:            "E_LOOP",
+	E_FSTAT:           "E_FSTAT",
+	E_FSYNC:           "E_FSYNC",
+	E_EBUSY:           "E_EBUSY",
+	E_FLOCK:           "E_FLOCK",
+	E_FTRUNCATE:       "E_FTRUNCATE",
+	E_FALLOCATE:       "E_FALLOCATE",
+	E_MOUNT:           "E_MOUNT",
+	E_UMOUNT:          "E_UMOUNT",
+	E_LOCK:            "E_LOCK",
+	E_MKFS:            "E_MKFS",
+	E_RESERVED_25:     "E_RESERVED",
+	E_RESIZE_FS:       "E_RESIZE_FS",
+	E_MKDIR:           "E_MKDIR",
+	E_RENAME:          "E_RENAME",
+	E_ABORT:           "E_ABORT",
+	E_RELOC:           "E_RELOC",
+	E_RESERVED_31:     "E_RESERVED",
+	E_RESERVED_32:     "E_RESERVED",
+	E_CHANGE_GPT:      "E_CHANGE_GPT",
+	E_RESERVED_34:     "E_RESERVED",
+	E_UNLINK:          "E_UNLINK",
+	E_MKNOD:           "E_MKNOD",
+	E_PLOOPINUSE:      "E_PLOOPINUSE",
+	E_PARAM:           "E_PARAM",
+	E_DISKDESCR:       "E_DISKDESCR",
+	E_DEV_NOT_MOUNTED: "E_DEV_NOT_MOUNTED",
+	E_FSCK:            "E_FSCK",
+	E_RESERVED_42:     "E_RESERVED",
+	E_NOSNAP:          "E_NOSNAP",
+}
+
+// Error returns a string representation of a ploop error
+func (e *Err) Error() string {
+	s := "E_UNKNOWN"
+	if e.c > 0 && e.c < len(ErrCodes) {
+		s = ErrCodes[e.c]
+	}
+
+	return fmt.Sprintf("ploop error %d (%s): %s", e.c, s, e.s)
+}
+
+// IsError checks if an error is a specific ploop error
+func IsError(err error, code int) bool {
+	perr, ok := err.(*Err)
+	return ok && perr.c == code
+}
+
+// IsNotMounted returns true if an error is ploop "device is not mounted"
+func IsNotMounted(err error) bool {
+	return IsError(err, E_DEV_NOT_MOUNTED)
+}

--- a/vendor/src/github.com/kolyshkin/goploop-cli/ploop_exec.go
+++ b/vendor/src/github.com/kolyshkin/goploop-cli/ploop_exec.go
@@ -1,0 +1,67 @@
+package ploop
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+func ploopRunCmd(stdout io.Writer, args ...string) error {
+	if verbosity != unsetVerbosity {
+		if !strings.HasPrefix(args[0], "-v") {
+			args = append(verbosityOpt, args...)
+		}
+		if verbosity > NoStdout && stdout == nil {
+			stdout = os.Stdout
+		}
+	}
+	var stderr bytes.Buffer
+	cmd := exec.Command("ploop", args...)
+	cmd.Stdout = stdout
+	cmd.Stderr = &stderr
+
+	if verbosity >= ShowCommands {
+		fmt.Printf("Run: %s\n", strings.Join([]string{cmd.Path, strings.Join(cmd.Args[1:], " ")}, " "))
+	}
+
+	err := cmd.Run()
+	if err == nil {
+		return nil
+	}
+
+	// Command returned an error, get the stderr
+	errStr := stderr.String()
+	// Get the exit code (Unix-specific)
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			errCode := status.ExitStatus()
+			return &Err{c: errCode, s: errStr}
+		}
+	}
+	// unknown exit code
+	return &Err{c: -1, s: errStr}
+}
+
+func ploop(args ...string) error {
+	return ploopRunCmd(nil, args...)
+}
+
+func ploopOut(args ...string) (string, error) {
+	var stdout bytes.Buffer
+	// Output is reqired, make sure verbosity is not negative
+	if verbosity < 0 {
+		v := []string{"-v0"}
+		args = append(v, args...)
+	}
+	ret := ploopRunCmd(&stdout, args...)
+	out := stdout.String()
+	// if verbosity requires so, print command's stdout
+	if verbosity > NoStdout {
+		fmt.Printf("%s", out)
+	}
+	return out, ret
+}

--- a/vendor/src/github.com/kolyshkin/goploop-cli/ploop_test.go
+++ b/vendor/src/github.com/kolyshkin/goploop-cli/ploop_test.go
@@ -1,0 +1,435 @@
+package ploop
+
+// A test suite, also serving as an example of how to use the package
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/dustin/go-humanize"
+)
+
+var (
+	old_pwd  string
+	test_dir string
+	d        Ploop
+	snap     string
+)
+
+const baseDelta = "root.hdd"
+
+// abort is used when the tests after the current one
+// can't be run as one of their prerequisite(s) failed
+func abort(format string, args ...interface{}) {
+	s := fmt.Sprintf("ABORT: "+format+"\n", args...)
+	f := bufio.NewWriter(os.Stderr)
+	f.Write([]byte(s))
+	f.Flush()
+	cleanup()
+	os.Exit(1)
+}
+
+// Check for a fatal error, call abort() if it is
+func chk(err error) {
+	if err != nil {
+		abort("%s", err)
+	}
+}
+
+func prepare(dir string) {
+	var err error
+
+	old_pwd, err = os.Getwd()
+	chk(err)
+
+	test_dir, err = ioutil.TempDir(old_pwd, dir)
+	chk(err)
+
+	err = os.Chdir(test_dir)
+	chk(err)
+
+	SetVerboseLevel(NoStdout)
+}
+
+func TestPrepare(t *testing.T) {
+	prepare("tmp-test")
+}
+
+func TestUUID(t *testing.T) {
+	uuid, e := UUID()
+	if e != nil {
+		t.Errorf("UUID: %s", e)
+	}
+
+	t.Logf("Got uuid %s", uuid)
+}
+
+func create() {
+	size := "384M"
+	var p CreateParam
+
+	s, e := humanize.ParseBytes(size)
+	if e != nil {
+		abort("humanize.ParseBytes: can't parse %s: %s", size, e)
+	}
+	p.Size = s / 1024
+	p.File = baseDelta
+
+	e = Create(&p)
+	if e != nil {
+		abort("Create: %s", e)
+	}
+}
+
+func TestCreate(t *testing.T) {
+	create()
+}
+
+func open() {
+	var e error
+
+	d, e = Open("DiskDescriptor.xml")
+	if e != nil {
+		abort("Open: %s", e)
+	}
+}
+
+func TestOpen(t *testing.T) {
+	open()
+}
+
+func TestMount(t *testing.T) {
+	mnt := "mnt"
+
+	e := os.Mkdir(mnt, 0755)
+	chk(e)
+
+	p := MountParam{Target: mnt}
+	dev, e := d.Mount(&p)
+	if e != nil {
+		abort("Mount: %s", e)
+	}
+
+	t.Logf("Mounted; ploop device %s", dev)
+}
+
+func resize(t *testing.T, size string, offline bool) {
+	if offline && testing.Short() {
+		t.Skip("skipping offline resize test in short mode.")
+	}
+	s, e := humanize.ParseBytes(size)
+	if e != nil {
+		t.Fatalf("humanize.ParseBytes: can't parse %s: %s", size, e)
+	}
+	s = s / 1024
+
+	e = d.Resize(s, offline)
+	if e != nil {
+		t.Fatalf("Resize to %s (%d bytes) failed: %s", size, s, e)
+	}
+}
+
+func TestResizeOnlineShrink(t *testing.T) {
+	resize(t, "256MB", false)
+}
+
+func TestResizeOnlineGrow(t *testing.T) {
+	resize(t, "512MB", false)
+}
+
+func TestSnapshot(t *testing.T) {
+	uuid, e := d.Snapshot()
+	if e != nil {
+		abort("Snapshot: %s", e)
+	}
+
+	t.Logf("Created online snapshot; uuid %s", uuid)
+	snap = uuid
+}
+
+func copyFile(src, dst string) error {
+	return exec.Command("cp", "-a", src, dst).Run()
+}
+
+func testReplace(t *testing.T) {
+	var p ReplaceParam
+	newDelta := baseDelta + ".new"
+	e := copyFile(baseDelta, newDelta)
+	if e != nil {
+		t.Fatalf("copyFile: %s", e)
+	}
+
+	p.File = newDelta
+	p.CurFile = baseDelta
+	p.Flags = KeepName
+	e = d.Replace(&p)
+	if e != nil {
+		t.Fatalf("Replace: %s", e)
+	}
+}
+
+func TestReplaceOnline(t *testing.T) {
+	testReplace(t)
+}
+
+func TestSwitchSnapshotOnline(t *testing.T) {
+	e := d.SwitchSnapshot(snap)
+	// should fail with E_PARAM
+	if IsError(e, E_PARAM) {
+		t.Logf("SwitchSnapshot: (online) good, expected error")
+	} else {
+		t.Fatalf("SwitchSnapshot: (should fail): %s", e)
+	}
+}
+
+func TestDeleteSnapshot(t *testing.T) {
+	e := d.DeleteSnapshot(snap)
+	if e != nil {
+		t.Fatalf("DeleteSnapshot: %s", e)
+	} else {
+		t.Logf("Deleted snapshot %s", snap)
+	}
+}
+
+func TestIsMounted1(t *testing.T) {
+	m, e := d.IsMounted()
+	if e != nil {
+		t.Fatalf("IsMounted: %s", e)
+	}
+	if !m {
+		t.Fatalf("IsMounted: unexpectedly returned false")
+	}
+}
+
+func TestUmount(t *testing.T) {
+	e := d.Umount()
+	if e != nil {
+		t.Fatalf("Umount: %s", e)
+	}
+}
+
+func TestIsMounted2(t *testing.T) {
+	m, e := d.IsMounted()
+	if e != nil {
+		t.Fatalf("IsMounted: %s", e)
+	}
+	if m {
+		t.Fatalf("IsMounted: unexpectedly returned true")
+	}
+}
+
+func TestUmountAgain(t *testing.T) {
+	e := d.Umount()
+	if IsNotMounted(e) {
+		t.Logf("Umount: (not mounted) good, expected error")
+	} else {
+		t.Fatalf("Umount: %s", e)
+	}
+}
+
+func TestResizeOfflineShrink(t *testing.T) {
+	resize(t, "256MB", true)
+}
+
+func TestResizeOfflineGrow(t *testing.T) {
+	resize(t, "512MB", true)
+}
+
+func TestResizeOfflineShrinkAgain(t *testing.T) {
+	resize(t, "256MB", true)
+}
+
+func TestSnapshotOffline(t *testing.T) {
+	uuid, e := d.Snapshot()
+	if e != nil {
+		t.Fatalf("Snapshot: %s", e)
+	} else {
+		t.Logf("Created offline snapshot; uuid %s", uuid)
+	}
+
+	snap = uuid
+}
+
+func TestReplaceOffline(t *testing.T) {
+	testReplace(t)
+}
+
+func TestSwitchSnapshot(t *testing.T) {
+	e := d.SwitchSnapshot(snap)
+	if e != nil {
+		t.Fatalf("SwitchSnapshot: %s", e)
+	} else {
+		t.Logf("Switched to snapshot %s", snap)
+	}
+}
+
+func TestFSInfo(t *testing.T) {
+	i, e := FSInfo("DiskDescriptor.xml")
+
+	if e != nil {
+		t.Errorf("FSInfo: %v", e)
+	} else {
+		bTotal := i.Blocks * i.BlockSize
+		bAvail := i.BlocksFree * i.BlockSize
+		bUsed := bTotal - bAvail
+
+		iTotal := i.Inodes
+		iAvail := i.InodesFree
+		iUsed := iTotal - iAvail
+
+		t.Logf("\n             Size       Used      Avail Use%%\n%7s %9s %10s %10s %3d%%\n%7s %9d %10d %10d %3d%%",
+			"Blocks",
+			humanize.Bytes(bTotal),
+			humanize.Bytes(bUsed),
+			humanize.Bytes(bAvail),
+			100*bUsed/bTotal,
+			"Inodes",
+			iTotal,
+			iUsed,
+			iAvail,
+			100*iUsed/iTotal)
+		t.Logf("\nInode ratio: 1 inode per %s of disk space",
+			humanize.Bytes(bTotal/iTotal))
+	}
+}
+
+func TestImageInfo(t *testing.T) {
+	i, e := d.ImageInfo()
+	if e != nil {
+		t.Errorf("ImageInfo: %v", e)
+	} else {
+		t.Logf("\n              Blocks  Blocksize       Size  Ver\n%20d %10d %10s %4d",
+			i.Blocks, i.BlockSize,
+			humanize.Bytes(512*i.Blocks),
+			i.Version)
+	}
+
+}
+
+func cleanup() {
+	if d.dd != "" {
+		if m, _ := d.IsMounted(); m {
+			d.Umount()
+		}
+		d.Close()
+	}
+	if old_pwd != "" {
+		os.Chdir(old_pwd)
+	}
+	if test_dir != "" {
+		os.RemoveAll(test_dir)
+	}
+}
+
+// TestCleanup is the last test, removing files created by previous tests
+func TestCleanup(t *testing.T) {
+	cleanup()
+}
+
+func BenchmarkMountUmount(b *testing.B) {
+	b.StopTimer()
+	prepare("tmp-bench")
+	SetVerboseLevel(NoStdout)
+	create()
+	open()
+	mnt := "mnt"
+	e := os.Mkdir(mnt, 0755)
+	chk(e)
+	p := MountParam{Target: mnt, Readonly: true}
+
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		_, e := d.Mount(&p)
+		if e != nil {
+			b.Fatalf("Mount: %s", e)
+		}
+		e = d.Umount()
+		if e != nil {
+			b.Fatalf("Umount: %s", e)
+		}
+	}
+	b.StopTimer()
+	cleanup()
+}
+
+func BenchmarkIsMounted(b *testing.B) {
+	b.StopTimer()
+	prepare("tmp-bench")
+	SetVerboseLevel(NoStdout)
+	create()
+	open()
+	mnt := "mnt"
+	e := os.Mkdir(mnt, 0755)
+	chk(e)
+	p := MountParam{Target: mnt, Readonly: true}
+	_, e = d.Mount(&p)
+	if e != nil {
+		b.Fatalf("Mount: %s", e)
+	}
+
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		_, e := d.IsMounted()
+		if e != nil {
+			b.Fatalf("IsMounted: %s", e)
+		}
+	}
+	b.StopTimer()
+	cleanup()
+}
+
+func BenchmarkFSInfo(b *testing.B) {
+	b.StopTimer()
+	prepare("tmp-bench")
+	SetVerboseLevel(NoStdout)
+	create()
+	open()
+	mnt := "mnt"
+	e := os.Mkdir(mnt, 0755)
+	chk(e)
+	p := MountParam{Target: mnt, Readonly: true}
+	_, e = d.Mount(&p)
+	if e != nil {
+		b.Fatalf("Mount: %s", e)
+	}
+
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		_, e := FSInfo("DiskDescriptor.xml")
+		if e != nil {
+			b.Fatalf("FSInfo: %s", e)
+		}
+	}
+	b.StopTimer()
+	cleanup()
+}
+
+func BenchmarkImageInfo(b *testing.B) {
+	b.StopTimer()
+	prepare("tmp-bench")
+	SetVerboseLevel(NoStdout)
+	create()
+	open()
+	mnt := "mnt"
+	e := os.Mkdir(mnt, 0755)
+	chk(e)
+	p := MountParam{Target: mnt, Readonly: true}
+	_, e = d.Mount(&p)
+	if e != nil {
+		b.Fatalf("Mount: %s", e)
+	}
+
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		_, e := d.ImageInfo()
+		if e != nil {
+			b.Fatalf("ImageInfo: %s", e)
+		}
+	}
+	b.StopTimer()
+	cleanup()
+}

--- a/vendor/src/github.com/kolyshkin/goploop-cli/ploop_uuid.go
+++ b/vendor/src/github.com/kolyshkin/goploop-cli/ploop_uuid.go
@@ -1,0 +1,23 @@
+package ploop
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// UUID generates a ploop UUID
+func UUID() (string, error) {
+	u := make([]byte, 16)
+	_, err := rand.Read(u)
+	if err != nil {
+		return "", err
+	}
+
+	u[6] = (u[6] & 0x0F) | 0x40 // Version 4
+	u[8] = (u[8] & 0x3F) | 0x80 // Variant is 10
+
+	uuid := fmt.Sprintf("{%08x-%04x-%04x-%04x-%012x}",
+		u[:4], u[4:6], u[6:8], u[8:10], u[10:])
+
+	return uuid, nil
+}


### PR DESCRIPTION
This is a second attempt in merging ploop graphdriver.
This time I have addressed all concerns voiced in previous iteration (https://github.com/docker/docker/pull/15516). Notable changes are:
- this no longer depends on any libraries
- vendoring commit is separate
- some more testing

The driver itself hasn't changed much since the last pull request; instead I rewrote the goploop wrapper to call ploop command line tool. I did some benchmarks and figured out performance doesn't differ much, as fork/exec overhead is negligible for most operations. 

Also, I no longer consider this experimental, it performs well and survives all the tests I threw at it (more on that in [README.md](https://github.com/kolyshkin/docker/blob/ploop-merge-2/daemon/graphdriver/ploop/README.md); if there are some more tests I should run, please let me know).

For more details, please see:
- [daemon/graphdriver/ploop/README.md](https://github.com/kolyshkin/docker/blob/ploop-merge-2/daemon/graphdriver/ploop/README.md)
- [github.com/kolyshkin/goploop-cli/blob/master/README.md](https://github.com/kolyshkin/goploop-cli/blob/master/README.md)
- [openvz.org/Ploop](https://openvz.org/Ploop)
