### PR TITLE
Make RegistryConfig a typed value in the api.

### DIFF
--- a/api/client/utils.go
+++ b/api/client/utils.go
@@ -27,6 +27,7 @@ import (
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/docker/registry"
+	"github.com/docker/docker/utils"
 )
 
 var (
@@ -96,7 +97,7 @@ func (cli *DockerCli) clientRequest(method, path string, in io.Reader, headers m
 	}
 
 	if err != nil {
-		if types.IsTimeout(err) || strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "dial unix") {
+		if utils.IsTimeout(err) || strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "dial unix") {
 			return serverResp, errConnectionFailed
 		}
 

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/docker/docker/daemon/network"
 	"github.com/docker/docker/pkg/version"
+	"github.com/docker/docker/registry"
 	"github.com/docker/docker/runconfig"
 )
 
@@ -201,7 +202,7 @@ type Info struct {
 	KernelVersion      string
 	OperatingSystem    string
 	IndexServerAddress string
-	RegistryConfig     interface{}
+	RegistryConfig     *registry.ServiceConfig
 	InitSha1           string
 	InitPath           string
 	NCPU               int

--- a/registry/session.go
+++ b/registry/session.go
@@ -20,12 +20,12 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/httputils"
 	"github.com/docker/docker/pkg/ioutils"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/tarsum"
+	"github.com/docker/docker/utils"
 )
 
 var (
@@ -425,7 +425,7 @@ func (r *Session) GetRepositoryData(remote string) (*RepositoryData, error) {
 		// and return a non-obtuse error message for users
 		// "Get https://index.docker.io/v1/repositories/library/busybox/images: i/o timeout"
 		// was a top search on the docker user forum
-		if types.IsTimeout(err) {
+		if utils.IsTimeout(err) {
 			return nil, fmt.Errorf("Network timed out while trying to connect to %s. You may want to check your internet connection or if you are behind a proxy.", repositoryTarget)
 		}
 		return nil, fmt.Errorf("Error while pulling image: %v", err)

--- a/utils/timeout.go
+++ b/utils/timeout.go
@@ -1,4 +1,4 @@
-package types
+package utils
 
 import (
 	"net"


### PR DESCRIPTION
Remove possible circular dependency that prevented us from using a real
type.

Signed-off-by: David Calavera david.calavera@gmail.com
