### PR TITLE
Add conflict error when create an exist volume with a different driver

### DIFF
--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -134,6 +134,10 @@ func getVolumeDriver(name string) (volume.Driver, error) {
 func (s *volumeStore) Create(name, driverName string, opts map[string]string) (volume.Volume, error) {
 	s.mu.Lock()
 	if vc, exists := s.vols[name]; exists {
+		if vc.Volume.DriverName() != driverName {
+			s.mu.Unlock()
+			return nil, fmt.Errorf("Conflict: volume '%s' exist with volume diver '%s'", name, vc.Volume.DriverName())
+		}
 		v := vc.Volume
 		s.mu.Unlock()
 		return v, nil


### PR DESCRIPTION
Signed-off-by: Lei Jitang leijitang@huawei.com

When create a volume and the volume exist,
but the volume driver is different, we should throw a
conflict error.
For example 
`$ docker run -ti -v data:/data busybox`
this will create a volume `data` with driver `local`
and then 
`docker run -ti --volume-driver convoy -v data:/data busybox`
user want to create a volume `data` with driver `convoy`
actually, the volume `data` is exist with driver `local`,  but 
`docker run -ti --volume-driver convoy -v data:/data busybox`
just run without any error or warning, so the user just think the
volume `data` is using driver  `convoy`. This could lead some problem.

With this patch, this will show a error
`Error response from daemon: Conflict: volume 'data' exist with volume diver 'local'`

ping @cpuguy83  
