### PR TITLE
add helpful note for mac/virtualbox users

### DIFF
--- a/docs/project/set-up-dev-env.md
+++ b/docs/project/set-up-dev-env.md
@@ -127,6 +127,8 @@ environment.
 
         Successfully built 676815d59283
 
+    > **Note:** Mac users may need to open/map port 4444 in VirtualBox to avoid a build error involving getting gpg keys from a key server.
+
 6. List your Docker images again.
 
         $ docker images


### PR DESCRIPTION
Had some problems building from source following the stock directions on my Mac + VirtualBox.  The part during 'docker build' that grabs a gpg key kept failing.  A lot of googling later I found an offhand reference to opening port 4444 on VirtualBox.  I mapped port 4444 and it worked fine after that.  Maybe this note will help someone else.
