### PR TITLE
Allow concurrent pushes within the same repository

### DIFF
--- a/graph/pools_test.go
+++ b/graph/pools_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/docker/docker/pkg/progressreader"
@@ -13,32 +14,39 @@ func init() {
 
 func TestPools(t *testing.T) {
 	s := &TagStore{
-		pullingPool: make(map[string]*progressreader.Broadcaster),
-		pushingPool: make(map[string]*progressreader.Broadcaster),
+		pullsByKey:      make(map[string]*progressreader.Broadcaster),
+		pushesByKey:     make(map[string]*progressreader.Broadcaster),
+		pullCountByRepo: make(map[string]int),
+		pushCountByRepo: make(map[string]int),
 	}
 
-	if _, found := s.poolAdd("pull", "test1"); found {
+	s.pushPullCond = sync.NewCond(s)
+
+	if _, found := s.acquirePull("test1", "test1", nil); found {
 		t.Fatal("Expected pull test1 not to be in progress")
 	}
-	if _, found := s.poolAdd("pull", "test2"); found {
+	if _, found := s.acquirePull("test1", "test1", nil); !found {
+		t.Fatal("Expected pull test1 to be in progress")
+	}
+	if _, found := s.acquirePull("test2", "test2", nil); found {
 		t.Fatal("Expected pull test2 not to be in progress")
 	}
-	if _, found := s.poolAdd("push", "test1"); !found {
-		t.Fatalf("Expected pull test1 to be in progress`")
+
+	callbackCalled := false
+	releasePullFunc := func() {
+		s.releasePull("test1", "test1")
+		callbackCalled = true
 	}
-	if _, found := s.poolAdd("pull", "test1"); !found {
-		t.Fatalf("Expected pull test1 to be in progress`")
+	if _, found := s.acquirePush("test1", "test1", releasePullFunc); found || !callbackCalled {
+		t.Fatalf("Expected pull test1 to be released`")
 	}
-	if err := s.poolRemove("pull", "test2"); err != nil {
-		t.Fatal(err)
+
+	callbackCalled = false
+	releasePushFunc := func() {
+		s.releasePush("test1", "test1")
+		callbackCalled = true
 	}
-	if err := s.poolRemove("pull", "test2"); err != nil {
-		t.Fatal(err)
-	}
-	if err := s.poolRemove("pull", "test1"); err != nil {
-		t.Fatal(err)
-	}
-	if err := s.poolRemove("push", "test1"); err != nil {
-		t.Fatal(err)
+	if _, found := s.acquirePull("test1", "test1", releasePushFunc); found || !callbackCalled {
+		t.Fatalf("Expected pull test1 to be in progress")
 	}
 }

--- a/graph/pull_v1.go
+++ b/graph/pull_v1.go
@@ -139,13 +139,16 @@ func (p *v1Puller) pullRepository(askedTag string) error {
 
 			// ensure no two downloads of the same image happen at the same time
 			poolKey := "img:" + img.ID
-			broadcaster, found := p.poolAdd("pull", poolKey)
+			broadcaster, found := p.acquirePull(poolKey, p.repoInfo.CanonicalName,
+				func() {
+					out.Write(p.sf.FormatStatus(stringid.TruncateID(img.ID), "Waiting for push to complete before pulling"))
+				})
 			broadcaster.Add(out)
 			if found {
 				errors <- broadcaster.Wait()
 				return
 			}
-			defer p.poolRemove("pull", poolKey)
+			defer p.releasePull(poolKey, p.repoInfo.CanonicalName)
 
 			// we need to retain it until tagging
 			p.graph.Retain(sessionID, img.ID)
@@ -245,7 +248,10 @@ func (p *v1Puller) pullImage(out io.Writer, imgID, endpoint string) (layersDownl
 
 		// ensure no two downloads of the same layer happen at the same time
 		poolKey := "layer:" + id
-		broadcaster, found := p.poolAdd("pull", poolKey)
+		broadcaster, found := p.acquirePull(poolKey, p.repoInfo.CanonicalName,
+			func() {
+				out.Write(p.sf.FormatStatus(stringid.TruncateID(id), "Waiting for push to complete before pulling"))
+			})
 		broadcaster.Add(out)
 		if found {
 			logrus.Debugf("Image (id: %s) pull is already running, skipping", id)
@@ -259,7 +265,7 @@ func (p *v1Puller) pullImage(out io.Writer, imgID, endpoint string) (layersDownl
 		// This must use a closure so it captures the value of err when
 		// the function returns, not when the 'defer' is evaluated.
 		defer func() {
-			p.poolRemoveWithError("pull", poolKey, err)
+			p.releasePullWithError(poolKey, p.repoInfo.CanonicalName, err)
 		}()
 
 		if !p.graph.Exists(id) {

--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -72,7 +72,10 @@ func (p *v2Puller) pullV2Repository(tag string) (err error) {
 
 	}
 
-	broadcaster, found := p.poolAdd("pull", taggedName)
+	broadcaster, found := p.acquirePull(taggedName, p.repoInfo.CanonicalName,
+		func() {
+			p.config.OutStream.Write(p.sf.FormatStatus("", "Repository %s is presently being pushed. Waiting.", p.repoInfo.CanonicalName))
+		})
 	broadcaster.Add(p.config.OutStream)
 	if found {
 		// Another push or pull of the same repository is already taking place; just wait
@@ -83,7 +86,7 @@ func (p *v2Puller) pullV2Repository(tag string) (err error) {
 	// This must use a closure so it captures the value of err when the
 	// function returns, not when the 'defer' is evaluated.
 	defer func() {
-		p.poolRemoveWithError("pull", taggedName, err)
+		p.releasePullWithError(taggedName, p.repoInfo.CanonicalName, err)
 	}()
 
 	var layersDownloaded bool
@@ -202,7 +205,7 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string) (verified bo
 		p.graph.Release(p.sessionID, layerIDs...)
 
 		for _, d := range downloads {
-			p.poolRemoveWithError("pull", d.poolKey, err)
+			p.releasePullWithError(d.poolKey, p.repoInfo.CanonicalName, err)
 			if d.tmpFile != nil {
 				d.tmpFile.Close()
 				if err := os.RemoveAll(d.tmpFile.Name()); err != nil {
@@ -247,7 +250,10 @@ func (p *v2Puller) pullV2Tag(out io.Writer, tag, taggedName string) (verified bo
 
 		downloads = append(downloads, d)
 
-		broadcaster, found := p.poolAdd("pull", d.poolKey)
+		broadcaster, found := p.acquirePull(d.poolKey, p.repoInfo.CanonicalName,
+			func() {
+				out.Write(p.sf.FormatStatus(stringid.TruncateID(img.ID), "Waiting for push to complete before pulling"))
+			})
 		broadcaster.Add(out)
 		d.broadcaster = broadcaster
 		if found {

--- a/graph/pull_v2.go
+++ b/graph/pull_v2.go
@@ -75,7 +75,8 @@ func (p *v2Puller) pullV2Repository(tag string) (err error) {
 	broadcaster, found := p.poolAdd("pull", taggedName)
 	broadcaster.Add(p.config.OutStream)
 	if found {
-		// Another pull of the same repository is already taking place; just wait for it to finish
+		// Another push or pull of the same repository is already taking place; just wait
+		// for it to finish
 		return broadcaster.Wait()
 	}
 

--- a/graph/tags.go
+++ b/graph/tags.go
@@ -35,10 +35,11 @@ type TagStore struct {
 	Repositories map[string]Repository
 	trustKey     libtrust.PrivateKey
 	sync.Mutex
-	// FIXME: move push/pull-related fields
-	// to a helper type
-	pullingPool     map[string]*progressreader.Broadcaster
-	pushingPool     map[string]*progressreader.Broadcaster
+	pullsByKey      map[string]*progressreader.Broadcaster
+	pushesByKey     map[string]*progressreader.Broadcaster
+	pullCountByRepo map[string]int
+	pushCountByRepo map[string]int
+	pushPullCond    *sync.Cond
 	registryService *registry.Service
 	eventsService   *events.Events
 	trustService    *trust.Store
@@ -94,12 +95,16 @@ func NewTagStore(path string, cfg *TagStoreConfig) (*TagStore, error) {
 		graph:           cfg.Graph,
 		trustKey:        cfg.Key,
 		Repositories:    make(map[string]Repository),
-		pullingPool:     make(map[string]*progressreader.Broadcaster),
-		pushingPool:     make(map[string]*progressreader.Broadcaster),
+		pullsByKey:      make(map[string]*progressreader.Broadcaster),
+		pushesByKey:     make(map[string]*progressreader.Broadcaster),
+		pullCountByRepo: make(map[string]int),
+		pushCountByRepo: make(map[string]int),
 		registryService: cfg.Registry,
 		eventsService:   cfg.Events,
 		trustService:    cfg.Trust,
 	}
+	store.pushPullCond = sync.NewCond(store)
+
 	// Load the json file if it exists, otherwise create it.
 	if err := store.reload(); os.IsNotExist(err) {
 		if err := store.save(); err != nil {
@@ -434,54 +439,117 @@ func validateDigest(dgst string) error {
 	return nil
 }
 
-// poolAdd checks if a push or pull is already running, and returns
-// (broadcaster, true) if a running operation is found. Otherwise, it creates a
-// new one and returns (broadcaster, false).
-func (store *TagStore) poolAdd(kind, key string) (*progressreader.Broadcaster, bool) {
+// acquirePull checks if a pull is already running, and returns the broadcaster
+// associated with the existing pull and found = true if a running pull is
+// found. Otherwise, it creates a new one and returns the broadcaster and
+// found = false.
+//
+// If a push in the same repository is running, acquirePull waits for the push
+// to finish before finding or creating the broadcaster for the pull. waitFunc
+// is called to provide the caller the opportunity to print a message explaining
+// the delay.
+//
+// releasePull should only be called in cases where acquirePull returned
+// found = true.
+func (store *TagStore) acquirePull(key, repo string, waitFunc func()) (broadcaster *progressreader.Broadcaster, found bool) {
 	store.Lock()
 	defer store.Unlock()
 
-	if p, exists := store.pullingPool[key]; exists {
+	waitFuncCalled := false
+	for {
+		if store.pushCountByRepo[repo] > 0 {
+			if waitFunc != nil && !waitFuncCalled {
+				store.Unlock()
+				waitFunc()
+				waitFuncCalled = true
+				store.Lock()
+			} else {
+				store.pushPullCond.Wait()
+			}
+		} else {
+			break
+		}
+	}
+
+	if p, exists := store.pullsByKey[key]; exists {
 		return p, true
 	}
-	if p, exists := store.pushingPool[key]; exists {
-		return p, true
-	}
 
-	broadcaster := progressreader.NewBroadcaster()
-
-	switch kind {
-	case "pull":
-		store.pullingPool[key] = broadcaster
-	case "push":
-		store.pushingPool[key] = broadcaster
-	default:
-		panic("Unknown pool type")
-	}
-
+	broadcaster = progressreader.NewBroadcaster()
+	store.pullsByKey[key] = broadcaster
+	store.pullCountByRepo[repo]++
 	return broadcaster, false
 }
 
-func (store *TagStore) poolRemoveWithError(kind, key string, broadcasterResult error) error {
+// acquirePush checks if a push is already running, and returns the broadcaster
+// associated with the existing push and found = true if a running push is
+// found. Otherwise, it creates a new one and returns the broadcaster and
+// found = false.
+//
+// If a pull in the same repository is running, acquirePull waits for the pull
+// to finish before finding or creating the broadcaster for the push. waitFunc
+// is // called to provide the caller the opportunity to print a message
+// explaining the delay.
+//
+// releasePush should only be called in cases where acquirePush returned
+// found = true.
+func (store *TagStore) acquirePush(key, repo string, waitFunc func()) (broadcaster *progressreader.Broadcaster, found bool) {
 	store.Lock()
 	defer store.Unlock()
-	switch kind {
-	case "pull":
-		if broadcaster, exists := store.pullingPool[key]; exists {
-			broadcaster.CloseWithError(broadcasterResult)
-			delete(store.pullingPool, key)
+
+	waitFuncCalled := false
+
+	for {
+		if store.pullCountByRepo[repo] > 0 {
+			if waitFunc != nil && !waitFuncCalled {
+				store.Unlock()
+				waitFunc()
+				waitFuncCalled = true
+				store.Lock()
+			} else {
+				store.pushPullCond.Wait()
+			}
+		} else {
+			break
 		}
-	case "push":
-		if broadcaster, exists := store.pushingPool[key]; exists {
-			broadcaster.CloseWithError(broadcasterResult)
-			delete(store.pushingPool, key)
-		}
-	default:
-		return fmt.Errorf("Unknown pool type")
 	}
-	return nil
+
+	if p, exists := store.pushesByKey[key]; exists {
+		return p, true
+	}
+
+	broadcaster = progressreader.NewBroadcaster()
+	store.pushesByKey[key] = broadcaster
+	store.pushCountByRepo[repo]++
+	return broadcaster, false
 }
 
-func (store *TagStore) poolRemove(kind, key string) error {
-	return store.poolRemoveWithError(kind, key, nil)
+func (store *TagStore) releasePullWithError(key, repo string, broadcasterResult error) {
+	store.Lock()
+	defer store.Unlock()
+	if broadcaster, exists := store.pullsByKey[key]; exists {
+		broadcaster.CloseWithError(broadcasterResult)
+		delete(store.pullsByKey, key)
+		store.pullCountByRepo[repo]--
+		store.pushPullCond.Broadcast()
+	}
+}
+
+func (store *TagStore) releasePull(key, repo string) {
+	store.releasePullWithError(key, repo, nil)
+}
+
+func (store *TagStore) releasePushWithError(key, repo string, broadcasterResult error) {
+	store.Lock()
+	defer store.Unlock()
+	if broadcaster, exists := store.pushesByKey[key]; exists {
+		broadcaster.CloseWithError(broadcasterResult)
+		delete(store.pushesByKey, key)
+		store.pushCountByRepo[repo]--
+		store.pushPullCond.Broadcast()
+	}
+}
+
+func (store *TagStore) releasePush(key, repo string) {
+	store.releasePushWithError(key, repo, nil)
 }


### PR DESCRIPTION
This change brings push behavior in line with pulling. If the requested
push matches one already in progress (same tag, if any), show the
progress of outstanding push operation. Otherwise, a new push is
started. Layer uploads are also deduplicated (but only within the same
repository, to avoid cross-repository push issues).

This change is only being made for v2 pushes.

Fixes #9132

cc: @dmcgowan @tonistiigi @stevvooe 
