### PR TITLE
Add missing defer to delete temp dir

### DIFF
--- a/cliconfig/config_test.go
+++ b/cliconfig/config_test.go
@@ -410,7 +410,12 @@ func TestJsonSaveWithNoFile(t *testing.T) {
 		t.Fatalf("Expected error. File should not have been able to save with no file name.")
 	}
 
-	tmpHome, _ := ioutil.TempDir("", "config-test")
+	tmpHome, err := ioutil.TempDir("", "config-test")
+	if err != nil {
+		t.Fatalf("Failed to create a temp dir: %q", err)
+	}
+	defer os.RemoveAll(tmpHome)
+
 	fn := filepath.Join(tmpHome, ConfigFileName)
 	f, _ := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	err = config.SaveToWriter(f)
@@ -433,7 +438,12 @@ func TestLegacyJsonSaveWithNoFile(t *testing.T) {
 		t.Fatalf("Expected error. File should not have been able to save with no file name.")
 	}
 
-	tmpHome, _ := ioutil.TempDir("", "config-test")
+	tmpHome, err := ioutil.TempDir("", "config-test")
+	if err != nil {
+		t.Fatalf("Failed to create a temp dir: %q", err)
+	}
+	defer os.RemoveAll(tmpHome)
+
 	fn := filepath.Join(tmpHome, ConfigFileName)
 	f, _ := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	err = config.SaveToWriter(f)

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -4790,7 +4790,8 @@ func (s *DockerSuite) TestBuildRenamedDockerfile(c *check.C) {
 		c.Fatalf("test4 should have used dFile, output:%s", out)
 	}
 
-	dirWithNoDockerfile, _ := ioutil.TempDir(os.TempDir(), "test5")
+	dirWithNoDockerfile, err := ioutil.TempDir(os.TempDir(), "test5")
+	c.Assert(err, check.IsNil)
 	nonDockerfileFile := filepath.Join(dirWithNoDockerfile, "notDockerfile")
 	if _, err = os.Create(nonDockerfileFile); err != nil {
 		c.Fatal(err)

--- a/integration-cli/docker_cli_config_test.go
+++ b/integration-cli/docker_cli_config_test.go
@@ -30,7 +30,8 @@ func (s *DockerSuite) TestConfigHttpHeader(c *check.C) {
 
 	homeKey := homedir.Key()
 	homeVal := homedir.Get()
-	tmpDir, _ := ioutil.TempDir("", "fake-home")
+	tmpDir, err := ioutil.TempDir("", "fake-home")
+	c.Assert(err, check.IsNil)
 	defer os.RemoveAll(tmpDir)
 
 	dotDocker := filepath.Join(tmpDir, ".docker")
@@ -44,7 +45,7 @@ func (s *DockerSuite) TestConfigHttpHeader(c *check.C) {
 		"HttpHeaders": { "MyHeader": "MyValue" }
 	}`
 
-	err := ioutil.WriteFile(tmpCfg, []byte(data), 0600)
+	err = ioutil.WriteFile(tmpCfg, []byte(data), 0600)
 	if err != nil {
 		c.Fatalf("Err creating file(%s): %v", tmpCfg, err)
 	}
@@ -66,7 +67,9 @@ func (s *DockerSuite) TestConfigHttpHeader(c *check.C) {
 }
 
 func (s *DockerSuite) TestConfigDir(c *check.C) {
-	cDir, _ := ioutil.TempDir("", "fake-home")
+	cDir, err := ioutil.TempDir("", "fake-home")
+	c.Assert(err, check.IsNil)
+	defer os.RemoveAll(cDir)
 
 	// First make sure pointing to empty dir doesn't generate an error
 	out, rc := dockerCmd(c, "--config", cDir, "ps")
@@ -78,7 +81,7 @@ func (s *DockerSuite) TestConfigDir(c *check.C) {
 	// Test with env var too
 	cmd := exec.Command(dockerBinary, "ps")
 	cmd.Env = append(os.Environ(), "DOCKER_CONFIG="+cDir)
-	out, rc, err := runCommandWithOutput(cmd)
+	out, rc, err = runCommandWithOutput(cmd)
 
 	if rc != 0 || err != nil {
 		c.Fatalf("ps2 didn't work:\nrc:%d\nout%s\nerr:%v", rc, out, err)


### PR DESCRIPTION
Minor thing I just noticed

per @runcom's comment - I also added checks for 'err' on TempDir calls.

Signed-off-by: Doug Davis dug@us.ibm.com
