### PR TITLE
Fix a daemon build error when cgo isn't available

### DIFF
--- a/pkg/graphdb/conn_sqlite3.go
+++ b/pkg/graphdb/conn_sqlite3.go
@@ -1,3 +1,5 @@
+// +build cgo
+
 package graphdb
 
 import "database/sql"


### PR DESCRIPTION
Avoid duplicate definitions of NewSqliteConn when cgo isn't enabled, so
that we can at least build the daemon.

Signed-off-by: Nalin Dahyabhai nalin@redhat.com (github: nalind)
