### PR TITLE
Show the in used containers of volume when delete the volume

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -1295,7 +1295,7 @@ func (container *Container) isDestinationMounted(destination string) bool {
 func (container *Container) prepareMountPoints() error {
 	for _, config := range container.MountPoints {
 		if len(config.Driver) > 0 {
-			v, err := container.daemon.createVolume(config.Name, config.Driver, nil)
+			v, err := container.daemon.createVolume(config.Name, config.Driver, nil, container.ID)
 			if err != nil {
 				return err
 			}
@@ -1311,7 +1311,7 @@ func (container *Container) removeMountPoints(rm bool) error {
 		if m.Volume == nil {
 			continue
 		}
-		container.daemon.volumes.Decrement(m.Volume)
+		container.daemon.volumes.Decrement(m.Volume, container.ID)
 		if rm {
 			err := container.daemon.volumes.Remove(m.Volume)
 			// ErrVolumeInUse is ignored because having this

--- a/daemon/create_unix.go
+++ b/daemon/create_unix.go
@@ -45,7 +45,7 @@ func createContainerPlatformSpecificSettings(container *Container, config *runco
 			}
 		}
 
-		v, err := container.daemon.createVolume(name, volumeDriver, nil)
+		v, err := container.daemon.createVolume(name, volumeDriver, nil, container.ID)
 		if err != nil {
 			return err
 		}

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	derr "github.com/docker/docker/errors"
-	"github.com/docker/docker/volume/store"
 )
 
 // ContainerRmConfig is a holder for passing in runtime config.
@@ -143,22 +142,5 @@ func (daemon *Daemon) rm(container *Container, forceRemove bool) (err error) {
 	daemon.containers.Delete(container.ID)
 
 	container.logEvent("destroy")
-	return nil
-}
-
-// VolumeRm removes the volume with the given name.
-// If the volume is referenced by a container it is not removed
-// This is called directly from the remote API
-func (daemon *Daemon) VolumeRm(name string) error {
-	v, err := daemon.volumes.Get(name)
-	if err != nil {
-		return err
-	}
-	if err := daemon.volumes.Remove(v); err != nil {
-		if err == store.ErrVolumeInUse {
-			return derr.ErrorCodeRmVolumeInUse.WithArgs(err)
-		}
-		return derr.ErrorCodeRmVolume.WithArgs(name, err)
-	}
 	return nil
 }

--- a/daemon/delete_unix.go
+++ b/daemon/delete_unix.go
@@ -1,0 +1,27 @@
+// +build !windows
+
+package daemon
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/volume/store"
+)
+
+// VolumeRm removes the volume with the given name.
+// If the volume is referenced by a container it is not removed
+// This is called directly from the remote API
+func (daemon *Daemon) VolumeRm(name string) error {
+	v, err := daemon.volumes.Get(name)
+	if err != nil {
+		return err
+	}
+	if err := daemon.volumes.Remove(v); err != nil {
+		if strings.Contains(err.Error(), store.ErrVolumeInUse.Error()) {
+			return fmt.Errorf("Conflict: %s", err)
+		}
+		return fmt.Errorf("Error while removing volume %s: %v", name, err)
+	}
+	return nil
+}

--- a/daemon/delete_windows.go
+++ b/daemon/delete_windows.go
@@ -1,0 +1,10 @@
+// +build windows
+
+package daemon
+
+// VolumeRm removes the volume with the given name.
+// If the volume is referenced by a container it is not removed
+// This is called directly from the remote API
+func (daemon *Daemon) VolumeRm(name string) error {
+	return nil
+}

--- a/daemon/volumes_unix.go
+++ b/daemon/volumes_unix.go
@@ -316,7 +316,7 @@ func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runc
 			}
 
 			if len(cp.Source) == 0 {
-				v, err := daemon.createVolume(cp.Name, cp.Driver, nil)
+				v, err := daemon.createVolume(cp.Name, cp.Driver, nil, container.ID)
 				if err != nil {
 					return err
 				}
@@ -341,7 +341,7 @@ func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runc
 
 		if len(bind.Name) > 0 && len(bind.Driver) > 0 {
 			// create the volume
-			v, err := daemon.createVolume(bind.Name, bind.Driver, nil)
+			v, err := daemon.createVolume(bind.Name, bind.Driver, nil, container.ID)
 			if err != nil {
 				return err
 			}
@@ -373,7 +373,7 @@ func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runc
 
 			// This mountpoint is replacing an existing one, so the count needs to be decremented
 			if mp, exists := container.MountPoints[m.Destination]; exists && mp.Volume != nil {
-				daemon.volumes.Decrement(mp.Volume)
+				daemon.volumes.Decrement(mp.Volume, container.ID)
 			}
 		}
 	}
@@ -388,12 +388,12 @@ func (daemon *Daemon) registerMountPoints(container *Container, hostConfig *runc
 }
 
 // createVolume creates a volume.
-func (daemon *Daemon) createVolume(name, driverName string, opts map[string]string) (volume.Volume, error) {
+func (daemon *Daemon) createVolume(name, driverName string, opts map[string]string, refName string) (volume.Volume, error) {
 	v, err := daemon.volumes.Create(name, driverName, opts)
 	if err != nil {
 		return nil, err
 	}
-	daemon.volumes.Increment(v)
+	daemon.volumes.Increment(v, refName)
 	return v, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com
Use `docker volume rm` to remove a volume which is in use, the error message is
useless
`Error response from daemon: Conflict: volume is in use`
The user don't know which containers is using this volumes, 
if they really want to remove the volume, the have to  figure out 
which container is using this volume one by one use `docker inspect`
and then remove the container.

Add show the in used containers of volume when delete the volume,
users can know which containners are using this volume and can remove
the container if they really want to remove the volume.

<pre><code>$ docker volume rm test
Error response from daemon: Conflict: volume is in use, used by containers: [a8f87b2c96bc 62ea5ec92c0d ebd469b34b37 e040499304f9]</code></pre> 


ping @cpuguy83  to have a look
if design is ok, I'll add tests
