### PR TITLE
Clean latest api doc from PortMapping and outdated error check

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -105,8 +104,7 @@ func (container *Container) fromDisk() error {
 	dec := json.NewDecoder(jsonSource)
 
 	// Load container settings
-	// udp broke compat of docker.PortMapping, but it's not used when loading a container, we can skip it
-	if err := dec.Decode(container); err != nil && !strings.Contains(err.Error(), "docker.PortMapping") {
+	if err := dec.Decode(container); err != nil {
 		return err
 	}
 

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -422,7 +422,6 @@ Return low-level information on the container `id`
 			"IPAddress": "",
 			"IPPrefixLen": 0,
 			"MacAddress": "",
-			"PortMapping": null,
 			"Ports": null
 		},
 		"Path": "/bin/sh",
@@ -2244,7 +2243,6 @@ Return low-level information about the `exec` command `id`.
           "MacAddress" : "02:42:ac:11:00:02",
           "Gateway" : "172.17.42.1",
           "Bridge" : "docker0",
-          "PortMapping" : null,
           "Ports" : {}
         },
         "ResolvConfPath" : "/var/lib/docker/containers/8f177a186b977fb451136e0fdf182abff5599a08b3c7f6ef0d36a55aaf89634c/resolv.conf",
@@ -2258,7 +2256,7 @@ Return low-level information about the `exec` command `id`.
         "ProcessLabel" : "",
         "AppArmorProfile" : "",
         "RestartCount" : 0,
-        "Mounts" : [],
+        "Mounts" : []
       }
     }
 


### PR DESCRIPTION
Regarding the outdated error check, there's no `docker.PortMapping`
struct anymore and this is linked to something really old #1334
Somehow I missed these, my b

Signed-off-by: Antonio Murdaca runcom@linux.com
