### PR TITLE
bash completion for `docker volume`

### DIFF
--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -138,6 +138,10 @@ __docker_containers_and_images() {
 	COMPREPLY+=( "${containers[@]}" )
 }
 
+__docker_volumes() {
+	COMPREPLY=( $(compgen -W "$(__docker_q volume ls -q)" -- "$cur") )
+}
+
 # Finds the position of the first word that is neither option nor an option's argument.
 # If there are options that require arguments, you should pass a glob describing those
 # options, e.g. "--option1|-o|--option2"
@@ -1441,6 +1445,99 @@ _docker_version() {
 	esac
 }
 
+_docker_volume_create() {
+	case "$prev" in
+		--driver|-d)
+			COMPREPLY=( $( compgen -W "local" -- "$cur" ) )
+			return
+			;;
+		--name|--opt|-o)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--driver -d --help --name --opt -o" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_volume_inspect() {
+	case "$prev" in
+		--format|-f)
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--format -f --help" -- "$cur" ) )
+			;;
+		*)
+			__docker_volumes
+			;;
+	esac
+}
+
+_docker_volume_ls() {
+	case "$prev" in
+		--filter|-f)
+			COMPREPLY=( $( compgen -W "dangling=true" -- "$cur" ) )
+			return
+			;;
+	esac
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--filter -f --help --quiet -q" -- "$cur" ) )
+			;;
+	esac
+}
+
+_docker_volume_rm() {
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			__docker_volumes
+			;;
+	esac
+}
+
+_docker_volume() {
+	local subcommands=(
+		create
+		inspect
+		ls
+		rm
+	)
+
+	local counter=$(($command_pos + 1))
+	while [ $counter -lt $cword ]; do
+		case "${words[$counter]}" in
+			$(__docker_to_extglob "${subcommands[*]}") )
+				local subcommand=${words[$counter]}
+				local completions_func=_docker_volume_$subcommand
+				declare -F $completions_func >/dev/null && $completions_func
+				return
+				;;
+
+		esac
+		(( counter++ ))
+	done
+
+	case "$cur" in
+		-*)
+			COMPREPLY=( $( compgen -W "--help" -- "$cur" ) )
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "${subcommands[*]}" -- "$cur" ) )
+			;;
+	esac
+}
+
 _docker_wait() {
 	case "$cur" in
 		-*)
@@ -1496,6 +1593,7 @@ _docker() {
 		top
 		unpause
 		version
+		volume
 		wait
 	)
 


### PR DESCRIPTION
ref: #14242, issue #15860

`docker volume` is the first command that has subcommands, so completion had to be extended to deal with those.

In this first step, I chose a minimal version where subcommands parsing is done in `_docker_version` in a similar way as the top level command is determined. This should probably be factored out later and used for both command and subcommand extraction.

There is also no completion for `docker help volume`.
