### PR TITLE
Final bits of enabling golint on the code base 🐹

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -266,7 +266,7 @@ func (devices *DeviceSet) allocateTransactionID() uint64 {
 }
 
 func (devices *DeviceSet) updatePoolTransactionID() error {
-	if err := devicemapper.SetTransactionId(devices.getPoolDevName(), devices.TransactionID, devices.OpenTransactionID); err != nil {
+	if err := devicemapper.SetTransactionID(devices.getPoolDevName(), devices.TransactionID, devices.OpenTransactionID); err != nil {
 		return fmt.Errorf("Error setting devmapper transaction ID: %s", err)
 	}
 	devices.TransactionID = devices.OpenTransactionID
@@ -596,7 +596,7 @@ func (devices *DeviceSet) createRegisterDevice(hash string) (*devInfo, error) {
 
 	for {
 		if err := devicemapper.CreateDevice(devices.getPoolDevName(), deviceID); err != nil {
-			if devicemapper.DeviceIdExists(err) {
+			if devicemapper.DeviceIDExists(err) {
 				// Device ID already exists. This should not
 				// happen. Now we have a mechianism to find
 				// a free device ID. So something is not right.
@@ -648,7 +648,7 @@ func (devices *DeviceSet) createRegisterSnapDevice(hash string, baseInfo *devInf
 
 	for {
 		if err := devicemapper.CreateSnapDevice(devices.getPoolDevName(), deviceID, baseInfo.Name(), baseInfo.DeviceID); err != nil {
-			if devicemapper.DeviceIdExists(err) {
+			if devicemapper.DeviceIDExists(err) {
 				// Device ID already exists. This should not
 				// happen. Now we have a mechianism to find
 				// a free device ID. So something is not right.

--- a/hack/make/validate-lint
+++ b/hack/make/validate-lint
@@ -2,116 +2,15 @@
 
 source "${MAKEDIR}/.validate"
 
-# We will eventually get to the point when packages should be the complete list
-# of subpackages, vendoring excluded, as given by:
-#
-# packages=( $(go list ./... 2> /dev/null | grep -vE "^github.com/docker/docker/vendor" || true ) )
-
-packages=(
-	api
-	api/client
-	api/client/ps
-	api/server
-	api/types
-	builder
-	builder/command
-	builder/parser
-	builder/parser/dumper
-	cliconfig
-	daemon
-	daemon/events
-	daemon/execdriver
-	daemon/execdriver/execdrivers
-	daemon/execdriver/lxc
-	daemon/execdriver/native
-	daemon/execdriver/native/template
-	daemon/execdriver/windows
-	daemon/graphdriver
-	daemon/graphdriver/aufs
-	daemon/graphdriver/devmapper
-	daemon/graphdriver/overlay
-	daemon/graphdriver/vfs
-	daemon/graphdriver/zfs
-	daemon/logger
-	daemon/logger/fluentd
-	daemon/logger/gelf
-	daemon/logger/journald
-	daemon/logger/jsonfilelog
-	daemon/logger/syslog
-	daemon/network
-	docker
-	dockerinit
-	graph
-	graph/tags
-	image
-	integration-cli
-	opts
-	pkg/archive
-	pkg/broadcastwriter
-	pkg/chrootarchive
-	pkg/directory
-	pkg/fileutils
-	pkg/graphdb
-	pkg/homedir
-	pkg/httputils
-	pkg/ioutils
-	pkg/jsonlog
-	pkg/jsonmessage
-	pkg/listenbuffer
-	pkg/mflag
-	pkg/mflag/example
-	pkg/mount
-	pkg/namesgenerator
-	pkg/nat
-	pkg/parsers
-	pkg/parsers/filters
-	pkg/parsers/kernel
-	pkg/parsers/operatingsystem
-	pkg/pidfile
-	pkg/plugins
-	pkg/pools
-	pkg/progressreader
-	pkg/promise
-	pkg/proxy
-	pkg/pubsub
-	pkg/random
-	pkg/reexec
-	pkg/signal
-	pkg/sockets
-	pkg/stdcopy
-	pkg/streamformatter
-	pkg/stringid
-	pkg/stringutils
-	pkg/symlink
-	pkg/sysinfo
-	pkg/system
-	pkg/tailfile
-	pkg/tarsum
-	pkg/term
-	pkg/term/windows
-	pkg/timeoutconn
-	pkg/timeutils
-	pkg/tlsconfig
-	pkg/truncindex
-	pkg/urlutil
-	pkg/ulimit
-	pkg/units
-	pkg/useragent
-	pkg/version
-	registry
-	runconfig
-	trust
-	utils
-	volume
-	volume/local
-	volume/drivers
-)
+packages=( $(go list ./... 2> /dev/null | grep -vE "^github.com/docker/docker/vendor|^github.com/docker/docker/autogen" || true ) )
 
 errors=()
 for p in "${packages[@]}"; do
+	# Remove the github.com/docker/docker/ prefix from listed package
+	package="${p#github.com/docker/docker/}"
 	# Run golint on package/*.go file explicitly to validate all go files
 	# and not just the ones for the current platform.
-	failedLint=$(golint "$p"/*.go)
+	failedLint=$(golint $package/*.go)
 	if [ "$failedLint" ]; then
 		errors+=( "$failedLint" )
 	fi

--- a/integration-cli/checker/checker.go
+++ b/integration-cli/checker/checker.go
@@ -1,4 +1,4 @@
-// Checker provide Docker specific implementations of the go-check.Checker interface.
+// Package checker provide Docker specific implementations of the go-check.Checker interface.
 package checker
 
 import (

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -25,7 +25,7 @@ func getWalkRoot(srcPath string, include string) string {
 	return filepath.Join(srcPath, include)
 }
 
-// canonicalTarNameForPath returns platform-specific filepath
+// CanonicalTarNameForPath returns platform-specific filepath
 // to canonical posix-style path for tar archival. p is relative
 // path.
 func CanonicalTarNameForPath(p string) (string, error) {

--- a/pkg/devicemapper/attach_loopback.go
+++ b/pkg/devicemapper/attach_loopback.go
@@ -82,7 +82,7 @@ func openNextAvailableLoopback(index int, sparseFile *os.File) (loopFile *os.Fil
 	return loopFile, nil
 }
 
-// attachLoopDevice attaches the given sparse file to the next
+// AttachLoopDevice attaches the given sparse file to the next
 // available loopback device. It returns an opened *os.File.
 func AttachLoopDevice(sparseName string) (loop *os.File, err error) {
 
@@ -108,7 +108,7 @@ func AttachLoopDevice(sparseName string) (loop *os.File, err error) {
 	}
 
 	// Set the status of the loopback device
-	loopInfo := &LoopInfo64{
+	loopInfo := &loopInfo64{
 		loFileName: stringToLoopName(loopFile.Name()),
 		loOffset:   0,
 		loFlags:    LoFlagsAutoClear,

--- a/pkg/devicemapper/devmapper_log.go
+++ b/pkg/devicemapper/devmapper_log.go
@@ -11,8 +11,9 @@ import (
 // Due to the way cgo works this has to be in a separate file, as devmapper.go has
 // definitions in the cgo block, which is incompatible with using "//export"
 
+// DevmapperLogCallback exports the devmapper log callback for cgo. (?)
 //export DevmapperLogCallback
-func DevmapperLogCallback(level C.int, file *C.char, line C.int, dm_errno_or_class C.int, message *C.char) {
+func DevmapperLogCallback(level C.int, file *C.char, line C.int, dmErrnoOrClass C.int, message *C.char) {
 	msg := C.GoString(message)
 	if level < 7 {
 		if strings.Contains(msg, "busy") {
@@ -29,6 +30,6 @@ func DevmapperLogCallback(level C.int, file *C.char, line C.int, dm_errno_or_cla
 	}
 
 	if dmLogger != nil {
-		dmLogger.DMLog(int(level), C.GoString(file), int(line), int(dm_errno_or_class), msg)
+		dmLogger.DMLog(int(level), C.GoString(file), int(line), int(dmErrnoOrClass), msg)
 	}
 }

--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -44,23 +44,23 @@ import (
 )
 
 type (
-	CDmTask C.struct_dm_task
+	cdmTask C.struct_dm_task
 
-	CLoopInfo64 C.struct_loop_info64
-	LoopInfo64  struct {
-		loDevice           uint64 /* ioctl r/o */
-		loInode            uint64 /* ioctl r/o */
-		loRdevice          uint64 /* ioctl r/o */
-		loOffset           uint64
-		loSizelimit        uint64 /* bytes, 0 == max available */
-		loNumber           uint32 /* ioctl r/o */
-		loEncrypt_type     uint32
-		loEncrypt_key_size uint32 /* ioctl w/o */
-		loFlags            uint32 /* ioctl r/o */
-		loFileName         [LoNameSize]uint8
-		loCryptName        [LoNameSize]uint8
-		loEncryptKey       [LoKeySize]uint8 /* ioctl w/o */
-		loInit             [2]uint64
+	cLoopInfo64 C.struct_loop_info64
+	loopInfo64  struct {
+		loDevice         uint64 /* ioctl r/o */
+		loInode          uint64 /* ioctl r/o */
+		loRdevice        uint64 /* ioctl r/o */
+		loOffset         uint64
+		loSizelimit      uint64 /* bytes, 0 == max available */
+		loNumber         uint32 /* ioctl r/o */
+		loEncryptType    uint32
+		loEncryptKeySize uint32 /* ioctl w/o */
+		loFlags          uint32 /* ioctl r/o */
+		loFileName       [LoNameSize]uint8
+		loCryptName      [LoNameSize]uint8
+		loEncryptKey     [LoKeySize]uint8 /* ioctl w/o */
+		loInit           [2]uint64
 	}
 )
 
@@ -77,6 +77,7 @@ const (
 	LoopSetCapacity = C.LOOP_SET_CAPACITY
 )
 
+// LOOP consts. (?)
 const (
 	LoFlagsAutoClear = C.LO_FLAGS_AUTOCLEAR
 	LoFlagsReadOnly  = C.LO_FLAGS_READ_ONLY
@@ -85,6 +86,7 @@ const (
 	LoNameSize       = C.LO_NAME_SIZE
 )
 
+// DeviceMapper Udev consts. (?)
 const (
 	DmUdevDisableSubsystemRulesFlag = C.DM_UDEV_DISABLE_SUBSYSTEM_RULES_FLAG
 	DmUdevDisableDiskRulesFlag      = C.DM_UDEV_DISABLE_DISK_RULES_FLAG
@@ -92,6 +94,7 @@ const (
 	DmUdevDisableLibraryFallback    = C.DM_UDEV_DISABLE_LIBRARY_FALLBACK
 )
 
+// DeviceMapper mapped functions.
 var (
 	DmGetLibraryVersion       = dmGetLibraryVersionFct
 	DmGetNextTarget           = dmGetNextTargetFct
@@ -123,38 +126,38 @@ func free(p *C.char) {
 	C.free(unsafe.Pointer(p))
 }
 
-func dmTaskDestroyFct(task *CDmTask) {
+func dmTaskDestroyFct(task *cdmTask) {
 	C.dm_task_destroy((*C.struct_dm_task)(task))
 }
 
-func dmTaskCreateFct(taskType int) *CDmTask {
-	return (*CDmTask)(C.dm_task_create(C.int(taskType)))
+func dmTaskCreateFct(taskType int) *cdmTask {
+	return (*cdmTask)(C.dm_task_create(C.int(taskType)))
 }
 
-func dmTaskRunFct(task *CDmTask) int {
+func dmTaskRunFct(task *cdmTask) int {
 	ret, _ := C.dm_task_run((*C.struct_dm_task)(task))
 	return int(ret)
 }
 
-func dmTaskSetNameFct(task *CDmTask, name string) int {
+func dmTaskSetNameFct(task *cdmTask, name string) int {
 	Cname := C.CString(name)
 	defer free(Cname)
 
 	return int(C.dm_task_set_name((*C.struct_dm_task)(task), Cname))
 }
 
-func dmTaskSetMessageFct(task *CDmTask, message string) int {
+func dmTaskSetMessageFct(task *cdmTask, message string) int {
 	Cmessage := C.CString(message)
 	defer free(Cmessage)
 
 	return int(C.dm_task_set_message((*C.struct_dm_task)(task), Cmessage))
 }
 
-func dmTaskSetSectorFct(task *CDmTask, sector uint64) int {
+func dmTaskSetSectorFct(task *cdmTask, sector uint64) int {
 	return int(C.dm_task_set_sector((*C.struct_dm_task)(task), C.uint64_t(sector)))
 }
 
-func dmTaskSetCookieFct(task *CDmTask, cookie *uint, flags uint16) int {
+func dmTaskSetCookieFct(task *cdmTask, cookie *uint, flags uint16) int {
 	cCookie := C.uint32_t(*cookie)
 	defer func() {
 		*cookie = uint(cCookie)
@@ -162,15 +165,15 @@ func dmTaskSetCookieFct(task *CDmTask, cookie *uint, flags uint16) int {
 	return int(C.dm_task_set_cookie((*C.struct_dm_task)(task), &cCookie, C.uint16_t(flags)))
 }
 
-func dmTaskSetAddNodeFct(task *CDmTask, addNode AddNodeType) int {
+func dmTaskSetAddNodeFct(task *cdmTask, addNode AddNodeType) int {
 	return int(C.dm_task_set_add_node((*C.struct_dm_task)(task), C.dm_add_node_t(addNode)))
 }
 
-func dmTaskSetRoFct(task *CDmTask) int {
+func dmTaskSetRoFct(task *cdmTask) int {
 	return int(C.dm_task_set_ro((*C.struct_dm_task)(task)))
 }
 
-func dmTaskAddTargetFct(task *CDmTask,
+func dmTaskAddTargetFct(task *cdmTask,
 	start, size uint64, ttype, params string) int {
 
 	Cttype := C.CString(ttype)
@@ -182,7 +185,7 @@ func dmTaskAddTargetFct(task *CDmTask,
 	return int(C.dm_task_add_target((*C.struct_dm_task)(task), C.uint64_t(start), C.uint64_t(size), Cttype, Cparams))
 }
 
-func dmTaskGetDepsFct(task *CDmTask) *Deps {
+func dmTaskGetDepsFct(task *cdmTask) *Deps {
 	Cdeps := C.dm_task_get_deps((*C.struct_dm_task)(task))
 	if Cdeps == nil {
 		return nil
@@ -206,7 +209,7 @@ func dmTaskGetDepsFct(task *CDmTask) *Deps {
 	return deps
 }
 
-func dmTaskGetInfoFct(task *CDmTask, info *Info) int {
+func dmTaskGetInfoFct(task *cdmTask, info *Info) int {
 	Cinfo := C.struct_dm_info{}
 	defer func() {
 		info.Exists = int(Cinfo.exists)
@@ -223,7 +226,7 @@ func dmTaskGetInfoFct(task *CDmTask, info *Info) int {
 	return int(C.dm_task_get_info((*C.struct_dm_task)(task), &Cinfo))
 }
 
-func dmTaskGetDriverVersionFct(task *CDmTask) string {
+func dmTaskGetDriverVersionFct(task *cdmTask) string {
 	buffer := C.malloc(128)
 	defer C.free(buffer)
 	res := C.dm_task_get_driver_version((*C.struct_dm_task)(task), (*C.char)(buffer), 128)
@@ -233,7 +236,7 @@ func dmTaskGetDriverVersionFct(task *CDmTask) string {
 	return C.GoString((*C.char)(buffer))
 }
 
-func dmGetNextTargetFct(task *CDmTask, next unsafe.Pointer, start, length *uint64, target, params *string) unsafe.Pointer {
+func dmGetNextTargetFct(task *cdmTask, next unsafe.Pointer, start, length *uint64, target, params *string) unsafe.Pointer {
 	var (
 		Cstart, Clength      C.uint64_t
 		CtargetType, Cparams *C.char

--- a/pkg/devicemapper/devmapper_wrapper_deferred_remove.go
+++ b/pkg/devicemapper/devmapper_wrapper_deferred_remove.go
@@ -8,6 +8,7 @@ package devicemapper
 */
 import "C"
 
+// LibraryDeferredRemovalsupport is supported when statically linked.
 const LibraryDeferredRemovalSupport = true
 
 func dmTaskDeferredRemoveFct(task *CDmTask) int {

--- a/pkg/devicemapper/devmapper_wrapper_no_deferred_remove.go
+++ b/pkg/devicemapper/devmapper_wrapper_no_deferred_remove.go
@@ -2,13 +2,14 @@
 
 package devicemapper
 
+// LibraryDeferredRemovalsupport is not supported when statically linked.
 const LibraryDeferredRemovalSupport = false
 
-func dmTaskDeferredRemoveFct(task *CDmTask) int {
+func dmTaskDeferredRemoveFct(task *cdmTask) int {
 	// Error. Nobody should be calling it.
 	return -1
 }
 
-func dmTaskGetInfoWithDeferredFct(task *CDmTask, info *Info) int {
+func dmTaskGetInfoWithDeferredFct(task *cdmTask, info *Info) int {
 	return -1
 }

--- a/pkg/devicemapper/ioctl.go
+++ b/pkg/devicemapper/ioctl.go
@@ -22,7 +22,7 @@ func ioctlLoopSetFd(loopFd, sparseFd uintptr) error {
 	return nil
 }
 
-func ioctlLoopSetStatus64(loopFd uintptr, loopInfo *LoopInfo64) error {
+func ioctlLoopSetStatus64(loopFd uintptr, loopInfo *loopInfo64) error {
 	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, loopFd, LoopSetStatus64, uintptr(unsafe.Pointer(loopInfo))); err != 0 {
 		return err
 	}
@@ -36,8 +36,8 @@ func ioctlLoopClrFd(loopFd uintptr) error {
 	return nil
 }
 
-func ioctlLoopGetStatus64(loopFd uintptr) (*LoopInfo64, error) {
-	loopInfo := &LoopInfo64{}
+func ioctlLoopGetStatus64(loopFd uintptr) (*loopInfo64, error) {
+	loopInfo := &loopInfo64{}
 
 	if _, _, err := syscall.Syscall(syscall.SYS_IOCTL, loopFd, LoopGetStatus64, uintptr(unsafe.Pointer(loopInfo))); err != 0 {
 		return nil, err

--- a/pkg/plugins/pluginrpc-gen/fixtures/foo.go
+++ b/pkg/plugins/pluginrpc-gen/fixtures/foo.go
@@ -6,12 +6,15 @@ type wobble struct {
 	Inception *wobble
 }
 
+// Fooer is an empty interface used for tests.
 type Fooer interface{}
 
+// Fooer2 is an interface used for tests.
 type Fooer2 interface {
 	Foo()
 }
 
+// Fooer3 is an interface used for tests.
 type Fooer3 interface {
 	Foo()
 	Bar(a string)
@@ -21,14 +24,17 @@ type Fooer3 interface {
 	Wiggle() (w wobble)
 }
 
+// Fooer4 is an interface used for tests.
 type Fooer4 interface {
 	Foo() error
 }
 
+// Bar is an interface used for tests.
 type Bar interface {
 	Boo(a string, b string) (s string, err error)
 }
 
+// Fooer5 is an interface used for tests.
 type Fooer5 interface {
 	Foo()
 	Bar

--- a/pkg/plugins/pluginrpc-gen/main.go
+++ b/pkg/plugins/pluginrpc-gen/main.go
@@ -72,7 +72,7 @@ func main() {
 		InterfaceType string
 		RPCName       string
 		BuildTags     map[string]struct{}
-		*parsedPkg
+		*ParsedPkg
 	}{toLower(*typeName), *rpcName, flBuildTags.GetValues(), pkg}
 	var buf bytes.Buffer
 

--- a/pkg/plugins/pluginrpc-gen/parser.go
+++ b/pkg/plugins/pluginrpc-gen/parser.go
@@ -9,18 +9,20 @@ import (
 	"reflect"
 )
 
-var ErrBadReturn = errors.New("found return arg with no name: all args must be named")
+var errBadReturn = errors.New("found return arg with no name: all args must be named")
 
-type ErrUnexpectedType struct {
+type errUnexpectedType struct {
 	expected string
 	actual   interface{}
 }
 
-func (e ErrUnexpectedType) Error() string {
+func (e errUnexpectedType) Error() string {
 	return fmt.Sprintf("got wrong type expecting %s, got: %v", e.expected, reflect.TypeOf(e.actual))
 }
 
-type parsedPkg struct {
+// ParsedPkg holds information about a package that has been parsed,
+// its name and the list of functions.
+type ParsedPkg struct {
 	Name      string
 	Functions []function
 }
@@ -41,14 +43,14 @@ func (a *arg) String() string {
 	return a.Name + " " + a.ArgType
 }
 
-// Parses the given file for an interface definition with the given name
-func Parse(filePath string, objName string) (*parsedPkg, error) {
+// Parse parses the given file for an interface definition with the given name.
+func Parse(filePath string, objName string) (*ParsedPkg, error) {
 	fs := token.NewFileSet()
 	pkg, err := parser.ParseFile(fs, filePath, nil, parser.AllErrors)
 	if err != nil {
 		return nil, err
 	}
-	p := &parsedPkg{}
+	p := &ParsedPkg{}
 	p.Name = pkg.Name.Name
 	obj, exists := pkg.Scope.Objects[objName]
 	if !exists {
@@ -59,11 +61,11 @@ func Parse(filePath string, objName string) (*parsedPkg, error) {
 	}
 	spec, ok := obj.Decl.(*ast.TypeSpec)
 	if !ok {
-		return nil, ErrUnexpectedType{"*ast.TypeSpec", obj.Decl}
+		return nil, errUnexpectedType{"*ast.TypeSpec", obj.Decl}
 	}
 	iface, ok := spec.Type.(*ast.InterfaceType)
 	if !ok {
-		return nil, ErrUnexpectedType{"*ast.InterfaceType", spec.Type}
+		return nil, errUnexpectedType{"*ast.InterfaceType", spec.Type}
 	}
 
 	p.Functions, err = parseInterface(iface)
@@ -90,11 +92,11 @@ func parseInterface(iface *ast.InterfaceType) ([]function, error) {
 		case *ast.Ident:
 			spec, ok := f.Obj.Decl.(*ast.TypeSpec)
 			if !ok {
-				return nil, ErrUnexpectedType{"*ast.TypeSpec", f.Obj.Decl}
+				return nil, errUnexpectedType{"*ast.TypeSpec", f.Obj.Decl}
 			}
 			iface, ok := spec.Type.(*ast.InterfaceType)
 			if !ok {
-				return nil, ErrUnexpectedType{"*ast.TypeSpec", spec.Type}
+				return nil, errUnexpectedType{"*ast.TypeSpec", spec.Type}
 			}
 			funcs, err := parseInterface(iface)
 			if err != nil {
@@ -103,7 +105,7 @@ func parseInterface(iface *ast.InterfaceType) ([]function, error) {
 			}
 			functions = append(functions, funcs...)
 		default:
-			return nil, ErrUnexpectedType{"*astFuncType or *ast.Ident", f}
+			return nil, errUnexpectedType{"*astFuncType or *ast.Ident", f}
 		}
 	}
 	return functions, nil
@@ -137,7 +139,7 @@ func parseArgs(fields []*ast.Field) ([]arg, error) {
 	var args []arg
 	for _, f := range fields {
 		if len(f.Names) == 0 {
-			return nil, ErrBadReturn
+			return nil, errBadReturn
 		}
 		for _, name := range f.Names {
 			var typeName string
@@ -147,11 +149,11 @@ func parseArgs(fields []*ast.Field) ([]arg, error) {
 			case *ast.StarExpr:
 				i, ok := argType.X.(*ast.Ident)
 				if !ok {
-					return nil, ErrUnexpectedType{"*ast.Ident", f.Type}
+					return nil, errUnexpectedType{"*ast.Ident", f.Type}
 				}
 				typeName = "*" + i.Name
 			default:
-				return nil, ErrUnexpectedType{"*ast.Ident or *ast.StarExpr", f.Type}
+				return nil, errUnexpectedType{"*ast.Ident or *ast.StarExpr", f.Type}
 			}
 
 			args = append(args, arg{name.Name, typeName})

--- a/pkg/plugins/pluginrpc-gen/parser_test.go
+++ b/pkg/plugins/pluginrpc-gen/parser_test.go
@@ -22,7 +22,7 @@ func TestParseEmptyInterface(t *testing.T) {
 
 func TestParseNonInterfaceType(t *testing.T) {
 	_, err := Parse(testFixture, "wobble")
-	if _, ok := err.(ErrUnexpectedType); !ok {
+	if _, ok := err.(errUnexpectedType); !ok {
 		t.Fatal("expected type error when parsing non-interface type")
 	}
 }
@@ -109,7 +109,7 @@ func TestParseWithMultipleFuncs(t *testing.T) {
 
 func TestParseWithUnamedReturn(t *testing.T) {
 	_, err := Parse(testFixture, "Fooer4")
-	if !strings.HasSuffix(err.Error(), ErrBadReturn.Error()) {
+	if !strings.HasSuffix(err.Error(), errBadReturn.Error()) {
 		t.Fatalf("expected ErrBadReturn, got %v", err)
 	}
 }


### PR DESCRIPTION
These are the final bits to "enable golint on the code base" for _great and good_ 🐹.

This is doing the following (in 3 commits) :
- Linting `pkg/plugins/pluginrpc-gen` package.
- Linting `pkg/devicemapper` package. That wasn't easy.. @vbatts I'm gonna need some reviews on that one for sure ! I marked some with `(?)` where I was completely lost :sweat_smile:. I ended up un-export a bunch of methods/const/var as they weren't used elsewhere.
- Update the `hack/make/validate-lint` script to **auto-magically** list files that have to pass the `lint` phase 🐙.

🐸

/cc @vbatts @icecrime

Closes #14756 :smile_cat:.
