### PR TITLE
Ensure goroutines dump is not truncated

### DIFF
--- a/pkg/signal/trap.go
+++ b/pkg/signal/trap.go
@@ -57,8 +57,17 @@ func Trap(cleanup func()) {
 
 // DumpStacks dumps the runtime stack.
 func DumpStacks() {
-	buf := make([]byte, 16384)
-	buf = buf[:runtime.Stack(buf, true)]
+	var (
+		buf       []byte
+		stackSize int
+	)
+	bufferLen := 16384
+	for stackSize == len(buf) {
+		buf = make([]byte, bufferLen)
+		stackSize = runtime.Stack(buf, true)
+		bufferLen *= 2
+	}
+	buf = buf[:stackSize]
 	// Note that if the daemon is started with a less-verbose log-level than "info" (the default), the goroutine
 	// traces won't show up in the log.
 	logrus.Infof("=== BEGIN goroutine stack dump ===\n%s\n=== END goroutine stack dump ===", buf)


### PR DESCRIPTION
Currently the goroutines dump printed in the logs when a SIGUSR1 is sent to the docker process have a great chance of being truncated.

Calling `runtime.Stack` requires the buffer to be big enough to fit the goroutines dump. If it's not big enough the dump will be truncated and the value returned will be the same size as the buffer.

This PR change the code responsible for dumping the goroutines to handle this situation and try again with a bigger buffer. Each time the dump doesn't fit in the buffer its size is doubled.
