### PR TITLE
Bump sqlite3

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -143,7 +143,7 @@ fi
 EXTLDFLAGS_STATIC='-static'
 # ORIG_BUILDFLAGS is necessary for the cross target which cannot always build
 # with options like -race.
-ORIG_BUILDFLAGS=( -a -tags "netgo static_build $DOCKER_BUILDTAGS" -installsuffix netgo )
+ORIG_BUILDFLAGS=( -a -tags "netgo static_build sqlite_omit_load_extension $DOCKER_BUILDTAGS" -installsuffix netgo )
 # see https://github.com/golang/go/issues/9369#issuecomment-69864440 for why -installsuffix is necessary here
 BUILDFLAGS=( $BUILDFLAGS "${ORIG_BUILDFLAGS[@]}" )
 # Test timeout.

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -152,7 +152,7 @@ TESTFLAGS+=" -test.timeout=${TIMEOUT}"
 
 # A few more flags that are specific just to building a completely-static binary (see hack/make/binary)
 # PLEASE do not use these anywhere else.
-EXTLDFLAGS_STATIC_DOCKER="$EXTLDFLAGS_STATIC -lpthread -Wl,--unresolved-symbols=ignore-in-object-files"
+EXTLDFLAGS_STATIC_DOCKER="$EXTLDFLAGS_STATIC -lpthread -ldl"
 LDFLAGS_STATIC_DOCKER="
 	$LDFLAGS_STATIC
 	-extldflags \"$EXTLDFLAGS_STATIC_DOCKER\"

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -13,7 +13,7 @@ clone git github.com/go-check/check 64131543e7896d5bcc6bd5a76287eb75ea96c673
 clone git github.com/gorilla/context 14f550f51a
 clone git github.com/gorilla/mux e444e69cbd
 clone git github.com/kr/pty 5cf931ef8f
-clone git github.com/mattn/go-sqlite3 b4142c444a8941d0d92b0b7103a24df9cd815e42
+clone git github.com/mattn/go-sqlite3 v1.1.0
 clone git github.com/microsoft/hcsshim 7f646aa6b26bcf90caee91e93cde4a80d0d8a83e
 clone git github.com/mistifyio/go-zfs v2.1.1
 clone git github.com/tchap/go-patricia v2.1.0

--- a/vendor/src/github.com/mattn/go-sqlite3/README.md
+++ b/vendor/src/github.com/mattn/go-sqlite3/README.md
@@ -30,6 +30,10 @@ FAQ
 
     Use `go build --tags "libsqlite3 linux"`
 
+* Want to build go-sqlite3 with icu extension.
+
+   Use `go build --tags "icu"`
+
 * Can't build go-sqlite3 on windows 64bit.
 
     > Probably, you are using go 1.0, go1.0 has a problem when it comes to compiling/linking on windows 64bit. 

--- a/vendor/src/github.com/mattn/go-sqlite3/sqlite3_icu.go
+++ b/vendor/src/github.com/mattn/go-sqlite3/sqlite3_icu.go
@@ -1,0 +1,13 @@
+// Copyright (C) 2014 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+// +build icu 
+
+package sqlite3
+
+/*
+#cgo LDFLAGS: -licuuc -licui18n
+#cgo CFLAGS: -DSQLITE_ENABLE_ICU
+*/
+import "C"

--- a/vendor/src/github.com/mattn/go-sqlite3/sqlite3_load_extension.go
+++ b/vendor/src/github.com/mattn/go-sqlite3/sqlite3_load_extension.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2014 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+// +build !sqlite_omit_load_extension
+
+package sqlite3
+
+/*
+#include <sqlite3-binding.h>
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"errors"
+	"unsafe"
+)
+
+func (c *SQLiteConn) loadExtensions(extensions []string) error {
+	rv := C.sqlite3_enable_load_extension(c.db, 1)
+	if rv != C.SQLITE_OK {
+		return errors.New(C.GoString(C.sqlite3_errmsg(c.db)))
+	}
+
+	for _, extension := range extensions {
+		cext := C.CString(extension)
+		defer C.free(unsafe.Pointer(cext))
+		rv = C.sqlite3_load_extension(c.db, cext, nil, nil)
+		if rv != C.SQLITE_OK {
+			return errors.New(C.GoString(C.sqlite3_errmsg(c.db)))
+		}
+	}
+
+	rv = C.sqlite3_enable_load_extension(c.db, 0)
+	if rv != C.SQLITE_OK {
+		return errors.New(C.GoString(C.sqlite3_errmsg(c.db)))
+	}
+	return nil
+}

--- a/vendor/src/github.com/mattn/go-sqlite3/sqlite3_omit_load_extension.go
+++ b/vendor/src/github.com/mattn/go-sqlite3/sqlite3_omit_load_extension.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2014 Yasuhiro Matsumoto <mattn.jp@gmail.com>.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+// +build sqlite_omit_load_extension
+
+package sqlite3
+
+/*
+#cgo CFLAGS: -DSQLITE_OMIT_LOAD_EXTENSION
+*/
+import "C"
+import (
+	"errors"
+)
+
+func (c *SQLiteConn) loadExtensions(extensions []string) error {
+	return errors.New("Extensions have been disabled for static builds")
+}


### PR DESCRIPTION
This removes the dlopen error when compiling statically

I also included @kolyshkin  commit from https://github.com/docker/docker/pull/15387 to show we can not ignore unresoved symbols and get none now :)
