### PR TITLE
Windows: Fix HTTP download directory

### DIFF
--- a/builder/internals.go
+++ b/builder/internals.go
@@ -360,7 +360,7 @@ func calcCopyInfo(b *builder, cmdName string, cInfos *[]*copyInfo, origPath stri
 			if err != nil {
 				return err
 			}
-			path := u.Path
+			path := filepath.FromSlash(u.Path) // Ensure in platform semantics
 			if strings.HasSuffix(path, string(os.PathSeparator)) {
 				path = path[:len(path)-1]
 			}


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Simple fix so that when doing Dockerfile ADD from URL, the destination is honoured correctly by ensuring the URL path is handles in platform semantics.

Without this fix, ADD http://site.com/files/directory/file.exe /, file.exe would be written to \files\directory\file.exe. With this fix, Windows will do the same as Linux and put file.exe in the root.

(Note to docker folks wanting to verify independently on master, you'll need 16030 and 16027 as well to make the end-to-end work)
