### PR TITLE
Golint only on changed files

### DIFF
--- a/hack/make/validate-lint
+++ b/hack/make/validate-lint
@@ -2,15 +2,14 @@
 
 source "${MAKEDIR}/.validate"
 
-packages=( $(go list ./... 2> /dev/null | grep -vE "^github.com/docker/docker/vendor|^github.com/docker/docker/autogen" || true ) )
+IFS=$'\n'
+files=( $(validate_diff --diff-filter=ACMR --name-only -- '*.go' | grep -v '^vendor/' || true) )
+unset IFS
 
 errors=()
-for p in "${packages[@]}"; do
-	# Remove the github.com/docker/docker/ prefix from listed package
-	package="${p#github.com/docker/docker/}"
-	# Run golint on package/*.go file explicitly to validate all go files
-	# and not just the ones for the current platform.
-	failedLint=$(golint $package/*.go)
+for f in "${files[@]}"; do
+	# we use "git show" here to validate that what's committed passes go vet
+	failedLint=$(golint "$f")
 	if [ "$failedLint" ]; then
 		errors+=( "$failedLint" )
 	fi


### PR DESCRIPTION
Just a real quick follow-up to #16096, based on @runcom  [comment](https://github.com/docker/docker/pull/16096#discussion_r38878781), now that we know for a fact that the source is `linted`, **we might want to run `golint` only on changed files**. 🐙

This updates `validate-lint` to used `validate_diff` command (this makes the bash code even smaller and cleaner :stuck_out_tongue_closed_eyes:).

🐹 I've put some `lint` errors to make sure and prove that it works :smile_cat:.

Given the follwing diff…

``` diff
diff --git a/cliconfig/config.go b/cliconfig/config.go
index 4e289a7..89ba0ea 100644
--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -1,3 +1,4 @@
+// Something is wrong here too
 package cliconfig

 import (
@@ -35,6 +36,9 @@ func init() {
        }
 }

+func Blabla() {
+}
+
 // ConfigDir returns the directory the configuration file is stored in
 func ConfigDir() string {
        return configDir
```

… the output is as follow:

``` bash
---> Making bundle: validate-lint (in bundles/1.9.0-dev/validate-lint)
Errors from golint:
cliconfig/config.go:1:1: package comment should be of the form "Package cliconfig ..."
cliconfig/config.go:39:1: exported function Blabla should have comment or be unexported
```

🐸

/cc @icecrime @jfrazelle @tianon 

Signed-off-by: Vincent Demeester vincent@sbr.pm
