### PR TITLE
Always close `Broadcaster` after pull

### DIFF
--- a/graph/pull_v1.go
+++ b/graph/pull_v1.go
@@ -191,6 +191,7 @@ func (p *v1Puller) pullRepository(askedTag string) error {
 				return
 			}
 			broadcaster.Write(p.sf.FormatProgress(stringid.TruncateID(img.ID), "Download complete", nil))
+			broadcaster.Close()
 
 			errors <- nil
 		}

--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -95,7 +95,7 @@ func (p *v2Puller) pullV2Repository(tag string) (err error) {
 	}
 
 	writeStatus(taggedName, broadcaster, p.sf, layersDownloaded)
-
+	broadcaster.Close()
 	return nil
 }
 


### PR DESCRIPTION
One of the test I updated as part of #16039 is showing random behavior on the CI (see [here](https://jenkins.dockerproject.org/job/Docker-PRs/15369/console) and [here](https://jenkins.dockerproject.org/job/Docker-PRs/15188/console)). I believe the test itself is not racy, but that it revealed a racy behavior of the server-side code.

I'm not 100% convinced this is the proper fix as I cannot reproduce the race locally.

> In an attempt to fix a race condition in the client-side output of a pull operation, always properly call `Close()` on a `Broadcaster` instance once done in order to flush its buffer.
