### PR TITLE
Windows: Fix dockerfile ADD from HTTP

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -348,8 +348,11 @@ func calcCopyInfo(b *builder, cmdName string, cInfos *[]*copyInfo, origPath stri
 			}
 		}
 
-		if err := system.UtimesNano(tmpFileName, times); err != nil {
-			return err
+		// Windows does not support UtimesNano.
+		if runtime.GOOS != "windows" {
+			if err := system.UtimesNano(tmpFileName, times); err != nil {
+				return err
+			}
 		}
 
 		ci.origPath = filepath.Join(filepath.Base(tmpDirName), filepath.Base(tmpFileName))


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

This fix enables users to user ADD http://some.url/file.txt /path in a Dockerfile on Windows. This was previously broken. It's due to the use of system.UtimesNano which will give an unsupported platform error.  @swernli 
