### PR TITLE
Carry #15539: Avoid redundant HEAD requests on push

### DIFF
--- a/graph/push.go
+++ b/graph/push.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/cliconfig"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/registry"
@@ -44,12 +45,13 @@ func (s *TagStore) NewPusher(endpoint registry.APIEndpoint, localRepo Repository
 	switch endpoint.Version {
 	case registry.APIVersion2:
 		return &v2Pusher{
-			TagStore:  s,
-			endpoint:  endpoint,
-			localRepo: localRepo,
-			repoInfo:  repoInfo,
-			config:    imagePushConfig,
-			sf:        sf,
+			TagStore:     s,
+			endpoint:     endpoint,
+			localRepo:    localRepo,
+			repoInfo:     repoInfo,
+			config:       imagePushConfig,
+			sf:           sf,
+			layersPushed: make(map[digest.Digest]bool),
 		}, nil
 	case registry.APIVersion1:
 		return &v1Pusher{


### PR DESCRIPTION
Carries #15539 to avoid redundant HEAD requests to a V2 registry during a push.

This improvement was originally added in #14884, but was reverted due to a regression. This PR is a corrected version.

Fixes #14873

cc @stevvooe @endophage @icecrime @dmcgowan @tiborvass @jfrazelle
