### PR TITLE
Remove -lpthread and -ldl from ldflags

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -150,12 +150,9 @@ BUILDFLAGS=( $BUILDFLAGS "${ORIG_BUILDFLAGS[@]}" )
 : ${TIMEOUT:=60m}
 TESTFLAGS+=" -test.timeout=${TIMEOUT}"
 
-# A few more flags that are specific just to building a completely-static binary (see hack/make/binary)
-# PLEASE do not use these anywhere else.
-EXTLDFLAGS_STATIC_DOCKER="$EXTLDFLAGS_STATIC -lpthread -ldl"
 LDFLAGS_STATIC_DOCKER="
 	$LDFLAGS_STATIC
-	-extldflags \"$EXTLDFLAGS_STATIC_DOCKER\"
+	-extldflags \"$EXTLDFLAGS_STATIC\"
 "
 
 if [ "$(uname -s)" = 'FreeBSD' ]; then

--- a/hack/make/.dockerinit-gccgo
+++ b/hack/make/.dockerinit-gccgo
@@ -11,7 +11,7 @@ go build --compiler=gccgo \
 	--gccgoflags "
 		-g
 		-Wl,--no-export-dynamic
-		$EXTLDFLAGS_STATIC_DOCKER
+		$EXTLDFLAGS_STATIC
 		-lnetgo
 	" \
 	./dockerinit

--- a/hack/make/dyngccgo
+++ b/hack/make/dyngccgo
@@ -13,7 +13,7 @@ fi
 
 (
 	export IAMSTATIC="false"
-	export EXTLDFLAGS_STATIC_DOCKER=''
+	export EXTLDFLAGS_STATIC=''
 	export LDFLAGS_STATIC_DOCKER=''
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/netgo /}" ) # disable netgo, since we don't need it for a dynamic binary
 	export BUILDFLAGS=( "${BUILDFLAGS[@]/static_build /}" ) # we're not building a "static" binary here

--- a/hack/make/gccgo
+++ b/hack/make/gccgo
@@ -8,14 +8,14 @@ BINARY_FULLNAME="$BINARY_NAME$BINARY_EXTENSION"
 source "${MAKEDIR}/.go-autogen"
 
 if [[ "${BUILDFLAGS[@]}" =~ 'netgo ' ]]; then
-	EXTLDFLAGS_STATIC_DOCKER+=' -lnetgo'
+	EXTLDFLAGS_STATIC+=' -lnetgo'
 fi
 go build -compiler=gccgo \
 	-o "$DEST/$BINARY_FULLNAME" \
 	"${BUILDFLAGS[@]}" \
 	-gccgoflags "
 		-g
-		$EXTLDFLAGS_STATIC_DOCKER
+		$EXTLDFLAGS_STATIC
 		-Wl,--no-export-dynamic
 		-ldl
 	" \


### PR DESCRIPTION
There is no need in those flags now when we use amalgamated sqlite3 from
mattn/go-sqlite3.
