### PR TITLE
Use pkg/mount to support more flags in dm.mountopt

### DIFF
--- a/daemon/graphdriver/devmapper/deviceset.go
+++ b/daemon/graphdriver/devmapper/deviceset.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/devicemapper"
+	"github.com/docker/docker/pkg/mount"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/units"
 	"github.com/opencontainers/runc/libcontainer/label"
@@ -1718,7 +1719,7 @@ func (devices *DeviceSet) MountDevice(hash, path, mountLabel string) error {
 	options = joinMountOptions(options, devices.mountOptions)
 	options = joinMountOptions(options, label.FormatMountLabel("", mountLabel))
 
-	if err := syscall.Mount(info.DevName(), path, fstype, syscall.MS_MGC_VAL, options); err != nil {
+	if err := mount.Mount(info.DevName(), path, fstype, options); err != nil {
 		return fmt.Errorf("Error mounting '%s' on '%s': %s", info.DevName(), path, err)
 	}
 


### PR DESCRIPTION
The mount syscall does not handle string flags like "noatime",
we must use bitmasks like MS_NOATIME instead.

pkg/mount.Mount already handles this work.  Use pkg/mount.Unmount for
symmetry.

Signed-off-by: Carl Henrik Lunde chlunde@ping.uio.no

PS! I initially wanted this because docker ps --all --size made each container use more space, and eventually filled my disk.
