### PR TITLE
fix 15962 to make the behavior of -v /containerpaht:ro right

### DIFF
--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -21,7 +21,26 @@ func createContainerPlatformSpecificSettings(container *Container, config *runco
 		var (
 			name, destination string
 			parts             = strings.Split(spec, ":")
+			mode              = true
 		)
+
+		switch len(parts) {
+		case 2:
+			if parts[1] == "ro" {
+				mode = false
+				parts = parts[:1]
+			} else if parts[1] == "rw" {
+				parts = parts[:1]
+			}
+		case 3:
+			if parts[2] == "ro" {
+				mode = false
+				parts = parts[:2]
+			} else if parts[2] == "rw" {
+				parts = parts[:2]
+			}
+		}
+
 		switch len(parts) {
 		case 2:
 			name, destination = parts[0], filepath.Clean(parts[1])
@@ -70,7 +89,7 @@ func createContainerPlatformSpecificSettings(container *Container, config *runco
 			}
 		}
 
-		container.addMountPointWithVolume(destination, v, true)
+		container.addMountPointWithVolume(destination, v, mode)
 	}
 	return nil
 }

--- a/integration-cli/docker_cli_run_test.go
+++ b/integration-cli/docker_cli_run_test.go
@@ -198,6 +198,27 @@ func (s *DockerSuite) TestRunWithVolumesFromExited(c *check.C) {
 	}
 }
 
+//test ro and rw volumes for #15962
+func (s *DockerSuite) TestCreateVolumesWithRoAndRwMode(c *check.C) {
+	dockerCmd(c, "run", "-i", "-t", "-d", "--name", "test-ro", "-v", "/test:ro", "busybox")
+
+	out, err := inspectField("test-ro", "Mounts")
+	c.Assert(err, check.IsNil)
+
+	if !strings.Contains(out, "false") {
+		c.Fatalf("create a container with a ro mode volume failed")
+	}
+
+	dockerCmd(c, "run", "-i", "-t", "-d", "--name", "test-rw", "-v", "/test:rw", "busybox")
+
+	out, err = inspectField("test-rw", "Mounts")
+	c.Assert(err, check.IsNil)
+
+	if !strings.Contains(out, "true") {
+		c.Fatalf("create a container with a rw mode volume failed")
+	}
+}
+
 // Volume path is a symlink which also exists on the host, and the host side is a file not a dir
 // But the volume call is just a normal volume, not a bind mount
 func (s *DockerSuite) TestRunCreateVolumesInSymlinkDir(c *check.C) {

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -185,6 +185,10 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 	// add any bind targets to the list of container volumes
 	for bind := range flVolumes.GetMap() {
 		if arr := strings.Split(bind, ":"); len(arr) > 1 {
+			if arr[1] == "ro" && len(arr) == 2 || arr[1] == "rw" && len(arr) == 2 {
+				continue
+			}
+
 			if arr[1] == "/" {
 				return nil, nil, cmd, fmt.Errorf("Invalid bind mount: destination can't be '/'")
 			}

--- a/runconfig/parse_test.go
+++ b/runconfig/parse_test.go
@@ -124,8 +124,12 @@ func TestParseRunVolumes(t *testing.T) {
 		t.Fatalf("Error parsing volume flags, `-v /hostTmp:/containerTmp:ro -v /hostVar:/containerVar:rw` should mount-bind /hostTmp into /containeTmp and /hostVar into /hostContainer. Received %v", hostConfig.Binds)
 	}
 
-	if _, hostConfig := mustParse(t, "-v /containerTmp:ro -v /containerVar:rw"); hostConfig.Binds == nil || compareRandomizedStrings(hostConfig.Binds[0], hostConfig.Binds[1], "/containerTmp:ro", "/containerVar:rw") != nil {
-		t.Fatalf("Error parsing volume flags, `-v /hostTmp:/containerTmp:ro -v /hostVar:/containerVar:rw` should mount-bind /hostTmp into /containeTmp and /hostVar into /hostContainer. Received %v", hostConfig.Binds)
+	if config, _ := mustParse(t, "-v /containerTmp:ro -v /containerVar:rw"); config.Volumes == nil {
+		t.Fatalf("Error parsing volume flags, config.Volumes shouldn't get nil")
+	} else if _, exists := config.Volumes["/containerTmp:ro"]; !exists {
+		t.Fatalf("Error parsing volume flags, `-v /containerTmp:ro` is missing from volumes. Received %v", config.Volumes)
+	} else if _, exists := config.Volumes["/containerVar:rw"]; !exists {
+		t.Fatalf("Error parsing volume flags, `-v /containerVar:rw` is missing from volumes. Received %v", config.Volumes)
 	}
 
 	if _, hostConfig := mustParse(t, "-v /hostTmp:/containerTmp:ro,Z -v /hostVar:/containerVar:rw,Z"); hostConfig.Binds == nil || compareRandomizedStrings(hostConfig.Binds[0], hostConfig.Binds[1], "/hostTmp:/containerTmp:ro,Z", "/hostVar:/containerVar:rw,Z") != nil {


### PR DESCRIPTION
fix #15962 
For now, If user uses this command line:

```
$ docker run -i -t -v /Documents:ro ubuntu:latest bash
```

It will mount the given directory onto /ro!

So, this change will make the above command line create a volume with ro mode.
And this change will also handled the rw mode.

Could you review the code please?
@calavera 
