### PR TITLE
Retire email address field

### DIFF
--- a/api/client/login.go
+++ b/api/client/login.go
@@ -16,20 +16,19 @@ import (
 	"github.com/docker/docker/registry"
 )
 
-// CmdLogin logs in or registers a user to a Docker registry service.
+// CmdLogin logs in a user to a Docker registry service.
 //
-// If no server is specified, the user will be logged into or registered to the registry's index server.
+// If no server is specified, the user will be logged into the registry's index server.
 //
 // Usage: docker login SERVER
 func (cli *DockerCli) CmdLogin(args ...string) error {
 	cmd := Cli.Subcmd("login", []string{"[SERVER]"}, Cli.DockerCommands["login"].Description+".\nIf no server is specified \""+registry.IndexServer+"\" is the default.", true)
 	cmd.Require(flag.Max, 1)
 
-	var username, password, email string
+	var username, password string
 
 	cmd.StringVar(&username, []string{"u", "-username"}, "", "Username")
 	cmd.StringVar(&password, []string{"p", "-password"}, "", "Password")
-	cmd.StringVar(&email, []string{"e", "-email"}, "", "Email")
 
 	cmd.ParseFlags(args, true)
 
@@ -75,7 +74,7 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 		}
 	}
 	// Assume that a different username means they may not want to use
-	// the password or email from the config file, so prompt them
+	// the password from the config file, so prompt them
 	if username != authconfig.Username {
 		if password == "" {
 			oldState, err := term.SaveState(cli.inFd)
@@ -93,29 +92,17 @@ func (cli *DockerCli) CmdLogin(args ...string) error {
 				return fmt.Errorf("Error : Password Required")
 			}
 		}
-
-		if email == "" {
-			promptDefault("Email", authconfig.Email)
-			email = readInput(cli.in, cli.out)
-			if email == "" {
-				email = authconfig.Email
-			}
-		}
 	} else {
 		// However, if they don't override the username use the
-		// password or email from the cmd line if specified. IOW, allow
+		// password from the cmd line if specified. IOW, allow
 		// then to change/override them.  And if not specified, just
 		// use what's in the config file
 		if password == "" {
 			password = authconfig.Password
 		}
-		if email == "" {
-			email = authconfig.Email
-		}
 	}
 	authconfig.Username = username
 	authconfig.Password = password
-	authconfig.Email = email
 	authconfig.ServerAddress = serverAddress
 	cli.configFile.AuthConfigs[serverAddress] = authconfig
 

--- a/api/types/auth.go
+++ b/api/types/auth.go
@@ -5,7 +5,6 @@ type AuthConfig struct {
 	Username      string `json:"username,omitempty"`
 	Password      string `json:"password,omitempty"`
 	Auth          string `json:"auth"`
-	Email         string `json:"email"`
 	ServerAddress string `json:"serveraddress,omitempty"`
 	RegistryToken string `json:"registrytoken,omitempty"`
 }

--- a/cliconfig/config.go
+++ b/cliconfig/config.go
@@ -84,11 +84,6 @@ func (configFile *ConfigFile) LegacyLoadFromReader(configData io.Reader) error {
 		if err != nil {
 			return err
 		}
-		origEmail := strings.Split(arr[1], " = ")
-		if len(origEmail) != 2 {
-			return fmt.Errorf("Invalid Auth config file")
-		}
-		authConfig.Email = origEmail[1]
 		authConfig.ServerAddress = defaultIndexserver
 		configFile.AuthConfigs[defaultIndexserver] = authConfig
 	} else {

--- a/cliconfig/config_test.go
+++ b/cliconfig/config_test.go
@@ -181,7 +181,14 @@ email = user@example.com`
 	// Now save it and make sure it shows up in new form
 	configStr := saveConfigAndValidateNewFormat(t, config, tmpHome)
 
-	if !strings.Contains(configStr, "user@example.com") {
+	if configStr != `{
+	"auths": {
+		"https://index.docker.io/v1/": {
+			"auth": "am9lam9lOmhlbGxv",
+			"email": "user@example.com"
+		}
+	}
+}` {
 		t.Fatalf("Should have save in new form: %s", configStr)
 	}
 }
@@ -243,7 +250,14 @@ func TestOldJson(t *testing.T) {
 	// Now save it and make sure it shows up in new form
 	configStr := saveConfigAndValidateNewFormat(t, config, tmpHome)
 
-	if !strings.Contains(configStr, "user@example.com") {
+	if configStr != `{
+	"auths": {
+		"https://index.docker.io/v1/": {
+			"auth": "am9lam9lOmhlbGxv",
+			"email": "user@example.com"
+		}
+	}
+}` {
 		t.Fatalf("Should have save in new form: %s", configStr)
 	}
 }
@@ -274,7 +288,14 @@ func TestNewJson(t *testing.T) {
 	// Now save it and make sure it shows up in new form
 	configStr := saveConfigAndValidateNewFormat(t, config, tmpHome)
 
-	if !strings.Contains(configStr, "user@example.com") {
+	if configStr != `{
+	"auths": {
+		"https://index.docker.io/v1/": {
+			"auth": "am9lam9lOmhlbGxv",
+			"email": "user@example.com"
+		}
+	}
+}` {
 		t.Fatalf("Should have save in new form: %s", configStr)
 	}
 }
@@ -423,8 +444,15 @@ func TestJsonSaveWithNoFile(t *testing.T) {
 		t.Fatalf("Failed saving to file: %q", err)
 	}
 	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, ConfigFileName))
-	if !strings.Contains(string(buf), `"auths":`) ||
-		!strings.Contains(string(buf), "user@example.com") {
+	if string(buf) != `{
+	"auths": {
+		"https://index.docker.io/v1/": {
+			"auth": "am9lam9lOmhlbGxv",
+			"email": "user@example.com"
+		}
+	},
+	"psFormat": "table {{.ID}}\\t{{.Label \"com.docker.label.cpu\"}}"
+}` {
 		t.Fatalf("Should have save in new form: %s", string(buf))
 	}
 
@@ -451,8 +479,14 @@ func TestLegacyJsonSaveWithNoFile(t *testing.T) {
 		t.Fatalf("Failed saving to file: %q", err)
 	}
 	buf, err := ioutil.ReadFile(filepath.Join(tmpHome, ConfigFileName))
-	if !strings.Contains(string(buf), `"auths":`) ||
-		!strings.Contains(string(buf), "user@example.com") {
+	if string(buf) != `{
+	"auths": {
+		"https://index.docker.io/v1/": {
+			"auth": "am9lam9lOmhlbGxv",
+			"email": "user@example.com"
+		}
+	}
+}` {
 		t.Fatalf("Should have save in new form: %s", string(buf))
 	}
 }

--- a/cliconfig/config_test.go
+++ b/cliconfig/config_test.go
@@ -174,7 +174,7 @@ email = user@example.com`
 
 	// defaultIndexserver is https://index.docker.io/v1/
 	ac := config.AuthConfigs["https://index.docker.io/v1/"]
-	if ac.Email != "user@example.com" || ac.Username != "joejoe" || ac.Password != "hello" {
+	if ac.Username != "joejoe" || ac.Password != "hello" {
 		t.Fatalf("Missing data from parsing:\n%q", config)
 	}
 
@@ -184,8 +184,7 @@ email = user@example.com`
 	if configStr != `{
 	"auths": {
 		"https://index.docker.io/v1/": {
-			"auth": "am9lam9lOmhlbGxv",
-			"email": "user@example.com"
+			"auth": "am9lam9lOmhlbGxv"
 		}
 	}
 }` {
@@ -243,7 +242,7 @@ func TestOldJson(t *testing.T) {
 	}
 
 	ac := config.AuthConfigs["https://index.docker.io/v1/"]
-	if ac.Email != "user@example.com" || ac.Username != "joejoe" || ac.Password != "hello" {
+	if ac.Username != "joejoe" || ac.Password != "hello" {
 		t.Fatalf("Missing data from parsing:\n%q", config)
 	}
 
@@ -253,8 +252,7 @@ func TestOldJson(t *testing.T) {
 	if configStr != `{
 	"auths": {
 		"https://index.docker.io/v1/": {
-			"auth": "am9lam9lOmhlbGxv",
-			"email": "user@example.com"
+			"auth": "am9lam9lOmhlbGxv"
 		}
 	}
 }` {
@@ -281,7 +279,7 @@ func TestNewJson(t *testing.T) {
 	}
 
 	ac := config.AuthConfigs["https://index.docker.io/v1/"]
-	if ac.Email != "user@example.com" || ac.Username != "joejoe" || ac.Password != "hello" {
+	if ac.Username != "joejoe" || ac.Password != "hello" {
 		t.Fatalf("Missing data from parsing:\n%q", config)
 	}
 
@@ -291,8 +289,7 @@ func TestNewJson(t *testing.T) {
 	if configStr != `{
 	"auths": {
 		"https://index.docker.io/v1/": {
-			"auth": "am9lam9lOmhlbGxv",
-			"email": "user@example.com"
+			"auth": "am9lam9lOmhlbGxv"
 		}
 	}
 }` {
@@ -384,7 +381,7 @@ func TestJsonReaderNoFile(t *testing.T) {
 	}
 
 	ac := config.AuthConfigs["https://index.docker.io/v1/"]
-	if ac.Email != "user@example.com" || ac.Username != "joejoe" || ac.Password != "hello" {
+	if ac.Username != "joejoe" || ac.Password != "hello" {
 		t.Fatalf("Missing data from parsing:\n%q", config)
 	}
 
@@ -399,7 +396,7 @@ func TestOldJsonReaderNoFile(t *testing.T) {
 	}
 
 	ac := config.AuthConfigs["https://index.docker.io/v1/"]
-	if ac.Email != "user@example.com" || ac.Username != "joejoe" || ac.Password != "hello" {
+	if ac.Username != "joejoe" || ac.Password != "hello" {
 		t.Fatalf("Missing data from parsing:\n%q", config)
 	}
 }
@@ -447,8 +444,7 @@ func TestJsonSaveWithNoFile(t *testing.T) {
 	if string(buf) != `{
 	"auths": {
 		"https://index.docker.io/v1/": {
-			"auth": "am9lam9lOmhlbGxv",
-			"email": "user@example.com"
+			"auth": "am9lam9lOmhlbGxv"
 		}
 	},
 	"psFormat": "table {{.ID}}\\t{{.Label \"com.docker.label.cpu\"}}"
@@ -482,8 +478,7 @@ func TestLegacyJsonSaveWithNoFile(t *testing.T) {
 	if string(buf) != `{
 	"auths": {
 		"https://index.docker.io/v1/": {
-			"auth": "am9lam9lOmhlbGxv",
-			"email": "user@example.com"
+			"auth": "am9lam9lOmhlbGxv"
 		}
 	}
 }` {

--- a/contrib/completion/bash/docker
+++ b/contrib/completion/bash/docker
@@ -1052,14 +1052,14 @@ _docker_load() {
 
 _docker_login() {
 	case "$prev" in
-		--email|-e|--password|-p|--username|-u)
+		--password|-p|--username|-u)
 			return
 			;;
 	esac
 
 	case "$cur" in
 		-*)
-			COMPREPLY=( $( compgen -W "--email -e --help --password -p --username -u" -- "$cur" ) )
+			COMPREPLY=( $( compgen -W "--help --password -p --username -u" -- "$cur" ) )
 			;;
 	esac
 }

--- a/contrib/completion/fish/docker.fish
+++ b/contrib/completion/fish/docker.fish
@@ -221,8 +221,7 @@ complete -c docker -A -f -n '__fish_seen_subcommand_from load' -l help -d 'Print
 complete -c docker -A -f -n '__fish_seen_subcommand_from load' -s i -l input -d 'Read from a tar archive file, instead of STDIN'
 
 # login
-complete -c docker -f -n '__fish_docker_no_subcommand' -a login -d 'Register or log in to a Docker registry server'
-complete -c docker -A -f -n '__fish_seen_subcommand_from login' -s e -l email -d 'Email'
+complete -c docker -f -n '__fish_docker_no_subcommand' -a login -d 'Log in to a Docker registry server'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -l help -d 'Print usage'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -s p -l password -d 'Password'
 complete -c docker -A -f -n '__fish_seen_subcommand_from login' -s u -l username -d 'Username'

--- a/contrib/completion/zsh/_docker
+++ b/contrib/completion/zsh/_docker
@@ -745,7 +745,6 @@ __docker_subcommand() {
         (login)
             _arguments $(__docker_arguments) \
                 $opts_help \
-                "($help -e --email)"{-e=,--email=}"[Email]:email: " \
                 "($help -p --password)"{-p=,--password=}"[Password]:password: " \
                 "($help -u --user)"{-u=,--user=}"[Username]:username: " \
                 "($help -)1:server: " && ret=0

--- a/docs/misc/deprecated.md
+++ b/docs/misc/deprecated.md
@@ -110,6 +110,7 @@ are deprecated and replaced with double-dash options (`--opt`):
 
 The following double-dash options are deprecated and have no replacement:
 
+    docker login --email
     docker run --cpuset
     docker run --networking
     docker ps --since-id

--- a/docs/reference/commandline/login.md
+++ b/docs/reference/commandline/login.md
@@ -12,10 +12,9 @@ parent = "smn_cli"
 
     Usage: docker login [OPTIONS] [SERVER]
 
-    Register or log in to a Docker registry server, if no server is
+    Log in to a Docker registry server, if no server is
 	specified "https://index.docker.io/v1/" is the default.
 
-      -e, --email=""       Email
       --help=false         Print usage
       -p, --password=""    Password
       -u, --username=""    Username

--- a/docs/userguide/dockerrepos.md
+++ b/docs/userguide/dockerrepos.md
@@ -32,15 +32,13 @@ Docker itself provides access to Docker Hub services via the `docker search`,
 ### Account creation and login
 Typically, you'll want to start by creating an account on Docker Hub (if you haven't
 already) and logging in. You can create your account directly on
-[Docker Hub](https://hub.docker.com/account/signup/), or by running:
+[Docker Hub](https://hub.docker.com/account/signup/).
+
+Log in by running:
 
     $ docker login
 
-This will prompt you for a user name, which will become the public namespace for your
-public repositories.
-If your user name is available, Docker will prompt you to enter a password and your
-e-mail address. It will then automatically log you in. You can now commit and
-push your own images up to your repos on Docker Hub.
+You can now commit and push your own images up to your repos on Docker Hub.
 
 > **Note:**
 > Your authentication credentials will be stored in the `~/.docker/config.json`

--- a/man/docker-login.1.md
+++ b/man/docker-login.1.md
@@ -2,18 +2,17 @@
 % Docker Community
 % JUNE 2014
 # NAME
-docker-login - Register or log in to a Docker registry. 
+docker-login - Log in to a Docker registry.
 
 # SYNOPSIS
 **docker login**
-[**-e**|**--email**[=*EMAIL*]]
 [**--help**]
 [**-p**|**--password**[=*PASSWORD*]]
 [**-u**|**--username**[=*USERNAME*]]
 [SERVER]
 
 # DESCRIPTION
-Register or log in to a Docker Registry located on the specified
+Log in to a Docker Registry located on the specified
 `SERVER`.  You can specify a URL or a `hostname` for the `SERVER` value. If you
 do not specify a `SERVER`, the command uses Docker's public registry located at
 `https://registry-1.docker.io/` by default.  To get a username/password for Docker's public registry, create an account on Docker Hub.
@@ -31,9 +30,6 @@ credentials.  When you log in, the command stores encoded credentials in
 >
 
 # OPTIONS
-**-e**, **--email**=""
-   Email
-
 **--help**
   Print usage statement
 

--- a/registry/auth.go
+++ b/registry/auth.go
@@ -12,7 +12,7 @@ import (
 	registrytypes "github.com/docker/docker/api/types/registry"
 )
 
-// Login tries to register/login to the registry server.
+// Login tries to login to the registry server.
 func Login(authConfig *types.AuthConfig, registryEndpoint *Endpoint) (string, error) {
 	// Separates the v2 registry login logic from the v1 logic.
 	if registryEndpoint.Version == APIVersion2 {
@@ -21,7 +21,7 @@ func Login(authConfig *types.AuthConfig, registryEndpoint *Endpoint) (string, er
 	return loginV1(authConfig, registryEndpoint)
 }
 
-// loginV1 tries to register/login to the v1 registry server.
+// loginV1 tries to login to the v1 registry server.
 func loginV1(authConfig *types.AuthConfig, registryEndpoint *Endpoint) (string, error) {
 	var (
 		status         string
@@ -61,15 +61,7 @@ func loginV1(authConfig *types.AuthConfig, registryEndpoint *Endpoint) (string, 
 		return "", fmt.Errorf("Server Error: [%#v] %s", respStatusCode, err)
 	}
 
-	if respStatusCode == 201 {
-		if loginAgainstOfficialIndex {
-			status = "Account created. Please use the confirmation link we sent" +
-				" to your e-mail to activate it."
-		} else {
-			// *TODO: Use registry configuration to determine what this says, if anything?
-			status = "Account created. Please see the documentation of the registry " + serverAddress + " for instructions how to activate it."
-		}
-	} else if respStatusCode == 400 {
+	if respStatusCode == 400 {
 		if string(respBody) == "\"Username or email already exists\"" {
 			req, err := http.NewRequest("GET", serverAddress+"users/", nil)
 			req.SetBasicAuth(authConfig.Username, authConfig.Password)

--- a/registry/auth_test.go
+++ b/registry/auth_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEncodeAuth(t *testing.T) {
-	newAuthConfig := &types.AuthConfig{Username: "ken", Password: "test", Email: "test@example.com"}
+	newAuthConfig := &types.AuthConfig{Username: "ken", Password: "test"}
 	authStr := cliconfig.EncodeAuth(newAuthConfig)
 	decAuthConfig := &types.AuthConfig{}
 	var err error
@@ -35,7 +35,6 @@ func buildAuthConfigs() map[string]types.AuthConfig {
 		authConfigs[registry] = types.AuthConfig{
 			Username: "docker-user",
 			Password: "docker-pass",
-			Email:    "docker@docker.io",
 		}
 	}
 
@@ -49,9 +48,6 @@ func TestSameAuthDataPostSave(t *testing.T) {
 		t.Fail()
 	}
 	if authConfig.Password != "docker-pass" {
-		t.Fail()
-	}
-	if authConfig.Email != "docker@docker.io" {
 		t.Fail()
 	}
 	if authConfig.Auth != "" {
@@ -83,17 +79,14 @@ func TestResolveAuthConfigFullURL(t *testing.T) {
 	registryAuth := types.AuthConfig{
 		Username: "foo-user",
 		Password: "foo-pass",
-		Email:    "foo@example.com",
 	}
 	localAuth := types.AuthConfig{
 		Username: "bar-user",
 		Password: "bar-pass",
-		Email:    "bar@example.com",
 	}
 	officialAuth := types.AuthConfig{
 		Username: "baz-user",
 		Password: "baz-pass",
-		Email:    "baz@example.com",
 	}
 	authConfigs[IndexServer] = officialAuth
 
@@ -126,7 +119,7 @@ func TestResolveAuthConfigFullURL(t *testing.T) {
 
 	for configKey, registries := range validRegistries {
 		configured, ok := expectedAuths[configKey]
-		if !ok || configured.Email == "" {
+		if !ok {
 			t.Fail()
 		}
 		index := &registrytypes.IndexInfo{
@@ -135,13 +128,13 @@ func TestResolveAuthConfigFullURL(t *testing.T) {
 		for _, registry := range registries {
 			authConfigs[registry] = configured
 			resolved := ResolveAuthConfig(authConfigs, index)
-			if resolved.Email != configured.Email {
-				t.Errorf("%s -> %q != %q\n", registry, resolved.Email, configured.Email)
+			if resolved.Username != configured.Username || resolved.Password != configured.Password {
+				t.Errorf("%s -> %v != %v\n", registry, resolved, configured)
 			}
 			delete(authConfigs, registry)
 			resolved = ResolveAuthConfig(authConfigs, index)
-			if resolved.Email == configured.Email {
-				t.Errorf("%s -> %q == %q\n", registry, resolved.Email, configured.Email)
+			if resolved.Username == configured.Username || resolved.Password == configured.Password {
+				t.Errorf("%s -> %v == %v\n", registry, resolved, configured)
 			}
 		}
 	}

--- a/registry/session.go
+++ b/registry/session.go
@@ -750,7 +750,6 @@ func (r *Session) GetAuthConfig(withPasswd bool) *types.AuthConfig {
 	return &types.AuthConfig{
 		Username: r.authConfig.Username,
 		Password: password,
-		Email:    r.authConfig.Email,
 	}
 }
 


### PR DESCRIPTION
I'm working on a third-party registry and it confused me that `docker login` will prompt for an email address which isn't even used for authentication.

This change will drop the unused email address while keeping support for reading configuration files that include the email address (plenty of the current tests assert that).

closes https://github.com/docker/docker/issues/6400
