### PR TITLE
Ignore stat errors on volume rm.

### DIFF
--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -152,7 +152,7 @@ func (daemon *Daemon) VolumeRm(name string) error {
 		if err == ErrVolumeInUse {
 			return fmt.Errorf("Conflict: %v", err)
 		}
-		return err
+		return fmt.Errorf("Error while removing volume %s: %v", name, err)
 	}
 	return nil
 }

--- a/volume/local/local_test.go
+++ b/volume/local/local_test.go
@@ -1,0 +1,81 @@
+package local
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestRemove(t *testing.T) {
+	rootDir, err := ioutil.TempDir("", "local-volume-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(rootDir)
+
+	r, err := New(rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vol, err := r.Create("testing", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.Remove(vol); err != nil {
+		t.Fatal(err)
+	}
+
+	vol, err = r.Create("testing2", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(vol.Path()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := r.Remove(vol); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(vol.Path()); err != nil && !os.IsNotExist(err) {
+		t.Fatal("volume dir not removed")
+	}
+
+	if len(r.List()) != 0 {
+		t.Fatal("expected there to be no volumes")
+	}
+}
+
+func TestInitializeWithVolumes(t *testing.T) {
+	rootDir, err := ioutil.TempDir("", "local-volume-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(rootDir)
+
+	r, err := New(rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vol, err := r.Create("testing", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err = New(rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v, err := r.Get(vol.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if v.Path() != vol.Path() {
+		t.Fatal("expected to re-initialize root with existing volumes")
+	}
+}


### PR DESCRIPTION
Underlying volume data may have been removed by some other tool.
Ignore and remove the reference in this case.

ping @vieux 
This should fix the lstat errors you were seeing on `docker volume rm`
