### PR TITLE
Update SUSE/openSUSE installation script

### DIFF
--- a/hack/install.sh
+++ b/hack/install.sh
@@ -80,6 +80,16 @@ check_forked() {
 	fi
 }
 
+rpm_import_repository_key() {
+	local key=$1; shift
+	local tmpdir=$(mktemp -d)
+	chmod 600 "$tmpdir"
+	gpg --homedir "$tmpdir" --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"
+	gpg --homedir "$tmpdir" --export --armor "$key" > "$tmpdir"/repo.key
+	rpm --import "$tmpdir"/repo.key
+	rm -rf "$tmpdir"
+}
+
 do_install() {
 	case "$(uname -m)" in
 		*64)
@@ -231,10 +241,60 @@ do_install() {
 			exit 0
 			;;
 
-		'opensuse project'|opensuse|'suse linux'|sle[sd])
+		'opensuse project'|opensuse)
+			echo 'Going to perform the following operations:'
+			if [ "$repo" != 'main' ]; then
+				echo '  * add repository obs://Virtualization:containers'
+			fi
+			echo '  * install Docker'
+			$sh_c 'echo "Press CTRL-C to abort"; sleep 3'
+
+			if [ "$repo" != 'main' ]; then
+				# install experimental packages from OBS://Virtualization:containers
+				(
+					set -x
+					zypper -n ar -f obs://Virtualization:containers Virtualization:containers
+					rpm_import_repository_key 55A0B34D49501BB7CA474F5AA193FBB572174FC2
+				)
+			fi
 			(
 				set -x
-				$sh_c 'sleep 3; zypper -n install docker'
+				zypper -n install docker
+			)
+			echo_docker_as_nonroot
+			exit 0
+			;;
+		'suse linux'|sle[sd])
+			echo 'Going to perform the following operations:'
+			if [ "$repo" != 'main' ]; then
+				echo '  * add repository obs://Virtualization:containers'
+				echo '  * install experimental Docker using packages NOT supported by SUSE'
+			else
+				echo '  * add the "Containers" module'
+				echo '  * install Docker using packages supported by SUSE'
+			fi
+			$sh_c 'echo "Press CTRL-C to abort"; sleep 3'
+
+			if [ "$repo" != 'main' ]; then
+				# install experimental packages from OBS://Virtualization:containers
+				echo >&2 'Warning: installing experimental packages from OBS, these packages are NOT supported by SUSE'
+				(
+					set -x
+					zypper -n ar -f obs://Virtualization:containers/SLE_12 Virtualization:containers
+					rpm_import_repository_key 55A0B34D49501BB7CA474F5AA193FBB572174FC2
+				)
+			else
+				# Add the containers module
+				# Note well-1: the SLE machine must already be registered against SUSE Customer Center
+				# Note well-2: the `-r ""` is required to workaround a known issue of SUSEConnect
+				(
+					set -x
+					SUSEConnect -p sle-module-containers/12/x86_64 -r ""
+				)
+			fi
+			(
+				set -x
+				zypper -n install docker
 			)
 			echo_docker_as_nonroot
 			exit 0


### PR DESCRIPTION
Fix installation on SUSE Linux Enterprise machine, the updated Docker RPMs have been moved to a different location.

Update both openSUSE and SUSE Linux Enterprise scripts to allow the installation of experimental builds.

This is required to add openSUSE and SUSE Linux Enterprise support to docker-machine, as discussed on [this](https://github.com/docker/machine/pull/1436) pull request.
