### PR TITLE
Refactoring of bufReader

### DIFF
--- a/pkg/ioutils/bytespipe.go
+++ b/pkg/ioutils/bytespipe.go
@@ -1,15 +1,16 @@
 package ioutils
 
-const maxCap = 10 * 1e6
+const maxCap = 1e6
 
-// BytesPipe is io.ReadWriter which works similary to pipe(queue).
-// All written data could be read only once. Also BytesPipe trying to adjust
-// internal []byte slice to current needs, so there won't be overgrown buffer
-// after highload peak.
+// BytesPipe is io.ReadWriter which works similarly to pipe(queue).
+// All written data could be read only once. Also BytesPipe is allocating
+// and releasing new byte slices to adjust to current needs, so there won't be
+// overgrown buffer after high load peak.
 // BytesPipe isn't goroutine-safe, caller must synchronize it if needed.
 type BytesPipe struct {
-	buf      []byte
-	lastRead int
+	buf      [][]byte // slice of byte-slices of buffered data
+	lastRead int      // index in the first slice to a read point
+	bufLen   int      // length of data buffered over the slices
 }
 
 // NewBytesPipe creates new BytesPipe, initialized by specified slice.
@@ -20,63 +21,69 @@ func NewBytesPipe(buf []byte) *BytesPipe {
 		buf = make([]byte, 0, 64)
 	}
 	return &BytesPipe{
-		buf: buf[:0],
-	}
-}
-
-func (bp *BytesPipe) grow(n int) {
-	if len(bp.buf)+n > cap(bp.buf) {
-		// not enough space
-		var buf []byte
-		remain := bp.len()
-		if remain+n <= cap(bp.buf)/2 {
-			// enough space in current buffer, just move data to head
-			copy(bp.buf, bp.buf[bp.lastRead:])
-			buf = bp.buf[:remain]
-		} else {
-			// reallocate buffer
-			buf = make([]byte, remain, 2*cap(bp.buf)+n)
-			copy(buf, bp.buf[bp.lastRead:])
-		}
-		bp.buf = buf
-		bp.lastRead = 0
+		buf: [][]byte{buf[:0]},
 	}
 }
 
 // Write writes p to BytesPipe.
-// It can increase cap of internal []byte slice in a process of writing.
+// It can allocate new []byte slices in a process of writing.
 func (bp *BytesPipe) Write(p []byte) (n int, err error) {
-	bp.grow(len(p))
-	bp.buf = append(bp.buf, p...)
+	for {
+		// write data to the last buffer
+		b := bp.buf[len(bp.buf)-1]
+		// copy data to the current empty allocated area
+		n := copy(b[len(b):cap(b)], p)
+		// increment buffered data length
+		bp.bufLen += n
+		// include written data in last buffer
+		bp.buf[len(bp.buf)-1] = b[:len(b)+n]
+
+		// if there was enough room to write all then break
+		if len(p) == n {
+			break
+		}
+
+		// more data: write to the next slice
+		p = p[n:]
+		// allocate slice that has twice the size of the last unless maximum reached
+		nextCap := 2 * cap(bp.buf[len(bp.buf)-1])
+		if maxCap < nextCap {
+			nextCap = maxCap
+		}
+		// add new byte slice to the buffers slice and continue writing
+		bp.buf = append(bp.buf, make([]byte, 0, nextCap))
+	}
 	return
 }
 
 func (bp *BytesPipe) len() int {
-	return len(bp.buf) - bp.lastRead
-}
-
-func (bp *BytesPipe) crop() {
-	// shortcut for empty buffer
-	if bp.lastRead == len(bp.buf) {
-		bp.lastRead = 0
-		bp.buf = bp.buf[:0]
-	}
-	r := bp.len()
-	// if we have too large buffer for too small data
-	if cap(bp.buf) > maxCap && r < cap(bp.buf)/10 {
-		copy(bp.buf, bp.buf[bp.lastRead:])
-		// will use same underlying slice until reach cap
-		bp.buf = bp.buf[:r : cap(bp.buf)/2]
-		bp.lastRead = 0
-	}
+	return bp.bufLen - bp.lastRead
 }
 
 // Read reads bytes from BytesPipe.
 // Data could be read only once.
-// Internal []byte slice could be shrinked.
 func (bp *BytesPipe) Read(p []byte) (n int, err error) {
-	n = copy(p, bp.buf[bp.lastRead:])
-	bp.lastRead += n
-	bp.crop()
+	for {
+		read := copy(p, bp.buf[0][bp.lastRead:])
+		n += read
+		bp.lastRead += read
+		if bp.len() == 0 {
+			// we have read everything. reset to the beginning.
+			bp.lastRead = 0
+			bp.bufLen -= len(bp.buf[0])
+			bp.buf[0] = bp.buf[0][:0]
+			break
+		}
+		// break if everything was read
+		if len(p) == read {
+			break
+		}
+		// more buffered data and more asked. read from next slice.
+		p = p[read:]
+		bp.lastRead = 0
+		bp.bufLen -= len(bp.buf[0])
+		bp.buf[0] = nil     // throw away old slice
+		bp.buf = bp.buf[1:] // switch to next
+	}
 	return
 }

--- a/pkg/ioutils/bytespipe.go
+++ b/pkg/ioutils/bytespipe.go
@@ -1,0 +1,82 @@
+package ioutils
+
+const maxCap = 10 * 1e6
+
+// BytesPipe is io.ReadWriter which works similary to pipe(queue).
+// All written data could be read only once. Also BytesPipe trying to adjust
+// internal []byte slice to current needs, so there won't be overgrown buffer
+// after highload peak.
+// BytesPipe isn't goroutine-safe, caller must synchronize it if needed.
+type BytesPipe struct {
+	buf      []byte
+	lastRead int
+}
+
+// NewBytesPipe creates new BytesPipe, initialized by specified slice.
+// If buf is nil, then it will be initialized with slice which cap is 64.
+// buf will be adjusted in a way that len(buf) == 0, cap(buf) == cap(buf).
+func NewBytesPipe(buf []byte) *BytesPipe {
+	if cap(buf) == 0 {
+		buf = make([]byte, 0, 64)
+	}
+	return &BytesPipe{
+		buf: buf[:0],
+	}
+}
+
+func (bp *BytesPipe) grow(n int) {
+	if len(bp.buf)+n > cap(bp.buf) {
+		// not enough space
+		var buf []byte
+		remain := bp.len()
+		if remain+n <= cap(bp.buf)/2 {
+			// enough space in current buffer, just move data to head
+			copy(bp.buf, bp.buf[bp.lastRead:])
+			buf = bp.buf[:remain]
+		} else {
+			// reallocate buffer
+			buf = make([]byte, remain, 2*cap(bp.buf)+n)
+			copy(buf, bp.buf[bp.lastRead:])
+		}
+		bp.buf = buf
+		bp.lastRead = 0
+	}
+}
+
+// Write writes p to BytesPipe.
+// It can increase cap of internal []byte slice in a process of writing.
+func (bp *BytesPipe) Write(p []byte) (n int, err error) {
+	bp.grow(len(p))
+	bp.buf = append(bp.buf, p...)
+	return
+}
+
+func (bp *BytesPipe) len() int {
+	return len(bp.buf) - bp.lastRead
+}
+
+func (bp *BytesPipe) crop() {
+	// shortcut for empty buffer
+	if bp.lastRead == len(bp.buf) {
+		bp.lastRead = 0
+		bp.buf = bp.buf[:0]
+	}
+	r := bp.len()
+	// if we have too large buffer for too small data
+	if cap(bp.buf) > maxCap && r < cap(bp.buf)/10 {
+		copy(bp.buf, bp.buf[bp.lastRead:])
+		// will use same underlying slice until reach cap
+		bp.buf = bp.buf[:r : cap(bp.buf)/2]
+		bp.lastRead = 0
+	}
+}
+
+// Read reads bytes from BytesPipe.
+// Data could be read only once.
+// Internal []byte slice could be shrinked.
+func (bp *BytesPipe) Read(p []byte) (n int, err error) {
+	n = copy(p, bp.buf[bp.lastRead:])
+	bp.lastRead += n
+	bp.crop()
+	return
+}

--- a/pkg/ioutils/bytespipe_test.go
+++ b/pkg/ioutils/bytespipe_test.go
@@ -1,0 +1,81 @@
+package ioutils
+
+import "testing"
+
+func TestBytesPipeRead(t *testing.T) {
+	buf := NewBytesPipe(nil)
+	buf.Write([]byte("12"))
+	buf.Write([]byte("34"))
+	buf.Write([]byte("56"))
+	buf.Write([]byte("78"))
+	buf.Write([]byte("90"))
+	rd := make([]byte, 4)
+	n, err := buf.Read(rd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 4 {
+		t.Fatalf("Wrong number of bytes read: %d, should be %d", n, 4)
+	}
+	if string(rd) != "1234" {
+		t.Fatalf("Read %s, but must be %s", rd, "1234")
+	}
+	n, err = buf.Read(rd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 4 {
+		t.Fatalf("Wrong number of bytes read: %d, should be %d", n, 4)
+	}
+	if string(rd) != "5678" {
+		t.Fatalf("Read %s, but must be %s", rd, "5679")
+	}
+	n, err = buf.Read(rd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("Wrong number of bytes read: %d, should be %d", n, 2)
+	}
+	if string(rd[:n]) != "90" {
+		t.Fatalf("Read %s, but must be %s", rd, "90")
+	}
+}
+
+func TestBytesPipeWrite(t *testing.T) {
+	buf := NewBytesPipe(nil)
+	buf.Write([]byte("12"))
+	buf.Write([]byte("34"))
+	buf.Write([]byte("56"))
+	buf.Write([]byte("78"))
+	buf.Write([]byte("90"))
+	if string(buf.buf) != "1234567890" {
+		t.Fatalf("Buffer %s, must be %s", buf.buf, "1234567890")
+	}
+}
+
+func BenchmarkBytesPipeWrite(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		buf := NewBytesPipe(nil)
+		for j := 0; j < 1000; j++ {
+			buf.Write([]byte("pretty short line, because why not?"))
+		}
+	}
+}
+
+func BenchmarkBytesPipeRead(b *testing.B) {
+	rd := make([]byte, 1024)
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		buf := NewBytesPipe(nil)
+		for j := 0; j < 1000; j++ {
+			buf.Write(make([]byte, 1024))
+		}
+		b.StartTimer()
+		for j := 0; j < 1000; j++ {
+			if n, _ := buf.Read(rd); n != 1024 {
+				b.Fatalf("Wrong number of bytes: %d", n)
+			}
+		}
+	}
+}

--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -5,11 +5,7 @@ import (
 	"encoding/hex"
 	"io"
 	"sync"
-
-	"github.com/docker/docker/pkg/random"
 )
-
-var rndSrc = random.NewSource()
 
 type readCloserWrapper struct {
 	io.Reader

--- a/pkg/ioutils/readers_test.go
+++ b/pkg/ioutils/readers_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"strings"
 	"testing"
+	"time"
 )
 
 // Implement io.Reader
@@ -61,8 +62,8 @@ func TestNewBufReaderWithDrainbufAndBuffer(t *testing.T) {
 	reader, writer := io.Pipe()
 
 	drainBuffer := make([]byte, 1024)
-	buffer := bytes.Buffer{}
-	bufreader := NewBufReaderWithDrainbufAndBuffer(reader, drainBuffer, &buffer)
+	buffer := NewBytesPipe(nil)
+	bufreader := NewBufReaderWithDrainbufAndBuffer(reader, drainBuffer, buffer)
 
 	// Write everything down to a Pipe
 	// Usually, a pipe should block but because of the buffered reader,
@@ -76,7 +77,11 @@ func TestNewBufReaderWithDrainbufAndBuffer(t *testing.T) {
 
 	// Drain the reader *after* everything has been written, just to verify
 	// it is indeed buffering
-	<-done
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("timeout")
+	}
 
 	output, err := ioutil.ReadAll(bufreader)
 	if err != nil {


### PR DESCRIPTION
Now it consumes much less memory and doesn't require complicated checks to release unused memory.
Before case with "yes adkfljdsalkjflkdsalkfdsalkfldsafjdsaf" took less than 20 seconds to eat all memory, no it take 30 minutes. So, it can easily survive pikes in load.
It doesn't solve leaks for slow reader totally, only dropping info from streams can solve that.
