### PR TITLE
Update docs and man pages for `docker volume` subcommands

### DIFF
--- a/docs/reference/commandline/volume_inspect.md
+++ b/docs/reference/commandline/volume_inspect.md
@@ -15,6 +15,7 @@ parent = "smn_cli"
     Inspect one or more volumes
 
     -f, --format=       Format the output using the given go template.
+    --help=false        Print usage
 
 Returns information about a volume. By default, this command renders all results
 in a JSON array. You can specify an alternate format to execute a given template

--- a/man/docker-volume-create.1.md
+++ b/man/docker-volume-create.1.md
@@ -6,11 +6,10 @@ docker-volume-create - Create a new volume
 
 # SYNOPSIS
 **docker volume create**
-[**-d**|**--driver**[=*local*]]
-[**--name**[=**]]
-[**-o**|**--opt**[=**]]
-
-[OPTIONS]
+[**-d**|**--driver**[=*DRIVER*]]
+[**--help**]
+[**--name**[=*NAME*]]
+[**-o**|**--opt**[=*[]*]]
 
 # DESCRIPTION
 
@@ -40,11 +39,16 @@ different volume drivers may do different things (or nothing at all).
 *Note*: The built-in `local` volume driver does not currently accept any options.
 
 # OPTIONS
-**-d**, **--driver**=[]
-   Specify volume driver name
+**-d**, **--driver**="local"
+  Specify volume driver name
+
+**--help**
+  Print usage statement
+
 **--name**=""
   Specify volume name
-**-o**, **--opt**=map[]
+
+**-o**, **--opt**=[]
   Set driver specific options
 
 # HISTORY

--- a/man/docker-volume-inspect.1.md
+++ b/man/docker-volume-inspect.1.md
@@ -6,9 +6,9 @@ docker-volume-inspect - Get low-level information about a volume
 
 # SYNOPSIS
 **docker volume inspect**
-[**-f**|**--format**[=**]]
-
-[OPTIONS] VOLUME [VOLUME...]
+[**-f**|**--format**[=*FORMAT*]]
+[**--help**]
+VOLUME [VOLUME...]
 
 # DESCRIPTION
 
@@ -20,7 +20,10 @@ format.
 
 # OPTIONS
 **-f**, **--format**=""
-   Format the output using the given go template.
+  Format the output using the given go template.
+
+**--help**
+  Print usage statement
 
 # HISTORY
 July 2015, created by Brian Goff <cpuguy83@gmail.com>

--- a/man/docker-volume-ls.1.md
+++ b/man/docker-volume-ls.1.md
@@ -6,10 +6,9 @@ docker-volume-ls - List all volumes
 
 # SYNOPSIS
 **docker volume ls**
-[**-f**|**--filter**[=**]]
-[**-q**|**--quiet**[=**]]
-
-[OPTIONS]
+[**-f**|**--filter**[=*FILTER*]]
+[**--help**]
+[**-q**|**--quiet**[=*true*|*false*]]
 
 # DESCRIPTION
 
@@ -19,7 +18,11 @@ There is a single supported filter `dangling=value` which takes a boolean of `tr
 
 # OPTIONS
 **-f**, **--filter**=""
-   Provide filter values (i.e. 'dangling=true')
+  Provide filter values (i.e. 'dangling=true')
+
+**--help**
+  Print usage statement
+
 **-q**, **--quiet**=false
   Only display volume names
 

--- a/man/docker-volume-rm.1.md
+++ b/man/docker-volume-rm.1.md
@@ -6,19 +6,21 @@ docker-volume-rm - Remove a volume
 
 # SYNOPSIS
 **docker volume rm**
-
-[OPTIONS] VOLUME [VOLUME...]
+[**--help**]
+VOLUME [VOLUME...]
 
 # DESCRIPTION
 
 Removes one or more volumes. You cannot remove a volume that is in use by a container.
 
-    ```
-    $ docker volume rm hello
-    hello
-    ```
+  ```
+  $ docker volume rm hello
+  hello
+  ```
 
 # OPTIONS
+**--help**
+  Print usage statement
 
 # HISTORY
 July 2015, created by Brian Goff <cpuguy83@gmail.com>


### PR DESCRIPTION
- One reference page lacked the `--help` option
- The man pages had no `--help` option
- There were some formatting issues in the man pages, e.g. missing blank lines between the options
- aligned some syntax details with existing pages
