### PR TITLE
Remove /containers/ps from the api router.

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -317,7 +317,6 @@ func createRouter(s *Server) *mux.Router {
 			"/images/{name:.*}/get":           s.getImagesGet,
 			"/images/{name:.*}/history":       s.getImagesHistory,
 			"/images/{name:.*}/json":          s.getImagesByName,
-			"/containers/ps":                  s.getContainersJSON,
 			"/containers/json":                s.getContainersJSON,
 			"/containers/{name:.*}/export":    s.getContainersExport,
 			"/containers/{name:.*}/changes":   s.getContainersChanges,


### PR DESCRIPTION
This route was deprecated more than two years ago in the linked
commit[1](https://github.com/docker/docker/commit/4f9443927e8bc8a724b43afae6cf7a183cd9acd0). It's not referenced anywhere in the documentation and it's
time to stop maintaning it.

Signed-off-by: David Calavera david.calavera@gmail.com
