### PR TITLE
Change ParseTCPAddr to use tcp://127.0.0.0:2375 format as default consistently

### DIFF
--- a/opts/hosts_windows.go
+++ b/opts/hosts_windows.go
@@ -2,7 +2,5 @@
 
 package opts
 
-import "fmt"
-
 // DefaultHost constant defines the default host string used by docker on Windows
-var DefaultHost = fmt.Sprintf("tcp://%s:%d", DefaultHTTPHost, DefaultHTTPPort)
+var DefaultHost = DefaultTCPHost

--- a/opts/opts.go
+++ b/opts/opts.go
@@ -25,6 +25,8 @@ var (
 	// DefaultUnixSocket Path for the unix socket.
 	// Docker daemon by default always listens on the default unix socket
 	DefaultUnixSocket = "/var/run/docker.sock"
+	// DefaultTCPHost constant defines the default host string used by docker on Windows
+	DefaultTCPHost = fmt.Sprintf("tcp://%s:%d", DefaultHTTPHost, DefaultHTTPPort)
 )
 
 // ListOpts holds a list of values and a validation function.
@@ -333,7 +335,7 @@ func ValidateLabel(val string) (string, error) {
 
 // ValidateHost validates that the specified string is a valid host and returns it.
 func ValidateHost(val string) (string, error) {
-	host, err := parsers.ParseHost(DefaultHTTPHost, DefaultUnixSocket, val)
+	host, err := parsers.ParseDockerDaemonHost(DefaultTCPHost, DefaultUnixSocket, val)
 	if err != nil {
 		return val, err
 	}

--- a/opts/opts_test.go
+++ b/opts/opts_test.go
@@ -441,7 +441,6 @@ func TestValidateHost(t *testing.T) {
 		"something with spaces": "Invalid bind address format: something with spaces",
 		"://":                "Invalid bind address format: ://",
 		"unknown://":         "Invalid bind address format: unknown://",
-		"tcp://":             "Invalid proto, expected tcp: ",
 		"tcp://:port":        "Invalid bind address format: :port",
 		"tcp://invalid":      "Invalid bind address format: invalid",
 		"tcp://invalid:port": "Invalid bind address format: invalid:port",
@@ -449,6 +448,8 @@ func TestValidateHost(t *testing.T) {
 	valid := map[string]string{
 		"fd://":                    "fd://",
 		"fd://something":           "fd://something",
+		"tcp://host:":              "tcp://host:2375",
+		"tcp://":                   "tcp://127.0.0.1:2375",
 		"tcp://:2375":              "tcp://127.0.0.1:2375", // default ip address
 		"tcp://:2376":              "tcp://127.0.0.1:2376", // default ip address
 		"tcp://0.0.0.0:8080":       "tcp://0.0.0.0:8080",


### PR DESCRIPTION
another extraction from #15753 

Also print the user input on error, not the parsed, and potentially defaulted values.

Signed-off-by: Sven Dowideit SvenDowideit@home.org.au
