### PR TITLE
Touch up Node.js and MongoDB examples

### DIFF
--- a/docs/articles/using_supervisord.md
+++ b/docs/articles/using_supervisord.md
@@ -10,9 +10,8 @@ parent = "smn_third_party"
 
 # Using Supervisor with Docker
 
-> **Note**:
-> - **If you don't like sudo** then see [*Giving non-root
->   access*](/installation/binaries/#giving-non-root-access)
+> **Note**: **If you don't like sudo** then see [*Giving non-root
+> access*](/installation/binaries/#giving-non-root-access)
 
 Traditionally a Docker container runs a single process when it is
 launched, for example an Apache daemon or a SSH server daemon. Often

--- a/docs/examples/apt-cacher-ng.md
+++ b/docs/examples/apt-cacher-ng.md
@@ -10,11 +10,10 @@ parent = "smn_applied"
 
 # Dockerizing an apt-cacher-ng service
 
-> **Note**: 
-> - **If you don't like sudo** then see [*Giving non-root
->   access*](/installation/binaries/#giving-non-root-access).
-> - **If you're using OS X or docker via TCP** then you shouldn't use
->   sudo.
+> **Note**: **If you don't like sudo** then see [*Giving non-root
+> access*](/installation/binaries/#giving-non-root-access).
+> **If you're using OS X or Docker via TCP** then you shouldn't use
+> sudo.
 
 When you have multiple Docker servers, or build unrelated Docker
 containers which can't make use of the Docker build cache, it can be

--- a/docs/examples/couchdb_data_volumes.md
+++ b/docs/examples/couchdb_data_volumes.md
@@ -10,9 +10,8 @@ parent = "smn_applied"
 
 # Dockerizing a CouchDB service
 
-> **Note**: 
-> - **If you don't like sudo** then see [*Giving non-root
->   access*](/installation/binaries/#giving-non-root-access)
+> **Note**: **If you don't like sudo** then see [*Giving non-root
+> access*](/installation/binaries/#giving-non-root-access)
 
 Here's an example of using data volumes to share the same data between
 two CouchDB containers. This could be used for hot upgrades, testing

--- a/docs/examples/mongodb.md
+++ b/docs/examples/mongodb.md
@@ -16,9 +16,7 @@ In this example, we are going to learn how to build a Docker image with
 MongoDB pre-installed.  We'll also see how to `push` that image to the
 [Docker Hub registry](https://hub.docker.com) and share it with others!
 
-> **Note:**
->
-> This guide will show the mechanics of building a MongoDB container, but
+> **Note:** This guide will show the mechanics of building a MongoDB container, but
 > you will probably want to use the official image on [Docker Hub]( https://registry.hub.docker.com/_/mongo/)
 
 Using Docker and containers for deploying [MongoDB](https://www.mongodb.org/)
@@ -148,7 +146,7 @@ as daemon process(es).
 
     # Dockerized MongoDB, lean and mean!
     # Usage: docker run --name <name for container> -d <user-name>/<repository> --noprealloc --smallfiles
-    $ docker run -p 27017:27017 --name mongo_instance_001 -d my/repo --noprealloc --smallfiles
+    $ docker run -p 27017:27017 --name mongo_instance_001 -d my/repo --smallfiles
 
     # Checking out the logs of a MongoDB container
     # Usage: docker logs <name for container>

--- a/docs/examples/nodejs_web_app.md
+++ b/docs/examples/nodejs_web_app.md
@@ -10,14 +10,11 @@ parent = "smn_applied"
 
 # Dockerizing a Node.js web app
 
-> **Note**: 
-> - **If you don't like sudo** then see [*Giving non-root
->   access*](/installation/binaries/#giving-non-root-access)
+> **Note**: **If you don't like sudo** then see [*Giving non-root
+> access*](/installation/binaries/#giving-non-root-access)
 
-The goal of this example is to show you how you can build your own
-Docker images from a parent image using a `Dockerfile`
-. We will do that by making a simple Node.js hello world web
-application running on CentOS. You can get the full source code at
+In this example, we are going to learn how to build a Docker image to run a
+simple Node.js "hello world" web application on CentOS. You can get the full source code at
 [https://github.com/enokd/docker-node-hello/](https://github.com/enokd/docker-node-hello/).
 
 ## Create Node.js app
@@ -75,16 +72,16 @@ available on the [Docker Hub](https://hub.docker.com/):
 
 Since we're building a Node.js app, you'll have to install Node.js as
 well as npm on your CentOS image. Node.js is required to run your app
-and npm to install your app's dependencies defined in
+and npm is required to install your app's dependencies defined in
 `package.json`. To install the right package for
 CentOS, we'll use the instructions from the [Node.js wiki](
 https://github.com/joyent/node/wiki/Installing-Node.js-
 via-package-manager#rhelcentosscientific-linux-6):
 
-    # Enable EPEL for Node.js
-    RUN     rpm -Uvh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+    # Enable Extra Packages for Enterprise Linux (EPEL) for CentOS
+    RUN     yum install -y epel-release
     # Install Node.js and npm
-    RUN     yum install -y npm
+    RUN     yum install -y nodejs npm
 
 To bundle your app's source code inside the Docker image, use the `COPY`
 instruction:
@@ -97,7 +94,7 @@ Install your app dependencies using the `npm` binary:
     # Install app dependencies
     RUN cd /src; npm install
 
-Your app binds to port `8080` so you'll use the` EXPOSE` instruction to have
+Your app binds to port `8080` so you'll use the `EXPOSE` instruction to have
 it mapped by the `docker` daemon:
 
     EXPOSE  8080
@@ -112,10 +109,10 @@ Your `Dockerfile` should now look like this:
 
     FROM    centos:centos6
 
-    # Enable EPEL for Node.js
-    RUN     rpm -Uvh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+    # Enable Extra Packages for Enterprise Linux (EPEL) for CentOS
+    RUN     yum install -y epel-release
     # Install Node.js and npm
-    RUN     yum install -y npm
+    RUN     yum install -y nodejs npm
 
     # Bundle app source
     COPY . /src

--- a/docs/examples/postgresql_service.md
+++ b/docs/examples/postgresql_service.md
@@ -10,9 +10,8 @@ parent = "smn_applied"
 
 # Dockerizing PostgreSQL
 
-> **Note**: 
-> - **If you don't like sudo** then see [*Giving non-root
->   access*](/installation/binaries/#giving-non-root-access)
+> **Note**: **If you don't like sudo** then see [*Giving non-root
+> access*](/installation/binaries/#giving-non-root-access)
 
 ## Installing PostgreSQL on Docker
 
@@ -21,7 +20,7 @@ Hub](http://hub.docker.com), you can create one yourself.
 
 Start by creating a new `Dockerfile`:
 
-> **Note**: 
+> **Note**:
 > This PostgreSQL setup is for development-only purposes. Refer to the
 > PostgreSQL documentation to fine-tune these settings so that it is
 > suitably secure.
@@ -61,7 +60,7 @@ Start by creating a new `Dockerfile`:
         createdb -O docker docker
 
     # Adjust PostgreSQL configuration so that remote connections to the
-    # database are possible. 
+    # database are possible.
     RUN echo "host all  all    0.0.0.0/0  md5" >> /etc/postgresql/9.3/main/pg_hba.conf
 
     # And add ``listen_addresses`` to ``/etc/postgresql/9.3/main/postgresql.conf``
@@ -88,7 +87,7 @@ There are 2 ways to connect to the PostgreSQL server. We can use [*Link
 Containers*](/userguide/dockerlinks), or we can access it from our host
 (or the network).
 
-> **Note**: 
+> **Note**:
 > The `--rm` removes the container and its image when
 > the container exits successfully.
 


### PR DESCRIPTION
- Remove extraneous '-' in sudo note.
- Correct space formatting (minor).
- Simplify instructions for install EPEL and install with yum directly.
- Add `nodejs` to yum install list explicitly to match the comments -- more transparent for new users who might not be clear `npm` package also installs `nodejs`.
- Remove '--noprealloc` from MongoDB example as the option has been depcated since Mongo 2.6 and is now the default behaviour. See: http://docs.mongodb.org/manual/reference/program/mongod/

Signed-off-by: Charles Chan charleswhchan@users.noreply.github.com
