### PR TITLE
Windows: Fix golint daemon breaking commit

### DIFF
--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -24,7 +24,7 @@ func (daemon *Daemon) Commit(container *Container, c *ContainerCommitConfig) (*i
 		defer container.unpause()
 	}
 
-	rwTar, err := container.exportRw()
+	rwTar, err := container.exportContainerRw()
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -18,9 +18,7 @@ import (
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/daemon/links"
 	"github.com/docker/docker/daemon/network"
-	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/directory"
-	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/nat"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/system"
@@ -955,21 +953,6 @@ func (container *Container) initializeNetworking() error {
 	}
 
 	return container.buildHostnameFile()
-}
-
-func (container *Container) exportRw() (archive.Archive, error) {
-	if container.daemon == nil {
-		return nil, fmt.Errorf("Can't load storage driver for unregistered container %s", container.ID)
-	}
-	archive, err := container.daemon.diff(container)
-	if err != nil {
-		return nil, err
-	}
-	return ioutils.NewReadCloserWrapper(archive, func() error {
-			err := archive.Close()
-			return err
-		}),
-		nil
 }
 
 func (container *Container) getIpcContainer() (*Container, error) {

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/docker/docker/daemon/execdriver"
-	"github.com/docker/docker/pkg/archive"
 )
 
 // DefaultPathEnv is deliberately empty on Windows as the default path will be set by
@@ -142,14 +141,6 @@ func (container *Container) getSize() (int64, int64) {
 // allocateNetwork is a no-op on Windows.
 func (container *Container) allocateNetwork() error {
 	return nil
-}
-
-func (container *Container) exportRw() (archive.Archive, error) {
-	if container.IsRunning() {
-		return nil, fmt.Errorf("Cannot export a running container.")
-	}
-	// TODO Windows. Implementation (different to Linux)
-	return nil, nil
 }
 
 func (container *Container) updateNetwork() error {


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@LK4D4 @calavera @swernli @MHBauer The golint fixes for the daemon package changed exportRw to exportContainerRw, but never changed the caller to call the new function. It also re-introduced (had been previously removed) exportRw in both the _unix and _windows files, but the Windows version was a no-op.

As a result, docker commit on master is broken in Windows.
