### PR TITLE
pkg: devicemapper: fix typo in function declaration

### DIFF
--- a/pkg/devicemapper/devmapper_wrapper_deferred_remove.go
+++ b/pkg/devicemapper/devmapper_wrapper_deferred_remove.go
@@ -11,11 +11,11 @@ import "C"
 // LibraryDeferredRemovalsupport is supported when statically linked.
 const LibraryDeferredRemovalSupport = true
 
-func dmTaskDeferredRemoveFct(task *CDmTask) int {
+func dmTaskDeferredRemoveFct(task *cdmTask) int {
 	return int(C.dm_task_deferred_remove((*C.struct_dm_task)(task)))
 }
 
-func dmTaskGetInfoWithDeferredFct(task *CDmTask, info *Info) int {
+func dmTaskGetInfoWithDeferredFct(task *cdmTask, info *Info) int {
 	Cinfo := C.struct_dm_info{}
 	defer func() {
 		info.Exists = int(Cinfo.exists)


### PR DESCRIPTION
6990b76a696dd265674f4c2973f25755a6485f05 introduced a typo in function
declaration, this patch fixes that.

Actually @shishir-a412ed had a build error while building master with this typo while I hadn't (we're both on fedora 22 but he ran `./hack/make.sh dynbinary` and me just `make`)
Reproduced error is (on fedora 22 with `AUTO_GOPATH=1 ./hack/make.sh dynbinary`):

```
 ---> Making bundle: dynbinary (in bundles/1.9.0-dev/dynbinary)
Created binary: bundles/1.9.0-dev/dynbinary/dockerinit-1.9.0-dev
Building: bundles/1.9.0-dev/dynbinary/docker-1.9.0-dev
# github.com/docker/docker/pkg/devicemapper
.gopath/src/github.com/docker/docker/pkg/devicemapper/devmapper_wrapper_deferred_remove.go:14: undefined: CDmTask
.gopath/src/github.com/docker/docker/pkg/devicemapper/devmapper_wrapper_deferred_remove.go:18: undefined: CDmTask
```

Signed-off-by: Antonio Murdaca runcom@linux.com
