### PR TITLE
Fix docker volume dangling filter

### DIFF
--- a/daemon/list.go
+++ b/daemon/list.go
@@ -381,7 +381,7 @@ func (daemon *Daemon) Volumes(filter string) ([]*types.Volume, error) {
 
 	volumes := daemon.volumes.List()
 	for _, v := range volumes {
-		if filterUsed && daemon.volumes.Count(v) == 0 {
+		if filterUsed && daemon.volumes.Count(v) > 0 {
 			continue
 		}
 		volumesOut = append(volumesOut, volumeToAPIType(v))

--- a/integration-cli/docker_cli_volume_test.go
+++ b/integration-cli/docker_cli_volume_test.go
@@ -4,6 +4,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/docker/docker/integration-cli/checker"
 	"github.com/go-check/check"
 )
 
@@ -52,6 +53,40 @@ func (s *DockerSuite) TestVolumeCliLs(c *check.C) {
 	// Since there is no guarentee of ordering of volumes, we just make sure the names are in the output
 	c.Assert(strings.Contains(out, id+"\n"), check.Equals, true)
 	c.Assert(strings.Contains(out, "test\n"), check.Equals, true)
+}
+
+func (s *DockerSuite) TestVolumeCliLsFilterDangling(c *check.C) {
+	testRequires(c, DaemonIsLinux)
+
+	dockerCmd(c, "volume", "create", "--name", "testnotinuse1")
+	dockerCmd(c, "volume", "create", "--name", "testisinuse1")
+	dockerCmd(c, "volume", "create", "--name", "testisinuse2")
+
+	// Make sure both "created" (but not started), and started
+	// containers are included in reference counting
+	dockerCmd(c, "run", "--name", "volume-test1", "-v", "testisinuse1:/foo", "busybox", "true")
+	dockerCmd(c, "create", "--name", "volume-test2", "-v", "testisinuse2:/foo", "busybox", "true")
+
+	out, _ := dockerCmd(c, "volume", "ls")
+
+	// No filter, all volumes should show
+	c.Assert(out, checker.Contains, "testnotinuse1\n", check.Commentf("expected volume 'testnotinuse1' in output"))
+	c.Assert(out, checker.Contains, "testisinuse1\n", check.Commentf("expected volume 'testisinuse1' in output"))
+	c.Assert(out, checker.Contains, "testisinuse2\n", check.Commentf("expected volume 'testisinuse2' in output"))
+
+	out, _ = dockerCmd(c, "volume", "ls", "--filter", "dangling=false")
+
+	// Same as above, but expicitly disabling dangling
+	c.Assert(out, checker.Contains, "testnotinuse1\n", check.Commentf("expected volume 'testnotinuse1' in output"))
+	c.Assert(out, checker.Contains, "testisinuse1\n", check.Commentf("expected volume 'testisinuse1' in output"))
+	c.Assert(out, checker.Contains, "testisinuse2\n", check.Commentf("expected volume 'testisinuse2' in output"))
+
+	out, _ = dockerCmd(c, "volume", "ls", "--filter", "dangling=true")
+
+	// Filter "dangling" volumes; ony "dangling" (unused) volumes should be in the output
+	c.Assert(out, checker.Contains, "testnotinuse1\n", check.Commentf("expected volume 'testnotinuse1' in output"))
+	c.Assert(out, check.Not(checker.Contains), "testisinuse1\n", check.Commentf("volume 'testisinuse1' in output, but not expected"))
+	c.Assert(out, check.Not(checker.Contains), "testisinuse2\n", check.Commentf("volume 'testisinuse2' in output, but not expected"))
 }
 
 func (s *DockerSuite) TestVolumeCliRm(c *check.C) {


### PR DESCRIPTION
The `docker volume ls -f dangling=true` filter was inverted; the filtered results actually returned all non-dangling volumes in stead of the 'dangling' ones.

This fixes the filter and adds some integration tests to test the correct behavior.

fixes #16095
