### PR TITLE
Add more unit tests on api/client/ps package

### DIFF
--- a/api/client/ps/custom.go
+++ b/api/client/ps/custom.go
@@ -1,12 +1,9 @@
 package ps
 
 import (
-	"bytes"
 	"fmt"
 	"strconv"
 	"strings"
-	"text/tabwriter"
-	"text/template"
 	"time"
 
 	"github.com/docker/docker/api"
@@ -150,68 +147,6 @@ func (c *containerContext) addHeader(header string) {
 		c.header = []string{}
 	}
 	c.header = append(c.header, strings.ToUpper(header))
-}
-
-func customFormat(ctx Context, containers []types.Container) {
-	var (
-		table  bool
-		header string
-		format = ctx.Format
-		buffer = bytes.NewBufferString("")
-	)
-
-	if strings.HasPrefix(ctx.Format, tableKey) {
-		table = true
-		format = format[len(tableKey):]
-	}
-
-	format = strings.Trim(format, " ")
-	r := strings.NewReplacer(`\t`, "\t", `\n`, "\n")
-	format = r.Replace(format)
-
-	if table && ctx.Size {
-		format += "\t{{.Size}}"
-	}
-
-	tmpl, err := template.New("").Parse(format)
-	if err != nil {
-		buffer.WriteString(fmt.Sprintf("Template parsing error: %v\n", err))
-		buffer.WriteTo(ctx.Output)
-		return
-	}
-
-	for _, container := range containers {
-		containerCtx := &containerContext{
-			trunc: ctx.Trunc,
-			c:     container,
-		}
-		if err := tmpl.Execute(buffer, containerCtx); err != nil {
-			buffer = bytes.NewBufferString(fmt.Sprintf("Template parsing error: %v\n", err))
-			buffer.WriteTo(ctx.Output)
-			return
-		}
-		if table && len(header) == 0 {
-			header = containerCtx.fullHeader()
-		}
-		buffer.WriteString("\n")
-	}
-
-	if table {
-		if len(header) == 0 {
-			// if we still don't have a header, we didn't have any containers so we need to fake it to get the right headers from the template
-			containerCtx := &containerContext{}
-			tmpl.Execute(bytes.NewBufferString(""), containerCtx)
-			header = containerCtx.fullHeader()
-		}
-
-		t := tabwriter.NewWriter(ctx.Output, 20, 1, 3, ' ', 0)
-		t.Write([]byte(header))
-		t.Write([]byte("\n"))
-		buffer.WriteTo(t)
-		t.Flush()
-	} else {
-		buffer.WriteTo(ctx.Output)
-	}
 }
 
 func stripNamePrefix(ss []string) []string {

--- a/api/client/ps/formatter_test.go
+++ b/api/client/ps/formatter_test.go
@@ -1,0 +1,208 @@
+package ps
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+)
+
+func TestFormat(t *testing.T) {
+	contexts := []struct {
+		context  Context
+		expected string
+	}{
+		// Errors
+		{
+			Context{
+				Format: "{{InvalidFunction}}",
+			},
+			`Template parsing error: template: :1: function "InvalidFunction" not defined
+`,
+		},
+		{
+			Context{
+				Format: "{{nil}}",
+			},
+			`Template parsing error: template: :1:2: executing "" at <nil>: nil is not a command
+`,
+		},
+		// Table Format
+		{
+			Context{
+				Format: "table",
+			},
+			`CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
+containerID1        ubuntu              ""                  45 years ago                                                foobar_baz
+containerID2        ubuntu              ""                  45 years ago                                                foobar_bar
+`,
+		},
+		{
+			Context{
+				Format: "table {{.Image}}",
+			},
+			"IMAGE\nubuntu\nubuntu\n",
+		},
+		{
+			Context{
+				Format: "table {{.Image}}",
+				Size:   true,
+			},
+			"IMAGE               SIZE\nubuntu              0 B\nubuntu              0 B\n",
+		},
+		{
+			Context{
+				Format: "table {{.Image}}",
+				Quiet:  true,
+			},
+			"IMAGE\nubuntu\nubuntu\n",
+		},
+		{
+			Context{
+				Format: "table",
+				Quiet:  true,
+			},
+			"containerID1\ncontainerID2\n",
+		},
+		// Raw Format
+		{
+			Context{
+				Format: "raw",
+			},
+			`container_id: containerID1
+image: ubuntu
+command: ""
+created_at: 1970-01-01 00:00:00 +0000 UTC
+status: 
+names: foobar_baz
+labels: 
+ports: 
+
+container_id: containerID2
+image: ubuntu
+command: ""
+created_at: 1970-01-01 00:00:00 +0000 UTC
+status: 
+names: foobar_bar
+labels: 
+ports: 
+
+`,
+		},
+		{
+			Context{
+				Format: "raw",
+				Size:   true,
+			},
+			`container_id: containerID1
+image: ubuntu
+command: ""
+created_at: 1970-01-01 00:00:00 +0000 UTC
+status: 
+names: foobar_baz
+labels: 
+ports: 
+size: 0 B
+
+container_id: containerID2
+image: ubuntu
+command: ""
+created_at: 1970-01-01 00:00:00 +0000 UTC
+status: 
+names: foobar_bar
+labels: 
+ports: 
+size: 0 B
+
+`,
+		},
+		{
+			Context{
+				Format: "raw",
+				Quiet:  true,
+			},
+			"container_id: containerID1\ncontainer_id: containerID2\n",
+		},
+		// Custom Format
+		{
+			Context{
+				Format: "{{.Image}}",
+			},
+			"ubuntu\nubuntu\n",
+		},
+		{
+			Context{
+				Format: "{{.Image}}",
+				Size:   true,
+			},
+			"ubuntu\nubuntu\n",
+		},
+	}
+
+	for _, context := range contexts {
+		containers := []types.Container{
+			{ID: "containerID1", Names: []string{"/foobar_baz"}, Image: "ubuntu"},
+			{ID: "containerID2", Names: []string{"/foobar_bar"}, Image: "ubuntu"},
+		}
+		out := bytes.NewBufferString("")
+		context.context.Output = out
+		Format(context.context, containers)
+		actual := out.String()
+		if actual != context.expected {
+			t.Fatalf("Expected \n%s, got \n%s", context.expected, actual)
+		}
+		// Clean buffer
+		out.Reset()
+	}
+}
+
+func TestCustomFormatNoContainers(t *testing.T) {
+	out := bytes.NewBufferString("")
+	containers := []types.Container{}
+
+	contexts := []struct {
+		context  Context
+		expected string
+	}{
+		{
+			Context{
+				Format: "{{.Image}}",
+				Output: out,
+			},
+			"",
+		},
+		{
+			Context{
+				Format: "table {{.Image}}",
+				Output: out,
+			},
+			"IMAGE\n",
+		},
+		{
+			Context{
+				Format: "{{.Image}}",
+				Output: out,
+				Size:   true,
+			},
+			"",
+		},
+		{
+			Context{
+				Format: "table {{.Image}}",
+				Output: out,
+				Size:   true,
+			},
+			"IMAGE               SIZE\n",
+		},
+	}
+
+	for _, context := range contexts {
+		customFormat(context.context, containers)
+		actual := out.String()
+		if actual != context.expected {
+			t.Fatalf("Expected \n%s, got \n%s", context.expected, actual)
+		}
+		// Clean buffer
+		out.Reset()
+	}
+}


### PR DESCRIPTION
Add some unit tests on `api/client/ps` 🐙. I've reorganized a little bit the code : moved `customFormat` to `formatter.go` as it seems the right place.

``` bash
# before
+ go test -test.timeout=60m github.com/docker/docker/api/client/ps
PASS
coverage: 59.1% of statements
# after
+ go test -test.timeout=60m github.com/docker/docker/api/client/ps
PASS
coverage: 100.0% of statements
```

There is a tests that does seems weird, I'll have to take a closer look.. 🐸 

Signed-off-by: Vincent Demeester vincent@sbr.pm
