### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ We are always open to suggestions on process improvements, and are always lookin
   <tr>
     <td>Stack Overflow</td>
     <td>
-      Stack Overflow has over 7000K Docker questions listed. We regularly
+      Stack Overflow has over 7000 Docker questions listed. We regularly
       monitor <a href="https://stackoverflow.com/search?tab=newest&q=docker" target="_blank">Docker questions</a>
       and so do many other knowledgeable Docker users.
     </td>


### PR DESCRIPTION
The number of StackOverflow questions is 7000, not 7000k. The extra 'k' is redundant. 
Signed-off-by: Suryakumar Sudar suryakumar.sudar@gmail.com
