### PR TITLE
graph: exported images times matching creation

### DIFF
--- a/graph/service.go
+++ b/graph/service.go
@@ -10,22 +10,6 @@ import (
 	"github.com/docker/docker/api/types"
 )
 
-// lookupRaw looks up an image by name in a TagStore and returns the raw JSON
-// describing the image.
-func (s *TagStore) lookupRaw(name string) ([]byte, error) {
-	image, err := s.LookupImage(name)
-	if err != nil || image == nil {
-		return nil, fmt.Errorf("No such image %s", name)
-	}
-
-	imageInspectRaw, err := s.graph.RawJSON(image.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	return imageInspectRaw, nil
-}
-
 // Lookup looks up an image by name in a TagStore and returns it as an
 // ImageInspect structure.
 func (s *TagStore) Lookup(name string) (*types.ImageInspect, error) {

--- a/integration-cli/docker_cli_save_load_test.go
+++ b/integration-cli/docker_cli_save_load_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/go-check/check"
 )
@@ -92,6 +94,24 @@ func (s *DockerSuite) TestSaveSingleTag(c *check.C) {
 	if err != nil {
 		c.Fatalf("failed to save repo with image ID and 'repositories' file: %s, %v", out, err)
 	}
+}
+
+func (s *DockerSuite) TestSaveCheckTimes(c *check.C) {
+	repoName := "busybox:latest"
+	out, _ := dockerCmd(c, "inspect", repoName)
+	data := []struct {
+		ID      string
+		Created time.Time
+	}{}
+	err := json.Unmarshal([]byte(out), &data)
+	c.Assert(err, check.IsNil, check.Commentf("failed to marshal from %q: err %v", repoName, err))
+	c.Assert(len(data), check.Not(check.Equals), 0, check.Commentf("failed to marshal the data from %q", repoName))
+	tarTvTimeFormat := "2006-01-02 15:04"
+	out, _, err = runCommandPipelineWithOutput(
+		exec.Command(dockerBinary, "save", repoName),
+		exec.Command("tar", "tv"),
+		exec.Command("grep", "-E", fmt.Sprintf("%s %s", data[0].Created.Format(tarTvTimeFormat), data[0].ID)))
+	c.Assert(err, check.IsNil, check.Commentf("failed to save repo with image ID and 'repositories' file: %s, %v", out, err))
 }
 
 func (s *DockerSuite) TestSaveImageId(c *check.C) {


### PR DESCRIPTION
the image export, that is used in `docker save` previous has just had
the layers times (atimes, mtimes) be when the save was done.

``` bash
vbatts@valse ~ (master) $ docker save busybox | tar tv
drwxr-xr-x 0/0               0 2015-09-03 22:22 6ce2e90b0bc7224de3db1f0d646fe8e2c4dd37f1793928287f6074bc451a57ea/
-rw-r--r-- 0/0               3 2015-09-03 22:22 6ce2e90b0bc7224de3db1f0d646fe8e2c4dd37f1793928287f6074bc451a57ea/VERSION
-rw-r--r-- 0/0            1405 2015-09-03 22:22 6ce2e90b0bc7224de3db1f0d646fe8e2c4dd37f1793928287f6074bc451a57ea/json
-rw-r--r-- 0/0         2643968 2015-09-03 22:22 6ce2e90b0bc7224de3db1f0d646fe8e2c4dd37f1793928287f6074bc451a57ea/layer.tar
drwxr-xr-x 0/0               0 2015-09-03 22:22 8c2e06607696bd4afb3d03b687e361cc43cf8ec1a4a725bc96e39f05ba97dd55/
-rw-r--r-- 0/0               3 2015-09-03 22:22 8c2e06607696bd4afb3d03b687e361cc43cf8ec1a4a725bc96e39f05ba97dd55/VERSION
-rw-r--r-- 0/0            1346 2015-09-03 22:22 8c2e06607696bd4afb3d03b687e361cc43cf8ec1a4a725bc96e39f05ba97dd55/json
-rw-r--r-- 0/0            1024 2015-09-03 22:22 8c2e06607696bd4afb3d03b687e361cc43cf8ec1a4a725bc96e39f05ba97dd55/layer.tar
drwxr-xr-x 0/0               0 2015-09-03 22:22 cf2616975b4a3cba083ca99bc3f0bf25f5f528c3c52be1596b30f60b0b1c37ff/
-rw-r--r-- 0/0               3 2015-09-03 22:22 cf2616975b4a3cba083ca99bc3f0bf25f5f528c3c52be1596b30f60b0b1c37ff/VERSION
-rw-r--r-- 0/0            1181 2015-09-03 22:22 cf2616975b4a3cba083ca99bc3f0bf25f5f528c3c52be1596b30f60b0b1c37ff/json
-rw-r--r-- 0/0            1024 2015-09-03 22:22 cf2616975b4a3cba083ca99bc3f0bf25f5f528c3c52be1596b30f60b0b1c37ff/layer.tar
-rw-r--r-- 0/0              90 2015-09-03 22:22 repositories
```

With this change, the layer's directory and artifact will have times
matching the image layer's created time. The "repositories" file is set
to epoch.

``` bash
vbatts@valse ~ (master) $ docker save busybox | tar tv
drwxr-xr-x 0/0               0 2015-04-17 18:01 6ce2e90b0bc7224de3db1f0d646fe8e2c4dd37f1793928287f6074bc451a57ea/
-rw-r--r-- 0/0               3 2015-04-17 18:01 6ce2e90b0bc7224de3db1f0d646fe8e2c4dd37f1793928287f6074bc451a57ea/VERSION
-rw-r--r-- 0/0            1405 2015-04-17 18:01 6ce2e90b0bc7224de3db1f0d646fe8e2c4dd37f1793928287f6074bc451a57ea/json
-rw-r--r-- 0/0         2643968 2015-04-17 18:01 6ce2e90b0bc7224de3db1f0d646fe8e2c4dd37f1793928287f6074bc451a57ea/layer.tar
drwxr-xr-x 0/0               0 2015-04-17 18:01 8c2e06607696bd4afb3d03b687e361cc43cf8ec1a4a725bc96e39f05ba97dd55/
-rw-r--r-- 0/0               3 2015-04-17 18:01 8c2e06607696bd4afb3d03b687e361cc43cf8ec1a4a725bc96e39f05ba97dd55/VERSION
-rw-r--r-- 0/0            1346 2015-04-17 18:01 8c2e06607696bd4afb3d03b687e361cc43cf8ec1a4a725bc96e39f05ba97dd55/json
-rw-r--r-- 0/0            1024 2015-04-17 18:01 8c2e06607696bd4afb3d03b687e361cc43cf8ec1a4a725bc96e39f05ba97dd55/layer.tar
drwxr-xr-x 0/0               0 2015-04-17 18:01 cf2616975b4a3cba083ca99bc3f0bf25f5f528c3c52be1596b30f60b0b1c37ff/
-rw-r--r-- 0/0               3 2015-04-17 18:01 cf2616975b4a3cba083ca99bc3f0bf25f5f528c3c52be1596b30f60b0b1c37ff/VERSION
-rw-r--r-- 0/0            1181 2015-04-17 18:01 cf2616975b4a3cba083ca99bc3f0bf25f5f528c3c52be1596b30f60b0b1c37ff/json
-rw-r--r-- 0/0            1024 2015-04-17 18:01 cf2616975b4a3cba083ca99bc3f0bf25f5f528c3c52be1596b30f60b0b1c37ff/layer.tar
-rw-r--r-- 0/0              90 1969-12-31 19:00 repositories
```

Side effect of this is that the tar stream from `docker save` is now
more deterministic.

``` bash
vbatts@valse ~ (master) $ docker save busybox | sha1sum
baf03e30ef79ca4d9c5e512d3a1b873880f404ca  -
vbatts@valse ~ (master) $ docker save busybox | sha1sum
baf03e30ef79ca4d9c5e512d3a1b873880f404ca  -
vbatts@valse ~ (master) $ docker save busybox | sha1sum
baf03e30ef79ca4d9c5e512d3a1b873880f404ca  -
vbatts@valse ~ (master) $ docker save busybox | sha1sum
baf03e30ef79ca4d9c5e512d3a1b873880f404ca  -
```

This idea came about from thinking about https://github.com/docker/docker/issues/8819#issuecomment-137606443

Signed-off-by: Vincent Batts vbatts@redhat.com
