### PR TITLE
Fix container register failed during daemon start and then start the container

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -314,7 +314,9 @@ func (daemon *Daemon) restore() error {
 			}
 
 			if err := daemon.Register(container); err != nil {
-				logrus.Debugf("Failed to register container %s: %s", container.ID, err)
+				logrus.Errorf("Failed to register container %s: %s", container.ID, err)
+				// The container register failed should not be started.
+				return
 			}
 
 			// check the restart policy on the containers and restart any container with
@@ -323,7 +325,7 @@ func (daemon *Daemon) restore() error {
 				logrus.Debugf("Starting container %s", container.ID)
 
 				if err := container.Start(); err != nil {
-					logrus.Debugf("Failed to start container %s: %s", container.ID, err)
+					logrus.Errorf("Failed to start container %s: %s", container.ID, err)
 				}
 			}
 		}(c.container, c.registered)


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

The container register failed during daemon starting should not be
started even if it has a restart policy  

Fixes #14199 
