### PR TITLE
docs: Explain volume_name in POST /container Binds

### DIFF
--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -264,6 +264,8 @@ Json Parameters:
            + `container_path` to create a new volume for the container
            + `host_path:container_path` to bind-mount a host path into the container
            + `host_path:container_path:ro` to make the bind-mount read-only inside the container.
+           + `volume_name:container_path` to bind-mount a volume managed by a volume plugin into the container.
+           + `volume_name:container_path:ro` to make the bind mount read-only inside the container.
     -   **Links** - A list of links for the container. Each link entry should be
           in the form of `container_name:alias`.
     -   **LxcConf** - LXC specific configurations. These configurations only


### PR DESCRIPTION
With docker/docker#14242 the semantics of `host_path` in `HostConfig.Binds` when creating a container via the remote API slightly changes. Now it's not unconditionally a `host_path` to be specified anymore, but also `volume_name` is possible. See [how this is handled in the CLI for comparison](https://github.com/docker/docker/pull/14242/files#diff-6d9e7586edc05102d4ad66e54659c8c5R1669).

When using volume plugins this is crucial, and the docs are not explicit about this change in semantics.

The supplied changes are just a very rough draft showing what needs clarification in principle.

This [came up on IRC](https://botbot.me/freenode/docker-dev/2015-09-02/) when talking to @erikh

Side note: Moving from `host_path` to `volume_name` is not a breaking change, as `host_path`s need to be absolute, and therefore start with `/`, which is not allowed for volume names, so they do not interfere.
