### PR TITLE
Updated systemd service to load sysconfig file

### DIFF
--- a/contrib/init/systemd/docker.service
+++ b/contrib/init/systemd/docker.service
@@ -6,7 +6,8 @@ Requires=docker.socket
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/docker daemon -H fd://
+EnvironmentFile=-/etc/sysconfig/docker
+ExecStart=/usr/bin/docker daemon $other_args -H fd://
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
Fixes #16251 

This makes the systemd service load the config file from sysconfig so that any docker startup options set there get applied as described in the doc: https://docs.docker.com/articles/configuring/#configuring-docker-1

Signed-off-by: David Gersting dgersting@gmail.com
