### PR TITLE
Add docker ps --filter=… ancestor image bash completion

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -975,6 +975,11 @@ _docker_ps() {
 	esac
 
 	case "${words[$cword-2]}$prev=" in
+		*ancestor=*)
+			cur="${cur#=}"
+			__docker_images
+			return
+			;;
 		*id=*)
 			cur="${cur#=}"
 			__docker_container_ids


### PR DESCRIPTION
I feel even more dumb 🐐 to do this PR because I should have thought about it on #14570 and even more #15919 :sweat_smile:. I missed that on #15919, thanks @albers.. This adds the bash completion for the `ancestor` filter **and** completion for images (name/id).

/ping @jfrazelle @tianon I still don't see these completion for filter (completing the images name in filter, etc.) on `fish` and `zsh` contrib files, is this normal ? 

🐸 (sorry sorry for the noise :sweat_smile: )

Signed-off-by: Vincent Demeester vincent@sbr.pm
