### PR TITLE
Windows: Get Integration CLI running

### DIFF
--- a/integration-cli/check_test.go
+++ b/integration-cli/check_test.go
@@ -59,10 +59,12 @@ type DockerDaemonSuite struct {
 }
 
 func (s *DockerDaemonSuite) SetUpTest(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	s.d = NewDaemon(c)
 }
 
 func (s *DockerDaemonSuite) TearDownTest(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	s.d.Stop()
 	s.ds.TearDownTest(c)
 }

--- a/integration-cli/docker_api_attach_test.go
+++ b/integration-cli/docker_api_attach_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func (s *DockerSuite) TestGetContainersAttachWebsocket(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-dit", "busybox", "cat")
 
 	rwc, err := sockConn(time.Duration(10 * time.Second))
@@ -97,6 +98,7 @@ func (s *DockerSuite) TestGetContainersWsAttachContainerNotFound(c *check.C) {
 }
 
 func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-dit", "busybox", "cat")
 
 	r, w := io.Pipe()
@@ -160,6 +162,7 @@ func (s *DockerSuite) TestPostContainersAttach(c *check.C) {
 }
 
 func (s *DockerSuite) TestPostContainersAttachStderr(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-dit", "busybox", "/bin/sh", "-c", "cat >&2")
 
 	r, w := io.Pipe()

--- a/integration-cli/docker_api_build_test.go
+++ b/integration-cli/docker_api_build_test.go
@@ -45,6 +45,7 @@ func (s *DockerSuite) TestBuildApiDockerfilePath(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildApiDockerFileRemote(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	server, err := fakeStorage(map[string]string{
 		"testD": `FROM busybox
 COPY * /tmp/
@@ -75,6 +76,7 @@ RUN find /tmp/`,
 }
 
 func (s *DockerSuite) TestBuildApiRemoteTarballContext(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	buffer := new(bytes.Buffer)
 	tw := tar.NewWriter(buffer)
 	defer tw.Close()
@@ -107,6 +109,7 @@ func (s *DockerSuite) TestBuildApiRemoteTarballContext(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildApiRemoteTarballContextWithCustomDockerfile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	buffer := new(bytes.Buffer)
 	tw := tar.NewWriter(buffer)
 	defer tw.Close()
@@ -161,6 +164,7 @@ RUN echo 'right'
 }
 
 func (s *DockerSuite) TestBuildApiLowerDockerfile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	git, err := newFakeGit("repo", map[string]string{
 		"dockerfile": `FROM busybox
 RUN echo from dockerfile`,
@@ -186,6 +190,7 @@ RUN echo from dockerfile`,
 }
 
 func (s *DockerSuite) TestBuildApiBuildGitWithF(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	git, err := newFakeGit("repo", map[string]string{
 		"baz": `FROM busybox
 RUN echo from baz`,

--- a/integration-cli/docker_api_containers_test.go
+++ b/integration-cli/docker_api_containers_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func (s *DockerSuite) TestContainerApiGetAll(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	startCount, err := getContainerCount()
 	if err != nil {
 		c.Fatalf("Cannot query container count: %v", err)
@@ -51,6 +52,7 @@ func (s *DockerSuite) TestContainerApiGetAll(c *check.C) {
 
 // regression test for empty json field being omitted #13691
 func (s *DockerSuite) TestContainerApiGetJSONNoFieldsOmitted(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "busybox", "true")
 
 	status, body, err := sockRequest("GET", "/containers/json?all=1", nil)
@@ -87,6 +89,7 @@ type containerPs struct {
 
 // regression test for non-empty fields from #13901
 func (s *DockerSuite) TestContainerPsOmitFields(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "pstest"
 	port := 80
 	dockerCmd(c, "run", "-d", "--name", name, "--expose", strconv.Itoa(port), "busybox", "top")
@@ -118,6 +121,7 @@ func (s *DockerSuite) TestContainerPsOmitFields(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiGetExport(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "exportcontainer"
 	dockerCmd(c, "run", "--name", name, "busybox", "touch", "/test")
 
@@ -146,6 +150,7 @@ func (s *DockerSuite) TestContainerApiGetExport(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiGetChanges(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "changescontainer"
 	dockerCmd(c, "run", "--name", name, "busybox", "rm", "/etc/passwd")
 
@@ -174,6 +179,7 @@ func (s *DockerSuite) TestContainerApiGetChanges(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiStartVolumeBinds(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testing"
 	config := map[string]interface{}{
 		"Image":   "busybox",
@@ -204,6 +210,7 @@ func (s *DockerSuite) TestContainerApiStartVolumeBinds(c *check.C) {
 
 // Test for GH#10618
 func (s *DockerSuite) TestContainerApiStartDupVolumeBinds(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testdups"
 	config := map[string]interface{}{
 		"Image":   "busybox",
@@ -230,6 +237,7 @@ func (s *DockerSuite) TestContainerApiStartDupVolumeBinds(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiStartVolumesFrom(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	volName := "voltst"
 	volPath := "/tmp"
 
@@ -267,6 +275,7 @@ func (s *DockerSuite) TestContainerApiStartVolumesFrom(c *check.C) {
 }
 
 func (s *DockerSuite) TestGetContainerStats(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	var (
 		name = "statscontainer"
 	)
@@ -306,6 +315,7 @@ func (s *DockerSuite) TestGetContainerStats(c *check.C) {
 }
 
 func (s *DockerSuite) TestGetContainerStatsRmRunning(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
 
@@ -345,6 +355,7 @@ func (s *DockerSuite) TestGetContainerStatsRmRunning(c *check.C) {
 // previous test was just checking one stat entry so it didn't fail (stats with
 // stream false always return one stat)
 func (s *DockerSuite) TestGetContainerStatsStream(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "statscontainer"
 	dockerCmd(c, "run", "-d", "--name", name, "busybox", "top")
 
@@ -381,6 +392,7 @@ func (s *DockerSuite) TestGetContainerStatsStream(c *check.C) {
 }
 
 func (s *DockerSuite) TestGetContainerStatsNoStream(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "statscontainer"
 	dockerCmd(c, "run", "-d", "--name", name, "busybox", "top")
 
@@ -417,6 +429,7 @@ func (s *DockerSuite) TestGetContainerStatsNoStream(c *check.C) {
 }
 
 func (s *DockerSuite) TestGetStoppedContainerStats(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// TODO: this test does nothing because we are c.Assert'ing in goroutine
 	var (
 		name = "statscontainer"
@@ -437,6 +450,7 @@ func (s *DockerSuite) TestGetStoppedContainerStats(c *check.C) {
 
 // #9981 - Allow a docker created volume (ie, one in /var/lib/docker/volumes) to be used to overwrite (via passing in Binds on api start) an existing volume
 func (s *DockerSuite) TestPostContainerBindNormalVolume(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "create", "-v", "/foo", "--name=one", "busybox")
 
 	fooDir, err := inspectMountSourceField("one", "/foo")
@@ -462,6 +476,7 @@ func (s *DockerSuite) TestPostContainerBindNormalVolume(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiPause(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	defer unpauseAllContainers()
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sleep", "30")
 	ContainerID := strings.TrimSpace(out)
@@ -496,6 +511,7 @@ func (s *DockerSuite) TestContainerApiPause(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiTop(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "top")
 	id := strings.TrimSpace(string(out))
 	c.Assert(waitRun(id), check.IsNil)
@@ -532,6 +548,7 @@ func (s *DockerSuite) TestContainerApiTop(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiCommit(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cName := "testapicommit"
 	dockerCmd(c, "run", "--name="+cName, "busybox", "/bin/sh", "-c", "touch /test")
 
@@ -560,6 +577,7 @@ func (s *DockerSuite) TestContainerApiCommit(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiCommitWithLabelInConfig(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cName := "testapicommitwithconfig"
 	dockerCmd(c, "run", "--name="+cName, "busybox", "/bin/sh", "-c", "touch /test")
 
@@ -605,6 +623,7 @@ func (s *DockerSuite) TestContainerApiCommitWithLabelInConfig(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiBadPort(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := map[string]interface{}{
 		"Image": "busybox",
 		"Cmd":   []string{"/bin/sh", "-c", "echo test"},
@@ -631,6 +650,7 @@ func (s *DockerSuite) TestContainerApiBadPort(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiCreate(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := map[string]interface{}{
 		"Image": "busybox",
 		"Cmd":   []string{"/bin/sh", "-c", "touch /test && ls /test"},
@@ -668,6 +688,7 @@ func (s *DockerSuite) TestContainerApiCreateEmptyConfig(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiCreateWithHostName(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	hostName := "test-host"
 	config := map[string]interface{}{
 		"Image":    "busybox",
@@ -698,6 +719,7 @@ func (s *DockerSuite) TestContainerApiCreateWithHostName(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiCreateWithDomainName(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	domainName := "test-domain"
 	config := map[string]interface{}{
 		"Image":      "busybox",
@@ -728,6 +750,7 @@ func (s *DockerSuite) TestContainerApiCreateWithDomainName(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiCreateNetworkMode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	UtilCreateNetworkMode(c, "host")
 	UtilCreateNetworkMode(c, "bridge")
 	UtilCreateNetworkMode(c, "container:web1")
@@ -763,6 +786,7 @@ func UtilCreateNetworkMode(c *check.C, networkMode string) {
 }
 
 func (s *DockerSuite) TestContainerApiCreateWithCpuSharesCpuset(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := map[string]interface{}{
 		"Image":      "busybox",
 		"CpuShares":  512,
@@ -796,6 +820,7 @@ func (s *DockerSuite) TestContainerApiCreateWithCpuSharesCpuset(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiVerifyHeader(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := map[string]interface{}{
 		"Image": "busybox",
 	}
@@ -829,6 +854,7 @@ func (s *DockerSuite) TestContainerApiVerifyHeader(c *check.C) {
 
 //Issue 14230. daemon should return 500 for invalid port syntax
 func (s *DockerSuite) TestContainerApiInvalidPortSyntax(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := `{
 				  "Image": "busybox",
 				  "HostConfig": {
@@ -854,6 +880,7 @@ func (s *DockerSuite) TestContainerApiInvalidPortSyntax(c *check.C) {
 // Issue 7941 - test to make sure a "null" in JSON is just ignored.
 // W/o this fix a null in JSON would be parsed into a string var as "null"
 func (s *DockerSuite) TestContainerApiPostCreateNull(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := `{
 		"Hostname":"",
 		"Domainname":"",
@@ -914,6 +941,7 @@ func (s *DockerSuite) TestContainerApiPostCreateNull(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateWithTooLowMemoryLimit(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := `{
 		"Image":     "busybox",
 		"Cmd":       "ls",
@@ -934,6 +962,7 @@ func (s *DockerSuite) TestCreateWithTooLowMemoryLimit(c *check.C) {
 }
 
 func (s *DockerSuite) TestStartWithTooLowMemoryLimit(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "create", "busybox")
 
 	containerID := strings.TrimSpace(out)
@@ -955,6 +984,7 @@ func (s *DockerSuite) TestStartWithTooLowMemoryLimit(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiRename(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--name", "TestContainerApiRename", "-d", "busybox", "sh")
 
 	containerID := strings.TrimSpace(out)
@@ -971,6 +1001,7 @@ func (s *DockerSuite) TestContainerApiRename(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiKill(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-api-kill"
 	dockerCmd(c, "run", "-di", "--name", name, "busybox", "top")
 
@@ -988,6 +1019,7 @@ func (s *DockerSuite) TestContainerApiKill(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiRestart(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-api-restart"
 	dockerCmd(c, "run", "-di", "--name", name, "busybox", "top")
 
@@ -1001,6 +1033,7 @@ func (s *DockerSuite) TestContainerApiRestart(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiRestartNotimeoutParam(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-api-restart-no-timeout-param"
 	out, _ := dockerCmd(c, "run", "-di", "--name", name, "busybox", "top")
 	id := strings.TrimSpace(out)
@@ -1016,6 +1049,7 @@ func (s *DockerSuite) TestContainerApiRestartNotimeoutParam(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiStart(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testing-start"
 	config := map[string]interface{}{
 		"Image":     "busybox",
@@ -1039,6 +1073,7 @@ func (s *DockerSuite) TestContainerApiStart(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiStop(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-api-stop"
 	dockerCmd(c, "run", "-di", "--name", name, "busybox", "top")
 
@@ -1057,6 +1092,7 @@ func (s *DockerSuite) TestContainerApiStop(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiWait(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-api-wait"
 	dockerCmd(c, "run", "--name", name, "busybox", "sleep", "5")
 
@@ -1079,6 +1115,7 @@ func (s *DockerSuite) TestContainerApiWait(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiCopy(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-container-api-copy"
 	dockerCmd(c, "run", "--name", name, "busybox", "touch", "/test.txt")
 
@@ -1108,6 +1145,7 @@ func (s *DockerSuite) TestContainerApiCopy(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiCopyResourcePathEmpty(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-container-api-copy-resource-empty"
 	dockerCmd(c, "run", "--name", name, "busybox", "touch", "/test.txt")
 
@@ -1122,6 +1160,7 @@ func (s *DockerSuite) TestContainerApiCopyResourcePathEmpty(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiCopyResourcePathNotFound(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-container-api-copy-resource-not-found"
 	dockerCmd(c, "run", "--name", name, "busybox")
 
@@ -1146,6 +1185,7 @@ func (s *DockerSuite) TestContainerApiCopyContainerNotFound(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiDelete(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 
 	id := strings.TrimSpace(out)
@@ -1166,6 +1206,7 @@ func (s *DockerSuite) TestContainerApiDeleteNotExist(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiDeleteForce(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 
 	id := strings.TrimSpace(out)
@@ -1177,6 +1218,7 @@ func (s *DockerSuite) TestContainerApiDeleteForce(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiDeleteRemoveLinks(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "--name", "tlink1", "busybox", "top")
 
 	id := strings.TrimSpace(out)
@@ -1207,6 +1249,7 @@ func (s *DockerSuite) TestContainerApiDeleteRemoveLinks(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiDeleteConflict(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 
 	id := strings.TrimSpace(out)
@@ -1218,6 +1261,7 @@ func (s *DockerSuite) TestContainerApiDeleteConflict(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerApiDeleteRemoveVolume(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 
 	out, _ := dockerCmd(c, "run", "-d", "-v", "/testvolume", "busybox", "top")
@@ -1240,6 +1284,7 @@ func (s *DockerSuite) TestContainerApiDeleteRemoveVolume(c *check.C) {
 
 // Regression test for https://github.com/docker/docker/issues/6231
 func (s *DockerSuite) TestContainersApiChunkedEncoding(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "create", "-v", "/foo", "busybox", "true")
 	id := strings.TrimSpace(out)
 
@@ -1290,6 +1335,7 @@ func (s *DockerSuite) TestContainersApiChunkedEncoding(c *check.C) {
 }
 
 func (s *DockerSuite) TestPostContainerStop(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 
 	containerID := strings.TrimSpace(out)
@@ -1307,6 +1353,7 @@ func (s *DockerSuite) TestPostContainerStop(c *check.C) {
 
 // #14170
 func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceEntrypoint(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := struct {
 		Image      string
 		Entrypoint string
@@ -1330,6 +1377,7 @@ func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceEntrypoint(c *che
 
 // #14170
 func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceCmd(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := struct {
 		Image      string
 		Entrypoint string
@@ -1352,6 +1400,7 @@ func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceCmd(c *check.C) {
 
 // regression #14318
 func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceCapAddDrop(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := struct {
 		Image   string
 		CapAdd  string
@@ -1373,6 +1422,7 @@ func (s *DockerSuite) TestPostContainersCreateWithStringOrSliceCapAddDrop(c *che
 
 // #14640
 func (s *DockerSuite) TestPostContainersStartWithoutLinksInHostConfig(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-host-config-links"
 	dockerCmd(c, "create", "--name", name, "busybox", "top")
 
@@ -1388,6 +1438,7 @@ func (s *DockerSuite) TestPostContainersStartWithoutLinksInHostConfig(c *check.C
 
 // #14640
 func (s *DockerSuite) TestPostContainersStartWithLinksInHostConfig(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-host-config-links"
 	dockerCmd(c, "run", "--name", "foo", "-d", "busybox", "top")
 	dockerCmd(c, "create", "--name", name, "--link", "foo:bar", "busybox", "top")
@@ -1404,6 +1455,7 @@ func (s *DockerSuite) TestPostContainersStartWithLinksInHostConfig(c *check.C) {
 
 // #14640
 func (s *DockerSuite) TestPostContainersStartWithLinksInHostConfigIdLinked(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-host-config-links"
 	out, _ := dockerCmd(c, "run", "--name", "link0", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
@@ -1421,6 +1473,7 @@ func (s *DockerSuite) TestPostContainersStartWithLinksInHostConfigIdLinked(c *ch
 
 // #14915
 func (s *DockerSuite) TestContainersApiCreateNoHostConfig118(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := struct {
 		Image string
 	}{"busybox"}

--- a/integration-cli/docker_api_exec_resize_test.go
+++ b/integration-cli/docker_api_exec_resize_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func (s *DockerSuite) TestExecResizeApiHeightWidthNoInt(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -24,6 +25,7 @@ func (s *DockerSuite) TestExecResizeApiHeightWidthNoInt(c *check.C) {
 
 // Part of #14845
 func (s *DockerSuite) TestExecResizeImmediatelyAfterExecStart(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, NativeExecDriver)
 
 	name := "exec_resize_test"

--- a/integration-cli/docker_api_exec_test.go
+++ b/integration-cli/docker_api_exec_test.go
@@ -13,6 +13,7 @@ import (
 
 // Regression test for #9414
 func (s *DockerSuite) TestExecApiCreateNoCmd(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "exec_test"
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
@@ -26,6 +27,7 @@ func (s *DockerSuite) TestExecApiCreateNoCmd(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecApiCreateNoValidContentType(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "exec_test"
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 

--- a/integration-cli/docker_api_images_test.go
+++ b/integration-cli/docker_api_images_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func (s *DockerSuite) TestApiImagesFilter(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "utest:tag1"
 	name2 := "utest/docker:tag2"
 	name3 := "utest:5000/docker:tag3"
@@ -50,6 +51,7 @@ func (s *DockerSuite) TestApiImagesFilter(c *check.C) {
 
 func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 	testRequires(c, Network)
+	testRequires(c, DaemonIsLinux)
 	out, err := buildImage("saveandload", "FROM hello-world\nENV FOO bar", false)
 	if err != nil {
 		c.Fatal(err)
@@ -78,6 +80,7 @@ func (s *DockerSuite) TestApiImagesSaveAndLoad(c *check.C) {
 
 func (s *DockerSuite) TestApiImagesDelete(c *check.C) {
 	testRequires(c, Network)
+	testRequires(c, DaemonIsLinux)
 	name := "test-api-images-delete"
 	out, err := buildImage(name, "FROM hello-world\nENV FOO bar", false)
 	if err != nil {
@@ -102,6 +105,7 @@ func (s *DockerSuite) TestApiImagesDelete(c *check.C) {
 
 func (s *DockerSuite) TestApiImagesHistory(c *check.C) {
 	testRequires(c, Network)
+	testRequires(c, DaemonIsLinux)
 	name := "test-api-images-history"
 	out, err := buildImage(name, "FROM hello-world\nENV FOO bar", false)
 	c.Assert(err, check.IsNil)

--- a/integration-cli/docker_api_inspect_test.go
+++ b/integration-cli/docker_api_inspect_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func (s *DockerSuite) TestInspectApiContainerResponse(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 
 	cleanedContainerID := strings.TrimSpace(out)

--- a/integration-cli/docker_api_logs_test.go
+++ b/integration-cli/docker_api_logs_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func (s *DockerSuite) TestLogsApiWithStdout(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "-t", "busybox", "/bin/sh", "-c", "while true; do echo hello; sleep 1; done")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
@@ -51,6 +52,7 @@ func (s *DockerSuite) TestLogsApiWithStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsApiNoStdoutNorStderr(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "logs_test"
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "/bin/sh")
 
@@ -66,6 +68,7 @@ func (s *DockerSuite) TestLogsApiNoStdoutNorStderr(c *check.C) {
 
 // Regression test for #12704
 func (s *DockerSuite) TestLogsApiFollowEmptyOutput(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "logs_test"
 	t0 := time.Now()
 	dockerCmd(c, "run", "-d", "-t", "--name", name, "busybox", "sleep", "10")

--- a/integration-cli/docker_api_resize_test.go
+++ b/integration-cli/docker_api_resize_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func (s *DockerSuite) TestResizeApiResponse(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -18,6 +19,7 @@ func (s *DockerSuite) TestResizeApiResponse(c *check.C) {
 }
 
 func (s *DockerSuite) TestResizeApiHeightWidthNoInt(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -28,6 +30,7 @@ func (s *DockerSuite) TestResizeApiHeightWidthNoInt(c *check.C) {
 }
 
 func (s *DockerSuite) TestResizeApiResponseWhenContainerNotStarted(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	cleanedContainerID := strings.TrimSpace(out)
 

--- a/integration-cli/docker_api_stats_test.go
+++ b/integration-cli/docker_api_stats_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func (s *DockerSuite) TestCliStatsNoStreamGetCpu(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true;do echo 'Hello'; usleep 100000; done")
 
 	id := strings.TrimSpace(out)
@@ -39,6 +40,7 @@ func (s *DockerSuite) TestCliStatsNoStreamGetCpu(c *check.C) {
 }
 
 func (s *DockerSuite) TestStoppedContainerStatsGoroutines(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo 1")
 	id := strings.TrimSpace(out)
 
@@ -75,6 +77,7 @@ func (s *DockerSuite) TestStoppedContainerStatsGoroutines(c *check.C) {
 
 func (s *DockerSuite) TestApiNetworkStats(c *check.C) {
 	testRequires(c, SameHostDaemon)
+	testRequires(c, DaemonIsLinux)
 	// Run container for 30 secs
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)

--- a/integration-cli/docker_api_volumes_test.go
+++ b/integration-cli/docker_api_volumes_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func (s *DockerSuite) TestVolumesApiList(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "-v", "/foo", "busybox")
 
 	status, b, err := sockRequest("GET", "/volumes", nil)
@@ -23,6 +24,7 @@ func (s *DockerSuite) TestVolumesApiList(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumesApiCreate(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := types.VolumeCreateRequest{
 		Name: "test",
 	}
@@ -38,6 +40,7 @@ func (s *DockerSuite) TestVolumesApiCreate(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumesApiRemove(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "-v", "/foo", "--name=test", "busybox")
 
 	status, b, err := sockRequest("GET", "/volumes", nil)
@@ -61,6 +64,7 @@ func (s *DockerSuite) TestVolumesApiRemove(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumesApiInspect(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := types.VolumeCreateRequest{
 		Name: "test",
 	}

--- a/integration-cli/docker_cli_attach_test.go
+++ b/integration-cli/docker_cli_attach_test.go
@@ -15,6 +15,7 @@ import (
 const attachWait = 5 * time.Second
 
 func (s *DockerSuite) TestAttachMultipleAndRestart(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 
 	endGroup := &sync.WaitGroup{}
 	startGroup := &sync.WaitGroup{}
@@ -87,6 +88,7 @@ func (s *DockerSuite) TestAttachMultipleAndRestart(c *check.C) {
 }
 
 func (s *DockerSuite) TestAttachTtyWithoutStdin(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "-ti", "busybox")
 
 	id := strings.TrimSpace(out)
@@ -128,6 +130,7 @@ func (s *DockerSuite) TestAttachTtyWithoutStdin(c *check.C) {
 }
 
 func (s *DockerSuite) TestAttachDisconnect(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-di", "busybox", "/bin/cat")
 	id := strings.TrimSpace(out)
 

--- a/integration-cli/docker_cli_build_test.go
+++ b/integration-cli/docker_cli_build_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func (s *DockerSuite) TestBuildJSONEmptyRun(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildjsonemptyrun"
 
 	_, err := buildImage(
@@ -42,6 +43,7 @@ func (s *DockerSuite) TestBuildJSONEmptyRun(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEmptyWhitespace(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildemptywhitespace"
 
 	_, err := buildImage(
@@ -61,6 +63,7 @@ func (s *DockerSuite) TestBuildEmptyWhitespace(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildShCmdJSONEntrypoint(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildshcmdjsonentrypoint"
 
 	_, err := buildImage(
@@ -85,6 +88,7 @@ func (s *DockerSuite) TestBuildShCmdJSONEntrypoint(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEnvironmentReplacementUser(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
 	_, err := buildImage(name, `
@@ -108,6 +112,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementUser(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEnvironmentReplacementVolume(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
 	_, err := buildImage(name, `
@@ -137,6 +142,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementVolume(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEnvironmentReplacementExpose(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
 	_, err := buildImage(name, `
@@ -166,6 +172,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementExpose(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEnvironmentReplacementWorkdir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
 	_, err := buildImage(name, `
@@ -182,6 +189,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementWorkdir(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEnvironmentReplacementAddCopy(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
 	ctx, err := fakeContext(`
@@ -216,6 +224,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementAddCopy(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEnvironmentReplacementEnv(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvironmentreplacement"
 
 	_, err := buildImage(name,
@@ -283,6 +292,7 @@ func (s *DockerSuite) TestBuildEnvironmentReplacementEnv(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildHandleEscapes(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildhandleescapes"
 
 	_, err := buildImage(name,
@@ -370,6 +380,7 @@ func (s *DockerSuite) TestBuildHandleEscapes(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildOnBuildLowercase(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuildlowercase"
 	name2 := "testbuildonbuildlowercase2"
 
@@ -402,6 +413,7 @@ func (s *DockerSuite) TestBuildOnBuildLowercase(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEnvEscapes(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvescapes"
 	_, err := buildImage(name,
 		`
@@ -424,6 +436,7 @@ func (s *DockerSuite) TestBuildEnvEscapes(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEnvOverwrite(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvoverwrite"
 
 	_, err := buildImage(name,
@@ -447,6 +460,7 @@ func (s *DockerSuite) TestBuildEnvOverwrite(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildOnBuildForbiddenMaintainerInSourceImage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuildforbiddenmaintainerinsourceimage"
 
 	out, _ := dockerCmd(c, "create", "busybox", "true")
@@ -469,6 +483,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenMaintainerInSourceImage(c *check.
 }
 
 func (s *DockerSuite) TestBuildOnBuildForbiddenFromInSourceImage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuildforbiddenfrominsourceimage"
 
 	out, _ := dockerCmd(c, "create", "busybox", "true")
@@ -491,6 +506,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenFromInSourceImage(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildOnBuildForbiddenChainedInSourceImage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuildforbiddenchainedinsourceimage"
 
 	out, _ := dockerCmd(c, "create", "busybox", "true")
@@ -513,6 +529,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenChainedInSourceImage(c *check.C) 
 }
 
 func (s *DockerSuite) TestBuildOnBuildCmdEntrypointJSON(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name1 := "onbuildcmd"
 	name2 := "onbuildgenerated"
 
@@ -542,6 +559,7 @@ ONBUILD RUN ["true"]`,
 }
 
 func (s *DockerSuite) TestBuildOnBuildEntrypointJSON(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name1 := "onbuildcmd"
 	name2 := "onbuildgenerated"
 
@@ -569,6 +587,7 @@ ONBUILD ENTRYPOINT ["echo"]`,
 }
 
 func (s *DockerSuite) TestBuildCacheAdd(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildtwoimageswithadd"
 	server, err := fakeStorage(map[string]string{
 		"robots.txt": "hello",
@@ -603,6 +622,7 @@ func (s *DockerSuite) TestBuildCacheAdd(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildLastModified(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildlastmodified"
 
 	server, err := fakeStorage(map[string]string{
@@ -668,6 +688,7 @@ RUN ls -le /file`
 }
 
 func (s *DockerSuite) TestBuildSixtySteps(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "foobuildsixtysteps"
 	ctx, err := fakeContext("FROM scratch\n"+strings.Repeat("ADD foo /\n", 60),
 		map[string]string{
@@ -684,6 +705,7 @@ func (s *DockerSuite) TestBuildSixtySteps(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddSingleFileToRoot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testaddimg"
 	ctx, err := fakeContext(fmt.Sprintf(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -709,6 +731,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`, expecte
 
 // Issue #3960: "ADD src ." hangs
 func (s *DockerSuite) TestBuildAddSingleFileToWorkdir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testaddsinglefiletoworkdir"
 	ctx, err := fakeContext(`FROM busybox
 ADD test_file .`,
@@ -735,6 +758,7 @@ ADD test_file .`,
 }
 
 func (s *DockerSuite) TestBuildAddSingleFileToExistDir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testaddsinglefiletoexistdir"
 	ctx, err := fakeContext(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -760,6 +784,7 @@ RUN [ $(ls -l /exists/exists_file | awk '{print $3":"$4}') = 'dockerio:dockerio'
 }
 
 func (s *DockerSuite) TestBuildCopyAddMultipleFiles(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	server, err := fakeStorage(map[string]string{
 		"robots.txt": "hello",
 	})
@@ -804,6 +829,7 @@ RUN [ $(ls -l /exists/exists_file | awk '{print $3":"$4}') = 'dockerio:dockerio'
 }
 
 func (s *DockerSuite) TestBuildAddMultipleFilesToFile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testaddmultiplefilestofile"
 	ctx, err := fakeContext(`FROM scratch
 	ADD file1.txt file2.txt test
@@ -825,6 +851,7 @@ func (s *DockerSuite) TestBuildAddMultipleFilesToFile(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildJSONAddMultipleFilesToFile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testjsonaddmultiplefilestofile"
 	ctx, err := fakeContext(`FROM scratch
 	ADD ["file1.txt", "file2.txt", "test"]
@@ -846,6 +873,7 @@ func (s *DockerSuite) TestBuildJSONAddMultipleFilesToFile(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddMultipleFilesToFileWild(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testaddmultiplefilestofilewild"
 	ctx, err := fakeContext(`FROM scratch
 	ADD file*.txt test
@@ -867,6 +895,7 @@ func (s *DockerSuite) TestBuildAddMultipleFilesToFileWild(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildJSONAddMultipleFilesToFileWild(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testjsonaddmultiplefilestofilewild"
 	ctx, err := fakeContext(`FROM scratch
 	ADD ["file*.txt", "test"]
@@ -888,6 +917,7 @@ func (s *DockerSuite) TestBuildJSONAddMultipleFilesToFileWild(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildCopyMultipleFilesToFile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopymultiplefilestofile"
 	ctx, err := fakeContext(`FROM scratch
 	COPY file1.txt file2.txt test
@@ -909,6 +939,7 @@ func (s *DockerSuite) TestBuildCopyMultipleFilesToFile(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildJSONCopyMultipleFilesToFile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testjsoncopymultiplefilestofile"
 	ctx, err := fakeContext(`FROM scratch
 	COPY ["file1.txt", "file2.txt", "test"]
@@ -930,6 +961,7 @@ func (s *DockerSuite) TestBuildJSONCopyMultipleFilesToFile(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddFileWithWhitespace(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testaddfilewithwhitespace"
 	ctx, err := fakeContext(`FROM busybox
 RUN mkdir "/test dir"
@@ -965,6 +997,7 @@ RUN [ $(cat "/test dir/test_file6") = 'test6' ]`,
 }
 
 func (s *DockerSuite) TestBuildCopyFileWithWhitespace(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopyfilewithwhitespace"
 	ctx, err := fakeContext(`FROM busybox
 RUN mkdir "/test dir"
@@ -1000,6 +1033,7 @@ RUN [ $(cat "/test dir/test_file6") = 'test6' ]`,
 }
 
 func (s *DockerSuite) TestBuildAddMultipleFilesToFileWithWhitespace(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testaddmultiplefilestofilewithwhitespace"
 	ctx, err := fakeContext(`FROM busybox
 	ADD [ "test file1", "test file2", "test" ]
@@ -1021,6 +1055,7 @@ func (s *DockerSuite) TestBuildAddMultipleFilesToFileWithWhitespace(c *check.C) 
 }
 
 func (s *DockerSuite) TestBuildCopyMultipleFilesToFileWithWhitespace(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopymultiplefilestofilewithwhitespace"
 	ctx, err := fakeContext(`FROM busybox
 	COPY [ "test file1", "test file2", "test" ]
@@ -1042,6 +1077,7 @@ func (s *DockerSuite) TestBuildCopyMultipleFilesToFileWithWhitespace(c *check.C)
 }
 
 func (s *DockerSuite) TestBuildCopyWildcard(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopywildcard"
 	server, err := fakeStorage(map[string]string{
 		"robots.txt": "hello",
@@ -1092,6 +1128,7 @@ func (s *DockerSuite) TestBuildCopyWildcard(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildCopyWildcardNoFind(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopywildcardnofind"
 	ctx, err := fakeContext(`FROM busybox
 	COPY file*.txt /tmp/
@@ -1112,6 +1149,7 @@ func (s *DockerSuite) TestBuildCopyWildcardNoFind(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildCopyWildcardInName(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopywildcardinname"
 	ctx, err := fakeContext(`FROM busybox
 	COPY *.txt /tmp/
@@ -1136,6 +1174,7 @@ func (s *DockerSuite) TestBuildCopyWildcardInName(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildCopyWildcardCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopywildcardcache"
 	ctx, err := fakeContext(`FROM busybox
 	COPY file1.txt /tmp/`,
@@ -1169,6 +1208,7 @@ func (s *DockerSuite) TestBuildCopyWildcardCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddSingleFileToNonExistingDir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testaddsinglefiletononexistingdir"
 	ctx, err := fakeContext(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -1194,6 +1234,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 }
 
 func (s *DockerSuite) TestBuildAddDirContentToRoot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testadddircontenttoroot"
 	ctx, err := fakeContext(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -1217,6 +1258,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 }
 
 func (s *DockerSuite) TestBuildAddDirContentToExistingDir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testadddircontenttoexistingdir"
 	ctx, err := fakeContext(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -1242,6 +1284,7 @@ RUN [ $(ls -l /exists/test_file | awk '{print $3":"$4}') = 'root:root' ]`,
 }
 
 func (s *DockerSuite) TestBuildAddWholeDirToRoot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testaddwholedirtoroot"
 	ctx, err := fakeContext(fmt.Sprintf(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -1269,6 +1312,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`, expecte
 
 // Testing #5941
 func (s *DockerSuite) TestBuildAddEtcToRoot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testaddetctoroot"
 	ctx, err := fakeContext(`FROM scratch
 ADD . /`,
@@ -1287,6 +1331,7 @@ ADD . /`,
 
 // Testing #9401
 func (s *DockerSuite) TestBuildAddPreservesFilesSpecialBits(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testaddpreservesfilesspecialbits"
 	ctx, err := fakeContext(`FROM busybox
 ADD suidbin /usr/bin/suidbin
@@ -1309,6 +1354,7 @@ RUN [ $(ls -l /usr/bin/suidbin | awk '{print $1}') = '-rwsr-xr-x' ]`,
 }
 
 func (s *DockerSuite) TestBuildCopySingleFileToRoot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopysinglefiletoroot"
 	ctx, err := fakeContext(fmt.Sprintf(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -1334,6 +1380,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`, expecte
 
 // Issue #3960: "ADD src ." hangs - adapted for COPY
 func (s *DockerSuite) TestBuildCopySingleFileToWorkdir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopysinglefiletoworkdir"
 	ctx, err := fakeContext(`FROM busybox
 COPY test_file .`,
@@ -1360,6 +1407,7 @@ COPY test_file .`,
 }
 
 func (s *DockerSuite) TestBuildCopySingleFileToExistDir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopysinglefiletoexistdir"
 	ctx, err := fakeContext(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -1385,6 +1433,7 @@ RUN [ $(ls -l /exists/exists_file | awk '{print $3":"$4}') = 'dockerio:dockerio'
 }
 
 func (s *DockerSuite) TestBuildCopySingleFileToNonExistDir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopysinglefiletononexistdir"
 	ctx, err := fakeContext(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -1409,6 +1458,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 }
 
 func (s *DockerSuite) TestBuildCopyDirContentToRoot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopydircontenttoroot"
 	ctx, err := fakeContext(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -1432,6 +1482,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`,
 }
 
 func (s *DockerSuite) TestBuildCopyDirContentToExistDir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopydircontenttoexistdir"
 	ctx, err := fakeContext(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -1457,6 +1508,7 @@ RUN [ $(ls -l /exists/test_file | awk '{print $3":"$4}') = 'root:root' ]`,
 }
 
 func (s *DockerSuite) TestBuildCopyWholeDirToRoot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopywholedirtoroot"
 	ctx, err := fakeContext(fmt.Sprintf(`FROM busybox
 RUN echo 'dockerio:x:1001:1001::/bin:/bin/false' >> /etc/passwd
@@ -1483,6 +1535,7 @@ RUN [ $(ls -l /exists | awk '{print $3":"$4}') = 'dockerio:dockerio' ]`, expecte
 }
 
 func (s *DockerSuite) TestBuildCopyEtcToRoot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopyetctoroot"
 	ctx, err := fakeContext(`FROM scratch
 COPY . /`,
@@ -1500,6 +1553,7 @@ COPY . /`,
 }
 
 func (s *DockerSuite) TestBuildCopyDisallowRemote(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testcopydisallowremote"
 	_, out, err := buildImageWithOut(name, `FROM scratch
 COPY https://index.docker.io/robots.txt /`,
@@ -1510,6 +1564,7 @@ COPY https://index.docker.io/robots.txt /`,
 }
 
 func (s *DockerSuite) TestBuildAddBadLinks(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	const (
 		dockerfile = `
 			FROM scratch
@@ -1596,6 +1651,7 @@ func (s *DockerSuite) TestBuildAddBadLinks(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddBadLinksVolume(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	const (
 		dockerfileTemplate = `
 		FROM busybox
@@ -1648,6 +1704,7 @@ func (s *DockerSuite) TestBuildAddBadLinksVolume(c *check.C) {
 // Issue #5270 - ensure we throw a better error than "unexpected EOF"
 // when we can't access files in the context.
 func (s *DockerSuite) TestBuildWithInaccessibleFilesInContext(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, UnixCli) // test uses chown/chmod: not available on windows
 
 	{
@@ -1773,6 +1830,7 @@ func (s *DockerSuite) TestBuildWithInaccessibleFilesInContext(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildForceRm(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	containerCountBefore, err := getContainerCount()
 	if err != nil {
 		c.Fatalf("failed to get the container count: %s", err)
@@ -1805,6 +1863,7 @@ func (s *DockerSuite) TestBuildForceRm(c *check.C) {
 // * When docker events sees container start, close the "docker build" command
 // * Wait for docker events to emit a dying event.
 func (s *DockerSuite) TestBuildCancellationKillsSleep(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildcancellation"
 
 	// (Note: one year, will never finish)
@@ -1906,6 +1965,7 @@ func (s *DockerSuite) TestBuildCancellationKillsSleep(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildRm(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildrm"
 	ctx, err := fakeContext("FROM scratch\nADD foo /\nADD foo /", map[string]string{"foo": "bar"})
 	if err != nil {
@@ -1985,6 +2045,7 @@ func (s *DockerSuite) TestBuildRm(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildWithVolumes(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	var (
 		result   map[string]map[string]struct{}
 		name     = "testbuildvolumes"
@@ -2031,6 +2092,7 @@ func (s *DockerSuite) TestBuildWithVolumes(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildMaintainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildmaintainer"
 	expected := "dockerio"
 	_, err := buildImage(name,
@@ -2050,6 +2112,7 @@ func (s *DockerSuite) TestBuildMaintainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildUser(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuilduser"
 	expected := "dockerio"
 	_, err := buildImage(name,
@@ -2071,6 +2134,7 @@ func (s *DockerSuite) TestBuildUser(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildRelativeWorkdir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildrelativeworkdir"
 	expected := "/test2/test3"
 	_, err := buildImage(name,
@@ -2096,6 +2160,7 @@ func (s *DockerSuite) TestBuildRelativeWorkdir(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildWorkdirWithEnvVariables(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildworkdirwithenvvariables"
 	expected := "/test1/test2"
 	_, err := buildImage(name,
@@ -2118,6 +2183,7 @@ func (s *DockerSuite) TestBuildWorkdirWithEnvVariables(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildRelativeCopy(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildrelativecopy"
 	dockerfile := `
 		FROM busybox
@@ -2156,6 +2222,7 @@ func (s *DockerSuite) TestBuildRelativeCopy(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEnv(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildenv"
 	expected := "[PATH=/test:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PORT=2375]"
 	_, err := buildImage(name,
@@ -2177,6 +2244,7 @@ func (s *DockerSuite) TestBuildEnv(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildContextCleanup(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 
 	name := "testbuildcontextcleanup"
@@ -2202,6 +2270,7 @@ func (s *DockerSuite) TestBuildContextCleanup(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildContextCleanupFailedBuild(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 
 	name := "testbuildcontextcleanup"
@@ -2227,6 +2296,7 @@ func (s *DockerSuite) TestBuildContextCleanupFailedBuild(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildCmd(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildcmd"
 	expected := "{[/bin/echo Hello World]}"
 	_, err := buildImage(name,
@@ -2246,6 +2316,7 @@ func (s *DockerSuite) TestBuildCmd(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildExpose(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildexpose"
 	expected := "map[2375/tcp:{}]"
 	_, err := buildImage(name,
@@ -2265,6 +2336,7 @@ func (s *DockerSuite) TestBuildExpose(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildExposeMorePorts(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// start building docker file with a large number of ports
 	portList := make([]string, 50)
 	line := make([]string, 100)
@@ -2319,6 +2391,7 @@ func (s *DockerSuite) TestBuildExposeMorePorts(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildExposeOrder(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	buildID := func(name, exposed string) string {
 		_, err := buildImage(name, fmt.Sprintf(`FROM scratch
 		EXPOSE %s`, exposed), true)
@@ -2340,6 +2413,7 @@ func (s *DockerSuite) TestBuildExposeOrder(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildExposeUpperCaseProto(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildexposeuppercaseproto"
 	expected := "map[5678/udp:{}]"
 	_, err := buildImage(name,
@@ -2359,6 +2433,7 @@ func (s *DockerSuite) TestBuildExposeUpperCaseProto(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEmptyEntrypointInheritance(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildentrypointinheritance"
 	name2 := "testbuildentrypointinheritance2"
 
@@ -2400,6 +2475,7 @@ func (s *DockerSuite) TestBuildEmptyEntrypointInheritance(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEmptyEntrypoint(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildentrypoint"
 	expected := "{[]}"
 
@@ -2421,6 +2497,7 @@ func (s *DockerSuite) TestBuildEmptyEntrypoint(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEntrypoint(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildentrypoint"
 	expected := "{[/bin/echo]}"
 	_, err := buildImage(name,
@@ -2442,6 +2519,7 @@ func (s *DockerSuite) TestBuildEntrypoint(c *check.C) {
 
 // #6445 ensure ONBUILD triggers aren't committed to grandchildren
 func (s *DockerSuite) TestBuildOnBuildLimitedInheritence(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	var (
 		out2, out3 string
 	)
@@ -2510,6 +2588,7 @@ func (s *DockerSuite) TestBuildOnBuildLimitedInheritence(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildWithCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildwithcache"
 	id1, err := buildImage(name,
 		`FROM scratch
@@ -2535,6 +2614,7 @@ func (s *DockerSuite) TestBuildWithCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildWithoutCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildwithoutcache"
 	name2 := "testbuildwithoutcache2"
 	id1, err := buildImage(name,
@@ -2562,6 +2642,7 @@ func (s *DockerSuite) TestBuildWithoutCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildConditionalCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildconditionalcache"
 
 	dockerfile := `
@@ -2602,6 +2683,7 @@ func (s *DockerSuite) TestBuildConditionalCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddLocalFileWithCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddlocalfilewithcache"
 	name2 := "testbuildaddlocalfilewithcache2"
 	dockerfile := `
@@ -2630,6 +2712,7 @@ func (s *DockerSuite) TestBuildAddLocalFileWithCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddMultipleLocalFileWithCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddmultiplelocalfilewithcache"
 	name2 := "testbuildaddmultiplelocalfilewithcache2"
 	dockerfile := `
@@ -2658,6 +2741,7 @@ func (s *DockerSuite) TestBuildAddMultipleLocalFileWithCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddLocalFileWithoutCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddlocalfilewithoutcache"
 	name2 := "testbuildaddlocalfilewithoutcache2"
 	dockerfile := `
@@ -2686,6 +2770,7 @@ func (s *DockerSuite) TestBuildAddLocalFileWithoutCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildCopyDirButNotFile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildcopydirbutnotfile"
 	name2 := "testbuildcopydirbutnotfile2"
 	dockerfile := `
@@ -2716,6 +2801,7 @@ func (s *DockerSuite) TestBuildCopyDirButNotFile(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddCurrentDirWithCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddcurrentdirwithcache"
 	name2 := name + "2"
 	name3 := name + "3"
@@ -2773,6 +2859,7 @@ func (s *DockerSuite) TestBuildAddCurrentDirWithCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddCurrentDirWithoutCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddcurrentdirwithoutcache"
 	name2 := "testbuildaddcurrentdirwithoutcache2"
 	dockerfile := `
@@ -2800,6 +2887,7 @@ func (s *DockerSuite) TestBuildAddCurrentDirWithoutCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddRemoteFileWithCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddremotefilewithcache"
 	server, err := fakeStorage(map[string]string{
 		"baz": "hello",
@@ -2831,6 +2919,7 @@ func (s *DockerSuite) TestBuildAddRemoteFileWithCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddRemoteFileWithoutCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddremotefilewithoutcache"
 	name2 := "testbuildaddremotefilewithoutcache2"
 	server, err := fakeStorage(map[string]string{
@@ -2863,6 +2952,7 @@ func (s *DockerSuite) TestBuildAddRemoteFileWithoutCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddRemoteFileMTime(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddremotefilemtime"
 	name2 := name + "2"
 	name3 := name + "3"
@@ -2924,6 +3014,7 @@ func (s *DockerSuite) TestBuildAddRemoteFileMTime(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddLocalAndRemoteFilesWithCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddlocalandremotefilewithcache"
 	server, err := fakeStorage(map[string]string{
 		"baz": "hello",
@@ -2958,6 +3049,7 @@ func (s *DockerSuite) TestBuildAddLocalAndRemoteFilesWithCache(c *check.C) {
 }
 
 func testContextTar(c *check.C, compression archive.Compression) {
+	testRequires(c, DaemonIsLinux)
 	ctx, err := fakeContext(
 		`FROM busybox
 ADD foo /foo
@@ -2992,6 +3084,7 @@ func (s *DockerSuite) TestBuildContextTarNoCompression(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildNoContext(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	buildCmd := exec.Command(dockerBinary, "build", "-t", "nocontext", "-")
 	buildCmd.Stdin = strings.NewReader("FROM busybox\nCMD echo ok\n")
 
@@ -3006,6 +3099,7 @@ func (s *DockerSuite) TestBuildNoContext(c *check.C) {
 
 // TODO: TestCaching
 func (s *DockerSuite) TestBuildAddLocalAndRemoteFilesWithoutCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddlocalandremotefilewithoutcache"
 	name2 := "testbuildaddlocalandremotefilewithoutcache2"
 	server, err := fakeStorage(map[string]string{
@@ -3041,6 +3135,7 @@ func (s *DockerSuite) TestBuildAddLocalAndRemoteFilesWithoutCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildWithVolumeOwnership(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildimg"
 
 	_, err := buildImage(name,
@@ -3068,6 +3163,7 @@ func (s *DockerSuite) TestBuildWithVolumeOwnership(c *check.C) {
 // testing #1405 - config.Cmd does not get cleaned up if
 // utilizing cache
 func (s *DockerSuite) TestBuildEntrypointRunCleanup(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildcmdcleanup"
 	if _, err := buildImage(name,
 		`FROM busybox
@@ -3101,6 +3197,7 @@ func (s *DockerSuite) TestBuildEntrypointRunCleanup(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildForbiddenContextPath(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildforbidpath"
 	ctx, err := fakeContext(`FROM scratch
         ADD ../../ test/
@@ -3122,6 +3219,7 @@ func (s *DockerSuite) TestBuildForbiddenContextPath(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddFileNotFound(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddnotfound"
 	ctx, err := fakeContext(`FROM scratch
         ADD foo /usr/local/bar`,
@@ -3140,6 +3238,7 @@ func (s *DockerSuite) TestBuildAddFileNotFound(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildInheritance(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildinheritance"
 
 	_, err := buildImage(name,
@@ -3179,6 +3278,7 @@ func (s *DockerSuite) TestBuildInheritance(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildFails(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildfails"
 	_, err := buildImage(name,
 		`FROM busybox
@@ -3206,6 +3306,7 @@ func (s *DockerSuite) TestBuildFailsDockerfileEmpty(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildOnBuild(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuild"
 	_, err := buildImage(name,
 		`FROM busybox
@@ -3224,6 +3325,7 @@ func (s *DockerSuite) TestBuildOnBuild(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildOnBuildForbiddenChained(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuildforbiddenchained"
 	_, err := buildImage(name,
 		`FROM busybox
@@ -3239,6 +3341,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenChained(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildOnBuildForbiddenFrom(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuildforbiddenfrom"
 	_, err := buildImage(name,
 		`FROM busybox
@@ -3254,6 +3357,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenFrom(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildOnBuildForbiddenMaintainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuildforbiddenmaintainer"
 	_, err := buildImage(name,
 		`FROM busybox
@@ -3270,6 +3374,7 @@ func (s *DockerSuite) TestBuildOnBuildForbiddenMaintainer(c *check.C) {
 
 // gh #2446
 func (s *DockerSuite) TestBuildAddToSymlinkDest(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddtosymlinkdest"
 	ctx, err := fakeContext(`FROM busybox
         RUN mkdir /foo
@@ -3290,6 +3395,7 @@ func (s *DockerSuite) TestBuildAddToSymlinkDest(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEscapeWhitespace(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildescaping"
 
 	_, err := buildImage(name, `
@@ -3315,6 +3421,7 @@ docker.com>"
 }
 
 func (s *DockerSuite) TestBuildVerifyIntString(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Verify that strings that look like ints are still passed as strings
 	name := "testbuildstringing"
 
@@ -3336,6 +3443,7 @@ func (s *DockerSuite) TestBuildVerifyIntString(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildDockerignore(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuilddockerignore"
 	dockerfile := `
         FROM busybox
@@ -3374,6 +3482,7 @@ dir`,
 }
 
 func (s *DockerSuite) TestBuildDockerignoreCleanPaths(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuilddockerignorecleanpaths"
 	dockerfile := `
         FROM busybox
@@ -3395,6 +3504,7 @@ func (s *DockerSuite) TestBuildDockerignoreCleanPaths(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildDockerignoreExceptions(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuilddockerignoreexceptions"
 	dockerfile := `
         FROM busybox
@@ -3443,6 +3553,7 @@ dir
 }
 
 func (s *DockerSuite) TestBuildDockerignoringDockerfile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuilddockerignoredockerfile"
 	dockerfile := `
         FROM busybox
@@ -3471,6 +3582,7 @@ func (s *DockerSuite) TestBuildDockerignoringDockerfile(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildDockerignoringRenamedDockerfile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuilddockerignoredockerfile"
 	dockerfile := `
         FROM busybox
@@ -3501,6 +3613,7 @@ func (s *DockerSuite) TestBuildDockerignoringRenamedDockerfile(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildDockerignoringDockerignore(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuilddockerignoredockerignore"
 	dockerfile := `
         FROM busybox
@@ -3521,6 +3634,7 @@ func (s *DockerSuite) TestBuildDockerignoringDockerignore(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildDockerignoreTouchDockerfile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	var id1 string
 	var id2 string
 
@@ -3573,6 +3687,7 @@ func (s *DockerSuite) TestBuildDockerignoreTouchDockerfile(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildDockerignoringWholeDir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuilddockerignorewholedir"
 	dockerfile := `
         FROM busybox
@@ -3608,6 +3723,7 @@ func (s *DockerSuite) TestBuildDockerignoringWholeDir(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildDockerignoringBadExclusion(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuilddockerignorewholedir"
 	dockerfile := `
         FROM busybox
@@ -3632,6 +3748,7 @@ func (s *DockerSuite) TestBuildDockerignoringBadExclusion(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildLineBreak(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildlinebreak"
 	_, err := buildImage(name,
 		`FROM  busybox
@@ -3647,6 +3764,7 @@ RUN    [ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]`,
 }
 
 func (s *DockerSuite) TestBuildEOLInLine(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildeolinline"
 	_, err := buildImage(name,
 		`FROM   busybox
@@ -3662,6 +3780,7 @@ RUN    [ "$(ls -d /var/run/sshd)" = "/var/run/sshd" ]`,
 }
 
 func (s *DockerSuite) TestBuildCommentsShebangs(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildcomments"
 	_, err := buildImage(name,
 		`FROM busybox
@@ -3680,6 +3799,7 @@ RUN [ "$(/hello.sh)" = "hello world" ]`,
 }
 
 func (s *DockerSuite) TestBuildUsersAndGroups(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildusers"
 	_, err := buildImage(name,
 		`FROM busybox
@@ -3742,6 +3862,7 @@ RUN [ "$(id -u):$(id -g)/$(id -un):$(id -gn)/$(id -G):$(id -Gn)" = '1042:1043/10
 }
 
 func (s *DockerSuite) TestBuildEnvUsage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvusage"
 	dockerfile := `FROM busybox
 ENV    HOME /root
@@ -3777,6 +3898,7 @@ RUN    [ "$ghi" = "def" ]
 }
 
 func (s *DockerSuite) TestBuildEnvUsage2(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildenvusage2"
 	dockerfile := `FROM busybox
 ENV    abc=def
@@ -3879,6 +4001,7 @@ RUN    [ "$eee1,$eee2,$eee3,$eee4" = 'foo,foo,foo,foo' ]
 }
 
 func (s *DockerSuite) TestBuildAddScript(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddscript"
 	dockerfile := `
 FROM busybox
@@ -3901,6 +4024,7 @@ RUN [ "$(cat /testfile)" = 'test!' ]`
 }
 
 func (s *DockerSuite) TestBuildAddTar(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddtar"
 
 	ctx := func() *FakeContext {
@@ -3955,6 +4079,8 @@ RUN cat /existing-directory-trailing-slash/test/foo | grep Hi`
 }
 
 func (s *DockerSuite) TestBuildAddTarXz(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddtarxz"
 
 	ctx := func() *FakeContext {
@@ -4006,6 +4132,7 @@ func (s *DockerSuite) TestBuildAddTarXz(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildAddTarXzGz(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildaddtarxzgz"
 
 	ctx := func() *FakeContext {
@@ -4064,6 +4191,7 @@ func (s *DockerSuite) TestBuildAddTarXzGz(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildFromGIT(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildfromgit"
 	git, err := newFakeGit("repo", map[string]string{
 		"Dockerfile": `FROM busybox
@@ -4091,6 +4219,7 @@ func (s *DockerSuite) TestBuildFromGIT(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildFromGITWithContext(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildfromgit"
 	git, err := newFakeGit("repo", map[string]string{
 		"docker/Dockerfile": `FROM busybox
@@ -4119,6 +4248,7 @@ func (s *DockerSuite) TestBuildFromGITWithContext(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildFromGITwithF(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildfromgitwithf"
 	git, err := newFakeGit("repo", map[string]string{
 		"myApp/myDockerfile": `FROM busybox
@@ -4140,6 +4270,7 @@ func (s *DockerSuite) TestBuildFromGITwithF(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildFromRemoteTarball(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildfromremotetarball"
 
 	buffer := new(bytes.Buffer)
@@ -4180,6 +4311,7 @@ func (s *DockerSuite) TestBuildFromRemoteTarball(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildCleanupCmdOnEntrypoint(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildcmdcleanuponentrypoint"
 	if _, err := buildImage(name,
 		`FROM scratch
@@ -4212,6 +4344,7 @@ func (s *DockerSuite) TestBuildCleanupCmdOnEntrypoint(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildClearCmd(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildclearcmd"
 	_, err := buildImage(name,
 		`From scratch
@@ -4231,6 +4364,7 @@ func (s *DockerSuite) TestBuildClearCmd(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEmptyCmd(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildemptycmd"
 	if _, err := buildImage(name, "FROM scratch\nMAINTAINER quux\n", true); err != nil {
 		c.Fatal(err)
@@ -4245,6 +4379,7 @@ func (s *DockerSuite) TestBuildEmptyCmd(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildOnBuildOutput(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildonbuildparent"
 	if _, err := buildImage(name, "FROM busybox\nONBUILD RUN echo foo\n", true); err != nil {
 		c.Fatal(err)
@@ -4261,6 +4396,7 @@ func (s *DockerSuite) TestBuildOnBuildOutput(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildInvalidTag(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "abcd:" + stringutils.GenerateRandomAlphaOnlyString(200)
 	_, out, err := buildImageWithOut(name, "FROM scratch\nMAINTAINER quux\n", true)
 	// if the error doesnt check for illegal tag name, or the image is built
@@ -4271,6 +4407,7 @@ func (s *DockerSuite) TestBuildInvalidTag(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildCmdShDashC(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildcmdshc"
 	if _, err := buildImage(name, "FROM busybox\nCMD echo cmd\n", true); err != nil {
 		c.Fatal(err)
@@ -4290,6 +4427,7 @@ func (s *DockerSuite) TestBuildCmdShDashC(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildCmdSpaces(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Test to make sure that when we strcat arrays we take into account
 	// the arg separator to make sure ["echo","hi"] and ["echo hi"] don't
 	// look the same
@@ -4326,6 +4464,7 @@ func (s *DockerSuite) TestBuildCmdSpaces(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildCmdJSONNoShDashC(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildcmdjson"
 	if _, err := buildImage(name, "FROM busybox\nCMD [\"echo\", \"cmd\"]", true); err != nil {
 		c.Fatal(err)
@@ -4345,6 +4484,7 @@ func (s *DockerSuite) TestBuildCmdJSONNoShDashC(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildErrorInvalidInstruction(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildignoreinvalidinstruction"
 
 	out, _, err := buildImageWithOut(name, "FROM busybox\nfoo bar", true)
@@ -4355,6 +4495,7 @@ func (s *DockerSuite) TestBuildErrorInvalidInstruction(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEntrypointInheritance(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 
 	if _, err := buildImage("parent", `
     FROM busybox
@@ -4381,6 +4522,7 @@ func (s *DockerSuite) TestBuildEntrypointInheritance(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEntrypointInheritanceInspect(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	var (
 		name     = "testbuildepinherit"
 		name2    = "testbuildepinherit2"
@@ -4415,6 +4557,7 @@ func (s *DockerSuite) TestBuildEntrypointInheritanceInspect(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildRunShEntrypoint(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildentrypoint"
 	_, err := buildImage(name,
 		`FROM busybox
@@ -4428,6 +4571,7 @@ func (s *DockerSuite) TestBuildRunShEntrypoint(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildExoticShellInterpolation(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildexoticshellinterpolation"
 
 	_, err := buildImage(name, `
@@ -4456,6 +4600,7 @@ func (s *DockerSuite) TestBuildExoticShellInterpolation(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildVerifySingleQuoteFails(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// This testcase is supposed to generate an error because the
 	// JSON array we're passing in on the CMD uses single quotes instead
 	// of double quotes (per the JSON spec). This means we interpret it
@@ -4477,6 +4622,7 @@ func (s *DockerSuite) TestBuildVerifySingleQuoteFails(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildVerboseOut(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildverboseout"
 
 	_, out, err := buildImageWithOut(name,
@@ -4494,6 +4640,7 @@ RUN echo 123`,
 }
 
 func (s *DockerSuite) TestBuildWithTabs(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildwithtabs"
 	_, err := buildImage(name,
 		"FROM busybox\nRUN echo\tone\t\ttwo", true)
@@ -4512,6 +4659,7 @@ func (s *DockerSuite) TestBuildWithTabs(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildLabels(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildlabel"
 	expected := `{"License":"GPL","Vendor":"Acme"}`
 	_, err := buildImage(name,
@@ -4532,6 +4680,7 @@ func (s *DockerSuite) TestBuildLabels(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildLabelsCache(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildlabelcache"
 
 	id1, err := buildImage(name,
@@ -4580,6 +4729,7 @@ func (s *DockerSuite) TestBuildLabelsCache(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildStderr(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// This test just makes sure that no non-error output goes
 	// to stderr
 	name := "testbuildstderr"
@@ -4606,6 +4756,7 @@ func (s *DockerSuite) TestBuildStderr(c *check.C) {
 
 func (s *DockerSuite) TestBuildChownSingleFile(c *check.C) {
 	testRequires(c, UnixCli) // test uses chown: not available on windows
+	testRequires(c, DaemonIsLinux)
 
 	name := "testbuildchownsinglefile"
 
@@ -4633,6 +4784,7 @@ RUN [ $(ls -l /test | awk '{print $3":"$4}') = 'root:root' ]
 }
 
 func (s *DockerSuite) TestBuildSymlinkBreakout(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildsymlinkbreakout"
 	tmpdir, err := ioutil.TempDir("", name)
 	if err != nil {
@@ -4686,6 +4838,7 @@ func (s *DockerSuite) TestBuildSymlinkBreakout(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildXZHost(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildxzhost"
 
 	ctx, err := fakeContext(`
@@ -4713,6 +4866,7 @@ RUN [ ! -e /injected ]`,
 }
 
 func (s *DockerSuite) TestBuildVolumesRetainContents(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	var (
 		name     = "testbuildvolumescontent"
 		expected = "some text"
@@ -4742,6 +4896,7 @@ CMD cat /foo/file`,
 }
 
 func (s *DockerSuite) TestBuildRenamedDockerfile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 
 	ctx, err := fakeContext(`FROM busybox
 	RUN echo from Dockerfile`,
@@ -4847,6 +5002,7 @@ func (s *DockerSuite) TestBuildRenamedDockerfile(c *check.C) {
 
 func (s *DockerSuite) TestBuildFromMixedcaseDockerfile(c *check.C) {
 	testRequires(c, UnixCli) // Dockerfile overwrites dockerfile on windows
+	testRequires(c, DaemonIsLinux)
 
 	ctx, err := fakeContext(`FROM busybox
 	RUN echo from dockerfile`,
@@ -4871,6 +5027,7 @@ func (s *DockerSuite) TestBuildFromMixedcaseDockerfile(c *check.C) {
 
 func (s *DockerSuite) TestBuildWithTwoDockerfiles(c *check.C) {
 	testRequires(c, UnixCli) // Dockerfile overwrites dockerfile on windows
+	testRequires(c, DaemonIsLinux)
 
 	ctx, err := fakeContext(`FROM busybox
 RUN echo from Dockerfile`,
@@ -4894,6 +5051,7 @@ RUN echo from Dockerfile`,
 }
 
 func (s *DockerSuite) TestBuildFromURLWithF(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 
 	server, err := fakeStorage(map[string]string{"baz": `FROM busybox
 RUN echo from baz
@@ -4928,7 +5086,7 @@ RUN echo from Dockerfile`,
 }
 
 func (s *DockerSuite) TestBuildFromStdinWithF(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	ctx, err := fakeContext(`FROM busybox
 RUN echo from Dockerfile`,
 		map[string]string{})
@@ -4959,6 +5117,7 @@ RUN find /tmp/`)
 }
 
 func (s *DockerSuite) TestBuildFromOfficialNames(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildfromofficial"
 	fromNames := []string{
 		"busybox",
@@ -4980,6 +5139,7 @@ func (s *DockerSuite) TestBuildFromOfficialNames(c *check.C) {
 
 func (s *DockerSuite) TestBuildDockerfileOutsideContext(c *check.C) {
 	testRequires(c, UnixCli) // uses os.Symlink: not implemented in windows at the time of writing (go-1.4.2)
+	testRequires(c, DaemonIsLinux)
 
 	name := "testbuilddockerfileoutsidecontext"
 	tmpdir, err := ioutil.TempDir("", name)
@@ -5038,6 +5198,7 @@ func (s *DockerSuite) TestBuildDockerfileOutsideContext(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildSpaces(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Test to make sure that leading/trailing spaces on a command
 	// doesn't change the error msg we get
 	var (
@@ -5108,6 +5269,7 @@ func (s *DockerSuite) TestBuildSpaces(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildSpacesWithQuotes(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Test to make sure that spaces in quotes aren't lost
 	name := "testspacesquotes"
 
@@ -5129,6 +5291,7 @@ RUN echo "  \
 
 // #4393
 func (s *DockerSuite) TestBuildVolumeFileExistsinContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	buildCmd := exec.Command(dockerBinary, "build", "-t", "docker-test-errcreatevolumewithfile", "-")
 	buildCmd.Stdin = strings.NewReader(`
 	FROM busybox
@@ -5144,6 +5307,7 @@ func (s *DockerSuite) TestBuildVolumeFileExistsinContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildMissingArgs(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Test to make sure that all Dockerfile commands (except the ones listed
 	// in skipCmds) will generate an error if no args are provided.
 	// Note: INSERT is deprecated so we exclude it because of that.
@@ -5185,6 +5349,7 @@ func (s *DockerSuite) TestBuildMissingArgs(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildEmptyScratch(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	_, out, err := buildImageWithOut("sc", "FROM scratch", true)
 	if err == nil {
 		c.Fatalf("Build was supposed to fail")
@@ -5195,6 +5360,8 @@ func (s *DockerSuite) TestBuildEmptyScratch(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildDotDotFile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
 	ctx, err := fakeContext("FROM busybox\n",
 		map[string]string{
 			"..gitme": "",
@@ -5210,7 +5377,7 @@ func (s *DockerSuite) TestBuildDotDotFile(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildNotVerbose(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	ctx, err := fakeContext("FROM busybox\nENV abc=hi\nRUN echo $abc there", map[string]string{})
 	if err != nil {
 		c.Fatal(err)
@@ -5238,6 +5405,7 @@ func (s *DockerSuite) TestBuildNotVerbose(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildRUNoneJSON(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildrunonejson"
 
 	ctx, err := fakeContext(`FROM hello-world:frozen
@@ -5259,6 +5427,7 @@ RUN [ "/hello" ]`, map[string]string{})
 }
 
 func (s *DockerSuite) TestBuildEmptyStringVolume(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildemptystringvolume"
 
 	_, err := buildImage(name, `
@@ -5275,6 +5444,7 @@ func (s *DockerSuite) TestBuildEmptyStringVolume(c *check.C) {
 func (s *DockerSuite) TestBuildContainerWithCgroupParent(c *check.C) {
 	testRequires(c, NativeExecDriver)
 	testRequires(c, SameHostDaemon)
+	testRequires(c, DaemonIsLinux)
 
 	cgroupParent := "test"
 	data, err := ioutil.ReadFile("/proc/self/cgroup")
@@ -5304,6 +5474,7 @@ RUN cat /proc/self/cgroup
 }
 
 func (s *DockerSuite) TestBuildNoDupOutput(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Check to make sure our build output prints the Dockerfile cmd
 	// property - there was a bug that caused it to be duplicated on the
 	// Step X  line
@@ -5324,6 +5495,7 @@ func (s *DockerSuite) TestBuildNoDupOutput(c *check.C) {
 
 // GH15826
 func (s *DockerSuite) TestBuildStartsFromOne(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Explicit check to ensure that build starts from step 1 rather than 0
 	name := "testbuildstartsfromone"
 
@@ -5340,6 +5512,7 @@ func (s *DockerSuite) TestBuildStartsFromOne(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildBadCmdFlag(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildbadcmdflag"
 
 	_, out, err := buildImageWithOut(name, `
@@ -5356,6 +5529,7 @@ func (s *DockerSuite) TestBuildBadCmdFlag(c *check.C) {
 }
 
 func (s *DockerSuite) TestBuildRUNErrMsg(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Test to make sure the bad command is quoted with just "s and
 	// not as a Go []string
 	name := "testbuildbadrunerrmsg"
@@ -5425,6 +5599,7 @@ func (s *DockerTrustSuite) TestTrustedBuildUntrustedTag(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestBuildContextDirIsSymlink(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	tempDir, err := ioutil.TempDir("", "test-build-dir-is-symlink-")
 	if err != nil {
 		c.Fatal(err)
@@ -5464,6 +5639,7 @@ func (s *DockerTrustSuite) TestBuildContextDirIsSymlink(c *check.C) {
 
 // Issue #15634: COPY fails when path starts with "null"
 func (s *DockerSuite) TestBuildNullStringInAddCopyVolume(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildnullstringinaddcopyvolume"
 
 	ctx, err := fakeContext(`

--- a/integration-cli/docker_cli_by_digest_test.go
+++ b/integration-cli/docker_cli_by_digest_test.go
@@ -60,6 +60,7 @@ func setupImageWithTag(c *check.C, tag string) (digest.Digest, error) {
 }
 
 func (s *DockerRegistrySuite) TestPullByTagDisplaysDigest(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	pushDigest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
@@ -82,6 +83,7 @@ func (s *DockerRegistrySuite) TestPullByTagDisplaysDigest(c *check.C) {
 }
 
 func (s *DockerRegistrySuite) TestPullByDigest(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	pushDigest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
@@ -105,6 +107,7 @@ func (s *DockerRegistrySuite) TestPullByDigest(c *check.C) {
 }
 
 func (s *DockerRegistrySuite) TestPullByDigestNoFallback(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// pull from the registry using the <name>@<digest> reference
 	imageReference := fmt.Sprintf("%s@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", repoName)
 	out, _, err := dockerCmdWithError("pull", imageReference)
@@ -446,6 +449,7 @@ func (s *DockerRegistrySuite) TestDeleteImageByIDOnlyPulledByDigest(c *check.C) 
 // TestPullFailsWithAlteredManifest tests that a `docker pull` fails when
 // we have modified a manifest blob and its digest cannot be verified.
 func (s *DockerRegistrySuite) TestPullFailsWithAlteredManifest(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	manifestDigest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)
@@ -495,6 +499,7 @@ func (s *DockerRegistrySuite) TestPullFailsWithAlteredManifest(c *check.C) {
 // TestPullFailsWithAlteredLayer tests that a `docker pull` fails when
 // we have modified a layer blob and its digest cannot be verified.
 func (s *DockerRegistrySuite) TestPullFailsWithAlteredLayer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	manifestDigest, err := setupImage(c)
 	if err != nil {
 		c.Fatalf("error setting up image: %v", err)

--- a/integration-cli/docker_cli_commit_test.go
+++ b/integration-cli/docker_cli_commit_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func (s *DockerSuite) TestCommitAfterContainerIsDone(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -21,6 +22,7 @@ func (s *DockerSuite) TestCommitAfterContainerIsDone(c *check.C) {
 }
 
 func (s *DockerSuite) TestCommitWithoutPause(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-i", "-a", "stdin", "busybox", "echo", "foo")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -36,6 +38,7 @@ func (s *DockerSuite) TestCommitWithoutPause(c *check.C) {
 
 //test commit a paused container should not unpause it after commit
 func (s *DockerSuite) TestCommitPausedContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	defer unpauseAllContainers()
 	out, _ := dockerCmd(c, "run", "-i", "-d", "busybox")
 
@@ -53,7 +56,7 @@ func (s *DockerSuite) TestCommitPausedContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestCommitNewFile(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "commiter", "busybox", "/bin/sh", "-c", "echo koye > /foo")
 
 	imageID, _ := dockerCmd(c, "commit", "commiter")
@@ -68,7 +71,7 @@ func (s *DockerSuite) TestCommitNewFile(c *check.C) {
 }
 
 func (s *DockerSuite) TestCommitHardlink(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	firstOutput, _ := dockerCmd(c, "run", "-t", "--name", "hardlinks", "busybox", "sh", "-c", "touch file1 && ln file1 file2 && ls -di file1 file2")
 
 	chunks := strings.Split(strings.TrimSpace(firstOutput), " ")
@@ -105,7 +108,7 @@ func (s *DockerSuite) TestCommitHardlink(c *check.C) {
 }
 
 func (s *DockerSuite) TestCommitTTY(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-t", "--name", "tty", "busybox", "/bin/ls")
 
 	imageID, _ := dockerCmd(c, "commit", "tty", "ttytest")
@@ -116,7 +119,7 @@ func (s *DockerSuite) TestCommitTTY(c *check.C) {
 }
 
 func (s *DockerSuite) TestCommitWithHostBindMount(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "bind-commit", "-v", "/dev/null:/winning", "busybox", "true")
 
 	imageID, _ := dockerCmd(c, "commit", "bind-commit", "bindtest")
@@ -127,7 +130,7 @@ func (s *DockerSuite) TestCommitWithHostBindMount(c *check.C) {
 }
 
 func (s *DockerSuite) TestCommitChange(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "test", "busybox", "true")
 
 	imageID, _ := dockerCmd(c, "commit",
@@ -169,6 +172,7 @@ func (s *DockerSuite) TestCommitChange(c *check.C) {
 
 // TODO: commit --run is deprecated, remove this once --run is removed
 func (s *DockerSuite) TestCommitMergeConfigRun(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "commit-test"
 	out, _ := dockerCmd(c, "run", "-d", "-e=FOO=bar", "busybox", "/bin/sh", "-c", "echo testing > /tmp/foo")
 	id := strings.TrimSpace(out)

--- a/integration-cli/docker_cli_cp_from_container_test.go
+++ b/integration-cli/docker_cli_cp_from_container_test.go
@@ -23,6 +23,7 @@ import (
 
 // Test for error when SRC does not exist.
 func (s *DockerSuite) TestCpFromErrSrcNotExists(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{})
 	defer deleteContainer(cID)
 
@@ -42,6 +43,7 @@ func (s *DockerSuite) TestCpFromErrSrcNotExists(c *check.C) {
 // Test for error when SRC ends in a trailing
 // path separator but it exists as a file.
 func (s *DockerSuite) TestCpFromErrSrcNotDir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
 	defer deleteContainer(cID)
 
@@ -61,6 +63,7 @@ func (s *DockerSuite) TestCpFromErrSrcNotDir(c *check.C) {
 // Test for error when SRC is a valid file or directory,
 // bu the DST parent directory does not exist.
 func (s *DockerSuite) TestCpFromErrDstParentNotExists(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
 	defer deleteContainer(cID)
 
@@ -97,6 +100,7 @@ func (s *DockerSuite) TestCpFromErrDstParentNotExists(c *check.C) {
 // Test for error when DST ends in a trailing
 // path separator but exists as a file.
 func (s *DockerSuite) TestCpFromErrDstNotDir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
 	defer deleteContainer(cID)
 
@@ -133,6 +137,7 @@ func (s *DockerSuite) TestCpFromErrDstNotDir(c *check.C) {
 // Check that copying from a container to a local symlink copies to the symlink
 // target and does not overwrite the local symlink itself.
 func (s *DockerSuite) TestCpFromSymlinkDestination(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
 	defer deleteContainer(cID)
 
@@ -258,6 +263,7 @@ func (s *DockerSuite) TestCpFromSymlinkDestination(c *check.C) {
 //    exist. This should create a file with the name DST and copy the
 //    contents of the source file into it.
 func (s *DockerSuite) TestCpFromCaseA(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
@@ -282,6 +288,7 @@ func (s *DockerSuite) TestCpFromCaseA(c *check.C) {
 //    exist. This should cause an error because the copy operation cannot
 //    create a directory when copying a single file.
 func (s *DockerSuite) TestCpFromCaseB(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
 	defer deleteContainer(cID)
 
@@ -304,6 +311,7 @@ func (s *DockerSuite) TestCpFromCaseB(c *check.C) {
 // C. SRC specifies a file and DST exists as a file. This should overwrite
 //    the file at DST with the contents of the source file.
 func (s *DockerSuite) TestCpFromCaseC(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
@@ -335,6 +343,7 @@ func (s *DockerSuite) TestCpFromCaseC(c *check.C) {
 //    a copy of the source file inside it using the basename from SRC. Ensure
 //    this works whether DST has a trailing path separator or not.
 func (s *DockerSuite) TestCpFromCaseD(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
 	defer deleteContainer(cID)
 
@@ -386,6 +395,7 @@ func (s *DockerSuite) TestCpFromCaseD(c *check.C) {
 //    directory. Ensure this works whether DST has a trailing path separator or
 //    not.
 func (s *DockerSuite) TestCpFromCaseE(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
 	defer deleteContainer(cID)
 
@@ -424,6 +434,7 @@ func (s *DockerSuite) TestCpFromCaseE(c *check.C) {
 // F. SRC specifies a directory and DST exists as a file. This should cause an
 //    error as it is not possible to overwrite a file with a directory.
 func (s *DockerSuite) TestCpFromCaseF(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
@@ -451,6 +462,7 @@ func (s *DockerSuite) TestCpFromCaseF(c *check.C) {
 //    the SRC directory and all its contents to the DST directory. Ensure this
 //    works whether DST has a trailing path separator or not.
 func (s *DockerSuite) TestCpFromCaseG(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
@@ -500,6 +512,7 @@ func (s *DockerSuite) TestCpFromCaseG(c *check.C) {
 //    directory (but not the directory itself) into the DST directory. Ensure
 //    this works whether DST has a trailing path separator or not.
 func (s *DockerSuite) TestCpFromCaseH(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
 	defer deleteContainer(cID)
 
@@ -539,6 +552,7 @@ func (s *DockerSuite) TestCpFromCaseH(c *check.C) {
 //    should cause an error as it is not possible to overwrite a file with a
 //    directory.
 func (s *DockerSuite) TestCpFromCaseI(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
@@ -567,6 +581,7 @@ func (s *DockerSuite) TestCpFromCaseI(c *check.C) {
 //    itself) into the DST directory. Ensure this works whether DST has a
 //    trailing path separator or not.
 func (s *DockerSuite) TestCpFromCaseJ(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})

--- a/integration-cli/docker_cli_cp_test.go
+++ b/integration-cli/docker_cli_cp_test.go
@@ -38,6 +38,7 @@ func (s *DockerSuite) TestCpLocalOnly(c *check.C) {
 // Test for #5656
 // Check that garbage paths don't escape the container's rootfs
 func (s *DockerSuite) TestCpGarbagePath(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
 	if exitCode != 0 {
 		c.Fatal("failed to create a container", out)
@@ -95,6 +96,7 @@ func (s *DockerSuite) TestCpGarbagePath(c *check.C) {
 
 // Check that relative paths are relative to the container's rootfs
 func (s *DockerSuite) TestCpRelativePath(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
 	if exitCode != 0 {
 		c.Fatal("failed to create a container", out)
@@ -160,6 +162,7 @@ func (s *DockerSuite) TestCpRelativePath(c *check.C) {
 
 // Check that absolute paths are relative to the container's rootfs
 func (s *DockerSuite) TestCpAbsolutePath(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath)
 	if exitCode != 0 {
 		c.Fatal("failed to create a container", out)
@@ -219,6 +222,7 @@ func (s *DockerSuite) TestCpAbsolutePath(c *check.C) {
 // Test for #5619
 // Check that absolute symlinks are still relative to the container's rootfs
 func (s *DockerSuite) TestCpAbsoluteSymlink(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpFullPath+" container_path")
 	if exitCode != 0 {
 		c.Fatal("failed to create a container", out)
@@ -271,6 +275,7 @@ func (s *DockerSuite) TestCpAbsoluteSymlink(c *check.C) {
 // Check that symlinks to a directory behave as expected when copying one from
 // a container.
 func (s *DockerSuite) TestCpFromSymlinkToDirectory(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpTestPathParent+" /dir_link")
 	if exitCode != 0 {
 		c.Fatal("failed to create a container", out)
@@ -330,6 +335,7 @@ func (s *DockerSuite) TestCpFromSymlinkToDirectory(c *check.C) {
 // Check that symlinks to a directory behave as expected when copying one to a
 // container.
 func (s *DockerSuite) TestCpToSymlinkToDirectory(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon) // Requires local volume mount bind.
 
 	testVol, err := ioutil.TempDir("", "test-cp-to-symlink-to-dir-")
@@ -434,6 +440,7 @@ func (s *DockerSuite) TestCpToSymlinkToDirectory(c *check.C) {
 // Test for #5619
 // Check that symlinks which are part of the resource path are still relative to the container's rootfs
 func (s *DockerSuite) TestCpSymlinkComponent(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "mkdir -p '"+cpTestPath+"' && echo -n '"+cpContainerContents+"' > "+cpFullPath+" && ln -s "+cpTestPath+" container_path")
 	if exitCode != 0 {
 		c.Fatal("failed to create a container", out)
@@ -492,6 +499,7 @@ func (s *DockerSuite) TestCpSymlinkComponent(c *check.C) {
 
 // Check that cp with unprivileged user doesn't return any error
 func (s *DockerSuite) TestCpUnprivilegedUser(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, UnixCli) // uses chmod/su: not available on windows
 
 	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "touch "+cpTestName)
@@ -527,6 +535,7 @@ func (s *DockerSuite) TestCpUnprivilegedUser(c *check.C) {
 }
 
 func (s *DockerSuite) TestCpSpecialFiles(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 
 	outDir, err := ioutil.TempDir("", "cp-test-special-files")
@@ -580,6 +589,7 @@ func (s *DockerSuite) TestCpSpecialFiles(c *check.C) {
 }
 
 func (s *DockerSuite) TestCpVolumePath(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 
 	tmpDir, err := ioutil.TempDir("", "cp-test-volumepath")
@@ -679,6 +689,7 @@ func (s *DockerSuite) TestCpVolumePath(c *check.C) {
 }
 
 func (s *DockerSuite) TestCpToDot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo lololol > /test")
 	if exitCode != 0 {
 		c.Fatal("failed to create a container", out)
@@ -712,6 +723,7 @@ func (s *DockerSuite) TestCpToDot(c *check.C) {
 }
 
 func (s *DockerSuite) TestCpToStdout(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, exitCode := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "echo lololol > /test")
 	if exitCode != 0 {
 		c.Fatalf("failed to create a container:%s\n", out)
@@ -765,6 +777,7 @@ func (s *DockerSuite) TestCpNameHasColon(c *check.C) {
 }
 
 func (s *DockerSuite) TestCopyAndRestart(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	expectedMsg := "hello"
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "echo", expectedMsg)
 	id := strings.TrimSpace(string(out))
@@ -793,6 +806,7 @@ func (s *DockerSuite) TestCopyAndRestart(c *check.C) {
 }
 
 func (s *DockerSuite) TestCopyCreatedContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "create", "--name", "test_cp", "-v", "/test", "busybox")
 
 	tmpDir, err := ioutil.TempDir("", "test")

--- a/integration-cli/docker_cli_cp_to_container_test.go
+++ b/integration-cli/docker_cli_cp_to_container_test.go
@@ -22,6 +22,7 @@ import (
 
 // Test for error when SRC does not exist.
 func (s *DockerSuite) TestCpToErrSrcNotExists(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{})
 	defer deleteContainer(cID)
 
@@ -44,6 +45,7 @@ func (s *DockerSuite) TestCpToErrSrcNotExists(c *check.C) {
 // Test for error when SRC ends in a trailing
 // path separator but it exists as a file.
 func (s *DockerSuite) TestCpToErrSrcNotDir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{})
 	defer deleteContainer(cID)
 
@@ -68,6 +70,7 @@ func (s *DockerSuite) TestCpToErrSrcNotDir(c *check.C) {
 // Test for error when SRC is a valid file or directory,
 // bu the DST parent directory does not exist.
 func (s *DockerSuite) TestCpToErrDstParentNotExists(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
 	defer deleteContainer(cID)
 
@@ -105,6 +108,7 @@ func (s *DockerSuite) TestCpToErrDstParentNotExists(c *check.C) {
 // file. Also test that we cannot overwirite an existing directory with a
 // non-directory and cannot overwrite an existing
 func (s *DockerSuite) TestCpToErrDstNotDir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{addContent: true})
 	defer deleteContainer(cID)
 
@@ -149,6 +153,7 @@ func (s *DockerSuite) TestCpToErrDstNotDir(c *check.C) {
 // Check that copying from a local path to a symlink in a container copies to
 // the symlink target and does not overwrite the container symlink itself.
 func (s *DockerSuite) TestCpToSymlinkDestination(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon) // Requires local volume mount bind.
 
 	testVol := getTestDir(c, "test-cp-to-symlink-destination-")
@@ -278,6 +283,7 @@ func (s *DockerSuite) TestCpToSymlinkDestination(c *check.C) {
 //    exist. This should create a file with the name DST and copy the
 //    contents of the source file into it.
 func (s *DockerSuite) TestCpToCaseA(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		workDir: "/root", command: makeCatFileCommand("itWorks.txt"),
 	})
@@ -304,6 +310,7 @@ func (s *DockerSuite) TestCpToCaseA(c *check.C) {
 //    exist. This should cause an error because the copy operation cannot
 //    create a directory when copying a single file.
 func (s *DockerSuite) TestCpToCaseB(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		command: makeCatFileCommand("testDir/file1"),
 	})
@@ -330,6 +337,7 @@ func (s *DockerSuite) TestCpToCaseB(c *check.C) {
 // C. SRC specifies a file and DST exists as a file. This should overwrite
 //    the file at DST with the contents of the source file.
 func (s *DockerSuite) TestCpToCaseC(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 		command: makeCatFileCommand("file2"),
@@ -363,6 +371,7 @@ func (s *DockerSuite) TestCpToCaseC(c *check.C) {
 //    a copy of the source file inside it using the basename from SRC. Ensure
 //    this works whether DST has a trailing path separator or not.
 func (s *DockerSuite) TestCpToCaseD(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true,
 		command:    makeCatFileCommand("/dir1/file1"),
@@ -422,6 +431,7 @@ func (s *DockerSuite) TestCpToCaseD(c *check.C) {
 //    directory. Ensure this works whether DST has a trailing path separator or
 //    not.
 func (s *DockerSuite) TestCpToCaseE(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		command: makeCatFileCommand("/testDir/file1-1"),
 	})
@@ -468,6 +478,7 @@ func (s *DockerSuite) TestCpToCaseE(c *check.C) {
 // F. SRC specifies a directory and DST exists as a file. This should cause an
 //    error as it is not possible to overwrite a file with a directory.
 func (s *DockerSuite) TestCpToCaseF(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
@@ -495,6 +506,7 @@ func (s *DockerSuite) TestCpToCaseF(c *check.C) {
 //    the SRC directory and all its contents to the DST directory. Ensure this
 //    works whether DST has a trailing path separator or not.
 func (s *DockerSuite) TestCpToCaseG(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 		command: makeCatFileCommand("dir2/dir1/file1-1"),
@@ -554,6 +566,7 @@ func (s *DockerSuite) TestCpToCaseG(c *check.C) {
 //    directory (but not the directory itself) into the DST directory. Ensure
 //    this works whether DST has a trailing path separator or not.
 func (s *DockerSuite) TestCpToCaseH(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		command: makeCatFileCommand("/testDir/file1-1"),
 	})
@@ -600,6 +613,7 @@ func (s *DockerSuite) TestCpToCaseH(c *check.C) {
 //    should cause an error as it is not possible to overwrite a file with a
 //    directory.
 func (s *DockerSuite) TestCpToCaseI(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 	})
@@ -628,6 +642,7 @@ func (s *DockerSuite) TestCpToCaseI(c *check.C) {
 //    itself) into the DST directory. Ensure this works whether DST has a
 //    trailing path separator or not.
 func (s *DockerSuite) TestCpToCaseJ(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID := makeTestContainer(c, testContainerOptions{
 		addContent: true, workDir: "/root",
 		command: makeCatFileCommand("/dir2/file1-1"),
@@ -684,6 +699,7 @@ func (s *DockerSuite) TestCpToCaseJ(c *check.C) {
 // The `docker cp` command should also ensure that you cannot
 // write to a container rootfs that is marked as read-only.
 func (s *DockerSuite) TestCpToErrReadOnlyRootfs(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	tmpDir := getTestDir(c, "test-cp-to-err-read-only-rootfs")
 	defer os.RemoveAll(tmpDir)
 
@@ -716,6 +732,7 @@ func (s *DockerSuite) TestCpToErrReadOnlyRootfs(c *check.C) {
 // The `docker cp` command should also ensure that you
 // cannot write to a volume that is mounted as read-only.
 func (s *DockerSuite) TestCpToErrReadOnlyVolume(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	tmpDir := getTestDir(c, "test-cp-to-err-read-only-volume")
 	defer os.RemoveAll(tmpDir)
 

--- a/integration-cli/docker_cli_create_test.go
+++ b/integration-cli/docker_cli_create_test.go
@@ -18,6 +18,7 @@ import (
 
 // Make sure we can create a simple container with some args
 func (s *DockerSuite) TestCreateArgs(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "create", "busybox", "command", "arg1", "arg2", "arg with space")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -59,7 +60,7 @@ func (s *DockerSuite) TestCreateArgs(c *check.C) {
 
 // Make sure we can set hostconfig options too
 func (s *DockerSuite) TestCreateHostConfig(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "create", "-P", "busybox", "echo")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -90,7 +91,7 @@ func (s *DockerSuite) TestCreateHostConfig(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateWithPortRange(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "create", "-p", "3300-3303:3300-3303/tcp", "busybox", "echo")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -129,7 +130,7 @@ func (s *DockerSuite) TestCreateWithPortRange(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateWithiLargePortRange(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "create", "-p", "1-65535:1-65535/tcp", "busybox", "echo")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -169,6 +170,7 @@ func (s *DockerSuite) TestCreateWithiLargePortRange(c *check.C) {
 
 // "test123" should be printed by docker create + start
 func (s *DockerSuite) TestCreateEchoStdout(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "create", "busybox", "echo", "test123")
 
@@ -183,6 +185,7 @@ func (s *DockerSuite) TestCreateEchoStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateVolumesCreated(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 
 	name := "test_create_volume"
@@ -203,6 +206,7 @@ func (s *DockerSuite) TestCreateVolumesCreated(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateLabels(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test_create_labels"
 	expected := map[string]string{"k1": "v1", "k2": "v2"}
 	dockerCmd(c, "create", "--name", name, "-l", "k1=v1", "--label", "k2=v2", "busybox")
@@ -219,6 +223,7 @@ func (s *DockerSuite) TestCreateLabels(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	imageName := "testcreatebuildlabel"
 	_, err := buildImage(imageName,
 		`FROM busybox
@@ -244,6 +249,7 @@ func (s *DockerSuite) TestCreateLabelFromImage(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateHostnameWithNumber(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-h", "web.0", "busybox", "hostname")
 	if strings.TrimSpace(out) != "web.0" {
 		c.Fatalf("hostname not set, expected `web.0`, got: %s", out)
@@ -251,6 +257,7 @@ func (s *DockerSuite) TestCreateHostnameWithNumber(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateRM(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Test to make sure we can 'rm' a new container that is in
 	// "Created" state, and has ever been run. Test "rm -f" too.
 
@@ -268,6 +275,7 @@ func (s *DockerSuite) TestCreateRM(c *check.C) {
 }
 
 func (s *DockerSuite) TestCreateModeIpcContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 
 	out, _ := dockerCmd(c, "create", "busybox")

--- a/integration-cli/docker_cli_diff_test.go
+++ b/integration-cli/docker_cli_diff_test.go
@@ -8,6 +8,7 @@ import (
 
 // ensure that an added file shows up in docker diff
 func (s *DockerSuite) TestDiffFilenameShownInOutput(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	containerCmd := `echo foo > /root/bar`
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", containerCmd)
 
@@ -28,6 +29,7 @@ func (s *DockerSuite) TestDiffFilenameShownInOutput(c *check.C) {
 
 // test to ensure GH #3840 doesn't occur any more
 func (s *DockerSuite) TestDiffEnsureDockerinitFilesAreIgnored(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// this is a list of files which shouldn't show up in `docker diff`
 	dockerinitFiles := []string{"/etc/resolv.conf", "/etc/hostname", "/etc/hosts", "/.dockerinit", "/.dockerenv"}
 	containerCount := 5
@@ -49,6 +51,7 @@ func (s *DockerSuite) TestDiffEnsureDockerinitFilesAreIgnored(c *check.C) {
 }
 
 func (s *DockerSuite) TestDiffEnsureOnlyKmsgAndPtmx(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sleep", "0")
 
 	cleanCID := strings.TrimSpace(out)

--- a/integration-cli/docker_cli_events_test.go
+++ b/integration-cli/docker_cli_events_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func (s *DockerSuite) TestEventsTimestampFormats(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	image := "busybox"
 
 	// Start stopwatch, generate an event
@@ -48,6 +49,7 @@ func (s *DockerSuite) TestEventsTimestampFormats(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsUntag(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	image := "busybox"
 	dockerCmd(c, "tag", image, "utest:tag1")
 	dockerCmd(c, "tag", image, "utest:tag2")
@@ -97,7 +99,7 @@ func (s *DockerSuite) TestEventsContainerFailStartDie(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsLimit(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	var waitGroup sync.WaitGroup
 	errChan := make(chan error, 17)
 
@@ -128,6 +130,7 @@ func (s *DockerSuite) TestEventsLimit(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsContainerEvents(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--rm", "busybox", "true")
 	out, _ := dockerCmd(c, "events", "--since=0", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	events := strings.Split(out, "\n")
@@ -159,6 +162,7 @@ func (s *DockerSuite) TestEventsContainerEvents(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsContainerEventsSinceUnixEpoch(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--rm", "busybox", "true")
 	timeBeginning := time.Unix(0, 0).Format(time.RFC3339Nano)
 	timeBeginning = strings.Replace(timeBeginning, "Z", ".000000000Z", -1)
@@ -193,6 +197,7 @@ func (s *DockerSuite) TestEventsContainerEventsSinceUnixEpoch(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsImageUntagDelete(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testimageevents"
 	_, err := buildImage(name,
 		`FROM scratch
@@ -222,6 +227,7 @@ func (s *DockerSuite) TestEventsImageUntagDelete(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsImageTag(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	time.Sleep(1 * time.Second) // because API has seconds granularity
 	since := daemonTime(c).Unix()
 	image := "testimageevents:tag"
@@ -245,6 +251,7 @@ func (s *DockerSuite) TestEventsImageTag(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsImagePull(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	since := daemonTime(c).Unix()
 	testRequires(c, Network)
 
@@ -264,6 +271,7 @@ func (s *DockerSuite) TestEventsImagePull(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsImageImport(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	since := daemonTime(c).Unix()
 
 	id := make(chan string)
@@ -312,6 +320,7 @@ func (s *DockerSuite) TestEventsImageImport(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsFilters(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	parseEvents := func(out, match string) {
 		events := strings.Split(out, "\n")
 		events = events[:len(events)-1]
@@ -342,6 +351,7 @@ func (s *DockerSuite) TestEventsFilters(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsFilterImageName(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	since := daemonTime(c).Unix()
 
 	out, _ := dockerCmd(c, "run", "--name", "container_1", "-d", "busybox:latest", "true")
@@ -374,6 +384,7 @@ func (s *DockerSuite) TestEventsFilterImageName(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsFilterContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	since := fmt.Sprintf("%d", daemonTime(c).Unix())
 	nameID := make(map[string]string)
 
@@ -425,6 +436,7 @@ func (s *DockerSuite) TestEventsFilterContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsStreaming(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	start := daemonTime(c).Unix()
 
 	id := make(chan string)
@@ -502,6 +514,7 @@ func (s *DockerSuite) TestEventsStreaming(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsCommit(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	since := daemonTime(c).Unix()
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
@@ -518,6 +531,7 @@ func (s *DockerSuite) TestEventsCommit(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsCopy(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	since := daemonTime(c).Unix()
 
 	// Build a test image.
@@ -557,6 +571,7 @@ func (s *DockerSuite) TestEventsCopy(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsResize(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	since := daemonTime(c).Unix()
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
@@ -577,6 +592,7 @@ func (s *DockerSuite) TestEventsResize(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsAttach(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	since := daemonTime(c).Unix()
 
 	out, _ := dockerCmd(c, "run", "-di", "busybox", "/bin/cat")
@@ -613,6 +629,7 @@ func (s *DockerSuite) TestEventsAttach(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsRename(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	since := daemonTime(c).Unix()
 
 	dockerCmd(c, "run", "--name", "oldName", "busybox", "true")
@@ -625,6 +642,7 @@ func (s *DockerSuite) TestEventsRename(c *check.C) {
 }
 
 func (s *DockerSuite) TestEventsTop(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	since := daemonTime(c).Unix()
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
@@ -642,6 +660,7 @@ func (s *DockerSuite) TestEventsTop(c *check.C) {
 
 // #13753
 func (s *DockerSuite) TestEventsDefaultEmpty(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "busybox")
 	out, _ := dockerCmd(c, "events", fmt.Sprintf("--until=%d", daemonTime(c).Unix()))
 	c.Assert(strings.TrimSpace(out), check.Equals, "")
@@ -649,6 +668,7 @@ func (s *DockerSuite) TestEventsDefaultEmpty(c *check.C) {
 
 // #14316
 func (s *DockerRegistrySuite) TestEventsImageFilterPush(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, Network)
 	since := daemonTime(c).Unix()
 	repoName := fmt.Sprintf("%v/dockercli/testf", privateRegistryURL)

--- a/integration-cli/docker_cli_exec_test.go
+++ b/integration-cli/docker_cli_exec_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func (s *DockerSuite) TestExec(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "testing", "busybox", "sh", "-c", "echo test > /tmp/file && top")
 
 	out, _ := dockerCmd(c, "exec", "testing", "cat", "/tmp/file")
@@ -30,6 +31,7 @@ func (s *DockerSuite) TestExec(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecInteractive(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "testing", "busybox", "sh", "-c", "echo test > /tmp/file && top")
 
 	execCmd := exec.Command(dockerBinary, "exec", "-i", "testing", "sh")
@@ -76,6 +78,7 @@ func (s *DockerSuite) TestExecInteractive(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecAfterContainerRestart(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 	dockerCmd(c, "restart", cleanedContainerID)
@@ -88,6 +91,7 @@ func (s *DockerSuite) TestExecAfterContainerRestart(c *check.C) {
 }
 
 func (s *DockerDaemonSuite) TestExecAfterDaemonRestart(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 
 	if err := s.d.StartWithBusybox(); err != nil {
@@ -119,6 +123,7 @@ func (s *DockerDaemonSuite) TestExecAfterDaemonRestart(c *check.C) {
 
 // Regression test for #9155, #9044
 func (s *DockerSuite) TestExecEnv(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-e", "LALA=value1", "-e", "LALA=value2",
 		"-d", "--name", "testing", "busybox", "top")
 
@@ -131,6 +136,7 @@ func (s *DockerSuite) TestExecEnv(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecExitStatus(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "top", "busybox", "top")
 
 	// Test normal (non-detached) case first
@@ -142,6 +148,7 @@ func (s *DockerSuite) TestExecExitStatus(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecPausedContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	defer unpauseAllContainers()
 
 	out, _ := dockerCmd(c, "run", "-d", "--name", "testing", "busybox", "top")
@@ -161,6 +168,7 @@ func (s *DockerSuite) TestExecPausedContainer(c *check.C) {
 
 // regression test for #9476
 func (s *DockerSuite) TestExecTtyCloseStdin(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "-it", "--name", "exec_tty_stdin", "busybox")
 
 	cmd := exec.Command(dockerBinary, "exec", "-i", "exec_tty_stdin", "cat")
@@ -184,6 +192,7 @@ func (s *DockerSuite) TestExecTtyCloseStdin(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecTtyWithoutStdin(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "-ti", "busybox")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
@@ -217,6 +226,7 @@ func (s *DockerSuite) TestExecTtyWithoutStdin(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecParseError(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "top", "busybox", "top")
 
 	// Test normal (non-detached) case first
@@ -227,6 +237,7 @@ func (s *DockerSuite) TestExecParseError(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecStopNotHanging(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "testing", "busybox", "top")
 
 	if err := exec.Command(dockerBinary, "exec", "testing", "top").Start(); err != nil {
@@ -253,6 +264,7 @@ func (s *DockerSuite) TestExecStopNotHanging(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecCgroup(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "testing", "busybox", "top")
 
 	out, _ := dockerCmd(c, "exec", "testing", "cat", "/proc/1/cgroup")
@@ -303,6 +315,7 @@ func (s *DockerSuite) TestExecCgroup(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectExecID(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSuffix(out, "\n")
 
@@ -388,6 +401,7 @@ func (s *DockerSuite) TestInspectExecID(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksPingLinkedContainersOnRename(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	var out string
 	out, _ = dockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
 	idA := strings.TrimSpace(out)
@@ -517,6 +531,7 @@ func (s *DockerSuite) TestRunMutableNetworkFiles(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecWithUser(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "parent", "busybox", "top")
 
 	out, _ := dockerCmd(c, "exec", "-u", "1", "parent", "id")
@@ -531,7 +546,7 @@ func (s *DockerSuite) TestExecWithUser(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecWithPrivileged(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	// Start main loop which attempts mknod repeatedly
 	dockerCmd(c, "run", "-d", "--name", "parent", "--cap-drop=ALL", "busybox", "sh", "-c", `while (true); do if [ -e /exec_priv ]; then cat /exec_priv && mknod /tmp/sda b 8 0 && echo "Success"; else echo "Privileged exec has not run yet"; fi; usleep 10000; done`)
 
@@ -569,6 +584,7 @@ func (s *DockerSuite) TestExecWithPrivileged(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecWithImageUser(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuilduser"
 	_, err := buildImage(name,
 		`FROM busybox
@@ -588,6 +604,7 @@ func (s *DockerSuite) TestExecWithImageUser(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecOnReadonlyContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--read-only", "--name", "parent", "busybox", "top")
 	if _, status := dockerCmd(c, "exec", "parent", "true"); status != 0 {
 		c.Fatalf("exec into a read-only container failed with exit status %d", status)
@@ -596,6 +613,7 @@ func (s *DockerSuite) TestExecOnReadonlyContainer(c *check.C) {
 
 // #15750
 func (s *DockerSuite) TestExecStartFails(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "exec-15750"
 	dockerCmd(c, "run", "-d", "--name", name, "busybox", "top")
 

--- a/integration-cli/docker_cli_exec_unix_test.go
+++ b/integration-cli/docker_cli_exec_unix_test.go
@@ -15,6 +15,7 @@ import (
 
 // regression test for #12546
 func (s *DockerSuite) TestExecInteractiveStdinClose(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-itd", "busybox", "/bin/cat")
 	contID := strings.TrimSpace(out)
 
@@ -44,6 +45,7 @@ func (s *DockerSuite) TestExecInteractiveStdinClose(c *check.C) {
 }
 
 func (s *DockerSuite) TestExecTTY(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name=test", "busybox", "sh", "-c", "echo hello > /foo && top")
 
 	cmd := exec.Command(dockerBinary, "exec", "-it", "test", "sh")

--- a/integration-cli/docker_cli_export_import_test.go
+++ b/integration-cli/docker_cli_export_import_test.go
@@ -10,6 +10,7 @@ import (
 
 // export an image and try to import it into a new one
 func (s *DockerSuite) TestExportContainerAndImportImage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	containerID := "testexportcontainerandimportimage"
 
 	dockerCmd(c, "run", "--name", containerID, "busybox", "true")
@@ -31,6 +32,7 @@ func (s *DockerSuite) TestExportContainerAndImportImage(c *check.C) {
 
 // Used to test output flag in the export command
 func (s *DockerSuite) TestExportContainerWithOutputAndImportImage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	containerID := "testexportcontainerwithoutputandimportimage"
 
 	dockerCmd(c, "run", "--name", containerID, "busybox", "true")

--- a/integration-cli/docker_cli_help_test.go
+++ b/integration-cli/docker_cli_help_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Make sure main help text fits within 80 chars and that
 	// on non-windows system we use ~ when possible (to shorten things).
 	// Test for HOME set to its default value and set to "/" on linux
@@ -251,6 +252,7 @@ func (s *DockerSuite) TestHelpTextVerify(c *check.C) {
 }
 
 func (s *DockerSuite) TestHelpExitCodesHelpOutput(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Test to make sure the exit code and output (stdout vs stderr) of
 	// various good and bad cases are what we expect
 

--- a/integration-cli/docker_cli_history_test.go
+++ b/integration-cli/docker_cli_history_test.go
@@ -12,6 +12,7 @@ import (
 // This is a heisen-test.  Because the created timestamp of images and the behavior of
 // sort is not predictable it doesn't always fail.
 func (s *DockerSuite) TestBuildHistory(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testbuildhistory"
 	_, err := buildImage(name, `FROM busybox
 RUN echo "A"
@@ -62,6 +63,7 @@ RUN echo "Z"`,
 }
 
 func (s *DockerSuite) TestHistoryExistentImage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "history", "busybox")
 }
 
@@ -73,6 +75,7 @@ func (s *DockerSuite) TestHistoryNonExistentImage(c *check.C) {
 }
 
 func (s *DockerSuite) TestHistoryImageWithComment(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testhistoryimagewithcomment"
 
 	// make a image through docker commit <container id> [ -m messages ]
@@ -95,6 +98,7 @@ func (s *DockerSuite) TestHistoryImageWithComment(c *check.C) {
 }
 
 func (s *DockerSuite) TestHistoryHumanOptionFalse(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "history", "--human=false", "busybox")
 	lines := strings.Split(out, "\n")
 	sizeColumnRegex, _ := regexp.Compile("SIZE +")
@@ -113,6 +117,7 @@ func (s *DockerSuite) TestHistoryHumanOptionFalse(c *check.C) {
 }
 
 func (s *DockerSuite) TestHistoryHumanOptionTrue(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "history", "--human=true", "busybox")
 	lines := strings.Split(out, "\n")
 	sizeColumnRegex, _ := regexp.Compile("SIZE +")

--- a/integration-cli/docker_cli_images_test.go
+++ b/integration-cli/docker_cli_images_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func (s *DockerSuite) TestImagesEnsureImageIsListed(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "images")
 	if !strings.Contains(out, "busybox") {
 		c.Fatal("images should've listed busybox")
@@ -19,6 +20,7 @@ func (s *DockerSuite) TestImagesEnsureImageIsListed(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesEnsureImageWithTagIsListed(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	_, err := buildImage("imagewithtag:v1",
 		`FROM scratch
 		MAINTAINER dockerio1`, true)
@@ -52,6 +54,7 @@ func (s *DockerSuite) TestImagesEnsureImageWithBadTagIsNotListed(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesOrderedByCreationDate(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	id1, err := buildImage("order:test_a",
 		`FROM scratch
 		MAINTAINER dockerio1`, true)
@@ -94,6 +97,7 @@ func (s *DockerSuite) TestImagesErrorWithInvalidFilterNameTest(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesFilterLabel(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	imageName1 := "images_filter_test1"
 	imageName2 := "images_filter_test2"
 	imageName3 := "images_filter_test3"
@@ -132,6 +136,7 @@ func (s *DockerSuite) TestImagesFilterLabel(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesFilterSpaceTrimCase(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	imageName := "images_filter_test"
 	buildImage(imageName,
 		`FROM scratch
@@ -170,6 +175,7 @@ func (s *DockerSuite) TestImagesFilterSpaceTrimCase(c *check.C) {
 }
 
 func (s *DockerSuite) TestImagesEnsureDanglingImageOnlyListedOnce(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// create container 1
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	containerID1 := strings.TrimSpace(out)

--- a/integration-cli/docker_cli_import_test.go
+++ b/integration-cli/docker_cli_import_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func (s *DockerSuite) TestImportDisplay(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -35,6 +36,7 @@ func (s *DockerSuite) TestImportDisplay(c *check.C) {
 }
 
 func (s *DockerSuite) TestImportBadURL(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("import", "http://nourl/bad")
 	if err == nil {
 		c.Fatal("import was supposed to fail but didn't")
@@ -45,6 +47,7 @@ func (s *DockerSuite) TestImportBadURL(c *check.C) {
 }
 
 func (s *DockerSuite) TestImportFile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "test-import", "busybox", "true")
 
 	temporaryFile, err := ioutil.TempFile("", "exportImportTest")
@@ -74,6 +77,7 @@ func (s *DockerSuite) TestImportFile(c *check.C) {
 }
 
 func (s *DockerSuite) TestImportFileWithMessage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "test-import", "busybox", "true")
 
 	temporaryFile, err := ioutil.TempFile("", "exportImportTest")

--- a/integration-cli/docker_cli_inspect_experimental_test.go
+++ b/integration-cli/docker_cli_inspect_experimental_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func (s *DockerSuite) TestInspectNamedMountPoint(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "test", "-v", "data:/data", "busybox", "cat")
 
 	vol, err := inspectFieldJSON("test", "Mounts")

--- a/integration-cli/docker_cli_inspect_test.go
+++ b/integration-cli/docker_cli_inspect_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func (s *DockerSuite) TestInspectImage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	imageTest := "emptyfs"
 	imageTestID := "511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158"
 	id, err := inspectField(imageTest, "Id")
@@ -25,6 +26,7 @@ func (s *DockerSuite) TestInspectImage(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectInt64(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	runCmd := exec.Command(dockerBinary, "run", "-d", "-m=300M", "busybox", "true")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
 	if err != nil {
@@ -41,7 +43,7 @@ func (s *DockerSuite) TestInspectInt64(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectDefault(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	//Both the container and image are named busybox. docker inspect will fetch the container JSON.
 	//If the container JSON is not available, it will go for the image JSON.
 
@@ -50,6 +52,7 @@ func (s *DockerSuite) TestInspectDefault(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectStatus(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	out = strings.TrimSpace(out)
 
@@ -82,7 +85,7 @@ func (s *DockerSuite) TestInspectStatus(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectTypeFlagContainer(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	//Both the container and image are named busybox. docker inspect will fetch container
 	//JSON State.Running field. If the field is true, it's a container.
 
@@ -100,7 +103,7 @@ func (s *DockerSuite) TestInspectTypeFlagContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectTypeFlagWithNoContainer(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	//Run this test on an image named busybox. docker inspect will try to fetch container
 	//JSON. Since there is no container named busybox and --type=container, docker inspect will
 	//not try to get the image JSON. It will throw an error.
@@ -114,7 +117,7 @@ func (s *DockerSuite) TestInspectTypeFlagWithNoContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectTypeFlagWithImage(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	//Both the container and image are named busybox. docker inspect will fetch image
 	//JSON as --type=image. if there is no image with name busybox, docker inspect
 	//will throw an error.
@@ -132,7 +135,7 @@ func (s *DockerSuite) TestInspectTypeFlagWithImage(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectTypeFlagWithInvalidValue(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	//Both the container and image are named busybox. docker inspect will fail
 	//as --type=foobar is not a valid value for the flag.
 
@@ -147,6 +150,7 @@ func (s *DockerSuite) TestInspectTypeFlagWithInvalidValue(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectImageFilterInt(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	imageTest := "emptyfs"
 	out, err := inspectField(imageTest, "Size")
 	c.Assert(err, check.IsNil)
@@ -168,6 +172,7 @@ func (s *DockerSuite) TestInspectImageFilterInt(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectContainerFilterInt(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	runCmd := exec.Command(dockerBinary, "run", "-i", "-a", "stdin", "busybox", "cat")
 	runCmd.Stdin = strings.NewReader("blahblah")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
@@ -194,6 +199,7 @@ func (s *DockerSuite) TestInspectContainerFilterInt(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectImageGraphDriver(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	imageTest := "emptyfs"
 	name, err := inspectField(imageTest, "GraphDriver.Name")
 	c.Assert(err, check.IsNil)
@@ -224,6 +230,7 @@ func (s *DockerSuite) TestInspectImageGraphDriver(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	out = strings.TrimSpace(out)
 
@@ -256,6 +263,7 @@ func (s *DockerSuite) TestInspectContainerGraphDriver(c *check.C) {
 }
 
 func (s *DockerSuite) TestInspectBindMountPoint(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "test", "-v", "/data:/data:ro,z", "busybox", "cat")
 
 	vol, err := inspectFieldJSON("test", "Mounts")
@@ -298,6 +306,7 @@ func (s *DockerSuite) TestInspectBindMountPoint(c *check.C) {
 
 // #14947
 func (s *DockerSuite) TestInspectTimesAsRFC3339Nano(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 	id := strings.TrimSpace(out)
 	startedAt, err := inspectField(id, "State.StartedAt")
@@ -323,6 +332,7 @@ func (s *DockerSuite) TestInspectTimesAsRFC3339Nano(c *check.C) {
 
 // #15633
 func (s *DockerSuite) TestInspectLogConfigNoType(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "create", "--name=test", "--log-opt", "max-file=42", "busybox")
 	var logConfig runconfig.LogConfig
 

--- a/integration-cli/docker_cli_kill_test.go
+++ b/integration-cli/docker_cli_kill_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func (s *DockerSuite) TestKillContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 	c.Assert(waitRun(cleanedContainerID), check.IsNil)
@@ -22,6 +23,7 @@ func (s *DockerSuite) TestKillContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestKillofStoppedContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -32,6 +34,7 @@ func (s *DockerSuite) TestKillofStoppedContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestKillDifferentUserContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-u", "daemon", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 	c.Assert(waitRun(cleanedContainerID), check.IsNil)
@@ -46,6 +49,7 @@ func (s *DockerSuite) TestKillDifferentUserContainer(c *check.C) {
 
 // regression test about correct signal parsing see #13665
 func (s *DockerSuite) TestKillWithSignal(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cid := strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
@@ -59,6 +63,7 @@ func (s *DockerSuite) TestKillWithSignal(c *check.C) {
 }
 
 func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	cid := strings.TrimSpace(out)
 	c.Assert(waitRun(cid), check.IsNil)
@@ -91,6 +96,7 @@ func (s *DockerSuite) TestKillWithInvalidSignal(c *check.C) {
 }
 
 func (s *DockerSuite) TestKillofStoppedContainerAPIPre120(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "docker-kill-test-api", "-d", "busybox", "top")
 	dockerCmd(c, "stop", "docker-kill-test-api")
 

--- a/integration-cli/docker_cli_links_test.go
+++ b/integration-cli/docker_cli_links_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *DockerSuite) TestLinksPingUnlinkedContainers(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	_, exitCode, err := dockerCmdWithError("run", "--rm", "busybox", "sh", "-c", "ping -c 1 alias1 -W 1 && ping -c 1 alias2 -W 1")
 
 	if exitCode == 0 {
@@ -22,7 +22,7 @@ func (s *DockerSuite) TestLinksPingUnlinkedContainers(c *check.C) {
 
 // Test for appropriate error when calling --link with an invalid target container
 func (s *DockerSuite) TestLinksInvalidContainerTarget(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "--link", "bogus:alias", "busybox", "true")
 
 	if err == nil {
@@ -35,7 +35,7 @@ func (s *DockerSuite) TestLinksInvalidContainerTarget(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksPingLinkedContainers(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "container1", "--hostname", "fred", "busybox", "top")
 	dockerCmd(c, "run", "-d", "--name", "container2", "--hostname", "wilma", "busybox", "top")
 
@@ -53,7 +53,7 @@ func (s *DockerSuite) TestLinksPingLinkedContainers(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksPingLinkedContainersAfterRename(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "--name", "container1", "busybox", "top")
 	idA := strings.TrimSpace(out)
 	out, _ = dockerCmd(c, "run", "-d", "--name", "container2", "busybox", "top")
@@ -66,6 +66,7 @@ func (s *DockerSuite) TestLinksPingLinkedContainersAfterRename(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksInspectLinksStarted(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	var (
 		expected = map[string]struct{}{"/container1:/testinspectlink/alias1": {}, "/container2:/testinspectlink/alias2": {}}
 		result   []string
@@ -93,6 +94,7 @@ func (s *DockerSuite) TestLinksInspectLinksStarted(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksInspectLinksStopped(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	var (
 		expected = map[string]struct{}{"/container1:/testinspectlink/alias1": {}, "/container2:/testinspectlink/alias2": {}}
 		result   []string
@@ -121,7 +123,7 @@ func (s *DockerSuite) TestLinksInspectLinksStopped(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksNotStartedParentNotFail(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "create", "--name=first", "busybox", "top")
 	dockerCmd(c, "create", "--name=second", "--link=first:first", "busybox", "top")
 	dockerCmd(c, "start", "first")
@@ -129,6 +131,7 @@ func (s *DockerSuite) TestLinksNotStartedParentNotFail(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksHostsFilesInject(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon, ExecSupport)
 
 	out, _ := dockerCmd(c, "run", "-itd", "--name", "one", "busybox", "top")
@@ -156,6 +159,7 @@ func (s *DockerSuite) TestLinksHostsFilesInject(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon, ExecSupport)
 	dockerCmd(c, "run", "-d", "--name", "one", "busybox", "top")
 	out, _ := dockerCmd(c, "run", "-d", "--name", "two", "--link", "one:onetwo", "--link", "one:one", "busybox", "top")
@@ -201,6 +205,7 @@ func (s *DockerSuite) TestLinksUpdateOnRestart(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksEnvs(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "-e", "e1=", "-e", "e2=v2", "-e", "e3=v3=v3", "--name=first", "busybox", "top")
 	out, _ := dockerCmd(c, "run", "--name=second", "--link=first:first", "busybox", "env")
 	if !strings.Contains(out, "FIRST_ENV_e1=\n") ||
@@ -211,6 +216,7 @@ func (s *DockerSuite) TestLinksEnvs(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinkShortDefinition(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "--name", "shortlinkdef", "busybox", "top")
 
 	cid := strings.TrimSpace(out)
@@ -227,6 +233,7 @@ func (s *DockerSuite) TestLinkShortDefinition(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksNetworkHostContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--net", "host", "--name", "host_container", "busybox", "top")
 	out, _, err := dockerCmdWithError("run", "--name", "should_fail", "--link", "host_container:tester", "busybox", "true")
 	if err == nil || !strings.Contains(out, "--net=host can't be used with links. This would result in undefined behavior") {
@@ -235,6 +242,7 @@ func (s *DockerSuite) TestLinksNetworkHostContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestLinksEtcHostsRegularFile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--net=host", "busybox", "ls", "-la", "/etc/hosts")
 	if !strings.HasPrefix(out, "-") {
 		c.Errorf("/etc/hosts should be a regular file")

--- a/integration-cli/docker_cli_logs_test.go
+++ b/integration-cli/docker_cli_logs_test.go
@@ -16,6 +16,7 @@ import (
 
 // This used to work, it test a log of PageSize-1 (gh#4851)
 func (s *DockerSuite) TestLogsContainerSmallerThanPage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testLen := 32767
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
 	cleanedContainerID := strings.TrimSpace(out)
@@ -29,6 +30,7 @@ func (s *DockerSuite) TestLogsContainerSmallerThanPage(c *check.C) {
 
 // Regression test: When going over the PageSize, it used to panic (gh#4851)
 func (s *DockerSuite) TestLogsContainerBiggerThanPage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testLen := 32768
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
 
@@ -44,6 +46,7 @@ func (s *DockerSuite) TestLogsContainerBiggerThanPage(c *check.C) {
 
 // Regression test: When going much over the PageSize, it used to block (gh#4851)
 func (s *DockerSuite) TestLogsContainerMuchBiggerThanPage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testLen := 33000
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo -n =; done; echo", testLen))
 
@@ -58,6 +61,7 @@ func (s *DockerSuite) TestLogsContainerMuchBiggerThanPage(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsTimestamps(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testLen := 100
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
 
@@ -88,6 +92,7 @@ func (s *DockerSuite) TestLogsTimestamps(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsSeparateStderr(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	msg := "stderr_log"
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
 
@@ -107,6 +112,7 @@ func (s *DockerSuite) TestLogsSeparateStderr(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsStderrInStdout(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	msg := "stderr_log"
 	out, _ := dockerCmd(c, "run", "-d", "-t", "busybox", "sh", "-c", fmt.Sprintf("echo %s 1>&2", msg))
 
@@ -125,6 +131,7 @@ func (s *DockerSuite) TestLogsStderrInStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsTail(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testLen := 100
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", fmt.Sprintf("for i in $(seq 1 %d); do echo =; done;", testLen))
 
@@ -155,6 +162,7 @@ func (s *DockerSuite) TestLogsTail(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsFollowStopped(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -180,6 +188,7 @@ func (s *DockerSuite) TestLogsFollowStopped(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsSince(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testlogssince"
 	out, _ := dockerCmd(c, "run", "--name="+name, "busybox", "/bin/sh", "-c", "for i in $(seq 1 3); do sleep 2; echo `date +%s` log$i; done")
 
@@ -215,6 +224,7 @@ func (s *DockerSuite) TestLogsSince(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsSinceFutureFollow(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", `for i in $(seq 1 5); do date +%s; sleep 1; done`)
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -238,6 +248,7 @@ func (s *DockerSuite) TestLogsSinceFutureFollow(c *check.C) {
 
 // Regression test for #8832
 func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", `usleep 200000;yes X | head -c 200000`)
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -271,6 +282,7 @@ func (s *DockerSuite) TestLogsFollowSlowStdoutConsumer(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsFollowGoroutinesWithStdout(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true; do echo hello; sleep 2; done")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)
@@ -322,6 +334,7 @@ func (s *DockerSuite) TestLogsFollowGoroutinesWithStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestLogsFollowGoroutinesNoOutput(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "while true; do sleep 2; done")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)

--- a/integration-cli/docker_cli_nat_test.go
+++ b/integration-cli/docker_cli_nat_test.go
@@ -54,6 +54,7 @@ func getContainerStatus(c *check.C, containerID string) string {
 }
 
 func (s *DockerSuite) TestNetworkNat(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon, NativeExecDriver)
 	msg := "it works"
 	startServerContainer(c, msg, 8080)
@@ -74,6 +75,7 @@ func (s *DockerSuite) TestNetworkNat(c *check.C) {
 }
 
 func (s *DockerSuite) TestNetworkLocalhostTCPNat(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon, NativeExecDriver)
 	var (
 		msg = "hi yall"
@@ -95,6 +97,7 @@ func (s *DockerSuite) TestNetworkLocalhostTCPNat(c *check.C) {
 }
 
 func (s *DockerSuite) TestNetworkLoopbackNat(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon, NativeExecDriver)
 	msg := "it works"
 	startServerContainer(c, msg, 8080)

--- a/integration-cli/docker_cli_netmode_test.go
+++ b/integration-cli/docker_cli_netmode_test.go
@@ -23,6 +23,7 @@ func checkContains(expected string, out string, c *check.C) {
 }
 
 func (s *DockerSuite) TestNetHostname(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 
 	var (
 		out    string
@@ -80,6 +81,7 @@ func (s *DockerSuite) TestNetHostname(c *check.C) {
 }
 
 func (s *DockerSuite) TestConflictContainerNetworkAndLinks(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	var (
 		out    string
 		err    error
@@ -100,6 +102,7 @@ func (s *DockerSuite) TestConflictContainerNetworkAndLinks(c *check.C) {
 }
 
 func (s *DockerSuite) TestConflictNetworkModeAndOptions(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	var (
 		out    string
 		err    error

--- a/integration-cli/docker_cli_pause_test.go
+++ b/integration-cli/docker_cli_pause_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func (s *DockerSuite) TestPause(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	defer unpauseAllContainers()
 
 	name := "testeventpause"
@@ -43,6 +44,7 @@ func (s *DockerSuite) TestPause(c *check.C) {
 }
 
 func (s *DockerSuite) TestPauseMultipleContainers(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	defer unpauseAllContainers()
 
 	containers := []string{

--- a/integration-cli/docker_cli_port_test.go
+++ b/integration-cli/docker_cli_port_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *DockerSuite) TestPortList(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	// one port
 	out, _ := dockerCmd(c, "run", "-d", "-p", "9876:80", "busybox", "top")
 	firstID := strings.TrimSpace(out)
@@ -181,6 +181,7 @@ func stopRemoveContainer(id string, c *check.C) {
 }
 
 func (s *DockerSuite) TestUnpublishedPortsInPsOutput(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Run busybox with command line expose (equivalent to EXPOSE in image's Dockerfile) for the following ports
 	port1 := 80
 	port2 := 443
@@ -248,6 +249,7 @@ func (s *DockerSuite) TestUnpublishedPortsInPsOutput(c *check.C) {
 }
 
 func (s *DockerSuite) TestPortHostBinding(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "-p", "9876:80", "busybox",
 		"nc", "-l", "-p", "80")
 	firstID := strings.TrimSpace(out)
@@ -270,6 +272,7 @@ func (s *DockerSuite) TestPortHostBinding(c *check.C) {
 }
 
 func (s *DockerSuite) TestPortExposeHostBinding(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "-P", "--expose", "80", "busybox",
 		"nc", "-l", "-p", "80")
 	firstID := strings.TrimSpace(out)

--- a/integration-cli/docker_cli_proxy_test.go
+++ b/integration-cli/docker_cli_proxy_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func (s *DockerSuite) TestCliProxyDisableProxyUnixSock(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon) // test is valid when DOCKER_HOST=unix://..
 
 	cmd := exec.Command(dockerBinary, "info")

--- a/integration-cli/docker_cli_ps_test.go
+++ b/integration-cli/docker_cli_ps_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func (s *DockerSuite) TestPsListContainersBase(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	firstID := strings.TrimSpace(out)
 
@@ -158,6 +159,7 @@ func assertContainerList(out string, expected []string) bool {
 }
 
 func (s *DockerSuite) TestPsListContainersSize(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "busybox", "echo", "hello")
 
 	baseOut, _ := dockerCmd(c, "ps", "-s", "-n=1")
@@ -210,6 +212,7 @@ func (s *DockerSuite) TestPsListContainersSize(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterStatus(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// FIXME: this should test paused, but it makes things hang and its wonky
 	// this is because paused containers can't be controlled by signals
 
@@ -245,7 +248,7 @@ func (s *DockerSuite) TestPsListContainersFilterStatus(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterID(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	// start container
 	out, _ := dockerCmd(c, "run", "-d", "busybox")
 	firstID := strings.TrimSpace(out)
@@ -263,7 +266,7 @@ func (s *DockerSuite) TestPsListContainersFilterID(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterName(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	// start container
 	out, _ := dockerCmd(c, "run", "-d", "--name=a_name_to_match", "busybox")
 	firstID := strings.TrimSpace(out)
@@ -289,6 +292,7 @@ func (s *DockerSuite) TestPsListContainersFilterName(c *check.C) {
 // - Run containers for each of those image (busybox, images_ps_filter_test1, images_ps_filter_test2)
 // - Filter them out :P
 func (s *DockerSuite) TestPsListContainersFilterAncestorImage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Build images
 	imageName1 := "images_ps_filter_test1"
 	imageID1, err := buildImage(imageName1,
@@ -388,6 +392,7 @@ func checkPsAncestorFilterOutput(c *check.C, out string, filterName string, expe
 }
 
 func (s *DockerSuite) TestPsListContainersFilterLabel(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// start container
 	out, _ := dockerCmd(c, "run", "-d", "-l", "match=me", "-l", "second=tag", "busybox")
 	firstID := strings.TrimSpace(out)
@@ -430,7 +435,7 @@ func (s *DockerSuite) TestPsListContainersFilterLabel(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterExited(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "top", "busybox", "top")
 
 	dockerCmd(c, "run", "--name", "zero1", "busybox", "true")
@@ -490,6 +495,7 @@ func (s *DockerSuite) TestPsListContainersFilterExited(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsRightTagName(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	tag := "asybox:shmatest"
 	dockerCmd(c, "tag", "busybox", tag)
 
@@ -538,6 +544,7 @@ func (s *DockerSuite) TestPsRightTagName(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsLinkedWithNoTrunc(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name=first", "-d", "busybox", "top")
 	dockerCmd(c, "run", "--name=second", "--link=first:first", "-d", "busybox", "top")
 
@@ -557,7 +564,7 @@ func (s *DockerSuite) TestPsLinkedWithNoTrunc(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsGroupPortRange(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	portRange := "3800-3900"
 	dockerCmd(c, "run", "-d", "--name", "porttest", "-p", portRange+":"+portRange, "busybox", "top")
 
@@ -571,6 +578,7 @@ func (s *DockerSuite) TestPsGroupPortRange(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsWithSize(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "sizetest", "busybox", "top")
 
 	out, _ := dockerCmd(c, "ps", "--size")
@@ -580,6 +588,7 @@ func (s *DockerSuite) TestPsWithSize(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsListContainersFilterCreated(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// create a container
 	out, _ := dockerCmd(c, "create", "busybox")
 	cID := strings.TrimSpace(out)
@@ -618,6 +627,7 @@ func (s *DockerSuite) TestPsListContainersFilterCreated(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsFormatMultiNames(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	//create 2 containers and link them
 	dockerCmd(c, "run", "--name=child", "-d", "busybox", "top")
 	dockerCmd(c, "run", "--name=parent", "--link=child:linkedone", "-d", "busybox", "top")
@@ -649,6 +659,7 @@ func (s *DockerSuite) TestPsFormatMultiNames(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsFormatHeaders(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// make sure no-container "docker ps" still prints the header row
 	out, _ := dockerCmd(c, "ps", "--format", "table {{.ID}}")
 	if out != "CONTAINER ID\n" {
@@ -664,6 +675,7 @@ func (s *DockerSuite) TestPsFormatHeaders(c *check.C) {
 }
 
 func (s *DockerSuite) TestPsDefaultFormatAndQuiet(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	config := `{
 		"psFormat": "{{ .ID }} default"
 }`
@@ -685,6 +697,7 @@ func (s *DockerSuite) TestPsDefaultFormatAndQuiet(c *check.C) {
 
 // Test for GitHub issue #12595
 func (s *DockerSuite) TestPsImageIDAfterUpdate(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 
 	originalImageName := "busybox:TestPsImageIDAfterUpdate-original"
 	updatedImageName := "busybox:TestPsImageIDAfterUpdate-updated"

--- a/integration-cli/docker_cli_pull_test.go
+++ b/integration-cli/docker_cli_pull_test.go
@@ -14,6 +14,7 @@ import (
 // TestPullFromCentralRegistry pulls an image from the central registry and verifies that the client
 // prints all expected output.
 func (s *DockerHubPullSuite) TestPullFromCentralRegistry(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out := s.Cmd(c, "pull", "hello-world")
 	defer deleteImages("hello-world")
 
@@ -39,6 +40,7 @@ func (s *DockerHubPullSuite) TestPullFromCentralRegistry(c *check.C) {
 // TestPullNonExistingImage pulls non-existing images from the central registry, with different
 // combinations of implicit tag and library prefix.
 func (s *DockerHubPullSuite) TestPullNonExistingImage(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	for _, e := range []struct {
 		Image string
 		Alias string
@@ -61,6 +63,7 @@ func (s *DockerHubPullSuite) TestPullNonExistingImage(c *check.C) {
 // reference (tag, repository, central registry url, ...) doesn't trigger a new pull nor leads to
 // multiple images.
 func (s *DockerHubPullSuite) TestPullFromCentralRegistryImplicitRefParts(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	s.Cmd(c, "pull", "hello-world")
 	defer deleteImages("hello-world")
 
@@ -87,6 +90,7 @@ func (s *DockerHubPullSuite) TestPullFromCentralRegistryImplicitRefParts(c *chec
 
 // TestPullScratchNotAllowed verifies that pulling 'scratch' is rejected.
 func (s *DockerHubPullSuite) TestPullScratchNotAllowed(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, err := s.CmdWithError("pull", "scratch")
 	c.Assert(err, checker.NotNil, check.Commentf("expected pull of scratch to fail"))
 	c.Assert(out, checker.Contains, "'scratch' is a reserved name")
@@ -96,6 +100,7 @@ func (s *DockerHubPullSuite) TestPullScratchNotAllowed(c *check.C) {
 // TestPullAllTagsFromCentralRegistry pulls using `all-tags` for a given image and verifies that it
 // results in more images than a naked pull.
 func (s *DockerHubPullSuite) TestPullAllTagsFromCentralRegistry(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	s.Cmd(c, "pull", "busybox")
 	outImageCmd := s.Cmd(c, "images", "busybox")
 	splitOutImageCmd := strings.Split(strings.TrimSpace(outImageCmd), "\n")
@@ -126,6 +131,7 @@ func (s *DockerHubPullSuite) TestPullAllTagsFromCentralRegistry(c *check.C) {
 //
 // Ref: docker/docker#15589
 func (s *DockerHubPullSuite) TestPullClientDisconnect(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	repoName := "hello-world:latest"
 
 	pullCmd := s.MakeCmd("pull", repoName)

--- a/integration-cli/docker_cli_rename_test.go
+++ b/integration-cli/docker_cli_rename_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func (s *DockerSuite) TestRenameStoppedContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--name", "first_name", "-d", "busybox", "sh")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -28,6 +29,7 @@ func (s *DockerSuite) TestRenameStoppedContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRenameRunningContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--name", "first_name", "-d", "busybox", "sh")
 
 	newName := "new_name" + stringid.GenerateNonCryptoID()
@@ -44,6 +46,7 @@ func (s *DockerSuite) TestRenameRunningContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "first_name", "-d", "busybox", "sh")
 
 	newName := "new_name" + stringid.GenerateNonCryptoID()
@@ -64,6 +67,7 @@ func (s *DockerSuite) TestRenameCheckNames(c *check.C) {
 }
 
 func (s *DockerSuite) TestRenameInvalidName(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "myname", "-d", "busybox", "top")
 
 	if out, _, err := dockerCmdWithError("rename", "myname", "new:invalid"); err == nil || !strings.Contains(out, "Invalid container name") {

--- a/integration-cli/docker_cli_restart_test.go
+++ b/integration-cli/docker_cli_restart_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func (s *DockerSuite) TestRestartStoppedContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "echo", "foobar")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -26,6 +27,7 @@ func (s *DockerSuite) TestRestartStoppedContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRestartRunningContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "echo foobar && sleep 30 && echo 'should not print this'")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -50,6 +52,7 @@ func (s *DockerSuite) TestRestartRunningContainer(c *check.C) {
 
 // Test that restarting a container with a volume does not create a new volume on restart. Regression test for #819.
 func (s *DockerSuite) TestRestartWithVolumes(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "-v", "/test", "busybox", "top")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -78,6 +81,7 @@ func (s *DockerSuite) TestRestartWithVolumes(c *check.C) {
 }
 
 func (s *DockerSuite) TestRestartPolicyNO(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "--restart=no", "busybox", "false")
 
 	id := strings.TrimSpace(string(out))
@@ -89,6 +93,7 @@ func (s *DockerSuite) TestRestartPolicyNO(c *check.C) {
 }
 
 func (s *DockerSuite) TestRestartPolicyAlways(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "--restart=always", "busybox", "false")
 
 	id := strings.TrimSpace(string(out))
@@ -108,6 +113,7 @@ func (s *DockerSuite) TestRestartPolicyAlways(c *check.C) {
 }
 
 func (s *DockerSuite) TestRestartPolicyOnFailure(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:1", "busybox", "false")
 
 	id := strings.TrimSpace(string(out))
@@ -122,6 +128,7 @@ func (s *DockerSuite) TestRestartPolicyOnFailure(c *check.C) {
 // a good container with --restart=on-failure:3
 // MaximumRetryCount!=0; RestartCount=0
 func (s *DockerSuite) TestContainerRestartwithGoodContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "true")
 
 	id := strings.TrimSpace(string(out))

--- a/integration-cli/docker_cli_rm_test.go
+++ b/integration-cli/docker_cli_rm_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func (s *DockerSuite) TestRmContainerWithRemovedVolume(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 
 	dockerCmd(c, "run", "--name", "losemyvolumes", "-v", "/tmp/testing:/test", "busybox", "true")
@@ -20,12 +21,14 @@ func (s *DockerSuite) TestRmContainerWithRemovedVolume(c *check.C) {
 }
 
 func (s *DockerSuite) TestRmContainerWithVolume(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "foo", "-v", "/srv", "busybox", "true")
 
 	dockerCmd(c, "rm", "-v", "foo")
 }
 
 func (s *DockerSuite) TestRmRunningContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	createRunningContainer(c, "foo")
 
 	if _, _, err := dockerCmdWithError("rm", "foo"); err == nil {
@@ -34,6 +37,7 @@ func (s *DockerSuite) TestRmRunningContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRmForceRemoveRunningContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	createRunningContainer(c, "foo")
 
 	// Stop then remove with -s
@@ -41,7 +45,7 @@ func (s *DockerSuite) TestRmForceRemoveRunningContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRmContainerOrphaning(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	dockerfile1 := `FROM busybox:latest
 	ENTRYPOINT ["/bin/true"]`
 	img := "test-container-orphaning"

--- a/integration-cli/docker_cli_rmi_test.go
+++ b/integration-cli/docker_cli_rmi_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func (s *DockerSuite) TestRmiWithContainerFails(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	errSubstr := "is using it"
 
 	// create a container
@@ -36,6 +37,7 @@ func (s *DockerSuite) TestRmiWithContainerFails(c *check.C) {
 }
 
 func (s *DockerSuite) TestRmiTag(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	imagesBefore, _ := dockerCmd(c, "images", "-a")
 	dockerCmd(c, "tag", "busybox", "utest:tag1")
 	dockerCmd(c, "tag", "busybox", "utest/docker:tag2")
@@ -73,6 +75,7 @@ func (s *DockerSuite) TestRmiTag(c *check.C) {
 }
 
 func (s *DockerSuite) TestRmiImgIDMultipleTag(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "-d", "busybox", "/bin/sh", "-c", "mkdir '/busybox-one'")
 	if err != nil {
 		c.Fatalf("failed to create a container:%s, %v", out, err)
@@ -121,6 +124,7 @@ func (s *DockerSuite) TestRmiImgIDMultipleTag(c *check.C) {
 }
 
 func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "-d", "busybox", "/bin/sh", "-c", "mkdir '/busybox-test'")
 	if err != nil {
 		c.Fatalf("failed to create a container:%s, %v", out, err)
@@ -163,6 +167,7 @@ func (s *DockerSuite) TestRmiImgIDForce(c *check.C) {
 
 // See https://github.com/docker/docker/issues/14116
 func (s *DockerSuite) TestRmiImageIDForceWithRunningContainersAndMultipleTags(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerfile := "FROM busybox\nRUN echo test 14116\n"
 	imgID, err := buildImage("test-14116", dockerfile, false)
 	c.Assert(err, check.IsNil)
@@ -179,6 +184,7 @@ func (s *DockerSuite) TestRmiImageIDForceWithRunningContainersAndMultipleTags(c 
 }
 
 func (s *DockerSuite) TestRmiTagWithExistingContainers(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	container := "test-delete-tag"
 	newtag := "busybox:newtag"
 	bb := "busybox:latest"
@@ -198,6 +204,7 @@ func (s *DockerSuite) TestRmiTagWithExistingContainers(c *check.C) {
 }
 
 func (s *DockerSuite) TestRmiForceWithExistingContainers(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	image := "busybox-clone"
 
 	cmd := exec.Command(dockerBinary, "build", "--no-cache", "-t", image, "-")
@@ -218,6 +225,7 @@ MAINTAINER foo`)
 }
 
 func (s *DockerSuite) TestRmiWithMultipleRepositories(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	newRepo := "127.0.0.1:5000/busybox"
 	oldRepo := "busybox"
 	newTag := "busybox:test"
@@ -246,6 +254,7 @@ func (s *DockerSuite) TestRmiWithMultipleRepositories(c *check.C) {
 }
 
 func (s *DockerSuite) TestRmiBlank(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// try to delete a blank image name
 	out, _, err := dockerCmdWithError("rmi", "")
 	if err == nil {
@@ -268,6 +277,7 @@ func (s *DockerSuite) TestRmiBlank(c *check.C) {
 }
 
 func (s *DockerSuite) TestRmiContainerImageNotFound(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Build 2 images for testing.
 	imageNames := []string{"test1", "test2"}
 	imageIds := make([]string, 2)
@@ -295,6 +305,7 @@ func (s *DockerSuite) TestRmiContainerImageNotFound(c *check.C) {
 
 // #13422
 func (s *DockerSuite) TestRmiUntagHistoryLayer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	image := "tmp1"
 	// Build a image for testing.
 	dockerfile := `FROM busybox

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -25,6 +25,7 @@ import (
 
 // "test123" should be printed by docker run
 func (s *DockerSuite) TestRunEchoStdout(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "busybox", "echo", "test123")
 	if out != "test123\n" {
 		c.Fatalf("container should've printed 'test123'")
@@ -33,6 +34,7 @@ func (s *DockerSuite) TestRunEchoStdout(c *check.C) {
 
 // "test" should be printed
 func (s *DockerSuite) TestRunEchoNamedContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--name", "testfoonamedcontainer", "busybox", "echo", "test")
 	if out != "test\n" {
 		c.Errorf("container should've printed 'test'")
@@ -41,6 +43,7 @@ func (s *DockerSuite) TestRunEchoNamedContainer(c *check.C) {
 
 // docker run should not leak file descriptors
 func (s *DockerSuite) TestRunLeakyFileDescriptors(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "busybox", "ls", "-C", "/proc/self/fd")
 
 	// normally, we should only get 0, 1, and 2, but 3 gets created by "ls" when it does "opendir" on the "fd" directory
@@ -52,6 +55,7 @@ func (s *DockerSuite) TestRunLeakyFileDescriptors(c *check.C) {
 // it should be possible to lookup Google DNS
 // this will fail when Internet access is unavailable
 func (s *DockerSuite) TestRunLookupGoogleDns(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, Network)
 	dockerCmd(c, "run", "busybox", "nslookup", "google.com")
 }
@@ -59,12 +63,14 @@ func (s *DockerSuite) TestRunLookupGoogleDns(c *check.C) {
 // the exit code should be 0
 // some versions of lxc might make this test fail
 func (s *DockerSuite) TestRunExitCodeZero(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "busybox", "true")
 }
 
 // the exit code should be 1
 // some versions of lxc might make this test fail
 func (s *DockerSuite) TestRunExitCodeOne(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	_, exitCode, err := dockerCmdWithError("run", "busybox", "false")
 	if err != nil && !strings.Contains("exit status 1", fmt.Sprintf("%s", err)) {
 		c.Fatal(err)
@@ -77,6 +83,7 @@ func (s *DockerSuite) TestRunExitCodeOne(c *check.C) {
 // it should be possible to pipe in data via stdin to a process running in a container
 // some versions of lxc might make this test fail
 func (s *DockerSuite) TestRunStdinPipe(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	runCmd := exec.Command(dockerBinary, "run", "-i", "-a", "stdin", "busybox", "cat")
 	runCmd.Stdin = strings.NewReader("blahblah")
 	out, _, _, err := runCommandWithStdoutStderr(runCmd)
@@ -99,6 +106,7 @@ func (s *DockerSuite) TestRunStdinPipe(c *check.C) {
 
 // the container's ID should be printed when starting a container in detached mode
 func (s *DockerSuite) TestRunDetachedContainerIDPrinting(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "true")
 
 	out = strings.TrimSpace(out)
@@ -114,6 +122,7 @@ func (s *DockerSuite) TestRunDetachedContainerIDPrinting(c *check.C) {
 
 // the working directory should be set correctly
 func (s *DockerSuite) TestRunWorkingDirectory(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-w", "/root", "busybox", "pwd")
 
 	out = strings.TrimSpace(out)
@@ -130,6 +139,7 @@ func (s *DockerSuite) TestRunWorkingDirectory(c *check.C) {
 
 // pinging Google's DNS resolver should fail when we disable the networking
 func (s *DockerSuite) TestRunWithoutNetworking(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, exitCode, err := dockerCmdWithError("run", "--net=none", "busybox", "ping", "-c", "1", "8.8.8.8")
 	if err != nil && exitCode != 1 {
 		c.Fatal(out, err)
@@ -149,6 +159,7 @@ func (s *DockerSuite) TestRunWithoutNetworking(c *check.C) {
 
 //test --link use container name to link target
 func (s *DockerSuite) TestRunLinksContainerWithContainerName(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-i", "-t", "-d", "--name", "parent", "busybox")
 
 	ip, err := inspectField("parent", "NetworkSettings.IPAddress")
@@ -162,6 +173,7 @@ func (s *DockerSuite) TestRunLinksContainerWithContainerName(c *check.C) {
 
 //test --link use container id to link target
 func (s *DockerSuite) TestRunLinksContainerWithContainerId(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cID, _ := dockerCmd(c, "run", "-i", "-t", "-d", "busybox")
 
 	cID = strings.TrimSpace(cID)
@@ -176,6 +188,7 @@ func (s *DockerSuite) TestRunLinksContainerWithContainerId(c *check.C) {
 
 // Issue 9677.
 func (s *DockerSuite) TestRunWithDaemonFlags(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("--selinux-enabled", "run", "-i", "-t", "busybox", "true")
 	if err != nil {
 		if !strings.Contains(out, "must follow the 'docker daemon' command") && // daemon
@@ -187,6 +200,7 @@ func (s *DockerSuite) TestRunWithDaemonFlags(c *check.C) {
 
 // Regression test for #4979
 func (s *DockerSuite) TestRunWithVolumesFromExited(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, exitCode := dockerCmd(c, "run", "--name", "test-data", "--volume", "/some/dir", "busybox", "touch", "/some/dir/file")
 	if exitCode != 0 {
 		c.Fatal("1", out, exitCode)
@@ -201,6 +215,7 @@ func (s *DockerSuite) TestRunWithVolumesFromExited(c *check.C) {
 // Volume path is a symlink which also exists on the host, and the host side is a file not a dir
 // But the volume call is just a normal volume, not a bind mount
 func (s *DockerSuite) TestRunCreateVolumesInSymlinkDir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 	testRequires(c, NativeExecDriver)
 	name := "test-volume-symlink"
@@ -226,12 +241,14 @@ func (s *DockerSuite) TestRunCreateVolumesInSymlinkDir(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunVolumesMountedAsReadonly(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if _, code, err := dockerCmdWithError("run", "-v", "/test:/test:ro", "busybox", "touch", "/test/somefile"); err == nil || code == 0 {
 		c.Fatalf("run should fail because volume is ro: exit code %d", code)
 	}
 }
 
 func (s *DockerSuite) TestRunVolumesFromInReadonlyMode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "parent", "-v", "/test", "busybox", "true")
 
 	if _, code, err := dockerCmdWithError("run", "--volumes-from", "parent:ro", "busybox", "touch", "/test/file"); err == nil || code == 0 {
@@ -241,6 +258,7 @@ func (s *DockerSuite) TestRunVolumesFromInReadonlyMode(c *check.C) {
 
 // Regression test for #1201
 func (s *DockerSuite) TestRunVolumesFromInReadWriteMode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "parent", "-v", "/test", "busybox", "true")
 	dockerCmd(c, "run", "--volumes-from", "parent:rw", "busybox", "touch", "/test/file")
 
@@ -252,6 +270,7 @@ func (s *DockerSuite) TestRunVolumesFromInReadWriteMode(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumesFromGetsProperMode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "parent", "-v", "/test:/test:ro", "busybox", "true")
 
 	// Expect this "rw" mode to be be ignored since the inherited volume is "ro"
@@ -269,6 +288,7 @@ func (s *DockerSuite) TestVolumesFromGetsProperMode(c *check.C) {
 
 // Test for GH#10618
 func (s *DockerSuite) TestRunNoDupVolumes(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	mountstr1 := randomUnixTmpDirPath("test1") + ":/someplace"
 	mountstr2 := randomUnixTmpDirPath("test2") + ":/someplace"
 
@@ -283,11 +303,13 @@ func (s *DockerSuite) TestRunNoDupVolumes(c *check.C) {
 
 // Test for #1351
 func (s *DockerSuite) TestRunApplyVolumesFromBeforeVolumes(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "parent", "-v", "/test", "busybox", "touch", "/test/foo")
 	dockerCmd(c, "run", "--volumes-from", "parent", "-v", "/test", "busybox", "cat", "/test/foo")
 }
 
 func (s *DockerSuite) TestRunMultipleVolumesFrom(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "parent1", "-v", "/test", "busybox", "touch", "/test/foo")
 	dockerCmd(c, "run", "--name", "parent2", "-v", "/other", "busybox", "touch", "/other/bar")
 	dockerCmd(c, "run", "--volumes-from", "parent1", "--volumes-from", "parent2", "busybox", "sh", "-c", "cat /test/foo && cat /other/bar")
@@ -295,6 +317,7 @@ func (s *DockerSuite) TestRunMultipleVolumesFrom(c *check.C) {
 
 // this tests verifies the ID format for the container
 func (s *DockerSuite) TestRunVerifyContainerID(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, exit, err := dockerCmdWithError("run", "-d", "busybox", "true")
 	if err != nil {
 		c.Fatal(err)
@@ -314,12 +337,14 @@ func (s *DockerSuite) TestRunVerifyContainerID(c *check.C) {
 
 // Test that creating a container with a volume doesn't crash. Regression test for #995.
 func (s *DockerSuite) TestRunCreateVolume(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-v", "/var/lib/data", "busybox", "true")
 }
 
 // Test that creating a volume with a symlink in its path works correctly. Test for #5152.
 // Note that this bug happens only with symlinks with a target that starts with '/'.
 func (s *DockerSuite) TestRunCreateVolumeWithSymlink(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	image := "docker-test-createvolumewithsymlink"
 
 	buildCmd := exec.Command(dockerBinary, "build", "-t", image, "-")
@@ -354,6 +379,7 @@ func (s *DockerSuite) TestRunCreateVolumeWithSymlink(c *check.C) {
 
 // Tests that a volume path that has a symlink exists in a container mounting it with `--volumes-from`.
 func (s *DockerSuite) TestRunVolumesFromSymlinkPath(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "docker-test-volumesfromsymlinkpath"
 
 	buildCmd := exec.Command(dockerBinary, "build", "-t", name, "-")
@@ -378,6 +404,7 @@ func (s *DockerSuite) TestRunVolumesFromSymlinkPath(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunExitCode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	_, exit, err := dockerCmdWithError("run", "busybox", "/bin/sh", "-c", "exit 72")
 	if err == nil {
 		c.Fatal("should not have a non nil error")
@@ -388,6 +415,7 @@ func (s *DockerSuite) TestRunExitCode(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunUserDefaultsToRoot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "busybox", "id")
 	if !strings.Contains(out, "uid=0(root) gid=0(root)") {
 		c.Fatalf("expected root user got %s", out)
@@ -395,6 +423,7 @@ func (s *DockerSuite) TestRunUserDefaultsToRoot(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunUserByName(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-u", "root", "busybox", "id")
 	if !strings.Contains(out, "uid=0(root) gid=0(root)") {
 		c.Fatalf("expected root user got %s", out)
@@ -402,6 +431,7 @@ func (s *DockerSuite) TestRunUserByName(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunUserByID(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-u", "1", "busybox", "id")
 	if !strings.Contains(out, "uid=1(daemon) gid=1(daemon)") {
 		c.Fatalf("expected daemon user got %s", out)
@@ -409,6 +439,7 @@ func (s *DockerSuite) TestRunUserByID(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunUserByIDBig(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "-u", "2147483648", "busybox", "id")
 	if err == nil {
 		c.Fatal("No error, but must be.", out)
@@ -419,6 +450,7 @@ func (s *DockerSuite) TestRunUserByIDBig(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunUserByIDNegative(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "-u", "-1", "busybox", "id")
 	if err == nil {
 		c.Fatal("No error, but must be.", out)
@@ -429,6 +461,7 @@ func (s *DockerSuite) TestRunUserByIDNegative(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunUserByIDZero(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "-u", "0", "busybox", "id")
 	if err != nil {
 		c.Fatal(err, out)
@@ -446,6 +479,7 @@ func (s *DockerSuite) TestRunUserNotFound(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunTwoConcurrentContainers(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	group := sync.WaitGroup{}
 	group.Add(2)
 
@@ -467,6 +501,7 @@ func (s *DockerSuite) TestRunTwoConcurrentContainers(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunEnvironment(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cmd := exec.Command(dockerBinary, "run", "-h", "testing", "-e=FALSE=true", "-e=TRUE", "-e=TRICKY", "-e=HOME=", "busybox", "env")
 	cmd.Env = append(os.Environ(),
 		"TRUE=false",
@@ -509,6 +544,7 @@ func (s *DockerSuite) TestRunEnvironment(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunEnvironmentErase(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Test to make sure that when we use -e on env vars that are
 	// not set in our local env that they're removed (if present) in
 	// the container
@@ -546,6 +582,7 @@ func (s *DockerSuite) TestRunEnvironmentErase(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunEnvironmentOverride(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// Test to make sure that when we use -e on env vars that are
 	// already in the env that we're overriding them
 
@@ -583,10 +620,12 @@ func (s *DockerSuite) TestRunEnvironmentOverride(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunContainerNetwork(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "busybox", "ping", "-c", "1", "127.0.0.1")
 }
 
 func (s *DockerSuite) TestRunNetHostNotAllowedWithLinks(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "linked", "busybox", "true")
 
 	_, _, err := dockerCmdWithError("run", "--net=host", "--link", "linked:linked", "busybox", "true")
@@ -601,6 +640,7 @@ func (s *DockerSuite) TestRunNetHostNotAllowedWithLinks(c *check.C) {
 // codepath is executed with "docker run -h <hostname>".  Both were manually
 // tested, but this testcase takes the simpler path of using "run -h .."
 func (s *DockerSuite) TestRunFullHostnameSet(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-h", "foo.bar.baz", "busybox", "hostname")
 	if actual := strings.Trim(out, "\r\n"); actual != "foo.bar.baz" {
 		c.Fatalf("expected hostname 'foo.bar.baz', received %s", actual)
@@ -608,6 +648,7 @@ func (s *DockerSuite) TestRunFullHostnameSet(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunPrivilegedCanMknod(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
@@ -615,6 +656,7 @@ func (s *DockerSuite) TestRunPrivilegedCanMknod(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunUnprivilegedCanMknod(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
 		c.Fatalf("expected output ok received %s", actual)
@@ -622,6 +664,7 @@ func (s *DockerSuite) TestRunUnprivilegedCanMknod(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapDropInvalid(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "--cap-drop=CHPASS", "busybox", "ls")
 	if err == nil {
 		c.Fatal(err, out)
@@ -629,6 +672,7 @@ func (s *DockerSuite) TestRunCapDropInvalid(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapDropCannotMknod(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "--cap-drop=MKNOD", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 
 	if err == nil {
@@ -640,6 +684,7 @@ func (s *DockerSuite) TestRunCapDropCannotMknod(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapDropCannotMknodLowerCase(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "--cap-drop=mknod", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 
 	if err == nil {
@@ -651,6 +696,7 @@ func (s *DockerSuite) TestRunCapDropCannotMknodLowerCase(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapDropALLCannotMknod(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "--cap-drop=ALL", "--cap-add=SETGID", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 	if err == nil {
 		c.Fatal(err, out)
@@ -661,6 +707,7 @@ func (s *DockerSuite) TestRunCapDropALLCannotMknod(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapDropALLAddMknodCanMknod(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=MKNOD", "--cap-add=SETGID", "busybox", "sh", "-c", "mknod /tmp/sda b 8 0 && echo ok")
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
@@ -669,6 +716,7 @@ func (s *DockerSuite) TestRunCapDropALLAddMknodCanMknod(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapAddInvalid(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "--cap-add=CHPASS", "busybox", "ls")
 	if err == nil {
 		c.Fatal(err, out)
@@ -676,6 +724,7 @@ func (s *DockerSuite) TestRunCapAddInvalid(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapAddCanDownInterface(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--cap-add=NET_ADMIN", "busybox", "sh", "-c", "ip link set eth0 down && echo ok")
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
@@ -684,6 +733,7 @@ func (s *DockerSuite) TestRunCapAddCanDownInterface(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapAddALLCanDownInterface(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--cap-add=ALL", "busybox", "sh", "-c", "ip link set eth0 down && echo ok")
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
@@ -692,6 +742,7 @@ func (s *DockerSuite) TestRunCapAddALLCanDownInterface(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapAddALLDropNetAdminCanDownInterface(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "--cap-add=ALL", "--cap-drop=NET_ADMIN", "busybox", "sh", "-c", "ip link set eth0 down && echo ok")
 	if err == nil {
 		c.Fatal(err, out)
@@ -702,6 +753,7 @@ func (s *DockerSuite) TestRunCapAddALLDropNetAdminCanDownInterface(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunGroupAdd(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, NativeExecDriver)
 	out, _ := dockerCmd(c, "run", "--group-add=audio", "--group-add=dbus", "--group-add=777", "busybox", "sh", "-c", "id")
 
@@ -712,6 +764,7 @@ func (s *DockerSuite) TestRunGroupAdd(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunPrivilegedCanMount(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--privileged", "busybox", "sh", "-c", "mount -t tmpfs none /tmp && echo ok")
 
 	if actual := strings.Trim(out, "\r\n"); actual != "ok" {
@@ -720,6 +773,7 @@ func (s *DockerSuite) TestRunPrivilegedCanMount(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunUnprivilegedCannotMount(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "busybox", "sh", "-c", "mount -t tmpfs none /tmp && echo ok")
 
 	if err == nil {
@@ -731,30 +785,35 @@ func (s *DockerSuite) TestRunUnprivilegedCannotMount(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunSysNotWritableInNonPrivilegedContainers(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if _, code, err := dockerCmdWithError("run", "busybox", "touch", "/sys/kernel/profiling"); err == nil || code == 0 {
 		c.Fatal("sys should not be writable in a non privileged container")
 	}
 }
 
 func (s *DockerSuite) TestRunSysWritableInPrivilegedContainers(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if _, code, err := dockerCmdWithError("run", "--privileged", "busybox", "touch", "/sys/kernel/profiling"); err != nil || code != 0 {
 		c.Fatalf("sys should be writable in privileged container")
 	}
 }
 
 func (s *DockerSuite) TestRunProcNotWritableInNonPrivilegedContainers(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if _, code, err := dockerCmdWithError("run", "busybox", "touch", "/proc/sysrq-trigger"); err == nil || code == 0 {
 		c.Fatal("proc should not be writable in a non privileged container")
 	}
 }
 
 func (s *DockerSuite) TestRunProcWritableInPrivilegedContainers(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if _, code := dockerCmd(c, "run", "--privileged", "busybox", "touch", "/proc/sysrq-trigger"); code != 0 {
 		c.Fatalf("proc should be writable in privileged container")
 	}
 }
 
 func (s *DockerSuite) TestRunDeviceNumbers(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "busybox", "sh", "-c", "ls -l /dev/null")
 	deviceLineFields := strings.Fields(out)
 	deviceLineFields[6] = ""
@@ -768,6 +827,7 @@ func (s *DockerSuite) TestRunDeviceNumbers(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunThatCharacterDevicesActLikeCharacterDevices(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "busybox", "sh", "-c", "dd if=/dev/zero of=/zero bs=1k count=5 2> /dev/null ; du -h /zero")
 	if actual := strings.Trim(out, "\r\n"); actual[0] == '0' {
 		c.Fatalf("expected a new file called /zero to be create that is greater than 0 bytes long, but du says: %s", actual)
@@ -775,10 +835,12 @@ func (s *DockerSuite) TestRunThatCharacterDevicesActLikeCharacterDevices(c *chec
 }
 
 func (s *DockerSuite) TestRunUnprivilegedWithChroot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "busybox", "chroot", "/", "true")
 }
 
 func (s *DockerSuite) TestRunAddingOptionalDevices(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--device", "/dev/zero:/dev/nulo", "busybox", "sh", "-c", "ls /dev/nulo")
 	if actual := strings.Trim(out, "\r\n"); actual != "/dev/nulo" {
 		c.Fatalf("expected output /dev/nulo, received %s", actual)
@@ -786,6 +848,7 @@ func (s *DockerSuite) TestRunAddingOptionalDevices(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunAddingOptionalDevicesNoSrc(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--device", "/dev/zero:rw", "busybox", "sh", "-c", "ls /dev/zero")
 	if actual := strings.Trim(out, "\r\n"); actual != "/dev/zero" {
 		c.Fatalf("expected output /dev/zero, received %s", actual)
@@ -793,6 +856,7 @@ func (s *DockerSuite) TestRunAddingOptionalDevicesNoSrc(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunAddingOptionalDevicesInvalidMode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	_, _, err := dockerCmdWithError("run", "--device", "/dev/zero:ro", "busybox", "sh", "-c", "ls /dev/zero")
 	if err == nil {
 		c.Fatalf("run container with device mode ro should fail")
@@ -800,7 +864,7 @@ func (s *DockerSuite) TestRunAddingOptionalDevicesInvalidMode(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunModeHostname(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "run", "-h=testhostname", "busybox", "cat", "/etc/hostname")
 
@@ -820,6 +884,7 @@ func (s *DockerSuite) TestRunModeHostname(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunRootWorkdir(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--workdir", "/", "busybox", "pwd")
 	if out != "/\n" {
 		c.Fatalf("pwd returned %q (expected /\\n)", s)
@@ -827,10 +892,12 @@ func (s *DockerSuite) TestRunRootWorkdir(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunAllowBindMountingRoot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-v", "/:/host", "busybox", "ls", "/host")
 }
 
 func (s *DockerSuite) TestRunDisallowBindMountingRootToRoot(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "-v", "/:/", "busybox", "ls", "/host")
 	if err == nil {
 		c.Fatal(out, err)
@@ -839,7 +906,7 @@ func (s *DockerSuite) TestRunDisallowBindMountingRootToRoot(c *check.C) {
 
 // Verify that a container gets default DNS when only localhost resolvers exist
 func (s *DockerSuite) TestRunDnsDefaultOptions(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	// preserve original resolv.conf for restoring after test
 	origResolvConf, err := ioutil.ReadFile("/etc/resolv.conf")
@@ -872,6 +939,7 @@ func (s *DockerSuite) TestRunDnsDefaultOptions(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunDnsOptions(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, stderr, _ := dockerCmdWithStdoutStderr(c, "run", "--dns=127.0.0.1", "--dns-search=mydomain", "busybox", "cat", "/etc/resolv.conf")
 
 	// The client will get a warning on stderr when setting DNS to a localhost address; verify this:
@@ -893,7 +961,7 @@ func (s *DockerSuite) TestRunDnsOptions(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunDnsOptionsBasedOnHostResolvConf(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	origResolvConf, err := ioutil.ReadFile("/etc/resolv.conf")
 	if os.IsNotExist(err) {
@@ -975,7 +1043,7 @@ func (s *DockerSuite) TestRunDnsOptionsBasedOnHostResolvConf(c *check.C) {
 // Test to see if a non-root user can resolve a DNS name and reach out to it. Also
 // check if the container resolv.conf file has at least 0644 perm.
 func (s *DockerSuite) TestRunNonRootUserResolvName(c *check.C) {
-	testRequires(c, SameHostDaemon, Network)
+	testRequires(c, SameHostDaemon, Network, DaemonIsLinux)
 
 	dockerCmd(c, "run", "--name=testperm", "--user=default", "busybox", "ping", "-c", "1", "apt.dockerproject.org")
 
@@ -999,7 +1067,7 @@ func (s *DockerSuite) TestRunNonRootUserResolvName(c *check.C) {
 // if host /etc/resolv.conf has changed. This only applies if the container
 // uses the host's /etc/resolv.conf and does not have any dns options provided.
 func (s *DockerSuite) TestRunResolvconfUpdate(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	tmpResolvConf := []byte("search pommesfrites.fr\nnameserver 12.34.56.78\n")
 	tmpLocalhostResolvConf := []byte("nameserver 127.0.0.1")
@@ -1178,6 +1246,7 @@ func (s *DockerSuite) TestRunResolvconfUpdate(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunAddHost(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--add-host=extra:86.75.30.9", "busybox", "grep", "extra", "/etc/hosts")
 
 	actual := strings.Trim(out, "\r\n")
@@ -1188,6 +1257,7 @@ func (s *DockerSuite) TestRunAddHost(c *check.C) {
 
 // Regression test for #6983
 func (s *DockerSuite) TestRunAttachStdErrOnlyTTYMode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	_, exitCode := dockerCmd(c, "run", "-t", "-a", "stderr", "busybox", "true")
 	if exitCode != 0 {
 		c.Fatalf("Container should have exited with error code 0")
@@ -1196,6 +1266,7 @@ func (s *DockerSuite) TestRunAttachStdErrOnlyTTYMode(c *check.C) {
 
 // Regression test for #6983
 func (s *DockerSuite) TestRunAttachStdOutOnlyTTYMode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	_, exitCode := dockerCmd(c, "run", "-t", "-a", "stdout", "busybox", "true")
 	if exitCode != 0 {
 		c.Fatalf("Container should have exited with error code 0")
@@ -1204,6 +1275,7 @@ func (s *DockerSuite) TestRunAttachStdOutOnlyTTYMode(c *check.C) {
 
 // Regression test for #6983
 func (s *DockerSuite) TestRunAttachStdOutAndErrTTYMode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	_, exitCode := dockerCmd(c, "run", "-t", "-a", "stdout", "-a", "stderr", "busybox", "true")
 	if exitCode != 0 {
 		c.Fatalf("Container should have exited with error code 0")
@@ -1213,6 +1285,7 @@ func (s *DockerSuite) TestRunAttachStdOutAndErrTTYMode(c *check.C) {
 // Test for #10388 - this will run the same test as TestRunAttachStdOutAndErrTTYMode
 // but using --attach instead of -a to make sure we read the flag correctly
 func (s *DockerSuite) TestRunAttachWithDetach(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cmd := exec.Command(dockerBinary, "run", "-d", "--attach", "stdout", "busybox", "true")
 	_, stderr, _, err := runCommandWithStdoutStderr(cmd)
 	if err == nil {
@@ -1223,6 +1296,7 @@ func (s *DockerSuite) TestRunAttachWithDetach(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunState(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 
 	id := strings.TrimSpace(out)
@@ -1264,6 +1338,7 @@ func (s *DockerSuite) TestRunState(c *check.C) {
 
 // Test for #1737
 func (s *DockerSuite) TestRunCopyVolumeUidGid(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testrunvolumesuidgid"
 	_, err := buildImage(name,
 		`FROM busybox
@@ -1285,6 +1360,7 @@ func (s *DockerSuite) TestRunCopyVolumeUidGid(c *check.C) {
 
 // Test for #1582
 func (s *DockerSuite) TestRunCopyVolumeContent(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testruncopyvolumecontent"
 	_, err := buildImage(name,
 		`FROM busybox
@@ -1302,6 +1378,7 @@ func (s *DockerSuite) TestRunCopyVolumeContent(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCleanupCmdOnEntrypoint(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testrunmdcleanuponentrypoint"
 	if _, err := buildImage(name,
 		`FROM busybox
@@ -1323,6 +1400,7 @@ func (s *DockerSuite) TestRunCleanupCmdOnEntrypoint(c *check.C) {
 
 // TestRunWorkdirExistsAndIsFile checks that if 'docker run -w' with existing file can be detected
 func (s *DockerSuite) TestRunWorkdirExistsAndIsFile(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, exit, err := dockerCmdWithError("run", "-w", "/bin/cat", "busybox")
 	if !(err != nil && exit == 1 && strings.Contains(out, "Cannot mkdir: /bin/cat is not a directory")) {
 		c.Fatalf("Docker must complains about making dir, but we got out: %s, exit: %d, err: %s", out, exit, err)
@@ -1330,6 +1408,7 @@ func (s *DockerSuite) TestRunWorkdirExistsAndIsFile(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunExitOnStdinClose(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "testrunexitonstdinclose"
 	runCmd := exec.Command(dockerBinary, "run", "--name", name, "-i", "busybox", "/bin/cat")
 
@@ -1382,6 +1461,7 @@ func (s *DockerSuite) TestRunExitOnStdinClose(c *check.C) {
 
 // Test for #2267
 func (s *DockerSuite) TestRunWriteHostsFileAndNotCommit(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "writehosts"
 	out, _ := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo test2267 >> /etc/hosts && cat /etc/hosts")
 	if !strings.Contains(out, "test2267") {
@@ -1422,6 +1502,7 @@ func sliceEq(a, b []string) bool {
 
 // Test for #2267
 func (s *DockerSuite) TestRunWriteHostnameFileAndNotCommit(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "writehostname"
 	out, _ := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo test2267 >> /etc/hostname && cat /etc/hostname")
 	if !strings.Contains(out, "test2267") {
@@ -1436,6 +1517,7 @@ func (s *DockerSuite) TestRunWriteHostnameFileAndNotCommit(c *check.C) {
 
 // Test for #2267
 func (s *DockerSuite) TestRunWriteResolvFileAndNotCommit(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "writeresolv"
 	out, _ := dockerCmd(c, "run", "--name", name, "busybox", "sh", "-c", "echo test2267 >> /etc/resolv.conf && cat /etc/resolv.conf")
 	if !strings.Contains(out, "test2267") {
@@ -1449,6 +1531,7 @@ func (s *DockerSuite) TestRunWriteResolvFileAndNotCommit(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunWithBadDevice(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "baddevice"
 	out, _, err := dockerCmdWithError("run", "--name", name, "--device", "/etc", "busybox", "true")
 
@@ -1462,6 +1545,7 @@ func (s *DockerSuite) TestRunWithBadDevice(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunEntrypoint(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "entrypoint"
 	out, _ := dockerCmd(c, "run", "--name", name, "--entrypoint", "/bin/echo", "busybox", "-n", "foobar")
 
@@ -1472,6 +1556,7 @@ func (s *DockerSuite) TestRunEntrypoint(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunBindMounts(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 
 	tmpDir, err := ioutil.TempDir("", "docker-test-container")
@@ -1511,6 +1596,7 @@ func (s *DockerSuite) TestRunBindMounts(c *check.C) {
 // Ensure that CIDFile gets deleted if it's empty
 // Perform this test by making `docker run` fail
 func (s *DockerSuite) TestRunCidFileCleanupIfEmpty(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	tmpDir, err := ioutil.TempDir("", "TestRunCidFile")
 	if err != nil {
 		c.Fatal(err)
@@ -1534,6 +1620,7 @@ func (s *DockerSuite) TestRunCidFileCleanupIfEmpty(c *check.C) {
 //sudo docker run --cidfile /tmp/docker_tesc.cid ubuntu echo "test"
 // TestRunCidFile tests that run --cidfile returns the longid
 func (s *DockerSuite) TestRunCidFileCheckIDLength(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	tmpDir, err := ioutil.TempDir("", "TestRunCidFile")
 	if err != nil {
 		c.Fatal(err)
@@ -1558,6 +1645,7 @@ func (s *DockerSuite) TestRunCidFileCheckIDLength(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunSetMacAddress(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	mac := "12:34:56:78:9a:bc"
 
 	out, _ := dockerCmd(c, "run", "-i", "--rm", fmt.Sprintf("--mac-address=%s", mac), "busybox", "/bin/sh", "-c", "ip link show eth0 | tail -1 | awk '{print $2}'")
@@ -1569,6 +1657,7 @@ func (s *DockerSuite) TestRunSetMacAddress(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunInspectMacAddress(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	mac := "12:34:56:78:9a:bc"
 	out, _ := dockerCmd(c, "run", "-d", "--mac-address="+mac, "busybox", "top")
 
@@ -1582,6 +1671,7 @@ func (s *DockerSuite) TestRunInspectMacAddress(c *check.C) {
 
 // test docker run use a invalid mac address
 func (s *DockerSuite) TestRunWithInvalidMacAddress(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "--mac-address", "92:d0:c6:0a:29", "busybox")
 	//use a invalid mac address should with a error out
 	if err == nil || !strings.Contains(out, "is not a valid mac address") {
@@ -1590,7 +1680,7 @@ func (s *DockerSuite) TestRunWithInvalidMacAddress(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunDeallocatePortOnMissingIptablesRule(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "run", "-d", "-p", "23:23", "busybox", "top")
 
@@ -1611,7 +1701,7 @@ func (s *DockerSuite) TestRunDeallocatePortOnMissingIptablesRule(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunPortInUse(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	port := "1234"
 	dockerCmd(c, "run", "-d", "-p", port+":80", "busybox", "top")
@@ -1627,6 +1717,7 @@ func (s *DockerSuite) TestRunPortInUse(c *check.C) {
 
 // https://github.com/docker/docker/issues/12148
 func (s *DockerSuite) TestRunAllocatePortInReservedRange(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// allocate a dynamic port to get the most recent
 	out, _ := dockerCmd(c, "run", "-d", "-P", "-p", "80", "busybox", "top")
 
@@ -1646,7 +1737,7 @@ func (s *DockerSuite) TestRunAllocatePortInReservedRange(c *check.C) {
 
 // Regression test for #7792
 func (s *DockerSuite) TestRunMountOrdering(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	tmpDir, err := ioutil.TempDir("", "docker_nested_mount_test")
 	if err != nil {
@@ -1689,7 +1780,7 @@ func (s *DockerSuite) TestRunMountOrdering(c *check.C) {
 
 // Regression test for https://github.com/docker/docker/issues/8259
 func (s *DockerSuite) TestRunReuseBindVolumeThatIsSymlink(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "testlink")
 	if err != nil {
@@ -1713,6 +1804,7 @@ func (s *DockerSuite) TestRunReuseBindVolumeThatIsSymlink(c *check.C) {
 
 //GH#10604: Test an "/etc" volume doesn't overlay special bind mounts in container
 func (s *DockerSuite) TestRunCreateVolumeEtc(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--dns=127.0.0.1", "-v", "/etc", "busybox", "cat", "/etc/resolv.conf")
 	if !strings.Contains(out, "nameserver 127.0.0.1") {
 		c.Fatal("/etc volume mount hides /etc/resolv.conf")
@@ -1731,6 +1823,7 @@ func (s *DockerSuite) TestRunCreateVolumeEtc(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumesNoCopyData(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if _, err := buildImage("dataimage",
 		`FROM busybox
 		RUN mkdir -p /foo
@@ -1765,6 +1858,7 @@ func (s *DockerSuite) TestRunNoOutputFromPullInStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunVolumesCleanPaths(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if _, err := buildImage("run_volumes_clean_paths",
 		`FROM busybox
 		VOLUME /foo/`,
@@ -1799,6 +1893,7 @@ func (s *DockerSuite) TestRunVolumesCleanPaths(c *check.C) {
 
 // Regression test for #3631
 func (s *DockerSuite) TestRunSlowStdoutConsumer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	cont := exec.Command(dockerBinary, "run", "--rm", "busybox", "/bin/sh", "-c", "dd if=/dev/zero of=/dev/stdout bs=1024 count=2000 | catv")
 
 	stdout, err := cont.StdoutPipe()
@@ -1821,6 +1916,7 @@ func (s *DockerSuite) TestRunSlowStdoutConsumer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunAllowPortRangeThroughExpose(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "--expose", "3000-3003", "-P", "busybox", "top")
 
 	id := strings.TrimSpace(out)
@@ -1843,6 +1939,7 @@ func (s *DockerSuite) TestRunAllowPortRangeThroughExpose(c *check.C) {
 
 // test docker run expose a invalid port
 func (s *DockerSuite) TestRunExposePort(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "--expose", "80000", "busybox")
 	//expose a invalid port should with a error out
 	if err == nil || !strings.Contains(out, "Invalid range format for --expose") {
@@ -1851,7 +1948,7 @@ func (s *DockerSuite) TestRunExposePort(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunUnknownCommand(c *check.C) {
-	testRequires(c, NativeExecDriver)
+	testRequires(c, NativeExecDriver, DaemonIsLinux)
 	out, _, _ := dockerCmdWithStdoutStderr(c, "create", "busybox", "/bin/nada")
 
 	cID := strings.TrimSpace(out)
@@ -1866,7 +1963,7 @@ func (s *DockerSuite) TestRunUnknownCommand(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunModeIpcHost(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	hostIpc, err := os.Readlink("/proc/1/ns/ipc")
 	if err != nil {
@@ -1887,7 +1984,7 @@ func (s *DockerSuite) TestRunModeIpcHost(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunModeIpcContainer(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 
@@ -1913,6 +2010,7 @@ func (s *DockerSuite) TestRunModeIpcContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunModeIpcContainerNotExists(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "-d", "--ipc", "container:abcd1234", "busybox", "top")
 	if !strings.Contains(out, "abcd1234") || err == nil {
 		c.Fatalf("run IPC from a non exists container should with correct error out")
@@ -1920,7 +2018,7 @@ func (s *DockerSuite) TestRunModeIpcContainerNotExists(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunModeIpcContainerNotRunning(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "create", "busybox")
 
@@ -1932,7 +2030,7 @@ func (s *DockerSuite) TestRunModeIpcContainerNotRunning(c *check.C) {
 }
 
 func (s *DockerSuite) TestContainerNetworkMode(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
@@ -1953,7 +2051,7 @@ func (s *DockerSuite) TestContainerNetworkMode(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunModePidHost(c *check.C) {
-	testRequires(c, NativeExecDriver, SameHostDaemon)
+	testRequires(c, NativeExecDriver, SameHostDaemon, DaemonIsLinux)
 
 	hostPid, err := os.Readlink("/proc/1/ns/pid")
 	if err != nil {
@@ -1974,7 +2072,7 @@ func (s *DockerSuite) TestRunModePidHost(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunModeUTSHost(c *check.C) {
-	testRequires(c, NativeExecDriver, SameHostDaemon)
+	testRequires(c, NativeExecDriver, SameHostDaemon, DaemonIsLinux)
 
 	hostUTS, err := os.Readlink("/proc/1/ns/uts")
 	if err != nil {
@@ -1995,6 +2093,7 @@ func (s *DockerSuite) TestRunModeUTSHost(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunTLSverify(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if out, code, err := dockerCmdWithError("ps"); err != nil || code != 0 {
 		c.Fatalf("Should have worked: %v:\n%v", err, out)
 	}
@@ -2013,6 +2112,7 @@ func (s *DockerSuite) TestRunTLSverify(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunPortFromDockerRangeInUse(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// first find allocator current position
 	out, _ := dockerCmd(c, "run", "-d", "-p", ":80", "busybox", "top")
 
@@ -2042,6 +2142,7 @@ func (s *DockerSuite) TestRunPortFromDockerRangeInUse(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunTtyWithPipe(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	errChan := make(chan error)
 	go func() {
 		defer close(errChan)
@@ -2071,6 +2172,7 @@ func (s *DockerSuite) TestRunTtyWithPipe(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunNonLocalMacAddress(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	addr := "00:16:3E:08:00:50"
 
 	if out, _ := dockerCmd(c, "run", "--mac-address", addr, "busybox", "ifconfig"); !strings.Contains(out, addr) {
@@ -2079,7 +2181,7 @@ func (s *DockerSuite) TestRunNonLocalMacAddress(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunNetHost(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	hostNet, err := os.Readlink("/proc/1/ns/net")
 	if err != nil {
@@ -2100,14 +2202,14 @@ func (s *DockerSuite) TestRunNetHost(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunNetHostTwiceSameName(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	dockerCmd(c, "run", "--rm", "--name=thost", "--net=host", "busybox", "true")
 	dockerCmd(c, "run", "--rm", "--name=thost", "--net=host", "busybox", "true")
 }
 
 func (s *DockerSuite) TestRunNetContainerWhichHost(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	hostNet, err := os.Readlink("/proc/1/ns/net")
 	if err != nil {
@@ -2124,6 +2226,7 @@ func (s *DockerSuite) TestRunNetContainerWhichHost(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunAllowPortRangeThroughPublish(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "--expose", "3000-3003", "-p", "3000-3003", "busybox", "top")
 
 	id := strings.TrimSpace(out)
@@ -2144,6 +2247,7 @@ func (s *DockerSuite) TestRunAllowPortRangeThroughPublish(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunSetDefaultRestartPolicy(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "test", "busybox", "top")
 
 	out, err := inspectField("test", "HostConfig.RestartPolicy.Name")
@@ -2154,6 +2258,7 @@ func (s *DockerSuite) TestRunSetDefaultRestartPolicy(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunRestartMaxRetries(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "--restart=on-failure:3", "busybox", "false")
 
 	id := strings.TrimSpace(string(out))
@@ -2175,11 +2280,12 @@ func (s *DockerSuite) TestRunRestartMaxRetries(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunContainerWithWritableRootfs(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--rm", "busybox", "touch", "/file")
 }
 
 func (s *DockerSuite) TestRunContainerWithReadonlyRootfs(c *check.C) {
-	testRequires(c, NativeExecDriver)
+	testRequires(c, NativeExecDriver, DaemonIsLinux)
 
 	for _, f := range []string{"/file", "/etc/hosts", "/etc/resolv.conf", "/etc/hostname", "/sys/kernel", "/dev/.dont.touch.me"} {
 		testReadOnlyFile(f, c)
@@ -2187,6 +2293,7 @@ func (s *DockerSuite) TestRunContainerWithReadonlyRootfs(c *check.C) {
 }
 
 func (s *DockerSuite) TestPermissionsPtsReadonlyRootfs(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, NativeExecDriver)
 
 	// Ensure we have not broken writing /dev/pts
@@ -2201,7 +2308,7 @@ func (s *DockerSuite) TestPermissionsPtsReadonlyRootfs(c *check.C) {
 }
 
 func testReadOnlyFile(filename string, c *check.C) {
-	testRequires(c, NativeExecDriver)
+	testRequires(c, NativeExecDriver, DaemonIsLinux)
 
 	out, _, err := dockerCmdWithError("run", "--read-only", "--rm", "busybox", "touch", filename)
 	if err == nil {
@@ -2223,7 +2330,7 @@ func testReadOnlyFile(filename string, c *check.C) {
 }
 
 func (s *DockerSuite) TestRunContainerWithReadonlyEtcHostsAndLinkedContainer(c *check.C) {
-	testRequires(c, NativeExecDriver)
+	testRequires(c, NativeExecDriver, DaemonIsLinux)
 
 	dockerCmd(c, "run", "-d", "--name", "test-etc-hosts-ro-linked", "busybox", "top")
 
@@ -2234,7 +2341,7 @@ func (s *DockerSuite) TestRunContainerWithReadonlyEtcHostsAndLinkedContainer(c *
 }
 
 func (s *DockerSuite) TestRunContainerWithReadonlyRootfsWithDnsFlag(c *check.C) {
-	testRequires(c, NativeExecDriver)
+	testRequires(c, NativeExecDriver, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "run", "--read-only", "--dns", "1.1.1.1", "busybox", "/bin/cat", "/etc/resolv.conf")
 	if !strings.Contains(string(out), "1.1.1.1") {
@@ -2243,7 +2350,7 @@ func (s *DockerSuite) TestRunContainerWithReadonlyRootfsWithDnsFlag(c *check.C) 
 }
 
 func (s *DockerSuite) TestRunContainerWithReadonlyRootfsWithAddHostFlag(c *check.C) {
-	testRequires(c, NativeExecDriver)
+	testRequires(c, NativeExecDriver, DaemonIsLinux)
 
 	out, _ := dockerCmd(c, "run", "--read-only", "--add-host", "testreadonly:127.0.0.1", "busybox", "/bin/cat", "/etc/hosts")
 	if !strings.Contains(string(out), "testreadonly") {
@@ -2252,6 +2359,7 @@ func (s *DockerSuite) TestRunContainerWithReadonlyRootfsWithAddHostFlag(c *check
 }
 
 func (s *DockerSuite) TestRunVolumesFromRestartAfterRemoved(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "voltest", "-v", "/foo", "busybox")
 	dockerCmd(c, "run", "-d", "--name", "restarter", "--volumes-from", "voltest", "busybox", "top")
 
@@ -2264,6 +2372,7 @@ func (s *DockerSuite) TestRunVolumesFromRestartAfterRemoved(c *check.C) {
 
 // run container with --rm should remove container if exit code != 0
 func (s *DockerSuite) TestRunContainerWithRmFlagExitCodeNotEqualToZero(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "flowers"
 	out, _, err := dockerCmdWithError("run", "--name", name, "--rm", "busybox", "ls", "/notexists")
 	if err == nil {
@@ -2281,6 +2390,7 @@ func (s *DockerSuite) TestRunContainerWithRmFlagExitCodeNotEqualToZero(c *check.
 }
 
 func (s *DockerSuite) TestRunContainerWithRmFlagCannotStartContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "sparkles"
 	out, _, err := dockerCmdWithError("run", "--name", name, "--rm", "busybox", "commandNotFound")
 	if err == nil {
@@ -2298,6 +2408,7 @@ func (s *DockerSuite) TestRunContainerWithRmFlagCannotStartContainer(c *check.C)
 }
 
 func (s *DockerSuite) TestRunPidHostWithChildIsKillable(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "ibuildthecloud"
 	dockerCmd(c, "run", "-d", "--pid=host", "--name", name, "busybox", "sh", "-c", "sleep 30; echo hi")
 
@@ -2319,6 +2430,7 @@ func (s *DockerSuite) TestRunPidHostWithChildIsKillable(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunWithTooSmallMemoryLimit(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// this memory limit is 1 byte less than the min, which is 4MB
 	// https://github.com/docker/docker/blob/v1.5.0/daemon/create.go#L22
 	out, _, err := dockerCmdWithError("run", "-m", "4194303", "busybox")
@@ -2328,6 +2440,7 @@ func (s *DockerSuite) TestRunWithTooSmallMemoryLimit(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunWriteToProcAsound(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	_, code, err := dockerCmdWithError("run", "busybox", "sh", "-c", "echo 111 >> /proc/asound/version")
 	if err == nil || code == 0 {
 		c.Fatal("standard container should not be able to write to /proc/asound")
@@ -2335,7 +2448,7 @@ func (s *DockerSuite) TestRunWriteToProcAsound(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunReadProcTimer(c *check.C) {
-	testRequires(c, NativeExecDriver)
+	testRequires(c, NativeExecDriver, DaemonIsLinux)
 	out, code, err := dockerCmdWithError("run", "busybox", "cat", "/proc/timer_stats")
 	if code != 0 {
 		return
@@ -2349,7 +2462,7 @@ func (s *DockerSuite) TestRunReadProcTimer(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunReadProcLatency(c *check.C) {
-	testRequires(c, NativeExecDriver)
+	testRequires(c, NativeExecDriver, DaemonIsLinux)
 	// some kernels don't have this configured so skip the test if this file is not found
 	// on the host running the tests.
 	if _, err := os.Stat("/proc/latency_stats"); err != nil {
@@ -2369,7 +2482,7 @@ func (s *DockerSuite) TestRunReadProcLatency(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunReadFilteredProc(c *check.C) {
-	testRequires(c, Apparmor)
+	testRequires(c, Apparmor, DaemonIsLinux)
 
 	testReadPaths := []string{
 		"/proc/latency_stats",
@@ -2391,6 +2504,7 @@ func (s *DockerSuite) TestRunReadFilteredProc(c *check.C) {
 }
 
 func (s *DockerSuite) TestMountIntoProc(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, NativeExecDriver)
 	_, code, err := dockerCmdWithError("run", "-v", "/proc//sys", "busybox", "true")
 	if err == nil || code == 0 {
@@ -2399,12 +2513,13 @@ func (s *DockerSuite) TestMountIntoProc(c *check.C) {
 }
 
 func (s *DockerSuite) TestMountIntoSys(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, NativeExecDriver)
 	dockerCmd(c, "run", "-v", "/sys/fs/cgroup", "busybox", "true")
 }
 
 func (s *DockerSuite) TestRunUnshareProc(c *check.C) {
-	testRequires(c, Apparmor, NativeExecDriver)
+	testRequires(c, Apparmor, NativeExecDriver, DaemonIsLinux)
 
 	name := "acidburn"
 	if out, _, err := dockerCmdWithError("run", "--name", name, "jess/unshare", "unshare", "-p", "-m", "-f", "-r", "--mount-proc=/proc", "mount"); err == nil || !strings.Contains(out, "Permission denied") {
@@ -2424,6 +2539,7 @@ func (s *DockerSuite) TestRunUnshareProc(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunPublishPort(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "test", "--expose", "8080", "busybox", "top")
 	out, _ := dockerCmd(c, "port", "test")
 	out = strings.Trim(out, "\r\n")
@@ -2434,6 +2550,7 @@ func (s *DockerSuite) TestRunPublishPort(c *check.C) {
 
 // Issue #10184.
 func (s *DockerSuite) TestDevicePermissions(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, NativeExecDriver)
 	const permissions = "crw-rw-rw-"
 	out, status := dockerCmd(c, "run", "--device", "/dev/fuse:/dev/fuse:mrw", "busybox:latest", "ls", "-l", "/dev/fuse")
@@ -2446,6 +2563,7 @@ func (s *DockerSuite) TestDevicePermissions(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapAddCHOWN(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, NativeExecDriver)
 	out, _ := dockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=CHOWN", "busybox", "sh", "-c", "adduser -D -H newuser && chown newuser /home && echo ok")
 
@@ -2456,6 +2574,7 @@ func (s *DockerSuite) TestRunCapAddCHOWN(c *check.C) {
 
 // https://github.com/docker/docker/pull/14498
 func (s *DockerSuite) TestVolumeFromMixedRWOptions(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "parent", "-v", "/test", "busybox", "true")
 	dockerCmd(c, "run", "--volumes-from", "parent:ro", "--name", "test-volumes-1", "busybox", "true")
 	dockerCmd(c, "run", "--volumes-from", "parent:rw", "--name", "test-volumes-2", "busybox", "true")
@@ -2474,7 +2593,7 @@ func (s *DockerSuite) TestVolumeFromMixedRWOptions(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunWriteFilteredProc(c *check.C) {
-	testRequires(c, Apparmor, NativeExecDriver)
+	testRequires(c, Apparmor, NativeExecDriver, DaemonIsLinux)
 
 	testWritePaths := []string{
 		/* modprobe and core_pattern should both be denied by generic
@@ -2500,7 +2619,7 @@ func (s *DockerSuite) TestRunWriteFilteredProc(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunNetworkFilesBindMount(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	expected := "test123"
 
@@ -2518,7 +2637,7 @@ func (s *DockerSuite) TestRunNetworkFilesBindMount(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunNetworkFilesBindMountRO(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	filename := createTmpFile(c, "test123")
 	defer os.Remove(filename)
@@ -2534,7 +2653,7 @@ func (s *DockerSuite) TestRunNetworkFilesBindMountRO(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunNetworkFilesBindMountROFilesystem(c *check.C) {
-	testRequires(c, SameHostDaemon)
+	testRequires(c, SameHostDaemon, DaemonIsLinux)
 
 	filename := createTmpFile(c, "test123")
 	defer os.Remove(filename)
@@ -2557,6 +2676,7 @@ func (s *DockerSuite) TestRunNetworkFilesBindMountROFilesystem(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedRun(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	repoName := s.setupTrustedImage(c, "trusted-run")
 
 	// Try run
@@ -2587,6 +2707,7 @@ func (s *DockerTrustSuite) TestTrustedRun(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestUntrustedRun(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	repoName := fmt.Sprintf("%v/dockercli/trusted:latest", privateRegistryURL)
 	// tag the image and upload it to the private registry
 	dockerCmd(c, "tag", "busybox", repoName)
@@ -2607,6 +2728,7 @@ func (s *DockerTrustSuite) TestUntrustedRun(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestRunWhenCertExpired(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	c.Skip("Currently changes system time, causing instability")
 	repoName := s.setupTrustedImage(c, "trusted-run-expired")
 
@@ -2643,6 +2765,7 @@ func (s *DockerTrustSuite) TestRunWhenCertExpired(c *check.C) {
 }
 
 func (s *DockerTrustSuite) TestTrustedRunFromBadTrustServer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	repoName := fmt.Sprintf("%v/dockerclievilrun/trusted:latest", privateRegistryURL)
 	evilLocalConfigDir, err := ioutil.TempDir("", "evil-local-config-dir")
 	if err != nil {
@@ -2714,6 +2837,7 @@ func (s *DockerTrustSuite) TestTrustedRunFromBadTrustServer(c *check.C) {
 }
 
 func (s *DockerSuite) TestPtraceContainerProcsFromHost(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
@@ -2729,7 +2853,7 @@ func (s *DockerSuite) TestPtraceContainerProcsFromHost(c *check.C) {
 }
 
 func (s *DockerSuite) TestAppArmorDeniesPtrace(c *check.C) {
-	testRequires(c, SameHostDaemon, NativeExecDriver, Apparmor)
+	testRequires(c, SameHostDaemon, NativeExecDriver, Apparmor, DaemonIsLinux)
 
 	// Run through 'sh' so we are NOT pid 1. Pid 1 may be able to trace
 	// itself, but pid>1 should not be able to trace pid1.
@@ -2740,6 +2864,7 @@ func (s *DockerSuite) TestAppArmorDeniesPtrace(c *check.C) {
 }
 
 func (s *DockerSuite) TestAppArmorTraceSelf(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, SameHostDaemon)
 	testRequires(c, Apparmor)
 
@@ -2750,7 +2875,7 @@ func (s *DockerSuite) TestAppArmorTraceSelf(c *check.C) {
 }
 
 func (s *DockerSuite) TestAppArmorDeniesChmodProc(c *check.C) {
-	testRequires(c, SameHostDaemon, NativeExecDriver, Apparmor)
+	testRequires(c, SameHostDaemon, NativeExecDriver, Apparmor, DaemonIsLinux)
 	_, exitCode, _ := dockerCmdWithError("run", "busybox", "chmod", "744", "/proc/cpuinfo")
 	if exitCode == 0 {
 		// If our test failed, attempt to repair the host system...
@@ -2762,6 +2887,7 @@ func (s *DockerSuite) TestAppArmorDeniesChmodProc(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunCapAddSYSTIME(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	testRequires(c, NativeExecDriver)
 
 	dockerCmd(c, "run", "--cap-drop=ALL", "--cap-add=SYS_TIME", "busybox", "sh", "-c", "grep ^CapEff /proc/self/status | sed 's/^CapEff:\t//' | grep ^0000000002000000$")
@@ -2769,6 +2895,7 @@ func (s *DockerSuite) TestRunCapAddSYSTIME(c *check.C) {
 
 // run create container failed should clean up the container
 func (s *DockerSuite) TestRunCreateContainerFailedCleanUp(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "unique_name"
 	_, _, err := dockerCmdWithError("run", "--name", name, "--link", "nothing:nothing", "busybox")
 	c.Assert(err, check.Not(check.IsNil), check.Commentf("Expected docker run to fail!"))
@@ -2778,6 +2905,7 @@ func (s *DockerSuite) TestRunCreateContainerFailedCleanUp(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunNamedVolume(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name=test", "-v", "testing:/foo", "busybox", "sh", "-c", "echo hello > /foo/bar")
 
 	out, _ := dockerCmd(c, "run", "--volumes-from", "test", "busybox", "sh", "-c", "cat /foo/bar")
@@ -2869,6 +2997,7 @@ func (s *DockerSuite) TestRunContainerWithCgroupMountRO(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunContainerNetworkModeToSelf(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "--name=me", "--net=container:me", "busybox", "true")
 	if err == nil || !strings.Contains(out, "cannot join own network") {
 		c.Fatalf("using container net mode to self should result in an error")
@@ -2876,6 +3005,7 @@ func (s *DockerSuite) TestRunContainerNetworkModeToSelf(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunContainerNetModeWithDnsMacHosts(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "-d", "--name", "parent", "busybox", "top")
 	if err != nil {
 		c.Fatalf("failed to run container: %v, output: %q", err, out)
@@ -2898,6 +3028,7 @@ func (s *DockerSuite) TestRunContainerNetModeWithDnsMacHosts(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunContainerNetModeWithExposePort(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "parent", "busybox", "top")
 
 	out, _, err := dockerCmdWithError("run", "-p", "5000:5000", "--net=container:parent", "busybox")
@@ -2917,6 +3048,7 @@ func (s *DockerSuite) TestRunContainerNetModeWithExposePort(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunLinkToContainerNetMode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--name", "test", "-d", "busybox", "top")
 	dockerCmd(c, "run", "--name", "parent", "-d", "--net=container:test", "busybox", "top")
 	dockerCmd(c, "run", "-d", "--link=parent:parent", "busybox", "top")
@@ -2925,6 +3057,7 @@ func (s *DockerSuite) TestRunLinkToContainerNetMode(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunLoopbackOnlyExistsWhenNetworkingDisabled(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--net=none", "busybox", "ip", "-o", "-4", "a", "show", "up")
 
 	var (
@@ -2949,11 +3082,12 @@ func (s *DockerSuite) TestRunLoopbackOnlyExistsWhenNetworkingDisabled(c *check.C
 
 // Issue #4681
 func (s *DockerSuite) TestRunLoopbackWhenNetworkDisabled(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "--net=none", "busybox", "ping", "-c", "1", "127.0.0.1")
 }
 
 func (s *DockerSuite) TestRunModeNetContainerHostname(c *check.C) {
-	testRequires(c, ExecSupport)
+	testRequires(c, DaemonIsLinux, ExecSupport)
 
 	dockerCmd(c, "run", "-i", "-d", "--name", "parent", "busybox", "top")
 	out, _ := dockerCmd(c, "exec", "parent", "cat", "/etc/hostname")
@@ -2965,6 +3099,7 @@ func (s *DockerSuite) TestRunModeNetContainerHostname(c *check.C) {
 }
 
 func (s *DockerSuite) TestRunNetworkNotInitializedNoneMode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, err := dockerCmdWithError("run", "-d", "--net=none", "busybox", "top")
 	id := strings.TrimSpace(out)
 	res, err := inspectField(id, "NetworkSettings.IPAddress")
@@ -2975,6 +3110,7 @@ func (s *DockerSuite) TestRunNetworkNotInitializedNoneMode(c *check.C) {
 }
 
 func (s *DockerSuite) TestTwoContainersInNetHost(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--net=host", "--name=first", "busybox", "top")
 	dockerCmd(c, "run", "-d", "--net=host", "--name=second", "busybox", "top")
 	dockerCmd(c, "stop", "first")

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -15,6 +15,7 @@ import (
 
 // save a repo using gz compression and try to load it using stdout
 func (s *DockerSuite) TestSaveXzAndLoadRepoStdout(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-save-xz-and-load-repo-stdout"
 	dockerCmd(c, "run", "--name", name, "busybox", "true")
 
@@ -47,6 +48,7 @@ func (s *DockerSuite) TestSaveXzAndLoadRepoStdout(c *check.C) {
 
 // save a repo using xz+gz compression and try to load it using stdout
 func (s *DockerSuite) TestSaveXzGzAndLoadRepoStdout(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-save-xz-gz-and-load-repo-stdout"
 	dockerCmd(c, "run", "--name", name, "busybox", "true")
 
@@ -79,6 +81,7 @@ func (s *DockerSuite) TestSaveXzGzAndLoadRepoStdout(c *check.C) {
 }
 
 func (s *DockerSuite) TestSaveSingleTag(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	repoName := "foobar-save-single-tag-test"
 	dockerCmd(c, "tag", "busybox:latest", fmt.Sprintf("%v:latest", repoName))
 
@@ -95,6 +98,7 @@ func (s *DockerSuite) TestSaveSingleTag(c *check.C) {
 }
 
 func (s *DockerSuite) TestSaveImageId(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	repoName := "foobar-save-image-id-test"
 	dockerCmd(c, "tag", "emptyfs:latest", fmt.Sprintf("%v:latest", repoName))
 
@@ -136,6 +140,7 @@ func (s *DockerSuite) TestSaveImageId(c *check.C) {
 
 // save a repo and try to load it using flags
 func (s *DockerSuite) TestSaveAndLoadRepoFlags(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "test-save-and-load-repo-flags"
 	dockerCmd(c, "run", "--name", name, "busybox", "true")
 
@@ -160,6 +165,7 @@ func (s *DockerSuite) TestSaveAndLoadRepoFlags(c *check.C) {
 }
 
 func (s *DockerSuite) TestSaveMultipleNames(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	repoName := "foobar-save-multi-name-test"
 
 	// Make one image
@@ -179,7 +185,7 @@ func (s *DockerSuite) TestSaveMultipleNames(c *check.C) {
 }
 
 func (s *DockerSuite) TestSaveRepoWithMultipleImages(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	makeImage := func(from string, tag string) string {
 		var (
 			out string
@@ -225,6 +231,7 @@ func (s *DockerSuite) TestSaveRepoWithMultipleImages(c *check.C) {
 
 // Issue #6722 #5892 ensure directories are included in changes
 func (s *DockerSuite) TestSaveDirectoryPermissions(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	layerEntries := []string{"opt/", "opt/a/", "opt/a/b/", "opt/a/b/c"}
 	layerEntriesAUFS := []string{"./", ".wh..wh.aufs", ".wh..wh.orph/", ".wh..wh.plnk/", "opt/", "opt/a/", "opt/a/b/", "opt/a/b/c"}
 

--- a/integration-cli/docker_cli_search_test.go
+++ b/integration-cli/docker_cli_search_test.go
@@ -8,7 +8,7 @@ import (
 
 // search for repos named  "registry" on the central registry
 func (s *DockerSuite) TestSearchOnCentralRegistry(c *check.C) {
-	testRequires(c, Network)
+	testRequires(c, Network, DaemonIsLinux)
 
 	out, exitCode := dockerCmd(c, "search", "busybox")
 	if exitCode != 0 {

--- a/integration-cli/docker_cli_start_test.go
+++ b/integration-cli/docker_cli_start_test.go
@@ -10,6 +10,7 @@ import (
 
 // Regression test for https://github.com/docker/docker/issues/7843
 func (s *DockerSuite) TestStartAttachReturnsOnError(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "run", "-d", "--name", "test", "busybox")
 	dockerCmd(c, "wait", "test")
 
@@ -38,6 +39,7 @@ func (s *DockerSuite) TestStartAttachReturnsOnError(c *check.C) {
 
 // gh#8555: Exit code should be passed through when using start -a
 func (s *DockerSuite) TestStartAttachCorrectExitCode(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _, _ := dockerCmdWithStdoutStderr(c, "run", "-d", "busybox", "sh", "-c", "sleep 2; exit 1")
 	out = strings.TrimSpace(out)
 
@@ -55,6 +57,7 @@ func (s *DockerSuite) TestStartAttachCorrectExitCode(c *check.C) {
 }
 
 func (s *DockerSuite) TestStartAttachSilent(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	name := "teststartattachcorrectexitcode"
 	dockerCmd(c, "run", "--name", name, "busybox", "echo", "test")
 
@@ -68,7 +71,7 @@ func (s *DockerSuite) TestStartAttachSilent(c *check.C) {
 }
 
 func (s *DockerSuite) TestStartRecordError(c *check.C) {
-
+	testRequires(c, DaemonIsLinux)
 	// when container runs successfully, we should not have state.Error
 	dockerCmd(c, "run", "-d", "-p", "9999:9999", "--name", "test", "busybox", "top")
 	stateErr, err := inspectField("test", "State.Error")
@@ -101,6 +104,7 @@ func (s *DockerSuite) TestStartRecordError(c *check.C) {
 }
 
 func (s *DockerSuite) TestStartPausedContainer(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	defer unpauseAllContainers()
 
 	dockerCmd(c, "run", "-d", "--name", "testing", "busybox", "top")
@@ -113,6 +117,7 @@ func (s *DockerSuite) TestStartPausedContainer(c *check.C) {
 }
 
 func (s *DockerSuite) TestStartMultipleContainers(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// run a container named 'parent' and create two container link to `parent`
 	dockerCmd(c, "run", "-d", "--name", "parent", "busybox", "top")
 
@@ -147,6 +152,7 @@ func (s *DockerSuite) TestStartMultipleContainers(c *check.C) {
 }
 
 func (s *DockerSuite) TestStartAttachMultipleContainers(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	// run  multiple containers to test
 	for _, container := range []string{"test1", "test2", "test3"} {
 		dockerCmd(c, "run", "-d", "--name", container, "busybox", "top")

--- a/integration-cli/docker_cli_stats_test.go
+++ b/integration-cli/docker_cli_stats_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func (s *DockerSuite) TestCliStatsNoStream(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "top")
 	id := strings.TrimSpace(out)
 	c.Assert(waitRun(id), check.IsNil)

--- a/integration-cli/docker_cli_tag_test.go
+++ b/integration-cli/docker_cli_tag_test.go
@@ -9,6 +9,7 @@ import (
 
 // tagging a named image in a new unprefixed repo should work
 func (s *DockerSuite) TestTagUnprefixedRepoByName(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if err := pullImageIfNotExist("busybox:latest"); err != nil {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
@@ -18,6 +19,7 @@ func (s *DockerSuite) TestTagUnprefixedRepoByName(c *check.C) {
 
 // tagging an image by ID in a new unprefixed repo should work
 func (s *DockerSuite) TestTagUnprefixedRepoByID(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	imageID, err := inspectField("busybox", "Id")
 	c.Assert(err, check.IsNil)
 	dockerCmd(c, "tag", imageID, "testfoobarbaz")
@@ -52,6 +54,7 @@ func (s *DockerSuite) TestTagInvalidPrefixedRepo(c *check.C) {
 
 // ensure we allow the use of valid tags
 func (s *DockerSuite) TestTagValidPrefixedRepo(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if err := pullImageIfNotExist("busybox:latest"); err != nil {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
@@ -70,6 +73,7 @@ func (s *DockerSuite) TestTagValidPrefixedRepo(c *check.C) {
 
 // tag an image with an existed tag name without -f option should fail
 func (s *DockerSuite) TestTagExistedNameWithoutForce(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if err := pullImageIfNotExist("busybox:latest"); err != nil {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
@@ -83,6 +87,7 @@ func (s *DockerSuite) TestTagExistedNameWithoutForce(c *check.C) {
 
 // tag an image with an existed tag name with -f option should work
 func (s *DockerSuite) TestTagExistedNameWithForce(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if err := pullImageIfNotExist("busybox:latest"); err != nil {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
@@ -92,6 +97,7 @@ func (s *DockerSuite) TestTagExistedNameWithForce(c *check.C) {
 }
 
 func (s *DockerSuite) TestTagWithPrefixHyphen(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	if err := pullImageIfNotExist("busybox:latest"); err != nil {
 		c.Fatal("couldn't find the busybox:latest image locally and failed to pull it")
 	}
@@ -115,6 +121,7 @@ func (s *DockerSuite) TestTagWithPrefixHyphen(c *check.C) {
 // ensure tagging using official names works
 // ensure all tags result in the same name
 func (s *DockerSuite) TestTagOfficialNames(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	names := []string{
 		"docker.io/busybox",
 		"index.docker.io/busybox",

--- a/integration-cli/docker_cli_top_test.go
+++ b/integration-cli/docker_cli_top_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func (s *DockerSuite) TestTopMultipleArgs(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-i", "-d", "busybox", "top")
 
 	cleanedContainerID := strings.TrimSpace(out)
@@ -19,6 +20,7 @@ func (s *DockerSuite) TestTopMultipleArgs(c *check.C) {
 }
 
 func (s *DockerSuite) TestTopNonPrivileged(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-i", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 
@@ -37,6 +39,7 @@ func (s *DockerSuite) TestTopNonPrivileged(c *check.C) {
 }
 
 func (s *DockerSuite) TestTopPrivileged(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "--privileged", "-i", "-d", "busybox", "top")
 	cleanedContainerID := strings.TrimSpace(out)
 

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func (s *DockerSuite) TestVolumeCliCreate(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	dockerCmd(c, "volume", "create")
 
 	_, err := runCommand(exec.Command(dockerBinary, "volume", "create", "-d", "nosuchdriver"))
@@ -19,6 +20,7 @@ func (s *DockerSuite) TestVolumeCliCreate(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumeCliInspect(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	c.Assert(
 		exec.Command(dockerBinary, "volume", "inspect", "doesntexist").Run(),
 		check.Not(check.IsNil),
@@ -36,6 +38,7 @@ func (s *DockerSuite) TestVolumeCliInspect(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumeCliLs(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "volume", "create")
 	id := strings.TrimSpace(out)
 
@@ -52,6 +55,7 @@ func (s *DockerSuite) TestVolumeCliLs(c *check.C) {
 }
 
 func (s *DockerSuite) TestVolumeCliRm(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "volume", "create")
 	id := strings.TrimSpace(out)
 

--- a/integration-cli/docker_cli_wait_test.go
+++ b/integration-cli/docker_cli_wait_test.go
@@ -11,6 +11,7 @@ import (
 
 // non-blocking wait with 0 exit code
 func (s *DockerSuite) TestWaitNonBlockedExitZero(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "true")
 	containerID := strings.TrimSpace(out)
 
@@ -27,6 +28,7 @@ func (s *DockerSuite) TestWaitNonBlockedExitZero(c *check.C) {
 
 // blocking wait with 0 exit code
 func (s *DockerSuite) TestWaitBlockedExitZero(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "trap 'exit 0' TERM; while true; do sleep 0.01; done")
 	containerID := strings.TrimSpace(out)
 
@@ -54,6 +56,7 @@ func (s *DockerSuite) TestWaitBlockedExitZero(c *check.C) {
 
 // non-blocking wait with random exit code
 func (s *DockerSuite) TestWaitNonBlockedExitRandom(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "sh", "-c", "exit 99")
 	containerID := strings.TrimSpace(out)
 
@@ -70,6 +73,7 @@ func (s *DockerSuite) TestWaitNonBlockedExitRandom(c *check.C) {
 
 // blocking wait with random exit code
 func (s *DockerSuite) TestWaitBlockedExitRandom(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	out, _ := dockerCmd(c, "run", "-d", "busybox", "/bin/sh", "-c", "trap 'exit 99' TERM; while true; do sleep 0.01; done")
 	containerID := strings.TrimSpace(out)
 	c.Assert(waitRun(containerID), check.IsNil)

--- a/integration-cli/docker_hub_pull_suite_test.go
+++ b/integration-cli/docker_hub_pull_suite_test.go
@@ -37,6 +37,7 @@ func newDockerHubPullSuite() *DockerHubPullSuite {
 
 // SetUpSuite starts the suite daemon.
 func (s *DockerHubPullSuite) SetUpSuite(c *check.C) {
+	testRequires(c, DaemonIsLinux)
 	s.d = NewDaemon(c)
 	if err := s.d.Start(); err != nil {
 		c.Fatalf("starting push/pull test daemon: %v", err)
@@ -45,8 +46,10 @@ func (s *DockerHubPullSuite) SetUpSuite(c *check.C) {
 
 // TearDownSuite stops the suite daemon.
 func (s *DockerHubPullSuite) TearDownSuite(c *check.C) {
-	if err := s.d.Stop(); err != nil {
-		c.Fatalf("stopping push/pull test daemon: %v", err)
+	if s.d != nil {
+		if err := s.d.Stop(); err != nil {
+			c.Fatalf("stopping push/pull test daemon: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@jfrazelle @swernli. This is an initial swag at getting the integration-cli tests running in Windows to Windows (TP3). This is mainly done by adding requirement `DaemonIsLinux` to tests which use base images which don't exist on Windows, or can't be supported on Windows yet (eg scratch, busybox). This is in preparation for a Windows to Windows CI.

We have a new hire who is going to look into how to start enabling chunks of tests on Windows to get better coverage over time.

Local results:

`OK: 39 passed, 761 skipped
--- PASS: Test (118.43s)
PASS
ok      github.com/docker/docker/integration-cli        118.560s`
