### PR TITLE
hack/make.sh: rm unneeded linker flags

### DIFF
--- a/hack/make.sh
+++ b/hack/make.sh
@@ -152,7 +152,7 @@ TESTFLAGS+=" -test.timeout=${TIMEOUT}"
 
 # A few more flags that are specific just to building a completely-static binary (see hack/make/binary)
 # PLEASE do not use these anywhere else.
-EXTLDFLAGS_STATIC_DOCKER="$EXTLDFLAGS_STATIC -lpthread -ldl"
+EXTLDFLAGS_STATIC_DOCKER="$EXTLDFLAGS_STATIC"
 LDFLAGS_STATIC_DOCKER="
 	$LDFLAGS_STATIC
 	-extldflags \"$EXTLDFLAGS_STATIC_DOCKER\"


### PR DESCRIPTION
1. Flag -ldl was added by me in commit 15aad5d. No one (including me)
   noticed that since sqlite3 is now being built with OMIT_LOAD_EXTENTION
   (see https://github.com/docker/docker/pull/16094) we no longer need -ldl.
2. Flag -lpthread was added by @crosbymichael in commit a263e07, I can't
   figure out why. I tried rebuilding with this flag removed and it's
   working just fine, so let's assume the flag is no longer needed.

PS ideally these should be two separate commits, but let's go wild!

This is sort of a followup to https://github.com/docker/docker/pull/15387.
