### PR TITLE
Set bind driver after volume is created

### DIFF
--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -64,7 +64,7 @@ func createContainerPlatformSpecificSettings(container *Container, config *runco
 		}
 
 		// never attempt to copy existing content in a container FS to a shared volume
-		if volumeDriver == volume.DefaultDriverName || volumeDriver == "" {
+		if v.DriverName() == volume.DefaultDriverName {
 			if err := container.copyImagePathContent(v, destination); err != nil {
 				return err
 			}

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -342,6 +342,8 @@ func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runc
 			}
 			bind.Volume = v
 			bind.Source = v.Path()
+			// bind.Name is an already existing volume, we need to use that here
+			bind.Driver = v.DriverName()
 			// Since this is just a named volume and not a typical bind, set to shared mode `z`
 			if bind.Mode == "" {
 				bind.Mode = "z"


### PR DESCRIPTION
Fixes #15994
When using a named volume without --volume-driver, the driver was
hardcoded to "local".
Even when the volume was already created by some other driver (and
visible in `docker volume ls`), the container would store in it's own
config that it was the `local` driver.
The external driver would work perfecly fine until the daemon is
restarted, at which point the `local` driver was assumed because that is
as it was set in the container config.

Set the bind driver to the driver returned by createVolume.
