### PR TITLE
Add a "context" to the api/server/* code

### DIFF
--- a/api/server/auth.go
+++ b/api/server/auth.go
@@ -4,10 +4,9 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/context"
 )
 
 func (s *Server) postAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/api/server/auth.go
+++ b/api/server/auth.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"golang.org/x/net/context"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cliconfig"
-	"github.com/docker/docker/pkg/version"
 )
 
-func (s *Server) postAuth(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) postAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	var config *cliconfig.AuthConfig
 	err := json.NewDecoder(r.Body).Decode(&config)
 	r.Body.Close()

--- a/api/server/container.go
+++ b/api/server/container.go
@@ -8,15 +8,14 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
 	"golang.org/x/net/websocket"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/signal"
-	"github.com/docker/docker/pkg/version"
 	"github.com/docker/docker/runconfig"
 )
 
@@ -251,7 +250,7 @@ func (s *Server) postContainersKill(ctx context.Context, w http.ResponseWriter, 
 		// Return error that's not caused because the container is stopped.
 		// Return error if the container is not running and the api is >= 1.20
 		// to keep backwards compatibility.
-		version, _ := ctx.Value("api-version").(version.Version)
+		version := ctx.Version()
 		if version.GreaterThanOrEqualTo("1.20") || !isStopped {
 			return fmt.Errorf("Cannot kill container %s: %v", name, err)
 		}
@@ -392,7 +391,7 @@ func (s *Server) postContainersCreate(ctx context.Context, w http.ResponseWriter
 	if err != nil {
 		return err
 	}
-	version, _ := ctx.Value("api-version").(version.Version)
+	version := ctx.Version()
 	adjustCPUShares := version.LessThan("1.19")
 
 	container, warnings, err := s.daemon.ContainerCreate(name, config, hostConfig, adjustCPUShares)

--- a/api/server/copy.go
+++ b/api/server/copy.go
@@ -9,12 +9,13 @@ import (
 	"os"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/pkg/version"
 )
 
 // postContainersCopy is deprecated in favor of getContainersArchive.
-func (s *Server) postContainersCopy(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) postContainersCopy(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
 	}
@@ -68,7 +69,7 @@ func setContainerPathStatHeader(stat *types.ContainerPathStat, header http.Heade
 	return nil
 }
 
-func (s *Server) headContainersArchive(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) headContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v, err := archiveFormValues(r, vars)
 	if err != nil {
 		return err
@@ -82,7 +83,7 @@ func (s *Server) headContainersArchive(version version.Version, w http.ResponseW
 	return setContainerPathStatHeader(stat, w.Header())
 }
 
-func (s *Server) getContainersArchive(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) getContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v, err := archiveFormValues(r, vars)
 	if err != nil {
 		return err
@@ -104,7 +105,7 @@ func (s *Server) getContainersArchive(version version.Version, w http.ResponseWr
 	return err
 }
 
-func (s *Server) putContainersArchive(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) putContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v, err := archiveFormValues(r, vars)
 	if err != nil {
 		return err

--- a/api/server/copy.go
+++ b/api/server/copy.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"strings"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/context"
 )
 
 // postContainersCopy is deprecated in favor of getContainersArchive.

--- a/api/server/daemon.go
+++ b/api/server/daemon.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/context"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
@@ -20,7 +22,7 @@ import (
 	"github.com/docker/docker/utils"
 )
 
-func (s *Server) getVersion(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) getVersion(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v := &types.Version{
 		Version:    dockerversion.VERSION,
 		APIVersion: api.Version,
@@ -30,6 +32,8 @@ func (s *Server) getVersion(version version.Version, w http.ResponseWriter, r *h
 		Arch:       runtime.GOARCH,
 		BuildTime:  dockerversion.BUILDTIME,
 	}
+
+	version, _ := ctx.Value("api-version").(version.Version)
 
 	if version.GreaterThanOrEqualTo("1.19") {
 		v.Experimental = utils.ExperimentalBuild()
@@ -42,7 +46,7 @@ func (s *Server) getVersion(version version.Version, w http.ResponseWriter, r *h
 	return writeJSON(w, http.StatusOK, v)
 }
 
-func (s *Server) getInfo(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) getInfo(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	info, err := s.daemon.SystemInfo()
 	if err != nil {
 		return err
@@ -51,7 +55,7 @@ func (s *Server) getInfo(version version.Version, w http.ResponseWriter, r *http
 	return writeJSON(w, http.StatusOK, info)
 }
 
-func (s *Server) getEvents(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) getEvents(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
 	}

--- a/api/server/daemon.go
+++ b/api/server/daemon.go
@@ -8,17 +8,15 @@ import (
 	"strings"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/autogen/dockerversion"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/parsers/filters"
 	"github.com/docker/docker/pkg/parsers/kernel"
-	"github.com/docker/docker/pkg/version"
 	"github.com/docker/docker/utils"
 )
 
@@ -33,7 +31,7 @@ func (s *Server) getVersion(ctx context.Context, w http.ResponseWriter, r *http.
 		BuildTime:  dockerversion.BUILDTIME,
 	}
 
-	version, _ := ctx.Value("api-version").(version.Version)
+	version := ctx.Version()
 
 	if version.GreaterThanOrEqualTo("1.19") {
 		v.Experimental = utils.ExperimentalBuild()

--- a/api/server/exec.go
+++ b/api/server/exec.go
@@ -7,14 +7,15 @@ import (
 	"net/http"
 	"strconv"
 
+	"golang.org/x/net/context"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/stdcopy"
-	"github.com/docker/docker/pkg/version"
 	"github.com/docker/docker/runconfig"
 )
 
-func (s *Server) getExecByID(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) getExecByID(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter 'id'")
 	}
@@ -27,7 +28,7 @@ func (s *Server) getExecByID(version version.Version, w http.ResponseWriter, r *
 	return writeJSON(w, http.StatusOK, eConfig)
 }
 
-func (s *Server) postContainerExecCreate(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) postContainerExecCreate(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
 	}
@@ -59,7 +60,7 @@ func (s *Server) postContainerExecCreate(version version.Version, w http.Respons
 }
 
 // TODO(vishh): Refactor the code to avoid having to specify stream config as part of both create and start.
-func (s *Server) postContainerExecStart(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) postContainerExecStart(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
 	}
@@ -106,7 +107,7 @@ func (s *Server) postContainerExecStart(version version.Version, w http.Response
 	return nil
 }
 
-func (s *Server) postContainerExecResize(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) postContainerExecResize(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
 	}

--- a/api/server/exec.go
+++ b/api/server/exec.go
@@ -7,10 +7,9 @@ import (
 	"net/http"
 	"strconv"
 
-	"golang.org/x/net/context"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/runconfig"
 )

--- a/api/server/image.go
+++ b/api/server/image.go
@@ -8,18 +8,16 @@ import (
 	"net/http"
 	"strings"
 
-	"golang.org/x/net/context"
-
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/graph"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/pkg/ulimit"
-	"github.com/docker/docker/pkg/version"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
 )
@@ -36,7 +34,7 @@ func (s *Server) postCommit(ctx context.Context, w http.ResponseWriter, r *http.
 	cname := r.Form.Get("container")
 
 	pause := boolValue(r, "pause")
-	version, _ := ctx.Value("api-version").(version.Version)
+	version := ctx.Version()
 	if r.FormValue("pause") == "" && version.GreaterThanOrEqualTo("1.13") {
 		pause = true
 	}
@@ -283,7 +281,7 @@ func (s *Server) postBuild(ctx context.Context, w http.ResponseWriter, r *http.R
 
 	w.Header().Set("Content-Type", "application/json")
 
-	version, _ := ctx.Value("api-version").(version.Version)
+	version := ctx.Version()
 	if boolValue(r, "forcerm") && version.GreaterThanOrEqualTo("1.12") {
 		buildConfig.Remove = true
 	} else if r.FormValue("rm") == "" && version.GreaterThanOrEqualTo("1.12") {

--- a/api/server/inspect.go
+++ b/api/server/inspect.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"golang.org/x/net/context"
-
-	"github.com/docker/docker/pkg/version"
+	"github.com/docker/docker/context"
 )
 
 // getContainersByName inspects containers configuration and serializes it as json.
@@ -18,7 +16,7 @@ func (s *Server) getContainersByName(ctx context.Context, w http.ResponseWriter,
 	var json interface{}
 	var err error
 
-	version, _ := ctx.Value("api-version").(version.Version)
+	version := ctx.Version()
 
 	switch {
 	case version.LessThan("1.20"):

--- a/api/server/inspect.go
+++ b/api/server/inspect.go
@@ -4,17 +4,21 @@ import (
 	"fmt"
 	"net/http"
 
+	"golang.org/x/net/context"
+
 	"github.com/docker/docker/pkg/version"
 )
 
 // getContainersByName inspects containers configuration and serializes it as json.
-func (s *Server) getContainersByName(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) getContainersByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
 	}
 
 	var json interface{}
 	var err error
+
+	version, _ := ctx.Value("api-version").(version.Version)
 
 	switch {
 	case version.LessThan("1.20"):

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -12,12 +12,14 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"golang.org/x/net/context"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/autogen/dockerversion"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/pkg/sockets"
+	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/version"
 )
 
@@ -122,7 +124,7 @@ func (s *HTTPServer) Close() error {
 
 // HTTPAPIFunc is an adapter to allow the use of ordinary functions as Docker API endpoints.
 // Any function that has the appropriate signature can be register as a API endpoint (e.g. getVersion).
-type HTTPAPIFunc func(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error
+type HTTPAPIFunc func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error
 
 func hijackServer(w http.ResponseWriter) (io.ReadCloser, io.Writer, error) {
 	conn, _, err := w.(http.Hijacker).Hijack()
@@ -219,7 +221,7 @@ func writeJSON(w http.ResponseWriter, code int, v interface{}) error {
 	return json.NewEncoder(w).Encode(v)
 }
 
-func (s *Server) optionsHandler(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) optionsHandler(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	w.WriteHeader(http.StatusOK)
 	return nil
 }
@@ -230,7 +232,7 @@ func writeCorsHeaders(w http.ResponseWriter, r *http.Request, corsHeaders string
 	w.Header().Add("Access-Control-Allow-Methods", "HEAD, GET, POST, DELETE, PUT, OPTIONS")
 }
 
-func (s *Server) ping(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) ping(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	_, err := w.Write([]byte{'O', 'K'})
 	return err
 }
@@ -250,6 +252,24 @@ func (s *Server) initTCPSocket(addr string) (l net.Listener, err error) {
 
 func makeHTTPHandler(logging bool, localMethod string, localRoute string, handlerFunc HTTPAPIFunc, corsHeaders string, dockerVersion version.Version) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Define the context that we'll pass around to share info
+		// like the docker-request-id.
+		//
+		// The 'context' will be used for global data that should
+		// apply to all requests. Data that is specific to the
+		// immediate function being called should still be passed
+		// as 'args' on the function call.
+
+		reqID := stringid.TruncateID(stringid.GenerateNonCryptoID())
+		api_version := version.Version(mux.Vars(r)["version"])
+		if api_version == "" {
+			api_version = api.Version
+		}
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, "docker-request-id", reqID)
+		ctx = context.WithValue(ctx, "api-version", api_version)
+
 		// log the request
 		logrus.Debugf("Calling %s %s", localMethod, localRoute)
 
@@ -270,26 +290,22 @@ func makeHTTPHandler(logging bool, localMethod string, localRoute string, handle
 				logrus.Debugf("Warning: client and server don't have the same version (client: %s, server: %s)", userAgent[1], dockerVersion)
 			}
 		}
-		version := version.Version(mux.Vars(r)["version"])
-		if version == "" {
-			version = api.Version
-		}
 		if corsHeaders != "" {
 			writeCorsHeaders(w, r, corsHeaders)
 		}
 
-		if version.GreaterThan(api.Version) {
-			http.Error(w, fmt.Errorf("client is newer than server (client API version: %s, server API version: %s)", version, api.Version).Error(), http.StatusBadRequest)
+		if api_version.GreaterThan(api.Version) {
+			http.Error(w, fmt.Errorf("client is newer than server (client API version: %s, server API version: %s)", api_version, api.Version).Error(), http.StatusBadRequest)
 			return
 		}
-		if version.LessThan(api.MinVersion) {
+		if api_version.LessThan(api.MinVersion) {
 			http.Error(w, fmt.Errorf("client is too old, minimum supported API version is %s, please upgrade your client to a newer version", api.MinVersion).Error(), http.StatusBadRequest)
 			return
 		}
 
 		w.Header().Set("Server", "Docker/"+dockerversion.VERSION+" ("+runtime.GOOS+")")
 
-		if err := handlerFunc(version, w, r, mux.Vars(r)); err != nil {
+		if err := handlerFunc(ctx, w, r, mux.Vars(r)); err != nil {
 			logrus.Errorf("Handler for %s %s returned error: %s", localMethod, localRoute, err)
 			httpError(w, err)
 		}

--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"golang.org/x/net/context"
+
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/pkg/version"
 )
 
-func (s *Server) getVolumesList(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) getVolumesList(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
 	}
@@ -20,7 +21,7 @@ func (s *Server) getVolumesList(version version.Version, w http.ResponseWriter, 
 	return writeJSON(w, http.StatusOK, &types.VolumesListResponse{Volumes: volumes})
 }
 
-func (s *Server) getVolumeByName(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) getVolumeByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
 	}
@@ -32,7 +33,7 @@ func (s *Server) getVolumeByName(version version.Version, w http.ResponseWriter,
 	return writeJSON(w, http.StatusOK, v)
 }
 
-func (s *Server) postVolumesCreate(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) postVolumesCreate(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
 	}
@@ -53,7 +54,7 @@ func (s *Server) postVolumesCreate(version version.Version, w http.ResponseWrite
 	return writeJSON(w, http.StatusCreated, volume)
 }
 
-func (s *Server) deleteVolumes(version version.Version, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
+func (s *Server) deleteVolumes(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
 	}

--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -4,9 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"golang.org/x/net/context"
-
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/context"
 )
 
 func (s *Server) getVolumesList(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {

--- a/context/context.go
+++ b/context/context.go
@@ -1,0 +1,64 @@
+package context
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/docker/docker/pkg/version"
+)
+
+const (
+	// RequestID is the unique ID for each http request
+	RequestID = "request-id"
+
+	// APIVersion is the client's requested API version
+	APIVersion = "api-version"
+)
+
+// Context is just our own wrapper for the golang 'Context' - mainly
+// so we can add our over version of the funcs.
+type Context struct {
+	context.Context
+}
+
+// Background creates a new Context based on golang's default one.
+func Background() Context {
+	return Context{context.Background()}
+}
+
+// WithValue will return a Context that has this new key/value pair
+// associated with it. Just uses the golang version but then wraps it.
+func WithValue(ctx Context, key, value interface{}) Context {
+	return Context{context.WithValue(ctx, key, value)}
+}
+
+// RequestID is a utility func to make it easier to get the
+// request ID associated with this Context/request.
+func (ctx Context) RequestID() string {
+	val := ctx.Value(RequestID)
+	if val == nil {
+		return ""
+	}
+
+	id, ok := val.(string)
+	if !ok {
+		// Ideally we shouldn't panic but we also should never get here
+		panic("Context RequestID isn't a string")
+	}
+	return id
+}
+
+// Version is a utility func to make it easier to get the
+// API version string associated with this Context/request.
+func (ctx Context) Version() version.Version {
+	val := ctx.Value(APIVersion)
+	if val == nil {
+		return version.Version("")
+	}
+
+	ver, ok := val.(version.Version)
+	if !ok {
+		// Ideally we shouldn't panic but we also should never get here
+		panic("Context APIVersion isn't a version.Version")
+	}
+	return ver
+}

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -1,0 +1,35 @@
+package context
+
+import (
+	"testing"
+
+	"github.com/docker/docker/pkg/version"
+)
+
+func TestContext(t *testing.T) {
+	ctx := Background()
+
+	// First make sure getting non-existent values doesn't break
+	if id := ctx.RequestID(); id != "" {
+		t.Fatalf("RequestID() should have been '', was: %q", id)
+	}
+
+	if ver := ctx.Version(); ver != "" {
+		t.Fatalf("Version() should have been '', was: %q", ver)
+	}
+
+	// Test basic set/get
+	ctx = WithValue(ctx, RequestID, "123")
+	if ctx.RequestID() != "123" {
+		t.Fatalf("RequestID() should have been '123'")
+	}
+
+	// Now make sure after a 2nd set we can still get both
+	ctx = WithValue(ctx, APIVersion, version.Version("x.y"))
+	if id := ctx.RequestID(); id != "123" {
+		t.Fatalf("RequestID() should have been '123', was %q", id)
+	}
+	if ver := ctx.Version(); ver != "x.y" {
+		t.Fatalf("Version() should have been 'x.y', was %q", ver)
+	}
+}


### PR DESCRIPTION
This defines a 'context' object that is passed to each API handler.
Right now the context just has a unique 'requestID' for each API call.
The next steps would be:
- use this 'requestID' in our logging and events
- determine the best way to format the logging to include this info.

In particular for actions that generate multiple events and log entries
we can use the requestID to help correlate the log entries. I view this 
as a prerequisite for #15216 .

Adding the requestID to the logging will be a challenge since it could mean
changing every single logrus.XXX() call to pass in the 'context' object.

But first step is to agree on a format, which we can discus in a subsequent
PR, but my initial thoughts are to add it right after the timestamp:

current format:

```
INFO[0039] POST /v1.21/build?buildargs=%7B%22foo%22%3A%22xxx%22%7D&cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=Dockerfile&memory=0&memswap=0&rm=1&t=&ulimits=null
```

proposed format:

```
INFO[0039-83dea1222191] POST /v1.21/build?buildargs=%7B%22foo%22%3A%22xxx%22%7D&cgroupparent=&cpuperiod=0&cpuquota=0&cpusetcpus=&cpusetmems=&cpushares=0&dockerfile=Dockerfile&memory=0&memswap=0&rm=1&t=&ulimits=null
```

We then also need to do this for events.  But, again, that's for follow-on PRs  - just mentioning it here so people know where this will lead.

Signed-off-by: Doug Davis dug@us.ibm.com
