### PR TITLE
Follow names convention in exec route.

### DIFF
--- a/api/server/exec.go
+++ b/api/server/exec.go
@@ -14,12 +14,12 @@ import (
 	"github.com/docker/docker/runconfig"
 )
 
-func (s *Server) getExecByID(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) getContainersExec(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
-		return fmt.Errorf("Missing parameter 'id'")
+		return fmt.Errorf("Missing parameter 'name'")
 	}
 
-	eConfig, err := s.daemon.ContainerExecInspect(vars["id"])
+	eConfig, err := s.daemon.ContainerExecInspect(vars["name"])
 	if err != nil {
 		return err
 	}

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -326,7 +326,7 @@ func createRouter(s *Server) *mux.Router {
 			"/containers/{name:.*}/logs":      s.getContainersLogs,
 			"/containers/{name:.*}/stats":     s.getContainersStats,
 			"/containers/{name:.*}/attach/ws": s.wsContainersAttach,
-			"/exec/{id:.*}/json":              s.getExecByID,
+			"/exec/{name:.*}/json":            s.getContainersExec,
 			"/containers/{name:.*}/archive":   s.getContainersArchive,
 			"/volumes":                        s.getVolumesList,
 			"/volumes/{name:.*}":              s.getVolumeByName,


### PR DESCRIPTION
Sorry, but it drives me nuts that this var is called different and the method name doesn't follow the rest of the method names.

Signed-off-by: David Calavera david.calavera@gmail.com
