### PR TITLE
Windows: Ensure workdir handled in platform semantics

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -1084,8 +1084,11 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, 
 
 	// First perform verification of settings common across all platforms.
 	if config != nil {
-		if config.WorkingDir != "" && !system.IsAbs(config.WorkingDir) {
-			return nil, fmt.Errorf("The working directory '%s' is invalid. It needs to be an absolute path.", config.WorkingDir)
+		if config.WorkingDir != "" {
+			config.WorkingDir = filepath.FromSlash(config.WorkingDir) // Ensure in platform semantics
+			if !system.IsAbs(config.WorkingDir) {
+				return nil, fmt.Errorf("The working directory '%s' is invalid. It needs to be an absolute path.", config.WorkingDir)
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli. This change ensures that the daemon handles the workdir path using platform specific semantics.
