### PR TITLE
Vendor-in libnetwork 2baa2ddc78b42f011f55633282ac63a72e1b09c1

### DIFF
--- a/daemon/container_unix.go
+++ b/daemon/container_unix.go
@@ -580,12 +580,10 @@ func (container *Container) buildEndpointInfo(ep libnetwork.Endpoint, networkSet
 		return networkSettings, nil
 	}
 
-	ifaceList := epInfo.InterfaceList()
-	if len(ifaceList) == 0 {
+	iface := epInfo.Iface()
+	if iface == nil {
 		return networkSettings, nil
 	}
-
-	iface := ifaceList[0]
 
 	ones, _ := iface.Address().Mask.Size()
 	networkSettings.IPAddress = iface.Address().IP.String()
@@ -595,24 +593,6 @@ func (container *Container) buildEndpointInfo(ep libnetwork.Endpoint, networkSet
 		onesv6, _ := iface.AddressIPv6().Mask.Size()
 		networkSettings.GlobalIPv6Address = iface.AddressIPv6().IP.String()
 		networkSettings.GlobalIPv6PrefixLen = onesv6
-	}
-
-	if len(ifaceList) == 1 {
-		return networkSettings, nil
-	}
-
-	networkSettings.SecondaryIPAddresses = make([]network.Address, 0, len(ifaceList)-1)
-	networkSettings.SecondaryIPv6Addresses = make([]network.Address, 0, len(ifaceList)-1)
-	for _, iface := range ifaceList[1:] {
-		ones, _ := iface.Address().Mask.Size()
-		addr := network.Address{Addr: iface.Address().IP.String(), PrefixLen: ones}
-		networkSettings.SecondaryIPAddresses = append(networkSettings.SecondaryIPAddresses, addr)
-
-		if iface.AddressIPv6().IP.To16() != nil {
-			onesv6, _ := iface.AddressIPv6().Mask.Size()
-			addrv6 := network.Address{Addr: iface.AddressIPv6().IP.String(), PrefixLen: onesv6}
-			networkSettings.SecondaryIPv6Addresses = append(networkSettings.SecondaryIPv6Addresses, addrv6)
-		}
 	}
 
 	return networkSettings, nil

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -820,9 +820,9 @@ func (daemon *Daemon) Shutdown() error {
 		}
 		group.Wait()
 
-		// trigger libnetwork GC only if it's initialized
+		// trigger libnetwork Stop only if it's initialized
 		if daemon.netController != nil {
-			daemon.netController.GC()
+			daemon.netController.Stop()
 		}
 	}
 

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -20,7 +20,7 @@ clone git github.com/tchap/go-patricia v2.1.0
 clone git golang.org/x/net 3cffabab72adf04f8e3b01c5baf775361837b5fe https://github.com/golang/net.git
 
 #get libnetwork packages
-clone git github.com/docker/libnetwork 3e31cead05cba8ec20241630d051e6d73765b3a2
+clone git github.com/docker/libnetwork 2baa2ddc78b42f011f55633282ac63a72e1b09c1
 clone git github.com/armon/go-metrics eb0af217e5e9747e41dd5303755356b62d28e3ec
 clone git github.com/hashicorp/go-msgpack 71c2886f5a673a35f909803f38ece5810165097b
 clone git github.com/hashicorp/memberlist 9a1e242e454d2443df330bdd51a436d5a9058fc4

--- a/vendor/src/github.com/docker/libnetwork/.gitignore
+++ b/vendor/src/github.com/docker/libnetwork/.gitignore
@@ -4,6 +4,7 @@
 *.so
 
 # Folders
+integration-tmp/
 _obj
 _test
 

--- a/vendor/src/github.com/docker/libnetwork/api/api.go
+++ b/vendor/src/github.com/docker/libnetwork/api/api.go
@@ -249,6 +249,9 @@ func (sc *sandboxCreate) parseOptions() []libnetwork.SandboxOption {
 	if sc.UseDefaultSandbox {
 		setFctList = append(setFctList, libnetwork.OptionUseDefaultSandbox())
 	}
+	if sc.UseExternalKey {
+		setFctList = append(setFctList, libnetwork.OptionUseExternalKey())
+	}
 	if sc.DNS != nil {
 		for _, d := range sc.DNS {
 			setFctList = append(setFctList, libnetwork.OptionDNS(d))

--- a/vendor/src/github.com/docker/libnetwork/api/types.go
+++ b/vendor/src/github.com/docker/libnetwork/api/types.go
@@ -57,6 +57,7 @@ type sandboxCreate struct {
 	DNS               []string    `json:"dns"`
 	ExtraHosts        []extraHost `json:"extra_hosts"`
 	UseDefaultSandbox bool        `json:"use_default_sandbox"`
+	UseExternalKey    bool        `json:"use_external_key"`
 }
 
 // endpointJoin represents the expected body of the "join endpoint" or "leave endpoint" http request messages

--- a/vendor/src/github.com/docker/libnetwork/client/service.go
+++ b/vendor/src/github.com/docker/libnetwork/client/service.go
@@ -115,7 +115,7 @@ func lookupContainerID(cli *NetworkCli, cnNameID string) (string, error) {
 }
 
 func lookupSandboxID(cli *NetworkCli, containerID string) (string, error) {
-	obj, _, err := readBody(cli.call("GET", fmt.Sprintf("/sandboxes?container-id=%s", containerID), nil, nil))
+	obj, _, err := readBody(cli.call("GET", fmt.Sprintf("/sandboxes?partial-container-id=%s", containerID), nil, nil))
 	if err != nil {
 		return "", err
 	}
@@ -360,12 +360,17 @@ func (cli *NetworkCli) CmdServiceDetach(chain string, args ...string) error {
 		return err
 	}
 
+	sandboxID, err := lookupSandboxID(cli, containerID)
+	if err != nil {
+		return err
+	}
+
 	serviceID, err := lookupServiceID(cli, nn, sn)
 	if err != nil {
 		return err
 	}
 
-	_, _, err = readBody(cli.call("DELETE", "/services/"+serviceID+"/backend/"+containerID, nil, nil))
+	_, _, err = readBody(cli.call("DELETE", "/services/"+serviceID+"/backend/"+sandboxID, nil, nil))
 	if err != nil {
 		return err
 	}

--- a/vendor/src/github.com/docker/libnetwork/config/config.go
+++ b/vendor/src/github.com/docker/libnetwork/config/config.go
@@ -109,7 +109,7 @@ func (c *Config) ProcessOptions(options ...Option) {
 
 // IsValidName validates configuration objects supported by libnetwork
 func IsValidName(name string) bool {
-	if name == "" || strings.Contains(name, ".") {
+	if strings.TrimSpace(name) == "" || strings.Contains(name, ".") {
 		return false
 	}
 	return true

--- a/vendor/src/github.com/docker/libnetwork/driverapi/driverapi.go
+++ b/vendor/src/github.com/docker/libnetwork/driverapi/driverapi.go
@@ -45,18 +45,16 @@ type Driver interface {
 
 // EndpointInfo provides a go interface to fetch or populate endpoint assigned network resources.
 type EndpointInfo interface {
-	// Interfaces returns a list of interfaces bound to the endpoint.
-	// If the list is not empty the driver is only expected to consume the interfaces.
-	// It is an error to try to add interfaces to a non-empty list.
-	// If the list is empty the driver is expected to populate with 0 or more interfaces.
-	Interfaces() []InterfaceInfo
+	// Interface returns the interface bound to the endpoint.
+	// If the value is not nil the driver is only expected to consume the interface.
+	// It is an error to try to add interface if the passed down value is non-nil
+	// If the value is nil the driver is expected to add an interface
+	Interface() InterfaceInfo
 
-	// AddInterface is used by the driver to add an interface to the interface list.
-	// This method will return an error if the driver attempts to add interfaces
-	// if the Interfaces() method returned a non-empty list.
-	// ID field need only have significance within the endpoint so it can be a simple
-	// monotonically increasing number
-	AddInterface(ID int, mac net.HardwareAddr, ipv4 net.IPNet, ipv6 net.IPNet) error
+	// AddInterface is used by the driver to add an interface for the endpoint.
+	// This method will return an error if the driver attempts to add interface
+	// if the Interface() method returned a non-nil value.
+	AddInterface(mac net.HardwareAddr, ipv4 net.IPNet, ipv6 net.IPNet) error
 }
 
 // InterfaceInfo provides a go interface for drivers to retrive
@@ -70,10 +68,6 @@ type InterfaceInfo interface {
 
 	// AddressIPv6 returns the IPv6 address.
 	AddressIPv6() net.IPNet
-
-	// ID returns the numerical id of the interface and has significance only within
-	// the endpoint.
-	ID() int
 }
 
 // InterfaceNameInfo provides a go interface for the drivers to assign names
@@ -81,18 +75,14 @@ type InterfaceInfo interface {
 type InterfaceNameInfo interface {
 	// SetNames method assigns the srcName and dstPrefix for the interface.
 	SetNames(srcName, dstPrefix string) error
-
-	// ID returns the numerical id that was assigned to the interface by the driver
-	// CreateEndpoint.
-	ID() int
 }
 
 // JoinInfo represents a set of resources that the driver has the ability to provide during
 // join time.
 type JoinInfo interface {
-	// InterfaceNames returns a list of InterfaceNameInfo go interface to facilitate
-	// setting the names for the interfaces.
-	InterfaceNames() []InterfaceNameInfo
+	// InterfaceName returns a InterfaceNameInfo go interface to facilitate
+	// setting the names for the interface.
+	InterfaceName() InterfaceNameInfo
 
 	// SetGateway sets the default IPv4 gateway when a container joins the endpoint.
 	SetGateway(net.IP) error
@@ -102,7 +92,7 @@ type JoinInfo interface {
 
 	// AddStaticRoute adds a routes to the sandbox.
 	// It may be used in addtion to or instead of a default gateway (as above).
-	AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP, interfaceID int) error
+	AddStaticRoute(destination *net.IPNet, routeType int, nextHop net.IP) error
 }
 
 // DriverCallback provides a Callback interface for Drivers into LibNetwork

--- a/vendor/src/github.com/docker/libnetwork/drivers/overlay/joinleave.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/overlay/joinleave.go
@@ -65,13 +65,10 @@ func (d *driver) Join(nid, eid string, sboxKey string, jinfo driverapi.JoinInfo,
 		return fmt.Errorf("could not set mac address to the container interface: %v", err)
 	}
 
-	for _, iNames := range jinfo.InterfaceNames() {
-		// Make sure to set names on the correct interface ID.
-		if iNames.ID() == 1 {
-			err = iNames.SetNames(name2, "eth")
-			if err != nil {
-				return err
-			}
+	if iNames := jinfo.InterfaceName(); iNames != nil {
+		err = iNames.SetNames(name2, "eth")
+		if err != nil {
+			return err
 		}
 	}
 

--- a/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_endpoint.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/overlay/ov_endpoint.go
@@ -51,10 +51,10 @@ func (d *driver) CreateEndpoint(nid, eid string, epInfo driverapi.EndpointInfo,
 		id: eid,
 	}
 
-	if epInfo != nil && (len(epInfo.Interfaces()) > 0) {
-		addr := epInfo.Interfaces()[0].Address()
+	if epInfo != nil && epInfo.Interface() != nil {
+		addr := epInfo.Interface().Address()
 		ep.addr = &addr
-		ep.mac = epInfo.Interfaces()[0].MacAddress()
+		ep.mac = epInfo.Interface().MacAddress()
 		n.addEndpoint(ep)
 		return nil
 	}
@@ -74,7 +74,7 @@ func (d *driver) CreateEndpoint(nid, eid string, epInfo driverapi.EndpointInfo,
 
 	ep.mac = netutils.GenerateMACFromIP(ep.addr.IP)
 
-	err = epInfo.AddInterface(1, ep.mac, *ep.addr, net.IPNet{})
+	err = epInfo.AddInterface(ep.mac, *ep.addr, net.IPNet{})
 	if err != nil {
 		return fmt.Errorf("could not add interface to endpoint info: %v", err)
 	}

--- a/vendor/src/github.com/docker/libnetwork/drivers/remote/api/api.go
+++ b/vendor/src/github.com/docker/libnetwork/drivers/remote/api/api.go
@@ -48,13 +48,12 @@ type CreateEndpointRequest struct {
 	NetworkID string
 	// The ID of the endpoint for later reference.
 	EndpointID string
-	Interfaces []*EndpointInterface
+	Interface  *EndpointInterface
 	Options    map[string]interface{}
 }
 
 // EndpointInterface represents an interface endpoint.
 type EndpointInterface struct {
-	ID          int
 	Address     string
 	AddressIPv6 string
 	MacAddress  string
@@ -63,12 +62,11 @@ type EndpointInterface struct {
 // CreateEndpointResponse is the response to the CreateEndpoint action.
 type CreateEndpointResponse struct {
 	Response
-	Interfaces []*EndpointInterface
+	Interface *EndpointInterface
 }
 
 // Interface is the representation of a linux interface.
 type Interface struct {
-	ID          int
 	Address     *net.IPNet
 	AddressIPv6 *net.IPNet
 	MacAddress  net.HardwareAddr
@@ -118,16 +116,15 @@ type StaticRoute struct {
 	Destination string
 	RouteType   int
 	NextHop     string
-	InterfaceID int
 }
 
 // JoinResponse is the response to a JoinRequest.
 type JoinResponse struct {
 	Response
-	InterfaceNames []*InterfaceName
-	Gateway        string
-	GatewayIPv6    string
-	StaticRoutes   []StaticRoute
+	InterfaceName *InterfaceName
+	Gateway       string
+	GatewayIPv6   string
+	StaticRoutes  []StaticRoute
 }
 
 // LeaveRequest describes the API for detaching an endpoint from a sandbox.

--- a/vendor/src/github.com/docker/libnetwork/network.go
+++ b/vendor/src/github.com/docker/libnetwork/network.go
@@ -305,7 +305,6 @@ func (n *network) CreateEndpoint(name string, options ...EndpointOption) (Endpoi
 	}
 
 	ep := &endpoint{name: name,
-		iFaces:  []*endpointInterface{},
 		generic: make(map[string]interface{})}
 	ep.id = stringid.GenerateRandomID()
 	ep.network = n
@@ -409,7 +408,7 @@ func (n *network) isGlobalScoped() (bool, error) {
 func (n *network) updateSvcRecord(ep *endpoint, isAdd bool) {
 	n.Lock()
 	var recs []etchosts.Record
-	for _, iface := range ep.InterfaceList() {
+	if iface := ep.Iface(); iface != nil {
 		if isAdd {
 			n.svcRecords[ep.Name()] = iface.Address().IP
 			n.svcRecords[ep.Name()+"."+n.name] = iface.Address().IP

--- a/vendor/src/github.com/docker/libnetwork/osl/namespace_unsupported.go
+++ b/vendor/src/github.com/docker/libnetwork/osl/namespace_unsupported.go
@@ -6,3 +6,7 @@ package osl
 // and waits for it.
 func GC() {
 }
+
+func GetSandboxForExternalKey(path string, key string) (Sandbox, error) {
+	return nil, nil
+}

--- a/vendor/src/github.com/docker/libnetwork/osl/namespace_windows.go
+++ b/vendor/src/github.com/docker/libnetwork/osl/namespace_windows.go
@@ -19,6 +19,10 @@ func NewSandbox(key string, osCreate bool) (Sandbox, error) {
 	return nil, nil
 }
 
+func GetSandboxForExternalKey(path string, key string) (Sandbox, error) {
+	return nil, nil
+}
+
 // GC triggers garbage collection of namespace path right away
 // and waits for it.
 func GC() {

--- a/vendor/src/github.com/docker/libnetwork/sandbox_externalkey.go
+++ b/vendor/src/github.com/docker/libnetwork/sandbox_externalkey.go
@@ -1,0 +1,185 @@
+package libnetwork
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/reexec"
+	"github.com/docker/libnetwork/types"
+	"github.com/opencontainers/runc/libcontainer"
+	"github.com/opencontainers/runc/libcontainer/configs"
+)
+
+type setKeyData struct {
+	ContainerID string
+	Key         string
+}
+
+func init() {
+	reexec.Register("libnetwork-setkey", processSetKeyReexec)
+}
+
+const udsBase = "/var/lib/docker/network/files/"
+const success = "success"
+
+// processSetKeyReexec is a private function that must be called only on an reexec path
+// It expects 3 args { [0] = "libnetwork-setkey", [1] = <container-id>, [2] = <controller-id> }
+// It also expects libcontainer.State as a json string in <stdin>
+// Refer to https://github.com/opencontainers/runc/pull/160/ for more information
+func processSetKeyReexec() {
+	var err error
+
+	// Return a failure to the calling process via ExitCode
+	defer func() {
+		if err != nil {
+			logrus.Fatalf("%v", err)
+		}
+	}()
+
+	// expecting 3 args {[0]="libnetwork-setkey", [1]=<container-id>, [2]=<controller-id> }
+	if len(os.Args) < 3 {
+		err = fmt.Errorf("Re-exec expects 3 args, received : %d", len(os.Args))
+		return
+	}
+	containerID := os.Args[1]
+
+	// We expect libcontainer.State as a json string in <stdin>
+	stateBuf, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return
+	}
+	var state libcontainer.State
+	if err = json.Unmarshal(stateBuf, &state); err != nil {
+		return
+	}
+
+	controllerID := os.Args[2]
+	key := state.NamespacePaths[configs.NamespaceType("NEWNET")]
+
+	err = SetExternalKey(controllerID, containerID, key)
+	return
+}
+
+// SetExternalKey provides a convenient way to set an External key to a sandbox
+func SetExternalKey(controllerID string, containerID string, key string) error {
+	keyData := setKeyData{
+		ContainerID: containerID,
+		Key:         key}
+
+	c, err := net.Dial("unix", udsBase+controllerID+".sock")
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	if err = sendKey(c, keyData); err != nil {
+		return fmt.Errorf("sendKey failed with : %v", err)
+	}
+	return processReturn(c)
+}
+
+func sendKey(c net.Conn, data setKeyData) error {
+	var err error
+	defer func() {
+		if err != nil {
+			c.Close()
+		}
+	}()
+
+	var b []byte
+	if b, err = json.Marshal(data); err != nil {
+		return err
+	}
+
+	_, err = c.Write(b)
+	return err
+}
+
+func processReturn(r io.Reader) error {
+	buf := make([]byte, 1024)
+	n, err := r.Read(buf[:])
+	if err != nil {
+		return fmt.Errorf("failed to read buf in processReturn : %v", err)
+	}
+	if string(buf[0:n]) != success {
+		return fmt.Errorf(string(buf[0:n]))
+	}
+	return nil
+}
+
+func (c *controller) startExternalKeyListener() error {
+	if err := os.MkdirAll(udsBase, 0600); err != nil {
+		return err
+	}
+	uds := udsBase + c.id + ".sock"
+	l, err := net.Listen("unix", uds)
+	if err != nil {
+		return err
+	}
+	if err := os.Chmod(uds, 0600); err != nil {
+		l.Close()
+		return err
+	}
+	c.Lock()
+	c.extKeyListener = l
+	c.Unlock()
+
+	go c.acceptClientConnections(uds, l)
+	return nil
+}
+
+func (c *controller) acceptClientConnections(sock string, l net.Listener) {
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			if _, err1 := os.Stat(sock); os.IsNotExist(err1) {
+				logrus.Warnf("Unix socket %s doesnt exist. cannot accept client connections", sock)
+				return
+			}
+			logrus.Errorf("Error accepting connection %v", err)
+			continue
+		}
+		go func() {
+			err := c.processExternalKey(conn)
+			ret := success
+			if err != nil {
+				ret = err.Error()
+			}
+
+			_, err = conn.Write([]byte(ret))
+			if err != nil {
+				logrus.Errorf("Error returning to the client %v", err)
+			}
+		}()
+	}
+}
+
+func (c *controller) processExternalKey(conn net.Conn) error {
+	buf := make([]byte, 1280)
+	nr, err := conn.Read(buf)
+	if err != nil {
+		return err
+	}
+	var s setKeyData
+	if err = json.Unmarshal(buf[0:nr], &s); err != nil {
+		return err
+	}
+
+	var sandbox Sandbox
+	search := SandboxContainerWalker(&sandbox, s.ContainerID)
+	c.WalkSandboxes(search)
+	if sandbox == nil {
+		return types.BadRequestErrorf("no sandbox present for %s", s.ContainerID)
+	}
+
+	return sandbox.SetKey(s.Key)
+}
+
+func (c *controller) stopExternalKeyListener() {
+	c.extKeyListener.Close()
+}

--- a/vendor/src/github.com/docker/libnetwork/types/types.go
+++ b/vendor/src/github.com/docker/libnetwork/types/types.go
@@ -266,12 +266,6 @@ type StaticRoute struct {
 
 	// NextHop will be resolved by the kernel (i.e. as a loose hop).
 	NextHop net.IP
-
-	// InterfaceID must refer to a defined interface on the
-	// Endpoint to which the routes are specified.  Routes specified this way
-	// are interpreted as directly connected to the specified interface (no
-	// next hop will be used).
-	InterfaceID int
 }
 
 // GetCopy returns a copy of this StaticRoute structure
@@ -279,9 +273,9 @@ func (r *StaticRoute) GetCopy() *StaticRoute {
 	d := GetIPNetCopy(r.Destination)
 	nh := GetIPCopy(r.NextHop)
 	return &StaticRoute{Destination: d,
-		RouteType:   r.RouteType,
-		NextHop:     nh,
-		InterfaceID: r.InterfaceID}
+		RouteType: r.RouteType,
+		NextHop:   nh,
+	}
 }
 
 /******************************


### PR DESCRIPTION
Changes include :
- libnetwork support for userns
- driver api change to have 1 interface per endpoint

No direct impact to docker daemon or other networking functionalities.
#15187 would need to make use of the new API from libnetwork (something similar to https://github.com/estesp/docker/commit/c1758151a09f4492474a6a5e1d97400fbb814721#diff-e25aebb8373cdbf4e75ed6f2f0574d05R149).

Signed-off-by: Madhu Venugopal madhu@docker.com
