### PR TITLE
Fix goroutine leak on pull

### DIFF
--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -230,6 +230,9 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string) (verified bo
 			// set the error. All successive reads/writes will return with this
 			// error.
 			pipeWriter.CloseWithError(errors.New("download canceled"))
+		} else {
+			// If no error then just close the pipe.
+			pipeWriter.Close()
 		}
 	}()
 


### PR DESCRIPTION
Close the pipeWriter even if there was no error.

The pipe in master probably needs bit more tweaking after the broadcastWriter change but I'll leave it to @aaronlehmann . This should be the minimal fix for `v1.8.2` to correct the leak. 

cc @calavera @aaronlehmann 

Signed-off-by: Tonis Tiigi tonistiigi@gmail.com
