### PR TITLE
Add context.RequestID to event stream

### DIFF
--- a/api/server/container.go
+++ b/api/server/container.go
@@ -45,7 +45,7 @@ func (s *Server) getContainersJSON(ctx context.Context, w http.ResponseWriter, r
 		config.Limit = limit
 	}
 
-	containers, err := s.daemon.Containers(config)
+	containers, err := s.daemon.Containers(ctx, config)
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (s *Server) getContainersStats(ctx context.Context, w http.ResponseWriter, 
 		Version:   version,
 	}
 
-	return s.daemon.ContainerStats(vars["name"], config)
+	return s.daemon.ContainerStats(ctx, vars["name"], config)
 }
 
 func (s *Server) getContainersLogs(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -118,7 +118,7 @@ func (s *Server) getContainersLogs(ctx context.Context, w http.ResponseWriter, r
 		closeNotifier = notifier.CloseNotify()
 	}
 
-	c, err := s.daemon.Get(vars["name"])
+	c, err := s.daemon.Get(ctx, vars["name"])
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (s *Server) getContainersLogs(ctx context.Context, w http.ResponseWriter, r
 		Stop:       closeNotifier,
 	}
 
-	if err := s.daemon.ContainerLogs(c, logsConfig); err != nil {
+	if err := s.daemon.ContainerLogs(ctx, c, logsConfig); err != nil {
 		// The client may be expecting all of the data we're sending to
 		// be multiplexed, so send it through OutStream, which will
 		// have been set up to handle that if needed.
@@ -155,7 +155,7 @@ func (s *Server) getContainersExport(ctx context.Context, w http.ResponseWriter,
 		return fmt.Errorf("Missing parameter")
 	}
 
-	return s.daemon.ContainerExport(vars["name"], w)
+	return s.daemon.ContainerExport(ctx, vars["name"], w)
 }
 
 func (s *Server) postContainersStart(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -183,7 +183,7 @@ func (s *Server) postContainersStart(ctx context.Context, w http.ResponseWriter,
 		hostConfig = c
 	}
 
-	if err := s.daemon.ContainerStart(vars["name"], hostConfig); err != nil {
+	if err := s.daemon.ContainerStart(ctx, vars["name"], hostConfig); err != nil {
 		return err
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -200,7 +200,7 @@ func (s *Server) postContainersStop(ctx context.Context, w http.ResponseWriter, 
 
 	seconds, _ := strconv.Atoi(r.Form.Get("t"))
 
-	if err := s.daemon.ContainerStop(vars["name"], seconds); err != nil {
+	if err := s.daemon.ContainerStop(ctx, vars["name"], seconds); err != nil {
 		return err
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -227,7 +227,7 @@ func (s *Server) postContainersKill(ctx context.Context, w http.ResponseWriter, 
 		}
 	}
 
-	if err := s.daemon.ContainerKill(name, uint64(sig)); err != nil {
+	if err := s.daemon.ContainerKill(ctx, name, uint64(sig)); err != nil {
 		theErr, isDerr := err.(errcode.ErrorCoder)
 		isStopped := isDerr && theErr.ErrorCode() == derr.ErrorCodeNotRunning
 
@@ -254,7 +254,7 @@ func (s *Server) postContainersRestart(ctx context.Context, w http.ResponseWrite
 
 	timeout, _ := strconv.Atoi(r.Form.Get("t"))
 
-	if err := s.daemon.ContainerRestart(vars["name"], timeout); err != nil {
+	if err := s.daemon.ContainerRestart(ctx, vars["name"], timeout); err != nil {
 		return err
 	}
 
@@ -271,7 +271,7 @@ func (s *Server) postContainersPause(ctx context.Context, w http.ResponseWriter,
 		return err
 	}
 
-	if err := s.daemon.ContainerPause(vars["name"]); err != nil {
+	if err := s.daemon.ContainerPause(ctx, vars["name"]); err != nil {
 		return err
 	}
 
@@ -288,7 +288,7 @@ func (s *Server) postContainersUnpause(ctx context.Context, w http.ResponseWrite
 		return err
 	}
 
-	if err := s.daemon.ContainerUnpause(vars["name"]); err != nil {
+	if err := s.daemon.ContainerUnpause(ctx, vars["name"]); err != nil {
 		return err
 	}
 
@@ -302,7 +302,7 @@ func (s *Server) postContainersWait(ctx context.Context, w http.ResponseWriter, 
 		return fmt.Errorf("Missing parameter")
 	}
 
-	status, err := s.daemon.ContainerWait(vars["name"], -1*time.Second)
+	status, err := s.daemon.ContainerWait(ctx, vars["name"], -1*time.Second)
 	if err != nil {
 		return err
 	}
@@ -317,7 +317,7 @@ func (s *Server) getContainersChanges(ctx context.Context, w http.ResponseWriter
 		return fmt.Errorf("Missing parameter")
 	}
 
-	changes, err := s.daemon.ContainerChanges(vars["name"])
+	changes, err := s.daemon.ContainerChanges(ctx, vars["name"])
 	if err != nil {
 		return err
 	}
@@ -334,7 +334,7 @@ func (s *Server) getContainersTop(ctx context.Context, w http.ResponseWriter, r 
 		return err
 	}
 
-	procList, err := s.daemon.ContainerTop(vars["name"], r.Form.Get("ps_args"))
+	procList, err := s.daemon.ContainerTop(ctx, vars["name"], r.Form.Get("ps_args"))
 	if err != nil {
 		return err
 	}
@@ -352,7 +352,7 @@ func (s *Server) postContainerRename(ctx context.Context, w http.ResponseWriter,
 
 	name := vars["name"]
 	newName := r.Form.Get("name")
-	if err := s.daemon.ContainerRename(name, newName); err != nil {
+	if err := s.daemon.ContainerRename(ctx, name, newName); err != nil {
 		return err
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -378,7 +378,7 @@ func (s *Server) postContainersCreate(ctx context.Context, w http.ResponseWriter
 	version := ctx.Version()
 	adjustCPUShares := version.LessThan("1.19")
 
-	container, warnings, err := s.daemon.ContainerCreate(name, config, hostConfig, adjustCPUShares)
+	container, warnings, err := s.daemon.ContainerCreate(ctx, name, config, hostConfig, adjustCPUShares)
 	if err != nil {
 		return err
 	}
@@ -404,7 +404,7 @@ func (s *Server) deleteContainers(ctx context.Context, w http.ResponseWriter, r 
 		RemoveLink:   boolValue(r, "link"),
 	}
 
-	if err := s.daemon.ContainerRm(name, config); err != nil {
+	if err := s.daemon.ContainerRm(ctx, name, config); err != nil {
 		// Force a 404 for the empty string
 		if strings.Contains(strings.ToLower(err.Error()), "prefix can't be empty") {
 			return fmt.Errorf("no such id: \"\"")
@@ -434,7 +434,7 @@ func (s *Server) postContainersResize(ctx context.Context, w http.ResponseWriter
 		return err
 	}
 
-	return s.daemon.ContainerResize(vars["name"], height, width)
+	return s.daemon.ContainerResize(ctx, vars["name"], height, width)
 }
 
 func (s *Server) postContainersAttach(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -446,7 +446,7 @@ func (s *Server) postContainersAttach(ctx context.Context, w http.ResponseWriter
 	}
 	containerName := vars["name"]
 
-	if !s.daemon.Exists(containerName) {
+	if !s.daemon.Exists(ctx, containerName) {
 		return derr.ErrorCodeNoSuchContainer.WithArgs(containerName)
 	}
 
@@ -472,7 +472,7 @@ func (s *Server) postContainersAttach(ctx context.Context, w http.ResponseWriter
 		Stream:    boolValue(r, "stream"),
 	}
 
-	if err := s.daemon.ContainerAttachWithLogs(containerName, attachWithLogsConfig); err != nil {
+	if err := s.daemon.ContainerAttachWithLogs(ctx, containerName, attachWithLogsConfig); err != nil {
 		fmt.Fprintf(outStream, "Error attaching: %s\n", err)
 	}
 
@@ -488,7 +488,7 @@ func (s *Server) wsContainersAttach(ctx context.Context, w http.ResponseWriter, 
 	}
 	containerName := vars["name"]
 
-	if !s.daemon.Exists(containerName) {
+	if !s.daemon.Exists(ctx, containerName) {
 		return derr.ErrorCodeNoSuchContainer.WithArgs(containerName)
 	}
 
@@ -503,7 +503,7 @@ func (s *Server) wsContainersAttach(ctx context.Context, w http.ResponseWriter, 
 			Stream:    boolValue(r, "stream"),
 		}
 
-		if err := s.daemon.ContainerWsAttachWithLogs(containerName, wsAttachWithLogsConfig); err != nil {
+		if err := s.daemon.ContainerWsAttachWithLogs(ctx, containerName, wsAttachWithLogsConfig); err != nil {
 			logrus.Errorf("Error attaching websocket: %s", err)
 		}
 	})

--- a/api/server/copy.go
+++ b/api/server/copy.go
@@ -32,7 +32,7 @@ func (s *Server) postContainersCopy(ctx context.Context, w http.ResponseWriter, 
 		return fmt.Errorf("Path cannot be empty")
 	}
 
-	data, err := s.daemon.ContainerCopy(vars["name"], cfg.Resource)
+	data, err := s.daemon.ContainerCopy(ctx, vars["name"], cfg.Resource)
 	if err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "no such id") {
 			w.WriteHeader(http.StatusNotFound)
@@ -74,7 +74,7 @@ func (s *Server) headContainersArchive(ctx context.Context, w http.ResponseWrite
 		return err
 	}
 
-	stat, err := s.daemon.ContainerStatPath(v.name, v.path)
+	stat, err := s.daemon.ContainerStatPath(ctx, v.name, v.path)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func (s *Server) getContainersArchive(ctx context.Context, w http.ResponseWriter
 		return err
 	}
 
-	tarArchive, stat, err := s.daemon.ContainerArchivePath(v.name, v.path)
+	tarArchive, stat, err := s.daemon.ContainerArchivePath(ctx, v.name, v.path)
 	if err != nil {
 		return err
 	}
@@ -111,5 +111,5 @@ func (s *Server) putContainersArchive(ctx context.Context, w http.ResponseWriter
 	}
 
 	noOverwriteDirNonDir := boolValue(r, "noOverwriteDirNonDir")
-	return s.daemon.ContainerExtractToDir(v.name, v.path, noOverwriteDirNonDir, r.Body)
+	return s.daemon.ContainerExtractToDir(ctx, v.name, v.path, noOverwriteDirNonDir, r.Body)
 }

--- a/api/server/daemon.go
+++ b/api/server/daemon.go
@@ -45,7 +45,7 @@ func (s *Server) getVersion(ctx context.Context, w http.ResponseWriter, r *http.
 }
 
 func (s *Server) getInfo(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	info, err := s.daemon.SystemInfo()
+	info, err := s.daemon.SystemInfo(ctx)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func (s *Server) getEvents(ctx context.Context, w http.ResponseWriter, r *http.R
 	enc := json.NewEncoder(outStream)
 
 	getContainerID := func(cn string) string {
-		c, err := d.Get(cn)
+		c, err := d.Get(ctx, cn)
 		if err != nil {
 			return ""
 		}

--- a/api/server/exec.go
+++ b/api/server/exec.go
@@ -19,7 +19,7 @@ func (s *Server) getExecByID(ctx context.Context, w http.ResponseWriter, r *http
 		return fmt.Errorf("Missing parameter 'id'")
 	}
 
-	eConfig, err := s.daemon.ContainerExecInspect(vars["id"])
+	eConfig, err := s.daemon.ContainerExecInspect(ctx, vars["id"])
 	if err != nil {
 		return err
 	}
@@ -47,7 +47,7 @@ func (s *Server) postContainerExecCreate(ctx context.Context, w http.ResponseWri
 	}
 
 	// Register an instance of Exec in container.
-	id, err := s.daemon.ContainerExecCreate(execConfig)
+	id, err := s.daemon.ContainerExecCreate(ctx, execConfig)
 	if err != nil {
 		logrus.Errorf("Error setting up exec command in container %s: %s", name, err)
 		return err
@@ -100,7 +100,7 @@ func (s *Server) postContainerExecStart(ctx context.Context, w http.ResponseWrit
 	}
 
 	// Now run the user process in container.
-	if err := s.daemon.ContainerExecStart(execName, stdin, stdout, stderr); err != nil {
+	if err := s.daemon.ContainerExecStart(ctx, execName, stdin, stdout, stderr); err != nil {
 		fmt.Fprintf(outStream, "Error running exec in container: %v\n", err)
 	}
 	return nil
@@ -123,5 +123,5 @@ func (s *Server) postContainerExecResize(ctx context.Context, w http.ResponseWri
 		return err
 	}
 
-	return s.daemon.ContainerExecResize(vars["name"], height, width)
+	return s.daemon.ContainerExecResize(ctx, vars["name"], height, width)
 }

--- a/api/server/image.go
+++ b/api/server/image.go
@@ -55,7 +55,7 @@ func (s *Server) postCommit(ctx context.Context, w http.ResponseWriter, r *http.
 		Config:  c,
 	}
 
-	imgID, err := builder.Commit(cname, s.daemon, commitCfg)
+	imgID, err := builder.Commit(ctx, cname, s.daemon, commitCfg)
 	if err != nil {
 		return err
 	}
@@ -112,7 +112,7 @@ func (s *Server) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 			OutStream:   output,
 		}
 
-		err = s.daemon.Repositories().Pull(image, tag, imagePullConfig)
+		err = s.daemon.Repositories(ctx).Pull(ctx, image, tag, imagePullConfig)
 	} else { //import
 		if tag == "" {
 			repo, tag = parsers.ParseRepositoryTag(repo)
@@ -124,12 +124,12 @@ func (s *Server) postImagesCreate(ctx context.Context, w http.ResponseWriter, r 
 		// generated from the download to be available to the output
 		// stream processing below
 		var newConfig *runconfig.Config
-		newConfig, err = builder.BuildFromConfig(s.daemon, &runconfig.Config{}, r.Form["changes"])
+		newConfig, err = builder.BuildFromConfig(ctx, s.daemon, &runconfig.Config{}, r.Form["changes"])
 		if err != nil {
 			return err
 		}
 
-		err = s.daemon.Repositories().Import(src, repo, tag, message, r.Body, output, newConfig)
+		err = s.daemon.Repositories(ctx).Import(ctx, src, repo, tag, message, r.Body, output, newConfig)
 	}
 	if err != nil {
 		if !output.Flushed() {
@@ -184,7 +184,7 @@ func (s *Server) postImagesPush(ctx context.Context, w http.ResponseWriter, r *h
 
 	w.Header().Set("Content-Type", "application/json")
 
-	if err := s.daemon.Repositories().Push(name, imagePushConfig); err != nil {
+	if err := s.daemon.Repositories(ctx).Push(ctx, name, imagePushConfig); err != nil {
 		if !output.Flushed() {
 			return err
 		}
@@ -212,7 +212,7 @@ func (s *Server) getImagesGet(ctx context.Context, w http.ResponseWriter, r *htt
 		names = r.Form["names"]
 	}
 
-	if err := s.daemon.Repositories().ImageExport(names, output); err != nil {
+	if err := s.daemon.Repositories(ctx).ImageExport(names, output); err != nil {
 		if !output.Flushed() {
 			return err
 		}
@@ -223,7 +223,7 @@ func (s *Server) getImagesGet(ctx context.Context, w http.ResponseWriter, r *htt
 }
 
 func (s *Server) postImagesLoad(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
-	return s.daemon.Repositories().Load(r.Body, w)
+	return s.daemon.Repositories(ctx).Load(r.Body, w)
 }
 
 func (s *Server) deleteImages(ctx context.Context, w http.ResponseWriter, r *http.Request, vars map[string]string) error {
@@ -243,7 +243,7 @@ func (s *Server) deleteImages(ctx context.Context, w http.ResponseWriter, r *htt
 	force := boolValue(r, "force")
 	prune := !boolValue(r, "noprune")
 
-	list, err := s.daemon.ImageDelete(name, force, prune)
+	list, err := s.daemon.ImageDelete(ctx, name, force, prune)
 	if err != nil {
 		return err
 	}
@@ -256,7 +256,7 @@ func (s *Server) getImagesByName(ctx context.Context, w http.ResponseWriter, r *
 		return fmt.Errorf("Missing parameter")
 	}
 
-	imageInspect, err := s.daemon.Repositories().Lookup(vars["name"])
+	imageInspect, err := s.daemon.Repositories(ctx).Lookup(vars["name"])
 	if err != nil {
 		return err
 	}
@@ -346,7 +346,7 @@ func (s *Server) postBuild(ctx context.Context, w http.ResponseWriter, r *http.R
 		}()
 	}
 
-	if err := builder.Build(s.daemon, buildConfig); err != nil {
+	if err := builder.Build(ctx, s.daemon, buildConfig); err != nil {
 		// Do not write the error in the http output if it's still empty.
 		// This prevents from writing a 200(OK) when there is an interal error.
 		if !output.Flushed() {
@@ -364,7 +364,7 @@ func (s *Server) getImagesJSON(ctx context.Context, w http.ResponseWriter, r *ht
 	}
 
 	// FIXME: The filter parameter could just be a match filter
-	images, err := s.daemon.Repositories().Images(r.Form.Get("filters"), r.Form.Get("filter"), boolValue(r, "all"))
+	images, err := s.daemon.Repositories(ctx).Images(r.Form.Get("filters"), r.Form.Get("filter"), boolValue(r, "all"))
 	if err != nil {
 		return err
 	}
@@ -378,7 +378,7 @@ func (s *Server) getImagesHistory(ctx context.Context, w http.ResponseWriter, r 
 	}
 
 	name := vars["name"]
-	history, err := s.daemon.Repositories().History(name)
+	history, err := s.daemon.Repositories(ctx).History(name)
 	if err != nil {
 		return err
 	}
@@ -398,10 +398,10 @@ func (s *Server) postImagesTag(ctx context.Context, w http.ResponseWriter, r *ht
 	tag := r.Form.Get("tag")
 	force := boolValue(r, "force")
 	name := vars["name"]
-	if err := s.daemon.Repositories().Tag(repo, tag, name, force); err != nil {
+	if err := s.daemon.Repositories(ctx).Tag(repo, tag, name, force); err != nil {
 		return err
 	}
-	s.daemon.EventsService.Log("tag", utils.ImageReference(repo, tag), "")
+	s.daemon.EventsService.Log(ctx, "tag", utils.ImageReference(repo, tag), "")
 	w.WriteHeader(http.StatusCreated)
 	return nil
 }

--- a/api/server/inspect.go
+++ b/api/server/inspect.go
@@ -20,11 +20,11 @@ func (s *Server) getContainersByName(ctx context.Context, w http.ResponseWriter,
 
 	switch {
 	case version.LessThan("1.20"):
-		json, err = s.daemon.ContainerInspectPre120(vars["name"])
+		json, err = s.daemon.ContainerInspectPre120(ctx, vars["name"])
 	case version.Equal("1.20"):
-		json, err = s.daemon.ContainerInspect120(vars["name"])
+		json, err = s.daemon.ContainerInspect120(ctx, vars["name"])
 	default:
-		json, err = s.daemon.ContainerInspect(vars["name"])
+		json, err = s.daemon.ContainerInspect(ctx, vars["name"])
 	}
 
 	if err != nil {

--- a/api/server/server_experimental_unix.go
+++ b/api/server/server_experimental_unix.go
@@ -2,8 +2,12 @@
 
 package server
 
-func (s *Server) registerSubRouter() {
-	httpHandler := s.daemon.NetworkAPIRouter()
+import (
+	"github.com/docker/docker/context"
+)
+
+func (s *Server) registerSubRouter(ctx context.Context) {
+	httpHandler := s.daemon.NetworkAPIRouter(ctx)
 
 	subrouter := s.router.PathPrefix("/v{version:[0-9.]+}/networks").Subrouter()
 	subrouter.Methods("GET", "POST", "PUT", "DELETE").HandlerFunc(httpHandler)

--- a/api/server/server_stub.go
+++ b/api/server/server_stub.go
@@ -2,5 +2,9 @@
 
 package server
 
-func (s *Server) registerSubRouter() {
+import (
+	"github.com/docker/docker/context"
+)
+
+func (s *Server) registerSubRouter(ctx context.Context) {
 }

--- a/api/server/server_unix.go
+++ b/api/server/server_unix.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/pkg/sockets"
 	"github.com/docker/libnetwork/portallocator"
@@ -63,10 +64,10 @@ func (s *Server) newServer(proto, addr string) ([]serverCloser, error) {
 // AcceptConnections allows clients to connect to the API server.
 // Referenced Daemon is notified about this server, and waits for the
 // daemon acknowledgement before the incoming connections are accepted.
-func (s *Server) AcceptConnections(d *daemon.Daemon) {
+func (s *Server) AcceptConnections(ctx context.Context, d *daemon.Daemon) {
 	// Tell the init daemon we are accepting requests
 	s.daemon = d
-	s.registerSubRouter()
+	s.registerSubRouter(ctx)
 	go systemdDaemon.SdNotify("READY=1")
 	// close the lock so the listeners start accepting connections
 	select {

--- a/api/server/server_windows.go
+++ b/api/server/server_windows.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon"
 )
 
@@ -42,9 +43,9 @@ func (s *Server) newServer(proto, addr string) ([]serverCloser, error) {
 }
 
 // AcceptConnections allows router to start listening for the incoming requests.
-func (s *Server) AcceptConnections(d *daemon.Daemon) {
+func (s *Server) AcceptConnections(ctx context.Context, d *daemon.Daemon) {
 	s.daemon = d
-	s.registerSubRouter()
+	s.registerSubRouter(ctx)
 	// close the lock so the listeners start accepting connections
 	select {
 	case <-s.start:

--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -13,7 +13,7 @@ func (s *Server) getVolumesList(ctx context.Context, w http.ResponseWriter, r *h
 		return err
 	}
 
-	volumes, err := s.daemon.Volumes(r.Form.Get("filters"))
+	volumes, err := s.daemon.Volumes(ctx, r.Form.Get("filters"))
 	if err != nil {
 		return err
 	}
@@ -25,7 +25,7 @@ func (s *Server) getVolumeByName(ctx context.Context, w http.ResponseWriter, r *
 		return err
 	}
 
-	v, err := s.daemon.VolumeInspect(vars["name"])
+	v, err := s.daemon.VolumeInspect(ctx, vars["name"])
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (s *Server) postVolumesCreate(ctx context.Context, w http.ResponseWriter, r
 		return err
 	}
 
-	volume, err := s.daemon.VolumeCreate(req.Name, req.Driver, req.DriverOpts)
+	volume, err := s.daemon.VolumeCreate(ctx, req.Name, req.Driver, req.DriverOpts)
 	if err != nil {
 		return err
 	}
@@ -57,7 +57,7 @@ func (s *Server) deleteVolumes(ctx context.Context, w http.ResponseWriter, r *ht
 	if err := parseForm(r); err != nil {
 		return err
 	}
-	if err := s.daemon.VolumeRm(vars["name"]); err != nil {
+	if err := s.daemon.VolumeRm(ctx, vars["name"]); err != nil {
 		return err
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -32,6 +32,7 @@ import (
 	"github.com/docker/docker/builder/command"
 	"github.com/docker/docker/builder/parser"
 	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/streamformatter"
@@ -57,10 +58,10 @@ var replaceEnvAllowed = map[string]struct{}{
 	command.Arg:        {},
 }
 
-var evaluateTable map[string]func(*builder, []string, map[string]bool, string) error
+var evaluateTable map[string]func(context.Context, *builder, []string, map[string]bool, string) error
 
 func init() {
-	evaluateTable = map[string]func(*builder, []string, map[string]bool, string) error{
+	evaluateTable = map[string]func(context.Context, *builder, []string, map[string]bool, string) error{
 		command.Env:        env,
 		command.Label:      label,
 		command.Maintainer: maintainer,
@@ -158,7 +159,7 @@ type builder struct {
 //   processing.
 // * Print a happy message and return the image ID.
 //
-func (b *builder) Run(context io.Reader) (string, error) {
+func (b *builder) Run(ctx context.Context, context io.Reader) (string, error) {
 	if err := b.readContext(context); err != nil {
 		return "", err
 	}
@@ -187,15 +188,15 @@ func (b *builder) Run(context io.Reader) (string, error) {
 		default:
 			// Not cancelled yet, keep going...
 		}
-		if err := b.dispatch(i, n); err != nil {
+		if err := b.dispatch(ctx, i, n); err != nil {
 			if b.ForceRemove {
-				b.clearTmp()
+				b.clearTmp(ctx)
 			}
 			return "", err
 		}
 		fmt.Fprintf(b.OutStream, " ---> %s\n", stringid.TruncateID(b.image))
 		if b.Remove {
-			b.clearTmp()
+			b.clearTmp(ctx)
 		}
 	}
 
@@ -311,7 +312,7 @@ func (b *builder) isBuildArgAllowed(arg string) bool {
 // such as `RUN` in ONBUILD RUN foo. There is special case logic in here to
 // deal with that, at least until it becomes more of a general concern with new
 // features.
-func (b *builder) dispatch(stepN int, ast *parser.Node) error {
+func (b *builder) dispatch(ctx context.Context, stepN int, ast *parser.Node) error {
 	cmd := ast.Value
 
 	// To ensure the user is give a decent error message if the platform
@@ -404,7 +405,7 @@ func (b *builder) dispatch(stepN int, ast *parser.Node) error {
 	if f, ok := evaluateTable[cmd]; ok {
 		b.BuilderFlags = NewBFlags()
 		b.BuilderFlags.Args = flags
-		return f(b, strList, attrs, original)
+		return f(ctx, b, strList, attrs, original)
 	}
 
 	return fmt.Errorf("Unknown instruction: %s", strings.ToUpper(cmd))

--- a/builder/job.go
+++ b/builder/job.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/builder/parser"
 	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/graph/tags"
 	"github.com/docker/docker/pkg/archive"
@@ -112,7 +113,7 @@ func NewBuildConfig() *Config {
 
 // Build is the main interface of the package, it gathers the Builder
 // struct and calls builder.Run() to do all the real build job.
-func Build(d *daemon.Daemon, buildConfig *Config) error {
+func Build(ctx context.Context, d *daemon.Daemon, buildConfig *Config) error {
 	var (
 		repoName string
 		tag      string
@@ -229,15 +230,15 @@ func Build(d *daemon.Daemon, buildConfig *Config) error {
 	}
 
 	defer func() {
-		builder.Daemon.Graph().Release(builder.id, builder.activeImages...)
+		builder.Daemon.Graph(ctx).Release(builder.id, builder.activeImages...)
 	}()
 
-	id, err := builder.Run(context)
+	id, err := builder.Run(ctx, context)
 	if err != nil {
 		return err
 	}
 	if repoName != "" {
-		return d.Repositories().Tag(repoName, tag, id, true)
+		return d.Repositories(ctx).Tag(repoName, tag, id, true)
 	}
 	return nil
 }
@@ -247,7 +248,7 @@ func Build(d *daemon.Daemon, buildConfig *Config) error {
 //
 // - call parse.Parse() to get AST root from Dockerfile entries
 // - do build by calling builder.dispatch() to call all entries' handling routines
-func BuildFromConfig(d *daemon.Daemon, c *runconfig.Config, changes []string) (*runconfig.Config, error) {
+func BuildFromConfig(ctx context.Context, d *daemon.Daemon, c *runconfig.Config, changes []string) (*runconfig.Config, error) {
 	ast, err := parser.Parse(bytes.NewBufferString(strings.Join(changes, "\n")))
 	if err != nil {
 		return nil, err
@@ -269,7 +270,7 @@ func BuildFromConfig(d *daemon.Daemon, c *runconfig.Config, changes []string) (*
 	}
 
 	for i, n := range ast.Children {
-		if err := builder.dispatch(i, n); err != nil {
+		if err := builder.dispatch(ctx, i, n); err != nil {
 			return nil, err
 		}
 	}
@@ -289,8 +290,8 @@ type CommitConfig struct {
 }
 
 // Commit will create a new image from a container's changes
-func Commit(name string, d *daemon.Daemon, c *CommitConfig) (string, error) {
-	container, err := d.Get(name)
+func Commit(ctx context.Context, name string, d *daemon.Daemon, c *CommitConfig) (string, error) {
+	container, err := d.Get(ctx, name)
 	if err != nil {
 		return "", err
 	}
@@ -304,7 +305,7 @@ func Commit(name string, d *daemon.Daemon, c *CommitConfig) (string, error) {
 		c.Config = &runconfig.Config{}
 	}
 
-	newConfig, err := BuildFromConfig(d, c.Config, c.Changes)
+	newConfig, err := BuildFromConfig(ctx, d, c.Config, c.Changes)
 	if err != nil {
 		return "", err
 	}
@@ -322,7 +323,7 @@ func Commit(name string, d *daemon.Daemon, c *CommitConfig) (string, error) {
 		Config:  newConfig,
 	}
 
-	img, err := d.Commit(container, commitCfg)
+	img, err := d.Commit(ctx, container, commitCfg)
 	if err != nil {
 		return "", err
 	}

--- a/daemon/attach.go
+++ b/daemon/attach.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"io"
 
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/pkg/stdcopy"
 )
 
@@ -15,8 +16,8 @@ type ContainerAttachWithLogsConfig struct {
 }
 
 // ContainerAttachWithLogs attaches to logs according to the config passed in. See ContainerAttachWithLogsConfig.
-func (daemon *Daemon) ContainerAttachWithLogs(prefixOrName string, c *ContainerAttachWithLogsConfig) error {
-	container, err := daemon.Get(prefixOrName)
+func (daemon *Daemon) ContainerAttachWithLogs(ctx context.Context, prefixOrName string, c *ContainerAttachWithLogsConfig) error {
+	container, err := daemon.Get(ctx, prefixOrName)
 	if err != nil {
 		return err
 	}
@@ -43,7 +44,7 @@ func (daemon *Daemon) ContainerAttachWithLogs(prefixOrName string, c *ContainerA
 		stderr = errStream
 	}
 
-	return container.attachWithLogs(stdin, stdout, stderr, c.Logs, c.Stream)
+	return container.attachWithLogs(ctx, stdin, stdout, stderr, c.Logs, c.Stream)
 }
 
 // ContainerWsAttachWithLogsConfig attach with websockets, since all
@@ -55,10 +56,10 @@ type ContainerWsAttachWithLogsConfig struct {
 }
 
 // ContainerWsAttachWithLogs websocket connection
-func (daemon *Daemon) ContainerWsAttachWithLogs(prefixOrName string, c *ContainerWsAttachWithLogsConfig) error {
-	container, err := daemon.Get(prefixOrName)
+func (daemon *Daemon) ContainerWsAttachWithLogs(ctx context.Context, prefixOrName string, c *ContainerWsAttachWithLogsConfig) error {
+	container, err := daemon.Get(ctx, prefixOrName)
 	if err != nil {
 		return err
 	}
-	return container.attachWithLogs(c.InStream, c.OutStream, c.ErrStream, c.Logs, c.Stream)
+	return container.attachWithLogs(ctx, c.InStream, c.OutStream, c.ErrStream, c.Logs, c.Stream)
 }

--- a/daemon/changes.go
+++ b/daemon/changes.go
@@ -1,10 +1,13 @@
 package daemon
 
-import "github.com/docker/docker/pkg/archive"
+import (
+	"github.com/docker/docker/context"
+	"github.com/docker/docker/pkg/archive"
+)
 
 // ContainerChanges returns a list of container fs changes
-func (daemon *Daemon) ContainerChanges(name string) ([]archive.Change, error) {
-	container, err := daemon.Get(name)
+func (daemon *Daemon) ContainerChanges(ctx context.Context, name string) ([]archive.Change, error) {
+	container, err := daemon.Get(ctx, name)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/commit.go
+++ b/daemon/commit.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/image"
 	"github.com/docker/docker/runconfig"
 )
@@ -18,10 +19,10 @@ type ContainerCommitConfig struct {
 
 // Commit creates a new filesystem image from the current state of a container.
 // The image can optionally be tagged into a repository.
-func (daemon *Daemon) Commit(container *Container, c *ContainerCommitConfig) (*image.Image, error) {
+func (daemon *Daemon) Commit(ctx context.Context, container *Container, c *ContainerCommitConfig) (*image.Image, error) {
 	if c.Pause && !container.isPaused() {
-		container.pause()
-		defer container.unpause()
+		container.pause(ctx)
+		defer container.unpause(ctx)
 	}
 
 	rwTar, err := container.exportContainerRw()
@@ -46,6 +47,6 @@ func (daemon *Daemon) Commit(container *Container, c *ContainerCommitConfig) (*i
 			return img, err
 		}
 	}
-	container.logEvent("commit")
+	container.logEvent(ctx, "commit")
 	return img, nil
 }

--- a/daemon/container_windows.go
+++ b/daemon/container_windows.go
@@ -5,6 +5,7 @@ package daemon
 import (
 	"strings"
 
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/execdriver"
 	derr "github.com/docker/docker/errors"
 )
@@ -25,7 +26,7 @@ func killProcessDirectly(container *Container) error {
 	return nil
 }
 
-func (container *Container) setupLinkedContainers() ([]string, error) {
+func (container *Container) setupLinkedContainers(ctx context.Context) ([]string, error) {
 	return nil, nil
 }
 
@@ -34,7 +35,7 @@ func (container *Container) createDaemonEnvironment(linkedEnv []string) []string
 	return container.Config.Env
 }
 
-func (container *Container) initializeNetworking() error {
+func (container *Container) initializeNetworking(ctx context.Context) error {
 	return nil
 }
 
@@ -42,7 +43,7 @@ func (container *Container) setupWorkingDirectory() error {
 	return nil
 }
 
-func populateCommand(c *Container, env []string) error {
+func populateCommand(ctx context.Context, c *Container, env []string) error {
 	en := &execdriver.Network{
 		Interface: nil,
 	}
@@ -135,7 +136,7 @@ func populateCommand(c *Container, env []string) error {
 }
 
 // GetSize returns real size & virtual size
-func (container *Container) getSize() (int64, int64) {
+func (container *Container) getSize(ctx context.Context) (int64, int64) {
 	// TODO Windows
 	return 0, 0
 }
@@ -150,7 +151,7 @@ func (container *Container) allocateNetwork() error {
 	return nil
 }
 
-func (container *Container) updateNetwork() error {
+func (container *Container) updateNetwork(ctx context.Context) error {
 	return nil
 }
 

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/context"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/graph/tags"
 	"github.com/docker/docker/image"
@@ -15,21 +16,21 @@ import (
 )
 
 // ContainerCreate takes configs and creates a container.
-func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hostConfig *runconfig.HostConfig, adjustCPUShares bool) (*Container, []string, error) {
+func (daemon *Daemon) ContainerCreate(ctx context.Context, name string, config *runconfig.Config, hostConfig *runconfig.HostConfig, adjustCPUShares bool) (*Container, []string, error) {
 	if config == nil {
 		return nil, nil, derr.ErrorCodeEmptyConfig
 	}
 
-	warnings, err := daemon.verifyContainerSettings(hostConfig, config)
+	warnings, err := daemon.verifyContainerSettings(ctx, hostConfig, config)
 	if err != nil {
 		return nil, warnings, err
 	}
 
 	daemon.adaptContainerSettings(hostConfig, adjustCPUShares)
 
-	container, buildWarnings, err := daemon.Create(config, hostConfig, name)
+	container, buildWarnings, err := daemon.Create(ctx, config, hostConfig, name)
 	if err != nil {
-		if daemon.Graph().IsNotExist(err, config.Image) {
+		if daemon.Graph(ctx).IsNotExist(err, config.Image) {
 			if strings.Contains(config.Image, "@") {
 				return nil, warnings, derr.ErrorCodeNoSuchImageHash.WithArgs(config.Image)
 			}
@@ -48,7 +49,7 @@ func (daemon *Daemon) ContainerCreate(name string, config *runconfig.Config, hos
 }
 
 // Create creates a new container from the given configuration with a given name.
-func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.HostConfig, name string) (retC *Container, retS []string, retErr error) {
+func (daemon *Daemon) Create(ctx context.Context, config *runconfig.Config, hostConfig *runconfig.HostConfig, name string) (retC *Container, retS []string, retErr error) {
 	var (
 		container *Container
 		warnings  []string
@@ -76,29 +77,29 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 		hostConfig = &runconfig.HostConfig{}
 	}
 	if hostConfig.SecurityOpt == nil {
-		hostConfig.SecurityOpt, err = daemon.generateSecurityOpt(hostConfig.IpcMode, hostConfig.PidMode)
+		hostConfig.SecurityOpt, err = daemon.generateSecurityOpt(ctx, hostConfig.IpcMode, hostConfig.PidMode)
 		if err != nil {
 			return nil, nil, err
 		}
 	}
-	if container, err = daemon.newContainer(name, config, imgID); err != nil {
+	if container, err = daemon.newContainer(ctx, name, config, imgID); err != nil {
 		return nil, nil, err
 	}
 	defer func() {
 		if retErr != nil {
-			if err := daemon.rm(container, false); err != nil {
+			if err := daemon.rm(ctx, container, false); err != nil {
 				logrus.Errorf("Clean up Error! Cannot destroy container %s: %v", container.ID, err)
 			}
 		}
 	}()
 
-	if err := daemon.Register(container); err != nil {
+	if err := daemon.Register(ctx, container); err != nil {
 		return nil, nil, err
 	}
 	if err := daemon.createRootfs(container); err != nil {
 		return nil, nil, err
 	}
-	if err := daemon.setHostConfig(container, hostConfig); err != nil {
+	if err := daemon.setHostConfig(ctx, container, hostConfig); err != nil {
 		return nil, nil, err
 	}
 	defer func() {
@@ -108,10 +109,10 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 			}
 		}
 	}()
-	if err := container.Mount(); err != nil {
+	if err := container.Mount(ctx); err != nil {
 		return nil, nil, err
 	}
-	defer container.Unmount()
+	defer container.Unmount(ctx)
 
 	if err := createContainerPlatformSpecificSettings(container, config, hostConfig, img); err != nil {
 		return nil, nil, err
@@ -121,16 +122,16 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 		logrus.Errorf("Error saving new container to disk: %v", err)
 		return nil, nil, err
 	}
-	container.logEvent("create")
+	container.logEvent(ctx, "create")
 	return container, warnings, nil
 }
 
-func (daemon *Daemon) generateSecurityOpt(ipcMode runconfig.IpcMode, pidMode runconfig.PidMode) ([]string, error) {
+func (daemon *Daemon) generateSecurityOpt(ctx context.Context, ipcMode runconfig.IpcMode, pidMode runconfig.PidMode) ([]string, error) {
 	if ipcMode.IsHost() || pidMode.IsHost() {
 		return label.DisableSecOpt(), nil
 	}
 	if ipcContainer := ipcMode.Container(); ipcContainer != "" {
-		c, err := daemon.Get(ipcContainer)
+		c, err := daemon.Get(ctx, ipcContainer)
 		if err != nil {
 			return nil, err
 		}
@@ -142,7 +143,7 @@ func (daemon *Daemon) generateSecurityOpt(ipcMode runconfig.IpcMode, pidMode run
 
 // VolumeCreate creates a volume with the specified name, driver, and opts
 // This is called directly from the remote API
-func (daemon *Daemon) VolumeCreate(name, driverName string, opts map[string]string) (*types.Volume, error) {
+func (daemon *Daemon) VolumeCreate(ctx context.Context, name, driverName string, opts map[string]string) (*types.Volume, error) {
 	if name == "" {
 		name = stringid.GenerateNonCryptoID()
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/events"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/daemon/execdriver/execdrivers"
@@ -127,14 +128,14 @@ type Daemon struct {
 //  - A partial container ID prefix (e.g. short ID) of any length that is
 //    unique enough to only return a single container object
 //  If none of these searches succeed, an error is returned
-func (daemon *Daemon) Get(prefixOrName string) (*Container, error) {
+func (daemon *Daemon) Get(ctx context.Context, prefixOrName string) (*Container, error) {
 	if containerByID := daemon.containers.Get(prefixOrName); containerByID != nil {
 		// prefix is an exact match to a full container ID
 		return containerByID, nil
 	}
 
 	// GetByName will match only an exact name provided; we ignore errors
-	if containerByName, _ := daemon.GetByName(prefixOrName); containerByName != nil {
+	if containerByName, _ := daemon.GetByName(ctx, prefixOrName); containerByName != nil {
 		// prefix is an exact match to a full container Name
 		return containerByName, nil
 	}
@@ -152,8 +153,8 @@ func (daemon *Daemon) Get(prefixOrName string) (*Container, error) {
 
 // Exists returns a true if a container of the specified ID or name exists,
 // false otherwise.
-func (daemon *Daemon) Exists(id string) bool {
-	c, _ := daemon.Get(id)
+func (daemon *Daemon) Exists(ctx context.Context, id string) bool {
+	c, _ := daemon.Get(ctx, id)
 	return c != nil
 }
 
@@ -178,8 +179,8 @@ func (daemon *Daemon) load(id string) (*Container, error) {
 }
 
 // Register makes a container object usable by the daemon as <container.ID>
-func (daemon *Daemon) Register(container *Container) error {
-	if container.daemon != nil || daemon.Exists(container.ID) {
+func (daemon *Daemon) Register(ctx context.Context, container *Container) error {
+	if container.daemon != nil || daemon.Exists(ctx, container.ID) {
 		return fmt.Errorf("Container is already loaded")
 	}
 	if err := validateID(container.ID); err != nil {
@@ -217,10 +218,7 @@ func (daemon *Daemon) Register(container *Container) error {
 		}
 		daemon.execDriver.Terminate(cmd)
 
-		if err := container.unmountIpcMounts(); err != nil {
-			logrus.Errorf("%s: Failed to umount ipc filesystems: %v", container.ID, err)
-		}
-		if err := container.Unmount(); err != nil {
+		if err := container.Unmount(ctx); err != nil {
 			logrus.Debugf("unmount error %s", err)
 		}
 		if err := container.toDiskLocking(); err != nil {
@@ -254,7 +252,7 @@ func (daemon *Daemon) ensureName(container *Container) error {
 	return nil
 }
 
-func (daemon *Daemon) restore() error {
+func (daemon *Daemon) restore(ctx context.Context) error {
 	type cr struct {
 		container  *Container
 		registered bool
@@ -324,7 +322,7 @@ func (daemon *Daemon) restore() error {
 				}
 			}
 
-			if err := daemon.Register(container); err != nil {
+			if err := daemon.Register(ctx, container); err != nil {
 				logrus.Errorf("Failed to register container %s: %s", container.ID, err)
 				// The container register failed should not be started.
 				return
@@ -335,7 +333,7 @@ func (daemon *Daemon) restore() error {
 			if daemon.configStore.AutoRestart && container.shouldRestart() {
 				logrus.Debugf("Starting container %s", container.ID)
 
-				if err := container.Start(); err != nil {
+				if err := container.Start(ctx); err != nil {
 					logrus.Errorf("Failed to start container %s: %s", container.ID, err)
 				}
 			}
@@ -365,7 +363,7 @@ func (daemon *Daemon) mergeAndVerifyConfig(config *runconfig.Config, img *image.
 	return nil
 }
 
-func (daemon *Daemon) generateIDAndName(name string) (string, string, error) {
+func (daemon *Daemon) generateIDAndName(ctx context.Context, name string) (string, string, error) {
 	var (
 		err error
 		id  = stringid.GenerateNonCryptoID()
@@ -378,14 +376,14 @@ func (daemon *Daemon) generateIDAndName(name string) (string, string, error) {
 		return id, name, nil
 	}
 
-	if name, err = daemon.reserveName(id, name); err != nil {
+	if name, err = daemon.reserveName(ctx, id, name); err != nil {
 		return "", "", err
 	}
 
 	return id, name, nil
 }
 
-func (daemon *Daemon) reserveName(id, name string) (string, error) {
+func (daemon *Daemon) reserveName(ctx context.Context, id, name string) (string, error) {
 	if !validContainerNamePattern.MatchString(name) {
 		return "", fmt.Errorf("Invalid container name (%s), only %s are allowed", name, validContainerNameChars)
 	}
@@ -399,7 +397,7 @@ func (daemon *Daemon) reserveName(id, name string) (string, error) {
 			return "", err
 		}
 
-		conflictingContainer, err := daemon.GetByName(name)
+		conflictingContainer, err := daemon.GetByName(ctx, name)
 		if err != nil {
 			if strings.Contains(err.Error(), "Could not find entity") {
 				return "", err
@@ -469,12 +467,12 @@ func (daemon *Daemon) getEntrypointAndArgs(configEntrypoint *stringutils.StrSlic
 	return entrypoint, args
 }
 
-func (daemon *Daemon) newContainer(name string, config *runconfig.Config, imgID string) (*Container, error) {
+func (daemon *Daemon) newContainer(ctx context.Context, name string, config *runconfig.Config, imgID string) (*Container, error) {
 	var (
 		id  string
 		err error
 	)
-	id, name, err = daemon.generateIDAndName(name)
+	id, name, err = daemon.generateIDAndName(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -511,7 +509,7 @@ func GetFullContainerName(name string) (string, error) {
 }
 
 // GetByName returns a container given a name.
-func (daemon *Daemon) GetByName(name string) (*Container, error) {
+func (daemon *Daemon) GetByName(ctx context.Context, name string) (*Container, error) {
 	fullName, err := GetFullContainerName(name)
 	if err != nil {
 		return nil, err
@@ -530,7 +528,7 @@ func (daemon *Daemon) GetByName(name string) (*Container, error) {
 // children returns all child containers of the container with the
 // given name. The containers are returned as a map from the container
 // name to a pointer to Container.
-func (daemon *Daemon) children(name string) (map[string]*Container, error) {
+func (daemon *Daemon) children(ctx context.Context, name string) (map[string]*Container, error) {
 	name, err := GetFullContainerName(name)
 	if err != nil {
 		return nil, err
@@ -538,7 +536,7 @@ func (daemon *Daemon) children(name string) (map[string]*Container, error) {
 	children := make(map[string]*Container)
 
 	err = daemon.containerGraphDB.Walk(name, func(p string, e *graphdb.Entity) error {
-		c, err := daemon.Get(e.ID())
+		c, err := daemon.Get(ctx, e.ID())
 		if err != nil {
 			return err
 		}
@@ -574,7 +572,7 @@ func (daemon *Daemon) registerLink(parent, child *Container, alias string) error
 
 // NewDaemon sets up everything for the daemon to be able to service
 // requests from the webserver.
-func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemon, err error) {
+func NewDaemon(ctx context.Context, config *Config, registryService *registry.Service) (daemon *Daemon, err error) {
 	setDefaultMtu(config)
 
 	// Ensure we have compatible configuration options
@@ -642,7 +640,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 	// Ensure the graph driver is shutdown at a later point
 	defer func() {
 		if err != nil {
-			if err := d.Shutdown(); err != nil {
+			if err := d.Shutdown(ctx); err != nil {
 				logrus.Error(err)
 			}
 		}
@@ -776,7 +774,7 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 
 	go d.execCommandGC()
 
-	if err := d.restore(); err != nil {
+	if err := d.restore(ctx); err != nil {
 		return nil, err
 	}
 
@@ -784,12 +782,12 @@ func NewDaemon(config *Config, registryService *registry.Service) (daemon *Daemo
 }
 
 // Shutdown stops the daemon.
-func (daemon *Daemon) Shutdown() error {
+func (daemon *Daemon) Shutdown(ctx context.Context) error {
 	daemon.shutdown = true
 	if daemon.containers != nil {
 		group := sync.WaitGroup{}
 		logrus.Debug("starting clean shutdown of all containers...")
-		for _, container := range daemon.List() {
+		for _, container := range daemon.List(ctx) {
 			c := container
 			if c.IsRunning() {
 				logrus.Debugf("stopping %s", c.ID)
@@ -812,7 +810,7 @@ func (daemon *Daemon) Shutdown() error {
 							logrus.Debugf("sending SIGTERM to container %s with error: %v", c.ID, err)
 							return
 						}
-						if err := c.unpause(); err != nil {
+						if err := c.unpause(ctx); err != nil {
 							logrus.Debugf("Failed to unpause container %s with error: %v", c.ID, err)
 							return
 						}
@@ -827,7 +825,7 @@ func (daemon *Daemon) Shutdown() error {
 						}
 					} else {
 						// If container failed to exit in 10 seconds of SIGTERM, then using the force
-						if err := c.Stop(10); err != nil {
+						if err := c.Stop(ctx, 10); err != nil {
 							logrus.Errorf("Stop container %s with error: %v", c.ID, err)
 						}
 					}
@@ -865,7 +863,7 @@ func (daemon *Daemon) Shutdown() error {
 
 // Mount sets container.basefs
 // (is it not set coming in? why is it unset?)
-func (daemon *Daemon) Mount(container *Container) error {
+func (daemon *Daemon) Mount(ctx context.Context, container *Container) error {
 	dir, err := daemon.driver.Get(container.ID, container.getMountLabel())
 	if err != nil {
 		return fmt.Errorf("Error getting container %s from driver %s: %s", container.ID, daemon.driver, err)
@@ -890,14 +888,14 @@ func (daemon *Daemon) unmount(container *Container) error {
 	return nil
 }
 
-func (daemon *Daemon) run(c *Container, pipes *execdriver.Pipes, startCallback execdriver.DriverCallback) (execdriver.ExitStatus, error) {
+func (daemon *Daemon) run(ctx context.Context, c *Container, pipes *execdriver.Pipes, startCallback execdriver.DriverCallback) (execdriver.ExitStatus, error) {
 	hooks := execdriver.Hooks{
 		Start: startCallback,
 	}
-	hooks.PreStart = append(hooks.PreStart, func(processConfig *execdriver.ProcessConfig, pid int, chOOM <-chan struct{}) error {
+	hooks.PreStart = append(hooks.PreStart, func(ctx context.Context, processConfig *execdriver.ProcessConfig, pid int, chOOM <-chan struct{}) error {
 		return c.setNetworkNamespaceKey(pid)
 	})
-	return daemon.execDriver.Run(c.command, pipes, hooks)
+	return daemon.execDriver.Run(ctx, c.command, pipes, hooks)
 }
 
 func (daemon *Daemon) kill(c *Container, sig int) error {
@@ -964,12 +962,12 @@ func (daemon *Daemon) createRootfs(container *Container) error {
 // which need direct access to daemon.graph.
 // Once the tests switch to using engine and jobs, this method
 // can go away.
-func (daemon *Daemon) Graph() *graph.Graph {
+func (daemon *Daemon) Graph(ctx context.Context) *graph.Graph {
 	return daemon.graph
 }
 
 // Repositories returns all repositories.
-func (daemon *Daemon) Repositories() *graph.TagStore {
+func (daemon *Daemon) Repositories(ctx context.Context) *graph.TagStore {
 	return daemon.repositories
 }
 
@@ -983,13 +981,13 @@ func (daemon *Daemon) systemInitPath() string {
 
 // GraphDriver returns the currently used driver for processing
 // container layers.
-func (daemon *Daemon) GraphDriver() graphdriver.Driver {
+func (daemon *Daemon) GraphDriver(ctx context.Context) graphdriver.Driver {
 	return daemon.driver
 }
 
 // ExecutionDriver returns the currently used driver for creating and
 // starting execs in a container.
-func (daemon *Daemon) ExecutionDriver() execdriver.Driver {
+func (daemon *Daemon) ExecutionDriver(ctx context.Context) execdriver.Driver {
 	return daemon.execDriver
 }
 
@@ -1001,9 +999,9 @@ func (daemon *Daemon) containerGraph() *graphdb.Database {
 // of the image with imgID, that had the same config when it was
 // created. nil is returned if a child cannot be found. An error is
 // returned if the parent image cannot be found.
-func (daemon *Daemon) ImageGetCached(imgID string, config *runconfig.Config) (*image.Image, error) {
+func (daemon *Daemon) ImageGetCached(ctx context.Context, imgID string, config *runconfig.Config) (*image.Image, error) {
 	// Retrieve all images
-	images := daemon.Graph().Map()
+	images := daemon.Graph(ctx).Map()
 
 	// Store the tree in a map of map (map[parentId][childId])
 	imageMap := make(map[string]map[string]struct{})
@@ -1039,7 +1037,7 @@ func tempDir(rootDir string) (string, error) {
 	return tmpDir, system.MkdirAll(tmpDir, 0700)
 }
 
-func (daemon *Daemon) setHostConfig(container *Container, hostConfig *runconfig.HostConfig) error {
+func (daemon *Daemon) setHostConfig(ctx context.Context, container *Container, hostConfig *runconfig.HostConfig) error {
 	container.Lock()
 	if err := parseSecurityOpt(container, hostConfig); err != nil {
 		container.Unlock()
@@ -1049,14 +1047,14 @@ func (daemon *Daemon) setHostConfig(container *Container, hostConfig *runconfig.
 
 	// Do not lock while creating volumes since this could be calling out to external plugins
 	// Don't want to block other actions, like `docker ps` because we're waiting on an external plugin
-	if err := daemon.registerMountPoints(container, hostConfig); err != nil {
+	if err := daemon.registerMountPoints(ctx, container, hostConfig); err != nil {
 		return err
 	}
 
 	container.Lock()
 	defer container.Unlock()
 	// Register any links from the host config before starting the container
-	if err := daemon.registerLinks(container, hostConfig); err != nil {
+	if err := daemon.registerLinks(ctx, container, hostConfig); err != nil {
 		return err
 	}
 
@@ -1094,7 +1092,7 @@ func getDefaultRouteMtu() (int, error) {
 
 // verifyContainerSettings performs validation of the hostconfig and config
 // structures.
-func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, config *runconfig.Config) ([]string, error) {
+func (daemon *Daemon) verifyContainerSettings(ctx context.Context, hostConfig *runconfig.HostConfig, config *runconfig.Config) ([]string, error) {
 
 	// First perform verification of settings common across all platforms.
 	if config != nil {
@@ -1131,7 +1129,7 @@ func (daemon *Daemon) verifyContainerSettings(hostConfig *runconfig.HostConfig, 
 	}
 
 	// Now do platform-specific verification
-	return verifyPlatformContainerSettings(daemon, hostConfig, config)
+	return verifyPlatformContainerSettings(ctx, daemon, hostConfig, config)
 }
 
 func configureVolumes(config *Config) (*store.VolumeStore, error) {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/pkg/graphdb"
 	"github.com/docker/docker/pkg/stringid"
 	"github.com/docker/docker/pkg/truncindex"
@@ -92,32 +93,34 @@ func TestGet(t *testing.T) {
 		containerGraphDB: graph,
 	}
 
-	if container, _ := daemon.Get("3cdbd1aa394fd68559fd1441d6eff2ab7c1e6363582c82febfaa8045df3bd8de"); container != c2 {
+	ctx := context.Background()
+
+	if container, _ := daemon.Get(ctx, "3cdbd1aa394fd68559fd1441d6eff2ab7c1e6363582c82febfaa8045df3bd8de"); container != c2 {
 		t.Fatal("Should explicitly match full container IDs")
 	}
 
-	if container, _ := daemon.Get("75fb0b8009"); container != c4 {
+	if container, _ := daemon.Get(ctx, "75fb0b8009"); container != c4 {
 		t.Fatal("Should match a partial ID")
 	}
 
-	if container, _ := daemon.Get("drunk_hawking"); container != c2 {
+	if container, _ := daemon.Get(ctx, "drunk_hawking"); container != c2 {
 		t.Fatal("Should match a full name")
 	}
 
 	// c3.Name is a partial match for both c3.ID and c2.ID
-	if c, _ := daemon.Get("3cdbd1aa"); c != c3 {
+	if c, _ := daemon.Get(ctx, "3cdbd1aa"); c != c3 {
 		t.Fatal("Should match a full name even though it collides with another container's ID")
 	}
 
-	if container, _ := daemon.Get("d22d69a2b896"); container != c5 {
+	if container, _ := daemon.Get(ctx, "d22d69a2b896"); container != c5 {
 		t.Fatal("Should match a container where the provided prefix is an exact match to the it's name, and is also a prefix for it's ID")
 	}
 
-	if _, err := daemon.Get("3cdbd1"); err == nil {
+	if _, err := daemon.Get(ctx, "3cdbd1"); err == nil {
 		t.Fatal("Should return an error when provided a prefix that partially matches multiple container ID's")
 	}
 
-	if _, err := daemon.Get("nothing"); err == nil {
+	if _, err := daemon.Get(ctx, "nothing"); err == nil {
 		t.Fatal("Should return an error when provided a prefix that is neither a name or a partial match to an ID")
 	}
 
@@ -486,13 +489,15 @@ func TestRemoveLocalVolumesFollowingSymlinks(t *testing.T) {
 		t.Fatalf("Expected 1 volume mounted, was 0\n")
 	}
 
+	ctx := context.Background()
+
 	m := c.MountPoints["/vol1"]
-	_, err = daemon.VolumeCreate(m.Name, m.Driver, nil)
+	_, err = daemon.VolumeCreate(ctx, m.Name, m.Driver, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := daemon.VolumeRm(m.Name); err != nil {
+	if err := daemon.VolumeRm(ctx, m.Name); err != nil {
 		t.Fatal(err)
 	}
 

--- a/daemon/daemon_unix.go
+++ b/daemon/daemon_unix.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/autogen/dockerversion"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/parsers"
@@ -114,12 +115,12 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, a
 
 // verifyPlatformContainerSettings performs platform-specific validation of the
 // hostconfig and config structures.
-func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostConfig, config *runconfig.Config) ([]string, error) {
+func verifyPlatformContainerSettings(ctx context.Context, daemon *Daemon, hostConfig *runconfig.HostConfig, config *runconfig.Config) ([]string, error) {
 	warnings := []string{}
 	sysInfo := sysinfo.New(true)
 
-	if hostConfig.LxcConf.Len() > 0 && !strings.Contains(daemon.ExecutionDriver().Name(), "lxc") {
-		return warnings, fmt.Errorf("Cannot use --lxc-conf with execdriver: %s", daemon.ExecutionDriver().Name())
+	if hostConfig.LxcConf.Len() > 0 && !strings.Contains(daemon.ExecutionDriver(ctx).Name(), "lxc") {
+		return warnings, fmt.Errorf("Cannot use --lxc-conf with execdriver: %s", daemon.ExecutionDriver(ctx).Name())
 	}
 
 	// memory subsystem checks and adjustments
@@ -484,12 +485,12 @@ func setupInitLayer(initLayer string) error {
 
 // NetworkAPIRouter implements a feature for server-experimental,
 // directly calling into libnetwork.
-func (daemon *Daemon) NetworkAPIRouter() func(w http.ResponseWriter, req *http.Request) {
+func (daemon *Daemon) NetworkAPIRouter(ctx context.Context) func(w http.ResponseWriter, req *http.Request) {
 	return nwapi.NewHTTPHandler(daemon.netController)
 }
 
 // registerLinks writes the links to a file.
-func (daemon *Daemon) registerLinks(container *Container, hostConfig *runconfig.HostConfig) error {
+func (daemon *Daemon) registerLinks(ctx context.Context, container *Container, hostConfig *runconfig.HostConfig) error {
 	if hostConfig == nil || hostConfig.Links == nil {
 		return nil
 	}
@@ -499,14 +500,14 @@ func (daemon *Daemon) registerLinks(container *Container, hostConfig *runconfig.
 		if err != nil {
 			return err
 		}
-		child, err := daemon.Get(name)
+		child, err := daemon.Get(ctx, name)
 		if err != nil {
 			//An error from daemon.Get() means this name could not be found
 			return fmt.Errorf("Could not get container for %s", name)
 		}
 		for child.hostConfig.NetworkMode.IsContainer() {
 			parts := strings.SplitN(string(child.hostConfig.NetworkMode), ":", 2)
-			child, err = daemon.Get(parts[1])
+			child, err = daemon.Get(ctx, parts[1])
 			if err != nil {
 				return fmt.Errorf("Could not get container for %s", parts[1])
 			}

--- a/daemon/daemon_windows.go
+++ b/daemon/daemon_windows.go
@@ -6,6 +6,7 @@ import (
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/graphdriver"
 	// register the windows graph driver
 	_ "github.com/docker/docker/daemon/graphdriver/windows"
@@ -47,7 +48,7 @@ func (daemon *Daemon) adaptContainerSettings(hostConfig *runconfig.HostConfig, a
 
 // verifyPlatformContainerSettings performs platform-specific validation of the
 // hostconfig and config structures.
-func verifyPlatformContainerSettings(daemon *Daemon, hostConfig *runconfig.HostConfig, config *runconfig.Config) ([]string, error) {
+func verifyPlatformContainerSettings(ctx context.Context, daemon *Daemon, hostConfig *runconfig.HostConfig, config *runconfig.Config) ([]string, error) {
 	return nil, nil
 }
 
@@ -104,7 +105,7 @@ func initNetworkController(config *Config) (libnetwork.NetworkController, error)
 
 // registerLinks sets up links between containers and writes the
 // configuration out for persistence.
-func (daemon *Daemon) registerLinks(container *Container, hostConfig *runconfig.HostConfig) error {
+func (daemon *Daemon) registerLinks(ctx context.Context, container *Container, hostConfig *runconfig.HostConfig) error {
 	// TODO Windows. Factored out for network modes. There may be more
 	// refactoring required here.
 
@@ -117,7 +118,7 @@ func (daemon *Daemon) registerLinks(container *Container, hostConfig *runconfig.
 		if err != nil {
 			return err
 		}
-		child, err := daemon.Get(name)
+		child, err := daemon.Get(ctx, name)
 		if err != nil {
 			//An error from daemon.Get() means this name could not be found
 			return fmt.Errorf("Could not get container for %s", name)

--- a/daemon/events/events.go
+++ b/daemon/events/events.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/docker/context"
+
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/pubsub"
 )
@@ -44,9 +46,9 @@ func (e *Events) Evict(l chan interface{}) {
 
 // Log broadcasts event to listeners. Each listener has 100 millisecond for
 // receiving event or it will be skipped.
-func (e *Events) Log(action, id, from string) {
+func (e *Events) Log(ctx context.Context, action, id, from string) {
 	now := time.Now().UTC()
-	jm := &jsonmessage.JSONMessage{Status: action, ID: id, From: from, Time: now.Unix(), TimeNano: now.UnixNano()}
+	jm := &jsonmessage.JSONMessage{RequestID: ctx.RequestID(), Status: action, ID: id, From: from, Time: now.Unix(), TimeNano: now.UnixNano()}
 	e.mu.Lock()
 	if len(e.events) == cap(e.events) {
 		// discard oldest event

--- a/daemon/events/events_test.go
+++ b/daemon/events/events_test.go
@@ -5,10 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/pkg/jsonmessage"
 )
 
 func TestEventsLog(t *testing.T) {
+	ctx := context.Background()
 	e := New()
 	_, l1 := e.Subscribe()
 	_, l2 := e.Subscribe()
@@ -18,7 +20,7 @@ func TestEventsLog(t *testing.T) {
 	if count != 2 {
 		t.Fatalf("Must be 2 subscribers, got %d", count)
 	}
-	e.Log("test", "cont", "image")
+	e.Log(ctx, "test", "cont", "image")
 	select {
 	case msg := <-l1:
 		jmsg, ok := msg.(*jsonmessage.JSONMessage)
@@ -64,13 +66,14 @@ func TestEventsLog(t *testing.T) {
 }
 
 func TestEventsLogTimeout(t *testing.T) {
+	ctx := context.Background()
 	e := New()
 	_, l := e.Subscribe()
 	defer e.Evict(l)
 
 	c := make(chan struct{})
 	go func() {
-		e.Log("test", "cont", "image")
+		e.Log(ctx, "test", "cont", "image")
 		close(c)
 	}()
 
@@ -82,13 +85,14 @@ func TestEventsLogTimeout(t *testing.T) {
 }
 
 func TestLogEvents(t *testing.T) {
+	ctx := context.Background()
 	e := New()
 
 	for i := 0; i < eventsLimit+16; i++ {
 		action := fmt.Sprintf("action_%d", i)
 		id := fmt.Sprintf("cont_%d", i)
 		from := fmt.Sprintf("image_%d", i)
-		e.Log(action, id, from)
+		e.Log(ctx, action, id, from)
 	}
 	time.Sleep(50 * time.Millisecond)
 	current, l := e.Subscribe()
@@ -97,7 +101,7 @@ func TestLogEvents(t *testing.T) {
 		action := fmt.Sprintf("action_%d", num)
 		id := fmt.Sprintf("cont_%d", num)
 		from := fmt.Sprintf("image_%d", num)
-		e.Log(action, id, from)
+		e.Log(ctx, action, id, from)
 	}
 	if len(e.events) != eventsLimit {
 		t.Fatalf("Must be %d events, got %d", eventsLimit, len(e.events))

--- a/daemon/execdriver/driver.go
+++ b/daemon/execdriver/driver.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	// TODO Windows: Factor out ulimit
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/pkg/ulimit"
 	"github.com/opencontainers/runc/libcontainer"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -29,7 +30,7 @@ var (
 // through PreStart, Start and PostStop events.
 // Callbacks are provided a processConfig pointer and the pid of the child.
 // The channel will be used to notify the OOM events.
-type DriverCallback func(processConfig *ProcessConfig, pid int, chOOM <-chan struct{}) error
+type DriverCallback func(ctx context.Context, processConfig *ProcessConfig, pid int, chOOM <-chan struct{}) error
 
 // Hooks is a struct containing function pointers to callbacks
 // used by any execdriver implementation exploiting hooks capabilities
@@ -69,11 +70,11 @@ type ExitStatus struct {
 type Driver interface {
 	// Run executes the process, blocks until the process exits and returns
 	// the exit code. It's the last stage on Docker side for running a container.
-	Run(c *Command, pipes *Pipes, hooks Hooks) (ExitStatus, error)
+	Run(ctx context.Context, c *Command, pipes *Pipes, hooks Hooks) (ExitStatus, error)
 
 	// Exec executes the process in an existing container, blocks until the
 	// process exits and returns the exit code.
-	Exec(c *Command, processConfig *ProcessConfig, pipes *Pipes, hooks Hooks) (int, error)
+	Exec(ctx context.Context, c *Command, processConfig *ProcessConfig, pipes *Pipes, hooks Hooks) (int, error)
 
 	// Kill sends signals to process in container.
 	Kill(c *Command, sig int) error

--- a/daemon/execdriver/lxc/driver.go
+++ b/daemon/execdriver/lxc/driver.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/pkg/stringutils"
 	sysinfo "github.com/docker/docker/pkg/system"
@@ -125,7 +126,7 @@ func killNetNsProc(proc *os.Process) {
 
 // Run implements the exec driver Driver interface,
 // it calls 'exec.Cmd' to launch lxc commands to run a container.
-func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execdriver.Hooks) (execdriver.ExitStatus, error) {
+func (d *Driver) Run(ctx context.Context, c *execdriver.Command, pipes *execdriver.Pipes, hooks execdriver.Hooks) (execdriver.ExitStatus, error) {
 	var (
 		term     execdriver.Terminal
 		err      error
@@ -329,7 +330,7 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execd
 
 	if hooks.Start != nil {
 		logrus.Debugf("Invoking startCallback")
-		hooks.Start(&c.ProcessConfig, pid, oomKillNotification)
+		hooks.Start(ctx, &c.ProcessConfig, pid, oomKillNotification)
 
 	}
 
@@ -871,7 +872,7 @@ func (t *TtyConsole) Close() error {
 
 // Exec implements the exec driver Driver interface,
 // it is not implemented by lxc.
-func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, hooks execdriver.Hooks) (int, error) {
+func (d *Driver) Exec(ctx context.Context, c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, hooks execdriver.Hooks) (int, error) {
 	return -1, ErrExec
 }
 

--- a/daemon/execdriver/native/create.go
+++ b/daemon/execdriver/native/create.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/opencontainers/runc/libcontainer/apparmor"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -18,7 +19,7 @@ import (
 
 // createContainer populates and configures the container type with the
 // data provided by the execdriver.Command
-func (d *Driver) createContainer(c *execdriver.Command, hooks execdriver.Hooks) (*configs.Config, error) {
+func (d *Driver) createContainer(ctx context.Context, c *execdriver.Command, hooks execdriver.Hooks) (*configs.Config, error) {
 	container := execdriver.InitContainer(c)
 
 	if err := d.createIpc(container, c); err != nil {
@@ -33,7 +34,7 @@ func (d *Driver) createContainer(c *execdriver.Command, hooks execdriver.Hooks) 
 		return nil, err
 	}
 
-	if err := d.createNetwork(container, c, hooks); err != nil {
+	if err := d.createNetwork(ctx, container, c, hooks); err != nil {
 		return nil, err
 	}
 
@@ -113,7 +114,7 @@ func generateIfaceName() (string, error) {
 	return "", errors.New("Failed to find name for new interface")
 }
 
-func (d *Driver) createNetwork(container *configs.Config, c *execdriver.Command, hooks execdriver.Hooks) error {
+func (d *Driver) createNetwork(ctx context.Context, container *configs.Config, c *execdriver.Command, hooks execdriver.Hooks) error {
 	if c.Network == nil {
 		return nil
 	}
@@ -150,7 +151,7 @@ func (d *Driver) createNetwork(container *configs.Config, c *execdriver.Command,
 						// non-blocking and return the correct result when read.
 						chOOM := make(chan struct{})
 						close(chOOM)
-						if err := fnHook(&c.ProcessConfig, s.Pid, chOOM); err != nil {
+						if err := fnHook(ctx, &c.ProcessConfig, s.Pid, chOOM); err != nil {
 							return err
 						}
 					}

--- a/daemon/execdriver/native/driver.go
+++ b/daemon/execdriver/native/driver.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/pools"
@@ -131,9 +132,9 @@ type execOutput struct {
 
 // Run implements the exec driver Driver interface,
 // it calls libcontainer APIs to run a container.
-func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execdriver.Hooks) (execdriver.ExitStatus, error) {
+func (d *Driver) Run(ctx context.Context, c *execdriver.Command, pipes *execdriver.Pipes, hooks execdriver.Hooks) (execdriver.ExitStatus, error) {
 	// take the Command and populate the libcontainer.Config from it
-	container, err := d.createContainer(c, hooks)
+	container, err := d.createContainer(ctx, c, hooks)
 	if err != nil {
 		return execdriver.ExitStatus{ExitCode: -1}, err
 	}
@@ -174,7 +175,7 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execd
 			p.Wait()
 			return execdriver.ExitStatus{ExitCode: -1}, err
 		}
-		hooks.Start(&c.ProcessConfig, pid, oom)
+		hooks.Start(ctx, &c.ProcessConfig, pid, oom)
 	}
 
 	waitF := p.Wait

--- a/daemon/execdriver/native/exec.go
+++ b/daemon/execdriver/native/exec.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"syscall"
 
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/opencontainers/runc/libcontainer"
 	// Blank import 'nsenter' so that init in that package will call c
@@ -19,7 +20,7 @@ import (
 
 // Exec implements the exec driver Driver interface,
 // it calls libcontainer APIs to execute a container.
-func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, hooks execdriver.Hooks) (int, error) {
+func (d *Driver) Exec(ctx context.Context, c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, hooks execdriver.Hooks) (int, error) {
 	active := d.activeContainers[c.ID]
 	if active == nil {
 		return -1, fmt.Errorf("No active container exists with ID %s", c.ID)
@@ -57,7 +58,7 @@ func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 		// non-blocking and return the correct result when read.
 		chOOM := make(chan struct{})
 		close(chOOM)
-		hooks.Start(&c.ProcessConfig, pid, chOOM)
+		hooks.Start(ctx, &c.ProcessConfig, pid, chOOM)
 	}
 
 	ps, err := p.Wait()

--- a/daemon/execdriver/windows/exec.go
+++ b/daemon/execdriver/windows/exec.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/microsoft/hcsshim"
 )
 
 // Exec implements the exec driver Driver interface.
-func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, hooks execdriver.Hooks) (int, error) {
+func (d *Driver) Exec(ctx context.Context, c *execdriver.Command, processConfig *execdriver.ProcessConfig, pipes *execdriver.Pipes, hooks execdriver.Hooks) (int, error) {
 
 	var (
 		term     execdriver.Terminal
@@ -74,7 +75,7 @@ func (d *Driver) Exec(c *execdriver.Command, processConfig *execdriver.ProcessCo
 		// non-blocking and return the correct result when read.
 		chOOM := make(chan struct{})
 		close(chOOM)
-		hooks.Start(&c.ProcessConfig, int(pid), chOOM)
+		hooks.Start(ctx, &c.ProcessConfig, int(pid), chOOM)
 	}
 
 	if exitCode, err = hcsshim.WaitForProcessInComputeSystem(c.ID, pid); err != nil {

--- a/daemon/execdriver/windows/run.go
+++ b/daemon/execdriver/windows/run.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/microsoft/hcsshim"
 )
@@ -79,7 +80,7 @@ type containerInit struct {
 const defaultOwner = "docker"
 
 // Run implements the exec driver Driver interface
-func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execdriver.Hooks) (execdriver.ExitStatus, error) {
+func (d *Driver) Run(ctx context.Context, c *execdriver.Command, pipes *execdriver.Pipes, hooks execdriver.Hooks) (execdriver.ExitStatus, error) {
 
 	var (
 		term execdriver.Terminal
@@ -298,7 +299,7 @@ func (d *Driver) Run(c *execdriver.Command, pipes *execdriver.Pipes, hooks execd
 		// non-blocking and return the correct result when read.
 		chOOM := make(chan struct{})
 		close(chOOM)
-		hooks.Start(&c.ProcessConfig, int(pid), chOOM)
+		hooks.Start(ctx, &c.ProcessConfig, int(pid), chOOM)
 	}
 
 	var exitCode int32

--- a/daemon/export.go
+++ b/daemon/export.go
@@ -3,18 +3,19 @@ package daemon
 import (
 	"io"
 
+	"github.com/docker/docker/context"
 	derr "github.com/docker/docker/errors"
 )
 
 // ContainerExport writes the contents of the container to the given
 // writer. An error is returned if the container cannot be found.
-func (daemon *Daemon) ContainerExport(name string, out io.Writer) error {
-	container, err := daemon.Get(name)
+func (daemon *Daemon) ContainerExport(ctx context.Context, name string, out io.Writer) error {
+	container, err := daemon.Get(ctx, name)
 	if err != nil {
 		return err
 	}
 
-	data, err := container.export()
+	data, err := container.export(ctx)
 	if err != nil {
 		return derr.ErrorCodeExportFailed.WithArgs(name, err)
 	}

--- a/daemon/image_delete.go
+++ b/daemon/image_delete.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/context"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/graph/tags"
 	"github.com/docker/docker/image"
@@ -50,10 +51,10 @@ import (
 // FIXME: remove ImageDelete's dependency on Daemon, then move to the graph
 // package. This would require that we no longer need the daemon to determine
 // whether images are being used by a stopped or running container.
-func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.ImageDelete, error) {
+func (daemon *Daemon) ImageDelete(ctx context.Context, imageRef string, force, prune bool) ([]types.ImageDelete, error) {
 	records := []types.ImageDelete{}
 
-	img, err := daemon.Repositories().LookupImage(imageRef)
+	img, err := daemon.Repositories(ctx).LookupImage(imageRef)
 	if err != nil {
 		return nil, err
 	}
@@ -64,8 +65,8 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 		// first. We can only remove this reference if either force is
 		// true, there are multiple repository references to this
 		// image, or there are no containers using the given reference.
-		if !(force || daemon.imageHasMultipleRepositoryReferences(img.ID)) {
-			if container := daemon.getContainerUsingImage(img.ID); container != nil {
+		if !(force || daemon.imageHasMultipleRepositoryReferences(ctx, img.ID)) {
+			if container := daemon.getContainerUsingImage(ctx, img.ID); container != nil {
 				// If we removed the repository reference then
 				// this image would remain "dangling" and since
 				// we really want to avoid that the client must
@@ -74,14 +75,14 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 			}
 		}
 
-		parsedRef, err := daemon.removeImageRef(imageRef)
+		parsedRef, err := daemon.removeImageRef(ctx, imageRef)
 		if err != nil {
 			return nil, err
 		}
 
 		untaggedRecord := types.ImageDelete{Untagged: parsedRef}
 
-		daemon.EventsService.Log("untag", img.ID, "")
+		daemon.EventsService.Log(ctx, "untag", img.ID, "")
 		records = append(records, untaggedRecord)
 
 		removedRepositoryRef = true
@@ -90,21 +91,21 @@ func (daemon *Daemon) ImageDelete(imageRef string, force, prune bool) ([]types.I
 		// repository reference to the image then we will want to
 		// remove that reference.
 		// FIXME: Is this the behavior we want?
-		repoRefs := daemon.Repositories().ByID()[img.ID]
+		repoRefs := daemon.Repositories(ctx).ByID()[img.ID]
 		if len(repoRefs) == 1 {
-			parsedRef, err := daemon.removeImageRef(repoRefs[0])
+			parsedRef, err := daemon.removeImageRef(ctx, repoRefs[0])
 			if err != nil {
 				return nil, err
 			}
 
 			untaggedRecord := types.ImageDelete{Untagged: parsedRef}
 
-			daemon.EventsService.Log("untag", img.ID, "")
+			daemon.EventsService.Log(ctx, "untag", img.ID, "")
 			records = append(records, untaggedRecord)
 		}
 	}
 
-	return records, daemon.imageDeleteHelper(img, &records, force, prune, removedRepositoryRef)
+	return records, daemon.imageDeleteHelper(ctx, img, &records, force, prune, removedRepositoryRef)
 }
 
 // isImageIDPrefix returns whether the given possiblePrefix is a prefix of the
@@ -115,14 +116,14 @@ func isImageIDPrefix(imageID, possiblePrefix string) bool {
 
 // imageHasMultipleRepositoryReferences returns whether there are multiple
 // repository references to the given imageID.
-func (daemon *Daemon) imageHasMultipleRepositoryReferences(imageID string) bool {
-	return len(daemon.Repositories().ByID()[imageID]) > 1
+func (daemon *Daemon) imageHasMultipleRepositoryReferences(ctx context.Context, imageID string) bool {
+	return len(daemon.Repositories(ctx).ByID()[imageID]) > 1
 }
 
 // getContainerUsingImage returns a container that was created using the given
 // imageID. Returns nil if there is no such container.
-func (daemon *Daemon) getContainerUsingImage(imageID string) *Container {
-	for _, container := range daemon.List() {
+func (daemon *Daemon) getContainerUsingImage(ctx context.Context, imageID string) *Container {
+	for _, container := range daemon.List(ctx) {
 		if container.ImageID == imageID {
 			return container
 		}
@@ -136,7 +137,7 @@ func (daemon *Daemon) getContainerUsingImage(imageID string) *Container {
 // repositoryRef must not be an image ID but a repository name followed by an
 // optional tag or digest reference. If tag or digest is omitted, the default
 // tag is used. Returns the resolved image reference and an error.
-func (daemon *Daemon) removeImageRef(repositoryRef string) (string, error) {
+func (daemon *Daemon) removeImageRef(ctx context.Context, repositoryRef string) (string, error) {
 	repository, ref := parsers.ParseRepositoryTag(repositoryRef)
 	if ref == "" {
 		ref = tags.DefaultTag
@@ -145,7 +146,7 @@ func (daemon *Daemon) removeImageRef(repositoryRef string) (string, error) {
 	// Ignore the boolean value returned, as far as we're concerned, this
 	// is an idempotent operation and it's okay if the reference didn't
 	// exist in the first place.
-	_, err := daemon.Repositories().Delete(repository, ref)
+	_, err := daemon.Repositories(ctx).Delete(repository, ref)
 
 	return utils.ImageReference(repository, ref), err
 }
@@ -155,18 +156,18 @@ func (daemon *Daemon) removeImageRef(repositoryRef string) (string, error) {
 // on the first encountered error. Removed references are logged to this
 // daemon's event service. An "Untagged" types.ImageDelete is added to the
 // given list of records.
-func (daemon *Daemon) removeAllReferencesToImageID(imgID string, records *[]types.ImageDelete) error {
-	imageRefs := daemon.Repositories().ByID()[imgID]
+func (daemon *Daemon) removeAllReferencesToImageID(ctx context.Context, imgID string, records *[]types.ImageDelete) error {
+	imageRefs := daemon.Repositories(ctx).ByID()[imgID]
 
 	for _, imageRef := range imageRefs {
-		parsedRef, err := daemon.removeImageRef(imageRef)
+		parsedRef, err := daemon.removeImageRef(ctx, imageRef)
 		if err != nil {
 			return err
 		}
 
 		untaggedRecord := types.ImageDelete{Untagged: parsedRef}
 
-		daemon.EventsService.Log("untag", imgID, "")
+		daemon.EventsService.Log(ctx, "untag", imgID, "")
 		*records = append(*records, untaggedRecord)
 	}
 
@@ -203,11 +204,11 @@ func (idc *imageDeleteConflict) Error() string {
 // conflict is encountered, it will be returned immediately without deleting
 // the image. If quiet is true, any encountered conflicts will be ignored and
 // the function will return nil immediately without deleting the image.
-func (daemon *Daemon) imageDeleteHelper(img *image.Image, records *[]types.ImageDelete, force, prune, quiet bool) error {
+func (daemon *Daemon) imageDeleteHelper(ctx context.Context, img *image.Image, records *[]types.ImageDelete, force, prune, quiet bool) error {
 	// First, determine if this image has any conflicts. Ignore soft conflicts
 	// if force is true.
-	if conflict := daemon.checkImageDeleteConflict(img, force); conflict != nil {
-		if quiet && !daemon.imageIsDangling(img) {
+	if conflict := daemon.checkImageDeleteConflict(ctx, img, force); conflict != nil {
+		if quiet && !daemon.imageIsDangling(ctx, img) {
 			// Ignore conflicts UNLESS the image is "dangling" in
 			// which case we want the user to know.
 			return nil
@@ -219,15 +220,15 @@ func (daemon *Daemon) imageDeleteHelper(img *image.Image, records *[]types.Image
 	}
 
 	// Delete all repository tag/digest references to this image.
-	if err := daemon.removeAllReferencesToImageID(img.ID, records); err != nil {
+	if err := daemon.removeAllReferencesToImageID(ctx, img.ID, records); err != nil {
 		return err
 	}
 
-	if err := daemon.Graph().Delete(img.ID); err != nil {
+	if err := daemon.Graph(ctx).Delete(img.ID); err != nil {
 		return err
 	}
 
-	daemon.EventsService.Log("delete", img.ID, "")
+	daemon.EventsService.Log(ctx, "delete", img.ID, "")
 	*records = append(*records, types.ImageDelete{Deleted: img.ID})
 
 	if !prune || img.Parent == "" {
@@ -237,14 +238,14 @@ func (daemon *Daemon) imageDeleteHelper(img *image.Image, records *[]types.Image
 	// We need to prune the parent image. This means delete it if there are
 	// no tags/digests referencing it and there are no containers using it (
 	// either running or stopped).
-	parentImg, err := daemon.Graph().Get(img.Parent)
+	parentImg, err := daemon.Graph(ctx).Get(img.Parent)
 	if err != nil {
 		return derr.ErrorCodeImgNoParent.WithArgs(err)
 	}
 
 	// Do not force prunings, but do so quietly (stopping on any encountered
 	// conflicts).
-	return daemon.imageDeleteHelper(parentImg, records, false, true, true)
+	return daemon.imageDeleteHelper(ctx, parentImg, records, false, true, true)
 }
 
 // checkImageDeleteConflict determines whether there are any conflicts
@@ -253,9 +254,9 @@ func (daemon *Daemon) imageDeleteHelper(img *image.Image, records *[]types.Image
 // using the image. A soft conflict is any tags/digest referencing the given
 // image or any stopped container using the image. If ignoreSoftConflicts is
 // true, this function will not check for soft conflict conditions.
-func (daemon *Daemon) checkImageDeleteConflict(img *image.Image, ignoreSoftConflicts bool) *imageDeleteConflict {
+func (daemon *Daemon) checkImageDeleteConflict(ctx context.Context, img *image.Image, ignoreSoftConflicts bool) *imageDeleteConflict {
 	// Check for hard conflicts first.
-	if conflict := daemon.checkImageDeleteHardConflict(img); conflict != nil {
+	if conflict := daemon.checkImageDeleteHardConflict(ctx, img); conflict != nil {
 		return conflict
 	}
 
@@ -265,12 +266,12 @@ func (daemon *Daemon) checkImageDeleteConflict(img *image.Image, ignoreSoftConfl
 		return nil
 	}
 
-	return daemon.checkImageDeleteSoftConflict(img)
+	return daemon.checkImageDeleteSoftConflict(ctx, img)
 }
 
-func (daemon *Daemon) checkImageDeleteHardConflict(img *image.Image) *imageDeleteConflict {
+func (daemon *Daemon) checkImageDeleteHardConflict(ctx context.Context, img *image.Image) *imageDeleteConflict {
 	// Check if the image ID is being used by a pull or build.
-	if daemon.Graph().IsHeld(img.ID) {
+	if daemon.Graph(ctx).IsHeld(img.ID) {
 		return &imageDeleteConflict{
 			hard:    true,
 			imgID:   img.ID,
@@ -279,7 +280,7 @@ func (daemon *Daemon) checkImageDeleteHardConflict(img *image.Image) *imageDelet
 	}
 
 	// Check if the image has any descendent images.
-	if daemon.Graph().HasChildren(img) {
+	if daemon.Graph(ctx).HasChildren(img) {
 		return &imageDeleteConflict{
 			hard:    true,
 			imgID:   img.ID,
@@ -288,7 +289,7 @@ func (daemon *Daemon) checkImageDeleteHardConflict(img *image.Image) *imageDelet
 	}
 
 	// Check if any running container is using the image.
-	for _, container := range daemon.List() {
+	for _, container := range daemon.List(ctx) {
 		if !container.IsRunning() {
 			// Skip this until we check for soft conflicts later.
 			continue
@@ -306,9 +307,9 @@ func (daemon *Daemon) checkImageDeleteHardConflict(img *image.Image) *imageDelet
 	return nil
 }
 
-func (daemon *Daemon) checkImageDeleteSoftConflict(img *image.Image) *imageDeleteConflict {
+func (daemon *Daemon) checkImageDeleteSoftConflict(ctx context.Context, img *image.Image) *imageDeleteConflict {
 	// Check if any repository tags/digest reference this image.
-	if daemon.Repositories().HasReferences(img) {
+	if daemon.Repositories(ctx).HasReferences(img) {
 		return &imageDeleteConflict{
 			imgID:   img.ID,
 			message: "image is referenced in one or more repositories",
@@ -316,7 +317,7 @@ func (daemon *Daemon) checkImageDeleteSoftConflict(img *image.Image) *imageDelet
 	}
 
 	// Check if any stopped containers reference this image.
-	for _, container := range daemon.List() {
+	for _, container := range daemon.List(ctx) {
 		if container.IsRunning() {
 			// Skip this as it was checked above in hard conflict conditions.
 			continue
@@ -336,6 +337,6 @@ func (daemon *Daemon) checkImageDeleteSoftConflict(img *image.Image) *imageDelet
 // imageIsDangling returns whether the given image is "dangling" which means
 // that there are no repository references to the given image and it has no
 // child images.
-func (daemon *Daemon) imageIsDangling(img *image.Image) bool {
-	return !(daemon.Repositories().HasReferences(img) || daemon.Graph().HasChildren(img))
+func (daemon *Daemon) imageIsDangling(ctx context.Context, img *image.Image) bool {
+	return !(daemon.Repositories(ctx).HasReferences(img) || daemon.Graph(ctx).HasChildren(img))
 }

--- a/daemon/info.go
+++ b/daemon/info.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/autogen/dockerversion"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/pkg/fileutils"
 	"github.com/docker/docker/pkg/parsers/kernel"
 	"github.com/docker/docker/pkg/parsers/operatingsystem"
@@ -18,8 +19,8 @@ import (
 )
 
 // SystemInfo returns information about the host server the daemon is running on.
-func (daemon *Daemon) SystemInfo() (*types.Info, error) {
-	images := daemon.Graph().Map()
+func (daemon *Daemon) SystemInfo(ctx context.Context) (*types.Info, error) {
+	images := daemon.Graph(ctx).Map()
 	var imgcount int
 	if images == nil {
 		imgcount = 0
@@ -65,10 +66,10 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 
 	v := &types.Info{
 		ID:                 daemon.ID,
-		Containers:         len(daemon.List()),
+		Containers:         len(daemon.List(ctx)),
 		Images:             imgcount,
-		Driver:             daemon.GraphDriver().String(),
-		DriverStatus:       daemon.GraphDriver().Status(),
+		Driver:             daemon.GraphDriver(ctx).String(),
+		DriverStatus:       daemon.GraphDriver(ctx).Status(),
 		IPv4Forwarding:     !sysInfo.IPv4ForwardingDisabled,
 		BridgeNfIptables:   !sysInfo.BridgeNfCallIptablesDisabled,
 		BridgeNfIP6tables:  !sysInfo.BridgeNfCallIP6tablesDisabled,
@@ -76,7 +77,7 @@ func (daemon *Daemon) SystemInfo() (*types.Info, error) {
 		NFd:                fileutils.GetTotalUsedFds(),
 		NGoroutines:        runtime.NumGoroutine(),
 		SystemTime:         time.Now().Format(time.RFC3339Nano),
-		ExecutionDriver:    daemon.ExecutionDriver().Name(),
+		ExecutionDriver:    daemon.ExecutionDriver(ctx).Name(),
 		LoggingDriver:      daemon.defaultLogConfig.Type,
 		NEventsListener:    daemon.EventsService.SubscribersCount(),
 		KernelVersion:      kernelVersion,

--- a/daemon/inspect_unix.go
+++ b/daemon/inspect_unix.go
@@ -2,7 +2,10 @@
 
 package daemon
 
-import "github.com/docker/docker/api/types"
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/context"
+)
 
 // This sets platform-specific fields
 func setPlatformSpecificContainerFields(container *Container, contJSONBase *types.ContainerJSONBase) *types.ContainerJSONBase {
@@ -15,8 +18,8 @@ func setPlatformSpecificContainerFields(container *Container, contJSONBase *type
 }
 
 // ContainerInspectPre120 gets containers for pre 1.20 APIs.
-func (daemon *Daemon) ContainerInspectPre120(name string) (*types.ContainerJSONPre120, error) {
-	container, err := daemon.Get(name)
+func (daemon *Daemon) ContainerInspectPre120(ctx context.Context, name string) (*types.ContainerJSONPre120, error) {
+	container, err := daemon.Get(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -24,7 +27,7 @@ func (daemon *Daemon) ContainerInspectPre120(name string) (*types.ContainerJSONP
 	container.Lock()
 	defer container.Unlock()
 
-	base, err := daemon.getInspectData(container)
+	base, err := daemon.getInspectData(ctx, container)
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/inspect_windows.go
+++ b/daemon/inspect_windows.go
@@ -1,6 +1,9 @@
 package daemon
 
-import "github.com/docker/docker/api/types"
+import (
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/context"
+)
 
 // This sets platform-specific fields
 func setPlatformSpecificContainerFields(container *Container, contJSONBase *types.ContainerJSONBase) *types.ContainerJSONBase {
@@ -12,6 +15,6 @@ func addMountPoints(container *Container) []types.MountPoint {
 }
 
 // ContainerInspectPre120 get containers for pre 1.20 APIs.
-func (daemon *Daemon) ContainerInspectPre120(name string) (*types.ContainerJSON, error) {
-	return daemon.ContainerInspect(name)
+func (daemon *Daemon) ContainerInspectPre120(ctx context.Context, name string) (*types.ContainerJSON, error) {
+	return daemon.ContainerInspect(ctx, name)
 }

--- a/daemon/kill.go
+++ b/daemon/kill.go
@@ -1,25 +1,29 @@
 package daemon
 
-import "syscall"
+import (
+	"syscall"
+
+	"github.com/docker/docker/context"
+)
 
 // ContainerKill send signal to the container
 // If no signal is given (sig 0), then Kill with SIGKILL and wait
 // for the container to exit.
 // If a signal is given, then just send it to the container and return.
-func (daemon *Daemon) ContainerKill(name string, sig uint64) error {
-	container, err := daemon.Get(name)
+func (daemon *Daemon) ContainerKill(ctx context.Context, name string, sig uint64) error {
+	container, err := daemon.Get(ctx, name)
 	if err != nil {
 		return err
 	}
 
 	// If no signal is passed, or SIGKILL, perform regular Kill (SIGKILL + wait())
 	if sig == 0 || syscall.Signal(sig) == syscall.SIGKILL {
-		if err := container.Kill(); err != nil {
+		if err := container.Kill(ctx); err != nil {
 			return err
 		}
 	} else {
 		// Otherwise, just send the requested signal
-		if err := container.killSig(int(sig)); err != nil {
+		if err := container.killSig(ctx, int(sig)); err != nil {
 			return err
 		}
 	}

--- a/daemon/logs.go
+++ b/daemon/logs.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/logger"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/pkg/stdcopy"
@@ -30,7 +31,7 @@ type ContainerLogsConfig struct {
 
 // ContainerLogs hooks up a container's stdout and stderr streams
 // configured with the given struct.
-func (daemon *Daemon) ContainerLogs(container *Container, config *ContainerLogsConfig) error {
+func (daemon *Daemon) ContainerLogs(ctx context.Context, container *Container, config *ContainerLogsConfig) error {
 	if !(config.UseStdout || config.UseStderr) {
 		return derr.ErrorCodeNeedStream
 	}

--- a/daemon/pause.go
+++ b/daemon/pause.go
@@ -1,17 +1,18 @@
 package daemon
 
 import (
+	"github.com/docker/docker/context"
 	derr "github.com/docker/docker/errors"
 )
 
 // ContainerPause pauses a container
-func (daemon *Daemon) ContainerPause(name string) error {
-	container, err := daemon.Get(name)
+func (daemon *Daemon) ContainerPause(ctx context.Context, name string) error {
+	container, err := daemon.Get(ctx, name)
 	if err != nil {
 		return err
 	}
 
-	if err := container.pause(); err != nil {
+	if err := container.pause(ctx); err != nil {
 		return derr.ErrorCodePauseError.WithArgs(name, err)
 	}
 

--- a/daemon/resize.go
+++ b/daemon/resize.go
@@ -1,20 +1,24 @@
 package daemon
 
+import (
+	"github.com/docker/docker/context"
+)
+
 // ContainerResize changes the size of the TTY of the process running
 // in the container with the given name to the given height and width.
-func (daemon *Daemon) ContainerResize(name string, height, width int) error {
-	container, err := daemon.Get(name)
+func (daemon *Daemon) ContainerResize(ctx context.Context, name string, height, width int) error {
+	container, err := daemon.Get(ctx, name)
 	if err != nil {
 		return err
 	}
 
-	return container.Resize(height, width)
+	return container.Resize(ctx, height, width)
 }
 
 // ContainerExecResize changes the size of the TTY of the process
 // running in the exec with the given name to the given height and
 // width.
-func (daemon *Daemon) ContainerExecResize(name string, height, width int) error {
+func (daemon *Daemon) ContainerExecResize(ctx context.Context, name string, height, width int) error {
 	ExecConfig, err := daemon.getExecConfig(name)
 	if err != nil {
 		return err

--- a/daemon/restart.go
+++ b/daemon/restart.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"github.com/docker/docker/context"
 	derr "github.com/docker/docker/errors"
 )
 
@@ -10,12 +11,12 @@ import (
 // timeout, ContainerRestart will wait forever until a graceful
 // stop. Returns an error if the container cannot be found, or if
 // there is an underlying error at any stage of the restart.
-func (daemon *Daemon) ContainerRestart(name string, seconds int) error {
-	container, err := daemon.Get(name)
+func (daemon *Daemon) ContainerRestart(ctx context.Context, name string, seconds int) error {
+	container, err := daemon.Get(ctx, name)
 	if err != nil {
 		return err
 	}
-	if err := container.Restart(seconds); err != nil {
+	if err := container.Restart(ctx, seconds); err != nil {
 		return derr.ErrorCodeCantRestart.WithArgs(name, err)
 	}
 	return nil

--- a/daemon/start.go
+++ b/daemon/start.go
@@ -3,14 +3,15 @@ package daemon
 import (
 	"runtime"
 
+	"github.com/docker/docker/context"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/runconfig"
 	"github.com/docker/docker/utils"
 )
 
 // ContainerStart starts a container.
-func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConfig) error {
-	container, err := daemon.Get(name)
+func (daemon *Daemon) ContainerStart(ctx context.Context, name string, hostConfig *runconfig.HostConfig) error {
+	container, err := daemon.Get(ctx, name)
 	if err != nil {
 		return err
 	}
@@ -28,7 +29,7 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConf
 		// This is kept for backward compatibility - hostconfig should be passed when
 		// creating a container, not during start.
 		if hostConfig != nil {
-			if err := daemon.setHostConfig(container, hostConfig); err != nil {
+			if err := daemon.setHostConfig(ctx, container, hostConfig); err != nil {
 				return err
 			}
 		}
@@ -40,11 +41,11 @@ func (daemon *Daemon) ContainerStart(name string, hostConfig *runconfig.HostConf
 
 	// check if hostConfig is in line with the current system settings.
 	// It may happen cgroups are umounted or the like.
-	if _, err = daemon.verifyContainerSettings(container.hostConfig, nil); err != nil {
+	if _, err = daemon.verifyContainerSettings(ctx, container.hostConfig, nil); err != nil {
 		return err
 	}
 
-	if err := container.Start(); err != nil {
+	if err := container.Start(ctx); err != nil {
 		return derr.ErrorCodeCantStart.WithArgs(name, utils.GetErrorMessage(err))
 	}
 

--- a/daemon/stats.go
+++ b/daemon/stats.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/pkg/version"
 	"github.com/docker/libnetwork/osl"
@@ -22,9 +23,9 @@ type ContainerStatsConfig struct {
 
 // ContainerStats writes information about the container to the stream
 // given in the config object.
-func (daemon *Daemon) ContainerStats(prefixOrName string, config *ContainerStatsConfig) error {
+func (daemon *Daemon) ContainerStats(ctx context.Context, prefixOrName string, config *ContainerStatsConfig) error {
 
-	container, err := daemon.Get(prefixOrName)
+	container, err := daemon.Get(ctx, prefixOrName)
 	if err != nil {
 		return err
 	}

--- a/daemon/stop.go
+++ b/daemon/stop.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"github.com/docker/docker/context"
 	derr "github.com/docker/docker/errors"
 )
 
@@ -10,15 +11,15 @@ import (
 // will wait for a graceful termination. An error is returned if the
 // container is not found, is already stopped, or if there is a
 // problem stopping the container.
-func (daemon *Daemon) ContainerStop(name string, seconds int) error {
-	container, err := daemon.Get(name)
+func (daemon *Daemon) ContainerStop(ctx context.Context, name string, seconds int) error {
+	container, err := daemon.Get(ctx, name)
 	if err != nil {
 		return err
 	}
 	if !container.IsRunning() {
 		return derr.ErrorCodeStopped
 	}
-	if err := container.Stop(seconds); err != nil {
+	if err := container.Stop(ctx, seconds); err != nil {
 		return derr.ErrorCodeCantStop.WithArgs(name, err)
 	}
 	return nil

--- a/daemon/top_unix.go
+++ b/daemon/top_unix.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/context"
 	derr "github.com/docker/docker/errors"
 )
 
@@ -16,12 +17,12 @@ import (
 // "-ef" if no args are given.  An error is returned if the container
 // is not found, or is not running, or if there are any problems
 // running ps, or parsing the output.
-func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.ContainerProcessList, error) {
+func (daemon *Daemon) ContainerTop(ctx context.Context, name string, psArgs string) (*types.ContainerProcessList, error) {
 	if psArgs == "" {
 		psArgs = "-ef"
 	}
 
-	container, err := daemon.Get(name)
+	container, err := daemon.Get(ctx, name)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +31,7 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.Container
 		return nil, derr.ErrorCodeNotRunning.WithArgs(name)
 	}
 
-	pids, err := daemon.ExecutionDriver().GetPidsForContainer(container.ID)
+	pids, err := daemon.ExecutionDriver(ctx).GetPidsForContainer(container.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -76,6 +77,6 @@ func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.Container
 			}
 		}
 	}
-	container.logEvent("top")
+	container.logEvent(ctx, "top")
 	return procList, nil
 }

--- a/daemon/top_windows.go
+++ b/daemon/top_windows.go
@@ -2,10 +2,11 @@ package daemon
 
 import (
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/context"
 	derr "github.com/docker/docker/errors"
 )
 
 // ContainerTop is not supported on Windows and returns an error.
-func (daemon *Daemon) ContainerTop(name string, psArgs string) (*types.ContainerProcessList, error) {
+func (daemon *Daemon) ContainerTop(ctx context.Context, name string, psArgs string) (*types.ContainerProcessList, error) {
 	return nil, derr.ErrorCodeNoTop
 }

--- a/daemon/unpause.go
+++ b/daemon/unpause.go
@@ -1,17 +1,18 @@
 package daemon
 
 import (
+	"github.com/docker/docker/context"
 	derr "github.com/docker/docker/errors"
 )
 
 // ContainerUnpause unpauses a container
-func (daemon *Daemon) ContainerUnpause(name string) error {
-	container, err := daemon.Get(name)
+func (daemon *Daemon) ContainerUnpause(ctx context.Context, name string) error {
+	container, err := daemon.Get(ctx, name)
 	if err != nil {
 		return err
 	}
 
-	if err := container.unpause(); err != nil {
+	if err := container.unpause(ctx); err != nil {
 		return derr.ErrorCodeCantUnpause.WithArgs(name, err)
 	}
 

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/execdriver"
 	derr "github.com/docker/docker/errors"
 	"github.com/docker/docker/pkg/system"
@@ -285,7 +286,7 @@ func parseVolumesFrom(spec string) (string, string, error) {
 // 1. Select the previously configured mount points for the containers, if any.
 // 2. Select the volumes mounted from another containers. Overrides previously configured mount point destination.
 // 3. Select the bind mounts set by the client. Overrides previously configured mount point destinations.
-func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runconfig.HostConfig) error {
+func (daemon *Daemon) registerMountPoints(ctx context.Context, container *Container, hostConfig *runconfig.HostConfig) error {
 	binds := map[string]bool{}
 	mountPoints := map[string]*mountPoint{}
 
@@ -301,7 +302,7 @@ func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runc
 			return err
 		}
 
-		c, err := daemon.Get(containerID)
+		c, err := daemon.Get(ctx, containerID)
 		if err != nil {
 			return err
 		}

--- a/daemon/volumes_windows.go
+++ b/daemon/volumes_windows.go
@@ -3,6 +3,7 @@
 package daemon
 
 import (
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/daemon/execdriver"
 	"github.com/docker/docker/runconfig"
 )
@@ -31,6 +32,6 @@ func (daemon *Daemon) verifyVolumesInfo(container *Container) error {
 // registerMountPoints initializes the container mount points with the
 // configured volumes and bind mounts. Windows does not support volumes or
 // mount points.
-func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runconfig.HostConfig) error {
+func (daemon *Daemon) registerMountPoints(ctx context.Context, container *Container, hostConfig *runconfig.HostConfig) error {
 	return nil
 }

--- a/daemon/wait.go
+++ b/daemon/wait.go
@@ -1,14 +1,18 @@
 package daemon
 
-import "time"
+import (
+	"time"
+
+	"github.com/docker/docker/context"
+)
 
 // ContainerWait stops processing until the given container is
 // stopped. If the container is not found, an error is returned. On a
 // successful stop, the exit code of the container is returned. On a
 // timeout, an error is returned. If you want to wait forever, supply
 // a negative duration for the timeout.
-func (daemon *Daemon) ContainerWait(name string, timeout time.Duration) (int, error) {
-	container, err := daemon.Get(name)
+func (daemon *Daemon) ContainerWait(ctx context.Context, name string, timeout time.Duration) (int, error) {
+	container, err := daemon.Get(ctx, name)
 	if err != nil {
 		return -1, err
 	}

--- a/graph/import.go
+++ b/graph/import.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/pkg/httputils"
 	"github.com/docker/docker/pkg/progressreader"
 	"github.com/docker/docker/pkg/streamformatter"
@@ -16,7 +17,7 @@ import (
 // inConfig (if src is "-"), or from a URI specified in src. Progress output is
 // written to outStream. Repository and tag names can optionally be given in
 // the repo and tag arguments, respectively.
-func (s *TagStore) Import(src string, repo string, tag string, msg string, inConfig io.ReadCloser, outStream io.Writer, containerConfig *runconfig.Config) error {
+func (s *TagStore) Import(ctx context.Context, src string, repo string, tag string, msg string, inConfig io.ReadCloser, outStream io.Writer, containerConfig *runconfig.Config) error {
 	var (
 		sf      = streamformatter.NewJSONStreamFormatter()
 		archive io.ReadCloser
@@ -74,6 +75,6 @@ func (s *TagStore) Import(src string, repo string, tag string, msg string, inCon
 		logID = utils.ImageReference(logID, tag)
 	}
 
-	s.eventsService.Log("import", logID, "")
+	s.eventsService.Log(ctx, "import", logID, "")
 	return nil
 }

--- a/graph/pull.go
+++ b/graph/pull.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/registry"
 	"github.com/docker/docker/utils"
@@ -62,7 +63,7 @@ func NewPuller(s *TagStore, endpoint registry.APIEndpoint, repoInfo *registry.Re
 
 // Pull initiates a pull operation. image is the repository name to pull, and
 // tag may be either empty, or indicate a specific tag to pull.
-func (s *TagStore) Pull(image string, tag string, imagePullConfig *ImagePullConfig) error {
+func (s *TagStore) Pull(ctx context.Context, image string, tag string, imagePullConfig *ImagePullConfig) error {
 	var sf = streamformatter.NewJSONStreamFormatter()
 
 	// Resolve the Repository name from fqn to RepositoryInfo
@@ -131,7 +132,7 @@ func (s *TagStore) Pull(image string, tag string, imagePullConfig *ImagePullConf
 
 		}
 
-		s.eventsService.Log("pull", logName, "")
+		s.eventsService.Log(ctx, "pull", logName, "")
 		return nil
 	}
 

--- a/graph/push.go
+++ b/graph/push.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution/digest"
 	"github.com/docker/docker/cliconfig"
+	"github.com/docker/docker/context"
 	"github.com/docker/docker/pkg/streamformatter"
 	"github.com/docker/docker/registry"
 )
@@ -67,7 +68,7 @@ func (s *TagStore) NewPusher(endpoint registry.APIEndpoint, localRepo Repository
 }
 
 // Push initiates a push operation on the repository named localName.
-func (s *TagStore) Push(localName string, imagePushConfig *ImagePushConfig) error {
+func (s *TagStore) Push(ctx context.Context, localName string, imagePushConfig *ImagePushConfig) error {
 	// FIXME: Allow to interrupt current push when new push of same image is done.
 
 	var sf = streamformatter.NewJSONStreamFormatter()
@@ -115,7 +116,7 @@ func (s *TagStore) Push(localName string, imagePushConfig *ImagePushConfig) erro
 
 		}
 
-		s.eventsService.Log("push", repoInfo.LocalName, "")
+		s.eventsService.Log(ctx, "push", repoInfo.LocalName, "")
 		return nil
 	}
 

--- a/pkg/jsonmessage/jsonmessage.go
+++ b/pkg/jsonmessage/jsonmessage.go
@@ -92,6 +92,7 @@ func (p *JSONProgress) String() string {
 // the created time, where it from, status, ID of the
 // message. It's used for docker events.
 type JSONMessage struct {
+	RequestID       string        `json:"reqid,omitempty"`
 	Stream          string        `json:"stream,omitempty"`
 	Status          string        `json:"status,omitempty"`
 	Progress        *JSONProgress `json:"progressDetail,omitempty"`
@@ -126,6 +127,9 @@ func (jm *JSONMessage) Display(out io.Writer, isTerminal bool) error {
 		fmt.Fprintf(out, "%s ", time.Unix(0, jm.TimeNano).Format(timeutils.RFC3339NanoFixed))
 	} else if jm.Time != 0 {
 		fmt.Fprintf(out, "%s ", time.Unix(jm.Time, 0).Format(timeutils.RFC3339NanoFixed))
+	}
+	if jm.RequestID != "" {
+		fmt.Fprintf(out, "[reqid: %s] ", jm.RequestID)
 	}
 	if jm.ID != "" {
 		fmt.Fprintf(out, "%s: ", jm.ID)


### PR DESCRIPTION
This PR adds a "request ID" to each event generated, the 'docker events'
stream now looks like this:

```
2015-09-10T15:02:50.000000000-07:00 [reqid: c01e3534ddca] de7c5d4ca927253cf4e978ee9c4545161e406e9b5a14617efb52c658b249174a: (from ubuntu) create
```

Note the `[reqID: c01e3534ddca]` part, that's new.

Each HTTP request will generate its own unique ID. So, if you do a
`docker build` you'll see a series of events all with the same reqID.
This allow for log processing tools to determine which events are all related
to the same http request.

I didn't propigate the context to all possible funcs in the daemon,
I decided to just do the ones that needed it in order to get the reqID
into the events and then exported funcs at the same top-level in the daemon so we have
consistency. 

I think the biggest question is the format of the event - so please let me know what you think.

In a subsequent PR I think we may need to modify the event even more since right now it seems too specific to images - e.g. it assumes there an image ID in each event, which may not be true going forward.

ping @icecrime @calavera @crosbymichael

Signed-off-by: Doug Davis dug@us.ibm.com
