### PR TITLE
Rename volumedrivers.opts to volumedrivers.Opts to make it public

### DIFF
--- a/volume/drivers/extpoint.go
+++ b/volume/drivers/extpoint.go
@@ -21,12 +21,13 @@ func NewVolumeDriver(name string, c client) volume.Driver {
 	return &volumeDriverAdapter{name, proxy}
 }
 
-type opts map[string]string
+// Opts are options to pass on creation for a new volume.
+type Opts map[string]string
 
 // VolumeDriver defines the available functions that volume plugins must implement.
 type VolumeDriver interface {
 	// Create a volume with the given name
-	Create(name string, opts opts) (err error)
+	Create(name string, opts Opts) (err error)
 	// Remove the volume with the given name
 	Remove(name string) (err error)
 	// Get the mountpoint of the given volume

--- a/volume/drivers/proxy.go
+++ b/volume/drivers/proxy.go
@@ -14,14 +14,14 @@ type volumeDriverProxy struct {
 
 type volumeDriverProxyCreateRequest struct {
 	Name string
-	Opts opts
+	Opts Opts
 }
 
 type volumeDriverProxyCreateResponse struct {
 	Err string
 }
 
-func (pp *volumeDriverProxy) Create(name string, opts opts) (err error) {
+func (pp *volumeDriverProxy) Create(name string, opts Opts) (err error) {
 	var (
 		req volumeDriverProxyCreateRequest
 		ret volumeDriverProxyCreateResponse


### PR DESCRIPTION
Signed-off-by: Peter Edge peter.edge@gmail.com

The `volumedrivers.VolumeDriver` interface is a natural interface for volume driver implementations to implement. However, with `volumedrivers.opts` being private, you can't create implementations of `volumedrivers.VolumeDriver` that conform to the interface specification outside of the `volumedrivers` package. An implementation with a function `func (v *volumeDriver) Create(name string, opts map[string]string)` does not fulfill the interface contract, and if you try to pass it as a `volumedrivers.VolumeDriver`, it will be a compile error.

I have this problem with https://github.com/peter-edge/go-dockervolume/blob/master/dockervolume.go, and had to add the interface seen there because of this problem.

\cc @cpuguy83 @calavera
