### PR TITLE
Use TrimSpace to instead of Trim

### DIFF
--- a/api/client/login.go
+++ b/api/client/login.go
@@ -64,7 +64,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 	if username == "" {
 		promptDefault("Username", authconfig.Username)
 		username = readInput(cli.in, cli.out)
-		username = strings.Trim(username, " ")
+		username = strings.TrimSpace(username)
 		if username == "" {
 			username = authconfig.Username
 		}


### PR DESCRIPTION
String.Trim(string, " ") can only get ride of the blank, but actully we need
to remove all leading and trailing white space include "\t" for example.

Prior to this patch, one can login with "[Tab][Tab]username", and it will
not be considered as the same with "username".

Signed-off-by: Hu Keping hukeping@huawei.com
