### PR TITLE
Remove volume references when container creation fails.

### DIFF
--- a/daemon/create.go
+++ b/daemon/create.go
@@ -101,6 +101,13 @@ func (daemon *Daemon) Create(config *runconfig.Config, hostConfig *runconfig.Hos
 	if err := daemon.setHostConfig(container, hostConfig); err != nil {
 		return nil, nil, err
 	}
+	defer func() {
+		if retErr != nil {
+			if err := container.removeMountPoints(true); err != nil {
+				logrus.Error(err)
+			}
+		}
+	}()
 	if err := container.Mount(); err != nil {
 		return nil, nil, err
 	}

--- a/daemon/delete.go
+++ b/daemon/delete.go
@@ -56,7 +56,7 @@ func (daemon *Daemon) ContainerRm(name string, config *ContainerRmConfig) error 
 	}
 
 	if err := container.removeMountPoints(config.RemoveVolume); err != nil {
-		logrus.Errorf("%v", err)
+		logrus.Error(err)
 	}
 
 	return nil

--- a/daemon/volumes.go
+++ b/daemon/volumes.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/pkg/chrootarchive"
 	"github.com/docker/docker/pkg/system"
@@ -139,6 +140,7 @@ func (s *volumeStore) Create(name, driverName string, opts map[string]string) (v
 		return v, nil
 	}
 	s.mu.Unlock()
+	logrus.Debugf("Registering new volume reference: driver %s, name %s", driverName, name)
 
 	vd, err := getVolumeDriver(driverName)
 	if err != nil {
@@ -173,6 +175,7 @@ func (s *volumeStore) Remove(v volume.Volume) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	name := v.Name()
+	logrus.Debugf("Removing volume reference: driver %s, name %s", v.DriverName(), name)
 	vc, exists := s.vols[name]
 	if !exists {
 		return ErrNoSuchVolume
@@ -197,6 +200,7 @@ func (s *volumeStore) Remove(v volume.Volume) error {
 func (s *volumeStore) Increment(v volume.Volume) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	logrus.Debugf("Incrementing volume reference: driver %s, name %s", v.DriverName(), v.Name())
 
 	vc, exists := s.vols[v.Name()]
 	if !exists {
@@ -211,6 +215,7 @@ func (s *volumeStore) Increment(v volume.Volume) {
 func (s *volumeStore) Decrement(v volume.Volume) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	logrus.Debugf("Decrementing volume reference: driver %s, name %s", v.DriverName(), v.Name())
 
 	vc, exists := s.vols[v.Name()]
 	if !exists {


### PR DESCRIPTION
Volumes are accounted when a container is created.
If the creation fails we should remove the reference from the counter.

Do not log ErrVolumeInUse as an error, having other volume references is not an error.

Signed-off-by: David Calavera david.calavera@gmail.com
