### PR TITLE
[Fix 16122] usage for `docker volume inspect` and `docker volume rm`

### DIFF
--- a/api/client/volume.go
+++ b/api/client/volume.go
@@ -102,7 +102,7 @@ func (cli *DockerCli) CmdVolumeLs(args ...string) error {
 //
 // Usage: docker volume inspect [OPTIONS] VOLUME [VOLUME...]
 func (cli *DockerCli) CmdVolumeInspect(args ...string) error {
-	cmd := Cli.Subcmd("volume inspect", []string{"[VOLUME NAME]"}, "Return low-level information on a volume", true)
+	cmd := Cli.Subcmd("volume inspect", []string{"VOLUME [VOLUME...]"}, "Return low-level information on a volume", true)
 	tmplStr := cmd.String([]string{"f", "-format"}, "", "Format the output using the given go template.")
 	if err := cmd.Parse(args); err != nil {
 		return nil
@@ -210,7 +210,7 @@ func (cli *DockerCli) CmdVolumeCreate(args ...string) error {
 //
 // Usage: docker volume rm VOLUME [VOLUME...]
 func (cli *DockerCli) CmdVolumeRm(args ...string) error {
-	cmd := Cli.Subcmd("volume rm", []string{"[NAME]"}, "Remove a volume", true)
+	cmd := Cli.Subcmd("volume rm", []string{"VOLUME [VOLUME...]"}, "Remove a volume", true)
 	cmd.Require(flag.Min, 1)
 	cmd.ParseFlags(args, true)
 

--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -10,9 +10,9 @@ parent = "smn_cli"
 
 # volume inspect
 
-    Usage: docker volume inspect [OPTIONS] [VOLUME NAME]
+    Usage: docker volume inspect [OPTIONS] VOLUME [VOLUME...]
 
-    Inspect a volume
+    Inspect one or more volumes
 
     -f, --format=       Format the output using the given go template.
 

--- a/docs/reference/commandline/volume_rm.md
+++ b/docs/reference/commandline/volume_rm.md
@@ -10,13 +10,13 @@ parent = "smn_cli"
 
 # volume rm
 
-    Usage: docker volume rm [OPTIONS] [VOLUME NAME]
+    Usage: docker volume rm [OPTIONS] VOLUME [VOLUME...]
 
     Remove a volume
 
     --help=false       Print usage
 
-Removes a volume. You cannot remove a volume that is in use by a container.
+Removes one or more volumes. You cannot remove a volume that is in use by a container.
 
   $ docker volume rm hello
   hello

--- a/man/docker-volume-inspect.1.md
+++ b/man/docker-volume-inspect.1.md
@@ -8,11 +8,11 @@ docker-volume-inspect - Get low-level information about a volume
 **docker volume inspect**
 [**-f**|**--format**[=**]]
 
-[OPTIONS] [VOLUME NAME]
+[OPTIONS] VOLUME [VOLUME...]
 
 # DESCRIPTION
 
-Returns information about a volume. By default, this command renders all results
+Returns information about one or more volumes. By default, this command renders all results
 in a JSON array. You can specify an alternate format to execute a given template
 is executed for each result. Go's
 http://golang.org/pkg/text/template/ package describes all the details of the

--- a/man/docker-volume-rm.1.md
+++ b/man/docker-volume-rm.1.md
@@ -7,11 +7,11 @@ docker-volume-rm - Remove a volume
 # SYNOPSIS
 **docker volume rm**
 
-[OPTIONS] [VOLUME NAME]
+[OPTIONS] VOLUME [VOLUME...]
 
 # DESCRIPTION
 
-Removes a volume. You cannot remove a volume that is in use by a container.
+Removes one or more volumes. You cannot remove a volume that is in use by a container.
 
     ```
     $ docker volume rm hello


### PR DESCRIPTION
ref: #16122

For both commands, volume is **not** optional. In addition, more than one volume may be specified.
Both commands now use the same name (VOLUME) for the command argument.

Note that this corresponds to the code comments right above the changed functions.
