### PR TITLE
Moved unix links tests to non-platform

### DIFF
--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -225,3 +225,18 @@ func (s *DockerSuite) TestLinkShortDefinition(c *check.C) {
 	c.Assert(err, check.IsNil)
 	c.Assert(links, check.Equals, "[\"/shortlinkdef:/link2/shortlinkdef\"]")
 }
+
+func (s *DockerSuite) TestLinksNetworkHostContainer(c *check.C) {
+	dockerCmd(c, "run", "-d", "--net", "host", "--name", "host_container", "busybox", "top")
+	out, _, err := dockerCmdWithError("run", "--name", "should_fail", "--link", "host_container:tester", "busybox", "true")
+	if err == nil || !strings.Contains(out, "--net=host can't be used with links. This would result in undefined behavior") {
+		c.Fatalf("Running container linking to a container with --net host should have failed: %s", out)
+	}
+}
+
+func (s *DockerSuite) TestLinksEtcHostsRegularFile(c *check.C) {
+	out, _ := dockerCmd(c, "run", "--net=host", "busybox", "ls", "-la", "/etc/hosts")
+	if !strings.HasPrefix(out, "-") {
+		c.Errorf("/etc/hosts should be a regular file")
+	}
+}

--- a/integration-cli/docker_cli_links_unix_test.go
+++ b/integration-cli/docker_cli_links_unix_test.go
@@ -5,19 +5,13 @@ package main
 import (
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/go-check/check"
 )
 
-func (s *DockerSuite) TestLinksEtcHostsRegularFile(c *check.C) {
-	out, _ := dockerCmd(c, "run", "--net=host", "busybox", "ls", "-la", "/etc/hosts")
-	if !strings.HasPrefix(out, "-") {
-		c.Errorf("/etc/hosts should be a regular file")
-	}
-}
-
 func (s *DockerSuite) TestLinksEtcHostsContentMatch(c *check.C) {
+	// In a _unix file as using Unix specific files, and must be on the
+	// same host as the daemon.
 	testRequires(c, SameHostDaemon)
 
 	out, _ := dockerCmd(c, "run", "--net=host", "busybox", "cat", "/etc/hosts")
@@ -28,15 +22,6 @@ func (s *DockerSuite) TestLinksEtcHostsContentMatch(c *check.C) {
 
 	if out != string(hosts) {
 		c.Errorf("container: %s\n\nhost:%s", out, hosts)
-	}
-
-}
-
-func (s *DockerSuite) TestLinksNetworkHostContainer(c *check.C) {
-	dockerCmd(c, "run", "-d", "--net", "host", "--name", "host_container", "busybox", "top")
-	out, _, err := dockerCmdWithError("run", "--name", "should_fail", "--link", "host_container:tester", "busybox", "true")
-	if err == nil || !strings.Contains(out, "--net=host can't be used with links. This would result in undefined behavior") {
-		c.Fatalf("Running container linking to a container with --net host should have failed: %s", out)
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This moves a couple of tests out of docker_cli_links_unix_test to docker_cli_links_test. There is no reason for these not to be run from a Windows CLI to a Linux daemon (and they pass in local verification).
