### PR TITLE
[aufs] No longer exclude ".wh..wh.*" files in Diff

### DIFF
--- a/daemon/graphdriver/aufs/aufs.go
+++ b/daemon/graphdriver/aufs/aufs.go
@@ -321,8 +321,7 @@ func (a *Driver) Put(id string) error {
 func (a *Driver) Diff(id, parent string) (archive.Archive, error) {
 	// AUFS doesn't need the parent layer to produce a diff.
 	return archive.TarWithOptions(path.Join(a.rootPath(), "diff", id), &archive.TarOptions{
-		Compression:     archive.Uncompressed,
-		ExcludePatterns: []string{".wh..wh.*"},
+		Compression: archive.Uncompressed,
 	})
 }
 


### PR DESCRIPTION
The exclusion of AUFS special files beginning with ".wh..wh." were made about
a year ago in an effort to reduce the differences in filesystem layer diffs
produced by the various storage drivers. While the exclusion of most of these
special files made no difference in behavior of the mounted filesytem, the
loss of ".wh..wh..opq" files did affect behavior of some directories.

A directory which contains a ".wh..wh..opq" file is considered to be "Opaque"
meaning that ReadDir() calls should not include the content of the directory
in any lower layers. An opaque directory is created when you have an AUFS
layer which deletes a directory (which may contain other files and directories)
and then recreate the directory with no contents:

```
rm -rf /dir && mkdir /dir
```

By excluding the ".wh..wh..opq" file from filesystem layer diffs, images made
on a system using the AUFS storage driver which created an opaque directory
would result in that directory no longer being opaque, exposing content of the
old/deleted directory that it replaced.

This patch fixes this bug by removing the now-outdated exclusion of ".wh..wh.*"
files when producing a diff of an AUFS layer. The original problem that this
exclusion addressed was never fully resolved by this exclusion and Docker 1.8
now addresses the problem by storing a manifest of layer tar archive entries to
reliably recreate the contents of a rootfs diff when pushing/pulling to a
docker registry.
