### PR TITLE
Windows: Nice error on stopsignal

### DIFF
--- a/builder/dispatchers.go
+++ b/builder/dispatchers.go
@@ -540,6 +540,9 @@ func volume(b *builder, args []string, attributes map[string]bool, original stri
 //
 // Set the signal that will be used to kill the container.
 func stopSignal(b *builder, args []string, attributes map[string]bool, original string) error {
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("STOPSIGNAL is not supported on Windows")
+	}
 	if len(args) != 1 {
 		return fmt.Errorf("STOPSIGNAL requires exactly one argument")
 	}

--- a/builder/evaluator.go
+++ b/builder/evaluator.go
@@ -367,7 +367,7 @@ func platformSupports(command string) error {
 		return nil
 	}
 	switch command {
-	case "expose", "volume", "user":
+	case "expose", "volume", "user", "stopsignal":
 		return fmt.Errorf("The daemon on this platform does not support the command '%s'", command)
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Windows doesn't support signals as per Unix. This blocks the use of STOPSIGNAL (introduced by #15307) in the builder on Windows and provides nice error message. Same pattern as for PR #15531

@calavera 
