### PR TITLE
Add a DOCKER_API_VERSION env var

### DIFF
--- a/api/client/cli.go
+++ b/api/client/cli.go
@@ -103,7 +103,12 @@ func NewDockerCli(in io.ReadCloser, out, err io.Writer, clientFlags *cli.ClientF
 		}
 		customHeaders["User-Agent"] = "Docker-Client/" + dockerversion.Version + " (" + runtime.GOOS + ")"
 
-		client, err := lib.NewClient(host, string(api.Version), clientFlags.Common.TLSOptions, customHeaders)
+		verStr := string(api.DefaultVersion)
+		if tmpStr := os.Getenv("DOCKER_API_VERSION"); tmpStr != "" {
+			verStr = tmpStr
+		}
+
+		client, err := lib.NewClient(host, verStr, clientFlags.Common.TLSOptions, customHeaders)
 		if err != nil {
 			return err
 		}

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -17,6 +17,7 @@ import (
 
 // apiClient is an interface that clients that talk with a docker server must implement.
 type apiClient interface {
+	ClientVersion() string
 	ContainerAttach(options types.ContainerAttachOptions) (types.HijackedResponse, error)
 	ContainerCommit(options types.ContainerCommitOptions) (types.ContainerCommitResponse, error)
 	ContainerCreate(config *runconfig.ContainerConfigWrapper, containerName string) (types.ContainerCreateResponse, error)

--- a/api/client/lib/client.go
+++ b/api/client/lib/client.go
@@ -96,3 +96,10 @@ func (cli *Client) getAPIPath(p string, query url.Values) string {
 	}
 	return apiPath
 }
+
+// ClientVersion returns the version string associated with this
+// instance of the Client. Note that this value can be changed
+// via the DOCKER_API_VERSION env var.
+func (cli *Client) ClientVersion() string {
+	return cli.version
+}

--- a/api/client/version.go
+++ b/api/client/version.go
@@ -5,11 +5,11 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/types"
 	Cli "github.com/docker/docker/cli"
 	"github.com/docker/docker/dockerversion"
 	flag "github.com/docker/docker/pkg/mflag"
+	"github.com/docker/docker/pkg/version"
 	"github.com/docker/docker/utils"
 )
 
@@ -57,7 +57,7 @@ func (cli *DockerCli) CmdVersion(args ...string) (err error) {
 	vd := types.VersionResponse{
 		Client: &types.Version{
 			Version:      dockerversion.Version,
-			APIVersion:   api.Version,
+			APIVersion:   version.Version(cli.client.ClientVersion()),
 			GoVersion:    runtime.Version(),
 			GitCommit:    dockerversion.GitCommit,
 			BuildTime:    dockerversion.BuildTime,

--- a/api/common.go
+++ b/api/common.go
@@ -18,7 +18,7 @@ import (
 // Common constants for daemon and client.
 const (
 	// Version of Current REST API
-	Version version.Version = "1.22"
+	DefaultVersion version.Version = "1.22"
 
 	// MinVersion represents Minimum REST API version supported
 	MinVersion version.Version = "1.12"

--- a/api/server/middleware.go
+++ b/api/server/middleware.go
@@ -121,14 +121,14 @@ func versionMiddleware(handler httputils.APIFunc) httputils.APIFunc {
 	return func(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 		apiVersion := version.Version(vars["version"])
 		if apiVersion == "" {
-			apiVersion = api.Version
+			apiVersion = api.DefaultVersion
 		}
 
-		if apiVersion.GreaterThan(api.Version) {
-			return errors.ErrorCodeNewerClientVersion.WithArgs(apiVersion, api.Version)
+		if apiVersion.GreaterThan(api.DefaultVersion) {
+			return errors.ErrorCodeNewerClientVersion.WithArgs(apiVersion, api.DefaultVersion)
 		}
 		if apiVersion.LessThan(api.MinVersion) {
-			return errors.ErrorCodeOldClientVersion.WithArgs(apiVersion, api.Version)
+			return errors.ErrorCodeOldClientVersion.WithArgs(apiVersion, api.DefaultVersion)
 		}
 
 		w.Header().Set("Server", "Docker/"+dockerversion.Version+" ("+runtime.GOOS+")")

--- a/api/server/router/system/system_routes.go
+++ b/api/server/router/system/system_routes.go
@@ -38,7 +38,7 @@ func (s *systemRouter) getInfo(ctx context.Context, w http.ResponseWriter, r *ht
 
 func (s *systemRouter) getVersion(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	info := s.backend.SystemVersion()
-	info.APIVersion = api.Version
+	info.APIVersion = api.DefaultVersion
 
 	return httputils.WriteJSON(w, http.StatusOK, info)
 }

--- a/docs/reference/commandline/cli.md
+++ b/docs/reference/commandline/cli.md
@@ -38,6 +38,7 @@ the [installation](../../installation/index.md) instructions for your operating 
 For easy reference, the following list of environment variables are supported
 by the `docker` command line:
 
+* `DOCKER_API_VERSION` The API version to use (e.g. `1.19`)
 * `DOCKER_CONFIG` The location of your client configuration files.
 * `DOCKER_CERT_PATH` The location of your authentication keys.
 * `DOCKER_DRIVER` The graph driver to use.

--- a/integration-cli/docker_api_test.go
+++ b/integration-cli/docker_api_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"net/http/httputil"
+	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"time"
@@ -46,7 +49,7 @@ func (s *DockerSuite) TestApiVersionStatusCode(c *check.C) {
 }
 
 func (s *DockerSuite) TestApiClientVersionNewerThanServer(c *check.C) {
-	v := strings.Split(string(api.Version), ".")
+	v := strings.Split(string(api.DefaultVersion), ".")
 	vMinInt, err := strconv.Atoi(v[1])
 	c.Assert(err, checker.IsNil)
 	vMinInt++
@@ -71,4 +74,26 @@ func (s *DockerSuite) TestApiClientVersionOldNotSupported(c *check.C) {
 	c.Assert(err, checker.IsNil)
 	c.Assert(status, checker.Equals, http.StatusBadRequest)
 	c.Assert(len(string(body)), checker.Not(check.Equals), 0) // Expected not empty body
+}
+
+func (s *DockerSuite) TestApiDockerApiVersion(c *check.C) {
+	var svrVersion string
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			url := r.URL.Path
+			svrVersion = url
+		}))
+	defer server.Close()
+
+	// Test using the env var first
+	cmd := exec.Command(dockerBinary, "-H="+server.URL[7:], "version")
+	cmd.Env = append([]string{"DOCKER_API_VERSION=xxx"}, os.Environ()...)
+	out, _, _ := runCommandWithOutput(cmd)
+
+	c.Assert(svrVersion, check.Equals, "/vxxx/version")
+
+	if !strings.Contains(out, "API version:  xxx") {
+		c.Fatalf("Out didn't have 'xxx' for the API version, had:\n%s", out)
+	}
 }


### PR DESCRIPTION
Closes: #11486

Just for @ahmetalpbalkan  :-)

Added DOCKER_API_VERSION env var and ApiVersion property in docker's config.json.

Cleaned up some comments that were > 80 chars.

Signed-off-by: Doug Davis dug@us.ibm.com
