### PR TITLE
Fixes 2 panics initialising tests

### DIFF
--- a/integration-cli/docker_utils.go
+++ b/integration-cli/docker_utils.go
@@ -502,10 +502,9 @@ func init() {
 	// Obtain the daemon platform so that it can be used by tests to make
 	// intelligent decisions about how to configure themselves, and validate
 	// that the target platform is valid.
-	res, b, err := sockRequestRaw("GET", "/version", nil, "application/json")
-	defer b.Close()
-	if err != nil || res.StatusCode != http.StatusOK {
-		panic("Init failed to get version: " + err.Error() + " " + string(res.StatusCode))
+	res, _, err := sockRequestRaw("GET", "/version", nil, "application/json")
+	if err != nil || res == nil || (res != nil && res.StatusCode != http.StatusOK) {
+		panic(fmt.Errorf("Init failed to get version: %v. Res=%v", err.Error(), res))
 	}
 	svrHeader, _ := httputils.ParseServerHeader(res.Header.Get("Server"))
 	daemonPlatform = svrHeader.OS


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@swernli Won't happen on automated Jenkins testing, but possible during local testing if DOCKER_HOST/DOCKER_TEST_HOST is set incorrectly or the daemon isn't reachable. The initial panic intended to be reached under those circumstances is never actually exercised. 

There are three bugs (pretty cool for 4 lines of code!) 
- Defer b.Close() without checking for nil will cause an unintentional panic
- Dereferencing through res to validate StatusCode when res is nil during the check will cause an unintentional panic.
- Dereferencing through res to get StatusCode when res is nil in the panic statement will cause a different panic itself! 
