### PR TITLE
Deprecate -c cli short variant flag in docker run

### DIFF
--- a/docs/misc/deprecated.md
+++ b/docs/misc/deprecated.md
@@ -12,6 +12,16 @@ parent = "mn_use_docker"
 
 The following list of features are deprecated.
 
+### Command line short variant options
+**Deprecated In Release: v1.9**
+
+**Target For Removal In Release: v1.11**
+
+The following short variant options are deprecated in favor of their long
+variants:
+
+    docker run -c (--cpu-shares)
+
 ### Driver Specific Log Tags
 **Deprecated In Release: v1.9**
 
@@ -22,8 +32,6 @@ Because of which, the driver specific log tag options `syslog-tag`, `gelf-tag` a
 `fluentd-tag` have been deprecated in favor of the generic `tag` option.
 
     docker --log-driver=syslog --log-opt tag="{{.ImageName}}/{{.Name}}/{{.ID}}"
-
-
 
 ### LXC built-in exec driver
 **Deprecated In Release: v1.8**

--- a/integration-cli/docker_cli_run_unix_test.go
+++ b/integration-cli/docker_cli_run_unix_test.go
@@ -217,9 +217,9 @@ func (s *DockerSuite) TestRunWithKernelMemory(c *check.C) {
 // "test" should be printed
 func (s *DockerSuite) TestRunEchoStdoutWitCPUShares(c *check.C) {
 	testRequires(c, cpuShare)
-	out, _ := dockerCmd(c, "run", "-c", "1000", "busybox", "echo", "test")
+	out, _ := dockerCmd(c, "run", "--cpu-shares", "1000", "busybox", "echo", "test")
 	if out != "test\n" {
-		c.Errorf("container should've printed 'test'")
+		c.Errorf("container should've printed 'test', got %q instead", out)
 	}
 }
 
@@ -227,7 +227,7 @@ func (s *DockerSuite) TestRunEchoStdoutWitCPUShares(c *check.C) {
 func (s *DockerSuite) TestRunEchoStdoutWithCPUSharesAndMemoryLimit(c *check.C) {
 	testRequires(c, cpuShare)
 	testRequires(c, memoryLimitSupport)
-	out, _, _ := dockerCmdWithStdoutStderr(c, "run", "-c", "1000", "-m", "16m", "busybox", "echo", "test")
+	out, _ := dockerCmd(c, "run", "--cpu-shares", "1000", "-m", "16m", "busybox", "echo", "test")
 	if out != "test\n" {
 		c.Errorf("container should've printed 'test', got %q instead", out)
 	}
@@ -291,7 +291,7 @@ func (s *DockerSuite) TestRunOOMExitCode(c *check.C) {
 // "test" should be printed
 func (s *DockerSuite) TestRunEchoStdoutWithMemoryLimit(c *check.C) {
 	testRequires(c, memoryLimitSupport)
-	out, _, _ := dockerCmdWithStdoutStderr(c, "run", "-m", "16m", "busybox", "echo", "test")
+	out, _ := dockerCmd(c, "run", "-m", "16m", "busybox", "echo", "test")
 	out = strings.Trim(out, "\r\n")
 
 	if expected := "test"; out != expected {

--- a/runconfig/parse.go
+++ b/runconfig/parse.go
@@ -80,7 +80,7 @@ func Parse(cmd *flag.FlagSet, args []string) (*Config, *HostConfig, *flag.FlagSe
 		flKernelMemory    = cmd.String([]string{"-kernel-memory"}, "", "Kernel memory limit")
 		flUser            = cmd.String([]string{"u", "-user"}, "", "Username or UID (format: <name|uid>[:<group|gid>])")
 		flWorkingDir      = cmd.String([]string{"w", "-workdir"}, "", "Working directory inside the container")
-		flCPUShares       = cmd.Int64([]string{"c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
+		flCPUShares       = cmd.Int64([]string{"#c", "-cpu-shares"}, 0, "CPU shares (relative weight)")
 		flCPUPeriod       = cmd.Int64([]string{"-cpu-period"}, 0, "Limit CPU CFS (Completely Fair Scheduler) period")
 		flCPUQuota        = cmd.Int64([]string{"-cpu-quota"}, 0, "Limit CPU CFS (Completely Fair Scheduler) quota")
 		flCpusetCpus      = cmd.String([]string{"#-cpuset", "-cpuset-cpus"}, "", "CPUs in which to allow execution (0-3, 0,1)")


### PR DESCRIPTION
`-c` seems like a `--config` opt
I think this short opt should be deprecated in favor of just its long variant.

Signed-off-by: Antonio Murdaca runcom@linux.com
