### PR TITLE
Temp: Turn off dockerhubpullsuite on Win2Linux CI

### DIFF
--- a/integration-cli/docker_hub_pull_suite_test.go
+++ b/integration-cli/docker_hub_pull_suite_test.go
@@ -2,13 +2,18 @@ package main
 
 import (
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/go-check/check"
 )
 
 func init() {
-	check.Suite(newDockerHubPullSuite())
+	// FIXME. Temporarily turning this off for Windows as GH16039 was breaking
+	// Windows to Linux CI @icecrime
+	if runtime.GOOS != "windows" {
+		check.Suite(newDockerHubPullSuite())
+	}
 }
 
 // DockerHubPullSuite provides a isolated daemon that doesn't have all the


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

@icecrime @jfrazelle (Think this should work...) Turns off dockerhubpullsuite on WIndows (introduced in #16039) which is causing Windows CI to currently fail. eg https://github.com/docker/docker/pull/15992
