### PR TITLE
Remove unnecessary check for nil CString

### DIFF
--- a/daemon/logger/journald/read.go
+++ b/daemon/logger/journald/read.go
@@ -220,10 +220,6 @@ func (s *journald) readLogs(logWatcher *logger.LogWatcher, config logger.ReadCon
 	}
 	// Add a match to have the library do the searching for us.
 	cmatch = C.CString("CONTAINER_ID_FULL=" + s.vars["CONTAINER_ID_FULL"])
-	if cmatch == nil {
-		logWatcher.Err <- fmt.Errorf("error reading container ID")
-		return
-	}
 	defer C.free(unsafe.Pointer(cmatch))
 	rc = C.sd_journal_add_match(j, unsafe.Pointer(cmatch), C.strlen(cmatch))
 	if rc != 0 {


### PR DESCRIPTION
@noxiouz points out that we don't need to check for a nil result from
C.CString(), since an out-of-memory condition causes a runtime panic
instead.

Signed-off-by: Nalin Dahyabhai nalin@redhat.com (github: nalind)
