### PR TITLE
Broadcaster writer goroutines must only finish when they are caught up

### DIFF
--- a/pkg/progressreader/broadcaster.go
+++ b/pkg/progressreader/broadcaster.go
@@ -77,6 +77,12 @@ func (broadcaster *Broadcaster) receiveWrites(observer io.Writer) {
 
 		broadcaster.Lock()
 
+		// If we are behind, we need to catch up instead of waiting
+		// or handling a closure.
+		if len(broadcaster.history) != n {
+			continue
+		}
+
 		// detect closure of the broadcast writer
 		if broadcaster.closed() {
 			broadcaster.Unlock()
@@ -84,9 +90,7 @@ func (broadcaster *Broadcaster) receiveWrites(observer io.Writer) {
 			return
 		}
 
-		if len(broadcaster.history) == n {
-			broadcaster.cond.Wait()
-		}
+		broadcaster.cond.Wait()
 
 		// Mutex is still locked as the loop continues
 	}


### PR DESCRIPTION
Without this change, there was a narrow race condition that would allow
writers to finish when there was still data left to write. This is
likely to be what was causing some integration tests to fail with
truncated pull output.

Signed-off-by: Aaron Lehmann aaron.lehmann@docker.com
