### PR TITLE
Make exec start return proper error codes

### DIFF
--- a/api/server/router/local/exec.go
+++ b/api/server/router/local/exec.go
@@ -75,6 +75,10 @@ func (s *router) postContainerExecStart(ctx context.Context, w http.ResponseWrit
 		return err
 	}
 
+	if exists, err := s.daemon.ExecExists(execName); !exists {
+		return err
+	}
+
 	if !execStartCheck.Detach {
 		var err error
 		// Setting up the streaming http interface.
@@ -102,6 +106,9 @@ func (s *router) postContainerExecStart(ctx context.Context, w http.ResponseWrit
 
 	// Now run the user process in container.
 	if err := s.daemon.ContainerExecStart(execName, stdin, stdout, stderr); err != nil {
+		if execStartCheck.Detach {
+			return err
+		}
 		fmt.Fprintf(outStream, "Error running exec in container: %v\n", err)
 	}
 	return nil

--- a/docs/reference/api/docker_remote_api.md
+++ b/docs/reference/api/docker_remote_api.md
@@ -90,6 +90,7 @@ list of DNS options to be used in the container.
 * `GET /events` now includes a `timenano` field, in addition to the existing `time` field.
 * `GET /info` now lists engine version information.
 * `GET /containers/json` will return `ImageID` of the image used by container.
+* `POST /exec/(name)/start` will now return an HTTP 409 when the container is either stopped or paused.
 
 ### v1.20 API changes
 

--- a/docs/reference/api/docker_remote_api_v1.15.md
+++ b/docs/reference/api/docker_remote_api_v1.15.md
@@ -1677,7 +1677,7 @@ Json Parameters:
 
 Status Codes:
 
--   **201** – no error
+-   **200** – no error
 -   **404** – no such exec instance
 
     **Stream details**:

--- a/docs/reference/api/docker_remote_api_v1.16.md
+++ b/docs/reference/api/docker_remote_api_v1.16.md
@@ -1638,7 +1638,7 @@ Json Parameters:
 
 Status Codes:
 
--   **201** – no error
+-   **200** – no error
 -   **404** – no such exec instance
 
     **Stream details**:

--- a/docs/reference/api/docker_remote_api_v1.17.md
+++ b/docs/reference/api/docker_remote_api_v1.17.md
@@ -1801,7 +1801,7 @@ Json Parameters:
 
 Status Codes:
 
--   **201** – no error
+-   **200** – no error
 -   **404** – no such exec instance
 
     **Stream details**:

--- a/docs/reference/api/docker_remote_api_v1.18.md
+++ b/docs/reference/api/docker_remote_api_v1.18.md
@@ -1922,7 +1922,7 @@ Json Parameters:
 
 Status Codes:
 
--   **201** – no error
+-   **200** – no error
 -   **404** – no such exec instance
 
     **Stream details**:

--- a/docs/reference/api/docker_remote_api_v1.19.md
+++ b/docs/reference/api/docker_remote_api_v1.19.md
@@ -1984,7 +1984,7 @@ Json Parameters:
 
 Status Codes:
 
--   **201** – no error
+-   **200** – no error
 -   **404** – no such exec instance
 
     **Stream details**:

--- a/docs/reference/api/docker_remote_api_v1.20.md
+++ b/docs/reference/api/docker_remote_api_v1.20.md
@@ -2126,7 +2126,7 @@ Json Parameters:
 
 Status Codes:
 
--   **201** – no error
+-   **200** – no error
 -   **404** – no such exec instance
 
     **Stream details**:

--- a/docs/reference/api/docker_remote_api_v1.21.md
+++ b/docs/reference/api/docker_remote_api_v1.21.md
@@ -2226,8 +2226,9 @@ Json Parameters:
 
 Status Codes:
 
--   **201** – no error
+-   **200** – no error
 -   **404** – no such exec instance
+-   **409** - container is stopped or paused
 
     **Stream details**:
     Similar to the stream behavior of `POST /container/(id)/attach` API

--- a/errors/daemon.go
+++ b/errors/daemon.go
@@ -654,7 +654,7 @@ var (
 		Value:          "CONTAINERNOTRUNNING",
 		Message:        "Container %s is not running: %s",
 		Description:    "An attempt was made to retrieve the information about an 'exec' but the container is not running",
-		HTTPStatusCode: http.StatusInternalServerError,
+		HTTPStatusCode: http.StatusConflict,
 	})
 
 	// ErrorCodeNoExecID is generated when we try to get the info
@@ -672,7 +672,7 @@ var (
 		Value:          "EXECPAUSED",
 		Message:        "Container %s is paused, unpause the container before exec",
 		Description:    "An attempt to start an 'exec' was made, but the owning container is paused",
-		HTTPStatusCode: http.StatusInternalServerError,
+		HTTPStatusCode: http.StatusConflict,
 	})
 
 	// ErrorCodeExecRunning is generated when we try to start an exec


### PR DESCRIPTION
Fixes #15487

Exec start was sending HTTP 500 for every error.

Fixed an error where pausing a container and then calling exec start
caused the daemon to freeze.

Updated API docs which incorrectly showed that a successful exec start
was an HTTP 201, in reality it is HTTP 200.
