### PR TITLE
Fix typo in test title

### DIFF
--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -792,7 +792,7 @@ func (s *DockerSuite) TestRunAddingOptionalDevicesNoSrc(c *check.C) {
 	}
 }
 
-func (s *DockerSuite) TestRunAddingOptionalDevicesInvalideMode(c *check.C) {
+func (s *DockerSuite) TestRunAddingOptionalDevicesInvalidMode(c *check.C) {
 	_, _, err := dockerCmdWithError("run", "--device", "/dev/zero:ro", "busybox", "sh", "-c", "ls /dev/zero")
 	if err == nil {
 		c.Fatalf("run container with device mode ro should fail")


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Fixes minor typo in the name of a test.
