### PR TITLE
make docker-engine-selinux findable

### DIFF
--- a/hack/make/release-rpm
+++ b/hack/make/release-rpm
@@ -47,7 +47,7 @@ for distro in "${distros[@]}"; do
 		fi
 
 		# path to rpms
-		RPMFILE=( "bundles/$VERSION/build-rpm/$version/RPMS/x86_64/docker-engine"*.rpm "bundles/$VERSION/build-rpm/$version/SRPMS/docker-engine"*.rpm )
+		RPMFILE=( "bundles/$VERSION/build-rpm/$version/RPMS/"*"/docker-engine"*.rpm "bundles/$VERSION/build-rpm/$version/SRPMS/docker-engine"*.rpm )
 
 		# if we have a $GPG_PASSPHRASE we may as well
 		# sign the rpms before adding to repo


### PR DESCRIPTION
realized this while releasing experimental, since the selinux package is under noarch gotta include it ;)

```
RPMS
            │   │   ├── noarch
            │   │   │   └── docker-engine-selinux-1.9.0-0.0.20150903.091854.gitd9065fc.fc21.noarch.rpm
            │   │   └── x86_64
            │   │       └── docker-engine-1.9.0-0.0.20150903.091854.gitd9065fc.fc21.x86_64.rpm
```
