### PR TITLE
Godoc for the API compatible with swagger generators

### DIFF
--- a/api/server/auth.go
+++ b/api/server/auth.go
@@ -9,6 +9,12 @@ import (
 	"github.com/docker/docker/context"
 )
 
+// @Title postAuth
+// @Description Authenticate the client against a remote registry
+// @Param   version     path    string     false        "API version number"
+// @Param   authConfig  body    []byte     true         "Auth credentials and configuration"
+// @Success 200 {object} types.AuthResponse
+// @Router /auth [post]
 func (s *Server) postAuth(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	var config *cliconfig.AuthConfig
 	err := json.NewDecoder(r.Body).Decode(&config)

--- a/api/server/container.go
+++ b/api/server/container.go
@@ -19,6 +19,12 @@ import (
 	"github.com/docker/docker/runconfig"
 )
 
+// @Title getContainersJSON
+// @Description Retrieve the JSON representation of a list of containers
+// @Param   version     path    string     false        "API version number"
+// @Success 200 {array} types.Container
+// @SubApi /containers
+// @Router /containers/json [get]
 func (s *Server) getContainersJSON(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -48,6 +54,14 @@ func (s *Server) getContainersJSON(ctx context.Context, w http.ResponseWriter, r
 	return writeJSON(w, http.StatusOK, containers)
 }
 
+// @Title getContainersStats
+// @Description Retrieve the JSON representation of a container stats
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   stream      query   boolean    false        "Container ID or name"
+// @Success 200 {array} types.Stats
+// @SubApi /containers
+// @Router /containers/:name/stats [get]
 func (s *Server) getContainersStats(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -89,6 +103,19 @@ func (s *Server) getContainersStats(ctx context.Context, w http.ResponseWriter, 
 	return s.daemon.ContainerStats(container, config)
 }
 
+// @Title getContainersLogs
+// @Description Retrieve the JSON representation of a container logs
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   stdout      query   boolean    false        "Display stdout messages"
+// @Param   stderr      query   boolean    false        "Display stderr messages"
+// @Param   since       query   integer    false        "Display logs since a given timestamp"
+// @Param   follow      query   boolean    false        "Stream the logs to the output"
+// @Param   timestamps  query   boolean    false        "Add timestamps to the logs or not"
+// @Param   tail        query   boolean    false        "Retrieve N number of lines from the tail of the logs"
+// @Success 200 {array} []byte
+// @SubApi /containers
+// @Router /containers/:name/logs [get]
 func (s *Server) getContainersLogs(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -146,6 +173,13 @@ func (s *Server) getContainersLogs(ctx context.Context, w http.ResponseWriter, r
 	return nil
 }
 
+// @Title getContainersExport
+// @Description Export a container as a tarball
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Success 200 {array} []byte
+// @SubApi /containers
+// @Router /containers/:name/export [get]
 func (s *Server) getContainersExport(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -154,6 +188,14 @@ func (s *Server) getContainersExport(ctx context.Context, w http.ResponseWriter,
 	return s.daemon.ContainerExport(vars["name"], w)
 }
 
+// @Title postContainersStart
+// @Description Start a container that has previously been created
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   hostConfig  body    []byte     false        "Container host configuration"
+// @Success 204
+// @SubApi /containers
+// @Router /containers/:name/start [post]
 func (s *Server) postContainersStart(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -190,6 +232,13 @@ func (s *Server) postContainersStart(ctx context.Context, w http.ResponseWriter,
 	return nil
 }
 
+// @Title postContainersStop
+// @Description Stop a running container
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Success 204
+// @SubApi /containers
+// @Router /containers/:name/stop [post]
 func (s *Server) postContainersStop(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -212,6 +261,14 @@ func (s *Server) postContainersStop(ctx context.Context, w http.ResponseWriter, 
 	return nil
 }
 
+// @Title postContainersKill
+// @Description Kill a running container
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   signal      query   string     false        "Signal to kill the container"
+// @Success 204
+// @SubApi /containers
+// @Router /containers/:name/kill [post]
 func (s *Server) postContainersKill(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -260,6 +317,14 @@ func (s *Server) postContainersKill(ctx context.Context, w http.ResponseWriter, 
 	return nil
 }
 
+// @Title postContainersRestart
+// @Description Restart a running container
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   t           query   integer    false        "Timeout to wait until the container starts again"
+// @Success 204
+// @SubApi /containers
+// @Router /containers/:name/restart [post]
 func (s *Server) postContainersRestart(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -279,6 +344,13 @@ func (s *Server) postContainersRestart(ctx context.Context, w http.ResponseWrite
 	return nil
 }
 
+// @Title postContainersPause
+// @Description Pause a running container
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Success 204
+// @SubApi /containers
+// @Router /containers/:name/pause [post]
 func (s *Server) postContainersPause(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -296,6 +368,13 @@ func (s *Server) postContainersPause(ctx context.Context, w http.ResponseWriter,
 	return nil
 }
 
+// @Title postContainersUnpause
+// @Description Unpause a paused container
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Success 204
+// @SubApi /containers
+// @Router /containers/:name/unpause [post]
 func (s *Server) postContainersUnpause(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -313,6 +392,13 @@ func (s *Server) postContainersUnpause(ctx context.Context, w http.ResponseWrite
 	return nil
 }
 
+// @Title postContainersWait
+// @Description Wait for a container until it starts
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Success 200 {object} types.ContainerWaitResponse
+// @SubApi /containers
+// @Router /containers/:name/wait [post]
 func (s *Server) postContainersWait(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -328,6 +414,13 @@ func (s *Server) postContainersWait(ctx context.Context, w http.ResponseWriter, 
 	})
 }
 
+// @Title getContainersChanges
+// @Description Get a list of changes in the container filesystem since it was started
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Success 200 {object} archive.Changes
+// @SubApi /containers
+// @Router /containers/:name/changes [get]
 func (s *Server) getContainersChanges(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -341,6 +434,14 @@ func (s *Server) getContainersChanges(ctx context.Context, w http.ResponseWriter
 	return writeJSON(w, http.StatusOK, changes)
 }
 
+// @Title getContainersTop
+// @Description Get a list of processes running inside the container and their status
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   ps_args     query   string     false        "Arguments to send to the top command inside the container"
+// @Success 200 {object} types.ContainerProcessList
+// @SubApi /containers
+// @Router /containers/:name/top [get]
 func (s *Server) getContainersTop(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -358,6 +459,14 @@ func (s *Server) getContainersTop(ctx context.Context, w http.ResponseWriter, r 
 	return writeJSON(w, http.StatusOK, procList)
 }
 
+// @Title postContainerRename
+// @Description Rename a container
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   name        form    string     true         "New name for the container"
+// @Success 204
+// @SubApi /containers
+// @Router /containers/:name/rename [post]
 func (s *Server) postContainerRename(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -375,6 +484,14 @@ func (s *Server) postContainerRename(ctx context.Context, w http.ResponseWriter,
 	return nil
 }
 
+// @Title postContainerCreate
+// @Description Create a new container from an image
+// @Param   version     path    string     false        "API version number"
+// @Param   name        form    string     false        "Container name"
+// @Param   hostConfig  body    []byte     false        "Container host configuration"
+// @Success 201 {object} types.ContainerCreateResponse
+// @SubApi /containers
+// @Router /containers/:name/create [post]
 func (s *Server) postContainersCreate(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -405,6 +522,16 @@ func (s *Server) postContainersCreate(ctx context.Context, w http.ResponseWriter
 	})
 }
 
+// @Title deleteContainers
+// @Description Create a new container from an image
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container name"
+// @Param   force       query   boolean    false        "Force remove the container"
+// @Param   v           query   boolean    false        "Remove the volumes associated to the container"
+// @Param   link        query   boolean    false        "Remove the links to other containers"
+// @Success 204
+// @SubApi /containers
+// @Router /containers/:name [delete]
 func (s *Server) deleteContainers(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -433,6 +560,15 @@ func (s *Server) deleteContainers(ctx context.Context, w http.ResponseWriter, r 
 	return nil
 }
 
+// @Title postContainersResize
+// @Description Change the tty size of the container
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container name"
+// @Param   h           query   integer    false        "High of the tty"
+// @Param   w           query   integer    false        "Width of the tty"
+// @Success 200
+// @SubApi /containers
+// @Router /containers/:name/resize [post]
 func (s *Server) postContainersResize(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -453,6 +589,18 @@ func (s *Server) postContainersResize(ctx context.Context, w http.ResponseWriter
 	return s.daemon.ContainerResize(vars["name"], height, width)
 }
 
+// @Title postContainersAttach
+// @Description Attach to the container's tty
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container name"
+// @Param   stdin       query   boolean    false        "Attach stdin to the container"
+// @Param   stdout      query   boolean    false        "Attach stdout to the container"
+// @Param   stderr      query   boolean    false        "Attach stderr to the container"
+// @Param   logs        query   boolean    false        "Attach logs from the container"
+// @Param   stream      query   boolean    false        "Stream logs from the container"
+// @Success 200
+// @SubApi /containers
+// @Router /containers/:name/attach [post]
 func (s *Server) postContainersAttach(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -495,6 +643,15 @@ func (s *Server) postContainersAttach(ctx context.Context, w http.ResponseWriter
 	return nil
 }
 
+// @Title wsContainersAttach
+// @Description Attach to the container via a websocket
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container name"
+// @Param   logs        query   boolean    false        "Attach logs from the container"
+// @Param   stream      query   boolean    false        "Stream logs from the container"
+// @Success 200
+// @SubApi /containers
+// @Router /containers/:name/attach [post]
 func (s *Server) wsContainersAttach(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err

--- a/api/server/copy.go
+++ b/api/server/copy.go
@@ -14,6 +14,14 @@ import (
 )
 
 // postContainersCopy is deprecated in favor of getContainersArchive.
+// @Title postContainersCopy
+// @Deprecated
+// @Description Copy a resource from the container to the host
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   copyConfig  body    []byte     true         "Resource configuration and location"
+// @Success 200
+// @Router /containers/:name/copy [post]
 func (s *Server) postContainersCopy(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -68,6 +76,13 @@ func setContainerPathStatHeader(stat *types.ContainerPathStat, header http.Heade
 	return nil
 }
 
+// @Title headContainersArchive
+// @Description Stat the container resource
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   path        query   string     true         "Resource path inside the container"
+// @Success 200
+// @Router /containers/:name/archive [head]
 func (s *Server) headContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v, err := archiveFormValues(r, vars)
 	if err != nil {
@@ -82,6 +97,13 @@ func (s *Server) headContainersArchive(ctx context.Context, w http.ResponseWrite
 	return setContainerPathStatHeader(stat, w.Header())
 }
 
+// @Title getContainersArchive
+// @Description Get a resource from the container in tar format
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   path        query   string     true         "Resource path inside the container"
+// @Success 200
+// @Router /containers/:name/archive [get]
 func (s *Server) getContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v, err := archiveFormValues(r, vars)
 	if err != nil {
@@ -104,6 +126,13 @@ func (s *Server) getContainersArchive(ctx context.Context, w http.ResponseWriter
 	return err
 }
 
+// @Title putContainersArchive
+// @Description Move a resource from the host to the container
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   path        query   string     true         "Resource path in the host"
+// @Success 200
+// @Router /containers/:name/archive [put]
 func (s *Server) putContainersArchive(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v, err := archiveFormValues(r, vars)
 	if err != nil {

--- a/api/server/daemon.go
+++ b/api/server/daemon.go
@@ -20,6 +20,11 @@ import (
 	"github.com/docker/docker/utils"
 )
 
+// @Title getVersion
+// @Description Retrieve the version information for the Docker server
+// @Param   version     path    string     false        "API version number"
+// @Success 200 {object} types.Version
+// @Router /version [get]
 func (s *Server) getVersion(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	v := &types.Version{
 		Version:    dockerversion.VERSION,
@@ -44,6 +49,11 @@ func (s *Server) getVersion(ctx context.Context, w http.ResponseWriter, r *http.
 	return writeJSON(w, http.StatusOK, v)
 }
 
+// @Title getInfo
+// @Description Retrieve the Docker server information
+// @Param   version     path    string     false        "API version number"
+// @Success 200 {object} types.Info
+// @Router /info [get]
 func (s *Server) getInfo(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	info, err := s.daemon.SystemInfo()
 	if err != nil {
@@ -53,6 +63,14 @@ func (s *Server) getInfo(ctx context.Context, w http.ResponseWriter, r *http.Req
 	return writeJSON(w, http.StatusOK, info)
 }
 
+// @Title getEvents
+// @Description Retrieve the events generated in the server
+// @Param   version     path    string     false        "API version number"
+// @Param   since       form    string     false        "Timestamp to start processing events from"
+// @Param   until       form    string     false        "Timestamp to end processing events"
+// @Param   filters     form    string     false        "JSON encoded value of filters to process on the event list"
+// @Success 200 {object} jsonmessage.JSONMessage
+// @Router /events [get]
 func (s *Server) getEvents(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err

--- a/api/server/exec.go
+++ b/api/server/exec.go
@@ -14,6 +14,13 @@ import (
 	"github.com/docker/docker/runconfig"
 )
 
+// @Title getExecByID
+// @Description Get exec process within the container by exec ID
+// @Param   version     path    string     false        "API version number"
+// @Param   id          path    string     true         "Execution ID"
+// @Success 200 {object} daemon.ExecConfig
+// @SubApi /exec
+// @Router /exec/:id/json [get]
 func (s *Server) getExecByID(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter 'id'")
@@ -27,6 +34,14 @@ func (s *Server) getExecByID(ctx context.Context, w http.ResponseWriter, r *http
 	return writeJSON(w, http.StatusOK, eConfig)
 }
 
+// @Title postContainerExecCreate
+// @Description Create a new execution process inside the container
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   execConfig  body    []byte     true         "Execution configuration"
+// @Success 201 {object} types.ContainerExecCreateResponse
+// @SubApi /containers
+// @Router /containers/:name/exec [post]
 func (s *Server) postContainerExecCreate(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -58,7 +73,14 @@ func (s *Server) postContainerExecCreate(ctx context.Context, w http.ResponseWri
 	})
 }
 
-// TODO(vishh): Refactor the code to avoid having to specify stream config as part of both create and start.
+// @Title postContainerExecStart
+// @Description Start an execution process inside the container
+// @Param   version         path    string     false        "API version number"
+// @Param   name            path    string     true         "Container ID or name"
+// @Param   execStartCheck  body    []byte     true         "Execution configuration"
+// @Success 200
+// @SubApi /exec
+// @Router /exec/:name/start [post]
 func (s *Server) postContainerExecStart(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -106,6 +128,15 @@ func (s *Server) postContainerExecStart(ctx context.Context, w http.ResponseWrit
 	return nil
 }
 
+// @Title postContainerExecResize
+// @Description Resize tty for the execution process
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Param   h           query   integer    false        "High of the tty"
+// @Param   w           query   integer    false        "Width of the tty"
+// @Success 200
+// @SubApi /exec
+// @Router /exec/:name/resize [post]
 func (s *Server) postContainerExecResize(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err

--- a/api/server/image.go
+++ b/api/server/image.go
@@ -22,6 +22,18 @@ import (
 	"github.com/docker/docker/utils"
 )
 
+// @Title postCommit
+// @Description Commit a new layer into an image
+// @Param   version     path    string     false        "API version number"
+// @Param   container   form    string     true         "Name of the container to extract the layer from"
+// @Param   pause       form    bool       false        "Pause the container"
+// @Param   repo        form    string     true         "Name of the image to commit the layer to"
+// @Param   tag         form    string     false        "Tag for the image"
+// @Param   author      form    string     false        "Person who committed the new layer"
+// @Param   comment     form    string     false        "Message to describe the changes"
+// @Param   changes     form    []string   true         "List of changes to commit"
+// @Success 200 {object} types.ContainerCommitResponse
+// @Router /commit [post]
 func (s *Server) postCommit(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -64,7 +76,17 @@ func (s *Server) postCommit(ctx context.Context, w http.ResponseWriter, r *http.
 	})
 }
 
-// Creates an image from Pull or from Import
+// @Title postImagesCreate
+// @Description Create an image from Pull or Import
+// @Param   version     path    string     false        "API version number"
+// @Param   fromImage   form    string     false        "Name of the image to inherit from"
+// @Param   fromSrc     form    string     false        "Source to import the image from"
+// @Param   repo        form    string     true         "Name of the image to create"
+// @Param   tag         form    string     false        "Tag for the image"
+// @Param   message     form    string     false        "Message to describe the changes"
+// @Success 200
+// @SubApi /images
+// @Router /images/create [post]
 func (s *Server) postImagesCreate(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -141,6 +163,14 @@ func (s *Server) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 	return nil
 }
 
+// @Title postImagesPush
+// @Description Push an image to the registry
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Name of the image to push"
+// @Param   tag         form    string     false        "Tag for the image"
+// @Success 200
+// @SubApi /images
+// @Router /images/:name/push [post]
 func (s *Server) postImagesPush(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -193,6 +223,14 @@ func (s *Server) postImagesPush(ctx context.Context, w http.ResponseWriter, r *h
 	return nil
 }
 
+// @Title getImagesGet
+// @Description Get an image from the registry
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Name of the image to get"
+// @Param   names       form    []string   false        "Names of the image to get"
+// @Success 200
+// @SubApi /images
+// @Router /images/:name/get [get]
 func (s *Server) getImagesGet(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -221,10 +259,23 @@ func (s *Server) getImagesGet(ctx context.Context, w http.ResponseWriter, r *htt
 	return nil
 }
 
+// @Title postImagesLoad
+// @Description Load an image from the host
+// @Param   version     path    string     false        "API version number"
+// @Success 200
+// @SubApi /images
+// @Router /images/load [post]
 func (s *Server) postImagesLoad(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	return s.daemon.Repositories().Load(r.Body, w)
 }
 
+// @Title deleteImages
+// @Description Delete the image from the host
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Name of the image to delete"
+// @Success 204
+// @SubApi /images
+// @Router /images/:name [delete]
 func (s *Server) deleteImages(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -250,6 +301,13 @@ func (s *Server) deleteImages(ctx context.Context, w http.ResponseWriter, r *htt
 	return writeJSON(w, http.StatusOK, list)
 }
 
+// @Title getImagesByName
+// @Description Retrieve the information for the image
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Name of the image"
+// @Success 200 {object} types.ImagesInspect
+// @SubApi /images
+// @Router /images/:name/json [get]
 func (s *Server) getImagesByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -263,6 +321,28 @@ func (s *Server) getImagesByName(ctx context.Context, w http.ResponseWriter, r *
 	return writeJSON(w, http.StatusOK, imageInspect)
 }
 
+// @Title postBuild
+// @Description Build an image
+// @Param   version       path    string     false        "API version number"
+// @Param   forcerm       form    bool       false        "Remove intermediate containers after completion"
+// @Param   rm            form    string     false        "Remove intermediate containers after completion"
+// @Param   pull          form    bool       false        "Attempt to download a newer version of the image"
+// @Param   remote        form    string     false        "Remote URL to build from, either a tarball or git repository"
+// @Param   dockerfile    form    string     true         "Path to the dockerfile"
+// @Param   t             form    string     true         "Image name"
+// @Param   q             form    bool       false        "Supporess the verbose output"
+// @Param   nocache       form    bool       false        "Do not use the cache when building the image"
+// @Param   memswap       form    integer    false        "Total memory limit, memory + swap"
+// @Param   memory        form    integer    false        "Memory limit"
+// @Param   cpushares     form    integer    false        "Relative CPU shares"
+// @Param   cpuperiod     form    integer    false        "CPU completely fair scheduler period"
+// @Param   cpuquota      form    integer    false        "CPU completely fair scheduler quota"
+// @Param   cpusetcpus    form    string     false        "CPUs in which to allow execution"
+// @Param   cpusetmems    form    string     false        "Memory nodes in which to allow execution"
+// @Param   cgroupparent  form    string     false        "Path to the parent cgroup"
+// @Param   ulimits       form    string     false        "Ulimit options as JSON"
+// @Success 200
+// @Router /build [post]
 func (s *Server) postBuild(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	var (
 		authConfigs        = map[string]cliconfig.AuthConfig{}
@@ -348,6 +428,14 @@ func (s *Server) postBuild(ctx context.Context, w http.ResponseWriter, r *http.R
 	return nil
 }
 
+// @Title getImagesJSON
+// @Description Retrieve the information for all the images in the host
+// @Param   version     path    string     false        "API version number"
+// @Param   filters     form    string     false        "Filters to the image list"
+// @Param   all         form    bool       false        "Show images that are not currently being used"
+// @Success 200 {array} types.Image
+// @SubApi /images
+// @Router /images/json [get]
 func (s *Server) getImagesJSON(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -362,6 +450,13 @@ func (s *Server) getImagesJSON(ctx context.Context, w http.ResponseWriter, r *ht
 	return writeJSON(w, http.StatusOK, images)
 }
 
+// @Title getImagesHistory
+// @Description Retrieve the history information for the image
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Name of the image"
+// @Success 200 {array} types.ImageHistory
+// @SubApi /images
+// @Router /images/:name/history [get]
 func (s *Server) getImagesHistory(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")
@@ -376,6 +471,16 @@ func (s *Server) getImagesHistory(ctx context.Context, w http.ResponseWriter, r 
 	return writeJSON(w, http.StatusOK, history)
 }
 
+// @Title postImagesTag
+// @Description Retrieve the history information for the image
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Name of the image"
+// @Param   repo        form    string     true         "Repository name to push the image to"
+// @Param   tag         form    string     true         "Name of the tag to push"
+// @Param   force       form    bool       false        "Force push the tag"
+// @Success 201
+// @SubApi /images
+// @Router /images/:name/tag [post]
 func (s *Server) postImagesTag(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -396,6 +501,13 @@ func (s *Server) postImagesTag(ctx context.Context, w http.ResponseWriter, r *ht
 	return nil
 }
 
+// @Title getImagesSearch
+// @Description Search images in the remote registry
+// @Param   version     path    string     false        "API version number"
+// @Param   term        form    string     true         "Term to search in the registry"
+// @Success 200 {object} registry.SearchResults
+// @SubApi /images
+// @Router /images/search [get]
 func (s *Server) getImagesSearch(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err

--- a/api/server/inspect.go
+++ b/api/server/inspect.go
@@ -7,7 +7,13 @@ import (
 	"github.com/docker/docker/context"
 )
 
-// getContainersByName inspects containers configuration and serializes it as json.
+// @Title getContainersByName
+// @Description Retrieve the JSON representation of a container
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Container ID or name"
+// @Success 200 {object} types.ContainerJSON
+// @SubApi /containers
+// @Router /containers/:name/json [get]
 func (s *Server) getContainersByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if vars == nil {
 		return fmt.Errorf("Missing parameter")

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -1,3 +1,14 @@
+// Package server contains the api handlers and other api functions.
+// @APIVersion 1.21
+// @APITitle Docker server API
+// @APIDescription API to manage Docker containers
+// @License Apache 2
+// @LicenseUrl http://opensource.org/licenses/Apache-2.0
+//
+// @SubApi Containers API [/containers]
+// @SubApi Images API [/images]
+// @SubApi Volumes API [/volumes]
+// @SubApi Exec API [/exec]
 package server
 
 import (

--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -8,6 +8,13 @@ import (
 	"github.com/docker/docker/context"
 )
 
+// @Title getVolumesList
+// @Description Get the list of volumes registered
+// @Param   version     path    string     false        "API version number"
+// @Param   filters     form    string     false        "Filters for the list of volumes"
+// @Success 200 {object} types.VolumesListResponse
+// @SubApi /volumes
+// @Router /volumes [get]
 func (s *Server) getVolumesList(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -20,6 +27,13 @@ func (s *Server) getVolumesList(ctx context.Context, w http.ResponseWriter, r *h
 	return writeJSON(w, http.StatusOK, &types.VolumesListResponse{Volumes: volumes})
 }
 
+// @Title getVolumeByName
+// @Description Get the list of volumes registered
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Name of the volume"
+// @Success 200 {object} types.Volume
+// @SubApi /volumes
+// @Router /volumes/:name [get]
 func (s *Server) getVolumeByName(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -32,6 +46,13 @@ func (s *Server) getVolumeByName(ctx context.Context, w http.ResponseWriter, r *
 	return writeJSON(w, http.StatusOK, v)
 }
 
+// @Title postVolumesCreate
+// @Description Create a new volume in the host
+// @Param   version     path    string     false        "API version number"
+// @Param   request     form    []byte     true         "Volume configuration"
+// @Success 201 {object} types.Volume
+// @SubApi /volumes
+// @Router /volumes [post]
 func (s *Server) postVolumesCreate(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err
@@ -53,6 +74,13 @@ func (s *Server) postVolumesCreate(ctx context.Context, w http.ResponseWriter, r
 	return writeJSON(w, http.StatusCreated, volume)
 }
 
+// @Title deleteVolumes
+// @Description Delete the volume from the host
+// @Param   version     path    string     false        "API version number"
+// @Param   name        path    string     true         "Name of the volume"
+// @Success 204
+// @SubApi /volumes
+// @Router /volumes/:name [delete]
 func (s *Server) deleteVolumes(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
 	if err := parseForm(r); err != nil {
 		return err


### PR DESCRIPTION
With this approach, we will be able to generate API documentation from go comments.
I think I like it better because it's less intrusive than moving to a
new router framework.

/cc @icecrime

Signed-off-by: David Calavera david.calavera@gmail.com
